### PR TITLE
Recover legacy empty-prompt automations

### DIFF
--- a/plugins/automations/src/data.ts
+++ b/plugins/automations/src/data.ts
@@ -5,6 +5,7 @@ import {
   automationResponseSchema,
   automationRunResponseSchema,
   automationTriggerSchema,
+  repairableAutomationExecutionSchema,
   type AutomationExecution,
   type AutomationOrigin,
   type AutomationResponse,
@@ -261,6 +262,12 @@ export function parseAutomationExecution(
   execution: string,
 ): AutomationExecution {
   return automationExecutionSchema.parse(JSON.parse(execution));
+}
+
+export function parseRepairableAutomationExecution(
+  execution: string,
+): AutomationExecution {
+  return repairableAutomationExecutionSchema.parse(JSON.parse(execution));
 }
 
 export function toAutomationResponse(row: AutomationRow): AutomationResponse {

--- a/plugins/automations/src/rpc-types.ts
+++ b/plugins/automations/src/rpc-types.ts
@@ -181,6 +181,13 @@ export const automationExecutionSchema = z.discriminatedUnion("mode", [
 ]);
 export type AutomationExecution = z.infer<typeof automationExecutionSchema>;
 
+// Desktop v0.40.0 persisted this otherwise-canonical empty-prompt shape.
+// Only update recovery may use it; every persisted write stays canonical.
+export const repairableAutomationExecutionSchema = z.union([
+  automationExecutionSchema,
+  automationAgentExecutionSchema.extend({ prompt: z.literal("") }),
+]);
+
 function requireExactlyOneScriptSource(
   exec: z.infer<typeof automationExecutionSchema>,
   ctx: z.RefinementCtx,

--- a/plugins/automations/src/server-harness.test.ts
+++ b/plugins/automations/src/server-harness.test.ts
@@ -675,6 +675,44 @@ describe("automations server plugin harness", () => {
     await harness.dispose();
   });
 
+  it("repairs a desktop v0.40.0 empty-prompt row through the public update path", async () => {
+    const host = await bootAutomationsPlugin();
+    const { harness } = host;
+    const created = await createAgentAutomation(harness);
+    if (created.execution.mode !== "agent") {
+      throw new Error("Expected an agent automation");
+    }
+    host.bb.storage
+      .database()
+      .prepare("UPDATE automations SET execution = ? WHERE id = ?")
+      .run(JSON.stringify({ ...created.execution, prompt: "" }), created.id);
+
+    await expect(
+      harness.callRpc("automations_list", { projectId: PROJECT_ID }),
+    ).rejects.toThrow("Too small");
+
+    const repaired = automationResponseSchema.parse(
+      await harness.callRpc("automations_update", {
+        projectId: PROJECT_ID,
+        automationId: created.id,
+        agent: { prompt: "repaired prompt" },
+      }),
+    );
+    expect(repaired.execution).toMatchObject({ prompt: "repaired prompt" });
+    expect(
+      automationListResponseSchema.parse(
+        await harness.callRpc("automations_list", { projectId: PROJECT_ID }),
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        id: created.id,
+        execution: expect.objectContaining({ prompt: "repaired prompt" }),
+      }),
+    ]);
+
+    await harness.dispose();
+  });
+
   it("preserves valid rows after rejected full and partial updates", async () => {
     const host = await bootAutomationsPlugin();
     const { harness } = host;

--- a/plugins/automations/src/service.ts
+++ b/plugins/automations/src/service.ts
@@ -11,6 +11,7 @@ import {
   listAutomationRuns,
   listAutomationsForProject,
   parseAutomationExecution,
+  parseRepairableAutomationExecution,
   parseAutomationTrigger,
   setAutomationEnabled,
   toAutomationResponse,
@@ -497,7 +498,9 @@ export function createAutomationService(args: {
         throw new Error("execution and agent updates cannot be combined");
       }
       const now = Date.now();
-      const currentExecution = parseAutomationExecution(current.execution);
+      const currentExecution = parseRepairableAutomationExecution(
+        current.execution,
+      );
       let stagedScriptFile: string | undefined;
       const patch: Parameters<typeof updateAutomation>[1]["patch"] = {};
       if (input.name !== undefined) patch.name = input.name;


### PR DESCRIPTION
## Human comments

## What was wrong

Desktop v0.40.0 could persist an agent automation with an empty prompt. New writes are now rejected, but the update path still parsed the already-persisted execution with the strict canonical schema before applying a valid replacement, so affected users could neither list nor repair the automation without editing SQLite directly.

## What changed

Added a narrowly scoped repair parser that accepts exactly the legacy empty-prompt agent shape while assembling an update. The normal data writer remains strict and still requires the resulting execution to pass the canonical persisted schema before mutation. Added a public-RPC regression proving the legacy row can be repaired and becomes readable again. There is no host-daemon protocol or wire-contract change.

## How you verified

- `pnpm exec turbo run test --filter=bb-plugin-automations --force` — 70 tests passed
- Focused legacy-row recovery regression — passed
- `pnpm exec turbo run typecheck --filter=bb-plugin-automations --force` — passed
- `pnpm exec turbo run build:runtime --filter=@get-bb/plugin-sdk` — passed
- Formatting and `git diff --check origin/main...HEAD` — passed

> AGENT GENERATED
