### PR TITLE
Fix packaged smoke exit settlement

### DIFF
--- a/apps/desktop/scripts/smoke-packaged-app.mjs
+++ b/apps/desktop/scripts/smoke-packaged-app.mjs
@@ -249,6 +249,7 @@ async function waitForOutputFlush(child) {
 
 async function waitForPreloadReady({ child, preloadReady, stdout, stderr }) {
   return await new Promise((resolvePromise, rejectPromise) => {
+    let exited = false;
     const timeout = setTimeout(() => {
       cleanup();
       rejectPromise(
@@ -261,6 +262,7 @@ async function waitForPreloadReady({ child, preloadReady, stdout, stderr }) {
     }, startupTimeoutMs);
 
     const handleExit = (code, signal) => {
+      exited = true;
       cleanup();
       void waitForOutputFlush(child).then(() => {
         rejectPromise(
@@ -296,10 +298,12 @@ async function waitForPreloadReady({ child, preloadReady, stdout, stderr }) {
     child.once("error", handleError);
     preloadReady.then(
       (result) => {
+        if (exited) return;
         cleanup();
         resolvePromise(result);
       },
       (error) => {
+        if (exited) return;
         cleanup();
         rejectPromise(error);
       },


### PR DESCRIPTION
## Human comments

## What was wrong

The packaged desktop smoke's child `exit` handler waited asynchronously for `close` or a two-second output-flush timeout. During that wait, the still-live preload-readiness continuation could resolve the shared startup promise first, bypassing the intended early-exit rejection and omitting final stderr from the diagnostic.

## What changed

- Latch child exit synchronously before cleanup and output flushing begin.
- Prevent both preload-readiness fulfillment and rejection from settling after exit.
- Preserve the existing bounded output-flush wait and diagnostic format.

## How you verified

- A deterministic `exit` → readiness → no-`close` harness failed before the fix and now rejects through the early-exit path after the bounded flush wait.
- A second harness scenario emits final stderr and `close`; rejection waits for close and includes that stderr.
- `pnpm exec turbo run typecheck test --filter=@bb/desktop --force` (38 test files; 245 tests passed, one skipped)
- `pnpm exec oxfmt --check apps/desktop/scripts/smoke-packaged-app.mjs`
- `node --check apps/desktop/scripts/smoke-packaged-app.mjs`
- `git diff --check origin/main...HEAD`

> AGENT GENERATED
