### PR TITLE
Silence malformed prompt history warnings

### DIFF
--- a/apps/server/src/services/prompt-history.ts
+++ b/apps/server/src/services/prompt-history.ts
@@ -18,8 +18,7 @@ import {
 } from "@bb/domain";
 import { z } from "zod";
 import { toThreadQueuedMessage } from "./threads/thread-queued-messages.js";
-import type { AppDeps, ServerLogger } from "../types.js";
-import { productionErrorLogFields } from "./lib/error-log-fields.js";
+import type { AppDeps } from "../types.js";
 
 const storedPromptHistoryInputSchema = z.array(promptInputSchema).min(1);
 
@@ -35,7 +34,7 @@ interface ThreadPromptHistoryArgs extends PromptHistoryArgs {
   threadId: string;
 }
 
-type PromptHistoryServiceDeps = Pick<AppDeps, "db" | "logger">;
+type PromptHistoryServiceDeps = Pick<AppDeps, "db">;
 type PromptHistoryEntryInput = PromptHistoryEntry["input"];
 type PromptHistoryScopeThread = Pick<Thread, "parentThreadId">;
 type PromptHistoryRecordThread = Pick<
@@ -53,8 +52,6 @@ interface InternalPromptHistoryEntry extends PromptHistoryEntry {
   state: InternalPromptHistoryEntryState;
 }
 
-type PromptHistoryRowLogContext = Record<string, number | string>;
-
 interface ResolveAcceptedPromptHistoryScopeArgs {
   initiator: ThreadTurnInitiator;
   target: TurnRequestTarget;
@@ -71,8 +68,6 @@ interface RecordAcceptedPromptHistoryEntryArgs {
 
 interface BuildPromptHistoryEntriesArgs<TRow> {
   buildEntry: (row: TRow) => InternalPromptHistoryEntry;
-  describeRow: (row: TRow) => PromptHistoryRowLogContext;
-  logger: ServerLogger;
   rows: readonly TRow[];
 }
 
@@ -133,8 +128,6 @@ function toPromptHistoryEntry(
 
 function buildPromptHistoryEntries<TRow>({
   buildEntry,
-  describeRow,
-  logger,
   rows,
 }: BuildPromptHistoryEntriesArgs<TRow>): InternalPromptHistoryEntry[] {
   const entries: InternalPromptHistoryEntry[] = [];
@@ -142,14 +135,10 @@ function buildPromptHistoryEntries<TRow>({
   for (const row of rows) {
     try {
       entries.push(buildEntry(row));
-    } catch (error) {
-      logger.warn(
-        {
-          ...describeRow(row),
-          ...productionErrorLogFields(error),
-        },
-        "Skipping malformed prompt history row",
-      );
+    } catch {
+      // Legacy malformed rows cannot be recalled, so omit them from the
+      // visible history. The write path prevents new empty-input rows.
+      continue;
     }
   }
 
@@ -197,13 +186,7 @@ export function listProjectPromptHistory(
       projectId: args.projectId,
       limit: args.limit,
     }),
-    logger: deps.logger,
     buildEntry: buildAcceptedPromptHistoryEntry,
-    describeRow: (row) => ({
-      entryId: row.id,
-      requestSequence: row.requestSequence,
-      threadId: row.threadId,
-    }),
   });
 
   return takeVisiblePromptHistoryEntries({
@@ -218,25 +201,14 @@ export function listThreadPromptHistory(
 ): PromptHistoryEntry[] {
   const queuedEntries = buildPromptHistoryEntries({
     rows: listQueuedThreadMessages(deps.db, args.threadId),
-    logger: deps.logger,
     buildEntry: buildQueuedPromptHistoryEntry,
-    describeRow: (row) => ({
-      queuedMessageId: row.id,
-      threadId: row.threadId,
-    }),
   });
   const acceptedEntries = buildPromptHistoryEntries({
     rows: listStoredThreadPromptHistoryRows(deps.db, {
       threadId: args.threadId,
       limit: args.limit,
     }),
-    logger: deps.logger,
     buildEntry: buildAcceptedPromptHistoryEntry,
-    describeRow: (row) => ({
-      entryId: row.id,
-      requestSequence: row.requestSequence,
-      threadId: row.threadId,
-    }),
   });
 
   return buildVisibleThreadPromptHistory(

--- a/apps/server/test/services/prompt-history.test.ts
+++ b/apps/server/test/services/prompt-history.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
   archiveThread,
   createConnection,
@@ -47,14 +47,7 @@ function setup() {
     name: "Project B",
     source: { type: "local_path", hostId: host.id, path: "/tmp/project-b" },
   }).project;
-  const logger = {
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-  };
-
-  return { db, firstProject, secondProject, logger };
+  return { db, firstProject, secondProject };
 }
 
 function insertPromptHistoryEntry(args: InsertPromptHistoryEntryArgs) {
@@ -70,7 +63,7 @@ function insertPromptHistoryEntry(args: InsertPromptHistoryEntryArgs) {
 
 describe("prompt history service", () => {
   it("returns project create history scoped to one project", () => {
-    const { db, firstProject, secondProject, logger } = setup();
+    const { db, firstProject, secondProject } = setup();
     const firstThread = createThread(db, noopNotifier, {
       projectId: firstProject.id,
       providerId: "codex",
@@ -132,7 +125,7 @@ describe("prompt history service", () => {
 
     expect(
       listProjectPromptHistory(
-        { db, logger },
+        { db },
         {
           projectId: firstProject.id,
           limit: 50,
@@ -153,7 +146,7 @@ describe("prompt history service", () => {
   });
 
   it("includes archived thread starter prompts in project history", () => {
-    const { db, firstProject, logger } = setup();
+    const { db, firstProject } = setup();
     const liveThread = createThread(db, noopNotifier, {
       projectId: firstProject.id,
       providerId: "codex",
@@ -185,7 +178,7 @@ describe("prompt history service", () => {
 
     expect(
       listProjectPromptHistory(
-        { db, logger },
+        { db },
         {
           projectId: firstProject.id,
           limit: 50,
@@ -206,7 +199,7 @@ describe("prompt history service", () => {
   });
 
   it("includes hidden root prompts in ordinary project history", () => {
-    const { db, firstProject, logger } = setup();
+    const { db, firstProject } = setup();
     const visibleThread = createThread(db, noopNotifier, {
       projectId: firstProject.id,
       providerId: "codex",
@@ -238,7 +231,7 @@ describe("prompt history service", () => {
 
     expect(
       listProjectPromptHistory(
-        { db, logger },
+        { db },
         {
           projectId: firstProject.id,
           limit: 50,
@@ -259,7 +252,7 @@ describe("prompt history service", () => {
   });
 
   it("excludes deleted thread starter prompts from project history", () => {
-    const { db, firstProject, logger } = setup();
+    const { db, firstProject } = setup();
     const liveThread = createThread(db, noopNotifier, {
       projectId: firstProject.id,
       providerId: "codex",
@@ -291,7 +284,7 @@ describe("prompt history service", () => {
 
     expect(
       listProjectPromptHistory(
-        { db, logger },
+        { db },
         {
           projectId: firstProject.id,
           limit: 50,
@@ -307,7 +300,7 @@ describe("prompt history service", () => {
   });
 
   it("does not record project history for child thread starts", () => {
-    const { db, firstProject, logger } = setup();
+    const { db, firstProject } = setup();
     const parentThread = createThread(db, noopNotifier, {
       projectId: firstProject.id,
       providerId: "codex",
@@ -349,7 +342,7 @@ describe("prompt history service", () => {
 
     expect(
       listProjectPromptHistory(
-        { db, logger },
+        { db },
         {
           projectId: firstProject.id,
           limit: 50,
@@ -365,7 +358,7 @@ describe("prompt history service", () => {
   });
 
   it("returns thread follow-up history with queued messages merged in", () => {
-    const { db, firstProject, logger } = setup();
+    const { db, firstProject } = setup();
     const thread = createThread(db, noopNotifier, {
       projectId: firstProject.id,
       providerId: "codex",
@@ -409,7 +402,7 @@ describe("prompt history service", () => {
 
     expect(
       listThreadPromptHistory(
-        { db, logger },
+        { db },
         {
           threadId: thread.id,
           limit: 50,
@@ -429,8 +422,8 @@ describe("prompt history service", () => {
     ]);
   });
 
-  it("skips malformed stored prompt history rows instead of failing the request", () => {
-    const { db, firstProject, logger } = setup();
+  it("silently skips malformed stored prompt history rows", () => {
+    const { db, firstProject } = setup();
     const validThread = createThread(db, noopNotifier, {
       projectId: firstProject.id,
       providerId: "codex",
@@ -463,7 +456,7 @@ describe("prompt history service", () => {
 
     expect(
       listProjectPromptHistory(
-        { db, logger },
+        { db },
         {
           projectId: firstProject.id,
           limit: 50,
@@ -476,19 +469,9 @@ describe("prompt history service", () => {
         input: textInput("Recover valid prompt history"),
       },
     ]);
-    expect(logger.warn).toHaveBeenCalledWith(
-      expect.objectContaining({
-        entryId: "phist_malformed",
-        errorName: expect.any(String),
-        errorMessage: expect.any(String),
-        requestSequence: 1,
-        threadId: malformedThread.id,
-      }),
-      "Skipping malformed prompt history row",
-    );
   });
   it("does not persist empty-input turns as prompt history rows", () => {
-    const { db, firstProject, logger } = setup();
+    const { db, firstProject } = setup();
     const thread = createThread(db, noopNotifier, {
       projectId: firstProject.id,
       providerId: "codex",
@@ -514,18 +497,17 @@ describe("prompt history service", () => {
     expect(db.select().from(promptHistoryEntries).all()).toEqual([]);
     expect(
       listProjectPromptHistory(
-        { db, logger },
+        { db },
         {
           projectId: firstProject.id,
           limit: 50,
         },
       ),
     ).toEqual([]);
-    expect(logger.warn).not.toHaveBeenCalled();
   });
 
   it("excludes agent-only context from recalled prompt history", () => {
-    const { db, firstProject, logger } = setup();
+    const { db, firstProject } = setup();
     const thread = createThread(db, noopNotifier, {
       projectId: firstProject.id,
       providerId: "codex",
@@ -553,10 +535,7 @@ describe("prompt history service", () => {
       ),
     ).toBe(true);
     expect(
-      listThreadPromptHistory(
-        { db, logger },
-        { threadId: thread.id, limit: 50 },
-      ),
+      listThreadPromptHistory({ db }, { threadId: thread.id, limit: 50 }),
     ).toEqual([
       {
         id: expect.stringMatching(/^phist_/u),


### PR DESCRIPTION
## Human comments

## What was wrong

Known malformed legacy prompt-history rows are deliberately skipped, but the read path logged a warning every time one of those indefinitely retained rows was encountered. Current writes already reject empty prompt-history inputs, so the repeated warning was noisy rather than actionable.

## What changed

Removed the logger dependency and row-description plumbing from prompt-history listing, and now silently omit malformed legacy rows while preserving the defensive skip behavior. Updated the focused regression test to cover silent skipping. This does not change the host-daemon protocol or any wire contract.

## How you verified

- `pnpm exec turbo run test --filter=@bb/server -- test/services/prompt-history.test.ts` — 9 tests passed
- `pnpm exec turbo run typecheck --filter=@bb/server` — passed
- `pnpm exec oxfmt --check apps/server/src/services/prompt-history.ts apps/server/test/services/prompt-history.test.ts` — passed
- `git diff --check origin/main...HEAD` — passed

> AGENT GENERATED
