### PR TITLE
Stabilize large-event migration regression

### DIFF
--- a/packages/db/test/helpers/migrated-connection.ts
+++ b/packages/db/test/helpers/migrated-connection.ts
@@ -3,6 +3,25 @@ import type { DbConnection } from "../../src/index.js";
 
 let migratedTemplate: Buffer | null = null;
 
+function getMigratedTemplate(): Buffer {
+  if (migratedTemplate === null) {
+    const db = createConnection(":memory:");
+    try {
+      migrate(db);
+      migratedTemplate = db.$client.serialize();
+    } finally {
+      db.$client.close();
+    }
+  }
+
+  return migratedTemplate;
+}
+
+/** Build the shared template outside a test's timeout budget. */
+export function prepareMigratedConnectionTemplate(): void {
+  getMigratedTemplate();
+}
+
 /**
  * A fresh in-memory database with every migration applied, exactly as
  * `createConnection(":memory:")` followed by `migrate(db)` leaves it. The
@@ -10,13 +29,10 @@ let migratedTemplate: Buffer | null = null;
  * call opens an independent copy of that image. Replaying the 100+
  * migrations costs ~57ms, which the data suites paid once per test.
  *
- * Suites that exercise `migrate` itself keep calling it directly.
+ * Tests that exercise the initial migration keep calling `migrate` directly.
+ * Migration tests may use this only for current-schema setup that they rewind
+ * before exercising a later `migrate` boundary.
  */
 export function createMigratedConnection(): DbConnection {
-  if (migratedTemplate === null) {
-    const db = createConnection(":memory:");
-    migrate(db);
-    migratedTemplate = db.$client.serialize();
-  }
-  return createConnection(migratedTemplate);
+  return createConnection(getMigratedTemplate());
 }

--- a/packages/db/test/migrate.test.ts
+++ b/packages/db/test/migrate.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -17,6 +17,10 @@ import {
   type DbConnection,
   type MigrationWarningLogger,
 } from "../src/index.js";
+import {
+  createMigratedConnection,
+  prepareMigratedConnectionTemplate,
+} from "./helpers/migrated-connection.js";
 
 type InsertMigrationParameters = [string, number];
 type DeleteMigrationParameters = [number];
@@ -1451,6 +1455,13 @@ function deleteDeferredCleanupMigrationRows(db: DbConnection): void {
 }
 
 describe("migrate", () => {
+  beforeAll(() => {
+    // The large-value replay cases need a current database only as a rewind
+    // fixture. Build that shared image outside either case's timeout budget;
+    // each case still exercises the real migrate() boundary after rewinding.
+    prepareMigratedConnectionTemplate();
+  });
+
   it("backfills the first checkout commit component for every artifact shape", () => {
     const db = createConnection(":memory:");
     const commit = "d".repeat(40);
@@ -4305,10 +4316,9 @@ describe("migrate", () => {
   });
 
   it("skips legacy large event value round trip when values are already inline", () => {
-    const db = createConnection(":memory:");
+    const db = createMigratedConnection();
 
     try {
-      migrate(db);
       dropRewindAddedTables(db);
       seedEventLargeValueBackfillThread(db);
       const values = seedEventLargeValueBackfillEvents(db);
@@ -4359,10 +4369,9 @@ describe("migrate", () => {
   });
 
   it("restores legacy large event values to inline payloads", () => {
-    const db = createConnection(":memory:");
+    const db = createMigratedConnection();
 
     try {
-      migrate(db);
       dropRewindAddedTables(db);
       seedEventLargeValueBackfillThread(db);
       const values = seedEventLargeValueBackfillEvents(db);


### PR DESCRIPTION
## Human comments

## What was wrong

The inline large-event migration regression constructed a current database with a full 100+ migration replay inside the case, rewound it to the legacy checkpoint, then ran the real forward migration under test. The first full migration was fixture setup rather than behavior under assertion, but it consumed the same 5 s test budget as the second migration. Stage measurements attributed 86% of the unloaded case and 83% under contention to those two full migrations, which made ordinary packages-shard CPU contention amplify the case past Vitest's unchanged ceiling in [CI run 33006897846](https://github.com/get-bb/bb/actions/runs/33006897846/job/98302865558).

## What changed

- Reuse the existing serialized current-schema database image for the two large-event replay cases, then clone and rewind that image independently for each case.
- Prepare the shared image in `beforeAll`, outside either case's timeout budget. Both cases still invoke the real production `migrate()` boundary after the rewind and retain their migration-ledger, removed-table, and inline-payload assertions.
- Close the one-time template-building connection after serialization instead of retaining it for the worker lifetime.
- No timeout, retry budget, polling deadline, or assertion changed. This is test-only and does not alter any host-daemon wire contract, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

## How you verified

- Exact red/green loop with 640 bounded CPU competitors and the unchanged 5 s timeout:
  - before: failed twice at 6.048 s and 6.534 s
  - after: passed twice at 4.115 s and 4.620 s
- Unloaded exact case: 126 ms before, 64 ms after.
- Focused skip + restore cases: 2/2 passed at 61 ms and 57 ms.
- `pnpm exec turbo run test --filter=@bb/db --force -- --reporter=verbose test/migrate.test.ts`: 42/42 passed; 2.68 s file duration.
- `pnpm exec turbo run test --filter=@bb/db --force`: 409/409 passed; 28/28 files.
- `pnpm exec turbo run typecheck --filter=@bb/db --force`: passed.
- `pnpm exec turbo run build --filter=@bb/db --force`: passed; Turbo reported that `@bb/db` defines no build task.
- PR CI `Tests (packages, ubuntu-latest, Node 22.x)`: passed; the exact case completed in 915 ms and the 42-case migration file in 26.764 s.

> AGENT GENERATED

> AGENT GENERATED: by GPT-5.6-Sol
