### PR TITLE
Fix iOS deep-link confirmation in Mobile E2E

### DIFF
--- a/apps/mobile/e2e/flows/shell-deep-link.yaml
+++ b/apps/mobile/e2e/flows/shell-deep-link.yaml
@@ -12,14 +12,20 @@ env:
 - runFlow: ../subflows/pair-direct-server.yaml
 
 # A scheme link into a page surface.
-- openLink: "bb://threads"
+- runFlow:
+    file: ../subflows/open-bb-link.yaml
+    env:
+      LINK: "bb://threads"
 - extendedWaitUntil:
     visible:
       id: "shell-webview"
     timeout: 30000
 
 # A scheme link carrying a page path lands on that page.
-- openLink: "bb://"
+- runFlow:
+    file: ../subflows/open-bb-link.yaml
+    env:
+      LINK: "bb://"
 - extendedWaitUntil:
     visible:
       id: "shell-webview"
@@ -37,7 +43,10 @@ env:
 
 # Connect enrolment holds the Keychain credential, so it can never move into
 # the page. It stays native even while the shell is on.
-- openLink: "bb://connect"
+- runFlow:
+    file: ../subflows/open-bb-link.yaml
+    env:
+      LINK: "bb://connect"
 - extendedWaitUntil:
     visible:
       id: "connect-screen"

--- a/apps/mobile/e2e/flows/shell-send.yaml
+++ b/apps/mobile/e2e/flows/shell-send.yaml
@@ -31,7 +31,10 @@ env:
     id: "add-server-submit"
 # Pairing lands in the shell, which loads the page the server serves. The
 # composer is page content.
-- openLink: "bb://"
+- runFlow:
+    file: ../subflows/open-bb-link.yaml
+    env:
+      LINK: "bb://"
 - extendedWaitUntil:
     visible:
       id: "shell-webview"
@@ -43,7 +46,10 @@ env:
 
 # A deep link resolves to one shell route carrying a web path; the page's own
 # router takes it from there.
-- openLink: "bb://threads"
+- runFlow:
+    file: ../subflows/open-bb-link.yaml
+    env:
+      LINK: "bb://threads"
 - extendedWaitUntil:
     visible:
       id: "shell-webview"
@@ -51,7 +57,10 @@ env:
 
 # Reach a thread and send a message, the plan's acceptance test. The seeded
 # "Idle thread" echoes through the fake provider adapter.
-- openLink: "bb://"
+- runFlow:
+    file: ../subflows/open-bb-link.yaml
+    env:
+      LINK: "bb://"
 - extendedWaitUntil:
     visible: ".*Idle thread.*"
     timeout: 60000
@@ -81,7 +90,10 @@ env:
 # discoverable entry; the failure screen and the Home Screen quick action are
 # the two that still work when the page will not load. Match on the row's text:
 # a WebView exposes no test ids to the accessibility tree.
-- openLink: "bb://settings"
+- runFlow:
+    file: ../subflows/open-bb-link.yaml
+    env:
+      LINK: "bb://settings"
 - extendedWaitUntil:
     visible:
       id: "shell-webview"

--- a/apps/mobile/e2e/manual/phase7-plugins-devserver.yaml
+++ b/apps/mobile/e2e/manual/phase7-plugins-devserver.yaml
@@ -16,7 +16,10 @@ env:
 # the dev-client launcher) and sitting on a screen that survives losing the
 # profile (home), so: launch, reset, launch again → first run → add server.
 - runFlow: ../subflows/launch-app.yaml
-- openLink: "bb://e2e/reset"
+- runFlow:
+    file: ../subflows/open-bb-link.yaml
+    env:
+      LINK: "bb://e2e/reset"
 - extendedWaitUntil:
     visible: ".*Connect to a bb server.*"
     timeout: 60000
@@ -129,7 +132,10 @@ env:
 - takeScreenshot: p7-plugins-dev-browse
 # Leave the simulator at first run again for the harness flows.
 - runFlow: ../subflows/launch-app.yaml
-- openLink: "bb://e2e/reset"
+- runFlow:
+    file: ../subflows/open-bb-link.yaml
+    env:
+      LINK: "bb://e2e/reset"
 - extendedWaitUntil:
     visible: ".*Connect to a bb server.*"
     timeout: 60000

--- a/apps/mobile/e2e/scripts/ci-run-flows.sh
+++ b/apps/mobile/e2e/scripts/ci-run-flows.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 # Runs the Maestro flows CI can run against a Release build of the app (the
 # embedded JS bundle, no Metro) and a fresh mobile e2e backend, one `maestro
-# test` per flow so each gets its own artifacts, continuing past failures and
-# exiting non-zero if any flow failed.
+# test` per flow so each gets its own artifacts. After a failure it clears and
+# verifies native confirmation state before continuing; if containment fails,
+# it stops instead of contaminating later flows. It exits non-zero if any flow
+# failed.
 #
 # Usage:
 #   SERVER_URL=http://127.0.0.1:41999 \
@@ -64,9 +66,28 @@ for flow in "${FLOWS[@]}"; do
   else
     echo "FAIL $flow"
     failed+=("$flow")
-    # A failed flow can leave the app on any screen; the next flow cold-starts
-    # it, but keep a screenshot of where this one ended.
+    # A failed flow can leave the app on any screen; keep a screenshot before
+    # cleanup changes it.
     xcrun simctl io "$UDID" screenshot "$out/final-screen.png" >/dev/null 2>&1 || true
+
+    # `openLink` can leave an iOS-owned confirmation above the app. Neither
+    # stopApp nor the next flow's cold launch dismisses it, so explicitly
+    # cancel and verify that exact dialog before allowing another stateful flow
+    # to run. If cleanup cannot establish isolation, stop here.
+    cleanup="$out/cleanup"
+    mkdir -p "$cleanup"
+    if maestro --device "$UDID" test \
+        ${LAUNCH_ENV[@]+"${LAUNCH_ENV[@]}"} \
+        --format junit --output "$cleanup/junit.xml" \
+        --test-output-dir "$cleanup" \
+        ${MAESTRO_FLAGS:-} \
+        "subflows/clear-open-confirmation.yaml" 2>&1 | tee "$cleanup/maestro.log"; then
+      echo "RESET after $flow"
+    else
+      echo "Failed to clear native state after $flow; stopping before the next flow" >&2
+      echo "::endgroup::"
+      break
+    fi
   fi
   echo "::endgroup::"
 done

--- a/apps/mobile/e2e/subflows/clear-open-confirmation.yaml
+++ b/apps/mobile/e2e/subflows/clear-open-confirmation.yaml
@@ -1,0 +1,14 @@
+# Contain native state after a failed flow. A custom-scheme confirmation is
+# owned by iOS, so stopping or relaunching the app does not dismiss it. Cancel
+# the exact system dialog, stop the app, and prove the dialog is gone before a
+# later stateful flow is allowed to run.
+appId: app.getbb.mobile
+---
+- runFlow:
+    when:
+      platform: iOS
+      visible: "Open in.*bb.*"
+    commands:
+      - tapOn: "Cancel"
+- stopApp
+- assertNotVisible: "Open in.*bb.*"

--- a/apps/mobile/e2e/subflows/open-bb-link.yaml
+++ b/apps/mobile/e2e/subflows/open-bb-link.yaml
@@ -1,0 +1,16 @@
+# Open one real bb custom-scheme URL. On a fresh iOS simulator the operating
+# system can require confirmation before it delivers the first deep link to
+# the app. The choice belongs to the simulator, not app state, so accept it
+# only when the native dialog is actually present.
+#
+# Required env: LINK (for example, bb://threads).
+appId: app.getbb.mobile
+---
+- openLink: "${LINK}"
+- runFlow:
+    when:
+      platform: iOS
+      visible: "Open in.*bb.*"
+    commands:
+      - tapOn: "Open"
+- assertNotVisible: "Open in.*bb.*"

--- a/apps/mobile/src/lib/e2e/ci-run-flows.test.ts
+++ b/apps/mobile/src/lib/e2e/ci-run-flows.test.ts
@@ -1,0 +1,107 @@
+import {
+  chmodSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+const runner = fileURLToPath(
+  new URL("../../../e2e/scripts/ci-run-flows.sh", import.meta.url),
+);
+
+function runFixture({ cleanupFails }: { cleanupFails: boolean }) {
+  const root = mkdtempSync(join(tmpdir(), "bb-mobile-flow-runner-"));
+  const bin = join(root, "bin");
+  const artifacts = join(root, "artifacts");
+  const trace = join(root, "trace.log");
+  mkdirSync(bin);
+
+  const maestro = join(bin, "maestro");
+  writeFileSync(
+    maestro,
+    `#!/usr/bin/env bash
+set -u
+flow="\${!#}"
+printf '%s\\n' "$flow" >> "$TRACE_FILE"
+if [ "$flow" = "flows/fails.yaml" ]; then
+  exit 1
+fi
+if [ "$flow" = "subflows/clear-open-confirmation.yaml" ] && [ "$CLEANUP_FAILS" = "1" ]; then
+  exit 1
+fi
+exit 0
+`,
+  );
+  chmodSync(maestro, 0o755);
+
+  const xcrun = join(bin, "xcrun");
+  writeFileSync(
+    xcrun,
+    `#!/usr/bin/env bash
+set -u
+printf 'xcrun %s\\n' "$*" >> "$TRACE_FILE"
+exit 0
+`,
+  );
+  chmodSync(xcrun, 0o755);
+
+  const result = spawnSync(
+    "bash",
+    [runner, "simulator", artifacts, "fails", "passes"],
+    {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${bin}:${process.env.PATH ?? ""}`,
+        TRACE_FILE: trace,
+        CLEANUP_FAILS: cleanupFails ? "1" : "0",
+      },
+    },
+  );
+
+  return {
+    dispose: () => rmSync(root, { force: true, recursive: true }),
+    result,
+    trace: readFileSync(trace, "utf8").trim().split("\n"),
+  };
+}
+
+describe("ci-run-flows", () => {
+  it("clears native confirmation state before continuing after a failed flow", () => {
+    const fixture = runFixture({ cleanupFails: false });
+    try {
+      expect(fixture.result.status).toBe(1);
+      expect(fixture.trace).toEqual([
+        "flows/fails.yaml",
+        expect.stringMatching(/^xcrun simctl io simulator screenshot /),
+        "subflows/clear-open-confirmation.yaml",
+        "flows/passes.yaml",
+      ]);
+      expect(fixture.result.stderr).toContain("Failed flows: fails");
+    } finally {
+      fixture.dispose();
+    }
+  });
+
+  it("stops before a later flow when native-state cleanup cannot be verified", () => {
+    const fixture = runFixture({ cleanupFails: true });
+    try {
+      expect(fixture.result.status).toBe(1);
+      expect(fixture.trace).toEqual([
+        "flows/fails.yaml",
+        expect.stringMatching(/^xcrun simctl io simulator screenshot /),
+        "subflows/clear-open-confirmation.yaml",
+      ]);
+      expect(fixture.result.stderr).toContain("stopping before the next flow");
+    } finally {
+      fixture.dispose();
+    }
+  });
+});


### PR DESCRIPTION
## Human comments

## What was wrong

The scheduled [Mobile E2E run](https://github.com/get-bb/bb/actions/runs/33110526170) exercised `openLink: "bb://threads"` on a fresh iOS simulator but did not accept the native first-deep-link confirmation. Maestro reports `openLink` complete while iOS still owns the “Open in ‘bb’?” dialog, so the flow waited for `shell-webview` behind that dialog and timed out. Stopping and relaunching the app does not clear simulator-owned confirmation state, which let the same modal contaminate the next two stateful flows. This matches [Maestro's documented iOS behavior](https://docs.maestro.dev/api-reference/commands/openlink) and reproduces without a backend, WebView, or scheduler contention.

## What changed

- Route every automated `bb://` action through one parameterized Maestro subflow. It preserves the real custom-scheme invocation, conditionally accepts only the native `Open in … bb` dialog on iOS, and proves that dialog is gone before route assertions continue.
- After a failed CI flow, capture the original screenshot, cancel and verify removal of that native dialog, and stop the app before continuing. If cleanup cannot establish isolation, stop instead of running later flows against contaminated state.
- Add runner regression coverage for both successful cleanup-before-continuation and fail-closed cleanup failure.
- No timeout, polling deadline, retry budget, or wrapper ceiling changed.
- This changes only Mobile E2E orchestration and tests. It does not affect the server/host-daemon wire, so no `HOST_DAEMON_PROTOCOL_VERSION` bump is needed.

## How you verified

- Fresh-main gate independently verified before inspection: clean status, `HEAD`, `origin/main`, and merge base all `b629714e31487bde8af5574639422a9b5c97cbb5`.
- Before: Maestro 2.8.0 on iOS 26.5 completed `openLink: "bb://threads"` and failed `assertNotVisible: "Open"`; the captured screen showed the native “Open in ‘bb’?” dialog. A following `launchApp` inherited the same dialog.
- After: the checked-in `open-bb-link.yaml` ran on an untouched iOS 26.5 simulator, detected and tapped “Open,” asserted the dialog absent, and the boundary fixture displayed `Opened bb://threads`. On an already-approved simulator the conditional tap skipped and the link still routed.
- `pnpm exec turbo run test --filter=@bb/mobile --force` — 38 files, 288 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/mobile` — passed.
- `pnpm exec turbo run lint --filter=@bb/mobile` — passed with four unrelated pre-existing React warnings and zero errors.
- `pnpm exec turbo run build --filter=@bb/app` — passed; 441 files precompressed.
- `bash -n apps/mobile/e2e/scripts/ci-run-flows.sh` and `git diff --check` — passed.
- The full local Release shell flow could not be built on this host because Xcode 26.6 reported its installed iOS 26.5 simulator SDK/runtime as having no eligible simulator destination. The faithful custom-scheme/Maestro/iOS boundary was exercised directly instead; the scheduled workflow remains the full-app validation.

> AGENT GENERATED: by GPT-5.6-Sol
