### PR TITLE
Retain interactive PATH across host shell probe failures

### DIFF
--- a/apps/host-daemon/src/runtime-shell-env.test.ts
+++ b/apps/host-daemon/src/runtime-shell-env.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path, { delimiter } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  createUserShellPathResolver,
   prepareRuntimeShellEnv,
   resolveLocalBbExecutablePath,
   resolveUserShellPath,
@@ -311,6 +312,35 @@ describe("resolveUserShellPath", () => {
     expect(fakeSpawn.calls.map((call) => call.args[0])).toEqual([
       "-ilc",
       "-lc",
+    ]);
+  });
+
+  it("retains the previous PATH when a refreshed interactive probe fails", async () => {
+    const interactivePath = "/home/me/.local/bin:/usr/bin";
+    const fakeSpawn = createFakeShellEnvSpawn({
+      results: [
+        createShellEnvSpawnResult({
+          stdout: createMarkedShellEnvOutput(interactivePath),
+        }),
+        createShellEnvSpawnResult({
+          status: 1,
+          stderr: "interactive shell failed",
+        }),
+      ],
+    });
+
+    const resolvePath = createUserShellPathResolver({
+      env: { SHELL: "/bin/zsh", PATH: "/usr/bin" },
+      platform: "linux",
+      spawnUserShellEnv: fakeSpawn.spawn,
+    });
+
+    await expect(resolvePath()).resolves.toBe(interactivePath);
+    await expect(resolvePath()).resolves.toBe(interactivePath);
+
+    expect(fakeSpawn.calls.map((call) => call.args[0])).toEqual([
+      "-ilc",
+      "-ilc",
     ]);
   });
 

--- a/apps/host-daemon/src/runtime-shell-env.ts
+++ b/apps/host-daemon/src/runtime-shell-env.ts
@@ -327,6 +327,13 @@ function parsePathFromUserShellEnv(stdout: string): string | null {
 export async function resolveUserShellPath(
   options: ResolveUserShellPathOptions = {},
 ): Promise<string | null> {
+  return resolveUserShellPathWithPrevious(options, null);
+}
+
+async function resolveUserShellPathWithPrevious(
+  options: ResolveUserShellPathOptions,
+  previousPath: string | null,
+): Promise<string | null> {
   const env = options.env ?? process.env;
   const shell = resolveUserShellCommand(
     env,
@@ -338,7 +345,8 @@ export async function resolveUserShellPath(
 
   const spawnUserShellEnv =
     options.spawnUserShellEnv ?? defaultSpawnUserShellEnv;
-  for (const shellArgs of userShellEnvArgSets(shell)) {
+  const shellArgSets = userShellEnvArgSets(shell);
+  for (const [index, shellArgs] of shellArgSets.entries()) {
     const result = await spawnUserShellEnv({
       command: shell,
       args: shellArgs,
@@ -350,15 +358,41 @@ export async function resolveUserShellPath(
       result.signal !== null ||
       result.status !== 0
     ) {
+      if (index === 0 && previousPath !== null) {
+        return previousPath;
+      }
       continue;
     }
     const path = parsePathFromUserShellEnv(result.stdout);
     if (path !== null) {
       return path;
     }
+    // The plain-login fallback is good enough to start a daemon that has no
+    // shell PATH yet. During a refresh, however, replacing a previously good
+    // interactive PATH after one slow or failed probe can resolve an entirely
+    // different npm prefix and provider executable. Keep the last answer and
+    // let a later successful interactive probe update it.
+    if (index === 0 && previousPath !== null) {
+      return previousPath;
+    }
   }
 
   return null;
+}
+
+/**
+ * Re-resolves the user's interactive shell PATH without downgrading a known
+ * answer to the plain-login fallback after a transient probe failure.
+ */
+export function createUserShellPathResolver(
+  options: ResolveUserShellPathOptions = {},
+): () => Promise<string | null> {
+  let previousPath: string | null = null;
+  return async () => {
+    const path = await resolveUserShellPathWithPrevious(options, previousPath);
+    if (path !== null) previousPath = path;
+    return path;
+  };
 }
 
 /**

--- a/apps/host-daemon/src/start-host-daemon.ts
+++ b/apps/host-daemon/src/start-host-daemon.ts
@@ -20,10 +20,10 @@ import { loadHostIdentity, persistHostId } from "./identity.js";
 import { acquireDaemonLock } from "./lock.js";
 import { resolveHostDaemonLocalApiConfig } from "./local-api-config.js";
 import {
+  createUserShellPathResolver,
   prepareRuntimeShellEnv,
   resolveBbExecutablePathInDirectory,
   resolveLocalBbExecutablePath,
-  resolveUserShellPath,
 } from "./runtime-shell-env.js";
 import type { HostDaemonLogger } from "./logger.js";
 import {
@@ -180,6 +180,7 @@ export async function startHostDaemon(
       }),
     );
     const hostWatcher = createHostWatcher();
+    const resolveUserShellPath = createUserShellPathResolver();
     const resolveRuntimeShellEnv = async () =>
       prepareRuntimeShellEnv({
         bbExecutableDirectory,


### PR DESCRIPTION
## What was wrong

The host daemon periodically re-resolves the user shell PATH by trying an interactive login shell and then falling back to a plain login shell. A transient timeout or failure during a refresh could replace a previously successful interactive PATH with the fallback PATH. On hosts using a Node version manager, those paths can resolve different provider executables and npm prefixes, so the UI could advertise an update for one Pi installation while action preflight inspected another and rejected the stale action.

## What changed

Added a stateful user-shell PATH resolver that retains the last successful interactive PATH when a later interactive probe fails or produces invalid output. Initial discovery still uses the existing plain-login fallback when no previous PATH is available. Host daemon startup now keeps one resolver for its runtime-shell refresh lifecycle.

No wire contracts changed, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

## How you verified

- Added a regression test that fails before the fix and passes after it.
- `pnpm exec turbo run typecheck --filter=@bb/host-daemon`
- `pnpm exec turbo run test --filter=@bb/host-daemon --force -- src/runtime-shell-env.test.ts` — 17 passed.
- Full `@bb/host-daemon` suite — 559 passed.
- Live Pi status remained on NVM Pi `0.84.3` with no update action across three refresh intervals.

Fixes: N/A — reported through a bb thread.

> AGENT GENERATED