### PR TITLE
Complete reserved plugin CLI command inventory

### DIFF
--- a/apps/cli/src/__tests__/plugin-cli-proxy.test.ts
+++ b/apps/cli/src/__tests__/plugin-cli-proxy.test.ts
@@ -1,21 +1,13 @@
 import { createServer, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { Command } from "commander";
 import { Agent, getGlobalDispatcher, setGlobalDispatcher } from "undici";
 import { RESERVED_BB_CLI_COMMANDS } from "@bb/domain/plugin-cli";
 
-import { registerEnvironmentCommands } from "../commands/environment.js";
-import { registerGuideCommand } from "../commands/guide.js";
-import { registerManagerCommands } from "../commands/manager.js";
-import { registerPluginCommands } from "../commands/plugin.js";
-import { registerProjectCommands } from "../commands/project.js";
-import { registerProviderCommands } from "../commands/provider.js";
-import { registerSkillCommands } from "../commands/skill.js";
-import { registerStatusCommand } from "../commands/status.js";
-import { registerThemeCommands } from "../commands/theme.js";
-import { registerThreadCommands } from "../commands/thread/index.js";
-import { pluginProxyCandidate } from "../command-groups.js";
+import {
+  CORE_COMMAND_GROUPS,
+  pluginProxyCandidate,
+} from "../command-groups.js";
 import {
   describeUnreachableServer,
   fetchPluginCliContributions,
@@ -26,50 +18,11 @@ import {
   type PluginCliContributionEntry,
 } from "../plugin-cli-proxy.js";
 
-function buildProgram(): Command {
-  const program = new Command();
-  const getUrl = () => "http://localhost";
-  registerStatusCommand(program, getUrl);
-  registerProjectCommands(program, getUrl);
-  registerProviderCommands(program, getUrl);
-  registerManagerCommands(program);
-  registerThreadCommands(program, getUrl);
-  registerEnvironmentCommands(program, getUrl);
-  registerThemeCommands(program, getUrl);
-  registerPluginCommands(program, getUrl);
-  registerSkillCommands(program, getUrl, () => ({ serverUrl: getUrl() }));
-  registerGuideCommand(program);
-  return program;
-}
-
-function topLevelCommandNames(program: Command): string[] {
-  return program.commands.flatMap((command) => [
-    command.name(),
-    ...command.aliases(),
-  ]);
-}
-
 describe("reserved bb CLI command names", () => {
-  it("every core top-level command is on the server's reserved list", () => {
-    const names = topLevelCommandNames(buildProgram());
-    const reserved = new Set(RESERVED_BB_CLI_COMMANDS);
-    for (const name of names) {
-      expect(
-        reserved,
-        `"${name}" is missing from RESERVED_BB_CLI_COMMANDS`,
-      ).toContain(name);
-    }
-  });
-
-  it("the reserved list carries no stale entries", () => {
-    const names = new Set(topLevelCommandNames(buildProgram()));
-    names.add("help"); // commander built-in
-    for (const reserved of RESERVED_BB_CLI_COMMANDS) {
-      expect(
-        names,
-        `"${reserved}" is reserved but not a core command`,
-      ).toContain(reserved);
-    }
+  it("matches the complete core command-group registry plus help", () => {
+    expect([...RESERVED_BB_CLI_COMMANDS].sort()).toEqual(
+      [...CORE_COMMAND_GROUPS.map((group) => group.name), "help"].sort(),
+    );
   });
 });
 
@@ -84,7 +37,7 @@ describe("pluginProxyCandidate", () => {
     // `automation` and `connect` moved into builtin plugins: they must not
     // be reserved, and the real program must not register them, so the
     // proxy resolves them against the running server.
-    const names = new Set(topLevelCommandNames(buildProgram()));
+    const names = new Set(CORE_COMMAND_GROUPS.map((group) => group.name));
     names.add("help");
     for (const moved of ["automation", "connect"]) {
       expect(RESERVED_BB_CLI_COMMANDS).not.toContain(moved);

--- a/packages/domain/src/plugin-cli.ts
+++ b/packages/domain/src/plugin-cli.ts
@@ -9,16 +9,23 @@
  */
 export const RESERVED_BB_CLI_COMMANDS: readonly string[] = [
   "environment",
+  "file",
   "guide",
   "help",
+  "machine",
   "manager",
+  "marketplace",
   "plugin",
   "project",
   "provider",
+  "settings",
   "skill",
   "status",
+  "terminal",
   "theme",
   "thread",
+  "updates",
+  "voice",
 ];
 
 export function pluginCliCall(pluginId: string, name: string): string {


### PR DESCRIPTION
## What was wrong

The shared reserved-name inventory introduced for plugin CLI collisions in #2411 covered only 10 of BB's 17 live core command groups plus Commander's built-in `help`. Its regression test manually assembled the same older subset instead of comparing with the authoritative command-group registry, so the inventory could drift while the guard stayed green. As a result, `bb plugin new settings` (and six sibling names) created plugins whose short command was already core-owned, while warning and discovery surfaces advertised that unreachable short form.

## What changed

Added the seven missing live core names: `settings`, `machine`, `updates`, `terminal`, `file`, `marketplace`, and `voice`. Replaced the duplicated hand-built test program with one exact invariant comparing `RESERVED_BB_CLI_COMMANDS` against `CORE_COMMAND_GROUPS` plus `help`; the existing command-group test independently proves that registry matches every real top-level Commander registrar and has no aliases.

This preserves intentional plugin-plugin arbitration and keeps plugin-contributed names such as `automation` and `connect` unreserved. It adds no registry, manager, public API, CLI command/flag, configuration knob, or documentation surface. No server/daemon wire contract changed, so `HOST_DAEMON_PROTOCOL_VERSION` remains unchanged.

## How you verified

Before the production fix, the new focused invariant failed with exactly the seven missing names. A detached build of the pre-fix `origin/main` SHA reproduced `bb plugin new settings` exiting 0 and creating the scaffold while `bb settings` remained core-owned; the fixed artifact exits 1 with the reserved-name error.

After the fix:

- Focused CLI/server/SDK/app collision and discovery coverage: 7 files, 169 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/domain --filter=@bb/cli` passed (5 tasks).
- `pnpm exec turbo run build --filter=@bb/cli` passed (4 tasks).
- `pnpm exec turbo run test --filter=@bb/domain --filter=@bb/cli --force` passed: 79 files, 667 tests.
- `git diff --check origin/main...HEAD` passed.

Follow-up to #2411.

> AGENT GENERATED
