### PR TITLE
fix(bb-app): reuse installed tarball in package smoke

### DIFF
--- a/packages/bb-app/scripts/smoke-tarball.mjs
+++ b/packages/bb-app/scripts/smoke-tarball.mjs
@@ -263,8 +263,14 @@ async function stopManagedProcess(processRef) {
   }
 }
 
-function createNpxArgs(tarballPath, bin, args) {
-  return ["--yes", "--package", tarballPath, "--", bin, ...args];
+function createInstalledBinInvocation(binDir, bin, args) {
+  // The tarball is installed once below. Run its npm-created bin links
+  // directly so package resolution and installation cannot consume a
+  // managed process's readiness budget before that process even starts.
+  return {
+    args,
+    command: join(binDir, bin),
+  };
 }
 
 async function packTarball() {
@@ -687,33 +693,29 @@ const SMOKE_EXECUTION_OPTIONS = {
   permissionEscalation: null,
 };
 
-async function smokeHelpCommands(tarballPath) {
+async function smokeHelpCommands(binDir) {
   await runCommand({
-    args: createNpxArgs(tarballPath, "bb-app", ["--help"]),
-    command: "npx",
+    ...createInstalledBinInvocation(binDir, "bb-app", ["--help"]),
     label: "bb-app help",
   });
   await runCommand({
-    args: createNpxArgs(tarballPath, "bb", ["--help"]),
-    command: "npx",
+    ...createInstalledBinInvocation(binDir, "bb", ["--help"]),
     label: "bb cli help",
   });
   await runCommand({
-    args: createNpxArgs(tarballPath, "bb-server", ["--help"]),
-    command: "npx",
+    ...createInstalledBinInvocation(binDir, "bb-server", ["--help"]),
     label: "bb-server help",
   });
   await runCommand({
-    args: createNpxArgs(tarballPath, "bb-host-daemon", ["--help"]),
-    command: "npx",
+    ...createInstalledBinInvocation(binDir, "bb-host-daemon", ["--help"]),
     label: "bb-host-daemon help",
   });
 }
 
-async function smokeConfigCommand(tarballPath) {
+async function smokeConfigCommand(binDir) {
   const dataDir = join(tempRoot, "config-command-data");
   await runCommand({
-    args: createNpxArgs(tarballPath, "bb-app", [
+    ...createInstalledBinInvocation(binDir, "bb-app", [
       "--data-dir",
       dataDir,
       "env",
@@ -721,11 +723,10 @@ async function smokeConfigCommand(tarballPath) {
       "OPENAI_API_KEY",
       "test-openai-key",
     ]),
-    command: "npx",
     label: "bb-app env OPENAI_API_KEY",
   });
   await runCommand({
-    args: createNpxArgs(tarballPath, "bb-app", [
+    ...createInstalledBinInvocation(binDir, "bb-app", [
       "--data-dir",
       dataDir,
       "config",
@@ -733,7 +734,6 @@ async function smokeConfigCommand(tarballPath) {
       "BB_APP_URL",
       "https://bb.example.test",
     ]),
-    command: "npx",
     label: "bb-app config BB_APP_URL",
   });
 
@@ -759,7 +759,7 @@ async function smokeSdkPackage(tarballPath) {
   await runCommand({
     args: [
       "install",
-      "--ignore-scripts",
+      "--ignore-scripts=false",
       "--no-audit",
       "--no-fund",
       tarballPath,
@@ -839,15 +839,18 @@ async function smokeInstalledRepack(installedPackageDir) {
   }
 }
 
-async function smokeBuiltinPluginsRunning({ cliEnv, tarballPath }) {
+async function smokeBuiltinPluginsRunning({ binDir, cliEnv }) {
   const deadline = Date.now() + PLUGIN_LOAD_TIMEOUT_MS;
   let lastSummary = "no plugin list output yet";
   // Plugins load after the HTTP server starts listening, so poll until every
   // expected builtin settles into "running".
   while (Date.now() <= deadline) {
     const stdout = await runCommand({
-      args: createNpxArgs(tarballPath, "bb", ["plugin", "list", "--json"]),
-      command: "npx",
+      ...createInstalledBinInvocation(binDir, "bb", [
+        "plugin",
+        "list",
+        "--json",
+      ]),
       env: cliEnv,
       label: "bb plugin list",
     });
@@ -886,12 +889,12 @@ async function smokeBuiltinPluginsRunning({ cliEnv, tarballPath }) {
   );
 }
 
-async function smokeFullStack(tarballPath, sdkDir) {
+async function smokeFullStack(binDir, sdkDir) {
   const dataDir = join(tempRoot, "full-stack-data");
   const [serverPort, daemonPort] = await getFreePorts(2);
   const serverUrl = `http://127.0.0.1:${serverPort}`;
   const stack = spawnManagedProcess({
-    args: createNpxArgs(tarballPath, "bb-app", [
+    ...createInstalledBinInvocation(binDir, "bb-app", [
       "--data-dir",
       dataDir,
       "--server-port",
@@ -899,7 +902,6 @@ async function smokeFullStack(tarballPath, sdkDir) {
       "--host-daemon-port",
       String(daemonPort),
     ]),
-    command: "npx",
     env: {
       BB_LOG_LEVEL: "info",
     },
@@ -923,12 +925,11 @@ async function smokeFullStack(tarballPath, sdkDir) {
       BB_SERVER_URL: serverUrl,
     };
     await runCommand({
-      args: createNpxArgs(tarballPath, "bb", ["status"]),
-      command: "npx",
+      ...createInstalledBinInvocation(binDir, "bb", ["status"]),
       env: cliEnv,
       label: "bb cli status",
     });
-    await smokeBuiltinPluginsRunning({ cliEnv, tarballPath });
+    await smokeBuiltinPluginsRunning({ binDir, cliEnv });
     // Keep Awake reconciles even its default disabled state, so reaching this
     // log proves the packed daemon found its companion worker, downloaded the
     // plugin artifact, and started the worker for a host RPC call.
@@ -958,7 +959,7 @@ async function smokeFullStack(tarballPath, sdkDir) {
   }
 }
 
-async function smokeDaemonJoin(tarballPath) {
+async function smokeDaemonJoin(binDir) {
   const serverDataDir = join(tempRoot, "join-server-data");
   const [serverPort, firstDaemonPort, secondDaemonPort, staleEnvPort] =
     await getFreePorts(4);
@@ -977,7 +978,7 @@ async function smokeDaemonJoin(tarballPath) {
     },
   ];
   const server = spawnManagedProcess({
-    args: createNpxArgs(tarballPath, "bb-server", [
+    ...createInstalledBinInvocation(binDir, "bb-server", [
       "--data-dir",
       serverDataDir,
       "--server-port",
@@ -985,7 +986,6 @@ async function smokeDaemonJoin(tarballPath) {
       "--host-daemon-port",
       String(firstDaemonPort),
     ]),
-    command: "npx",
     env: {
       BB_LOG_LEVEL: "warn",
     },
@@ -1001,7 +1001,7 @@ async function smokeDaemonJoin(tarballPath) {
     });
     for (const spec of daemonSpecs) {
       const daemon = spawnManagedProcess({
-        args: createNpxArgs(tarballPath, "bb-app", [
+        ...createInstalledBinInvocation(binDir, "bb-app", [
           "host-daemon",
           "join",
           "--data-dir",
@@ -1011,7 +1011,6 @@ async function smokeDaemonJoin(tarballPath) {
           "--host-daemon-port",
           String(spec.port),
         ]),
-        command: "npx",
         env: {
           BB_LOG_LEVEL: "info",
           BB_SERVER_URL: staleEnvServerUrl,
@@ -1038,7 +1037,7 @@ async function smokeDaemonJoin(tarballPath) {
       BB_HOST_DAEMON_PORT: String(firstDaemonPort),
       BB_SERVER_URL: serverUrl,
     };
-    await smokeBuiltinPluginsRunning({ cliEnv, tarballPath });
+    await smokeBuiltinPluginsRunning({ binDir, cliEnv });
     // Both daemons joined a server in a different process and data directory.
     // Ready workers on both prove host-plugin artifacts and calls fan out to
     // enrolled machines instead of assuming server-local paths.
@@ -1058,15 +1057,16 @@ async function smokeDaemonJoin(tarballPath) {
 
 try {
   const tarballPath = await packTarball();
-  await smokeHelpCommands(tarballPath);
-  await smokeConfigCommand(tarballPath);
   const sdkDir = await smokeSdkPackage(tarballPath);
+  const installedBinDir = join(sdkDir, "node_modules", ".bin");
   const installedPackageDir = join(sdkDir, "node_modules", "bb-app");
+  await smokeHelpCommands(installedBinDir);
+  await smokeConfigCommand(installedBinDir);
   await smokeInstalledRepack(installedPackageDir);
   await smokeProviderBridgeBundles(installedPackageDir);
   await smokePluginHostWorkerBundle(installedPackageDir);
-  await smokeFullStack(tarballPath, sdkDir);
-  await smokeDaemonJoin(tarballPath);
+  await smokeFullStack(installedBinDir, sdkDir);
+  await smokeDaemonJoin(installedBinDir);
   process.stdout.write("bb-app tarball smoke passed\n");
 } finally {
   await rm(tempRoot, { force: true, recursive: true });

--- a/packages/bb-app/scripts/smoke-tarball.mjs
+++ b/packages/bb-app/scripts/smoke-tarball.mjs
@@ -273,6 +273,17 @@ function createInstalledBinInvocation(binDir, bin, args) {
   };
 }
 
+async function smokeNpxEntrypoint(tarballPath) {
+  // Keep one real invocation through the package's advertised npx path. Once
+  // npx dispatches the bin, the installed-package smokes below cover the same
+  // launcher without repeatedly charging npm startup to readiness budgets.
+  await runCommand({
+    args: ["--yes", "--package", tarballPath, "--", "bb-app", "--help"],
+    command: "npx",
+    label: "bb-app npx help",
+  });
+}
+
 async function packTarball() {
   const stdout = await runCommand({
     args: ["pack", packageRoot, "--pack-destination", tempRoot, "--json"],
@@ -1057,6 +1068,7 @@ async function smokeDaemonJoin(binDir) {
 
 try {
   const tarballPath = await packTarball();
+  await smokeNpxEntrypoint(tarballPath);
   const sdkDir = await smokeSdkPackage(tarballPath);
   const installedBinDir = join(sdkDir, "node_modules", ".bin");
   const installedPackageDir = join(sdkDir, "node_modules", "bb-app");


### PR DESCRIPTION
## What was wrong

The tarball smoke installed the packed package once for SDK checks, but then launched every packaged CLI, server, and daemon through a fresh `npx --package <tarball>` wrapper. That put npm package resolution and subprocess startup inside each managed process's 60-second HTTP-readiness budget. Under scheduler contention the wrapper could consume nearly the entire budget before `bb-app` started its server child, producing the observed live-child signature from [main push run 32810192666](https://github.com/get-bb/bb/actions/runs/32810192666/job/97687946973): only the bb banner and `Starting server`, then the outer health timeout. A scaled packed-startup harness reproduced that exact output three times: under the same 60-burner load, the wrapped path emitted `Starting server` at 9.582s of a 10s ceiling and timed out, while the already-installed tarball emitted it at 112ms and reached health at 1.808s. The triggering PR #2245 changed only type imports and had no runtime effect. The package-smoke job runs one Turbo task on its own runner, so there is no evidence of within-job package-shard oversubscription; transient runner contention is the reproduction condition, not the root cause.

## What changed

Keep one real `npx --package <tarball> -- bb-app --help` invocation to verify the package's advertised npx resolution, installation, and bin-dispatch path. Separately install the packed tarball once with lifecycle scripts enabled, then execute its npm-created `.bin` entries directly for help/config, full-stack, CLI/plugin, standalone server, and daemon-join checks. This removes repeated npm startup from readiness budgets while preserving the real packed-install boundary and every existing assertion: server and daemon health, builtin plugins, SDK import/status, provider bridges, plugin host worker, installed-package repacking, and multi-daemon join behavior.

No timeout or retry budget changed. No server/daemon wire contract, public CLI behavior, documentation, or `HOST_DAEMON_PROTOCOL_VERSION` change is involved.

## How you verified

- Red before the fix: the scaled packed-startup harness under 60 CPU burners produced the exact `bb` / `Starting server` timeout three times for `npx --package <tarball> bb-app`; direct execution of the same installed tarball passed each reversed-order run in 1.724–1.856s.
- Green after the fix: the exact final full smoke, including the retained real npx entrypoint, passed under the same 60-burner contention in 192.78s. Its unchanged plugins, host worker, bridges, full-stack, and daemon-join assertions all passed.
- Normal local smoke improved from 51.02s before to 34.44s after without changing any clock.
- `pnpm exec turbo run build typecheck test --filter=bb-app --force` — 14/14 tasks passed; bb-app 72/72 tests passed.
- `pnpm exec turbo run smoke:tarball --filter=bb-app --force --cache-dir=.turbo/cache --output-logs=new-only` — 12/12 tasks passed; real tarball smoke passed after restoring the npx boundary.
- `pnpm exec prettier --check packages/bb-app/scripts/smoke-tarball.mjs` and `git diff --check` passed.

> AGENT GENERATED: by GPT-5.6-Sol