### PR TITLE
test(github): remove costly navigation test polling

### DIFF
--- a/plugins/github/app.test.tsx
+++ b/plugins/github/app.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import { describe, expect, it } from "vitest";
+import { act } from "react";
 import { loadPluginApp, renderSlot } from "@get-bb/plugin-sdk/testing/app";
 
 const app = await loadPluginApp(() => import("./app"));
@@ -139,16 +140,27 @@ describe("GitHub app navigation", () => {
       },
     );
 
-    await slot.findByText("Navigation fix");
-    expect(slot.queryByRole("link", { name: "removed.ts" })).toBeNull();
-    expect(slot.getByRole("link", { name: "modified.ts" })).toBeDefined();
+    await act(async () => {});
+    const removedFile = slot.getByText("removed.ts");
+    const modifiedFile = slot.getByText("modified.ts");
+    expect(removedFile.closest("a")).toBeNull();
+    expect(modifiedFile.closest("a")?.getAttribute("href")).toBe(
+      "./modified.ts",
+    );
 
-    slot.getByRole("button", { name: "Expand removed.ts diff" }).click();
-    const diff = await slot.findByTestId("bb-diff");
+    const diffToggle = removedFile.parentElement?.querySelector("button");
+    if (!(diffToggle instanceof HTMLButtonElement)) {
+      throw new Error("removed file diff toggle was not rendered");
+    }
+    expect(diffToggle.getAttribute("aria-label")).toBe(
+      "Expand removed.ts diff",
+    );
+    await act(async () => diffToggle.click());
+    const diff = slot.getByTestId("bb-diff");
     expect(diff.getAttribute("data-path")).toBe("removed.ts");
-    expect(
-      slot.getByRole("button", { name: "Collapse removed.ts diff" }),
-    ).toBeDefined();
+    expect(diffToggle.getAttribute("aria-label")).toBe(
+      "Collapse removed.ts diff",
+    );
     slot.lifecycle.unmount();
   });
 });


### PR DESCRIPTION
## Human comments

## What was wrong

The GitHub removed-file navigation regression test repeatedly ran whole-tree named `queryByRole`/`getByRole` accessibility walks after the pull request rendered, then used another polling query after expanding the diff. Instrumentation showed that the negative removed-link lookup alone cost about 42 ms wall time / 100 ms process CPU unloaded and 1.3–1.8 seconds wall time under contention. The packages CI shard amplifies that avoidable work by running 76 package test tasks, with Turbo's default ten concurrent tasks, on 4 vCPUs. That scheduler contention was the reproduction condition; the root cause was the test's repeated accessible-name computation and polling boundaries.

This reproduced the exact failure from [run 33001027428](https://github.com/get-bb/bb/actions/runs/33001027428), job [98283670219](https://github.com/get-bb/bb/actions/runs/33001027428/job/98283670219): the exact unchanged case timed out at `app.test.tsx:81` under its existing 5-second ceiling. Exact GitHub issue/PR searches for the run ID, job ID, signature, and file/timeout found no open match. BB run-ID/job-ID searches found only this worker, and an exact-substring signature filter found no other active or archived worker.

## What changed

The existing UI regression test now:

- flushes the immediate in-memory RPC/effect chain with React's completion boundary instead of elapsed-time polling;
- checks the removed file is not wrapped in a link and the modified file keeps its workspace href;
- scopes the removed-file toggle lookup to that file's header;
- verifies expand/collapse through the toggle's accessible label and checks the rendered diff path synchronously after the click completes.

The behavioral coverage is unchanged: removed files do not navigate live workspaces, modified files remain navigable, removed diffs expand, and collapse state is exposed. There are no product, wire-protocol, CLI, guide, or documentation changes, and no timeout was changed.

## How you verified

Verified fresh merge-base before task work: `7a6fe643250a93551f31441ff2c8d39aa09c638f` (clean worktree; HEAD, fetched `origin/main`, and merge-base all exactly matched, independently confirmed by the parent worker).

Measured the exact case through Turbo with the original 5-second ceiling:

- Before, unloaded: 91–98 ms.
- Before, representative 8× local CPU saturation: 1.049 seconds.
- Before, 32×–40× saturation: 4.54–4.55 seconds.
- Before, 48× saturation: exact `Test timed out in 5000ms` failure, 5.843-second reported body.
- After, unloaded: 29–31 ms.
- After, four representative 8× saturation runs: 28–303 ms, all passing.
- After, the formerly red 48× saturation condition: 1.637 seconds, passing.

Validation commands:

- `pnpm exec turbo run test --force --filter=bb-plugin-github` — 6 files, 25 tests passed.
- `pnpm exec turbo run typecheck --force --filter=bb-plugin-github` — passed.
- `pnpm exec turbo run build --force --filter=bb-plugin-github` — passed.
- `pnpm exec oxfmt plugins/github/app.test.tsx --check` — passed.
- `pnpm exec oxlint plugins/github/app.test.tsx` — passed.
- `git diff --check` — passed.

Follow-up base update: the original independently verified base remains `7a6fe643250a93551f31441ff2c8d39aa09c638f`. After [PR #2497](https://github.com/get-bb/bb/pull/2497) resolved the unrelated inherited SDK inventory/version regression, this branch merged current main `ead4c605d0fe16066baef12fa544ab14243c9f78` non-destructively. The PR still changes only `plugins/github/app.test.tsx` relative to main, and the structural fix is preserved unchanged.

> AGENT GENERATED: by GPT-5.6-Sol
