### PR TITLE
Reload a thread's provider session from current config

### DIFF
--- a/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.test.tsx
+++ b/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.test.tsx
@@ -20,6 +20,7 @@ const mocks = vi.hoisted(() => ({
   }>,
   queuedMessages: [] as Array<{ id: string }>,
   readTrackingThreads: [] as Array<unknown>,
+  reloadThreadMutateAsync: vi.fn(),
   sendThreadMessageMutateAsync: vi.fn(),
   threadRuntimeDisplayStatus: "idle" as string,
   // Stands in for the realtime-updated timeline query cache: rows appended here
@@ -278,6 +279,10 @@ vi.mock("@/hooks/mutations/thread-runtime-mutations", () => ({
     mutate: vi.fn(),
     isPending: false,
   }),
+  useReloadThread: () => ({
+    mutateAsync: mocks.reloadThreadMutateAsync,
+    isPending: false,
+  }),
   useSendThreadMessage: () => ({
     mutateAsync: mocks.sendThreadMessageMutateAsync,
     isPending: false,
@@ -373,6 +378,9 @@ describe("EmbeddedThreadChat", () => {
   beforeEach(() => {
     window.localStorage.clear();
     mocks.createQueuedMessageMutateAsync.mockReset().mockResolvedValue({});
+    mocks.reloadThreadMutateAsync
+      .mockReset()
+      .mockResolvedValue({ status: "reloaded" });
     mocks.sendThreadMessageMutateAsync.mockReset().mockResolvedValue({});
     mocks.markThreadReadMutate.mockReset();
     mocks.onOpenLink.mockReset();
@@ -498,6 +506,40 @@ describe("EmbeddedThreadChat", () => {
       screen.getByTestId<HTMLInputElement>("embedded-chat-composer").value,
     ).toBe("");
   });
+
+  it("reloads the provider session for exact /reload without sending a message", async () => {
+    renderEmbeddedChat();
+    fireEvent.change(screen.getByTestId("embedded-chat-composer"), {
+      target: { value: "/reload" },
+    });
+    fireEvent.click(screen.getByText("Send"));
+
+    await vi.waitFor(() => {
+      expect(mocks.reloadThreadMutateAsync).toHaveBeenCalledWith("thr_child");
+    });
+    expect(mocks.sendThreadMessageMutateAsync).not.toHaveBeenCalled();
+    expect(mocks.createQueuedMessageMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it.each(["/reload now", " /reload", "/reload ", "\\/reload"])(
+    "sends non-exact reload text to the model: %s",
+    async (text) => {
+      renderEmbeddedChat();
+      fireEvent.change(screen.getByTestId("embedded-chat-composer"), {
+        target: { value: text },
+      });
+      fireEvent.click(screen.getByText("Send"));
+
+      await vi.waitFor(() => {
+        expect(mocks.sendThreadMessageMutateAsync).toHaveBeenCalledWith(
+          expect.objectContaining({
+            input: [{ type: "text", text: text.trim(), mentions: [] }],
+          }),
+        );
+      });
+      expect(mocks.reloadThreadMutateAsync).not.toHaveBeenCalled();
+    },
+  );
 
   it("sends directly when the thread runtime is idle", async () => {
     mocks.threadRuntimeDisplayStatus = "idle";

--- a/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.tsx
+++ b/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.tsx
@@ -55,6 +55,7 @@ import { useThreadDefaultExecutionOptions } from "@/hooks/queries/thread-default
 import { useSystemConfig } from "@/hooks/queries/system-queries";
 import {
   useCreateThreadQueuedMessage,
+  useReloadThread,
   useSendThreadMessage,
   useStopThread,
 } from "@/hooks/mutations/thread-runtime-mutations";
@@ -74,6 +75,7 @@ import { useComposerAttachmentUploads } from "./useComposerAttachmentUploads";
 import { useComposerTypeahead } from "./useComposerTypeahead";
 import { useInlineQueuedMessageEditing } from "./useInlineQueuedMessageEditing";
 import { useQueuedMessageActions } from "./useQueuedMessageActions";
+import { isExactThreadReloadCommand } from "./thread-reload-command";
 
 /**
  * A thread that awaits a user interaction cannot take a prompt, so the server
@@ -261,6 +263,7 @@ function EmbeddedThreadChatWithComposer({
   const surfaceKey = threadId;
   const markThreadRead = useMarkThreadRead();
   const stopThread = useStopThread();
+  const reloadThread = useReloadThread();
   const sendThreadMessage = useSendThreadMessage();
   const createQueuedMessage = useCreateThreadQueuedMessage();
   const threadQuery = useThread(threadId);
@@ -502,10 +505,45 @@ function EmbeddedThreadChatWithComposer({
       threadId,
     ],
   );
+  const submitReloadIfExact = useCallback(
+    (submittedDraft: typeof currentPromptDraft): boolean => {
+      if (!isExactThreadReloadCommand(submittedDraft)) {
+        return false;
+      }
+      promptDraft.clearIfCurrentMatches(submittedDraft);
+      setBottomAttachmentError(null);
+      setIsTurnSubmitting(true);
+      void reloadThread
+        .mutateAsync(threadId)
+        .catch((error) => {
+          if (!isMountedRef.current) {
+            return;
+          }
+          promptDraft.restoreIfEmpty(submittedDraft);
+          appToast.error(
+            getMutationErrorMessage({
+              error,
+              fallbackMessage: "Failed to reload provider session",
+            }),
+          );
+        })
+        .finally(() => {
+          if (isMountedRef.current) {
+            setIsTurnSubmitting(false);
+          }
+        });
+      return true;
+    },
+    [promptDraft, reloadThread, setBottomAttachmentError, threadId],
+  );
+
   const handleSubmit = useCallback(() => {
     const submittedDraft = currentPromptDraft;
     const submittedInput = currentPromptDraftInput;
     if (submittedInput.length === 0 || isTurnSubmitting) {
+      return;
+    }
+    if (submitReloadIfExact(submittedDraft)) {
       return;
     }
     promptDraft.clearIfCurrentMatches(submittedDraft);
@@ -541,6 +579,7 @@ function EmbeddedThreadChatWithComposer({
     labels.sendError,
     promptDraft,
     setBottomAttachmentError,
+    submitReloadIfExact,
   ]);
 
   const isQueueMutationPending =
@@ -561,6 +600,9 @@ function EmbeddedThreadChatWithComposer({
 
     const submittedDraft = currentPromptDraft;
     const submittedInput = currentPromptDraftInput;
+    if (submitReloadIfExact(submittedDraft)) {
+      return;
+    }
     if (submittedInput.length === 0) {
       const nextQueuedMessage = queuedMessages[0];
       if (nextQueuedMessage) {
@@ -611,6 +653,7 @@ function EmbeddedThreadChatWithComposer({
     queuedMessages,
     sendThreadMessage,
     setBottomAttachmentError,
+    submitReloadIfExact,
     threadId,
   ]);
 

--- a/apps/app/src/components/thread/embedded-chat/thread-reload-command.ts
+++ b/apps/app/src/components/thread/embedded-chat/thread-reload-command.ts
@@ -1,0 +1,9 @@
+import type { PromptDraftState } from "@bb/client-core";
+
+export function isExactThreadReloadCommand(draft: PromptDraftState): boolean {
+  return (
+    draft.text === "/reload" &&
+    draft.mentions.length === 0 &&
+    draft.attachments.length === 0
+  );
+}

--- a/apps/app/src/hooks/mutations/thread-runtime-mutations.ts
+++ b/apps/app/src/hooks/mutations/thread-runtime-mutations.ts
@@ -480,6 +480,17 @@ export function useDeleteThreadQueuedMessage() {
   });
 }
 
+export function useReloadThread() {
+  return useMutation({
+    meta: {
+      errorMessage: "Failed to reload provider session.",
+      showErrorToast: false,
+    },
+    mutationFn: (threadId: string) =>
+      sdk.threads.experimental_reload({ threadId }),
+  });
+}
+
 export function useStopThread() {
   const queryClient = useQueryClient();
 

--- a/apps/app/src/views/thread-detail/ThreadDetailPromptArea.keystrokes.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailPromptArea.keystrokes.test.tsx
@@ -237,6 +237,7 @@ vi.mock("@/hooks/mutations/thread-runtime-mutations", () => {
     useCancelThreadPlan: idleMutation,
     useClearThreadGoal: idleMutation,
     useCreateThreadQueuedMessage: idleMutation,
+    useReloadThread: idleMutation,
     useDeleteThreadQueuedMessage: idleMutation,
     useReorderThreadQueuedMessage: idleMutation,
     useSetThreadQueuedMessageGroupBoundary: idleMutation,

--- a/apps/app/src/views/thread-detail/ThreadDetailPromptArea.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailPromptArea.test.tsx
@@ -514,6 +514,10 @@ vi.mock("@/hooks/mutations/thread-runtime-mutations", () => ({
     isPending: false,
     mutateAsync: mocks.createQueuedMessageMutateAsync,
   }),
+  useReloadThread: () => ({
+    isPending: false,
+    mutateAsync: vi.fn(),
+  }),
   useDeleteThreadQueuedMessage: () => ({
     isPending: false,
     mutateAsync: mocks.deleteQueuedMessageMutateAsync,

--- a/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
@@ -83,6 +83,7 @@ import {
   useCancelThreadPlan,
   useClearThreadGoal,
   useStopThread,
+  useReloadThread,
 } from "@/hooks/mutations/thread-runtime-mutations";
 import { useUnarchiveThread } from "@/hooks/mutations/thread-state-mutations";
 import {
@@ -97,6 +98,7 @@ import { usePromptHistoryEnabled } from "@/hooks/usePromptHistoryEnabled";
 import { getProjectComposeRoutePath } from "@/lib/route-paths";
 import { getThreadDisplayTitle } from "@/lib/thread-title";
 import { buildThreadHandoffLocationState } from "@bb/client-core";
+import { isExactThreadReloadCommand } from "@/components/thread/embedded-chat/thread-reload-command";
 import { appToast } from "@/components/ui/app-toast";
 import {
   emptyPromptDraftState,
@@ -514,6 +516,7 @@ export function ThreadDetailPromptArea({
     },
   );
   const createQueuedMessage = useCreateThreadQueuedMessage();
+  const reloadThread = useReloadThread();
   const stopThread = useStopThread();
   const cancelThreadPlan = useCancelThreadPlan();
   const clearThreadGoal = useClearThreadGoal();
@@ -875,6 +878,24 @@ export function ThreadDetailPromptArea({
     ) {
       return;
     }
+    // An exact `/reload` is the reload operation, not model input — the same
+    // rule the embedded composer applies.
+    if (isExactThreadReloadCommand(submittedDraft)) {
+      promptDraft.clearIfCurrentMatches(submittedDraft);
+      setBottomAttachmentError(null);
+      try {
+        await reloadThread.mutateAsync(thread.id);
+      } catch (nextError) {
+        promptDraft.restoreIfEmpty(submittedDraft);
+        appToast.error(
+          getMutationErrorMessage({
+            error: nextError,
+            fallbackMessage: "Failed to reload provider session",
+          }),
+        );
+      }
+      return;
+    }
 
     promptDraft.clearIfCurrentMatches(submittedDraft);
     setBottomAttachmentError(null);
@@ -920,6 +941,7 @@ export function ThreadDetailPromptArea({
     followUpExecutionSelection,
     isDefaultExecutionOptionsLoading,
     promptDraft,
+    reloadThread,
     sendMessage,
     setBottomAttachmentError,
     thread.id,

--- a/apps/cli/src/__tests__/command-output/thread-actions.test.ts
+++ b/apps/cli/src/__tests__/command-output/thread-actions.test.ts
@@ -381,6 +381,22 @@ describe("bb thread action command output", () => {
     });
   });
 
+  it("bb thread reload reports the recreated provider session", async () => {
+    const post = vi.fn(async () => ({ status: "reloaded" }));
+    stubServerApi({ "v1.threads.:id.reload.$post": post });
+
+    await runCommand(["thread", "reload", "thread-reload", "--json"], register);
+
+    expect(post).toHaveBeenCalledWith({ param: { id: "thread-reload" } });
+    expect(collectLogLines(vi.mocked(console.log))).toContain(
+      JSON.stringify(
+        { threadId: "thread-reload", status: "reloaded" },
+        null,
+        2,
+      ),
+    );
+  });
+
   it("bb thread stop lets the server no-op when the thread is already idle", async () => {
     const get = vi.fn(async () =>
       fixtures.makeThread({

--- a/apps/cli/src/commands/thread/actions.ts
+++ b/apps/cli/src/commands/thread/actions.ts
@@ -463,6 +463,21 @@ export function registerActionsCommands(
     );
 
   parent
+    .command("reload [id]")
+    .description("Recreate an idle provider session from current configuration")
+    .option("--self", "Target the current thread (from BB_THREAD_ID)")
+    .option("--json", "Print machine-readable JSON output")
+    .action(
+      action(async (id: string | undefined, opts: ThreadActionOptions) => {
+        const threadId = requireThreadIdOrSelf(id, opts);
+        const sdk = createCliBbSdk(getUrl());
+        const result = await sdk.threads.experimental_reload({ threadId });
+        if (outputJson(opts, { threadId, ...result })) return;
+        console.log(`Thread ${threadId} provider session reloaded`);
+      }),
+    );
+
+  parent
     .command("stop [id]")
     .description("Stop work and release the loaded agent runtime")
     .option("--self", "Target the current thread (from BB_THREAD_ID)")

--- a/apps/host-daemon/src/app.test.ts
+++ b/apps/host-daemon/src/app.test.ts
@@ -240,6 +240,9 @@ function createFakeRuntime(): AgentRuntime {
     async resumeThread() {
       return { providerThreadId: "provider-thread-app-test" };
     },
+    async reloadThread(args) {
+      return { status: "reloaded", providerThreadId: args.providerThreadId };
+    },
     async runTurn() {},
     async steerTurn() {
       return { status: "steered" };

--- a/apps/host-daemon/src/command-dispatch.test.ts
+++ b/apps/host-daemon/src/command-dispatch.test.ts
@@ -176,6 +176,15 @@ function createRuntime(): FakeDispatchRuntime {
       hostedThreadIds.add(args.threadId);
       return { providerThreadId: "provider-thread-1" };
     }),
+    reloadThread: vi.fn(
+      async (args: { providerThreadId: string; threadId: string }) => {
+        hostedThreadIds.add(args.threadId);
+        return {
+          status: "reloaded" as const,
+          providerThreadId: args.providerThreadId,
+        };
+      },
+    ),
     runTurn: vi.fn(async () => undefined),
     steerTurn: vi.fn(async () => ({ status: "steered" as const })),
     stopThread: vi.fn(async (args: { threadId: string }) => {

--- a/apps/host-daemon/src/command-dispatch.ts
+++ b/apps/host-daemon/src/command-dispatch.ts
@@ -62,6 +62,7 @@ import {
   discardThreadRewind,
   ensureThreadRuntime,
   prepareThreadRewind,
+  reloadThread,
   startThread,
   submitTurn,
 } from "./command-handlers/thread.js";
@@ -328,6 +329,7 @@ const commandHandlers: CommandHandlerMap = {
       release();
     }
   },
+  "thread.reload": reloadThread,
   "turn.submit": async (command, options) => {
     const release =
       await options.runtimeManager.retainEnvironmentForThreadCommand(

--- a/apps/host-daemon/src/command-handlers/thread.ts
+++ b/apps/host-daemon/src/command-handlers/thread.ts
@@ -278,6 +278,86 @@ export async function startThread(
   }
 }
 
+export async function reloadThread(
+  command: CommandOf<"thread.reload">,
+  options: CommandDispatchOptions,
+): Promise<HostDaemonCommandResult<"thread.reload">> {
+  const release =
+    await options.runtimeManager.retainEnvironmentForThreadCommand(
+      command.environmentId,
+      command.threadId,
+    );
+  try {
+    const released =
+      await options.runtimeManager.releaseThreadFromOtherEnvironments({
+        activeTurn: "keep",
+        environmentId: command.environmentId,
+        threadId: command.threadId,
+      });
+    const [busyEnvironmentId] = released.activeTurnEnvironmentIds;
+    if (busyEnvironmentId !== undefined) {
+      throw new ExpectedCommandDispatchError(
+        "thread_active_in_other_environment",
+        `Thread ${command.threadId} is active in environment ${busyEnvironmentId} and cannot be reloaded`,
+      );
+    }
+
+    const bridgeLaunch = await resolveRuntimeBridgeLaunch(
+      command.bridgeLaunch,
+      options,
+    );
+    const entry = await requireResolvedWorkspaceForCommand({
+      dataDir: options.dataDir,
+      environmentId: command.environmentId,
+      injectedSkillSources: command.injectedSkillSources,
+      runtimeManager: options.runtimeManager,
+      targetThreadId: command.threadId,
+      workspaceContext: command.workspaceContext,
+    });
+    const result = await entry.runtime.reloadThread({
+      bridgeLaunch,
+      environmentId: command.environmentId,
+      threadId: command.threadId,
+      projectId: command.projectId,
+      providerThreadId: command.providerThreadId,
+      providerId: command.providerId,
+      options: command.options,
+      instructions: command.instructions,
+      dynamicTools: command.dynamicTools,
+      disallowedTools: command.disallowedTools,
+      instructionMode: command.instructionMode,
+    });
+    if (result.status === "reloaded") {
+      return { status: "reloaded" };
+    }
+
+    switch (result.reason) {
+      case "active-turn":
+        throw new ExpectedCommandDispatchError(
+          "thread_active",
+          `Thread ${command.threadId} has an active turn and cannot be reloaded`,
+        );
+      case "pending-turn-start":
+        throw new ExpectedCommandDispatchError(
+          "thread_pending",
+          `Thread ${command.threadId} is starting a turn and cannot be reloaded`,
+        );
+      case "background-work":
+        throw new ExpectedCommandDispatchError(
+          "thread_pending",
+          `Thread ${command.threadId} has pending background work and cannot be reloaded`,
+        );
+      case "session-mismatch":
+        throw new ExpectedCommandDispatchError(
+          "stale_thread_session",
+          `Thread ${command.threadId} changed provider sessions before it could be reloaded; retry the operation`,
+        );
+    }
+  } finally {
+    release();
+  }
+}
+
 export async function prepareThreadRewind(
   command: CommandOf<"thread.rewind.prepare">,
   options: CommandDispatchOptions,

--- a/apps/host-daemon/src/command-router.ts
+++ b/apps/host-daemon/src/command-router.ts
@@ -472,6 +472,7 @@ export class CommandRouter {
       case "thread.archive":
       case "interactive.resolve":
       case "thread.stop":
+      case "thread.reload":
       case "thread.plan.cancel":
       case "thread.goal.clear":
         return `${command.environmentId}\0thread:${command.threadId}`;

--- a/apps/host-daemon/src/runtime-manager.test.ts
+++ b/apps/host-daemon/src/runtime-manager.test.ts
@@ -42,6 +42,7 @@ type ProvisionWorkspaceMockArgs = Parameters<
 type EnsureProviderArgs = Parameters<AgentRuntime["ensureProvider"]>[0];
 type StartThreadArgs = Parameters<AgentRuntime["startThread"]>[0];
 type ResumeThreadArgs = Parameters<AgentRuntime["resumeThread"]>[0];
+type ReloadThreadArgs = Parameters<AgentRuntime["reloadThread"]>[0];
 type RunTurnArgs = Parameters<AgentRuntime["runTurn"]>[0];
 type SteerTurnArgs = Parameters<AgentRuntime["steerTurn"]>[0];
 type StopThreadArgs = Parameters<AgentRuntime["stopThread"]>[0];
@@ -257,6 +258,10 @@ function createFakeRuntime() {
     discardThreadRewind: vi.fn(async () => undefined),
     resumeThread: vi.fn(async (_args: ResumeThreadArgs) => ({
       providerThreadId: "provider-1",
+    })),
+    reloadThread: vi.fn(async (args: ReloadThreadArgs) => ({
+      status: "reloaded" as const,
+      providerThreadId: args.providerThreadId,
     })),
     runTurn: vi.fn(async (_args: RunTurnArgs) => undefined),
     steerTurn: vi.fn(async (_args: SteerTurnArgs) => ({

--- a/apps/host-daemon/src/runtime-manager.ts
+++ b/apps/host-daemon/src/runtime-manager.ts
@@ -10,12 +10,7 @@ import {
 } from "@bb/agent-runtime";
 import type { Logger } from "@bb/logger";
 import { killProcessesWithCwdUnder } from "@bb/process-utils";
-import type {
-  PendingInteractionCreate,
-  PendingInteractionResolution,
-  ThreadEvent,
-  WorkspaceProvisionType,
-} from "@bb/domain";
+import type { ThreadEvent, WorkspaceProvisionType } from "@bb/domain";
 import { threadScope, turnScope } from "@bb/domain";
 import type {
   HostDaemonActiveThread,
@@ -221,9 +216,7 @@ export interface RuntimeManagerOptions {
     changeKinds: HostDaemonEnvironmentChange[];
     environmentId: string;
   }) => void;
-  onInteractiveRequest?: (
-    request: PendingInteractionCreate,
-  ) => Promise<PendingInteractionResolution>;
+  onInteractiveRequest?: AgentRuntimeOptions["onInteractiveRequest"];
   onToolCall?: AgentRuntimeOptions["onToolCall"];
   onStderr?: AgentRuntimeOptions["onStderr"];
   onProcessExit?: AgentRuntimeOptions["onProcessExit"];

--- a/apps/host-daemon/src/terminals/terminal-manager.test.ts
+++ b/apps/host-daemon/src/terminals/terminal-manager.test.ts
@@ -205,6 +205,10 @@ function createFakeRuntime(): AgentRuntime {
     resumeThread: vi.fn(async () => ({
       providerThreadId: "provider-thread",
     })),
+    reloadThread: vi.fn(async (args) => ({
+      status: "reloaded" as const,
+      providerThreadId: args.providerThreadId,
+    })),
     runTurn: vi.fn(async () => undefined),
     steerTurn: vi.fn(async () => steerTurnResult),
     stopThread: vi.fn(async () => ({ providerCheckpointId: null })),

--- a/apps/host-daemon/test/command/dispatch-helpers.ts
+++ b/apps/host-daemon/test/command/dispatch-helpers.ts
@@ -124,6 +124,10 @@ interface FakeRuntimeState {
   ranTurnInput: PromptInput[] | undefined;
   ranTurnText: string | undefined;
   renamedTitle: string | undefined;
+  reloadedDynamicTools: DynamicTool[] | undefined;
+  reloadedInstructions: string | undefined;
+  reloadedProviderThreadId: string | undefined;
+  reloadedThreadId: string | undefined;
   resumedBridgeLaunch: AgentRuntimeBridgeLaunch | undefined;
   resumedEnvironmentId: string | undefined;
   resumedProviderThreadId: string | undefined;
@@ -296,6 +300,10 @@ export function createFakeRuntime() {
     ranTurnInput: undefined,
     ranTurnText: undefined,
     renamedTitle: undefined,
+    reloadedDynamicTools: undefined,
+    reloadedInstructions: undefined,
+    reloadedProviderThreadId: undefined,
+    reloadedThreadId: undefined,
     resumedBridgeLaunch: undefined,
     resumedEnvironmentId: undefined,
     resumedProviderThreadId: undefined,
@@ -383,6 +391,23 @@ export function createFakeRuntime() {
         providerThreadId,
       });
       return { providerThreadId };
+    },
+    async reloadThread(args) {
+      state.reloadedDynamicTools = args.dynamicTools;
+      state.reloadedInstructions = args.instructions;
+      state.reloadedProviderThreadId = args.providerThreadId;
+      state.reloadedThreadId = args.threadId;
+      if (activeTurnsByThreadId.has(args.threadId)) {
+        return { status: "rejected", reason: "active-turn" };
+      }
+      providerSessionsByThreadId.set(args.threadId, {
+        providerId: args.providerId,
+        providerThreadId: args.providerThreadId,
+      });
+      return {
+        status: "reloaded",
+        providerThreadId: args.providerThreadId,
+      };
     },
     async runTurn(args) {
       const firstInput = args.input[0];

--- a/apps/host-daemon/test/command/thread-dispatch.test.ts
+++ b/apps/host-daemon/test/command/thread-dispatch.test.ts
@@ -172,6 +172,56 @@ describe("thread command dispatch", () => {
     expect(harness.runtimeState.resumedThreadId).toBeUndefined();
   });
 
+  it("reloads an idle runtime with the command's current config", async () => {
+    const harness = createHarness({ workspacePath: "/tmp/env-reload" });
+    const command: Extract<HostDaemonCommand, { type: "thread.reload" }> = {
+      type: "thread.reload",
+      environmentId: "env-reload",
+      threadId: "thread-reload",
+      workspaceContext: {
+        workspacePath: "/tmp/env-reload",
+        workspaceProvisionType: "unmanaged",
+      },
+      projectId: "project-reload",
+      providerId: "fake",
+      providerThreadId: "provider-reload",
+      bridgeLaunch: DISPATCH_TEST_BRIDGE_LAUNCH,
+      options: {
+        model: "fresh-model",
+        serviceTier: "default",
+        reasoningLevel: "medium",
+        providerOptions: {},
+        permissionMode: "full",
+        permissionScope: "full",
+        approvalReviewer: null,
+        permissionEscalation: null,
+      },
+      instructions: "Fresh startup instructions",
+      dynamicTools: [],
+      injectedSkillSources: [],
+      instructionMode: "append",
+    };
+
+    await expect(
+      dispatchCommand(command, harness.dispatchOptions()),
+    ).resolves.toEqual({ status: "reloaded" });
+    expect(harness.runtimeState.reloadedThreadId).toBe("thread-reload");
+    expect(harness.runtimeState.reloadedProviderThreadId).toBe(
+      "provider-reload",
+    );
+    expect(harness.runtimeState.reloadedInstructions).toBe(
+      "Fresh startup instructions",
+    );
+
+    harness.threadControls.setActiveTurn("thread-reload", "turn-active");
+    await expect(
+      dispatchCommand(command, harness.dispatchOptions()),
+    ).rejects.toMatchObject({
+      code: "thread_active",
+      message: expect.stringContaining("active turn"),
+    });
+  });
+
   it("stages uploaded thread.start attachments before runtime input", async () => {
     const threadStorageRootPath = await makeTempDir(
       "bb-thread-start-attachments-",

--- a/apps/server/src/routes/threads/actions.ts
+++ b/apps/server/src/routes/threads/actions.ts
@@ -3,6 +3,8 @@ import {
   getEnvironment,
   getQueuedThreadMessage,
   listActiveVisiblePinnedThreadRootsWithPendingInteractionState,
+  listPendingInteractionsByThread,
+  listQueuedThreadMessages,
   pinThread,
   reorderPinnedThread,
   reorderQueuedThreadMessage,
@@ -52,6 +54,7 @@ import { acceptThreadSendRequest } from "../../services/threads/thread-send-requ
 import { editThreadMessage } from "../../services/threads/thread-edit-message.js";
 import {
   buildExecutionOptions,
+  buildThreadReloadCommand,
   dispatchThreadUnarchiveCommand,
   prepareTurnSubmitCommandPayload,
 } from "../../services/threads/thread-commands.js";
@@ -117,6 +120,48 @@ function toQueuedMessageOrderResponse(
         "Queued messages with different execution options cannot be grouped",
       );
   }
+}
+
+function requireReloadableThread(deps: AppDeps, thread: Thread): string {
+  ensureThreadIsWritable(thread);
+  // An errored thread has no work in flight either, and a fresh session is
+  // exactly what it needs; only a running or starting turn is in the way.
+  if (thread.status !== "idle" && thread.status !== "error") {
+    throw new ApiError(
+      409,
+      "invalid_request",
+      "Provider sessions can only be reloaded while the thread is idle or errored",
+    );
+  }
+  if (listQueuedThreadMessages(deps.db, thread.id).length > 0) {
+    throw new ApiError(
+      409,
+      "invalid_request",
+      "Provider sessions cannot be reloaded while the thread has queued messages",
+    );
+  }
+  if (
+    listPendingInteractionsByThread(deps.db, {
+      threadId: thread.id,
+      statuses: ["pending", "resolving"],
+      limit: 1,
+    }).length > 0
+  ) {
+    throw new ApiError(
+      409,
+      "invalid_request",
+      "Provider sessions cannot be reloaded while the thread has a pending interaction",
+    );
+  }
+  const providerThreadId = getLastProviderThreadId(deps, thread.id);
+  if (providerThreadId === null) {
+    throw new ApiError(
+      409,
+      "invalid_request",
+      `Thread ${thread.id} has no provider session to reload`,
+    );
+  }
+  return providerThreadId;
 }
 
 async function compactThreadContext(
@@ -362,6 +407,44 @@ export function registerThreadActionRoutes(app: Hono, deps: AppDeps): void {
     });
     await stopThreadForCurrentState(deps, thread, environment);
     return context.json({ ok: true });
+  });
+
+  post(routes.experimental_reload, async (context) => {
+    const thread = requirePublicThread(deps.db, context.req.param("id"));
+    const providerThreadId = requireReloadableThread(deps, thread);
+    const environment = await requireThreadCommandEnvironment(deps, { thread });
+    const execution = await buildExecutionOptions(
+      deps,
+      {},
+      { threadId: thread.id },
+    );
+    const command = await buildThreadReloadCommand(deps, {
+      environment,
+      execution,
+      providerThreadId,
+      thread,
+    });
+
+    const currentThread = requirePublicThread(deps.db, thread.id);
+    const currentProviderThreadId = requireReloadableThread(
+      deps,
+      currentThread,
+    );
+    if (currentProviderThreadId !== providerThreadId) {
+      throw new ApiError(
+        409,
+        "invalid_request",
+        "The provider session changed while reload was being prepared; retry the operation",
+      );
+    }
+
+    return context.json(
+      await runLiveHostCommand(deps, {
+        command,
+        hostId: environment.hostId,
+        timeoutMs: LIVE_DAEMON_COMMAND_TIMEOUT_MS,
+      }),
+    );
   });
 
   post(routes.compact, async (context) => {

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
@@ -521,6 +521,10 @@ For review or fix pipelines, get the environment ID from
   the retry.
 - For interrupted or stopped threads, inspect first. If the user stopped the
   thread, treat that as intentional unless they ask you to continue.
+- Use `bb thread reload <id>` to recreate an idle provider session after its
+  extension or startup configuration changes. Reload keeps the provider
+  conversation id, starts no turn, and adds no timeline message. It rejects
+  active or pending work.
 - Use `bb thread stop <id>` when a thread is stuck or no longer needed.
 - `bb thread stop <id>` also releases an idle or stuck agent runtime. The
   command is idempotent and preserves thread history.

--- a/apps/server/src/services/threads/thread-commands.ts
+++ b/apps/server/src/services/threads/thread-commands.ts
@@ -47,6 +47,13 @@ import {
 
 type ExecutionOptionsRequest = ExistingThreadExecutionInputRequest;
 
+export interface ThreadReloadCommandArgs {
+  environment: ThreadRuntimeCommandEnvironment;
+  execution: ResolvedThreadExecutionOptions;
+  providerThreadId: string;
+  thread: Thread;
+}
+
 export interface ThreadStopCommandArgs {
   environmentId: string;
   hostId: string;
@@ -320,6 +327,48 @@ export async function buildThreadStartCommand(
     instructionMode: runtimeContext.instructionMode,
     threadStoragePath: runtimeContext.threadStoragePath,
     ...(args.fork ? { fork: args.fork } : {}),
+  };
+}
+
+export async function buildThreadReloadCommand(
+  deps: LoggedWorkSessionDeps,
+  args: ThreadReloadCommandArgs,
+): Promise<Extract<HostDaemonCommand, { type: "thread.reload" }>> {
+  await deps.providerRegistry.whenRegistrationsSettled();
+  const runtimeContext = await resolveThreadRuntimeCommandConfig(deps, {
+    thread: args.thread,
+    environment: args.environment,
+    model: args.execution.model,
+  });
+  return {
+    type: "thread.reload",
+    environmentId: args.environment.id,
+    threadId: args.thread.id,
+    workspaceContext: workspaceContextFromPath({
+      path: runtimeContext.workspacePath,
+      workspaceProvisionType: runtimeContext.workspaceProvisionType,
+    }),
+    projectId: runtimeContext.projectId,
+    providerId: runtimeContext.providerId,
+    providerThreadId: args.providerThreadId,
+    bridgeLaunch: requireBridgeLaunchForProviderId(
+      deps,
+      runtimeContext.providerId,
+    ),
+    options: toRuntimeExecutionOptions({
+      deps,
+      execution: args.execution,
+      hostId: args.environment.hostId,
+      input: [],
+      permissionEscalation: "ask",
+      projectId: runtimeContext.projectId,
+      providerId: runtimeContext.providerId,
+      threadId: args.thread.id,
+    }),
+    instructions: runtimeContext.instructions,
+    dynamicTools: runtimeContext.dynamicTools,
+    injectedSkillSources: runtimeContext.injectedSkillSources,
+    instructionMode: runtimeContext.instructionMode,
   };
 }
 

--- a/apps/server/test/public/public-thread-reload.test.ts
+++ b/apps/server/test/public/public-thread-reload.test.ts
@@ -1,0 +1,179 @@
+import {
+  createPendingInteraction,
+  createQueuedThreadMessage,
+  listEvents,
+} from "@bb/db";
+import { describe, expect, it } from "vitest";
+import {
+  registerHostRpcResponder,
+  type HostRpcHandlerResult,
+} from "../helpers/host-rpc.js";
+import { readJson } from "../helpers/json.js";
+import { seedThreadFixture, seedThreadRuntimeState } from "../helpers/seed.js";
+import { withTestHarness, type TestAppHarness } from "../helpers/test-app.js";
+
+function registerReloadResponder(
+  harness: TestAppHarness,
+  args: { hostId: string; sessionId: string },
+) {
+  return registerHostRpcResponder(harness, {
+    ...args,
+    handle: ({ command }): HostRpcHandlerResult => {
+      if (command.type === "host.list_files") {
+        return { ok: true, result: { files: [], truncated: false } };
+      }
+      if (command.type === "host.read_file") {
+        if (command.path.endsWith("/AGENTS.md")) {
+          return {
+            ok: true,
+            result: {
+              path: command.path,
+              content: "Fresh reload instructions",
+              contentEncoding: "utf8",
+              mimeType: "text/markdown",
+              sizeBytes: 25,
+              sha256: "0".repeat(64),
+            },
+          };
+        }
+        return {
+          ok: false,
+          errorCode: "ENOENT",
+          errorMessage: `Path does not exist: ${command.path}`,
+        };
+      }
+      if (command.type === "thread.reload") {
+        return { ok: true, result: { status: "reloaded" } };
+      }
+      throw new Error(`Unexpected command ${command.type}`);
+    },
+  });
+}
+
+describe("public thread reload", () => {
+  it("recreates an idle session from current startup config without adding a timeline message", async () => {
+    await withTestHarness(async (harness) => {
+      const { environment, host, session, thread } = seedThreadFixture(
+        harness,
+        {
+          thread: { status: "idle" },
+        },
+      );
+      seedThreadRuntimeState(harness.deps, {
+        environmentId: environment.id,
+        providerThreadId: "provider-reload",
+        threadId: thread.id,
+      });
+      const responder = registerReloadResponder(harness, {
+        hostId: host.id,
+        sessionId: session.id,
+      });
+      const eventCountBefore = listEvents(harness.db, {
+        threadId: thread.id,
+      }).length;
+
+      const response = await harness.app.request(
+        `/api/v1/threads/${thread.id}/reload`,
+        { method: "POST" },
+      );
+
+      expect(
+        response.status,
+        JSON.stringify(await readJson(response.clone())),
+      ).toBe(200);
+      await expect(readJson(response)).resolves.toEqual({ status: "reloaded" });
+      const reloads = responder.requests.filter(
+        ({ command }) => command.type === "thread.reload",
+      );
+      expect(reloads).toHaveLength(1);
+      expect(reloads[0]?.command).toMatchObject({
+        type: "thread.reload",
+        environmentId: environment.id,
+        threadId: thread.id,
+        providerThreadId: expect.any(String),
+        instructions: expect.stringContaining("Fresh reload instructions"),
+      });
+      expect(
+        responder.requests.filter(
+          ({ command }) => command.type === "turn.submit",
+        ),
+      ).toHaveLength(0);
+      expect(listEvents(harness.db, { threadId: thread.id })).toHaveLength(
+        eventCountBefore,
+      );
+    });
+  });
+
+  it("reloads a thread whose last turn ended in a provider error", async () => {
+    await withTestHarness(async (harness) => {
+      const { environment, host, session, thread } = seedThreadFixture(harness, {
+        thread: { status: "error" },
+      });
+      seedThreadRuntimeState(harness.deps, {
+        environmentId: environment.id,
+        providerThreadId: "provider-reload-error",
+        threadId: thread.id,
+      });
+      const responder = registerReloadResponder(harness, {
+        hostId: host.id,
+        sessionId: session.id,
+      });
+
+      const response = await harness.app.request(
+        `/api/v1/threads/${thread.id}/reload`,
+        { method: "POST" },
+      );
+
+      expect(response.status, JSON.stringify(await readJson(response.clone()))).toBe(200);
+      expect(
+        responder.requests.filter(({ command }) => command.type === "thread.reload"),
+      ).toHaveLength(1);
+    });
+  });
+
+  it("rejects active threads, queued messages, and pending interactions", async () => {
+    await withTestHarness(async (harness) => {
+      const active = seedThreadFixture(harness, {
+        thread: { status: "active" },
+      }).thread;
+      const queued = seedThreadFixture(harness, {
+        thread: { status: "idle" },
+      }).thread;
+      createQueuedThreadMessage(harness.db, harness.deps.hub, {
+        threadId: queued.id,
+        content: [{ type: "text", text: "pending", mentions: [] }],
+        model: "test-model",
+        reasoningLevel: "medium",
+        permissionMode: "auto",
+        serviceTier: "default",
+        senderThreadId: null,
+      });
+      const interacting = seedThreadFixture(harness, {
+        thread: { status: "idle" },
+      }).thread;
+      createPendingInteraction(harness.db, {
+        originKind: "plugin",
+        pluginId: "reload-test",
+        rendererId: "reload-test",
+        threadId: interacting.id,
+        turnId: null,
+        payload: JSON.stringify({ kind: "plugin", title: "Pending" }),
+      });
+
+      for (const [threadId, message] of [
+        [active.id, "only be reloaded while the thread is idle"],
+        [queued.id, "has queued messages"],
+        [interacting.id, "has a pending interaction"],
+      ] as const) {
+        const response = await harness.app.request(
+          `/api/v1/threads/${threadId}/reload`,
+          { method: "POST" },
+        );
+        expect(response.status).toBe(409);
+        await expect(readJson(response)).resolves.toMatchObject({
+          message: expect.stringContaining(message),
+        });
+      }
+    });
+  });
+});

--- a/docs/api_to_audit.md
+++ b/docs/api_to_audit.md
@@ -250,6 +250,20 @@ observation event is needed instead of weakening short-circuit behavior. Audit
 whether raw tool input needs a size limit before plugins inspect it. Confirm
 that provider-native tools should remain a provider-extension concern.
 
+## Provider session reload (`bb.sdk.threads.experimental_reload`)
+
+**What it does.** Recreates an idle provider session from current startup
+configuration while retaining the provider conversation id. It starts no turn
+and adds no user or assistant timeline message. The operation rejects active
+turns, pending turn starts, background work, queued messages, and pending user
+interactions.
+
+**Audit before stabilizing.** Confirm reload remains one session-replacement
+operation across every provider; verify which idle provider-owned work must
+block replacement; review failure recovery after the old session closes but the
+new session fails to start; and confirm the `{ status: "reloaded" }` result is
+sufficient before dropping the prefix.
+
 ## `experimental_buildBridgeToolCallContent`
 
 **Kept experimental (2026-08-22).** it still accepts two input shapes (ordered `contentBlocks` and the legacy aggregate `{ content, images }`) though every first-party caller now passes the ordered form, and no image MIME/size policy exists at the server boundary; drop the legacy input and settle the policy, then stabilize.

--- a/packages/agent-runtime/src/runtime.ts
+++ b/packages/agent-runtime/src/runtime.ts
@@ -2131,6 +2131,43 @@ export function createAgentRuntime(options: AgentRuntimeOptions): AgentRuntime {
       });
     },
 
+    async reloadThread(args) {
+      return runThreadOperation({
+        threadId: args.threadId,
+        work: async () => {
+          if (turnState.getActiveTurnId(args.threadId) !== null) {
+            return { status: "rejected", reason: "active-turn" };
+          }
+          if (pendingTurnStarts.has(args.threadId)) {
+            return { status: "rejected", reason: "pending-turn-start" };
+          }
+          if (backgroundWorkState.hasOpenThreadWork(args.threadId)) {
+            return { status: "rejected", reason: "background-work" };
+          }
+
+          const currentSession = threadIdentityRegistry.getProviderSession(
+            args.threadId,
+          );
+          if (
+            currentSession !== null &&
+            (currentSession.providerId !== args.providerId ||
+              currentSession.providerThreadId !== args.providerThreadId)
+          ) {
+            return { status: "rejected", reason: "session-mismatch" };
+          }
+          if (currentSession !== null) {
+            await runtime.stopThread({ threadId: args.threadId });
+          }
+
+          const resumed = await runtime.resumeThread(args);
+          return {
+            status: "reloaded",
+            providerThreadId: resumed.providerThreadId,
+          };
+        },
+      });
+    },
+
     async runTurn({
       threadId,
       input,

--- a/packages/agent-runtime/src/test/runtime-test-harness.ts
+++ b/packages/agent-runtime/src/test/runtime-test-harness.ts
@@ -180,6 +180,7 @@ type LaunchBearingMethod =
   | "resumeThread"
   | "archiveThread"
   | "unarchiveThread"
+  | "reloadThread"
   | "listModels"
   | "providerHealth"
   | "providerUsage"
@@ -226,6 +227,7 @@ export function withBridgeLaunch(
     archiveThread: (args) => runtime.archiveThread({ bridgeLaunch, ...args }),
     unarchiveThread: (args) =>
       runtime.unarchiveThread({ bridgeLaunch, ...args }),
+    reloadThread: (args) => runtime.reloadThread({ bridgeLaunch, ...args }),
     listModels: (args) => runtime.listModels({ bridgeLaunch, ...args }),
     providerHealth: (args) => runtime.providerHealth({ bridgeLaunch, ...args }),
     providerUsage: (args) => runtime.providerUsage({ bridgeLaunch, ...args }),

--- a/packages/agent-runtime/src/types.ts
+++ b/packages/agent-runtime/src/types.ts
@@ -270,6 +270,16 @@ export interface ResumeThreadResult {
   providerThreadId: string;
 }
 
+export type ReloadThreadRejectedReason =
+  | "active-turn"
+  | "background-work"
+  | "pending-turn-start"
+  | "session-mismatch";
+
+export type ReloadThreadResult =
+  | { status: "reloaded"; providerThreadId: string }
+  | { status: "rejected"; reason: ReloadThreadRejectedReason };
+
 export interface RunTurnArgs {
   threadId: string;
   input: PromptInput[];
@@ -389,6 +399,16 @@ export interface AgentRuntime {
   discardThreadRewind(args: DiscardThreadRewindArgs): Promise<void>;
 
   resumeThread(args: ResumeThreadArgs): Promise<ResumeThreadResult>;
+
+  /**
+   * Replaces an idle provider session with a fresh session bound to the same
+   * provider conversation. The caller supplies newly resolved startup config.
+   */
+  reloadThread(
+    args: ResumeThreadArgs & {
+      providerThreadId: string;
+    },
+  ): Promise<ReloadThreadResult>;
 
   runTurn(args: RunTurnArgs): Promise<void>;
 

--- a/packages/host-daemon-contract/src/commands.ts
+++ b/packages/host-daemon-contract/src/commands.ts
@@ -315,6 +315,11 @@ const threadStartCommandSchema = hostDaemonThreadTargetSchema
     refineGroupedInputMatchesFlatInput(value, ctx);
   });
 
+const threadReloadCommandSchema = hostDaemonThreadTargetSchema
+  .merge(hostDaemonExistingThreadRuntimeContextSchema)
+  .extend({ type: z.literal("thread.reload") })
+  .strict();
+
 const threadRewindPrepareCommandSchema = hostDaemonThreadTargetSchema
   .merge(hostDaemonThreadRuntimeContextSchema)
   .extend({
@@ -1411,6 +1416,9 @@ const providerListModelsResultSchema = z.object({
 const threadStartResultSchema = z.object({
   providerThreadId: z.string().min(1),
 });
+const threadReloadResultSchema = z
+  .object({ status: z.literal("reloaded") })
+  .strict();
 const turnSubmitResultSchema = z.object({
   appliedAs: z.enum(["new-turn", "steer"]),
 });
@@ -1562,6 +1570,15 @@ export const hostDaemonCommandRegistry = {
     type: "thread.start",
     schema: threadStartCommandSchema,
     resultSchema: threadStartResultSchema,
+    transport: "settled",
+    retryable: false,
+    flushEventsBeforeResult: true,
+    envLane: "read",
+  }),
+  "thread.reload": defineHostDaemonCommandDescriptor({
+    type: "thread.reload",
+    schema: threadReloadCommandSchema,
+    resultSchema: threadReloadResultSchema,
     transport: "settled",
     retryable: false,
     flushEventsBeforeResult: true,
@@ -2059,7 +2076,9 @@ type HostDaemonRetryableOnlineRpcCommandSchema =
 type HostDaemonResultSchemaMapForTransport<
   Transport extends HostDaemonCommandTransport,
 > = {
-  [Descriptor in HostDaemonCommandDescriptorForTransport<Transport> as Descriptor["type"]]: Descriptor["resultSchema"];
+  [
+    Descriptor in HostDaemonCommandDescriptorForTransport<Transport> as Descriptor["type"]
+  ]: Descriptor["resultSchema"];
 };
 
 type HostDaemonCommandResultSchemaMap =

--- a/packages/host-daemon-contract/src/protocol.ts
+++ b/packages/host-daemon-contract/src/protocol.ts
@@ -333,7 +333,12 @@
 //
 // The version mismatch is what triggers the enrolled daemon's automatic update
 // instead of an `invalid-message` reconnect loop.
-export const HOST_DAEMON_PROTOCOL_VERSION = 170 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 171 as const;
+// Version 171 adds `thread.reload` (server → daemon): recreate an idle
+// thread's provider session from the thread's current config, answered with
+// the provider thread id. An older daemon rejects the unknown command, so the
+// bump is what moves an enrolled machine forward.
+
 
 /**
  * Absolute ceiling for any executable artifact delivered to a host daemon —

--- a/packages/host-daemon-contract/src/session.ts
+++ b/packages/host-daemon-contract/src/session.ts
@@ -455,6 +455,7 @@ const hostDaemonOnlineRpcResponseSuccessSchema = z.discriminatedUnion(
     commandRpcResponseSuccessSchemaFor("thread.rewind.discard"),
     commandRpcResponseSuccessSchemaFor("thread.rewind.prepare"),
     commandRpcResponseSuccessSchemaFor("thread.start"),
+    commandRpcResponseSuccessSchemaFor("thread.reload"),
     commandRpcResponseSuccessSchemaFor("turn.submit"),
     commandRpcResponseSuccessSchemaFor("thread.stop"),
     commandRpcResponseSuccessSchemaFor("thread.goal.clear"),

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -454,6 +454,7 @@ const SETTLED_RESPONSE_RESULT_FIXTURES: SettledResponseResultFixtures = {
   "thread.start": {
     providerThreadId: "provider-thread-123",
   },
+  "thread.reload": { status: "reloaded" },
   "turn.submit": {
     appliedAs: "new-turn",
   },
@@ -1046,7 +1047,7 @@ describe("host-daemon command schemas", () => {
   // mixed version. Version 113 carried the Devin Desktop open target rename
   // and remains part of the protocol lineage.
   it("uses the current host-daemon protocol version", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(170);
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(171);
     expect(HOST_ARTIFACT_MAX_BYTES).toBe(256 * 1024 * 1024);
   });
 

--- a/packages/sdk/src/areas/threads.ts
+++ b/packages/sdk/src/areas/threads.ts
@@ -10,10 +10,14 @@ import {
   type ThreadQueuedMessage,
   type ThreadStatus,
 } from "@bb/domain";
-import { threadTabsResponseSchema } from "@bb/server-contract";
+import {
+  experimental_threadReloadResponseSchema,
+  threadTabsResponseSchema,
+} from "@bb/server-contract";
 import type {
   CreateQueuedMessageRequest,
   CreateThreadRequest,
+  ExperimentalThreadReloadResponse,
   EditMessageRequest,
   EditMessageResponse,
   ForkThreadRequest,
@@ -122,6 +126,7 @@ export type ThreadDeleteResult = { ok: true };
 export type ThreadSendResult = SendMessageResponse;
 export type ThreadEditMessageResult = EditMessageResponse;
 export type ThreadStopResult = { ok: true };
+export type ExperimentalThreadReloadResult = ExperimentalThreadReloadResponse;
 export type ThreadCompactResult = { ok: true };
 export type ThreadBannerActionResult = { ok: true };
 export type ThreadUnarchiveResult = { ok: true };
@@ -443,6 +448,9 @@ export interface ThreadsArea {
   ): Promise<ThreadDefaultExecutionOptionsResult>;
   delete(args: ThreadDeleteArgs): Promise<ThreadDeleteResult>;
   editMessage(args: ThreadEditMessageArgs): Promise<ThreadEditMessageResult>;
+  experimental_reload(
+    args: ThreadStatusArgs,
+  ): Promise<ExperimentalThreadReloadResult>;
   events: ThreadEventsArea;
   fork(args: ThreadForkArgs): Promise<ThreadForkResult>;
   get(args: ThreadGetArgs): Promise<ThreadGetResult>;
@@ -1068,6 +1076,15 @@ export function createThreadsArea(args: CreateSdkAreaArgs): ThreadsArea {
           json: spawnJson(input),
         }),
       );
+    },
+    async experimental_reload(input) {
+      const body = await transport.readJson(
+        transport.api.v1.threads[":id"].reload.$post(
+          { param: { id: input.threadId } },
+          ...signalRequestArgs(input.signal),
+        ),
+      );
+      return experimental_threadReloadResponseSchema.parse(body);
     },
     async stop(input) {
       await transport.readVoid(

--- a/packages/sdk/test/public-types.test.ts
+++ b/packages/sdk/test/public-types.test.ts
@@ -361,6 +361,7 @@ type ExpectedThreadsKey =
   | "delete"
   | "editMessage"
   | "events"
+  | "experimental_reload"
   | "fork"
   | "get"
   | "interactions"

--- a/packages/server-contract/src/api/threads.ts
+++ b/packages/server-contract/src/api/threads.ts
@@ -826,6 +826,13 @@ export type TimelineTurnSummaryDetailsResponse = z.infer<
   typeof timelineTurnSummaryDetailsResponseSchema
 >;
 
+export const experimental_threadReloadResponseSchema = z
+  .object({ status: z.literal("reloaded") })
+  .strict();
+export type ExperimentalThreadReloadResponse = z.infer<
+  typeof experimental_threadReloadResponseSchema
+>;
+
 export const threadTimelineResponseSchema = z.object({
   rows: z.array(timelineRowSchema),
   activePromptMode: threadTimelineActivePromptModeSchema.nullable(),

--- a/packages/server-contract/src/public-api.ts
+++ b/packages/server-contract/src/public-api.ts
@@ -167,6 +167,7 @@ import type {
   TerminalResizeRequest,
   ThreadArchiveAllResponse,
   ThreadChildSummaryResponse,
+  ExperimentalThreadReloadResponse,
   ThreadEventWaitQuery,
   ThreadEventsQuery,
   ThreadSectionMutationResponse,
@@ -1073,6 +1074,12 @@ export const publicApiRoutes = {
       method: "post",
       request: noRequest<PathId>(),
       response: jsonResponse<{ ok: true }>(),
+    }),
+    experimental_reload: defineRoute({
+      path: "/threads/:id/reload",
+      method: "post",
+      request: noRequest<PathId>(),
+      response: jsonResponse<ExperimentalThreadReloadResponse>(),
     }),
     compact: defineRoute({
       path: "/threads/:id/compact",

--- a/packages/templates/src/templates/bb-guide-threads.md
+++ b/packages/templates/src/templates/bb-guide-threads.md
@@ -207,11 +207,17 @@ Messaging:
   `createBuiltinPlanCommandTextInput(text)` from `@bb/sdk` and pass it as
   `input` to `threads.spawn` or `threads.send`.
 
+  bb thread reload [id]                    Recreate an idle provider session from current configuration
   bb thread stop [id]                      Stop work and release the agent runtime
   bb thread compact [id]                   Request compaction of an idle or errored thread's context
   bb thread cancel-plan [id]               Exit the provider's active Plan mode
   bb thread clear-goal [id]                Clear the provider's active Goal
     --self                                 Target current thread
+
+  `thread reload` keeps the provider conversation id, starts no turn, and adds
+  no timeline message. It rejects active work, queued messages, and pending
+  user interactions. The composer runs the same operation only for exact
+  `/reload`; other text remains model input.
 
   `thread compact` enqueues the same structured /compact turn used by the
   composer. Follow the thread timeline for the eventual compaction result.


### PR DESCRIPTION
## Human comments

## What was wrong

Changing a provider's configuration (pi extensions, AGENTS.md, skills, plugin agent config, dynamic tools) needed a new thread; an idle thread's provider session could not be rebuilt in place.

## What changed

- `AgentRuntime.reloadThread` → daemon `thread.reload` (stop with intent `release`, then resume the same `providerThreadId`, no timeline events) → `POST /api/v1/threads/:id/reload` → `sdk.threads.experimental_reload` → `bb thread reload [id] [--self]` → `useReloadThread`. Both composers treat an exact `/reload` as the operation, not model input.
- The server re-resolves environment, execution options, instructions, and tools at request time and refuses with 409 while the thread is active, has queued messages, or has a pending interaction; `idle` and `error` threads may reload.
- **Wire change:** `HOST_DAEMON_PROTOCOL_VERSION` 170 → 171 (new daemon command). Guide (`bb guide threads`), `bb-cli` skill, and `docs/api_to_audit.md` updated.

Prerequisite: #2444 (stack order; shares `routes/threads/actions.ts` context only).

## How you verified

`turbo run typecheck`; `turbo run test` for `@bb/server` (`public-thread-reload.test.ts`), `@bb/host-daemon` (`thread-dispatch.test.ts`, dispatch/runtime-manager mocks), `@bb/agent-runtime`, `@bb/cli`, `@bb/app` (thread-detail, embedded-chat), `@bb/host-daemon-contract`, `@bb/server-contract`, `@bb/sdk`.

Fixes: none (upstream stack split).

> AGENT GENERATED
