### PR TITLE
Restore inactive right-panel pane ownership

### DIFF
--- a/apps/app/src/components/secondary-panel/SidebarSplitContainer.test.tsx
+++ b/apps/app/src/components/secondary-panel/SidebarSplitContainer.test.tsx
@@ -168,7 +168,7 @@ describe("SidebarSplitContainer", () => {
     document.body.style.userSelect = "";
   });
 
-  it("activates a focused pane outside React's state updater", async () => {
+  it("activates a pane before a descendant stops pointer propagation", async () => {
     const split = createTwoPaneState();
     const firstPaneId =
       split.layout.root.type === "split"
@@ -206,7 +206,13 @@ describe("SidebarSplitContainer", () => {
           onToggleFullScreen={vi.fn()}
           panelStateId={PANEL_STATE_ID}
           renderPane={({ paneId }) => (
-            <div data-testid={`pane-content-${paneId}`}>{paneId}</div>
+            <button
+              type="button"
+              data-testid={`pane-content-${paneId}`}
+              onPointerDown={(event) => event.stopPropagation()}
+            >
+              {paneId}
+            </button>
           )}
           tabs={TABS}
         />
@@ -233,6 +239,40 @@ describe("SidebarSplitContainer", () => {
         ),
       ),
     ).toBe(false);
+  });
+
+  it("activates a pane when keyboard focus enters it", async () => {
+    const split = createTwoPaneState();
+    const paneIds =
+      split.layout.root.type === "split"
+        ? split.layout.root.children.flatMap((child) =>
+            child.type === "pane" ? [child.paneId] : [],
+          )
+        : [];
+    expect(paneIds).toHaveLength(2);
+    const [firstPaneId, secondPaneId] = paneIds;
+    if (firstPaneId === undefined || secondPaneId === undefined) return;
+    persistState(focusSidebarPane(split, firstPaneId));
+    const activate = vi.fn();
+
+    renderContainer({
+      activeTabId: "tab-a",
+      onActivateTab: activate,
+      renderPane: ({ paneId }) => (
+        <button type="button" data-testid={`focus-target-${paneId}`}>
+          {paneId}
+        </button>
+      ),
+    });
+    fireEvent.focus(screen.getByTestId(`focus-target-${secondPaneId}`));
+
+    await waitFor(() => expect(activate).toHaveBeenCalledWith("tab-b"));
+    expect(activate).toHaveBeenCalledTimes(1);
+    expect(
+      document.querySelector(
+        `[data-split-pane-id="${secondPaneId}"][data-focused="true"]`,
+      ),
+    ).not.toBeNull();
   });
 
   it("assigns focus and outer controls to the appropriate panes", () => {

--- a/apps/app/src/components/secondary-panel/SidebarSplitContainer.tsx
+++ b/apps/app/src/components/secondary-panel/SidebarSplitContainer.tsx
@@ -648,7 +648,8 @@ function SidebarSplitLeaf(props: SidebarSplitLeafProps) {
   return (
     <PaneContext.Provider value={context}>
       <div
-        onPointerDown={() => props.onFocusPane(pane.paneId)}
+        onPointerDownCapture={() => props.onFocusPane(pane.paneId)}
+        onFocusCapture={() => props.onFocusPane(pane.paneId)}
         aria-hidden={isHiddenByMaximize || undefined}
         style={
           isMaximized


### PR DESCRIPTION
## Human comments

## What was wrong

A split-pane leaf only claimed pane ownership during bubble-phase pointer events. Descendants that stopped pointer propagation, and keyboard focus entering another pane, could therefore leave the previously focused pane and global active tab owning subsequent pane actions.

## What changed

Handle pointer entry in the capture phase and claim pane ownership when focus enters a split leaf. Regression coverage verifies stopped pointer events and keyboard focus both activate the correct pane. This is app-only behavior with no wire, CLI, or documentation changes.

## How you verified

- `pnpm exec turbo run typecheck --filter=@bb/app --force`
- `pnpm exec turbo run test --filter=@bb/app --force -- src/components/secondary-panel/SidebarSplitContainer.test.tsx` (33 tests)
- `git diff --check origin/main...HEAD`
- Manual pointer and keyboard focus flows in the in-app browser

Fixes: no linked issue (local directive)

> AGENT GENERATED