### PR TITLE
Fix provider-parity response ordering under contention

### DIFF
--- a/packages/provider-bridge-protocol/src/testing/parity.test.ts
+++ b/packages/provider-bridge-protocol/src/testing/parity.test.ts
@@ -7,14 +7,16 @@ import { replayRecording } from "./parity.js";
 
 function writeLane(
   dir: string,
-  direction: "runtime→bridge" | "bridge→runtime",
+  direction:
+    | "runtime→bridge"
+    | "bridge→runtime"
+    | "provider→bridge"
+    | "bridge→provider",
   entries: ReadonlyArray<{ seq: number; line: string }>,
+  current: boolean,
 ): void {
   writeFileSync(
-    join(
-      dir,
-      `${direction}${direction === "bridge→runtime" ? ".current" : ""}.ndjson`,
-    ),
+    join(dir, `${direction}${current ? ".current" : ""}.ndjson`),
     `${entries
       .map((entry) =>
         JSON.stringify({
@@ -85,11 +87,11 @@ it("waits for the exact planned tail and a quiet period before closing", async (
           params: {},
         }),
       },
-    ]);
+    ], false);
     writeLane(dir, "bridge→runtime", [
       { seq: 1.1, line: delta(prefixEvents) },
       { seq: 1.2, line: delta(tailEvents) },
-    ]);
+    ], true);
     writeFileSync(
       bridgePath,
       [
@@ -162,6 +164,139 @@ it("waits for the exact planned tail and a quiet period before closing", async (
       ...tailEvents,
       ...extraEvents,
     ]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+it("holds a provider notification for the runtime response recorded before it", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "bb-parity-response-gate-test-"));
+  const bridgePath = join(dir, "delayed-response-bridge.mjs");
+  const event: ThreadEvent = {
+    type: "thread/contextWindowUsage/updated",
+    threadId: "thr_test",
+    providerThreadId: "provider_test",
+    scope: { kind: "thread" },
+    contextWindowUsage: {
+      usedTokens: 42,
+      modelContextWindow: 1_000,
+      estimated: false,
+    },
+  };
+  const runtimeRequest = JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "thread/start",
+    params: {},
+  });
+  const runtimeResponse = JSON.stringify({ jsonrpc: "2.0", id: 1, result: {} });
+  const providerRequest = JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {},
+  });
+  const providerResponse = JSON.stringify({ jsonrpc: "2.0", id: 1, result: {} });
+  const providerNotification = JSON.stringify({
+    jsonrpc: "2.0",
+    method: "update",
+    params: {},
+  });
+  const delta = JSON.stringify({
+    jsonrpc: "2.0",
+    method: "thread/delta",
+    params: { events: [event] },
+  });
+  const bridgeOutput = [
+    { seq: 4, line: runtimeResponse },
+    { seq: 6, line: delta },
+  ];
+
+  try {
+    writeLane(dir, "runtime→bridge", [{ seq: 1, line: runtimeRequest }], false);
+    writeLane(dir, "bridge→provider", [{ seq: 2, line: providerRequest }], false);
+    writeLane(
+      dir,
+      "provider→bridge",
+      [
+        { seq: 3, line: providerResponse },
+        { seq: 5, line: providerNotification },
+      ],
+      false,
+    );
+    writeLane(dir, "bridge→runtime", bridgeOutput, false);
+    writeLane(dir, "bridge→runtime", bridgeOutput, true);
+    // The old child advanced after a 50ms sleep. Keep the bridge response
+    // pending long enough for that notification to overtake it deterministically.
+    writeFileSync(
+      bridgePath,
+      [
+        "import { spawn } from 'node:child_process';",
+        "import { createInterface } from 'node:readline';",
+        `const event = ${JSON.stringify(event)};`,
+        "const provider = spawn(process.env.REPLAY_PROVIDER_COMMAND, [], { stdio: ['pipe', 'pipe', 'inherit'] });",
+        "let pendingRuntimeId = null;",
+        "const send = (message) => process.stdout.write(JSON.stringify(message) + '\\n');",
+        "createInterface({ input: provider.stdout, terminal: false }).on('line', (line) => {",
+        "  const message = JSON.parse(line);",
+        "  if (message.id !== undefined && message.method === undefined) {",
+        "    setTimeout(() => send({ jsonrpc: '2.0', id: pendingRuntimeId, result: {} }), 250);",
+        "    return;",
+        "  }",
+        "  send({ jsonrpc: '2.0', method: 'thread/delta', params: { events: [event] } });",
+        "});",
+        "createInterface({ input: process.stdin, terminal: false }).on('line', (line) => {",
+        "  const message = JSON.parse(line);",
+        "  if (message.method === 'initialize') {",
+        "    send({ jsonrpc: '2.0', id: message.id, result: {} });",
+        "    return;",
+        "  }",
+        "  pendingRuntimeId = message.id;",
+        "  provider.stdin.write(JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} }) + '\\n');",
+        "});",
+        "process.stdin.on('end', () => provider.stdin.end());",
+        "provider.on('exit', () => process.exit(0));",
+        "",
+      ].join("\n"),
+    );
+
+    const run = await replayRecording({
+      recordingDir: dir,
+      providerId: "test-provider",
+      bridge: {
+        command: process.execPath,
+        args: [bridgePath],
+        cwd: dir,
+        env: {},
+      },
+      profile: {
+        dialect: "json-rpc",
+        env: ({ wrapperPath }) => ({ REPLAY_PROVIDER_COMMAND: wrapperPath }),
+      },
+      createAssembler: () => ({
+        assembleMessage: (message) => {
+          const params = message.params;
+          if (
+            typeof params !== "object" ||
+            params === null ||
+            !("events" in params)
+          ) {
+            return [];
+          }
+          return threadEventSchema.array().parse(params.events);
+        },
+      }),
+      planFromCurrentLane: true,
+      settleMs: 20,
+      timeoutMs: 2_000,
+    });
+
+    const runtimeResponseIndex = run.lines.indexOf(runtimeResponse);
+    const notificationIndex = run.lines.indexOf(delta);
+    expect(run.stalls).toEqual([]);
+    expect(run.events).toEqual([event]);
+    expect(runtimeResponseIndex).toBeGreaterThan(-1);
+    expect(notificationIndex).toBeGreaterThan(runtimeResponseIndex);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/packages/provider-bridge-protocol/src/testing/parity.ts
+++ b/packages/provider-bridge-protocol/src/testing/parity.ts
@@ -27,7 +27,7 @@
  * injected.
  */
 import { spawn, type ChildProcess } from "node:child_process";
-import { existsSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -472,6 +472,8 @@ export async function replayRecording(options: ReplayRecordingOptions): Promise<
   const recording = readBridgeRecording(options.recordingDir);
 
   const stateDir = mkdtempSync(join(tmpdir(), "bb-parity-replay-"));
+  const runtimeResponseDir = join(stateDir, "runtime-responses");
+  mkdirSync(runtimeResponseDir);
   // The replayed session's workspace: the recording's cwd belongs to the
   // machine that recorded it, and nothing in a replay runs real commands.
   // Resolved to its real path: macOS's `tmpdir()` is a symlink, and the Agent
@@ -559,6 +561,7 @@ export async function replayRecording(options: ReplayRecordingOptions): Promise<
     : null;
 
   const answeredIds = new Set<string>();
+  const runtimeResponseCounts = new Map<string, number>();
   const pendingBridgeRequests: { id: string | number; method: string }[] = [];
   /** Recorded runtime responses to bridge requests, queued per method. */
   const recordedAnswers = new Map<string, ParsedWireMessage[]>();
@@ -616,7 +619,12 @@ export async function replayRecording(options: ReplayRecordingOptions): Promise<
       const message = parseWire(line);
       if (message === null) return;
       if (isResponse(message)) {
-        answeredIds.add(String(message.id));
+        const responseId = String(message.id);
+        answeredIds.add(responseId);
+        const occurrence = (runtimeResponseCounts.get(responseId) ?? 0) + 1;
+        runtimeResponseCounts.set(responseId, occurrence);
+        const marker = `${Buffer.from(responseId, "utf8").toString("hex")}-${occurrence}`;
+        writeFileSync(join(runtimeResponseDir, marker), "");
         return;
       }
       if (isRequest(message)) {

--- a/packages/provider-bridge-protocol/src/testing/replay-provider-child.mjs
+++ b/packages/provider-bridge-protocol/src/testing/replay-provider-child.mjs
@@ -49,20 +49,9 @@ const LOOKAHEAD_MS = 750;
 const CURSOR_POLL_MS = 5;
 /**
  * Gap between two emitted provider lines. A real provider never delivers a
- * response and the notification after it in one read; the bridge's response
- * handlers (which emit the steer's ack, say) must get the event loop between
- * them, or the replay reorders what the recording had in order.
+ * response and the notification after it in one read.
  */
 const EMIT_GAP_MS = 2;
-/**
- * Gap after a response. The bridge continues its request's continuation in
- * a microtask once the line loop yields; a notification read in the same
- * chunk is handled first, so under load two milliseconds let a steer's ack
- * (emitted after `await request("turn/steer")`) land after the next
- * notification instead of before it, as the recording had it. A response
- * is rare, so the longer gap costs nothing measurable.
- */
-const RESPONSE_GAP_MS = 50;
 /** A request that opens or addresses a provider session; see segment release. */
 const SESSION_DEFINING_KEY =
   /^(thread|session)\/(start|resume|fork|new|load|archive|unarchive|name\/set)$/;
@@ -250,6 +239,55 @@ function buildSegments(entries, dialect) {
   return segments;
 }
 
+/**
+ * Runtime responses recorded between a provider response and the next
+ * provider-originated line. The fake provider must not advance across those
+ * observable bridge outputs: the four-lane recording fixed their wire order.
+ */
+function runtimeResponseGates(script, entries) {
+  const occurrences = new Map();
+  const runtimeResponses = [];
+  for (const entry of entries) {
+    const message = parseLine(entry.line);
+    if (
+      message === null ||
+      (typeof message.id !== "string" && typeof message.id !== "number") ||
+      message.method !== undefined
+    ) {
+      continue;
+    }
+    const id = String(message.id);
+    const occurrence = (occurrences.get(id) ?? 0) + 1;
+    occurrences.set(id, occurrence);
+    runtimeResponses.push({
+      ...entry,
+      marker: `${Buffer.from(id, "utf8").toString("hex")}-${occurrence}`,
+    });
+  }
+
+  const gates = new Map();
+  for (let position = 0; position < script.length; position += 1) {
+    const step = script[position];
+    if (step.dir !== "provider→bridge" || step.classified.kind !== "response") {
+      continue;
+    }
+    const nextProvider = script
+      .slice(position + 1)
+      .find((candidate) => candidate.dir === "provider→bridge");
+    if (nextProvider === undefined || nextProvider.run !== step.run) continue;
+    const markers = runtimeResponses
+      .filter(
+        (response) =>
+          response.run === step.run &&
+          response.seq > step.seq &&
+          response.seq < nextProvider.seq,
+      )
+      .map((response) => response.marker);
+    if (markers.length > 0) gates.set(position, markers);
+  }
+  return gates;
+}
+
 function claimSegmentIndex(stateDir) {
   mkdirSync(stateDir, { recursive: true });
   for (let index = 0; index < 10_000; index += 1) {
@@ -381,6 +419,11 @@ function main() {
   let cursorWait = null;
 
   let position = 0;
+  const responseGates = runtimeResponseGates(
+    script,
+    readLane(args.recording, "bridge→runtime"),
+  );
+  let pendingRuntimeResponseMarkers = [];
   const pendingLive = [];
   /** recorded bridge request id → live bridge request id */
   const liveIdByRecordedId = new Map();
@@ -453,6 +496,23 @@ function main() {
       // A line just went out; the next one waits its gap.
       return;
     }
+    if (pendingRuntimeResponseMarkers.length > 0) {
+      const responseDir = join(args.state, "runtime-responses");
+      if (
+        pendingRuntimeResponseMarkers.some(
+          (marker) => !existsSync(join(responseDir, marker)),
+        )
+      ) {
+        if (cursorWait === null) {
+          cursorWait = setTimeout(() => {
+            cursorWait = null;
+            advance();
+          }, CURSOR_POLL_MS);
+        }
+        return;
+      }
+      pendingRuntimeResponseMarkers = [];
+    }
     while (position < script.length) {
       const step = script[position];
       if (step.dir === "provider→bridge") {
@@ -489,10 +549,9 @@ function main() {
           }
         }
         emitRecorded(step);
+        pendingRuntimeResponseMarkers = responseGates.get(position) ?? [];
         position += 1;
-        scheduleAdvance(
-          step.classified.kind === "response" ? RESPONSE_GAP_MS : EMIT_GAP_MS,
-        );
+        scheduleAdvance();
         return;
       }
       // An expectation of what the bridge writes.


### PR DESCRIPTION
## Human comments

## What was wrong

The replay provider child used a fixed 50 ms delay after a provider response as a proxy for an ordering boundary. Under package-shard CPU contention, the child could advance to the next provider notification before the Codex bridge resumed its turn/steer continuation and emitted input.accepted. That reordered the identical creq_sqcjrsq4n7 acceptance event and everything after it even though the recorded four-lane wire order was fixed. This is the signature from [main run 33122014881](https://github.com/get-bb/bb/actions/runs/33122014881) and [packages job 98690932357](https://github.com/get-bb/bb/actions/runs/33122014881/job/98690932357). The mandatory clean merge-base was independently verified as 3d57259ab032301d08c1cd9a7e3562f659ac1b3e.

## What changed

- Record an occurrence-scoped marker whenever the replay harness observes a runtime response from the bridge. Occurrence scope preserves repeated JSON-RPC ids across recorded bridge runs.
- Derive response gates from the original four-lane recording. When a runtime response was recorded between a provider response and the next provider-originated line, the fake provider now waits for that observable marker instead of sleeping.
- Remove the 50 ms response gap and add a focused delayed-bridge regression that proves the notification cannot overtake the recorded runtime response.

This changes only the parity test harness. It does not change server/daemon wire behavior, so HOST_DAEMON_PROTOCOL_VERSION is unchanged. No timeout, polling deadline, retry budget, or wrapper limit was increased.

## How you verified

- Before the fix, a controlled 100 ms delay after the Codex turn/steer provider response made the exact codex/compaction parity cell fail in 5.06 s with the same first diff: turn/input/accepted for creq_sqcjrsq4n7 moved, followed by the large row divergence. The focused regression also failed with the provider notification at output index 1 and the runtime response at index 2.
- After the fix, that focused regression passes, and the same controlled delayed-continuation exact cell passes in 4.77 s.
- Eight consecutive exact codex/compaction replays passed with 16 CPU-bound peer processes; cleanup was trapped for every run.
- pnpm exec turbo run test --filter=@bb/provider-bridge-protocol --filter=@bb/provider-parity --force — 239 protocol tests and 56 provider-parity tests passed.
- pnpm exec turbo run typecheck --filter=@bb/provider-bridge-protocol --filter=@bb/provider-parity — passed.
- pnpm exec turbo run build --filter=@get-bb/plugin-sdk — built all 17 runtime entries and bundled provider-bridge-testing declarations.
- git diff --check — passed.

> AGENT GENERATED: by GPT-5.6-Sol