### PR TITLE
Keep sidebar thread pills visible while truncating

### DIFF
--- a/apps/app/src/components/sidebar/ThreadRow.stories.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.stories.tsx
@@ -563,6 +563,25 @@ export function Overview() {
         </SidebarStage>
       </StoryRow>
       <StoryRow
+        label="long title + rich pills"
+        hint="title truncates in reading order through mention pills; hover reveals row actions"
+      >
+        <SidebarStage>
+          <StoryThreadRow
+            projectId="proj_demo"
+            crossProjectId={null}
+            thread={makeThread({
+              title:
+                "Review this branch using @docs/CODE_REVIEW.md and @apps/app/src/components/sidebar/ThreadRow.tsx before merging",
+              titleFallback:
+                "Review this branch using @docs/CODE_REVIEW.md and @apps/app/src/components/sidebar/ThreadRow.tsx before merging",
+            })}
+            isActive={false}
+            options={defaultOption}
+          />
+        </SidebarStage>
+      </StoryRow>
+      <StoryRow
         label="long title + draft"
         hint="title truncates before the right-aligned draft icon"
       >

--- a/apps/app/src/components/sidebar/ThreadRow.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.tsx
@@ -734,7 +734,7 @@ function ThreadRowComponent({
           </span>
         ) : (
           <span
-            className="min-w-0 truncate"
+            className="bb-sidebar-thread-title min-w-0 truncate"
             title={labelTitle}
             onDoubleClick={startTitleEditing}
           >

--- a/apps/app/src/components/ui/theme.css
+++ b/apps/app/src/components/ui/theme.css
@@ -955,6 +955,18 @@ body.sidebar-resizing [data-sidebar="panel"] {
 }
 
 @layer utilities {
+  /* Let the title's outer ellipsis clip through rich pills in reading order
+   * instead of treating each inline-flex pill as one replaceable box. */
+  .bb-sidebar-thread-title .prompt-mention-pill {
+    display: inline;
+  }
+
+  .bb-sidebar-thread-title .prompt-mention-pill > :first-child {
+    display: inline-block;
+    margin-inline-end: 0.125rem;
+    vertical-align: -0.2em;
+  }
+
   /*
    * The sweep animates `background-position` / `mask-position`, which the
    * compositor cannot run: every frame is a main-thread repaint. `will-change:

--- a/packages/domain/src/plugin-sdk-version.ts
+++ b/packages/domain/src/plugin-sdk-version.ts
@@ -16,7 +16,7 @@
 // PLUGIN_SDK_MAJOR is 0, so the major-only artifact gate cannot distinguish
 // 0.x releases and is intentionally vacuous for them until a future 1.0.
 // Rebuildable artifacts still rebuild on the exact sdkVersion-differs trigger.
-export const PLUGIN_SDK_VERSION = "0.4.24";
+export const PLUGIN_SDK_VERSION = "0.4.25";
 
 /** Major of {@link PLUGIN_SDK_VERSION} — the plugin API compatibility number. */
 export const PLUGIN_SDK_MAJOR = Number(PLUGIN_SDK_VERSION.split(".", 1)[0]);

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@get-bb/plugin-sdk",
-  "version": "0.4.24",
+  "version": "0.4.25",
   "homepage": "https://github.com/get-bb/bb#readme",
   "bugs": {
     "url": "https://github.com/get-bb/bb/issues"


### PR DESCRIPTION
## Human comments

## What was wrong

Sidebar thread titles use an outer single-line ellipsis, while rich mention pills render as atomic `inline-flex` boxes. When hover actions reduced the title’s available width, the browser discarded the entire pill at the truncation boundary, making it disappear instead of clipping the title in reading order.

## What changed

Scoped the rich-title treatment to sidebar thread rows and made mention pills participate in inline text layout there. The pill’s leading icon remains an aligned inline block, so the outer title ellipsis can clip through the pill without losing its visual identity. Added a narrow, mention-bearing `ThreadRow` story for visual regression checks. The implementation adds no React state, wrappers, subscriptions, or public/wire contract changes.

Also advanced the Plugin SDK patch version to `0.4.25`. The preceding merge changed `provider-bridge-acp`, which is bundled into the published SDK, but left the immutable npm version at `0.4.24`; the npm version guard correctly caught that baseline drift on this PR.

## How you verified

- Reproduced the original disappearance with dev-browser and captured before/after screenshots through the user-reviewed preview flow.
- After rebasing onto current `origin/main`, measured the target row before and during hover: the pill remained visible, its left edge moved 0px, and only its visible clipped width changed as the actions appeared.
- Ran `pnpm exec turbo run test typecheck lint --filter=@bb/app --force`: all six Turbo tasks executed without cache reuse; 3,439 tests passed, typecheck passed, and lint completed with 0 errors (173 existing warnings).
- Ran targeted `oxfmt --check`, `git diff --check`, and a debug-marker search successfully.
- Ran the Plugin SDK npm-version guard and surface check locally: `0.4.25` is unpublished and the public SDK surface is unchanged.

> AGENT GENERATED
