### PR TITLE
Stabilize automations picker test under CI contention

### DIFF
--- a/plugins/automations/src/automation-provider-model-picker.test.tsx
+++ b/plugins/automations/src/automation-provider-model-picker.test.tsx
@@ -120,18 +120,16 @@ describe("automation provider and model picker", () => {
       />,
     );
 
-    const picker = screen.getByRole("button", { name: "Choose Claude" });
+    const picker = screen.getByText("Choose Claude");
     expect(picker.getAttribute("data-routing-kind")).toBe("environment");
     expect(picker.getAttribute("data-routing-id")).toBe("env_test");
     expect(picker.getAttribute("data-provider-change-allowed")).toBe("true");
     fireEvent.click(picker);
-    const permission = screen.getByRole("button", {
-      name: "Permission mode",
-    });
+    const permission = screen.getByLabelText("Permission mode");
     expect(permission.getAttribute("data-provider-id")).toBe("claude");
     expect(permission.getAttribute("data-routing-kind")).toBe("environment");
     fireEvent.click(permission);
-    fireEvent.click(screen.getByRole("button", { name: "Save Prompt" }));
+    fireEvent.click(screen.getByText("Save Prompt"));
 
     expect(onUpdate).toHaveBeenCalledWith({
       prompt: "Summarize the inbox",


### PR DESCRIPTION
## Human comments

## What was wrong

The Automations picker integration test rendered the full detail page and then called `getByRole` three times for controls supplied by its own lightweight SDK mocks. Each call recomputed accessible roles, names, and visibility across the entire jsdom tree. Under the packages job's systemic CPU oversubscription—73 package test tasks on a 4-vCPU runner with no shard-level Turbo concurrency cap, plus Vitest file parallelism—those avoidable accessibility transforms consumed 4.033 seconds of a measured 5.081-second body and crossed Vitest's existing 5-second hang ceiling. Scheduler contention amplified the cost; it was not the root cause. Production behavior was correct.

## What changed

The test now locates the mocked provider control and real save control by their exact text, and the permission control by its exact accessible label. It still renders `AutomationDetailView`, clicks the same controls, verifies the same environment routing and provider reconciliation, and asserts the same persisted provider/model/reasoning/service-tier/permission tuple. No timeout, polling, retry budget, assertion, production behavior, wire contract, CLI surface, or documentation changed.

## How you verified

- Pre-fix controlled reproduction: with 640 CPU workers on a 16-core host and the test process at niceness 20, the exact test failed with the CI signature at line 96 after 6.417 seconds. At 512 workers, temporary operation timings measured 1.034 seconds rendering and 4.033 seconds across the three role queries; state-changing clicks took 14 milliseconds, and the body reached its assertion at 5.081 seconds before Vitest reported the 5-second timeout.
- Post-fix controlled reproduction: the cleaned test passed the identical 640-worker stress command in 2.62 seconds. No clock changed.
- `pnpm exec turbo run test --filter=bb-plugin-automations --force -- --run src/automation-provider-model-picker.test.tsx` (1 passed; focused test 53ms)
- `pnpm exec turbo run test --filter=bb-plugin-automations --force` (5 files, 66 tests passed)
- `pnpm exec turbo run test --filter=@bb/app --force -- --run src/components/tools/detail-page-recipes.test.tsx -t 'Automation detail recipe'` (11 passed, 21 intentionally filtered)
- `pnpm exec turbo run typecheck --filter=bb-plugin-automations --filter=@bb/app --force` (5 Turbo tasks passed)
- `pnpm exec turbo run build --filter=bb-app --force` (11 Turbo tasks passed, including App, plugin SDK, server, host daemon, CLI, and packaged app)
- `pnpm exec oxfmt plugins/automations/src/automation-provider-model-picker.test.tsx --check`
- `pnpm exec oxlint plugins/automations/src/automation-provider-model-picker.test.tsx`
- `git diff --check`

> AGENT GENERATED: by GPT-5.6-Sol
