### PR TITLE
Fix macOS PTY master leak

### DIFF
--- a/apps/host-daemon/package.json
+++ b/apps/host-daemon/package.json
@@ -43,7 +43,7 @@
     "gray-matter": "^4.0.3",
     "jiti": "^2.6.1",
     "mime-types": "^3.0.2",
-    "node-pty": "1.1.0",
+    "node-pty": "1.2.0-beta.14",
     "p-retry": "^6.2.1",
     "partysocket": "^1.3.0",
     "pino": "^9.6.0",

--- a/apps/host-daemon/test/node-pty-resource-release.test.ts
+++ b/apps/host-daemon/test/node-pty-resource-release.test.ts
@@ -1,0 +1,46 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const probe = `
+import { execFileSync } from "node:child_process";
+import { spawn } from "node-pty";
+
+const countOpenPtyMasters = () =>
+  execFileSync(
+    "/usr/sbin/lsof",
+    ["-Fn", "-a", "-p", String(process.pid)],
+    { encoding: "utf8" },
+  )
+    .split("\\n")
+    .filter((line) => line === "n/dev/ptmx").length;
+
+const before = countOpenPtyMasters();
+const pty = spawn("/usr/bin/true", [], {
+  cols: 80,
+  cwd: process.cwd(),
+  env: process.env,
+  name: "xterm-256color",
+  rows: 24,
+});
+
+await new Promise((resolve) => pty.onExit(resolve));
+pty.destroy();
+console.log(countOpenPtyMasters() - before);
+`;
+
+describe.skipIf(process.platform !== "darwin")(
+  "node-pty resource release",
+  () => {
+    it("closes the PTY master after the child exits", async () => {
+      const { stdout } = await execFileAsync(
+        process.execPath,
+        ["--input-type=module", "--eval", probe],
+        { cwd: import.meta.dirname },
+      );
+
+      expect(stdout.trim()).toBe("0");
+    });
+  },
+);

--- a/packages/bb-app/package.json
+++ b/packages/bb-app/package.json
@@ -72,7 +72,7 @@
     "better-sqlite3": "12.10.0",
     "hono": "^4.7.0",
     "jiti": "^2.6.1",
-    "node-pty": "1.1.0",
+    "node-pty": "1.2.0-beta.14",
     "pino": "^9.6.0",
     "pino-pretty": "^13.0.0",
     "pino-roll": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -719,8 +719,8 @@ importers:
         specifier: ^3.0.2
         version: 3.0.2
       node-pty:
-        specifier: 1.1.0
-        version: 1.1.0
+        specifier: 1.2.0-beta.14
+        version: 1.2.0-beta.14
       p-retry:
         specifier: ^6.2.1
         version: 6.2.1
@@ -1421,8 +1421,8 @@ importers:
         specifier: ^2.6.1
         version: 2.7.0
       node-pty:
-        specifier: 1.1.0
-        version: 1.1.0
+        specifier: 1.2.0-beta.14
+        version: 1.2.0-beta.14
       pino:
         specifier: ^9.6.0
         version: 9.14.0
@@ -13033,8 +13033,8 @@ packages:
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
 
-  node-pty@1.1.0:
-    resolution: {integrity: sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==}
+  node-pty@1.2.0-beta.14:
+    resolution: {integrity: sha512-XORU9BQgpxVgqr7WivjJ17mLenOHUgKKWzuZZNaw3NDYgHc/wPJQMSaoLDrpEgqV6aU1nNwil1o/OqYj6lWmUA==}
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
@@ -26192,7 +26192,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-pty@1.1.0:
+  node-pty@1.2.0-beta.14:
     dependencies:
       node-addon-api: 7.1.1
 


### PR DESCRIPTION
## Human comments

## What was wrong

The application-level cleanup added in #2644 calls `pty.destroy()`, but `node-pty@1.1.0` still leaves the macOS `/dev/ptmx` master open after the child exits and the terminal is destroyed. Each completed terminal can therefore consume one of macOS's finite PTY slots until the long-lived host daemon exhausts the pool and `forkpty` or `posix_spawnp` fails. This is the remaining native-resource layer of #2641.

## What changed

- Pin `node-pty@1.2.0-beta.14` in both the host daemon and packaged `bb-app` runtime.
- Update the lockfile to resolve that exact version for both importers.
- Add a macOS regression test that opens a real PTY, waits for the child to exit, destroys the terminal, and verifies the process did not retain another `/dev/ptmx` master.

This changes no host-daemon wire contract, so `HOST_DAEMON_PROTOCOL_VERSION` does not change.

## How you verified

- The direct macOS probe reports a retained `/dev/ptmx` delta of `1` with `node-pty@1.1.0` and `0` with `node-pty@1.2.0-beta.14`.
- `pnpm exec turbo run typecheck --filter=@bb/host-daemon --filter=bb-app --filter=@bb/desktop --output-logs=new-only` completed 6/6 tasks after rebasing onto current `main`.
- `pnpm exec turbo run test --filter=@bb/host-daemon --filter=bb-app --force --output-logs=new-only` passed 563 host-daemon tests and 73 `bb-app` tests after the rebase.
- A locally packaged macOS app containing the new dependency passes `codesign --verify --deep --strict`; its live terminal probe retains zero PTY masters.
- The existing `apps/desktop/test/preload-build.test.ts` GUI leg cannot run from this agent session: raw Electron aborts inside macOS `_RegisterApplication` before bb code executes. The macOS CI desktop test and packaged smoke remain required review gates.

## Risk and rollout

`node-pty@1.2.0-beta.14` is a prerelease native dependency, so macOS packaging, native-module preparation, and the complete desktop CI suite are the important merge gates. Release through the normal signed and notarized desktop workflow; do not publish the local emergency build.

Follow-up to #2641 and #2644.

> AGENT GENERATED
