### PR TITLE
test(app): settle code theme probes before teardown

### DIFF
--- a/apps/app/src/lib/plugin-code-theme.test.tsx
+++ b/apps/app/src/lib/plugin-code-theme.test.tsx
@@ -47,6 +47,7 @@ describe("useCodeTheme", () => {
     // The two halves an editor needs: the surface and the token rules.
     expect(theme?.colors["editor.background"]).toMatch(/^#[0-9a-f]{6,8}$/i);
     expect(theme?.tokenColors.length).toBeGreaterThan(10);
+    probe.unmount();
   });
 
   it("keeps the resolved document while the next palette is in flight", async () => {
@@ -77,6 +78,7 @@ describe("useCodeTheme", () => {
     await waitFor(() => {
       expect(probe.latest().theme?.name).toBe("solarized-light");
     });
+    probe.unmount();
   });
 
   it("serves an already-resolved theme on the first render of the next consumer", async () => {
@@ -92,6 +94,8 @@ describe("useCodeTheme", () => {
     first.unmount();
 
     // No unthemed first frame for the second editor tab the user opens.
-    expect(renderProbe().latest().theme?.name).toBe("solarized-light");
+    const second = renderProbe();
+    expect(second.latest().theme?.name).toBe("solarized-light");
+    second.unmount();
   });
 });


### PR DESCRIPTION
## Human comments

## What was wrong

`plugin-code-theme.test.tsx` observed the real asynchronous Pierre theme resolutions, but it left three React render roots mounted until Testing Library's automatic `afterEach` cleanup. React 19 can queue follow-up Scheduler work while those roots are cleaned up; because that cleanup happened at file teardown, shard contention could let Vitest dispose jsdom first and the queued task then read the missing `window`. The failing CI run had exactly three post-test exceptions, matching the three roots left for automatic cleanup; the first consumer in the third test was explicitly unmounted and did not produce a fourth exception. A deterministic teardown harness reproduced the same `window is not defined` React DOM/Scheduler stack while every assertion passed, then stopped reproducing when the root was explicitly unmounted. This isolates the leak to test lifecycle ownership rather than the production hook or its resolver cancellation guard. See the [failing app-1 job](https://github.com/get-bb/bb/actions/runs/32921820985/job/98036738215) and the [subsequent passing app-1 job](https://github.com/get-bb/bb/actions/runs/32923019976/job/98040190034).

## What changed

Each test now explicitly unmounts every probe after its asynchronous assertions settle. The cached-theme test also retains the second probe long enough to unmount it. There are no production, wire-protocol, CLI, guide, or documentation changes.

## How you verified

- Verified merge-base before inspection and implementation: `7dc6756e20ba749ad9d4d6d939b1dd7de363250b` (`HEAD`, `origin/main`, and merge-base all matched; worktree was clean).
- Temporary deterministic teardown harness before: 3/3 test assertions passed, then Vitest reported the exact unhandled `ReferenceError: window is not defined` from React DOM/Scheduler. Minimized to one test with the same error.
- Same deterministic harness after: 3/3 passed and the former post-test Scheduler callback was no longer queued.
- `pnpm exec vitest run apps/app/src/lib/plugin-code-theme.test.tsx` — 3/3 passed.
- 100 parallel focused invocations — all passed with no unhandled errors.
- `pnpm exec turbo run test --filter=@bb/app --cache-dir=.turbo/cache --output-logs=new-only --force -- --shard=1/3` — 146 files passed; 1125 tests passed, 3 skipped.
- `pnpm exec turbo run test --filter=@bb/app --cache-dir=.turbo/cache --output-logs=new-only --force` — 438 files passed; 3418 tests passed, 3 skipped.
- `pnpm exec turbo run typecheck --filter=@bb/app` — passed.
- `pnpm exec turbo run build --filter=@bb/app` — passed.

> AGENT GENERATED: by GPT-5.6-Sol
