### PR TITLE
fix(side-chat): bind reply anchor to accepted turn

### DIFF
--- a/apps/server/src/services/threads/deferred-first-turn-context.ts
+++ b/apps/server/src/services/threads/deferred-first-turn-context.ts
@@ -1,4 +1,8 @@
-import { findStoredEventRow, getLastStoredTurnRequestEvent } from "@bb/db";
+import {
+  findStoredEventRow,
+  getLastStoredTurnRequestEvent,
+  getThread,
+} from "@bb/db";
 import type { DbQueryConnection } from "@bb/db";
 import type { PromptInput } from "@bb/domain";
 import { ApiError } from "../../errors.js";
@@ -19,6 +23,16 @@ interface GroupedPrompt {
   inputGroups: PromptInput[][];
 }
 
+export function getLeadingAgentOnlyInput(input: PromptInput[]): PromptInput[] {
+  const visibleInputIndex = input.findIndex(
+    (item) => item.visibility !== "agent-only",
+  );
+  return input.slice(
+    0,
+    visibleInputIndex === -1 ? input.length : visibleInputIndex,
+  );
+}
+
 export function resolveDeferredFirstTurnContext(
   db: DbQueryConnection,
   threadId: string,
@@ -37,14 +51,9 @@ export function resolveDeferredFirstTurnContext(
   const isUndeliveredRetry =
     request.source === "tell" &&
     request.request.method === "turn/start" &&
-    request.target.kind === "new-turn";
-  const visibleInputIndex = request.input.findIndex(
-    (item) => item.visibility !== "agent-only",
-  );
-  const leadingInput =
-    visibleInputIndex === -1
-      ? request.input
-      : request.input.slice(0, visibleInputIndex);
+    request.target.kind === "new-turn" &&
+    getThread(db, threadId)?.status === "error";
+  const leadingInput = getLeadingAgentOnlyInput(request.input);
   const context = leadingInput.length > 0 ? [...leadingInput] : null;
   if (
     context === null ||

--- a/apps/server/src/services/threads/thread-edit-message.ts
+++ b/apps/server/src/services/threads/thread-edit-message.ts
@@ -12,7 +12,12 @@ import {
   listActiveBackgroundTaskCountsByThreadIds,
   type DbQueryConnection,
 } from "@bb/db";
-import { threadScope, type Thread, type ThreadEvent } from "@bb/domain";
+import {
+  threadScope,
+  type PromptInput,
+  type Thread,
+  type ThreadEvent,
+} from "@bb/domain";
 import type {
   EditMessageRequest,
   EditMessageResponse,
@@ -45,6 +50,7 @@ import {
   sendThreadMessage,
 } from "./thread-send.js";
 import { requestThreadStopForCurrentState } from "./thread-lifecycle.js";
+import { getLeadingAgentOnlyInput } from "./deferred-first-turn-context.js";
 
 type ThreadRewindPrepareCommand = Extract<
   HostDaemonCommand,
@@ -52,6 +58,7 @@ type ThreadRewindPrepareCommand = Extract<
 >;
 
 interface EditableTurn {
+  leadingAgentOnlyInput: PromptInput[];
   currentTurnId: string;
   oldMaxSequence: number;
   precedingProviderCheckpoint: string | null;
@@ -297,6 +304,7 @@ function resolveEditableTurnCandidate(
     conflict("This earlier provider turn has no editable history checkpoint");
   }
   return {
+    leadingAgentOnlyInput: getLeadingAgentOnlyInput(request.input),
     currentTurnId: accepted.turnId,
     oldMaxSequence: getHighWaterMarks(db, [thread.id])[thread.id] ?? 0,
     precedingProviderCheckpoint,
@@ -599,7 +607,11 @@ export async function editThreadMessage(
           ? { onCommandSettled: discardStagedRewind }
           : {}),
       },
-      payload: { ...sendPayload, mode: "start" },
+      payload: {
+        ...sendPayload,
+        input: [...target.leadingAgentOnlyInput, ...sendPayload.input],
+        mode: "start",
+      },
       thread: editableThread,
       trigger: "user",
     });

--- a/apps/server/test/public/public-thread-fork.test.ts
+++ b/apps/server/test/public/public-thread-fork.test.ts
@@ -427,7 +427,7 @@ describe("public thread fork route", () => {
     });
   });
 
-  it("stops deferring the seed after a provider turn starts", async () => {
+  it("does not defer the seed to later accepted sends", async () => {
     await withTestHarness(async (harness) => {
       const seed = {
         type: "text" as const,
@@ -462,6 +462,27 @@ describe("public thread fork route", () => {
       if (firstTurn.command.type !== "turn.submit") {
         throw new Error("Expected turn.submit");
       }
+      const rapidInput = textInput("Rapid follow-up");
+      const rapidResponse = await harness.app.request(
+        `/api/v1/threads/${fork.id}/send`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            input: rapidInput,
+            mode: "auto",
+            permissionMode: "full",
+          }),
+        },
+      );
+      expect(rapidResponse.status).toBe(200);
+      const rapidTurn = await waitForQueuedCommandAfter(
+        harness,
+        firstTurn.row.cursor,
+        ({ command }) =>
+          command.type === "turn.submit" && command.threadId === fork.id,
+      );
+      expect(rapidTurn.command).toMatchObject({ input: rapidInput });
       const lastSequence =
         listEvents(harness.db, { threadId: fork.id }).at(-1)?.sequence ?? 0;
       seedTurnStarted(harness.deps, {
@@ -492,7 +513,7 @@ describe("public thread fork route", () => {
       expect(secondResponse.status).toBe(200);
       const secondTurn = await waitForQueuedCommandAfter(
         harness,
-        firstTurn.row.cursor,
+        rapidTurn.row.cursor,
         ({ command }) =>
           command.type === "turn.submit" && command.threadId === fork.id,
       );

--- a/apps/server/test/threads/thread-edit-message.test.ts
+++ b/apps/server/test/threads/thread-edit-message.test.ts
@@ -88,6 +88,7 @@ function seedTurn(
     completionStatus?: ThreadEventTurnStatus | null;
     inputGroups?: PromptInput[][];
     initiator?: "agent" | "user";
+    leadingAgentOnlyInput?: PromptInput[];
     requestSequence: number;
     senderThreadId?: string;
     text: string;
@@ -111,7 +112,10 @@ function seedTurn(
         index === 0
           ? group
           : [{ type: "text" as const, text: "\n\n", mentions: [] }, ...group],
-      ) ?? [{ type: "text", text: args.text, mentions: [] }],
+      ) ?? [
+        ...(args.leadingAgentOnlyInput ?? []),
+        { type: "text", text: args.text, mentions: [] },
+      ],
       ...(args.inputGroups !== undefined
         ? { inputGroups: args.inputGroups }
         : {}),
@@ -193,6 +197,7 @@ function seedEditableThread(
     firstProviderCheckpoint?: string | null;
     firstProviderThreadId?: string;
     firstTurnId?: string;
+    firstTurnLeadingAgentOnlyInput?: PromptInput[];
     includeIdentity?: boolean;
     includeSecondTurn?: boolean;
     providerId?: string;
@@ -240,6 +245,9 @@ function seedEditableThread(
     text: "First message",
     threadId: thread.id,
     turnId: args.firstTurnId ?? "turn-first",
+    ...(args.firstTurnLeadingAgentOnlyInput === undefined
+      ? {}
+      : { leadingAgentOnlyInput: args.firstTurnLeadingAgentOnlyInput }),
     ...(args.firstCompletionStatus !== undefined
       ? { completionStatus: args.firstCompletionStatus }
       : {}),
@@ -446,7 +454,14 @@ describe("editThreadMessage", () => {
     "starts a fresh %s session when editing the first turn",
     async (providerId) => {
       await withTestHarness(async (harness) => {
+        const anchor = {
+          type: "text" as const,
+          text: "Reply anchor",
+          mentions: [],
+          visibility: "agent-only" as const,
+        };
         const { environment, thread } = seedEditableThread(harness, {
+          firstTurnLeadingAgentOnlyInput: [anchor],
           includeIdentity: false,
           includeSecondTurn: false,
           providerId,
@@ -478,12 +493,15 @@ describe("editThreadMessage", () => {
         expect(
           listQueuedThreadCommands(harness, "thread.rewind.prepare", thread.id),
         ).toHaveLength(0);
-        await waitForQueuedCommand(
+        const replacement = await waitForQueuedCommand(
           harness,
           (queued) =>
             queued.command.type === "thread.start" &&
             queued.command.threadId === thread.id,
         );
+        expect(replacement.command).toMatchObject({
+          input: [anchor, { text: "Replacement first message" }],
+        });
         expect(
           listQueuedThreadCommands(harness, "thread.start", thread.id),
         ).toEqual([expect.not.objectContaining({ fork: expect.anything() })]);

--- a/packages/host-daemon-contract/src/protocol.ts
+++ b/packages/host-daemon-contract/src/protocol.ts
@@ -326,9 +326,14 @@
 // options are opaque but their bytes and meaning changed and mixed-version
 // compatibility was not deliberately preserved and tested.
 //
+// Version 170 binds deferred agent-only context to its accepted server turn.
+// Rapid later turn.submit input omits that context, while a thread.start that
+// replaces the owning turn retains it. The wire shape is unchanged, but the
+// server-to-daemon payload semantics differ.
+//
 // The version mismatch is what triggers the enrolled daemon's automatic update
 // instead of an `invalid-message` reconnect loop.
-export const HOST_DAEMON_PROTOCOL_VERSION = 169 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 170 as const;
 
 /**
  * Absolute ceiling for any executable artifact delivered to a host daemon —

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -1046,7 +1046,7 @@ describe("host-daemon command schemas", () => {
   // mixed version. Version 113 carried the Devin Desktop open target rename
   // and remains part of the protocol lineage.
   it("uses the current host-daemon protocol version", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(169);
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(170);
     expect(HOST_ARTIFACT_MAX_BYTES).toBe(256 * 1024 * 1024);
   });
 


### PR DESCRIPTION
## Human comments

<!-- Agents: Do not fill in this section. This is for human users to fill in. -->

## What was wrong

Side-chat hidden reply context was inferred from the latest accepted request and the absence of a later `turn/started`, instead of being owned by the specific first accepted user turn. A rapid second send accepted before provider start could therefore receive the anchor again, while editing the completed owning turn rebuilt provider input without the anchor.

## What changed

- Treat the accepted anchor-bearing request as the owner while its thread is active, and allow retry only after the existing thread lifecycle reports an observable dispatch error.
- Preserve the selected request's leading agent-only input when editing that exact turn, using the existing request-sequence and transaction checks.
- Keep the fix at the shared server input boundary so direct, queued/grouped, Codex, Claude Code, Pi, built-in ACP, and custom ACP paths retain the same ownership behavior.
- Bump `HOST_DAEMON_PROTOCOL_VERSION` from 169 to 170 because the meaning of server-to-daemon turn input changed even though its wire shape did not.

## How you verified

- Reproduced both route failures before production edits with real server routes and in-memory SQLite: 2/2 failed.
- Added tracked regressions for the rapid second send and first-turn edit replacement across Codex, Claude Code, and Pi; confirmed they failed before the fix and passed after it.
- Re-ran the real-route harness after the fix: 2/2 passed.
- `pnpm exec turbo run test --filter=@bb/server -- test/public/public-thread-fork.test.ts test/services/prompt-history.test.ts test/threads/thread-edit-message.test.ts`: 71/71 passed.
- `pnpm exec turbo run test --filter=bb-plugin-side-chat`: 25/25 passed.
- `pnpm exec turbo run test --filter=@bb/host-daemon-contract -- test/contract.test.ts`: 37/37 passed.
- `pnpm exec turbo run typecheck --filter=@bb/server --filter=bb-plugin-side-chat --filter=@bb/host-daemon-contract`: passed.
- `pnpm exec turbo run build --filter=@bb/server`: passed.
- `git diff --check` and `git show --check`: passed.

Fixes #2316

> AGENT GENERATED
