### PR TITLE
Reserve space for the pinned right-panel toggle

### DIFF
--- a/apps/app/src/views/thread-detail/ThreadDetailHeader.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailHeader.test.tsx
@@ -97,6 +97,58 @@ describe("ThreadDetailHeader", () => {
     const button = screen.getByRole("button", { name: "Hide right panel" });
     expect(button.getAttribute("aria-expanded")).toBe("true");
     expect(button.parentElement?.classList).toContain("fixed");
+    expect(
+      document.querySelector("[data-thread-header-panel-toggle-reserve]"),
+    ).toBeNull();
+  });
+
+  it("reserves the pinned right-panel toggle footprint while the panel is closed", () => {
+    render(
+      <PaneContext.Provider value={PANE_CONTEXT}>
+        <ThreadDetailHeader
+          actionsMenu={null}
+          childPillLabel={null}
+          isSecondaryPanelOpen={false}
+          onOpenThreadGitAction={vi.fn()}
+          onToggleSecondaryPanel={vi.fn()}
+          threadHeaderGitActions={[]}
+          threadId={THREAD_ID}
+          threadTitle="Panel state"
+        />
+      </PaneContext.Provider>,
+    );
+
+    const toggle = screen.getByRole("button", { name: "Show right panel" });
+    expect(toggle.parentElement?.classList).toContain("fixed");
+    const reserve = document.querySelector(
+      "[data-thread-header-panel-toggle-reserve]",
+    );
+    expect(reserve?.classList).toContain("header-icon-button");
+  });
+
+  it("does not reserve toggle space for the compact drawer trigger", () => {
+    viewportState.isCompactViewport = true;
+
+    render(
+      <PaneContext.Provider value={PANE_CONTEXT}>
+        <ThreadDetailHeader
+          actionsMenu={null}
+          childPillLabel={null}
+          isSecondaryPanelOpen={false}
+          onOpenThreadGitAction={vi.fn()}
+          onToggleSecondaryPanel={vi.fn()}
+          threadHeaderGitActions={[]}
+          threadId={THREAD_ID}
+          threadTitle="Panel state"
+        />
+      </PaneContext.Provider>,
+    );
+
+    const toggle = screen.getByRole("button", { name: "Show right panel" });
+    expect(toggle.parentElement?.classList).not.toContain("fixed");
+    expect(
+      document.querySelector("[data-thread-header-panel-toggle-reserve]"),
+    ).toBeNull();
   });
 
   it("leaves the open compact-panel collapse control to the drawer", () => {

--- a/apps/app/src/views/thread-detail/ThreadDetailHeader.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailHeader.tsx
@@ -150,6 +150,9 @@ export function ThreadDetailHeader({
   const rightPanelIconName = getRightPanelToggleIconName(renderAsDrawer);
   const showRightPanelToggle =
     secondaryPanelHost === null && (!renderAsDrawer || !isSecondaryPanelOpen);
+  const pinsRightPanelToggle = showRightPanelToggle && !renderAsDrawer;
+  const reservesPinnedRightPanelToggle =
+    pinsRightPanelToggle && !isSecondaryPanelOpen;
 
   const center = (
     <>
@@ -251,9 +254,9 @@ export function ThreadDetailHeader({
           <span
             className={cn(
               "inline-flex items-center gap-1.5",
-              !renderAsDrawer &&
+              pinsRightPanelToggle &&
                 "fixed right-[calc(1rem+env(safe-area-inset-right))] top-[calc(0.625rem+env(safe-area-inset-top))] z-40",
-              !renderAsDrawer &&
+              pinsRightPanelToggle &&
                 usesDesktopChrome &&
                 MACOS_WINDOW_NO_DRAG_CLASS,
             )}
@@ -279,6 +282,13 @@ export function ThreadDetailHeader({
               <Icon name={rightPanelIconName} />
             </Button>
           </span>
+        ) : null}
+        {reservesPinnedRightPanelToggle ? (
+          <span
+            aria-hidden
+            data-thread-header-panel-toggle-reserve=""
+            className={HEADER_ICON_BUTTON_CLASS}
+          />
         ) : null}
         <PaneMaximizeButton />
         {onClosePane ? (


### PR DESCRIPTION
## Human comments

## What was wrong

#2638 pinned the right-panel toggle with `position: fixed` so the icon stays still while the sidebar animates. A fixed element leaves the flow, so the thread header's action row lost the 28px that the toggle used to occupy. The header pads `px-4` and the pinned toggle sits at `right: 1rem`, so with the right panel closed the action row ran under the toggle and the toggle painted on top of the `Commit` split button.

The header already had a reserve slot, but it renders only when `reservesWindowPanelToggle` is true. That flag is true for split panes at the right edge (`SplitThreadArea.tsx`). The default `PaneContext` value is `false`, so the single-pane thread view reserved nothing.

## What changed

`apps/app/src/views/thread-detail/ThreadDetailHeader.tsx`

- Add `pinsRightPanelToggle` and `reservesPinnedRightPanelToggle`, and render an `aria-hidden` placeholder that carries `HEADER_ICON_BUTTON_CLASS` (a 28px box, the same box the button occupies).
- The toggle stays pinned, so #2638's motion goal does not change.

The reservation is conditional, and it follows the pattern the layout already uses: each surface under the pinned toggle reserves one slot for it.

- Panel closed: the header reaches the window edge, so the header reserves.
- Panel open: the header ends at the panel boundary, and the panel header already reserves the slot (`ThreadDetailSecondaryContent.tsx` passes `inlinePanelToggle="reserved"`).
- Compact drawer: the toggle is not pinned and keeps its own space.

No wire, route, CLI, guide, SDK, or data changes.

## How you verified

`apps/app/src/views/thread-detail/ThreadDetailHeader.test.tsx` gets three cases: the reserve is present when the panel is closed, absent when the panel is open, and absent in the compact drawer.

The closed-panel test fails on the code before the fix and passes after it:

```
× reserves the pinned right-panel toggle footprint while the panel is closed   (before)
✓ 18 tests passed                                                              (after)
```

- `pnpm exec turbo run test --filter=@bb/app` — 444 files, 3508 passed, 4 skipped.
- `pnpm exec turbo run typecheck lint --filter=@bb/app` — 0 errors.

> AGENT GENERATED
