### PR TITLE
Prioritize parent threads with children

### DIFF
--- a/apps/app/src/views/thread-detail/threadParentSelectorOptions.test.ts
+++ b/apps/app/src/views/thread-detail/threadParentSelectorOptions.test.ts
@@ -72,6 +72,40 @@ describe("thread parent selector options", () => {
     ]);
   });
 
+  it("prioritizes threads with children while preserving group order", () => {
+    const options = buildParentSelectorOptions({
+      currentThreadId: "thr_current",
+      parentThreadDisplayName: null,
+      parentThreadId: null,
+      parentThreads: [
+        makeThread({ id: "thr_leaf_new", title: "New leaf" }),
+        makeThread({
+          id: "thr_child_two",
+          parentThreadId: "thr_parent_two",
+          title: "Child two",
+        }),
+        makeThread({ id: "thr_parent_two", title: "Parent two" }),
+        makeThread({ id: "thr_parent_one", title: "Parent one" }),
+        makeThread({
+          id: "thr_child_one",
+          parentThreadId: "thr_parent_one",
+          title: "Child one",
+        }),
+        makeThread({ id: "thr_leaf_old", title: "Old leaf" }),
+      ],
+    });
+
+    expect(options).toEqual([
+      { value: "none", label: "None" },
+      { value: "thr_parent_two", label: "Parent two" },
+      { value: "thr_parent_one", label: "Parent one" },
+      { value: "thr_leaf_new", label: "New leaf" },
+      { value: "thr_child_two", label: "Child two" },
+      { value: "thr_child_one", label: "Child one" },
+      { value: "thr_leaf_old", label: "Old leaf" },
+    ]);
+  });
+
   it("excludes the current thread and descendants from parent candidates", () => {
     const options = buildParentSelectorOptions({
       currentThreadId: "thr_parent",

--- a/apps/app/src/views/thread-detail/threadParentSelectorOptions.ts
+++ b/apps/app/src/views/thread-detail/threadParentSelectorOptions.ts
@@ -98,14 +98,25 @@ export function buildParentSelectorOptions({
     parentThreadId ?? undefined,
     parentThreadDisplayName ?? "Parent thread",
   );
-  for (const parentThread of parentThreads) {
-    if (isHiddenThread(parentThread)) {
-      continue;
+  const threadIdsWithChildren = new Set<string>();
+  for (const thread of parentThreads) {
+    if (thread.parentThreadId !== null) {
+      threadIdsWithChildren.add(thread.parentThreadId);
     }
-    addOption(
-      parentThread.id,
-      parentThread.title?.trim() ? parentThread.title : "Parent thread",
-    );
+  }
+  for (const hasChildren of [true, false]) {
+    for (const parentThread of parentThreads) {
+      if (
+        isHiddenThread(parentThread) ||
+        threadIdsWithChildren.has(parentThread.id) !== hasChildren
+      ) {
+        continue;
+      }
+      addOption(
+        parentThread.id,
+        parentThread.title?.trim() ? parentThread.title : "Parent thread",
+      );
+    }
   }
 
   return options;


### PR DESCRIPTION
## Human comments

## What was wrong

The parent-thread selector preserved the raw thread-list order, so likely parent targets were mixed among leaf threads and could be harder to find.

## What changed

Collect thread IDs that currently have children, then list those threads before leaf threads in the parent selector. The partition is stable within each group, keeps `None` first, does not mutate the input list, and retains the existing hidden-thread, current-thread, descendant, and duplicate exclusions.

## How you verified

- Added a regression covering parents and leaves interleaved in the source list and asserting stable parent-first grouping.
- Rebased cleanly onto current `origin/main`.
- `pnpm exec turbo run test --filter=@bb/app --force -- --run src/views/thread-detail/threadParentSelectorOptions.test.ts` (5 tests passed; no cached tasks)
- `pnpm exec turbo run typecheck --filter=@bb/app --force`
- Targeted `oxfmt --check` and `git diff --check`

> AGENT GENERATED
