### PR TITLE
Fix Codex spend-control rate limits

### DIFF
--- a/plugins/provider-codex/src/delta-translation.test.ts
+++ b/plugins/provider-codex/src/delta-translation.test.ts
@@ -13,9 +13,14 @@ import {
   PLAN_PRESENTATION,
 } from "./presentation.js";
 import {
+  applyCodexRateLimitUpdate,
+  createCodexEventTranslationState,
+} from "./delta-translation.js";
+import {
   createCodexEventTranslator,
   type CodexEventTranslator,
 } from "./translator.js";
+import { codexRateLimitReadResponseSchema } from "./schemas.js";
 
 /**
  * Per-event Codex translation equivalence for the narrow-grammar path.
@@ -1959,6 +1964,65 @@ describe("codex error and warning translation", () => {
 // ---------------------------------------------------------------------------
 
 describe("codex account rate-limit translation", () => {
+  const blockedSpendControlSnapshot = {
+    limitId: "codex",
+    limitName: "Codex",
+    primary: null,
+    secondary: null,
+    credits: null,
+    individualLimit: null,
+    spendControlReached: true,
+    planType: "team",
+    rateLimitReachedType: null,
+  } as const;
+
+  it("carries Codex spend-control state from the initial read", () => {
+    const response = codexRateLimitReadResponseSchema.parse({
+      rateLimits: blockedSpendControlSnapshot,
+    });
+    const snapshot = applyCodexRateLimitUpdate(
+      createCodexEventTranslationState(),
+      response.rateLimits,
+    );
+
+    expect(snapshot.spendControlReached).toBe(true);
+  });
+
+  it.each([
+    ["null", { spendControlReached: null }],
+    ["absence", {}],
+  ])("does not resurrect blocked spend control after %s", (_, clearUpdate) => {
+    const harness = createHarness();
+    const [blockedEvent] = harness.translate(
+      codexEvent("account/rateLimits/updated", {
+        rateLimits: blockedSpendControlSnapshot,
+      }),
+    );
+    expect(blockedEvent).toMatchObject({
+      type: "provider/rateLimits/updated",
+      rateLimits: {
+        status: "blocked",
+        kind: "spend-control",
+        windows: [],
+        reachedReason: null,
+      },
+    });
+
+    const [clearedEvent] = harness.translate({
+      jsonrpc: "2.0",
+      method: "account/rateLimits/updated",
+      params: { rateLimits: clearUpdate },
+    });
+    expect(clearedEvent).toMatchObject({
+      type: "provider/rateLimits/updated",
+      rateLimits: {
+        status: "unknown",
+        kind: "unknown",
+        reachedReason: null,
+      },
+    });
+  });
+
   it("preserves Codex subscription rate limits", () => {
     const harness = createHarness();
     const events = harness.translate(

--- a/plugins/provider-codex/src/delta-translation.ts
+++ b/plugins/provider-codex/src/delta-translation.ts
@@ -177,6 +177,7 @@ function mergeCodexRateLimitSnapshot(
     credits: update.credits ?? previous?.credits ?? null,
     individualLimit:
       update.individualLimit ?? previous?.individualLimit ?? null,
+    spendControlReached: update.spendControlReached ?? null,
     planType: update.planType ?? previous?.planType ?? null,
     rateLimitReachedType: update.rateLimitReachedType ?? null,
   };
@@ -249,11 +250,12 @@ function normalizeCodexRateLimits(
           : windows.length > 0 || snapshot.credits?.hasCredits === true
             ? "allowed"
             : "unknown";
+  const isSpendControlBlocked = snapshot.spendControlReached === true;
 
   return {
     providerId: "codex",
-    status,
-    kind,
+    status: isSpendControlBlocked ? "blocked" : status,
+    kind: isSpendControlBlocked ? "spend-control" : kind,
     windows,
     reachedReason,
     overageStatus: null,

--- a/plugins/provider-codex/src/schemas.ts
+++ b/plugins/provider-codex/src/schemas.ts
@@ -787,6 +787,7 @@ const codexRateLimitSnapshotUpdateSchema = z
     secondary: codexRateLimitWindowSchema.nullable().optional(),
     credits: codexCreditsSnapshotSchema.nullable().optional(),
     individualLimit: codexSpendControlLimitSnapshotSchema.nullable().optional(),
+    spendControlReached: z.boolean().nullable().optional(),
     planType: z.string().nullable().optional(),
     rateLimitReachedType: z.string().nullable().optional(),
   })
@@ -802,6 +803,7 @@ export interface CodexRateLimitSnapshot {
   secondary: z.output<typeof codexRateLimitWindowSchema> | null;
   credits: z.output<typeof codexCreditsSnapshotSchema> | null;
   individualLimit: z.output<typeof codexSpendControlLimitSnapshotSchema> | null;
+  spendControlReached: boolean | null;
   planType: string | null;
   rateLimitReachedType: string | null;
 }


### PR DESCRIPTION
## Human comments

## What was wrong

Codex 0.149.1 added `spendControlReached` to its rate-limit snapshot, but BB's handwritten snapshot model and merge did not carry the field. A real workspace spend-control payload with `spendControlReached: true` and `individualLimit: null` therefore normalized to unknown instead of blocked, which also prevented provider retry from recognizing the state. This follows up the generated schema update in #2436.

## What changed

- Parse and carry optional nullable `spendControlReached` through the handwritten Codex rate-limit snapshot.
- Treat the field as full-snapshot state: explicit null or absence clears it instead of inheriting a stale prior value.
- Normalize `true` to `status: "blocked"` and `kind: "spend-control"`.
- Cover initial rate-limit reads, full update notifications, explicit-null clearing, and absence clearing.

This is provider-local Codex app-server normalization. It does not change the server/host-daemon wire protocol, public SDK or CLI surfaces, or configuration, so no protocol bump or documentation change is required.

## How you verified

- Before the production change, the initial-read regression failed with `spendControlReached: undefined`; the two update regressions failed with `unknown/unknown` instead of blocked spend control.
- After the change, all three focused regressions pass.
- `pnpm exec turbo run test typecheck build --filter=bb-plugin-provider-codex --force`: 24 test files / 243 tests pass; typecheck and build prerequisites pass.
- The original upstream-shaped runtime harness now returns `{"readSpendControlReached":true,"updateStatus":"blocked","updateKind":"spend-control"}`.
- Prettier and `git diff --check` pass.

> AGENT GENERATED
