### PR TITLE
Fix copied chat selections with invisible trailing newlines

### DIFF
--- a/apps/app/src/components/thread/timeline/SelectableMessageProse.events.test.tsx
+++ b/apps/app/src/components/thread/timeline/SelectableMessageProse.events.test.tsx
@@ -64,6 +64,7 @@ const SHARED_DOCUMENT_EVENT_TYPES = [
   "mouseup",
   "selectionchange",
   "keyup",
+  "copy",
 ];
 
 function countSharedListenerCalls(spy: {
@@ -409,6 +410,192 @@ describe("SelectableMessageProse", () => {
         }),
       ),
     );
+  });
+
+  it("clips whitespace-only boundary spill for native copy, then restores it", () => {
+    vi.useFakeTimers();
+    const { getByTestId, getByText } = render(
+      <div>
+        <SelectableMessageProse>
+          <p>Copy only this message.</p>
+        </SelectableMessageProse>
+        <div data-testid="message-actions">Actions</div>
+      </div>,
+    );
+    const target = getByText("Copy only this message.");
+    const textNode = target.firstChild;
+    const outsideNode = getByTestId("message-actions").firstChild;
+    const messageNode = target.closest("[data-sidebar-swipe-selectable]");
+    expect(textNode).not.toBeNull();
+    expect(outsideNode).not.toBeNull();
+    expect(messageNode).not.toBeNull();
+
+    const range = document.createRange();
+    range.setStart(textNode!, 0);
+    range.setEnd(outsideNode!, 0);
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+
+    fireEvent.copy(target);
+
+    expect(range.endContainer).toBe(messageNode);
+    expect(range.endOffset).toBe(messageNode!.childNodes.length);
+
+    vi.runAllTimers();
+    expect(selection?.focusNode).toBe(outsideNode);
+    expect(selection?.focusOffset).toBe(0);
+  });
+
+  it("clips a leading boundary spill when copy starts outside the message", () => {
+    vi.useFakeTimers();
+    const { getByText } = render(
+      <div>
+        <div>Earlier row</div>
+        <SelectableMessageProse>
+          <p>Copy this prefix.</p>
+        </SelectableMessageProse>
+      </div>,
+    );
+    const outside = getByText("Earlier row");
+    const target = getByText("Copy this prefix.");
+    const outsideText = outside.firstChild;
+    const targetText = target.firstChild;
+    const messageNode = target.closest("[data-sidebar-swipe-selectable]");
+    expect(outsideText).not.toBeNull();
+    expect(targetText).not.toBeNull();
+    expect(messageNode).not.toBeNull();
+
+    const range = document.createRange();
+    range.setStart(outsideText!, outsideText!.textContent!.length);
+    range.setEnd(targetText!, targetText!.textContent!.length);
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+
+    fireEvent.copy(outside);
+
+    expect(range.startContainer).toBe(messageNode);
+    expect(range.startOffset).toBe(0);
+    vi.runAllTimers();
+  });
+
+  it("does not clip selected text outside the message", () => {
+    const { getByTestId, getByText } = render(
+      <div>
+        <SelectableMessageProse>
+          <p>foo bar foo</p>
+        </SelectableMessageProse>
+        <div data-testid="following-text"> bar</div>
+      </div>,
+    );
+    const target = getByText("foo bar foo");
+    const outside = getByTestId("following-text");
+    const targetText = target.firstChild;
+    const outsideText = outside.firstChild;
+    expect(targetText).not.toBeNull();
+    expect(outsideText).not.toBeNull();
+
+    const range = document.createRange();
+    range.setStart(targetText!, 8);
+    range.setEnd(outsideText!, outsideText!.textContent!.length);
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+
+    fireEvent.copy(target);
+
+    expect(range.endContainer).toBe(outsideText);
+    expect(range.endOffset).toBe(outsideText!.textContent!.length);
+  });
+
+  it("does not clip selected image content outside the message", () => {
+    const { getByTestId, getByText } = render(
+      <div>
+        <SelectableMessageProse>
+          <p>Copy text and image</p>
+        </SelectableMessageProse>
+        <div data-testid="following-image">
+          <img alt="Selected attachment" />
+        </div>
+      </div>,
+    );
+    const target = getByText("Copy text and image");
+    const outside = getByTestId("following-image");
+    const targetText = target.firstChild;
+    expect(targetText).not.toBeNull();
+
+    const range = document.createRange();
+    range.setStart(targetText!, 0);
+    range.setEnd(outside, outside.childNodes.length);
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+
+    fireEvent.copy(target);
+
+    expect(range.endContainer).toBe(outside);
+    expect(range.endOffset).toBe(outside.childNodes.length);
+  });
+
+  it("leaves multi-range selections untouched", () => {
+    const { getByText } = render(
+      <SelectableMessageProse>
+        <p>Copy one of several ranges.</p>
+      </SelectableMessageProse>,
+    );
+    const target = getByText("Copy one of several ranges.");
+    const textNode = target.firstChild;
+    expect(textNode).not.toBeNull();
+
+    const range = document.createRange();
+    range.selectNodeContents(target);
+    const setEnd = vi.spyOn(range, "setEnd");
+    const selection = makeWindowSelection({
+      node: textNode!,
+      text: "Copy one of several ranges.",
+    });
+    Object.defineProperty(selection, "rangeCount", { value: 2 });
+    vi.spyOn(selection, "getRangeAt").mockReturnValue(range);
+    vi.spyOn(window, "getSelection").mockReturnValue(selection);
+
+    fireEvent.copy(target);
+
+    expect(setEnd).not.toHaveBeenCalled();
+  });
+
+  it("does not restore a copied range over a newer selection", () => {
+    vi.useFakeTimers();
+    const { getByText } = render(
+      <div>
+        <SelectableMessageProse>
+          <p>Copy this message.</p>
+        </SelectableMessageProse>
+        <div>New selection</div>
+      </div>,
+    );
+    const target = getByText("Copy this message.");
+    const outside = getByText("New selection");
+    const targetText = target.firstChild;
+    const outsideText = outside.firstChild;
+    expect(targetText).not.toBeNull();
+    expect(outsideText).not.toBeNull();
+
+    const copiedRange = document.createRange();
+    copiedRange.setStart(targetText!, 0);
+    copiedRange.setEnd(outsideText!, 0);
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(copiedRange);
+    fireEvent.copy(target);
+
+    const newerRange = document.createRange();
+    newerRange.selectNodeContents(outside);
+    selection?.removeAllRanges();
+    selection?.addRange(newerRange);
+    vi.runAllTimers();
+
+    expect(selection?.toString()).toBe("New selection");
   });
 
   it("registers the shared pointer listeners as passive", () => {

--- a/apps/app/src/components/thread/timeline/SelectableMessageProse.tsx
+++ b/apps/app/src/components/thread/timeline/SelectableMessageProse.tsx
@@ -33,6 +33,8 @@ interface SelectableMessageProseProps {
 
 export const MULTI_CLICK_SELECTION_REPORT_DELAY_MS = 180;
 const SELECTION_DRAG_DIRECTION_THRESHOLD_PX = 4;
+const CLIPBOARD_REPLACED_CONTENT_SELECTOR =
+  "audio, canvas, embed, iframe, img, object, video";
 
 /**
  * Pure predicate: does `selection` fall entirely within `node`?
@@ -195,6 +197,97 @@ function readSelectionWithinNode(
   }
 
   return null;
+}
+
+function clippedRangeForWhitespaceBoundarySpill(
+  node: HTMLElement,
+  range: Range,
+): Range | null {
+  if (
+    typeof range.intersectsNode !== "function" ||
+    !range.intersectsNode(node)
+  ) {
+    return null;
+  }
+
+  const clippedRange = range.cloneRange();
+  if (!node.contains(range.startContainer)) {
+    const leadingRange = range.cloneRange();
+    leadingRange.setEnd(node, 0);
+    if (
+      leadingRange.toString().trim().length > 0 ||
+      leadingRange
+        .cloneContents()
+        .querySelector(CLIPBOARD_REPLACED_CONTENT_SELECTOR) !== null
+    ) {
+      return null;
+    }
+    clippedRange.setStart(node, 0);
+  }
+  if (!node.contains(range.endContainer)) {
+    const trailingRange = range.cloneRange();
+    trailingRange.setStart(node, node.childNodes.length);
+    if (
+      trailingRange.toString().trim().length > 0 ||
+      trailingRange
+        .cloneContents()
+        .querySelector(CLIPBOARD_REPLACED_CONTENT_SELECTOR) !== null
+    ) {
+      return null;
+    }
+    clippedRange.setEnd(node, node.childNodes.length);
+  }
+
+  return clippedRange.toString().trim().length > 0 ? clippedRange : null;
+}
+
+function clipWhitespaceOnlyBoundarySpillForCopy(node: HTMLElement): boolean {
+  const selection = window.getSelection();
+  if (selection === null || selection.rangeCount === 0) return false;
+  const range = selection.getRangeAt(0);
+  if (
+    node.contains(range.startContainer) &&
+    node.contains(range.endContainer)
+  ) {
+    return false;
+  }
+  const clippedRange = clippedRangeForWhitespaceBoundarySpill(node, range);
+  if (clippedRange === null) return false;
+
+  const { anchorNode, anchorOffset, focusNode, focusOffset } = selection;
+  range.setStart(clippedRange.startContainer, clippedRange.startOffset);
+  range.setEnd(clippedRange.endContainer, clippedRange.endOffset);
+  const clippedStartContainer = range.startContainer;
+  const clippedStartOffset = range.startOffset;
+  const clippedEndContainer = range.endContainer;
+  const clippedEndOffset = range.endOffset;
+
+  // Chromium serializes the live range after the copy event returns. Restore
+  // the user's selection in the next task, after both clipboard formats exist.
+  window.setTimeout(() => {
+    if (
+      anchorNode?.isConnected &&
+      focusNode?.isConnected &&
+      selection.rangeCount > 0
+    ) {
+      const liveRange = selection.getRangeAt(0);
+      if (
+        liveRange.startContainer !== clippedStartContainer ||
+        liveRange.startOffset !== clippedStartOffset ||
+        liveRange.endContainer !== clippedEndContainer ||
+        liveRange.endOffset !== clippedEndOffset
+      ) {
+        return;
+      }
+      selection.setBaseAndExtent(
+        anchorNode,
+        anchorOffset,
+        focusNode,
+        focusOffset,
+      );
+    }
+  }, 0);
+  return true;
 }
 
 // Every assistant message mounts one SelectableMessageProse, so per-instance
@@ -405,6 +498,21 @@ function handleSharedKeyUp(): void {
   scheduleSharedReport();
 }
 
+function handleSharedCopy(): void {
+  const selection = window.getSelection();
+  if (selection === null || selection.rangeCount !== 1) return;
+  const range = selection.getRangeAt(0);
+  for (const instance of proseInstances) {
+    if (
+      typeof range.intersectsNode === "function" &&
+      range.intersectsNode(instance.node) &&
+      clipWhitespaceOnlyBoundarySpillForCopy(instance.node)
+    ) {
+      return;
+    }
+  }
+}
+
 function attachSharedDocumentListeners(): void {
   // Passive: none of the pointer handlers call preventDefault, so declare it
   // and keep every tap off the compositor's blocking-handler list.
@@ -420,6 +528,7 @@ function attachSharedDocumentListeners(): void {
   document.addEventListener("mouseup", handleSharedPointerRelease);
   document.addEventListener("selectionchange", handleSharedSelectionChange);
   document.addEventListener("keyup", handleSharedKeyUp);
+  document.addEventListener("copy", handleSharedCopy);
 }
 
 function detachSharedDocumentListeners(): void {
@@ -429,6 +538,7 @@ function detachSharedDocumentListeners(): void {
   document.removeEventListener("mouseup", handleSharedPointerRelease);
   document.removeEventListener("selectionchange", handleSharedSelectionChange);
   document.removeEventListener("keyup", handleSharedKeyUp);
+  document.removeEventListener("copy", handleSharedCopy);
 }
 
 function registerSelectableProseInstance(


### PR DESCRIPTION
## Human comments

## What was wrong

A browser selection can visually end at the last word of an assistant message while its DOM Range extends through whitespace-only timeline rows. Chromium serializes those hidden block boundaries into `text/plain`, so pasting the excerpt into the composer shows several blank lines even though the submitted message is unaffected. See #2523.

## What changed

The shared selection controller now clips whitespace-only boundary spill for the duration of native copy serialization, preserving both plain text and rich HTML, then restores the user's original selection if it has not changed. It leaves intentional cross-message text, selected media, newer selections, and multi-range selections untouched. Focused regression coverage pins those boundaries and the selection lifecycle. There are no wire, daemon protocol, CLI, or documentation changes.

## How you verified

- The regression test failed before the fix because the copied Range still ended in the following timeline row.
- `pnpm exec turbo run test --filter=@bb/app --force` — 440 test files passed; 3,442 tests passed and 4 skipped.
- `pnpm exec turbo run typecheck --filter=@bb/app` — 3/3 tasks passed.
- Manual Chromium check: the same cross-row selection carried seven trailing newlines before the fix and zero after it; the composer stays compact after paste. Before/after recordings are attached in PR comments.

Fixes #2523

> AGENT GENERATED
