### PR TITLE
Stabilize PromptBox selection reveal test

### DIFF
--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -3106,9 +3106,6 @@ describe("PromptBoxInternal selection reveal", () => {
     const lines = Array.from({ length: 40 }, (_, index) => `line ${index}`);
     const { promptBoxRef } = renderPromptBox(lines.join("\n"));
 
-    await focusPromptEnd(promptBoxRef);
-    await nextAnimationFrame();
-
     const scrollContainer = document.querySelector(
       "[data-promptbox-editor-scroll]",
     );
@@ -3144,8 +3141,16 @@ describe("PromptBoxInternal selection reveal", () => {
       });
 
     try {
-      await waitFor(() => expect(view).not.toBeNull());
-      const liveView = view as unknown as EditorView;
+      // Install the layout spies above before triggering the reveal whose
+      // EditorView this test uses; there is no guaranteed later reveal.
+      await focusPromptEnd(promptBoxRef);
+      await nextAnimationFrame();
+
+      expect(view).not.toBeNull();
+      if (view === null) {
+        throw new Error("Expected focus reveal to capture the editor view");
+      }
+      const liveView: EditorView = view;
       const { doc } = liveView.state;
       // The focusEnd reveal above captured `view`; reset the baseline it set.
       scrollTop = 500;


### PR DESCRIPTION
## Human comments

## What was wrong

The selection-head regression test installed its emulated viewport and `EditorView.prototype.coordsAtPos` spy only after `focusEnd()` and one animation frame. `focusEnd()` schedules the reveal that the test intended to use to capture the editor view, so that reveal could finish before the spy existed. The subsequent `waitFor` then depended on an unrelated future reveal that is not guaranteed, producing the [app-3 failure](https://github.com/get-bb/bb/actions/runs/33104606917/job/98631030389) with `expected null not to be null`. The verified merge-base for this fix is `a2d47f5a6e7779c1d30f3b297582dc342878faec`.

## What changed

The existing PromptBox selection-reveal test now installs its layout and coordinate spies before calling `focusEnd()`, then asserts immediately after the scheduled reveal frame instead of polling for another reveal. It still dispatches an upward selection and verifies that `scrollTop` decreases, preserving the behavioral assertion that reveal follows the moving selection head rather than the anchor. The explicit null guard also removes the test's `unknown` cast.

This is test-only. There are no wire, host-daemon protocol, CLI, guide, or documentation changes, and `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

## How you verified

- Deterministic before/after regression: with the immediate boundary assertion and the old setup order, the focused Turbo test failed at line 3147 with `AssertionError: expected null not to be null`; after moving setup before `focusEnd()`, the same command passed.
- 20/20 uncached focused Turbo stress iterations passed.
- `pnpm exec turbo run test --filter=@bb/app --force -- --run src/components/promptbox/PromptBoxInternal.test.tsx` — 109 tests passed.
- `pnpm exec turbo run test --filter=@bb/app --force -- --shard=3/3` — exact CI shard, 146 files and 1,200 tests passed.
- `pnpm exec turbo run build typecheck lint --filter=@bb/app --force` — passed (lint: 173 existing warnings, 0 errors).
- `pnpm exec oxfmt apps/app/src/components/promptbox/PromptBoxInternal.test.tsx --check` — passed.
- `git diff --check` — passed.

> AGENT GENERATED: by GPT-5.6-Sol
