### PR TITLE
Preserve Tasks Markdown table atoms and pasted content

### DIFF
--- a/plugins/tasks/editor/editor.test.tsx
+++ b/plugins/tasks/editor/editor.test.tsx
@@ -425,6 +425,26 @@ describe("TasksEditor component", () => {
     ).toBeTruthy();
   });
 
+  it("renders pasted Markdown as rich content", async () => {
+    const markdown =
+      "| Task |\n| --- |\n| [TSK-42](bbtask://TSK-42) |";
+    const onChange = vi.fn();
+    const screen = render(<TasksEditor value="" onChange={onChange} />);
+
+    fireEvent.paste(getEditorSurface(screen.container), {
+      clipboardData: {
+        files: [],
+        getData: (type: string) => (type === "text/plain" ? markdown : ""),
+      },
+    });
+
+    await waitFor(() => expect(screen.getByRole("table")).toBeTruthy());
+    expect(
+      screen.container.querySelector('[data-task-mention="TSK-42"]'),
+    ).toBeTruthy();
+    expect(onChange.mock.lastCall?.[0]?.trimEnd()).toBe(markdown);
+  });
+
   it("routes pasted and dropped files to onAttachFiles instead of inline upload", () => {
     const onAttachFiles = vi.fn();
     const onUploadImage = vi.fn();

--- a/plugins/tasks/editor/editor.test.tsx
+++ b/plugins/tasks/editor/editor.test.tsx
@@ -88,6 +88,40 @@ describe("markdown round-trip", () => {
     expect(roundTrip(markdown).trimEnd()).toBe(markdown);
   });
 
+  it("preserves a pipe inside a table-cell link destination", () => {
+    const markdown =
+      "| Value |\n| --- |\n| [destination](https://example.com/a\\|b) |";
+
+    expect(roundTrip(markdown).trimEnd()).toBe(
+      "| Value |\n| --- |\n| [destination](https://example.com/a%7Cb) |",
+    );
+  });
+
+  it("preserves atom-only cells when another block is edited", async () => {
+    const value = [
+      "| Image | Task | Thread |",
+      "| --- | --- | --- |",
+      "| ![diagram](https://example.com/diagram.png) | [TSK-42](bbtask://TSK-42) | [Fix login](bbthread://thr_test) |",
+      "",
+      "Edit here",
+    ].join("\n");
+    const onChange = vi.fn();
+    let editor: Editor | null = null;
+    render(
+      <TasksEditor
+        value={value}
+        onChange={onChange}
+        onEditorReady={(ready) => (editor = ready)}
+      />,
+    );
+
+    editor!.chain().focus("end").insertContent(" elsewhere").run();
+
+    await waitFor(() =>
+      expect(onChange).toHaveBeenLastCalledWith(`${value} elsewhere`),
+    );
+  });
+
   it("renders table headers and cells", () => {
     const screen = render(
       <TasksEditor
@@ -97,7 +131,7 @@ describe("markdown round-trip", () => {
       />,
     );
 
-    expect(screen.getByRole("table")).toBeTruthy();
+    expect(screen.getByRole("table").closest(".tableWrapper")).toBeTruthy();
     expect(screen.getAllByRole("columnheader")).toHaveLength(2);
     expect(screen.getAllByRole("cell")).toHaveLength(2);
   });

--- a/plugins/tasks/editor/extensions.ts
+++ b/plugins/tasks/editor/extensions.ts
@@ -454,6 +454,7 @@ export function createEditorExtensions(options?: {
       tightLists: true,
       bulletListMarker: "-",
       linkify: true,
+      transformPastedText: true,
     }),
   ];
 }

--- a/plugins/tasks/editor/extensions.ts
+++ b/plugins/tasks/editor/extensions.ts
@@ -115,6 +115,7 @@ interface TableMarkdownState {
   write(value: string): void;
   ensureNewLine(): void;
   closeBlock(node: ProseMirrorNode): void;
+  render(node: ProseMirrorNode, parent: ProseMirrorNode, index: number): void;
   renderInline(node: ProseMirrorNode): void;
 }
 
@@ -154,9 +155,10 @@ function renderTableCell(
   cell: ProseMirrorNode,
 ): void {
   const content = cell.firstChild;
-  if (!content?.textContent.trim()) return;
+  if (!content) return;
   const start = state.out.length;
-  state.renderInline(content);
+  if (content.type.name === "image") state.render(content, cell, 0);
+  else if (content.childCount > 0) state.renderInline(content);
   state.out =
     state.out.slice(0, start) +
     state.out.slice(start).replaceAll("|", "\\|");
@@ -433,7 +435,7 @@ export function createEditorExtensions(options?: {
     Image.configure({ allowBase64: false }),
     TightTaskList,
     TaskItem.configure({ nested: true }),
-    MarkdownTable.configure({ resizable: true, lastColumnResizable: false }),
+    MarkdownTable.configure({ renderWrapper: true }),
     TableRow,
     TableHeader,
     TableCell,

--- a/plugins/tasks/editor/tasks-editor.tsx
+++ b/plugins/tasks/editor/tasks-editor.tsx
@@ -86,8 +86,6 @@ const EDITOR_CSS = `
 .bb-tasks-editor .tiptap :is(th, td) > p { margin-top: 0; }
 .bb-tasks-editor .tiptap :is(th, td) > p + p { margin-top: 0.5em; }
 .bb-tasks-editor .tiptap .selectedCell::after { position: absolute; inset: 0; z-index: 2; pointer-events: none; content: ""; background: color-mix(in oklab, var(--primary) 14%, transparent); }
-.bb-tasks-editor .tiptap .column-resize-handle { position: absolute; top: 0; right: -2px; bottom: -1px; width: 4px; z-index: 3; pointer-events: none; background: var(--primary); }
-.bb-tasks-editor .tiptap.resize-cursor { cursor: col-resize; }
 .bb-tasks-editor .tiptap ul[data-type="taskList"] { list-style: none; padding-left: 0.25em; }
 .bb-tasks-editor .tiptap ul[data-type="taskList"] ul[data-type="taskList"] { margin-top: 0; }
 .bb-tasks-editor .tiptap ul[data-type="taskList"] li { display: flex; align-items: flex-start; gap: 0.5em; margin-top: 0.3em; padding-left: 0; }


### PR DESCRIPTION
## Human comments

## What was wrong

Tasks table-cell Markdown serialization treated atom-only content as empty, so image, task-mention, and thread-mention cells could be erased when an edit elsewhere serialized the document. The table overflow wrapper also depended on editability, and pasted plain-text Markdown stayed literal instead of becoming semantic editor content.

## What changed

Distinguish genuinely empty paragraphs from atom-only table-cell content and route images and mentions through their Markdown serializers. Keep the table overflow wrapper in read-only views, remove the non-persistent resize affordance, and enable the shared Tasks Markdown extension's plain-text paste transformation. Add regression coverage through the real editor `onChange` and clipboard paths. This is intentionally Tasks-only; it does not claim to fix the separate pre-existing Docs Markdown defect. There are no server/daemon wire, database, SDK API, CLI, configuration, or mobile contract changes.

## How you verified

- Red evidence: atom-cell serialization and read-only wrapper tests failed before the production fix; the clipboard-path test failed before paste transformation was enabled
- `pnpm exec turbo run test typecheck build --filter=bb-plugin-tasks --force`
  - 35 test files, 364/364 tests passed
  - Tasks typecheck passed
  - official Tasks server and app bundles built
  - 9/9 Turbo tasks passed
- `git diff --check origin/main...HEAD`

> AGENT GENERATED
