### PR TITLE
Add managed worktree teardown hook

### DIFF
--- a/apps/host-daemon/src/command-dispatch.ts
+++ b/apps/host-daemon/src/command-dispatch.ts
@@ -471,6 +471,8 @@ const commandHandlers: CommandHandlerMap = {
     }),
   "environment.provision.cancel": cancelEnvironmentProvision,
   "environment.destroy": async (command, options) => {
+    const transcript: HostDaemonCommandResult<"environment.destroy">["transcript"] =
+      [];
     const resolution = await resolveWorkspaceForCommand({
       dataDir: options.dataDir,
       environmentId: command.environmentId,
@@ -479,7 +481,7 @@ const commandHandlers: CommandHandlerMap = {
     });
     if (!resolution.ok) {
       if (resolution.failure.code === "path_not_found") {
-        return {};
+        return { transcript };
       }
       throw new ExpectedCommandDispatchError(
         resolution.failure.code,
@@ -490,8 +492,11 @@ const commandHandlers: CommandHandlerMap = {
       environmentId: command.environmentId,
       reason: "environment-destroyed",
     });
-    await options.runtimeManager.destroyEnvironment(command.environmentId);
-    return {};
+    await options.runtimeManager.destroyEnvironment(command.environmentId, {
+      timeoutMs: command.teardownTimeoutMs,
+      onProgress: (entry) => transcript.push(entry),
+    });
+    return { transcript };
   },
   "workspace.commit": async (command, options) => {
     const entry = await requireResolvedWorkspaceForCommand({

--- a/apps/host-daemon/src/runtime-manager.test.ts
+++ b/apps/host-daemon/src/runtime-manager.test.ts
@@ -1784,7 +1784,7 @@ describe("RuntimeManager", () => {
       environmentId: "env-1",
       workspacePath: "/tmp/env-1",
     });
-    await manager.destroyEnvironment("env-1");
+    await manager.destroyEnvironment("env-1", { timeoutMs: 900000 });
 
     expect(runtime.shutdown).toHaveBeenCalledTimes(1);
     expect(workspace.destroy).toHaveBeenCalledTimes(1);
@@ -1831,7 +1831,7 @@ describe("RuntimeManager", () => {
       try {
         expect(isAlive(grandchildPid)).toBe(true);
 
-        await manager.destroyEnvironment("env-procs");
+        await manager.destroyEnvironment("env-procs", { timeoutMs: 900000 });
 
         expect(managedWorkspace.destroy).toHaveBeenCalledTimes(1);
         const deadline = Date.now() + 5000;

--- a/apps/host-daemon/src/runtime-manager.ts
+++ b/apps/host-daemon/src/runtime-manager.ts
@@ -31,6 +31,7 @@ import type {
 import {
   provisionWorkspace,
   WorkspaceError,
+  type DestroyWorkspaceArgs,
   type HostWorkspace,
   type ProvisionWorkspaceArgs,
 } from "@bb/host-workspace";
@@ -1089,7 +1090,10 @@ export class RuntimeManager {
     });
   }
 
-  async destroyEnvironment(environmentId: string): Promise<void> {
+  async destroyEnvironment(
+    environmentId: string,
+    args: DestroyWorkspaceArgs,
+  ): Promise<void> {
     const existing = this.entries.get(environmentId);
     const pending = this.pendingEntries.get(environmentId);
     const entry = existing ?? (pending ? await pending : undefined);
@@ -1102,7 +1106,7 @@ export class RuntimeManager {
     await this.stopWatchingStatus(entry);
     await entry.runtime.shutdown();
     await this.killManagedWorkspaceProcesses(entry);
-    await entry.workspace.destroy();
+    await entry.workspace.destroy(args);
     await this.cleanupUnusedInjectedSkillStagingDirs([]);
   }
 

--- a/apps/host-daemon/test/command/command-router.test.ts
+++ b/apps/host-daemon/test/command/command-router.test.ts
@@ -187,6 +187,7 @@ function createEnvironmentDestroyCommand(): EnvironmentDestroyCommand {
   return {
     type: "environment.destroy",
     environmentId: "env-router",
+    teardownTimeoutMs: 900000,
     workspaceContext: {
       workspacePath: "/tmp/env-router",
       workspaceProvisionType: "unmanaged",

--- a/apps/host-daemon/test/command/environment-dispatch.test.ts
+++ b/apps/host-daemon/test/command/environment-dispatch.test.ts
@@ -666,6 +666,7 @@ describe("environment command dispatch", () => {
       {
         type: "environment.destroy",
         environmentId: "env-1",
+        teardownTimeoutMs: 900000,
         workspaceContext: {
           workspacePath: "/tmp/env-1",
           workspaceProvisionType: "managed-worktree",
@@ -677,13 +678,54 @@ describe("environment command dispatch", () => {
       }),
     );
 
-    expect(result).toEqual({});
+    expect(result).toEqual({ transcript: [] });
     expect(closeEnvironmentTerminals).toHaveBeenCalledWith({
       environmentId: "env-1",
       reason: "environment-destroyed",
     });
     expect(harness.runtimeState.shutdownCount).toBe(1);
     expect(harness.workspaceState.destroyed).toBe(true);
+  });
+
+  it("returns the teardown transcript from environment.destroy", async () => {
+    const harness = createHarness();
+    await harness.manager.ensureEnvironment({
+      environmentId: "env-teardown",
+      workspacePath: "/tmp/env-1",
+    });
+    harness.workspace.destroy = async (args) => {
+      expect(args.timeoutMs).toBe(1234);
+      args.onProgress?.({
+        type: "step",
+        key: "teardown-completed",
+        text: ".bb-env-teardown.sh finished",
+        status: "completed",
+        startedAt: 100,
+      });
+    };
+
+    const result = await dispatchCommand(
+      {
+        type: "environment.destroy",
+        environmentId: "env-teardown",
+        teardownTimeoutMs: 1234,
+        workspaceContext: {
+          workspacePath: "/tmp/env-1",
+          workspaceProvisionType: "managed-worktree",
+        },
+      },
+      makeDispatchOptions({ runtimeManager: harness.manager }),
+    );
+
+    expect(result.transcript).toEqual([
+      {
+        type: "step",
+        key: "teardown-completed",
+        text: ".bb-env-teardown.sh finished",
+        status: "completed",
+        startedAt: 100,
+      },
+    ]);
   });
 
   it("waits for terminal closes before destroying an environment", async () => {
@@ -700,6 +742,7 @@ describe("environment command dispatch", () => {
       {
         type: "environment.destroy",
         environmentId: "env-1",
+        teardownTimeoutMs: 900000,
         workspaceContext: {
           workspacePath: "/tmp/env-1",
           workspaceProvisionType: "managed-worktree",
@@ -725,7 +768,7 @@ describe("environment command dispatch", () => {
     expect(harness.workspaceState.destroyed).toBe(false);
 
     terminalClose.resolve(undefined);
-    await expect(destroyPromise).resolves.toEqual({});
+    await expect(destroyPromise).resolves.toEqual({ transcript: [] });
     expect(destroyResolved).toBe(true);
     expect(harness.runtimeState.shutdownCount).toBe(1);
     expect(harness.workspaceState.destroyed).toBe(true);
@@ -771,6 +814,7 @@ describe("environment command dispatch", () => {
       {
         type: "environment.destroy",
         environmentId: "env-1",
+        teardownTimeoutMs: 900000,
         workspaceContext: {
           workspacePath: "/tmp/env-1",
           workspaceProvisionType: "managed-worktree",
@@ -807,6 +851,7 @@ describe("environment command dispatch", () => {
       {
         type: "environment.destroy",
         environmentId: "env-restart",
+        teardownTimeoutMs: 900000,
         workspaceContext: {
           workspacePath: "/tmp/env-1",
           workspaceProvisionType: "managed-worktree",
@@ -815,7 +860,7 @@ describe("environment command dispatch", () => {
       makeDispatchOptions({ runtimeManager: harness.manager }),
     );
 
-    expect(result).toEqual({});
+    expect(result).toEqual({ transcript: [] });
     expect(harness.workspaceState.destroyed).toBe(true);
     expect(harness.provisions).toEqual([
       {
@@ -848,6 +893,7 @@ describe("environment command dispatch", () => {
       {
         type: "environment.destroy",
         environmentId: "env-retry",
+        teardownTimeoutMs: 900000,
         workspaceContext: {
           workspacePath: "/tmp/env-retry",
           workspaceProvisionType: "managed-worktree",
@@ -860,6 +906,7 @@ describe("environment command dispatch", () => {
       {
         type: "environment.destroy",
         environmentId: "env-retry",
+        teardownTimeoutMs: 900000,
         workspaceContext: {
           workspacePath: "/tmp/env-retry",
           workspaceProvisionType: "managed-worktree",
@@ -868,6 +915,6 @@ describe("environment command dispatch", () => {
       makeDispatchOptions({ runtimeManager: manager }),
     );
 
-    expect(retryResult).toEqual({});
+    expect(retryResult).toEqual({ transcript: [] });
   });
 });

--- a/apps/server/src/services/environments/environment-cleanup-internal.ts
+++ b/apps/server/src/services/environments/environment-cleanup-internal.ts
@@ -67,6 +67,8 @@ type EnvironmentDestroyCommand =
 type EnvironmentDestroyCommandResultReport =
   CommandResultReportForType<"environment.destroy">;
 
+const TEARDOWN_TIMEOUT_MS = 15 * 60 * 1000;
+
 interface SettleEnvironmentDestroyCommandResultArgs {
   command: EnvironmentDestroyCommand;
   deps: EnvironmentCleanupSettlementDeps;
@@ -252,6 +254,7 @@ function dispatchEnvironmentDestroy(
       type: "environment.destroy",
       environmentId: environment.id,
       workspaceContext: workspaceContextFromPath(environment),
+      teardownTimeoutMs: TEARDOWN_TIMEOUT_MS,
     },
     execution,
     hostId: environment.hostId,

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
@@ -31,11 +31,11 @@ message agents, or inspect projects, providers, and environments.
   the colocated daemon still use loopback. This opt-in is IPv4-only. Containers
   must also publish the port to the host.
 
-## Environment Setup Script
+## Environment Setup And Teardown Scripts
 
 - To make a repo work with bb worktrees, run `bb guide environments`. It
-  documents the repo-level `.bb-env-setup.sh` setup hook and the
-  `.worktreeinclude` file.
+  documents the repo-level `.bb-env-setup.sh` and `.bb-env-teardown.sh` hooks,
+  and the `.worktreeinclude` file.
 - A new worktree checks out tracked files only. Commit a `.worktreeinclude`
   file at the repo root to list untracked files, such as `.env`, that bb must
   copy from the source checkout. It uses gitignore pattern syntax. bb copies

--- a/apps/server/test/environments/environment-cleanup.test.ts
+++ b/apps/server/test/environments/environment-cleanup.test.ts
@@ -48,6 +48,9 @@ describe("environment cleanup", () => {
           command.type === "environment.destroy" &&
           command.environmentId === environment.id,
       );
+      expect(destroyCommand.command).toMatchObject({
+        teardownTimeoutMs: 900000,
+      });
       const destroyingEnvironment = getEnvironment(harness.db, environment.id);
       expect(destroyingEnvironment).toMatchObject({
         destroyAttemptId: expect.any(String),
@@ -73,7 +76,9 @@ describe("environment cleanup", () => {
         status: "destroying",
       });
 
-      await reportQueuedCommandSuccess(harness, destroyCommand, {});
+      await reportQueuedCommandSuccess(harness, destroyCommand, {
+        transcript: [],
+      });
       expect(getEnvironment(harness.db, environment.id)).toMatchObject({
         status: "destroyed",
       });

--- a/apps/server/test/services/managed-environment-cleanup-recovery.test.ts
+++ b/apps/server/test/services/managed-environment-cleanup-recovery.test.ts
@@ -69,6 +69,7 @@ describe("managed environment cleanup recovery sweep", () => {
           command: {
             type: "environment.destroy",
             environmentId: environment.id,
+            teardownTimeoutMs: 900000,
             workspaceContext: {
               workspacePath: "/tmp/in-flight-destroying-environment",
               workspaceProvisionType: "managed-worktree",
@@ -84,7 +85,7 @@ describe("managed environment cleanup recovery sweep", () => {
             completedAt: Date.now(),
             executionId: "rpc-in-flight-destroying",
             ok: true,
-            result: {},
+            result: { transcript: [] },
             type: "environment.destroy",
           },
         });
@@ -133,6 +134,7 @@ describe("managed environment cleanup recovery sweep", () => {
           command: {
             type: "environment.destroy",
             environmentId: environment.id,
+            teardownTimeoutMs: 900000,
             workspaceContext: {
               workspacePath,
               workspaceProvisionType: "managed-worktree",
@@ -148,7 +150,7 @@ describe("managed environment cleanup recovery sweep", () => {
             completedAt: Date.now(),
             executionId: "rpc-late-success",
             ok: true,
-            result: {},
+            result: { transcript: [] },
             type: "environment.destroy",
           },
         });
@@ -195,6 +197,7 @@ describe("managed environment cleanup recovery sweep", () => {
           command: {
             type: "environment.destroy",
             environmentId: environment.id,
+            teardownTimeoutMs: 900000,
             workspaceContext: {
               workspacePath,
               workspaceProvisionType: "managed-worktree",
@@ -271,6 +274,7 @@ describe("managed environment cleanup recovery sweep", () => {
           command: {
             type: "environment.destroy",
             environmentId: environment.id,
+            teardownTimeoutMs: 900000,
             workspaceContext: {
               workspacePath,
               workspaceProvisionType: "managed-worktree",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,6 +24,14 @@ npx bb-app env list
 npx bb-app env unset OPENAI_API_KEY
 ```
 
+## Repository worktree hooks
+
+Commit `.bb-env-setup.sh` when a managed worktree needs repository setup.
+Commit `.bb-env-teardown.sh` when bb must release external resources before it
+removes that worktree. See [Worktrees, setup scripts, and teardown
+scripts](worktrees.md) for the lifecycle, environment, timeout, and failure
+contracts.
+
 `bb-app config list` shows non-secret values. `bb-app env list` redacts every
 value and only shows whether a key is set.
 

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -172,6 +172,7 @@ rebuild the native dependency, for example `npm rebuild better-sqlite3`.
 ## Setup Hook Policy
 
 - The supported setup hook is POSIX `.bb-env-setup.sh`.
+- The supported teardown hook is POSIX `.bb-env-teardown.sh`.
 - The same shell-based hook contract is used across macOS, Linux, and WSL2.
 - No parallel `.bb-env-setup.ts` product-path mechanism is supported.
 - The `.worktreeinclude` copy step runs no shell. It works on every platform,

--- a/docs/worktrees.md
+++ b/docs/worktrees.md
@@ -1,4 +1,4 @@
-# Worktrees and setup scripts
+# Worktrees, setup scripts, and teardown scripts
 
 When you start a thread in bb, you can run it in your project's existing
 checkout or in a fresh **managed worktree** — a separate working copy on disk
@@ -10,6 +10,8 @@ You can pair a worktree with a **`.worktreeinclude` file** that lists the local
 files each new worktree needs, and with a **setup script** that bb runs the
 first time the worktree is created — useful for installing dependencies,
 generating secrets, or anything else you need before the agent starts.
+You can also add a **teardown script** that releases resources outside the
+worktree before bb removes it.
 
 ## What is a managed worktree?
 
@@ -123,6 +125,33 @@ an editor terminal. Each process gets `SIGTERM`, then `SIGKILL` after a
 short grace period. Move your own shells out of the worktree before you
 delete the environment if you want to keep them.
 
+## Run teardown with `.bb-env-teardown.sh`
+
+Commit a file named `.bb-env-teardown.sh` at the project root when setup
+creates resources outside the worktree. For example, the script can remove a
+database, a proxy registration, a container, or a port reservation.
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+docker rm -f "my-project-${USER}"
+```
+
+Contract:
+
+- bb runs the script only when it destroys a managed worktree.
+- bb runs `env bash .bb-env-teardown.sh` from the worktree before it removes
+  the worktree, so the script can read tracked and generated files.
+- stdin is closed. bb records stdout and stderr in the environment destroy
+  transcript.
+- The script gets a separate 15-minute timeout.
+- A non-zero exit, a signal, or a timeout reports a failure. It never stops bb
+  from removing the worktree.
+- The script receives the same sanitized environment as the setup script.
+- POSIX only — supported on macOS, Linux, and WSL2. Native Windows isn't
+  supported.
+
 ## If something isn't working
 
 A few quick checks:
@@ -138,3 +167,5 @@ A few quick checks:
    prompts for input will time out at 15 minutes.
 4. Run `bash .bb-env-setup.sh` manually in a clean clone to verify it works
    outside bb before debugging through the provisioning transcript.
+5. Run `bash .bb-env-teardown.sh` manually before you delete a test worktree.
+   Confirm that repeated runs do not fail or remove shared resources.

--- a/packages/bb-app/README.md
+++ b/packages/bb-app/README.md
@@ -232,4 +232,4 @@ behavior, see the
 - [Platform support](https://github.com/get-bb/bb/blob/main/docs/platform-support.md)
 - [Configuration](https://github.com/get-bb/bb/blob/main/docs/configuration.md)
 - [Using bb on multiple devices](https://github.com/get-bb/bb/blob/main/docs/multiple-devices.md)
-- [Worktrees and setup scripts](https://github.com/get-bb/bb/blob/main/docs/worktrees.md)
+- [Worktree setup and teardown scripts](https://github.com/get-bb/bb/blob/main/docs/worktrees.md)

--- a/packages/domain/src/setup-script.ts
+++ b/packages/domain/src/setup-script.ts
@@ -1,3 +1,4 @@
 export const DEFAULT_ENV_SETUP_SCRIPT_NAME = ".bb-env-setup.sh";
+export const DEFAULT_ENV_TEARDOWN_SCRIPT_NAME = ".bb-env-teardown.sh";
 
 export const WORKTREE_INCLUDE_FILE_NAME = ".worktreeinclude";

--- a/packages/host-daemon-contract/src/commands.ts
+++ b/packages/host-daemon-contract/src/commands.ts
@@ -897,6 +897,8 @@ const environmentProvisionCancelCommandSchema =
 const environmentDestroyCommandSchema = hostDaemonWorkspaceTargetSchema
   .extend({
     type: z.literal("environment.destroy"),
+    /** Maximum time in ms to wait for the teardown script. */
+    teardownTimeoutMs: z.number().int().positive(),
   })
   .strict();
 
@@ -1213,6 +1215,11 @@ const environmentProvisionResultSchema =
 const environmentProvisionCancelResultSchema = z.object({
   aborted: z.boolean(),
 });
+const environmentDestroyResultSchema = z
+  .object({
+    transcript: z.array(provisioningTranscriptEntrySchema),
+  })
+  .strict();
 const workspaceCommitResultSchema = z.object({
   commitSha: z.string().min(1),
   commitSubject: z.string().min(1),
@@ -1425,7 +1432,7 @@ export const hostDaemonCommandRegistry = {
   "environment.destroy": defineHostDaemonCommandDescriptor({
     type: "environment.destroy",
     schema: environmentDestroyCommandSchema,
-    resultSchema: emptyCommandResultSchema,
+    resultSchema: environmentDestroyResultSchema,
     transport: "settled",
     retryable: false,
     flushEventsBeforeResult: false,

--- a/packages/host-daemon-contract/src/protocol.ts
+++ b/packages/host-daemon-contract/src/protocol.ts
@@ -1,3 +1,3 @@
-export const HOST_DAEMON_PROTOCOL_VERSION = 172 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 173 as const;
 
 export const HOST_ARTIFACT_MAX_BYTES = 256 * 1024 * 1024;

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -486,7 +486,9 @@ const SETTLED_RESPONSE_RESULT_FIXTURES: SettledResponseResultFixtures = {
     path: "/home/me/.bb/checkouts/project",
     gitRemoteUrl: "git@example.com:me/project.git",
   },
-  "environment.destroy": {},
+  "environment.destroy": {
+    transcript: [],
+  },
   "workspace.commit": {
     commitSha: "abcdef123456",
     commitSubject: "Checkpoint work",
@@ -941,7 +943,7 @@ const ACP_BRIDGE_LAUNCH = {
 
 describe("host-daemon command schemas", () => {
   it("uses the current host-daemon protocol version", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(172);
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(173);
     expect(HOST_ARTIFACT_MAX_BYTES).toBe(256 * 1024 * 1024);
   });
 

--- a/packages/host-workspace/src/index.ts
+++ b/packages/host-workspace/src/index.ts
@@ -3,7 +3,11 @@ export {
   provisionWorkspace,
   validatePersonalWorkspaceTargetPath,
 } from "./provision.js";
-export type { HostWorkspace, ProvisionWorkspaceArgs } from "./provision.js";
+export type {
+  DestroyWorkspaceArgs,
+  HostWorkspace,
+  ProvisionWorkspaceArgs,
+} from "./provision.js";
 
 export type { PullRequestActionOptions } from "./workspace.js";
 export type { GitHostCliOptions } from "./git-host.js";

--- a/packages/host-workspace/src/provision.ts
+++ b/packages/host-workspace/src/provision.ts
@@ -47,6 +47,12 @@ import { resolveAdditionalWorkspaceWriteRoots } from "./workspace-write-roots.js
 
 type ProvisionProgressCallback = (entry: ProvisioningTranscriptEntry) => void;
 
+export interface DestroyWorkspaceArgs {
+  /** Teardown script timeout in ms. Controlled by the server. */
+  timeoutMs: number;
+  onProgress?: ProvisionProgressCallback;
+}
+
 interface ProvisionBase {
   onProgress?: ProvisionProgressCallback;
   shellPath?: string;
@@ -137,7 +143,7 @@ export interface HostWorkspace {
   reset(): Promise<void>;
   squashMerge(options: SquashMergeOptions): Promise<SquashMergeResult>;
 
-  destroy(): Promise<void>;
+  destroy(args: DestroyWorkspaceArgs): Promise<void>;
 }
 
 async function detectWorktree(
@@ -163,7 +169,7 @@ class ProvisionedHostWorkspace implements HostWorkspace {
 
   private readonly ws: Workspace;
   private readonly gitProcessOptions: GitProcessOptions;
-  private readonly destroyFn: () => Promise<void>;
+  private readonly destroyFn: (args: DestroyWorkspaceArgs) => Promise<void>;
 
   constructor(opts: {
     path: string;
@@ -171,7 +177,7 @@ class ProvisionedHostWorkspace implements HostWorkspace {
     isGitRepo: boolean;
     isWorktree: boolean;
     shellPath?: string;
-    destroyFn: () => Promise<void>;
+    destroyFn: (args: DestroyWorkspaceArgs) => Promise<void>;
   }) {
     this.path = opts.path;
     this.managed = opts.managed;
@@ -267,8 +273,8 @@ class ProvisionedHostWorkspace implements HostWorkspace {
     return this.ws.squashMergeInto(options);
   }
 
-  destroy(): Promise<void> {
-    return this.destroyFn();
+  destroy(args: DestroyWorkspaceArgs): Promise<void> {
+    return this.destroyFn(args);
   }
 }
 
@@ -678,12 +684,16 @@ async function provisionWorktree(
     isGitRepo: true,
     isWorktree: true,
     shellPath: opts.shellPath,
-    destroyFn: () =>
+    destroyFn: (args) =>
       removeWorktree({
         path: wsPath,
+        timeoutMs: args.timeoutMs,
         force: true,
         pruneEmptyParent: true,
         shellPath: opts.shellPath,
+        ...(args.onProgress !== undefined
+          ? { onProgress: args.onProgress }
+          : {}),
       }),
   });
 }
@@ -732,7 +742,7 @@ async function provisionPersonalWorkspace(
 
 async function reconnectManaged(
   wsPath: string,
-  destroyFn: () => Promise<void>,
+  destroyFn: (args: DestroyWorkspaceArgs) => Promise<void>,
   shellPath: string | undefined,
   signal: AbortSignal | undefined,
 ): Promise<HostWorkspace> {
@@ -765,12 +775,16 @@ async function reconnectManagedWorktree(
 ): Promise<HostWorkspace> {
   return reconnectManaged(
     opts.path,
-    () =>
+    (args) =>
       removeWorktree({
         path: opts.path,
+        timeoutMs: args.timeoutMs,
         force: true,
         pruneEmptyParent: true,
         shellPath: opts.shellPath,
+        ...(args.onProgress !== undefined
+          ? { onProgress: args.onProgress }
+          : {}),
       }),
     opts.shellPath,
     opts.signal,

--- a/packages/host-workspace/src/provisioning.ts
+++ b/packages/host-workspace/src/provisioning.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import {
   DEFAULT_ENV_SETUP_SCRIPT_NAME,
+  DEFAULT_ENV_TEARDOWN_SCRIPT_NAME,
   WORKTREE_INCLUDE_FILE_NAME,
   createTerminalOutputLineReader,
   readTerminalOutputLines,
@@ -62,22 +63,38 @@ interface RunSetupScriptArgs {
   signal?: AbortSignal;
 }
 
+interface RunTeardownScriptArgs {
+  workspacePath: string;
+  timeoutMs: number;
+  /** Resolved user-shell PATH. Falls back to the daemon process PATH. */
+  shellPath?: string;
+  onProgress?: ProgressCallback;
+}
+
 interface RemoveWorktreeArgs {
   path: string;
+  /** Teardown script timeout in ms. Controlled by the server. */
+  timeoutMs: number;
   force?: boolean;
   pruneEmptyParent?: boolean;
   shellPath?: string;
+  onProgress?: ProgressCallback;
 }
 
-interface SetupScriptCommand {
+interface LifecycleScriptCommand {
   command: string;
   args: string[];
   text: string;
 }
 
-interface BuildSetupScriptCommandArgs {
+interface BuildLifecycleScriptCommandArgs {
   platform: NodeJS.Platform;
   scriptPath: string;
+}
+
+interface RunLifecycleScriptArgs extends RunSetupScriptArgs {
+  kind: "setup" | "teardown";
+  scriptName: string;
 }
 
 const SETUP_SCRIPT_ABORT_KILL_GRACE_MS = 2_000;
@@ -177,16 +194,17 @@ async function ensureWorkspaceParentDirectory(
   await fs.mkdir(path.dirname(targetPath), { recursive: true });
 }
 
-async function resolveSetupScriptPath(
+async function resolveLifecycleScriptPath(
   workspacePath: string,
+  scriptName: string,
 ): Promise<string | null> {
-  const scriptPath = path.join(workspacePath, DEFAULT_ENV_SETUP_SCRIPT_NAME);
+  const scriptPath = path.join(workspacePath, scriptName);
   return (await pathExists(scriptPath)) ? scriptPath : null;
 }
 
 export function buildSetupScriptCommand(
-  args: BuildSetupScriptCommandArgs,
-): SetupScriptCommand {
+  args: BuildLifecycleScriptCommandArgs,
+): LifecycleScriptCommand {
   if (args.platform === "win32") {
     throw new WorkspaceError(
       "setup_script_failed",
@@ -198,6 +216,21 @@ export function buildSetupScriptCommand(
     command: "env",
     args: ["bash", args.scriptPath],
     text: `env bash ${DEFAULT_ENV_SETUP_SCRIPT_NAME}`,
+  };
+}
+
+function buildTeardownScriptCommand(args: BuildLifecycleScriptCommandArgs) {
+  if (args.platform === "win32") {
+    throw new WorkspaceError(
+      "setup_script_failed",
+      `POSIX shell teardown scripts are not supported on Windows: ${DEFAULT_ENV_TEARDOWN_SCRIPT_NAME}`,
+    );
+  }
+
+  return {
+    command: "env",
+    args: ["bash", args.scriptPath],
+    text: `env bash ${DEFAULT_ENV_TEARDOWN_SCRIPT_NAME}`,
   };
 }
 
@@ -441,6 +474,7 @@ export async function createWorktree(
     }
     await removeWorktree({
       path: args.targetPath,
+      timeoutMs: args.timeoutMs,
       force: true,
       pruneEmptyParent: args.pruneEmptyParent,
       shellPath: args.shellPath,
@@ -526,25 +560,32 @@ async function copyIncludedFiles(args: {
   });
 }
 
-export async function runSetupScript(
-  args: RunSetupScriptArgs,
+async function runLifecycleScript(
+  args: RunLifecycleScriptArgs,
 ): Promise<{ ran: boolean; exitCode?: number; output?: string }> {
-  throwIfProvisionAborted(args.signal);
-  const scriptPath = await resolveSetupScriptPath(args.workspacePath);
+  if (args.kind === "setup") {
+    throwIfProvisionAborted(args.signal);
+  }
+  const scriptPath = await resolveLifecycleScriptPath(
+    args.workspacePath,
+    args.scriptName,
+  );
   if (!scriptPath) {
     return { ran: false };
   }
 
-  throwIfProvisionAborted(args.signal);
-  const command = buildSetupScriptCommand({
-    platform: process.platform,
-    scriptPath,
-  });
+  if (args.kind === "setup") {
+    throwIfProvisionAborted(args.signal);
+  }
+  const command =
+    args.kind === "setup"
+      ? buildSetupScriptCommand({ platform: process.platform, scriptPath })
+      : buildTeardownScriptCommand({ platform: process.platform, scriptPath });
   const startedAt = Date.now();
   emitStep({
     onProgress: args.onProgress,
-    key: "setup-started",
-    text: "Running .bb-env-setup.sh",
+    key: `${args.kind}-started`,
+    text: `Running ${args.scriptName}`,
     status: "started",
     startedAt,
   });
@@ -569,17 +610,17 @@ export async function runSetupScript(
   let abortRequested = false;
   let timedOut = false;
 
-  const emitSetupOutputLines = (lines: string[]): void => {
+  const emitScriptOutputLines = (lines: string[]): void => {
     for (const line of lines) {
       outputIndex += 1;
-      emitOutput(args.onProgress, `setup-output-${outputIndex}`, line);
+      emitOutput(args.onProgress, `${args.kind}-output-${outputIndex}`, line);
     }
   };
 
   const handleChunk = (chunk: Buffer) => {
     const text = chunk.toString("utf8");
     outputChunks.push(text);
-    emitSetupOutputLines(outputLineReader.push(text));
+    emitScriptOutputLines(outputLineReader.push(text));
   };
 
   child.stdout.on("data", handleChunk);
@@ -592,7 +633,7 @@ export async function runSetupScript(
       signal: "SIGKILL",
     });
   }, timeoutMs);
-  const abortSetupScript = () => {
+  const abortLifecycleScript = () => {
     if (abortRequested) {
       return;
     }
@@ -608,9 +649,13 @@ export async function runSetupScript(
       });
     }, SETUP_SCRIPT_ABORT_KILL_GRACE_MS);
   };
-  args.signal?.addEventListener("abort", abortSetupScript, { once: true });
-  if (args.signal?.aborted) {
-    abortSetupScript();
+  if (args.kind === "setup") {
+    args.signal?.addEventListener("abort", abortLifecycleScript, {
+      once: true,
+    });
+    if (args.signal?.aborted) {
+      abortLifecycleScript();
+    }
   }
 
   try {
@@ -623,13 +668,13 @@ export async function runSetupScript(
     });
 
     const output = outputChunks.join("");
-    emitSetupOutputLines(outputLineReader.flush());
+    emitScriptOutputLines(outputLineReader.flush());
     const durationMs = Date.now() - startedAt;
-    if (abortRequested || args.signal?.aborted) {
+    if (args.kind === "setup" && (abortRequested || args.signal?.aborted)) {
       emitStep({
         onProgress: args.onProgress,
-        key: "setup-cancelled",
-        text: ".bb-env-setup.sh cancelled",
+        key: `${args.kind}-cancelled`,
+        text: `${args.scriptName} cancelled`,
         status: "failed",
         startedAt,
         metadata: { durationMs },
@@ -640,52 +685,52 @@ export async function runSetupScript(
     if (timedOut) {
       emitStep({
         onProgress: args.onProgress,
-        key: "setup-failed",
-        text: ".bb-env-setup.sh failed",
+        key: `${args.kind}-failed`,
+        text: `${args.scriptName} failed`,
         status: "failed",
         startedAt,
         metadata: { durationMs },
       });
       throw new WorkspaceError(
         "setup_script_failed",
-        `Setup script timed out after ${timeoutMs}ms: ${scriptPath}`,
+        `${args.kind === "setup" ? "Setup" : "Teardown"} script timed out after ${timeoutMs}ms: ${scriptPath}`,
       );
     }
 
     if (result.signal) {
       emitStep({
         onProgress: args.onProgress,
-        key: "setup-failed",
-        text: ".bb-env-setup.sh failed",
+        key: `${args.kind}-failed`,
+        text: `${args.scriptName} failed`,
         status: "failed",
         startedAt,
         metadata: { durationMs },
       });
       throw new WorkspaceError(
         "setup_script_failed",
-        `Setup script exited via signal ${result.signal}: ${scriptPath}`,
+        `${args.kind === "setup" ? "Setup" : "Teardown"} script exited via signal ${result.signal}: ${scriptPath}`,
       );
     }
 
     if ((result.exitCode ?? 0) !== 0) {
       emitStep({
         onProgress: args.onProgress,
-        key: "setup-failed",
-        text: ".bb-env-setup.sh failed",
+        key: `${args.kind}-failed`,
+        text: `${args.scriptName} failed`,
         status: "failed",
         startedAt,
         metadata: { durationMs },
       });
       throw new WorkspaceError(
         "setup_script_failed",
-        `Setup script failed with exit code ${result.exitCode}: ${scriptPath}`,
+        `${args.kind === "setup" ? "Setup" : "Teardown"} script failed with exit code ${result.exitCode}: ${scriptPath}`,
       );
     }
 
     emitStep({
       onProgress: args.onProgress,
-      key: "setup-completed",
-      text: ".bb-env-setup.sh finished",
+      key: `${args.kind}-completed`,
+      text: `${args.scriptName} finished`,
       status: "completed",
       startedAt,
       metadata: { durationMs },
@@ -696,7 +741,57 @@ export async function runSetupScript(
     if (abortKillTimeout) {
       clearTimeout(abortKillTimeout);
     }
-    args.signal?.removeEventListener("abort", abortSetupScript);
+    if (args.kind === "setup") {
+      args.signal?.removeEventListener("abort", abortLifecycleScript);
+    }
+  }
+}
+
+export function runSetupScript(
+  args: RunSetupScriptArgs,
+): Promise<{ ran: boolean; exitCode?: number; output?: string }> {
+  return runLifecycleScript({
+    ...args,
+    kind: "setup",
+    scriptName: DEFAULT_ENV_SETUP_SCRIPT_NAME,
+  });
+}
+
+export async function runTeardownScript(
+  args: RunTeardownScriptArgs,
+): Promise<{ ran: boolean; exitCode?: number; output?: string }> {
+  const startedAt = Date.now();
+  let failureReported = false;
+  const onProgress: ProgressCallback = (entry) => {
+    if (entry.type === "step" && entry.key === "teardown-failed") {
+      failureReported = true;
+    }
+    args.onProgress?.(entry);
+  };
+  try {
+    return await runLifecycleScript({
+      ...args,
+      onProgress,
+      kind: "teardown",
+      scriptName: DEFAULT_ENV_TEARDOWN_SCRIPT_NAME,
+    });
+  } catch (error) {
+    if (!failureReported) {
+      emitStep({
+        onProgress: args.onProgress,
+        key: "teardown-failed",
+        text: `${DEFAULT_ENV_TEARDOWN_SCRIPT_NAME} failed`,
+        status: "failed",
+        startedAt,
+        metadata: { durationMs: Date.now() - startedAt },
+      });
+    }
+    emitOutput(
+      args.onProgress,
+      "teardown-error",
+      error instanceof Error ? error.message : String(error),
+    );
+    return { ran: true };
   }
 }
 
@@ -710,6 +805,13 @@ export async function removeWorktree(args: RemoveWorktreeArgs): Promise<void> {
     }
     return;
   }
+
+  await runTeardownScript({
+    workspacePath,
+    timeoutMs: args.timeoutMs,
+    ...(args.shellPath !== undefined ? { shellPath: args.shellPath } : {}),
+    ...(args.onProgress !== undefined ? { onProgress: args.onProgress } : {}),
+  });
 
   const commonDirResult = await runGit(["rev-parse", "--git-common-dir"], {
     cwd: workspacePath,

--- a/packages/host-workspace/test/provision.test.ts
+++ b/packages/host-workspace/test/provision.test.ts
@@ -318,7 +318,7 @@ describe("provisionWorkspace", () => {
         path: repoPath,
       });
 
-      await ws.destroy();
+      await ws.destroy({ timeoutMs: 900000 });
 
       await expect(fs.stat(repoPath)).resolves.toBeDefined();
     });
@@ -517,7 +517,7 @@ describe("provisionWorkspace", () => {
         timeoutMs: 900000,
       });
 
-      await ws.destroy();
+      await ws.destroy({ timeoutMs: 900000 });
 
       await expect(fs.stat(targetPath)).rejects.toThrow();
       await expect(fs.stat(envDir)).rejects.toThrow();
@@ -625,7 +625,7 @@ describe("provisionWorkspace", () => {
       expect(ws.isWorktree).toBe(false);
       expect((await fs.stat(targetPath)).isDirectory()).toBe(true);
 
-      await ws.destroy();
+      await ws.destroy({ timeoutMs: 900000 });
       await expect(fs.stat(targetPath)).rejects.toThrow();
     });
 
@@ -733,7 +733,7 @@ describe("provisionWorkspace", () => {
       expect(ws.isGitRepo).toBe(true);
       expect(ws.isWorktree).toBe(true);
 
-      await ws.destroy();
+      await ws.destroy({ timeoutMs: 900000 });
       await expect(fs.stat(wtPath)).rejects.toThrow();
       await expect(fs.stat(envDir)).rejects.toThrow();
     });

--- a/packages/host-workspace/test/provisioning.test.ts
+++ b/packages/host-workspace/test/provisioning.test.ts
@@ -2,7 +2,10 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { DEFAULT_ENV_SETUP_SCRIPT_NAME } from "@bb/domain";
+import {
+  DEFAULT_ENV_SETUP_SCRIPT_NAME,
+  DEFAULT_ENV_TEARDOWN_SCRIPT_NAME,
+} from "@bb/domain";
 import { shellSingleQuote, waitForSetupMarkerCount } from "@bb/test-helpers";
 import { Workspace } from "../src/workspace.js";
 import {
@@ -10,6 +13,7 @@ import {
   createWorktree,
   removeWorktree,
   runSetupScript,
+  runTeardownScript,
 } from "../src/provisioning.js";
 import { runGit } from "../src/git.js";
 
@@ -52,6 +56,19 @@ async function initRemoteBackedRepo(): Promise<{
   await runGit(["push", "-u", "origin", "main"], { cwd: repoPath });
   await runGit(["fetch", "origin"], { cwd: repoPath });
   return { remotePath, repoPath };
+}
+
+async function commitTeardownScript(
+  repoPath: string,
+  script: string,
+): Promise<void> {
+  await fs.writeFile(
+    path.join(repoPath, DEFAULT_ENV_TEARDOWN_SCRIPT_NAME),
+    script,
+    "utf8",
+  );
+  await runGit(["add", DEFAULT_ENV_TEARDOWN_SCRIPT_NAME], { cwd: repoPath });
+  await runGit(["commit", "-m", "Add teardown script"], { cwd: repoPath });
 }
 
 async function pushRemoteMainCommit(remotePath: string): Promise<string> {
@@ -604,6 +621,122 @@ describe("workspace provisioning", () => {
     ).resolves.toEqual({ ran: false });
   });
 
+  it("returns a no-op when the teardown script is missing", async () => {
+    const workspacePath = await makeTempDir("bb-teardown-noop-");
+
+    await expect(
+      runTeardownScript({ workspacePath, timeoutMs: 900000 }),
+    ).resolves.toEqual({ ran: false });
+  });
+
+  it("runs teardown scripts before it removes managed worktrees", async () => {
+    const sourceRepo = await initRepoWithOptionalSetup();
+    const markerPath = path.join(
+      await makeTempDir("bb-teardown-marker-"),
+      "marker.txt",
+    );
+    await commitTeardownScript(
+      sourceRepo,
+      [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        `printf '%s\\n' "$PWD" "$(cat README.md)" > ${shellSingleQuote(markerPath)}`,
+        'echo "released external resource"',
+      ].join("\n"),
+    );
+    const parentDir = await makeTempDir("bb-remove-teardown-parent-");
+    const targetPath = path.join(parentDir, "feature");
+    await createWorktree({
+      sourcePath: sourceRepo,
+      targetPath,
+      branchName: "feature-teardown",
+      baseBranch: "main",
+      timeoutMs: 900000,
+    });
+    const entries: string[] = [];
+
+    await removeWorktree({
+      path: targetPath,
+      timeoutMs: 900000,
+      force: true,
+      onProgress: (entry) => entries.push(`${entry.key}:${entry.text}`),
+    });
+
+    expect(await fs.readFile(markerPath, "utf8")).toBe(
+      `${targetPath}\nhello\n`,
+    );
+    expect(entries).toContain("teardown-started:Running .bb-env-teardown.sh");
+    expect(entries).toContain("teardown-output-1:released external resource");
+    expect(entries).toContain(
+      "teardown-completed:.bb-env-teardown.sh finished",
+    );
+    await expect(fs.stat(targetPath)).rejects.toThrow();
+  });
+
+  it("reports teardown failures and removes the worktree", async () => {
+    const sourceRepo = await initRepoWithOptionalSetup();
+    await commitTeardownScript(
+      sourceRepo,
+      ["#!/usr/bin/env bash", 'echo "cleanup failed"', "exit 7"].join("\n"),
+    );
+    const parentDir = await makeTempDir("bb-remove-failed-teardown-parent-");
+    const targetPath = path.join(parentDir, "feature");
+    await createWorktree({
+      sourcePath: sourceRepo,
+      targetPath,
+      branchName: "feature-failed-teardown",
+      baseBranch: "main",
+      timeoutMs: 900000,
+    });
+    const entries: string[] = [];
+
+    await expect(
+      removeWorktree({
+        path: targetPath,
+        timeoutMs: 900000,
+        force: true,
+        onProgress: (entry) => entries.push(`${entry.key}:${entry.text}`),
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(entries).toContain("teardown-output-1:cleanup failed");
+    expect(entries).toContain("teardown-failed:.bb-env-teardown.sh failed");
+    expect(entries.some((entry) => entry.includes("exit code 7"))).toBe(true);
+    await expect(fs.stat(targetPath)).rejects.toThrow();
+  });
+
+  it("stops timed out teardown scripts and removes the worktree", async () => {
+    const sourceRepo = await initRepoWithOptionalSetup();
+    await commitTeardownScript(
+      sourceRepo,
+      ["#!/usr/bin/env bash", 'echo "waiting"', "sleep 30"].join("\n"),
+    );
+    const parentDir = await makeTempDir("bb-remove-timeout-teardown-parent-");
+    const targetPath = path.join(parentDir, "feature");
+    await createWorktree({
+      sourcePath: sourceRepo,
+      targetPath,
+      branchName: "feature-timeout-teardown",
+      baseBranch: "main",
+      timeoutMs: 900000,
+    });
+    const entries: string[] = [];
+
+    await expect(
+      removeWorktree({
+        path: targetPath,
+        timeoutMs: 50,
+        force: true,
+        onProgress: (entry) => entries.push(`${entry.key}:${entry.text}`),
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(entries).toContain("teardown-output-1:waiting");
+    expect(entries).toContain("teardown-failed:.bb-env-teardown.sh failed");
+    expect(entries.some((entry) => entry.includes("timed out"))).toBe(true);
+    await expect(fs.stat(targetPath)).rejects.toThrow();
+  });
+
   it("removes worktrees and plain directories", async () => {
     const sourceRepo = await initRepoWithOptionalSetup();
     const parentDir = await makeTempDir("bb-remove-parent-");
@@ -617,7 +750,7 @@ describe("workspace provisioning", () => {
       timeoutMs: 900000,
     });
     await fs.writeFile(path.join(targetPath, "local.txt"), "dirty\n", "utf8");
-    await removeWorktree({ path: targetPath, force: true });
+    await removeWorktree({ path: targetPath, timeoutMs: 900000, force: true });
     await expect(fs.stat(targetPath)).rejects.toThrow();
     const worktrees = await runGit(["worktree", "list", "--porcelain"], {
       cwd: sourceRepo,
@@ -639,7 +772,7 @@ describe("workspace provisioning", () => {
     });
     await fs.rm(path.join(targetPath, ".git"), { force: true });
 
-    await removeWorktree({ path: targetPath, force: true });
+    await removeWorktree({ path: targetPath, timeoutMs: 900000, force: true });
 
     await expect(fs.stat(targetPath)).rejects.toThrow();
   });
@@ -648,7 +781,7 @@ describe("workspace provisioning", () => {
     const targetPath = await makeTempDir("bb-remove-non-git-dir-");
     await fs.writeFile(path.join(targetPath, "file.txt"), "data\n", "utf8");
 
-    await removeWorktree({ path: targetPath, force: true });
+    await removeWorktree({ path: targetPath, timeoutMs: 900000, force: true });
 
     await expect(fs.stat(targetPath)).rejects.toThrow();
   });
@@ -667,7 +800,7 @@ describe("workspace provisioning", () => {
     });
     await fs.writeFile(path.join(targetPath, "local.txt"), "dirty\n", "utf8");
 
-    await removeWorktree({ path: targetPath, force: false });
+    await removeWorktree({ path: targetPath, timeoutMs: 900000, force: false });
 
     await expect(fs.stat(targetPath)).rejects.toThrow();
   });

--- a/packages/plugin-api-map/sdk-public-api.json
+++ b/packages/plugin-api-map/sdk-public-api.json
@@ -3,7 +3,7 @@
   "entries": {
     ".": {
       "types": "bundled-types/bb-plugin-sdk.d.ts",
-      "sha256": "1f2656d8eccf35f38966e0ecfc62e81db684ea2baa14ff6a3de3e997aa0c6d70"
+      "sha256": "057bfb57c4a11dcbb0b83125e1b42a0e360fcb28ce62083fa37acb28541df741"
     },
     "./ai-services": {
       "types": "bundled-types/bb-plugin-sdk-ai-services.d.ts",

--- a/packages/templates/src/templates/bb-guide-environments.md
+++ b/packages/templates/src/templates/bb-guide-environments.md
@@ -37,6 +37,17 @@ Making your repo work with bb:
   "Running .bb-env-setup.sh" and then ".bb-env-setup.sh finished",
   ".bb-env-setup.sh failed", or ".bb-env-setup.sh cancelled".
 
+  Commit a .bb-env-teardown.sh script at the repo root when setup creates
+  resources outside the managed worktree. BB runs the hook as
+  `env bash .bb-env-teardown.sh` from the worktree before it removes the
+  worktree. The hook receives the same sanitized environment as the setup
+  hook, and stdin is closed.
+
+  Teardown has a separate 15-minute timeout. A non-zero exit, timeout, or
+  signal reports failure in the destroy transcript, but bb removes the
+  worktree regardless. The teardown hook runs only when bb destroys managed
+  worktrees. It does not run for unmanaged or personal environments.
+
   New worktrees do not contain untracked files such as .env.local. To copy
   them from the source checkout, commit a .worktreeinclude file at the repo
   root. It uses gitignore syntax: one pattern per line, # for comments, ! to

--- a/packages/templates/src/templates/bb-guide-overview.md
+++ b/packages/templates/src/templates/bb-guide-overview.md
@@ -32,13 +32,14 @@ upgrade, failed to load, or missing); run `bb plugin list` for the detail.
 All commands support --json for machine-readable output.
 
 To make a repo work with bb worktrees, run `bb guide environments` for the
-repo-level `.bb-env-setup.sh` setup hook. Run `bb guide agent-configuration` for
-the data-dir and workspace files that customize agent behavior.
+repo-level `.bb-env-setup.sh` and `.bb-env-teardown.sh` hooks. Run `bb guide
+agent-configuration` for the data-dir and workspace files that customize agent
+behavior.
 
 Run `bb guide <chapter>` for command details:
 
   threads              Spawning, inspecting, messaging, and managing threads
-  environments         Environment setup hooks, operations, commits, and merges
+  environments         Environment lifecycle hooks, operations, commits, and merges
   agent-configuration  AGENTS.md and skills files that shape agents
   providers            Discovering providers and models
   projects             Project CRUD and sources


### PR DESCRIPTION
## Human comments

## What was wrong

Managed worktree creation supported `.bb-env-setup.sh`, but destruction had no repository hook. Resources created outside a worktree could remain after bb removed the worktree.

## What changed

- Run `.bb-env-teardown.sh` before Git removes a managed worktree.
- Use the same sanitized environment and closed stdin as the setup hook.
- Apply a separate 15-minute timeout and continue removal after any hook failure.
- Return teardown output and status in the environment destroy transcript.
- Add the timeout and transcript to the daemon wire contract.
- Increment `HOST_DAEMON_PROTOCOL_VERSION` from 172 to 173.
- Document the hook in the guide, skill, configuration, platform, and worktree documentation.

## How you verified

- Added worktree tests for success, missing scripts, non-zero exit, timeout, output, and pre-removal order.
- Added a daemon dispatch test for the timeout and returned transcript.
- Ran `pnpm exec turbo run typecheck` for the six affected packages.
- Ran the full `@bb/host-workspace`, `@bb/host-daemon-contract`, `@bb/host-daemon`, `@bb/server`, and `@bb/templates` test suites.

Fixes #2477

> AGENT GENERATED
