### PR TITLE
Make branch source refresh explicit

### DIFF
--- a/apps/app/src/components/plugin/PluginNewThreadComposer.test.tsx
+++ b/apps/app/src/components/plugin/PluginNewThreadComposer.test.tsx
@@ -645,7 +645,7 @@ describe("PluginNewThreadComposer seeding", () => {
       hostId: "host_1",
       workspace: {
         type: "managed-worktree",
-        baseBranch: { kind: "default" },
+        baseBranch: { kind: "named", name: "main" },
       },
     });
   });

--- a/apps/app/src/components/plugin/new-thread-environment-seed.test.ts
+++ b/apps/app/src/components/plugin/new-thread-environment-seed.test.ts
@@ -12,8 +12,6 @@ function roundTrip(
   expect(seed).not.toBeNull();
   if (seed === null) return null;
   return resolveRootComposeThreadEnvironment({
-    defaultBranch: "main",
-    defaultWorktreeBaseBranch: null,
     environmentValue: seed.selectionValue,
     projectId: PROJECT_ID,
     selectedBranch: seed.branch,

--- a/apps/app/src/components/plugin/new-thread-environment-seed.test.ts
+++ b/apps/app/src/components/plugin/new-thread-environment-seed.test.ts
@@ -12,6 +12,8 @@ function roundTrip(
   expect(seed).not.toBeNull();
   if (seed === null) return null;
   return resolveRootComposeThreadEnvironment({
+    defaultBranch: undefined,
+    defaultWorktreeBaseBranch: undefined,
     environmentValue: seed.selectionValue,
     projectId: PROJECT_ID,
     selectedBranch: seed.branch,

--- a/apps/app/src/components/promptbox/NewThreadComposer.tsx
+++ b/apps/app/src/components/promptbox/NewThreadComposer.tsx
@@ -778,20 +778,11 @@ export function NewThreadComposer({
   const selectedEnvironment = useMemo(
     () =>
       resolveRootComposeThreadEnvironment({
-        defaultBranch: branchesQuery.data?.defaultBranch,
-        defaultWorktreeBaseBranch:
-          branchesQuery.data?.defaultWorktreeBaseBranch,
         environmentValue: effectiveEnvironmentValue,
         projectId,
         selectedBranch,
       }),
-    [
-      branchesQuery.data?.defaultBranch,
-      branchesQuery.data?.defaultWorktreeBaseBranch,
-      effectiveEnvironmentValue,
-      projectId,
-      selectedBranch,
-    ],
+    [effectiveEnvironmentValue, projectId, selectedBranch],
   );
 
   const seedInitialPrompt = promptDraft.restoreIfEmpty;
@@ -1169,12 +1160,12 @@ export function NewThreadComposer({
     },
     [serviceTier, setServiceTier, snapshotDraftBeforeOptionChange],
   );
-  const refetchBranches = branchesQuery.refetch;
+  const refreshBranchesFromRemote = branchesQuery.refreshFromRemote;
   const handleBranchOpenChange = useCallback(
     (open: boolean) => {
-      if (open) void refetchBranches();
+      if (open) void refreshBranchesFromRemote().catch(() => undefined);
     },
-    [refetchBranches],
+    [refreshBranchesFromRemote],
   );
   const handleWorktreeChange = useCallback(
     (environmentId: string) => {

--- a/apps/app/src/components/promptbox/NewThreadComposer.tsx
+++ b/apps/app/src/components/promptbox/NewThreadComposer.tsx
@@ -778,11 +778,20 @@ export function NewThreadComposer({
   const selectedEnvironment = useMemo(
     () =>
       resolveRootComposeThreadEnvironment({
+        defaultBranch: branchesQuery.data?.defaultBranch,
+        defaultWorktreeBaseBranch:
+          branchesQuery.data?.defaultWorktreeBaseBranch,
         environmentValue: effectiveEnvironmentValue,
         projectId,
         selectedBranch,
       }),
-    [effectiveEnvironmentValue, projectId, selectedBranch],
+    [
+      branchesQuery.data?.defaultBranch,
+      branchesQuery.data?.defaultWorktreeBaseBranch,
+      effectiveEnvironmentValue,
+      projectId,
+      selectedBranch,
+    ],
   );
 
   const seedInitialPrompt = promptDraft.restoreIfEmpty;

--- a/apps/app/src/hooks/queries/project-queries.test.tsx
+++ b/apps/app/src/hooks/queries/project-queries.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
-import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { ProjectBranchesResponse } from "@bb/server-contract";
 import { sdk } from "@/lib/sdk";
 import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -15,35 +16,69 @@ vi.mock("@/hooks/useRealtimeSubscription", () => ({
   useProjectDetailRealtimeSubscription: vi.fn(),
 }));
 
+const INITIAL_BRANCHES = {
+  branches: ["main"],
+  branchesTruncated: false,
+  checkout: { kind: "branch", branchName: "main", headSha: null },
+  defaultBranch: "main",
+  defaultBranchRelation: "equal",
+  defaultWorktreeBaseBranch: null,
+  hasUncommittedChanges: false,
+  operation: { kind: "none" },
+  originDefaultBranch: "origin/main",
+  remoteBranches: [],
+  remoteBranchesTruncated: false,
+  selectedBranch: null,
+} satisfies ProjectBranchesResponse;
+
 describe("useProjectSourceBranches", () => {
   afterEach(() => {
     cleanup();
     vi.clearAllMocks();
   });
 
-  it("does not re-run the daemon branch RPC on window focus while the list is fresh", async () => {
+  it("starts with cached refs and exposes an explicit blocking remote refresh", async () => {
     const { wrapper, queryClient } = createQueryClientTestHarness();
-    vi.mocked(sdk.projects.branches).mockResolvedValue({
-      branches: ["main"],
-      branchesTruncated: false,
-      checkout: { kind: "branch", branchName: "main", headSha: null },
-      defaultBranch: "main",
-      defaultBranchRelation: "equal",
-      defaultWorktreeBaseBranch: null,
-      hasUncommittedChanges: false,
-      operation: { kind: "none" },
-      originDefaultBranch: "main",
-      remoteBranches: [],
-      remoteBranchesTruncated: false,
-      selectedBranch: null,
-    });
+    vi.mocked(sdk.projects.branches)
+      .mockResolvedValueOnce(INITIAL_BRANCHES)
+      .mockResolvedValueOnce({
+        ...INITIAL_BRANCHES,
+        remoteBranches: ["origin/main", "origin/new"],
+      });
 
-    renderHook(() => useProjectSourceBranches("project-1", "host-1"), {
-      wrapper,
-    });
+    const { result } = renderHook(
+      () => useProjectSourceBranches("project-1", "host-1"),
+      { wrapper },
+    );
     await waitFor(() => {
       expect(sdk.projects.branches).toHaveBeenCalledTimes(1);
     });
+    expect(sdk.projects.branches).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ refresh: "background" }),
+    );
+
+    await act(async () => {
+      await result.current.refreshFromRemote();
+    });
+    await waitFor(() => {
+      expect(result.current.data?.remoteBranches).toEqual([
+        "origin/main",
+        "origin/new",
+      ]);
+    });
+    expect(sdk.projects.branches).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        hostId: "host-1",
+        limit: "50",
+        projectId: "project-1",
+        refresh: "blocking",
+      }),
+    );
+    expect(vi.mocked(sdk.projects.branches).mock.calls[1]?.[0]).toHaveProperty(
+      "signal",
+    );
 
     const [query] = queryClient.getQueryCache().findAll({
       queryKey: projectSourceBranchesQueryKeyPrefix("project-1"),
@@ -53,6 +88,145 @@ describe("useProjectSourceBranches", () => {
         refetchOnWindowFocus: false,
         staleTime: 30_000,
       }),
+    );
+  });
+
+  it("reports fetching while the blocking refresh waits, then reverts to cached reads", async () => {
+    const { wrapper } = createQueryClientTestHarness();
+    let releaseBlocking: ((value: ProjectBranchesResponse) => void) | undefined;
+    vi.mocked(sdk.projects.branches)
+      .mockResolvedValueOnce(INITIAL_BRANCHES)
+      .mockImplementationOnce(
+        () =>
+          new Promise<ProjectBranchesResponse>((resolve) => {
+            releaseBlocking = resolve;
+          }),
+      )
+      .mockResolvedValueOnce(INITIAL_BRANCHES);
+
+    const { result } = renderHook(
+      () => useProjectSourceBranches("project-1", "host-1"),
+      { wrapper },
+    );
+    await waitFor(() => {
+      expect(result.current.isFetching).toBe(false);
+    });
+
+    let refreshed: Promise<void> | undefined;
+    act(() => {
+      refreshed = result.current.refreshFromRemote();
+    });
+    await waitFor(() => {
+      expect(result.current.isFetching).toBe(true);
+    });
+
+    await act(async () => {
+      releaseBlocking?.(INITIAL_BRANCHES);
+      await refreshed;
+    });
+    await waitFor(() => {
+      expect(result.current.isFetching).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.refetch();
+    });
+    expect(sdk.projects.branches).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({ refresh: "background" }),
+    );
+  });
+
+  it("still reaches the daemon when the picker opens during the initial cached fetch", async () => {
+    const { wrapper } = createQueryClientTestHarness();
+    let releaseInitial: ((value: ProjectBranchesResponse) => void) | undefined;
+    vi.mocked(sdk.projects.branches)
+      .mockImplementationOnce(
+        () =>
+          new Promise<ProjectBranchesResponse>((resolve) => {
+            releaseInitial = resolve;
+          }),
+      )
+      .mockResolvedValueOnce({
+        ...INITIAL_BRANCHES,
+        remoteBranches: ["origin/main", "origin/new"],
+      })
+      .mockResolvedValueOnce(INITIAL_BRANCHES);
+
+    const { result } = renderHook(
+      () => useProjectSourceBranches("project-1", "host-1"),
+      { wrapper },
+    );
+    await waitFor(() => {
+      expect(sdk.projects.branches).toHaveBeenCalledTimes(1);
+    });
+
+    let refreshed: Promise<void> | undefined;
+    act(() => {
+      refreshed = result.current.refreshFromRemote();
+    });
+    await act(async () => {
+      releaseInitial?.(INITIAL_BRANCHES);
+      await refreshed;
+    });
+
+    await waitFor(() => {
+      expect(sdk.projects.branches).toHaveBeenCalledTimes(2);
+    });
+    expect(sdk.projects.branches).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ refresh: "blocking" }),
+    );
+    await waitFor(() => {
+      expect(result.current.data?.remoteBranches).toEqual([
+        "origin/main",
+        "origin/new",
+      ]);
+    });
+
+    await act(async () => {
+      await result.current.refetch();
+    });
+    expect(sdk.projects.branches).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({ refresh: "background" }),
+    );
+  });
+
+  it("keeps every retry of a blocking refresh blocking", async () => {
+    const { wrapper } = createQueryClientTestHarness({
+      queries: { retry: 1, retryDelay: 0 },
+    });
+    vi.mocked(sdk.projects.branches)
+      .mockResolvedValueOnce(INITIAL_BRANCHES)
+      .mockRejectedValueOnce(new Error("Failed to fetch"))
+      .mockResolvedValueOnce({
+        ...INITIAL_BRANCHES,
+        remoteBranches: ["origin/new"],
+      });
+
+    const { result } = renderHook(
+      () => useProjectSourceBranches("project-1", "host-1"),
+      { wrapper },
+    );
+    await waitFor(() => {
+      expect(sdk.projects.branches).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      await result.current.refreshFromRemote();
+    });
+
+    await waitFor(() => {
+      expect(sdk.projects.branches).toHaveBeenCalledTimes(3);
+    });
+    expect(sdk.projects.branches).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ refresh: "blocking" }),
+    );
+    expect(sdk.projects.branches).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({ refresh: "blocking" }),
     );
   });
 });

--- a/apps/app/src/hooks/queries/project-queries.ts
+++ b/apps/app/src/hooks/queries/project-queries.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { useCallback, useRef } from "react";
 import type {
   CommandListResponse,
   ProjectBranchesResponse,
@@ -93,7 +94,12 @@ export function useProjectSourceBranches(
   const query = options?.query?.trim() ?? "";
   const limit = options?.limit ?? PROJECT_SOURCE_BRANCHES_LIMIT;
   const selectedBranch = options?.selectedBranch?.trim() ?? "";
-  return useQuery<ProjectBranchesResponse>({
+  const remoteRefreshRef = useRef<{
+    blockingSignal: AbortSignal | null;
+    inFlight: Promise<void> | null;
+    requested: boolean;
+  }>({ blockingSignal: null, inFlight: null, requested: false });
+  const result = useQuery<ProjectBranchesResponse>({
     queryKey: projectSourceBranchesQueryKey(
       projectId ?? "",
       hostId ?? "",
@@ -101,15 +107,28 @@ export function useProjectSourceBranches(
       limit,
       selectedBranch,
     ),
-    queryFn: ({ signal }) =>
-      sdk.projects.branches({
+    queryFn: ({ signal }) => {
+      const remoteRefresh = remoteRefreshRef.current;
+      const startsBlockingRefresh =
+        remoteRefresh.requested && remoteRefresh.blockingSignal === null;
+      const refresh =
+        startsBlockingRefresh || remoteRefresh.blockingSignal === signal
+          ? "blocking"
+          : "background";
+      if (startsBlockingRefresh) {
+        remoteRefresh.requested = false;
+        remoteRefresh.blockingSignal = signal;
+      }
+      return sdk.projects.branches({
         projectId: requireProjectId(projectId, "useProjectSourceBranches"),
         hostId: hostId ?? "",
         ...(query ? { query } : {}),
         ...(selectedBranch ? { selectedBranch } : {}),
         limit: String(limit),
+        refresh,
         signal,
-      }),
+      });
+    },
     enabled,
     ...REALTIME_OWNED_NO_FOCUS_QUERY_POLICY,
     staleTime: PROJECT_SOURCE_BRANCHES_STALE_MS,
@@ -125,6 +144,27 @@ export function useProjectSourceBranches(
           })
         : undefined,
   });
+  const refetch = result.refetch;
+  const refreshFromRemote = useCallback((): Promise<void> => {
+    const remoteRefresh = remoteRefreshRef.current;
+    if (remoteRefresh.inFlight) return remoteRefresh.inFlight;
+
+    const run = async (): Promise<void> => {
+      remoteRefresh.requested = true;
+      remoteRefresh.blockingSignal = null;
+      try {
+        await refetch();
+        if (remoteRefresh.requested) await refetch();
+      } finally {
+        remoteRefresh.requested = false;
+        remoteRefresh.blockingSignal = null;
+        remoteRefresh.inFlight = null;
+      }
+    };
+    remoteRefresh.inFlight = run();
+    return remoteRefresh.inFlight;
+  }, [refetch]);
+  return { ...result, refreshFromRemote };
 }
 
 export function useProjectPromptHistory(

--- a/apps/app/src/test/queryClientTestHarness.tsx
+++ b/apps/app/src/test/queryClientTestHarness.tsx
@@ -1,5 +1,9 @@
 import { Provider as JotaiProvider } from "jotai";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  QueryClient,
+  QueryClientProvider,
+  type QueryClientConfig,
+} from "@tanstack/react-query";
 import type { JSX, ReactNode } from "react";
 import { createAppQueryClient } from "@/lib/query-client";
 
@@ -16,15 +20,19 @@ interface QueryClientTestHarness {
   wrapper: QueryClientTestWrapper;
 }
 
-export function createQueryClientTestHarness(): QueryClientTestHarness {
+export function createQueryClientTestHarness(
+  overrides?: QueryClientConfig["defaultOptions"],
+): QueryClientTestHarness {
   const queryClient = createAppQueryClient({
     defaultOptions: {
       mutations: {
         retry: false,
+        ...overrides?.mutations,
       },
       queries: {
         gcTime: Infinity,
         retry: false,
+        ...overrides?.queries,
       },
     },
   });

--- a/apps/app/src/views/root-compose-thread-environment.test.ts
+++ b/apps/app/src/views/root-compose-thread-environment.test.ts
@@ -17,8 +17,6 @@ describe("resolveRootComposeThreadEnvironment", () => {
   it("omits unmanaged branch checkout when no branch is selected", () => {
     expect(
       resolveRootComposeThreadEnvironment({
-        defaultBranch: null,
-        defaultWorktreeBaseBranch: null,
         environmentValue: hostLocalEnvironmentValue,
         projectId,
         selectedBranch: null,
@@ -36,8 +34,6 @@ describe("resolveRootComposeThreadEnvironment", () => {
   it("sends explicit existing branch checkout for host local", () => {
     expect(
       resolveRootComposeThreadEnvironment({
-        defaultBranch: null,
-        defaultWorktreeBaseBranch: null,
         environmentValue: hostLocalEnvironmentValue,
         projectId,
         selectedBranch: selectedBranch("develop"),
@@ -56,8 +52,6 @@ describe("resolveRootComposeThreadEnvironment", () => {
   it("sends explicit new branch checkout for host local", () => {
     expect(
       resolveRootComposeThreadEnvironment({
-        defaultBranch: null,
-        defaultWorktreeBaseBranch: null,
         environmentValue: hostLocalEnvironmentValue,
         projectId,
         selectedBranch: { name: "develop", isNew: true },
@@ -70,11 +64,9 @@ describe("resolveRootComposeThreadEnvironment", () => {
     });
   });
 
-  it("sends default base branch for managed worktrees without an explicit pick", () => {
+  it("preserves implicit default intent for authoritative server resolution", () => {
     expect(
       resolveRootComposeThreadEnvironment({
-        defaultBranch: "main",
-        defaultWorktreeBaseBranch: "main",
         environmentValue: hostWorktreeEnvironmentValue,
         projectId,
         selectedBranch: null,
@@ -83,40 +75,6 @@ describe("resolveRootComposeThreadEnvironment", () => {
       workspace: {
         type: "managed-worktree",
         baseBranch: { kind: "default" },
-      },
-    });
-  });
-
-  it("can submit the server-resolved default while branch metadata is still loading", () => {
-    expect(
-      resolveRootComposeThreadEnvironment({
-        defaultBranch: undefined,
-        defaultWorktreeBaseBranch: undefined,
-        environmentValue: hostWorktreeEnvironmentValue,
-        projectId,
-        selectedBranch: null,
-      }),
-    ).toMatchObject({
-      workspace: {
-        type: "managed-worktree",
-        baseBranch: { kind: "default" },
-      },
-    });
-  });
-
-  it("sends smart remote default base branch for managed worktrees without an explicit pick", () => {
-    expect(
-      resolveRootComposeThreadEnvironment({
-        defaultBranch: "main",
-        defaultWorktreeBaseBranch: "origin/main",
-        environmentValue: hostWorktreeEnvironmentValue,
-        projectId,
-        selectedBranch: null,
-      }),
-    ).toMatchObject({
-      workspace: {
-        type: "managed-worktree",
-        baseBranch: { kind: "named", name: "origin/main" },
       },
     });
   });
@@ -124,8 +82,6 @@ describe("resolveRootComposeThreadEnvironment", () => {
   it("sends a named base branch when the selected branch matches the env's current", () => {
     expect(
       resolveRootComposeThreadEnvironment({
-        defaultBranch: "main",
-        defaultWorktreeBaseBranch: "origin/main",
         environmentValue: hostWorktreeEnvironmentValue,
         projectId,
         selectedBranch: selectedBranch("develop"),
@@ -141,8 +97,6 @@ describe("resolveRootComposeThreadEnvironment", () => {
   it("uses personal workspaces for the personal project", () => {
     expect(
       resolveRootComposeThreadEnvironment({
-        defaultBranch: null,
-        defaultWorktreeBaseBranch: null,
         environmentValue: hostLocalEnvironmentValue,
         projectId: PERSONAL_PROJECT_ID,
         selectedBranch: selectedBranch("develop"),

--- a/apps/app/src/views/root-compose-thread-environment.test.ts
+++ b/apps/app/src/views/root-compose-thread-environment.test.ts
@@ -17,6 +17,8 @@ describe("resolveRootComposeThreadEnvironment", () => {
   it("omits unmanaged branch checkout when no branch is selected", () => {
     expect(
       resolveRootComposeThreadEnvironment({
+        defaultBranch: null,
+        defaultWorktreeBaseBranch: null,
         environmentValue: hostLocalEnvironmentValue,
         projectId,
         selectedBranch: null,
@@ -34,6 +36,8 @@ describe("resolveRootComposeThreadEnvironment", () => {
   it("sends explicit existing branch checkout for host local", () => {
     expect(
       resolveRootComposeThreadEnvironment({
+        defaultBranch: null,
+        defaultWorktreeBaseBranch: null,
         environmentValue: hostLocalEnvironmentValue,
         projectId,
         selectedBranch: selectedBranch("develop"),
@@ -52,6 +56,8 @@ describe("resolveRootComposeThreadEnvironment", () => {
   it("sends explicit new branch checkout for host local", () => {
     expect(
       resolveRootComposeThreadEnvironment({
+        defaultBranch: null,
+        defaultWorktreeBaseBranch: null,
         environmentValue: hostLocalEnvironmentValue,
         projectId,
         selectedBranch: { name: "develop", isNew: true },
@@ -64,9 +70,45 @@ describe("resolveRootComposeThreadEnvironment", () => {
     });
   });
 
-  it("preserves implicit default intent for authoritative server resolution", () => {
+  it("submits the resolved local default displayed by the selector", () => {
     expect(
       resolveRootComposeThreadEnvironment({
+        defaultBranch: "main",
+        defaultWorktreeBaseBranch: "main",
+        environmentValue: hostWorktreeEnvironmentValue,
+        projectId,
+        selectedBranch: null,
+      }),
+    ).toMatchObject({
+      workspace: {
+        type: "managed-worktree",
+        baseBranch: { kind: "named", name: "main" },
+      },
+    });
+  });
+
+  it("submits the resolved remote default displayed by the selector", () => {
+    expect(
+      resolveRootComposeThreadEnvironment({
+        defaultBranch: "main",
+        defaultWorktreeBaseBranch: "origin/main",
+        environmentValue: hostWorktreeEnvironmentValue,
+        projectId,
+        selectedBranch: null,
+      }),
+    ).toMatchObject({
+      workspace: {
+        type: "managed-worktree",
+        baseBranch: { kind: "named", name: "origin/main" },
+      },
+    });
+  });
+
+  it("falls back to default while branch metadata is unavailable", () => {
+    expect(
+      resolveRootComposeThreadEnvironment({
+        defaultBranch: undefined,
+        defaultWorktreeBaseBranch: undefined,
         environmentValue: hostWorktreeEnvironmentValue,
         projectId,
         selectedBranch: null,
@@ -82,6 +124,8 @@ describe("resolveRootComposeThreadEnvironment", () => {
   it("sends a named base branch when the selected branch matches the env's current", () => {
     expect(
       resolveRootComposeThreadEnvironment({
+        defaultBranch: "main",
+        defaultWorktreeBaseBranch: "origin/main",
         environmentValue: hostWorktreeEnvironmentValue,
         projectId,
         selectedBranch: selectedBranch("develop"),
@@ -97,6 +141,8 @@ describe("resolveRootComposeThreadEnvironment", () => {
   it("uses personal workspaces for the personal project", () => {
     expect(
       resolveRootComposeThreadEnvironment({
+        defaultBranch: null,
+        defaultWorktreeBaseBranch: null,
         environmentValue: hostLocalEnvironmentValue,
         projectId: PERSONAL_PROJECT_ID,
         selectedBranch: selectedBranch("develop"),

--- a/apps/app/src/views/root-compose-thread-environment.ts
+++ b/apps/app/src/views/root-compose-thread-environment.ts
@@ -8,34 +8,19 @@ export interface RootComposeSelectedBranch {
 }
 
 interface ResolveRootComposeThreadEnvironmentArgs {
-  defaultBranch: string | null | undefined;
-  defaultWorktreeBaseBranch: string | null | undefined;
   environmentValue: string;
   projectId: string | undefined;
   selectedBranch: RootComposeSelectedBranch | null;
 }
 
-interface ResolveManagedBaseBranchArgs {
-  defaultBranch: string | null | undefined;
-  defaultWorktreeBaseBranch: string | null | undefined;
-  selectedBranch: RootComposeSelectedBranch | null;
-}
-
 function resolveManagedBaseBranch(
-  args: ResolveManagedBaseBranchArgs,
+  selectedBranch: RootComposeSelectedBranch | null,
 ): BaseBranchSpec {
-  if (!args.selectedBranch) {
-    if (
-      args.defaultWorktreeBaseBranch &&
-      args.defaultWorktreeBaseBranch !== args.defaultBranch
-    ) {
-      return { kind: "named", name: args.defaultWorktreeBaseBranch };
-    }
-
+  if (!selectedBranch) {
     return { kind: "default" };
   }
 
-  return { kind: "named", name: args.selectedBranch.name };
+  return { kind: "named", name: selectedBranch.name };
 }
 
 export function resolveRootComposeThreadEnvironment(
@@ -65,11 +50,7 @@ export function resolveRootComposeThreadEnvironment(
         hostId: parsed.hostId,
         workspace: {
           type: "managed-worktree",
-          baseBranch: resolveManagedBaseBranch({
-            defaultBranch: args.defaultBranch,
-            defaultWorktreeBaseBranch: args.defaultWorktreeBaseBranch,
-            selectedBranch: args.selectedBranch,
-          }),
+          baseBranch: resolveManagedBaseBranch(args.selectedBranch),
         },
       };
     }

--- a/apps/app/src/views/root-compose-thread-environment.ts
+++ b/apps/app/src/views/root-compose-thread-environment.ts
@@ -8,19 +8,27 @@ export interface RootComposeSelectedBranch {
 }
 
 interface ResolveRootComposeThreadEnvironmentArgs {
+  defaultBranch: string | null | undefined;
+  defaultWorktreeBaseBranch: string | null | undefined;
   environmentValue: string;
   projectId: string | undefined;
   selectedBranch: RootComposeSelectedBranch | null;
 }
 
-function resolveManagedBaseBranch(
-  selectedBranch: RootComposeSelectedBranch | null,
-): BaseBranchSpec {
-  if (!selectedBranch) {
-    return { kind: "default" };
-  }
+type ResolveManagedBaseBranchArgs = Pick<
+  ResolveRootComposeThreadEnvironmentArgs,
+  "defaultBranch" | "defaultWorktreeBaseBranch" | "selectedBranch"
+>;
 
-  return { kind: "named", name: selectedBranch.name };
+function resolveManagedBaseBranch(
+  args: ResolveManagedBaseBranchArgs,
+): BaseBranchSpec {
+  const branchName =
+    args.selectedBranch?.name ??
+    args.defaultWorktreeBaseBranch ??
+    args.defaultBranch;
+
+  return branchName ? { kind: "named", name: branchName } : { kind: "default" };
 }
 
 export function resolveRootComposeThreadEnvironment(
@@ -50,7 +58,7 @@ export function resolveRootComposeThreadEnvironment(
         hostId: parsed.hostId,
         workspace: {
           type: "managed-worktree",
-          baseBranch: resolveManagedBaseBranch(args.selectedBranch),
+          baseBranch: resolveManagedBaseBranch(args),
         },
       };
     }

--- a/apps/cli/src/__tests__/command-output/project.test.ts
+++ b/apps/cli/src/__tests__/command-output/project.test.ts
@@ -232,6 +232,33 @@ describe("bb project command output", () => {
     ).toEqual(projects);
   });
 
+  it("bb project branches can wait for remote refs", async () => {
+    const branches = { branches: ["main"], remoteBranches: ["origin/main"] };
+    const get = vi.fn(async () => branches);
+    stubServerApi({ "v1.projects.:id.branches.$get": get });
+
+    await runCommand(
+      [
+        "project",
+        "branches",
+        "proj-1",
+        "--host",
+        "host-1",
+        "--refresh",
+        "--json",
+      ],
+      register,
+    );
+
+    expect(get).toHaveBeenCalledWith({
+      param: { id: "proj-1" },
+      query: { hostId: "host-1", refresh: "blocking" },
+    });
+    expect(
+      JSON.parse(String(vi.mocked(console.log).mock.calls[0]?.[0])),
+    ).toEqual(branches);
+  });
+
   it("bb project list renders the shared borderless table", async () => {
     const projects = [
       {

--- a/apps/cli/src/commands/project.ts
+++ b/apps/cli/src/commands/project.ts
@@ -53,6 +53,7 @@ interface ProjectDiscoveryCommandOptions {
   limit?: string;
   provider?: string;
   query?: string;
+  refresh?: boolean;
 }
 
 function addProjectWorkspaceRoutingOptions(command: Command): Command {
@@ -390,6 +391,7 @@ export function registerProjectCommands(
     .requiredOption("--host <id>", "Source machine ID")
     .option("--query <query>", "Branch-name filter")
     .option("--limit <count>", "Maximum branches")
+    .option("--refresh", "Wait for remote refs before listing")
     .option("--json", "Print machine-readable JSON output")
     .action(
       action(async (id: string, opts: ProjectDiscoveryCommandOptions) => {
@@ -398,6 +400,7 @@ export function registerProjectCommands(
           hostId: opts.host ?? "",
           ...(opts.query ? { query: opts.query } : {}),
           ...(opts.limit ? { limit: opts.limit } : {}),
+          ...(opts.refresh ? { refresh: "blocking" as const } : {}),
         });
         if (outputJson(opts, result)) return;
         console.log(JSON.stringify(result, null, 2));

--- a/apps/host-daemon/src/command-dispatch.ts
+++ b/apps/host-daemon/src/command-dispatch.ts
@@ -20,8 +20,8 @@ import {
   provisionEnvironment,
 } from "./command-handlers/environment.js";
 import {
+  inspectHostGitSource,
   listHostBranchOptions,
-  listHostBranches,
 } from "./command-handlers/host-branches.js";
 import {
   installGlobalSkills,
@@ -595,8 +595,8 @@ const onlineRpcHandlers: OnlineRpcHandlerMap = {
   "host.install_global_skills": installGlobalSkills,
   "host.global_skills_status": async (command) =>
     readGlobalSkillsStatus(command, {}),
+  "host.inspect_git_source": inspectHostGitSource,
   "host.list_branch_options": listHostBranchOptions,
-  "host.list_branches": listHostBranches,
   "host.file_metadata": readHostFileMetadata,
   "host.read_file": readHostFile,
   "host.read_file_relative": readHostRelativeFile,

--- a/apps/host-daemon/src/command-handlers/host-branches.ts
+++ b/apps/host-daemon/src/command-handlers/host-branches.ts
@@ -4,7 +4,6 @@ import type {
   WorkspaceGitOperation,
 } from "@bb/domain";
 import {
-  detectGitRepo,
   detectGitRepoKind,
   fetchRemoteBranches,
   getCheckoutRef,
@@ -12,8 +11,6 @@ import {
   getWorkspaceGitOperation,
   hasUncommittedChanges,
   listBranchRefsWithDefaults,
-  listBranches,
-  listRemoteBranches,
   readDefaultBranchRefs,
   type GitProcessOptions,
 } from "@bb/host-workspace";
@@ -38,7 +35,7 @@ interface LimitedBranchList {
 
 interface PinBranchArgs {
   branches: readonly string[];
-  branch: string | null | undefined;
+  branch: string | undefined;
 }
 
 interface ClassifySelectedBranchArgs {
@@ -200,7 +197,7 @@ export async function listHostBranchOptions(
   const gitProcessOptions = userExecutableProcessOptions(
     options?.runtimeManager.getShellEnv() ?? {},
   );
-  if (!(await detectGitRepo(command.path, gitProcessOptions))) {
+  if ((await detectGitRepoKind(command.path, gitProcessOptions)) === "none") {
     return {
       branches: [],
       branchesTruncated: false,
@@ -223,10 +220,10 @@ export async function listHostBranchOptions(
   return readBranchOptions({ ...command, ...gitProcessOptions });
 }
 
-export async function listHostBranches(
-  command: CommandOf<"host.list_branches">,
+export async function inspectHostGitSource(
+  command: CommandOf<"host.inspect_git_source">,
   options?: Pick<CommandDispatchOptions, "runtimeManager">,
-): Promise<HostDaemonOnlineRpcResult<"host.list_branches">> {
+): Promise<HostDaemonOnlineRpcResult<"host.inspect_git_source">> {
   if (!path.isAbsolute(command.path)) {
     throw new CommandDispatchError("invalid_path", "Path must be absolute");
   }
@@ -237,73 +234,41 @@ export async function listHostBranches(
   const repoKind = await detectGitRepoKind(command.path, gitProcessOptions);
   if (repoKind === "none") {
     return {
-      branches: [],
-      branchesTruncated: false,
       checkout: { kind: "unknown", reason: "Path is not a git repository" },
       defaultBranch: null,
       defaultBranchRelation: null,
       hasUncommittedChanges: false,
       operation: { kind: "none" },
       originDefaultBranch: null,
-      remoteBranches: [],
-      remoteBranchesTruncated: false,
-      selectedBranch: classifySelectedBranch({
-        branches: [],
-        remoteBranches: [],
-        selectedBranch: command.selectedBranch,
-      }),
     };
   }
 
-  await refreshRemoteBranches(command.path, gitProcessOptions);
+  if (command.remoteRefresh === "blocking") {
+    await refreshRemoteBranches(command.path, gitProcessOptions);
+  } else {
+    void refreshRemoteBranches(command.path, gitProcessOptions).catch(
+      () => undefined,
+    );
+  }
 
-  const [branches, remoteBranches, checkout, defaultRefs, dirty, operation] =
-    await Promise.all([
-      listBranches(command.path, gitProcessOptions),
-      listRemoteBranches(command.path, gitProcessOptions),
-      getCheckoutRef(command.path, gitProcessOptions),
-      readDefaultBranchRefs(command.path, gitProcessOptions),
-      repoKind === "work-tree"
-        ? hasUncommittedChanges(command.path, gitProcessOptions)
-        : false,
-      repoKind === "work-tree"
-        ? getWorkspaceGitOperation(command.path, gitProcessOptions)
-        : NO_GIT_OPERATION,
-    ]);
+  const [checkout, defaultRefs, dirty, operation] = await Promise.all([
+    getCheckoutRef(command.path, gitProcessOptions),
+    readDefaultBranchRefs(command.path, gitProcessOptions),
+    repoKind === "work-tree"
+      ? hasUncommittedChanges(command.path, gitProcessOptions)
+      : false,
+    repoKind === "work-tree"
+      ? getWorkspaceGitOperation(command.path, gitProcessOptions)
+      : NO_GIT_OPERATION,
+  ]);
   const defaultBranch = defaultRefs.defaultBranch;
   const originDefaultBranch = defaultRefs.originDefaultBranch;
-  const sorted = pinBranch({ branches, branch: defaultBranch });
-  const sortedRemoteBranches = pinBranch({
-    branches: remoteBranches,
-    branch:
-      originDefaultBranch ?? (defaultBranch ? `origin/${defaultBranch}` : null),
-  });
-  const limitedBranches = limitBranchList({
-    branches: sorted,
-    limit: command.limit,
-    query: command.query,
-  });
-  const limitedRemoteBranches = limitBranchList({
-    branches: sortedRemoteBranches,
-    limit: command.limit,
-    query: command.query,
-  });
-  const selectedBranch = classifySelectedBranch({
-    branches,
-    remoteBranches,
-    selectedBranch: command.selectedBranch,
-  });
   return {
-    branches: limitedBranches.branches,
-    branchesTruncated: limitedBranches.truncated,
     checkout,
     defaultBranch: defaultBranch ?? null,
     defaultBranchRelation: defaultRefs.defaultBranchRelation ?? null,
     hasUncommittedChanges: dirty,
     operation,
     originDefaultBranch: originDefaultBranch ?? null,
-    remoteBranches: limitedRemoteBranches.branches,
-    remoteBranchesTruncated: limitedRemoteBranches.truncated,
-    selectedBranch,
   };
 }

--- a/apps/host-daemon/test/command/host-branches-dispatch.test.ts
+++ b/apps/host-daemon/test/command/host-branches-dispatch.test.ts
@@ -26,6 +26,58 @@ async function initBranchRepo(): Promise<string> {
   return repoPath;
 }
 
+interface StaleOriginMainRepo {
+  releaseRefreshPath: string;
+  refreshStartedPath: string;
+  repoPath: string;
+}
+
+async function initStaleOriginMainRepo(): Promise<StaleOriginMainRepo> {
+  const repoPath = await initBranchRepo();
+  const remotePath = await makeTempDir("bb-host-branches-stale-remote-");
+  await runGitCommand(["init", "--bare"], { cwd: remotePath });
+  await runGitCommand(["symbolic-ref", "HEAD", "refs/heads/main"], {
+    cwd: remotePath,
+  });
+  await runGitCommand(["remote", "add", "origin", remotePath], {
+    cwd: repoPath,
+  });
+  await runGitCommand(["push", "origin", "main"], { cwd: repoPath });
+  await runGitCommand(["fetch", "origin"], { cwd: repoPath });
+  await runGitCommand(["remote", "set-head", "origin", "main"], {
+    cwd: repoPath,
+  });
+
+  const cloneParent = await makeTempDir("bb-host-branches-stale-clone-");
+  const clonePath = path.join(cloneParent, "repo");
+  await runGitCommand(["clone", remotePath, clonePath], { cwd: cloneParent });
+  await runGitCommand(["config", "user.name", "BB Tests"], {
+    cwd: clonePath,
+  });
+  await runGitCommand(["config", "user.email", "bb@example.com"], {
+    cwd: clonePath,
+  });
+  await fs.writeFile(path.join(clonePath, "remote.txt"), "remote\n", "utf8");
+  await runGitCommand(["add", "."], { cwd: clonePath });
+  await runGitCommand(["commit", "-m", "Advance remote main"], {
+    cwd: clonePath,
+  });
+  await runGitCommand(["push", "origin", "main"], { cwd: clonePath });
+
+  const refreshStartedPath = path.join(repoPath, "refresh-started");
+  const releaseRefreshPath = path.join(repoPath, "release-refresh");
+  const uploadPackPath = path.join(repoPath, "delayed-upload-pack.sh");
+  await fs.writeFile(
+    uploadPackPath,
+    `#!/bin/sh\ntouch ${JSON.stringify(refreshStartedPath)}\nwhile [ ! -f ${JSON.stringify(releaseRefreshPath)} ]; do sleep 0.01; done\nsleep 0.2\nexec git-upload-pack "$@"\n`,
+    { encoding: "utf8", mode: 0o755 },
+  );
+  await runGitCommand(["config", "remote.origin.uploadpack", uploadPackPath], {
+    cwd: repoPath,
+  });
+  return { releaseRefreshPath, refreshStartedPath, repoPath };
+}
+
 async function expectResolvesWithin<T>(
   promise: Promise<T>,
   timeoutMs: number,
@@ -47,6 +99,22 @@ async function expectResolvesWithin<T>(
   }
 }
 
+async function expectRemainsPending(
+  promise: Promise<unknown>,
+  timeoutMs = 100,
+): Promise<void> {
+  const state = await Promise.race([
+    promise.then(
+      () => "settled" as const,
+      () => "settled" as const,
+    ),
+    new Promise<"pending">((resolve) => {
+      setTimeout(() => resolve("pending"), timeoutMs);
+    }),
+  ]);
+  expect(state).toBe("pending");
+}
+
 async function waitForFile(filePath: string): Promise<void> {
   const deadline = Date.now() + 2_000;
   while (Date.now() < deadline) {
@@ -60,189 +128,100 @@ async function waitForFile(filePath: string): Promise<void> {
   throw new Error(`File did not appear within 2000ms: ${filePath}`);
 }
 
-describe("host.list_branches dispatch", () => {
-  it("lists branches for a git repo and pins the default branch first", async () => {
-    const repoPath = await initBranchRepo();
-    const harness = createHarness();
-
-    const result = await dispatchOnlineRpcCommand(
-      { type: "host.list_branches", path: repoPath, limit: 50 },
-      harness.dispatchOptions(),
-    );
-
-    expect(result.checkout).toMatchObject({
-      kind: "branch",
-      branchName: "develop",
-    });
-    expect(result.defaultBranch).toBe("main");
-    expect(result.hasUncommittedChanges).toBe(false);
-    expect(result.operation).toEqual({ kind: "none" });
-    expect(result.remoteBranches).toEqual([]);
-    expect(result.selectedBranch).toBeNull();
-    expect(result.branchesTruncated).toBe(false);
-    expect(result.remoteBranchesTruncated).toBe(false);
-    expect(result.branches[0]).toBe("main");
-    expect(result.branches).toHaveLength(3);
-    expect(result.branches).toEqual(
-      expect.arrayContaining(["main", "develop", "release/1.2"]),
-    );
-  });
-
-  it("lists remote branches separately from local checkout branches", async () => {
-    const repoPath = await initBranchRepo();
-    const remotePath = await makeTempDir("bb-host-branches-remote-");
-    await runGitCommand(["init", "--bare"], { cwd: remotePath });
-    await runGitCommand(["remote", "add", "upstream", remotePath], {
-      cwd: repoPath,
-    });
-    await runGitCommand(["push", "upstream", "develop", "main"], {
-      cwd: repoPath,
-    });
-    await runGitCommand(["fetch", "upstream"], { cwd: repoPath });
-    const harness = createHarness();
-
-    const result = await dispatchOnlineRpcCommand(
-      { type: "host.list_branches", path: repoPath, limit: 50 },
-      harness.dispatchOptions(),
-    );
-
-    expect(result.branches).toEqual(["main", "develop", "release/1.2"]);
-    expect(result.remoteBranches).toEqual([
-      "upstream/develop",
-      "upstream/main",
-    ]);
-  });
-
-  it("pins origin default branch first in remote branch results", async () => {
-    const repoPath = await initBranchRepo();
-    const remotePath = await makeTempDir("bb-host-branches-origin-");
-    await runGitCommand(["init", "--bare"], { cwd: remotePath });
-    await runGitCommand(["remote", "add", "origin", remotePath], {
-      cwd: repoPath,
-    });
-    await runGitCommand(["branch", "bb/aardvark"], { cwd: repoPath });
-    await runGitCommand(["push", "origin", "bb/aardvark", "main"], {
-      cwd: repoPath,
-    });
-    await runGitCommand(["fetch", "origin"], { cwd: repoPath });
-    const harness = createHarness();
-
-    const result = await dispatchOnlineRpcCommand(
-      { type: "host.list_branches", path: repoPath, limit: 1 },
-      harness.dispatchOptions(),
-    );
-
-    expect(result.defaultBranch).toBe("main");
-    expect(result.remoteBranches).toEqual(["origin/main"]);
-    expect(result.remoteBranchesTruncated).toBe(true);
-  });
-
-  it("classifies a selected branch before filtering and pagination", async () => {
-    const repoPath = await initBranchRepo();
-    const remotePath = await makeTempDir("bb-host-branches-remote-");
-    await runGitCommand(["init", "--bare"], { cwd: remotePath });
-    await runGitCommand(["remote", "add", "upstream", remotePath], {
-      cwd: repoPath,
-    });
-    await runGitCommand(["push", "upstream", "develop", "main"], {
-      cwd: repoPath,
-    });
-    await runGitCommand(["fetch", "upstream"], { cwd: repoPath });
-    const harness = createHarness();
-
-    const result = await dispatchOnlineRpcCommand(
-      {
-        type: "host.list_branches",
-        path: repoPath,
-        query: "release",
-        selectedBranch: "upstream/main",
-        limit: 1,
-      },
-      harness.dispatchOptions(),
-    );
-
-    expect(result.branches).toEqual(["release/1.2"]);
-    expect(result.remoteBranches).toEqual([]);
-    expect(result.selectedBranch).toEqual({
-      name: "upstream/main",
-      kind: "remote",
-    });
-
-    const missingResult = await dispatchOnlineRpcCommand(
-      {
-        type: "host.list_branches",
-        path: repoPath,
-        query: "release",
-        selectedBranch: "origin/main",
-        limit: 1,
-      },
-      harness.dispatchOptions(),
-    );
-
-    expect(missingResult.selectedBranch).toEqual({
-      name: "origin/main",
-      kind: "missing",
-    });
-  });
-
-  it("refreshes remote branches before filtering branch lists", async () => {
-    const repoPath = await initBranchRepo();
-    const remotePath = await makeTempDir("bb-host-branches-fetch-remote-");
-    await runGitCommand(["init", "--bare"], { cwd: remotePath });
-    await runGitCommand(["remote", "add", "origin", remotePath], {
-      cwd: repoPath,
-    });
-    await runGitCommand(["push", "origin", "main"], { cwd: repoPath });
-    await runGitCommand(["fetch", "origin"], { cwd: repoPath });
-    const cloneParent = await makeTempDir("bb-host-branches-fetch-clone-");
-    const clonePath = path.join(cloneParent, "repo");
-    await runGitCommand(["clone", remotePath, clonePath], { cwd: cloneParent });
-    await runGitCommand(["config", "user.name", "BB Tests"], {
-      cwd: clonePath,
-    });
-    await runGitCommand(["config", "user.email", "bb@example.com"], {
-      cwd: clonePath,
-    });
-    await runGitCommand(["switch", "-c", "feature/remote-only"], {
-      cwd: clonePath,
-    });
-    await fs.writeFile(path.join(clonePath, "remote.txt"), "remote\n", "utf8");
-    await runGitCommand(["add", "."], { cwd: clonePath });
-    await runGitCommand(["commit", "-m", "Remote branch"], { cwd: clonePath });
-    await runGitCommand(["push", "origin", "feature/remote-only"], {
-      cwd: clonePath,
-    });
-    const harness = createHarness();
-
-    const result = await dispatchOnlineRpcCommand(
-      {
-        type: "host.list_branches",
-        path: repoPath,
-        query: "remote-only",
-        limit: 50,
-      },
-      harness.dispatchOptions(),
-    );
-
-    expect(result.remoteBranches).toEqual(["origin/feature/remote-only"]);
-  });
-
-  it("filters and limits branch lists", async () => {
+describe("host.inspect_git_source dispatch", () => {
+  it("reports checkout and default-ref metadata without branch pages", async () => {
     const repoPath = await initBranchRepo();
     const harness = createHarness();
 
     const result = await dispatchOnlineRpcCommand(
       {
-        type: "host.list_branches",
+        type: "host.inspect_git_source",
         path: repoPath,
-        query: "e",
-        limit: 1,
+        remoteRefresh: "blocking",
       },
       harness.dispatchOptions(),
     );
 
-    expect(result.branches).toEqual(["develop"]);
-    expect(result.branchesTruncated).toBe(true);
+    expect(result).toMatchObject({
+      checkout: { kind: "branch", branchName: "develop" },
+      defaultBranch: "main",
+      defaultBranchRelation: null,
+      hasUncommittedChanges: false,
+      operation: { kind: "none" },
+      originDefaultBranch: null,
+    });
+  });
+
+  it("returns cached metadata while refreshing remotes in the background", async () => {
+    const { releaseRefreshPath, refreshStartedPath, repoPath } =
+      await initStaleOriginMainRepo();
+    const harness = createHarness();
+    let refreshedResult: Awaited<ReturnType<typeof dispatchOnlineRpcCommand>>;
+
+    try {
+      const result = await expectResolvesWithin(
+        dispatchOnlineRpcCommand(
+          {
+            type: "host.inspect_git_source",
+            path: repoPath,
+            remoteRefresh: "background",
+          },
+          harness.dispatchOptions(),
+        ),
+        2_000,
+      );
+      expect(result).toMatchObject({
+        defaultBranch: "main",
+        defaultBranchRelation: "equal",
+        originDefaultBranch: "origin/main",
+      });
+      await waitForFile(refreshStartedPath);
+    } finally {
+      await fs.writeFile(releaseRefreshPath, "release\n", "utf8");
+      refreshedResult = await dispatchOnlineRpcCommand(
+        {
+          type: "host.inspect_git_source",
+          path: repoPath,
+          remoteRefresh: "blocking",
+        },
+        harness.dispatchOptions(),
+      );
+    }
+
+    expect(refreshedResult).toMatchObject({
+      defaultBranch: "main",
+      defaultBranchRelation: "local-behind",
+      originDefaultBranch: "origin/main",
+    });
+  });
+
+  it("waits for a blocking refresh before reading default-ref metadata", async () => {
+    const { releaseRefreshPath, refreshStartedPath, repoPath } =
+      await initStaleOriginMainRepo();
+    const harness = createHarness();
+    const resultPromise = dispatchOnlineRpcCommand(
+      {
+        type: "host.inspect_git_source",
+        path: repoPath,
+        remoteRefresh: "blocking",
+      },
+      harness.dispatchOptions(),
+    );
+    let result: Awaited<typeof resultPromise>;
+
+    try {
+      await waitForFile(refreshStartedPath);
+      await expectRemainsPending(resultPromise);
+    } finally {
+      await fs.writeFile(releaseRefreshPath, "release\n", "utf8");
+      result = await resultPromise;
+    }
+
+    expect(result).toMatchObject({
+      defaultBranch: "main",
+      defaultBranchRelation: "local-behind",
+      originDefaultBranch: "origin/main",
+    });
   });
 
   it("reports detached HEAD in checkout state", async () => {
@@ -251,14 +230,15 @@ describe("host.list_branches dispatch", () => {
     const harness = createHarness();
 
     const result = await dispatchOnlineRpcCommand(
-      { type: "host.list_branches", path: repoPath, limit: 50 },
+      {
+        type: "host.inspect_git_source",
+        path: repoPath,
+        remoteRefresh: "blocking",
+      },
       harness.dispatchOptions(),
     );
 
     expect(result.checkout.kind).toBe("detached");
-    expect(result.branches).toEqual(
-      expect.arrayContaining(["main", "develop", "release/1.2"]),
-    );
   });
 
   it("reports dirty primary checkouts", async () => {
@@ -267,7 +247,11 @@ describe("host.list_branches dispatch", () => {
     const harness = createHarness();
 
     const result = await dispatchOnlineRpcCommand(
-      { type: "host.list_branches", path: repoPath, limit: 50 },
+      {
+        type: "host.inspect_git_source",
+        path: repoPath,
+        remoteRefresh: "blocking",
+      },
       harness.dispatchOptions(),
     );
 
@@ -275,7 +259,7 @@ describe("host.list_branches dispatch", () => {
     expect(result.operation).toEqual({ kind: "none" });
   });
 
-  it("lists branches for a bare repository root that holds sibling worktrees", async () => {
+  it("inspects a bare repository root that holds sibling worktrees", async () => {
     const origin = await initBranchRepo();
     const root = await makeTempDir("bb-host-branches-bare-root-");
     await runGitCommand(["clone", "--bare", origin, ".bare"], { cwd: root });
@@ -284,7 +268,11 @@ describe("host.list_branches dispatch", () => {
     const harness = createHarness();
 
     const result = await dispatchOnlineRpcCommand(
-      { type: "host.list_branches", path: root, limit: 50 },
+      {
+        type: "host.inspect_git_source",
+        path: root,
+        remoteRefresh: "blocking",
+      },
       harness.dispatchOptions(),
     );
 
@@ -293,67 +281,127 @@ describe("host.list_branches dispatch", () => {
       branchName: "develop",
     });
     expect(result.defaultBranch).toBe("main");
-    expect(result.branches).toEqual(
-      expect.arrayContaining(["main", "develop", "release/1.2"]),
-    );
     expect(result.hasUncommittedChanges).toBe(false);
     expect(result.operation).toEqual({ kind: "none" });
   });
 
-  it("returns an empty list for non-git directories", async () => {
+  it("reports non-git directories", async () => {
     const dirPath = await makeTempDir("bb-host-branches-nongit-");
     const harness = createHarness();
 
     const result = await dispatchOnlineRpcCommand(
-      { type: "host.list_branches", path: dirPath, limit: 50 },
-      harness.dispatchOptions(),
-    );
-
-    expect(result).toEqual({
-      branches: [],
-      branchesTruncated: false,
-      checkout: { kind: "unknown", reason: "Path is not a git repository" },
-      defaultBranch: null,
-      defaultBranchRelation: null,
-      hasUncommittedChanges: false,
-      operation: { kind: "none" },
-      originDefaultBranch: null,
-      remoteBranches: [],
-      remoteBranchesTruncated: false,
-      selectedBranch: null,
-    });
-  });
-
-  it("returns an empty list for missing paths", async () => {
-    const parentPath = await makeTempDir("bb-host-branches-missing-parent-");
-    const harness = createHarness();
-
-    const result = await dispatchOnlineRpcCommand(
       {
-        type: "host.list_branches",
-        path: path.join(parentPath, "missing"),
-        limit: 50,
+        type: "host.inspect_git_source",
+        path: dirPath,
+        remoteRefresh: "blocking",
       },
       harness.dispatchOptions(),
     );
 
     expect(result).toEqual({
-      branches: [],
-      branchesTruncated: false,
       checkout: { kind: "unknown", reason: "Path is not a git repository" },
       defaultBranch: null,
       defaultBranchRelation: null,
       hasUncommittedChanges: false,
       operation: { kind: "none" },
       originDefaultBranch: null,
-      remoteBranches: [],
-      remoteBranchesTruncated: false,
-      selectedBranch: null,
+    });
+  });
+
+  it("reports missing paths", async () => {
+    const parentPath = await makeTempDir("bb-host-branches-missing-parent-");
+    const harness = createHarness();
+
+    const result = await dispatchOnlineRpcCommand(
+      {
+        type: "host.inspect_git_source",
+        path: path.join(parentPath, "missing"),
+        remoteRefresh: "blocking",
+      },
+      harness.dispatchOptions(),
+    );
+
+    expect(result).toEqual({
+      checkout: { kind: "unknown", reason: "Path is not a git repository" },
+      defaultBranch: null,
+      defaultBranchRelation: null,
+      hasUncommittedChanges: false,
+      operation: { kind: "none" },
+      originDefaultBranch: null,
     });
   });
 });
 
 describe("host.list_branch_options dispatch", () => {
+  it("preserves complete local branch ordering", async () => {
+    const repoPath = await initBranchRepo();
+    const harness = createHarness();
+
+    const result = await dispatchOnlineRpcCommand(
+      {
+        type: "host.list_branch_options",
+        path: repoPath,
+        limit: 50,
+        remoteRefresh: "none",
+      },
+      harness.dispatchOptions(),
+    );
+
+    expect(result.branches).toEqual(["main", "develop", "release/1.2"]);
+    expect(result.branchesTruncated).toBe(false);
+  });
+
+  it("lists multiple branches from a non-origin remote in stable order", async () => {
+    const repoPath = await initBranchRepo();
+    const remotePath = await makeTempDir("bb-host-branch-options-upstream-");
+    await runGitCommand(["init", "--bare"], { cwd: remotePath });
+    await runGitCommand(["remote", "add", "upstream", remotePath], {
+      cwd: repoPath,
+    });
+    await runGitCommand(["push", "upstream", "develop", "main"], {
+      cwd: repoPath,
+    });
+    await runGitCommand(["fetch", "upstream"], { cwd: repoPath });
+    const harness = createHarness();
+
+    const result = await dispatchOnlineRpcCommand(
+      {
+        type: "host.list_branch_options",
+        path: repoPath,
+        limit: 50,
+        remoteRefresh: "none",
+      },
+      harness.dispatchOptions(),
+    );
+
+    expect(result.remoteBranches).toEqual([
+      "upstream/develop",
+      "upstream/main",
+    ]);
+    expect(result.remoteBranchesTruncated).toBe(false);
+  });
+
+  it("computes truncation after query filtering", async () => {
+    const repoPath = await initBranchRepo();
+    await runGitCommand(["branch", "release/2.0"], { cwd: repoPath });
+    const harness = createHarness();
+
+    const result = await dispatchOnlineRpcCommand(
+      {
+        type: "host.list_branch_options",
+        path: repoPath,
+        query: "release",
+        limit: 1,
+        remoteRefresh: "none",
+      },
+      harness.dispatchOptions(),
+    );
+
+    expect(result.branches).toEqual(["release/1.2"]);
+    expect(result.branchesTruncated).toBe(true);
+    expect(result.remoteBranchesTruncated).toBe(false);
+  });
+
   it("pins local and remote defaults before applying the page limit", async () => {
     const repoPath = await initBranchRepo();
     const remotePath = await makeTempDir("bb-host-branch-options-origin-");
@@ -456,13 +504,108 @@ describe("host.list_branch_options dispatch", () => {
       await waitForFile(refreshStartedPath);
     } finally {
       await fs.writeFile(releaseRefreshPath, "release\n", "utf8");
+      await dispatchOnlineRpcCommand(
+        {
+          type: "host.inspect_git_source",
+          path: repoPath,
+          remoteRefresh: "blocking",
+        },
+        harness.dispatchOptions(),
+      );
     }
 
     const refreshed = await dispatchOnlineRpcCommand(
-      { type: "host.list_branches", path: repoPath, limit: 50 },
+      {
+        type: "host.list_branch_options",
+        path: repoPath,
+        query: "remote-only",
+        limit: 50,
+        remoteRefresh: "none",
+      },
       harness.dispatchOptions(),
     );
     expect(refreshed.remoteBranches).toContain("origin/feature/remote-only");
+  });
+
+  it("classifies selected refs before filtering and pagination", async () => {
+    const repoPath = await initBranchRepo();
+    const remotePath = await makeTempDir("bb-host-branch-options-upstream-");
+    await runGitCommand(["init", "--bare"], { cwd: remotePath });
+    await runGitCommand(["remote", "add", "upstream", remotePath], {
+      cwd: repoPath,
+    });
+    await runGitCommand(["push", "upstream", "develop", "main"], {
+      cwd: repoPath,
+    });
+    await runGitCommand(["fetch", "upstream"], { cwd: repoPath });
+    const harness = createHarness();
+
+    const result = await dispatchOnlineRpcCommand(
+      {
+        type: "host.list_branch_options",
+        path: repoPath,
+        query: "release",
+        selectedBranch: "upstream/main",
+        limit: 1,
+        remoteRefresh: "none",
+      },
+      harness.dispatchOptions(),
+    );
+
+    expect(result.branches).toEqual(["release/1.2"]);
+    expect(result.remoteBranches).toEqual([]);
+    expect(result.selectedBranch).toEqual({
+      name: "upstream/main",
+      kind: "remote",
+    });
+  });
+
+  it("lists cached branches from bare project sources", async () => {
+    const origin = await initBranchRepo();
+    const root = await makeTempDir("bb-host-branch-options-bare-root-");
+    await runGitCommand(["clone", "--bare", origin, ".bare"], { cwd: root });
+    await fs.writeFile(path.join(root, ".git"), "gitdir: ./.bare\n", "utf8");
+    const harness = createHarness();
+
+    const result = await dispatchOnlineRpcCommand(
+      {
+        type: "host.list_branch_options",
+        path: root,
+        limit: 50,
+        remoteRefresh: "none",
+      },
+      harness.dispatchOptions(),
+    );
+
+    expect(result.branches).toEqual(
+      expect.arrayContaining(["main", "develop", "release/1.2"]),
+    );
+  });
+
+  it("returns empty pages for non-git and missing paths", async () => {
+    const dirPath = await makeTempDir("bb-host-branch-options-nongit-");
+    const harness = createHarness();
+
+    for (const sourcePath of [dirPath, path.join(dirPath, "missing")]) {
+      const result = await dispatchOnlineRpcCommand(
+        {
+          type: "host.list_branch_options",
+          path: sourcePath,
+          selectedBranch: "main",
+          limit: 50,
+          remoteRefresh: "none",
+        },
+        harness.dispatchOptions(),
+      );
+
+      expect(result).toEqual({
+        branches: [],
+        branchesTruncated: false,
+        remoteBranches: [],
+        remoteBranchesTruncated: false,
+        selectedBranch: { kind: "missing", name: "main" },
+      });
+    }
   });
 
   it("does not start a remote refresh when the caller opts out", async () => {

--- a/apps/server/src/routes/projects.ts
+++ b/apps/server/src/routes/projects.ts
@@ -834,17 +834,38 @@ export function registerProjectRoutes(app: Hono, deps: AppDeps): void {
     });
     const branchQuery = normalizeBranchQuery(query.query);
     const selectedBranch = normalizeBranchQuery(query.selectedBranch);
-    const result = await callHostRetryableOnlineRpc(deps, {
+    const remoteRefresh = query.refresh ?? "background";
+    const inspectionPromise = callHostRetryableOnlineRpc(deps, {
       hostId: source.hostId,
       timeoutMs: COMMAND_TIMEOUT_MS,
       command: {
-        type: "host.list_branches",
+        type: "host.inspect_git_source",
         path: source.path,
-        ...(branchQuery ? { query: branchQuery } : {}),
-        ...(selectedBranch ? { selectedBranch } : {}),
-        limit: parseBranchListLimit(query.limit),
+        remoteRefresh,
       },
     });
+    const readBranchOptions = () =>
+      callHostRetryableOnlineRpc(deps, {
+        hostId: source.hostId,
+        timeoutMs: COMMAND_TIMEOUT_MS,
+        command: {
+          type: "host.list_branch_options",
+          path: source.path,
+          ...(branchQuery ? { query: branchQuery } : {}),
+          ...(selectedBranch ? { selectedBranch } : {}),
+          limit: parseBranchListLimit(query.limit),
+          remoteRefresh: "none",
+        },
+      });
+    const branchOptionsPromise =
+      remoteRefresh === "background"
+        ? readBranchOptions()
+        : inspectionPromise.then(readBranchOptions);
+    const [inspection, branchOptions] = await Promise.all([
+      inspectionPromise,
+      branchOptionsPromise,
+    ]);
+    const result = { ...inspection, ...branchOptions };
     return context.json({
       ...result,
       defaultWorktreeBaseBranch: resolveDefaultWorktreeBaseBranch(result),

--- a/apps/server/src/services/projects/worktree-base-branch.ts
+++ b/apps/server/src/services/projects/worktree-base-branch.ts
@@ -38,16 +38,3 @@ export function resolveManagedDefaultBaseBranchSpec(
 
   return { kind: "default" };
 }
-
-export function resolveManagedNamedBaseBranchSpec(
-  spec: Extract<BaseBranchSpec, { kind: "named" }>,
-  checkout: ResolveDefaultWorktreeBaseBranchArgs,
-): BaseBranchSpec {
-  if (spec.name !== checkout.defaultBranch) {
-    return spec;
-  }
-  const resolved = resolveDefaultWorktreeBaseBranch(checkout);
-  return resolved && resolved !== spec.name
-    ? { kind: "named", name: resolved }
-    : spec;
-}

--- a/apps/server/src/services/projects/worktree-base-branch.ts
+++ b/apps/server/src/services/projects/worktree-base-branch.ts
@@ -1,10 +1,10 @@
-import type { ProjectSourceCheckout } from "@bb/domain";
+import type { GitSourceInspection } from "@bb/domain";
 import type { BaseBranchSpec } from "@bb/server-contract";
 
 interface ResolveDefaultWorktreeBaseBranchArgs {
-  defaultBranch: ProjectSourceCheckout["defaultBranch"];
-  defaultBranchRelation: ProjectSourceCheckout["defaultBranchRelation"];
-  originDefaultBranch: ProjectSourceCheckout["originDefaultBranch"];
+  defaultBranch: GitSourceInspection["defaultBranch"];
+  defaultBranchRelation: GitSourceInspection["defaultBranchRelation"];
+  originDefaultBranch: GitSourceInspection["originDefaultBranch"];
 }
 
 export function resolveDefaultWorktreeBaseBranch(

--- a/apps/server/src/services/threads/thread-create.ts
+++ b/apps/server/src/services/threads/thread-create.ts
@@ -62,10 +62,7 @@ import type {
   ThreadProvisionContext,
   ThreadProvisionEnvironmentIntent,
 } from "./thread-provisioning-context.js";
-import {
-  resolveManagedDefaultBaseBranchSpec,
-  resolveManagedNamedBaseBranchSpec,
-} from "../projects/worktree-base-branch.js";
+import { resolveManagedDefaultBaseBranchSpec } from "../projects/worktree-base-branch.js";
 import { applyLoggedEnvironmentLifecycleEvent } from "../environments/lifecycle-outcome.js";
 import { resolveSystemProviderModels } from "../system/execution-options.js";
 
@@ -214,7 +211,6 @@ function modelCatalogCwdForResolvedEnvironment(
 interface ResolveManagedBaseBranchForCreateArgs {
   baseBranch: BaseBranchSpec;
   hostId: string;
-  originKind: ThreadOriginKind | null;
   sourcePath: string;
 }
 
@@ -316,10 +312,7 @@ async function resolveManagedBaseBranchForCreate(
   deps: ThreadCreateDeps,
   args: ResolveManagedBaseBranchForCreateArgs,
 ): Promise<BaseBranchSpec> {
-  if (
-    args.baseBranch.kind === "named" &&
-    (args.originKind !== null || args.baseBranch.name.startsWith("origin/"))
-  ) {
+  if (args.baseBranch.kind === "named") {
     return args.baseBranch;
   }
 
@@ -330,12 +323,10 @@ async function resolveManagedBaseBranchForCreate(
       command: {
         type: "host.inspect_git_source",
         path: args.sourcePath,
-        remoteRefresh: "blocking",
+        remoteRefresh: "background",
       },
     });
-    return args.baseBranch.kind === "named"
-      ? resolveManagedNamedBaseBranchSpec(args.baseBranch, result)
-      : resolveManagedDefaultBaseBranchSpec(result);
+    return resolveManagedDefaultBaseBranchSpec(result);
   } catch (error) {
     deps.logger.warn(
       {
@@ -782,7 +773,6 @@ export async function createThreadFromRequest(
         baseBranch: await resolveManagedBaseBranchForCreate(deps, {
           baseBranch: workspace.baseBranch,
           hostId,
-          originKind,
           sourcePath: managedSource.path,
         }),
         workspaceProvisionType: workspace.type,

--- a/apps/server/src/services/threads/thread-create.ts
+++ b/apps/server/src/services/threads/thread-create.ts
@@ -328,9 +328,9 @@ async function resolveManagedBaseBranchForCreate(
       hostId: args.hostId,
       timeoutMs: COMMAND_TIMEOUT_MS,
       command: {
-        type: "host.list_branches",
+        type: "host.inspect_git_source",
         path: args.sourcePath,
-        limit: 1,
+        remoteRefresh: "blocking",
       },
     });
     return args.baseBranch.kind === "named"

--- a/apps/server/src/services/threads/thread-default-policy.ts
+++ b/apps/server/src/services/threads/thread-default-policy.ts
@@ -215,9 +215,9 @@ export async function resolveProjectDefaultThreadEnvironment(
     hostId,
     timeoutMs: COMMAND_TIMEOUT_MS,
     command: {
-      type: "host.list_branches",
+      type: "host.inspect_git_source",
       path: source.path,
-      limit: 1,
+      remoteRefresh: "blocking",
     },
   });
   const baseBranch = resolveDefaultWorktreeBaseBranch(checkout);

--- a/apps/server/src/services/threads/thread-default-policy.ts
+++ b/apps/server/src/services/threads/thread-default-policy.ts
@@ -217,7 +217,7 @@ export async function resolveProjectDefaultThreadEnvironment(
     command: {
       type: "host.inspect_git_source",
       path: source.path,
-      remoteRefresh: "blocking",
+      remoteRefresh: "background",
     },
   });
   const baseBranch = resolveDefaultWorktreeBaseBranch(checkout);

--- a/apps/server/test/helpers/commands.ts
+++ b/apps/server/test/helpers/commands.ts
@@ -129,9 +129,17 @@ const testRpcCursorByHost = new Map<string, number>();
 interface RegisterTestHostRpcCaptureArgs {
   hostId: string;
   sessionId: string;
-  listBranchesResult?: HostDaemonOnlineRpcResult<"host.list_branches">;
-  onListBranches?: (
-    command: Extract<HostDaemonRpcCommand, { type: "host.list_branches" }>,
+  queueBranchOptions?: boolean;
+  gitBranchOptionsResult?: HostDaemonOnlineRpcResult<"host.list_branch_options">;
+  onListBranchOptions?: (
+    command: Extract<
+      HostDaemonRpcCommand,
+      { type: "host.list_branch_options" }
+    >,
+  ) => void;
+  gitSourceInspectionResult?: HostDaemonOnlineRpcResult<"host.inspect_git_source">;
+  onInspectGitSource?: (
+    command: Extract<HostDaemonRpcCommand, { type: "host.inspect_git_source" }>,
   ) => void;
 }
 
@@ -263,12 +271,8 @@ function respondToProviderModelListCommand(
   return true;
 }
 
-function buildDefaultBranchListResult(
-  selectedBranch: string | undefined,
-): HostDaemonOnlineRpcResult<"host.list_branches"> {
+function buildDefaultGitSourceInspectionResult(): HostDaemonOnlineRpcResult<"host.inspect_git_source"> {
   return {
-    branches: ["main"],
-    branchesTruncated: false,
     checkout: {
       kind: "branch",
       branchName: "main",
@@ -279,6 +283,15 @@ function buildDefaultBranchListResult(
     hasUncommittedChanges: false,
     operation: { kind: "none" },
     originDefaultBranch: "origin/main",
+  };
+}
+
+function buildDefaultGitBranchOptionsResult(
+  selectedBranch: string | undefined,
+): HostDaemonOnlineRpcResult<"host.list_branch_options"> {
+  return {
+    branches: ["main"],
+    branchesTruncated: false,
     remoteBranches: ["origin/main"],
     remoteBranchesTruncated: false,
     selectedBranch: selectedBranch
@@ -383,8 +396,11 @@ export function registerTestHostRpcCapture(
       if (respondToProviderModelListCommand(deps, args, message)) {
         return;
       }
-      if (command.type === "host.list_branches") {
-        args.onListBranches?.(command);
+      if (
+        command.type === "host.list_branch_options" &&
+        !args.queueBranchOptions
+      ) {
+        args.onListBranchOptions?.(command);
         deps.hub.recordHostOnlineRpcResponse({
           message: hostDaemonOnlineRpcResponseMessageSchema.parse({
             type: "host-rpc.response",
@@ -392,8 +408,24 @@ export function registerTestHostRpcCapture(
             commandType: command.type,
             ok: true,
             result:
-              args.listBranchesResult ??
-              buildDefaultBranchListResult(command.selectedBranch),
+              args.gitBranchOptionsResult ??
+              buildDefaultGitBranchOptionsResult(command.selectedBranch),
+          }),
+          sessionId: args.sessionId,
+        });
+        return;
+      }
+      if (command.type === "host.inspect_git_source") {
+        args.onInspectGitSource?.(command);
+        deps.hub.recordHostOnlineRpcResponse({
+          message: hostDaemonOnlineRpcResponseMessageSchema.parse({
+            type: "host-rpc.response",
+            requestId: message.requestId,
+            commandType: command.type,
+            ok: true,
+            result:
+              args.gitSourceInspectionResult ??
+              buildDefaultGitSourceInspectionResult(),
           }),
           sessionId: args.sessionId,
         });

--- a/apps/server/test/public/public-environments.test.ts
+++ b/apps/server/test/public/public-environments.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { getEnvironment } from "@bb/db";
 import {
+  registerTestHostRpcCapture,
   reportQueuedCommandSuccess,
   waitForQueuedCommand,
 } from "../helpers/commands.js";
@@ -15,8 +16,13 @@ import { withTestHarness } from "../helpers/test-app.js";
 describe("public environments", () => {
   it("lists cached branch options while remotes refresh in the background", async () => {
     await withTestHarness(async (harness) => {
-      const { host } = seedHostSession(harness.deps, {
+      const { host, session } = seedHostSession(harness.deps, {
         id: "host-environment-branch-options",
+      });
+      registerTestHostRpcCapture(harness, {
+        hostId: host.id,
+        sessionId: session.id,
+        queueBranchOptions: true,
       });
       const { project } = seedProjectWithSource(harness.deps, {
         hostId: host.id,

--- a/apps/server/test/public/public-project-workspace-routing.test.ts
+++ b/apps/server/test/public/public-project-workspace-routing.test.ts
@@ -1,6 +1,6 @@
 import { createProjectSource } from "@bb/db";
 import type { HostProviderCommand } from "@bb/host-daemon-contract";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { registerHostRpcResponder } from "../helpers/host-rpc.js";
 import { declaredNativeRootSet } from "../helpers/provider-registry.js";
 import { readJson } from "../helpers/json.js";
@@ -26,6 +26,146 @@ const primaryCommand: HostProviderCommand = {
 };
 
 describe("public project workspace routing", () => {
+  it("reads cached branch metadata while refreshing project remotes in the background", async () => {
+    await withTestHarness(async (harness) => {
+      const { host, session } = seedHostSession(harness.deps, {
+        id: "host-project-branches",
+      });
+      seedPrimaryHost(harness.deps, host.id);
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.id,
+        path: "/project/branches",
+      });
+      let releaseBackgroundInspection: (() => void) | undefined;
+      const backgroundInspectionGate = new Promise<void>((resolve) => {
+        releaseBackgroundInspection = resolve;
+      });
+      let releaseBlockingInspection: (() => void) | undefined;
+      const blockingInspectionGate = new Promise<void>((resolve) => {
+        releaseBlockingInspection = resolve;
+      });
+      const responder = registerHostRpcResponder(harness, {
+        hostId: host.id,
+        sessionId: session.id,
+        handle: async (request) => {
+          if (request.command.type === "host.list_branch_options") {
+            return {
+              ok: true,
+              result: {
+                branches: ["main"],
+                branchesTruncated: false,
+                remoteBranches: ["origin/main"],
+                remoteBranchesTruncated: false,
+                selectedBranch: null,
+              },
+            };
+          }
+          if (request.command.type !== "host.inspect_git_source") {
+            throw new Error(
+              `Unexpected project branch RPC ${request.command.type}`,
+            );
+          }
+          await (request.command.remoteRefresh === "blocking"
+            ? blockingInspectionGate
+            : backgroundInspectionGate);
+          return {
+            ok: true,
+            result: {
+              checkout: {
+                kind: "branch",
+                branchName: "main",
+                headSha: "abc123",
+              },
+              defaultBranch: "main",
+              defaultBranchRelation: "equal",
+              hasUncommittedChanges: false,
+              operation: { kind: "none" },
+              originDefaultBranch: "origin/main",
+            },
+          };
+        },
+      });
+
+      const responsePromise = harness.app.request(
+        `/api/v1/projects/${project.id}/branches?hostId=${host.id}&limit=50`,
+      );
+
+      try {
+        await vi.waitFor(() => expect(responder.requests).toHaveLength(2));
+        expect(responder.requests.map((request) => request.command)).toEqual([
+          {
+            type: "host.inspect_git_source",
+            path: "/project/branches",
+            remoteRefresh: "background",
+          },
+          {
+            type: "host.list_branch_options",
+            path: "/project/branches",
+            limit: 50,
+            remoteRefresh: "none",
+          },
+        ]);
+      } finally {
+        releaseBackgroundInspection?.();
+      }
+      const response = await responsePromise;
+
+      expect(response.status).toBe(200);
+      expect(responder.requests.map((request) => request.command)).toEqual([
+        {
+          type: "host.inspect_git_source",
+          path: "/project/branches",
+          remoteRefresh: "background",
+        },
+        {
+          type: "host.list_branch_options",
+          path: "/project/branches",
+          limit: 50,
+          remoteRefresh: "none",
+        },
+      ]);
+      await expect(readJson(response)).resolves.toMatchObject({
+        branches: ["main"],
+        branchesTruncated: false,
+        defaultBranch: "main",
+        defaultWorktreeBaseBranch: "origin/main",
+        remoteBranches: ["origin/main"],
+        remoteBranchesTruncated: false,
+        selectedBranch: null,
+      });
+
+      responder.requests.length = 0;
+      const refreshedResponsePromise = harness.app.request(
+        `/api/v1/projects/${project.id}/branches?hostId=${host.id}&limit=50&refresh=blocking`,
+      );
+      try {
+        await vi.waitFor(() => expect(responder.requests).toHaveLength(1));
+        expect(responder.requests[0]?.command).toEqual({
+          type: "host.inspect_git_source",
+          path: "/project/branches",
+          remoteRefresh: "blocking",
+        });
+      } finally {
+        releaseBlockingInspection?.();
+      }
+      const refreshedResponse = await refreshedResponsePromise;
+      expect(refreshedResponse.status).toBe(200);
+      expect(responder.requests.map((request) => request.command)).toEqual([
+        {
+          type: "host.inspect_git_source",
+          path: "/project/branches",
+          remoteRefresh: "blocking",
+        },
+        {
+          type: "host.list_branch_options",
+          path: "/project/branches",
+          limit: 50,
+          remoteRefresh: "none",
+        },
+      ]);
+    });
+  });
+
   it("isolates primary, explicit-host, and environment workspace discovery", async () => {
     await withTestHarness(async (harness) => {
       const { host: primaryHost, session: primarySession } = seedHostSession(

--- a/apps/server/test/public/public-threads.named-base-branch.test.ts
+++ b/apps/server/test/public/public-threads.named-base-branch.test.ts
@@ -1,5 +1,6 @@
 import { getThread } from "@bb/db";
-import { threadSchema, type ProjectSourceCheckout } from "@bb/domain";
+import { threadSchema, type GitSourceInspection } from "@bb/domain";
+import type { HostDaemonRpcCommand } from "@bb/host-daemon-contract";
 import { threadResponseSchema } from "@bb/server-contract";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -22,20 +23,15 @@ import { withTestHarness, type TestAppHarness } from "../helpers/test-app.js";
 const SOURCE_PATH = "/tmp/named-base-branch-source";
 
 function buildCheckout(
-  defaultBranchRelation: ProjectSourceCheckout["defaultBranchRelation"],
-): ProjectSourceCheckout {
+  defaultBranchRelation: GitSourceInspection["defaultBranchRelation"],
+): GitSourceInspection {
   return {
-    branches: ["main"],
-    branchesTruncated: false,
     checkout: { kind: "branch", branchName: "main", headSha: "abc123" },
     defaultBranch: "main",
     defaultBranchRelation,
     hasUncommittedChanges: false,
     operation: { kind: "none" },
     originDefaultBranch: "origin/main",
-    remoteBranches: ["origin/main"],
-    remoteBranchesTruncated: false,
-    selectedBranch: null,
   };
 }
 
@@ -43,8 +39,13 @@ async function createNamedBaseBranchThread(
   harness: TestAppHarness,
   args: {
     baseBranch: string;
-    defaultBranchRelation: ProjectSourceCheckout["defaultBranchRelation"];
-    onListBranches?: () => void;
+    defaultBranchRelation: GitSourceInspection["defaultBranchRelation"];
+    onInspectGitSource?: (
+      command: Extract<
+        HostDaemonRpcCommand,
+        { type: "host.inspect_git_source" }
+      >,
+    ) => void;
   },
 ): Promise<string | null> {
   const { host, session } = seedHostSession(harness.deps);
@@ -52,8 +53,10 @@ async function createNamedBaseBranchThread(
   registerTestHostRpcCapture(harness, {
     hostId: host.id,
     sessionId: session.id,
-    listBranchesResult: buildCheckout(args.defaultBranchRelation),
-    ...(args.onListBranches ? { onListBranches: args.onListBranches } : {}),
+    gitSourceInspectionResult: buildCheckout(args.defaultBranchRelation),
+    ...(args.onInspectGitSource
+      ? { onInspectGitSource: args.onInspectGitSource }
+      : {}),
   });
   const { project } = seedProjectWithSource(harness.deps, {
     hostId: host.id,
@@ -91,12 +94,19 @@ async function createNamedBaseBranchThread(
 describe("named managed-worktree base branch", () => {
   it("bases on origin when the named default branch is behind origin", async () => {
     await withTestHarness(async (harness) => {
+      const onInspectGitSource = vi.fn();
       await expect(
         createNamedBaseBranchThread(harness, {
           baseBranch: "main",
           defaultBranchRelation: "local-behind",
+          onInspectGitSource,
         }),
       ).resolves.toBe("origin/main");
+      expect(onInspectGitSource).toHaveBeenCalledExactlyOnceWith({
+        type: "host.inspect_git_source",
+        path: SOURCE_PATH,
+        remoteRefresh: "blocking",
+      });
     });
   });
 
@@ -124,15 +134,15 @@ describe("named managed-worktree base branch", () => {
 
   it("does not inspect an origin-qualified branch before provisioning", async () => {
     await withTestHarness(async (harness) => {
-      const onListBranches = vi.fn();
+      const onInspectGitSource = vi.fn();
       await expect(
         createNamedBaseBranchThread(harness, {
           baseBranch: "origin/main",
           defaultBranchRelation: "local-behind",
-          onListBranches,
+          onInspectGitSource,
         }),
       ).resolves.toBe("origin/main");
-      expect(onListBranches).not.toHaveBeenCalled();
+      expect(onInspectGitSource).not.toHaveBeenCalled();
     });
   });
 
@@ -142,7 +152,7 @@ describe("named managed-worktree base branch", () => {
       registerTestHostRpcCapture(harness, {
         hostId: host.id,
         sessionId: session.id,
-        listBranchesResult: buildCheckout("local-behind"),
+        gitSourceInspectionResult: buildCheckout("local-behind"),
       });
       const { project } = seedProjectWithSource(harness.deps, {
         hostId: host.id,

--- a/apps/server/test/public/public-threads.named-base-branch.test.ts
+++ b/apps/server/test/public/public-threads.named-base-branch.test.ts
@@ -92,7 +92,7 @@ async function createNamedBaseBranchThread(
 }
 
 describe("named managed-worktree base branch", () => {
-  it("bases on origin when the named default branch is behind origin", async () => {
+  it("preserves a named default branch without inspecting or reinterpreting it", async () => {
     await withTestHarness(async (harness) => {
       const onInspectGitSource = vi.fn();
       await expect(
@@ -101,12 +101,8 @@ describe("named managed-worktree base branch", () => {
           defaultBranchRelation: "local-behind",
           onInspectGitSource,
         }),
-      ).resolves.toBe("origin/main");
-      expect(onInspectGitSource).toHaveBeenCalledExactlyOnceWith({
-        type: "host.inspect_git_source",
-        path: SOURCE_PATH,
-        remoteRefresh: "blocking",
-      });
+      ).resolves.toBe("main");
+      expect(onInspectGitSource).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/server/test/public/public-threads.project-default.test.ts
+++ b/apps/server/test/public/public-threads.project-default.test.ts
@@ -2,7 +2,7 @@ import { getThread } from "@bb/db";
 import {
   PERSONAL_PROJECT_ID,
   threadSchema,
-  type ProjectSourceCheckout,
+  type GitSourceInspection,
 } from "@bb/domain";
 import { describe, expect, it } from "vitest";
 import { resolveProjectDefaultThreadEnvironment } from "../../src/services/threads/thread-default-policy.js";
@@ -137,24 +137,17 @@ describe("project-default thread environment", () => {
     {
       name: "a repository with no commits",
       checkout: {
-        branches: [],
-        branchesTruncated: false,
         checkout: { kind: "unborn" as const, branchName: "main" },
         defaultBranch: null,
         defaultBranchRelation: null,
         hasUncommittedChanges: false,
         operation: { kind: "none" as const },
         originDefaultBranch: null,
-        remoteBranches: [],
-        remoteBranchesTruncated: false,
-        selectedBranch: null,
-      } satisfies ProjectSourceCheckout,
+      } satisfies GitSourceInspection,
     },
     {
       name: "a non-Git directory",
       checkout: {
-        branches: [],
-        branchesTruncated: false,
         checkout: {
           kind: "unknown" as const,
           reason: "Path is not a git repository",
@@ -164,10 +157,7 @@ describe("project-default thread environment", () => {
         hasUncommittedChanges: false,
         operation: { kind: "none" as const },
         originDefaultBranch: null,
-        remoteBranches: [],
-        remoteBranchesTruncated: false,
-        selectedBranch: null,
-      } satisfies ProjectSourceCheckout,
+      } satisfies GitSourceInspection,
     },
   ])(
     "dispatches a plugin thread in the project source for $name",
@@ -186,9 +176,9 @@ describe("project-default thread environment", () => {
           restoreCommandCaptureAfterResponse: true,
           handle(request) {
             expect(request.command).toEqual({
-              type: "host.list_branches",
+              type: "host.inspect_git_source",
               path: sourcePath,
-              limit: 1,
+              remoteRefresh: "blocking",
             });
             return { ok: true, result: checkout };
           },

--- a/apps/server/test/public/public-threads.project-default.test.ts
+++ b/apps/server/test/public/public-threads.project-default.test.ts
@@ -178,7 +178,7 @@ describe("project-default thread environment", () => {
             expect(request.command).toEqual({
               type: "host.inspect_git_source",
               path: sourcePath,
-              remoteRefresh: "blocking",
+              remoteRefresh: "background",
             });
             return { ok: true, result: checkout };
           },

--- a/apps/server/test/services/worktree-base-branch.test.ts
+++ b/apps/server/test/services/worktree-base-branch.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 import {
   resolveDefaultWorktreeBaseBranch,
   resolveManagedDefaultBaseBranchSpec,
-  resolveManagedNamedBaseBranchSpec,
 } from "../../src/services/projects/worktree-base-branch.js";
 
 describe("resolveDefaultWorktreeBaseBranch", () => {
@@ -72,62 +71,5 @@ describe("resolveManagedDefaultBaseBranchSpec", () => {
         originDefaultBranch: "origin/main",
       }),
     ).toEqual({ kind: "named", name: "origin/main" });
-  });
-});
-
-describe("resolveManagedNamedBaseBranchSpec", () => {
-  it("prefers origin when the named default branch is equal or behind", () => {
-    for (const relation of ["equal", "local-behind"] as const) {
-      expect(
-        resolveManagedNamedBaseBranchSpec(
-          { kind: "named", name: "main" },
-          {
-            defaultBranch: "main",
-            defaultBranchRelation: relation,
-            originDefaultBranch: "origin/main",
-          },
-        ),
-      ).toEqual({ kind: "named", name: "origin/main" });
-    }
-  });
-
-  it("keeps the named default branch when local is ahead, diverged, unknown, or has no origin", () => {
-    for (const relation of ["local-ahead", "diverged", "unknown"] as const) {
-      expect(
-        resolveManagedNamedBaseBranchSpec(
-          { kind: "named", name: "main" },
-          {
-            defaultBranch: "main",
-            defaultBranchRelation: relation,
-            originDefaultBranch: "origin/main",
-          },
-        ),
-      ).toEqual({ kind: "named", name: "main" });
-    }
-    expect(
-      resolveManagedNamedBaseBranchSpec(
-        { kind: "named", name: "main" },
-        {
-          defaultBranch: "main",
-          defaultBranchRelation: null,
-          originDefaultBranch: null,
-        },
-      ),
-    ).toEqual({ kind: "named", name: "main" });
-  });
-
-  it("leaves names that are not the default branch untouched", () => {
-    for (const name of ["develop", "origin/main", "feature/x"]) {
-      expect(
-        resolveManagedNamedBaseBranchSpec(
-          { kind: "named", name },
-          {
-            defaultBranch: "main",
-            defaultBranchRelation: "local-behind",
-            originDefaultBranch: "origin/main",
-          },
-        ),
-      ).toEqual({ kind: "named", name });
-    }
   });
 });

--- a/packages/domain/src/git-checkout.ts
+++ b/packages/domain/src/git-checkout.ts
@@ -109,17 +109,25 @@ const defaultBranchRelationSchema = z.enum([
 ]);
 export type DefaultBranchRelation = z.infer<typeof defaultBranchRelationSchema>;
 
-export const projectSourceCheckoutSchema = z.object({
-  branches: z.array(z.string()),
-  branchesTruncated: z.boolean(),
+export const gitSourceInspectionSchema = z.object({
   checkout: gitCheckoutRefSchema,
   defaultBranch: z.string().min(1).nullable(),
   defaultBranchRelation: defaultBranchRelationSchema.nullable(),
   hasUncommittedChanges: z.boolean(),
   operation: workspaceGitOperationSchema,
   originDefaultBranch: z.string().min(1).nullable(),
+});
+export type GitSourceInspection = z.infer<typeof gitSourceInspectionSchema>;
+
+export const gitBranchOptionsSchema = z.object({
+  branches: z.array(z.string()),
+  branchesTruncated: z.boolean(),
   remoteBranches: z.array(z.string()),
   remoteBranchesTruncated: z.boolean(),
   selectedBranch: gitBranchRefClassificationSchema.nullable(),
 });
+
+export const projectSourceCheckoutSchema = gitSourceInspectionSchema.extend(
+  gitBranchOptionsSchema.shape,
+);
 export type ProjectSourceCheckout = z.infer<typeof projectSourceCheckoutSchema>;

--- a/packages/domain/src/plugin-sdk-version.ts
+++ b/packages/domain/src/plugin-sdk-version.ts
@@ -1,3 +1,3 @@
-export const PLUGIN_SDK_VERSION = "0.4.27";
+export const PLUGIN_SDK_VERSION = "0.4.28";
 
 export const PLUGIN_SDK_MAJOR = Number(PLUGIN_SDK_VERSION.split(".", 1)[0]);

--- a/packages/host-daemon-contract/src/commands.ts
+++ b/packages/host-daemon-contract/src/commands.ts
@@ -2,11 +2,12 @@ import {
   availableModelSchema,
   discoveredWorkspacePropertiesSchema,
   dynamicToolSchema,
+  gitBranchOptionsSchema,
+  gitSourceInspectionSchema,
   instructionModeSchema,
   pendingInteractionResolutionSchema,
   permissionModeSchema,
   promptInputSchema,
-  projectSourceCheckoutSchema,
   providerForkSchema,
   threadGitDiffResponseSchema,
   workspaceProvisionTypeSchema,
@@ -746,13 +747,13 @@ const hostGlobalSkillsStatusCommandSchema = z
   })
   .strict();
 
-const hostListBranchesCommandSchema = z.object({
-  type: z.literal("host.list_branches"),
-  path: z.string().min(1),
-  query: z.string().max(BRANCH_LIST_QUERY_MAX_LENGTH).optional(),
-  selectedBranch: gitBranchNameSchema.optional(),
-  limit: z.number().int().positive().max(BRANCH_LIST_LIMIT_MAX),
-});
+const hostInspectGitSourceCommandSchema = z
+  .object({
+    type: z.literal("host.inspect_git_source"),
+    path: z.string().min(1),
+    remoteRefresh: z.enum(["background", "blocking"]),
+  })
+  .strict();
 
 const hostListBranchOptionsCommandSchema = z
   .object({
@@ -764,14 +765,6 @@ const hostListBranchOptionsCommandSchema = z
     remoteRefresh: z.enum(["background", "none"]),
   })
   .strict();
-
-const hostBranchOptionsResultSchema = projectSourceCheckoutSchema.pick({
-  branches: true,
-  branchesTruncated: true,
-  remoteBranches: true,
-  remoteBranchesTruncated: true,
-  selectedBranch: true,
-});
 
 const providerListModelsCommandSchema = z.object({
   type: z.literal("provider.list_models"),
@@ -1645,10 +1638,10 @@ export const hostDaemonCommandRegistry = {
     flushEventsBeforeResult: false,
     envLane: null,
   }),
-  "host.list_branches": defineHostDaemonCommandDescriptor({
-    type: "host.list_branches",
-    schema: hostListBranchesCommandSchema,
-    resultSchema: projectSourceCheckoutSchema,
+  "host.inspect_git_source": defineHostDaemonCommandDescriptor({
+    type: "host.inspect_git_source",
+    schema: hostInspectGitSourceCommandSchema,
+    resultSchema: gitSourceInspectionSchema,
     transport: "onlineRpc",
     retryable: true,
     flushEventsBeforeResult: false,
@@ -1657,7 +1650,7 @@ export const hostDaemonCommandRegistry = {
   "host.list_branch_options": defineHostDaemonCommandDescriptor({
     type: "host.list_branch_options",
     schema: hostListBranchOptionsCommandSchema,
-    resultSchema: hostBranchOptionsResultSchema,
+    resultSchema: gitBranchOptionsSchema,
     transport: "onlineRpc",
     retryable: true,
     flushEventsBeforeResult: false,

--- a/packages/host-daemon-contract/src/protocol.ts
+++ b/packages/host-daemon-contract/src/protocol.ts
@@ -1,3 +1,3 @@
-export const HOST_DAEMON_PROTOCOL_VERSION = 173 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 174 as const;
 
 export const HOST_ARTIFACT_MAX_BYTES = 256 * 1024 * 1024;

--- a/packages/host-daemon-contract/src/session.ts
+++ b/packages/host-daemon-contract/src/session.ts
@@ -424,7 +424,7 @@ const hostDaemonOnlineRpcResponseSuccessSchema = z.discriminatedUnion(
     onlineRpcResponseSuccessSchemaFor("host.global_skills_status"),
     onlineRpcResponseSuccessSchemaFor("host.file_metadata"),
     onlineRpcResponseSuccessSchemaFor("host.list_branch_options"),
-    onlineRpcResponseSuccessSchemaFor("host.list_branches"),
+    onlineRpcResponseSuccessSchemaFor("host.inspect_git_source"),
     onlineRpcResponseSuccessSchemaFor("host.read_file"),
     onlineRpcResponseSuccessSchemaFor("host.read_file_relative"),
     onlineRpcResponseSuccessSchemaFor("host.write_file"),

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -273,9 +273,7 @@ const ONLINE_RPC_RESPONSE_RESULT_FIXTURES: OnlineRpcResponseResultFixtures = {
       { name: "bb-cli", path: "/home/user/.agents/skills/bb-cli" },
     ],
   },
-  "host.list_branches": {
-    branches: ["main"],
-    branchesTruncated: false,
+  "host.inspect_git_source": {
     checkout: {
       kind: "branch",
       branchName: "main",
@@ -288,12 +286,6 @@ const ONLINE_RPC_RESPONSE_RESULT_FIXTURES: OnlineRpcResponseResultFixtures = {
       kind: "none",
     },
     originDefaultBranch: "origin/main",
-    remoteBranches: ["origin/main"],
-    remoteBranchesTruncated: false,
-    selectedBranch: {
-      name: "main",
-      kind: "local",
-    },
   },
   "host.list_branch_options": {
     branches: ["main"],
@@ -670,7 +662,7 @@ const INTENTIONAL_OPTIONAL_HOST_DAEMON_FIELDS: Record<string, string> = {
   "hostDaemonOnlineRpcCommandSchema.rootPath":
     "host.read_file and host.file_metadata may omit rootPath only for explicit absolute disk reads; ref-based reads still require it.",
   "hostDaemonOnlineRpcCommandSchema.selectedBranch":
-    "host.list_branches may omit exact selected-branch classification when the caller only needs a branch option page.",
+    "host.list_branch_options may omit exact selected-branch classification when the caller only needs a branch option page.",
   "hostDaemonCommandSchema.threadStoragePath":
     "thread.start may include a storage path so the daemon creates the directory before the agent starts.",
   "hostDaemonCommandSchema.fork":
@@ -943,7 +935,7 @@ const ACP_BRIDGE_LAUNCH = {
 
 describe("host-daemon command schemas", () => {
   it("uses the current host-daemon protocol version", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(173);
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(174);
     expect(HOST_ARTIFACT_MAX_BYTES).toBe(256 * 1024 * 1024);
   });
 
@@ -1391,18 +1383,14 @@ describe("host-daemon command schemas", () => {
 
     expect(
       hostDaemonOnlineRpcCommandSchema.parse({
-        type: "host.list_branches",
+        type: "host.inspect_git_source",
         path: "/tmp/workspace",
-        query: "release",
-        selectedBranch: "origin/main",
-        limit: 50,
+        remoteRefresh: "background",
       }),
     ).toMatchObject({
-      type: "host.list_branches",
+      type: "host.inspect_git_source",
       path: "/tmp/workspace",
-      query: "release",
-      selectedBranch: "origin/main",
-      limit: 50,
+      remoteRefresh: "background",
     });
 
     expect(
@@ -1558,9 +1546,9 @@ describe("host-daemon command schemas", () => {
         remoteRefresh: "none",
       },
       {
-        type: "host.list_branches",
+        type: "host.inspect_git_source",
         path: "/tmp/workspace",
-        limit: 50,
+        remoteRefresh: "blocking",
       },
       {
         type: "host.file_metadata",
@@ -2567,10 +2555,11 @@ describe("host-daemon command schemas", () => {
   it("rejects invalid branch names at command boundaries", () => {
     expect(
       hostDaemonCommandSchema.safeParse({
-        type: "host.list_branches",
+        type: "host.list_branch_options",
         path: "/tmp/workspace",
         selectedBranch: "origin/main lock",
         limit: 50,
+        remoteRefresh: "none",
       }).success,
     ).toBe(false);
 
@@ -2789,9 +2778,7 @@ describe("host-daemon command schemas", () => {
     });
 
     expect(
-      hostDaemonOnlineRpcResultSchemaByType["host.list_branches"].parse({
-        branches: ["main", "feature/test"],
-        branchesTruncated: false,
+      hostDaemonOnlineRpcResultSchemaByType["host.inspect_git_source"].parse({
         checkout: {
           kind: "branch",
           branchName: "feature/test",
@@ -2802,9 +2789,6 @@ describe("host-daemon command schemas", () => {
         hasUncommittedChanges: true,
         operation: { kind: "merge", hasConflicts: true },
         originDefaultBranch: "origin/main",
-        remoteBranches: ["origin/main"],
-        remoteBranchesTruncated: false,
-        selectedBranch: { name: "origin/main", kind: "remote" },
       }),
     ).toMatchObject({
       checkout: {

--- a/packages/plugin-api-map/sdk-public-api.json
+++ b/packages/plugin-api-map/sdk-public-api.json
@@ -3,7 +3,7 @@
   "entries": {
     ".": {
       "types": "bundled-types/bb-plugin-sdk.d.ts",
-      "sha256": "057bfb57c4a11dcbb0b83125e1b42a0e360fcb28ce62083fa37acb28541df741"
+      "sha256": "70077a510684588d29816ecb221ca99476640c7972c31730025064904265535e"
     },
     "./ai-services": {
       "types": "bundled-types/bb-plugin-sdk-ai-services.d.ts",

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@get-bb/plugin-sdk",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "homepage": "https://github.com/get-bb/bb#readme",
   "bugs": {
     "url": "https://github.com/get-bb/bb/issues"

--- a/packages/server-contract/src/api/projects.ts
+++ b/packages/server-contract/src/api/projects.ts
@@ -210,6 +210,7 @@ export type ProjectFileContentQuery = z.infer<
 
 export const projectBranchesQuerySchema = branchListQuerySchema.extend({
   hostId: z.string().min(1),
+  refresh: z.enum(["background", "blocking"]).optional(),
   selectedBranch: gitBranchNameSchema.optional(),
 });
 export type ProjectBranchesQuery = z.infer<typeof projectBranchesQuerySchema>;

--- a/packages/server-contract/test/contract.test.ts
+++ b/packages/server-contract/test/contract.test.ts
@@ -483,9 +483,16 @@ describe("git branch name contract", () => {
     expect(
       contract.projectBranchesQuerySchema.safeParse({
         hostId: "host_123",
+        refresh: "blocking",
         selectedBranch: "upstream/main",
       }).success,
     ).toBe(true);
+    expect(
+      contract.projectBranchesQuerySchema.safeParse({
+        hostId: "host_123",
+        refresh: "eager",
+      }).success,
+    ).toBe(false);
     expect(
       contract.projectBranchesQuerySchema.safeParse({
         hostId: "host_123",

--- a/packages/templates/src/templates/bb-guide-projects.md
+++ b/packages/templates/src/templates/bb-guide-projects.md
@@ -34,6 +34,7 @@ A project maps to a code repository. All threads belong to a project.
 Discovery:
 
   bb project branches <id> --host <id>   List branches for a machine source
+    --refresh                            Wait for remote refs before listing
   bb project paths <id>                   Search workspace paths
   bb project files <id>                   List workspace files
   bb project content <id> <path>          Read file content (binary is base64)


### PR DESCRIPTION
## Human comments

## What was wrong

The new-thread branch selector used one `host.list_branches` request for three different jobs: inspecting the checkout, refreshing remote refs, and paginating branch choices. That made an initial/default selection wait on network work it did not need. Remote freshness needed to be explicit, and the branch displayed by the selector needed to remain the exact branch submitted for creation rather than being reinterpreted later.

## What changed

- Split the host RPC into `host.inspect_git_source` for checkout/default/dirty metadata and `host.list_branch_options` for branch pagination.
- Compose cached inspection and branch options concurrently on initial load while a throttled fetch runs in the background.
- Make picker-open request an explicit blocking refresh when the user asks for authoritative choices.
- Submit the selector's resolved `main` or `origin/main` value as a named branch and trust named branches during creation.
- Keep creation off the network: unresolved defaults inspect cached refs while refreshing remotes in the background.
- Route explicit picker refreshes through the owning TanStack query, including initial-fetch coalescing and retries, so `isFetching`, cancellation, and cache ownership remain correct.
- Add `bb project branches --refresh`; expose it through live CLI help and document it in the project guide.
- Bump `HOST_DAEMON_PROTOCOL_VERSION` from current `main`'s 173 to 174 for the changed host command contract.
- Add coverage for cached/background reads, blocking refreshes, retry/coalescing races, branch ordering/filtering, bare and non-Git sources, multiple remotes, creation policy, CLI output, and wire contracts.

## How you verified

- Focused app branch-query and cache-owner suites — 8 tests passed.
- Focused host-daemon branch dispatch suite — 17 tests passed.
- Focused server suites for project workspace routing, named/default branch creation, and public environments — 24 tests passed.
- Updated named/default creation-policy suites — 16 tests passed.
- Full app suite — 3,505 tests passed, 4 skipped.
- Focused host-daemon and server contract suites — 37 and 35 tests passed.
- Focused CLI project suite — 24 tests passed.
- Plugin SDK, domain, and Plugin API Map test/typecheck matrix — 465 tests passed across 62 files.
- Plugin Guide production build passed.
- Turbo typechecks passed for `@bb/app`, `@bb/cli`, `@bb/domain`, `@bb/host-daemon`, `@bb/host-daemon-contract`, `@bb/server`, and `@bb/server-contract`.
- Targeted formatting checks and `git diff --check` passed.

Fixes: N/A — no issue was filed for this thread.

> AGENT GENERATED
