### PR TITLE
test(app): restore ThreadRow resolver spy

### DIFF
--- a/apps/app/src/components/sidebar/ThreadRow.test.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.test.tsx
@@ -246,6 +246,7 @@ afterEach(() => {
   mocks.renameThread.mockReset();
   resetSidebarTitleDoubleClickForTest();
   resetPluginThreadRowStatusesForTest();
+  expect(vi.isMockFunction(sdk.threads.resolveMentions)).toBe(false);
   // The layout is tab-scoped, so it lands in both stores (createTabScopedStorage).
   window.localStorage.removeItem(SPLIT_LAYOUT_STORAGE_KEY);
   window.sessionStorage.removeItem(SPLIT_LAYOUT_STORAGE_KEY);
@@ -666,31 +667,37 @@ describe("ThreadRow", () => {
         },
       ]);
 
-    render(
-      <ThreadTitleMentionResourcesProvider
-        sectionNamesById={new Map()}
-        projectNamesById={new Map()}
-        threadById={new Map()}
-      >
-        <ThreadRowTestHarness
-          thread={createThread({
-            title: "Continue from @thread:thr_dcwivn5n8w",
-            titleFallback: "Continue from @thread:thr_dcwivn5n8w",
-          })}
-        />
-      </ThreadTitleMentionResourcesProvider>,
-    );
+    try {
+      render(
+        <ThreadTitleMentionResourcesProvider
+          sectionNamesById={new Map()}
+          projectNamesById={new Map()}
+          threadById={new Map()}
+        >
+          <ThreadRowTestHarness
+            thread={createThread({
+              title: "Continue from @thread:thr_dcwivn5n8w",
+              titleFallback: "Continue from @thread:thr_dcwivn5n8w",
+            })}
+          />
+        </ThreadTitleMentionResourcesProvider>,
+      );
 
-    expect(screen.queryByText("thr_dcwivn5n8w")).toBeNull();
-    expect(
-      screen.getByRole("link", { name: "Open Continue from Thread" }),
-    ).not.toBeNull();
-    await waitFor(() => expect(resolveMentions).toHaveBeenCalledTimes(1));
-    expect(screen.getByText("Mention target")).not.toBeNull();
-    expect(screen.queryByText("thr_dcwivn5n8w")).toBeNull();
-    expect(
-      screen.getByRole("link", { name: "Open Continue from Mention target" }),
-    ).not.toBeNull();
+      expect(screen.queryByText("thr_dcwivn5n8w")).toBeNull();
+      expect(
+        screen.getByRole("link", { name: "Open Continue from Thread" }),
+      ).not.toBeNull();
+      await waitFor(() => expect(resolveMentions).toHaveBeenCalledTimes(1));
+      expect(screen.getByText("Mention target")).not.toBeNull();
+      expect(screen.queryByText("thr_dcwivn5n8w")).toBeNull();
+      expect(
+        screen.getByRole("link", {
+          name: "Open Continue from Mention target",
+        }),
+      ).not.toBeNull();
+    } finally {
+      resolveMentions.mockRestore();
+    }
   });
 
   it("marks a child from another project with the project name", () => {


### PR DESCRIPTION
## Human comments

## What was wrong

The archived-thread title regression added in #2527 replaced the shared `sdk.threads.resolveMentions` method without restoring it. Because later tests in `ThreadRow.test.tsx` reuse that SDK object, they could inherit the canned result and become order-dependent or falsely green.

## What changed

The resolver regression now restores its exact spy in `finally`, including when rendering or an assertion throws. The file teardown also asserts that the shared resolver is no longer mocked, preserving the isolation invariant for future tests. This is test-only: no production, wire, CLI, SDK, or documentation behavior changed.

## How you verified

- Before the cleanup, the targeted Turbo run failed its teardown isolation assertion, and the full file reported 42 failures after the leaking test.
- `pnpm exec turbo run test --filter=@bb/app -- src/components/sidebar/ThreadRow.test.tsx` — 71 passed.
- `pnpm exec prettier --check apps/app/src/components/sidebar/ThreadRow.test.tsx` — passed.
- `git diff --check origin/main...HEAD` — passed.
- Rebasing from `ad79bbb5` onto current `origin/main` preserved the stable patch ID exactly.

Follow-up to #2527; no issue.

> AGENT GENERATED