### PR TITLE
Replace the steer-on-Enter toggle with a Queue/Steer picker

### DIFF
--- a/apps/app/src/views/SettingsView.tsx
+++ b/apps/app/src/views/SettingsView.tsx
@@ -536,12 +536,14 @@ const FOLLOW_UP_BEHAVIOR_OPTIONS = [
   {
     steerOnEnter: false,
     label: "Queue",
-    description: "Enter adds a follow-up. Command+Enter steers the run.",
+    description:
+      "Enter adds a follow-up. It runs when the agent stops. Command+Enter steers the run.",
   },
   {
     steerOnEnter: true,
     label: "Steer",
-    description: "Enter steers the run. Command+Enter adds a follow-up.",
+    description:
+      "Enter steers the run now. Command+Enter adds a follow-up for later.",
   },
 ] as const;
 const STREAMER_MODE_SETTING_LABEL = "Streamer mode";

--- a/apps/app/src/views/SettingsView.tsx
+++ b/apps/app/src/views/SettingsView.tsx
@@ -531,8 +531,19 @@ const NAVIGATE_TO_THREAD_AFTER_CREATE_SETTING_LABEL =
 const RICH_TEXT_EDITING_SETTING_LABEL = "Markdown formatting in prompt box";
 const UNHANDLED_PROVIDER_EVENTS_SETTING_LABEL =
   "Show unhandled provider events";
-const STEER_ACTIVE_THREAD_ON_ENTER_SETTING_LABEL =
-  "Steer running threads on Enter";
+const FOLLOW_UP_BEHAVIOR_SETTING_LABEL = "Default thread followup behavior";
+const FOLLOW_UP_BEHAVIOR_OPTIONS = [
+  {
+    steerOnEnter: false,
+    label: "Queue",
+    description: "Enter adds a follow-up. Command+Enter steers the run.",
+  },
+  {
+    steerOnEnter: true,
+    label: "Steer",
+    description: "Enter steers the run. Command+Enter adds a follow-up.",
+  },
+] as const;
 const STREAMER_MODE_SETTING_LABEL = "Streamer mode";
 
 export function AppearanceSettingsSection({
@@ -728,15 +739,56 @@ export function GeneralSettingsSection({
         </SettingsWithControl>
 
         <SettingsWithControl
-          label={STEER_ACTIVE_THREAD_ON_ENTER_SETTING_LABEL}
-          description="Use Enter to steer the current run and Command+Enter to queue a follow-up."
+          label={FOLLOW_UP_BEHAVIOR_SETTING_LABEL}
+          description="What Enter does in the prompt box while the thread runs."
         >
-          <Switch
-            checked={steerActiveThreadOnEnter}
-            disabled={steerActiveThreadOnEnterDisabled}
-            onCheckedChange={onSteerActiveThreadOnEnterChange}
-            aria-label={STEER_ACTIVE_THREAD_ON_ENTER_SETTING_LABEL}
-          />
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="outline"
+                size="sm"
+                className={SETTINGS_DROPDOWN_TRIGGER_CLASS}
+                disabled={steerActiveThreadOnEnterDisabled}
+                aria-label={FOLLOW_UP_BEHAVIOR_SETTING_LABEL}
+              >
+                {steerActiveThreadOnEnter ? "Steer" : "Queue"}
+                <Icon
+                  name="ChevronDown"
+                  className="size-3.5 text-muted-foreground"
+                />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              align="end"
+              className={cn(SETTINGS_DROPDOWN_CONTENT_CLASS, "max-w-72")}
+            >
+              {FOLLOW_UP_BEHAVIOR_OPTIONS.map((option) => (
+                <DropdownMenuItem
+                  key={option.label}
+                  className="items-start"
+                  onSelect={() =>
+                    onSteerActiveThreadOnEnterChange(option.steerOnEnter)
+                  }
+                >
+                  <span className="min-w-0">
+                    <span className="block">{option.label}</span>
+                    <span className="block text-2xs leading-snug text-subtle-foreground">
+                      {option.description}
+                    </span>
+                  </span>
+                  <Icon
+                    name="Check"
+                    className={cn(
+                      "ml-auto",
+                      steerActiveThreadOnEnter !== option.steerOnEnter &&
+                        "opacity-0",
+                      COARSE_POINTER_ICON_SIZE_CLASS,
+                    )}
+                  />
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
         </SettingsWithControl>
 
         {desktopBrowserAvailable ? (

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -136,7 +136,7 @@ signal it, so a stale file left by a crash cannot stop an unrelated process.
 | Key                     | Command                                            | When to set             | Used for                                                                                                                                                                                                                                                                                                                                                                                              |
 | ----------------------- | -------------------------------------------------- | ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `BB_APP_URL`            | `bb-app config`                                    | Optional for remote use | Human-facing app URL used for generated links and allowed browser origins. Leave empty for local-only use.                                                                                                                                                                                                                                                                                            |
-| `BB_INFERENCE`          | `bb-app config`                                    | Optional                | Primary server-side helper model in `<service>/<model>` format, where `<service>` is an AI service a loaded plugin registers (`bb settings ai-services` lists them; `codex` comes with the codex plugin and uses the codex CLI's credentials with no reasoning) or a pi-ai provider the server calls directly with its API key. Defaults to `codex/gpt-5.6-luna`.                                  |
+| `BB_INFERENCE`          | `bb-app config`                                    | Optional                | Primary server-side helper model in `<service>/<model>` format, where `<service>` is an AI service a loaded plugin registers (`bb settings ai-services` lists them; `codex` comes with the codex plugin and uses the codex CLI's credentials with no reasoning) or a pi-ai provider the server calls directly with its API key. Defaults to `codex/gpt-5.6-luna`.                                     |
 | `BB_INFERENCE_FALLBACK` | `bb-app config`                                    | Optional                | Helper model used after a transient primary timeout, rate limit, or service-unavailable failure. Defaults to `codex/gpt-5.4-mini`.                                                                                                                                                                                                                                                                    |
 | `BB_TRANSCRIPTION`      | `bb-app config`                                    | Optional                | Voice transcription model in `<service>/<model>` format: a plugin-registered AI service (`codex` with the codex plugin; audio up to 5MB) or `openai/<model>` with `OPENAI_API_KEY`. Defaults to `codex/gpt-transcribe`.                                                                                                                                                                               |
 | `BB_MARKETPLACE_URL`    | `bb-app env`, or environment                       | Startup-only testing    | Manifest URL of the reserved `bb-community` plugin marketplace, which lists as BB Community. Defaults to `https://getbb.app/marketplace/v1/marketplace.json`; point it at a local file server to test catalog refreshes. It sets only the reserved `bb-community` marketplace; other marketplaces are added at runtime with `bb marketplace add`. A full launcher or desktop app restart is required. |
@@ -186,11 +186,12 @@ to show them regardless of the toggle. Set the persisted preference from an
 agent or terminal with
 `bb settings general showUnhandledProviderEvents <true|false>`.
 
-The "Steer running threads on Enter" toggle in Settings → General changes the
+The "Default thread followup behavior" picker in Settings → General changes the
 active-thread composer shortcuts when no typeahead suggestion is active. It
-defaults to off: Enter queues and Command+Enter steers. When enabled, Enter
-steers and Command+Enter queues. Set it with
-`bb settings general steerActiveThreadOnEnter <true|false>`.
+defaults to "Queue": Enter queues and Command+Enter steers. "Steer" swaps them:
+Enter steers and Command+Enter queues. Set it with
+`bb settings general steerActiveThreadOnEnter <true|false>`, where `true` is
+"Steer".
 
 The "Streamer mode" toggle in Settings → General hides every `customModels`
 entry from `~/.bb/config.json` in all model lists: the web and mobile pickers,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -187,9 +187,11 @@ agent or terminal with
 `bb settings general showUnhandledProviderEvents <true|false>`.
 
 The "Default thread followup behavior" picker in Settings → General changes the
-active-thread composer shortcuts when no typeahead suggestion is active. It
-defaults to "Queue": Enter queues and Command+Enter steers. "Steer" swaps them:
-Enter steers and Command+Enter queues. Set it with
+active-thread composer shortcuts when no typeahead suggestion is active. A
+queued message waits and then runs when the agent stops. A steer message goes
+to the agent during the current run. The picker defaults to "Queue": Enter
+queues and Command+Enter steers. "Steer" swaps them: Enter steers and
+Command+Enter queues. Set it with
 `bb settings general steerActiveThreadOnEnter <true|false>`, where `true` is
 "Steer".
 


### PR DESCRIPTION
## Human comments

## What was wrong

Settings → General showed the follow-up shortcut preference as a switch labeled "Steer running threads on Enter". A switch names only one of the two modes, so the off position had no name and the row could not say what each mode does. A reader had to infer that "off" means "queue".

## What changed

- `apps/app/src/views/SettingsView.tsx`: the row is now a "Default thread followup behavior" dropdown, built with the same `DropdownMenu` pattern as the Theme picker. It has two named options with their own descriptions:
  - **Queue** — "Enter adds a follow-up. It runs when the agent stops. Command+Enter steers the run."
  - **Steer** — "Enter steers the run now. Command+Enter adds a follow-up for later."
- `docs/configuration.md`: the paragraph now describes the picker, states when a queued message runs, and maps `true` to "Steer".

The stored preference stays the boolean `steerActiveThreadOnEnter`. There is no schema change, no route change, no wire change, and `bb settings general steerActiveThreadOnEnter <true|false>` keeps working. The `GeneralSettingsSection` props are unchanged, so the Storybook stories still render.

## How you verified

- `pnpm exec turbo run typecheck lint --filter=@bb/app` passed.
- `vitest run src/views/SettingsView.stories.test.tsx src/components/promptbox/FollowUpPromptBox.test.tsx` passed (35 tests).
- Opened the dev app and used the dropdown in Settings → General.

No test was added: the change replaces one control with another and adds no branch that a unit test can protect.

> AGENT GENERATED
