### PR TITLE
Remove the 8,000-character automation prompt cap

### DIFF
--- a/plugins/automations/detail-view.tsx
+++ b/plugins/automations/detail-view.tsx
@@ -8,7 +8,6 @@ import type {
   AutomationRunStatus,
   AgentExecutionUpdate,
 } from "./src/rpc-types";
-import { AUTOMATION_PROMPT_MAX_LENGTH } from "./src/limits";
 import {
   experimental_PermissionModePicker as PermissionModePicker,
   experimental_ProviderModelPicker as ProviderModelPicker,
@@ -628,7 +627,6 @@ function AgentAutomationDefinition({
       <Textarea
         value={prompt}
         onChange={(event) => setPrompt(event.target.value)}
-        maxLength={AUTOMATION_PROMPT_MAX_LENGTH}
         aria-label="Automation prompt"
         disabled={pending}
         className="min-h-28 resize-none border-0 bg-transparent px-4 pb-1 pr-14 pt-3 text-sm leading-relaxed shadow-none focus-visible:ring-0"

--- a/plugins/automations/src/frontend-imports.test.ts
+++ b/plugins/automations/src/frontend-imports.test.ts
@@ -212,7 +212,6 @@ describe("automations frontend bundle", () => {
         "detail-view.tsx",
         "overview-view.tsx",
         "lib/format-schedule.ts",
-        "src/limits.ts",
         "../../packages/domain/src/update-state.ts",
         "../../packages/shared-ui/src/components/ui/button.tsx",
       ]),

--- a/plugins/automations/src/limits.ts
+++ b/plugins/automations/src/limits.ts
@@ -1,15 +1,15 @@
 /**
- * Size and count limits shared by the RPC schemas and the plugin frontend.
+ * Size and count limits used by the RPC schemas.
  *
- * Kept free of imports on purpose: the frontend only needs these numbers,
- * and importing them from `rpc-types.ts` would drag zod and every schema
+ * Kept free of imports on purpose: when the frontend needs one of these
+ * numbers it must import it from here, because importing it from
+ * `rpc-types.ts` would drag zod and every schema
  * into `dist/app.js`, which the app dynamic-imports and evaluates on every
  * boot (the bundle URL is content-hashed and served immutable, so the
  * recurring cost is parse/evaluate, not download). `frontend-imports.test.ts`
  * guards the split.
  */
 export const AUTOMATION_NAME_MAX_LENGTH = 200;
-export const AUTOMATION_PROMPT_MAX_LENGTH = 8_000;
 export const AUTOMATION_SCRIPT_MAX_LENGTH = 262_144;
 export const AUTOMATION_SCRIPT_FILE_MAX_LENGTH = 200;
 export const SCHEDULE_CRON_MAX_LENGTH = 100;

--- a/plugins/automations/src/rpc-types.ts
+++ b/plugins/automations/src/rpc-types.ts
@@ -2,7 +2,6 @@ import { z } from "zod";
 import {
   AUTOMATION_IDEMPOTENCY_KEY_MAX_LENGTH,
   AUTOMATION_NAME_MAX_LENGTH,
-  AUTOMATION_PROMPT_MAX_LENGTH,
   AUTOMATION_RUNS_LIMIT_DEFAULT,
   AUTOMATION_RUNS_LIMIT_MAX,
   AUTOMATION_SCRIPT_FILE_MAX_LENGTH,
@@ -17,7 +16,6 @@ import {
 // number without bundling zod; these re-exports keep the backend's existing
 // imports and the package's `./rpc-types` export map entry unchanged.
 export {
-  AUTOMATION_PROMPT_MAX_LENGTH,
   AUTOMATION_RUNS_LIMIT_MAX,
   AUTOMATION_SCRIPT_TIMEOUT_DEFAULT_MS,
   AUTOMATION_SCRIPT_TIMEOUT_MAX_MS,
@@ -146,7 +144,7 @@ export type AutomationTrigger = z.infer<typeof automationTriggerSchema>;
 const automationAgentExecutionSchema = z
   .object({
     mode: z.literal("agent"),
-    prompt: z.string().min(1).max(AUTOMATION_PROMPT_MAX_LENGTH),
+    prompt: z.string().min(1),
     providerId: z.string().min(1),
     model: z.string().min(1),
     reasoningLevel: reasoningLevelSchema.default("medium"),
@@ -233,7 +231,7 @@ const agentExecutionTargetSchema = z.discriminatedUnion("type", [
 
 const agentExecutionUpdateSchema = z
   .object({
-    prompt: z.string().min(1).max(AUTOMATION_PROMPT_MAX_LENGTH).optional(),
+    prompt: z.string().min(1).optional(),
     providerId: z.string().min(1).optional(),
     model: z.string().min(1).optional(),
     reasoningLevel: reasoningLevelSchema.optional(),

--- a/plugins/automations/src/server-harness.test.ts
+++ b/plugins/automations/src/server-harness.test.ts
@@ -592,6 +592,59 @@ describe("automations server plugin harness", () => {
     await harness.dispose();
   });
 
+  it("accepts a long prompt and keeps the automation readable afterwards", async () => {
+    // Regression for #2166: an 8,000-character cap once rejected the update
+    // after the row was written, and the same cap on the response schema
+    // then failed every list/get/update of that project.
+    const { harness } = await bootAutomationsPlugin();
+    const created = await createAgentAutomation(harness);
+    const longPrompt = "review every open pull request carefully. ".repeat(250);
+    expect(longPrompt.length).toBeGreaterThan(8_000);
+
+    const update = await harness.runCli([
+      "update",
+      created.id,
+      "--project",
+      PROJECT_ID,
+      "--prompt",
+      longPrompt,
+      "--json",
+    ]);
+    expect(update.exitCode).toBe(0);
+    expect(
+      automationResponseSchema.parse(JSON.parse(update.stdout ?? "")).execution,
+    ).toMatchObject({ mode: "agent", prompt: longPrompt });
+
+    const listed = automationListResponseSchema.parse(
+      await harness.callRpc("automations_list", { projectId: PROJECT_ID }),
+    );
+    expect(listed).toHaveLength(1);
+    expect(listed[0]?.execution).toMatchObject({ prompt: longPrompt });
+
+    const shown = await harness.runCli([
+      "show",
+      created.id,
+      "--project",
+      PROJECT_ID,
+      "--json",
+    ]);
+    expect(shown.exitCode).toBe(0);
+    expect(
+      automationResponseSchema.parse(JSON.parse(shown.stdout ?? "")).execution,
+    ).toMatchObject({ prompt: longPrompt });
+
+    const repaired = automationResponseSchema.parse(
+      await harness.callRpc("automations_update", {
+        projectId: PROJECT_ID,
+        automationId: created.id,
+        agent: { prompt: "short again" },
+      }),
+    );
+    expect(repaired.execution).toMatchObject({ prompt: "short again" });
+
+    await harness.dispose();
+  });
+
   it("rejects conflicting targets and invalid permission modes before updating", async () => {
     const { harness } = await bootAutomationsPlugin();
     const created = await createAgentAutomation(harness);


### PR DESCRIPTION
## Human comments

## What was wrong

`AUTOMATION_PROMPT_MAX_LENGTH = 8_000` came with the original plugin rewrite (#516) with no stated reason. It sat on the agent execution schema, which also decodes every stored row on list, show, update, and the scheduler sweep. The `bb automation update` CLI path commits the row before that schema runs, so a prompt over the cap was written and then made the row unreadable. `list` failed for the whole project, and the `update` that would repair it read the row first and failed the same way. Issue: #2166. Report: https://get-bb.github.io/reports/issues/2166.html

## What changed

- `plugins/automations/src/limits.ts`: removed the constant.
- `plugins/automations/src/rpc-types.ts`: `prompt` is now `z.string().min(1)` in the execution schema and the partial-update schema. Removed the import and re-export.
- `plugins/automations/detail-view.tsx`: removed the `maxLength` on the prompt textarea.
- `plugins/automations/src/frontend-imports.test.ts`: the frontend no longer reaches `src/limits.ts`, so the guard's coverage list no longer expects it. The zod guard is unchanged.

Deviation from the issue's proposed fixes: instead of adding request-side validation at the CLI boundary, this removes the cap end to end. Thread messages have no prompt cap, and a cap on the stored-row schema makes a row unrepairable. A row that an older build already corrupted becomes readable as soon as this version loads.

No wire change. No CLI, guide, or doc surface described the cap.

## How you verified

- New test in `plugins/automations/src/server-harness.test.ts`: a CLI update with a 10,500-character prompt succeeds, and `list`, `show`, and a later RPC update still read the row. It fails on the previous source with the `too_big` rejection and passes after the change.
- `pnpm exec turbo run test typecheck build lint --filter=bb-plugin-automations --force`: 67/67 tests pass, all tasks green.
- `rg AUTOMATION_PROMPT_MAX_LENGTH` finds no reference in `plugins/`, `apps/`, `packages/`, or `docs/`.

Fixes #2166

> AGENT GENERATED
