### PR TITLE
Make plugin authoring doc guard truthful

### DIFF
--- a/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/SKILL.md
@@ -2340,7 +2340,7 @@ serviceTier?, executionInputSources, environment, input }`. Forward it
   />;
   ```
 
-  ```ts
+  ```ts create-thread-handler
   // server.ts
   async createThread({ request, sectionId }) {
     const thread = await bb.sdk.threads.spawn({

--- a/apps/server/test/services/plugins/plugin-authoring-doc-examples.test.ts
+++ b/apps/server/test/services/plugins/plugin-authoring-doc-examples.test.ts
@@ -1,13 +1,10 @@
-import { execFile } from "node:child_process";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { promisify } from "node:util";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-
-const execFileAsync = promisify(execFile);
 
 const SKILL_PATH = fileURLToPath(
   new URL(
@@ -26,28 +23,51 @@ const pluginSdkEntry = join(
 );
 const tsc = join(repoRoot, "node_modules", ".bin", "tsc");
 
-interface SdkExample {
+interface SdkReference {
   path: string;
-  pattern: string | null;
   line: number;
 }
 
-const SDK_CALL =
-  /(?:const\s*\{([^}]*)\}\s*=\s*await\s+)?bb\.sdk\.([A-Za-z0-9_$]+(?:\.[A-Za-z0-9_$]+)*)\s*\(/g;
+interface SdkFence {
+  mode: "function" | "create-thread-handler";
+  source: string;
+  line: number;
+}
 
-function sdkExamples(skill: string): SdkExample[] {
-  const found = new Map<string, SdkExample>();
+const SDK_CALL = /bb\.sdk\.([A-Za-z0-9_$]+(?:\.[A-Za-z0-9_$]+)*)\s*\(/g;
+const SDK_CALL_IN_SOURCE = /bb\.sdk\.[A-Za-z0-9_$]+(?:\.[A-Za-z0-9_$]+)*\s*\(/;
+const TYPESCRIPT_FENCE = /```(?:ts|typescript)([^\n]*)\n([\s\S]*?)```/g;
+
+function skillLine(skill: string, index: number): number {
+  return skill.slice(0, index).split("\n").length;
+}
+
+function sdkReferences(skill: string): SdkReference[] {
+  const found = new Map<string, SdkReference>();
   for (const match of skill.matchAll(SDK_CALL)) {
-    const [, pattern, path] = match;
+    const path = match[1];
     if (path === undefined) continue;
-    const line = skill.slice(0, match.index).split("\n").length;
-    found.set(`${path}|${pattern ?? ""}`, {
-      path,
-      pattern: pattern === undefined ? null : pattern.trim(),
-      line,
-    });
+    found.set(path, { path, line: skillLine(skill, match.index) });
   }
   return [...found.values()];
+}
+
+function sdkFences(skill: string): SdkFence[] {
+  const found: SdkFence[] = [];
+  for (const match of skill.matchAll(TYPESCRIPT_FENCE)) {
+    const [, rawMode, source] = match;
+    if (source === undefined || !SDK_CALL_IN_SOURCE.test(source)) continue;
+    const mode = rawMode?.trim() ?? "";
+    if (mode !== "" && mode !== "create-thread-handler") {
+      throw new Error(`Unsupported SDK example mode: ${mode}`);
+    }
+    found.push({
+      mode: mode === "create-thread-handler" ? mode : "function",
+      source,
+      line: skillLine(skill, match.index),
+    });
+  }
+  return found;
 }
 
 function typeIndex(path: string): string {
@@ -57,25 +77,37 @@ function typeIndex(path: string): string {
     .join("");
 }
 
-function probeSource(examples: readonly SdkExample[]): string {
+function probeSource(
+  references: readonly SdkReference[],
+  fences: readonly SdkFence[],
+): string {
   return [
     `import type { BbPluginApi } from "@get-bb/plugin-sdk";`,
-    ``,
-    `type AwaitedReturn<F> = F extends (...args: never[]) => infer R`,
-    `  ? R extends Promise<infer V>`,
-    `    ? V`,
-    `    : R`,
-    `  : never;`,
     `type Sdk = BbPluginApi["sdk"];`,
-    ``,
-    ...examples.flatMap((example, index) => [
-      `// SKILL.md:${example.line} — bb.sdk.${example.path}`,
-      `declare const result${index}: AwaitedReturn<Sdk${typeIndex(example.path)}>;`,
-      example.pattern === null
-        ? `void result${index};`
-        : `const { ${example.pattern} } = result${index};`,
-      ``,
-    ]),
+    `type Callable = (...args: never[]) => unknown;`,
+    `type AssertCallable<F extends Callable> = F;`,
+    ...references.map(
+      (reference) =>
+        `type SdkReferenceAtLine${reference.line} = AssertCallable<Sdk${typeIndex(reference.path)}>;`,
+    ),
+    `declare const bb: BbPluginApi;`,
+    `type SpawnArgs = Parameters<Sdk["threads"]["spawn"]>[0];`,
+    `declare const projectId: SpawnArgs["projectId"];`,
+    `declare const threadId: Parameters<Sdk["threads"]["get"]>[0]["threadId"];`,
+    `type CreateThreadInput = { request: SpawnArgs; sectionId?: SpawnArgs["sectionId"] };`,
+    ...fences.flatMap((fence) =>
+      fence.mode === "create-thread-handler"
+        ? [
+            `const skillExampleAtLine${fence.line}: { createThread(input: CreateThreadInput): unknown } = {`,
+            fence.source,
+            `};`,
+          ]
+        : [
+            `async function skillExampleAtLine${fence.line}() {`,
+            fence.source,
+            `}`,
+          ],
+    ),
   ].join("\n");
 }
 
@@ -87,7 +119,6 @@ const PROBE_TSCONFIG = {
     moduleResolution: "bundler",
     noEmit: true,
     skipLibCheck: true,
-    noUnusedLocals: false,
     types: [],
     paths: { "@get-bb/plugin-sdk": [pluginSdkEntry] },
   },
@@ -105,27 +136,26 @@ describe("bb-plugin-authoring skill examples", () => {
     await rm(workDir, { recursive: true, force: true });
   });
 
-  it("calls and destructures bb.sdk the way the SDK actually declares it", async () => {
+  it("resolves every SDK reference and compiles every TypeScript example", async () => {
     const skill = readFileSync(SKILL_PATH, "utf8");
-    const examples = sdkExamples(skill);
-    expect(examples.length).toBeGreaterThan(0);
+    const references = sdkReferences(skill);
+    const fences = sdkFences(skill);
+    expect(references.length).toBeGreaterThan(0);
+    expect(fences.length).toBeGreaterThan(0);
 
-    await writeFile(join(workDir, "probe.ts"), probeSource(examples), "utf8");
+    await writeFile(
+      join(workDir, "probe.ts"),
+      `${probeSource(references, fences)}\n`,
+      "utf8",
+    );
     await writeFile(
       join(workDir, "tsconfig.json"),
       `${JSON.stringify(PROBE_TSCONFIG, null, 2)}\n`,
       "utf8",
     );
 
-    let diagnostics = "";
-    try {
-      await execFileAsync(tsc, ["--project", workDir]);
-    } catch (cause) {
-      diagnostics = `${(cause as { stdout?: string }).stdout ?? ""}${
-        (cause as { stderr?: string }).stderr ?? ""
-      }`.trim();
-    }
-
-    expect(diagnostics).toBe("");
-  }, 60_000);
+    const result = spawnSync(tsc, ["--project", workDir], { encoding: "utf8" });
+    if (result.error !== undefined) throw result.error;
+    expect(result.status, `${result.stdout}${result.stderr}`).toBe(0);
+  });
 });


### PR DESCRIPTION
## Human comments

## What was wrong

The Plugin Authoring documentation guard claimed to compile every documented `bb.sdk` example, but it reconstructed simplified surrogate types that discarded real call arguments and ordinary result usage. Invalid documented arguments could therefore pass CI. The error handler also converted a compiler-launch failure with empty output into successful diagnostics, so the test could pass without TypeScript running.

## What changed

Validate every call-shaped SDK reference as a callable path under `BbPluginApi["sdk"]`, and compile every SDK-bearing TypeScript fence from its exact Markdown source so arguments, assignments, result usage, and control flow are preserved. Mark the documented `createThread` fragment with its explicit handler context. Compiler execution now checks the real process status and surfaces launch errors directly.

## How you verified

- Confirmed the pre-fix guard stayed green with an invalid `threads.list` argument and with a missing TypeScript executable.
- Confirmed post-fix negative controls reject invalid arguments, bad result destructuring, invalid SDK paths, and a missing compiler.
- Rebased onto current `origin/main`.
- `pnpm exec turbo run test --filter=@bb/server --force -- --run test/services/plugins/plugin-authoring-docs.test.ts test/services/plugins/plugin-authoring-doc-examples.test.ts` (16 tests passed; no cached tasks)
- `pnpm exec turbo run typecheck --filter=@bb/server --force`
- Targeted `oxfmt --check` and `git diff --check`

> AGENT GENERATED
