### PR TITLE
Publish owned runtime marker atomically

### DIFF
--- a/apps/desktop/src/owned-runtime-supervisor.ts
+++ b/apps/desktop/src/owned-runtime-supervisor.ts
@@ -1,4 +1,5 @@
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import {
   createNodeVerifiedProcessOps,
@@ -100,11 +101,22 @@ export async function writeOwnedRuntimePidFile(
     startedAt: new Date().toISOString(),
   };
   await mkdir(args.userDataPath, { recursive: true });
-  await writeFile(
-    ownedRuntimePidFilePath(args.userDataPath),
-    `${JSON.stringify(pidFile, null, 2)}\n`,
-    "utf8",
+  // Keep staging in the same directory so rename publishes only complete JSON.
+  const temporaryPath = join(
+    args.userDataPath,
+    `.${OWNED_RUNTIME_PID_FILE_NAME}.${process.pid}.${randomUUID()}.tmp`,
   );
+  try {
+    await writeFile(
+      temporaryPath,
+      `${JSON.stringify(pidFile, null, 2)}\n`,
+      "utf8",
+    );
+    await rename(temporaryPath, ownedRuntimePidFilePath(args.userDataPath));
+  } catch (error) {
+    await rm(temporaryPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
 }
 
 export async function clearOwnedRuntimePidFile(

--- a/apps/desktop/test/owned-runtime-supervisor.test.ts
+++ b/apps/desktop/test/owned-runtime-supervisor.test.ts
@@ -1,7 +1,29 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const writeControl = vi.hoisted(() => ({
+  enabled: false,
+  onStarted: (): void => {},
+  pauseUntil: Promise.resolve(),
+}));
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const original = await importOriginal<typeof import("node:fs/promises")>();
+  return {
+    ...original,
+    writeFile: async (...args: Parameters<typeof original.writeFile>) => {
+      if (writeControl.enabled) {
+        await original.writeFile(args[0], "", args[2]);
+        writeControl.onStarted();
+        await writeControl.pauseUntil;
+      }
+      await original.writeFile(...args);
+    },
+  };
+});
+
 import {
   readOwnedRuntimePidFile,
   reapStaleOwnedRuntime,
@@ -60,6 +82,9 @@ function createFakeProcessOps(args: CreateFakeProcessOpsArgs): FakeProcessOps {
 }
 
 afterEach(async () => {
+  writeControl.enabled = false;
+  writeControl.onStarted = (): void => {};
+  writeControl.pauseUntil = Promise.resolve();
   while (tempDirs.length > 0) {
     const tempDir = tempDirs.pop();
     if (tempDir !== undefined) {
@@ -69,6 +94,46 @@ afterEach(async () => {
 });
 
 describe("owned runtime supervisor", () => {
+  it("does not publish incomplete pid file JSON", async () => {
+    const tempDir = await createTempDir();
+    let releaseWrite = (): void => {};
+    writeControl.pauseUntil = new Promise<void>((resolve) => {
+      releaseWrite = resolve;
+    });
+    const writeStarted = new Promise<void>((resolve) => {
+      writeControl.onStarted = resolve;
+    });
+    writeControl.enabled = true;
+
+    const writePromise = writeOwnedRuntimePidFile({
+      bridgePath: "/tmp/app/resources/app.asar.unpacked/bb-app-bridge.mjs",
+      pid: 12345,
+      serverUrl: "http://127.0.0.1:38886",
+      userDataPath: tempDir.path,
+    });
+    await writeStarted;
+    const [observation] = await Promise.allSettled([
+      readFile(join(tempDir.path, "owned-runtime.json"), "utf8").then((raw) =>
+        JSON.parse(raw),
+      ),
+    ]);
+
+    releaseWrite();
+    await writePromise;
+
+    expect(observation).toMatchObject({
+      reason: { code: "ENOENT" },
+      status: "rejected",
+    });
+    await expect(
+      readOwnedRuntimePidFile({ userDataPath: tempDir.path }),
+    ).resolves.toMatchObject({
+      bridgePath: "/tmp/app/resources/app.asar.unpacked/bb-app-bridge.mjs",
+      pid: 12345,
+      serverUrl: "http://127.0.0.1:38886",
+    });
+  });
+
   it("reaps a stale Electron-owned bb-app bridge process", async () => {
     const tempDir = await createTempDir();
     const bridgePath = "/Applications/bb.app/bb-app-bridge.mjs";


### PR DESCRIPTION
## Human comments

## What was wrong

The desktop owned-runtime supervisor wrote `owned-runtime.json` directly at its final pathname. `writeFile` makes that pathname observable after creation/truncation but before all JSON bytes are written, so the AppImage startup poll could read an empty or truncated marker and fail immediately in `JSON.parse`, as captured in [main CI run 33093605671](https://github.com/get-bb/bb/actions/runs/33093605671). Investigation and implementation started from the independently verified main SHA `47ba90e6c2f379615a76d9e4c2dc421f8da08aef`.

## What changed

- Stage the complete owned-runtime marker in a unique file beside the destination, then publish it with a same-directory atomic rename.
- Remove a failed staging file without changing the existing final marker.
- Add a deterministic producer-boundary regression that pauses the write after file creation and asserts that `owned-runtime.json` is not yet visible.

The smoke reader, its assertions, and all polling intervals, deadlines, retry budgets, and wrapper clocks are unchanged. Persistent malformed JSON at the final pathname therefore remains a meaningful smoke failure instead of being treated as readiness. This is desktop-local filesystem publication only: no server/host-daemon wire contract changed, so `HOST_DAEMON_PROTOCOL_VERSION` remains 171.

## How you verified

- Red before the fix: the producer-boundary regression now in `test/owned-runtime-supervisor.test.ts` deterministically observed `Unexpected end of JSON input` while the base producer write was paused (it was first run as a standalone publication test before consolidation).
- Green after the fix: `pnpm exec turbo run test --filter=@bb/desktop --force -- test/owned-runtime-supervisor.test.ts` (4 tests).
- Stress: the focused Turbo test passed 25/25 consecutive runs.
- `pnpm exec turbo run typecheck --filter=@bb/desktop --force`.
- `pnpm exec turbo run build --filter=@bb/desktop --force` and a final cached-upstream `pnpm exec turbo run typecheck build --filter=@bb/desktop`.
- `pnpm exec oxfmt --check apps/desktop/src/owned-runtime-supervisor.ts apps/desktop/test/owned-runtime-supervisor.test.ts`.
- [PR CI run 33097922213](https://github.com/get-bb/bb/actions/runs/33097922213) passed, including Linux `Smoke Linux AppImage mount lifecycle`, both package-smoke jobs, and every test/check job.
- The full desktop suite reached 37 passing files / 242 passing tests, then its existing Linux-specific `bb-process` AppImage supervisor test failed on this macOS host because `/proc` is unavailable. The changed focused suite is green; no unrelated SIGTRAP behavior was exercised or changed.

> AGENT GENERATED: by GPT-5.6-Sol