### PR TITLE
Fix provider icon alignment in settings

### DIFF
--- a/apps/app/src/components/settings/UpdatesSettingsSection.test.tsx
+++ b/apps/app/src/components/settings/UpdatesSettingsSection.test.tsx
@@ -1004,6 +1004,8 @@ The canonical release summary.
     expect(
       providerIcon?.querySelector("[data-provider-logo]")?.getAttribute("class"),
     ).toContain("text-muted-foreground");
+    expect(providerIcon?.classList.contains("flex")).toBe(true);
+    expect(providerIcon?.classList.contains("size-3.5")).toBe(true);
     // Icon-only. The accessible name is the state and the verb — the row
     // already prints the CLI, its versions, and the machine above it. Row and
     // bulk actions share the same quiet treatment so neither competes with the

--- a/apps/app/src/components/settings/UpdatesSettingsSection.tsx
+++ b/apps/app/src/components/settings/UpdatesSettingsSection.tsx
@@ -1267,7 +1267,11 @@ export function MachineUpdatesRows({
         onOpen={() => onOpenProvider(providerId)}
         leading={
           ProviderIcon === undefined ? null : (
-            <span data-provider-icon={providerId} aria-hidden>
+            <span
+              data-provider-icon={providerId}
+              aria-hidden
+              className="flex size-3.5 shrink-0 items-center justify-center"
+            >
               <ProviderIcon className="size-3.5 text-muted-foreground" />
             </span>
           )

--- a/apps/app/src/views/MachineSettingsView.test.tsx
+++ b/apps/app/src/views/MachineSettingsView.test.tsx
@@ -219,6 +219,13 @@ describe("MachineSettingsView", () => {
       document.querySelector('[data-provider-icon="acp-cursor"]'),
     ).not.toBeNull();
     expect(
+      [...document.querySelectorAll("[data-provider-icon]")].every(
+        (node) =>
+          node.classList.contains("flex") &&
+          node.classList.contains("size-3.5"),
+      ),
+    ).toBe(true);
+    expect(
       screen
         .getByRole("heading", { name: "Provider CLIs" })
         .querySelector("[data-icon]"),

--- a/apps/app/src/views/MachineSettingsView.tsx
+++ b/apps/app/src/views/MachineSettingsView.tsx
@@ -361,6 +361,7 @@ export function MachineSettingsView() {
                             <span
                               data-provider-icon={entry.providerId}
                               aria-hidden
+                              className="flex size-3.5 shrink-0 items-center justify-center"
                             >
                               {entry.provider === undefined ? (
                                 <entry.ProviderIcon className="size-3.5" />


### PR DESCRIPTION
## Human comments

## What was wrong

Provider marks in Machine Settings installed-provider rows and Settings → Updates provider rows remained inside inline wrappers. Those wrappers retained a text baseline line box, lifting the 14px mark above neighboring content even though the surrounding rows were centered. This is the reproduced sibling root cause left after #2517 fixed the sidebar badge.

## What changed

Applied the existing fixed 14px flex-box utilities to the immediate provider-icon wrapper in both reproduced settings flows. Added focused assertions at each existing real-flow test seam. The change does not alter tint, accessible names, actions, responsive behavior, wire contracts, CLI surfaces, or documentation, and it deliberately leaves the unreproduced Skills provenance tooltip unchanged.

## How you verified

- Before the production edit, the focused test command failed exactly the two new layout assertions.
- pnpm exec turbo run test --filter=@bb/app --force -- src/views/MachineSettingsView.test.tsx src/components/settings/UpdatesSettingsSection.test.tsx — 36/36 tests passed after the fix and again after rebasing onto current main.
- pnpm exec turbo run typecheck --filter=@bb/app — passed after rebase with an app typecheck cache miss.
- DevBrowser exercised both live routes at 1280×900. Every Machine Settings mark now shares the label/version center, and every Updates mark exactly matches its 24px leading-slot center.
- git diff origin/main...HEAD --check — passed.

Fixes #2517

> AGENT GENERATED