### PR TITLE
Fix timeline scroll anchor while older rows load

### DIFF
--- a/apps/app/src/components/ui/bottom-anchored-scroll-body.scroll-preservation.test.tsx
+++ b/apps/app/src/components/ui/bottom-anchored-scroll-body.scroll-preservation.test.tsx
@@ -125,29 +125,34 @@ function renderTimeline({
   showScrollToBottomControl = false,
   virtualized = false,
 }: RenderArgs) {
-  const rows = rowIds.map((rowId) => (
-    <div key={rowId} data-timeline-row-id={rowId}>
-      {rowId}
-    </div>
-  ));
-  const view = render(
-    <BottomAnchoredScrollBody
-      footer={<div>Footer</div>}
-      maxWidthClassName="max-w-none"
-      scrollAreaClassName={SCROLL_AREA_CLASS}
-      scrollAnchorThreadId={threadId}
-    >
-      {showCapturePrependAnchorControl ? <CapturePrependAnchorControl /> : null}
-      {showScrollToBottomControl ? <ScrollToBottomControl /> : null}
-      {virtualized ? (
-        <div data-timeline-row-list="top-level">
-          <div data-timeline-virtual-spacer="">{rows}</div>
-        </div>
-      ) : (
-        rows
-      )}
-    </BottomAnchoredScrollBody>,
-  );
+  const timeline = (renderedRowIds: string[]) => {
+    const rows = renderedRowIds.map((rowId) => (
+      <div key={rowId} data-timeline-row-id={rowId}>
+        {rowId}
+      </div>
+    ));
+    return (
+      <BottomAnchoredScrollBody
+        footer={<div>Footer</div>}
+        maxWidthClassName="max-w-none"
+        scrollAreaClassName={SCROLL_AREA_CLASS}
+        scrollAnchorThreadId={threadId}
+      >
+        {showCapturePrependAnchorControl ? (
+          <CapturePrependAnchorControl />
+        ) : null}
+        {showScrollToBottomControl ? <ScrollToBottomControl /> : null}
+        {virtualized ? (
+          <div data-timeline-row-list="top-level">
+            <div data-timeline-virtual-spacer="">{rows}</div>
+          </div>
+        ) : (
+          rows
+        )}
+      </BottomAnchoredScrollBody>
+    );
+  };
+  const view = render(timeline(rowIds));
 
   const scrollArea = requireHTMLElement(
     view.container.querySelector(`.${SCROLL_AREA_CLASS}`),
@@ -166,6 +171,7 @@ function renderTimeline({
     getByRole: view.getByRole,
     scrollArea,
     rowElements,
+    rerenderRows: (nextRowIds: string[]) => view.rerender(timeline(nextRowIds)),
     unmount: view.unmount,
   };
 }
@@ -331,7 +337,7 @@ describe("BottomAnchoredScrollBody scroll preservation", () => {
   });
 
   it("does not treat a native-anchor jump during prepend as bottom intent", () => {
-    const { getByRole, scrollArea } = renderTimeline({
+    const { getByRole, rerenderRows, scrollArea } = renderTimeline({
       threadId: "thread-a",
       rowIds: ["row-a", "row-b", "row-c"],
       showCapturePrependAnchorControl: true,
@@ -367,6 +373,46 @@ describe("BottomAnchoredScrollBody scroll preservation", () => {
     getLatestResizeObserver().trigger();
 
     expect(scrollArea.scrollTop).toBe(300);
+
+    // The browser-induced scroll event must not replace the explicit anchor
+    // captured at 150; the 100px prepend therefore restores to 250.
+    rerenderRows(["older-row", "row-a", "row-b", "row-c"]);
+    expect(scrollArea.scrollTop).toBe(250);
+  });
+
+  it("preserves user scrolling that continues while older rows load", () => {
+    const { getByRole, rerenderRows, scrollArea } = renderTimeline({
+      threadId: "thread-a",
+      rowIds: ["row-a", "row-b", "row-c"],
+      showCapturePrependAnchorControl: true,
+    });
+    setScrollMetrics(scrollArea, {
+      scrollHeight: 400,
+      clientHeight: 100,
+      scrollTop: 300,
+    });
+    getLatestResizeObserver().trigger();
+
+    scrollArea.scrollTop = 150;
+    fireEvent.wheel(scrollArea, { deltaY: -100 });
+    fireEvent.scroll(scrollArea);
+    fireEvent.click(getByRole("button", { name: "Capture prepend anchor" }));
+
+    // The request remains in flight while the user keeps scrolling upward.
+    scrollArea.scrollTop = 100;
+    fireEvent.wheel(scrollArea, { deltaY: -50 });
+    fireEvent.scroll(scrollArea);
+
+    // One 100px row is prepended. Preserve the user's newer 100px position,
+    // not the stale 150px position captured when loading began.
+    setScrollMetrics(scrollArea, {
+      scrollHeight: 500,
+      clientHeight: 100,
+      scrollTop: scrollArea.scrollTop,
+    });
+    rerenderRows(["older-row", "row-a", "row-b", "row-c"]);
+
+    expect(scrollArea.scrollTop).toBe(200);
   });
 
   it("restores near the saved row when returning to a thread", () => {

--- a/apps/app/src/components/ui/bottom-anchored-scroll-body.tsx
+++ b/apps/app/src/components/ui/bottom-anchored-scroll-body.tsx
@@ -281,6 +281,7 @@ export function BottomAnchoredScrollBody({
   const scrollContentRef = useRef<HTMLDivElement>(null);
   const shouldStickToBottomRef = useRef(true);
   const userScrollIntentUntilRef = useRef(0);
+  const userScrollInputPendingRef = useRef(false);
   const pointerScrollIntentRef = useRef(false);
   const restoreFrameRef = useRef<number | null>(null);
   const restoreFramesRemainingRef = useRef(0);
@@ -482,6 +483,9 @@ export function BottomAnchoredScrollBody({
   const captureScrollAnchor = useCallback(() => {
     const scrollArea = scrollAreaRef.current;
     if (!scrollArea) return;
+    // Input that produced the captured position is already reflected in
+    // scrollTop. Only later input should advance this pending anchor.
+    userScrollInputPendingRef.current = false;
     pendingPrependAnchorRef.current = {
       scrollHeight: scrollArea.scrollHeight,
       scrollTop: scrollArea.scrollTop,
@@ -625,6 +629,7 @@ export function BottomAnchoredScrollBody({
   );
 
   const markUserScrollIntent = useCallback(() => {
+    userScrollInputPendingRef.current = true;
     userScrollIntentUntilRef.current =
       window.performance.now() + USER_SCROLL_INTENT_MS;
   }, []);
@@ -702,11 +707,22 @@ export function BottomAnchoredScrollBody({
   const syncBottomStateFromScroll = useCallback(() => {
     const scrollArea = scrollAreaRef.current;
     if (!scrollArea) return;
+    const hasDirectUserScrollInput =
+      userScrollInputPendingRef.current || pointerScrollIntentRef.current;
+    userScrollInputPendingRef.current = false;
 
     if (
       pendingPrependAnchorRef.current !== null &&
       hasRecentUserScrollIntent()
     ) {
+      if (hasDirectUserScrollInput) {
+        // The user can keep moving while the older-page request is in flight.
+        // Advance only the position: scrollHeight remains the pre-prepend
+        // baseline used to compensate once the new rows mount. Browser-native
+        // anchoring emits scroll without fresh input, so it cannot overwrite
+        // this explicit anchor with a transient position.
+        pendingPrependAnchorRef.current.scrollTop = scrollArea.scrollTop;
+      }
       // Native scroll anchoring can temporarily move a user-scrolled viewport
       // to the current maximum while prepended rows mount. That is not a user
       // request to resume following the bottom. Keep sticky-bottom disabled


### PR DESCRIPTION
## What was wrong

When loading older timeline rows, `BottomAnchoredScrollBody` captured both the current `scrollHeight` and `scrollTop` before starting the request. If the user continued scrolling while that request was in flight, the pending anchor kept the earlier `scrollTop`. Once the rows mounted, prepend compensation restored that stale position plus the height delta, visibly undoing part of the user's scroll. Browser-native scroll anchoring also emits scroll events during a prepend, so those events cannot safely be treated as fresh user intent.

## What changed

- Track whether the next scroll event follows direct wheel, touch, keyboard, or pointer input.
- While a prepend anchor is pending, advance its `scrollTop` to the user's latest position but retain the original `scrollHeight` baseline used for compensation.
- Clear the direct-input marker when capturing an anchor, so browser-generated scroll events cannot replace the explicit position.
- Extend the scroll-preservation tests to exercise actual row prepends, continued user scrolling during the load, and native browser anchoring.

This is UI-only and does not change the host-daemon protocol or any CLI surface.

## How you verified

- Confirmed the new regression test failed before the implementation (`expected 200`, `received 250`) and passed afterward.
- `pnpm exec turbo run test --filter=@bb/app -- --run src/components/ui/bottom-anchored-scroll-body.scroll-preservation.test.tsx src/components/thread/timeline/useAutoLoadOlderRows.test.tsx src/components/thread/timeline/ThreadTimelineRows.height.test.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run test --filter=@bb/app --force` — 431 files and 3,358 tests passed; 3 skipped.
- `pnpm exec turbo run lint --filter=@bb/app` — 0 errors.
- Reproduced against the affected real thread with dev-browser and a controlled 1.2-second older-page delay: the tracked message moved 252px before the fix and 1px after it.

Fixes the timeline scroll-position jump while older messages load.

> AGENT GENERATED
