### PR TITLE
Add nav panel menu example plugin

### DIFF
--- a/examples/plugins/nav-panel-menu/README.md
+++ b/examples/plugins/nav-panel-menu/README.md
@@ -1,0 +1,16 @@
+# Nav panel menu
+
+Living example for a plugin-owned sidebar page menu. It contributes two
+host-rendered groups and a lazy **API surfaces** submenu through
+`experimental_menu`.
+
+Install it from a bb source checkout:
+
+```sh
+bb plugin install ./examples/plugins/nav-panel-menu --yes
+```
+
+Open the sidebar page's `...` menu or right-click its row. The host renders BB's
+own ordering, split, and settings actions first, followed by the example's
+**Navigation** and **Workspace** groups. The submenu's children are constructed
+only when **API surfaces** opens.

--- a/examples/plugins/nav-panel-menu/app.test.tsx
+++ b/examples/plugins/nav-panel-menu/app.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import { cleanup } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ExperimentalPluginNavPanelMenuContext } from "@get-bb/plugin-sdk/app";
+import { loadPluginApp, renderSlot } from "@get-bb/plugin-sdk/testing/app";
+
+const app = await loadPluginApp(() => import("./app"));
+
+afterEach(cleanup);
+
+describe("nav panel menu example", () => {
+  it("registers two groups and keeps API surface children lazy", async () => {
+    const panel = app.navPanels[0];
+    expect(panel).toMatchObject({
+      id: "nav-panel-menu",
+      title: "Nav panel menu",
+      path: "nav-panel-menu",
+    });
+    expect(panel?.experimental_menu).toHaveLength(2);
+    expect(panel?.experimental_menu?.map((group) => group.label)).toEqual([
+      "Navigation",
+      "Workspace",
+    ]);
+
+    const lazySubmenu = panel?.experimental_menu?.[0]?.items[1];
+    expect(lazySubmenu).toBeDefined();
+    if (lazySubmenu === undefined || !("items" in lazySubmenu)) {
+      throw new Error("Expected the API surfaces submenu");
+    }
+    expect(lazySubmenu.items).toBeTypeOf("function");
+    if (typeof lazySubmenu.items !== "function") {
+      throw new Error("Expected lazy submenu items to be a function");
+    }
+
+    const navigate = vi.fn();
+    const context: ExperimentalPluginNavPanelMenuContext = {
+      pluginId: "nav-panel-menu",
+      panelId: "nav-panel-menu",
+      navigate,
+      openInSplit: vi.fn(),
+    };
+    const items = await lazySubmenu.items(context);
+    expect(items.map((item) => item.label)).toEqual([
+      "Agents",
+      "App slots",
+      "Storage",
+    ]);
+
+    await items[1]?.run(context);
+    expect(navigate).toHaveBeenCalledWith("surfaces/app-slots");
+  });
+
+  it("renders the selected surface route", async () => {
+    const panel = app.navPanels[0];
+    if (panel === undefined) throw new Error("Expected a nav panel");
+
+    const slot = renderSlot(panel, { subPath: "surfaces/agents" });
+    expect(await slot.findByRole("heading", { name: "Agents" })).toBeTruthy();
+  });
+});

--- a/examples/plugins/nav-panel-menu/app.tsx
+++ b/examples/plugins/nav-panel-menu/app.tsx
@@ -1,0 +1,92 @@
+import {
+  definePluginApp,
+  type ExperimentalPluginNavPanelMenuContext,
+  type ExperimentalPluginNavPanelMenuItem,
+  type PluginNavPanelProps,
+} from "@get-bb/plugin-sdk/app";
+
+const API_SURFACES = [
+  { id: "agents", title: "Agents" },
+  { id: "app-slots", title: "App slots" },
+  { id: "storage", title: "Storage" },
+] as const;
+
+export async function loadApiSurfaceItems(
+  context: ExperimentalPluginNavPanelMenuContext,
+): Promise<readonly ExperimentalPluginNavPanelMenuItem[]> {
+  // A real plugin can fetch or derive its current pages here. Function-form
+  // submenu items are resolved by BB only when the submenu opens.
+  await Promise.resolve();
+  return API_SURFACES.map((surface) => ({
+    id: surface.id,
+    label: surface.title,
+    run: () => context.navigate(`surfaces/${surface.id}`),
+  }));
+}
+
+function NavPanelMenuPage({ subPath }: PluginNavPanelProps) {
+  const activeSurface = subPath.startsWith("surfaces/")
+    ? API_SURFACES.find((surface) => `surfaces/${surface.id}` === subPath)
+        ?.title
+    : undefined;
+
+  return (
+    <main className="h-full overflow-y-auto p-5 text-foreground">
+      <div className="mx-auto max-w-2xl rounded-lg border border-border bg-card p-5">
+        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          Nav panel menu example
+        </p>
+        <h1 className="mt-2 text-xl font-semibold">
+          {activeSurface ?? "Overview"}
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Use this page's sidebar menu to navigate, open a surface in split, or
+          inspect the lazy API surfaces submenu.
+        </p>
+      </div>
+    </main>
+  );
+}
+
+export default definePluginApp((app) => {
+  app.slots.navPanel({
+    id: "nav-panel-menu",
+    title: "Nav panel menu",
+    icon: "ListTree",
+    path: "nav-panel-menu",
+    component: NavPanelMenuPage,
+    experimental_menu: [
+      {
+        id: "navigation",
+        label: "Navigation",
+        items: [
+          {
+            id: "overview",
+            label: "Overview",
+            icon: "House",
+            description: "Open the example page root",
+            run: (context) => context.navigate(""),
+          },
+          {
+            id: "api-surfaces",
+            label: "API surfaces",
+            icon: "Library",
+            items: loadApiSurfaceItems,
+          },
+        ],
+      },
+      {
+        id: "workspace",
+        label: "Workspace",
+        items: [
+          {
+            id: "open-agents-in-split",
+            label: "Open Agents in split",
+            icon: "PanelRightOpen",
+            run: (context) => context.openInSplit("surfaces/agents"),
+          },
+        ],
+      },
+    ],
+  });
+});

--- a/examples/plugins/nav-panel-menu/package.json
+++ b/examples/plugins/nav-panel-menu/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "bb-plugin-nav-panel-menu-example",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "bb": ">=0.0",
+    "bbPluginSdk": ">=0.4.18"
+  },
+  "bb": {
+    "name": "Nav panel menu",
+    "description": "Living example for plugin-owned nav panel menu groups and lazy submenus.",
+    "branding": {
+      "icon": "ListTree"
+    },
+    "server": "./server.ts",
+    "app": "./app.tsx"
+  },
+  "keywords": [
+    "bb-plugin"
+  ],
+  "scripts": {
+    "test": "vitest run --config vitest.config.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@get-bb/plugin-sdk": "workspace:*",
+    "@testing-library/react": "^16.3.2",
+    "@types/node": "^22.0.0",
+    "@types/react": "^19.0.0",
+    "jsdom": "^29.0.1",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "typescript": "npm:@typescript/typescript6@^6.0.2",
+    "vitest": "^4.1.1"
+  }
+}

--- a/examples/plugins/nav-panel-menu/server.ts
+++ b/examples/plugins/nav-panel-menu/server.ts
@@ -1,0 +1,5 @@
+import type { BbPluginApi } from "@get-bb/plugin-sdk";
+
+export default function plugin(bb: BbPluginApi) {
+  bb.log.info("nav panel menu example loaded");
+}

--- a/examples/plugins/nav-panel-menu/tsconfig.json
+++ b/examples/plugins/nav-panel-menu/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "lib": ["ES2022", "DOM"],
+    "noEmit": true,
+    "skipLibCheck": true,
+    "paths": {
+      "@get-bb/plugin-sdk": [
+        "../../../packages/plugin-sdk/bundled-types/bb-plugin-sdk.d.ts"
+      ],
+      "@get-bb/plugin-sdk/app": [
+        "../../../packages/plugin-sdk/bundled-types/bb-plugin-sdk-app.d.ts"
+      ]
+    }
+  },
+  "include": ["app.test.tsx", "app.tsx", "server.ts"]
+}

--- a/examples/plugins/nav-panel-menu/vitest.config.ts
+++ b/examples/plugins/nav-panel-menu/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineWorkspaceTestConfig } from "../../../vitest.shared.js";
+
+export default defineWorkspaceTestConfig({
+  test: {
+    silent: "passed-only",
+    name: "bb-plugin-nav-panel-menu-example",
+    include: ["**/*.test.{ts,tsx}"],
+    exclude: ["node_modules/**"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1360,6 +1360,36 @@ importers:
         specifier: ^4.1.1
         version: 4.1.1(@opentelemetry/api@1.9.1)(@types/node@22.19.10)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@22.19.10)(@typescript/typescript6@6.0.2))(vite@8.0.12(@types/node@22.19.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.1)(yaml@2.9.0))
 
+  examples/plugins/nav-panel-menu:
+    devDependencies:
+      '@get-bb/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../../packages/plugin-sdk
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.10
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.13
+      jsdom:
+        specifier: ^29.0.1
+        version: 29.0.1(@noble/hashes@2.0.1)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.4(react@19.2.4)
+      typescript:
+        specifier: npm:@typescript/typescript6@^6.0.2
+        version: '@typescript/typescript6@6.0.2'
+      vitest:
+        specifier: ^4.1.1
+        version: 4.1.1(@opentelemetry/api@1.9.1)(@types/node@22.19.10)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@22.19.10)(@typescript/typescript6@6.0.2))(vite@8.0.12(@types/node@22.19.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.1)(yaml@2.9.0))
+
   examples/plugins/replacement-lab-alpha:
     devDependencies:
       '@get-bb/plugin-sdk':

--- a/turbo.json
+++ b/turbo.json
@@ -668,6 +668,9 @@
     "bb-plugin-echo-provider#typecheck": {
       "dependsOn": ["@get-bb/plugin-sdk#build:types", "topo"]
     },
+    "bb-plugin-nav-panel-menu-example#typecheck": {
+      "dependsOn": ["@get-bb/plugin-sdk#build:types", "topo"]
+    },
     "bb-plugin-scripted-echo-provider#typecheck": {
       "dependsOn": ["@get-bb/plugin-sdk#build:types", "topo"]
     },


### PR DESCRIPTION
## What was wrong

The new optional plugin-page menu contract had no in-repository consumer, so its group ordering, context helpers, and lazy-submenu shape could regress without exercising the same API a real plugin would import.

## What changed

- Adds `examples/plugins/nav-panel-menu`, a self-contained plugin that registers two labeled groups and a lazy `API surfaces` submenu through `experimental_menu`.
- Exercises `MenuContext.navigate` and `openInSplit` from real menu actions while keeping lazy submenu items unresolved until the submenu opens.
- Gives only this new consumer the capability-based `engines.bbPluginSdk >=0.4.18` floor; unrelated examples and the shared released baseline are unchanged.
- Adds focused rendering and lazy-resolution tests, a frozen lockfile importer, and the example-specific Turbo typecheck edge to the layer-1 SDK declarations. No other bb behavior changes in this layer.

### Before — parent layer `dd32116ce`

![Before: the nine-page fixture has no menu API example](https://github.com/user-attachments/assets/7ce7dcb1-8218-4d62-b8be-6580a9847293)

### After — this PR head `0c8d9af82`

![After: the installed example contributes groups and a lazy submenu](https://github.com/user-attachments/assets/621ee6c5-5735-4dd3-a5e0-489091f1ccee)

## How you verified

- Frozen offline lockfile validation passed with `pnpm install --lockfile-only --frozen-lockfile --ignore-scripts --offline` against an isolated modules directory.
- `pnpm exec oxfmt --threads=1 --check examples/plugins/nav-panel-menu` passed.
- `pnpm exec oxlint examples/plugins/nav-panel-menu` passed.
- Focused Vitest passed: 1 file, 2 tests.
- Focused source-contract TypeScript validation passed against the layer-1 `@get-bb/plugin-sdk/app` source in 9.7 seconds.
- The real plugin installed as `running` against the exact SDK 0.4.18 branch app; its two groups rendered, the lazy submenu produced Agents / App slots / Storage only on open, and selecting Agents navigated to `surfaces/agents` without a console exception.
- The full Turbo typecheck correctly reached the SDK declaration build but remained CPU-bound on this 8 GB host at one worker and was stopped after more than two minutes; CI must run the complete check.
- Chrome for Testing 152.0.7977.54 passed the cumulative responsive, theme, persistence, active-promotion, right-click, and repeated-disclosure flow. Safari 18.2 remains unverified because **Allow remote automation** is disabled on this host.

## Fixes

No linked issue; supplies the required living consumer layer for Phase 3 of the Updated Sidebar Spec.

BB-Thread-ID: thr_jgmy8ay2qd

> AGENT GENERATED
