### PR TITLE
Keep FSEvents overflow recovery subscription-scoped

### DIFF
--- a/packages/host-watcher/src/parcel-subprocess/messages.ts
+++ b/packages/host-watcher/src/parcel-subprocess/messages.ts
@@ -23,4 +23,9 @@ export type ChildToParentMessage =
   | { kind: "subscribe-failed"; id: string; message: string }
   | { kind: "unsubscribed"; id: string }
   | { kind: "events"; id: string; events: SerializedParcelEvent[] }
-  | { kind: "watch-error"; id: string; message: string };
+  | {
+      kind: "watch-error";
+      id: string;
+      message: string;
+      recovery: "rescan-subscription" | "recycle-child";
+    };

--- a/packages/host-watcher/src/parcel-subprocess/parcel-child-handler.ts
+++ b/packages/host-watcher/src/parcel-subprocess/parcel-child-handler.ts
@@ -4,6 +4,7 @@ import type {
   ParcelWatcherBackend,
   ParcelWatcherEventBatch,
 } from "../parcel-watcher-backend.js";
+import { isRescanRequiredMessage } from "../watch-recovery.js";
 import { toWatchErrorMessage } from "../watch-error.js";
 import type {
   ChildToParentMessage,
@@ -58,10 +59,14 @@ export function createParcelChildHandler(args: {
         message.dir,
         (error, events) => {
           if (error) {
+            const errorMessage = toWatchErrorMessage(error);
             args.send({
               kind: "watch-error",
               id: message.id,
-              message: toWatchErrorMessage(error),
+              message: errorMessage,
+              recovery: isRescanRequiredMessage(errorMessage)
+                ? "rescan-subscription"
+                : "recycle-child",
             });
             return;
           }

--- a/packages/host-watcher/src/parcel-subprocess/parcel-watcher-proxy.ts
+++ b/packages/host-watcher/src/parcel-subprocess/parcel-watcher-proxy.ts
@@ -233,6 +233,17 @@ export function createParcelWatcherProxy(
         break;
       }
       case "watch-error":
+        if (message.recovery === "rescan-subscription") {
+          const record = subscriptions.get(message.id);
+          if (record) {
+            log("warn", "Watcher subscription requires targeted recovery", {
+              activeSubscriptions: subscriptions.size,
+              watchError: message.message,
+            });
+            record.callback(new Error(message.message), []);
+          }
+          break;
+        }
         log("warn", "Watcher child reported a backend error; recycling", {
           watchError: message.message,
         });

--- a/packages/host-watcher/test/fixtures/parcel-recovery-benchmark-child.ts
+++ b/packages/host-watcher/test/fixtures/parcel-recovery-benchmark-child.ts
@@ -1,0 +1,112 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type {
+  ParcelAsyncSubscription,
+  ParcelWatcherBackend,
+} from "../../src/parcel-watcher-backend.js";
+import { realParcelWatcher } from "../../src/real-parcel-watcher.js";
+import { RESCAN_REQUIRED_MESSAGE } from "../../src/watch-recovery.js";
+import type { ParentToChildMessage } from "../../src/parcel-subprocess/messages.js";
+import { createParcelChildHandler } from "../../src/parcel-subprocess/parcel-child-handler.js";
+
+const faultRoot = process.env.BB_WATCHER_BENCHMARK_FAULT_ROOT;
+const triggerPath = process.env.BB_WATCHER_BENCHMARK_TRIGGER_PATH;
+
+if (!faultRoot || !triggerPath) {
+  throw new Error("Watcher recovery benchmark fault paths are required");
+}
+
+const canonicalTriggerPath = await fs.realpath(triggerPath);
+
+type TelemetryEvent =
+  | "fault-injected"
+  | "list-entries-complete"
+  | "native-subscribe-ready"
+  | "native-subscribe-start"
+  | "native-unsubscribe-ready"
+  | "native-unsubscribe-start";
+
+function sendTelemetry(
+  event: TelemetryEvent,
+  rootPath: string,
+  entryCount?: number,
+): void {
+  process.send?.({
+    kind: "benchmark-telemetry",
+    event,
+    rootPath,
+    ...(entryCount === undefined ? {} : { entryCount }),
+  });
+}
+
+let affectedSubscriptionEpoch = 0;
+let armedSubscriptionEpoch = 0;
+
+const benchmarkParcel: ParcelWatcherBackend = {
+  async subscribe(dir, callback, opts): Promise<ParcelAsyncSubscription> {
+    const normalizedDir = path.resolve(dir);
+    const isAffected = normalizedDir === path.resolve(faultRoot);
+    const subscriptionEpoch = isAffected ? (affectedSubscriptionEpoch += 1) : 0;
+    sendTelemetry("native-subscribe-start", normalizedDir);
+    const subscription = await realParcelWatcher.subscribe(
+      dir,
+      (error, events) => {
+        const includesTrigger = events.some((event) => {
+          const eventPath = path.isAbsolute(event.path)
+            ? path.normalize(event.path)
+            : path.resolve(dir, event.path);
+          return eventPath === canonicalTriggerPath;
+        });
+        if (!error && isAffected && includesTrigger) {
+          if (subscriptionEpoch !== armedSubscriptionEpoch) {
+            return;
+          }
+          armedSubscriptionEpoch = 0;
+          sendTelemetry("fault-injected", normalizedDir);
+          callback(
+            new Error(
+              `Events were dropped by the FSEvents client. ${RESCAN_REQUIRED_MESSAGE}.`,
+            ),
+            [],
+          );
+          return;
+        }
+        callback(error, events);
+      },
+      opts,
+    );
+    if (isAffected) {
+      armedSubscriptionEpoch = subscriptionEpoch;
+    }
+    sendTelemetry("native-subscribe-ready", normalizedDir);
+    return {
+      async unsubscribe() {
+        sendTelemetry("native-unsubscribe-start", normalizedDir);
+        await subscription.unsubscribe();
+        sendTelemetry("native-unsubscribe-ready", normalizedDir);
+      },
+    };
+  },
+};
+
+const handler = createParcelChildHandler({
+  parcel: benchmarkParcel,
+  send: (message) => {
+    process.send?.(message);
+  },
+  listEntries: async (dir) => {
+    const entries = await fs.readdir(dir);
+    sendTelemetry("list-entries-complete", path.resolve(dir), entries.length);
+    return entries;
+  },
+});
+
+process.on("message", (message: unknown) => {
+  handler.handleMessage(message as ParentToChildMessage);
+});
+
+process.on("disconnect", () => {
+  void handler.dispose().finally(() => process.exit(0));
+});
+
+process.send?.({ kind: "ready" });

--- a/packages/host-watcher/test/parcel-watcher-proxy.test.ts
+++ b/packages/host-watcher/test/parcel-watcher-proxy.test.ts
@@ -165,6 +165,163 @@ function createHarness(options?: {
   return { proxy, children, current };
 }
 
+interface RecoveryBenchmarkCounts {
+  subscriptions: number;
+  affectedSubscriptions: number;
+  unaffectedSubscriptions: number;
+  childRestarts: number;
+  proxyResubscriptions: number;
+  listEntriesCalls: number;
+  affectedSubscriptionsReceivingErrors: number;
+  affectedSubscriptionsReceivingEvents: number;
+  unaffectedSubscriptionsReceivingErrors: number;
+  unaffectedSubscriptionsReceivingEvents: number;
+}
+
+interface RecoveryBenchmarkSample extends RecoveryBenchmarkCounts {
+  elapsedMs: number;
+}
+
+interface RecoveryBenchmarkSummary {
+  iterations: number;
+  medianElapsedMs: number;
+  p95ElapsedMs: number;
+  countsDeterministic: boolean;
+  counts: RecoveryBenchmarkCounts;
+}
+
+function benchmarkCounts(
+  sample: RecoveryBenchmarkSample,
+): RecoveryBenchmarkCounts {
+  return {
+    subscriptions: sample.subscriptions,
+    affectedSubscriptions: sample.affectedSubscriptions,
+    unaffectedSubscriptions: sample.unaffectedSubscriptions,
+    childRestarts: sample.childRestarts,
+    proxyResubscriptions: sample.proxyResubscriptions,
+    listEntriesCalls: sample.listEntriesCalls,
+    affectedSubscriptionsReceivingErrors:
+      sample.affectedSubscriptionsReceivingErrors,
+    affectedSubscriptionsReceivingEvents:
+      sample.affectedSubscriptionsReceivingEvents,
+    unaffectedSubscriptionsReceivingErrors:
+      sample.unaffectedSubscriptionsReceivingErrors,
+    unaffectedSubscriptionsReceivingEvents:
+      sample.unaffectedSubscriptionsReceivingEvents,
+  };
+}
+
+function percentile(values: readonly number[], quantile: number): number {
+  const sorted = [...values].sort((left, right) => left - right);
+  const index = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.ceil(sorted.length * quantile) - 1),
+  );
+  const value = sorted[index];
+  if (value === undefined) {
+    throw new Error("Cannot calculate a percentile without samples");
+  }
+  return value;
+}
+
+async function runRecoveryBenchmarkSample(
+  subscriptionCount: number,
+): Promise<RecoveryBenchmarkSample> {
+  let listEntriesCalls = 0;
+  const { proxy, children, current } = createHarness({
+    listEntries: () => {
+      listEntriesCalls += 1;
+      return Promise.resolve(["current-entry"]);
+    },
+  });
+  let affectedErrors = 0;
+  let affectedEvents = 0;
+  const unaffectedSubscriptionsReceivingErrors = new Set<number>();
+  const unaffectedSubscriptionsReceivingEvents = new Set<number>();
+
+  for (let index = 0; index < subscriptionCount; index += 1) {
+    await proxy.subscribe(`/root-${index}`, (error, events) => {
+      if (index === 0) {
+        if (error) {
+          affectedErrors += 1;
+        } else {
+          affectedEvents += events.length;
+        }
+        return;
+      }
+      if (error) {
+        unaffectedSubscriptionsReceivingErrors.add(index);
+      } else if (events.length > 0) {
+        unaffectedSubscriptionsReceivingEvents.add(index);
+      }
+    });
+  }
+  await flush();
+
+  const startedAt = performance.now();
+  current().parcel.emitError(
+    "/root-0",
+    `Events were dropped by the FSEvents client. ${RESCAN_REQUIRED_MESSAGE}.`,
+  );
+  await flush();
+  const elapsedMs = performance.now() - startedAt;
+  const totalSubscribeCalls = children.reduce(
+    (total, child) => total + child.parcel.subscriptions.length,
+    0,
+  );
+  const sample: RecoveryBenchmarkSample = {
+    subscriptions: subscriptionCount,
+    affectedSubscriptions: 1,
+    unaffectedSubscriptions: subscriptionCount - 1,
+    childRestarts: children.length - 1,
+    proxyResubscriptions: totalSubscribeCalls - subscriptionCount,
+    listEntriesCalls,
+    affectedSubscriptionsReceivingErrors: affectedErrors > 0 ? 1 : 0,
+    affectedSubscriptionsReceivingEvents: affectedEvents > 0 ? 1 : 0,
+    unaffectedSubscriptionsReceivingErrors:
+      unaffectedSubscriptionsReceivingErrors.size,
+    unaffectedSubscriptionsReceivingEvents:
+      unaffectedSubscriptionsReceivingEvents.size,
+    elapsedMs,
+  };
+  proxy.dispose();
+  return sample;
+}
+
+async function runRecoveryBenchmark(
+  subscriptionCount: number,
+  iterations: number,
+): Promise<RecoveryBenchmarkSummary> {
+  for (let index = 0; index < 10; index += 1) {
+    await runRecoveryBenchmarkSample(subscriptionCount);
+  }
+  const samples: RecoveryBenchmarkSample[] = [];
+  for (let index = 0; index < iterations; index += 1) {
+    samples.push(await runRecoveryBenchmarkSample(subscriptionCount));
+  }
+  const firstSample = samples[0];
+  if (!firstSample) {
+    throw new Error("Recovery benchmark requires at least one iteration");
+  }
+  const counts = benchmarkCounts(firstSample);
+  return {
+    iterations,
+    medianElapsedMs: percentile(
+      samples.map((sample) => sample.elapsedMs),
+      0.5,
+    ),
+    p95ElapsedMs: percentile(
+      samples.map((sample) => sample.elapsedMs),
+      0.95,
+    ),
+    countsDeterministic: samples.every(
+      (sample) =>
+        JSON.stringify(benchmarkCounts(sample)) === JSON.stringify(counts),
+    ),
+    counts,
+  };
+}
+
 describe("createParcelWatcherProxy", () => {
   it("delivers parcel events from the child to the subscriber", async () => {
     const { proxy, current } = createHarness();
@@ -266,6 +423,52 @@ describe("createParcelWatcherProxy", () => {
       { path: "/root/healed.ts", type: "update" },
     ]);
     expect(received).toEqual(["/root/healed.ts"]);
+    proxy.dispose();
+  });
+
+  it("routes rescan-required errors only to the affected subscription", async () => {
+    const listEntries = vi.fn(() => Promise.resolve(["current-entry"]));
+    const { proxy, children, current } = createHarness({ listEntries });
+    const affectedErrors: string[] = [];
+    const affectedEvents: string[] = [];
+    const unaffectedErrors: string[] = [];
+    const unaffectedEvents: string[] = [];
+
+    await proxy.subscribe("/affected", (error, events) => {
+      if (error) {
+        affectedErrors.push(error.message);
+        return;
+      }
+      affectedEvents.push(...events.map((event) => event.path));
+    });
+    await proxy.subscribe("/unaffected", (error, events) => {
+      if (error) {
+        unaffectedErrors.push(error.message);
+        return;
+      }
+      unaffectedEvents.push(...events.map((event) => event.path));
+    });
+    await flush();
+    expect(children).toHaveLength(1);
+
+    current().parcel.emitError(
+      "/affected",
+      `Events were dropped by the FSEvents client. ${RESCAN_REQUIRED_MESSAGE}.`,
+    );
+    await flush();
+
+    expect(children).toHaveLength(1);
+    expect(affectedErrors).toEqual([
+      `Events were dropped by the FSEvents client. ${RESCAN_REQUIRED_MESSAGE}.`,
+    ]);
+    expect(affectedEvents).toEqual([]);
+    expect(unaffectedErrors).toEqual([]);
+    expect(unaffectedEvents).toEqual([]);
+    expect(listEntries).not.toHaveBeenCalled();
+    expect(current().parcel.activeDirs().sort()).toEqual([
+      "/affected",
+      "/unaffected",
+    ]);
     proxy.dispose();
   });
 
@@ -459,3 +662,19 @@ describe("createParcelWatcherProxy", () => {
     proxy.dispose();
   });
 });
+
+if (process.env.BB_WATCHER_RECOVERY_BENCHMARK === "1") {
+  describe("watcher recovery benchmark", () => {
+    it("reports two-subscription and fan-out recovery costs", async () => {
+      const result = {
+        twoSubscriptions: await runRecoveryBenchmark(2, 100),
+        fanOut: await runRecoveryBenchmark(100, 100),
+      };
+      expect(result.twoSubscriptions.countsDeterministic).toBe(true);
+      expect(result.fanOut.countsDeterministic).toBe(true);
+      process.stdout.write(
+        `WATCHER_RECOVERY_BENCHMARK ${JSON.stringify(result)}\n`,
+      );
+    }, 30_000);
+  });
+}

--- a/packages/host-watcher/test/parcel-watcher-proxy.test.ts
+++ b/packages/host-watcher/test/parcel-watcher-proxy.test.ts
@@ -178,55 +178,9 @@ interface RecoveryBenchmarkCounts {
   unaffectedSubscriptionsReceivingEvents: number;
 }
 
-interface RecoveryBenchmarkSample extends RecoveryBenchmarkCounts {
-  elapsedMs: number;
-}
-
-interface RecoveryBenchmarkSummary {
-  iterations: number;
-  medianElapsedMs: number;
-  p95ElapsedMs: number;
-  countsDeterministic: boolean;
-  counts: RecoveryBenchmarkCounts;
-}
-
-function benchmarkCounts(
-  sample: RecoveryBenchmarkSample,
-): RecoveryBenchmarkCounts {
-  return {
-    subscriptions: sample.subscriptions,
-    affectedSubscriptions: sample.affectedSubscriptions,
-    unaffectedSubscriptions: sample.unaffectedSubscriptions,
-    childRestarts: sample.childRestarts,
-    proxyResubscriptions: sample.proxyResubscriptions,
-    listEntriesCalls: sample.listEntriesCalls,
-    affectedSubscriptionsReceivingErrors:
-      sample.affectedSubscriptionsReceivingErrors,
-    affectedSubscriptionsReceivingEvents:
-      sample.affectedSubscriptionsReceivingEvents,
-    unaffectedSubscriptionsReceivingErrors:
-      sample.unaffectedSubscriptionsReceivingErrors,
-    unaffectedSubscriptionsReceivingEvents:
-      sample.unaffectedSubscriptionsReceivingEvents,
-  };
-}
-
-function percentile(values: readonly number[], quantile: number): number {
-  const sorted = [...values].sort((left, right) => left - right);
-  const index = Math.min(
-    sorted.length - 1,
-    Math.max(0, Math.ceil(sorted.length * quantile) - 1),
-  );
-  const value = sorted[index];
-  if (value === undefined) {
-    throw new Error("Cannot calculate a percentile without samples");
-  }
-  return value;
-}
-
-async function runRecoveryBenchmarkSample(
+async function runRecoveryCountSample(
   subscriptionCount: number,
-): Promise<RecoveryBenchmarkSample> {
+): Promise<RecoveryBenchmarkCounts> {
   let listEntriesCalls = 0;
   const { proxy, children, current } = createHarness({
     listEntries: () => {
@@ -258,18 +212,16 @@ async function runRecoveryBenchmarkSample(
   }
   await flush();
 
-  const startedAt = performance.now();
   current().parcel.emitError(
     "/root-0",
     `Events were dropped by the FSEvents client. ${RESCAN_REQUIRED_MESSAGE}.`,
   );
   await flush();
-  const elapsedMs = performance.now() - startedAt;
   const totalSubscribeCalls = children.reduce(
     (total, child) => total + child.parcel.subscriptions.length,
     0,
   );
-  const sample: RecoveryBenchmarkSample = {
+  const counts: RecoveryBenchmarkCounts = {
     subscriptions: subscriptionCount,
     affectedSubscriptions: 1,
     unaffectedSubscriptions: subscriptionCount - 1,
@@ -282,44 +234,9 @@ async function runRecoveryBenchmarkSample(
       unaffectedSubscriptionsReceivingErrors.size,
     unaffectedSubscriptionsReceivingEvents:
       unaffectedSubscriptionsReceivingEvents.size,
-    elapsedMs,
   };
   proxy.dispose();
-  return sample;
-}
-
-async function runRecoveryBenchmark(
-  subscriptionCount: number,
-  iterations: number,
-): Promise<RecoveryBenchmarkSummary> {
-  for (let index = 0; index < 10; index += 1) {
-    await runRecoveryBenchmarkSample(subscriptionCount);
-  }
-  const samples: RecoveryBenchmarkSample[] = [];
-  for (let index = 0; index < iterations; index += 1) {
-    samples.push(await runRecoveryBenchmarkSample(subscriptionCount));
-  }
-  const firstSample = samples[0];
-  if (!firstSample) {
-    throw new Error("Recovery benchmark requires at least one iteration");
-  }
-  const counts = benchmarkCounts(firstSample);
-  return {
-    iterations,
-    medianElapsedMs: percentile(
-      samples.map((sample) => sample.elapsedMs),
-      0.5,
-    ),
-    p95ElapsedMs: percentile(
-      samples.map((sample) => sample.elapsedMs),
-      0.95,
-    ),
-    countsDeterministic: samples.every(
-      (sample) =>
-        JSON.stringify(benchmarkCounts(sample)) === JSON.stringify(counts),
-    ),
-    counts,
-  };
+  return counts;
 }
 
 describe("createParcelWatcherProxy", () => {
@@ -664,16 +581,18 @@ describe("createParcelWatcherProxy", () => {
 });
 
 if (process.env.BB_WATCHER_RECOVERY_BENCHMARK === "1") {
-  describe("watcher recovery benchmark", () => {
-    it("reports two-subscription and fan-out recovery costs", async () => {
+  describe("watcher recovery count harness", () => {
+    it("reports two-subscription and fan-out recovery work", async () => {
       const result = {
-        twoSubscriptions: await runRecoveryBenchmark(2, 100),
-        fanOut: await runRecoveryBenchmark(100, 100),
+        twoSubscriptions: await runRecoveryCountSample(2),
+        fanOut: await runRecoveryCountSample(100),
       };
-      expect(result.twoSubscriptions.countsDeterministic).toBe(true);
-      expect(result.fanOut.countsDeterministic).toBe(true);
+      expect(result.twoSubscriptions.affectedSubscriptions).toBe(1);
+      expect(result.twoSubscriptions.unaffectedSubscriptions).toBe(1);
+      expect(result.fanOut.affectedSubscriptions).toBe(1);
+      expect(result.fanOut.unaffectedSubscriptions).toBe(99);
       process.stdout.write(
-        `WATCHER_RECOVERY_BENCHMARK ${JSON.stringify(result)}\n`,
+        `WATCHER_RECOVERY_COUNTS ${JSON.stringify(result)}\n`,
       );
     }, 30_000);
   });

--- a/packages/host-watcher/test/root-recovery-benchmark.test.ts
+++ b/packages/host-watcher/test/root-recovery-benchmark.test.ts
@@ -1,0 +1,949 @@
+import { fork } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { monitorEventLoopDelay, performance } from "node:perf_hooks";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  disposeParcelWatcherBackend,
+  setParcelWatcherBackend,
+} from "../src/parcel-watcher-backend.js";
+import { createParcelHostWatcher } from "../src/parcel-host-watcher.js";
+import { createChildChannel } from "../src/parcel-subprocess/fork-channel.js";
+import type {
+  ChildToParentMessage,
+  ParentToChildMessage,
+} from "../src/parcel-subprocess/messages.js";
+import {
+  createParcelWatcherProxy,
+  type ChildChannel,
+} from "../src/parcel-subprocess/parcel-watcher-proxy.js";
+import { createDebouncedCallbackScheduler } from "../src/watch-callback-scheduler.js";
+
+const BENCHMARK_ENABLED =
+  process.env.BB_WATCHER_ROOT_RECOVERY_BENCHMARK === "1";
+const ROOT_COUNTS: readonly number[] = [57, 100];
+const DIRECTORY_COUNT_PER_ROOT = 8;
+const FILE_COUNT_PER_DIRECTORY = 16;
+const FILE_SIZE_BYTES = 4 * 1024;
+const FILE_COUNT_PER_ROOT =
+  DIRECTORY_COUNT_PER_ROOT * FILE_COUNT_PER_DIRECTORY + 1;
+const BYTE_COUNT_PER_ROOT = FILE_COUNT_PER_ROOT * FILE_SIZE_BYTES;
+const TOP_LEVEL_ENTRY_COUNT_PER_ROOT = DIRECTORY_COUNT_PER_ROOT + 1;
+const TREE_ENTRY_COUNT_PER_ROOT =
+  TOP_LEVEL_ENTRY_COUNT_PER_ROOT +
+  DIRECTORY_COUNT_PER_ROOT * FILE_COUNT_PER_DIRECTORY;
+const DOWNSTREAM_DEBOUNCE_MS = 75;
+const DOWNSTREAM_MAX_WAIT_MS = 500;
+const LOAD_BURST_MS = 8;
+const LOAD_YIELD_MS = 8;
+const DEFAULT_ITERATIONS = 20;
+const DEFAULT_WARMUP_ITERATIONS = 2;
+const RECOVERY_TIMEOUT_MS = 30_000;
+const QUIESCENCE_MS = 100;
+const benchmarkChildPath = fileURLToPath(
+  new URL("./fixtures/parcel-recovery-benchmark-child.ts", import.meta.url),
+);
+
+type LoadMode = "controlled-cpu" | "idle";
+type RecoveryKind = "global-restart" | "targeted-subscription";
+
+interface BenchmarkTelemetryMessage {
+  kind: "benchmark-telemetry";
+  event:
+    | "fault-injected"
+    | "list-entries-complete"
+    | "native-subscribe-ready"
+    | "native-subscribe-start"
+    | "native-unsubscribe-ready"
+    | "native-unsubscribe-start";
+  rootPath: string;
+  entryCount?: number;
+}
+
+interface Fixture {
+  baseDir: string;
+  roots: string[];
+  triggerPath: string;
+  rootCount: number;
+  filesPerRoot: number;
+  bytesPerRoot: number;
+  topLevelEntriesPerRoot: number;
+  treeEntriesPerRoot: number;
+  totalFiles: number;
+  totalBytes: number;
+}
+
+interface TreeScanResult {
+  bytes: number;
+  entries: number;
+  files: number;
+}
+
+interface RecoveryCounters {
+  affectedDownstreamScans: number;
+  childEventBatches: number;
+  childEvents: number;
+  childRestarts: number;
+  downstreamBytesRead: number;
+  downstreamEntriesProcessed: number;
+  downstreamFilesRead: number;
+  downstreamScans: number;
+  faultInjections: number;
+  hostEventBatches: number;
+  hostEvents: number;
+  listEntriesCalls: number;
+  listEntriesProcessed: number;
+  nativeSubscribeReady: number;
+  nativeSubscribeStarts: number;
+  nativeUnsubscribeReady: number;
+  nativeUnsubscribeStarts: number;
+  proxyReplaySubscriptions: number;
+  proxySubscribeMessages: number;
+  proxyUnsubscribeMessages: number;
+  rescanNotifications: number;
+  unaffectedDownstreamScans: number;
+  watchErrors: number;
+}
+
+interface IterationResult {
+  counters: RecoveryCounters;
+  eventLoopDelayMaxMs: number;
+  eventLoopDelayP50Ms: number;
+  eventLoopDelayP95Ms: number;
+  eventLoopUtilization: number;
+  initialReadyMs: number;
+  loadCycles: number;
+  loadMode: LoadMode;
+  recoveryKind: RecoveryKind;
+  recoveryLatencyMs: number;
+  rootCount: number;
+}
+
+interface Distribution {
+  max: number;
+  p50: number;
+  p95: number;
+}
+
+interface ScenarioSummary {
+  counts: RecoveryCounters;
+  countsDeterministic: boolean;
+  eventLoopDelayMaxMs: Distribution;
+  eventLoopUtilization: Distribution;
+  initialReadyMs: Distribution;
+  iterations: number;
+  loadMode: LoadMode;
+  recoveryKind: RecoveryKind;
+  recoveryLatencyMs: Distribution;
+  rootCount: number;
+}
+
+interface BenchmarkDocument {
+  fixture: {
+    bytesPerRoot: number;
+    directoriesPerRoot: number;
+    fileSizeBytes: number;
+    filesPerDirectory: number;
+    filesPerRoot: number;
+    topLevelEntriesPerRoot: number;
+    treeEntriesPerRoot: number;
+  };
+  host: {
+    arch: string;
+    node: string;
+    platform: string;
+    release: string;
+  };
+  iterations: number;
+  raw: IterationResult[];
+  summary: ScenarioSummary[];
+  warmupIterations: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isBenchmarkTelemetryMessage(
+  value: unknown,
+): value is BenchmarkTelemetryMessage {
+  if (
+    !isRecord(value) ||
+    value.kind !== "benchmark-telemetry" ||
+    typeof value.event !== "string" ||
+    typeof value.rootPath !== "string"
+  ) {
+    return false;
+  }
+  return [
+    "fault-injected",
+    "list-entries-complete",
+    "native-subscribe-ready",
+    "native-subscribe-start",
+    "native-unsubscribe-ready",
+    "native-unsubscribe-start",
+  ].includes(value.event);
+}
+
+function createCounters(): RecoveryCounters {
+  return {
+    affectedDownstreamScans: 0,
+    childEventBatches: 0,
+    childEvents: 0,
+    childRestarts: 0,
+    downstreamBytesRead: 0,
+    downstreamEntriesProcessed: 0,
+    downstreamFilesRead: 0,
+    downstreamScans: 0,
+    faultInjections: 0,
+    hostEventBatches: 0,
+    hostEvents: 0,
+    listEntriesCalls: 0,
+    listEntriesProcessed: 0,
+    nativeSubscribeReady: 0,
+    nativeSubscribeStarts: 0,
+    nativeUnsubscribeReady: 0,
+    nativeUnsubscribeStarts: 0,
+    proxyReplaySubscriptions: 0,
+    proxySubscribeMessages: 0,
+    proxyUnsubscribeMessages: 0,
+    rescanNotifications: 0,
+    unaffectedDownstreamScans: 0,
+    watchErrors: 0,
+  };
+}
+
+class RecoveryObserver {
+  readonly counters = createCounters();
+  readonly hostReadyRoots = new Set<number>();
+  readonly initialNativeReadyRoots = new Set<string>();
+  private readonly listeners = new Set<() => void>();
+  private failure: Error | null = null;
+  private measuring = false;
+
+  startMeasuring(): void {
+    this.measuring = true;
+    this.signal();
+  }
+
+  stopMeasuring(): void {
+    this.measuring = false;
+  }
+
+  fail(error: unknown): void {
+    this.failure =
+      error instanceof Error ? error : new Error("Benchmark callback failed");
+    this.signal();
+  }
+
+  recordChildSpawn(): void {
+    if (this.measuring) {
+      this.counters.childRestarts += 1;
+      this.signal();
+    }
+  }
+
+  recordParentMessage(message: ParentToChildMessage): void {
+    if (!this.measuring) {
+      return;
+    }
+    if (message.kind === "subscribe") {
+      this.counters.proxySubscribeMessages += 1;
+      if (message.rescan === true) {
+        this.counters.proxyReplaySubscriptions += 1;
+      }
+    } else if (message.kind === "unsubscribe") {
+      this.counters.proxyUnsubscribeMessages += 1;
+    }
+    this.signal();
+  }
+
+  recordChildMessage(message: ChildToParentMessage): void {
+    if (!this.measuring) {
+      return;
+    }
+    if (message.kind === "events") {
+      this.counters.childEventBatches += 1;
+      this.counters.childEvents += message.events.length;
+    }
+    this.signal();
+  }
+
+  recordTelemetry(message: BenchmarkTelemetryMessage): void {
+    if (message.event === "native-subscribe-ready") {
+      this.initialNativeReadyRoots.add(path.resolve(message.rootPath));
+    }
+    if (!this.measuring) {
+      this.signal();
+      return;
+    }
+    switch (message.event) {
+      case "fault-injected":
+        this.counters.faultInjections += 1;
+        break;
+      case "list-entries-complete":
+        this.counters.listEntriesCalls += 1;
+        this.counters.listEntriesProcessed += message.entryCount ?? 0;
+        break;
+      case "native-subscribe-ready":
+        this.counters.nativeSubscribeReady += 1;
+        break;
+      case "native-subscribe-start":
+        this.counters.nativeSubscribeStarts += 1;
+        break;
+      case "native-unsubscribe-ready":
+        this.counters.nativeUnsubscribeReady += 1;
+        break;
+      case "native-unsubscribe-start":
+        this.counters.nativeUnsubscribeStarts += 1;
+        break;
+    }
+    this.signal();
+  }
+
+  recordHostReady(rootIndex: number): void {
+    this.hostReadyRoots.add(rootIndex);
+    this.signal();
+  }
+
+  recordHostEvents(eventCount: number): void {
+    if (!this.measuring) {
+      return;
+    }
+    this.counters.hostEventBatches += 1;
+    this.counters.hostEvents += eventCount;
+    this.signal();
+  }
+
+  recordRescanNotification(): void {
+    if (!this.measuring) {
+      return;
+    }
+    this.counters.rescanNotifications += 1;
+    this.signal();
+  }
+
+  recordWatchError(error: Error): void {
+    if (!this.measuring) {
+      return;
+    }
+    this.counters.watchErrors += 1;
+    this.fail(error);
+  }
+
+  recordDownstreamScan(rootIndex: number, result: TreeScanResult): void {
+    if (!this.measuring) {
+      return;
+    }
+    this.counters.downstreamScans += 1;
+    this.counters.downstreamBytesRead += result.bytes;
+    this.counters.downstreamEntriesProcessed += result.entries;
+    this.counters.downstreamFilesRead += result.files;
+    if (rootIndex === 0) {
+      this.counters.affectedDownstreamScans += 1;
+    } else {
+      this.counters.unaffectedDownstreamScans += 1;
+    }
+    this.signal();
+  }
+
+  waitFor(
+    label: string,
+    predicate: () => boolean,
+    timeoutMs: number = RECOVERY_TIMEOUT_MS,
+  ): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.listeners.delete(check);
+        reject(
+          new Error(`${label} timed out: ${JSON.stringify(this.counters)}`),
+        );
+      }, timeoutMs);
+      const check = () => {
+        if (this.failure) {
+          clearTimeout(timeout);
+          this.listeners.delete(check);
+          reject(this.failure);
+          return;
+        }
+        if (predicate()) {
+          clearTimeout(timeout);
+          this.listeners.delete(check);
+          resolve();
+        }
+      };
+      this.listeners.add(check);
+      check();
+    });
+  }
+
+  private signal(): void {
+    for (const listener of [...this.listeners]) {
+      listener();
+    }
+  }
+}
+
+class ControlledCpuLoad {
+  private readonly payload = Buffer.alloc(64 * 1024, 0x5a);
+  private stopped = false;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  cycles = 0;
+
+  start(): void {
+    this.timer = setTimeout(() => this.runBurst(), 0);
+  }
+
+  async warm(): Promise<void> {
+    await new Promise<void>((resolve) =>
+      setTimeout(resolve, 4 * LOAD_BURST_MS),
+    );
+  }
+
+  async stop(): Promise<void> {
+    this.stopped = true;
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  }
+
+  private runBurst(): void {
+    if (this.stopped) {
+      return;
+    }
+    const deadline = performance.now() + LOAD_BURST_MS;
+    while (performance.now() < deadline) {
+      createHash("sha256").update(this.payload).digest();
+      this.cycles += 1;
+    }
+    this.timer = setTimeout(() => this.runBurst(), LOAD_YIELD_MS);
+  }
+}
+
+function parsePositiveInteger(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return parsed;
+}
+
+async function createFixture(rootCount: number): Promise<Fixture> {
+  const baseDir = await fs.mkdtemp(
+    path.join(os.tmpdir(), `bb-watcher-root-recovery-${rootCount}-`),
+  );
+  const roots: string[] = [];
+  for (let rootIndex = 0; rootIndex < rootCount; rootIndex += 1) {
+    const rootPath = path.join(baseDir, `root-${rootIndex}`);
+    roots.push(rootPath);
+    await fs.mkdir(rootPath);
+    for (
+      let directoryIndex = 0;
+      directoryIndex < DIRECTORY_COUNT_PER_ROOT;
+      directoryIndex += 1
+    ) {
+      const directoryPath = path.join(rootPath, `dir-${directoryIndex}`);
+      await fs.mkdir(directoryPath);
+      const writes: Promise<void>[] = [];
+      for (
+        let fileIndex = 0;
+        fileIndex < FILE_COUNT_PER_DIRECTORY;
+        fileIndex += 1
+      ) {
+        const fill = (rootIndex + directoryIndex + fileIndex) % 251;
+        writes.push(
+          fs.writeFile(
+            path.join(directoryPath, `file-${fileIndex}.bin`),
+            Buffer.alloc(FILE_SIZE_BYTES, fill),
+          ),
+        );
+      }
+      await Promise.all(writes);
+    }
+    await fs.writeFile(
+      path.join(rootPath, "fault-trigger.bin"),
+      Buffer.alloc(FILE_SIZE_BYTES, rootIndex % 251),
+    );
+  }
+  return {
+    baseDir,
+    roots,
+    triggerPath: path.join(roots[0] ?? baseDir, "fault-trigger.bin"),
+    rootCount,
+    filesPerRoot: FILE_COUNT_PER_ROOT,
+    bytesPerRoot: BYTE_COUNT_PER_ROOT,
+    topLevelEntriesPerRoot: TOP_LEVEL_ENTRY_COUNT_PER_ROOT,
+    treeEntriesPerRoot: TREE_ENTRY_COUNT_PER_ROOT,
+    totalFiles: FILE_COUNT_PER_ROOT * rootCount,
+    totalBytes: BYTE_COUNT_PER_ROOT * rootCount,
+  };
+}
+
+async function scanTree(rootPath: string): Promise<TreeScanResult> {
+  const hash = createHash("sha256");
+  const directories = [rootPath];
+  let bytes = 0;
+  let entries = 0;
+  let files = 0;
+  while (directories.length > 0) {
+    const directory = directories.pop();
+    if (!directory) {
+      break;
+    }
+    const children = (
+      await fs.readdir(directory, { withFileTypes: true })
+    ).sort((left, right) => left.name.localeCompare(right.name));
+    entries += children.length;
+    for (const child of children) {
+      const childPath = path.join(directory, child.name);
+      if (child.isDirectory()) {
+        directories.push(childPath);
+        continue;
+      }
+      if (!child.isFile()) {
+        continue;
+      }
+      const data = await fs.readFile(childPath);
+      hash.update(childPath);
+      hash.update(data);
+      bytes += data.byteLength;
+      files += 1;
+    }
+  }
+  hash.digest();
+  return { bytes, entries, files };
+}
+
+function createInstrumentedChannel(
+  observer: RecoveryObserver,
+  faultRoot: string,
+  triggerPath: string,
+): ChildChannel {
+  observer.recordChildSpawn();
+  const child = fork(benchmarkChildPath, [], {
+    env: {
+      ...process.env,
+      BB_WATCHER_BENCHMARK_FAULT_ROOT: faultRoot,
+      BB_WATCHER_BENCHMARK_TRIGGER_PATH: triggerPath,
+    },
+    execArgv: ["--import", "tsx"],
+    stdio: ["ignore", "inherit", "inherit", "ipc"],
+  });
+  const channel = createChildChannel(child);
+  return {
+    send(message) {
+      observer.recordParentMessage(message);
+      channel.send(message);
+    },
+    onMessage(listener) {
+      channel.onMessage((message) => {
+        const boundaryMessage: unknown = message;
+        if (isBenchmarkTelemetryMessage(boundaryMessage)) {
+          observer.recordTelemetry(boundaryMessage);
+          return;
+        }
+        observer.recordChildMessage(message);
+        listener(message);
+      });
+    },
+    onExit(listener) {
+      channel.onExit(listener);
+    },
+    kill() {
+      channel.kill();
+    },
+  };
+}
+
+function triggerPayload(sequence: number): Buffer {
+  const payload = Buffer.alloc(FILE_SIZE_BYTES, sequence % 251);
+  payload.writeUInt32BE(sequence, 0);
+  return payload;
+}
+
+function expectedGlobalRecovery(
+  observer: RecoveryObserver,
+  fixture: Fixture,
+): boolean {
+  const counters = observer.counters;
+  return (
+    counters.childRestarts === 1 &&
+    counters.proxySubscribeMessages === fixture.rootCount &&
+    counters.proxyReplaySubscriptions === fixture.rootCount &&
+    counters.nativeSubscribeReady === fixture.rootCount &&
+    counters.listEntriesCalls === fixture.rootCount &&
+    counters.listEntriesProcessed ===
+      fixture.rootCount * fixture.topLevelEntriesPerRoot &&
+    counters.childEventBatches === fixture.rootCount &&
+    counters.childEvents ===
+      fixture.rootCount * fixture.topLevelEntriesPerRoot &&
+    counters.hostEventBatches === fixture.rootCount &&
+    counters.hostEvents ===
+      fixture.rootCount * fixture.topLevelEntriesPerRoot &&
+    counters.downstreamScans === fixture.rootCount &&
+    counters.downstreamFilesRead === fixture.totalFiles &&
+    counters.downstreamBytesRead === fixture.totalBytes &&
+    counters.downstreamEntriesProcessed ===
+      fixture.rootCount * fixture.treeEntriesPerRoot
+  );
+}
+
+function expectedTargetedRecovery(
+  observer: RecoveryObserver,
+  fixture: Fixture,
+): boolean {
+  const counters = observer.counters;
+  return (
+    counters.childRestarts === 0 &&
+    counters.proxySubscribeMessages === 1 &&
+    counters.proxyReplaySubscriptions === 0 &&
+    counters.proxyUnsubscribeMessages === 1 &&
+    counters.nativeSubscribeReady === 1 &&
+    counters.nativeUnsubscribeReady === 1 &&
+    counters.listEntriesCalls === 0 &&
+    counters.childEventBatches === 0 &&
+    counters.hostEventBatches === 0 &&
+    counters.rescanNotifications === 2 &&
+    counters.downstreamScans === 2 &&
+    counters.downstreamFilesRead === 2 * fixture.filesPerRoot &&
+    counters.downstreamBytesRead === 2 * fixture.bytesPerRoot &&
+    counters.downstreamEntriesProcessed === 2 * fixture.treeEntriesPerRoot
+  );
+}
+
+function cloneCounters(counters: RecoveryCounters): RecoveryCounters {
+  return { ...counters };
+}
+
+async function runIteration(args: {
+  fixture: Fixture;
+  loadMode: LoadMode;
+  sequence: number;
+}): Promise<IterationResult> {
+  const { fixture, loadMode, sequence } = args;
+  const observer = new RecoveryObserver();
+  const proxy = createParcelWatcherProxy({
+    spawnChannel: () =>
+      createInstrumentedChannel(
+        observer,
+        fixture.roots[0] ?? fixture.baseDir,
+        fixture.triggerPath,
+      ),
+  });
+  setParcelWatcherBackend(proxy);
+  const hostWatcher = createParcelHostWatcher();
+  const watchPathRoot = hostWatcher.watchPathRoot;
+  if (!watchPathRoot) {
+    throw new Error("Host watcher path-root support is required");
+  }
+  const schedulers: ReturnType<typeof createDebouncedCallbackScheduler>[] = [];
+  const stops: Array<() => void | Promise<void>> = [];
+  const setupStartedAt = performance.now();
+  let cpuLoad: ControlledCpuLoad | null = null;
+  const eventLoopDelay = monitorEventLoopDelay({ resolution: 1 });
+
+  try {
+    for (let rootIndex = 0; rootIndex < fixture.roots.length; rootIndex += 1) {
+      const rootPath = fixture.roots[rootIndex];
+      if (!rootPath) {
+        throw new Error(`Missing fixture root ${rootIndex}`);
+      }
+      const scheduler = createDebouncedCallbackScheduler({
+        debounceMs: DOWNSTREAM_DEBOUNCE_MS,
+        maxWaitMs: DOWNSTREAM_MAX_WAIT_MS,
+        onFlush: () => {
+          void scanTree(rootPath)
+            .then((result) => {
+              if (
+                result.files !== fixture.filesPerRoot ||
+                result.bytes !== fixture.bytesPerRoot ||
+                result.entries !== fixture.treeEntriesPerRoot
+              ) {
+                throw new Error(
+                  `Unexpected tree scan for ${rootPath}: ${JSON.stringify(result)}`,
+                );
+              }
+              observer.recordDownstreamScan(rootIndex, result);
+            })
+            .catch((error: unknown) => observer.fail(error));
+        },
+      });
+      schedulers.push(scheduler);
+      stops.push(
+        watchPathRoot({
+          rootPath,
+          ignoredPaths: [],
+          onChange: (changes) => {
+            observer.recordHostEvents(changes.length);
+            scheduler.schedule();
+          },
+          onReady: () => observer.recordHostReady(rootIndex),
+          onRescanRequired: () => {
+            observer.recordRescanNotification();
+            scheduler.schedule();
+          },
+          onWatchError: (error) => {
+            observer.recordWatchError(new Error(error.message));
+          },
+        }),
+      );
+    }
+
+    await observer.waitFor(
+      "initial watcher readiness",
+      () =>
+        observer.hostReadyRoots.size === fixture.rootCount &&
+        observer.initialNativeReadyRoots.size === fixture.rootCount,
+    );
+    const initialReadyMs = performance.now() - setupStartedAt;
+
+    if (loadMode === "controlled-cpu") {
+      cpuLoad = new ControlledCpuLoad();
+      cpuLoad.start();
+      await cpuLoad.warm();
+    }
+
+    eventLoopDelay.enable();
+    eventLoopDelay.reset();
+    const eventLoopUtilizationStart = performance.eventLoopUtilization();
+    observer.startMeasuring();
+    const recoveryStartedAt = performance.now();
+    await fs.writeFile(fixture.triggerPath, triggerPayload(sequence));
+
+    await observer.waitFor(
+      "fault injection",
+      () => observer.counters.faultInjections === 1,
+    );
+    await observer.waitFor(
+      "recovery classification",
+      () =>
+        observer.counters.childRestarts === 1 ||
+        observer.counters.nativeUnsubscribeStarts === 1,
+    );
+
+    const recoveryKind: RecoveryKind =
+      observer.counters.childRestarts === 1
+        ? "global-restart"
+        : "targeted-subscription";
+    await observer.waitFor("settled watcher recovery", () =>
+      recoveryKind === "global-restart"
+        ? expectedGlobalRecovery(observer, fixture)
+        : expectedTargetedRecovery(observer, fixture),
+    );
+    const recoveryLatencyMs = performance.now() - recoveryStartedAt;
+    eventLoopDelay.disable();
+    const eventLoopUtilization = performance.eventLoopUtilization(
+      eventLoopUtilizationStart,
+    );
+    if (cpuLoad) {
+      await cpuLoad.stop();
+    }
+    const countersAtSettlement = JSON.stringify(observer.counters);
+    await new Promise<void>((resolve) => setTimeout(resolve, QUIESCENCE_MS));
+    expect(JSON.stringify(observer.counters)).toBe(countersAtSettlement);
+    expect(observer.counters.faultInjections).toBe(1);
+    expect(observer.counters.watchErrors).toBe(0);
+    expect(observer.counters.nativeSubscribeStarts).toBe(
+      observer.counters.nativeSubscribeReady,
+    );
+    expect(observer.counters.nativeUnsubscribeStarts).toBe(
+      observer.counters.nativeUnsubscribeReady,
+    );
+    if (recoveryKind === "global-restart") {
+      expect(expectedGlobalRecovery(observer, fixture)).toBe(true);
+      expect(observer.counters.rescanNotifications).toBe(0);
+      expect(observer.counters.affectedDownstreamScans).toBe(1);
+      expect(observer.counters.unaffectedDownstreamScans).toBe(
+        fixture.rootCount - 1,
+      );
+    } else {
+      expect(expectedTargetedRecovery(observer, fixture)).toBe(true);
+      expect(observer.counters.affectedDownstreamScans).toBe(2);
+      expect(observer.counters.unaffectedDownstreamScans).toBe(0);
+    }
+    observer.stopMeasuring();
+
+    return {
+      counters: cloneCounters(observer.counters),
+      eventLoopDelayMaxMs: eventLoopDelay.max / 1_000_000,
+      eventLoopDelayP50Ms: eventLoopDelay.percentile(50) / 1_000_000,
+      eventLoopDelayP95Ms: eventLoopDelay.percentile(95) / 1_000_000,
+      eventLoopUtilization: eventLoopUtilization.utilization,
+      initialReadyMs,
+      loadCycles: cpuLoad?.cycles ?? 0,
+      loadMode,
+      recoveryKind,
+      recoveryLatencyMs,
+      rootCount: fixture.rootCount,
+    };
+  } finally {
+    eventLoopDelay.disable();
+    if (cpuLoad) {
+      await cpuLoad.stop();
+    }
+    for (const scheduler of schedulers) {
+      scheduler.dispose();
+    }
+    await Promise.all(stops.map(async (stop) => stop()));
+    disposeParcelWatcherBackend();
+  }
+}
+
+function percentile(values: readonly number[], quantile: number): number {
+  const sorted = [...values].sort((left, right) => left - right);
+  const index = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.ceil(sorted.length * quantile) - 1),
+  );
+  const value = sorted[index];
+  if (value === undefined) {
+    throw new Error("Benchmark distribution requires samples");
+  }
+  return value;
+}
+
+function distribution(values: readonly number[]): Distribution {
+  return {
+    max: Math.max(...values),
+    p50: percentile(values, 0.5),
+    p95: percentile(values, 0.95),
+  };
+}
+
+function summarize(
+  rootCount: number,
+  loadMode: LoadMode,
+  samples: readonly IterationResult[],
+): ScenarioSummary {
+  const first = samples[0];
+  if (!first) {
+    throw new Error("Benchmark summary requires samples");
+  }
+  const counts = JSON.stringify(first.counters);
+  return {
+    counts: first.counters,
+    countsDeterministic: samples.every(
+      (sample) => JSON.stringify(sample.counters) === counts,
+    ),
+    eventLoopDelayMaxMs: distribution(
+      samples.map((sample) => sample.eventLoopDelayMaxMs),
+    ),
+    eventLoopUtilization: distribution(
+      samples.map((sample) => sample.eventLoopUtilization),
+    ),
+    initialReadyMs: distribution(
+      samples.map((sample) => sample.initialReadyMs),
+    ),
+    iterations: samples.length,
+    loadMode,
+    recoveryKind: first.recoveryKind,
+    recoveryLatencyMs: distribution(
+      samples.map((sample) => sample.recoveryLatencyMs),
+    ),
+    rootCount,
+  };
+}
+
+describe.runIf(BENCHMARK_ENABLED)("root watcher recovery benchmark", () => {
+  it(
+    "measures settled recovery through real subprocess and filesystem work",
+    async () => {
+      const iterations = parsePositiveInteger(
+        "BB_WATCHER_BENCHMARK_ITERATIONS",
+        DEFAULT_ITERATIONS,
+      );
+      const warmupIterations = parsePositiveInteger(
+        "BB_WATCHER_BENCHMARK_WARMUPS",
+        DEFAULT_WARMUP_ITERATIONS,
+      );
+      const raw: IterationResult[] = [];
+      const summary: ScenarioSummary[] = [];
+      let sequence = 1;
+
+      for (const rootCount of ROOT_COUNTS) {
+        const fixture = await createFixture(rootCount);
+        try {
+          for (const loadMode of [
+            "idle",
+            "controlled-cpu",
+          ] satisfies readonly LoadMode[]) {
+            for (let index = 0; index < warmupIterations; index += 1) {
+              await runIteration({ fixture, loadMode, sequence });
+              sequence += 1;
+            }
+            const samples: IterationResult[] = [];
+            for (let index = 0; index < iterations; index += 1) {
+              const sample = await runIteration({
+                fixture,
+                loadMode,
+                sequence,
+              });
+              sequence += 1;
+              samples.push(sample);
+              raw.push(sample);
+            }
+            const scenario = summarize(rootCount, loadMode, samples);
+            expect(scenario.countsDeterministic).toBe(true);
+            expect(
+              samples.every(
+                (sample) => sample.recoveryKind === scenario.recoveryKind,
+              ),
+            ).toBe(true);
+            summary.push(scenario);
+          }
+        } finally {
+          await fs.rm(fixture.baseDir, { force: true, recursive: true });
+        }
+      }
+
+      const document: BenchmarkDocument = {
+        fixture: {
+          bytesPerRoot: BYTE_COUNT_PER_ROOT,
+          directoriesPerRoot: DIRECTORY_COUNT_PER_ROOT,
+          fileSizeBytes: FILE_SIZE_BYTES,
+          filesPerDirectory: FILE_COUNT_PER_DIRECTORY,
+          filesPerRoot: FILE_COUNT_PER_ROOT,
+          topLevelEntriesPerRoot: TOP_LEVEL_ENTRY_COUNT_PER_ROOT,
+          treeEntriesPerRoot: TREE_ENTRY_COUNT_PER_ROOT,
+        },
+        host: {
+          arch: os.arch(),
+          node: process.version,
+          platform: os.platform(),
+          release: os.release(),
+        },
+        iterations,
+        raw,
+        summary,
+        warmupIterations,
+      };
+      const outputPath = process.env.BB_WATCHER_BENCHMARK_OUTPUT;
+      if (outputPath) {
+        await fs.writeFile(
+          outputPath,
+          `${JSON.stringify(document, null, 2)}\n`,
+        );
+      }
+      process.stdout.write(
+        `WATCHER_ROOT_RECOVERY_BENCHMARK ${JSON.stringify({
+          fixture: document.fixture,
+          host: document.host,
+          iterations,
+          summary,
+          warmupIterations,
+          ...(outputPath ? { outputPath } : {}),
+        })}\n`,
+      );
+    },
+    30 * 60_000,
+  );
+});


### PR DESCRIPTION
## Human comments

## What was wrong

`RootSubscription` already distinguishes the native FSEvents `File system must be re-scanned` condition from fatal watcher failures and performs targeted refresh/reconnect/refresh recovery. The subprocess boundary introduced by PR #250 erased that distinction: every parcel callback error became the same `watch-error`, and the parent unconditionally killed the shared watcher child, replayed every subscription, called `listEntries` for every root, and emitted synthetic updates to unaffected watches. Whole-child recycling is required for fatal Linux backend failures such as inotify `EINTR`, but it turns a recoverable subscription-specific FSEvents overflow into O(all active watches) work.

Historical supporting evidence, separate from the controlled benchmark below:

- Apr 20 commits `64c74f0a0` and `1283e636e` introduced targeted FSEvents recovery.
- Jun 8 commit `2160f2838` moved that lifecycle into `RootSubscription`.
- Jun 12 commit `9786b64d9` made fatal Linux inotify callback errors terminal in-process to prevent retry leaks.
- Jun 22 PR #250 / commit `cba0b9e89` intentionally added whole-child recycling for fatal `EINTR`, child crashes, and hangs. Its interception was broad because the child protocol had no recovery classification, not because FSEvents overflow was intended to become global.
- The investigation observed 57 ready environment watches in the affected deployment. That production observation selected the N=57 fixture; it is not included in the controlled timing data.

## What changed

- Classify parcel callback errors in the watcher child as either `rescan-subscription` or `recycle-child`.
- Route `rescan-subscription` only to the matching proxy callback with the original message, allowing the existing `RootSubscription` targeted recovery to run without replacing the child.
- Keep all non-rescan callback errors on the existing whole-child recycle path. Child exits and liveness timeouts are unchanged.
- Add a two-subscription regression, a deterministic proxy fan-out count harness, and an opt-in end-to-end N=57/N=100 recovery benchmark.

This changes only the bundled parent/child watcher subprocess protocol. It does not change the server/host-daemon wire protocol, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

## How you verified

### Controlled end-to-end benchmark

Both revisions ran sequentially on the same machine with byte-identical benchmark code and generated fixture contents: macOS 26.5.1 / Darwin 25.5.0 arm64, Node 22.23.1, pnpm 9.15.0. “Before” is `origin/main` at `a2fcbaf55` with only the two benchmark files applied; “after” is `d3078ca4c`. Each scenario used 2 warm-ups and 20 measured iterations. Every iteration created a fresh real child process, IPC channel, native watcher set, `HostWatcher`, and `RootSubscription` set.

Each root contains 8 directories with 16 × 4 KiB files each plus one 4 KiB trigger file: 129 files, 528,384 bytes, 9 top-level entries, and 137 recursive tree entries per root.

| Roots | Nested directories | Files | Bytes | Recursive entries |
| ---: | ---: | ---: | ---: | ---: |
| 57 | 456 | 7,353 | 30,117,888 (28.72 MiB) | 7,809 |
| 100 | 800 | 12,900 | 52,838,400 (50.39 MiB) | 13,700 |

The measured path is:

`real file write → real @parcel/watcher/FSEvents subscription in a forked child → production child handler and IPC channel → production proxy → HostWatcher.watchPathRoot → RootSubscription → production 250 ms reconnect retry and 75/500 ms callback scheduler → calibrated recursive readdir/read/SHA-256 downstream refresh`

Root 0 alone receives the injected overflow. Measurement begins before the real trigger-file write and stops only after exact settled-work predicates pass. Before requires one child restart, all N proxy/native replay subscriptions, all N real `listEntries` calls, all N synthetic event callbacks, and all N recursive downstream scans. After requires the affected native unsubscribe/reconnect, both targeted rescan notifications, and both affected-root downstream scans. Subscribe/unsubscribe starts must equal completions, and a 100 ms quiescence assertion rejects late work after settlement.

The controlled-load mode runs repeated SHA-256 work for 8 ms and yields for 8 ms on the benchmark process's event-loop thread. It is reproducible and does not load every CPU core or the live bb server. “Idle” means no intentional benchmark load, not a dedicated idle host.

#### Settled recovery latency

Milliseconds, p50 / p95 / max. The N=57 distributions mostly overlap because targeted recovery deliberately retains its retry and two debounce phases; the after idle p50 is higher. The scaling benefit becomes clear at N=100, especially under controlled load.

| Roots | Mode | Before | After |
| ---: | --- | ---: | ---: |
| 57 | idle | 291.6 / 449.7 / 529.4 | 340.1 / 379.9 / 445.0 |
| 57 | controlled CPU | 380.2 / 383.7 / 400.2 | 367.3 / 390.0 / 429.4 |
| 100 | idle | 361.5 / 1,179.5 / 2,419.7 | 355.6 / 460.1 / 510.3 |
| 100 | controlled CPU | 2,606.9 / 5,095.9 / 6,599.1 | 367.8 / 375.4 / 441.1 |

#### Maximum event-loop delay per iteration

Milliseconds, distribution of each iteration's maximum delay as p50 / p95 / max.

| Roots | Mode | Before | After |
| ---: | --- | ---: | ---: |
| 57 | idle | 1.88 / 6.34 / 6.35 | 2.05 / 6.92 / 8.31 |
| 57 | controlled CPU | 9.32 / 9.52 / 9.54 | 9.36 / 10.22 / 23.41 |
| 100 | idle | 1.89 / 27.20 / 50.30 | 2.20 / 7.51 / 8.08 |
| 100 | controlled CPU | 67.08 / 145.88 / 211.81 | 9.34 / 10.57 / 14.03 |

#### Initial readiness

Milliseconds from constructing the watcher graph until all HostWatcher `onReady` callbacks and all native subscriptions were ready, p50 / p95 / max. This happens before overflow injection and is recorded separately from recovery latency.

| Roots | Mode | Before | After |
| ---: | --- | ---: | ---: |
| 57 | idle | 129.0 / 277.4 / 461.9 | 220.4 / 350.0 / 402.0 |
| 57 | controlled CPU | 128.5 / 131.2 / 132.9 | 129.9 / 157.7 / 171.3 |
| 100 | idle | 135.8 / 426.6 / 771.4 | 152.9 / 906.5 / 981.8 |
| 100 | controlled CPU | 339.0 / 843.9 / 901.1 | 139.1 / 1,104.0 / 1,239.0 |

#### Deterministic settled work

Counts were identical across all 20 idle iterations and all 20 controlled-load iterations for each revision. “2 scans after” is the affected `RootSubscription`'s dropped-event refresh plus its post-reconnect refresh; zero `listEntries` means zero global proxy replay scans, not zero targeted recovery.

| Metric after one overflow | 57 before | 57 after | 100 before | 100 after |
| --- | ---: | ---: | ---: | ---: |
| watcher-child restarts | 1 | 0 | 1 | 0 |
| proxy subscribe messages | 57 | 1 | 100 | 1 |
| proxy replay subscriptions | 57 | 0 | 100 | 0 |
| proxy unsubscribe messages | 0 | 1 | 0 | 1 |
| native subscribe starts / ready | 57 / 57 | 1 / 1 | 100 / 100 | 1 / 1 |
| native unsubscribe starts / ready | 0 / 0 | 1 / 1 | 0 / 0 | 1 / 1 |
| real `listEntries` calls / entries | 57 / 513 | 0 / 0 | 100 / 900 | 0 / 0 |
| child event batches / events | 57 / 513 | 0 / 0 | 100 / 900 | 0 / 0 |
| host event batches / events | 57 / 513 | 0 / 0 | 100 / 900 | 0 / 0 |
| targeted rescan notifications | 0 | 2 | 0 | 2 |
| affected / unaffected downstream scans | 1 / 56 | 2 / 0 | 1 / 99 | 2 / 0 |
| downstream files read | 7,353 | 258 | 12,900 | 258 |
| downstream bytes read | 30,117,888 | 1,056,768 | 52,838,400 | 1,056,768 |
| downstream entries processed | 7,809 | 274 | 13,700 | 274 |
| watcher errors | 0 | 0 | 0 | 0 |

#### Remaining controlled substitutions and limitations

- A native FSEvents overflow is not induced. At the narrowest deterministic seam, the benchmark child converts the real trigger-file event into the exact rescan-required callback error immediately before the production child handler. The native subscription, trigger event, process fork, IPC, handler, proxy, HostWatcher, RootSubscription, retry, reconnect, and filesystem work remain real.
- The benchmark child entry is TypeScript under `tsx`, rather than the packaged production entry, so it can wrap the real parcel backend and emit telemetry. The child handler and IPC protocol under test are production code.
- Running the full daemon/workspace callback graph safely would mix status/environment/server effects into a watcher-only PR. The downstream callback is explicitly calibrated: production debounce scheduling followed by recursive real filesystem reads and SHA-256 of every file. It does not include WatchManager status/environment work, database/server work, production logging, or production filesystem shape/cache state.
- The load generator contends with the host-side watcher/recovery event loop only. It models event-loop pressure reproducibly; it is not a whole-machine production-load replay.

Full per-iteration JSON, including event-loop utilization, per-iteration delay p50/p95/max, load cycles, readiness, latency, and all counters, is produced by `BB_WATCHER_BENCHMARK_OUTPUT`.

Reproduction harness: `packages/host-watcher/test/root-recovery-benchmark.test.ts` and `packages/host-watcher/test/fixtures/parcel-recovery-benchmark-child.ts`.

```sh
git worktree add /tmp/bb-watcher-before a2fcbaf55
git worktree add /tmp/bb-watcher-after d3078ca4c
git -C /tmp/bb-watcher-before checkout d3078ca4c -- packages/host-watcher/test/root-recovery-benchmark.test.ts packages/host-watcher/test/fixtures/parcel-recovery-benchmark-child.ts
pnpm --dir /tmp/bb-watcher-before install --frozen-lockfile
pnpm --dir /tmp/bb-watcher-after install --frozen-lockfile

BB_WATCHER_ROOT_RECOVERY_BENCHMARK=1 BB_WATCHER_BENCHMARK_ITERATIONS=20 BB_WATCHER_BENCHMARK_WARMUPS=2 BB_WATCHER_BENCHMARK_OUTPUT=/tmp/watcher-before.json pnpm --dir /tmp/bb-watcher-before exec turbo run test --filter=@bb/host-watcher --force --env-mode=loose -- --run test/root-recovery-benchmark.test.ts --silent=false
BB_WATCHER_ROOT_RECOVERY_BENCHMARK=1 BB_WATCHER_BENCHMARK_ITERATIONS=20 BB_WATCHER_BENCHMARK_WARMUPS=2 BB_WATCHER_BENCHMARK_OUTPUT=/tmp/watcher-after.json pnpm --dir /tmp/bb-watcher-after exec turbo run test --filter=@bb/host-watcher --force --env-mode=loose -- --run test/root-recovery-benchmark.test.ts --silent=false
```

### Regression and validation

- Applying the new proxy test to `a2fcbaf55` fails with `expected [ Array(2) ] to have a length of 1 but got 2`; it passes on `d3078ca4c`:

  ```sh
  pnpm exec turbo run test --filter=@bb/host-watcher --force -- --run test/parcel-watcher-proxy.test.ts -t "routes rescan-required errors only to the affected subscription"
  ```

- `pnpm exec turbo run test --filter=@bb/host-watcher --force` — 47 passed, 3 opt-in/platform-skipped.
- `pnpm exec turbo run typecheck --filter=@bb/host-watcher` — passed.
- `pnpm exec turbo run build --filter=@bb/host-watcher --filter=@bb/host-daemon` — 5 Turbo tasks passed; watcher child bundle built at 1,945 bytes.
- `pnpm exec turbo run test --filter=@bb/host-daemon --force -- --run src/watch-manager.test.ts test/parcel-watcher-not-loaded-in-parent.test.ts` — 19 passed.
- The full host-daemon run reached 564/565 passing tests, but current `origin/main` and this branch both fail host-daemon typecheck at `host-branches-dispatch.test.ts:392` because `host.list_branches` is absent from the current command union. That unrelated daemon work is not changed here.

No linked issue.

> AGENT GENERATED
