### PR TITLE
Unify prompt box affordance colors

### DIFF
--- a/apps/app/src/components/pickers/ModelReasoningPicker.test.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.test.tsx
@@ -260,6 +260,7 @@ describe("ModelReasoningPicker", () => {
     expect(
       trigger.querySelector('[data-icon="ChevronDown"]')?.classList,
     ).toContain("text-subtle-foreground/75");
+    expect(trigger.classList).toContain("font-normal");
   });
 
   it("gives a non-SVG provider mark the same 16px trigger size as button SVGs", () => {

--- a/apps/app/src/components/pickers/ModelReasoningPicker.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.tsx
@@ -790,6 +790,7 @@ export function ModelReasoningPicker({
         OPTION_INTERACTIVE_CLASS_NAME,
         LIST_HOVER_TRANSITION,
         muted && OPTION_MUTED_CLASS_NAME,
+        muted && "font-normal",
         disabled && "cursor-default disabled:opacity-100",
         className,
       )}

--- a/apps/app/src/components/pickers/OptionPicker.tsx
+++ b/apps/app/src/components/pickers/OptionPicker.tsx
@@ -40,6 +40,7 @@ interface OptionPickerProps<T extends string> {
   options: readonly PickerOption<T>[];
   onChange: (value: T) => void;
   className?: string;
+  caretClassName?: string;
   contentClassName?: string;
   muted?: boolean;
   defaultOpen?: boolean;
@@ -61,6 +62,7 @@ export function OptionPicker<T extends string>({
   options,
   onChange,
   className,
+  caretClassName,
   contentClassName,
   muted,
   defaultOpen,
@@ -122,7 +124,10 @@ export function OptionPicker<T extends string>({
       {disabled && !showChevronWhenDisabled ? null : (
         <Icon
           name="ChevronDown"
-          className="size-3.5 shrink-0 text-muted-foreground"
+          className={cn(
+            "size-3.5 shrink-0 text-muted-foreground",
+            caretClassName,
+          )}
         />
       )}
     </Button>

--- a/apps/app/src/components/pickers/OptionPicker.tsx
+++ b/apps/app/src/components/pickers/OptionPicker.tsx
@@ -22,7 +22,6 @@ import {
 const OPTION_WARNING_TEXT_CLASS_NAME = "text-warning-text";
 const OPTION_WARNING_INTERACTIVE_CLASS_NAME =
   "hover:text-warning-text data-[state=open]:text-warning-text";
-const OPTION_WARNING_ICON_CLASS_NAME = "text-warning-text";
 
 export interface PickerOption<T extends string> {
   value: T;
@@ -123,12 +122,7 @@ export function OptionPicker<T extends string>({
       {disabled && !showChevronWhenDisabled ? null : (
         <Icon
           name="ChevronDown"
-          className={cn(
-            "size-3.5 shrink-0",
-            selectedIsWarning
-              ? OPTION_WARNING_ICON_CLASS_NAME
-              : "text-muted-foreground",
-          )}
+          className="size-3.5 shrink-0 text-muted-foreground"
         />
       )}
     </Button>

--- a/apps/app/src/components/pickers/PermissionModePicker.test.tsx
+++ b/apps/app/src/components/pickers/PermissionModePicker.test.tsx
@@ -16,6 +16,22 @@ afterEach(() => {
 });
 
 describe("PermissionModePicker", () => {
+  it("keeps the warning mode caret aligned with the other prompt box carets", () => {
+    const { container } = render(
+      <PermissionModePicker
+        value="full"
+        options={permissionOptions}
+        onChange={vi.fn()}
+        supported
+      />,
+    );
+
+    const caret = container.querySelector('[data-icon="ChevronDown"]');
+    expect(caret).not.toBeNull();
+    expect(caret!.classList).toContain("text-muted-foreground");
+    expect(caret!.classList).not.toContain("text-warning-text");
+  });
+
   it("can show an effective display override without changing the selected value", () => {
     const onChange = vi.fn();
     render(

--- a/apps/app/src/components/pickers/PermissionModePicker.test.tsx
+++ b/apps/app/src/components/pickers/PermissionModePicker.test.tsx
@@ -28,7 +28,7 @@ describe("PermissionModePicker", () => {
 
     const caret = container.querySelector('[data-icon="ChevronDown"]');
     expect(caret).not.toBeNull();
-    expect(caret!.classList).toContain("text-muted-foreground");
+    expect(caret!.classList).toContain("text-subtle-foreground/75");
     expect(caret!.classList).not.toContain("text-warning-text");
   });
 

--- a/apps/app/src/components/pickers/PermissionModePicker.tsx
+++ b/apps/app/src/components/pickers/PermissionModePicker.tsx
@@ -81,6 +81,7 @@ export function PermissionModePicker({
       options={compactOptions}
       onChange={onChange}
       className={cn(LIST_HOVER_TRANSITION, className)}
+      caretClassName="text-subtle-foreground/75"
       contentClassName="max-w-72"
       muted={muted}
       defaultOpen={defaultOpen}

--- a/apps/app/src/components/promptbox/FollowUpPromptBox.stories.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.stories.tsx
@@ -865,7 +865,11 @@ function StackedCardsWithPillsRow() {
 export function ControlEmphasis() {
   return (
     <div className="mx-auto flex min-h-[28rem] w-full max-w-3xl items-end p-4">
-      <Row submitMode={{ kind: "ready" }} />
+      <Row
+        submitMode={{ kind: "ready" }}
+        permission={{ ...basePermission, value: "full" }}
+        environmentSummary={worktreeEnvironmentSummary}
+      />
     </div>
   );
 }

--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -1654,6 +1654,10 @@ describe("PromptBoxInternal size controls", () => {
     expect(collapseButton.classList).toContain("text-subtle-foreground/75");
     expect(collapseButton.classList).toContain("w-6");
     expect(collapseButton.classList).toContain("px-0");
+    expect(collapseButton.parentElement?.classList).toContain("right-[13px]");
+    expect(
+      collapseButton.querySelector('[data-icon="ChevronDown"]')?.classList,
+    ).toContain("size-3.5");
     fireEvent.click(collapseButton);
 
     expect(onCollapse).toHaveBeenCalledOnce();

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -3020,7 +3020,7 @@ export function PromptBoxInternal({
                     data-promptbox-expanded-only=""
                     data-promptbox-standard-actions=""
                     inert={showVoiceActionGroup ? true : undefined}
-                    className="absolute right-2 top-2 z-20 flex items-center"
+                    className="absolute right-[13px] top-2 z-20 flex items-center"
                   >
                     <Button
                       type="button"
@@ -3037,7 +3037,7 @@ export function PromptBoxInternal({
                         PROMPT_STACK_EDGE_CARET_BUTTON_WIDTH_CLASS,
                       )}
                     >
-                      <Icon name="ChevronDown" className="size-3" />
+                      <Icon name="ChevronDown" className="size-3.5" />
                     </Button>
                   </div>
                 ) : null}

--- a/apps/app/src/components/promptbox/ThreadEnvironmentSummary.test.tsx
+++ b/apps/app/src/components/promptbox/ThreadEnvironmentSummary.test.tsx
@@ -105,7 +105,7 @@ describe("ThreadEnvironmentSummary", () => {
   );
 
   it("explains the create-thread action in a tooltip", async () => {
-    render(
+    const { container } = render(
       <TooltipProvider delayDuration={0}>
         <ThreadEnvironmentSummary
           environmentLabel="Worktree"
@@ -114,11 +114,17 @@ describe("ThreadEnvironmentSummary", () => {
       </TooltipProvider>,
     );
 
-    fireEvent.focus(
-      screen.getByRole("button", {
-        name: "Create thread in worktree",
-      }),
+    const createThreadButton = screen.getByRole("button", {
+      name: "Create thread in worktree",
+    });
+    expect(createThreadButton.classList).toContain("text-muted-foreground");
+    expect(createThreadButton.classList).toContain(
+      "hover:text-muted-foreground",
     );
+    expect(
+      container.querySelector('[data-icon="MessageSquarePlus"]'),
+    ).not.toBeNull();
+    fireEvent.focus(createThreadButton);
 
     expect((await screen.findByRole("tooltip")).textContent).toBe(
       "Create thread in worktree",

--- a/apps/app/src/components/promptbox/ThreadEnvironmentSummary.test.tsx
+++ b/apps/app/src/components/promptbox/ThreadEnvironmentSummary.test.tsx
@@ -117,7 +117,9 @@ describe("ThreadEnvironmentSummary", () => {
     const createThreadButton = screen.getByRole("button", {
       name: "Create thread in worktree",
     });
-    expect(createThreadButton.classList).toContain("text-muted-foreground");
+    expect(createThreadButton.classList).toContain(
+      "text-subtle-foreground/75",
+    );
     expect(createThreadButton.classList).toContain(
       "hover:text-muted-foreground",
     );

--- a/apps/app/src/components/promptbox/ThreadEnvironmentSummary.tsx
+++ b/apps/app/src/components/promptbox/ThreadEnvironmentSummary.tsx
@@ -4,6 +4,7 @@ import { copyToClipboardWithToast } from "@/lib/clipboard";
 import { Icon, type IconName } from "@bb/shared-ui/icon";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@bb/shared-ui/tooltip";
 import { cn } from "@bb/shared-ui/lib/utils";
+import { CHROME_SUBTLE_ICON_BUTTON_FOREGROUND_CLASS } from "@bb/shared-ui/chrome-style-tokens";
 import type { EnvironmentWorkspaceTypeLabel } from "@/lib/environment-workspace-display";
 import type { WorkspaceCheckoutDisplay } from "@/lib/workspace-checkout-display";
 
@@ -128,7 +129,10 @@ export const ThreadEnvironmentSummary = memo(function ThreadEnvironmentSummary({
               type="button"
               aria-label="Create thread in worktree"
               onClick={onCreateNewThreadInWorktree}
-              className="-ml-1 inline-flex cursor-pointer shrink-0 items-center justify-center rounded-md px-1 py-0.5 text-muted-foreground transition-colors hover:bg-state-hover hover:text-muted-foreground"
+              className={cn(
+                "-ml-1 inline-flex cursor-pointer shrink-0 items-center justify-center rounded-md px-1 py-0.5 transition-colors hover:bg-state-hover",
+                CHROME_SUBTLE_ICON_BUTTON_FOREGROUND_CLASS,
+              )}
             >
               <Icon name="MessageSquarePlus" className="size-4" />
             </button>

--- a/apps/app/src/components/promptbox/ThreadEnvironmentSummary.tsx
+++ b/apps/app/src/components/promptbox/ThreadEnvironmentSummary.tsx
@@ -128,7 +128,7 @@ export const ThreadEnvironmentSummary = memo(function ThreadEnvironmentSummary({
               type="button"
               aria-label="Create thread in worktree"
               onClick={onCreateNewThreadInWorktree}
-              className="-ml-1 inline-flex cursor-pointer shrink-0 items-center justify-center rounded-md px-1 py-0.5 text-muted-foreground transition-colors hover:bg-state-hover hover:text-foreground"
+              className="-ml-1 inline-flex cursor-pointer shrink-0 items-center justify-center rounded-md px-1 py-0.5 text-muted-foreground transition-colors hover:bg-state-hover hover:text-muted-foreground"
             >
               <Icon name="MessageSquarePlus" className="size-4" />
             </button>


### PR DESCRIPTION
## Human comments

## What was wrong

The prompt-box footer applied semantic warning and hover colors to secondary affordances. Full Access correctly made the permission label amber, but it also made the dropdown caret amber; hovering Create thread in worktree promoted its icon to foreground. Both controls therefore stood out from the prompt box's other neutral affordances.

## What changed

- Moves the permission caret to the prompt box’s `text-subtle-foreground/75` chrome tier while the selected permission label retains its warning tone.
- Moves the Create thread in worktree icon to the same low-emphasis chrome tier, with the established muted hover treatment.
- Uses normal weight for the model selector so its long label and provider mark do not dominate the composer.
- Aligns the top-right collapse caret exactly with the permission caret while preserving its hit target.
- Expands the existing Control emphasis story to show Full Access and the worktree-create action together.
- Adds focused regression assertions for the color, weight, and caret-alignment contracts.
- No wire, persistence, SDK, CLI, or daemon protocol behavior changed.

## How you verified

- Chrome for Testing 149.0.7827.55 rendered matched DPR 2 crops of the same Control emphasis fixture at 1440×900. Per product review, the Before image combines the target controls’ parent behavior (`68a9aa715db41ede83ae66ccf72cf385aabab28c`) with main’s plus/model/composer-caret styling (`ec8f4ef04105c2cb5a59f7a9a9328bf2b16b39ce`); After is the exact child head `cb254b273da66575afcc307fefd466602650f02d`.
- Before: the permission label and caret both resolved to the amber warning color; the worktree-create icon sat at the stronger muted tier.
- After: the permission label remains amber, while the permission caret, worktree-create icon, model caret, composer caret, and plus icon all resolve to the exact same `text-subtle-foreground/75` color in light and dark themes.
- The same neutral equality was checked in dark theme. On the final light-theme capture, the model selector resolves to weight 400; the collapse and permission carets both render at 16px with center x=894 and the same color. Local CI-equivalent checks were not run per repository policy; GitHub CI owns test and typecheck execution.

### Before — main styling for the other prompt-box controls

The plus, model caret, and composer caret use their main styling; the permission caret remains amber and the worktree-create icon remains darker.

![Before — mismatched prompt-box affordance colors](https://raw.githubusercontent.com/brsbl/bb/26f9bfcf704b980867b455fd962d2e92ee2c3600/promptbox-control-colors-before-main-controls-retina.png)

### After — child head `cb254b273da66575afcc307fefd466602650f02d`

The warning remains on the Full Access label; the model returns to normal weight, and the two right-edge carets align exactly.

![After — balanced prompt-box control hierarchy](https://raw.githubusercontent.com/get-bb/bb/6247139cf44b266f4f8c34b18e26596df6ef55ef/promptbox-control-colors-after-final-retina.png)

BB-Thread-ID: thr_fdabesxhdr

> AGENT GENERATED
