### PR TITLE
Retain shared ports while hosts are offline

### DIFF
--- a/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/SKILL.md
@@ -609,8 +609,11 @@ Control-plane declarations for host-local daemon behavior. Use
 `bb.hosts.declareSharedPorts(hostId, ports)` to replace this plugin's
 desired loopback port set for one host. `ports` contains integers from 1–65535;
 the server deduplicates and sorts them, owns the generation, and delivers the
-resulting set to the daemon. The call fails with an actionable error if the
-host has no bb connect machine enrollment.
+resulting set to the daemon. If an enrolled host is offline, the declaration
+stays dormant on the server and is delivered when a credentialed daemon
+session reconnects. The call fails with an actionable error if the host has no
+bb connect machine enrollment or its connected daemon reports that the local
+machine credential is missing.
 
 Call `await bb.hosts.ensureSharedPortTunnel(hostId)` to lazily assign and read
 the host's `{ label, baseDomain }` for constructing public URLs. The enrolled

--- a/apps/server/src/ws/host-shared-ports.ts
+++ b/apps/server/src/ws/host-shared-ports.ts
@@ -21,6 +21,11 @@ interface HostConnectCapability {
   sessionId: string;
 }
 
+interface HostConnectCapabilityState {
+  capability: HostConnectCapability;
+  leaseExpiresAt: number;
+}
+
 function normalizePorts(ports: readonly number[]): number[] {
   const normalized = new Set<number>();
   for (const port of ports) {
@@ -93,7 +98,17 @@ export class HostSharedPortCoordinator {
       throw new Error("shared-port declaration hostId must be non-empty");
     }
     const normalized = normalizePorts(ports);
-    if (normalized.length > 0) this.requireEnrolledHost(hostId);
+    if (normalized.length > 0) {
+      const host = this.requireDurablyEnrolledHost(hostId);
+      const state = this.connectCapabilityState(hostId);
+      if (
+        state !== null &&
+        state.leaseExpiresAt > Date.now() &&
+        !state.capability.hasMachineCredential
+      ) {
+        this.throwMissingMachineCredential(host);
+      }
+    }
     return normalized;
   }
 
@@ -101,20 +116,20 @@ export class HostSharedPortCoordinator {
     ownerId: string;
     hostId: string;
     ports: readonly number[];
-  }): HostDaemonConnectShares {
+  }): void {
     if (args.ownerId.trim().length === 0) {
       throw new Error("shared-port declaration ownerId must be non-empty");
     }
     const ports = this.validateSharedPortDeclaration(args.hostId, args.ports);
     // Clearing server-owned desired state is always safe. In particular, it
     // must remain possible after a host goes offline, loses enrollment, or is
-    // removed. Only an active request to share ports requires a live enrolled
-    // daemon with its own machine credential.
+    // removed. Non-empty declarations require durable enrollment, but remain
+    // dormant until a daemon with its machine credential reconnects.
     const current = this.declarationsByHost.get(args.hostId);
     const candidate = new Map(current ?? []);
     candidate.set(args.ownerId, { ports });
     this.declarationsByHost.set(args.hostId, candidate);
-    return this.publishIfChanged(args.hostId);
+    this.publishIfChanged(args.hostId);
   }
 
   replaceDeclarationsForOwner(
@@ -142,10 +157,7 @@ export class HostSharedPortCoordinator {
       if (current.has(ownerId)) affectedHostIds.add(hostId);
     }
 
-    const replacements = new Map<
-      string,
-      Map<string, SharedPortDeclaration>
-    >();
+    const replacements = new Map<string, Map<string, SharedPortDeclaration>>();
     for (const hostId of affectedHostIds) {
       const replacement = new Map(this.declarationsByHost.get(hostId) ?? []);
       const ports = normalizedByHost.get(hostId);
@@ -179,14 +191,14 @@ export class HostSharedPortCoordinator {
     hostId: string,
     identity: HostDaemonConnectTunnelIdentity,
   ): HostDaemonConnectTunnelIdentity {
-    this.requireEnrolledHost(hostId);
+    this.requireConnectedEnrolledHost(hostId);
     const parsed = hostDaemonConnectTunnelIdentitySchema.parse(identity);
     this.tunnelIdentityByHost.set(hostId, parsed);
     return parsed;
   }
 
   getTunnelIdentity(hostId: string): HostDaemonConnectTunnelIdentity | null {
-    this.requireEnrolledHost(hostId);
+    this.requireConnectedEnrolledHost(hostId);
     return this.tunnelIdentityByHost.get(hostId) ?? null;
   }
 
@@ -215,9 +227,13 @@ export class HostSharedPortCoordinator {
   }
 
   reconcileSharedPortsForHost(hostId: string): HostDaemonConnectShares {
+    const generation = this.generationByHost.get(hostId) ?? 0;
+    if (!this.canReceiveSharedPorts(hostId)) {
+      return { generation, ports: [] };
+    }
     return this.resolveDeclarations(
       this.declarationsByHost.get(hostId) ?? new Map(),
-      this.generationByHost.get(hostId) ?? 0,
+      generation,
     );
   }
 
@@ -242,34 +258,9 @@ export class HostSharedPortCoordinator {
     return host;
   }
 
-  private requireEnrolledHost(hostId: string) {
+  private requireDurablyEnrolledHost(hostId: string) {
     const host = this.requireShareCapableHost(hostId);
     if (host.connectMachineId === null) {
-      throw new ApiError(
-        409,
-        "connect_host_unenrolled",
-        `cannot share ports from host "${host.name}" (${host.id}) because it has no bb connect machine credential; enroll it via Connect in Settings > Machines`,
-        false,
-      );
-    }
-    const capability = this.connectCapabilityByHost.get(hostId);
-    const session = capability
-      ? getSessionById(this.deps.db, { sessionId: capability.sessionId })
-      : null;
-    if (
-      capability === undefined ||
-      session?.hostId !== host.id ||
-      session.status !== "active" ||
-      session.leaseExpiresAt <= Date.now()
-    ) {
-      throw new ApiError(
-        503,
-        "connect_host_offline",
-        `cannot share ports from host "${host.name}" (${host.id}) because it is not connected right now; bring the host online and try again`,
-        true,
-      );
-    }
-    if (!capability.hasMachineCredential) {
       throw new ApiError(
         409,
         "connect_host_unenrolled",
@@ -280,7 +271,62 @@ export class HostSharedPortCoordinator {
     return host;
   }
 
-  private publishIfChanged(hostId: string): HostDaemonConnectShares {
+  private connectCapabilityState(
+    hostId: string,
+  ): HostConnectCapabilityState | null {
+    const capability = this.connectCapabilityByHost.get(hostId);
+    const session = capability
+      ? getSessionById(this.deps.db, { sessionId: capability.sessionId })
+      : null;
+    if (
+      capability === undefined ||
+      session?.hostId !== hostId ||
+      session.status !== "active"
+    ) {
+      return null;
+    }
+    return { capability, leaseExpiresAt: session.leaseExpiresAt };
+  }
+
+  private canReceiveSharedPorts(hostId: string): boolean {
+    const host = getNonDestroyedHost(this.deps.db, hostId);
+    if (!host || host.connectMachineId === null) return false;
+    return (
+      this.connectCapabilityState(hostId)?.capability.hasMachineCredential ===
+      true
+    );
+  }
+
+  private requireConnectedEnrolledHost(hostId: string) {
+    const host = this.requireDurablyEnrolledHost(hostId);
+    const state = this.connectCapabilityState(hostId);
+    if (state === null || state.leaseExpiresAt <= Date.now()) {
+      throw new ApiError(
+        503,
+        "connect_host_offline",
+        `cannot share ports from host "${host.name}" (${host.id}) because it is not connected right now; bring the host online and try again`,
+        true,
+      );
+    }
+    if (!state.capability.hasMachineCredential) {
+      this.throwMissingMachineCredential(host);
+    }
+    return host;
+  }
+
+  private throwMissingMachineCredential(host: {
+    id: string;
+    name: string;
+  }): never {
+    throw new ApiError(
+      409,
+      "connect_host_unenrolled",
+      `cannot share ports from host "${host.name}" (${host.id}) because it has no bb connect machine credential; enroll it via Connect in Settings > Machines`,
+      false,
+    );
+  }
+
+  private publishIfChanged(hostId: string): void {
     const currentGeneration = this.generationByHost.get(hostId) ?? 0;
     const nextGeneration = currentGeneration + 1;
     const shares = this.resolveDeclarations(
@@ -292,16 +338,17 @@ export class HostSharedPortCoordinator {
       this.fingerprintByHost.get(hostId) ??
       fingerprint({ generation: currentGeneration, ports: [] });
     if (nextFingerprint === previousFingerprint) {
-      return { ...shares, generation: currentGeneration };
+      return;
     }
 
     this.fingerprintByHost.set(hostId, nextFingerprint);
     this.generationByHost.set(hostId, nextGeneration);
-    this.deps.hub.sendDaemonMessage(hostId, {
-      type: "connect-shares.replace",
-      ...shares,
-    });
-    return shares;
+    if (this.canReceiveSharedPorts(hostId)) {
+      this.deps.hub.sendDaemonMessage(hostId, {
+        type: "connect-shares.replace",
+        ...shares,
+      });
+    }
   }
 
   private resolveDeclarations(

--- a/apps/server/src/ws/host-shared-ports.ts
+++ b/apps/server/src/ws/host-shared-ports.ts
@@ -103,7 +103,6 @@ export class HostSharedPortCoordinator {
       const state = this.connectCapabilityState(hostId);
       if (
         state !== null &&
-        state.leaseExpiresAt > Date.now() &&
         !state.capability.hasMachineCredential
       ) {
         this.throwMissingMachineCredential(host);

--- a/apps/server/test/app/host-shared-ports.test.ts
+++ b/apps/server/test/app/host-shared-ports.test.ts
@@ -1,5 +1,6 @@
 import {
   createConnection,
+  heartbeatSession,
   migrate,
   noopNotifier,
   openSession,
@@ -72,11 +73,12 @@ describe("HostSharedPortCoordinator", () => {
       ports: [],
     });
 
-    const first = sharedPorts.declareSharedPorts({
+    sharedPorts.declareSharedPorts({
       ownerId: "connect",
       hostId: host.id,
       ports: [8080, 3000, 8080],
     });
+    const first = sharedPorts.reconcileSharedPortsForHost(host.id);
     expect(first).toEqual({ generation: 1, ports: [3000, 8080] });
     expect(
       hostDaemonServerWsMessageSchema.parse(
@@ -91,21 +93,23 @@ describe("HostSharedPortCoordinator", () => {
       hostId: host.id,
       ports: [4173],
     });
-    const replacement = sharedPorts.declareSharedPorts({
+    sharedPorts.declareSharedPorts({
       ownerId: "connect",
       hostId: host.id,
       ports: [8080],
     });
+    const replacement = sharedPorts.reconcileSharedPortsForHost(host.id);
     expect(replacement).toEqual({ generation: 3, ports: [4173, 8080] });
 
     // Identical replacement is a no-op and retains generation.
-    expect(
-      sharedPorts.declareSharedPorts({
-        ownerId: "connect",
-        hostId: host.id,
-        ports: [8080],
-      }),
-    ).toEqual(replacement);
+    sharedPorts.declareSharedPorts({
+      ownerId: "connect",
+      hostId: host.id,
+      ports: [8080],
+    });
+    expect(sharedPorts.reconcileSharedPortsForHost(host.id)).toEqual(
+      replacement,
+    );
     expect(daemonSocket.messages).toHaveLength(3);
 
     sharedPorts.clearDeclarationsForOwner("connect");
@@ -141,7 +145,100 @@ describe("HostSharedPortCoordinator", () => {
     ]);
   });
 
-  it("distinguishes unknown, unenrolled, and enrolled-but-offline hosts", () => {
+  it("delivers changed ports over a registered credentialed socket after its lease stales", () => {
+    const { db, host, hub, session, sharedPorts } = setup();
+    if (!session) throw new Error("expected an online host session");
+    const daemonSocket = createMockHubSocket();
+    hub.registerDaemon(session.id, host.id, daemonSocket);
+
+    sharedPorts.declareSharedPorts({
+      ownerId: "connect",
+      hostId: host.id,
+      ports: [3000],
+    });
+    heartbeatSession(db, session.id, Date.now() - 1);
+    sharedPorts.declareSharedPorts({
+      ownerId: "connect",
+      hostId: host.id,
+      ports: [],
+    });
+
+    expect(daemonSocket.messages.map((message) => JSON.parse(message))).toEqual(
+      [
+        {
+          type: "connect-shares.replace",
+          generation: 1,
+          ports: [3000],
+        },
+        {
+          type: "connect-shares.replace",
+          generation: 2,
+          ports: [],
+        },
+      ],
+    );
+  });
+
+  it("retains changed generations through a full disconnect and reconnect", () => {
+    const { db, host, hub, session, sharedPorts } = setup();
+    if (!session) throw new Error("expected an online host session");
+    const firstSocket = createMockHubSocket();
+    hub.registerDaemon(session.id, host.id, firstSocket);
+    sharedPorts.declareSharedPorts({
+      ownerId: "connect",
+      hostId: host.id,
+      ports: [3000],
+    });
+
+    hub.unregisterDaemon(session.id);
+    sharedPorts.clearHostConnectCapability(session.id);
+    sharedPorts.declareSharedPorts({
+      ownerId: "connect",
+      hostId: host.id,
+      ports: [4173],
+    });
+    expect(firstSocket.messages.map((message) => JSON.parse(message))).toEqual([
+      {
+        type: "connect-shares.replace",
+        generation: 1,
+        ports: [3000],
+      },
+    ]);
+
+    const reconnected = openSession(db, {
+      hostId: host.id,
+      instanceId: "reconnected-instance",
+      hostName: host.name,
+      hostType: host.type,
+      dataDir: "/tmp/host-data",
+      protocolVersion: HOST_DAEMON_PROTOCOL_VERSION,
+      heartbeatIntervalMs: 30_000,
+      leaseTimeoutMs: 90_000,
+    });
+    sharedPorts.recordHostConnectCapability({
+      hostId: host.id,
+      sessionId: reconnected.id,
+      hasMachineCredential: true,
+    });
+    const secondSocket = createMockHubSocket();
+    hub.registerDaemon(reconnected.id, host.id, secondSocket);
+
+    expect(sharedPorts.pushCurrentSharedPortsForHost(host.id)).toEqual({
+      generation: 2,
+      ports: [4173],
+    });
+    expect(secondSocket.messages.map((message) => JSON.parse(message))).toEqual(
+      [
+        {
+          type: "connect-shares.replace",
+          generation: 2,
+          ports: [4173],
+        },
+      ],
+    );
+  });
+
+  it("retains declarations for offline enrolled hosts and delivers them on reconnect", () => {
     const { sharedPorts } = setup();
     expect(() =>
       sharedPorts.declareSharedPorts({
@@ -171,27 +268,44 @@ describe("HostSharedPortCoordinator", () => {
     });
 
     const offline = setup({ online: false });
-    let offlineError: unknown;
-    try {
+    expect(() =>
       offline.sharedPorts.declareSharedPorts({
         ownerId: "connect",
         hostId: offline.host.id,
         ports: [3000],
-      });
-    } catch (error) {
-      offlineError = error;
-    }
-    expect(offlineError).toBeInstanceOf(ApiError);
-    expect(offlineError).toMatchObject({
-      body: {
-        code: "connect_host_offline",
-        message: expect.stringContaining("bring the host online"),
-      },
+      }),
+    ).not.toThrow();
+
+    const session = openSession(offline.db, {
+      hostId: offline.host.id,
+      instanceId: "reconnected-instance",
+      hostName: offline.host.name,
+      hostType: offline.host.type,
+      dataDir: "/tmp/host-data",
+      protocolVersion: HOST_DAEMON_PROTOCOL_VERSION,
+      heartbeatIntervalMs: 30_000,
+      leaseTimeoutMs: 90_000,
     });
-    if (!(offlineError instanceof ApiError)) {
-      throw new Error("expected an ApiError for the offline host");
-    }
-    expect(offlineError.body.message).not.toMatch(/remove and re-add|enroll/i);
+    offline.sharedPorts.recordHostConnectCapability({
+      hostId: offline.host.id,
+      sessionId: session.id,
+      hasMachineCredential: true,
+    });
+    const daemonSocket = createMockHubSocket();
+    offline.hub.registerDaemon(session.id, offline.host.id, daemonSocket);
+
+    expect(
+      offline.sharedPorts.pushCurrentSharedPortsForHost(offline.host.id),
+    ).toEqual({ generation: 1, ports: [3000] });
+    expect(daemonSocket.messages.map((message) => JSON.parse(message))).toEqual(
+      [
+        {
+          type: "connect-shares.replace",
+          generation: 1,
+          ports: [3000],
+        },
+      ],
+    );
   });
 
   it("always accepts empty declarations for offline, unenrolled, and removed hosts", () => {
@@ -203,21 +317,23 @@ describe("HostSharedPortCoordinator", () => {
       ports: [3000],
     });
     offline.sharedPorts.clearHostConnectCapability(offline.session.id);
+    offline.sharedPorts.declareSharedPorts({
+      ownerId: "connect",
+      hostId: offline.host.id,
+      ports: [],
+    });
     expect(
-      offline.sharedPorts.declareSharedPorts({
-        ownerId: "connect",
-        hostId: offline.host.id,
-        ports: [],
-      }),
+      offline.sharedPorts.reconcileSharedPortsForHost(offline.host.id),
     ).toEqual({ generation: 2, ports: [] });
 
     const unenrolled = setup({ enrolled: false });
+    unenrolled.sharedPorts.declareSharedPorts({
+      ownerId: "connect",
+      hostId: unenrolled.host.id,
+      ports: [],
+    });
     expect(
-      unenrolled.sharedPorts.declareSharedPorts({
-        ownerId: "connect",
-        hostId: unenrolled.host.id,
-        ports: [],
-      }),
+      unenrolled.sharedPorts.reconcileSharedPortsForHost(unenrolled.host.id),
     ).toEqual({ generation: 0, ports: [] });
 
     const removed = setup();
@@ -229,20 +345,22 @@ describe("HostSharedPortCoordinator", () => {
     updateHost(removed.db, noopNotifier, removed.host.id, {
       destroyedAt: Date.now(),
     });
+    removed.sharedPorts.declareSharedPorts({
+      ownerId: "connect",
+      hostId: removed.host.id,
+      ports: [],
+    });
     expect(
-      removed.sharedPorts.declareSharedPorts({
-        ownerId: "connect",
-        hostId: removed.host.id,
-        ports: [],
-      }),
+      removed.sharedPorts.reconcileSharedPortsForHost(removed.host.id),
     ).toEqual({ generation: 2, ports: [] });
 
+    removed.sharedPorts.declareSharedPorts({
+      ownerId: "connect",
+      hostId: "missing-host",
+      ports: [],
+    });
     expect(
-      removed.sharedPorts.declareSharedPorts({
-        ownerId: "connect",
-        hostId: "missing-host",
-        ports: [],
-      }),
+      removed.sharedPorts.reconcileSharedPortsForHost("missing-host"),
     ).toEqual({ generation: 0, ports: [] });
   });
 
@@ -389,7 +507,7 @@ describe("daemon session connect shares", () => {
     });
   });
 
-  it("rejects declarations when the current session lacks its persisted machine credential", async () => {
+  it("rejects declarations while the current session lacks its machine credential", async () => {
     await withTestHarness(async (harness) => {
       upsertHost(harness.db, harness.hub, {
         id: "host-1",

--- a/apps/server/test/app/host-shared-ports.test.ts
+++ b/apps/server/test/app/host-shared-ports.test.ts
@@ -179,6 +179,38 @@ describe("HostSharedPortCoordinator", () => {
     );
   });
 
+  it("rejects a registered credentialless session after its lease stales", () => {
+    const { db, host, hub, session, sharedPorts } = setup();
+    if (!session) throw new Error("expected an online host session");
+    hub.registerDaemon(session.id, host.id, createMockHubSocket());
+    sharedPorts.recordHostConnectCapability({
+      hostId: host.id,
+      sessionId: session.id,
+      hasMachineCredential: false,
+    });
+    heartbeatSession(db, session.id, Date.now() - 1);
+
+    let declarationError: unknown;
+    try {
+      sharedPorts.declareSharedPorts({
+        ownerId: "connect",
+        hostId: host.id,
+        ports: [3000],
+      });
+    } catch (error) {
+      declarationError = error;
+    }
+
+    expect(declarationError).toBeInstanceOf(ApiError);
+    expect(declarationError).toMatchObject({
+      body: { code: "connect_host_unenrolled" },
+    });
+    expect(sharedPorts.reconcileSharedPortsForHost(host.id)).toEqual({
+      generation: 0,
+      ports: [],
+    });
+  });
+
   it("retains changed generations through a full disconnect and reconnect", () => {
     const { db, host, hub, session, sharedPorts } = setup();
     if (!session) throw new Error("expected an online host session");

--- a/packages/domain/src/plugin-sdk-version.ts
+++ b/packages/domain/src/plugin-sdk-version.ts
@@ -16,7 +16,7 @@
 // PLUGIN_SDK_MAJOR is 0, so the major-only artifact gate cannot distinguish
 // 0.x releases and is intentionally vacuous for them until a future 1.0.
 // Rebuildable artifacts still rebuild on the exact sdkVersion-differs trigger.
-export const PLUGIN_SDK_VERSION = "0.4.25";
+export const PLUGIN_SDK_VERSION = "0.4.26";
 
 /** Major of {@link PLUGIN_SDK_VERSION} — the plugin API compatibility number. */
 export const PLUGIN_SDK_MAJOR = Number(PLUGIN_SDK_VERSION.split(".", 1)[0]);

--- a/packages/host-daemon-contract/src/protocol.ts
+++ b/packages/host-daemon-contract/src/protocol.ts
@@ -335,9 +335,14 @@
 // capacity implied by each model id. The usage event meaning changed across
 // the daemon boundary, so enrolled daemons must update with the server.
 //
+// Version 172 lets the server retain shared-port declarations while an
+// enrolled host is offline, then sends that desired set in the next daemon
+// session. The session-open connectShares semantics changed across the daemon
+// boundary, so enrolled daemons must update with the server.
+//
 // The version mismatch is what triggers the enrolled daemon's automatic update
 // instead of an `invalid-message` reconnect loop.
-export const HOST_DAEMON_PROTOCOL_VERSION = 171 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 172 as const;
 
 /**
  * Absolute ceiling for any executable artifact delivered to a host daemon —

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -1046,7 +1046,7 @@ describe("host-daemon command schemas", () => {
   // mixed version. Version 113 carried the Devin Desktop open target rename
   // and remains part of the protocol lineage.
   it("uses the current host-daemon protocol version", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(171);
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(172);
     expect(HOST_ARTIFACT_MAX_BYTES).toBe(256 * 1024 * 1024);
   });
 

--- a/packages/plugin-api-map/src/surfaces.ts
+++ b/packages/plugin-api-map/src/surfaces.ts
@@ -656,6 +656,7 @@ export const SURFACE_GROUPS: SurfaceGroup[] = [
           "Ship a Node entry point bb starts on demand on the machine it calls",
           "Call that worker from its server code over typed RPC",
           "Do work that has to happen on the machine itself, such as watching files or holding a wake lock",
+          "Declare desired loopback ports once and let bb deliver retained declarations when an enrolled machine reconnects",
         ],
         apiSymbols: ["PluginHosts"],
         firstParty: ["Keep Awake", "Remote access"],

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@get-bb/plugin-sdk",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "homepage": "https://github.com/get-bb/bb#readme",
   "bugs": {
     "url": "https://github.com/get-bb/bb/issues"

--- a/packages/plugin-sdk/src/backend-contract.ts
+++ b/packages/plugin-sdk/src/backend-contract.ts
@@ -1160,8 +1160,11 @@ export interface PluginHosts {
   /**
    * Replace this plugin's desired shared-loopback ports for one host. The
    * server aggregates declarations, owns generations, and delivers the
-   * resulting set to that host's daemon. Tunnel identity is deliberately not
-   * accepted here: it is owned by the daemon's trusted enrollment.
+   * resulting set to that host's daemon. When an enrolled host is offline,
+   * the server retains the declaration and delivers it on the next
+   * credentialed daemon session. A connected daemon that reports no machine
+   * credential is rejected. Tunnel identity is deliberately not accepted
+   * here: it is owned by the daemon's trusted enrollment.
    */
   declareSharedPorts(hostId: string, ports: readonly number[]): void;
 }

--- a/plugins/connect/src/connect.test.ts
+++ b/plugins/connect/src/connect.test.ts
@@ -1852,12 +1852,10 @@ describe("connect plugin", () => {
     ]);
   });
 
-  it("unexposes a persisted machine share when its declaration push fails offline", async () => {
+  it("unexposes a persisted machine share when its declaration update fails", async () => {
     host = createConnectFakeHost();
     const declarations = vi.fn((_hostId: string, _ports: readonly number[]) => {
-      throw Object.assign(new Error("host is offline"), {
-        body: { code: "connect_host_offline" },
-      });
+      throw new Error("temporary declaration failure");
     });
     Object.defineProperty(host.bb.hosts, "declareSharedPorts", {
       value: declarations,

--- a/plugins/connect/src/tunnel.ts
+++ b/plugins/connect/src/tunnel.ts
@@ -337,8 +337,9 @@ export class ConnectTunnel {
   }
 
   /**
-   * A disconnected enrolled host must not block this server's own tunnel.
-   * Keep retrying persisted machine-share hydration/declaration separately.
+   * Persisted declarations stay dormant while enrolled hosts are offline.
+   * Keep hydration separate so other transient declaration failures can retry
+   * without blocking this server's own tunnel.
    */
   private startShareActivation(): void {
     const epoch = ++this.shareActivationEpoch;


### PR DESCRIPTION
## Human comments

## What was wrong

Shared-port declarations were validated against the current host session lease instead of durable Connect enrollment. When an enrolled machine was offline, Connect hydration failed, retried every five seconds, and emitted duplicate warnings. Delivery also reused lease freshness, so a registered socket whose lease briefly staled could miss a port removal after the desired generation advanced.

## What changed

- Separate durable host enrollment from live daemon delivery capability.
- Retain desired port declarations while enrolled hosts are offline and reconcile them on session and socket reconnect.
- Continue delivering changes to registered credentialed sockets when their lease is stale, including unexpose removals.
- Reject credentialless current sessions even after their lease expires; lease freshness remains required for tunnel identity operations.
- Make declareSharedPorts command-shaped so callers cannot confuse desired and effective state under one generation.
- Bump HOST_DAEMON_PROTOCOL_VERSION from 171 to 172 for the changed reconnect payload semantics.
- Bump the public Plugin SDK from 0.4.25 to 0.4.26 because the declareSharedPorts behavior contract changed.
- Update the Plugin SDK contract docs, Plugin Guide, plugin-authoring skill, and Connect tests and comments.

## How you verified

- Added regressions for offline declaration retention, stale-lease delivery, reconnect generation recovery, and credentialless sessions including expired leases. These fail against the prior behavior and pass with this change.
- pnpm exec turbo run test --filter=@bb/server --force: 2,051 passed before the final review regression.
- pnpm exec turbo run test --filter=@bb/server --force -- test/app/host-shared-ports.test.ts: 11 passed after the final review fix.
- pnpm exec turbo run test --filter=bb-plugin-connect --force: 90 passed.
- pnpm exec turbo run test --filter=@bb/host-daemon-contract --force: 51 passed.
- pnpm exec turbo run test typecheck --filter=@get-bb/plugin-sdk --force: 219 passed and typecheck passed.
- node .github/workflows/check-plugin-sdk-version.mjs passed.
- Plugin API map, Plugin Guide, and full app workflow passed; the app suite ran 3,437 tests.
- Affected server, daemon, contract, SDK, API map, and Connect typechecks passed.
- Rebased onto current origin/main and reran the focused shared-port, Connect, contract, and typecheck checks.

Fixes: no linked issue; reported from server logs.

@slopcop please review.

> AGENT GENERATED