### PR TITLE
Default Add Project to this machine and flag duplicate folders

### DIFF
--- a/apps/app/src/components/dialogs/ProjectPathDialog.test.tsx
+++ b/apps/app/src/components/dialogs/ProjectPathDialog.test.tsx
@@ -153,3 +153,75 @@ describe("ProjectPathDialog machine selection", () => {
     expect(onSubmit).not.toHaveBeenCalled();
   });
 });
+
+describe("ProjectPathDialog duplicate folders", () => {
+  const projects = [
+    {
+      id: "proj_givecare",
+      name: "givecare",
+      sources: [{ hostId: "host_atum", path: "/home/deploy/repos/givecare" }],
+    },
+  ];
+
+  it("names the owning project and blocks submit for a known folder", () => {
+    const onSubmit = vi.fn();
+    render(
+      <ProjectPathDialog
+        target={{ kind: "create" }}
+        platform="linux"
+        hostId={atum.id}
+        hostName={atum.name}
+        hosts={[atum]}
+        projects={projects}
+        onOpenChange={vi.fn()}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Choose folder on host_atum" }),
+    );
+
+    expect(
+      screen.getByText(/already the project "givecare"/u).textContent,
+    ).toContain("on atum");
+    expect(
+      screen
+        .getByRole("button", { name: "Add project" })
+        .hasAttribute("disabled"),
+    ).toBe(true);
+
+    fireEvent.click(screen.getByRole("button", { name: "Add project" }));
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("keeps submit enabled when another machine owns the same path", () => {
+    const onSubmit = vi.fn();
+    render(
+      <ProjectPathDialog
+        target={{ kind: "create" }}
+        platform="linux"
+        hostId={atum.id}
+        hostName={atum.name}
+        hosts={[atum, kunst]}
+        projects={projects}
+        onOpenChange={vi.fn()}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Machine" });
+    fireEvent.pointerDown(trigger, { button: 0 });
+    fireEvent.click(screen.getByRole("menuitem", { name: /Kunst/u }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Choose folder on host_kunst" }),
+    );
+
+    expect(screen.queryByText(/already the project/u)).toBeNull();
+    expect(
+      screen
+        .getByRole("button", { name: "Add project" })
+        .hasAttribute("disabled"),
+    ).toBe(false);
+  });
+});

--- a/apps/app/src/components/dialogs/ProjectPathDialog.tsx
+++ b/apps/app/src/components/dialogs/ProjectPathDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useState, type FormEvent } from "react";
+import { useEffect, useId, useMemo, useState, type FormEvent } from "react";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -50,6 +50,12 @@ export type ProjectPathDialogSubmitHandler = (
   hostId: string | null,
 ) => Promise<void> | void;
 
+export interface ProjectPathDialogProject {
+  id: string;
+  name: string;
+  sources: readonly { hostId: string; path: string }[];
+}
+
 interface ProjectPathDialogProps {
   target: ProjectPathDialogTarget | null;
   pending?: boolean;
@@ -57,6 +63,7 @@ interface ProjectPathDialogProps {
   hostId: string | null;
   hostName: string | null;
   hosts?: readonly Host[];
+  projects?: readonly ProjectPathDialogProject[];
   onOpenChange: (open: boolean) => void;
   onSubmit: ProjectPathDialogSubmitHandler;
 }
@@ -68,6 +75,7 @@ export function ProjectPathDialog({
   hostId,
   hostName,
   hosts,
+  projects,
   onOpenChange,
   onSubmit,
 }: ProjectPathDialogProps) {
@@ -83,6 +91,7 @@ export function ProjectPathDialog({
             hostId={hostId}
             hostName={hostName}
             hosts={hosts}
+            projects={projects}
             onSubmit={onSubmit}
           />
         ) : null}
@@ -98,6 +107,7 @@ interface ProjectPathDialogContentProps {
   hostId: string | null;
   hostName: string | null;
   hosts?: readonly Host[];
+  projects?: readonly ProjectPathDialogProject[];
   onSubmit: ProjectPathDialogSubmitHandler;
 }
 
@@ -153,6 +163,7 @@ export function ProjectPathDialogContent({
   hostId,
   hostName,
   hosts,
+  projects,
   onSubmit,
 }: ProjectPathDialogContentProps) {
   const inputId = useId();
@@ -199,6 +210,20 @@ export function ProjectPathDialogContent({
   const derivedProjectName = selectedPath
     ? deriveProjectNameFromPath(selectedPath)
     : "";
+  const duplicateProject = useMemo(() => {
+    if (target.kind !== "create" || !selectedHostId || !selectedPath) {
+      return null;
+    }
+    return (
+      projects?.find((project) =>
+        project.sources.some(
+          (source) =>
+            source.hostId === selectedHostId &&
+            normalizeProjectPathInput(source.path) === selectedPath,
+        ),
+      ) ?? null
+    );
+  }, [projects, selectedHostId, selectedPath, target.kind]);
 
   useEffect(() => {
     setValidationMessage(null);
@@ -338,7 +363,8 @@ export function ProjectPathDialogContent({
           />
         )}
         {(derivedProjectName && target.kind === "create") ||
-        validationMessage ? (
+        validationMessage ||
+        duplicateProject ? (
           <div className="space-y-1">
             {target.kind === "create" && derivedProjectName ? (
               <p className="flex min-w-0 gap-1 text-sm text-muted-foreground">
@@ -351,6 +377,13 @@ export function ProjectPathDialogContent({
             {validationMessage ? (
               <p className="text-sm text-destructive">{validationMessage}</p>
             ) : null}
+            {duplicateProject ? (
+              <p className="text-sm text-destructive">
+                {`This folder is already the project "${duplicateProject.name}"${
+                  selectedHostName ? ` on ${selectedHostName}` : ""
+                }. Open that project instead of adding the folder again.`}
+              </p>
+            ) : null}
           </div>
         ) : null}
         <DialogFooter>
@@ -360,7 +393,8 @@ export function ProjectPathDialogContent({
               pending ||
               !selectedPath ||
               !selectedHostConnected ||
-              noMachineAvailable
+              noMachineAvailable ||
+              duplicateProject !== null
             }
           >
             {getDialogSubmitLabel(target.kind)}

--- a/apps/app/src/components/layout/AppLayout.tsx
+++ b/apps/app/src/components/layout/AppLayout.tsx
@@ -793,6 +793,7 @@ export function AppLayout({ children }: AppLayoutProps) {
             hostId={quickCreateProject.hostId}
             hostName={quickCreateProject.hostName}
             hosts={quickCreateProject.hosts}
+            projects={quickCreateProject.projects}
             onOpenChange={quickCreateProject.projectPathDialog.onOpenChange}
             onSubmit={quickCreateProject.submitProjectPath}
           />

--- a/apps/app/src/hooks/useLocalPathPicker.test.tsx
+++ b/apps/app/src/hooks/useLocalPathPicker.test.tsx
@@ -8,6 +8,8 @@ import { useLocalPathPicker } from "./useLocalPathPicker";
 const mocks = vi.hoisted(() => ({
   hosts: undefined as Host[] | undefined,
   isLoadingHosts: false,
+  localDaemonHostId: "host_atum" as string | null,
+  localHostId: "host_atum" as string | null,
   pickFolder: vi.fn(),
   primaryHost: null as Host | null,
   supportsNativeFolderPicker: true,
@@ -15,12 +17,13 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("@/hooks/useHostDaemon", () => ({
   useHostDaemon: () => ({
-    localDaemonHostId: "host_atum",
-    localHostId: "host_atum",
+    localDaemonHostId: mocks.localDaemonHostId,
+    localHostId: mocks.localHostId,
     hasDaemon: true,
     supportsNativeFolderPicker: mocks.supportsNativeFolderPicker,
     platform: "linux",
-    isLocalDaemonHost: (hostId: string | null) => hostId === "host_atum",
+    isLocalDaemonHost: (hostId: string | null) =>
+      hostId !== null && hostId === mocks.localDaemonHostId,
   }),
 }));
 
@@ -58,12 +61,69 @@ beforeEach(() => {
   mocks.supportsNativeFolderPicker = true;
   mocks.hosts = [atum];
   mocks.isLoadingHosts = false;
+  mocks.localDaemonHostId = "host_atum";
+  mocks.localHostId = "host_atum";
   mocks.pickFolder.mockResolvedValue({ path: "/home/me/repo" });
 });
 
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+});
+
+describe("usePathPickerHost", () => {
+  it("targets this machine when its daemon is enrolled and connected", () => {
+    const thoth = host("host_thoth", "Thoth");
+    mocks.primaryHost = thoth;
+    mocks.hosts = [thoth, atum];
+
+    const { result } = renderHook(() =>
+      useLocalPathPicker({ isPending: false, submit: vi.fn() }),
+    );
+
+    expect(result.current.hostId).toBe("host_atum");
+    expect(result.current.hostName).toBe("atum");
+  });
+
+  it("falls back to the primary host when this machine is enrolled elsewhere", () => {
+    const thoth = host("host_thoth", "Thoth");
+    mocks.primaryHost = thoth;
+    mocks.hosts = [thoth];
+    mocks.localDaemonHostId = "host_elsewhere";
+    mocks.localHostId = "host_elsewhere";
+
+    const { result } = renderHook(() =>
+      useLocalPathPicker({ isPending: false, submit: vi.fn() }),
+    );
+
+    expect(result.current.hostId).toBe("host_thoth");
+  });
+
+  it("falls back to the primary host when this machine is offline on the server", () => {
+    const thoth = host("host_thoth", "Thoth");
+    mocks.primaryHost = thoth;
+    mocks.hosts = [thoth, host("host_atum", "atum", "disconnected")];
+
+    const { result } = renderHook(() =>
+      useLocalPathPicker({ isPending: false, submit: vi.fn() }),
+    );
+
+    expect(result.current.hostId).toBe("host_thoth");
+  });
+
+  it("falls back to the primary host with no local daemon", () => {
+    const thoth = host("host_thoth", "Thoth");
+    mocks.primaryHost = thoth;
+    mocks.hosts = [thoth, atum];
+    mocks.localDaemonHostId = null;
+    mocks.localHostId = null;
+
+    const { result } = renderHook(() =>
+      useLocalPathPicker({ isPending: false, submit: vi.fn() }),
+    );
+
+    expect(result.current.hostId).toBe("host_thoth");
+  });
 });
 
 describe("useLocalPathPicker", () => {

--- a/apps/app/src/hooks/useLocalPathPicker.tsx
+++ b/apps/app/src/hooks/useLocalPathPicker.tsx
@@ -41,14 +41,24 @@ interface PathPickerHost {
 }
 
 export function usePathPickerHost(): PathPickerHost {
-  const { localDaemonHostId, supportsNativeFolderPicker } = useHostDaemon();
+  const { localDaemonHostId, localHostId, supportsNativeFolderPicker } =
+    useHostDaemon();
+  const hostsQuery = useHosts();
   const primaryHost = usePrimaryHost();
 
+  const connectedLocalHostId =
+    localHostId !== null &&
+    (hostsQuery.data ?? []).some(
+      (host) => host.id === localHostId && host.status === "connected",
+    )
+      ? localHostId
+      : null;
   const connectedPrimaryHostId =
     primaryHost?.status === "connected" ? primaryHost.id : null;
-  const hostId = connectedPrimaryHostId ?? localDaemonHostId;
+  const hostId =
+    connectedLocalHostId ?? connectedPrimaryHostId ?? localDaemonHostId;
   const hostName =
-    primaryHost && primaryHost.id === hostId ? primaryHost.name : null;
+    hostsQuery.data?.find((host) => host.id === hostId)?.name ?? null;
   const canUseNativeFolderPicker =
     supportsNativeFolderPicker &&
     localDaemonHostId !== null &&

--- a/apps/app/src/hooks/useQuickCreateProject.test.tsx
+++ b/apps/app/src/hooks/useQuickCreateProject.test.tsx
@@ -16,6 +16,15 @@ const mocks = vi.hoisted(() => ({
   openPathEntry: vi.fn(),
   openPicker: vi.fn(),
   setRootComposeProjectId: vi.fn(),
+  sidebarNavigation: undefined as
+    | {
+        projects: Array<{
+          id: string;
+          name: string;
+          sources: Array<{ hostId: string; path: string }>;
+        }>;
+      }
+    | undefined,
 }));
 
 vi.mock("react-router-dom", () => ({
@@ -29,6 +38,10 @@ vi.mock("@/hooks/mutations/project-mutations", () => ({
 
 vi.mock("@/hooks/queries/host-queries", () => ({
   useHosts: () => ({ data: mocks.hosts, isPending: mocks.isLoadingHosts }),
+}));
+
+vi.mock("@/hooks/queries/sidebar-navigation-query", () => ({
+  useSidebarNavigation: () => ({ data: mocks.sidebarNavigation }),
 }));
 
 vi.mock("@/hooks/useLocalPathPicker", () => ({
@@ -75,6 +88,7 @@ function host(
 beforeEach(() => {
   mocks.hosts = [host("host_atum", "atum")];
   mocks.isLoadingHosts = false;
+  mocks.sidebarNavigation = undefined;
 });
 
 afterEach(() => {
@@ -98,6 +112,27 @@ describe("useQuickCreateProject", () => {
     expect(result.current.hosts.map((item) => item.id)).toEqual([
       "host_atum",
       "host_thoth",
+    ]);
+  });
+
+  it("exposes project local-path sources for duplicate-folder detection", () => {
+    mocks.sidebarNavigation = {
+      projects: [
+        {
+          id: "proj_givecare",
+          name: "givecare",
+          sources: [{ hostId: "host_atum", path: "/home/deploy/repos/givecare" }],
+        },
+      ],
+    };
+    const { result } = renderHook(() => useQuickCreateProject());
+
+    expect(result.current.projects).toEqual([
+      {
+        id: "proj_givecare",
+        name: "givecare",
+        sources: [{ hostId: "host_atum", path: "/home/deploy/repos/givecare" }],
+      },
     ]);
   });
 });

--- a/apps/app/src/hooks/useQuickCreateProject.tsx
+++ b/apps/app/src/hooks/useQuickCreateProject.tsx
@@ -10,6 +10,7 @@ import { deriveProjectNameFromPath, type Host } from "@bb/domain";
 import type { HostPlatform } from "@bb/host-daemon-contract";
 import { useCreateProject } from "@/hooks/mutations/project-mutations";
 import { useHosts } from "@/hooks/queries/host-queries";
+import { useSidebarNavigation } from "@/hooks/queries/sidebar-navigation-query";
 import {
   useLocalPathPicker,
   type LocalPathSubmitParams,
@@ -20,6 +21,7 @@ import {
 } from "@/lib/route-paths";
 import { useSetRootComposeProjectId } from "@/lib/root-compose-selection";
 import type {
+  ProjectPathDialogProject,
   ProjectPathDialogSubmitHandler,
   ProjectPathDialogTarget,
 } from "@/components/dialogs/ProjectPathDialog";
@@ -38,6 +40,7 @@ interface QuickCreateProjectController {
   hostId: string | null;
   hostName: string | null;
   hosts: readonly Host[];
+  projects: readonly ProjectPathDialogProject[];
   projectPathDialog: QuickCreateProjectDialogState;
   submitProjectPath: ProjectPathDialogSubmitHandler;
 }
@@ -50,6 +53,19 @@ export function useQuickCreateProject(): QuickCreateProjectController {
   const { mutate, isPending } = useCreateProject();
   const hostsQuery = useHosts();
   const hosts = hostsQuery.data ?? EMPTY_HOSTS;
+  const sidebarNavigationQuery = useSidebarNavigation();
+  const projects = useMemo<readonly ProjectPathDialogProject[]>(
+    () =>
+      (sidebarNavigationQuery.data?.projects ?? []).map((project) => ({
+        id: project.id,
+        name: project.name,
+        sources: project.sources.map((source) => ({
+          hostId: source.hostId,
+          path: source.path,
+        })),
+      })),
+    [sidebarNavigationQuery.data],
+  );
   const navigate = useNavigate();
   const location = useLocation();
   const setRootComposeProjectId = useSetRootComposeProjectId();
@@ -88,7 +104,6 @@ export function useQuickCreateProject(): QuickCreateProjectController {
   const openCreateDialog = useCallback(() => {
     controller.openPathEntry({ kind: "create" });
   }, [controller]);
-
   return useMemo(
     () => ({
       isAvailable: controller.isAvailable,
@@ -98,10 +113,11 @@ export function useQuickCreateProject(): QuickCreateProjectController {
       hostId: controller.hostId,
       hostName: controller.hostName,
       hosts,
+      projects,
       projectPathDialog: controller.projectPathDialog,
       submitProjectPath: controller.submitProjectPath,
     }),
-    [controller, hosts, isPending, openCreateDialog],
+    [controller, hosts, isPending, openCreateDialog, projects],
   );
 }
 


### PR DESCRIPTION
## Human comments

## What was wrong

On a server with several enrolled machines, the Add Project dialog's
machine dropdown always defaulted to the server's primary host
(`usePathPickerHost` resolved `connectedPrimaryHostId ?? localDaemonHostId`),
even when the app was running on a secondary machine whose daemon bb had
already detected. Submitting with that default bound the new project to
the primary machine's checkout, and when the chosen path matched an
existing project's `(host, path)` source, `POST /projects` deduped by
returning the existing project with `201` — the dialog closed and the
app navigated to a different project with no feedback. From the second
machine this compounds into "I cannot create a project; it always
defaults to the last project on another machine".

## What changed

- `apps/app/src/hooks/useLocalPathPicker.tsx` — `usePathPickerHost` now
  prefers the machine this app runs on when its daemon is enrolled and
  connected. The daemon-reported host id is cross-checked against the
  server's host list, so a daemon enrolled on a different server cannot
  hijack the default; the primary host and the raw local daemon id
  remain the fallbacks, keeping the single-machine and
  plain-remote-browser behavior unchanged.
- `apps/app/src/components/dialogs/ProjectPathDialog.tsx` — the create
  flow accepts the known projects (id, name, local-path sources) and,
  when the selected folder on the selected machine already belongs to a
  project, shows `This folder is already the project "<name>" on
  <machine>.` and disables submit, replacing the silent dedupe redirect.
- `apps/app/src/hooks/useQuickCreateProject.tsx` — derives that project
  list from the sidebar bootstrap and exposes it on the controller;
  `AppLayout` passes it to the dialog. No wire or contract changes.

## How you verified

- New tests: `usePathPickerHost` targets this machine when its daemon is
  enrolled and connected, and falls back to the primary host when the
  daemon is enrolled elsewhere, offline on the server, or absent;
  `ProjectPathDialog` names the owning project and blocks submit for a
  known folder and stays enabled when another machine owns the same
  path; `useQuickCreateProject` exposes project sources for the check.
- `pnpm exec turbo run typecheck --filter=@bb/app` passes.
- `vitest run` over the seven touched/consuming test files: 45 passed.
- Manual: launched the dev app (`scripts/bb-dev-app current`), seeded a
  project at a local path, and drove the dialog in a real browser —
  selecting that folder shows the notice and greys out Add project;
  selecting a different folder creates the project normally.

Fixes #

> AGENT GENERATED