### PR TITLE
Hash forbidden Plugin Guide skill path

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -49,6 +49,7 @@
         // source, and maintenance-skill.test.ts reads the repository skill plus
         // Plugin Guide source; all are inputs to prevent stale cache hits.
         "$TURBO_ROOT$/apps/app/src/views/thread-detail/ThreadDetailView.tsx",
+        "$TURBO_ROOT$/.agents/skills/plugin-guide-maintenance/**",
         "$TURBO_ROOT$/.bb/skills/plugin-guide-maintenance/**",
         "$TURBO_ROOT$/plugins/plugin-api-docs/**",
         "$TURBO_ROOT$/vitest.shared.ts"


### PR DESCRIPTION
## Human comments

## What was wrong

`maintenance-skill.test.ts` checks that the Plugin Guide maintenance skill is absent from `.agents/skills`, but the `@bb/plugin-api-map#test` Turbo task did not include that out-of-package path in its inputs. A forbidden provider-native skill copy could therefore be added while Turbo replayed a stale passing test result.

## What changed

Added `.agents/skills/plugin-guide-maintenance/**` to the existing `@bb/plugin-api-map#test` inputs in `turbo.json`, alongside the repository-owned skill and Plugin Guide source inputs. This is test-cache infrastructure only; it does not change runtime behavior, wire contracts, public APIs, or user-facing documentation.

## How you verified

- Reproduced the pre-fix stale-cache behavior with a temporary forbidden skill file.
- Verified the resolved Turbo inputs include the forbidden path and that the focused guard executes and fails while the temporary file exists.
- Removed the temporary file and ran `pnpm exec turbo run test typecheck --filter=@bb/plugin-api-map --force` after rebasing onto current `origin/main`: all 75 tests passed, typecheck passed, and all four Turbo tasks executed without cache reuse.
- Ran `git diff --check` successfully.

> AGENT GENERATED
