### PR TITLE
Archive workflow worker threads when retention deletes their run

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -820,7 +820,7 @@ settings accept base-10 integer strings through Extensions → Plugins or
 | `maxConcurrentAgents`  |        `8` |            `1`–`64` | Concurrent agent calls within one run.                 |
 | `maxAgentCalls`        |      `100` |          `1`–`1000` | Total agent calls within one run.                      |
 | `totalRunTimeoutMs`    | `86400000` | `60000`–`604800000` | Maximum total run duration in milliseconds.            |
-| `retentionDays`        |       `30` |          `1`–`3650` | Days to retain completed workflow data.                |
+| `retentionDays`        |        `7` |          `1`–`3650` | Days to retain completed workflow data.                |
 | `maxNotificationBytes` |    `16384` |     `1024`–`262144` | Maximum UTF-8 size of a completion notification.       |
 
 The five settings other than `maxActiveRuns` are snapshotted into each new run.

--- a/packages/templates/src/templates/bb-guide-plugins.md
+++ b/packages/templates/src/templates/bb-guide-plugins.md
@@ -71,7 +71,7 @@ Commands must run from a BB project thread. Workflows has six plugin
 settings, configurable with `bb plugin config workflows set <key> <value>`:
 `maxActiveRuns` (default 4, range 1–32), `maxConcurrentAgents` (8, 1–64),
 `maxAgentCalls` (100, 1–1000), `totalRunTimeoutMs` (86400000, 60000–604800000),
-`retentionDays` (30, 1–3650), and `maxNotificationBytes` (16384,
+`retentionDays` (7, 1–3650), and `maxNotificationBytes` (16384,
 1024–262144). `maxActiveRuns` applies live; the other five are snapshotted for
 each new run. Settings changes do not require a plugin reload.
 

--- a/plugins/workflows/README.md
+++ b/plugins/workflows/README.md
@@ -106,7 +106,9 @@ corrective retries after their initial invalid attempt.
 
 Workflow workers use BB's generic hidden-thread visibility. They remain
 out of sidebar organization without contributing unread/pending favicon
-attention. Ordinary search, prompt history,
+attention. Retention archives them when it deletes their run, because a
+stopped worker keeps its thread row and no server cascade reaches a root
+hidden thread. Ordinary search, prompt history,
 lifecycle, and direct operations remain available. Workers are root threads,
 so no parent notification applies; a hidden thread that does have a parent
 still reports its turns and blockers to it. Workflows does not create a
@@ -130,7 +132,9 @@ Workflows declares six plugin settings:
 - `maxAgentCalls` bounds the shared parent/child call count.
 - `totalRunTimeoutMs` fails a run independently of explicit cancellation.
 - `retentionDays` controls terminal-run cleanup while preserving active runs
-  and retained resume ancestors.
+  and retained resume ancestors. The sweep archives each expired run's worker
+  threads before it deletes the run, and keeps the run for a later sweep when a
+  worker does not archive.
 - `maxNotificationBytes` bounds completion messages by UTF-8 byte length.
 
 `maxActiveRuns` is live plugin-global dispatch policy: changing it immediately

--- a/plugins/workflows/src/data.test.ts
+++ b/plugins/workflows/src/data.test.ts
@@ -5,11 +5,12 @@ import {
   cancelRun,
   countCallsForRun,
   createRun,
-  deleteExpiredTerminalRuns,
+  deleteTerminalRuns,
   getCall,
   getRunRequired,
   incrementRepairAttempts,
   listCallsForRunPage,
+  listExpiredTerminalRuns,
   migrations,
   queueCallProviderRetry,
   recoverInterruptedRuns,
@@ -29,6 +30,13 @@ describe("workflow durable data", () => {
   });
 
   afterEach(() => db.close());
+
+  function sweepExpired(now: number, limit: number): number {
+    return deleteTerminalRuns(
+      db,
+      listExpiredTerminalRuns(db, now, limit).runIds,
+    );
+  }
 
   function newRun() {
     return createRun(db, {
@@ -555,7 +563,7 @@ describe("workflow durable data", () => {
        WHERE id = ?`,
     ).run(Date.now() - 3 * 86_400_000, expired.id);
 
-    expect(deleteExpiredTerminalRuns(db, Date.now(), 100)).toBe(1);
+    expect(sweepExpired(Date.now(), 100)).toBe(1);
     expect(getRunRequired(db, parent.id).id).toBe(parent.id);
     expect(getRunRequired(db, parent.id).replayBarrierIndex).toBeNull();
     expect(getRunRequired(db, retainedChild.id).status).toBe("queued");
@@ -588,7 +596,7 @@ describe("workflow durable data", () => {
        WHERE id IN (?, ?)`,
     ).run(Date.now() - 3 * 86_400_000, parent.id, child.id);
 
-    expect(deleteExpiredTerminalRuns(db, Date.now(), 100)).toBe(2);
+    expect(sweepExpired(Date.now(), 100)).toBe(2);
     expect(() => getRunRequired(db, parent.id)).toThrow("Unknown workflow run");
     expect(() => getRunRequired(db, child.id)).toThrow("Unknown workflow run");
   });

--- a/plugins/workflows/src/data.ts
+++ b/plugins/workflows/src/data.ts
@@ -797,14 +797,7 @@ export function listPendingNotificationRuns(
     .map(runRow);
 }
 
-export function deleteExpiredTerminalRuns(
-  db: Db,
-  now: number,
-  limit: number,
-): number {
-  return db
-    .prepare(
-      `WITH RECURSIVE retained(id, resumed_from_run_id) AS (
+const EXPIRED_TERMINAL_RUN_IDS_SQL = `WITH RECURSIVE retained(id, resumed_from_run_id) AS (
          SELECT id, resumed_from_run_id FROM workflow_runs
          WHERE status IN ('queued', 'running')
            OR finished_at + json_extract(settings_json, '$.retentionDays') * 86400000 > ?
@@ -835,7 +828,40 @@ export function deleteExpiredTerminalRuns(
          ORDER BY MAX(depth), id
          LIMIT ?
        )
-       DELETE FROM workflow_runs WHERE id IN (SELECT id FROM expired)`,
-    )
-    .run(now, now, limit).changes;
+       SELECT id FROM expired`;
+
+export interface ExpiredTerminalRuns {
+  runIds: string[];
+  childThreadIds: string[];
+}
+
+export function listExpiredTerminalRuns(
+  db: Db,
+  now: number,
+  limit: number,
+): ExpiredTerminalRuns {
+  const runIds = (
+    db.prepare(EXPIRED_TERMINAL_RUN_IDS_SQL).all(now, now, limit) as Array<{
+      id: string;
+    }>
+  ).map((row) => row.id);
+  if (runIds.length === 0) return { runIds: [], childThreadIds: [] };
+  const placeholders = runIds.map(() => "?").join(", ");
+  const childThreadIds = (
+    db
+      .prepare(
+        `SELECT DISTINCT child_thread_id AS childThreadId FROM workflow_calls
+         WHERE run_id IN (${placeholders}) AND child_thread_id IS NOT NULL`,
+      )
+      .all(...runIds) as Array<{ childThreadId: string }>
+  ).map((row) => row.childThreadId);
+  return { runIds, childThreadIds };
+}
+
+export function deleteTerminalRuns(db: Db, runIds: readonly string[]): number {
+  if (runIds.length === 0) return 0;
+  const placeholders = runIds.map(() => "?").join(", ");
+  return db
+    .prepare(`DELETE FROM workflow_runs WHERE id IN (${placeholders})`)
+    .run(...runIds).changes;
 }

--- a/plugins/workflows/src/service-policy.test.ts
+++ b/plugins/workflows/src/service-policy.test.ts
@@ -1,9 +1,12 @@
 import { createFakePluginHost } from "@get-bb/plugin-sdk/testing";
 import { afterEach, describe, expect, it } from "vitest";
 import {
-  deleteExpiredTerminalRuns,
+  type Db,
+  deleteTerminalRuns,
   getCall,
+  getRun,
   getRunRequired,
+  listExpiredTerminalRuns,
   migrations,
 } from "./data.js";
 import plugin from "./server.js";
@@ -68,6 +71,8 @@ function setup(
   let childCount = 0;
   let originDeleted = false;
   const workers = new Map<string, WorkerState>();
+  const archived: string[] = [];
+  const archiveFailures = new Set<string>();
   const { bb, harness } = createFakePluginHost({
     pluginId: "workflows",
     sdk: {
@@ -119,6 +124,13 @@ function setup(
         },
         send: async () => ({ ok: true }),
         stop: async () => ({ ok: true }),
+        archive: async ({ threadId }) => {
+          if (archiveFailures.has(threadId)) {
+            throw new Error("Host unavailable");
+          }
+          archived.push(threadId);
+          return { ok: true } as never;
+        },
       },
       providers: {
         list: async () => [
@@ -189,11 +201,57 @@ function setup(
     service,
     workers,
     start,
+    archived,
+    failArchive: (threadId: string) => archiveFailures.add(threadId),
     childCount: () => childCount,
     deleteOrigin: () => {
       originDeleted = true;
     },
   };
+}
+
+function expiredRunWithWorkers(
+  db: Db,
+  runId: string,
+  threadIds: readonly string[],
+): string {
+  const finishedAt = Date.now() - 3 * 86_400_000;
+  db.prepare(
+    `INSERT INTO workflow_runs (
+      id, project_id, origin_thread_id, environment_id, origin_provider,
+      origin_model, origin_reasoning_level, origin_permission_mode,
+      name, source, source_hash, args_json, settings_json, status,
+      resumed_from_run_id, result_json, notification_sent, created_at,
+      started_at, finished_at
+    ) VALUES (?, 'project-test', 'origin', 'environment-1', 'codex',
+      'gpt-test', 'medium', 'full', 'sweep', 'source', ?, 'null', ?,
+      'succeeded', NULL, 'null', 1, ?, ?, ?)`,
+  ).run(
+    runId,
+    runId,
+    JSON.stringify({ ...DEFAULT_WORKFLOW_SETTINGS, retentionDays: 1 }),
+    finishedAt,
+    finishedAt,
+    finishedAt,
+  );
+  threadIds.forEach((threadId, index) => {
+    db.prepare(
+      `INSERT INTO workflow_calls (
+        id, run_id, call_index, cache_key, prompt, options_json,
+        resolved_provider, resolved_model, resolved_reasoning_level,
+        resolved_permission_mode, status, child_thread_id, created_at
+      ) VALUES (?, ?, ?, ?, 'prompt', '{}', 'codex', 'gpt-test', 'medium',
+        'full', 'succeeded', ?, ?)`,
+    ).run(
+      `${runId}-call-${index}`,
+      runId,
+      index,
+      `${runId}-key-${index}`,
+      threadId,
+      finishedAt,
+    );
+  });
+  return runId;
 }
 
 describe("workflow service policy integration", () => {
@@ -1284,6 +1342,43 @@ describe("workflow service policy integration", () => {
     await worker;
   });
 
+  it("archives worker threads before it deletes their expired run", async () => {
+    const test = setup();
+    harnesses.push(test.harness);
+    const expired = expiredRunWithWorkers(test.db, "sweep-archive", [
+      "worker-a",
+      "worker-b",
+    ]);
+
+    const controller = new AbortController();
+    const worker = test.service.runWorker(controller.signal);
+    await eventually(() => {
+      expect(test.archived).toEqual(["worker-a", "worker-b"]);
+      expect(getRun(test.db, expired)).toBeNull();
+    });
+
+    controller.abort();
+    await worker;
+  });
+
+  it("keeps an expired run when one of its workers does not archive", async () => {
+    const test = setup();
+    harnesses.push(test.harness);
+    const expired = expiredRunWithWorkers(test.db, "sweep-retry", [
+      "worker-ok",
+      "worker-broken",
+    ]);
+    test.failArchive("worker-broken");
+
+    const controller = new AbortController();
+    const worker = test.service.runWorker(controller.signal);
+    await eventually(() => expect(test.archived).toContain("worker-ok"));
+    expect(getRunRequired(test.db, expired).id).toBe(expired);
+
+    controller.abort();
+    await worker;
+  });
+
   it("deletes expired resume chains leaf-first across bounded batches", () => {
     const test = setup();
     harnesses.push(test.harness);
@@ -1316,7 +1411,12 @@ describe("workflow service policy integration", () => {
       }
     })();
 
-    expect(deleteExpiredTerminalRuns(test.db, Date.now(), 100)).toBe(100);
+    expect(
+      deleteTerminalRuns(
+        test.db,
+        listExpiredTerminalRuns(test.db, Date.now(), 100).runIds,
+      ),
+    ).toBe(100);
     expect(
       test.db
         .prepare(
@@ -1329,7 +1429,12 @@ describe("workflow service policy integration", () => {
         .prepare(`SELECT id FROM workflow_runs WHERE id = 'chain-0'`)
         .get(),
     ).toEqual({ id: "chain-0" });
-    expect(deleteExpiredTerminalRuns(test.db, Date.now(), 100)).toBe(50);
+    expect(
+      deleteTerminalRuns(
+        test.db,
+        listExpiredTerminalRuns(test.db, Date.now(), 100).runIds,
+      ),
+    ).toBe(50);
   });
 
   it("bounds UTF-8 notifications while preserving the stable run marker", async () => {

--- a/plugins/workflows/src/service.ts
+++ b/plugins/workflows/src/service.ts
@@ -15,7 +15,7 @@ import {
   claimQueuedRun,
   countCallsForRun,
   createRun,
-  deleteExpiredTerminalRuns,
+  deleteTerminalRuns,
   getCall,
   getCallByChildThread,
   getLatestRunForOriginThread,
@@ -24,6 +24,7 @@ import {
   incrementRepairAttempts,
   listCallsForRun,
   listCallsForRunPage,
+  listExpiredTerminalRuns,
   listActiveRunsForOriginThread,
   listRuns,
   listPendingNotificationRuns,
@@ -96,6 +97,7 @@ const VALUE_LIMITS = { bytes: 1024 * 1024, nodes: 100_000, depth: 128 };
 const NOTIFICATION_RETRY_BASE_MS = 1_000;
 const NOTIFICATION_RETRY_MAX_MS = 60 * 60 * 1_000;
 const PROVIDER_RETRY_DELAYS_MS = [1_000, 4_000] as const;
+const RETENTION_SWEEP_RUNS = 20;
 
 function message(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -1420,6 +1422,32 @@ export function createWorkflowService(
     }
   }
 
+  async function archiveRetiredWorker(threadId: string): Promise<boolean> {
+    try {
+      await bb.sdk.threads.archive({ threadId });
+      return true;
+    } catch (error) {
+      if (isMissingThread(error)) return true;
+      bb.log.warn(
+        `Could not archive retired workflow worker ${threadId}: ${message(error)}`,
+      );
+      return false;
+    }
+  }
+
+  async function sweepExpiredRuns(now: number): Promise<void> {
+    const expired = listExpiredTerminalRuns(db, now, RETENTION_SWEEP_RUNS);
+    if (expired.runIds.length === 0) return;
+    for (const threadId of expired.childThreadIds) {
+      if (await archiveRetiredWorker(threadId)) continue;
+      bb.log.warn(
+        `Retention kept ${expired.runIds.length} expired workflow runs until their workers archive`,
+      );
+      return;
+    }
+    deleteTerminalRuns(db, expired.runIds);
+  }
+
   async function maintenanceTick(): Promise<void> {
     const now = Date.now();
     const isolated = async (
@@ -1436,9 +1464,7 @@ export function createWorkflowService(
     };
     await isolated("reconcile-workers", reconcileRunningCalls);
     await isolated("enforce-timeouts", () => enforceTimeouts(now));
-    await isolated("retention", () => {
-      deleteExpiredTerminalRuns(db, now, 100);
-    });
+    await isolated("retention", () => sweepExpiredRuns(now));
   }
 
   async function runWorker(signal: AbortSignal): Promise<void> {

--- a/plugins/workflows/src/settings.ts
+++ b/plugins/workflows/src/settings.ts
@@ -34,7 +34,7 @@ export const WORKFLOW_SETTING_DESCRIPTORS = {
     type: "string",
     label: "Retention (days)",
     description: "Days to retain completed workflow data (1-3650).",
-    default: "30",
+    default: "7",
   },
   maxNotificationBytes: {
     type: "string",
@@ -64,7 +64,7 @@ export const DEFAULT_WORKFLOW_SETTINGS: Readonly<WorkflowSettings> =
     maxConcurrentAgents: 8,
     maxAgentCalls: 100,
     totalRunTimeoutMs: 24 * 60 * 60 * 1_000,
-    retentionDays: 30,
+    retentionDays: 7,
     maxNotificationBytes: 16 * 1_024,
   });
 


### PR DESCRIPTION
## Human comments

## What was wrong

The workflows plugin spawns every agent call as a hidden root thread and only ever calls `threads.stop` on it. Stop resolves to `stopThreadForCurrentState`, which sends an `interrupt`/`release` command to the host daemon to tear down the provider session — it never writes `archived_at` or `deleted_at`, so the thread row survives. The server's archive cascades (`archiveThreadAndHiddenSourceForks`, `archiveThreadAndChildren`) key on `parent_thread_id` and `source_thread_id`, and a workflow worker sets neither, so no cascade reached them. The retention sweep then deleted the `workflow_runs` rows that held the only pointer back to those threads, making them permanently unreachable.

On one real install this left 1,408 live hidden `workflows` threads accumulated over 40 days, none archived, all with null parent and null source.

## What changed

- `plugins/workflows/src/service.ts`: new `sweepExpiredRuns` replaces the bare delete in `maintenanceTick`. It lists each expired run's worker thread ids, archives every one via `bb.sdk.threads.archive`, then deletes the run rows. A worker that fails to archive keeps the whole batch for a later sweep — `resumed_from_run_id` has no delete cascade, so a partial chain delete would break the foreign key. A 404 counts as archived, and the server's archive route is already idempotent for an archived thread, so retries are safe. `RETENTION_SWEEP_RUNS` is 20, down from the previous 100-run batch, now that the sweep does host I/O on a one-second tick.
- `plugins/workflows/src/data.ts`: `deleteExpiredTerminalRuns` splits into `listExpiredTerminalRuns` (same CTE and leaf-first selection, now returning run ids plus their workers' thread ids) and `deleteTerminalRuns`, so the sweep can read the call rows before `ON DELETE CASCADE` removes them. The selected set and the single-statement delete are unchanged.
- `plugins/workflows/src/settings.ts`: `retentionDays` default drops from 30 to 7.
- Docs: `docs/configuration.md` settings table and `packages/templates/src/templates/bb-guide-plugins.md` (the plugin guide surface) both state the default, updated to 7. `plugins/workflows/README.md` documents the new archive step and why a stopped worker needs it.

No wire changes, so `HOST_DAEMON_PROTOCOL_VERSION` is untouched.

Note that `retentionDays` is snapshotted per run at creation, so the new default applies only to new runs; runs already on disk keep their 30-day snapshot.

## How you verified

Two new tests in `plugins/workflows/src/service-policy.test.ts`, driving the real worker loop against a fake host:

- `archives worker threads before it deletes their expired run`
- `keeps an expired run when one of its workers does not archive`

Fail-before proof: with the archive step removed from `sweepExpiredRuns` and everything else identical, both fail (`2 failed | 226 passed`). With the fix restored, `228 passed`.

```
pnpm exec turbo run typecheck test --filter=bb-plugin-workflows --force   # 228 passed
pnpm exec turbo run typecheck test --filter=@bb/templates --force         # 43 passed
```

Also `oxfmt` on the touched TypeScript, and a project-wide `rg` for the old `deleteExpiredTerminalRuns` name and for stale `retentionDays` defaults (the one remaining hit is a recorded provider transcript fixture, deliberately left as-is).

> AGENT GENERATED
