### PR TITLE
Align follow-up composer stack carets

### DIFF
--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -1652,6 +1652,8 @@ describe("PromptBoxInternal size controls", () => {
       name: "Collapse prompt box",
     });
     expect(collapseButton.classList).toContain("text-subtle-foreground/75");
+    expect(collapseButton.classList).toContain("w-6");
+    expect(collapseButton.classList).toContain("px-0");
     fireEvent.click(collapseButton);
 
     expect(onCollapse).toHaveBeenCalledOnce();

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -87,6 +87,7 @@ import {
   type PromptDraftState,
 } from "@bb/client-core";
 import { cn } from "@bb/shared-ui/lib/utils";
+import { PROMPT_STACK_EDGE_CARET_BUTTON_WIDTH_CLASS } from "./banner/PromptStackCard";
 import { AttachmentPreview } from "./AttachmentPreview";
 import { VoiceRecordingBar } from "./VoiceRecordingBar";
 import {
@@ -3033,6 +3034,7 @@ export function PromptBoxInternal({
                       className={cn(
                         CHROME_SUBTLE_ICON_BUTTON_FOREGROUND_CLASS,
                         COARSE_POINTER_PROMPT_ICON_ACTION_BUTTON_CLASS,
+                        PROMPT_STACK_EDGE_CARET_BUTTON_WIDTH_CLASS,
                       )}
                     >
                       <Icon name="ChevronDown" className="size-3" />

--- a/apps/app/src/components/promptbox/banner/PromptStackCard.tsx
+++ b/apps/app/src/components/promptbox/banner/PromptStackCard.tsx
@@ -9,8 +9,6 @@ export const PROMPT_STACK_INLAY_SEGMENT_CLASS = cn(
   "min-h-6 px-2 py-1",
   PROMPT_STACK_INLAY_RADIUS_CLASS,
 );
-// Right-edge caret controls share a 24px horizontal box so their icon centers
-// land on the same visual line, even when their vertical hit targets differ.
 export const PROMPT_STACK_EDGE_CARET_BUTTON_WIDTH_CLASS = "w-6 px-0";
 const BASE_CHROME = cn(
   PROMPT_STACK_CARD_RADIUS_CLASS,

--- a/apps/app/src/components/promptbox/banner/PromptStackCard.tsx
+++ b/apps/app/src/components/promptbox/banner/PromptStackCard.tsx
@@ -9,6 +9,9 @@ export const PROMPT_STACK_INLAY_SEGMENT_CLASS = cn(
   "min-h-6 px-2 py-1",
   PROMPT_STACK_INLAY_RADIUS_CLASS,
 );
+// Right-edge caret controls share a 24px horizontal box so their icon centers
+// land on the same visual line, even when their vertical hit targets differ.
+export const PROMPT_STACK_EDGE_CARET_BUTTON_WIDTH_CLASS = "w-6 px-0";
 const BASE_CHROME = cn(
   PROMPT_STACK_CARD_RADIUS_CLASS,
   "border border-border bg-surface-raised-solid",

--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
@@ -51,7 +51,10 @@ import {
   DropdownMenuTrigger,
 } from "@bb/shared-ui/dropdown-menu";
 import { Icon } from "@bb/shared-ui/icon";
-import { PromptStackCard } from "@/components/promptbox/banner/PromptStackCard";
+import {
+  PROMPT_STACK_EDGE_CARET_BUTTON_WIDTH_CLASS,
+  PromptStackCard,
+} from "@/components/promptbox/banner/PromptStackCard";
 import { useScrollOverflowState } from "@/components/thread/timeline/useScrollOverflowState";
 import { OverflowFade } from "@/components/ui/overflow-fade";
 import { InlineMessageEditorFrame } from "@/components/promptbox/InlineMessageEditorFrame";
@@ -1522,7 +1525,10 @@ export function QueuedMessagesList({
                   type="button"
                   size="icon"
                   variant="ghost"
-                  className="size-6 text-muted-foreground hover:bg-surface-recessed"
+                  className={cn(
+                    "h-6 text-muted-foreground hover:bg-surface-recessed",
+                    PROMPT_STACK_EDGE_CARET_BUTTON_WIDTH_CLASS,
+                  )}
                   onClick={handleCaretClick}
                   aria-label={caretLabel}
                   aria-expanded={mode !== "collapsed"}


### PR DESCRIPTION
## What was wrong

The three right-edge disclosure controls in the follow-up composer stack did not share a horizontal geometry contract. The branch and queued-message controls centered their 16px chevrons in a 24px edge column, while the composer collapse control used a 32px icon button against the same right edge. That put the composer caret four pixels left of the carets above it.

## What changed

- Adds one shared 24px horizontal edge-caret class for the follow-up prompt stack.
- Applies it to the branch banner, queued-message header, and wide composer collapse control while preserving their existing vertical hit targets.
- Adds a regression assertion at the stable composer behavior boundary so the collapse control cannot drift back to a wider horizontal box.
- No wire, persistence, SDK, CLI, or daemon protocol behavior changed.

## How you verified

- Red proof: with the production composer class absent, the new assertion fails because the collapse control does not contain `w-6`.
- Green proof: the focused composer assertion passes, and neighboring queued-message coverage passes 36/36.
- Exact rebased head `400f7c6674cbeb5a1df9c2f331f97b020865c3ba` passes every required GitHub check, including all app shards, packages, server, integration, and Linux/macOS package smoke.
- Chrome for Testing 152.0.7977.64 rendered the same `Stacked cards with pills` fixture at 1440×900 on exact parent and child heads. On the child, branch, queue, and composer caret centers all measured x=1019; the deliberate real-app pass also covered expanded/collapsed behavior, plus/model menus, focus re-expansion, responsive overflow, and runtime exceptions. The later rebase changed only ancestor SDK inventory metadata, not this layer's app tree. Safari is not required for this non-marketing bb UI change.

### Before — parent head `f4707e0ad2ea6622fa4c314e943c6735a1d21f34`

The composer caret sits four pixels left of the banner and queue carets.

![Before — composer caret is left of the two carets above it](https://raw.githubusercontent.com/brsbl/bb/a236be40b18b147c043415ff93f70ece328baa78/carets-before-f4707e-final.png)

### After — child head `400f7c6674cbeb5a1df9c2f331f97b020865c3ba`

All three carets share the same horizontal center.

![After — composer, queue, and branch carets are aligned](https://raw.githubusercontent.com/brsbl/bb/a236be40b18b147c043415ff93f70ece328baa78/carets-after-400f7c-final.png)

BB-Thread-ID: thr_sjdd7gudiq

> AGENT GENERATED
