### PR TITLE
test(ask-user-question): avoid repeated accessibility transforms

### DIFF
--- a/plugins/ask-user-question/app.test.tsx
+++ b/plugins/ask-user-question/app.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { loadPluginApp, renderSlot } from "@get-bb/plugin-sdk/testing/app";
 import type { InteractionPayload, InteractionResponse } from "./src/contracts";
@@ -71,18 +71,32 @@ function render(
   });
 }
 
+function getButtonByText(
+  slot: ReturnType<typeof render>,
+  text: string,
+): HTMLButtonElement {
+  const button = slot.getByText(text).closest("button");
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error(`${text} is not rendered inside a button`);
+  }
+  return button;
+}
+
 describe("answering a single-select question", () => {
-  it("submits the selected option value", async () => {
+  it("submits the selected option value", () => {
     const submit = vi.fn(async () => undefined);
     const slot = render(singleSelect, { submit });
 
     // The prompt renders twice by design: the visible heading plus the
     // fieldset's sr-only legend.
     expect(slot.getAllByText("Which database should we use?")).toHaveLength(2);
-    fireEvent.click(slot.getByRole("button", { name: /SQLite/ }));
-    fireEvent.click(slot.getByRole("button", { name: "Submit answer" }));
+    // This assertion is about payload plumbing, so use the visible labels and
+    // verify their native button boundary without recomputing the full
+    // accessibility tree for each click.
+    fireEvent.click(getButtonByText(slot, "SQLite"));
+    fireEvent.click(getButtonByText(slot, "Submit answer"));
 
-    await waitFor(() => expect(submit).toHaveBeenCalledTimes(1));
+    expect(submit).toHaveBeenCalledTimes(1);
     expect(submit.mock.calls[0]?.[0]).toEqual({
       answers: { q0: { selected: ["q0o1"] } },
     } satisfies InteractionResponse);
@@ -90,12 +104,10 @@ describe("answering a single-select question", () => {
 
   it("blocks submission until something is chosen", () => {
     const slot = render(singleSelect);
-    const submitButton = slot.getByRole("button", {
-      name: "Submit answer",
-    }) as HTMLButtonElement;
+    const submitButton = getButtonByText(slot, "Submit answer");
 
     expect(submitButton.disabled).toBe(true);
-    fireEvent.click(slot.getByRole("button", { name: /Postgres/ }));
+    fireEvent.click(getButtonByText(slot, "Postgres"));
     expect(submitButton.disabled).toBe(false);
   });
 
@@ -104,38 +116,38 @@ describe("answering a single-select question", () => {
     const preview = "CREATE TABLE users (id uuid primary key);";
 
     expect(slot.queryByText(preview)).toBeNull();
-    fireEvent.click(slot.getByRole("button", { name: /Postgres/ }));
+    fireEvent.click(getButtonByText(slot, "Postgres"));
     expect(slot.getByText(preview)).toBeTruthy();
 
     // Switching to an option without a preview retires the block.
-    fireEvent.click(slot.getByRole("button", { name: /SQLite/ }));
+    fireEvent.click(getButtonByText(slot, "SQLite"));
     expect(slot.queryByText(preview)).toBeNull();
   });
 
-  it("makes 'Other' and a real option mutually exclusive", async () => {
+  it("makes 'Other' and a real option mutually exclusive", () => {
     const submit = vi.fn(async () => undefined);
     const slot = render(singleSelect, { submit });
 
-    fireEvent.click(slot.getByRole("button", { name: /Postgres/ }));
-    fireEvent.click(slot.getByRole("button", { name: /Other/ }));
+    fireEvent.click(getButtonByText(slot, "Postgres"));
+    fireEvent.click(getButtonByText(slot, "Other…"));
     const textarea = slot.getByLabelText("Database answer");
     fireEvent.change(textarea, { target: { value: "DuckDB" } });
-    fireEvent.click(slot.getByRole("button", { name: "Submit answer" }));
+    fireEvent.click(getButtonByText(slot, "Submit answer"));
 
-    await waitFor(() => expect(submit).toHaveBeenCalledTimes(1));
+    expect(submit).toHaveBeenCalledTimes(1);
     expect(submit.mock.calls[0]?.[0]).toEqual({
       answers: { q0: { selected: [], freeText: "DuckDB" } },
     } satisfies InteractionResponse);
   });
 
-  it("selects an option with its number-key shortcut", async () => {
+  it("selects an option with its number-key shortcut", () => {
     const submit = vi.fn(async () => undefined);
     const slot = render(singleSelect, { submit });
 
     fireEvent.keyDown(window, { key: "2" });
-    fireEvent.click(slot.getByRole("button", { name: "Submit answer" }));
+    fireEvent.click(getButtonByText(slot, "Submit answer"));
 
-    await waitFor(() => expect(submit).toHaveBeenCalledTimes(1));
+    expect(submit).toHaveBeenCalledTimes(1);
     expect(submit.mock.calls[0]?.[0]).toEqual({
       answers: { q0: { selected: ["q0o1"] } },
     } satisfies InteractionResponse);
@@ -143,17 +155,15 @@ describe("answering a single-select question", () => {
 
   it("ignores number keys typed into the free-text box", () => {
     const slot = render(singleSelect);
-    fireEvent.click(slot.getByRole("button", { name: /Other/ }));
+    fireEvent.click(getButtonByText(slot, "Other…"));
     const textarea = slot.getByLabelText("Database answer");
 
     fireEvent.keyDown(textarea, { key: "1" });
 
     // A digit must reach the textarea as text, not pick option 1.
-    expect(
-      slot
-        .getByRole("button", { name: /Postgres/ })
-        .getAttribute("aria-pressed"),
-    ).toBe("false");
+    expect(getButtonByText(slot, "Postgres").getAttribute("aria-pressed")).toBe(
+      "false",
+    );
   });
 });
 
@@ -185,21 +195,21 @@ describe("multi-select and multi-question flows", () => {
     ],
   };
 
-  it("keeps several options selected and walks both questions before submitting", async () => {
+  it("keeps several options selected and walks both questions before submitting", () => {
     const submit = vi.fn(async () => undefined);
     const slot = render(multi, { submit });
 
     expect(slot.getByText("1 of 2")).toBeTruthy();
-    fireEvent.click(slot.getByRole("button", { name: /Metrics/ }));
-    fireEvent.click(slot.getByRole("button", { name: /Tracing/ }));
+    fireEvent.click(getButtonByText(slot, "Metrics"));
+    fireEvent.click(getButtonByText(slot, "Tracing"));
     // The first question is not the last, so the primary button advances.
-    fireEvent.click(slot.getByRole("button", { name: "Next" }));
+    fireEvent.click(getButtonByText(slot, "Next"));
 
     expect(slot.getByText("2 of 2")).toBeTruthy();
-    fireEvent.click(slot.getByRole("button", { name: /Postgres/ }));
-    fireEvent.click(slot.getByRole("button", { name: "Submit answer" }));
+    fireEvent.click(getButtonByText(slot, "Postgres"));
+    fireEvent.click(getButtonByText(slot, "Submit answer"));
 
-    await waitFor(() => expect(submit).toHaveBeenCalledTimes(1));
+    expect(submit).toHaveBeenCalledTimes(1);
     expect(submit.mock.calls[0]?.[0]).toEqual({
       answers: {
         q0: { selected: ["q0o0", "q0o1"] },
@@ -208,17 +218,17 @@ describe("multi-select and multi-question flows", () => {
     } satisfies InteractionResponse);
   });
 
-  it("cancels the request instead of submitting", async () => {
+  it("cancels the request instead of submitting", () => {
     const cancel = vi.fn(async () => undefined);
     const slot = render(multi, { cancel });
 
-    fireEvent.click(slot.getByRole("button", { name: "Cancel" }));
-    await waitFor(() => expect(cancel).toHaveBeenCalledTimes(1));
+    fireEvent.click(getButtonByText(slot, "Cancel"));
+    expect(cancel).toHaveBeenCalledTimes(1);
   });
 });
 
 describe("a payload the form cannot read", () => {
-  it("offers a cancel escape rather than blocking the composer", async () => {
+  it("offers a cancel escape rather than blocking the composer", () => {
     const cancel = vi.fn(async () => undefined);
     const slot = renderSlot(app.pendingInteractions[0]!, {
       interaction: {
@@ -236,7 +246,7 @@ describe("a payload the form cannot read", () => {
     expect(
       slot.getByText("This question could not be displayed."),
     ).toBeTruthy();
-    fireEvent.click(slot.getByRole("button", { name: "Cancel" }));
-    await waitFor(() => expect(cancel).toHaveBeenCalledTimes(1));
+    fireEvent.click(getButtonByText(slot, "Cancel"));
+    expect(cancel).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## What was wrong

The ask-user-question UI tests repeatedly used named `getByRole` queries for ordinary click targets, even though these tests assert selection state, payload construction, and callback invocation rather than accessible-name computation. Testing Library recomputes accessible names and visibility across every matching role candidate for each such query. Under package-shard CPU oversubscription, that avoidable work dominated the synchronous test body and exhausted Vitest's unchanged 5-second ceiling. A focused 768-way contention reproduction produced the exact CI signature at `app.test.tsx:75` in 6.765s; the full package reproduction reported it in 8.548s with the same 1 failed/2 passed files and 1 failed/35 passed tests. Instrumentation separated a named option-role query from its click at 512-way contention: the query took 2.163s while the React click/update took 32ms. The verified origin/main and merge-base for this investigation is `c65d2ec8bf4be50ef8518fc026b85260cae73921`. CI evidence: [run 32892243548](https://github.com/get-bb/bb/actions/runs/32892243548), [packages job 97946623016](https://github.com/get-bb/bb/actions/runs/32892243548/job/97946623016).

## What changed

`plugins/ask-user-question/app.test.tsx` now resolves visible labels to their native `HTMLButtonElement` boundary through one small helper, avoiding repeated accessibility-tree transforms while still proving that each clicked label is rendered inside a real button. Submit and cancel spies are asserted directly because those callbacks are invoked synchronously by the click handlers; elapsed-time polling did not represent a real lifecycle boundary. All payload, disabled-state, preview, `aria-pressed`, navigation, cancellation, and malformed-payload assertions remain intact. There are no production, wire-protocol, timeout, CLI, or documentation changes.

## How you verified

- Before: `pnpm exec turbo run test --filter=bb-plugin-ask-user-question --force` under 768-way contention reproduced the exact failure at 8.548s. The focused named test also reproduced at 6.765s.
- Intermediate structural check: after optimizing only the original test, it passed in 2.070s but the same full stress run moved the timeout to the sibling role-heavy test at 5.574s. This records package-shard oversubscription as systemic amplification and justified applying the same structural pattern across the file rather than distributing larger clocks.
- After: the full unchanged-timeout package suite passed all 36 tests under the same 768-way contention; `app.test.tsx` completed in 4.255s and the original test in 1.393s.
- The exact named regression passed 20 consecutive Turbo-filtered runs.
- `pnpm exec turbo run test --filter=bb-plugin-ask-user-question --force` — 36/36 tests pass unloaded.
- `pnpm exec turbo run typecheck --filter=bb-plugin-ask-user-question --force` — passes.
- `pnpm exec turbo run build --filter=bb-plugin-ask-user-question --force` — build graph passes (2/2 upstream generation tasks; this private plugin has no package build script).
- `pnpm exec prettier --check plugins/ask-user-question/app.test.tsx` — passes.

## Alternatives rejected

A timeout increase was rejected because the work is reducible and the existing completion signals are synchronous; changing the clock would hide the repeated transforms and weaken hang detection. Quarantining, retrying, or disabling the test was rejected because the assertions remain valuable. Changing production code was rejected because the measured cost was in test queries, not the plugin interaction lifecycle. Limiting the fix to the one recorded signature was also rejected after the identical contention condition exposed the same structural issue in a sibling test.

> AGENT GENERATED: by GPT-5.6-Sol
