### PR TITLE
Harden queued-editor measurement and capture a renderer stack on unresponsive (Refs #2401)

### DIFF
--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.test.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.test.tsx
@@ -25,17 +25,21 @@ import {
   type QueuedEditorTypeaheadLayout,
 } from "@/components/promptbox/queued-editor-typeahead-layout";
 
-const bottomAnchorMocks = vi.hoisted(() => ({
-  scrollElement: null as HTMLElement | null,
-}));
+const bottomAnchorMocks = vi.hoisted(() => {
+  const mocks = {
+    scrollElement: null as HTMLElement | null,
+    // Identity-stable like the real context value, so effects keyed on it do
+    // not re-run on every render.
+    getScrollElement: () => mocks.scrollElement,
+  };
+  return mocks;
+});
 
 vi.mock("@/components/ui/bottom-anchored-scroll-body", () => ({
   useBottomAnchoredScroll: () =>
     bottomAnchorMocks.scrollElement === null
       ? null
-      : {
-          getScrollElement: () => bottomAnchorMocks.scrollElement,
-        },
+      : { getScrollElement: bottomAnchorMocks.getScrollElement },
 }));
 
 const noop = () => {};
@@ -92,6 +96,58 @@ function makeGroupedQueuedMessages(): ThreadQueuedMessage[] {
 
 function rect({ top, bottom }: { top: number; bottom: number }) {
   return new DOMRect(0, top, 100, bottom - top);
+}
+
+function nextAnimationFrame(): Promise<void> {
+  return new Promise((resolve) => {
+    window.requestAnimationFrame(() => resolve());
+  });
+}
+
+/**
+ * Stubs ResizeObserver and returns a notifier that models one frame's
+ * delivery pass: every live observer gets a single callback carrying one entry
+ * per observed target, as if all of its targets changed size in that frame.
+ */
+function stubResizeObserver(): () => void {
+  const observers = new Set<ResizeObserverMock>();
+  class ResizeObserverMock {
+    private readonly targets = new Set<Element>();
+
+    constructor(private readonly callback: ResizeObserverCallback) {
+      observers.add(this);
+    }
+
+    observe(target: Element) {
+      this.targets.add(target);
+    }
+
+    unobserve(target: Element) {
+      this.targets.delete(target);
+    }
+
+    disconnect() {
+      this.targets.clear();
+      observers.delete(this);
+    }
+
+    notify() {
+      const entries: ResizeObserverEntry[] = [...this.targets].map(
+        (target) => ({
+          target,
+          contentRect: new DOMRect(),
+          borderBoxSize: [],
+          contentBoxSize: [],
+          devicePixelContentBoxSize: [],
+        }),
+      );
+      this.callback(entries, this as unknown as ResizeObserver);
+    }
+  }
+  vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+  return () => {
+    for (const observer of [...observers]) observer.notify();
+  };
 }
 
 function renderQueuedMessages(queuedMessages: readonly ThreadQueuedMessage[]) {
@@ -679,17 +735,7 @@ describe("QueuedMessagesList", () => {
   });
 
   it("realigns both neighbors as the edit surface finishes growing", async () => {
-    let notifyResize = noop;
-    class ResizeObserverMock {
-      constructor(callback: ResizeObserverCallback) {
-        notifyResize = () => callback([], this as unknown as ResizeObserver);
-      }
-
-      observe() {}
-      unobserve() {}
-      disconnect() {}
-    }
-    vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+    const notifyResize = stubResizeObserver();
 
     const viewport = document.createElement("div");
     Object.defineProperty(viewport, "clientHeight", { value: 500 });
@@ -765,10 +811,120 @@ describe("QueuedMessagesList", () => {
     scroll.scrollTop = 100;
 
     act(() => notifyResize());
+    await act(() => nextAnimationFrame());
     expect(scroll.scrollTop).toBe(100);
 
     queueViewportBottom = 300;
     act(() => notifyResize());
+    await act(() => nextAnimationFrame());
+    expect(scroll.scrollTop).toBe(60);
+  });
+
+  it("measures once, on the next frame, when the observer delivers and the window resizes together", async () => {
+    const notifyResize = stubResizeObserver();
+
+    // Every measurement reads the timeline viewport height exactly once, so
+    // the getter counts measurements.
+    let measurements = 0;
+    const viewport = document.createElement("div");
+    Object.defineProperty(viewport, "clientHeight", {
+      get: () => {
+        measurements += 1;
+        return 500;
+      },
+    });
+    bottomAnchorMocks.scrollElement = viewport;
+
+    let queueViewportBottom = 180;
+    const nativeGetBoundingClientRect =
+      HTMLElement.prototype.getBoundingClientRect;
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+      function (this: HTMLElement) {
+        if (this.hasAttribute("data-queue-test-footer")) {
+          return new DOMRect(0, 0, 600, 340);
+        }
+        if (this.getAttribute("aria-label") === "Queued messages") {
+          return new DOMRect(0, 0, 600, 240);
+        }
+        if (this.hasAttribute("data-queued-messages-scroll")) {
+          return new DOMRect(0, 32, 600, queueViewportBottom - 32);
+        }
+        const queueScrollTop =
+          this.closest<HTMLElement>("[data-queued-messages-scroll]")
+            ?.scrollTop ?? 0;
+        if (this.hasAttribute("data-queued-message-inline-editor")) {
+          return new DOMRect(0, 132 - queueScrollTop, 600, 180);
+        }
+        if (this.hasAttribute("data-queued-message-row")) {
+          if (this.textContent?.includes("Previous queued message")) {
+            return new DOMRect(0, 92 - queueScrollTop, 600, 40);
+          }
+          if (this.textContent?.includes("Following queued message")) {
+            return new DOMRect(0, 312 - queueScrollTop, 600, 30);
+          }
+        }
+        return nativeGetBoundingClientRect.call(this);
+      },
+    );
+
+    const queuedMessages = [
+      makeQueuedMessage("q_previous", "Previous queued message"),
+      makeQueuedMessage("q_editing", "Edited queued message"),
+      makeQueuedMessage("q_following", "Following queued message"),
+    ];
+    const { container } = render(
+      <div data-queue-test-footer="">
+        <div data-app-composer="">
+          <QueuedMessagesList
+            queuedMessages={queuedMessages}
+            inlineEditor={{
+              queuedMessageId: "q_editing",
+              queuedMessageIndex: 1,
+              content: <div>Inline editor</div>,
+              onDismiss: noop,
+            }}
+            sendDisabled={false}
+            actionDisabled={false}
+            processingMessageId={null}
+            processingAction={null}
+            onSendImmediately={noop}
+            onReorder={noop}
+            onSetGroupBoundary={noop}
+            onEdit={noop}
+            onDelete={noop}
+          />
+          <div>Bottom composer</div>
+        </div>
+      </div>,
+    );
+    const scroll = container.querySelector<HTMLElement>(
+      "[data-queued-messages-scroll]",
+    );
+    expect(scroll).not.toBeNull();
+    if (!scroll) return;
+    // Let the mount-time measurement and its realignment settle.
+    await act(async () => {
+      await nextAnimationFrame();
+      await nextAnimationFrame();
+    });
+    scroll.scrollTop = 100;
+    measurements = 0;
+
+    // One frame of the 260ms surface transition: the window resize event
+    // fires first, then the observer delivers one callback for every observed
+    // box that changed (viewport, surface, list, editor, composer shell and
+    // container). Neither callback measures; the layout reads, state writes
+    // and scroll realignment run once, from the next animation frame.
+    queueViewportBottom = 300;
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+      notifyResize();
+    });
+    expect(measurements).toBe(0);
+    expect(scroll.scrollTop).toBe(100);
+
+    await act(() => nextAnimationFrame());
+    expect(measurements).toBe(1);
     expect(scroll.scrollTop).toBe(60);
   });
 

--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
@@ -905,6 +905,19 @@ function QueuedMessageInlineEditorSlot({
 }) {
   const [typeaheadLayout, setTypeaheadLayout] =
     useState<QueuedEditorTypeaheadLayout>({ height: 0, isOpen: false });
+  // The typeahead reports a fresh object from its ResizeObserver on every
+  // delivery; only a changed layout should re-render the slot, since the
+  // reservation padding below resizes the editor row.
+  const reportTypeaheadLayout = useCallback(
+    (layout: QueuedEditorTypeaheadLayout) => {
+      setTypeaheadLayout((current) =>
+        current.height === layout.height && current.isOpen === layout.isOpen
+          ? current
+          : layout,
+      );
+    },
+    [],
+  );
   const typeaheadReservation = typeaheadLayout.isOpen
     ? Math.ceil(typeaheadLayout.height) + TYPEAHEAD_MENU_GAP
     : 0;
@@ -919,7 +932,9 @@ function QueuedMessageInlineEditorSlot({
         label={`Editing queued message ${editor.queuedMessageIndex + 1}`}
         onCancel={editor.onDismiss}
       >
-        <QueuedEditorTypeaheadLayoutContext.Provider value={setTypeaheadLayout}>
+        <QueuedEditorTypeaheadLayoutContext.Provider
+          value={reportTypeaheadLayout}
+        >
           <div
             data-queued-editor-typeahead-reservation=""
             style={{ paddingTop: typeaheadReservation }}
@@ -1095,9 +1110,10 @@ export function QueuedMessagesList({
     setInlineEditorDesiredHeight((currentHeight) =>
       currentHeight === desiredHeight ? currentHeight : desiredHeight,
     );
-    // The surface height is animated. ResizeObserver calls this throughout the
-    // transition, so re-align the neighborhood as usable space appears instead
-    // of leaving the editor pinned to the top based on the first, short frame.
+    // The surface height is animated. The observer below schedules this on
+    // each frame of the transition, so re-align the neighborhood as usable
+    // space appears instead of leaving the editor pinned to the top based on
+    // the first, short frame.
     scrollInlineEditorNeighborhoodIntoView();
   }, [
     getScrollElement,
@@ -1114,13 +1130,27 @@ export function QueuedMessagesList({
     const surface = surfaceRef.current;
     const composerShell = surface?.closest<HTMLElement>("[data-app-composer]");
     const container = composerShell?.parentElement;
-    const animationFrame = window.requestAnimationFrame(
-      measureInlineEditorMaxHeight,
-    );
+    // The surface height animates for 260ms while the editor mounts and the
+    // composer re-flows around it. The browser delivers one ResizeObserver
+    // callback per frame for every observed box that changed, and a window
+    // resize event can precede it in the same frame. Both callbacks only
+    // schedule: the layout reads, the two state writes and the scroll
+    // realignment run from one pending animation frame, so this effect
+    // measures at most once per frame and never from inside the observer
+    // callback, where a layout write would re-enter observer delivery.
+    let animationFrame: number | null = null;
+    const scheduleMeasure = () => {
+      if (animationFrame !== null) return;
+      animationFrame = window.requestAnimationFrame(() => {
+        animationFrame = null;
+        measureInlineEditorMaxHeight();
+      });
+    };
+    scheduleMeasure();
     const resizeObserver =
       typeof ResizeObserver === "undefined"
         ? null
-        : new ResizeObserver(measureInlineEditorMaxHeight);
+        : new ResizeObserver(scheduleMeasure);
     if (viewport) resizeObserver?.observe(viewport);
     if (surface) resizeObserver?.observe(surface);
     if (listRef.current) resizeObserver?.observe(listRef.current);
@@ -1130,11 +1160,13 @@ export function QueuedMessagesList({
     if (editorElement) resizeObserver?.observe(editorElement);
     if (composerShell) resizeObserver?.observe(composerShell);
     if (container) resizeObserver?.observe(container);
-    window.addEventListener("resize", measureInlineEditorMaxHeight);
+    window.addEventListener("resize", scheduleMeasure);
     return () => {
-      window.cancelAnimationFrame(animationFrame);
+      if (animationFrame !== null) {
+        window.cancelAnimationFrame(animationFrame);
+      }
       resizeObserver?.disconnect();
-      window.removeEventListener("resize", measureInlineEditorMaxHeight);
+      window.removeEventListener("resize", scheduleMeasure);
     };
   }, [getScrollElement, inlineEditorActive, measureInlineEditorMaxHeight]);
 

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -292,6 +292,21 @@ BB_DESKTOP_OPEN_DEVTOOLS=1 apps/desktop/release/mac-arm64/bb.app/Contents/MacOS/
 When the desktop app spawns `bb-app`, server and daemon logs land under
 `~/.bb/logs/` or `$BB_DATA_DIR/logs/` when `BB_DATA_DIR` is set.
 
+When an application window's renderer stops responding, the main process asks
+V8 to break through the DevTools protocol and writes a
+`renderer-hang-window-<id>-<timestamp>.json` report to that same logs directory,
+then resumes the renderer and detaches. Attach the file when reporting a desktop
+hang; the `commit` field maps the minified frame locations back to source.
+
+The break lands only when the renderer next yields, so a long-but-yielding hang
+gets the top JavaScript call frames plus heap usage, working set and build
+identity. A renderer pinned in one never-returning loop (the 100%-CPU,
+Cmd+R-dead case) never reaches a break point; that report instead records a
+`timed-out` capture -- confirming a fully pinned main thread -- with the working
+set and build identity but no stack. The report path is also printed to the
+main process's stderr, so it is visible when the app is launched from a
+terminal; otherwise find the file in the logs directory.
+
 To verify attach-if-found manually, start a compatible bb first, then launch the
 desktop app:
 

--- a/apps/desktop/src/desktop-renderer-hang-diagnostic.ts
+++ b/apps/desktop/src/desktop-renderer-hang-diagnostic.ts
@@ -1,0 +1,466 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { app, type BrowserWindow, type Debugger } from "electron";
+import { z } from "zod";
+import type { DesktopAboutFacts } from "./desktop-about-panel.js";
+
+/**
+ * Captures diagnostics when a window's renderer becomes unresponsive.
+ *
+ * Issue #2401 reports a renderer pinned at ~100% CPU with an RSS past 10 GiB
+ * after Edit on a queued message. A process sample of the renderer bottoms
+ * out in V8 microtask execution and never names the application callback, so
+ * the hang cannot be attributed from the report. The main process can reach
+ * the renderer's inspector through the webContents debugger and ask V8 to
+ * break with Debugger.pause. A pause takes effect only when V8 next checks
+ * for an interrupt, which a renderer that yields between tasks reaches
+ * promptly, so for a long-but-yielding hang this module writes the top call
+ * frames, the JS heap usage, the renderer's working set and the build
+ * identity (so minified frames can be mapped) to a JSON file, then resumes
+ * the renderer and detaches.
+ *
+ * A renderer executing a single never-returning synchronous or microtask loop
+ * -- the #2401 class, where Cmd+R is also dead -- never reaches an interrupt
+ * check, so the pause is acknowledged but no Debugger.paused ever arrives and
+ * the capture times out. Measured on Electron 41.7.0: with the Debugger domain
+ * pre-enabled, Debugger.pause is acked in ~1 ms yet no break is delivered to a
+ * for(;;) or self-rescheduling-microtask loop within seconds. The capture is
+ * bounded by a single deadline; on expiry it records which protocol step went
+ * unanswered ("Debugger.enable" for a loop that never yields at all, since
+ * attach and Debugger.enable are ordinary main-thread messages) together with
+ * the renderer's working set. That timeout report is itself diagnostic: it
+ * confirms a fully pinned main thread and captures memory + build identity
+ * even when no JavaScript stack can be obtained.
+ */
+
+export const RENDERER_HANG_DIAGNOSTIC_TIMEOUT_MS = 5_000;
+export const RENDERER_HANG_DIAGNOSTIC_MAX_CALL_FRAMES = 64;
+const DEVTOOLS_PROTOCOL_VERSION = "1.3";
+
+export interface RendererHangDebuggerClient {
+  attach(protocolVersion: string): void;
+  detach(): void;
+  /** Subscribes to protocol events; the returned function unsubscribes. */
+  onMessage(listener: (method: string, params: unknown) => void): () => void;
+  sendCommand(method: string): Promise<unknown>;
+}
+
+export interface RendererHangDiagnosticLogger {
+  warn(message: string): void;
+}
+
+export interface RendererHangWindowInfo {
+  id: number;
+  rendererPid: number;
+  url: string;
+  webContentsId: number;
+}
+
+export interface RendererHangProcessMemory {
+  peakWorkingSetSizeKb: number;
+  workingSetSizeKb: number;
+}
+
+export interface RendererHangCallFrame {
+  columnNumber?: number;
+  functionName: string;
+  lineNumber: number;
+  url: string;
+}
+
+interface RendererHangHeapUsage {
+  totalSize: number;
+  usedSize: number;
+}
+
+type RendererHangStep =
+  | "Debugger.enable"
+  | "Debugger.pause"
+  | "Debugger.paused"
+  | "Runtime.getHeapUsage";
+
+interface RendererHangPausedCapture {
+  callFrames: RendererHangCallFrame[];
+  droppedCallFrames: number;
+  heapUsage: RendererHangHeapUsage | null;
+  kind: "paused";
+  reason: string;
+}
+
+export type RendererHangCapture =
+  | RendererHangPausedCapture
+  | { kind: "timed-out"; step: RendererHangStep; timeoutMs: number }
+  | { error: string; kind: "failed"; step: RendererHangStep };
+
+export interface RendererHangReport {
+  build: DesktopAboutFacts;
+  capture: RendererHangCapture;
+  capturedAt: string;
+  kind: "bb-desktop-renderer-hang";
+  rendererMemory: RendererHangProcessMemory | null;
+  window: RendererHangWindowInfo;
+}
+
+export type RendererHangDiagnosticResult =
+  | { kind: "written"; path: string }
+  | {
+      kind: "skipped";
+      reason: "attach-failed" | "window-destroyed" | "write-failed";
+    };
+
+export interface CaptureRendererHangDiagnosticArgs {
+  build: DesktopAboutFacts;
+  debuggerClient: RendererHangDebuggerClient;
+  isWindowDestroyed(): boolean;
+  logDirectory: string;
+  logger: RendererHangDiagnosticLogger;
+  now(): number;
+  readRendererMemory(): RendererHangProcessMemory | null;
+  timeoutMs: number;
+  window: RendererHangWindowInfo;
+  writeFile(path: string, contents: string): Promise<void>;
+}
+
+const debuggerPausedSchema = z.object({
+  callFrames: z.array(
+    z.object({
+      functionName: z.string(),
+      location: z.object({
+        columnNumber: z.number().optional(),
+        lineNumber: z.number(),
+      }),
+      url: z.string(),
+    }),
+  ),
+  reason: z.string(),
+});
+
+const heapUsageSchema = z.object({
+  totalSize: z.number(),
+  usedSize: z.number(),
+});
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function createPausedCapture(
+  data: z.infer<typeof debuggerPausedSchema>,
+): RendererHangPausedCapture {
+  const callFrames = data.callFrames
+    .slice(0, RENDERER_HANG_DIAGNOSTIC_MAX_CALL_FRAMES)
+    .map((frame) => ({
+      columnNumber: frame.location.columnNumber,
+      functionName: frame.functionName,
+      lineNumber: frame.location.lineNumber,
+      url: frame.url,
+    }));
+  return {
+    callFrames,
+    droppedCallFrames: data.callFrames.length - callFrames.length,
+    heapUsage: null,
+    kind: "paused",
+    reason: data.reason,
+  };
+}
+
+async function readHeapUsage(
+  client: RendererHangDebuggerClient,
+): Promise<RendererHangHeapUsage | null> {
+  try {
+    const parsed = heapUsageSchema.safeParse(
+      await client.sendCommand("Runtime.getHeapUsage"),
+    );
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
+  }
+}
+
+interface CaptureRendererStackArgs {
+  client: RendererHangDebuggerClient;
+  timeoutMs: number;
+}
+
+async function captureRendererStack(
+  args: CaptureRendererStackArgs,
+): Promise<RendererHangCapture> {
+  const { client, timeoutMs } = args;
+  let step: RendererHangStep = "Debugger.enable";
+  let pausedCapture: RendererHangPausedCapture | null = null;
+  let removeListener = (): void => {};
+  let resolveTimedOut = (_capture: RendererHangCapture): void => {};
+
+  const paused = new Promise<unknown>((resolvePaused) => {
+    removeListener = client.onMessage((method, params) => {
+      if (method === "Debugger.paused") {
+        resolvePaused(params);
+      }
+    });
+  });
+  const timedOut = new Promise<RendererHangCapture>((resolve) => {
+    resolveTimedOut = resolve;
+  });
+  const timer = setTimeout(() => {
+    // The frames are the point of the capture: a pause that answered but a
+    // heap read that did not is still a capture, without the heap usage.
+    resolveTimedOut(pausedCapture ?? { kind: "timed-out", step, timeoutMs });
+  }, timeoutMs);
+
+  const run = async (): Promise<RendererHangCapture> => {
+    try {
+      await client.sendCommand("Debugger.enable");
+      step = "Debugger.pause";
+      await client.sendCommand("Debugger.pause");
+      step = "Debugger.paused";
+      const parsed = debuggerPausedSchema.safeParse(await paused);
+      if (!parsed.success) {
+        return {
+          error: `unrecognised Debugger.paused payload: ${parsed.error.message}`,
+          kind: "failed",
+          step,
+        };
+      }
+      pausedCapture = createPausedCapture(parsed.data);
+      step = "Runtime.getHeapUsage";
+      return { ...pausedCapture, heapUsage: await readHeapUsage(client) };
+    } catch (error) {
+      return { error: describeError(error), kind: "failed", step };
+    }
+  };
+
+  try {
+    return await Promise.race([run(), timedOut]);
+  } finally {
+    clearTimeout(timer);
+    removeListener();
+  }
+}
+
+function describeCapture(capture: RendererHangCapture): string {
+  switch (capture.kind) {
+    case "paused": {
+      const top = capture.callFrames[0];
+      const topFrame =
+        top === undefined
+          ? "no call frames"
+          : `top frame ${top.functionName || "(anonymous)"} at ${top.url}:${top.lineNumber}:${top.columnNumber ?? 0}`;
+      return `paused with ${capture.callFrames.length} call frames, ${topFrame}`;
+    }
+    case "timed-out":
+      return `no answer to ${capture.step} within ${capture.timeoutMs} ms`;
+    case "failed":
+      return `${capture.step} failed: ${capture.error}`;
+  }
+}
+
+function formatReportFileName(args: {
+  capturedAt: string;
+  windowId: number;
+}): string {
+  const timestamp = args.capturedAt.replace(/[:.]/g, "-");
+  return `renderer-hang-window-${args.windowId}-${timestamp}.json`;
+}
+
+function detachQuietly(client: RendererHangDebuggerClient): void {
+  try {
+    client.detach();
+  } catch {
+    // The target is already gone; there is nothing left to detach from.
+  }
+}
+
+function readRendererMemoryQuietly(
+  read: () => RendererHangProcessMemory | null,
+): RendererHangProcessMemory | null {
+  try {
+    return read();
+  } catch {
+    // The report is still worth writing without the memory numbers.
+    return null;
+  }
+}
+
+/**
+ * Pure core: attaches the debugger, breaks into the renderer, writes the
+ * report and always leaves the debugger detached. Never throws. The renderer
+ * is resumed by Debugger.resume (interrupt-safe) and by the detach itself,
+ * which disposes the inspector session; Debugger.disable is not sent because
+ * it is a main-thread message that a resumed loop would never answer.
+ */
+export async function captureRendererHangDiagnostic(
+  args: CaptureRendererHangDiagnosticArgs,
+): Promise<RendererHangDiagnosticResult> {
+  const { debuggerClient: client, logger } = args;
+  const label = `[desktop] renderer hang diagnostic for window ${args.window.id}`;
+  if (args.isWindowDestroyed()) {
+    return { kind: "skipped", reason: "window-destroyed" };
+  }
+
+  const rendererMemory = readRendererMemoryQuietly(args.readRendererMemory);
+  try {
+    client.attach(DEVTOOLS_PROTOCOL_VERSION);
+  } catch (error) {
+    logger.warn(
+      `${label}: could not attach the debugger: ${describeError(error)}`,
+    );
+    return { kind: "skipped", reason: "attach-failed" };
+  }
+
+  const capture = await captureRendererStack({
+    client,
+    timeoutMs: args.timeoutMs,
+  });
+  if (args.isWindowDestroyed()) {
+    detachQuietly(client);
+    logger.warn(`${label}: the window was destroyed during the capture`);
+    return { kind: "skipped", reason: "window-destroyed" };
+  }
+  if (capture.kind === "paused") {
+    client.sendCommand("Debugger.resume").catch(() => {
+      // Detaching below resumes the renderer as well.
+    });
+  }
+  detachQuietly(client);
+
+  const capturedAt = new Date(args.now()).toISOString();
+  const report: RendererHangReport = {
+    build: args.build,
+    capture,
+    capturedAt,
+    kind: "bb-desktop-renderer-hang",
+    rendererMemory,
+    window: args.window,
+  };
+  const path = join(
+    args.logDirectory,
+    formatReportFileName({ capturedAt, windowId: args.window.id }),
+  );
+  try {
+    await args.writeFile(path, `${JSON.stringify(report, null, 2)}\n`);
+  } catch (error) {
+    logger.warn(`${label}: could not write ${path}: ${describeError(error)}`);
+    return { kind: "skipped", reason: "write-failed" };
+  }
+  logger.warn(`${label}: wrote ${path} (${describeCapture(capture)})`);
+  return { kind: "written", path };
+}
+
+function createElectronDebuggerClient(
+  electronDebugger: Debugger,
+): RendererHangDebuggerClient {
+  return {
+    attach(protocolVersion) {
+      electronDebugger.attach(protocolVersion);
+    },
+    detach() {
+      electronDebugger.detach();
+    },
+    onMessage(listener) {
+      const handler = (
+        _event: unknown,
+        method: string,
+        params: unknown,
+      ): void => {
+        listener(method, params);
+      };
+      electronDebugger.on("message", handler);
+      return () => {
+        electronDebugger.off("message", handler);
+      };
+    },
+    sendCommand(method) {
+      return electronDebugger.sendCommand(method);
+    },
+  };
+}
+
+function readRendererProcessMemory(
+  rendererPid: number,
+): RendererHangProcessMemory | null {
+  const metric = app
+    .getAppMetrics()
+    .find((candidate) => candidate.pid === rendererPid);
+  if (metric === undefined) {
+    return null;
+  }
+  return {
+    peakWorkingSetSizeKb: metric.memory.peakWorkingSetSize,
+    workingSetSizeKb: metric.memory.workingSetSize,
+  };
+}
+
+async function writeReportFile(path: string, contents: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, contents, "utf8");
+}
+
+export interface RegisterRendererHangDiagnosticArgs {
+  browserWindow: BrowserWindow;
+  build: DesktopAboutFacts;
+  logDirectory: string;
+  logger: RendererHangDiagnosticLogger;
+}
+
+/**
+ * Electron wiring: one capture per hang, and never two on the same debugger at
+ * once. A single webContents.debugger session backs every capture, so a second
+ * capture started while the first is in flight would fail to attach ("Debugger
+ * is already attached"). "responsive" that lands mid-capture therefore only
+ * marks the window to re-arm when that capture finishes rather than opening the
+ * gate immediately; a renderer that stays hung is not paused again on every
+ * repeated "unresponsive", and a later, separate hang still gets its own
+ * report.
+ */
+export function registerRendererHangDiagnostic(
+  args: RegisterRendererHangDiagnosticArgs,
+): void {
+  const { browserWindow, logger } = args;
+  const { webContents } = browserWindow;
+  const debuggerClient = createElectronDebuggerClient(webContents.debugger);
+  let state: "armed" | "capturing" | "captured" = "armed";
+  let rearmAfterCapture = false;
+
+  browserWindow.on("unresponsive", () => {
+    if (state !== "armed" || webContents.isDestroyed()) {
+      return;
+    }
+    state = "capturing";
+    rearmAfterCapture = false;
+    const windowId = browserWindow.id;
+    const rendererPid = webContents.getOSProcessId();
+    void captureRendererHangDiagnostic({
+      build: args.build,
+      debuggerClient,
+      isWindowDestroyed: () => webContents.isDestroyed(),
+      logDirectory: args.logDirectory,
+      logger,
+      now: Date.now,
+      readRendererMemory: () => readRendererProcessMemory(rendererPid),
+      timeoutMs: RENDERER_HANG_DIAGNOSTIC_TIMEOUT_MS,
+      window: {
+        id: windowId,
+        rendererPid,
+        url: webContents.getURL(),
+        webContentsId: webContents.id,
+      },
+      writeFile: writeReportFile,
+    })
+      .catch((error: unknown) => {
+        logger.warn(
+          `[desktop] renderer hang diagnostic for window ${windowId} failed: ${describeError(error)}`,
+        );
+      })
+      .finally(() => {
+        state = rearmAfterCapture ? "armed" : "captured";
+        rearmAfterCapture = false;
+      });
+  });
+  browserWindow.on("responsive", () => {
+    if (state === "capturing") {
+      rearmAfterCapture = true;
+      return;
+    }
+    state = "armed";
+  });
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -161,6 +161,7 @@ import { registerDesktopBrowserIpc } from "./desktop-browser-main-ipc.js";
 import { parseDesktopSystemConfig } from "./desktop-system-config.js";
 import { ensurePackagedUserShellPath } from "./desktop-shell-path.js";
 import { resolveDesktopReloadShortcut } from "./desktop-reload-shortcut.js";
+import { registerRendererHangDiagnostic } from "./desktop-renderer-hang-diagnostic.js";
 import {
   createLogTailer,
   createLogLineBuffer,
@@ -2355,9 +2356,17 @@ async function runDesktopApp(): Promise<void> {
     );
   }
 
+  const buildFacts = readDesktopAboutFacts(applicationName);
   const browserWindowCreator: DesktopBrowserWindowCreator = {
     create(options) {
-      return new BrowserWindow(options);
+      const browserWindow = new BrowserWindow(options);
+      registerRendererHangDiagnostic({
+        browserWindow,
+        build: buildFacts,
+        logDirectory: formatLogDirectory(),
+        logger,
+      });
+      return browserWindow;
     },
   };
   logViewerPreloadPath = resolvedLogViewerPreloadPath;

--- a/apps/desktop/test/desktop-renderer-hang-diagnostic-wiring.test.ts
+++ b/apps/desktop/test/desktop-renderer-hang-diagnostic-wiring.test.ts
@@ -1,0 +1,225 @@
+import { EventEmitter } from "node:events";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { DesktopAboutFacts } from "../src/desktop-about-panel.js";
+import {
+  registerRendererHangDiagnostic,
+  RENDERER_HANG_DIAGNOSTIC_TIMEOUT_MS,
+  type RendererHangReport,
+} from "../src/desktop-renderer-hang-diagnostic.js";
+
+const RENDERER_PID = 4242;
+
+const fsState = vi.hoisted(() => ({
+  writes: [] as { contents: string; path: string }[],
+}));
+
+vi.mock("node:fs/promises", () => ({
+  async mkdir() {},
+  async writeFile(path: string, contents: string) {
+    fsState.writes.push({ contents, path });
+  },
+}));
+
+vi.mock("electron", () => ({
+  app: {
+    getAppMetrics: () => [
+      {
+        memory: { peakWorkingSetSize: 200, workingSetSize: 100 },
+        pid: RENDERER_PID,
+      },
+    ],
+  },
+}));
+
+const BUILD: DesktopAboutFacts = {
+  applicationName: "bb",
+  buildDate: "2026-08-24T20:00:00.000Z",
+  channel: "latest",
+  commit: "b33abbff098ac4c857578e7350d492dcaa65d489",
+  electronVersion: "41.7.0",
+  osArch: "arm64",
+  osRelease: "25.0.0",
+  osType: "Darwin",
+  platform: "darwin",
+  pluginSdkVersion: "0.39.0",
+  version: "0.39.0",
+};
+
+function pausedParams(): unknown {
+  return {
+    callFrames: [
+      {
+        functionName: "spin",
+        location: { columnNumber: 4, lineNumber: 1 },
+        url: "http://127.0.0.1/assets/index.js",
+      },
+    ],
+    reason: "other",
+  };
+}
+
+class FakeDebugger extends EventEmitter {
+  /** Every attach call, including one that throws because it is a re-attach. */
+  attachAttempts = 0;
+  attachCount = 0;
+  detachCount = 0;
+  emitPausedOnPause = true;
+  /** Models a pinned main thread: Debugger.enable is never processed. */
+  stallEnable = false;
+  private attached = false;
+
+  attach(_protocolVersion: string): void {
+    this.attachAttempts += 1;
+    if (this.attached) {
+      throw new Error("Debugger is already attached to the target");
+    }
+    this.attached = true;
+    this.attachCount += 1;
+  }
+
+  detach(): void {
+    this.attached = false;
+    this.detachCount += 1;
+  }
+
+  sendCommand(method: string): Promise<unknown> {
+    switch (method) {
+      case "Debugger.enable":
+        return this.stallEnable ? new Promise(() => {}) : Promise.resolve({});
+      case "Debugger.pause":
+        if (this.emitPausedOnPause) {
+          queueMicrotask(() => {
+            this.emit("message", {}, "Debugger.paused", pausedParams());
+          });
+        }
+        return Promise.resolve({});
+      case "Runtime.getHeapUsage":
+        return Promise.resolve({ totalSize: 1, usedSize: 1 });
+      case "Debugger.resume":
+        return Promise.resolve({});
+      default:
+        return Promise.reject(new Error(`unexpected command ${method}`));
+    }
+  }
+}
+
+class FakeWindow extends EventEmitter {
+  readonly id = 3;
+  readonly webContents: {
+    debugger: FakeDebugger;
+    getOSProcessId(): number;
+    getURL(): string;
+    id: number;
+    isDestroyed(): boolean;
+  };
+
+  constructor(readonly dbg: FakeDebugger) {
+    super();
+    this.webContents = {
+      debugger: dbg,
+      getOSProcessId: () => RENDERER_PID,
+      getURL: () => "http://127.0.0.1/thread",
+      id: 9,
+      isDestroyed: () => false,
+    };
+  }
+}
+
+function register(win: FakeWindow): void {
+  registerRendererHangDiagnostic({
+    // The fake matches the shape the wiring reads; the Electron types are wider.
+    browserWindow: win as never,
+    build: BUILD,
+    logDirectory: "/logs",
+    logger: { warn() {} },
+  });
+}
+
+/** Drains the capture's promise chain without advancing the deadline timer. */
+async function settle(): Promise<void> {
+  for (let i = 0; i < 12; i += 1) {
+    await vi.advanceTimersByTimeAsync(0);
+  }
+}
+
+describe("registerRendererHangDiagnostic", () => {
+  afterEach(() => {
+    fsState.writes.length = 0;
+    vi.useRealTimers();
+  });
+
+  it("captures once per hang and re-arms only after 'responsive'", async () => {
+    vi.useFakeTimers();
+    const dbg = new FakeDebugger();
+    const win = new FakeWindow(dbg);
+    register(win);
+
+    win.emit("unresponsive");
+    await settle();
+    expect(dbg.attachCount).toBe(1);
+    expect(dbg.detachCount).toBe(1);
+    expect(fsState.writes).toHaveLength(1);
+
+    // A renderer that stays hung fires "unresponsive" again; without a
+    // "responsive" in between it must not be captured a second time.
+    win.emit("unresponsive");
+    await settle();
+    expect(dbg.attachCount).toBe(1);
+    expect(fsState.writes).toHaveLength(1);
+
+    // A fresh hang after the window recovered gets its own capture.
+    vi.advanceTimersByTime(5);
+    win.emit("responsive");
+    win.emit("unresponsive");
+    await settle();
+    expect(dbg.attachCount).toBe(2);
+    expect(dbg.detachCount).toBe(2);
+    expect(fsState.writes).toHaveLength(2);
+  });
+
+  it("ignores 'unresponsive' during an in-flight capture and re-arms when it finishes", async () => {
+    vi.useFakeTimers();
+    const dbg = new FakeDebugger();
+    // The renderer's main thread is pinned, so Debugger.enable is never
+    // processed and capture 1 stays in flight until the deadline.
+    dbg.stallEnable = true;
+    const win = new FakeWindow(dbg);
+    register(win);
+
+    win.emit("unresponsive");
+    await settle();
+    expect(dbg.attachCount).toBe(1);
+    expect(fsState.writes).toHaveLength(0);
+
+    // "responsive" then "unresponsive" while capture 1 is still running must not
+    // even attempt a second attach on the same (already attached) session.
+    win.emit("responsive");
+    win.emit("unresponsive");
+    await settle();
+    expect(dbg.attachAttempts).toBe(1);
+    expect(dbg.attachCount).toBe(1);
+    expect(fsState.writes).toHaveLength(0);
+
+    // Capture 1 hits its deadline, writes a timed-out report and detaches; the
+    // "responsive" seen mid-capture then re-arms the window.
+    await vi.advanceTimersByTimeAsync(RENDERER_HANG_DIAGNOSTIC_TIMEOUT_MS);
+    expect(fsState.writes).toHaveLength(1);
+    expect(dbg.detachCount).toBe(1);
+    const [firstWrite] = fsState.writes;
+    if (firstWrite === undefined) {
+      throw new Error("expected a report to be written");
+    }
+    const report = JSON.parse(firstWrite.contents) as RendererHangReport;
+    expect(report.capture).toEqual({
+      kind: "timed-out",
+      step: "Debugger.enable",
+      timeoutMs: RENDERER_HANG_DIAGNOSTIC_TIMEOUT_MS,
+    });
+
+    dbg.stallEnable = false;
+    win.emit("unresponsive");
+    await settle();
+    expect(dbg.attachCount).toBe(2);
+    expect(fsState.writes).toHaveLength(2);
+  });
+});

--- a/apps/desktop/test/desktop-renderer-hang-diagnostic.test.ts
+++ b/apps/desktop/test/desktop-renderer-hang-diagnostic.test.ts
@@ -1,0 +1,448 @@
+import { describe, expect, it, vi } from "vitest";
+import type { DesktopAboutFacts } from "../src/desktop-about-panel.js";
+import {
+  captureRendererHangDiagnostic,
+  RENDERER_HANG_DIAGNOSTIC_MAX_CALL_FRAMES,
+  RENDERER_HANG_DIAGNOSTIC_TIMEOUT_MS,
+  type CaptureRendererHangDiagnosticArgs,
+  type RendererHangDebuggerClient,
+  type RendererHangReport,
+} from "../src/desktop-renderer-hang-diagnostic.js";
+
+type FakeCommandHandler = (
+  method: string,
+  client: FakeDebuggerClient,
+) => Promise<unknown>;
+
+class FakeDebuggerClient implements RendererHangDebuggerClient {
+  readonly attachedProtocolVersions: string[] = [];
+  readonly commands: string[] = [];
+  /** Ordered log of every send and detach, for pinning their relative order. */
+  readonly events: string[] = [];
+  detachCount = 0;
+  private readonly listeners = new Set<
+    (method: string, params: unknown) => void
+  >();
+
+  constructor(private readonly handleCommand: FakeCommandHandler) {}
+
+  attach(protocolVersion: string): void {
+    this.attachedProtocolVersions.push(protocolVersion);
+  }
+
+  detach(): void {
+    this.detachCount += 1;
+    this.events.push("detach");
+  }
+
+  emit(method: string, params: unknown): void {
+    for (const listener of this.listeners) {
+      listener(method, params);
+    }
+  }
+
+  get listenerCount(): number {
+    return this.listeners.size;
+  }
+
+  onMessage(listener: (method: string, params: unknown) => void): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  sendCommand(method: string): Promise<unknown> {
+    this.commands.push(method);
+    this.events.push(method);
+    return this.handleCommand(method, this);
+  }
+}
+
+const BUILD: DesktopAboutFacts = {
+  applicationName: "bb",
+  buildDate: "2026-08-24T20:00:00.000Z",
+  channel: "latest",
+  commit: "b33abbff098ac4c857578e7350d492dcaa65d489",
+  electronVersion: "41.7.0",
+  osArch: "arm64",
+  osRelease: "25.0.0",
+  osType: "Darwin",
+  platform: "darwin",
+  pluginSdkVersion: "0.39.0",
+  version: "0.39.0",
+};
+const WINDOW = {
+  id: 7,
+  rendererPid: 55035,
+  url: "http://127.0.0.1:38886/projects/proj_ivbg7bbvgw/threads/thr_n9sh8rhz6t",
+  webContentsId: 3,
+};
+const MEMORY = {
+  peakWorkingSetSizeKb: 11_000_000,
+  workingSetSizeKb: 10_500_000,
+};
+const NOW_MS = Date.parse("2026-08-25T04:02:13.250Z");
+const EXPECTED_PATH =
+  "/home/dan/.bb/logs/renderer-hang-window-7-2026-08-25T04-02-13-250Z.json";
+const SCRIPT_URL = "http://127.0.0.1:38886/assets/index-C3k9Zx.js";
+
+function createPausedParams(frameCount: number): unknown {
+  return {
+    callFrames: Array.from({ length: frameCount }, (_, index) => ({
+      callFrameId: `{"ordinal":${index},"injectedScriptId":1}`,
+      functionName: index === 0 ? "measureInlineEditorMaxHeight" : `f${index}`,
+      location: { columnNumber: index * 10, lineNumber: index, scriptId: "12" },
+      scopeChain: [],
+      this: { type: "undefined" },
+      url: SCRIPT_URL,
+    })),
+    hitBreakpoints: [],
+    reason: "other",
+  };
+}
+
+const never = (): Promise<unknown> => new Promise(() => {});
+
+function pausingHandler(
+  overrides: Partial<Record<string, FakeCommandHandler>> = {},
+): FakeCommandHandler {
+  return async (method, client) => {
+    const override = overrides[method];
+    if (override !== undefined) {
+      return await override(method, client);
+    }
+    switch (method) {
+      case "Debugger.enable":
+        return { debuggerId: "(ABCDEF)" };
+      case "Debugger.pause":
+        // The response comes first, then the paused event, like the protocol.
+        queueMicrotask(() => {
+          client.emit("Debugger.scriptParsed", { scriptId: "13" });
+          client.emit("Debugger.paused", createPausedParams(3));
+        });
+        return {};
+      case "Runtime.getHeapUsage":
+        return {
+          backingStorageSize: 4096,
+          totalSize: 10_200_000_000,
+          usedSize: 9_800_000_000,
+        };
+      case "Debugger.resume":
+        return {};
+      default:
+        throw new Error(`unexpected command ${method}`);
+    }
+  };
+}
+
+interface Harness {
+  args: CaptureRendererHangDiagnosticArgs;
+  client: FakeDebuggerClient;
+  files: Map<string, string>;
+  warnings: string[];
+}
+
+function createHarness(
+  client: FakeDebuggerClient,
+  overrides: Partial<CaptureRendererHangDiagnosticArgs> = {},
+): Harness {
+  const files = new Map<string, string>();
+  const warnings: string[] = [];
+  return {
+    args: {
+      build: BUILD,
+      debuggerClient: client,
+      isWindowDestroyed: () => false,
+      logDirectory: "/home/dan/.bb/logs",
+      logger: {
+        warn(message) {
+          warnings.push(message);
+        },
+      },
+      now: () => NOW_MS,
+      readRendererMemory: () => MEMORY,
+      timeoutMs: RENDERER_HANG_DIAGNOSTIC_TIMEOUT_MS,
+      window: WINDOW,
+      async writeFile(path, contents) {
+        files.set(path, contents);
+      },
+      ...overrides,
+    },
+    client,
+    files,
+    warnings,
+  };
+}
+
+function readReport(files: Map<string, string>): RendererHangReport {
+  const contents = files.get(EXPECTED_PATH);
+  if (contents === undefined) {
+    throw new Error(`expected a report at ${EXPECTED_PATH}`);
+  }
+  return JSON.parse(contents) as RendererHangReport;
+}
+
+describe("captureRendererHangDiagnostic", () => {
+  it("writes the paused call frames, heap usage, memory and build identity, then resumes and detaches", async () => {
+    const frameCount = RENDERER_HANG_DIAGNOSTIC_MAX_CALL_FRAMES + 6;
+    const client = new FakeDebuggerClient(
+      pausingHandler({
+        "Debugger.pause": async (_method, pausingClient) => {
+          queueMicrotask(() => {
+            pausingClient.emit(
+              "Debugger.paused",
+              createPausedParams(frameCount),
+            );
+          });
+          return {};
+        },
+      }),
+    );
+    const harness = createHarness(client);
+
+    const result = await captureRendererHangDiagnostic(harness.args);
+
+    expect(result).toEqual({ kind: "written", path: EXPECTED_PATH });
+    expect([...harness.files.keys()]).toEqual([EXPECTED_PATH]);
+    const report = readReport(harness.files);
+    expect(report).toEqual({
+      build: BUILD,
+      capture: {
+        callFrames: expect.any(Array),
+        droppedCallFrames: 6,
+        heapUsage: { totalSize: 10_200_000_000, usedSize: 9_800_000_000 },
+        kind: "paused",
+        reason: "other",
+      },
+      capturedAt: "2026-08-25T04:02:13.250Z",
+      kind: "bb-desktop-renderer-hang",
+      rendererMemory: MEMORY,
+      window: WINDOW,
+    });
+    if (report.capture.kind !== "paused") {
+      throw new Error("expected a paused capture");
+    }
+    expect(report.capture.callFrames).toHaveLength(
+      RENDERER_HANG_DIAGNOSTIC_MAX_CALL_FRAMES,
+    );
+    expect(report.capture.callFrames[0]).toEqual({
+      columnNumber: 0,
+      functionName: "measureInlineEditorMaxHeight",
+      lineNumber: 0,
+      url: SCRIPT_URL,
+    });
+    expect(report.capture.callFrames[1]).toEqual({
+      columnNumber: 10,
+      functionName: "f1",
+      lineNumber: 1,
+      url: SCRIPT_URL,
+    });
+
+    expect(client.attachedProtocolVersions).toEqual(["1.3"]);
+    expect(client.commands).toEqual([
+      "Debugger.enable",
+      "Debugger.pause",
+      "Runtime.getHeapUsage",
+      "Debugger.resume",
+    ]);
+    expect(client.detachCount).toBe(1);
+    expect(client.listenerCount).toBe(0);
+    // The renderer must be resumed before the session is detached: detach on a
+    // still-paused session is a deliberate part of the design, so pin the order.
+    expect(client.events).toEqual([
+      "Debugger.enable",
+      "Debugger.pause",
+      "Runtime.getHeapUsage",
+      "Debugger.resume",
+      "detach",
+    ]);
+    expect(harness.warnings).toEqual([
+      `[desktop] renderer hang diagnostic for window 7: wrote ${EXPECTED_PATH} (paused with 64 call frames, top frame measureInlineEditorMaxHeight at ${SCRIPT_URL}:0:0)`,
+    ]);
+  });
+
+  it("logs and skips when the debugger cannot attach", async () => {
+    const client = new FakeDebuggerClient(pausingHandler());
+    client.attach = () => {
+      throw new Error("Debugger is already attached to the webContents");
+    };
+    const harness = createHarness(client);
+
+    const result = await captureRendererHangDiagnostic(harness.args);
+
+    expect(result).toEqual({ kind: "skipped", reason: "attach-failed" });
+    expect(harness.files.size).toBe(0);
+    expect(client.commands).toEqual([]);
+    expect(client.detachCount).toBe(0);
+    expect(harness.warnings).toEqual([
+      "[desktop] renderer hang diagnostic for window 7: could not attach the debugger: Debugger is already attached to the webContents",
+    ]);
+  });
+
+  it.each([
+    {
+      commands: ["Debugger.enable"],
+      overrides: { "Debugger.enable": never },
+      scenario: "the renderer never processes Debugger.enable",
+      step: "Debugger.enable",
+    },
+    {
+      commands: ["Debugger.enable", "Debugger.pause"],
+      overrides: { "Debugger.pause": never },
+      scenario: "the renderer never acknowledges Debugger.pause",
+      step: "Debugger.pause",
+    },
+    {
+      commands: ["Debugger.enable", "Debugger.pause"],
+      overrides: { "Debugger.pause": async () => ({}) },
+      scenario: "the pause is acknowledged but Debugger.paused never arrives",
+      step: "Debugger.paused",
+    },
+  ])(
+    "records the unanswered step and detaches when $scenario",
+    async ({ commands, overrides, step }) => {
+      vi.useFakeTimers();
+      try {
+        const client = new FakeDebuggerClient(pausingHandler(overrides));
+        const harness = createHarness(client);
+
+        const resultPromise = captureRendererHangDiagnostic(harness.args);
+        await vi.advanceTimersByTimeAsync(
+          RENDERER_HANG_DIAGNOSTIC_TIMEOUT_MS - 1,
+        );
+        expect(harness.files.size).toBe(0);
+        expect(client.detachCount).toBe(0);
+        await vi.advanceTimersByTimeAsync(1);
+        const result = await resultPromise;
+
+        expect(result).toEqual({ kind: "written", path: EXPECTED_PATH });
+        expect(readReport(harness.files).capture).toEqual({
+          kind: "timed-out",
+          step,
+          timeoutMs: RENDERER_HANG_DIAGNOSTIC_TIMEOUT_MS,
+        });
+        expect(client.commands).toEqual(commands);
+        expect(client.detachCount).toBe(1);
+        expect(client.listenerCount).toBe(0);
+        expect(harness.warnings).toEqual([
+          `[desktop] renderer hang diagnostic for window 7: wrote ${EXPECTED_PATH} (no answer to ${step} within ${RENDERER_HANG_DIAGNOSTIC_TIMEOUT_MS} ms)`,
+        ]);
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it("keeps the call frames when the heap usage read does not answer in time", async () => {
+    vi.useFakeTimers();
+    try {
+      const client = new FakeDebuggerClient(
+        pausingHandler({ "Runtime.getHeapUsage": never }),
+      );
+      const harness = createHarness(client);
+
+      const resultPromise = captureRendererHangDiagnostic(harness.args);
+      await vi.advanceTimersByTimeAsync(RENDERER_HANG_DIAGNOSTIC_TIMEOUT_MS);
+      const result = await resultPromise;
+
+      expect(result).toEqual({ kind: "written", path: EXPECTED_PATH });
+      const report = readReport(harness.files);
+      expect(report.capture).toEqual({
+        callFrames: expect.any(Array),
+        droppedCallFrames: 0,
+        heapUsage: null,
+        kind: "paused",
+        reason: "other",
+      });
+      if (report.capture.kind !== "paused") {
+        throw new Error("expected a paused capture");
+      }
+      expect(report.capture.callFrames).toHaveLength(3);
+      expect(client.commands).toEqual([
+        "Debugger.enable",
+        "Debugger.pause",
+        "Runtime.getHeapUsage",
+        "Debugger.resume",
+      ]);
+      expect(client.detachCount).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("skips the report and detaches when the window is destroyed mid-capture", async () => {
+    let destroyed = false;
+    const client = new FakeDebuggerClient(
+      pausingHandler({
+        "Debugger.pause": async () => {
+          destroyed = true;
+          throw new Error("target closed while handling command");
+        },
+      }),
+    );
+    const harness = createHarness(client, {
+      isWindowDestroyed: () => destroyed,
+    });
+
+    const result = await captureRendererHangDiagnostic(harness.args);
+
+    expect(result).toEqual({ kind: "skipped", reason: "window-destroyed" });
+    expect(harness.files.size).toBe(0);
+    expect(client.commands).toEqual(["Debugger.enable", "Debugger.pause"]);
+    expect(client.detachCount).toBe(1);
+    expect(client.listenerCount).toBe(0);
+    expect(harness.warnings).toEqual([
+      "[desktop] renderer hang diagnostic for window 7: the window was destroyed during the capture",
+    ]);
+  });
+
+  it("records a failed capture without resuming when a command rejects while the window is alive", async () => {
+    const client = new FakeDebuggerClient(
+      pausingHandler({
+        "Debugger.pause": async () => {
+          throw new Error("Debugger agent is not enabled");
+        },
+      }),
+    );
+    const harness = createHarness(client);
+
+    const result = await captureRendererHangDiagnostic(harness.args);
+
+    expect(result).toEqual({ kind: "written", path: EXPECTED_PATH });
+    expect(readReport(harness.files).capture).toEqual({
+      error: "Debugger agent is not enabled",
+      kind: "failed",
+      step: "Debugger.pause",
+    });
+    // A failed capture never paused the renderer, so it must not send resume.
+    expect(client.commands).toEqual(["Debugger.enable", "Debugger.pause"]);
+    expect(client.events).toEqual([
+      "Debugger.enable",
+      "Debugger.pause",
+      "detach",
+    ]);
+    expect(client.detachCount).toBe(1);
+    expect(client.listenerCount).toBe(0);
+    expect(harness.warnings).toEqual([
+      `[desktop] renderer hang diagnostic for window 7: wrote ${EXPECTED_PATH} (Debugger.pause failed: Debugger agent is not enabled)`,
+    ]);
+  });
+
+  it("logs and skips when the report cannot be written", async () => {
+    const client = new FakeDebuggerClient(pausingHandler());
+    const harness = createHarness(client, {
+      async writeFile() {
+        throw new Error("EACCES: permission denied");
+      },
+    });
+
+    const result = await captureRendererHangDiagnostic(harness.args);
+
+    expect(result).toEqual({ kind: "skipped", reason: "write-failed" });
+    expect(client.detachCount).toBe(1);
+    expect(harness.warnings).toEqual([
+      `[desktop] renderer hang diagnostic for window 7: could not write ${EXPECTED_PATH}: EACCES: permission denied`,
+    ]);
+  });
+});


### PR DESCRIPTION
## Human comments

## What was wrong

#2401 reports the desktop renderer locking at ~100% CPU with RSS past 10 GiB after clicking **Edit** on a queued message during an active turn; Cmd+R does not recover, Force Reload does. Both macOS process samples bottom out in V8 microtask execution and do not name the application callback.

**This PR does not fix that hang and must not close the issue** (it uses `Refs`). Two independent investigations and four verification passes audited the Edit path and concluded the root cause is not attributable from the report: every `MutationObserver`, `queueMicrotask`, and Promise site reachable from Edit is one-shot or rAF-coalesced; `getInlineEditorSurfaceMaxHeight` has a fixed point in every host because the footer is sticky inside the timeline scroll area; and a `ResizeObserver` loop is delivered once per frame and loop-limited by the browser, so the reported lead cannot pin the main thread in microtask execution or block Cmd+R. The remaining suspects are content- or plugin-dependent code (a plugin composer slot notifying a store from a microtask would present exactly as reported, since React 19.2's nested-update guard does not count a cascade re-entered via a microtask) or Chromium itself.

## What changed

Two commits:

1. `fix(app): defer queued-editor measurement out of the ResizeObserver callback` — hardening of the reported lead in `QueuedMessagesList.tsx`. The observer and window-resize callbacks now only schedule one pending `requestAnimationFrame`; the layout reads, two state writes, and scroll realignment run at most once per frame and never from inside the observer callback. Cost: one frame of latency during the 260 ms open animation. The typeahead reservation in `QueuedMessageInlineEditorSlot` bails out of a re-render when the reported layout is unchanged.
2. `feat(desktop): capture a renderer stack when a window becomes unresponsive` — new `apps/desktop/src/desktop-renderer-hang-diagnostic.ts`. On BrowserWindow `unresponsive` (once per hang, re-armed on `responsive`) the main process attaches `webContents.debugger`, sends `Debugger.enable` + `Debugger.pause`, and writes the top 64 call frames, `Runtime.getHeapUsage`, the renderer working set, and the build identity to `renderer-hang-window-<id>-<timestamp>.json` in the desktop log directory, then resumes and detaches. One 5 s deadline; attach failure, destroyed window, and write failure are logged and swallowed.

**Owner decision requested on commit 2.** Live probes on the pinned Electron 41.7.0 (Xvfb) show the capture yields a stack only for a hang that still yields between tasks. For a never-yielding loop (the #2401 class), `Debugger.enable` never answers — and with the domain pre-enabled, `Debugger.pause` is acked but `Debugger.paused` never arrives — so the report records "timed out at `Debugger.enable`" plus the working set. Chromium also suppresses `unresponsive` while any CDP client (including DevTools) is attached, so a pre-armed session is not an alternative. The README and module doc state this limitation. If a stack for a pinned renderer is required, the remaining levers are non-cooperative (`webContents.forcefullyCrashRenderer()` + crashReporter, or the macOS sample the reporter already provides); say the word and I will drop commit 2 from this PR.

Reporter follow-up needed to attribute the hang: `bb plugin list --json`, the leaf frames under the microtask runner in `/tmp/bb-renderer-hang.txt` and `/tmp/bb-renderer-55035.sample`, whether rich-text editing is enabled, and whether macOS Reduce Motion is on.

## How you verified

- `QueuedMessagesList.test.tsx`: "measures once, on the next frame, when the observer delivers and the window resizes together" models one frame as the browser delivers it and fails on the previous component (`expected 2 to be +0`); the ResizeObserver stub was fixed to notify every live observer.
- `desktop-renderer-hang-diagnostic.test.ts` (9 tests) drives the pure core with a fake debugger client: paused delivery with frame truncation, attach failure, timeouts at `Debugger.enable`/`Debugger.pause`/`Debugger.paused`, stalled heap read, failed command, window destroyed mid-capture, write failure, resume-before-detach order, detach exactly once. `desktop-renderer-hang-diagnostic-wiring.test.ts` covers once-per-hang, re-arm on `responsive`, and no overlapping capture.
- Commands on the rebased tip: `pnpm exec turbo run typecheck --filter=@bb/app --filter=@bb/desktop --force` and `pnpm exec turbo run test --filter=@bb/app --filter=@bb/desktop --force`: green (app 431 files / 3357 tests; desktop 37 files / 242 tests). EAP codename scan of `origin/main..HEAD`: clean.

Refs #2401

> AGENT GENERATED
