### PR TITLE
Improve follow-up environment story coverage

### DIFF
--- a/apps/app/src/components/promptbox/FollowUpPromptBox.stories.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.stories.tsx
@@ -298,6 +298,20 @@ const remoteWorktreeEnvironmentSummary: ReactNode = makeEnvironmentSummary({
   onCreateNewThreadInWorktree: noop,
 });
 
+const unmanagedWorktreeEnvironmentSummary: ReactNode = makeEnvironmentSummary({
+  environment: makeEnvironment({
+    name: "Linked review tree",
+    managed: false,
+    isWorktree: true,
+    workspaceProvisionType: "unmanaged",
+    status: "ready",
+  }),
+  host: localEnvironmentDisplayHost,
+  machineName: "Bersabel's MacBook Pro",
+  branchName: STORY_BRANCH_NAME,
+  onCreateNewThreadInWorktree: noop,
+});
+
 const namedWorktreeEnvironmentSummary: ReactNode = makeEnvironmentSummary({
   environment: makeEnvironment({
     name: "Design system polish",
@@ -317,6 +331,7 @@ const detachedWorktreeEnvironmentSummary: ReactNode = makeEnvironmentSummary({
     status: "ready",
   }),
   host: localEnvironmentDisplayHost,
+  machineName: "Bersabel's MacBook Pro",
   environmentCheckout: formatWorkspaceCheckoutDisplay({
     checkout: {
       kind: "detached",
@@ -842,6 +857,7 @@ function StackedCardsWithPillsRow() {
       stack={contextBannerElement}
       queuedMessages={queuedMessages}
       contextWindowUsage={usage}
+      environmentSummary={remoteEnvironmentSummary}
     />
   );
 }
@@ -854,6 +870,9 @@ export function ControlEmphasis() {
   );
 }
 
+// This catalog is intentionally mixed across direct/worktree and local/remote
+// environments. Leaving every functional row on Row's local default hides the
+// environment icon and label variants this overview is meant to expose.
 export function Overview() {
   return (
     <StoryCard>
@@ -868,6 +887,7 @@ export function Overview() {
           submitMode={{ kind: "queue", onStop: noop }}
           threadRuntimeDisplayStatus="active"
           contextWindowUsage={usage}
+          environmentSummary={worktreeEnvironmentSummary}
         />
       </StoryRow>
       <StoryRow
@@ -877,13 +897,17 @@ export function Overview() {
         <Row
           submitMode={{ kind: "stop-only", onStop: noop }}
           threadRuntimeDisplayStatus="host-reconnecting"
+          environmentSummary={remoteEnvironmentSummary}
         />
       </StoryRow>
       <StoryRow
         label="blocked: pending interaction"
         hint="agent is waiting on a tool decision — composer locked"
       >
-        <Row submitMode={{ kind: "blocked", reason: "pending-interaction" }} />
+        <Row
+          submitMode={{ kind: "blocked", reason: "pending-interaction" }}
+          environmentSummary={remoteWorktreeEnvironmentSummary}
+        />
       </StoryRow>
       <StoryRow
         label="stop-only: starting"
@@ -904,6 +928,7 @@ export function Overview() {
           isFollowUpSubmitting
           threadRuntimeDisplayStatus="active"
           initialMessage="And confirm the new env summary renders correctly."
+          environmentSummary={namedWorktreeEnvironmentSummary}
         />
       </StoryRow>
       <StoryRow
@@ -923,6 +948,7 @@ export function Overview() {
               loadFailed: false,
             },
           }}
+          environmentSummary={unmanagedWorktreeEnvironmentSummary}
         />
       </StoryRow>
       <StoryRow
@@ -943,6 +969,7 @@ export function Overview() {
               loadError: codexModelLoadError,
             },
           }}
+          environmentSummary={remoteEnvironmentSummary}
         />
       </StoryRow>
       <StoryRow label="no models" hint="locked provider with empty catalog">
@@ -960,6 +987,7 @@ export function Overview() {
               loadError: null,
             },
           }}
+          environmentSummary={detachedWorktreeEnvironmentSummary}
         />
       </StoryRow>
       <StoryRow
@@ -971,10 +999,15 @@ export function Overview() {
           threadRuntimeDisplayStatus="active"
           queuedMessages={queuedMessages}
           contextWindowUsage={usage}
+          environmentSummary={remoteWorktreeEnvironmentSummary}
         />
       </StoryRow>
       <StoryRow label="with promptbox context banner">
-        <Row submitMode={{ kind: "ready" }} stack={contextBannerElement} />
+        <Row
+          submitMode={{ kind: "ready" }}
+          stack={contextBannerElement}
+          environmentSummary={localEnvironmentSummary}
+        />
       </StoryRow>
       <StoryRow
         label="plan mode: permission locked"
@@ -990,6 +1023,7 @@ export function Overview() {
             providerId: "claude-code",
             prompt: "inspect the failing command before making changes",
           }}
+          environmentSummary={remoteEnvironmentSummary}
         />
       </StoryRow>
       <StoryRow
@@ -1022,6 +1056,7 @@ export function Overview() {
           stack={contextBannerElement}
           queuedMessages={queuedMessages}
           contextWindowUsage={usage}
+          environmentSummary={namedWorktreeEnvironmentSummary}
         />
       </StoryRow>
       <StoryRow
@@ -1084,6 +1119,7 @@ export function Overview() {
           execution={readOnlyExecution}
           permission={readOnlyPermission}
           readOnly
+          environmentSummary={remoteEnvironmentSummary}
         />
       </StoryRow>
     </StoryCard>
@@ -1130,7 +1166,7 @@ export function EnvironmentMatrix() {
       </StoryRow>
       <StoryRow
         label="ready · local worktree"
-        hint="worktree icon · Local worktree tooltip"
+        hint="managed worktree · worktree icon · Local worktree tooltip"
       >
         <Row
           submitMode={{ kind: "ready" }}
@@ -1139,11 +1175,38 @@ export function EnvironmentMatrix() {
       </StoryRow>
       <StoryRow
         label="ready · remote worktree"
-        hint="worktree icon · Remote worktree tooltip"
+        hint="managed worktree · worktree icon · Remote worktree tooltip"
       >
         <Row
           submitMode={{ kind: "ready" }}
           environmentSummary={remoteWorktreeEnvironmentSummary}
+        />
+      </StoryRow>
+      <StoryRow
+        label="ready · unmanaged worktree"
+        hint="linked worktree · same worktree icon; ownership is not encoded here"
+      >
+        <Row
+          submitMode={{ kind: "ready" }}
+          environmentSummary={unmanagedWorktreeEnvironmentSummary}
+        />
+      </StoryRow>
+      <StoryRow
+        label="ready · named worktree"
+        hint="worktree icon · custom environment name"
+      >
+        <Row
+          submitMode={{ kind: "ready" }}
+          environmentSummary={namedWorktreeEnvironmentSummary}
+        />
+      </StoryRow>
+      <StoryRow
+        label="ready · detached worktree"
+        hint="worktree icon · detached commit checkout"
+      >
+        <Row
+          submitMode={{ kind: "ready" }}
+          environmentSummary={detachedWorktreeEnvironmentSummary}
         />
       </StoryRow>
       <StoryRow

--- a/apps/app/src/components/promptbox/FollowUpPromptBox.stories.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.stories.tsx
@@ -870,9 +870,6 @@ export function ControlEmphasis() {
   );
 }
 
-// This catalog is intentionally mixed across direct/worktree and local/remote
-// environments. Leaving every functional row on Row's local default hides the
-// environment icon and label variants this overview is meant to expose.
 export function Overview() {
   return (
     <StoryCard>


### PR DESCRIPTION
## What was wrong

The follow-up composer story catalog defaulted every row without an explicit environment fixture to the same local-direct summary, so most functional states repeated one environment treatment. The environment matrix also omitted unmanaged, named, and detached worktree shapes, and its detached fixture lacked the machine label needed to render the worktree icon.

## What changed

- Rotates the functional overview through a balanced mix of local/remote and direct/worktree summaries.
- Expands `Environment matrix` with unmanaged, named, and detached worktree rows.
- Supplies the detached fixture's machine label so the production `FolderGit` environment icon renders.
- Keeps provisioning on bb’s active-work `Loading03` indicator because discovery has not confirmed the eventual workspace type.
- Changes only Ladle fixtures; there are no product, daemon-wire, SDK, API, CLI, or persistence changes.

## How you verified

- Exact rebased head `f4707e0ad2ea6622fa4c314e943c6735a1d21f34` passes every required GitHub check, including all app shards, packages, server, integration, and Linux/macOS package smoke.
- Ladle metadata registers both the native-skill-call and environment-matrix stories; neither renders a missing-story state.
- Chrome for Testing 152.0.7977.64 rendered the exact parent and child matrix at the same 1440×900 viewport and scroll position. The child visibly adds unmanaged, named, and detached worktree rows with the production worktree icon; provisioning uses bb’s active-work `Loading03` indicator. The deliberate QA pass also verified all environment accessible labels, a balanced overview mix, no horizontal overflow, and no runtime exceptions.
- Safari is not required for this non-marketing Ladle change.

### Before — parent head `699352c7e7576ee937d68d3e9f43f02f570aecfd`

The matrix ends after managed local/remote worktrees.

![Before — environment matrix without unmanaged, named, or detached worktrees](https://raw.githubusercontent.com/brsbl/bb/a236be40b18b147c043415ff93f70ece328baa78/environment-before-699352-final.png)

### After — child head `f4707e0ad2ea6622fa4c314e943c6735a1d21f34`

The same fixture now exposes unmanaged, named, and detached worktree label/icon shapes.

![After — expanded environment matrix with unmanaged, named, and detached worktrees](https://raw.githubusercontent.com/brsbl/bb/a236be40b18b147c043415ff93f70ece328baa78/environment-after-f4707e-final.png)

BB-Thread-ID: thr_sjdd7gudiq

> AGENT GENERATED