### PR TITLE
Preserve bb-app chunk cleanup on cached builds

### DIFF
--- a/.github/workflows/publish-bb-app.yml
+++ b/.github/workflows/publish-bb-app.yml
@@ -301,8 +301,8 @@ jobs:
           echo "version=${nightly_version}" >> "$GITHUB_OUTPUT"
           echo "Prepared bb-app and desktop version ${nightly_version}."
 
-      # bb-app's prepack hook only prunes stale bb CLI chunks; its `files`
-      # list ships built output, so `npm publish` packs whatever is on disk.
+      # bb-app's prepack hook prunes stale bb CLI chunks immediately before
+      # `npm publish` packs the built output selected by its `files` list.
       # This job runs on a fresh runner, so it must build before it packs.
       # smoke:tarball depends on build and also proves the packed tarball
       # runs at the nightly version.

--- a/packages/bb-app/package.json
+++ b/packages/bb-app/package.json
@@ -62,6 +62,7 @@
   "scripts": {
     "build": "node scripts/build.mjs",
     "clean": "rimraf dist app host-daemon server tsconfig.tsbuildinfo",
+    "prepack": "node dist/prune-bb-chunks.mjs",
     "smoke:tarball": "node scripts/smoke-tarball.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --config vitest.config.ts"

--- a/packages/bb-app/scripts/build.mjs
+++ b/packages/bb-app/scripts/build.mjs
@@ -60,6 +60,12 @@ await buildNodeEsmEntry({
   packageRoot,
 });
 await buildPublicSdkDeclarations();
+await buildNodeEsmEntry({
+  cleanDist: false,
+  entryPoint: resolve(scriptsDir, "prune-bb-chunks.mjs"),
+  outfile: resolve(packageRoot, "dist", "prune-bb-chunks.mjs"),
+  packageRoot,
+});
 
 await copyBuildOutput({
   from: resolve(workspaceRoot, "apps", "app", "dist"),
@@ -107,7 +113,7 @@ await assertPathExists(
 );
 const pruneRun = await execFileAsync(
   "node",
-  [resolve(scriptsDir, "prune-bb-chunks.mjs")],
+  [resolve(packageRoot, "dist", "prune-bb-chunks.mjs")],
   { cwd: packageRoot },
 );
 process.stderr.write(pruneRun.stderr);

--- a/packages/bb-app/scripts/prune-bb-chunks.mjs
+++ b/packages/bb-app/scripts/prune-bb-chunks.mjs
@@ -5,10 +5,10 @@ import { pruneUnreferencedChunks } from "../../../scripts/build-utils.mjs";
 /**
  * Delete the bb CLI chunks that host-daemon/dist/bb does not reach.
  *
- * Runs from scripts/build.mjs after copying apps/host-daemon/dist.
+ * Bundled into dist/prune-bb-chunks.mjs: the build runs that copy after
+ * assembling the package, and npm prepack runs it again at the pack boundary.
  *
- * The package root is the working directory, as for every package script:
- * npm runs lifecycle hooks, and turbo the build, from the package directory.
+ * The package root is the working directory, as for every package script.
  */
 const packageRoot = process.cwd();
 const distDir = resolve(packageRoot, "host-daemon", "dist");

--- a/packages/bb-app/scripts/smoke-tarball.mjs
+++ b/packages/bb-app/scripts/smoke-tarball.mjs
@@ -1,6 +1,13 @@
 import { fork, spawn } from "node:child_process";
 import { mkdirSync, readdirSync } from "node:fs";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import {
+  copyFile,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -268,25 +275,44 @@ function createNpxArgs(tarballPath, bin, args) {
 }
 
 async function packTarball() {
-  const stdout = await runCommand({
-    args: ["pack", packageRoot, "--pack-destination", tempRoot, "--json"],
-    command: "npm",
-    label: "npm pack",
-  });
-  const packed = JSON.parse(stdout);
-  if (!Array.isArray(packed) || packed.length !== 1) {
-    throw new Error(`Unexpected npm pack output: ${stdout}`);
+  const chunkDir = join(packageRoot, "host-daemon", "dist", "bb-chunks");
+  const liveChunk = readdirSync(chunkDir).find((name) => name.endsWith(".js"));
+  if (liveChunk === undefined) {
+    throw new Error("Built bb-app has no CLI chunk to exercise");
   }
-  const [entry] = packed;
-  if (
-    typeof entry !== "object" ||
-    entry === null ||
-    !("filename" in entry) ||
-    typeof entry.filename !== "string"
-  ) {
-    throw new Error(`Unexpected npm pack entry: ${stdout}`);
+  // Model a Turbo cache restore over existing output: a dead hashed chunk can
+  // remain beside the current generation immediately before source npm pack.
+  const staleChunkName = "chunk-SLOP-CACHE-STALE.js";
+  const staleChunk = join(chunkDir, staleChunkName);
+  await copyFile(join(chunkDir, liveChunk), staleChunk);
+  try {
+    const stdout = await runCommand({
+      args: ["pack", packageRoot, "--pack-destination", tempRoot, "--json"],
+      command: "npm",
+      label: "npm pack",
+    });
+    const packed = JSON.parse(stdout);
+    if (!Array.isArray(packed) || packed.length !== 1) {
+      throw new Error(`Unexpected npm pack output: ${stdout}`);
+    }
+    const [entry] = packed;
+    if (
+      typeof entry !== "object" ||
+      entry === null ||
+      !("filename" in entry) ||
+      typeof entry.filename !== "string" ||
+      !Array.isArray(entry.files)
+    ) {
+      throw new Error(`Unexpected npm pack entry: ${stdout}`);
+    }
+    const staleChunkPath = `host-daemon/dist/bb-chunks/${staleChunkName}`;
+    if (entry.files.some((file) => file.path === staleChunkPath)) {
+      throw new Error(`npm pack included stale CLI chunk ${staleChunkPath}`);
+    }
+    return join(tempRoot, entry.filename);
+  } finally {
+    await rm(staleChunk, { force: true });
   }
-  return join(tempRoot, entry.filename);
 }
 
 function waitForJsonRpcResponse({ childProcess, id, label, output }) {


### PR DESCRIPTION
## What was wrong

Removing bb-app's source-only `prepack` cleanup in #2373 made an installed package self-repackable, but also removed the cleanup that ran immediately before source packaging. When Turbo restores bb-app output from cache, unreachable CLI chunks from an older generation can remain on disk and enter the next tarball as dead package weight.

## What changed

The bb-app build now bundles the existing chunk-pruning implementation into a self-contained script that ships in `dist`, and the restored `prepack` command runs that script before npm creates an archive. This preserves both source cleanup after a cache hit and ordinary `npm pack` from an installed copy. The tarball smoke now injects a stale chunk immediately before real packaging and rejects an archive that contains it; the publish workflow comment now describes the restored behavior.

No host-daemon wire contract, CLI/config surface, SDK API, database, migration, or generated committed file changed. `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

## How you verified

- Red: with 11/11 Turbo tasks cached, an injected stale CLI chunk survived and appeared in `npm pack --dry-run --json`.
- Green: with the same 11/11 cached build, normal npm packaging ran the bundled cleanup, removed one stale chunk, and excluded it from the archive.
- Extracted the real tarball and repacked the installed-package shape with ordinary `npm pack`; it succeeded and ran the included cleanup.
- `pnpm exec turbo run build --filter=bb-app --output-logs=new-only`
- `pnpm exec turbo run test --filter=bb-app -- test/index.test.ts` — 67 tests passed.
- `pnpm exec turbo run test --filter=@bb/server -- test/app/bb-app-artifact.test.ts` — 12 tests passed.
- `pnpm exec turbo run typecheck --filter=bb-app --filter=@bb/server --output-logs=new-only`
- `pnpm exec turbo run smoke:tarball --filter=bb-app --force --output-logs=new-only` — 12/12 tasks passed.
- `git diff --check`

Fixes: no issue filed; follow-up to #2373.

> AGENT GENERATED