### PR TITLE
Complete persisted Cursor model compatibility

### DIFF
--- a/packages/provider-bridge-acp/src/bridge/bridge.test.ts
+++ b/packages/provider-bridge-acp/src/bridge/bridge.test.ts
@@ -756,6 +756,7 @@ describe("acp bridge", () => {
     ]);
     expect(result.selectedOnlyModels.map((model) => model.id)).toEqual([
       "grok-4.5",
+      "claude-sonnet-4-6",
     ]);
   });
 
@@ -823,7 +824,7 @@ describe("acp bridge", () => {
   it.each([
     // Project-default reuse reaches the bridge as an ordinary thread/start.
     ["thread/start", "cursor-grok-4.6-medium", "grok-4.6"],
-    ["thread/resume", "cursor-grok-4.5-medium", "grok-4.5"],
+    ["thread/resume", "claude-4.6-sonnet-medium-thinking", "claude-sonnet-4-6"],
     ["thread/fork", "auto", "default"],
   ] as const)(
     "translates a legacy Cursor model for %s session construction",

--- a/packages/provider-bridge-acp/src/bridge/fake-acp-agent.mjs
+++ b/packages/provider-bridge-acp/src/bridge/fake-acp-agent.mjs
@@ -211,6 +211,7 @@ function cursorModelOptions() {
         { value: "composer-2.5", name: "Composer 2.5" },
         { value: "grok-4.6", name: "Cursor Grok 4.6" },
         { value: "grok-4.5", name: "Cursor Grok 4.5" },
+        { value: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
       ]
     : [
         { value: "default[]", name: "Auto" },
@@ -244,7 +245,10 @@ function cursorConfigOptions() {
       options: models,
     },
   ];
-  if (clientSupportsParameterizedModels && selectedModel.startsWith("grok-")) {
+  if (
+    clientSupportsParameterizedModels &&
+    (selectedModel.startsWith("grok-") || selectedModel === "claude-sonnet-4-6")
+  ) {
     options.push(
       {
         id: "effort",

--- a/packages/provider-bridge-acp/src/session-params.test.ts
+++ b/packages/provider-bridge-acp/src/session-params.test.ts
@@ -1,4 +1,9 @@
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
+import {
+  buildAgentModelCatalog,
+  parseAgentModelLines,
+} from "./bridge/model-catalog.js";
 import { acpLaunchSpecSchema, type AcpLaunchSpec } from "./launch-spec.js";
 import {
   buildAcpModelListParams,
@@ -249,6 +254,16 @@ describe("buildAcpSessionParams", () => {
 });
 
 describe("buildAcpSessionParams parameterized model selection", () => {
+  const cursorParameterizedModelIds = new Set(
+    `default grok-4.6 composer-2.5 claude-opus-5 claude-opus-4-8
+gpt-5.6-sol gpt-5.5 claude-fable-5 grok-4.5 gemini-3.7-flash gpt-5.6-terra
+claude-sonnet-5 claude-sonnet-4-6 gpt-5.3-codex claude-opus-4-7 gpt-5.4
+claude-opus-4-6 claude-opus-4-5 gpt-5.2 gpt-5.6-luna gemini-3.6-flash gemini-3.1-pro
+gpt-5.4-mini gpt-5.4-nano claude-haiku-4-5 claude-sonnet-4-5 gpt-5.1 gemini-3-flash
+gemini-3.5-flash claude-sonnet-4 gpt-5-mini gemini-2.5-flash kimi-k3 kimi-k2.7-code glm-5.2`.split(
+      /\s+/u,
+    ),
+  );
   const cursorSpec: AcpLaunchSpec = {
     displayName: "Cursor",
     command: "cursor-agent",
@@ -294,6 +309,46 @@ describe("buildAcpSessionParams parameterized model selection", () => {
   it("keeps Cursor's new default id unchanged", () => {
     expect(cursorSessionParams({ model: "default" }).modelSelection).toEqual({
       modelId: "default",
+    });
+  });
+
+  it("translates every persisted Cursor family to an accepted parameterized id", () => {
+    const persistedCatalog = buildAgentModelCatalog(
+      parseAgentModelLines(
+        readFileSync(
+          new URL(
+            "./bridge/issue-1688-cursor-list-models.txt",
+            import.meta.url,
+          ),
+          "utf8",
+        ),
+      ),
+    );
+    const translations = persistedCatalog?.models.map(({ id }) => {
+      const selection = cursorSessionParams({ model: id }).modelSelection;
+      return [
+        id,
+        selection && "modelId" in selection ? selection.modelId : undefined,
+      ];
+    });
+    expect(translations).toHaveLength(34);
+    expect(
+      translations?.filter(
+        ([, id]) => id === undefined || !cursorParameterizedModelIds.has(id),
+      ),
+    ).toEqual([]);
+  });
+
+  it.each([
+    ["claude-4.6-sonnet-medium-thinking", "claude-sonnet-4-6"],
+    ["claude-4.6-opus-high-thinking", "claude-opus-4-6"],
+    ["claude-4.5-opus-high-thinking", "claude-opus-4-5"],
+    ["gemini-3.6-flash-minimal", "gemini-3.6-flash"],
+    ["claude-4.5-sonnet-thinking", "claude-sonnet-4-5"],
+    ["claude-4-sonnet-thinking", "claude-sonnet-4"],
+  ] as const)("maps persisted Cursor family %s to %s", (model, modelId) => {
+    expect(cursorSessionParams({ model }).modelSelection).toMatchObject({
+      modelId,
     });
   });
 

--- a/packages/provider-bridge-acp/src/session-params.ts
+++ b/packages/provider-bridge-acp/src/session-params.ts
@@ -267,11 +267,21 @@ export function buildAcpModelListParams(
   };
 }
 
+const CURSOR_LEGACY_FAMILY_RENAMES: Readonly<Record<string, string>> = {
+  "claude-4-sonnet": "claude-sonnet-4",
+  "claude-4.5-opus": "claude-opus-4-5",
+  "claude-4.5-sonnet": "claude-sonnet-4-5",
+  "claude-4.6-opus": "claude-opus-4-6",
+  "claude-4.6-sonnet": "claude-sonnet-4-6",
+  "gemini-3.6-flash-minimal": "gemini-3.6-flash",
+};
+
 function cursorParameterizedModelId(model: string): string {
   const familyId = model === "auto" ? "default" : agentModelFamilyId(model);
-  return familyId.startsWith("cursor-")
+  const bareFamilyId = familyId.startsWith("cursor-")
     ? familyId.slice("cursor-".length)
     : familyId;
+  return CURSOR_LEGACY_FAMILY_RENAMES[bareFamilyId] ?? bareFamilyId;
 }
 
 /** The synthetic "acp-default" id is never forwarded. */


### PR DESCRIPTION
## Human comments

## What was wrong

Cursor's parameterized ACP picker accepts current bare model IDs, but six families persisted by the historical Cursor picker use spellings that generic effort/thinking collapse cannot derive. The compatibility translator added in [PR #2432](https://github.com/get-bb/bb/pull/2432) therefore produced IDs absent from Cursor's live catalog, and affected sessions failed during construction before the first prompt.

## What changed

Apply six explicit Cursor-only legacy-family renames after the existing variant collapse at the shared ACP session-construction boundary. No rows are rewritten, and current bare IDs, `auto`/`default`, reasoning, service tier, non-Cursor ACP, and non-parameterized behavior remain unchanged. A fixture-backed table test now checks all 34 historical persisted families against Cursor's accepted parameterized catalog, with a representative renamed Claude resume case through the bridge. `HOST_DAEMON_PROTOCOL_VERSION` remains 170 because the server/daemon wire contract did not change. There is no CLI, guide, documentation, or public plugin API change. Current main already carries the unpublished plugin SDK 0.4.24 version, whose pending publication will include this changed ACP runtime, so the rebased branch needs no additional version bump.

## How you verified

Before the production change, the fixture-backed test failed with 1 failed / 19 passed and identified exactly six incompatible translations; a live representative flow translated to rejected `claude-4.6-sonnet`. Afterward, that flow translated to accepted `claude-sonnet-4-6`, and the all-family live probe reported `legacy-families=34`, `accepted-parameterized=35`, and `missing=[]`.

- `pnpm exec turbo run test --filter=@bb/provider-bridge-acp --force` — 17 files, 295 tests passed after rebase.
- `pnpm exec turbo run typecheck --filter=@bb/provider-bridge-acp --filter=@get-bb/plugin-sdk --filter=bb-plugin-provider-acp --force` — 6 tasks passed after rebase.
- `pnpm exec turbo run build --filter=@get-bb/plugin-sdk --force` — 2 tasks passed; 17 runtime entries built.
- `node packages/plugin-sdk/scripts/check-npm-version-guard.mjs` — passed; `@get-bb/plugin-sdk@0.4.24` is not on npm.
- Targeted formatting and `git diff --check origin/main..HEAD` passed.

Fixes #1688

> AGENT GENERATED
