### PR TITLE
Keep composer metadata stable on hover

### DIFF
--- a/apps/app/src/components/sidebar/AppSidebar.tsx
+++ b/apps/app/src/components/sidebar/AppSidebar.tsx
@@ -243,9 +243,6 @@ export function AppSidebar({
         splitEnabled
         toolsRoutePath={toolsRoutePath}
       />
-      <div className="relative z-10 shrink-0 group-data-[collapsible=icon]:hidden">
-        <OverflowFade placement="below" tone="sidebar" size="sm" />
-      </div>
       <SidebarContent>
         <PluginThreadList
           replacement={threadListReplacement}

--- a/apps/app/src/components/sidebar/AppSidebar.tsx
+++ b/apps/app/src/components/sidebar/AppSidebar.tsx
@@ -243,6 +243,9 @@ export function AppSidebar({
         splitEnabled
         toolsRoutePath={toolsRoutePath}
       />
+      <div className="relative z-10 shrink-0 group-data-[collapsible=icon]:hidden">
+        <OverflowFade placement="below" tone="sidebar" size="sm" />
+      </div>
       <SidebarContent>
         <PluginThreadList
           replacement={threadListReplacement}

--- a/packages/shared-ui/src/components/ui/option-display.tsx
+++ b/packages/shared-ui/src/components/ui/option-display.tsx
@@ -9,7 +9,7 @@ export const OPTION_CONTENT_CLASS_NAME = "flex min-w-0 items-center gap-1.5";
 export const OPTION_TRIGGER_CONTENT_CLASS_NAME = "contents";
 export const OPTION_MENU_CONTENT_CLASS_NAME = "w-max min-w-0 max-w-96";
 export const OPTION_MUTED_CLASS_NAME =
-  "text-muted-foreground hover:text-foreground";
+  "text-muted-foreground hover:text-muted-foreground";
 
 export interface OptionDisplayProps {
   label: string;


### PR DESCRIPTION
## Human comments

## What was wrong

Muted project, environment, and model controls changed foreground treatment on hover, creating a subtle visual jump in the composer metadata row.

## What changed

Keeps the muted foreground token stable across hover while preserving the existing interactive background treatment.

### Before hover

The composer metadata row is settled in its resting geometry.

![Before hover — settled composer metadata](https://raw.githubusercontent.com/brsbl/bb/a8df5aae7c5fb670a9ba5b3e13c600650d1c7e74/2611-hover-before.png)

### After hover

Hovering the model control preserves the row geometry while exposing its normal interactive treatment.

![After hover — stable composer metadata geometry](https://raw.githubusercontent.com/brsbl/bb/a8df5aae7c5fb670a9ba5b3e13c600650d1c7e74/2611-hover-after.png)

## How you verified

- Chrome for Testing 149.0.7827.55 exercised project, environment, and model controls in the real composer.
- Element bounds remained unchanged across rest and hover; only the intended interactive background changed.
- All required CI checks are green.

## Fixes

No linked GitHub issue; addresses the reported hover regression.

BB-Thread-ID: thr_fdabesxhdr

> AGENT GENERATED