### PR TITLE
Use Zap icon for native Claude Skill calls

### DIFF
--- a/apps/app/src/components/thread/timeline/rows/Tool.stories.tsx
+++ b/apps/app/src/components/thread/timeline/rows/Tool.stories.tsx
@@ -36,6 +36,26 @@ const toolSearchTool: TimelineRow = toolRow({
   durationMs: 105,
 });
 
+const nativeSkillTool: TimelineRow = toolRow({
+  id: "thr_skill_native:tool:toolu_skill_native",
+  threadId: "thr_skill_native",
+  turnId: "turn_skill_native_1",
+  sourceSeqStart: 1,
+  sourceSeqEnd: 2,
+  status: "completed",
+  callId: "toolu_skill_native",
+  toolName: "Skill",
+  toolArgs: { skill: "visual-qa-loop" },
+  output: "Skill loaded",
+  approvalStatus: null,
+  durationMs: 120,
+  presentation: {
+    label: { pending: "Loading skill", completed: "Loaded skill" },
+    icon: { glyph: "Zap" },
+    title: "visual-qa-loop",
+  },
+});
+
 const longOutputTool: TimelineRow = toolRow({
   id: "thr_tool_long_output:tool:toolu_long_output",
   threadId: "thr_tool_long_output",
@@ -432,6 +452,21 @@ export function SkillReads() {
           </TimelineStage>
         </StoryRow>
       ))}
+    </StoryCard>
+  );
+}
+
+export function NativeSkillCall() {
+  return (
+    <StoryCard>
+      <StoryRow
+        label="Claude native Skill call"
+        hint="provider presentation uses the established lightning glyph"
+      >
+        <TimelineStage>
+          <ThreadTimelineRows {...baseProps} timelineRows={[nativeSkillTool]} />
+        </TimelineStage>
+      </StoryRow>
     </StoryCard>
   );
 }

--- a/plugins/provider-claude-code/src/presentation.test.ts
+++ b/plugins/provider-claude-code/src/presentation.test.ts
@@ -371,6 +371,19 @@ describe("claude item presentation", () => {
     });
   });
 
+  it("uses the established skill glyph for native Skill calls", () => {
+    const harness = createClaudeDeltaHarness();
+    const events = harness.translate(
+      toolUse("skill-1", "Skill", { skill: "debugging" }),
+    );
+
+    expect(presentationOf(startedItems(events)[0])).toEqual({
+      label: { pending: "Loading skill", completed: "Loaded skill" },
+      icon: { glyph: "Zap" },
+      title: "debugging",
+    });
+  });
+
   it("maps MultiEdit and NotebookEdit to file changes with their own verbs", () => {
     const harness = createClaudeDeltaHarness();
     const events = harness.translate({

--- a/plugins/provider-claude-code/src/presentation.ts
+++ b/plugins/provider-claude-code/src/presentation.ts
@@ -167,7 +167,7 @@ const BUILTIN_TOOL_PRESENTATIONS: Readonly<
   },
   Skill: {
     label: { pending: "Loading skill", completed: "Loaded skill" },
-    glyph: "Puzzle",
+    glyph: "Zap",
     titleField: "skill",
   },
   StructuredOutput: {


### PR DESCRIPTION
## Human comments

## What was wrong

Native Claude `Skill` calls used the generic plugin Puzzle glyph instead of bb’s established skill glyph.

## What changed

Maps native Claude `Skill` calls to the Zap glyph and adds focused provider and story coverage.

### Before — parent `main` at `93643a53`

Native Claude Skill calls use the generic Puzzle glyph.

![Before — native Skill call with Puzzle icon](https://raw.githubusercontent.com/brsbl/bb/a8df5aae7c5fb670a9ba5b3e13c600650d1c7e74/2609-skill-before.png)

### After — PR head `d8a06e53`

The same row uses the established Zap skill glyph.

![After — native Skill call with Zap icon](https://raw.githubusercontent.com/brsbl/bb/a8df5aae7c5fb670a9ba5b3e13c600650d1c7e74/2609-skill-after.png)

## How you verified

- Exact parent/head Ladle states rendered in Chrome for Testing 149.0.7827.55.
- The focused provider presentation test and app story coverage pass in remote CI.
- All required CI checks are green.

## Fixes

No linked GitHub issue; addresses the reported icon regression.

BB-Thread-ID: thr_fdabesxhdr

> AGENT GENERATED