### PR TITLE
fix(host-workspace): avoid overflow listing large directories

### DIFF
--- a/packages/host-workspace/src/workspace.ts
+++ b/packages/host-workspace/src/workspace.ts
@@ -429,12 +429,11 @@ async function listWorkspaceFilesRecursively(
     }
     const fullPath = path.join(args.dir, entry.name);
     if (entry.isDirectory()) {
-      results.push(
-        ...(await listWorkspaceFilesRecursively({
-          dir: fullPath,
-          root: args.root,
-        })),
-      );
+      const childResults = await listWorkspaceFilesRecursively({
+        dir: fullPath,
+        root: args.root,
+      });
+      for (const childResult of childResults) results.push(childResult);
       continue;
     }
     results.push(path.relative(args.root, fullPath));

--- a/packages/host-workspace/test/workspace.test.ts
+++ b/packages/host-workspace/test/workspace.test.ts
@@ -1245,6 +1245,26 @@ describe("Workspace", () => {
     expect(files).toEqual(["nested/notes.txt"]);
   });
 
+  it("does not overflow the call stack merging a large subdirectory", async () => {
+    const folder = await makeTempDir("bb-workspace-large-files-");
+    const nested = path.join(folder, "many");
+    await fs.mkdir(nested);
+    const fileCount = 150_000;
+    const batchSize = 500;
+    for (let start = 0; start < fileCount; start += batchSize) {
+      const end = Math.min(start + batchSize, fileCount);
+      await Promise.all(
+        Array.from({ length: end - start }, (_, offset) =>
+          fs.writeFile(path.join(nested, `f${start + offset}.txt`), ""),
+        ),
+      );
+    }
+
+    const files = await new Workspace(folder).listFiles();
+
+    expect(files).toHaveLength(fileCount);
+  }, 60_000);
+
   it("returns null when HEAD is unavailable in an empty repository", async () => {
     const repoPath = await makeTempDir("bb-workspace-empty-repo-");
     await runGit(["init", "-b", "main"], { cwd: repoPath });


### PR DESCRIPTION
## Human comments

## What was wrong

Recursive non-Git workspace listing expanded every child result as JavaScript function arguments. PR #2363 fixed the host-daemon sibling, but `Workspace.listFiles()` retained the same unbounded spread and threw `RangeError` for a 150,000-file child subtree.

## What changed

Replace the recursive spread in `packages/host-workspace` with a direct element loop and add a physical 150,000-file regression at the public `Workspace.listFiles()` boundary. Return types and filtering semantics are unchanged. This does not change the server/host-daemon wire contract, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged; no CLI, SDK, guide, or configuration surface changed.

## How you verified

- Confirmed the new focused regression failed before the production change with `RangeError: Maximum call stack size exceeded`.
- Confirmed the same regression passed after the change and the original harness returned all 150,000 files.
- Rebased cleanly onto current `origin/main`.
- `pnpm exec turbo run test typecheck --filter=@bb/host-workspace --force` (216 tests and typecheck passed; no cached tasks)
- `git diff --check`

Fixes #2362

> AGENT GENERATED
