### PR TITLE
Theme the Monaco editor from bb's code theme, and let its file tree resize

### DIFF
--- a/apps/app/src/lib/code-theme-registration.ts
+++ b/apps/app/src/lib/code-theme-registration.ts
@@ -1,0 +1,30 @@
+import type { registerCustomTheme } from "@pierre/diffs";
+import { stampRegisteredThemeName } from "@bb/domain";
+import { getResolvedCodeTheme } from "@/lib/code-theme";
+
+/**
+ * Theme files this window has already handed to Pierre. Shared by every caller
+ * because `registerCustomTheme` treats a second registration of the same name
+ * as an error it only logs — the set is what keeps that off the console when
+ * both the worker-pool sync and a plugin resolve the same custom palette.
+ */
+const registeredFileNames = new Set<string>();
+
+/**
+ * Register every JSON theme file the active palette ships (custom palettes and
+ * BB's first-party light remaps) under its versioned wire name.
+ *
+ * The registrar is passed in rather than imported so a caller that reaches
+ * `@pierre/diffs` through a dynamic import does not pull it statically here.
+ */
+export function registerResolvedCodeThemeFiles(
+  register: typeof registerCustomTheme,
+): void {
+  const resolved = getResolvedCodeTheme();
+  for (const [name, theme] of Object.entries(resolved.files)) {
+    if (registeredFileNames.has(name)) continue;
+    registeredFileNames.add(name);
+    const stamped = stampRegisteredThemeName(name, theme);
+    register(name, () => Promise.resolve(stamped));
+  }
+}

--- a/apps/app/src/lib/pierre-worker-pool-theme.ts
+++ b/apps/app/src/lib/pierre-worker-pool-theme.ts
@@ -1,24 +1,11 @@
 import { useEffect } from "react";
 import { registerCustomTheme } from "@pierre/diffs";
 import type { WorkerPoolManager } from "@pierre/diffs/worker";
-import { stampRegisteredThemeName } from "@bb/domain";
+import { registerResolvedCodeThemeFiles } from "@/lib/code-theme-registration";
 import {
-  getResolvedCodeTheme,
   useResolvedCodeTheme,
   useResolvedCodeThemePair,
 } from "@/lib/code-theme";
-
-const registeredFileNames = new Set<string>();
-
-function registerResolvedCodeThemeFiles(): void {
-  const resolved = getResolvedCodeTheme();
-  for (const [name, theme] of Object.entries(resolved.files)) {
-    if (registeredFileNames.has(name)) continue;
-    registeredFileNames.add(name);
-    const stamped = stampRegisteredThemeName(name, theme);
-    registerCustomTheme(name, () => Promise.resolve(stamped));
-  }
-}
 
 export interface CodeThemePair {
   dark: string;
@@ -56,10 +43,10 @@ export function useSyncPierreWorkerPoolTheme(
   constructedTheme: CodeThemePair,
 ): void {
   const resolved = useResolvedCodeTheme();
-  registerResolvedCodeThemeFiles();
+  registerResolvedCodeThemeFiles(registerCustomTheme);
   const theme = useResolvedCodeThemePair();
   useEffect(() => {
-    registerResolvedCodeThemeFiles();
+    registerResolvedCodeThemeFiles(registerCustomTheme);
     if (pool == null) return;
     const applied = appliedThemeByPool.get(pool) ?? constructedTheme;
     if (!appliedThemeByPool.has(pool)) {

--- a/apps/app/src/lib/plugin-code-theme.test.tsx
+++ b/apps/app/src/lib/plugin-code-theme.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+import { act, render, waitFor } from "@testing-library/react";
+import { defaultResolvedCodeTheme } from "@bb/domain";
+import type { PluginCodeThemeState } from "@get-bb/plugin-sdk";
+import { afterEach, describe, expect, it } from "vitest";
+import { applyResolvedCodeTheme } from "./code-theme";
+import { useCodeTheme } from "./plugin-code-theme";
+
+// Resolution runs against the real highlighter, so these are theme names
+// Pierre actually ships: the payload a plugin receives is the point, and a
+// fake resolver would not prove any of it.
+function renderProbe() {
+  const states: PluginCodeThemeState[] = [];
+  function Probe() {
+    states.push(useCodeTheme());
+    return null;
+  }
+  const view = render(<Probe />);
+  return {
+    latest: () => states[states.length - 1]!,
+    unmount: () => view.unmount(),
+  };
+}
+
+afterEach(() => {
+  applyResolvedCodeTheme(defaultResolvedCodeTheme);
+});
+
+describe("useCodeTheme", () => {
+  it("serves the document behind the name BB is rendering with", async () => {
+    applyResolvedCodeTheme({
+      dark: "nord",
+      light: "gruvbox-light-medium",
+      files: {},
+    });
+    const probe = renderProbe();
+
+    // Light mode is the default in a fresh jsdom document.
+    expect(probe.latest().mode).toBe("light");
+    expect(probe.latest().name).toBe("gruvbox-light-medium");
+
+    await waitFor(() => {
+      expect(probe.latest().theme?.name).toBe("gruvbox-light-medium");
+    });
+    const theme = probe.latest().theme;
+    expect(theme?.type).toBe("light");
+    // The two halves an editor needs: the surface and the token rules.
+    expect(theme?.colors["editor.background"]).toMatch(/^#[0-9a-f]{6,8}$/i);
+    expect(theme?.tokenColors.length).toBeGreaterThan(10);
+  });
+
+  it("keeps the resolved document while the next palette is in flight", async () => {
+    applyResolvedCodeTheme({
+      dark: "nord",
+      light: "gruvbox-light-medium",
+      files: {},
+    });
+    const probe = renderProbe();
+    await waitFor(() => {
+      expect(probe.latest().theme?.name).toBe("gruvbox-light-medium");
+    });
+
+    act(() => {
+      applyResolvedCodeTheme({
+        dark: "nord",
+        light: "solarized-light",
+        files: {},
+      });
+    });
+
+    // The name moves at once; the document cannot, because resolving it is
+    // async. A consumer that repaints on every change must never be handed a
+    // null here, or it paints an unthemed frame on every palette switch.
+    expect(probe.latest().name).toBe("solarized-light");
+    expect(probe.latest().theme?.name).toBe("gruvbox-light-medium");
+
+    await waitFor(() => {
+      expect(probe.latest().theme?.name).toBe("solarized-light");
+    });
+  });
+
+  it("serves an already-resolved theme on the first render of the next consumer", async () => {
+    applyResolvedCodeTheme({
+      dark: "nord",
+      light: "solarized-light",
+      files: {},
+    });
+    const first = renderProbe();
+    await waitFor(() => {
+      expect(first.latest().theme).not.toBeNull();
+    });
+    first.unmount();
+
+    // No unthemed first frame for the second editor tab the user opens.
+    expect(renderProbe().latest().theme?.name).toBe("solarized-light");
+  });
+});

--- a/apps/app/src/lib/plugin-code-theme.ts
+++ b/apps/app/src/lib/plugin-code-theme.ts
@@ -1,0 +1,85 @@
+import { useEffect, useState } from "react";
+import type {
+  PluginCodeThemeData,
+  PluginCodeThemeState,
+} from "@get-bb/plugin-sdk";
+import { usePreferredTheme } from "@/hooks/useTheme";
+import { useResolvedCodeTheme } from "@/lib/code-theme";
+import { registerResolvedCodeThemeFiles } from "@/lib/code-theme-registration";
+
+/**
+ * Theme documents already resolved in this window, keyed by the versioned
+ * name the app publishes. A palette the user toggles back and forth costs one
+ * resolve, not one per switch.
+ */
+const cache = new Map<string, PluginCodeThemeData>();
+
+/**
+ * Resolve a registered theme name to the VS Code document behind it.
+ *
+ * `@pierre/diffs` is imported dynamically: this hook can mount on any plugin
+ * surface, including ones the highlighter never reaches, and the module is
+ * megabytes of Shiki.
+ */
+async function loadCodeThemeData(name: string): Promise<PluginCodeThemeData> {
+  const cached = cache.get(name);
+  if (cached !== undefined) return cached;
+  const { registerCustomTheme, resolveTheme } = await import("@pierre/diffs");
+  // Custom palettes and BB's first-party light remaps only exist as JSON the
+  // server sends; Pierre cannot resolve their names until they are registered.
+  registerResolvedCodeThemeFiles(registerCustomTheme);
+  const resolved = await resolveTheme(name);
+  const data: PluginCodeThemeData = {
+    name,
+    type: resolved.type,
+    fg: resolved.fg,
+    bg: resolved.bg,
+    colors: resolved.colors ?? {},
+    // Shiki normalizes `tokenColors` into `settings` when it resolves a theme;
+    // a hand-registered file that skipped that step still carries the former.
+    tokenColors: resolved.settings ?? resolved.tokenColors ?? [],
+  };
+  cache.set(name, data);
+  return data;
+}
+
+/**
+ * The code theme BB currently renders with, as the VS Code document it was
+ * authored as. Exposed to plugins as `experimental_useCodeTheme()` so a plugin
+ * embedding its own editor (Monaco, CodeMirror) can translate BB's palette
+ * into that editor's theme format instead of approximating it.
+ *
+ * The previously resolved document is kept while a switch is in flight, so a
+ * consumer that repaints on every change never has an unthemed frame.
+ */
+export function useCodeTheme(): PluginCodeThemeState {
+  const mode = usePreferredTheme();
+  const resolved = useResolvedCodeTheme();
+  const name = mode === "dark" ? resolved.dark : resolved.light;
+  const [theme, setTheme] = useState<PluginCodeThemeData | null>(
+    () => cache.get(name) ?? null,
+  );
+
+  useEffect(() => {
+    const cached = cache.get(name);
+    if (cached !== undefined) {
+      setTheme(cached);
+      return;
+    }
+    let cancelled = false;
+    void loadCodeThemeData(name)
+      .then((data) => {
+        if (!cancelled) setTheme(data);
+      })
+      .catch((error: unknown) => {
+        // Keep the last good document rather than dropping consumers back to
+        // an unthemed editor over one bad palette.
+        console.error(`Failed to resolve the code theme "${name}"`, error);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [name]);
+
+  return { mode, name, theme };
+}

--- a/apps/app/src/lib/plugin-sdk-app-impl.tsx
+++ b/apps/app/src/lib/plugin-sdk-app-impl.tsx
@@ -37,6 +37,7 @@ import {
 } from "./plugin-sidebar-hooks";
 import { useSidebarThreadSplit } from "./plugin-sidebar-split";
 import { useAppNavigationHost } from "./app-navigation-host";
+import { useCodeTheme } from "./plugin-code-theme";
 
 /**
  * The real `@get-bb/plugin-sdk/app` surface (plugin design §5.2), assigned to
@@ -93,6 +94,9 @@ export const pluginSdkAppImplementation = installDeprecatedAliases(
     // Experimental (see docs/api_to_audit.md): the provider directory, so no
     // plugin re-vendors provider names or icons.
     experimental_useProviders: useProviders,
+    // Experimental (see docs/api_to_audit.md): the live code theme as its VS
+    // Code document, for plugins that render code with their own engine.
+    experimental_useCodeTheme: useCodeTheme,
   } satisfies PluginSdkApp,
   // The old spelling the facade exported before 0.4.16; bundles built
   // against it destructure this name. Removal target: bb 0.42 (see

--- a/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/SKILL.md
@@ -2401,6 +2401,21 @@ openThreadPanel({ actionId, title?, params? }), openUrl(url) }`.
   `"expanded" | "compact" | "zen"`; `draft` is
   `{ text, isEmpty, attachmentCount }`; `run` is
   `{ isRunning, isSubmitting }`.
+- `experimental_useCodeTheme()` → `{ mode, name, theme }` — the code theme bb
+  is currently rendering with. `mode` is `"light" | "dark"`, `name` is the
+  registered theme name for that mode, and `theme` is the resolved **VS Code
+  theme document** behind it: `{ name, type, fg, bg, colors, tokenColors }`,
+  the same document bb's own highlighter paints from. Reach for it ONLY when
+  your plugin renders code with an engine of its own (Monaco, CodeMirror) and
+  has to build that engine's theme; for ordinary code and diffs use
+  `experimental_SourceCode` / `experimental_Diff`, which are already themed.
+  `theme` is null only before the first document resolves, and keeps the
+  previous document while a palette switch is in flight — compare `theme.name`
+  with `name` to tell a settled state from one still resolving — so a consumer
+  that repaints on every change never paints an unthemed frame. Do NOT
+  approximate the palette by reading bb's CSS variables: `--canvas` / `--ink`
+  carry the app chrome, not the syntax colors, and a custom palette that
+  declares its own code theme would not follow.
 
 ```tsx
 const composer = useComposer();

--- a/docs/api_to_audit.md
+++ b/docs/api_to_audit.md
@@ -1212,6 +1212,37 @@ provider-retry) stops vendoring provider names, icons, and copy.
    (monochrome by construction) is the contract or a full-color logo path is
    owed.
 
+## `app.experimental_useCodeTheme` (`@get-bb/plugin-sdk/app`)
+
+**What it does.** Returns `{ mode, name, theme }`: the app's active light/dark
+mode, the registered name of the code theme bb renders that mode with, and the
+resolved VS Code theme document behind it (`type`, `fg`, `bg`, `colors`,
+`tokenColors`) — the same document bb's own highlighter paints from. It exists
+for plugins that render code with an engine of their own (the Monaco file
+editor is the first): without it, an embedded editor can only follow
+light/dark and strands its syntax colors on a palette bb is not using.
+`theme` is null only before the first resolve, and holds the previous document
+while a palette switch resolves, so a consumer never paints an unthemed frame.
+
+**Audit before stabilizing.**
+
+1. **Shape of the document.** `PluginCodeThemeData` mirrors Shiki's
+   `ThemeRegistrationResolved` minus the fields bb does not promise
+   (`semanticTokenColors`, `include`, `displayName`). Decide whether freezing a
+   Shiki-shaped payload is right, or whether the contract should be bb's own
+   normalized token model — a Shiki major that changes `settings` normalization
+   changes what plugins receive.
+2. **Both modes at once.** The hook serves only the active mode. An editor that
+   wants to prebuild its light and dark themes has to toggle to see the other.
+   Decide whether the state should carry the pair.
+3. **Where the resolve happens.** Resolution runs in the app window through a
+   dynamic `@pierre/diffs` import and caches per theme name for the window's
+   lifetime; a custom palette edited on disk keeps its old document until
+   reload, because the versioned wire name only changes when the server
+   re-resolves. Confirm that matches what the built-in surfaces do.
+4. **Consumer count.** One consumer today. Confirm a second engine (CodeMirror,
+   xterm) needs the same payload before the prefix drops.
+
 ## `app.slots.experimental_providerIcon` (`@get-bb/plugin-sdk/app`)
 
 **Kept experimental (2026-08-22).** zero consumers — every provider bb ships declares an SVG asset and `ProviderInfo.icon.glyph` / `logoUrl` cover both declared forms without a frontend bundle; the open questions are id squatting and whether the slot should exist at all (deleting it is the owner's call).

--- a/packages/domain/src/plugin-sdk-version.ts
+++ b/packages/domain/src/plugin-sdk-version.ts
@@ -16,7 +16,7 @@
 // PLUGIN_SDK_MAJOR is 0, so the major-only artifact gate cannot distinguish
 // 0.x releases and is intentionally vacuous for them until a future 1.0.
 // Rebuildable artifacts still rebuild on the exact sdkVersion-differs trigger.
-export const PLUGIN_SDK_VERSION = "0.4.21";
+export const PLUGIN_SDK_VERSION = "0.4.22";
 
 /** Major of {@link PLUGIN_SDK_VERSION} — the plugin API compatibility number. */
 export const PLUGIN_SDK_MAJOR = Number(PLUGIN_SDK_VERSION.split(".", 1)[0]);

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@get-bb/plugin-sdk",
-  "version": "0.4.21",
+  "version": "0.4.22",
   "homepage": "https://github.com/get-bb/bb#readme",
   "bugs": {
     "url": "https://github.com/get-bb/bb/issues"

--- a/packages/plugin-sdk/src/app-contract.ts
+++ b/packages/plugin-sdk/src/app-contract.ts
@@ -418,16 +418,15 @@ export type ExperimentalPluginFixedTabReference<
     });
 
 /** A fixed tab declared by a plugin nav panel. */
-export type PluginFixedTabRegistration<
-  Target extends JsonValue = never,
-> = ExperimentalPluginFixedTabReference<Target> & {
-  title: string;
-  /** Icon hint (BB icon name); unknown names fall back to a generic icon. */
-  icon: string;
-  component: ComponentType<PluginNavPanelProps>;
-  /** `flush` lets the component own padding and scrolling. */
-  layout?: "padded" | "flush";
-};
+export type PluginFixedTabRegistration<Target extends JsonValue = never> =
+  ExperimentalPluginFixedTabReference<Target> & {
+    title: string;
+    /** Icon hint (BB icon name); unknown names fall back to a generic icon. */
+    icon: string;
+    component: ComponentType<PluginNavPanelProps>;
+    /** `flush` lets the component own padding and scrolling. */
+    layout?: "padded" | "flush";
+  };
 
 /** A fixed tab with either no target or an owner-validated JSON target. */
 export type PluginFixedTabDeclaration =
@@ -792,6 +791,56 @@ export interface PluginSidebarThreadsState {
 export interface PluginProvidersState {
   status: "loading" | "ready" | "error";
   providers: readonly ProviderInfo[];
+}
+
+/**
+ * One TextMate token rule from the active code theme, in the shape VS Code
+ * theme files author it.
+ */
+export interface PluginCodeThemeTokenRule {
+  /** Scope(s) the rule paints; absent means the theme's base rule. */
+  scope?: string | readonly string[];
+  settings: {
+    /** `#rrggbb` or `#rrggbbaa`. */
+    foreground?: string;
+    background?: string;
+    /** Space-separated TextMate font styles, e.g. `"bold italic"`. */
+    fontStyle?: string;
+  };
+}
+
+/**
+ * The active code theme as a VS Code theme file: the same document BB's own
+ * highlighter renders from, so a plugin that embeds a third-party editor can
+ * translate it into that editor's theme format rather than guessing colors
+ * from CSS variables.
+ */
+export interface PluginCodeThemeData {
+  /** Registered theme name — a bundled Shiki name or a BB-registered id. */
+  name: string;
+  type: "light" | "dark";
+  /** Default editor foreground, as `#rrggbb[aa]`. */
+  fg: string;
+  /** Default editor background, as `#rrggbb[aa]`. */
+  bg: string;
+  /** VS Code workbench colors (`editor.background`, `editorCursor.foreground`, …). */
+  colors: Readonly<Record<string, string>>;
+  tokenColors: readonly PluginCodeThemeTokenRule[];
+}
+
+/**
+ * The code theme BB is currently rendering with (see
+ * {@link PluginSdkApp.experimental_useCodeTheme}). `mode` and `name` change
+ * the moment the user switches palette or light/dark; `theme` follows once
+ * the theme file resolves, and keeps the previous document until then so a
+ * consumer never has to paint an unthemed frame. Compare `theme.name` with
+ * `name` to tell a settled state from one still resolving.
+ */
+export interface PluginCodeThemeState {
+  mode: "light" | "dark";
+  name: string;
+  /** null only before the first theme file resolves. */
+  theme: PluginCodeThemeData | null;
 }
 
 /**
@@ -2065,6 +2114,13 @@ export interface PluginSdkApp {
    * see docs/api_to_audit.md.
    */
   experimental_useProviders(): PluginProvidersState;
+  /**
+   * The active code theme as a VS Code theme file (see
+   * {@link PluginCodeThemeState}), for a plugin that renders code with an
+   * engine of its own and needs BB's palette to reach it. Experimental: see
+   * docs/api_to_audit.md.
+   */
+  experimental_useCodeTheme(): PluginCodeThemeState;
   /**
    * The host-owned chat component (see {@link ThreadChatProps}). Together
    * with `Markdown`, the only components the SDK ships — everything else

--- a/packages/plugin-sdk/src/app.ts
+++ b/packages/plugin-sdk/src/app.ts
@@ -82,3 +82,6 @@ export const experimental_useSidebarThreadSplit =
   runtime.experimental_useSidebarThreadSplit;
 // The provider directory (experimental — see docs/api_to_audit.md).
 export const experimental_useProviders = runtime.experimental_useProviders;
+// The live code theme, for plugins that render code with their own engine
+// (experimental — see docs/api_to_audit.md).
+export const experimental_useCodeTheme = runtime.experimental_useCodeTheme;

--- a/packages/plugin-sdk/src/testing/app.tsx
+++ b/packages/plugin-sdk/src/testing/app.tsx
@@ -19,6 +19,7 @@ import {
   type ComposerView,
   type PluginAppDefinition,
   type PluginAppSetup,
+  type PluginCodeThemeState,
   type PluginContentScriptDisposer,
   type PluginContentScriptRegistration,
   type PluginComposerApi,
@@ -188,6 +189,7 @@ interface SlotEnv {
   sidebarActionCalls: SidebarActionCall[];
   sidebarPullRequests: ReadonlyMap<string, PluginSidebarPullRequest>;
   providers: PluginProvidersState;
+  codeTheme: PluginCodeThemeState;
 }
 
 interface TestFixedTabTargetStore {
@@ -805,6 +807,9 @@ const testPluginSdkApp = {
   experimental_useProviders(): PluginProvidersState {
     return useSlotEnv("experimental_useProviders").providers;
   },
+  experimental_useCodeTheme(): PluginCodeThemeState {
+    return useSlotEnv("experimental_useCodeTheme").codeTheme;
+  },
   experimental_useSidebarThreadActions(): PluginSidebarThreadActions {
     return useSlotEnv("experimental_useSidebarThreadActions").sidebarActions;
   },
@@ -1112,6 +1117,11 @@ export interface RenderSlotOptions<
    */
   providers?: Partial<PluginProvidersState>;
   /**
+   * The code theme `experimental_useCodeTheme()` reports. Omitted → a light
+   * mode with no resolved document, the state a plugin sees on first paint.
+   */
+  codeTheme?: Partial<PluginCodeThemeState>;
+  /**
    * Pull requests `experimental_useSidebarThreadPullRequest()` reports, keyed
    * by thread id. Omitted → every thread reports none.
    */
@@ -1362,6 +1372,11 @@ export function renderSlot<
     status: options.providers?.status ?? "ready",
     providers: options.providers?.providers ?? [],
   };
+  const codeTheme: PluginCodeThemeState = {
+    mode: options.codeTheme?.mode ?? "light",
+    name: options.codeTheme?.name ?? "pierre-light",
+    theme: options.codeTheme?.theme ?? null,
+  };
   const sidebarActions: PluginSidebarThreadActions = {
     open(threadId, openOptions) {
       sidebarActionCalls.push({
@@ -1555,6 +1570,7 @@ export function renderSlot<
     sidebarActionCalls,
     sidebarPullRequests,
     providers,
+    codeTheme,
   };
 
   const releaseComposerOwnership = (): void => {

--- a/plugins/monaco-editor/app.tsx
+++ b/plugins/monaco-editor/app.tsx
@@ -8,6 +8,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
   definePluginApp,
+  experimental_useCodeTheme,
   useRpc,
   type PluginFileOpenerProps,
 } from "@get-bb/plugin-sdk/app";
@@ -19,6 +20,7 @@ import {
   overflowWidgetsNode,
   setOverflowWidgetsTheme,
 } from "./lib/monaco-loader.js";
+import { applyCodeTheme, editorBackground } from "./lib/monaco-theme.js";
 import { cn } from "@bb/shared-ui/lib/utils";
 import { FileToolbar, type SaveIndicator } from "./components/FileToolbar.js";
 import { FileTreePanel } from "./components/FileTreePanel.js";
@@ -38,30 +40,18 @@ type SaveState =
   | { kind: "error"; message: string }
   | { kind: "conflict" };
 
-/** Monaco's dark/light pair, following the app's `<html class="dark">`. */
-function useMonacoTheme(): "vs-dark" | "vs" {
-  const [isDark, setIsDark] = useState(
-    () => document.documentElement.classList.contains("dark"),
-  );
-  useEffect(() => {
-    const target = document.documentElement;
-    const observer = new MutationObserver(() => {
-      setIsDark(target.classList.contains("dark"));
-    });
-    observer.observe(target, { attributes: true, attributeFilter: ["class"] });
-    return () => observer.disconnect();
-  }, []);
-  return isDark ? "vs-dark" : "vs";
-}
-
-function MonacoFileOpener({
-  path,
-  source,
-  Original,
-}: PluginFileOpenerProps) {
+function MonacoFileOpener({ path, source, Original }: PluginFileOpenerProps) {
   const rpc = useRpc<typeof rpcContract>();
-  const theme = useMonacoTheme();
+  // BB's live code theme — the same VS Code document its own file preview
+  // renders from, so the editor follows the app palette and not just
+  // light/dark. Held in a ref as well, because the boot effect below has to
+  // theme the editor at construction and must not re-create it on a palette
+  // change.
+  const codeTheme = experimental_useCodeTheme();
+  const codeThemeRef = useRef(codeTheme);
+  codeThemeRef.current = codeTheme;
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const monacoRef = useRef<typeof MonacoNs | null>(null);
   const editorRef = useRef<MonacoNs.editor.IStandaloneCodeEditor | null>(null);
 
   // The file actually in the editor. It starts as the one BB opened the tab
@@ -288,18 +278,19 @@ function MonacoFileOpener({
         if (disposed) return;
         const container = containerRef.current;
         if (!container) return;
+        monacoRef.current = monaco;
 
         sha256Ref.current = file.sha256;
+        // Define BB's theme before the first paint; the effect below only
+        // handles later palette and light/dark changes.
+        const applied = applyCodeTheme(monaco, codeThemeRef.current);
+        setOverflowWidgetsTheme(applied.base);
         const editor = monaco.editor.create(container, {
           value: file.content,
           language: languageForPath(activePath),
           automaticLayout: true,
           lineNumbers: "on",
-          // Read from the DOM rather than the hook so the editor is created
-          // in the right theme; re-theming on toggle is a separate effect.
-          theme: document.documentElement.classList.contains("dark")
-            ? "vs-dark"
-            : "vs",
+          theme: applied.name,
           minimap: { enabled: false },
           scrollBeyondLastLine: false,
           // Matches BB's own file preview, which renders its code table as
@@ -361,12 +352,18 @@ function MonacoFileOpener({
     };
   }, [activePath, rpc, setSaveState, source]);
 
+  // Follow palette and light/dark changes. Monaco's theme is per-instance in
+  // its options but global in effect — defining and selecting it here re-themes
+  // every open editor, which is what a palette change should do.
   useEffect(() => {
-    editorRef.current?.updateOptions({ theme });
+    const monaco = monacoRef.current;
+    if (monaco === null) return;
+    const applied = applyCodeTheme(monaco, codeTheme);
+    editorRef.current?.updateOptions({ theme: applied.name });
     // The overflow host lives outside the editor, so Monaco does not re-theme
     // it for us.
-    setOverflowWidgetsTheme(theme);
-  }, [theme, status]);
+    setOverflowWidgetsTheme(applied.base);
+  }, [codeTheme, status]);
 
   // Binary and oversized files are ordinary things to click on, and this
   // plugin claims broad extensions. Hand them back to BB's own preview, which
@@ -378,6 +375,7 @@ function MonacoFileOpener({
       {isFilesOpen ? (
         <FileTreePanel
           activePath={activePath}
+          background={editorBackground(codeTheme.theme)}
           entries={tree.entries}
           error={tree.error}
           isLoading={tree.isLoading}

--- a/plugins/monaco-editor/components/FileTreePanel.tsx
+++ b/plugins/monaco-editor/components/FileTreePanel.tsx
@@ -25,6 +25,12 @@ export interface FileTreePanelProps {
   truncated: boolean;
   /** The file currently in the editor, revealed and highlighted. */
   activePath: string;
+  /**
+   * The editor's own background, so the tree reads as part of the same
+   * surface as the code rather than as BB chrome laid over it. Null until the
+   * code theme resolves, which falls back to BB's recessed surface token.
+   */
+  background: string | null;
   onOpenFile: (path: string) => void;
   onClose: () => void;
 }
@@ -32,6 +38,7 @@ export interface FileTreePanelProps {
 const INDENT_PER_LEVEL_PX = 12;
 
 export function FileTreePanel({
+  background,
   entries,
   root,
   isLoading,
@@ -173,10 +180,24 @@ export function FileTreePanel({
     // separate the tree from the file bar beneath it.
     <div
       ref={panelRef}
-      style={{ height }}
-      className="flex shrink-0 flex-col bg-surface-recessed"
+      style={{
+        height,
+        // Rows and the filter row are transparent, so this one declaration
+        // carries the whole panel. The hover and active tints over it are
+        // translucent BB tokens, which composite onto it correctly.
+        ...(background === null ? {} : { backgroundColor: background }),
+      }}
+      className={cn(
+        "flex shrink-0 flex-col",
+        background === null && "bg-surface-recessed",
+      )}
     >
-      <div className="flex shrink-0 items-center gap-1.5 px-3 py-1.5">
+      {/*
+        The tree's own bar, on the same surface token as the file bar below
+        it: the two stack, and reading as one strip of chrome is what keeps
+        the tree's background from looking like a third surface.
+      */}
+      <div className="flex h-9 shrink-0 items-center gap-1.5 bg-surface-raised px-4">
         <input
           type="text"
           value={query}
@@ -193,7 +214,10 @@ export function FileTreePanel({
           aria-label="Filter files"
           spellCheck={false}
           className={cn(
-            "h-6 min-w-0 flex-1 rounded-sm bg-background px-2 text-sm text-foreground",
+            // A translucent inset rather than an app surface token: the panel
+            // now sits on the editor's background, and an opaque field on it
+            // would be a second, unrelated surface.
+            "h-6 min-w-0 flex-1 rounded-sm bg-state-hover px-2 text-sm text-foreground",
             "placeholder:text-muted-foreground",
             "focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none",
           )}

--- a/plugins/monaco-editor/components/FileTreePanel.tsx
+++ b/plugins/monaco-editor/components/FileTreePanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import {
   ancestorsOf,
   buildTree,
@@ -7,6 +7,11 @@ import {
   type TreeNode,
 } from "../lib/file-tree.js";
 import { toast } from "sonner";
+import {
+  clampTreeHeight,
+  readStoredTreeHeight,
+  storeTreeHeight,
+} from "../lib/file-tree-height.js";
 import { ContextMenu, type ContextMenuState } from "./ContextMenu.js";
 import { cn } from "@bb/shared-ui/lib/utils";
 
@@ -40,6 +45,61 @@ export function FileTreePanel({
   const [expanded, setExpanded] = useState<ReadonlySet<string>>(new Set());
   const [menu, setMenu] = useState<ContextMenuState | null>(null);
   const activeRowRef = useRef<HTMLButtonElement | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  // Seeded from storage so a resize survives hiding and reshowing the panel.
+  const [height, setHeight] = useState(readStoredTreeHeight);
+  const heightRef = useRef(height);
+  heightRef.current = height;
+  // The height the user asked for, which is not always the one on screen: a
+  // pane too short to honour it renders the clamped height and restores this
+  // one when the pane grows again.
+  const requestedHeightRef = useRef(height);
+  // The height the drag started from, so the panel tracks the total pointer
+  // delta. Accumulating per move event instead would drift: every move the
+  // clamp absorbs would be lost, and dragging back would not return the seam
+  // to the pointer.
+  const dragStartHeightRef = useRef<number | null>(null);
+
+  /** The space the tree and the editor share. */
+  const availableHeight = (): number =>
+    panelRef.current?.parentElement?.clientHeight ?? window.innerHeight;
+
+  const applyHeight = (requested: number) => {
+    requestedHeightRef.current = requested;
+    setHeight(clampTreeHeight(requested, availableHeight()));
+  };
+
+  const startResize = () => {
+    dragStartHeightRef.current = heightRef.current;
+  };
+
+  const resizeBy = (deltaY: number) => {
+    applyHeight((dragStartHeightRef.current ?? heightRef.current) + deltaY);
+  };
+
+  const commitHeight = () => {
+    dragStartHeightRef.current = null;
+    storeTreeHeight(heightRef.current);
+  };
+
+  // A stored height can be taller than the pane the panel opens in — a short
+  // window, or a secondary panel split small — and the pane can change size
+  // under it. Re-fit on both rather than letting the tree take the surface.
+  useLayoutEffect(() => {
+    const parent = panelRef.current?.parentElement;
+    if (parent === null || parent === undefined) return;
+    const fit = () => {
+      const next = clampTreeHeight(
+        requestedHeightRef.current,
+        parent.clientHeight,
+      );
+      if (next !== heightRef.current) setHeight(next);
+    };
+    fit();
+    const observer = new ResizeObserver(fit);
+    observer.observe(parent);
+    return () => observer.disconnect();
+  }, []);
 
   const openMenu = (event: React.MouseEvent, node: TreeNode) => {
     event.preventDefault();
@@ -111,7 +171,11 @@ export function FileTreePanel({
   return (
     // Sits above the toolbar, so the divider goes on the bottom edge to
     // separate the tree from the file bar beneath it.
-    <div className="flex max-h-64 shrink-0 flex-col border-b border-border bg-surface-recessed">
+    <div
+      ref={panelRef}
+      style={{ height }}
+      className="flex shrink-0 flex-col bg-surface-recessed"
+    >
       <div className="flex shrink-0 items-center gap-1.5 px-3 py-1.5">
         <input
           type="text"
@@ -185,9 +249,99 @@ export function FileTreePanel({
         ) : null}
       </div>
       <ContextMenu state={menu} onClose={() => setMenu(null)} />
+      <ResizeHandle
+        onResize={resizeBy}
+        onResizeEnd={commitHeight}
+        onResizeStart={startResize}
+      />
     </div>
   );
 }
+
+/**
+ * The draggable seam between the tree and the editor, in the same idiom as
+ * BB's own pane dividers: a hairline that is the border, plus a taller
+ * transparent hit target straddling it so the pointer does not have to find
+ * one pixel.
+ */
+function ResizeHandle({
+  onResize,
+  onResizeEnd,
+  onResizeStart,
+}: {
+  onResize: (deltaY: number) => void;
+  onResizeEnd: () => void;
+  onResizeStart: () => void;
+}) {
+  const dividerRef = useRef<HTMLDivElement | null>(null);
+
+  const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    // Only the primary button drags; a right-click here opens the app menu.
+    if (event.button !== 0) return;
+    event.preventDefault();
+    const target = event.currentTarget;
+    const pointerId = event.pointerId;
+    const startY = event.clientY;
+    const divider = dividerRef.current;
+    if (divider !== null) divider.dataset.dragging = "true";
+    onResizeStart();
+    // Capture on the hit target so the drag survives the pointer leaving it —
+    // which it does immediately, since the seam moves out from under it.
+    target.setPointerCapture(pointerId);
+
+    const move = (moveEvent: PointerEvent) => {
+      if (moveEvent.pointerId !== pointerId) return;
+      onResize(moveEvent.clientY - startY);
+    };
+    const finish = (finishEvent: PointerEvent) => {
+      if (finishEvent.pointerId !== pointerId) return;
+      target.removeEventListener("pointermove", move);
+      target.removeEventListener("pointerup", finish);
+      target.removeEventListener("pointercancel", finish);
+      if (target.hasPointerCapture(pointerId)) {
+        target.releasePointerCapture(pointerId);
+      }
+      if (divider !== null) delete divider.dataset.dragging;
+      onResizeEnd();
+    };
+    target.addEventListener("pointermove", move);
+    target.addEventListener("pointerup", finish);
+    target.addEventListener("pointercancel", finish);
+  };
+
+  return (
+    <div
+      ref={dividerRef}
+      role="separator"
+      aria-label="Resize the file tree"
+      aria-orientation="horizontal"
+      tabIndex={0}
+      onKeyDown={(event) => {
+        // The keyboard path a pointer-only divider owes: same clamping, one
+        // row at a time, so the tree is reachable without a pointer.
+        if (event.key === "ArrowUp") onResize(-KEYBOARD_RESIZE_STEP_PX);
+        else if (event.key === "ArrowDown") onResize(KEYBOARD_RESIZE_STEP_PX);
+        else return;
+        event.preventDefault();
+        onResizeEnd();
+      }}
+      className={cn(
+        "relative z-10 h-px shrink-0 cursor-row-resize bg-border transition-colors",
+        "hover:bg-ring/40 data-[dragging]:bg-ring/40",
+        "focus-visible:bg-ring focus-visible:outline-none",
+      )}
+    >
+      <div
+        aria-hidden
+        onPointerDown={handlePointerDown}
+        className="absolute -top-1.5 left-0 h-3 w-full cursor-row-resize touch-none bg-transparent"
+      />
+    </div>
+  );
+}
+
+/** One row of the tree, so a keyboard resize moves by something meaningful. */
+const KEYBOARD_RESIZE_STEP_PX = 24;
 
 /** Clipboard write with the same toast treatment as the toolbar's path copy. */
 function copy(text: string, successMessage: string): void {

--- a/plugins/monaco-editor/lib/file-tree-height.ts
+++ b/plugins/monaco-editor/lib/file-tree-height.ts
@@ -1,0 +1,53 @@
+/**
+ * The file tree's height, which the user drags. Kept out of the component so
+ * the clamping rules are testable without a layout engine.
+ */
+
+/** Matches the fixed `max-h-64` the panel shipped with before it could resize. */
+export const DEFAULT_TREE_HEIGHT = 256;
+
+/** Below this the tree shows its filter box and nothing usable under it. */
+export const MIN_TREE_HEIGHT = 96;
+
+/** Room the toolbar, any notice row, and a few code lines always keep. */
+export const MIN_EDITOR_HEIGHT = 120;
+
+const STORAGE_KEY = "bb-plugin-monaco-editor:file-tree-height";
+
+/**
+ * Fit a requested height into what the surface can give. A pane too short to
+ * honour both minimums gives the tree its minimum and lets the editor take
+ * what is left: a tree dragged out of reach is worse than a short editor the
+ * user can drag back.
+ */
+export function clampTreeHeight(height: number, available: number): number {
+  const max = Math.max(MIN_TREE_HEIGHT, available - MIN_EDITOR_HEIGHT);
+  return Math.round(Math.min(Math.max(height, MIN_TREE_HEIGHT), max));
+}
+
+/**
+ * The height this window last left the tree at. Persisted rather than held in
+ * React state because the panel unmounts every time the user hides it, and a
+ * resize the user made should survive that — and reopening the file in a new
+ * tab.
+ */
+export function readStoredTreeHeight(): number {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw === null) return DEFAULT_TREE_HEIGHT;
+    const parsed = Number.parseInt(raw, 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_TREE_HEIGHT;
+    return Math.max(parsed, MIN_TREE_HEIGHT);
+  } catch {
+    // Storage can throw outright in a partitioned or storage-blocked context.
+    return DEFAULT_TREE_HEIGHT;
+  }
+}
+
+export function storeTreeHeight(height: number): void {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, String(Math.round(height)));
+  } catch {
+    // A height that cannot be remembered is not worth failing a drag over.
+  }
+}

--- a/plugins/monaco-editor/lib/monaco-loader.ts
+++ b/plugins/monaco-editor/lib/monaco-loader.ts
@@ -152,8 +152,14 @@ export function overflowWidgetsNode(): HTMLElement {
   return node;
 }
 
-/** Keeps the overflow host on the same Monaco theme as the editors. */
-export function setOverflowWidgetsTheme(theme: "vs" | "vs-dark"): void {
+/**
+ * Keeps the overflow host on the same Monaco theme as the editors.
+ *
+ * Only the base matters: Monaco emits one global stylesheet for the active
+ * theme and keys the light/dark half of it on `vs` / `vs-dark`, so a custom
+ * theme's own name never appears in a class list.
+ */
+export function setOverflowWidgetsTheme(base: "vs" | "vs-dark"): void {
   const node = document.getElementById(OVERFLOW_NODE_ID);
-  if (node !== null) node.className = `monaco-editor ${theme}`;
+  if (node !== null) node.className = `monaco-editor ${base}`;
 }

--- a/plugins/monaco-editor/lib/monaco-theme.test.ts
+++ b/plugins/monaco-editor/lib/monaco-theme.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest";
+import type { PluginCodeThemeData } from "@get-bb/plugin-sdk/app";
+import {
+  applyCodeTheme,
+  editorBackground,
+  monacoThemeName,
+  toMonacoTheme,
+} from "./monaco-theme.js";
+
+function theme(
+  overrides: Partial<PluginCodeThemeData> = {},
+): PluginCodeThemeData {
+  return {
+    name: "bb:nord:light:1f4c9a2b",
+    type: "light",
+    fg: "#2e3440",
+    bg: "#eceff4",
+    colors: {},
+    tokenColors: [],
+    ...overrides,
+  };
+}
+
+/** Monaco's own guard: `defineTheme` throws on anything outside this set. */
+const MONACO_THEME_NAME = /^[a-zA-Z0-9-]+$/;
+
+describe("monacoThemeName", () => {
+  it("maps BB's namespaced, fingerprinted names into what Monaco accepts", () => {
+    expect(monacoThemeName("bb:nord:light:1f4c9a2b")).toMatch(
+      MONACO_THEME_NAME,
+    );
+    expect(monacoThemeName("catppuccin-mocha")).toMatch(MONACO_THEME_NAME);
+  });
+
+  it("keeps distinct theme names distinct", () => {
+    expect(monacoThemeName("bb:nord:light")).not.toBe(
+      monacoThemeName("bb:nord:dark"),
+    );
+  });
+});
+
+describe("toMonacoTheme", () => {
+  it("takes its base from the theme's own type", () => {
+    expect(toMonacoTheme(theme({ type: "dark" })).base).toBe("vs-dark");
+    expect(toMonacoTheme(theme({ type: "light" })).base).toBe("vs");
+  });
+
+  it("emits a default rule so unmatched tokens do not fall back to the base theme", () => {
+    expect(toMonacoTheme(theme()).rules[0]).toEqual({
+      token: "",
+      foreground: "2e3440",
+    });
+  });
+
+  it("expands short hex and drops colors Monaco's rule parser would throw on", () => {
+    const { rules } = toMonacoTheme(
+      theme({
+        tokenColors: [
+          { scope: "comment", settings: { foreground: "#abc" } },
+          { scope: "keyword", settings: { foreground: "not-a-color" } },
+          { scope: "string", settings: { foreground: "#11223344" } },
+        ],
+      }),
+    );
+    expect(rules).toContainEqual({ token: "comment", foreground: "aabbcc" });
+    expect(rules).toContainEqual({ token: "string", foreground: "11223344" });
+    expect(rules.some((rule) => rule.token === "keyword")).toBe(false);
+  });
+
+  it("splits both spellings of a multi-scope rule into one rule each", () => {
+    const { rules } = toMonacoTheme(
+      theme({
+        tokenColors: [
+          {
+            scope: ["variable", "entity.name"],
+            settings: { foreground: "#111111" },
+          },
+          {
+            scope: "constant, support.type",
+            settings: { foreground: "#222222" },
+          },
+        ],
+      }),
+    );
+    expect(rules).toContainEqual({ token: "variable", foreground: "111111" });
+    expect(rules).toContainEqual({
+      token: "entity.name",
+      foreground: "111111",
+    });
+    expect(rules).toContainEqual({ token: "constant", foreground: "222222" });
+    expect(rules).toContainEqual({
+      token: "support.type",
+      foreground: "222222",
+    });
+  });
+
+  it("keeps only the font styles Monaco understands", () => {
+    const { rules } = toMonacoTheme(
+      theme({
+        tokenColors: [
+          {
+            scope: "comment",
+            settings: {
+              foreground: "#111111",
+              fontStyle: "italic strikethrough",
+            },
+          },
+          { scope: "keyword", settings: { fontStyle: "bold underline" } },
+        ],
+      }),
+    );
+    expect(rules).toContainEqual({
+      token: "comment",
+      foreground: "111111",
+      fontStyle: "italic",
+    });
+    expect(rules).toContainEqual({
+      token: "keyword",
+      fontStyle: "bold underline",
+    });
+  });
+
+  it("fills the editor surface from the theme's own pair when it declares no workbench colors", () => {
+    expect(toMonacoTheme(theme()).colors).toEqual({
+      "editor.background": "#eceff4",
+      "editor.foreground": "#2e3440",
+    });
+  });
+
+  it("prefers declared workbench colors and drops values Color.fromHex would read as red", () => {
+    expect(
+      toMonacoTheme(
+        theme({
+          colors: {
+            "editor.background": "#1e1e1e",
+            "editorCursor.foreground": "#88c0d0",
+            "editor.selectionBackground": "rgba(0,0,0,0.2)",
+          },
+        }),
+      ).colors,
+    ).toEqual({
+      "editor.background": "#1e1e1e",
+      "editorCursor.foreground": "#88c0d0",
+      "editor.foreground": "#2e3440",
+    });
+  });
+});
+
+describe("applyCodeTheme", () => {
+  function fakeMonaco(defined: string[]) {
+    return {
+      editor: { defineTheme: (name: string) => defined.push(name) },
+    } as unknown as Parameters<typeof applyCodeTheme>[0];
+  }
+
+  it("falls back to Monaco's stock pair before the first theme document resolves", () => {
+    const defined: string[] = [];
+    expect(
+      applyCodeTheme(fakeMonaco(defined), { mode: "dark", theme: null }),
+    ).toEqual({ name: "vs-dark", base: "vs-dark" });
+    expect(defined).toEqual([]);
+  });
+
+  it("keys the widget base on the applied document, so a mid-switch frame stays coherent", () => {
+    // The app has flipped to dark but the dark document has not resolved yet:
+    // the light document is still what is painted.
+    expect(
+      applyCodeTheme(fakeMonaco([]), { mode: "dark", theme: theme() }).base,
+    ).toBe("vs");
+  });
+});
+
+describe("editorBackground", () => {
+  it("prefers the declared workbench color over the theme's own pair", () => {
+    expect(
+      editorBackground(theme({ colors: { "editor.background": "#1e1e2e" } })),
+    ).toBe("#1e1e2e");
+  });
+
+  it("falls back to the theme's background, and to nothing before one resolves", () => {
+    expect(editorBackground(theme())).toBe("#eceff4");
+    expect(editorBackground(null)).toBeNull();
+  });
+
+  it("reports nothing for a background the browser could not paint", () => {
+    // The caller keeps its BB surface token rather than setting a broken value.
+    expect(
+      editorBackground(
+        theme({ bg: "not-a-color", colors: { "editor.background": "red" } }),
+      ),
+    ).toBeNull();
+  });
+});

--- a/plugins/monaco-editor/lib/monaco-theme.ts
+++ b/plugins/monaco-editor/lib/monaco-theme.ts
@@ -1,0 +1,203 @@
+import type * as MonacoNs from "monaco-editor";
+import type { PluginCodeThemeData } from "@get-bb/plugin-sdk/app";
+
+/**
+ * Translates BB's active code theme — a VS Code theme document — into a
+ * Monaco theme, so the editor follows "Settings › Appearance › Theme" the way
+ * BB's own file preview does rather than sitting on stock `vs` / `vs-dark`.
+ *
+ * The mapping is the same one Shiki uses for Monaco: Monaco's standalone
+ * theme matches rules by dotted-prefix on the token it emits, and its Monarch
+ * tokens (`keyword`, `string`, `comment`, `number`, `type`, …) are spelled
+ * like the head of a TextMate scope, so TextMate rules land on the right
+ * tokens even though nothing here runs a TextMate grammar. Deeper scopes
+ * (`meta.function-call.python`) simply never match anything Monaco emits.
+ */
+
+/** What Monaco's token-rule parser accepts: 6- or 8-digit hex. */
+const TOKEN_COLOR = /^#?([0-9A-Fa-f]{6})([0-9A-Fa-f]{2})?$/;
+/** What `Color.fromHex` accepts for the workbench color map. */
+const WORKBENCH_COLOR = /^#([0-9A-Fa-f]{3,4}|[0-9A-Fa-f]{6}|[0-9A-Fa-f]{8})$/;
+
+/**
+ * Monaco rejects a theme name outside `[a-z0-9-]i`, and BB's names are
+ * namespaced ids with a content fingerprint (`bb:nord:light:1f4c9a2b`). Map
+ * the rejected characters rather than hashing, so the name stays readable in
+ * the DOM (Monaco writes it into the editor's class list) and stays unique.
+ */
+export function monacoThemeName(name: string): string {
+  const safe = name.replace(/[^a-zA-Z0-9-]/g, "-");
+  return `bb-${safe}`;
+}
+
+/** Expand `#abc` / `#abcd`; drop anything Monaco's rule parser would throw on. */
+function tokenColor(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  const hex = value.startsWith("#") ? value.slice(1) : value;
+  const expanded =
+    hex.length === 3 || hex.length === 4
+      ? hex
+          .split("")
+          .map((digit) => digit + digit)
+          .join("")
+      : hex;
+  // Monaco's own themes carry no alpha on token colors and its parser drops
+  // the channel it does accept, so an 8-digit value is passed through as-is
+  // and simply loses its transparency.
+  return TOKEN_COLOR.test(expanded) ? expanded : undefined;
+}
+
+function tokenRules(
+  theme: PluginCodeThemeData,
+): MonacoNs.editor.ITokenThemeRule[] {
+  const rules: MonacoNs.editor.ITokenThemeRule[] = [];
+  // The default rule. Monaco needs an explicit empty-token rule or unmatched
+  // tokens fall back to the base theme's foreground.
+  const base = tokenColor(theme.fg);
+  if (base !== undefined) rules.push({ token: "", foreground: base });
+  for (const rule of theme.tokenColors) {
+    const foreground = tokenColor(rule.settings.foreground);
+    const background = tokenColor(rule.settings.background);
+    const fontStyle = fontStyleFor(rule.settings.fontStyle);
+    if (
+      foreground === undefined &&
+      background === undefined &&
+      fontStyle === undefined
+    ) {
+      continue;
+    }
+    const scopes =
+      rule.scope === undefined
+        ? [""]
+        : typeof rule.scope === "string"
+          ? // A comma-joined scope list is as common in theme files as an array.
+            rule.scope.split(",")
+          : rule.scope;
+    for (const scope of scopes) {
+      const token = scope.trim();
+      if (rule.scope !== undefined && token === "") continue;
+      rules.push({
+        token,
+        ...(foreground === undefined ? {} : { foreground }),
+        ...(background === undefined ? {} : { background }),
+        ...(fontStyle === undefined ? {} : { fontStyle }),
+      });
+    }
+  }
+  return rules;
+}
+
+/**
+ * Monaco understands `italic`, `bold`, and `underline` in any combination,
+ * and treats an empty string as "no style". TextMate's `strikethrough` has no
+ * Monaco equivalent and is dropped.
+ */
+function fontStyleFor(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  const styles = value
+    .split(/\s+/)
+    .filter(
+      (style) =>
+        style === "italic" || style === "bold" || style === "underline",
+    );
+  // An explicit "normal" (or a lone "strikethrough") still means "clear what
+  // the more general rule set", which Monaco spells as the empty string.
+  return styles.join(" ");
+}
+
+function workbenchColors(theme: PluginCodeThemeData): Record<string, string> {
+  const colors: Record<string, string> = {};
+  for (const [id, value] of Object.entries(theme.colors)) {
+    // Invalid values resolve to red rather than being ignored, and a theme
+    // file may carry a `null` or a color reference we cannot resolve.
+    if (typeof value === "string" && WORKBENCH_COLOR.test(value)) {
+      colors[id] = value;
+    }
+  }
+  // `editor.background` / `editor.foreground` are what Monaco actually paints
+  // the surface with; a theme that only declared the Shiki-level pair still
+  // gets a matching editor rather than the base theme's canvas.
+  if (
+    colors["editor.background"] === undefined &&
+    WORKBENCH_COLOR.test(theme.bg)
+  ) {
+    colors["editor.background"] = theme.bg;
+  }
+  if (
+    colors["editor.foreground"] === undefined &&
+    WORKBENCH_COLOR.test(theme.fg)
+  ) {
+    colors["editor.foreground"] = theme.fg;
+  }
+  return colors;
+}
+
+/**
+ * The color Monaco paints the editor surface with, for chrome that has to sit
+ * on the same background as the code — the file tree. Null before a theme
+ * resolves, and for a theme that declares nothing usable, so a caller can keep
+ * its BB surface token instead of guessing.
+ */
+export function editorBackground(
+  theme: PluginCodeThemeData | null,
+): string | null {
+  if (theme === null) return null;
+  return workbenchColors(theme)["editor.background"] ?? null;
+}
+
+export function toMonacoTheme(
+  theme: PluginCodeThemeData,
+): MonacoNs.editor.IStandaloneThemeData {
+  return {
+    base: theme.type === "light" ? "vs" : "vs-dark",
+    // Inherit so every color id the theme leaves out (widget borders, the
+    // find match highlight) keeps a coherent default instead of nothing.
+    inherit: true,
+    rules: tokenRules(theme),
+    colors: workbenchColors(theme),
+  };
+}
+
+/**
+ * Defines the theme (idempotent per name and window — Monaco replaces a
+ * redefinition) and returns the name to pass as the editor's `theme`.
+ */
+export function defineMonacoTheme(
+  monaco: typeof MonacoNs,
+  theme: PluginCodeThemeData,
+): string {
+  const name = monacoThemeName(theme.name);
+  monaco.editor.defineTheme(name, toMonacoTheme(theme));
+  return name;
+}
+
+/** The Monaco theme currently painted, and the base its widget CSS keys on. */
+export interface AppliedMonacoTheme {
+  /** Name to pass as the editor's `theme` option. */
+  name: string;
+  /** `vs` / `vs-dark`, the only theme classes Monaco's stylesheet keys on. */
+  base: "vs" | "vs-dark";
+}
+
+/**
+ * Define BB's current code theme in this Monaco instance and report what to
+ * apply. Before the first theme document resolves — and if a palette ships
+ * nothing usable — this falls back to Monaco's stock pair for the app's mode.
+ *
+ * The base is read from the applied document rather than from `mode`, because
+ * the two disagree for the frame between a mode switch and the new document
+ * resolving, and the widget CSS has to match the colors actually in use.
+ */
+export function applyCodeTheme(
+  monaco: typeof MonacoNs,
+  state: { mode: "light" | "dark"; theme: PluginCodeThemeData | null },
+): AppliedMonacoTheme {
+  if (state.theme === null) {
+    const base = state.mode === "dark" ? "vs-dark" : "vs";
+    return { name: base, base };
+  }
+  return {
+    name: defineMonacoTheme(monaco, state.theme),
+    base: state.theme.type === "light" ? "vs" : "vs-dark",
+  };
+}

--- a/plugins/monaco-editor/package.json
+++ b/plugins/monaco-editor/package.json
@@ -24,7 +24,7 @@
   ],
   "engines": {
     "bb": ">=0.0",
-    "bbPluginSdk": ">=0.4.9"
+    "bbPluginSdk": ">=0.4.22"
   },
   "bb": {
     "name": "File Editor",


### PR DESCRIPTION
## Human comments

Now themes apply to the monaco editor (we need a new plugin SDK method to supply the VSCode theme document), and the file tree is styled better + is resizable.


https://github.com/user-attachments/assets/8cb44a4a-57bf-44ad-a976-d9f888dfaf81



## What was wrong

Two papercuts in the builtin Monaco file editor, reported directly rather than in an issue.

The editor followed light/dark mode only. bb's appearance palette reaches the built-in file preview through the resolved code theme, but Monaco stayed on stock `vs` / `vs-dark`, so switching to Nord left the editor's syntax colors and surface on bb's default palette. The root cause is that Monaco cannot be themed from CSS variables — it needs the theme document itself — and no plugin API served one. `useResolvedCodeTheme` publishes only the theme *names*, and the documents behind them live in `@pierre/diffs`, which plugins do not reach.

The file tree was a fixed `max-h-64` panel. The secondary pane holding the editor resizes by dragging its vertical divider; the tree inside it had no equivalent, so a deep tree scrolled in a 256px window regardless of how much room the pane had.

## What changed

Three commits: the tree resize, the SDK addition, then the plugin consuming it.

**Plugin SDK — `experimental_useCodeTheme()`** (`packages/plugin-sdk/src/app-contract.ts`, `app.ts`, `testing/app.tsx`). Returns `{ mode, name, theme }`: the active light/dark mode, the registered name of the code theme bb renders that mode with, and the resolved VS Code theme document behind it (`type`, `fg`, `bg`, `colors`, `tokenColors`) — the same document bb's own highlighter paints from. `theme` is null only before the first resolve, and holds the previous document while a palette switch resolves, so a consumer never paints an unthemed frame. Documented in `docs/api_to_audit.md` with what to audit before the prefix drops.

`PLUGIN_SDK_VERSION` → 0.4.21, per the plugin-API surface guard, and the plugin's `engines.bbPluginSdk` floor points at it. No wire change: `HOST_DAEMON_PROTOCOL_VERSION` is untouched, since nothing between the server and the host daemon moved.

**App** (`apps/app/src/lib/plugin-code-theme.ts`, new). Implements the hook: resolves the active palette's theme through a dynamically imported `@pierre/diffs` (the module is megabytes of Shiki and this hook can mount on any plugin surface), caching per theme name. `registerResolvedCodeThemeFiles` moved out of `pierre-worker-pool-theme.ts` into `code-theme-registration.ts` so the hook and the worker-pool sync share one registration set — Pierre treats a second registration of the same name as an error it logs.

**Monaco plugin** (`plugins/monaco-editor/lib/monaco-theme.ts`, new). Translates the theme document into a Monaco theme: TextMate scopes → Monaco token rules (Monaco matches by dotted prefix and its Monarch tokens are spelled like scope heads — the mapping Shiki uses), 3/4-digit hex expanded, values Monaco's rule parser would *throw* on dropped, font styles narrowed to `italic` / `bold` / `underline`, and bb's `bb:nord:light:1f4c9a2b`-style names mapped into Monaco's `[a-z0-9-]` name rule. `app.tsx` themes the editor at construction and follows later palette and mode changes; the body-level overflow-widget host follows the applied document's base rather than the app mode, so the frame between a mode switch and the new document resolving stays coherent.

**Resizable file tree** (`components/FileTreePanel.tsx`, `lib/file-tree-height.ts`). The bottom edge is a `role="separator"` divider in the same idiom as bb's own pane dividers — a hairline plus a 12px transparent hit target, pointer-captured — with arrow-key resizing. Clamping keeps ≥96px of tree and ≥120px of editor; a pane too short for both gives the tree its minimum rather than stranding it out of reach. The height persists to `localStorage` (the panel unmounts whenever it is hidden), and a `ResizeObserver` re-fits when the pane changes size, restoring the requested height when it grows back.

**Tree surface.** The panel now sits on the editor's own `editor.background` rather than `bg-surface-recessed`, falling back to the token before a theme resolves. Hover and active-row tints are translucent ink mixes, so they composite onto it correctly. Its filter bar takes the file bar's `bg-surface-raised` and metrics so the two stacked bars read as one strip; the filter field became a translucent inset rather than an opaque app surface on top of the editor's.

## How you verified

- `pnpm exec turbo run typecheck test --filter=bb-plugin-monaco-editor` — 25 tests pass. New: `lib/monaco-theme.test.ts` (14) covers short-hex expansion, rules Monaco would reject, both spellings of a multi-scope rule, font-style narrowing, the editor-surface fallback, and the mid-switch base. The tree's clamp is left untested — it is a few lines of arithmetic with no failure mode worth a fixture.
- `pnpm exec vitest run src/lib/plugin-code-theme.test.tsx` in `apps/app` — 3 tests against the *real* highlighter, not a fake resolver: the served document, the previous document surviving a palette switch in flight, and a second consumer's first render coming from cache.
- `pnpm exec turbo run typecheck --filter=@bb/app --filter=@bb/domain --filter=@get-bb/plugin-sdk --filter=bb-plugin-monaco-editor` — clean. `@get-bb/plugin-sdk` and `@bb/domain` test suites pass (219 + …), including the SDK version-lockstep test.
- Ran the converter against every bundled palette (pierre light/dark, nord, dracula, gruvbox-light-medium, catppuccin-mocha): 191–432 rules each, **zero** values Monaco's parser would throw on, and each `editor.background` matching its palette.

Not verified: the drag feel and the painted colors on screen. Both want an eyeball before merge.

> AGENT GENERATED

