### PR TITLE
Disable Plugin Guide by default

### DIFF
--- a/apps/server/src/services/plugins/builtin-registry.ts
+++ b/apps/server/src/services/plugins/builtin-registry.ts
@@ -129,7 +129,7 @@ export const BUILTIN_PLUGINS = [
   {
     name: "plugin-api-docs",
     pluginId: "plugin-api-docs",
-    defaultEnabled: true,
+    defaultEnabled: false,
     category: "Developer tools",
   },
   {

--- a/apps/server/test/services/plugins/builtin-plugins.test.ts
+++ b/apps/server/test/services/plugins/builtin-plugins.test.ts
@@ -472,6 +472,31 @@ describe("builtin plugin reconciliation", () => {
     expect(monacoEditor?.defaultEnabled).toBe(false);
   });
 
+  it("ships the Plugin Guide disabled on a fresh database", async () => {
+    const pluginGuide = BUILTIN_PLUGINS.find(
+      (builtin) => builtin.name === "plugin-api-docs",
+    );
+    expect(pluginGuide?.defaultEnabled).toBe(false);
+
+    service = createService({
+      db,
+      dataDir: join(workDir, "data"),
+      builtinName: "plugin-api-docs",
+      defaultEnabled: pluginGuide?.defaultEnabled,
+      rootDir: resolveBuiltinPluginRootPath("plugin-api-docs"),
+    });
+    await service.start();
+
+    expect(service.list()).toMatchObject([
+      {
+        id: "plugin-api-docs",
+        source: "builtin:plugin-api-docs",
+        enabled: false,
+        status: "disabled",
+      },
+    ]);
+  });
+
   it("ships Workflows disabled on a fresh database", async () => {
     const workflows = BUILTIN_PLUGINS.find(
       (builtin) => builtin.name === "workflows",

--- a/packages/bb-app/scripts/smoke-tarball.mjs
+++ b/packages/bb-app/scripts/smoke-tarball.mjs
@@ -34,7 +34,6 @@ const EXPECTED_RUNNING_BUILTIN_PLUGINS = [
   "inline-vis",
   "keep-awake",
   "pdf-preview",
-  "plugin-api-docs",
   "provider-retry",
   "secrets",
 ];


### PR DESCRIPTION
## Human comments

## What was wrong

The built-in plugin registry enabled the Plugin Guide on each fresh database. This made a developer tool run before the user chose it.

## What changed

The Plugin Guide now installs in the disabled state on a fresh database. Existing databases keep their saved choice. The package smoke test no longer expects this plugin to run by default.

## How you verified

- Added a server test that confirms a fresh database leaves the Plugin Guide disabled.
- Ran `pnpm exec turbo run test --filter=@bb/server -- test/services/plugins/builtin-plugins.test.ts`.
- Ran `pnpm exec turbo run typecheck --filter=@bb/server`.
- Ran `node --check packages/bb-app/scripts/smoke-tarball.mjs`.
- Ran `git diff --check`.

> AGENT GENERATED
