### PR TITLE
Handle new Codex terminal error variants

### DIFF
--- a/plugins/provider-codex/src/delta-translation.test.ts
+++ b/plugins/provider-codex/src/delta-translation.test.ts
@@ -1829,6 +1829,65 @@ describe("codex error and warning translation", () => {
     );
   });
 
+  it.each([
+    ["sessionBudgetExceeded", "budget-exceeded"],
+    ["misalignmentPolicyViolation", "policy"],
+  ] as const)(
+    "normalizes %s errors and failed turn completion",
+    (codexErrorInfo, category) => {
+      const harness = createHarness();
+
+      expect(
+        harness.translate(
+          codexEvent("error", {
+            threadId: "t1",
+            turnId: "turn-1",
+            error: {
+              message: "terminal failure",
+              codexErrorInfo,
+              additionalDetails: null,
+            },
+            willRetry: false,
+          }),
+        ),
+      ).toEqual([
+        expect.objectContaining({
+          type: "provider/error",
+          scope: turnScope(harness.turnId("turn-1")),
+          errorInfo: {
+            category,
+            providerCode: codexErrorInfo,
+            httpStatusCode: null,
+          },
+        }),
+      ]);
+
+      expect(
+        harness.translate(
+          codexEvent("turn/completed", {
+            threadId: "t1",
+            turn: codexTurn({
+              id: "turn-1",
+              status: "failed",
+              error: {
+                message: "terminal failure",
+                codexErrorInfo,
+                additionalDetails: null,
+              },
+            }),
+          }),
+        ),
+      ).toEqual([
+        expect.objectContaining({
+          type: "turn/completed",
+          scope: turnScope(harness.turnId("turn-1")),
+          status: "failed",
+          error: { message: "terminal failure" },
+        }),
+      ]);
+    },
+  );
+
   it("maps deprecationNotice to a thread-scoped warning", () => {
     const harness = createHarness();
     const events = harness.translate(

--- a/plugins/provider-codex/src/delta-translation.ts
+++ b/plugins/provider-codex/src/delta-translation.ts
@@ -327,11 +327,14 @@ function getProviderErrorCategory(
     switch (errorInfo) {
       case "contextWindowExceeded":
         return "context-window-exceeded";
+      case "sessionBudgetExceeded":
+        return "budget-exceeded";
       case "usageLimitExceeded":
         return "rate-limit";
       case "serverOverloaded":
         return "overloaded";
       case "cyberPolicy":
+      case "misalignmentPolicyViolation":
         return "policy";
       case "internalServerError":
         return "internal";

--- a/plugins/provider-codex/src/schemas.ts
+++ b/plugins/provider-codex/src/schemas.ts
@@ -7,6 +7,7 @@ import {
   jsonRpcEnvelopeSchema,
 } from "@get-bb/plugin-sdk/provider-bridge";
 import { z } from "zod";
+import type { CodexErrorInfo as GeneratedCodexErrorInfo } from "./generated/codex-app-server/schema/v2/CodexErrorInfo.js";
 
 const codexTurnStatusSchema = z.enum([
   "completed",
@@ -478,9 +479,11 @@ const codexErrorHttpStatusSchema = z
 
 const codexErrorInfoSchema = z.union([
   z.literal("contextWindowExceeded"),
+  z.literal("sessionBudgetExceeded"),
   z.literal("usageLimitExceeded"),
   z.literal("serverOverloaded"),
   z.literal("cyberPolicy"),
+  z.literal("misalignmentPolicyViolation"),
   z.object({ httpConnectionFailed: codexErrorHttpStatusSchema }),
   z.object({ responseStreamConnectionFailed: codexErrorHttpStatusSchema }),
   z.literal("internalServerError"),
@@ -500,6 +503,14 @@ const codexErrorInfoSchema = z.union([
   z.literal("other"),
 ]);
 export type CodexErrorInfo = z.infer<typeof codexErrorInfoSchema>;
+// Fails to compile if regeneration changes the generated error contract
+// without the shared runtime admission boundary changing with it.
+const codexErrorInfoSchemaMatchesGenerated: GeneratedCodexErrorInfo extends CodexErrorInfo
+  ? CodexErrorInfo extends GeneratedCodexErrorInfo
+    ? true
+    : false
+  : false = true;
+void codexErrorInfoSchemaMatchesGenerated;
 
 const codexTurnErrorSchema = z
   .object({


### PR DESCRIPTION
## Human comments

## What was wrong

Codex 0.149.1 added `sessionBudgetExceeded` and `misalignmentPolicyViolation` to its generated error contract, but BB's handwritten runtime schema and category mapper remained stale. Because both `error` and failed `turn/completed` pass through that shared parser, either new literal was downgraded to an unhandled provider event and the failed turn omitted its terminal boundary. The root cause and current-main reproduction are recorded in the [fixer thread](https://ymichael.getbb.app/projects/proj_qrv2s45kmq/threads/thr_7pa2mstkg5).

## What changed

- Admit both generated literals at the shared runtime error boundary.
- Enforce bidirectional compile-time parity between the generated `CodexErrorInfo` union and the handwritten runtime schema so future regeneration drift fails typecheck.
- Classify session rollout budget exhaustion as `budget-exceeded`, not an account `rate-limit`, and classify misalignment as `policy`; preserve both exact provider codes.
- Cover both literals through both normalized `error` and failed `turn/completed` behavior.

This is provider-local runtime translation. No server/daemon wire contract changed, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

## How you verified

- The focused regression failed before the production change: both cases produced `provider/unhandled` instead of `provider/error` and never reached their failed-turn boundary assertion.
- The same focused Turbo test passed after the fix and again after rebasing onto current `origin/main`.
- `pnpm exec turbo run typecheck test build --filter=bb-plugin-provider-codex --force`: 24 test files and 240 tests passed; typecheck and applicable build prerequisites passed.
- A two-pass translator harness now consistently produces `provider.error` plus `turn.boundary`; error info is exactly `budget-exceeded` / `sessionBudgetExceeded` and `policy` / `misalignmentPolicyViolation`.
- The rebased diff remains 73 manually authored lines: 14 production and 59 tests.

Fixes #

> AGENT GENERATED
