### PR TITLE
Correlate codex turn dispatches with the turn the turn/start response names

### DIFF
--- a/packages/host-daemon-contract/src/protocol.ts
+++ b/packages/host-daemon-contract/src/protocol.ts
@@ -1,3 +1,3 @@
-export const HOST_DAEMON_PROTOCOL_VERSION = 173 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 174 as const;
 
 export const HOST_ARTIFACT_MAX_BYTES = 256 * 1024 * 1024;

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -943,7 +943,7 @@ const ACP_BRIDGE_LAUNCH = {
 
 describe("host-daemon command schemas", () => {
   it("uses the current host-daemon protocol version", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(173);
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(174);
     expect(HOST_ARTIFACT_MAX_BYTES).toBe(256 * 1024 * 1024);
   });
 

--- a/plugins/provider-codex/src/bridge/bridge.ts
+++ b/plugins/provider-codex/src/bridge/bridge.ts
@@ -59,6 +59,7 @@ import {
 } from "../interactive-requests.js";
 import { parseModelsResponse } from "../models.js";
 import { macOsPermissionPresentation } from "../presentation.js";
+import { codexTurnSchema } from "../schemas.js";
 import {
   resolveCodexInstructionOverrides,
   toCodexDynamicTools,
@@ -1292,6 +1293,40 @@ async function requireLiveSessionForTurn(
   return { session, connection: session.connection };
 }
 
+const codexTurnStartResultSchema = z
+  .object({ turn: codexTurnSchema })
+  .passthrough();
+
+function settleAcceptedDispatch(args: {
+  clientRequestId: TurnStartParamsShape["clientRequestId"];
+  prepared: PreparedProviderCommandDispatch | null;
+  session: CodexBridgeSession;
+  result: unknown;
+}): void {
+  const { clientRequestId, prepared, session, result } = args;
+  const parsed = codexTurnStartResultSchema.safeParse(result);
+  if (!parsed.success) {
+    scheduleZeroWorkTurnSettlement({ clientRequestId, prepared, session });
+    return;
+  }
+  if (prepared === null) {
+    return;
+  }
+  const live = currentSession(session.bbThreadId, session.serial);
+  if (!live || live.codexThreadId === null) {
+    return;
+  }
+  sendThreadDeltas(
+    live,
+    live.translator.openTurnFromStartResponse({
+      providerThreadId: live.codexThreadId,
+      turn: parsed.data.turn,
+      clientRequestId,
+      turnAlreadyOpen: live.openCodexTurnIds.has(parsed.data.turn.id),
+    }),
+  );
+}
+
 const ZERO_WORK_SETTLEMENT_GRACE_MS = 250;
 
 let syntheticZeroWorkTurnCounter = 0;
@@ -1356,8 +1391,9 @@ async function handleTurnStart(
   });
 
   try {
+    let result: unknown;
     if (isStandaloneBuiltinCompactCommand(input)) {
-      await connection.request({
+      result = await connection.request({
         method: "thread/compact/start",
         params: { threadId: codexThreadId },
         resultSchema: ignoredChildResultSchema,
@@ -1371,7 +1407,7 @@ async function handleTurnStart(
         ),
         options: decoded.sessionOptions,
       });
-      await connection.request({
+      result = await connection.request({
         method: "turn/start",
         params: {
           threadId: codexThreadId,
@@ -1387,10 +1423,11 @@ async function handleTurnStart(
       });
     }
     sendResult(id, { threadId: params.threadId });
-    scheduleZeroWorkTurnSettlement({
+    settleAcceptedDispatch({
       clientRequestId: params.clientRequestId,
       prepared,
       session,
+      result,
     });
   } catch (error) {
     prepared?.rollback();

--- a/plugins/provider-codex/src/bridge/bridge.zero-work-turn.test.ts
+++ b/plugins/provider-codex/src/bridge/bridge.zero-work-turn.test.ts
@@ -158,7 +158,7 @@ it("preserves the native checkpoint when thread/stop interrupts a turn", async (
   );
 }, 30_000);
 
-it("lets a turn/started that lands after the turn/start response win the race", async () => {
+it("keeps one lifecycle when turn/started lags the turn/start response past the grace window", async () => {
   const providerThreadId = await startSession();
   harness.sendRequest(2, "turn/start", {
     threadId: THREAD_ID,
@@ -175,17 +175,209 @@ it("lets a turn/started that lands after the turn/start response win the race", 
   await new Promise((resolve) => setTimeout(resolve, 500));
   const settledEvents = threadEvents();
 
-  expect(
-    settledEvents.filter((event) => event.type === "turn/started"),
-  ).toHaveLength(1);
-  expect(
-    settledEvents.filter((event) => event.type === "turn/completed"),
-  ).toHaveLength(1);
+  const started = settledEvents.filter(
+    (event) => event.type === "turn/started",
+  );
+  const completed = settledEvents.filter(
+    (event) => event.type === "turn/completed",
+  );
+  expect(started).toHaveLength(1);
+  expect(completed).toHaveLength(1);
+  const turnId =
+    started[0]?.scope.kind === "turn" ? started[0].scope.turnId : "";
+  expect(turnId).not.toBe("");
+  expect(completed[0]).toMatchObject({
+    status: "completed",
+    providerCheckpointId: "turn-fx-1",
+    scope: { kind: "turn", turnId },
+  });
   expect(
     settledEvents.some((event) => event.type === "item/agentMessage/delta"),
   ).toBe(true);
   expect(
     settledEvents.filter((event) => event.type === "turn/input/accepted"),
-  ).toHaveLength(1);
+  ).toEqual([
+    expect.objectContaining({
+      clientRequestId: "creq_atestart23",
+      scope: { kind: "turn", turnId },
+    }),
+  ]);
   expect(events.length).toBeGreaterThan(0);
+}, 30_000);
+
+it("settles a response-proved turn as failed when codex dies before turn/started", async () => {
+  const providerThreadId = await startSession();
+  harness.sendRequest(2, "turn/start", {
+    threadId: THREAD_ID,
+    providerThreadId,
+    input: [{ type: "text", text: "/respond-then-exit", mentions: [] }],
+    clientRequestId: "creq_dies234567",
+    options: { ...sessionOptions },
+  });
+  await harness.waitForResponse(2);
+
+  const events = await waitForEvents((all) =>
+    all.some((event) => event.type === "turn/completed"),
+  );
+  const started = events.filter((event) => event.type === "turn/started");
+  const completed = events.filter((event) => event.type === "turn/completed");
+  expect(started).toHaveLength(1);
+  expect(completed).toHaveLength(1);
+  const turnId =
+    started[0]?.scope.kind === "turn" ? started[0].scope.turnId : "";
+  expect(turnId).not.toBe("");
+  expect(completed[0]).toMatchObject({
+    status: "failed",
+    scope: { kind: "turn", turnId },
+  });
+  expect(
+    events.filter((event) => event.type === "turn/input/accepted"),
+  ).toEqual([
+    expect.objectContaining({
+      clientRequestId: "creq_dies234567",
+      scope: { kind: "turn", turnId },
+    }),
+  ]);
+}, 30_000);
+
+it("settles a turn the turn/start response reports as already completed", async () => {
+  const providerThreadId = await startSession();
+  harness.sendRequest(2, "turn/start", {
+    threadId: THREAD_ID,
+    providerThreadId,
+    input: [{ type: "text", text: "/respond-completed", mentions: [] }],
+    clientRequestId: "creq_instdn2345",
+    options: { ...sessionOptions },
+  });
+  await harness.waitForResponse(2);
+
+  const events = await waitForEvents((all) =>
+    all.some((event) => event.type === "turn/completed"),
+  );
+  const started = events.filter((event) => event.type === "turn/started");
+  const completed = events.filter((event) => event.type === "turn/completed");
+  expect(started).toHaveLength(1);
+  expect(completed).toHaveLength(1);
+  const turnId =
+    started[0]?.scope.kind === "turn" ? started[0].scope.turnId : "";
+  expect(turnId).not.toBe("");
+  expect(completed[0]).toMatchObject({
+    status: "completed",
+    providerCheckpointId: "turn-fx-1",
+    scope: { kind: "turn", turnId },
+  });
+  expect(
+    events.filter((event) => event.type === "turn/input/accepted"),
+  ).toEqual([
+    expect.objectContaining({
+      clientRequestId: "creq_instdn2345",
+      scope: { kind: "turn", turnId },
+    }),
+  ]);
+}, 30_000);
+
+it("acknowledges a dispatch codex steers into the already-running turn", async () => {
+  const providerThreadId = await startSession();
+  harness.sendRequest(2, "turn/start", {
+    threadId: THREAD_ID,
+    providerThreadId,
+    input: [{ type: "text", text: "/wait-for-interrupt", mentions: [] }],
+    clientRequestId: "creq_first23456",
+    options: { ...sessionOptions },
+  });
+  await harness.waitForResponse(2);
+  await waitForEvents((events) =>
+    events.some((event) => event.type === "turn/started"),
+  );
+
+  harness.sendRequest(3, "turn/start", {
+    threadId: THREAD_ID,
+    providerThreadId,
+    input: [{ type: "text", text: "/steer-into-active", mentions: [] }],
+    clientRequestId: "creq_steer23456",
+    options: { ...sessionOptions },
+  });
+  await harness.waitForResponse(3);
+  const events = await waitForEvents(
+    (all) =>
+      all.filter((event) => event.type === "turn/input/accepted").length === 2,
+  );
+
+  const started = events.filter((event) => event.type === "turn/started");
+  expect(started).toHaveLength(1);
+  const turnId =
+    started[0]?.scope.kind === "turn" ? started[0].scope.turnId : "";
+  expect(turnId).not.toBe("");
+  expect(
+    events.filter((event) => event.type === "turn/input/accepted"),
+  ).toEqual([
+    expect.objectContaining({
+      clientRequestId: "creq_first23456",
+      scope: { kind: "turn", turnId },
+    }),
+    expect.objectContaining({
+      clientRequestId: "creq_steer23456",
+      scope: { kind: "turn", turnId },
+    }),
+  ]);
+  expect(events.filter((event) => event.type === "turn/completed")).toEqual([]);
+
+  harness.sendRequest(4, "thread/stop", {
+    threadId: THREAD_ID,
+    providerThreadId,
+    intent: "interrupt",
+    activeTurnId: "turn-fx-1",
+  });
+  await harness.waitForResponse(4);
+  await waitForEvents((all) =>
+    all.some(
+      (event) =>
+        event.type === "turn/completed" && event.status === "interrupted",
+    ),
+  );
+}, 30_000);
+
+it("does not resurrect a response-opened turn settled before its turn/started arrives", async () => {
+  const providerThreadId = await startSession();
+  harness.sendRequest(2, "turn/start", {
+    threadId: THREAD_ID,
+    providerThreadId,
+    input: [{ type: "text", text: "/interrupt-before-start", mentions: [] }],
+    clientRequestId: "creq_prestart23",
+    options: { ...sessionOptions },
+  });
+  await harness.waitForResponse(2);
+  await waitForEvents((events) =>
+    events.some((event) => event.type === "turn/started"),
+  );
+
+  harness.sendRequest(3, "thread/stop", {
+    threadId: THREAD_ID,
+    providerThreadId,
+    intent: "interrupt",
+    activeTurnId: "turn-fx-1",
+  });
+  await harness.waitForResponse(3);
+  await new Promise((resolve) => setTimeout(resolve, 200));
+
+  const events = threadEvents();
+  const started = events.filter((event) => event.type === "turn/started");
+  expect(started).toHaveLength(1);
+  const turnId =
+    started[0]?.scope.kind === "turn" ? started[0].scope.turnId : "";
+  expect(turnId).not.toBe("");
+  const completed = events.filter((event) => event.type === "turn/completed");
+  expect(completed).toHaveLength(1);
+  expect(completed[0]).toMatchObject({
+    status: "interrupted",
+    scope: { kind: "turn", turnId },
+  });
+  expect(
+    events.filter((event) => event.type === "turn/input/accepted"),
+  ).toEqual([
+    expect.objectContaining({
+      clientRequestId: "creq_prestart23",
+      scope: { kind: "turn", turnId },
+    }),
+  ]);
 }, 30_000);

--- a/plugins/provider-codex/src/bridge/fake-codex-app-server.mjs
+++ b/plugins/provider-codex/src/bridge/fake-codex-app-server.mjs
@@ -36,6 +36,7 @@ import { createInterface } from "node:readline";
 let threadCounter = 0;
 let turnCounter = 0;
 const openTurnIdsByThreadId = new Map();
+const pendingStartTurnIdsByThreadId = new Map();
 const processInstanceId = `${process.pid}-${Date.now()}-${Math.random()}`;
 
 function send(message) {
@@ -57,15 +58,16 @@ function respondError(id, code, message) {
 /** The prompt the kit's turn/settles-without-activity scenario sends. */
 const ZERO_WORK_PROMPT_TEXT = "/clear";
 
-/**
- * A prompt answered BEFORE any turn notification, whose real turn then arrives
- * late. Codex normally emits `turn/started` ahead of its `turn/start`
- * response; this inverts that order so the bridge's zero-work settlement has
- * to lose the race to the real turn (fabricating a turn from a late signal is
- * the ACP bug 0c2f4cc9a).
- */
 const LATE_TURN_START_PROMPT_TEXT = "/late-start";
-const LATE_TURN_START_DELAY_MS = 60;
+const LATE_TURN_START_DELAY_MS = 350;
+
+const RESPOND_THEN_EXIT_PROMPT_TEXT = "/respond-then-exit";
+
+const RESPOND_COMPLETED_PROMPT_TEXT = "/respond-completed";
+
+const STEER_INTO_ACTIVE_PROMPT_TEXT = "/steer-into-active";
+
+const INTERRUPT_BEFORE_START_PROMPT_TEXT = "/interrupt-before-start";
 
 /** A prompt that stays open until the client sends turn/interrupt. */
 const INTERRUPTIBLE_PROMPT_TEXT = "/wait-for-interrupt";
@@ -101,9 +103,9 @@ const FIXED_TOKEN_USAGE = {
   modelContextWindow: 258400,
 };
 
-function runScriptedTurn(threadId) {
+function runScriptedTurn(threadId, presetTurnId) {
   turnCounter += 1;
-  const turnId = `turn-fx-${turnCounter}`;
+  const turnId = presetTurnId ?? `turn-fx-${turnCounter}`;
   const itemId = `item-fx-${turnCounter}`;
   const text = `hello from codex turn ${turnCounter}`;
   openTurnIdsByThreadId.set(threadId, turnId);
@@ -435,11 +437,38 @@ async function handleRequest(message) {
         return;
       }
       if (firstInputText(params.input) === LATE_TURN_START_PROMPT_TEXT) {
-        respond(id, {});
+        turnCounter += 1;
+        const turnId = `turn-fx-${turnCounter}`;
+        respond(id, { turn: { id: turnId, status: "inProgress" } });
         setTimeout(
-          () => runScriptedTurn(params.threadId),
+          () => runScriptedTurn(params.threadId, turnId),
           LATE_TURN_START_DELAY_MS,
         );
+        return;
+      }
+      if (firstInputText(params.input) === RESPOND_THEN_EXIT_PROMPT_TEXT) {
+        turnCounter += 1;
+        const turnId = `turn-fx-${turnCounter}`;
+        respond(id, { turn: { id: turnId, status: "inProgress" } });
+        setTimeout(() => process.exit(1), 20);
+        return;
+      }
+      if (firstInputText(params.input) === RESPOND_COMPLETED_PROMPT_TEXT) {
+        turnCounter += 1;
+        const turnId = `turn-fx-${turnCounter}`;
+        respond(id, { turn: { id: turnId, status: "completed" } });
+        return;
+      }
+      if (firstInputText(params.input) === STEER_INTO_ACTIVE_PROMPT_TEXT) {
+        const activeTurnId = openTurnIdsByThreadId.get(params.threadId);
+        respond(id, { turn: { id: activeTurnId, status: "inProgress" } });
+        return;
+      }
+      if (firstInputText(params.input) === INTERRUPT_BEFORE_START_PROMPT_TEXT) {
+        turnCounter += 1;
+        const turnId = `turn-fx-${turnCounter}`;
+        pendingStartTurnIdsByThreadId.set(params.threadId, turnId);
+        respond(id, { turn: { id: turnId, status: "inProgress" } });
         return;
       }
       if (firstInputText(params.input) === INTERRUPTIBLE_PROMPT_TEXT) {
@@ -465,6 +494,20 @@ async function handleRequest(message) {
       respond(id, {});
       return;
     case "turn/interrupt": {
+      const pendingTurnId = pendingStartTurnIdsByThreadId.get(params.threadId);
+      if (pendingTurnId !== undefined) {
+        pendingStartTurnIdsByThreadId.delete(params.threadId);
+        notify("turn/completed", {
+          threadId: params.threadId,
+          turn: { id: pendingTurnId, status: "interrupted" },
+        });
+        notify("turn/started", {
+          threadId: params.threadId,
+          turn: { id: pendingTurnId, status: "inProgress" },
+        });
+        respond(id, {});
+        return;
+      }
       const openTurnId = openTurnIdsByThreadId.get(params.threadId);
       if (openTurnId !== undefined) {
         openTurnIdsByThreadId.delete(params.threadId);

--- a/plugins/provider-codex/src/schemas.ts
+++ b/plugins/provider-codex/src/schemas.ts
@@ -518,13 +518,14 @@ const codexTurnErrorSchema = z
   })
   .passthrough();
 
-const codexTurnSchema = z
+export const codexTurnSchema = z
   .object({
     id: z.string(),
     status: codexTurnStatusSchema,
     error: codexTurnErrorSchema.nullable().optional(),
   })
   .passthrough();
+export type CodexTurn = z.infer<typeof codexTurnSchema>;
 
 const codexThreadSchema = z
   .object({

--- a/plugins/provider-codex/src/translator.ts
+++ b/plugins/provider-codex/src/translator.ts
@@ -24,6 +24,7 @@ import {
   codexSubAgentActivityItemSchema,
   codexThreadClosedParamsSchema,
   type CodexSubAgentActivityItem,
+  type CodexTurn,
 } from "./schemas.js";
 import {
   buildCodexConfig,
@@ -35,6 +36,10 @@ import {
 } from "./session-params.js";
 import type { JsonValue } from "./generated/codex-app-server/schema/serde_json/JsonValue.js";
 import { subAgentPresentation } from "./presentation.js";
+
+const codexTurnLifecyclePeekSchema = z
+  .object({ turn: z.object({ id: z.string() }).passthrough() })
+  .passthrough();
 
 const CODEX_SHELL_TOOL_NAMES = new Set(["exec_command", "Bash", "bash"]);
 const CODEX_DELEGATION_TOOL_NAMES = new Set(["spawnAgent", "resumeAgent"]);
@@ -377,6 +382,8 @@ export function createCodexEventTranslator(
     string,
     ClientTurnRequestId[]
   >();
+  const responseOpenedTurnIds = new Set<string>();
+  const responseSettledTurnIds = new Set<string>();
   const pendingWorkspaceWriteGitWritableRootsByThreadId = new Map<
     string,
     string[]
@@ -661,6 +668,62 @@ export function createCodexEventTranslator(
       args.providerThreadId,
       nextSequences,
     );
+  }
+
+  function openTurnFromStartResponse(args: {
+    providerThreadId: string;
+    turn: CodexTurn;
+    clientRequestId: ClientTurnRequestId;
+    turnAlreadyOpen: boolean;
+  }): ThreadDelta[] {
+    const { providerThreadId, turn, clientRequestId, turnAlreadyOpen } = args;
+    const queued =
+      nativeTurnStartClientRequestIdsByProviderThreadId.get(providerThreadId);
+    if (queued?.[0] !== clientRequestId) {
+      return [];
+    }
+    if (turnAlreadyOpen) {
+      removeNativeTurnStartClientRequestId({
+        clientRequestId,
+        providerThreadId,
+      });
+      responseOpenedTurnIds.add(turn.id);
+      return [
+        { kind: "input.accepted", clientRequestId, providerTurnId: turn.id },
+      ];
+    }
+    const startedDeltas = translateEvent({
+      jsonrpc: "2.0",
+      method: "turn/started",
+      params: { threadId: providerThreadId, turn },
+    });
+    responseOpenedTurnIds.add(turn.id);
+    if (turn.status === "inProgress") {
+      return startedDeltas;
+    }
+    const settledDeltas = translateEvent({
+      jsonrpc: "2.0",
+      method: "turn/completed",
+      params: { threadId: providerThreadId, turn },
+    });
+    responseSettledTurnIds.add(turn.id);
+    return [...startedDeltas, ...settledDeltas];
+  }
+
+  function consumeResponseHandledTurnLifecycle(
+    event: ProviderRuntimeEvent,
+  ): boolean {
+    const consumedBy =
+      event.method === "turn/started"
+        ? responseOpenedTurnIds
+        : event.method === "turn/completed"
+          ? responseSettledTurnIds
+          : null;
+    if (consumedBy === null) {
+      return false;
+    }
+    const parsed = codexTurnLifecyclePeekSchema.safeParse(event.params);
+    return parsed.success && consumedBy.delete(parsed.data.turn.id);
   }
 
   function shiftNativeTurnStartClientRequestId(
@@ -1521,6 +1584,9 @@ export function createCodexEventTranslator(
   }
 
   function translateEvent(event: ProviderRuntimeEvent): ThreadDelta[] {
+    if (consumeResponseHandledTurnLifecycle(event)) {
+      return [];
+    }
     const closedThreadDeltas = clearClosedThreadState(event);
     if (closedThreadDeltas.length > 0) {
       return closedThreadDeltas;
@@ -1564,6 +1630,7 @@ export function createCodexEventTranslator(
     clearExitedChildThreadState,
     configureInjectedTools,
     getThreadGitWritableRoots,
+    openTurnFromStartResponse,
     prepareTurnStart: queueNativeTurnStartClientRequestId,
     prepareWorkspaceWriteGitRoots,
     translateEvent,


### PR DESCRIPTION
## Human comments

## What was wrong

The bridge ignored the `turn/start` result (`z.unknown()`, discarded) and settled accepted dispatches by guessing: if no `turn/started` claimed the correlation within 250 ms of the answer, it fabricated a completed zero-work turn. Codex answers `turn/start` at turn creation and can emit `turn/started` later than that window (observed 351 ms to 2.7 s under load), so the bridge recorded a synthetic completed turn followed by the real turn. A parent thread saw its child complete with no output while the child was still working. Root cause and repro in #2580.

## What changed

- `plugins/provider-codex/src/bridge/bridge.ts`: `handleTurnStart` captures the dispatch result. `settleAcceptedDispatch` parses it; a response naming a turn settles against that real turn, anything else (compact's `{}`, malformed body) keeps the existing zero-work timer unchanged.
- `plugins/provider-codex/src/translator.ts`: `openTurnFromStartResponse` proves ownership the same way `claim()` does (dispatch still at the correlation queue head), then opens the turn through the same `turn/started` translation the real notification would take. The provider's own later `turn/started` for that id is suppressed so it cannot double-open the turn or shift another dispatch's correlation. A response reporting an already-terminal status settles the full lifecycle at once and suppresses both later notifications. A dispatch codex steers into the running turn only emits `input.accepted` against it.
- Because the turn enters `openCodexTurnIds` at response time, interrupt waiting, steering, and child-exit settlement see it with no new state: a crash between answer and notification now settles the real turn as failed instead of fabricating a completed one.
- `packages/host-daemon-contract`: `HOST_DAEMON_PROTOCOL_VERSION` 173 → 174 (same delta kinds, but the lifecycle sequences the daemon emits change) and the version assertion in `contract.test.ts`.
- `fake-codex-app-server.mjs`: `turn/start` scenarios now answer with the turn like every supported codex (0.136.0 up already returns `{ turn }`; verified against codex-rs `rust-v0.136.0`), the late-start delay crosses the grace window, and new prompts cover the crash, steer, terminal-response, and settle-before-started shapes.

Known limit: a codex whose `turn/start` answers without a turn still gets the old 250 ms guess; with no turn id there is nothing to correlate. No supported version does this.

## How you verified

- New/updated tests in `bridge.zero-work-turn.test.ts` fail before and pass after: exactly-once lifecycle when `turn/started` lags past the grace window (the issue's repro, previously two lifecycles), failed settlement when codex dies before `turn/started` (previously a fabricated completed turn), steered dispatch acknowledged on the running turn, terminal-status response settling at once, and no resurrection when an interrupt settles a response-opened turn before its `turn/started` arrives.
- `pnpm exec turbo run test` green for `bb-plugin-provider-codex` (253), `@bb/host-daemon-contract` (51), `@bb/provider-bridge-protocol` (238), `@bb/agent-runtime` (318), `@bb/host-daemon` (561), `@bb/integration-tests` (77); full-repo `turbo run typecheck` (80 tasks).
- Probed real `codex app-server` 0.149.1: `turn/start` answers at turn creation with `{"turn":{"id":…,"status":"inProgress"}}`, and the answer can precede `turn/started`.

Fixes #2580

> AGENT GENERATED
