### PR TITLE
Stop desktop smokes from depending on runner sandbox policy

### DIFF
--- a/apps/desktop/scripts/packaged-app-launch.d.mts
+++ b/apps/desktop/scripts/packaged-app-launch.d.mts
@@ -1,0 +1,10 @@
+export const LINUX_DISABLE_SANDBOX_ARGUMENT: "--no-sandbox";
+
+export interface PackagedAppLaunchArgumentsArgs {
+  platform: NodeJS.Platform;
+  userDataDir: string;
+}
+
+export function createPackagedAppLaunchArguments(
+  args: PackagedAppLaunchArgumentsArgs,
+): string[];

--- a/apps/desktop/scripts/packaged-app-launch.mjs
+++ b/apps/desktop/scripts/packaged-app-launch.mjs
@@ -1,0 +1,7 @@
+export const LINUX_DISABLE_SANDBOX_ARGUMENT = "--no-sandbox";
+
+export function createPackagedAppLaunchArguments({ platform, userDataDir }) {
+  const sandboxArguments =
+    platform === "linux" ? [LINUX_DISABLE_SANDBOX_ARGUMENT] : [];
+  return [...sandboxArguments, `--user-data-dir=${userDataDir}`];
+}

--- a/apps/desktop/scripts/smoke-linux-appimage-lifecycle.mjs
+++ b/apps/desktop/scripts/smoke-linux-appimage-lifecycle.mjs
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
+import { createPackagedAppLaunchArguments } from "./packaged-app-launch.mjs";
 
 const execFileAsync = promisify(execFile);
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
@@ -12,6 +13,7 @@ const desktopPackageRoot = resolve(scriptDirectory, "..");
 const releaseDir = join(desktopPackageRoot, "release");
 const startupTimeoutMs = 60_000;
 const exitTimeoutMs = 10_000;
+const outputFlushTimeoutMs = 2_000;
 const pollIntervalMs = 100;
 const maxCapturedOutputCharacters = 20_000;
 
@@ -440,21 +442,32 @@ async function smokeLinuxAppImageLifecycle() {
     delete childEnv.BB_DESKTOP_NODE_EXEC_PATH;
     delete childEnv.ELECTRON_RUN_AS_NODE;
 
-    child = spawn(appImage, [`--user-data-dir=${userDataDir}`], {
-      detached: true,
-      env: childEnv,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+    child = spawn(
+      appImage,
+      createPackagedAppLaunchArguments({
+        platform: process.platform,
+        userDataDir,
+      }),
+      {
+        detached: true,
+        env: childEnv,
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
     if (child.pid === undefined) {
       throw new Error("The AppImage process did not expose a PID");
     }
     child.stdout.on("data", (chunk) => appendOutput(stdout, chunk));
     child.stderr.on("data", (chunk) => appendOutput(stderr, chunk));
+    const childClosed = new Promise((resolveClosed) => {
+      child.once("close", resolveClosed);
+    });
 
     runtime = await waitFor({
       describe: "the desktop-owned runtime PID file",
       predicate: async () => {
         if (child.exitCode !== null || child.signalCode !== null) {
+          await Promise.race([childClosed, sleep(outputFlushTimeoutMs)]);
           throw new Error(
             `AppImage exited before its runtime started: code=${String(
               child.exitCode,

--- a/apps/desktop/scripts/smoke-packaged-app.mjs
+++ b/apps/desktop/scripts/smoke-packaged-app.mjs
@@ -8,6 +8,7 @@ import {
   createDesktopReleaseConfig,
   resolveDesktopReleaseChannel,
 } from "./desktop-release-channel.mjs";
+import { createPackagedAppLaunchArguments } from "./packaged-app-launch.mjs";
 import { resolvePackagedAppBinary } from "./packaged-app-paths.mjs";
 
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
@@ -17,6 +18,7 @@ const releaseChannel = resolveDesktopReleaseChannel(process.env);
 const releaseConfig = createDesktopReleaseConfig(releaseChannel);
 const startupTimeoutMs = 20_000;
 const exitTimeoutMs = 5_000;
+const outputFlushTimeoutMs = 2_000;
 const postReadySettleMs = 300;
 const maxCapturedOutputCharacters = 20_000;
 
@@ -236,6 +238,15 @@ function formatProcessOutput({ stdout, stderr }) {
     .join("\n\n");
 }
 
+async function waitForOutputFlush(child) {
+  await Promise.race([
+    new Promise((resolveClosed) => {
+      child.once("close", resolveClosed);
+    }),
+    sleep(outputFlushTimeoutMs),
+  ]);
+}
+
 async function waitForPreloadReady({ child, preloadReady, stdout, stderr }) {
   return await new Promise((resolvePromise, rejectPromise) => {
     const timeout = setTimeout(() => {
@@ -251,16 +262,18 @@ async function waitForPreloadReady({ child, preloadReady, stdout, stderr }) {
 
     const handleExit = (code, signal) => {
       cleanup();
-      rejectPromise(
-        new Error(
-          `Packaged Electron app exited before startup completed: code=${String(
-            code,
-          )} signal=${String(signal)}.\n${formatProcessOutput({
-            stdout,
-            stderr,
-          })}`,
-        ),
-      );
+      void waitForOutputFlush(child).then(() => {
+        rejectPromise(
+          new Error(
+            `Packaged Electron app exited before startup completed: code=${String(
+              code,
+            )} signal=${String(signal)}.\n${formatProcessOutput({
+              stdout,
+              stderr,
+            })}`,
+          ),
+        );
+      });
     };
     const handleError = (error) => {
       cleanup();
@@ -378,9 +391,16 @@ async function smokePackagedApp() {
   delete childEnv.BB_DESKTOP_NODE_EXEC_PATH;
   delete childEnv.ELECTRON_RUN_AS_NODE;
 
-  const child = spawn(appBinary, [`--user-data-dir=${userDataDir}`], {
-    env: childEnv,
-  });
+  const child = spawn(
+    appBinary,
+    createPackagedAppLaunchArguments({
+      platform: process.platform,
+      userDataDir,
+    }),
+    {
+      env: childEnv,
+    },
+  );
   child.stdout.on("data", (chunk) => {
     appendOutput(stdout, chunk);
   });

--- a/apps/desktop/test/packaged-app-launch.test.ts
+++ b/apps/desktop/test/packaged-app-launch.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { createPackagedAppLaunchArguments } from "../scripts/packaged-app-launch.mjs";
+
+describe("createPackagedAppLaunchArguments", () => {
+  it("disables the Chromium sandbox on Linux", () => {
+    expect(
+      createPackagedAppLaunchArguments({
+        platform: "linux",
+        userDataDir: "/tmp/smoke/user-data",
+      }),
+    ).toEqual(["--no-sandbox", "--user-data-dir=/tmp/smoke/user-data"]);
+  });
+
+  it("keeps the Chromium sandbox on macOS", () => {
+    expect(
+      createPackagedAppLaunchArguments({
+        platform: "darwin",
+        userDataDir: "/tmp/smoke/user-data",
+      }),
+    ).toEqual(["--user-data-dir=/tmp/smoke/user-data"]);
+  });
+});

--- a/plugins/provider-pi/src/bridge/catalog.test.ts
+++ b/plugins/provider-pi/src/bridge/catalog.test.ts
@@ -50,5 +50,5 @@ describe("pi catalog child generations", () => {
     ]);
     expect(second.models[0]?.isDefault).toBe(true);
     expect(readFileSync(spawnCounterPath, "utf8")).toBe("2");
-  });
+  }, 60_000);
 });


### PR DESCRIPTION
## Human comments

## What was wrong

`Smoke Linux AppImage mount lifecycle` failed on `main` about once every ten runs with `Error: AppImage exited before its runtime started: code=null signal=SIGTRAP.` and an empty output block (runs [33189247983](https://github.com/get-bb/bb/actions/runs/33189247983), [33186584144](https://github.com/get-bb/bb/actions/runs/33186584144), [33137455128](https://github.com/get-bb/bb/actions/runs/33137455128), [33100377644](https://github.com/get-bb/bb/actions/runs/33100377644)). Electron probes whether it can create an unprivileged user namespace, and falls back to the SUID sandbox helper when the kernel refuses. The `chrome-sandbox` binary inside an AppImage mount can never be root-owned with mode 4755, so Chromium calls `LOG(FATAL)`, which traps and kills the GUI about a second after launch. Whether the runner permits the namespace is the only variable, which is why the job passed most of the time. The harness hid the evidence: it read the child's captured output at the `exit` event, before the pipes flushed, so CI printed the error with no `stderr`.

## What changed

- Added `apps/desktop/scripts/packaged-app-launch.mjs` (plus a `.d.mts` declaration, following `desktop-release-channel.d.mts`). It builds the packaged-app launch arguments and adds `--no-sandbox` on Linux only. These smokes cover the AppImage mount lifecycle and the packaged startup path, not the Chromium sandbox, so the result no longer depends on runner namespace policy.
- `smoke-linux-appimage-lifecycle.mjs` and `smoke-packaged-app.mjs` now build their arguments with that helper, and both wait for stdio close (2 s maximum) before they format an early-exit error, so a future crash prints its reason.
- `smoke:packaged` had the identical latent failure on the release workflows (`build-desktop.yml`, `publish-bb-app.yml`), confirmed locally, and gets the same treatment.

No wire, CLI, or plugin API surface changed.

## How you verified

Local reproduction used the same condition as the flaky runner: `kernel.apparmor_restrict_unprivileged_userns=1`, which makes the failure deterministic.

| Condition | Before | After |
| --- | --- | --- |
| restriction on, `smoke:appimage-lifecycle` | `signal=SIGTRAP`, exit 1 | passed 3 of 3 |
| restriction on, `smoke:packaged` | `signal=SIGTRAP`, exit 1 | passed |
| restriction off, `smoke:appimage-lifecycle` | passed | passed |

The captured fatal, which CI never printed:

```
FATAL:sandbox/linux/suid/client/setuid_sandbox_host.cc:166] The SUID sandbox helper binary
was found, but is not configured correctly. Rather than run without sandboxing I'm aborting
now. You need to make sure that /tmp/.mount_bb-0.4yo0DSF/chrome-sandbox is owned by root
and has mode 4755.
```

Also run:

- `pnpm exec turbo run typecheck test --filter=@bb/desktop` — 38 files, 246 tests passed, including the new `test/packaged-app-launch.test.ts`.
- `pnpm exec oxfmt --check` on all five touched files — clean.

Note for maintainers, out of scope here: the shipped AppImage aborts the same way on a stock Ubuntu 23.10+ desktop, where that AppArmor restriction is the default. `scripts/run-packaged-app.mjs` (`pnpm start:linux`) has the same problem. A product fix needs an owner decision, such as an AppArmor profile or a launcher flag.

## Second flake found while closing out

The `Tests (packages)` shard failed twice on this PR, in `plugins/provider-pi/src/bridge/catalog.test.ts` > `re-reads model scope after the catalog child restarts`, with `Test timed out in 5000ms`. That test is unrelated to this change. It arrived in #2476 and kept vitest's 5 s default, while every sibling test in that package that spawns a pi child allows 60-90 s. It took 5.8 s and 8.2 s on the 2-vCPU runner, and 1.8 s locally on 16 cores. The second commit gives it the same 60 s timeout as its siblings. `turbo run typecheck test --filter=bb-plugin-provider-pi` passes: 20 files, 116 tests.

> AGENT GENERATED
