### PR TITLE
Fix persisted Cursor model IDs for parameterized ACP

### DIFF
--- a/packages/domain/src/plugin-sdk-version.ts
+++ b/packages/domain/src/plugin-sdk-version.ts
@@ -16,7 +16,7 @@
 // PLUGIN_SDK_MAJOR is 0, so the major-only artifact gate cannot distinguish
 // 0.x releases and is intentionally vacuous for them until a future 1.0.
 // Rebuildable artifacts still rebuild on the exact sdkVersion-differs trigger.
-export const PLUGIN_SDK_VERSION = "0.4.18";
+export const PLUGIN_SDK_VERSION = "0.4.19";
 
 /** Major of {@link PLUGIN_SDK_VERSION} — the plugin API compatibility number. */
 export const PLUGIN_SDK_MAJOR = Number(PLUGIN_SDK_VERSION.split(".", 1)[0]);

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@get-bb/plugin-sdk",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "homepage": "https://github.com/get-bb/bb#readme",
   "bugs": {
     "url": "https://github.com/get-bb/bb/issues"

--- a/packages/provider-bridge-acp/src/bridge/bridge.test.ts
+++ b/packages/provider-bridge-acp/src/bridge/bridge.test.ts
@@ -820,6 +820,63 @@ describe("acp bridge", () => {
     },
   );
 
+  it.each([
+    // Project-default reuse reaches the bridge as an ordinary thread/start.
+    ["thread/start", "cursor-grok-4.6-medium", "grok-4.6"],
+    ["thread/resume", "cursor-grok-4.5-medium", "grok-4.5"],
+    ["thread/fork", "auto", "default"],
+  ] as const)(
+    "translates a legacy Cursor model for %s session construction",
+    async (method, legacyModel, selectedModel) => {
+      const threadId = `legacy-cursor-${method.slice("thread/".length)}`;
+      const requestLog = join(workspaceDir, `${threadId}.jsonl`);
+      const id = sendRequest(method, {
+        threadId,
+        cwd: workspaceDir,
+        instructionMode: "append",
+        options: executionOptions({
+          model: legacyModel,
+          reasoningLevel: "high",
+          serviceTier: "fast",
+          providerOptions: {
+            acpDialect: "cursor",
+            parameterizedModelPicker: true,
+            acpLaunchSpec: acpLaunchSpec({
+              envVars: {
+                FAKE_ACP_CURSOR_PARAMETERIZED_MODELS: "1",
+                FAKE_ACP_REQUEST_LOG: requestLog,
+                ...(method === "thread/resume"
+                  ? { FAKE_ACP_LOAD_SESSION: "1" }
+                  : {}),
+                ...(method === "thread/fork"
+                  ? { FAKE_ACP_FORK_SESSION: "1" }
+                  : {}),
+              },
+            }),
+          },
+        }),
+        ...(method === "thread/resume"
+          ? { providerThreadId: "legacy-resume-session" }
+          : {}),
+        ...(method === "thread/fork"
+          ? { sourceProviderThreadId: "legacy-source-session" }
+          : {}),
+      });
+      const response = await waitForResponse(id);
+      expect(response.error).toBeUndefined();
+      expect(
+        loggedAcpRequests(requestLog)
+          .filter((request) => request.method === "session/set_config_option")
+          .map((request) => request.params?.["value"]),
+      ).toEqual(
+        selectedModel === "default" ? [] : [selectedModel, "high", "true"],
+      );
+      const providerThreadId = providerThreadIdOf(response);
+      startedProviderThreadIds.push(providerThreadId);
+      bbThreadIdByProviderThreadId.set(providerThreadId, threadId);
+    },
+  );
+
   it("fails session construction when an advertised Fast selection is rejected", async () => {
     await expect(
       startThread({

--- a/packages/provider-bridge-acp/src/bridge/model-catalog.ts
+++ b/packages/provider-bridge-acp/src/bridge/model-catalog.ts
@@ -366,6 +366,10 @@ function splitVariant(id: string): {
   };
 }
 
+export function agentModelFamilyId(id: string): string {
+  return splitVariant(id).familyKey;
+}
+
 // How the agent's display names spell each effort token, for stripping the
 // default variant's effort word out of the family display name.
 const EFFORT_DISPLAY_WORDS: Readonly<Record<string, string>> = {

--- a/packages/provider-bridge-acp/src/session-params.test.ts
+++ b/packages/provider-bridge-acp/src/session-params.test.ts
@@ -262,6 +262,7 @@ describe("buildAcpSessionParams parameterized model selection", () => {
     return buildAcpSessionParams({
       additionalWorkspaceWriteRoots: [],
       cwd: "/workspace",
+      dialectId: "cursor",
       options: { ...BASE_OPTIONS, ...options },
       parameterizedModelPicker: true,
       launchSpec: launchSpecFor(cursorSpec),
@@ -288,6 +289,12 @@ describe("buildAcpSessionParams parameterized model selection", () => {
       .modelSelection as Record<string, unknown>;
     expect(selection).toMatchObject({ modelId: "grok-4.6" });
     expect("reasoningLevel" in selection).toBe(false);
+  });
+
+  it("keeps Cursor's new default id unchanged", () => {
+    expect(cursorSessionParams({ model: "default" }).modelSelection).toEqual({
+      modelId: "default",
+    });
   });
 
   it.each(["default", "fast"] as const)(

--- a/packages/provider-bridge-acp/src/session-params.ts
+++ b/packages/provider-bridge-acp/src/session-params.ts
@@ -18,6 +18,7 @@ import {
   type AcpBridgePermissionCli,
   type AcpBridgeReasoningCli,
 } from "./bridge-protocol.js";
+import { agentModelFamilyId } from "./bridge/model-catalog.js";
 import type { AcpLaunchSpec } from "./launch-spec.js";
 
 /**
@@ -266,11 +267,19 @@ export function buildAcpModelListParams(
   };
 }
 
+function cursorParameterizedModelId(model: string): string {
+  const familyId = model === "auto" ? "default" : agentModelFamilyId(model);
+  return familyId.startsWith("cursor-")
+    ? familyId.slice("cursor-".length)
+    : familyId;
+}
+
 /** The synthetic "acp-default" id is never forwarded. */
 function buildAcpModelSelectionParam(
   launchSpec: AcpLaunchSpec,
   options: AcpSessionExecutionOptions,
   parameterizedModelPicker: boolean,
+  dialectId: string | undefined,
 ): { modelSelection?: AcpModelSelection } {
   const model = options.model;
   const listCommand = buildAcpModelListCommand(launchSpec);
@@ -284,7 +293,10 @@ function buildAcpModelSelectionParam(
   ) {
     return {
       modelSelection: {
-        modelId: model,
+        modelId:
+          parameterizedModelPicker && dialectId === "cursor"
+            ? cursorParameterizedModelId(model)
+            : model,
         ...(options.reasoningLevel !== undefined
           ? { reasoningLevel: options.reasoningLevel }
           : {}),
@@ -352,6 +364,7 @@ export function buildAcpSessionParams(
       launchSpec,
       options,
       args.parameterizedModelPicker,
+      args.dialectId,
     ),
     parameterizedModelPicker: args.parameterizedModelPicker,
     ...(launchSpec.reasoningCli !== undefined


### PR DESCRIPTION
## Human comments

## What was wrong

Cursor's parameterized ACP picker accepts bare model IDs, but the shared session builder forwarded previously persisted Cursor CLI-family IDs unchanged. Existing threads and project defaults could therefore send values such as `cursor-grok-4.6-medium` or `auto`, which Cursor rejects before the first prompt.

## What changed

Normalize persisted model IDs only for Cursor's parameterized picker at the shared ACP session-construction boundary. The implementation reuses the existing CLI variant parser, maps `auto` to `default`, removes historical variant syntax and the `cursor-` prefix, and leaves current bare IDs unchanged. Start, resume, fork, selected-only models, project-default starts, reasoning, and service tier share the covered path. `HOST_DAEMON_PROTOCOL_VERSION` remains 170 because no server-to-daemon wire contract changed; no CLI, SDK, documentation, migration, or generated-file update is required.

## How you verified

The new start, resume, and fork cases failed before the fix with `model not found` for `cursor-grok-4.6-medium`, `cursor-grok-4.5-medium`, and `auto` (3 failed, 284 passed), then passed after the fix.

- `pnpm exec turbo run test --filter=@bb/provider-bridge-acp --force` — 17 files, 288 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/provider-bridge-acp --filter=@get-bb/plugin-sdk --filter=bb-plugin-provider-acp --force` — 6 tasks passed.
- `pnpm exec turbo run build --filter=@get-bb/plugin-sdk --force` — 2 tasks passed; 17 runtime entries built.
- Focused `oxfmt --check`, `git diff --check`, and the original bridge reproduction passed.

Fixes #1688

> AGENT GENERATED
