### PR TITLE
Fix Codex rollout writer handoff races

### DIFF
--- a/plugins/provider-codex/src/bridge/app-server-connection.ts
+++ b/plugins/provider-codex/src/bridge/app-server-connection.ts
@@ -44,7 +44,6 @@ interface CodexAppServerRequestArgs<TResult> {
 export interface CodexAppServerConnection {
   request<TResult>(args: CodexAppServerRequestArgs<TResult>): Promise<TResult>;
   notify(method: string, params?: unknown): void;
-  /** Signal the child and resolve once its exit has been finalized. */
   kill(): Promise<void>;
   readonly exited: boolean;
 }

--- a/plugins/provider-codex/src/bridge/app-server-connection.ts
+++ b/plugins/provider-codex/src/bridge/app-server-connection.ts
@@ -44,7 +44,8 @@ interface CodexAppServerRequestArgs<TResult> {
 export interface CodexAppServerConnection {
   request<TResult>(args: CodexAppServerRequestArgs<TResult>): Promise<TResult>;
   notify(method: string, params?: unknown): void;
-  kill(): void;
+  /** Signal the child and resolve once its exit has been finalized. */
+  kill(): Promise<void>;
   readonly exited: boolean;
 }
 
@@ -112,6 +113,10 @@ export function createCodexAppServerConnection(
   } | null = null;
   let closeGraceTimer: NodeJS.Timeout | null = null;
   let stdoutLines: Interface | null = null;
+  let resolveExit!: () => void;
+  const exitPromise = new Promise<void>((resolve) => {
+    resolveExit = resolve;
+  });
 
   function writeLine(message: object): void {
     const stdin = child.stdin;
@@ -155,7 +160,11 @@ export function createCodexAppServerConnection(
         { spawnFailed },
       ),
     );
-    options.onExit({ ...status, stderrTail, spawnFailed });
+    try {
+      options.onExit({ ...status, stderrTail, spawnFailed });
+    } finally {
+      resolveExit();
+    }
   }
 
   if (child.stdout) {
@@ -313,7 +322,7 @@ export function createCodexAppServerConnection(
 
     kill() {
       if (finalized) {
-        return;
+        return exitPromise;
       }
       const escalation = setTimeout(() => {
         if (!finalized) {
@@ -322,6 +331,7 @@ export function createCodexAppServerConnection(
       }, KILL_ESCALATION_MS);
       escalation.unref?.();
       child.kill("SIGTERM");
+      return exitPromise;
     },
   };
 }

--- a/plugins/provider-codex/src/bridge/bridge-process.test-support.ts
+++ b/plugins/provider-codex/src/bridge/bridge-process.test-support.ts
@@ -1,0 +1,130 @@
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import type { experimental_createBridgeJsonRpcTestHarness as createBridgeJsonRpcTestHarness } from "@get-bb/plugin-sdk/provider-bridge/testing";
+
+type BridgeJsonRpcTestHarness = ReturnType<
+  typeof createBridgeJsonRpcTestHarness
+>;
+
+const PROCESS_POLL_INTERVAL_MS = 20;
+
+function readProcessLog(processLogPath: string): string {
+  if (!existsSync(processLogPath)) {
+    return "";
+  }
+  try {
+    return readFileSync(processLogPath, "utf8");
+  } catch (error) {
+    if (error instanceof Error && Reflect.get(error, "code") === "ENOENT") {
+      return "";
+    }
+    throw error;
+  }
+}
+
+export function spawnedAppServerPids(processLogPath: string): number[] {
+  return readProcessLog(processLogPath)
+    .split("\n")
+    .filter((line) => line.startsWith("spawn:"))
+    .map((line) => Number(line.split(":")[1]))
+    .filter((pid) => Number.isSafeInteger(pid) && pid > 0);
+}
+
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (error instanceof Error && Reflect.get(error, "code") === "ESRCH") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+export async function waitForAppServerChildrenToExit(
+  processLogPath: string,
+  timeoutMs = 8_000,
+): Promise<void> {
+  const childPids = spawnedAppServerPids(processLogPath);
+  const deadline = Date.now() + timeoutMs;
+  while (childPids.some(processIsAlive)) {
+    if (Date.now() > deadline) {
+      throw new Error(
+        `Timed out waiting for app-server children to exit: ${JSON.stringify(childPids.filter(processIsAlive))}`,
+      );
+    }
+    await new Promise((resolveTick) =>
+      setTimeout(resolveTick, PROCESS_POLL_INTERVAL_MS),
+    );
+  }
+}
+
+export async function waitForAppServerProcessStep(
+  processLogPath: string,
+  step: string,
+  timeoutMs = 5_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (readProcessLog(processLogPath).includes(`${step}:`)) {
+      return;
+    }
+    await new Promise((resolveTick) =>
+      setTimeout(resolveTick, PROCESS_POLL_INTERVAL_MS),
+    );
+  }
+  throw new Error(`Timed out waiting for app-server process step: ${step}`);
+}
+
+export async function cleanupBridgeProcessTest(args: {
+  harness: BridgeJsonRpcTestHarness | undefined;
+  cleanupId: number;
+  threadId: string;
+  providerThreadId: string;
+  processLogPath: string;
+  workspaceDir: string;
+  unstubEnvs: () => void;
+}): Promise<void> {
+  const errors: unknown[] = [];
+  if (args.harness !== undefined) {
+    try {
+      args.harness.sendRequest(args.cleanupId, "thread/stop", {
+        threadId: args.threadId,
+        providerThreadId: args.providerThreadId,
+        intent: "release",
+        activeTurnId: null,
+      });
+      await args.harness.waitForResponse(args.cleanupId).catch(() => undefined);
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  try {
+    await waitForAppServerChildrenToExit(args.processLogPath);
+  } catch (error) {
+    errors.push(error);
+  }
+  try {
+    args.harness?.restore();
+  } catch (error) {
+    errors.push(error);
+  }
+  try {
+    args.unstubEnvs();
+  } catch (error) {
+    errors.push(error);
+  }
+  try {
+    if (args.workspaceDir !== "") {
+      rmSync(args.workspaceDir, { recursive: true, force: true });
+    }
+  } catch (error) {
+    errors.push(error);
+  }
+  if (errors.length === 1) {
+    throw errors[0];
+  }
+  if (errors.length > 1) {
+    throw new AggregateError(errors, "Bridge process test cleanup failed");
+  }
+}

--- a/plugins/provider-codex/src/bridge/bridge.archived-rebuild.test.ts
+++ b/plugins/provider-codex/src/bridge/bridge.archived-rebuild.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -6,6 +6,10 @@ import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { experimental_createBridgeJsonRpcTestHarness as createBridgeJsonRpcTestHarness } from "@get-bb/plugin-sdk/provider-bridge/testing";
 import type { BridgeJsonRpcOutputMessage } from "@get-bb/plugin-sdk/provider-bridge/testing";
 import { handleLine } from "./bridge.js";
+import {
+  cleanupBridgeProcessTest,
+  spawnedAppServerPids,
+} from "./bridge-process.test-support.js";
 
 const THREAD_ID = "thr_archived_rebuild_1";
 const PROVIDER_THREAD_ID = "rebuild-rollout-1";
@@ -31,9 +35,9 @@ const changedSessionOptions = {
 const turnInput = [{ type: "text", text: "hello", mentions: [] }];
 
 let harness: ReturnType<typeof createBridgeJsonRpcTestHarness>;
-let workspaceDir: string;
-let archiveStatePath: string;
-let processLogPath: string;
+let workspaceDir = "";
+let archiveStatePath = "";
+let processLogPath = "";
 
 beforeEach(() => {
   workspaceDir = mkdtempSync(join(tmpdir(), "bb-codex-archived-rebuild-"));
@@ -53,51 +57,16 @@ beforeEach(() => {
 });
 
 afterEach(async () => {
-  const cleanupId = 993_001;
-  harness.sendRequest(cleanupId, "thread/stop", {
+  await cleanupBridgeProcessTest({
+    harness,
+    cleanupId: 993_001,
     threadId: THREAD_ID,
     providerThreadId: PROVIDER_THREAD_ID,
-    intent: "release",
-    activeTurnId: null,
+    processLogPath,
+    workspaceDir,
+    unstubEnvs: vi.unstubAllEnvs,
   });
-  await harness.waitForResponse(cleanupId).catch(() => undefined);
-  await waitForAppServerChildrenToExit();
-  harness.restore();
-  vi.unstubAllEnvs();
-  rmSync(workspaceDir, { recursive: true, force: true });
 });
-
-function spawnedAppServerPids(): number[] {
-  return readFileSync(processLogPath, "utf8")
-    .split("\n")
-    .filter((line) => line.startsWith("spawn:"))
-    .map((line) => Number(line.split(":")[1]));
-}
-
-function processIsAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (error) {
-    if (error instanceof Error && Reflect.get(error, "code") === "ESRCH") {
-      return false;
-    }
-    throw error;
-  }
-}
-
-async function waitForAppServerChildrenToExit(): Promise<void> {
-  const childPids = spawnedAppServerPids();
-  const deadline = Date.now() + 15_000;
-  while (childPids.some(processIsAlive)) {
-    if (Date.now() > deadline) {
-      throw new Error(
-        `Timed out waiting for app-server children to exit: ${JSON.stringify(childPids.filter(processIsAlive))}`,
-      );
-    }
-    await new Promise((resolveTick) => setTimeout(resolveTick, 20));
-  }
-}
 
 async function resumeThread(): Promise<void> {
   harness.sendRequest(1, "thread/resume", {
@@ -197,11 +166,11 @@ it("keeps the thread resumable when a settings-change rebuild hits an externally
 
 it("keeps the thread resumable when the rebuild after the child died hits an externally archived rollout", async () => {
   await resumeThread();
-  const spawnLine = readFileSync(processLogPath, "utf8")
-    .split("\n")
-    .find((line) => line.startsWith("spawn:"));
-  const childPid = Number(spawnLine?.split(":")[1]);
-  expect(Number.isInteger(childPid)).toBe(true);
+  const [childPid] = spawnedAppServerPids(processLogPath);
+  expect(childPid).toBeDefined();
+  if (childPid === undefined) {
+    throw new Error("Expected the fake app-server child to have spawned");
+  }
   process.kill(childPid, "SIGKILL");
   const deadline = Date.now() + 15_000;
   while (

--- a/plugins/provider-codex/src/bridge/bridge.ts
+++ b/plugins/provider-codex/src/bridge/bridge.ts
@@ -276,6 +276,9 @@ const CHILD_REQUEST_TIMEOUT_MS = 60_000;
 const INTERRUPT_SETTLEMENT_TIMEOUT_MS = 5_000;
 const CODEX_ARCHIVED_SESSION_ERROR_PATTERN =
   /\b(?:session|thread)\s+\S+\s+is archived\b/i;
+const CODEX_ACTIVE_WRITER_ERROR_PATTERN =
+  /\bthread\s+\S+\s+already has an active writer\b/i;
+const CODEX_ACTIVE_WRITER_RETRY_DELAYS_MS = [100, 400, 1_000] as const;
 const CODEX_ALREADY_ARCHIVED_ERROR_PATTERN =
   /\bno rollout found for thread id\b/i;
 const CODEX_NOT_ARCHIVED_ERROR_PATTERN =
@@ -316,6 +319,12 @@ function archivedSessionHint(message: string): ProviderRecoveryHint | null {
   return CODEX_ARCHIVED_SESSION_ERROR_PATTERN.test(message)
     ? { kind: "sessionArchived", message, retryable: true }
     : null;
+}
+
+function withActiveWriterGuidance(message: string): string {
+  return CODEX_ACTIVE_WRITER_ERROR_PATTERN.test(message)
+    ? `${message}. Close the other Codex session and retry.`
+    : message;
 }
 
 async function delay(ms: number): Promise<void> {
@@ -399,13 +408,14 @@ function currentSession(
   return session;
 }
 
-function releaseSession(session: CodexBridgeSession): void {
+function releaseSession(session: CodexBridgeSession): Promise<void> {
   session.closing = true;
   if (sessionsByBbThreadId.get(session.bbThreadId) === session) {
     sessionsByBbThreadId.delete(session.bbThreadId);
   }
-  session.connection?.kill();
+  const exitPromise = session.connection?.kill() ?? Promise.resolve();
   session.connection = null;
+  return exitPromise;
 }
 
 const codexProviderOptionsSchema = z
@@ -816,6 +826,34 @@ const codexThreadIdentityResultSchema = z
   .object({ thread: z.object({ id: z.string().min(1) }).passthrough() })
   .passthrough();
 
+async function requestThreadConstructionWithWriterRetry(
+  connection: CodexAppServerConnection,
+  method: string,
+  params: BbThreadStartParams | ThreadResumeParams | BbThreadForkParams,
+): Promise<z.infer<typeof codexThreadIdentityResultSchema>> {
+  const sendOnce = (): Promise<
+    z.infer<typeof codexThreadIdentityResultSchema>
+  > =>
+    connection.request({
+      method,
+      params,
+      resultSchema: codexThreadIdentityResultSchema,
+      timeoutMs: CHILD_REQUEST_TIMEOUT_MS,
+    });
+  for (const retryDelayMs of CODEX_ACTIVE_WRITER_RETRY_DELAYS_MS) {
+    try {
+      return await sendOnce();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (!CODEX_ACTIVE_WRITER_ERROR_PATTERN.test(message)) {
+        throw error;
+      }
+      await delay(retryDelayMs);
+    }
+  }
+  return await sendOnce();
+}
+
 type CodexSessionConstructionRequest =
   | { kind: "start" }
   | { kind: "resume"; providerThreadId: string }
@@ -844,7 +882,10 @@ async function constructThreadSession(
 ): Promise<ConstructedCodexSession> {
   const existing = sessionsByBbThreadId.get(args.threadId);
   if (existing) {
-    releaseSession(existing);
+    // Codex holds a rollout's writer lock for the app-server process lifetime.
+    // Do not let the replacement resume that rollout until the old child has
+    // fully exited and released its ownership.
+    await releaseSession(existing);
   }
 
   const decoded = decodeCodexOptions(args.options);
@@ -968,12 +1009,11 @@ async function constructThreadSession(
       }
     }
 
-    const result = await connection.request({
+    const result = await requestThreadConstructionWithWriterRetry(
+      connection,
       method,
       params,
-      resultSchema: codexThreadIdentityResultSchema,
-      timeoutMs: CHILD_REQUEST_TIMEOUT_MS,
-    });
+    );
     const codexThreadId = result.thread.id;
     session.codexThreadId = codexThreadId;
     translator.activateThreadGitWritableRoots({
@@ -1212,8 +1252,9 @@ function sendConstructionError(
   error: unknown,
   resumable: boolean,
 ): void {
-  const message = describeCodexLaunchError(error);
-  const recovery = archivedSessionHint(message);
+  const providerMessage = describeCodexLaunchError(error);
+  const recovery = archivedSessionHint(providerMessage);
+  const message = withActiveWriterGuidance(providerMessage);
   sendError(
     id,
     resumable && recovery !== null
@@ -1453,7 +1494,7 @@ async function handleThreadStop(
 
   if (params.intent === "release") {
     if (session) {
-      releaseSession(session);
+      await releaseSession(session);
     }
     sendResult(id, { ok: true });
     return;
@@ -1509,7 +1550,7 @@ async function handleThreadStop(
       providerThreadId: session.codexThreadId,
     }),
   );
-  releaseSession(session);
+  await releaseSession(session);
   sendResult(id, { ok: true });
 }
 
@@ -1557,11 +1598,11 @@ async function handleThreadMaintenance(
     alreadyInRequestedState?: RegExp;
   },
 ): Promise<void> {
-  const settle = (): void => {
+  const settle = async (): Promise<void> => {
     if (options?.releaseAfter) {
       const session = sessionsByBbThreadId.get(params.threadId);
       if (session) {
-        releaseSession(session);
+        await releaseSession(session);
       }
     }
     sendResult(id, { ok: true });
@@ -1570,13 +1611,13 @@ async function handleThreadMaintenance(
     await withChildForThread(params.threadId, (connection) =>
       sendMaintenanceRequestWithRetries(connection, request),
     );
-    settle();
+    await settle();
   } catch (error) {
     if (
       error instanceof Error &&
       options?.alreadyInRequestedState?.test(error.message) === true
     ) {
-      settle();
+      await settle();
       return;
     }
     rejectWithCodexError(id, error);
@@ -1584,8 +1625,9 @@ async function handleThreadMaintenance(
 }
 
 function rejectWithCodexError(id: string | number, error: unknown): void {
-  const message = describeCodexLaunchError(error);
-  const recovery = archivedSessionHint(message);
+  const providerMessage = describeCodexLaunchError(error);
+  const recovery = archivedSessionHint(providerMessage);
+  const message = withActiveWriterGuidance(providerMessage);
   if (recovery !== null) {
     sendError(id, BRIDGE_JSON_RPC_ERRORS.BRIDGE_ERROR, message, { recovery });
     return;

--- a/plugins/provider-codex/src/bridge/bridge.ts
+++ b/plugins/provider-codex/src/bridge/bridge.ts
@@ -323,7 +323,7 @@ function archivedSessionHint(message: string): ProviderRecoveryHint | null {
 
 function withActiveWriterGuidance(message: string): string {
   return CODEX_ACTIVE_WRITER_ERROR_PATTERN.test(message)
-    ? `${message}. Close the other Codex session and retry.`
+    ? `${message}. Another Codex process still owns this thread. Close any other Codex session using it; if none is open, wait for a previous Codex process to finish shutting down or stop the leftover codex app-server process, then retry.`
     : message;
 }
 
@@ -840,7 +840,10 @@ async function requestThreadConstructionWithWriterRetry(
       resultSchema: codexThreadIdentityResultSchema,
       timeoutMs: CHILD_REQUEST_TIMEOUT_MS,
     });
-  for (const retryDelayMs of CODEX_ACTIVE_WRITER_RETRY_DELAYS_MS) {
+  for (const [
+    retryIndex,
+    retryDelayMs,
+  ] of CODEX_ACTIVE_WRITER_RETRY_DELAYS_MS.entries()) {
     try {
       return await sendOnce();
     } catch (error) {
@@ -848,6 +851,9 @@ async function requestThreadConstructionWithWriterRetry(
       if (!CODEX_ACTIVE_WRITER_ERROR_PATTERN.test(message)) {
         throw error;
       }
+      process.stderr.write(
+        `codex ${method} found an active rollout writer; retrying in ${retryDelayMs}ms (${retryIndex + 1}/${CODEX_ACTIVE_WRITER_RETRY_DELAYS_MS.length}).\n`,
+      );
       await delay(retryDelayMs);
     }
   }
@@ -881,13 +887,6 @@ async function constructThreadSession(
   args: ConstructThreadSessionArgs,
 ): Promise<ConstructedCodexSession> {
   const existing = sessionsByBbThreadId.get(args.threadId);
-  if (existing) {
-    // Codex holds a rollout's writer lock for the app-server process lifetime.
-    // Do not let the replacement resume that rollout until the old child has
-    // fully exited and released its ownership.
-    await releaseSession(existing);
-  }
-
   const decoded = decodeCodexOptions(args.options);
   sessionSerialCounter += 1;
   const serial = sessionSerialCounter;
@@ -927,6 +926,16 @@ async function constructThreadSession(
     closing: false,
   };
   sessionsByBbThreadId.set(args.threadId, session);
+  if (existing) {
+    await releaseSession(existing);
+    if (session.closing) {
+      throw new CodexSessionReleasedError(
+        new Error(
+          "codex session was released while waiting for the previous app-server to exit",
+        ),
+      );
+    }
+  }
   if (args.request.kind === "resume") {
     announceSessionIdentity(session, args.request.providerThreadId);
   }

--- a/plugins/provider-codex/src/bridge/bridge.ts
+++ b/plugins/provider-codex/src/bridge/bridge.ts
@@ -381,6 +381,7 @@ interface CodexBridgeSession {
   pendingPreIdentityDeltas: ThreadDelta[];
   rebuildBeforeNextTurnReason: string | null;
   closing: boolean;
+  previousChildExit: Promise<void> | null;
 }
 
 const sessionsByBbThreadId = new Map<string, CodexBridgeSession>();
@@ -413,9 +414,13 @@ function releaseSession(session: CodexBridgeSession): Promise<void> {
   if (sessionsByBbThreadId.get(session.bbThreadId) === session) {
     sessionsByBbThreadId.delete(session.bbThreadId);
   }
-  const exitPromise = session.connection?.kill() ?? Promise.resolve();
+  const previousChildExit = session.previousChildExit;
+  session.previousChildExit = null;
+  const currentChildExit = session.connection?.kill() ?? Promise.resolve();
   session.connection = null;
-  return exitPromise;
+  return previousChildExit === null
+    ? currentChildExit
+    : Promise.all([previousChildExit, currentChildExit]).then(() => undefined);
 }
 
 const codexProviderOptionsSchema = z
@@ -924,10 +929,16 @@ async function constructThreadSession(
     pendingPreIdentityDeltas: [],
     rebuildBeforeNextTurnReason: null,
     closing: false,
+    previousChildExit: null,
   };
   sessionsByBbThreadId.set(args.threadId, session);
   if (existing) {
-    await releaseSession(existing);
+    const previousChildExit = releaseSession(existing);
+    session.previousChildExit = previousChildExit;
+    await previousChildExit;
+    if (session.previousChildExit === previousChildExit) {
+      session.previousChildExit = null;
+    }
     if (session.closing) {
       throw new CodexSessionReleasedError(
         new Error(
@@ -1072,6 +1083,7 @@ function registerResumableSession(session: CodexBridgeSession): void {
     pendingPreIdentityDeltas: [],
     rebuildBeforeNextTurnReason: null,
     closing: false,
+    previousChildExit: null,
   });
 }
 

--- a/plugins/provider-codex/src/bridge/bridge.writer-lock.test.ts
+++ b/plugins/provider-codex/src/bridge/bridge.writer-lock.test.ts
@@ -1,0 +1,186 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { experimental_createBridgeJsonRpcTestHarness as createBridgeJsonRpcTestHarness } from "@get-bb/plugin-sdk/provider-bridge/testing";
+import { handleLine } from "./bridge.js";
+
+const THREAD_ID = "thr_writer_lock_1";
+const PROVIDER_THREAD_ID = "codex-writer-lock-1";
+
+const fakeAppServerPath = fileURLToPath(
+  new URL("./fake-codex-app-server.mjs", import.meta.url),
+);
+
+const sessionOptions = {
+  permissionMode: "full",
+  permissionScope: "full",
+  approvalReviewer: null,
+  permissionEscalation: null,
+  reasoningLevel: "low",
+} as const;
+
+const changedSessionOptions = {
+  ...sessionOptions,
+  reasoningLevel: "high",
+} as const;
+
+let harness: ReturnType<typeof createBridgeJsonRpcTestHarness>;
+let workspaceDir: string;
+let processLogPath: string;
+let writerLockPath: string;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "bb-codex-writer-lock-"));
+  processLogPath = join(workspaceDir, "app-server-processes.log");
+  writerLockPath = join(workspaceDir, "writer.lock");
+  const scriptPath = join(workspaceDir, "fake-codex-script.json");
+  writeFileSync(
+    scriptPath,
+    JSON.stringify({
+      processLogPath,
+      writerLockPath,
+      sigtermDelayMs: 500,
+    }),
+  );
+  vi.stubEnv("BB_CODEX_BRIDGE_APP_SERVER_COMMAND", process.execPath);
+  vi.stubEnv(
+    "BB_CODEX_BRIDGE_APP_SERVER_ARGS",
+    JSON.stringify([fakeAppServerPath, scriptPath]),
+  );
+  harness = createBridgeJsonRpcTestHarness(handleLine);
+});
+
+afterEach(async () => {
+  const cleanupId = 995_001;
+  harness.sendRequest(cleanupId, "thread/stop", {
+    threadId: THREAD_ID,
+    providerThreadId: PROVIDER_THREAD_ID,
+    intent: "release",
+    activeTurnId: null,
+  });
+  await harness.waitForResponse(cleanupId).catch(() => undefined);
+  await waitForAppServerChildrenToExit();
+  harness.restore();
+  vi.unstubAllEnvs();
+  rmSync(workspaceDir, { recursive: true, force: true });
+});
+
+function spawnedAppServerPids(): number[] {
+  return readFileSync(processLogPath, "utf8")
+    .split("\n")
+    .filter((line) => line.startsWith("spawn:"))
+    .map((line) => Number(line.split(":")[1]));
+}
+
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (error instanceof Error && Reflect.get(error, "code") === "ESRCH") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function waitForAppServerChildrenToExit(): Promise<void> {
+  const childPids = spawnedAppServerPids();
+  const deadline = Date.now() + 15_000;
+  while (childPids.some(processIsAlive)) {
+    if (Date.now() > deadline) {
+      throw new Error(
+        `Timed out waiting for app-server children to exit: ${JSON.stringify(childPids.filter(processIsAlive))}`,
+      );
+    }
+    await new Promise((resolveTick) => setTimeout(resolveTick, 20));
+  }
+}
+
+async function resumeThread(id: number): Promise<void> {
+  harness.sendRequest(id, "thread/resume", {
+    threadId: THREAD_ID,
+    providerThreadId: PROVIDER_THREAD_ID,
+    cwd: workspaceDir,
+    instructionMode: "append",
+    options: sessionOptions,
+  });
+  expect((await harness.waitForResponse(id)).error).toBeUndefined();
+}
+
+it("waits for the previous writer before resuming during a settings rebuild", async () => {
+  await resumeThread(1);
+
+  harness.sendRequest(2, "turn/start", {
+    threadId: THREAD_ID,
+    providerThreadId: PROVIDER_THREAD_ID,
+    clientRequestId: "creq_abcdefghjk",
+    input: [{ type: "text", text: "hello", mentions: [] }],
+    options: changedSessionOptions,
+  });
+  const rebuiltTurn = await harness.waitForResponse(2);
+
+  expect(rebuiltTurn.error).toBeUndefined();
+  expect(rebuiltTurn.result).toEqual({ threadId: THREAD_ID });
+}, 30_000);
+
+it("finishes releasing the writer before acknowledging thread stop", async () => {
+  await resumeThread(1);
+
+  harness.sendRequest(2, "thread/stop", {
+    threadId: THREAD_ID,
+    providerThreadId: PROVIDER_THREAD_ID,
+    intent: "release",
+    activeTurnId: null,
+  });
+  expect((await harness.waitForResponse(2)).error).toBeUndefined();
+
+  await resumeThread(3);
+}, 30_000);
+
+it("retries a resume while another Codex process is releasing the writer", async () => {
+  writeFileSync(writerLockPath, String(process.pid));
+  const foreignWriterReleased = new Promise<void>((resolve) => {
+    setTimeout(() => {
+      rmSync(writerLockPath, { force: true });
+      resolve();
+    }, 150);
+  });
+
+  harness.sendRequest(1, "thread/resume", {
+    threadId: THREAD_ID,
+    providerThreadId: PROVIDER_THREAD_ID,
+    cwd: workspaceDir,
+    instructionMode: "append",
+    options: sessionOptions,
+  });
+  const resumed = await harness.waitForResponse(1);
+  await foreignWriterReleased;
+
+  expect(resumed.error).toBeUndefined();
+  expect(resumed.result).toEqual({
+    providerThreadId: PROVIDER_THREAD_ID,
+    sessionRestorable: true,
+  });
+}, 30_000);
+
+it("explains persistent writer contention and resumes after the owner closes", async () => {
+  writeFileSync(writerLockPath, String(process.pid));
+
+  harness.sendRequest(1, "thread/resume", {
+    threadId: THREAD_ID,
+    providerThreadId: PROVIDER_THREAD_ID,
+    cwd: workspaceDir,
+    instructionMode: "append",
+    options: sessionOptions,
+  });
+  const blocked = await harness.waitForResponse(1);
+  rmSync(writerLockPath, { force: true });
+
+  expect(blocked.error?.message).toContain(
+    "Close the other Codex session and retry",
+  );
+  await resumeThread(2);
+}, 30_000);

--- a/plugins/provider-codex/src/bridge/bridge.writer-lock.test.ts
+++ b/plugins/provider-codex/src/bridge/bridge.writer-lock.test.ts
@@ -1,10 +1,15 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { experimental_createBridgeJsonRpcTestHarness as createBridgeJsonRpcTestHarness } from "@get-bb/plugin-sdk/provider-bridge/testing";
 import { handleLine } from "./bridge.js";
+import {
+  cleanupBridgeProcessTest,
+  spawnedAppServerPids,
+  waitForAppServerProcessStep,
+} from "./bridge-process.test-support.js";
 
 const THREAD_ID = "thr_writer_lock_1";
 const PROVIDER_THREAD_ID = "codex-writer-lock-1";
@@ -27,9 +32,9 @@ const changedSessionOptions = {
 } as const;
 
 let harness: ReturnType<typeof createBridgeJsonRpcTestHarness>;
-let workspaceDir: string;
-let processLogPath: string;
-let writerLockPath: string;
+let workspaceDir = "";
+let processLogPath = "";
+let writerLockPath = "";
 
 beforeEach(() => {
   workspaceDir = mkdtempSync(join(tmpdir(), "bb-codex-writer-lock-"));
@@ -53,51 +58,16 @@ beforeEach(() => {
 });
 
 afterEach(async () => {
-  const cleanupId = 995_001;
-  harness.sendRequest(cleanupId, "thread/stop", {
+  await cleanupBridgeProcessTest({
+    harness,
+    cleanupId: 995_001,
     threadId: THREAD_ID,
     providerThreadId: PROVIDER_THREAD_ID,
-    intent: "release",
-    activeTurnId: null,
+    processLogPath,
+    workspaceDir,
+    unstubEnvs: vi.unstubAllEnvs,
   });
-  await harness.waitForResponse(cleanupId).catch(() => undefined);
-  await waitForAppServerChildrenToExit();
-  harness.restore();
-  vi.unstubAllEnvs();
-  rmSync(workspaceDir, { recursive: true, force: true });
 });
-
-function spawnedAppServerPids(): number[] {
-  return readFileSync(processLogPath, "utf8")
-    .split("\n")
-    .filter((line) => line.startsWith("spawn:"))
-    .map((line) => Number(line.split(":")[1]));
-}
-
-function processIsAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (error) {
-    if (error instanceof Error && Reflect.get(error, "code") === "ESRCH") {
-      return false;
-    }
-    throw error;
-  }
-}
-
-async function waitForAppServerChildrenToExit(): Promise<void> {
-  const childPids = spawnedAppServerPids();
-  const deadline = Date.now() + 15_000;
-  while (childPids.some(processIsAlive)) {
-    if (Date.now() > deadline) {
-      throw new Error(
-        `Timed out waiting for app-server children to exit: ${JSON.stringify(childPids.filter(processIsAlive))}`,
-      );
-    }
-    await new Promise((resolveTick) => setTimeout(resolveTick, 20));
-  }
-}
 
 async function resumeThread(id: number): Promise<void> {
   harness.sendRequest(id, "thread/resume", {
@@ -136,34 +106,95 @@ it("finishes releasing the writer before acknowledging thread stop", async () =>
     activeTurnId: null,
   });
   expect((await harness.waitForResponse(2)).error).toBeUndefined();
+  expect(existsSync(writerLockPath)).toBe(false);
 
   await resumeThread(3);
 }, 30_000);
 
-it("retries a resume while another Codex process is releasing the writer", async () => {
-  writeFileSync(writerLockPath, String(process.pid));
-  const foreignWriterReleased = new Promise<void>((resolve) => {
-    setTimeout(() => {
-      rmSync(writerLockPath, { force: true });
-      resolve();
-    }, 150);
-  });
+it("does not install a replacement after a concurrent release is acknowledged", async () => {
+  await resumeThread(1);
 
-  harness.sendRequest(1, "thread/resume", {
+  harness.sendRequest(2, "turn/start", {
     threadId: THREAD_ID,
     providerThreadId: PROVIDER_THREAD_ID,
-    cwd: workspaceDir,
-    instructionMode: "append",
-    options: sessionOptions,
+    clientRequestId: "creq_abcdefghjk",
+    input: [{ type: "text", text: "hello", mentions: [] }],
+    options: changedSessionOptions,
   });
-  const resumed = await harness.waitForResponse(1);
-  await foreignWriterReleased;
+  await waitForAppServerProcessStep(processLogPath, "sigterm");
 
-  expect(resumed.error).toBeUndefined();
-  expect(resumed.result).toEqual({
+  harness.sendRequest(3, "thread/stop", {
+    threadId: THREAD_ID,
     providerThreadId: PROVIDER_THREAD_ID,
-    sessionRestorable: true,
+    intent: "release",
+    activeTurnId: null,
   });
+  expect((await harness.waitForResponse(3)).error).toBeUndefined();
+
+  const rebuiltTurn = await harness.waitForResponse(2);
+  expect(rebuiltTurn.error).toBeDefined();
+  expect(
+    harness.messages.filter((message) => message.method === "session/replaced"),
+  ).toHaveLength(0);
+  expect(spawnedAppServerPids(processLogPath)).toHaveLength(1);
+}, 30_000);
+
+it("does not install a replacement after concurrent discard maintenance settles", async () => {
+  await resumeThread(1);
+
+  harness.sendRequest(2, "turn/start", {
+    threadId: THREAD_ID,
+    providerThreadId: PROVIDER_THREAD_ID,
+    clientRequestId: "creq_abcdefghjk",
+    input: [{ type: "text", text: "hello", mentions: [] }],
+    options: changedSessionOptions,
+  });
+  await waitForAppServerProcessStep(processLogPath, "sigterm");
+
+  harness.sendRequest(3, "thread/discard", {
+    threadId: THREAD_ID,
+    providerThreadId: PROVIDER_THREAD_ID,
+  });
+  expect((await harness.waitForResponse(3)).result).toEqual({ ok: true });
+
+  const rebuiltTurn = await harness.waitForResponse(2);
+  expect(rebuiltTurn.error).toBeDefined();
+  expect(
+    harness.messages.filter((message) => message.method === "session/replaced"),
+  ).toHaveLength(0);
+  expect(spawnedAppServerPids(processLogPath)).toHaveLength(2);
+}, 30_000);
+
+it("retries a resume while another Codex process is releasing the writer", async () => {
+  writeFileSync(writerLockPath, String(process.pid));
+  const stderrWrite = vi
+    .spyOn(process.stderr, "write")
+    .mockImplementation(() => true);
+
+  try {
+    harness.sendRequest(1, "thread/resume", {
+      threadId: THREAD_ID,
+      providerThreadId: PROVIDER_THREAD_ID,
+      cwd: workspaceDir,
+      instructionMode: "append",
+      options: sessionOptions,
+    });
+    await waitForAppServerProcessStep(processLogPath, "writer-conflict");
+    rmSync(writerLockPath, { force: true });
+    const resumed = await harness.waitForResponse(1);
+
+    expect(resumed.error).toBeUndefined();
+    expect(resumed.result).toEqual({
+      providerThreadId: PROVIDER_THREAD_ID,
+      sessionRestorable: true,
+    });
+    expect(stderrWrite).toHaveBeenCalledWith(
+      "codex thread/resume found an active rollout writer; retrying in 100ms (1/3).\n",
+    );
+  } finally {
+    stderrWrite.mockRestore();
+    rmSync(writerLockPath, { force: true });
+  }
 }, 30_000);
 
 it("explains persistent writer contention and resumes after the owner closes", async () => {
@@ -179,8 +210,8 @@ it("explains persistent writer contention and resumes after the owner closes", a
   const blocked = await harness.waitForResponse(1);
   rmSync(writerLockPath, { force: true });
 
-  expect(blocked.error?.message).toContain(
-    "Close the other Codex session and retry",
+  expect(blocked.error?.message).toBe(
+    `thread ${PROVIDER_THREAD_ID} already has an active writer. Another Codex process still owns this thread. Close any other Codex session using it; if none is open, wait for a previous Codex process to finish shutting down or stop the leftover codex app-server process, then retry.`,
   );
   await resumeThread(2);
 }, 30_000);

--- a/plugins/provider-codex/src/bridge/bridge.writer-lock.test.ts
+++ b/plugins/provider-codex/src/bridge/bridge.writer-lock.test.ts
@@ -130,6 +130,7 @@ it("does not install a replacement after a concurrent release is acknowledged", 
     activeTurnId: null,
   });
   expect((await harness.waitForResponse(3)).error).toBeUndefined();
+  expect(existsSync(writerLockPath)).toBe(false);
 
   const rebuiltTurn = await harness.waitForResponse(2);
   expect(rebuiltTurn.error).toBeDefined();
@@ -156,6 +157,7 @@ it("does not install a replacement after concurrent discard maintenance settles"
     providerThreadId: PROVIDER_THREAD_ID,
   });
   expect((await harness.waitForResponse(3)).result).toEqual({ ok: true });
+  expect(existsSync(writerLockPath)).toBe(false);
 
   const rebuiltTurn = await harness.waitForResponse(2);
   expect(rebuiltTurn.error).toBeDefined();

--- a/plugins/provider-codex/src/bridge/fake-codex-app-server.mjs
+++ b/plugins/provider-codex/src/bridge/fake-codex-app-server.mjs
@@ -29,6 +29,7 @@ import {
   existsSync,
   openSync,
   readFileSync,
+  unlinkSync,
   writeFileSync,
 } from "node:fs";
 import { createInterface } from "node:readline";
@@ -166,6 +167,15 @@ const archivedThreadIds = new Set();
 const processLogPath = script?.processLogPath ?? null;
 /** `startDelayMs`: answer `thread/start` only after this many milliseconds. */
 const startDelayMs = script?.startDelayMs ?? 0;
+/**
+ * `writerLockPath`: optional single-writer fixture shared by every fake child
+ * from one script. A resumed thread owns it until that child exits, mirroring
+ * Codex's process-lifetime writer lock.
+ */
+const writerLockPath = script?.writerLockPath ?? null;
+/** `sigtermDelayMs`: keep a writer alive briefly after SIGTERM. */
+const sigtermDelayMs = script?.sigtermDelayMs ?? 0;
+let ownsWriterLock = false;
 
 function logProcessStep(step) {
   if (processLogPath === null) {
@@ -175,9 +185,63 @@ function logProcessStep(step) {
 }
 
 logProcessStep("spawn");
-process.on("SIGTERM", () => {
+
+function releaseWriterLock() {
+  if (!ownsWriterLock || writerLockPath === null) {
+    return;
+  }
+  ownsWriterLock = false;
+  if (
+    existsSync(writerLockPath) &&
+    readFileSync(writerLockPath, "utf8") === String(process.pid)
+  ) {
+    unlinkSync(writerLockPath);
+  }
+}
+
+function acquireWriterLock() {
+  if (writerLockPath === null || ownsWriterLock) {
+    return true;
+  }
+  try {
+    writeFileSync(writerLockPath, String(process.pid), { flag: "wx" });
+    ownsWriterLock = true;
+    return true;
+  } catch (error) {
+    if (!error || typeof error !== "object" || error.code !== "EEXIST") {
+      throw error;
+    }
+    const ownerPid = Number(readFileSync(writerLockPath, "utf8"));
+    try {
+      process.kill(ownerPid, 0);
+      return false;
+    } catch (ownerError) {
+      if (
+        !ownerError ||
+        typeof ownerError !== "object" ||
+        ownerError.code !== "ESRCH"
+      ) {
+        throw ownerError;
+      }
+      unlinkSync(writerLockPath);
+      return acquireWriterLock();
+    }
+  }
+}
+
+function exitCleanly() {
+  releaseWriterLock();
   logProcessStep("exit");
   process.exit(0);
+}
+
+process.on("exit", releaseWriterLock);
+process.on("SIGTERM", () => {
+  if (sigtermDelayMs > 0) {
+    setTimeout(exitCleanly, sigtermDelayMs);
+    return;
+  }
+  exitCleanly();
 });
 let scriptedTurnIndex = 0;
 
@@ -351,6 +415,14 @@ async function handleRequest(message) {
       return;
     }
     case "thread/resume": {
+      if (!acquireWriterLock()) {
+        respondError(
+          id,
+          -32603,
+          `thread ${params.threadId} already has an active writer`,
+        );
+        return;
+      }
       // Scripted archived-session rejection: the real app-server refuses to
       // resume an archived thread with an error naming the session. Tests use
       // an `archived-` provider-thread-id prefix to trigger it.
@@ -552,6 +624,5 @@ stdinLines.on("line", (line) => {
   }
 });
 stdinLines.on("close", () => {
-  logProcessStep("exit");
-  process.exit(0);
+  exitCleanly();
 });

--- a/plugins/provider-codex/src/bridge/fake-codex-app-server.mjs
+++ b/plugins/provider-codex/src/bridge/fake-codex-app-server.mjs
@@ -237,6 +237,7 @@ function exitCleanly() {
 
 process.on("exit", releaseWriterLock);
 process.on("SIGTERM", () => {
+  logProcessStep("sigterm");
   if (sigtermDelayMs > 0) {
     setTimeout(exitCleanly, sigtermDelayMs);
     return;
@@ -416,6 +417,7 @@ async function handleRequest(message) {
     }
     case "thread/resume": {
       if (!acquireWriterLock()) {
+        logProcessStep("writer-conflict");
         respondError(
           id,
           -32603,


### PR DESCRIPTION
## Human comments

<!-- Agents: Do not fill in this section. -->

## What was wrong

Codex 0.146+ holds a rollout writer lock for the lifetime of each app-server process, but the Codex bridge acknowledged release and spawned replacement children immediately after sending SIGTERM. A settings rebuild, stop/resume, bridge restart, or environment move could therefore resume while bb's previous child still owned the rollout.

The first implementation awaited child exit, but review found two more bridge-local windows. Reconstruction initially removed the old map entry before awaiting exit, allowing a concurrent stop or release-after-maintenance request to miss the in-flight replacement. Publishing the replacement closed that gap, but the pending old-child exit still lived only on the constructor stack: concurrent release found the connection-less replacement and acknowledged before the old child released its writer lock.

## What changed

- Make Codex child termination awaitable through finalized process exit, including the existing SIGKILL and close-grace bounds.
- Await release before rebuilding, answering `thread/stop`, and completing maintenance operations that release a session.
- Publish a connection-less replacement before waiting for the old child, and park the old child's exit promise on it. Concurrent stop/discard now marks the replacement closing and waits for both the parked old exit and any current child exit before acknowledging; reconstruction re-checks closing before spawning.
- Retry transient active-writer construction refusals on a bounded 100/400/1000 ms ladder and log every retry with its method, delay, and attempt number.
- Improve persistent-writer guidance to cover both another visible Codex session and a previous/leftover `codex app-server` process.
- Add deterministic regressions for settings rebuild, response-time stop serialization, concurrent stop and discard during reconstruction, transient ownership, and persistent ownership recovery. Shared process-test cleanup is missing-log-safe and attempts every cleanup stage even if an earlier one fails.
- Keep recovery provider-local. Independent real-Codex reproduction showed that the same losing app-server can retry resume after the owner exits, so no new wire recovery kind is needed. Native late-item ordering is orthogonal to the process-lifetime writer lock.
- No host-daemon wire contract changed, so this PR does not increment `HOST_DAEMON_PROTOCOL_VERSION` beyond the version already on `main`.

This PR fixes bb-owned writer handoff races. A persistent writer owned by an independent Codex process is improved, not eliminated: after bounded retries it still returns an untyped bridge error, now with retry diagnostics and actionable guidance.

## How you verified

The regressions were proven red against the exact behaviors they guard:

- Mutating the stop path back to fire-and-forget makes the response-time lock assertion fail with `expected true to be false`.
- Restoring the old map-before-await gap makes both concurrent release tests fail because reconstruction succeeds after release was already acknowledged.
- Before parking the old-child exit on the published replacement, the concurrent stop and concurrent discard tests both acknowledged while `writer.lock` still existed; both immediate lock-absence assertions failed deterministically with `expected true to be false` on two runs.

Green checks on the final tree:

- `pnpm exec turbo run test --filter=bb-plugin-provider-codex --force -- src/bridge/bridge.writer-lock.test.ts src/bridge/bridge.archived-rebuild.test.ts` (2 files, 8/8 passed)
- `pnpm exec turbo run test --filter=bb-plugin-provider-codex --force` (25 files, 255/255 passed)
- `pnpm exec turbo run test --filter=@bb/agent-runtime --force` (22 files, 318/318 passed)
- `pnpm exec turbo run typecheck --filter=bb-plugin-provider-codex --force`
- `pnpm exec turbo run build --filter=@bb/host-daemon --force`
- `pnpm exec oxlint` and `pnpm exec oxfmt --check` on every changed TypeScript file
- Real Codex 0.148.0 scratch smoke: app-server B received the native active-writer refusal while A held the rollout, then the same B process resumed successfully after A exited.

Fixes #2327

> AGENT GENERATED
