### PR TITLE
Polish workflow panel surface

### DIFF
--- a/packages/domain/src/plugin-sdk-version.ts
+++ b/packages/domain/src/plugin-sdk-version.ts
@@ -16,7 +16,7 @@
 // PLUGIN_SDK_MAJOR is 0, so the major-only artifact gate cannot distinguish
 // 0.x releases and is intentionally vacuous for them until a future 1.0.
 // Rebuildable artifacts still rebuild on the exact sdkVersion-differs trigger.
-export const PLUGIN_SDK_VERSION = "0.4.22";
+export const PLUGIN_SDK_VERSION = "0.4.23";
 
 /** Major of {@link PLUGIN_SDK_VERSION} — the plugin API compatibility number. */
 export const PLUGIN_SDK_MAJOR = Number(PLUGIN_SDK_VERSION.split(".", 1)[0]);

--- a/packages/plugin-api-map/sdk-public-api.json
+++ b/packages/plugin-api-map/sdk-public-api.json
@@ -27,7 +27,7 @@
     },
     "./provider-bridge/testing": {
       "types": "bundled-types/bb-plugin-sdk-provider-bridge-testing.d.ts",
-      "sha256": "7c97c6976876e450ecc9dab36314a48215aae11054e410f985433cd322f9cde8"
+      "sha256": "c35f7c70cdde2281a6fc5b51a041ea9281f4c232d6a4d730a823cbd5ef8aa8a9"
     },
     "./testing": {
       "types": "bundled-types/bb-plugin-sdk-testing.d.ts",

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@get-bb/plugin-sdk",
-  "version": "0.4.22",
+  "version": "0.4.23",
   "homepage": "https://github.com/get-bb/bb#readme",
   "bugs": {
     "url": "https://github.com/get-bb/bb/issues"

--- a/plugins/workflows/src/app.test.tsx
+++ b/plugins/workflows/src/app.test.tsx
@@ -685,6 +685,11 @@ describe("workflow thread panel", () => {
     );
 
     await slot.findByText("Run independent checks before shipping.");
+    const scrollArea = slot.container.querySelector(
+      '[data-detail-scroll-area="workflow-panel"]',
+    );
+    expect(scrollArea?.className).toContain("p-4");
+    expect(scrollArea?.parentElement?.className).toContain("bg-border");
     // The settled Discover phase starts collapsed; the active phase is open.
     expect(slot.queryByText("Inspect implementation")).toBeNull();
     expect(slot.getByText("Adversarial review")).toBeTruthy();

--- a/plugins/workflows/src/app.tsx
+++ b/plugins/workflows/src/app.tsx
@@ -861,11 +861,13 @@ function WorkflowPreviewLoaded({
 function WorkflowRunPanel({ threadId, params }: PluginThreadPanelProps) {
   const runId = panelRunId(params);
   return (
-    <div className="h-full min-h-0 flex-1 p-4">
+    <div className="h-full min-h-0 flex-1 bg-border">
       {runId === undefined ? (
-        <EmptyOrError>
-          This workflow panel has invalid run parameters.
-        </EmptyOrError>
+        <div className="p-4">
+          <EmptyOrError>
+            This workflow panel has invalid run parameters.
+          </EmptyOrError>
+        </div>
       ) : (
         <WorkflowRunPanelLoaded threadId={threadId} runId={runId} />
       )}
@@ -921,10 +923,10 @@ function WorkflowRunPanelLoaded({
     }
   };
   return (
-    <div className="flex h-full min-h-0 flex-col bg-background">
+    <div className="flex h-full min-h-0 flex-col bg-border">
       <div
         data-detail-scroll-area="workflow-panel"
-        className="min-h-0 flex-1 overflow-y-auto"
+        className="min-h-0 flex-1 overflow-y-auto p-4"
       >
         <div className="flex items-start gap-2">
           <div className="min-w-0 flex-1">


### PR DESCRIPTION
## Human comments

## What was wrong

The workflow panel added an outer content inset over the host panel surface. The inset exposed a separate background edge around the panel.

The current `main` branch also changed an exported provider parity type after the last plugin SDK release. The SDK package and inventory no longer matched version 0.4.22.

## What changed

The workflow panel now fills the host surface with the border color. The content keeps its spacing inside the scroll area. The empty state keeps its local spacing.

The plugin SDK version is now 0.4.23. The Plugin Guide inventory now records the current provider parity declaration.

This change does not alter a wire contract, a CLI command, or documentation.

## How you verified

- `pnpm exec turbo run test --filter=bb-plugin-workflows --force`
- 13 test files passed with 223 tests.
- A panel test verifies the content spacing and the surface color.
- `pnpm exec turbo run test --filter=@bb/domain --filter=@get-bb/plugin-sdk --filter=@bb/plugin-api-map --filter=bb-plugin-workflows --force`
- `node packages/plugin-sdk/scripts/check-npm-version-guard.mjs`

No issue is linked.

> AGENT GENERATED
