### PR TITLE
Contain loading skeleton in split panes

### DIFF
--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -306,7 +306,9 @@ function AppRoutes() {
           <Route
             path="*"
             element={
-              <Suspense fallback={<RouteLoadingSkeleton />}>
+              <Suspense
+                fallback={<RouteLoadingSkeleton isBoundedPane={false} />}
+              >
                 <SplitWorkspaceRoute />
               </Suspense>
             }

--- a/apps/app/src/components/ui/route-loading-skeleton.test.tsx
+++ b/apps/app/src/components/ui/route-loading-skeleton.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { RouteLoadingSkeleton } from "./route-loading-skeleton";
+
+afterEach(cleanup);
+
+describe("RouteLoadingSkeleton", () => {
+  it("bleeds through standalone page padding", () => {
+    render(<RouteLoadingSkeleton isBoundedPane={false} />);
+
+    const skeleton = screen.getByTestId("route-loading-skeleton");
+    const header = skeleton.firstElementChild;
+
+    expect(skeleton.className).toContain("-mx-4");
+    expect(skeleton.className).toContain("-mt-4");
+    expect(skeleton.className).toContain("md:-mx-5");
+    expect(skeleton.className).toContain("md:-mt-5");
+    expect(header?.className).toContain("pl-12");
+  });
+
+  it("keeps bounded-pane placeholders inside their pane", () => {
+    render(<RouteLoadingSkeleton isBoundedPane />);
+
+    const skeleton = screen.getByTestId("route-loading-skeleton");
+    const header = skeleton.firstElementChild;
+
+    expect(skeleton.className).not.toContain("-mx-4");
+    expect(skeleton.className).not.toContain("-mt-4");
+    expect(skeleton.className).not.toContain("md:-mx-5");
+    expect(skeleton.className).not.toContain("md:-mt-5");
+    expect(header?.className).toContain("px-4");
+    expect(header?.className).not.toContain("pl-12");
+  });
+});

--- a/apps/app/src/components/ui/route-loading-skeleton.tsx
+++ b/apps/app/src/components/ui/route-loading-skeleton.tsx
@@ -3,13 +3,22 @@ import { CHROME_ROW_CLASS } from "@/lib/bb-desktop";
 import { Skeleton } from "@bb/shared-ui/skeleton";
 import { cn } from "@bb/shared-ui/lib/utils";
 
-const SHELL_BLEED_CLASS =
-  "-mx-4 -mt-4 flex h-full min-h-0 flex-1 flex-col overflow-hidden md:-mx-5 md:-mt-5";
+interface RouteLoadingSkeletonProps {
+  isBoundedPane: boolean;
+}
 
-export function RouteLoadingSkeleton() {
+const SHELL_CLASS = "flex h-full min-h-0 flex-1 flex-col overflow-hidden";
+const STANDALONE_SHELL_BLEED_CLASS = "-mx-4 -mt-4 md:-mx-5 md:-mt-5";
+
+export function RouteLoadingSkeleton({
+  isBoundedPane,
+}: RouteLoadingSkeletonProps) {
   return (
     <div
-      className={SHELL_BLEED_CLASS}
+      className={cn(
+        SHELL_CLASS,
+        !isBoundedPane && STANDALONE_SHELL_BLEED_CLASS,
+      )}
       role="status"
       aria-busy="true"
       aria-label="Loading"
@@ -19,7 +28,8 @@ export function RouteLoadingSkeleton() {
         className={cn(
           CHROME_ROW_CLASS,
           HEADER_SEAM_CLASS,
-          "shrink-0 gap-2 px-3 pl-12",
+          "shrink-0 gap-2",
+          isBoundedPane ? "px-4" : "px-3 pl-12",
         )}
       >
         <Skeleton className="h-4 w-40 max-w-[50%]" />

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -475,7 +475,7 @@ export function LegacyProjectComposeRedirect({
     });
   }, [location.state, navigate, projectId, setRootComposeProjectId]);
 
-  return <RouteLoadingSkeleton />;
+  return <RouteLoadingSkeleton isBoundedPane={false} />;
 }
 
 export function RootComposeView() {

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -2320,7 +2320,7 @@ function ThreadDetailViewInternal(props: ThreadRoutePathArgs) {
   );
 
   if (threadQueryState.status === "loading") {
-    return <RouteLoadingSkeleton />;
+    return <RouteLoadingSkeleton isBoundedPane={isBoundedPane} />;
   }
   if (!thread || thread.projectId !== projectId) {
     return (


### PR DESCRIPTION
## Human comments

## What was wrong

The shared route-loading skeleton always used negative margins and standalone-page header padding. When rendered inside a split pane, those styles bled beyond the pane boundary and made the loading layout look wider and offset from the real thread view.

## What changed

- Add a required `isBoundedPane` mode to the shared loading skeleton.
- Keep the existing bleed and header inset for standalone routes while containing split-pane placeholders and matching their header padding.
- Pass the pane mode explicitly from every caller.
- Add regression coverage for both standalone and bounded layouts.

## How you verified

- Compared before/after browser geometry: the loading wrapper matches the split-pane bounds, and its header and prompt placeholders remain fully contained.
- `pnpm exec turbo run test typecheck lint --filter=@bb/app --force` (3,505 tests passed, four skipped; typecheck passed; lint reported zero errors)
- `pnpm exec prettier --check apps/app/src/App.tsx apps/app/src/components/ui/route-loading-skeleton.tsx apps/app/src/components/ui/route-loading-skeleton.test.tsx apps/app/src/views/RootComposeView.tsx apps/app/src/views/thread-detail/ThreadDetailView.tsx`
- `git diff --check origin/main...HEAD`

> AGENT GENERATED
