### PR TITLE
Add optional transparent Linux desktop windows

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -111,6 +111,19 @@ native Electron title bar with `--no-window-frame`:
 The native frame remains the default. Changing this startup option requires a
 full desktop app restart.
 
+Linux users can opt into a transparent Electron window with
+`--transparent-window`:
+
+```bash
+./bb-x86_64.AppImage --transparent-window
+```
+
+The window remains opaque by default. Transparency also requires a compositor
+that supports it, and Electron documents limitations including unsupported
+window shaping and unreliable resize behavior on some platforms. The flag can
+be combined with `--no-window-frame`, and changing it requires a full desktop
+app restart.
+
 CI builds Linux artifacts on the pinned `ubuntu-22.04` runner. The AppImage
 links against the build machine's glibc, so that pin sets the oldest
 distribution that can run a published build. Raise it deliberately.

--- a/apps/desktop/src/desktop-window-factory.ts
+++ b/apps/desktop/src/desktop-window-factory.ts
@@ -87,6 +87,7 @@ interface CreateDesktopWindowFactoryArgs {
   createWindowStateKey(): WindowStateKey;
   displayWorkAreas: DisplayWorkArea[] | null;
   icon: DesktopWindowIcon;
+  isLinuxTransparent: boolean;
   isMac: boolean;
   isLinuxFrameless: boolean;
   isQuitting(): boolean;
@@ -138,6 +139,7 @@ interface LoadUrlIntoWindowArgs {
 interface CreateWindowOptionsArgs {
   bounds: WindowBounds;
   icon: DesktopWindowIcon;
+  isLinuxTransparent: boolean;
   isMac: boolean;
   isLinuxFrameless: boolean;
   preloadPath: string;
@@ -171,6 +173,9 @@ function createWindowOptions(
 ): BrowserWindowConstructorOptions {
   return {
     ...(args.isLinuxFrameless ? { frame: false } : {}),
+    ...(args.isLinuxTransparent
+      ? { backgroundColor: "#00000000", transparent: true }
+      : {}),
     ...(args.isMac
       ? {
           frame: false,
@@ -240,6 +245,7 @@ export function createDesktopWindowFactory(
         createWindowOptions({
           bounds: restoredState.bounds,
           icon: args.icon,
+          isLinuxTransparent: args.isLinuxTransparent,
           isMac: args.isMac,
           isLinuxFrameless: args.isLinuxFrameless,
           preloadPath: args.preloadPath,

--- a/apps/desktop/src/desktop-window-transparency.ts
+++ b/apps/desktop/src/desktop-window-transparency.ts
@@ -1,0 +1,15 @@
+export const LINUX_TRANSPARENT_WINDOW_ARGUMENT = "--transparent-window";
+
+interface ShouldUseLinuxTransparentWindowArgs {
+  argv: readonly string[];
+  platform: NodeJS.Platform;
+}
+
+export function shouldUseLinuxTransparentWindow(
+  args: ShouldUseLinuxTransparentWindowArgs,
+): boolean {
+  return (
+    args.platform === "linux" &&
+    args.argv.includes(LINUX_TRANSPARENT_WINDOW_ARGUMENT)
+  );
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -110,6 +110,7 @@ import {
   type DesktopWindowFactory,
 } from "./desktop-window-factory.js";
 import { shouldUseLinuxFramelessWindow } from "./desktop-window-frame.js";
+import { shouldUseLinuxTransparentWindow } from "./desktop-window-transparency.js";
 import {
   createDesktopAboutDialogOptions,
   createDesktopAboutPanelOptions,
@@ -2372,6 +2373,10 @@ async function runDesktopApp(): Promise<void> {
     },
     displayWorkAreas: null,
     icon: nativeImage.createFromPath(iconPath),
+    isLinuxTransparent: shouldUseLinuxTransparentWindow({
+      argv: process.argv,
+      platform: process.platform,
+    }),
     isMac: process.platform === "darwin",
     isLinuxFrameless: shouldUseLinuxFramelessWindow({
       argv: process.argv,

--- a/apps/desktop/test/desktop-window-factory.test.ts
+++ b/apps/desktop/test/desktop-window-factory.test.ts
@@ -240,6 +240,7 @@ describe("desktop window factory", () => {
       ],
       icon: undefined,
       isMac: true,
+      isLinuxTransparent: false,
       isLinuxFrameless: false,
       isQuitting() {
         return false;
@@ -336,6 +337,7 @@ describe("desktop window factory", () => {
       ],
       icon: undefined,
       isMac: true,
+      isLinuxTransparent: false,
       isLinuxFrameless: false,
       isQuitting() {
         return false;
@@ -395,6 +397,7 @@ describe("desktop window factory", () => {
       ],
       icon: undefined,
       isMac: true,
+      isLinuxTransparent: false,
       isLinuxFrameless: false,
       isQuitting() {
         return false;
@@ -451,6 +454,7 @@ describe("desktop window factory", () => {
       ],
       icon: undefined,
       isMac: true,
+      isLinuxTransparent: false,
       isLinuxFrameless: false,
       isQuitting() {
         return false;
@@ -509,6 +513,7 @@ describe("desktop window factory", () => {
       ],
       icon: undefined,
       isMac: true,
+      isLinuxTransparent: false,
       isLinuxFrameless: false,
       isQuitting() {
         return false;
@@ -570,6 +575,7 @@ describe("desktop window factory", () => {
       ],
       icon: undefined,
       isMac: true,
+      isLinuxTransparent: false,
       isLinuxFrameless: false,
       isQuitting() {
         return false;
@@ -629,6 +635,7 @@ describe("desktop window factory", () => {
       ],
       icon: undefined,
       isMac: false,
+      isLinuxTransparent: false,
       isLinuxFrameless: false,
       isQuitting() {
         return false;
@@ -645,6 +652,41 @@ describe("desktop window factory", () => {
     expect(createdWindows[0]?.options).not.toHaveProperty(
       "trafficLightPosition",
     );
+  });
+
+  it("enables transparent Linux windows when requested", async () => {
+    const tempDir = await createTempDir();
+    const createdWindows: FakeDesktopWindow[] = [];
+    const browserWindowCreator: DesktopBrowserWindowCreator = {
+      create(options) {
+        const browserWindow = new FakeDesktopWindow({ options });
+        createdWindows.push(browserWindow);
+        return browserWindow;
+      },
+    };
+    const factory = createDesktopWindowFactory({
+      browserWindowCreator,
+      createWindowStateKey() {
+        return "transparent-linux-window";
+      },
+      displayWorkAreas: [{ height: 900, width: 1440, x: 0, y: 0 }],
+      icon: undefined,
+      isLinuxTransparent: true,
+      isMac: false,
+      isLinuxFrameless: false,
+      isQuitting() {
+        return false;
+      },
+      openExternalUrl() {},
+      preloadPath: "/tmp/preload.cjs",
+      userDataPath: tempDir.path,
+    });
+
+    await factory.createWindow({ initialUrl: null, stateKey: null });
+
+    expect(createdWindows[0]?.options.transparent).toBe(true);
+    expect(createdWindows[0]?.options.backgroundColor).toBe("#00000000");
+    expect(createdWindows[0]?.options).not.toHaveProperty("frame");
   });
 
   it("removes the native window frame when requested on Linux", async () => {
@@ -672,6 +714,7 @@ describe("desktop window factory", () => {
       ],
       icon: undefined,
       isMac: false,
+      isLinuxTransparent: false,
       isLinuxFrameless: true,
       isQuitting() {
         return false;

--- a/apps/desktop/test/desktop-window-transparency.test.ts
+++ b/apps/desktop/test/desktop-window-transparency.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  LINUX_TRANSPARENT_WINDOW_ARGUMENT,
+  shouldUseLinuxTransparentWindow,
+} from "../src/desktop-window-transparency.js";
+
+describe("desktop window transparency", () => {
+  it("enables transparent windows on Linux when requested", () => {
+    expect(
+      shouldUseLinuxTransparentWindow({
+        argv: ["bb", LINUX_TRANSPARENT_WINDOW_ARGUMENT],
+        platform: "linux",
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps Linux windows opaque by default", () => {
+    expect(
+      shouldUseLinuxTransparentWindow({
+        argv: ["bb"],
+        platform: "linux",
+      }),
+    ).toBe(false);
+  });
+
+  it("ignores the option on other platforms", () => {
+    for (const platform of ["darwin", "win32"] as const) {
+      expect(
+        shouldUseLinuxTransparentWindow({
+          argv: ["bb", LINUX_TRANSPARENT_WINDOW_ARGUMENT],
+          platform,
+        }),
+      ).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Human comments
Small fix to allow transparency - added as an option. Maybe opinionated but suggest it's a default as can't see it causing any issues.

## What was wrong

Electron creates opaque desktop windows by default, so Linux compositors cannot show transparency or blur behind bb even when a custom CSS theme uses translucent colors. This leaves compositor-level effects unavailable after the frameless Linux window option added in #1785. Fixes #1916.

## What changed

- Added a Linux-only `--transparent-window` startup flag.
- Set Electron's `transparent: true` and `backgroundColor: "#00000000"` window options when requested.
- Kept the option independent from `--no-window-frame`; both remain opt-in and can be combined.
- Added argument parsing and `BrowserWindow` option coverage.
- Documented Linux usage, restart requirements, and Electron transparency limitations.
- No host-daemon protocol changes.

## How you verified

- `pnpm exec turbo run typecheck --filter=@bb/desktop`
- `pnpm exec turbo run test --filter=@bb/desktop --force` (37 files, 243 tests passed)
- `pnpm exec prettier --check apps/desktop/README.md apps/desktop/src/desktop-window-factory.ts apps/desktop/src/desktop-window-transparency.ts apps/desktop/src/main.ts apps/desktop/test/desktop-window-factory.test.ts apps/desktop/test/desktop-window-transparency.test.ts`
- `git diff --check`

Fixes #1916

> AGENT GENERATED