### PR TITLE
Keep worktree archive from detaching external children

### DIFF
--- a/apps/server/src/services/threads/thread-archive.ts
+++ b/apps/server/src/services/threads/thread-archive.ts
@@ -1,4 +1,5 @@
 import {
+  archiveThread,
   listLiveThreadsInEnvironment,
   listUnarchivedAssignedChildThreads,
   listUnarchivedHiddenSourceThreads,
@@ -33,9 +34,13 @@ interface ArchiveThreadEnvironment {
   id: string;
 }
 
-interface ArchiveThreadWithLifecycleEffectsArgs {
+interface ArchiveThreadTarget {
   environment: ArchiveThreadEnvironment | null;
   thread: Pick<Thread, "environmentId" | "id" | "status">;
+}
+
+interface ArchiveThreadWithLifecycleEffectsArgs extends ArchiveThreadTarget {
+  releaseChildren: boolean;
 }
 
 interface ResolveArchiveThreadEnvironmentArgs {
@@ -85,9 +90,9 @@ function archiveThreadWithLifecycleEffects(
   deps: AppDeps,
   args: ArchiveThreadWithLifecycleEffectsArgs,
 ): Thread | null {
-  const archivedThread = archiveThreadAndReleaseChildren(deps, {
-    threadId: args.thread.id,
-  });
+  const archivedThread = args.releaseChildren
+    ? archiveThreadAndReleaseChildren(deps, { threadId: args.thread.id })
+    : archiveThread(deps.db, deps.hub, args.thread.id);
   if (!archivedThread) {
     return null;
   }
@@ -126,9 +131,12 @@ function archiveThreadWithLifecycleEffects(
  */
 export function archiveThreadAndHiddenSourceForks(
   deps: AppDeps,
-  args: ArchiveThreadWithLifecycleEffectsArgs,
+  args: ArchiveThreadTarget,
 ): Thread | null {
-  const archivedThread = archiveThreadWithLifecycleEffects(deps, args);
+  const archivedThread = archiveThreadWithLifecycleEffects(deps, {
+    ...args,
+    releaseChildren: true,
+  });
   if (!archivedThread) {
     return null;
   }
@@ -137,6 +145,7 @@ export function archiveThreadAndHiddenSourceForks(
   })) {
     archiveThreadWithLifecycleEffects(deps, {
       environment: resolveArchiveThreadEnvironment(deps, { thread: fork }),
+      releaseChildren: true,
       thread: fork,
     });
   }
@@ -155,6 +164,9 @@ export function archiveEnvironmentThreads(
   for (const thread of threads) {
     const result = archiveThreadWithLifecycleEffects(deps, {
       environment: args.environment,
+      // This operation is scoped to one worktree. Releasing a live child in
+      // another environment would mutate ownership outside that scope.
+      releaseChildren: false,
       thread,
     });
     if (!result) {
@@ -206,6 +218,7 @@ export function archiveThreadAndChildren(
     const environment = resolveArchiveThreadEnvironment(deps, { thread });
     const result = archiveThreadWithLifecycleEffects(deps, {
       environment,
+      releaseChildren: true,
       thread,
     });
     if (!result) {

--- a/apps/server/test/public/public-thread-parenting.test.ts
+++ b/apps/server/test/public/public-thread-parenting.test.ts
@@ -2,6 +2,7 @@ import { getThread } from "@bb/db";
 import { threadSchema } from "@bb/domain";
 import {
   apiErrorSchema,
+  environmentArchiveThreadsResponseSchema,
   sidebarBootstrapResponseSchema,
   threadArchiveAllResponseSchema,
   threadChildSummaryResponseSchema,
@@ -404,6 +405,54 @@ describe("public thread parenting routes", () => {
       const archivedChildThread = getThread(harness.db, childThread.id);
       expect(archivedChildThread?.archivedAt).not.toBeNull();
       expect(archivedChildThread?.parentThreadId).toBe(parentThread.id);
+    });
+  });
+
+  it("preserves child ownership outside an archived worktree", async () => {
+    await withTestHarness(async (harness) => {
+      const { host } = seedHostSession(harness.deps);
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.id,
+      });
+      const parentEnvironment = seedEnvironment(harness.deps, {
+        hostId: host.id,
+        managed: true,
+        projectId: project.id,
+        workspaceProvisionType: "managed-worktree",
+      });
+      const childEnvironment = seedEnvironment(harness.deps, {
+        hostId: host.id,
+        managed: true,
+        path: "/tmp/child-test-environment",
+        projectId: project.id,
+        workspaceProvisionType: "managed-worktree",
+      });
+      const parentThread = seedThread(harness.deps, {
+        environmentId: parentEnvironment.id,
+        projectId: project.id,
+      });
+      const childThread = seedThread(harness.deps, {
+        environmentId: childEnvironment.id,
+        parentThreadId: parentThread.id,
+        projectId: project.id,
+      });
+
+      const response = await harness.app.request(
+        `/api/v1/environments/${parentEnvironment.id}/archive-threads`,
+        { method: "POST" },
+      );
+
+      expect(response.status).toBe(200);
+      expect(
+        environmentArchiveThreadsResponseSchema.parse(await readJson(response)),
+      ).toEqual({
+        ok: true,
+        archivedThreadIds: [parentThread.id],
+      });
+      expect(getThread(harness.db, parentThread.id)?.archivedAt).not.toBeNull();
+      const preservedChild = getThread(harness.db, childThread.id);
+      expect(preservedChild?.archivedAt).toBeNull();
+      expect(preservedChild?.parentThreadId).toBe(parentThread.id);
     });
   });
 


### PR DESCRIPTION
## User story

As a user coordinating a parent thread with children in separate worktrees, I expect **Archive worktree** to affect only that worktree. If a child is working somewhere else, archiving the parent's worktree must not silently detach that child and flatten the thread tree.

This came from a real session: one worktree held an orchestrator thread, while nine active child threads used isolated worktrees. Archiving the shared worktree also cleared the parent link on all nine isolated children. The links then had to be restored manually before orchestration could continue.

## What was wrong

The environment archive path correctly selected only threads attached to the chosen worktree. However, it archived each selected thread through the ordinary single-thread helper. That helper deliberately releases active children when their parent is archived, without checking which environment those children use.

The result was a scope leak: an action on one worktree changed thread ownership in nine other worktrees. Unarchiving the original worktree also could not restore those links because the ownership changes had already been persisted.

## What changed

The archive lifecycle now makes child-release behavior explicit:

- Ordinary single-thread and hierarchy archive operations still release children as before.
- Environment/worktree archive preserves child ownership, so it does not mutate threads outside the selected worktree.
- A regression test covers a parent in one managed worktree with an active child in another. It verifies that the parent is archived, the child stays active, and the child's parent link remains intact.

There are no wire, daemon protocol, CLI, configuration, or documentation changes.

## How you verified

- `pnpm exec turbo run test --filter=@bb/server -- test/public/public-thread-parenting.test.ts` — 12 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/server` — passed.
- Re-ran both checks on a clean branch containing only this commit on top of current `get-bb/bb:main` (`31d66d9d4`).

> AGENT GENERATED
