### PR TITLE
Reject invalid automation executions before persistence

### DIFF
--- a/plugins/automations/src/data.ts
+++ b/plugins/automations/src/data.ts
@@ -248,7 +248,7 @@ function serializeTrigger(trigger: AutomationTrigger): string {
 }
 
 function serializeExecution(execution: AutomationExecution): string {
-  return JSON.stringify(execution);
+  return JSON.stringify(automationExecutionSchema.parse(execution));
 }
 
 export function parseAutomationTrigger(

--- a/plugins/automations/src/server-harness.test.ts
+++ b/plugins/automations/src/server-harness.test.ts
@@ -6,6 +6,7 @@ import {
   type FakePluginHost,
 } from "@get-bb/plugin-sdk/testing";
 import plugin from "./server.js";
+import { createAutomationService } from "./service.js";
 import {
   automationListResponseSchema,
   automationsOverviewResponseSchema,
@@ -641,6 +642,85 @@ describe("automations server plugin harness", () => {
       }),
     );
     expect(repaired.execution).toMatchObject({ prompt: "short again" });
+
+    await harness.dispose();
+  });
+
+  it("does not persist a CLI create rejected by execution validation", async () => {
+    const { harness } = await bootAutomationsPlugin();
+
+    const result = await harness.runCli([
+      "create",
+      "--project",
+      PROJECT_ID,
+      "--name",
+      "Invalid empty prompt",
+      "--in",
+      "1h",
+      "--prompt",
+      "",
+      "--provider",
+      "codex",
+      "--model",
+      "gpt-5",
+    ]);
+
+    expect(result.exitCode).toBe(1);
+    expect(
+      automationListResponseSchema.parse(
+        await harness.callRpc("automations_list", { projectId: PROJECT_ID }),
+      ),
+    ).toHaveLength(0);
+
+    await harness.dispose();
+  });
+
+  it("preserves valid rows after rejected full and partial updates", async () => {
+    const host = await bootAutomationsPlugin();
+    const { harness } = host;
+    const full = await createAgentAutomation(harness, { name: "Full" });
+    const partial = await createAgentAutomation(harness, { name: "Partial" });
+
+    const fullResult = await harness.runCli([
+      "update",
+      full.id,
+      "--project",
+      PROJECT_ID,
+      "--prompt",
+      "",
+      "--provider",
+      "codex",
+      "--model",
+      "gpt-5",
+    ]);
+    expect(fullResult.exitCode).toBe(1);
+
+    const service = createAutomationService({
+      bb: host.bb as never,
+      db: host.bb.storage.database(),
+      pluginDataDir: "/tmp/bb-automations-test",
+      serverUrl: "http://127.0.0.1:38886",
+    });
+    await expect(
+      service.update({
+        projectId: PROJECT_ID,
+        automationId: partial.id,
+        agent: { prompt: "" },
+      } as never),
+    ).rejects.toThrow();
+
+    for (const automationId of [full.id, partial.id]) {
+      const unchanged = automationResponseSchema.parse(
+        await harness.callRpc("automations_get", {
+          projectId: PROJECT_ID,
+          automationId,
+        }),
+      );
+      expect(unchanged.execution).toMatchObject({
+        mode: "agent",
+        prompt: "summarize the inbox",
+      });
+    }
 
     await harness.dispose();
   });


### PR DESCRIPTION
## Human comments

## What was wrong

The automation CLI constructs create and update requests in-process, so TypeScript types were the only protection before the shared data writer serialized an execution. A runtime-invalid value such as an empty prompt was committed first; only the response/stored-row decoder then rejected it. That poisoned project listing and made an ordinary repair update decode and fail on the invalid row before it could write. This is the residual write-before-validation invariant behind #2166 after #2431 correctly removed the arbitrary prompt-length cap.

## What changed

The shared execution serializer now parses the final execution with the existing persisted-row schema before converting it to JSON and issuing SQL. Both production writers use that seam, so CLI create, full replacement, and partial agent updates cannot persist an execution that later reads would reject. The stored schema remains unbounded for prompt length, preserving valid long prompts and recovery of older over-cap rows.

Focused server-harness regressions prove that rejected create leaves the project list empty and rejected full/partial updates preserve their previously valid rows. There is no server/daemon wire change, no `HOST_DAEMON_PROTOCOL_VERSION` bump, and no CLI/guide/doc surface change; the same invalid input still fails, now before persistence.

## How you verified

- New create regression failed before the fix because listing decoded the committed empty prompt, then passed after the persistence guard.
- New full/partial update regression failed before the fix because both valid rows became unreadable, then passed after the persistence guard.
- `pnpm exec turbo run test typecheck build lint --filter=bb-plugin-automations --force` (5 test files, 69 tests passed; all 6 Turbo tasks succeeded, including long-prompt and scheduler coverage)
- `pnpm exec oxfmt plugins/automations/src/data.ts plugins/automations/src/server-harness.test.ts --check`
- `pnpm exec oxlint plugins/automations/src/data.ts plugins/automations/src/server-harness.test.ts`
- `git diff --check 1f064e5a0b11d0a1e84b5fe6b3600ffc66ad9445`

Fixes #2166

> AGENT GENERATED
