### PR TITLE
fix: park input the provider is too busy to take instead of failing the run

### DIFF
--- a/apps/cli/src/commands/thread/actions.ts
+++ b/apps/cli/src/commands/thread/actions.ts
@@ -425,7 +425,10 @@ export function registerActionsCommands(
       "Reasoning level: low, medium, high, xhigh, max (provider-dependent)",
     )
     .option("--permission-mode <mode>", PERMISSION_MODE_HELP)
-    .option("--mode <mode>", "Message mode: steer (default), queue, or auto")
+    .option(
+      "--mode <mode>",
+      "Message mode: steer (default), queue, or auto (steer a live turn, else start one)",
+    )
     .option("--plan", PLAN_HELP)
     .option(
       "--file <path>",

--- a/apps/host-daemon/src/command-dispatch-support.ts
+++ b/apps/host-daemon/src/command-dispatch-support.ts
@@ -1,15 +1,19 @@
-import type { AgentRuntimeBridgeLaunch } from "@bb/agent-runtime";
+import type {
+  AgentRuntimeBridgeLaunch,
+  AgentRuntimeTurnBusyError,
+} from "@bb/agent-runtime";
 import type { AvailableModel } from "@bb/domain";
 import type { EventSinkInput } from "./event-sink.js";
-import type {
-  HostDaemonCommand,
-  ProviderHealthResult,
-  ProviderUsageResult,
-  HostDaemonBridgeLaunch,
-  HostDaemonInjectedSkillSource,
-  HostDaemonOnlineRpcCommand,
-  HostDaemonConnectTunnelIdentity,
-  WorkspaceContext,
+import {
+  THREAD_TURN_BUSY_ERROR_CODE,
+  type HostDaemonCommand,
+  type ProviderHealthResult,
+  type ProviderUsageResult,
+  type HostDaemonBridgeLaunch,
+  type HostDaemonInjectedSkillSource,
+  type HostDaemonOnlineRpcCommand,
+  type HostDaemonConnectTunnelIdentity,
+  type WorkspaceContext,
 } from "@bb/host-daemon-contract";
 import type {
   ProviderInstallationCommand,
@@ -130,9 +134,15 @@ export function isExpectedCommandDispatchError(
   return error instanceof ExpectedCommandDispatchError;
 }
 
-const EXPECTED_ONLINE_RPC_FAILURE_CODES = new Set([
+const EXPECTED_ONLINE_RPC_FAILURE_CODES = new Set<string>([
   "file_too_large",
   "provision_cancelled",
+  // A turn submission the thread could not take: the shared runtime refused
+  // a competing start (`AgentRuntimeTurnBusyError`) or the bridge answered
+  // TURN_BUSY. The live turn is fine and the server parks the input. The
+  // runtime's error code is what reaches the wire, so it must be the
+  // contract's string.
+  THREAD_TURN_BUSY_ERROR_CODE satisfies AgentRuntimeTurnBusyError["code"],
 ]);
 
 export function isExpectedOnlineRpcFailureError(error: unknown): boolean {

--- a/apps/host-daemon/src/command-dispatch.test.ts
+++ b/apps/host-daemon/src/command-dispatch.test.ts
@@ -22,7 +22,10 @@ import {
   fetchDispatchTestArtifact,
   unexpectedProviderMaintenance,
 } from "../test/command/dispatch-helpers.js";
-import type { CommandOf } from "./command-dispatch-support.js";
+import {
+  isExpectedOnlineRpcFailureError,
+  type CommandOf,
+} from "./command-dispatch-support.js";
 import { RuntimeManager } from "./runtime-manager.js";
 
 const WORKSPACE_PATH = "/tmp/bb-command-dispatch-test";
@@ -581,10 +584,57 @@ describe("dispatchCommand", () => {
           threadStorageRootPath: "/tmp/bb-thread-storage",
         },
       ),
-    ).rejects.toThrow(
-      "Refusing to start a competing turn while thread-1 is still starting",
-    );
+    ).rejects.toMatchObject({
+      code: "thread_turn_busy",
+      message:
+        "Refusing to start a competing turn while thread-1 is still starting",
+    });
     expect(runtime.runTurn).not.toHaveBeenCalled();
+    expect(runtime.steerTurn).not.toHaveBeenCalled();
+  });
+
+  it("reports a runtime turn admission refusal as an expected thread_turn_busy failure", async () => {
+    const runtime = createRuntime();
+    const manager = new RuntimeManager({
+      createRuntime: () => runtime,
+      provisionWorkspace: async () => createWorkspace(),
+    });
+    await manager.ensureEnvironment({
+      environmentId: "env-1",
+      workspacePath: WORKSPACE_PATH,
+    });
+    runtime.setIdle("thread-1");
+    // The shared runtime refuses a competing start with its typed busy code
+    // (a turn is active or starting on the thread, or the bridge answered
+    // TURN_BUSY). The daemon must pass the code through unchanged and treat
+    // the failure as expected: the server keeps the thread active and
+    // re-queues the input, so nothing here warrants a warning.
+    const busy = Object.assign(
+      new Error(
+        'Refusing to start a competing turn for thread "thread-1" while another turn is active or starting',
+      ),
+      { code: "thread_turn_busy" },
+    );
+    vi.mocked(runtime.runTurn).mockRejectedValueOnce(busy);
+
+    let caught: unknown;
+    try {
+      await dispatchCommand(createTurnSubmitCommand({ mode: "start" }), {
+        dataDir: "/tmp/bb-data",
+        logger: silentLogger,
+        eventSink: { emit: vi.fn(), flush: vi.fn(async () => undefined) },
+        fetchProjectAttachment: async () => {
+          throw new Error("Unexpected project attachment fetch");
+        },
+        ...unexpectedProviderMaintenance,
+        runtimeManager: manager,
+        threadStorageRootPath: "/tmp/bb-thread-storage",
+      });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toMatchObject({ code: "thread_turn_busy" });
+    expect(isExpectedOnlineRpcFailureError(caught)).toBe(true);
     expect(runtime.steerTurn).not.toHaveBeenCalled();
   });
 

--- a/apps/host-daemon/src/command-handlers/thread.ts
+++ b/apps/host-daemon/src/command-handlers/thread.ts
@@ -1,6 +1,9 @@
 import fs from "node:fs/promises";
 import type { PromptInput } from "@bb/domain";
-import type { HostDaemonCommandResult } from "@bb/host-daemon-contract";
+import {
+  THREAD_TURN_BUSY_ERROR_CODE,
+  type HostDaemonCommandResult,
+} from "@bb/host-daemon-contract";
 import { resolveContainedPath } from "@bb/process-utils";
 import type { RuntimeEntry } from "../runtime-manager.js";
 import {
@@ -448,7 +451,10 @@ async function resolveLiveSubmittedTurnTarget(
     return refreshedTurnId;
   }
   if (entry.runtime.getLiveThreadIds().includes(command.threadId)) {
-    throw new Error(
+    // Typed so the server keeps the thread active and parks the input
+    // instead of failing the run that is still starting (#2370).
+    throw new ExpectedCommandDispatchError(
+      THREAD_TURN_BUSY_ERROR_CODE,
       `Refusing to start a competing turn while ${command.threadId} is still starting`,
     );
   }

--- a/apps/server/src/services/hosts/live-command.ts
+++ b/apps/server/src/services/hosts/live-command.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import {
+  THREAD_TURN_BUSY_ERROR_CODE,
   type HostDaemonCommand,
   type HostDaemonCommandResult,
   type HostDaemonSettledCommandType,
@@ -94,7 +95,12 @@ interface LiveHostCommandBaseLogFields {
   threadId?: string;
 }
 
-const EXPECTED_LIVE_HOST_COMMAND_ERROR_CODES = new Set(["provision_cancelled"]);
+const EXPECTED_LIVE_HOST_COMMAND_ERROR_CODES = new Set<string>([
+  "provision_cancelled",
+  // The daemon could not take a turn submission because the thread's turn is
+  // still live; the dispatcher parks the input (thread-turn-busy.ts).
+  THREAD_TURN_BUSY_ERROR_CODE,
+]);
 
 function commandFailureCode(error: Error): string {
   if (error instanceof ApiError) {
@@ -278,18 +284,31 @@ export function startLiveHostCommand<
       };
       const expectedErrorFields =
         expectedLiveHostCommandErrorLogFields(normalized);
-      if (expectedErrorFields !== null) {
-        deps.logger.debug(
+      // A handler that throws (the busy re-queue writes to the database)
+      // must not turn a settled failure into an unhandled rejection.
+      try {
+        if (expectedErrorFields !== null) {
+          deps.logger.debug(
+            {
+              ...liveHostCommandBaseLogFields(handlerArgs),
+              ...expectedErrorFields,
+            },
+            "Expected live host command failure",
+          );
+          args.onExpectedError?.(handlerArgs);
+          return;
+        }
+        args.onError?.(handlerArgs);
+      } catch (handlerError) {
+        deps.logger.error(
           {
+            err: handlerError,
             ...liveHostCommandBaseLogFields(handlerArgs),
-            ...expectedErrorFields,
+            originalError: normalized,
           },
-          "Expected live host command failure",
+          "Live command failure handler failed",
         );
-        args.onExpectedError?.(handlerArgs);
-        return;
       }
-      args.onError?.(handlerArgs);
     })
     .finally(async () => {
       try {

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
@@ -406,6 +406,10 @@ or artifacts, validation performed, and blockers.
   agent can finish its current work first. Steer is especially important for a
   wrong direction, hard stop, or critical clarification.
   Example: `bb thread tell <thread-id> "Stop and use approach B" --mode steer`.
+  `--mode auto` steers a live turn and starts a new one on an idle thread.
+- If the provider cannot take a message mid-run (for example while it compacts
+  its context), the message is not lost and the thread does not fail: it moves
+  to the thread's queue and delivers after the live turn. Do not resend.
 - If the target thread is awaiting user interaction (an open question or
   approval), `bb thread tell` cannot interrupt it. The message is held and
   delivers in the requested mode once the interaction settles; the CLI prints

--- a/apps/server/src/services/threads/deferred-thread-messages.ts
+++ b/apps/server/src/services/threads/deferred-thread-messages.ts
@@ -29,15 +29,40 @@ export const deferredThreadMessagePayloadSchema = z.discriminatedUnion("kind", [
     input: z.array(promptInputSchema),
     systemMessageKind: systemMessageKindSchema,
     systemMessageSubject: systemMessageSubjectSchema.nullable(),
+    /**
+     * Set when the daemon refused the message as `thread_turn_busy`: the
+     * thread's live turn at that moment (null while its start was still
+     * pending). The flush skips the row while that is still the live turn,
+     * so a busy thread sees one attempt per turn rather than one per sweep
+     * (#2370). Null for a row held behind a pending interaction (#1650);
+     * rows persisted before the field existed parse as null.
+     */
+    heldForTurn: z
+      .object({ activeTurnId: z.string().nullable() })
+      .nullable()
+      .default(null),
   }),
 ]);
 export type DeferredThreadMessagePayload = z.infer<
   typeof deferredThreadMessagePayloadSchema
 >;
 
+export type DeferThreadMessageReason = "pending-interaction" | "turn-busy";
+
+const DEFER_LOG_MESSAGES: Record<DeferThreadMessageReason, string> = {
+  "pending-interaction":
+    "Thread awaits user interaction; deferred message until it settles",
+  "turn-busy":
+    "Thread's live turn refused the message; deferred until that turn is over",
+};
+
 export function deferThreadMessage(
   deps: Pick<AppDeps, "db" | "logger">,
-  args: { threadId: string; payload: DeferredThreadMessagePayload },
+  args: {
+    payload: DeferredThreadMessagePayload;
+    reason: DeferThreadMessageReason;
+    threadId: string;
+  },
 ): void {
   const row = createDeferredThreadMessage(deps.db, {
     threadId: args.threadId,
@@ -48,9 +73,10 @@ export function deferThreadMessage(
     {
       deferredMessageId: row.id,
       kind: args.payload.kind,
+      reason: args.reason,
       threadId: args.threadId,
     },
-    "Thread awaits user interaction; deferred message until it settles",
+    DEFER_LOG_MESSAGES[args.reason],
   );
 }
 

--- a/apps/server/src/services/threads/parent-system-messages.ts
+++ b/apps/server/src/services/threads/parent-system-messages.ts
@@ -18,6 +18,10 @@ import type { LoggedPendingInteractionWorkSessionDeps } from "../../types.js";
 import { requireThreadEnvironment } from "../lib/entity-lookup.js";
 import { deferThreadMessage } from "./deferred-thread-messages.js";
 import {
+  holdParentSystemMessageForBusyTurn,
+  isThreadTurnBusyError,
+} from "./thread-turn-busy.js";
+import {
   addRequestIdToTurnSubmitCommandPayload,
   buildExecutionOptions,
   prepareTurnSubmitCommandPayload,
@@ -296,6 +300,7 @@ async function queueActiveParentSystemMessage(
     command,
     hostId: args.environment.hostId,
     timeoutMs: LIVE_DAEMON_COMMAND_TIMEOUT_MS,
+    onExpectedError: ({ error }) => holdOnBusyTurn(deps, args, error),
     onError: ({ error }) => {
       deps.logger.warn(
         { err: error, threadId: args.thread.id },
@@ -304,6 +309,28 @@ async function queueActiveParentSystemMessage(
     },
   });
   return true;
+}
+
+/**
+ * The daemon answered `thread_turn_busy`: the provider would not take the
+ * notice mid-run, and the server keeps the thread active rather than failing
+ * it. The notice must still reach the parent, so it is held for the turn
+ * that refused it (#2370).
+ */
+function holdOnBusyTurn(
+  deps: LoggedPendingInteractionWorkSessionDeps,
+  args: QueueReadyParentSystemMessageArgs,
+  error: Error,
+): void {
+  if (!isThreadTurnBusyError(error)) {
+    return;
+  }
+  holdParentSystemMessageForBusyTurn(deps, {
+    input: args.input,
+    systemMessageKind: args.systemMessageKind,
+    systemMessageSubject: args.systemMessageSubject,
+    threadId: args.thread.id,
+  });
 }
 
 async function queueReadyParentSystemMessage(
@@ -378,6 +405,14 @@ async function queueReadyParentSystemMessage(
     command: command.command,
     hostId: args.environment.hostId,
     timeoutMs: LIVE_DAEMON_COMMAND_TIMEOUT_MS,
+    // Only a turn.submit can answer `thread_turn_busy` with its run kept
+    // alive; a failed thread.start still fails the run.
+    ...(command.mode === "turn.submit"
+      ? {
+          onExpectedError: ({ error }: { error: Error }) =>
+            holdOnBusyTurn(deps, args, error),
+        }
+      : {}),
     onError: ({ error }) => {
       deps.logger.warn(
         { err: error, threadId: args.thread.id },
@@ -412,13 +447,15 @@ export async function queueParentSystemMessage(
     // notice left the parent believing its child had gone silent (#1650). It
     // waits and flushes when the parent's interactions settle.
     deferThreadMessage(deps, {
-      threadId: parentThread.id,
       payload: {
         kind: "parent-system",
         input: args.input,
         systemMessageKind: args.systemMessageKind,
         systemMessageSubject: args.systemMessageSubject,
+        heldForTurn: null,
       },
+      reason: "pending-interaction",
+      threadId: parentThread.id,
     });
     return true;
   }

--- a/apps/server/src/services/threads/queued-messages.ts
+++ b/apps/server/src/services/threads/queued-messages.ts
@@ -53,6 +53,10 @@ import { recoverThreadModelOverride } from "./thread-execution-override.js";
 import { requireReadyThreadEnvironment } from "./thread-turn-dispatch.js";
 import { resolvePermissionEscalation } from "./thread-runtime-config.js";
 import {
+  isThreadTurnBusyError,
+  restoreQueuedMessagesForBusyTurn,
+} from "./thread-turn-busy.js";
+import {
   ensureThreadIsWritable,
   formatAgentThreadInput,
   groupedInputForRuntime,
@@ -539,6 +543,19 @@ async function sendClaimedQueuedMessageForIdleProviderThread(
     command,
     hostId: environment.hostId,
     timeoutMs: LIVE_DAEMON_COMMAND_TIMEOUT_MS,
+    onExpectedError: ({ error }) => {
+      if (!isThreadTurnBusyError(error)) {
+        return;
+      }
+      // The rows were consumed at dispatch; the daemon still runs a turn on
+      // the thread (a start whose turn/started is pending, or a provider
+      // mid-run), so put the same rows back at the head for the drain that
+      // follows that turn (#2370).
+      restoreQueuedMessagesForBusyTurn(deps, {
+        queuedMessages: args.queuedMessages,
+        threadId: thread.id,
+      });
+    },
     onError: ({ error }) => {
       deps.logger.warn(
         { err: error, threadId: thread.id },
@@ -576,6 +593,7 @@ async function sendClaimedQueuedMessageForThread(
         throw createQueuedMessageClaimLostError();
       }
     },
+    consumedQueuedMessages: args.queuedMessages,
     environment,
     payload: {
       ...sendQueuedMessagePayload(

--- a/apps/server/src/services/threads/thread-lifecycle.ts
+++ b/apps/server/src/services/threads/thread-lifecycle.ts
@@ -24,6 +24,7 @@ import {
   type DbTransaction,
 } from "@bb/db";
 import { assertNever } from "@bb/core-ui";
+import { THREAD_TURN_BUSY_ERROR_CODE } from "@bb/host-daemon-contract";
 import {
   type ProvisioningTranscriptEntry,
   type SystemThreadInterruptedReason,
@@ -792,6 +793,17 @@ function settleThreadCommandFailure(
     });
   }
   if (hasExpectedTurnCompletedEvent(args.deps, args.command)) {
+    return emptyCommandResultSideEffects();
+  }
+  if (
+    args.command.type === "turn.submit" &&
+    args.report.errorCode === THREAD_TURN_BUSY_ERROR_CODE
+  ) {
+    // The provider is still running a turn the daemon would not interrupt.
+    // That run owns the thread's status and settles it when it ends; the
+    // dispatcher parks the refused input. Failing the run here flipped a
+    // working thread to `error` and stranded its queue, which only drains
+    // from `idle` (#2370).
     return emptyCommandResultSideEffects();
   }
   appendSystemErrorEventInTransaction(args.deps, {

--- a/apps/server/src/services/threads/thread-send-request.ts
+++ b/apps/server/src/services/threads/thread-send-request.ts
@@ -36,7 +36,7 @@ import {
   queuedMessagePayloadFromSendRequest,
 } from "./queued-messages.js";
 import { requireThreadCommandEnvironment } from "./thread-command-environment.js";
-import { isManualCompactionActive } from "./thread-events.js";
+import { getActiveTurnId, isManualCompactionActive } from "./thread-events.js";
 import {
   ensureThreadIsWritable,
   resolveMessageSenderThreadId,
@@ -95,8 +95,9 @@ export async function acceptThreadSendRequest(
       projectId: thread.projectId,
     });
     deferThreadMessage(deps, {
-      threadId: thread.id,
       payload: { kind: "send", request: payload },
+      reason: "pending-interaction",
+      threadId: thread.id,
     });
     return { ok: true, delivery: "deferred" };
   }
@@ -223,6 +224,20 @@ function dropUndeliverableDeferredThreadMessages(
   );
 }
 
+function isHeldForLiveTurn(
+  deps: Pick<AppDeps, "db">,
+  thread: Thread,
+  payload: DeferredThreadMessagePayload,
+): boolean {
+  if (payload.kind !== "parent-system" || payload.heldForTurn === null) {
+    return false;
+  }
+  return (
+    thread.status === "active" &&
+    getActiveTurnId(deps, thread.id) === payload.heldForTurn.activeTurnId
+  );
+}
+
 async function flushDeferredThreadMessagesNow(
   deps: LoggedPendingInteractionWorkSessionDeps,
   threadId: string,
@@ -257,6 +272,15 @@ async function flushDeferredThreadMessagesNow(
         { err: error, deferredMessageId: row.id, threadId },
         "Dropped malformed deferred thread message",
       );
+      continue;
+    }
+    if (isHeldForLiveTurn(deps, thread, payload)) {
+      // Refused as `thread_turn_busy` for the turn that is still live; another
+      // attempt now would be refused the same way, so the row waits for the
+      // tick after that turn ends or a new one starts. The rows behind it get
+      // their attempt: a send refused the same way is parked in the queue,
+      // not lost, and holding a steer for the rest of a long turn would undo
+      // the #1650 promise that it delivers once the interaction settles.
       continue;
     }
     try {

--- a/apps/server/src/services/threads/thread-send.ts
+++ b/apps/server/src/services/threads/thread-send.ts
@@ -3,7 +3,11 @@ import {
   getThread,
   requireThreadLifecycleEventApplied,
 } from "@bb/db";
-import type { DbConnection, DbTransaction } from "@bb/db";
+import type {
+  ClaimedQueuedThreadMessageRow,
+  DbConnection,
+  DbTransaction,
+} from "@bb/db";
 import type {
   ClientTurnRequestId,
   Environment,
@@ -44,6 +48,11 @@ import {
 } from "./thread-turn-dispatch.js";
 import { resolvePermissionEscalation } from "./thread-runtime-config.js";
 import {
+  isThreadTurnBusyError,
+  requeueInputForBusyTurn,
+  restoreQueuedMessagesForBusyTurn,
+} from "./thread-turn-busy.js";
+import {
   buildThreadStatusChangeMetadata,
   resolveThreadRuntimeState,
 } from "./thread-runtime-display.js";
@@ -73,6 +82,13 @@ type SendThreadMessagePayload = SendMessageRequest & {
 
 interface SendThreadMessageArgs {
   beforeAppendInTransaction?: SendThreadMessageTransactionPreflight;
+  /**
+   * The queue rows `beforeAppendInTransaction` consumes for this send. A
+   * `thread_turn_busy` refusal puts these rows back (same ids and grouping,
+   * head of the queue) instead of queueing the flattened payload at the
+   * tail. Absent for input that did not come from the queue.
+   */
+  consumedQueuedMessages?: readonly ClaimedQueuedThreadMessageRow[];
   environment: Environment;
   /**
    * Internal edit-message path. Presence forces a new provider session;
@@ -472,6 +488,36 @@ export async function sendThreadMessage(
   const permissionEscalation = resolvePermissionEscalation({
     initiator,
   });
+  // What goes back to the queue if the daemon answers `thread_turn_busy`:
+  // the rows a queued send consumed, as they were; otherwise the sender's
+  // own input, before the cross-thread envelope and the plugin mention
+  // context were applied, so the drain applies them exactly once.
+  const requeueOnBusyTurn = ({ error }: { error: Error }): void => {
+    if (!isThreadTurnBusyError(error)) {
+      return;
+    }
+    if (args.consumedQueuedMessages !== undefined) {
+      restoreQueuedMessagesForBusyTurn(deps, {
+        queuedMessages: args.consumedQueuedMessages,
+        threadId: thread.id,
+      });
+      return;
+    }
+    requeueInputForBusyTurn(deps, {
+      input: {
+        content:
+          payload.inputGroups !== undefined
+            ? groupedInputForRuntime(payload.inputGroups)
+            : payload.input,
+        senderThreadId,
+        model: execution.model,
+        reasoningLevel: execution.reasoningLevel,
+        permissionMode: execution.permissionMode,
+        serviceTier: execution.serviceTier,
+      },
+      threadId: thread.id,
+    });
+  };
 
   if (
     await dispatchTurnDuringReprovision({
@@ -603,6 +649,13 @@ export async function sendThreadMessage(
       ...(args.historyReplacement?.onCommandSettled !== undefined
         ? { onSettled: args.historyReplacement.onCommandSettled }
         : {}),
+      // Only a turn.submit can answer `thread_turn_busy` with its run kept
+      // alive (settleThreadCommandFailure exempts exactly that); a failed
+      // thread.start still fails the run, so its input is not queued behind
+      // an `error` thread.
+      ...(command.mode === "turn.submit"
+        ? { onExpectedError: requeueOnBusyTurn }
+        : {}),
       onError: ({ error }) => {
         deps.logger.warn(
           { err: error, threadId: thread.id },
@@ -673,6 +726,7 @@ export async function sendThreadMessage(
     command,
     hostId: readyEnvironment.hostId,
     timeoutMs: LIVE_DAEMON_COMMAND_TIMEOUT_MS,
+    onExpectedError: requeueOnBusyTurn,
     onError: ({ error }) => {
       deps.logger.warn(
         { err: error, threadId: thread.id },

--- a/apps/server/src/services/threads/thread-turn-busy.ts
+++ b/apps/server/src/services/threads/thread-turn-busy.ts
@@ -1,0 +1,168 @@
+import {
+  createQueuedThreadMessageInTransaction,
+  getThread,
+  restoreConsumedQueuedThreadMessagesInTransaction,
+  type ClaimedQueuedThreadMessageRow,
+  type DbTransaction,
+} from "@bb/db";
+import type {
+  PermissionMode,
+  PromptInput,
+  SystemMessageKind,
+  SystemMessageSubject,
+} from "@bb/domain";
+import { THREAD_TURN_BUSY_ERROR_CODE } from "@bb/host-daemon-contract";
+import { ApiError } from "../../errors.js";
+import type { AppDeps } from "../../types.js";
+import { deferThreadMessage } from "./deferred-thread-messages.js";
+import { getActiveTurnId } from "./thread-events.js";
+
+/**
+ * The daemon's answer when a turn submission cannot take the thread: its
+ * runtime already has a turn active or starting on it, or the bridge refused
+ * the input because its provider is mid-run (pi while it compacts). The live
+ * turn is untouched, so the server keeps the thread active and parks the
+ * input instead of failing the run (#2370): a send goes to the thread's
+ * queue, a consumed queued group goes back to the head of the queue, and a
+ * parent system message is held until that turn is no longer the live one.
+ */
+export function isThreadTurnBusyError(error: unknown): boolean {
+  return (
+    error instanceof ApiError && error.body.code === THREAD_TURN_BUSY_ERROR_CODE
+  );
+}
+
+export interface BusyTurnRequeueInput {
+  /** The input as the sender gave it: no cross-thread envelope, no resolved mention context. */
+  content: PromptInput[];
+  senderThreadId: string | null;
+  model: string;
+  reasoningLevel: string;
+  permissionMode: PermissionMode;
+  serviceTier: string;
+}
+
+interface RequeueInputForBusyTurnArgs {
+  input: BusyTurnRequeueInput;
+  threadId: string;
+}
+
+type BusyTurnDeps = Pick<AppDeps, "db" | "hub" | "logger">;
+
+function withLiveThread(
+  deps: BusyTurnDeps,
+  threadId: string,
+  work: (tx: DbTransaction) => void,
+): boolean {
+  return deps.db.transaction(
+    (tx) => {
+      const thread = getThread(tx, threadId);
+      if (!thread || thread.deletedAt !== null) {
+        return false;
+      }
+      work(tx);
+      return true;
+    },
+    { behavior: "immediate" },
+  );
+}
+
+/**
+ * Queue the input of a busy-refused send behind whatever the thread's queue
+ * already holds (arrival order, like a message queued up front). The raw
+ * payload is what goes back: the drain re-applies the sender envelope and
+ * resolves plugin mentions exactly once, so nothing is delivered twice or
+ * stripped.
+ */
+export function requeueInputForBusyTurn(
+  deps: BusyTurnDeps,
+  args: RequeueInputForBusyTurnArgs,
+): void {
+  // A queued row needs content to deliver; an empty send only ever carried
+  // its envelope, which the drain would rebuild from nothing.
+  if (args.input.content.length === 0) {
+    return;
+  }
+  const queued = withLiveThread(deps, args.threadId, (tx) => {
+    createQueuedThreadMessageInTransaction(tx, {
+      threadId: args.threadId,
+      ...args.input,
+    });
+  });
+  if (!queued) {
+    return;
+  }
+  deps.hub.notifyThread(args.threadId, ["queue-changed"]);
+  deps.logger.info(
+    { threadId: args.threadId },
+    "Queued input the provider was too busy to take",
+  );
+}
+
+interface RestoreQueuedMessagesForBusyTurnArgs {
+  /** The group exactly as the auto-send claimed and consumed it. */
+  queuedMessages: readonly ClaimedQueuedThreadMessageRow[];
+  threadId: string;
+}
+
+/**
+ * Put a consumed queued group back at the head of the queue, with its
+ * grouping, so it drains again ahead of everything the thread holds: what was
+ * queued behind it and what arrived while the refusal was in flight. A sender
+ * that queued "do X" then "stop, do Y" keeps that order. The idle auto-drain
+ * always consumes the head, so the head is the group's original place; a
+ * "send now" on a row further back was the user asking for it next.
+ */
+export function restoreQueuedMessagesForBusyTurn(
+  deps: BusyTurnDeps,
+  args: RestoreQueuedMessagesForBusyTurnArgs,
+): void {
+  const restored = withLiveThread(deps, args.threadId, (tx) => {
+    restoreConsumedQueuedThreadMessagesInTransaction(tx, {
+      queuedMessages: args.queuedMessages,
+    });
+  });
+  if (!restored) {
+    return;
+  }
+  deps.hub.notifyThread(args.threadId, ["queue-changed"]);
+  deps.logger.info(
+    { count: args.queuedMessages.length, threadId: args.threadId },
+    "Restored queued messages the provider was too busy to take",
+  );
+}
+
+interface HoldParentSystemMessageForBusyTurnArgs {
+  input: PromptInput[];
+  systemMessageKind: SystemMessageKind;
+  systemMessageSubject: SystemMessageSubject | null;
+  threadId: string;
+}
+
+/**
+ * A parent system message (a child's completion notice to its orchestrator)
+ * has no queue row shape: the queue would deliver it as a user message and
+ * drop its taxonomy. It waits in `deferred_thread_messages` instead, stamped
+ * with the turn it was refused for, and the flush skips it while that is
+ * still the thread's live turn (one attempt per turn, not one per sweep).
+ */
+export function holdParentSystemMessageForBusyTurn(
+  deps: Pick<AppDeps, "db" | "logger">,
+  args: HoldParentSystemMessageForBusyTurnArgs,
+): void {
+  const thread = getThread(deps.db, args.threadId);
+  if (!thread || thread.deletedAt !== null) {
+    return;
+  }
+  deferThreadMessage(deps, {
+    payload: {
+      kind: "parent-system",
+      input: args.input,
+      systemMessageKind: args.systemMessageKind,
+      systemMessageSubject: args.systemMessageSubject,
+      heldForTurn: { activeTurnId: getActiveTurnId(deps, args.threadId) },
+    },
+    reason: "turn-busy",
+    threadId: args.threadId,
+  });
+}

--- a/apps/server/test/threads/thread-send-dispatch.test.ts
+++ b/apps/server/test/threads/thread-send-dispatch.test.ts
@@ -2,14 +2,19 @@ import {
   archiveThread,
   getQueuedThreadMessage,
   getThread,
+  listDeferredThreadMessages,
   listEvents,
   listQueuedThreadMessages,
   markThreadDeleted,
+  setQueuedThreadMessageGroupBoundary,
 } from "@bb/db";
 import { turnScope, type Environment, type Thread } from "@bb/domain";
 import { describe, expect, it, vi } from "vitest";
 import type { TelemetryService } from "../../src/services/system/telemetry.js";
+import { deferThreadMessage } from "../../src/services/threads/deferred-thread-messages.js";
+import { queueParentSystemMessage } from "../../src/services/threads/parent-system-messages.js";
 import { sendQueuedMessage } from "../../src/services/threads/queued-messages.js";
+import { flushDeferredThreadMessages } from "../../src/services/threads/thread-send-request.js";
 import { handleUpdateEnvironmentDirectoryToolCall } from "../../src/services/threads/thread-environment-directory.js";
 import { sendThreadMessage } from "../../src/services/threads/thread-send.js";
 import {
@@ -314,6 +319,438 @@ describe("turn submit failure settlement", () => {
         requestId: queued.command.requestId,
         reason: "provider_rpc_error",
         message: "No active turn to steer",
+      });
+      // A genuine provider failure still fails the run and queues nothing.
+      expect(getThread(harness.db, thread.id)).toMatchObject({
+        status: "error",
+      });
+      expect(listQueuedThreadMessages(harness.db, thread.id)).toHaveLength(0);
+    });
+  });
+
+  it("keeps a busy-refused auto send: the thread stays active and the raw input is re-queued (#2370)", async () => {
+    await withTestHarness(async (harness) => {
+      const { environment, thread } = seedProviderThreadFixture({
+        harness,
+        status: "active",
+        value: 10,
+      });
+      seedTurnStarted(harness.deps, {
+        environmentId: environment.id,
+        providerThreadId: "provider-send-dispatch-10",
+        sequence: 3,
+        threadId: thread.id,
+        turnId: "turn-active",
+      });
+      const senderThread = seedThread(harness.deps, {
+        environmentId: environment.id,
+        projectId: thread.projectId,
+        status: "active",
+      });
+      const activeThread = getThread(harness.db, thread.id);
+      if (!activeThread) throw new Error("Expected an active thread");
+
+      await sendThreadMessage(harness.deps, {
+        environment,
+        payload: {
+          input: textInput("status update from the worker"),
+          mode: "auto",
+          model: "gpt-5",
+          permissionMode: "full",
+          reasoningLevel: "medium",
+          senderThreadId: senderThread.id,
+          serviceTier: "default",
+        },
+        thread: activeThread,
+        trigger: "user",
+      });
+      const queued = await waitForQueuedCommand(
+        harness,
+        (candidate) =>
+          candidate.command.type === "turn.submit" &&
+          candidate.command.threadId === thread.id,
+      );
+      if (queued.command.type !== "turn.submit") {
+        throw new Error("Expected a turn.submit command");
+      }
+      // The daemon could not take the input: the provider is mid-run and
+      // refused it (pi while it compacts).
+      await reportQueuedCommandError(harness, queued, {
+        errorCode: "thread_turn_busy",
+        errorMessage:
+          "Cannot submit a prompt while compaction is in progress. Wait for compaction to finish and retry.",
+      });
+
+      // The live turn keeps the thread active; no run failure, no error row.
+      expect(getThread(harness.db, thread.id)).toMatchObject({
+        status: "active",
+      });
+      const eventTypes = listEvents(harness.db, { threadId: thread.id }).map(
+        (event) => event.type,
+      );
+      expect(eventTypes).toContain("client/turn/rejected");
+      expect(eventTypes).not.toContain("system/error");
+      // The message waits in the queue with its original (un-enveloped)
+      // text and its sender, so the drain delivers it exactly once, as the
+      // agent-to-agent message it was.
+      const requeued = listQueuedThreadMessages(harness.db, thread.id);
+      expect(requeued).toHaveLength(1);
+      expect(JSON.parse(requeued[0]!.content)).toEqual(
+        textInput("status update from the worker"),
+      );
+      expect(requeued[0]).toMatchObject({
+        senderThreadId: senderThread.id,
+        model: "gpt-5",
+        permissionMode: "full",
+        reasoningLevel: "medium",
+        serviceTier: "default",
+      });
+    });
+  });
+
+  it("restores a busy-refused queued auto-send at the head of the queue instead of failing the run (#2370)", async () => {
+    await withTestHarness(async (harness) => {
+      const { thread } = seedProviderThreadFixture({ harness, value: 11 });
+      const queuedMessage = seedQueuedMessage(harness.deps, {
+        threadId: thread.id,
+        content: textInput("queued while idle"),
+      });
+      const queuedBehind = seedQueuedMessage(harness.deps, {
+        threadId: thread.id,
+        content: textInput("queued behind it"),
+      });
+
+      await sendQueuedMessage(harness.deps, {
+        threadId: thread.id,
+        queuedMessageId: queuedMessage.id,
+        mode: "auto",
+      });
+      const queued = await waitForQueuedCommand(
+        harness,
+        (candidate) =>
+          candidate.command.type === "turn.submit" &&
+          candidate.command.threadId === thread.id,
+      );
+      if (queued.command.type !== "turn.submit") {
+        throw new Error("Expected a turn.submit command");
+      }
+      expect(queued.command.target).toEqual({ mode: "start" });
+      // The server saw an idle thread, but the daemon still runs a turn on
+      // it (a start whose turn/started is pending, or a provider mid-run).
+      await reportQueuedCommandError(harness, queued, {
+        errorCode: "thread_turn_busy",
+        errorMessage:
+          "Refusing to start a competing turn while the thread is still starting",
+      });
+
+      expect(getThread(harness.db, thread.id)).toMatchObject({
+        status: "active",
+      });
+      const eventTypes = listEvents(harness.db, { threadId: thread.id }).map(
+        (event) => event.type,
+      );
+      expect(eventTypes).not.toContain("system/error");
+      // The same row is back where it was, ahead of what was queued behind
+      // it, so the drain after the live turn delivers in the original order.
+      const requeued = listQueuedThreadMessages(harness.db, thread.id);
+      expect(requeued.map((row) => row.id)).toEqual([
+        queuedMessage.id,
+        queuedBehind.id,
+      ]);
+      expect(JSON.parse(requeued[0]!.content)).toEqual(
+        textInput("queued while idle"),
+      );
+      expect(requeued[0]).toMatchObject({
+        claimToken: null,
+        claimedAt: null,
+        senderThreadId: null,
+      });
+    });
+  });
+
+  it("holds a busy-refused parent system message for the live turn and delivers it once that turn is over (#2370)", async () => {
+    await withTestHarness(async (harness) => {
+      const { environment, thread: parent } = seedProviderThreadFixture({
+        harness,
+        status: "active",
+        value: 12,
+      });
+      seedTurnStarted(harness.deps, {
+        environmentId: environment.id,
+        providerThreadId: "provider-send-dispatch-12",
+        threadId: parent.id,
+        turnId: "turn-live",
+      });
+      const child = seedThread(harness.deps, {
+        environmentId: environment.id,
+        parentThreadId: parent.id,
+        projectId: parent.projectId,
+        title: "Worker child",
+      });
+      const subject = {
+        kind: "thread" as const,
+        threadId: child.id,
+        threadName: "Worker child",
+      };
+
+      expect(
+        await queueParentSystemMessage(harness.deps, {
+          input: textInput("[bb system] child completed"),
+          parentThreadId: parent.id,
+          systemMessageKind: "child-completed",
+          systemMessageSubject: subject,
+        }),
+      ).toBe(true);
+      const queued = await waitForQueuedCommand(
+        harness,
+        (candidate) =>
+          candidate.command.type === "turn.submit" &&
+          candidate.command.threadId === parent.id,
+      );
+      if (queued.command.type !== "turn.submit") {
+        throw new Error("Expected a turn.submit command");
+      }
+      expect(queued.command.target).toEqual({
+        mode: "auto",
+        expectedTurnId: "turn-live",
+      });
+      // The provider would not take the notice mid-run.
+      await reportQueuedCommandError(harness, queued, {
+        errorCode: "thread_turn_busy",
+        errorMessage:
+          "Cannot submit a prompt while compaction is in progress. Wait for compaction to finish and retry.",
+      });
+
+      // The live turn keeps the thread active; the notice is held, with its
+      // taxonomy, for the turn that refused it. Nothing went to the queue:
+      // a queued row would deliver it as a user message.
+      expect(getThread(harness.db, parent.id)).toMatchObject({
+        status: "active",
+      });
+      expect(
+        listEvents(harness.db, { threadId: parent.id }).map(
+          (event) => event.type,
+        ),
+      ).not.toContain("system/error");
+      expect(listQueuedThreadMessages(harness.db, parent.id)).toHaveLength(0);
+      const held = listDeferredThreadMessages(harness.db, parent.id);
+      expect(held).toHaveLength(1);
+      expect(JSON.parse(held[0]!.payload)).toMatchObject({
+        kind: "parent-system",
+        systemMessageKind: "child-completed",
+        systemMessageSubject: subject,
+        heldForTurn: { activeTurnId: "turn-live" },
+      });
+
+      // A sweep while that turn is still live does not retry (one attempt
+      // per turn, not one per tick).
+      await flushDeferredThreadMessages(harness.deps, parent.id);
+      expect(listDeferredThreadMessages(harness.db, parent.id)).toHaveLength(1);
+      // No new dispatch went to the host (the refused one was already settled).
+      expect(
+        listQueuedThreadCommands(harness, "turn.submit", parent.id),
+      ).toHaveLength(0);
+
+      // The next turn opens: the notice steers into it and leaves the hold.
+      seedTurnStarted(harness.deps, {
+        environmentId: environment.id,
+        providerThreadId: "provider-send-dispatch-12",
+        threadId: parent.id,
+        turnId: "turn-next",
+      });
+      await flushDeferredThreadMessages(harness.deps, parent.id);
+      const commands = listQueuedThreadCommands(
+        harness,
+        "turn.submit",
+        parent.id,
+      );
+      expect(commands).toHaveLength(1);
+      const redelivered = commands[0]!;
+      if (redelivered.type !== "turn.submit") {
+        throw new Error("Expected a turn.submit command");
+      }
+      expect(redelivered.target).toEqual({
+        mode: "auto",
+        expectedTurnId: "turn-next",
+      });
+      expect(listDeferredThreadMessages(harness.db, parent.id)).toHaveLength(0);
+      // The refused attempt and the redelivery, both as the system notice
+      // they are (not as a user message).
+      const notices = listEvents(harness.db, { threadId: parent.id })
+        .filter((event) => event.type === "client/turn/requested")
+        .map((event) => JSON.parse(event.data))
+        .filter((request) => request.initiator === "system");
+      expect(notices).toHaveLength(2);
+      expect(notices[1]).toMatchObject({
+        systemMessageKind: "child-completed",
+        systemMessageSubject: subject,
+      });
+    });
+  });
+
+  it("restores a busy-refused queued group sent into an active thread at the head with its grouping (#2370)", async () => {
+    await withTestHarness(async (harness) => {
+      const { environment, thread } = seedProviderThreadFixture({
+        harness,
+        status: "active",
+        value: 13,
+      });
+      seedTurnStarted(harness.deps, {
+        environmentId: environment.id,
+        providerThreadId: "provider-send-dispatch-13",
+        threadId: thread.id,
+        turnId: "turn-live",
+      });
+      const first = seedQueuedMessage(harness.deps, {
+        threadId: thread.id,
+        content: textInput("do X"),
+      });
+      const second = seedQueuedMessage(harness.deps, {
+        threadId: thread.id,
+        content: textInput("then Y"),
+      });
+      const third = seedQueuedMessage(harness.deps, {
+        threadId: thread.id,
+        content: textInput("queued behind the group"),
+      });
+      setQueuedThreadMessageGroupBoundary({
+        db: harness.db,
+        expectedGroupedPrefixQueuedMessageIds: [first.id, second.id],
+        groupBoundaryQueuedMessageId: second.id,
+        notifier: harness.hub,
+        threadId: thread.id,
+      });
+
+      // "Send now" into the live turn: the queued path through
+      // sendThreadMessage, not the idle fast path.
+      await sendQueuedMessage(harness.deps, {
+        threadId: thread.id,
+        queuedMessageId: first.id,
+        mode: "auto",
+      });
+      const queued = await waitForQueuedCommand(
+        harness,
+        (candidate) =>
+          candidate.command.type === "turn.submit" &&
+          candidate.command.threadId === thread.id,
+      );
+      if (queued.command.type !== "turn.submit") {
+        throw new Error("Expected a turn.submit command");
+      }
+      expect(queued.command.target).toEqual({
+        mode: "auto",
+        expectedTurnId: "turn-live",
+      });
+      expect(listQueuedThreadMessages(harness.db, thread.id).map((row) => row.id)).toEqual([third.id]);
+      await reportQueuedCommandError(harness, queued, {
+        errorCode: "thread_turn_busy",
+        errorMessage:
+          "Cannot submit a prompt while compaction is in progress. Wait for compaction to finish and retry.",
+      });
+
+      expect(getThread(harness.db, thread.id)).toMatchObject({
+        status: "active",
+      });
+      expect(
+        listEvents(harness.db, { threadId: thread.id }).map(
+          (event) => event.type,
+        ),
+      ).not.toContain("system/error");
+      // The same rows, grouped as before, ahead of what was queued behind
+      // them: not one flattened row at the tail.
+      const requeued = listQueuedThreadMessages(harness.db, thread.id);
+      expect(
+        requeued.map((row) => ({
+          id: row.id,
+          groupWithNext: row.groupWithNext,
+          claimToken: row.claimToken,
+        })),
+      ).toEqual([
+        { id: first.id, groupWithNext: true, claimToken: null },
+        { id: second.id, groupWithNext: false, claimToken: null },
+        { id: third.id, groupWithNext: false, claimToken: null },
+      ]);
+      expect(JSON.parse(requeued[0]!.content)).toEqual(textInput("do X"));
+      expect(JSON.parse(requeued[1]!.content)).toEqual(textInput("then Y"));
+    });
+  });
+
+  it("delivers a send deferred behind a held parent system message while that turn is still live (#2370)", async () => {
+    await withTestHarness(async (harness) => {
+      const { environment, thread } = seedProviderThreadFixture({
+        harness,
+        status: "active",
+        value: 14,
+      });
+      seedTurnStarted(harness.deps, {
+        environmentId: environment.id,
+        providerThreadId: "provider-send-dispatch-14",
+        threadId: thread.id,
+        turnId: "turn-live",
+      });
+      const child = seedThread(harness.deps, {
+        environmentId: environment.id,
+        parentThreadId: thread.id,
+        projectId: thread.projectId,
+        title: "Worker child",
+      });
+      // A notice the live turn already refused, then a steer that waited on
+      // a pending interaction (#1650) and is now free to go.
+      deferThreadMessage(harness.deps, {
+        payload: {
+          kind: "parent-system",
+          input: textInput("[bb system] child completed"),
+          systemMessageKind: "child-completed",
+          systemMessageSubject: {
+            kind: "thread",
+            threadId: child.id,
+            threadName: "Worker child",
+          },
+          heldForTurn: { activeTurnId: "turn-live" },
+        },
+        reason: "turn-busy",
+        threadId: thread.id,
+      });
+      deferThreadMessage(harness.deps, {
+        payload: {
+          kind: "send",
+          request: {
+            input: textInput("stop and use approach B"),
+            mode: "steer",
+            model: "gpt-5",
+            permissionMode: "full",
+            reasoningLevel: "medium",
+            serviceTier: "default",
+          },
+        },
+        reason: "pending-interaction",
+        threadId: thread.id,
+      });
+
+      await flushDeferredThreadMessages(harness.deps, thread.id);
+
+      // The held notice is skipped, not retried; the steer behind it is
+      // delivered into the live turn rather than parked for its remainder.
+      const commands = listQueuedThreadCommands(
+        harness,
+        "turn.submit",
+        thread.id,
+      );
+      expect(commands).toHaveLength(1);
+      const steered = commands[0]!;
+      if (steered.type !== "turn.submit") {
+        throw new Error("Expected a turn.submit command");
+      }
+      expect(steered.target).toEqual({
+        mode: "steer",
+        expectedTurnId: "turn-live",
+      });
+      expect(steered.input).toEqual(textInput("stop and use approach B"));
+      const remaining = listDeferredThreadMessages(harness.db, thread.id);
+      expect(remaining).toHaveLength(1);
+      expect(JSON.parse(remaining[0]!.payload)).toMatchObject({
+        kind: "parent-system",
+        heldForTurn: { activeTurnId: "turn-live" },
       });
     });
   });

--- a/docs/provider-bridge-protocol.md
+++ b/docs/provider-bridge-protocol.md
@@ -61,6 +61,14 @@ Hygiene rules (each traces to incident #853):
   `INVALID_PARAMS (-32602)` carrying the validation issues. Never silently
   dropped — a dropped request is an undebuggable 30-second timeout.
 - An unrecognized method is answered with `METHOD_NOT_FOUND (-32601)`.
+- A `turn/start` or `turn/steer` the provider refuses because it is mid-run
+  (or compacting) and will not queue the input is answered with
+  `TURN_BUSY (-32004)`. The live turn is untouched: the bridge settles
+  nothing and raises no session error, because the rejection is the whole
+  report. The runtime surfaces it as a typed `thread_turn_busy` failure and
+  the server keeps the thread active and parks the input in its queue
+  (#2370). Settling the live turn here is what flipped a working thread to
+  `error` and stranded its queue.
 - Anything written to stdout that is not protocol traffic is ignored by the
   reader; bridges must guard stdout against stray writes.
 

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -1,4 +1,8 @@
-export { AgentRuntimeRecoveryError, createAgentRuntime } from "./runtime.js";
+export {
+  AgentRuntimeRecoveryError,
+  AgentRuntimeTurnBusyError,
+  createAgentRuntime,
+} from "./runtime.js";
 export { bridgeLaunchProcessKey } from "./bridge-launch-process-key.js";
 export type {
   AgentRuntime,

--- a/packages/agent-runtime/src/runtime.lifecycle.test.ts
+++ b/packages/agent-runtime/src/runtime.lifecycle.test.ts
@@ -992,7 +992,10 @@ describe("createAgentRuntime lifecycle", () => {
           input: [promptTextInput({ text: "competing active turn" })],
           options: fullRuntimeOptions,
         }),
-      ).rejects.toThrow(/active or starting/);
+      ).rejects.toMatchObject({
+        code: "thread_turn_busy",
+        message: expect.stringMatching(/active or starting/),
+      });
       expect(
         recordedMethods(record).filter((method) => method === "turn/start"),
       ).toHaveLength(1);
@@ -1035,7 +1038,10 @@ describe("createAgentRuntime lifecycle", () => {
             input: [promptTextInput({ text: "competing pending turn" })],
             options: fullRuntimeOptions,
           }),
-        ).rejects.toThrow(/active or starting/);
+        ).rejects.toMatchObject({
+          code: "thread_turn_busy",
+          message: expect.stringMatching(/active or starting/),
+        });
         expect(
           recordedMethods(record).filter((method) => method === "turn/start"),
         ).toHaveLength(1);

--- a/packages/agent-runtime/src/runtime.recovery.test.ts
+++ b/packages/agent-runtime/src/runtime.recovery.test.ts
@@ -840,6 +840,82 @@ describe("runtime recovery hints", () => {
     expect(runtime.getActiveTurnId("t-stale")).toBeNull();
   });
 
+  it("TURN_BUSY: a steer the bridge refuses as busy is a typed thread_turn_busy error and keeps the live turn", async () => {
+    const { events, runtime } = createRecoveryRuntime({
+      failMethods: [
+        {
+          method: "turn/steer",
+          code: BRIDGE_JSON_RPC_ERRORS.TURN_BUSY,
+          message: "Agent is already processing a prompt",
+        },
+      ],
+    });
+    await startThread(runtime, "t-busy-steer");
+    await runtime.runTurn({
+      clientRequestId: "creq_rcvrhint29",
+      input: [promptTextInput({ text: "hold_turn" })],
+      options: fullRuntimeOptions,
+      threadId: "t-busy-steer",
+    });
+    const { turnId } = await waitForThreadTurnStarted({
+      events,
+      providerId: PROVIDER_ID,
+      runtime,
+      threadId: "t-busy-steer",
+    });
+
+    await expect(
+      runtime.steerTurn({
+        clientRequestId: "creq_rcvrhint30",
+        expectedTurnId: turnId,
+        input: [promptTextInput({ text: "refused" })],
+        options: fullRuntimeOptions,
+        threadId: "t-busy-steer",
+      }),
+    ).rejects.toMatchObject({
+      code: "thread_turn_busy",
+      message: "Agent is already processing a prompt",
+    });
+    // The provider is still running the turn: nothing about it changed.
+    expect(runtime.getActiveTurnId("t-busy-steer")).toBe(turnId);
+    expect(runtime.getLiveThreadIds()).toEqual(["t-busy-steer"]);
+  });
+
+  it("TURN_BUSY: a start the bridge refuses as busy is a typed thread_turn_busy error", async () => {
+    const { record, runtime } = createRecoveryRuntime({
+      failMethods: [
+        {
+          method: "turn/start",
+          code: BRIDGE_JSON_RPC_ERRORS.TURN_BUSY,
+          message: "Agent is already processing a prompt",
+        },
+      ],
+      sessionRestorable: true,
+    });
+    const providerThreadId = await startThread(runtime, "t-busy-start");
+
+    await expect(
+      runtime.runTurn({
+        clientRequestId: "creq_rcvrhint31",
+        input: [promptTextInput({ text: "refused" })],
+        options: fullRuntimeOptions,
+        threadId: "t-busy-start",
+      }),
+    ).rejects.toMatchObject({ code: "thread_turn_busy" });
+    expect(countRequests(record, "turn/start")).toBe(1);
+    // The refused start left no pending turn behind, and the session is as
+    // idle as it was before the attempt: the reaper can still release it.
+    expect(runtime.getLiveThreadIds()).toEqual([]);
+    const reaped = await runtime.reapIdleProviderSessions({
+      idleForMs: 0,
+      nowMs: Date.now() + 60 * 60 * 1000,
+      providerSessionReapingEnabled: true,
+    });
+    expect(reaped.reapedSessions).toEqual([
+      expect.objectContaining({ providerThreadId, threadId: "t-busy-start" }),
+    ]);
+  });
+
   it("restartRecommended: an idle thread is moved to a fresh bridge process right away", async () => {
     const { events, hints, processLog, record, runtime } =
       createRecoveryRuntime();

--- a/packages/agent-runtime/src/runtime.ts
+++ b/packages/agent-runtime/src/runtime.ts
@@ -176,6 +176,29 @@ export class AgentRuntimeRecoveryError extends Error {
 }
 
 /**
+ * A turn submission the thread cannot take right now: the runtime already
+ * has a turn active or starting on it, or the bridge answered `TURN_BUSY`
+ * (its provider is mid-run and will not queue the input). The live turn is
+ * untouched. `code` reaches the server as `thread_turn_busy`, which keeps the
+ * thread active and re-queues the input instead of failing the run (#2370).
+ */
+export class AgentRuntimeTurnBusyError extends Error {
+  readonly code = "thread_turn_busy" as const;
+
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "AgentRuntimeTurnBusyError";
+  }
+}
+
+function isTurnBusyRejection(error: unknown): error is JsonRpcResponseError {
+  return (
+    error instanceof JsonRpcResponseError &&
+    error.code === BRIDGE_JSON_RPC_ERRORS.TURN_BUSY
+  );
+}
+
+/**
  * A `rateLimited { retryable: true }` rejection is retried on this ladder;
  * the failure after the last rung propagates as a typed error.
  */
@@ -931,7 +954,7 @@ export function createAgentRuntime(options: AgentRuntimeOptions): AgentRuntime {
       turnState.getActiveTurnId(threadId) !== null ||
       pendingTurnStarts.has(threadId)
     ) {
-      throw new Error(
+      throw new AgentRuntimeTurnBusyError(
         `Refusing to start a competing turn for thread "${threadId}" while another turn is active or starting`,
       );
     }
@@ -2200,7 +2223,19 @@ export function createAgentRuntime(options: AgentRuntimeOptions): AgentRuntime {
             });
           } catch (error) {
             pendingTurnStarts.delete(threadId);
+            // The refused start left the session as it found it. For the
+            // runtime that is idle (no turn, no pending start), so the idle
+            // clock restarts here as after any other refusal; a provider
+            // that is in fact mid-run re-marks the session busy with the
+            // turn events it emits, and those protect it from the reaper.
             markHostedProviderSessionIdle(threadId);
+            if (isTurnBusyRejection(error)) {
+              // The typed code lets the host keep the thread active and
+              // re-queue the input (#2370).
+              throw new AgentRuntimeTurnBusyError(error.message, {
+                cause: error,
+              });
+            }
             throw error;
           }
         },
@@ -2304,6 +2339,14 @@ export function createAgentRuntime(options: AgentRuntimeOptions): AgentRuntime {
             ) {
               turnState.clearThread(threadId);
               return { status: "stale", activeTurnId: null };
+            }
+            // TURN_BUSY: the provider would not take the steer but the turn
+            // it targeted is still running. The turn state stays as it is;
+            // the typed code lets the host re-queue the input (#2370).
+            if (isTurnBusyRejection(error)) {
+              throw new AgentRuntimeTurnBusyError(error.message, {
+                cause: error,
+              });
             }
             throw error;
           }

--- a/packages/db/src/data/index.ts
+++ b/packages/db/src/data/index.ts
@@ -365,6 +365,7 @@ export {
   releaseQueuedMessageClaim,
   releaseStaleQueuedMessageClaims,
   reorderQueuedThreadMessage,
+  restoreConsumedQueuedThreadMessagesInTransaction,
   setQueuedThreadMessageGroupBoundary,
   updateQueuedThreadMessage,
 } from "./queued-thread-messages.js";
@@ -381,6 +382,7 @@ export type {
   DeferredThreadMessageRow,
 } from "./deferred-thread-messages.js";
 export type {
+  ClaimedQueuedThreadMessageRow,
   QueuedThreadMessageRow,
   ReorderQueuedThreadMessageResult,
   SetQueuedThreadMessageGroupBoundaryResult,

--- a/packages/db/src/data/queued-thread-messages.ts
+++ b/packages/db/src/data/queued-thread-messages.ts
@@ -87,6 +87,11 @@ export interface DeleteClaimedQueuedThreadMessageBatchInTransactionArgs {
   queuedMessages: readonly ClaimedQueuedThreadMessageMutationArgs[];
 }
 
+export interface RestoreConsumedQueuedThreadMessagesInTransactionArgs {
+  /** The rows exactly as they were claimed, before the batch delete. */
+  queuedMessages: readonly ClaimedQueuedThreadMessageRow[];
+}
+
 export interface ReleaseStaleQueuedMessageClaimsArgs {
   claimedBefore: number;
   protectedClaimTokens: readonly string[];
@@ -276,6 +281,21 @@ function getLastQueuedThreadMessage(
       .from(queuedThreadMessages)
       .where(eq(queuedThreadMessages.threadId, threadId))
       .orderBy(desc(queuedThreadMessages.sortKey), desc(queuedThreadMessages.id))
+      .limit(1)
+      .get() ?? null
+  );
+}
+
+function getFirstQueuedThreadMessage(
+  db: DbQueryConnection,
+  threadId: string,
+): QueuedThreadMessageRow | null {
+  return (
+    db
+      .select()
+      .from(queuedThreadMessages)
+      .where(eq(queuedThreadMessages.threadId, threadId))
+      .orderBy(asc(queuedThreadMessages.sortKey), asc(queuedThreadMessages.id))
       .limit(1)
       .get() ?? null
   );
@@ -1114,6 +1134,50 @@ export function deleteClaimedQueuedThreadMessageBatchInTransaction(
     }
   }
   return true;
+}
+
+/**
+ * Puts back rows that `deleteClaimedQueuedThreadMessageBatchInTransaction`
+ * consumed for a dispatch the host then refused (`thread_turn_busy`, #2370):
+ * same ids, content and grouping, claim cleared, at the head of the queue in
+ * the given order. The group drains again ahead of everything the thread
+ * holds, claimed or not, instead of as ungrouped rows at the tail.
+ *
+ * The rows get fresh sort keys rather than their stored ones. The consume
+ * often empties the queue, and a row queued into an empty queue takes the
+ * same initial key the consumed head had; re-inserting the old keys would
+ * then tie on `sortKey` and let the random id decide whether the newcomer
+ * drains first or lands inside the restored group. The caller notifies
+ * `queue-changed` after the transaction commits.
+ */
+export function restoreConsumedQueuedThreadMessagesInTransaction(
+  tx: DbTransaction,
+  args: RestoreConsumedQueuedThreadMessagesInTransactionArgs,
+): void {
+  if (args.queuedMessages.length === 0) return;
+  const threadId = args.queuedMessages[0]!.threadId;
+  const now = Date.now();
+  // Chain the keys from the last row back to the first: each is strictly
+  // before the current head (or the restored row behind it), so the group
+  // keeps its internal order and lands ahead of the head.
+  let nextKey = getFirstQueuedThreadMessage(tx, threadId)?.sortKey ?? null;
+  const sortKeys: string[] = [];
+  for (let index = args.queuedMessages.length - 1; index >= 0; index -= 1) {
+    const sortKey = createOrderKeyBetween({ previousKey: null, nextKey });
+    sortKeys[index] = sortKey;
+    nextKey = sortKey;
+  }
+  tx.insert(queuedThreadMessages)
+    .values(
+      args.queuedMessages.map((queuedMessage, index) => ({
+        ...queuedMessage,
+        claimedAt: null,
+        claimToken: null,
+        sortKey: sortKeys[index]!,
+        updatedAt: now,
+      })),
+    )
+    .run();
 }
 
 export function deleteQueuedThreadMessage(

--- a/packages/db/test/data/queued-thread-messages.test.ts
+++ b/packages/db/test/data/queued-thread-messages.test.ts
@@ -13,6 +13,7 @@ import {
   releaseQueuedMessageClaim,
   releaseStaleQueuedMessageClaims,
   reorderQueuedThreadMessage,
+  restoreConsumedQueuedThreadMessagesInTransaction,
   setQueuedThreadMessageGroupBoundary,
   updateQueuedThreadMessage,
 } from "../../src/data/queued-thread-messages.js";
@@ -1339,5 +1340,148 @@ describe("queued thread messages", () => {
         nextQueuedMessageId: secondQueuedMessage.id,
       }).kind,
     ).toBe("stale_neighbor");
+  });
+
+  it("restores a consumed group at its original place with its grouping and claim cleared (#2370)", () => {
+    const { db, thread } = setup();
+    const base = {
+      threadId: thread.id,
+      model: "gpt-5",
+      reasoningLevel: "medium",
+      permissionMode: "full" as const,
+      serviceTier: "default",
+    };
+    const first = createQueuedThreadMessage(db, noopNotifier, {
+      ...base,
+      content: textInput("do X"),
+    });
+    const second = createQueuedThreadMessage(db, noopNotifier, {
+      ...base,
+      content: textInput("then Y"),
+    });
+    const third = createQueuedThreadMessage(db, noopNotifier, {
+      ...base,
+      content: textInput("queued later"),
+    });
+    setQueuedThreadMessageGroupBoundary({
+      db,
+      expectedGroupedPrefixQueuedMessageIds: [first.id, second.id],
+      groupBoundaryQueuedMessageId: second.id,
+      notifier: noopNotifier,
+      threadId: thread.id,
+    });
+    const claimed = claimQueuedThreadMessageGroup(db, noopNotifier, first.id);
+    if (!claimed) {
+      throw new Error("Expected the head group to be claimed");
+    }
+    expect(claimed.map((row) => row.id)).toEqual([first.id, second.id]);
+    expect(
+      db.transaction((tx) =>
+        deleteClaimedQueuedThreadMessageBatchInTransaction(tx, {
+          queuedMessages: claimed,
+        }),
+      ),
+    ).toBe(true);
+    expect(listQueuedThreadMessages(db, thread.id).map((row) => row.id)).toEqual([
+      third.id,
+    ]);
+
+    // The host refused the dispatch: the same rows go back where they were,
+    // ahead of what was queued behind them, grouped as before and claimable.
+    db.transaction((tx) =>
+      restoreConsumedQueuedThreadMessagesInTransaction(tx, {
+        queuedMessages: claimed,
+      }),
+    );
+    const restored = listQueuedThreadMessages(db, thread.id);
+    expect(
+      restored.map((row) => ({
+        id: row.id,
+        groupWithNext: row.groupWithNext,
+        claimToken: row.claimToken,
+        claimedAt: row.claimedAt,
+      })),
+    ).toEqual([
+      { id: first.id, groupWithNext: true, claimToken: null, claimedAt: null },
+      { id: second.id, groupWithNext: false, claimToken: null, claimedAt: null },
+      { id: third.id, groupWithNext: false, claimToken: null, claimedAt: null },
+    ]);
+    expect(JSON.parse(restored[0]?.content ?? "null")).toEqual(textInput("do X"));
+    expect(claimQueuedThreadMessageGroup(db, noopNotifier, first.id)?.map((row) => row.id)).toEqual([
+      first.id,
+      second.id,
+    ]);
+  });
+
+  it("restores a consumed group ahead of a row queued into the emptied queue while the host refused it (#2370)", () => {
+    const { db, thread } = setup();
+    const base = {
+      threadId: thread.id,
+      model: "gpt-5",
+      reasoningLevel: "medium",
+      permissionMode: "full" as const,
+      serviceTier: "default",
+    };
+    const first = createQueuedThreadMessage(db, noopNotifier, {
+      ...base,
+      content: textInput("do X"),
+    });
+    const second = createQueuedThreadMessage(db, noopNotifier, {
+      ...base,
+      content: textInput("then Y"),
+    });
+    setQueuedThreadMessageGroupBoundary({
+      db,
+      expectedGroupedPrefixQueuedMessageIds: [first.id, second.id],
+      groupBoundaryQueuedMessageId: second.id,
+      notifier: noopNotifier,
+      threadId: thread.id,
+    });
+    const claimed = claimNextQueuedThreadMessageGroup(
+      db,
+      noopNotifier,
+      thread.id,
+    );
+    if (!claimed) {
+      throw new Error("Expected the head group to be claimed");
+    }
+    expect(claimed.map((row) => row.id)).toEqual([first.id, second.id]);
+    db.transaction((tx) =>
+      deleteClaimedQueuedThreadMessageBatchInTransaction(tx, {
+        queuedMessages: claimed,
+      }),
+    );
+    expect(listQueuedThreadMessages(db, thread.id)).toEqual([]);
+
+    // Queued while the dispatch was in flight: an empty queue hands out the
+    // same initial key the consumed head had.
+    const later = createQueuedThreadMessage(db, noopNotifier, {
+      ...base,
+      content: textInput("queued during the round trip"),
+    });
+    expect(later.sortKey).toBe(first.sortKey);
+
+    db.transaction((tx) =>
+      restoreConsumedQueuedThreadMessagesInTransaction(tx, {
+        queuedMessages: claimed,
+      }),
+    );
+    const restored = listQueuedThreadMessages(db, thread.id);
+    expect(
+      restored.map((row) => ({ id: row.id, groupWithNext: row.groupWithNext })),
+    ).toEqual([
+      { id: first.id, groupWithNext: true },
+      { id: second.id, groupWithNext: false },
+      { id: later.id, groupWithNext: false },
+    ]);
+    // Strict key order, not a tie the random id breaks.
+    expect(restored[0]!.sortKey < restored[1]!.sortKey).toBe(true);
+    expect(restored[1]!.sortKey < restored[2]!.sortKey).toBe(true);
+    // The next drain takes the restored group, whole, and nothing else.
+    expect(
+      claimNextQueuedThreadMessageGroup(db, noopNotifier, thread.id)?.map(
+        (row) => row.id,
+      ),
+    ).toEqual([first.id, second.id]);
   });
 });

--- a/packages/host-daemon-contract/src/commands.ts
+++ b/packages/host-daemon-contract/src/commands.ts
@@ -349,12 +349,27 @@ const turnSubmitTargetSchema = z.discriminatedUnion("mode", [
 export type TurnSubmitTarget = z.infer<typeof turnSubmitTargetSchema>;
 
 /**
+ * `turn.submit` failure code for a submission the thread cannot take right
+ * now: the daemon's runtime already has a turn active or starting on it, or
+ * the bridge refused the input as `TURN_BUSY` (its provider is mid-run). The
+ * live turn is untouched, so the server keeps the thread active and parks the
+ * input instead of failing the run (#2370). The runtime's
+ * `AgentRuntimeTurnBusyError.code` is this string; the daemon checks the two
+ * against each other at compile time.
+ */
+export const THREAD_TURN_BUSY_ERROR_CODE = "thread_turn_busy" as const;
+
+/**
  * Submit input for an existing provider thread. The daemon chooses whether
  * auto-targeted input steers the live active turn or starts a new turn. The
  * nullable expected id is the server's snapshot; the daemon rechecks its
  * runtime so input sent while turn/started is still in flight is not mistaken
- * for a competing turn, and rejects instead of starting another turn if the
- * pending start does not produce an id within its bounded wait.
+ * for a competing turn, and rejects with `thread_turn_busy` instead of
+ * starting another turn if the pending start does not produce an id within
+ * its bounded wait. The same code answers a start the runtime refuses while
+ * a turn is active and a submission the bridge refuses as `TURN_BUSY`: the
+ * live turn is untouched, so the server keeps the thread active and
+ * re-queues the input rather than failing the run.
  */
 const turnSubmitCommandSchema = hostDaemonThreadTargetSchema
   .extend({
@@ -2059,7 +2074,9 @@ type HostDaemonRetryableOnlineRpcCommandSchema =
 type HostDaemonResultSchemaMapForTransport<
   Transport extends HostDaemonCommandTransport,
 > = {
-  [Descriptor in HostDaemonCommandDescriptorForTransport<Transport> as Descriptor["type"]]: Descriptor["resultSchema"];
+  [
+    Descriptor in HostDaemonCommandDescriptorForTransport<Transport> as Descriptor["type"]
+  ]: Descriptor["resultSchema"];
 };
 
 type HostDaemonCommandResultSchemaMap =

--- a/packages/host-daemon-contract/src/protocol.ts
+++ b/packages/host-daemon-contract/src/protocol.ts
@@ -307,9 +307,17 @@
 // lets turn submission recover a stale target by re-steering the live turn.
 // An old daemon can still start a competing provider turn in that race.
 //
+// Version 167 adds the `thread_turn_busy` turn.submit failure code. The daemon
+// answers it, instead of a generic failure, when the thread's live turn is
+// untouched: the runtime refused to start a competing turn, or the bridge
+// reported its provider mid-run (`TURN_BUSY`). The server keeps the thread
+// active and re-queues the input. An older daemon reports the same conditions
+// as `command_failed`, which the server still turns into `run.failed` and a
+// lost message (#2370).
+//
 // The version mismatch is what triggers the enrolled daemon's automatic update
 // instead of an `invalid-message` reconnect loop.
-export const HOST_DAEMON_PROTOCOL_VERSION = 166 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 167 as const;
 
 /**
  * Absolute ceiling for any executable artifact delivered to a host daemon —

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -1039,7 +1039,7 @@ describe("host-daemon command schemas", () => {
   // mixed version. Version 113 carried the Devin Desktop open target rename
   // and remains part of the protocol lineage.
   it("uses the current host-daemon protocol version", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(166);
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(167);
     expect(HOST_ARTIFACT_MAX_BYTES).toBe(256 * 1024 * 1024);
   });
 

--- a/packages/provider-bridge-protocol/src/errors.ts
+++ b/packages/provider-bridge-protocol/src/errors.ts
@@ -23,6 +23,14 @@ export const BRIDGE_JSON_RPC_ERRORS = {
   SESSION_NOT_RESTORABLE: -32002,
   /** thread/fork with a checkpoint on a bridge that only forks at the tip. */
   FORK_CHECKPOINT_UNSUPPORTED: -32003,
+  /**
+   * A turn/start or turn/steer the provider refused because it is mid-run
+   * (or compacting) and will not queue the input. The live turn is
+   * untouched: the bridge settles nothing and raises no session error. The
+   * runtime reports the rejection as `thread_turn_busy`, and the server keeps
+   * the thread active and parks the input in its queue (#2370).
+   */
+  TURN_BUSY: -32004,
 } as const;
 
 /**

--- a/packages/templates/src/templates/bb-guide-threads.md
+++ b/packages/templates/src/templates/bb-guide-threads.md
@@ -191,12 +191,16 @@ Messaging:
 
   Tell steers by default, delivering the message immediately into the active
   turn. Use --mode queue for non-urgent follow-ups that can wait until the agent
-  is free. A target that is awaiting user interaction (an open question or
+  is free; --mode auto steers a live turn and starts a new one on an idle
+  thread. A target that is awaiting user interaction (an open question or
   approval) cannot take a prompt; tell then holds the message and delivers it
   in the requested mode once the interaction settles. That outcome is not a
   failure, so do not resend. `--json` reports `delivery` as `sent`, `queued`,
   or `deferred`. A held message waits for a thread that failed while it was
-  held, and delivers when the thread is retried.
+  held, and delivers when the thread is retried. A provider that cannot take
+  a message mid-run (for example while it compacts its context) does not fail
+  the thread: the message moves to the thread's queue and delivers after the
+  live turn.
 
   --plan sends the same structured /plan command the composer's plan action
   sends, so the agent proposes a plan for approval before executing (Claude

--- a/plugins/provider-pi/src/bridge/bridge.round2.test.ts
+++ b/plugins/provider-pi/src/bridge/bridge.round2.test.ts
@@ -2,6 +2,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { BRIDGE_JSON_RPC_ERRORS } from "@get-bb/plugin-sdk/provider-bridge";
 import { handleLine } from "./bridge.js";
 import { PI_BRIDGE_ARGS_ENV, PI_BRIDGE_COMMAND_ENV } from "./rpc-child.js";
 import { FULL_PERMISSION_OPTIONS, type FakePiBridgeHarness, startFakePiBridge } from "./test-support.js";
@@ -190,6 +191,108 @@ function queueUpdateSteering(delta: Record<string, unknown>): unknown[] | null {
   if (message?.type !== "queue_update" || !Array.isArray(message.steering)) return null;
   return message.steering;
 }
+
+it("a steer pi refuses as busy answers TURN_BUSY and leaves the held run open (#2370)", async () => {
+  const threadId = "thr_r2_steer_busy";
+  await harness.startThread(threadId);
+  turnStart(threadId, "/hold", "creq_ab23456789");
+  await harness.waitForDelta(threadId, (d) => d.kind === "turn.open");
+  const before = harness.deltasOf(threadId).length;
+  const refused = await harness.request((nextId += 1), "turn/steer", {
+    threadId,
+    providerThreadId: threadId,
+    expectedTurnId: "turn-1",
+    clientRequestId: "creq_cd23456789",
+    input: [{ type: "text", text: "/busy", mentions: [] }],
+    options: FULL_PERMISSION_OPTIONS,
+  });
+  expect(refused.error).toMatchObject({
+    code: BRIDGE_JSON_RPC_ERRORS.TURN_BUSY,
+    message: expect.stringContaining("compaction is in progress"),
+  });
+  // The rejected request is the whole report: pi is still running the held
+  // turn, so the bridge must not settle it or raise a session error (that is
+  // what flipped a working thread to `error` and stranded its queue).
+  expect(
+    harness.deltasOf(threadId).slice(before).some((d) => d.kind === "turn.boundary" || d.kind === "provider.error"),
+  ).toBe(false);
+  expect(harness.messages.some((m) => m.method === "error")).toBe(false);
+  // The held run is untouched: the next steer pi accepts is consumed by it.
+  const steer = await harness.request((nextId += 1), "turn/steer", {
+    threadId,
+    providerThreadId: threadId,
+    expectedTurnId: "turn-1",
+    clientRequestId: "creq_ef23456789",
+    input: [{ type: "text", text: "carry on", mentions: [] }],
+    options: FULL_PERMISSION_OPTIONS,
+  });
+  expect(steer.result).toMatchObject({ threadId });
+  await harness.waitForDelta(threadId, (d) => d.kind === "turn.boundary" && d.status === "completed", before);
+  expect(harness.deltasOf(threadId).some((d) => d.kind === "item.textDelta" && String(d.text).includes("Steered: carry on"))).toBe(true);
+  expect(harness.messages.some((m) => m.method === "error")).toBe(false);
+}, 90_000);
+
+it("a turn/start pi refuses as busy answers TURN_BUSY without a session error (#2370)", async () => {
+  const threadId = "thr_r2_start_busy";
+  await harness.startThread(threadId);
+  const refused = await harness.request((nextId += 1), "turn/start", {
+    threadId,
+    providerThreadId: threadId,
+    clientRequestId: "creq_ab23456789",
+    input: [{ type: "text", text: "/busy", mentions: [] }],
+    options: FULL_PERMISSION_OPTIONS,
+  });
+  expect(refused.error).toMatchObject({
+    code: BRIDGE_JSON_RPC_ERRORS.TURN_BUSY,
+    message: expect.stringContaining("compaction is in progress"),
+  });
+  // Pi started no run for the refused input, so there is nothing to settle:
+  // a failed boundary here would claim a pending accepted input as a failed
+  // synthetic turn, and a session error would fail the thread.
+  expect(
+    harness.deltasOf(threadId).some((d) => d.kind === "turn.boundary" || d.kind === "provider.error"),
+  ).toBe(false);
+  expect(harness.messages.some((m) => m.method === "error")).toBe(false);
+  // The session is still serving: the next prompt runs a turn.
+  turnStart(threadId, "hello again", "creq_cd23456789");
+  await harness.waitForDelta(threadId, (d) => d.kind === "turn.boundary" && d.status === "completed");
+  expect(harness.deltasOf(threadId).some((d) => d.kind === "input.accepted" && d.clientRequestId === "creq_cd23456789")).toBe(true);
+}, 90_000);
+
+it("a turn/start pi refuses as busy during a held run leaves that run open (#2370)", async () => {
+  const threadId = "thr_r2_start_busy_held";
+  await harness.startThread(threadId);
+  turnStart(threadId, "/hold", "creq_ab23456789");
+  await harness.waitForDelta(threadId, (d) => d.kind === "turn.open");
+  const before = harness.deltasOf(threadId).length;
+  const refused = await harness.request((nextId += 1), "turn/start", {
+    threadId,
+    providerThreadId: threadId,
+    clientRequestId: "creq_cd23456789",
+    input: [{ type: "text", text: "/busy", mentions: [] }],
+    options: FULL_PERMISSION_OPTIONS,
+  });
+  expect(refused.error).toMatchObject({ code: BRIDGE_JSON_RPC_ERRORS.TURN_BUSY });
+  // The held run is still the live turn: the refusal settled no boundary on
+  // it (that is what closed a working turn as failed) and raised no error.
+  expect(
+    harness.deltasOf(threadId).slice(before).some((d) => d.kind === "turn.boundary" || d.kind === "provider.error"),
+  ).toBe(false);
+  expect(harness.messages.some((m) => m.method === "error")).toBe(false);
+  // The run resumes on the next steer and settles itself.
+  const steer = await harness.request((nextId += 1), "turn/steer", {
+    threadId,
+    providerThreadId: threadId,
+    expectedTurnId: "turn-1",
+    clientRequestId: "creq_ef23456789",
+    input: [{ type: "text", text: "carry on", mentions: [] }],
+    options: FULL_PERMISSION_OPTIONS,
+  });
+  expect(steer.result).toMatchObject({ threadId });
+  await harness.waitForDelta(threadId, (d) => d.kind === "turn.boundary" && d.status === "completed", before);
+  expect(harness.deltasOf(threadId).some((d) => d.kind === "item.textDelta" && String(d.text).includes("Steered: carry on"))).toBe(true);
+  expect(harness.messages.some((m) => m.method === "error")).toBe(false);
+}, 90_000);
 
 it("a steer still queued when the run ends is reported dropped through the delivery barrier, not a timer", async () => {
   vi.stubEnv("FAKE_PI_DROP_STEER_AT_END", "1");

--- a/plugins/provider-pi/src/bridge/bridge.ts
+++ b/plugins/provider-pi/src/bridge/bridge.ts
@@ -1096,8 +1096,37 @@ async function handleTurnStart(id: string | number, params: TurnStartParams): Pr
     recordAcceptedTurnInput(params);
     sendResult(id, { threadId: params.threadId });
   } catch (error) {
-    sendError(id, -32000, error instanceof Error ? error.message : String(error));
+    sendInputDispatchError(id, error);
   }
+}
+
+/**
+ * Pi's own refusals of input while it is mid-run. Pi's RPC mode answers a
+ * `prompt` with an error only when the refusal precedes its preflight
+ * (`preflightResult(true)` is already the success response), which is how
+ * `AgentSession.prompt`'s compaction refusal arrives. The `Agent.prompt`
+ * guard ("Agent is already processing a prompt", a run live while the
+ * session's streaming flag is down) fires after preflight, so pi 0.84's RPC
+ * mode swallows it; it is matched for a pi that surfaces it (the reporter's
+ * in-process session did, #2370). Neither refusal touches the live run, so
+ * the bridge answers `TURN_BUSY` and the runtime keeps the turn.
+ */
+const PI_BUSY_REFUSAL_PATTERNS = [
+  /Cannot submit a prompt while compaction is in progress/u,
+  /Agent is already processing/u,
+];
+
+function isPiBusyRefusal(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return PI_BUSY_REFUSAL_PATTERNS.some((pattern) => pattern.test(message));
+}
+
+function sendInputDispatchError(id: string | number, error: unknown): void {
+  sendError(
+    id,
+    isPiBusyRefusal(error) ? BRIDGE_JSON_RPC_ERRORS.TURN_BUSY : -32000,
+    error instanceof Error ? error.message : String(error),
+  );
 }
 
 async function handleTurnSteer(id: string | number, params: TurnSteerParams): Promise<void> {
@@ -1112,7 +1141,8 @@ async function handleTurnSteer(id: string | number, params: TurnSteerParams): Pr
     return;
   }
   if (threadSession.session.getIsCompacting()) {
-    sendError(id, -32000, "Cannot steer while context compaction is active");
+    // The compaction turn is live and pi takes no input during it.
+    sendError(id, BRIDGE_JSON_RPC_ERRORS.TURN_BUSY, "Cannot steer while context compaction is active");
     return;
   }
   try {
@@ -1122,7 +1152,7 @@ async function handleTurnSteer(id: string | number, params: TurnSteerParams): Pr
     ]);
     sendResult(id, { threadId: params.threadId });
   } catch (error) {
-    sendError(id, -32000, error instanceof Error ? error.message : String(error));
+    sendInputDispatchError(id, error);
   }
 }
 

--- a/plugins/provider-pi/src/bridge/fake-pi-rpc.mjs
+++ b/plugins/provider-pi/src/bridge/fake-pi-rpc.mjs
@@ -57,6 +57,10 @@
  *   FAKE_PI_BATCH_STEER_REPLY=1 writes a steer's `prompt` response and the
  *   resumed run's first event in one stdout write (one read on the bridge's
  *   side). The prompt `/die` exits the process mid-run without answering.
+ *   The prompt `/busy` (any streamingBehavior) is refused with pi's own
+ *   compaction preflight error ("Cannot submit a prompt while compaction is
+ *   in progress"), the one prompt refusal pi's RPC mode answers as an error
+ *   (#2370); queues and the live run are untouched.
  * - `prompt` with `streamingBehavior: "steer"` during a `/hold` run is queued
  *   (`queue_update.steering`), consumed when the run resumes, and the run's
  *   reply names it.
@@ -464,6 +468,17 @@ async function handle(command) {
       });
       return;
     case "prompt": {
+      if (command.message === "/busy") {
+        // `AgentSession.prompt` throws this before `preflightResult`, so RPC
+        // mode answers the prompt with the error. Nothing is queued and the
+        // live run keeps going.
+        respondError(
+          id,
+          "prompt",
+          "Cannot submit a prompt while compaction is in progress. Wait for compaction to finish and retry.",
+        );
+        return;
+      }
       if (isStreaming && command.streamingBehavior === "steer") {
         // A steer into a live run: pi reports the queue BEFORE it answers the
         // preflight (recorded order), then hands it to the run (a held run
@@ -563,12 +578,14 @@ readLines(process.stdin, (line) => {
     return;
   }
   // Commands are handled in order, but `prompt` runs its scripted turn
-  // asynchronously so `abort` — and a steer into a held run — can reach it.
+  // asynchronously so `abort` — and a steer or a `/busy` refusal into a held
+  // run — can reach it.
   if (
     command.type === "abort" ||
     command.type === "get_state" ||
     command.type === "get_session_stats" ||
-    (command.type === "prompt" && command.streamingBehavior === "steer")
+    (command.type === "prompt" &&
+      (command.streamingBehavior === "steer" || command.message === "/busy"))
   ) {
     void loaded.then(() => handle(command));
     return;

--- a/plugins/provider-pi/src/bridge/rpc-session.ts
+++ b/plugins/provider-pi/src/bridge/rpc-session.ts
@@ -385,6 +385,7 @@ export class PiRpcSession {
       void consumed.catch(() => undefined);
       return { consumed, settled: Promise.resolve(null) };
     }
+    const wasProcessing = this.isProcessing;
     this.isProcessing = true;
     const tracked = this.trackPendingInputConsumption("followUp");
     const settlement = new Promise<PiPromptRunOutcome>((resolve) => {
@@ -415,15 +416,19 @@ export class PiRpcSession {
         return outcome;
       },
       (error: unknown): PiPromptRunOutcome | null => {
-        this.isProcessing = false;
+        // The rejected request is the whole report: pi started no run for
+        // this input, so there is nothing to settle — not on the session
+        // (a session error closed a live turn from under pi) and not as a
+        // prompt settlement (a failed settlement is a failed turn boundary,
+        // which the assembler applies to the open turn or, with an accepted
+        // input pending, to a synthetic one). A run that is live (pi
+        // refusing the prompt while it compacts) keeps going and its own
+        // agent_end settles it (#2370). Inputs pi already queued for that
+        // run stay tracked; the run consumes them.
+        this.isProcessing = wasProcessing;
         this.dropRunSettlement(settlement);
-        const queued = tracked.pending.queuedText !== null;
         this.rejectPendingInputConsumption(tracked.pending, asError(error));
-        this.rejectPendingInputConsumptions(
-          "Pi prompt failed before input was consumed",
-        );
-        this.onDone(error);
-        return queued ? null : { error };
+        return null;
       },
     );
     return { consumed: tracked.promise, settled };
@@ -440,8 +445,9 @@ export class PiRpcSession {
         streamingBehavior: "steer",
       });
     } catch (error) {
+      // The rejection is the report; the run the steer targeted is still
+      // live, so no session error (it would settle that run, #2370).
       this.rejectPendingInputConsumption(tracked.pending, asError(error));
-      this.onDone(error);
       throw error;
     }
     if (tracked.pending.queuedText === null) {


### PR DESCRIPTION
## Human comments

## What was wrong

A turn submission the thread could not take was a generic failure at every layer. `bb thread tell --mode auto` into a thread whose turn the daemon still holds (a start whose `turn/started` is in flight, the pending-start wait, #2379's admission assert) or whose provider refuses input mid-run (pi while it compacts) came back as `command_failed`. The server appended `system/error`, applied `run.failed` (status `error` while the native transcript advanced), and dropped the message. The queue never drained because it only drains from `idle`, until `thread stop` released the runtime.

The pi bridge amplified a refusal: a rejected prompt raised a session error (`onDone(error)` → `provider.error {settlesTurn}`) and resolved a failed prompt settlement (→ a failed `turn.boundary` with `claimIfIdle`). Either closed the open turn from under pi, after which every later send resolved to `start` and was refused identically; those are the repeated error blocks in #2370. There is no bb retry loop: each block was one new send hitting the same state.

The most common trigger in practice is two sends a few seconds apart from the UI or CLI on an idle thread: send 1 starts a turn, send 2 arrives while `turn/started` is still pending, and the daemon waited only 5 s (#2242) before refusing with "Refusing to start a competing turn while … is still starting". Measured on a Claude Code thread on 2026-08-25, `client/turn/requested` → `turn/started` took 7–15 s, so the refusal fired routinely.

On the reporter's nightly (7e10ea4b, before #2379) the refusal text came from `Agent.prompt` in the in-process pi SDK session. On `main`, pi runs as an RPC child whose `prompt` answers an error only for refusals that precede its preflight (compaction); the post-preflight guard is swallowed. The pattern is kept as a defensive match only.

## What changed

Two commits.

**Commit 1 — park input the provider is too busy to take instead of failing the run**

- `packages/provider-bridge-protocol`: `BRIDGE_JSON_RPC_ERRORS.TURN_BUSY` (-32004) for a `turn/start` or `turn/steer` the provider refuses because it is mid-run (or compacting) and will not queue the input. Documented in `docs/provider-bridge-protocol.md`.
- `plugins/provider-pi`: a rejected prompt/steer dispatch settles nothing (no session error, no prompt settlement) and keeps `isProcessing` as it was. Pi's compaction refusal, the bridge's own compaction-active steer refusal, and (defensively) the `Agent.prompt` guard answer `TURN_BUSY`. The fake pi's `/busy` knob models the compaction refusal pi really sends over RPC.
- `packages/agent-runtime`: `AgentRuntimeTurnBusyError` (code `thread_turn_busy`) for the competing-start refusal and for `TURN_BUSY` rejections; turn state is left untouched; a refused start re-marks the session idle so the idle reaper can still release it.
- `packages/host-daemon-contract`: `THREAD_TURN_BUSY_ERROR_CODE`, the one wire spelling. **`HOST_DAEMON_PROTOCOL_VERSION` 170 → 171** (new `turn.submit` failure code on the wire).
- `apps/host-daemon`: the pending-start refusal is an `ExpectedCommandDispatchError` with that code; `thread_turn_busy` is an expected RPC failure, checked against the runtime error's literal type at compile time.
- `apps/server` (policy): a `thread_turn_busy` `turn.submit` failure records `client/turn/rejected` but appends no `system/error` and applies no `run.failed`; the live turn owns the status. The input is parked, never lost: a direct send goes to the thread's queue (raw payload, arrival order); a consumed queued group is restored at the head of the queue with its ids and grouping (`restoreConsumedQueuedThreadMessagesInTransaction`) on both drain paths, with fresh sort keys ahead of the current head; a parent system message (child-completed notice) is held in `deferred_thread_messages` with its taxonomy, stamped with the turn that refused it, and skipped while that turn is live (one attempt per turn); rows behind it still get their attempt. The re-queue hook is scoped to `turn.submit` dispatches.
- CLI/skill/guide: `--mode auto` and the busy fallback are described on `bb thread tell --help`, the bb-cli skill, and the threads guide.

**Commit 2 — wait out a starting turn and steer into it instead of refusing**

- `packages/agent-runtime`: `RuntimeTurnState.releaseWaiters(threadId)` resolves every `waitForActiveTurn` waiter with `null` when a pending start ends without a turn (bridge refused the start, a thread-scoped non-retrying `provider/error`, thread stop, process detach, shutdown) via `dropPendingTurnStartWithoutTurn`. `turn/started` still resolves waiters with the id first. `WaitForActiveTurnArgs.signal` (AbortSignal) lets a caller cancel the wait. `DEFAULT_TURN_START_WATCHDOG_THRESHOLD_MS` (120 s) is exported.
- `apps/host-daemon`: the pending-start wait is now `DEFAULT_TURN_START_WATCHDOG_THRESHOLD_MS` instead of 5 s, so "still starting" has one meaning (the watchdog's); because the runtime releases waiters early, the bound is only reached for a start the watchdog also reports as stuck. `thread.stop` shares the per-thread lane with `turn.submit`, so the router keeps an `AbortController` per admitted `turn.submit` and an **interrupt** stop aborts them synchronously on arrival (`abortQueuedTurnSubmits`); an aborted wait, or a steer whose stop signal is already aborted, falls to the typed `thread_turn_busy` refusal, the server parks the input, and the stop runs next. A **release** stop does not abort (it leaves lifecycle state alone and skips a busy runtime, so a parked input would have nothing left to settle the thread); the submit keeps its wait and starts its turn if the release ends the pending start. No wire change (`threadStopRequested` is a daemon-internal dispatch option).
- `tests/scripted-echo-provider`: `thread_scoped_fail:<text>` directive (accept input, emit a thread-scoped non-retrying `provider/error`, no turn), matching codex's real shape.
- Contract comment, bb-cli skill, and threads guide updated: a message sent while the turn is starting waits for the start and steers into it; only a start the runtime reports as stuck, or a stop that arrives first, parks the message in the queue.

Known follow-ups (documented, not in this PR): the timeline still renders a busy-parked request as a rejected user row before the queued copy is delivered (thread-view projection change); a `start` refused busy on an idle thread waits on the daemon's turn events with no server-side watchdog; a later parent-system notice can overtake a held one when the provider accepts a steer mid-turn; `thread.archive` / `interactive.resolve` / `thread.plan.cancel` / `thread.goal.clear` queued behind a waiting submit still wait up to the bound (benign today, untested).

## How you verified

Regression tests fail on the previous source and pass after (file-swap proofs logged per package):
- pi bridge `bridge.round2.test.ts`: busy steer/start answer `TURN_BUSY` with no `turn.boundary` and no session error, including a `turn/start` refused during a held run.
- agent-runtime `runtime.recovery.test.ts` / `runtime.lifecycle.test.ts`: typed busy on refused start/steer, live turn kept, refused start still reapable; a `waitForActiveTurn` waiter is released as soon as the bridge refuses the pending start, when an accepted start fails before its turn opens, and when the thread is stopped while its start is pending; `runtime-turn-state.test.ts`: `releaseWaiters` releases one thread's waiters only; abort signal resolves the wait.
- host-daemon `command-dispatch.test.ts` / `thread-stop-races.test.ts`: typed expected code; pending start → id → `appliedAs: steer` with the 120 s bound; a start that ends without a turn runs the input as a new turn; an interrupt `thread.stop` aborts a waiting submit, which parks its input, and the stop runs next; a release stop waits behind the submit instead; a steer whose stop is already queued is parked.
- db `queued-thread-messages.test.ts`: restore keeps ids and grouping, clears claims, lands ahead of a row queued into the emptied queue, and is what the next drain claims.
- server `thread-send-dispatch.test.ts`: busy send keeps the thread active and queues the raw input; busy queued auto-send restores the group at the head; busy queued send into an active thread restores the group with its grouping ahead of the trailing row; busy parent system message is held with its taxonomy, not retried while the turn is live, steered into the next turn, and does not block a send deferred behind it.
- contract test: protocol version expectation.

Commands (all through turbo, `--force`, on the rebased tip): typecheck for `@bb/db`, `@bb/provider-bridge-protocol`, `@bb/agent-runtime`, `@bb/host-daemon`, `@bb/host-daemon-contract`, `bb-plugin-provider-pi`, `@bb/server`, `@bb/cli`, `@bb/templates`, `bb-plugin-scripted-echo-provider`; the matching `test` tasks plus `@bb/agent-runtime#test:integration` and `@bb/server#test:provider-corpus`: all green. Four independent adversarial review rounds (the stop-lane finding came from one of them). EAP codename scan of `origin/main..HEAD`: clean.

Not done: no live reproduction against a real `pi --mode rpc` session during manual compaction (proven from pi's source and the fake's RPC shape instead).

Fixes #2370

> AGENT GENERATED
