### PR TITLE
Disable the Monaco editor by default and rename it to File Editor

### DIFF
--- a/apps/server/src/services/plugins/builtin-registry.ts
+++ b/apps/server/src/services/plugins/builtin-registry.ts
@@ -81,7 +81,7 @@ export const BUILTIN_PLUGINS = [
   {
     name: "monaco-editor",
     pluginId: "monaco-editor",
-    defaultEnabled: true,
+    defaultEnabled: false,
     category: "Interface",
   },
   {

--- a/apps/server/test/services/plugins/builtin-plugins.test.ts
+++ b/apps/server/test/services/plugins/builtin-plugins.test.ts
@@ -463,6 +463,14 @@ describe("builtin plugin reconciliation", () => {
     expect(pluginApiTester?.defaultEnabled).toBe(false);
   });
 
+  it("ships the File Editor (monaco-editor) disabled on a fresh database", () => {
+    const monacoEditor = BUILTIN_PLUGINS.find(
+      (builtin) => builtin.name === "monaco-editor",
+    );
+
+    expect(monacoEditor?.defaultEnabled).toBe(false);
+  });
+
   it("ships Workflows disabled on a fresh database", async () => {
     const workflows = BUILTIN_PLUGINS.find(
       (builtin) => builtin.name === "workflows",

--- a/packages/bb-app/scripts/smoke-tarball.mjs
+++ b/packages/bb-app/scripts/smoke-tarball.mjs
@@ -33,7 +33,6 @@ const EXPECTED_RUNNING_BUILTIN_PLUGINS = [
   "custom-instructions",
   "inline-vis",
   "keep-awake",
-  "monaco-editor",
   "pdf-preview",
   "provider-retry",
   "secrets",

--- a/plugins/monaco-editor/app.tsx
+++ b/plugins/monaco-editor/app.tsx
@@ -547,7 +547,7 @@ function NoticeAction({
 export default definePluginApp((app) => {
   app.slots.fileOpener({
     id: "monaco",
-    title: "Monaco",
+    title: "File Editor",
     extensions: CLAIMED_EXTENSIONS,
     component: MonacoFileOpener,
   });

--- a/plugins/monaco-editor/package.json
+++ b/plugins/monaco-editor/package.json
@@ -27,7 +27,7 @@
     "bbPluginSdk": ">=0.4.9"
   },
   "bb": {
-    "name": "Monaco editor",
+    "name": "File Editor",
     "description": "Edit files in BB with the Monaco editor instead of the read-only preview.",
     "branding": {
       "icon": "Code"


### PR DESCRIPTION
## Human comments

## What was wrong

#2127 shipped the Monaco builtin with `defaultEnabled: true`. On a fresh install it replaces the read-only file preview for ~86 text extensions without the user opting in. Its user-facing name also described the engine (Monaco) rather than what it does in BB.

## What changed

- `apps/server/src/services/plugins/builtin-registry.ts`: `monaco-editor` now has `defaultEnabled: false`. A fresh database registers it disabled. Existing registrations keep their stored `enabled` state because reconciliation uses `existing?.enabled ?? bundled.defaultEnabled`, so this does not turn it off for users who already have it.
- `plugins/monaco-editor/package.json`: manifest `bb.name` is now `File Editor` (Settings > Plugins, plugin store).
- `plugins/monaco-editor/app.tsx`: the `fileOpener` `title` is now `File Editor` (Settings > File openers).
- The plugin id `monaco-editor`, the directory, the package name, and the opener id `monaco` do not change, so existing registration rows and per-extension opt-outs still match.
- `packages/bb-app/scripts/smoke-tarball.mjs`: `monaco-editor` leaves `EXPECTED_RUNNING_BUILTIN_PLUGINS`. That list is the default-enabled set the package smoke waits on, and a disabled plugin never reaches `running`.

No wire changes. No CLI or doc surfaces name the plugin.

## How you verified

- Added `ships the File Editor (monaco-editor) disabled on a fresh database` to `apps/server/test/services/plugins/builtin-plugins.test.ts`. It fails on `main` (`defaultEnabled` is `true`) and passes here.
- `pnpm exec turbo run test --filter=@bb/server -- test/services/plugins/builtin-plugins.test.ts test/services/plugins/official-plugins.test.ts`: 34/34 pass.
- `pnpm exec turbo run test typecheck --filter=bb-plugin-monaco-editor`: typecheck clean, 11/11 pass.
- EAP codename scan of the working tree, `HEAD`, and `origin/main..HEAD`: clean.

> AGENT GENERATED
