### PR TITLE
Scroll the project picker menu instead of clipping it

### DIFF
--- a/apps/app/src/components/pickers/ProjectSelector.test.tsx
+++ b/apps/app/src/components/pickers/ProjectSelector.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { CompactViewportOverrideProvider } from "@bb/shared-ui/hooks/use-compact-viewport";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ProjectSelector } from "./ProjectSelector";
+
+const CAP_VARIABLE = "--radix-dropdown-menu-content-available-height";
+
+// Enough projects that the menu outgrows any window it opens in — the
+// condition #2551 needs to reproduce.
+const projects = Array.from({ length: 30 }, (_, index) => ({
+  id: `project_${index}`,
+  name: `Project ${index}`,
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function openProjectMenu(options?: { compact?: boolean }) {
+  const compact = options?.compact === true;
+  const selector = (
+    <ProjectSelector
+      projects={projects}
+      value={projects[0]!.id}
+      onChange={vi.fn()}
+      modal={false}
+    />
+  );
+  render(
+    compact ? (
+      <CompactViewportOverrideProvider isCompactViewport>
+        {selector}
+      </CompactViewportOverrideProvider>
+    ) : (
+      selector
+    ),
+  );
+  const trigger = screen.getByRole("button", { name: "Project" });
+  // The desktop menu opens on pointerdown; the compact drawer opens on click.
+  if (compact) {
+    fireEvent.click(trigger);
+  } else {
+    fireEvent.pointerDown(trigger, { button: 0 });
+  }
+}
+
+/** Every element carrying the desktop height cap, drawer included. */
+function cappedElements() {
+  return [...document.querySelectorAll("[class]")].filter((element) =>
+    (element.getAttribute("class") ?? "").includes(CAP_VARIABLE),
+  );
+}
+
+describe("ProjectSelector", () => {
+  it("caps the desktop menu at the height Radix measured and scrolls the rest", () => {
+    openProjectMenu();
+
+    const menu = screen.getByRole("menu");
+    expect(menu.className).toContain(`max-h-[var(${CAP_VARIABLE})]`);
+    expect(menu.className).toContain("overflow-y-auto");
+    expect(menu.className).toContain("overscroll-contain");
+  });
+
+  it("keeps every project in the menu, including the ones past the window edge", () => {
+    openProjectMenu();
+
+    expect(screen.getAllByRole("menuitem")).toHaveLength(projects.length);
+    // The last project is the one the clipped menu made unreachable.
+    expect(
+      screen.getAllByRole("menuitem", { name: /Project 29/u }),
+    ).toHaveLength(1);
+  });
+
+  it("leaves the compact drawer sizing itself", () => {
+    openProjectMenu({ compact: true });
+
+    // The compact branch is a drawer, not a Radix popper, so the variable the
+    // cap reads is never defined there. Keep the desktop rule off it rather
+    // than relying on an undefined variable to make the declaration drop out.
+    expect(screen.getByRole("dialog")).toBeDefined();
+    expect(cappedElements()).toHaveLength(0);
+  });
+});

--- a/apps/app/src/components/pickers/ProjectSelector.tsx
+++ b/apps/app/src/components/pickers/ProjectSelector.tsx
@@ -7,6 +7,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@bb/shared-ui/dropdown-menu";
+import { useIsCompactViewport } from "@bb/shared-ui/hooks/use-compact-viewport";
 import { Icon } from "@bb/shared-ui/icon";
 import { cn } from "@bb/shared-ui/lib/utils";
 import {
@@ -80,6 +81,7 @@ export function ProjectSelector({
   modal,
 }: ProjectSelectorProps) {
   const disabled = disabledProp || isLoading;
+  const isCompactViewport = useIsCompactViewport();
   const selected = value !== null ? projects.find((p) => p.id === value) : null;
   // When allowNoProject is false and the caller's value doesn't match any
   // project (shouldn't happen in normal use), the trigger falls back to the
@@ -141,7 +143,23 @@ export function ProjectSelector({
           )}
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" side="bottom" className="w-52">
+      <DropdownMenuContent
+        align="start"
+        side="bottom"
+        className={cn(
+          "w-52",
+          // Radix measures the room between the trigger and the viewport edge
+          // and publishes it as `--radix-dropdown-menu-content-available-height`.
+          // Without the cap the list renders at its full natural height and the
+          // projects past the window edge are unreachable, because the shared
+          // menu is `overflow-hidden` (#2551). `overscroll-contain` keeps the
+          // wheel from chaining to the page once the list bottoms out. The
+          // compact branch is a drawer, not a popper: it sizes itself and the
+          // variable is not defined there.
+          !isCompactViewport &&
+            "max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto overscroll-contain",
+        )}
+      >
         <DropdownMenuLabel>Project</DropdownMenuLabel>
         {projects.map((project) => (
           <DropdownMenuItem


### PR DESCRIPTION
Fixes #2551.

## What was wrong

`ProjectSelector` renders every project into the shared desktop dropdown, which is `overflow-hidden` with no height limit. Once the list is taller than the room below the trigger it lays out at its full natural height and runs off the window edge, and the projects past the cutoff cannot be scrolled to or selected.

## The fix

Radix already measures that room and publishes it as `--radix-dropdown-menu-content-available-height` on the content element — nothing consumed it. Cap the menu at it, scroll the overflow, and contain the overscroll so the wheel does not chain to the page once the list bottoms out.

The reproduction report on #2551 proposed applying the classes unconditionally. This gates them behind `!isCompactViewport` instead, matching how `ModelReasoningPicker` applies `max-h-[var(--radix-popover-content-available-height)]` (ModelReasoningPicker.tsx:1019). The compact branch renders a drawer rather than a Radix popper, so the variable is undefined there; the declaration would drop out on its own, but relying on an undefined variable to neutralize a rule seemed more fragile than not emitting it. Happy to simplify to the unconditional form if you would rather keep the component free of the hook.

## Verification

Measured in Chromium against the stylesheet built from this branch — 30 items, 694px of available height:

| | `max-height` | `overflow-y` | scrollable |
| --- | --- | --- | --- |
| before | `none` | `hidden` | no — 1088px of content, clipped |
| after | `694px` | `auto` | yes — 692px viewport, 1088px content |
| compact drawer | `none` | `auto` | unchanged |

`ProjectSelector.test.tsx` is new and covers the desktop cap, that all 30 projects stay reachable in the menu, and that the compact drawer does not inherit the desktop height rule. The first test fails on `main` without the component change.

`turbo run typecheck lint --filter=bb-app` passes, and all 8 test files under `apps/app/src/components/pickers` (72 tests) pass.
