### PR TITLE
Align plugin thread-list guidance with palette search

### DIFF
--- a/apps/app/src/app.css
+++ b/apps/app/src/app.css
@@ -60,8 +60,8 @@
    * selection with `select-none` so drags and Select All only pick up
    * content. `user-select: auto` resolves from the parent, so WebKit would
    * carry that opt-out into editable controls inside those regions (the
-   * sidebar thread search, the inline thread-title rename) and refuse to
-   * select their text. Restore native selection on the controls themselves.
+   * inline thread-title rename, for example) and refuse to select their text.
+   * Restore native selection on the controls themselves.
    */
   .select-none
     :where(input, textarea, [contenteditable]:not([contenteditable="false"])) {
@@ -725,7 +725,7 @@
   }
 }
 
-/* Briefly highlight a conversation message that a sidebar search result
+/* Briefly highlight a conversation message that a thread-search result
  * deep-links to, then fade back to transparent. */
 @keyframes bb-search-flash {
   from {

--- a/apps/app/src/components/layout/app-chrome-selection.test.tsx
+++ b/apps/app/src/components/layout/app-chrome-selection.test.tsx
@@ -81,8 +81,8 @@ describe("app chrome opts out of text selection", () => {
 
   it("restores native selection on editable controls inside opted-out chrome", () => {
     // `user-select: auto` resolves from the parent, so without this rule
-    // WebKit would refuse to select text in the sidebar thread search and the
-    // inline thread-title rename input.
+    // WebKit would refuse to select text in the inline thread-title rename
+    // input.
     const css = readFileSync(
       join(dirname(fileURLToPath(import.meta.url)), "../../app.css"),
       "utf8",

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.actions.test.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.actions.test.tsx
@@ -961,7 +961,7 @@ describe("ThreadTimelineRows actions", () => {
     );
   });
 
-  it("ignores sidebar search scroll state for a different thread", () => {
+  it("ignores thread-search scroll state for a different thread", () => {
     // Row wrappers schedule frames of their own (containment arming), so run
     // every frame synchronously and assert on the reveal itself.
     vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
@@ -1007,7 +1007,7 @@ describe("ThreadTimelineRows actions", () => {
     ).toBe(false);
   });
 
-  it("scrolls sidebar search matches to the nested row instead of the containing parent", async () => {
+  it("scrolls thread-search matches to the nested row instead of the containing parent", async () => {
     vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
       callback(performance.now());
       return 1;
@@ -1122,7 +1122,7 @@ describe("ThreadTimelineRows actions", () => {
     }
   });
 
-  it("loads older timeline rows before scrolling to an older sidebar search match", async () => {
+  it("loads older timeline rows before scrolling to an older thread-search match", async () => {
     const onLoadOlderRows = vi.fn();
     vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
       callback(performance.now());

--- a/apps/app/src/components/thread/timeline/useScrollToSearchedMessage.ts
+++ b/apps/app/src/components/thread/timeline/useScrollToSearchedMessage.ts
@@ -157,7 +157,7 @@ export function collectSearchedMessageAncestorRowIds(
   return ancestorIds;
 }
 
-// Sidebar search hands the matched message's event sequence to the thread route
+// Thread search hands the matched message's event sequence to the thread route
 // via `navigate(path, { state: { searchMessageSeq, searchThreadId } })`.
 export function readSearchMessageTarget(
   state: unknown,
@@ -182,7 +182,7 @@ export function readSearchMessageTarget(
 }
 
 /**
- * When the thread was opened from a sidebar search result whose match was in a
+ * When the thread was opened from a thread-search result whose match was in a
  * message body, scroll that message into view and briefly highlight it.
  *
  * Keyed off `location.key` so it fires once per navigation (not on every render

--- a/docs/api_to_audit.md
+++ b/docs/api_to_audit.md
@@ -1581,13 +1581,14 @@ one toast.
 2. **Fallback discoverability.** Confirm one toast is the right signal when a
    crash silently swaps the user's sidebar back.
 3. **Region boundary.** The plugin gets the scrolling list and nothing else:
-   the New-thread button, search field, plugin nav rows, and footer stay
+   the New-thread button, search action, plugin nav rows, and footer stay
    host-rendered, because they are shared surfaces (other plugins live in two
    of them) and a replaced list must not remove them. Confirm no real sidebar
    needs to claim more, and that passing those regions down as props — letting
    a plugin place them, at the risk of dropping them — stays the wrong trade.
-4. **Search ownership.** The host owns the search field and passes
-   `searchQuery` down. Confirm a plugin list never needs its own field.
+4. **Search compatibility.** Confirm released plugins no longer need the
+   required deprecated `searchQuery` field before removing it in a deliberate
+   breaking change. Until then, the host supplies `""`.
 5. **Accessibility.** Confirm the host can still guarantee list semantics,
    focus order, and the mobile close behavior when a plugin owns the markup —
    `onNavigate` is currently the plugin's responsibility to call.

--- a/docs/plugin-sidebar-thread-list.md
+++ b/docs/plugin-sidebar-thread-list.md
@@ -33,8 +33,9 @@ handle carry desktop window behavior that is not a plugin concern.
 An earlier revision let a list claim the New-thread and search row too. That
 is gone: the row is shared chrome, and passing it down as a prop would mean a
 plugin could silently drop it. A list that wants its own controls puts them at
-the top of its own scroll area, and filters by the `searchQuery` prop rather
-than shipping a second search field.
+the top of its own scroll area. Thread search stays host-owned in the quick
+palette; the required `searchQuery` prop remains only for compatibility and is
+always `""`.
 
 ---
 
@@ -65,14 +66,14 @@ interface PluginThreadListProps {
   /** True on phone-width viewports and coarse pointers. */
   isCompactViewport: boolean;
   /**
-   * Call after the user opens a thread. It closes the mobile sidebar, and it
-   * clears the host search field on every viewport. Always call it, or the
-   * sidebar stays in search mode after the thread opens.
+   * Call after the user opens a thread. It closes the mobile sidebar drawer.
    */
   onNavigate: () => void;
   /**
-   * The host search field's text, or "" when the field is closed. The host
-   * owns that field, so filter by this rather than shipping a second one.
+   * Compatibility value for the former sidebar search field. BB now searches
+   * threads in the quick palette, so the host always supplies "".
+   *
+   * @deprecated The quick palette owns thread search. Ignore this value.
    */
   searchQuery: string;
   /**
@@ -645,8 +646,9 @@ missing explicitly selected plugin falls back to the built-in list.
    Confirm no real sidebar needs more, and that handing the shared regions
    down as props — letting a plugin place them, at the risk of dropping them —
    stays the wrong trade.
-4. **Search ownership.** Confirm passing `searchQuery` down is right, versus
-   a callback that lets the plugin own the field.
+4. **Search compatibility.** Confirm released plugins no longer need the
+   required deprecated `searchQuery` field before removing it in a deliberate
+   breaking change. Until then, the host supplies `""`.
 5. **Accessibility.** Confirm the host can still guarantee list semantics,
    focus order, and the mobile close behavior when a plugin owns the markup.
 


### PR DESCRIPTION
## Human comments

## What was wrong

When #2513 moved thread search from the sidebar into the quick palette, the SDK compatibility contract and host runtime were updated but two sibling public guidance sources were not. They still told replacement thread-list plugins to filter on a host-owned sidebar search field and said `onNavigate` cleared that field, even though the required deprecated `searchQuery` value is always `""` and `onNavigate` now only closes the compact drawer.

## What changed

- Updated the public thread-list replacement guide and API stabilization checklist to describe quick-palette ownership and the required empty compatibility value.
- Renamed directly related live comments and test titles from “sidebar search” to “thread search.”
- Kept `searchQuery` required and deprecated; no SDK declaration, runtime behavior, host/daemon wire contract, mobile code, CLI, or Plugin Guide fixture changed. `HOST_DAEMON_PROTOCOL_VERSION` is therefore unchanged.

## How you verified

- `pnpm exec turbo run test --filter=@bb/app -- src/components/layout/app-chrome-selection.test.tsx src/components/thread/timeline/ThreadTimelineRows.actions.test.tsx` — 2 files, 39 tests passed.
- `pnpm exec oxfmt apps/app/src/app.css apps/app/src/components/layout/app-chrome-selection.test.tsx apps/app/src/components/thread/timeline/ThreadTimelineRows.actions.test.tsx apps/app/src/components/thread/timeline/useScrollToSearchedMessage.ts docs/api_to_audit.md docs/plugin-sidebar-thread-list.md --check`
- `git diff --check origin/main..HEAD`
- Project-wide terminology and contract sweep across public docs, built-in agent guidance, SDK declarations, host props, code comments, CSS names, and test names.

Follow-up to #2513

> AGENT GENERATED
