### PR TITLE
Make Claude native-roots cap test deterministic

### DIFF
--- a/plugins/provider-claude-code/src/native-roots.test.ts
+++ b/plugins/provider-claude-code/src/native-roots.test.ts
@@ -7,9 +7,15 @@
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import type { ExperimentalVendorPluginRoots } from "@get-bb/plugin-sdk/host";
+import type {
+  ExperimentalClaudePluginRoots,
+  ExperimentalVendorPluginRoots,
+} from "@get-bb/plugin-sdk/host";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { resolveClaudeNativeRoots } from "./native-roots.js";
+import {
+  filterClaudeNativeRoots,
+  resolveClaudeNativeRoots,
+} from "./native-roots.js";
 
 interface Fixture {
   cwd: string;
@@ -274,44 +280,35 @@ describe("resolveClaudeNativeRoots contract filtering", () => {
     }
   });
 
-  it("keeps the first 256 command roots of 260 plugins and warns once", async () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
-    const fixture = await makeFixture();
-    const cacheRoot = path.join(
-      fixture.claudeDir,
-      "plugins",
-      "cache",
-      "market",
+  it("keeps the first 256 command roots of 260 plugins and warns once", () => {
+    const warn = vi.fn();
+    const claudeDir = path.join(
+      path.parse(process.cwd()).root,
+      "claude-config",
     );
-    // Just past the cap: enough plugins to drop some, few enough that the
-    // fixture (two writes per plugin, issued together) stays well inside the
-    // default test timeout on a slow CI runner.
-    const plugins: Record<string, { scope: string; installPath: string }[]> =
-      {};
-    const writes: Promise<void>[] = [];
-    for (let index = 0; index < 260; index += 1) {
-      const name = `plugin-${String(index).padStart(3, "0")}`;
-      const root = path.join(cacheRoot, name, "1");
-      plugins[`${name}@market`] = [{ scope: "user", installPath: root }];
-      writes.push(
-        writePlugin(root, { name }).then(() =>
-          mkdir(path.join(root, "commands"), { recursive: true }).then(
-            () => undefined,
-          ),
-        ),
-      );
-    }
-    await Promise.all(writes);
-    await writeJson(
-      path.join(fixture.claudeDir, "plugins", "installed_plugins.json"),
-      { version: 2, plugins },
-    );
+    const cacheRoot = path.join(claudeDir, "plugins", "cache", "market");
+    // Discovery has small real-filesystem cases above. The cap belongs to the
+    // synchronous composition/filter seam so proving it does not require 260
+    // manifests, directories, and repeated filesystem probes.
+    const pluginCommands: ExperimentalClaudePluginRoots["commands"] =
+      Array.from({ length: 260 }, (_, index) => {
+        const name = `plugin-${String(index).padStart(3, "0")}`;
+        return {
+          path: path.join(cacheRoot, name, "1", "commands"),
+          origin: "user",
+          namePrefix: `${name}:`,
+          shape: "commands",
+        };
+      });
 
-    const roots = await resolve(fixture, null);
+    const roots = filterClaudeNativeRoots(
+      { claudeDir, skills: [], commands: pluginCommands },
+      warn,
+    );
 
     expect(roots.commands).toHaveLength(256);
     expect(commandPaths(roots).slice(0, 2)).toEqual([
-      path.join(fixture.claudeDir, "commands"),
+      path.join(claudeDir, "commands"),
       path.join(cacheRoot, "plugin-000", "1", "commands"),
     ]);
     expect(roots.commands[255]?.namePrefix).toBe("plugin-254:");

--- a/plugins/provider-claude-code/src/native-roots.ts
+++ b/plugins/provider-claude-code/src/native-roots.ts
@@ -19,6 +19,7 @@ import type { PluginProviderDeclaration } from "@get-bb/plugin-sdk";
 import {
   experimental_filterResolvedNativeRoots,
   experimental_resolveClaudePluginRoots,
+  type ExperimentalClaudePluginRoots,
   type ExperimentalClaudePluginRootsArgs,
   type ExperimentalVendorPluginRoots,
 } from "@get-bb/plugin-sdk/host";
@@ -64,19 +65,16 @@ const CLAUDE_PLUGIN_MANIFEST_MARKER = ".claude-plugin/plugin.json";
 type ClaudeResolvedRoot = ExperimentalVendorPluginRoots["skills"][number];
 
 /**
- * The Claude Code roots that only this host can name, for one workspace.
- * Always: the user `skills` and `commands` directories under the config
- * directory. Then, per enabled Claude plugin (installed ones, then plugins
- * found inside the project and user `skills` directories): its root
- * `SKILL.md`, `skills/`, `commands/`, and the manifest's `skills` and
- * `commands` entries, each prefixed `<plugin>:`. Project roots (the project
- * `skills` directory's plugins, project- and local-scoped installs inside the
- * workspace) appear only when `cwd` is given.
+ * Put Claude's own user roots before the already-discovered plugin roots,
+ * remove duplicate user paths, and apply the resolved-roots contract. Keeping
+ * this synchronous lets the ordering and cap be proved without manufacturing
+ * hundreds of plugins on disk; plugin discovery keeps its separate filesystem
+ * integration coverage.
  */
-export async function resolveClaudeNativeRoots(
-  args: ExperimentalClaudePluginRootsArgs,
-): Promise<ExperimentalVendorPluginRoots> {
-  const plugins = await experimental_resolveClaudePluginRoots(args);
+export function filterClaudeNativeRoots(
+  plugins: ExperimentalClaudePluginRoots,
+  warn: (message: string) => void,
+): ExperimentalVendorPluginRoots {
   const userSkillsRoot: ClaudeResolvedRoot = {
     path: path.join(plugins.claudeDir, "skills"),
     origin: "user",
@@ -109,6 +107,23 @@ export async function resolveClaudeNativeRoots(
         ),
       ],
     },
-    { warn: console.warn },
+    { warn },
   ).answer;
+}
+
+/**
+ * The Claude Code roots that only this host can name, for one workspace.
+ * Always: the user `skills` and `commands` directories under the config
+ * directory. Then, per enabled Claude plugin (installed ones, then plugins
+ * found inside the project and user `skills` directories): its root
+ * `SKILL.md`, `skills/`, `commands/`, and the manifest's `skills` and
+ * `commands` entries, each prefixed `<plugin>:`. Project roots (the project
+ * `skills` directory's plugins, project- and local-scoped installs inside the
+ * workspace) appear only when `cwd` is given.
+ */
+export async function resolveClaudeNativeRoots(
+  args: ExperimentalClaudePluginRootsArgs,
+): Promise<ExperimentalVendorPluginRoots> {
+  const plugins = await experimental_resolveClaudePluginRoots(args);
+  return filterClaudeNativeRoots(plugins, console.warn);
 }


### PR DESCRIPTION
## Human comments

## What was wrong

The Claude native-roots cap test coupled a deterministic 256-root contract assertion to a 260-plugin filesystem fixture. It created a manifest and commands directory for every plugin, then made the registry resolver probe all 260 plugin trees. Scheduler and filesystem contention only amplified that unnecessary structural cost: the fixture and scan consumed the test's 5-second budget even though the production contract filtering was correct. This surfaced in the [packages job](https://github.com/get-bb/bb/actions/runs/32910895673/job/98004697503) for unrelated PR #2440; the same test passed with little headroom in the [preceding main job](https://github.com/get-bb/bb/actions/runs/32909294708/job/98000003411).

## What changed

Extracted the synchronous Claude root composition/filter step from filesystem discovery. The cap regression now supplies 260 synthetic plugin command roots directly to that seam while retaining assertions for user-root-first ordering, the exact 256-root cap, the last kept plugin, the first dropped root, the dropped count, and the single warning. The existing small real-filesystem cases continue to cover registry discovery and plugin layouts.

Runtime output and wire behavior are unchanged, so `HOST_DAEMON_PROTOCOL_VERSION` was not bumped.

## How you verified

- Before the fix, a 22-way exact focused Turbo loop reproduced `Test timed out in 5000ms` in 14/22 runs. Temporary phase timing showed fixture creation alone taking 5.9–7.4 seconds under contention; runs that reached resolution spent another roughly 4.5–5.0 seconds scanning the plugin trees. The temporary instrumentation was removed.
- After the fix, the same 22-way loop passed 22/22; the exact test took 6–10 ms in every process.
- `pnpm exec turbo run test --filter=bb-plugin-provider-claude-code --force -- --run src/native-roots.test.ts` — 5/5 passed.
- `pnpm exec turbo run test --filter=bb-plugin-provider-claude-code --force` — 335/335 passed.
- `pnpm exec turbo run typecheck --filter=bb-plugin-provider-claude-code --force` — passed.
- `pnpm exec turbo run build --filter=bb-app --force` — 11/11 Turbo tasks passed.
- Targeted `oxfmt --check`, `oxlint`, `git diff --check`, and debug-instrumentation grep passed.

> AGENT GENERATED: by GPT-5.6-Sol
