### PR TITLE
Shorten worktree thread action copy

### DIFF
--- a/apps/app/src/components/promptbox/ThreadEnvironmentSummary.test.tsx
+++ b/apps/app/src/components/promptbox/ThreadEnvironmentSummary.test.tsx
@@ -34,12 +34,12 @@ describe("ThreadEnvironmentSummary", () => {
 
     fireEvent.focus(
       screen.getByRole("button", {
-        name: "Create new thread in this worktree",
+        name: "Create thread in worktree",
       }),
     );
 
     expect((await screen.findByRole("tooltip")).textContent).toBe(
-      "Create new thread in this worktree",
+      "Create thread in worktree",
     );
   });
 });

--- a/apps/app/src/components/promptbox/ThreadEnvironmentSummary.tsx
+++ b/apps/app/src/components/promptbox/ThreadEnvironmentSummary.tsx
@@ -90,14 +90,14 @@ export const ThreadEnvironmentSummary = memo(function ThreadEnvironmentSummary({
           <TooltipTrigger asChild>
             <button
               type="button"
-              aria-label="Create new thread in this worktree"
+              aria-label="Create thread in worktree"
               onClick={onCreateNewThreadInWorktree}
               className="-ml-1 inline-flex cursor-pointer shrink-0 items-center justify-center rounded-md px-1 py-0.5 text-muted-foreground transition-colors hover:bg-state-hover hover:text-foreground"
             >
               <Icon name="MessageSquarePlus" className="size-4" />
             </button>
           </TooltipTrigger>
-          <TooltipContent>Create new thread in this worktree</TooltipContent>
+          <TooltipContent>Create thread in worktree</TooltipContent>
         </Tooltip>
       ) : null}
     </div>

--- a/apps/app/src/components/secondary-panel/ThreadMetadataContent.test.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadMetadataContent.test.tsx
@@ -118,7 +118,7 @@ describe("ThreadMetadataCard", () => {
 describe("EnvironmentRow", () => {
   it("shows the create-thread action for a provisioned worktree", () => {
     expect(renderEnvironmentRow(makeEnvironment())).toContain(
-      'aria-label="Create new thread in this worktree"',
+      'aria-label="Create thread in worktree"',
     );
   });
 
@@ -137,12 +137,12 @@ describe("EnvironmentRow", () => {
 
     fireEvent.focus(
       screen.getByRole("button", {
-        name: "Create new thread in this worktree",
+        name: "Create thread in worktree",
       }),
     );
 
     expect((await screen.findByRole("tooltip")).textContent).toBe(
-      "Create new thread in this worktree",
+      "Create thread in worktree",
     );
   });
 
@@ -155,9 +155,7 @@ describe("EnvironmentRow", () => {
       }),
     );
 
-    expect(markup).not.toContain(
-      'aria-label="Create new thread in this worktree"',
-    );
+    expect(markup).not.toContain('aria-label="Create thread in worktree"');
   });
 
   it("hides the create-thread action before a prepared worktree has a path", () => {
@@ -168,9 +166,7 @@ describe("EnvironmentRow", () => {
       }),
     );
 
-    expect(markup).not.toContain(
-      'aria-label="Create new thread in this worktree"',
-    );
+    expect(markup).not.toContain('aria-label="Create thread in worktree"');
   });
 });
 

--- a/apps/app/src/components/secondary-panel/ThreadMetadataContent.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadMetadataContent.tsx
@@ -337,14 +337,14 @@ export function EnvironmentRow({
             <TooltipTrigger asChild>
               <button
                 type="button"
-                aria-label="Create new thread in this worktree"
+                aria-label="Create thread in worktree"
                 onClick={createThreadInWorktree}
                 className="inline-flex shrink-0 items-center justify-center rounded-md p-0.5 text-muted-foreground transition-colors hover:bg-state-hover hover:text-foreground"
               >
                 <Icon name="MessageSquarePlus" className="size-4" />
               </button>
             </TooltipTrigger>
-            <TooltipContent>Create new thread in this worktree</TooltipContent>
+            <TooltipContent>Create thread in worktree</TooltipContent>
           </Tooltip>
         ) : null}
       </span>


### PR DESCRIPTION
## Human comments

## What was wrong

The worktree action tooltip said “Create new thread in this worktree,” which was longer than needed and inconsistent across the composer and metadata panel.

## What changed

Uses “Create thread in worktree” for the tooltip and accessible label in both surfaces.

### Before — parent head `a1b2d5c8`

![Before — verbose worktree action tooltip](https://raw.githubusercontent.com/brsbl/bb/a8df5aae7c5fb670a9ba5b3e13c600650d1c7e74/2612-tooltip-before.png)

### After — PR head `738b5606`

![After — concise worktree action tooltip](https://raw.githubusercontent.com/brsbl/bb/a8df5aae7c5fb670a9ba5b3e13c600650d1c7e74/2612-tooltip-after.png)

## How you verified

- The same isolated worktree thread and 1440×900 viewport were rendered against the exact parent and PR head in Chrome for Testing 149.0.7827.55.
- The composer action exposed the expected visible tooltip and matching accessible label on each revision.
- All required CI checks are green.

## Fixes

No linked GitHub issue; addresses the reported tooltip copy regression.

BB-Thread-ID: thr_fdabesxhdr

> AGENT GENERATED