### PR TITLE
Coordinate shared Git ref mutations

### DIFF
--- a/apps/host-daemon/src/command-handlers/host-branches.ts
+++ b/apps/host-daemon/src/command-handlers/host-branches.ts
@@ -16,6 +16,7 @@ import {
   listRemoteBranches,
   readDefaultBranchRefs,
   type GitProcessOptions,
+  withGitRefMutationLock,
 } from "@bb/host-workspace";
 import type { HostDaemonOnlineRpcResult } from "@bb/host-daemon-contract";
 import { CommandDispatchError } from "../command-dispatch-support.js";
@@ -131,10 +132,18 @@ async function refreshRemoteBranches(
     return;
   }
 
-  const inFlight = fetchRemoteBranches(cwd, {
-    timeoutMs: REMOTE_BRANCH_FETCH_TIMEOUT_MS,
-    ...options,
-  })
+  const refreshDeadline = Date.now() + REMOTE_BRANCH_FETCH_TIMEOUT_MS;
+  const inFlight = withGitRefMutationLock(
+    commonDir,
+    () => {
+      const remainingTimeoutMs = Math.max(1, refreshDeadline - Date.now());
+      return fetchRemoteBranches(cwd, {
+        ...options,
+        timeoutMs: remainingTimeoutMs,
+      });
+    },
+    { timeoutMs: REMOTE_BRANCH_FETCH_TIMEOUT_MS },
+  )
     .catch(() => undefined)
     .then(() => undefined)
     .finally(() => {

--- a/apps/host-daemon/test/command/host-branches-dispatch.test.ts
+++ b/apps/host-daemon/test/command/host-branches-dispatch.test.ts
@@ -1,6 +1,8 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { shellSingleQuote } from "@bb/test-helpers";
+import { provisionWorkspace, type HostWorkspace } from "@bb/host-workspace";
 import { dispatchOnlineRpcCommand } from "../../src/command-dispatch.js";
 import {
   cleanupTempDirs,
@@ -351,6 +353,105 @@ describe("host.list_branches dispatch", () => {
       selectedBranch: null,
     });
   });
+
+  it.runIf(process.platform !== "win32")(
+    "serializes branch refresh and provisioning fetches for one repository",
+    async () => {
+      const repoPath = await initBranchRepo();
+      const remotePath = await makeTempDir("bb-host-branches-lock-remote-");
+      await runGitCommand(["init", "--bare"], { cwd: remotePath });
+      await runGitCommand(["remote", "add", "origin", remotePath], {
+        cwd: repoPath,
+      });
+      await runGitCommand(["push", "origin", "develop", "main"], {
+        cwd: repoPath,
+      });
+      await runGitCommand(["fetch", "origin"], { cwd: repoPath });
+
+      const refreshStartedPath = path.join(repoPath, "refresh-started");
+      const releaseRefreshPath = path.join(repoPath, "release-refresh");
+      const uploadPackPath = path.join(repoPath, "delayed-upload-pack.sh");
+      await fs.writeFile(
+        uploadPackPath,
+        `#!/bin/sh\ntouch ${JSON.stringify(refreshStartedPath)}\nwhile [ ! -f ${JSON.stringify(releaseRefreshPath)} ]; do sleep 0.01; done\nexec git-upload-pack "$@"\n`,
+        { encoding: "utf8", mode: 0o755 },
+      );
+      await runGitCommand(
+        ["config", "remote.origin.uploadpack", uploadPackPath],
+        { cwd: repoPath },
+      );
+
+      const binPath = await makeTempDir("bb-host-branches-lock-bin-");
+      const commonDirMarker = path.join(binPath, "common-dir-resolved");
+      const targetedFetchMarker = path.join(binPath, "targeted-fetch");
+      const gitWrapperPath = path.join(binPath, "git");
+      const systemPath = process.env.PATH ?? "";
+      await fs.writeFile(
+        gitWrapperPath,
+        [
+          "#!/bin/sh",
+          "set -u",
+          `system_path=${shellSingleQuote(systemPath)}`,
+          `common_dir_marker=${shellSingleQuote(commonDirMarker)}`,
+          `targeted_fetch_marker=${shellSingleQuote(targetedFetchMarker)}`,
+          'if [ "$#" -eq 2 ] && [ "$1" = "rev-parse" ] && [ "$2" = "--git-common-dir" ]; then',
+          '  PATH="$system_path" git "$@"',
+          "  status=$?",
+          '  touch "$common_dir_marker"',
+          '  exit "$status"',
+          "fi",
+          'if [ "$#" -eq 4 ] && [ "$1" = "fetch" ] && [ "$2" = "--quiet" ] && [ "$3" = "origin" ] && [ "$4" = "+refs/heads/main:refs/remotes/origin/main" ]; then',
+          '  touch "$targeted_fetch_marker"',
+          "fi",
+          'PATH="$system_path" exec git "$@"',
+        ].join("\n") + "\n",
+        { encoding: "utf8", mode: 0o755 },
+      );
+
+      const harness = createHarness();
+      const branchListing = dispatchOnlineRpcCommand(
+        { type: "host.list_branches", path: repoPath, limit: 50 },
+        harness.dispatchOptions(),
+      );
+      let provisioning: Promise<HostWorkspace> | undefined;
+      try {
+        await waitForFile(refreshStartedPath);
+        const targetParent = await makeTempDir(
+          "bb-host-branches-lock-worktree-",
+        );
+        const targetPath = path.join(targetParent, "coordinated");
+        provisioning = provisionWorkspace({
+          workspaceProvisionType: "managed-worktree",
+          sourcePath: repoPath,
+          targetPath,
+          branchName: "bb/coordinated",
+          baseBranch: "origin/main",
+          timeoutMs: 900_000,
+          shellPath: `${binPath}${path.delimiter}${systemPath}`,
+        });
+
+        await waitForFile(commonDirMarker);
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        await expect(fs.access(targetedFetchMarker)).rejects.toThrow();
+
+        await fs.writeFile(releaseRefreshPath, "release\n", "utf8");
+        await branchListing;
+        const workspace = await provisioning;
+        expect(workspace.path).toBe(targetPath);
+        await expect(fs.access(targetedFetchMarker)).resolves.toBeUndefined();
+      } finally {
+        await fs.writeFile(releaseRefreshPath, "release\n", "utf8");
+        await Promise.allSettled([branchListing]);
+        const provisionResult = await Promise.allSettled(
+          provisioning ? [provisioning] : [],
+        );
+        const workspace = provisionResult[0];
+        if (workspace?.status === "fulfilled") {
+          await workspace.value.destroy({ timeoutMs: 900_000 });
+        }
+      }
+    },
+  );
 });
 
 describe("host.list_branch_options dispatch", () => {

--- a/packages/host-workspace/src/git-ref-mutation-lock.ts
+++ b/packages/host-workspace/src/git-ref-mutation-lock.ts
@@ -1,0 +1,34 @@
+import fs from "node:fs/promises";
+import {
+  withProcessLocalQueuedLocks,
+  type ProcessLocalQueuedLockWork,
+} from "./process-local-queued-lock.js";
+
+type GitRefMutationLockWork<T> = ProcessLocalQueuedLockWork<T>;
+
+interface GitRefMutationLockOptions {
+  signal?: AbortSignal;
+  timeoutMs?: number;
+}
+
+const gitRefMutationLockKeyPrefix = "git-ref-mutation:";
+
+export async function withGitRefMutationLock<T>(
+  commonDir: string,
+  work: GitRefMutationLockWork<T>,
+  options: GitRefMutationLockOptions = {},
+): Promise<T> {
+  const commonDirIdentity = await fs.stat(commonDir, { bigint: true });
+  return withProcessLocalQueuedLocks({
+    locks: [
+      {
+        key: `${gitRefMutationLockKeyPrefix}${commonDirIdentity.dev}:${commonDirIdentity.ino}`,
+        ...(options.timeoutMs !== undefined
+          ? { timeoutMs: options.timeoutMs }
+          : {}),
+      },
+    ],
+    signal: options.signal,
+    work,
+  });
+}

--- a/packages/host-workspace/src/git.ts
+++ b/packages/host-workspace/src/git.ts
@@ -489,7 +489,7 @@ export async function getAbsoluteGitDir(
 
 export async function getGitCommonDir(
   cwd: string,
-  options: GitProcessOptions = {},
+  options: GitProcessOptions & { signal?: AbortSignal } = {},
 ): Promise<string> {
   const result = await runGit(["rev-parse", "--git-common-dir"], {
     cwd,

--- a/packages/host-workspace/src/index.ts
+++ b/packages/host-workspace/src/index.ts
@@ -11,6 +11,7 @@ export type {
 
 export type { PullRequestActionOptions } from "./workspace.js";
 export type { GitHostCliOptions } from "./git-host.js";
+export { withGitRefMutationLock } from "./git-ref-mutation-lock.js";
 
 export {
   WorkspaceError,

--- a/packages/host-workspace/src/provisioning.ts
+++ b/packages/host-workspace/src/provisioning.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 import {
   DEFAULT_ENV_SETUP_SCRIPT_NAME,
   DEFAULT_ENV_TEARDOWN_SCRIPT_NAME,
@@ -17,6 +18,7 @@ import {
 import { Workspace } from "./workspace.js";
 import { tryWithCheckoutMutationLock } from "./checkout-mutation-lock.js";
 import {
+  getGitCommonDir,
   pathExists,
   readDefaultBranch,
   readGitRepositoryState,
@@ -24,6 +26,8 @@ import {
   WorkspaceError,
   type GitCommandResult,
 } from "./git.js";
+import { withGitRefMutationLock } from "./git-ref-mutation-lock.js";
+import { ProcessLocalQueuedLockTimeoutError } from "./process-local-queued-lock.js";
 import {
   runGitWithWorktreeMetadataLock,
   withWorktreeMetadataLock,
@@ -98,6 +102,51 @@ interface RunLifecycleScriptArgs extends RunSetupScriptArgs {
 }
 
 const SETUP_SCRIPT_ABORT_KILL_GRACE_MS = 2_000;
+const REMOTE_BASE_FETCH_TIMEOUT_MS = 60_000;
+const REMOTE_REF_LOCK_RETRY_INTERVAL_MS = 200;
+const REMOTE_REF_LOCK_RETRY_TIMEOUT_MS = 2_000;
+
+type ConcurrentRemoteRefUpdateErrorKind = "stale-value" | "lock-file-exists";
+
+function classifyConcurrentRemoteRefUpdateError(
+  error: unknown,
+  remoteRef: string,
+): ConcurrentRemoteRefUpdateErrorKind | null {
+  if (
+    !(error instanceof WorkspaceError) ||
+    error.code !== "git_command_failed"
+  ) {
+    return null;
+  }
+
+  if (
+    error.message.endsWith(
+      `error: fetching ref ${remoteRef} failed: reference already exists`,
+    )
+  ) {
+    return "lock-file-exists";
+  }
+
+  const lockFailurePrefix = `cannot lock ref '${remoteRef}': `;
+  const lockFailureDetail = error.message.split(lockFailurePrefix)[1];
+  if (lockFailureDetail === undefined) {
+    return null;
+  }
+
+  if (
+    /^is at [0-9a-f]+ but expected [0-9a-f]+(?:\n|$)/u.test(lockFailureDetail)
+  ) {
+    return "stale-value";
+  }
+  if (
+    /^Unable to create '.+\.lock': File exists\.(?:\n|$)/u.test(
+      lockFailureDetail,
+    )
+  ) {
+    return "lock-file-exists";
+  }
+  return null;
+}
 
 function emitProgress(
   onProgress: ProgressCallback | undefined,
@@ -254,6 +303,24 @@ function isProvisionAbortError(error: unknown): boolean {
   );
 }
 
+async function waitForProvisionRetry(
+  delayMs: number,
+  signal: AbortSignal | undefined,
+): Promise<void> {
+  try {
+    await delay(
+      delayMs,
+      undefined,
+      signal !== undefined ? { signal } : undefined,
+    );
+  } catch (error) {
+    if (signal?.aborted) {
+      throw createProvisionCancelledError(error);
+    }
+    throw error;
+  }
+}
+
 async function resolveRemoteBaseBranch(
   sourcePath: string,
   baseBranch: string,
@@ -292,9 +359,10 @@ async function resolveRemoteBaseBranch(
   };
 }
 
-async function fetchRemoteBaseBranch(args: {
+export async function fetchRemoteBaseBranch(args: {
   sourcePath: string;
   baseBranch: string;
+  fetchTimeoutMs: number;
   onProgress: ProgressCallback | undefined;
   shellPath: string | undefined;
   signal: AbortSignal | undefined;
@@ -318,13 +386,77 @@ async function fetchRemoteBaseBranch(args: {
     startedAt,
   });
 
-  const refspec = `+refs/heads/${remoteBase.branch}:refs/remotes/${remoteBase.remote}/${remoteBase.branch}`;
+  const remoteRef = `refs/remotes/${remoteBase.remote}/${remoteBase.branch}`;
+  const refspec = `+refs/heads/${remoteBase.branch}:${remoteRef}`;
+  const gitProcessOptions = {
+    ...(args.shellPath !== undefined ? { shellPath: args.shellPath } : {}),
+    ...(args.signal !== undefined ? { signal: args.signal } : {}),
+  };
   try {
-    await runGit(["fetch", "--quiet", remoteBase.remote, refspec], {
-      cwd: args.sourcePath,
-      ...(args.shellPath !== undefined ? { shellPath: args.shellPath } : {}),
-      signal: args.signal,
-    });
+    throwIfProvisionAborted(args.signal);
+    const commonDir = await getGitCommonDir(args.sourcePath, gitProcessOptions);
+    const fetchBaseBranch = async (): Promise<void> => {
+      try {
+        await withGitRefMutationLock(
+          commonDir,
+          () =>
+            runGit(["fetch", "--quiet", remoteBase.remote, refspec], {
+              cwd: args.sourcePath,
+              ...gitProcessOptions,
+              env: { GIT_TERMINAL_PROMPT: "0", LC_ALL: "C" },
+              timeoutMs: args.fetchTimeoutMs,
+            }),
+          args.signal !== undefined ? { signal: args.signal } : {},
+        );
+      } catch (error) {
+        if (args.signal?.aborted && !isProvisionAbortError(error)) {
+          throw createProvisionCancelledError(error);
+        }
+        if (error instanceof ProcessLocalQueuedLockTimeoutError) {
+          throw new WorkspaceError(
+            "git_command_timeout",
+            `Timed out waiting to fetch ${args.baseBranch} because another Git ref update is still running`,
+            { cause: error },
+          );
+        }
+        throw error;
+      }
+    };
+    let staleValueRetried = false;
+    let lockFileRetryDeadline: number | undefined;
+    while (true) {
+      try {
+        await fetchBaseBranch();
+        break;
+      } catch (error) {
+        const errorKind = classifyConcurrentRemoteRefUpdateError(
+          error,
+          remoteRef,
+        );
+        if (errorKind === null) {
+          throw error;
+        }
+        if (errorKind === "stale-value") {
+          if (staleValueRetried) {
+            throw error;
+          }
+          staleValueRetried = true;
+          throwIfProvisionAborted(args.signal);
+          continue;
+        }
+
+        lockFileRetryDeadline ??= Date.now() + REMOTE_REF_LOCK_RETRY_TIMEOUT_MS;
+        const remainingRetryMs = lockFileRetryDeadline - Date.now();
+        if (remainingRetryMs <= 0) {
+          throw error;
+        }
+        throwIfProvisionAborted(args.signal);
+        await waitForProvisionRetry(
+          Math.min(REMOTE_REF_LOCK_RETRY_INTERVAL_MS, remainingRetryMs),
+          args.signal,
+        );
+      }
+    }
     emitStep({
       onProgress: args.onProgress,
       key: "git-fetch-completed",
@@ -403,6 +535,7 @@ export async function createWorktree(
   await fetchRemoteBaseBranch({
     sourcePath: args.sourcePath,
     baseBranch,
+    fetchTimeoutMs: REMOTE_BASE_FETCH_TIMEOUT_MS,
     onProgress: args.onProgress,
     shellPath: args.shellPath,
     signal: args.signal,

--- a/packages/host-workspace/test/git-ref-mutation-lock.test.ts
+++ b/packages/host-workspace/test/git-ref-mutation-lock.test.ts
@@ -1,0 +1,114 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createDeferredPromise } from "@bb/test-helpers";
+import { withGitRefMutationLock } from "../src/git-ref-mutation-lock.js";
+import { ProcessLocalQueuedLockTimeoutError } from "../src/process-local-queued-lock.js";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(name: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), `bb-${name}-`));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function waitForLockContention(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 100));
+}
+
+async function expectPathsShareLock(
+  firstCommonDir: string,
+  secondCommonDir: string,
+): Promise<void> {
+  const firstEntered = createDeferredPromise<void>();
+  const releaseFirst = createDeferredPromise<void>();
+  const first = withGitRefMutationLock(firstCommonDir, async () => {
+    firstEntered.resolve();
+    await releaseFirst.promise;
+  });
+  await firstEntered.promise;
+
+  let secondEntered = false;
+  const second = withGitRefMutationLock(secondCommonDir, async () => {
+    secondEntered = true;
+  });
+  try {
+    await waitForLockContention();
+    expect(secondEntered).toBe(false);
+  } finally {
+    releaseFirst.resolve();
+    await Promise.all([first, second]);
+  }
+  expect(secondEntered).toBe(true);
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs
+      .splice(0)
+      .map((dir) => fs.rm(dir, { recursive: true, force: true })),
+  );
+});
+
+describe("git ref mutation lock", () => {
+  it("serializes mutations for the same resolved common directory", async () => {
+    const commonDir = await makeTempDir("git-ref-lock");
+    await expectPathsShareLock(commonDir, `${commonDir}${path.sep}.`);
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "serializes symbolic-link aliases of one common directory",
+    async () => {
+      const parentDir = await makeTempDir("git-ref-lock-symlink");
+      const commonDir = path.join(parentDir, "common");
+      const aliasDir = path.join(parentDir, "alias");
+      await fs.mkdir(commonDir);
+      await fs.symlink(commonDir, aliasDir, "dir");
+
+      await expectPathsShareLock(commonDir, aliasDir);
+    },
+  );
+
+  it.runIf(process.platform === "darwin")(
+    "serializes macOS data-volume aliases of one common directory",
+    async () => {
+      const dataVolumePrefix = "/System/Volumes/Data";
+      const commonDir = process.cwd();
+      const aliasDir = commonDir.startsWith(dataVolumePrefix)
+        ? commonDir.slice(dataVolumePrefix.length)
+        : `${dataVolumePrefix}${commonDir}`;
+      const [commonStats, aliasStats] = await Promise.all([
+        fs.stat(commonDir, { bigint: true }),
+        fs.stat(aliasDir, { bigint: true }),
+      ]);
+      expect(aliasStats.dev).toBe(commonStats.dev);
+      expect(aliasStats.ino).toBe(commonStats.ino);
+
+      await expectPathsShareLock(commonDir, aliasDir);
+    },
+  );
+
+  it("allows callers to bound how long they wait for the lock", async () => {
+    const commonDir = await makeTempDir("git-ref-lock-timeout");
+    const firstEntered = createDeferredPromise<void>();
+    const releaseFirst = createDeferredPromise<void>();
+    const first = withGitRefMutationLock(commonDir, async () => {
+      firstEntered.resolve();
+      await releaseFirst.promise;
+    });
+    await firstEntered.promise;
+
+    try {
+      await expect(
+        withGitRefMutationLock(commonDir, async () => undefined, {
+          timeoutMs: 10,
+        }),
+      ).rejects.toBeInstanceOf(ProcessLocalQueuedLockTimeoutError);
+    } finally {
+      releaseFirst.resolve();
+      await first;
+    }
+  });
+});

--- a/packages/host-workspace/test/provisioning.test.ts
+++ b/packages/host-workspace/test/provisioning.test.ts
@@ -5,17 +5,24 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   DEFAULT_ENV_SETUP_SCRIPT_NAME,
   DEFAULT_ENV_TEARDOWN_SCRIPT_NAME,
+  type ProvisioningTranscriptEntry,
 } from "@bb/domain";
-import { shellSingleQuote, waitForSetupMarkerCount } from "@bb/test-helpers";
+import {
+  createDeferredPromise,
+  shellSingleQuote,
+  waitForSetupMarkerCount,
+} from "@bb/test-helpers";
 import { Workspace } from "../src/workspace.js";
 import {
   buildSetupScriptCommand,
   createWorktree,
+  fetchRemoteBaseBranch,
   removeWorktree,
   runSetupScript,
   runTeardownScript,
 } from "../src/provisioning.js";
-import { runGit } from "../src/git.js";
+import { getGitCommonDir, runGit } from "../src/git.js";
+import { withGitRefMutationLock } from "../src/git-ref-mutation-lock.js";
 
 const tempDirs: string[] = [];
 
@@ -244,6 +251,386 @@ describe("workspace provisioning", () => {
       cwd: targetPath,
     });
     expect(worktreeHead.stdout.trim()).toBe(remoteHead);
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "recovers from known concurrent remote-ref update failures",
+    async () => {
+      const failures = [
+        "error: cannot lock ref 'refs/remotes/origin/main': is at 2222222222222222222222222222222222222222 but expected 1111111111111111111111111111111111111111",
+        "error: cannot lock ref 'refs/remotes/origin/main': Unable to create '/repo/.git/refs/remotes/origin/main.lock': File exists.",
+        "error: fetching ref refs/remotes/origin/main failed: reference already exists",
+      ];
+
+      for (const failure of failures) {
+        const { remotePath, repoPath } = await initRemoteBackedRepo();
+        const parentDir = await makeTempDir("bb-worktree-fetch-race-parent-");
+        const binPath = await makeTempDir("bb-worktree-fetch-race-bin-");
+        const failedFetchMarker = path.join(binPath, "failed-fetch");
+        const fetchLocaleMarker = path.join(binPath, "fetch-locale");
+        const gitWrapperPath = path.join(binPath, "git");
+        const targetPath = path.join(parentDir, "feature");
+        const remoteHead = await pushRemoteMainCommit(remotePath);
+        const systemPath = process.env.PATH ?? "";
+        await fs.writeFile(
+          gitWrapperPath,
+          [
+            "#!/bin/sh",
+            "set -eu",
+            `system_path=${shellSingleQuote(systemPath)}`,
+            `failed_fetch_marker=${shellSingleQuote(failedFetchMarker)}`,
+            `fetch_locale_marker=${shellSingleQuote(fetchLocaleMarker)}`,
+            'if [ "$#" -eq 4 ] && [ "$1" = "fetch" ] && [ "$2" = "--quiet" ] && [ "$3" = "origin" ] && [ "$4" = "+refs/heads/main:refs/remotes/origin/main" ] && [ ! -f "$failed_fetch_marker" ]; then',
+            '  touch "$failed_fetch_marker"',
+            '  printf "%s" "${LC_ALL:-}" > "$fetch_locale_marker"',
+            '  if [ "${LC_ALL:-}" = "C" ]; then',
+            `    echo ${shellSingleQuote(failure)} >&2`,
+            "  else",
+            "    echo \"Fehler: Referenz 'refs/remotes/origin/main' kann nicht gesperrt werden\" >&2",
+            "  fi",
+            "  exit 1",
+            "fi",
+            'PATH="$system_path" exec git "$@"',
+          ].join("\n") + "\n",
+          "utf8",
+        );
+        await fs.chmod(gitWrapperPath, 0o755);
+
+        await expect(
+          createWorktree({
+            sourcePath: repoPath,
+            targetPath,
+            branchName: "feature",
+            baseBranch: "origin/main",
+            timeoutMs: 900000,
+            shellPath: `${binPath}${path.delimiter}${systemPath}`,
+          }),
+        ).resolves.toEqual({ path: targetPath });
+        await expect(fs.stat(failedFetchMarker)).resolves.toBeDefined();
+        await expect(fs.readFile(fetchLocaleMarker, "utf8")).resolves.toBe("C");
+        await expect(
+          fs.readFile(path.join(targetPath, "remote.txt"), "utf8"),
+        ).resolves.toBe("remote\n");
+        const worktreeHead = await runGit(["rev-parse", "HEAD"], {
+          cwd: targetPath,
+        });
+        expect(worktreeHead.stdout.trim()).toBe(remoteHead);
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "waits for a live remote-ref lock before retrying the fetch",
+    async () => {
+      const { remotePath, repoPath } = await initRemoteBackedRepo();
+      const parentDir = await makeTempDir("bb-worktree-live-ref-lock-parent-");
+      const binPath = await makeTempDir("bb-worktree-live-ref-lock-bin-");
+      const firstFetchFailedMarker = path.join(
+        binPath,
+        "started-first-fetch-failed",
+      );
+      const gitWrapperPath = path.join(binPath, "git");
+      const targetPath = path.join(parentDir, "feature");
+      const remoteHead = await pushRemoteMainCommit(remotePath);
+      const commonDir = await getGitCommonDir(repoPath);
+      const remoteRefLockPath = path.join(
+        commonDir,
+        "refs",
+        "remotes",
+        "origin",
+        "main.lock",
+      );
+      await fs.mkdir(path.dirname(remoteRefLockPath), { recursive: true });
+      await fs.writeFile(remoteRefLockPath, "held\n", "utf8");
+      const systemPath = process.env.PATH ?? "";
+      await fs.writeFile(
+        gitWrapperPath,
+        [
+          "#!/bin/sh",
+          "set -eu",
+          `system_path=${shellSingleQuote(systemPath)}`,
+          `first_fetch_failed=${shellSingleQuote(firstFetchFailedMarker)}`,
+          'if [ "$#" -eq 4 ] && [ "$1" = "fetch" ] && [ "$2" = "--quiet" ] && [ "$3" = "origin" ] && [ "$4" = "+refs/heads/main:refs/remotes/origin/main" ]; then',
+          "  set +e",
+          '  PATH="$system_path" git "$@"',
+          "  status=$?",
+          "  set -e",
+          '  if [ "$status" -ne 0 ]; then touch "$first_fetch_failed"; fi',
+          '  exit "$status"',
+          "fi",
+          'PATH="$system_path" exec git "$@"',
+        ].join("\n") + "\n",
+        "utf8",
+      );
+      await fs.chmod(gitWrapperPath, 0o755);
+
+      const provisioning = createWorktree({
+        sourcePath: repoPath,
+        targetPath,
+        branchName: "feature",
+        baseBranch: "origin/main",
+        timeoutMs: 900000,
+        shellPath: `${binPath}${path.delimiter}${systemPath}`,
+      });
+      const settledProvisioning = provisioning.then(
+        (result) => result,
+        (error: unknown) => error,
+      );
+      try {
+        await waitForSetupMarkerCount({
+          expectedCount: 1,
+          markerDir: binPath,
+          timeoutMs: 2_000,
+        });
+        await fs.rm(remoteRefLockPath);
+        await expect(settledProvisioning).resolves.toEqual({
+          path: targetPath,
+        });
+        const worktreeHead = await runGit(["rev-parse", "HEAD"], {
+          cwd: targetPath,
+        });
+        expect(worktreeHead.stdout.trim()).toBe(remoteHead);
+      } finally {
+        await fs.rm(remoteRefLockPath, { force: true });
+        await Promise.allSettled([provisioning]);
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "releases the ref lock after a targeted fetch times out",
+    async () => {
+      const { repoPath } = await initRemoteBackedRepo();
+      const uploadPackStartedPath = path.join(repoPath, "started-upload-pack");
+      const releaseUploadPackPath = path.join(repoPath, "release-upload-pack");
+      const uploadPackPath = path.join(repoPath, "stalled-upload-pack.sh");
+      await fs.writeFile(
+        uploadPackPath,
+        `#!/bin/sh\ntouch ${JSON.stringify(uploadPackStartedPath)}\nwhile [ ! -f ${JSON.stringify(releaseUploadPackPath)} ]; do sleep 0.01; done\nexec git-upload-pack "$@"\n`,
+        { encoding: "utf8", mode: 0o755 },
+      );
+      await runGit(["config", "remote.origin.uploadpack", uploadPackPath], {
+        cwd: repoPath,
+      });
+      const commonDir = await getGitCommonDir(repoPath);
+      const stalledFetch = fetchRemoteBaseBranch({
+        sourcePath: repoPath,
+        baseBranch: "origin/main",
+        fetchTimeoutMs: 250,
+        onProgress: undefined,
+        shellPath: undefined,
+        signal: undefined,
+      });
+      const stalledFetchError = stalledFetch.then(
+        () => null,
+        (error: unknown) => error,
+      );
+
+      try {
+        await waitForSetupMarkerCount({
+          expectedCount: 1,
+          markerDir: repoPath,
+          timeoutMs: 2_000,
+        });
+        const nextMutation = withGitRefMutationLock(
+          commonDir,
+          async () => undefined,
+          { timeoutMs: 2_000 },
+        );
+        await expect(stalledFetchError).resolves.toMatchObject({
+          code: "git_command_timeout",
+        });
+        await expect(nextMutation).resolves.toBeUndefined();
+      } finally {
+        await fs.writeFile(releaseUploadPackPath, "release\n", "utf8");
+        await Promise.allSettled([stalledFetch]);
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "records a failed fetch when resolving the common Git directory fails",
+    async () => {
+      const { repoPath } = await initRemoteBackedRepo();
+      const parentDir = await makeTempDir("bb-worktree-common-dir-parent-");
+      const binPath = await makeTempDir("bb-worktree-common-dir-bin-");
+      const gitWrapperPath = path.join(binPath, "git");
+      const targetPath = path.join(parentDir, "feature");
+      const systemPath = process.env.PATH ?? "";
+      await fs.writeFile(
+        gitWrapperPath,
+        [
+          "#!/bin/sh",
+          "set -eu",
+          `system_path=${shellSingleQuote(systemPath)}`,
+          'if [ "$#" -eq 2 ] && [ "$1" = "rev-parse" ] && [ "$2" = "--git-common-dir" ]; then',
+          '  echo "common dir unavailable" >&2',
+          "  exit 1",
+          "fi",
+          'PATH="$system_path" exec git "$@"',
+        ].join("\n") + "\n",
+        "utf8",
+      );
+      await fs.chmod(gitWrapperPath, 0o755);
+      const transcript: ProvisioningTranscriptEntry[] = [];
+
+      await expect(
+        createWorktree({
+          sourcePath: repoPath,
+          targetPath,
+          branchName: "feature",
+          baseBranch: "origin/main",
+          timeoutMs: 900000,
+          shellPath: `${binPath}${path.delimiter}${systemPath}`,
+          onProgress: (entry) => transcript.push(entry),
+        }),
+      ).rejects.toMatchObject({ code: "git_command_failed" });
+      expect(
+        transcript.some(
+          (entry) =>
+            entry.type === "step" &&
+            entry.key === "git-fetch-failed" &&
+            entry.status === "failed",
+        ),
+      ).toBe(true);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "cancels while resolving the common Git directory",
+    async () => {
+      const { repoPath } = await initRemoteBackedRepo();
+      const parentDir = await makeTempDir(
+        "bb-worktree-common-dir-abort-parent-",
+      );
+      const binPath = await makeTempDir("bb-worktree-common-dir-abort-bin-");
+      const commonDirStartedPath = path.join(binPath, "started-common-dir");
+      const releaseCommonDirPath = path.join(binPath, "release-common-dir");
+      const gitWrapperPath = path.join(binPath, "git");
+      const targetPath = path.join(parentDir, "feature");
+      const systemPath = process.env.PATH ?? "";
+      await fs.writeFile(
+        gitWrapperPath,
+        [
+          "#!/bin/sh",
+          "set -eu",
+          `system_path=${shellSingleQuote(systemPath)}`,
+          `common_dir_started=${shellSingleQuote(commonDirStartedPath)}`,
+          `release_common_dir=${shellSingleQuote(releaseCommonDirPath)}`,
+          'if [ "$#" -eq 2 ] && [ "$1" = "rev-parse" ] && [ "$2" = "--git-common-dir" ]; then',
+          '  touch "$common_dir_started"',
+          '  while [ ! -f "$release_common_dir" ]; do sleep 0.01; done',
+          "fi",
+          'PATH="$system_path" exec git "$@"',
+        ].join("\n") + "\n",
+        "utf8",
+      );
+      await fs.chmod(gitWrapperPath, 0o755);
+      const abortController = new AbortController();
+      const transcript: ProvisioningTranscriptEntry[] = [];
+      const provisioning = createWorktree({
+        sourcePath: repoPath,
+        targetPath,
+        branchName: "feature",
+        baseBranch: "origin/main",
+        timeoutMs: 900000,
+        shellPath: `${binPath}${path.delimiter}${systemPath}`,
+        signal: abortController.signal,
+        onProgress: (entry) => transcript.push(entry),
+      });
+      let cancellationTimeout: ReturnType<typeof setTimeout> | undefined;
+
+      try {
+        await waitForSetupMarkerCount({
+          expectedCount: 1,
+          markerDir: binPath,
+          timeoutMs: 2_000,
+        });
+        abortController.abort(new Error("test abort"));
+        await expect(
+          Promise.race([
+            provisioning,
+            new Promise<never>((_, reject) => {
+              cancellationTimeout = setTimeout(
+                () =>
+                  reject(
+                    new Error(
+                      "Provisioning did not cancel while resolving the common Git directory",
+                    ),
+                  ),
+                2_000,
+              );
+            }),
+          ]),
+        ).rejects.toMatchObject({ code: "provision_cancelled" });
+        expect(
+          transcript.some(
+            (entry) =>
+              entry.type === "step" &&
+              entry.key === "git-fetch-failed" &&
+              entry.status === "failed",
+          ),
+        ).toBe(true);
+      } finally {
+        if (cancellationTimeout !== undefined) {
+          clearTimeout(cancellationTimeout);
+        }
+        await fs.writeFile(releaseCommonDirPath, "release\n", "utf8");
+        await Promise.allSettled([provisioning]);
+      }
+    },
+  );
+
+  it("keeps cancellation typed while waiting for a coordinated remote fetch", async () => {
+    const { repoPath } = await initRemoteBackedRepo();
+    const parentDir = await makeTempDir("bb-worktree-fetch-abort-parent-");
+    const targetPath = path.join(parentDir, "feature");
+    const abortController = new AbortController();
+    const commonDir = await getGitCommonDir(repoPath);
+    const lockEntered = createDeferredPromise<void>();
+    const releaseLock = createDeferredPromise<void>();
+    const lockHolder = withGitRefMutationLock(commonDir, async () => {
+      lockEntered.resolve();
+      await releaseLock.promise;
+    });
+    await lockEntered.promise;
+    const fetchStarted = createDeferredPromise<void>();
+    const transcript: ProvisioningTranscriptEntry[] = [];
+
+    const provisioning = createWorktree({
+      sourcePath: repoPath,
+      targetPath,
+      branchName: "feature",
+      baseBranch: "origin/main",
+      timeoutMs: 900000,
+      signal: abortController.signal,
+      onProgress: (entry) => {
+        transcript.push(entry);
+        if (entry.key === "git-fetch-started") {
+          fetchStarted.resolve();
+        }
+      },
+    });
+
+    try {
+      await fetchStarted.promise;
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      abortController.abort(new Error("test abort"));
+      await expect(provisioning).rejects.toMatchObject({
+        code: "provision_cancelled",
+      });
+      expect(
+        transcript.some(
+          (entry) =>
+            entry.type === "step" &&
+            entry.key === "git-fetch-failed" &&
+            entry.status === "failed",
+        ),
+      ).toBe(true);
+    } finally {
+      releaseLock.resolve();
+      await lockHolder;
+    }
   });
 
   it("rolls back failed worktree setup scripts", async () => {


### PR DESCRIPTION
## Human comments

## What was wrong

Workspace provisioning and remote-branch discovery could fetch into the same repository concurrently. Both operations mutate shared remote-tracking refs, so Git could reject provisioning with either a stale compare-and-swap error or an existing ref-lock error even though both fetches were otherwise valid.

## What changed

- Added a process-local queued lock keyed by the Git common directory's physical filesystem identity and used it for both bb-owned ref-mutating fetch paths.
- Kept remote branch refresh best-effort and bounded while it waits for the lock, then derives the child-process timeout from the remaining refresh budget.
- Retried stale compare-and-swap failures once and live ref-lock failures on a bounded, abort-aware deadline; forced parsed Git diagnostics to the C locale.
- Added a 60-second deadline and disabled terminal credential prompts for targeted provisioning fetches.
- Preserved typed cancellation, timeout reporting, and terminal provisioning progress while resolving or waiting on the shared-ref lock.
- Added unit and cross-path integration coverage for real ref locks, stalled fetches, symbolic links, and macOS Data-volume aliases.
- No host-daemon wire contract changed, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

## How you verified

- Added regression coverage for stale-ref CAS failures, a real held `.lock`, stable Git locale, fetch timeouts releasing the lock, physical path aliases, cancellation, bounded lock waits, and actual branch-refresh/provisioning contention.
- `@bb/host-workspace`: 10 focused regressions passed; 229 other tests passed with one unrelated macOS `/tmp` versus `/private/tmp` assertion from unmodified `origin/main` excluded.
- `@bb/host-daemon`: 45 test files, 562 tests passed.
- Both package typechecks passed.
- Ran `git diff origin/main...HEAD --check`.

> AGENT GENERATED
