### PR TITLE
Lower follow-up composer control emphasis

### DIFF
--- a/apps/app/src/components/pickers/ModelReasoningPicker.test.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.test.tsx
@@ -159,6 +159,7 @@ function renderPicker({
   modelLoadError = null,
   compact = false,
   splitPane = false,
+  muted = false,
 }: {
   onSelectedProviderChange?: ((value: string) => void) | null;
   onModelChange?: (value: string) => void;
@@ -176,6 +177,7 @@ function renderPicker({
   modelLoadError?: SystemExecutionOptionsModelLoadError | null;
   compact?: boolean;
   splitPane?: boolean;
+  muted?: boolean;
 } = {}) {
   const { queryClient, wrapper } = createQueryClientTestHarness();
   queryClient.setQueryData(
@@ -215,6 +217,7 @@ function renderPicker({
         fastModeEnabled={false}
         onFastModeChange={vi.fn()}
         showFastModeToggle={false}
+        muted={muted}
         modal={false}
       />
       <button type="button">Composer action</button>
@@ -248,6 +251,17 @@ afterEach(() => {
 });
 
 describe("ModelReasoningPicker", () => {
+  it("uses the lower-emphasis chrome token for the composer caret", () => {
+    renderPicker({ muted: true });
+
+    const trigger = screen.getByRole("button", {
+      name: "Provider, model and reasoning",
+    });
+    expect(
+      trigger.querySelector('[data-icon="ChevronDown"]')?.classList,
+    ).toContain("text-subtle-foreground/75");
+  });
+
   it("gives a non-SVG provider mark the same 16px trigger size as button SVGs", () => {
     renderPicker({
       pickerProviderOptions: [

--- a/apps/app/src/components/pickers/ModelReasoningPicker.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.tsx
@@ -855,7 +855,10 @@ export function ModelReasoningPicker({
       {disabled ? null : (
         <Icon
           name="ChevronDown"
-          className="size-3.5 shrink-0 text-muted-foreground"
+          className={cn(
+            "size-3.5 shrink-0",
+            muted ? "text-subtle-foreground/75" : "text-muted-foreground",
+          )}
         />
       )}
       <AppCommandShortcutHint

--- a/apps/app/src/components/promptbox/FollowUpPromptBox.stories.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.stories.tsx
@@ -30,9 +30,7 @@ import {
   getFollowUpPromptPlaceholder,
   getCompactFollowUpPromptPlaceholder,
 } from "@/components/promptbox/follow-up-placeholder";
-import {
-  getEnvironmentWorkspaceSummaryDisplay,
-} from "@/lib/environment-workspace-display";
+import { getEnvironmentWorkspaceSummaryDisplay } from "@/lib/environment-workspace-display";
 import {
   INERT_TYPEAHEAD_COMMAND_CONFIG,
   type AttachmentsConfig,
@@ -845,6 +843,14 @@ function StackedCardsWithPillsRow() {
       queuedMessages={queuedMessages}
       contextWindowUsage={usage}
     />
+  );
+}
+
+export function ControlEmphasis() {
+  return (
+    <div className="mx-auto flex min-h-[28rem] w-full max-w-3xl items-end p-4">
+      <Row submitMode={{ kind: "ready" }} />
+    </div>
   );
 }
 

--- a/apps/app/src/components/promptbox/PromptBoxActionsMenu.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxActionsMenu.test.tsx
@@ -43,10 +43,9 @@ describe("PromptBoxActionsMenu", () => {
     const onAttach = vi.fn();
     render(<PromptBoxActionsMenu onAction={() => {}} onAttach={onAttach} />);
 
-    fireEvent.pointerDown(
-      screen.getByRole("button", { name: "Prompt actions" }),
-      { button: 0 },
-    );
+    const trigger = screen.getByRole("button", { name: "Prompt actions" });
+    expect(trigger.classList).toContain("text-subtle-foreground/75");
+    fireEvent.pointerDown(trigger, { button: 0 });
     fireEvent.click(
       await screen.findByRole("menuitem", { name: "Attach files" }),
     );

--- a/apps/app/src/components/promptbox/PromptBoxActionsMenu.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxActionsMenu.tsx
@@ -17,6 +17,7 @@ import { useResolvedComposerPlusMenuItems } from "@/components/plugin/composer-s
 import { useOptionalPluginComposerView } from "@/components/plugin/plugin-composer-host";
 import { Icon, type IconName } from "@bb/shared-ui/icon";
 import { COARSE_POINTER_PROMPT_ICON_ACTION_BUTTON_CLASS } from "@bb/shared-ui/coarse-pointer-sizing";
+import { CHROME_SUBTLE_ICON_BUTTON_FOREGROUND_CLASS } from "@bb/shared-ui/chrome-style-tokens";
 import { CREATE_PLUGIN_PROMPT } from "@bb/client-core";
 import type { ProviderPromptActionCommand } from "@bb/client-core";
 
@@ -181,6 +182,7 @@ export function PromptBoxActionsMenu({
           aria-label="Prompt actions"
           className={cn(
             COARSE_POINTER_PROMPT_ICON_ACTION_BUTTON_CLASS,
+            CHROME_SUBTLE_ICON_BUTTON_FOREGROUND_CLASS,
             "-ml-1.5",
           )}
         >

--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -1648,9 +1648,11 @@ describe("PromptBoxInternal size controls", () => {
     expect(
       screen.queryByRole("button", { name: /Make prompt box/u }),
     ).toBeNull();
-    fireEvent.click(
-      screen.getByRole("button", { name: "Collapse prompt box" }),
-    );
+    const collapseButton = screen.getByRole("button", {
+      name: "Collapse prompt box",
+    });
+    expect(collapseButton.classList).toContain("text-subtle-foreground/75");
+    fireEvent.click(collapseButton);
 
     expect(onCollapse).toHaveBeenCalledOnce();
     expect(document.activeElement).not.toBe(getPromptEditorElement());

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -68,6 +68,7 @@ import {
   COARSE_POINTER_PROMPT_ACTION_BUTTON_CLASS,
   COARSE_POINTER_PROMPT_ICON_ACTION_BUTTON_CLASS,
 } from "@bb/shared-ui/coarse-pointer-sizing";
+import { CHROME_SUBTLE_ICON_BUTTON_FOREGROUND_CLASS } from "@bb/shared-ui/chrome-style-tokens";
 import { usePointerCoarse } from "@bb/shared-ui/hooks/use-pointer-coarse";
 import {
   getMediaQuerySnapshot,
@@ -3030,7 +3031,7 @@ export function PromptBoxInternal({
                       onClick={collapsePromptBox}
                       aria-label="Collapse prompt box"
                       className={cn(
-                        "text-subtle-foreground hover:text-muted-foreground",
+                        CHROME_SUBTLE_ICON_BUTTON_FOREGROUND_CLASS,
                         COARSE_POINTER_PROMPT_ICON_ACTION_BUTTON_CLASS,
                       )}
                     >


### PR DESCRIPTION
## What was wrong

Secondary follow-up composer affordances used three different foreground tiers: the plus action inherited the primary foreground, the model caret used the muted foreground, and the collapse caret used the subtle foreground. That inconsistency gave low-priority chrome more visual weight than its function warranted.

## What changed

- Moves the composer collapse caret and plus action to the established shared subtle chrome-button treatment.
- Moves the model-picker caret to the same `text-subtle-foreground/75` tier only in its muted composer presentation; non-composer styling is unchanged.
- Preserves hover, focus, menu, collapse, and responsive behavior.
- Adds focused regression assertions for all three foreground treatments and a focused Ladle state.
- No daemon wire, SDK, API, CLI, or persisted contract changes.

## How you verified

- Red proof on the parent behavior: computed light-theme colors resolved to three different tiers—`foreground` for plus, `muted-foreground` for the model caret, and `subtle-foreground` for collapse.
- Green proof on the child behavior: the focused class assertions pass with all three resolving to `subtle-foreground/75`; the relevant app test files passed 144/144.
- Exact rebased head `699352c7e7576ee937d68d3e9f43f02f570aecfd` passes every required GitHub check, including all app shards, packages, server, integration, and Linux/macOS package smoke.
- Chrome for Testing 152.0.7977.64 rendered the same `Stacked cards with pills` fixture at 1440×900 on exact parent and child heads. The deliberate interaction pass covered plus-menu, model-menu, collapse, focus re-expansion, light/dark rendering, responsive widths, and runtime exceptions. The later rebase changed only ancestor SDK inventory metadata, not this layer's app tree. Safari is not required for this non-marketing bb UI change.

### Before — parent head `38bec6236a6b58ca75542bb3e5cff98182cd3b71`

The plus action, model caret, and collapse caret use stronger, inconsistent foreground tiers.

![Before — composer controls at inconsistent foreground tiers](https://raw.githubusercontent.com/brsbl/bb/a236be40b18b147c043415ff93f70ece328baa78/controls-before-38bec-final.png)

### After — child head `699352c7e7576ee937d68d3e9f43f02f570aecfd`

All three affordances use the same lower-emphasis chrome tier while model text and primary actions retain their hierarchy.

![After — composer controls share the lower-emphasis chrome tier](https://raw.githubusercontent.com/brsbl/bb/a236be40b18b147c043415ff93f70ece328baa78/controls-after-699352-final.png)

BB-Thread-ID: thr_sjdd7gudiq

> AGENT GENERATED
