### PR TITLE
Reject reused plugin migration indexes

### DIFF
--- a/apps/server/src/services/plugins/plugin-api.ts
+++ b/apps/server/src/services/plugins/plugin-api.ts
@@ -616,12 +616,13 @@ export function createPluginApi(options: {
         .all();
       const applied = new Map<number, string | null>();
       for (const row of rows) applied.set(row.id, row.statement_hash);
-      statements.forEach((statement, index) => {
+      const statementHashes = statements.map(migrationStatementHash);
+      statementHashes.forEach((statementHash, index) => {
         const recordedHash = applied.get(index);
         if (
           recordedHash !== undefined &&
           recordedHash !== null &&
-          recordedHash !== migrationStatementHash(statement)
+          recordedHash !== statementHash
         ) {
           throw new Error(
             `migration ${index} does not match the recorded statement; append a new migration instead of changing or reusing an index`,
@@ -636,18 +637,16 @@ export function createPluginApi(options: {
       );
       database.transaction(() => {
         for (const row of rows) {
-          const statement = statements[row.id];
+          if (row.statement_hash !== null) continue;
           adopt.run(
-            statement === undefined
-              ? LEGACY_UNKNOWN_MIGRATION_HASH
-              : migrationStatementHash(statement),
+            statementHashes[row.id] ?? LEGACY_UNKNOWN_MIGRATION_HASH,
             row.id,
           );
         }
         statements.forEach((statement, index) => {
           if (applied.has(index)) return;
           database.exec(statement);
-          record.run(index, Date.now(), migrationStatementHash(statement));
+          record.run(index, Date.now(), statementHashes[index]);
         });
       })();
     },

--- a/apps/server/src/services/plugins/plugin-api.ts
+++ b/apps/server/src/services/plugins/plugin-api.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { mkdirSync } from "node:fs";
 import { join } from "node:path";
 import Database from "better-sqlite3";
@@ -95,6 +96,12 @@ import type { PluginInteractionResult } from "../interactions/pending-interactio
 import { appendPluginLogLine } from "./plugin-log.js";
 import type { PluginHostArtifactSnapshot } from "./plugin-service-internal.js";
 import { readPluginSettingsValues } from "./plugin-settings.js";
+
+const LEGACY_UNKNOWN_MIGRATION_HASH = "legacy-unknown";
+
+function migrationStatementHash(statement: string): string {
+  return createHash("sha256").update(statement).digest("hex");
+}
 
 export type {
   BbPluginApi,
@@ -589,23 +596,58 @@ export function createPluginApi(options: {
     migrate(database, statements) {
       assertLive();
       database.exec(
-        "CREATE TABLE IF NOT EXISTS _bb_migrations (id INTEGER PRIMARY KEY, applied_at INTEGER NOT NULL)",
+        "CREATE TABLE IF NOT EXISTS _bb_migrations (id INTEGER PRIMARY KEY, applied_at INTEGER NOT NULL, statement_hash TEXT)",
       );
-      const applied = new Set(
-        (
-          database.prepare("SELECT id FROM _bb_migrations").all() as Array<{
-            id: number;
-          }>
-        ).map((row) => row.id),
+      const migrationColumns = database
+        .prepare<[], { name: string }>("PRAGMA table_info(_bb_migrations)")
+        .all();
+      if (
+        !migrationColumns.some((column) => column.name === "statement_hash")
+      ) {
+        database.exec(
+          "ALTER TABLE _bb_migrations ADD COLUMN statement_hash TEXT",
+        );
+      }
+      const rows = database
+        .prepare<
+          [],
+          { id: number; statement_hash: string | null }
+        >("SELECT id, statement_hash FROM _bb_migrations ORDER BY id")
+        .all();
+      const applied = new Map<number, string | null>();
+      for (const row of rows) applied.set(row.id, row.statement_hash);
+      statements.forEach((statement, index) => {
+        const recordedHash = applied.get(index);
+        if (
+          recordedHash !== undefined &&
+          recordedHash !== null &&
+          recordedHash !== migrationStatementHash(statement)
+        ) {
+          throw new Error(
+            `migration ${index} does not match the recorded statement; append a new migration instead of changing or reusing an index`,
+          );
+        }
+      });
+      const adopt = database.prepare(
+        "UPDATE _bb_migrations SET statement_hash = ? WHERE id = ? AND statement_hash IS NULL",
       );
       const record = database.prepare(
-        "INSERT INTO _bb_migrations (id, applied_at) VALUES (?, ?)",
+        "INSERT INTO _bb_migrations (id, applied_at, statement_hash) VALUES (?, ?, ?)",
       );
       database.transaction(() => {
+        for (const row of rows) {
+          const statement = statements[row.id];
+          adopt.run(
+            statement === undefined
+              ? LEGACY_UNKNOWN_MIGRATION_HASH
+              : migrationStatementHash(statement),
+            row.id,
+          );
+        }
         statements.forEach((statement, index) => {
           if (applied.has(index)) return;
           database.exec(statement);
-          record.run(index, Date.now());
+          record.run(index, Date.now(), migrationStatementHash(statement));
         });
       })();
     },

--- a/apps/server/test/services/plugins/plugin-settings-storage.test.ts
+++ b/apps/server/test/services/plugins/plugin-settings-storage.test.ts
@@ -403,6 +403,65 @@ describe("plugin settings + storage", () => {
       expect(rerunRow.count).toBe(1);
     });
 
+    it("rejects a changed migration statement at an applied index", async () => {
+      const rootDir = await writePlugin(workDir, {
+        name: "bb-plugin-migration-collision",
+        serverSource: `
+          export default function plugin(bb: any) {
+            const db = bb.storage.database();
+            bb.storage.migrate(db, [
+              "CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT NOT NULL)",
+            ]);
+          }
+        `,
+      });
+      await service.installPath(rootDir);
+
+      const api = service.getApi("migration-collision");
+      expect(api).toBeDefined();
+      if (!api) throw new Error("migration-collision plugin did not load");
+      const database = api.storage.database();
+      expect(() =>
+        api.storage.migrate(database, [
+          "CREATE TABLE replacements (id INTEGER PRIMARY KEY)",
+        ]),
+      ).toThrow(/migration 0 does not match the recorded statement/);
+    });
+
+    it("reserves unknown legacy indexes before later statements can reuse them", async () => {
+      const rootDir = await writePlugin(workDir, {
+        name: "bb-plugin-legacy-migrations",
+        serverSource: `export default function plugin() {}`,
+      });
+      await service.installPath(rootDir);
+
+      const api = service.getApi("legacy-migrations");
+      expect(api).toBeDefined();
+      if (!api) throw new Error("legacy-migrations plugin did not load");
+      const database = api.storage.database();
+      database.exec(
+        "CREATE TABLE items (id INTEGER PRIMARY KEY); CREATE TABLE _bb_migrations (id INTEGER PRIMARY KEY, applied_at INTEGER NOT NULL); INSERT INTO _bb_migrations VALUES (0, 1), (2, 1)",
+      );
+      api.storage.migrate(database, [
+        "CREATE TABLE items (id INTEGER PRIMARY KEY)",
+      ]);
+
+      const rows = database
+        .prepare("SELECT id, statement_hash FROM _bb_migrations ORDER BY id")
+        .all();
+      expect(rows).toEqual([
+        { id: 0, statement_hash: expect.stringMatching(/^[a-f0-9]{64}$/) },
+        { id: 2, statement_hash: "legacy-unknown" },
+      ]);
+      expect(() =>
+        api.storage.migrate(database, [
+          "CREATE TABLE items (id INTEGER PRIMARY KEY)",
+          "SELECT 1",
+          "SELECT 2",
+        ]),
+      ).toThrow(/migration 2 does not match the recorded statement/);
+    });
+
     it("returns one reused handle per plugin load instead of a connection per call", async () => {
       const CALLS = 200;
       const rootDir = await writePlugin(workDir, {

--- a/packages/domain/src/plugin-sdk-version.ts
+++ b/packages/domain/src/plugin-sdk-version.ts
@@ -1,3 +1,3 @@
-export const PLUGIN_SDK_VERSION = "0.4.26";
+export const PLUGIN_SDK_VERSION = "0.4.27";
 
 export const PLUGIN_SDK_MAJOR = Number(PLUGIN_SDK_VERSION.split(".", 1)[0]);

--- a/packages/plugin-api-map/src/surfaces.ts
+++ b/packages/plugin-api-map/src/surfaces.ts
@@ -631,6 +631,7 @@ export const SURFACE_GROUPS: SurfaceGroup[] = [
         bullets: [
           "Get a key-value store for small values such as flags and cursors",
           "Get its own SQLite database, with migrations, for larger or relational data",
+          "Reject a changed or reused migration number before it can hide a schema change",
           "Read and write only its own namespace; other plugins cannot see it",
         ],
         apiSymbols: ["PluginStorage"],

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@get-bb/plugin-sdk",
-  "version": "0.4.26",
+  "version": "0.4.27",
   "homepage": "https://github.com/get-bb/bb#readme",
   "bugs": {
     "url": "https://github.com/get-bb/bb/issues"

--- a/packages/plugin-sdk/src/backend-contract.ts
+++ b/packages/plugin-sdk/src/backend-contract.ts
@@ -138,7 +138,8 @@ export interface PluginStorage {
   database(): Database.Database;
   /**
    * Ordered-statement migration helper: statement index = migration id in a
-   * `_bb_migrations` table; unapplied statements run in one transaction.
+   * `_bb_migrations` table; unapplied statements run in one transaction. The
+   * host records each statement hash and rejects changed or reused indexes.
    * Append-only — never reorder or edit shipped statements.
    */
   migrate(db: Database.Database, statements: string[]): void;

--- a/packages/plugin-sdk/src/testing/__tests__/fake-plugin-host.test.ts
+++ b/packages/plugin-sdk/src/testing/__tests__/fake-plugin-host.test.ts
@@ -198,6 +198,37 @@ describe("storage", () => {
     ]);
     const rows = again.prepare("SELECT body, starred FROM notes").all();
     expect(rows).toEqual([{ body: "hello", starred: 0 }]);
+    expect(() =>
+      bb.storage.migrate(again, [
+        "CREATE TABLE replacements (id INTEGER PRIMARY KEY)",
+      ]),
+    ).toThrow(/migration 0 does not match the recorded statement/);
+  });
+
+  it("reserves unknown legacy migration indexes", () => {
+    const { bb } = createFakePluginHost();
+    const db = bb.storage.database();
+    db.exec(
+      "CREATE TABLE notes (id INTEGER PRIMARY KEY); CREATE TABLE _bb_migrations (id INTEGER PRIMARY KEY, applied_at INTEGER NOT NULL); INSERT INTO _bb_migrations VALUES (0, 1), (2, 1)",
+    );
+
+    bb.storage.migrate(db, ["CREATE TABLE notes (id INTEGER PRIMARY KEY)"]);
+
+    expect(
+      db
+        .prepare("SELECT id, statement_hash FROM _bb_migrations ORDER BY id")
+        .all(),
+    ).toEqual([
+      { id: 0, statement_hash: expect.stringMatching(/^[a-f0-9]{64}$/) },
+      { id: 2, statement_hash: "legacy-unknown" },
+    ]);
+    expect(() =>
+      bb.storage.migrate(db, [
+        "CREATE TABLE notes (id INTEGER PRIMARY KEY)",
+        "SELECT 1",
+        "SELECT 2",
+      ]),
+    ).toThrow(/migration 2 does not match the recorded statement/);
   });
 
   it("database() replaces a handle the plugin closed itself, like the host", () => {

--- a/packages/plugin-sdk/src/testing/fake-plugin-host.ts
+++ b/packages/plugin-sdk/src/testing/fake-plugin-host.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -99,6 +100,12 @@ import {
   type FakeSdkHarness,
   type FakeSdkOverrides,
 } from "./fake-sdk.js";
+
+const LEGACY_UNKNOWN_MIGRATION_HASH = "legacy-unknown";
+
+function migrationStatementHash(statement: string): string {
+  return createHash("sha256").update(statement).digest("hex");
+}
 
 /**
  * `createFakePluginHost` — an in-process stand-in for the BB server's plugin
@@ -952,23 +959,58 @@ function createFakePluginHostInternal(
     migrate(database, statements) {
       assertLive();
       database.exec(
-        "CREATE TABLE IF NOT EXISTS _bb_migrations (id INTEGER PRIMARY KEY, applied_at INTEGER NOT NULL)",
+        "CREATE TABLE IF NOT EXISTS _bb_migrations (id INTEGER PRIMARY KEY, applied_at INTEGER NOT NULL, statement_hash TEXT)",
       );
-      const applied = new Set(
-        (
-          database.prepare("SELECT id FROM _bb_migrations").all() as Array<{
-            id: number;
-          }>
-        ).map((row) => row.id),
+      const migrationColumns = database
+        .prepare<[], { name: string }>("PRAGMA table_info(_bb_migrations)")
+        .all();
+      if (
+        !migrationColumns.some((column) => column.name === "statement_hash")
+      ) {
+        database.exec(
+          "ALTER TABLE _bb_migrations ADD COLUMN statement_hash TEXT",
+        );
+      }
+      const rows = database
+        .prepare<
+          [],
+          { id: number; statement_hash: string | null }
+        >("SELECT id, statement_hash FROM _bb_migrations ORDER BY id")
+        .all();
+      const applied = new Map<number, string | null>();
+      for (const row of rows) applied.set(row.id, row.statement_hash);
+      statements.forEach((statement, index) => {
+        const recordedHash = applied.get(index);
+        if (
+          recordedHash !== undefined &&
+          recordedHash !== null &&
+          recordedHash !== migrationStatementHash(statement)
+        ) {
+          throw new Error(
+            `migration ${index} does not match the recorded statement; append a new migration instead of changing or reusing an index`,
+          );
+        }
+      });
+      const adopt = database.prepare(
+        "UPDATE _bb_migrations SET statement_hash = ? WHERE id = ? AND statement_hash IS NULL",
       );
       const record = database.prepare(
-        "INSERT INTO _bb_migrations (id, applied_at) VALUES (?, ?)",
+        "INSERT INTO _bb_migrations (id, applied_at, statement_hash) VALUES (?, ?, ?)",
       );
       database.transaction(() => {
+        for (const row of rows) {
+          const statement = statements[row.id];
+          adopt.run(
+            statement === undefined
+              ? LEGACY_UNKNOWN_MIGRATION_HASH
+              : migrationStatementHash(statement),
+            row.id,
+          );
+        }
         statements.forEach((statement, index) => {
           if (applied.has(index)) return;
           database.exec(statement);
-          record.run(index, Date.now());
+          record.run(index, Date.now(), migrationStatementHash(statement));
         });
       })();
     },

--- a/packages/plugin-sdk/src/testing/fake-plugin-host.ts
+++ b/packages/plugin-sdk/src/testing/fake-plugin-host.ts
@@ -979,12 +979,13 @@ function createFakePluginHostInternal(
         .all();
       const applied = new Map<number, string | null>();
       for (const row of rows) applied.set(row.id, row.statement_hash);
-      statements.forEach((statement, index) => {
+      const statementHashes = statements.map(migrationStatementHash);
+      statementHashes.forEach((statementHash, index) => {
         const recordedHash = applied.get(index);
         if (
           recordedHash !== undefined &&
           recordedHash !== null &&
-          recordedHash !== migrationStatementHash(statement)
+          recordedHash !== statementHash
         ) {
           throw new Error(
             `migration ${index} does not match the recorded statement; append a new migration instead of changing or reusing an index`,
@@ -999,18 +1000,16 @@ function createFakePluginHostInternal(
       );
       database.transaction(() => {
         for (const row of rows) {
-          const statement = statements[row.id];
+          if (row.statement_hash !== null) continue;
           adopt.run(
-            statement === undefined
-              ? LEGACY_UNKNOWN_MIGRATION_HASH
-              : migrationStatementHash(statement),
+            statementHashes[row.id] ?? LEGACY_UNKNOWN_MIGRATION_HASH,
             row.id,
           );
         }
         statements.forEach((statement, index) => {
           if (applied.has(index)) return;
           database.exec(statement);
-          record.run(index, Date.now(), migrationStatementHash(statement));
+          record.run(index, Date.now(), statementHashes[index]);
         });
       })();
     },


### PR DESCRIPTION
## Human comments

## What was wrong

The plugin migration helper tracked only a statement index. A plugin could later reuse that index for another statement. The host then treated the new statement as applied and silently omitted its schema change.

## What changed

The host and the fake plugin host now store a SHA-256 hash for each migration statement. They reject a changed or reused index. Legacy applied indexes beyond the current migration list receive a reserved value, so later statements cannot reuse them. The Plugin Guide and the SDK contract now document this behavior. The Plugin SDK version increases to 0.4.27. This change does not alter the host daemon protocol.

## How you verified

- Added server integration tests for changed statements and legacy index reuse.
- Added matching fake plugin host tests.
- Ran the server, plugin SDK, and plugin API map test suites.
- Ran Turbo type checks for the server, plugin SDK, and plugin API map.
- Regenerated the SDK inventory and confirmed that no public symbol changed.
- Ran the plugin SDK version check.

> AGENT GENERATED
