### PR TITLE
Handle reserved plugin CLI name collisions

### DIFF
--- a/apps/app/src/components/tools/PluginCapabilities.tsx
+++ b/apps/app/src/components/tools/PluginCapabilities.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { PERSONAL_PROJECT_ID } from "@bb/domain";
+import { pluginCliInvocation } from "@bb/domain/plugin-cli";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
 import { Button } from "@bb/shared-ui/button";
@@ -391,7 +392,7 @@ export function PluginIncludes({ plugin }: { plugin: PluginListItem }) {
         ? [
             {
               key: plugin.cliCommand.name,
-              label: `bb ${plugin.cliCommand.name}`,
+              label: pluginCliInvocation(plugin.id, plugin.cliCommand.name),
               detail: plugin.cliCommand.summary || undefined,
               mono: true,
             },

--- a/apps/app/src/components/tools/PluginCapabilities.tsx
+++ b/apps/app/src/components/tools/PluginCapabilities.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { PERSONAL_PROJECT_ID } from "@bb/domain";
-import { pluginCliInvocation } from "@bb/domain/plugin-cli";
+import { pluginCliCall } from "@bb/domain/plugin-cli";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
 import { Button } from "@bb/shared-ui/button";
@@ -392,7 +392,7 @@ export function PluginIncludes({ plugin }: { plugin: PluginListItem }) {
         ? [
             {
               key: plugin.cliCommand.name,
-              label: pluginCliInvocation(plugin.id, plugin.cliCommand.name),
+              label: pluginCliCall(plugin.id, plugin.cliCommand.name),
               detail: plugin.cliCommand.summary || undefined,
               mono: true,
             },

--- a/apps/cli/src/__tests__/command-output/plugin-updates.test.ts
+++ b/apps/cli/src/__tests__/command-output/plugin-updates.test.ts
@@ -194,6 +194,32 @@ describe("bb plugin update commands", () => {
     expect(output).not.toContain("other@1.0.0");
   });
 
+  it("list annotates only CLI commands shadowed by core", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      jsonResponse({
+        plugins: [
+          {
+            ...pluginList("shadower", "path:/shadower").plugins[0],
+            cliCommand: { name: "thread", summary: "Shadow threads" },
+          },
+          {
+            ...pluginList("notes", "path:/notes").plugins[0],
+            cliCommand: { name: "notes", summary: "Take notes" },
+          },
+        ],
+      }),
+    );
+
+    await runCommand(["plugin", "list"], register);
+
+    const output = collectLogPayloads(vi.mocked(console.log)).join("\n");
+    expect(output).toContain(
+      'command: bb plugin run shadower — Shadow threads (core command "bb thread" takes precedence)',
+    );
+    expect(output).toContain("command: bb notes — Take notes");
+    expect(output).not.toContain('core command "bb notes"');
+  });
+
   it("skips pinned plugins with manual reinstall guidance", async () => {
     vi.mocked(fetch).mockResolvedValueOnce(
       jsonResponse({

--- a/apps/cli/src/__tests__/plugin-new.test.ts
+++ b/apps/cli/src/__tests__/plugin-new.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { PLUGIN_SDK_VERSION } from "@bb/domain";
+import { RESERVED_BB_CLI_COMMANDS } from "@bb/domain/plugin-cli";
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -30,6 +31,12 @@ describe("resolveNewPluginTarget", () => {
     "@acme/team/bb-plugin-hello",
   ])("rejects %s", (name) => {
     expect(resolveNewPluginTarget(name)).toBeNull();
+  });
+
+  it.each(RESERVED_BB_CLI_COMMANDS)("rejects reserved id %s", (id) => {
+    expect(resolveNewPluginTarget(id)).toBeNull();
+    expect(resolveNewPluginTarget(`bb-plugin-${id}`)).toBeNull();
+    expect(resolveNewPluginTarget(`@acme/bb-plugin-${id}`)).toBeNull();
   });
 });
 

--- a/apps/cli/src/commands/plugin.ts
+++ b/apps/cli/src/commands/plugin.ts
@@ -7,6 +7,7 @@ import { setTimeout as sleep } from "node:timers/promises";
 import { Command } from "commander";
 import { z } from "zod";
 import { derivePluginId } from "@bb/domain";
+import { RESERVED_BB_CLI_COMMANDS } from "@bb/domain/plugin-cli";
 import type {
   InstalledPlugin as PluginEntry,
   PluginApplyUpdateResult,
@@ -61,9 +62,11 @@ export function resolveNewPluginTarget(name: string): NewPluginTarget | null {
   ) {
     return null;
   }
+  const pluginId = derivePluginId(packageName);
+  if (RESERVED_BB_CLI_COMMANDS.includes(pluginId)) return null;
   return {
     packageName,
-    directoryName: `bb-plugin-${derivePluginId(packageName)}`,
+    directoryName: `bb-plugin-${pluginId}`,
   };
 }
 
@@ -1293,7 +1296,7 @@ export function registerPluginCommands(
         const target = resolveNewPluginTarget(name);
         if (target === null) {
           console.error(
-            `Invalid plugin name "${name}" — use name, bb-plugin-name, or @scope/bb-plugin-name.`,
+            `Invalid or reserved plugin name "${name}" — use a non-core name, bb-plugin-name, or @scope/bb-plugin-name.`,
           );
           process.exit(1);
         }

--- a/apps/cli/src/commands/plugin.ts
+++ b/apps/cli/src/commands/plugin.ts
@@ -7,7 +7,10 @@ import { setTimeout as sleep } from "node:timers/promises";
 import { Command } from "commander";
 import { z } from "zod";
 import { derivePluginId } from "@bb/domain";
-import { RESERVED_BB_CLI_COMMANDS } from "@bb/domain/plugin-cli";
+import {
+  pluginCliInvocation,
+  RESERVED_BB_CLI_COMMANDS,
+} from "@bb/domain/plugin-cli";
 import type {
   InstalledPlugin as PluginEntry,
   PluginApplyUpdateResult,
@@ -810,7 +813,7 @@ function printPlugin(plugin: PluginEntry): void {
   }
   if (plugin.cliCommand) {
     console.log(
-      `  command: bb ${plugin.cliCommand.name} — ${plugin.cliCommand.summary}`,
+      `  command: ${pluginCliInvocation(plugin.id, plugin.cliCommand.name)} — ${plugin.cliCommand.summary}`,
     );
   }
 }

--- a/apps/cli/src/commands/plugin.ts
+++ b/apps/cli/src/commands/plugin.ts
@@ -7,10 +7,7 @@ import { setTimeout as sleep } from "node:timers/promises";
 import { Command } from "commander";
 import { z } from "zod";
 import { derivePluginId } from "@bb/domain";
-import {
-  pluginCliInvocation,
-  RESERVED_BB_CLI_COMMANDS,
-} from "@bb/domain/plugin-cli";
+import { pluginCliCall, RESERVED_BB_CLI_COMMANDS } from "@bb/domain/plugin-cli";
 import type {
   InstalledPlugin as PluginEntry,
   PluginApplyUpdateResult,
@@ -813,7 +810,7 @@ function printPlugin(plugin: PluginEntry): void {
   }
   if (plugin.cliCommand) {
     console.log(
-      `  command: ${pluginCliInvocation(plugin.id, plugin.cliCommand.name)} — ${plugin.cliCommand.summary}`,
+      `  command: ${pluginCliCall(plugin.id, plugin.cliCommand.name)} — ${plugin.cliCommand.summary}`,
     );
   }
 }

--- a/apps/cli/src/commands/plugin.ts
+++ b/apps/cli/src/commands/plugin.ts
@@ -809,8 +809,13 @@ function printPlugin(plugin: PluginEntry): void {
     );
   }
   if (plugin.cliCommand) {
+    const collisionNote = RESERVED_BB_CLI_COMMANDS.includes(
+      plugin.cliCommand.name,
+    )
+      ? ` (core command "bb ${plugin.cliCommand.name}" takes precedence)`
+      : "";
     console.log(
-      `  command: ${pluginCliCall(plugin.id, plugin.cliCommand.name)} — ${plugin.cliCommand.summary}`,
+      `  command: ${pluginCliCall(plugin.id, plugin.cliCommand.name)} — ${plugin.cliCommand.summary}${collisionNote}`,
     );
   }
 }

--- a/apps/server/src/services/plugins/plugin-api.ts
+++ b/apps/server/src/services/plugins/plugin-api.ts
@@ -69,6 +69,7 @@ import {
   PLUGIN_AGENT_STATIC_INSTRUCTIONS_MAX_CHARS,
   PLUGIN_HTTP_METHODS,
   parsePluginAgentToolPresentation,
+  pluginCliCollisionWarning,
   readRpcMethodContract,
   registerSettingDescriptors,
   rejectStaleAgentToolFields,
@@ -1471,6 +1472,10 @@ export function createPluginApi(options: {
       providerRegistrations.flush();
       aiServiceRegistrations.flush();
       activated = true;
+      const cliWarning = cliRecord.registration
+        ? pluginCliCollisionWarning(pluginId, cliRecord.registration.name)
+        : null;
+      if (cliWarning) emitLog("warn", cliWarning);
       pendingSharedPorts.clear();
       for (const problem of pendingAgentToolProblems) {
         reportAgentToolProblem(problem);

--- a/apps/server/src/services/plugins/plugin-api.ts
+++ b/apps/server/src/services/plugins/plugin-api.ts
@@ -73,7 +73,6 @@ import {
   registerSettingDescriptors,
   rejectStaleAgentToolFields,
   RESERVED_AGENT_TOOL_NAMES,
-  RESERVED_BB_CLI_COMMANDS,
   RPC_METHOD_PATTERN,
   isStandardSchema,
   summarizeParseIssues,
@@ -1203,11 +1202,6 @@ export function createPluginApi(options: {
       if (typeof name !== "string" || !CLI_COMMAND_NAME_PATTERN.test(name)) {
         throw new Error(
           `invalid cli command name ${JSON.stringify(name)} — use lowercase letters, digits, and "-"`,
-        );
-      }
-      if (RESERVED_BB_CLI_COMMANDS.includes(name)) {
-        throw new Error(
-          `cli command name "${name}" is reserved by the bb CLI — pick another name`,
         );
       }
       if (

--- a/apps/server/src/services/plugins/plugin-commands-skill.ts
+++ b/apps/server/src/services/plugins/plugin-commands-skill.ts
@@ -1,6 +1,6 @@
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { pluginCliInvocation } from "@bb/domain/plugin-cli";
+import { pluginCliCall } from "@bb/domain/plugin-cli";
 import { PLUGIN_CLI_OUTPUT_MAX_BYTES } from "@get-bb/plugin-sdk";
 import type { PluginCliCommandInfo } from "./plugin-api.js";
 
@@ -34,10 +34,7 @@ function renderPluginCommandsSkill(
 ): string {
   const sections = contributions.map((contribution) => {
     const direct = `bb ${contribution.name}`;
-    const invocation = pluginCliInvocation(
-      contribution.pluginId,
-      contribution.name,
-    );
+    const invocation = pluginCliCall(contribution.pluginId, contribution.name);
     const lines = [
       `## ${invocation} — ${contribution.summary}`,
       "",
@@ -64,8 +61,7 @@ function renderPluginCommandsSkill(
     "",
     "# Plugin Commands",
     "",
-    "Installed BB plugins contribute these commands. Most use a top-level `bb`",
-    "subcommand; core-name collisions use the explicit plugin-id form.",
+    "Installed BB plugins contribute commands; core-name collisions use the explicit plugin-id form while others use a top-level `bb` subcommand.",
     `Combined stdout and stderr is capped at ${PLUGIN_CLI_OUTPUT_MAX_BYTES} UTF-8 bytes. Above-limit`,
     "results fail atomically as `plugin_cli_output_too_large` and are never clipped;",
     "use pagination or file/streaming commands for large results.",

--- a/apps/server/src/services/plugins/plugin-commands-skill.ts
+++ b/apps/server/src/services/plugins/plugin-commands-skill.ts
@@ -1,5 +1,6 @@
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { pluginCliInvocation } from "@bb/domain/plugin-cli";
 import { PLUGIN_CLI_OUTPUT_MAX_BYTES } from "@get-bb/plugin-sdk";
 import type { PluginCliCommandInfo } from "./plugin-api.js";
 
@@ -32,16 +33,25 @@ function renderPluginCommandsSkill(
   contributions: readonly PluginCliContribution[],
 ): string {
   const sections = contributions.map((contribution) => {
+    const direct = `bb ${contribution.name}`;
+    const invocation = pluginCliInvocation(
+      contribution.pluginId,
+      contribution.name,
+    );
     const lines = [
-      `## bb ${contribution.name} — ${contribution.summary}`,
+      `## ${invocation} — ${contribution.summary}`,
       "",
-      `Contributed by plugin \`${contribution.pluginId}\`. Run \`bb ${contribution.name} --help\` for details;`,
-      `\`bb plugin run ${contribution.pluginId} <args...>\` is the explicit equivalent.`,
+      `Contributed by plugin \`${contribution.pluginId}\`. Run \`${invocation} --help\` for details.`,
+      `\`bb plugin run ${contribution.pluginId} <args...>\` is always available.`,
     ];
     if (contribution.commands.length > 0) {
       lines.push("");
       for (const command of contribution.commands) {
-        lines.push(`- \`${command.usage}\` — ${command.summary}`);
+        const usage =
+          command.usage === direct || command.usage.startsWith(`${direct} `)
+            ? `${invocation}${command.usage.slice(direct.length)}`
+            : command.usage;
+        lines.push(`- \`${usage}\` — ${command.summary}`);
       }
     }
     return lines.join("\n");
@@ -54,8 +64,8 @@ function renderPluginCommandsSkill(
     "",
     "# Plugin Commands",
     "",
-    "Installed BB plugins contribute these `bb` subcommands. Invoke them with",
-    "bash exactly like core `bb` commands; they run server-side.",
+    "Installed BB plugins contribute these commands. Most use a top-level `bb`",
+    "subcommand; core-name collisions use the explicit plugin-id form.",
     `Combined stdout and stderr is capped at ${PLUGIN_CLI_OUTPUT_MAX_BYTES} UTF-8 bytes. Above-limit`,
     "results fail atomically as `plugin_cli_output_too_large` and are never clipped;",
     "use pagination or file/streaming commands for large results.",

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
@@ -894,7 +894,8 @@ them by mixing ink into canvas), the `--primary` accent, the secondary text tier
   - `bb plugin config <id> [set <key> <value> | unset <key>]` — declared
     settings. Reload the plugin after configuring (`bb plugin reload <id>`).
   - `bb plugin logs <id> [-n N] [-f]` — the plugin's `bb.log` output.
-  - `bb plugin run <id> [args...]` — explicit form, including commands shadowed by core.
+  - `bb plugin run <id> [args...]` — explicit form; collisions log an activation
+    warning and are annotated by `bb plugin list`.
   - `bb plugin new <name>` — scaffold a todo-list plugin (`server.ts`,
     `app.tsx` with a sidebar page, a `bb <name>` CLI command, a skill, and
     vendored UI components) and install its npm dependencies (scaffold sets

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
@@ -894,7 +894,7 @@ them by mixing ink into canvas), the `--primary` accent, the secondary text tier
   - `bb plugin config <id> [set <key> <value> | unset <key>]` — declared
     settings. Reload the plugin after configuring (`bb plugin reload <id>`).
   - `bb plugin logs <id> [-n N] [-f]` — the plugin's `bb.log` output.
-  - `bb plugin run <id> [args...]` — explicit form of a plugin's CLI command.
+  - `bb plugin run <id> [args...]` — explicit form, including commands shadowed by core.
   - `bb plugin new <name>` — scaffold a todo-list plugin (`server.ts`,
     `app.tsx` with a sidebar page, a `bb <name>` CLI command, a skill, and
     vendored UI components) and install its npm dependencies (scaffold sets

--- a/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/SKILL.md
@@ -952,7 +952,7 @@ proxies it to the server, where `run` executes.
 
 ```ts
 bb.cli.register({
-  name: "weather", // lowercase [a-z0-9-]+; core names (thread, plugin, …) are reserved
+  name: "weather", // lowercase [a-z0-9-]+; core collisions use bb plugin run <id>
   summary: "Weather lookups",
   commands: [
     // help/skill metadata only; parsing argv is yours

--- a/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/SKILL.md
@@ -948,7 +948,8 @@ if (!initial.apiKey)
 One top-level command per plugin; a second `register` in one factory
 execution is rejected.
 Users and agents run `bb <name> …` like any core command; the bb CLI
-proxies it to the server, where `run` executes.
+proxies it to the server, where `run` executes. Core collisions log an
+activation warning and appear in `bb plugin list` as `bb plugin run <id>`.
 
 ```ts
 bb.cli.register({

--- a/apps/server/test/services/plugins/plugin-cli.test.ts
+++ b/apps/server/test/services/plugins/plugin-cli.test.ts
@@ -269,21 +269,29 @@ describe("plugin CLI commands (bb.cli.register + endpoints + skill + logs)", () 
     expect(unknown.stderr).toContain('unknown plugin "nope"');
   });
 
-  it("rejects reserved and invalid CLI command names at load", async () => {
+  it("keeps a core-name collision callable by plugin id", async () => {
     const reserved = await writePlugin(
       join(harness.config.dataDir, "fixtures"),
       {
         name: "bb-plugin-shadower",
         serverSource: `
           export default function plugin(bb: any) {
-            bb.cli.register({ name: "thread", summary: "s", run: async () => ({ exitCode: 0 }) });
+            bb.cli.register({ name: "thread", summary: "s", commands: [{ name: "inspect", summary: "Inspect", usage: "bb thread inspect" }], run: async () => ({ exitCode: 0, stdout: "thread" }) });
           }
         `,
       },
     );
     const entry = await harness.pluginService.installPath(reserved);
-    expect(entry.status).toBe("error");
-    expect(entry.statusDetail).toContain("reserved");
+    expect(entry.status).toBe("running");
+    expect(
+      await (await runCli(harness, "shadower", { argv: [] })).json(),
+    ).toMatchObject({ exitCode: 0, stdout: "thread" });
+    expect(
+      await readFile(
+        join(pluginCommandsSkillDir(harness.config.dataDir), "SKILL.md"),
+        "utf8",
+      ),
+    ).toContain("bb plugin run shadower inspect");
 
     const invalid = await writePlugin(
       join(harness.config.dataDir, "fixtures"),

--- a/apps/server/test/services/plugins/plugin-cli.test.ts
+++ b/apps/server/test/services/plugins/plugin-cli.test.ts
@@ -286,12 +286,11 @@ describe("plugin CLI commands (bb.cli.register + endpoints + skill + logs)", () 
     expect(
       await (await runCli(harness, "shadower", { argv: [] })).json(),
     ).toMatchObject({ exitCode: 0, stdout: "thread" });
-    expect(
-      await readFile(
-        join(pluginCommandsSkillDir(harness.config.dataDir), "SKILL.md"),
-        "utf8",
-      ),
-    ).toContain("bb plugin run shadower inspect");
+    const skill = await readFile(
+      join(pluginCommandsSkillDir(harness.config.dataDir), "SKILL.md"),
+      "utf8",
+    );
+    expect(skill).toContain("bb plugin run shadower inspect");
 
     const invalid = await writePlugin(
       join(harness.config.dataDir, "fixtures"),

--- a/apps/server/test/services/plugins/plugin-cli.test.ts
+++ b/apps/server/test/services/plugins/plugin-cli.test.ts
@@ -283,6 +283,17 @@ describe("plugin CLI commands (bb.cli.register + endpoints + skill + logs)", () 
     );
     const entry = await harness.pluginService.installPath(reserved);
     expect(entry.status).toBe("running");
+    const warnings = (await harness.pluginService.readLogTail("shadower", 10))
+      ?.map((line) => JSON.parse(line) as { level: string; message: string })
+      .filter((line) => line.level === "warn")
+      .map(({ level, message }) => ({ level, message }));
+    expect(warnings).toEqual([
+      {
+        level: "warn",
+        message:
+          'CLI command "thread" collides with core command "bb thread"; core keeps the short form. Use "bb plugin run shadower" to invoke this plugin.',
+      },
+    ]);
     expect(
       await (await runCli(harness, "shadower", { argv: [] })).json(),
     ).toMatchObject({ exitCode: 0, stdout: "thread" });

--- a/packages/domain/src/plugin-cli.ts
+++ b/packages/domain/src/plugin-cli.ts
@@ -1,7 +1,7 @@
 /**
  * Core `bb` CLI top-level command names (plus commander's built-in help).
- * Plugin CLI commands may not shadow these. Maintained by hand and checked
- * against the real Commander program by
+ * Core commands win these names; plugin scaffolding rejects them. Maintained
+ * by hand and checked against the real Commander program by
  * apps/cli/src/__tests__/plugin-cli-proxy.test.ts.
  *
  * "automation" and "connect" are intentionally absent: builtin plugins own
@@ -21,7 +21,8 @@ export const RESERVED_BB_CLI_COMMANDS: readonly string[] = [
   "thread",
 ];
 
-export const pluginCliInvocation = (pluginId: string, name: string): string =>
-  RESERVED_BB_CLI_COMMANDS.includes(name)
-    ? `bb plugin run ${pluginId}`
-    : `bb ${name}`;
+export function pluginCliCall(pluginId: string, name: string): string {
+  if (RESERVED_BB_CLI_COMMANDS.includes(name))
+    return `bb plugin run ${pluginId}`;
+  return `bb ${name}`;
+}

--- a/packages/domain/src/plugin-cli.ts
+++ b/packages/domain/src/plugin-cli.ts
@@ -20,3 +20,8 @@ export const RESERVED_BB_CLI_COMMANDS: readonly string[] = [
   "theme",
   "thread",
 ];
+
+export const pluginCliInvocation = (pluginId: string, name: string): string =>
+  RESERVED_BB_CLI_COMMANDS.includes(name)
+    ? `bb plugin run ${pluginId}`
+    : `bb ${name}`;

--- a/packages/domain/src/plugin-sdk-version.ts
+++ b/packages/domain/src/plugin-sdk-version.ts
@@ -16,7 +16,7 @@
 // PLUGIN_SDK_MAJOR is 0, so the major-only artifact gate cannot distinguish
 // 0.x releases and is intentionally vacuous for them until a future 1.0.
 // Rebuildable artifacts still rebuild on the exact sdkVersion-differs trigger.
-export const PLUGIN_SDK_VERSION = "0.4.17";
+export const PLUGIN_SDK_VERSION = "0.4.18";
 
 /** Major of {@link PLUGIN_SDK_VERSION} — the plugin API compatibility number. */
 export const PLUGIN_SDK_MAJOR = Number(PLUGIN_SDK_VERSION.split(".", 1)[0]);

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@get-bb/plugin-sdk",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "homepage": "https://github.com/get-bb/bb#readme",
   "bugs": {
     "url": "https://github.com/get-bb/bb/issues"

--- a/packages/plugin-sdk/src/backend-contract.ts
+++ b/packages/plugin-sdk/src/backend-contract.ts
@@ -330,7 +330,8 @@ export interface PluginCliExecutionResult {
 
 export interface PluginCliRegistration {
   /** Preferred top-level command name (`bb <name> …`): lowercase [a-z0-9-]+.
-   * A core collision remains available through `bb plugin run <plugin-id>`. */
+   * A core collision logs an activation warning and remains available through
+   * `bb plugin run <plugin-id>`. */
   name: string;
   summary: string;
   /** Subcommand metadata rendered in help and the plugin-commands skill
@@ -346,7 +347,7 @@ export interface PluginCli {
   /**
    * Register this plugin's `bb` subcommand. One registration per factory
    * execution; a repeated call is rejected. Core bb commands always win
-   * name collisions; the plugin remains explicitly callable by id.
+   * name collisions; the plugin is warned and remains explicitly callable by id.
    */
   register(registration: PluginCliRegistration): void;
 }

--- a/packages/plugin-sdk/src/backend-contract.ts
+++ b/packages/plugin-sdk/src/backend-contract.ts
@@ -329,8 +329,8 @@ export interface PluginCliExecutionResult {
 }
 
 export interface PluginCliRegistration {
-  /** Top-level command name (`bb <name> …`): lowercase [a-z0-9-]+, and not
-   * a core bb command (see RESERVED_BB_CLI_COMMANDS in the server). */
+  /** Preferred top-level command name (`bb <name> …`): lowercase [a-z0-9-]+.
+   * A core collision remains available through `bb plugin run <plugin-id>`. */
   name: string;
   summary: string;
   /** Subcommand metadata rendered in help and the plugin-commands skill
@@ -346,7 +346,7 @@ export interface PluginCli {
   /**
    * Register this plugin's `bb` subcommand. One registration per factory
    * execution; a repeated call is rejected. Core bb commands always win
-   * name collisions; reserved names are rejected at registration.
+   * name collisions; the plugin remains explicitly callable by id.
    */
   register(registration: PluginCliRegistration): void;
 }

--- a/packages/plugin-sdk/src/internal/host-policy.ts
+++ b/packages/plugin-sdk/src/internal/host-policy.ts
@@ -49,6 +49,14 @@ import type {
 
 export { RESERVED_BB_CLI_COMMANDS };
 
+export function pluginCliCollisionWarning(
+  pluginId: string,
+  commandName: string,
+): string | null {
+  if (!RESERVED_BB_CLI_COMMANDS.includes(commandName)) return null;
+  return `CLI command "${commandName}" collides with core command "bb ${commandName}"; core keeps the short form. Use "bb plugin run ${pluginId}" to invoke this plugin.`;
+}
+
 /**
  * Built-in dynamic tool names plugins may not shadow. Maintained by hand —
  * kept in sync with the built-in tools in

--- a/packages/plugin-sdk/src/testing/__tests__/fake-plugin-host.test.ts
+++ b/packages/plugin-sdk/src/testing/__tests__/fake-plugin-host.test.ts
@@ -540,6 +540,12 @@ describe("cli", () => {
           run: () => ({ exitCode: 0 }),
         }),
       ).not.toThrow();
+      expect(reservedHost.harness.logEntries).toEqual([
+        {
+          level: "warn",
+          message: `CLI command "${name}" collides with core command "bb ${name}"; core keeps the short form. Use "bb plugin run test-plugin" to invoke this plugin.`,
+        },
+      ]);
     }
 
     const availableHost = createFakePluginHost();
@@ -550,6 +556,7 @@ describe("cli", () => {
         run: () => ({ exitCode: 0 }),
       }),
     ).not.toThrow();
+    expect(availableHost.harness.logEntries).toEqual([]);
   });
 
   it("rejects a duplicate registration like the production host", () => {

--- a/packages/plugin-sdk/src/testing/__tests__/fake-plugin-host.test.ts
+++ b/packages/plugin-sdk/src/testing/__tests__/fake-plugin-host.test.ts
@@ -10,6 +10,7 @@ import { defineRpcContract } from "../../rpc-contract.js";
 import {
   parsePluginAgentToolPresentation,
   PLUGIN_AGENT_STATUS_LABEL_MAX_CHARS,
+  RESERVED_BB_CLI_COMMANDS,
 } from "../../internal/host-policy.js";
 import { createFakePluginHost, makeThreadResponse } from "../index.js";
 
@@ -530,14 +531,16 @@ describe("cli", () => {
   });
 
   it("uses the production host's reserved CLI names", () => {
-    const reservedHost = createFakePluginHost();
-    expect(() =>
-      reservedHost.bb.cli.register({
-        name: "skill",
-        summary: "nope",
-        run: () => ({ exitCode: 0 }),
-      }),
-    ).toThrow('cli command name "skill" is reserved by the bb CLI');
+    for (const name of RESERVED_BB_CLI_COMMANDS) {
+      const reservedHost = createFakePluginHost();
+      expect(() =>
+        reservedHost.bb.cli.register({
+          name,
+          summary: "nope",
+          run: () => ({ exitCode: 0 }),
+        }),
+      ).not.toThrow();
+    }
 
     const availableHost = createFakePluginHost();
     expect(() =>

--- a/packages/plugin-sdk/src/testing/fake-plugin-host.ts
+++ b/packages/plugin-sdk/src/testing/fake-plugin-host.ts
@@ -22,6 +22,7 @@ import {
   MENTION_PROVIDER_ID_PATTERN,
   normalizeMentionProviderTriggers,
   parsePluginAgentToolPresentation,
+  pluginCliCollisionWarning,
   PLUGIN_AGENT_DYNAMIC_INSTRUCTIONS_MAX_CHARS,
   PLUGIN_AGENT_SELECTION_MAX_IDS,
   PLUGIN_AGENT_STATIC_INSTRUCTIONS_MAX_CHARS,
@@ -1225,6 +1226,8 @@ function createFakePluginHostInternal(
         commands: validatedCommands,
         run: registration.run.bind(registration),
       };
+      const warning = pluginCliCollisionWarning(pluginId, name);
+      if (warning) emitLog("warn", warning);
     },
   };
 

--- a/packages/plugin-sdk/src/testing/fake-plugin-host.ts
+++ b/packages/plugin-sdk/src/testing/fake-plugin-host.ts
@@ -34,7 +34,6 @@ import {
   registerSettingDescriptors,
   rejectStaleAgentToolFields,
   RESERVED_AGENT_TOOL_NAMES,
-  RESERVED_BB_CLI_COMMANDS,
   RPC_METHOD_PATTERN,
   summarizeParseIssues,
   undeclaredIconProblem,
@@ -1186,11 +1185,6 @@ function createFakePluginHostInternal(
       if (typeof name !== "string" || !CLI_COMMAND_NAME_PATTERN.test(name)) {
         throw new Error(
           `invalid cli command name ${JSON.stringify(name)} — use lowercase letters, digits, and "-"`,
-        );
-      }
-      if (RESERVED_BB_CLI_COMMANDS.includes(name)) {
-        throw new Error(
-          `cli command name "${name}" is reserved by the bb CLI — pick another name`,
         );
       }
       if (

--- a/packages/templates/src/templates/bb-guide-plugins.md
+++ b/packages/templates/src/templates/bb-guide-plugins.md
@@ -225,7 +225,7 @@ added/updated/unchanged counts.
   bb plugin config <id> [set <key> <value> | unset <key>]
                                  Show or change a plugin's declared settings
   bb plugin logs <id> [-n N] [-f]  Print (or follow) a plugin's bb.log output
-  bb plugin run <id> [args...]   Run the plugin's CLI command explicitly
+  bb plugin run <id> [args...]   Run a plugin command explicitly (also works when core owns its name)
   bb plugin token <id> [--rotate]  Print the token for auth:"token" HTTP
                                  routes; --rotate generates a new token,
                                  invalidating the old one

--- a/packages/templates/src/templates/bb-guide-plugins.md
+++ b/packages/templates/src/templates/bb-guide-plugins.md
@@ -610,8 +610,9 @@ touching the rest of the app. Installed plugins and their declared settings
 Plugin CLI commands: a plugin can register one top-level subcommand (for
 example `bb github …`). Unknown `bb` commands are looked up against installed
 plugins and proxied to the server, so plugin commands work exactly like core
-commands; core command names always win. Inside agent threads the generated
-`plugin-commands` skill lists the available plugin commands.
+commands; core command names always win. A collision logs an activation warning,
+and `bb plugin list` shows the required `bb plugin run <id>` form. Inside agent
+threads the generated `plugin-commands` skill lists the available plugin commands.
 
 Settings changes do not auto-reload a plugin — run `bb plugin reload <id>`
 after configuring. Add --json to plugin commands for machine-readable output.


### PR DESCRIPTION
## What was wrong

The plugin scaffold admitted ids such as `thread` even though its generated backend registers that id as a top-level CLI command and BB permanently reserves the short form for core commands. Runtime registration also rejected those names, which meant the scaffold produced a plugin that could not load and a future core reservation could brick an already-installed third-party plugin.

## What changed

`bb plugin new` now rejects every id in the shared `RESERVED_BB_CLI_COMMANDS` policy, including bare, `bb-plugin-`-prefixed, and scoped package forms. Runtime plugin registration permits collisions so existing or manually authored plugins remain loaded: core commands still own `bb <name>`, while the plugin stays explicitly callable through `bb plugin run <id>`. CLI listing, the app capability view, generated agent command guidance, SDK contract comments, and the plugin guide now show that explicit fallback for reserved collisions. Duplicate plugin-contributed names retain their existing first-sorted short-form arbitration and explicit-by-id access.

On each successful activation, a colliding plugin now logs one warning that names the shadowed core command and the explicit invocation. `bb plugin list` annotates only the affected plugin row with the core-precedence reason; ordinary plugin commands keep their existing `bb <name>` display without a warning or annotation.

The corrected SDK JSDoc is part of the published declaration surface, so `@get-bb/plugin-sdk` advances from `0.4.17` to `0.4.18` in lockstep with `PLUGIN_SDK_VERSION`.

This changes no server/daemon wire contract, database schema, public plugin API member, or `HOST_DAEMON_PROTOCOL_VERSION`.

## How you verified

Before the fix, the scaffold regression failed all 11 shared reserved-name cases, the real plugin service reported a colliding plugin as `error`, and fake-host registration threw for all 11 names. Before the warning follow-up, production and fake-host warning assertions received `[]`, and the CLI output lacked the collision annotation. After the fix:

- Server plugin CLI tests: 12/12.
- SDK fake-host tests: 54/54.
- CLI scaffold, proxy, list-output, and guide-doc tests: 68/68.
- App plugin-detail tests: 28/28.
- Focused total: 162/162.
- SDK package/version consistency test: 1/1.
- Turbo typecheck passed all 10 tasks for `@bb/domain`, `@bb/templates`, `@get-bb/plugin-sdk`, `@bb/server`, `@bb/cli`, and `@bb/app`.
- Turbo build passed all 8 tasks for the same packages; only existing chunk-size/plugin-timing warnings appeared.
- Plugin SDK surface-version and unpublished-npm-version guards passed for `0.4.18`.
- `git diff --check origin/main..HEAD` passed after rebasing onto current `origin/main` at `90db2ae69`.

Related: #2371

> AGENT GENERATED
