### PR TITLE
Derive shipped skill quality inventory

### DIFF
--- a/apps/server/test/skills/shipped-skills-quality.test.ts
+++ b/apps/server/test/skills/shipped-skills-quality.test.ts
@@ -1,33 +1,30 @@
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+import { listBundledPluginRegistrations } from "../../src/services/plugins/builtin-registry.js";
+import { readPluginManifest } from "../../src/services/plugins/manifest.js";
+import { resolveBuiltinSkillsRootPath } from "../../src/services/skills/builtin-skills-copy.js";
 
-const REPO_ROOT = fileURLToPath(new URL("../../../..", import.meta.url));
+function skillDirectories(
+  rootPath: string,
+): ReadonlyArray<readonly [string, string]> {
+  if (!existsSync(rootPath)) return [];
+  return readdirSync(rootPath, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => [entry.name, path.join(rootPath, entry.name)] as const);
+}
 
+const pluginManifests = await Promise.all(
+  listBundledPluginRegistrations().map((plugin) =>
+    readPluginManifest(plugin.rootDir),
+  ),
+);
 const SHIPPED_SKILLS = [
-  ["bb-cli", "apps/server/src/services/skills/builtin-skills/bb-cli"],
-  [
-    "bb-plugin-authoring",
-    "apps/server/src/services/skills/builtin-skills/bb-plugin-authoring",
-  ],
-  [
-    "skill-creator",
-    "apps/server/src/services/skills/builtin-skills/skill-creator",
-  ],
-  [
-    "submit-a-plugin",
-    "apps/server/src/services/skills/builtin-skills/submit-a-plugin",
-  ],
-  ["automations", "plugins/automations/skills/automations"],
-  ["share-server-links", "plugins/connect/skills/share-server-links"],
-  ["docs", "plugins/docs/skills/docs"],
-  ["inline-vis", "plugins/inline-vis/skills/inline-vis"],
-  ["memory", "plugins/memory/skills/memory"],
-  ["secrets", "plugins/secrets/skills/secrets"],
-  ["tasks", "plugins/tasks/skills/tasks"],
-  ["workflows", "plugins/workflows/skills/workflows"],
-] as const;
+  ...skillDirectories(resolveBuiltinSkillsRootPath()),
+  ...pluginManifests.flatMap((manifest) =>
+    manifest.skillsRootPaths.flatMap(skillDirectories),
+  ),
+].sort(([left], [right]) => left.localeCompare(right));
 
 function lineCount(text: string): number {
   return text.trimEnd().split("\n").length;
@@ -36,8 +33,7 @@ function lineCount(text: string): number {
 describe("shipped skills", () => {
   it.each(SHIPPED_SKILLS)(
     "%s uses concise frontmatter and one-level progressive disclosure",
-    (expectedName, relativeRoot) => {
-      const skillRoot = path.join(REPO_ROOT, relativeRoot);
+    (expectedName, skillRoot) => {
       const skill = readFileSync(path.join(skillRoot, "SKILL.md"), "utf8");
       const frontmatter = skill.match(
         /^---\nname: ([^\n]+)\ndescription: ([^\n]+)\n---\n/,


### PR DESCRIPTION
## Human comments

## What was wrong

The shipped-skill quality test hard-coded twelve skill directories. A new skill added under an already packaged bundled-plugin skill root would therefore ship without joining the guard for trigger wording, line count, and reference routing.

## What changed

- Derive built-in skill cases from the authoritative built-in skills root.
- Derive bundled-plugin skill cases from the bundled-plugin registry and each validated manifest's declared skill roots.
- Discover every immediate skill directory and sort the resulting cases for deterministic output.

## How you verified

- Added a temporary invalid thirteenth skill and confirmed the quality test failed specifically for it, then removed the probe.
- `pnpm exec turbo run test --filter=@bb/server --force -- test/skills/shipped-skills-quality.test.ts test/services/plugins/plugin-manifest.test.ts test/services/plugins/builtin-plugins.test.ts` (62 tests passed)
- `pnpm exec turbo run typecheck --filter=@bb/server --force`
- `pnpm exec prettier --check apps/server/test/skills/shipped-skills-quality.test.ts`
- `git diff --check origin/main...HEAD`

> AGENT GENERATED
