### PR TITLE
Fix rejected steer details ownership

### DIFF
--- a/apps/server/test/services/threads/timeline-in-turn-window.test.ts
+++ b/apps/server/test/services/threads/timeline-in-turn-window.test.ts
@@ -519,12 +519,41 @@ function walkAllPages(
 }
 
 describe("in-turn timeline windows", () => {
-  it("keeps an accepted steer out of details for work that spans the steer", () => {
+  const expectSteerDetailsOwnership = (
+    steerStatus: "accepted" | "rejected",
+  ): void => {
     const { db, thread } = setup();
     const initialRequestId = requestId(1);
     const steerRequestId = requestId(2);
     const turnId = "turn-1";
     const commandId = "command-1";
+    const steerTerminalEvent: EventInput =
+      steerStatus === "accepted"
+        ? {
+            threadId: thread.id,
+            sequence: 6,
+            type: "turn/input/accepted",
+            scope: turnScope(turnId),
+            providerThreadId,
+            itemId: null,
+            itemKind: null,
+            parentToolCallId: null,
+            data: JSON.stringify({ clientRequestId: steerRequestId }),
+          }
+        : {
+            threadId: thread.id,
+            sequence: 6,
+            type: "client/turn/rejected",
+            scope: threadScope(),
+            itemId: null,
+            itemKind: null,
+            parentToolCallId: null,
+            data: JSON.stringify({
+              requestId: steerRequestId,
+              reason: "command_failed",
+              message: "The steer was rejected",
+            }),
+          };
 
     insertEvents(db, noopNotifier, [
       {
@@ -615,17 +644,7 @@ describe("in-turn timeline windows", () => {
           execution,
         }),
       },
-      {
-        threadId: thread.id,
-        sequence: 6,
-        type: "turn/input/accepted",
-        scope: turnScope(turnId),
-        providerThreadId,
-        itemId: null,
-        itemKind: null,
-        parentToolCallId: null,
-        data: JSON.stringify({ clientRequestId: steerRequestId }),
-      },
+      steerTerminalEvent,
       {
         threadId: thread.id,
         sequence: 7,
@@ -670,14 +689,16 @@ describe("in-turn timeline windows", () => {
     if (!turnRow) {
       throw new Error("expected a turn row");
     }
-    expect(
-      timeline.rows.filter(
-        (row) =>
-          row.kind === "conversation" &&
-          row.role === "user" &&
-          row.turnRequest?.kind === "steer",
-      ),
-    ).toHaveLength(1);
+    const rootSteers = timeline.rows.filter(
+      (row) =>
+        row.kind === "conversation" &&
+        row.role === "user" &&
+        row.turnRequest?.kind === "steer",
+    );
+    expect(rootSteers).toHaveLength(1);
+    expect(rootSteers[0]).toMatchObject({
+      turnRequest: { kind: "steer", status: steerStatus },
+    });
 
     const details = buildTimelineTurnSummaryDetails(db, thread, {
       includeProviderUnhandledOperations: false,
@@ -698,6 +719,14 @@ describe("in-turn timeline windows", () => {
         (row) => row.kind === "work" && row.workKind === "command",
       ),
     ).toHaveLength(1);
+  };
+
+  it("keeps an accepted steer out of details for work that spans it", () => {
+    expectSteerDetailsOwnership("accepted");
+  });
+
+  it("keeps a rejected steer out of details for work that spans it", () => {
+    expectSteerDetailsOwnership("rejected");
   });
 
   it("bounds a running turn that is larger than the whole budget", () => {

--- a/packages/thread-view/src/build-thread-timeline.ts
+++ b/packages/thread-view/src/build-thread-timeline.ts
@@ -1281,13 +1281,12 @@ function hasTurnSummaryRows(rows: TimelineRow[]): boolean {
   return rows.some((row) => row.kind === "turn");
 }
 
-function isAcceptedHumanSteerRow(row: TimelineRow): boolean {
+function isRootOwnedHumanSteerRow(row: TimelineRow): boolean {
   return (
     row.kind === "conversation" &&
     row.role === "user" &&
     row.initiator === "user" &&
-    row.turnRequest?.kind === "steer" &&
-    row.turnRequest.status === "accepted"
+    row.turnRequest?.kind === "steer"
   );
 }
 
@@ -1489,9 +1488,10 @@ export function buildThreadTimelineTurnDetailsFromEvents(
     // A work item can begin before a steer and complete after it, so the
     // summary's source range necessarily overlaps the steer. Lazy details do
     // not include the later turn/completed event and therefore project that
-    // slice as ungrouped rows. Accepted human steers belong to the root
-    // timeline, just as they do when children are built eagerly; returning one
-    // here would render the same row both inside and outside the summary.
-    rows: nestedRows.filter((row) => !isAcceptedHumanSteerRow(row)),
+    // slice as ungrouped rows. External human steers belong to the root
+    // timeline regardless of outcome, just as they do when children are built
+    // eagerly; returning one here would render the same row both inside and
+    // outside the summary.
+    rows: nestedRows.filter((row) => !isRootOwnedHumanSteerRow(row)),
   };
 }


### PR DESCRIPTION
## What was wrong

The lazy expanded-details projection filtered only accepted human steers. Rejected human steers are also root-owned, so a rejected steer spanning a completed work item appeared once in the root timeline and again inside the expanded summary.

## What changed

Renamed the shared predicate around the ownership invariant and removed its accepted-status restriction while retaining the human-initiator and steer-kind checks. The persisted-event regression now covers accepted and rejected outcomes and proves each appears once at the root and never in expanded details. No server/daemon wire contract changed; `HOST_DAEMON_PROTOCOL_VERSION` remains 166.

## How you verified

- Red: `pnpm exec turbo run test --filter=@bb/server --force -- --run test/services/threads/timeline-in-turn-window.test.ts` failed only the new rejected case (25 passed, 1 failed) because details contained the rejected steer.
- Green: the same focused command passed 26/26 tests.
- `pnpm exec turbo run test --filter=@bb/thread-view --force` passed 368/368 tests.
- `pnpm exec turbo run typecheck --filter=@bb/thread-view --filter=@bb/server` passed all 5 Turbo tasks.
- Changed-file formatting and `git diff --check` passed.

Fixes #2378

> AGENT GENERATED