### PR TITLE
fix(composer): show Cursor plugin skills

### DIFF
--- a/plugins/provider-acp/src/known-agents.ts
+++ b/plugins/provider-acp/src/known-agents.ts
@@ -1,4 +1,5 @@
 import type { AcpAgentDefinition } from "./agents.js";
+import { resolveCursorNativeRoots } from "./native-roots/cursor.js";
 import { resolveGrokNativeRoots } from "./native-roots/grok.js";
 import { resolveHermesNativeRoots } from "./native-roots/hermes.js";
 import { resolveOmpNativeRoots } from "./native-roots/omp.js";
@@ -76,6 +77,7 @@ export const KNOWN_ACP_AGENTS: readonly AcpAgentDefinition[] = [
         ),
       },
     },
+    nativeRootsResolver: resolveCursorNativeRoots,
   },
   {
     id: "acp-opencode",

--- a/plugins/provider-acp/src/native-roots/cursor.ts
+++ b/plugins/provider-acp/src/native-roots/cursor.ts
@@ -21,6 +21,11 @@ const cursorPluginManifestSchema = z
 
 type CursorPluginManifest = z.infer<typeof cursorPluginManifestSchema>;
 
+interface CursorPluginCandidate {
+  completedAtMs: number;
+  plugin: ExperimentalVendorPlugin;
+}
+
 async function readCursorPluginManifest(
   pluginRootPath: string,
 ): Promise<CursorPluginManifest | null> {
@@ -39,16 +44,38 @@ async function readCursorPluginManifest(
   return null;
 }
 
+function cursorVendorPlugin(
+  pluginRootPath: string,
+  manifest: CursorPluginManifest,
+): ExperimentalVendorPlugin {
+  return {
+    rootPath: pluginRootPath,
+    name: manifest.name,
+    origin: "user",
+    ...(manifest.skills === undefined ? {} : { skills: manifest.skills }),
+    ...(manifest.commands === undefined ? {} : { commands: manifest.commands }),
+  };
+}
+
+async function readDirectoryEntries(directoryPath: string): Promise<Dirent[]> {
+  try {
+    return await fs.readdir(directoryPath, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+}
+
+function sortedDirectoryEntries(entries: readonly Dirent[]): Dirent[] {
+  return entries
+    .filter((entry) => entry.isDirectory())
+    .sort((left, right) => left.name.localeCompare(right.name));
+}
+
 async function resolveLocalCursorPlugins(
   homeDir: string,
 ): Promise<ExperimentalVendorPlugin[]> {
   const localPluginsPath = path.join(homeDir, ".cursor", "plugins", "local");
-  let entries: Dirent[];
-  try {
-    entries = await fs.readdir(localPluginsPath, { withFileTypes: true });
-  } catch {
-    return [];
-  }
+  const entries = await readDirectoryEntries(localPluginsPath);
 
   const plugins: ExperimentalVendorPlugin[] = [];
   for (const entry of entries.sort((left, right) =>
@@ -63,21 +90,82 @@ async function resolveLocalCursorPlugins(
     if (manifest === null) {
       continue;
     }
-    plugins.push({
-      rootPath: pluginRootPath,
-      name: manifest.name,
-      origin: "user",
-      ...(manifest.skills === undefined ? {} : { skills: manifest.skills }),
-      ...(manifest.commands === undefined
-        ? {}
-        : { commands: manifest.commands }),
-    });
+    plugins.push(cursorVendorPlugin(pluginRootPath, manifest));
   }
   return plugins;
 }
 
-export const resolveCursorNativeRoots: AcpNativeRootsResolver = async (args) =>
-  experimental_resolveVendorPluginRoots({
-    plugins: await resolveLocalCursorPlugins(args.homeDir),
+async function resolveMarketplaceCursorPlugins(
+  homeDir: string,
+): Promise<ExperimentalVendorPlugin[]> {
+  const cachePath = path.join(homeDir, ".cursor", "plugins", "cache");
+  const plugins: ExperimentalVendorPlugin[] = [];
+  for (const marketplace of sortedDirectoryEntries(
+    await readDirectoryEntries(cachePath),
+  )) {
+    const marketplacePath = path.join(cachePath, marketplace.name);
+    for (const pluginEntry of sortedDirectoryEntries(
+      await readDirectoryEntries(marketplacePath),
+    )) {
+      const pluginPath = path.join(marketplacePath, pluginEntry.name);
+      const candidates: CursorPluginCandidate[] = [];
+      for (const version of sortedDirectoryEntries(
+        await readDirectoryEntries(pluginPath),
+      )) {
+        const pluginRootPath = path.join(pluginPath, version.name);
+        const completion = await fs
+          .lstat(path.join(pluginRootPath, ".cache-complete"))
+          .catch(() => null);
+        if (completion === null || !completion.isFile()) {
+          continue;
+        }
+        const manifest = await readCursorPluginManifest(pluginRootPath);
+        if (manifest === null) {
+          continue;
+        }
+        candidates.push({
+          completedAtMs: completion.mtimeMs,
+          plugin: cursorVendorPlugin(pluginRootPath, manifest),
+        });
+      }
+      const latest = candidates.sort(
+        (left, right) =>
+          right.completedAtMs - left.completedAtMs ||
+          right.plugin.rootPath.localeCompare(left.plugin.rootPath),
+      )[0];
+      if (latest !== undefined) {
+        plugins.push(latest.plugin);
+      }
+    }
+  }
+  return plugins;
+}
+
+async function deduplicateCursorPlugins(
+  plugins: readonly ExperimentalVendorPlugin[],
+): Promise<ExperimentalVendorPlugin[]> {
+  const uniquePlugins: ExperimentalVendorPlugin[] = [];
+  const seen = new Set<string>();
+  for (const plugin of plugins) {
+    const key = await fs.realpath(plugin.rootPath).catch(() => plugin.rootPath);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    uniquePlugins.push(plugin);
+  }
+  return uniquePlugins;
+}
+
+export const resolveCursorNativeRoots: AcpNativeRootsResolver = async (
+  args,
+) => {
+  const plugins = await deduplicateCursorPlugins([
+    ...(await resolveLocalCursorPlugins(args.homeDir)),
+    ...(await resolveMarketplaceCursorPlugins(args.homeDir)),
+  ]);
+  return experimental_resolveVendorPluginRoots({
+    plugins,
     layout: "claude",
   });
+};

--- a/plugins/provider-acp/src/native-roots/cursor.ts
+++ b/plugins/provider-acp/src/native-roots/cursor.ts
@@ -1,0 +1,83 @@
+import type { Dirent } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import {
+  experimental_resolveVendorPluginRoots,
+  type ExperimentalVendorPlugin,
+} from "@get-bb/plugin-sdk/host";
+import { z } from "zod";
+import type { AcpNativeRootsResolver } from "./resolver.js";
+import { readJsonFile } from "./shared.js";
+
+const cursorPluginPathsSchema = z.union([z.string(), z.array(z.string())]);
+
+const cursorPluginManifestSchema = z
+  .object({
+    name: z.string().min(1),
+    skills: cursorPluginPathsSchema.optional(),
+    commands: cursorPluginPathsSchema.optional(),
+  })
+  .passthrough();
+
+type CursorPluginManifest = z.infer<typeof cursorPluginManifestSchema>;
+
+async function readCursorPluginManifest(
+  pluginRootPath: string,
+): Promise<CursorPluginManifest | null> {
+  for (const relativePath of [
+    path.join(".cursor-plugin", "plugin.json"),
+    "plugin.json",
+  ]) {
+    const manifest = await readJsonFile(
+      path.join(pluginRootPath, relativePath),
+      cursorPluginManifestSchema,
+    );
+    if (manifest !== null) {
+      return manifest;
+    }
+  }
+  return null;
+}
+
+async function resolveLocalCursorPlugins(
+  homeDir: string,
+): Promise<ExperimentalVendorPlugin[]> {
+  const localPluginsPath = path.join(homeDir, ".cursor", "plugins", "local");
+  let entries: Dirent[];
+  try {
+    entries = await fs.readdir(localPluginsPath, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const plugins: ExperimentalVendorPlugin[] = [];
+  for (const entry of entries.sort((left, right) =>
+    left.name.localeCompare(right.name),
+  )) {
+    const pluginRootPath = path.join(localPluginsPath, entry.name);
+    const stat = await fs.stat(pluginRootPath).catch(() => null);
+    if (stat === null || !stat.isDirectory()) {
+      continue;
+    }
+    const manifest = await readCursorPluginManifest(pluginRootPath);
+    if (manifest === null) {
+      continue;
+    }
+    plugins.push({
+      rootPath: pluginRootPath,
+      name: manifest.name,
+      origin: "user",
+      ...(manifest.skills === undefined ? {} : { skills: manifest.skills }),
+      ...(manifest.commands === undefined
+        ? {}
+        : { commands: manifest.commands }),
+    });
+  }
+  return plugins;
+}
+
+export const resolveCursorNativeRoots: AcpNativeRootsResolver = async (args) =>
+  experimental_resolveVendorPluginRoots({
+    plugins: await resolveLocalCursorPlugins(args.homeDir),
+    layout: "claude",
+  });

--- a/plugins/provider-acp/src/native-roots/index.test.ts
+++ b/plugins/provider-acp/src/native-roots/index.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -18,6 +18,90 @@ afterEach(async () => {
 });
 
 describe("resolveAcpNativeRoots", () => {
+  it("lists Cursor plugin skills", async () => {
+    const homeDir = path.join(tempRoot, "home");
+    const pluginRoot = path.join(tempRoot, "plugins", "review-tools");
+    const installedPluginRoot = path.join(
+      homeDir,
+      ".cursor",
+      "plugins",
+      "local",
+      "review-tools",
+    );
+    await Promise.all([
+      mkdir(path.join(pluginRoot, ".cursor-plugin"), { recursive: true }),
+      mkdir(path.join(pluginRoot, "skills", "review"), { recursive: true }),
+      mkdir(path.dirname(installedPluginRoot), { recursive: true }),
+    ]);
+    await writeFile(
+      path.join(pluginRoot, ".cursor-plugin", "plugin.json"),
+      JSON.stringify({ name: "review-tools", skills: "./skills/" }),
+      "utf8",
+    );
+    await symlink(pluginRoot, installedPluginRoot, "dir");
+    await writeFile(
+      path.join(pluginRoot, "skills", "review", "SKILL.md"),
+      "---\nname: review\ndescription: Review code\n---\n",
+      "utf8",
+    );
+
+    const answer = await resolveAcpNativeRoots({
+      agentId: "acp-cursor",
+      cwd: path.join(tempRoot, "workspace"),
+      homeDir,
+      env: {},
+    });
+
+    expect(answer.skills).toEqual([
+      {
+        path: path.join(installedPluginRoot, "skills"),
+        origin: "user",
+        namePrefix: "review-tools:",
+        shape: "skills",
+      },
+    ]);
+  });
+
+  it("lists conventional skills from a portable Cursor plugin", async () => {
+    const homeDir = path.join(tempRoot, "home");
+    const pluginRoot = path.join(
+      homeDir,
+      ".cursor",
+      "plugins",
+      "local",
+      "scott-engineering",
+    );
+    await mkdir(path.join(pluginRoot, "skills", "code-review"), {
+      recursive: true,
+    });
+    await writeFile(
+      path.join(pluginRoot, "plugin.json"),
+      JSON.stringify({ name: "scott-engineering" }),
+      "utf8",
+    );
+    await writeFile(
+      path.join(pluginRoot, "skills", "code-review", "SKILL.md"),
+      "---\nname: code-review\ndescription: Review code\n---\n",
+      "utf8",
+    );
+
+    const answer = await resolveAcpNativeRoots({
+      agentId: "acp-cursor",
+      cwd: path.join(tempRoot, "workspace"),
+      homeDir,
+      env: {},
+    });
+
+    expect(answer.skills).toEqual([
+      {
+        path: path.join(pluginRoot, "skills"),
+        origin: "user",
+        namePrefix: "scott-engineering:",
+        shape: "skills",
+      },
+    ]);
+  });
+
   it("answers for the agent asked and nothing for the rest", async () => {
     const homeDir = path.join(tempRoot, "home");
     const args = { cwd: null, homeDir, env: { OPENCODE_CONFIG_DIR: "oc" } };
@@ -32,7 +116,7 @@ describe("resolveAcpNativeRoots", () => {
     ]);
     expect(
       await resolveAcpNativeRoots({ ...args, agentId: "acp-cursor" }),
-    ).toEqual({});
+    ).toEqual({ skills: [], commands: [] });
     expect(
       await resolveAcpNativeRoots({ ...args, agentId: "acp-amp" }),
     ).toEqual({});
@@ -75,6 +159,7 @@ describe("known agent declarations", () => {
         acpProviderDeclaration(agent).experimental_resolvesNativeRoots === true,
     ).map((agent) => agent.id);
     expect(resolving).toEqual([
+      "acp-cursor",
       "acp-opencode",
       "acp-omp",
       "acp-grok",

--- a/plugins/provider-acp/src/native-roots/index.test.ts
+++ b/plugins/provider-acp/src/native-roots/index.test.ts
@@ -1,4 +1,11 @@
-import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  mkdtemp,
+  rm,
+  symlink,
+  utimes,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -97,6 +104,149 @@ describe("resolveAcpNativeRoots", () => {
         path: path.join(pluginRoot, "skills"),
         origin: "user",
         namePrefix: "scott-engineering:",
+        shape: "skills",
+      },
+    ]);
+  });
+
+  it("lists skills from a completed Cursor marketplace cache entry", async () => {
+    const homeDir = path.join(tempRoot, "home");
+    const pluginRoot = path.join(
+      homeDir,
+      ".cursor",
+      "plugins",
+      "cache",
+      "cursor-public",
+      "review-tools",
+      "revision-one",
+    );
+    await mkdir(path.join(pluginRoot, ".cursor-plugin"), { recursive: true });
+    await mkdir(path.join(pluginRoot, "skills", "review"), {
+      recursive: true,
+    });
+    await writeFile(path.join(pluginRoot, ".cache-complete"), "", "utf8");
+    await writeFile(
+      path.join(pluginRoot, ".cursor-plugin", "plugin.json"),
+      JSON.stringify({ name: "review-tools", skills: "./skills/" }),
+      "utf8",
+    );
+    await writeFile(
+      path.join(pluginRoot, "skills", "review", "SKILL.md"),
+      "---\nname: review\ndescription: Review code\n---\n",
+      "utf8",
+    );
+
+    const answer = await resolveAcpNativeRoots({
+      agentId: "acp-cursor",
+      cwd: path.join(tempRoot, "workspace"),
+      homeDir,
+      env: {},
+    });
+
+    expect(answer.skills).toEqual([
+      {
+        path: path.join(pluginRoot, "skills"),
+        origin: "user",
+        namePrefix: "review-tools:",
+        shape: "skills",
+      },
+    ]);
+  });
+
+  it("uses the newest completed Cursor marketplace plugin revision", async () => {
+    const homeDir = path.join(tempRoot, "home");
+    const pluginCache = path.join(
+      homeDir,
+      ".cursor",
+      "plugins",
+      "cache",
+      "cursor-public",
+      "review-tools",
+    );
+    const olderRoot = path.join(pluginCache, "older");
+    const newerRoot = path.join(pluginCache, "newer");
+    const incompleteRoot = path.join(pluginCache, "incomplete");
+    for (const pluginRoot of [olderRoot, newerRoot, incompleteRoot]) {
+      await mkdir(path.join(pluginRoot, "skills", "review"), {
+        recursive: true,
+      });
+      await writeFile(
+        path.join(pluginRoot, "plugin.json"),
+        JSON.stringify({ name: "review-tools" }),
+        "utf8",
+      );
+      await writeFile(
+        path.join(pluginRoot, "skills", "review", "SKILL.md"),
+        "---\nname: review\ndescription: Review code\n---\n",
+        "utf8",
+      );
+    }
+    const olderMarker = path.join(olderRoot, ".cache-complete");
+    const newerMarker = path.join(newerRoot, ".cache-complete");
+    await writeFile(olderMarker, "", "utf8");
+    await writeFile(newerMarker, "", "utf8");
+    await utimes(olderMarker, new Date(1_000), new Date(1_000));
+    await utimes(newerMarker, new Date(2_000), new Date(2_000));
+
+    const answer = await resolveAcpNativeRoots({
+      agentId: "acp-cursor",
+      cwd: null,
+      homeDir,
+      env: {},
+    });
+
+    expect(answer.skills?.map((root) => root.path)).toEqual([
+      path.join(newerRoot, "skills"),
+    ]);
+  });
+
+  it("deduplicates a local link to a cached Cursor plugin", async () => {
+    const homeDir = path.join(tempRoot, "home");
+    const pluginRoot = path.join(
+      homeDir,
+      ".cursor",
+      "plugins",
+      "cache",
+      "cursor-public",
+      "review-tools",
+      "revision-one",
+    );
+    const localPluginRoot = path.join(
+      homeDir,
+      ".cursor",
+      "plugins",
+      "local",
+      "review-tools",
+    );
+    await mkdir(path.join(pluginRoot, "skills", "review"), {
+      recursive: true,
+    });
+    await mkdir(path.dirname(localPluginRoot), { recursive: true });
+    await writeFile(path.join(pluginRoot, ".cache-complete"), "", "utf8");
+    await writeFile(
+      path.join(pluginRoot, "plugin.json"),
+      JSON.stringify({ name: "review-tools" }),
+      "utf8",
+    );
+    await writeFile(
+      path.join(pluginRoot, "skills", "review", "SKILL.md"),
+      "---\nname: review\ndescription: Review code\n---\n",
+      "utf8",
+    );
+    await symlink(pluginRoot, localPluginRoot, "dir");
+
+    const answer = await resolveAcpNativeRoots({
+      agentId: "acp-cursor",
+      cwd: null,
+      homeDir,
+      env: {},
+    });
+
+    expect(answer.skills).toEqual([
+      {
+        path: path.join(localPluginRoot, "skills"),
+        origin: "user",
+        namePrefix: "review-tools:",
         shape: "skills",
       },
     ]);


### PR DESCRIPTION
## Human comments

## What was wrong

Cursor skill discovery covered conventional skill directories, but not plugins installed under the local plugin directory or completed marketplace cache. The composer therefore omitted skills and commands supplied by installed Cursor plugins. This is a follow-up to #1292.

## What changed

- Added a Cursor native-roots resolver for local and marketplace plugins.
- Parsed Cursor plugin manifests and forwarded declared skills and commands.
- Selected the newest completed marketplace revision and ignored incomplete cache entries.
- Deduplicated local links that resolve to the same cached plugin.
- No host-daemon protocol change.

## How you verified

- pnpm exec turbo run test typecheck --filter=bb-plugin-provider-acp --force
- 81 provider ACP tests passed across 8 files.
- Provider ACP typecheck passed.

> AGENT GENERATED