### PR TITLE
Add the Escape-to-stop composer setting

### DIFF
--- a/apps/app/src/components/promptbox/ComposerEditorSlot.tsx
+++ b/apps/app/src/components/promptbox/ComposerEditorSlot.tsx
@@ -19,13 +19,6 @@ const COMPOSER_EDITOR_MAX_HEIGHT_BY_LAYOUT: Record<
   "root-compose": "calc(70dvh - 3rem)",
 };
 
-// TipTap's `blur` command defers to the next animation frame, so blur the
-// editor DOM directly and drop the caret with it.
-function blurComposerEditor(editor: Editor): void {
-  editor.view.dom.blur();
-  window.getSelection()?.removeAllRanges();
-}
-
 /** BB's editor region with the effects already resolved by the Composer host. */
 export function ComposerEditorSlot({
   editor,
@@ -35,6 +28,7 @@ export function ComposerEditorSlot({
   minHeight,
   layout,
   resolveMentionLink,
+  onLockedEditorEscape,
 }: {
   editor: Editor | null;
   scrollContainerRef: RefObject<HTMLDivElement | null>;
@@ -43,6 +37,7 @@ export function ComposerEditorSlot({
   minHeight: number;
   layout: ComposerEditorLayout;
   resolveMentionLink: PromptMentionLinkResolver | undefined;
+  onLockedEditorEscape: (event: KeyboardEvent) => boolean;
 }) {
   return (
     <div
@@ -74,8 +69,9 @@ export function ComposerEditorSlot({
           onKeyDown={(event) => {
             if (event.key !== "Escape") return;
             if (editor === null || editor.isEditable) return;
-            event.preventDefault();
-            blurComposerEditor(editor);
+            if (onLockedEditorEscape(event.nativeEvent)) {
+              event.preventDefault();
+            }
           }}
           data-promptbox-editor-content=""
           data-promptbox-compact-content={isCompactLayout ? "" : undefined}

--- a/apps/app/src/components/promptbox/FollowUpPromptBox.stories.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.stories.tsx
@@ -712,6 +712,7 @@ function Row({
                   promptPlaceholder: resolvedPlaceholder,
                   canModifierSubmit: true,
                   steerActiveThreadOnEnter: false,
+                  composerEscapeBehavior: "blur",
                   submitMode: { kind: "ready" },
                   threadRuntimeDisplayStatus,
                 }}
@@ -804,6 +805,7 @@ function Row({
                 promptPlaceholder: resolvedPlaceholder,
                 canModifierSubmit: submitMode.kind === "queue",
                 steerActiveThreadOnEnter: false,
+                composerEscapeBehavior: "blur",
                 submitMode,
                 threadRuntimeDisplayStatus,
               }

--- a/apps/app/src/components/promptbox/FollowUpPromptBox.test.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.test.tsx
@@ -211,6 +211,7 @@ function createFollowUpPromptBoxProps(
       promptPlaceholder: "Ask for a follow-up",
       canModifierSubmit: true,
       steerActiveThreadOnEnter: false,
+      composerEscapeBehavior: "blur",
       submitMode,
       threadRuntimeDisplayStatus:
         submitMode.kind === "queue" ? "active" : "idle",

--- a/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
@@ -13,6 +13,7 @@ import {
   type RefObject,
 } from "react";
 import type {
+  ComposerEscapeBehavior,
   PromptTextMention,
   ThreadRuntimeDisplayStatus,
   ThreadTimelineActivePromptMode,
@@ -161,6 +162,7 @@ export interface FollowUpComposerProps {
    * for queue. False preserves the default Enter-to-queue behavior.
    */
   steerActiveThreadOnEnter: boolean;
+  composerEscapeBehavior: ComposerEscapeBehavior;
   submitMode: FollowUpSubmitMode;
   /** Used by the scroll-to-bottom button to know whether the runtime is actively streaming. */
   threadRuntimeDisplayStatus: ThreadRuntimeDisplayStatus;
@@ -749,6 +751,7 @@ function FollowUpPromptBoxWithComposer({
         mentionMenuPlacement="top"
         submission={{
           onStop: onStopRuntime,
+          escapeBehavior: composer.composerEscapeBehavior,
           isSubmitting: composer.isFollowUpSubmitting || isStopping,
           disabled:
             !canSubmit ||

--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -1561,12 +1561,21 @@ describe("PromptBoxInternal escape", () => {
     expect(document.activeElement).not.toBe(editor);
   });
 
-  it("routes Escape to onEscape instead of blurring the editor", async () => {
+  it("routes Escape to message editing before a configured stop", async () => {
     const onEscape = vi.fn();
+    const onStop = vi.fn();
     const promptBoxRef = createRef<PromptBoxHandle>();
     render(
       <PromptBoxInternal
-        {...createPromptBoxProps({ onEscape, value: "Edited message" })}
+        {...createPromptBoxProps({
+          onEscape,
+          submission: {
+            escapeBehavior: "stop-running-thread",
+            isRunning: true,
+            onStop,
+          },
+          value: "Edited message",
+        })}
         promptBoxRef={promptBoxRef}
       />,
     );
@@ -1577,18 +1586,23 @@ describe("PromptBoxInternal escape", () => {
     });
 
     expect(onEscape).toHaveBeenCalledTimes(1);
+    expect(onStop).not.toHaveBeenCalled();
     expect(wasNotCanceled).toBe(false);
     // The cancel action owns what happens next; the editor must not also blur.
     expect(document.activeElement).toBe(getPromptEditorElement());
   });
 
-  it("dismisses an open typeahead before Escape reaches onEscape", async () => {
-    const onEscape = vi.fn();
+  it("dismisses an open typeahead before a configured stop", async () => {
+    const onStop = vi.fn();
     const promptBoxRef = createRef<PromptBoxHandle>();
     render(
       <PromptBoxInternal
         {...createPromptBoxProps({
-          onEscape,
+          submission: {
+            escapeBehavior: "stop-running-thread",
+            isRunning: true,
+            onStop,
+          },
           value: "/re",
           typeahead: buildTypeaheadConfig({
             commandSuggestions: [
@@ -1611,13 +1625,162 @@ describe("PromptBoxInternal escape", () => {
 
     fireEvent.keyDown(getPromptEditorElement(), { key: "Escape" });
 
-    expect(onEscape).not.toHaveBeenCalled();
+    expect(onStop).not.toHaveBeenCalled();
     await waitFor(() =>
       expect(screen.queryByRole("button", { name: "review" })).toBeNull(),
     );
 
     fireEvent.keyDown(getPromptEditorElement(), { key: "Escape" });
-    expect(onEscape).toHaveBeenCalledTimes(1);
+    expect(onStop).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops a running composer and retains focus when enabled", async () => {
+    const onStop = vi.fn();
+    const promptBoxRef = createRef<PromptBoxHandle>();
+    render(
+      <PromptBoxInternal
+        {...createPromptBoxProps({
+          submission: {
+            escapeBehavior: "stop-running-thread",
+            isRunning: true,
+            onStop,
+          },
+        })}
+        promptBoxRef={promptBoxRef}
+      />,
+    );
+    await focusPromptEnd(promptBoxRef);
+    const editor = getPromptEditorElement();
+
+    const wasNotCanceled = fireEvent.keyDown(editor, { key: "Escape" });
+
+    expect(wasNotCanceled).toBe(false);
+    expect(onStop).toHaveBeenCalledOnce();
+    expect(document.activeElement).toBe(editor);
+  });
+
+  it("blurs an idle composer in stop-running-thread mode", async () => {
+    const onStop = vi.fn();
+    const promptBoxRef = createRef<PromptBoxHandle>();
+    render(
+      <PromptBoxInternal
+        {...createPromptBoxProps({
+          submission: {
+            escapeBehavior: "stop-running-thread",
+            isRunning: false,
+            onStop,
+          },
+        })}
+        promptBoxRef={promptBoxRef}
+      />,
+    );
+    await focusPromptEnd(promptBoxRef);
+    const editor = getPromptEditorElement();
+
+    fireEvent.keyDown(editor, { key: "Escape" });
+
+    expect(onStop).not.toHaveBeenCalled();
+    expect(document.activeElement).not.toBe(editor);
+  });
+
+  it.each([
+    ["Alt", { altKey: true }],
+    ["Control", { ctrlKey: true }],
+    ["Meta", { metaKey: true }],
+    ["Shift", { shiftKey: true }],
+    ["repeat", { repeat: true }],
+    ["composition", { isComposing: true }],
+  ])("does not stop for %s Escape", async (_name, init) => {
+    const onStop = vi.fn();
+    const promptBoxRef = createRef<PromptBoxHandle>();
+    render(
+      <PromptBoxInternal
+        {...createPromptBoxProps({
+          submission: {
+            escapeBehavior: "stop-running-thread",
+            isRunning: true,
+            onStop,
+          },
+        })}
+        promptBoxRef={promptBoxRef}
+      />,
+    );
+    await focusPromptEnd(promptBoxRef);
+    const editor = getPromptEditorElement();
+
+    fireEvent.keyDown(editor, { key: "Escape", ...init });
+
+    expect(onStop).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(editor);
+  });
+
+  it("leaves an Escape already consumed by a dialog untouched", async () => {
+    const onStop = vi.fn();
+    const promptBoxRef = createRef<PromptBoxHandle>();
+    render(
+      <PromptBoxInternal
+        {...createPromptBoxProps({
+          submission: {
+            escapeBehavior: "stop-running-thread",
+            isRunning: true,
+            onStop,
+          },
+        })}
+        promptBoxRef={promptBoxRef}
+      />,
+    );
+    await focusPromptEnd(promptBoxRef);
+    const editor = getPromptEditorElement();
+    const event = new KeyboardEvent("keydown", {
+      key: "Escape",
+      bubbles: true,
+      cancelable: true,
+    });
+    event.preventDefault();
+
+    editor.dispatchEvent(event);
+
+    expect(onStop).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(editor);
+  });
+
+  it("stops only the focused split composer", () => {
+    const stopLeft = vi.fn();
+    const stopRight = vi.fn();
+    render(
+      <>
+        <PromptBoxInternal
+          {...createPromptBoxProps({
+            id: "left-composer",
+            submission: {
+              escapeBehavior: "stop-running-thread",
+              isRunning: true,
+              onStop: stopLeft,
+            },
+          })}
+        />
+        <PromptBoxInternal
+          {...createPromptBoxProps({
+            id: "right-composer",
+            submission: {
+              escapeBehavior: "stop-running-thread",
+              isRunning: true,
+              onStop: stopRight,
+            },
+          })}
+        />
+      </>,
+    );
+    const editors = document.querySelectorAll<HTMLElement>(".ProseMirror");
+    const rightEditor = editors[1];
+    if (!rightEditor) throw new Error("Expected right split composer");
+    rightEditor.focus();
+
+    fireEvent.keyDown(rightEditor, { key: "Escape" });
+
+    expect(stopLeft).not.toHaveBeenCalled();
+    expect(stopRight).toHaveBeenCalledOnce();
+    expect(document.activeElement).toBe(rightEditor);
   });
 });
 
@@ -1799,7 +1962,8 @@ describe("PromptBoxInternal plugin composer actions", () => {
     warnSpy.mockRestore();
   });
 
-  it("makes the editor read-only while locked and restores it on unlock", async () => {
+  it("keeps Escape-to-stop available while a plugin locks the editor", async () => {
+    const onStop = vi.fn();
     function LockAction() {
       const composer = useComposer();
       const view = useComposerView();
@@ -1851,7 +2015,14 @@ describe("PromptBoxInternal plugin composer actions", () => {
       <MemoryRouter>
         <PluginComposerHostProvider value={host}>
           <PromptBoxInternal
-            {...createPromptBoxProps({ value: "Thread draft" })}
+            {...createPromptBoxProps({
+              submission: {
+                escapeBehavior: "stop-running-thread",
+                isRunning: true,
+                onStop,
+              },
+              value: "Thread draft",
+            })}
           />
         </PluginComposerHostProvider>
       </MemoryRouter>,
@@ -1881,6 +2052,10 @@ describe("PromptBoxInternal plugin composer actions", () => {
       ).toBe("true");
     });
     expect(screen.getByRole("button", { name: "Submit (Enter)" })).toBeTruthy();
+    editor.focus();
+    fireEvent.keyDown(editor, { key: "Escape" });
+    expect(onStop).toHaveBeenCalledOnce();
+    expect(document.activeElement).toBe(editor);
 
     fireEvent.click(
       screen.getByRole("button", { name: "Toggle lock (thread)" }),
@@ -3997,11 +4172,19 @@ describe("voice recording escape", () => {
     return event;
   }
 
-  it("cancels the recording on Escape and consumes the event before the composer's dismiss", () => {
+  it("cancels recording before the configured running-thread stop", () => {
     const cancel = vi.fn();
+    const onStop = vi.fn();
     render(
       <PromptBoxInternal
-        {...createPromptBoxProps({ voice: voiceConfig({ cancel }) })}
+        {...createPromptBoxProps({
+          submission: {
+            escapeBehavior: "stop-running-thread",
+            isRunning: true,
+            onStop,
+          },
+          voice: voiceConfig({ cancel }),
+        })}
       />,
     );
 
@@ -4015,6 +4198,7 @@ describe("voice recording escape", () => {
     window.removeEventListener("keydown", onWindowEscape);
 
     expect(cancel).toHaveBeenCalledTimes(1);
+    expect(onStop).not.toHaveBeenCalled();
     expect(event.defaultPrevented).toBe(true);
     expect(dismiss).not.toHaveBeenCalled();
   });

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -1,4 +1,5 @@
 import type {
+  ComposerEscapeBehavior,
   PromptMentionCommandTrigger,
   PromptTextMention,
 } from "@bb/domain";
@@ -210,6 +211,7 @@ export interface PromptBoxSubmissionConfig {
   title?: string;
   isRunning?: boolean;
   onStop?: () => void;
+  escapeBehavior?: ComposerEscapeBehavior;
   onModifierSubmit?: () => void;
 }
 
@@ -1145,6 +1147,20 @@ function blurPromptEditor(editor: Editor | null | undefined): void {
   window.getSelection()?.removeAllRanges();
 }
 
+function isUnmodifiedComposerEscape(event: KeyboardEvent): boolean {
+  return (
+    event.key === "Escape" &&
+    !event.altKey &&
+    !event.ctrlKey &&
+    !event.metaKey &&
+    !event.shiftKey &&
+    !event.repeat &&
+    !event.isComposing &&
+    event.keyCode !== 229 &&
+    !event.defaultPrevented
+  );
+}
+
 function focusEditorAtEnd(editor: Editor): void {
   const transaction = editor.state.tr
     .setSelection(TextSelection.atEnd(editor.state.doc))
@@ -1225,6 +1241,7 @@ export function PromptBoxInternal({
     title: submitTitle = "Submit (Enter)",
     isRunning = false,
     onStop,
+    escapeBehavior = "blur",
     onModifierSubmit,
   } = submission;
   const {
@@ -2883,6 +2900,10 @@ export function PromptBoxInternal({
       ) {
         return false;
       }
+      // A dialog or another capture-phase owner has already consumed this key.
+      if (event.defaultPrevented) {
+        return false;
+      }
       // App keybindings win over the editor's own keymap. TipTap cancels the
       // chords it knows (Mod+Shift+B for a blockquote, Mod+B, Mod+Shift+7/8 for
       // lists), and the window listener skips a canceled event — so without
@@ -2983,15 +3004,20 @@ export function PromptBoxInternal({
         }
       }
 
-      // Escape releases the composer so the keyboard can reach the rest of the
-      // app — or cancels the sent-message editor when `onEscape` is provided.
-      // Higher-priority Escape behavior still runs first: the typeahead menu
-      // above dismisses itself, and voice recording cancels from a window
-      // capture listener that stops the event before the editor sees it. A
-      // locked editor never reaches here — see the editor container below.
+      // Typeahead above, voice capture, dialogs, and sent-message editing keep
+      // their existing Escape ownership. Only a plain, first Escape can reach
+      // the configurable stop action.
       if (event.key === "Escape") {
         if (onEscape) {
           onEscape();
+          return true;
+        }
+        if (!isUnmodifiedComposerEscape(event)) {
+          return false;
+        }
+        if (escapeBehavior === "stop-running-thread" && isRunning && onStop) {
+          event.preventDefault();
+          onStop();
           return true;
         }
         blurPromptEditor(currentEditor);
@@ -3120,11 +3146,14 @@ export function PromptBoxInternal({
       commandIsLoadingMore,
       dispatchAppCommandKey,
       dismissActiveTrigger,
+      escapeBehavior,
       history,
       isPointerCoarse,
+      isRunning,
       loadMoreCommands,
       onEscape,
       onModifierSubmit,
+      onStop,
       postCompositionKeyDownEvents,
       resetHistorySession,
       selectedIndex,
@@ -3258,6 +3287,7 @@ export function PromptBoxInternal({
               minHeight={minHeight}
               layout={editorLayout}
               resolveMentionLink={mentionResolveLink}
+              onLockedEditorEscape={handleEditorKeyDown}
             />
           </div>
 

--- a/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.test.tsx
+++ b/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.test.tsx
@@ -266,6 +266,7 @@ vi.mock("@/hooks/queries/system-queries", () => ({
     data: {
       generalSettings: {
         steerActiveThreadOnEnter: false,
+        composerEscapeBehavior: "blur",
       },
     },
   }),

--- a/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.tsx
+++ b/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.tsx
@@ -255,6 +255,9 @@ function EmbeddedThreadChatWithComposer({
   const steerActiveThreadOnEnter =
     systemConfigQuery.data?.generalSettings.steerActiveThreadOnEnter ??
     defaultAppSettings.steerActiveThreadOnEnter;
+  const composerEscapeBehavior =
+    systemConfigQuery.data?.generalSettings.composerEscapeBehavior ??
+    defaultAppSettings.composerEscapeBehavior;
   const surfaceKey = threadId;
   const markThreadRead = useMarkThreadRead();
   const stopThread = useStopThread();
@@ -826,11 +829,13 @@ function EmbeddedThreadChatWithComposer({
       promptPlaceholder: composerPlaceholder,
       canModifierSubmit: canSubmitModifierShortcut,
       steerActiveThreadOnEnter,
+      composerEscapeBehavior,
       submitMode,
       threadRuntimeDisplayStatus: displayStatus,
     }),
     [
       canSubmitModifierShortcut,
+      composerEscapeBehavior,
       composerPlaceholder,
       currentPromptDraft,
       displayStatus,
@@ -864,6 +869,7 @@ function EmbeddedThreadChatWithComposer({
               activeComposerDraftInput.length > 0 &&
               !isUpdateQueuedMessagePending,
             steerActiveThreadOnEnter: false,
+            composerEscapeBehavior,
             submitMode: { kind: "ready" },
             threadRuntimeDisplayStatus: displayStatus,
           }
@@ -871,6 +877,7 @@ function EmbeddedThreadChatWithComposer({
     [
       activeComposerDraft,
       activeComposerDraftInput.length,
+      composerEscapeBehavior,
       composerPlaceholder,
       displayStatus,
       handleChangeMessage,

--- a/apps/app/src/views/thread-detail/ThreadDetailPromptArea.keystrokes.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailPromptArea.keystrokes.test.tsx
@@ -398,6 +398,7 @@ function buildPromptArea({
         canUseGitUi={false}
         childPendingInteractions={[]}
         childThreadsSection={null}
+        composerEscapeBehavior="blur"
         composerFocusRequestNonce={0}
         contextBannerMergeBase={null}
         environmentGoneStatus={null}

--- a/apps/app/src/views/thread-detail/ThreadDetailPromptArea.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailPromptArea.test.tsx
@@ -110,8 +110,11 @@ vi.mock("@/components/promptbox/FollowUpPromptBox", async () => {
         onChangeMessage: (message: string, mentions: []) => void;
         onEscape?: () => void;
         onSubmit: () => void;
+        composerEscapeBehavior: "blur" | "stop-running-thread";
         submitTitle?: string;
-        submitMode: { kind: string; reason?: string };
+        submitMode:
+          | { kind: "queue" | "stop-only"; onStop: () => void }
+          | { kind: string; reason?: string };
       } | null;
       execution: {
         footerAction?: {
@@ -161,7 +164,10 @@ vi.mock("@/components/promptbox/FollowUpPromptBox", async () => {
           {pendingInteraction ? "true" : "false"}
         </div>
         <div data-testid="submit-mode">
-          {composer?.submitMode.kind}:{composer?.submitMode.reason ?? ""}
+          {composer?.submitMode.kind}:
+          {composer && "reason" in composer.submitMode
+            ? (composer.submitMode.reason ?? "")
+            : ""}
         </div>
         <div data-testid="submit-title">
           {composer?.submitTitle ?? "Submit"}
@@ -252,11 +258,21 @@ vi.mock("@/components/promptbox/FollowUpPromptBox", async () => {
             <button type="button" onClick={composer.onSubmit}>
               Submit composer
             </button>
-            {composer.onEscape ? (
-              <button type="button" onClick={composer.onEscape}>
-                Escape composer
-              </button>
-            ) : null}
+            <button
+              type="button"
+              onClick={() => {
+                if (composer.onEscape) {
+                  composer.onEscape();
+                } else if (
+                  composer.composerEscapeBehavior === "stop-running-thread" &&
+                  "onStop" in composer.submitMode
+                ) {
+                  composer.submitMode.onStop();
+                }
+              }}
+            >
+              Escape composer
+            </button>
             <button
               type="button"
               onClick={() =>
@@ -666,6 +682,7 @@ function makePluginPendingInteraction(): PendingInteraction {
 
 interface RenderPromptAreaOptions {
   activePromptMode?: ThreadTimelineActivePromptMode | null;
+  composerEscapeBehavior?: "blur" | "stop-running-thread";
   activeWorkflows?: TimelineWorkflowWorkRow[];
   goal?: ThreadTimelineGoal | null;
   modelFallback?: ThreadTimelineModelFallback | null;
@@ -678,6 +695,7 @@ interface RenderPromptAreaOptions {
 
 function buildPromptAreaElement({
   activePromptMode = null,
+  composerEscapeBehavior = "blur",
   activeWorkflows = [],
   goal = null,
   modelFallback = null,
@@ -696,6 +714,7 @@ function buildPromptAreaElement({
       canUseGitUi={false}
       childPendingInteractions={childPendingInteractions}
       childThreadsSection={null}
+      composerEscapeBehavior={composerEscapeBehavior}
       composerFocusRequestNonce={0}
       contextBannerMergeBase={null}
       environmentGoneStatus={null}
@@ -850,17 +869,36 @@ describe("ThreadDetailPromptArea", () => {
     );
     expect(onCancel).toHaveBeenCalledTimes(1);
 
-    // Escape in the edit composer cancels too; the bottom composer keeps its
-    // default Escape behavior (no onEscape).
-    expect(
-      within(bottomComposer!).queryByRole("button", {
-        name: "Escape composer",
-      }),
-    ).toBeNull();
+    // Escape in the edit composer cancels; the bottom composer has no edit
+    // action and remains on its default blur behavior.
     fireEvent.click(
       inlineEditor.getByRole("button", { name: "Escape composer" }),
     );
     expect(onCancel).toHaveBeenCalledTimes(2);
+    fireEvent.click(
+      within(bottomComposer!).getByRole("button", {
+        name: "Escape composer",
+      }),
+    );
+    expect(onCancel).toHaveBeenCalledTimes(2);
+  });
+
+  it("binds Escape stop to the composer-owned running thread", () => {
+    renderPromptArea({
+      composerEscapeBehavior: "stop-running-thread",
+      thread: makeThread({
+        id: "thr_escape_owner",
+        runtime: {
+          displayStatus: "active",
+          hostReconnectGraceExpiresAt: null,
+        },
+        status: "active",
+      }),
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Escape composer" }));
+
+    expect(mocks.stopThreadMutate).toHaveBeenCalledWith("thr_escape_owner");
   });
 
   it("blocks a staged sent-message edit when the thread becomes ineligible", () => {

--- a/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/promptbox/follow-up-placeholder";
 import { PERSONAL_PROJECT_ID } from "@bb/domain";
 import type {
+  ComposerEscapeBehavior,
   EnvironmentStatus,
   PendingInteraction,
   PromptInput,
@@ -217,6 +218,7 @@ interface ThreadDetailPromptAreaProps {
   /** Present only while a sent-message editor is mounted in the timeline. */
   sentMessageEdit?: ThreadDetailSentMessageEdit;
   steerActiveThreadOnEnter: boolean;
+  composerEscapeBehavior: ComposerEscapeBehavior;
   /**
    * Bumped by the timeline host each time a quote is appended to the shared
    * draft via "Add to chat", so the composer can focus its caret at the end —
@@ -230,6 +232,7 @@ interface InlineDraftComposerOptions {
   attachments: FollowUpPromptBoxProps["attachments"];
   canModifierSubmit: boolean;
   compactPromptPlaceholder: string;
+  composerEscapeBehavior: ComposerEscapeBehavior;
   composerId: string;
   /** Live draft under edit; supplies the message text, mentions, and history draft. */
   draft: PromptDraftState;
@@ -289,6 +292,7 @@ function buildInlineDraftComposer(options: InlineDraftComposerOptions) {
         promptPlaceholder: options.promptPlaceholder,
         canModifierSubmit: options.canModifierSubmit,
         steerActiveThreadOnEnter: false,
+        composerEscapeBehavior: options.composerEscapeBehavior,
         submitMode: options.submitMode,
         threadRuntimeDisplayStatus: options.threadRuntimeDisplayStatus,
       }}
@@ -440,6 +444,7 @@ export function ThreadDetailPromptArea({
   sendMessage,
   sentMessageEdit,
   steerActiveThreadOnEnter,
+  composerEscapeBehavior,
   composerFocusRequestNonce,
   thread,
 }: ThreadDetailPromptAreaProps) {
@@ -1080,12 +1085,14 @@ export function ThreadDetailPromptArea({
       promptPlaceholder,
       canModifierSubmit: canSubmitModifierShortcut,
       steerActiveThreadOnEnter,
+      composerEscapeBehavior,
       submitMode,
       threadRuntimeDisplayStatus: runtimeDisplayStatus,
     }),
     [
       canSubmitModifierShortcut,
       compactPromptPlaceholder,
+      composerEscapeBehavior,
       currentPromptDraft,
       handleBottomComposerModifierSubmit,
       handleBottomComposerSubmit,
@@ -1379,6 +1386,7 @@ export function ThreadDetailPromptArea({
         canModifierSubmit:
           activeComposerDraftInput.length > 0 && !isUpdateQueuedMessagePending,
         compactPromptPlaceholder,
+        composerEscapeBehavior,
         composerId: `${THREAD_DETAIL_COMPOSER_TEXTAREA_ID}-queued-${queuedMessageId}`,
         draft: activeComposerDraft,
         editFocusNonce,
@@ -1405,6 +1413,7 @@ export function ThreadDetailPromptArea({
     activeComposerDraft,
     activeComposerDraftInput.length,
     compactPromptPlaceholder,
+    composerEscapeBehavior,
     dismissInlineQueuedMessageEditor,
     editFocusNonce,
     handleAttachInlineFiles,
@@ -1498,6 +1507,7 @@ export function ThreadDetailPromptArea({
           },
           canModifierSubmit: canSubmitSentMessageEdit,
           compactPromptPlaceholder: "Edit message",
+          composerEscapeBehavior,
           composerId: `${THREAD_DETAIL_COMPOSER_TEXTAREA_ID}-sent-${operationId}`,
           draft,
           editFocusNonce,
@@ -1534,6 +1544,7 @@ export function ThreadDetailPromptArea({
     bottomPermissionConfig,
     canSubmitSentMessageEdit,
     compactExecutionConfig,
+    composerEscapeBehavior,
     editFocusNonce,
     handleAttachSentMessageFiles,
     handleSentMessageEditSubmit,

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -2606,6 +2606,10 @@ function ThreadDetailViewInternal(props: ThreadRoutePathArgs) {
         systemConfigQuery.data?.generalSettings.steerActiveThreadOnEnter ??
         defaultAppSettings.steerActiveThreadOnEnter
       }
+      composerEscapeBehavior={
+        systemConfigQuery.data?.generalSettings.composerEscapeBehavior ??
+        defaultAppSettings.composerEscapeBehavior
+      }
       pendingInteractions={pendingInteractions}
       pendingInteractionsInitialLoading={pendingInteractionsInitialLoading}
       pendingTodos={pendingTodos}

--- a/apps/cli/src/__tests__/command-output/settings.test.ts
+++ b/apps/cli/src/__tests__/command-output/settings.test.ts
@@ -90,6 +90,29 @@ describe("bb settings commands", () => {
     });
   });
 
+  it("updates composer Escape behavior while preserving the full contract", async () => {
+    const put = vi.fn(async ({ json }) => json);
+    stubServerApi({
+      "v1.system.config.$get": vi.fn(async () => ({
+        generalSettings: defaultAppSettings,
+        experiments: defaultExperiments,
+      })),
+      "v1.settings.general.$put": put,
+    });
+
+    await runCommand(
+      ["settings", "general", "composerEscapeBehavior", "stop-running-thread"],
+      register,
+    );
+
+    expect(put).toHaveBeenCalledWith({
+      json: {
+        ...defaultAppSettings,
+        composerEscapeBehavior: "stop-running-thread",
+      },
+    });
+  });
+
   it("enables the changelog preview experiment", async () => {
     const put = vi.fn(async ({ json }) => json);
     stubServerApi({

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
@@ -93,6 +93,12 @@ message agents, or inspect projects, providers, and environments.
   the software keyboard keeps Return as a newline; iPadOS WebKit preserves the
   Enter shortcuts for a connected Magic Keyboard. Update the preference with
   `bb settings general steerActiveThreadOnEnter <true|false>`.
+- The `composerEscapeBehavior` General preference defaults to `blur`. Set it
+  to `stop-running-thread` to make an unmodified, non-repeated Escape stop only
+  the running thread owned by the focused composer while retaining focus. An
+  idle composer still blurs. Typeahead, dialogs, voice input, message editing,
+  and composition take priority and do not stop a thread. Update it with
+  `bb settings general composerEscapeBehavior <blur|stop-running-thread>`.
 - The `streamerMode` General preference defaults to false. Enable it to hide
   every `customModels` entry from `~/.bb/config.json` in all model lists
   (pickers, `bb provider models`, and the SDK) during a screen share. Update it

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/references/app-settings.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/references/app-settings.md
@@ -49,6 +49,18 @@ every window and client sees the same value.
   software-keyboard Return path stays a newline; iPadOS WebKit preserves the
   Enter shortcuts for a connected Magic Keyboard.
 
+## Composer Escape behavior
+
+- `composerEscapeBehavior` defaults to `blur`. Set it with
+  `bb settings general composerEscapeBehavior <blur|stop-running-thread>`.
+- `blur` moves focus out of the composer.
+- `stop-running-thread` makes an unmodified, non-repeated Escape stop only the
+  running thread owned by the focused composer and retain focus. An idle
+  composer still blurs.
+- Typeahead, dialogs, voice input, message editing, and composition keep
+  priority and do not stop a thread. Modified and repeated Escape events do
+  not stop a thread.
+
 ## Streamer mode
 
 - `streamerMode` defaults to false. Set it with

--- a/apps/server/test/system/general-settings.test.ts
+++ b/apps/server/test/system/general-settings.test.ts
@@ -26,6 +26,7 @@ describe("general settings", () => {
           ...defaultAppSettings,
           showKeyboardHints: false,
           steerActiveThreadOnEnter: true,
+          composerEscapeBehavior: "stop-running-thread",
           providerOrder: ["pi", "codex"],
           defaultProviderId: "pi",
         }),
@@ -35,6 +36,7 @@ describe("general settings", () => {
         ...defaultAppSettings,
         showKeyboardHints: false,
         steerActiveThreadOnEnter: true,
+        composerEscapeBehavior: "stop-running-thread",
         providerOrder: ["pi", "codex"],
         defaultProviderId: "pi",
       });
@@ -42,6 +44,7 @@ describe("general settings", () => {
         ...defaultAppSettings,
         showKeyboardHints: false,
         steerActiveThreadOnEnter: true,
+        composerEscapeBehavior: "stop-running-thread",
         providerOrder: ["pi", "codex"],
         defaultProviderId: "pi",
       });
@@ -54,6 +57,7 @@ describe("general settings", () => {
         ...defaultAppSettings,
         showKeyboardHints: false,
         steerActiveThreadOnEnter: true,
+        composerEscapeBehavior: "stop-running-thread",
         providerOrder: ["pi", "codex"],
         defaultProviderId: "pi",
       });
@@ -66,6 +70,20 @@ describe("general settings", () => {
         method: "PUT",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({}),
+      });
+      expect(response.status).toBe(400);
+    });
+  });
+
+  it("rejects an invalid composer Escape behavior", async () => {
+    await withTestHarness(async (harness) => {
+      const response = await harness.app.request("/api/v1/settings/general", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          ...defaultAppSettings,
+          composerEscapeBehavior: "stop-all-threads",
+        }),
       });
       expect(response.status).toBe(400);
     });

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -184,6 +184,14 @@ defaults to off: Enter queues and Command+Enter steers. When enabled, Enter
 steers and Command+Enter queues. Set it with
 `bb settings general steerActiveThreadOnEnter <true|false>`.
 
+The "Escape in composer" preference in Settings → General defaults to
+`blur`, which moves focus out of the composer. Set it to
+`stop-running-thread` to make an unmodified, non-repeated Escape stop the
+running thread owned by the focused composer while retaining focus. An idle
+composer still blurs. Typeahead, dialogs, voice input, message editing, and
+composition keep priority and do not stop a thread. Set it with
+`bb settings general composerEscapeBehavior <blur|stop-running-thread>`.
+
 The "Streamer mode" toggle in Settings → General hides every `customModels`
 entry from `~/.bb/config.json` in all model lists: the web and mobile pickers,
 `bb provider models`, and `sdk.providers.models`. Turn it on before a screen

--- a/packages/db/test/migrate.test.ts
+++ b/packages/db/test/migrate.test.ts
@@ -1625,6 +1625,7 @@ describe("migrate", () => {
       expect(getAppSettings(db)).toEqual({
         showKeyboardHints: false,
         steerActiveThreadOnEnter: true,
+        composerEscapeBehavior: "blur",
         showUnhandledProviderEvents: true,
         providerOrder: [],
         defaultProviderId: null,

--- a/packages/domain/src/app-settings.ts
+++ b/packages/domain/src/app-settings.ts
@@ -1,5 +1,13 @@
 import { z } from "zod";
 
+export const composerEscapeBehaviorSchema = z.enum([
+  "blur",
+  "stop-running-thread",
+]);
+export type ComposerEscapeBehavior = z.infer<
+  typeof composerEscapeBehaviorSchema
+>;
+
 // Adding a preference here plus its default below is the whole change: values
 // persist as key/value rows, the route and SDK carry the object as a whole,
 // and `bb settings general` takes its keys from this schema. Only the UI
@@ -17,6 +25,8 @@ export const appSettingsSchema = z
      * Command+Enter to queue a follow-up.
      */
     steerActiveThreadOnEnter: z.boolean(),
+    /** What unmodified Escape does in a focused composer. */
+    composerEscapeBehavior: composerEscapeBehaviorSchema,
     /** Show raw provider events that bb does not yet understand. */
     showUnhandledProviderEvents: z.boolean(),
     /**
@@ -43,6 +53,7 @@ export type AppSettings = z.infer<typeof appSettingsSchema>;
 export const defaultAppSettings: AppSettings = {
   showKeyboardHints: true,
   steerActiveThreadOnEnter: false,
+  composerEscapeBehavior: "blur",
   showUnhandledProviderEvents: false,
   providerOrder: [],
   defaultProviderId: null,

--- a/packages/sdk/src/public-types.ts
+++ b/packages/sdk/src/public-types.ts
@@ -3,7 +3,9 @@
  * barrel so DTO availability does not depend on a Node or browser constructor.
  */
 export type {
+  AppSettings,
   CallerExecutionInputSource,
+  ComposerEscapeBehavior,
   JsonValue,
   PermissionMode,
   PromptInput,

--- a/packages/templates/src/templates/bb-guide-customization.md
+++ b/packages/templates/src/templates/bb-guide-customization.md
@@ -88,6 +88,12 @@ reversed. Shift+Enter inserts a newline. On coarse-pointer touch devices, the
 software-keyboard Return path inserts a newline. iPadOS WebKit preserves these
 Enter shortcuts for a connected Magic Keyboard.
 
+Settings → General also includes `composerEscapeBehavior`, which defaults to
+`blur`. Set it to `stop-running-thread` to make an unmodified, non-repeated
+Escape stop only the running thread owned by the focused composer while
+retaining focus. An idle composer still blurs. Typeahead, dialogs, voice input,
+message editing, and composition keep priority and do not stop a thread.
+
 Settings → General also includes `streamerMode`, which defaults to false. Turn
 it on to hide every `customModels` entry from `~/.bb/config.json` in all model
 lists (pickers, `bb provider models`, and the SDK) during a screen share. The


### PR DESCRIPTION
## Human comments

## What was wrong

Escape in the composer could only blur it. Users who steer a running thread from the keyboard wanted Escape to stop the running thread instead, without giving up focus.

## What changed

- New app setting `composerEscapeBehavior` (`blur` | `stop-running-thread`, default `blur`) in `packages/domain/src/app-settings.ts`, exposed through the settings API/CLI (`bb settings`), documented in `docs/configuration.md` and the `bb-cli` skill's app-settings reference.
- `PromptBoxInternal` / `FollowUpPromptBox` / `ThreadDetailPromptArea` / `EmbeddedThreadChat` thread the behavior to the key handler; Settings → General gets the "Escape in composer" row.

No wire change. Prerequisite: #2441 (stack order only; no code dependency).

## How you verified

`turbo run typecheck`; `turbo run test` for `@bb/app` (promptbox, thread-detail, embedded-chat), `@bb/server` (general settings), `@bb/cli` (settings output), `@bb/db` (migrate defaults), `@bb/domain`.

Fixes: none (upstream stack split).

> AGENT GENERATED
