### PR TITLE
Keep model picker settings visible

### DIFF
--- a/apps/app/src/components/pickers/ModelReasoningPicker.test.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.test.tsx
@@ -511,7 +511,7 @@ describe("ModelReasoningPicker", () => {
     const models = screen.getByRole("listbox", { name: "Models" });
     expect(scrollers[0]).toBe(models);
     expect(models.className).toContain("overscroll-contain");
-    expect(models.className).not.toContain("max-h-");
+    expect(models.className).toContain("max-h-64");
     expect(models.contains(screen.getByText("High"))).toBe(false);
   });
 

--- a/apps/app/src/components/pickers/ModelReasoningPicker.test.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.test.tsx
@@ -489,7 +489,7 @@ describe("ModelReasoningPicker", () => {
     ).toBe("");
   });
 
-  it("scrolls the desktop models and reasoning rows as one region", () => {
+  it("caps the desktop picker and scrolls only the model list", () => {
     renderPicker({ modelOptions: manyCodexModels });
 
     fireEvent.click(
@@ -498,8 +498,9 @@ describe("ModelReasoningPicker", () => {
 
     const menu = screen.getByRole("dialog");
     expect(menu.className).toContain(
-      "max-h-[var(--radix-popover-content-available-height)]",
+      "max-h-[min(var(--radix-popover-content-available-height),calc(100dvh-0.5rem))]",
     );
+    expect(menu.className).toContain("overflow-hidden");
 
     const scrollers = [
       ...(menu.className.includes("overflow-y-auto") ? [menu] : []),
@@ -507,15 +508,11 @@ describe("ModelReasoningPicker", () => {
     ];
     expect(scrollers).toHaveLength(1);
 
-    const body = scrollers[0];
-    expect(body.className).toContain("overscroll-contain");
-    expect(body.contains(screen.getByRole("listbox", { name: "Models" }))).toBe(
-      true,
-    );
-    expect(body.contains(screen.getByText("High"))).toBe(true);
-
     const models = screen.getByRole("listbox", { name: "Models" });
+    expect(scrollers[0]).toBe(models);
+    expect(models.className).toContain("overscroll-contain");
     expect(models.className).not.toContain("max-h-");
+    expect(models.contains(screen.getByText("High"))).toBe(false);
   });
 
   it("leaves compact drawer height and scrolling to the responsive shell", async () => {
@@ -525,9 +522,7 @@ describe("ModelReasoningPicker", () => {
       screen.getByRole("button", { name: "Provider, model and reasoning" }),
     );
 
-    expect(screen.getByRole("dialog").className).not.toContain(
-      "max-h-[var(--radix-popover-content-available-height)]",
-    );
+    expect(screen.getByRole("dialog").className).not.toContain("100dvh");
     expect(
       (await screen.findByRole("listbox", { name: "Models" })).className,
     ).not.toContain("max-h-");

--- a/apps/app/src/components/pickers/ModelReasoningPicker.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.tsx
@@ -970,7 +970,7 @@ export function ModelReasoningPicker({
                 "px-1 pb-1 pt-0",
                 isCompactViewport
                   ? "overflow-y-auto"
-                  : "min-h-0 flex-1 overflow-y-auto overscroll-contain",
+                  : "min-h-0 max-h-64 flex-1 overflow-y-auto overscroll-contain",
               )}
             >
               {isShowingModelError ? null : (

--- a/apps/app/src/components/pickers/ModelReasoningPicker.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.tsx
@@ -888,11 +888,10 @@ export function ModelReasoningPicker({
           MODEL_PICKER_MENU_WIDTH_CLASS_NAME,
           "max-md:w-full max-md:min-w-0 max-md:max-w-none",
           !isCompactViewport &&
-            "max-h-[var(--radix-popover-content-available-height)] overflow-hidden",
+            "max-h-[min(var(--radix-popover-content-available-height),calc(100dvh-0.5rem))] overflow-hidden",
         )}
       >
         <ResetBrowseStateOnContentUnmount onReset={resetBrowseState} />
-        {}
         {showProviderTabs ? (
           <div
             className={cn(
@@ -956,14 +955,12 @@ export function ModelReasoningPicker({
         ) : null}
 
         <MenuHoverProvider>
-          {}
           <div
             className={cn(
               !isCompactViewport &&
-                "min-h-0 flex-1 overflow-y-auto overscroll-contain",
+                "min-h-0 flex flex-1 flex-col overflow-hidden",
             )}
           >
-            {}
             <div
               key={activeProviderId || "no-provider"}
               role={showSearchInput ? "listbox" : undefined}
@@ -971,7 +968,9 @@ export function ModelReasoningPicker({
               aria-label={showSearchInput ? "Models" : undefined}
               className={cn(
                 "px-1 pb-1 pt-0",
-                isCompactViewport && "overflow-y-auto",
+                isCompactViewport
+                  ? "overflow-y-auto"
+                  : "min-h-0 flex-1 overflow-y-auto overscroll-contain",
               )}
             >
               {isShowingModelError ? null : (
@@ -1015,7 +1014,6 @@ export function ModelReasoningPicker({
                       />
                     );
                   })}
-                  {}
                   {!isCompactViewport &&
                   !isSearching &&
                   filteredMoreModelOptions.length > 0 ? (
@@ -1066,11 +1064,10 @@ export function ModelReasoningPicker({
               )}
             </div>
 
-            {}
             {showReasoningSection ? (
               <>
-                <div className="border-t border-border" />
-                <div className="px-1 pb-1 pt-0">
+                <div className="shrink-0 border-t border-border" />
+                <div className="shrink-0 px-1 pb-1 pt-0">
                   <MenuSectionLabel>Reasoning</MenuSectionLabel>
                   {activeReasoningOptions.map((option) => (
                     <MenuRowButton
@@ -1087,11 +1084,10 @@ export function ModelReasoningPicker({
               </>
             ) : null}
 
-            {}
             {effectiveShowFastModeToggle ? (
               <>
-                <div className="border-t border-border" />
-                <div className="p-1">
+                <div className="shrink-0 border-t border-border" />
+                <div className="shrink-0 p-1">
                   <div className="flex items-center justify-between gap-3 rounded-sm px-2 py-[0.3125rem] text-xs">
                     <span className="flex min-w-0 items-center gap-2">
                       <Icon
@@ -1113,8 +1109,8 @@ export function ModelReasoningPicker({
 
             {footerAction ? (
               <>
-                <div className="border-t border-border" />
-                <div className="p-1">
+                <div className="shrink-0 border-t border-border" />
+                <div className="shrink-0 p-1">
                   <MenuActionButton
                     label={footerAction.label}
                     iconName={footerAction.iconName ?? "MessageSquarePlus"}


### PR DESCRIPTION
## Human comments

## What was wrong

PR #2310 gave the desktop model picker one shared scroll area to remove a nested-scroll failure. That fix also placed Reasoning, Fast mode, and the footer after the complete model catalog. Providers with long catalogs required users to reach the list end before they could change these settings, as #2645 reports.

## What changed

`ModelReasoningPicker` now gives scroll ownership only to the desktop model list. The Reasoning, Fast mode, and footer sections remain outside that scroll area. The popover uses the smaller available height from Radix and the desktop viewport, with outer overflow hidden. The mobile drawer remains unchanged.

This change addresses the list layout in #2645. It does not change the close behavior or add favorite-model shortcuts. No wire or CLI surface changed.

## How you verified

- Updated the desktop regression test to require exactly one scroll area, owned by the model list. The test fails on the prior shared-scroll layout because that scroll area also contains Reasoning.
- Checked the picker story at 1000x520 and 1000x400. The model list scrolls, Reasoning keeps its position, and the popover stays inside the viewport.
- Ran `pnpm exec turbo run test typecheck lint build --filter=@bb/app`: 442 test files passed with 3,493 tests passed and three skipped.
- Ran the focused picker test again: 28 tests passed.

Addresses #2645

> AGENT GENERATED
