### PR TITLE
Fix ACP intentional-stop write race

### DIFF
--- a/packages/provider-bridge-acp/src/bridge/agent-connection.test.ts
+++ b/packages/provider-bridge-acp/src/bridge/agent-connection.test.ts
@@ -159,6 +159,82 @@ describe("ACP agent stdio lifecycle", () => {
     }
   });
 
+  it("makes an intentionally stopped connection unavailable before stdin teardown", async () => {
+    const ready = deferred<void>();
+    const stdinClosed = deferred<void>();
+    const exited = deferred<AcpAgentExitInfo>();
+    const connection = createAcpAgentConnection({
+      recordThreadId: null,
+      command: process.execPath,
+      args: [
+        "-e",
+        [
+          'const fs = require("node:fs");',
+          'const send = (method) => process.stdout.write(JSON.stringify({ jsonrpc: "2.0", method }) + "\\n");',
+          'process.on("SIGTERM", () => { fs.closeSync(0); send("stdin-closed"); setTimeout(() => process.exit(0), 50); });',
+          'send("ready");',
+          "setInterval(() => {}, 1000);",
+        ].join(" "),
+      ],
+      cwd: process.cwd(),
+      env: process.env,
+      onNotification(method) {
+        if (method === "ready") ready.resolve();
+        if (method === "stdin-closed") stdinClosed.resolve();
+      },
+      onRequest() {},
+      onExit: exited.resolve,
+    });
+
+    try {
+      await ready.promise;
+      const pendingError = connection
+        .request({
+          method: "session/new",
+          params: null,
+          resultSchema: z.unknown(),
+        })
+        .then(
+          () => undefined,
+          (error: Error) => error,
+        );
+      connection.kill();
+      await stdinClosed.promise;
+      // Reproduce the write that used to win the race with child exit and
+      // replace the pending request's release result with an EPIPE message.
+      connection.notify("construction/continues", {
+        payload: "x".repeat(EPIPE_PAYLOAD_SIZE),
+      });
+
+      const error = await Promise.race([
+        pendingError,
+        delay(500).then(() => {
+          throw new Error(
+            "ACP request remained pending after intentional stop",
+          );
+        }),
+      ]);
+      expect(error).toBeInstanceOf(AcpAgentExitedError);
+      expect(error?.message).toBe(
+        `ACP agent "${process.execPath}" is not running`,
+      );
+      expect(connection.exited).toBe(true);
+      await expect(
+        connection.request({
+          method: "fixture/future",
+          params: null,
+          resultSchema: z.unknown(),
+        }),
+      ).rejects.toThrow(`ACP agent "${process.execPath}" is not running`);
+      await expect(exited.promise).resolves.toMatchObject({
+        code: 0,
+        signal: null,
+      });
+    } finally {
+      await stopConnection(connection, exited.promise);
+    }
+  });
+
   it("rejects pending requests when the agent exits", async () => {
     const exited = deferred<AcpAgentExitInfo>();
     const connection = createAcpAgentConnection({

--- a/packages/provider-bridge-acp/src/bridge/agent-connection.ts
+++ b/packages/provider-bridge-acp/src/bridge/agent-connection.ts
@@ -174,6 +174,9 @@ export function createAcpAgentConnection(
   const stderrChunks: string[] = [];
   let nextRequestId = 1;
   let exited = false;
+  // `kill()` is a synchronous API boundary even though process exit is not:
+  // once called, no more protocol traffic may reach this connection.
+  let stopping = false;
 
   function rejectAllPending(error: Error): void {
     for (const [, request] of pending) {
@@ -203,6 +206,12 @@ export function createAcpAgentConnection(
   }
 
   function writeLine(message: object): void {
+    // An agent request can be answered asynchronously after the session that
+    // owned it has been released. Do not write that stale response to a child
+    // whose termination has already begun.
+    if (stopping) {
+      return;
+    }
     const stdin = child.stdin;
     if (!stdin || stdin.destroyed || !stdin.writable) {
       closeForAgentStdin(new Error("stdin is not writable"));
@@ -218,6 +227,12 @@ export function createAcpAgentConnection(
   child.stdin?.on("error", (error) => {
     if (!isClosedAgentStdinError(error)) {
       throw error;
+    }
+    if (stopping) {
+      // Preserve the existing leak backstop for a child that closes stdin in
+      // response to SIGTERM but keeps another handle alive.
+      child.kill("SIGKILL");
+      return;
     }
     closeForAgentStdin(error);
   });
@@ -330,11 +345,11 @@ export function createAcpAgentConnection(
 
   return {
     get exited() {
-      return exited;
+      return stopping || exited;
     },
 
     request({ method, params, resultSchema }) {
-      if (exited) {
+      if (stopping || exited) {
         return Promise.reject(
           new AcpAgentExitedError(
             `ACP agent "${options.command}" is not running`,
@@ -364,16 +379,22 @@ export function createAcpAgentConnection(
     },
 
     notify(method, params) {
-      if (exited) {
+      if (stopping || exited) {
         return;
       }
       writeLine({ jsonrpc: "2.0", method, params });
     },
 
     kill() {
-      if (exited) {
+      if (stopping || exited) {
         return;
       }
+      stopping = true;
+      rejectAllPending(
+        new AcpAgentExitedError(
+          `ACP agent "${options.command}" is not running`,
+        ),
+      );
       child.kill("SIGTERM");
     },
   };


### PR DESCRIPTION
## Human comments

## What was wrong

On the independently verified fresh-main baseline [`1d97c63ed13b5231c1051b7af7ac36661d1f65ab`](https://github.com/get-bb/bb/commit/1d97c63ed13b5231c1051b7af7ac36661d1f65ab), `AcpAgentConnection.kill()` sent SIGTERM but left the connection writable and its requests pending until the asynchronous child exit event. When a release landed during `thread/start` construction, a buffered or continuing write could therefore hit the child after stdin closed; the EPIPE handler then won the race and rejected the pending start with transport wording. That is the failure seen in [main CI run 33029831856](https://github.com/get-bb/bb/actions/runs/33029831856). The EPIPE was handled, but accepting traffic after an intentional stop was the underlying lifecycle bug, so expanding the bridge test's message regex would have hidden it.

## What changed

`AcpAgentConnection` now latches an intentional stop synchronously. It immediately makes the connection unavailable, rejects pending requests with the existing `is not running` lifecycle error, and drops later request/notification responses before they can write to the terminating child. The existing SIGKILL backstop remains for a child that closes stdin during SIGTERM without exiting.

A connection-level regression deterministically closes the fixture child's stdin during intentional stop, attempts the late write that previously produced EPIPE, and verifies the pending and future requests both observe the normalized stopped state while the child exits normally.

This changes no server/daemon wire data, CLI, configuration, or public plugin contract, so no `HOST_DAEMON_PROTOCOL_VERSION`, guide, or API documentation update is required.

## How you verified

- Failing-first regression on unmodified production code: 1 test failed in 56 ms with `Received: ACP agent ".../node" stdin closed (EPIPE): write EPIPE`; the same test passes in 77 ms with the stop latch.
- Focused original lifecycle regression: `pnpm exec vitest run --root packages/provider-bridge-acp --config vitest.config.ts --project '@bb/provider-bridge-acp:isolated' src/bridge/bridge.test.ts -t 'releases a session still under construction: the agent is reaped and the pending thread/start fails'`.
- `pnpm exec turbo run test --filter=@bb/provider-bridge-acp --force` - 17 files and 289 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/provider-bridge-acp --filter=bb-plugin-provider-acp --force` - both package typechecks and the SDK type-generation dependencies passed.
- `pnpm exec turbo run build --filter=@get-bb/plugin-sdk --force` - all 17 published runtime entries built, including the ACP bridge bundle.
- Repeated the exact release-under-construction bridge test 64 times with eight concurrent Vitest processes after the fix: 64 passed, zero failures or EPIPE output.
- `git diff --check` passed; only the ACP connection and its lifecycle test changed.

> AGENT GENERATED: by GPT-5.6-Sol
