### PR TITLE
Hash shipped skill inputs in test tasks

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -401,7 +401,11 @@
         "@get-bb/plugin-sdk#build:types",
         "topo"
       ],
-      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/vitest.shared.ts"]
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/apps/server/src/services/skills/builtin-skills/bb-cli/**",
+        "$TURBO_ROOT$/vitest.shared.ts"
+      ]
     },
     // Integration tests typecheck without the `source` condition, so
     // @get-bb/plugin-sdk (reached through apps/server sources) resolves to the
@@ -467,6 +471,7 @@
       ],
       "inputs": [
         "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/plugins/*/skills/**",
         "$TURBO_ROOT$/tests/scripted-echo-provider/host.ts",
         "$TURBO_ROOT$/tests/scripted-echo-provider/src/**",
         "$TURBO_ROOT$/examples/plugins/echo-provider/*.ts",


### PR DESCRIPTION
## Human comments

## What was wrong

The CLI and server test tasks read shipped skill trees outside their package roots, but those external files were absent from the tasks' Turbo inputs. A documentation-only skill change could therefore violate a coverage guard while Turbo replayed an earlier green result.

## What changed

- Add the server-owned built-in `bb-cli` skill tree to `@bb/cli#test` inputs.
- Add bundled-plugin skill trees to `@bb/server#test` inputs.
- Keep caching enabled and limit each fingerprint to the exact external tree the task reads.

## How you verified

- Before the fix, controlled invalid skill edits left both task hashes unchanged, cached runs replayed green results, and forced runs failed the intended guards.
- After the fix, the same edits changed each task hash and restoring the files restored each clean hash.
- `pnpm exec turbo run test --filter=@bb/cli --filter=@bb/server --force` (502 CLI tests and 2,072 server tests passed; one empty server snapshot suite skipped)
- A non-forced rerun reported cache hits for both `@bb/cli#test` and `@bb/server#test`.
- `pnpm exec turbo run typecheck --filter=@bb/cli --filter=@bb/server --force`
- `git diff --check origin/main...HEAD`

> AGENT GENERATED
