### PR TITLE
test(app): isolate Markdown mention resolver mocks

### DIFF
--- a/apps/app/src/components/ui/markdown-thread-mentions.test.tsx
+++ b/apps/app/src/components/ui/markdown-thread-mentions.test.tsx
@@ -165,7 +165,7 @@ const ACTIVE_MESSAGE_DIRECTIVES: MarkdownMessageDirectives = {
 
 afterEach(() => {
   cleanup();
-  vi.clearAllMocks();
+  vi.resetAllMocks();
   setPreferredTheme("system");
 });
 


### PR DESCRIPTION
## Human comments

## What was wrong

The `retries a failed title mention batch once` test replaced `sdk.threads.resolveMentions` with a persistent rejected implementation, but this file's `afterEach` only cleared mock call history. Later raw-ID Markdown-link tests therefore inherited the earlier `temporary failure`; the production resolver correctly scheduled its single transient-failure retry, racing those tests' one-call assertions. Successful omission (`[]`) is already terminal, StrictMode registration remains deduplicated, and resolver unmount cleanup aborts outstanding work—the leaked test implementation prevented those later cases from exercising that path. This reproduced on the [main app-2 job](https://github.com/get-bb/bb/actions/runs/33101367947/job/98619634889) and multiple unrelated PR heads.

## What changed

Reset this test file's mocks after React cleanup instead of only clearing call history. Vitest restores the original `vi.fn(async () => [])` implementation, so every test starts with a successful-omission resolver unless it explicitly configures a failure. Production retry, terminal-unavailable, external-link, accessible-label, request-deduplication, and abort behavior are unchanged. There are no wire, CLI, guide, or documentation changes.

## How you verified

- Fresh-main gate was independently confirmed with empty status and `HEAD`, `origin/main`, and merge-base all at `54d6e3ee64f073872766a09a70a474999acb9f68` before investigation.
- Before the fix, the exact Turbo app-2 shard reproduced the mixed-label `resolveMentions` one-call-versus-two failure on stress run 5. A focused probe proved the adjacent raw-link test's first resolver promise rejected with the predecessor's literal `temporary failure`.
- After the fix, the retry / terminal-omission / two adjacent raw-link subset passed (4 tests), and the complete focused file passed (34 tests).
- The exact app-2 shard passed 10 consecutive forced runs (147 files, 1,097 passed and 1 skipped per run).
- `pnpm exec turbo run typecheck --filter=@bb/app --force`
- `pnpm exec turbo run build --filter=@bb/app --force`
- `pnpm exec turbo run lint --filter=@bb/app --force` (0 errors; existing warnings only)
- `pnpm exec oxfmt --check apps/app/src/components/ui/markdown-thread-mentions.test.tsx`
- `git diff --check`

> AGENT GENERATED: by GPT-5.6-Sol
