### PR TITLE
Wait for quiet after exact replay completion

### DIFF
--- a/packages/provider-bridge-protocol/src/testing/parity.test.ts
+++ b/packages/provider-bridge-protocol/src/testing/parity.test.ts
@@ -29,7 +29,7 @@ function writeLane(
   );
 }
 
-it("waits for the exact planned tail before closing bridge stdin", async () => {
+it("waits for the exact planned tail and a quiet period before closing", async () => {
   const dir = mkdtempSync(join(tmpdir(), "bb-parity-tail-test-"));
   const bridgePath = join(dir, "delayed-tail-bridge.mjs");
   const identity = {
@@ -54,6 +54,18 @@ it("waits for the exact planned tail before closing bridge stdin", async () => {
       item: { type: "agentMessage", id: "item_test", text: "done" },
     },
     { type: "turn/completed", ...identity, scope, status: "completed" },
+  ];
+  const extraEvents: ThreadEvent[] = [
+    {
+      type: "thread/contextWindowUsage/updated",
+      ...identity,
+      scope: { kind: "thread" },
+      contextWindowUsage: {
+        usedTokens: 42,
+        modelContextWindow: 1_000,
+        estimated: false,
+      },
+    },
   ];
   const delta = (events: readonly ThreadEvent[]): string =>
     JSON.stringify({
@@ -83,6 +95,7 @@ it("waits for the exact planned tail before closing bridge stdin", async () => {
       [
         `const prefix = ${JSON.stringify(prefixEvents)};`,
         `const tail = ${JSON.stringify(tailEvents)};`,
+        `const extra = ${JSON.stringify(extraEvents)};`,
         "const delta = (events) => JSON.stringify({ jsonrpc: '2.0', method: 'thread/delta', params: { events } });",
         "let pending = '';",
         "let tailTimer = null;",
@@ -100,7 +113,10 @@ it("waits for the exact planned tail before closing bridge stdin", async () => {
         "    } else if (message.method === 'thread/start') {",
         "      process.stdout.write(delta(prefix) + '\\n');",
         "      process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: message.id, result: {} }) + '\\n');",
-        "      tailTimer = setTimeout(() => process.stdout.write(delta(tail) + '\\n'), 100);",
+        "      tailTimer = setTimeout(() => {",
+        "        process.stdout.write(delta(tail) + '\\n');",
+        "        tailTimer = setTimeout(() => process.stdout.write(delta(extra) + '\\n'), 40);",
+        "      }, 100);",
         "    }",
         "  }",
         "});",
@@ -135,13 +151,17 @@ it("waits for the exact planned tail before closing bridge stdin", async () => {
         },
       }),
       planFromCurrentLane: true,
-      settleMs: 20,
+      settleMs: 60,
       timeoutMs: 1_000,
     });
 
     expect(run.stalls).toEqual([]);
-    expect(run.events).toEqual([...prefixEvents, ...tailEvents]);
-    expect(run.events.at(-1)?.type).toBe("turn/completed");
+    expect(run.grammarViolations).toEqual([]);
+    expect(run.events).toEqual([
+      ...prefixEvents,
+      ...tailEvents,
+      ...extraEvents,
+    ]);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/packages/provider-bridge-protocol/src/testing/parity.ts
+++ b/packages/provider-bridge-protocol/src/testing/parity.ts
@@ -301,8 +301,8 @@ export interface ReplayRecordingOptions {
    */
   orderTimeoutMs?: number;
   /**
-   * Quiet period after the last request before a non-exact replay is closed.
-   * An exact current-lane replay waits for every planned event instead.
+   * Quiet period after the last bridge output before the replay is closed.
+   * An exact current-lane replay first waits for every planned event.
    */
   settleMs?: number;
   /**
@@ -760,21 +760,19 @@ export async function replayRecording(options: ReplayRecordingOptions): Promise<
   }
   setCursor("end");
   await waitFor("the last responses", () => sentRequestIds.every((id) => answeredIds.has(id)));
-  // An exact plan is this bridge's own recorded lane, so its complete accepted
-  // event count is the deterministic end of replay. Output silence is not:
-  // the provider child and bridge can be alive in provider-internal control
-  // flow without emitting runtime deltas, especially under scheduler load.
+  // An exact plan is this bridge's own recorded lane, so wait for its complete
+  // accepted event count before considering the stream settled. Output silence
+  // alone is not enough while planned events are still missing.
   if (plannedEventCount !== null) {
     await waitFor(
       `all ${plannedEventCount} planned events before closing the bridge`,
       () => events.length >= plannedEventCount,
     );
-  } else {
-    // A bridge compared with a lane from another version may deliberately
-    // emit fewer events, so only that non-exact comparison needs the quiet
-    // fallback to terminate and report its parity diff.
-    await waitFor("the stream to settle", () => Date.now() - lastOutputAt >= settleMs);
   }
+  // Reaching the planned count is only a lower bound: another valid event may
+  // still be in flight. Non-exact replays retain this same divergent-version
+  // fallback because they may deliberately emit fewer events than the plan.
+  await waitFor("the stream to settle", () => Date.now() - lastOutputAt >= settleMs);
   child.stdin?.end();
   const exitCode = await Promise.race([
     exited,


### PR DESCRIPTION
## Human comments

## What was wrong

Exact current-lane parity replay treated reaching the planned grammar-accepted event count as proof that the stream had ended. That count is only a lower bound: a bridge can emit another valid event shortly after the recorded tail. Closing stdin immediately at the count discarded that delayed event and let exact replay falsely pass with no stall.

## What changed

At the shared `replayRecording` settlement boundary, exact replay still waits for every planned event and then also waits for the existing output quiet period before closing stdin. Non-exact cross-version replay retains its existing quiet-period termination and does not gain a planned-count requirement.

The real-child regression continues to delay the planned tail beyond the quiet window, preserving missing-tail coverage, and then emits a fifth valid context-usage event after the planned count. The test requires all five events with no stalls or grammar violations.

This changes only the published provider-bridge testing harness behavior and documentation for the existing `settleMs` option. There is no new API member, CLI/config surface, persisted state, provider exception, or server↔host-daemon wire change, so `HOST_DAEMON_PROTOCOL_VERSION` remains unchanged. `@get-bb/plugin-sdk` 0.4.22 is still unpublished and its publish job will include the changed testing bundle, so another SDK version bump is not needed.

## How you verified

Before the production change, the focused real-child regression failed twice with four observed events versus five expected; the planned prefix and tail arrived, no stall was reported, and only the valid delayed fifth event was missing. After the fix, the focused regression passed.

- `pnpm exec turbo run test --filter=@bb/provider-bridge-protocol --filter=@bb/provider-parity --filter=@get-bb/plugin-sdk --force` — 238 protocol, 56 parity, and 219 plugin SDK tests passed after rebasing onto current `main`.
- `pnpm exec turbo run build typecheck --filter=@get-bb/plugin-sdk --filter=@bb/domain --filter=@bb/provider-bridge-protocol --filter=@bb/provider-parity --force` — 8/8 tasks passed.
- `node packages/plugin-sdk/scripts/check-npm-version-guard.mjs` — passed; 0.4.22 is unpublished and will ship this bundle.
- `git diff --check origin/main...HEAD` — passed.

Follow-up to #2440.

> AGENT GENERATED
