### PR TITLE
Cmd+click links open in the default browser

### DIFF
--- a/apps/app/src/components/thread/terminal/ThreadTerminalView.tsx
+++ b/apps/app/src/components/thread/terminal/ThreadTerminalView.tsx
@@ -21,7 +21,10 @@ import type {
 } from "@bb/server-contract";
 import { useAppThemeEpoch } from "@/hooks/useAppTheme";
 import { usePreferredTheme } from "@/hooks/useTheme";
-import type { MarkdownPreviewLinkHandler } from "@/components/ui/markdown-link";
+import {
+  isExternalBrowserModifierClick,
+  type MarkdownPreviewLinkHandler,
+} from "@/components/ui/markdown-link";
 import { openUrlInExternalBrowser } from "@/lib/url-open-routing";
 import { useAppNavigationHost } from "@/lib/app-navigation-host";
 import type { MessageProseSelection } from "@/components/thread/timeline/SelectableMessageProse.js";
@@ -519,7 +522,7 @@ function openTerminalWebLink({
   onOpenLink,
   uri,
 }: OpenTerminalWebLinkArgs): void {
-  if (onOpenLink({ href: uri })) {
+  if (!isExternalBrowserModifierClick(event) && onOpenLink({ href: uri })) {
     event.preventDefault();
     return;
   }

--- a/apps/app/src/components/ui/markdown-link.ts
+++ b/apps/app/src/components/ui/markdown-link.ts
@@ -10,3 +10,14 @@ interface MarkdownPreviewLink {
  * anchor with its default behavior.
  */
 export type MarkdownPreviewLinkHandler = (link: MarkdownPreviewLink) => boolean;
+
+/**
+ * Cmd/Ctrl+click means "open this elsewhere" everywhere else in the OS, so it
+ * opts out of in-app routing and falls back to the external browser.
+ */
+export function isExternalBrowserModifierClick(event: {
+  ctrlKey: boolean;
+  metaKey: boolean;
+}): boolean {
+  return event.metaKey || event.ctrlKey;
+}

--- a/apps/app/src/components/ui/markdown-preview.test.tsx
+++ b/apps/app/src/components/ui/markdown-preview.test.tsx
@@ -407,6 +407,25 @@ describe("MarkdownPreview", () => {
     expect(resolveSrc).toHaveBeenCalledTimes(2);
   });
 
+  it("leaves Cmd+click to the anchor default instead of in-app routing", () => {
+    const onOpenLink = vi.fn(() => true);
+    const href = "https://example.com/docs";
+
+    render(
+      <MarkdownPreview
+        content={`Open [docs](${href}).`}
+        linkRouting={{ onOpenLink }}
+      />,
+    );
+
+    const link = screen.getByRole("link", { name: "docs" });
+    fireEvent.click(link, { metaKey: true });
+    expect(onOpenLink).not.toHaveBeenCalled();
+
+    fireEvent.click(link);
+    expect(onOpenLink).toHaveBeenCalledWith({ href });
+  });
+
   it("keeps absolute app-origin URLs on the app-route path", () => {
     const onOpenLink = vi.fn(() => true);
     const href = `${window.location.origin}/threads/thr_localhost`;

--- a/apps/app/src/components/ui/markdown-preview.tsx
+++ b/apps/app/src/components/ui/markdown-preview.tsx
@@ -53,6 +53,7 @@ import {
 } from "./markdown-code-block.js";
 import { highlightMarkdownCode } from "./markdown-code-highlight.js";
 import "./markdown-code-highlight.css";
+import { isExternalBrowserModifierClick } from "./markdown-link.js";
 import { normalizeLocalFileMarkdownLinks } from "./markdown-local-file-link-normalize.js";
 import {
   buildLocalFileAnchorHref,
@@ -669,6 +670,12 @@ function MarkdownAnchor({
     // Internal BB destinations belong to RouteAnchor so they participate in
     // SPA history. URL preference routing only sees non-route destinations.
     if (isAppRouteHref) {
+      return;
+    }
+
+    // Cmd/Ctrl+click keeps the anchor's `target="_blank"` default, which the
+    // desktop shell sends to the OS browser and the web build to a new tab.
+    if (isExternalBrowserModifierClick(event)) {
       return;
     }
 


### PR DESCRIPTION
Web links in threads always go to the in-app browser, and the only way out is the global toggle in Settings → General. Cmd+click is the muscle memory for "open this somewhere else", so it now skips in-app routing and lets the anchor's target=_blank default take over, which the desktop shell already hands to shell.openExternal. Plain click is unchanged and still follows the setting.

Terminal links get the same treatment: with Cmd/Ctrl held they fall through to the external open that was already there.

Only meta/ctrl for now. Alt and shift clicks are untouched.

_Edit: forgot to open a issue first (as requested in CONTRIBUTING.md) so do what you want with this._ 