### PR TITLE
Tweak sidebar motion to be more dynamic + consistent between left/right sidebar

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -93,6 +93,7 @@
     "katex": "^0.16.22",
     "lucide-react": "^1.23.0",
     "mermaid": "^11.15.0",
+    "motion": "^13.1.0",
     "nanoid": "^5.1.6",
     "partysocket": "^1.1.16",
     "react": "^19.0.0",

--- a/apps/app/src/components/layout/AppPageHeader.tsx
+++ b/apps/app/src/components/layout/AppPageHeader.tsx
@@ -1,5 +1,15 @@
-import { useState, type ReactNode, type Ref } from "react";
-import { useIsSidebarShowing } from "@/components/ui/sidebar.js";
+import {
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactNode,
+  type Ref,
+} from "react";
+import { clamp } from "motion";
+import {
+  useIsSidebarShowing,
+  useSidebarDesktopMotionProgress,
+} from "@/components/ui/sidebar.js";
 import {
   COARSE_POINTER_HEADER_ICON_BUTTON_CLASS,
   COARSE_POINTER_HEADER_REDUCED_GLYPH_ICON_BUTTON_CLASS,
@@ -47,6 +57,7 @@ export function AppPageHeader({
   ownsWindowTopLeft = true,
 }: AppPageHeaderProps) {
   const isSidebarShowing = useIsSidebarShowing();
+  const sidebarMotionProgress = useSidebarDesktopMotionProgress();
   const isCompactViewport = useIsCompactViewport();
   const [desktopInfo] = useState(getBbDesktopInfo);
   const desktopWindowState = useDesktopWindowState();
@@ -57,6 +68,26 @@ export function AppPageHeader({
   });
   const shouldReserveSidebarTrigger =
     ownsWindowTopLeft && (isCompactViewport || !isSidebarShowing);
+  const desktopSidebarTriggerReservePx = reserveMacosTrafficLights ? 104 : 32;
+  const contentRowRef = useRef<HTMLDivElement>(null);
+  const initialSidebarProgress = clamp(0, 1, sidebarMotionProgress.get());
+  useLayoutEffect(() => {
+    const contentRow = contentRowRef.current;
+    if (!contentRow || !ownsWindowTopLeft || isCompactViewport) return;
+
+    const applyProgress = (progress: number) => {
+      contentRow.style.paddingInlineStart = `${
+        (1 - clamp(0, 1, progress)) * desktopSidebarTriggerReservePx
+      }px`;
+    };
+    applyProgress(sidebarMotionProgress.get());
+    return sidebarMotionProgress.on("change", applyProgress);
+  }, [
+    desktopSidebarTriggerReservePx,
+    isCompactViewport,
+    ownsWindowTopLeft,
+    sidebarMotionProgress,
+  ]);
   return (
     <header
       ref={headerRef}
@@ -70,13 +101,23 @@ export function AppPageHeader({
       )}
     >
       <div
+        ref={contentRowRef}
         data-testid="app-page-header-content-row"
+        style={
+          ownsWindowTopLeft && !isCompactViewport
+            ? {
+                paddingInlineStart: `${
+                  (1 - initialSidebarProgress) * desktopSidebarTriggerReservePx
+                }px`,
+              }
+            : undefined
+        }
         className={cn(
           CHROME_ROW_CLASS,
           "relative z-10 gap-1 md:gap-2",
           usesDesktopChrome && MACOS_CHROME_CONTROL_AXIS_CLASS,
-          "transition-[padding] duration-200 ease-linear",
-          shouldReserveSidebarTrigger &&
+          isCompactViewport &&
+            shouldReserveSidebarTrigger &&
             (reserveMacosTrafficLights
               ? MACOS_COLLAPSED_TOP_LEFT_RESERVE_CLASS
               : BROWSER_COLLAPSED_HEADER_RESERVE_CLASS),

--- a/apps/app/src/components/plugin/PluginPanelRightPanelHost.tsx
+++ b/apps/app/src/components/plugin/PluginPanelRightPanelHost.tsx
@@ -22,7 +22,10 @@ import { useAppCommandHandler } from "@/components/commands/AppCommandProvider";
 import { PluginIcon } from "@/components/plugin/PluginIcon";
 import { PluginSlotMount } from "@/components/plugin/PluginSlotMount";
 import { getRightPanelToggleIconName } from "@/components/secondary-panel/panelToggleControlState";
-import { SecondaryPanelLayout } from "@/components/secondary-panel/SecondaryPanelLayout";
+import {
+  SecondaryPanelLayout,
+  type SecondaryPanelRenderArgs,
+} from "@/components/secondary-panel/SecondaryPanelLayout";
 import {
   LazyBrowserTabDeck,
   LazyHostScopedFilePreviewTabContent,
@@ -868,14 +871,9 @@ export function PluginPanelRightPanelHost({
     ({
       presentation,
       canShowNativeBrowserView,
+      inlinePanelToggle,
       resizablePanelId,
-    }: {
-      presentation: "inline" | "drawer";
-      canShowNativeBrowserView: boolean;
-      isMainCollapsed: boolean;
-      onToggleMainCollapse: () => void;
-      resizablePanelId?: string;
-    }) => {
+    }: SecondaryPanelRenderArgs) => {
       const renderDeck = (
         activeBrowserTabId: string | null,
         canHandleBrowserCommands: boolean,
@@ -923,6 +921,7 @@ export function PluginPanelRightPanelHost({
           onOpenNewTab={openNewTab}
           isConversationCollapsed={false}
           onToggleConversationCollapse={() => undefined}
+          inlinePanelToggle={inlinePanelToggle}
           renderAsDrawer={presentation === "drawer"}
           resizablePanelId={resizablePanelId}
         />

--- a/apps/app/src/components/secondary-panel/SecondaryPanelLayout.test.tsx
+++ b/apps/app/src/components/secondary-panel/SecondaryPanelLayout.test.tsx
@@ -329,7 +329,13 @@ describe("SecondaryPanelLayout", () => {
     const panelGroup = screen.getByTestId("panel-group");
     const mainContent = screen.getByTestId("main-content");
     expect(panelGroup.style.getPropertyValue("--panel-collapse-duration")).toBe(
-      "220ms",
+      "500ms",
+    );
+    expect(
+      panelGroup.style.getPropertyValue("--panel-collapse-easing"),
+    ).toMatch(/^linear\(/u);
+    expect(mainContent.parentElement?.className).toContain(
+      "motion-reduce:duration-0",
     );
 
     view.rerenderWith({ resetKey: "plugin-page-b" });
@@ -363,7 +369,7 @@ describe("SecondaryPanelLayout", () => {
 
     act(() => frames.flushAll());
     expect(panelGroup.style.getPropertyValue("--panel-collapse-duration")).toBe(
-      "220ms",
+      "500ms",
     );
   });
 
@@ -386,7 +392,7 @@ describe("SecondaryPanelLayout", () => {
     expect(panelGroupState.setLayout).toHaveBeenLastCalledWith([60, 40]);
   });
 
-  it("owns the desktop open, closed, and conversation-collapse layouts", () => {
+  it("owns the animated desktop open, closed, and conversation layouts", () => {
     const renderPanel = createPanelRenderer();
     const view = renderLayout({
       collapseActive: false,
@@ -454,6 +460,7 @@ describe("SecondaryPanelLayout", () => {
       expect.objectContaining({
         presentation: "inline",
         canShowNativeBrowserView: true,
+        inlinePanelToggle: "reserved",
         isMainCollapsed: true,
         resizablePanelId: "thread-detail-secondary-panel-pane-test",
       }),

--- a/apps/app/src/components/secondary-panel/SecondaryPanelLayout.tsx
+++ b/apps/app/src/components/secondary-panel/SecondaryPanelLayout.tsx
@@ -15,6 +15,7 @@ import {
   type ImperativePanelGroupHandle,
 } from "react-resizable-panels";
 import { useIsCompactViewport } from "@bb/shared-ui/hooks/use-compact-viewport";
+import { usePrefersReducedMotion } from "@bb/shared-ui/hooks/use-media-query";
 import {
   PersistentResponsiveDrawerShell,
   useResponsiveDrawerRealization,
@@ -33,6 +34,10 @@ import {
   usePanelCollapseTransitionsReady,
 } from "./panelTransitionTokens";
 import { secondaryPanelWidthPercentAtom } from "./threadSecondaryPanelAtoms";
+import {
+  createSecondaryPanelGroupMotion,
+  type SecondaryPanelGroupMotion,
+} from "./secondaryPanelGroupMotion";
 
 const FULL_PANEL_SIZE_PERCENT = 100;
 const MAIN_PANEL_MIN_SIZE_PERCENT = 30;
@@ -42,6 +47,7 @@ function noopToggleMainCollapse(): void {}
 export interface SecondaryPanelRenderArgs {
   presentation: "inline" | "drawer";
   canShowNativeBrowserView: boolean;
+  inlinePanelToggle: "button" | "reserved";
   isMainCollapsed: boolean;
   onToggleMainCollapse: () => void;
   resizablePanelId?: string;
@@ -88,6 +94,7 @@ export function SecondaryPanelLayout({
   const paneContext = useOptionalPaneContext();
   const secondaryPanelHost = paneContext?.secondaryPanelHost ?? null;
   const renderAsDrawer = useIsCompactViewport();
+  const shouldReduceMotion = usePrefersReducedMotion();
   const transitionsReady = usePanelCollapseTransitionsReady(
     resetKey,
     !renderAsDrawer,
@@ -100,6 +107,11 @@ export function SecondaryPanelLayout({
   const horizontalPanelGroupRef = useRef<ImperativePanelGroupHandle | null>(
     null,
   );
+  const panelGroupMotionRef = useRef<SecondaryPanelGroupMotion | null>(null);
+  if (panelGroupMotionRef.current === null) {
+    panelGroupMotionRef.current = createSecondaryPanelGroupMotion();
+  }
+  const panelGroupMotion = panelGroupMotionRef.current;
   const persistedSecondaryWidthRef = useRef(persistedSecondaryWidthPercent);
   useEffect(() => {
     persistedSecondaryWidthRef.current = persistedSecondaryWidthPercent;
@@ -114,18 +126,31 @@ export function SecondaryPanelLayout({
       return;
     }
 
-    if (!open) {
-      group.setLayout([FULL_PANEL_SIZE_PERCENT, 0]);
-      return;
-    }
-    if (isMainCollapsed) {
-      group.setLayout([0, FULL_PANEL_SIZE_PERCENT]);
-      return;
-    }
+    const secondaryWidth = !open
+      ? 0
+      : isMainCollapsed
+        ? FULL_PANEL_SIZE_PERCENT
+        : persistedSecondaryWidthRef.current;
+    panelGroupMotion.setLayout(
+      group,
+      [FULL_PANEL_SIZE_PERCENT - secondaryWidth, secondaryWidth],
+      shouldReduceMotion || !transitionsReady,
+    );
+  }, [
+    isMainCollapsed,
+    open,
+    panelGroupMotion,
+    renderAsDrawer,
+    shouldReduceMotion,
+    transitionsReady,
+  ]);
 
-    const secondaryWidth = persistedSecondaryWidthRef.current;
-    group.setLayout([FULL_PANEL_SIZE_PERCENT - secondaryWidth, secondaryWidth]);
-  }, [isMainCollapsed, open, renderAsDrawer]);
+  useLayoutEffect(
+    () => () => {
+      panelGroupMotion.stop();
+    },
+    [panelGroupMotion],
+  );
 
   const [isCompactDrawerContentSettled, setIsCompactDrawerContentSettled] =
     useState(false);
@@ -233,6 +258,8 @@ export function SecondaryPanelLayout({
         : renderPanel({
             presentation: "inline",
             canShowNativeBrowserView,
+            inlinePanelToggle:
+              secondaryPanelHost === null ? "button" : "reserved",
             isMainCollapsed,
             onToggleMainCollapse: collapse?.onToggle ?? noopToggleMainCollapse,
             resizablePanelId,
@@ -244,6 +271,7 @@ export function SecondaryPanelLayout({
       renderAsDrawer,
       renderPanel,
       resizablePanelId,
+      secondaryPanelHost,
     ],
   );
   const drawerPanel = useMemo(
@@ -252,6 +280,7 @@ export function SecondaryPanelLayout({
         ? renderPanel({
             presentation: "drawer",
             canShowNativeBrowserView,
+            inlinePanelToggle: "button",
             isMainCollapsed: false,
             onToggleMainCollapse: collapse?.onToggle ?? noopToggleMainCollapse,
           })
@@ -325,19 +354,10 @@ export function SecondaryPanelLayout({
             {...(collapse === undefined
               ? {}
               : { collapsible: true, collapsedSize: 0 })}
-            defaultSize={
-              isMainCollapsed
-                ? 0
-                : open && !renderAsDrawer
-                  ? FULL_PANEL_SIZE_PERCENT - persistedSecondaryWidthPercent
-                  : FULL_PANEL_SIZE_PERCENT
-            }
+            defaultSize={FULL_PANEL_SIZE_PERCENT}
             minSize={MAIN_PANEL_MIN_SIZE_PERCENT}
             order={1}
-            className={cn(
-              "min-w-0 overflow-clip transition-[flex-grow,flex-basis]",
-              PANEL_COLLAPSE_TRANSITION_CLASS,
-            )}
+            className="min-w-0 overflow-clip"
           >
             {mainContent}
           </Panel>

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.test.ts
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 import {
   getSecondaryPanelChromeStackClassName,
   getReservedInlinePanelToggleClassName,
-  isSecondaryPanelLayoutTransition,
   resolveCollapsedPanelTrafficLightReserveClassName,
 } from "./ThreadSecondaryPanel";
 import {
@@ -15,14 +14,6 @@ import { SECONDARY_PANEL_TOP_CHROME_BACKGROUND_CLASS } from "./panelChromeClasse
 describe("secondary panel surface tone", () => {
   it("uses the same sidebar background token as the primary sidebar", () => {
     expect(SECONDARY_PANEL_TOP_CHROME_BACKGROUND_CLASS).toBe("bg-sidebar");
-  });
-});
-
-describe("secondary panel native browser bounds settling", () => {
-  it("recognizes the flex transitions that move the panel back to its restored position", () => {
-    expect(isSecondaryPanelLayoutTransition("flex-grow")).toBe(true);
-    expect(isSecondaryPanelLayoutTransition("flex-basis")).toBe(true);
-    expect(isSecondaryPanelLayoutTransition("opacity")).toBe(false);
   });
 });
 

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
@@ -3,7 +3,6 @@ import {
   type FocusEvent,
   type PointerEvent as ReactPointerEvent,
   type ReactNode,
-  type TransitionEvent,
   useCallback,
   useContext,
   useLayoutEffect,
@@ -90,7 +89,6 @@ import { AppCommandShortcutHint } from "@/components/commands/AppCommandShortcut
 import type { AppShortcutPresentation } from "@/lib/app-keybindings";
 import { TabPill } from "@/components/ui/tab-pill";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@bb/shared-ui/tooltip";
-import { dispatchBrowserViewBoundsSync } from "@/lib/browser-view-bounds-sync";
 import type { SplitSide } from "@/lib/split-layout";
 import { PaneArrangementButton } from "@/views/thread-detail/PaneMaximizeButton";
 import {
@@ -105,11 +103,6 @@ export type {
   SecondaryPanelRenderableTab,
 } from "./secondaryPanelTab";
 
-export function isSecondaryPanelLayoutTransition(
-  propertyName: string,
-): boolean {
-  return propertyName === "flex-grow" || propertyName === "flex-basis";
-}
 const PANEL_SCROLL_SLOT_CLASS =
   "min-h-0 flex-1 overflow-x-auto overflow-y-auto";
 const SECONDARY_RESIZABLE_PANEL_STYLE: CSSProperties = {
@@ -273,9 +266,8 @@ export function ThreadSecondaryPanel({
     handleSecondaryPanelResizePointerDownCapture,
     persistedWidthPercent,
     secondaryPanelRef: panelRef,
-    secondaryResizablePanelRef: resizablePanelRef,
+    secondaryResizablePanelRef,
   } = useSecondaryPanelResize({
-    isSecondaryPanelOpen: isOpen,
     onPanelWidthChange: handleSecondaryPanelWidthChange,
   });
   const handleSecondaryPanelDragging: SecondaryPanelDraggingHandler =
@@ -312,19 +304,6 @@ export function ThreadSecondaryPanel({
     hasPanelExpandedRef.current = false;
     onCollapse();
   }, [hostLayout?.isSuppressed, onCollapse]);
-  const handlePanelTransitionEnd = useCallback(
-    (event: TransitionEvent<HTMLElement>) => {
-      if (
-        event.target !== event.currentTarget ||
-        !isSecondaryPanelLayoutTransition(event.propertyName)
-      ) {
-        return;
-      }
-
-      dispatchBrowserViewBoundsSync();
-    },
-    [],
-  );
   const isLayoutOpen =
     (hostLayout?.isOpen ?? isOpen) && !hostLayout?.isSuppressed;
   const activeFixedTab =
@@ -998,9 +977,6 @@ export function ThreadSecondaryPanel({
         renderAsDrawer && "min-w-0 flex-1",
         !renderAsDrawer && [
           "absolute inset-y-0 left-0",
-          hostLayout === null &&
-            !isConversationCollapsed &&
-            "border-l border-border-seam",
           isSecondaryPanelResizing && "right-0",
           !isOpen && "pointer-events-none",
         ],
@@ -1028,17 +1004,11 @@ export function ThreadSecondaryPanel({
         onPointerDown={handleSecondaryPanelResizePointerDownCapture}
       />
       <Panel
-        ref={resizablePanelRef}
+        ref={secondaryResizablePanelRef}
         id={resizablePanelId}
         collapsible
         collapsedSize={0}
-        defaultSize={
-          isLayoutOpen
-            ? isConversationCollapsed
-              ? CONVERSATION_COLLAPSED_PANEL_SIZE_PERCENT
-              : persistedWidthPercent
-            : 0
-        }
+        defaultSize={0}
         minSize={THREAD_SECONDARY_PANEL_MIN_SIZE_PERCENT}
         maxSize={
           isConversationCollapsed
@@ -1047,13 +1017,9 @@ export function ThreadSecondaryPanel({
         }
         onCollapse={handlePanelCollapse}
         onResize={handlePanelResize}
-        onTransitionEnd={handlePanelTransitionEnd}
         order={2}
         style={SECONDARY_RESIZABLE_PANEL_STYLE}
-        className={cn(
-          "min-w-0 overflow-clip",
-          `relative transition-[flex-grow,flex-basis] ${PANEL_COLLAPSE_TRANSITION_CLASS}`,
-        )}
+        className={cn("min-w-0 overflow-clip", "relative")}
       >
         {asideMarkup}
       </Panel>
@@ -1163,13 +1129,14 @@ function SecondaryPanelResizeHandle({
   return (
     <PanelResizeHandle
       id="thread-detail-secondary-panel-handle"
+      data-secondary-panel-boundary=""
       disabled={!isOpen || isConversationCollapsed}
       onDragging={onDragging}
       onPointerDownCapture={(event) => onPointerDown(event.nativeEvent)}
       data-panel-resize-snap-handle=""
       hitAreaMargins={PANEL_RESIZE_HIT_AREA_MARGINS}
       className={cn(
-        "group relative shrink-0 overflow-visible transition-[width,opacity,background-color]",
+        "group relative shrink-0 overflow-visible transition-[width,background-color]",
         PANEL_RESIZE_HANDLE_LAYER_CLASS,
         PANEL_COLLAPSE_TRANSITION_CLASS,
         isConversationCollapsed ? "cursor-default" : "cursor-col-resize",
@@ -1202,7 +1169,7 @@ function SecondaryPanelResizeHandle({
             "pointer-events-none absolute inset-y-0 left-full z-10 w-px transition-colors",
             isResizing
               ? "bg-accent-foreground/50"
-              : "bg-transparent group-hover:bg-accent-foreground/35",
+              : "bg-border-seam group-hover:bg-accent-foreground/35",
           )}
         />
       )}

--- a/apps/app/src/components/secondary-panel/lazySecondaryPanelComponents.tsx
+++ b/apps/app/src/components/secondary-panel/lazySecondaryPanelComponents.tsx
@@ -2,8 +2,6 @@ import { lazy, Suspense, type ComponentProps, type ReactNode } from "react";
 import { useAtomValue } from "jotai";
 import { Panel } from "react-resizable-panels";
 import { Skeleton } from "@bb/shared-ui/skeleton";
-import { cn } from "@bb/shared-ui/lib/utils";
-import { PANEL_COLLAPSE_TRANSITION_CLASS } from "./panelTransitionTokens";
 import {
   CONVERSATION_COLLAPSED_PANEL_SIZE_PERCENT,
   THREAD_SECONDARY_PANEL_MAX_SIZE_PERCENT,
@@ -130,10 +128,7 @@ function ThreadSecondaryPanelInlinePlaceholder({
           : THREAD_SECONDARY_PANEL_MAX_SIZE_PERCENT
       }
       order={2}
-      className={cn(
-        "min-w-0 overflow-clip",
-        `relative transition-[flex-grow,flex-basis] ${PANEL_COLLAPSE_TRANSITION_CLASS}`,
-      )}
+      className="relative min-w-0 overflow-clip"
       data-testid="thread-secondary-panel-placeholder"
     >
       {isOpen ? (

--- a/apps/app/src/components/secondary-panel/panelTransitionTokens.ts
+++ b/apps/app/src/components/secondary-panel/panelTransitionTokens.ts
@@ -1,17 +1,25 @@
 import { useEffect, useState, type CSSProperties, type Key } from "react";
+import {
+  PANEL_MOTION_DURATION_MS,
+  PANEL_SPRING_CSS_EASING,
+} from "@/lib/panel-motion";
 
 type PanelCollapseTransitionStyle = CSSProperties & {
   "--panel-collapse-duration": string;
+  "--panel-collapse-easing": string;
 };
 
 export const PANEL_COLLAPSE_TRANSITION_CLASS =
-  "duration-[var(--panel-collapse-duration,220ms)] ease-[cubic-bezier(0.32,0.72,0,1)]";
+  "duration-[var(--panel-collapse-duration,500ms)] ease-[var(--panel-collapse-easing)] motion-reduce:duration-0";
 
 export function getPanelCollapseTransitionStyle(
   transitionsReady: boolean,
 ): PanelCollapseTransitionStyle {
   return {
-    "--panel-collapse-duration": transitionsReady ? "220ms" : "0ms",
+    "--panel-collapse-duration": transitionsReady
+      ? `${PANEL_MOTION_DURATION_MS}ms`
+      : "0ms",
+    "--panel-collapse-easing": PANEL_SPRING_CSS_EASING,
   };
 }
 

--- a/apps/app/src/components/secondary-panel/secondaryPanelGroupMotion.test.ts
+++ b/apps/app/src/components/secondary-panel/secondaryPanelGroupMotion.test.ts
@@ -112,6 +112,24 @@ describe("createSecondaryPanelGroupMotion", () => {
     expect(panels[1]?.style.flexGrow).toBe("30");
   });
 
+  it("starts closing from the width applied by a resize drag", () => {
+    const { group, panels } = createHarness();
+    const motion = createSecondaryPanelGroupMotion();
+
+    motion.setLayout(group, [60, 40], false);
+    const openingAnimation = motionAnimationState.calls[0];
+    openingAnimation?.value.set(40);
+    openingAnimation?.options.onComplete?.();
+
+    group.setLayout([65, 35]);
+    motion.setLayout(group, [100, 0], false);
+
+    const closingAnimation = motionAnimationState.calls[1];
+    expect(closingAnimation?.value.get()).toBe(35);
+    expect(panels[0]?.style.flexGrow).toBe("65");
+    expect(panels[1]?.style.flexGrow).toBe("35");
+  });
+
   it("defers the panel library's target layout until Motion completes", () => {
     const { group } = createHarness();
     const motion = createSecondaryPanelGroupMotion();

--- a/apps/app/src/components/secondary-panel/secondaryPanelGroupMotion.test.ts
+++ b/apps/app/src/components/secondary-panel/secondaryPanelGroupMotion.test.ts
@@ -39,9 +39,9 @@ function createHarness() {
   const groupElement = document.createElement("div");
   groupElement.setAttribute("data-panel-group", "");
   groupElement.setAttribute("data-panel-group-id", groupId);
-  vi.spyOn(groupElement, "getBoundingClientRect").mockReturnValue({
-    width: 800,
-  } as DOMRect);
+  const measureGroup = vi
+    .spyOn(groupElement, "getBoundingClientRect")
+    .mockReturnValue({ width: 800 } as DOMRect);
   const panels = [document.createElement("div"), document.createElement("div")];
   for (const panel of panels) {
     panel.setAttribute("data-panel", "");
@@ -69,7 +69,7 @@ function createHarness() {
   };
   group.setLayout(layout);
 
-  return { boundary, group, panels };
+  return { boundary, group, measureGroup, panels };
 }
 
 afterEach(() => {
@@ -94,6 +94,42 @@ describe("createSecondaryPanelGroupMotion", () => {
     expect(boundary.style.opacity).toBe("0");
     animation?.value.set(safePercent);
     expect(boundary.style.opacity).toBe("1");
+  });
+
+  it("keeps the disabled boundary hidden at the full-width layout", () => {
+    const { boundary, group } = createHarness();
+    const motion = createSecondaryPanelGroupMotion();
+
+    motion.setLayout(group, [60, 40], false);
+    const animation = motionAnimationState.calls[0];
+    animation?.value.set(40);
+    animation?.options.onComplete?.();
+    expect(boundary.style.opacity).toBe("1");
+
+    motion.setLayout(group, [0, 100], false);
+    const collapsing = motionAnimationState.calls[1];
+    collapsing?.value.set(99);
+    expect(boundary.style.opacity).toBe("1");
+    collapsing?.value.set(100);
+    expect(boundary.style.opacity).toBe("0");
+    collapsing?.options.onComplete?.();
+    expect(boundary.style.opacity).toBe("0");
+  });
+
+  it("measures the group once per layout instead of on every frame", () => {
+    const { group, measureGroup } = createHarness();
+    const motion = createSecondaryPanelGroupMotion();
+
+    motion.setLayout(group, [60, 40], false);
+    const measurementsAfterStart = measureGroup.mock.calls.length;
+
+    const animation = motionAnimationState.calls[0];
+    animation?.value.set(10);
+    animation?.value.set(20);
+    animation?.value.set(40);
+    animation?.options.onComplete?.();
+
+    expect(measureGroup.mock.calls.length).toBe(measurementsAfterStart);
   });
 
   it("restarts an interrupted layout from its rendered flex values", () => {

--- a/apps/app/src/components/secondary-panel/secondaryPanelGroupMotion.test.ts
+++ b/apps/app/src/components/secondary-panel/secondaryPanelGroupMotion.test.ts
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ImperativePanelGroupHandle } from "react-resizable-panels";
+import type { MotionValue, ValueAnimationTransition } from "motion";
+import {
+  SECONDARY_PANEL_BOUNDARY_SAFE_WIDTH_PX,
+  createSecondaryPanelGroupMotion,
+} from "./secondaryPanelGroupMotion";
+
+type RecordedAnimation = {
+  options: ValueAnimationTransition<number>;
+  stop: ReturnType<typeof vi.fn>;
+  target: number;
+  value: MotionValue<number>;
+};
+
+const motionAnimationState = vi.hoisted(() => ({
+  calls: [] as RecordedAnimation[],
+}));
+
+vi.mock("motion", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("motion")>()),
+  animate: vi.fn(
+    (
+      value: MotionValue<number>,
+      target: number,
+      options: ValueAnimationTransition<number>,
+    ) => {
+      const stop = vi.fn();
+      motionAnimationState.calls.push({ options, stop, target, value });
+      return { stop };
+    },
+  ),
+}));
+
+function createHarness() {
+  const groupId = "right-panel-group";
+  const groupElement = document.createElement("div");
+  groupElement.setAttribute("data-panel-group", "");
+  groupElement.setAttribute("data-panel-group-id", groupId);
+  vi.spyOn(groupElement, "getBoundingClientRect").mockReturnValue({
+    width: 800,
+  } as DOMRect);
+  const panels = [document.createElement("div"), document.createElement("div")];
+  for (const panel of panels) {
+    panel.setAttribute("data-panel", "");
+    panel.setAttribute("data-panel-group-id", groupId);
+    groupElement.append(panel);
+  }
+  const boundary = document.createElement("div");
+  boundary.setAttribute("data-panel-resize-handle-id", "right-panel-handle");
+  boundary.setAttribute("data-secondary-panel-boundary", "");
+  boundary.setAttribute("data-panel-group-id", groupId);
+  groupElement.insertBefore(boundary, panels[1] ?? null);
+  document.body.append(groupElement);
+
+  let layout = [100, 0];
+  const group: ImperativePanelGroupHandle = {
+    getId: () => groupId,
+    getLayout: () => layout,
+    setLayout: vi.fn((nextLayout) => {
+      layout = nextLayout;
+      panels.forEach((panel, index) => {
+        panel.style.flexBasis = "0px";
+        panel.style.flexGrow = String(nextLayout[index]);
+      });
+    }),
+  };
+  group.setLayout(layout);
+
+  return { boundary, group, panels };
+}
+
+afterEach(() => {
+  motionAnimationState.calls.length = 0;
+  document.body.replaceChildren();
+});
+
+describe("createSecondaryPanelGroupMotion", () => {
+  it("hides the opening boundary until the panel clears the fixed toggle", () => {
+    const { boundary, group } = createHarness();
+    const motion = createSecondaryPanelGroupMotion();
+
+    motion.setLayout(group, [60, 40], false);
+
+    const animation = motionAnimationState.calls[0];
+    const safePercent = (SECONDARY_PANEL_BOUNDARY_SAFE_WIDTH_PX / 800) * 100;
+    expect(animation).toMatchObject({
+      target: 40,
+      options: { type: "spring", duration: 0.5, bounce: 0.1 },
+    });
+    animation?.value.set(safePercent - 0.01);
+    expect(boundary.style.opacity).toBe("0");
+    animation?.value.set(safePercent);
+    expect(boundary.style.opacity).toBe("1");
+  });
+
+  it("restarts an interrupted layout from its rendered flex values", () => {
+    const { group, panels } = createHarness();
+    const motion = createSecondaryPanelGroupMotion();
+
+    motion.setLayout(group, [60, 40], false);
+    const openingAnimation = motionAnimationState.calls[0];
+    openingAnimation?.value.set(30);
+    motion.setLayout(group, [100, 0], false);
+
+    const closingAnimation = motionAnimationState.calls[1];
+    expect(closingAnimation?.value).toBe(openingAnimation?.value);
+    expect(closingAnimation?.target).toBe(0);
+    expect(panels[0]?.style.flexGrow).toBe("70");
+    expect(panels[1]?.style.flexGrow).toBe("30");
+  });
+
+  it("defers the panel library's target layout until Motion completes", () => {
+    const { group } = createHarness();
+    const motion = createSecondaryPanelGroupMotion();
+
+    motion.setLayout(group, [60, 40], false);
+
+    expect(group.getLayout()).toEqual([100, 0]);
+    motionAnimationState.calls[0]?.options.onComplete?.();
+    expect(group.getLayout()).toEqual([60, 40]);
+  });
+});

--- a/apps/app/src/components/secondary-panel/secondaryPanelGroupMotion.ts
+++ b/apps/app/src/components/secondary-panel/secondaryPanelGroupMotion.ts
@@ -9,6 +9,9 @@ import { PANEL_SPRING_TRANSITION } from "@/lib/panel-motion";
 
 export const SECONDARY_PANEL_BOUNDARY_SAFE_WIDTH_PX = 80;
 
+const FULL_SIZE_PERCENT = 100;
+const FALLBACK_BOUNDARY_SAFE_SIZE_PERCENT = 10;
+
 export type SecondaryPanelGroupMotion = {
   setLayout: (
     group: ImperativePanelGroupHandle,
@@ -20,7 +23,7 @@ export type SecondaryPanelGroupMotion = {
 
 type PanelGroupElements = {
   boundaries: HTMLElement[];
-  group: HTMLElement;
+  groupWidth: number;
   panels: [HTMLElement, HTMLElement];
 };
 
@@ -39,7 +42,7 @@ function findGroupElements(
 
   return {
     panels: [mainPanel, secondaryPanel],
-    group: groupElement,
+    groupWidth: groupElement.getBoundingClientRect().width,
     boundaries: getResizeHandleElementsForGroup(groupId, groupElement).filter(
       (element) => element.hasAttribute("data-secondary-panel-boundary"),
     ),
@@ -52,19 +55,19 @@ function readFlexGrow(element: HTMLElement): number {
 }
 
 function renderPanelGroup(
-  { boundaries, group, panels }: PanelGroupElements,
+  { boundaries, groupWidth, panels }: PanelGroupElements,
   secondarySize: number,
 ): void {
-  const size = Math.min(100, Math.max(0, secondarySize));
-  panels[0].style.flexGrow = String(100 - size);
+  const size = Math.min(FULL_SIZE_PERCENT, Math.max(0, secondarySize));
+  panels[0].style.flexGrow = String(FULL_SIZE_PERCENT - size);
   panels[1].style.flexGrow = String(size);
 
-  const groupWidth = group.getBoundingClientRect().width;
   const safeSize =
     groupWidth > 0
       ? (SECONDARY_PANEL_BOUNDARY_SAFE_WIDTH_PX / groupWidth) * 100
-      : 10;
-  const opacity = size >= safeSize ? "1" : "0";
+      : FALLBACK_BOUNDARY_SAFE_SIZE_PERCENT;
+  const isBoundaryShowing = size >= safeSize && size < FULL_SIZE_PERCENT;
+  const opacity = isBoundaryShowing ? "1" : "0";
   for (const boundary of boundaries) boundary.style.opacity = opacity;
 }
 

--- a/apps/app/src/components/secondary-panel/secondaryPanelGroupMotion.ts
+++ b/apps/app/src/components/secondary-panel/secondaryPanelGroupMotion.ts
@@ -92,14 +92,8 @@ export function createSecondaryPanelGroupMotion(): SecondaryPanelGroupMotion {
         return;
       }
 
-      const panelsChanged =
-        elements === null ||
-        elements.panels[0] !== nextElements.panels[0] ||
-        elements.panels[1] !== nextElements.panels[1];
       elements = nextElements;
-      if (panelsChanged) {
-        secondarySize.jump(readFlexGrow(elements.panels[1]));
-      }
+      secondarySize.jump(readFlexGrow(elements.panels[1]));
 
       const currentSize = secondarySize.get();
       renderPanelGroup(elements, currentSize);

--- a/apps/app/src/components/secondary-panel/secondaryPanelGroupMotion.ts
+++ b/apps/app/src/components/secondary-panel/secondaryPanelGroupMotion.ts
@@ -1,0 +1,127 @@
+import {
+  getPanelElementsForGroup,
+  getPanelGroupElement,
+  getResizeHandleElementsForGroup,
+  type ImperativePanelGroupHandle,
+} from "react-resizable-panels";
+import { animate, motionValue } from "motion";
+import { PANEL_SPRING_TRANSITION } from "@/lib/panel-motion";
+
+export const SECONDARY_PANEL_BOUNDARY_SAFE_WIDTH_PX = 80;
+
+export type SecondaryPanelGroupMotion = {
+  setLayout: (
+    group: ImperativePanelGroupHandle,
+    layout: readonly [mainSize: number, secondarySize: number],
+    instant: boolean,
+  ) => void;
+  stop: () => void;
+};
+
+type PanelGroupElements = {
+  boundaries: HTMLElement[];
+  group: HTMLElement;
+  panels: [HTMLElement, HTMLElement];
+};
+
+function findGroupElements(
+  group: ImperativePanelGroupHandle,
+): PanelGroupElements | null {
+  if (typeof group.getId !== "function") return null;
+  const groupId = group.getId();
+  const groupElement = getPanelGroupElement(groupId);
+  if (groupElement === null) return null;
+
+  const panels = getPanelElementsForGroup(groupId, groupElement);
+  const mainPanel = panels[0];
+  const secondaryPanel = panels[1];
+  if (mainPanel === undefined || secondaryPanel === undefined) return null;
+
+  return {
+    panels: [mainPanel, secondaryPanel],
+    group: groupElement,
+    boundaries: getResizeHandleElementsForGroup(groupId, groupElement).filter(
+      (element) => element.hasAttribute("data-secondary-panel-boundary"),
+    ),
+  };
+}
+
+function readFlexGrow(element: HTMLElement): number {
+  const value = Number(window.getComputedStyle(element).flexGrow);
+  return Number.isFinite(value) ? value : 0;
+}
+
+function renderPanelGroup(
+  { boundaries, group, panels }: PanelGroupElements,
+  secondarySize: number,
+): void {
+  const size = Math.min(100, Math.max(0, secondarySize));
+  panels[0].style.flexGrow = String(100 - size);
+  panels[1].style.flexGrow = String(size);
+
+  const groupWidth = group.getBoundingClientRect().width;
+  const safeSize =
+    groupWidth > 0
+      ? (SECONDARY_PANEL_BOUNDARY_SAFE_WIDTH_PX / groupWidth) * 100
+      : 10;
+  const opacity = size >= safeSize ? "1" : "0";
+  for (const boundary of boundaries) boundary.style.opacity = opacity;
+}
+
+export function createSecondaryPanelGroupMotion(): SecondaryPanelGroupMotion {
+  const secondarySize = motionValue(0);
+  let elements: PanelGroupElements | null = null;
+  let revision = 0;
+  secondarySize.on("change", (size) => {
+    if (elements !== null) renderPanelGroup(elements, size);
+  });
+
+  const clearBinding = () => {
+    revision += 1;
+    secondarySize.stop();
+    elements = null;
+  };
+
+  return {
+    setLayout: (group, layout, instant) => {
+      const nextElements = findGroupElements(group);
+      const targetSize = layout[1];
+      if (nextElements === null) {
+        clearBinding();
+        group.setLayout([...layout]);
+        return;
+      }
+
+      const panelsChanged =
+        elements === null ||
+        elements.panels[0] !== nextElements.panels[0] ||
+        elements.panels[1] !== nextElements.panels[1];
+      elements = nextElements;
+      if (panelsChanged) {
+        secondarySize.jump(readFlexGrow(elements.panels[1]));
+      }
+
+      const currentSize = secondarySize.get();
+      renderPanelGroup(elements, currentSize);
+      if (instant || currentSize === targetSize) {
+        revision += 1;
+        secondarySize.stop();
+        group.setLayout([...layout]);
+        secondarySize.jump(targetSize);
+        renderPanelGroup(elements, targetSize);
+        return;
+      }
+
+      const currentRevision = ++revision;
+      animate(secondarySize, targetSize, {
+        ...PANEL_SPRING_TRANSITION,
+        onComplete: () => {
+          if (revision !== currentRevision || elements === null) return;
+          group.setLayout([...layout]);
+          renderPanelGroup(elements, targetSize);
+        },
+      });
+    },
+    stop: clearBinding,
+  };
+}

--- a/apps/app/src/components/secondary-panel/useSecondaryPanelResize.ts
+++ b/apps/app/src/components/secondary-panel/useSecondaryPanelResize.ts
@@ -16,12 +16,10 @@ export type SecondaryPanelWidthChangeHandler = (
 type SecondaryPanelResizeHandler = (size: number) => void;
 
 interface UseSecondaryPanelResizeArgs {
-  isSecondaryPanelOpen: boolean;
   onPanelWidthChange: SecondaryPanelWidthChangeHandler;
 }
 
 export function useSecondaryPanelResize({
-  isSecondaryPanelOpen,
   onPanelWidthChange,
 }: UseSecondaryPanelResizeArgs) {
   const [isSecondaryPanelDragging, setIsSecondaryPanelDragging] =
@@ -47,28 +45,6 @@ export function useSecondaryPanelResize({
     onResize: handleSecondaryPanelPointerResize,
     target: { boundaryIndex: 1, childCount: 2 },
   });
-
-  const prevOpenRef = useRef(isSecondaryPanelOpen);
-  useEffect(() => {
-    if (prevOpenRef.current === isSecondaryPanelOpen) {
-      return;
-    }
-    prevOpenRef.current = isSecondaryPanelOpen;
-
-    const panel = secondaryResizablePanelRef.current;
-    if (!panel) {
-      return;
-    }
-
-    if (isSecondaryPanelOpen) {
-      panel.expand(lastSecondaryPanelSizeRef.current);
-      onPanelWidthChange(
-        secondaryPanelRef.current?.getBoundingClientRect().width,
-      );
-    } else {
-      panel.collapse();
-    }
-  }, [isSecondaryPanelOpen, onPanelWidthChange]);
 
   useResizeObserver({
     ref: secondaryPanelRef,

--- a/apps/app/src/components/ui/sidebar.test.tsx
+++ b/apps/app/src/components/ui/sidebar.test.tsx
@@ -414,6 +414,39 @@ describe("mobile sidebar deferred realization", () => {
     expect(panel.classList).toContain("[overflow-clip-margin:6px]");
   });
 
+  it("takes the collapsed desktop panel out of the keyboard and accessibility tree", () => {
+    render(
+      <CompactViewportOverrideProvider isCompactViewport={false}>
+        <SidebarProvider>
+          <Sidebar>
+            <button type="button">New thread</button>
+          </Sidebar>
+          <SidebarTrigger />
+        </SidebarProvider>
+      </CompactViewportOverrideProvider>,
+    );
+
+    const panel = document.querySelector('[data-sidebar="panel"]');
+    if (!(panel instanceof HTMLElement)) {
+      throw new Error("Expected the desktop sidebar panel");
+    }
+    expect(panel.hasAttribute("inert")).toBe(false);
+    expect(panel.getAttribute("aria-hidden")).toBe("false");
+    expect(screen.getByRole("button", { name: "New thread" })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Toggle Sidebar" }));
+
+    expect(panel.hasAttribute("inert")).toBe(true);
+    expect(panel.getAttribute("aria-hidden")).toBe("true");
+    expect(screen.queryByRole("button", { name: "New thread" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Toggle Sidebar" }));
+
+    expect(panel.hasAttribute("inert")).toBe(false);
+    expect(panel.getAttribute("aria-hidden")).toBe("false");
+    expect(screen.getByRole("button", { name: "New thread" })).toBeTruthy();
+  });
+
   it("uses the shared duration spring and reverses from its current width", () => {
     render(
       <CompactViewportOverrideProvider isCompactViewport={false}>

--- a/apps/app/src/components/ui/sidebar.test.tsx
+++ b/apps/app/src/components/ui/sidebar.test.tsx
@@ -11,6 +11,7 @@ import { memo } from "react";
 import { flushSync } from "react-dom";
 import { renderToString } from "react-dom/server";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { MotionValue, ValueAnimationTransition } from "motion";
 import { CompactViewportOverrideProvider } from "@bb/shared-ui/hooks/use-compact-viewport";
 import {
   Sidebar,
@@ -22,8 +23,37 @@ import {
   useSidebar,
 } from "./sidebar";
 
+type RecordedMotionAnimation = {
+  options: ValueAnimationTransition<number>;
+  target: number;
+  value: MotionValue<number>;
+};
+
+const motionAnimationState = vi.hoisted(() => ({
+  calls: [] as RecordedMotionAnimation[],
+}));
+
+vi.mock("motion", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("motion")>()),
+  animate: vi.fn(
+    (
+      value: MotionValue<number>,
+      target: number,
+      options: ValueAnimationTransition<number>,
+    ) => {
+      motionAnimationState.calls.push({
+        options,
+        target,
+        value,
+      });
+      return { stop: vi.fn() };
+    },
+  ),
+}));
+
 afterEach(() => {
   cleanup();
+  motionAnimationState.calls.length = 0;
   vi.restoreAllMocks();
   vi.useRealTimers();
 });
@@ -341,7 +371,7 @@ describe("mobile sidebar deferred realization", () => {
     expect(getMobilePanel()?.dataset.state).toBe("open");
   });
 
-  it("writes the desktop width on the gap and panel, not on the provider wrapper", () => {
+  it("writes the desktop width on each reader, not on the provider wrapper", () => {
     render(
       <CompactViewportOverrideProvider isCompactViewport={false}>
         <SidebarProvider width="333px" data-testid="wrapper">
@@ -353,12 +383,78 @@ describe("mobile sidebar deferred realization", () => {
     const wrapper = screen.getByTestId("wrapper");
     const gap = document.querySelector('[data-sidebar="gap"]');
     const panel = document.querySelector('[data-sidebar="panel"]');
-    if (!(gap instanceof HTMLElement) || !(panel instanceof HTMLElement)) {
-      throw new Error("Expected desktop gap and panel");
+    const content = document.querySelector('[data-sidebar="desktop-content"]');
+    if (
+      !(gap instanceof HTMLElement) ||
+      !(panel instanceof HTMLElement) ||
+      !(content instanceof HTMLElement)
+    ) {
+      throw new Error("Expected desktop gap, panel, and content");
     }
     expect(gap.style.getPropertyValue("--sidebar-width")).toBe("333px");
     expect(panel.style.getPropertyValue("--sidebar-width")).toBe("333px");
+    expect(content.style.getPropertyValue("--sidebar-width")).toBe("333px");
     expect(wrapper.style.getPropertyValue("--sidebar-width")).toBe("");
+  });
+
+  it("keeps the boundary-centered resize target outside the motion clip", () => {
+    render(
+      <CompactViewportOverrideProvider isCompactViewport={false}>
+        <SidebarProvider>
+          <Sidebar>Sidebar content</Sidebar>
+        </SidebarProvider>
+      </CompactViewportOverrideProvider>,
+    );
+
+    const panel = document.querySelector('[data-sidebar="panel"]');
+    if (!(panel instanceof HTMLElement)) {
+      throw new Error("Expected the desktop sidebar panel");
+    }
+    expect(panel.classList).toContain("overflow-clip");
+    expect(panel.classList).toContain("[overflow-clip-margin:6px]");
+  });
+
+  it("uses the shared duration spring and reverses from its current width", () => {
+    render(
+      <CompactViewportOverrideProvider isCompactViewport={false}>
+        <SidebarProvider>
+          <Sidebar>Sidebar content</Sidebar>
+          <SidebarTrigger />
+        </SidebarProvider>
+      </CompactViewportOverrideProvider>,
+    );
+
+    const panel = document.querySelector('[data-sidebar="panel"]');
+    if (!(panel instanceof HTMLElement)) {
+      throw new Error("Expected the desktop sidebar panel");
+    }
+    const readProgress = () => {
+      if (panel.style.width === "0px") return 0;
+      if (panel.style.width === "var(--sidebar-width)") return 1;
+      const match = panel.style.width.match(/^calc\(([-\d.]+) \*/u);
+      if (!match) throw new Error(`Unexpected width: ${panel.style.width}`);
+      return Number(match[1]);
+    };
+
+    fireEvent.click(screen.getByRole("button", { name: "Toggle Sidebar" }));
+    const closingAnimation = motionAnimationState.calls[0];
+    expect(closingAnimation).toMatchObject({
+      target: 0,
+      options: { type: "spring", duration: 0.5, bounce: 0.1 },
+    });
+    act(() => closingAnimation?.value.set(0.32));
+    const closingProgress = readProgress();
+    expect(closingProgress).toBeCloseTo(0.32, 2);
+
+    fireEvent.click(screen.getByRole("button", { name: "Toggle Sidebar" }));
+    const openingAnimation = motionAnimationState.calls[1];
+    expect(openingAnimation?.value).toBe(closingAnimation?.value);
+    expect(openingAnimation?.target).toBe(1);
+    expect(readProgress()).toBeCloseTo(closingProgress, 4);
+    act(() => openingAnimation?.value.set(0.5));
+    expect(readProgress()).toBeGreaterThan(closingProgress);
+    act(() => openingAnimation?.value.set(1));
+    expect(readProgress()).toBe(1);
   });
 
   it("renders the desktop sidebar subtree synchronously", () => {

--- a/apps/app/src/components/ui/sidebar.tsx
+++ b/apps/app/src/components/ui/sidebar.tsx
@@ -816,11 +816,13 @@ const Sidebar = React.forwardRef<HTMLDivElement, React.ComponentProps<"div">>(
       );
     }
 
+    const isDesktopSidebarCollapsed = state === "collapsed";
+
     return (
       <div
         className="group peer text-sidebar-foreground"
         data-state={state}
-        data-collapsible={state === "collapsed" ? "offcanvas" : ""}
+        data-collapsible={isDesktopSidebarCollapsed ? "offcanvas" : ""}
         data-variant="sidebar"
         data-side="left"
       >
@@ -837,6 +839,8 @@ const Sidebar = React.forwardRef<HTMLDivElement, React.ComponentProps<"div">>(
         <div
           ref={composedDesktopPanelRef}
           data-sidebar="panel"
+          inert={isDesktopSidebarCollapsed}
+          aria-hidden={isDesktopSidebarCollapsed}
           className={cn(
             "fixed inset-y-0 left-0 z-10 flex h-(--bb-shell-height) select-none overflow-clip [overflow-clip-margin:6px] group-data-[collapsible=offcanvas]:pointer-events-none",
             "group-data-[collapsible=icon]:w-(--sidebar-width-icon)",

--- a/apps/app/src/components/ui/sidebar.tsx
+++ b/apps/app/src/components/ui/sidebar.tsx
@@ -1,8 +1,11 @@
 import * as React from "react";
 import { flushSync } from "react-dom";
+import { useComposedRefs } from "@radix-ui/react-compose-refs";
 import { Slot } from "@radix-ui/react-slot";
+import { animate, clamp, motionValue, type MotionValue } from "motion";
 
 import { useIsCompactViewport } from "@bb/shared-ui/hooks/use-compact-viewport";
+import { usePrefersReducedMotion } from "@bb/shared-ui/hooks/use-media-query";
 import { cn } from "@bb/shared-ui/lib/utils";
 import { Button } from "@bb/shared-ui/button";
 import { COARSE_POINTER_HEADER_ICON_BUTTON_CLASS } from "@bb/shared-ui/coarse-pointer-sizing";
@@ -14,6 +17,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@bb/shared-ui/tooltip";
+import { PANEL_SPRING_TRANSITION } from "@/lib/panel-motion";
 import { setCompactSidebarDrawerShowing } from "./sidebar-mobile-drawer-visibility.js";
 
 const SIDEBAR_WIDTH = "16rem";
@@ -42,6 +46,13 @@ const SIDEBAR_GROUP_LABEL_BASE_CLASS =
   "duration-200 flex shrink-0 items-center rounded-md px-1 text-xs font-medium text-sidebar-foreground/75 outline-none ring-sidebar-ring transition-[margin,opa] ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0";
 const SIDEBAR_GROUP_LABEL_COLLAPSED_CLASS =
   "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0";
+
+function sidebarDesktopWidth(progress: number): string {
+  const clampedProgress = clamp(0, 1, progress);
+  if (clampedProgress === 0) return "0px";
+  if (clampedProgress === 1) return "var(--sidebar-width)";
+  return `calc(${clampedProgress} * var(--sidebar-width))`;
+}
 
 type SidebarMobileWidthStyle = React.CSSProperties & {
   "--sidebar-width-mobile": string;
@@ -412,6 +423,8 @@ const SidebarContext = React.createContext<SidebarContext | null>(null);
 const SidebarWidthContext = React.createContext<string>(SIDEBAR_WIDTH);
 
 const SidebarShowingContext = React.createContext<boolean | null>(null);
+const SidebarDesktopMotionContext =
+  React.createContext<MotionValue<number> | null>(null);
 
 const SidebarContentElementContext =
   React.createContext<React.RefObject<HTMLDivElement | null> | null>(null);
@@ -443,6 +456,15 @@ function useOptionalIsSidebarShowing(): boolean | null {
   return React.useContext(SidebarShowingContext);
 }
 
+function useSidebarDesktopMotionProgress(): MotionValue<number> {
+  const progress = React.useContext(SidebarDesktopMotionContext);
+  if (progress === null) {
+    throw new Error(
+      "useSidebarDesktopMotionProgress must be used within a SidebarProvider.",
+    );
+  }
+  return progress;
+}
 function useCloseMobileSidebar() {
   const { closeMobileSidebar } = useSidebar();
   return closeMobileSidebar;
@@ -572,6 +594,14 @@ const SidebarProvider = React.forwardRef<
 
     const [_open, _setOpen] = React.useState(defaultOpen);
     const open = openProp ?? _open;
+    const shouldReduceMotion = usePrefersReducedMotion();
+    const desktopMotionProgressRef = React.useRef<MotionValue<number> | null>(
+      null,
+    );
+    if (desktopMotionProgressRef.current === null) {
+      desktopMotionProgressRef.current = motionValue(open ? 1 : 0);
+    }
+    const desktopMotionProgress = desktopMotionProgressRef.current;
     const setOpen = React.useCallback(
       (value: boolean | ((value: boolean) => boolean)) => {
         const openState = typeof value === "function" ? value(open) : value;
@@ -584,6 +614,15 @@ const SidebarProvider = React.forwardRef<
       [setOpenProp, open],
     );
 
+    React.useLayoutEffect(() => {
+      const target = open ? 1 : 0;
+      if (shouldReduceMotion) {
+        desktopMotionProgress.jump(target);
+      } else if (desktopMotionProgress.get() !== target) {
+        animate(desktopMotionProgress, target, PANEL_SPRING_TRANSITION);
+      }
+      return () => desktopMotionProgress.stop();
+    }, [desktopMotionProgress, open, shouldReduceMotion]);
     const toggleSidebar = React.useCallback(() => {
       if (!isCompactViewport) {
         setOpen((open) => !open);
@@ -646,27 +685,28 @@ const SidebarProvider = React.forwardRef<
     return (
       <SidebarContext.Provider value={contextValue}>
         <SidebarShowingContext.Provider value={isSidebarShowing}>
-          <SidebarWidthContext.Provider value={width}>
-            {}
-            <TooltipProvider delayDuration={300} disableHoverableContent>
-              <div
-                style={
-                  {
-                    "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
-                    ...style,
-                  } as React.CSSProperties
-                }
-                className={cn(
-                  "group/sidebar-wrapper flex h-full min-h-0 w-full has-[[data-variant=inset]]:bg-sidebar",
-                  className,
-                )}
-                ref={ref}
-                {...props}
-              >
-                {children}
-              </div>
-            </TooltipProvider>
-          </SidebarWidthContext.Provider>
+          <SidebarDesktopMotionContext.Provider value={desktopMotionProgress}>
+            <SidebarWidthContext.Provider value={width}>
+              <TooltipProvider delayDuration={300} disableHoverableContent>
+                <div
+                  style={
+                    {
+                      "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
+                      ...style,
+                    } as React.CSSProperties
+                  }
+                  className={cn(
+                    "group/sidebar-wrapper flex h-full min-h-0 w-full has-[[data-variant=inset]]:bg-sidebar",
+                    className,
+                  )}
+                  ref={ref}
+                  {...props}
+                >
+                  {children}
+                </div>
+              </TooltipProvider>
+            </SidebarWidthContext.Provider>
+          </SidebarDesktopMotionContext.Provider>
         </SidebarShowingContext.Provider>
       </SidebarContext.Provider>
     );
@@ -689,6 +729,30 @@ const Sidebar = React.forwardRef<HTMLDivElement, React.ComponentProps<"div">>(
       setSuppressMobileCloseAnimation,
     } = useSidebar();
     const width = React.useContext(SidebarWidthContext);
+    const desktopMotionProgress = useSidebarDesktopMotionProgress();
+    const desktopGapRef = React.useRef<HTMLDivElement>(null);
+    const desktopPanelRef = React.useRef<HTMLDivElement>(null);
+    const desktopContentRef = React.useRef<HTMLDivElement>(null);
+    const composedDesktopPanelRef = useComposedRefs(ref, desktopPanelRef);
+    const initialDesktopProgress = clamp(0, 1, desktopMotionProgress.get());
+    const desktopAnimatedWidth = sidebarDesktopWidth(initialDesktopProgress);
+    React.useLayoutEffect(() => {
+      const applyProgress = (progress: number) => {
+        const clampedProgress = clamp(0, 1, progress);
+        const animatedWidth = sidebarDesktopWidth(clampedProgress);
+        if (desktopGapRef.current) {
+          desktopGapRef.current.style.width = animatedWidth;
+        }
+        if (desktopPanelRef.current) {
+          desktopPanelRef.current.style.width = animatedWidth;
+        }
+        if (desktopContentRef.current) {
+          desktopContentRef.current.style.opacity = String(clampedProgress);
+        }
+      };
+      applyProgress(desktopMotionProgress.get());
+      return desktopMotionProgress.on("change", applyProgress);
+    }, [desktopMotionProgress, width]);
     const widthStyle = { "--sidebar-width": width } as React.CSSProperties;
     const handleOpenMobileChange = React.useCallback(
       (nextOpen: boolean) => {
@@ -754,41 +818,48 @@ const Sidebar = React.forwardRef<HTMLDivElement, React.ComponentProps<"div">>(
 
     return (
       <div
-        ref={ref}
         className="group peer text-sidebar-foreground"
         data-state={state}
         data-collapsible={state === "collapsed" ? "offcanvas" : ""}
         data-variant="sidebar"
         data-side="left"
       >
-        {}
         <div
+          ref={desktopGapRef}
           data-sidebar="gap"
-          style={widthStyle}
+          style={{ ...widthStyle, width: desktopAnimatedWidth }}
           className={cn(
-            "relative hidden h-full w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear md:block",
-            "group-data-[collapsible=offcanvas]:w-0",
+            "relative hidden h-full shrink-0 bg-transparent md:block",
             "group-data-[side=right]:rotate-180",
             "group-data-[collapsible=icon]:w-(--sidebar-width-icon)",
           )}
         />
         <div
+          ref={composedDesktopPanelRef}
           data-sidebar="panel"
           className={cn(
-            "fixed inset-y-0 z-10 flex h-(--bb-shell-height) w-(--sidebar-width) select-none flex-col bg-sidebar text-sidebar-foreground [transition:left_200ms_linear,right_200ms_linear,width_200ms_linear,visibility_0s_linear_0s]",
-            "group-data-[collapsible=offcanvas]:invisible group-data-[collapsible=offcanvas]:[transition:left_200ms_linear,right_200ms_linear,width_200ms_linear,visibility_0s_linear_200ms]",
-            "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]",
-            "group-data-[collapsible=icon]:w-(--sidebar-width-icon) border-border-seam group-data-[side=left]:border-r group-data-[side=right]:border-l",
-            className,
+            "fixed inset-y-0 left-0 z-10 flex h-(--bb-shell-height) select-none overflow-clip [overflow-clip-margin:6px] group-data-[collapsible=offcanvas]:pointer-events-none",
+            "group-data-[collapsible=icon]:w-(--sidebar-width-icon)",
           )}
-          style={{ ...widthStyle, ...style }}
+          style={{ ...widthStyle, ...style, width: desktopAnimatedWidth }}
           {...props}
         >
           <div
-            data-sidebar="sidebar"
-            className="flex h-full w-full flex-col bg-sidebar pt-[env(safe-area-inset-top)] pr-[env(safe-area-inset-right)] pb-[env(safe-area-inset-bottom)] pl-[env(safe-area-inset-left)] group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow"
+            ref={desktopContentRef}
+            data-sidebar="desktop-content"
+            className={cn(
+              "flex h-full min-w-(--sidebar-width) w-(--sidebar-width) flex-col bg-sidebar text-sidebar-foreground",
+              "border-border-seam group-data-[side=left]:border-r group-data-[side=right]:border-l",
+              className,
+            )}
+            style={{ ...widthStyle, opacity: initialDesktopProgress }}
           >
-            {children}
+            <div
+              data-sidebar="sidebar"
+              className="flex h-full w-full flex-col bg-sidebar pt-[env(safe-area-inset-top)] pr-[env(safe-area-inset-right)] pb-[env(safe-area-inset-bottom)] pl-[env(safe-area-inset-left)] group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow"
+            >
+              {children}
+            </div>
           </div>
         </div>
       </div>
@@ -2166,6 +2237,7 @@ export {
   SidebarStickyTier,
   SidebarTrigger,
   useCloseMobileSidebar,
+  useSidebarDesktopMotionProgress,
   useIsSidebarShowing,
   useOptionalIsSidebarShowing,
   useSidebar,

--- a/apps/app/src/components/ui/theme.css
+++ b/apps/app/src/components/ui/theme.css
@@ -1106,16 +1106,6 @@ body.sidebar-resizing [data-sidebar="panel"] {
 }
 
 /*
- * During an active panel-resize drag, suppress flex transitions on sibling
- * panels so their size snaps to each pointer position instead of animating
- * through 220ms of intermediate layouts per frame. Opacity/visibility
- * transitions are preserved for open/close animations.
- */
-[data-panel-group]:has([data-resize-handle-active]) [data-panel] {
-  transition-property: opacity;
-}
-
-/*
  * Bottom-anchored scroll bodies (see bottom-anchored-scroll-body.tsx). The
  * class goes on the content wrapper alone: scroll anchoring skips an excluded
  * element's whole subtree, so no descendant rule is needed. A `*` descendant

--- a/apps/app/src/components/ui/theme.css
+++ b/apps/app/src/components/ui/theme.css
@@ -927,8 +927,9 @@
  * every animation frame; an inherited custom property change makes the
  * engine restyle every descendant of the element it is set on (measured at
  * ~20-45 µs per element, so a long thread cost 50-400 ms per frame).
- * `Sidebar` therefore sets it directly on the two elements that read it (the
- * desktop gap and panel), and a change touches only those. The initial value
+ * `Sidebar` therefore sets it directly on the three elements that read it (the
+ * desktop gap, panel, and content), and a change touches only those. The
+ * initial value
  * mirrors the 16rem default in sidebar.tsx (`@property` requires an absolute
  * length here).
  */

--- a/apps/app/src/lib/panel-motion.ts
+++ b/apps/app/src/lib/panel-motion.ts
@@ -1,0 +1,19 @@
+import { spring, type ValueAnimationTransition } from "motion";
+
+export const PANEL_MOTION_DURATION_MS = 500;
+export const PANEL_SPRING_TRANSITION = {
+  type: "spring",
+  duration: PANEL_MOTION_DURATION_MS / 1000,
+  bounce: 0.1,
+} satisfies ValueAnimationTransition<number>;
+
+const panelSpringCss = String(
+  spring({
+    keyframes: [0, 1],
+    duration: PANEL_MOTION_DURATION_MS,
+    bounce: PANEL_SPRING_TRANSITION.bounce,
+  }),
+);
+export const PANEL_SPRING_CSS_EASING = panelSpringCss.slice(
+  panelSpringCss.indexOf(" ") + 1,
+);

--- a/apps/app/src/views/RootComposeSecondaryContent.test.tsx
+++ b/apps/app/src/views/RootComposeSecondaryContent.test.tsx
@@ -117,11 +117,13 @@ vi.mock("@/components/secondary-panel/ThreadSecondaryPanel", async () => {
 
   const ThreadSecondaryPanel = ({
     browserDeck,
+    inlinePanelToggle,
     isOpen,
     renderAsDrawer,
     showNewTabButton,
   }: {
     browserDeck?: ReactNode;
+    inlinePanelToggle?: "button" | "reserved" | "hidden";
     isOpen: boolean;
     renderAsDrawer: boolean;
     showNewTabButton?: boolean;
@@ -130,6 +132,7 @@ vi.mock("@/components/secondary-panel/ThreadSecondaryPanel", async () => {
       "section",
       {
         "data-open": String(isOpen),
+        "data-inline-panel-toggle": inlinePanelToggle,
         "data-show-new-tab-button": String(showNewTabButton),
         "data-testid": renderAsDrawer
           ? "drawer-secondary-panel"
@@ -280,7 +283,7 @@ describe("RootComposeSecondaryContent desktop layout", () => {
     ).toBeNull();
   });
 
-  it("carves the pinned toggle footprint out of the drag strip while the panel is closed", () => {
+  it("carves the fixed toggle footprint out of the drag strip while the panel is closed", () => {
     setMacosDesktopChrome();
 
     renderRootCompose({
@@ -300,7 +303,7 @@ describe("RootComposeSecondaryContent desktop layout", () => {
     }
   });
 
-  it("keeps the drag strip whole while the panel is open (the panel chrome carves instead)", () => {
+  it("keeps the drag strip whole while the panel is open", () => {
     setMacosDesktopChrome();
 
     renderRootCompose({
@@ -316,7 +319,20 @@ describe("RootComposeSecondaryContent desktop layout", () => {
     ).toBeNull();
   });
 
-  it("forwards root panel open and close state to the shared desktop layout", () => {
+  it("reserves the inline toolbar for the fixed toggle", () => {
+    renderRootCompose({
+      isCompactViewport: false,
+      isSecondaryPanelOpen: true,
+    });
+
+    expect(
+      screen
+        .getByTestId("inline-secondary-panel")
+        .getAttribute("data-inline-panel-toggle"),
+    ).toBe("reserved");
+  });
+
+  it("animates root panel open and close state through the shared desktop layout", () => {
     const view = renderRootCompose({
       isCompactViewport: false,
       isSecondaryPanelOpen: false,

--- a/apps/app/src/views/RootComposeSecondaryContent.tsx
+++ b/apps/app/src/views/RootComposeSecondaryContent.tsx
@@ -132,6 +132,7 @@ export function RootComposeSecondaryContent({
         renderPanel={({
           presentation,
           canShowNativeBrowserView,
+          inlinePanelToggle,
           onToggleMainCollapse,
           resizablePanelId,
         }) => (
@@ -150,6 +151,9 @@ export function RootComposeSecondaryContent({
             renderAsDrawer={presentation === "drawer"}
             isConversationCollapsed={false}
             onToggleConversationCollapse={onToggleMainCollapse}
+            inlinePanelToggle={
+              presentation === "inline" ? "reserved" : inlinePanelToggle
+            }
             showNewTabButton
             resizablePanelId={resizablePanelId}
           />

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -1726,8 +1726,7 @@ function RootComposeSurface({
     },
     [openWorkspaceFile],
   );
-  const showPinnedToggle =
-    (paneContext?.secondaryPanelHost ?? null) === null && !isSecondaryPanelOpen;
+  const showPinnedToggle = (paneContext?.secondaryPanelHost ?? null) === null;
   const rootPanelToggle = showPinnedToggle ? (
     <div
       className={`fixed z-40 ${ROOT_COMPOSE_PINNED_PANEL_TOGGLE_POSITION_CLASS}`}
@@ -1805,7 +1804,6 @@ function RootComposeSurface({
     }
     return (
       <div className="flex">
-        {}
         <div
           aria-label={`Forking ${forkSeed.sourceThreadTitle}`}
           className="-ml-1.5 inline-flex h-7 max-w-full items-center gap-1.5 rounded-full bg-muted py-0 pl-2.5 pr-1 text-xs font-medium text-muted-foreground"

--- a/apps/app/src/views/thread-detail/SplitThreadArea.test.tsx
+++ b/apps/app/src/views/thread-detail/SplitThreadArea.test.tsx
@@ -52,7 +52,21 @@ const threadStore = vi.hoisted(
     new Map<string, { archivedAt: number | null; deletedAt: number | null }>(),
 );
 const viewportState = vi.hoisted(() => ({ compact: false }));
-const sidebarState = vi.hoisted(() => ({ showing: true }));
+const sidebarState = vi.hoisted(() => {
+  const state = { showing: true };
+  return {
+    progress: {
+      get: () => (state.showing ? 1 : 0),
+      on: () => () => {},
+    },
+    set showing(showing: boolean) {
+      state.showing = showing;
+    },
+    get showing() {
+      return state.showing;
+    },
+  };
+});
 const panelFullScreenState = vi.hoisted(() => ({
   isMainCollapsed: false,
 }));
@@ -203,6 +217,7 @@ vi.mock("react-resizable-panels", async () => {
 });
 
 vi.mock("@/components/ui/sidebar.js", () => ({
+  useSidebarDesktopMotionProgress: () => sidebarState.progress,
   useIsSidebarShowing: () => sidebarState.showing,
 }));
 
@@ -235,13 +250,6 @@ vi.mock("@/components/plugin/PluginPanelRightPanelHost", () => ({
             <div data-testid="workspace-panel-resize-handle" className="z-[30]">
               <span data-panel-resize-hit-target="" />
             </div>
-            {isPanelOpen ? (
-              <button
-                type="button"
-                aria-label="Hide right panel"
-                onClick={() => setIsPanelOpen(false)}
-              />
-            ) : null}
           </div>
         ),
         onToggle: () => setIsPanelOpen((open) => !open),
@@ -1337,6 +1345,11 @@ describe("SplitThreadArea", () => {
       screen.getByTestId("workspace-panel-group").dataset.splitResizeGridRoot,
     ).toBe("");
     expect(
+      document
+        .querySelector('[data-panel-id="split-workspace-main-panel"]')
+        ?.contains(toggle),
+    ).toBe(false);
+    expect(
       screen.queryAllByTestId("split-workspace-panel-toggle"),
     ).toHaveLength(1);
     expect(screen.getByTestId("hosted-panel-thr-a")).toBeTruthy();
@@ -1344,13 +1357,10 @@ describe("SplitThreadArea", () => {
       "thr-a",
     );
     expect(screen.queryByTestId("hosted-panel-thr-b")).toBeNull();
-    expect(toggle.querySelector("button")?.getAttribute("aria-expanded")).toBe(
-      "true",
-    );
-    expect(toggle.classList).toContain("hidden");
-    expect(toggle.querySelector("button")?.hasAttribute("aria-pressed")).toBe(
-      false,
-    );
+    const toggleButton = toggle.querySelector("button");
+    expect(toggleButton?.getAttribute("aria-expanded")).toBe("true");
+    expect(toggle.classList).not.toContain("hidden");
+    expect(toggleButton?.hasAttribute("aria-pressed")).toBe(false);
 
     fireEvent.pointerDown(screen.getByTestId("pane-thr-b"));
     await screen.findByTestId("hosted-panel-thr-b");
@@ -1372,6 +1382,7 @@ describe("SplitThreadArea", () => {
         .querySelector("button")
         ?.getAttribute("aria-expanded"),
     ).toBe("false");
+    expect(toggle.querySelector("button")).toBe(toggleButton);
     expect(toggle.classList).not.toContain("hidden");
 
     fireEvent.pointerDown(screen.getByTestId("pane-thr-a"));
@@ -1513,10 +1524,7 @@ describe("SplitThreadArea", () => {
 
     await screen.findByTestId("hosted-plugin-app-panel");
     fireEvent.click(screen.getByRole("button", { name: "Show right panel" }));
-    await within(screen.getByTestId("hosted-plugin-app-panel")).findByRole(
-      "button",
-      { name: "Hide right panel" },
-    );
+    await screen.findByRole("button", { name: "Hide right panel" });
 
     fireEvent.pointerDown(screen.getByTestId("pane-thr-a"));
     expect(await screen.findByTestId("hosted-panel-thr-a")).toBeTruthy();
@@ -1528,7 +1536,7 @@ describe("SplitThreadArea", () => {
     ).toBeTruthy();
   });
 
-  it("drops the corner reserve while the hosted plugin panel holds the toggle", async () => {
+  it("keeps one pinned toggle while the hosted plugin panel opens", async () => {
     const layout = pluginSplitLayout();
     layout.focusedPaneId = "pane-2";
     renderSplitArea({
@@ -1549,13 +1557,16 @@ describe("SplitThreadArea", () => {
     );
     expect(
       screen.getByTestId("split-workspace-panel-toggle").classList,
-    ).toContain("hidden");
+    ).not.toContain("hidden");
     expect(
-      within(screen.getByTestId("hosted-plugin-app-panel")).getByRole(
+      screen.getAllByRole("button", { name: "Hide right panel" }),
+    ).toHaveLength(1);
+    expect(
+      within(screen.getByTestId("hosted-plugin-app-panel")).queryByRole(
         "button",
         { name: "Hide right panel" },
       ),
-    ).toBeTruthy();
+    ).toBeNull();
   });
 
   it("preserves plugin-owned right panels with and without a plugin split", async () => {
@@ -1888,10 +1899,14 @@ describe("SplitThreadArea", () => {
     const contentRow = async (path: string) =>
       (await screen.findByText(path))
         .closest("header")
-        ?.querySelector('[data-testid="app-page-header-content-row"]');
-    expect((await contentRow("top-left"))?.className).toContain("pl-[104px]");
+        ?.querySelector<HTMLElement>(
+          '[data-testid="app-page-header-content-row"]',
+        );
+    expect((await contentRow("top-left"))?.style.paddingInlineStart).toBe(
+      "104px",
+    );
     for (const path of ["top-right", "bottom-left", "bottom-right"]) {
-      expect((await contentRow(path))?.className).not.toContain("pl-[104px]");
+      expect((await contentRow(path))?.style.paddingInlineStart).toBe("");
     }
 
     expect(screen.getAllByRole("button", { name: /Full Screen/ })).toHaveLength(
@@ -2036,7 +2051,7 @@ describe("SplitThreadArea", () => {
     );
   });
 
-  it("drops the corner reserve once an open panel hosts the toggle", async () => {
+  it("drops the pane reserve while the fixed toggle overlays an open panel", async () => {
     const layout = pluginSplitLayout();
     layout.focusedPaneId = "pane-1";
     renderSplitArea({

--- a/apps/app/src/views/thread-detail/SplitThreadArea.tsx
+++ b/apps/app/src/views/thread-detail/SplitThreadArea.tsx
@@ -618,7 +618,6 @@ function SplitThreadAreaContent({ routeContent }: SplitThreadAreaProps) {
   return (
     <>
       {commandHandlers}
-      {}
       <div
         ref={preservedScrollWorkspaceRef}
         className="relative -m-4 flex min-h-0 min-w-0 flex-1 overflow-hidden md:-m-5"
@@ -750,7 +749,6 @@ function SplitTree(props: SplitTreeProps) {
         data-focused={isFocused ? "true" : "false"}
         data-maximized={isMaximized ? "true" : undefined}
       >
-        {}
         {node.content.kind === "thread" ? (
           <PaneStaleWatcher
             threadId={node.content.threadId}
@@ -778,7 +776,6 @@ function SplitTree(props: SplitTreeProps) {
           onNavigateInPane={props.onNavigateInPane}
           onBeginPaneDrag={props.onBeginPaneDrag}
         />
-        {}
         <div
           aria-hidden
           data-pane-focus-scrim=""
@@ -1037,7 +1034,8 @@ function NonThreadPaneContent({
     isFocused: true,
   };
   const hostLayout = useContext(SecondaryPanelHostLayoutContext);
-  const showsWindowPanelToggle = hostLayout?.pinsCornerToggle === true;
+  const reservesWindowPanelToggleSlot =
+    hostLayout?.pinsCornerToggle === true && hostLayout.isOpen === false;
   const [desktopInfo] = useState(getBbDesktopInfo);
   const usesDesktopChrome = shouldUseMacosDesktopChrome(desktopInfo);
   const panelEntry =
@@ -1099,7 +1097,7 @@ function NonThreadPaneContent({
           />
         </Button>
       ) : null}
-      {reservesWindowPanelToggle && showsWindowPanelToggle ? (
+      {reservesWindowPanelToggle && reservesWindowPanelToggleSlot ? (
         <span aria-hidden className={HEADER_ICON_BUTTON_CLASS} />
       ) : null}
     </>

--- a/apps/app/src/views/thread-detail/SplitWorkspaceSecondaryPanelHost.tsx
+++ b/apps/app/src/views/thread-detail/SplitWorkspaceSecondaryPanelHost.tsx
@@ -18,6 +18,7 @@ import { Button } from "@bb/shared-ui/button";
 import { EmptyStatePanel } from "@bb/shared-ui/empty-state";
 import { Icon } from "@bb/shared-ui/icon";
 import { cn } from "@bb/shared-ui/lib/utils";
+import { usePrefersReducedMotion } from "@bb/shared-ui/hooks/use-media-query";
 import { HEADER_ICON_BUTTON_CLASS } from "@/components/layout/AppPageHeader";
 import { AppCommandShortcutHint } from "@/components/commands/AppCommandShortcutHint";
 import {
@@ -36,7 +37,6 @@ import {
 import { useRightPanelToggleIconName } from "@/components/secondary-panel/panelToggleControlState";
 import {
   getPanelCollapseTransitionStyle,
-  PANEL_COLLAPSE_TRANSITION_CLASS,
   PANEL_RESIZE_HIT_AREA_MARGINS,
   PANEL_RESIZE_HANDLE_LAYER_CLASS,
   PANEL_RESIZE_HIT_TARGET_CLASS,
@@ -44,6 +44,10 @@ import {
 import { MACOS_APP_REGION_NO_DRAG_CLASS } from "@/lib/bb-desktop";
 import { PluginComposerHostProvider } from "@/components/plugin/plugin-composer-host";
 import { usePanelResizeSnap } from "@/components/secondary-panel/usePanelResizeSnap";
+import {
+  createSecondaryPanelGroupMotion,
+  type SecondaryPanelGroupMotion,
+} from "@/components/secondary-panel/secondaryPanelGroupMotion";
 import {
   type PaneSecondaryPanelRegistry,
   usePaneSecondaryPanelModel,
@@ -67,7 +71,13 @@ export function SplitWorkspaceSecondaryPanelHost({
 }: SplitWorkspaceSecondaryPanelHostProps) {
   const model = usePaneSecondaryPanelModel(registry, focusedPaneId);
   const panelGroupRef = useRef<ImperativePanelGroupHandle | null>(null);
+  const panelGroupMotionRef = useRef<SecondaryPanelGroupMotion | null>(null);
+  if (panelGroupMotionRef.current === null) {
+    panelGroupMotionRef.current = createSecondaryPanelGroupMotion();
+  }
+  const panelGroupMotion = panelGroupMotionRef.current;
   const panelWidthPercent = useAtomValue(secondaryPanelWidthPercentAtom);
+  const shouldReduceMotion = usePrefersReducedMotion();
   const shortcut = useAppCommandShortcut("panel.toggle");
 
   const [isPanelVisible, setIsPanelVisible] = useState<boolean | null>(null);
@@ -106,33 +116,61 @@ export function SplitWorkspaceSecondaryPanelHost({
     if (model.isOpen !== isPanelVisible) model.onToggle();
   }, [focusedPaneId, isPanelVisible, model]);
 
-  useEffect(() => {
-    const group = panelGroupRef.current;
-    if (group === null) return;
-    if (group.getLayout().length !== 2) return;
-    if (isPaneMaximized) {
-      group.setLayout([MAIN_PANEL_OPEN_SIZE_PERCENT, 0]);
-      return;
-    }
-    if (!isOpen) {
-      group.setLayout([MAIN_PANEL_OPEN_SIZE_PERCENT, 0]);
-      return;
-    }
-    if (model?.isMainCollapsed) {
-      group.setLayout([0, MAIN_PANEL_OPEN_SIZE_PERCENT]);
-      return;
-    }
-    group.setLayout([
-      MAIN_PANEL_OPEN_SIZE_PERCENT - panelWidthPercent,
-      panelWidthPercent,
-    ]);
+  const panelLayoutTargetRef = useRef({
+    isMainCollapsed: model?.isMainCollapsed === true,
+    isOpen,
+    isPaneMaximized,
+    panelWidthPercent,
+  });
+  panelLayoutTargetRef.current = {
+    isMainCollapsed: model?.isMainCollapsed === true,
+    isOpen,
+    isPaneMaximized,
+    panelWidthPercent,
+  };
+  const applyPanelLayout = useCallback(
+    (reduceMotion: boolean) => {
+      const group = panelGroupRef.current;
+      if (group === null) return;
+      if (group.getLayout().length !== 2) return;
+
+      const target = panelLayoutTargetRef.current;
+      const secondaryWidth =
+        target.isPaneMaximized || !target.isOpen
+          ? 0
+          : target.isMainCollapsed
+            ? MAIN_PANEL_OPEN_SIZE_PERCENT
+            : target.panelWidthPercent;
+      panelGroupMotion.setLayout(
+        group,
+        [MAIN_PANEL_OPEN_SIZE_PERCENT - secondaryWidth, secondaryWidth],
+        reduceMotion,
+      );
+    },
+    [panelGroupMotion],
+  );
+
+  useLayoutEffect(() => {
+    applyPanelLayout(shouldReduceMotion || model?.transitionsReady === false);
   }, [
-    focusedPaneId,
+    applyPanelLayout,
     isOpen,
     isPaneMaximized,
     model?.isMainCollapsed,
-    panelWidthPercent,
+    model?.transitionsReady,
+    shouldReduceMotion,
   ]);
+
+  useEffect(() => {
+    applyPanelLayout(true);
+  }, [applyPanelLayout, focusedPaneId, model?.contentKey]);
+
+  useLayoutEffect(
+    () => () => {
+      panelGroupMotion.stop();
+    },
+    [panelGroupMotion],
+  );
 
   const toggleWindowPanel = () => {
     if (model !== null) {
@@ -182,8 +220,8 @@ export function SplitWorkspaceSecondaryPanelHost({
 
   const toggleLabel = isOpen ? "Hide right panel" : "Show right panel";
   const toggleIconName = useRightPanelToggleIconName();
-  const showsCornerToggle = !isPaneMaximized && !(isOpen && model !== null);
-  const pinsCornerToggle = showsCornerToggle && !isOpen;
+  const showsCornerToggle = !isPaneMaximized;
+  const pinsCornerToggle = showsCornerToggle;
   const hostLayout = useMemo<SecondaryPanelHostLayout>(
     () => ({ isOpen, isSuppressed: isPaneMaximized, pinsCornerToggle }),
     [isOpen, isPaneMaximized, pinsCornerToggle],
@@ -233,32 +271,20 @@ export function SplitWorkspaceSecondaryPanelHost({
             id="split-workspace-main-panel"
             collapsible
             collapsedSize={0}
-            defaultSize={
-              isPaneMaximized
-                ? MAIN_PANEL_OPEN_SIZE_PERCENT
-                : model?.isMainCollapsed
-                  ? 0
-                  : isOpen
-                    ? MAIN_PANEL_OPEN_SIZE_PERCENT - panelWidthPercent
-                    : MAIN_PANEL_OPEN_SIZE_PERCENT
-            }
+            defaultSize={MAIN_PANEL_OPEN_SIZE_PERCENT}
             minSize={MAIN_PANEL_MIN_SIZE_PERCENT}
             order={1}
-            className={cn(
-              "min-w-0 overflow-clip transition-[flex-grow,flex-basis]",
-              PANEL_COLLAPSE_TRANSITION_CLASS,
-            )}
+            className="min-w-0 overflow-clip"
           >
-            {}
             <div className="relative flex h-full min-h-0 min-w-0">
               {children}
             </div>
           </Panel>
           {model === null ? (
             <>
-              {}
               <PanelResizeHandle
                 id="split-workspace-empty-secondary-panel-handle"
+                data-secondary-panel-boundary=""
                 disabled={!isOpen}
                 onDragging={handleEmptyPanelDragging}
                 onPointerDownCapture={(event) =>
@@ -267,9 +293,8 @@ export function SplitWorkspaceSecondaryPanelHost({
                 data-panel-resize-snap-handle=""
                 hitAreaMargins={PANEL_RESIZE_HIT_AREA_MARGINS}
                 className={cn(
-                  "relative shrink-0 overflow-visible bg-border-seam transition-[width,opacity,background-color] hover:bg-ring/40 data-[resize-handle-state=drag]:bg-ring/40",
+                  "relative shrink-0 overflow-visible bg-border-seam transition-colors hover:bg-ring/40 data-[resize-handle-state=drag]:bg-ring/40",
                   PANEL_RESIZE_HANDLE_LAYER_CLASS,
-                  PANEL_COLLAPSE_TRANSITION_CLASS,
                   isOpen
                     ? "w-px cursor-col-resize opacity-100"
                     : "pointer-events-none w-0 opacity-0",
@@ -286,16 +311,13 @@ export function SplitWorkspaceSecondaryPanelHost({
                 id="split-workspace-empty-secondary-panel"
                 collapsible
                 collapsedSize={0}
-                defaultSize={isOpen ? panelWidthPercent : 0}
+                defaultSize={0}
                 minSize={THREAD_SECONDARY_PANEL_MIN_SIZE_PERCENT}
                 maxSize={THREAD_SECONDARY_PANEL_MAX_SIZE_PERCENT}
                 onCollapse={handleEmptyPanelCollapse}
                 onResize={handleEmptyPanelResize}
                 order={2}
-                className={cn(
-                  "min-w-0 overflow-clip transition-[flex-grow,flex-basis]",
-                  PANEL_COLLAPSE_TRANSITION_CLASS,
-                )}
+                className="min-w-0 overflow-clip"
               >
                 <div
                   data-testid="split-workspace-empty-panel-state"

--- a/apps/app/src/views/thread-detail/ThreadDetailHeader.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailHeader.test.tsx
@@ -78,7 +78,30 @@ afterEach(() => {
 });
 
 describe("ThreadDetailHeader", () => {
-  it("leaves the open right-panel collapse control to the panel header", () => {
+  it("keeps the desktop right-panel toggle fixed while open", () => {
+    render(
+      <PaneContext.Provider value={PANE_CONTEXT}>
+        <ThreadDetailHeader
+          actionsMenu={null}
+          childPillLabel={null}
+          isSecondaryPanelOpen
+          onOpenThreadGitAction={vi.fn()}
+          onToggleSecondaryPanel={vi.fn()}
+          threadHeaderGitActions={[]}
+          threadId={THREAD_ID}
+          threadTitle="Panel state"
+        />
+      </PaneContext.Provider>,
+    );
+
+    const button = screen.getByRole("button", { name: "Hide right panel" });
+    expect(button.getAttribute("aria-expanded")).toBe("true");
+    expect(button.parentElement?.classList).toContain("fixed");
+  });
+
+  it("leaves the open compact-panel collapse control to the drawer", () => {
+    viewportState.isCompactViewport = true;
+
     render(
       <PaneContext.Provider value={PANE_CONTEXT}>
         <ThreadDetailHeader

--- a/apps/app/src/views/thread-detail/ThreadDetailHeader.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailHeader.tsx
@@ -149,7 +149,7 @@ export function ThreadDetailHeader({
     : "Show right panel";
   const rightPanelIconName = getRightPanelToggleIconName(renderAsDrawer);
   const showRightPanelToggle =
-    secondaryPanelHost === null && !isSecondaryPanelOpen;
+    secondaryPanelHost === null && (!renderAsDrawer || !isSecondaryPanelOpen);
 
   const center = (
     <>
@@ -189,7 +189,6 @@ export function ThreadDetailHeader({
           {childPillLabel}
         </Pill>
       ) : null}
-      {}
       {actionsMenu == null ? null : (
         <span
           data-testid="thread-detail-header-actions-menu"
@@ -249,7 +248,16 @@ export function ThreadDetailHeader({
         data-thread-header-pane-actions=""
       >
         {showRightPanelToggle ? (
-          <span className="inline-flex items-center gap-1.5">
+          <span
+            className={cn(
+              "inline-flex items-center gap-1.5",
+              !renderAsDrawer &&
+                "fixed right-[calc(1rem+env(safe-area-inset-right))] top-[calc(0.625rem+env(safe-area-inset-top))] z-40",
+              !renderAsDrawer &&
+                usesDesktopChrome &&
+                MACOS_WINDOW_NO_DRAG_CLASS,
+            )}
+          >
             <AppCommandShortcutHint shortcut={panelShortcut} />
             <Button
               type="button"

--- a/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.test.tsx
@@ -367,7 +367,7 @@ afterEach(() => {
 });
 
 describe("ThreadDetailSecondaryContent", () => {
-  it("keeps the standalone panel hide control in the panel toolbar", async () => {
+  it("reserves the standalone panel toolbar for the fixed toggle", async () => {
     renderThreadDetail(false);
 
     expect(
@@ -378,10 +378,10 @@ describe("ThreadDetailSecondaryContent", () => {
           { timeout: 5_000 },
         )
       ).getAttribute("data-inline-panel-toggle"),
-    ).toBe("button");
+    ).toBe("reserved");
   });
 
-  it("places the hosted panel hide control at the outer edge of its toolbar", async () => {
+  it("reserves the hosted panel toolbar for the fixed window toggle", async () => {
     renderThreadDetail(true, false, true);
 
     expect(screen.getByTestId("header").closest("[inert]")).toBeNull();
@@ -400,7 +400,7 @@ describe("ThreadDetailSecondaryContent", () => {
       (await screen.findByTestId("inline-secondary-panel")).getAttribute(
         "data-inline-panel-toggle",
       ),
-    ).toBe("button");
+    ).toBe("reserved");
   });
 
   it("keeps the thread header inside the timeline column beside the panel", async () => {

--- a/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.tsx
@@ -134,6 +134,7 @@ function ThreadDetailSecondaryContentBody({
         renderPanel={({
           presentation,
           canShowNativeBrowserView,
+          inlinePanelToggle,
           isMainCollapsed,
           onToggleMainCollapse,
           resizablePanelId,
@@ -155,9 +156,9 @@ function ThreadDetailSecondaryContentBody({
               presentation === "inline" && isMainCollapsed
             }
             onToggleConversationCollapse={onToggleMainCollapse}
-            {...(presentation === "inline"
-              ? { inlinePanelToggle: "button" as const }
-              : {})}
+            inlinePanelToggle={
+              presentation === "inline" ? "reserved" : inlinePanelToggle
+            }
             resizablePanelId={resizablePanelId}
             metadataContent={metadataContent}
           />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -290,6 +290,9 @@ importers:
       mermaid:
         specifier: ^11.15.0
         version: 11.15.0
+      motion:
+        specifier: ^13.1.0
+        version: 13.1.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       nanoid:
         specifier: ^5.1.6
         version: 5.1.6
@@ -11280,6 +11283,17 @@ packages:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
 
+  framer-motion@13.1.1:
+    resolution: {integrity: sha512-B/xn2TPS4f61cEBLFjiYlQFnBZUW1YVj/LM+C+N4OP8Rs95VLEI2ot/RlfBg111la/EiyECFaJJi/A3FWA8MUA==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
@@ -12861,6 +12875,22 @@ packages:
   monaco-editor@0.56.0:
     resolution: {integrity: sha512-sXboRm3BeBeLm938eaiyLMe0OxzfXIlZvbv4ir/jVgQy1zDhWjgmny0WoN45fuDKhCCQsYMbBJrv/A6jd8aCUg==}
 
+  motion-dom@13.1.1:
+    resolution: {integrity: sha512-XSf8VYWSB6G/0IY3rWVbyLcxWXtAVHkN1PQE2agTaCv3u8RGvbwu56TyyR/MNzBqqNavEBTZzErcxI1TxBrjcA==}
+
+  motion-utils@13.0.0:
+    resolution: {integrity: sha512-7DnN7TmbLcYXcG4RVadXIihWlyuM9afoUww8Y5Agg431kGKiuL2/OMyP4mJ5wLz+pvN3t5ySClLOaVXJ+wekRQ==}
+
+  motion@13.1.1:
+    resolution: {integrity: sha512-WNZoK6xiF+kkTqkZ5K7FDDh6A8BG4i5Hc7KXtW8gtTxkpJFds+hIOrDaQGKjQj/AE/i4hJqAaUHEqp/Qo02y6Q==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
@@ -23784,6 +23814,15 @@ snapshots:
 
   forwarded@0.2.0: {}
 
+  framer-motion@13.1.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      motion-dom: 13.1.1
+      motion-utils: 13.0.0
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   fresh@0.5.2: {}
 
   fresh@2.0.0: {}
@@ -25984,7 +26023,19 @@ snapshots:
     dependencies:
       dompurify: 3.4.8
       marked: 14.0.0
+  motion-dom@13.1.1:
+    dependencies:
+      motion-utils: 13.0.0
 
+  motion-utils@13.0.0: {}
+
+  motion@13.1.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      framer-motion: 13.1.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
   ms@2.0.0: {}
 
   ms@2.1.3: {}


### PR DESCRIPTION
## Human comments

### Before

Hard to see, but notice that the right sidebar toggle icon jumps from it's location in the right sidebar to the header. Also notice that the left/right sidebar motion is noticeably different.

https://github.com/user-attachments/assets/4e060e4f-d245-44a8-9105-61917e367835

### After

A more springy dynamic motion for both sidebar. Sidebar toggle icon doesn't teleport.

https://github.com/user-attachments/assets/5559a674-019f-4886-9d54-949a09c05abf

## Why this change

The left and right sidebars are paired parts of the app shell, but their transitions did not share the same motion. The mismatch made the layout feel disconnected.

Opening a thread also changed the right-side layout while its toggle moved with the panel. The control jumped during the transition, which made the interface feel unstable and moved the click target away from the user.

This PR gives both sidebars one dynamic motion language and keeps the right toggle stationary while the surrounding layout changes.

## What was wrong

The left and right sidebars used separate transition behavior. The right toggle also participated in the moving layout when a thread opened, so its screen position shifted during the transition.

## What changed

- Give both sidebars the same spring profile and transition behavior.
- Keep the right sidebar toggle in a fixed position while a thread opens and the panel moves.
- Retarget interrupted transitions from the current rendered layout so repeated clicks remain smooth.

## Why this approach

One motion owner coordinates the right panel and its layout boundary. The panel can move without carrying the toggle with it, and repeated clicks retarget the current motion instead of starting competing transitions.

The scope stays inside the app sidebar and secondary-panel components. There are no server, protocol, route, SDK, CLI, guide, or data changes.

## Review fixes

SlopCop found four problems. This PR fixes three of them. The `motion` dependency size is a separate decision.

### The closed sidebar stayed in the keyboard order

The old panel used `visibility: hidden` when it collapsed, which takes its descendants out of the focus order. The motion rewrite replaced that with a zero width and an opacity fade. Neither removes an element from the focus order, so Chrome could still move focus into the closed panel. The collapsed panel is now `inert` and `aria-hidden`.

### The panel animation forced a layout on every frame

`renderPanelGroup` wrote both flex values and then read the group geometry. That read after a write forces a synchronous layout each frame. The group width does not change while the panels resize inside it, so the code now measures the group one time for each layout, before the writes.

### The full-screen panel could show a seam

At the 100-percent layout the boundary is disabled and carries an `opacity-0` class, but the inline `opacity: 1` won. The handle's inner 1-pixel span painted a line down the left edge of the full-screen panel. The boundary now stays hidden at the 0 and 100-percent layouts.

### Removed a dead CSS rule

`theme.css` suppressed flex transitions on panels during a drag. This PR removed the last `transition-[flex-grow,flex-basis]` on a `[data-panel]`, so that `:has()` rule now costs style recalculation and changes nothing.

## How you verified the review fixes

- The three new tests fail on the code before the fixes and pass after them.
- The app suite passed 3,502 tests. Lint reported 0 errors.
- Chrome QA on the dev app: Tab reached 12 sidebar controls when the sidebar was open and 0 when it was closed.
- The full-screen panel showed no seam. Inline and computed opacity were both `0`.
- A divider drag still tracked the pointer exactly, so the removed CSS rule was dead.
- Close from a resized width returned to the same width. The browser reported no errors.

## Bug fixed while developing this PR

The first version of this PR could flicker when a resized right sidebar closed. We fixed that path so it closes from its current rendered width. This is a correction to this PR's implementation, not the feature's primary goal.

## How you verified

- `pnpm exec turbo run typecheck --filter=@bb/app` passed.
- All 8 affected test files passed: 125 tests.
- The full app suite passed 3,499 tests and skipped 3. One unrelated test failed because `plugins/t3sidebar/package.json` is missing from this workspace.
- The live app used matching motion for the left and right sidebars.
- The right toggle stayed in place while a thread opened and during repeated clicks.
- The resized close path no longer flickered, and the resize handle remained on the panel edge.
- The browser reported no runtime errors.

> AGENT GENERATED

