### PR TITLE
Preserve naked thread title labels

### DIFF
--- a/apps/app/src/components/sidebar/ThreadRow.test.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.test.tsx
@@ -700,6 +700,54 @@ describe("ThreadRow", () => {
     }
   });
 
+  it("keeps missing naked thread ids literal across sidebar labels", async () => {
+    const missingThreadId = "thr_dcwivn5n8w";
+    const resolveMentions = vi
+      .spyOn(sdk.threads, "resolveMentions")
+      .mockResolvedValue([]);
+
+    try {
+      render(
+        <ThreadTitleMentionResourcesProvider
+          sectionNamesById={new Map()}
+          projectNamesById={new Map()}
+          threadById={new Map()}
+        >
+          <ThreadRowTestHarness
+            thread={createThread({
+              id: "thr_canonical",
+              title: `Canonical @thread:${missingThreadId}`,
+              titleFallback: `Canonical @thread:${missingThreadId}`,
+            })}
+          />
+          <ThreadRowTestHarness
+            thread={createThread({
+              id: "thr_naked",
+              title: `Naked ${missingThreadId}`,
+              titleFallback: `Naked ${missingThreadId}`,
+            })}
+          />
+        </ThreadTitleMentionResourcesProvider>,
+      );
+
+      await waitFor(() => expect(resolveMentions).toHaveBeenCalledTimes(1));
+      expect(
+        await screen.findByRole("link", {
+          name: "Open Canonical Unavailable thread",
+        }),
+      ).not.toBeNull();
+      expect(screen.getByTitle("Canonical Unavailable thread")).not.toBeNull();
+
+      const nakedTitle = `Naked ${missingThreadId}`;
+      expect(
+        screen.getByRole("link", { name: `Open ${nakedTitle}` }),
+      ).not.toBeNull();
+      expect(screen.getByTitle(nakedTitle).textContent).toBe(nakedTitle);
+    } finally {
+      resolveMentions.mockRestore();
+    }
+  });
+
   it("marks a child from another project with the project name", () => {
     const { container } = render(
       <ThreadTitleMentionResourcesProvider

--- a/apps/app/src/components/thread/ThreadTitleMentions.tsx
+++ b/apps/app/src/components/thread/ThreadTitleMentions.tsx
@@ -700,7 +700,8 @@ export function useThreadTitleDisplayText(title: string): string {
           segment.unresolvedThreadId === null
             ? segment.text
             : (resolvedThreadsById.get(segment.unresolvedThreadId)?.label ??
-              (unavailableThreadIds.has(segment.unresolvedThreadId)
+              (segment.serializedText?.startsWith("@thread:") === true &&
+              unavailableThreadIds.has(segment.unresolvedThreadId)
                 ? UNAVAILABLE_THREAD_MENTION_LABEL
                 : segment.text)),
         )


### PR DESCRIPTION
## Human comments

## What was wrong

Thread titles can contain both canonical serialized mentions such as `@thread:thr_…` and naked `thr_…` text. When resolution confirmed that a referenced thread was unavailable, the shared plain-text title projection replaced both forms with `Unavailable thread`, even though the visible rich-title renderer correctly preserved naked IDs literally. Sidebar text, tooltips, and accessible names could therefore contradict one another.

## What changed

Restricted unavailable-thread substitution in `useThreadTitleDisplayText` to parsed segments whose serialized text starts with `@thread:`. Added a `ThreadRow` regression test that covers a missing canonical mention and a missing naked ID together across visible title text, tooltip text, accessible link names, and shared resolver deduplication. There are no server/daemon wire, public API, or mobile changes.

## How you verified

- Reproduced the original mismatch in the isolated dev app: visible naked ID text remained literal while the tooltip and accessible row label said `Unavailable thread`.
- Verified the fixed browser flow keeps visible text, tooltip, and accessible name consistent while the resolver still returns an empty result.
- Ran `pnpm exec turbo run test --filter=@bb/app --force -- src/components/sidebar/ThreadRow.test.tsx src/components/ui/markdown-thread-mentions.test.tsx src/components/thread/toc/ThreadTableOfContents.test.tsx src/components/thread/timeline/GeneratedConversationMessage.test.tsx`: 148 tests passed.
- Ran `pnpm exec turbo run typecheck --filter=@bb/app --force`: passed.
- Ran `pnpm exec turbo run lint --filter=@bb/app --force`: 0 errors; 173 existing warnings.
- Ran `git diff --check`: passed.

> AGENT GENERATED
