### PR TITLE
Fix Linux AppImage runtime mount lifecycle

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -165,6 +165,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --prefer-offline
 
+      - name: Install AppImage FUSE runtime
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes libfuse2
+
       - name: Typecheck desktop and launcher
         run: pnpm exec turbo run typecheck --filter=@bb/desktop --filter=bb-app --output-logs=new-only
 
@@ -183,6 +188,11 @@ jobs:
         # The packaged app opens a real BrowserWindow, so the headless runner
         # needs a virtual display.
         run: xvfb-run -a pnpm exec turbo run smoke:packaged --filter=@bb/desktop --force --output-logs=new-only
+
+      - name: Smoke test AppImage mount lifecycle
+        # Launches the generated AppImage itself, tears down only its GUI mount,
+        # and verifies the separately mounted owned runtime remains healthy.
+        run: xvfb-run -a pnpm exec turbo run smoke:appimage-lifecycle --filter=@bb/desktop --force --output-logs=new-only
 
       - name: Generate desktop version feed
         run: pnpm --dir apps/desktop run desktop:version-feed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
   package-smoke:
     name: Package Smoke (${{ matrix.os }}, Node ${{ matrix.node-version }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     strategy:
       fail-fast: false
@@ -178,6 +178,20 @@ jobs:
 
       - name: Smoke bb-app tarball
         run: pnpm exec turbo run smoke:tarball --filter=bb-app --cache-dir=.turbo/cache --output-logs=new-only
+
+      - name: Install AppImage FUSE runtime
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes libfuse2t64
+
+      - name: Package Linux AppImage
+        if: ${{ runner.os == 'Linux' }}
+        run: pnpm exec turbo run desktop:build:linux --filter=@bb/desktop --cache-dir=.turbo/cache --output-logs=new-only
+
+      - name: Smoke Linux AppImage mount lifecycle
+        if: ${{ runner.os == 'Linux' }}
+        run: xvfb-run -a pnpm exec turbo run smoke:appimage-lifecycle --filter=@bb/desktop --force --cache-dir=.turbo/cache --output-logs=new-only
 
   node-compat-smoke:
     name: Node Compatibility Smoke (${{ matrix.os }}, Node ${{ matrix.node-version }})

--- a/.github/workflows/publish-bb-app.yml
+++ b/.github/workflows/publish-bb-app.yml
@@ -665,6 +665,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --prefer-offline
 
+      - name: Install AppImage FUSE runtime
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes libfuse2
+
       - name: Apply the nightly version
         id: nightly_version
         env:
@@ -702,6 +707,11 @@ jobs:
         # The packaged app opens a real BrowserWindow, so the headless runner
         # needs a virtual display.
         run: xvfb-run -a pnpm exec turbo run smoke:packaged --filter=@bb/desktop --force --output-logs=new-only
+
+      - name: Smoke test nightly AppImage mount lifecycle
+        # Launches the generated AppImage itself, tears down only its GUI mount,
+        # and verifies the separately mounted owned runtime remains healthy.
+        run: xvfb-run -a pnpm exec turbo run smoke:appimage-lifecycle --filter=@bb/desktop --force --output-logs=new-only
 
       - name: Generate nightly desktop version feed
         run: pnpm --dir apps/desktop run desktop:version-feed

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -20,6 +20,7 @@
     "package": "pnpm run prepare-runtime && pnpm run build && node scripts/run-electron-builder.mjs --mac --dir --arm64",
     "package:linux": "pnpm run prepare-runtime && pnpm run build && node scripts/run-electron-builder.mjs --linux --dir --x64",
     "prepare-runtime": "pnpm exec turbo run build --filter=bb-app --output-logs=new-only",
+    "smoke:appimage-lifecycle": "node scripts/smoke-linux-appimage-lifecycle.mjs",
     "smoke:packaged": "node scripts/smoke-packaged-app.mjs",
     "start": "pnpm run package && node scripts/run-packaged-app.mjs",
     "start:linux": "pnpm run package:linux && node scripts/run-packaged-app.mjs",

--- a/apps/desktop/scripts/smoke-linux-appimage-lifecycle.mjs
+++ b/apps/desktop/scripts/smoke-linux-appimage-lifecycle.mjs
@@ -1,0 +1,572 @@
+import { execFile, spawn } from "node:child_process";
+import { createServer } from "node:net";
+import { mkdtemp, readFile, readdir, readlink, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const desktopPackageRoot = resolve(scriptDirectory, "..");
+const releaseDir = join(desktopPackageRoot, "release");
+const startupTimeoutMs = 60_000;
+const exitTimeoutMs = 10_000;
+const pollIntervalMs = 100;
+const maxCapturedOutputCharacters = 20_000;
+
+function appendOutput(chunks, chunk) {
+  chunks.push(String(chunk));
+  let totalLength = chunks.reduce((total, value) => total + value.length, 0);
+  while (totalLength > maxCapturedOutputCharacters && chunks.length > 1) {
+    const removed = chunks.shift();
+    totalLength -= removed.length;
+  }
+}
+
+function formatProcessOutput({ stdout, stderr }) {
+  const stdoutText = stdout.join("").trim();
+  const stderrText = stderr.join("").trim();
+  return [
+    stdoutText.length > 0 ? `stdout:\n${stdoutText}` : "",
+    stderrText.length > 0 ? `stderr:\n${stderrText}` : "",
+  ]
+    .filter((part) => part.length > 0)
+    .join("\n\n");
+}
+
+async function sleep(delayMs) {
+  await new Promise((resolvePromise) => {
+    setTimeout(resolvePromise, delayMs);
+  });
+}
+
+async function waitFor({
+  describe,
+  predicate,
+  retryErrors = true,
+  timeoutMs = startupTimeoutMs,
+}) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError = null;
+  while (Date.now() <= deadline) {
+    try {
+      const result = await predicate();
+      if (result !== false && result !== null && result !== undefined) {
+        return result;
+      }
+    } catch (error) {
+      if (!retryErrors) {
+        throw error;
+      }
+      lastError = error;
+    }
+    await sleep(pollIntervalMs);
+  }
+
+  const detail =
+    lastError instanceof Error ? ` Last error: ${lastError.message}` : "";
+  throw new Error(`Timed out waiting for ${describe}.${detail}`);
+}
+
+async function allocateTcpPort() {
+  const server = createServer();
+  await new Promise((resolvePromise, rejectPromise) => {
+    server.once("error", rejectPromise);
+    server.listen(0, "127.0.0.1", resolvePromise);
+  });
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("Expected an ephemeral TCP listener");
+  }
+  await new Promise((resolvePromise, rejectPromise) => {
+    server.close((error) => {
+      if (error) {
+        rejectPromise(error);
+        return;
+      }
+      resolvePromise();
+    });
+  });
+  return address.port;
+}
+
+async function resolveAppImage() {
+  const entries = await readdir(releaseDir, { withFileTypes: true });
+  const appImages = entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".AppImage"))
+    .map((entry) => join(releaseDir, entry.name))
+    .sort();
+  if (appImages.length !== 1) {
+    throw new Error(
+      `Expected exactly one AppImage under ${releaseDir}, found ${String(
+        appImages.length,
+      )}`,
+    );
+  }
+  return appImages[0];
+}
+
+function parseProcessStat(stat) {
+  const fields = stat.slice(stat.lastIndexOf(")") + 2).split(" ");
+  return {
+    processGroupId: Number(fields[2]),
+    state: fields[0] ?? "",
+  };
+}
+
+function parseProcessEnvironment(rawEnvironment) {
+  const entries = rawEnvironment
+    .split("\0")
+    .filter((entry) => entry.length > 0);
+  return Object.fromEntries(
+    entries.map((entry) => {
+      const separatorIndex = entry.indexOf("=");
+      if (separatorIndex === -1) {
+        return [entry, ""];
+      }
+      return [entry.slice(0, separatorIndex), entry.slice(separatorIndex + 1)];
+    }),
+  );
+}
+
+async function readProcess(pid) {
+  try {
+    const [stat, command, environment, executablePath] = await Promise.all([
+      readFile(`/proc/${String(pid)}/stat`, "utf8"),
+      readFile(`/proc/${String(pid)}/cmdline`, "utf8"),
+      readFile(`/proc/${String(pid)}/environ`, "utf8"),
+      readlink(`/proc/${String(pid)}/exe`),
+    ]);
+    return {
+      command: command.split("\0").filter((part) => part.length > 0),
+      environment: parseProcessEnvironment(environment),
+      executablePath,
+      pid,
+      ...parseProcessStat(stat),
+    };
+  } catch (error) {
+    if (
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      (error.code === "EACCES" ||
+        error.code === "ENOENT" ||
+        error.code === "EPERM" ||
+        error.code === "ESRCH")
+    ) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function processIsLive(pid) {
+  const processInfo = await readProcess(pid);
+  return processInfo !== null && processInfo.state !== "Z";
+}
+
+async function findProcessesExecutingFromMount(mountPath) {
+  const entries = await readdir("/proc", { withFileTypes: true });
+  const processes = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory() || !/^\d+$/u.test(entry.name)) {
+      continue;
+    }
+    const processInfo = await readProcess(Number(entry.name));
+    if (
+      processInfo !== null &&
+      processInfo.state !== "Z" &&
+      (processInfo.executablePath === mountPath ||
+        processInfo.executablePath.startsWith(`${mountPath}/`))
+    ) {
+      processes.push(processInfo);
+    }
+  }
+  return processes;
+}
+
+async function killProcessesExecutingFromMount(mountPath) {
+  const mountProcesses = await findProcessesExecutingFromMount(mountPath);
+  for (const processInfo of mountProcesses) {
+    try {
+      process.kill(processInfo.pid, "SIGKILL");
+    } catch (error) {
+      if (
+        typeof error !== "object" ||
+        error === null ||
+        !("code" in error) ||
+        error.code !== "ESRCH"
+      ) {
+        throw error;
+      }
+    }
+  }
+  if (mountProcesses.length > 0) {
+    await waitFor({
+      describe: `processes executing from ${mountPath} to exit`,
+      predicate: async () =>
+        (await findProcessesExecutingFromMount(mountPath)).length === 0,
+      timeoutMs: exitTimeoutMs,
+    });
+  }
+}
+
+async function readOwnedRuntime(userDataDir) {
+  try {
+    const raw = await readFile(join(userDataDir, "owned-runtime.json"), "utf8");
+    const parsed = JSON.parse(raw);
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      typeof parsed.bridgePath === "string" &&
+      parsed.bridgePath.length > 0 &&
+      Number.isInteger(parsed.pid) &&
+      parsed.pid > 0 &&
+      typeof parsed.serverUrl === "string" &&
+      parsed.serverUrl.length > 0
+    ) {
+      return parsed;
+    }
+  } catch (error) {
+    if (
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      error.code === "ENOENT"
+    ) {
+      return null;
+    }
+    throw error;
+  }
+  return null;
+}
+
+function resolveMountFromBridgePath(bridgePath) {
+  const marker = "/resources/app.asar.unpacked/";
+  const markerIndex = bridgePath.indexOf(marker);
+  if (markerIndex <= 0) {
+    throw new Error(`Unexpected AppImage bridge path: ${bridgePath}`);
+  }
+  return bridgePath.slice(0, markerIndex);
+}
+
+function decodeMountInfoPath(path) {
+  return path.replace(/\\(040|011|012|134)/gu, (match, code) => {
+    if (code === "040") return " ";
+    if (code === "011") return "\t";
+    if (code === "012") return "\n";
+    if (code === "134") return "\\";
+    return match;
+  });
+}
+
+async function readMountPoints() {
+  const mountInfo = await readFile("/proc/self/mountinfo", "utf8");
+  return new Set(
+    mountInfo
+      .trim()
+      .split("\n")
+      .map((line) => line.split(" ")[4])
+      .filter((path) => path !== undefined)
+      .map(decodeMountInfoPath),
+  );
+}
+
+async function isMounted(path) {
+  return (await readMountPoints()).has(path);
+}
+
+async function unmount(path) {
+  if (!(await isMounted(path))) {
+    return;
+  }
+
+  let lastError = null;
+  for (const command of ["fusermount3", "fusermount"]) {
+    for (const options of [
+      ["-u", path],
+      ["-u", "-z", path],
+    ]) {
+      try {
+        await execFileAsync(command, options);
+        return;
+      } catch (error) {
+        lastError = error;
+        if (!(await isMounted(path))) {
+          return;
+        }
+        if (
+          typeof error === "object" &&
+          error !== null &&
+          "code" in error &&
+          error.code === "ENOENT"
+        ) {
+          break;
+        }
+      }
+    }
+  }
+  throw lastError ?? new Error(`Could not unmount ${path}`);
+}
+
+async function serverIsHealthy(serverUrl) {
+  try {
+    const response = await fetch(new URL("/health", serverUrl), {
+      signal: AbortSignal.timeout(2_000),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForChildExit(child, timeoutMs) {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return true;
+  }
+  return await new Promise((resolvePromise) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      resolvePromise(false);
+    }, timeoutMs);
+    const handleExit = () => {
+      cleanup();
+      resolvePromise(true);
+    };
+    const cleanup = () => {
+      clearTimeout(timeout);
+      child.off("exit", handleExit);
+    };
+    child.once("exit", handleExit);
+  });
+}
+
+async function stopRuntime(runtime) {
+  const processInfo = await readProcess(runtime.pid);
+  if (
+    processInfo === null ||
+    !processInfo.command.includes(runtime.bridgePath)
+  ) {
+    return;
+  }
+
+  process.kill(runtime.pid, "SIGTERM");
+  try {
+    await waitFor({
+      describe: `runtime supervisor ${String(runtime.pid)} to exit`,
+      predicate: async () => !(await processIsLive(runtime.pid)),
+      timeoutMs: exitTimeoutMs,
+    });
+  } catch {
+    const survivingProcess = await readProcess(runtime.pid);
+    if (
+      survivingProcess !== null &&
+      survivingProcess.command.includes(runtime.bridgePath)
+    ) {
+      process.kill(runtime.pid, "SIGKILL");
+    }
+  }
+}
+
+async function killIsolatedProcesses({ dataDir, userDataDir }) {
+  const entries = await readdir("/proc", { withFileTypes: true });
+  for (const entry of entries) {
+    if (!entry.isDirectory() || !/^\d+$/u.test(entry.name)) {
+      continue;
+    }
+    const pid = Number(entry.name);
+    if (pid === process.pid) {
+      continue;
+    }
+    const processInfo = await readProcess(pid);
+    if (
+      processInfo !== null &&
+      (processInfo.environment.BB_DATA_DIR === dataDir ||
+        processInfo.command.includes(`--user-data-dir=${userDataDir}`))
+    ) {
+      try {
+        process.kill(pid, "SIGKILL");
+      } catch (error) {
+        if (
+          typeof error !== "object" ||
+          error === null ||
+          !("code" in error) ||
+          error.code !== "ESRCH"
+        ) {
+          throw error;
+        }
+      }
+    }
+  }
+}
+
+async function smokeLinuxAppImageLifecycle() {
+  if (process.platform !== "linux") {
+    throw new Error("The AppImage lifecycle smoke only runs on Linux.");
+  }
+
+  const appImage = await resolveAppImage();
+  const smokeRoot = await mkdtemp(
+    join(tmpdir(), "bb-appimage-lifecycle-smoke-"),
+  );
+  const dataDir = join(smokeRoot, "data");
+  const userDataDir = join(smokeRoot, "user-data");
+  const stdout = [];
+  const stderr = [];
+  let child = null;
+  let guiMount = null;
+  let runtimeMount = null;
+  let runtime = null;
+
+  try {
+    const serverPort = await allocateTcpPort();
+    let daemonPort = await allocateTcpPort();
+    while (serverPort === daemonPort) {
+      daemonPort = await allocateTcpPort();
+    }
+
+    const childEnv = {
+      ...process.env,
+      BB_DATA_DIR: dataDir,
+      BB_DESKTOP_AUTO_UPDATE: "0",
+      BB_DESKTOP_OPEN_DEVTOOLS: "0",
+      BB_DESKTOP_VERSION_CHECK: "0",
+      BB_HOST_DAEMON_PORT: String(daemonPort),
+      BB_SERVER_PORT: String(serverPort),
+    };
+    delete childEnv.APPIMAGE_EXTRACT_AND_RUN;
+    delete childEnv.BB_DESKTOP_APP_URL;
+    delete childEnv.BB_DESKTOP_NODE_EXEC_PATH;
+    delete childEnv.ELECTRON_RUN_AS_NODE;
+
+    child = spawn(appImage, [`--user-data-dir=${userDataDir}`], {
+      detached: true,
+      env: childEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    if (child.pid === undefined) {
+      throw new Error("The AppImage process did not expose a PID");
+    }
+    child.stdout.on("data", (chunk) => appendOutput(stdout, chunk));
+    child.stderr.on("data", (chunk) => appendOutput(stderr, chunk));
+
+    runtime = await waitFor({
+      describe: "the desktop-owned runtime PID file",
+      predicate: async () => {
+        if (child.exitCode !== null || child.signalCode !== null) {
+          throw new Error(
+            `AppImage exited before its runtime started: code=${String(
+              child.exitCode,
+            )} signal=${String(child.signalCode)}.\n${formatProcessOutput({
+              stdout,
+              stderr,
+            })}`,
+          );
+        }
+        return await readOwnedRuntime(userDataDir);
+      },
+      retryErrors: false,
+    });
+    await waitFor({
+      describe: `bb health at ${runtime.serverUrl}`,
+      predicate: async () => await serverIsHealthy(runtime.serverUrl),
+    });
+
+    const guiProcess = await readProcess(child.pid);
+    const runtimeProcess = await readProcess(runtime.pid);
+    if (guiProcess === null || runtimeProcess === null) {
+      throw new Error("The GUI or runtime supervisor exited during startup");
+    }
+    if (guiProcess.processGroupId !== child.pid) {
+      throw new Error("The test AppImage GUI is not its process-group leader");
+    }
+    if (runtimeProcess.processGroupId !== runtime.pid) {
+      throw new Error(
+        "The AppImage runtime supervisor is not its group leader",
+      );
+    }
+    if (!runtimeProcess.command.includes(runtime.bridgePath)) {
+      throw new Error("The runtime PID does not match its ownership marker");
+    }
+
+    guiMount = resolveMountFromBridgePath(runtime.bridgePath);
+    runtimeMount = runtimeProcess.environment.APPDIR ?? null;
+    if (runtimeMount === null || runtimeMount.length === 0) {
+      throw new Error("The runtime supervisor did not inherit APPDIR");
+    }
+    if (guiMount === runtimeMount) {
+      throw new Error("The GUI and owned runtime unexpectedly share a mount");
+    }
+    if (!(await isMounted(guiMount)) || !(await isMounted(runtimeMount))) {
+      throw new Error("Expected both AppImage FUSE mounts to be active");
+    }
+
+    // The GUI is an anchored group of its own. The runtime supervisor starts a
+    // separate session, so killing this exact group models an unclean desktop
+    // crash without touching the owned server/daemon/watcher tree.
+    process.kill(-child.pid, "SIGKILL");
+    await waitForChildExit(child, exitTimeoutMs);
+    await killProcessesExecutingFromMount(guiMount);
+    await unmount(guiMount);
+    await waitFor({
+      describe: `GUI mount ${guiMount} to disappear`,
+      predicate: async () => !(await isMounted(guiMount)),
+      timeoutMs: exitTimeoutMs,
+    });
+
+    if (!(await processIsLive(runtime.pid))) {
+      throw new Error("The owned runtime exited with the GUI AppImage");
+    }
+    if (!(await isMounted(runtimeMount))) {
+      throw new Error(
+        "The owned runtime AppImage mount disappeared with the GUI",
+      );
+    }
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      if (!(await serverIsHealthy(runtime.serverUrl))) {
+        throw new Error("bb became unhealthy after the GUI mount teardown");
+      }
+      await sleep(250);
+    }
+
+    console.log(
+      `AppImage lifecycle smoke passed: ${appImage}\n` +
+        `GUI mount removed: ${guiMount}\n` +
+        `Owned runtime remained healthy on: ${runtimeMount}`,
+    );
+  } finally {
+    if (runtime !== null) {
+      await stopRuntime(runtime);
+    }
+    if (
+      child !== null &&
+      child.pid !== undefined &&
+      child.exitCode === null &&
+      child.signalCode === null
+    ) {
+      const guiProcess = await readProcess(child.pid);
+      if (guiProcess?.processGroupId === child.pid) {
+        process.kill(-child.pid, "SIGKILL");
+      } else {
+        child.kill("SIGKILL");
+      }
+      await waitForChildExit(child, exitTimeoutMs);
+    }
+    await killIsolatedProcesses({ dataDir, userDataDir });
+    for (const mount of [guiMount, runtimeMount]) {
+      if (mount !== null) {
+        await killProcessesExecutingFromMount(mount);
+        await unmount(mount);
+      }
+    }
+    await rm(smokeRoot, { force: true, recursive: true });
+  }
+}
+
+await smokeLinuxAppImageLifecycle().catch((error) => {
+  const message =
+    error instanceof Error ? (error.stack ?? error.message) : error;
+  console.error(message);
+  process.exitCode = 1;
+});

--- a/apps/desktop/src/bb-process.ts
+++ b/apps/desktop/src/bb-process.ts
@@ -1,4 +1,5 @@
 import { spawn, type ChildProcess } from "node:child_process";
+import { posix as posixPath } from "node:path";
 
 interface RuntimeLogBuffer {
   append(chunk: Buffer | string): void;
@@ -39,9 +40,33 @@ interface StopBbAppProcessArgs {
 
 type BbAppProcessRuntimeMode = "electron-node" | "node";
 
-interface BbAppProcessRuntime {
+interface DirectBbAppProcessRuntime {
   executablePath: string;
+  kind: "direct";
   mode: BbAppProcessRuntimeMode;
+}
+
+interface AppImageBbAppProcessRuntime {
+  appDirPath: string;
+  executablePath: string;
+  kind: "appimage";
+  mode: "electron-node";
+}
+
+type BbAppProcessRuntime =
+  | AppImageBbAppProcessRuntime
+  | DirectBbAppProcessRuntime;
+
+interface CreateBbAppProcessLaunchArgs {
+  bridgePath: string;
+  env: NodeJS.ProcessEnv;
+  runtime: BbAppProcessRuntime;
+}
+
+interface BbAppProcessLaunch {
+  args: string[];
+  env: NodeJS.ProcessEnv;
+  executablePath: string;
 }
 
 interface CreateBbAppProcessEnvArgs {
@@ -52,6 +77,7 @@ interface CreateBbAppProcessEnvArgs {
 interface ResolveBbAppProcessRuntimeArgs {
   env: NodeJS.ProcessEnv;
   isPackaged: boolean;
+  platform: NodeJS.Platform;
   processExecPath: string;
 }
 
@@ -64,6 +90,112 @@ type WaitForProcessExitWithTimeoutResult = "exited" | "timed-out";
 type ResolveWaitForProcessExitWithTimeout = (
   result: WaitForProcessExitWithTimeoutResult,
 ) => void;
+
+const APPIMAGE_BRIDGE_RELATIVE_PATH_ENV =
+  "BB_DESKTOP_APPIMAGE_BRIDGE_RELATIVE_PATH";
+
+async function runAppImageBridgeSupervisor(
+  bridgeRelativePathEnv: string,
+): Promise<void> {
+  const { spawn: spawnChild } = process.getBuiltinModule("node:child_process");
+  const { readdirSync, readFileSync } = process.getBuiltinModule("node:fs");
+  const { resolve: resolvePath } = process.getBuiltinModule("node:path");
+  const appDirPath = process.env.APPDIR;
+  const bridgeRelativePath = process.env[bridgeRelativePathEnv];
+  if (!appDirPath || !bridgeRelativePath) {
+    throw new Error("AppImage bridge bootstrap environment is incomplete");
+  }
+
+  const bridgePath = resolvePath(appDirPath, bridgeRelativePath);
+  const bridgeProcess = spawnChild(process.execPath, [bridgePath], {
+    env: process.env,
+    stdio: "inherit",
+  });
+  if (bridgeProcess.pid === undefined) {
+    throw new Error("AppImage bridge process did not expose a PID");
+  }
+
+  const supervisorPid = process.pid;
+  let terminationSignal: NodeJS.Signals | null = null;
+  let killTimer: ReturnType<typeof setTimeout> | null = null;
+  const signalBridgeGroup = (signal: NodeJS.Signals | 0): boolean => {
+    try {
+      process.kill(-supervisorPid, signal);
+      return true;
+    } catch (error) {
+      if (
+        typeof error === "object" &&
+        error !== null &&
+        "code" in error &&
+        error.code === "ESRCH"
+      ) {
+        return false;
+      }
+      throw error;
+    }
+  };
+  const bridgeGroupHasLiveDescendants = (): boolean => {
+    for (const entry of readdirSync("/proc", { withFileTypes: true })) {
+      if (!entry.isDirectory() || !/^\d+$/u.test(entry.name)) {
+        continue;
+      }
+      const pid = Number(entry.name);
+      if (pid === supervisorPid) {
+        continue;
+      }
+      try {
+        const stat = readFileSync(`/proc/${entry.name}/stat`, "utf8");
+        const fields = stat.slice(stat.lastIndexOf(")") + 2).split(" ");
+        const state = fields[0];
+        const processGroupId = Number(fields[2]);
+        if (state !== "Z" && processGroupId === supervisorPid) {
+          return true;
+        }
+      } catch (error) {
+        if (
+          typeof error === "object" &&
+          error !== null &&
+          "code" in error &&
+          (error.code === "ENOENT" || error.code === "ESRCH")
+        ) {
+          continue;
+        }
+        throw error;
+      }
+    }
+    return false;
+  };
+  const beginTermination = (signal: NodeJS.Signals): void => {
+    if (terminationSignal !== null) {
+      return;
+    }
+    terminationSignal = signal;
+    signalBridgeGroup(signal);
+    killTimer = setTimeout(() => signalBridgeGroup("SIGKILL"), 4_000);
+  };
+  process.on("SIGINT", () => beginTermination("SIGINT"));
+  process.on("SIGTERM", () => beginTermination("SIGTERM"));
+
+  const bridgeExitCode = await new Promise<number | null>(
+    (resolveExit, rejectExit) => {
+      bridgeProcess.once("error", rejectExit);
+      bridgeProcess.once("exit", (code) => resolveExit(code));
+    },
+  );
+  while (bridgeGroupHasLiveDescendants()) {
+    await new Promise<void>((resolveDelay) => {
+      setTimeout(resolveDelay, 100);
+    });
+  }
+  if (killTimer !== null) {
+    clearTimeout(killTimer);
+  }
+  if (terminationSignal === null) {
+    process.exitCode = bridgeExitCode ?? 1;
+  }
+}
+
+const APPIMAGE_BRIDGE_BOOTSTRAP = `await (${runAppImageBridgeSupervisor.toString()})(${JSON.stringify(APPIMAGE_BRIDGE_RELATIVE_PATH_ENV)});`;
 
 function createRuntimeLogBuffer(
   args: CreateRuntimeLogBufferArgs,
@@ -105,8 +237,34 @@ export function resolveBbAppProcessRuntime(
   args: ResolveBbAppProcessRuntimeArgs,
 ): BbAppProcessRuntime {
   if (args.isPackaged) {
+    const appImagePath = args.env.APPIMAGE?.trim();
+    const appDirPath = args.env.APPDIR?.trim();
+    if (
+      args.platform === "linux" &&
+      appImagePath !== undefined &&
+      appImagePath.length > 0 &&
+      appDirPath !== undefined &&
+      appDirPath.length > 0
+    ) {
+      return {
+        appDirPath,
+        // process.execPath inside an AppImage points into the desktop shell's
+        // temporary FUSE mount. The bb-app bridge intentionally outlives an
+        // unclean shell exit so the next launch can identify and reap it, but
+        // reusing that inner executable leaves the bridge and its descendants
+        // executing from a mount that disappears with the shell. Starting the
+        // outer AppImage gives the managed process tree its own mount. Its
+        // bootstrap supervises a separate bridge process group and keeps the
+        // mount alive until the bridge and all descendants have exited.
+        executablePath: appImagePath,
+        kind: "appimage",
+        mode: "electron-node",
+      };
+    }
+
     return {
       executablePath: args.processExecPath,
+      kind: "direct",
       mode: "electron-node",
     };
   }
@@ -120,7 +278,53 @@ export function resolveBbAppProcessRuntime(
 
   return {
     executablePath: rawNodeExecPath,
+    kind: "direct",
     mode: "node",
+  };
+}
+
+export function createBbAppProcessLaunch(
+  args: CreateBbAppProcessLaunchArgs,
+): BbAppProcessLaunch {
+  const env = createBbAppProcessEnv({
+    env: args.env,
+    runtimeMode: args.runtime.mode,
+  });
+  if (args.runtime.kind === "direct") {
+    return {
+      args: [args.bridgePath],
+      env,
+      executablePath: args.runtime.executablePath,
+    };
+  }
+
+  const bridgeRelativePath = posixPath.relative(
+    args.runtime.appDirPath,
+    args.bridgePath,
+  );
+  if (
+    bridgeRelativePath.length === 0 ||
+    posixPath.isAbsolute(bridgeRelativePath) ||
+    bridgeRelativePath === ".." ||
+    bridgeRelativePath.startsWith("../")
+  ) {
+    throw new Error("bb-app bridge path must be inside the AppImage mount");
+  }
+
+  return {
+    // Keep the original bridge path as an inert argv entry. The stale-runtime
+    // supervisor uses it to verify ownership before signaling a recorded PID.
+    args: [
+      "--input-type=module",
+      "--eval",
+      APPIMAGE_BRIDGE_BOOTSTRAP,
+      args.bridgePath,
+    ],
+    env: {
+      ...env,
+      [APPIMAGE_BRIDGE_RELATIVE_PATH_ENV]: bridgeRelativePath,
+    },
+    executablePath: args.runtime.executablePath,
   };
 }
 
@@ -181,12 +385,19 @@ function waitForProcessExitWithTimeout(
 
 export function startBbAppProcess(args: StartBbAppProcessArgs): BbAppProcess {
   const logs = createRuntimeLogBuffer({ maxLines: args.logLineLimit });
-  const childProcess = spawn(args.runtime.executablePath, [args.bridgePath], {
+  const launch = createBbAppProcessLaunch({
+    bridgePath: args.bridgePath,
+    env: args.env,
+    runtime: args.runtime,
+  });
+  const childProcess = spawn(launch.executablePath, launch.args, {
     cwd: args.cwd,
-    env: createBbAppProcessEnv({
-      env: args.env,
-      runtimeMode: args.runtime.mode,
-    }),
+    // The AppImage bootstrap must remain the process-group leader until every
+    // managed descendant has exited. Besides keeping its FUSE mount alive,
+    // owning the PGID prevents a delayed group signal from ever targeting a
+    // recycled ID after the bridge process exits.
+    detached: args.runtime.kind === "appimage",
+    env: launch.env,
     stdio: ["ignore", "pipe", "pipe"],
   });
   const pid = childProcess.pid;

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1808,6 +1808,7 @@ async function startOwnedRuntime(
     runtime: resolveBbAppProcessRuntime({
       env: process.env,
       isPackaged: app.isPackaged,
+      platform: process.platform,
       processExecPath: process.execPath,
     }),
   });

--- a/apps/desktop/test/bb-process.test.ts
+++ b/apps/desktop/test/bb-process.test.ts
@@ -1,8 +1,11 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  createBbAppProcessLaunch,
   createBbAppProcessEnv,
   resolveBbAppProcessRuntime,
   startBbAppProcess,
@@ -24,8 +27,23 @@ interface CreateTempScriptArgs {
   contents: string;
 }
 
+interface LinuxProcessStat {
+  processGroupId: number;
+  state: string;
+}
+
 const tempScripts: TempScript[] = [];
 const processes: BbAppProcess[] = [];
+const execFileAsync = promisify(execFile);
+
+async function readLinuxProcessStat(pid: number): Promise<LinuxProcessStat> {
+  const stat = await readFile(`/proc/${String(pid)}/stat`, "utf8");
+  const fields = stat.slice(stat.lastIndexOf(")") + 2).split(" ");
+  return {
+    processGroupId: Number(fields[2]),
+    state: fields[0] ?? "",
+  };
+}
 
 async function createTempScript(
   args: CreateTempScriptArgs,
@@ -57,8 +75,12 @@ afterEach(async () => {
       processEntry.childProcess.exitCode === null &&
       processEntry.childProcess.signalCode === null
     ) {
-      processEntry.childProcess.kill("SIGKILL");
-      await processEntry.exit;
+      await processEntry.stop({
+        killSignal: "SIGKILL",
+        killTimeoutMs: 1_000,
+        signal: "SIGTERM",
+        timeoutMs: 5_000,
+      });
     }
   }
 
@@ -86,11 +108,13 @@ describe("bb app process", () => {
     const runtime = resolveBbAppProcessRuntime({
       env: {},
       isPackaged: true,
+      platform: "darwin",
       processExecPath: "/Applications/bb.app/Contents/MacOS/bb",
     });
 
     expect(runtime).toEqual({
       executablePath: "/Applications/bb.app/Contents/MacOS/bb",
+      kind: "direct",
       mode: "electron-node",
     });
     expect(
@@ -101,11 +125,135 @@ describe("bb app process", () => {
     ).toBe("1");
   });
 
+  it("gives a packaged Linux bridge its own AppImage mount", () => {
+    expect(
+      resolveBbAppProcessRuntime({
+        env: {
+          APPIMAGE: "/home/user/Apps/bb-x86_64.AppImage",
+          APPDIR: "/tmp/.mount_bb",
+        },
+        isPackaged: true,
+        platform: "linux",
+        processExecPath: "/tmp/.mount_bb/bb",
+      }),
+    ).toEqual({
+      appDirPath: "/tmp/.mount_bb",
+      executablePath: "/home/user/Apps/bb-x86_64.AppImage",
+      kind: "appimage",
+      mode: "electron-node",
+    });
+  });
+
+  it("imports the bridge from the child AppImage mount", async () => {
+    const desktopMountScript = await createTempScript({
+      contents: 'process.stdout.write("desktop mount\\n");\n',
+    });
+    const childMountScript = await createTempScript({
+      contents: 'process.stdout.write("child mount\\n");\n',
+    });
+    const launch = createBbAppProcessLaunch({
+      bridgePath: desktopMountScript.path,
+      env: process.env,
+      runtime: {
+        appDirPath: desktopMountScript.root,
+        executablePath: process.execPath,
+        kind: "appimage",
+        mode: "electron-node",
+      },
+    });
+
+    expect(launch.args).toContain(desktopMountScript.path);
+    const result = await execFileAsync(launch.executablePath, launch.args, {
+      env: {
+        ...launch.env,
+        APPDIR: childMountScript.root,
+      },
+    });
+
+    expect(result.stdout).toBe("child mount\n");
+  });
+
+  it.skipIf(process.platform !== "linux")(
+    "anchors the process group while supervising descendants after the bridge exits",
+    async () => {
+      const script = await createTempScript({
+        contents: `
+import { spawn } from "node:child_process";
+const grandchild = spawn(
+  process.execPath,
+  ["--eval", "setInterval(() => undefined, 1000)"],
+  { stdio: "inherit" },
+);
+process.stdout.write(\`grandchild=\${grandchild.pid}\\n\`);
+`,
+      });
+      const processEntry = startBbAppProcess({
+        bridgePath: script.path,
+        cwd: script.root,
+        env: {
+          ...process.env,
+          APPDIR: script.root,
+        },
+        logLineLimit: 20,
+        runtime: {
+          appDirPath: script.root,
+          executablePath: process.execPath,
+          kind: "appimage",
+          mode: "electron-node",
+        },
+      });
+      processes.push(processEntry);
+      await waitForLog({
+        process: processEntry,
+        text: "grandchild=",
+        timeoutMs: 1_000,
+      });
+      const grandchildPid = Number(
+        processEntry.logs.text().match(/grandchild=(\d+)/u)?.[1],
+      );
+      expect(grandchildPid).toBeGreaterThan(0);
+      const supervisorStat = await readLinuxProcessStat(processEntry.pid);
+      const grandchildStat = await readLinuxProcessStat(grandchildPid);
+      expect(supervisorStat.processGroupId).toBe(processEntry.pid);
+      expect(supervisorStat.state).not.toBe("Z");
+      expect(grandchildStat.processGroupId).toBe(processEntry.pid);
+      await new Promise<void>((resolvePromise) => {
+        setTimeout(resolvePromise, 50);
+      });
+      expect(processEntry.childProcess.exitCode).toBeNull();
+
+      await processEntry.stop({
+        killSignal: "SIGKILL",
+        killTimeoutMs: 1_000,
+        signal: "SIGTERM",
+        timeoutMs: 5_000,
+      });
+
+      expect(() => process.kill(grandchildPid, 0)).toThrow();
+    },
+  );
+
+  it("uses the inner executable for an unpacked Linux build", () => {
+    expect(
+      resolveBbAppProcessRuntime({
+        env: {},
+        isPackaged: true,
+        platform: "linux",
+        processExecPath: "/opt/bb/bb",
+      }),
+    ).toEqual({
+      executablePath: "/opt/bb/bb",
+      kind: "direct",
+      mode: "electron-node",
+    });
+  });
+
   it("requires the host Node executable in desktop dev mode", () => {
     expect(() =>
       resolveBbAppProcessRuntime({
         env: {},
         isPackaged: false,
+        platform: "linux",
         processExecPath: "/path/to/electron",
       }),
     ).toThrow("BB_DESKTOP_NODE_EXEC_PATH is required");
@@ -116,10 +264,12 @@ describe("bb app process", () => {
           BB_DESKTOP_NODE_EXEC_PATH: "/usr/local/bin/node",
         },
         isPackaged: false,
+        platform: "linux",
         processExecPath: "/path/to/electron",
       }),
     ).toEqual({
       executablePath: "/usr/local/bin/node",
+      kind: "direct",
       mode: "node",
     });
   });
@@ -141,6 +291,7 @@ setInterval(() => undefined, 1000);
       logLineLimit: 20,
       runtime: {
         executablePath: process.execPath,
+        kind: "direct",
         mode: "node",
       },
     });

--- a/turbo.json
+++ b/turbo.json
@@ -189,6 +189,13 @@
       "outputs": [],
       "passThroughEnv": ["*"]
     },
+    "@bb/desktop#smoke:appimage-lifecycle": {
+      "cache": false,
+      "outputs": [],
+      "passThroughEnv": [
+        "*"
+      ]
+    },
     "@bb/desktop#dev": {
       "dependsOn": ["bb-app#build"],
       "cache": false,


### PR DESCRIPTION
## Human comments

This pull request replaces #1781 because the source branch for that pull request was deleted.

The replacement preserves the original work and gives co-author credit to @salemsayed.

## What was wrong

The packaged desktop started the long-lived bb-app bridge through an executable inside the desktop AppImage mount. The bridge and its descendants could continue after that mount disappeared. These processes could then fail with `SIGBUS` or `BUS_ADRERR` errors.

## What changed

- Start the packaged Linux runtime through the outer AppImage.
- Give the owned runtime an independent FUSE mount.
- Resolve the bridge path inside the new runtime mount.
- Keep the AppImage supervisor as the process-group leader until all descendants exit.
- Keep the original bridge path in the command line for stale-process verification.
- Add an AppImage lifecycle smoke test to the Linux build and release jobs.

This change does not alter the host daemon protocol.

## How you verified

- `pnpm exec turbo run typecheck test --filter=@bb/desktop`
- The desktop typecheck passed.
- All 235 desktop tests passed.
- The prior Linux package smoke passed on #1781.
- `git diff --check origin/main...HEAD`

Replaces #1781.

> AGENT GENERATED
