### PR TITLE
Grant the macOS desktop Apple Events entitlement

### DIFF
--- a/apps/desktop/build/entitlements.mac.plist
+++ b/apps/desktop/build/entitlements.mac.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
+    <key>com.apple.security.automation.apple-events</key>
+    <true/>
     <key>com.apple.security.cs.allow-jit</key>
     <true/>
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>

--- a/apps/desktop/test/electron-builder-config.test.ts
+++ b/apps/desktop/test/electron-builder-config.test.ts
@@ -150,6 +150,8 @@ const signingEnvironmentKeys = [
   "CSC_LINK",
   "CSC_NAME",
 ];
+const appleEventsEntitlementPattern =
+  /<key>com\.apple\.security\.automation\.apple-events<\/key>\s*<true\s*\/>/u;
 const audioInputEntitlementPattern =
   /<key>com\.apple\.security\.device\.audio-input<\/key>\s*<true\s*\/>/u;
 
@@ -519,6 +521,20 @@ describe("electron-builder signing config", () => {
     await expect(
       access(resolve(desktopPackageRoot, config.linux.icon)),
     ).resolves.toBeUndefined();
+  });
+
+  it("allows the signed app to request Apple Events access", async () => {
+    const configText = await readFile(
+      resolve(desktopPackageRoot, "electron-builder.config.json"),
+      "utf8",
+    );
+    const config = electronBuilderConfigSchema.parse(JSON.parse(configText));
+    const entitlements = await readFile(
+      resolve(desktopPackageRoot, config.mac.entitlements),
+      "utf8",
+    );
+
+    expect(entitlements).toMatch(appleEventsEntitlementPattern);
   });
 
   it("grants audio input to the signed app and helper processes", async () => {


### PR DESCRIPTION
## What was wrong

The hardened macOS app lacked `com.apple.security.automation.apple-events`, so macOS TCC rejected Apple Events from agent-launched child processes before it could present the normal Automation consent prompt. This blocks tools such as `codex-computer-use-mcp`, whose signed helper is attributed to the responsible `dev.bb.desktop` process.

## What changed

- Added the Apple Events entitlement to the main desktop app's `entitlements.mac.plist`.
- Kept it out of `entitlements.mac.inherit.plist` so Electron helpers do not receive the capability unnecessarily.
- Added a packaging regression test that reads the configured main-app entitlement file and requires the entitlement.
- No wire, CLI, guide, or protocol changes.

## How you verified

The new regression test fails against the pre-fix entitlement file:

```text
FAIL electron-builder signing config > allows the signed app to request Apple Events access
AssertionError: expected ... to match /com\.apple\.security\.automation\.apple-events/
```

It passes with this change as part of:

```text
pnpm exec turbo run test --filter=@bb/desktop --force
# 35 files passed; 232 tests passed

pnpm exec turbo run typecheck --filter=@bb/desktop
# 3 tasks successful

pnpm exec oxfmt apps/desktop/build/entitlements.mac.plist apps/desktop/test/electron-builder-config.test.ts --check
# formatting passed
```

Fixes #2368

> AGENT GENERATED
