### PR TITLE
Stop ACP inbound dispatch after kill

### DIFF
--- a/packages/provider-bridge-acp/src/bridge/agent-connection.test.ts
+++ b/packages/provider-bridge-acp/src/bridge/agent-connection.test.ts
@@ -1,3 +1,6 @@
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
@@ -161,7 +164,6 @@ describe("ACP agent stdio lifecycle", () => {
 
   it("makes an intentionally stopped connection unavailable before stdin teardown", async () => {
     const ready = deferred<void>();
-    const stdinClosed = deferred<void>();
     const exited = deferred<AcpAgentExitInfo>();
     const connection = createAcpAgentConnection({
       recordThreadId: null,
@@ -171,7 +173,7 @@ describe("ACP agent stdio lifecycle", () => {
         [
           'const fs = require("node:fs");',
           'const send = (method) => process.stdout.write(JSON.stringify({ jsonrpc: "2.0", method }) + "\\n");',
-          'process.on("SIGTERM", () => { fs.closeSync(0); send("stdin-closed"); setTimeout(() => process.exit(0), 50); });',
+          'process.on("SIGTERM", () => { fs.closeSync(0); setTimeout(() => process.exit(0), 50); });',
           'send("ready");',
           "setInterval(() => {}, 1000);",
         ].join(" "),
@@ -180,7 +182,6 @@ describe("ACP agent stdio lifecycle", () => {
       env: process.env,
       onNotification(method) {
         if (method === "ready") ready.resolve();
-        if (method === "stdin-closed") stdinClosed.resolve();
       },
       onRequest() {},
       onExit: exited.resolve,
@@ -199,7 +200,6 @@ describe("ACP agent stdio lifecycle", () => {
           (error: Error) => error,
         );
       connection.kill();
-      await stdinClosed.promise;
       // Reproduce the write that used to win the race with child exit and
       // replace the pending request's release result with an EPIPE message.
       connection.notify("construction/continues", {
@@ -232,6 +232,48 @@ describe("ACP agent stdio lifecycle", () => {
       });
     } finally {
       await stopConnection(connection, exited.promise);
+    }
+  });
+
+  it("ignores an ACP request emitted during SIGTERM", async () => {
+    const workspace = mkdtempSync(join(tmpdir(), "bb-acp-stop-"));
+    const lateWrite = join(workspace, "late-write.txt");
+    const ready = deferred<void>();
+    const exited = deferred<AcpAgentExitInfo>();
+    let requestCount = 0;
+    const connection = createAcpAgentConnection({
+      recordThreadId: null,
+      command: process.execPath,
+      args: [
+        "-e",
+        [
+          'const send = (message) => process.stdout.write(JSON.stringify(message) + "\\n");',
+          'process.on("SIGTERM", () => { send({ jsonrpc: "2.0", id: 1, method: "fs/write_text_file", params: {} }); setTimeout(() => process.exit(0), 50); });',
+          'send({ jsonrpc: "2.0", method: "ready" });',
+          "setInterval(() => {}, 1000);",
+        ].join(" "),
+      ],
+      cwd: workspace,
+      env: process.env,
+      onNotification(method) {
+        if (method === "ready") ready.resolve();
+      },
+      onRequest() {
+        requestCount += 1;
+        writeFileSync(lateWrite, "written after release");
+      },
+      onExit: exited.resolve,
+    });
+
+    try {
+      await ready.promise;
+      connection.kill();
+      await exited.promise;
+      expect(requestCount).toBe(0);
+      expect(existsSync(lateWrite)).toBe(false);
+    } finally {
+      await stopConnection(connection, exited.promise);
+      rmSync(workspace, { recursive: true });
     }
   });
 

--- a/packages/provider-bridge-acp/src/bridge/agent-connection.ts
+++ b/packages/provider-bridge-acp/src/bridge/agent-connection.ts
@@ -243,6 +243,9 @@ export function createAcpAgentConnection(
       terminal: false,
     });
     stdoutLines.on("line", (line) => {
+      if (stopping) {
+        return;
+      }
       const message = parseAgentLine(line);
       if (!message) {
         return;


### PR DESCRIPTION
## Human comments

## What was wrong

`AcpAgentConnection.kill()` synchronously stopped bb-to-agent writes, but the ACP stdout listener continued dispatching agent-to-bb JSON-RPC while the child was terminating. An ACP agent could emit a request such as `fs/write_text_file` from its SIGTERM handler and have bb execute it after the owning session had already been released.

## What changed

Added an early `stopping` guard at the shared ACP stdout-listener boundary, before inbound messages are parsed or classified as responses, requests, or notifications. Updated the lifecycle coverage and added a real-child regression whose SIGTERM handler emits a write request; the test proves neither the request callback nor its filesystem mutation occurs after `kill()`. No server/daemon wire contract changed, so `HOST_DAEMON_PROTOCOL_VERSION` remains unchanged.

## How you verified

- Before the production guard, the focused real-child regression failed deterministically on three runs with one post-stop request dispatch and a created `late-write.txt` file.
- After rebasing onto current `origin/main`, force-ran the focused SIGTERM regression three times: all three passed with no cache reuse.
- Ran `pnpm exec turbo run test --filter=@bb/provider-bridge-acp --filter=bb-plugin-provider-acp --force`: 299 bridge tests and 76 provider-plugin tests passed.
- Ran `pnpm exec turbo run typecheck --filter=@bb/provider-bridge-acp --filter=bb-plugin-provider-acp --force`: passed.
- Ran `pnpm exec turbo run build --filter=@get-bb/plugin-sdk --force`: all 17 runtime entries built.
- Ran targeted `oxfmt --check`, `git diff --check`, and a debug-marker search successfully.

> AGENT GENERATED
