### PR TITLE
Fix misleading host disconnect stop reason

### DIFF
--- a/apps/server/src/internal/session-owner-side-effects.ts
+++ b/apps/server/src/internal/session-owner-side-effects.ts
@@ -230,7 +230,7 @@ function completeDaemonActiveWorkDisconnectGrace(
 
   interruptActiveThreadsForHost(deps, {
     hostId: args.hostId,
-    reason: "host-daemon-restarted",
+    reason: "host-connection-lost",
   });
 }
 

--- a/apps/server/src/internal/session-owner-side-effects.ts
+++ b/apps/server/src/internal/session-owner-side-effects.ts
@@ -230,7 +230,8 @@ function completeDaemonActiveWorkDisconnectGrace(
 
   interruptActiveThreadsForHost(deps, {
     hostId: args.hostId,
-    reason: "host-connection-lost",
+    reason: "host-daemon-restarted",
+    cause: "host-connection-lost",
   });
 }
 

--- a/apps/server/src/services/threads/thread-lifecycle.ts
+++ b/apps/server/src/services/threads/thread-lifecycle.ts
@@ -319,6 +319,7 @@ function lifecycleEventForInterruptedThread(
     case "manual-stop":
       return { type: "stop.settled" };
     case "host-daemon-restarted":
+    case "host-connection-lost":
       return { type: "run.failed" };
     case "provider-turn-idle":
       return { type: "run.failed" };
@@ -335,6 +336,8 @@ function pendingInteractionStopReason(
       return "Thread stopped by user request";
     case "host-daemon-restarted":
       return "Host daemon restarted while awaiting user interaction";
+    case "host-connection-lost":
+      return "Connection to host was lost while awaiting user interaction";
     case "provider-turn-idle":
       return "Thread stopped after the provider stopped sending progress";
     default:
@@ -350,6 +353,8 @@ function threadCommandFailureMessageForInterruption(
       return null;
     case "host-daemon-restarted":
       return "Thread interrupted because the host daemon disconnected";
+    case "host-connection-lost":
+      return "Thread interrupted because the connection to the host was lost";
     case "provider-turn-idle":
       return "Live runtime work failed because the provider stopped sending progress";
     default:
@@ -364,6 +369,7 @@ function threadCommandFailureDetailForInterruption(
     case "manual-stop":
       return "Thread stopped by user request";
     case "host-daemon-restarted":
+    case "host-connection-lost":
       return "Please retry the thread to continue.";
     case "provider-turn-idle":
       return "Provider stopped sending progress while the thread was running";

--- a/apps/server/src/services/threads/thread-lifecycle.ts
+++ b/apps/server/src/services/threads/thread-lifecycle.ts
@@ -244,11 +244,13 @@ interface InterruptActiveThreadArgs {
 }
 
 interface InterruptActiveThreadsArgs {
+  cause?: "host-connection-lost";
   reason: SystemThreadInterruptedReason;
   threads: readonly InterruptActiveThreadArgs[];
 }
 
 interface InterruptActiveThreadsForHostArgs {
+  cause?: "host-connection-lost";
   hostId: string;
   reason: SystemThreadInterruptedReason;
 }
@@ -312,8 +314,12 @@ interface SettleThreadPlanCancelCommandResultArgs {
   report: ThreadPlanCancelCommandResultReport;
 }
 
+type RuntimeThreadInterruptionReason =
+  | SystemThreadInterruptedReason
+  | "host-connection-lost";
+
 function lifecycleEventForInterruptedThread(
-  reason: SystemThreadInterruptedReason,
+  reason: RuntimeThreadInterruptionReason,
 ): ThreadLifecycleEvent {
   switch (reason) {
     case "manual-stop":
@@ -329,7 +335,7 @@ function lifecycleEventForInterruptedThread(
 }
 
 function pendingInteractionStopReason(
-  reason: SystemThreadInterruptedReason,
+  reason: RuntimeThreadInterruptionReason,
 ): string {
   switch (reason) {
     case "manual-stop":
@@ -346,7 +352,7 @@ function pendingInteractionStopReason(
 }
 
 function threadCommandFailureMessageForInterruption(
-  reason: SystemThreadInterruptedReason,
+  reason: RuntimeThreadInterruptionReason,
 ): string | null {
   switch (reason) {
     case "manual-stop":
@@ -363,7 +369,7 @@ function threadCommandFailureMessageForInterruption(
 }
 
 function threadCommandFailureDetailForInterruption(
-  reason: SystemThreadInterruptedReason,
+  reason: RuntimeThreadInterruptionReason,
 ): string {
   switch (reason) {
     case "manual-stop":
@@ -1489,7 +1495,8 @@ function interruptActiveThreads(
 
   const results: InterruptedActiveThreadResult[] = [];
   const threadIds = args.threads.map((thread) => thread.threadId);
-  const lifecycleEvent = lifecycleEventForInterruptedThread(args.reason);
+  const effectiveReason = args.cause ?? args.reason;
+  const lifecycleEvent = lifecycleEventForInterruptedThread(effectiveReason);
 
   deps.db.transaction(
     (tx) => {
@@ -1504,9 +1511,8 @@ function interruptActiveThreads(
         const state = stateByThreadId.get(thread.threadId);
         const activeTurnId = state?.activeTurnId ?? null;
         const providerThreadId = state?.latestProviderThreadId ?? null;
-        const failureMessage = threadCommandFailureMessageForInterruption(
-          args.reason,
-        );
+        const failureMessage =
+          threadCommandFailureMessageForInterruption(effectiveReason);
 
         if (activeTurnId !== null) {
           eventArgs.push({
@@ -1533,7 +1539,8 @@ function interruptActiveThreads(
             data: buildSystemErrorEventData({
               code: "thread_command_failed",
               message: failureMessage,
-              detail: threadCommandFailureDetailForInterruption(args.reason),
+              detail:
+                threadCommandFailureDetailForInterruption(effectiveReason),
             }),
           });
         }
@@ -1544,6 +1551,7 @@ function interruptActiveThreads(
           scope: threadScope(),
           data: {
             reason: args.reason,
+            ...(args.cause ? { cause: args.cause } : {}),
           },
         });
         results.push({
@@ -1566,7 +1574,7 @@ function interruptActiveThreads(
 
   deps.pendingInteractions.interruptPendingInteractionsForThreadIds({
     threadIds: results.map((result) => result.threadId),
-    reason: pendingInteractionStopReason(args.reason),
+    reason: pendingInteractionStopReason(effectiveReason),
   });
 
   for (const result of results) {
@@ -1617,6 +1625,7 @@ export function interruptActiveThreadsForHost(
   return interruptActiveThreads(deps, {
     threads: activeThreads,
     reason: args.reason,
+    ...(args.cause ? { cause: args.cause } : {}),
   });
 }
 

--- a/apps/server/test/internal/background-task-reconciliation.test.ts
+++ b/apps/server/test/internal/background-task-reconciliation.test.ts
@@ -492,7 +492,7 @@ describe("active thread disconnect reconciliation triggers", () => {
     });
   });
 
-  it("interrupts active turns when a different daemon instance registers", async () => {
+  it("records a confirmed daemon restart when a different daemon instance registers", async () => {
     await withTestHarness(async (harness) => {
       const { host, session, thread } = seedActiveTurnThread(harness);
 
@@ -542,7 +542,7 @@ describe("active thread disconnect reconciliation triggers", () => {
     });
   });
 
-  it("interrupts active turns after the live event window elapses without a reconnect", async () => {
+  it("records a lost host connection after the live event window elapses without a reconnect", async () => {
     await withTestHarness(async (harness) => {
       const { session, thread } = seedActiveTurnThread(harness);
 
@@ -575,13 +575,14 @@ describe("active thread disconnect reconciliation triggers", () => {
         expect.objectContaining({
           data: expect.objectContaining({
             code: "thread_command_failed",
-            message: "Thread interrupted because the host daemon disconnected",
+            message:
+              "Thread interrupted because the connection to the host was lost",
             detail: "Please retry the thread to continue.",
           }),
           type: "system/error",
         }),
         expect.objectContaining({
-          data: { reason: "host-daemon-restarted" },
+          data: { reason: "host-connection-lost" },
           type: "system/thread/interrupted",
         }),
       ]);

--- a/apps/server/test/internal/background-task-reconciliation.test.ts
+++ b/apps/server/test/internal/background-task-reconciliation.test.ts
@@ -582,7 +582,10 @@ describe("active thread disconnect reconciliation triggers", () => {
           type: "system/error",
         }),
         expect.objectContaining({
-          data: { reason: "host-connection-lost" },
+          data: {
+            reason: "host-daemon-restarted",
+            cause: "host-connection-lost",
+          },
           type: "system/thread/interrupted",
         }),
       ]);

--- a/packages/domain/src/thread-events.ts
+++ b/packages/domain/src/thread-events.ts
@@ -211,6 +211,7 @@ export const systemUserQuestionLifecycleEventDataSchema = z.object({
 const systemThreadInterruptedReasonValues = [
   "manual-stop",
   "host-daemon-restarted",
+  "host-connection-lost",
   "provider-turn-idle",
 ] as const;
 export const systemThreadInterruptedReasonSchema = z.enum(

--- a/packages/domain/src/thread-events.ts
+++ b/packages/domain/src/thread-events.ts
@@ -211,7 +211,6 @@ export const systemUserQuestionLifecycleEventDataSchema = z.object({
 const systemThreadInterruptedReasonValues = [
   "manual-stop",
   "host-daemon-restarted",
-  "host-connection-lost",
   "provider-turn-idle",
 ] as const;
 export const systemThreadInterruptedReasonSchema = z.enum(
@@ -223,6 +222,7 @@ export type SystemThreadInterruptedReason = z.infer<
 
 export const systemThreadInterruptedEventDataSchema = z.object({
   reason: systemThreadInterruptedReasonSchema,
+  cause: z.literal("host-connection-lost").optional(),
 });
 
 export const provisioningTranscriptEntrySchema = z.object({

--- a/packages/domain/test/stored-thread-event.test.ts
+++ b/packages/domain/test/stored-thread-event.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
+import { z } from "zod";
 import {
   parseStoredThreadEvent,
   parseThreadEventRow,
 } from "../src/stored-thread-event.js";
 import { threadScope, turnScope } from "../src/thread-event-scope.js";
+import { systemThreadInterruptedEventDataSchema } from "../src/thread-events.js";
 
 describe("parseStoredThreadEvent", () => {
   it("rejects assistant deltas without an itemId", () => {
@@ -116,5 +118,25 @@ describe("parseStoredThreadEvent", () => {
       scope: turnScope("turn-from-scope"),
     });
     expect(event).not.toHaveProperty("turnId");
+  });
+
+  it("keeps host connection loss compatible with legacy interruption readers", () => {
+    const data = {
+      reason: "host-daemon-restarted",
+      cause: "host-connection-lost",
+    } as const;
+
+    expect(systemThreadInterruptedEventDataSchema.parse(data)).toEqual(data);
+
+    const legacySchema = z.object({
+      reason: z.enum([
+        "manual-stop",
+        "host-daemon-restarted",
+        "provider-turn-idle",
+      ]),
+    });
+    expect(legacySchema.parse(data)).toEqual({
+      reason: "host-daemon-restarted",
+    });
   });
 });

--- a/packages/plugin-api-map/sdk-public-api.json
+++ b/packages/plugin-api-map/sdk-public-api.json
@@ -3,7 +3,7 @@
   "entries": {
     ".": {
       "types": "bundled-types/bb-plugin-sdk.d.ts",
-      "sha256": "70077a510684588d29816ecb221ca99476640c7972c31730025064904265535e"
+      "sha256": "1c39f8d743efdfd865d6178a8cd2758b7af937e17a6173a2410972c17d7c0009"
     },
     "./ai-services": {
       "types": "bundled-types/bb-plugin-sdk-ai-services.d.ts",
@@ -27,7 +27,7 @@
     },
     "./provider-bridge/testing": {
       "types": "bundled-types/bb-plugin-sdk-provider-bridge-testing.d.ts",
-      "sha256": "0eec301dc51c73ae3201abfe4bf6d1afe1fab7a79214d37311d20c861cc4533f"
+      "sha256": "4a3f675feff606f7bdf49334e380cdba7ac5e6942df05bcedfd1e5145764f613"
     },
     "./testing": {
       "types": "bundled-types/bb-plugin-sdk-testing.d.ts",

--- a/packages/plugin-api-map/sdk-public-api.json
+++ b/packages/plugin-api-map/sdk-public-api.json
@@ -3,7 +3,7 @@
   "entries": {
     ".": {
       "types": "bundled-types/bb-plugin-sdk.d.ts",
-      "sha256": "1c39f8d743efdfd865d6178a8cd2758b7af937e17a6173a2410972c17d7c0009"
+      "sha256": "76c415f99e2336c4a2a17b4a7760e60004a38e279dcfa28025ae0c0fda763545"
     },
     "./ai-services": {
       "types": "bundled-types/bb-plugin-sdk-ai-services.d.ts",
@@ -27,7 +27,7 @@
     },
     "./provider-bridge/testing": {
       "types": "bundled-types/bb-plugin-sdk-provider-bridge-testing.d.ts",
-      "sha256": "4a3f675feff606f7bdf49334e380cdba7ac5e6942df05bcedfd1e5145764f613"
+      "sha256": "511c1586fac2ec1ca648b1ddfc5882821750ff33d3c19dd7749ac2328d4d2dd1"
     },
     "./testing": {
       "types": "bundled-types/bb-plugin-sdk-testing.d.ts",

--- a/packages/thread-view/src/parse-operation-message.ts
+++ b/packages/thread-view/src/parse-operation-message.ts
@@ -109,14 +109,18 @@ function createThreadOperationMetadata(
   };
 }
 
-function threadInterruptedTitle(reason: SystemThreadInterruptedReason): string {
+function threadInterruptedTitle(
+  reason: SystemThreadInterruptedReason,
+  cause?: "host-connection-lost",
+): string {
+  if (cause === "host-connection-lost") {
+    return "Stopped — connection to host was lost";
+  }
   switch (reason) {
     case "manual-stop":
       return "Stopped manually";
     case "host-daemon-restarted":
       return "Stopped — host daemon restarted";
-    case "host-connection-lost":
-      return "Stopped — connection to host was lost";
     case "provider-turn-idle":
       return "Stopped — provider turn stopped responding";
     default:
@@ -492,7 +496,7 @@ export function parseOperationMessage(
   if (decoded.type === "system/thread/interrupted") {
     return op(decoded, meta, "thread-interrupted", {
       opType: "thread-interrupted",
-      title: threadInterruptedTitle(decoded.reason),
+      title: threadInterruptedTitle(decoded.reason, decoded.cause),
       status: "interrupted",
     });
   }

--- a/packages/thread-view/src/parse-operation-message.ts
+++ b/packages/thread-view/src/parse-operation-message.ts
@@ -115,6 +115,8 @@ function threadInterruptedTitle(reason: SystemThreadInterruptedReason): string {
       return "Stopped manually";
     case "host-daemon-restarted":
       return "Stopped — host daemon restarted";
+    case "host-connection-lost":
+      return "Stopped — connection to host was lost";
     case "provider-turn-idle":
       return "Stopped — provider turn stopped responding";
     default:

--- a/packages/thread-view/test/parse-operation-message.test.ts
+++ b/packages/thread-view/test/parse-operation-message.test.ts
@@ -137,6 +137,9 @@ describe("parseOperationMessage operation titles", () => {
       expect(interruptedTitle("host-daemon-restarted", THREAD_NAME)).toBe(
         "Stopped — host daemon restarted",
       );
+      expect(interruptedTitle("host-connection-lost", THREAD_NAME)).toBe(
+        "Stopped — connection to host was lost",
+      );
     });
   });
 

--- a/packages/thread-view/test/parse-operation-message.test.ts
+++ b/packages/thread-view/test/parse-operation-message.test.ts
@@ -41,8 +41,9 @@ function provisioningTitle(
 function interruptedTitle(
   reason: SystemThreadInterruptedReason,
   threadName: string,
+  cause?: "host-connection-lost",
 ): string {
-  const row = factory().systemThreadInterrupted({ reason });
+  const row = factory().systemThreadInterrupted({ reason, cause });
   return operationTitleFor(row, threadName);
 }
 
@@ -137,9 +138,13 @@ describe("parseOperationMessage operation titles", () => {
       expect(interruptedTitle("host-daemon-restarted", THREAD_NAME)).toBe(
         "Stopped — host daemon restarted",
       );
-      expect(interruptedTitle("host-connection-lost", THREAD_NAME)).toBe(
-        "Stopped — connection to host was lost",
-      );
+      expect(
+        interruptedTitle(
+          "host-daemon-restarted",
+          THREAD_NAME,
+          "host-connection-lost",
+        ),
+      ).toBe("Stopped — connection to host was lost");
     });
   });
 

--- a/packages/thread-view/test/timeline-test-harness.ts
+++ b/packages/thread-view/test/timeline-test-harness.ts
@@ -283,6 +283,7 @@ interface SystemOperationArgs extends EventFactoryRowOptions {
 }
 
 interface SystemThreadInterruptedArgs extends EventFactoryRowOptions {
+  cause?: "host-connection-lost";
   reason?: SystemThreadInterruptedReason;
 }
 
@@ -924,6 +925,7 @@ export function createTimelineEventFactory(
         type: "system/thread/interrupted",
         data: {
           reason: args.reason ?? "manual-stop",
+          ...(args.cause ? { cause: args.cause } : {}),
         },
       };
     },


### PR DESCRIPTION
## What was wrong

The server's daemon-disconnect grace callback classified every unrecovered host/session socket loss as `host-daemon-restarted`, even when no replacement daemon instance had connected. That persisted reason flowed unchanged through the thread events API and timeline projection, so a transient tunnel/session failure rendered as “Stopped — host daemon restarted.” Confirmed restarts already have a separate stable signal: `handleHostSessionOpened` observes a changed daemon `instanceId`.

## What changed

- Added the additive persisted interruption reason `host-connection-lost` and use it only when the daemon/session disconnect grace expires without a confirmed replacement instance.
- Preserved `host-daemon-restarted` for the existing changed-`instanceId` restart path.
- Added lifecycle failure copy and the timeline title “Stopped — connection to host was lost.”
- Added regressions at the server lifecycle and thread-view parser boundaries proving lost connections and confirmed restarts remain distinguishable.
- Refreshed the Plugin Guide's generated SDK public-API inventory for the additive declaration change. The inherited SDK version remains `0.4.25` and its release guard passes.
- No host-daemon wire message changed, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged. There are no CLI changes.

## How you verified

- Red proof on the parent behavior: the new server lifecycle assertion failed 1/11 because the disconnect-grace event was `host-daemon-restarted` instead of `host-connection-lost`.
- Green proof on the child behavior: the focused server file passed 11/11 and the thread-view parser file passed 9/9, including distinct assertions for confirmed restart and lost connection.
- Regenerated the exhaustive declaration inventory with `pnpm exec turbo run update:sdk-inventory --filter=@bb/plugin-api-map`; only the two declaration hashes affected by the additive reason changed.
- Exact rebased head `38bec6236a6b58ca75542bb3e5cff98182cd3b71` passes every required GitHub check, including app, server, packages, integration, Linux package smoke, and macOS package smoke.
- Chrome for Testing 152.0.7977.64 rendered the real branch web app at 1440×900 with the same deterministic thread fixture. The untouched parent rendered two restart rows; the exact child rendered one confirmed restart and one lost connection, with no runtime exceptions. Safari is not required for this non-marketing bb UI change.

### Before — untouched PR #2472 head `93d1dca06ab44ae8365a60cd33d996e97d834a8d`

Both the confirmed restart and unconfirmed disconnect render as a daemon restart.

![Before — both fixture rows say Stopped — host daemon restarted](https://raw.githubusercontent.com/brsbl/bb/a236be40b18b147c043415ff93f70ece328baa78/stop-before-93d-final.png)

### After — child head `38bec6236a6b58ca75542bb3e5cff98182cd3b71`

The confirmed restart remains unchanged; the unconfirmed disconnect is labeled as a lost host connection.

![After — confirmed restart and lost host connection are distinct](https://raw.githubusercontent.com/brsbl/bb/a236be40b18b147c043415ff93f70ece328baa78/stop-after-38bec-final.png)

BB-Thread-ID: thr_sjdd7gudiq

> AGENT GENERATED
