### PR TITLE
Gate AppImage supervisor test execution on Linux

### DIFF
--- a/apps/desktop/test/bb-process.test.ts
+++ b/apps/desktop/test/bb-process.test.ts
@@ -163,6 +163,9 @@ describe("bb app process", () => {
     });
 
     expect(launch.args).toContain(desktopMountScript.path);
+    if (process.platform !== "linux") {
+      return;
+    }
     const result = await execFileAsync(launch.executablePath, launch.args, {
       env: {
         ...launch.env,


### PR DESCRIPTION
## Human comments

## What was wrong

The AppImage launch-construction test continued into the Linux-only serialized supervisor after its portable assertions. On macOS, that supervisor scanned `/proc`, causing a deterministic `ENOENT` failure even though shipped macOS runtime behavior was unaffected.

## What changed

The test still constructs the AppImage launch and verifies its inert bridge argument on every platform, then returns before executing the serialized supervisor when the host is not Linux. Production code and runtime behavior are unchanged.

## How you verified

- Before the fix on macOS, the focused desktop files failed consistently when the test attempted to scan `/proc`.
- `pnpm exec turbo run test --filter=@bb/desktop --force` (37 files; 242 passed, 1 intentional Linux-only skip)
- `pnpm exec turbo run typecheck --filter=@bb/desktop` (3/3 Turbo tasks passed)
- The focused test was also validated on Linux/arm64 before handoff.
- `git diff --check origin/main...HEAD`

> AGENT GENERATED
