### PR TITLE
Point the refresh serialization test at inspect_git_source

### DIFF
--- a/apps/host-daemon/test/command/host-branches-dispatch.test.ts
+++ b/apps/host-daemon/test/command/host-branches-dispatch.test.ts
@@ -388,8 +388,12 @@ describe("host.inspect_git_source dispatch", () => {
       );
 
       const harness = createHarness();
-      const branchListing = dispatchOnlineRpcCommand(
-        { type: "host.list_branches", path: repoPath, limit: 50 },
+      const sourceInspection = dispatchOnlineRpcCommand(
+        {
+          type: "host.inspect_git_source",
+          path: repoPath,
+          remoteRefresh: "blocking",
+        },
         harness.dispatchOptions(),
       );
       let provisioning: Promise<HostWorkspace> | undefined;
@@ -414,13 +418,13 @@ describe("host.inspect_git_source dispatch", () => {
         await expect(fs.access(targetedFetchMarker)).rejects.toThrow();
 
         await fs.writeFile(releaseRefreshPath, "release\n", "utf8");
-        await branchListing;
+        await sourceInspection;
         const workspace = await provisioning;
         expect(workspace.path).toBe(targetPath);
         await expect(fs.access(targetedFetchMarker)).resolves.toBeUndefined();
       } finally {
         await fs.writeFile(releaseRefreshPath, "release\n", "utf8");
-        await Promise.allSettled([branchListing]);
+        await Promise.allSettled([sourceInspection]);
         const provisionResult = await Promise.allSettled(
           provisioning ? [provisioning] : [],
         );


### PR DESCRIPTION
## Human comments

## What was wrong

`main` is red. PR #2616 removed the `host.list_branches` command from the host daemon contract (`packages/host-daemon-contract/src/commands.ts`) and from the dispatch table (`apps/host-daemon/src/command-dispatch.ts`), but one call to it stayed behind in `apps/host-daemon/test/command/host-branches-dispatch.test.ts`. Two jobs fail on every branch:

- `Checks`: `error TS2820: Type '"host.list_branches"' is not assignable to ...`
- `Tests (packages)`: `TypeError: onlineRpcHandlers[command.type] is not a function`, then `File did not appear within 2000ms: .../refresh-started`

Commits a2fcbaf5 and 7cdd77ba on `main` both fail this way.

## What changed

- `apps/host-daemon/test/command/host-branches-dispatch.test.ts`: the test "serializes branch refresh and provisioning fetches for one repository" now dispatches `host.inspect_git_source` with `remoteRefresh: "blocking"`. That test sits inside the `host.inspect_git_source dispatch` describe block, and its siblings already use that command; the stale call was the one the rename missed. A blocking refresh holds the promise until the fetch ends, which is what this test awaits after it releases the refresh. The local `branchListing` becomes `sourceInspection` to match.

No source file changes, so there is no wire change and `HOST_DAEMON_PROTOCOL_VERSION` stays as it is.

## How you verified

- Before: `pnpm exec turbo run typecheck --filter=@bb/host-daemon` fails with TS2820, and the test file throws the unhandled rejection above.
- After: `pnpm exec turbo run typecheck test --filter=@bb/host-daemon` passes, 45 test files. The repaired test runs and passes in 309ms instead of throwing.

Fixes #

> AGENT GENERATED
