### PR TITLE
Align provider icons in the sidebar update badge

### DIFF
--- a/apps/app/src/components/sidebar/SidebarUpdatesBadge.test.tsx
+++ b/apps/app/src/components/sidebar/SidebarUpdatesBadge.test.tsx
@@ -255,6 +255,11 @@ describe("SidebarUpdatesBadge", () => {
         node.getAttribute("data-provider-icon"),
       ),
     ).toEqual(["claude-code", "codex"]);
+    expect(
+      [...providerChip.querySelectorAll("[data-provider-icon]")].every((node) =>
+        node.classList.contains("flex"),
+      ),
+    ).toBe(true);
     expect(screen.getByTestId("sidebar-updates-badge-bb")).toBeTruthy();
   });
 });

--- a/apps/app/src/components/sidebar/SidebarUpdatesBadge.tsx
+++ b/apps/app/src/components/sidebar/SidebarUpdatesBadge.tsx
@@ -139,6 +139,7 @@ export function SidebarUpdatesBadge({ onNavigate }: SidebarUpdatesBadgeProps) {
                       key={stale.provider}
                       data-provider-icon={providerId}
                       aria-hidden
+                      className="flex size-3 shrink-0 items-center justify-center"
                     >
                       {provider === undefined ? (
                         <iconInfo.icon className="size-3" />


### PR DESCRIPTION
## Human comments

## What was wrong

The provider marks in the sidebar update badge used inline wrappers. Their text baselines placed the marks at different vertical positions from the download icon.

## What changed

The provider mark wrappers now use fixed-size flex boxes that center each mark with the download icon. The badge test now checks the flex alignment wrapper. This change has no wire, CLI, or documentation effect.

## How you verified

- `pnpm exec turbo run test --filter=@bb/app -- src/components/sidebar/SidebarUpdatesBadge.test.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- Captured the badge with Codex and Claude Code update fixtures in the development app.

> AGENT GENERATED
