### PR TITLE
Fix Skills provenance provider mark alignment

### DIFF
--- a/apps/app/src/components/tools/SkillsCollection.tsx
+++ b/apps/app/src/components/tools/SkillsCollection.tsx
@@ -153,7 +153,11 @@ export function SkillProvenanceTooltip({
   return (
     <span className="inline-flex items-center gap-1.5">
       <span>{prefix}</span>
-      <span data-provider-icon={providerId ?? "bb"} aria-hidden="true">
+      <span
+        data-provider-icon={providerId ?? "bb"}
+        aria-hidden="true"
+        className="flex size-3.5 shrink-0 items-center justify-center"
+      >
         {providerId === null ? (
           <BbLogo className="size-3.5 brightness-0 invert" />
         ) : (

--- a/apps/app/src/views/SkillsView.test.tsx
+++ b/apps/app/src/views/SkillsView.test.tsx
@@ -1609,9 +1609,15 @@ describe("SkillDetailDialogView", () => {
     const tooltip = await screen.findByRole("tooltip");
     expect(tooltip.textContent).toContain("Included with");
     expect(tooltip.textContent).toContain(example.tooltipName);
+    const providerIcon = tooltip.querySelector(
+      `[data-provider-icon="${example.providerIcon}"]`,
+    );
+    expect(providerIcon).not.toBeNull();
     expect(
-      tooltip.querySelector(`[data-provider-icon="${example.providerIcon}"]`),
-    ).not.toBeNull();
+      ["flex", "size-3.5", "shrink-0", "items-center", "justify-center"].every(
+        (className) => providerIcon?.classList.contains(className),
+      ),
+    ).toBe(true);
   });
 
   it("labels externally discovered provider skills as imported", async () => {


### PR DESCRIPTION
## Human comments

## What was wrong

Skills provenance provider marks used a text-line-box wrapper, leaving the 14px artwork about 2px above the adjacent tooltip text. The equivalent provider marks in Machine Settings and Updates already use a fixed centered slot, but this sibling was missed.

## What changed

Give the existing Skills provenance provider wrapper a 14px flex slot with centered alignment and no shrinking. Add rendered regression coverage for both configured provider artwork and the bb fallback mark. This is app-only styling and test coverage; there are no wire, CLI, guide, or documentation changes.

## How you verified

- `pnpm exec turbo run test --filter=@bb/app -- --run src/views/SkillsView.test.tsx` (37/37 passed)
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run typecheck lint --filter=@bb/app` before the final rebase (typecheck passed; lint had 0 errors and 173 existing warnings)
- `git diff --check origin/main...HEAD`
- DevBrowser geometry checks at 1280x900 for pointer hover and keyboard focus

> AGENT GENERATED
