### PR TITLE
Point the refresh serialization test at inspect_git_source

### DIFF
--- a/apps/host-daemon/test/command/host-branches-dispatch.test.ts
+++ b/apps/host-daemon/test/command/host-branches-dispatch.test.ts
@@ -388,8 +388,12 @@ describe("host.inspect_git_source dispatch", () => {
       );
 
       const harness = createHarness();
-      const branchListing = dispatchOnlineRpcCommand(
-        { type: "host.list_branches", path: repoPath, limit: 50 },
+      const sourceInspection = dispatchOnlineRpcCommand(
+        {
+          type: "host.inspect_git_source",
+          path: repoPath,
+          remoteRefresh: "blocking",
+        },
         harness.dispatchOptions(),
       );
       let provisioning: Promise<HostWorkspace> | undefined;
@@ -414,13 +418,13 @@ describe("host.inspect_git_source dispatch", () => {
         await expect(fs.access(targetedFetchMarker)).rejects.toThrow();
 
         await fs.writeFile(releaseRefreshPath, "release\n", "utf8");
-        await branchListing;
+        await sourceInspection;
         const workspace = await provisioning;
         expect(workspace.path).toBe(targetPath);
         await expect(fs.access(targetedFetchMarker)).resolves.toBeUndefined();
       } finally {
         await fs.writeFile(releaseRefreshPath, "release\n", "utf8");
-        await Promise.allSettled([branchListing]);
+        await Promise.allSettled([sourceInspection]);
         const provisionResult = await Promise.allSettled(
           provisioning ? [provisioning] : [],
         );


### PR DESCRIPTION
## Human comments

## What was wrong

#2616 split the host RPC `host.list_branches` into `host.inspect_git_source` (checkout metadata, `remoteRefresh: "background" | "blocking"`) and `host.list_branch_options` (branch pagination). One call in `apps/host-daemon/test/command/host-branches-dispatch.test.ts` kept the removed name.

CI is red on `main` and on every open PR:

- `Checks (ubuntu-latest, Node 22.x)` — `test/command/host-branches-dispatch.test.ts(392,11): error TS2820: Type '"host.list_branches"' is not assignable`.
- `Tests (packages, ubuntu-latest, Node 22.x)` — `host.inspect_git_source dispatch > serializes branch refresh and provisioning fetches for one repository` fails with `File did not appear within 2000ms: .../refresh-started`. The removed command never triggers the delayed upload-pack, so the marker never appears.

## What changed

`apps/host-daemon/test/command/host-branches-dispatch.test.ts` — one call site.

The test asserts that a blocking remote refresh holds the repository lock while a worktree provisions, so the provisioning fetch waits. Blocking refresh moved to `host.inspect_git_source`, and the test already sits inside that command's `describe` block. The call now uses `{ type: "host.inspect_git_source", path: repoPath, remoteRefresh: "blocking" }`, and the promise is renamed `branchListing` -> `sourceInspection` to match.

No source, contract, wire, CLI, or doc changes. `HOST_DAEMON_PROTOCOL_VERSION` is untouched, because the command contract does not change here.

## How you verified

- `pnpm exec turbo run typecheck --filter=@bb/host-daemon` — passes. It fails on `main` with TS2820.
- `pnpm exec turbo run test --filter=@bb/host-daemon -- host-branches-dispatch` — 18 tests pass, including the serialization test that fails on `main`.

> AGENT GENERATED
