### PR TITLE
Bound plugin pages and add experimental panel menus

### DIFF
--- a/apps/app/src/components/plugin/PluginNavSidebarItems.test.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.test.tsx
@@ -12,7 +12,14 @@ import { createStore, Provider } from "jotai";
 import { MemoryRouter, useLocation } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CompactViewportOverrideProvider } from "@bb/shared-ui/hooks/use-compact-viewport";
+import type { PluginNavPanelRegistration } from "@get-bb/plugin-sdk/app";
 import { SidebarProvider } from "@/components/ui/sidebar.js";
+import { appToast } from "@/components/ui/app-toast";
+import { writeLastKnownPluginNavPanelChrome } from "@/lib/plugin-nav-panel-chrome";
+import {
+  markPluginFrontendsSettled,
+  resetPluginFrontendBootStateForTest,
+} from "@/lib/plugin-frontend-boot-state";
 import {
   resetPluginSlotStoreForTest,
   setPluginSlotRegistrations,
@@ -26,7 +33,10 @@ import {
   ExtensionsNavSidebarItem,
   PluginNavSidebarItems,
 } from "./PluginNavSidebarItems";
-import { pluginNavPanelOrderAtom } from "./pluginNavSidebarAtoms";
+import {
+  pluginNavPanelOrderAtom,
+  pluginNavPanelOverflowExpandedAtom,
+} from "./pluginNavSidebarAtoms";
 
 function registrationSet(
   overrides: Partial<PluginRegistrationSet>,
@@ -47,6 +57,7 @@ function registerPanel(
   pluginId: string,
   title: string,
   experimentalSidebarAccessory?: ComponentType,
+  experimentalMenu?: PluginNavPanelRegistration["experimental_menu"],
 ) {
   setPluginSlotRegistrations(
     pluginId,
@@ -63,6 +74,9 @@ function registerPanel(
             : {
                 experimental_sidebarAccessory: experimentalSidebarAccessory,
               }),
+          ...(experimentalMenu === undefined
+            ? {}
+            : { experimental_menu: experimentalMenu }),
         },
       ],
     }),
@@ -73,6 +87,10 @@ function renderSidebarItems(
   options: {
     storedOrder?: string[];
     compactViewport?: boolean;
+    initialEntry?: string;
+    overflowExpanded?: boolean;
+    splitEnabled?: boolean;
+    bootComplete?: boolean;
   } = {},
 ) {
   const store = createStore();
@@ -81,14 +99,19 @@ function renderSidebarItems(
   if (options.storedOrder) {
     store.set(pluginNavPanelOrderAtom, options.storedOrder);
   }
+  if (options.overflowExpanded !== undefined) {
+    store.set(pluginNavPanelOverflowExpandedAtom, options.overflowExpanded);
+  }
+  if (options.bootComplete !== false) markPluginFrontendsSettled();
   return render(
     <CompactViewportOverrideProvider
       isCompactViewport={options.compactViewport ?? false}
     >
       <Provider store={store}>
-        <MemoryRouter initialEntries={["/"]}>
+        <MemoryRouter initialEntries={[options.initialEntry ?? "/"]}>
           <SidebarProvider>
-            <PluginNavSidebarItems />
+            <PluginNavSidebarItems splitEnabled={options.splitEnabled} />
+            <LocationPath />
           </SidebarProvider>
         </MemoryRouter>
       </Provider>
@@ -96,7 +119,12 @@ function renderSidebarItems(
   );
 }
 
-const ROW_LABELS = new Set(["Docs", "GitHub"]);
+const ROW_LABELS = new Set([
+  "Docs",
+  "GitHub",
+  "Tasks",
+  ...Array.from({ length: 9 }, (_, index) => `Plugin ${index + 1}`),
+]);
 
 function panelRowNames(): string[] {
   return screen
@@ -107,6 +135,7 @@ function panelRowNames(): string[] {
 
 beforeEach(() => {
   window.localStorage.clear();
+  resetPluginFrontendBootStateForTest();
   resetAllCrashedPluginSlotsForTest();
   // React reports errors caught by the slot boundary; keep expected crashes
   // from obscuring the regression assertions below.
@@ -117,6 +146,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   resetPluginSlotStoreForTest();
+  resetPluginFrontendBootStateForTest();
   resetAllCrashedPluginSlotsForTest();
   vi.restoreAllMocks();
   window.localStorage.clear();
@@ -218,7 +248,7 @@ describe("PluginNavSidebarItems", () => {
       { button: 0 },
     );
     expect(
-      await screen.findByRole("menuitem", { name: "Hide from sidebar" }),
+      await screen.findByRole("menuitem", { name: "Plugin settings" }),
     ).not.toBeNull();
 
     expect(accessory?.getAttribute("data-sidebar-hover-actions-open")).toBe(
@@ -263,77 +293,326 @@ describe("PluginNavSidebarItems", () => {
     expect(screen.queryByText("plugin tasks crashed")).toBeNull();
   });
 
-  it("moves a hidden panel into an expanded More disclosure and back", async () => {
-    registerPanel("docs", "Docs");
-    registerPanel("github", "GitHub");
+  it.each([1, 4, 5])("renders %i pages as a flat list", (count) => {
+    for (let index = 1; index <= count; index += 1) {
+      registerPanel(`plugin-${index}`, `Plugin ${index}`);
+    }
 
     renderSidebarItems();
 
-    expect(panelRowNames()).toEqual(["Docs", "GitHub"]);
+    expect(panelRowNames()).toEqual(
+      Array.from({ length: count }, (_, index) => `Plugin ${index + 1}`),
+    );
+    expect(screen.queryByTestId("plugin-nav-sidebar-heading")).toBeNull();
     expect(
       screen.queryByTestId("plugin-nav-sidebar-overflow-toggle"),
     ).toBeNull();
-
-    fireEvent.pointerDown(
-      screen.getByRole("button", { name: "Docs panel options" }),
-      { button: 0 },
-    );
-    fireEvent.click(
-      await screen.findByRole("menuitem", { name: "Hide from sidebar" }),
-    );
-
-    // The row moves under a collapsed "More (1)" — hiding never expands the
-    // disclosure, so the sidebar doesn't grow back to its old height.
-    await waitFor(() => {
-      expect(
-        screen.getByTestId("plugin-nav-sidebar-overflow-toggle").textContent,
-      ).toContain("More (1)");
-    });
-    expect(panelRowNames()).toEqual(["GitHub"]);
-    expect(
-      window.localStorage.getItem("bb.sidebar.hiddenPluginPanels"),
-    ).toContain("docs/main");
-
-    fireEvent.click(screen.getByTestId("plugin-nav-sidebar-overflow-toggle"));
-    await waitFor(() => {
-      expect(panelRowNames()).toEqual(["GitHub", "Docs"]);
-    });
-
-    fireEvent.pointerDown(
-      screen.getByRole("button", { name: "Docs panel options" }),
-      { button: 0 },
-    );
-    fireEvent.click(
-      await screen.findByRole("menuitem", { name: "Show in sidebar" }),
-    );
-
-    await waitFor(() => {
-      expect(
-        screen.queryByTestId("plugin-nav-sidebar-overflow-toggle"),
-      ).toBeNull();
-    });
-    // Unhiding restores the panel's original slot rather than appending it.
-    expect(panelRowNames()).toEqual(["Docs", "GitHub"]);
   });
 
-  it("collapses hidden panels behind the More toggle on a later mount", async () => {
-    registerPanel("docs", "Docs");
-    registerPanel("github", "GitHub");
+  it.each([6, 9])("caps %i pages and labels the overflow", (count) => {
+    for (let index = 1; index <= count; index += 1) {
+      registerPanel(`plugin-${index}`, `Plugin ${index}`);
+    }
+
+    renderSidebarItems();
+
+    expect(panelRowNames()).toEqual([
+      "Plugin 1",
+      "Plugin 2",
+      "Plugin 3",
+      "Plugin 4",
+      "Plugin 5",
+    ]);
+    expect(screen.getByTestId("plugin-nav-sidebar-heading").textContent).toBe(
+      `Plugin pages${count}`,
+    );
+    expect(
+      screen.getByTestId("plugin-nav-sidebar-overflow-toggle").textContent,
+    ).toContain(`Show ${count - 5} more`);
+  });
+
+  it("moves pages across the cap with the same ordering verbs in both menus", async () => {
+    for (let index = 1; index <= 6; index += 1) {
+      registerPanel(`plugin-${index}`, `Plugin ${index}`);
+    }
+    renderSidebarItems();
+
+    fireEvent.contextMenu(screen.getByRole("button", { name: "Plugin 1" }));
+    expect(
+      await screen.findByRole("menuitem", { name: "Move to overflow" }),
+    ).not.toBeNull();
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: "Plugin 1 panel options" }),
+      { button: 0 },
+    );
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: "Move to overflow" }),
+    );
+    await waitFor(() => {
+      expect(panelRowNames()).toEqual([
+        "Plugin 2",
+        "Plugin 3",
+        "Plugin 4",
+        "Plugin 5",
+        "Plugin 6",
+      ]);
+    });
+    expect(screen.queryByText("Hide from sidebar")).toBeNull();
+
+    fireEvent.click(screen.getByTestId("plugin-nav-sidebar-overflow-toggle"));
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: "Plugin 1 panel options" }),
+      { button: 0 },
+    );
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: "Move to top" }),
+    );
+    await waitFor(() => {
+      expect(panelRowNames().slice(0, 5)).toEqual([
+        "Plugin 1",
+        "Plugin 2",
+        "Plugin 3",
+        "Plugin 4",
+        "Plugin 5",
+      ]);
+    });
+  });
+
+  it("persists the expanded overflow preference", async () => {
+    for (let index = 1; index <= 6; index += 1) {
+      registerPanel(`plugin-${index}`, `Plugin ${index}`);
+    }
+    const first = renderSidebarItems();
+    fireEvent.click(screen.getByTestId("plugin-nav-sidebar-overflow-toggle"));
+    await waitFor(() => expect(panelRowNames()).toHaveLength(6));
+    expect(
+      window.localStorage.getItem("bb.sidebar.pluginPanelOverflowExpanded"),
+    ).toBe("true");
+
+    first.unmount();
+    renderSidebarItems();
+    expect(panelRowNames()).toHaveLength(6);
+    expect(
+      screen.getByTestId("plugin-nav-sidebar-overflow-toggle").textContent,
+    ).toContain("Show less");
+  });
+
+  it("promotes the active overflow page without changing stored order", () => {
+    for (let index = 1; index <= 9; index += 1) {
+      registerPanel(`plugin-${index}`, `Plugin ${index}`);
+    }
+    renderSidebarItems({ initialEntry: "/plugins/plugin-9/main" });
+
+    expect(panelRowNames()).toEqual([
+      "Plugin 1",
+      "Plugin 2",
+      "Plugin 3",
+      "Plugin 4",
+      "Plugin 9",
+    ]);
+    expect(
+      JSON.parse(
+        window.localStorage.getItem("bb.sidebar.pluginPanelOrder") ?? "[]",
+      ),
+    ).toEqual(
+      Array.from({ length: 9 }, (_, index) => `plugin-${index + 1}/main`),
+    );
+  });
+
+  it("migrates hidden pages to the end once and clears the hidden set", async () => {
+    for (let index = 1; index <= 9; index += 1) {
+      registerPanel(`plugin-${index}`, `Plugin ${index}`);
+    }
+    window.localStorage.setItem(
+      "bb.sidebar.pluginPanelOrder",
+      JSON.stringify(
+        Array.from({ length: 9 }, (_, index) => `plugin-${index + 1}/main`),
+      ),
+    );
     window.localStorage.setItem(
       "bb.sidebar.hiddenPluginPanels",
-      JSON.stringify(["docs/main"]),
+      JSON.stringify(["plugin-4/main", "plugin-2/main"]),
     );
 
     renderSidebarItems();
 
-    expect(panelRowNames()).toEqual(["GitHub"]);
-    const toggle = screen.getByTestId("plugin-nav-sidebar-overflow-toggle");
-    expect(toggle.textContent).toContain("More (1)");
-
-    fireEvent.click(toggle);
     await waitFor(() => {
-      expect(panelRowNames()).toEqual(["GitHub", "Docs"]);
+      expect(window.localStorage.getItem("bb.sidebar.hiddenPluginPanels")).toBe(
+        "[]",
+      );
     });
+    expect(panelRowNames()).toEqual([
+      "Plugin 1",
+      "Plugin 3",
+      "Plugin 5",
+      "Plugin 6",
+      "Plugin 7",
+    ]);
+    expect(
+      JSON.parse(
+        window.localStorage.getItem("bb.sidebar.pluginPanelOrder") ?? "[]",
+      ).slice(-2),
+    ).toEqual(["plugin-2/main", "plugin-4/main"]);
+  });
+
+  it("keeps a newly installed page at the end when five already show", async () => {
+    for (let index = 1; index <= 5; index += 1) {
+      registerPanel(`plugin-${index}`, `Plugin ${index}`);
+    }
+    renderSidebarItems();
+
+    act(() => registerPanel("plugin-6", "Plugin 6"));
+
+    await waitFor(() => {
+      expect(panelRowNames()).toEqual([
+        "Plugin 1",
+        "Plugin 2",
+        "Plugin 3",
+        "Plugin 4",
+        "Plugin 5",
+      ]);
+    });
+    expect(
+      screen.getByTestId("plugin-nav-sidebar-overflow-toggle").textContent,
+    ).toContain("Show 1 more");
+  });
+
+  it("renders plugin groups and resolves a lazy submenu only when opened", async () => {
+    const run = vi.fn();
+    const lazyItems = vi.fn(async () => [
+      { id: "api", label: "API reference", run },
+    ]);
+    registerPanel("docs", "Docs", undefined, [
+      {
+        id: "docs",
+        label: "API docs",
+        items: [
+          { id: "overview", label: "Open overview", run },
+          { id: "surfaces", label: "API surfaces", items: lazyItems },
+        ],
+      },
+    ]);
+    renderSidebarItems({ splitEnabled: true });
+
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: "Docs panel options" }),
+      { button: 0 },
+    );
+    expect(await screen.findByText("API docs")).not.toBeNull();
+    expect(
+      screen.getByRole("menuitem", { name: "Open in split" }),
+    ).not.toBeNull();
+    expect(
+      screen.getByRole("menuitem", { name: "Plugin settings" }),
+    ).not.toBeNull();
+    expect(lazyItems).not.toHaveBeenCalled();
+
+    const submenuTrigger = screen.getByRole("menuitem", {
+      name: "API surfaces",
+    });
+    submenuTrigger.focus();
+    fireEvent.keyDown(submenuTrigger, { key: "ArrowRight" });
+    expect(
+      await screen.findByRole("menuitem", { name: "API reference" }),
+    ).not.toBeNull();
+    expect(lazyItems).toHaveBeenCalledTimes(1);
+  });
+
+  it("contains failing plugin actions and lazy resolvers", async () => {
+    const actionError = vi.spyOn(appToast, "error").mockImplementation(() => 1);
+    registerPanel("docs", "Docs", undefined, [
+      {
+        id: "broken",
+        items: [
+          {
+            id: "action",
+            label: "Broken action",
+            run: () => {
+              throw new Error("action failed");
+            },
+          },
+          {
+            id: "submenu",
+            label: "Broken submenu",
+            items: async () => {
+              throw new Error("resolver failed");
+            },
+          },
+        ],
+      },
+    ]);
+    renderSidebarItems();
+
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: "Docs panel options" }),
+      { button: 0 },
+    );
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: "Broken action" }),
+    );
+    await waitFor(() => {
+      expect(actionError).toHaveBeenCalledWith("Could not run plugin action", {
+        description: "action failed",
+      });
+    });
+
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: "Docs panel options" }),
+      { button: 0 },
+    );
+    const submenuTrigger = await screen.findByRole("menuitem", {
+      name: "Broken submenu",
+    });
+    submenuTrigger.focus();
+    fireEvent.keyDown(submenuTrigger, { key: "ArrowRight" });
+    expect(await screen.findByText("Could not load")).not.toBeNull();
+  });
+
+  it("opens Plugin settings in Extensions and omits split on compact viewports", async () => {
+    registerPanel("docs", "Docs");
+    const first = renderSidebarItems({ splitEnabled: true });
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: "Docs panel options" }),
+      { button: 0 },
+    );
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: "Plugin settings" }),
+    );
+    expect(screen.getByTestId("location-path").textContent).toBe(
+      "/extensions/plugins/docs",
+    );
+
+    first.unmount();
+    renderSidebarItems({ compactViewport: true, splitEnabled: true });
+    fireEvent.click(screen.getByRole("button", { name: "Docs panel options" }));
+    expect(
+      await screen.findByRole("menuitem", { name: "Plugin settings" }),
+    ).not.toBeNull();
+    expect(
+      screen.queryByRole("menuitem", { name: "Open in split" }),
+    ).toBeNull();
+  });
+
+  it("draws no empty menu for a remembered row with no applicable action", () => {
+    writeLastKnownPluginNavPanelChrome([
+      {
+        pluginId: "docs",
+        id: "main",
+        title: "Docs",
+        icon: "FileText",
+        path: "main",
+      },
+    ]);
+    renderSidebarItems({ bootComplete: false });
+
+    expect(screen.getByRole("button", { name: "Docs" })).not.toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Docs panel options" }),
+    ).toBeNull();
+    fireEvent.contextMenu(screen.getByRole("button", { name: "Docs" }));
+    expect(screen.queryByRole("menu")).toBeNull();
   });
 
   it("keeps a saved order when plugin frontends register after the first render", async () => {

--- a/apps/app/src/components/plugin/PluginNavSidebarItems.test.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.test.tsx
@@ -9,7 +9,7 @@ import {
 } from "@testing-library/react";
 import { useEffect, type ComponentType } from "react";
 import { createStore, Provider } from "jotai";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, useLocation } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CompactViewportOverrideProvider } from "@bb/shared-ui/hooks/use-compact-viewport";
 import { SidebarProvider } from "@/components/ui/sidebar.js";
@@ -22,7 +22,10 @@ import {
   resetAllCrashedPluginSlotsForTest,
   resetCrashedPluginSlots,
 } from "./PluginSlotMount";
-import { PluginNavSidebarItems } from "./PluginNavSidebarItems";
+import {
+  ExtensionsNavSidebarItem,
+  PluginNavSidebarItems,
+} from "./PluginNavSidebarItems";
 import { pluginNavPanelOrderAtom } from "./pluginNavSidebarAtoms";
 
 function registrationSet(
@@ -68,7 +71,6 @@ function registerPanel(
 
 function renderSidebarItems(
   options: {
-    toolsRoutePath?: string;
     storedOrder?: string[];
     compactViewport?: boolean;
   } = {},
@@ -86,7 +88,7 @@ function renderSidebarItems(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
           <SidebarProvider>
-            <PluginNavSidebarItems toolsRoutePath={options.toolsRoutePath} />
+            <PluginNavSidebarItems />
           </SidebarProvider>
         </MemoryRouter>
       </Provider>
@@ -94,7 +96,7 @@ function renderSidebarItems(
   );
 }
 
-const ROW_LABELS = new Set(["Extensions", "Docs", "GitHub"]);
+const ROW_LABELS = new Set(["Docs", "GitHub"]);
 
 function panelRowNames(): string[] {
   return screen
@@ -334,92 +336,59 @@ describe("PluginNavSidebarItems", () => {
     });
   });
 
-  it("hides the built-in Extensions row like a plugin row", async () => {
-    registerPanel("docs", "Docs");
-
-    renderSidebarItems({ toolsRoutePath: "/extensions/skills" });
-
-    // Extensions leads the list, above the plugin rows.
-    expect(panelRowNames()).toEqual(["Extensions", "Docs"]);
-
-    fireEvent.pointerDown(
-      screen.getByRole("button", { name: "Extensions panel options" }),
-      { button: 0 },
-    );
-    fireEvent.click(
-      await screen.findByRole("menuitem", { name: "Hide from sidebar" }),
-    );
-
-    await waitFor(() => {
-      expect(panelRowNames()).toEqual(["Docs"]);
-    });
-    expect(
-      screen.getByTestId("plugin-nav-sidebar-overflow-toggle").textContent,
-    ).toContain("More (1)");
-    expect(
-      window.localStorage.getItem("bb.sidebar.hiddenPluginPanels"),
-    ).toContain("__builtin__/tools");
-  });
-
-  it("keeps Extensions on top for users who already reordered their plugin rows", () => {
-    registerPanel("docs", "Docs");
-    registerPanel("github", "GitHub");
-
+  it("keeps a saved order when plugin frontends register after the first render", async () => {
     renderSidebarItems({
-      toolsRoutePath: "/extensions/skills",
       storedOrder: ["github/main", "docs/main"],
     });
 
-    expect(panelRowNames()).toEqual(["Extensions", "GitHub", "Docs"]);
-  });
-
-  it("keeps a saved order when plugin frontends register after the first render", async () => {
-    // The Extensions row makes this list mount before any plugin has registered.
-    // The order effect must not save that empty snapshot over the user's rows.
-    renderSidebarItems({
-      toolsRoutePath: "/extensions/skills",
-      storedOrder: ["github/main", "__builtin__/tools", "docs/main"],
-    });
-
-    expect(panelRowNames()).toEqual(["Extensions"]);
+    expect(screen.queryByTestId("plugin-nav-sidebar-items")).toBeNull();
 
     registerPanel("docs", "Docs");
     registerPanel("github", "GitHub");
 
     await waitFor(() => {
-      expect(panelRowNames()).toEqual(["GitHub", "Extensions", "Docs"]);
+      expect(panelRowNames()).toEqual(["GitHub", "Docs"]);
     });
   });
 
-  it("saves no Extensions key while the row is absent", async () => {
+  it("orders only plugin pages and never seeds a host-owned Extensions key", async () => {
     registerPanel("docs", "Docs");
-
-    // This isolated host renders plugin rows without the Extensions route, so
-    // nothing should reserve a slot for a row that never renders here.
     renderSidebarItems({ storedOrder: ["docs/main"] });
 
-    await waitFor(() => {
-      expect(panelRowNames()).toEqual(["Docs"]);
-    });
+    await waitFor(() => expect(panelRowNames()).toEqual(["Docs"]));
     expect(
       window.localStorage.getItem("bb.sidebar.pluginPanelOrder") ?? "",
-    ).not.toContain("__builtin__/tools");
+    ).not.toContain("__builtin__");
   });
+});
 
-  it("carries both Extensions glyphs so hover swaps without reflow", () => {
-    renderSidebarItems({ toolsRoutePath: "/extensions/plugins" });
+function LocationPath() {
+  return <span data-testid="location-path">{useLocation().pathname}</span>;
+}
 
-    const extensionsRow = screen
-      .getAllByRole("button")
-      .find((button) => button.textContent?.trim() === "Extensions");
-    expect(extensionsRow).toBeTruthy();
+describe("ExtensionsNavSidebarItem", () => {
+  it("navigates independently of plugin ordering and has no panel menu", () => {
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <ExtensionsNavSidebarItem routePath="/extensions/plugins" />
+        <LocationPath />
+      </MemoryRouter>,
+    );
+
+    const extensionsRow = screen.getByRole("button", { name: "Extensions" });
+    fireEvent.click(extensionsRow);
+
+    expect(screen.getByTestId("location-path").textContent).toBe(
+      "/extensions/plugins",
+    );
+    expect(
+      screen.queryByRole("button", { name: "Extensions panel options" }),
+    ).toBeNull();
 
     // The swap is CSS on the row's :hover, which jsdom cannot evaluate. What is
-    // testable — and what the CSS depends on — is that BOTH glyphs are rendered
-    // into the one swap container: a regression to a single icon, or to React
-    // hover state, breaks this and would also reintroduce the layout shift the
-    // shared grid cell exists to prevent.
-    const swap = extensionsRow?.querySelector(".bb-sidebar-row-icon-swap");
+    // testable is that both glyphs share one swap container without reflow.
+    expect(extensionsRow).toBeTruthy();
+    const swap = extensionsRow.querySelector(".bb-sidebar-row-icon-swap");
     expect(swap).toBeTruthy();
     expect(
       swap?.querySelector('.bb-sidebar-row-icon-rest[data-icon="Toolbox"]'),

--- a/apps/app/src/components/plugin/PluginNavSidebarItems.test.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.test.tsx
@@ -34,6 +34,8 @@ import {
   PluginNavSidebarItems,
 } from "./PluginNavSidebarItems";
 import {
+  hiddenPluginNavPanelsAtom,
+  pluginNavPanelMigratedVisibleLimitAtom,
   pluginNavPanelOrderAtom,
   pluginNavPanelOverflowExpandedAtom,
 } from "./pluginNavSidebarAtoms";
@@ -89,6 +91,8 @@ function renderSidebarItems(
     compactViewport?: boolean;
     initialEntry?: string;
     overflowExpanded?: boolean;
+    hiddenKeys?: string[];
+    migratedVisibleLimit?: number | null;
     splitEnabled?: boolean;
     bootComplete?: boolean;
   } = {},
@@ -98,9 +102,36 @@ function renderSidebarItems(
   // initial value when this module was imported, before the test could write.
   if (options.storedOrder) {
     store.set(pluginNavPanelOrderAtom, options.storedOrder);
+    window.localStorage.setItem(
+      "bb.sidebar.pluginPanelOrder",
+      JSON.stringify(options.storedOrder),
+    );
   }
   if (options.overflowExpanded !== undefined) {
     store.set(pluginNavPanelOverflowExpandedAtom, options.overflowExpanded);
+  }
+  if (options.hiddenKeys !== undefined) {
+    store.set(hiddenPluginNavPanelsAtom, options.hiddenKeys);
+    window.localStorage.setItem(
+      "bb.sidebar.hiddenPluginPanels",
+      JSON.stringify(options.hiddenKeys),
+    );
+  }
+  if (options.migratedVisibleLimit !== undefined) {
+    store.set(
+      pluginNavPanelMigratedVisibleLimitAtom,
+      options.migratedVisibleLimit,
+    );
+    if (options.migratedVisibleLimit === null) {
+      window.localStorage.removeItem(
+        "bb.sidebar.pluginPanelMigratedVisibleLimit",
+      );
+    } else {
+      window.localStorage.setItem(
+        "bb.sidebar.pluginPanelMigratedVisibleLimit",
+        JSON.stringify(options.migratedVisibleLimit),
+      );
+    }
   }
   if (options.bootComplete !== false) markPluginFrontendsSettled();
   return render(
@@ -369,6 +400,7 @@ describe("PluginNavSidebarItems", () => {
     fireEvent.click(
       await screen.findByRole("menuitem", { name: "Move to top" }),
     );
+    fireEvent.click(screen.getByTestId("plugin-nav-sidebar-overflow-toggle"));
     await waitFor(() => {
       expect(panelRowNames().slice(0, 5)).toEqual([
         "Plugin 1",
@@ -455,6 +487,149 @@ describe("PluginNavSidebarItems", () => {
         window.localStorage.getItem("bb.sidebar.pluginPanelOrder") ?? "[]",
       ).slice(-2),
     ).toEqual(["plugin-2/main", "plugin-4/main"]);
+  });
+
+  it("preserves the felt state for four pages with two hidden", async () => {
+    for (let index = 1; index <= 4; index += 1) {
+      registerPanel(`plugin-${index}`, `Plugin ${index}`);
+    }
+
+    renderSidebarItems({
+      storedOrder: [
+        "plugin-3/main",
+        "plugin-1/main",
+        "plugin-4/main",
+        "plugin-2/main",
+      ],
+      hiddenKeys: ["plugin-4/main", "plugin-2/main"],
+    });
+
+    expect(panelRowNames()).toEqual(["Plugin 3", "Plugin 1"]);
+    expect(screen.queryByTestId("plugin-nav-sidebar-heading")).toBeNull();
+    expect(
+      screen.getByTestId("plugin-nav-sidebar-overflow-toggle").textContent,
+    ).toContain("Show 2 more");
+    await waitFor(() => {
+      expect(window.localStorage.getItem("bb.sidebar.hiddenPluginPanels")).toBe(
+        "[]",
+      );
+    });
+  });
+
+  it("keeps an all-hidden list collapsed while temporarily surfacing the active page", async () => {
+    for (let index = 1; index <= 4; index += 1) {
+      registerPanel(`plugin-${index}`, `Plugin ${index}`);
+    }
+    const hiddenKeys = Array.from(
+      { length: 4 },
+      (_, index) => `plugin-${index + 1}/main`,
+    );
+
+    const first = renderSidebarItems({ hiddenKeys });
+    expect(panelRowNames()).toEqual([]);
+    expect(screen.queryByTestId("plugin-nav-sidebar-heading")).toBeNull();
+    expect(
+      screen.getByTestId("plugin-nav-sidebar-overflow-toggle").textContent,
+    ).toContain("Show 4 more");
+    await waitFor(() => {
+      expect(
+        window.localStorage.getItem(
+          "bb.sidebar.pluginPanelMigratedVisibleLimit",
+        ),
+      ).toBe("0");
+    });
+
+    first.unmount();
+    renderSidebarItems({
+      initialEntry: "/plugins/plugin-4/main",
+      migratedVisibleLimit: 0,
+    });
+    expect(panelRowNames()).toEqual(["Plugin 4"]);
+    expect(
+      screen.getByTestId("plugin-nav-sidebar-overflow-toggle").textContent,
+    ).toContain("Show 3 more");
+  });
+
+  it("returns to the plain list after the migrated overflow is emptied", async () => {
+    for (let index = 1; index <= 4; index += 1) {
+      registerPanel(`plugin-${index}`, `Plugin ${index}`);
+    }
+    renderSidebarItems({
+      storedOrder: [
+        "plugin-1/main",
+        "plugin-2/main",
+        "plugin-3/main",
+        "plugin-4/main",
+      ],
+      hiddenKeys: ["plugin-3/main", "plugin-4/main"],
+    });
+    await waitFor(() => {
+      expect(window.localStorage.getItem("bb.sidebar.hiddenPluginPanels")).toBe(
+        "[]",
+      );
+    });
+
+    fireEvent.click(screen.getByTestId("plugin-nav-sidebar-overflow-toggle"));
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: "Plugin 3 panel options" }),
+      { button: 0 },
+    );
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: "Move to top" }),
+    );
+    fireEvent.click(screen.getByTestId("plugin-nav-sidebar-overflow-toggle"));
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("plugin-nav-sidebar-overflow-toggle").textContent,
+      ).toContain("Show 1 more");
+    });
+    fireEvent.click(screen.getByTestId("plugin-nav-sidebar-overflow-toggle"));
+
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: "Plugin 4 panel options" }),
+      { button: 0 },
+    );
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: "Move to top" }),
+    );
+    await waitFor(() => {
+      expect(panelRowNames()).toHaveLength(4);
+      expect(
+        screen.queryByTestId("plugin-nav-sidebar-overflow-toggle"),
+      ).toBeNull();
+      expect(
+        window.localStorage.getItem(
+          "bb.sidebar.pluginPanelMigratedVisibleLimit",
+        ),
+      ).toBeNull();
+    });
+  });
+
+  it("leaves the legacy Extensions key for its owning migration", async () => {
+    for (let index = 1; index <= 4; index += 1) {
+      registerPanel(`plugin-${index}`, `Plugin ${index}`);
+    }
+    renderSidebarItems({
+      hiddenKeys: ["plugin-4/main", "__builtin__/tools"],
+    });
+
+    await waitFor(() => {
+      expect(
+        JSON.parse(
+          window.localStorage.getItem("bb.sidebar.hiddenPluginPanels") ?? "[]",
+        ),
+      ).toEqual(["__builtin__/tools"]);
+    });
+    expect(
+      window.localStorage.getItem("bb.sidebar.pluginPanelOrder") ?? "",
+    ).not.toContain("__builtin__/tools");
+    fireEvent.click(screen.getByTestId("plugin-nav-sidebar-overflow-toggle"));
+    expect(panelRowNames()).toEqual([
+      "Plugin 1",
+      "Plugin 2",
+      "Plugin 3",
+      "Plugin 4",
+    ]);
   });
 
   it("keeps a newly installed page at the end when five already show", async () => {

--- a/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
@@ -84,12 +84,16 @@ import {
   getPluginPanelRoutePath,
 } from "@/lib/route-paths";
 import {
+  HIDDEN_PLUGIN_NAV_PANELS_STORAGE_KEY,
   hiddenPluginNavPanelsAtom,
+  PLUGIN_NAV_PANEL_MIGRATED_VISIBLE_LIMIT_STORAGE_KEY,
+  pluginNavPanelMigratedVisibleLimitAtom,
   pluginNavPanelOrderAtom,
   pluginNavPanelOverflowExpandedAtom,
 } from "./pluginNavSidebarAtoms";
 import {
   HIDDEN_PLUGIN_NAV_PANELS_MIGRATION_STORAGE_KEY,
+  isPluginNavPanelKey,
   migrateHiddenPluginNavPanels,
 } from "./pluginNavSidebarMigration";
 import {
@@ -98,6 +102,7 @@ import {
   havePluginNavPanelOrdersDiverged,
   movePluginNavPanelToOverflow,
   movePluginNavPanelToTop,
+  normalizePluginNavPanelOrder,
   PLUGIN_NAV_PANEL_VISIBLE_LIMIT,
   reorderPluginNavPanels,
 } from "./pluginNavSidebarOrder";
@@ -137,6 +142,34 @@ function routePathForRow(row: SidebarNavRow): string {
   });
 }
 
+function readStoredPluginNavPanelKeys(storageKey: string): string[] {
+  const value = getLocalStorage()?.getItem(storageKey);
+  if (value === null || value === undefined) return [];
+  try {
+    return normalizePluginNavPanelOrder(JSON.parse(value));
+  } catch {
+    return [];
+  }
+}
+
+function readStoredMigratedVisibleLimit(): number | null {
+  const value = getLocalStorage()?.getItem(
+    PLUGIN_NAV_PANEL_MIGRATED_VISIBLE_LIMIT_STORAGE_KEY,
+  );
+  if (value === null || value === undefined) return null;
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return typeof parsed === "number" &&
+      Number.isInteger(parsed) &&
+      parsed >= 0 &&
+      parsed <= PLUGIN_NAV_PANEL_VISIBLE_LIMIT
+      ? parsed
+      : null;
+  } catch {
+    return null;
+  }
+}
+
 function PluginNavSidebarItemList({
   onNavigate,
   rows,
@@ -151,6 +184,9 @@ function PluginNavSidebarItemList({
   const [storedOrder, setStoredOrder] = useAtom(pluginNavPanelOrderAtom);
   const [legacyHiddenKeys, setLegacyHiddenKeys] = useAtom(
     hiddenPluginNavPanelsAtom,
+  );
+  const [migratedVisibleLimit, setMigratedVisibleLimit] = useAtom(
+    pluginNavPanelMigratedVisibleLimitAtom,
   );
   const [isOverflowOpen, setIsOverflowOpen] = useAtom(
     pluginNavPanelOverflowExpandedAtom,
@@ -174,23 +210,62 @@ function PluginNavSidebarItemList({
     getLocalStorage()?.getItem(
       HIDDEN_PLUGIN_NAV_PANELS_MIGRATION_STORAGE_KEY,
     ) !== "1";
+  const pendingStoredHiddenKeys = migrationPending
+    ? readStoredPluginNavPanelKeys(HIDDEN_PLUGIN_NAV_PANELS_STORAGE_KEY)
+    : [];
+  const legacyPluginHiddenKeys = useMemo(
+    () =>
+      normalizePluginNavPanelOrder([
+        ...legacyHiddenKeys,
+        ...pendingStoredHiddenKeys,
+      ]).filter(isPluginNavPanelKey),
+    [legacyHiddenKeys, pendingStoredHiddenKeys],
+  );
+  const pendingVisibleLimit = useMemo(() => {
+    if (!migrationPending || legacyPluginHiddenKeys.length === 0) return null;
+    const hiddenSet = new Set(legacyPluginHiddenKeys);
+    return Math.min(
+      registrationOrder.filter((key) => !hiddenSet.has(key)).length,
+      PLUGIN_NAV_PANEL_VISIBLE_LIMIT,
+    );
+  }, [legacyPluginHiddenKeys, migrationPending, registrationOrder]);
+  const visibleLimit =
+    pendingVisibleLimit ??
+    migratedVisibleLimit ??
+    readStoredMigratedVisibleLimit() ??
+    PLUGIN_NAV_PANEL_VISIBLE_LIMIT;
   const displayOrder = useMemo(() => {
-    if (!migrationPending || legacyHiddenKeys.length === 0) return storedOrder;
-    const hiddenSet = new Set(legacyHiddenKeys);
+    const pluginOrder = normalizePluginNavPanelOrder([
+      ...storedOrder.filter(isPluginNavPanelKey),
+      ...registrationOrder,
+    ]);
+    if (!migrationPending || legacyPluginHiddenKeys.length === 0) {
+      return pluginOrder;
+    }
+    const hiddenSet = new Set(legacyPluginHiddenKeys);
+    const completeOrder = normalizePluginNavPanelOrder([
+      ...pluginOrder,
+      ...legacyPluginHiddenKeys,
+    ]);
     return [
-      ...storedOrder.filter((key) => !hiddenSet.has(key)),
-      ...registrationOrder.filter((key) => hiddenSet.has(key)),
-      ...legacyHiddenKeys.filter((key) => !registrationOrder.includes(key)),
+      ...completeOrder.filter((key) => !hiddenSet.has(key)),
+      ...completeOrder.filter((key) => hiddenSet.has(key)),
     ];
-  }, [legacyHiddenKeys, migrationPending, registrationOrder, storedOrder]);
+  }, [
+    legacyPluginHiddenKeys,
+    migrationPending,
+    registrationOrder,
+    storedOrder,
+  ]);
   const { visible, overflow, ordered, normalizedOrder } = useMemo(
     () =>
       arrangePluginNavPanels({
         panels: rows,
         storedOrder: displayOrder,
+        visibleLimit,
         ...(activeKey === undefined ? {} : { activeKey }),
       }),
-    [activeKey, displayOrder, rows],
+    [activeKey, displayOrder, rows, visibleLimit],
   );
   const registeredKeys = useMemo(
     () => ordered.map(getPluginNavPanelKey),
@@ -203,10 +278,11 @@ function PluginNavSidebarItemList({
     if (storage === null) return;
     let cancelled = false;
     void migrateHiddenPluginNavPanels({ storage, registrationOrder })
-      .then((nextOrder) => {
+      .then((result) => {
         if (cancelled) return;
-        setStoredOrder(nextOrder);
-        setLegacyHiddenKeys([]);
+        setStoredOrder(result.order);
+        setLegacyHiddenKeys(result.remainingHiddenKeys);
+        setMigratedVisibleLimit(result.migratedVisibleLimit);
       })
       .catch((error: unknown) => {
         console.warn("Could not migrate hidden plugin pages", error);
@@ -214,15 +290,21 @@ function PluginNavSidebarItemList({
     return () => {
       cancelled = true;
     };
-  }, [bootComplete, registrationOrder, setLegacyHiddenKeys, setStoredOrder]);
+  }, [
+    bootComplete,
+    registrationOrder,
+    setLegacyHiddenKeys,
+    setMigratedVisibleLimit,
+    setStoredOrder,
+  ]);
 
   useEffect(() => {
-    if (!bootComplete || legacyHiddenKeys.length > 0) return;
+    if (!bootComplete || migrationPending) return;
     if (!havePluginNavPanelOrdersDiverged(storedOrder, normalizedOrder)) return;
     setStoredOrder(normalizedOrder);
   }, [
     bootComplete,
-    legacyHiddenKeys.length,
+    migrationPending,
     normalizedOrder,
     setStoredOrder,
     storedOrder,
@@ -244,21 +326,72 @@ function PluginNavSidebarItemList({
         overKey: event.over.id,
         order: normalizedOrder,
       });
-      if (nextOrder) setStoredOrder(nextOrder);
+      if (nextOrder) {
+        setStoredOrder(nextOrder);
+        const from = registeredKeys.indexOf(event.active.id);
+        const to = registeredKeys.indexOf(event.over.id);
+        if (
+          migratedVisibleLimit !== null &&
+          from >= visibleLimit &&
+          to >= 0 &&
+          to < visibleLimit
+        ) {
+          const standardVisibleLimit = Math.min(
+            registeredKeys.length,
+            PLUGIN_NAV_PANEL_VISIBLE_LIMIT,
+          );
+          const nextVisibleLimit = Math.min(
+            visibleLimit + 1,
+            standardVisibleLimit,
+          );
+          setMigratedVisibleLimit(
+            nextVisibleLimit >= standardVisibleLimit ? null : nextVisibleLimit,
+          );
+        }
+      }
     },
-    [normalizedOrder, setStoredOrder],
+    [
+      migratedVisibleLimit,
+      normalizedOrder,
+      registeredKeys,
+      setMigratedVisibleLimit,
+      setStoredOrder,
+      visibleLimit,
+    ],
   );
   const { dndContextProps, onClickCapture } = useSidebarReorderDnd({
     onDragEnd: handleDragEnd,
   });
 
+  const handleOrderChange = useCallback(
+    (order: string[], promotesFromOverflow = false) => {
+      setStoredOrder(order);
+      if (!promotesFromOverflow || migratedVisibleLimit === null) return;
+      const standardVisibleLimit = Math.min(
+        registeredKeys.length,
+        PLUGIN_NAV_PANEL_VISIBLE_LIMIT,
+      );
+      const nextVisibleLimit = Math.min(visibleLimit + 1, standardVisibleLimit);
+      setMigratedVisibleLimit(
+        nextVisibleLimit >= standardVisibleLimit ? null : nextVisibleLimit,
+      );
+    },
+    [
+      migratedVisibleLimit,
+      registeredKeys.length,
+      setMigratedVisibleLimit,
+      setStoredOrder,
+      visibleLimit,
+    ],
+  );
   const rowProps = {
     onNavigate,
     pathname: location.pathname,
     splitEnabled,
     registeredKeys,
     normalizedOrder,
-    onOrderChange: setStoredOrder,
+    visibleLimit,
+    onOrderChange: handleOrderChange,
   };
   const reorderDisabled = displayedRows.length < 2;
 
@@ -268,7 +401,7 @@ function PluginNavSidebarItemList({
       data-testid="plugin-nav-sidebar-items"
       onClickCapture={onClickCapture}
     >
-      {overflow.length > 0 ? (
+      {ordered.length > PLUGIN_NAV_PANEL_VISIBLE_LIMIT ? (
         <div
           className={cn(
             CHROME_SECTION_LABEL_CLASS,
@@ -362,7 +495,8 @@ interface SidebarNavRowItemProps {
   splitEnabled: boolean;
   registeredKeys: readonly string[];
   normalizedOrder: readonly string[];
-  onOrderChange(order: string[]): void;
+  visibleLimit: number;
+  onOrderChange(order: string[], promotesFromOverflow?: boolean): void;
   dragBindings?: SidebarSortableDragBindings;
   rowRef?: (element: HTMLElement | null) => void;
   rowStyle?: CSSProperties;
@@ -719,6 +853,7 @@ function PluginNavSidebarItem({
   splitEnabled,
   registeredKeys,
   normalizedOrder,
+  visibleLimit,
   onOrderChange,
   ...props
 }: SidebarNavRowItemProps) {
@@ -748,9 +883,8 @@ function PluginNavSidebarItem({
   const hostActions = useMemo<HostMenuAction[]>(() => {
     const actions: HostMenuAction[] = [];
     if (
-      storedIndex >= PLUGIN_NAV_PANEL_VISIBLE_LIMIT ||
-      (registeredKeys.length <= PLUGIN_NAV_PANEL_VISIBLE_LIMIT &&
-        storedIndex > 0)
+      storedIndex >= visibleLimit ||
+      (registeredKeys.length <= visibleLimit && storedIndex > 0)
     ) {
       actions.push({
         id: "move-top",
@@ -762,13 +896,10 @@ function PluginNavSidebarItem({
             registeredKeys,
             rowKey,
           );
-          if (order) onOrderChange(order);
+          if (order) onOrderChange(order, storedIndex >= visibleLimit);
         },
       });
-    } else if (
-      registeredKeys.length > PLUGIN_NAV_PANEL_VISIBLE_LIMIT &&
-      storedIndex >= 0
-    ) {
+    } else if (registeredKeys.length > visibleLimit && storedIndex >= 0) {
       actions.push({
         id: "move-overflow",
         label: "Move to overflow",
@@ -778,6 +909,7 @@ function PluginNavSidebarItem({
             normalizedOrder,
             registeredKeys,
             rowKey,
+            visibleLimit,
           );
           if (order) onOrderChange(order);
         },
@@ -821,6 +953,7 @@ function PluginNavSidebarItem({
     rowKey,
     splitEnabled,
     storedIndex,
+    visibleLimit,
   ]);
   const menuContext = useMemo<ExperimentalPluginNavPanelMenuContext>(
     () => ({

--- a/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
@@ -1021,17 +1021,19 @@ function SidebarNavRowChrome({
     </div>
   );
 
-  if (menuDefinition === null) return rowContent;
   if (isCompactViewport) {
     return (
       <CompactLongPressMenu
+        disabled={menuDefinition === null}
         label={`${title} panel options`}
         onOpenChange={setIsActionsOpen}
         items={
-          <PluginNavRowMenuItems
-            definition={menuDefinition}
-            surface="dropdown"
-          />
+          menuDefinition ? (
+            <PluginNavRowMenuItems
+              definition={menuDefinition}
+              surface="dropdown"
+            />
+          ) : null
         }
       >
         {rowContent}
@@ -1040,10 +1042,17 @@ function SidebarNavRowChrome({
   }
   return (
     <ContextMenu onOpenChange={setIsActionsOpen}>
-      <ContextMenuTrigger asChild>{rowContent}</ContextMenuTrigger>
-      <ContextMenuContent aria-label={`${title} panel options`}>
-        <PluginNavRowMenuItems definition={menuDefinition} surface="context" />
-      </ContextMenuContent>
+      <ContextMenuTrigger disabled={menuDefinition === null} asChild>
+        {rowContent}
+      </ContextMenuTrigger>
+      {menuDefinition ? (
+        <ContextMenuContent aria-label={`${title} panel options`}>
+          <PluginNavRowMenuItems
+            definition={menuDefinition}
+            surface="context"
+          />
+        </ContextMenuContent>
+      ) : null}
     </ContextMenu>
   );
 }

--- a/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
@@ -65,57 +65,25 @@ import {
   havePluginNavPanelOrdersDiverged,
   hidePluginNavPanel,
   reorderPluginNavPanels,
-  seedLeadingNavPanelKeys,
   showPluginNavPanel,
 } from "./pluginNavSidebarOrder";
 
-/**
- * Reserved plugin id for rows the host owns rather than a plugin. Real plugin
- * ids come from a plugin manifest name, so they never take this shape.
- */
-const BUILTIN_NAV_ROW_PLUGIN_ID = "__builtin__";
+/** One sidebar nav row contributed by a plugin `navPanel` slot. */
+type SidebarNavRow = {
+  pluginId: string;
+  id: string;
+  title: string;
+  chrome: PluginNavPanelChrome;
+  /**
+   * The live registration; null while the row is drawn from remembered chrome
+   * before plugin frontends have booted (no sidebar accessory).
+   */
+  panel: PluginNavPanelSlot | null;
+};
 
 /**
- * Order/hidden preference key of the built-in Extensions row. The id stays
- * "tools" so an order or hidden list saved under the row's old name keeps
- * naming the same row.
- */
-const TOOLS_NAV_ROW_KEY = getPluginNavPanelKey({
-  pluginId: BUILTIN_NAV_ROW_PLUGIN_ID,
-  id: "tools",
-});
-
-/**
- * One sidebar nav row. Plugin rows come from `navPanel` slots; the Extensions
- * row is host chrome that shares the list so both obey the same order and hide
- * preferences.
- */
-type SidebarNavRow =
-  | {
-      kind: "tools";
-      pluginId: string;
-      id: string;
-      title: string;
-      /** Last visited Extensions route, so the row returns where the user was. */
-      routePath: string;
-    }
-  | {
-      kind: "plugin";
-      pluginId: string;
-      id: string;
-      title: string;
-      chrome: PluginNavPanelChrome;
-      /**
-       * The live registration; null while the row is drawn from remembered
-       * chrome before plugin frontends have booted (no sidebar accessory).
-       */
-      panel: PluginNavPanelSlot | null;
-    };
-
-/**
- * Sidebar entries for plugin `navPanel` slots (plugin design §5.2) plus the
- * built-in Extensions row: one row per entry, styled like primary sidebar
- * actions.
+ * Sidebar entries for plugin `navPanel` slots (plugin design §5.2): one row
+ * per entry, styled like primary sidebar actions.
  * Plugin rows navigate to the panel's own route under
  * /plugins/<pluginId>/<path>. Renders nothing while no row qualifies. The host
  * owns the row chrome; only an optional bounded sidebar accessory mounts here.
@@ -125,37 +93,22 @@ type SidebarNavRow =
  * collapsed "More" disclosure below the list rather than disappearing. Both
  * preferences live in `pluginNavSidebarAtoms`.
  */
-export function PluginNavSidebarItems({
-  toolsRoutePath,
-  ...props
-}: {
+export function PluginNavSidebarItems(props: {
   onNavigate?: () => void;
   splitEnabled?: boolean;
-  /** Omit when a host surface should render plugin rows without Extensions. */
-  toolsRoutePath?: string;
 }) {
   const navPanels = usePluginNavPanelChrome();
-  const rows = useMemo<SidebarNavRow[]>(() => {
-    const pluginRows = navPanels.map<SidebarNavRow>(({ chrome, panel }) => ({
-      kind: "plugin",
-      pluginId: chrome.pluginId,
-      id: chrome.id,
-      title: chrome.title,
-      chrome,
-      panel,
-    }));
-    if (toolsRoutePath === undefined) return pluginRows;
-    return [
-      {
-        kind: "tools",
-        pluginId: BUILTIN_NAV_ROW_PLUGIN_ID,
-        id: "tools",
-        title: "Extensions",
-        routePath: toolsRoutePath,
-      },
-      ...pluginRows,
-    ];
-  }, [navPanels, toolsRoutePath]);
+  const rows = useMemo<SidebarNavRow[]>(
+    () =>
+      navPanels.map(({ chrome, panel }) => ({
+        pluginId: chrome.pluginId,
+        id: chrome.id,
+        title: chrome.title,
+        chrome,
+        panel,
+      })),
+    [navPanels],
+  );
   // Router hooks live in the inner component so hosts without a Router
   // (isolated sidebar tests/stories) can render the empty state.
   if (rows.length === 0) return null;
@@ -177,15 +130,9 @@ function PluginNavSidebarItemList({
   const [isOverflowOpen, setIsOverflowOpen] = useState(false);
 
   const { visible, hidden, normalizedOrder } = useMemo(() => {
-    // Users who customized their plugin order before the Extensions row joined
-    // the list keep it on top instead of finding it at the bottom. Seed only
-    // while the row exists, so a build without it saves no key for it.
-    const leadingKeys = rows.some((row) => row.kind === "tools")
-      ? [TOOLS_NAV_ROW_KEY]
-      : [];
     return arrangePluginNavPanels({
       panels: rows,
-      storedOrder: seedLeadingNavPanelKeys(storedOrder, leadingKeys),
+      storedOrder,
       hiddenKeys,
     });
   }, [hiddenKeys, rows, storedOrder]);
@@ -248,9 +195,7 @@ function PluginNavSidebarItemList({
 
   return (
     <div
-      // Pull back most of the primary-actions bottom padding so plugin panel
-      // rows keep the same compact 2px rhythm as sidebar thread rows.
-      className="-mt-1.5 shrink-0 space-y-0.5 px-2 pb-2 group-data-[collapsible=icon]:hidden"
+      className="shrink-0 space-y-0.5 px-2 py-2 group-data-[collapsible=icon]:hidden"
       data-testid="plugin-nav-sidebar-items"
       onClickCapture={onClickCapture}
     >
@@ -371,9 +316,7 @@ function SidebarNavRowItem({
   splitEnabled,
   ...props
 }: SidebarNavRowItemProps) {
-  return row.kind === "tools" ? (
-    <ToolsNavSidebarItem {...props} row={row} />
-  ) : (
+  return (
     <PluginNavSidebarItem {...props} row={row} splitEnabled={splitEnabled} />
   );
 }
@@ -422,33 +365,31 @@ function ToolsNavSidebarItemIcon() {
 }
 
 /**
- * The Extensions row. It has no split-pane content kind, so it navigates in
- * place and draws no mini-map; everything else matches a plugin row.
+ * Host-owned Extensions navigation. It lives beside New thread rather than in
+ * plugin ordering and has no per-row visibility or split actions.
  */
-function ToolsNavSidebarItem({
-  row,
-  pathname: _pathname,
+export function ExtensionsNavSidebarItem({
+  routePath,
   onNavigate,
-  ...props
-}: Omit<SidebarNavRowItemProps, "row" | "splitEnabled"> & {
-  row: Extract<SidebarNavRow, { kind: "tools" }>;
+}: {
+  routePath: string;
+  onNavigate?: () => void;
 }) {
   const navigate = useNavigate();
   return (
-    <SidebarNavRowChrome
-      {...props}
-      rowKey={getPluginNavPanelKey(row)}
-      title={row.title}
-      icon={<ToolsNavSidebarItemIcon />}
-      // Never active: AppLayout swaps AppSidebar out for ToolsSidebar on every
-      // Extensions route, so this row is only on screen while Extensions is
-      // closed.
-      isActive={false}
-      onSelect={() => {
+    <Button
+      type="button"
+      size="sm"
+      variant="ghost"
+      className={cn(PROJECT_LIST_ACTION_BUTTON_CLASS, "w-full")}
+      onClick={() => {
         onNavigate?.();
-        void navigate(row.routePath);
+        void navigate(routePath);
       }}
-    />
+    >
+      <ToolsNavSidebarItemIcon />
+      <span className="min-w-0 flex-1 truncate text-left">Extensions</span>
+    </Button>
   );
 }
 
@@ -459,7 +400,7 @@ function PluginNavSidebarItem({
   splitEnabled,
   ...props
 }: Omit<SidebarNavRowItemProps, "row"> & {
-  row: Extract<SidebarNavRow, { kind: "plugin" }>;
+  row: SidebarNavRow;
 }) {
   const { chrome, panel } = row;
   const navigate = useNavigate();

--- a/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
@@ -213,28 +213,24 @@ function PluginNavSidebarItemList({
   const pendingStoredHiddenKeys = migrationPending
     ? readStoredPluginNavPanelKeys(HIDDEN_PLUGIN_NAV_PANELS_STORAGE_KEY)
     : [];
-  const legacyPluginHiddenKeys = useMemo(
-    () =>
-      normalizePluginNavPanelOrder([
-        ...legacyHiddenKeys,
-        ...pendingStoredHiddenKeys,
-      ]).filter(isPluginNavPanelKey),
-    [legacyHiddenKeys, pendingStoredHiddenKeys],
-  );
-  const pendingVisibleLimit = useMemo(() => {
+  const legacyPluginHiddenKeys = normalizePluginNavPanelOrder([
+    ...legacyHiddenKeys,
+    ...pendingStoredHiddenKeys,
+  ]).filter(isPluginNavPanelKey);
+  const pendingVisibleLimit = (() => {
     if (!migrationPending || legacyPluginHiddenKeys.length === 0) return null;
     const hiddenSet = new Set(legacyPluginHiddenKeys);
     return Math.min(
       registrationOrder.filter((key) => !hiddenSet.has(key)).length,
       PLUGIN_NAV_PANEL_VISIBLE_LIMIT,
     );
-  }, [legacyPluginHiddenKeys, migrationPending, registrationOrder]);
+  })();
   const visibleLimit =
     pendingVisibleLimit ??
     migratedVisibleLimit ??
     readStoredMigratedVisibleLimit() ??
     PLUGIN_NAV_PANEL_VISIBLE_LIMIT;
-  const displayOrder = useMemo(() => {
+  const displayOrder = (() => {
     const pluginOrder = normalizePluginNavPanelOrder([
       ...storedOrder.filter(isPluginNavPanelKey),
       ...registrationOrder,
@@ -251,26 +247,15 @@ function PluginNavSidebarItemList({
       ...completeOrder.filter((key) => !hiddenSet.has(key)),
       ...completeOrder.filter((key) => hiddenSet.has(key)),
     ];
-  }, [
-    legacyPluginHiddenKeys,
-    migrationPending,
-    registrationOrder,
-    storedOrder,
-  ]);
-  const { visible, overflow, ordered, normalizedOrder } = useMemo(
-    () =>
-      arrangePluginNavPanels({
-        panels: rows,
-        storedOrder: displayOrder,
-        visibleLimit,
-        ...(activeKey === undefined ? {} : { activeKey }),
-      }),
-    [activeKey, displayOrder, rows, visibleLimit],
-  );
-  const registeredKeys = useMemo(
-    () => ordered.map(getPluginNavPanelKey),
-    [ordered],
-  );
+  })();
+  const { visible, overflow, ordered, normalizedOrder } =
+    arrangePluginNavPanels({
+      panels: rows,
+      storedOrder: displayOrder,
+      visibleLimit,
+      ...(activeKey === undefined ? {} : { activeKey }),
+    });
+  const registeredKeys = ordered.map(getPluginNavPanelKey);
 
   useEffect(() => {
     if (!bootComplete) return;

--- a/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
@@ -1,98 +1,115 @@
 import {
   useCallback,
   useEffect,
+  Fragment,
   useMemo,
+  useRef,
   useState,
   type CSSProperties,
   type MouseEvent as ReactMouseEvent,
   type PointerEventHandler,
   type ReactNode,
 } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
 import { useAtom } from "jotai";
+import { useLocation, useNavigate } from "react-router-dom";
 import { DndContext, type DragEndEvent } from "@dnd-kit/core";
 import {
   SortableContext,
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
+import type {
+  ExperimentalPluginNavPanelMenuContext,
+  ExperimentalPluginNavPanelMenuGroup,
+  ExperimentalPluginNavPanelMenuItem,
+  ExperimentalPluginNavPanelSubmenu,
+} from "@get-bb/plugin-sdk/app";
+import { validateExperimentalPluginNavPanelMenuItems } from "@get-bb/plugin-sdk/internal/plugin-app-collector";
 import { Button } from "@bb/shared-ui/button";
-import { Icon } from "@bb/shared-ui/icon";
+import { COARSE_POINTER_ICON_SIZE_CLASS } from "@bb/shared-ui/coarse-pointer-sizing";
+import { CHROME_SECTION_LABEL_CLASS } from "@bb/shared-ui/chrome-style-tokens";
 import {
   ContextMenu,
   ContextMenuContent,
   ContextMenuItem,
+  ContextMenuLabel,
+  ContextMenuSeparator,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
   ContextMenuTrigger,
 } from "@bb/shared-ui/context-menu";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@bb/shared-ui/dropdown-menu";
-import { COARSE_POINTER_ICON_SIZE_CLASS } from "@bb/shared-ui/coarse-pointer-sizing";
 import { useIsCompactViewport } from "@bb/shared-ui/hooks/use-compact-viewport";
+import { Icon, ICON_NAMES, type IconName } from "@bb/shared-ui/icon";
+import { cn } from "@bb/shared-ui/lib/utils";
 import { PluginIcon } from "@/components/plugin/PluginIcon";
 import { PluginSlotMount } from "@/components/plugin/PluginSlotMount";
 import { PROJECT_LIST_ACTION_BUTTON_CLASS } from "@/components/sidebar/ProjectList";
-import { getPluginPanelRoutePath } from "@/lib/route-paths";
-import {
-  usePluginNavPanelChrome,
-  type PluginNavPanelChrome,
-} from "@/lib/plugin-nav-panel-chrome";
-import { cn } from "@bb/shared-ui/lib/utils";
-import type { PluginNavPanelSlot } from "@/lib/plugin-slots";
-import { usePaneContentSplitDrag } from "@/components/sidebar/usePaneContentSplitDrag";
-import { usePaneContentSplitIndicator } from "@/components/sidebar/paneContentSplitIndicator";
-import type { MiniMapSlot } from "@/components/sidebar/paneContentSplitIndicator";
 import { SplitPaneMiniMap } from "@/components/sidebar/SplitPaneMiniMap";
+import type { MiniMapSlot } from "@/components/sidebar/paneContentSplitIndicator";
+import { usePaneContentSplitIndicator } from "@/components/sidebar/paneContentSplitIndicator";
 import { SIDEBAR_MORE_ACTION_TRIGGER_CLASS } from "@/components/sidebar/sidebarRowClasses";
+import type { SidebarSortableDragBindings } from "@/components/sidebar/sortableMotion";
+import { useSidebarSortable } from "@/components/sidebar/sortableMotion";
+import { usePaneContentSplitDrag } from "@/components/sidebar/usePaneContentSplitDrag";
+import { useSidebarReorderDnd } from "@/components/sidebar/useSidebarReorderDnd";
+import { appToast } from "@/components/ui/app-toast";
+import { CompactLongPressMenu } from "@/components/ui/compact-long-press-menu";
 import {
   SIDEBAR_HOVER_ACTIONS_CLASS,
   SIDEBAR_HOVER_ACTIONS_FADE_CLASS,
   SIDEBAR_HOVER_ACTIONS_MOBILE_ALWAYS_VALUE,
   SIDEBAR_HOVER_ACTIONS_ROW_CLASS,
 } from "@/components/ui/sidebar-hover-actions";
-import { useSidebarSortable } from "@/components/sidebar/sortableMotion";
-import { useSidebarReorderDnd } from "@/components/sidebar/useSidebarReorderDnd";
-import type { SidebarSortableDragBindings } from "@/components/sidebar/sortableMotion";
+import { getLocalStorage } from "@/lib/browser-storage";
+import { usePluginFrontendBootComplete } from "@/lib/plugin-frontend-boot-state";
+import { usePluginDisplayName } from "@/lib/plugin-logos";
+import {
+  usePluginNavPanelChrome,
+  type PluginNavPanelChrome,
+} from "@/lib/plugin-nav-panel-chrome";
+import type { PluginNavPanelSlot } from "@/lib/plugin-slots";
+import {
+  getPluginDetailRoutePath,
+  getPluginPanelRoutePath,
+} from "@/lib/route-paths";
 import {
   hiddenPluginNavPanelsAtom,
   pluginNavPanelOrderAtom,
+  pluginNavPanelOverflowExpandedAtom,
 } from "./pluginNavSidebarAtoms";
+import {
+  HIDDEN_PLUGIN_NAV_PANELS_MIGRATION_STORAGE_KEY,
+  migrateHiddenPluginNavPanels,
+} from "./pluginNavSidebarMigration";
 import {
   arrangePluginNavPanels,
   getPluginNavPanelKey,
   havePluginNavPanelOrdersDiverged,
-  hidePluginNavPanel,
+  movePluginNavPanelToOverflow,
+  movePluginNavPanelToTop,
+  PLUGIN_NAV_PANEL_VISIBLE_LIMIT,
   reorderPluginNavPanels,
-  showPluginNavPanel,
 } from "./pluginNavSidebarOrder";
 
-/** One sidebar nav row contributed by a plugin `navPanel` slot. */
 type SidebarNavRow = {
   pluginId: string;
   id: string;
   title: string;
   chrome: PluginNavPanelChrome;
-  /**
-   * The live registration; null while the row is drawn from remembered chrome
-   * before plugin frontends have booted (no sidebar accessory).
-   */
   panel: PluginNavPanelSlot | null;
 };
 
-/**
- * Sidebar entries for plugin `navPanel` slots (plugin design §5.2): one row
- * per entry, styled like primary sidebar actions.
- * Plugin rows navigate to the panel's own route under
- * /plugins/<pluginId>/<path>. Renders nothing while no row qualifies. The host
- * owns the row chrome; only an optional bounded sidebar accessory mounts here.
- * The panel component itself mounts on the route (PluginPanelView).
- *
- * Rows are drag-reorderable and can be hidden; hidden rows move into a
- * collapsed "More" disclosure below the list rather than disappearing. Both
- * preferences live in `pluginNavSidebarAtoms`.
- */
 export function PluginNavSidebarItems(props: {
   onNavigate?: () => void;
   splitEnabled?: boolean;
@@ -109,10 +126,15 @@ export function PluginNavSidebarItems(props: {
       })),
     [navPanels],
   );
-  // Router hooks live in the inner component so hosts without a Router
-  // (isolated sidebar tests/stories) can render the empty state.
   if (rows.length === 0) return null;
   return <PluginNavSidebarItemList {...props} rows={rows} />;
+}
+
+function routePathForRow(row: SidebarNavRow): string {
+  return getPluginPanelRoutePath({
+    pluginId: row.chrome.pluginId,
+    path: row.chrome.path,
+  });
 }
 
 function PluginNavSidebarItemList({
@@ -125,31 +147,89 @@ function PluginNavSidebarItemList({
   splitEnabled?: boolean;
 }) {
   const location = useLocation();
+  const bootComplete = usePluginFrontendBootComplete();
   const [storedOrder, setStoredOrder] = useAtom(pluginNavPanelOrderAtom);
-  const [hiddenKeys, setHiddenKeys] = useAtom(hiddenPluginNavPanelsAtom);
-  const [isOverflowOpen, setIsOverflowOpen] = useState(false);
-
-  const { visible, hidden, normalizedOrder } = useMemo(() => {
-    return arrangePluginNavPanels({
-      panels: rows,
-      storedOrder,
-      hiddenKeys,
+  const [legacyHiddenKeys, setLegacyHiddenKeys] = useAtom(
+    hiddenPluginNavPanelsAtom,
+  );
+  const [isOverflowOpen, setIsOverflowOpen] = useAtom(
+    pluginNavPanelOverflowExpandedAtom,
+  );
+  const registrationOrder = useMemo(
+    () => rows.map(getPluginNavPanelKey),
+    [rows],
+  );
+  const activeKey = useMemo(() => {
+    const activeRow = rows.find((row) => {
+      const path = routePathForRow(row);
+      return (
+        location.pathname === path || location.pathname.startsWith(`${path}/`)
+      );
     });
-  }, [hiddenKeys, rows, storedOrder]);
-
-  // Give newly installed panels a slot in the persisted order. This only ever
-  // adds keys: a plugin frontend that has not registered yet keeps its slot, so
-  // an early mount cannot save a shortened order over the user's arrangement.
-  useEffect(() => {
-    if (!havePluginNavPanelOrdersDiverged(storedOrder, normalizedOrder)) return;
-    setStoredOrder(normalizedOrder);
-  }, [normalizedOrder, setStoredOrder, storedOrder]);
-
-  const visibleKeys = useMemo(
-    () => visible.map(getPluginNavPanelKey),
-    [visible],
+    return activeRow === undefined
+      ? undefined
+      : getPluginNavPanelKey(activeRow);
+  }, [location.pathname, rows]);
+  const migrationPending =
+    getLocalStorage()?.getItem(
+      HIDDEN_PLUGIN_NAV_PANELS_MIGRATION_STORAGE_KEY,
+    ) !== "1";
+  const displayOrder = useMemo(() => {
+    if (!migrationPending || legacyHiddenKeys.length === 0) return storedOrder;
+    const hiddenSet = new Set(legacyHiddenKeys);
+    return [
+      ...storedOrder.filter((key) => !hiddenSet.has(key)),
+      ...registrationOrder.filter((key) => hiddenSet.has(key)),
+      ...legacyHiddenKeys.filter((key) => !registrationOrder.includes(key)),
+    ];
+  }, [legacyHiddenKeys, migrationPending, registrationOrder, storedOrder]);
+  const { visible, overflow, ordered, normalizedOrder } = useMemo(
+    () =>
+      arrangePluginNavPanels({
+        panels: rows,
+        storedOrder: displayOrder,
+        ...(activeKey === undefined ? {} : { activeKey }),
+      }),
+    [activeKey, displayOrder, rows],
+  );
+  const registeredKeys = useMemo(
+    () => ordered.map(getPluginNavPanelKey),
+    [ordered],
   );
 
+  useEffect(() => {
+    if (!bootComplete) return;
+    const storage = getLocalStorage();
+    if (storage === null) return;
+    let cancelled = false;
+    void migrateHiddenPluginNavPanels({ storage, registrationOrder })
+      .then((nextOrder) => {
+        if (cancelled) return;
+        setStoredOrder(nextOrder);
+        setLegacyHiddenKeys([]);
+      })
+      .catch((error: unknown) => {
+        console.warn("Could not migrate hidden plugin pages", error);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [bootComplete, registrationOrder, setLegacyHiddenKeys, setStoredOrder]);
+
+  useEffect(() => {
+    if (!bootComplete || legacyHiddenKeys.length > 0) return;
+    if (!havePluginNavPanelOrdersDiverged(storedOrder, normalizedOrder)) return;
+    setStoredOrder(normalizedOrder);
+  }, [
+    bootComplete,
+    legacyHiddenKeys.length,
+    normalizedOrder,
+    setStoredOrder,
+    storedOrder,
+  ]);
+
+  const displayedRows = isOverflowOpen ? [...visible, ...overflow] : visible;
+  const displayedKeys = displayedRows.map(getPluginNavPanelKey);
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
       if (
@@ -163,35 +243,24 @@ function PluginNavSidebarItemList({
         activeKey: event.active.id,
         overKey: event.over.id,
         order: normalizedOrder,
-        visibleKeys,
       });
       if (nextOrder) setStoredOrder(nextOrder);
     },
-    [normalizedOrder, setStoredOrder, visibleKeys],
+    [normalizedOrder, setStoredOrder],
   );
   const { dndContextProps, onClickCapture } = useSidebarReorderDnd({
     onDragEnd: handleDragEnd,
   });
 
-  const handleHide = useCallback(
-    (key: string) => {
-      setHiddenKeys((current) => hidePluginNavPanel(current, key));
-    },
-    [setHiddenKeys],
-  );
-  const handleShow = useCallback(
-    (key: string) => {
-      setHiddenKeys((current) => showPluginNavPanel(current, key));
-    },
-    [setHiddenKeys],
-  );
-
-  const reorderDisabled = visible.length < 2;
   const rowProps = {
     onNavigate,
     pathname: location.pathname,
     splitEnabled,
+    registeredKeys,
+    normalizedOrder,
+    onOrderChange: setStoredOrder,
   };
+  const reorderDisabled = displayedRows.length < 2;
 
   return (
     <div
@@ -199,9 +268,23 @@ function PluginNavSidebarItemList({
       data-testid="plugin-nav-sidebar-items"
       onClickCapture={onClickCapture}
     >
+      {overflow.length > 0 ? (
+        <div
+          className={cn(
+            CHROME_SECTION_LABEL_CLASS,
+            "flex h-7 items-center justify-between px-2",
+          )}
+          data-testid="plugin-nav-sidebar-heading"
+        >
+          <span>Plugin pages</span>
+          <span aria-label={`${ordered.length} plugin pages`}>
+            {ordered.length}
+          </span>
+        </div>
+      ) : null}
       <DndContext {...dndContextProps}>
         <SortableContext
-          items={visibleKeys}
+          items={displayedKeys}
           strategy={verticalListSortingStrategy}
         >
           {visible.map((row) => (
@@ -209,32 +292,28 @@ function PluginNavSidebarItemList({
               key={getPluginNavPanelKey(row)}
               row={row}
               reorderDisabled={reorderDisabled}
-              onHide={handleHide}
               {...rowProps}
             />
           ))}
-        </SortableContext>
-      </DndContext>
-      {hidden.length > 0 ? (
-        <>
-          <PluginNavSidebarOverflowToggle
-            count={hidden.length}
-            isOpen={isOverflowOpen}
-            onToggle={() => setIsOverflowOpen((open) => !open)}
-          />
+          {overflow.length > 0 ? (
+            <PluginNavSidebarOverflowToggle
+              count={overflow.length}
+              isOpen={isOverflowOpen}
+              onToggle={() => setIsOverflowOpen((open) => !open)}
+            />
+          ) : null}
           {isOverflowOpen
-            ? hidden.map((row) => (
-                <SidebarNavRowItem
+            ? overflow.map((row) => (
+                <SortableSidebarNavRow
                   key={getPluginNavPanelKey(row)}
                   row={row}
-                  isHidden
-                  onShow={handleShow}
+                  reorderDisabled={reorderDisabled}
                   {...rowProps}
                 />
               ))
             : null}
-        </>
-      ) : null}
+        </SortableContext>
+      </DndContext>
     </div>
   );
 }
@@ -256,9 +335,6 @@ function PluginNavSidebarOverflowToggle({
       aria-expanded={isOpen}
       className={cn(
         PROJECT_LIST_ACTION_BUTTON_CLASS,
-        // Quieter than the hidden rows it heads, matching the sidebar's
-        // section labels ("Pinned"). Hover still brightens it via the shared
-        // interactive-state class.
         "w-full text-subtle-foreground/75",
       )}
       onClick={onToggle}
@@ -272,12 +348,27 @@ function PluginNavSidebarOverflowToggle({
         )}
         aria-hidden="true"
       />
-      <span className="min-w-0 truncate text-left">{`More (${count})`}</span>
+      <span className="min-w-0 truncate text-left">
+        {isOpen ? "Show less" : `Show ${count} more`}
+      </span>
     </Button>
   );
 }
 
-const SortableSidebarNavRow = function SortableSidebarNavRow({
+interface SidebarNavRowItemProps {
+  row: SidebarNavRow;
+  pathname: string;
+  onNavigate?: () => void;
+  splitEnabled: boolean;
+  registeredKeys: readonly string[];
+  normalizedOrder: readonly string[];
+  onOrderChange(order: string[]): void;
+  dragBindings?: SidebarSortableDragBindings;
+  rowRef?: (element: HTMLElement | null) => void;
+  rowStyle?: CSSProperties;
+}
+
+function SortableSidebarNavRow({
   row,
   reorderDisabled,
   ...props
@@ -287,7 +378,7 @@ const SortableSidebarNavRow = function SortableSidebarNavRow({
     disabled: reorderDisabled,
   });
   return (
-    <SidebarNavRowItem
+    <PluginNavSidebarItem
       {...props}
       row={row}
       dragBindings={dragBindings}
@@ -295,66 +386,298 @@ const SortableSidebarNavRow = function SortableSidebarNavRow({
       rowStyle={style}
     />
   );
-};
-
-interface SidebarNavRowItemProps {
-  row: SidebarNavRow;
-  pathname: string;
-  onNavigate?: () => void;
-  splitEnabled: boolean;
-  /** Present for rows parked in the "More" disclosure. */
-  isHidden?: boolean;
-  onHide?: (key: string) => void;
-  onShow?: (key: string) => void;
-  dragBindings?: SidebarSortableDragBindings;
-  rowRef?: (element: HTMLElement | null) => void;
-  rowStyle?: CSSProperties;
-}
-
-function SidebarNavRowItem({
-  row,
-  splitEnabled,
-  ...props
-}: SidebarNavRowItemProps) {
-  return (
-    <PluginNavSidebarItem {...props} row={row} splitEnabled={splitEnabled} />
-  );
 }
 
 type PluginNavRowMenuSurface = "context" | "dropdown";
 
-function PluginNavRowVisibilityMenuItem({
-  isHidden,
-  onSelect,
-  surface,
-}: {
-  isHidden: boolean;
-  onSelect: () => void;
-  surface: PluginNavRowMenuSurface;
-}) {
-  const content = (
-    <>
-      <Icon name={isHidden ? "Eye" : "EyeOff"} aria-hidden="true" />
-      {isHidden ? "Show in sidebar" : "Hide from sidebar"}
-    </>
-  );
-  return surface === "context" ? (
-    <ContextMenuItem onSelect={onSelect}>{content}</ContextMenuItem>
-  ) : (
-    <DropdownMenuItem onSelect={onSelect}>{content}</DropdownMenuItem>
+interface HostMenuAction {
+  id: string;
+  label: string;
+  icon: IconName;
+  run(): void;
+}
+
+interface PluginNavRowMenuDefinition {
+  context: ExperimentalPluginNavPanelMenuContext;
+  hostActions: readonly HostMenuAction[];
+  pluginGroups: readonly ExperimentalPluginNavPanelMenuGroup[];
+  pluginDisplayName: string;
+}
+
+function isIconName(value: string | undefined): value is IconName {
+  return (
+    value !== undefined && (ICON_NAMES as readonly string[]).includes(value)
   );
 }
 
-/**
- * The Extensions row's glyph. Resting is the toolbox; hovering (or focusing)
- * the row swaps in the tool case.
- *
- * Both glyphs are always rendered into one grid cell and only their opacity
- * changes, so the icon box is the same size in both states and the swap cannot
- * shift the row's text. The trigger is the shared row-hover CSS the sidebar's
- * other affordances already use rather than React hover state, so it stays a
- * paint-only change and matches keyboard focus for free.
- */
+function MenuIcon({ name }: { name?: string }) {
+  return isIconName(name) ? <Icon name={name} aria-hidden="true" /> : null;
+}
+
+function PluginMenuItemContent({
+  item,
+}: {
+  item: ExperimentalPluginNavPanelMenuItem;
+}) {
+  return (
+    <>
+      <MenuIcon name={item.icon} />
+      <span className="flex min-w-0 flex-col">
+        <span className="truncate">{item.label}</span>
+        {item.description ? (
+          <span className="truncate text-xs text-muted-foreground">
+            {item.description}
+          </span>
+        ) : null}
+      </span>
+    </>
+  );
+}
+
+function pluginActionErrorDescription(error: unknown): string {
+  return error instanceof Error ? error.message : "The plugin action failed.";
+}
+
+function runPluginAction(
+  item: ExperimentalPluginNavPanelMenuItem,
+  context: ExperimentalPluginNavPanelMenuContext,
+): void {
+  void Promise.resolve()
+    .then(() => item.run(context))
+    .catch((error: unknown) => {
+      console.warn(
+        `Plugin menu action ${context.pluginId}/${context.panelId}/${item.id} failed`,
+        error,
+      );
+      appToast.error("Could not run plugin action", {
+        description: pluginActionErrorDescription(error),
+      });
+    });
+}
+
+function PluginLeafMenuItems({
+  context,
+  items,
+  surface,
+}: {
+  context: ExperimentalPluginNavPanelMenuContext;
+  items: readonly ExperimentalPluginNavPanelMenuItem[];
+  surface: PluginNavRowMenuSurface;
+}) {
+  return items.map((item) => {
+    const content = <PluginMenuItemContent item={item} />;
+    const onSelect = () => runPluginAction(item, context);
+    return surface === "context" ? (
+      <ContextMenuItem
+        key={item.id}
+        disabled={item.disabled}
+        onSelect={onSelect}
+      >
+        {content}
+      </ContextMenuItem>
+    ) : (
+      <DropdownMenuItem
+        key={item.id}
+        disabled={item.disabled}
+        onSelect={onSelect}
+      >
+        {content}
+      </DropdownMenuItem>
+    );
+  });
+}
+
+type LazySubmenuState =
+  | { status: "idle" | "loading" | "error" }
+  | { status: "ready"; items: readonly ExperimentalPluginNavPanelMenuItem[] };
+
+function PluginMenuSubmenu({
+  context,
+  submenu,
+  surface,
+}: {
+  context: ExperimentalPluginNavPanelMenuContext;
+  submenu: ExperimentalPluginNavPanelSubmenu;
+  surface: PluginNavRowMenuSurface;
+}) {
+  const eagerItems = typeof submenu.items === "function" ? null : submenu.items;
+  const [lazyState, setLazyState] = useState<LazySubmenuState>(
+    eagerItems === null
+      ? { status: "idle" }
+      : { status: "ready", items: eagerItems },
+  );
+  const loadedForOpenRef = useRef(false);
+  const requestIdRef = useRef(0);
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        loadedForOpenRef.current = false;
+        requestIdRef.current += 1;
+        if (eagerItems === null) setLazyState({ status: "idle" });
+        return;
+      }
+      if (
+        eagerItems !== null ||
+        loadedForOpenRef.current ||
+        typeof submenu.items !== "function"
+      ) {
+        return;
+      }
+      loadedForOpenRef.current = true;
+      const requestId = ++requestIdRef.current;
+      const resolveItems = submenu.items;
+      setLazyState({ status: "loading" });
+      void Promise.resolve()
+        .then(() =>
+          typeof resolveItems === "function"
+            ? resolveItems(context)
+            : resolveItems,
+        )
+        .then((items) =>
+          validateExperimentalPluginNavPanelMenuItems(
+            `experimental_menu submenu ${submenu.id}`,
+            items,
+          ),
+        )
+        .then((items) => {
+          if (requestIdRef.current === requestId) {
+            setLazyState({ status: "ready", items });
+          }
+        })
+        .catch((error: unknown) => {
+          console.warn(
+            `Plugin submenu ${context.pluginId}/${context.panelId}/${submenu.id} failed`,
+            error,
+          );
+          if (requestIdRef.current === requestId) {
+            setLazyState({ status: "error" });
+          }
+        });
+    },
+    [context, eagerItems, submenu],
+  );
+  const trigger = (
+    <>
+      <MenuIcon name={submenu.icon} />
+      {submenu.label}
+    </>
+  );
+  const content =
+    lazyState.status === "ready" ? (
+      <PluginLeafMenuItems
+        context={context}
+        items={lazyState.items}
+        surface={surface}
+      />
+    ) : surface === "context" ? (
+      <ContextMenuItem disabled>
+        {lazyState.status === "error" ? "Could not load" : "Loading…"}
+      </ContextMenuItem>
+    ) : (
+      <DropdownMenuItem disabled>
+        {lazyState.status === "error" ? "Could not load" : "Loading…"}
+      </DropdownMenuItem>
+    );
+
+  return surface === "context" ? (
+    <ContextMenuSub onOpenChange={handleOpenChange}>
+      <ContextMenuSubTrigger>{trigger}</ContextMenuSubTrigger>
+      <ContextMenuSubContent>{content}</ContextMenuSubContent>
+    </ContextMenuSub>
+  ) : (
+    <DropdownMenuSub onOpenChange={handleOpenChange}>
+      <DropdownMenuSubTrigger>{trigger}</DropdownMenuSubTrigger>
+      <DropdownMenuSubContent>{content}</DropdownMenuSubContent>
+    </DropdownMenuSub>
+  );
+}
+
+function PluginMenuGroupItems({
+  context,
+  group,
+  surface,
+}: {
+  context: ExperimentalPluginNavPanelMenuContext;
+  group: ExperimentalPluginNavPanelMenuGroup;
+  surface: PluginNavRowMenuSurface;
+}) {
+  return group.items.map((item) =>
+    "items" in item ? (
+      <PluginMenuSubmenu
+        key={item.id}
+        context={context}
+        submenu={item}
+        surface={surface}
+      />
+    ) : (
+      <PluginLeafMenuItems
+        key={item.id}
+        context={context}
+        items={[item]}
+        surface={surface}
+      />
+    ),
+  );
+}
+
+function PluginNavRowMenuItems({
+  definition,
+  surface,
+}: {
+  definition: PluginNavRowMenuDefinition;
+  surface: PluginNavRowMenuSurface;
+}) {
+  return (
+    <>
+      {definition.hostActions.map((action) => {
+        const content = (
+          <>
+            <Icon name={action.icon} aria-hidden="true" />
+            {action.label}
+          </>
+        );
+        return surface === "context" ? (
+          <ContextMenuItem key={action.id} onSelect={action.run}>
+            {content}
+          </ContextMenuItem>
+        ) : (
+          <DropdownMenuItem key={action.id} onSelect={action.run}>
+            {content}
+          </DropdownMenuItem>
+        );
+      })}
+      {definition.pluginGroups.map((group, index) => (
+        <Fragment key={group.id}>
+          {surface === "context" ? (
+            <>
+              {(definition.hostActions.length > 0 || index > 0) && (
+                <ContextMenuSeparator />
+              )}
+              <ContextMenuLabel>
+                {group.label ?? definition.pluginDisplayName}
+              </ContextMenuLabel>
+            </>
+          ) : (
+            <>
+              {(definition.hostActions.length > 0 || index > 0) && (
+                <DropdownMenuSeparator />
+              )}
+              <DropdownMenuLabel>
+                {group.label ?? definition.pluginDisplayName}
+              </DropdownMenuLabel>
+            </>
+          )}
+          <PluginMenuGroupItems
+            context={definition.context}
+            group={group}
+            surface={surface}
+          />
+        </Fragment>
+      ))}
+    </>
+  );
+}
+
 function ToolsNavSidebarItemIcon() {
   return (
     <span className="bb-sidebar-row-icon-swap shrink-0" aria-hidden="true">
@@ -364,10 +687,6 @@ function ToolsNavSidebarItemIcon() {
   );
 }
 
-/**
- * Host-owned Extensions navigation. It lives beside New thread rather than in
- * plugin ordering and has no per-row visibility or split actions.
- */
 export function ExtensionsNavSidebarItem({
   routePath,
   onNavigate,
@@ -398,29 +717,151 @@ function PluginNavSidebarItem({
   pathname,
   onNavigate,
   splitEnabled,
+  registeredKeys,
+  normalizedOrder,
+  onOrderChange,
   ...props
-}: Omit<SidebarNavRowItemProps, "row"> & {
-  row: SidebarNavRow;
-}) {
+}: SidebarNavRowItemProps) {
   const { chrome, panel } = row;
   const navigate = useNavigate();
+  const pluginDisplayName = usePluginDisplayName(chrome.pluginId);
   const isCompactViewport = useIsCompactViewport();
-  const path = getPluginPanelRoutePath({
-    pluginId: chrome.pluginId,
-    path: chrome.path,
-  });
-  const content = {
-    kind: "plugin-panel",
-    pluginId: chrome.pluginId,
-    panelPath: chrome.path,
-    subPath: "",
-  } as const;
+  const path = routePathForRow(row);
+  const content = useMemo(
+    () =>
+      ({
+        kind: "plugin-panel",
+        pluginId: chrome.pluginId,
+        panelPath: chrome.path,
+        subPath: "",
+      }) as const,
+    [chrome.path, chrome.pluginId],
+  );
   const { onPointerDown, openInSplit } = usePaneContentSplitDrag({
     content,
     enabled: splitEnabled,
     label: chrome.title,
   });
   const splitIndicator = usePaneContentSplitIndicator(content, splitEnabled);
+  const rowKey = getPluginNavPanelKey(row);
+  const storedIndex = registeredKeys.indexOf(rowKey);
+  const hostActions = useMemo<HostMenuAction[]>(() => {
+    const actions: HostMenuAction[] = [];
+    if (
+      storedIndex >= PLUGIN_NAV_PANEL_VISIBLE_LIMIT ||
+      (registeredKeys.length <= PLUGIN_NAV_PANEL_VISIBLE_LIMIT &&
+        storedIndex > 0)
+    ) {
+      actions.push({
+        id: "move-top",
+        label: "Move to top",
+        icon: "ArrowUp",
+        run: () => {
+          const order = movePluginNavPanelToTop(
+            normalizedOrder,
+            registeredKeys,
+            rowKey,
+          );
+          if (order) onOrderChange(order);
+        },
+      });
+    } else if (
+      registeredKeys.length > PLUGIN_NAV_PANEL_VISIBLE_LIMIT &&
+      storedIndex >= 0
+    ) {
+      actions.push({
+        id: "move-overflow",
+        label: "Move to overflow",
+        icon: "ChevronsDown",
+        run: () => {
+          const order = movePluginNavPanelToOverflow(
+            normalizedOrder,
+            registeredKeys,
+            rowKey,
+          );
+          if (order) onOrderChange(order);
+        },
+      });
+    }
+    if (splitEnabled && !isCompactViewport) {
+      actions.push({
+        id: "open-split",
+        label: "Open in split",
+        icon: "Columns2",
+        run: () => openInSplit(),
+      });
+    }
+    if (panel !== null) {
+      actions.push({
+        id: "plugin-settings",
+        label: "Plugin settings",
+        icon: "Settings",
+        run: () => {
+          onNavigate?.();
+          void navigate(
+            getPluginDetailRoutePath({
+              pluginId: chrome.pluginId,
+              view: "installed",
+            }),
+          );
+        },
+      });
+    }
+    return actions;
+  }, [
+    chrome.pluginId,
+    isCompactViewport,
+    navigate,
+    normalizedOrder,
+    onNavigate,
+    onOrderChange,
+    openInSplit,
+    panel,
+    registeredKeys,
+    rowKey,
+    splitEnabled,
+    storedIndex,
+  ]);
+  const menuContext = useMemo<ExperimentalPluginNavPanelMenuContext>(
+    () => ({
+      pluginId: chrome.pluginId,
+      panelId: chrome.id,
+      navigate: (subPath) => {
+        onNavigate?.();
+        void navigate(
+          getPluginPanelRoutePath({
+            pluginId: chrome.pluginId,
+            path: chrome.path,
+            subPath,
+          }),
+        );
+      },
+      openInSplit: (subPath = "") => {
+        openInSplit({ ...content, subPath });
+      },
+    }),
+    [
+      chrome.id,
+      chrome.path,
+      chrome.pluginId,
+      content,
+      navigate,
+      onNavigate,
+      openInSplit,
+    ],
+  );
+  const pluginGroups = (panel?.experimental_menu ?? []).filter(
+    (group) => group.items.length > 0,
+  );
+  const menuDefinition: PluginNavRowMenuDefinition | null =
+    hostActions.length === 0 && pluginGroups.length === 0
+      ? null
+      : {
+          context: menuContext,
+          hostActions,
+          pluginGroups,
+          pluginDisplayName,
+        };
   const SidebarAccessory = panel?.experimental_sidebarAccessory;
   const sidebarAccessory =
     panel !== null && !isCompactViewport && SidebarAccessory !== undefined ? (
@@ -438,14 +879,13 @@ function PluginNavSidebarItem({
   return (
     <SidebarNavRowChrome
       {...props}
-      rowKey={getPluginNavPanelKey(row)}
+      rowKey={rowKey}
       title={chrome.title}
       icon={<PluginIcon pluginId={chrome.pluginId} icon={chrome.icon} />}
       isActive={pathname === path || pathname.startsWith(`${path}/`)}
       splitMiniMap={splitIndicator.miniMap}
       accessory={sidebarAccessory}
-      // Split-drag initiator; engages only when the pointer leaves the
-      // sidebar, so it coexists with the dnd-kit reorder listeners.
+      menuDefinition={menuDefinition}
       onPointerDown={onPointerDown}
       onSelect={(event) => {
         onNavigate?.();
@@ -464,21 +904,17 @@ interface SidebarNavRowChromeProps {
   title: string;
   icon: ReactNode;
   isActive: boolean;
-  onSelect: (event: ReactMouseEvent<HTMLButtonElement>) => void;
+  onSelect(event: ReactMouseEvent<HTMLButtonElement>): void;
   onPointerDown?: PointerEventHandler<HTMLElement>;
   splitMiniMap?: MiniMapSlot[] | null;
   accessory?: ReactNode;
-  isHidden?: boolean;
-  onHide?: (key: string) => void;
-  onShow?: (key: string) => void;
+  menuDefinition: PluginNavRowMenuDefinition | null;
   dragBindings?: SidebarSortableDragBindings;
   rowRef?: (element: HTMLElement | null) => void;
   rowStyle?: CSSProperties;
 }
 
-/** Shared chrome for every sidebar nav row: button, hide menus, drag handle. */
 function SidebarNavRowChrome({
-  rowKey,
   title,
   icon,
   isActive,
@@ -486,126 +922,127 @@ function SidebarNavRowChrome({
   onPointerDown,
   splitMiniMap = null,
   accessory,
-  isHidden = false,
-  onHide,
-  onShow,
+  menuDefinition,
   dragBindings,
   rowRef,
   rowStyle,
 }: SidebarNavRowChromeProps) {
+  const isCompactViewport = useIsCompactViewport();
   const [isActionsOpen, setIsActionsOpen] = useState(false);
-  // dnd-kit's KeyboardSensor activates on Space/Enter and preventDefaults them.
-  // On a real <button> row that would swallow Enter-to-open, so the row keeps
-  // only the pointer/touch drag activators. Reordering stays a pointer gesture.
   const { onKeyDown: _keyboardDragActivator, ...pointerDragListeners } =
     dragBindings?.listeners ?? {};
-  const visibilityItem = (surface: PluginNavRowMenuSurface): ReactNode => (
-    <PluginNavRowVisibilityMenuItem
-      surface={surface}
-      isHidden={isHidden}
-      onSelect={() => (isHidden ? onShow?.(rowKey) : onHide?.(rowKey))}
-    />
+  const rowContent = (
+    <div
+      ref={rowRef}
+      style={rowStyle}
+      className={cn(SIDEBAR_HOVER_ACTIONS_ROW_CLASS, "relative")}
+    >
+      <Button
+        type="button"
+        size="sm"
+        variant="ghost"
+        className={cn(
+          PROJECT_LIST_ACTION_BUTTON_CLASS,
+          "w-full pr-7",
+          accessory && "pr-18",
+          isActive && "bg-sidebar-accent text-sidebar-foreground",
+        )}
+        aria-current={isActive ? "page" : undefined}
+        ref={dragBindings?.setActivatorNodeRef}
+        {...dragBindings?.attributes}
+        onPointerDown={(event) => {
+          pointerDragListeners.onPointerDown?.(event);
+          onPointerDown?.(event);
+        }}
+        onClick={onSelect}
+      >
+        {icon}
+        <span className="flex min-w-0 flex-1 items-center gap-1.5 text-left">
+          <span className="min-w-0 truncate">{title}</span>
+          {splitMiniMap ? (
+            <SplitPaneMiniMap
+              slots={splitMiniMap}
+              label={`${title} — open in split`}
+            />
+          ) : null}
+        </span>
+      </Button>
+      {accessory ? (
+        <span
+          data-plugin-nav-sidebar-accessory=""
+          data-sidebar-hover-actions-open={isActionsOpen ? "true" : undefined}
+          className={cn(
+            SIDEBAR_HOVER_ACTIONS_FADE_CLASS,
+            "pointer-events-none absolute right-1 top-1/2 block min-w-5 max-h-5 max-w-16 -translate-y-1/2 overflow-hidden text-xs text-ellipsis whitespace-nowrap text-center leading-5",
+          )}
+        >
+          {accessory}
+        </span>
+      ) : null}
+      {menuDefinition ? (
+        <div
+          data-sidebar-hover-actions-open={isActionsOpen ? "true" : undefined}
+          data-sidebar-hover-actions-mobile={
+            SIDEBAR_HOVER_ACTIONS_MOBILE_ALWAYS_VALUE
+          }
+          className={cn(
+            SIDEBAR_HOVER_ACTIONS_CLASS,
+            "absolute inset-y-0 right-0 flex items-center",
+          )}
+        >
+          <DropdownMenu onOpenChange={setIsActionsOpen}>
+            <DropdownMenuTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                aria-label={`${title} panel options`}
+                className={cn(
+                  "rounded-md p-0 text-muted-foreground",
+                  "data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-foreground",
+                  SIDEBAR_MORE_ACTION_TRIGGER_CLASS,
+                )}
+              >
+                <Icon
+                  name="MoreHorizontal"
+                  className={COARSE_POINTER_ICON_SIZE_CLASS}
+                />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" mobileTitle={`${title} options`}>
+              <PluginNavRowMenuItems
+                definition={menuDefinition}
+                surface="dropdown"
+              />
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      ) : null}
+    </div>
   );
 
+  if (menuDefinition === null) return rowContent;
+  if (isCompactViewport) {
+    return (
+      <CompactLongPressMenu
+        label={`${title} panel options`}
+        onOpenChange={setIsActionsOpen}
+        items={
+          <PluginNavRowMenuItems
+            definition={menuDefinition}
+            surface="dropdown"
+          />
+        }
+      >
+        {rowContent}
+      </CompactLongPressMenu>
+    );
+  }
   return (
     <ContextMenu onOpenChange={setIsActionsOpen}>
-      <ContextMenuTrigger asChild>
-        <div
-          ref={rowRef}
-          style={rowStyle}
-          className={cn(SIDEBAR_HOVER_ACTIONS_ROW_CLASS, "relative")}
-        >
-          <Button
-            type="button"
-            size="sm"
-            variant="ghost"
-            className={cn(
-              PROJECT_LIST_ACTION_BUTTON_CLASS,
-              // Accessory-less rows keep their existing title width. A row
-              // with one reserves its 4rem trailing value; the options trigger
-              // replaces that value on hover rather than taking more space.
-              "w-full pr-7",
-              accessory && "pr-18",
-              isActive && "bg-sidebar-accent text-sidebar-foreground",
-              isHidden && "text-subtle-foreground",
-            )}
-            aria-current={isActive ? "page" : undefined}
-            ref={dragBindings?.setActivatorNodeRef}
-            {...dragBindings?.attributes}
-            {...pointerDragListeners}
-            onPointerDown={onPointerDown}
-            onClick={onSelect}
-          >
-            {icon}
-            <span className="flex min-w-0 flex-1 items-center gap-1.5 text-left">
-              <span className="min-w-0 truncate">{title}</span>
-              {splitMiniMap ? (
-                <SplitPaneMiniMap
-                  slots={splitMiniMap}
-                  label={`${title} — open in split`}
-                />
-              ) : null}
-            </span>
-          </Button>
-          {accessory ? (
-            <span
-              data-plugin-nav-sidebar-accessory=""
-              data-sidebar-hover-actions-open={
-                isActionsOpen ? "true" : undefined
-              }
-              // Share the action column with the options trigger. A short
-              // value centers on the trigger glyph; a longer value grows left
-              // up to 4rem. The shared fade class hides it on hover/focus or
-              // while the menu is open without unmounting plugin state.
-              className={cn(
-                SIDEBAR_HOVER_ACTIONS_FADE_CLASS,
-                "pointer-events-none absolute right-1 top-1/2 block min-w-5 max-h-5 max-w-16 -translate-y-1/2 overflow-hidden text-xs text-ellipsis whitespace-nowrap text-center leading-5",
-              )}
-            >
-              {accessory}
-            </span>
-          ) : null}
-          <div
-            data-sidebar-hover-actions-open={isActionsOpen ? "true" : undefined}
-            data-sidebar-hover-actions-mobile={
-              SIDEBAR_HOVER_ACTIONS_MOBILE_ALWAYS_VALUE
-            }
-            className={cn(
-              SIDEBAR_HOVER_ACTIONS_CLASS,
-              // right-0 (not right-1): the trigger's own m-1 supplies the inset,
-              // so the glyph centers on the same column as the sidebar search
-              // icon above and the thread-row more menus below.
-              "absolute inset-y-0 right-0 flex items-center",
-            )}
-          >
-            <DropdownMenu onOpenChange={setIsActionsOpen}>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  aria-label={`${title} panel options`}
-                  className={cn(
-                    "rounded-md p-0 text-muted-foreground",
-                    "data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-foreground",
-                    SIDEBAR_MORE_ACTION_TRIGGER_CLASS,
-                  )}
-                >
-                  <Icon
-                    name="MoreHorizontal"
-                    className={COARSE_POINTER_ICON_SIZE_CLASS}
-                  />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                {visibilityItem("dropdown")}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
-        </div>
-      </ContextMenuTrigger>
+      <ContextMenuTrigger asChild>{rowContent}</ContextMenuTrigger>
       <ContextMenuContent aria-label={`${title} panel options`}>
-        {visibilityItem("context")}
+        <PluginNavRowMenuItems definition={menuDefinition} surface="context" />
       </ContextMenuContent>
     </ContextMenu>
   );

--- a/apps/app/src/components/plugin/pluginNavSidebarAtoms.ts
+++ b/apps/app/src/components/plugin/pluginNavSidebarAtoms.ts
@@ -1,30 +1,61 @@
 import { atomWithStorage } from "jotai/utils";
-import { createJsonLocalStorage } from "@/lib/browser-storage";
+import {
+  createBooleanPreferenceAtom,
+  createJsonLocalStorage,
+  type SyncStorage,
+} from "@/lib/browser-storage";
+import { normalizePluginNavPanelOrder } from "./pluginNavSidebarOrder";
 
-const PLUGIN_NAV_PANEL_ORDER_STORAGE_KEY = "bb.sidebar.pluginPanelOrder";
-const HIDDEN_PLUGIN_NAV_PANELS_STORAGE_KEY = "bb.sidebar.hiddenPluginPanels";
+export const PLUGIN_NAV_PANEL_ORDER_STORAGE_KEY = "bb.sidebar.pluginPanelOrder";
+export const HIDDEN_PLUGIN_NAV_PANELS_STORAGE_KEY =
+  "bb.sidebar.hiddenPluginPanels";
+export const PLUGIN_NAV_PANEL_OVERFLOW_EXPANDED_STORAGE_KEY =
+  "bb.sidebar.pluginPanelOverflowExpanded";
+
+const jsonStringArrayStorage = createJsonLocalStorage<unknown>();
+const normalizedStringArrayStorage: SyncStorage<string[]> = {
+  getItem: (key, initialValue) =>
+    normalizePluginNavPanelOrder(
+      jsonStringArrayStorage.getItem(key, initialValue),
+    ),
+  setItem: (key, value) => {
+    jsonStringArrayStorage.setItem(key, normalizePluginNavPanelOrder(value));
+  },
+  removeItem: (key) => {
+    jsonStringArrayStorage.removeItem(key);
+  },
+  subscribe: (key, callback, initialValue) =>
+    jsonStringArrayStorage.subscribe?.(
+      key,
+      (value) => callback(normalizePluginNavPanelOrder(value)),
+      initialValue,
+    ),
+};
 
 /**
- * User-chosen order of the sidebar's plugin panel rows, as
- * `<pluginId>/<panelId>` keys. Includes hidden panels so unhiding restores a
- * panel to its old slot. Empty until the first drag, which means "registry
- * order". Client-local, like the other sidebar layout preferences.
+ * User-chosen order of every sidebar plugin panel row, as
+ * `<pluginId>/<panelId>` keys. Reads dedupe malformed stored values so two
+ * windows cannot make one panel render twice. Empty means registry order.
  */
 export const pluginNavPanelOrderAtom = atomWithStorage<string[]>(
   PLUGIN_NAV_PANEL_ORDER_STORAGE_KEY,
   [],
-  createJsonLocalStorage<string[]>(),
+  normalizedStringArrayStorage,
   { getOnInit: true },
 );
 
 /**
- * Plugin panel keys the user moved into the sidebar's "More" disclosure. The
- * panel and its route stay fully available — this only affects sidebar
- * placement.
+ * Legacy hidden page keys. Phase 3 reads this atom only to migrate those pages
+ * to the end of the one order, then clears it.
  */
 export const hiddenPluginNavPanelsAtom = atomWithStorage<string[]>(
   HIDDEN_PLUGIN_NAV_PANELS_STORAGE_KEY,
   [],
-  createJsonLocalStorage<string[]>(),
+  normalizedStringArrayStorage,
   { getOnInit: true },
+);
+
+export const pluginNavPanelOverflowExpandedAtom = createBooleanPreferenceAtom(
+  PLUGIN_NAV_PANEL_OVERFLOW_EXPANDED_STORAGE_KEY,
+  false,
 );

--- a/apps/app/src/components/plugin/pluginNavSidebarAtoms.ts
+++ b/apps/app/src/components/plugin/pluginNavSidebarAtoms.ts
@@ -11,6 +11,8 @@ export const HIDDEN_PLUGIN_NAV_PANELS_STORAGE_KEY =
   "bb.sidebar.hiddenPluginPanels";
 export const PLUGIN_NAV_PANEL_OVERFLOW_EXPANDED_STORAGE_KEY =
   "bb.sidebar.pluginPanelOverflowExpanded";
+export const PLUGIN_NAV_PANEL_MIGRATED_VISIBLE_LIMIT_STORAGE_KEY =
+  "bb.sidebar.pluginPanelMigratedVisibleLimit";
 
 const jsonStringArrayStorage = createJsonLocalStorage<unknown>();
 const normalizedStringArrayStorage: SyncStorage<string[]> = {
@@ -32,6 +34,39 @@ const normalizedStringArrayStorage: SyncStorage<string[]> = {
     ),
 };
 
+function normalizeMigratedVisibleLimit(value: unknown): number | null {
+  return typeof value === "number" &&
+    Number.isInteger(value) &&
+    value >= 0 &&
+    value <= 5
+    ? value
+    : null;
+}
+
+const jsonMigratedVisibleLimitStorage = createJsonLocalStorage<unknown>();
+const migratedVisibleLimitStorage: SyncStorage<number | null> = {
+  getItem: (key, initialValue) =>
+    normalizeMigratedVisibleLimit(
+      jsonMigratedVisibleLimitStorage.getItem(key, initialValue),
+    ),
+  setItem: (key, value) => {
+    if (value === null) {
+      jsonMigratedVisibleLimitStorage.removeItem(key);
+      return;
+    }
+    jsonMigratedVisibleLimitStorage.setItem(key, value);
+  },
+  removeItem: (key) => {
+    jsonMigratedVisibleLimitStorage.removeItem(key);
+  },
+  subscribe: (key, callback, initialValue) =>
+    jsonMigratedVisibleLimitStorage.subscribe?.(
+      key,
+      (value) => callback(normalizeMigratedVisibleLimit(value)),
+      initialValue,
+    ),
+};
+
 /**
  * User-chosen order of every sidebar plugin panel row, as
  * `<pluginId>/<panelId>` keys. Reads dedupe malformed stored values so two
@@ -45,8 +80,8 @@ export const pluginNavPanelOrderAtom = atomWithStorage<string[]>(
 );
 
 /**
- * Legacy hidden page keys. Phase 3 reads this atom only to migrate those pages
- * to the end of the one order, then clears it.
+ * Legacy hidden row keys. Phase 3 consumes plugin-page keys only; host-owned
+ * keys remain for the migration that owns their replacement preference.
  */
 export const hiddenPluginNavPanelsAtom = atomWithStorage<string[]>(
   HIDDEN_PLUGIN_NAV_PANELS_STORAGE_KEY,
@@ -58,4 +93,18 @@ export const hiddenPluginNavPanelsAtom = atomWithStorage<string[]>(
 export const pluginNavPanelOverflowExpandedAtom = createBooleanPreferenceAtom(
   PLUGIN_NAV_PANEL_OVERFLOW_EXPANDED_STORAGE_KEY,
   false,
+);
+
+/**
+ * Temporary fold that preserves the number of visible plugin pages from the
+ * legacy hidden-page model. It disappears once the user promotes enough pages
+ * to reach the standard cap, after which the ordinary <=5 flat-list rule wins.
+ */
+export const pluginNavPanelMigratedVisibleLimitAtom = atomWithStorage<
+  number | null
+>(
+  PLUGIN_NAV_PANEL_MIGRATED_VISIBLE_LIMIT_STORAGE_KEY,
+  null,
+  migratedVisibleLimitStorage,
+  { getOnInit: true },
 );

--- a/apps/app/src/components/plugin/pluginNavSidebarMigration.test.ts
+++ b/apps/app/src/components/plugin/pluginNavSidebarMigration.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import {
+  HIDDEN_PLUGIN_NAV_PANELS_STORAGE_KEY,
+  PLUGIN_NAV_PANEL_ORDER_STORAGE_KEY,
+} from "./pluginNavSidebarAtoms";
+import {
+  HIDDEN_PLUGIN_NAV_PANELS_MIGRATION_STORAGE_KEY,
+  migrateHiddenPluginNavPanels,
+} from "./pluginNavSidebarMigration";
+
+class MemoryStorage {
+  readonly values = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+}
+
+class SerializedLockManager {
+  private tail = Promise.resolve();
+
+  request<T>(_name: string, callback: () => Promise<T>): Promise<T> {
+    const result = this.tail.then(callback);
+    this.tail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  }
+}
+
+const registrationOrder = [
+  "docs/main",
+  "github/main",
+  "tasks/main",
+  "notes/main",
+];
+
+describe("migrateHiddenPluginNavPanels", () => {
+  it("appends legacy hidden pages in registration order and clears hiding", async () => {
+    const storage = new MemoryStorage();
+    storage.setItem(
+      PLUGIN_NAV_PANEL_ORDER_STORAGE_KEY,
+      JSON.stringify(["tasks/main", "docs/main", "github/main"]),
+    );
+    storage.setItem(
+      HIDDEN_PLUGIN_NAV_PANELS_STORAGE_KEY,
+      JSON.stringify(["tasks/main", "github/main"]),
+    );
+
+    await expect(
+      migrateHiddenPluginNavPanels({
+        storage,
+        registrationOrder,
+        lockManager: null,
+      }),
+    ).resolves.toEqual([
+      "docs/main",
+      "notes/main",
+      "github/main",
+      "tasks/main",
+    ]);
+    expect(storage.getItem(HIDDEN_PLUGIN_NAV_PANELS_STORAGE_KEY)).toBe("[]");
+    expect(
+      storage.getItem(HIDDEN_PLUGIN_NAV_PANELS_MIGRATION_STORAGE_KEY),
+    ).toBe("1");
+  });
+
+  it("never re-demotes a migrated page that the user moved to the top", async () => {
+    const storage = new MemoryStorage();
+    storage.setItem(
+      HIDDEN_PLUGIN_NAV_PANELS_STORAGE_KEY,
+      JSON.stringify(["tasks/main"]),
+    );
+    await migrateHiddenPluginNavPanels({
+      storage,
+      registrationOrder,
+      lockManager: null,
+    });
+    storage.setItem(
+      PLUGIN_NAV_PANEL_ORDER_STORAGE_KEY,
+      JSON.stringify(["tasks/main", "docs/main", "github/main", "notes/main"]),
+    );
+    storage.setItem(
+      HIDDEN_PLUGIN_NAV_PANELS_STORAGE_KEY,
+      JSON.stringify(["tasks/main"]),
+    );
+
+    await expect(
+      migrateHiddenPluginNavPanels({
+        storage,
+        registrationOrder,
+        lockManager: null,
+      }),
+    ).resolves.toEqual([
+      "tasks/main",
+      "docs/main",
+      "github/main",
+      "notes/main",
+    ]);
+    expect(storage.getItem(HIDDEN_PLUGIN_NAV_PANELS_STORAGE_KEY)).toBe("[]");
+  });
+
+  it("serializes concurrent windows and dedupes the order on read", async () => {
+    const storage = new MemoryStorage();
+    const lockManager = new SerializedLockManager();
+    storage.setItem(
+      PLUGIN_NAV_PANEL_ORDER_STORAGE_KEY,
+      JSON.stringify(["docs/main", "docs/main", "tasks/main"]),
+    );
+    storage.setItem(
+      HIDDEN_PLUGIN_NAV_PANELS_STORAGE_KEY,
+      JSON.stringify(["tasks/main"]),
+    );
+
+    const [first, second] = await Promise.all([
+      migrateHiddenPluginNavPanels({ storage, registrationOrder, lockManager }),
+      migrateHiddenPluginNavPanels({ storage, registrationOrder, lockManager }),
+    ]);
+    expect(first).toEqual([
+      "docs/main",
+      "github/main",
+      "notes/main",
+      "tasks/main",
+    ]);
+    expect(second).toEqual(first);
+    expect(
+      JSON.parse(storage.getItem(PLUGIN_NAV_PANEL_ORDER_STORAGE_KEY) ?? "[]"),
+    ).toEqual(first);
+  });
+});

--- a/apps/app/src/components/plugin/pluginNavSidebarMigration.test.ts
+++ b/apps/app/src/components/plugin/pluginNavSidebarMigration.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
   HIDDEN_PLUGIN_NAV_PANELS_STORAGE_KEY,
+  PLUGIN_NAV_PANEL_MIGRATED_VISIBLE_LIMIT_STORAGE_KEY,
   PLUGIN_NAV_PANEL_ORDER_STORAGE_KEY,
 } from "./pluginNavSidebarAtoms";
 import {
   HIDDEN_PLUGIN_NAV_PANELS_MIGRATION_STORAGE_KEY,
+  LEGACY_TOOLS_NAV_ROW_KEY,
   migrateHiddenPluginNavPanels,
 } from "./pluginNavSidebarMigration";
 
@@ -17,6 +19,10 @@ class MemoryStorage {
 
   setItem(key: string, value: string): void {
     this.values.set(key, value);
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
   }
 }
 
@@ -41,7 +47,7 @@ const registrationOrder = [
 ];
 
 describe("migrateHiddenPluginNavPanels", () => {
-  it("appends legacy hidden pages in registration order and clears hiding", async () => {
+  it("appends legacy hidden pages in their stored order and clears only those keys", async () => {
     const storage = new MemoryStorage();
     storage.setItem(
       PLUGIN_NAV_PANEL_ORDER_STORAGE_KEY,
@@ -49,7 +55,7 @@ describe("migrateHiddenPluginNavPanels", () => {
     );
     storage.setItem(
       HIDDEN_PLUGIN_NAV_PANELS_STORAGE_KEY,
-      JSON.stringify(["tasks/main", "github/main"]),
+      JSON.stringify(["tasks/main", "github/main", LEGACY_TOOLS_NAV_ROW_KEY]),
     );
 
     await expect(
@@ -58,13 +64,17 @@ describe("migrateHiddenPluginNavPanels", () => {
         registrationOrder,
         lockManager: null,
       }),
-    ).resolves.toEqual([
-      "docs/main",
-      "notes/main",
-      "github/main",
-      "tasks/main",
-    ]);
-    expect(storage.getItem(HIDDEN_PLUGIN_NAV_PANELS_STORAGE_KEY)).toBe("[]");
+    ).resolves.toEqual({
+      order: ["docs/main", "notes/main", "tasks/main", "github/main"],
+      remainingHiddenKeys: [LEGACY_TOOLS_NAV_ROW_KEY],
+      migratedVisibleLimit: 2,
+    });
+    expect(storage.getItem(HIDDEN_PLUGIN_NAV_PANELS_STORAGE_KEY)).toBe(
+      JSON.stringify([LEGACY_TOOLS_NAV_ROW_KEY]),
+    );
+    expect(
+      storage.getItem(PLUGIN_NAV_PANEL_MIGRATED_VISIBLE_LIMIT_STORAGE_KEY),
+    ).toBe("2");
     expect(
       storage.getItem(HIDDEN_PLUGIN_NAV_PANELS_MIGRATION_STORAGE_KEY),
     ).toBe("1");
@@ -87,8 +97,9 @@ describe("migrateHiddenPluginNavPanels", () => {
     );
     storage.setItem(
       HIDDEN_PLUGIN_NAV_PANELS_STORAGE_KEY,
-      JSON.stringify(["tasks/main"]),
+      JSON.stringify(["tasks/main", LEGACY_TOOLS_NAV_ROW_KEY]),
     );
+    storage.removeItem(PLUGIN_NAV_PANEL_MIGRATED_VISIBLE_LIMIT_STORAGE_KEY);
 
     await expect(
       migrateHiddenPluginNavPanels({
@@ -96,13 +107,14 @@ describe("migrateHiddenPluginNavPanels", () => {
         registrationOrder,
         lockManager: null,
       }),
-    ).resolves.toEqual([
-      "tasks/main",
-      "docs/main",
-      "github/main",
-      "notes/main",
-    ]);
-    expect(storage.getItem(HIDDEN_PLUGIN_NAV_PANELS_STORAGE_KEY)).toBe("[]");
+    ).resolves.toEqual({
+      order: ["tasks/main", "docs/main", "github/main", "notes/main"],
+      remainingHiddenKeys: [LEGACY_TOOLS_NAV_ROW_KEY],
+      migratedVisibleLimit: null,
+    });
+    expect(storage.getItem(HIDDEN_PLUGIN_NAV_PANELS_STORAGE_KEY)).toBe(
+      JSON.stringify([LEGACY_TOOLS_NAV_ROW_KEY]),
+    );
   });
 
   it("serializes concurrent windows and dedupes the order on read", async () => {
@@ -121,15 +133,33 @@ describe("migrateHiddenPluginNavPanels", () => {
       migrateHiddenPluginNavPanels({ storage, registrationOrder, lockManager }),
       migrateHiddenPluginNavPanels({ storage, registrationOrder, lockManager }),
     ]);
-    expect(first).toEqual([
-      "docs/main",
-      "github/main",
-      "notes/main",
-      "tasks/main",
-    ]);
+    expect(first).toEqual({
+      order: ["docs/main", "github/main", "notes/main", "tasks/main"],
+      remainingHiddenKeys: [],
+      migratedVisibleLimit: 3,
+    });
     expect(second).toEqual(first);
     expect(
       JSON.parse(storage.getItem(PLUGIN_NAV_PANEL_ORDER_STORAGE_KEY) ?? "[]"),
-    ).toEqual(first);
+    ).toEqual(first.order);
+  });
+
+  it("records a zero-row fold when every registered page was hidden", async () => {
+    const storage = new MemoryStorage();
+    storage.setItem(
+      HIDDEN_PLUGIN_NAV_PANELS_STORAGE_KEY,
+      JSON.stringify(registrationOrder),
+    );
+
+    await expect(
+      migrateHiddenPluginNavPanels({
+        storage,
+        registrationOrder,
+        lockManager: null,
+      }),
+    ).resolves.toMatchObject({
+      order: registrationOrder,
+      migratedVisibleLimit: 0,
+    });
   });
 });

--- a/apps/app/src/components/plugin/pluginNavSidebarMigration.ts
+++ b/apps/app/src/components/plugin/pluginNavSidebarMigration.ts
@@ -1,8 +1,12 @@
 import {
   HIDDEN_PLUGIN_NAV_PANELS_STORAGE_KEY,
+  PLUGIN_NAV_PANEL_MIGRATED_VISIBLE_LIMIT_STORAGE_KEY,
   PLUGIN_NAV_PANEL_ORDER_STORAGE_KEY,
 } from "./pluginNavSidebarAtoms";
-import { normalizePluginNavPanelOrder } from "./pluginNavSidebarOrder";
+import {
+  normalizePluginNavPanelOrder,
+  PLUGIN_NAV_PANEL_VISIBLE_LIMIT,
+} from "./pluginNavSidebarOrder";
 
 export const HIDDEN_PLUGIN_NAV_PANELS_MIGRATION_STORAGE_KEY =
   "bb.sidebar.hiddenPluginPanelsMigrated.v1";
@@ -10,9 +14,16 @@ const HIDDEN_PLUGIN_NAV_PANELS_MIGRATION_LOCK =
   "bb.sidebar.hiddenPluginPanelsMigration.v1";
 const MIGRATION_COMPLETE = "1";
 
+export const LEGACY_TOOLS_NAV_ROW_KEY = "__builtin__/tools";
+
+export function isPluginNavPanelKey(key: string): boolean {
+  return !key.startsWith("__builtin__/");
+}
+
 interface PluginNavPanelMigrationStorage {
   getItem(key: string): string | null;
   setItem(key: string, value: string): void;
+  removeItem(key: string): void;
 }
 
 interface PluginNavPanelMigrationLockManager {
@@ -23,6 +34,12 @@ interface MigrateHiddenPluginNavPanelsArgs {
   storage: PluginNavPanelMigrationStorage;
   registrationOrder: readonly string[];
   lockManager?: PluginNavPanelMigrationLockManager | null;
+}
+
+export interface HiddenPluginNavPanelsMigrationResult {
+  order: string[];
+  remainingHiddenKeys: string[];
+  migratedVisibleLimit: number | null;
 }
 
 function readStoredKeys(
@@ -38,48 +55,109 @@ function readStoredKeys(
   }
 }
 
+function readMigratedVisibleLimit(
+  storage: PluginNavPanelMigrationStorage,
+): number | null {
+  const value = storage.getItem(
+    PLUGIN_NAV_PANEL_MIGRATED_VISIBLE_LIMIT_STORAGE_KEY,
+  );
+  if (value === null) return null;
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return typeof parsed === "number" &&
+      Number.isInteger(parsed) &&
+      parsed >= 0 &&
+      parsed <= PLUGIN_NAV_PANEL_VISIBLE_LIMIT
+      ? parsed
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeMigratedVisibleLimit(
+  storage: PluginNavPanelMigrationStorage,
+  visibleLimit: number | null,
+): void {
+  if (visibleLimit === null) {
+    storage.removeItem(PLUGIN_NAV_PANEL_MIGRATED_VISIBLE_LIMIT_STORAGE_KEY);
+    return;
+  }
+  storage.setItem(
+    PLUGIN_NAV_PANEL_MIGRATED_VISIBLE_LIMIT_STORAGE_KEY,
+    JSON.stringify(visibleLimit),
+  );
+}
+
 function migrateUnderLock(
   storage: PluginNavPanelMigrationStorage,
   registrationOrderValue: readonly string[],
-): string[] {
+): HiddenPluginNavPanelsMigrationResult {
   const registrationOrder = normalizePluginNavPanelOrder(
     registrationOrderValue,
-  );
+  ).filter(isPluginNavPanelKey);
   const currentOrder = normalizePluginNavPanelOrder([
-    ...readStoredKeys(storage, PLUGIN_NAV_PANEL_ORDER_STORAGE_KEY),
+    ...readStoredKeys(storage, PLUGIN_NAV_PANEL_ORDER_STORAGE_KEY).filter(
+      isPluginNavPanelKey,
+    ),
     ...registrationOrder,
   ]);
+  const hiddenKeys = readStoredKeys(
+    storage,
+    HIDDEN_PLUGIN_NAV_PANELS_STORAGE_KEY,
+  );
+  const remainingHiddenKeys = hiddenKeys.filter(
+    (key) => !isPluginNavPanelKey(key),
+  );
 
   if (
     storage.getItem(HIDDEN_PLUGIN_NAV_PANELS_MIGRATION_STORAGE_KEY) ===
     MIGRATION_COMPLETE
   ) {
-    storage.setItem(HIDDEN_PLUGIN_NAV_PANELS_STORAGE_KEY, "[]");
-    return currentOrder;
+    storage.setItem(
+      HIDDEN_PLUGIN_NAV_PANELS_STORAGE_KEY,
+      JSON.stringify(remainingHiddenKeys),
+    );
+    return {
+      order: currentOrder,
+      remainingHiddenKeys,
+      migratedVisibleLimit: readMigratedVisibleLimit(storage),
+    };
   }
 
-  const hiddenKeys = readStoredKeys(
-    storage,
-    HIDDEN_PLUGIN_NAV_PANELS_STORAGE_KEY,
-  );
-  const hiddenSet = new Set(hiddenKeys);
-  const nextOrder = [
-    ...currentOrder.filter((key) => !hiddenSet.has(key)),
-    ...registrationOrder.filter((key) => hiddenSet.has(key)),
-    ...hiddenKeys.filter((key) => !registrationOrder.includes(key)),
-  ];
-  const normalizedOrder = normalizePluginNavPanelOrder(nextOrder);
+  const hiddenPluginKeys = hiddenKeys.filter(isPluginNavPanelKey);
+  const hiddenSet = new Set(hiddenPluginKeys);
+  const completeOrder = normalizePluginNavPanelOrder([
+    ...currentOrder,
+    ...hiddenPluginKeys,
+  ]);
+  const normalizedOrder = normalizePluginNavPanelOrder([
+    ...completeOrder.filter((key) => !hiddenSet.has(key)),
+    ...completeOrder.filter((key) => hiddenSet.has(key)),
+  ]);
+  const previouslyVisibleCount = registrationOrder.filter(
+    (key) => !hiddenSet.has(key),
+  ).length;
+  const migratedVisibleLimit =
+    hiddenPluginKeys.length > 0 &&
+    previouslyVisibleCount < PLUGIN_NAV_PANEL_VISIBLE_LIMIT
+      ? previouslyVisibleCount
+      : null;
 
   storage.setItem(
     PLUGIN_NAV_PANEL_ORDER_STORAGE_KEY,
     JSON.stringify(normalizedOrder),
   );
+  writeMigratedVisibleLimit(storage, migratedVisibleLimit);
   storage.setItem(
     HIDDEN_PLUGIN_NAV_PANELS_MIGRATION_STORAGE_KEY,
     MIGRATION_COMPLETE,
   );
-  storage.setItem(HIDDEN_PLUGIN_NAV_PANELS_STORAGE_KEY, "[]");
-  return normalizedOrder;
+  storage.setItem(
+    HIDDEN_PLUGIN_NAV_PANELS_STORAGE_KEY,
+    JSON.stringify(remainingHiddenKeys),
+  );
+  return { order: normalizedOrder, remainingHiddenKeys, migratedVisibleLimit };
 }
 
 export async function migrateHiddenPluginNavPanels({
@@ -89,7 +167,7 @@ export async function migrateHiddenPluginNavPanels({
     ? null
     : ((navigator.locks as PluginNavPanelMigrationLockManager | undefined) ??
       null),
-}: MigrateHiddenPluginNavPanelsArgs): Promise<string[]> {
+}: MigrateHiddenPluginNavPanelsArgs): Promise<HiddenPluginNavPanelsMigrationResult> {
   if (lockManager === null) {
     return migrateUnderLock(storage, registrationOrder);
   }

--- a/apps/app/src/components/plugin/pluginNavSidebarMigration.ts
+++ b/apps/app/src/components/plugin/pluginNavSidebarMigration.ts
@@ -1,0 +1,100 @@
+import {
+  HIDDEN_PLUGIN_NAV_PANELS_STORAGE_KEY,
+  PLUGIN_NAV_PANEL_ORDER_STORAGE_KEY,
+} from "./pluginNavSidebarAtoms";
+import { normalizePluginNavPanelOrder } from "./pluginNavSidebarOrder";
+
+export const HIDDEN_PLUGIN_NAV_PANELS_MIGRATION_STORAGE_KEY =
+  "bb.sidebar.hiddenPluginPanelsMigrated.v1";
+const HIDDEN_PLUGIN_NAV_PANELS_MIGRATION_LOCK =
+  "bb.sidebar.hiddenPluginPanelsMigration.v1";
+const MIGRATION_COMPLETE = "1";
+
+interface PluginNavPanelMigrationStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+interface PluginNavPanelMigrationLockManager {
+  request<T>(name: string, callback: () => Promise<T>): Promise<T>;
+}
+
+interface MigrateHiddenPluginNavPanelsArgs {
+  storage: PluginNavPanelMigrationStorage;
+  registrationOrder: readonly string[];
+  lockManager?: PluginNavPanelMigrationLockManager | null;
+}
+
+function readStoredKeys(
+  storage: PluginNavPanelMigrationStorage,
+  key: string,
+): string[] {
+  const value = storage.getItem(key);
+  if (value === null) return [];
+  try {
+    return normalizePluginNavPanelOrder(JSON.parse(value));
+  } catch {
+    return [];
+  }
+}
+
+function migrateUnderLock(
+  storage: PluginNavPanelMigrationStorage,
+  registrationOrderValue: readonly string[],
+): string[] {
+  const registrationOrder = normalizePluginNavPanelOrder(
+    registrationOrderValue,
+  );
+  const currentOrder = normalizePluginNavPanelOrder([
+    ...readStoredKeys(storage, PLUGIN_NAV_PANEL_ORDER_STORAGE_KEY),
+    ...registrationOrder,
+  ]);
+
+  if (
+    storage.getItem(HIDDEN_PLUGIN_NAV_PANELS_MIGRATION_STORAGE_KEY) ===
+    MIGRATION_COMPLETE
+  ) {
+    storage.setItem(HIDDEN_PLUGIN_NAV_PANELS_STORAGE_KEY, "[]");
+    return currentOrder;
+  }
+
+  const hiddenKeys = readStoredKeys(
+    storage,
+    HIDDEN_PLUGIN_NAV_PANELS_STORAGE_KEY,
+  );
+  const hiddenSet = new Set(hiddenKeys);
+  const nextOrder = [
+    ...currentOrder.filter((key) => !hiddenSet.has(key)),
+    ...registrationOrder.filter((key) => hiddenSet.has(key)),
+    ...hiddenKeys.filter((key) => !registrationOrder.includes(key)),
+  ];
+  const normalizedOrder = normalizePluginNavPanelOrder(nextOrder);
+
+  storage.setItem(
+    PLUGIN_NAV_PANEL_ORDER_STORAGE_KEY,
+    JSON.stringify(normalizedOrder),
+  );
+  storage.setItem(
+    HIDDEN_PLUGIN_NAV_PANELS_MIGRATION_STORAGE_KEY,
+    MIGRATION_COMPLETE,
+  );
+  storage.setItem(HIDDEN_PLUGIN_NAV_PANELS_STORAGE_KEY, "[]");
+  return normalizedOrder;
+}
+
+export async function migrateHiddenPluginNavPanels({
+  storage,
+  registrationOrder,
+  lockManager = typeof navigator === "undefined"
+    ? null
+    : ((navigator.locks as PluginNavPanelMigrationLockManager | undefined) ??
+      null),
+}: MigrateHiddenPluginNavPanelsArgs): Promise<string[]> {
+  if (lockManager === null) {
+    return migrateUnderLock(storage, registrationOrder);
+  }
+  return lockManager.request(
+    HIDDEN_PLUGIN_NAV_PANELS_MIGRATION_LOCK,
+    async () => migrateUnderLock(storage, registrationOrder),
+  );
+}

--- a/apps/app/src/components/plugin/pluginNavSidebarOrder.test.ts
+++ b/apps/app/src/components/plugin/pluginNavSidebarOrder.test.ts
@@ -3,7 +3,6 @@ import {
   arrangePluginNavPanels,
   getPluginNavPanelKey,
   reorderPluginNavPanels,
-  seedLeadingNavPanelKeys,
 } from "./pluginNavSidebarOrder";
 
 function panel(pluginId: string, id: string) {
@@ -156,29 +155,5 @@ describe("reorderPluginNavPanels", () => {
         visibleKeys: ["github/pulls"],
       }),
     ).toBeNull();
-  });
-});
-
-describe("seedLeadingNavPanelKeys", () => {
-  it("leaves an untouched order empty so registry order still wins", () => {
-    expect(seedLeadingNavPanelKeys([], ["__builtin__/tools"])).toEqual([]);
-  });
-
-  it("prepends a built-in key that a customized order predates", () => {
-    expect(
-      seedLeadingNavPanelKeys(
-        ["github/pulls", "docs/vault"],
-        ["__builtin__/tools"],
-      ),
-    ).toEqual(["__builtin__/tools", "github/pulls", "docs/vault"]);
-  });
-
-  it("keeps the user's slot for a built-in key they already moved", () => {
-    expect(
-      seedLeadingNavPanelKeys(
-        ["github/pulls", "__builtin__/tools"],
-        ["__builtin__/tools"],
-      ),
-    ).toEqual(["github/pulls", "__builtin__/tools"]);
   });
 });

--- a/apps/app/src/components/plugin/pluginNavSidebarOrder.test.ts
+++ b/apps/app/src/components/plugin/pluginNavSidebarOrder.test.ts
@@ -2,158 +2,135 @@ import { describe, expect, it } from "vitest";
 import {
   arrangePluginNavPanels,
   getPluginNavPanelKey,
+  movePluginNavPanelToOverflow,
+  movePluginNavPanelToTop,
+  normalizePluginNavPanelOrder,
   reorderPluginNavPanels,
 } from "./pluginNavSidebarOrder";
 
-function panel(pluginId: string, id: string) {
+function panel(pluginId: string, id = "main") {
   return { pluginId, id };
 }
 
-const github = panel("github", "pulls");
-const docs = panel("docs", "vault");
-const tasks = panel("tasks", "board");
+const panels = Array.from({ length: 9 }, (_, index) =>
+  panel(`plugin-${index + 1}`),
+);
+const keys = panels.map(getPluginNavPanelKey);
 
 describe("arrangePluginNavPanels", () => {
-  it("falls back to registry order before the user has reordered anything", () => {
-    const { visible, normalizedOrder } = arrangePluginNavPanels({
-      panels: [github, docs, tasks],
+  it.each([1, 4, 5])("keeps %i pages in one flat list", (count) => {
+    const arranged = arrangePluginNavPanels({
+      panels: panels.slice(0, count),
       storedOrder: [],
-      hiddenKeys: [],
     });
+    expect(arranged.visible.map(getPluginNavPanelKey)).toEqual(
+      keys.slice(0, count),
+    );
+    expect(arranged.overflow).toEqual([]);
+  });
 
-    expect(visible.map(getPluginNavPanelKey)).toEqual([
-      "github/pulls",
-      "docs/vault",
-      "tasks/board",
-    ]);
-    expect(normalizedOrder).toEqual([
-      "github/pulls",
-      "docs/vault",
-      "tasks/board",
+  it.each([6, 9])("caps %i pages at five", (count) => {
+    const arranged = arrangePluginNavPanels({
+      panels: panels.slice(0, count),
+      storedOrder: [],
+    });
+    expect(arranged.visible.map(getPluginNavPanelKey)).toEqual(
+      keys.slice(0, 5),
+    );
+    expect(arranged.overflow.map(getPluginNavPanelKey)).toEqual(
+      keys.slice(5, count),
+    );
+  });
+
+  it("appends a newly installed panel after a customized order", () => {
+    const arranged = arrangePluginNavPanels({
+      panels: panels.slice(0, 3),
+      storedOrder: [keys[2], keys[0]],
+    });
+    expect(arranged.ordered.map(getPluginNavPanelKey)).toEqual([
+      keys[2],
+      keys[0],
+      keys[1],
     ]);
   });
 
-  it("appends newly installed panels last instead of at the top of a customized list", () => {
-    const { visible } = arrangePluginNavPanels({
-      panels: [github, docs, tasks],
-      storedOrder: ["tasks/board", "github/pulls"],
-      hiddenKeys: [],
+  it("keeps unregistered keys and restores a late registration to its slot", () => {
+    const storedOrder = [keys[2], keys[1], keys[0]];
+    const before = arrangePluginNavPanels({
+      panels: [panels[0], panels[1]],
+      storedOrder,
     });
-
-    expect(visible.map(getPluginNavPanelKey)).toEqual([
-      "tasks/board",
-      "github/pulls",
-      "docs/vault",
+    const after = arrangePluginNavPanels({
+      panels: panels.slice(0, 3),
+      storedOrder,
+    });
+    expect(before.normalizedOrder).toEqual(storedOrder);
+    expect(before.ordered.map(getPluginNavPanelKey)).toEqual([
+      keys[1],
+      keys[0],
     ]);
+    expect(after.ordered.map(getPluginNavPanelKey)).toEqual(storedOrder);
   });
 
-  it("renders no row for an unregistered key but keeps its slot in the order", () => {
-    // A plugin frontend can register after the sidebar mounts. Dropping the key
-    // here would persist a shortened order and lose the user's arrangement.
-    const { visible, normalizedOrder } = arrangePluginNavPanels({
-      panels: [github, docs],
-      storedOrder: ["strudel/repl", "docs/vault", "github/pulls"],
-      hiddenKeys: [],
+  it("temporarily promotes the active overflow page into the fifth slot", () => {
+    const arranged = arrangePluginNavPanels({
+      panels,
+      storedOrder: keys,
+      activeKey: keys[8],
     });
-
-    expect(visible.map(getPluginNavPanelKey)).toEqual([
-      "docs/vault",
-      "github/pulls",
+    expect(arranged.visible.map(getPluginNavPanelKey)).toEqual([
+      ...keys.slice(0, 4),
+      keys[8],
     ]);
-    expect(normalizedOrder).toEqual([
-      "strudel/repl",
-      "docs/vault",
-      "github/pulls",
+    expect(arranged.overflow.map(getPluginNavPanelKey)).toEqual([
+      keys[4],
+      ...keys.slice(5, 8),
     ]);
-  });
-
-  it("returns a late-registering panel to its stored slot", () => {
-    const { visible } = arrangePluginNavPanels({
-      panels: [github, docs, tasks],
-      // The order saved while only github had registered still names all three.
-      storedOrder: ["tasks/board", "docs/vault", "github/pulls"],
-      hiddenKeys: [],
-    });
-
-    expect(visible.map(getPluginNavPanelKey)).toEqual([
-      "tasks/board",
-      "docs/vault",
-      "github/pulls",
-    ]);
-  });
-
-  it("splits hidden panels out while both lists keep the user's order", () => {
-    const { visible, hidden } = arrangePluginNavPanels({
-      panels: [github, docs, tasks],
-      storedOrder: ["tasks/board", "docs/vault", "github/pulls"],
-      hiddenKeys: ["docs/vault", "tasks/board"],
-    });
-
-    expect(visible.map(getPluginNavPanelKey)).toEqual(["github/pulls"]);
-    expect(hidden.map(getPluginNavPanelKey)).toEqual([
-      "tasks/board",
-      "docs/vault",
-    ]);
-  });
-
-  it("ignores duplicate stored keys so a corrupted list can't render a panel twice", () => {
-    const { visible } = arrangePluginNavPanels({
-      panels: [github, docs],
-      storedOrder: ["github/pulls", "github/pulls", "docs/vault"],
-      hiddenKeys: [],
-    });
-
-    expect(visible.map(getPluginNavPanelKey)).toEqual([
-      "github/pulls",
-      "docs/vault",
-    ]);
+    expect(arranged.normalizedOrder).toEqual(keys);
   });
 });
 
-describe("reorderPluginNavPanels", () => {
-  it("moves a visible row to the target slot", () => {
+describe("plugin panel order mutations", () => {
+  it("drags a row across the cap boundary in the stored order", () => {
     expect(
       reorderPluginNavPanels({
-        activeKey: "tasks/board",
-        overKey: "github/pulls",
-        order: ["github/pulls", "docs/vault", "tasks/board"],
-        visibleKeys: ["github/pulls", "docs/vault", "tasks/board"],
+        activeKey: keys[1],
+        overKey: keys[7],
+        order: keys,
       }),
-    ).toEqual(["tasks/board", "github/pulls", "docs/vault"]);
+    ).toEqual([keys[0], ...keys.slice(2, 8), keys[1], keys[8]]);
   });
 
-  it("keeps hidden panels pinned to their index in the stored order", () => {
-    // docs is hidden and sits between the two visible rows; swapping those two
-    // must not shuffle docs, so unhiding it later restores its old slot.
-    expect(
-      reorderPluginNavPanels({
-        activeKey: "tasks/board",
-        overKey: "github/pulls",
-        order: ["github/pulls", "docs/vault", "tasks/board"],
-        visibleKeys: ["github/pulls", "tasks/board"],
-      }),
-    ).toEqual(["tasks/board", "docs/vault", "github/pulls"]);
+  it("moves a visible page to the first overflow position", () => {
+    expect(movePluginNavPanelToOverflow(keys, keys, keys[1])).toEqual([
+      keys[0],
+      ...keys.slice(2, 6),
+      keys[1],
+      ...keys.slice(6),
+    ]);
   });
 
-  it("returns null when the drag lands where it started", () => {
-    expect(
-      reorderPluginNavPanels({
-        activeKey: "github/pulls",
-        overKey: "github/pulls",
-        order: ["github/pulls", "docs/vault"],
-        visibleKeys: ["github/pulls", "docs/vault"],
-      }),
-    ).toBeNull();
+  it("moves an overflow page to the top", () => {
+    expect(movePluginNavPanelToTop(keys, keys, keys[7])).toEqual([
+      keys[7],
+      ...keys.slice(0, 7),
+      keys[8],
+    ]);
   });
 
-  it("returns null when the drop target is not a visible row", () => {
+  it("keeps unregistered key slots while moving a registered page", () => {
+    const order = ["missing/main", ...keys.slice(0, 6)];
     expect(
-      reorderPluginNavPanels({
-        activeKey: "github/pulls",
-        overKey: "docs/vault",
-        order: ["github/pulls", "docs/vault"],
-        visibleKeys: ["github/pulls"],
-      }),
-    ).toBeNull();
+      movePluginNavPanelToOverflow(order, keys.slice(0, 6), keys[0]),
+    ).toEqual(["missing/main", ...keys.slice(1, 6), keys[0]]);
+  });
+});
+
+describe("normalizePluginNavPanelOrder", () => {
+  it("dedupes valid ids and drops malformed values", () => {
+    expect(
+      normalizePluginNavPanelOrder([keys[0], keys[0], null, "", keys[1]]),
+    ).toEqual(keys.slice(0, 2));
+    expect(normalizePluginNavPanelOrder({})).toEqual([]);
   });
 });

--- a/apps/app/src/components/plugin/pluginNavSidebarOrder.test.ts
+++ b/apps/app/src/components/plugin/pluginNavSidebarOrder.test.ts
@@ -88,6 +88,27 @@ describe("arrangePluginNavPanels", () => {
     ]);
     expect(arranged.normalizedOrder).toEqual(keys);
   });
+
+  it("preserves a migrated fold below five and promotes an active page from zero", () => {
+    const folded = arrangePluginNavPanels({
+      panels: panels.slice(0, 4),
+      storedOrder: keys.slice(0, 4),
+      visibleLimit: 2,
+    });
+    expect(folded.visible.map(getPluginNavPanelKey)).toEqual(keys.slice(0, 2));
+    expect(folded.overflow.map(getPluginNavPanelKey)).toEqual(keys.slice(2, 4));
+
+    const allHidden = arrangePluginNavPanels({
+      panels: panels.slice(0, 4),
+      storedOrder: keys.slice(0, 4),
+      visibleLimit: 0,
+      activeKey: keys[3],
+    });
+    expect(allHidden.visible.map(getPluginNavPanelKey)).toEqual([keys[3]]);
+    expect(allHidden.overflow.map(getPluginNavPanelKey)).toEqual(
+      keys.slice(0, 3),
+    );
+  });
 });
 
 describe("plugin panel order mutations", () => {
@@ -123,6 +144,17 @@ describe("plugin panel order mutations", () => {
     expect(
       movePluginNavPanelToOverflow(order, keys.slice(0, 6), keys[0]),
     ).toEqual(["missing/main", ...keys.slice(1, 6), keys[0]]);
+  });
+
+  it("moves a page below a migrated fold", () => {
+    expect(
+      movePluginNavPanelToOverflow(
+        keys.slice(0, 4),
+        keys.slice(0, 4),
+        keys[0],
+        2,
+      ),
+    ).toEqual([keys[1], keys[2], keys[0], keys[3]]);
   });
 });
 

--- a/apps/app/src/components/plugin/pluginNavSidebarOrder.ts
+++ b/apps/app/src/components/plugin/pluginNavSidebarOrder.ts
@@ -124,22 +124,6 @@ export function reorderPluginNavPanels({
   );
 }
 
-/**
- * Puts `leadingKeys` at the front of a customized order when it does not name
- * them yet. Rows that nobody has ordered normally land last, which is right for
- * a newly installed plugin but wrong for a built-in row that always sat above
- * the plugin rows. An empty order means "registry order" and stays empty.
- */
-export function seedLeadingNavPanelKeys(
-  order: readonly string[],
-  leadingKeys: readonly string[],
-): string[] {
-  const next = [...order];
-  if (next.length === 0) return next;
-  const missing = leadingKeys.filter((key) => !next.includes(key));
-  return missing.length === 0 ? next : [...missing, ...next];
-}
-
 export function hidePluginNavPanel(
   hiddenKeys: readonly string[],
   key: string,

--- a/apps/app/src/components/plugin/pluginNavSidebarOrder.ts
+++ b/apps/app/src/components/plugin/pluginNavSidebarOrder.ts
@@ -1,13 +1,13 @@
 /**
- * Ordering and hide/show logic for the plugin panel rows in the sidebar.
+ * Ordering logic for plugin panel rows in the sidebar.
  *
- * Panels arrive from the slot registry in a fixed registration order (plugin id
- * then declaration order). Users can drag them into their own order and hide
- * the ones they don't use; hidden panels are not removed, they move into the
- * sidebar's "More" disclosure. Both preferences persist client-side keyed by
- * `<pluginId>/<panelId>`, so an uninstalled-and-reinstalled plugin keeps its
- * place and a renamed panel id starts fresh at the end of the list.
+ * One persisted order covers every registered panel. The first five rows are
+ * visible and the rest are an overflow; no panel has a separate hidden state.
+ * Keys for temporarily unregistered panels remain in the persisted order so a
+ * late or reinstalled frontend returns to the user's chosen position.
  */
+
+export const PLUGIN_NAV_PANEL_VISIBLE_LIMIT = 5;
 
 interface PluginNavPanelIdentity {
   pluginId: string;
@@ -18,55 +18,47 @@ export function getPluginNavPanelKey(panel: PluginNavPanelIdentity): string {
   return `${panel.pluginId}/${panel.id}`;
 }
 
+export function normalizePluginNavPanelOrder(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const normalized: string[] = [];
+  const seen = new Set<string>();
+  for (const key of value) {
+    if (typeof key !== "string" || key.length === 0 || seen.has(key)) continue;
+    seen.add(key);
+    normalized.push(key);
+  }
+  return normalized;
+}
+
 interface ArrangePluginNavPanelsArgs<TPanel extends PluginNavPanelIdentity> {
-  /** Registered panels, in registry order. */
   panels: readonly TPanel[];
-  /** Persisted key order; may name panels that no longer exist. */
   storedOrder: readonly string[];
-  /** Persisted hidden keys; may name panels that no longer exist. */
-  hiddenKeys: readonly string[];
+  activeKey?: string;
 }
 
 interface ArrangedPluginNavPanels<TPanel extends PluginNavPanelIdentity> {
-  /** Panels rendered in the sidebar proper, in user order. */
   visible: TPanel[];
-  /** Panels parked in the "More" disclosure, in user order. */
-  hidden: TPanel[];
-  /**
-   * `storedOrder` with duplicates dropped and never-ordered panels appended.
-   * Callers persist this so newly installed panels get a slot.
-   *
-   * Keys of panels that are not registered right now keep their position. A
-   * plugin frontend can register late — the sidebar mounts before every plugin
-   * has loaded — so treating "absent" as "removed" would save a shortened order
-   * during startup and lose the user's arrangement. Keeping the key also makes
-   * an uninstalled-and-reinstalled plugin return to its old slot.
-   */
+  overflow: TPanel[];
+  ordered: TPanel[];
   normalizedOrder: string[];
 }
 
 export function arrangePluginNavPanels<TPanel extends PluginNavPanelIdentity>({
   panels,
   storedOrder,
-  hiddenKeys,
+  activeKey,
 }: ArrangePluginNavPanelsArgs<TPanel>): ArrangedPluginNavPanels<TPanel> {
   const byKey = new Map(
     panels.map((panel) => [getPluginNavPanelKey(panel), panel]),
   );
   const ordered: TPanel[] = [];
-  const normalizedOrder: string[] = [];
-  const seen = new Set<string>();
-  for (const key of storedOrder) {
-    // Skip duplicates (corrupted storage). An unregistered key keeps its slot
-    // in the order but contributes no row.
-    if (seen.has(key)) continue;
-    seen.add(key);
-    normalizedOrder.push(key);
+  const normalizedOrder = normalizePluginNavPanelOrder(storedOrder);
+  const seen = new Set(normalizedOrder);
+
+  for (const key of normalizedOrder) {
     const panel = byKey.get(key);
     if (panel) ordered.push(panel);
   }
-  // Panels the user has never ordered — newly installed plugins — land last, in
-  // registry order, rather than jumping to the top of a customized list.
   for (const panel of panels) {
     const key = getPluginNavPanelKey(panel);
     if (seen.has(key)) continue;
@@ -75,67 +67,95 @@ export function arrangePluginNavPanels<TPanel extends PluginNavPanelIdentity>({
     ordered.push(panel);
   }
 
-  const hiddenSet = new Set(hiddenKeys);
-  const visible: TPanel[] = [];
-  const hidden: TPanel[] = [];
-  for (const panel of ordered) {
-    if (hiddenSet.has(getPluginNavPanelKey(panel))) hidden.push(panel);
-    else visible.push(panel);
+  const visible = ordered.slice(0, PLUGIN_NAV_PANEL_VISIBLE_LIMIT);
+  let overflow = ordered.slice(PLUGIN_NAV_PANEL_VISIBLE_LIMIT);
+  const activeOverflowIndex =
+    activeKey === undefined
+      ? -1
+      : overflow.findIndex(
+          (panel) => getPluginNavPanelKey(panel) === activeKey,
+        );
+  if (activeOverflowIndex !== -1) {
+    const active = overflow[activeOverflowIndex];
+    const displaced = visible[PLUGIN_NAV_PANEL_VISIBLE_LIMIT - 1];
+    if (active !== undefined && displaced !== undefined) {
+      visible[PLUGIN_NAV_PANEL_VISIBLE_LIMIT - 1] = active;
+      overflow = [
+        displaced,
+        ...overflow.slice(0, activeOverflowIndex),
+        ...overflow.slice(activeOverflowIndex + 1),
+      ];
+    }
   }
 
-  return { visible, hidden, normalizedOrder };
+  return { visible, overflow, ordered, normalizedOrder };
 }
 
 interface ReorderPluginNavPanelsArgs {
   activeKey: string;
   overKey: string;
-  /** Full persisted order, including hidden panels. */
   order: readonly string[];
-  /** Keys currently rendered in the sidebar proper, in display order. */
-  visibleKeys: readonly string[];
 }
 
-/**
- * Moves `activeKey` to `overKey`'s slot among the visible rows and folds the
- * result back into the full order. Hidden keys keep their index in the stored
- * list, so unhiding a panel restores it near where it used to sit instead of
- * appending it to the end.
- *
- * Returns `null` when the drag is a no-op.
- */
 export function reorderPluginNavPanels({
   activeKey,
   overKey,
   order,
-  visibleKeys,
 }: ReorderPluginNavPanelsArgs): string[] | null {
-  const from = visibleKeys.indexOf(activeKey);
-  const to = visibleKeys.indexOf(overKey);
+  const from = order.indexOf(activeKey);
+  const to = order.indexOf(overKey);
   if (from === -1 || to === -1 || from === to) return null;
 
-  const nextVisible = [...visibleKeys];
-  const [moved] = nextVisible.splice(from, 1);
-  nextVisible.splice(to, 0, moved);
+  const next = [...order];
+  const [moved] = next.splice(from, 1);
+  if (moved === undefined) return null;
+  next.splice(to, 0, moved);
+  return next;
+}
 
-  const visibleSet = new Set(visibleKeys);
+function replaceRegisteredOrder(
+  order: readonly string[],
+  registeredKeys: readonly string[],
+  nextRegisteredKeys: readonly string[],
+): string[] {
+  const registeredSet = new Set(registeredKeys);
   let cursor = 0;
   return order.map((key) =>
-    visibleSet.has(key) ? nextVisible[cursor++] : key,
+    registeredSet.has(key) ? (nextRegisteredKeys[cursor++] ?? key) : key,
   );
 }
 
-export function hidePluginNavPanel(
-  hiddenKeys: readonly string[],
+export function movePluginNavPanelToTop(
+  order: readonly string[],
+  registeredKeys: readonly string[],
   key: string,
-): string[] {
-  return hiddenKeys.includes(key) ? [...hiddenKeys] : [...hiddenKeys, key];
+): string[] | null {
+  const from = registeredKeys.indexOf(key);
+  if (from <= 0) return null;
+  const nextRegisteredKeys = [...registeredKeys];
+  nextRegisteredKeys.splice(from, 1);
+  nextRegisteredKeys.unshift(key);
+  return replaceRegisteredOrder(order, registeredKeys, nextRegisteredKeys);
 }
 
-export function showPluginNavPanel(
-  hiddenKeys: readonly string[],
+export function movePluginNavPanelToOverflow(
+  order: readonly string[],
+  registeredKeys: readonly string[],
   key: string,
-): string[] {
-  return hiddenKeys.filter((hiddenKey) => hiddenKey !== key);
+): string[] | null {
+  const from = registeredKeys.indexOf(key);
+  if (
+    registeredKeys.length <= PLUGIN_NAV_PANEL_VISIBLE_LIMIT ||
+    from < 0 ||
+    from >= PLUGIN_NAV_PANEL_VISIBLE_LIMIT
+  ) {
+    return null;
+  }
+
+  const nextRegisteredKeys = [...registeredKeys];
+  nextRegisteredKeys.splice(from, 1);
+  nextRegisteredKeys.splice(PLUGIN_NAV_PANEL_VISIBLE_LIMIT, 0, key);
+  return replaceRegisteredOrder(order, registeredKeys, nextRegisteredKeys);
 }
 
 export function havePluginNavPanelOrdersDiverged(

--- a/apps/app/src/components/plugin/pluginNavSidebarOrder.ts
+++ b/apps/app/src/components/plugin/pluginNavSidebarOrder.ts
@@ -34,6 +34,7 @@ interface ArrangePluginNavPanelsArgs<TPanel extends PluginNavPanelIdentity> {
   panels: readonly TPanel[];
   storedOrder: readonly string[];
   activeKey?: string;
+  visibleLimit?: number;
 }
 
 interface ArrangedPluginNavPanels<TPanel extends PluginNavPanelIdentity> {
@@ -47,6 +48,7 @@ export function arrangePluginNavPanels<TPanel extends PluginNavPanelIdentity>({
   panels,
   storedOrder,
   activeKey,
+  visibleLimit: visibleLimitValue = PLUGIN_NAV_PANEL_VISIBLE_LIMIT,
 }: ArrangePluginNavPanelsArgs<TPanel>): ArrangedPluginNavPanels<TPanel> {
   const byKey = new Map(
     panels.map((panel) => [getPluginNavPanelKey(panel), panel]),
@@ -67,8 +69,12 @@ export function arrangePluginNavPanels<TPanel extends PluginNavPanelIdentity>({
     ordered.push(panel);
   }
 
-  const visible = ordered.slice(0, PLUGIN_NAV_PANEL_VISIBLE_LIMIT);
-  let overflow = ordered.slice(PLUGIN_NAV_PANEL_VISIBLE_LIMIT);
+  const visibleLimit = Math.max(
+    0,
+    Math.min(PLUGIN_NAV_PANEL_VISIBLE_LIMIT, visibleLimitValue),
+  );
+  const visible = ordered.slice(0, visibleLimit);
+  let overflow = ordered.slice(visibleLimit);
   const activeOverflowIndex =
     activeKey === undefined
       ? -1
@@ -77,9 +83,15 @@ export function arrangePluginNavPanels<TPanel extends PluginNavPanelIdentity>({
         );
   if (activeOverflowIndex !== -1) {
     const active = overflow[activeOverflowIndex];
-    const displaced = visible[PLUGIN_NAV_PANEL_VISIBLE_LIMIT - 1];
-    if (active !== undefined && displaced !== undefined) {
-      visible[PLUGIN_NAV_PANEL_VISIBLE_LIMIT - 1] = active;
+    const displaced = visible[visibleLimit - 1];
+    if (active !== undefined && visibleLimit === 0) {
+      visible.push(active);
+      overflow = [
+        ...overflow.slice(0, activeOverflowIndex),
+        ...overflow.slice(activeOverflowIndex + 1),
+      ];
+    } else if (active !== undefined && displaced !== undefined) {
+      visible[visibleLimit - 1] = active;
       overflow = [
         displaced,
         ...overflow.slice(0, activeOverflowIndex),
@@ -142,19 +154,20 @@ export function movePluginNavPanelToOverflow(
   order: readonly string[],
   registeredKeys: readonly string[],
   key: string,
+  visibleLimit = PLUGIN_NAV_PANEL_VISIBLE_LIMIT,
 ): string[] | null {
   const from = registeredKeys.indexOf(key);
   if (
-    registeredKeys.length <= PLUGIN_NAV_PANEL_VISIBLE_LIMIT ||
+    registeredKeys.length <= visibleLimit ||
     from < 0 ||
-    from >= PLUGIN_NAV_PANEL_VISIBLE_LIMIT
+    from >= visibleLimit
   ) {
     return null;
   }
 
   const nextRegisteredKeys = [...registeredKeys];
   nextRegisteredKeys.splice(from, 1);
-  nextRegisteredKeys.splice(PLUGIN_NAV_PANEL_VISIBLE_LIMIT, 0, key);
+  nextRegisteredKeys.splice(visibleLimit, 0, key);
   return replaceRegisteredOrder(order, registeredKeys, nextRegisteredKeys);
 }
 

--- a/apps/app/src/components/sidebar/AppSidebar.sections.test.tsx
+++ b/apps/app/src/components/sidebar/AppSidebar.sections.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { SidebarTopLevelSections } from "./AppSidebar";
+
+afterEach(cleanup);
+
+const sections = {
+  "new-thread-extensions": <button type="button">New thread</button>,
+  "plugin-pages": <button type="button">Plugin page</button>,
+  "thread-list": <button type="button">Thread row</button>,
+} as const;
+
+function renderedSectionIds(): string[] {
+  return Array.from(
+    document.querySelectorAll("[data-sidebar-top-level-section]"),
+  ).map((section) => section.getAttribute("data-sidebar-top-level-section")!);
+}
+
+describe("SidebarTopLevelSections", () => {
+  it("renders all three sections in default order with full dividers", () => {
+    const view = render(
+      <SidebarTopLevelSections
+        order={["new-thread-extensions", "plugin-pages", "thread-list"]}
+        hiddenSectionIds={[]}
+        sections={sections}
+      />,
+    );
+
+    expect(renderedSectionIds()).toEqual([
+      "new-thread-extensions",
+      "plugin-pages",
+      "thread-list",
+    ]);
+    const dividers = view.container.querySelectorAll(
+      "[data-sidebar-top-level-divider]",
+    );
+    expect(dividers).toHaveLength(2);
+    for (const divider of dividers) {
+      expect(divider.getAttribute("aria-hidden")).toBe("true");
+      expect(divider.getAttribute("tabindex")).toBeNull();
+      expect(divider.classList.contains("bg-sidebar-border")).toBe(true);
+    }
+    expect(
+      screen.getAllByRole("button").map((button) => button.textContent),
+    ).toEqual(["New thread", "Plugin page", "Thread row"]);
+  });
+
+  it("reorders all regions and keeps keyboard controls in that order", () => {
+    render(
+      <SidebarTopLevelSections
+        order={["thread-list", "new-thread-extensions", "plugin-pages"]}
+        hiddenSectionIds={[]}
+        sections={sections}
+      />,
+    );
+
+    expect(renderedSectionIds()).toEqual([
+      "thread-list",
+      "new-thread-extensions",
+      "plugin-pages",
+    ]);
+    expect(
+      screen.getAllByRole("button").map((button) => button.textContent),
+    ).toEqual(["Thread row", "New thread", "Plugin page"]);
+  });
+
+  it("draws no divider beside a hidden or empty region", () => {
+    const view = render(
+      <SidebarTopLevelSections
+        order={["new-thread-extensions", "plugin-pages", "thread-list"]}
+        hiddenSectionIds={["new-thread-extensions"]}
+        sections={{ ...sections, "plugin-pages": null }}
+      />,
+    );
+
+    expect(renderedSectionIds()).toEqual(["thread-list"]);
+    expect(
+      view.container.querySelectorAll("[data-sidebar-top-level-divider]"),
+    ).toHaveLength(0);
+  });
+});

--- a/apps/app/src/components/sidebar/AppSidebar.tsx
+++ b/apps/app/src/components/sidebar/AppSidebar.tsx
@@ -1,4 +1,13 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  Fragment,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { useAtomValue } from "jotai";
 import { cn } from "@bb/shared-ui/lib/utils";
 import { THREAD_JUMP_APP_COMMAND_IDS } from "@bb/domain";
 import { Link, useNavigate } from "react-router-dom";
@@ -19,7 +28,10 @@ import {
 import { ProjectList, ProjectListActionButtons } from "./ProjectList";
 import { PluginThreadList } from "./PluginThreadList";
 import { useThreadListReplacement } from "./threadListProvider";
-import { PluginNavSidebarItems } from "@/components/plugin/PluginNavSidebarItems";
+import {
+  ExtensionsNavSidebarItem,
+  PluginNavSidebarItems,
+} from "@/components/plugin/PluginNavSidebarItems";
 import { PluginSidebarFooterActions } from "@/components/plugin/PluginSidebarFooterActions";
 import { SidebarPluginAttentionGlyph } from "./SidebarPluginAttentionGlyph";
 import { SidebarUpdatesBadge } from "./SidebarUpdatesBadge";
@@ -53,6 +65,14 @@ import {
   useIndexedAppCommandHandlers,
 } from "@/components/commands/AppCommandProvider";
 import { useRouteState } from "@/hooks/useRouteState";
+import { usePluginNavPanelChrome } from "@/lib/plugin-nav-panel-chrome";
+import {
+  hiddenSidebarTopLevelSectionIdsAtom,
+  normalizeHiddenSidebarTopLevelSectionIds,
+  normalizeSidebarTopLevelSectionOrder,
+  sidebarTopLevelSectionOrderAtom,
+  type SidebarTopLevelSectionId,
+} from "./sidebarTopLevelSectionPreferences";
 
 const NEW_THREAD_PANE_CONTENT = { kind: "new-thread" } as const;
 
@@ -61,6 +81,54 @@ const SIDEBAR_FOOTER_ACTION_CLASS = cn(
   COARSE_POINTER_CHILD_ICON_BUTTON_CLASS,
   "text-muted-foreground hover:text-sidebar-foreground [&>svg]:opacity-80",
 );
+
+interface SidebarTopLevelSectionsProps {
+  order: readonly SidebarTopLevelSectionId[];
+  hiddenSectionIds: readonly SidebarTopLevelSectionId[];
+  sections: Readonly<Record<SidebarTopLevelSectionId, ReactNode>>;
+}
+
+/**
+ * Renders the three persistent sidebar regions and derives dividers from the
+ * regions that actually contribute content. The divider is structural only:
+ * it is absent beside an empty/hidden region and never joins keyboard order.
+ */
+export function SidebarTopLevelSections({
+  order,
+  hiddenSectionIds,
+  sections,
+}: SidebarTopLevelSectionsProps) {
+  const hidden = new Set(
+    normalizeHiddenSidebarTopLevelSectionIds(hiddenSectionIds),
+  );
+  const visibleSections = normalizeSidebarTopLevelSectionOrder(order).flatMap(
+    (id) => {
+      const content = sections[id];
+      return hidden.has(id) || content === null ? [] : [{ id, content }];
+    },
+  );
+
+  return visibleSections.map(({ id, content }, index) => (
+    <Fragment key={id}>
+      {index > 0 ? (
+        <div
+          aria-hidden="true"
+          data-sidebar-top-level-divider=""
+          className="mx-2 h-px shrink-0 bg-sidebar-border"
+        />
+      ) : null}
+      <div
+        data-sidebar-top-level-section={id}
+        className={cn(
+          "min-w-0",
+          id === "thread-list" ? "flex min-h-0 flex-1 flex-col" : "shrink-0",
+        )}
+      >
+        {content}
+      </div>
+    </Fragment>
+  ));
+}
 
 interface AppSidebarProps {
   onResizeMouseDown: (event: React.MouseEvent<HTMLDivElement>) => void;
@@ -114,6 +182,11 @@ export function AppSidebar({
   );
   const isAppCommandModifierHeld = useIsAppCommandModifierHeld();
   const settingsShortcut = useAppCommandShortcut("settings.open");
+  const topLevelSectionOrder = useAtomValue(sidebarTopLevelSectionOrderAtom);
+  const hiddenTopLevelSectionIds = useAtomValue(
+    hiddenSidebarTopLevelSectionIdsAtom,
+  );
+  const pluginNavPanels = usePluginNavPanelChrome();
 
   const openSidebarForThreadSearch = useCallback(() => {
     if (isCompactViewport) {
@@ -329,38 +402,53 @@ export function AppSidebar({
           />
         </div>
       ) : null}
-      <div
-        data-testid="app-sidebar-primary-actions"
-        className="shrink-0 px-2 py-2 group-data-[collapsible=icon]:hidden"
-      >
-        <ProjectListActionButtons
-          splitEnabled
-          newThreadSplit={newThreadSplit}
-          onNewChat={handleNewChat}
-          threadSearch={{
-            activeDescendantId: threadSearch.activeDescendantId,
-            inputRef: threadSearch.inputRef,
-            isActive: threadSearch.isActive,
-            onActivate: threadSearch.onActivate,
-            onClose: threadSearch.onClose,
-            onQueryChange: threadSearch.onQueryChange,
-            query: threadSearch.query,
-          }}
-        />
-      </div>
-      <PluginNavSidebarItems
-        onNavigate={closeOnMobile}
-        splitEnabled
-        toolsRoutePath={toolsRoutePath}
+      <SidebarTopLevelSections
+        order={topLevelSectionOrder}
+        hiddenSectionIds={hiddenTopLevelSectionIds}
+        sections={{
+          "new-thread-extensions": (
+            <div
+              data-testid="app-sidebar-primary-actions"
+              className="space-y-1 px-2 py-2 group-data-[collapsible=icon]:hidden"
+            >
+              <ProjectListActionButtons
+                splitEnabled
+                newThreadSplit={newThreadSplit}
+                onNewChat={handleNewChat}
+                threadSearch={{
+                  activeDescendantId: threadSearch.activeDescendantId,
+                  inputRef: threadSearch.inputRef,
+                  isActive: threadSearch.isActive,
+                  onActivate: threadSearch.onActivate,
+                  onClose: threadSearch.onClose,
+                  onQueryChange: threadSearch.onQueryChange,
+                  query: threadSearch.query,
+                }}
+              />
+              {toolsRoutePath ? (
+                <ExtensionsNavSidebarItem
+                  routePath={toolsRoutePath}
+                  onNavigate={closeOnMobile}
+                />
+              ) : null}
+            </div>
+          ),
+          "plugin-pages":
+            pluginNavPanels.length > 0 ? (
+              <PluginNavSidebarItems onNavigate={closeOnMobile} splitEnabled />
+            ) : null,
+          "thread-list": (
+            <SidebarContent>
+              <PluginThreadList
+                replacement={threadListReplacement}
+                original={originalThreadList}
+                searchQuery={threadSearch.query}
+                onNavigate={threadSearch.onExternalThreadOpen}
+              />
+            </SidebarContent>
+          ),
+        }}
       />
-      <SidebarContent>
-        <PluginThreadList
-          replacement={threadListReplacement}
-          original={originalThreadList}
-          searchQuery={threadSearch.query}
-          onNavigate={threadSearch.onExternalThreadOpen}
-        />
-      </SidebarContent>
       <SidebarFooter className="relative">
         <OverflowFade placement="above" tone="sidebar" size="sm" />
         {/* The footer holds a variable number of plugin action buttons, so a

--- a/apps/app/src/components/sidebar/ProjectList.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.tsx
@@ -123,8 +123,12 @@ import {
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuGroup,
+  DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@bb/shared-ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@bb/shared-ui/tooltip";
@@ -156,6 +160,13 @@ import {
   resolveThreadTitleDisplayText,
   type ThreadTitleMentionResources,
 } from "@/components/thread/ThreadTitleMentions";
+import {
+  hiddenSidebarTopLevelSectionIdsAtom,
+  moveSidebarTopLevelSection,
+  sidebarTopLevelSectionOrderAtom,
+  setSidebarTopLevelSectionHidden,
+  SIDEBAR_TOP_LEVEL_SECTION_DEFINITIONS,
+} from "./sidebarTopLevelSectionPreferences";
 
 interface ProjectListProps {
   onNewProject?: () => void;
@@ -659,9 +670,9 @@ function SidebarDisplayMenuTrigger({
   );
 }
 
-// Single combined display-options menu (organize + sort) rendered on every
-// section header. Both the organization mode and the sort field are
-// global, so any header's menu drives the whole sidebar.
+// Single combined display-options menu rendered on every section header.
+// Organization, sorting, and top-level sidebar structure are global, so any
+// header's menu drives the whole sidebar and can restore a hidden region.
 export function SidebarDisplayOptionsMenu({
   open,
   onOpenChange,
@@ -671,6 +682,12 @@ export function SidebarDisplayOptionsMenu({
   );
   const [chronologicalSort, setChronologicalSort] = useAtom(
     sidebarChronologicalSortAtom,
+  );
+  const [topLevelSectionOrder, setTopLevelSectionOrder] = useAtom(
+    sidebarTopLevelSectionOrderAtom,
+  );
+  const [hiddenTopLevelSectionIds, setHiddenTopLevelSectionIds] = useAtom(
+    hiddenSidebarTopLevelSectionIdsAtom,
   );
   const selectedSort: SidebarChronologicalSort =
     chronologicalSort === "none" ? "updated" : chronologicalSort;
@@ -716,6 +733,67 @@ export function SidebarDisplayOptionsMenu({
               {option.label}
             </DropdownMenuCheckboxItem>
           ))}
+        </DropdownMenuGroup>
+        <DropdownMenuSeparator />
+        <DropdownMenuLabel className={CHROME_SECTION_LABEL_CLASS}>
+          Sidebar sections
+        </DropdownMenuLabel>
+        <DropdownMenuGroup aria-label="Sidebar sections">
+          {topLevelSectionOrder.map((sectionId, index) => {
+            const section = SIDEBAR_TOP_LEVEL_SECTION_DEFINITIONS.find(
+              (candidate) => candidate.id === sectionId,
+            );
+            if (!section) return null;
+            const isHidden = hiddenTopLevelSectionIds.includes(sectionId);
+            return (
+              <DropdownMenuSub key={sectionId}>
+                <DropdownMenuSubTrigger>{section.label}</DropdownMenuSubTrigger>
+                <DropdownMenuSubContent>
+                  {section.hideable ? (
+                    <>
+                      <DropdownMenuCheckboxItem
+                        checked={!isHidden}
+                        onCheckedChange={(shown) =>
+                          setHiddenTopLevelSectionIds((current) =>
+                            setSidebarTopLevelSectionHidden(
+                              current,
+                              sectionId,
+                              !shown,
+                            ),
+                          )
+                        }
+                      >
+                        Show section
+                      </DropdownMenuCheckboxItem>
+                      <DropdownMenuSeparator />
+                    </>
+                  ) : null}
+                  <DropdownMenuItem
+                    disabled={index === 0}
+                    onSelect={() =>
+                      setTopLevelSectionOrder((current) =>
+                        moveSidebarTopLevelSection(current, sectionId, -1),
+                      )
+                    }
+                  >
+                    <Icon name="ArrowUp" aria-hidden="true" />
+                    Move up
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    disabled={index === topLevelSectionOrder.length - 1}
+                    onSelect={() =>
+                      setTopLevelSectionOrder((current) =>
+                        moveSidebarTopLevelSection(current, sectionId, 1),
+                      )
+                    }
+                  >
+                    <Icon name="ArrowDown" aria-hidden="true" />
+                    Move down
+                  </DropdownMenuItem>
+                </DropdownMenuSubContent>
+              </DropdownMenuSub>
+            );
+          })}
         </DropdownMenuGroup>
       </DropdownMenuContent>
     </DropdownMenu>
@@ -1928,7 +2006,7 @@ function ProjectListComponent({
     actionsOpen: isSectionDisplayOptionsOpen("pinned"),
   };
   const threadsSection = {
-    label: organizationMode === "chronological" ? "Unorganized" : "Threads",
+    label: "Threads",
     actions: threadsSectionActions,
     actionsOpen: threadsDisplayOptionsMenuOpen,
   } satisfies Omit<BuiltInSidebarSectionOptions, "content">;
@@ -1958,7 +2036,7 @@ function ProjectListComponent({
       {sectionDeleteDialog.target ? (
         <ConfirmDeleteDialogContent
           title="Remove section?"
-          description="Threads in this section will move back to Unorganized."
+          description="Threads in this section will move back to Threads."
           confirmLabel="Remove section"
           pending={isDeleteThreadSectionPending}
           onConfirm={handleConfirmRemoveThreadSection}

--- a/apps/app/src/components/sidebar/SidebarDisplayOptionsMenu.test.tsx
+++ b/apps/app/src/components/sidebar/SidebarDisplayOptionsMenu.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
+import { createStore, Provider } from "jotai";
+import { afterEach, describe, expect, it } from "vitest";
+import { TooltipProvider } from "@bb/shared-ui/tooltip";
+import { SidebarDisplayOptionsMenu } from "./ProjectList";
+import {
+  hiddenSidebarTopLevelSectionIdsAtom,
+  sidebarTopLevelSectionOrderAtom,
+} from "./sidebarTopLevelSectionPreferences";
+
+afterEach(cleanup);
+
+function renderMenu() {
+  const store = createStore();
+  store.set(sidebarTopLevelSectionOrderAtom, [
+    "new-thread-extensions",
+    "plugin-pages",
+    "thread-list",
+  ]);
+  store.set(hiddenSidebarTopLevelSectionIdsAtom, []);
+  render(
+    <Provider store={store}>
+      <TooltipProvider>
+        <SidebarDisplayOptionsMenu />
+      </TooltipProvider>
+    </Provider>,
+  );
+  return store;
+}
+
+function openMenu() {
+  fireEvent.pointerDown(
+    screen.getByRole("button", { name: "Sidebar display options" }),
+    { button: 0 },
+  );
+}
+
+function openSectionSubmenu(name: string) {
+  const group = screen.getByRole("group", { name: "Sidebar sections" });
+  const trigger = within(group).getByRole("menuitem", { name });
+  fireEvent.click(trigger);
+}
+
+describe("SidebarDisplayOptionsMenu top-level sections", () => {
+  it("lists all sections in order and never offers a Thread list hide control", async () => {
+    renderMenu();
+    openMenu();
+
+    const group = await screen.findByRole("group", {
+      name: "Sidebar sections",
+    });
+    expect(
+      within(group)
+        .getAllByRole("menuitem")
+        .map((item) => item.textContent),
+    ).toEqual(["New thread / Extensions", "Plugin pages", "Thread list"]);
+
+    openSectionSubmenu("Thread list");
+    expect(
+      screen.queryByRole("menuitemcheckbox", { name: "Show section" }),
+    ).toBeNull();
+    expect(screen.getByRole("menuitem", { name: "Move up" })).toBeDefined();
+  });
+
+  it("hides and restores the first section from Display options", async () => {
+    const store = renderMenu();
+    openMenu();
+    await screen.findByRole("group", { name: "Sidebar sections" });
+    openSectionSubmenu("New thread / Extensions");
+
+    const showSection = await screen.findByRole("menuitemcheckbox", {
+      name: "Show section",
+    });
+    expect(showSection.getAttribute("data-state")).toBe("checked");
+    fireEvent.click(showSection);
+    expect(store.get(hiddenSidebarTopLevelSectionIdsAtom)).toEqual([
+      "new-thread-extensions",
+    ]);
+
+    openMenu();
+    await screen.findByRole("group", { name: "Sidebar sections" });
+    openSectionSubmenu("New thread / Extensions");
+    const restoreSection = await screen.findByRole("menuitemcheckbox", {
+      name: "Show section",
+    });
+    expect(restoreSection.getAttribute("data-state")).toBe("unchecked");
+    fireEvent.click(restoreSection);
+    expect(store.get(hiddenSidebarTopLevelSectionIdsAtom)).toEqual([]);
+  });
+
+  it("reorders the Thread list from the same menu", async () => {
+    const store = renderMenu();
+    openMenu();
+    await screen.findByRole("group", { name: "Sidebar sections" });
+    openSectionSubmenu("Thread list");
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Move up" }));
+
+    expect(store.get(sidebarTopLevelSectionOrderAtom)).toEqual([
+      "new-thread-extensions",
+      "thread-list",
+      "plugin-pages",
+    ]);
+  });
+});

--- a/apps/app/src/components/sidebar/SidebarOverview.stories.tsx
+++ b/apps/app/src/components/sidebar/SidebarOverview.stories.tsx
@@ -43,7 +43,10 @@ import {
 } from "@/hooks/queries/query-keys";
 import { THREAD_SEARCH_LIMIT_PER_GROUP } from "@/hooks/queries/thread-queries";
 import { StoryCard, StoryRow } from "../../../.ladle/story-card";
-import { PluginNavSidebarItems } from "@/components/plugin/PluginNavSidebarItems";
+import {
+  ExtensionsNavSidebarItem,
+  PluginNavSidebarItems,
+} from "@/components/plugin/PluginNavSidebarItems";
 import {
   removePluginSlotRegistrations,
   setPluginSlotRegistrations,
@@ -347,11 +350,12 @@ function SidebarFrame({ children }: SidebarFrameProps) {
     <ProjectActionsProvider>
       <ThreadActionsProvider>
         <div className="flex h-[680px] w-full max-w-[320px] min-w-0 flex-col overflow-hidden rounded-md border border-sidebar-border bg-sidebar text-sidebar-foreground shadow-sm">
-          <div className="shrink-0 px-2 py-2">
+          <div className="shrink-0 space-y-1 px-2 py-2">
             <ProjectListActionButtons onNewChat={noop} />
+            <ExtensionsNavSidebarItem routePath={getSkillsRoutePath()} />
           </div>
-          {/* Extensions rides in the nav list, exactly as AppSidebar mounts it. */}
-          <PluginNavSidebarItems toolsRoutePath={getSkillsRoutePath()} />
+          <div aria-hidden="true" className="mx-2 h-px bg-sidebar-border" />
+          <PluginNavSidebarItems />
           <div className="min-h-0 flex-1 overflow-y-auto">{children}</div>
           <div className="shrink-0 border-t border-sidebar-border/70 px-2 py-2">
             <button

--- a/apps/app/src/components/sidebar/SidebarSectionRow.stories.tsx
+++ b/apps/app/src/components/sidebar/SidebarSectionRow.stories.tsx
@@ -224,7 +224,7 @@ export function DragInto() {
       </StoryRow>
       <StoryRow
         label="loose-list drop"
-        hint="dragging a thread out of a section previews the same slot at root depth in Unorganized"
+        hint="dragging a thread out of a section previews the same slot at root depth in Threads"
       >
         <SidebarStage>
           <DropPreviewRow depth={0} />

--- a/apps/app/src/components/sidebar/sidebarTopLevelSectionPreferences.test.ts
+++ b/apps/app/src/components/sidebar/sidebarTopLevelSectionPreferences.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+
+import { createStore } from "jotai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  moveSidebarTopLevelSection,
+  normalizeHiddenSidebarTopLevelSectionIds,
+  normalizeSidebarTopLevelSectionOrder,
+  setSidebarTopLevelSectionHidden,
+} from "./sidebarTopLevelSectionPreferences";
+
+afterEach(() => {
+  window.localStorage.clear();
+  vi.resetModules();
+});
+
+describe("top-level sidebar section preferences", () => {
+  it("skips unknown and duplicate ids without dropping valid persisted order", () => {
+    expect(
+      normalizeSidebarTopLevelSectionOrder([
+        "plugin-pages",
+        "future-section",
+        "new-thread-extensions",
+        "plugin-pages",
+      ]),
+    ).toEqual(["plugin-pages", "new-thread-extensions", "thread-list"]);
+  });
+
+  it("normalizes an unknown id from persisted order without dropping valid ids", async () => {
+    window.localStorage.setItem(
+      "bb.sidebar.topLevelSectionOrder",
+      JSON.stringify([
+        "plugin-pages",
+        "future-section",
+        "new-thread-extensions",
+      ]),
+    );
+
+    vi.resetModules();
+    const reloadedModule = await import("./sidebarTopLevelSectionPreferences");
+    const reloadedStore = createStore();
+
+    expect(
+      reloadedStore.get(reloadedModule.sidebarTopLevelSectionOrderAtom),
+    ).toEqual(["plugin-pages", "new-thread-extensions", "thread-list"]);
+  });
+
+  it("never admits the Thread list or unknown ids into the hidden set", () => {
+    expect(
+      normalizeHiddenSidebarTopLevelSectionIds([
+        "thread-list",
+        "plugin-pages",
+        "future-section",
+      ]),
+    ).toEqual(["plugin-pages"]);
+    expect(setSidebarTopLevelSectionHidden([], "thread-list", true)).toEqual(
+      [],
+    );
+  });
+
+  it("moves all three sections while hiding the first two independently", () => {
+    expect(
+      moveSidebarTopLevelSection(
+        ["new-thread-extensions", "plugin-pages", "thread-list"],
+        "thread-list",
+        -1,
+      ),
+    ).toEqual(["new-thread-extensions", "thread-list", "plugin-pages"]);
+
+    const firstHidden = setSidebarTopLevelSectionHidden(
+      [],
+      "new-thread-extensions",
+      true,
+    );
+    expect(
+      setSidebarTopLevelSectionHidden(firstHidden, "plugin-pages", true),
+    ).toEqual(["new-thread-extensions", "plugin-pages"]);
+  });
+
+  it("persists order and hidden sections across a fresh atom import", async () => {
+    const firstModule = await import("./sidebarTopLevelSectionPreferences");
+    const firstStore = createStore();
+    firstStore.set(firstModule.sidebarTopLevelSectionOrderAtom, [
+      "thread-list",
+      "plugin-pages",
+      "new-thread-extensions",
+    ]);
+    firstStore.set(firstModule.hiddenSidebarTopLevelSectionIdsAtom, [
+      "new-thread-extensions",
+    ]);
+
+    vi.resetModules();
+    const reloadedModule = await import("./sidebarTopLevelSectionPreferences");
+    const reloadedStore = createStore();
+
+    expect(
+      reloadedStore.get(reloadedModule.sidebarTopLevelSectionOrderAtom),
+    ).toEqual(["thread-list", "plugin-pages", "new-thread-extensions"]);
+    expect(
+      reloadedStore.get(reloadedModule.hiddenSidebarTopLevelSectionIdsAtom),
+    ).toEqual(["new-thread-extensions"]);
+  });
+});

--- a/apps/app/src/components/sidebar/sidebarTopLevelSectionPreferences.ts
+++ b/apps/app/src/components/sidebar/sidebarTopLevelSectionPreferences.ts
@@ -1,0 +1,155 @@
+import { atomWithStorage } from "jotai/utils";
+import {
+  createJsonLocalStorage,
+  type SyncStorage,
+} from "@/lib/browser-storage";
+
+export const SIDEBAR_TOP_LEVEL_SECTION_IDS = [
+  "new-thread-extensions",
+  "plugin-pages",
+  "thread-list",
+] as const;
+
+export type SidebarTopLevelSectionId =
+  (typeof SIDEBAR_TOP_LEVEL_SECTION_IDS)[number];
+
+export interface SidebarTopLevelSectionDefinition {
+  id: SidebarTopLevelSectionId;
+  label: string;
+  hideable: boolean;
+}
+
+export const SIDEBAR_TOP_LEVEL_SECTION_DEFINITIONS = [
+  {
+    id: "new-thread-extensions",
+    label: "New thread / Extensions",
+    hideable: true,
+  },
+  { id: "plugin-pages", label: "Plugin pages", hideable: true },
+  { id: "thread-list", label: "Thread list", hideable: false },
+] as const satisfies readonly SidebarTopLevelSectionDefinition[];
+
+const SIDEBAR_TOP_LEVEL_SECTION_ORDER_STORAGE_KEY =
+  "bb.sidebar.topLevelSectionOrder";
+const HIDDEN_SIDEBAR_TOP_LEVEL_SECTIONS_STORAGE_KEY =
+  "bb.sidebar.hiddenTopLevelSections";
+
+const SIDEBAR_TOP_LEVEL_SECTION_ID_SET = new Set<string>(
+  SIDEBAR_TOP_LEVEL_SECTION_IDS,
+);
+const HIDEABLE_SIDEBAR_TOP_LEVEL_SECTION_ID_SET = new Set<string>(
+  SIDEBAR_TOP_LEVEL_SECTION_DEFINITIONS.filter(
+    (section) => section.hideable,
+  ).map((section) => section.id),
+);
+
+function isSidebarTopLevelSectionId(
+  value: unknown,
+): value is SidebarTopLevelSectionId {
+  return (
+    typeof value === "string" && SIDEBAR_TOP_LEVEL_SECTION_ID_SET.has(value)
+  );
+}
+
+export function normalizeSidebarTopLevelSectionOrder(
+  value: unknown,
+): SidebarTopLevelSectionId[] {
+  const normalized: SidebarTopLevelSectionId[] = [];
+  const seen = new Set<SidebarTopLevelSectionId>();
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      if (!isSidebarTopLevelSectionId(item) || seen.has(item)) continue;
+      seen.add(item);
+      normalized.push(item);
+    }
+  }
+  for (const id of SIDEBAR_TOP_LEVEL_SECTION_IDS) {
+    if (seen.has(id)) continue;
+    normalized.push(id);
+  }
+  return normalized;
+}
+
+export function normalizeHiddenSidebarTopLevelSectionIds(
+  value: unknown,
+): SidebarTopLevelSectionId[] {
+  if (!Array.isArray(value)) return [];
+  const normalized: SidebarTopLevelSectionId[] = [];
+  const seen = new Set<SidebarTopLevelSectionId>();
+  for (const item of value) {
+    if (
+      !isSidebarTopLevelSectionId(item) ||
+      !HIDEABLE_SIDEBAR_TOP_LEVEL_SECTION_ID_SET.has(item) ||
+      seen.has(item)
+    ) {
+      continue;
+    }
+    seen.add(item);
+    normalized.push(item);
+  }
+  return normalized;
+}
+
+export function moveSidebarTopLevelSection(
+  value: unknown,
+  id: SidebarTopLevelSectionId,
+  offset: -1 | 1,
+): SidebarTopLevelSectionId[] {
+  const order = normalizeSidebarTopLevelSectionOrder(value);
+  const from = order.indexOf(id);
+  const to = from + offset;
+  if (from === -1 || to < 0 || to >= order.length) return order;
+  const next = [...order];
+  next.splice(from, 1);
+  next.splice(to, 0, id);
+  return next;
+}
+
+export function setSidebarTopLevelSectionHidden(
+  value: unknown,
+  id: SidebarTopLevelSectionId,
+  hidden: boolean,
+): SidebarTopLevelSectionId[] {
+  const current = normalizeHiddenSidebarTopLevelSectionIds(value);
+  if (!HIDEABLE_SIDEBAR_TOP_LEVEL_SECTION_ID_SET.has(id)) return current;
+  if (hidden) {
+    return current.includes(id) ? current : [...current, id];
+  }
+  return current.filter((sectionId) => sectionId !== id);
+}
+
+function createNormalizedSectionStorage(
+  normalize: (value: unknown) => SidebarTopLevelSectionId[],
+): SyncStorage<SidebarTopLevelSectionId[]> {
+  const storage = createJsonLocalStorage<unknown>();
+  return {
+    getItem: (key, initialValue) =>
+      normalize(storage.getItem(key, initialValue)),
+    setItem: (key, value) => storage.setItem(key, normalize(value)),
+    removeItem: storage.removeItem,
+    subscribe: (key, callback, initialValue) =>
+      storage.subscribe?.(
+        key,
+        (value) => callback(normalize(value)),
+        initialValue,
+      ),
+  };
+}
+
+export const sidebarTopLevelSectionOrderAtom = atomWithStorage<
+  SidebarTopLevelSectionId[]
+>(
+  SIDEBAR_TOP_LEVEL_SECTION_ORDER_STORAGE_KEY,
+  [...SIDEBAR_TOP_LEVEL_SECTION_IDS],
+  createNormalizedSectionStorage(normalizeSidebarTopLevelSectionOrder),
+  { getOnInit: true },
+);
+
+export const hiddenSidebarTopLevelSectionIdsAtom = atomWithStorage<
+  SidebarTopLevelSectionId[]
+>(
+  HIDDEN_SIDEBAR_TOP_LEVEL_SECTIONS_STORAGE_KEY,
+  [],
+  createNormalizedSectionStorage(normalizeHiddenSidebarTopLevelSectionIds),
+  { getOnInit: true },
+);

--- a/apps/app/src/components/sidebar/usePaneContentSplitDrag.ts
+++ b/apps/app/src/components/sidebar/usePaneContentSplitDrag.ts
@@ -53,23 +53,26 @@ export function usePaneContentSplitDrag({
   const navigate = useNavigate();
   const isCompact = useIsCompactViewport();
 
-  const openInSplit = useCallback(() => {
-    const route = routeForContent(content);
-    const layout = store.get(splitLayoutAtom);
-    if (!enabled || isCompact || layout === null) {
-      navigate(route);
-      return;
-    }
-    const existing = findPaneByContent(layout.root, content);
-    const next =
-      existing !== null
-        ? setFocus(layout, existing.paneId)
-        : countPanes(layout.root) >= MAX_PANES
-          ? replacePaneContent(layout, layout.focusedPaneId, content)
-          : splitPane(layout, layout.focusedPaneId, "right", content);
-    if (next !== layout) store.set(splitLayoutAtom, next);
-    navigate(route, existing !== null ? { replace: true } : undefined);
-  }, [content, enabled, isCompact, navigate, store]);
+  const openInSplit = useCallback(
+    (nextContent: PaneContent = content) => {
+      const route = routeForContent(nextContent);
+      const layout = store.get(splitLayoutAtom);
+      if (!enabled || isCompact || layout === null) {
+        navigate(route);
+        return;
+      }
+      const existing = findPaneByContent(layout.root, nextContent);
+      const next =
+        existing !== null
+          ? setFocus(layout, existing.paneId)
+          : countPanes(layout.root) >= MAX_PANES
+            ? replacePaneContent(layout, layout.focusedPaneId, nextContent)
+            : splitPane(layout, layout.focusedPaneId, "right", nextContent);
+      if (next !== layout) store.set(splitLayoutAtom, next);
+      navigate(route, existing !== null ? { replace: true } : undefined);
+    },
+    [content, enabled, isCompact, navigate, store],
+  );
 
   const onPointerDown = useCallback(
     (event: ReactPointerEvent<HTMLElement>) => {

--- a/apps/app/src/components/ui/compact-long-press-menu.test.tsx
+++ b/apps/app/src/components/ui/compact-long-press-menu.test.tsx
@@ -15,10 +15,12 @@ import { CompactLongPressMenu } from "./compact-long-press-menu";
 const LONG_PRESS_MS = 700;
 
 function renderRow({
+  disabled = false,
   onRowClick = vi.fn(),
   onOpenChange = vi.fn(),
   onRename = vi.fn(),
 }: {
+  disabled?: boolean;
   onRowClick?: () => void;
   onOpenChange?: (open: boolean) => void;
   onRename?: () => void;
@@ -29,6 +31,7 @@ function renderRow({
   const utils = render(
     <CompactViewportOverrideProvider isCompactViewport>
       <CompactLongPressMenu
+        disabled={disabled}
         label="Thread actions"
         onOpenChange={onOpenChange}
         items={<DropdownMenuItem onSelect={onRename}>Rename</DropdownMenuItem>}
@@ -214,5 +217,25 @@ describe("CompactLongPressMenu", () => {
     fireEvent(row, event);
     expect(event.defaultPrevented).toBe(true);
     expect(onOpenChange).toHaveBeenCalledWith(true);
+  });
+
+  it("leaves long-press and context-menu gestures untouched when disabled", () => {
+    vi.useFakeTimers();
+    const { row, onOpenChange } = renderRow({ disabled: true });
+
+    touchPointerDown(row);
+    act(() => {
+      vi.advanceTimersByTime(LONG_PRESS_MS);
+    });
+    expect(onOpenChange).not.toHaveBeenCalled();
+
+    const event = new MouseEvent("contextmenu", {
+      bubbles: true,
+      cancelable: true,
+    });
+    fireEvent(row, event);
+    expect(event.defaultPrevented).toBe(false);
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(screen.queryByRole("menuitem")).toBeNull();
   });
 });

--- a/apps/app/src/components/ui/compact-long-press-menu.tsx
+++ b/apps/app/src/components/ui/compact-long-press-menu.tsx
@@ -34,6 +34,8 @@ const claimedPressEvents = new WeakSet<Event>();
 interface CompactLongPressMenuProps {
   /** The single element that receives the long-press gesture (a row). */
   children: ReactNode;
+  /** Leaves the child chrome mounted without claiming context-menu gestures. */
+  disabled?: boolean;
   /** Menu items rendered inside the compact drawer; mounted on first open. */
   items: ReactNode;
   /** Screen-reader label for the drawer surface. */
@@ -56,6 +58,7 @@ interface CompactLongPressMenuProps {
  */
 export function CompactLongPressMenu({
   children,
+  disabled = false,
   items,
   label,
   onOpenChange,
@@ -87,13 +90,19 @@ export function CompactLongPressMenu({
   );
 
   const openMenu = useCallback(() => {
+    if (disabled) {
+      return;
+    }
     clearPress();
     setHasOpened(true);
     handleOpenChange(true);
-  }, [clearPress, handleOpenChange]);
+  }, [clearPress, disabled, handleOpenChange]);
 
   const handlePointerDown = useCallback(
     (event: ReactPointerEvent<HTMLElement>) => {
+      if (disabled) {
+        return;
+      }
       if (event.pointerType !== "touch" && event.pointerType !== "pen") {
         return;
       }
@@ -121,7 +130,7 @@ export function CompactLongPressMenu({
         openMenu();
       }, LONG_PRESS_MS);
     },
-    [clearPress, openMenu],
+    [clearPress, disabled, openMenu],
   );
 
   const handlePointerMove = useCallback(
@@ -151,6 +160,9 @@ export function CompactLongPressMenu({
 
   const handleContextMenu = useCallback(
     (event: ReactMouseEvent<HTMLElement>) => {
+      if (disabled) {
+        return;
+      }
       // An enclosed menu (or another handler) already took this one; the same
       // rule Radix's ContextMenuTrigger applies through defaultPrevented.
       if (event.defaultPrevented) {
@@ -167,7 +179,7 @@ export function CompactLongPressMenu({
       }
       openMenu();
     },
-    [openMenu],
+    [disabled, openMenu],
   );
 
   const handleClickCapture = useCallback(

--- a/apps/app/src/lib/plugin-app-definition.test.ts
+++ b/apps/app/src/lib/plugin-app-definition.test.ts
@@ -881,4 +881,81 @@ describe("collectPluginAppRegistrations", () => {
       experimental_sidebarAccessory: SidebarAccessory,
     });
   });
+
+  it("keeps experimental nav-panel menu groups and lazy submenus", () => {
+    const run = vi.fn();
+    const lazyItems = vi.fn(() => [{ id: "api", label: "API", run }]);
+    const definition = definePluginApp((app) => {
+      app.slots.navPanel({
+        id: "docs",
+        title: "Docs",
+        icon: "FileText",
+        path: "docs",
+        component: Component,
+        experimental_menu: [
+          {
+            id: "surfaces",
+            label: "API docs",
+            items: [
+              {
+                id: "by-surface",
+                label: "API surfaces",
+                items: lazyItems,
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    const menu =
+      collectPluginAppRegistrations(definition).navPanels[0]?.experimental_menu;
+    expect(menu?.[0]).toMatchObject({
+      id: "surfaces",
+      label: "API docs",
+    });
+    expect(menu?.[0]?.items[0]).toMatchObject({
+      id: "by-surface",
+      items: lazyItems,
+    });
+    expect(lazyItems).not.toHaveBeenCalled();
+  });
+
+  it("merges menu groups beyond the fourth into the fourth and logs it", () => {
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const definition = definePluginApp((app) => {
+      app.slots.navPanel({
+        id: "docs",
+        title: "Docs",
+        icon: "FileText",
+        path: "docs",
+        component: Component,
+        experimental_menu: Array.from({ length: 6 }, (_, index) => ({
+          id: `group-${index + 1}`,
+          label: `Group ${index + 1}`,
+          items: [
+            {
+              id: `item-${index + 1}`,
+              label: `Item ${index + 1}`,
+              run: () => {},
+            },
+          ],
+        })),
+      });
+    });
+
+    const groups =
+      collectPluginAppRegistrations(definition).navPanels[0]?.experimental_menu;
+    expect(groups).toHaveLength(4);
+    expect(groups?.[3]?.label).toBe("Group 4");
+    expect(groups?.[3]?.items.map((item) => item.id)).toEqual([
+      "item-4",
+      "item-5",
+      "item-6",
+    ]);
+    expect(warning).toHaveBeenCalledWith(
+      expect.stringContaining("groups beyond the fourth were merged"),
+    );
+    warning.mockRestore();
+  });
 });

--- a/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/SKILL.md
@@ -394,7 +394,12 @@ const settings = bb.settings.define({
   teamKey: { type: "string", label: "Team", default: "" },
   // Multi-line editor (JSON, lists); the value is still a string the plugin
   // parses itself. Cannot be combined with `secret`.
-  agents: { type: "string", label: "Agents", experimental_multiline: true, default: "[]" },
+  agents: {
+    type: "string",
+    label: "Agents",
+    experimental_multiline: true,
+    default: "[]",
+  },
   mode: {
     type: "select",
     label: "Mode",
@@ -1022,7 +1027,10 @@ bb.agents.registerTool({
   // tool name and the plugin's branding glyph. Errors/interruptions keep
   // that standard rendering so the failing tool remains identifiable.
   presentation: {
-    label: { pending: "Searching bundled docs", completed: "Searched bundled docs" },
+    label: {
+      pending: "Searching bundled docs",
+      completed: "Searched bundled docs",
+    },
   },
   parameters: z.object({ query: z.string().min(1) }),
   async execute({ query }, { threadId, projectId, signal }) {
@@ -1500,6 +1508,30 @@ export default definePluginApp((app) => {
       },
     ],
     experimental_sidebarAccessory: OpenIssueCount,
+    experimental_menu: [
+      {
+        id: "board-actions",
+        label: "Issue tracker",
+        items: [
+          {
+            id: "overview",
+            label: "Open overview",
+            run: ({ navigate }) => navigate(""),
+          },
+          {
+            id: "saved-views",
+            label: "Saved views",
+            items: async ({ navigate }) => [
+              {
+                id: "mine",
+                label: "Assigned to me",
+                run: () => navigate("views/mine"),
+              },
+            ],
+          },
+        ],
+      },
+    ],
   });
   app.slots.threadPanelAction({
     id: "issue",
@@ -1798,7 +1830,7 @@ Slot props contracts (versioned, additive-only):
   back/forward then walks panel-internal history (prefer this over hash
   routing).
   Registration:
-  `{ id, title, icon, path, component, fixedTabs?, experimental_sidebarAccessory?, headerContent? }`.
+  `{ id, title, icon, path, component, fixedTabs?, experimental_sidebarAccessory?, experimental_menu?, headerContent? }`.
   BB automatically wraps every plugin page in the same host-owned App panel
   used by New thread and thread pages. The page component supplies only its
   main body; it must not mount a second panel layout or register Browser and
@@ -1859,6 +1891,18 @@ target? })`. Inside the fixed-tab component,
   button on row hover or keyboard focus without unmounting. Do not render
   controls or portalled content there. A throw hides only the accessory.
   Experimental: see `docs/api_to_audit.md`.
+  `experimental_menu` contributes host-rendered data to this page's sidebar
+  ellipsis and right-click menus. Declare up to four ordered groups:
+  `{ id, label?, items }`, where an item is
+  `{ id, label, icon?, description?, disabled?, run(context) }`. A submenu is
+  `{ id, label, icon?, items }`; its `items` is either a leaf-item array or a
+  function that returns one synchronously or asynchronously when the submenu
+  opens. Only one submenu level exists. The context is
+  `{ pluginId, panelId, navigate(subPath), openInSplit(subPath?) }` and is
+  scoped to the owning page. Unknown Lucide icon names render no glyph. BB
+  catches action and resolver failures. Groups after the fourth merge into the
+  fourth in declaration order and log a warning. Experimental: see
+  `docs/api_to_audit.md`.
   The host renders your compact plugin icon + `title` into the SHARED app
   header (the same title bar as Settings pages) with your optional
   `headerContent` component as the header actions on the right — so do NOT
@@ -2054,10 +2098,10 @@ openWorkspaceFile }` — register a leaf
   through the bridge's presentation. The component receives `row` (id,
   threadId, turnId, kind, toolName, status, startedAt, completedAt),
   `payload` (the extension item's validated payload, or `{ arguments,
-  output }` for a tool call), `presentation` (the bridge's label, icon,
+output }` for a tool call), `presentation` (the bridge's label, icon,
   title, detail, suppress and tint for the row; null only for a tool row
   persisted before bridges attached one), `thread` (`{ id,
-  providerId }`) and `Original`, the host's declarative base for the body —
+providerId }`) and `Original`, the host's declarative base for the body —
   render `<Original />` to keep it beside your own content. The row header
   (label, glyph, tint, headline) stays host-rendered; a glyph of the form
   `"<pluginId>/<name>"` draws the plugin's declared icon

--- a/apps/server/test/fixtures/plugins/bb-plugin-sdk-0.4.17-scaffold/package.json
+++ b/apps/server/test/fixtures/plugins/bb-plugin-sdk-0.4.17-scaffold/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "bb-plugin-sdk-upgrade-fixture",
+  "version": "0.1.0",
+  "type": "module",
+  "engines": {
+    "bb": ">=0.39",
+    "bbPluginSdk": ">=0.4.17"
+  },
+  "bb": {
+    "name": "Sdk upgrade fixture",
+    "description": "A BB plugin.",
+    "branding": {
+      "icon": "Zap"
+    },
+    "server": "./server.ts"
+  },
+  "dependencies": {
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@get-bb/plugin-sdk": "0.4.17",
+    "@types/better-sqlite3": "^7.6.12",
+    "@types/node": "^22.0.0",
+    "@types/react": "^19.0.0",
+    "better-sqlite3": "^12.0.0",
+    "hono": "^4.11.9",
+    "typescript": "^5.7.0"
+  }
+}

--- a/apps/server/test/fixtures/plugins/bb-plugin-sdk-0.4.17-scaffold/server.ts
+++ b/apps/server/test/fixtures/plugins/bb-plugin-sdk-0.4.17-scaffold/server.ts
@@ -1,0 +1,5 @@
+import type { BbPluginApi } from "@get-bb/plugin-sdk";
+
+export default function plugin(bb: BbPluginApi) {
+  bb.log.info("0.4.17 scaffold upgrade fixture loaded");
+}

--- a/apps/server/test/services/plugins/plugin-authoring-docs.test.ts
+++ b/apps/server/test/services/plugins/plugin-authoring-docs.test.ts
@@ -309,6 +309,7 @@ const NAV_PANEL_REGISTRATION_FIELDS = [
   "component",
   "fixedTabs",
   "experimental_sidebarAccessory",
+  "experimental_menu",
   "headerContent",
 ] as const satisfies readonly (keyof PluginNavPanelRegistration)[];
 

--- a/apps/server/test/services/plugins/plugin-service.test.ts
+++ b/apps/server/test/services/plugins/plugin-service.test.ts
@@ -1,6 +1,8 @@
 import {
+  cp,
   mkdtemp,
   mkdir,
+  readFile,
   rename,
   rm,
   symlink,
@@ -16,7 +18,7 @@ import {
   upsertInstalledPlugin,
   type DbConnection,
 } from "@bb/db";
-import type { SystemChangeKind } from "@bb/domain";
+import { PLUGIN_SDK_VERSION, type SystemChangeKind } from "@bb/domain";
 import type { Logger } from "@bb/logger";
 import { createAiServiceRegistry } from "../../../src/services/ai/ai-service-registry.js";
 import {
@@ -592,7 +594,7 @@ describe("plugin service", () => {
     } as unknown as Logger;
     const makeService = (appVersion: string) =>
       createPluginService({
-      aiServices: createAiServiceRegistry(),
+        aiServices: createAiServiceRegistry(),
         telemetry: createNoopTelemetryService(),
         db,
         hub: {
@@ -646,6 +648,72 @@ describe("plugin service", () => {
       "warn plugin notify not loaded (incompatible): requires bb >=0.38.0 <0.39.0, this is 0.39.0",
     );
     await after.stop();
+  });
+
+  it("keeps a persisted 0.4.17 scaffold plugin running after the 0.4.18 SDK upgrade", async () => {
+    // Frozen output from the last released scaffold proves an existing user
+    // install still clears the compatibility gate after the additive bump.
+    // In-repo plugins built against the new SDK would not exercise an upgrade.
+    const fixtureDir = new URL(
+      "../../fixtures/plugins/bb-plugin-sdk-0.4.17-scaffold/",
+      import.meta.url,
+    );
+    const rootDir = join(workDir, "bb-plugin-sdk-upgrade-fixture");
+    await cp(fixtureDir, rootDir, { recursive: true });
+    const manifest = JSON.parse(
+      await readFile(join(rootDir, "package.json"), "utf8"),
+    ) as {
+      engines: { bbPluginSdk: string };
+      devDependencies: Record<string, string>;
+    };
+    expect(manifest.engines.bbPluginSdk).toBe(">=0.4.17");
+    expect(manifest.devDependencies["@get-bb/plugin-sdk"]).toBe("0.4.17");
+    expect(PLUGIN_SDK_VERSION).toBe("0.4.18");
+
+    upsertInstalledPlugin(db, {
+      id: "sdk-upgrade-fixture",
+      source: `path:${rootDir}`,
+      provenance: { kind: "direct" },
+      sourceIntent: { kind: "path", canonicalPath: rootDir },
+      exactResolution: { kind: "path" },
+      updateState: {
+        lastCheckAt: null,
+        availableCompatibleVersion: null,
+        newestIncompatibleVersion: null,
+        statusDetail: null,
+      },
+      activeArtifactId: null,
+      rootDir,
+      version: "0.1.0",
+      enabled: true,
+    });
+
+    const upgraded = createPluginService({
+      aiServices: createAiServiceRegistry(),
+      telemetry: createNoopTelemetryService(),
+      db,
+      hub: {
+        getDaemonSessionIdForHost: () => null,
+        notifyPluginSignal: () => 0,
+        notifySystem: () => {},
+      },
+      logger,
+      dataDir: join(workDir, "data"),
+      appVersion: "0.39.0",
+      loadTimeoutMs: 2000,
+      bundledPlugins: [],
+    });
+    await upgraded.start();
+    try {
+      const entry = upgraded
+        .list()
+        .find((plugin) => plugin.id === "sdk-upgrade-fixture");
+      expect(entry?.status).toBe("running");
+      expect(entry?.statusDetail).toBeNull();
+      expect(upgraded.getApi("sdk-upgrade-fixture")).toBeDefined();
+    } finally {
+      await upgraded.stop();
+    }
   });
 
   it("skips the engines gate on 0.0.0 dev builds instead of marking everything incompatible", async () => {
@@ -1034,9 +1102,7 @@ describe("plugin service", () => {
       version: "0.2.0",
       status: "running",
     });
-    expect((globalThis as Record<string, unknown>).__brittleCheckout).toBe(
-      "a",
-    );
+    expect((globalThis as Record<string, unknown>).__brittleCheckout).toBe("a");
     expect(service.getApi("brittle")).toBeDefined();
     expect((await service.getSettings("brittle"))?.values).toEqual({
       token: { set: true },

--- a/apps/server/test/services/plugins/plugin-service.test.ts
+++ b/apps/server/test/services/plugins/plugin-service.test.ts
@@ -650,7 +650,7 @@ describe("plugin service", () => {
     await after.stop();
   });
 
-  it("keeps a persisted 0.4.17 scaffold plugin running after the 0.4.18 SDK upgrade", async () => {
+  it("keeps a persisted 0.4.17 scaffold plugin running after the 0.4.24 SDK upgrade", async () => {
     // Frozen output from the last released scaffold proves an existing user
     // install still clears the compatibility gate after the additive bump.
     // In-repo plugins built against the new SDK would not exercise an upgrade.
@@ -668,7 +668,7 @@ describe("plugin service", () => {
     };
     expect(manifest.engines.bbPluginSdk).toBe(">=0.4.17");
     expect(manifest.devDependencies["@get-bb/plugin-sdk"]).toBe("0.4.17");
-    expect(PLUGIN_SDK_VERSION).toBe("0.4.18");
+    expect(PLUGIN_SDK_VERSION).toBe("0.4.24");
 
     upsertInstalledPlugin(db, {
       id: "sdk-upgrade-fixture",

--- a/docs/api_to_audit.md
+++ b/docs/api_to_audit.md
@@ -272,6 +272,7 @@ ever needs two configured differently. For `acpLaunchSpecSchema`: the shape
 is stored in the ACP plugin's `customAgents` setting and in registrations'
 bridge options, so a change is a migration of stored agents — decide what a
 plugin is owed when the spec grows a field.
+
 ## `PluginProviderDeclaration.experimental_nativeSkillRoots`
 
 **Kept experimental (2026-08-22).** every first-party provider declares it now (stabilization S5 moved the daemon's per-provider scan table here), but no third-party agent has validated the relative-path / 32-root rule or the per-root options, and the split between a global declaration and the per-workspace resolver (`experimental_resolvesNativeRoots`) is one release old.
@@ -860,6 +861,35 @@ unmounting. A crash hides only the accessory.
    order and the focus-triggered accessory/options swap work for counts and
    short statuses, and decide whether a dedicated label prop or host-rendered
    status semantics are needed.
+
+## `PluginNavPanelRegistration.experimental_menu`
+
+**Added experimental (2026-08-25).** One example consumer exercises the shape;
+the waiting API-docs plugin is not yet a second production consumer.
+
+**What it does.** Lets the plugin that owns a nav panel append up to four
+host-rendered menu groups to that page's sidebar ellipsis and right-click
+menus. Contributions are data and callbacks, not components. Items can run an
+action or open one level of submenu; a submenu resolver may load its leaf
+items when opened. The host supplies owner-scoped navigation and split helpers,
+omits unknown icon names, contains rejected resolvers and actions, and merges
+groups after the fourth into the fourth in declaration order.
+
+**Audit before stabilizing.**
+
+1. Confirm two independent plugins can express their real actions without
+   arbitrary menu components, deeper nesting, checkboxes, or destructive-item
+   metadata.
+2. Verify the one-level lazy resolver lifecycle across repeated opens, plugin
+   reloads, slow promises, rejected promises, and menus dismissed mid-load.
+3. Audit `navigate` and `openInSplit` as the right owner-scoped capabilities;
+   neither should gain cross-plugin or global route access.
+4. Confirm four plugin groups, with later groups merged and logged, remains a
+   useful cap under localization and long plugin display names.
+5. Exercise keyboard, screen-reader, pointer, touch-drawer, and right-click
+   parity before freezing the host-rendered presentation.
+6. Decide whether action failures need a structured error or telemetry
+   contract beyond the current contained toast and warning.
 
 ## `PluginContentScriptContext.experimental_setThreadRowStatus`
 

--- a/packages/domain/src/plugin-sdk-version.ts
+++ b/packages/domain/src/plugin-sdk-version.ts
@@ -16,7 +16,7 @@
 // PLUGIN_SDK_MAJOR is 0, so the major-only artifact gate cannot distinguish
 // 0.x releases and is intentionally vacuous for them until a future 1.0.
 // Rebuildable artifacts still rebuild on the exact sdkVersion-differs trigger.
-export const PLUGIN_SDK_VERSION = "0.4.18";
+export const PLUGIN_SDK_VERSION = "0.4.24";
 
 /** Major of {@link PLUGIN_SDK_VERSION} — the plugin API compatibility number. */
 export const PLUGIN_SDK_MAJOR = Number(PLUGIN_SDK_VERSION.split(".", 1)[0]);

--- a/packages/domain/src/plugin-sdk-version.ts
+++ b/packages/domain/src/plugin-sdk-version.ts
@@ -16,7 +16,7 @@
 // PLUGIN_SDK_MAJOR is 0, so the major-only artifact gate cannot distinguish
 // 0.x releases and is intentionally vacuous for them until a future 1.0.
 // Rebuildable artifacts still rebuild on the exact sdkVersion-differs trigger.
-export const PLUGIN_SDK_VERSION = "0.4.17";
+export const PLUGIN_SDK_VERSION = "0.4.18";
 
 /** Major of {@link PLUGIN_SDK_VERSION} — the plugin API compatibility number. */
 export const PLUGIN_SDK_MAJOR = Number(PLUGIN_SDK_VERSION.split(".", 1)[0]);

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@get-bb/plugin-sdk",
-  "version": "0.4.18",
+  "version": "0.4.24",
   "homepage": "https://github.com/get-bb/bb#readme",
   "bugs": {
     "url": "https://github.com/get-bb/bb/issues"

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@get-bb/plugin-sdk",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "homepage": "https://github.com/get-bb/bb#readme",
   "bugs": {
     "url": "https://github.com/get-bb/bb/issues"

--- a/packages/plugin-sdk/src/app-contract.ts
+++ b/packages/plugin-sdk/src/app-contract.ts
@@ -418,21 +418,69 @@ export type ExperimentalPluginFixedTabReference<
     });
 
 /** A fixed tab declared by a plugin nav panel. */
-export type PluginFixedTabRegistration<
-  Target extends JsonValue = never,
-> = ExperimentalPluginFixedTabReference<Target> & {
-  title: string;
-  /** Icon hint (BB icon name); unknown names fall back to a generic icon. */
-  icon: string;
-  component: ComponentType<PluginNavPanelProps>;
-  /** `flush` lets the component own padding and scrolling. */
-  layout?: "padded" | "flush";
-};
+export type PluginFixedTabRegistration<Target extends JsonValue = never> =
+  ExperimentalPluginFixedTabReference<Target> & {
+    title: string;
+    /** Icon hint (BB icon name); unknown names fall back to a generic icon. */
+    icon: string;
+    component: ComponentType<PluginNavPanelProps>;
+    /** `flush` lets the component own padding and scrolling. */
+    layout?: "padded" | "flush";
+  };
 
 /** A fixed tab with either no target or an owner-validated JSON target. */
 export type PluginFixedTabDeclaration =
   | PluginFixedTabRegistration
   | PluginFixedTabRegistration<JsonValue>;
+
+/** Host capabilities passed to an experimental nav-panel menu action. */
+export interface ExperimentalPluginNavPanelMenuContext {
+  /** Plugin that owns the nav panel and menu. */
+  pluginId: string;
+  /** Owning nav panel registration id. */
+  panelId: string;
+  /** Navigate within the owning page. An empty path opens its root. */
+  navigate(subPath: string): void;
+  /** Open the owning page or one of its subpaths in the split workspace. */
+  openInSplit(subPath?: string): void;
+}
+
+/** One host-rendered action contributed to a nav-panel menu. */
+export interface ExperimentalPluginNavPanelMenuItem {
+  id: string;
+  label: string;
+  /** Lucide icon name. Unknown names render no icon. */
+  icon?: string;
+  description?: string;
+  disabled?: boolean;
+  run(context: ExperimentalPluginNavPanelMenuContext): void | Promise<void>;
+}
+
+/** One lazy or eager submenu. Submenus cannot contain another submenu. */
+export interface ExperimentalPluginNavPanelSubmenu {
+  id: string;
+  label: string;
+  /** Lucide icon name. Unknown names render no icon. */
+  icon?: string;
+  /** A function is evaluated once when this submenu opens. */
+  items:
+    | readonly ExperimentalPluginNavPanelMenuItem[]
+    | ((
+        context: ExperimentalPluginNavPanelMenuContext,
+      ) =>
+        | readonly ExperimentalPluginNavPanelMenuItem[]
+        | Promise<readonly ExperimentalPluginNavPanelMenuItem[]>);
+}
+
+export interface ExperimentalPluginNavPanelMenuGroup {
+  id: string;
+  /** Host-rendered group heading; defaults to the plugin's display name. */
+  label?: string;
+  items: readonly (
+    | ExperimentalPluginNavPanelMenuItem
+    | ExperimentalPluginNavPanelSubmenu
+  )[];
+}
 
 export interface PluginNavPanelRegistration {
   /** Unique within the plugin; letters, digits, `-`, `_`. */
@@ -466,6 +514,14 @@ export interface PluginNavPanelRegistration {
    * Experimental: see docs/api_to_audit.md.
    */
   experimental_sidebarAccessory?: ComponentType;
+  /**
+   * Optional host-rendered action groups appended to this panel's sidebar
+   * menus. Up to four groups render; later groups merge into the fourth. A
+   * plugin supplies data and callbacks, never sidebar components.
+   *
+   * Experimental: see docs/api_to_audit.md.
+   */
+  experimental_menu?: readonly ExperimentalPluginNavPanelMenuGroup[];
   /**
    * Optional component rendered on the right side of the shared title bar
    * (e.g. a sync button or a count). Contained separately from the body: a

--- a/packages/plugin-sdk/src/internal/plugin-app-collector.ts
+++ b/packages/plugin-sdk/src/internal/plugin-app-collector.ts
@@ -3,6 +3,9 @@ import type {
   PluginAppDefinition,
   PluginContentScriptRegistration,
   PluginDiffRendererRegistration,
+  ExperimentalPluginNavPanelMenuGroup,
+  ExperimentalPluginNavPanelMenuItem,
+  ExperimentalPluginNavPanelSubmenu,
   PluginFileOpenerRegistration,
   PluginHomepageSectionRegistration,
   PluginCommandPaletteActionRegistration,
@@ -50,6 +53,7 @@ const NAV_PANEL_REGISTRATION_KEYS: ReadonlySet<string> = new Set(
     component: true,
     fixedTabs: true,
     experimental_sidebarAccessory: true,
+    experimental_menu: true,
     headerContent: true,
   } satisfies Record<keyof PluginNavPanelRegistration, true>),
 );
@@ -79,6 +83,180 @@ function rejectStaleNavPanelKeys(kind: string, registration: object): void {
       throw new Error(`${kind}: unknown field "${key}"`);
     }
   }
+}
+
+type ExperimentalPluginNavPanelMenuEntry =
+  | ExperimentalPluginNavPanelMenuItem
+  | ExperimentalPluginNavPanelSubmenu;
+
+function requireMenuRecord(
+  kind: string,
+  value: unknown,
+): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${kind}: must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function rejectUnknownMenuKeys(
+  kind: string,
+  value: Record<string, unknown>,
+  allowedKeys: ReadonlySet<string>,
+): void {
+  for (const key of Object.keys(value)) {
+    if (!allowedKeys.has(key)) {
+      throw new Error(`${kind}: unknown field ${JSON.stringify(key)}`);
+    }
+  }
+}
+
+const MENU_ITEM_KEYS = new Set([
+  "id",
+  "label",
+  "icon",
+  "description",
+  "disabled",
+  "run",
+]);
+const SUBMENU_KEYS = new Set(["id", "label", "icon", "items"]);
+const MENU_GROUP_KEYS = new Set(["id", "label", "items"]);
+
+/** Validate lazy submenu output at the moment the plugin produces it. */
+export function validateExperimentalPluginNavPanelMenuItems(
+  kind: string,
+  value: unknown,
+): ExperimentalPluginNavPanelMenuItem[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`${kind}: must be an array`);
+  }
+  const seenIds = new Set<string>();
+  return value.map((entryValue, index) => {
+    const entryKind = `${kind}[${index}]`;
+    const entry = requireMenuRecord(entryKind, entryValue);
+    rejectUnknownMenuKeys(entryKind, entry, MENU_ITEM_KEYS);
+    const id = requireSlotId(entryKind, entry.id);
+    requireUniqueId(kind, seenIds, id);
+    if (typeof entry.run !== "function") {
+      throw new Error(`${entryKind}: "run" must be a function`);
+    }
+    const icon = requireOptionalString(entryKind, "icon", entry.icon);
+    const description = requireOptionalString(
+      entryKind,
+      "description",
+      entry.description,
+    );
+    if (entry.disabled !== undefined && typeof entry.disabled !== "boolean") {
+      throw new Error(`${entryKind}: "disabled" must be a boolean when set`);
+    }
+    return {
+      id,
+      label: requireNonEmptyString(entryKind, "label", entry.label),
+      ...(icon === undefined ? {} : { icon }),
+      ...(description === undefined ? {} : { description }),
+      ...(entry.disabled === undefined ? {} : { disabled: entry.disabled }),
+      run: entry.run as ExperimentalPluginNavPanelMenuItem["run"],
+    };
+  });
+}
+
+function collectExperimentalPluginNavPanelMenuEntries(
+  kind: string,
+  value: unknown,
+): ExperimentalPluginNavPanelMenuEntry[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`${kind}: must be an array`);
+  }
+  const seenIds = new Set<string>();
+  return value.map((entryValue, index) => {
+    const entryKind = `${kind}[${index}]`;
+    const entry = requireMenuRecord(entryKind, entryValue);
+    const isSubmenu = Object.hasOwn(entry, "items");
+    rejectUnknownMenuKeys(
+      entryKind,
+      entry,
+      isSubmenu ? SUBMENU_KEYS : MENU_ITEM_KEYS,
+    );
+    const id = requireSlotId(entryKind, entry.id);
+    requireUniqueId(kind, seenIds, id);
+    const label = requireNonEmptyString(entryKind, "label", entry.label);
+    const icon = requireOptionalString(entryKind, "icon", entry.icon);
+    if (isSubmenu) {
+      if (typeof entry.items !== "function" && !Array.isArray(entry.items)) {
+        throw new Error(`${entryKind}: "items" must be an array or function`);
+      }
+      return {
+        id,
+        label,
+        ...(icon === undefined ? {} : { icon }),
+        items:
+          typeof entry.items === "function"
+            ? (entry.items as ExperimentalPluginNavPanelSubmenu["items"])
+            : validateExperimentalPluginNavPanelMenuItems(
+                `${entryKind}.items`,
+                entry.items,
+              ),
+      };
+    }
+    if (typeof entry.run !== "function") {
+      throw new Error(`${entryKind}: "run" must be a function`);
+    }
+    const description = requireOptionalString(
+      entryKind,
+      "description",
+      entry.description,
+    );
+    if (entry.disabled !== undefined && typeof entry.disabled !== "boolean") {
+      throw new Error(`${entryKind}: "disabled" must be a boolean when set`);
+    }
+    return {
+      id,
+      label,
+      ...(icon === undefined ? {} : { icon }),
+      ...(description === undefined ? {} : { description }),
+      ...(entry.disabled === undefined ? {} : { disabled: entry.disabled }),
+      run: entry.run as ExperimentalPluginNavPanelMenuItem["run"],
+    };
+  });
+}
+
+function collectExperimentalPluginNavPanelMenuGroups(
+  kind: string,
+  value: unknown,
+): ExperimentalPluginNavPanelMenuGroup[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`${kind}: must be an array when set`);
+  }
+  const seenIds = new Set<string>();
+  const groups = value.map((groupValue, index) => {
+    const groupKind = `${kind}[${index}]`;
+    const group = requireMenuRecord(groupKind, groupValue);
+    rejectUnknownMenuKeys(groupKind, group, MENU_GROUP_KEYS);
+    const id = requireSlotId(groupKind, group.id);
+    requireUniqueId(kind, seenIds, id);
+    const label = requireOptionalString(groupKind, "label", group.label);
+    return {
+      id,
+      ...(label === undefined ? {} : { label }),
+      items: collectExperimentalPluginNavPanelMenuEntries(
+        `${groupKind}.items`,
+        group.items,
+      ),
+    } satisfies ExperimentalPluginNavPanelMenuGroup;
+  });
+  if (groups.length <= 4) return groups;
+
+  const fourth = groups[3];
+  if (fourth === undefined) return groups;
+  const mergedItems = groups.slice(3).flatMap((group) => group.items);
+  const mergedIds = new Set<string>();
+  for (const item of mergedItems) {
+    requireUniqueId(`${kind}[3].items`, mergedIds, item.id);
+  }
+  console.warn(
+    `${kind}: groups beyond the fourth were merged into ${JSON.stringify(fourth.id)}`,
+  );
+  return [...groups.slice(0, 3), { ...fourth, items: mergedItems }];
 }
 
 /** Validated registrations produced by one plugin app setup execution. */
@@ -280,6 +458,13 @@ export function collectPluginAppRegistrations(
             };
           });
         })();
+        const experimentalMenu =
+          registration.experimental_menu === undefined
+            ? []
+            : collectExperimentalPluginNavPanelMenuGroups(
+                `${kind}.experimental_menu`,
+                registration.experimental_menu,
+              );
         collected.navPanels.push({
           id,
           title: requireNonEmptyString(kind, "title", registration.title),
@@ -292,6 +477,9 @@ export function collectPluginAppRegistrations(
                 experimental_sidebarAccessory:
                   registration.experimental_sidebarAccessory,
               }
+            : {}),
+          ...(experimentalMenu.length > 0
+            ? { experimental_menu: experimentalMenu }
             : {}),
           ...(registration.headerContent !== undefined
             ? { headerContent: registration.headerContent }

--- a/packages/plugin-sdk/src/testing/__tests__/app-harness.test.tsx
+++ b/packages/plugin-sdk/src/testing/__tests__/app-harness.test.tsx
@@ -250,9 +250,7 @@ function UrlNavigationProbe() {
       </UrlLink>
       <button
         type="button"
-        onClick={() =>
-          navigate.openUrl("https://example.com/imperative")
-        }
+        onClick={() => navigate.openUrl("https://example.com/imperative")}
       >
         Open imperatively
       </button>
@@ -825,6 +823,39 @@ describe("loadPluginApp", () => {
     expect(captured.navPanels[0]?.experimental_sidebarAccessory).toBe(
       SidebarAccessory,
     );
+  });
+
+  it("captures nav panel menu groups without resolving lazy submenus", async () => {
+    const run = vi.fn();
+    const lazyItems = vi.fn(() => [{ id: "threads", label: "Threads", run }]);
+    const captured = await loadPluginApp(
+      definePluginApp((builder) => {
+        builder.slots.navPanel({
+          id: "tasks",
+          title: "Tasks",
+          icon: "ListTodo",
+          path: "tasks",
+          component: Panel,
+          experimental_menu: [
+            {
+              id: "browse",
+              items: [
+                {
+                  id: "by-kind",
+                  label: "Browse by kind",
+                  items: lazyItems,
+                },
+              ],
+            },
+          ],
+        });
+      }),
+    );
+
+    expect(
+      captured.navPanels[0]?.experimental_menu?.[0]?.items[0],
+    ).toMatchObject({ id: "by-kind", items: lazyItems });
+    expect(lazyItems).not.toHaveBeenCalled();
   });
 
   it("validates and captures nav panel fixed tabs", async () => {

--- a/packages/templates/src/templates/bb-guide-plugins.md
+++ b/packages/templates/src/templates/bb-guide-plugins.md
@@ -5,6 +5,7 @@ summary: Command reference for installing, configuring, running, and authoring b
 intent: Provide complete plugin command documentation plus an authoring walkthrough for agents and humans building bb plugins.
 editingNotes: Keep flags accurate against the CLI implementation (apps/cli/src/commands/plugin.ts, apps/cli/src/commands/marketplace.ts) and the server plugin service; a CLI test asserts every `bb plugin` and `bb marketplace` subcommand appears in this chapter. The full authoring reference is the bb-plugin-authoring builtin skill.
 ---
+
 Plugin commands
 
 A bb plugin is a TypeScript package that extends the bb server in-process and
@@ -57,15 +58,15 @@ The builtin Workflows plugin runs durable provider-independent JavaScript
 orchestration. It is disabled on fresh installations; enable `workflows` under
 Extensions → Plugins or run `bb plugin enable workflows` before using:
 
-  bb workflows validate (--script '<javascript>'|--source '<javascript>'|
-                        --file <path>|--name <name>)
-  bb workflows run (--script '<javascript>'|--source '<javascript>'|
-                   --file <path>|--name <name>)
-                   [--args '<json>'] [--resume <run-id>]
-  bb workflows status <run-id>
-  bb workflows history <run-id> [--cursor <call-index>] [--limit <1-100>]
-  bb workflows list [--limit <1-50>]
-  bb workflows stop <run-id>
+bb workflows validate (--script '<javascript>'|--source '<javascript>'|
+--file <path>|--name <name>)
+bb workflows run (--script '<javascript>'|--source '<javascript>'|
+--file <path>|--name <name>)
+[--args '<json>'] [--resume <run-id>]
+bb workflows status <run-id>
+bb workflows history <run-id> [--cursor <call-index>] [--limit <1-100>]
+bb workflows list [--limit <1-50>]
+bb workflows stop <run-id>
 
 Commands must run from a BB project thread. Workflows has six plugin
 settings, configurable with `bb plugin config workflows set <key> <value>`:
@@ -94,15 +95,15 @@ Providers to avoid duplicate or conflicting stores. Settings → Memory lists
 every global and project memory and supports version-checked edits and soft
 deletion.
 
-  bb memory catalog [--scope project|global|all] [--json]
-  bb memory search <query> [--scope project|global|all] [--json]
-  bb memory get <id> [--scope project|global|all] [--json]
-  bb memory add --scope project|global --name <name> --summary <text>
-                --details <text> --reason <text> [--kind <kind>]
-                [--tag <tag>]... [--importance <0-100>] [--pinned] [--json]
-  bb memory update <id> --expected-version <n> [fields...] [--json]
-  bb memory forget <id> --expected-version <n> --reason <text> [--json]
-  bb memory history <id> [--scope project|global|all] [--limit 1-100] [--json]
+bb memory catalog [--scope project|global|all] [--json]
+bb memory search <query> [--scope project|global|all] [--json]
+bb memory get <id> [--scope project|global|all] [--json]
+bb memory add --scope project|global --name <name> --summary <text>
+--details <text> --reason <text> [--kind <kind>]
+[--tag <tag>]... [--importance <0-100>] [--pinned] [--json]
+bb memory update <id> --expected-version <n> [fields...] [--json]
+bb memory forget <id> --expected-version <n> --reason <text> [--json]
+bb memory history <id> [--scope project|global|all] [--limit 1-100] [--json]
 
 Project writes use the invoking CLI's current project. Global writes require
 the explicit `--scope global` flag.
@@ -111,13 +112,13 @@ The Docs plugin is an opt-in official plugin bundled with the app:
 `bb plugin install docs`. Read-only discovery remains direct, while edits use
 a manifest-backed local workspace:
 
-  bb docs vaults [--json]
-  bb docs list [--vault <id>] [--json]
-  bb docs read <path> [--vault <id>]
-  bb docs pull <path> [--folder] [--vault <id>] [--into <dir>]
-  bb docs pull --all [--vault <id>] [--into <dir>]
-  bb docs status [workspace-dir] [--delete] [--diff] [--json]
-  bb docs push [workspace-dir] [--delete] [--dry-run] [--diff] [--json]
+bb docs vaults [--json]
+bb docs list [--vault <id>] [--json]
+bb docs read <path> [--vault <id>]
+bb docs pull <path> [--folder] [--vault <id>] [--into <dir>]
+bb docs pull --all [--vault <id>] [--into <dir>]
+bb docs status [workspace-dir] [--delete] [--diff] [--json]
+bb docs push [workspace-dir] [--delete] [--dry-run] [--diff] [--json]
 
 Pull preserves vault-relative paths and writes `.bb-docs-state.json`; edit the
 ordinary files and leave that state file untouched. Push uses pulled SHA-256
@@ -132,15 +133,15 @@ The Tasks plugin is an opt-in official plugin bundled with the app:
 `bb plugin install tasks`. It adds a task tracker, agent delegation,
 and the `bb tasks` command. Common agent operations are:
 
-  bb tasks show <key-or-id> [--json]
-  bb tasks list [--project <prefix-or-id>] [filters...] [--sort manual|priority|due] [--limit 1-500] [--cursor <opaque>] [--json]
-  bb tasks comment <key-or-id> (--body <markdown> | --body-file <path>) [--json]
-  bb tasks attachment add <key-or-comment-id> --file <path> [--json]
-  bb tasks attachment get <attachment-id> --out <path> [--json]
-  bb tasks attach <key-or-id> [--thread <thread-id>] [--json]
-  bb tasks detach <key-or-id> [--thread <thread-id>] [--json]
-  bb tasks update <key-or-id> --status in_review [--json]
-  bb tasks update <key-or-id> (--parent <parent-key-or-id> | --no-parent) [--json]
+bb tasks show <key-or-id> [--json]
+bb tasks list [--project <prefix-or-id>] [filters...] [--sort manual|priority|due] [--limit 1-500] [--cursor <opaque>] [--json]
+bb tasks comment <key-or-id> (--body <markdown> | --body-file <path>) [--json]
+bb tasks attachment add <key-or-comment-id> --file <path> [--json]
+bb tasks attachment get <attachment-id> --out <path> [--json]
+bb tasks attach <key-or-id> [--thread <thread-id>] [--json]
+bb tasks detach <key-or-id> [--thread <thread-id>] [--json]
+bb tasks update <key-or-id> --status in_review [--json]
+bb tasks update <key-or-id> (--parent <parent-key-or-id> | --no-parent) [--json]
 
 Run `bb tasks --help` for project, folder, task, label, attachment, and demo-data
 commands, plus preset management, delegation, and attached-thread inspection.
@@ -162,134 +163,134 @@ snapshot.
 The builtin Secrets plugin provides a secure credential form and guarded
 dotenv reconciliation:
 
-  bb secret request <NAME...> --write-env <path>
-                    [--purpose <text>] [--describe <NAME> <text>]...
+bb secret request <NAME...> --write-env <path>
+[--purpose <text>] [--describe <NAME> <text>]...
 
 The command blocks until the user submits or cancels the form. Secret values
 never appear in command arguments, model-visible output, or persisted
 interaction data; success prints only the path, variable names, and
 added/updated/unchanged counts.
 
-  bb plugin search <query>       Search the store: the plugins bundled with
-                                 the app plus every registered marketplace
-                                 catalog
-  bb plugin install <entry>      Install a bundled official plugin by name
-                                 (github, docs, memory, tasks),
-                                 <entry-id>@<marketplace>, a Git repository
-                                 URL, local path, builtin:<name>,
-                                 git:<url>[@<ref|semver-range>], or
-                                 npm:<package>[@<version|tag|range>]
-                                 (npm: needs npm on PATH; installs prompt —
-                                 pass --yes to skip). Managed git:/npm:
-                                 installs refuse engines.bb / engines.bbPluginSdk
-                                 mismatches, manifest/artifact identity
-                                 mismatches, and ids reserved by bundled plugins
-                                 Omitted npm specs, ranges, dist-tags, omitted
-                                 Git refs, Git branches, and Git semver ranges
-                                 track; exact npm versions, Git tags, and Git
-                                 commits are pinned
-                                 --subdirectory <path> installs one plugin
-                                 directory of a multi-plugin git:/path:
-                                 repository; --plugin <name> installs the
-                                 .bb/plugins.json entry with that name
-                                 (the two flags are mutually exclusive)
-                                 --tag-prefix <prefix> resolves a git: semver
-                                 range over <prefix>vX.Y.Z tags
-                                 Installing a local path for an id that is
-                                 already installed from another local path
-                                 moves it there and keeps its settings
-  bb plugin outdated             Check installed plugins for compatible
-                                 updates (table; --json for raw results).
-                                 Columns: installed, latest compatible,
-                                 blocked newer (incompatible releases not
-                                 selected), status. Dev builds (bb 0.0.0)
-                                 annotate that engines.bb is not enforced
-  bb plugin update <id> | --all  Apply compatible updates for one plugin or
-                                 every tracking plugin with an update. Same
-                                 full-trust confirmation as
-                                 install (--yes skips; non-TTY refuses without
-                                 --yes). Use outdated to preview; pinned
-                                 installs stay put
-  bb plugin list                 Status, services, schedules, handler timings.
-                                 `bb status` also names enabled plugins that
-                                 are incompatible, failed, or missing
-  bb plugin source <id> [--json] Show requested/resolved source, subdirectory,
-                                 semver range with its tag prefix and resolved
-                                 tag, engine ranges, install time, and recent
-                                 activation history
-  bb plugin enable|disable <id>  Load or unload an installed plugin
-  bb plugin reload [id]          Re-run factories against current sources.
-                                 Exits 1 when a plugin does not come up on
-                                 them (previous instance kept, or degraded
-                                 because a service ignored its abort)
-  bb plugin config <id> [set <key> <value> | unset <key>]
-                                 Show or change a plugin's declared settings
-  bb plugin logs <id> [-n N] [-f]  Print (or follow) a plugin's bb.log output
-  bb plugin run <id> [args...]   Run the plugin's CLI command explicitly
-  bb plugin token <id> [--rotate]  Print the token for auth:"token" HTTP
-                                 routes; --rotate generates a new token,
-                                 invalidating the old one
-  bb plugin remove <id>          Uninstall and delete the plugin's settings,
-                                 secrets, and schedules (managed git:/npm:
-                                 files deleted; local path sources stay on
-                                 disk; builtin removals are remembered)
-  bb plugin new <name>           Scaffold a todo-list plugin (server.ts,
-                                 app.tsx with a sidebar page, a `bb <id>` CLI
-                                 command, and a skill) and install its npm
-                                 dependencies, including @get-bb/plugin-sdk
-                                 pinned to this bb's exact SDK version (no
-                                 server required)
-  bb plugin types [path]         Sync a plugin's @get-bb/plugin-sdk surface to
-                                 this bb (default: cwd): repin the npm
-                                 devDependency to this bb's SDK version, or
-                                 rewrite the vendored types/ of a plugin that
-                                 still carries them; --check writes nothing
-                                 and exits non-zero on a mismatch
-  bb plugin migrate [path]       Switch a plugin that still vendors types/ to
-                                 the @get-bb/plugin-sdk npm package (default:
-                                 cwd): pin the devDependency, drop the tsconfig
-                                 path map, delete the vendored declarations.
-                                 Prints the plan and asks first; --yes skips
-                                 the prompt (required when stdin is not a
-                                 terminal). The old layout keeps working, so
-                                 nothing migrates unless you ask
-  bb plugin build [path]         Compile the plugin into dist/ — the backend
-                                 bundle (server.js, server.meta.json); when
-                                 bb.app is declared, the minified frontend
-                                 bundle (app.js, app.css, app.meta.json); when
-                                 bb.host is declared, the self-contained Node
-                                 host bundle (host.js, host.js.map,
-                                 host.meta.json recording its digest — host
-                                 daemons fetch and verify the bundle by that
-                                 digest, and run it as a host RPC worker, a
-                                 provider bridge, or both). Each
-                                 *.meta.json is stamped with SDK
-                                 major/version, artifactFormatVersion,
-                                 pluginId, pluginVersion, and builtWith (bb +
-                                 plugin SDK versions); no server required
-  bb plugin dev [path]           Watch a plugin's sources (default: cwd) and
-                                 on every change rebuild its declared frontend
-                                 (unminified, for readable stack traces),
-                                 host, and provider-bridge bundles, then
-                                 reload the plugin; Ctrl+C to stop
+bb plugin search <query> Search the store: the plugins bundled with
+the app plus every registered marketplace
+catalog
+bb plugin install <entry> Install a bundled official plugin by name
+(github, docs, memory, tasks),
+<entry-id>@<marketplace>, a Git repository
+URL, local path, builtin:<name>,
+git:<url>[@<ref|semver-range>], or
+npm:<package>[@<version|tag|range>]
+(npm: needs npm on PATH; installs prompt —
+pass --yes to skip). Managed git:/npm:
+installs refuse engines.bb / engines.bbPluginSdk
+mismatches, manifest/artifact identity
+mismatches, and ids reserved by bundled plugins
+Omitted npm specs, ranges, dist-tags, omitted
+Git refs, Git branches, and Git semver ranges
+track; exact npm versions, Git tags, and Git
+commits are pinned
+--subdirectory <path> installs one plugin
+directory of a multi-plugin git:/path:
+repository; --plugin <name> installs the
+.bb/plugins.json entry with that name
+(the two flags are mutually exclusive)
+--tag-prefix <prefix> resolves a git: semver
+range over <prefix>vX.Y.Z tags
+Installing a local path for an id that is
+already installed from another local path
+moves it there and keeps its settings
+bb plugin outdated Check installed plugins for compatible
+updates (table; --json for raw results).
+Columns: installed, latest compatible,
+blocked newer (incompatible releases not
+selected), status. Dev builds (bb 0.0.0)
+annotate that engines.bb is not enforced
+bb plugin update <id> | --all Apply compatible updates for one plugin or
+every tracking plugin with an update. Same
+full-trust confirmation as
+install (--yes skips; non-TTY refuses without
+--yes). Use outdated to preview; pinned
+installs stay put
+bb plugin list Status, services, schedules, handler timings.
+`bb status` also names enabled plugins that
+are incompatible, failed, or missing
+bb plugin source <id> [--json] Show requested/resolved source, subdirectory,
+semver range with its tag prefix and resolved
+tag, engine ranges, install time, and recent
+activation history
+bb plugin enable|disable <id> Load or unload an installed plugin
+bb plugin reload [id] Re-run factories against current sources.
+Exits 1 when a plugin does not come up on
+them (previous instance kept, or degraded
+because a service ignored its abort)
+bb plugin config <id> [set <key> <value> | unset <key>]
+Show or change a plugin's declared settings
+bb plugin logs <id> [-n N] [-f] Print (or follow) a plugin's bb.log output
+bb plugin run <id> [args...] Run the plugin's CLI command explicitly
+bb plugin token <id> [--rotate] Print the token for auth:"token" HTTP
+routes; --rotate generates a new token,
+invalidating the old one
+bb plugin remove <id> Uninstall and delete the plugin's settings,
+secrets, and schedules (managed git:/npm:
+files deleted; local path sources stay on
+disk; builtin removals are remembered)
+bb plugin new <name> Scaffold a todo-list plugin (server.ts,
+app.tsx with a sidebar page, a `bb <id>` CLI
+command, and a skill) and install its npm
+dependencies, including @get-bb/plugin-sdk
+pinned to this bb's exact SDK version (no
+server required)
+bb plugin types [path] Sync a plugin's @get-bb/plugin-sdk surface to
+this bb (default: cwd): repin the npm
+devDependency to this bb's SDK version, or
+rewrite the vendored types/ of a plugin that
+still carries them; --check writes nothing
+and exits non-zero on a mismatch
+bb plugin migrate [path] Switch a plugin that still vendors types/ to
+the @get-bb/plugin-sdk npm package (default:
+cwd): pin the devDependency, drop the tsconfig
+path map, delete the vendored declarations.
+Prints the plan and asks first; --yes skips
+the prompt (required when stdin is not a
+terminal). The old layout keeps working, so
+nothing migrates unless you ask
+bb plugin build [path] Compile the plugin into dist/ — the backend
+bundle (server.js, server.meta.json); when
+bb.app is declared, the minified frontend
+bundle (app.js, app.css, app.meta.json); when
+bb.host is declared, the self-contained Node
+host bundle (host.js, host.js.map,
+host.meta.json recording its digest — host
+daemons fetch and verify the bundle by that
+digest, and run it as a host RPC worker, a
+provider bridge, or both). Each
+\*.meta.json is stamped with SDK
+major/version, artifactFormatVersion,
+pluginId, pluginVersion, and builtWith (bb +
+plugin SDK versions); no server required
+bb plugin dev [path] Watch a plugin's sources (default: cwd) and
+on every change rebuild its declared frontend
+(unminified, for readable stack traces),
+host, and provider-bridge bundles, then
+reload the plugin; Ctrl+C to stop
 
-  bb marketplace add <source>    Add a marketplace from an https manifest URL,
-                                 git:<url>[@<ref>], or path:<directory>. bb
-                                 validates the manifest, caches the catalog,
-                                 and fetches the entry icons. Adding a
-                                 marketplace installs nothing
-  bb marketplace list            Name, source, entry count, and last refresh of
-                                 every marketplace (--json for raw rows)
-  bb marketplace refresh [name]  Re-read one catalog, or every one of them.
-                                 Discovery metadata and icons only — a refresh
-                                 never installs, updates, or runs plugin code.
-                                 A failed refresh keeps the last catalog bb
-                                 validated and exits non-zero
-  bb marketplace remove <name>   Forget a marketplace. Its catalog rows and
-                                 cached icons are deleted; plugins installed
-                                 from it keep running as direct installs and
-                                 keep checking for updates from their recorded
-                                 source. bb-community cannot be removed
+bb marketplace add <source> Add a marketplace from an https manifest URL,
+git:<url>[@<ref>], or path:<directory>. bb
+validates the manifest, caches the catalog,
+and fetches the entry icons. Adding a
+marketplace installs nothing
+bb marketplace list Name, source, entry count, and last refresh of
+every marketplace (--json for raw rows)
+bb marketplace refresh [name] Re-read one catalog, or every one of them.
+Discovery metadata and icons only — a refresh
+never installs, updates, or runs plugin code.
+A failed refresh keeps the last catalog bb
+validated and exits non-zero
+bb marketplace remove <name> Forget a marketplace. Its catalog rows and
+cached icons are deleted; plugins installed
+from it keep running as direct installs and
+keep checking for updates from their recorded
+source. bb-community cannot be removed
 
 Multi-plugin repositories
 
@@ -297,15 +298,15 @@ One repository can hold several plugins. Each plugin directory stays an
 ordinary plugin package with its own package.json and bb manifest. An optional
 collection manifest at .bb/plugins.json indexes them:
 
-  {
-    "$schema": "https://getbb.app/schemas/plugins.schema.json",
-    "schemaVersion": 1,
-    "name": "acme-plugins",
-    "plugins": [
-      { "name": "sidebar", "source": "./plugins/sidebar" },
-      { "name": "status", "source": "./apps/status" }
-    ]
-  }
+{
+"$schema": "https://getbb.app/schemas/plugins.schema.json",
+"schemaVersion": 1,
+"name": "acme-plugins",
+"plugins": [
+{ "name": "sidebar", "source": "./plugins/sidebar" },
+{ "name": "status", "source": "./apps/status" }
+]
+}
 
 Every source is a repository-relative directory that starts with "./".
 Absolute paths, "..", and a source that selects the repository root are
@@ -315,9 +316,9 @@ plugin's own manifest.
 
 Install one plugin of the repository:
 
-  bb plugin install git:github.com/acme/repo@main --plugin sidebar
-  bb plugin install git:github.com/acme/repo@main --subdirectory plugins/sidebar
-  bb plugin install path:/work/repo --plugin sidebar
+bb plugin install git:github.com/acme/repo@main --plugin sidebar
+bb plugin install git:github.com/acme/repo@main --subdirectory plugins/sidebar
+bb plugin install path:/work/repo --plugin sidebar
 
 --subdirectory is the primitive and works without a collection manifest.
 --plugin resolves a name from .bb/plugins.json. Installs from one repository
@@ -354,9 +355,9 @@ Anyone can host a marketplace manifest. Add one with its https manifest URL,
 with git:<url>[@<ref>] (bb reads marketplace.json from the checkout), or with
 path:<directory> on the bb server's machine:
 
-  bb marketplace add https://plugins.acme.dev/marketplace.json
-  bb marketplace add git:github.com/acme/bb-marketplace@main
-  bb marketplace add path:/work/acme-marketplace
+bb marketplace add https://plugins.acme.dev/marketplace.json
+bb marketplace add git:github.com/acme/bb-marketplace@main
+bb marketplace add path:/work/acme-marketplace
 
 The manifest's own `name` is the marketplace's identity, so adding refuses a
 name another marketplace already uses. `bb-community` is reserved: it cannot be
@@ -369,7 +370,7 @@ it — the validated manifest and icon bytes are all bb keeps.
 
 Install an entry of a specific marketplace with <entry-id>@<marketplace>:
 
-  bb plugin install thread-hover-cards@acme-plugins
+bb plugin install thread-hover-cards@acme-plugins
 
 A bare id resolves across every marketplace. Exactly one match installs, no
 match falls back to the bundled official plugin of that name, and several
@@ -419,9 +420,9 @@ Git semver ranges
 A git source can track releases the way an npm range does, over the
 repository's tags:
 
-  bb plugin install git:github.com/acme/repo@^1.2.0
-  bb plugin install git:github.com/acme/repo@semver:^1.2.0
-  bb plugin install git:github.com/acme/repo@^1.2.0 --tag-prefix notes/
+bb plugin install git:github.com/acme/repo@^1.2.0
+bb plugin install git:github.com/acme/repo@semver:^1.2.0
+bb plugin install git:github.com/acme/repo@^1.2.0 --tag-prefix notes/
 
 bb lists refs/tags, keeps the tags named [<tag-prefix>]vX.Y.Z that parse as
 semver, and installs the highest one the range allows. Prereleases are
@@ -512,14 +513,16 @@ Frontend entries (app.tsx) default-export `definePluginApp` from
 `@get-bb/plugin-sdk/app` and register UI slots: homepageSection (root compose),
 settingsSection (per-plugin settings page below the host-rendered settings
 form; no props in V1, optional host-rendered title),
-navPanel (own sidebar entry + /plugins/<id>/<path>/* route; the remainder
+navPanel (own sidebar entry + /plugins/<id>/<path>/\* route; the remainder
 arrives as the component's subPath prop for panel-internal deep links; the
 host always renders the shared plugin title bar and the component owns a
 zero-padding full-bleed body, including its scrolling; optional
 experimental_sidebarAccessory mounts a presentational live-value component at
 the trailing edge of the sidebar row on wide viewports, bounded to one short
 line, replaced visually by the host options button on hover/focus, and omitted
-on compact viewports),
+on compact viewports; optional experimental_menu contributes owner-scoped,
+host-rendered action groups and one-level eager or lazy submenus to the same
+ellipsis and right-click menus),
 threadPanelAction
 (a thread-only entry in an existing thread's right-panel new-tab Actions list;
 it is never offered on root compose, and its run() can
@@ -673,8 +676,8 @@ the plugin to pick up branding changes.
 
 The backend entry default-exports a factory receiving the full plugin API:
 
-  import type { BbPluginApi } from "@get-bb/plugin-sdk";
-  export default async function plugin(bb: BbPluginApi) { ... }
+import type { BbPluginApi } from "@get-bb/plugin-sdk";
+export default async function plugin(bb: BbPluginApi) { ... }
 
 The import is type-only and erased at load; the scaffold depends on the npm
 package @get-bb/plugin-sdk, pinned to this bb's exact SDK version, so
@@ -706,7 +709,7 @@ its parent's visibility and still notifies that parent; plugins must archive
 finished hidden workers when appropriate and call `threads.stop` in a
 `finally` block to release each agent runtime promptly);
 bb.events.on (observe thread.created/idle/failed/deleted);
-bb.http.route (routes under /api/v1/plugins/<id>/http/* with
+bb.http.route (routes under /api/v1/plugins/<id>/http/\* with
 local/token/none auth); defineRpcContract + bb.rpc.register (Standard
 Schema-validated frontend data plane with inferred backend handlers and
 type-only frontend method/input/result inference);


### PR DESCRIPTION
## What was wrong

Plugin pages used two overlapping persistence concepts—an order and a hidden set—while the sidebar rendered every non-hidden page without a cap. That let plugin-heavy installs crowd threads out of the column and gave keyboard users no route to split a plugin page or reach plugin-contributed actions.

The first hidden-page migration did not preserve the old UI's felt state. Legacy “Hide from sidebar” rows lived behind `More (N)`, but the migration used the ordinary five-row cap and therefore resurfaced hidden pages when an installation had five or fewer plugin pages. It also cleared the entire legacy hidden set, even though the host-owned `__builtin__/tools` entry belongs to the later top-region toggle migration.

## What changed

- Replaces per-page hiding with one deduplicated user order over every registered plugin page; the first five render above a persistent `Show N more` disclosure.
- Temporarily promotes an active overflow page into the last visible slot without changing stored order.
- Adds `Move to top` / `Move to overflow`, cross-cap reordering, split, and plugin-settings actions through one menu definition shared by the ellipsis button and right-click.
- Migrates hidden plugin pages once under a Web Lock while preserving their prior felt state: visible pages remain ahead of hidden pages, and a temporary persisted fold records the previously visible count (capped at five), including installations with five or fewer total pages and the all-hidden case.
- Removes that temporary fold once the overflow is emptied, restoring the ordinary flat list for five or fewer pages.
- Makes migration ownership explicit: only plugin-page keys are consumed. Host-reserved entries such as `__builtin__/tools` never enter plugin order or overflow and remain in the legacy atom for the toggles layer to consume.
- Adds the optional additive `experimental_menu` plugin-app contract, including up to four labeled groups, one lazy submenu level, contained action/resolver failures, unknown-icon tolerance, and context helpers for navigation and splits.
- Advances the additive plugin SDK surface to 0.4.24, adds the public-API audit entry and authoring-guide coverage, and proves an installed 0.4.17 scaffold remains compatible. No server/daemon wire contract changed, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

## UI evidence

Identical fixture and viewport in both images: four plugin pages, with GitHub and Docs present in the legacy hidden set before first paint. The crop excludes unrelated project data.

### Before — merge base `c781d323e`

The same two pages are visible and the two hidden pages remain parked behind `More (2)`.

![Before: Automations and Tasks visible with two hidden pages behind More (2)](https://raw.githubusercontent.com/brsbl/bb/55df2709a481b35ad360cea930ea3fa4646c2a7d/pr-2405/before-4pages-2hidden.png)

### After — PR head `c3612aae6`

The same two pages remain visible, while the migrated disclosure uses the new `Show 2 more` label.

![After: Automations and Tasks visible with two migrated overflow pages behind Show 2 more](https://raw.githubusercontent.com/brsbl/bb/55df2709a481b35ad360cea930ea3fa4646c2a7d/pr-2405/after-4pages-2hidden.png)

The immutable screenshot assets are pinned to fork commit `55df2709a481b35ad360cea930ea3fa4646c2a7d`; both raw URLs return HTTP 200 with `image/png`.

## How you verified

- Focused migration, ordering, and sidebar-rendering regression suites: 46/46 passed, including the four upgrade cases from the updated spec.
- Installed 0.4.17 scaffold server compatibility suite: 29/29 passed against SDK 0.4.24.
- Plugin SDK suite: 220/220 passed.
- Full workspace lint passed through Turbo.
- Full workspace typecheck passed through Turbo.
- The full workspace test graph was exercised through Turbo on Node 22 with the repository's isolated npm cache. Twenty-six package suites passed serially before the pre-existing `@bb/host-watcher` nested-directory event test timed out waiting for a macOS filesystem event; an isolated retry reproduced that one timeout after its other 45 tests passed. `@bb/process-utils`, whose macOS cwd tests require `/usr/sbin/lsof`, passed 20/20 in an isolated Node 22 run. No Task 1 file touches either package.
- Required GitHub Actions are green at `c3612aae6`, including all app, package, server, integration, package-smoke, version-lockstep, and SDK-version guards.
- Exact-branch Chrome for Testing capture passed at 1440×900 for the migration path, including setting the legacy hidden state before first paint and hard reload into the settled state.
- Safari remains unverified on this host because automation access is unavailable; this PR is not being presented as fully cross-browser verified or merge-ready.

## Fixes

No linked issue; implements Phase 3 layer 1 of the Updated Sidebar Spec on top of PR #2395.

BB-Thread-ID: thr_jgmy8ay2qd

BB-Thread-ID: thr_2e2gbjx943

> AGENT GENERATED
