### PR TITLE
Group external browser tabs by agent task

### DIFF
--- a/packages/templates/src/templates/standard-agent-append-instructions.md
+++ b/packages/templates/src/templates/standard-agent-append-instructions.md
@@ -12,4 +12,5 @@ You are working inside bb, an agentic IDE for managing coding agents in projects
 - Run `bb status` to see the current project, thread, and environment.
 - Run `bb guide` for BB concepts and `bb guide <chapter>` for command details.
 - Use `bb thread ...` when you need to create, inspect, message, wait for, or coordinate other BB threads.
+- When an external browser integration exposes a session-naming action such as `name_session`, invoke it once before opening task-owned tabs. Use a concise two- or three-word label derived from the task.
 - Use Markdown links for files, artifacts, and URLs you want the user to open; bb is a visual IDE and renders them as clickable links.

--- a/packages/templates/test/templates.test.ts
+++ b/packages/templates/test/templates.test.ts
@@ -48,6 +48,9 @@ describe("@bb/templates", () => {
 
     expect(rendered).toContain("You are working inside bb");
     expect(rendered).toContain("agentic IDE");
+    expect(rendered).toContain(
+      "session-naming action such as `name_session`",
+    );
     expect(rendered).not.toContain(
       "Ask the user a blocking question only when",
     );


### PR DESCRIPTION
## Human comments

## What was wrong

bb's standard provider instructions did not cover the lifecycle offered by external browser integrations that support named sessions. Even when a browser exposed a session-naming action, agents could open task-owned tabs first, leaving those tabs outside a task-specific group and making concurrent browser work difficult to distinguish. See #2595.

## What changed

- Tell agents to invoke an available external-browser session-naming action once before opening task-owned tabs.
- Require a concise two- or three-word label derived from the task.
- Keep the behavior conditional, so providers and browser integrations without session naming remain unchanged.
- Add a template regression assertion for the new instruction.

This changes provider instructions only. It does not change the server/host-daemon wire contract, CLI, SDK, or user-facing configuration, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

## How you verified

- `pnpm exec turbo run typecheck --filter=@bb/templates`
- `pnpm exec turbo run test --filter=@bb/templates` (7 files, 43 tests passed)
- `git diff --check`

Fixes #2595

> AGENT GENERATED
