### PR TITLE
fix(desktop): load the packaged shell PATH deterministically

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -292,6 +292,48 @@ BB_DESKTOP_OPEN_DEVTOOLS=1 apps/desktop/release/mac-arm64/bb.app/Contents/MacOS/
 When the desktop app spawns `bb-app`, server and daemon logs land under
 `~/.bb/logs/` or `$BB_DATA_DIR/logs/` when `BB_DATA_DIR` is set.
 
+### PATH in packaged launches
+
+A packaged app started from the Dock, Finder, or a Linux desktop session
+inherits the launcher's bare PATH (`/usr/bin:/bin:/usr/sbin:/sbin` under
+launchd), not the user's shell PATH. Before it spawns `bb-app`, the desktop
+main process repairs `process.env.PATH` in `src/desktop-shell-path.ts`, and
+every child (bb-app, server, host daemon, in-process server plugins) inherits
+the result:
+
+1. `$SHELL -ilc '<print PATH between marker lines>'` with a 5 s budget, where
+   `$SHELL` is the login shell the launcher passed, taken verbatim (fallback
+   `/bin/zsh` on macOS, `/bin/bash` on Linux). The interactive login shell is
+   what sources `~/.zshrc`, where Homebrew, nvm, and Volta usually extend PATH.
+2. `$SHELL -lc ...` with a 3 s budget when the interactive stage fails or
+   times out. That shell skips the rc file, so the tool directories from step
+   4 that exist on disk are appended to its PATH as well.
+3. If `$SHELL` itself cannot be started (`ENOENT` or `EACCES`: an uninstalled
+   login shell, or an account record pointing at a stale path) and it is not
+   the platform default, steps 1 and 2 run once more with the platform default
+   shell. The warning names the retry.
+4. If every stage fails, well-known tool directories that exist on disk
+   (`~/.volta/bin`, nvm's default Node `bin` unless the default alias is
+   `system`, fnm's default alias, the mise, asdf, nodenv, and proto shims,
+   `~/.n/bin`, pnpm's home, `~/.bun/bin`, `~/.deno/bin`, `~/.cargo/bin`,
+   `~/go/bin`, `~/.local/bin`, `~/bin`, Homebrew, `/usr/local/bin`, and on
+   Linux `/snap/bin`) are appended to the inherited PATH. Nothing is executed
+   to discover them, and because they are appended, they never shadow a tool
+   the shell or the launcher already put on PATH.
+
+The shell prints its PATH between marker lines, so banners and version-manager
+hooks that write to stdout during login are ignored, and a complete block counts
+even when the shell then hangs or exits non-zero. The probe settles when the
+shell exits rather than when its pipes close, so a login file that leaves a
+background job attached to stdout does not hold it for the whole budget. A
+probed PATH is merged with the inherited one rather than replacing it: probed
+entries come first, then any inherited entries the shell did not report. Every
+fallback writes a warning with the failing stage and its reason to the main
+process stderr and to `desktop.log` in the log directory, so a silent success
+never hides a broken probe. Startup is bounded by the stage budgets; a shell
+that hangs costs at most 8 s before the window opens (a missing `$SHELL` fails
+immediately, so the retry does not add to that).
+
 To verify attach-if-found manually, start a compatible bb first, then launch the
 desktop app:
 

--- a/apps/desktop/src/desktop-shell-path.ts
+++ b/apps/desktop/src/desktop-shell-path.ts
@@ -1,11 +1,46 @@
-import { spawnSync } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { delimiter, join } from "node:path";
 
-const MACOS_LOGIN_SHELL = "/bin/zsh";
-const SHELL_PATH_COMMAND = 'printf "%s" "$PATH"';
-const SHELL_PATH_TIMEOUT_MS = 2_000;
+const MACOS_DEFAULT_SHELL = "/bin/zsh";
+const LINUX_DEFAULT_SHELL = "/bin/bash";
+const SHELL_PATH_START_MARKER = "__BB_DESKTOP_SHELL_PATH_START__";
+const SHELL_PATH_END_MARKER = "__BB_DESKTOP_SHELL_PATH_END__";
+// The markers fence the PATH line so banners, `nvm use` hooks, and other
+// login output on stdout cannot be mistaken for it. The leading newline
+// detaches the start marker from output that ends without one.
+const SHELL_PATH_COMMAND = `printf '\\n%s\\nPATH=%s\\n%s\\n' '${SHELL_PATH_START_MARKER}' "$PATH" '${SHELL_PATH_END_MARKER}'`;
+// An interactive login shell sources ~/.zshrc (brew shellenv, nvm, volta),
+// which is where macOS users usually extend PATH, so it runs first. It also
+// pays for completion and prompt-framework startup, hence the larger budget.
+const INTERACTIVE_SHELL_PATH_TIMEOUT_MS = 5_000;
+// A non-interactive login shell sources only the profile files and is the
+// cheaper second stage when the interactive one hangs or times out.
+const LOGIN_SHELL_PATH_TIMEOUT_MS = 3_000;
+// A login file can leave a background job holding the shell's stdout open
+// after the shell itself has exited. Once the shell exits, its output is in
+// the pipe; this is how long to keep reading it before settling.
+const SHELL_EXIT_PIPE_GRACE_MS = 250;
+const NVM_ALIAS_MAX_HOPS = 8;
+const NVM_INSTALLED_VERSION_PATTERN = /^v\d+\.\d+\.\d+$/u;
+const NVM_VERSION_ALIAS_PATTERN = /^v?\d+(?:\.\d+){0,2}$/u;
+// nvm's built-in aliases have no alias file. `node` and `stable` mean the
+// newest installed version; `system` means the user opted out of nvm's node,
+// and `iojs`/`unstable` name io.js and odd-numbered releases that nvm keeps
+// outside versions/node, so none of these three adds a Node bin directory.
+const NVM_NEWEST_INSTALLED_ALIASES = new Set(["node", "stable"]);
+const NVM_UNMANAGED_ALIASES = new Set(["system", "iojs", "unstable"]);
 
 export interface DesktopShellPathLogger {
   warn(message: string): void;
+}
+
+export interface DesktopShellPathFs {
+  isDirectory(path: string): boolean;
+  /** Names inside `path`; empty when it is missing or unreadable. */
+  listDirectory(path: string): string[];
+  /** File contents; `null` when it is missing or unreadable. */
+  readTextFile(path: string): string | null;
 }
 
 export interface SpawnLoginShellPathArgs {
@@ -15,28 +50,67 @@ export interface SpawnLoginShellPathArgs {
 }
 
 export interface ShellPathSpawnResult {
+  /** Set when the shell could not be started or did not exit within budget. */
   error?: Error;
   signal: NodeJS.Signals | null;
   status: number | null;
   stderr: string;
+  /** Everything the shell wrote before the result settled, complete or not. */
   stdout: string;
 }
 
 export type SpawnLoginShellPath = (
   args: SpawnLoginShellPathArgs,
-) => ShellPathSpawnResult;
+) => Promise<ShellPathSpawnResult>;
 
-type EnsurePackagedUserShellPathResult =
+export interface ShellPathStageFailure {
+  flags: ShellPathStageFlags;
+  message: string;
+  /**
+   * `missing-shell` is a spawn error of ENOENT or EACCES: the shell binary
+   * itself could not be started, so every stage with it would fail the same
+   * way. Other spawn errors and timeouts are `shell-error`.
+   */
+  reason:
+    | "empty-output"
+    | "missing-output"
+    | "missing-shell"
+    | "non-zero-status"
+    | "shell-error"
+    | "signal";
+  shell: string;
+}
+
+export type EnsurePackagedUserShellPathResult =
+  | ShellPathAugmentedResult
   | ShellPathSkippedResult
-  | ShellPathUpdatedResult
-  | ShellPathUnchangedResult;
+  | ShellPathUnchangedResult
+  | ShellPathUpdatedResult;
+
+type ShellPathStageFlags = "-ilc" | "-lc";
+type ShellPathSource = "interactive-login-shell" | "login-shell";
+
+interface ShellPathStage {
+  flags: ShellPathStageFlags;
+  source: ShellPathSource;
+  timeoutMs: number;
+}
 
 interface EnsurePackagedUserShellPathArgs {
   env: NodeJS.ProcessEnv;
+  fs?: DesktopShellPathFs;
+  homeDir: string;
   isPackaged: boolean;
   logger: DesktopShellPathLogger;
   platform: NodeJS.Platform;
   spawnLoginShellPath?: SpawnLoginShellPath;
+}
+
+interface ShellPathAugmentedResult {
+  appended: string[];
+  failures: ShellPathStageFailure[];
+  kind: "augmented";
+  path: string;
 }
 
 interface ShellPathSkippedResult {
@@ -45,44 +119,542 @@ interface ShellPathSkippedResult {
 }
 
 interface ShellPathUnchangedResult {
+  failures: ShellPathStageFailure[];
   kind: "unchanged";
-  reason: "empty-output" | "non-zero-status" | "shell-error" | "signal";
 }
 
 interface ShellPathUpdatedResult {
+  /**
+   * Existing tool directories appended because an earlier stage failed and
+   * the one that succeeded may not source the files that add them. Empty
+   * when the first stage succeeded.
+   */
+  appended: string[];
+  failures: ShellPathStageFailure[];
   kind: "updated";
   path: string;
+  /**
+   * The shell that printed the PATH: `$SHELL`, or the platform default when
+   * `$SHELL` could not be started and the stages were retried with it.
+   */
+  shell: string;
+  source: ShellPathSource;
+  /**
+   * How the stage that printed the PATH then failed to exit cleanly (timed
+   * out, signalled, non-zero status); `null` when it exited cleanly.
+   */
+  uncleanExit: string | null;
 }
 
-function defaultSpawnLoginShellPath(
-  args: SpawnLoginShellPathArgs,
-): ShellPathSpawnResult {
-  const result = spawnSync(args.command, args.args, {
-    encoding: "utf8",
-    timeout: args.timeoutMs,
-  });
+interface KnownToolDirectoriesArgs {
+  fs: DesktopShellPathFs;
+  homeDir: string;
+  platform: NodeJS.Platform;
+}
 
+interface ShellExitProblem {
+  detail: string;
+  message: string;
+  reason: ShellPathStageFailure["reason"];
+}
+
+type ShellPathOutput =
+  | { kind: "empty" }
+  | { kind: "missing" }
+  | { kind: "path"; path: string };
+
+type ShellPathStageOutcome =
+  | { kind: "failure"; failure: ShellPathStageFailure }
+  | { kind: "success"; path: string; uncleanExit: string | null };
+
+interface ShellPathStageSuccess {
+  flags: ShellPathStageFlags;
+  path: string;
+  shell: string;
+  source: ShellPathSource;
+  uncleanExit: string | null;
+}
+
+/** Every stage run with one shell, in order, up to the first success. */
+interface ShellPathProbeRun {
+  failures: ShellPathStageFailure[];
+  shell: string;
+  success: ShellPathStageSuccess | null;
+}
+
+const SHELL_PATH_STAGES: readonly ShellPathStage[] = [
+  {
+    flags: "-ilc",
+    source: "interactive-login-shell",
+    timeoutMs: INTERACTIVE_SHELL_PATH_TIMEOUT_MS,
+  },
+  {
+    flags: "-lc",
+    source: "login-shell",
+    timeoutMs: LOGIN_SHELL_PATH_TIMEOUT_MS,
+  },
+];
+
+const defaultDesktopShellPathFs: DesktopShellPathFs = {
+  isDirectory(path) {
+    try {
+      return statSync(path).isDirectory();
+    } catch {
+      return false;
+    }
+  },
+  listDirectory(path) {
+    try {
+      return readdirSync(path);
+    } catch {
+      return [];
+    }
+  },
+  readTextFile(path) {
+    try {
+      return readFileSync(path, "utf8");
+    } catch {
+      return null;
+    }
+  },
+};
+
+function toError(value: unknown): Error {
+  return value instanceof Error ? value : new Error(String(value));
+}
+
+/**
+ * Runs the shell with stdin closed (an rc file that reads from it cannot
+ * block the probe) and settles as soon as the shell exits, after a short
+ * grace to drain its pipes: waiting for the pipes to close would let a
+ * background job started by a login file hold the probe until the budget
+ * expires. A shell that has not exited by the budget is SIGKILLed so a TERM
+ * trap cannot extend it; whatever it printed is still returned.
+ */
+export function defaultSpawnLoginShellPath(
+  args: SpawnLoginShellPathArgs,
+): Promise<ShellPathSpawnResult> {
+  return new Promise<ShellPathSpawnResult>((resolveSpawn) => {
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    let budgetTimer: ReturnType<typeof setTimeout> | undefined;
+    let graceTimer: ReturnType<typeof setTimeout> | undefined;
+    let child: ChildProcess;
+
+    function settle(
+      result: Omit<ShellPathSpawnResult, "stderr" | "stdout">,
+    ): void {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(budgetTimer);
+      clearTimeout(graceTimer);
+      // Release the pipes: a lingering background job may keep them open.
+      child.stdout?.destroy();
+      child.stderr?.destroy();
+      resolveSpawn({ ...result, stderr, stdout });
+    }
+
+    try {
+      child = spawn(args.command, args.args, {
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    } catch (error) {
+      resolveSpawn({
+        error: toError(error),
+        signal: null,
+        status: null,
+        stderr,
+        stdout,
+      });
+      return;
+    }
+
+    child.stdout?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr?.setEncoding("utf8");
+    child.stderr?.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.on("error", (error) => {
+      settle({ error, signal: null, status: null });
+    });
+    child.on("exit", (status, signal) => {
+      if (settled) {
+        return;
+      }
+      clearTimeout(budgetTimer);
+      graceTimer = setTimeout(() => {
+        settle({ signal, status });
+      }, SHELL_EXIT_PIPE_GRACE_MS);
+    });
+    child.on("close", (status, signal) => {
+      settle({ signal, status });
+    });
+    budgetTimer = setTimeout(() => {
+      child.kill("SIGKILL");
+      settle({
+        error: new Error(`timed out after ${args.timeoutMs} ms`),
+        signal: "SIGKILL",
+        status: null,
+      });
+    }, args.timeoutMs);
+  });
+}
+
+function parseShellPathOutput(stdout: string): ShellPathOutput {
+  const lines = stdout.split(/\r?\n/u);
+  const startIndex = lines.findIndex(
+    (line) => line.trim() === SHELL_PATH_START_MARKER,
+  );
+  if (startIndex === -1) {
+    return { kind: "missing" };
+  }
+  const endIndex = lines.findIndex(
+    (line, index) =>
+      index > startIndex && line.trim() === SHELL_PATH_END_MARKER,
+  );
+  if (endIndex === -1) {
+    return { kind: "missing" };
+  }
+  const pathLine = lines
+    .slice(startIndex + 1, endIndex)
+    .find((line) => line.startsWith("PATH="));
+  if (pathLine === undefined) {
+    return { kind: "missing" };
+  }
+  const path = pathLine.slice("PATH=".length).trim();
+  return path.length === 0 ? { kind: "empty" } : { kind: "path", path };
+}
+
+/** Node reports a missing or non-executable command as an errno on the error. */
+function isMissingShellError(error: Error): boolean {
+  if (!("code" in error)) {
+    return false;
+  }
+  return error.code === "ENOENT" || error.code === "EACCES";
+}
+
+function classifyShellExit(
+  result: ShellPathSpawnResult,
+): ShellExitProblem | null {
+  if (result.error !== undefined) {
+    if (isMissingShellError(result.error)) {
+      return {
+        detail: result.error.message,
+        message: `could not be started: ${result.error.message}`,
+        reason: "missing-shell",
+      };
+    }
+    return {
+      detail: result.error.message,
+      message: `failed: ${result.error.message}`,
+      reason: "shell-error",
+    };
+  }
+  if (result.signal !== null) {
+    return {
+      detail: `signal ${result.signal}`,
+      message: `exited from signal ${result.signal}`,
+      reason: "signal",
+    };
+  }
+  if (result.status !== 0) {
+    const stderr = result.stderr.trim();
+    return {
+      detail: `status ${result.status}`,
+      message:
+        stderr.length > 0
+          ? `exited with status ${result.status}: ${stderr}`
+          : `exited with status ${result.status}`,
+      reason: "non-zero-status",
+    };
+  }
+  return null;
+}
+
+function stageFailure(
+  shell: string,
+  stage: ShellPathStage,
+  reason: ShellPathStageFailure["reason"],
+  message: string,
+): ShellPathStageOutcome {
   return {
-    ...(result.error === undefined ? {} : { error: result.error }),
-    signal: result.signal,
-    status: result.status,
-    stderr: result.stderr,
-    stdout: result.stdout,
+    failure: { flags: stage.flags, message, reason, shell },
+    kind: "failure",
   };
 }
 
-function warnShellPathFallback(
-  args: EnsurePackagedUserShellPathArgs,
-  message: string,
-): void {
-  args.logger.warn(
-    `Could not load the user shell PATH for the packaged desktop app: ${message}. Continuing with the inherited PATH.`,
+/**
+ * A complete marker block is authoritative: the shell only prints it after
+ * every login file has run, so the PATH is valid even when the shell then
+ * hung, was killed at the budget, or exited non-zero.
+ */
+async function runShellPathStage(
+  spawnLoginShellPath: SpawnLoginShellPath,
+  shell: string,
+  stage: ShellPathStage,
+): Promise<ShellPathStageOutcome> {
+  const result = await spawnLoginShellPath({
+    args: [stage.flags, SHELL_PATH_COMMAND],
+    command: shell,
+    timeoutMs: stage.timeoutMs,
+  });
+  const output = parseShellPathOutput(result.stdout);
+  const exitProblem = classifyShellExit(result);
+  if (output.kind === "path") {
+    return {
+      kind: "success",
+      path: output.path,
+      uncleanExit: exitProblem === null ? null : exitProblem.detail,
+    };
+  }
+  if (exitProblem !== null) {
+    return stageFailure(shell, stage, exitProblem.reason, exitProblem.message);
+  }
+  if (output.kind === "empty") {
+    return stageFailure(shell, stage, "empty-output", "printed an empty PATH");
+  }
+  return stageFailure(
+    shell,
+    stage,
+    "missing-output",
+    "exited without printing its PATH",
   );
 }
 
-export function ensurePackagedUserShellPath(
+/**
+ * Runs the stages with one shell until one prints a PATH. A `missing-shell`
+ * failure ends the run early: the binary cannot be started, so the remaining
+ * stages would fail identically.
+ */
+async function runShellPathStages(
+  spawnLoginShellPath: SpawnLoginShellPath,
+  shell: string,
+): Promise<ShellPathProbeRun> {
+  const failures: ShellPathStageFailure[] = [];
+  for (const stage of SHELL_PATH_STAGES) {
+    const outcome = await runShellPathStage(spawnLoginShellPath, shell, stage);
+    if (outcome.kind === "success") {
+      return {
+        failures,
+        shell,
+        success: {
+          flags: stage.flags,
+          path: outcome.path,
+          shell,
+          source: stage.source,
+          uncleanExit: outcome.uncleanExit,
+        },
+      };
+    }
+    failures.push(outcome.failure);
+    if (outcome.failure.reason === "missing-shell") {
+      break;
+    }
+  }
+  return { failures, shell, success: null };
+}
+
+function formatStageFailures(failures: ShellPathStageFailure[]): string {
+  return failures
+    .map((failure) => `${failure.shell} ${failure.flags} ${failure.message}`)
+    .join("; ");
+}
+
+/** The failed stages in the order they ran, naming the retry shell. */
+function formatProbeFailures(
+  configuredRun: ShellPathProbeRun,
+  retryRun: ShellPathProbeRun | null,
+): string {
+  let summary = formatStageFailures(configuredRun.failures);
+  if (retryRun !== null) {
+    summary += `; retried with the platform default shell ${retryRun.shell}`;
+    if (retryRun.failures.length > 0) {
+      summary += `: ${formatStageFailures(retryRun.failures)}`;
+    }
+  }
+  return summary;
+}
+
+function describeShellPathSource(source: ShellPathSource): string {
+  return source === "interactive-login-shell"
+    ? "interactive login shell"
+    : "non-interactive login shell";
+}
+
+function splitPathEntries(value: string): string[] {
+  return value.split(delimiter).filter((entry) => entry.length > 0);
+}
+
+function mergePathEntries(...entryLists: string[][]): string {
+  const merged: string[] = [];
+  const seen = new Set<string>();
+  for (const entries of entryLists) {
+    for (const entry of entries) {
+      if (seen.has(entry)) {
+        continue;
+      }
+      seen.add(entry);
+      merged.push(entry);
+    }
+  }
+  return merged.join(delimiter);
+}
+
+function compareNvmVersionsDescending(left: string, right: string): number {
+  const leftParts = left.slice(1).split(".").map(Number);
+  const rightParts = right.slice(1).split(".").map(Number);
+  for (let index = 0; index < 3; index += 1) {
+    const difference = (rightParts[index] ?? 0) - (leftParts[index] ?? 0);
+    if (difference !== 0) {
+      return difference;
+    }
+  }
+  return 0;
+}
+
+/**
+ * Resolves nvm's default Node `bin` directory without running nvm. nvm keeps
+ * aliases as files whose content is either a version (`v22.11.0`, `22`) or
+ * another alias (`default` -> `lts/*` -> `lts/jod` -> `v22.11.0`). A chain
+ * that ends at the built-in `node` or `stable`, or a `default` alias that is
+ * missing or broken, resolves to the newest installed version; a chain that
+ * ends at `system`, `iojs`, or `unstable` resolves to nothing, because the
+ * user's login does not put a versions/node `bin` on PATH.
+ */
+function resolveNvmDefaultNodeBin(
+  homeDir: string,
+  fs: DesktopShellPathFs,
+): string | null {
+  const nvmDir = join(homeDir, ".nvm");
+  const versionsDir = join(nvmDir, "versions", "node");
+  const installed = fs
+    .listDirectory(versionsDir)
+    .filter((name) => NVM_INSTALLED_VERSION_PATTERN.test(name))
+    .sort(compareNvmVersionsDescending);
+  const newest = installed[0];
+  if (newest === undefined) {
+    return null;
+  }
+
+  let alias = "default";
+  for (let hop = 0; hop < NVM_ALIAS_MAX_HOPS; hop += 1) {
+    const target = fs.readTextFile(join(nvmDir, "alias", alias))?.trim();
+    if (target === undefined || target.length === 0) {
+      break;
+    }
+    if (NVM_UNMANAGED_ALIASES.has(target)) {
+      return null;
+    }
+    if (NVM_NEWEST_INSTALLED_ALIASES.has(target)) {
+      break;
+    }
+    if (NVM_VERSION_ALIAS_PATTERN.test(target)) {
+      const prefix = target.startsWith("v") ? target : `v${target}`;
+      const match = installed.find(
+        (version) => version === prefix || version.startsWith(`${prefix}.`),
+      );
+      return join(versionsDir, match ?? newest, "bin");
+    }
+    alias = target;
+  }
+  return join(versionsDir, newest, "bin");
+}
+
+/**
+ * Well-known user tool directories that exist on disk, in the order their
+ * shell hooks usually prepend themselves: version managers, then language
+ * toolchains, then Homebrew and /usr/local. That order only ranks these
+ * directories among themselves. The caller appends them after the probed or
+ * inherited PATH, so they fill in what that PATH lacks and never shadow it: a
+ * Homebrew `node` the login shell already reported keeps winning over a
+ * version-managed one appended here.
+ */
+function knownToolDirectories(args: KnownToolDirectoriesArgs): string[] {
+  const { fs, homeDir } = args;
+  const nvmNodeBin = resolveNvmDefaultNodeBin(homeDir, fs);
+  const candidates = [
+    join(homeDir, ".volta", "bin"),
+    ...(nvmNodeBin === null ? [] : [nvmNodeBin]),
+    join(homeDir, ".local", "share", "fnm", "aliases", "default", "bin"),
+    join(
+      homeDir,
+      "Library",
+      "Application Support",
+      "fnm",
+      "aliases",
+      "default",
+      "bin",
+    ),
+    join(homeDir, ".fnm", "aliases", "default", "bin"),
+    join(homeDir, ".local", "share", "mise", "shims"),
+    join(homeDir, ".asdf", "shims"),
+    join(homeDir, ".nodenv", "shims"),
+    join(homeDir, ".n", "bin"),
+    join(homeDir, ".proto", "shims"),
+    // pnpm's default PNPM_HOME, where `pnpm add -g` and `pnpm env` put binaries.
+    ...(args.platform === "darwin"
+      ? [join(homeDir, "Library", "pnpm")]
+      : [join(homeDir, ".local", "share", "pnpm")]),
+    join(homeDir, ".bun", "bin"),
+    join(homeDir, ".deno", "bin"),
+    join(homeDir, ".cargo", "bin"),
+    join(homeDir, "go", "bin"),
+    join(homeDir, ".local", "bin"),
+    join(homeDir, "bin"),
+    ...(args.platform === "darwin"
+      ? ["/opt/homebrew/bin", "/opt/homebrew/sbin"]
+      : ["/home/linuxbrew/.linuxbrew/bin", "/snap/bin"]),
+    "/usr/local/bin",
+  ];
+  return candidates.filter((candidate) => fs.isDirectory(candidate));
+}
+
+function platformDefaultShell(platform: NodeJS.Platform): string {
+  return platform === "darwin" ? MACOS_DEFAULT_SHELL : LINUX_DEFAULT_SHELL;
+}
+
+/**
+ * The user's login shell when the launcher passed one (launchd and desktop
+ * sessions set `SHELL` from the account record), taken verbatim, otherwise
+ * the platform default; the host daemon's resolveUserShellPath makes the same
+ * choice. Whether the shell can actually run is learned from the probe.
+ */
+function resolveShellCommand(args: EnsurePackagedUserShellPathArgs): string {
+  const configuredShell = args.env.SHELL?.trim();
+  if (configuredShell !== undefined && configuredShell.length > 0) {
+    return configuredShell;
+  }
+  return platformDefaultShell(args.platform);
+}
+
+/**
+ * Loads the user's shell PATH into `args.env` for packaged GUI launches, which
+ * inherit launchd's `/usr/bin:/bin:/usr/sbin:/sbin` on macOS (and a similarly
+ * bare PATH from a Linux desktop session).
+ *
+ * Stages run in order until one prints a PATH: interactive login shell, then
+ * non-interactive login shell, with `$SHELL`. When `$SHELL` itself cannot be
+ * started (ENOENT or EACCES: a login shell that was uninstalled or an account
+ * record pointing at a stale path) and differs from the platform default, the
+ * stages run once more with the platform default shell. The probed PATH is
+ * merged with the inherited one (probed entries first, inherited entries that
+ * are missing appended) so nothing the parent already had is lost. When an
+ * earlier stage failed, existing well-known tool directories are appended as
+ * well, because the stage that succeeded may not source the files that
+ * usually add them; when every stage fails they are appended to the inherited
+ * PATH instead, so the server, host daemon, and plugins can still find
+ * `node`, `gh`, and provider CLIs. Every fallback is logged at warn; startup
+ * stays bounded by the sum of the stage budgets.
+ */
+export async function ensurePackagedUserShellPath(
   args: EnsurePackagedUserShellPathArgs,
-): EnsurePackagedUserShellPathResult {
+): Promise<EnsurePackagedUserShellPathResult> {
   if (args.platform !== "darwin" && args.platform !== "linux") {
     return { kind: "skipped", reason: "unsupported-platform" };
   }
@@ -92,42 +664,77 @@ export function ensurePackagedUserShellPath(
 
   const spawnLoginShellPath =
     args.spawnLoginShellPath ?? defaultSpawnLoginShellPath;
-  const result = spawnLoginShellPath({
-    args: ["-ilc", SHELL_PATH_COMMAND],
-    command:
-      args.platform === "darwin"
-        ? MACOS_LOGIN_SHELL
-        : (args.env.SHELL ?? "/bin/bash"),
-    timeoutMs: SHELL_PATH_TIMEOUT_MS,
-  });
+  const fs = args.fs ?? defaultDesktopShellPathFs;
+  const configuredShell = resolveShellCommand(args);
+  const defaultShell = platformDefaultShell(args.platform);
+  const inheritedEntries = splitPathEntries(args.env.PATH ?? "");
 
-  if (result.error !== undefined) {
-    warnShellPathFallback(args, result.error.message);
-    return { kind: "unchanged", reason: "shell-error" };
+  const configuredRun = await runShellPathStages(
+    spawnLoginShellPath,
+    configuredShell,
+  );
+  const retryRun =
+    configuredRun.success === null &&
+    configuredShell !== defaultShell &&
+    configuredRun.failures.some((failure) => failure.reason === "missing-shell")
+      ? await runShellPathStages(spawnLoginShellPath, defaultShell)
+      : null;
+  const failures = [...configuredRun.failures, ...(retryRun?.failures ?? [])];
+  const success = retryRun === null ? configuredRun.success : retryRun.success;
+  const failureSummary = `Could not load the user shell PATH for the packaged desktop app: ${formatProbeFailures(configuredRun, retryRun)}`;
+
+  if (success !== null) {
+    const probedEntries = splitPathEntries(success.path);
+    const present = new Set([...probedEntries, ...inheritedEntries]);
+    const appended =
+      failures.length === 0
+        ? []
+        : knownToolDirectories({
+            fs,
+            homeDir: args.homeDir,
+            platform: args.platform,
+          }).filter((directory) => !present.has(directory));
+    const path = mergePathEntries(probedEntries, inheritedEntries, appended);
+    if (success.uncleanExit !== null) {
+      args.logger.warn(
+        `${success.shell} ${success.flags} printed the user shell PATH for the packaged desktop app but did not exit cleanly (${success.uncleanExit}). Using the printed PATH.`,
+      );
+    }
+    if (failures.length > 0) {
+      args.logger.warn(
+        `${failureSummary}. Using the ${describeShellPathSource(success.source)} PATH from ${success.shell} ${success.flags} instead${
+          appended.length > 0
+            ? ` plus existing tool directories: ${appended.join(", ")}`
+            : ""
+        }.`,
+      );
+    }
+    args.env.PATH = path;
+    return {
+      appended,
+      failures,
+      kind: "updated",
+      path,
+      shell: success.shell,
+      source: success.source,
+      uncleanExit: success.uncleanExit,
+    };
   }
 
-  if (result.signal !== null) {
-    warnShellPathFallback(args, `shell exited from signal ${result.signal}`);
-    return { kind: "unchanged", reason: "signal" };
+  const appended = knownToolDirectories({
+    fs,
+    homeDir: args.homeDir,
+    platform: args.platform,
+  }).filter((directory) => !inheritedEntries.includes(directory));
+  if (appended.length === 0) {
+    args.logger.warn(`${failureSummary}. Continuing with the inherited PATH.`);
+    return { failures, kind: "unchanged" };
   }
 
-  if (result.status !== 0) {
-    const stderr = result.stderr.trim();
-    warnShellPathFallback(
-      args,
-      stderr.length > 0
-        ? `shell exited with status ${result.status}: ${stderr}`
-        : `shell exited with status ${result.status}`,
-    );
-    return { kind: "unchanged", reason: "non-zero-status" };
-  }
-
-  const shellPath = result.stdout.trim();
-  if (shellPath.length === 0) {
-    warnShellPathFallback(args, "shell returned an empty PATH");
-    return { kind: "unchanged", reason: "empty-output" };
-  }
-
-  args.env.PATH = shellPath;
-  return { kind: "updated", path: shellPath };
+  const path = mergePathEntries(inheritedEntries, appended);
+  args.logger.warn(
+    `${failureSummary}. Continuing with the inherited PATH plus existing tool directories: ${appended.join(", ")}.`,
+  );
+  args.env.PATH = path;
+  return { appended, failures, kind: "augmented", path };
 }

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { accessSync, constants as fsConstants } from "node:fs";
+import { appendFile, mkdir } from "node:fs/promises";
 import { arch, homedir, release, type as osType } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import {
@@ -159,7 +160,10 @@ import {
 import { resolveDesktopBrowserAppCommand } from "./desktop-browser-shortcuts.js";
 import { registerDesktopBrowserIpc } from "./desktop-browser-main-ipc.js";
 import { parseDesktopSystemConfig } from "./desktop-system-config.js";
-import { ensurePackagedUserShellPath } from "./desktop-shell-path.js";
+import {
+  ensurePackagedUserShellPath,
+  type DesktopShellPathLogger,
+} from "./desktop-shell-path.js";
 import { resolveDesktopReloadShortcut } from "./desktop-reload-shortcut.js";
 import {
   createLogTailer,
@@ -560,6 +564,39 @@ function createDesktopLogger(): DesktopAutoUpdateLogger {
       process.stderr.write(`${message}\n`);
     },
   };
+}
+
+const DESKTOP_MAIN_LOG_FILE_NAME = "desktop.log";
+
+/**
+ * Shell PATH probe warnings go to stderr for terminal launches and to
+ * `desktop.log` in the log directory, because a Dock or Finder launch has no
+ * stderr anyone can read and the probe is what decides whether bb-app and the
+ * plugins can find `node` at all.
+ */
+function createShellPathLogger(): DesktopShellPathLogger {
+  const stderrLogger = createDesktopLogger();
+  return {
+    warn(message) {
+      stderrLogger.warn(message);
+      void appendDesktopLogLine(message);
+    },
+  };
+}
+
+async function appendDesktopLogLine(message: string): Promise<void> {
+  const logDir = formatLogDirectory();
+  try {
+    await mkdir(logDir, { recursive: true });
+    await appendFile(
+      join(logDir, DESKTOP_MAIN_LOG_FILE_NAME),
+      `${new Date().toISOString()} ${message}\n`,
+      "utf8",
+    );
+  } catch {
+    // stderr already has the warning; an unwritable log directory must not
+    // block startup.
+  }
 }
 
 function resolveDataDirFromEnv(args: ResolveDataDirFromEnvArgs): string {
@@ -2075,13 +2112,6 @@ async function initializeRuntime(args: InitializeRuntimeArgs): Promise<void> {
 }
 
 async function runDesktopApp(): Promise<void> {
-  ensurePackagedUserShellPath({
-    env: process.env,
-    isPackaged: app.isPackaged,
-    logger: createDesktopLogger(),
-    platform: process.platform,
-  });
-
   const applicationName = app.isPackaged
     ? DESKTOP_RELEASE_INFO.applicationName
     : "bb-dev";
@@ -2145,6 +2175,19 @@ async function runDesktopApp(): Promise<void> {
       quitting = true;
       await stopOwnedRuntime();
     },
+  });
+
+  // bb-app, the server, the host daemon, and in-process server plugins inherit
+  // process.env.PATH through startOwnedRuntime -> startBbAppProcess, so the
+  // repair must land before initializeRuntime, the only path that spawns a
+  // child. It runs after the single-instance lock so a duplicate launch quits
+  // without paying for the shell probe.
+  await ensurePackagedUserShellPath({
+    env: process.env,
+    homeDir: homedir(),
+    isPackaged: app.isPackaged,
+    logger: createShellPathLogger(),
+    platform: process.platform,
   });
 
   await app.whenReady();

--- a/apps/desktop/test/bb-process.test.ts
+++ b/apps/desktop/test/bb-process.test.ts
@@ -75,11 +75,13 @@ describe("bb app process", () => {
     const env = createBbAppProcessEnv({
       env: {
         ELECTRON_RUN_AS_NODE: "1",
+        PATH: "/fake/user/bin:/usr/bin",
       },
       runtimeMode: "node",
     });
 
     expect(env.ELECTRON_RUN_AS_NODE).toBeUndefined();
+    expect(env.PATH).toBe("/fake/user/bin:/usr/bin");
   });
 
   it("uses Electron node mode for packaged runtimes", () => {
@@ -93,12 +95,14 @@ describe("bb app process", () => {
       executablePath: "/Applications/bb.app/Contents/MacOS/bb",
       mode: "electron-node",
     });
+    // The packaged desktop repairs PATH before spawning bb-app; the child env
+    // carries it through unchanged alongside the node-mode flag.
     expect(
       createBbAppProcessEnv({
-        env: {},
+        env: { PATH: "/fake/user/bin:/usr/bin" },
         runtimeMode: runtime.mode,
-      }).ELECTRON_RUN_AS_NODE,
-    ).toBe("1");
+      }),
+    ).toEqual({ ELECTRON_RUN_AS_NODE: "1", PATH: "/fake/user/bin:/usr/bin" });
   });
 
   it("requires the host Node executable in desktop dev mode", () => {

--- a/apps/desktop/test/desktop-shell-path.test.ts
+++ b/apps/desktop/test/desktop-shell-path.test.ts
@@ -1,11 +1,25 @@
-import { describe, expect, it } from "vitest";
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
 import {
+  defaultSpawnLoginShellPath,
   ensurePackagedUserShellPath,
+  type DesktopShellPathFs,
   type DesktopShellPathLogger,
   type ShellPathSpawnResult,
   type SpawnLoginShellPath,
   type SpawnLoginShellPathArgs,
 } from "../src/desktop-shell-path.js";
+
+const START_MARKER = "__BB_DESKTOP_SHELL_PATH_START__";
+const END_MARKER = "__BB_DESKTOP_SHELL_PATH_END__";
+const SHELL_PATH_COMMAND = `printf '\\n%s\\nPATH=%s\\n%s\\n' '${START_MARKER}' "$PATH" '${END_MARKER}'`;
+const LAUNCHD_PATH = "/usr/bin:/bin:/usr/sbin:/sbin";
+const HOME_DIR = "/Users/sawyerhood";
+const NVM_VERSIONS_DIR = join(HOME_DIR, ".nvm", "versions", "node");
+const HOMEBREW_PROFILE_PATH =
+  "/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin";
 
 interface FakeSpawn {
   calls: SpawnLoginShellPathArgs[];
@@ -20,13 +34,19 @@ interface CreateSpawnResultArgs {
   stdout?: string;
 }
 
-interface CreateFakeSpawnArgs {
-  result: ShellPathSpawnResult;
+interface CreateFakeFsArgs {
+  directories?: string[];
+  files?: Record<string, string>;
 }
 
 interface WarningLogger {
   logger: DesktopShellPathLogger;
   warnings: string[];
+}
+
+/** What the probe command prints: the PATH fenced by the marker lines. */
+function shellPathOutput(path: string): string {
+  return `\n${START_MARKER}\nPATH=${path}\n${END_MARKER}\n`;
 }
 
 function createSpawnResult(args: CreateSpawnResultArgs): ShellPathSpawnResult {
@@ -39,13 +59,61 @@ function createSpawnResult(args: CreateSpawnResultArgs): ShellPathSpawnResult {
   };
 }
 
-function createFakeSpawn(args: CreateFakeSpawnArgs): FakeSpawn {
+function createTimedOutResult(stdout = ""): ShellPathSpawnResult {
+  return createSpawnResult({
+    error: new Error("timed out after 5000 ms"),
+    signal: "SIGKILL",
+    status: null,
+    stdout,
+  });
+}
+
+/** The shape Node gives a spawn error: the errno on `code`, in the message. */
+function createSpawnError(command: string, code: string): Error {
+  return Object.assign(new Error(`spawn ${command} ${code}`), { code });
+}
+
+function createFakeSpawn(results: ShellPathSpawnResult[]): FakeSpawn {
   const calls: SpawnLoginShellPathArgs[] = [];
+  const queue = [...results];
   return {
     calls,
     spawn(spawnArgs) {
       calls.push(spawnArgs);
-      return args.result;
+      const result = queue.shift();
+      if (result === undefined) {
+        throw new Error(
+          `unexpected shell spawn: ${spawnArgs.command} ${spawnArgs.args.join(" ")}`,
+        );
+      }
+      return Promise.resolve(result);
+    },
+  };
+}
+
+function createFakeFs(args: CreateFakeFsArgs = {}): DesktopShellPathFs {
+  const directories = new Set(args.directories ?? []);
+  const files = new Map(Object.entries(args.files ?? {}));
+  return {
+    isDirectory(path) {
+      return directories.has(path) && !files.has(path);
+    },
+    listDirectory(path) {
+      const prefix = `${path}/`;
+      const names = new Set<string>();
+      for (const directory of directories) {
+        if (!directory.startsWith(prefix)) {
+          continue;
+        }
+        const [name] = directory.slice(prefix.length).split("/");
+        if (name !== undefined && name.length > 0) {
+          names.add(name);
+        }
+      }
+      return [...names];
+    },
+    readTextFile(path) {
+      return files.get(path) ?? null;
     },
   };
 }
@@ -69,40 +137,779 @@ function failIfSpawned(): SpawnLoginShellPath {
 }
 
 describe("desktop shell PATH loading", () => {
-  it("uses the macOS login shell PATH for packaged desktop launches", () => {
+  it("uses the macOS login shell PATH for packaged desktop launches", async () => {
     const env: NodeJS.ProcessEnv = { PATH: "/usr/bin:/bin" };
     const shellPath = "/Users/sawyerhood/.bun/bin:/usr/bin:/bin";
-    const fakeSpawn = createFakeSpawn({
-      result: createSpawnResult({ stdout: shellPath }),
-    });
+    const fakeSpawn = createFakeSpawn([
+      createSpawnResult({ stdout: shellPathOutput(shellPath) }),
+    ]);
     const warningLogger = createWarningLogger();
 
-    const result = ensurePackagedUserShellPath({
+    const result = await ensurePackagedUserShellPath({
       env,
+      fs: createFakeFs(),
+      homeDir: HOME_DIR,
       isPackaged: true,
       logger: warningLogger.logger,
       platform: "darwin",
       spawnLoginShellPath: fakeSpawn.spawn,
     });
 
-    expect(result).toEqual({ kind: "updated", path: shellPath });
+    expect(result).toEqual({
+      appended: [],
+      failures: [],
+      kind: "updated",
+      path: shellPath,
+      shell: "/bin/zsh",
+      source: "interactive-login-shell",
+      uncleanExit: null,
+    });
     expect(env.PATH).toBe(shellPath);
     expect(warningLogger.warnings).toEqual([]);
     expect(fakeSpawn.calls).toEqual([
       {
-        args: ["-ilc", 'printf "%s" "$PATH"'],
+        args: ["-ilc", SHELL_PATH_COMMAND],
         command: "/bin/zsh",
-        timeoutMs: 2_000,
+        timeoutMs: 5_000,
       },
     ]);
   });
 
-  it("leaves PATH alone in desktop dev mode", () => {
+  it("probes the login shell launchd passes in SHELL instead of assuming zsh", async () => {
+    const env: NodeJS.ProcessEnv = {
+      PATH: LAUNCHD_PATH,
+      SHELL: "/opt/homebrew/bin/fish",
+    };
+    const fakeSpawn = createFakeSpawn([
+      createSpawnResult({
+        stdout: shellPathOutput("/Users/sawyerhood/.volta/bin:/usr/bin:/bin"),
+      }),
+    ]);
+
+    await ensurePackagedUserShellPath({
+      env,
+      fs: createFakeFs(),
+      homeDir: HOME_DIR,
+      isPackaged: true,
+      logger: createWarningLogger().logger,
+      platform: "darwin",
+      spawnLoginShellPath: fakeSpawn.spawn,
+    });
+
+    expect(fakeSpawn.calls.map((call) => call.command)).toEqual([
+      "/opt/homebrew/bin/fish",
+    ]);
+  });
+
+  it("merges the probed PATH with inherited entries the shell did not report", async () => {
+    const env: NodeJS.ProcessEnv = { PATH: LAUNCHD_PATH };
+    const fakeSpawn = createFakeSpawn([
+      createSpawnResult({
+        stdout: shellPathOutput("/opt/homebrew/bin:/usr/bin"),
+      }),
+    ]);
+
+    const result = await ensurePackagedUserShellPath({
+      env,
+      fs: createFakeFs(),
+      homeDir: HOME_DIR,
+      isPackaged: true,
+      logger: createWarningLogger().logger,
+      platform: "darwin",
+      spawnLoginShellPath: fakeSpawn.spawn,
+    });
+
+    expect(result).toMatchObject({ kind: "updated" });
+    expect(env.PATH).toBe("/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin");
+    expect(fakeSpawn.calls).toHaveLength(1);
+  });
+
+  it("ignores login banners and version-manager hook output around the PATH block", async () => {
+    const env: NodeJS.ProcessEnv = { PATH: LAUNCHD_PATH };
+    const nvmBin = join(NVM_VERSIONS_DIR, "v22.11.0", "bin");
+    const fakeSpawn = createFakeSpawn([
+      createSpawnResult({
+        stdout: `Welcome to my shell\nNow using node v22.11.0 (npm v10.9.0)${shellPathOutput(`${nvmBin}:/usr/bin:/bin`)}bye\n`,
+      }),
+    ]);
+    const warningLogger = createWarningLogger();
+
+    const result = await ensurePackagedUserShellPath({
+      env,
+      fs: createFakeFs(),
+      homeDir: HOME_DIR,
+      isPackaged: true,
+      logger: warningLogger.logger,
+      platform: "darwin",
+      spawnLoginShellPath: fakeSpawn.spawn,
+    });
+
+    expect(result).toMatchObject({
+      kind: "updated",
+      path: `${nvmBin}:/usr/bin:/bin:/usr/sbin:/sbin`,
+      uncleanExit: null,
+    });
+    expect(env.PATH).toBe(`${nvmBin}:/usr/bin:/bin:/usr/sbin:/sbin`);
+    expect(warningLogger.warnings).toEqual([]);
+  });
+
+  it("keeps a complete PATH block when the shell printed it but did not exit cleanly", async () => {
+    // A login file that leaves a background job holding stdout, or a hung
+    // logout hook, makes the probe time out after the PATH was printed.
+    const env: NodeJS.ProcessEnv = { PATH: LAUNCHD_PATH };
+    const shellPath = "/Users/sawyerhood/.volta/bin:/usr/bin:/bin";
+    const fakeSpawn = createFakeSpawn([
+      createTimedOutResult(shellPathOutput(shellPath)),
+    ]);
+    const warningLogger = createWarningLogger();
+
+    const result = await ensurePackagedUserShellPath({
+      env,
+      fs: createFakeFs(),
+      homeDir: HOME_DIR,
+      isPackaged: true,
+      logger: warningLogger.logger,
+      platform: "darwin",
+      spawnLoginShellPath: fakeSpawn.spawn,
+    });
+
+    expect(result).toEqual({
+      appended: [],
+      failures: [],
+      kind: "updated",
+      path: `${shellPath}:/usr/sbin:/sbin`,
+      shell: "/bin/zsh",
+      source: "interactive-login-shell",
+      uncleanExit: "timed out after 5000 ms",
+    });
+    expect(env.PATH).toBe(`${shellPath}:/usr/sbin:/sbin`);
+    expect(fakeSpawn.calls).toHaveLength(1);
+    expect(warningLogger.warnings).toEqual([
+      "/bin/zsh -ilc printed the user shell PATH for the packaged desktop app but did not exit cleanly (timed out after 5000 ms). Using the printed PATH.",
+    ]);
+
+    // The reporter's shape: a numeric non-zero status with the block printed.
+    const statusEnv: NodeJS.ProcessEnv = { PATH: LAUNCHD_PATH };
+    const statusResult = await ensurePackagedUserShellPath({
+      env: statusEnv,
+      fs: createFakeFs(),
+      homeDir: HOME_DIR,
+      isPackaged: true,
+      logger: createWarningLogger().logger,
+      platform: "darwin",
+      spawnLoginShellPath: createFakeSpawn([
+        createSpawnResult({
+          error: new Error("timed out after 5000 ms"),
+          status: 13,
+          stdout: shellPathOutput(shellPath),
+        }),
+      ]).spawn,
+    });
+    expect(statusResult).toMatchObject({
+      kind: "updated",
+      source: "interactive-login-shell",
+      uncleanExit: "timed out after 5000 ms",
+    });
+    expect(statusEnv.PATH).toBe(`${shellPath}:/usr/sbin:/sbin`);
+  });
+
+  it("falls back to the non-interactive login shell when the interactive probe times out", async () => {
+    const env: NodeJS.ProcessEnv = { PATH: LAUNCHD_PATH };
+    const fakeSpawn = createFakeSpawn([
+      createTimedOutResult(),
+      createSpawnResult({
+        stdout: shellPathOutput("/Users/sawyerhood/.volta/bin:/usr/bin:/bin"),
+      }),
+    ]);
+    const warningLogger = createWarningLogger();
+
+    const result = await ensurePackagedUserShellPath({
+      env,
+      fs: createFakeFs(),
+      homeDir: HOME_DIR,
+      isPackaged: true,
+      logger: warningLogger.logger,
+      platform: "darwin",
+      spawnLoginShellPath: fakeSpawn.spawn,
+    });
+
+    expect(result).toEqual({
+      appended: [],
+      failures: [
+        {
+          flags: "-ilc",
+          message: "failed: timed out after 5000 ms",
+          reason: "shell-error",
+          shell: "/bin/zsh",
+        },
+      ],
+      kind: "updated",
+      path: "/Users/sawyerhood/.volta/bin:/usr/bin:/bin:/usr/sbin:/sbin",
+      shell: "/bin/zsh",
+      source: "login-shell",
+      uncleanExit: null,
+    });
+    expect(env.PATH).toBe(
+      "/Users/sawyerhood/.volta/bin:/usr/bin:/bin:/usr/sbin:/sbin",
+    );
+    expect(
+      fakeSpawn.calls.map((call) => [call.command, call.args, call.timeoutMs]),
+    ).toEqual([
+      ["/bin/zsh", ["-ilc", SHELL_PATH_COMMAND], 5_000],
+      ["/bin/zsh", ["-lc", SHELL_PATH_COMMAND], 3_000],
+    ]);
+    expect(warningLogger.warnings).toEqual([
+      "Could not load the user shell PATH for the packaged desktop app: /bin/zsh -ilc failed: timed out after 5000 ms. Using the non-interactive login shell PATH from /bin/zsh -lc instead.",
+    ]);
+  });
+
+  it("appends existing tool directories when the interactive stage fails and the login shell succeeds", async () => {
+    // zsh -lc skips ~/.zshrc, which is where nvm and Volta install their PATH
+    // hooks, so the profile PATH usually has Homebrew but no managed node.
+    const env: NodeJS.ProcessEnv = { PATH: LAUNCHD_PATH };
+    const voltaBin = join(HOME_DIR, ".volta", "bin");
+    const nvmBin = join(NVM_VERSIONS_DIR, "v22.11.0", "bin");
+    const fakeSpawn = createFakeSpawn([
+      createTimedOutResult(),
+      createSpawnResult({ stdout: shellPathOutput(HOMEBREW_PROFILE_PATH) }),
+    ]);
+    const warningLogger = createWarningLogger();
+
+    const result = await ensurePackagedUserShellPath({
+      env,
+      fs: createFakeFs({
+        directories: [voltaBin, nvmBin, "/opt/homebrew/bin", "/usr/local/bin"],
+      }),
+      homeDir: HOME_DIR,
+      isPackaged: true,
+      logger: warningLogger.logger,
+      platform: "darwin",
+      spawnLoginShellPath: fakeSpawn.spawn,
+    });
+
+    expect(result).toMatchObject({
+      appended: [voltaBin, nvmBin],
+      kind: "updated",
+      path: `${HOMEBREW_PROFILE_PATH}:${voltaBin}:${nvmBin}`,
+      source: "login-shell",
+    });
+    expect(env.PATH).toBe(`${HOMEBREW_PROFILE_PATH}:${voltaBin}:${nvmBin}`);
+    expect(warningLogger.warnings).toEqual([
+      `Could not load the user shell PATH for the packaged desktop app: /bin/zsh -ilc failed: timed out after 5000 ms. Using the non-interactive login shell PATH from /bin/zsh -lc instead plus existing tool directories: ${voltaBin}, ${nvmBin}.`,
+    ]);
+  });
+
+  it("treats a truncated PATH block as a failed stage", async () => {
+    const env: NodeJS.ProcessEnv = { PATH: LAUNCHD_PATH };
+    const fakeSpawn = createFakeSpawn([
+      createTimedOutResult(`Welcome\n${START_MARKER}\nPATH=/opt/homebrew/bin`),
+      createSpawnResult({
+        stdout: shellPathOutput("/usr/local/bin:/usr/bin:/bin"),
+      }),
+    ]);
+
+    const result = await ensurePackagedUserShellPath({
+      env,
+      fs: createFakeFs(),
+      homeDir: HOME_DIR,
+      isPackaged: true,
+      logger: createWarningLogger().logger,
+      platform: "darwin",
+      spawnLoginShellPath: fakeSpawn.spawn,
+    });
+
+    expect(result).toMatchObject({
+      failures: [
+        {
+          flags: "-ilc",
+          message: "failed: timed out after 5000 ms",
+          reason: "shell-error",
+          shell: "/bin/zsh",
+        },
+      ],
+      kind: "updated",
+      source: "login-shell",
+    });
+    expect(env.PATH).toBe("/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin");
+  });
+
+  it("treats a shell that exits without printing the block as a failed stage", async () => {
+    const env: NodeJS.ProcessEnv = { PATH: LAUNCHD_PATH };
+    const fakeSpawn = createFakeSpawn([
+      createSpawnResult({ stdout: "Welcome to my shell\n" }),
+      createSpawnResult({
+        stdout: shellPathOutput("/usr/local/bin:/usr/bin:/bin"),
+      }),
+    ]);
+
+    const result = await ensurePackagedUserShellPath({
+      env,
+      fs: createFakeFs(),
+      homeDir: HOME_DIR,
+      isPackaged: true,
+      logger: createWarningLogger().logger,
+      platform: "darwin",
+      spawnLoginShellPath: fakeSpawn.spawn,
+    });
+
+    expect(result).toMatchObject({
+      failures: [
+        {
+          flags: "-ilc",
+          message: "exited without printing its PATH",
+          reason: "missing-output",
+          shell: "/bin/zsh",
+        },
+      ],
+      kind: "updated",
+      source: "login-shell",
+    });
+    expect(env.PATH).toBe("/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin");
+  });
+
+  it("augments the inherited PATH with existing user tool directories when every shell stage fails", async () => {
+    const env: NodeJS.ProcessEnv = { PATH: LAUNCHD_PATH };
+    const fakeSpawn = createFakeSpawn([
+      createTimedOutResult(),
+      createSpawnResult({ signal: "SIGKILL", status: null }),
+    ]);
+    const warningLogger = createWarningLogger();
+    const voltaBin = join(HOME_DIR, ".volta", "bin");
+    const miseShims = join(HOME_DIR, ".local", "share", "mise", "shims");
+    const pnpmHome = join(HOME_DIR, "Library", "pnpm");
+    const cargoBin = join(HOME_DIR, ".cargo", "bin");
+
+    const result = await ensurePackagedUserShellPath({
+      env,
+      fs: createFakeFs({
+        directories: [
+          "/opt/homebrew/bin",
+          pnpmHome,
+          miseShims,
+          voltaBin,
+          cargoBin,
+        ],
+        // A candidate that exists as a file, not a directory, is skipped.
+        files: { [cargoBin]: "" },
+      }),
+      homeDir: HOME_DIR,
+      isPackaged: true,
+      logger: warningLogger.logger,
+      platform: "darwin",
+      spawnLoginShellPath: fakeSpawn.spawn,
+    });
+
+    // Version-manager directories rank ahead of Homebrew among the appended
+    // entries, but all of them land after the inherited PATH.
+    const appended = [voltaBin, miseShims, pnpmHome, "/opt/homebrew/bin"];
+    expect(result).toEqual({
+      appended,
+      failures: [
+        {
+          flags: "-ilc",
+          message: "failed: timed out after 5000 ms",
+          reason: "shell-error",
+          shell: "/bin/zsh",
+        },
+        {
+          flags: "-lc",
+          message: "exited from signal SIGKILL",
+          reason: "signal",
+          shell: "/bin/zsh",
+        },
+      ],
+      kind: "augmented",
+      path: `${LAUNCHD_PATH}:${appended.join(":")}`,
+    });
+    expect(env.PATH).toBe(`${LAUNCHD_PATH}:${appended.join(":")}`);
+    expect(fakeSpawn.calls.map((call) => call.args[0])).toEqual([
+      "-ilc",
+      "-lc",
+    ]);
+    expect(warningLogger.warnings).toEqual([
+      `Could not load the user shell PATH for the packaged desktop app: /bin/zsh -ilc failed: timed out after 5000 ms; /bin/zsh -lc exited from signal SIGKILL. Continuing with the inherited PATH plus existing tool directories: ${appended.join(", ")}.`,
+    ]);
+  });
+
+  it("does not append tool directories that are already on the inherited PATH", async () => {
+    const env: NodeJS.ProcessEnv = {
+      PATH: `/opt/homebrew/bin:${LAUNCHD_PATH}`,
+    };
+    const fakeSpawn = createFakeSpawn([
+      createTimedOutResult(),
+      createTimedOutResult(),
+    ]);
+
+    const result = await ensurePackagedUserShellPath({
+      env,
+      fs: createFakeFs({
+        directories: ["/opt/homebrew/bin", "/usr/local/bin"],
+      }),
+      homeDir: HOME_DIR,
+      isPackaged: true,
+      logger: createWarningLogger().logger,
+      platform: "darwin",
+      spawnLoginShellPath: fakeSpawn.spawn,
+    });
+
+    expect(result).toMatchObject({
+      appended: ["/usr/local/bin"],
+      kind: "augmented",
+    });
+    expect(env.PATH).toBe(`/opt/homebrew/bin:${LAUNCHD_PATH}:/usr/local/bin`);
+  });
+
+  it("keeps the inherited PATH and warns when no stage succeeds and no known tool directory exists", async () => {
+    const env: NodeJS.ProcessEnv = { PATH: "/usr/bin:/bin" };
+    const fakeSpawn = createFakeSpawn([
+      createSpawnResult({ error: createSpawnError("/bin/zsh", "EAGAIN") }),
+      createSpawnResult({ status: 1, stderr: "zsh: bad option\n" }),
+    ]);
+    const warningLogger = createWarningLogger();
+
+    const result = await ensurePackagedUserShellPath({
+      env,
+      fs: createFakeFs(),
+      homeDir: HOME_DIR,
+      isPackaged: true,
+      logger: warningLogger.logger,
+      platform: "darwin",
+      spawnLoginShellPath: fakeSpawn.spawn,
+    });
+
+    expect(result).toEqual({
+      failures: [
+        {
+          flags: "-ilc",
+          message: "failed: spawn /bin/zsh EAGAIN",
+          reason: "shell-error",
+          shell: "/bin/zsh",
+        },
+        {
+          flags: "-lc",
+          message: "exited with status 1: zsh: bad option",
+          reason: "non-zero-status",
+          shell: "/bin/zsh",
+        },
+      ],
+      kind: "unchanged",
+    });
+    expect(env.PATH).toBe("/usr/bin:/bin");
+    expect(warningLogger.warnings).toEqual([
+      "Could not load the user shell PATH for the packaged desktop app: /bin/zsh -ilc failed: spawn /bin/zsh EAGAIN; /bin/zsh -lc exited with status 1: zsh: bad option. Continuing with the inherited PATH.",
+    ]);
+  });
+
+  it("retries with the platform default shell when the SHELL launchd passed cannot be started", async () => {
+    // An uninstalled login shell (Homebrew fish removed, account record still
+    // pointing at it) fails every stage with ENOENT; zsh is still there.
+    const env: NodeJS.ProcessEnv = {
+      PATH: LAUNCHD_PATH,
+      SHELL: "/opt/homebrew/bin/fish",
+    };
+    const voltaBin = join(HOME_DIR, ".volta", "bin");
+    const fakeSpawn = createFakeSpawn([
+      createSpawnResult({
+        error: createSpawnError("/opt/homebrew/bin/fish", "ENOENT"),
+      }),
+      createSpawnResult({ stdout: shellPathOutput(HOMEBREW_PROFILE_PATH) }),
+    ]);
+    const warningLogger = createWarningLogger();
+
+    const result = await ensurePackagedUserShellPath({
+      env,
+      fs: createFakeFs({ directories: [voltaBin, "/opt/homebrew/bin"] }),
+      homeDir: HOME_DIR,
+      isPackaged: true,
+      logger: warningLogger.logger,
+      platform: "darwin",
+      spawnLoginShellPath: fakeSpawn.spawn,
+    });
+
+    // The missing shell is not retried with -lc: it would fail identically.
+    expect(fakeSpawn.calls.map((call) => [call.command, call.args[0]])).toEqual(
+      [
+        ["/opt/homebrew/bin/fish", "-ilc"],
+        ["/bin/zsh", "-ilc"],
+      ],
+    );
+    expect(result).toEqual({
+      appended: [voltaBin],
+      failures: [
+        {
+          flags: "-ilc",
+          message: "could not be started: spawn /opt/homebrew/bin/fish ENOENT",
+          reason: "missing-shell",
+          shell: "/opt/homebrew/bin/fish",
+        },
+      ],
+      kind: "updated",
+      path: `${HOMEBREW_PROFILE_PATH}:${voltaBin}`,
+      shell: "/bin/zsh",
+      source: "interactive-login-shell",
+      uncleanExit: null,
+    });
+    expect(env.PATH).toBe(`${HOMEBREW_PROFILE_PATH}:${voltaBin}`);
+    expect(warningLogger.warnings).toEqual([
+      `Could not load the user shell PATH for the packaged desktop app: /opt/homebrew/bin/fish -ilc could not be started: spawn /opt/homebrew/bin/fish ENOENT; retried with the platform default shell /bin/zsh. Using the interactive login shell PATH from /bin/zsh -ilc instead plus existing tool directories: ${voltaBin}.`,
+    ]);
+  });
+
+  it("names both shells when the platform default retry fails as well", async () => {
+    const env: NodeJS.ProcessEnv = {
+      PATH: "/usr/bin:/bin",
+      SHELL: "/usr/bin/fish",
+    };
+    const fakeSpawn = createFakeSpawn([
+      createSpawnResult({ error: createSpawnError("/usr/bin/fish", "EACCES") }),
+      createTimedOutResult(),
+      createSpawnResult({ status: 127 }),
+    ]);
+    const warningLogger = createWarningLogger();
+
+    const result = await ensurePackagedUserShellPath({
+      env,
+      fs: createFakeFs({ directories: ["/home/user/.local/bin"] }),
+      homeDir: "/home/user",
+      isPackaged: true,
+      logger: warningLogger.logger,
+      platform: "linux",
+      spawnLoginShellPath: fakeSpawn.spawn,
+    });
+
+    expect(fakeSpawn.calls.map((call) => [call.command, call.args[0]])).toEqual(
+      [
+        ["/usr/bin/fish", "-ilc"],
+        ["/bin/bash", "-ilc"],
+        ["/bin/bash", "-lc"],
+      ],
+    );
+    expect(result).toEqual({
+      appended: ["/home/user/.local/bin"],
+      failures: [
+        {
+          flags: "-ilc",
+          message: "could not be started: spawn /usr/bin/fish EACCES",
+          reason: "missing-shell",
+          shell: "/usr/bin/fish",
+        },
+        {
+          flags: "-ilc",
+          message: "failed: timed out after 5000 ms",
+          reason: "shell-error",
+          shell: "/bin/bash",
+        },
+        {
+          flags: "-lc",
+          message: "exited with status 127",
+          reason: "non-zero-status",
+          shell: "/bin/bash",
+        },
+      ],
+      kind: "augmented",
+      path: "/usr/bin:/bin:/home/user/.local/bin",
+    });
+    expect(warningLogger.warnings).toEqual([
+      "Could not load the user shell PATH for the packaged desktop app: /usr/bin/fish -ilc could not be started: spawn /usr/bin/fish EACCES; retried with the platform default shell /bin/bash: /bin/bash -ilc failed: timed out after 5000 ms; /bin/bash -lc exited with status 127. Continuing with the inherited PATH plus existing tool directories: /home/user/.local/bin.",
+    ]);
+  });
+
+  it("does not retry when the missing shell already is the platform default", async () => {
+    const env: NodeJS.ProcessEnv = { PATH: LAUNCHD_PATH, SHELL: "/bin/zsh" };
+    const fakeSpawn = createFakeSpawn([
+      createSpawnResult({ error: createSpawnError("/bin/zsh", "ENOENT") }),
+    ]);
+
+    const result = await ensurePackagedUserShellPath({
+      env,
+      fs: createFakeFs(),
+      homeDir: HOME_DIR,
+      isPackaged: true,
+      logger: createWarningLogger().logger,
+      platform: "darwin",
+      spawnLoginShellPath: fakeSpawn.spawn,
+    });
+
+    expect(fakeSpawn.calls.map((call) => call.command)).toEqual(["/bin/zsh"]);
+    expect(result).toMatchObject({
+      failures: [{ reason: "missing-shell", shell: "/bin/zsh" }],
+      kind: "unchanged",
+    });
+    expect(env.PATH).toBe(LAUNCHD_PATH);
+  });
+
+  it("treats an empty shell PATH as a failed stage", async () => {
+    const env: NodeJS.ProcessEnv = { PATH: LAUNCHD_PATH };
+    const fakeSpawn = createFakeSpawn([
+      createSpawnResult({ stdout: shellPathOutput("  ") }),
+      createSpawnResult({
+        stdout: shellPathOutput("/usr/local/bin:/usr/bin:/bin"),
+      }),
+    ]);
+
+    const result = await ensurePackagedUserShellPath({
+      env,
+      fs: createFakeFs(),
+      homeDir: HOME_DIR,
+      isPackaged: true,
+      logger: createWarningLogger().logger,
+      platform: "darwin",
+      spawnLoginShellPath: fakeSpawn.spawn,
+    });
+
+    expect(result).toMatchObject({
+      failures: [
+        {
+          flags: "-ilc",
+          message: "printed an empty PATH",
+          reason: "empty-output",
+          shell: "/bin/zsh",
+        },
+      ],
+      kind: "updated",
+      source: "login-shell",
+    });
+    expect(env.PATH).toBe("/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin");
+  });
+
+  it("resolves the nvm default alias chain to an installed Node version", async () => {
+    const env: NodeJS.ProcessEnv = { PATH: LAUNCHD_PATH };
+    const fakeSpawn = createFakeSpawn([
+      createTimedOutResult(),
+      createTimedOutResult(),
+    ]);
+
+    const result = await ensurePackagedUserShellPath({
+      env,
+      fs: createFakeFs({
+        directories: [
+          join(NVM_VERSIONS_DIR, "v20.11.1", "bin"),
+          join(NVM_VERSIONS_DIR, "v22.11.0", "bin"),
+          join(NVM_VERSIONS_DIR, "v24.1.0", "bin"),
+        ],
+        files: {
+          [join(HOME_DIR, ".nvm", "alias", "default")]: "lts/*\n",
+          [join(HOME_DIR, ".nvm", "alias", "lts", "*")]: "lts/jod\n",
+          [join(HOME_DIR, ".nvm", "alias", "lts", "jod")]: "v22.11.0\n",
+        },
+      }),
+      homeDir: HOME_DIR,
+      isPackaged: true,
+      logger: createWarningLogger().logger,
+      platform: "darwin",
+      spawnLoginShellPath: fakeSpawn.spawn,
+    });
+
+    expect(result).toMatchObject({
+      appended: [join(NVM_VERSIONS_DIR, "v22.11.0", "bin")],
+      kind: "augmented",
+    });
+  });
+
+  it("falls back to the newest installed nvm Node version for unresolvable or partial aliases", async () => {
+    const directories = [
+      join(NVM_VERSIONS_DIR, "v20.11.1", "bin"),
+      join(NVM_VERSIONS_DIR, "v20.9.0", "bin"),
+      join(NVM_VERSIONS_DIR, "v24.1.0", "bin"),
+      join(NVM_VERSIONS_DIR, "v9.11.2", "bin"),
+    ];
+    const resolveAppended = async (
+      files: Record<string, string>,
+    ): Promise<string[]> => {
+      const env: NodeJS.ProcessEnv = { PATH: LAUNCHD_PATH };
+      const result = await ensurePackagedUserShellPath({
+        env,
+        fs: createFakeFs({ directories, files }),
+        homeDir: HOME_DIR,
+        isPackaged: true,
+        logger: createWarningLogger().logger,
+        platform: "darwin",
+        spawnLoginShellPath: createFakeSpawn([
+          createTimedOutResult(),
+          createTimedOutResult(),
+        ]).spawn,
+      });
+      return result.kind === "augmented" ? result.appended : [];
+    };
+
+    // `node` is an nvm built-in alias for the newest installed version.
+    await expect(
+      resolveAppended({
+        [join(HOME_DIR, ".nvm", "alias", "default")]: "node\n",
+      }),
+    ).resolves.toEqual([join(NVM_VERSIONS_DIR, "v24.1.0", "bin")]);
+    // No default alias at all: newest installed version, numerically sorted.
+    await expect(resolveAppended({})).resolves.toEqual([
+      join(NVM_VERSIONS_DIR, "v24.1.0", "bin"),
+    ]);
+    // A partial version alias selects the newest matching major.
+    await expect(
+      resolveAppended({
+        [join(HOME_DIR, ".nvm", "alias", "default")]: "20\n",
+      }),
+    ).resolves.toEqual([join(NVM_VERSIONS_DIR, "v20.11.1", "bin")]);
+  });
+
+  it("does not append an nvm Node bin when the default alias opts out of nvm's node", async () => {
+    // `nvm alias default system` keeps the system node on PATH at login, so
+    // nothing under versions/node belongs there; `iojs`/`unstable` likewise
+    // never point into versions/node. A non-nvm directory keeps the result
+    // augmented so the absence of the nvm entry is what the test observes.
+    const directories = [
+      join(NVM_VERSIONS_DIR, "v22.11.0", "bin"),
+      join(NVM_VERSIONS_DIR, "v24.1.0", "bin"),
+      "/usr/local/bin",
+    ];
+    const resolveAppended = async (
+      files: Record<string, string>,
+    ): Promise<string[]> => {
+      const env: NodeJS.ProcessEnv = { PATH: LAUNCHD_PATH };
+      const result = await ensurePackagedUserShellPath({
+        env,
+        fs: createFakeFs({ directories, files }),
+        homeDir: HOME_DIR,
+        isPackaged: true,
+        logger: createWarningLogger().logger,
+        platform: "darwin",
+        spawnLoginShellPath: createFakeSpawn([
+          createTimedOutResult(),
+          createTimedOutResult(),
+        ]).spawn,
+      });
+      return result.kind === "augmented" ? result.appended : [];
+    };
+
+    await expect(
+      resolveAppended({
+        [join(HOME_DIR, ".nvm", "alias", "default")]: "system\n",
+      }),
+    ).resolves.toEqual(["/usr/local/bin"]);
+    // The chain is followed to the built-in, not cut at the first hop.
+    await expect(
+      resolveAppended({
+        [join(HOME_DIR, ".nvm", "alias", "default")]: "mine\n",
+        [join(HOME_DIR, ".nvm", "alias", "mine")]: "unstable\n",
+      }),
+    ).resolves.toEqual(["/usr/local/bin"]);
+    // `stable` still means the newest installed version.
+    await expect(
+      resolveAppended({
+        [join(HOME_DIR, ".nvm", "alias", "default")]: "stable\n",
+      }),
+    ).resolves.toEqual([
+      join(NVM_VERSIONS_DIR, "v24.1.0", "bin"),
+      "/usr/local/bin",
+    ]);
+  });
+
+  it("leaves PATH alone in desktop dev mode", async () => {
     const env: NodeJS.ProcessEnv = { PATH: "/opt/homebrew/bin:/usr/bin:/bin" };
     const warningLogger = createWarningLogger();
 
-    const result = ensurePackagedUserShellPath({
+    const result = await ensurePackagedUserShellPath({
       env,
+      fs: createFakeFs({ directories: ["/usr/local/bin"] }),
+      homeDir: HOME_DIR,
       isPackaged: false,
       logger: warningLogger.logger,
       platform: "darwin",
@@ -114,88 +921,97 @@ describe("desktop shell PATH loading", () => {
     expect(warningLogger.warnings).toEqual([]);
   });
 
-  it("falls back to the inherited PATH when the shell spawn fails", () => {
-    const env: NodeJS.ProcessEnv = { PATH: "/usr/bin:/bin" };
-    const fakeSpawn = createFakeSpawn({
-      result: createSpawnResult({ error: new Error("spawn failed") }),
-    });
-    const warningLogger = createWarningLogger();
-
-    const result = ensurePackagedUserShellPath({
-      env,
-      isPackaged: true,
-      logger: warningLogger.logger,
-      platform: "darwin",
-      spawnLoginShellPath: fakeSpawn.spawn,
-    });
-
-    expect(result).toEqual({ kind: "unchanged", reason: "shell-error" });
-    expect(env.PATH).toBe("/usr/bin:/bin");
-    expect(warningLogger.warnings).toEqual([
-      "Could not load the user shell PATH for the packaged desktop app: spawn failed. Continuing with the inherited PATH.",
-    ]);
-  });
-
-  it("falls back to the inherited PATH when shell PATH loading times out", () => {
-    const env: NodeJS.ProcessEnv = { PATH: "/usr/bin:/bin" };
-    const fakeSpawn = createFakeSpawn({
-      result: createSpawnResult({
-        error: new Error("spawnSync /bin/zsh ETIMEDOUT"),
-        signal: "SIGTERM",
-      }),
-    });
-    const warningLogger = createWarningLogger();
-
-    const result = ensurePackagedUserShellPath({
-      env,
-      isPackaged: true,
-      logger: warningLogger.logger,
-      platform: "darwin",
-      spawnLoginShellPath: fakeSpawn.spawn,
-    });
-
-    expect(result).toEqual({ kind: "unchanged", reason: "shell-error" });
-    expect(env.PATH).toBe("/usr/bin:/bin");
-    expect(warningLogger.warnings[0]).toContain("ETIMEDOUT");
-  });
-
-  it("uses the configured Linux login shell", () => {
+  it("uses the configured Linux login shell", async () => {
     const env: NodeJS.ProcessEnv = {
       PATH: "/usr/bin:/bin",
       SHELL: "/usr/bin/fish",
     };
     const shellPath = "/home/user/.local/bin:/usr/bin:/bin";
-    const fakeSpawn = createFakeSpawn({
-      result: createSpawnResult({ stdout: shellPath }),
-    });
+    const fakeSpawn = createFakeSpawn([
+      createSpawnResult({ stdout: shellPathOutput(shellPath) }),
+    ]);
 
-    const result = ensurePackagedUserShellPath({
+    const result = await ensurePackagedUserShellPath({
       env,
+      fs: createFakeFs(),
+      homeDir: "/home/user",
       isPackaged: true,
       logger: createWarningLogger().logger,
       platform: "linux",
       spawnLoginShellPath: fakeSpawn.spawn,
     });
 
-    expect(result).toEqual({ kind: "updated", path: shellPath });
+    expect(result).toEqual({
+      appended: [],
+      failures: [],
+      kind: "updated",
+      path: shellPath,
+      shell: "/usr/bin/fish",
+      source: "interactive-login-shell",
+      uncleanExit: null,
+    });
     expect(env.PATH).toBe(shellPath);
     expect(fakeSpawn.calls).toEqual([
       {
-        args: ["-ilc", 'printf "%s" "$PATH"'],
+        args: ["-ilc", SHELL_PATH_COMMAND],
         command: "/usr/bin/fish",
-        timeoutMs: 2_000,
+        timeoutMs: 5_000,
       },
     ]);
   });
 
-  it("falls back to bash when Linux SHELL is unset", () => {
-    const env: NodeJS.ProcessEnv = { PATH: "/usr/bin:/bin" };
-    const fakeSpawn = createFakeSpawn({
-      result: createSpawnResult({ stdout: "/home/user/bin:/usr/bin:/bin" }),
+  it("stages and augments Linux launches the same way as macOS", async () => {
+    const env: NodeJS.ProcessEnv = {
+      PATH: "/usr/bin:/bin",
+      SHELL: "/bin/bash",
+    };
+    const fakeSpawn = createFakeSpawn([
+      createTimedOutResult(),
+      createTimedOutResult(),
+    ]);
+
+    const result = await ensurePackagedUserShellPath({
+      env,
+      fs: createFakeFs({
+        directories: [
+          "/home/linuxbrew/.linuxbrew/bin",
+          "/home/user/.local/bin",
+        ],
+      }),
+      homeDir: "/home/user",
+      isPackaged: true,
+      logger: createWarningLogger().logger,
+      platform: "linux",
+      spawnLoginShellPath: fakeSpawn.spawn,
     });
 
-    ensurePackagedUserShellPath({
+    expect(fakeSpawn.calls.map((call) => [call.command, call.args[0]])).toEqual(
+      [
+        ["/bin/bash", "-ilc"],
+        ["/bin/bash", "-lc"],
+      ],
+    );
+    expect(result).toMatchObject({
+      appended: ["/home/user/.local/bin", "/home/linuxbrew/.linuxbrew/bin"],
+      kind: "augmented",
+    });
+    expect(env.PATH).toBe(
+      "/usr/bin:/bin:/home/user/.local/bin:/home/linuxbrew/.linuxbrew/bin",
+    );
+  });
+
+  it("falls back to bash when Linux SHELL is unset", async () => {
+    const env: NodeJS.ProcessEnv = { PATH: "/usr/bin:/bin" };
+    const fakeSpawn = createFakeSpawn([
+      createSpawnResult({
+        stdout: shellPathOutput("/home/user/bin:/usr/bin:/bin"),
+      }),
+    ]);
+
+    await ensurePackagedUserShellPath({
       env,
+      fs: createFakeFs(),
+      homeDir: "/home/user",
       isPackaged: true,
       logger: createWarningLogger().logger,
       platform: "linux",
@@ -205,11 +1021,13 @@ describe("desktop shell PATH loading", () => {
     expect(fakeSpawn.calls[0]?.command).toBe("/bin/bash");
   });
 
-  it("skips unsupported platforms", () => {
+  it("skips unsupported platforms", async () => {
     const env: NodeJS.ProcessEnv = { PATH: "C:\\Windows\\System32" };
 
-    const result = ensurePackagedUserShellPath({
+    const result = await ensurePackagedUserShellPath({
       env,
+      fs: createFakeFs(),
+      homeDir: "C:\\Users\\user",
       isPackaged: true,
       logger: createWarningLogger().logger,
       platform: "win32",
@@ -223,3 +1041,128 @@ describe("desktop shell PATH loading", () => {
     expect(env.PATH).toBe("C:\\Windows\\System32");
   });
 });
+
+describe.skipIf(process.platform === "win32")(
+  "desktop shell PATH probe against real shells",
+  () => {
+    const tempRoots: string[] = [];
+
+    afterAll(async () => {
+      for (const root of tempRoots.splice(0)) {
+        await rm(root, { force: true, recursive: true });
+      }
+    });
+
+    async function createFakeLoginShell(contents: string): Promise<string> {
+      const root = await mkdtemp(join(tmpdir(), "bb-desktop-shell-path-"));
+      tempRoots.push(root);
+      const path = join(root, "fake-login-shell");
+      await writeFile(path, contents, "utf8");
+      await chmod(path, 0o755);
+      return path;
+    }
+
+    it("settles when the shell exits even though a background job keeps stdout open", async () => {
+      // The job outlives the budget, so settling on pipe close instead of on
+      // the shell's exit would surface here as a timeout with SIGKILL.
+      const startedAt = Date.now();
+
+      const result = await defaultSpawnLoginShellPath({
+        args: ["-c", 'printf "%s" hello; sleep 10 & exit 0'],
+        command: "/bin/bash",
+        timeoutMs: 2_000,
+      });
+
+      expect(result).toEqual({
+        signal: null,
+        status: 0,
+        stderr: "",
+        stdout: "hello",
+      });
+      // Loose upper bound: the real cost is the 250 ms pipe grace.
+      expect(Date.now() - startedAt).toBeLessThan(2_000);
+    });
+
+    it("surfaces a missing shell as a spawn error that carries its errno", async () => {
+      // The retry with the platform default shell keys on this code; a
+      // wrapper that rethrew a plain Error would silently disable it.
+      const result = await defaultSpawnLoginShellPath({
+        args: ["-ilc", "true"],
+        command: "/nonexistent/bb-login-shell",
+        timeoutMs: 2_000,
+      });
+
+      expect(result).toMatchObject({
+        error: expect.objectContaining({ code: "ENOENT" }),
+        signal: null,
+        status: null,
+        stdout: "",
+      });
+    });
+
+    it("kills a shell that ignores SIGTERM once its budget expires", async () => {
+      const startedAt = Date.now();
+
+      const result = await defaultSpawnLoginShellPath({
+        args: ["-c", "trap '' TERM; printf '%s' partial; sleep 5"],
+        command: "/bin/bash",
+        timeoutMs: 300,
+      });
+
+      expect(result).toMatchObject({
+        error: expect.objectContaining({ message: "timed out after 300 ms" }),
+        signal: "SIGKILL",
+        status: null,
+        stdout: "partial",
+      });
+      const elapsedMs = Date.now() - startedAt;
+      expect(elapsedMs).toBeGreaterThanOrEqual(290);
+      expect(elapsedMs).toBeLessThan(2_000);
+    });
+
+    it(
+      "loads the PATH from a login shell that prints a banner and leaves a background job",
+      { timeout: 10_000 },
+      async () => {
+        // Stand-in for a user's login shell: a banner on stdout, a PATH
+        // extension, a background job inheriting stdout that outlives the 5 s
+        // interactive budget, then the probe command. The test timeout exceeds
+        // that budget so a pipe-close regression is reported by the shape
+        // assertion below (an unclean exit) rather than by vitest's own timeout.
+        const shell = await createFakeLoginShell(`#!/bin/bash
+echo "Welcome to my shell"
+export PATH="/fake/tools/bin:$PATH"
+sleep 10 &
+eval "\${@: -1}"
+`);
+        const env: NodeJS.ProcessEnv = { PATH: "/usr/bin:/bin", SHELL: shell };
+        const warningLogger = createWarningLogger();
+        const startedAt = Date.now();
+
+        const result = await ensurePackagedUserShellPath({
+          env,
+          fs: createFakeFs(),
+          homeDir: HOME_DIR,
+          isPackaged: true,
+          logger: warningLogger.logger,
+          platform: process.platform,
+        });
+
+        expect(result).toMatchObject({
+          appended: [],
+          failures: [],
+          kind: "updated",
+          source: "interactive-login-shell",
+          uncleanExit: null,
+        });
+        const entries = (env.PATH ?? "").split(":");
+        expect(entries[0]).toBe("/fake/tools/bin");
+        expect(entries).toContain("/usr/bin");
+        expect(env.PATH).not.toContain("\n");
+        expect(env.PATH).not.toContain("Welcome");
+        expect(warningLogger.warnings).toEqual([]);
+        expect(Date.now() - startedAt).toBeLessThan(2_500);
+      },
+    );
+  },
+);


### PR DESCRIPTION
## Human comments

## What was wrong

A packaged macOS bb launched from the GUI inherits launchd's restricted PATH (`/usr/bin:/bin:/usr/sbin:/sbin`). `ensurePackagedUserShellPath` was a single `/bin/zsh -ilc 'printf "%s" "$PATH"'` `spawnSync` with a 2,000 ms timeout, and every failure branch (ETIMEDOUT, signal, non-zero status, empty stdout) kept the inherited PATH. Two further mechanisms discarded valid PATHs: `spawnSync` waits for the pipes to close, so a login file that leaves a background job attached to stdout reports ETIMEDOUT (with a numeric status, exactly the reporter's `status 13`) even after the shell exited and printed its PATH; and raw stdout was used as the PATH, so a banner or `nvm use` line became part of the first entry. bb-app, the server, the host daemon, and in-process server plugins inherit `process.env.PATH` through `startOwnedRuntime → startBbAppProcess`, so every child lost `node` and `gh` while the app looked healthy, and the only warning went to the Electron main-process stderr, which a Dock launch discards. (#2343)

## What changed

`apps/desktop/src/desktop-shell-path.ts` (probe rewritten; pure, injectable), `apps/desktop/src/main.ts` (call site), `apps/desktop/README.md`:

- The shell prints its PATH between marker lines. A complete block is authoritative even when the shell then times out, is signalled, or exits non-zero; everything else on stdout is ignored.
- The default spawn is async: stdin closed, settle on the shell's exit plus a 250 ms pipe grace instead of on pipe close, SIGKILL at the budget.
- `$SHELL -ilc` (5 s budget), then `$SHELL -lc` (3 s), `$SHELL` taken verbatim (fallback `/bin/zsh` on macOS, `/bin/bash` on Linux). When `$SHELL` cannot be started (spawn ENOENT/EACCES) and is not the platform default, the stages run once more with the platform default shell.
- A probed PATH is merged with the inherited one (probed entries first, then inherited entries the shell did not report).
- When an earlier stage failed, well-known tool directories that exist on disk (volta, nvm's default Node bin resolved from the alias files without running nvm, fnm, mise/asdf/nodenv/proto shims, n, pnpm home, bun, deno, cargo, go, `~/.local/bin`, `~/bin`, Homebrew, `/usr/local/bin`, `/snap/bin`) are appended, because `-lc` skips the rc file where nvm and Volta install their hooks. Appended entries never shadow a tool the shell already put on PATH. An nvm default alias ending at `system` adds no nvm bin.
- Every fallback logs one warn line naming each failed stage, the platform-default retry, and any appended directory, to stderr and to `desktop.log` in the log directory.
- The probe runs after the single-instance lock and handler registration and before `app.whenReady()`, so a duplicate launch quits without paying for it and the repair still precedes `initializeRuntime`, the only path that spawns a child.

Linux goes through the same stages and augmentation. No server/daemon wire change, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged. Worst-case blocked startup is ~8.5 s and only when the interactive shell hangs before printing.

Scope: PATH acquisition in the desktop main process and its propagation to bb-app and everything bb-app spawns. The issue's second ask, a visible degraded state in the affected plugin reader when a required executable is still missing, is a separate feature and is left for a follow-up. Related follow-up: the host daemon's own `resolveUserShellPath` still settles on pipe close and has no augmentation, so daemons started by launchd/systemd without the desktop keep the old behavior.

## How you verified

`apps/desktop/test/desktop-shell-path.test.ts` (28 tests; 20 of them fail against the `origin/main` source): marker parsing (banners, CRLF, truncated and missing blocks), complete block kept on timeout / status 13, `-ilc` timeout → `-lc` fallback, merge with inherited entries, augmentation only on the degraded paths, nvm alias chains (`lts/*`, partial, `system`), `$SHELL` honored and the platform-default retry on ENOENT/EACCES, Linux parity. Three real-shell tests (bash) exercise the default spawn end to end: settle on exit with a background job holding stdout, SIGKILL at budget for a TERM-trapping shell, and a login shell that prints a banner and leaves a background job (run 3× under turbo, no flake). A pipe-close-settling regression was proven to fail the shape assertions deterministically.

Commands: `pnpm exec turbo run typecheck --filter=@bb/desktop --force` and `pnpm exec turbo run test --filter=@bb/desktop --force` on the rebased tip: 35 files / 252 tests pass. Three independent adversarial review rounds. EAP codename scan of `origin/main..HEAD`: clean.

Not done: no packaged macOS smoke (this machine is Linux); the default spawn and marker command were exercised against real bash shells instead.

Fixes #2343

> AGENT GENERATED
