### PR TITLE
Revert active workspace label in composer footer

### DIFF
--- a/apps/app/src/components/promptbox/ThreadEnvironmentSummary.test.tsx
+++ b/apps/app/src/components/promptbox/ThreadEnvironmentSummary.test.tsx
@@ -22,64 +22,6 @@ describe("ThreadEnvironmentSummary", () => {
     ).toBe("Worktree");
   });
 
-  it("updates the active workspace directory and full-path tooltip", async () => {
-    const { container, rerender } = render(
-      <TooltipProvider delayDuration={0}>
-        <ThreadEnvironmentSummary
-          projectName="project-a"
-          projectRootPath="/path/to/project-a"
-          environmentPath="/path/to/project-b/."
-          environmentLabel="Working locally"
-        />
-      </TooltipProvider>,
-    );
-
-    const projectLabel = container.querySelector("[data-option-display]");
-    expect(
-      projectLabel?.querySelector("[data-promptbox-full-label]")?.textContent,
-    ).toBe("project-a / project-b");
-    fireEvent.pointerMove(projectLabel?.parentElement ?? projectLabel!);
-    expect((await screen.findByRole("tooltip")).textContent).toBe(
-      "/path/to/project-b/.",
-    );
-
-    rerender(
-      <TooltipProvider delayDuration={0}>
-        <ThreadEnvironmentSummary
-          projectName="project-a"
-          projectRootPath="/path/to/project-a"
-          environmentPath="/other/project-c"
-          environmentLabel="Working locally"
-        />
-      </TooltipProvider>,
-    );
-
-    const updatedProjectLabel = container.querySelector(
-      "[data-option-display]",
-    );
-    expect(
-      updatedProjectLabel?.querySelector("[data-promptbox-full-label]")
-        ?.textContent,
-    ).toBe("project-a / project-c");
-  });
-
-  it("keeps only the project name at the project root", () => {
-    const { container } = render(
-      <TooltipProvider>
-        <ThreadEnvironmentSummary
-          projectName="project-a"
-          projectRootPath="/path/to/project-a/"
-          environmentPath="/path/to/project-a/child/.."
-          environmentLabel="Working locally"
-        />
-      </TooltipProvider>,
-    );
-
-    expect(
-      container.querySelector("[data-promptbox-full-label]")?.textContent,
-    ).toBe("project-a");
-  });
-
   it("explains the create-thread action in a tooltip", async () => {
     render(
       <TooltipProvider delayDuration={0}>

--- a/apps/app/src/components/promptbox/ThreadEnvironmentSummary.tsx
+++ b/apps/app/src/components/promptbox/ThreadEnvironmentSummary.tsx
@@ -7,7 +7,6 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@bb/shared-ui/tooltip";
-import { normalizeAbsoluteFilePath } from "@/lib/absolute-file-path";
 import type { WorkspaceCheckoutDisplay } from "@/lib/workspace-checkout-display";
 
 const CHECKOUT_CHIP_BASE_CLASS_NAME =
@@ -17,10 +16,6 @@ const CHECKOUT_CHIP_BUTTON_CLASS_NAME = `${CHECKOUT_CHIP_BASE_CLASS_NAME} cursor
 interface ThreadEnvironmentSummaryProps {
   /** Display name of the thread's project, shown alongside the environment. */
   projectName?: string;
-  /** Project source path on the environment's host. */
-  projectRootPath?: string;
-  /** Full path of the thread's active environment. */
-  environmentPath?: string;
   /** Full mode label used on larger prompt boxes and in the title. */
   environmentLabel?: string;
   /** Short label used when the promptbox switches to its compact layout. */
@@ -50,8 +45,6 @@ interface ThreadEnvironmentSummaryProps {
  */
 export const ThreadEnvironmentSummary = memo(function ThreadEnvironmentSummary({
   projectName,
-  projectRootPath,
-  environmentPath,
   environmentLabel,
   environmentCompactLabel,
   environmentIcon,
@@ -63,45 +56,18 @@ export const ThreadEnvironmentSummary = memo(function ThreadEnvironmentSummary({
   }
 
   const checkoutCopyValue = environmentCheckout?.copyValue ?? null;
-  const normalizedProjectRootPath = projectRootPath
-    ? normalizeAbsoluteFilePath({ path: projectRootPath })
-    : null;
-  const normalizedEnvironmentPath = environmentPath
-    ? normalizeAbsoluteFilePath({ path: environmentPath })
-    : null;
-  const environmentDirectoryName = normalizedEnvironmentPath
-    ?.split("/")
-    .at(-1);
-  const visibleProjectName =
-    projectName &&
-    normalizedProjectRootPath &&
-    normalizedEnvironmentPath &&
-    normalizedProjectRootPath !== normalizedEnvironmentPath &&
-    environmentDirectoryName
-      ? `${projectName} / ${environmentDirectoryName}`
-      : projectName;
-
   return (
     <div className="flex min-w-0 max-w-full items-center gap-2 pr-1.5">
-      {visibleProjectName ? (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span className="inline-flex min-w-0 shrink-0">
-              <OptionDisplay
-                label="Project"
-                value={visibleProjectName}
-                compactValue={visibleProjectName}
-                leading={<Icon name="Folder" className="size-4 shrink-0" />}
-                className="h-6 max-w-[10rem]"
-                title=""
-                muted
-              />
-            </span>
-          </TooltipTrigger>
-          <TooltipContent>
-            {environmentPath ?? `Project: ${projectName}`}
-          </TooltipContent>
-        </Tooltip>
+      {projectName ? (
+        <OptionDisplay
+          label="Project"
+          value={projectName}
+          compactValue={projectName}
+          leading={<Icon name="Folder" className="size-4 shrink-0" />}
+          className="h-6 max-w-[10rem] shrink-0"
+          title={`Project: ${projectName}`}
+          muted
+        />
       ) : null}
       <OptionDisplay
         label="Environment"

--- a/apps/app/src/components/ui/markdown-thread-mentions.test.tsx
+++ b/apps/app/src/components/ui/markdown-thread-mentions.test.tsx
@@ -563,9 +563,9 @@ describe("MarkdownPreview thread mentions", () => {
     vi.useFakeTimers();
     try {
       const threadId = "thr_2222222222";
-      vi.mocked(sdk.threads.resolveMentions).mockRejectedValue(
-        new Error("temporary failure"),
-      );
+    vi.mocked(sdk.threads.resolveMentions)
+      .mockRejectedValueOnce(new Error("temporary failure"))
+      .mockRejectedValueOnce(new Error("temporary failure"));
       renderMarkdown(
         <ThreadTitleMentions title={`Review @thread:${threadId}`} />,
         [],

--- a/apps/app/src/hooks/queries/sidebar-navigation-query.ts
+++ b/apps/app/src/hooks/queries/sidebar-navigation-query.ts
@@ -1,10 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { useCallback } from "react";
-import {
-  findLocalPathProjectSourceForHost,
-  PERSONAL_PROJECT_ID,
-  type ThreadListEntry,
-} from "@bb/domain";
+import { PERSONAL_PROJECT_ID, type ThreadListEntry } from "@bb/domain";
 import type { SidebarBootstrapResponse } from "@bb/server-contract";
 import { listSidebarNavigationThreads } from "@/hooks/cache-owners/query-cache";
 import { apiClient } from "@/lib/api-server";
@@ -60,16 +56,15 @@ export function useSidebarNavigation(options?: QueryOptions) {
 }
 
 /**
- * Read the active project's name and host-specific root from the shared
- * sidebar-navigation cache. The sidebar owns the realtime subscriptions and
- * initial load. This hook only reads the cache so the follow-up composer can
- * identify the active workspace. Returns undefined until the cache is populated
- * or when the project is unknown.
+ * Read the active project's display name from the shared sidebar-navigation
+ * cache. The sidebar owns the realtime subscriptions and initial load; this only
+ * reads the cached projects (no extra subscriptions) so surfaces like the
+ * follow-up composer footer can label the current project. Returns undefined
+ * until the cache is populated or when the project is unknown.
  */
-export function useProjectWorkspaceDisplay(
+export function useProjectDisplayName(
   projectId: string | undefined,
-  hostId: string | undefined,
-): { name: string; rootPath: string | undefined } | undefined {
+): string | undefined {
   const { data } = useQuery<SidebarBootstrapResponse>({
     queryKey: sidebarNavigationQueryKey(),
     queryFn: ({ signal }) => fetchSidebarNavigation(signal),
@@ -81,19 +76,10 @@ export function useProjectWorkspaceDisplay(
   if (!data || !projectId) {
     return undefined;
   }
-  const project =
-    projectId === PERSONAL_PROJECT_ID
-      ? data.personalProject
-      : data.projects.find((candidate) => candidate.id === projectId);
-  if (!project) {
-    return undefined;
+  if (projectId === PERSONAL_PROJECT_ID) {
+    return data.personalProject.name;
   }
-  return {
-    name: project.name,
-    rootPath: hostId
-      ? findLocalPathProjectSourceForHost(project.sources, hostId)?.path
-      : undefined,
-  };
+  return data.projects.find((project) => project.id === projectId)?.name;
 }
 
 interface SidebarNavigationThreadSelection<T> {

--- a/apps/app/src/views/thread-detail/ThreadDetailPromptArea.keystrokes.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailPromptArea.keystrokes.test.tsx
@@ -258,7 +258,7 @@ vi.mock("@/hooks/mutations/thread-state-mutations", () => ({
 }));
 
 vi.mock("@/hooks/queries/sidebar-navigation-query", () => ({
-  useProjectWorkspaceDisplay: () => null,
+  useProjectDisplayName: () => null,
 }));
 
 vi.mock("@/hooks/queries/thread-default-execution-options-query", () => ({

--- a/apps/app/src/views/thread-detail/ThreadDetailPromptArea.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailPromptArea.test.tsx
@@ -534,7 +534,7 @@ vi.mock("@/hooks/mutations/thread-state-mutations", () => ({
 }));
 
 vi.mock("@/hooks/queries/sidebar-navigation-query", () => ({
-  useProjectWorkspaceDisplay: () => null,
+  useProjectDisplayName: () => null,
 }));
 
 vi.mock("@/hooks/queries/thread-default-execution-options-query", () => ({

--- a/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
@@ -67,7 +67,7 @@ import type { WorkspaceCheckoutDisplay } from "@/lib/workspace-checkout-display"
 import { useComposerTextEffects } from "@/lib/composer-text-effects";
 import { useLatestRef } from "@/hooks/useLatestRef";
 import { useThreadCreationOptions } from "@/hooks/useThreadCreationOptions";
-import { useProjectWorkspaceDisplay } from "@/hooks/queries/sidebar-navigation-query";
+import { useProjectDisplayName } from "@/hooks/queries/sidebar-navigation-query";
 import {
   useActiveComposerDraft,
   useComposerAttachmentUploads,
@@ -159,7 +159,6 @@ interface ThreadDetailPromptAreaProps {
   environmentHostId?: string;
   environmentIcon?: IconName;
   environmentLabel?: string;
-  environmentPath?: string;
   onCreateNewThreadInWorktree?: () => void;
   onPullRequestDraft?: () => void;
   onPullRequestMerge?: (method: PullRequestMergeMethod) => void;
@@ -414,7 +413,6 @@ export function ThreadDetailPromptArea({
   environmentHostId,
   environmentIcon,
   environmentLabel,
-  environmentPath,
   onCreateNewThreadInWorktree,
   onPullRequestDraft,
   onPullRequestMerge,
@@ -516,9 +514,8 @@ export function ThreadDetailPromptArea({
   const clearThreadGoal = useClearThreadGoal();
   const unarchiveThread = useUnarchiveThread();
   // The personal project isn't a meaningful label in the footer, so skip it.
-  const projectWorkspaceDisplay = useProjectWorkspaceDisplay(
+  const projectName = useProjectDisplayName(
     thread.projectId === PERSONAL_PROJECT_ID ? undefined : thread.projectId,
-    environmentHostId,
   );
   const {
     promptDraft,
@@ -1263,9 +1260,7 @@ export function ThreadDetailPromptArea({
     () =>
       environmentLabel ? (
         <ThreadEnvironmentSummary
-          projectName={projectWorkspaceDisplay?.name}
-          projectRootPath={projectWorkspaceDisplay?.rootPath}
-          environmentPath={environmentPath}
+          projectName={projectName}
           environmentLabel={environmentLabel}
           environmentCompactLabel={environmentCompactLabel}
           environmentIcon={environmentIcon}
@@ -1278,9 +1273,8 @@ export function ThreadDetailPromptArea({
       environmentCompactLabel,
       environmentIcon,
       environmentLabel,
-      environmentPath,
       onCreateNewThreadInWorktree,
-      projectWorkspaceDisplay,
+      projectName,
     ],
   );
   const activePromptModeCard = useMemo(

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -2568,7 +2568,6 @@ function ThreadDetailViewInternal(props: ThreadRoutePathArgs) {
           ? `${environmentMachinePrefix}${threadEnvironmentDisplay.modeLabel}`
           : undefined
       }
-      environmentPath={environment?.path ?? undefined}
       environmentGoneStatus={threadEnvironmentGoneStatus}
       environmentHostId={environment?.hostId}
       isEnvironmentActionPending={requestEnvironmentAction.isPending}


### PR DESCRIPTION
## Human comments

## What was wrong

Pull request #1507 added the active environment directory beside the project name. It produced a duplicate `bb / bb` footer label.

## What changed

This change reverts pull request #1507. The composer footer now shows only the project name again.

The change restores the prior project-name query and removes the added environment-path props. It does not change the host daemon protocol.

The change also isolates an existing thread-mention retry mock. That mock caused a later app test to fail after the first CI run.

## How you verified

- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run lint --filter=@bb/app`
- The targeted app tests did not start because the host returned `Unknown system error -122, write`.
- GitHub CI runs the affected footer and thread-mention tests.

Reverts #1507

> AGENT GENERATED
