### PR TITLE
Add sidebar lifecycle filters and drafts

### DIFF
--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -57,6 +57,7 @@ import { AppCommandProvider } from "./components/commands/AppCommandProvider";
 import { ProviderCliInstallLogDialogHost } from "./components/provider-cli/provider-cli-install";
 import { PluginSettingsCompatibilityRoute } from "./components/settings/PluginSettingsCompatibilityRoute";
 import { RouteLoadingSkeleton } from "./components/ui/route-loading-skeleton";
+import { AppLocalStateInitialization } from "./components/AppLocalStateInitialization";
 
 const SettingsView = lazy(() =>
   import("./views/SettingsView").then((m) => ({
@@ -337,6 +338,7 @@ export function App() {
 
   return (
     <QuickCreateProjectProvider>
+      <AppLocalStateInitialization />
       <AppCommandProvider>
         <RouteNavigationProvider>
           <AppNavigationUrlHost>
@@ -350,7 +352,6 @@ export function App() {
                 />
                 <Route path="*" element={<AppRoutes />} />
               </Routes>
-              {}
               <ProviderCliInstallLogDialogHost />
             </AppFileExternalNavigationHost>
           </AppNavigationUrlHost>

--- a/apps/app/src/components/AppLocalStateInitialization.test.tsx
+++ b/apps/app/src/components/AppLocalStateInitialization.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { StrictMode } from "react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  promptDraftSlotStorageKeysForTests,
+  readNewThreadDraftSlots,
+} from "@/lib/prompt-draft-slots";
+import { useNewThreadDraftSlots } from "@/hooks/useNewThreadDraftSlots";
+import { AppLocalStateInitialization } from "./AppLocalStateInitialization";
+
+function DraftRows() {
+  const drafts = useNewThreadDraftSlots();
+  return <output>{drafts.map((draft) => draft.title).join(", ")}</output>;
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+  window.localStorage.clear();
+});
+
+describe("AppLocalStateInitialization", () => {
+  it("migrates the legacy shared composer draft at app boot", () => {
+    window.localStorage.setItem(
+      "bb.root-compose.project-id",
+      "project-at-launch",
+    );
+    window.localStorage.setItem(
+      promptDraftSlotStorageKeysForTests.legacy,
+      JSON.stringify({ text: "Never lose this draft", attachments: [] }),
+    );
+
+    render(
+      <StrictMode>
+        <AppLocalStateInitialization />
+        <DraftRows />
+      </StrictMode>,
+    );
+
+    expect(readNewThreadDraftSlots()).toEqual([
+      expect.objectContaining({
+        draft: {
+          attachments: [],
+          mentions: [],
+          text: "Never lose this draft",
+        },
+        destination: {
+          projectId: "project-at-launch",
+          sectionId: null,
+        },
+      }),
+    ]);
+    expect(
+      window.localStorage.getItem(promptDraftSlotStorageKeysForTests.legacy),
+    ).toBeNull();
+    expect(screen.getByText("Never lose this draft")).not.toBeNull();
+  });
+});

--- a/apps/app/src/components/AppLocalStateInitialization.tsx
+++ b/apps/app/src/components/AppLocalStateInitialization.tsx
@@ -1,0 +1,17 @@
+import { useEffect, useRef } from "react";
+import { refreshNewThreadDraftSlots } from "@/hooks/usePromptDraftStorage";
+import { initializeNewThreadDraftSlots } from "@/lib/prompt-draft-slots";
+import { readRootComposeProjectId } from "@/lib/root-compose-selection";
+
+export function AppLocalStateInitialization() {
+  const didInitializeDraftSlots = useRef(false);
+
+  useEffect(() => {
+    if (didInitializeDraftSlots.current) return;
+    didInitializeDraftSlots.current = true;
+    initializeNewThreadDraftSlots(readRootComposeProjectId());
+    refreshNewThreadDraftSlots();
+  }, []);
+
+  return null;
+}

--- a/apps/app/src/components/sidebar/ProjectList.modes.test.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.modes.test.tsx
@@ -17,7 +17,11 @@ import {
 } from "jotai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ThreadListEntry } from "@bb/domain";
-import { ActiveSidebarModeSections, MachineModeSections } from "./ProjectList";
+import {
+  ActiveSidebarModeSections,
+  BuiltInSidebarLifecycleSections,
+  MachineModeSections,
+} from "./ProjectList";
 import { buildMachineThreadGroups } from "@bb/client-core";
 import {
   collapsedSidebarSectionIdsAtom,
@@ -195,6 +199,35 @@ afterEach(() => {
 });
 
 describe("sidebar organization mode sections", () => {
+  it.each<SidebarOrganizationMode>(["project", "chronological", "machine"])(
+    "keeps drafts above %s sections and archived rows trailing",
+    (mode) => {
+      const { container } = render(
+        <BuiltInSidebarLifecycleSections
+          draftRows={<div>Drafts</div>}
+          activeModeSections={
+            <ActiveSidebarModeSections
+              mode={mode}
+              renderChronological={() => <div>Chronological</div>}
+              renderMachine={() => <div>Machine</div>}
+              renderProject={() => <div>Project</div>}
+            />
+          }
+          archivedRows={<div>Archived</div>}
+          emptyState={null}
+        />,
+      );
+
+      const activeLabel =
+        mode === "chronological"
+          ? "Chronological"
+          : mode === "machine"
+            ? "Machine"
+            : "Project";
+      expect(container.textContent).toBe(`Drafts${activeLabel}Archived`);
+    },
+  );
+
   it("does not mount inactive ordering or machine-grouping work", async () => {
     const store = createStore();
     store.set(sidebarSectionOrderAtom, ["threads", "project:a", "pinned"]);

--- a/apps/app/src/components/sidebar/ProjectList.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.tsx
@@ -27,6 +27,7 @@ import {
 import { isTransientReadError } from "@/hooks/queries/query-helpers";
 import { stripProjectThreads } from "@/hooks/queries/project-queries";
 import { useSidebarNavigation } from "@/hooks/queries/sidebar-navigation-query";
+import { useArchivedThreads } from "@/hooks/queries/thread-queries";
 import { useReorderPinnedThread } from "@/hooks/mutations/thread-state-mutations";
 import {
   useCreateThreadSection,
@@ -40,8 +41,10 @@ import {
 import { useHosts, usePrimaryHost } from "@/hooks/queries/host-queries";
 import { useDialogState } from "@/hooks/useDialogState";
 import { usePromptDraftInputThreadIds } from "@/hooks/usePromptDraftStorage";
+import { useNewThreadDraftSlots } from "@/hooks/useNewThreadDraftSlots";
 import { getCollapsedChildActivity } from "@bb/client-core";
 import { getRootComposeRoutePath } from "@/lib/route-paths";
+import { withRootComposeDraftSlotId } from "@/lib/root-compose-location-state";
 import { getThreadDisplayTitle } from "@/lib/thread-title";
 import { getMutationErrorMessage } from "@/lib/mutation-errors";
 import { BbHttpError } from "@bb/sdk/browser";
@@ -75,6 +78,10 @@ import {
   ChronologicalSectionThreadSections,
   ProjectThreadTree,
 } from "./ProjectRow";
+import {
+  SidebarArchivedThreadGroup,
+  SidebarDraftRows,
+} from "./SidebarLifecycleRows";
 import type { ProjectThreadListState } from "./ProjectRow";
 import {
   buildMachineThreadGroups,
@@ -130,7 +137,8 @@ import {
   SIDEBAR_ROW_INTERACTIVE_STATE_CLASS,
   SIDEBAR_STANDARD_ROW_PADDING_CLASS,
 } from "./sidebarRowClasses";
-export { TopLevelSidebarSection } from "./TopLevelSidebarSection";
+import { TopLevelSidebarSection } from "./TopLevelSidebarSection";
+export { TopLevelSidebarSection };
 import {
   useAppCommandRunner,
   useAppCommandShortcut,
@@ -150,6 +158,15 @@ import {
   resolveThreadTitleDisplayText,
   type ThreadTitleMentionResources,
 } from "@/components/thread/ThreadTitleMentions";
+import {
+  isDefaultSidebarThreadLifecycleSelection,
+  builtInSidebarDraftRowsVisibleAtom,
+  getBuiltInSidebarLifecycleRenderState,
+  sidebarThreadLifecycleSelectionAtom,
+  SIDEBAR_THREAD_LIFECYCLE_STATES,
+  toggleSidebarThreadLifecycleState,
+  type SidebarThreadLifecycleState,
+} from "./sidebarThreadLifecycle";
 
 interface ProjectListProps {
   onNewProject?: () => void;
@@ -588,10 +605,12 @@ const SIDEBAR_SORT_OPTIONS = [
 
 function SidebarDisplayMenuTrigger({
   ariaLabel,
+  filtered,
   iconName,
   tooltip,
 }: {
   ariaLabel: string;
+  filtered: boolean;
   iconName: IconName;
   tooltip: string;
 }) {
@@ -608,13 +627,20 @@ function SidebarDisplayMenuTrigger({
             size="icon"
             aria-label={ariaLabel}
             className={cn(
-              "rounded-md p-0 text-muted-foreground",
+              "relative rounded-md p-0 text-muted-foreground",
               "data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-foreground",
               LIST_HOVER_TRANSITION,
               COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
             )}
           >
             <Icon name={iconName} className={COARSE_POINTER_ICON_SIZE_CLASS} />
+            {filtered ? (
+              <span
+                aria-hidden="true"
+                data-sidebar-display-filter-dot=""
+                className="absolute right-0.5 top-0.5 size-1.5 rounded-full bg-primary"
+              />
+            ) : null}
           </Button>
         </DropdownMenuTrigger>
       </TooltipTrigger>
@@ -635,13 +661,28 @@ export function SidebarDisplayOptionsMenu({
   const [chronologicalSort, setChronologicalSort] = useAtom(
     sidebarChronologicalSortAtom,
   );
+  const [lifecycleSelection, setLifecycleSelection] = useAtom(
+    sidebarThreadLifecycleSelectionAtom,
+  );
   const selectedSort: SidebarChronologicalSort =
     chronologicalSort === "none" ? "updated" : chronologicalSort;
+  const isFiltered =
+    !isDefaultSidebarThreadLifecycleSelection(lifecycleSelection);
+  const lifecycleLabels: Record<SidebarThreadLifecycleState, string> = {
+    active: "Active",
+    drafts: "Drafts",
+    archived: "Archived",
+  };
 
   return (
     <DropdownMenu open={open} onOpenChange={onOpenChange}>
       <SidebarDisplayMenuTrigger
-        ariaLabel="Sidebar display options"
+        ariaLabel={
+          isFiltered
+            ? "Sidebar display options (filtered)"
+            : "Sidebar display options"
+        }
+        filtered={isFiltered}
         iconName="SlidersHorizontal"
         tooltip="Display options"
       />
@@ -675,6 +716,25 @@ export function SidebarDisplayOptionsMenu({
               onCheckedChange={() => setChronologicalSort(option.sort)}
             >
               {option.label}
+            </DropdownMenuCheckboxItem>
+          ))}
+        </DropdownMenuGroup>
+        <DropdownMenuSeparator />
+        <DropdownMenuLabel className={CHROME_SECTION_LABEL_CLASS}>
+          Thread status
+        </DropdownMenuLabel>
+        <DropdownMenuGroup aria-label="Thread status">
+          {SIDEBAR_THREAD_LIFECYCLE_STATES.map((state) => (
+            <DropdownMenuCheckboxItem
+              key={state}
+              checked={lifecycleSelection.has(state)}
+              onCheckedChange={() =>
+                setLifecycleSelection((current) =>
+                  toggleSidebarThreadLifecycleState(current, state),
+                )
+              }
+            >
+              {lifecycleLabels[state]}
             </DropdownMenuCheckboxItem>
           ))}
         </DropdownMenuGroup>
@@ -847,6 +907,29 @@ interface ActiveSidebarModeSectionsProps {
   renderChronological: () => ReactNode;
   renderMachine: () => ReactNode;
   renderProject: () => ReactNode;
+}
+
+interface BuiltInSidebarLifecycleSectionsProps {
+  activeModeSections: ReactNode;
+  archivedRows: ReactNode;
+  draftRows: ReactNode;
+  emptyState: ReactNode;
+}
+
+export function BuiltInSidebarLifecycleSections({
+  activeModeSections,
+  archivedRows,
+  draftRows,
+  emptyState,
+}: BuiltInSidebarLifecycleSectionsProps) {
+  return (
+    <>
+      {draftRows}
+      {activeModeSections}
+      {archivedRows}
+      {emptyState}
+    </>
+  );
 }
 
 export function ActiveSidebarModeSections({
@@ -1401,6 +1484,27 @@ function ProjectListComponent({
     return sidebarThreads;
   }, [sidebarNavigation]);
   const draftThreadIds = usePromptDraftInputThreadIds(threads);
+  const newThreadDrafts = useNewThreadDraftSlots();
+  const [lifecycleSelection] = useAtom(sidebarThreadLifecycleSelectionAtom);
+  const setBuiltInDraftRowsVisible = useSetAtom(
+    builtInSidebarDraftRowsVisibleAtom,
+  );
+  const showDrafts = lifecycleSelection.has("drafts");
+  const showArchivedThreads = lifecycleSelection.has("archived");
+  const archivedThreadsQuery = useArchivedThreads(
+    {},
+    {
+      enabled: showArchivedThreads,
+    },
+  );
+  const archivedThreads = useMemo(
+    () => archivedThreadsQuery.data?.pages.flat() ?? [],
+    [archivedThreadsQuery.data],
+  );
+  useEffect(() => {
+    setBuiltInDraftRowsVisible(showDrafts);
+    return () => setBuiltInDraftRowsVisible(false);
+  }, [setBuiltInDraftRowsVisible, showDrafts]);
   const titleMentionResources = useThreadTitleMentionResources();
   const threadById = useMemo(() => {
     const map = new Map<string, ThreadListEntry>();
@@ -1473,6 +1577,15 @@ function ProjectListComponent({
   const handleCreateProjectlessThread = useCallback(() => {
     openRootComposeForProject(PERSONAL_PROJECT_ID);
   }, [openRootComposeForProject]);
+  const handleOpenDraft = useCallback(
+    (draftSlotId: string) => {
+      onProjectSelect?.();
+      navigate(getRootComposeRoutePath(), {
+        state: withRootComposeDraftSlotId({ focusPrompt: true }, draftSlotId),
+      });
+    },
+    [navigate, onProjectSelect],
+  );
   const handleCreateThreadInSection = useCallback(
     (sectionId: string) => {
       openRootComposeForProject(PERSONAL_PROJECT_ID, sectionId);
@@ -1603,7 +1716,7 @@ function ProjectListComponent({
   );
   const threadsDisplayOptionsMenuOpen =
     openSidebarMenu === "threadsDisplayOptions";
-  const renderSectionDisplayOptions = (sectionId: SidebarSectionId) => {
+  const renderSectionDisplayOptions = (sectionId: string) => {
     const menuId = `displayOptions:${sectionId}` as const;
     return (
       <SidebarDisplayOptionsMenu
@@ -1865,6 +1978,20 @@ function ProjectListComponent({
       ) : null}
     </ConfirmDeleteDialog>
   );
+  const {
+    showActiveModeSections,
+    showArchivedOnlyControl,
+    showFilteredEmptyState,
+    showLifecycleControlOnlySection,
+  } = getBuiltInSidebarLifecycleRenderState({
+    activeCount: threads.length,
+    archivedCount: archivedThreads.length,
+    archivedHasNextPage: archivedThreadsQuery.hasNextPage,
+    archivedIsPending: archivedThreadsQuery.isPending,
+    draftCount: newThreadDrafts.length,
+    isReady: projectsState.status === "ready",
+    selection: lifecycleSelection,
+  });
 
   if (projectsState.status === "loading") {
     return (
@@ -1876,110 +2003,166 @@ function ProjectListComponent({
 
   return (
     <ProjectListShell>
-      <ActiveSidebarModeSections
-        mode={organizationMode}
-        renderMachine={() => (
-          <MachineModeSections
-            threads={threads}
-            draftThreadIds={draftThreadIds}
-            effectivePinnedThreadIds={
-              pinnedSidebarState.effectivePinnedThreadIds
-            }
-            status={projectsState.status}
-            isReady={Boolean(sidebarNavigation)}
-            showPinnedSection={hasPinnedSection}
-            pinnedSection={pinnedSection}
-            threadsSection={threadsSection}
-            selectedThreadId={selectedThreadId}
-            collapsedSectionIds={collapsedSidebarSectionIds}
-            collapsedThreadIds={collapsedThreadIds}
-            collapsedEnvironmentIds={collapsedEnvironmentIds}
-            compareThreads={sidebarThreadComparator}
-            renderSectionDisplayOptions={renderSectionDisplayOptions}
-            isSectionDisplayOptionsOpen={isSectionDisplayOptionsOpen}
-            onProjectSelect={onProjectSelect}
-            onToggleCollapsed={toggleSidebarSectionCollapsed}
-            onToggleThreadCollapsed={toggleThreadCollapsed}
-            onToggleEnvironmentCollapsed={toggleEnvironmentCollapsed}
-          />
-        )}
-        renderChronological={() => (
-          <>
-            <SectionModeSections
-              threads={threads}
-              effectivePinnedThreadIds={
-                pinnedSidebarState.effectivePinnedThreadIds
-              }
-              status={projectsState.status}
-              isReady={Boolean(sidebarNavigation)}
-              showPinnedSection={hasPinnedSection}
-              sections={sections}
-              pinnedSection={pinnedSection}
-              pinnedReorderPending={isPinnedReorderPending}
-              pinnedThreads={pinnedRootThreads}
-              onReorderPinnedThread={handleReorderPinnedRoot}
-              threadsSection={threadsSection}
-              selectedThreadId={selectedThreadId}
-              collapsedSectionIds={collapsedSidebarSectionIds}
-              collapsedThreadIds={collapsedThreadIds}
-              collapsedEnvironmentIds={collapsedEnvironmentIds}
-              compareThreads={sidebarThreadComparator}
-              onProjectSelect={onProjectSelect}
-              onCreateThreadInSection={handleCreateThreadInSection}
-              onRenameSection={handleOpenRenameThreadSection}
-              onRemoveSection={handleRemoveThreadSection}
-              renderTopLevelSectionHeaderActions={(section) => {
-                const sectionId = buildSidebarEntitySectionId(
-                  "section",
-                  section.id,
-                );
-                return {
-                  actions: renderSectionDisplayOptions(sectionId),
-                  actionsOpen: isSectionDisplayOptionsOpen(sectionId),
-                };
+      <BuiltInSidebarLifecycleSections
+        draftRows={
+          showDrafts ? (
+            <SidebarDraftRows
+              drafts={newThreadDrafts}
+              onOpenDraft={handleOpenDraft}
+            />
+          ) : null
+        }
+        activeModeSections={
+          showActiveModeSections ? (
+            <ActiveSidebarModeSections
+              mode={organizationMode}
+              renderMachine={() => (
+                <MachineModeSections
+                  threads={threads}
+                  draftThreadIds={draftThreadIds}
+                  effectivePinnedThreadIds={
+                    pinnedSidebarState.effectivePinnedThreadIds
+                  }
+                  status={projectsState.status}
+                  isReady={Boolean(sidebarNavigation)}
+                  showPinnedSection={hasPinnedSection}
+                  pinnedSection={pinnedSection}
+                  threadsSection={threadsSection}
+                  selectedThreadId={selectedThreadId}
+                  collapsedSectionIds={collapsedSidebarSectionIds}
+                  collapsedThreadIds={collapsedThreadIds}
+                  collapsedEnvironmentIds={collapsedEnvironmentIds}
+                  compareThreads={sidebarThreadComparator}
+                  renderSectionDisplayOptions={renderSectionDisplayOptions}
+                  isSectionDisplayOptionsOpen={isSectionDisplayOptionsOpen}
+                  onProjectSelect={onProjectSelect}
+                  onToggleCollapsed={toggleSidebarSectionCollapsed}
+                  onToggleThreadCollapsed={toggleThreadCollapsed}
+                  onToggleEnvironmentCollapsed={toggleEnvironmentCollapsed}
+                />
+              )}
+              renderChronological={() => (
+                <SectionModeSections
+                  threads={threads}
+                  effectivePinnedThreadIds={
+                    pinnedSidebarState.effectivePinnedThreadIds
+                  }
+                  status={projectsState.status}
+                  isReady={Boolean(sidebarNavigation)}
+                  showPinnedSection={hasPinnedSection}
+                  sections={sections}
+                  pinnedSection={pinnedSection}
+                  pinnedReorderPending={isPinnedReorderPending}
+                  pinnedThreads={pinnedRootThreads}
+                  onReorderPinnedThread={handleReorderPinnedRoot}
+                  threadsSection={threadsSection}
+                  selectedThreadId={selectedThreadId}
+                  collapsedSectionIds={collapsedSidebarSectionIds}
+                  collapsedThreadIds={collapsedThreadIds}
+                  collapsedEnvironmentIds={collapsedEnvironmentIds}
+                  compareThreads={sidebarThreadComparator}
+                  onProjectSelect={onProjectSelect}
+                  onCreateThreadInSection={handleCreateThreadInSection}
+                  onRenameSection={handleOpenRenameThreadSection}
+                  onRemoveSection={handleRemoveThreadSection}
+                  renderTopLevelSectionHeaderActions={(section) => {
+                    const sectionId = buildSidebarEntitySectionId(
+                      "section",
+                      section.id,
+                    );
+                    return {
+                      actions: renderSectionDisplayOptions(sectionId),
+                      actionsOpen: isSectionDisplayOptionsOpen(sectionId),
+                    };
+                  }}
+                  onToggleCollapsed={toggleSidebarSectionCollapsed}
+                  onToggleThreadCollapsed={toggleThreadCollapsed}
+                  onToggleEnvironmentCollapsed={toggleEnvironmentCollapsed}
+                />
+              )}
+              renderProject={() => (
+                <ProjectModeSections
+                  projects={projects ?? EMPTY_PROJECTS}
+                  threads={threads}
+                  draftThreadIds={draftThreadIds}
+                  effectivePinnedThreadIds={
+                    pinnedSidebarState.effectivePinnedThreadIds
+                  }
+                  status={projectsState.status}
+                  isReady={Boolean(sidebarNavigation)}
+                  showPinnedSection={hasPinnedSection}
+                  pinnedSection={pinnedSection}
+                  threadsSection={threadsSection}
+                  selectedThreadId={selectedThreadId}
+                  collapsedSectionIds={collapsedSidebarSectionIds}
+                  collapsedThreadIds={collapsedThreadIds}
+                  collapsedEnvironmentIds={collapsedEnvironmentIds}
+                  compareThreads={sidebarThreadComparator}
+                  renderSectionDisplayOptions={renderSectionDisplayOptions}
+                  isSectionDisplayOptionsOpen={isSectionDisplayOptionsOpen}
+                  onProjectSelect={onProjectSelect}
+                  onCreateProjectThread={handleCreateProjectThread}
+                  onToggleCollapsed={toggleSidebarSectionCollapsed}
+                  onToggleThreadCollapsed={toggleThreadCollapsed}
+                  onToggleEnvironmentCollapsed={toggleEnvironmentCollapsed}
+                />
+              )}
+            />
+          ) : null
+        }
+        archivedRows={
+          showArchivedThreads ? (
+            <SidebarArchivedThreadGroup
+              threads={archivedThreads}
+              activeThreadId={selectedThreadId}
+              actions={renderSectionDisplayOptions("archived")}
+              actionsOpen={openSidebarMenu === "displayOptions:archived"}
+              hasNextPage={archivedThreadsQuery.hasNextPage}
+              isFetchingNextPage={archivedThreadsQuery.isFetchingNextPage}
+              onLoadMore={() => {
+                void archivedThreadsQuery.fetchNextPage();
               }}
-              onToggleCollapsed={toggleSidebarSectionCollapsed}
-              onToggleThreadCollapsed={toggleThreadCollapsed}
-              onToggleEnvironmentCollapsed={toggleEnvironmentCollapsed}
+              onNavigate={onProjectSelect}
             />
-            {sectionCreateDialog}
-            {sectionRenameDialogContent}
-            {sectionDeleteDialogContent}
-          </>
-        )}
-        renderProject={() => (
-          <>
-            <ProjectModeSections
-              projects={projects ?? EMPTY_PROJECTS}
-              threads={threads}
-              draftThreadIds={draftThreadIds}
-              effectivePinnedThreadIds={
-                pinnedSidebarState.effectivePinnedThreadIds
+          ) : null
+        }
+        emptyState={
+          showLifecycleControlOnlySection ? (
+            <TopLevelSidebarSection
+              label={showArchivedOnlyControl ? "Archived" : "Threads"}
+              actions={
+                showArchivedOnlyControl
+                  ? renderSectionDisplayOptions("archived")
+                  : threadsSectionActions
               }
-              status={projectsState.status}
-              isReady={Boolean(sidebarNavigation)}
-              showPinnedSection={hasPinnedSection}
-              pinnedSection={pinnedSection}
-              threadsSection={threadsSection}
-              selectedThreadId={selectedThreadId}
-              collapsedSectionIds={collapsedSidebarSectionIds}
-              collapsedThreadIds={collapsedThreadIds}
-              collapsedEnvironmentIds={collapsedEnvironmentIds}
-              compareThreads={sidebarThreadComparator}
-              renderSectionDisplayOptions={renderSectionDisplayOptions}
-              isSectionDisplayOptionsOpen={isSectionDisplayOptionsOpen}
-              onProjectSelect={onProjectSelect}
-              onCreateProjectThread={handleCreateProjectThread}
-              onToggleCollapsed={toggleSidebarSectionCollapsed}
-              onToggleThreadCollapsed={toggleThreadCollapsed}
-              onToggleEnvironmentCollapsed={toggleEnvironmentCollapsed}
-            />
-            {sectionCreateDialog}
-            {sectionRenameDialogContent}
-            {sectionDeleteDialogContent}
-          </>
-        )}
+              actionsOpen={
+                showArchivedOnlyControl
+                  ? openSidebarMenu === "displayOptions:archived"
+                  : threadsDisplayOptionsMenuOpen
+              }
+            >
+              {showFilteredEmptyState ? (
+                <p
+                  role="status"
+                  className="px-3 py-2 text-xs text-muted-foreground"
+                >
+                  No threads match this filter.
+                </p>
+              ) : null}
+            </TopLevelSidebarSection>
+          ) : showFilteredEmptyState ? (
+            <p
+              role="status"
+              className="px-3 py-2 text-xs text-muted-foreground"
+            >
+              No threads match this filter.
+            </p>
+          ) : null
+        }
       />
+      {sectionCreateDialog}
+      {sectionRenameDialogContent}
+      {sectionDeleteDialogContent}
     </ProjectListShell>
   );
 }

--- a/apps/app/src/components/sidebar/SidebarDisplayOptionsMenu.test.tsx
+++ b/apps/app/src/components/sidebar/SidebarDisplayOptionsMenu.test.tsx
@@ -1,41 +1,89 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { Provider } from "jotai";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
+import { createStore, Provider } from "jotai";
 import { afterEach, describe, expect, it } from "vitest";
 import { TooltipProvider } from "@bb/shared-ui/tooltip";
 import { SidebarDisplayOptionsMenu } from "./ProjectList";
+import { sidebarThreadLifecycleSelectionAtom } from "./sidebarThreadLifecycle";
 
 afterEach(cleanup);
 
 function renderMenu() {
+  const store = createStore();
   render(
-    <Provider>
+    <Provider store={store}>
       <TooltipProvider>
         <SidebarDisplayOptionsMenu />
       </TooltipProvider>
     </Provider>,
   );
+  return store;
+}
+
+function openMenu() {
   fireEvent.pointerDown(
-    screen.getByRole("button", { name: "Sidebar display options" }),
+    screen.getByRole("button", { name: /^Sidebar display options/ }),
     { button: 0 },
   );
 }
 
-describe("SidebarDisplayOptionsMenu section ownership", () => {
-  it("contains thread display controls but no whole-region controls", async () => {
-    renderMenu();
+function getStatusItem(name: string) {
+  return within(screen.getByRole("group", { name: "Thread status" })).getByRole(
+    "menuitemcheckbox",
+    { name: new RegExp(`^${name}`) },
+  );
+}
 
+describe("SidebarDisplayOptionsMenu lifecycle filter", () => {
+  it("renders count-free Thread status below Organize and Sort by", async () => {
+    renderMenu();
+    openMenu();
+
+    await screen.findByRole("group", { name: "Thread status" });
     expect(
-      await screen.findByRole("group", { name: "Organize" }),
+      screen
+        .getAllByRole("group")
+        .map((group) => group.getAttribute("aria-label"))
+        .filter(Boolean),
+    ).toEqual(["Organize", "Sort by", "Thread status"]);
+    expect(getStatusItem("Active").textContent).toBe("Active");
+    expect(getStatusItem("Drafts").textContent).toBe("Drafts");
+    expect(getStatusItem("Archived").textContent).toBe("Archived");
+    expect(
+      document.querySelector("[data-sidebar-display-filter-dot]"),
+    ).toBeNull();
+  });
+
+  it("builds unions, keeps one state selected, and marks an off-default filter", async () => {
+    const store = renderMenu();
+    openMenu();
+    await screen.findByRole("group", { name: "Thread status" });
+
+    fireEvent.click(getStatusItem("Drafts"));
+    openMenu();
+    fireEvent.click(getStatusItem("Active"));
+    expect([...store.get(sidebarThreadLifecycleSelectionAtom)]).toEqual([
+      "drafts",
+    ]);
+    openMenu();
+    fireEvent.click(getStatusItem("Drafts"));
+    expect([...store.get(sidebarThreadLifecycleSelectionAtom)]).toEqual([
+      "drafts",
+    ]);
+    expect(
+      screen.getByRole("button", {
+        name: "Sidebar display options (filtered)",
+      }),
     ).toBeDefined();
-    expect(screen.getByRole("group", { name: "Sort by" })).toBeDefined();
     expect(
-      screen.queryByRole("group", { name: "Sidebar sections" }),
-    ).toBeNull();
-    expect(screen.queryByRole("menuitem", { name: "Move up" })).toBeNull();
-    expect(
-      screen.queryByRole("menuitemcheckbox", { name: "Show section" }),
-    ).toBeNull();
+      document.querySelector("[data-sidebar-display-filter-dot]"),
+    ).not.toBeNull();
   });
 });

--- a/apps/app/src/components/sidebar/SidebarLifecycleRows.test.tsx
+++ b/apps/app/src/components/sidebar/SidebarLifecycleRows.test.tsx
@@ -1,0 +1,405 @@
+// @vitest-environment jsdom
+
+import type { ThreadListEntry } from "@bb/domain";
+import { TooltipProvider } from "@bb/shared-ui/tooltip";
+import { CompactViewportOverrideProvider } from "@bb/shared-ui/hooks/use-compact-viewport";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SidebarContent } from "@/components/ui/sidebar.js";
+import {
+  SidebarArchivedThreadGroup,
+  SidebarDraftRows,
+  type SidebarDraftRowItem,
+} from "./SidebarLifecycleRows";
+
+const threadActions = vi.hoisted(() => ({
+  archiveThreadAndChildren: vi.fn(),
+  requestDelete: vi.fn(),
+  requestRename: vi.fn(),
+  togglePin: vi.fn(),
+  toggleRead: vi.fn(),
+  unarchiveThread: vi.fn(),
+}));
+
+vi.mock("@/components/thread/ThreadActionsProvider", () => ({
+  useThreadActions: () => ({
+    ...threadActions,
+    renameThread: vi.fn(),
+  }),
+}));
+
+function createThread(
+  id: string,
+  title: string,
+  overrides: Partial<ThreadListEntry> = {},
+): ThreadListEntry {
+  return {
+    id,
+    projectId: "proj_test",
+    environmentId: null,
+    providerId: "codex",
+    title,
+    titleFallback: title,
+    sectionId: null,
+    status: "idle",
+    parentThreadId: null,
+    sourceThreadId: null,
+    originKind: null,
+    originPluginId: null,
+    visibility: "visible",
+    archivedAt: 100,
+    pinnedAt: null,
+    pinSortKey: null,
+    deletedAt: null,
+    lastReadAt: 100,
+    latestAttentionAt: 100,
+    createdAt: 0,
+    updatedAt: 100,
+    activity: {
+      activeWorkflowCount: 0,
+      activeBackgroundAgentCount: 0,
+      activeBackgroundCommandCount: 0,
+      activePlanModeCount: 0,
+      activeGoalCount: 0,
+    },
+    hasPendingInteraction: false,
+    environmentHostId: null,
+    environmentName: null,
+    environmentBranchName: null,
+    environmentWorkspaceDisplayKind: "other",
+    runtime: { displayStatus: "idle", hostReconnectGraceExpiresAt: null },
+    ...overrides,
+  };
+}
+
+function renderLifecycleRows(
+  children: ReactNode,
+  { compact = false }: { compact?: boolean } = {},
+) {
+  const root = document.createElement("div");
+  root.id = "root";
+  document.body.appendChild(root);
+  return render(
+    <CompactViewportOverrideProvider isCompactViewport={compact}>
+      <TooltipProvider>
+        <MemoryRouter>{children}</MemoryRouter>
+      </TooltipProvider>
+    </CompactViewportOverrideProvider>,
+    { container: root },
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  document.getElementById("root")?.remove();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+  for (const action of Object.values(threadActions)) {
+    action.mockReset();
+  }
+});
+
+describe("SidebarDraftRows", () => {
+  function createDrafts(): SidebarDraftRowItem[] {
+    return [
+      { id: "newest", title: "Newest draft", delete: vi.fn() },
+      { id: "older", title: "Older draft", delete: vi.fn() },
+    ];
+  }
+
+  it("keeps the input's newest-first order and opens the selected slot", () => {
+    const drafts = createDrafts();
+    const onOpenDraft = vi.fn();
+    const { container } = renderLifecycleRows(
+      <SidebarDraftRows drafts={drafts} onOpenDraft={onOpenDraft} />,
+    );
+
+    const rows = [
+      ...container.querySelectorAll<HTMLElement>("[data-sidebar-draft-id]"),
+    ];
+    expect(rows.map((row) => row.dataset.sidebarDraftId)).toEqual([
+      "newest",
+      "older",
+    ]);
+    expect(container.querySelector('[data-icon="EditFile"]')).toBeNull();
+    expect(
+      container.querySelectorAll("[data-sidebar-draft-state]"),
+    ).toHaveLength(2);
+    expect(screen.getAllByText("Draft")).toHaveLength(2);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open draft Older draft" }),
+    );
+    expect(onOpenDraft).toHaveBeenCalledWith("older");
+  });
+
+  it("offers Delete draft and no Archive from both the overflow and right-click menus", () => {
+    const drafts = createDrafts();
+    const { container } = renderLifecycleRows(
+      <SidebarDraftRows drafts={drafts} onOpenDraft={vi.fn()} />,
+    );
+
+    fireEvent.pointerDown(
+      screen.getAllByRole("button", { name: "Draft actions" })[0],
+    );
+    const overflowDelete = screen.getByRole("menuitem", {
+      name: "Delete draft",
+    });
+    expect(screen.queryByRole("menuitem", { name: /archive/iu })).toBeNull();
+    fireEvent.click(overflowDelete);
+    expect(drafts[0]?.delete).toHaveBeenCalledTimes(1);
+
+    const olderRow = container.querySelector<HTMLElement>(
+      '[data-sidebar-draft-id="older"]',
+    );
+    expect(olderRow).not.toBeNull();
+    fireEvent.contextMenu(olderRow!);
+    const contextMenu = screen.getByRole("menu", { name: "Draft actions" });
+    expect(
+      within(contextMenu).getByRole("menuitem", { name: "Delete draft" }),
+    ).not.toBeNull();
+    expect(within(contextMenu).queryByText(/archive/iu)).toBeNull();
+  });
+
+  it("uses the persistent compact drawer for a touch long-press", () => {
+    vi.useFakeTimers();
+    const drafts = createDrafts();
+    const { container } = renderLifecycleRows(
+      <SidebarDraftRows drafts={drafts} onOpenDraft={vi.fn()} />,
+      { compact: true },
+    );
+    const row = container.querySelector<HTMLElement>(
+      '[data-sidebar-draft-id="newest"]',
+    );
+    expect(row).not.toBeNull();
+
+    fireEvent.pointerDown(row!, {
+      pointerId: 1,
+      pointerType: "touch",
+      isPrimary: true,
+      clientX: 100,
+      clientY: 100,
+    });
+    act(() => {
+      vi.advanceTimersByTime(700);
+    });
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(
+      screen.getByRole("menuitem", { name: "Delete draft" }),
+    ).not.toBeNull();
+    expect(document.querySelector("#root")?.hasAttribute("inert")).toBe(false);
+    expect(document.querySelector("#root")?.getAttribute("aria-hidden")).toBe(
+      null,
+    );
+  });
+});
+
+describe("SidebarArchivedThreadGroup", () => {
+  const archivedThreads = [
+    createThread("first", "First archived"),
+    createThread("second", "Second archived"),
+    createThread("third", "Third archived"),
+  ];
+
+  it("renders one labeled group in archive-query order and opens a thread", () => {
+    const onNavigate = vi.fn();
+    const { container } = renderLifecycleRows(
+      <SidebarArchivedThreadGroup
+        threads={archivedThreads}
+        hasNextPage={false}
+        isFetchingNextPage={false}
+        onLoadMore={vi.fn()}
+        onNavigate={onNavigate}
+      />,
+    );
+
+    expect(screen.getByTitle("Archived")).not.toBeNull();
+    const rows = [
+      ...container.querySelectorAll<HTMLElement>(
+        "[data-sidebar-archived-thread-id]",
+      ),
+    ];
+    expect(rows.map((row) => row.dataset.sidebarArchivedThreadId)).toEqual([
+      "first",
+      "second",
+      "third",
+    ]);
+    expect(container.querySelector('[data-icon="Archive"]')).toBeNull();
+    expect(
+      container.querySelectorAll("[data-sidebar-archived-state]"),
+    ).toHaveLength(3);
+    const secondLink = screen.getByRole("link", {
+      name: "Open archived thread Second archived",
+    });
+    expect(secondLink.getAttribute("href")).toBe(
+      "/projects/proj_test/threads/second",
+    );
+    fireEvent.click(secondLink);
+    expect(onNavigate).toHaveBeenCalledOnce();
+  });
+
+  it("replaces the right-edge state with quick Unarchive and keeps it in both menus", () => {
+    const { container } = renderLifecycleRows(
+      <SidebarArchivedThreadGroup
+        threads={[archivedThreads[0]!]}
+        hasNextPage={false}
+        isFetchingNextPage={false}
+        onLoadMore={vi.fn()}
+      />,
+    );
+
+    const archivedState = container.querySelector<HTMLElement>(
+      "[data-sidebar-archived-state]",
+    );
+    expect(archivedState?.textContent).toBe("Archived");
+    expect(archivedState?.className).toContain(
+      "group-focus-within/archived-thread-row:opacity-0",
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Unarchive thread" }));
+    expect(threadActions.unarchiveThread).toHaveBeenCalledWith(
+      archivedThreads[0],
+    );
+    threadActions.unarchiveThread.mockClear();
+
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: "Thread actions" }),
+    );
+    expect(screen.getByRole("menuitem", { name: "Unarchive" })).not.toBeNull();
+    expect(
+      screen.queryByRole("menuitem", { name: "Open in split" }),
+    ).toBeNull();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Unarchive" }));
+    expect(threadActions.unarchiveThread).toHaveBeenCalledWith(
+      archivedThreads[0],
+    );
+
+    const row = container.querySelector<HTMLElement>(
+      '[data-sidebar-archived-thread-id="first"]',
+    );
+    expect(row).not.toBeNull();
+    fireEvent.contextMenu(row!);
+    const contextMenu = screen.getByRole("menu", { name: "Thread actions" });
+    expect(
+      within(contextMenu).getByRole("menuitem", { name: "Unarchive" }),
+    ).not.toBeNull();
+    expect(
+      within(contextMenu).queryByRole("menuitem", { name: "Open in split" }),
+    ).toBeNull();
+  });
+
+  it("windows archived rows through SidebarWindowedItems", () => {
+    vi.stubGlobal(
+      "IntersectionObserver",
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
+    vi.spyOn(Element.prototype, "clientHeight", "get").mockReturnValue(500);
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+      function (this: HTMLElement) {
+        if (this.hasAttribute("data-sidebar-windowed-item")) {
+          return new DOMRect(0, 1_000, 300, 30);
+        }
+        return new DOMRect(0, 0, 300, 500);
+      },
+    );
+
+    const { container } = renderLifecycleRows(
+      <SidebarContent>
+        <SidebarArchivedThreadGroup
+          threads={archivedThreads}
+          hasNextPage={false}
+          isFetchingNextPage={false}
+          onLoadMore={vi.fn()}
+        />
+      </SidebarContent>,
+    );
+
+    expect(
+      container.querySelectorAll("[data-sidebar-windowed-item]"),
+    ).toHaveLength(3);
+    expect(
+      container.querySelectorAll("[data-sidebar-windowed-nav]"),
+    ).toHaveLength(3);
+    expect(
+      container.querySelector("[data-sidebar-archived-thread-id]"),
+    ).toBeNull();
+  });
+
+  it("exposes click and scroll loading through one accessible sentinel", () => {
+    const observers: Array<{
+      callback: IntersectionObserverCallback;
+      observed: Element[];
+    }> = [];
+    vi.stubGlobal(
+      "IntersectionObserver",
+      class {
+        private readonly record: (typeof observers)[number];
+
+        constructor(callback: IntersectionObserverCallback) {
+          this.record = { callback, observed: [] };
+          observers.push(this.record);
+        }
+
+        observe(target: Element) {
+          this.record.observed.push(target);
+        }
+
+        unobserve() {}
+        disconnect() {}
+      },
+    );
+    const onLoadMore = vi.fn();
+    renderLifecycleRows(
+      <SidebarArchivedThreadGroup
+        threads={archivedThreads}
+        hasNextPage
+        isFetchingNextPage={false}
+        onLoadMore={onLoadMore}
+      />,
+    );
+    const loadMore = screen.getByRole("button", {
+      name: "Load more archived threads",
+    });
+
+    fireEvent.click(loadMore);
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
+
+    const sentinelObserver = observers.find((observer) =>
+      observer.observed.includes(loadMore),
+    );
+    expect(sentinelObserver).toBeDefined();
+    act(() => {
+      sentinelObserver?.callback(
+        [
+          {
+            boundingClientRect: new DOMRect(),
+            intersectionRatio: 1,
+            intersectionRect: new DOMRect(),
+            isIntersecting: true,
+            rootBounds: null,
+            target: loadMore,
+            time: 0,
+          },
+        ],
+        {} as IntersectionObserver,
+      );
+    });
+    expect(onLoadMore).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/app/src/components/sidebar/SidebarLifecycleRows.tsx
+++ b/apps/app/src/components/sidebar/SidebarLifecycleRows.tsx
@@ -1,0 +1,489 @@
+import type { ThreadListEntry } from "@bb/domain";
+import { Button } from "@bb/shared-ui/button";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from "@bb/shared-ui/context-menu";
+import {
+  COARSE_POINTER_ICON_SIZE_CLASS,
+  COARSE_POINTER_ROW_HEIGHT_CLASS,
+} from "@bb/shared-ui/coarse-pointer-sizing";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@bb/shared-ui/dropdown-menu";
+import { useIsCompactViewport } from "@bb/shared-ui/hooks/use-compact-viewport";
+import { Icon } from "@bb/shared-ui/icon";
+import { cn } from "@bb/shared-ui/lib/utils";
+import { LIST_HOVER_TRANSITION } from "@bb/shared-ui/motion";
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { NavLink } from "react-router-dom";
+import {
+  ThreadArchiveQuickAction,
+  ThreadActionsContextMenu,
+  ThreadActionsMenu,
+} from "@/components/thread/ThreadActionsMenu";
+import { CompactLongPressMenu } from "@/components/ui/compact-long-press-menu";
+import {
+  SIDEBAR_CONTENT_SELECTOR,
+  useSidebarContentElementRef,
+} from "@/components/ui/sidebar.js";
+import {
+  SIDEBAR_HOVER_ACTIONS_CLASS,
+  SIDEBAR_HOVER_ACTIONS_INSET_CLASS,
+  SIDEBAR_HOVER_ACTIONS_ROW_CLASS,
+} from "@/components/ui/sidebar-hover-actions.js";
+import { getThreadDisplayTitle } from "@/lib/thread-title";
+import { getThreadRoutePath } from "@/lib/route-paths";
+import {
+  SIDEBAR_MORE_ACTION_TRIGGER_CLASS,
+  SIDEBAR_ROW_BASE_CLASS,
+  SIDEBAR_ROW_INTERACTIVE_STATE_CLASS,
+  SIDEBAR_ROW_SELECTED_STATE_CLASS,
+  SIDEBAR_STANDARD_ROW_PADDING_CLASS,
+} from "./sidebarRowClasses";
+import { SidebarWindowedItems } from "./SidebarWindowedItems";
+import { TopLevelSidebarSection } from "./TopLevelSidebarSection";
+
+export interface SidebarDraftRowItem {
+  id: string;
+  title: string;
+  delete: () => void;
+}
+
+interface SidebarDraftRowsProps {
+  drafts: readonly SidebarDraftRowItem[];
+  onOpenDraft: (draftId: string) => void;
+}
+
+type DraftActionsMenuSurface = "context" | "dropdown";
+
+function DraftActionsMenuItem({
+  onDelete,
+  surface,
+}: {
+  onDelete: () => void;
+  surface: DraftActionsMenuSurface;
+}) {
+  const content = (
+    <>
+      <Icon name="Trash2" aria-hidden="true" />
+      Delete draft
+    </>
+  );
+
+  if (surface === "context") {
+    return (
+      <ContextMenuItem
+        className="text-destructive focus:bg-destructive/15 focus:text-destructive data-[last-hovered]:bg-destructive/15 data-[last-hovered]:text-destructive"
+        onSelect={onDelete}
+      >
+        {content}
+      </ContextMenuItem>
+    );
+  }
+
+  return (
+    <DropdownMenuItem variant="destructive" onSelect={onDelete}>
+      {content}
+    </DropdownMenuItem>
+  );
+}
+
+function DraftActionsMenu({
+  onDelete,
+  onOpenChange,
+}: {
+  onDelete: () => void;
+  onOpenChange: (open: boolean) => void;
+}) {
+  return (
+    <DropdownMenu onOpenChange={onOpenChange}>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className={cn(
+            "rounded-md p-0 text-subtle-foreground hover:bg-transparent hover:text-foreground",
+            "data-[state=open]:bg-state-active data-[state=open]:text-foreground",
+            SIDEBAR_MORE_ACTION_TRIGGER_CLASS,
+          )}
+          aria-label="Draft actions"
+          onClick={(event) => {
+            event.stopPropagation();
+          }}
+        >
+          <Icon
+            name="MoreHorizontal"
+            className={COARSE_POINTER_ICON_SIZE_CLASS}
+          />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DraftActionsMenuItem surface="dropdown" onDelete={onDelete} />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function DraftActionsContextMenu({
+  children,
+  onDelete,
+  onOpenChange,
+}: {
+  children: ReactNode;
+  onDelete: () => void;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const isCompactViewport = useIsCompactViewport();
+
+  if (isCompactViewport) {
+    return (
+      <CompactLongPressMenu
+        label="Draft actions"
+        onOpenChange={onOpenChange}
+        items={<DraftActionsMenuItem surface="dropdown" onDelete={onDelete} />}
+      >
+        {children}
+      </CompactLongPressMenu>
+    );
+  }
+
+  return (
+    <ContextMenu onOpenChange={onOpenChange}>
+      <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
+      <ContextMenuContent aria-label="Draft actions">
+        <DraftActionsMenuItem surface="context" onDelete={onDelete} />
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+}
+
+function SidebarDraftRow({
+  draft,
+  onOpenDraft,
+}: {
+  draft: SidebarDraftRowItem;
+  onOpenDraft: (draftId: string) => void;
+}) {
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [contextOpen, setContextOpen] = useState(false);
+  const actionsOpen = dropdownOpen || contextOpen;
+
+  const row = (
+    <div
+      data-sidebar-draft-id={draft.id}
+      className={cn(
+        SIDEBAR_HOVER_ACTIONS_ROW_CLASS,
+        SIDEBAR_ROW_BASE_CLASS,
+        SIDEBAR_ROW_INTERACTIVE_STATE_CLASS,
+        SIDEBAR_STANDARD_ROW_PADDING_CLASS,
+        COARSE_POINTER_ROW_HEIGHT_CLASS,
+        LIST_HOVER_TRANSITION,
+        "group/draft-row relative min-w-0",
+        "has-[[data-state=open]]:bg-sidebar-accent",
+      )}
+    >
+      <button
+        type="button"
+        className="absolute inset-0 rounded-md outline-none ring-sidebar-ring focus-visible:ring-2"
+        aria-label={`Open draft ${draft.title}`}
+        onClick={() => onOpenDraft(draft.id)}
+      />
+      <span
+        className={cn(
+          SIDEBAR_HOVER_ACTIONS_INSET_CLASS,
+          "flex min-w-0 flex-1 items-center gap-2",
+        )}
+      >
+        <span className="min-w-0 truncate" title={draft.title}>
+          {draft.title}
+        </span>
+        <span
+          data-sidebar-draft-state=""
+          className="ml-auto shrink-0 text-xs text-muted-foreground transition-opacity group-hover/draft-row:opacity-0 group-focus-within/draft-row:opacity-0"
+        >
+          Draft
+        </span>
+      </span>
+      <span
+        data-sidebar-hover-actions-open={actionsOpen ? "true" : undefined}
+        className={cn(
+          SIDEBAR_HOVER_ACTIONS_CLASS,
+          "absolute inset-y-0 right-0 z-10 flex items-center justify-end max-md:pointer-coarse:hidden",
+        )}
+      >
+        <DraftActionsMenu
+          onDelete={draft.delete}
+          onOpenChange={setDropdownOpen}
+        />
+      </span>
+    </div>
+  );
+
+  return (
+    <DraftActionsContextMenu
+      onDelete={draft.delete}
+      onOpenChange={setContextOpen}
+    >
+      {row}
+    </DraftActionsContextMenu>
+  );
+}
+
+export function SidebarDraftRows({
+  drafts,
+  onOpenDraft,
+}: SidebarDraftRowsProps) {
+  if (drafts.length === 0) {
+    return null;
+  }
+
+  return (
+    <div data-sidebar-draft-cluster="">
+      {drafts.map((draft) => (
+        <SidebarDraftRow
+          key={draft.id}
+          draft={draft}
+          onOpenDraft={onOpenDraft}
+        />
+      ))}
+    </div>
+  );
+}
+
+interface SidebarArchivedThreadGroupProps {
+  threads: readonly ThreadListEntry[];
+  activeThreadId?: string | null;
+  actions?: ReactNode;
+  actionsOpen?: boolean;
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  onLoadMore: () => void;
+  onNavigate?: () => void;
+}
+
+function SidebarArchivedThreadRow({
+  isActive,
+  onNavigate,
+  thread,
+}: {
+  isActive: boolean;
+  onNavigate?: () => void;
+  thread: ThreadListEntry;
+}) {
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [contextOpen, setContextOpen] = useState(false);
+  const actionsOpen = dropdownOpen || contextOpen;
+  const title = getThreadDisplayTitle(thread);
+
+  const row = (
+    <div
+      data-sidebar-archived-thread-id={thread.id}
+      className={cn(
+        SIDEBAR_HOVER_ACTIONS_ROW_CLASS,
+        SIDEBAR_ROW_BASE_CLASS,
+        SIDEBAR_STANDARD_ROW_PADDING_CLASS,
+        COARSE_POINTER_ROW_HEIGHT_CLASS,
+        LIST_HOVER_TRANSITION,
+        "group/archived-thread-row relative min-w-0",
+        isActive
+          ? SIDEBAR_ROW_SELECTED_STATE_CLASS
+          : [
+              SIDEBAR_ROW_INTERACTIVE_STATE_CLASS,
+              "text-sidebar-foreground/60 dark:text-sidebar-foreground/60",
+            ],
+        !isActive && "has-[[data-state=open]]:bg-sidebar-accent",
+      )}
+    >
+      <NavLink
+        to={getThreadRoutePath({
+          projectId: thread.projectId,
+          threadId: thread.id,
+        })}
+        data-sidebar-thread-shortcut-target=""
+        data-sidebar-thread-id={thread.id}
+        className="absolute inset-0 rounded-md outline-none ring-sidebar-ring focus-visible:ring-2"
+        aria-label={`Open archived thread ${title}`}
+        onClick={onNavigate}
+      />
+      <span
+        className={cn(
+          SIDEBAR_HOVER_ACTIONS_INSET_CLASS,
+          "flex min-w-0 flex-1 items-center gap-2",
+        )}
+      >
+        <span className="min-w-0 truncate" title={title}>
+          {title}
+        </span>
+        <span
+          data-sidebar-archived-state=""
+          className="ml-auto shrink-0 text-xs text-muted-foreground transition-opacity group-hover/archived-thread-row:opacity-0 group-focus-within/archived-thread-row:opacity-0"
+        >
+          Archived
+        </span>
+      </span>
+      <span
+        data-sidebar-hover-actions-open={actionsOpen ? "true" : undefined}
+        className={cn(
+          SIDEBAR_HOVER_ACTIONS_CLASS,
+          "absolute inset-y-0 right-0 z-10 flex items-center justify-end max-md:pointer-coarse:hidden",
+        )}
+      >
+        <ThreadArchiveQuickAction
+          thread={thread}
+          showLabel
+          className="h-6 px-1.5 text-xs text-muted-foreground hover:bg-transparent hover:text-foreground"
+        />
+        <ThreadActionsMenu
+          thread={thread}
+          triggerClassName={cn(
+            "text-subtle-foreground hover:bg-transparent hover:text-foreground",
+            SIDEBAR_MORE_ACTION_TRIGGER_CLASS,
+          )}
+          onOpenChange={setDropdownOpen}
+        />
+      </span>
+    </div>
+  );
+
+  return (
+    <ThreadActionsContextMenu thread={thread} onOpenChange={setContextOpen}>
+      {row}
+    </ThreadActionsContextMenu>
+  );
+}
+
+function ArchivedThreadsLoadMore({
+  hasNextPage,
+  isFetchingNextPage,
+  loadedCount,
+  onLoadMore,
+}: {
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  loadedCount: number;
+  onLoadMore: () => void;
+}) {
+  const sentinelRef = useRef<HTMLButtonElement>(null);
+  const scrollElementRef = useSidebarContentElementRef();
+  const autoRequestedAtCountRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (
+      !hasNextPage ||
+      isFetchingNextPage ||
+      typeof IntersectionObserver === "undefined"
+    ) {
+      return;
+    }
+    const sentinel = sentinelRef.current;
+    if (sentinel === null) {
+      return;
+    }
+    const scrollElement =
+      scrollElementRef?.current ??
+      sentinel.closest<HTMLElement>(SIDEBAR_CONTENT_SELECTOR);
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (
+          entries.some((entry) => entry.isIntersecting) &&
+          autoRequestedAtCountRef.current !== loadedCount
+        ) {
+          autoRequestedAtCountRef.current = loadedCount;
+          onLoadMore();
+        }
+      },
+      { root: scrollElement ?? null, rootMargin: "240px 0px" },
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [
+    hasNextPage,
+    isFetchingNextPage,
+    loadedCount,
+    onLoadMore,
+    scrollElementRef,
+  ]);
+
+  if (!hasNextPage) {
+    return null;
+  }
+
+  return (
+    <Button
+      ref={sentinelRef}
+      type="button"
+      variant="ghost"
+      className={cn(
+        "mx-2 mt-1 w-[calc(100%-1rem)] font-normal text-muted-foreground",
+        "h-7 max-md:pointer-coarse:h-9",
+      )}
+      disabled={isFetchingNextPage}
+      aria-busy={isFetchingNextPage}
+      onClick={onLoadMore}
+    >
+      {isFetchingNextPage
+        ? "Loading more archived threads…"
+        : "Load more archived threads"}
+    </Button>
+  );
+}
+
+export function SidebarArchivedThreadGroup({
+  threads,
+  activeThreadId = null,
+  actions,
+  actionsOpen = false,
+  hasNextPage,
+  isFetchingNextPage,
+  onLoadMore,
+  onNavigate,
+}: SidebarArchivedThreadGroupProps) {
+  if (threads.length === 0 && !hasNextPage) {
+    return null;
+  }
+
+  return (
+    <TopLevelSidebarSection
+      label="Archived"
+      actions={actions}
+      actionsOpen={actionsOpen}
+    >
+      <SidebarWindowedItems
+        itemKeys={threads.map((thread) => thread.id)}
+        estimateRows={() => 1}
+        alwaysMountedKeys={
+          activeThreadId === null ? undefined : new Set([activeThreadId])
+        }
+        getNavigationEntries={(index) => {
+          const thread = threads[index];
+          return thread
+            ? [{ projectId: thread.projectId, threadId: thread.id }]
+            : [];
+        }}
+        renderItem={(index) => {
+          const thread = threads[index];
+          return thread ? (
+            <SidebarArchivedThreadRow
+              thread={thread}
+              isActive={thread.id === activeThreadId}
+              onNavigate={onNavigate}
+            />
+          ) : null;
+        }}
+      />
+      <ArchivedThreadsLoadMore
+        hasNextPage={hasNextPage}
+        isFetchingNextPage={isFetchingNextPage}
+        loadedCount={threads.length}
+        onLoadMore={onLoadMore}
+      />
+    </TopLevelSidebarSection>
+  );
+}

--- a/apps/app/src/components/sidebar/sidebarThreadLifecycle.test.ts
+++ b/apps/app/src/components/sidebar/sidebarThreadLifecycle.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_SIDEBAR_THREAD_LIFECYCLE_SELECTION,
+  getBuiltInSidebarLifecycleRenderState,
+  isDefaultSidebarThreadLifecycleSelection,
+  toggleSidebarThreadLifecycleState,
+} from "./sidebarThreadLifecycle";
+
+describe("sidebar thread lifecycle selection", () => {
+  it("starts active-only and recognizes only that selection as the default", () => {
+    expect([...DEFAULT_SIDEBAR_THREAD_LIFECYCLE_SELECTION]).toEqual(["active"]);
+    expect(
+      isDefaultSidebarThreadLifecycleSelection(
+        DEFAULT_SIDEBAR_THREAD_LIFECYCLE_SELECTION,
+      ),
+    ).toBe(true);
+    expect(
+      isDefaultSidebarThreadLifecycleSelection(new Set(["active", "drafts"])),
+    ).toBe(false);
+  });
+
+  it("builds clean unions while refusing to remove the final state", () => {
+    const activeAndDrafts = toggleSidebarThreadLifecycleState(
+      DEFAULT_SIDEBAR_THREAD_LIFECYCLE_SELECTION,
+      "drafts",
+    );
+    expect([...activeAndDrafts]).toEqual(["active", "drafts"]);
+
+    const draftsOnly = toggleSidebarThreadLifecycleState(
+      activeAndDrafts,
+      "active",
+    );
+    expect([...draftsOnly]).toEqual(["drafts"]);
+    expect(toggleSidebarThreadLifecycleState(draftsOnly, "drafts")).toBe(
+      draftsOnly,
+    );
+  });
+
+  it("derives union visibility, loading, and filtered-empty states", () => {
+    expect(
+      getBuiltInSidebarLifecycleRenderState({
+        activeCount: 0,
+        archivedCount: 0,
+        archivedHasNextPage: false,
+        archivedIsPending: false,
+        draftCount: 0,
+        isReady: true,
+        selection: DEFAULT_SIDEBAR_THREAD_LIFECYCLE_SELECTION,
+      }),
+    ).toEqual({
+      showActiveModeSections: true,
+      showArchivedOnlyControl: false,
+      showFilteredEmptyState: false,
+      showLifecycleControlOnlySection: false,
+    });
+
+    expect(
+      getBuiltInSidebarLifecycleRenderState({
+        activeCount: 0,
+        archivedCount: 0,
+        archivedHasNextPage: false,
+        archivedIsPending: false,
+        draftCount: 1,
+        isReady: true,
+        selection: new Set(["active", "drafts"]),
+      }),
+    ).toEqual({
+      showActiveModeSections: false,
+      showArchivedOnlyControl: false,
+      showFilteredEmptyState: false,
+      showLifecycleControlOnlySection: true,
+    });
+
+    expect(
+      getBuiltInSidebarLifecycleRenderState({
+        activeCount: 0,
+        archivedCount: 0,
+        archivedHasNextPage: false,
+        archivedIsPending: true,
+        draftCount: 0,
+        isReady: true,
+        selection: new Set(["archived"]),
+      }),
+    ).toEqual({
+      showActiveModeSections: false,
+      showArchivedOnlyControl: true,
+      showFilteredEmptyState: false,
+      showLifecycleControlOnlySection: true,
+    });
+
+    expect(
+      getBuiltInSidebarLifecycleRenderState({
+        activeCount: 0,
+        archivedCount: 0,
+        archivedHasNextPage: false,
+        archivedIsPending: false,
+        draftCount: 0,
+        isReady: true,
+        selection: new Set(["archived"]),
+      }).showFilteredEmptyState,
+    ).toBe(true);
+  });
+});

--- a/apps/app/src/components/sidebar/sidebarThreadLifecycle.ts
+++ b/apps/app/src/components/sidebar/sidebarThreadLifecycle.ts
@@ -1,0 +1,94 @@
+import { atom } from "jotai";
+
+export const SIDEBAR_THREAD_LIFECYCLE_STATES = [
+  "active",
+  "drafts",
+  "archived",
+] as const;
+
+export type SidebarThreadLifecycleState =
+  (typeof SIDEBAR_THREAD_LIFECYCLE_STATES)[number];
+
+export type SidebarThreadLifecycleSelection =
+  ReadonlySet<SidebarThreadLifecycleState>;
+
+export const DEFAULT_SIDEBAR_THREAD_LIFECYCLE_SELECTION =
+  new Set<SidebarThreadLifecycleState>(["active"]);
+
+export const sidebarThreadLifecycleSelectionAtom =
+  atom<SidebarThreadLifecycleSelection>(
+    DEFAULT_SIDEBAR_THREAD_LIFECYCLE_SELECTION,
+  );
+
+export const builtInSidebarDraftRowsVisibleAtom = atom(false);
+
+export function toggleSidebarThreadLifecycleState(
+  current: SidebarThreadLifecycleSelection,
+  state: SidebarThreadLifecycleState,
+): SidebarThreadLifecycleSelection {
+  if (current.has(state)) {
+    if (current.size === 1) return current;
+    const next = new Set(current);
+    next.delete(state);
+    return next;
+  }
+
+  const next = new Set(current);
+  next.add(state);
+  return next;
+}
+
+export function isDefaultSidebarThreadLifecycleSelection(
+  selection: SidebarThreadLifecycleSelection,
+): boolean {
+  return selection.size === 1 && selection.has("active");
+}
+
+export interface BuiltInSidebarLifecycleRenderState {
+  showActiveModeSections: boolean;
+  showArchivedOnlyControl: boolean;
+  showFilteredEmptyState: boolean;
+  showLifecycleControlOnlySection: boolean;
+}
+
+export function getBuiltInSidebarLifecycleRenderState({
+  activeCount,
+  archivedCount,
+  archivedHasNextPage,
+  archivedIsPending,
+  draftCount,
+  isReady,
+  selection,
+}: {
+  activeCount: number;
+  archivedCount: number;
+  archivedHasNextPage: boolean;
+  archivedIsPending: boolean;
+  draftCount: number;
+  isReady: boolean;
+  selection: SidebarThreadLifecycleSelection;
+}): BuiltInSidebarLifecycleRenderState {
+  const selectionIsDefault =
+    isDefaultSidebarThreadLifecycleSelection(selection);
+  const showActive = selection.has("active");
+  const showDrafts = selection.has("drafts");
+  const showArchived = selection.has("archived");
+  const hasMatches =
+    (showActive && activeCount > 0) ||
+    (showDrafts && draftCount > 0) ||
+    (showArchived && archivedCount > 0);
+  const showActiveModeSections =
+    showActive && (selectionIsDefault || activeCount > 0 || !isReady);
+
+  return {
+    showActiveModeSections,
+    showArchivedOnlyControl: selection.size === 1 && showArchived,
+    showFilteredEmptyState:
+      !selectionIsDefault &&
+      isReady &&
+      !(showArchived && archivedIsPending) &&
+      !hasMatches,
+    showLifecycleControlOnlySection:
+      !showActiveModeSections && archivedCount === 0 && !archivedHasNextPage,
+  };
+}

--- a/apps/app/src/components/thread/ThreadActionsMenu.tsx
+++ b/apps/app/src/components/thread/ThreadActionsMenu.tsx
@@ -253,9 +253,11 @@ function ThreadActionsMenuItems({
 export function ThreadArchiveQuickAction({
   thread,
   className,
+  showLabel = false,
 }: {
   thread: Thread;
   className?: string;
+  showLabel?: boolean;
 }) {
   const { archiveThreadAndChildren, unarchiveThread } = useThreadActions();
   const isArchived = thread.archivedAt != null;
@@ -266,7 +268,7 @@ export function ThreadArchiveQuickAction({
         <Button
           type="button"
           variant="ghost"
-          size="icon"
+          size={showLabel ? "sm" : "icon"}
           className={cn("rounded-md p-0", className)}
           aria-label={`${label} thread`}
           onClick={(event) => {
@@ -279,10 +281,14 @@ export function ThreadArchiveQuickAction({
             archiveThreadAndChildren(thread);
           }}
         >
-          <Icon
-            name={isArchived ? "ArchiveRestore" : "Archive"}
-            className={COARSE_POINTER_ICON_SIZE_CLASS}
-          />
+          {showLabel ? (
+            label
+          ) : (
+            <Icon
+              name={isArchived ? "ArchiveRestore" : "Archive"}
+              className={COARSE_POINTER_ICON_SIZE_CLASS}
+            />
+          )}
         </Button>
       </TooltipTrigger>
       <TooltipContent side="bottom">{label}</TooltipContent>

--- a/apps/app/src/hooks/cache-owners/thread-state-cache-owner.test.ts
+++ b/apps/app/src/hooks/cache-owners/thread-state-cache-owner.test.ts
@@ -3,11 +3,13 @@ import type { SidebarBootstrapResponse } from "@bb/server-contract";
 import { describe, expect, it } from "vitest";
 import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
 import {
+  archivedThreadsListQueryKey,
   sidebarNavigationQueryKey,
   threadListQueryKey,
   threadQueryKey,
 } from "../queries/query-keys";
 import {
+  beginUnarchiveThreadTransaction,
   beginThreadReadStateTransaction,
   beginThreadMetadataTransaction,
   rollbackThreadListMutationTransaction,
@@ -100,6 +102,49 @@ function makeSidebarNavigation(
 }
 
 describe("thread state cache owner", () => {
+  it("optimistically removes an unarchived thread from paged archive rows", async () => {
+    const { queryClient } = createQueryClientTestHarness();
+    const threadId = "thread-1";
+    const archivedThread = makeThreadWithRuntime({
+      id: threadId,
+      archivedAt: 100,
+    });
+    const archivedListEntry = makeThreadListEntry({
+      id: threadId,
+      archivedAt: 100,
+    });
+    const archivedListKey = archivedThreadsListQueryKey({});
+    queryClient.setQueryData(threadQueryKey(threadId), archivedThread);
+    queryClient.setQueryData(archivedListKey, {
+      pageParams: [0],
+      pages: [[archivedListEntry]],
+    });
+
+    const transaction = await beginUnarchiveThreadTransaction({
+      queryClient,
+      threadId,
+    });
+
+    expect(
+      queryClient.getQueryData<ThreadWithRuntime>(threadQueryKey(threadId))
+        ?.archivedAt,
+    ).toBeNull();
+    expect(
+      queryClient.getQueryData<{ pages: ThreadListEntry[][] }>(archivedListKey)
+        ?.pages,
+    ).toEqual([[]]);
+
+    rollbackThreadListMutationTransaction({
+      queryClient,
+      threadId,
+      transaction,
+    });
+    expect(
+      queryClient.getQueryData<{ pages: ThreadListEntry[][] }>(archivedListKey)
+        ?.pages,
+    ).toEqual([[archivedListEntry]]);
+  });
+
   it("optimistically renames thread in thread, list, and sidebar caches", async () => {
     const { queryClient } = createQueryClientTestHarness();
     const threadId = "thread-1";

--- a/apps/app/src/hooks/useNewThreadDraftLeaveToast.test.ts
+++ b/apps/app/src/hooks/useNewThreadDraftLeaveToast.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import { createElement, StrictMode, type PropsWithChildren } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { PromptDraftState } from "@bb/client-core";
+import {
+  shouldAnnounceNewThreadDraftLeave,
+  useNewThreadDraftLeaveToast,
+} from "./useNewThreadDraftLeaveToast";
+
+const mockToastMessage = vi.hoisted(() => vi.fn());
+
+vi.mock("@/components/ui/app-toast", () => ({
+  appToast: { message: mockToastMessage },
+}));
+
+const EMPTY_DRAFT: PromptDraftState = {
+  attachments: [],
+  mentions: [],
+  text: "",
+};
+
+function StrictModeWrapper({ children }: PropsWithChildren) {
+  return createElement(StrictMode, null, children);
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("new-thread draft leave toast", () => {
+  it("announces exactly once on real unmount with no action payload", async () => {
+    const draft = { ...EMPTY_DRAFT, text: "Keep this work" };
+    const hook = renderHook(
+      () =>
+        useNewThreadDraftLeaveToast({
+          getCurrentDraft: () => draft,
+          isSplitPane: false,
+        }),
+      { wrapper: StrictModeWrapper },
+    );
+
+    await act(async () => {
+      hook.unmount();
+      await Promise.resolve();
+    });
+
+    expect(mockToastMessage).toHaveBeenCalledTimes(1);
+    expect(mockToastMessage).toHaveBeenCalledWith("Saved to Drafts");
+  });
+
+  it("announces a page-composer draft only when its built-in row is hidden", () => {
+    const draft = { ...EMPTY_DRAFT, text: "Keep this work" };
+    expect(
+      shouldAnnounceNewThreadDraftLeave({
+        draft,
+        draftRowsVisible: false,
+        isSplitPane: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldAnnounceNewThreadDraftLeave({
+        draft,
+        draftRowsVisible: true,
+        isSplitPane: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not announce empty or split-pane drafts in Phase 2", () => {
+    expect(
+      shouldAnnounceNewThreadDraftLeave({
+        draft: EMPTY_DRAFT,
+        draftRowsVisible: false,
+        isSplitPane: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldAnnounceNewThreadDraftLeave({
+        draft: { ...EMPTY_DRAFT, text: "Split work" },
+        draftRowsVisible: false,
+        isSplitPane: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/app/src/hooks/useNewThreadDraftLeaveToast.ts
+++ b/apps/app/src/hooks/useNewThreadDraftLeaveToast.ts
@@ -1,0 +1,54 @@
+import { useEffect, useRef } from "react";
+import { useAtomValue } from "jotai";
+import { isPromptDraftEmpty, type PromptDraftState } from "@bb/client-core";
+import { appToast } from "@/components/ui/app-toast";
+import { builtInSidebarDraftRowsVisibleAtom } from "@/components/sidebar/sidebarThreadLifecycle";
+
+export function shouldAnnounceNewThreadDraftLeave({
+  draft,
+  draftRowsVisible,
+  isSplitPane,
+}: {
+  draft: PromptDraftState;
+  draftRowsVisible: boolean;
+  isSplitPane: boolean;
+}): boolean {
+  return !isSplitPane && !draftRowsVisible && !isPromptDraftEmpty(draft);
+}
+
+export function useNewThreadDraftLeaveToast({
+  getCurrentDraft,
+  isSplitPane,
+}: {
+  getCurrentDraft: () => PromptDraftState;
+  isSplitPane: boolean;
+}): void {
+  const draftRowsVisible = useAtomValue(builtInSidebarDraftRowsVisibleAtom);
+  const draftRowsVisibleRef = useRef(draftRowsVisible);
+  const getCurrentDraftRef = useRef(getCurrentDraft);
+  const isSplitPaneRef = useRef(isSplitPane);
+  const mountedRef = useRef(false);
+
+  draftRowsVisibleRef.current = draftRowsVisible;
+  getCurrentDraftRef.current = getCurrentDraft;
+  isSplitPaneRef.current = isSplitPane;
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      const shouldAnnounce = shouldAnnounceNewThreadDraftLeave({
+        draft: getCurrentDraftRef.current(),
+        draftRowsVisible: draftRowsVisibleRef.current,
+        isSplitPane: isSplitPaneRef.current,
+      });
+      if (!shouldAnnounce) return;
+
+      queueMicrotask(() => {
+        if (!mountedRef.current) {
+          appToast.message("Saved to Drafts");
+        }
+      });
+    };
+  }, []);
+}

--- a/apps/app/src/hooks/useNewThreadDraftSlots.test.tsx
+++ b/apps/app/src/hooks/useNewThreadDraftSlots.test.tsx
@@ -1,0 +1,218 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PromptDraftAttachment, PromptDraftState } from "@bb/client-core";
+import {
+  getPromptDraftAccessor,
+  usePromptDraftStorage,
+} from "@/hooks/usePromptDraftStorage";
+import {
+  getNewThreadDraftSlotStorageKey,
+  serializeNewThreadDraftSlot,
+  type NewThreadDraftDestination,
+} from "@/lib/prompt-draft-slots";
+import {
+  getNewThreadDraftTitle,
+  useNewThreadDraftSlots,
+} from "./useNewThreadDraftSlots";
+
+const DESTINATION: NewThreadDraftDestination = {
+  projectId: "project-work",
+  sectionId: "section-inbox",
+};
+const ATTACHMENT: PromptDraftAttachment = {
+  type: "localFile",
+  path: "uploads/requirements.pdf",
+  name: "requirements.pdf",
+  mimeType: "application/pdf",
+  sizeBytes: 42,
+};
+
+function draft(text: string): PromptDraftState {
+  return { text, mentions: [], attachments: [] };
+}
+
+function dispatchStorageChange(
+  key: string | null,
+  oldValue: string | null = null,
+  newValue: string | null = null,
+): void {
+  window.dispatchEvent(
+    new StorageEvent("storage", {
+      key,
+      oldValue,
+      newValue,
+      storageArea: window.localStorage,
+    }),
+  );
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  dispatchStorageChange(null);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("useNewThreadDraftSlots", () => {
+  it("derives a live title before the debounced content write and sorts newest first", () => {
+    vi.useFakeTimers();
+    const firstComposer = renderHook(() =>
+      usePromptDraftStorage({
+        kind: "new-thread",
+        slotId: "first",
+        destination: DESTINATION,
+      }),
+    );
+    const secondComposer = renderHook(() =>
+      usePromptDraftStorage({
+        kind: "new-thread",
+        slotId: "second",
+        destination: DESTINATION,
+      }),
+    );
+    const rows = renderHook(() => useNewThreadDraftSlots());
+
+    vi.setSystemTime(100);
+    act(() =>
+      firstComposer.result.current.setTextAndMentions(
+        "  Refactor\n the   split layout  ",
+        [],
+      ),
+    );
+    expect(
+      window.localStorage.getItem(firstComposer.result.current.storageKey),
+    ).toBeNull();
+    expect(rows.result.current).toEqual([
+      expect.objectContaining({
+        id: "first",
+        title: "Refactor the split layout",
+        destination: DESTINATION,
+        lastEditedAt: 100,
+      }),
+    ]);
+
+    vi.setSystemTime(200);
+    act(() =>
+      secondComposer.result.current.setTextAndMentions("Write tests", []),
+    );
+    expect(rows.result.current.map((row) => row.id)).toEqual([
+      "second",
+      "first",
+    ]);
+
+    act(() => {
+      for (const row of rows.result.current) row.delete();
+    });
+  });
+
+  it("titles an attachment-only slot New thread", () => {
+    const composer = renderHook(() =>
+      usePromptDraftStorage({
+        kind: "new-thread",
+        slotId: "attachment-only",
+        destination: DESTINATION,
+      }),
+    );
+    const rows = renderHook(() => useNewThreadDraftSlots());
+
+    act(() => composer.result.current.addAttachment(ATTACHMENT));
+
+    expect(rows.result.current).toEqual([
+      expect.objectContaining({
+        id: "attachment-only",
+        title: "New thread",
+        draft: { text: "", mentions: [], attachments: [ATTACHMENT] },
+      }),
+    ]);
+    act(() => rows.result.current[0]?.delete());
+  });
+
+  it("deleting a row synchronously empties a live composer bound to its slot", () => {
+    const composer = renderHook(() =>
+      usePromptDraftStorage({
+        kind: "new-thread",
+        slotId: "open-composer",
+        destination: DESTINATION,
+      }),
+    );
+    const rows = renderHook(() => useNewThreadDraftSlots());
+    act(() => composer.result.current.setDraft(draft("Keep this visible")));
+    expect(rows.result.current).toHaveLength(1);
+
+    act(() => rows.result.current[0]?.delete());
+
+    expect(composer.result.current.text).toBe("");
+    expect(composer.result.current.attachments).toEqual([]);
+    expect(rows.result.current).toEqual([]);
+    expect(
+      window.localStorage.getItem(composer.result.current.storageKey),
+    ).toBeNull();
+  });
+
+  it("reacts to another window adding and deleting a slot", () => {
+    const rows = renderHook(() => useNewThreadDraftSlots());
+    const storageKey = getNewThreadDraftSlotStorageKey("other-window");
+    const serialized = serializeNewThreadDraftSlot(
+      draft("Arrived from storage"),
+      300,
+      DESTINATION,
+    );
+    expect(serialized).not.toBeNull();
+
+    act(() => {
+      window.localStorage.setItem(storageKey, serialized!);
+      dispatchStorageChange(storageKey, null, serialized);
+    });
+    expect(rows.result.current).toEqual([
+      expect.objectContaining({
+        id: "other-window",
+        title: "Arrived from storage",
+        lastEditedAt: 300,
+      }),
+    ]);
+
+    act(() => {
+      window.localStorage.removeItem(storageKey);
+      dispatchStorageChange(storageKey, serialized, null);
+    });
+    expect(rows.result.current).toEqual([]);
+  });
+
+  it("excludes active-thread and plugin-rendered composer drafts", () => {
+    const rows = renderHook(() => useNewThreadDraftSlots());
+
+    act(() => {
+      getPromptDraftAccessor({
+        kind: "thread",
+        projectId: "project-work",
+        threadId: "thread-active",
+      }).setDraft(draft("Unsent active-thread text"));
+      getPromptDraftAccessor({
+        kind: "plugin-new-thread",
+        key: "plugin-composer",
+      }).setDraft(draft("Plugin-owned draft"));
+    });
+
+    expect(rows.result.current).toEqual([]);
+  });
+});
+
+describe("getNewThreadDraftTitle", () => {
+  it("uses New thread only when the draft has no text", () => {
+    expect(getNewThreadDraftTitle(draft("  first\n words  "))).toBe(
+      "first words",
+    );
+    expect(
+      getNewThreadDraftTitle({
+        text: " \n ",
+        mentions: [],
+        attachments: [ATTACHMENT],
+      }),
+    ).toBe("New thread");
+  });
+});

--- a/apps/app/src/hooks/useNewThreadDraftSlots.ts
+++ b/apps/app/src/hooks/useNewThreadDraftSlots.ts
@@ -1,0 +1,51 @@
+import { useMemo, useSyncExternalStore } from "react";
+import { isPromptDraftEmpty, type PromptDraftState } from "@bb/client-core";
+import {
+  deleteNewThreadDraftSlot,
+  getNewThreadDraftSlotsSnapshot,
+  subscribeNewThreadDraftSlots,
+} from "@/hooks/usePromptDraftStorage";
+import type {
+  NewThreadDraftDestination,
+  NewThreadDraftSlot,
+} from "@/lib/prompt-draft-slots";
+
+const EMPTY_NEW_THREAD_DRAFT_SLOTS: readonly NewThreadDraftSlot[] = [];
+
+export interface NewThreadDraftRow {
+  id: string;
+  draft: PromptDraftState;
+  title: string;
+  lastEditedAt: number;
+  destination: NewThreadDraftDestination;
+  delete: () => void;
+}
+
+export function getNewThreadDraftTitle(draft: PromptDraftState): string {
+  const firstWords = draft.text.replace(/\s+/gu, " ").trim();
+  return firstWords.length > 0 ? firstWords : "New thread";
+}
+
+function toNewThreadDraftRow(slot: NewThreadDraftSlot): NewThreadDraftRow {
+  return {
+    ...slot,
+    title: getNewThreadDraftTitle(slot.draft),
+    delete: () => deleteNewThreadDraftSlot(slot.id),
+  };
+}
+
+export function useNewThreadDraftSlots(): readonly NewThreadDraftRow[] {
+  const slots = useSyncExternalStore(
+    subscribeNewThreadDraftSlots,
+    getNewThreadDraftSlotsSnapshot,
+    () => EMPTY_NEW_THREAD_DRAFT_SLOTS,
+  );
+
+  return useMemo(
+    () =>
+      slots
+        .filter((slot) => !isPromptDraftEmpty(slot.draft))
+        .map(toNewThreadDraftRow),
+    [slots],
+  );
+}

--- a/apps/app/src/hooks/usePromptDraftStorage.ts
+++ b/apps/app/src/hooks/usePromptDraftStorage.ts
@@ -14,7 +14,9 @@ import {
   getNewThreadDraftSlotStorageKey,
   parseNewThreadDraftSlot,
   persistNewThreadDraftSlot,
+  readNewThreadDraftSlots,
   type NewThreadDraftComposerSelection,
+  type NewThreadDraftSlot,
   type NewThreadDraftDestination,
 } from "@/lib/prompt-draft-slots";
 
@@ -53,7 +55,11 @@ const promptDraftCache = new Map<string, PromptDraftCacheEntry>();
 const promptDraftSubscribers = new Map<string, Set<PromptDraftListener>>();
 const pendingPromptDraftStorageKeys = new Set<string>();
 const promptDraftPersistTimers = new Map<string, number>();
+const newThreadDraftSlotSubscribers = new Set<PromptDraftListener>();
+let newThreadDraftSlotsSnapshot: readonly NewThreadDraftSlot[] | null = null;
 let promptDraftStorageObserverInitialized = false;
+
+const EMPTY_NEW_THREAD_DRAFT_SLOTS: readonly NewThreadDraftSlot[] = [];
 
 function normalizeStorageSegment(value: string): string {
   return encodeURIComponent(value.trim());
@@ -134,6 +140,7 @@ function updatePromptDraftDestination(
   cachedEntry.destination = destination;
   if (!isPromptDraftEmpty(draft)) {
     persistPromptDraftCache(storageKey);
+    emitNewThreadDraftSlotsChange();
   }
 }
 
@@ -144,6 +151,17 @@ function emitPromptDraftChange(storageKey: string): void {
   for (const listener of listeners) {
     listener();
   }
+}
+
+function emitNewThreadDraftSlotsChange(): void {
+  newThreadDraftSlotsSnapshot = null;
+  for (const listener of newThreadDraftSlotSubscribers) {
+    listener();
+  }
+}
+
+export function refreshNewThreadDraftSlots(): void {
+  emitNewThreadDraftSlotsChange();
 }
 
 function clearPromptDraftPersistTimer(storageKey: string): void {
@@ -233,10 +251,16 @@ function ensurePromptDraftStorageObserver(): void {
 
   promptDraftStorageObserverInitialized = true;
   window.addEventListener("storage", (event) => {
-    if (!event.key) return;
+    if (event.key === null) {
+      emitNewThreadDraftSlotsChange();
+      return;
+    }
     if (pendingPromptDraftStorageKeys.has(event.key)) return;
     promptDraftCache.delete(event.key);
     emitPromptDraftChange(event.key);
+    if (getNewThreadDraftSlotIdFromStorageKey(event.key) !== null) {
+      emitNewThreadDraftSlotsChange();
+    }
   });
   window.addEventListener("pagehide", flushPendingPromptDraftPersists);
   document.addEventListener("visibilitychange", () => {
@@ -305,6 +329,75 @@ function writePromptDraft(
     persistPromptDraftCache(storageKey);
   }
   emitPromptDraftChange(storageKey);
+  if (slotId !== null) {
+    emitNewThreadDraftSlotsChange();
+  }
+}
+
+function readLiveNewThreadDraftSlots(): readonly NewThreadDraftSlot[] {
+  if (typeof window === "undefined") return EMPTY_NEW_THREAD_DRAFT_SLOTS;
+
+  const slotsById = new Map(
+    readNewThreadDraftSlots().map((slot) => [slot.id, slot]),
+  );
+  for (const [storageKey, cachedEntry] of promptDraftCache) {
+    const slotId = getNewThreadDraftSlotIdFromStorageKey(storageKey);
+    if (slotId === null) continue;
+
+    const isAuthoritative =
+      pendingPromptDraftStorageKeys.has(storageKey) ||
+      cachedEntry.rawValue === readStoredPromptDraftValue(storageKey);
+    if (!isAuthoritative) continue;
+
+    if (
+      isPromptDraftEmpty(cachedEntry.draft) ||
+      cachedEntry.lastEditedAt === null ||
+      cachedEntry.destination === null
+    ) {
+      slotsById.delete(slotId);
+      continue;
+    }
+    slotsById.set(slotId, {
+      id: slotId,
+      draft: cachedEntry.draft,
+      lastEditedAt: cachedEntry.lastEditedAt,
+      destination: cachedEntry.destination,
+      composerSelection: cachedEntry.composerSelection,
+    });
+  }
+
+  return [...slotsById.values()].sort(
+    (left, right) =>
+      right.lastEditedAt - left.lastEditedAt || left.id.localeCompare(right.id),
+  );
+}
+
+export function getNewThreadDraftSlotsSnapshot(): readonly NewThreadDraftSlot[] {
+  if (newThreadDraftSlotsSnapshot === null) {
+    newThreadDraftSlotsSnapshot = readLiveNewThreadDraftSlots();
+  }
+  return newThreadDraftSlotsSnapshot;
+}
+
+export function subscribeNewThreadDraftSlots(
+  listener: PromptDraftListener,
+): () => void {
+  ensurePromptDraftStorageObserver();
+  newThreadDraftSlotSubscribers.add(listener);
+  return () => {
+    newThreadDraftSlotSubscribers.delete(listener);
+  };
+}
+
+export function deleteNewThreadDraftSlot(slotId: string): void {
+  writePromptDraft(
+    getNewThreadDraftSlotStorageKey(slotId),
+    EMPTY_PROMPT_DRAFT,
+    {
+      persist: "immediate",
+      clearComposerSelection: true,
+    },
+  );
 }
 
 function areDraftComposerSelectionsEqual(

--- a/apps/app/src/lib/root-compose-selection.ts
+++ b/apps/app/src/lib/root-compose-selection.ts
@@ -26,6 +26,13 @@ const rootComposeProjectIdAtom = atomWithStorage<string>(
 
 const rootComposeReuseEnvironmentAtom = atom<string | null>(null);
 
+export function readRootComposeProjectId(): string {
+  return rootComposeProjectIdStorage.getItem(
+    ROOT_COMPOSE_PROJECT_ID_STORAGE_KEY,
+    PERSONAL_PROJECT_ID,
+  );
+}
+
 export function useRootComposeProjectId() {
   return useAtom(rootComposeProjectIdAtom);
 }

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -179,6 +179,7 @@ import {
   useAppCommandShortcut,
 } from "@/components/commands/AppCommandProvider";
 import { useOptionalPaneContext } from "./thread-detail/PaneContext";
+import { useNewThreadDraftLeaveToast } from "@/hooks/useNewThreadDraftLeaveToast";
 import { RootComposePanelCommandHandlers } from "./RootComposePanelCommandHandlers";
 import {
   ROOT_COMPOSE_FIXED_PANEL_STATE_ID,
@@ -734,6 +735,10 @@ function RootComposeSurface({
     setServiceTier,
     renderPromptBox,
   } = composer;
+  useNewThreadDraftLeaveToast({
+    getCurrentDraft: promptDraft.getCurrent,
+    isSplitPane: paneContext?.isSplitPane === true,
+  });
   const rootPanelEnvironmentId =
     parsedEnvironment?.type === "reuse"
       ? parsedEnvironment.environmentId


### PR DESCRIPTION
## What was wrong

The built-in sidebar represented only active server threads. Client-local new-thread drafts disappeared after navigation, and archived threads had no in-context lifecycle view or direct restore action.

## What changed

- adds **Active**, **Drafts**, and **Archived** lifecycle filters without counts
- renders local draft rows at the top with a right-edge **Draft** label
- renders archived rows as a contiguous trailing group with a right-edge **Archived** label
- restores an archived thread from the row affordance with **Unarchive**
- keeps drafts and lifecycle preferences client-local and leaves plugin-provided thread lists unchanged

No server count route, public SDK change, or daemon protocol change is introduced by this layer.

## Visual evidence

> Rebase evidence status: current parent `62d4e332a20d6bf8adaf24910a23ce994f343942` and current head `d01d336283f40f580b7216ad12ccce4f2a5723c0`. The embedded captures below were made from the exact pre-rebase revisions and remain useful behavioral references, but they are not exact-current-revision evidence. Replace them before merge.

Pre-rebase behavioral comparison: `a2f8eea7dedf54396c68500d826f2ab3772a0cc3` → `4a78545610576c1839ca271cb9440be657e93874`.

### Before — pre-rebase base `a2f8eea7dedf54396c68500d826f2ab3772a0cc3`

The same Display options state ends after organization and sorting.

![Before — no lifecycle filter](https://raw.githubusercontent.com/brsbl/bb/76fb4286cdd417380548c4ab629a7edf72474932/updated-sidebar-stack-2026-08-27/pr2421-before.png)

### After — pre-rebase head `4a78545610576c1839ca271cb9440be657e93874`

The menu adds Active, Drafts, and Archived with no counts.

![After — lifecycle filters without counts](https://raw.githubusercontent.com/brsbl/bb/76fb4286cdd417380548c4ab629a7edf72474932/updated-sidebar-stack-2026-08-27/pr2421-after.png)

### After — lifecycle rows

![After — drafts, active threads, and trailing archived rows](https://raw.githubusercontent.com/brsbl/bb/76fb4286cdd417380548c4ab629a7edf72474932/updated-sidebar-stack-2026-08-27/pr2421-after-lifecycle.png)

## How you verified

- Google Chrome for Testing 151.0.7922.71, pre-rebase exact branch web apps from `scripts/bb-dev-app`, light theme, `/`, 1440×900.
- Enabled Drafts and Archived and observed draft rows first, active rows in the middle, and archived rows last; labels stayed on the right edge.
- Hovered an archived row, observed **Unarchive**, activated it with a real pointer action, and confirmed the row left the archived group (21 → 20). No page or console errors were recorded.

Fixes: N/A — Updated Sidebar lifecycle layer.

BB-Thread-ID: thr_2e2gbjx943

> AGENT GENERATED


