### PR TITLE
Key bundled install counts by canonical plugin ID

### DIFF
--- a/apps/server/src/services/plugin-catalog/plugin-catalog-service.ts
+++ b/apps/server/src/services/plugin-catalog/plugin-catalog-service.ts
@@ -441,9 +441,9 @@ export function createPluginCatalogService(deps: {
       // Bundled plugins are BB's own; attribute them like the seed entries.
       author: { name: "BB Team", url: "https://getbb.app" },
       installed: getInstalledPlugin(deps.db, entry.pluginId) !== undefined,
-      // Bundled plugins are counted under their own entry id: telemetry sends
-      // a plugin_id for them too, so the curated sidecar names them alongside
-      // the entries it lists.
+      // Bundled plugins are counted under their canonical plugin id: telemetry
+      // sends that id too, so the curated sidecar names them alongside the
+      // entries it lists.
       installs,
       compatible: problem === null,
       incompatibleReason: problem,
@@ -1180,7 +1180,7 @@ export function createPluginCatalogService(deps: {
               entry,
               manifest,
               icon?.hash ?? null,
-              curatedInstalls.get(entry.name) ?? null,
+              curatedInstalls.get(entry.pluginId) ?? null,
             ),
           };
         }),

--- a/apps/server/test/services/plugin-catalog/plugin-catalog-service.test.ts
+++ b/apps/server/test/services/plugin-catalog/plugin-catalog-service.test.ts
@@ -634,13 +634,15 @@ describe("plugin catalog service", () => {
     }
 
     it("reports counts for curated entries and bundled plugins", async () => {
-      const bundled = listBundledPluginRegistrations()[0];
-      if (bundled === undefined) throw new Error("no bundled plugin");
+      const bundled = listBundledPluginRegistrations().find(
+        (plugin) => plugin.name === "docs" && plugin.pluginId === "simple-notes",
+      );
+      if (bundled === undefined) throw new Error("docs registration missing");
       const catalog = service({
         fetch: fetchWith(() =>
           statsResponse({
             widgets: { installs: 4_210 },
-            [bundled.name]: { installs: 12 },
+            [bundled.pluginId]: { installs: 12 },
           }),
         ),
       });


### PR DESCRIPTION
## What was wrong

Plugin install telemetry and the trusted marketplace stats sidecar key bundled plugins by canonical plugin ID, but the server's bundled search-result mapper joined those counts with the separate source entry name. Docs is the existing alias: its source entry is `docs`, while its canonical plugin ID is `simple-notes`, so both the web store and `bb plugin search` omitted its published count. The same mismatch would affect any future bundled alias. This is a focused follow-up to #2282.

## What changed

The bundled mapper now reads the trusted count map with the canonical `entry.pluginId`. The existing server regression uses the repository's real `docs` / `simple-notes` registration, so it protects the class-wide identity invariant rather than a same-name fixture.

Curated marketplace entries remain keyed by `entry.id`; third-party counts remain null; lifetime-count and privacy semantics are unchanged. No alias registry, compatibility layer, migration, persisted state, public API, CLI/app code, guide/docs, or mobile change was added. Nothing crosses the server/host-daemon boundary, so `HOST_DAEMON_PROTOCOL_VERSION` remains 167.

## How you verified

- The regression failed before the production change with `expected null to be 12`, then passed after it.
- Focused install-count group: 6 passed.
- `pnpm exec turbo run test --filter=@bb/server --force`: 211 test files passed, 1 skipped; 2,030 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/server`: passed.
- `pnpm exec turbo run build --filter=@bb/server`: passed.
- Current dev API returned `{ entryId: "docs", pluginId: "simple-notes", installs: 139 }`.
- Checkout-built `bb plugin search Docs` printed an `Installs` column with 139.
- DevBrowser verified Extensions → Plugins renders `139 installs` on the Docs card.
- `git diff --check`: passed.

Fixes: none — follow-up to #2282.

> AGENT GENERATED
