### PR TITLE
Bound thread mention resolution retries

### DIFF
--- a/apps/app/src/components/thread/ThreadTitleMentions.tsx
+++ b/apps/app/src/components/thread/ThreadTitleMentions.tsx
@@ -204,12 +204,14 @@ export function useSidebarThreadTitleMentionResources(
 interface RawThreadMentionResolverContextValue {
   register: (threadId: string) => void;
   resourceById: ReadonlyMap<string, PromptMentionResource>;
+  unavailableIds: ReadonlySet<string>;
 }
 
 const EMPTY_RAW_THREAD_MENTION_RESOLVER: RawThreadMentionResolverContextValue =
   {
     register: () => {},
     resourceById: new Map(),
+    unavailableIds: new Set(),
   };
 
 const RawThreadMentionResolverContext =
@@ -223,6 +225,7 @@ function RawThreadMentionResolverProvider({
   children: ReactNode;
 }) {
   const scheduledOrResolvedIdsRef = useRef(new Set<string>());
+  const retriedIdsRef = useRef(new Set<string>());
   const pendingIdsRef = useRef(new Set<string>());
   const flushTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const flushPendingRef = useRef<() => void>(() => {});
@@ -230,6 +233,9 @@ function RawThreadMentionResolverProvider({
   const [resourceById, setResourceById] = useState<
     ReadonlyMap<string, PromptMentionResource>
   >(new Map());
+  const [unavailableIds, setUnavailableIds] = useState<ReadonlySet<string>>(
+    new Set(),
+  );
 
   flushPendingRef.current = () => {
     const threadIds = [...pendingIdsRef.current].slice(
@@ -248,6 +254,9 @@ function RawThreadMentionResolverProvider({
       .resolveMentions({ threadIds, signal: controller.signal })
       .then((resolutions) => {
         if (controller.signal.aborted) return;
+        const resolvedIds = new Set(
+          resolutions.map((resolution) => resolution.threadId),
+        );
         setResourceById((current) => {
           const next = new Map(current);
           for (const resolution of resolutions) {
@@ -260,10 +269,21 @@ function RawThreadMentionResolverProvider({
           }
           return next;
         });
+        setUnavailableIds((current) => {
+          const next = new Set(current);
+          for (const threadId of threadIds) {
+            if (resolvedIds.has(threadId)) next.delete(threadId);
+            else next.add(threadId);
+          }
+          return next;
+        });
       })
       .catch(() => {
+        if (controller.signal.aborted) return;
         for (const threadId of threadIds) {
-          scheduledOrResolvedIdsRef.current.delete(threadId);
+          if (retriedIdsRef.current.has(threadId)) continue;
+          retriedIdsRef.current.add(threadId);
+          pendingIdsRef.current.add(threadId);
         }
       })
       .finally(() => {
@@ -291,8 +311,8 @@ function RawThreadMentionResolverProvider({
   }, []);
 
   const value = useMemo(
-    () => ({ register, resourceById }),
-    [register, resourceById],
+    () => ({ register, resourceById, unavailableIds }),
+    [register, resourceById, unavailableIds],
   );
 
   useEffect(
@@ -303,6 +323,7 @@ function RawThreadMentionResolverProvider({
       }
       pendingIdsRef.current.clear();
       scheduledOrResolvedIdsRef.current.clear();
+      retriedIdsRef.current.clear();
       for (const controller of activeControllersRef.current) {
         controller.abort();
       }
@@ -321,6 +342,7 @@ function RawThreadMentionResolverProvider({
 const EMPTY_RAW_THREAD_MENTION_BATCH: RawThreadMentionResolverContextValue = {
   register: () => {},
   resourceById: new Map(),
+  unavailableIds: new Set(),
 };
 
 const RawThreadMentionBatchContext =
@@ -341,8 +363,12 @@ function RawThreadMentionBatchScope({ children }: { children: ReactNode }) {
     [resolver],
   );
   const value = useMemo(
-    () => ({ register, resourceById: resolver.resourceById }),
-    [register, resolver.resourceById],
+    () => ({
+      register,
+      resourceById: resolver.resourceById,
+      unavailableIds: resolver.unavailableIds,
+    }),
+    [register, resolver.resourceById, resolver.unavailableIds],
   );
   useEffect(
     () => () => {
@@ -487,14 +513,16 @@ function threadMentionResource(
 }
 
 const UNRESOLVED_THREAD_MENTION_LABEL = "Thread";
+const UNAVAILABLE_THREAD_MENTION_LABEL = "Unavailable thread";
 
 function unresolvedThreadMentionResource(
   threadId: string,
+  label = UNRESOLVED_THREAD_MENTION_LABEL,
 ): PromptMentionResource {
   return {
     kind: "thread",
     threadId,
-    label: UNRESOLVED_THREAD_MENTION_LABEL,
+    label,
   };
 }
 
@@ -639,9 +667,18 @@ export function resolveThreadTitleDisplayText(
     .join("");
 }
 
+function useUnavailableRawThreadMentionIds(): ReadonlySet<string> {
+  const batch = useContext(RawThreadMentionBatchContext);
+  const resolver = useContext(RawThreadMentionResolverContext);
+  return batch === EMPTY_RAW_THREAD_MENTION_BATCH
+    ? resolver.unavailableIds
+    : batch.unavailableIds;
+}
+
 /** Resolves serialized mentions in a thread title to one plain display label. */
 export function useThreadTitleDisplayText(title: string): string {
   const resources = useContext(ThreadTitleMentionResourcesContext);
+  const unavailableThreadIds = useUnavailableRawThreadMentionIds();
   const segments = useMemo(
     () => threadTitleTextSegments(title, resources),
     [resources, title],
@@ -663,10 +700,12 @@ export function useThreadTitleDisplayText(title: string): string {
           segment.unresolvedThreadId === null
             ? segment.text
             : (resolvedThreadsById.get(segment.unresolvedThreadId)?.label ??
-              segment.text),
+              (unavailableThreadIds.has(segment.unresolvedThreadId)
+                ? UNAVAILABLE_THREAD_MENTION_LABEL
+                : segment.text)),
         )
         .join(""),
-    [resolvedThreadsById, segments],
+    [resolvedThreadsById, segments, unavailableThreadIds],
   );
 }
 
@@ -817,11 +856,17 @@ function ResolvingThreadTitleMention({
   threadId,
 }: ResolvingThreadTitleMentionProps) {
   const resource = useRawThreadMentionResource(threadId);
+  const unavailableIds = useUnavailableRawThreadMentionIds();
   if (resource === null) {
     return renderFallbackPill ? (
       <PromptMentionPill
         interactive={false}
-        resource={unresolvedThreadMentionResource(threadId)}
+        resource={unresolvedThreadMentionResource(
+          threadId,
+          unavailableIds.has(threadId)
+            ? UNAVAILABLE_THREAD_MENTION_LABEL
+            : UNRESOLVED_THREAD_MENTION_LABEL,
+        )}
         serializedText={serializedText}
       />
     ) : (

--- a/apps/app/src/components/ui/markdown-thread-mentions.test.tsx
+++ b/apps/app/src/components/ui/markdown-thread-mentions.test.tsx
@@ -559,6 +559,39 @@ describe("MarkdownPreview thread mentions", () => {
     expect(sdk.threads.resolveMentions).toHaveBeenCalledTimes(1);
   });
 
+  it("retries a failed title mention batch once", async () => {
+    vi.useFakeTimers();
+    try {
+      const threadId = "thr_2222222222";
+      vi.mocked(sdk.threads.resolveMentions).mockRejectedValue(
+        new Error("temporary failure"),
+      );
+      renderMarkdown(
+        <ThreadTitleMentions title={`Review @thread:${threadId}`} />,
+        [],
+      );
+
+      await act(async () => vi.advanceTimersByTimeAsync(60));
+      expect(sdk.threads.resolveMentions).toHaveBeenCalledTimes(2);
+      await act(async () => vi.advanceTimersByTimeAsync(1_000));
+      expect(sdk.threads.resolveMentions).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("marks an omitted title mention unavailable", async () => {
+    const threadId = "thr_2222222222";
+    vi.mocked(sdk.threads.resolveMentions).mockResolvedValueOnce([]);
+    renderMarkdown(
+      <ThreadTitleMentions title={`Review @thread:${threadId}`} />,
+      [],
+    );
+
+    expect(await screen.findByText("Unavailable thread")).not.toBeNull();
+    expect(sdk.threads.resolveMentions).toHaveBeenCalledTimes(1);
+  });
+
   it("shares one raw-id resolution across sibling messages and a title", async () => {
     const threadId = "thr_2222222222";
     vi.mocked(sdk.threads.resolveMentions).mockResolvedValueOnce([


### PR DESCRIPTION
## Human comments

## What was wrong

The shared thread-mention resolver treated a failed request and a successful response that omitted a deleted or missing thread as the same unresolved state. One transient failure therefore left valid archived mentions at the generic `Thread` label until reload, while terminal misses looked permanently pending.

## What changed

- Requeue each failed thread ID once at the root resolver boundary while preserving request deduplication and the 32-ID batch cap.
- Do not consume or schedule retries for aborted requests.
- Track successful omissions as terminally unavailable and render `Unavailable thread` in canonical visible and accessible title labels, without exposing raw IDs.
- Clear terminal-unavailable state when a later successful response resolves the ID.

This changes no server/daemon wire contract, CLI, SDK, configuration, or public plugin API.

## How you verified

- Before the production change, the two new regression cases failed: no retry occurred, and an omitted mention stayed labeled `Thread`.
- Focused post-rebase regression file: 34/34 tests passed.
- Affected consumer suite: 4 files, 123/123 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/app` (3/3 Turbo tasks passed)
- `pnpm exec turbo run lint --filter=@bb/app` (0 errors; existing warnings only)
- `git diff --check origin/main...HEAD`

> AGENT GENERATED
