### PR TITLE
Fix tab split movement and fullscreen

### DIFF
--- a/apps/app/src/components/secondary-panel/SidebarSplitContainer.test.tsx
+++ b/apps/app/src/components/secondary-panel/SidebarSplitContainer.test.tsx
@@ -33,6 +33,13 @@ const TABS: readonly SidebarSplitTabDescriptor[] = [
 const PANEL_STATE_ID = "sidebar-split-container-test";
 let nextPaneInstance = 0;
 
+function listPaneIds(): string[] {
+  return Array.from(
+    document.querySelectorAll<HTMLElement>("[data-split-pane-id]"),
+    (pane) => pane.dataset.splitPaneId,
+  ).filter((paneId): paneId is string => paneId !== undefined);
+}
+
 function createTwoPaneState(): SidebarSplitState {
   const initial = createSidebarSplitState(
     TABS.map((tab) => tab.id),
@@ -70,12 +77,16 @@ function persistState(state: SidebarSplitState): void {
 
 function renderContainer({
   activeTabId = "tab-a",
+  isFullScreen = false,
   onActivateTab = vi.fn(),
+  onToggleFullScreen = vi.fn(),
   renderPane,
   tabs = TABS,
 }: {
   activeTabId?: string;
+  isFullScreen?: boolean;
   onActivateTab?: (tabId: string) => void;
+  onToggleFullScreen?: () => void;
   renderPane: (args: SidebarSplitPaneRenderArgs) => ReactNode;
   tabs?: readonly SidebarSplitTabDescriptor[];
 }) {
@@ -84,8 +95,10 @@ function renderContainer({
       <TooltipProvider>
         <SidebarSplitContainer
           activeTabId={activeTabId}
+          isFullScreen={isFullScreen}
           onActivateTab={onActivateTab}
           onGlobalTabReorder={vi.fn()}
+          onToggleFullScreen={onToggleFullScreen}
           panelStateId={PANEL_STATE_ID}
           renderPane={renderPane}
           tabs={tabs}
@@ -111,6 +124,32 @@ function StatefulPane({
       <button type="button" onClick={() => onMoveActiveTabToSide("left")}>
         Move {paneId} left
       </button>
+    </div>
+  );
+}
+
+function MultiTabStatefulPane({
+  activeTabId,
+  canMove,
+  onMove,
+  paneId,
+  side,
+}: {
+  activeTabId: string;
+  canMove: boolean;
+  onMove: () => void;
+  paneId: string;
+  side: "left" | "right" | "top" | "bottom";
+}) {
+  const [instance] = useState(() => `${paneId}-${nextPaneInstance++}`);
+  return (
+    <div>
+      <span data-testid={`multi-instance-${paneId}`}>{instance}</span>
+      {canMove ? (
+        <button type="button" onClick={onMove}>
+          Move {activeTabId} {side}
+        </button>
+      ) : null}
     </div>
   );
 }
@@ -157,11 +196,13 @@ describe("SidebarSplitContainer", () => {
       return (
         <SidebarSplitContainer
           activeTabId={activeTabId}
+          isFullScreen={false}
           onActivateTab={(tabId) => {
             activate(tabId);
             setActiveTabId(tabId);
           }}
           onGlobalTabReorder={vi.fn()}
+          onToggleFullScreen={vi.fn()}
           panelStateId={PANEL_STATE_ID}
           renderPane={({ paneId }) => (
             <div data-testid={`pane-content-${paneId}`}>{paneId}</div>
@@ -249,8 +290,10 @@ describe("SidebarSplitContainer", () => {
           </button>
           <SidebarSplitContainer
             activeTabId={terminalOpen ? "terminal-a" : "tab-b"}
+            isFullScreen={false}
             onActivateTab={vi.fn()}
             onGlobalTabReorder={vi.fn()}
+            onToggleFullScreen={vi.fn()}
             panelStateId={PANEL_STATE_ID}
             renderPane={({ group, paneId }) => (
               <div data-testid={`active-tab-${paneId}`}>
@@ -281,13 +324,13 @@ describe("SidebarSplitContainer", () => {
   });
 
   it.each([
-    ["left", "flex-row", "tab-a,tab-b"],
-    ["right", "flex-row", "tab-b,tab-a"],
-    ["top", "flex-col", "tab-a,tab-b"],
-    ["bottom", "flex-col", "tab-b,tab-a"],
+    ["left", "row", "tab-a,tab-b"],
+    ["right", "row", "tab-b,tab-a"],
+    ["top", "col", "tab-a,tab-b"],
+    ["bottom", "col", "tab-b,tab-a"],
   ] as const)(
     "moves the active tab to the supported %s position without dragging",
-    (side, directionClass, expectedOrder) => {
+    (side, expectedDirection, expectedOrder) => {
       renderContainer({
         renderPane: ({ group, onMoveActiveTabToSide }) => (
           <button type="button" onClick={() => onMoveActiveTabToSide?.(side)}>
@@ -305,9 +348,10 @@ describe("SidebarSplitContainer", () => {
         document.querySelectorAll<HTMLElement>("[data-split-pane-id]"),
       );
       expect(panes).toHaveLength(2);
-      expect(panes[0]?.parentElement?.parentElement?.className).toContain(
-        directionClass,
-      );
+      expect(
+        document.querySelector<HTMLElement>("[data-sidebar-split-container]")
+          ?.dataset.sidebarSplitRootDirection,
+      ).toBe(expectedDirection);
       expect(
         panes
           .map(
@@ -320,43 +364,111 @@ describe("SidebarSplitContainer", () => {
     },
   );
 
-  it("positions the focused active tab even when the control is in the outer pane", () => {
-    const split = createTwoPaneState();
-    const firstPane =
-      split.layout.root.type === "split" &&
-      split.layout.root.children[0]?.type === "pane"
-        ? split.layout.root.children[0]
-        : null;
-    expect(firstPane).not.toBeNull();
-    if (firstPane === null) return;
-    persistState(focusSidebarPane(split, firstPane.paneId));
+  it.each(["left", "right", "top", "bottom"] as const)(
+    "splits the active tab from an unfocused multi-tab pane to the %s",
+    (side) => {
+      const tabs = [...TABS, { id: "tab-c", label: "C" }];
+      const initial = createSidebarSplitState(
+        tabs.map((tab) => tab.id),
+        "tab-a",
+      );
+      const split = moveSidebarTab(
+        initial,
+        initial.layout.focusedPaneId,
+        "tab-c",
+        { paneId: initial.layout.focusedPaneId, zone: "right" },
+        { groupId: "group-c" },
+      );
+      persistState(split);
 
-    renderContainer({
-      renderPane: ({ group, onMoveActiveTabToSide, showOuterControls }) => (
-        <div>
-          <span data-testid="active-pane-tab">{group.activeTabId}</span>
-          {showOuterControls ? (
-            <button
-              type="button"
-              onClick={() => onMoveActiveTabToSide?.("bottom")}
-            >
-              Move focused bottom
-            </button>
-          ) : null}
-        </div>
-      ),
-    });
+      renderContainer({
+        tabs,
+        renderPane: ({ group, onMoveActiveTabToSide, paneId }) => (
+          <MultiTabStatefulPane
+            activeTabId={group.activeTabId}
+            canMove={group.tabIds.length > 1}
+            onMove={() => onMoveActiveTabToSide?.(side)}
+            paneId={paneId}
+            side={side}
+          />
+        ),
+      });
+      const originalPaneIds = listPaneIds();
+      const instancesBefore = new Map(
+        originalPaneIds.map((paneId) => [
+          paneId,
+          screen.getByTestId(`multi-instance-${paneId}`).textContent,
+        ]),
+      );
 
-    fireEvent.click(
-      screen.getByRole("button", { name: "Move focused bottom" }),
-    );
-    expect(
-      screen
-        .getAllByTestId("active-pane-tab")
-        .map((tab) => tab.textContent)
-        .join(","),
-    ).toBe("tab-b,tab-a");
-  });
+      fireEvent.click(
+        screen.getByRole("button", { name: `Move tab-a ${side}` }),
+      );
+
+      expect(listPaneIds()).toHaveLength(3);
+      for (const paneId of originalPaneIds) {
+        expect(screen.getByTestId(`multi-instance-${paneId}`).textContent).toBe(
+          instancesBefore.get(paneId),
+        );
+      }
+    },
+  );
+
+  it.each([
+    ["left", "row", "tab-a,tab-b"],
+    ["right", "row", "tab-b,tab-a"],
+    ["top", "col", "tab-a,tab-b"],
+    ["bottom", "col", "tab-b,tab-a"],
+  ] as const)(
+    "moves the unfocused Info pane %s from its own control",
+    (side, expectedDirection, expectedOrder) => {
+      const split = createTwoPaneState();
+      const infoPane =
+        split.layout.root.type === "split" &&
+        split.layout.root.children[0]?.type === "pane"
+          ? split.layout.root.children[0]
+          : null;
+      const diffPane =
+        split.layout.root.type === "split" &&
+        split.layout.root.children[1]?.type === "pane"
+          ? split.layout.root.children[1]
+          : null;
+      expect(infoPane).not.toBeNull();
+      expect(diffPane).not.toBeNull();
+      if (infoPane === null || diffPane === null) return;
+      persistState(focusSidebarPane(split, diffPane.paneId));
+
+      renderContainer({
+        renderPane: ({ group, onMoveActiveTabToSide, paneId }) => (
+          <div>
+            <span data-testid="active-pane-tab">{group.activeTabId}</span>
+            {paneId === infoPane.paneId ? (
+              <button
+                type="button"
+                onClick={() => onMoveActiveTabToSide?.(side)}
+              >
+                Move Info {side}
+              </button>
+            ) : null}
+          </div>
+        ),
+      });
+
+      fireEvent.click(
+        screen.getByRole("button", { name: `Move Info ${side}` }),
+      );
+      expect(
+        document.querySelector<HTMLElement>("[data-sidebar-split-container]")
+          ?.dataset.sidebarSplitRootDirection,
+      ).toBe(expectedDirection);
+      expect(
+        screen
+          .getAllByTestId("active-pane-tab")
+          .map((tab) => tab.textContent)
+          .join(","),
+      ).toBe(expectedOrder);
+    },
+  );
 
   it("keeps stateful pane content attached to pane identity after a move", () => {
     const split = createTwoPaneState();
@@ -396,6 +508,149 @@ describe("SidebarSplitContainer", () => {
         before.get(paneId) ?? "missing-instance",
       );
     }
+  });
+
+  it("maximizes one pane while preserving the mounted split for restoration", async () => {
+    const split = createStackedPaneState();
+    const paneIds =
+      split.layout.root.type === "split"
+        ? split.layout.root.children.flatMap((child) =>
+            child.type === "pane" ? [child.paneId] : [],
+          )
+        : [];
+    const paneToMaximize = paneIds[0];
+    expect(paneToMaximize).toBeDefined();
+    if (paneToMaximize === undefined) return;
+    persistState(split);
+
+    function Pane({
+      isMaximized,
+      onToggleMaximize,
+      paneId,
+    }: Pick<
+      SidebarSplitPaneRenderArgs,
+      "isMaximized" | "onToggleMaximize" | "paneId"
+    >) {
+      const [instance] = useState(() => `${paneId}-${nextPaneInstance++}`);
+      return (
+        <div>
+          <span data-testid={`max-instance-${paneId}`}>{instance}</span>
+          <button type="button" onClick={onToggleMaximize}>
+            {isMaximized ? `Restore ${paneId}` : `Maximize ${paneId}`}
+          </button>
+        </div>
+      );
+    }
+
+    function Harness() {
+      const [isFullScreen, setIsFullScreen] = useState(false);
+      return (
+        <SidebarSplitContainer
+          activeTabId="tab-b"
+          isFullScreen={isFullScreen}
+          onActivateTab={vi.fn()}
+          onGlobalTabReorder={vi.fn()}
+          onToggleFullScreen={() => setIsFullScreen((current) => !current)}
+          panelStateId={PANEL_STATE_ID}
+          renderPane={(pane) => <Pane {...pane} />}
+          tabs={TABS}
+        />
+      );
+    }
+
+    render(
+      <SidebarProvider>
+        <TooltipProvider>
+          <Harness />
+        </TooltipProvider>
+      </SidebarProvider>,
+    );
+    const instancesBefore = new Map(
+      paneIds.map((paneId) => [
+        paneId,
+        screen.getByTestId(`max-instance-${paneId}`).textContent,
+      ]),
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: `Maximize ${paneToMaximize}` }),
+    );
+
+    await waitFor(() =>
+      expect(
+        document.querySelector(
+          `[data-split-pane-id="${paneToMaximize}"][data-maximized="true"]`,
+        ),
+      ).not.toBeNull(),
+    );
+    const hiddenPaneId = paneIds.find((paneId) => paneId !== paneToMaximize);
+    expect(hiddenPaneId).toBeDefined();
+    if (hiddenPaneId === undefined) return;
+    const hiddenPane = document.querySelector(
+      `[data-split-pane-id="${hiddenPaneId}"]`,
+    );
+    if (!(hiddenPane instanceof HTMLElement)) {
+      throw new Error("Expected the preserved hidden split pane");
+    }
+    expect(hiddenPane.getAttribute("aria-hidden")).toBe("true");
+    expect(hiddenPane.style.contentVisibility).toBe("hidden");
+    expect(hiddenPane.className).toContain("invisible");
+    expect(hiddenPane.className).toContain("pointer-events-none");
+    expect(document.querySelector('[role="separator"]')?.className).toContain(
+      "invisible",
+    );
+    for (const paneId of paneIds) {
+      expect(screen.getByTestId(`max-instance-${paneId}`).textContent).toBe(
+        instancesBefore.get(paneId),
+      );
+    }
+
+    fireEvent.click(
+      screen.getByRole("button", { name: `Restore ${paneToMaximize}` }),
+    );
+    await waitFor(() =>
+      expect(
+        document.querySelector('[data-split-pane-id][data-maximized="true"]'),
+      ).toBeNull(),
+    );
+    expect(hiddenPane.getAttribute("aria-hidden")).toBeNull();
+    expect(hiddenPane.style.contentVisibility).toBe("");
+    expect(screen.getByRole("separator")).not.toBeNull();
+    for (const paneId of paneIds) {
+      expect(screen.getByTestId(`max-instance-${paneId}`).textContent).toBe(
+        instancesBefore.get(paneId),
+      );
+    }
+  });
+
+  it("keeps a newly created split maximized while the right panel is full screen", () => {
+    const onToggleFullScreen = vi.fn();
+    renderContainer({
+      isFullScreen: true,
+      onToggleFullScreen,
+      renderPane: ({ onMoveActiveTabToSide, paneId }) => (
+        <button
+          type="button"
+          onClick={() => onMoveActiveTabToSide?.("bottom")}
+        >
+          Split {paneId}
+        </button>
+      ),
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /^Split / }));
+
+    const panes = Array.from(
+      document.querySelectorAll<HTMLElement>("[data-split-pane-id]"),
+    );
+    expect(panes).toHaveLength(2);
+    expect(panes.filter((pane) => pane.dataset.maximized === "true")).toHaveLength(
+      1,
+    );
+    expect(
+      panes.filter((pane) => pane.getAttribute("aria-hidden") === "true"),
+    ).toHaveLength(1);
+    expect(onToggleFullScreen).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -509,6 +764,17 @@ describe("SidebarSplitContainer", () => {
     });
     expect(Number.parseFloat(previous.style.flex)).toBeCloseTo(0.749, 3);
     expect(Number.parseFloat(next.style.flex)).toBeCloseTo(0.251, 3);
+    const panes = Array.from(
+      document.querySelectorAll<HTMLElement>("[data-split-pane-id]"),
+    );
+    expect(Number.parseFloat(panes[0]?.style.height ?? "0")).toBeCloseTo(
+      74.9,
+      1,
+    );
+    expect(Number.parseFloat(panes[1]?.style.height ?? "0")).toBeCloseTo(
+      25.1,
+      1,
+    );
     fireEvent.pointerUp(hitTarget, {
       clientX: 700,
       clientY: 600,
@@ -691,9 +957,9 @@ describe("SidebarSplitContainer", () => {
     });
 
     fireEvent.pointerDown(hitTarget, { clientY: 400, pointerId: 9 });
-    expect(
-      screen.getByTestId("iframe-drag-guard-overlay").className,
-    ).toContain("cursor-row-resize");
+    expect(screen.getByTestId("iframe-drag-guard-overlay").className).toContain(
+      "cursor-row-resize",
+    );
 
     fireEvent.pointerCancel(hitTarget, { clientY: 400, pointerId: 9 });
     expect(screen.queryByTestId("iframe-drag-guard-overlay")).toBeNull();

--- a/apps/app/src/components/secondary-panel/SidebarSplitContainer.tsx
+++ b/apps/app/src/components/secondary-panel/SidebarSplitContainer.tsx
@@ -18,6 +18,7 @@ import {
   listPanes,
   MAX_PANES,
   type LayoutNode,
+  type SplitLayout,
   type SplitPath,
   type SplitSide,
 } from "@/lib/split-layout";
@@ -44,14 +45,17 @@ import {
   resizeSidebarSplit,
   selectSidebarTab,
   serializeSidebarSplitState,
+  setSidebarPaneMaximized,
   sidebarPaneGroupId,
   sidebarSplitStorageKey,
+  toggleSidebarPaneMaximize,
   type SidebarSplitState,
   type SidebarTabGroup,
 } from "./sidebarSplitLayout";
 import type { SecondaryPanelTabReorderRequest } from "./secondaryPanelTab";
 
 const PANE_DRAG_ENGAGE_DISTANCE_PX = 7;
+const PANE_EDGE_EPSILON = 1e-9;
 type SidebarSplitResizeCursor = "col-resize" | "row-resize";
 
 export interface SidebarSplitTabDescriptor {
@@ -63,6 +67,7 @@ export interface SidebarSplitPaneRenderArgs {
   group: SidebarTabGroup;
   isFocused: boolean;
   isLeftEdge: boolean;
+  isMaximized: boolean;
   isTopRow: boolean;
   onBeginTabDrag: (
     tabId: string,
@@ -73,14 +78,17 @@ export interface SidebarSplitPaneRenderArgs {
   onRemoveSplit?: () => void;
   onMoveActiveTabToSide?: (side: SplitSide) => void;
   onSelectTab: (tabId: string) => void;
+  onToggleMaximize: () => void;
   paneId: string;
   showOuterControls: boolean;
 }
 
 interface SidebarSplitContainerProps {
   activeTabId: string;
+  isFullScreen: boolean;
   onActivateTab: (tabId: string) => void;
   onGlobalTabReorder: (request: SecondaryPanelTabReorderRequest) => void;
+  onToggleFullScreen: () => void;
   panelStateId: string;
   renderPane: (args: SidebarSplitPaneRenderArgs) => ReactNode;
   tabs: readonly SidebarSplitTabDescriptor[];
@@ -88,8 +96,10 @@ interface SidebarSplitContainerProps {
 
 export function SidebarSplitContainer({
   activeTabId,
+  isFullScreen,
   onActivateTab,
   onGlobalTabReorder,
+  onToggleFullScreen,
   panelStateId,
   renderPane,
   tabs,
@@ -101,24 +111,32 @@ export function SidebarSplitContainer({
       ? null
       : window.localStorage.getItem(storageKey),
   );
-  const [state, setState] = useState<SidebarSplitState>(() =>
-    typeof window === "undefined"
-      ? createSidebarSplitState(availableTabIds, activeTabId)
-      : parseSidebarSplitState(
-          initialStorageValue,
-          availableTabIds,
-          activeTabId,
-        ),
-  );
+  const [state, setState] = useState<SidebarSplitState>(() => {
+    const restored =
+      typeof window === "undefined"
+        ? createSidebarSplitState(availableTabIds, activeTabId)
+        : parseSidebarSplitState(
+            initialStorageValue,
+            availableTabIds,
+            activeTabId,
+          );
+    return setSidebarPaneMaximized(
+      restored,
+      isFullScreen ? restored.layout.focusedPaneId : null,
+    );
+  });
   const stateRef = useRef(state);
   const lastPersistedValueRef = useRef({
     storageKey,
     value: initialStorageValue,
   });
   const previousActiveTabId = useRef(activeTabId);
+  const previousFullScreen = useRef(isFullScreen);
   const dimsInactiveSplits = useAtomValue(dimInactiveSplitsAtom);
   const [resizeCursor, setResizeCursor] =
     useState<SidebarSplitResizeCursor | null>(null);
+  const [resizePreviewLayout, setResizePreviewLayout] =
+    useState<SplitLayout | null>(null);
   const paneCount = countPanes(state.layout.root);
   const hasMultiplePanes = paneCount > 1;
 
@@ -217,6 +235,17 @@ export function SidebarSplitContainer({
     [activeTabId, onActivateTab],
   );
 
+  useEffect(() => {
+    if (previousFullScreen.current === isFullScreen) return;
+    previousFullScreen.current = isFullScreen;
+    commitState((current) =>
+      setSidebarPaneMaximized(
+        current,
+        isFullScreen ? current.layout.focusedPaneId : null,
+      ),
+    );
+  }, [commitState, isFullScreen]);
+
   const selectTab = useCallback(
     (paneId: string, tabId: string) => {
       commitState((current) => selectSidebarTab(current, paneId, tabId));
@@ -240,23 +269,26 @@ export function SidebarSplitContainer({
   );
 
   const moveActiveTabToSide = useCallback(
-    (side: SplitSide) => {
+    (paneId: string, side: SplitSide) => {
       commitState((current) => {
-        const paneId = current.layout.focusedPaneId;
-        const sourceGroup = getSidebarGroupForPane(current, paneId);
+        const focused = focusSidebarPane(current, paneId);
+        const sourceGroup = getSidebarGroupForPane(focused, paneId);
         if (sourceGroup === null) return current;
         if (sourceGroup.tabIds.length > 1) {
-          if (countPanes(current.layout.root) >= MAX_PANES) return current;
-          return moveSidebarTab(
-            current,
+          if (countPanes(focused.layout.root) >= MAX_PANES) return focused;
+          const moved = moveSidebarTab(
+            focused,
             paneId,
             sourceGroup.activeTabId,
             { paneId, zone: side },
-            { groupId: nextSidebarSplitGroupId(current) },
+            { groupId: nextSidebarSplitGroupId(focused) },
           );
+          return isFullScreen
+            ? setSidebarPaneMaximized(moved, moved.layout.focusedPaneId)
+            : moved;
         }
-        const rects = computePaneRects(current.layout.root);
-        const target = listPanes(current.layout.root)
+        const rects = computePaneRects(focused.layout.root);
+        const target = listPanes(focused.layout.root)
           .filter((pane) => pane.paneId !== paneId)
           .sort((first, second) => {
             const a = rects.get(first.paneId);
@@ -277,25 +309,45 @@ export function SidebarSplitContainer({
             return edge(a) - edge(b);
           })[0];
         return target === undefined
-          ? current
-          : moveSidebarPaneToSide(current, paneId, target.paneId, side);
+          ? focused
+          : moveSidebarPaneToSide(focused, paneId, target.paneId, side);
       }, true);
     },
-    [commitState],
+    [commitState, isFullScreen],
+  );
+
+  const toggleMaximizePane = useCallback(
+    (paneId: string) => {
+      const current = stateRef.current;
+      const next = commitState((latest) =>
+        toggleSidebarPaneMaximize(latest, paneId),
+      );
+      if (
+        next !== current &&
+        (next.maximizedPaneId !== null) !== isFullScreen
+      ) {
+        onToggleFullScreen();
+      }
+    },
+    [commitState, isFullScreen, onToggleFullScreen],
   );
 
   const moveTab = useCallback(
     (sourcePaneId: string, tabId: string, target: SplitDropTarget) => {
       const groupId = nextSidebarSplitGroupId(stateRef.current);
       commitState(
-        (current) =>
-          moveSidebarTab(current, sourcePaneId, tabId, target, {
+        (current) => {
+          const moved = moveSidebarTab(current, sourcePaneId, tabId, target, {
             groupId,
-          }),
+          });
+          return isFullScreen
+            ? setSidebarPaneMaximized(moved, moved.layout.focusedPaneId)
+            : moved;
+        },
         true,
       );
     },
-    [commitState],
+    [commitState, isFullScreen],
   );
 
   const beginTabDrag = useCallback(
@@ -387,18 +439,28 @@ export function SidebarSplitContainer({
     },
     [commitState],
   );
+  const previewResize = useCallback(
+    (path: SplitPath, childIndex: number, fraction: number | null) => {
+      setResizePreviewLayout(
+        fraction === null
+          ? null
+          : resizeSidebarSplit(stateRef.current, path, childIndex, fraction)
+              .layout,
+      );
+    },
+    [],
+  );
 
   const firstPane = listPanes(state.layout.root)[0];
-  const focusedGroup = getSidebarGroupForPane(
-    state,
-    state.layout.focusedPaneId,
-  );
-  const canMoveActiveTabToSide =
-    focusedGroup !== null &&
-    (focusedGroup.tabIds.length > 1 ? paneCount < MAX_PANES : paneCount > 1);
-  const activeTabPositionHandler = canMoveActiveTabToSide
-    ? moveActiveTabToSide
-    : undefined;
+  const moveActiveTabHandler = (paneId: string) => {
+    const group = getSidebarGroupForPane(state, paneId);
+    const canMove =
+      group !== null &&
+      (group.tabIds.length > 1 ? paneCount < MAX_PANES : paneCount > 1);
+    return canMove
+      ? (side: SplitSide) => moveActiveTabToSide(paneId, side)
+      : undefined;
+  };
   if (!hasMultiplePanes && firstPane !== undefined) {
     const group = getSidebarGroupForPane(state, firstPane.paneId);
     if (group === null) return null;
@@ -408,43 +470,66 @@ export function SidebarSplitContainer({
       group,
       isFocused: true,
       isLeftEdge: true,
+      isMaximized: isFullScreen,
       isTopRow: true,
       onBeginTabDrag: (tabId, event) =>
         beginTabDrag(firstPane.paneId, tabId, event),
       onReorderTab: (request) => reorderTab(firstPane.paneId, request),
       onFocusPane: () => focusPane(firstPane.paneId),
       onRemoveSplit: undefined,
-      onMoveActiveTabToSide: activeTabPositionHandler,
+      onMoveActiveTabToSide: moveActiveTabHandler(firstPane.paneId),
       onSelectTab: (tabId) => selectTab(firstPane.paneId, tabId),
+      onToggleMaximize: onToggleFullScreen,
       paneId: firstPane.paneId,
       showOuterControls: true,
     });
   }
+  const presentedLayout = resizePreviewLayout ?? state.layout;
+  const paneRects = computePaneRects(presentedLayout.root);
 
   return (
     <div
       className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden"
       data-sidebar-split-container=""
+      data-sidebar-split-root-direction={
+        presentedLayout.root.type === "split"
+          ? presentedLayout.root.dir
+          : undefined
+      }
     >
-      <SidebarSplitTree
-        node={state.layout.root}
+      <SidebarSplitTrackTree
+        node={presentedLayout.root}
         path={[]}
-        isLeftEdge
-        isTopRow
-        isRightEdge
-        dimsInactiveSplits={dimsInactiveSplits}
-        focusedPaneId={state.layout.focusedPaneId}
-        renderPane={renderPane}
-        state={state}
-        onBeginTabDrag={beginTabDrag}
-        onFocusPane={focusPane}
-        onRemoveSplit={removeSplit}
-        onMoveActiveTabToSide={activeTabPositionHandler}
-        onReorderTab={reorderTab}
+        maximizedPaneId={state.maximizedPaneId}
         onResize={resize}
         onResizeDragChange={setResizeCursor}
-        onSelectTab={selectTab}
+        onPreviewResize={previewResize}
       />
+      {listPanes(state.layout.root).map((pane) => {
+        const rect = paneRects.get(pane.paneId);
+        return rect === undefined ? null : (
+          <SidebarSplitLeaf
+            key={pane.paneId}
+            dimsInactiveSplits={dimsInactiveSplits}
+            focusedPaneId={state.layout.focusedPaneId}
+            isLeftEdge={rect.x <= PANE_EDGE_EPSILON}
+            isRightEdge={rect.x + rect.w >= 1 - PANE_EDGE_EPSILON}
+            isTopRow={rect.y <= PANE_EDGE_EPSILON}
+            maximizedPaneId={state.maximizedPaneId}
+            pane={pane}
+            rect={rect}
+            renderPane={renderPane}
+            state={state}
+            onBeginTabDrag={beginTabDrag}
+            onFocusPane={focusPane}
+            onRemoveSplit={removeSplit}
+            onMoveActiveTabToSide={moveActiveTabToSide}
+            onReorderTab={reorderTab}
+            onSelectTab={selectTab}
+            onToggleMaximize={toggleMaximizePane}
+          />
+        );
+      })}
       <IframeDragGuardOverlay
         active={resizeCursor !== null}
         cursor={resizeCursor ?? "col-resize"}
@@ -453,42 +538,28 @@ export function SidebarSplitContainer({
   );
 }
 
-interface SidebarSplitTreeProps {
-  dimsInactiveSplits: boolean;
-  focusedPaneId: string;
-  isLeftEdge: boolean;
-  isRightEdge: boolean;
-  isTopRow: boolean;
+interface SidebarSplitTrackTreeProps {
+  maximizedPaneId: string | null;
   node: LayoutNode;
-  onBeginTabDrag: (
-    paneId: string,
-    tabId: string,
-    event: ReactPointerEvent<HTMLElement>,
-  ) => void;
-  onFocusPane: (paneId: string) => void;
-  onRemoveSplit: (paneId: string) => void;
-  onMoveActiveTabToSide?: (side: SplitSide) => void;
-  onReorderTab: (
-    paneId: string,
-    request: SecondaryPanelTabReorderRequest,
-  ) => void;
   onResize: (path: SplitPath, childIndex: number, fraction: number) => void;
   onResizeDragChange: (cursor: SidebarSplitResizeCursor | null) => void;
-  onSelectTab: (paneId: string, tabId: string) => void;
+  onPreviewResize: (
+    path: SplitPath,
+    childIndex: number,
+    fraction: number | null,
+  ) => void;
   path: number[];
-  renderPane: (args: SidebarSplitPaneRenderArgs) => ReactNode;
-  state: SidebarSplitState;
 }
 
-function SidebarSplitTree(props: SidebarSplitTreeProps) {
+function SidebarSplitTrackTree(props: SidebarSplitTrackTreeProps) {
   if (props.node.type === "pane") {
-    return <SidebarSplitLeaf {...props} pane={props.node} />;
+    return <div className="flex min-h-0 min-w-0 flex-1" />;
   }
   const node = props.node;
   return (
     <div
       className={cn(
-        "flex min-h-0 min-w-0 flex-1",
+        "pointer-events-none flex min-h-0 min-w-0 flex-1",
         node.dir === "row" ? "flex-row" : "flex-col",
       )}
     >
@@ -497,28 +568,24 @@ function SidebarSplitTree(props: SidebarSplitTreeProps) {
           {index > 0 ? (
             <SidebarSplitDivider
               dir={node.dir}
+              hidden={props.maximizedPaneId !== null}
               onResize={(fraction) =>
                 props.onResize(props.path, index - 1, fraction)
               }
               onResizeDragChange={props.onResizeDragChange}
+              onPreviewResize={(fraction) =>
+                props.onPreviewResize(props.path, index - 1, fraction)
+              }
             />
           ) : null}
           <div
             className="flex min-h-0 min-w-0"
             style={{ flex: `${node.sizes[index] ?? 1} 1 0px` }}
           >
-            <SidebarSplitTree
+            <SidebarSplitTrackTree
               {...props}
               node={child}
               path={[...props.path, index]}
-              isLeftEdge={
-                props.isLeftEdge && (node.dir === "col" || index === 0)
-              }
-              isTopRow={props.isTopRow && (node.dir === "row" || index === 0)}
-              isRightEdge={
-                props.isRightEdge &&
-                (node.dir === "col" || index === node.children.length - 1)
-              }
             />
           </div>
         </Fragment>
@@ -527,17 +594,48 @@ function SidebarSplitTree(props: SidebarSplitTreeProps) {
   );
 }
 
-function SidebarSplitLeaf(
-  props: SidebarSplitTreeProps & {
-    pane: Extract<LayoutNode, { type: "pane" }>;
-  },
-) {
+interface SidebarSplitLeafProps {
+  dimsInactiveSplits: boolean;
+  focusedPaneId: string;
+  isLeftEdge: boolean;
+  isRightEdge: boolean;
+  isTopRow: boolean;
+  maximizedPaneId: string | null;
+  onBeginTabDrag: (
+    paneId: string,
+    tabId: string,
+    event: ReactPointerEvent<HTMLElement>,
+  ) => void;
+  onFocusPane: (paneId: string) => void;
+  onMoveActiveTabToSide: (paneId: string, side: SplitSide) => void;
+  onRemoveSplit: (paneId: string) => void;
+  onReorderTab: (
+    paneId: string,
+    request: SecondaryPanelTabReorderRequest,
+  ) => void;
+  onSelectTab: (paneId: string, tabId: string) => void;
+  onToggleMaximize: (paneId: string) => void;
+  pane: Extract<LayoutNode, { type: "pane" }>;
+  rect: { h: number; w: number; x: number; y: number };
+  renderPane: (args: SidebarSplitPaneRenderArgs) => ReactNode;
+  state: SidebarSplitState;
+}
+
+function SidebarSplitLeaf(props: SidebarSplitLeafProps) {
   const { pane } = props;
   const groupId = sidebarPaneGroupId(pane);
   const group = groupId === null ? undefined : props.state.groups[groupId];
   if (group === undefined) return null;
   const isFocused = pane.paneId === props.focusedPaneId;
-  const showOuterControls = props.isTopRow && props.isRightEdge;
+  const isMaximized = pane.paneId === props.maximizedPaneId;
+  const isHiddenByMaximize = props.maximizedPaneId !== null && !isMaximized;
+  const canMoveActiveTabToSide =
+    group.tabIds.length > 1
+      ? countPanes(props.state.layout.root) < MAX_PANES
+      : countPanes(props.state.layout.root) > 1;
+  const showOuterControls =
+    isMaximized ||
+    (props.maximizedPaneId === null && props.isTopRow && props.isRightEdge);
   const context: PaneContextValue = {
     paneId: pane.paneId,
     isFocused,
@@ -545,10 +643,10 @@ function SidebarSplitLeaf(
     secondaryPanelHost: null,
     reservesWindowPanelToggle: showOuterControls,
     onRequestClose: null,
-    isMaximized: false,
-    onToggleMaximize: null,
+    isMaximized,
+    onToggleMaximize: () => props.onToggleMaximize(pane.paneId),
     isBoundedPane: true,
-    isTopRow: props.isTopRow,
+    isTopRow: isMaximized || props.isTopRow,
     ownsWindowTopLeft: false,
     navigateInPane: () => {},
   };
@@ -556,23 +654,44 @@ function SidebarSplitLeaf(
     <PaneContext.Provider value={context}>
       <div
         onPointerDown={() => props.onFocusPane(pane.paneId)}
-        className="relative flex min-h-0 min-w-0 flex-1 overflow-hidden"
+        aria-hidden={isHiddenByMaximize || undefined}
+        style={
+          isMaximized
+            ? undefined
+            : {
+                contentVisibility: isHiddenByMaximize ? "hidden" : undefined,
+                height: `${props.rect.h * 100}%`,
+                left: `${props.rect.x * 100}%`,
+                top: `${props.rect.y * 100}%`,
+                width: `${props.rect.w * 100}%`,
+              }
+        }
+        className={cn(
+          "absolute flex min-h-0 min-w-0 overflow-hidden",
+          isHiddenByMaximize && "invisible pointer-events-none",
+          isMaximized && "absolute inset-0 z-30",
+        )}
         data-split-pane-id={pane.paneId}
         data-focused={isFocused ? "true" : "false"}
+        data-maximized={isMaximized ? "true" : undefined}
       >
         <section className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-sidebar">
           {props.renderPane({
             group,
             isFocused,
-            isLeftEdge: props.isLeftEdge,
-            isTopRow: props.isTopRow,
+            isLeftEdge: isMaximized || props.isLeftEdge,
+            isMaximized,
+            isTopRow: isMaximized || props.isTopRow,
             onBeginTabDrag: (tabId, event) =>
               props.onBeginTabDrag(pane.paneId, tabId, event),
             onReorderTab: (request) => props.onReorderTab(pane.paneId, request),
             onFocusPane: () => props.onFocusPane(pane.paneId),
             onRemoveSplit: () => props.onRemoveSplit(pane.paneId),
-            onMoveActiveTabToSide: props.onMoveActiveTabToSide,
+            onMoveActiveTabToSide: canMoveActiveTabToSide
+              ? (side) => props.onMoveActiveTabToSide(pane.paneId, side)
+              : undefined,
             onSelectTab: (tabId) => props.onSelectTab(pane.paneId, tabId),
+            onToggleMaximize: () => props.onToggleMaximize(pane.paneId),
             paneId: pane.paneId,
             showOuterControls,
           })}
@@ -594,12 +713,16 @@ function SidebarSplitLeaf(
 
 function SidebarSplitDivider({
   dir,
+  hidden,
   onResize,
   onResizeDragChange,
+  onPreviewResize,
 }: {
   dir: "row" | "col";
+  hidden: boolean;
   onResize: (fraction: number) => void;
   onResizeDragChange: (cursor: SidebarSplitResizeCursor | null) => void;
+  onPreviewResize: (fraction: number | null) => void;
 }) {
   const horizontal = dir === "row";
   const finishResizeRef = useRef<(() => void) | null>(null);
@@ -646,6 +769,7 @@ function SidebarSplitDivider({
         pendingFraction = fraction;
         pair.previous.style.flex = `${pair.total * fraction} 1 0px`;
         pair.next.style.flex = `${pair.total * (1 - fraction)} 1 0px`;
+        onPreviewResize(fraction);
       };
       const move = (moveEvent: PointerEvent) => {
         if (moveEvent.pointerId !== pointerId) return;
@@ -664,6 +788,7 @@ function SidebarSplitDivider({
           hitTarget.releasePointerCapture(pointerId);
         }
         onResizeDragChange(null);
+        onPreviewResize(null);
         if (commit && pendingFraction !== null) {
           onResize(pendingFraction);
           return;
@@ -693,11 +818,12 @@ function SidebarSplitDivider({
       finishResizeRef.current = () => finish(false);
       onResizeDragChange(horizontal ? "col-resize" : "row-resize");
     },
-    [horizontal, onResize, onResizeDragChange],
+    [horizontal, onPreviewResize, onResize, onResizeDragChange],
   );
   return (
     <div
       role="separator"
+      aria-hidden={hidden || undefined}
       aria-label={
         horizontal
           ? "Resize right panel panes"
@@ -707,6 +833,8 @@ function SidebarSplitDivider({
       className={cn(
         "group relative z-[25] shrink-0 bg-border-seam transition-colors hover:bg-ring/40 data-[dragging]:bg-ring/40",
         MACOS_APP_REGION_NO_DRAG_CLASS,
+        "pointer-events-auto",
+        hidden && "invisible pointer-events-none",
         horizontal ? "w-px cursor-col-resize" : "h-px cursor-row-resize",
       )}
     >

--- a/apps/app/src/components/secondary-panel/ThreadMetadataContent.test.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadMetadataContent.test.tsx
@@ -1,12 +1,16 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { MemoryRouter } from "react-router-dom";
 import type { Environment, Thread } from "@bb/domain";
 import { TooltipProvider } from "@bb/shared-ui/tooltip";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { EnvironmentRow, ParentSelectorRow } from "./ThreadMetadataContent";
+import {
+  EnvironmentRow,
+  ParentSelectorRow,
+  ThreadMetadataCard,
+} from "./ThreadMetadataContent";
 import { parentThreads } from "./ThreadMetadataContent.fixtures";
 
 const localHost = { locality: "local", identity: null } as const;
@@ -73,7 +77,37 @@ function renderEnvironmentRow(environment: Environment): string {
   );
 }
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("ThreadMetadataCard", () => {
+  it("shows its scrollbar only during active scrolling", () => {
+    vi.useFakeTimers();
+    const { container } = render(
+      <ThreadMetadataCard>
+        <div>Thread information</div>
+      </ThreadMetadataCard>,
+    );
+    const scrollArea = container.querySelector("dl");
+    if (!(scrollArea instanceof HTMLElement)) {
+      throw new Error("missing info scroll area");
+    }
+
+    expect(scrollArea.classList).toContain("transient-scrollbar");
+    expect(scrollArea.hasAttribute("data-scrollbar-scrolling")).toBe(false);
+
+    fireEvent.scroll(scrollArea);
+    expect(scrollArea.dataset.scrollbarScrolling).toBe("true");
+
+    act(() => vi.advanceTimersByTime(599));
+    expect(scrollArea.dataset.scrollbarScrolling).toBe("true");
+
+    act(() => vi.advanceTimersByTime(1));
+    expect(scrollArea.hasAttribute("data-scrollbar-scrolling")).toBe(false);
+  });
+});
 
 describe("EnvironmentRow", () => {
   it("shows the create-thread action for a provisioned worktree", () => {

--- a/apps/app/src/components/secondary-panel/ThreadMetadataContent.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadMetadataContent.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useMemo, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  type ReactNode,
+  type UIEvent,
+} from "react";
 import { ThreadStorageBrowser } from "./ThreadStorageBrowser";
 import type { ThreadStorageBrowserController } from "./useThreadStorageBrowser";
 import { Link } from "react-router-dom";
@@ -968,6 +975,8 @@ interface DetailCardWrapperProps {
   children: ReactNode;
 }
 
+const INFO_SCROLLBAR_IDLE_DELAY_MS = 600;
+
 /**
  * Shared DetailCard styling used by ThreadMetadataContent and the per-row
  * stories so a single row in isolation looks the same as it does inside the
@@ -981,10 +990,36 @@ interface DetailCardWrapperProps {
  * card itself only scrolls once those minimums no longer fit.
  */
 export function ThreadMetadataCard({ children }: DetailCardWrapperProps) {
+  const scrollbarIdleTimeoutRef = useRef<number | null>(null);
+
+  useEffect(
+    () => () => {
+      if (scrollbarIdleTimeoutRef.current !== null) {
+        window.clearTimeout(scrollbarIdleTimeoutRef.current);
+      }
+    },
+    [],
+  );
+
+  const handleScroll = useCallback((event: UIEvent<HTMLDListElement>) => {
+    const scrollArea = event.currentTarget;
+    if (scrollArea.dataset.scrollbarScrolling !== "true") {
+      scrollArea.dataset.scrollbarScrolling = "true";
+    }
+    if (scrollbarIdleTimeoutRef.current !== null) {
+      window.clearTimeout(scrollbarIdleTimeoutRef.current);
+    }
+    scrollbarIdleTimeoutRef.current = window.setTimeout(() => {
+      scrollbarIdleTimeoutRef.current = null;
+      scrollArea.removeAttribute("data-scrollbar-scrolling");
+    }, INFO_SCROLLBAR_IDLE_DELAY_MS);
+  }, []);
+
   return (
     <DetailCard
       appearance="flat"
-      className="min-h-0 flex-1 gap-1.5 overflow-x-hidden overflow-y-auto px-4 py-3"
+      className="transient-scrollbar min-h-0 flex-1 gap-1.5 overflow-x-hidden overflow-y-auto px-4 py-3"
+      onScroll={handleScroll}
     >
       {children}
     </DetailCard>

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.collapseControl.test.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.collapseControl.test.tsx
@@ -772,6 +772,14 @@ describe("ThreadSecondaryPanel full-screen control", () => {
       </Wrapper>,
     );
 
+    expect(screen.getByRole("button", { name: "Open new tab" })).not.toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Open new tab in this pane" }),
+    ).toBeNull();
+    expect(
+      document.querySelectorAll("[data-new-tab-control-reserved]"),
+    ).toHaveLength(0);
+
     const control = screen.getByRole("button", { name: "Maximize pane" });
     fireEvent.focus(control);
     expect(
@@ -815,11 +823,41 @@ describe("ThreadSecondaryPanel full-screen control", () => {
     ).toHaveLength(1);
     expect(document.querySelectorAll("header")).toHaveLength(0);
     const newTabControls = screen.getAllByRole("button", {
-      name: "Open new tab",
+      name: "Open new tab in this pane",
     });
     expect(newTabControls).toHaveLength(1);
-    fireEvent.click(newTabControls[0] as HTMLElement);
+    expect(
+      document.querySelectorAll("[data-new-tab-control-reserved]"),
+    ).toHaveLength(1);
+    const initiallyFocusedPane = panes.find(
+      (pane) => pane.dataset.focused === "true",
+    );
+    const initiallyInactivePane = panes.find(
+      (pane) => pane.dataset.focused === "false",
+    );
+    expect(
+      initiallyFocusedPane?.querySelector(
+        'button[aria-label^="Open new tab in this pane"]',
+      ),
+    ).not.toBeNull();
+    expect(
+      initiallyInactivePane?.querySelector("[data-new-tab-control-reserved]"),
+    ).not.toBeNull();
+
+    fireEvent.pointerDown(initiallyInactivePane as HTMLElement);
+    const focusedPaneNewTabControl = screen.getByRole("button", {
+      name: "Open new tab in this pane",
+    });
+    expect(
+      focusedPaneNewTabControl.closest("[data-split-pane-id]"),
+    ).toBe(initiallyInactivePane);
+    expect(
+      initiallyFocusedPane?.querySelector("[data-new-tab-control-reserved]"),
+    ).not.toBeNull();
+    fireEvent.click(focusedPaneNewTabControl);
     expect(onOpenNewTab).toHaveBeenCalledTimes(1);
+    expect(initiallyInactivePane?.dataset.focused).toBe("true");
+    expect(initiallyFocusedPane?.dataset.focused).toBe("false");
   });
 
   it("maximizes one stacked pane while keeping both tab rows mounted", () => {

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.collapseControl.test.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.collapseControl.test.tsx
@@ -724,6 +724,7 @@ describe("ThreadSecondaryPanel full-screen control", () => {
 
     const control = view.getByRole("button", { name: "Exit Full Screen" });
     expect(control.getAttribute("aria-pressed")).toBe("true");
+    expect(document.querySelector("aside")?.style.width).toBe("100%");
 
     fireEvent.click(control);
     expect(onToggleConversationCollapse).toHaveBeenCalledTimes(1);
@@ -771,7 +772,7 @@ describe("ThreadSecondaryPanel full-screen control", () => {
       </Wrapper>,
     );
 
-    const control = screen.getByRole("button", { name: "Full Screen" });
+    const control = screen.getByRole("button", { name: "Maximize pane" });
     fireEvent.focus(control);
     expect(
       screen.getByRole("menu", { name: "Pane arrangement" }),
@@ -803,6 +804,15 @@ describe("ThreadSecondaryPanel full-screen control", () => {
         pane.querySelector('[data-testid="thread-secondary-panel-top-chrome"]'),
       ),
     ).toBe(true);
+    expect(
+      screen.getAllByRole("button", { name: "Maximize pane" }),
+    ).toHaveLength(2);
+    expect(
+      screen.getAllByRole("button", { name: "Remove split" }),
+    ).toHaveLength(2);
+    expect(
+      screen.getAllByRole("button", { name: "Hide right panel" }),
+    ).toHaveLength(1);
     expect(document.querySelectorAll("header")).toHaveLength(0);
     const newTabControls = screen.getAllByRole("button", {
       name: "Open new tab",
@@ -812,7 +822,7 @@ describe("ThreadSecondaryPanel full-screen control", () => {
     expect(onOpenNewTab).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps pane-local tab rows and one restore control in a stacked split", () => {
+  it("maximizes one stacked pane while keeping both tab rows mounted", () => {
     const { wrapper: Wrapper } = createQueryClientTestHarness();
     const fileTab = createWorkspaceFilePreviewFixedPanelTab({
       environmentId: "env-test",
@@ -871,7 +881,7 @@ describe("ThreadSecondaryPanel full-screen control", () => {
     );
 
     const restoreControls = screen.getAllByRole("button", {
-      name: "Exit Full Screen",
+      name: "Restore split",
     });
     expect(restoreControls).toHaveLength(1);
     const panes = Array.from(
@@ -895,23 +905,30 @@ describe("ThreadSecondaryPanel full-screen control", () => {
           ).length,
       ),
     ).toEqual([1, 1]);
-    expect(
-      screen
-        .getByRole("separator", {
-          name: "Resize stacked right panel panes",
-        })
-        .getAttribute("aria-orientation"),
-    ).toBe("horizontal");
+    const separator = document.querySelector<HTMLElement>(
+      '[aria-label="Resize stacked right panel panes"]',
+    );
+    expect(separator?.getAttribute("aria-orientation")).toBe("horizontal");
+    expect(separator?.getAttribute("aria-hidden")).toBe("true");
+    expect(separator?.className).toContain("invisible");
     expect(
       panes.map(
-        (pane) =>
-          pane.querySelectorAll('[aria-label="Exit Full Screen"]').length,
+        (pane) => pane.querySelectorAll('[aria-label="Restore split"]').length,
       ),
-    ).toEqual([1, 0]);
+    ).toEqual([0, 1]);
+    expect(panes[0]?.getAttribute("aria-hidden")).toBe("true");
+    expect(panes[0]?.style.contentVisibility).toBe("hidden");
+    expect(panes[1]?.dataset.maximized).toBe("true");
     const restoreControl = restoreControls[0];
     if (restoreControl === undefined)
       throw new Error("Missing restore control");
     fireEvent.click(restoreControl);
     expect(onToggleConversationCollapse).toHaveBeenCalledTimes(1);
+    expect(
+      panes.every((pane) => pane.getAttribute("aria-hidden") === null),
+    ).toBe(true);
+    expect(
+      document.querySelector('[data-split-pane-id][data-maximized="true"]'),
+    ).toBeNull();
   });
 });

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
@@ -567,6 +567,7 @@ export function ThreadSecondaryPanel({
     onSurfaceTabReorder: SecondaryPanelTabReorderHandler;
     paneId: string | null;
     reserveLeadingChrome: boolean;
+    reserveNewTabControl: boolean;
     showNewTabControl: boolean;
     showOuterControls: boolean;
     usesPaneArrangementControl: boolean;
@@ -582,7 +583,9 @@ export function ThreadSecondaryPanel({
       tabId: string,
       event: ReactPointerEvent<HTMLElement>,
     ) => void;
+    newTabAriaLabel: string;
     onSurfaceTabReorder: SecondaryPanelTabReorderHandler;
+    reserveNewTabButton: boolean;
     showNewTabButton: boolean;
   }
 
@@ -687,8 +690,10 @@ export function ThreadSecondaryPanel({
     activeSurfaceTabId,
     surfaceTabs,
     fixedSurfaceTabs,
+    newTabAriaLabel,
     onBeginTabDrag,
     onSurfaceTabReorder,
+    reserveNewTabButton,
     showNewTabButton: showGroupNewTabButton,
   }: PanelTabGroupArgs) => {
     const activeSurfaceTab = surfaceTabs.find(
@@ -742,9 +747,19 @@ export function ThreadSecondaryPanel({
         ) : null}
         {showGroupNewTabButton ? (
           <NewTabButton
+            ariaLabel={newTabAriaLabel}
             onOpenNewTab={onOpenNewTab}
             shortcut={newTabShortcut}
             usesDesktopChrome={usesDesktopChrome}
+          />
+        ) : reserveNewTabButton ? (
+          <div
+            aria-hidden
+            data-new-tab-control-reserved=""
+            className={cn(
+              SECONDARY_PANEL_CHROME_ICON_BUTTON_CLASS,
+              usesDesktopChrome && MACOS_WINDOW_NO_DRAG_CLASS,
+            )}
           />
         ) : null}
       </>
@@ -767,6 +782,7 @@ export function ThreadSecondaryPanel({
     onSurfaceTabReorder,
     paneId,
     reserveLeadingChrome,
+    reserveNewTabControl,
     showNewTabControl,
     showOuterControls,
     usesPaneArrangementControl,
@@ -837,8 +853,13 @@ export function ThreadSecondaryPanel({
                 activeSurfaceTabId,
                 surfaceTabs,
                 fixedSurfaceTabs,
+                newTabAriaLabel:
+                  onRemoveSplit === undefined
+                    ? "Open new tab"
+                    : "Open new tab in this pane",
                 onBeginTabDrag,
                 onSurfaceTabReorder,
+                reserveNewTabButton: reserveNewTabControl,
                 showNewTabButton: showNewTabControl,
               })}
             </div>
@@ -1020,6 +1041,7 @@ export function ThreadSecondaryPanel({
       tabs={splitTabs}
       renderPane={(pane: SidebarSplitPaneRenderArgs) => {
         const activePaneTabId = pane.group.activeTabId;
+        const isSplitPane = pane.onRemoveSplit !== undefined;
         const paneTabs = resolveSplitPaneTabs(pane);
         const paneFixedTabs = fixedTabs
           .filter((fixedTab) => pane.group.tabIds.includes(fixedTab.tab.id))
@@ -1049,7 +1071,10 @@ export function ThreadSecondaryPanel({
           onSurfaceTabReorder: pane.onReorderTab,
           paneId: pane.paneId,
           reserveLeadingChrome: pane.isTopRow && pane.isLeftEdge,
-          showNewTabControl: pane.showOuterControls && showNewTabButton,
+          reserveNewTabControl:
+            isSplitPane && !pane.isFocused && showNewTabButton,
+          showNewTabControl:
+            (!isSplitPane || pane.isFocused) && showNewTabButton,
           showOuterControls: pane.showOuterControls,
           usesPaneArrangementControl: true,
           usesWindowChrome: pane.isTopRow,
@@ -1068,6 +1093,7 @@ export function ThreadSecondaryPanel({
       onSurfaceTabReorder: onTabReorder,
       paneId: null,
       reserveLeadingChrome: true,
+      reserveNewTabControl: false,
       showNewTabControl: showNewTabButton,
       showOuterControls: true,
       usesPaneArrangementControl: false,
@@ -1207,6 +1233,7 @@ export function ThreadSecondaryPanel({
 }
 
 interface NewTabButtonProps {
+  ariaLabel: string;
   onOpenNewTab: () => void;
   shortcut: AppShortcutPresentation | null;
   usesDesktopChrome: boolean;
@@ -1265,6 +1292,7 @@ function PinnedIconTab({
 }
 
 function NewTabButton({
+  ariaLabel,
   onOpenNewTab,
   shortcut,
   usesDesktopChrome,
@@ -1279,9 +1307,7 @@ function NewTabButton({
         usesDesktopChrome && MACOS_WINDOW_NO_DRAG_CLASS,
       )}
       onClick={onOpenNewTab}
-      aria-label={
-        shortcut ? `Open new tab (${shortcut.label})` : "Open new tab"
-      }
+      aria-label={shortcut ? `${ariaLabel} (${shortcut.label})` : ariaLabel}
       aria-keyshortcuts={shortcut?.ariaKeyshortcuts}
     >
       <Icon name="Plus" />

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
@@ -554,6 +554,7 @@ export function ThreadSecondaryPanel({
     surfaceTabs: readonly SecondaryPanelRenderableTab[];
     fixedSurfaceTabs: readonly SecondaryPanelFixedTab[];
     isFocused: boolean;
+    isFullScreen?: boolean;
     isSurfaceDiffEligibilityPending: boolean;
     onBeginTabDrag?: (
       tabId: string,
@@ -561,6 +562,7 @@ export function ThreadSecondaryPanel({
     ) => void;
     onMoveActiveTabToSide?: (side: SplitSide) => void;
     onRemoveSplit?: () => void;
+    onToggleFullScreen?: () => void;
     onFocusPane: () => void;
     onSurfaceTabReorder: SecondaryPanelTabReorderHandler;
     paneId: string | null;
@@ -630,26 +632,31 @@ export function ThreadSecondaryPanel({
     ) : null;
 
   const renderConversationCollapseButton = ({
+    isFullScreen,
     onMoveActiveTabToSide,
+    onToggleFullScreen,
     usesPaneArrangementControl,
   }: {
+    isFullScreen?: boolean;
     onMoveActiveTabToSide?: (side: SplitSide) => void;
+    onToggleFullScreen?: () => void;
     usesPaneArrangementControl: boolean;
   }) => {
-    if (conversationCollapseControl === null) return null;
     if (usesPaneArrangementControl) {
+      if (onToggleFullScreen === undefined) return null;
       return (
         <PaneArrangementButton
           className={cn(
             "shrink-0",
             usesDesktopChrome && MACOS_WINDOW_NO_DRAG_CLASS,
           )}
-          isFullScreen={conversationCollapseControl.isFullScreen}
+          isFullScreen={isFullScreen ?? false}
           onMoveToSide={onMoveActiveTabToSide}
-          onToggleFullScreen={conversationCollapseControl.onClick}
+          onToggleFullScreen={onToggleFullScreen}
         />
       );
     }
+    if (conversationCollapseControl === null) return null;
     return (
       <Tooltip>
         <TooltipTrigger asChild>
@@ -750,11 +757,13 @@ export function ThreadSecondaryPanel({
     surfaceTabs,
     fixedSurfaceTabs,
     isFocused,
+    isFullScreen,
     isSurfaceDiffEligibilityPending,
     onBeginTabDrag,
     onFocusPane,
     onMoveActiveTabToSide,
     onRemoveSplit,
+    onToggleFullScreen,
     onSurfaceTabReorder,
     paneId,
     reserveLeadingChrome,
@@ -833,14 +842,18 @@ export function ThreadSecondaryPanel({
                 showNewTabButton: showNewTabControl,
               })}
             </div>
-            {showOuterControls || onRemoveSplit ? (
+            {showOuterControls ||
+            onRemoveSplit ||
+            usesPaneArrangementControl ? (
               <div
                 className="flex min-w-0 shrink-0 items-center gap-1"
                 onPointerDown={(event) => event.stopPropagation()}
               >
-                {showOuterControls
+                {usesPaneArrangementControl || showOuterControls
                   ? renderConversationCollapseButton({
+                      isFullScreen,
                       onMoveActiveTabToSide,
+                      onToggleFullScreen,
                       usesPaneArrangementControl,
                     })
                   : null}
@@ -993,6 +1006,7 @@ export function ThreadSecondaryPanel({
     <SidebarSplitContainer
       key={splitPanelStateId}
       activeTabId={globalActiveTabId}
+      isFullScreen={isConversationCollapsed}
       onActivateTab={(tabId) => {
         const fixedTab = fixedTabs.find(
           (candidate) => candidate.tab.id === tabId,
@@ -1001,6 +1015,7 @@ export function ThreadSecondaryPanel({
         else tabs.find((tab) => tab.tab.id === tabId)?.onSelect();
       }}
       onGlobalTabReorder={onTabReorder}
+      onToggleFullScreen={onToggleConversationCollapse}
       panelStateId={splitPanelStateId}
       tabs={splitTabs}
       renderPane={(pane: SidebarSplitPaneRenderArgs) => {
@@ -1021,6 +1036,7 @@ export function ThreadSecondaryPanel({
           surfaceTabs: paneTabs,
           fixedSurfaceTabs: paneFixedTabs,
           isFocused: pane.isFocused,
+          isFullScreen: pane.isMaximized,
           isSurfaceDiffEligibilityPending:
             activePaneFixedTab?.tab.kind === "git-diff" &&
             (resolvedGitDiffTabStatus === "loading" ||
@@ -1029,6 +1045,7 @@ export function ThreadSecondaryPanel({
           onFocusPane: pane.onFocusPane,
           onMoveActiveTabToSide: pane.onMoveActiveTabToSide,
           onRemoveSplit: pane.onRemoveSplit,
+          onToggleFullScreen: pane.onToggleMaximize,
           onSurfaceTabReorder: pane.onReorderTab,
           paneId: pane.paneId,
           reserveLeadingChrome: pane.isTopRow && pane.isLeftEdge,
@@ -1091,7 +1108,13 @@ export function ThreadSecondaryPanel({
       style={
         !renderAsDrawer && !isSecondaryPanelResizing
           ? {
-              width: `var(--secondary-swipe-width, ${persistedWidthPercent}cqw)`,
+              // Full screen collapses the conversation and lifts this Panel to
+              // 100% of its host. Do not retain the ordinary persisted panel
+              // width inside that expanded shell: it leaves the tab surface at
+              // its old half-width with an empty region to the right.
+              width: isConversationCollapsed
+                ? "100%"
+                : `var(--secondary-swipe-width, ${persistedWidthPercent}cqw)`,
             }
           : undefined
       }

--- a/apps/app/src/components/secondary-panel/sidebarSplitLayout.test.ts
+++ b/apps/app/src/components/secondary-panel/sidebarSplitLayout.test.ts
@@ -24,6 +24,7 @@ import {
   resizeSidebarSplit,
   selectSidebarTab,
   serializeSidebarSplitState,
+  setSidebarPaneMaximized,
   sidebarPaneNode,
   sidebarSplitStorageKey,
   type SidebarSplitState,
@@ -71,6 +72,7 @@ function persistedStateWithPaneCount(count: number): SidebarSplitState {
       },
       focusedPaneId: "pane-0",
     },
+    maximizedPaneId: null,
   };
 }
 
@@ -106,18 +108,54 @@ describe("sidebar split layout", () => {
     ).toEqual(TABS);
   });
 
-  it("continues to parse the original raw v1 state", () => {
+  it("parses raw v1 states written both with and without maximize state", () => {
     const split = splitOff(
       createSidebarSplitState(TABS, SIDEBAR_FIXED_INFO_TAB_ID),
       "file-a",
     );
-    const parsed = parseSidebarSplitState(
+    const withoutMaximize = parseSidebarSplitState(
+      JSON.stringify(
+        Object.fromEntries(
+          Object.entries(split).filter(([key]) => key !== "maximizedPaneId"),
+        ),
+      ),
+      TABS,
+      SIDEBAR_FIXED_INFO_TAB_ID,
+    );
+    const withNullMaximize = parseSidebarSplitState(
       JSON.stringify({ ...split, maximizedPaneId: null }),
       TABS,
       SIDEBAR_FIXED_INFO_TAB_ID,
     );
-    expect(parsed).toEqual(split);
-    expect(parsed).not.toHaveProperty("maximizedPaneId");
+    expect(withoutMaximize).toEqual(split);
+    expect(withNullMaximize).toEqual(split);
+  });
+
+  it("restores a valid maximized pane and clears only a stale maximize id", () => {
+    const split = splitOff(
+      createSidebarSplitState(TABS, SIDEBAR_FIXED_INFO_TAB_ID),
+      "file-a",
+    );
+    const maximized = setSidebarPaneMaximized(
+      split,
+      split.layout.focusedPaneId,
+    );
+    expect(
+      parseSidebarSplitState(
+        serializeSidebarSplitState(maximized),
+        TABS,
+        SIDEBAR_FIXED_INFO_TAB_ID,
+      ),
+    ).toEqual(maximized);
+
+    const stale = parseSidebarSplitState(
+      JSON.stringify({ ...maximized, maximizedPaneId: "pane-missing" }),
+      TABS,
+      SIDEBAR_FIXED_INFO_TAB_ID,
+    );
+    expect(stale.layout).toEqual(split.layout);
+    expect(stale.groups).toEqual(split.groups);
+    expect(stale.maximizedPaneId).toBeNull();
   });
 
   it("preserves state identity for no-op reconciliation, selection, and focus", () => {
@@ -504,6 +542,56 @@ describe("sidebar split layout", () => {
     expect(removeSidebarSplit(state, "pane-missing")).toBe(state);
   });
 
+  it("clears maximize state when removing a split leaves one pane", () => {
+    const split = splitOff(
+      createSidebarSplitState(TABS, SIDEBAR_FIXED_INFO_TAB_ID),
+      "file-a",
+    );
+    const maximized = setSidebarPaneMaximized(
+      split,
+      split.layout.focusedPaneId,
+    );
+
+    const unsplit = removeSidebarSplit(
+      maximized,
+      maximized.layout.focusedPaneId,
+    );
+
+    expect(countPanes(unsplit.layout.root)).toBe(1);
+    expect(unsplit.maximizedPaneId).toBeNull();
+  });
+
+  it("carries maximize state to the focused survivor during reconciliation", () => {
+    let state = splitOff(
+      createSidebarSplitState(TABS, SIDEBAR_FIXED_INFO_TAB_ID),
+      "file-a",
+    );
+    const source = listPanes(state.layout.root).find((pane) =>
+      getSidebarGroupForPane(state, pane.paneId)?.tabIds.includes(
+        SIDEBAR_FIXED_DIFF_TAB_ID,
+      ),
+    );
+    expect(source).toBeDefined();
+    if (source === undefined) return;
+    state = moveSidebarTab(
+      state,
+      source.paneId,
+      SIDEBAR_FIXED_DIFF_TAB_ID,
+      { paneId: source.paneId, zone: "bottom" },
+      { groupId: "group-diff" },
+    );
+    state = setSidebarPaneMaximized(state, state.layout.focusedPaneId);
+
+    const reconciled = reconcileSidebarSplitState(
+      state,
+      [SIDEBAR_FIXED_INFO_TAB_ID, "file-a"],
+      "file-a",
+    );
+
+    expect(countPanes(reconciled.layout.root)).toBe(2);
+    expect(reconciled.maximizedPaneId).toBe(reconciled.layout.focusedPaneId);
+  });
+
   it("moves panes through the shared split operations", () => {
     const split = splitOff(
       createSidebarSplitState(TABS, SIDEBAR_FIXED_INFO_TAB_ID),
@@ -517,7 +605,7 @@ describe("sidebar split layout", () => {
     if (sourcePaneId === undefined || targetPaneId === undefined) return;
 
     const moved = moveSidebarPaneToSide(
-      split,
+      setSidebarPaneMaximized(split, sourcePaneId),
       sourcePaneId,
       targetPaneId,
       "top",
@@ -525,6 +613,7 @@ describe("sidebar split layout", () => {
     expect(moved.layout.root.type).toBe("split");
     if (moved.layout.root.type !== "split") return;
     expect(moved.layout.root.dir).toBe("col");
+    expect(moved.maximizedPaneId).toBe(sourcePaneId);
   });
 
   it("uses the existing split cap and clamps divider fractions", () => {

--- a/apps/app/src/components/secondary-panel/sidebarSplitLayout.ts
+++ b/apps/app/src/components/secondary-panel/sidebarSplitLayout.ts
@@ -50,6 +50,7 @@ export interface SidebarSplitState {
   version: typeof SIDEBAR_SPLIT_LAYOUT_STORAGE_VERSION;
   groups: Record<string, SidebarTabGroup>;
   layout: SplitLayout;
+  maximizedPaneId: string | null;
 }
 
 interface SidebarSplitIds {
@@ -99,6 +100,7 @@ export function createSidebarSplitState(
       root: sidebarPaneNode(ids.paneId, ids.groupId),
       focusedPaneId: ids.paneId,
     },
+    maximizedPaneId: null,
   };
 }
 
@@ -143,6 +145,7 @@ function areSidebarSplitStatesEqual(
   if (
     first.version !== second.version ||
     first.layout.focusedPaneId !== second.layout.focusedPaneId ||
+    first.maximizedPaneId !== second.maximizedPaneId ||
     !areStringArraysEqual(firstGroupIds, secondGroupIds) ||
     !areLayoutNodesEqual(first.layout.root, second.layout.root)
   ) {
@@ -208,7 +211,12 @@ export function selectSidebarTab(
   ) {
     return state;
   }
-  if (group.activeTabId === tabId && state.layout.focusedPaneId === paneId) {
+  const maximizedPaneId = state.maximizedPaneId === null ? null : paneId;
+  if (
+    group.activeTabId === tabId &&
+    state.layout.focusedPaneId === paneId &&
+    state.maximizedPaneId === maximizedPaneId
+  ) {
     return state;
   }
   return {
@@ -218,6 +226,7 @@ export function selectSidebarTab(
       [groupId]: { ...group, activeTabId: tabId },
     },
     layout: setFocus(state.layout, paneId),
+    maximizedPaneId,
   };
 }
 
@@ -226,12 +235,17 @@ export function focusSidebarPane(
   paneId: string,
 ): SidebarSplitState {
   if (findPane(state.layout.root, paneId) === null) return state;
-  if (state.layout.focusedPaneId === paneId) {
+  const maximizedPaneId = state.maximizedPaneId === null ? null : paneId;
+  if (
+    state.layout.focusedPaneId === paneId &&
+    state.maximizedPaneId === maximizedPaneId
+  ) {
     return state;
   }
   return {
     ...state,
     layout: setFocus(state.layout, paneId),
+    maximizedPaneId,
   };
 }
 
@@ -336,6 +350,10 @@ export function moveSidebarTab(
         ...state,
         groups,
         layout: setFocus(layout, target.paneId),
+        maximizedPaneId:
+          countPanes(layout.root) > 1 && state.maximizedPaneId !== null
+            ? target.paneId
+            : null,
       };
     }
     const remainingTabs = sourceGroup.tabIds.filter((id) => id !== tabId);
@@ -351,6 +369,7 @@ export function moveSidebarTab(
       ...state,
       groups,
       layout: setFocus(state.layout, target.paneId),
+      maximizedPaneId: state.maximizedPaneId === null ? null : target.paneId,
     };
   }
 
@@ -367,6 +386,12 @@ export function moveSidebarTab(
   if (state.groups[ids.groupId] !== undefined) return state;
 
   const remainingTabs = sourceGroup.tabIds.filter((id) => id !== tabId);
+  const layout = splitPane(
+    state.layout,
+    target.paneId,
+    target.zone,
+    groupContent(ids.groupId),
+  );
   return {
     ...state,
     groups: {
@@ -385,12 +410,11 @@ export function moveSidebarTab(
         activeTabId: tabId,
       },
     },
-    layout: splitPane(
-      state.layout,
-      target.paneId,
-      target.zone,
-      groupContent(ids.groupId),
-    ),
+    layout,
+    maximizedPaneId:
+      state.maximizedPaneId === sourcePaneId
+        ? layout.focusedPaneId
+        : state.maximizedPaneId,
   };
 }
 
@@ -413,7 +437,20 @@ function removeEmptySidebarPane(
 
   const groups = { ...state.groups };
   delete groups[closedGroupId];
-  return { ...state, groups, layout: removePane(state.layout, paneId) };
+  const layout = removePane(state.layout, paneId);
+  return {
+    ...state,
+    groups,
+    layout,
+    maximizedPaneId:
+      state.maximizedPaneId === paneId
+        ? countPanes(layout.root) > 1
+          ? layout.focusedPaneId
+          : null
+        : countPanes(layout.root) > 1
+          ? state.maximizedPaneId
+          : null,
+  };
 }
 
 /**
@@ -456,7 +493,57 @@ export function removeSidebarSplit(
       ? removedGroup.activeTabId
       : survivorGroup.activeTabId,
   };
-  return { ...state, groups, layout };
+  return {
+    ...state,
+    groups,
+    layout,
+    maximizedPaneId:
+      state.maximizedPaneId === paneId
+        ? countPanes(layout.root) > 1
+          ? layout.focusedPaneId
+          : null
+        : countPanes(layout.root) > 1
+          ? state.maximizedPaneId
+          : null,
+  };
+}
+
+export function setSidebarPaneMaximized(
+  state: SidebarSplitState,
+  paneId: string | null,
+): SidebarSplitState {
+  if (paneId === null) {
+    return state.maximizedPaneId === null
+      ? state
+      : { ...state, maximizedPaneId: null };
+  }
+  if (
+    countPanes(state.layout.root) < 2 ||
+    findPane(state.layout.root, paneId) === null
+  ) {
+    return state;
+  }
+  if (
+    state.maximizedPaneId === paneId &&
+    state.layout.focusedPaneId === paneId
+  ) {
+    return state;
+  }
+  return {
+    ...state,
+    layout: setFocus(state.layout, paneId),
+    maximizedPaneId: paneId,
+  };
+}
+
+export function toggleSidebarPaneMaximize(
+  state: SidebarSplitState,
+  paneId: string,
+): SidebarSplitState {
+  return setSidebarPaneMaximized(
+    state,
+    state.maximizedPaneId === paneId ? null : paneId,
+  );
 }
 
 export function moveSidebarPaneToSide(
@@ -577,6 +664,16 @@ export function reconcileSidebarSplitState(
       };
     }
   }
+  if (
+    next.maximizedPaneId !== null &&
+    findPane(next.layout.root, next.maximizedPaneId) === null
+  ) {
+    next = {
+      ...next,
+      maximizedPaneId:
+        countPanes(next.layout.root) > 1 ? next.layout.focusedPaneId : null,
+    };
+  }
   return preserveSidebarSplitStateIdentity(state, next);
 }
 
@@ -638,8 +735,9 @@ const sidebarSplitStateSchema = z
         focusedPaneId: z.string().min(1),
       })
       .strict(),
-    // Layouts written by the original implementation always included this
-    // unused field. Accept and discard it while reading existing v1 storage.
+    // Both the original split implementation and current layouts use this v1
+    // field. The intervening implementation omitted it, so absence means the
+    // preserved tree is restored without a maximized pane.
     maximizedPaneId: z.string().min(1).nullable().optional(),
   })
   .strict()
@@ -718,13 +816,17 @@ const sidebarSplitStateSchema = z
       }
     }
   })
-  .transform(
-    (storedState): SidebarSplitState => ({
-      version: storedState.version,
-      groups: storedState.groups,
-      layout: storedState.layout,
-    }),
-  );
+  .transform((storedState): SidebarSplitState => ({
+    version: storedState.version,
+    groups: storedState.groups,
+    layout: storedState.layout,
+    maximizedPaneId:
+      storedState.maximizedPaneId !== undefined &&
+      storedState.maximizedPaneId !== null &&
+      findPane(storedState.layout.root, storedState.maximizedPaneId) !== null
+        ? storedState.maximizedPaneId
+        : null,
+  }));
 
 export function sidebarSplitStorageKey(panelStateId: string): string {
   return `${SIDEBAR_SPLIT_LAYOUT_STORAGE_PREFIX}.${panelStateId}`;

--- a/apps/app/src/components/ui/detail-card.tsx
+++ b/apps/app/src/components/ui/detail-card.tsx
@@ -1,4 +1,8 @@
-import { type CSSProperties, type ReactNode } from "react";
+import {
+  type CSSProperties,
+  type ReactNode,
+  type UIEventHandler,
+} from "react";
 import { Icon, type IconName } from "@bb/shared-ui/icon";
 import { cn } from "@bb/shared-ui/lib/utils";
 
@@ -49,6 +53,7 @@ type DetailCardAppearance = "card" | "flat";
 interface DetailCardProps {
   children: ReactNode;
   className?: string;
+  onScroll?: UIEventHandler<HTMLDListElement>;
   /**
    * Width of the label column. Applied as a CSS custom property so descendant
    * rows inherit it without prop drilling. Defaults to 96px.
@@ -69,11 +74,13 @@ const DETAIL_CARD_CARD_CLASS =
 export function DetailCard({
   children,
   className,
+  onScroll,
   labelWidth,
   appearance = "card",
 }: DetailCardProps) {
   return (
     <dl
+      onScroll={onScroll}
       className={cn(
         DETAIL_CARD_BASE_CLASS,
         appearance === "card" && DETAIL_CARD_CARD_CLASS,

--- a/apps/app/src/components/ui/hooks/use-hover-popover.ts
+++ b/apps/app/src/components/ui/hooks/use-hover-popover.ts
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { usePointerCoarse } from "@bb/shared-ui/hooks/use-pointer-coarse";
 
 interface HoverPopoverHandlers {
+  onBlur: () => void;
+  onFocus: () => void;
   onPointerEnter: () => void;
   onPointerLeave: () => void;
   onOpenAutoFocus?: (event: Event) => void;
@@ -29,11 +31,15 @@ const preventAutoFocus = (event: Event) => {
 };
 
 const EMPTY_HOVER_PROPS: HoverPopoverHandlers = {
+  onBlur: noop,
+  onFocus: noop,
   onPointerEnter: noop,
   onPointerLeave: noop,
 };
 
 const NON_HOVERABLE_CONTENT_PROPS: HoverPopoverHandlers = {
+  onBlur: noop,
+  onFocus: noop,
   onPointerEnter: noop,
   onPointerLeave: noop,
   // Hover-driven popovers should not steal or restore focus.
@@ -48,6 +54,8 @@ export function useHoverPopover({
 }: UseHoverPopoverOptions = {}): UseHoverPopoverResult {
   const isPointerCoarse = usePointerCoarse();
   const [open, setOpen] = useState(false);
+  const [isFocusOverTrigger, setIsFocusOverTrigger] = useState(false);
+  const [isFocusOverContent, setIsFocusOverContent] = useState(false);
   const [isPointerOverTrigger, setIsPointerOverTrigger] = useState(false);
   const [isPointerOverContent, setIsPointerOverContent] = useState(false);
   const toggleTimeoutRef = useRef<number | null>(null);
@@ -65,6 +73,11 @@ export function useHoverPopover({
     if (isPointerCoarse) return;
 
     clearToggleTimeout();
+
+    if (isFocusOverTrigger || isFocusOverContent) {
+      if (!open) setOpen(true);
+      return;
+    }
 
     if (isPointerOverTrigger || isPointerOverContent) {
       if (open) return;
@@ -93,6 +106,8 @@ export function useHoverPopover({
   }, [
     clearToggleTimeout,
     closeDelayMs,
+    isFocusOverContent,
+    isFocusOverTrigger,
     isPointerCoarse,
     isPointerOverContent,
     isPointerOverTrigger,
@@ -112,38 +127,48 @@ export function useHoverPopover({
 
       setIsPointerOverTrigger(false);
       setIsPointerOverContent(false);
+      setIsFocusOverTrigger(false);
+      setIsFocusOverContent(false);
       clearToggleTimeout();
       setOpen(false);
     },
     [clearToggleTimeout],
   );
 
-  const triggerHoverProps = isPointerCoarse
-    ? EMPTY_HOVER_PROPS
-    : {
-        onPointerEnter: () => {
-          setIsPointerOverTrigger(true);
-        },
-        onPointerLeave: () => {
-          setIsPointerOverTrigger(false);
-        },
-      };
-
-  const contentHoverProps = isPointerCoarse
-    ? EMPTY_HOVER_PROPS
-    : hoverableContent
-      ? {
+  const triggerHoverProps = {
+    ...(isPointerCoarse
+      ? EMPTY_HOVER_PROPS
+      : {
           onPointerEnter: () => {
-            setIsPointerOverContent(true);
+            setIsPointerOverTrigger(true);
           },
           onPointerLeave: () => {
-            setIsPointerOverContent(false);
+            setIsPointerOverTrigger(false);
           },
-          // Hover-driven popovers should not steal or restore focus.
-          onOpenAutoFocus: preventAutoFocus,
-          onCloseAutoFocus: preventAutoFocus,
-        }
-      : NON_HOVERABLE_CONTENT_PROPS;
+        }),
+    onFocus: () => setIsFocusOverTrigger(true),
+    onBlur: () => setIsFocusOverTrigger(false),
+  };
+
+  const contentHoverProps = {
+    ...(isPointerCoarse
+      ? EMPTY_HOVER_PROPS
+      : hoverableContent
+        ? {
+            onPointerEnter: () => {
+              setIsPointerOverContent(true);
+            },
+            onPointerLeave: () => {
+              setIsPointerOverContent(false);
+            },
+            // Hover-driven popovers should not steal or restore focus.
+            onOpenAutoFocus: preventAutoFocus,
+            onCloseAutoFocus: preventAutoFocus,
+          }
+        : NON_HOVERABLE_CONTENT_PROPS),
+    onFocus: () => setIsFocusOverContent(true),
+    onBlur: () => setIsFocusOverContent(false),
+  };
 
   return {
     open,

--- a/apps/app/src/hooks/useBrowserDimmingModal.ts
+++ b/apps/app/src/hooks/useBrowserDimmingModal.ts
@@ -2,19 +2,18 @@ import { useEffect } from "react";
 import { atom, useAtomValue, useSetAtom } from "jotai";
 
 /**
- * Count of open modals that should dim the in-app browser. The native browser
- * `WebContentsView` is an OS-level overlay that a DOM modal backdrop cannot
- * dim, so while one of these modals is open the browser view is hidden (and the
- * DOM new-tab screen shown in its place) so the backdrop covers the whole
- * panel. A count — not a boolean — keeps overlapping/nested modals correct.
+ * Count of open DOM overlays that must cover the in-app browser. The native
+ * browser `WebContentsView` is an OS-level overlay that always paints above the
+ * renderer, so dialogs, popovers, and tooltips cannot cover it with z-index.
+ * While one of these overlays is open the browser view is hidden. A count —
+ * not a boolean — keeps overlapping/nested overlays correct.
  */
 const browserDimmingModalCountAtom = atom(0);
 
 /**
- * Register a modal as browser-dimming while `active`: increments the shared
- * count on open and decrements on close/unmount.
+ * Register any renderer overlay that needs to cover the native browser view.
  */
-export function useBrowserDimmingModal(active: boolean): void {
+export function useBrowserDimmingOverlay(active: boolean): void {
   const setCount = useSetAtom(browserDimmingModalCountAtom);
   useEffect(() => {
     if (!active) {
@@ -25,7 +24,12 @@ export function useBrowserDimmingModal(active: boolean): void {
   }, [active, setCount]);
 }
 
-/** Whether any browser-dimming modal is currently open. */
+/** Shared-ui dialogs retain their existing semantic entry point. */
+export function useBrowserDimmingModal(active: boolean): void {
+  useBrowserDimmingOverlay(active);
+}
+
+/** Whether any browser-dimming overlay is currently open. */
 export function useIsBrowserDimmingModalOpen(): boolean {
   return useAtomValue(browserDimmingModalCountAtom) > 0;
 }

--- a/apps/app/src/views/thread-detail/PaneMaximizeButton.test.tsx
+++ b/apps/app/src/views/thread-detail/PaneMaximizeButton.test.tsx
@@ -8,9 +8,15 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { TooltipProvider } from "@bb/shared-ui/tooltip";
+import type { BbDesktopInfo } from "@bb/desktop-contract";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createBbDesktopApi } from "@/test/bb-desktop-test-utils";
+import { useIsBrowserDimmingModalOpen } from "@/hooks/useBrowserDimmingModal";
 import { PaneContext, type PaneContextValue } from "./PaneContext";
-import { PaneMaximizeButton } from "./PaneMaximizeButton";
+import {
+  PaneMaximizeButton,
+  resolvePaneArrangementLabel,
+} from "./PaneMaximizeButton";
 
 vi.mock("@/components/commands/AppCommandProvider", () => ({
   useAppCommandShortcut: () => ({
@@ -20,6 +26,14 @@ vi.mock("@/components/commands/AppCommandProvider", () => ({
 }));
 
 const noop = () => {};
+
+function BrowserOverlayProbe() {
+  return (
+    <span data-testid="browser-overlay-state">
+      {useIsBrowserDimmingModalOpen() ? "hidden" : "visible"}
+    </span>
+  );
+}
 
 function renderButton(
   isMaximized: boolean,
@@ -45,30 +59,40 @@ function renderButton(
     <TooltipProvider delayDuration={0}>
       <PaneContext.Provider value={value}>
         <PaneMaximizeButton />
+        <BrowserOverlayProbe />
       </PaneContext.Provider>
     </TooltipProvider>,
   );
 }
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  delete window.bbDesktop;
+});
 
 describe("PaneMaximizeButton", () => {
-  it("enters full screen immediately on the default click", () => {
+  it("renders a keyboard-focusable native button that maximizes a web pane", () => {
     const onToggle = vi.fn();
     renderButton(false, onToggle);
-    const button = screen.getByRole("button", { name: "Full Screen (⌘⇧E)" });
+    const button = screen.getByRole("button", {
+      name: "Maximize pane (⌘⇧E)",
+    });
 
     expect(button.getAttribute("aria-keyshortcuts")).toBe("Meta+Shift+E");
     expect(button.getAttribute("aria-pressed")).toBe("false");
+    button.focus();
+    expect(document.activeElement).toBe(button);
+    expect(button.tagName).toBe("BUTTON");
+    expect(button.getAttribute("type")).toBe("button");
     fireEvent.click(button);
     expect(onToggle).toHaveBeenCalledOnce();
   });
 
-  it("exits full screen on click and uses the clear tooltip copy", async () => {
+  it("restores a web split on click and uses the clear tooltip copy", async () => {
     const onToggle = vi.fn();
     renderButton(true, onToggle);
     const button = screen.getByRole("button", {
-      name: "Exit Full Screen (⌘⇧E)",
+      name: "Restore split (⌘⇧E)",
     });
     expect(button.getAttribute("aria-pressed")).toBe("true");
 
@@ -77,7 +101,7 @@ describe("PaneMaximizeButton", () => {
       expect(
         screen
           .getAllByRole("tooltip")
-          .some((tooltip) => tooltip.textContent?.includes("Exit Full Screen")),
+          .some((tooltip) => tooltip.textContent?.includes("Restore split")),
       ).toBe(true);
     });
 
@@ -88,15 +112,17 @@ describe("PaneMaximizeButton", () => {
   it("shows only BB's supported split arrangement actions on hover", async () => {
     const onMoveToSide = vi.fn();
     renderButton(false, noop, onMoveToSide);
-    const button = screen.getByRole("button", { name: "Full Screen (⌘⇧E)" });
+    const button = screen.getByRole("button", {
+      name: "Maximize pane (⌘⇧E)",
+    });
 
     fireEvent.pointerEnter(button);
     const menu = await screen.findByRole("menu", { name: "Pane arrangement" });
-    expect(menu.textContent).toContain("Full Screen");
+    expect(menu.textContent).toContain("Maximize pane");
     expect(menu.textContent).toContain("Move");
     expect(
       screen.getAllByRole("menuitem").map((item) => item.textContent),
-    ).toEqual(["Full Screen⌘⇧E", "", "", "", ""]);
+    ).toEqual(["Maximize pane⌘⇧E", "", "", "", ""]);
     for (const side of ["left", "right", "top", "bottom"]) {
       const action = screen.getByRole("menuitem", {
         name: `Move ${side}`,
@@ -107,22 +133,112 @@ describe("PaneMaximizeButton", () => {
       expect(action.className).toContain("cursor-pointer");
     }
     expect(
-      screen.getByRole("menuitem", { name: /Full Screen/ }).className,
+      screen.getByRole("menuitem", { name: /Maximize pane/ }).className,
     ).toContain("cursor-pointer");
 
     fireEvent.click(screen.getByRole("menuitem", { name: "Move left" }));
     expect(onMoveToSide).toHaveBeenCalledWith("left");
   });
 
+  it("keeps the arrangement menu open for keyboard focus and enters it with Arrow Down", async () => {
+    const onMoveToSide = vi.fn();
+    renderButton(false, noop, onMoveToSide);
+    const button = screen.getByRole("button", {
+      name: "Maximize pane (⌘⇧E)",
+    });
+
+    fireEvent.focus(button);
+    const menu = await screen.findByRole("menu", { name: "Pane arrangement" });
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    expect(menu.isConnected).toBe(true);
+
+    fireEvent.keyDown(button, { key: "ArrowDown" });
+    await waitFor(() =>
+      expect(document.activeElement).toBe(
+        screen.getByRole("menuitem", { name: /Maximize pane/ }),
+      ),
+    );
+
+    const moveBottom = screen.getByRole("menuitem", { name: "Move bottom" });
+    moveBottom.focus();
+    moveBottom.click();
+    expect(onMoveToSide).toHaveBeenCalledWith("bottom");
+  });
+
   it("keeps the menu closed while the pointer only passes over the button", async () => {
     renderButton(false);
-    const button = screen.getByRole("button", { name: "Full Screen (⌘⇧E)" });
+    const button = screen.getByRole("button", {
+      name: "Maximize pane (⌘⇧E)",
+    });
 
     fireEvent.pointerEnter(button);
     fireEvent.pointerLeave(button);
 
     await new Promise((resolve) => setTimeout(resolve, 500));
     expect(screen.queryByRole("menu", { name: "Pane arrangement" })).toBeNull();
+  });
+
+  it("preserves full-screen copy in every desktop app context", async () => {
+    const desktopInfo: BbDesktopInfo = {
+      lastCheckedAt: null,
+      latestVersion: null,
+      pendingVersion: null,
+      platform: "linux",
+      updateAvailable: false,
+      updateDownloaded: false,
+      version: "0.0.0-test",
+    };
+    window.bbDesktop = createBbDesktopApi(desktopInfo);
+    renderButton(false);
+
+    const button = screen.getByRole("button", {
+      name: "Full Screen (⌘⇧E)",
+    });
+    fireEvent.focus(button);
+    const menu = await screen.findByRole("menu", { name: "Pane arrangement" });
+    expect(
+      screen.getByRole("menuitem", { name: /Full Screen/ }),
+    ).not.toBeNull();
+    expect(menu.textContent).not.toContain("Maximize pane");
+  });
+
+  it("hides the native desktop browser while the arrangement menu can cover it", async () => {
+    const desktopInfo: BbDesktopInfo = {
+      lastCheckedAt: null,
+      latestVersion: null,
+      pendingVersion: null,
+      platform: "macos",
+      updateAvailable: false,
+      updateDownloaded: false,
+      version: "0.0.0-test",
+    };
+    window.bbDesktop = createBbDesktopApi(desktopInfo);
+    renderButton(false);
+    expect(screen.getByTestId("browser-overlay-state").textContent).toBe(
+      "visible",
+    );
+
+    const trigger = screen.getByRole("button", {
+      name: "Full Screen (⌘⇧E)",
+    });
+    fireEvent.pointerEnter(trigger);
+    const menu = await screen.findByRole("menu", {
+      name: "Pane arrangement",
+    });
+    fireEvent.pointerLeave(trigger);
+    fireEvent.pointerEnter(menu);
+    await waitFor(() =>
+      expect(screen.getByTestId("browser-overlay-state").textContent).toBe(
+        "hidden",
+      ),
+    );
+
+    fireEvent.pointerLeave(menu);
+    await waitFor(() =>
+      expect(screen.getByTestId("browser-overlay-state").textContent).toBe(
+        "visible",
+      ),
+    );
   });
 
   it("does not render outside a multi-pane workspace", () => {
@@ -147,4 +263,20 @@ describe("PaneMaximizeButton", () => {
     );
     expect(screen.queryByRole("button")).toBeNull();
   });
+});
+
+describe("resolvePaneArrangementLabel", () => {
+  it.each([
+    [false, false, "Maximize pane"],
+    [false, true, "Restore split"],
+    [true, false, "Full Screen"],
+    [true, true, "Exit Full Screen"],
+  ] as const)(
+    "resolves desktop=%s fullScreen=%s as %s",
+    (isDesktopApp, isFullScreen, expected) => {
+      expect(resolvePaneArrangementLabel({ isDesktopApp, isFullScreen })).toBe(
+        expected,
+      );
+    },
+  );
 });

--- a/apps/app/src/views/thread-detail/PaneMaximizeButton.tsx
+++ b/apps/app/src/views/thread-detail/PaneMaximizeButton.tsx
@@ -6,7 +6,11 @@ import { useAppCommandShortcut } from "@/components/commands/AppCommandProvider"
 import { HEADER_PANE_ACTION_ICON_BUTTON_CLASS } from "@/components/layout/AppPageHeader";
 import { CHROME_SUBTLE_ICON_BUTTON_FOREGROUND_CLASS } from "@bb/shared-ui/chrome-style-tokens";
 import { useHoverPopover } from "@/components/ui/hooks/use-hover-popover";
+import { useBrowserDimmingOverlay } from "@/hooks/useBrowserDimmingModal";
 import type { AppShortcutPresentation } from "@/lib/app-keybindings";
+import { getBbDesktopInfo } from "@/lib/bb-desktop";
+import type { KeyboardEvent as ReactKeyboardEvent } from "react";
+import { useRef } from "react";
 import type { SplitSide } from "@/lib/split-layout";
 import { cn } from "@bb/shared-ui/lib/utils";
 import { usePaneContext } from "./PaneContext";
@@ -30,6 +34,19 @@ const ARRANGEMENT_REGION_CLASS: Record<SplitSide, string> = {
   top: "inset-x-[3px] top-[3px] h-1.5",
   bottom: "inset-x-[3px] bottom-[3px] h-1.5",
 };
+
+export function resolvePaneArrangementLabel({
+  isDesktopApp,
+  isFullScreen,
+}: {
+  isDesktopApp: boolean;
+  isFullScreen: boolean;
+}): string {
+  if (isDesktopApp) {
+    return isFullScreen ? "Exit Full Screen" : "Full Screen";
+  }
+  return isFullScreen ? "Restore split" : "Maximize pane";
+}
 
 function ArrangementGlyph({ side }: { side: SplitSide }) {
   return (
@@ -86,9 +103,30 @@ export function PaneArrangementButton({
     handleOpenChange,
   } = useHoverPopover({ openDelayMs: 400, closeDelayMs: 100 });
 
-  const label = isFullScreen ? "Exit Full Screen" : "Full Screen";
+  const label = resolvePaneArrangementLabel({
+    isDesktopApp: getBbDesktopInfo() !== null,
+    isFullScreen,
+  });
   const accessibleLabel = shortcut ? `${label} (${shortcut.label})` : label;
   const menuOpen = !isFullScreen && hoverOpen;
+  const menuRef = useRef<HTMLDivElement>(null);
+  const focusFirstMenuItem = () => {
+    window.setTimeout(() => {
+      menuRef.current?.querySelector<HTMLElement>('[role="menuitem"]')?.focus();
+    }, 0);
+  };
+  const handleTriggerKeyDown = (
+    event: ReactKeyboardEvent<HTMLButtonElement>,
+  ) => {
+    if (event.key !== "ArrowDown" || isFullScreen) return;
+    event.preventDefault();
+    handleOpenChange(true);
+    focusFirstMenuItem();
+  };
+  // Electron's native browser WebContentsView paints above every DOM z-index.
+  // Hide it while this renderer-owned menu (and its move tooltips) is open so
+  // the full arrangement surface remains visible over a Browser tab.
+  useBrowserDimmingOverlay(menuOpen);
   const button = (
     <Button
       type="button"
@@ -104,7 +142,7 @@ export function PaneArrangementButton({
       aria-pressed={isFullScreen}
       aria-haspopup={!isFullScreen ? "menu" : undefined}
       aria-expanded={!isFullScreen ? menuOpen : undefined}
-      onFocus={!isFullScreen ? () => handleOpenChange(true) : undefined}
+      onKeyDown={handleTriggerKeyDown}
       onClick={() => {
         handleOpenChange(false);
         onToggleFullScreen();
@@ -120,7 +158,7 @@ export function PaneArrangementButton({
       <Tooltip>
         <TooltipTrigger asChild>{button}</TooltipTrigger>
         <TooltipContent side="bottom">
-          <span>Exit Full Screen</span>
+          <span>{label}</span>
           {shortcut ? ` (${shortcut.label})` : ""}
         </TooltipContent>
       </Tooltip>
@@ -131,6 +169,7 @@ export function PaneArrangementButton({
     <Popover open={menuOpen} onOpenChange={handleOpenChange}>
       <PopoverAnchor asChild>{button}</PopoverAnchor>
       <PopoverContent
+        ref={menuRef}
         role="menu"
         aria-label="Pane arrangement"
         side="bottom"
@@ -149,7 +188,7 @@ export function PaneArrangementButton({
           }}
         >
           <Icon name="Maximize2" />
-          <span className="flex-1">Full Screen</span>
+          <span className="flex-1">{label}</span>
           {shortcut ? (
             <span className="text-subtle-foreground">{shortcut.label}</span>
           ) : null}

--- a/apps/app/src/views/thread-detail/SplitThreadArea.test.tsx
+++ b/apps/app/src/views/thread-detail/SplitThreadArea.test.tsx
@@ -1374,7 +1374,7 @@ describe("SplitThreadArea", () => {
       .querySelector("button");
     expect(pluginToggle?.hasAttribute("disabled")).toBe(false);
     expect(
-      pluginPane.querySelector('button[aria-label*="Full Screen"]'),
+      pluginPane.querySelector('button[aria-label*="Maximize pane"]'),
     ).not.toBeNull();
 
     // The plugin page's hosted panel owns the open/close transition.
@@ -1552,9 +1552,9 @@ describe("SplitThreadArea", () => {
     expect(screen.getByTestId("split-workspace-panel-toggle")).toBeTruthy();
     // The app panel belongs to a publishing pane, but full screen is pane
     // chrome: every pane in a split owns it, plugin panes included.
-    expect(screen.getAllByRole("button", { name: /Full Screen/ })).toHaveLength(
-      2,
-    );
+    expect(
+      screen.getAllByRole("button", { name: /Maximize pane/ }),
+    ).toHaveLength(2);
 
     fireEvent.click(screen.getAllByRole("button", { name: "Close pane" })[0]!);
 
@@ -1967,7 +1967,9 @@ describe("SplitThreadArea", () => {
     expect(reserve?.getAttribute("aria-hidden")).toBe("true");
 
     // Full screen hides the host toggle, so the reserved slot must go with it.
-    fireEvent.click(screen.getAllByRole("button", { name: /Full Screen/ })[0]!);
+    fireEvent.click(
+      screen.getAllByRole("button", { name: /Maximize pane/ })[0]!,
+    );
     await waitFor(() =>
       expect(
         screen.getAllByRole("button", { name: "Close pane" })[0]

--- a/apps/app/src/views/thread-detail/ThreadDetailHeader.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailHeader.test.tsx
@@ -159,7 +159,9 @@ describe("ThreadDetailHeader", () => {
       </PaneContext.Provider>,
     );
 
-    expect(screen.getByRole("button", { name: /Full Screen/ })).not.toBeNull();
+    expect(
+      screen.getByRole("button", { name: /Maximize pane/ }),
+    ).not.toBeNull();
     expect(
       screen.queryByRole("button", { name: "Hide right panel" }),
     ).toBeNull();


### PR DESCRIPTION
## Summary

- Bind Info move actions to the pane that owns the control instead of the globally focused pane.
- Give tab splits real maximize/restore behavior while preserving their split layout and selection state.
- Use `Maximize pane` / `Restore split` on web and `Full Screen` / `Exit Full Screen` in desktop.
- Keep the desktop Browser's native `WebContentsView` from covering the arrangement menu and move targets.
- Show the new-tab `+` only in the focused split pane while reserving its space in inactive panes.
- Keep the Info scrollbar hidden at rest, show it during active scrolling, then hide it after 600 ms of inactivity.

Info and Diff remain fixed throughout; this layer does not make them closeable.

## Screenshot evidence

Web captures use Chrome for Testing 151.0.7922.71 at the same 1440×900 CSS viewport (DPR 2) and the same one-file `Split tab UX verification` fixture. Desktop captures use Electron 41.7.0 / Chrome 146.0.7680.216 with identical 1440×900 native window bounds and the same Browser/Info split. The before revision is exact parent head `35050edb632c1007f14978c6c5e5bfe4dd83a259`; the after revision is exact PR head `1dbfc83bd587b98968d6b0a839da9f81751ce3b9`.

### Info move ownership

Before, `Move bottom` invoked from Info moves the previously focused Diff pane instead, leaving Info above Diff.

![Before: Info move action moves the wrong pane](https://raw.githubusercontent.com/get-bb/bb/3f81b1bc1a3f1ef6c00707aef744aec97d6ec932/exact-stack-2026-08-27/pr2487-before-move-bottom-crop.png)

After, Info itself moves below Diff.

![After: Info moves below Diff in its own split](https://raw.githubusercontent.com/get-bb/bb/3f81b1bc1a3f1ef6c00707aef744aec97d6ec932/exact-stack-2026-08-27/pr2487-after-move-bottom-crop.png)

### True pane maximization

Before, activating fullscreen expands the right panel but leaves both split panes visible.

![Before: fullscreen leaves the sibling pane visible](https://raw.githubusercontent.com/get-bb/bb/3f81b1bc1a3f1ef6c00707aef744aec97d6ec932/exact-stack-2026-08-27/pr2487-before-maximize-crop.png)

After, Info fills the right workspace and the preserved Diff pane is hidden until restore.

![After: Info is maximized across the right workspace](https://raw.githubusercontent.com/get-bb/bb/3f81b1bc1a3f1ef6c00707aef744aec97d6ec932/exact-stack-2026-08-27/pr2487-after-maximize-crop.png)

### Runtime-specific copy

Before, the web arrangement menu says `Full Screen`.

![Before: web menu uses Full Screen copy](https://raw.githubusercontent.com/get-bb/bb/3f81b1bc1a3f1ef6c00707aef744aec97d6ec932/exact-stack-2026-08-27/pr2487-before-web-copy-crop.png)

After, web says `Maximize pane`.

![After: web menu uses Maximize pane copy](https://raw.githubusercontent.com/get-bb/bb/3f81b1bc1a3f1ef6c00707aef744aec97d6ec932/exact-stack-2026-08-27/pr2487-after-web-copy-crop.png)

### Focused-pane new-tab action

Before, the `+` stays in the upper Diff pane even though the lower Info pane is focused.

![Before: new-tab action stays in the wrong vertical pane](https://raw.githubusercontent.com/get-bb/bb/3f81b1bc1a3f1ef6c00707aef744aec97d6ec932/exact-stack-2026-08-27/pr2487-before-vertical-plus-crop.png)

After, the only visible `+` follows focus into the lower Info pane; the upper row keeps a reserved slot so its tabs do not shift.

![After: focused lower Info pane owns the new-tab action](https://raw.githubusercontent.com/get-bb/bb/3f81b1bc1a3f1ef6c00707aef744aec97d6ec932/exact-stack-2026-08-27/pr2487-after-vertical-plus-crop.png)

### Desktop Browser overlay

Before, the native Example Domain view paints over the renderer menu, leaving only the `Full Screen` row visible.

![Before: native Browser view clips the desktop arrangement menu](https://raw.githubusercontent.com/get-bb/bb/3f81b1bc1a3f1ef6c00707aef744aec97d6ec932/exact-stack-2026-08-27/pr2487-before-desktop-browser-menu-crop.png)

After, desktop retains `Full Screen` copy and the complete Move grid renders above the Browser surface.

![After: complete desktop arrangement menu renders above the Browser](https://raw.githubusercontent.com/get-bb/bb/3f81b1bc1a3f1ef6c00707aef744aec97d6ec932/exact-stack-2026-08-27/pr2487-after-desktop-browser-menu-crop.png)

### Info scrollbar final behavior

At rest after a completed scroll, the overflowing Info pane has no visible thumb.

![After at rest: Info scrollbar is hidden](https://raw.githubusercontent.com/get-bb/bb/3f81b1bc1a3f1ef6c00707aef744aec97d6ec932/exact-stack-2026-08-27/pr2487-after-info-scrollbar-settled-crop.png)

During active scrolling in the same layout, the thumb is visible at the right edge.

![After while scrolling: Info scrollbar is visible](https://raw.githubusercontent.com/get-bb/bb/3f81b1bc1a3f1ef6c00707aef744aec97d6ec932/exact-stack-2026-08-27/pr2487-after-info-scrollbar-active-crop.png)

## Validation

- Capture manifests record the exact revisions and environments above, identical fixtures and viewports, zero rendered error states, corrected pane order, a maximized Info pane, runtime-specific menu copy, focused-pane `+` ownership, and transparent/active scrollbar states.
- The desktop pair is a native `screencapture`, not a renderer-only image, so it includes the `WebContentsView` that caused the clipping.
- Regression coverage in this layer targets pane-bound move actions, maximize/restore persistence, keyboard menu entry, runtime copy, Browser overlay reference counting, focused-pane new-tab ownership, and the 600 ms transient-scrollbar lifecycle.
- Tests, typechecks, lint, and other CI-equivalent checks run on the pull request through GitHub Actions; none were run locally for this screenshot audit.

BB-Thread-ID: thr_q8degf2y66

> AGENT GENERATED: by GPT-5.6-Sol
