### PR TITLE
Add sidebar Split lifecycle

### DIFF
--- a/apps/app/src/components/commands/CommandPalette.test.tsx
+++ b/apps/app/src/components/commands/CommandPalette.test.tsx
@@ -156,7 +156,13 @@ function Handler({ command }: { command: AppCommandId }) {
   return null;
 }
 
-function renderPalette(isCompactViewport = false) {
+function renderPalette({
+  isCompactViewport = false,
+  onSplit,
+}: {
+  isCompactViewport?: boolean;
+  onSplit?: () => void;
+} = {}) {
   const result = render(
     <MemoryRouter>
       <AppCommandProvider>
@@ -167,7 +173,7 @@ function renderPalette(isCompactViewport = false) {
         <Handler command="thread.next" />
         <Handler command="panel.toggle" />
         <Handler command="terminal.open" />
-        <CommandPalette threadId={null} projectId={null} />
+        <CommandPalette threadId={null} projectId={null} onSplit={onSplit} />
         <LocationProbe />
       </AppCommandProvider>
     </MemoryRouter>,
@@ -274,8 +280,24 @@ describe("CommandPalette", () => {
     expect(document.activeElement).toBe(screen.getByTestId("origin"));
   });
 
+  it("runs Split as an internal palette action without an app command", async () => {
+    const onSplit = vi.fn();
+    renderPalette({ onSplit });
+    openPalette();
+    await waitFor(() => expect(searchField()).toBeTruthy());
+
+    fireEvent.change(searchField(), { target: { value: ">split" } });
+    await waitFor(() =>
+      expect(selectedOption()?.textContent).toContain("Split"),
+    );
+    fireEvent.keyDown(searchField(), { key: "Enter" });
+
+    await waitFor(() => expect(onSplit).toHaveBeenCalledOnce());
+    expect(testState.calls).toEqual([]);
+  });
+
   it("runs a compact selection once after restoring focus", async () => {
-    renderPalette(true);
+    renderPalette({ isCompactViewport: true });
     openPalette();
     await waitFor(() => expect(searchField()).toBeTruthy());
 

--- a/apps/app/src/components/commands/CommandPalette.tsx
+++ b/apps/app/src/components/commands/CommandPalette.tsx
@@ -46,9 +46,14 @@ type PaletteMode = "commands" | "threads";
 export interface CommandPaletteProps {
   threadId: string | null;
   projectId: string | null;
+  onSplit?: () => void;
 }
 
-export function CommandPalette({ threadId, projectId }: CommandPaletteProps) {
+export function CommandPalette({
+  threadId,
+  projectId,
+  onSplit,
+}: CommandPaletteProps) {
   const navigate = useNavigate();
   const runner = useAppCommandRunner();
   const shortcuts = useAppCommandShortcuts(PALETTE_COMMAND_IDS);
@@ -76,6 +81,17 @@ export function CommandPalette({ threadId, projectId }: CommandPaletteProps) {
         dispatch: runner.dispatch,
         shortcuts,
       }),
+      ...(onSplit === undefined
+        ? []
+        : [
+            {
+              id: "internal:thread.split",
+              group: "Threads",
+              title: "Split",
+              shortcut: null,
+              run: onSplit,
+            } satisfies PaletteAction,
+          ]),
       ...buildPluginPaletteActions({
         slots: getPluginSlotSnapshot().commandPaletteActions,
         threadId,
@@ -85,6 +101,7 @@ export function CommandPalette({ threadId, projectId }: CommandPaletteProps) {
     ],
     [
       projectId,
+      onSplit,
       runner.dispatch,
       runner.isCommandAvailable,
       shortcuts,

--- a/apps/app/src/components/layout/AppLayout.root-compose-project.test.tsx
+++ b/apps/app/src/components/layout/AppLayout.root-compose-project.test.tsx
@@ -1,10 +1,21 @@
 // @vitest-environment jsdom
 
-import { act, cleanup, render, waitFor } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import type { ReactNode } from "react";
+import { createStore, Provider } from "jotai";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AppLayout } from "./AppLayout";
+import { splitLayoutAtom } from "@/lib/split-layout/atoms";
+import { listPanes } from "@/lib/split-layout";
+import { getPromptDraftAccessor } from "@/hooks/usePromptDraftStorage";
 
 const ROOT_COMPOSE_PROJECT_ID_STORAGE_KEY = "bb.root-compose.project-id";
 
@@ -13,8 +24,14 @@ const mockUseThreadDetailBootstrap = vi.hoisted(() => vi.fn());
 const commandHandlers = vi.hoisted(() => new Map<string, () => boolean>());
 
 vi.mock("@/components/commands/AppCommandProvider", () => ({
-  useAppCommandHandler: (command: string, handler: () => boolean) => {
-    commandHandlers.set(command, handler);
+  useAppCommandHandler: (
+    command: string,
+    handler: () => boolean,
+    _priority = 0,
+    enabled = true,
+  ) => {
+    if (enabled) commandHandlers.set(command, handler);
+    else commandHandlers.delete(command);
   },
   useAppCommandShortcut: () => null,
   useAppCommandShortcuts: () => new Map(),
@@ -26,7 +43,15 @@ vi.mock("@/components/commands/AppCommandProvider", () => ({
 }));
 
 vi.mock("@/components/sidebar/AppSidebar", () => ({
-  AppSidebar: () => <aside data-testid="app-sidebar" />,
+  AppSidebar: ({ onSplit }: { onSplit?: () => void }) => (
+    <aside data-testid="app-sidebar">
+      {onSplit ? (
+        <button type="button" onClick={onSplit}>
+          Split
+        </button>
+      ) : null}
+    </aside>
+  ),
 }));
 
 vi.mock("@/hooks/queries/system-queries", () => ({
@@ -231,5 +256,68 @@ describe("AppLayout root compose project preference", () => {
     expect(
       window.localStorage.getItem(ROOT_COMPOSE_PROJECT_ID_STORAGE_KEY),
     ).toBe("proj_last_run");
+  });
+
+  it("enters Split with two independently writable draft slots and left focus", async () => {
+    const store = createStore();
+
+    render(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={["/projects/proj_opened/threads/thr_opened"]}
+        >
+          <AppLayout>
+            <div>Thread route</div>
+          </AppLayout>
+        </MemoryRouter>
+      </Provider>,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "Split" }));
+    expect(commandHandlers.has("thread.split")).toBe(false);
+
+    const layout = store.get(splitLayoutAtom);
+    expect(layout).not.toBeNull();
+    const panes = listPanes(layout!.root);
+    expect(panes).toHaveLength(2);
+    expect(layout?.focusedPaneId).toBe(panes[0]?.paneId);
+    const leftContent = panes[0]?.content;
+    const rightContent = panes[1]?.content;
+    expect(leftContent?.kind).toBe("new-thread");
+    expect(rightContent?.kind).toBe("new-thread");
+    if (
+      leftContent?.kind !== "new-thread" ||
+      rightContent?.kind !== "new-thread"
+    ) {
+      throw new Error("Split did not create two New thread panes.");
+    }
+    expect(leftContent.draftSlotId).not.toBe(rightContent.draftSlotId);
+
+    const destination = { projectId: "proj_opened", sectionId: null };
+    const leftDraft = getPromptDraftAccessor({
+      kind: "new-thread",
+      slotId: leftContent.draftSlotId,
+      destination,
+    });
+    const rightDraft = getPromptDraftAccessor({
+      kind: "new-thread",
+      slotId: rightContent.draftSlotId,
+      destination,
+    });
+    act(() => {
+      leftDraft.setDraft({
+        text: "Left pane draft",
+        mentions: [],
+        attachments: [],
+      });
+      rightDraft.setDraft({
+        text: "Right pane draft",
+        mentions: [],
+        attachments: [],
+      });
+    });
+
+    expect(leftDraft.getCurrent().text).toBe("Left pane draft");
+    expect(rightDraft.getCurrent().text).toBe("Right pane draft");
   });
 });

--- a/apps/app/src/components/layout/AppLayout.tsx
+++ b/apps/app/src/components/layout/AppLayout.tsx
@@ -95,11 +95,13 @@ import {
   useMobileVisualViewportHeight,
 } from "./useMobileVisualViewportHeight";
 import { wsManager } from "@/lib/ws";
-import { splitLayoutAtom } from "@/lib/split-layout/atoms";
-import { findPaneByThread } from "@/lib/split-layout";
+import { maximizedPaneIdAtom, splitLayoutAtom } from "@/lib/split-layout/atoms";
+import { findPaneByThread, replaceWithTwoPaneLayout } from "@/lib/split-layout";
 import { applyThreadOpenToLayout } from "@/views/thread-detail/splitThreadNavigation";
 import { useAppSettingsRouteMemory } from "@/hooks/useAppSettingsRouteMemory";
 import { useSetRootComposeProjectId } from "@/lib/root-compose-selection";
+import { createNewThreadDraftSlotId } from "@/lib/prompt-draft-slots";
+import { withRootComposeDraftSlotId } from "@/lib/root-compose-location-state";
 
 const SIDEBAR_WIDTH_KEY = "bb.sidebar.width";
 const SIDEBAR_OPEN_KEY = "bb.sidebar.open";
@@ -450,6 +452,26 @@ export function AppLayout({ children }: AppLayoutProps) {
     });
     return true;
   });
+  const startTwoPaneCompose = useCallback(() => {
+    if (isCompactViewport) return;
+    if (projectId !== undefined) {
+      setRootComposeProjectId(projectId);
+    }
+    const leftDraftSlotId = createNewThreadDraftSlotId();
+    const rightDraftSlotId = createNewThreadDraftSlotId();
+    store.set(
+      splitLayoutAtom,
+      replaceWithTwoPaneLayout(
+        store.get(splitLayoutAtom),
+        { kind: "new-thread", draftSlotId: leftDraftSlotId },
+        { kind: "new-thread", draftSlotId: rightDraftSlotId },
+      ),
+    );
+    store.set(maximizedPaneIdAtom, null);
+    void navigate(getRootComposeRoutePath(), {
+      state: withRootComposeDraftSlotId(null, leftDraftSlotId),
+    });
+  }, [isCompactViewport, navigate, projectId, setRootComposeProjectId, store]);
   useAppCommandHandler("settings.open", () => {
     void navigate(settingsRoutePath);
     return true;
@@ -746,6 +768,7 @@ export function AppLayout({ children }: AppLayoutProps) {
               settingsRoutePath={settingsRoutePath}
               toolsBackRoutePath={toolsBackRoutePath}
               toolsRoutePath={toolsRoutePath}
+              onSplit={isCompactViewport ? undefined : startTwoPaneCompose}
             />
             <SidebarInset>
               <div
@@ -785,6 +808,7 @@ export function AppLayout({ children }: AppLayoutProps) {
           <CommandPalette
             threadId={threadId ?? null}
             projectId={projectId ?? null}
+            onSplit={isCompactViewport ? undefined : startTwoPaneCompose}
           />
           <ProjectPathDialog
             target={quickCreateProject.projectPathDialog.target}

--- a/apps/app/src/components/layout/AppLayoutSidebar.tsx
+++ b/apps/app/src/components/layout/AppLayoutSidebar.tsx
@@ -14,6 +14,7 @@ interface AppLayoutSidebarProps {
   settingsRoutePath: string;
   toolsBackRoutePath: string;
   toolsRoutePath?: string;
+  onSplit?: () => void;
 }
 
 export function AppLayoutSidebar({
@@ -24,6 +25,7 @@ export function AppLayoutSidebar({
   settingsRoutePath,
   toolsBackRoutePath,
   toolsRoutePath,
+  onSplit,
 }: AppLayoutSidebarProps) {
   const { isCompactViewport, isMobileSidebarClosing } = useSidebar();
   const holdCurrentMode = isCompactViewport && isMobileSidebarClosing;
@@ -42,6 +44,7 @@ export function AppLayoutSidebar({
           showTopReserve={true}
           settingsRoutePath={settingsRoutePath}
           toolsRoutePath={toolsRoutePath}
+          onSplit={onSplit}
           mobileHosted={{ hidden: renderedMode !== "app" }}
         />
         {renderedMode === "settings" ? (
@@ -95,6 +98,7 @@ export function AppLayoutSidebar({
       showTopReserve={true}
       settingsRoutePath={settingsRoutePath}
       toolsRoutePath={toolsRoutePath}
+      onSplit={onSplit}
     />
   );
 }

--- a/apps/app/src/components/sidebar/AppSidebar.tsx
+++ b/apps/app/src/components/sidebar/AppSidebar.tsx
@@ -121,6 +121,7 @@ interface AppSidebarProps {
   showTopReserve: boolean;
   settingsRoutePath: string;
   toolsRoutePath?: string;
+  onSplit?: () => void;
   mobileHosted?: { hidden: boolean };
 }
 
@@ -130,6 +131,7 @@ export function AppSidebar({
   showTopReserve,
   settingsRoutePath,
   toolsRoutePath,
+  onSplit,
   mobileHosted,
 }: AppSidebarProps) {
   const quickCreateProject = useQuickCreateProjectController();
@@ -309,6 +311,8 @@ export function AppSidebar({
                 splitEnabled
                 newThreadSplit={newThreadSplit}
                 onNewChat={handleNewChat}
+                onSplit={onSplit}
+                onSearchThreads={closeOnMobile}
               />
               {toolsRoutePath ? (
                 <ExtensionsNavSidebarItem

--- a/apps/app/src/components/sidebar/ProjectList.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.tsx
@@ -70,6 +70,11 @@ import {
   SidebarStickyStack,
 } from "@/components/ui/sidebar.js";
 import {
+  SIDEBAR_HOVER_ACTIONS_CLASS,
+  SIDEBAR_HOVER_ACTIONS_INSET_CLASS,
+  SIDEBAR_HOVER_ACTIONS_ROW_CLASS,
+} from "@/components/ui/sidebar-hover-actions";
+import {
   COARSE_POINTER_ICON_SIZE_CLASS,
   COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
   COARSE_POINTER_ROW_HEIGHT_CLASS,
@@ -181,6 +186,7 @@ interface ProjectListActionButtonsProps {
     openInSplit(): void;
   };
   onNewChat?: () => void;
+  onSplit?: () => void;
   onSearchThreads?: () => void;
 }
 
@@ -818,6 +824,7 @@ export function ProjectListActionButtons({
   splitEnabled = false,
   newThreadSplit,
   onNewChat,
+  onSplit,
   onSearchThreads,
 }: ProjectListActionButtonsProps) {
   const commandRunner = useAppCommandRunner();
@@ -829,39 +836,73 @@ export function ProjectListActionButtons({
   return (
     <div className="space-y-1">
       <div className="flex min-w-0 items-center gap-0.5">
-        <Button
-          type="button"
-          size="sm"
-          variant="ghost"
-          className={cn(PROJECT_LIST_ACTION_BUTTON_CLASS, "flex-1")}
-          onPointerDown={newThreadSplit?.onPointerDown}
-          onClick={(event) => {
-            if (event.metaKey || event.ctrlKey) {
-              newThreadSplit?.openInSplit();
-              return;
-            }
-            onNewChat?.();
-          }}
-          disabled={isNewChatDisabled}
-          aria-label={
-            newThreadShortcut
-              ? `New thread (${newThreadShortcut.label})`
-              : "New thread"
-          }
-          aria-keyshortcuts={newThreadShortcut?.ariaKeyshortcuts}
+        <div
+          className={cn(
+            "relative min-w-0 flex-1",
+            SIDEBAR_HOVER_ACTIONS_ROW_CLASS,
+          )}
         >
-          <Icon name="MessageSquarePlus" />
-          <span className="flex min-w-0 flex-1 items-center gap-1.5">
-            <span className="min-w-0 truncate text-left">New thread</span>
-            {newThreadSplitIndicator.miniMap ? (
-              <SplitPaneMiniMap
-                slots={newThreadSplitIndicator.miniMap}
-                label="New thread — open in split"
-              />
-            ) : null}
-            <AppCommandShortcutHint shortcut={newThreadShortcut} />
-          </span>
-        </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            className={cn(PROJECT_LIST_ACTION_BUTTON_CLASS, "w-full")}
+            onPointerDown={newThreadSplit?.onPointerDown}
+            onClick={(event) => {
+              if (event.metaKey || event.ctrlKey) {
+                newThreadSplit?.openInSplit();
+                return;
+              }
+              onNewChat?.();
+            }}
+            disabled={isNewChatDisabled}
+            aria-label={
+              newThreadShortcut
+                ? `New thread (${newThreadShortcut.label})`
+                : "New thread"
+            }
+            aria-keyshortcuts={newThreadShortcut?.ariaKeyshortcuts}
+          >
+            <Icon name="MessageSquarePlus" />
+            <span
+              className={cn(
+                "flex min-w-0 flex-1 items-center gap-1.5",
+                onSplit && SIDEBAR_HOVER_ACTIONS_INSET_CLASS,
+              )}
+            >
+              <span className="min-w-0 truncate text-left">New thread</span>
+              {newThreadSplitIndicator.miniMap ? (
+                <SplitPaneMiniMap
+                  slots={newThreadSplitIndicator.miniMap}
+                  label="New thread — open in split"
+                />
+              ) : null}
+              <AppCommandShortcutHint shortcut={newThreadShortcut} />
+            </span>
+          </Button>
+          {onSplit ? (
+            <div
+              className={cn(
+                SIDEBAR_HOVER_ACTIONS_CLASS,
+                "absolute inset-y-0 right-0 flex items-center",
+              )}
+            >
+              <Button
+                type="button"
+                size="icon"
+                variant="ghost"
+                aria-label="Split"
+                className={PROJECT_LIST_ACTION_ICON_BUTTON_CLASS}
+                onClick={onSplit}
+              >
+                <Icon
+                  name="Columns2"
+                  className={COARSE_POINTER_ICON_SIZE_CLASS}
+                />
+              </Button>
+            </div>
+          ) : null}
+        </div>
         <span className="flex shrink-0 items-center gap-1">
           <AppCommandShortcutHint shortcut={threadSearchShortcut} />
           <Button

--- a/apps/app/src/components/sidebar/SidebarLifecycleRows.test.tsx
+++ b/apps/app/src/components/sidebar/SidebarLifecycleRows.test.tsx
@@ -13,6 +13,7 @@ import {
 } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router-dom";
+import { createStore, Provider } from "jotai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { SidebarContent } from "@/components/ui/sidebar.js";
 import {
@@ -20,6 +21,8 @@ import {
   SidebarDraftRows,
   type SidebarDraftRowItem,
 } from "./SidebarLifecycleRows";
+import { splitLayoutAtom } from "@/lib/split-layout/atoms";
+import { listPanes } from "@/lib/split-layout";
 
 const threadActions = vi.hoisted(() => ({
   archiveThreadAndChildren: vi.fn(),
@@ -83,17 +86,22 @@ function createThread(
 
 function renderLifecycleRows(
   children: ReactNode,
-  { compact = false }: { compact?: boolean } = {},
+  {
+    compact = false,
+    store = createStore(),
+  }: { compact?: boolean; store?: ReturnType<typeof createStore> } = {},
 ) {
   const root = document.createElement("div");
   root.id = "root";
   document.body.appendChild(root);
   return render(
-    <CompactViewportOverrideProvider isCompactViewport={compact}>
-      <TooltipProvider>
-        <MemoryRouter>{children}</MemoryRouter>
-      </TooltipProvider>
-    </CompactViewportOverrideProvider>,
+    <Provider store={store}>
+      <CompactViewportOverrideProvider isCompactViewport={compact}>
+        <TooltipProvider>
+          <MemoryRouter>{children}</MemoryRouter>
+        </TooltipProvider>
+      </CompactViewportOverrideProvider>
+    </Provider>,
     { container: root },
   );
 }
@@ -143,7 +151,7 @@ describe("SidebarDraftRows", () => {
     expect(onOpenDraft).toHaveBeenCalledWith("older");
   });
 
-  it("offers Delete draft and no Archive from both the overflow and right-click menus", () => {
+  it("offers Delete draft and Open in split, but no Archive, from both menus", () => {
     const drafts = createDrafts();
     const { container } = renderLifecycleRows(
       <SidebarDraftRows drafts={drafts} onOpenDraft={vi.fn()} />,
@@ -155,6 +163,9 @@ describe("SidebarDraftRows", () => {
     const overflowDelete = screen.getByRole("menuitem", {
       name: "Delete draft",
     });
+    expect(
+      screen.getByRole("menuitem", { name: "Open in split" }),
+    ).not.toBeNull();
     expect(screen.queryByRole("menuitem", { name: /archive/iu })).toBeNull();
     fireEvent.click(overflowDelete);
     expect(drafts[0]?.delete).toHaveBeenCalledTimes(1);
@@ -168,7 +179,55 @@ describe("SidebarDraftRows", () => {
     expect(
       within(contextMenu).getByRole("menuitem", { name: "Delete draft" }),
     ).not.toBeNull();
+    expect(
+      within(contextMenu).getByRole("menuitem", { name: "Open in split" }),
+    ).not.toBeNull();
     expect(within(contextMenu).queryByText(/archive/iu)).toBeNull();
+  });
+
+  it("opens the selected draft slot in a split and omits the item when unavailable", () => {
+    const store = createStore();
+    store.set(splitLayoutAtom, {
+      focusedPaneId: "pane-thread",
+      root: {
+        type: "pane",
+        paneId: "pane-thread",
+        content: {
+          kind: "thread",
+          projectId: "proj_test",
+          threadId: "thr_test",
+        },
+      },
+    });
+    const drafts = createDrafts();
+    const wide = renderLifecycleRows(
+      <SidebarDraftRows drafts={drafts} onOpenDraft={vi.fn()} />,
+      { store },
+    );
+
+    fireEvent.pointerDown(
+      screen.getAllByRole("button", { name: "Draft actions" })[0],
+    );
+    fireEvent.click(screen.getByRole("menuitem", { name: "Open in split" }));
+
+    const panes = listPanes(store.get(splitLayoutAtom)!.root);
+    expect(panes).toHaveLength(2);
+    expect(panes[1]?.content).toEqual({
+      kind: "new-thread",
+      draftSlotId: "newest",
+    });
+
+    wide.unmount();
+    renderLifecycleRows(
+      <SidebarDraftRows drafts={drafts} onOpenDraft={vi.fn()} />,
+      { compact: true },
+    );
+    fireEvent.pointerDown(
+      screen.getAllByRole("button", { name: "Draft actions" })[0],
+    );
+    expect(
+      screen.queryByRole("menuitem", { name: "Open in split" }),
+    ).toBeNull();
   });
 
   it("uses the persistent compact drawer for a touch long-press", () => {

--- a/apps/app/src/components/sidebar/SidebarLifecycleRows.tsx
+++ b/apps/app/src/components/sidebar/SidebarLifecycleRows.tsx
@@ -39,6 +39,7 @@ import {
 } from "@/components/ui/sidebar-hover-actions.js";
 import { getThreadDisplayTitle } from "@/lib/thread-title";
 import { getThreadRoutePath } from "@/lib/route-paths";
+import { useSplitWorkspaceActive } from "@/hooks/useSplitWorkspaceActive";
 import {
   SIDEBAR_MORE_ACTION_TRIGGER_CLASS,
   SIDEBAR_ROW_BASE_CLASS,
@@ -48,6 +49,7 @@ import {
 } from "./sidebarRowClasses";
 import { SidebarWindowedItems } from "./SidebarWindowedItems";
 import { TopLevelSidebarSection } from "./TopLevelSidebarSection";
+import { usePaneContentSplitDrag } from "./usePaneContentSplitDrag";
 
 export interface SidebarDraftRowItem {
   id: string;
@@ -62,14 +64,16 @@ interface SidebarDraftRowsProps {
 
 type DraftActionsMenuSurface = "context" | "dropdown";
 
-function DraftActionsMenuItem({
+function DraftActionsMenuItems({
   onDelete,
+  onOpenInSplit,
   surface,
 }: {
   onDelete: () => void;
+  onOpenInSplit?: () => void;
   surface: DraftActionsMenuSurface;
 }) {
-  const content = (
+  const deleteContent = (
     <>
       <Icon name="Trash2" aria-hidden="true" />
       Delete draft
@@ -78,27 +82,45 @@ function DraftActionsMenuItem({
 
   if (surface === "context") {
     return (
-      <ContextMenuItem
-        className="text-destructive focus:bg-destructive/15 focus:text-destructive data-[last-hovered]:bg-destructive/15 data-[last-hovered]:text-destructive"
-        onSelect={onDelete}
-      >
-        {content}
-      </ContextMenuItem>
+      <>
+        {onOpenInSplit ? (
+          <ContextMenuItem onSelect={onOpenInSplit}>
+            <Icon name="Columns2" aria-hidden="true" />
+            Open in split
+          </ContextMenuItem>
+        ) : null}
+        <ContextMenuItem
+          className="text-destructive focus:bg-destructive/15 focus:text-destructive data-[last-hovered]:bg-destructive/15 data-[last-hovered]:text-destructive"
+          onSelect={onDelete}
+        >
+          {deleteContent}
+        </ContextMenuItem>
+      </>
     );
   }
 
   return (
-    <DropdownMenuItem variant="destructive" onSelect={onDelete}>
-      {content}
-    </DropdownMenuItem>
+    <>
+      {onOpenInSplit ? (
+        <DropdownMenuItem onSelect={onOpenInSplit}>
+          <Icon name="Columns2" aria-hidden="true" />
+          Open in split
+        </DropdownMenuItem>
+      ) : null}
+      <DropdownMenuItem variant="destructive" onSelect={onDelete}>
+        {deleteContent}
+      </DropdownMenuItem>
+    </>
   );
 }
 
 function DraftActionsMenu({
   onDelete,
+  onOpenInSplit,
   onOpenChange,
 }: {
   onDelete: () => void;
+  onOpenInSplit?: () => void;
   onOpenChange: (open: boolean) => void;
 }) {
   return (
@@ -125,7 +147,11 @@ function DraftActionsMenu({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
-        <DraftActionsMenuItem surface="dropdown" onDelete={onDelete} />
+        <DraftActionsMenuItems
+          surface="dropdown"
+          onDelete={onDelete}
+          onOpenInSplit={onOpenInSplit}
+        />
       </DropdownMenuContent>
     </DropdownMenu>
   );
@@ -134,10 +160,12 @@ function DraftActionsMenu({
 function DraftActionsContextMenu({
   children,
   onDelete,
+  onOpenInSplit,
   onOpenChange,
 }: {
   children: ReactNode;
   onDelete: () => void;
+  onOpenInSplit?: () => void;
   onOpenChange: (open: boolean) => void;
 }) {
   const isCompactViewport = useIsCompactViewport();
@@ -147,7 +175,13 @@ function DraftActionsContextMenu({
       <CompactLongPressMenu
         label="Draft actions"
         onOpenChange={onOpenChange}
-        items={<DraftActionsMenuItem surface="dropdown" onDelete={onDelete} />}
+        items={
+          <DraftActionsMenuItems
+            surface="dropdown"
+            onDelete={onDelete}
+            onOpenInSplit={onOpenInSplit}
+          />
+        }
       >
         {children}
       </CompactLongPressMenu>
@@ -158,7 +192,11 @@ function DraftActionsContextMenu({
     <ContextMenu onOpenChange={onOpenChange}>
       <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
       <ContextMenuContent aria-label="Draft actions">
-        <DraftActionsMenuItem surface="context" onDelete={onDelete} />
+        <DraftActionsMenuItems
+          surface="context"
+          onDelete={onDelete}
+          onOpenInSplit={onOpenInSplit}
+        />
       </ContextMenuContent>
     </ContextMenu>
   );
@@ -167,13 +205,20 @@ function DraftActionsContextMenu({
 function SidebarDraftRow({
   draft,
   onOpenDraft,
+  splitEnabled,
 }: {
   draft: SidebarDraftRowItem;
   onOpenDraft: (draftId: string) => void;
+  splitEnabled: boolean;
 }) {
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [contextOpen, setContextOpen] = useState(false);
   const actionsOpen = dropdownOpen || contextOpen;
+  const draftSplit = usePaneContentSplitDrag({
+    content: { kind: "new-thread", draftSlotId: draft.id },
+    enabled: splitEnabled,
+    label: draft.title,
+  });
 
   const row = (
     <div
@@ -220,6 +265,7 @@ function SidebarDraftRow({
       >
         <DraftActionsMenu
           onDelete={draft.delete}
+          onOpenInSplit={splitEnabled ? draftSplit.openInSplit : undefined}
           onOpenChange={setDropdownOpen}
         />
       </span>
@@ -229,6 +275,7 @@ function SidebarDraftRow({
   return (
     <DraftActionsContextMenu
       onDelete={draft.delete}
+      onOpenInSplit={splitEnabled ? draftSplit.openInSplit : undefined}
       onOpenChange={setContextOpen}
     >
       {row}
@@ -240,6 +287,7 @@ export function SidebarDraftRows({
   drafts,
   onOpenDraft,
 }: SidebarDraftRowsProps) {
+  const splitEnabled = useSplitWorkspaceActive();
   if (drafts.length === 0) {
     return null;
   }
@@ -251,6 +299,7 @@ export function SidebarDraftRows({
           key={draft.id}
           draft={draft}
           onOpenDraft={onOpenDraft}
+          splitEnabled={splitEnabled}
         />
       ))}
     </div>

--- a/apps/app/src/hooks/useNewThreadDraftLeaveToast.test.ts
+++ b/apps/app/src/hooks/useNewThreadDraftLeaveToast.test.ts
@@ -36,7 +36,6 @@ describe("new-thread draft leave toast", () => {
       () =>
         useNewThreadDraftLeaveToast({
           getCurrentDraft: () => draft,
-          isSplitPane: false,
         }),
       { wrapper: StrictModeWrapper },
     );
@@ -56,32 +55,60 @@ describe("new-thread draft leave toast", () => {
       shouldAnnounceNewThreadDraftLeave({
         draft,
         draftRowsVisible: false,
-        isSplitPane: false,
       }),
     ).toBe(true);
     expect(
       shouldAnnounceNewThreadDraftLeave({
         draft,
         draftRowsVisible: true,
-        isSplitPane: false,
       }),
     ).toBe(false);
   });
 
-  it("does not announce empty or split-pane drafts in Phase 2", () => {
+  it("does not announce empty drafts", () => {
     expect(
       shouldAnnounceNewThreadDraftLeave({
         draft: EMPTY_DRAFT,
         draftRowsVisible: false,
-        isSplitPane: false,
       }),
     ).toBe(false);
+  });
+
+  it("announces split-pane drafts when their built-in row is hidden", () => {
     expect(
       shouldAnnounceNewThreadDraftLeave({
         draft: { ...EMPTY_DRAFT, text: "Split work" },
         draftRowsVisible: false,
-        isSplitPane: true,
       }),
-    ).toBe(false);
+    ).toBe(true);
+  });
+
+  it("coalesces composers removed by the same leave event into one toast", async () => {
+    const leftDraft = { ...EMPTY_DRAFT, text: "Left work" };
+    const rightDraft = { ...EMPTY_DRAFT, text: "Right work" };
+    const left = renderHook(
+      () =>
+        useNewThreadDraftLeaveToast({
+          getCurrentDraft: () => leftDraft,
+        }),
+      { wrapper: StrictModeWrapper },
+    );
+    const right = renderHook(
+      () =>
+        useNewThreadDraftLeaveToast({
+          getCurrentDraft: () => rightDraft,
+        }),
+      { wrapper: StrictModeWrapper },
+    );
+
+    await act(async () => {
+      left.unmount();
+      right.unmount();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockToastMessage).toHaveBeenCalledTimes(1);
+    expect(mockToastMessage).toHaveBeenCalledWith("Saved to Drafts");
   });
 });

--- a/apps/app/src/hooks/useNewThreadDraftLeaveToast.ts
+++ b/apps/app/src/hooks/useNewThreadDraftLeaveToast.ts
@@ -7,31 +7,36 @@ import { builtInSidebarDraftRowsVisibleAtom } from "@/components/sidebar/sidebar
 export function shouldAnnounceNewThreadDraftLeave({
   draft,
   draftRowsVisible,
-  isSplitPane,
 }: {
   draft: PromptDraftState;
   draftRowsVisible: boolean;
-  isSplitPane: boolean;
 }): boolean {
-  return !isSplitPane && !draftRowsVisible && !isPromptDraftEmpty(draft);
+  return !draftRowsVisible && !isPromptDraftEmpty(draft);
+}
+
+let savedDraftToastScheduled = false;
+
+function scheduleSavedDraftToast(): void {
+  if (savedDraftToastScheduled) return;
+  savedDraftToastScheduled = true;
+  queueMicrotask(() => {
+    savedDraftToastScheduled = false;
+    appToast.message("Saved to Drafts");
+  });
 }
 
 export function useNewThreadDraftLeaveToast({
   getCurrentDraft,
-  isSplitPane,
 }: {
   getCurrentDraft: () => PromptDraftState;
-  isSplitPane: boolean;
 }): void {
   const draftRowsVisible = useAtomValue(builtInSidebarDraftRowsVisibleAtom);
   const draftRowsVisibleRef = useRef(draftRowsVisible);
   const getCurrentDraftRef = useRef(getCurrentDraft);
-  const isSplitPaneRef = useRef(isSplitPane);
   const mountedRef = useRef(false);
 
   draftRowsVisibleRef.current = draftRowsVisible;
   getCurrentDraftRef.current = getCurrentDraft;
-  isSplitPaneRef.current = isSplitPane;
 
   useEffect(() => {
     mountedRef.current = true;
@@ -40,13 +45,12 @@ export function useNewThreadDraftLeaveToast({
       const shouldAnnounce = shouldAnnounceNewThreadDraftLeave({
         draft: getCurrentDraftRef.current(),
         draftRowsVisible: draftRowsVisibleRef.current,
-        isSplitPane: isSplitPaneRef.current,
       });
       if (!shouldAnnounce) return;
 
       queueMicrotask(() => {
         if (!mountedRef.current) {
-          appToast.message("Saved to Drafts");
+          scheduleSavedDraftToast();
         }
       });
     };

--- a/apps/app/src/lib/command-palette/palette-app-commands.test.ts
+++ b/apps/app/src/lib/command-palette/palette-app-commands.test.ts
@@ -76,11 +76,6 @@ describe("buildAppCommandActions", () => {
     });
   });
 
-  it("leaves the shortcut null for a command the user has not bound", () => {
-    const { actions } = build(["thread.rename"]);
-    expect(actions[0]?.shortcut).toBeNull();
-  });
-
   it("dispatches with the element that was focused before the palette opened", () => {
     const target = { id: "composer" } as unknown as EventTarget;
     const dispatch = vi.fn();

--- a/apps/app/src/lib/split-layout/ops.test.ts
+++ b/apps/app/src/lib/split-layout/ops.test.ts
@@ -10,6 +10,7 @@ import {
   normalize,
   removePane,
   replacePaneContent,
+  replaceWithTwoPaneLayout,
   resizeSplit,
   setFocus,
   splitPane,
@@ -68,6 +69,67 @@ function expectNormalizedSizes(layout: SplitLayout): void {
 }
 
 describe("split layout operations", () => {
+  it("creates two equal new-thread panes and focuses the left pane", () => {
+    const leftContent = newThreadContent("left-draft");
+    const rightContent = newThreadContent("right-draft");
+
+    const layout = replaceWithTwoPaneLayout(
+      null,
+      leftContent,
+      rightContent,
+    );
+
+    expect(layout).toEqual({
+      root: {
+        type: "split",
+        dir: "row",
+        sizes: [0.5, 0.5],
+        children: [
+          { type: "pane", paneId: "pane-1", content: leftContent },
+          { type: "pane", paneId: "pane-2", content: rightContent },
+        ],
+      },
+      focusedPaneId: "pane-1",
+    });
+  });
+
+  it.each([1, 2, MAX_PANES])(
+    "replaces a %i-pane workspace without retaining old panes or content",
+    (paneCount) => {
+      const current = layoutAtPaneCount(paneCount);
+      const previousPanes = listPanes(current.root);
+      const previousPaneIds = new Set(previousPanes.map((item) => item.paneId));
+      const leftContent = newThreadContent(`left-draft-${paneCount}`);
+      const rightContent = newThreadContent(`right-draft-${paneCount}`);
+
+      const replacement = replaceWithTwoPaneLayout(
+        current,
+        leftContent,
+        rightContent,
+      );
+      const replacementPanes = listPanes(replacement.root);
+
+      expect(countPanes(replacement.root)).toBe(2);
+      expect(replacement.root).toMatchObject({
+        type: "split",
+        dir: "row",
+        sizes: [0.5, 0.5],
+      });
+      expect(replacementPanes[0]?.content).toBe(leftContent);
+      expect(replacementPanes[1]?.content).toBe(rightContent);
+      expect(replacement.focusedPaneId).toBe(replacementPanes[0]?.paneId);
+      expect(
+        replacementPanes.every(
+          (item) => !previousPaneIds.has(item.paneId),
+        ),
+      ).toBe(true);
+      expect(
+        replacementPanes.some((item) => previousPanes.includes(item)),
+      ).toBe(false);
+      expect(countPanes(current.root)).toBe(paneCount);
+    },
+  );
+
   it("keeps independent new-thread slots distinct and finds the exact binding", () => {
     const withFirstDraft = splitPane(
       singlePaneLayout(),

--- a/apps/app/src/lib/split-layout/ops.ts
+++ b/apps/app/src/lib/split-layout/ops.ts
@@ -112,13 +112,41 @@ function replacePaneNode(
   };
 }
 
-function nextPaneId(root: LayoutNode): string {
-  const existingIds = new Set(listPanes(root).map((pane) => pane.paneId));
+function nextPaneId(
+  root: LayoutNode | null,
+  reservedIds: readonly string[] = [],
+): string {
+  const existingIds = new Set([
+    ...(root === null ? [] : listPanes(root).map((pane) => pane.paneId)),
+    ...reservedIds,
+  ]);
   let sequence = 1;
   while (existingIds.has(`pane-${sequence}`)) {
     sequence += 1;
   }
   return `pane-${sequence}`;
+}
+
+export function replaceWithTwoPaneLayout(
+  layout: SplitLayout | null,
+  leftContent: PaneContent,
+  rightContent: PaneContent,
+): SplitLayout {
+  const previousRoot = layout?.root ?? null;
+  const leftPaneId = nextPaneId(previousRoot);
+  const rightPaneId = nextPaneId(previousRoot, [leftPaneId]);
+  return {
+    root: {
+      type: "split",
+      dir: "row",
+      sizes: [0.5, 0.5],
+      children: [
+        { type: "pane", paneId: leftPaneId, content: leftContent },
+        { type: "pane", paneId: rightPaneId, content: rightContent },
+      ],
+    },
+    focusedPaneId: leftPaneId,
+  };
 }
 
 function splitDirection(side: SplitSide): SplitNode["dir"] {

--- a/apps/app/src/views/RootComposeView.test.ts
+++ b/apps/app/src/views/RootComposeView.test.ts
@@ -27,6 +27,7 @@ import {
   buildRootComposeTerminalSessions,
   buildMobileRecentThreads,
   canCreateRootComposeTerminal,
+  finishRootComposeThreadCreate,
   hasSingleUseRootComposeTargetState,
   readSectionIdFromLocationState,
   readRootComposeSectionTargetFromLocationState,
@@ -38,6 +39,7 @@ import {
   shouldNavigateAfterThreadCreate,
 } from "./RootComposeView";
 import { withRootComposeDraftSlotId } from "@/lib/root-compose-location-state";
+import { getThreadRoutePath } from "@/lib/route-paths";
 import { resolveRootComposeProjectFileRouting } from "./RootComposePanelTabContent";
 import {
   resolveProjectSourceWorktreeDisabledReason,
@@ -868,6 +870,80 @@ describe("shouldNavigateAfterThreadCreate", () => {
       }),
     ).toBe(true);
   });
+});
+
+describe("finishRootComposeThreadCreate", () => {
+  const thread = { projectId: "proj_created", threadId: "thr_created" };
+
+  it("uses page navigation for the standalone composer", () => {
+    const navigatedPaths: string[] = [];
+
+    finishRootComposeThreadCreate({
+      navigate: (path) => navigatedPaths.push(path),
+      paneContext: {
+        paneId: "main",
+        navigateInPane: () => {
+          throw new Error("Standalone composer must not use pane navigation");
+        },
+      },
+      shouldNavigateToCreatedThread: true,
+      thread,
+    });
+
+    expect(navigatedPaths).toEqual([getThreadRoutePath(thread)]);
+  });
+
+  it.each(["pane-left", "pane-right"])(
+    "replaces only the submitted workspace pane when navigation is on (%s)",
+    (paneId) => {
+      const navigatedPaths: string[] = [];
+      const paneThreads: typeof thread[] = [];
+      let resetCount = 0;
+
+      finishRootComposeThreadCreate({
+        navigate: (path) => navigatedPaths.push(path),
+        paneContext: {
+          paneId,
+          navigateInPane: (nextThread) => paneThreads.push(nextThread),
+          resetNewThreadPane: () => {
+            resetCount += 1;
+          },
+        },
+        shouldNavigateToCreatedThread: true,
+        thread,
+      });
+
+      expect(paneThreads).toEqual([thread]);
+      expect(navigatedPaths).toEqual([]);
+      expect(resetCount).toBe(0);
+    },
+  );
+
+  it.each(["pane-left", "pane-right"])(
+    "refreshes only the submitted workspace pane when navigation is off (%s)",
+    (paneId) => {
+      let resetCount = 0;
+
+      finishRootComposeThreadCreate({
+        navigate: () => {
+          throw new Error("Workspace pane must not use page navigation");
+        },
+        paneContext: {
+          paneId,
+          navigateInPane: () => {
+            throw new Error("Navigation is disabled");
+          },
+          resetNewThreadPane: () => {
+            resetCount += 1;
+          },
+        },
+        shouldNavigateToCreatedThread: false,
+        thread,
+      });
+
+      expect(resetCount).toBe(1);
+    },
+  );
 });
 
 describe("resolveProjectSourceWorktreeDisabledReason", () => {

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -94,6 +94,7 @@ import {
   getProjectComposeRoutePath,
   getRootComposeRoutePath,
   isRoutePath,
+  type ThreadRoutePathArgs,
 } from "@/lib/route-paths";
 import { getBrowserUrlHost } from "@/lib/browser-url";
 import {
@@ -178,7 +179,10 @@ import {
   useAppCommandHandler,
   useAppCommandShortcut,
 } from "@/components/commands/AppCommandProvider";
-import { useOptionalPaneContext } from "./thread-detail/PaneContext";
+import {
+  useOptionalPaneContext,
+  type PaneContextValue,
+} from "./thread-detail/PaneContext";
 import { useNewThreadDraftLeaveToast } from "@/hooks/useNewThreadDraftLeaveToast";
 import { RootComposePanelCommandHandlers } from "./RootComposePanelCommandHandlers";
 import {
@@ -335,6 +339,39 @@ export function shouldNavigateAfterThreadCreate({
   navigateToThreadAfterCreate,
 }: ShouldNavigateAfterThreadCreateArgs): boolean {
   return isForkDraft || navigateToThreadAfterCreate;
+}
+
+interface FinishRootComposeThreadCreateArgs {
+  navigate: (path: string) => void;
+  paneContext: Pick<
+    PaneContextValue,
+    "navigateInPane" | "paneId" | "resetNewThreadPane"
+  > | null;
+  shouldNavigateToCreatedThread: boolean;
+  thread: ThreadRoutePathArgs;
+}
+
+export function finishRootComposeThreadCreate({
+  navigate,
+  paneContext,
+  shouldNavigateToCreatedThread,
+  thread,
+}: FinishRootComposeThreadCreateArgs): void {
+  const isWorkspacePane =
+    paneContext !== null && paneContext.paneId !== "main";
+
+  if (shouldNavigateToCreatedThread) {
+    if (isWorkspacePane) {
+      paneContext.navigateInPane(thread);
+    } else {
+      navigate(getThreadRoutePath(thread));
+    }
+    return;
+  }
+
+  if (isWorkspacePane) {
+    paneContext.resetNewThreadPane?.();
+  }
 }
 
 function readForkThreadCreateSeedFromLocationState(
@@ -603,14 +640,15 @@ function RootComposeSlotView({ draftSlotId }: RootComposeViewProps) {
       setLastCreatedThreadId(thread.id);
       setForkSeed(null);
       setRootComposeSectionId(null);
-      if (shouldNavigateToCreatedThread) {
-        navigate(
-          getThreadRoutePath({
-            projectId: thread.projectId,
-            threadId: thread.id,
-          }),
-        );
-      }
+      finishRootComposeThreadCreate({
+        navigate,
+        paneContext,
+        shouldNavigateToCreatedThread,
+        thread: {
+          projectId: thread.projectId,
+          threadId: thread.id,
+        },
+      });
     },
     [
       createThread,
@@ -618,6 +656,7 @@ function RootComposeSlotView({ draftSlotId }: RootComposeViewProps) {
       queryClient,
       navigate,
       navigateToThreadAfterCreate,
+      paneContext,
       rootComposeSectionId,
     ],
   );
@@ -737,7 +776,6 @@ function RootComposeSurface({
   } = composer;
   useNewThreadDraftLeaveToast({
     getCurrentDraft: promptDraft.getCurrent,
-    isSplitPane: paneContext?.isSplitPane === true,
   });
   const rootPanelEnvironmentId =
     parsedEnvironment?.type === "reuse"
@@ -890,12 +928,18 @@ function RootComposeSurface({
     "focusPrompt" in location.state &&
     location.state.focusPrompt === true;
   useEffect(() => {
-    if (!shouldFocusPrompt || isPointerCoarse) return;
+    if (!shouldFocusPrompt || !isFocusedPane || isPointerCoarse) return;
     const handle = window.requestAnimationFrame(() => {
       promptBoxRef.current?.focusEnd();
     });
     return () => window.cancelAnimationFrame(handle);
-  }, [isPointerCoarse, location.key, promptBoxRef, shouldFocusPrompt]);
+  }, [
+    isFocusedPane,
+    isPointerCoarse,
+    location.key,
+    promptBoxRef,
+    shouldFocusPrompt,
+  ]);
 
   const mobileRecentThreads = useMemo(
     () => buildMobileRecentThreads({ sidebarNavigation }),
@@ -1983,7 +2027,7 @@ function RootComposeSurface({
 
   const promptBox = renderPromptBox({
     id: "root-compose-prompt",
-    autoFocus: !isProviderCliVersionBlocked,
+    autoFocus: isFocusedPane && !isProviderCliVersionBlocked,
     banner: promptBanner,
     header: promptHeader,
     blockedReason: isProviderCliVersionBlocked

--- a/apps/app/src/views/thread-detail/PaneContext.tsx
+++ b/apps/app/src/views/thread-detail/PaneContext.tsx
@@ -30,6 +30,7 @@ export interface PaneContextValue {
   isTopRow: boolean;
   ownsWindowTopLeft: boolean;
   navigateInPane: (thread: ThreadRoutePathArgs) => void;
+  resetNewThreadPane?: () => void;
   beginPaneDrag?: (event: ReactPointerEvent, label: string) => void;
 }
 

--- a/apps/app/src/views/thread-detail/SplitThreadArea.test.tsx
+++ b/apps/app/src/views/thread-detail/SplitThreadArea.test.tsx
@@ -36,6 +36,7 @@ import { usePromptDraftStorage } from "@/hooks/usePromptDraftStorage";
 import { createBbDesktopApi } from "@/test/bb-desktop-test-utils";
 import { resourceRouteLabelAtom } from "@/components/layout/resourceRouteLabelAtom";
 import { readRootComposeDraftSlotId } from "@/lib/root-compose-location-state";
+import { readNewThreadDraftSlots } from "@/lib/prompt-draft-slots";
 import {
   resetPluginSlotStoreForTest,
   setPluginSlotRegistrations,
@@ -91,6 +92,11 @@ function HostedComposerScopeProbe({ threadId }: { threadId: string }) {
 function RootComposeFixture({ draftSlotId }: { draftSlotId: string }) {
   const pane = useContext(PaneContext);
   const [isPanelOpen, setIsPanelOpen] = useState(false);
+  const draft = usePromptDraftStorage({
+    kind: "new-thread",
+    slotId: draftSlotId,
+    destination: { projectId: PERSONAL_PROJECT_ID, sectionId: null },
+  });
   const panelModel = useMemo(
     () => ({
       composerHost: null,
@@ -108,7 +114,61 @@ function RootComposeFixture({ draftSlotId }: { draftSlotId: string }) {
     panelModel,
   );
   return (
-    <div data-testid="root-compose-view" data-draft-slot-id={draftSlotId} />
+    <div
+      data-testid="root-compose-view"
+      data-draft-slot-id={draftSlotId}
+      data-focused={pane?.isFocused ? "true" : "false"}
+    >
+      <textarea
+        aria-label={`Draft ${draftSlotId}`}
+        value={draft.text}
+        onChange={(event) =>
+          draft.setDraft({
+            ...draft.getCurrent(),
+            text: event.target.value,
+          })
+        }
+      />
+      <button
+        type="button"
+        data-testid={`add-attachment-${draftSlotId}`}
+        onClick={() =>
+          draft.setAttachments([
+            {
+              name: "plan.md",
+              path: `/tmp/${draftSlotId}-plan.md`,
+              sizeBytes: 12,
+              type: "localFile",
+            },
+          ])
+        }
+      >
+        add attachment
+      </button>
+      <button
+        type="button"
+        data-testid={`navigate-compose-${draftSlotId}`}
+        onClick={() => {
+          draft.clear();
+          pane?.navigateInPane({
+            projectId: PERSONAL_PROJECT_ID,
+            threadId: `created-${draftSlotId}`,
+          });
+        }}
+      >
+        navigate after send
+      </button>
+      <button
+        type="button"
+        data-testid={`reset-compose-${draftSlotId}`}
+        onClick={() => {
+          draft.clear();
+          pane?.resetNewThreadPane?.();
+        }}
+      >
+        reset after send
+      </button>
+    </div>
   );
 }
 
@@ -437,6 +497,29 @@ function newThreadContentFor(draftSlotId: string): PaneContent {
 }
 
 const newThreadContent = newThreadContentFor("draft-slot-default");
+
+function twoPaneComposeLayout(focusedPaneId: string): SplitLayout {
+  return {
+    root: {
+      type: "split",
+      dir: "row",
+      sizes: [0.5, 0.5],
+      children: [
+        {
+          type: "pane",
+          paneId: "pane-left",
+          content: newThreadContentFor("draft-slot-left"),
+        },
+        {
+          type: "pane",
+          paneId: "pane-right",
+          content: newThreadContentFor("draft-slot-right"),
+        },
+      ],
+    },
+    focusedPaneId,
+  };
+}
 
 function pluginContent(panelPath: string): PaneContent {
   return {
@@ -1502,6 +1585,243 @@ describe("SplitThreadArea", () => {
     expect(screen.getByTestId("root-compose-view").dataset.draftSlotId).toBe(
       "draft-slot-right",
     );
+  });
+
+  it.each([
+    {
+      label: "left",
+      paneId: "pane-left",
+      slotId: "draft-slot-left",
+      siblingPaneId: "pane-right",
+      siblingSlotId: "draft-slot-right",
+    },
+    {
+      label: "right",
+      paneId: "pane-right",
+      slotId: "draft-slot-right",
+      siblingPaneId: "pane-left",
+      siblingSlotId: "draft-slot-left",
+    },
+  ])(
+    "replaces the $label composer in place after send when navigation is on",
+    async ({ paneId, slotId, siblingPaneId, siblingSlotId }) => {
+      const store = renderSplitArea({
+        path: "/",
+        layout: twoPaneComposeLayout(paneId),
+        routeContent: newThreadContentFor(slotId),
+      });
+      fireEvent.change(screen.getByRole("textbox", { name: `Draft ${slotId}` }), {
+        target: { value: "Submitted work" },
+      });
+      fireEvent.change(
+        screen.getByRole("textbox", { name: `Draft ${siblingSlotId}` }),
+        { target: { value: "Untouched sibling" } },
+      );
+
+      fireEvent.click(screen.getByTestId(`navigate-compose-${slotId}`));
+
+      await waitFor(() => {
+        const layout = store.get(splitLayoutAtom);
+        const panes = layout === null ? [] : listPanes(layout.root);
+        expect(panes.find((pane) => pane.paneId === paneId)?.content).toEqual({
+          kind: "thread",
+          projectId: PERSONAL_PROJECT_ID,
+          threadId: `created-${slotId}`,
+        });
+        expect(
+          panes.find((pane) => pane.paneId === siblingPaneId)?.content,
+        ).toEqual(newThreadContentFor(siblingSlotId));
+        expect(layout?.focusedPaneId).toBe(paneId);
+      });
+      expect(
+        (
+          screen.getByRole("textbox", {
+            name: `Draft ${siblingSlotId}`,
+          }) as HTMLTextAreaElement
+        ).value,
+      ).toBe("Untouched sibling");
+      expect(readNewThreadDraftSlots().map((slot) => slot.id)).not.toContain(
+        slotId,
+      );
+    },
+  );
+
+  it.each([
+    {
+      label: "left",
+      paneId: "pane-left",
+      slotId: "draft-slot-left",
+      siblingPaneId: "pane-right",
+      siblingSlotId: "draft-slot-right",
+    },
+    {
+      label: "right",
+      paneId: "pane-right",
+      slotId: "draft-slot-right",
+      siblingPaneId: "pane-left",
+      siblingSlotId: "draft-slot-left",
+    },
+  ])(
+    "refreshes the $label composer with a fresh slot when navigation is off",
+    async ({ paneId, slotId, siblingPaneId, siblingSlotId }) => {
+      const store = renderSplitArea({
+        path: "/",
+        layout: twoPaneComposeLayout(paneId),
+        routeContent: newThreadContentFor(slotId),
+      });
+      fireEvent.change(screen.getByRole("textbox", { name: `Draft ${slotId}` }), {
+        target: { value: "Submitted work" },
+      });
+      fireEvent.change(
+        screen.getByRole("textbox", { name: `Draft ${siblingSlotId}` }),
+        { target: { value: "Untouched sibling" } },
+      );
+
+      fireEvent.click(screen.getByTestId(`reset-compose-${slotId}`));
+
+      let freshSlotId: string | null = null;
+      await waitFor(() => {
+        const layout = store.get(splitLayoutAtom);
+        const panes = layout === null ? [] : listPanes(layout.root);
+        const targetContent = panes.find(
+          (pane) => pane.paneId === paneId,
+        )?.content;
+        expect(targetContent?.kind).toBe("new-thread");
+        if (targetContent?.kind === "new-thread") {
+          freshSlotId = targetContent.draftSlotId;
+          expect(freshSlotId).not.toBe(slotId);
+        }
+        expect(
+          panes.find((pane) => pane.paneId === siblingPaneId)?.content,
+        ).toEqual(newThreadContentFor(siblingSlotId));
+        expect(layout?.focusedPaneId).toBe(paneId);
+      });
+      expect(freshSlotId).not.toBeNull();
+      expect(screen.getByTestId("location").dataset.draftSlotId).toBe(
+        freshSlotId ?? undefined,
+      );
+      expect(
+        (
+          screen.getByRole("textbox", {
+            name: `Draft ${siblingSlotId}`,
+          }) as HTMLTextAreaElement
+        ).value,
+      ).toBe("Untouched sibling");
+      expect(readNewThreadDraftSlots().map((slot) => slot.id)).not.toContain(
+        slotId,
+      );
+    },
+  );
+
+  it.each([
+    { kind: "text", expectedAttachments: 0 },
+    { kind: "attachment", expectedAttachments: 1 },
+  ])(
+    "keeps a closed compose pane whose only input is $kind",
+    async ({ kind, expectedAttachments }) => {
+      const layout = twoPaneComposeLayout("pane-left");
+      renderSplitArea({
+        path: "/",
+        layout,
+        routeContent: newThreadContentFor("draft-slot-left"),
+      });
+      const leftPane = document.querySelector<HTMLElement>(
+        '[data-split-pane-id="pane-left"]',
+      );
+      expect(leftPane).not.toBeNull();
+      if (leftPane === null) return;
+
+      if (kind === "text") {
+        fireEvent.change(
+          within(leftPane).getByRole("textbox", {
+            name: "Draft draft-slot-left",
+          }),
+          { target: { value: "Keep after close" } },
+        );
+      } else {
+        fireEvent.click(
+          within(leftPane).getByTestId("add-attachment-draft-slot-left"),
+        );
+      }
+      fireEvent.click(
+        within(leftPane).getByRole("button", { name: "Close pane" }),
+      );
+
+      await waitFor(() =>
+        expect(screen.queryByRole("textbox", { name: "Draft draft-slot-left" })).toBeNull(),
+      );
+      const persisted = readNewThreadDraftSlots().find(
+        (slot) => slot.id === "draft-slot-left",
+      );
+      expect(persisted).toBeDefined();
+      expect(persisted?.draft.text).toBe(
+        kind === "text" ? "Keep after close" : "",
+      );
+      expect(persisted?.draft.attachments).toHaveLength(expectedAttachments);
+    },
+  );
+
+  it("leaves no draft row after closing an empty compose pane", async () => {
+    renderSplitArea({
+      path: "/",
+      layout: twoPaneComposeLayout("pane-left"),
+      routeContent: newThreadContentFor("draft-slot-left"),
+    });
+    const leftPane = document.querySelector<HTMLElement>(
+      '[data-split-pane-id="pane-left"]',
+    );
+    expect(leftPane).not.toBeNull();
+    if (leftPane === null) return;
+
+    fireEvent.click(
+      within(leftPane).getByRole("button", { name: "Close pane" }),
+    );
+
+    await waitFor(() =>
+      expect(screen.queryByRole("textbox", { name: "Draft draft-slot-left" })).toBeNull(),
+    );
+    expect(readNewThreadDraftSlots().map((slot) => slot.id)).not.toContain(
+      "draft-slot-left",
+    );
+  });
+
+  it("restores both compose drafts after the split remounts", () => {
+    const layout = twoPaneComposeLayout("pane-left");
+    renderSplitArea({
+      path: "/",
+      layout,
+      routeContent: newThreadContentFor("draft-slot-left"),
+    });
+    fireEvent.change(
+      screen.getByRole("textbox", { name: "Draft draft-slot-left" }),
+      { target: { value: "Restored left" } },
+    );
+    fireEvent.change(
+      screen.getByRole("textbox", { name: "Draft draft-slot-right" }),
+      { target: { value: "Restored right" } },
+    );
+
+    cleanup();
+    renderSplitArea({
+      path: "/",
+      layout,
+      routeContent: newThreadContentFor("draft-slot-left"),
+    });
+
+    expect(
+      (
+        screen.getByRole("textbox", {
+          name: "Draft draft-slot-left",
+        }) as HTMLTextAreaElement
+      ).value,
+    ).toBe("Restored left");
+    expect(
+      (
+        screen.getByRole("textbox", {
+          name: "Draft draft-slot-right",
+        }) as HTMLTextAreaElement
+      ).value,
+    ).toBe("Restored right");
   });
 
   it("passes the route slot to the standalone compose surface", () => {

--- a/apps/app/src/views/thread-detail/SplitThreadArea.tsx
+++ b/apps/app/src/views/thread-detail/SplitThreadArea.tsx
@@ -19,6 +19,7 @@ import {
 import { useNavigate } from "react-router-dom";
 import { useRouteState } from "@/hooks/useRouteState";
 import {
+  getRootComposeRoutePath,
   getThreadRoutePath,
   type ThreadRoutePathArgs,
 } from "@/lib/route-paths";
@@ -113,6 +114,8 @@ import {
 } from "@/components/ui/context-selection";
 import { PaneMaximizeButton } from "./PaneMaximizeButton";
 import { wsManager } from "@/lib/ws";
+import { createNewThreadDraftSlotId } from "@/lib/prompt-draft-slots";
+import { withRootComposeDraftSlotId } from "@/lib/root-compose-location-state";
 
 const LazyPluginPanelRightPanelHost = lazy(() =>
   import("@/components/plugin/PluginPanelRightPanelHost").then(
@@ -165,6 +168,7 @@ type BeginPaneDrag = (
 const EMPTY_PATH: SplitPath = [];
 
 type NavigateInPane = (paneId: string, thread: ThreadRoutePathArgs) => void;
+type ResetNewThreadPane = (paneId: string) => void;
 
 interface SplitThreadAreaProps {
   routeContent?: PaneContent;
@@ -391,6 +395,30 @@ function SplitThreadAreaContent({ routeContent }: SplitThreadAreaProps) {
       navigate(getThreadRoutePath(thread));
     },
     [navigate, setLayout],
+  );
+
+  const resetNewThreadPane = useCallback<ResetNewThreadPane>(
+    (paneId) => {
+      const current = store.get(splitLayoutAtom);
+      if (current === null || findPane(current.root, paneId) === null) return;
+      const draftSlotId = createNewThreadDraftSlotId();
+      const replaced = replacePaneContent(current, paneId, {
+        kind: "new-thread",
+        draftSlotId,
+      });
+      const next =
+        current.focusedPaneId === paneId
+          ? replaced
+          : setFocus(replaced, current.focusedPaneId);
+      store.set(splitLayoutAtom, next);
+      if (current.focusedPaneId === paneId) {
+        void navigate(getRootComposeRoutePath(), {
+          replace: true,
+          state: withRootComposeDraftSlotId(null, draftSlotId),
+        });
+      }
+    },
+    [navigate, store],
   );
 
   const focusPane = useCallback(
@@ -625,6 +653,7 @@ function SplitThreadAreaContent({ routeContent }: SplitThreadAreaProps) {
           isTopRow
           ownsWindowTopLeft
           onNavigateInPane={navigateInPane}
+          onResetNewThreadPane={resetNewThreadPane}
         />
       </>
     );
@@ -659,6 +688,7 @@ function SplitThreadAreaContent({ routeContent }: SplitThreadAreaProps) {
             onMovePaneToSide={movePaneToSide}
             onResize={resize}
             onNavigateInPane={navigateInPane}
+            onResetNewThreadPane={resetNewThreadPane}
             onBeginPaneDrag={beginPaneDrag}
             onPruneStalePane={pruneStalePane}
           />
@@ -739,6 +769,7 @@ interface SplitTreeProps {
     fraction: number,
   ) => void;
   onNavigateInPane: NavigateInPane;
+  onResetNewThreadPane: ResetNewThreadPane;
   onBeginPaneDrag: BeginPaneDrag;
   onPruneStalePane: (paneId: string) => void;
 }
@@ -791,6 +822,7 @@ function SplitTree(props: SplitTreeProps) {
               : isTopRow && isLeftEdge
           }
           onNavigateInPane={props.onNavigateInPane}
+          onResetNewThreadPane={props.onResetNewThreadPane}
           onBeginPaneDrag={props.onBeginPaneDrag}
         />
         {}
@@ -864,6 +896,7 @@ interface WorkspacePaneContentProps {
   isTopRow: boolean;
   ownsWindowTopLeft: boolean;
   onNavigateInPane: NavigateInPane;
+  onResetNewThreadPane?: ResetNewThreadPane;
   onBeginPaneDrag?: BeginPaneDrag;
 }
 
@@ -882,6 +915,7 @@ function WorkspacePaneContent({
   isTopRow,
   ownsWindowTopLeft,
   onNavigateInPane,
+  onResetNewThreadPane,
   onBeginPaneDrag,
 }: WorkspacePaneContentProps) {
   const navigateInPane = useCallback(
@@ -895,6 +929,13 @@ function WorkspacePaneContent({
             onBeginPaneDrag(paneId, event, label)
         : undefined,
     [onBeginPaneDrag, paneId],
+  );
+  const resetNewThreadPane = useMemo(
+    () =>
+      onResetNewThreadPane
+        ? () => onResetNewThreadPane(paneId)
+        : undefined,
+    [onResetNewThreadPane, paneId],
   );
   const secondaryPanelHost = useMemo<PaneSecondaryPanelRegistration | null>(
     () =>
@@ -921,6 +962,7 @@ function WorkspacePaneContent({
       isTopRow,
       ownsWindowTopLeft,
       navigateInPane,
+      resetNewThreadPane,
       beginPaneDrag,
     }),
     [
@@ -931,6 +973,7 @@ function WorkspacePaneContent({
       isTopRow,
       ownsWindowTopLeft,
       navigateInPane,
+      resetNewThreadPane,
       onRequestClose,
       isMaximized,
       onToggleMaximize,


### PR DESCRIPTION
## What was wrong

The primary **New thread** control could replace the current pane but could not deliberately create the spec's two-pane drafting workspace. Draft reopening and submission also lacked pane-local split lifecycle behavior.

## What changed

- adds a trailing **Split** action to the **New thread** row on hover/focus
- replaces the workspace with exactly two fresh blank composers and focuses the left pane
- removes the action in compact viewports
- keeps new-thread submission pane-local and supports reopening an existing draft in the split
- uses internal app behavior only; this layer does not add a public command ID or bump the plugin SDK

## Visual evidence

> Rebase evidence status: current parent `d01d336283f40f580b7216ad12ccce4f2a5723c0` and current head `4f7fcae65c029baa8cc91b657251da9dbfaf6947`. The embedded captures below were made from the exact pre-rebase revisions and remain useful behavioral references, but they are not exact-current-revision evidence. Replace them before merge.

Pre-rebase behavioral comparison: `4a78545610576c1839ca271cb9440be657e93874` → `fd1c3ea60b4ffeafefeab4c5bff8b893d8364531`.

### Before — pre-rebase base `4a78545610576c1839ca271cb9440be657e93874`

The hovered **New thread** row has no trailing split action.

![Before — hovered New thread without Split](https://raw.githubusercontent.com/brsbl/bb/76fb4286cdd417380548c4ab629a7edf72474932/updated-sidebar-stack-2026-08-27/pr2473-before.png)

### After — pre-rebase head `fd1c3ea60b4ffeafefeab4c5bff8b893d8364531`

The same route, fixture, lifecycle filters, draft, viewport, and hover state reveal **Split**.

![After — hovered New thread with Split](https://raw.githubusercontent.com/brsbl/bb/76fb4286cdd417380548c4ab629a7edf72474932/updated-sidebar-stack-2026-08-27/pr2473-after.png)

### After — split result

![After — exactly two blank composers with left focus](https://raw.githubusercontent.com/brsbl/bb/76fb4286cdd417380548c4ab629a7edf72474932/updated-sidebar-stack-2026-08-27/pr2473-after-split.png)

### After — compact viewport

![After — Split is absent at 700 px](https://raw.githubusercontent.com/brsbl/bb/76fb4286cdd417380548c4ab629a7edf72474932/updated-sidebar-stack-2026-08-27/pr2473-after-compact.png)

## How you verified

- Google Chrome for Testing 151.0.7922.71, pre-rebase exact branch web apps from `scripts/bb-dev-app`, light theme, `/`, 1440×900 plus the scoped 700×900 compact check.
- Hovered **New thread**, activated **Split**, and observed exactly two blank composers with the left editor focused.
- At 700 px, inspected the same row and confirmed the Split control was absent. No page or console errors were recorded.

Fixes: N/A — Updated Sidebar split layer.

BB-Thread-ID: thr_2e2gbjx943

> AGENT GENERATED


