### PR TITLE
Hash Plugin Guide maintenance skill in tests

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -46,9 +46,10 @@
         "$TURBO_ROOT$/packages/plugin-sdk/bundled-types/**",
         "$TURBO_ROOT$/packages/plugin-sdk/package.json",
         // wireframes.test.ts asserts fixture fidelity against the real app
-        // source, and maintenance-skill.test.ts reads the shipped skill, so
-        // both are inputs — otherwise edits to them cache-hit a stale pass.
+        // source, and maintenance-skill.test.ts reads the repository skill plus
+        // Plugin Guide source; all are inputs to prevent stale cache hits.
         "$TURBO_ROOT$/apps/app/src/views/thread-detail/ThreadDetailView.tsx",
+        "$TURBO_ROOT$/.bb/skills/plugin-guide-maintenance/**",
         "$TURBO_ROOT$/plugins/plugin-api-docs/**",
         "$TURBO_ROOT$/vitest.shared.ts"
       ]


### PR DESCRIPTION
## Human comments

## What was wrong

The Plugin Guide maintenance test reads the repository's `.bb/skills/plugin-guide-maintenance` skill and QA script, but `@bb/plugin-api-map#test` did not hash that relocated tree. A skill-only edit could therefore reuse a cached green test result instead of rerunning the regression coverage.

## What changed

Added the owned Plugin Guide maintenance skill tree to the existing Turbo test inputs and clarified the adjacent comment. The change intentionally avoids hashing all of `.bb`, disabling caching, or adding another task.

No runtime, SDK/API, UI, generated, lockfile, CLI, or server/daemon wire behavior changed.

## How you verified

- Before the change, the Turbo dry run had 41 inputs and omitted both the maintenance `SKILL.md` and `verify-guide-chrome.mjs`.
- After rebasing, the resolved task has 58 inputs and includes both repository skill files while retaining the Plugin Guide plugin inputs.
- `pnpm exec turbo run test typecheck --filter=@bb/plugin-api-map --force` (75/75 tests passed; 4/4 Turbo tasks passed)
- `git diff --check origin/main...HEAD`

> AGENT GENERATED
