### PR TITLE
test(tasks): isolate dispatch rail fixture

### DIFF
--- a/plugins/tasks/views/detail/rail.test.tsx
+++ b/plugins/tasks/views/detail/rail.test.tsx
@@ -1,7 +1,11 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, waitFor } from "@testing-library/react";
+import type { ComponentProps } from "react";
 import { afterEach, describe, expect, it } from "vitest";
-import { loadPluginApp, renderSlot } from "@get-bb/plugin-sdk/testing/app";
+import {
+  installTestPluginRuntime,
+  renderSlot,
+} from "@get-bb/plugin-sdk/testing/app";
 
 // jsdom lacks matchMedia; the vendored Dialog's responsive root needs it.
 if (!window.matchMedia) {
@@ -17,9 +21,20 @@ if (!window.matchMedia) {
   });
 }
 
-// loadPluginApp installs the fake SDK runtime; nothing SDK-touching may be
-// imported before it runs.
-const app = await loadPluginApp(() => import("../../app"));
+// The rail binds SDK hooks at import time, after the fake runtime is installed.
+installTestPluginRuntime();
+const { PropertiesRail } = await import("./rail");
+const { TasksRefreshProvider } = await import("../../shell/refresh");
+
+// Mount the smallest real lifecycle: the full panel gates this rail on an
+// unrelated project query and renders an editor this behavior never touches.
+function RailHarness(props: ComponentProps<typeof PropertiesRail>) {
+  return (
+    <TasksRefreshProvider>
+      <PropertiesRail {...props} />
+    </TasksRefreshProvider>
+  );
+}
 
 afterEach(cleanup);
 
@@ -56,56 +71,37 @@ const task = {
   labelIds: [],
 };
 
-function detailRpc(
-  linkedBbProjectId: string | null,
-  overrides: Record<string, unknown> = {},
-) {
+function railProps(linkedBbProjectId: string | null) {
   return {
-    listProjects: () => ({ projects: [projectRow(linkedBbProjectId)] }),
-    listFolders: () => ({ folders: [] }),
-    listPresets: () => ({ presets: [] }),
-    sidebarSummary: () => ({ projects: [] }),
-    listTasks: (input: { parentTaskId?: string } | null) =>
-      input?.parentTaskId ? { tasks: [] } : { tasks: [task] },
-    getTaskByKey: () => ({ task }),
-    listLabels: () => ({ labels: [] }),
-    listAttachments: () => ({ attachments: [] }),
-    listTaskThreads: () => ({ taskThreads: [] }),
-    listTaskPullRequests: () => ({
-      pullRequests: [],
-      unavailableThreadIds: [],
-    }),
-    listComments: () => ({ comments: [] }),
-    listBbProjects: () => ({ bbProjects: [] }),
-    ...overrides,
+    task,
+    project: projectRow(linkedBbProjectId),
+    labels: [],
+    threads: [],
+    presets: [],
+    onUpdate: () => {},
+    onError: () => {},
   };
 }
 
 describe("dispatch target rail control", () => {
   it("links a discovered bb project", async () => {
     const updateCalls: Array<Record<string, unknown>> = [];
-    const slot = renderSlot(
-      app.navPanels[0]!,
-      { subPath: "task/TSK-5" },
-      {
-        rpc: detailRpc(null, {
-          listBbProjects: () => ({
-            bbProjects: [{ id: BB_PROJECT_ID, name: "bb monorepo" }],
-          }),
-          updateProject: (input: Record<string, unknown>) => {
-            updateCalls.push(input);
-            return {
-              project: {
-                ...projectRow(input.linkedBbProjectId as string | null),
-              },
-            };
-          },
+    const slot = renderSlot({ component: RailHarness }, railProps(null), {
+      rpc: {
+        listBbProjects: () => ({
+          bbProjects: [{ id: BB_PROJECT_ID, name: "bb monorepo" }],
         }),
+        updateProject: (input: Record<string, unknown>) => {
+          updateCalls.push(input);
+          return {
+            project: {
+              ...projectRow(input.linkedBbProjectId as string | null),
+            },
+          };
+        },
       },
-    );
-    fireEvent.click(
-      await slot.findByRole("button", { name: "Edit dispatch target" }),
-    );
+    });
+    fireEvent.click(slot.getByRole("button", { name: "Edit dispatch target" }));
     fireEvent.click(await slot.findByLabelText("Linked bb project"));
     fireEvent.click(await slot.findByRole("option", { name: "bb monorepo" }));
     fireEvent.click(slot.getByRole("button", { name: "Save" }));
@@ -119,10 +115,10 @@ describe("dispatch target rail control", () => {
   it("shows the linked bb project's name and unlinks it", async () => {
     const updateCalls: Array<Record<string, unknown>> = [];
     const slot = renderSlot(
-      app.navPanels[0]!,
-      { subPath: "task/TSK-5" },
+      { component: RailHarness },
+      railProps(BB_PROJECT_ID),
       {
-        rpc: detailRpc(BB_PROJECT_ID, {
+        rpc: {
           listBbProjects: () => ({
             bbProjects: [{ id: BB_PROJECT_ID, name: "bb monorepo" }],
           }),
@@ -134,10 +130,10 @@ describe("dispatch target rail control", () => {
               },
             };
           },
-        }),
+        },
       },
     );
-    const trigger = await slot.findByRole("button", {
+    const trigger = slot.getByRole("button", {
       name: "Edit dispatch target",
     });
     await slot.findByText("bb monorepo");


### PR DESCRIPTION
## Human comments

## What was wrong

The dispatch-target rail test mounted the entire Tasks navigation panel even though it only exercises `PropertiesRail`. That made the "Edit dispatch target" trigger wait for `DetailView`'s unrelated `listProjects` effect while jsdom rendered the editor, activity view, and the rest of the task shell. In the [failing package-shard run](https://github.com/get-bb/bb/actions/runs/33027277207), a 4-vCPU runner executed 67 Turbo test tasks; the Tasks suite took 159.69s, this file took 16.55s, and the first case exhausted the existing 8-second Testing Library deadline at 10.62s while its sibling passed after 5.91s. Withholding only `listProjects` locally reproduced the exact missing-button error and rendered shell in 8.03s. Scheduler oversubscription amplified the avoidable dependency and accessibility-query cost; it was not itself the root cause. PR [#2512](https://github.com/get-bb/bb/pull/2512) changed no Tasks files and its final package run passed, which is consistent with a main-rooted flake.

## What changed

- Install the fake plugin runtime directly and import the exported `PropertiesRail` instead of loading the full plugin app.
- Mount the rail with the real `TasksRefreshProvider` and prebuilt task/project fixtures.
- Keep the real `listBbProjects` query, popover interactions, save/unlink RPC lifecycle, and exact payload assertions.
- Make the project-backed trigger a synchronous assertion because the project is now part of the fixture under test.

No production behavior, wire contract, CLI surface, or deadline changed. Increasing the already-raised 8-second async utility timeout would only move the failure. Awaiting the full panel's project query would remove polling but retain the unrelated editor/tree work; the direct rail seam removes both the irrelevant readiness gate and repeated large accessibility-tree transforms while keeping the behavior lifecycle this test owns. The fresh-main gate was independently verified clean at `1d97c63ed13b5231c1051b7af7ac36661d1f65ab` before inspection or edits.

## How you verified

- Exact GitHub open PR/issue searches and literal BB signature searches found no overlapping fix.
- Diagnostic red: withholding only `listProjects` made the focused first case fail with `Unable to find role="button" and name "Edit dispatch target"` after 8.03s; the diagnostic was removed.
- Controlled 48-burner stress, eight forced package runs before and after:
  - rail file before: 2.82–3.98s, median 3.18s
  - rail file after: 1.00–1.84s, median 1.40s (56% lower)
  - whole Tasks suite before: 17.56–23.94s
  - whole Tasks suite after: 15.84–18.05s; all 2,888 assertions passed
- `pnpm --dir plugins/tasks exec vitest run --config vitest.config.ts views/detail/rail.test.tsx` — 2/2 passed in 229ms.
- `pnpm exec turbo run test --filter=bb-plugin-tasks --force` — 35 files and 361 tests passed; rail file 348ms.
- `pnpm exec turbo run typecheck --filter=bb-plugin-tasks --force` — 5/5 tasks passed.
- `pnpm exec turbo run build --filter=bb-plugin-tasks --force` — 6/6 tasks passed.
- `pnpm exec oxfmt plugins/tasks/views/detail/rail.test.tsx --check` and `git diff --check` passed.

> AGENT GENERATED: by GPT-5.6-Sol
