### PR TITLE
fix(tasks): persist the New task dialog draft across navigation

### DIFF
--- a/plugins/tasks/views/manage/new-task-dialog.tsx
+++ b/plugins/tasks/views/manage/new-task-dialog.tsx
@@ -48,6 +48,11 @@ import { Icon } from "@bb/shared-ui/icon";
 import { cn } from "@bb/shared-ui/lib/utils";
 import { CheckboxField, DEFAULT_COLOR } from "./shared.js";
 import { PRIORITY_LABELS, STATUS_LABELS } from "../list/lib.js";
+import {
+  clearNewTaskDraft,
+  loadNewTaskDraft,
+  storeNewTaskDraft,
+} from "./new-task-draft.js";
 
 const CHIP_TRIGGER =
   "h-7 w-auto gap-1.5 rounded-md px-2 text-xs text-muted-foreground";
@@ -101,12 +106,15 @@ export function NewTaskDialog({
   const titleRef = useRef<HTMLInputElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  // Each open starts a fresh draft seeded from the invoking context.
+  // Each open seeds context (project/status/parent) fresh, but restores any
+  // unsubmitted title/description the user typed before navigating away. Drafts
+  // are the normal new-task flow only, never the "Add sub-task" variant.
   useEffect(() => {
     if (!open) return;
+    const draft = subtaskMode ? null : loadNewTaskDraft();
     setSelectedProjectId(projectId);
-    setTitle("");
-    setDescription("");
+    setTitle(draft?.title ?? "");
+    setDescription(draft?.description ?? "");
     setStatus(defaultStatus ?? "todo");
     setPriority("none");
     setLabelIds([]);
@@ -118,6 +126,14 @@ export function NewTaskDialog({
     setError(null);
     // oxlint-disable-next-line react/exhaustive-deps
   }, [open]);
+
+  // Mirror the typed title/description into the browser profile while the
+  // compose step is open, so navigating away and returning keeps the draft.
+  // storeNewTaskDraft clears storage once both fields are blank again.
+  useEffect(() => {
+    if (!open || subtaskMode || createdTask !== null) return;
+    storeNewTaskDraft({ title, description });
+  }, [open, subtaskMode, createdTask, title, description]);
 
   const projectList = projects.data ?? [];
   const effectiveProjectId =
@@ -281,6 +297,9 @@ export function NewTaskDialog({
         setError(result.error.message);
         return;
       }
+      // The task now exists, so the saved draft is spent — drop it before the
+      // attachment phase so it never lingers past a successful create.
+      if (!subtaskMode) clearNewTaskDraft();
       // The task now exists; upload the staged files to it. Failures become
       // retryable chips bound to the created task instead of vanishing.
       const staged = pendingFiles.filter((entry) => entry.status === "staged");

--- a/plugins/tasks/views/manage/new-task-draft.test.ts
+++ b/plugins/tasks/views/manage/new-task-draft.test.ts
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  NEW_TASK_DRAFT_STORAGE_KEY,
+  clearNewTaskDraft,
+  loadNewTaskDraft,
+  storeNewTaskDraft,
+} from "./new-task-draft.js";
+
+beforeEach(() => window.localStorage.clear());
+
+describe("new task draft storage", () => {
+  it("reads as unset before anything is stored", () => {
+    expect(loadNewTaskDraft()).toBeNull();
+  });
+
+  it("round-trips a typed title and description", () => {
+    storeNewTaskDraft({ title: "Fix flaky test", description: "See CI run 42" });
+    expect(loadNewTaskDraft()).toEqual({
+      title: "Fix flaky test",
+      description: "See CI run 42",
+    });
+  });
+
+  it("clears storage once both fields are blank again", () => {
+    storeNewTaskDraft({ title: "Something", description: "" });
+    storeNewTaskDraft({ title: "   ", description: "" });
+    expect(loadNewTaskDraft()).toBeNull();
+    expect(window.localStorage.getItem(NEW_TASK_DRAFT_STORAGE_KEY)).toBeNull();
+  });
+
+  it("treats a blank draft as nothing to restore", () => {
+    storeNewTaskDraft({ title: "", description: "" });
+    expect(loadNewTaskDraft()).toBeNull();
+  });
+
+  it("clearNewTaskDraft removes a stored draft", () => {
+    storeNewTaskDraft({ title: "Keep me", description: "" });
+    clearNewTaskDraft();
+    expect(loadNewTaskDraft()).toBeNull();
+  });
+
+  it("treats corrupt or future-version documents as unset rather than throwing", () => {
+    window.localStorage.setItem(NEW_TASK_DRAFT_STORAGE_KEY, "{not json");
+    expect(loadNewTaskDraft()).toBeNull();
+
+    window.localStorage.setItem(
+      NEW_TASK_DRAFT_STORAGE_KEY,
+      JSON.stringify({ version: 999, title: "future", description: "" }),
+    );
+    expect(loadNewTaskDraft()).toBeNull();
+  });
+});

--- a/plugins/tasks/views/manage/new-task-draft.ts
+++ b/plugins/tasks/views/manage/new-task-draft.ts
@@ -1,0 +1,91 @@
+/**
+ * Client-local draft for the "New task" dialog so navigating away — which
+ * unmounts the dialog — does not discard what the user has typed. Stored in the
+ * browser profile like the view and sidebar preferences, so one client never
+ * rewrites another connected to the same bb server.
+ *
+ * Only the free-text fields are kept. The project, status, parent, and labels
+ * are reseeded from the invoking context on every open, so a restored draft can
+ * never land in a project or parent the user did not choose this time.
+ */
+export const NEW_TASK_DRAFT_STORAGE_KEY = "bb-tasks:new-task-draft";
+export const NEW_TASK_DRAFT_VERSION = 1 as const;
+
+export interface NewTaskDraft {
+  title: string;
+  description: string;
+}
+
+interface StoredDocumentV1 {
+  version: typeof NEW_TASK_DRAFT_VERSION;
+  title: string;
+  description: string;
+}
+
+function isBlank(draft: NewTaskDraft): boolean {
+  return draft.title.trim() === "" && draft.description.trim() === "";
+}
+
+/**
+ * Read the saved draft, or null when nothing usable is stored. Corrupt,
+ * partial, blank, or future-version documents read as unset rather than throw.
+ */
+export function loadNewTaskDraft(): NewTaskDraft | null {
+  try {
+    const raw = window.localStorage.getItem(NEW_TASK_DRAFT_STORAGE_KEY);
+    if (raw === null) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      parsed === null ||
+      typeof parsed !== "object" ||
+      Array.isArray(parsed)
+    ) {
+      return null;
+    }
+    const record = parsed as Record<string, unknown>;
+    const version =
+      typeof record.version === "number" && Number.isFinite(record.version)
+        ? record.version
+        : null;
+    // No other versions shipped; refuse rather than invent fields.
+    if (version !== null && version !== NEW_TASK_DRAFT_VERSION) return null;
+    const draft: NewTaskDraft = {
+      title: typeof record.title === "string" ? record.title : "",
+      description:
+        typeof record.description === "string" ? record.description : "",
+    };
+    return isBlank(draft) ? null : draft;
+  } catch {
+    return null;
+  }
+}
+
+/** Persist the draft, or clear storage once every field is blank again. */
+export function storeNewTaskDraft(draft: NewTaskDraft): void {
+  try {
+    if (isBlank(draft)) {
+      clearNewTaskDraft();
+      return;
+    }
+    const document: StoredDocumentV1 = {
+      version: NEW_TASK_DRAFT_VERSION,
+      title: draft.title,
+      description: draft.description,
+    };
+    window.localStorage.setItem(
+      NEW_TASK_DRAFT_STORAGE_KEY,
+      JSON.stringify(document),
+    );
+  } catch {
+    // Persistence is best-effort (private mode / storage disabled).
+  }
+}
+
+/** Drop the saved draft, e.g. once the task has been created. */
+export function clearNewTaskDraft(): void {
+  try {
+    window.localStorage.removeItem(NEW_TASK_DRAFT_STORAGE_KEY);
+  } catch {
+    // Best-effort.
+  }
+}


### PR DESCRIPTION
## Problem

In the Tasks plugin, if you start typing a new task in the **New task** dialog and then navigate to another page, everything you typed is lost. The dialog keeps its `title`/`description` in component state and resets them on every open, so navigating away (which unmounts the dialog) discards the draft.

Reported by a user: *"when I start typing a task and move to another page to do something else, the task progress of whatever I wrote is now gone completely."*

## Fix

Add a small client-local draft for the New task dialog, mirroring the existing `view-preference.ts` pattern (same browser-profile boundary as the view/sidebar preferences, so one client never rewrites another on the same server):

- **`new-task-draft.ts`** — versioned, guarded `load`/`store`/`clear` helpers for `{ title, description }`. Corrupt / partial / blank / future-version documents read as unset rather than throw.
- **`new-task-dialog.tsx`**:
  - the open effect restores any saved title/description instead of always blanking them;
  - an effect mirrors the typed title/description into storage while the compose step is open (and clears storage once both are blank again);
  - the draft is cleared as soon as the task is created.

### Scope / intentional limits

- Only the **normal new-task flow** persists a draft. The **"Add sub-task"** variant (`subtaskMode`) is unchanged.
- Only the free-text fields are kept. **Project, status, parent, and labels** are still reseeded from the invoking context on every open, so a restored draft can never land in a project/parent the user didn't choose this time.

## Testing

- Added `new-task-draft.test.ts` (round-trip, blank-clears-storage, corrupt/future-version safety), mirroring `view-preference.test.ts`.
- Existing `NewTaskDialog` tests are unaffected: with no stored draft the dialog opens empty as before, and `vitest.setup.ts` already clears `localStorage` before every test.