### PR TITLE
Wait for exact replay completion before closing bridges

### DIFF
--- a/packages/domain/src/plugin-sdk-version.ts
+++ b/packages/domain/src/plugin-sdk-version.ts
@@ -16,7 +16,7 @@
 // PLUGIN_SDK_MAJOR is 0, so the major-only artifact gate cannot distinguish
 // 0.x releases and is intentionally vacuous for them until a future 1.0.
 // Rebuildable artifacts still rebuild on the exact sdkVersion-differs trigger.
-export const PLUGIN_SDK_VERSION = "0.4.20";
+export const PLUGIN_SDK_VERSION = "0.4.21";
 
 /** Major of {@link PLUGIN_SDK_VERSION} — the plugin API compatibility number. */
 export const PLUGIN_SDK_MAJOR = Number(PLUGIN_SDK_VERSION.split(".", 1)[0]);

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@get-bb/plugin-sdk",
-  "version": "0.4.20",
+  "version": "0.4.21",
   "homepage": "https://github.com/get-bb/bb#readme",
   "bugs": {
     "url": "https://github.com/get-bb/bb/issues"

--- a/packages/provider-bridge-protocol/src/testing/parity.test.ts
+++ b/packages/provider-bridge-protocol/src/testing/parity.test.ts
@@ -1,0 +1,148 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, it } from "vitest";
+import { threadEventSchema, type ThreadEvent } from "@bb/domain";
+import { replayRecording } from "./parity.js";
+
+function writeLane(
+  dir: string,
+  direction: "runtime→bridge" | "bridge→runtime",
+  entries: ReadonlyArray<{ seq: number; line: string }>,
+): void {
+  writeFileSync(
+    join(
+      dir,
+      `${direction}${direction === "bridge→runtime" ? ".current" : ""}.ndjson`,
+    ),
+    `${entries
+      .map((entry) =>
+        JSON.stringify({
+          ts: entry.seq,
+          run: 1,
+          seq: entry.seq,
+          dir: direction,
+          line: entry.line,
+        }),
+      )
+      .join("\n")}\n`,
+  );
+}
+
+it("waits for the exact planned tail before closing bridge stdin", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "bb-parity-tail-test-"));
+  const bridgePath = join(dir, "delayed-tail-bridge.mjs");
+  const identity = {
+    threadId: "thr_test",
+    providerThreadId: "provider_test",
+  } as const;
+  const scope = { kind: "turn", turnId: "turn_test" } as const;
+  const prefixEvents: ThreadEvent[] = [
+    { type: "turn/started", ...identity, scope },
+    {
+      type: "item/started",
+      ...identity,
+      scope,
+      item: { type: "agentMessage", id: "item_test", text: "" },
+    },
+  ];
+  const tailEvents: ThreadEvent[] = [
+    {
+      type: "item/completed",
+      ...identity,
+      scope,
+      item: { type: "agentMessage", id: "item_test", text: "done" },
+    },
+    { type: "turn/completed", ...identity, scope, status: "completed" },
+  ];
+  const delta = (events: readonly ThreadEvent[]): string =>
+    JSON.stringify({
+      jsonrpc: "2.0",
+      method: "thread/delta",
+      params: { events },
+    });
+
+  try {
+    writeLane(dir, "runtime→bridge", [
+      {
+        seq: 1,
+        line: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "thread/start",
+          params: {},
+        }),
+      },
+    ]);
+    writeLane(dir, "bridge→runtime", [
+      { seq: 1.1, line: delta(prefixEvents) },
+      { seq: 1.2, line: delta(tailEvents) },
+    ]);
+    writeFileSync(
+      bridgePath,
+      [
+        `const prefix = ${JSON.stringify(prefixEvents)};`,
+        `const tail = ${JSON.stringify(tailEvents)};`,
+        "const delta = (events) => JSON.stringify({ jsonrpc: '2.0', method: 'thread/delta', params: { events } });",
+        "let pending = '';",
+        "let tailTimer = null;",
+        "process.stdin.setEncoding('utf8');",
+        "process.stdin.on('data', (chunk) => {",
+        "  pending += chunk;",
+        "  for (;;) {",
+        "    const newline = pending.indexOf('\\n');",
+        "    if (newline === -1) break;",
+        "    const line = pending.slice(0, newline);",
+        "    pending = pending.slice(newline + 1);",
+        "    const message = JSON.parse(line);",
+        "    if (message.method === 'initialize') {",
+        "      process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: message.id, result: {} }) + '\\n');",
+        "    } else if (message.method === 'thread/start') {",
+        "      process.stdout.write(delta(prefix) + '\\n');",
+        "      process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: message.id, result: {} }) + '\\n');",
+        "      tailTimer = setTimeout(() => process.stdout.write(delta(tail) + '\\n'), 100);",
+        "    }",
+        "  }",
+        "});",
+        "process.stdin.on('end', () => {",
+        "  if (tailTimer !== null) clearTimeout(tailTimer);",
+        "  process.exit(0);",
+        "});",
+        "",
+      ].join("\n"),
+    );
+
+    const run = await replayRecording({
+      recordingDir: dir,
+      providerId: "test-provider",
+      bridge: {
+        command: process.execPath,
+        args: [bridgePath],
+        cwd: dir,
+        env: {},
+      },
+      createAssembler: () => ({
+        assembleMessage: (message) => {
+          const params = message.params;
+          if (
+            typeof params !== "object" ||
+            params === null ||
+            !("events" in params)
+          ) {
+            return [];
+          }
+          return threadEventSchema.array().parse(params.events);
+        },
+      }),
+      planFromCurrentLane: true,
+      settleMs: 20,
+      timeoutMs: 1_000,
+    });
+
+    expect(run.stalls).toEqual([]);
+    expect(run.events).toEqual([...prefixEvents, ...tailEvents]);
+    expect(run.events.at(-1)?.type).toBe("turn/completed");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/provider-bridge-protocol/src/testing/parity.ts
+++ b/packages/provider-bridge-protocol/src/testing/parity.ts
@@ -300,7 +300,10 @@ export interface ReplayRecordingOptions {
    * alone lands before them, at a point the recording never had.
    */
   orderTimeoutMs?: number;
-  /** Quiet period after the last request before the bridge is closed. */
+  /**
+   * Quiet period after the last request before a non-exact replay is closed.
+   * An exact current-lane replay waits for every planned event instead.
+   */
   settleMs?: number;
   /**
    * Quiet period a request waits for once the gates are met. The replay child
@@ -545,10 +548,15 @@ export async function replayRecording(options: ReplayRecordingOptions): Promise<
   const liveAssembler = options.createAssembler(providerId);
   const planAssembler = (options.createPlanAssembler ?? options.createAssembler)(providerId);
   const exactPlan = options.planFromCurrentLane === true;
-  const steps = planRuntimeSteps(
-    exactPlan ? withCurrentBridgeLane(recording) : recording,
-    planAssembler,
-  );
+  const planRecording = exactPlan ? withCurrentBridgeLane(recording) : recording;
+  const steps = planRuntimeSteps(planRecording, planAssembler);
+  const plannedEventCount = exactPlan
+    ? assembleRecordedEvents(
+        planRecording,
+        options.createPlanAssembler ?? options.createAssembler,
+        providerId,
+      ).events.length
+    : null;
 
   const answeredIds = new Set<string>();
   const pendingBridgeRequests: { id: string | number; method: string }[] = [];
@@ -752,8 +760,21 @@ export async function replayRecording(options: ReplayRecordingOptions): Promise<
   }
   setCursor("end");
   await waitFor("the last responses", () => sentRequestIds.every((id) => answeredIds.has(id)));
-  // Let trailing notifications drain, then close the wire like the runtime.
-  await waitFor("the stream to settle", () => Date.now() - lastOutputAt >= settleMs);
+  // An exact plan is this bridge's own recorded lane, so its complete accepted
+  // event count is the deterministic end of replay. Output silence is not:
+  // the provider child and bridge can be alive in provider-internal control
+  // flow without emitting runtime deltas, especially under scheduler load.
+  if (plannedEventCount !== null) {
+    await waitFor(
+      `all ${plannedEventCount} planned events before closing the bridge`,
+      () => events.length >= plannedEventCount,
+    );
+  } else {
+    // A bridge compared with a lane from another version may deliberately
+    // emit fewer events, so only that non-exact comparison needs the quiet
+    // fallback to terminate and report its parity diff.
+    await waitFor("the stream to settle", () => Date.now() - lastOutputAt >= settleMs);
+  }
   child.stdin?.end();
   const exitCode = await Promise.race([
     exited,


### PR DESCRIPTION
## Human comments

## What was wrong

Exact current-lane parity replays used elapsed bridge-output silence as their terminal condition. After the final runtime request was answered, `replayRecording` closed bridge stdin once `lastOutputAt` had been quiet for 750ms, even though the replay provider child and Claude SDK could still be processing provider-internal control flow. Under scheduler contention, that EOF landed after WebFetch opened but before its provider tail reached the bridge, so shutdown discarded the WebFetch completion, assistant message, usage, and `turn/completed`; the projection consequently showed an interrupted WebFetch row. This is the failure observed in [main CI run 32906829649](https://github.com/get-bb/bb/actions/runs/32906829649).

## What changed

Exact `planFromCurrentLane` replays now assemble the complete current-lane plan and wait for its full grammar-accepted event count before closing bridge stdin. That lane was emitted by the bridge under test, so it is a deterministic completion boundary; the existing timeout remains hang detection only. Non-exact cross-version comparisons retain the quiet fallback because a deliberately divergent bridge can validly emit fewer events.

A real-child regression bridge acknowledges its final request, delays `item/completed` and `turn/completed` past a deliberately shorter quiet period, and exits without them if stdin closes early. It fails on the old policy and passes when replay waits for the planned lifecycle tail.

This changes test-harness process sequencing only. No server↔host-daemon or provider bridge wire fields changed, so `HOST_DAEMON_PROTOCOL_VERSION` remains unchanged. The published provider-bridge testing bundle changes, so `@get-bb/plugin-sdk` is coherently bumped from 0.4.20 to 0.4.21; no new public API member, CLI, or user-facing configuration is introduced.

## How you verified

- Before the fix, the deterministic regression failed in 657ms with only 2 of 4 expected events.
- A temporary exact Claude replay pause immediately after recorded WebFetch-open seq 1500 reproduced the CI signature in 2.76s: the same missing WebFetch completion/message/usage/`turn/completed` and interrupted projected row. With the structural fix and the same 1s pause, the exact case passed without changing any timeout.
- Exact-cell stress: 32/32 `claude-code/web-search` replays passed in two batches of 16 concurrent real bridges, with zero stalls and 14/14 events each.
- `pnpm exec turbo run test --filter=@bb/provider-bridge-protocol --filter=@bb/provider-parity --force` — 238/238 protocol tests and 56/56 parity tests passed; the exact Claude case completed in 3.701s.
- `pnpm exec turbo run test --filter=bb-plugin-provider-claude-code --force` — 335/335 tests passed; the unrelated CI-timed-out native-roots case completed in 470ms locally.
- `pnpm exec turbo run build typecheck --filter=@get-bb/plugin-sdk --filter=@bb/domain --filter=@bb/provider-bridge-protocol --filter=@bb/provider-parity --force` — 8/8 tasks passed.
- `node packages/plugin-sdk/scripts/check-npm-version-guard.mjs` — passed; 0.4.21 is unpublished and will be shipped by the publish job.
- The full packages Turbo test command completed 71/73 tasks on macOS. Its only failures were two unchanged `@bb/plugin-build` assertions that compare `/tmp/...` to macOS's canonical `/private/tmp/...`; both passed in the PR's Ubuntu packages job.
- `git diff --check` — passed.

> AGENT GENERATED: by GPT-5.6-Sol
