### PR TITLE
Fix path dialogs, shell-search inference, and toast dismissal

### DIFF
--- a/apps/app/src/components/dialogs/AddMachineDialog.test.tsx
+++ b/apps/app/src/components/dialogs/AddMachineDialog.test.tsx
@@ -9,7 +9,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 import type { Host } from "@bb/domain";
-import type { InstalledPlugin } from "@bb/server-contract";
+import type { HostResponse, InstalledPlugin } from "@bb/server-contract";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { BbHttpError, sdk } from "@/lib/sdk";
@@ -35,17 +35,22 @@ vi.mock("@/lib/ws", () => ({
   wsManager: { subscribe: vi.fn(), unsubscribe: vi.fn() },
 }));
 
-function host(overrides: Partial<Host> & Pick<Host, "id" | "name">): Host {
-  return {
-    type: "persistent",
-    status: "connected",
+function host(
+  overrides: Partial<Host> & Pick<Host, "id" | "name">,
+): HostResponse {
+  const status = overrides.status ?? "connected";
+  const fields = {
+    type: "persistent" as const,
     lastSeenAt: null,
-    maxPermissionMode: "full",
+    maxPermissionMode: "full" as const,
     lastRejectedProtocolVersion: null,
     createdAt: 0,
     updatedAt: 0,
     ...overrides,
   };
+  return status === "connected"
+    ? { ...fields, status, connectedRuntime: { platform: "darwin" } }
+    : { ...fields, status, connectedRuntime: null };
 }
 
 const existingHost = host({ id: "host_primary", name: "MacBook Pro" });

--- a/apps/app/src/components/dialogs/ProjectPathDialog.stories.tsx
+++ b/apps/app/src/components/dialogs/ProjectPathDialog.stories.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { QueryClientProvider } from "@tanstack/react-query";
-import type { HostDirectoryListing } from "@bb/server-contract";
+import type { HostDirectoryListing, HostResponse } from "@bb/server-contract";
 import {
   ProjectPathDialogContent,
   type ProjectPathDialogTarget,
@@ -38,18 +38,33 @@ const addSourceTarget: ProjectPathDialogTarget = {
   projectName: PROJECT_NAMES.bb,
 };
 
-const connectedMachine = makeHost();
-const offlineMachine = makeHost({
-  id: HOST_IDS.remote,
-  name: HOST_NAMES.remote,
-  status: "disconnected",
-});
-const offlineLocalMachine = makeHost({ status: "disconnected" });
+const connectedMachine = {
+  ...makeHost(),
+  status: "connected" as const,
+  connectedRuntime: { platform: "darwin" as const },
+} satisfies HostResponse;
+const offlineMachine = {
+  ...makeHost({
+    id: HOST_IDS.remote,
+    name: HOST_NAMES.remote,
+  }),
+  status: "disconnected" as const,
+  connectedRuntime: null,
+} satisfies HostResponse;
+const offlineLocalMachine = {
+  ...makeHost(),
+  status: "disconnected" as const,
+  connectedRuntime: null,
+} satisfies HostResponse;
 
-const longNamesMachine = makeHost({
-  id: "host_long_names",
-  name: "sandbox",
-});
+const longNamesMachine = {
+  ...makeHost({
+    id: "host_long_names",
+    name: "sandbox",
+  }),
+  status: "connected" as const,
+  connectedRuntime: { platform: "linux" as const },
+} satisfies HostResponse;
 const longProjectName = "long-project-name-".repeat(18);
 const longProjectPath = `/home/winter/${longProjectName}`;
 const longFileName = `${"appdata-buzz-pre-sandbox-migration-".repeat(8)}.tar.gz`;

--- a/apps/app/src/components/dialogs/ProjectPathDialog.test.tsx
+++ b/apps/app/src/components/dialogs/ProjectPathDialog.test.tsx
@@ -2,6 +2,8 @@
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { Host } from "@bb/domain";
+import type { HostPlatform } from "@bb/host-daemon-contract";
+import type { HostResponse } from "@bb/server-contract";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ProjectPathDialog } from "./ProjectPathDialog";
 
@@ -9,22 +11,27 @@ vi.mock("@/components/dialogs/RemotePathBrowser", () => ({
   RemotePathBrowser: ({
     hostId,
     allowCreateFolder,
+    pathPlaceholder,
     onDirectoryChange,
   }: {
     hostId: string;
     allowCreateFolder: boolean;
+    pathPlaceholder: string;
     onDirectoryChange: (directory: string) => void;
   }) => (
     <button
       type="button"
       data-allow-create-folder={String(allowCreateFolder)}
+      data-path-placeholder={pathPlaceholder}
       onClick={() =>
         onDirectoryChange(
           hostId === "host_kunst"
             ? "/Users/amadad/projects/reachy_mini"
-            : hostId === "host_long"
-              ? `/home/deploy/repos/${"long-project-name-".repeat(20)}`
-              : "/home/deploy/repos/givecare",
+            : hostId === "host_wsl"
+              ? "/mnt/c/Users/amadad/projects/reachy_mini"
+              : hostId === "host_long"
+                ? `/home/deploy/repos/${"long-project-name-".repeat(20)}`
+                : "/home/deploy/repos/givecare",
         )
       }
     >
@@ -33,27 +40,50 @@ vi.mock("@/components/dialogs/RemotePathBrowser", () => ({
   ),
 }));
 
-function host(overrides: Partial<Host> & Pick<Host, "id" | "name">): Host {
-  return {
-    type: "persistent",
-    status: "connected",
+function host(
+  overrides: Partial<Host> &
+    Pick<Host, "id" | "name"> & { platform?: HostPlatform },
+): HostResponse {
+  const status = overrides.status ?? "connected";
+  const fields = {
+    type: "persistent" as const,
     lastSeenAt: null,
-    maxPermissionMode: "full",
+    maxPermissionMode: "full" as const,
     lastRejectedProtocolVersion: null,
     createdAt: 0,
     updatedAt: 0,
     ...overrides,
   };
+  return status === "connected"
+    ? {
+        ...fields,
+        status,
+        connectedRuntime: { platform: overrides.platform ?? "linux" },
+      }
+    : { ...fields, status, connectedRuntime: null };
 }
 
 const atum = host({ id: "host_atum", name: "atum" });
-const kunst = host({ id: "host_kunst", name: "Kunst" });
+const kunst = host({
+  id: "host_kunst",
+  name: "Kunst",
+  platform: "darwin",
+});
+const wsl = host({
+  id: "host_wsl",
+  name: "WSL dev",
+  platform: "wsl",
+});
 const offline = host({
   id: "host_offline",
   name: "Offline Mac",
   status: "disconnected",
 });
-const offlineKunst = host({ ...kunst, status: "disconnected" });
+const offlineKunst = host({
+  id: kunst.id,
+  name: kunst.name,
+  status: "disconnected",
+});
 
 afterEach(() => {
   cleanup();
@@ -101,6 +131,80 @@ describe("ProjectPathDialog machine selection", () => {
       "/Users/amadad/projects/reachy_mini",
       "host_kunst",
     );
+  });
+
+  it("uses the selected host's path syntax and restores the local Mac picker", () => {
+    const onPickNativeFolder = vi.fn();
+    const onSubmit = vi.fn();
+    render(
+      <ProjectPathDialog
+        target={{ kind: "create" }}
+        platform="darwin"
+        hostId={kunst.id}
+        hostName={kunst.name}
+        hosts={[kunst, atum, wsl]}
+        nativeFolderPicker={{
+          hostId: kunst.id,
+          onPick: onPickNativeFolder,
+        }}
+        onOpenChange={vi.fn()}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Machine" });
+    expect(screen.getByText(/edit the macOS path directly/u)).toBeTruthy();
+    expect(
+      screen
+        .getByRole("button", { name: "Choose folder on host_kunst" })
+        .getAttribute("data-path-placeholder"),
+    ).toBe("/Users/me/project");
+    expect(
+      screen.getByRole("button", { name: "Choose folder with Finder" }),
+    ).toBeTruthy();
+
+    fireEvent.pointerDown(trigger, { button: 0 });
+    fireEvent.click(screen.getByRole("menuitem", { name: /atum/u }));
+    expect(screen.getByText(/edit the Linux path directly/u)).toBeTruthy();
+    expect(
+      screen
+        .getByRole("button", { name: "Choose folder on host_atum" })
+        .getAttribute("data-path-placeholder"),
+    ).toBe("/home/me/project");
+    expect(
+      screen.queryByRole("button", { name: "Choose folder with Finder" }),
+    ).toBeNull();
+
+    fireEvent.pointerDown(trigger, { button: 0 });
+    fireEvent.click(screen.getByRole("menuitem", { name: /WSL dev/u }));
+    expect(screen.getByText(/edit the WSL path directly/u)).toBeTruthy();
+    expect(
+      screen
+        .getByRole("button", { name: "Choose folder on host_wsl" })
+        .getAttribute("data-path-placeholder"),
+    ).toBe("/mnt/c/Users/me/project");
+    expect(
+      screen.queryByRole("button", { name: "Choose folder with Finder" }),
+    ).toBeNull();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Choose folder on host_wsl" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Add project" }));
+    expect(onSubmit).toHaveBeenLastCalledWith(
+      { kind: "create" },
+      "/mnt/c/Users/amadad/projects/reachy_mini",
+      "host_wsl",
+    );
+
+    fireEvent.pointerDown(trigger, { button: 0 });
+    fireEvent.click(screen.getByRole("menuitem", { name: /Kunst/u }));
+    expect(screen.getByText(/edit the macOS path directly/u)).toBeTruthy();
+    const nativePicker = screen.getByRole("button", {
+      name: "Choose folder with Finder",
+    });
+    fireEvent.click(nativePicker);
+    expect(onPickNativeFolder).toHaveBeenCalledWith({ kind: "create" });
   });
 
   it("preserves the direct single-machine folder flow", () => {

--- a/apps/app/src/components/dialogs/ProjectPathDialog.tsx
+++ b/apps/app/src/components/dialogs/ProjectPathDialog.tsx
@@ -10,9 +10,9 @@ import {
   deriveProjectNameFromPath,
   getProjectPathValidationMessage,
   normalizeProjectPathInput,
-  type Host,
 } from "@bb/domain";
 import type { HostPlatform } from "@bb/host-daemon-contract";
+import type { HostResponse } from "@bb/server-contract";
 import { Button } from "@bb/shared-ui/button";
 import {
   Dialog,
@@ -50,13 +50,19 @@ export type ProjectPathDialogSubmitHandler = (
   hostId: string | null,
 ) => Promise<void> | void;
 
+export interface ProjectPathDialogNativeFolderPicker {
+  hostId: string;
+  onPick: (target: ProjectPathDialogTarget) => Promise<void> | void;
+}
+
 interface ProjectPathDialogProps {
   target: ProjectPathDialogTarget | null;
   pending?: boolean;
   platform: HostPlatform | null;
   hostId: string | null;
   hostName: string | null;
-  hosts?: readonly Host[];
+  hosts?: readonly HostResponse[];
+  nativeFolderPicker?: ProjectPathDialogNativeFolderPicker | null;
   onOpenChange: (open: boolean) => void;
   onSubmit: ProjectPathDialogSubmitHandler;
 }
@@ -68,6 +74,7 @@ export function ProjectPathDialog({
   hostId,
   hostName,
   hosts,
+  nativeFolderPicker = null,
   onOpenChange,
   onSubmit,
 }: ProjectPathDialogProps) {
@@ -83,6 +90,7 @@ export function ProjectPathDialog({
             hostId={hostId}
             hostName={hostName}
             hosts={hosts}
+            nativeFolderPicker={nativeFolderPicker}
             onSubmit={onSubmit}
           />
         ) : null}
@@ -97,12 +105,14 @@ interface ProjectPathDialogContentProps {
   platform: HostPlatform | null;
   hostId: string | null;
   hostName: string | null;
-  hosts?: readonly Host[];
+  hosts?: readonly HostResponse[];
+  nativeFolderPicker?: ProjectPathDialogNativeFolderPicker | null;
   onSubmit: ProjectPathDialogSubmitHandler;
 }
 
 interface PlatformCopy {
   description: string;
+  pathLabel: string;
   placeholder: string;
 }
 
@@ -132,20 +142,36 @@ function getPlatformCopy(
   platform: HostPlatform | null,
   hostName: string | null,
 ): PlatformCopy {
-  const placeholder = "/path/to/project";
   // The path is resolved on the host machine, not the device showing this
-  // dialog — name the host so remote users don't type a local path.
+  // dialog. Name the host so remote users don't type a path from the browser.
   const hostSuffix = hostName ? ` on ${hostName}` : "";
-  if (platform === "wsl") {
-    return {
-      description: `Enter an absolute WSL path${hostSuffix} to the project folder, such as /home/me/repo or /mnt/c/...`,
-      placeholder,
-    };
+  switch (platform) {
+    case "darwin":
+      return {
+        description: `Enter an absolute macOS path${hostSuffix} to the project folder.`,
+        pathLabel: "macOS path",
+        placeholder: "/Users/me/project",
+      };
+    case "linux":
+      return {
+        description: `Enter an absolute Linux path${hostSuffix} to the project folder.`,
+        pathLabel: "Linux path",
+        placeholder: "/home/me/project",
+      };
+    case "wsl":
+      return {
+        description: `Enter an absolute WSL path${hostSuffix} to the project folder, such as /home/me/repo or /mnt/c/...`,
+        pathLabel: "WSL path",
+        placeholder: "/mnt/c/Users/me/project",
+      };
+    case "unknown":
+    case null:
+      return {
+        description: `Enter an absolute path${hostSuffix} to the project folder.`,
+        pathLabel: "path",
+        placeholder: "/path/to/project",
+      };
   }
-  return {
-    description: `Enter an absolute path${hostSuffix} to the project folder.`,
-    placeholder,
-  };
 }
 
 export function ProjectPathDialogContent({
@@ -155,6 +181,7 @@ export function ProjectPathDialogContent({
   hostId,
   hostName,
   hosts,
+  nativeFolderPicker = null,
   onSubmit,
 }: ProjectPathDialogContentProps) {
   const inputId = useId();
@@ -176,6 +203,8 @@ export function ProjectPathDialogContent({
     (host) => host.id === selectedHostId,
   );
   const selectedHostName = selectedHost?.name ?? hostName;
+  const selectedHostPlatform =
+    selectedHost?.connectedRuntime?.platform ?? platform;
   const selectedHostConnected =
     selectedHost === undefined || selectedHost.status === "connected";
   const showMachinePicker = (machineOptions?.length ?? 0) > 1;
@@ -193,11 +222,16 @@ export function ProjectPathDialogContent({
   const [validationMessage, setValidationMessage] = useState<string | null>(
     null,
   );
-  const copy = getPlatformCopy(platform, selectedHostName);
+  const copy = getPlatformCopy(selectedHostPlatform, selectedHostName);
   const placeholder =
     target.kind === "update"
       ? target.currentPath || copy.placeholder
       : copy.placeholder;
+
+  const canUseNativeFolderPicker =
+    nativeFolderPicker !== null &&
+    selectedHostId === nativeFolderPicker.hostId &&
+    selectedHostPlatform === "darwin";
 
   const selectedPath = selectedHostId
     ? browserDirectory
@@ -246,7 +280,7 @@ export function ProjectPathDialogContent({
           {selectedHostId
             ? `Browse to the project folder${
                 selectedHostName ? ` on ${selectedHostName}` : ""
-              }, or edit the path directly.`
+              }, or edit the ${copy.pathLabel} directly.`
             : noMachineAvailable
               ? "No machine is online. Start one to choose a project folder."
               : copy.description}
@@ -317,12 +351,24 @@ export function ProjectPathDialogContent({
             </DropdownMenuContent>
           </DropdownMenu>
         ) : null}
+        {canUseNativeFolderPicker ? (
+          <Button
+            type="button"
+            variant="outline"
+            disabled={pending}
+            onClick={() => void nativeFolderPicker.onPick(target)}
+          >
+            <Icon name="FolderOpen" />
+            Choose folder with Finder
+          </Button>
+        ) : null}
         {selectedHostId ? (
           <RemotePathBrowser
             key={selectedHostId}
             hostId={selectedHostId}
             initialPath={target.kind === "update" ? target.currentPath : null}
             allowCreateFolder={target.kind === "create"}
+            pathPlaceholder={copy.placeholder}
             onDirectoryChange={setBrowserDirectory}
             disabled={pending || !selectedHostConnected}
           />

--- a/apps/app/src/components/dialogs/RemotePathBrowser.tsx
+++ b/apps/app/src/components/dialogs/RemotePathBrowser.tsx
@@ -87,6 +87,7 @@ interface RemotePathBrowserProps {
   initialPath?: string | null;
   /** Whether this picker may create and select a new child directory. */
   allowCreateFolder: boolean;
+  pathPlaceholder?: string;
   /**
    * Reports the resolved directory currently shown (the folder that would be
    * picked). Null while the first listing loads or a manual path fails to read.
@@ -99,6 +100,7 @@ export function RemotePathBrowser({
   hostId,
   initialPath = null,
   allowCreateFolder,
+  pathPlaceholder = "/path/to/project",
   onDirectoryChange,
   disabled = false,
 }: RemotePathBrowserProps) {
@@ -336,7 +338,7 @@ export function RemotePathBrowser({
               className="h-7 flex-1 text-xs"
               value={editValue}
               disabled={disabled}
-              placeholder="/path/to/project"
+              placeholder={pathPlaceholder}
               onChange={(event) => setEditValue(event.target.value)}
               onKeyDown={(event) => {
                 if (event.key === "Enter") {

--- a/apps/app/src/components/project/ProjectActionsProvider.tsx
+++ b/apps/app/src/components/project/ProjectActionsProvider.tsx
@@ -183,6 +183,7 @@ export function ProjectActionsProvider({
         platform={addLocalSourcePicker.platform}
         hostId={addLocalSourcePicker.hostId}
         hostName={addLocalSourcePicker.hostName}
+        nativeFolderPicker={addLocalSourcePicker.nativeFolderPicker}
         onOpenChange={addLocalSourcePicker.projectPathDialog.onOpenChange}
         onSubmit={addLocalSourcePicker.submitProjectPath}
       />

--- a/apps/app/src/components/settings/MachinesSettingsSection.test.tsx
+++ b/apps/app/src/components/settings/MachinesSettingsSection.test.tsx
@@ -10,7 +10,7 @@ import {
 import type { Host } from "@bb/domain";
 import { RETRY_ACTION_ICON } from "@bb/domain/update-state";
 import { HOST_DAEMON_PROTOCOL_VERSION } from "@bb/host-daemon-contract";
-import type { SystemConfigResponse } from "@bb/server-contract";
+import type { HostResponse, SystemConfigResponse } from "@bb/server-contract";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { sdk } from "@/lib/sdk";
@@ -48,17 +48,22 @@ vi.mock("@/hooks/useHostDaemon", () => ({
 
 const NOW = Date.now();
 
-function host(overrides: Partial<Host> & Pick<Host, "id" | "name">): Host {
-  return {
-    type: "persistent",
-    status: "connected",
+function host(
+  overrides: Partial<Host> & Pick<Host, "id" | "name">,
+): HostResponse {
+  const status = overrides.status ?? "connected";
+  const fields = {
+    type: "persistent" as const,
     lastSeenAt: NOW,
-    maxPermissionMode: "full",
+    maxPermissionMode: "full" as const,
     lastRejectedProtocolVersion: null,
     createdAt: 0,
     updatedAt: 0,
     ...overrides,
   };
+  return status === "connected"
+    ? { ...fields, status, connectedRuntime: { platform: "darwin" } }
+    : { ...fields, status, connectedRuntime: null };
 }
 
 const primaryHost = host({ id: "host_primary", name: "MacBook Pro" });

--- a/apps/app/src/components/ui/app-toast.tsx
+++ b/apps/app/src/components/ui/app-toast.tsx
@@ -131,8 +131,20 @@ export function AppToastContent({
 
   return (
     <div
-      className="relative w-[var(--width,356px)] max-w-[calc(100vw-32px)] rounded-md border border-border bg-popover px-4 py-3 text-popover-foreground shadow-sm max-[600px]:w-[calc(100vw-32px)]"
+      className="relative w-[var(--width,356px)] max-w-[calc(100vw-32px)] rounded-md border border-border bg-popover px-4 py-3 pr-9 text-popover-foreground shadow-sm max-[600px]:w-[calc(100vw-32px)]"
     >
+      {id !== undefined ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-label="Dismiss notification"
+          className="absolute right-1.5 top-1.5 size-6 text-muted-foreground"
+          onClick={() => dismissToast(id)}
+        >
+          <Icon name="X" className="size-3.5" />
+        </Button>
+      ) : null}
       <div className="flex items-start gap-3">
         <div className="mt-0.5 flex size-4 shrink-0 items-center justify-center text-foreground">
           <Icon

--- a/apps/app/src/hooks/queries/host-queries.ts
+++ b/apps/app/src/hooks/queries/host-queries.ts
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { keepPreviousData, skipToken, useQuery } from "@tanstack/react-query";
 import type { Host } from "@bb/domain";
-import type { HostDirectoryListing } from "@bb/server-contract";
+import type { HostDirectoryListing, HostResponse } from "@bb/server-contract";
 import { sdk } from "@/lib/sdk";
 import { useHostListRealtimeSubscription } from "@/hooks/useRealtimeSubscription";
 import { useSystemConfig } from "@/hooks/queries/system-queries";
@@ -21,7 +21,7 @@ export function useHosts(options?: QueryOptions) {
   const enabled = options?.enabled ?? true;
   useHostListRealtimeSubscription({ enabled });
 
-  return useQuery<Host[]>({
+  return useQuery<HostResponse[]>({
     queryKey: hostsQueryKey(),
     queryFn: ({ signal }) => sdk.hosts.list({ signal }),
     enabled,
@@ -37,10 +37,10 @@ export function useHosts(options?: QueryOptions) {
  * loading). A non-null id that isn't in the list means the primary isn't
  * visible here: return null rather than promote another machine.
  */
-export function selectPrimaryHost(
-  hosts: readonly Host[] | undefined,
+export function selectPrimaryHost<THost extends Host>(
+  hosts: readonly THost[] | undefined,
   primaryHostId: string | null,
-): Host | null {
+): THost | null {
   if (!hosts || hosts.length === 0) return null;
   if (primaryHostId !== null) {
     return hosts.find((host) => host.id === primaryHostId) ?? null;
@@ -52,7 +52,7 @@ export function selectPrimaryHost(
  * The single host the server runs work on by default, resolved server-side.
  * Returns null while loading or before any host has ever connected.
  */
-export function usePrimaryHost(options?: QueryOptions): Host | null {
+export function usePrimaryHost(options?: QueryOptions): HostResponse | null {
   const { data: hosts } = useHosts(options);
   const primaryHostId = useSystemConfig(options).data?.primaryHostId ?? null;
   return useMemo(

--- a/apps/app/src/hooks/useLocalPathPicker.test.tsx
+++ b/apps/app/src/hooks/useLocalPathPicker.test.tsx
@@ -1,26 +1,30 @@
 // @vitest-environment jsdom
 
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
-import type { Host } from "@bb/domain";
+import type { HostPlatform } from "@bb/host-daemon-contract";
+import type { HostResponse } from "@bb/server-contract";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useLocalPathPicker } from "./useLocalPathPicker";
 
 const mocks = vi.hoisted(() => ({
-  hosts: undefined as Host[] | undefined,
+  hosts: undefined as HostResponse[] | undefined,
   isLoadingHosts: false,
+  localDaemonHostId: "host_atum" as string | null,
+  localDaemonPlatform: "darwin" as const,
   pickFolder: vi.fn(),
-  primaryHost: null as Host | null,
+  primaryHost: null as HostResponse | null,
   supportsNativeFolderPicker: true,
 }));
 
 vi.mock("@/hooks/useHostDaemon", () => ({
   useHostDaemon: () => ({
-    localDaemonHostId: "host_atum",
-    localHostId: "host_atum",
+    localDaemonHostId: mocks.localDaemonHostId,
+    localHostId: mocks.localDaemonHostId,
     hasDaemon: true,
     supportsNativeFolderPicker: mocks.supportsNativeFolderPicker,
-    platform: "linux",
-    isLocalDaemonHost: (hostId: string | null) => hostId === "host_atum",
+    platform: mocks.localDaemonPlatform,
+    isLocalDaemonHost: (hostId: string | null) =>
+      hostId === mocks.localDaemonHostId,
   }),
 }));
 
@@ -33,11 +37,12 @@ vi.mock("@/lib/sdk", () => ({
   sdk: { hosts: { pickFolder: mocks.pickFolder } },
 }));
 
-const atum: Host = {
+const atum: HostResponse = {
   id: "host_atum",
   name: "atum",
   type: "persistent",
   status: "connected",
+  connectedRuntime: { platform: "darwin" },
   lastSeenAt: null,
   maxPermissionMode: "full",
   lastRejectedProtocolVersion: null,
@@ -48,13 +53,18 @@ const atum: Host = {
 function host(
   id: string,
   name: string,
-  status: Host["status"] = "connected",
-): Host {
-  return { ...atum, id, name, status };
+  status: HostResponse["status"] = "connected",
+  platform: HostPlatform = "linux",
+): HostResponse {
+  const fields = { ...atum, id, name };
+  return status === "connected"
+    ? { ...fields, status, connectedRuntime: { platform } }
+    : { ...fields, status, connectedRuntime: null };
 }
 
 beforeEach(() => {
   mocks.primaryHost = atum;
+  mocks.localDaemonHostId = atum.id;
   mocks.supportsNativeFolderPicker = true;
   mocks.hosts = [atum];
   mocks.isLoadingHosts = false;
@@ -67,6 +77,32 @@ afterEach(() => {
 });
 
 describe("useLocalPathPicker", () => {
+  it("reports the selected work host platform instead of the Mac browser platform", () => {
+    mocks.primaryHost = host("host_wsl", "WSL dev", "connected", "wsl");
+
+    const { result } = renderHook(() =>
+      useLocalPathPicker({ isPending: false, submit: vi.fn() }),
+    );
+
+    expect(result.current.platform).toBe("wsl");
+    expect(result.current.nativeFolderPicker?.hostId).toBe("host_atum");
+  });
+
+  it("does not offer the Mac native picker for a selected Linux host", () => {
+    const linuxHost = host("host_linux", "Linux dev");
+    mocks.primaryHost = linuxHost;
+    mocks.hosts = [atum, linuxHost];
+    const { result } = renderHook(() =>
+      useLocalPathPicker({ isPending: false, submit: vi.fn() }),
+    );
+
+    act(() => result.current.openPicker({ kind: "create" }));
+
+    expect(result.current.platform).toBe("linux");
+    expect(result.current.projectPathDialog.isOpen).toBe(true);
+    expect(mocks.pickFolder).not.toHaveBeenCalled();
+  });
+
   // The dialog reports the machine it actually resolved a path on. An explicit
   // null means "no machine selected" and must not silently fall back to the
   // primary host — the create would land on the wrong machine.
@@ -113,6 +149,10 @@ describe("useLocalPathPicker", () => {
     });
 
     await waitFor(() => {
+      expect(mocks.pickFolder).toHaveBeenCalledWith({
+        hostId: "host_atum",
+        clientHostId: "host_atum",
+      });
       expect(submit).toHaveBeenCalledWith(
         expect.objectContaining({ hostId: "host_atum", path: "/home/me/repo" }),
       );

--- a/apps/app/src/hooks/useLocalPathPicker.tsx
+++ b/apps/app/src/hooks/useLocalPathPicker.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { normalizeProjectPathInput } from "@bb/domain";
 import type { HostPlatform } from "@bb/host-daemon-contract";
 import { useDialogState } from "@/hooks/useDialogState";
@@ -6,6 +6,7 @@ import { useHostDaemon } from "@/hooks/useHostDaemon";
 import { useHosts, usePrimaryHost } from "@/hooks/queries/host-queries";
 import { sdk } from "@/lib/sdk";
 import type {
+  ProjectPathDialogNativeFolderPicker,
   ProjectPathDialogSubmitHandler,
   ProjectPathDialogTarget,
 } from "@/components/dialogs/ProjectPathDialog";
@@ -34,6 +35,7 @@ interface LocalPathPickerController {
    */
   openPathEntry: (target: ProjectPathDialogTarget) => void;
   openPicker: (target: ProjectPathDialogTarget) => void;
+  nativeFolderPicker: ProjectPathDialogNativeFolderPicker | null;
   platform: HostPlatform | null;
   projectPathDialog: ReturnType<typeof useDialogState<ProjectPathDialogTarget>>;
   submitProjectPath: ProjectPathDialogSubmitHandler;
@@ -41,9 +43,10 @@ interface LocalPathPickerController {
 
 interface PathPickerHost {
   canUseNativeFolderPicker: boolean;
-  clientHostId: string | null;
   hostId: string | null;
   hostName: string | null;
+  nativeFolderPickerHostId: string | null;
+  platform: HostPlatform | null;
 }
 
 /**
@@ -52,7 +55,11 @@ interface PathPickerHost {
  * decide whether a native picker can be shown on the same physical machine.
  */
 export function usePathPickerHost(): PathPickerHost {
-  const { localDaemonHostId, supportsNativeFolderPicker } = useHostDaemon();
+  const {
+    localDaemonHostId,
+    platform: localDaemonPlatform,
+    supportsNativeFolderPicker,
+  } = useHostDaemon();
   const primaryHost = usePrimaryHost();
 
   const connectedPrimaryHostId =
@@ -60,16 +67,24 @@ export function usePathPickerHost(): PathPickerHost {
   const hostId = connectedPrimaryHostId ?? localDaemonHostId;
   const hostName =
     primaryHost && primaryHost.id === hostId ? primaryHost.name : null;
+  const nativeFolderPickerHostId = supportsNativeFolderPicker
+    ? localDaemonHostId
+    : null;
   const canUseNativeFolderPicker =
-    supportsNativeFolderPicker &&
-    localDaemonHostId !== null &&
-    hostId === localDaemonHostId;
+    hostId !== null && hostId === nativeFolderPickerHostId;
+  const platform =
+    primaryHost?.id === hostId && primaryHost.status === "connected"
+      ? primaryHost.connectedRuntime.platform
+      : hostId === localDaemonHostId
+        ? localDaemonPlatform
+        : null;
 
   return {
     canUseNativeFolderPicker,
-    clientHostId: localDaemonHostId,
     hostId,
     hostName,
+    nativeFolderPickerHostId,
+    platform,
   };
 }
 
@@ -77,9 +92,13 @@ export function useLocalPathPicker({
   isPending,
   submit,
 }: UseLocalPathPickerOptions): LocalPathPickerController {
-  const { platform } = useHostDaemon();
-  const { canUseNativeFolderPicker, clientHostId, hostId, hostName } =
-    usePathPickerHost();
+  const {
+    canUseNativeFolderPicker,
+    hostId,
+    hostName,
+    nativeFolderPickerHostId,
+    platform,
+  } = usePathPickerHost();
   const hostsQuery = useHosts();
   const isLoadingHosts = hostsQuery.isPending;
   const connectedHostCount = (hostsQuery.data ?? []).filter(
@@ -103,24 +122,48 @@ export function useLocalPathPicker({
     [closeDialog, isPending, submit],
   );
 
+  const pickNativeFolder = useCallback(
+    (target: ProjectPathDialogTarget) => {
+      if (isPending || nativeFolderPickerHostId === null) return;
+
+      void (async () => {
+        let selectedPath: string | null;
+        try {
+          selectedPath = (
+            await sdk.hosts.pickFolder({
+              hostId: nativeFolderPickerHostId,
+              clientHostId: nativeFolderPickerHostId,
+            })
+          ).path;
+        } catch {
+          projectPathDialog.onOpen(target);
+          return;
+        }
+        if (!selectedPath) return;
+        submitPath(
+          normalizeProjectPathInput(selectedPath),
+          target,
+          nativeFolderPickerHostId,
+        );
+      })();
+    },
+    [isPending, nativeFolderPickerHostId, projectPathDialog, submitPath],
+  );
+  const nativeFolderPicker =
+    useMemo<ProjectPathDialogNativeFolderPicker | null>(
+      () =>
+        nativeFolderPickerHostId === null
+          ? null
+          : { hostId: nativeFolderPickerHostId, onPick: pickNativeFolder },
+      [nativeFolderPickerHostId, pickNativeFolder],
+    );
+
   const openPicker = useCallback(
     (target: ProjectPathDialogTarget) => {
       if (isPending || !hostId) return;
 
-      if (canUseNativeFolderPicker && clientHostId !== null) {
-        void (async () => {
-          let selectedPath: string | null;
-          try {
-            selectedPath = (
-              await sdk.hosts.pickFolder({ hostId, clientHostId })
-            ).path;
-          } catch {
-            projectPathDialog.onOpen(target);
-            return;
-          }
-          if (!selectedPath) return;
-          submitPath(normalizeProjectPathInput(selectedPath), target, hostId);
-        })();
+      if (canUseNativeFolderPicker) {
+        pickNativeFolder(target);
         return;
       }
 
@@ -128,11 +171,10 @@ export function useLocalPathPicker({
     },
     [
       canUseNativeFolderPicker,
-      clientHostId,
       hostId,
       isPending,
+      pickNativeFolder,
       projectPathDialog,
-      submitPath,
     ],
   );
 
@@ -165,6 +207,7 @@ export function useLocalPathPicker({
     hostName,
     openPathEntry,
     openPicker,
+    nativeFolderPicker,
     platform,
     projectPathDialog,
     submitProjectPath,

--- a/apps/app/src/hooks/useQuickCreateProject.tsx
+++ b/apps/app/src/hooks/useQuickCreateProject.tsx
@@ -6,8 +6,9 @@ import {
   type ReactNode,
 } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
-import { deriveProjectNameFromPath, type Host } from "@bb/domain";
+import { deriveProjectNameFromPath } from "@bb/domain";
 import type { HostPlatform } from "@bb/host-daemon-contract";
+import type { HostResponse } from "@bb/server-contract";
 import { useCreateProject } from "@/hooks/mutations/project-mutations";
 import { useHosts } from "@/hooks/queries/host-queries";
 import {
@@ -20,6 +21,7 @@ import {
 } from "@/lib/route-paths";
 import { useSetRootComposeProjectId } from "@/lib/root-compose-selection";
 import type {
+  ProjectPathDialogNativeFolderPicker,
   ProjectPathDialogSubmitHandler,
   ProjectPathDialogTarget,
 } from "@/components/dialogs/ProjectPathDialog";
@@ -37,14 +39,15 @@ interface QuickCreateProjectController {
   platform: HostPlatform | null;
   hostId: string | null;
   hostName: string | null;
-  hosts: readonly Host[];
+  hosts: readonly HostResponse[];
+  nativeFolderPicker: ProjectPathDialogNativeFolderPicker | null;
   projectPathDialog: QuickCreateProjectDialogState;
   submitProjectPath: ProjectPathDialogSubmitHandler;
 }
 
 const quickCreateProjectContext =
   createContext<QuickCreateProjectController | null>(null);
-const EMPTY_HOSTS: readonly Host[] = [];
+const EMPTY_HOSTS: readonly HostResponse[] = [];
 
 export function useQuickCreateProject(): QuickCreateProjectController {
   const { mutate, isPending } = useCreateProject();
@@ -98,6 +101,7 @@ export function useQuickCreateProject(): QuickCreateProjectController {
       hostId: controller.hostId,
       hostName: controller.hostName,
       hosts,
+      nativeFolderPicker: controller.nativeFolderPicker,
       projectPathDialog: controller.projectPathDialog,
       submitProjectPath: controller.submitProjectPath,
     }),

--- a/apps/app/src/main.tsx
+++ b/apps/app/src/main.tsx
@@ -72,7 +72,7 @@ createRoot(document.getElementById("root")!, {
       <QueryClientProvider client={queryClient}>
         <BrowserRouter>
           <App />
-          <AppToaster position="bottom-right" />
+          <AppToaster position="bottom-right" closeButton />
         </BrowserRouter>
       </QueryClientProvider>
     </AppErrorBoundary>

--- a/apps/app/src/views/MachineSettingsView.test.tsx
+++ b/apps/app/src/views/MachineSettingsView.test.tsx
@@ -8,7 +8,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 import type { Host } from "@bb/domain";
-import type { SystemConfigResponse } from "@bb/server-contract";
+import type { HostResponse, SystemConfigResponse } from "@bb/server-contract";
 import type {
   ProviderCliKey,
   ProviderCliStatus,
@@ -54,19 +54,22 @@ vi.mock("@/hooks/useHostDaemon", () => ({
 
 const HOST_ID = "host_remote";
 
-function host(overrides: Partial<Host> = {}): Host {
-  return {
+function host(overrides: Partial<Host> = {}): HostResponse {
+  const status = overrides.status ?? "connected";
+  const fields = {
     id: HOST_ID,
     name: "dev-vm",
-    type: "persistent",
-    status: "connected",
-    maxPermissionMode: "full",
+    type: "persistent" as const,
+    maxPermissionMode: "full" as const,
     lastSeenAt: Date.now(),
     lastRejectedProtocolVersion: null,
     createdAt: Date.now() - 86_400_000,
     updatedAt: Date.now(),
     ...overrides,
   };
+  return status === "connected"
+    ? { ...fields, status, connectedRuntime: { platform: "linux" } }
+    : { ...fields, status, connectedRuntime: null };
 }
 
 function systemConfig(): SystemConfigResponse {
@@ -138,11 +141,12 @@ function stubSupportingFetches(): void {
   ]);
   vi.stubGlobal(
     "fetch",
-    vi.fn(async () =>
-      new Response(JSON.stringify({ projects: [] }), {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      }),
+    vi.fn(
+      async () =>
+        new Response(JSON.stringify({ projects: [] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
     ),
   );
 }

--- a/apps/app/src/views/ProjectSettingsView.tsx
+++ b/apps/app/src/views/ProjectSettingsView.tsx
@@ -285,6 +285,7 @@ export function ProjectSettingsView() {
         platform={localSourcePicker.platform}
         hostId={localSourcePicker.hostId}
         hostName={localSourcePicker.hostName}
+        nativeFolderPicker={localSourcePicker.nativeFolderPicker}
         onOpenChange={localSourcePicker.projectPathDialog.onOpenChange}
         onSubmit={localSourcePicker.submitProjectPath}
       />

--- a/apps/demo-server/src/fixtures/world.ts
+++ b/apps/demo-server/src/fixtures/world.ts
@@ -8,12 +8,12 @@
 // rows (stamped with the device clock) above rows the server appends.
 
 import type {
-  Host,
   ResolvedThreadExecutionOptions,
   ThreadListEntry,
   ThreadQueuedMessage,
 } from "@bb/domain";
 import type {
+  HostResponse,
   ProjectWithThreadsResponse,
   SidebarBootstrapResponse,
   SystemVersionResponse,
@@ -159,13 +159,14 @@ export function sidebarBootstrap(
   return { sections: [], projects: [project], personalProject };
 }
 
-export function hosts(now: number): Host[] {
+export function hosts(now: number): HostResponse[] {
   return [
     {
       id: DEMO_HOST_ID,
       name: "demo",
       type: "persistent",
       status: "connected",
+      connectedRuntime: { platform: "linux" },
       maxPermissionMode: "full",
       lastSeenAt: now,
       lastRejectedProtocolVersion: null,

--- a/apps/mobile/src/data/thread-detail/thread-detail-cache.test.ts
+++ b/apps/mobile/src/data/thread-detail/thread-detail-cache.test.ts
@@ -39,7 +39,11 @@ describe("ingestThreadDetailBootstrap", () => {
     ingestThreadDetailBootstrap(queryClient, {
       ...thread,
       environment,
-      host: hostFixture({ id: "h1", name: "laptop" }),
+      host: {
+        ...hostFixture({ id: "h1", name: "laptop" }),
+        status: "disconnected" as const,
+        connectedRuntime: null,
+      },
     });
 
     expect(queryClient.getQueryData(threadQueryKey("t1"))).toEqual(thread);

--- a/apps/server/src/services/lib/entity-lookup.ts
+++ b/apps/server/src/services/lib/entity-lookup.ts
@@ -10,6 +10,7 @@ import {
 } from "@bb/db";
 import type { Environment, Host } from "@bb/domain";
 import type { DbConnection } from "@bb/db";
+import type { HostResponse } from "@bb/server-contract";
 import type { NotificationHub } from "../../ws/hub.js";
 import { ApiError } from "../../errors.js";
 import {
@@ -27,7 +28,10 @@ type HostRow = NonNullable<ReturnType<typeof getHost>>;
 type ProjectRow = NonNullable<ReturnType<typeof getProject>>;
 type ThreadRow = NonNullable<ReturnType<typeof getThread>>;
 type StandardProject = ProjectRow & { kind: "standard" };
-type HostLookupHub = Pick<NotificationHub, "getDaemonSessionIdForHost">;
+type HostLookupHub = Pick<
+  NotificationHub,
+  "getDaemonPlatformForHost" | "getDaemonSessionIdForHost"
+>;
 
 interface HostLookupDeps {
   db: DbConnection;
@@ -79,18 +83,35 @@ function toHostStatus(deps: HostLookupDeps, hostId: string): Host["status"] {
     : "disconnected";
 }
 
-function toHostRecord(row: HostRow, status: Host["status"]): Host {
-  return {
+function toHostRecord(
+  deps: HostLookupDeps,
+  row: HostRow,
+  status: Host["status"],
+): HostResponse {
+  const fields = {
     id: row.id,
     name: row.name,
     type: row.type,
-    status,
     maxPermissionMode: row.maxPermissionMode,
     lastSeenAt: row.lastSeenAt,
     lastRejectedProtocolVersion: row.lastRejectedProtocolVersion,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };
+
+  if (status === "connected") {
+    const platform = deps.hub.getDaemonPlatformForHost(row.id);
+    if (platform === null) {
+      throw new Error(`Connected host ${row.id} has no runtime platform`);
+    }
+    return {
+      ...fields,
+      status,
+      connectedRuntime: { platform },
+    };
+  }
+
+  return { ...fields, status, connectedRuntime: null };
 }
 
 function throwHostNotFound(): never {
@@ -101,11 +122,14 @@ function isStandardProject(project: ProjectRow): project is StandardProject {
   return project.kind === "standard";
 }
 
-export function listPublicHostsWithStatus(deps: HostLookupDeps): Host[] {
+export function listPublicHostsWithStatus(
+  deps: HostLookupDeps,
+): HostResponse[] {
   const rows = listPublicHosts(deps.db);
 
   return rows.map((row) =>
     toHostRecord(
+      deps,
       row,
       getOpenDaemonSessionForHost(deps, row.id) ? "connected" : "disconnected",
     ),
@@ -115,7 +139,7 @@ export function listPublicHostsWithStatus(deps: HostLookupDeps): Host[] {
 export function requireNonDestroyedHostWithStatus(
   deps: HostLookupDeps,
   hostId: string,
-): Host {
+): HostResponse {
   const host = getHost(deps.db, hostId);
   if (!host) {
     throwHostNotFound();
@@ -127,18 +151,18 @@ export function requireNonDestroyedHostWithStatus(
       destroyedHostUnavailableDetails(host.destroyedAt),
     );
   }
-  return toHostRecord(host, toHostStatus(deps, host.id));
+  return toHostRecord(deps, host, toHostStatus(deps, host.id));
 }
 
 export function getNonDestroyedHostWithStatus(
   deps: HostLookupDeps,
   hostId: string,
-): Host | null {
+): HostResponse | null {
   const host = getNonDestroyedHost(deps.db, hostId);
   if (!host) {
     return null;
   }
-  return toHostRecord(host, toHostStatus(deps, host.id));
+  return toHostRecord(deps, host, toHostStatus(deps, host.id));
 }
 
 export function requireConnectedHostSession(

--- a/apps/server/test/public/public-host-management.test.ts
+++ b/apps/server/test/public/public-host-management.test.ts
@@ -7,6 +7,7 @@ import {
 } from "@bb/db";
 import {
   createHostJoinCodeResponseSchema,
+  hostResponseSchema,
   type CreateHostJoinCodeResponse,
 } from "@bb/server-contract";
 import {
@@ -49,6 +50,54 @@ function requestJoinCode(app: {
 }
 
 describe("public host management", () => {
+  it("returns each connected host's validated runtime platform", async () => {
+    await withTestHarness(async (harness) => {
+      const host = seedHost(harness.deps, { id: "host_runtime_platform" });
+      const session = seedSession(harness.deps, host.id);
+
+      const listResponse = await harness.app.request(`${API}/hosts`);
+      expect(listResponse.status).toBe(200);
+      expect(
+        z.array(hostResponseSchema).parse(await readJson(listResponse)),
+      ).toContainEqual(
+        expect.objectContaining({
+          id: host.id,
+          status: "connected",
+          connectedRuntime: { platform: "darwin" },
+        }),
+      );
+
+      harness.hub.unregisterDaemon(session.id);
+      const disconnectedResponse = await harness.app.request(
+        `${API}/hosts/${host.id}`,
+      );
+      expect(disconnectedResponse.status).toBe(200);
+      expect(
+        hostResponseSchema.parse(await readJson(disconnectedResponse)),
+      ).toMatchObject({
+        id: host.id,
+        status: "disconnected",
+        connectedRuntime: null,
+      });
+
+      harness.hub.recordDaemonSessionPlatform(session.id, "wsl");
+      harness.hub.registerDaemon(session.id, host.id, {
+        close() {},
+        send() {},
+      });
+      const reconnectedResponse = await harness.app.request(
+        `${API}/hosts/${host.id}`,
+      );
+      expect(
+        hostResponseSchema.parse(await readJson(reconnectedResponse)),
+      ).toMatchObject({
+        id: host.id,
+        status: "connected",
+        connectedRuntime: { platform: "wsl" },
+      });
+    });
+  });
+
   it("preserves a renamed host across a daemon reconnect", async () => {
     await withTestHarness(async (harness) => {
       const issued = await createJoinCode(harness.app);

--- a/packages/sdk/src/areas/hosts.ts
+++ b/packages/sdk/src/areas/hosts.ts
@@ -1,5 +1,4 @@
 import { hostProviderCliInstallEventSchema } from "@bb/server-contract";
-import type { Host } from "@bb/domain";
 import type {
   CreateHostJoinCodeResponse,
   HostCloneDefaultPathQuery,
@@ -13,6 +12,7 @@ import type {
   HostProviderCliInstallEvent,
   HostProviderCliInstallRequest,
   HostProviderCliStatusResponse,
+  HostResponse,
   HostRetryUpdateResponse,
   UpdateHostRequest,
 } from "@bb/server-contract";
@@ -66,15 +66,15 @@ export interface HostListArgs {
 export type HostCreateJoinCodeResult = CreateHostJoinCodeResponse;
 export type HostDeleteResult = { ok: true };
 export type HostDirectoryResult = HostDirectoryListing;
-export type HostGetResult = Host;
+export type HostGetResult = HostResponse;
 export type HostCloneDefaultPathResult = HostCloneDefaultPathResponse;
 export type HostProviderCliInstallResult = HostProviderCliInstallEvent[];
-export type HostListResult = Host[];
+export type HostListResult = HostResponse[];
 export type HostPathsExistResult = HostPathsExistResponse;
 export type HostPickFolderResult = HostPickFolderResponse;
 export type HostProviderCliStatusResult = HostProviderCliStatusResponse;
 export type HostRetryUpdateResult = HostRetryUpdateResponse;
-export type HostUpdateResult = Host;
+export type HostUpdateResult = HostResponse;
 
 export interface HostsArea {
   createJoinCode(): Promise<HostCreateJoinCodeResult>;

--- a/packages/server-contract/src/api/hosts.ts
+++ b/packages/server-contract/src/api/hosts.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
-import { permissionModeSchema } from "@bb/domain";
+import { hostSchema, permissionModeSchema } from "@bb/domain";
 import {
+  hostPlatformSchema,
   pathsExistRequestSchema,
   providerCliInstallEventSchema,
   providerCliInstallRequestSchema,
@@ -11,6 +12,24 @@ import {
   type ProviderCliInstallRequest,
   type ProviderCliStatusResponse,
 } from "@bb/host-daemon-contract/local";
+
+const connectedHostRuntimeSchema = z
+  .object({
+    platform: hostPlatformSchema,
+  })
+  .strict();
+
+export const hostResponseSchema = z.discriminatedUnion("status", [
+  hostSchema.extend({
+    status: z.literal("connected"),
+    connectedRuntime: connectedHostRuntimeSchema,
+  }),
+  hostSchema.extend({
+    status: z.literal("disconnected"),
+    connectedRuntime: z.null(),
+  }),
+]);
+export type HostResponse = z.infer<typeof hostResponseSchema>;
 
 /**
  * Query for `GET /hosts/:id/directory`, the interactive path browser's

--- a/packages/server-contract/src/api/threads.ts
+++ b/packages/server-contract/src/api/threads.ts
@@ -3,7 +3,6 @@ import {
   activeThinkingSchema,
   callerExecutionInputSourceSchema,
   environmentSchema,
-  hostSchema,
   jsonValueSchema,
   pendingInteractionResolutionSchema,
   pendingInteractionSchema,
@@ -25,6 +24,7 @@ import {
   threadWithRuntimeSchema,
 } from "@bb/domain";
 import type { CallerExecutionInputSource } from "@bb/domain";
+import { hostResponseSchema } from "./hosts.js";
 import {
   timelineDeltaSchema,
   timelineRowSchema,
@@ -420,7 +420,9 @@ export type ThreadGetQuery = z.infer<typeof threadGetQuerySchema>;
 
 export const threadWithIncludesResponseSchema = threadResponseSchema.extend({
   environment: environmentSchema.nullable().optional(),
-  host: hostSchema.nullable().optional(),
+  // The host with its connection status, the same shape the hosts list
+  // serves, so a client can seed that list from a thread fetch.
+  host: hostResponseSchema.nullable().optional(),
 });
 export type ThreadWithIncludesResponse = z.infer<
   typeof threadWithIncludesResponseSchema

--- a/packages/server-contract/src/public-api.ts
+++ b/packages/server-contract/src/public-api.ts
@@ -6,7 +6,6 @@ import type {
   AppKeybindingOverrides,
   Environment,
   Experiments,
-  Host,
   PendingInteraction,
   ProjectExecutionDefaults,
   ProjectSource,
@@ -79,6 +78,7 @@ import type {
   EnvironmentStatusResponse,
   HostDirectoryListing,
   HostDirectoryQuery,
+  HostResponse,
   HostCloneDefaultPathQuery,
   HostCloneDefaultPathResponse,
   HostFileListRequest,
@@ -599,19 +599,19 @@ export const publicApiRoutes = {
       path: "/hosts",
       method: "get",
       request: noRequest(),
-      response: jsonResponse<Host[]>(),
+      response: jsonResponse<HostResponse[]>(),
     }),
     get: defineRoute({
       path: "/hosts/:id",
       method: "get",
       request: noRequest<PathId>(),
-      response: jsonResponse<Host>(),
+      response: jsonResponse<HostResponse>(),
     }),
     update: defineRoute({
       path: "/hosts/:id",
       method: "patch",
       request: jsonRequest<PathId, UpdateHostRequest>(updateHostRequestSchema),
-      response: jsonResponse<Host>(),
+      response: jsonResponse<HostResponse>(),
     }),
     updatePermissionCeiling: defineRoute({
       path: "/hosts/:id/permission-ceiling",
@@ -619,7 +619,7 @@ export const publicApiRoutes = {
       request: jsonRequest<PathId, UpdateHostPermissionCeilingRequest>(
         updateHostPermissionCeilingRequestSchema,
       ),
-      response: jsonResponse<Host>(),
+      response: jsonResponse<HostResponse>(),
     }),
     retryUpdate: defineRoute({
       path: "/hosts/:id/retry-update",

--- a/packages/server-contract/test/contract.test.ts
+++ b/packages/server-contract/test/contract.test.ts
@@ -21,6 +21,7 @@ import {
   environmentActionRequestSchema,
   baseBranchSpecSchema,
   gitBranchNameSchema,
+  hostResponseSchema,
   reorderPinnedThreadRequestSchema,
   reorderQueuedMessageRequestSchema,
   resolvePendingInteractionRequestSchema,
@@ -538,6 +539,43 @@ describe("git branch name contract", () => {
       contract.environmentDiffQuerySchema.safeParse({
         target: "all",
         mergeBaseBranch: "origin/main lock",
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("public host contracts", () => {
+  const host = {
+    id: "host-1",
+    name: "Mac",
+    type: "persistent" as const,
+    maxPermissionMode: "full" as const,
+    lastSeenAt: null,
+    lastRejectedProtocolVersion: null,
+    createdAt: 1,
+    updatedAt: 1,
+  };
+
+  it("requires platform facts exactly while a host is connected", () => {
+    expect(
+      hostResponseSchema.parse({
+        ...host,
+        status: "connected",
+        connectedRuntime: { platform: "darwin" },
+      }),
+    ).toMatchObject({ connectedRuntime: { platform: "darwin" } });
+    expect(
+      hostResponseSchema.safeParse({
+        ...host,
+        status: "connected",
+        connectedRuntime: null,
+      }).success,
+    ).toBe(false);
+    expect(
+      hostResponseSchema.safeParse({
+        ...host,
+        status: "disconnected",
+        connectedRuntime: { platform: "darwin" },
       }).success,
     ).toBe(false);
   });

--- a/packages/thread-view/src/tool-call-parsing.ts
+++ b/packages/thread-view/src/tool-call-parsing.ts
@@ -287,24 +287,6 @@ function tokenizeShellWords(command: string): ShellToken[] {
 
 const ENV_ASSIGNMENT_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*=/u;
 
-/** Search flags that take a separate value. */
-const SEARCH_FLAGS_WITH_VALUE: ReadonlySet<string> = new Set([
-  "-g",
-  "--glob",
-  "-t",
-  "--type",
-  "-T",
-  "--type-not",
-  "-A",
-  "--after-context",
-  "-B",
-  "--before-context",
-  "-C",
-  "--context",
-  "-m",
-  "--max-count",
-]);
-
 /** `find` flags whose value is the next token. Only the common ones —
  * unknown flags are treated as value-less, which is harmless for path extraction
  * since `find` puts the start path before the expression. */
@@ -545,24 +527,8 @@ function classifyShellSegment(
 
   switch (commandName) {
     case "rg":
-    case "grep": {
-      const positionals = collectPositionals(
-        argTokens,
-        SEARCH_FLAGS_WITH_VALUE,
-      );
-      return {
-        kind: "intent",
-        intent: {
-          type: "search",
-          cmd: fullCommand,
-          query: positionals[0] ?? null,
-          path:
-            positionals.length > 1
-              ? positionals[positionals.length - 1]!
-              : null,
-        },
-      };
-    }
+    case "grep":
+      return { kind: "none" };
     case "find": {
       const positionals = collectPositionals(argTokens, FIND_FLAGS_WITH_VALUE);
       const path = positionals[0];

--- a/packages/thread-view/test/timeline-cli-rendering.snapshots.test.ts
+++ b/packages/thread-view/test/timeline-cli-rendering.snapshots.test.ts
@@ -337,7 +337,7 @@ describe("timeline CLI rendering snapshots", () => {
           "text": "── User ────────────────────────────────────────────────────
       Patch the timeline output
 
-      ── Searching for timeline in packages/core-ui ──────────────
+      ── Running rg timeline packages/core-ui ────────────────────
         $ rg timeline packages/core-ui",
         },
         {
@@ -349,8 +349,9 @@ describe("timeline CLI rendering snapshots", () => {
           "text": "── User ────────────────────────────────────────────────────
       Patch the timeline output
 
-      ── Searched for timeline in packages/core-ui ───────────────
-        $ rg timeline packages/core-ui",
+      ── Ran rg timeline packages/core-ui ────────────────────────
+        $ rg timeline packages/core-ui
+        packages/core-ui/src/format-timeline-text.ts",
         },
         {
           "messageKinds": [
@@ -363,8 +364,9 @@ describe("timeline CLI rendering snapshots", () => {
           "text": "── User ────────────────────────────────────────────────────
       Patch the timeline output
 
-      ── Searched for timeline in packages/core-ui ───────────────
+      ── Ran rg timeline packages/core-ui ────────────────────────
         $ rg timeline packages/core-ui
+        packages/core-ui/src/format-timeline-text.ts
 
       ── Ran web search: timeline rendering ──────────────────────
 
@@ -383,8 +385,10 @@ describe("timeline CLI rendering snapshots", () => {
       Patch the timeline output
 
       ── Worked for (10ms) ───────────────────────────────────────
-        ── Explored 1 search, researched 1 search query, edited 1 file
-          ── Searched for timeline in packages/core-ui
+        ── Ran 1 command, researched 1 search query, edited 1 file
+          ── Ran rg timeline packages/core-ui
+            $ rg timeline packages/core-ui
+            packages/core-ui/src/format-timeline-text.ts
           ── Ran web search: timeline rendering
           ── Edited /repo/packages/core-ui/src/format-timeline-text.ts +1 -1
             @@ -1 +1 @@
@@ -960,8 +964,10 @@ describe("timeline CLI rendering snapshots", () => {
     expect(timeline.turnRows[0]?.summaryCount).toBe(2);
     expect(timeline.text).toMatchInlineSnapshot(`
       "── Worked for (4ms) ────────────────────────────────────────
-        ── Explored 1 search, ran 1 command
-          ── Searched for TODO in packages/core-ui
+        ── Ran 2 commands
+          ── Ran rg TODO packages/core-ui
+            $ rg TODO packages/core-ui
+            packages/core-ui/src/a.ts:10: TODO
           ── Ran pnpm test
             $ pnpm test
             Tests passed
@@ -1122,8 +1128,9 @@ describe("timeline CLI rendering snapshots", () => {
       ── Assistant ───────────────────────────────────────────────
       I found the test path.
 
-      ── Searched for setState in packages/excalidraw/tests/helpers/ui.ts
-        $ rg setState packages/excalidraw/tests/helpers/ui.ts"
+      ── Ran rg setState packages/excalidraw/tests/helpers/ui.ts ─
+        $ rg setState packages/excalidraw/tests/helpers/ui.ts
+        packages/excalidraw/tests/helpers/ui.ts:42: setState"
     `);
   });
 
@@ -2168,11 +2175,12 @@ describe("timeline CLI rendering snapshots", () => {
 
     expect(timeline.text).toMatchInlineSnapshot(`
       "── Worked for (7ms) ────────────────────────────────────────
-        ── Explored 1 file, 2 lists, 1 search
+        ── Explored 1 file, 2 lists, ran 1 command
           ── Read src/a.ts
           ── Listed files in src
           ── Listed files in test
-          ── Searched for TODO in src
+          ── Ran rg TODO src
+            $ rg TODO src
 
       ── Assistant ───────────────────────────────────────────────
       Done."

--- a/packages/thread-view/test/tool-call-parsing.test.ts
+++ b/packages/thread-view/test/tool-call-parsing.test.ts
@@ -5,15 +5,7 @@ import {
 } from "../src/tool-call-parsing.js";
 
 describe("tool-call shell parsing", () => {
-  it("treats quoted shell operators as literal arguments", () => {
-    expect(parseShellCommandIntents('grep "a|b" "src > docs.txt"')).toEqual([
-      {
-        type: "search",
-        cmd: 'grep "a|b" "src > docs.txt"',
-        query: "a|b",
-        path: "src > docs.txt",
-      },
-    ]);
+  it("keeps read and list intents for shell commands", () => {
     expect(parseShellCommandIntents('cat ">"')).toEqual([
       {
         type: "read",
@@ -22,6 +14,30 @@ describe("tool-call shell parsing", () => {
         path: ">",
       },
     ]);
+    expect(parseShellCommandIntents("ls -la src")).toEqual([
+      {
+        type: "list_files",
+        cmd: "ls -la src",
+        path: "src",
+      },
+    ]);
+  });
+
+  it("does not infer search intents from shell commands", () => {
+    expect(parseShellCommandIntents('grep "a|b" src/app.ts')).toEqual([]);
+    expect(parseShellCommandIntents("rg TODO src")).toEqual([]);
+
+    const incidentCommand =
+      "rm -f result && nix build . 2>&1 | " +
+      "grep -vE '^warning|^Using saved|SQLite' | tail -3";
+    expect(parseShellCommandIntents(incidentCommand)).toEqual([]);
+
+    const multilineCommand =
+      "git ls-tree -d main packages/ | head -30\n" +
+      'echo "==="\n' +
+      "git show main:.gitignore 2>/dev/null | " +
+      "grep -E 'legacy-audit|timeline-replay' || echo \"(no matches)\"";
+    expect(parseShellCommandIntents(multilineCommand)).toEqual([]);
   });
 
   it("disqualifies commands with unquoted write redirects", () => {
@@ -32,34 +48,16 @@ describe("tool-call shell parsing", () => {
 
   it("unwraps known shell wrappers before intent parsing", () => {
     const command = extractShellCommandFromString(
-      '/bin/zsh -lc "grep \\"a|b\\" src/app.ts"',
+      '/bin/zsh -lc "cat src/app.ts"',
     );
 
-    expect(command).toBe('grep "a|b" src/app.ts');
+    expect(command).toBe("cat src/app.ts");
     expect(parseShellCommandIntents(command)).toEqual([
       {
-        type: "search",
-        cmd: 'grep "a|b" src/app.ts',
-        query: "a|b",
+        type: "read",
+        cmd: "cat src/app.ts",
+        name: "cat",
         path: "src/app.ts",
-      },
-    ]);
-  });
-
-  it("treats unquoted newlines as shell segment boundaries", () => {
-    const command =
-      "git ls-tree -d main packages/ | head -30\n" +
-      'echo "==="\n' +
-      "git show main:.gitignore 2>/dev/null | grep -E 'legacy-audit|timeline-replay' || echo \"(no matches)\"";
-
-    expect(
-      parseShellCommandIntents(command),
-    ).toEqual([
-      {
-        type: "search",
-        cmd: command,
-        query: "legacy-audit|timeline-replay",
-        path: null,
       },
     ]);
   });

--- a/plans/pi-session-tool-precedence-and-search-intents.md
+++ b/plans/pi-session-tool-precedence-and-search-intents.md
@@ -1,0 +1,89 @@
+# Handoff: pi-bubblewrap sandboxing is silently void under bb (bash), and "Searching for…" rows come from sniffed bash commands
+
+> **Status (2026-08-24):** historical. Bug A described the in-process Pi SDK
+> bridge (`packages/agent-runtime/src/pi/…`), which #2325 replaced with a
+> `pi --mode rpc` child that registers bb's tools through pi's own extension
+> API, so the `customTools` precedence it analyzes no longer exists. Bug B's
+> fix landed as "fix(thread-view): stop inferring shell searches". Kept for
+> the production analysis.
+
+Filed 2026-08-23 from live incident analysis on ryzen (bb 0.39.0-unstable-2026-08-23, pi 0.84.0).
+Author thread: nixos-config / thr_jycipttndr. Two independent bugs, two small patches, one verification pass.
+
+## Background (what happened in production)
+
+1. With the pi-bubblewrap pi extension loaded and healthy (its status card rendered, its slash commands and approval dialogs worked), **bash tool calls were never sandboxed**: they spawned as plain `/bin/bash -c` direct children of the bridge worker process, with the real `$HOME` and no bwrap anywhere in the tree. Verified on two threads sharing bridge PID:
+   - `ps --ppid <bridge-pid> -o pid,stat,etime,cmd` during a bash call → `/bin/bash -c …` directly, no guardian/bwrap layers.
+   - Inside a bash call: `HOME=/home/mbullington` (a wrapped call would land in `*/pi-bubblewrap/state/*/home`).
+   Meanwhile read/grep/find/ls **are** still extension-wrapped (a `read` outside the project root was refused with the extension's own `path escapes sandbox read roots` message). So the sandbox holds for every tool except the one that can do everything.
+2. A 7-minute `nix build … | grep -vE '^warning|^Using saved|SQLite' | tail -3` bash call rendered in the thread UI as **"Exploring 2 searches / Searching for ^warning|^Using saved|SQLite"** with a spinner for the whole duration. It looked like a hung grep tool; it was a normal long build. The pattern matched the pipeline's inline grep verbatim (confirmed in `/proc/<pid>/cmdline`).
+
+## Bug A — bridge `customTools` always replace extension-registered core tools
+
+Mechanism chain (all verified in source):
+
+1. `packages/agent-runtime/src/pi/session-params.ts` (~L70–86): `shellEnvOverrides` always contains `BB_THREAD_ID` (`/** Always carries BB_THREAD_ID; pi applies it as its shell env policy. */`).
+2. `packages/agent-runtime/src/pi/bridge/sdk-session.ts` (~L150–190): `buildSessionCustomTools()` pushes `createBashToolWithShellEnvOverlay()` whenever `shellEnvOverrides` is non-empty → **always**, for every session on every thread. It builds pi's stock bash via `createBashToolDefinition(cwd, { commandPrefix, shellPath, spawnHook })` and returns it as a `customTools` entry named `bash`.
+3. pi precedence (`@earendil-works/pi-coding-agent@0.84.0`, `dist/core/agent-session.js`, `_refreshToolRegistry` ~L1940–1975):
+   ```js
+   const definitionRegistry = new Map(/* baseToolDefinitions (built-ins) */);
+   const allCustomTools = [ ...registeredTools /* extensions */, ...this._customTools /* sdk */ ];
+   for (const tool of allCustomTools) definitionRegistry.set(tool.definition.name, tool); // later wins
+   ```
+   Built-ins seeded → extension `registerTool()` overwrites built-ins → SDK `customTools` overwrite extensions. So bb's bash definition replaces pi-bubblewrap's sandboxed bash every session, silently.
+
+Why the overlay exists (keep this constraint): sdk-session.ts comment — "This is intentionally bash-only; non-bash tools must not depend on per-thread env in this shared bridge process." Multiple threads share one bridge process, so `BB_THREAD_ID`/thread env vars must be injected per-spawn, not via process env. Any fix must preserve per-thread bash env overlay semantics.
+
+### Fix direction (recommended)
+
+Use pi's `baseToolsOverride` session option instead of `customTools` for the bash overlay. Pi builds base tools from `_baseToolsOverride` when provided (`agent-session.js` `_buildRuntime` ~L2021: `this._baseToolsOverride ? … : createAllToolDefinitions(this._cwd, …)`), and base tools are the layer extensions overwrite — so an extension's `bash` registration wins over bb's override, while sessions without such an extension get the env-overlaid bash. That restores the documented layering (built-ins < extensions) without changing pi.
+
+- `baseToolsOverride` replaces the **whole** base tool set, so construct the full set (`createAllToolDefinitions`, or the individual `create*ToolDefinition` builders bb already imports for `bash`) and substitute bb's env-overlay bash into it. Verify `createAllToolDefinitions` (or each needed builder) is exported from `@earendil-works/pi-coding-agent`; if not, compose the map from the exported per-tool builders.
+- Document the tradeoff in the commit message: when an extension registers `bash`, bb's env overlay yields to it. That is the desired security posture (sandboxing beats env convenience); pi-bubblewrap injects `PI_*`/allowlist env into its sandbox already, and it does not know `BB_THREAD_ID` — acceptable; note `user_bash` (`!` commands) keeps its own path either way.
+- Alternative (larger, upstream): ask/PR pi for an explicit compose point (e.g. a session-level `bashSpawnHook`/env overlay applied to the resolved bash tool, or documented precedence making extensions beat sdk customTools). Do not gate this fix on upstream.
+
+### Tests for Bug A
+
+- Extend `packages/agent-runtime/src/pi/bridge/` tests (see `bridge.conformance.test.ts`, `packages/agent-runtime/src/integration.provider-basic.test.ts`, and the fixtures under `packages/agent-runtime/src/__fixtures__/pi`): create a session with `shellEnvOverrides` plus a fake extension registering `bash`; assert the extension's definition is the one executed, and that without the extension the spawn hook still injects `BB_THREAD_ID`.
+- Keep a regression test that garden/dynamic `customTools` (`buildDynamicTools` path in `bridge.ts` `applyDynamicTools`) still win over same-named extension tools, or explicitly decide they should not — thread-view/garden tools currently rely on sdk precedence; do not change that accidentally. `applyDynamicTools` currently **overwrites** `sessionOptions.customTools` (`bridge.ts` ~L655); if you move bash env-overlay out of the `customTools` channel, make sure dynamic tools continue to merge cleanly.
+
+## Bug B — thread-view projects "search" intents out of arbitrary bash pipelines
+
+1. `packages/thread-view/src/tool-call-parsing.ts`:
+   - `classifyShellSegment` (~L589–606): any `grep`/`rg` segment of a shell command becomes an intent `{ type: "search", query: <first positional> }`.
+   - `parseShellCommandIntents` (~L667–686): splits the command into segments; write-shaped segments disqualify the whole command; otherwise the **first** search/read/list intent is projected. A leading `rm -f` segment classifies as "none" (not "write"), so `rm -f … && nix build … | grep -vE '…' | tail -3` **does** project a search intent.
+2. `packages/thread-view/src/exec-lifecycle.ts` (~L274–282): live `commandExecution` items carry `parsedIntents`, so the in-flight build renders as an in-flight search ("Searching for …") until it exits — minutes, with no sign a build is running.
+3. The bundle header ("Exploring N searches") then aggregates these rows (see the comment at exec-lifecycle.ts ~L333–336).
+
+### Fix direction (recommended)
+
+Per user direction: "Searching" rows should come from structured search **tools** only (`isStructuredSearchToolName`, tool-call-parsing.ts L15 — note it only lists `Grep`/`grep`; consider `ffgrep` if desirable), not from grep-shaped segments of long-running shell commands. Two acceptable shapes:
+
+- **Narrow (preferred):** stop projecting `search` intents from `parsedIntents` on live `commandExecution` items; bash greps stay inside the bash row. Keep structured-tool search rows exactly as they are.
+- **Conservative alternative:** still summarize, but label the row with the command's verb ("Running …") while the commandExecution is in flight, and only show the past-tense "Searched for …" label after completion for genuinely search-shaped commands.
+
+Whichever shape: the acceptance test is the incident command — a bash call running `nix build … 2>&1 \| grep -vE '^warning\|^Using saved\|SQLite' \| tail -3` must render as a command execution (ideally showing the `nix build …` headline), never as an in-flight "Searching for ^warning|^Using saved|SQLite" row.
+
+### Tests for Bug B
+
+- Extend/add unit tests next to `packages/thread-view/src/tool-call-parsing.ts` and `exec-lifecycle.ts` covering: piped grep filters (intent suppressed or verb-labeled), `rm -f` prefix + build pipeline (the incident command), pure `grep foo -r src` bash (decide and pin the chosen behavior), and structured `grep` tool calls (unchanged, still search rows).
+
+## Already fixed elsewhere (do not patch)
+
+- ffgrep/fffind/@-autocomplete missing under bb: pi-bubblewrap registers FFF only when `PI_BUBBLEWRAP_FFF` is set in the pi **process** env; bb runs as the `garden` **system** service on ryzen, which never inherits `home.sessionVariables` (`/proc/<garden>/environ` had zero `PI_*` vars). Fixed in nixos-config by adding `environment.PI_BUBBLEWRAP_FFF = "1"` to `modules/machine-ryzen/garden.nix`; FFF harness tests pass on-host. Takes effect on the next `nixos-rebuild switch` + `systemctl restart garden`. No bb change needed.
+- The same analysis found bb control-plane flakiness after the 2026-08-23 02:41 update (a wedged extension question that never delivered its answer on one thread; `turn.start` JSON-RPC timeout after stop on another; a third thread's bridge killed by an uncaught stale-ctx throw in `~/.pi/agent/extensions/goal.ts` `:686` in a `Timeout` callback, exit code 1). Separate issues, not in this handoff's scope.
+
+## Verification recipe (after both patches)
+
+1. `pnpm vitest run` (or the repo's per-package test commands) for `packages/agent-runtime` and `packages/thread-view`.
+2. Run a dev bb from this worktree; open a thread in a repo with pi-bubblewrap active (e.g. nixos-config, after the garden restart above). In that thread:
+   - `ps --ppid <bridge-pid> -o pid,cmd` during a bash call → guardian + `bwrap` between bridge and `/bin/bash` (not a direct child).
+   - `echo "$HOME"` in a bash tool call → points under `*/pi-bubblewrap/state/*/home`.
+   - `/bubblewrap` status matches the repo policy; ffgrep appears in the tool list.
+3. Run the incident command `nix build … \| grep -vE '…' \| tail -3` in a thread and confirm the UI shows a running command, not an in-flight search.
+
+## Guardrails
+
+- Do not change pi vendor code under `node_modules`; patch bb only (pi upstream notes belong in a comment/issue).
+- Preserve `BB_THREAD_ID` injection into every bash spawn; it is load-bearing for bb's per-thread shell policy.
+- Keep changes additive: dynamic (garden) tools, `shellPath`, and `commandPrefix` behaviors must be untouched.

--- a/plugins/keep-awake/server.test.ts
+++ b/plugins/keep-awake/server.test.ts
@@ -33,17 +33,26 @@ function hostRecord(
   id: string,
   status: HostRecord["status"] = "connected",
 ): HostRecord {
-  return {
+  const common = {
     id,
     name: id,
     type: "persistent",
-    status,
     maxPermissionMode: "full",
     lastSeenAt: null,
     lastRejectedProtocolVersion: null,
     createdAt: 1,
     updatedAt: 1,
-  };
+  } satisfies Omit<
+    Extract<HostRecord, { status: "connected" }>,
+    "status" | "connectedRuntime"
+  >;
+  return status === "connected"
+    ? {
+        ...common,
+        status,
+        connectedRuntime: { platform: "linux" },
+      }
+    : { ...common, status, connectedRuntime: null };
 }
 
 function enabledInput(input: unknown): boolean {


### PR DESCRIPTION
## Human comments

## What was wrong

Three small, independent problems from mbullington's `agent/garden-upstream-stack`, rebased onto `main`:

- Project path dialogs (new project, change workspace, add machine) assumed the local platform. On a remote host with a different OS the separator, root, and home heuristics were wrong.
- The thread view inferred a "search" intent from any shell command that mentioned `grep`/`rg`, so an unrelated bash call rendered as a search row.
- Raw Sonner toasts (plugin toasts, provider notifications) had no close button, and `AppToastContent` never rendered one for custom content.

## What changed

- `apps/app` path dialogs and `useLocalPathPicker` take the selected host's platform; `HostResponse` exposes it (`packages/server-contract/src/api/hosts.ts`, `packages/sdk/src/areas/hosts.ts`). Offline hosts fall back to the prop platform.
- `packages/thread-view/src/tool-call-parsing.ts` stops inferring search intents from shell text; tests and CLI rendering snapshots updated. The handoff notes live in `plans/pi-session-tool-precedence-and-search-intents.md`.
- `apps/app/src/main.tsx` enables Sonner's `closeButton`; `AppToastContent` renders its own dismiss X.

No wire change. Bottom of the stack: no prerequisite.

## How you verified

`pnpm exec turbo run typecheck` on this layer, plus `turbo run test` for `@bb/app`, `@bb/server`, `@bb/server-contract`, `@bb/sdk`, `@bb/thread-view`, `@bb/mobile`, `@bb/host-daemon` (see the stack validation log in the thread).

Fixes: none (upstream stack split).

> AGENT GENERATED
