### PR TITLE
Fix ACP topology marker publication race

### DIFF
--- a/packages/provider-bridge-acp/src/bridge/fake-acp-agent.mjs
+++ b/packages/provider-bridge-acp/src/bridge/fake-acp-agent.mjs
@@ -68,7 +68,7 @@
  */
 
 import { createInterface } from "node:readline";
-import { appendFileSync, writeFileSync } from "node:fs";
+import { appendFileSync, renameSync, writeFileSync } from "node:fs";
 
 const failLoad = process.env.FAKE_ACP_FAIL_LOAD === "1";
 const loadSession = process.env.FAKE_ACP_LOAD_SESSION === "1" || failLoad;
@@ -144,7 +144,12 @@ for (let i = fakeModels.length; i < modelCount; i += 1) {
 
 process.on("SIGTERM", () => {
   if (process.env.FAKE_ACP_SIGNAL_FILE) {
-    writeFileSync(process.env.FAKE_ACP_SIGNAL_FILE, "SIGTERM\n");
+    const signalFile = process.env.FAKE_ACP_SIGNAL_FILE;
+    const stagedSignalFile = `${signalFile}.${process.pid}.tmp`;
+    // The final path is the test's completion boundary: publish it only after
+    // the marker bytes are complete.
+    writeFileSync(stagedSignalFile, "SIGTERM\n");
+    renameSync(stagedSignalFile, signalFile);
   }
   process.exit(0);
 });


### PR DESCRIPTION
## Human comments

## What was wrong

On the independently verified fresh-main baseline [`54d6e3ee64f073872766a09a70a474999acb9f68`](https://github.com/get-bb/bb/commit/54d6e3ee64f073872766a09a70a474999acb9f68), the ACP topology test treated existence of the fake agent's SIGTERM marker as completed publication and immediately read it. `writeFileSync(path, data)` creates or truncates the final pathname before writing its bytes, so scheduler contention could let the test observe that intermediate zero-length file. Tagged instrumentation reproduced the exact [main CI failure](https://github.com/get-bb/bb/actions/runs/33100377644/job/98616171627): every empty first read became `"SIGTERM\n"` shortly afterward, with exactly one fake-agent launch. The runtime timeout and release behavior were correct; the fixture exposed an incomplete marker as if it were complete.

## What changed

The fake ACP agent now writes the SIGTERM marker to a same-directory, PID-specific staging file and atomically renames it to the observed path only after the marker bytes are complete. Existence of the final path is therefore a real completion boundary, while the existing topology test still covers the 300 ms construction timeout, best-effort release, real SIGTERM lifecycle, child exit, and live bridge. No test clock or assertion changed. [PR #2552](https://github.com/get-bb/bb/pull/2552) changes intentional-stop connection state but retains the same SIGTERM and does not touch this fake-marker seam, so the fixes do not conflict or duplicate one another. This changes no server/daemon wire data, CLI, configuration, or public plugin contract, so no `HOST_DAEMON_PROTOCOL_VERSION`, guide, or API documentation update is required.

## How you verified

- Red/green exact stress harness on 16 logical CPUs, 64 focused runs at 16-way concurrency: before, 59/64 passed and 5/64 failed with `expected '' to contain 'SIGTERM'`; after, 64/64 passed with zero failures. A tagged diagnostic run reproduced 12/64 exact failures and proved each empty first read later contained `"SIGTERM\n"` with one child launch.
- `pnpm exec turbo run test --filter=@bb/agent-runtime --force -- --run src/runtime.acp-topology.test.ts -t "releases the thread on the bridge when a construction times out on the runtime's side"` — 1 test passed.
- `pnpm exec turbo run test --filter=@bb/provider-bridge-acp --force -- --run src/bridge/bridge.test.ts -t "releases a session still under construction: the agent is reaped and the pending thread/start fails"` — 1 focused lifecycle test passed.
- `pnpm exec turbo run test --filter=@bb/agent-runtime --filter=@bb/provider-bridge-acp --force` — agent-runtime 22 files / 318 tests and ACP bridge 17 files / 295 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/agent-runtime --filter=@bb/provider-bridge-acp --force` — passed.
- `pnpm exec turbo run build --filter=@bb/agent-runtime --filter=@bb/provider-bridge-acp --force` — applicable Turbo build graph passed.
- `pnpm exec prettier --check packages/provider-bridge-acp/src/bridge/fake-acp-agent.mjs` and `git diff --check` — passed; all temporary `[DEBUG-acp-marker]` instrumentation was removed.

> AGENT GENERATED: by GPT-5.6-Sol
