### PR TITLE
Keep touch-only controls visible on tablets

### DIFF
--- a/apps/app/src/components/plugin/docs-anatomy-manifest.test.tsx
+++ b/apps/app/src/components/plugin/docs-anatomy-manifest.test.tsx
@@ -227,7 +227,7 @@ describe("docs anatomy manifest", () => {
         <MessageActionBar
           messageText="hello"
           alignment="start"
-          mobileActionDisplay="inline"
+          touchActionDisplay="inline"
           onAddToChat={() => {}}
           onEdit={() => {}}
           onFork={() => {}}

--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.test.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.test.tsx
@@ -391,6 +391,19 @@ describe("QueuedMessagesList", () => {
       container.querySelector('[data-icon="DragDropVertical"]'),
     ).not.toBeNull();
 
+    const desktopActions = container.querySelector<HTMLElement>(
+      "[data-queued-message-actions]",
+    );
+    const overflowTrigger = getByRole("button", {
+      name: "Queued message 1 actions",
+    });
+    expect(desktopActions?.classList).toContain("pointer-coarse:hidden");
+    expect(desktopActions?.classList).toContain("[@media(hover:none)]:hidden");
+    expect(overflowTrigger.classList).toContain("pointer-coarse:inline-flex");
+    expect(overflowTrigger.classList).toContain(
+      "[@media(hover:none)]:inline-flex",
+    );
+
     for (const [button, label] of [
       [sendButton, "Send now"],
       [editButton, "Edit"],

--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
@@ -863,7 +863,7 @@ const QueuedMessageRow = memo(function QueuedMessageRow({
                 data-queued-message-actions=""
                 className={cn(
                   QUEUED_MESSAGE_ACTION_TAKEOVER_CLASS,
-                  "pointer-events-none absolute right-2.5 top-1/2 hidden -translate-y-1/2 items-center gap-0.5 rounded-md opacity-0 transition-opacity duration-[120ms] ease-out md:flex",
+                  "pointer-events-none absolute right-2.5 top-1/2 hidden -translate-y-1/2 items-center gap-0.5 rounded-md opacity-0 transition-opacity duration-[120ms] ease-out md:flex pointer-coarse:hidden [@media(hover:none)]:hidden",
                   "group-hover/dispatch-row:pointer-events-auto group-hover/dispatch-row:opacity-100",
                   "group-focus-within/dispatch-row:pointer-events-auto group-focus-within/dispatch-row:opacity-100",
                 )}
@@ -948,7 +948,8 @@ const QueuedMessageRow = memo(function QueuedMessageRow({
                     "group-hover/dispatch-row:pointer-events-auto group-hover/dispatch-row:opacity-100",
                     "group-focus-within/dispatch-row:pointer-events-auto group-focus-within/dispatch-row:opacity-100",
                     "data-[state=open]:pointer-events-auto data-[state=open]:opacity-100",
-                    "[@media(hover:none)]:pointer-events-auto [@media(hover:none)]:opacity-100",
+                    "pointer-coarse:inline-flex pointer-coarse:pointer-events-auto pointer-coarse:opacity-100",
+                    "[@media(hover:none)]:inline-flex [@media(hover:none)]:pointer-events-auto [@media(hover:none)]:opacity-100",
                     compact ? "size-7" : "size-8",
                   )}
                   disabled={actionDisabled}

--- a/apps/app/src/components/thread/timeline/ConversationMessageContent.streaming.test.tsx
+++ b/apps/app/src/components/thread/timeline/ConversationMessageContent.streaming.test.tsx
@@ -26,7 +26,7 @@ function renderAssistantMessage(text: string, streaming: boolean) {
           threadId="thr_stream"
           turnId="turn_stream"
           showActions={false}
-          mobileActionDisplay="overflow"
+          touchActionDisplay="overflow"
           streaming={streaming}
           text={text}
         />
@@ -47,7 +47,7 @@ function renderAssistantMessage(text: string, streaming: boolean) {
               threadId="thr_stream"
               turnId="turn_stream"
               showActions={false}
-              mobileActionDisplay="overflow"
+              touchActionDisplay="overflow"
               streaming={nextStreaming}
               text={nextText}
             />

--- a/apps/app/src/components/thread/timeline/ConversationMessageContent.test.tsx
+++ b/apps/app/src/components/thread/timeline/ConversationMessageContent.test.tsx
@@ -74,7 +74,7 @@ describe("ConversationMessageContent assistant images", () => {
             threadId="thr_image"
             turnId="turn_image"
             showActions={false}
-            mobileActionDisplay="overflow"
+            touchActionDisplay="overflow"
             streaming={false}
             text="![Generated diagram](/workspace/output/diagram.png)"
           />
@@ -124,7 +124,7 @@ describe("ConversationMessageContent assistant thread mentions", () => {
                 threadId="thr_parent"
                 turnId="turn_spawned"
                 showActions={false}
-                mobileActionDisplay="overflow"
+                touchActionDisplay="overflow"
                 streaming={false}
                 text="Spawned and parented: @thread:thr_xpxxt2ipz8"
               />

--- a/apps/app/src/components/thread/timeline/ConversationMessageContent.tsx
+++ b/apps/app/src/components/thread/timeline/ConversationMessageContent.tsx
@@ -82,7 +82,7 @@ interface ConversationMessageContentBaseProps {
 
 interface ConversationMessageContentUserProps extends ConversationMessageContentBaseProps {
   role: "user";
-  mobileActionDisplay?: "inline" | "overflow";
+  touchActionDisplay?: "inline" | "overflow";
   originKind: ThreadOriginKind | null;
   initiator: TimelineUserConversationRow["initiator"];
   mentions: readonly PromptTextMention[];
@@ -132,7 +132,7 @@ interface ConversationMessageContentAssistantProps
   forkDisabled?: boolean;
   onSelectProse?: (selection: MessageProseSelection | null) => void;
   showActions: boolean;
-  mobileActionDisplay: "inline" | "overflow";
+  touchActionDisplay: "inline" | "overflow";
   streaming: boolean;
   workspaceRootPath?: string;
 }
@@ -148,7 +148,7 @@ interface UserConversationMessageProps {
   pluginActions?: readonly ThreadTimelinePluginMessageAction[];
   initiator: TimelineUserConversationRow["initiator"];
   mentions: readonly PromptTextMention[];
-  mobileActionDisplay: "inline" | "overflow";
+  touchActionDisplay: "inline" | "overflow";
   onAddToChat?: ThreadTimelineAddToChatHandler;
   onEdit?: () => void;
   onOpenLink?: ThreadTimelineLinkHandler;
@@ -181,7 +181,7 @@ interface AssistantConversationMessageProps extends AssistantMessageRowIdentity 
   onOpenPluginPanel?: MarkdownMessageDirectives["openThreadPanel"];
   projectId?: string;
   showActions: boolean;
-  mobileActionDisplay: "inline" | "overflow";
+  touchActionDisplay: "inline" | "overflow";
   streaming: boolean;
   text: string;
   workspaceRootPath?: string;
@@ -330,7 +330,7 @@ function UserConversationMessage({
   originKind,
   initiator,
   mentions,
-  mobileActionDisplay,
+  touchActionDisplay,
   onAddToChat,
   onEdit,
   onOpenLink,
@@ -455,7 +455,7 @@ function UserConversationMessage({
           <MessageActionBar
             messageText={messageText}
             alignment="end"
-            mobileActionDisplay={mobileActionDisplay}
+            touchActionDisplay={touchActionDisplay}
             addToChatAttachments={addToChatAttachments}
             onAddToChat={onAddToChat}
             onEdit={onEdit}
@@ -482,7 +482,7 @@ function AssistantConversationMessage({
   pluginActions,
   projectId,
   showActions,
-  mobileActionDisplay,
+  touchActionDisplay,
   streaming,
   text,
   threadId,
@@ -624,7 +624,7 @@ function AssistantConversationMessage({
         <MessageActionBar
           messageText={text}
           alignment="start"
-          mobileActionDisplay={mobileActionDisplay}
+          touchActionDisplay={touchActionDisplay}
           addToChatAttachments={addToChatAttachments}
           onAddToChat={onAddToChat}
           onFork={onFork}
@@ -671,7 +671,7 @@ export function ConversationMessageContent(
         pluginActions={props.pluginActions}
         initiator={props.initiator}
         mentions={props.mentions}
-        mobileActionDisplay={props.mobileActionDisplay ?? "overflow"}
+        touchActionDisplay={props.touchActionDisplay ?? "overflow"}
         onAddToChat={props.onAddToChat}
         onEdit={props.onEdit}
         onOpenLink={props.onOpenLink}
@@ -708,7 +708,7 @@ export function ConversationMessageContent(
       onOpenPluginPanel={onOpenPluginPanel}
       projectId={projectId}
       showActions={props.showActions}
-      mobileActionDisplay={props.mobileActionDisplay}
+      touchActionDisplay={props.touchActionDisplay}
       streaming={props.streaming}
       text={text}
       threadId={props.threadId}

--- a/apps/app/src/components/thread/timeline/MessageActionBar.stories.tsx
+++ b/apps/app/src/components/thread/timeline/MessageActionBar.stories.tsx
@@ -25,7 +25,7 @@ export function Overview() {
             <MessageActionBar
               messageText="An agent message you can fork or reply to."
               alignment="end"
-              mobileActionDisplay="inline"
+              touchActionDisplay="inline"
               onFork={noop}
             />
           </HoverRevealStage>
@@ -35,7 +35,7 @@ export function Overview() {
             <MessageActionBar
               messageText="A user message you can quote into the composer."
               alignment="end"
-              mobileActionDisplay="overflow"
+              touchActionDisplay="overflow"
               onAddToChat={noop}
             />
           </HoverRevealStage>
@@ -45,7 +45,7 @@ export function Overview() {
             <MessageActionBar
               messageText="Fork/Reply greyed when the thread can't fork."
               alignment="end"
-              mobileActionDisplay="inline"
+              touchActionDisplay="inline"
               onFork={noop}
               disabled
             />
@@ -59,7 +59,7 @@ export function Overview() {
             <MessageActionBar
               messageText="A side-chat reply you can hand back to the main thread."
               alignment="start"
-              mobileActionDisplay="inline"
+              touchActionDisplay="inline"
               onSendToMain={noop}
             />
           </HoverRevealStage>

--- a/apps/app/src/components/thread/timeline/MessageActionBar.test.tsx
+++ b/apps/app/src/components/thread/timeline/MessageActionBar.test.tsx
@@ -79,6 +79,19 @@ function mockMobileCoarsePointer() {
   }));
 }
 
+function mockWideCoarsePointer() {
+  vi.spyOn(window, "matchMedia").mockImplementation((query) => ({
+    matches: query === POINTER_COARSE_QUERY,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }));
+}
+
 describe("MessageActionBar", () => {
   it("uses the nearest thread window as the tooltip collision boundary", () => {
     const threadWindow = document.createElement("div");
@@ -429,6 +442,23 @@ describe("MessageActionBar", () => {
     expect(
       screen.queryByRole("button", { name: "Message actions" }),
     ).toBeNull();
+  });
+
+  it("uses the always-visible touch surface on wide coarse-pointer viewports", () => {
+    mockWideCoarsePointer();
+    render(
+      <MessageActionBar
+        messageText="The latest answer."
+        alignment="start"
+        mobileActionDisplay="inline"
+        onFork={vi.fn()}
+      />,
+    );
+
+    const fork = screen.getByRole("button", { name: "Fork into new thread" });
+    expect(fork.hasAttribute("data-state")).toBe(false);
+    expect(fork.classList).toContain("pointer-coarse:opacity-100");
+    expect(fork.classList).not.toContain("max-md:pointer-coarse:opacity-100");
   });
 
   it("collapses desktop actions that do not fit into a trailing overflow menu", () => {

--- a/apps/app/src/components/thread/timeline/MessageActionBar.test.tsx
+++ b/apps/app/src/components/thread/timeline/MessageActionBar.test.tsx
@@ -11,6 +11,7 @@ import {
 } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { COMPACT_VIEWPORT_QUERY } from "@bb/shared-ui/hooks/use-compact-viewport";
+import { HOVER_NONE_QUERY } from "@bb/shared-ui/hooks/use-media-query";
 import { POINTER_COARSE_QUERY } from "@bb/shared-ui/hooks/use-pointer-coarse";
 import {
   computeMessageActionRowLayout,
@@ -92,6 +93,19 @@ function mockWideCoarsePointer() {
   }));
 }
 
+function mockWideNoHoverPointer() {
+  vi.spyOn(window, "matchMedia").mockImplementation((query) => ({
+    matches: query === HOVER_NONE_QUERY,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }));
+}
+
 describe("MessageActionBar", () => {
   it("uses the nearest thread window as the tooltip collision boundary", () => {
     const threadWindow = document.createElement("div");
@@ -115,7 +129,7 @@ describe("MessageActionBar", () => {
       <MessageActionBar
         messageText="An answer worth keeping."
         alignment="start"
-        mobileActionDisplay="overflow"
+        touchActionDisplay="overflow"
         onSendToMain={onSendToMain}
       />,
     );
@@ -132,7 +146,7 @@ describe("MessageActionBar", () => {
       <MessageActionBar
         messageText="An answer."
         alignment="start"
-        mobileActionDisplay="inline"
+        touchActionDisplay="inline"
         onAddToChat={vi.fn()}
         onFork={vi.fn()}
       />,
@@ -151,7 +165,7 @@ describe("MessageActionBar", () => {
       <MessageActionBar
         messageText="An answer."
         alignment="start"
-        mobileActionDisplay="overflow"
+        touchActionDisplay="overflow"
         onAddToChat={vi.fn()}
         onFork={vi.fn()}
       />,
@@ -174,7 +188,7 @@ describe("MessageActionBar", () => {
       <MessageActionBar
         messageText="An answer."
         alignment="start"
-        mobileActionDisplay="inline"
+        touchActionDisplay="inline"
         onAddToChat={vi.fn()}
         onFork={vi.fn()}
         pluginActions={[
@@ -208,7 +222,7 @@ describe("MessageActionBar", () => {
       <MessageActionBar
         messageText=""
         alignment="start"
-        mobileActionDisplay="inline"
+        touchActionDisplay="inline"
         pluginActions={[
           {
             key: "demo/summarize/1",
@@ -230,7 +244,7 @@ describe("MessageActionBar", () => {
       <MessageActionBar
         messageText="An answer."
         alignment="start"
-        mobileActionDisplay="overflow"
+        touchActionDisplay="overflow"
         onAddToChat={vi.fn()}
         pluginActions={[
           {
@@ -258,7 +272,7 @@ describe("MessageActionBar", () => {
       <MessageActionBar
         messageText="Quote this message."
         alignment="end"
-        mobileActionDisplay="overflow"
+        touchActionDisplay="overflow"
         onAddToChat={onAddToChat}
       />,
     );
@@ -280,7 +294,7 @@ describe("MessageActionBar", () => {
       <MessageActionBar
         messageText="Quote this message."
         alignment="end"
-        mobileActionDisplay="overflow"
+        touchActionDisplay="overflow"
         addToChatAttachments={[attachment]}
         onAddToChat={onAddToChat}
       />,
@@ -304,7 +318,7 @@ describe("MessageActionBar", () => {
       <MessageActionBar
         messageText=""
         alignment="end"
-        mobileActionDisplay="overflow"
+        touchActionDisplay="overflow"
         addToChatAttachments={[attachment]}
         onAddToChat={onAddToChat}
       />,
@@ -319,7 +333,7 @@ describe("MessageActionBar", () => {
       <MessageActionBar
         messageText="An answer."
         alignment="start"
-        mobileActionDisplay="overflow"
+        touchActionDisplay="overflow"
       />,
     );
 
@@ -334,7 +348,7 @@ describe("MessageActionBar", () => {
       <MessageActionBar
         messageText="An answer."
         alignment="start"
-        mobileActionDisplay="overflow"
+        touchActionDisplay="overflow"
         onSendToMain={onSendToMain}
         disabled
       />,
@@ -353,7 +367,7 @@ describe("MessageActionBar", () => {
       <MessageActionBar
         messageText="Quote this message."
         alignment="end"
-        mobileActionDisplay="overflow"
+        touchActionDisplay="overflow"
         onAddToChat={onAddToChat}
       />,
     );
@@ -384,7 +398,7 @@ describe("MessageActionBar", () => {
       <MessageActionBar
         messageText="Copy this answer."
         alignment="start"
-        mobileActionDisplay="overflow"
+        touchActionDisplay="overflow"
       />,
     );
 
@@ -409,7 +423,7 @@ describe("MessageActionBar", () => {
       <MessageActionBar
         messageText="The latest answer."
         alignment="start"
-        mobileActionDisplay="inline"
+        touchActionDisplay="inline"
         onFork={onFork}
       />,
     );
@@ -426,7 +440,7 @@ describe("MessageActionBar", () => {
       <MessageActionBar
         messageText="The latest answer."
         alignment="start"
-        mobileActionDisplay="inline"
+        touchActionDisplay="inline"
         onAddToChat={vi.fn()}
         onFork={vi.fn()}
       />,
@@ -450,7 +464,7 @@ describe("MessageActionBar", () => {
       <MessageActionBar
         messageText="The latest answer."
         alignment="start"
-        mobileActionDisplay="inline"
+        touchActionDisplay="inline"
         onFork={vi.fn()}
       />,
     );
@@ -461,6 +475,25 @@ describe("MessageActionBar", () => {
     expect(fork.classList).not.toContain("max-md:pointer-coarse:opacity-100");
   });
 
+  it("uses the always-visible touch surface when the pointer cannot hover", () => {
+    mockWideNoHoverPointer();
+    render(
+      <MessageActionBar
+        messageText="The latest answer."
+        alignment="start"
+        touchActionDisplay="overflow"
+        onFork={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Message actions" }).classList,
+    ).toContain("[@media(hover:none)]:inline-flex");
+    expect(
+      screen.queryByRole("button", { name: "Fork into new thread" }),
+    ).toBeNull();
+  });
+
   it("collapses desktop actions that do not fit into a trailing overflow menu", () => {
     const resizeObserver = installControlledResizeObserver();
     const onAddToChat = vi.fn();
@@ -468,7 +501,7 @@ describe("MessageActionBar", () => {
       <MessageActionBar
         messageText="An answer."
         alignment="end"
-        mobileActionDisplay="overflow"
+        touchActionDisplay="overflow"
         onAddToChat={onAddToChat}
         onFork={vi.fn()}
       />,
@@ -495,7 +528,7 @@ describe("MessageActionBar", () => {
       <MessageActionBar
         messageText="An answer."
         alignment="end"
-        mobileActionDisplay="overflow"
+        touchActionDisplay="overflow"
         onAddToChat={vi.fn()}
         onFork={vi.fn()}
       />,
@@ -517,7 +550,7 @@ describe("MessageActionBar", () => {
       <MessageActionBar
         messageText="An answer."
         alignment="start"
-        mobileActionDisplay="inline"
+        touchActionDisplay="inline"
         onAddToChat={vi.fn()}
         onFork={onFork}
       />,
@@ -553,7 +586,7 @@ describe("MessageActionBar", () => {
         <MessageActionBar
           messageText="An answer."
           alignment="end"
-          mobileActionDisplay="overflow"
+          touchActionDisplay="overflow"
           onAddToChat={onAddToChat}
           onFork={vi.fn()}
         />
@@ -587,7 +620,7 @@ describe("MessageActionBar", () => {
         <MessageActionBar
           messageText="Copy this answer."
           alignment="end"
-          mobileActionDisplay="overflow"
+          touchActionDisplay="overflow"
           onAddToChat={vi.fn()}
           onFork={vi.fn()}
         />
@@ -617,7 +650,7 @@ describe("MessageActionBar", () => {
         <MessageActionBar
           messageText="An answer."
           alignment="end"
-          mobileActionDisplay="overflow"
+          touchActionDisplay="overflow"
           onAddToChat={vi.fn()}
           onFork={vi.fn()}
         />
@@ -642,7 +675,7 @@ describe("MessageActionBar", () => {
       <MessageActionBar
         messageText="The latest answer."
         alignment="start"
-        mobileActionDisplay="inline"
+        touchActionDisplay="inline"
         onFork={vi.fn()}
       />,
     );
@@ -674,7 +707,7 @@ describe("MessageActionBar observer budget", () => {
         <MessageActionBar
           messageText="An answer."
           alignment="start"
-          mobileActionDisplay="overflow"
+          touchActionDisplay="overflow"
           onAddToChat={vi.fn()}
         />
       </div>,
@@ -691,7 +724,7 @@ describe("MessageActionBar observer budget", () => {
         <MessageActionBar
           messageText="An answer."
           alignment="end"
-          mobileActionDisplay="overflow"
+          touchActionDisplay="overflow"
           onAddToChat={vi.fn()}
           onFork={vi.fn()}
         />
@@ -714,7 +747,7 @@ describe("MessageActionBar observer budget", () => {
         <MessageActionBar
           messageText="An answer."
           alignment="end"
-          mobileActionDisplay="overflow"
+          touchActionDisplay="overflow"
           onAddToChat={vi.fn()}
           onFork={vi.fn()}
         />
@@ -737,7 +770,7 @@ describe("MessageActionBar shared column width", () => {
         <MessageActionBar
           messageText="An answer."
           alignment={alignment}
-          mobileActionDisplay="overflow"
+          touchActionDisplay="overflow"
           onAddToChat={vi.fn()}
           onFork={vi.fn()}
         />

--- a/apps/app/src/components/thread/timeline/MessageActionBar.tsx
+++ b/apps/app/src/components/thread/timeline/MessageActionBar.tsx
@@ -11,7 +11,6 @@ import { flushSync } from "react-dom";
 import * as PopoverPrimitive from "@radix-ui/react-popover";
 import { CopyButton } from "../../ui/copy-button.js";
 import { Icon } from "@bb/shared-ui/icon";
-import { useIsCompactViewport } from "@bb/shared-ui/hooks/use-compact-viewport";
 import { usePointerCoarse } from "@bb/shared-ui/hooks/use-pointer-coarse";
 import { preventOverlayTriggerSelection } from "@bb/shared-ui/overlay-trigger";
 import { copyToClipboardWithToast } from "@/lib/clipboard";
@@ -178,17 +177,17 @@ export const MessageColumnWidthContext =
 const resolveMessageColumn = (node: HTMLElement): Element | null =>
   node.closest("[data-message-column]");
 
-interface MobileMessageOverflowPopoverProps {
+interface CoarsePointerMessageOverflowPopoverProps {
   actions: readonly MessageOverflowAction[];
   alignment: MessageActionBarProps["alignment"];
   triggerClassName?: string;
 }
 
-function MobileMessageOverflowPopover({
+function CoarsePointerMessageOverflowPopover({
   actions,
   alignment,
   triggerClassName,
-}: MobileMessageOverflowPopoverProps) {
+}: CoarsePointerMessageOverflowPopoverProps) {
   const [open, setOpen] = useState(false);
   const [copied, setCopied] = useState(false);
   const portalScopeProps = usePortalScopeProps();
@@ -207,7 +206,10 @@ function MobileMessageOverflowPopover({
       <PopoverPrimitive.Trigger asChild>
         <button
           type="button"
-          className={cn(MOBILE_OVERFLOW_TRIGGER_CLASS, triggerClassName)}
+          className={cn(
+            COARSE_POINTER_OVERFLOW_TRIGGER_CLASS,
+            triggerClassName,
+          )}
           aria-label="Message actions"
           data-no-sidebar-swipe=""
           onMouseDown={preventOverlayTriggerSelection}
@@ -228,7 +230,7 @@ function MobileMessageOverflowPopover({
           align={alignment === "end" ? "end" : "start"}
           sideOffset={6}
           collisionPadding={8}
-          className={MOBILE_OVERFLOW_CONTENT_CLASS}
+          className={COARSE_POINTER_OVERFLOW_CONTENT_CLASS}
           onOpenAutoFocus={(event) => event.preventDefault()}
           onCloseAutoFocus={(event) => event.preventDefault()}
         >
@@ -236,7 +238,7 @@ function MobileMessageOverflowPopover({
             <button
               key={action.key ?? action.label}
               type="button"
-              className={MOBILE_OVERFLOW_ITEM_CLASS}
+              className={COARSE_POINTER_OVERFLOW_ITEM_CLASS}
               disabled={action.disabled}
               onClick={() => {
                 if (action.kind === "copy") {
@@ -275,16 +277,16 @@ const ACTION_BUTTON_CLASS =
   "inline-flex size-5 cursor-pointer items-center justify-center text-muted-foreground hover:text-foreground disabled:pointer-events-none disabled:opacity-40";
 const HOVER_REVEAL_CLASS =
   "opacity-0 transition-opacity group-hover/message:opacity-100 group-focus-within/message:opacity-100";
-const MOBILE_INLINE_ACTION_CLASS =
-  "max-md:pointer-coarse:size-7 max-md:pointer-coarse:opacity-100 max-md:pointer-coarse:disabled:opacity-40 max-md:pointer-coarse:[&_svg]:size-4";
-const MOBILE_OVERFLOW_ACTION_CLASS = "max-md:pointer-coarse:hidden";
-const MOBILE_OVERFLOW_TRIGGER_CLASS =
-  "hidden size-7 cursor-pointer items-center justify-center rounded-md text-muted-foreground hover:text-foreground data-[state=open]:bg-state-active data-[state=open]:text-foreground max-md:pointer-coarse:inline-flex max-md:pointer-coarse:[&_svg]:size-4";
+const COARSE_POINTER_INLINE_ACTION_CLASS =
+  "pointer-coarse:size-7 pointer-coarse:opacity-100 pointer-coarse:disabled:opacity-40 pointer-coarse:[&_svg]:size-4";
+const COARSE_POINTER_OVERFLOW_ACTION_CLASS = "pointer-coarse:hidden";
+const COARSE_POINTER_OVERFLOW_TRIGGER_CLASS =
+  "hidden size-7 cursor-pointer items-center justify-center rounded-md text-muted-foreground hover:text-foreground data-[state=open]:bg-state-active data-[state=open]:text-foreground pointer-coarse:inline-flex pointer-coarse:[&_svg]:size-4";
 const ACTION_TOOLTIP_SIDE = "bottom";
 const MENU_CONTENT_WIDTH_CLASS = "max-w-[min(16rem,calc(100vw-1rem))]";
-const MOBILE_OVERFLOW_CONTENT_CLASS =
+const COARSE_POINTER_OVERFLOW_CONTENT_CLASS =
   "z-50 flex max-h-[50dvh] w-max min-w-32 max-w-[min(15rem,calc(100vw-1.5rem))] flex-col gap-0.5 overflow-y-auto rounded-md border bg-popover p-0.5 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95";
-const MOBILE_OVERFLOW_ITEM_CLASS =
+const COARSE_POINTER_OVERFLOW_ITEM_CLASS =
   "flex min-h-8 w-full cursor-pointer items-center gap-2 rounded px-2 py-1 text-left text-xs text-foreground transition-colors hover:bg-surface-recessed focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring active:bg-state-active disabled:pointer-events-none disabled:opacity-40 select-none";
 
 const ACTION_ROW_CLASS =
@@ -389,7 +391,6 @@ export function MessageActionBar({
   disabled,
   pluginActions = [],
 }: MessageActionBarProps) {
-  const isCompactViewport = useIsCompactViewport();
   const isPointerCoarse = usePointerCoarse();
   const hasCopy = messageText.length > 0;
   const hasAddToChat =
@@ -397,9 +398,11 @@ export function MessageActionBar({
   const [collisionBoundary, setCollisionBoundary] = useState<
     HTMLElement | undefined
   >();
-  const useMobileOverflowPopover = isCompactViewport && isPointerCoarse;
+  const useCoarsePointerActionSurface = isPointerCoarse;
   const { measureRef, width: availableWidth } = useMeasuredWidth({
-    enabled: !(useMobileOverflowPopover && mobileActionDisplay === "overflow"),
+    enabled: !(
+      useCoarsePointerActionSurface && mobileActionDisplay === "overflow"
+    ),
   });
   const sharedColumnWidth = useContext(MessageColumnWidthContext);
   const { measureRef: measureColumnRef, width: ownColumnWidth } =
@@ -454,10 +457,10 @@ export function MessageActionBar({
     const timeoutId = window.setTimeout(() => setCopiedFromRow(false), 2000);
     return () => window.clearTimeout(timeoutId);
   }, [copiedFromRow]);
-  const mobileDirectActionClass =
+  const coarsePointerDirectActionClass =
     mobileActionDisplay === "inline"
-      ? MOBILE_INLINE_ACTION_CLASS
-      : MOBILE_OVERFLOW_ACTION_CLASS;
+      ? COARSE_POINTER_INLINE_ACTION_CLASS
+      : COARSE_POINTER_OVERFLOW_ACTION_CLASS;
   const handleAddToChat = useCallback(() => {
     if (!onAddToChat) return;
     if (addToChatAttachments.length > 0) {
@@ -543,7 +546,7 @@ export function MessageActionBar({
     alignment === "end" && BUBBLE_ALIGN_INSET_CLASS,
   );
 
-  if (useMobileOverflowPopover) {
+  if (useCoarsePointerActionSurface) {
     const layout =
       mobileActionDisplay === "overflow"
         ? { inlineCount: 0, overflowCount: actions.length }
@@ -570,7 +573,7 @@ export function MessageActionBar({
             )}
             onClick={handleExpandedRowClick}
           >
-            <MobileInlineActions
+            <CoarsePointerInlineActions
               actions={actions}
               onCopied={() => setCopiedFromRow(true)}
             />
@@ -582,7 +585,7 @@ export function MessageActionBar({
       <div ref={slotRef} className={cn(slotClass, "h-7")}>
         <div className={rowClass}>
           {layout.inlineCount > 0 ? (
-            <MobileInlineActions
+            <CoarsePointerInlineActions
               actions={actions.slice(0, layout.inlineCount)}
             />
           ) : null}
@@ -591,7 +594,7 @@ export function MessageActionBar({
               <button
                 type="button"
                 className={cn(
-                  MOBILE_OVERFLOW_TRIGGER_CLASS,
+                  COARSE_POINTER_OVERFLOW_TRIGGER_CLASS,
                   layout.inlineCount > 0 && OVERFLOW_TRIGGER_TIGHTEN_CLASS,
                 )}
                 aria-label="Message actions"
@@ -608,7 +611,7 @@ export function MessageActionBar({
                 />
               </button>
             ) : (
-              <MobileMessageOverflowPopover
+              <CoarsePointerMessageOverflowPopover
                 actions={actions.slice(layout.inlineCount)}
                 alignment={alignment}
                 triggerClassName={
@@ -635,14 +638,14 @@ export function MessageActionBar({
     <TooltipProvider delayDuration={300}>
       <div
         ref={desktopSlotRef}
-        className={cn(slotClass, "h-5 max-md:pointer-coarse:h-7")}
+        className={cn(slotClass, "h-5 pointer-coarse:h-7")}
       >
         <div className={rowClass}>
           {actions.slice(0, layout.inlineCount).map((action) => (
             <DesktopMessageAction
               key={action.key ?? action.label}
               action={action}
-              className={cn(HOVER_REVEAL_CLASS, mobileDirectActionClass)}
+              className={cn(HOVER_REVEAL_CLASS, coarsePointerDirectActionClass)}
               collisionBoundary={collisionBoundary}
             />
           ))}
@@ -654,7 +657,7 @@ export function MessageActionBar({
                   className={cn(
                     ACTION_BUTTON_CLASS,
                     HOVER_REVEAL_CLASS,
-                    mobileDirectActionClass,
+                    coarsePointerDirectActionClass,
                     layout.inlineCount > 0 && OVERFLOW_TRIGGER_TIGHTEN_CLASS,
                     "data-[state=open]:text-foreground data-[state=open]:opacity-100",
                   )}
@@ -679,7 +682,7 @@ export function MessageActionBar({
               <DropdownMenuTrigger asChild>
                 <button
                   type="button"
-                  className={MOBILE_OVERFLOW_TRIGGER_CLASS}
+                  className={COARSE_POINTER_OVERFLOW_TRIGGER_CLASS}
                   aria-label="Message actions"
                   data-no-sidebar-swipe=""
                 >
@@ -701,7 +704,7 @@ export function MessageActionBar({
   );
 }
 
-function MobileInlineActions({
+function CoarsePointerInlineActions({
   actions,
   onCopied,
 }: {
@@ -717,7 +720,7 @@ function MobileInlineActions({
           className={cn(
             ACTION_BUTTON_CLASS,
             HOVER_REVEAL_CLASS,
-            MOBILE_INLINE_ACTION_CLASS,
+            COARSE_POINTER_INLINE_ACTION_CLASS,
           )}
           onClick={() => {
             void copyToClipboardWithToast(action.copyText ?? "", {
@@ -736,7 +739,7 @@ function MobileInlineActions({
           key={action.key ?? action.label}
           text={action.copyText ?? ""}
           label={action.label}
-          className={cn(HOVER_REVEAL_CLASS, MOBILE_INLINE_ACTION_CLASS)}
+          className={cn(HOVER_REVEAL_CLASS, COARSE_POINTER_INLINE_ACTION_CLASS)}
         />
       )
     ) : (
@@ -746,7 +749,7 @@ function MobileInlineActions({
         className={cn(
           ACTION_BUTTON_CLASS,
           HOVER_REVEAL_CLASS,
-          MOBILE_INLINE_ACTION_CLASS,
+          COARSE_POINTER_INLINE_ACTION_CLASS,
         )}
         onClick={action.onSelect}
         disabled={action.disabled}

--- a/apps/app/src/components/thread/timeline/MessageActionBar.tsx
+++ b/apps/app/src/components/thread/timeline/MessageActionBar.tsx
@@ -11,6 +11,10 @@ import { flushSync } from "react-dom";
 import * as PopoverPrimitive from "@radix-ui/react-popover";
 import { CopyButton } from "../../ui/copy-button.js";
 import { Icon } from "@bb/shared-ui/icon";
+import {
+  HOVER_NONE_QUERY,
+  useMediaQuery,
+} from "@bb/shared-ui/hooks/use-media-query";
 import { usePointerCoarse } from "@bb/shared-ui/hooks/use-pointer-coarse";
 import { preventOverlayTriggerSelection } from "@bb/shared-ui/overlay-trigger";
 import { copyToClipboardWithToast } from "@/lib/clipboard";
@@ -55,7 +59,7 @@ function PluginActionIcon({
 interface MessageActionBarProps {
   messageText: string;
   alignment: "start" | "end";
-  mobileActionDisplay: "inline" | "overflow";
+  touchActionDisplay: "inline" | "overflow";
   addToChatAttachments?: readonly PromptDraftAttachment[];
   onAddToChat?: (
     text: string,
@@ -177,17 +181,17 @@ export const MessageColumnWidthContext =
 const resolveMessageColumn = (node: HTMLElement): Element | null =>
   node.closest("[data-message-column]");
 
-interface CoarsePointerMessageOverflowPopoverProps {
+interface TouchMessageOverflowPopoverProps {
   actions: readonly MessageOverflowAction[];
   alignment: MessageActionBarProps["alignment"];
   triggerClassName?: string;
 }
 
-function CoarsePointerMessageOverflowPopover({
+function TouchMessageOverflowPopover({
   actions,
   alignment,
   triggerClassName,
-}: CoarsePointerMessageOverflowPopoverProps) {
+}: TouchMessageOverflowPopoverProps) {
   const [open, setOpen] = useState(false);
   const [copied, setCopied] = useState(false);
   const portalScopeProps = usePortalScopeProps();
@@ -206,10 +210,7 @@ function CoarsePointerMessageOverflowPopover({
       <PopoverPrimitive.Trigger asChild>
         <button
           type="button"
-          className={cn(
-            COARSE_POINTER_OVERFLOW_TRIGGER_CLASS,
-            triggerClassName,
-          )}
+          className={cn(TOUCH_OVERFLOW_TRIGGER_CLASS, triggerClassName)}
           aria-label="Message actions"
           data-no-sidebar-swipe=""
           onMouseDown={preventOverlayTriggerSelection}
@@ -230,7 +231,7 @@ function CoarsePointerMessageOverflowPopover({
           align={alignment === "end" ? "end" : "start"}
           sideOffset={6}
           collisionPadding={8}
-          className={COARSE_POINTER_OVERFLOW_CONTENT_CLASS}
+          className={TOUCH_OVERFLOW_CONTENT_CLASS}
           onOpenAutoFocus={(event) => event.preventDefault()}
           onCloseAutoFocus={(event) => event.preventDefault()}
         >
@@ -238,7 +239,7 @@ function CoarsePointerMessageOverflowPopover({
             <button
               key={action.key ?? action.label}
               type="button"
-              className={COARSE_POINTER_OVERFLOW_ITEM_CLASS}
+              className={TOUCH_OVERFLOW_ITEM_CLASS}
               disabled={action.disabled}
               onClick={() => {
                 if (action.kind === "copy") {
@@ -277,16 +278,17 @@ const ACTION_BUTTON_CLASS =
   "inline-flex size-5 cursor-pointer items-center justify-center text-muted-foreground hover:text-foreground disabled:pointer-events-none disabled:opacity-40";
 const HOVER_REVEAL_CLASS =
   "opacity-0 transition-opacity group-hover/message:opacity-100 group-focus-within/message:opacity-100";
-const COARSE_POINTER_INLINE_ACTION_CLASS =
-  "pointer-coarse:size-7 pointer-coarse:opacity-100 pointer-coarse:disabled:opacity-40 pointer-coarse:[&_svg]:size-4";
-const COARSE_POINTER_OVERFLOW_ACTION_CLASS = "pointer-coarse:hidden";
-const COARSE_POINTER_OVERFLOW_TRIGGER_CLASS =
-  "hidden size-7 cursor-pointer items-center justify-center rounded-md text-muted-foreground hover:text-foreground data-[state=open]:bg-state-active data-[state=open]:text-foreground pointer-coarse:inline-flex pointer-coarse:[&_svg]:size-4";
+const TOUCH_INLINE_ACTION_CLASS =
+  "pointer-coarse:size-7 pointer-coarse:opacity-100 pointer-coarse:disabled:opacity-40 pointer-coarse:[&_svg]:size-4 [@media(hover:none)]:size-7 [@media(hover:none)]:opacity-100 [@media(hover:none)]:disabled:opacity-40 [@media(hover:none)]:[&_svg]:size-4";
+const TOUCH_OVERFLOW_ACTION_CLASS =
+  "pointer-coarse:hidden [@media(hover:none)]:hidden";
+const TOUCH_OVERFLOW_TRIGGER_CLASS =
+  "hidden size-7 cursor-pointer items-center justify-center rounded-md text-muted-foreground hover:text-foreground data-[state=open]:bg-state-active data-[state=open]:text-foreground pointer-coarse:inline-flex pointer-coarse:[&_svg]:size-4 [@media(hover:none)]:inline-flex [@media(hover:none)]:[&_svg]:size-4";
 const ACTION_TOOLTIP_SIDE = "bottom";
 const MENU_CONTENT_WIDTH_CLASS = "max-w-[min(16rem,calc(100vw-1rem))]";
-const COARSE_POINTER_OVERFLOW_CONTENT_CLASS =
+const TOUCH_OVERFLOW_CONTENT_CLASS =
   "z-50 flex max-h-[50dvh] w-max min-w-32 max-w-[min(15rem,calc(100vw-1.5rem))] flex-col gap-0.5 overflow-y-auto rounded-md border bg-popover p-0.5 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95";
-const COARSE_POINTER_OVERFLOW_ITEM_CLASS =
+const TOUCH_OVERFLOW_ITEM_CLASS =
   "flex min-h-8 w-full cursor-pointer items-center gap-2 rounded px-2 py-1 text-left text-xs text-foreground transition-colors hover:bg-surface-recessed focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring active:bg-state-active disabled:pointer-events-none disabled:opacity-40 select-none";
 
 const ACTION_ROW_CLASS =
@@ -382,7 +384,7 @@ function MessageActionMenuItems({
 export function MessageActionBar({
   messageText,
   alignment,
-  mobileActionDisplay,
+  touchActionDisplay,
   addToChatAttachments = [],
   onAddToChat,
   onEdit,
@@ -392,17 +394,16 @@ export function MessageActionBar({
   pluginActions = [],
 }: MessageActionBarProps) {
   const isPointerCoarse = usePointerCoarse();
+  const cannotHover = useMediaQuery(HOVER_NONE_QUERY);
   const hasCopy = messageText.length > 0;
   const hasAddToChat =
     (hasCopy || addToChatAttachments.length > 0) && onAddToChat !== undefined;
   const [collisionBoundary, setCollisionBoundary] = useState<
     HTMLElement | undefined
   >();
-  const useCoarsePointerActionSurface = isPointerCoarse;
+  const useTouchActionSurface = isPointerCoarse || cannotHover;
   const { measureRef, width: availableWidth } = useMeasuredWidth({
-    enabled: !(
-      useCoarsePointerActionSurface && mobileActionDisplay === "overflow"
-    ),
+    enabled: !(useTouchActionSurface && touchActionDisplay === "overflow"),
   });
   const sharedColumnWidth = useContext(MessageColumnWidthContext);
   const { measureRef: measureColumnRef, width: ownColumnWidth } =
@@ -457,10 +458,10 @@ export function MessageActionBar({
     const timeoutId = window.setTimeout(() => setCopiedFromRow(false), 2000);
     return () => window.clearTimeout(timeoutId);
   }, [copiedFromRow]);
-  const coarsePointerDirectActionClass =
-    mobileActionDisplay === "inline"
-      ? COARSE_POINTER_INLINE_ACTION_CLASS
-      : COARSE_POINTER_OVERFLOW_ACTION_CLASS;
+  const touchDirectActionClass =
+    touchActionDisplay === "inline"
+      ? TOUCH_INLINE_ACTION_CLASS
+      : TOUCH_OVERFLOW_ACTION_CLASS;
   const handleAddToChat = useCallback(() => {
     if (!onAddToChat) return;
     if (addToChatAttachments.length > 0) {
@@ -546,9 +547,9 @@ export function MessageActionBar({
     alignment === "end" && BUBBLE_ALIGN_INSET_CLASS,
   );
 
-  if (useCoarsePointerActionSurface) {
+  if (useTouchActionSurface) {
     const layout =
-      mobileActionDisplay === "overflow"
+      touchActionDisplay === "overflow"
         ? { inlineCount: 0, overflowCount: actions.length }
         : computeMessageActionRowLayout({
             actionCount: actions.length,
@@ -573,7 +574,7 @@ export function MessageActionBar({
             )}
             onClick={handleExpandedRowClick}
           >
-            <CoarsePointerInlineActions
+            <TouchInlineActions
               actions={actions}
               onCopied={() => setCopiedFromRow(true)}
             />
@@ -585,7 +586,7 @@ export function MessageActionBar({
       <div ref={slotRef} className={cn(slotClass, "h-7")}>
         <div className={rowClass}>
           {layout.inlineCount > 0 ? (
-            <CoarsePointerInlineActions
+            <TouchInlineActions
               actions={actions.slice(0, layout.inlineCount)}
             />
           ) : null}
@@ -594,7 +595,7 @@ export function MessageActionBar({
               <button
                 type="button"
                 className={cn(
-                  COARSE_POINTER_OVERFLOW_TRIGGER_CLASS,
+                  TOUCH_OVERFLOW_TRIGGER_CLASS,
                   layout.inlineCount > 0 && OVERFLOW_TRIGGER_TIGHTEN_CLASS,
                 )}
                 aria-label="Message actions"
@@ -611,7 +612,7 @@ export function MessageActionBar({
                 />
               </button>
             ) : (
-              <CoarsePointerMessageOverflowPopover
+              <TouchMessageOverflowPopover
                 actions={actions.slice(layout.inlineCount)}
                 alignment={alignment}
                 triggerClassName={
@@ -645,7 +646,7 @@ export function MessageActionBar({
             <DesktopMessageAction
               key={action.key ?? action.label}
               action={action}
-              className={cn(HOVER_REVEAL_CLASS, coarsePointerDirectActionClass)}
+              className={cn(HOVER_REVEAL_CLASS, touchDirectActionClass)}
               collisionBoundary={collisionBoundary}
             />
           ))}
@@ -657,7 +658,7 @@ export function MessageActionBar({
                   className={cn(
                     ACTION_BUTTON_CLASS,
                     HOVER_REVEAL_CLASS,
-                    coarsePointerDirectActionClass,
+                    touchDirectActionClass,
                     layout.inlineCount > 0 && OVERFLOW_TRIGGER_TIGHTEN_CLASS,
                     "data-[state=open]:text-foreground data-[state=open]:opacity-100",
                   )}
@@ -677,12 +678,12 @@ export function MessageActionBar({
               </DropdownMenuContent>
             </DropdownMenu>
           ) : null}
-          {mobileActionDisplay === "overflow" ? (
+          {touchActionDisplay === "overflow" ? (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <button
                   type="button"
-                  className={COARSE_POINTER_OVERFLOW_TRIGGER_CLASS}
+                  className={TOUCH_OVERFLOW_TRIGGER_CLASS}
                   aria-label="Message actions"
                   data-no-sidebar-swipe=""
                 >
@@ -704,7 +705,7 @@ export function MessageActionBar({
   );
 }
 
-function CoarsePointerInlineActions({
+function TouchInlineActions({
   actions,
   onCopied,
 }: {
@@ -720,7 +721,7 @@ function CoarsePointerInlineActions({
           className={cn(
             ACTION_BUTTON_CLASS,
             HOVER_REVEAL_CLASS,
-            COARSE_POINTER_INLINE_ACTION_CLASS,
+            TOUCH_INLINE_ACTION_CLASS,
           )}
           onClick={() => {
             void copyToClipboardWithToast(action.copyText ?? "", {
@@ -739,7 +740,7 @@ function CoarsePointerInlineActions({
           key={action.key ?? action.label}
           text={action.copyText ?? ""}
           label={action.label}
-          className={cn(HOVER_REVEAL_CLASS, COARSE_POINTER_INLINE_ACTION_CLASS)}
+          className={cn(HOVER_REVEAL_CLASS, TOUCH_INLINE_ACTION_CLASS)}
         />
       )
     ) : (
@@ -749,7 +750,7 @@ function CoarsePointerInlineActions({
         className={cn(
           ACTION_BUTTON_CLASS,
           HOVER_REVEAL_CLASS,
-          COARSE_POINTER_INLINE_ACTION_CLASS,
+          TOUCH_INLINE_ACTION_CLASS,
         )}
         onClick={action.onSelect}
         disabled={action.disabled}

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.actions.test.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.actions.test.tsx
@@ -596,7 +596,7 @@ describe("ThreadTimelineRows actions", () => {
     expect(markup).toContain("Streaming assistant response.");
     expect(markup).toContain('aria-label="Copy message"');
     expect(markup).not.toContain('aria-label="Message actions"');
-    expect(markup).toContain("max-md:pointer-coarse:opacity-100");
+    expect(markup).toContain("pointer-coarse:opacity-100");
   });
 
   it("hides assistant message actions inside delegation rows", () => {

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
@@ -357,7 +357,7 @@ interface ConversationRowProps {
 }
 
 interface ConversationRowContentProps extends ConversationRowProps {
-  mobileActionDisplay: "inline" | "overflow";
+  touchActionDisplay: "inline" | "overflow";
   streaming: boolean;
 }
 
@@ -874,7 +874,7 @@ function ConversationRow({
     <ConversationRowContent
       row={row}
       showAssistantMessageActions={showAssistantMessageActions}
-      mobileActionDisplay={
+      touchActionDisplay={
         row.id === latestActionableMessageId ? "inline" : "overflow"
       }
       streaming={
@@ -902,7 +902,7 @@ function InlineMessageEditorHost({
 const ConversationRowContent = memo(function ConversationRowContent({
   row,
   showAssistantMessageActions,
-  mobileActionDisplay,
+  touchActionDisplay,
   streaming,
 }: ConversationRowContentProps) {
   const {
@@ -1002,7 +1002,7 @@ const ConversationRowContent = memo(function ConversationRowContent({
         originKind={originKind}
         initiator={row.initiator}
         mentions={row.mentions}
-        mobileActionDisplay={mobileActionDisplay}
+        touchActionDisplay={touchActionDisplay}
         onAddToChat={onSelectionAddToChat}
         onEdit={onEdit}
         onOpenLink={onOpenLink}
@@ -1063,7 +1063,7 @@ const ConversationRowContent = memo(function ConversationRowContent({
       resolveUserAttachmentImageSrc={resolveUserAttachmentImageSrc}
       role="assistant"
       showActions={showAssistantMessageActions}
-      mobileActionDisplay={mobileActionDisplay}
+      touchActionDisplay={touchActionDisplay}
       streaming={streaming}
       text={row.text}
       threadId={row.threadId}
@@ -1218,7 +1218,7 @@ function TimelineExpandableBody({
                   resolveUserAttachmentImageSrc={resolveUserAttachmentImageSrc}
                   role="assistant"
                   showActions={false}
-                  mobileActionDisplay="overflow"
+                  touchActionDisplay="overflow"
                   streaming={delegationActive}
                   text={row.output}
                   threadId={row.threadId}

--- a/apps/app/src/components/thread/timeline/rows/AssistantMessage.stories.tsx
+++ b/apps/app/src/components/thread/timeline/rows/AssistantMessage.stories.tsx
@@ -195,7 +195,7 @@ export function Overview() {
             text={shortMessage}
             attachments={null}
             showActions={true}
-            mobileActionDisplay="inline"
+            touchActionDisplay="inline"
             streaming={false}
           />
         </TimelineStage>
@@ -213,7 +213,7 @@ export function Overview() {
             text={longMessage}
             attachments={null}
             showActions={true}
-            mobileActionDisplay="inline"
+            touchActionDisplay="inline"
             streaming={false}
           />
         </TimelineStage>
@@ -277,7 +277,7 @@ export function ActionOverflow() {
               text="Done — the migration ran cleanly on all three environments."
               attachments={null}
               showActions={true}
-              mobileActionDisplay="inline"
+              touchActionDisplay="inline"
               streaming={false}
               onAddToChat={noop}
               onFork={noop}
@@ -299,7 +299,7 @@ export function ActionOverflow() {
             text="Done — migration complete."
             attachments={null}
             showActions={true}
-            mobileActionDisplay="inline"
+            touchActionDisplay="inline"
             streaming={false}
             onAddToChat={noop}
             onFork={noop}

--- a/apps/app/src/components/ui/tab-pill.test.tsx
+++ b/apps/app/src/components/ui/tab-pill.test.tsx
@@ -134,7 +134,10 @@ describe("TabPill", () => {
     const close = screen.getByRole("button", { name: "Close side chat" });
     expect(close.classList).toContain("pointer-coarse:opacity-100");
     expect(close.classList).toContain("[@media(hover:none)]:opacity-100");
+    expect(close.classList).toContain("pointer-coarse:size-5");
+    expect(close.classList).toContain("[@media(hover:none)]:size-5");
     expect(close.classList).not.toContain("max-md:pointer-coarse:opacity-100");
+    expect(close.classList).not.toContain("max-md:pointer-coarse:size-5");
 
     const leadingVisual = screen.getByText("chat").parentElement;
     expect(leadingVisual?.classList).toContain("pointer-coarse:opacity-0");

--- a/apps/app/src/components/ui/tab-pill.test.tsx
+++ b/apps/app/src/components/ui/tab-pill.test.tsx
@@ -118,4 +118,28 @@ describe("TabPill", () => {
         .classList.contains("max-md:pointer-coarse:pl-3.5"),
     ).toBe(true);
   });
+
+  it("keeps the close affordance visible without hover at any viewport width", () => {
+    render(
+      <TabPill
+        label="Side chat"
+        leadingVisual={<span aria-hidden>chat</span>}
+        title="Side chat"
+        isActive
+        onSelect={vi.fn()}
+        closeAction={{ onClose: vi.fn(), closeLabel: "Close side chat" }}
+      />,
+    );
+
+    const close = screen.getByRole("button", { name: "Close side chat" });
+    expect(close.classList).toContain("pointer-coarse:opacity-100");
+    expect(close.classList).toContain("[@media(hover:none)]:opacity-100");
+    expect(close.classList).not.toContain("max-md:pointer-coarse:opacity-100");
+
+    const leadingVisual = screen.getByText("chat").parentElement;
+    expect(leadingVisual?.classList).toContain("pointer-coarse:opacity-0");
+    expect(leadingVisual?.classList).toContain(
+      "[@media(hover:none)]:opacity-0",
+    );
+  });
 });

--- a/apps/app/src/components/ui/tab-pill.tsx
+++ b/apps/app/src/components/ui/tab-pill.tsx
@@ -7,13 +7,14 @@ import { CONTEXT_SELECTION_SURFACE_CLASS } from "./context-selection";
 
 const TAB_PILL_DEFAULT_LABEL_MAX_WIDTH_CLASS = "max-w-[180px]";
 const TAB_PILL_AFFORDANCE_BUTTON_BASE_CLASS =
-  "inline-flex size-4 shrink-0 items-center justify-center rounded-sm hover:bg-muted-foreground/15 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none max-md:pointer-coarse:size-5";
-const TAB_PILL_AFFORDANCE_ICON_CLASS = "size-3.5 max-md:pointer-coarse:size-5";
+  "inline-flex size-4 shrink-0 items-center justify-center rounded-sm hover:bg-muted-foreground/15 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none pointer-coarse:size-5 [@media(hover:none)]:size-5";
+const TAB_PILL_AFFORDANCE_ICON_CLASS =
+  "size-3.5 pointer-coarse:size-5 [@media(hover:none)]:size-5";
 const TAB_PILL_CLOSE_BUTTON_CLASS = `pointer-events-none absolute left-1.5 top-1/2 z-10 -translate-y-1/2 ${TAB_PILL_AFFORDANCE_BUTTON_BASE_CLASS} opacity-0 hover:opacity-100 group-hover/tab-pill:pointer-events-auto group-hover/tab-pill:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100 disabled:opacity-30 pointer-coarse:pointer-events-auto pointer-coarse:opacity-100 [@media(hover:none)]:pointer-events-auto [@media(hover:none)]:opacity-100`;
 const TAB_PILL_LARGE_COARSE_POINTER_CLOSE_BUTTON_CLASS =
   "max-md:pointer-coarse:min-h-9 max-md:pointer-coarse:min-w-9";
 const TAB_PILL_LEADING_VISUAL_CLASS =
-  "inline-flex size-4 shrink-0 items-center justify-center [&_svg]:size-3.5 max-md:pointer-coarse:size-5 max-md:pointer-coarse:[&_svg]:size-5";
+  "inline-flex size-4 shrink-0 items-center justify-center [&_svg]:size-3.5 pointer-coarse:size-5 pointer-coarse:[&_svg]:size-5 [@media(hover:none)]:size-5 [@media(hover:none)]:[&_svg]:size-5";
 
 interface TabPillCloseAction {
   onClose: () => void;
@@ -67,7 +68,7 @@ export function TabPill({
         closeAction.onClose();
       }}
       className={cn(
-        `group/tab-pill relative inline-flex h-7 shrink-0 items-center rounded-md ${LIST_HOVER_TRANSITION} max-md:pointer-coarse:h-9`,
+        `group/tab-pill relative inline-flex h-7 shrink-0 items-center rounded-md ${LIST_HOVER_TRANSITION} pointer-coarse:h-9 [@media(hover:none)]:h-9`,
         COARSE_POINTER_TEXT_SM_CLASS,
         isActive
           ? cn(CONTEXT_SELECTION_SURFACE_CLASS, "text-foreground")

--- a/apps/app/src/components/ui/tab-pill.tsx
+++ b/apps/app/src/components/ui/tab-pill.tsx
@@ -9,7 +9,7 @@ const TAB_PILL_DEFAULT_LABEL_MAX_WIDTH_CLASS = "max-w-[180px]";
 const TAB_PILL_AFFORDANCE_BUTTON_BASE_CLASS =
   "inline-flex size-4 shrink-0 items-center justify-center rounded-sm hover:bg-muted-foreground/15 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none max-md:pointer-coarse:size-5";
 const TAB_PILL_AFFORDANCE_ICON_CLASS = "size-3.5 max-md:pointer-coarse:size-5";
-const TAB_PILL_CLOSE_BUTTON_CLASS = `pointer-events-none absolute left-1.5 top-1/2 z-10 -translate-y-1/2 ${TAB_PILL_AFFORDANCE_BUTTON_BASE_CLASS} opacity-0 hover:opacity-100 group-hover/tab-pill:pointer-events-auto group-hover/tab-pill:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100 disabled:opacity-30 max-md:pointer-coarse:pointer-events-auto max-md:pointer-coarse:opacity-100`;
+const TAB_PILL_CLOSE_BUTTON_CLASS = `pointer-events-none absolute left-1.5 top-1/2 z-10 -translate-y-1/2 ${TAB_PILL_AFFORDANCE_BUTTON_BASE_CLASS} opacity-0 hover:opacity-100 group-hover/tab-pill:pointer-events-auto group-hover/tab-pill:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100 disabled:opacity-30 pointer-coarse:pointer-events-auto pointer-coarse:opacity-100 [@media(hover:none)]:pointer-events-auto [@media(hover:none)]:opacity-100`;
 const TAB_PILL_LARGE_COARSE_POINTER_CLOSE_BUTTON_CLASS =
   "max-md:pointer-coarse:min-h-9 max-md:pointer-coarse:min-w-9";
 const TAB_PILL_LEADING_VISUAL_CLASS =
@@ -96,7 +96,7 @@ export function TabPill({
               TAB_PILL_LEADING_VISUAL_CLASS,
               !iconOnly && "mr-1.5",
               closeAction
-                ? "group-hover/tab-pill:opacity-0 tab-pill-close-focus-visible:opacity-0 max-md:pointer-coarse:opacity-0"
+                ? "group-hover/tab-pill:opacity-0 tab-pill-close-focus-visible:opacity-0 pointer-coarse:opacity-0 [@media(hover:none)]:opacity-0"
                 : null,
             )}
           >

--- a/apps/app/src/components/ui/theme.css
+++ b/apps/app/src/components/ui/theme.css
@@ -329,6 +329,22 @@
     opacity: 0;
   }
 
+  @media (min-width: 768px) and (hover: none),
+    (min-width: 768px) and (pointer: coarse) {
+    .bb-sidebar-hover-actions-row .bb-sidebar-hover-actions {
+      pointer-events: auto;
+      opacity: 1;
+    }
+
+    .bb-sidebar-hover-actions-row .bb-sidebar-hover-actions-inset {
+      padding-right: 1.5rem;
+    }
+
+    .bb-sidebar-hover-actions-row .bb-sidebar-hover-actions-fade {
+      opacity: 0;
+    }
+  }
+
   @media (max-width: 767px) and (pointer: coarse) {
     /* The overlay is hidden on coarse phones, so no room is reserved. */
     .bb-sidebar-hover-actions-row .bb-sidebar-hover-actions-inset {

--- a/apps/app/src/components/ui/theme.test.ts
+++ b/apps/app/src/components/ui/theme.test.ts
@@ -115,6 +115,21 @@ function contrastRatio(foreground: OklchColor, background: OklchColor): number {
 }
 
 describe("theme.css neutral ramp", () => {
+  it("keeps sidebar hover actions available on wide non-hover pointers", () => {
+    expect(css).toContain(
+      "@media (min-width: 768px) and (hover: none),\n    (min-width: 768px) and (pointer: coarse)",
+    );
+    expect(css).toMatch(
+      /\.bb-sidebar-hover-actions-row \.bb-sidebar-hover-actions\s*\{\s*pointer-events: auto;\s*opacity: 1;/s,
+    );
+    expect(css).toMatch(
+      /\.bb-sidebar-hover-actions-row \.bb-sidebar-hover-actions-inset\s*\{\s*padding-right: 1\.5rem;/s,
+    );
+    expect(css).toMatch(
+      /\.bb-sidebar-hover-actions-row \.bb-sidebar-hover-actions-fade\s*\{\s*opacity: 0;/s,
+    );
+  });
+
   it("backs selected sticky sidebar rows with an opaque sidebar layer", () => {
     const rule = css.match(
       /\[data-sidebar-sticky-tier\]\.bb-sidebar-selected-row\s*\{([^}]*)\}/s,

--- a/packages/shared-ui/src/components/ui/hooks/use-media-query.ts
+++ b/packages/shared-ui/src/components/ui/hooks/use-media-query.ts
@@ -1,6 +1,7 @@
 import { useSyncExternalStore } from "react";
 
 export const DARK_COLOR_SCHEME_QUERY = "(prefers-color-scheme: dark)";
+export const HOVER_NONE_QUERY = "(hover: none)";
 export const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
 
 type MediaQueryRef = {


### PR DESCRIPTION
## Human comments

Using `bb` on a 13" Boox Note Max tablet these days, which is pretty awesome. There are a few areas where I'm unable to perform commands in the UI due to lack of a mouse, though. This PR fixes that.

## What was wrong

Several tab and message actions were revealed only on hover. The touch fallback was also restricted to compact viewport widths, leaving coarse-pointer tablets at desktop widths without a reliable way to close panel tabs or access message actions.

## What changed

Tab close buttons now remain visible whenever the device reports a coarse pointer or no hover capability, regardless of viewport width. Message action bars likewise select their touch-friendly inline or overflow surface from pointer capability instead of combining it with the compact viewport breakpoint.

The affected tests now cover wide coarse-pointer message actions and width-independent tab close affordances. This is an app-only change with no protocol, CLI, or guide changes.

## How you verified

- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run test --filter=@bb/app --force`
  - 442 test files passed
  - 3,495 tests passed; 3 skipped
- `pnpm exec oxfmt --check` on all five changed files
- `git diff --check upstream/main...HEAD`

> AGENT GENERATED