### PR TITLE
Group model picker by provider for ACP route models

### DIFF
--- a/apps/app/.ladle/model-picker-query-provider.tsx
+++ b/apps/app/.ladle/model-picker-query-provider.tsx
@@ -16,6 +16,8 @@ import {
   STORY_CLAUDE_REASONING,
   STORY_CODEX_MODELS,
   STORY_CODEX_REASONING,
+  STORY_OMP_MODELS,
+  STORY_OMP_PROVIDER_OPTION,
   STORY_PI_MODELS,
   STORY_PROVIDER_OPTIONS,
   STORY_SERVICE_TIER_SUPPORT,
@@ -46,31 +48,33 @@ const STORY_COMPOSER_ACTIONS_BY_PROVIDER: Record<
     },
   ],
   pi: [],
+  omp: [],
 };
 
-const STORY_PROVIDER_INFOS: ProviderInfo[] = STORY_PROVIDER_OPTIONS.map(
-  (provider) => ({
-    id: provider.value,
-    pluginId: `provider-${provider.value}`,
-    displayName: provider.label,
-    logoUrl: null,
-    available: true,
-    maintenance: { health: true, usage: true, installation: true },
-    composerActions: [
-      ...(STORY_COMPOSER_ACTIONS_BY_PROVIDER[provider.value] ?? []),
-    ],
-    capabilities: {
-      supportsThreadArchive: true,
-      supportsThreadRename: true,
-      supportsServiceTier: STORY_SERVICE_TIER_SUPPORT[provider.value] ?? false,
-      supportsNativeUserQuestion: true,
-      supportsFork: true,
-      supportsSessionRewind: true,
-      modelCatalogScope: "workspace",
-      permissionModes: [...permissionModes],
-    },
-  }),
-);
+const STORY_PROVIDER_INFOS: ProviderInfo[] = [
+  ...STORY_PROVIDER_OPTIONS,
+  STORY_OMP_PROVIDER_OPTION,
+].map((provider) => ({
+  id: provider.value,
+  pluginId: `provider-${provider.value}`,
+  displayName: provider.label,
+  logoUrl: null,
+  available: true,
+  maintenance: { health: true, usage: true, installation: true },
+  composerActions: [
+    ...(STORY_COMPOSER_ACTIONS_BY_PROVIDER[provider.value] ?? []),
+  ],
+  capabilities: {
+    supportsThreadArchive: true,
+    supportsThreadRename: true,
+    supportsServiceTier: STORY_SERVICE_TIER_SUPPORT[provider.value] ?? false,
+    supportsNativeUserQuestion: true,
+    supportsFork: true,
+    supportsSessionRewind: true,
+    modelCatalogScope: "workspace",
+    permissionModes: [...permissionModes],
+  },
+}));
 
 function makeSupportedReasoningEfforts(
   reasoningOptions: readonly PickerOption<ReasoningLevel>[],
@@ -159,6 +163,12 @@ function createStoryQueryClient(): QueryClient {
     pi: makeExecutionOptions(
       makeAvailableModels({
         models: STORY_PI_MODELS,
+        reasoningOptions: STORY_CODEX_REASONING,
+      }),
+    ),
+    omp: makeExecutionOptions(
+      makeAvailableModels({
+        models: STORY_OMP_MODELS,
         reasoningOptions: STORY_CODEX_REASONING,
       }),
     ),

--- a/apps/app/.ladle/story-fixtures.ts
+++ b/apps/app/.ladle/story-fixtures.ts
@@ -220,6 +220,60 @@ export const STORY_PI_MODELS: readonly ModelPickerOption[] = [
   },
 ];
 
+export const STORY_OMP_MODELS: readonly ModelPickerOption[] = [
+  {
+    value: "cursor/claude-sonnet-4-5",
+    label: "Claude Sonnet 4.5",
+    description: "cursor/claude-sonnet-4-5",
+  },
+  {
+    value: "cursor/glm-5.3",
+    label: "GLM-5.3",
+    description: "cursor/glm-5.3",
+  },
+  {
+    value: "zai/glm-5.3",
+    label: "GLM-5.3",
+    description: "zai/glm-5.3",
+  },
+  {
+    value: "zai/glm-5.2-air",
+    label: "GLM-5.2 Air",
+    description: "zai/glm-5.2-air",
+  },
+  {
+    value: "commandcode/zai-org/GLM-5",
+    label: "GLM-5",
+    description: "commandcode/zai-org/GLM-5",
+  },
+  {
+    value: "mistral/mistral-medium-latest",
+    label: "mistral-medium-latest",
+    description: "mistral/mistral-medium-latest",
+  },
+  {
+    value: "mistral/mistral-medium-2506",
+    label: "mistral-medium-latest",
+    description: "mistral/mistral-medium-2506",
+  },
+  {
+    value: "mistral/mistral-medium-latest-2501",
+    label: "mistral-medium-latest",
+    description: "mistral/mistral-medium-latest-2501",
+  },
+  {
+    value: "mistral/mistral-large-latest",
+    label: "Mistral Large",
+    description: "mistral/mistral-large-latest",
+  },
+];
+
+export const STORY_OMP_PROVIDER_OPTION: PickerOption<string> = {
+  value: "omp",
+  label: "OMP",
+  icon: storyProviderIcon("omp", "Layers"),
+};
+
 export const STORY_CODEX_REASONING: readonly PickerOption<ReasoningLevel>[] = [
   { value: "low", label: "Low" },
   { value: "medium", label: "Medium" },

--- a/apps/app/src/components/pickers/ModelReasoningPicker.stories.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.stories.tsx
@@ -10,6 +10,8 @@ import {
   STORY_CLAUDE_REASONING,
   STORY_CODEX_MODELS,
   STORY_CODEX_REASONING,
+  STORY_OMP_MODELS,
+  STORY_OMP_PROVIDER_OPTION,
   STORY_PI_MODELS,
   STORY_PROVIDER_OPTIONS,
   STORY_SERVICE_TIER_SUPPORT,
@@ -68,6 +70,7 @@ const MODEL_OPTIONS_BY_PROVIDER_ID: Record<
   codex: STORY_CODEX_MODELS,
   "claude-code": STORY_CLAUDE_CODE_MODELS,
   pi: STORY_PI_MODELS,
+  omp: STORY_OMP_MODELS,
 };
 
 const MORE_MODEL_OPTIONS_BY_PROVIDER_ID: Record<
@@ -77,6 +80,7 @@ const MORE_MODEL_OPTIONS_BY_PROVIDER_ID: Record<
   codex: [],
   "claude-code": STORY_CLAUDE_CODE_MORE_MODELS,
   pi: [],
+  omp: [],
 };
 
 const REASONING_OPTIONS_BY_PROVIDER_ID: Record<
@@ -86,6 +90,7 @@ const REASONING_OPTIONS_BY_PROVIDER_ID: Record<
   codex: STORY_CODEX_REASONING,
   "claude-code": STORY_CLAUDE_REASONING,
   pi: STORY_CODEX_REASONING,
+  omp: STORY_CODEX_REASONING,
 };
 
 export function Overview() {
@@ -115,6 +120,12 @@ export function Overview() {
           hint="provider tabs and model selection use seeded story data"
         >
           <ModelReasoningPickerInteractive />
+        </StoryRow>
+        <StoryRow
+          label="open: acp grouped"
+          hint="omp-style catalog; provider headers, collision qualifiers, ambiguous-selection token"
+        >
+          <ModelReasoningPickerOpenGrouped />
         </StoryRow>
         <StoryRow
           label="loading models"
@@ -170,6 +181,7 @@ function ModelReasoningPickerInteractive() {
   return (
     <ModelReasoningPicker
       {...codexBase}
+      providerOptions={[...STORY_PROVIDER_OPTIONS, STORY_OMP_PROVIDER_OPTION]}
       selectedProviderId={selectedProviderId}
       onSelectedProviderChange={(providerId) => {
         setSelectedProviderId(providerId);
@@ -186,6 +198,23 @@ function ModelReasoningPickerInteractive() {
         STORY_SERVICE_TIER_SUPPORT[selectedProviderId] ?? false
       }
       onReasoningChange={setReasoningValue}
+      modal={false}
+    />
+  );
+}
+
+function ModelReasoningPickerOpenGrouped() {
+  return (
+    <ModelReasoningPicker
+      {...codexBase}
+      providerOptions={[STORY_OMP_PROVIDER_OPTION]}
+      selectedProviderId="omp"
+      modelValue="zai/glm-5.3"
+      modelOptions={STORY_OMP_MODELS}
+      moreModelOptions={[]}
+      reasoningOptions={STORY_CODEX_REASONING}
+      showFastModeToggle={false}
+      defaultOpen
       modal={false}
     />
   );

--- a/apps/app/src/components/pickers/ModelReasoningPicker.test.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.test.tsx
@@ -804,6 +804,7 @@ describe("ModelReasoningPicker", () => {
     fireEvent.change(search, { target: { value: "glm" } });
 
     fireEvent.keyDown(search, { key: "ArrowDown" });
+    fireEvent.keyDown(search, { key: "ArrowDown" });
     expect(search.getAttribute("aria-activedescendant")).not.toBeNull();
     fireEvent.keyDown(search, { key: "Enter" });
     expect(onModelChange).toHaveBeenCalledWith("cursor/glm-5.3");

--- a/apps/app/src/components/pickers/ModelReasoningPicker.test.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.test.tsx
@@ -6,6 +6,7 @@ import {
   fireEvent,
   render,
   screen,
+  within,
 } from "@testing-library/react";
 import type { AvailableModel, ReasoningLevel } from "@bb/domain";
 import type {
@@ -23,6 +24,8 @@ import {
 } from "@/views/thread-detail/PaneContext";
 import {
   buildModelNavRows,
+  MODEL_GROUP_HEADER_STICKY_TOP_COMPACT,
+  MODEL_GROUP_HEADER_STICKY_TOP_DESKTOP,
   ModelReasoningPicker,
 } from "./ModelReasoningPicker";
 import type { PickerOption } from "./OptionPicker";
@@ -81,6 +84,34 @@ const manyCodexModels: readonly PickerOption<string>[] = [
   { value: "o3", label: "o3" },
   { value: "o4-mini", label: "o4-mini" },
   { value: "sonnet-in-codex", label: "Sonnet" },
+];
+
+const ompStyleModels: readonly ModelPickerOption[] = [
+  { value: "cursor/claude-sonnet-4-5", label: "Claude Sonnet 4.5" },
+  { value: "cursor/glm-5.3", label: "GLM-5.3" },
+  { value: "zai/glm-5.3", label: "GLM-5.3" },
+  { value: "zai/glm-5.2-air", label: "GLM-5.2 Air" },
+  { value: "commandcode/zai-org/GLM-5", label: "GLM-5" },
+  { value: "mistral/mistral-medium-latest", label: "mistral-medium-latest" },
+  { value: "mistral/mistral-medium-2506", label: "mistral-medium-latest" },
+  {
+    value: "mistral/mistral-medium-latest-2501",
+    label: "mistral-medium-latest",
+  },
+  { value: "mistral/mistral-large-latest", label: "Mistral Large" },
+];
+
+const ompProviderOptions: readonly ProviderPickerOption[] = [
+  { value: "omp", label: "OMP" },
+];
+
+const singleRouteZai: readonly ModelPickerOption[] = [
+  { value: "zai/glm-5.3", label: "GLM-5.3" },
+  { value: "zai/glm-5.3-preview", label: "GLM-5.3" },
+  { value: "zai/glm-5.2-air", label: "GLM-5.2 Air" },
+  { value: "zai/glm-5.2", label: "GLM-5.2" },
+  { value: "zai/glm-5.1", label: "GLM-5.1" },
+  { value: "zai/glm-4.7", label: "GLM-4.7" },
 ];
 
 const reasoningOptions: readonly PickerOption<ReasoningLevel>[] = [
@@ -578,7 +609,7 @@ describe("ModelReasoningPicker", () => {
     expect(await screen.findByText("Opus 4.7")).not.toBeNull();
   });
 
-  it("keeps duplicate Pi models distinct by their nested provider", () => {
+  it("groups Pi's nested-provider models under labelled route groups", () => {
     const apiModel = "openai/gpt-5.3-codex-spark";
     const subscriptionModel = "openai-codex/gpt-5.3-codex-spark";
     const modelLabel = "GPT-5.3 Codex Spark";
@@ -597,20 +628,311 @@ describe("ModelReasoningPicker", () => {
     });
 
     const trigger = screen.getByRole("button", {
-      name: "Provider, model and reasoning",
+      name: "Provider, model and reasoning, OpenAI Codex",
     });
+    expect(trigger.textContent).toContain("OpenAI Codex");
     expect(trigger.textContent).toContain(modelLabel);
-    expect(trigger.textContent).not.toContain("openai-codex");
+    expect(
+      (trigger.querySelector("span[title]") as HTMLElement | null)?.title,
+    ).toContain(subscriptionModel);
 
     fireEvent.click(trigger);
 
-    expect(screen.getAllByText(modelLabel)).toHaveLength(3);
-    const apiQualifier = screen.getByText("openai");
-    expect(screen.getByText("openai-codex")).not.toBeNull();
+    expect(screen.getByRole("group", { name: "OpenAI" })).not.toBeNull();
+    expect(screen.getByRole("group", { name: "OpenAI Codex" })).not.toBeNull();
+    const rows = screen.getAllByText(modelLabel);
+    expect(rows).toHaveLength(3);
 
-    fireEvent.click(apiQualifier);
-
+    fireEvent.click(rows[1]);
     expect(onModelChange).toHaveBeenCalledWith(apiModel);
+
+    fireEvent.click(rows[2]);
+    expect(onModelChange).toHaveBeenCalledWith(subscriptionModel);
+  });
+
+  it("groups a multi-route catalog under labelled provider headers", () => {
+    const { onModelChange } = renderPicker({
+      modelOptions: ompStyleModels,
+      modelValue: "zai/glm-5.3",
+      pickerProviderOptions: ompProviderOptions,
+      selectedProviderId: "omp",
+    });
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Provider, model and reasoning, Z.ai",
+      }),
+    );
+    expect(screen.getByText("Model")).not.toBeNull();
+    expect(screen.getByRole("group", { name: "Cursor" })).not.toBeNull();
+    expect(screen.getByRole("group", { name: "Z.ai" })).not.toBeNull();
+    expect(screen.getByRole("group", { name: "CommandCode" })).not.toBeNull();
+    expect(screen.getByRole("group", { name: "Mistral" })).not.toBeNull();
+
+    expect(
+      screen
+        .getAllByText("Z.ai")
+        .some((node) =>
+          node.className.includes(MODEL_GROUP_HEADER_STICKY_TOP_DESKTOP),
+        ),
+    ).toBe(true);
+
+    expect(screen.getAllByText("GLM-5.3")).toHaveLength(3);
+    expect(screen.queryByText("glm-5.3")).toBeNull();
+    expect(screen.getByTitle("zai/glm-5.3")).not.toBeNull();
+    expect(screen.getByTitle("cursor/glm-5.3")).not.toBeNull();
+
+    fireEvent.click(screen.getAllByText("GLM-5.3")[1]);
+    expect(onModelChange).toHaveBeenCalledWith("cursor/glm-5.3");
+  });
+
+  it("renders single-route lists flat, keeping the pre-grouping DOM", () => {
+    renderPicker({ modelOptions: manyCodexModels });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Provider, model and reasoning" }),
+    );
+
+    expect(screen.getByTitle("5.5")).not.toBeNull();
+    expect(screen.queryByText("gpt-5.5")).toBeNull();
+    expect(screen.queryByRole("group")).toBeNull();
+  });
+
+  it("renders a single-route keyed list headerless but keeps raw-id tooltips and within-group qualifiers", () => {
+    renderPicker({ modelOptions: singleRouteZai });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Provider, model and reasoning" }),
+    );
+
+    expect(screen.queryByRole("group")).toBeNull();
+    expect(screen.getByTitle("zai/glm-5.3")).not.toBeNull();
+    expect(screen.getByTitle("zai/glm-5.3-preview")).not.toBeNull();
+    expect(
+      screen.getByRole("option", { name: "GLM-5.2 Air" }).textContent,
+    ).toBe("GLM-5.2 Air");
+    expect(
+      screen.getByRole("option", { name: "GLM-5.3glm-5.3-preview" }),
+    ).not.toBeNull();
+    expect(screen.getByRole("option", { name: "GLM-5.3" }).textContent).toBe(
+      "GLM-5.3",
+    );
+  });
+
+  it("qualifies only within-provider label collisions", () => {
+    renderPicker({
+      modelOptions: ompStyleModels,
+      modelValue: "mistral/mistral-medium-2506",
+      pickerProviderOptions: ompProviderOptions,
+      selectedProviderId: "omp",
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Provider, model and reasoning, Mistral · mistral-medium-2506",
+      }),
+    );
+
+    const listbox = screen.getByRole("listbox", { name: "Models" });
+    expect(within(listbox).getAllByText("mistral-medium-latest")).toHaveLength(
+      3,
+    );
+
+    const aliasRow = within(listbox).getByRole("option", {
+      name: "mistral-medium-latest",
+    });
+    expect(aliasRow.textContent).toBe("mistral-medium-latest");
+    expect(
+      within(listbox).getByRole("option", {
+        name: "mistral-medium-latestmistral-medium-2506",
+      }).textContent,
+    ).toContain("mistral-medium-2506");
+    expect(
+      within(listbox).getByRole("option", {
+        name: "mistral-medium-latestmistral-medium-latest-2501",
+      }).textContent,
+    ).toContain("mistral-medium-latest-2501");
+    const largeRow = within(listbox)
+      .getByText("Mistral Large")
+      .closest("button")?.textContent;
+    expect(largeRow).toBe("Mistral Large");
+  });
+
+  it("regroups search results and re-applies the header rule", () => {
+    renderPicker({
+      modelOptions: ompStyleModels,
+      pickerProviderOptions: ompProviderOptions,
+      selectedProviderId: "omp",
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Provider, model and reasoning" }),
+    );
+    const search = screen.getByPlaceholderText("Search models");
+
+    fireEvent.change(search, { target: { value: "zai" } });
+    expect(screen.getByRole("group", { name: "Z.ai" })).not.toBeNull();
+    expect(screen.getByRole("group", { name: "CommandCode" })).not.toBeNull();
+    expect(screen.queryByRole("group", { name: "Cursor" })).toBeNull();
+    expect(screen.queryByRole("group", { name: "Mistral" })).toBeNull();
+    expect(
+      within(screen.getByRole("listbox", { name: "Models" })).queryByText(
+        "Claude Sonnet 4.5",
+      ),
+    ).toBeNull();
+
+    fireEvent.change(search, { target: { value: "Z.ai" } });
+    expect(screen.getByText("GLM-5.3")).not.toBeNull();
+    expect(screen.queryByRole("group")).toBeNull();
+
+    fireEvent.change(search, { target: { value: "mistral-large" } });
+    expect(screen.queryByRole("group")).toBeNull();
+    expect(screen.getByText("Mistral Large")).not.toBeNull();
+    expect(screen.queryByText("mistral-medium-latest")).toBeNull();
+  });
+
+  it("keeps keyboard selection working across group wrappers", () => {
+    const { onModelChange } = renderPicker({
+      modelOptions: ompStyleModels,
+      pickerProviderOptions: ompProviderOptions,
+      selectedProviderId: "omp",
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Provider, model and reasoning" }),
+    );
+    const search = screen.getByPlaceholderText("Search models");
+    fireEvent.change(search, { target: { value: "glm" } });
+
+    fireEvent.keyDown(search, { key: "ArrowDown" });
+    expect(search.getAttribute("aria-activedescendant")).not.toBeNull();
+    fireEvent.keyDown(search, { key: "Enter" });
+    expect(onModelChange).toHaveBeenCalledWith("cursor/glm-5.3");
+  });
+
+  it("cycles a grouped catalog in list order", () => {
+    const { onModelChange } = renderPicker({
+      modelOptions: ompStyleModels,
+      modelValue: "zai/glm-5.3",
+      pickerProviderOptions: ompProviderOptions,
+      selectedProviderId: "omp",
+    });
+    const target = screen.getByRole("button", {
+      name: "Provider, model and reasoning, Z.ai",
+    });
+
+    expect(
+      commandHandlers.get("modelPicker.cycleModelBackward")?.({ target }),
+    ).toBe(true);
+    expect(onModelChange).toHaveBeenCalledWith("cursor/glm-5.3");
+  });
+
+  it("shows the distinguishing token on the trigger only when ambiguous", () => {
+    const ambiguous = renderPicker({
+      modelOptions: ompStyleModels,
+      modelValue: "zai/glm-5.3",
+      pickerProviderOptions: ompProviderOptions,
+      selectedProviderId: "omp",
+    });
+    const ambiguousTrigger = screen.getByRole("button", {
+      name: "Provider, model and reasoning, Z.ai",
+    });
+    expect(ambiguousTrigger.textContent).toContain("Z.ai");
+    expect(ambiguousTrigger.textContent).not.toContain("Cursor");
+    cleanup();
+
+    renderPicker({
+      modelOptions: ompStyleModels,
+      modelValue: "zai/glm-5.2-air",
+      pickerProviderOptions: ompProviderOptions,
+      selectedProviderId: "omp",
+      onModelChange: ambiguous.onModelChange,
+    });
+    const uniqueTrigger = screen.getByRole("button", {
+      name: "Provider, model and reasoning",
+    });
+    expect(uniqueTrigger.textContent).toContain("GLM-5.2 Air");
+    expect(uniqueTrigger.textContent).not.toContain("Z.ai");
+    expect(uniqueTrigger.textContent).not.toContain("zai");
+  });
+
+  it("qualifies a within-group collision on the trigger with route name and id tail", () => {
+    renderPicker({
+      modelOptions: ompStyleModels,
+      modelValue: "mistral/mistral-medium-2506",
+      pickerProviderOptions: ompProviderOptions,
+      selectedProviderId: "omp",
+    });
+
+    const trigger = screen.getByRole("button", {
+      name: "Provider, model and reasoning, Mistral · mistral-medium-2506",
+    });
+    expect(trigger.textContent).toContain("Mistral · mistral-medium-2506");
+  });
+
+  it("groups the more-models submenu under the same headers", () => {
+    const { onModelChange } = renderPicker({
+      modelOptions: manyCodexModels,
+      moreModelOptions: ompStyleModels,
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Provider, model and reasoning" }),
+    );
+    fireEvent.pointerOver(screen.getByText("More models"));
+
+    expect(screen.getByRole("group", { name: "Z.ai" })).not.toBeNull();
+    expect(screen.getByTitle("zai/glm-5.3")).not.toBeNull();
+    fireEvent.click(screen.getByTitle("zai/glm-5.3"));
+    expect(onModelChange).toHaveBeenCalledWith("zai/glm-5.3");
+  });
+
+  it("groups the compact drawer's model list and keeps the more-models toggle in place", () => {
+    const frames: FrameRequestCallback[] = [];
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      frames.push(callback);
+      return frames.length;
+    });
+    renderPicker({
+      modelOptions: ompStyleModels,
+      moreModelOptions: [
+        { value: "cursor/claude-haiku-4-5", label: "Claude Haiku 4.5" },
+        { value: "mistral/codestral-latest", label: "Codestral" },
+      ],
+      pickerProviderOptions: ompProviderOptions,
+      selectedProviderId: "omp",
+      compact: true,
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Provider, model and reasoning" }),
+    );
+    act(() => frames.shift()?.(0));
+    act(() => frames.shift()?.(16));
+    expect(screen.getByRole("group", { name: "Z.ai" })).not.toBeNull();
+    expect(screen.getByRole("group", { name: "Cursor" })).not.toBeNull();
+    expect(screen.getByText("Z.ai").className).toContain(
+      MODEL_GROUP_HEADER_STICKY_TOP_COMPACT,
+    );
+
+    fireEvent.click(screen.getByText("More models"));
+    const groups = screen.getAllByRole("group");
+    const labelledBy = groups.map((group) =>
+      group.getAttribute("aria-labelledby"),
+    );
+    const groupLabels = labelledBy.map(
+      (id) => document.getElementById(id ?? "")?.textContent,
+    );
+    expect(groupLabels).toEqual([
+      "Cursor",
+      "Z.ai",
+      "CommandCode",
+      "Mistral",
+      "Cursor",
+      "Mistral",
+    ]);
+    expect(new Set(labelledBy).size).toBe(labelledBy.length);
+    expect(screen.getByText("Claude Haiku 4.5")).not.toBeNull();
+    expect(screen.getByText("Codestral")).not.toBeNull();
   });
 
   it("uses picker search policy and selects the match by keyboard", () => {

--- a/apps/app/src/components/pickers/ModelReasoningPicker.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.tsx
@@ -1,4 +1,5 @@
 import {
+  Fragment,
   useCallback,
   useEffect,
   useId,
@@ -53,7 +54,15 @@ import {
   OPTION_TRIGGER_CONTENT_CLASS_NAME,
 } from "@bb/shared-ui/option-display";
 import { type PickerOption } from "./OptionPicker";
-import type { ModelPickerOption } from "./model-picker-option";
+import {
+  groupModelOptions,
+  hasMultipleRouteGroups,
+  modelRouteKey,
+  qualifyCollidingLabels,
+  routeProviderDisplayName,
+  selectedModelQualifier,
+  type ModelPickerOption,
+} from "./model-picker-option";
 import { searchPickerOptions } from "./picker-search";
 import { useResetPickerScroll } from "./useResetPickerScroll";
 import {
@@ -157,6 +166,35 @@ export function buildModelNavRows({
   }
 
   return rows;
+}
+
+type ModelListBlock =
+  | { kind: "toggle"; navIndex: number }
+  | {
+      kind: "group";
+      routeKey: string | null;
+      entries: { navIndex: number; option: ModelPickerOption }[];
+    };
+
+function buildModelListBlocks(
+  navRows: readonly ModelNavRow[],
+): ModelListBlock[] {
+  const blocks: ModelListBlock[] = [];
+  let currentGroup: Extract<ModelListBlock, { kind: "group" }> | null = null;
+  navRows.forEach((row, navIndex) => {
+    if (row.kind === "more-toggle") {
+      currentGroup = null;
+      blocks.push({ kind: "toggle", navIndex });
+      return;
+    }
+    const routeKey = modelRouteKey(row.option);
+    if (currentGroup === null || currentGroup.routeKey !== routeKey) {
+      currentGroup = { kind: "group", routeKey, entries: [] };
+      blocks.push(currentGroup);
+    }
+    currentGroup.entries.push({ navIndex, option: row.option });
+  });
+  return blocks;
 }
 
 interface ModelReasoningPickerProps {
@@ -313,6 +351,16 @@ export function ModelReasoningPicker({
   const { base: triggerModelBase, tag: triggerModelTag } =
     splitModelLabelTag(triggerModelLabel);
 
+  const triggerModelQualifier = useMemo(
+    () =>
+      selectedModelQualifier(
+        [...modelOptions, ...moreModelOptions],
+        modelValue,
+        selectedProvider?.brandPrefix,
+      ),
+    [modelOptions, moreModelOptions, modelValue, selectedProvider?.brandPrefix],
+  );
+
   const selectedReasoningOption = reasoningOptions.find(
     (r) => r.value === reasoningValue,
   );
@@ -452,10 +500,15 @@ export function ModelReasoningPicker({
       query: searchQuery,
       getLabel: (option) =>
         stripModelBrandPrefix(option.label, activeBrandPrefix),
-      getAliases: (option) =>
-        option.routeProviderId
-          ? [option.routeProviderId, option.value]
-          : [option.value],
+      getAliases: (option) => {
+        const routeKey = modelRouteKey(option);
+        return [
+          ...(routeKey !== null
+            ? [routeKey, routeProviderDisplayName(routeKey)]
+            : []),
+          option.value,
+        ];
+      },
     });
   }, [
     activeBrandPrefix,
@@ -485,6 +538,25 @@ export function ModelReasoningPicker({
       showMoreModels,
     ],
   );
+
+  const visibleModelOptions = useMemo(
+    () => navRows.flatMap((row) => (row.kind === "model" ? [row.option] : [])),
+    [navRows],
+  );
+  const visibleModelQualifiers = useMemo(
+    () => qualifyCollidingLabels(visibleModelOptions, activeBrandPrefix),
+    [visibleModelOptions, activeBrandPrefix],
+  );
+  const modelListBlocks = useMemo(
+    () => buildModelListBlocks(navRows),
+    [navRows],
+  );
+  const showModelGroupHeaders = useMemo(
+    () => hasMultipleRouteGroups(groupModelOptions(visibleModelOptions)),
+    [visibleModelOptions],
+  );
+  const modelGroupHeaderId = (routeKey: string, blockIndex: number): string =>
+    `${navId}-group-${routeKey}-${blockIndex}`;
 
   const highlightedIndex =
     activeIndex >= 0 && activeIndex < navRows.length ? activeIndex : -1;
@@ -745,23 +817,27 @@ export function ModelReasoningPicker({
     ? "Loading models..."
     : selectedModelLoadFailed
       ? selectedModelLoadErrorText
-      : triggerModelLabel;
+      : triggerModelQualifier
+        ? `${triggerModelLabel} · ${modelValue}`
+        : triggerModelLabel;
   const triggerTitle = [
     `${selectedProviderLabel}: ${triggerTitleModelLabel}`,
     triggerReasoningLabel ? ` · ${triggerReasoningLabel} reasoning` : "",
     showSelectedFastMode ? " (Fast mode)" : "",
   ].join("");
+  const triggerBaseAriaLabel = toggleShortcut
+    ? `Provider, model and reasoning (${toggleShortcut.label})`
+    : "Provider, model and reasoning";
+  const triggerAriaLabel = triggerModelQualifier
+    ? `${triggerBaseAriaLabel}, ${triggerModelQualifier}`
+    : triggerBaseAriaLabel;
   const trigger = (
     <Button
       ref={triggerRef}
       type="button"
       variant="ghost"
       size="sm"
-      aria-label={
-        toggleShortcut
-          ? `Provider, model and reasoning (${toggleShortcut.label})`
-          : "Provider, model and reasoning"
-      }
+      aria-label={triggerAriaLabel}
       aria-keyshortcuts={toggleShortcut?.ariaKeyshortcuts}
       disabled={disabled}
       className={cn(
@@ -819,6 +895,11 @@ export function ModelReasoningPicker({
             {triggerModelTag ? (
               <span className="shrink-0 text-subtle-foreground">
                 {triggerModelTag}
+              </span>
+            ) : null}
+            {triggerModelQualifier ? (
+              <span className="shrink-0 text-subtle-foreground">
+                {triggerModelQualifier}
               </span>
             ) : null}
             {triggerReasoningLabel ? (
@@ -966,15 +1047,13 @@ export function ModelReasoningPicker({
                 <ModelPickerLoadingRows />
               ) : hasActiveModelOptions ? (
                 <>
-                  {navRows.map((row, index) => {
-                    const active = highlightedIndex === index;
-                    const domId = optionDomId(index);
-                    if (row.kind === "more-toggle") {
+                  {modelListBlocks.map((block, blockIndex) => {
+                    if (block.kind === "toggle") {
                       return (
                         <MoreModelsToggleRow
                           key="more-toggle"
-                          id={domId}
-                          isActive={active}
+                          id={optionDomId(block.navIndex)}
+                          isActive={highlightedIndex === block.navIndex}
                           expanded={showMoreModels}
                           onToggle={() =>
                             setShowMoreModels((current) => !current)
@@ -982,22 +1061,51 @@ export function ModelReasoningPicker({
                         />
                       );
                     }
-                    const option = row.option;
-                    return (
+                    const headerKey =
+                      showModelGroupHeaders && block.routeKey !== null
+                        ? block.routeKey
+                        : null;
+                    const rows = block.entries.map(({ navIndex, option }) => (
                       <MenuRowButton
                         key={option.value}
-                        id={domId}
+                        id={optionDomId(navIndex)}
                         role={showSearchInput ? "option" : undefined}
-                        isActive={active}
+                        isActive={highlightedIndex === navIndex}
                         label={stripModelBrandPrefix(
                           option.label,
                           activeBrandPrefix,
                         )}
-                        qualifier={option.routeProviderId}
+                        qualifier={visibleModelQualifiers.get(option.value)}
+                        title={
+                          block.routeKey === null ? undefined : option.value
+                        }
                         selected={!isPreviewing && option.value === modelValue}
                         disabled={previewSelectionBlocked}
                         onClick={() => handleModelSelect(option.value)}
                       />
+                    ));
+                    if (headerKey === null) {
+                      return (
+                        <Fragment
+                          key={`ungrouped-${blockIndex}-${block.routeKey}`}
+                        >
+                          {rows}
+                        </Fragment>
+                      );
+                    }
+                    const headerId = modelGroupHeaderId(headerKey, blockIndex);
+                    return (
+                      <div
+                        key={`group-${headerKey}-${blockIndex}`}
+                        role="group"
+                        aria-labelledby={headerId}
+                      >
+                        {}
+                        <MenuSectionLabel id={headerId} pinBelowLabel>
+                          {routeProviderDisplayName(headerKey)}
+                        </MenuSectionLabel>
+                        {rows}
+                      </div>
                     );
                   })}
                   {!isCompactViewport &&
@@ -1114,13 +1222,30 @@ export function ModelReasoningPicker({
   );
 }
 
-function MenuSectionLabel({ children }: { children: ReactNode }) {
+export const MODEL_GROUP_HEADER_STICKY_TOP_DESKTOP = "top-[33px]";
+export const MODEL_GROUP_HEADER_STICKY_TOP_COMPACT = "top-[34px]";
+
+function MenuSectionLabel({
+  id,
+  pinBelowLabel = false,
+  children,
+}: {
+  id?: string;
+  pinBelowLabel?: boolean;
+  children: ReactNode;
+}) {
   const isCompactViewport = useIsCompactViewport();
 
   return (
     <div
+      id={id}
       className={cn(
-        "sticky top-0 z-10 bg-background px-2 text-xs font-medium text-muted-foreground",
+        "sticky z-10 bg-background px-2 text-xs font-medium text-muted-foreground",
+        pinBelowLabel
+          ? isCompactViewport
+            ? MODEL_GROUP_HEADER_STICKY_TOP_COMPACT
+            : MODEL_GROUP_HEADER_STICKY_TOP_DESKTOP
+          : "top-0",
         isCompactViewport ? "pb-1.5 pt-2" : "pb-[0.3125rem] pt-2",
       )}
     >
@@ -1220,8 +1345,15 @@ function MoreModelsSubmenu({
   onSelect: (value: string) => void;
 }) {
   const { isLastHovered, hoverProps } = useMenuItemHover();
+  const submenuId = useId();
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   const contentRef = useRef<HTMLDivElement | null>(null);
+  const groups = useMemo(() => groupModelOptions(options), [options]);
+  const qualifiers = useMemo(
+    () => qualifyCollidingLabels(options, activeBrandPrefix),
+    [options, activeBrandPrefix],
+  );
+  const showGroupHeaders = hasMultipleRouteGroups(groups);
   const focusFirstSubItem = useCallback(() => {
     window.setTimeout(() => {
       contentRef.current?.querySelector<HTMLButtonElement>("button")?.focus();
@@ -1296,15 +1428,36 @@ function MoreModelsSubmenu({
         }}
       >
         <MenuHoverProvider>
-          {options.map((option) => (
-            <MenuRowButton
-              key={option.value}
-              label={stripModelBrandPrefix(option.label, activeBrandPrefix)}
-              qualifier={option.routeProviderId}
-              selected={!isPreviewing && option.value === modelValue}
-              onClick={() => onSelect(option.value)}
-            />
-          ))}
+          {groups.map((group, groupIndex) => {
+            const rows = group.options.map((option) => (
+              <MenuRowButton
+                key={option.value}
+                label={stripModelBrandPrefix(option.label, activeBrandPrefix)}
+                qualifier={qualifiers.get(option.value)}
+                title={group.key === null ? undefined : option.value}
+                selected={!isPreviewing && option.value === modelValue}
+                onClick={() => onSelect(option.value)}
+              />
+            ));
+            if (group.key === null || !showGroupHeaders) {
+              return (
+                <Fragment key={`ungrouped-${groupIndex}`}>{rows}</Fragment>
+              );
+            }
+            const headerId = `${submenuId}-group-${group.key}`;
+            return (
+              <div
+                key={`group-${group.key}-${groupIndex}`}
+                role="group"
+                aria-labelledby={headerId}
+              >
+                <MenuSectionLabel id={headerId}>
+                  {routeProviderDisplayName(group.key)}
+                </MenuSectionLabel>
+                {rows}
+              </div>
+            );
+          })}
         </MenuHoverProvider>
       </PopoverContent>
     </Popover>
@@ -1323,6 +1476,7 @@ function ResetBrowseStateOnContentUnmount({
 function MenuRowButton({
   label,
   qualifier,
+  title,
   selected,
   disabled = false,
   onClick,
@@ -1334,6 +1488,7 @@ function MenuRowButton({
 }: {
   label: string;
   qualifier?: string;
+  title?: string;
   selected: boolean;
   disabled?: boolean;
   onClick: () => void;
@@ -1369,7 +1524,7 @@ function MenuRowButton({
     >
       <span
         className="truncate"
-        title={qualifier ? `${label} · ${qualifier}` : label}
+        title={title ?? (qualifier ? `${label} · ${qualifier}` : label)}
       >
         {base}
         {tag ? (

--- a/apps/app/src/components/pickers/model-picker-option.test.ts
+++ b/apps/app/src/components/pickers/model-picker-option.test.ts
@@ -1,0 +1,329 @@
+import { describe, expect, it } from "vitest";
+import type { ModelPickerOption } from "./model-picker-option";
+import {
+  groupModelOptions,
+  hasMultipleRouteGroups,
+  modelRouteKey,
+  qualifyCollidingLabels,
+  ROUTE_PROVIDER_DISPLAY_NAMES,
+  routeProviderDisplayName,
+  selectedModelQualifier,
+} from "./model-picker-option";
+
+function model({
+  value,
+  label,
+  routeProviderId,
+}: {
+  value: string;
+  label: string;
+  routeProviderId?: string;
+}): ModelPickerOption {
+  return {
+    value,
+    label,
+    ...(routeProviderId === undefined ? {} : { routeProviderId }),
+  };
+}
+
+const glmDupAcrossProviders: readonly ModelPickerOption[] = [
+  model({ value: "cursor/glm-5.3", label: "GLM-5.3" }),
+  model({ value: "zai/glm-5.3", label: "GLM-5.3" }),
+  model({ value: "zai/glm-5.2-air", label: "GLM-5.2 Air" }),
+];
+
+const mistralTripleCollision: readonly ModelPickerOption[] = [
+  model({
+    value: "mistral/mistral-medium-latest",
+    label: "mistral-medium-latest",
+  }),
+  model({
+    value: "mistral/mistral-medium-2506",
+    label: "mistral-medium-latest",
+  }),
+  model({
+    value: "mistral/mistral-medium-latest-2501",
+    label: "mistral-medium-latest",
+  }),
+  model({ value: "mistral/mistral-large-latest", label: "Mistral Large" }),
+];
+
+describe("modelRouteKey", () => {
+  it("derives the key from the value's route prefix", () => {
+    expect(
+      modelRouteKey(model({ value: "zai/glm-5.3", label: "GLM-5.3" })),
+    ).toBe("zai");
+  });
+
+  it("keeps only the leading segment of nested route ids", () => {
+    expect(
+      modelRouteKey(
+        model({ value: "commandcode/zai-org/GLM-5", label: "GLM-5" }),
+      ),
+    ).toBe("commandcode");
+  });
+
+  it("prefers a declared routeProviderId over the value prefix", () => {
+    expect(
+      modelRouteKey(
+        model({
+          value: "cursor/glm-5.3",
+          label: "GLM-5.3",
+          routeProviderId: "zai",
+        }),
+      ),
+    ).toBe("zai");
+  });
+
+  it("returns null for route-less ids and missing prefixes", () => {
+    expect(
+      modelRouteKey(model({ value: "gpt-5.5", label: "GPT-5.5" })),
+    ).toBeNull();
+    expect(modelRouteKey(model({ value: "/glm", label: "GLM" }))).toBeNull();
+  });
+});
+
+describe("groupModelOptions", () => {
+  it("groups by key in first-appearance order, merging repeats", () => {
+    const groups = groupModelOptions([
+      model({ value: "zai/glm-5.3", label: "GLM-5.3" }),
+      model({ value: "cursor/claude-sonnet-4-5", label: "Claude Sonnet 4.5" }),
+      model({ value: "zai/glm-5.2-air", label: "GLM-5.2 Air" }),
+    ]);
+
+    expect(groups.map((group) => group.key)).toEqual(["zai", "cursor"]);
+    expect(groups[0].options.map((option) => option.value)).toEqual([
+      "zai/glm-5.3",
+      "zai/glm-5.2-air",
+    ]);
+  });
+
+  it("collects route-less models into the leading, headerless group", () => {
+    const groups = groupModelOptions([
+      model({ value: "gpt-5.5", label: "GPT-5.5" }),
+      model({ value: "zai/glm-5.3", label: "GLM-5.3" }),
+      model({ value: "gpt-5.4", label: "GPT-5.4" }),
+    ]);
+
+    expect(groups.map((group) => group.key)).toEqual([null, "zai"]);
+    expect(groups[0].options.map((option) => option.value)).toEqual([
+      "gpt-5.5",
+      "gpt-5.4",
+    ]);
+  });
+
+  it("yields a single headerless group for an all-route-less list", () => {
+    const groups = groupModelOptions([
+      model({ value: "gpt-5.5", label: "GPT-5.5" }),
+      model({ value: "claude-sonnet-5", label: "Claude Sonnet 5" }),
+    ]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].key).toBeNull();
+  });
+});
+
+describe("hasMultipleRouteGroups", () => {
+  it("is true only when ≥2 keyed groups are present", () => {
+    const single = groupModelOptions([
+      model({ value: "zai/glm-5.3", label: "GLM-5.3" }),
+      model({ value: "zai/glm-5.2", label: "GLM-5.2" }),
+      model({ value: "gpt-5.5", label: "GPT-5.5" }),
+    ]);
+    expect(hasMultipleRouteGroups(single)).toBe(false);
+
+    const multi = groupModelOptions(glmDupAcrossProviders);
+    expect(hasMultipleRouteGroups(multi)).toBe(true);
+  });
+
+  it("stays false for an all-route-less list", () => {
+    expect(
+      hasMultipleRouteGroups(
+        groupModelOptions([
+          model({ value: "gpt-5.5", label: "GPT-5.5" }),
+          model({ value: "gpt-5.2", label: "GPT-5.2" }),
+        ]),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("routeProviderDisplayName", () => {
+  it("maps every known route key to its human-readable name", () => {
+    expect(ROUTE_PROVIDER_DISPLAY_NAMES.get("cursor")).toBe("Cursor");
+    expect(ROUTE_PROVIDER_DISPLAY_NAMES.get("zai")).toBe("Z.ai");
+    expect(ROUTE_PROVIDER_DISPLAY_NAMES.get("mistral")).toBe("Mistral");
+    expect(ROUTE_PROVIDER_DISPLAY_NAMES.get("google-antigravity")).toBe(
+      "Google Antigravity",
+    );
+    expect(ROUTE_PROVIDER_DISPLAY_NAMES.get("xai-oauth")).toBe("xAI");
+    expect(ROUTE_PROVIDER_DISPLAY_NAMES.get("alibaba-token-plan")).toBe(
+      "Alibaba",
+    );
+    expect(ROUTE_PROVIDER_DISPLAY_NAMES.get("opencode-zen")).toBe(
+      "OpenCode Zen",
+    );
+    expect(ROUTE_PROVIDER_DISPLAY_NAMES.get("openai-codex")).toBe(
+      "OpenAI Codex",
+    );
+    expect(ROUTE_PROVIDER_DISPLAY_NAMES.get("commandcode")).toBe("CommandCode");
+  });
+
+  it("prettifies unknown keys: hyphens become spaces, words capitalize", () => {
+    expect(routeProviderDisplayName("new-route-x")).toBe("New Route X");
+    expect(routeProviderDisplayName("acme")).toBe("Acme");
+    expect(routeProviderDisplayName("a--b")).toBe("A B");
+  });
+
+  it("is display-only: grouping keys stay raw", () => {
+    const groups = groupModelOptions([
+      model({ value: "zai/glm-5.3", label: "GLM-5.3" }),
+      model({ value: "commandcode/zai-org/GLM-5", label: "GLM-5" }),
+    ]);
+
+    expect(groups.map((group) => group.key)).toEqual(["zai", "commandcode"]);
+  });
+});
+
+describe("qualifyCollidingLabels", () => {
+  it("qualifies only within-group collisions, suppressing id-restating remainders", () => {
+    const qualifiers = qualifyCollidingLabels([
+      ...glmDupAcrossProviders,
+      ...mistralTripleCollision,
+    ]);
+
+    expect(qualifiers.has("cursor/glm-5.3")).toBe(false);
+    expect(qualifiers.has("zai/glm-5.3")).toBe(false);
+    expect(qualifiers.has("zai/glm-5.2-air")).toBe(false);
+
+    expect(qualifiers.has("mistral/mistral-medium-latest")).toBe(false);
+    expect(qualifiers.get("mistral/mistral-medium-2506")).toBe(
+      "mistral-medium-2506",
+    );
+    expect(qualifiers.get("mistral/mistral-medium-latest-2501")).toBe(
+      "mistral-medium-latest-2501",
+    );
+    expect(qualifiers.has("mistral/mistral-large-latest")).toBe(false);
+  });
+
+  it("suppresses a remainder that restates the label case-insensitively", () => {
+    const qualifiers = qualifyCollidingLabels([
+      model({ value: "zai/glm-5", label: "GLM-5" }),
+      model({ value: "zai/glm-5.5", label: "GLM-5" }),
+    ]);
+
+    expect(qualifiers.has("zai/glm-5")).toBe(false);
+    expect(qualifiers.get("zai/glm-5.5")).toBe("glm-5.5");
+  });
+
+  it("keeps nested route ids' remainder path intact", () => {
+    const qualifiers = qualifyCollidingLabels([
+      model({ value: "commandcode/zai-org/GLM-5", label: "GLM-5" }),
+      model({ value: "commandcode/zai-org/GLM-5.5", label: "GLM-5" }),
+    ]);
+
+    expect(qualifiers.get("commandcode/zai-org/GLM-5")).toBe("zai-org/GLM-5");
+    expect(qualifiers.get("commandcode/zai-org/GLM-5.5")).toBe(
+      "zai-org/GLM-5.5",
+    );
+  });
+
+  it("falls back to the full value when it carries no route prefix", () => {
+    const qualifiers = qualifyCollidingLabels([
+      model({ value: "gpt-5.5", label: "GPT" }),
+      model({ value: "gpt-5.4", label: "GPT" }),
+    ]);
+
+    expect(qualifiers.get("gpt-5.5")).toBe("gpt-5.5");
+    expect(qualifiers.get("gpt-5.4")).toBe("gpt-5.4");
+  });
+
+  it("compares brand-stripped rendered labels", () => {
+    const qualifiers = qualifyCollidingLabels(
+      [
+        model({ value: "zai/Codex-5", label: "Zai Codex 5" }),
+        model({ value: "zai/codex-5-preview", label: "Codex 5" }),
+      ],
+      "Zai ",
+    );
+
+    expect(qualifiers.get("zai/Codex-5")).toBe("Codex-5");
+    expect(qualifiers.get("zai/codex-5-preview")).toBe("codex-5-preview");
+  });
+
+  it("treats trailing parenthetical tags as part of the rendered label", () => {
+    const qualifiers = qualifyCollidingLabels([
+      model({ value: "zai/glm-5.3", label: "GLM-5.3 (1M)" }),
+      model({ value: "zai/glm-5.3-pro", label: "GLM-5.3" }),
+    ]);
+
+    expect(qualifiers.size).toBe(0);
+  });
+});
+
+describe("selectedModelQualifier", () => {
+  it("uses the pretty route name for a cross-group collision", () => {
+    expect(selectedModelQualifier(glmDupAcrossProviders, "zai/glm-5.3")).toBe(
+      "Z.ai",
+    );
+    expect(
+      selectedModelQualifier(glmDupAcrossProviders, "cursor/glm-5.3"),
+    ).toBe("Cursor");
+  });
+
+  it("qualifies a within-group collision with route name and remainder", () => {
+    expect(
+      selectedModelQualifier(
+        mistralTripleCollision,
+        "mistral/mistral-medium-2506",
+      ),
+    ).toBe("Mistral · mistral-medium-2506");
+  });
+
+  it("returns null while the label is unambiguous", () => {
+    expect(
+      selectedModelQualifier(glmDupAcrossProviders, "zai/glm-5.2-air"),
+    ).toBeNull();
+    expect(
+      selectedModelQualifier(
+        mistralTripleCollision,
+        "mistral/mistral-large-latest",
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null when the value is not in the list", () => {
+    expect(selectedModelQualifier(glmDupAcrossProviders, "gone/1")).toBeNull();
+  });
+
+  it("drops a remainder that restates the label, within-group only", () => {
+    expect(
+      selectedModelQualifier(
+        mistralTripleCollision,
+        "mistral/mistral-medium-latest",
+      ),
+    ).toBeNull();
+  });
+
+  it("falls back to the pretty route name for a degenerate remainder with a cross-group collision", () => {
+    const options: readonly ModelPickerOption[] = [
+      model({ value: "cursor/glm-5.3", label: "GLM-5.3" }),
+      model({ value: "zai/glm-5.3", label: "GLM-5.3" }),
+      model({ value: "zai/glm-5.3-air", label: "GLM-5.3" }),
+    ];
+
+    expect(selectedModelQualifier(options, "zai/glm-5.3")).toBe("Z.ai");
+  });
+
+  it("prefers the remainder when collisions span both scopes", () => {
+    const options: readonly ModelPickerOption[] = [
+      model({ value: "cursor/glm-5.3", label: "GLM-5.3" }),
+      model({ value: "zai/glm-5.3", label: "GLM-5.3" }),
+      model({ value: "zai/glm-5.3-air", label: "GLM-5.3" }),
+    ];
+
+    expect(selectedModelQualifier(options, "zai/glm-5.3-air")).toBe(
+      "Z.ai · glm-5.3-air",
+    );
+  });
+});

--- a/apps/app/src/components/pickers/model-picker-option.ts
+++ b/apps/app/src/components/pickers/model-picker-option.ts
@@ -1,5 +1,155 @@
 import type { PickerOption } from "./OptionPicker";
+import { stripModelBrandPrefix } from "./model-brand-prefix";
 
 export interface ModelPickerOption extends PickerOption<string> {
   routeProviderId?: string;
+}
+
+export interface ModelOptionGroup {
+  key: string | null;
+  options: ModelPickerOption[];
+}
+
+export function modelRouteKey(option: ModelPickerOption): string | null {
+  if (option.routeProviderId !== undefined) {
+    return option.routeProviderId;
+  }
+  const separatorIndex = option.value.indexOf("/");
+  return separatorIndex > 0 ? option.value.slice(0, separatorIndex) : null;
+}
+
+export const ROUTE_PROVIDER_DISPLAY_NAMES: ReadonlyMap<string, string> =
+  new Map([
+    ["cursor", "Cursor"],
+    ["openai", "OpenAI"],
+    ["zai", "Z.ai"],
+    ["mistral", "Mistral"],
+    ["google-antigravity", "Google Antigravity"],
+    ["xai-oauth", "xAI"],
+    ["alibaba-token-plan", "Alibaba"],
+    ["opencode-zen", "OpenCode Zen"],
+    ["openai-codex", "OpenAI Codex"],
+    ["commandcode", "CommandCode"],
+  ]);
+
+export function routeProviderDisplayName(key: string): string {
+  const known = ROUTE_PROVIDER_DISPLAY_NAMES.get(key);
+  if (known !== undefined) {
+    return known;
+  }
+  return key
+    .split("-")
+    .filter((word) => word.length > 0)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+export function groupModelOptions(
+  options: readonly ModelPickerOption[],
+): ModelOptionGroup[] {
+  const keyedGroups: ModelOptionGroup[] = [];
+  const groupsByKey = new Map<string, ModelOptionGroup>();
+  const ungrouped: ModelPickerOption[] = [];
+
+  for (const option of options) {
+    const key = modelRouteKey(option);
+    if (key === null) {
+      ungrouped.push(option);
+      continue;
+    }
+    let group = groupsByKey.get(key);
+    if (group === undefined) {
+      group = { key, options: [] };
+      groupsByKey.set(key, group);
+      keyedGroups.push(group);
+    }
+    group.options.push(option);
+  }
+
+  return ungrouped.length > 0
+    ? [{ key: null, options: ungrouped }, ...keyedGroups]
+    : keyedGroups;
+}
+
+export function hasMultipleRouteGroups(
+  groups: readonly ModelOptionGroup[],
+): boolean {
+  let keyedGroupCount = 0;
+  for (const group of groups) {
+    if (group.key !== null) {
+      keyedGroupCount += 1;
+    }
+  }
+  return keyedGroupCount >= 2;
+}
+
+function routeRemainder(option: ModelPickerOption, key: string | null): string {
+  return key !== null && option.value.startsWith(`${key}/`)
+    ? option.value.slice(key.length + 1)
+    : option.value;
+}
+
+export function qualifyCollidingLabels(
+  options: readonly ModelPickerOption[],
+  brandPrefix?: string,
+): ReadonlyMap<string, string> {
+  const qualifiers = new Map<string, string>();
+  for (const group of groupModelOptions(options)) {
+    const labels = group.options.map((option) =>
+      stripModelBrandPrefix(option.label, brandPrefix),
+    );
+    group.options.forEach((option, index) => {
+      const collides = labels.some(
+        (label, otherIndex) => otherIndex !== index && label === labels[index],
+      );
+      if (!collides) {
+        return;
+      }
+      const remainder = routeRemainder(option, group.key);
+      if (remainder.toLowerCase() === labels[index].toLowerCase()) {
+        return;
+      }
+      qualifiers.set(option.value, remainder);
+    });
+  }
+  return qualifiers;
+}
+
+export function selectedModelQualifier(
+  options: readonly ModelPickerOption[],
+  value: string,
+  brandPrefix?: string,
+): string | null {
+  const selected = options.find((option) => option.value === value);
+  if (selected === undefined) {
+    return null;
+  }
+  const label = stripModelBrandPrefix(selected.label, brandPrefix);
+  const key = modelRouteKey(selected);
+  let sameGroupCollision = false;
+  let crossGroupCollision = false;
+  for (const other of options) {
+    if (other.value === value) {
+      continue;
+    }
+    if (stripModelBrandPrefix(other.label, brandPrefix) !== label) {
+      continue;
+    }
+    if (modelRouteKey(other) === key) {
+      sameGroupCollision = true;
+    } else {
+      crossGroupCollision = true;
+    }
+  }
+  if (sameGroupCollision) {
+    const remainder = routeRemainder(selected, key);
+    if (remainder.toLowerCase() !== label.toLowerCase()) {
+      return key !== null
+        ? `${routeProviderDisplayName(key)} · ${remainder}`
+        : remainder;
+    }
+  }
+  return crossGroupCollision && key !== null
+    ? routeProviderDisplayName(key)
+    : null;
 }

--- a/packages/domain/src/plugin-sdk-version.ts
+++ b/packages/domain/src/plugin-sdk-version.ts
@@ -1,3 +1,3 @@
-export const PLUGIN_SDK_VERSION = "0.4.40";
+export const PLUGIN_SDK_VERSION = "0.4.41";
 
 export const PLUGIN_SDK_MAJOR = Number(PLUGIN_SDK_VERSION.split(".", 1)[0]);

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@get-bb/plugin-sdk",
-  "version": "0.4.40",
+  "version": "0.4.41",
   "homepage": "https://github.com/get-bb/bb#readme",
   "bugs": {
     "url": "https://github.com/get-bb/bb/issues"

--- a/packages/provider-bridge-acp/src/bridge/model-catalog.test.ts
+++ b/packages/provider-bridge-acp/src/bridge/model-catalog.test.ts
@@ -414,6 +414,35 @@ describe("acp configOptions model catalog", () => {
     ]);
   });
 
+  it("preserves select-option descriptions, defaulting missing ones to empty", () => {
+    const models = buildModelCatalogFromConfigOptions({
+      id: "model",
+      name: "Model",
+      category: "model",
+      type: "select",
+      currentValue: "zai/glm-5.3",
+      options: [
+        {
+          value: "zai/glm-5.3",
+          name: "GLM 5.3",
+          description: "zai/glm-5.3",
+        },
+        { value: "cursor/glm-5.3", name: "GLM 5.3" },
+        {
+          value: "mistral/mistral-medium-latest",
+          name: "Mistral Medium",
+          description: undefined,
+        },
+      ],
+    });
+
+    expect(models.map((model) => model.description)).toEqual([
+      "zai/glm-5.3",
+      "",
+      "",
+    ]);
+  });
+
   it("finds and maps ACP thought_level config options", () => {
     const thoughtLevel = {
       id: "effort",

--- a/packages/provider-bridge-acp/src/bridge/model-catalog.ts
+++ b/packages/provider-bridge-acp/src/bridge/model-catalog.ts
@@ -223,7 +223,7 @@ export function buildModelCatalogFromConfigOptions(
       id: option.value,
       model: option.value,
       displayName: option.name ?? option.value,
-      description: "",
+      description: option.description ?? "",
       supportedReasoningEfforts: reasoning.supportedReasoningEfforts,
       defaultReasoningEffort: reasoning.defaultReasoningEffort,
       isDefault,

--- a/packages/provider-bridge-acp/src/wire.test.ts
+++ b/packages/provider-bridge-acp/src/wire.test.ts
@@ -125,6 +125,11 @@ describe("acpSessionNewResultSchema", () => {
               name: "openai-codex/GPT-5.5",
               description: null,
             },
+            {
+              value: "openai-codex/gpt-5.5-codex-max",
+              name: "openai-codex/GPT-5.5 Codex Max",
+              description: "openai-codex/gpt-5.5-codex-max",
+            },
           ],
         },
         {
@@ -147,6 +152,12 @@ describe("acpSessionNewResultSchema", () => {
     ).toBeUndefined();
     expect(parsed.data.configOptions?.[0].options?.[0].name).toBe(
       "openai-codex/GPT-5.5",
+    );
+    expect(
+      parsed.data.configOptions?.[0].options?.[0].description,
+    ).toBeUndefined();
+    expect(parsed.data.configOptions?.[0].options?.[1].description).toBe(
+      "openai-codex/gpt-5.5-codex-max",
     );
     expect(parsed.data.configOptions?.[1].category).toBeUndefined();
     expect(parsed.data.configOptions?.[1].options?.[0].name).toBeUndefined();

--- a/packages/provider-bridge-acp/src/wire.ts
+++ b/packages/provider-bridge-acp/src/wire.ts
@@ -255,6 +255,7 @@ const acpConfigOptionSelectOptionSchema = z
   .object({
     value: z.string(),
     name: acpOptionalString,
+    description: acpOptionalString,
   })
   .passthrough();
 


### PR DESCRIPTION
## Human comments

## What was wrong

`buildModelCatalogFromConfigOptions` hard-coded `description: ""` for every ACP model select option, and `acpConfigOptionSelectOptionSchema` did not type `description` (it only survived via `.passthrough()`). Agents such as omp send `description: "provider/modelId"` and advertise the same display name under several routes (on this machine: 279 models across 9 providers, 37 duplicate display names). The desktop picker rendered only the display name, so those rows were identical in text, tooltip, and accessible name. Issue: #2062. Closed PR #2226 had the bridge fix plus inline qualifiers; this redo keeps the bridge hunks and replaces the desktop UX with provider-grouped headers.

## What changed

Bridge (`packages/provider-bridge-acp`):

- `src/wire.ts`: `description: acpOptionalString` on the select-option schema.
- `src/bridge/model-catalog.ts`: `description: option.description ?? ""`, mirroring `buildModelCatalogFromSessionModels`.
- No `HOST_DAEMON_PROTOCOL_VERSION` bump: `AvailableModel.description` is already a required string.

Desktop (`apps/app`):

- Two-level grouped list by route key (`routeProviderId`, else the first segment of a slashed id). Sticky `MenuSectionLabel` headers only when ≥2 routes are visible. Search that narrows to one route hides the headers (same rule).
- Within-group label collisions get an inline qualifier (id remainder after `provider/`). The trigger shows a distinguishing token only when the committed label is ambiguous across `modelOptions` + `moreModelOptions`.
- Tooltips stay on the inner `span[title]` with the full raw id; keyboard order matches DOM order (contiguous route runs, not merged).
- Curated short display names (`zai` → Z.ai, `xai-oauth` → xAI, …) with a hyphen→title-case fallback. omp 18.0.5 does not expose provider display names on `omp models --json`; group keys and tooltips stay on raw ids.
- Single-provider lists (Claude Code, Codex) render with no headers and no qualifiers.
- `.ladle` fixture + story cover the omp-style multi-route catalog.

The former mobile assertion (`apps/mobile/src/data/compose/execution-options.test.ts`) was dropped during the rebase: `apps/mobile/src/data/compose/` no longer exists on main. The bridge fix itself is unchanged, so whichever surface consumes `AvailableModel.description` now gets the provider-qualified subtitle.

Deviation from closed #2226: grouping + headers instead of always-on inline qualifiers.

## How you verified

Tests (fail before, pass after):

- `packages/provider-bridge-acp/src/bridge/model-catalog.test.ts` — catalog keeps the per-option description (17 files / 301 tests green).
- `packages/provider-bridge-acp/src/wire.test.ts` — schema returns `description` and normalizes `null` → `undefined`.
- `apps/app/src/components/pickers/model-picker-option.test.ts` — grouping, ≥2-route header gate, within-group qualifiers, trigger token, display-name map.
- `apps/app/src/components/pickers/ModelReasoningPicker.test.tsx` — grouped headers, `role="group"` / `aria-labelledby`, raw-id tooltips, single-route lists stay flat, sticky offsets, unique-trigger shape, submenu + compact drawer grouping (65 tests across the two picker files).

Mutation-kills (reverted after): `hasMultipleRouteGroups` → `return false` fails the grouped-catalog test; `title` always `undefined` fails `getByTitle("zai/glm-5.3")`; `qualifyCollidingLabels` early `return new Map()` fails the within-provider qualifier test.

Commands (rebased onto `688eb42`, then `pnpm install --frozen-lockfile`): `pnpm exec turbo run typecheck lint test --filter=@bb/provider-bridge-acp --filter=@bb/app --filter=@bb/mobile` — **11/11 tasks green**. New code carries no comments, per the repo-wide `bb(no-comments)` rule.

Manual: Ladle `pickers--model-reasoning-picker--overview`, "open: acp grouped" — pretty headers (Cursor / Z.ai / CommandCode / Mistral), collision tails, full-id tooltips, `role=group`.

Fixes #2062

> AGENT GENERATED: by GLM-5.3 (Z.ai)
