### PR TITLE
Fix thread search result counter spacing

### DIFF
--- a/apps/app/src/components/commands/ThreadPaletteResults.tsx
+++ b/apps/app/src/components/commands/ThreadPaletteResults.tsx
@@ -280,7 +280,7 @@ export function ThreadPaletteResults({
             <div
               className={cn(
                 CHROME_SECTION_LABEL_CLASS,
-                "sticky top-0 z-10 rounded-none bg-popover px-2",
+                "sticky top-0 z-10 flex items-center gap-2 rounded-none bg-popover px-2",
               )}
             >
               <span className="min-w-0 truncate">{section.label}</span>


### PR DESCRIPTION
## Human comments

## What was wrong

The thread-search section header gave its overflow counter `ml-auto`, but the header itself was not a flex container. The auto margin therefore had no horizontal layout effect, rendering labels and counts together as text such as `Threads20/38`.

## What changed

Made the existing sticky result-section header a flex row with centered items and the standard 8px gap. This lets the existing auto margin push the N/M counter to the far edge while preserving truncation for long section labels. No state, behavior, public API, or wire contract changed.

## How you verified

- Reproduced the issue in the isolated dev app at 390×844 and captured the broken `Threads20/38` layout.
- Repeated the same dev-browser scenario after rebasing: the header computed as `display: flex` with an 8px gap, and “Threads” and “20/38” had 283.23px of measured separation.
- Ran `pnpm exec turbo run test --filter=@bb/app --force -- src/components/commands/ThreadPaletteResults.test.tsx`: all 4 existing tests passed.
- Ran `pnpm exec turbo run typecheck --filter=@bb/app --force`: passed.
- Ran `pnpm exec turbo run lint --filter=@bb/app --force`: 0 errors; 173 existing warnings.
- Ran `git diff --check`: passed.

> AGENT GENERATED
