### PR TITLE
Keep compact mobile submit stable

### DIFF
--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -2184,6 +2184,38 @@ describe("PromptBoxInternal compact layout", () => {
     }
   });
 
+  it("keeps an unfocused compact submit stable on coarse pointers", () => {
+    const restoreMatchMedia = mockPointerCoarse(true);
+    try {
+      const onSubmit = vi.fn();
+      render(
+        <PromptBoxInternal
+          {...createPromptBoxProps({
+            value: "Transcript ready to send",
+            onSubmit,
+            compact: {
+              isCompact: true,
+              placeholder: "Ask a follow-up",
+            },
+          })}
+        />,
+      );
+
+      expect(document.activeElement).not.toBe(getPromptEditorElement());
+      const submit = screen.getByRole("button", { name: "Submit (Enter)" });
+      expect(
+        fireEvent.pointerDown(submit, {
+          button: 0,
+          pointerType: "touch",
+        }),
+      ).toBe(false);
+      fireEvent.click(submit, { detail: 1 });
+      expect(onSubmit).toHaveBeenCalledOnce();
+    } finally {
+      restoreMatchMedia();
+    }
+  });
+
   it("keeps the editor focused through a pointer submit", async () => {
     const onSubmit = vi.fn();
     render(

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -2572,6 +2572,10 @@ export function PromptBoxInternal({
   const handleSubmitPointerDown = useCallback(
     (event: ReactPointerEvent<HTMLButtonElement>) => {
       if (event.button !== 0) return;
+      if (isPointerCoarse) {
+        event.preventDefault();
+        return;
+      }
       const currentEditor = editorRef.current;
       const editorElement = currentEditor?.view.dom;
       const activeElement = editorElement?.ownerDocument.activeElement;
@@ -2585,7 +2589,7 @@ export function PromptBoxInternal({
 
       event.preventDefault();
     },
-    [],
+    [isPointerCoarse],
   );
 
   const [pendingCommandSubmit, setPendingCommandSubmit] = useState(false);


### PR DESCRIPTION
## Human comments

## What was wrong

On coarse-pointer/mobile devices, pressing submit in an unfocused compact prompt transferred focus to the editor during `pointerdown`. That expanded and reflowed the compact composer before the click completed, so the first tap could expand the prompt instead of submitting it.

## What changed

- Prevent primary coarse-pointer submit presses from transferring focus before click.
- Preserve the existing fine-pointer behavior that keeps an already-focused editor focused through submission.
- Add regression coverage proving an unfocused compact prompt submits on the first touch interaction without focusing the editor.

## How you verified

- The focused regression probe failed before the fix and passes after it.
- `pnpm exec turbo run test typecheck lint --filter=@bb/app --force` (444 test files; 3,506 tests passed, four skipped; typecheck passed; lint reported zero errors)
- `pnpm exec prettier --check apps/app/src/components/promptbox/PromptBoxInternal.tsx apps/app/src/components/promptbox/PromptBoxInternal.test.tsx`
- `git diff --check origin/main...HEAD`

> AGENT GENERATED
