### PR TITLE
Test desktop graceful signal ordering

### DIFF
--- a/apps/desktop/test/bb-process.test.ts
+++ b/apps/desktop/test/bb-process.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createBbAppProcessLaunch,
   createBbAppProcessEnv,
@@ -309,6 +309,7 @@ setInterval(() => undefined, 1000);
       text: "ignored SIGTERM",
       timeoutMs: 1_000,
     });
+    const killSpy = vi.spyOn(processEntry.childProcess, "kill");
 
     await processEntry.stop({
       killSignal: "SIGKILL",
@@ -318,7 +319,8 @@ setInterval(() => undefined, 1000);
     });
 
     const exit = await processEntry.exit;
-    expect(processEntry.logs.text()).toContain("ignored SIGTERM");
+    expect(killSpy).toHaveBeenNthCalledWith(1, "SIGTERM");
+    expect(killSpy).toHaveBeenNthCalledWith(2, "SIGKILL");
     expect(exit.signal).toBe("SIGKILL");
   });
 });


### PR DESCRIPTION
## Human comments

## What was wrong

The desktop real-process shutdown test proved that its fixture could ignore `SIGTERM`, but its final log assertion reused the preparatory acknowledgement written before `stop()` began. The test therefore still passed if production skipped graceful shutdown and sent `SIGKILL` immediately.

## What changed

The test now spies on the real child process's parent-side `kill` method after fixture readiness and asserts that `stop()` sends `SIGTERM` first and `SIGKILL` second. Production behavior, timeouts, and fixture protocol are unchanged.

## How you verified

- Temporarily removed production's graceful kill call: the original test passed falsely, while the revised test failed because `SIGKILL` was the first observed signal.
- `pnpm exec turbo run test --filter=@bb/desktop --force -- --run test/bb-process.test.ts -t 'escalates to SIGKILL when the bridge ignores SIGTERM'` (1 passed, 7 skipped)
- `pnpm exec turbo run typecheck --filter=@bb/desktop` (3/3 Turbo tasks passed)
- `git diff --check origin/main...HEAD`

> AGENT GENERATED
