### PR TITLE
Add reopen closed tab shortcut

### DIFF
--- a/apps/app/src/components/plugin/PluginPanelRightPanelHost.tsx
+++ b/apps/app/src/components/plugin/PluginPanelRightPanelHost.tsx
@@ -278,6 +278,7 @@ export function PluginPanelRightPanelHost({
     closeTab,
     openTab,
     orderedSecondaryFileTabs,
+    reopenClosedTab,
     reorderTab,
     updateBrowserTab,
   } = useThreadFileTabs({
@@ -485,6 +486,11 @@ export function PluginPanelRightPanelHost({
   useAppCommandHandler("panel.newTab", () => {
     if (!isFocused || panel === null) return false;
     openNewTab();
+    return true;
+  });
+  useAppCommandHandler("panel.reopenClosedTab", () => {
+    if (!isFocused || panel === null || !reopenClosedTab()) return false;
+    revealPanel();
     return true;
   });
 

--- a/apps/app/src/components/secondary-panel/SidebarSplitContainer.tsx
+++ b/apps/app/src/components/secondary-panel/SidebarSplitContainer.tsx
@@ -33,6 +33,7 @@ import {
   createSidebarSplitState,
   focusSidebarPane,
   getSidebarGroupForPane,
+  getSidebarTabPlacement,
   isCanonicalSidebarSplitState,
   moveSidebarPaneToSide,
   moveSidebarTab,
@@ -43,6 +44,7 @@ import {
   reorderSidebarTab,
   replaceSidebarTab,
   resizeSidebarSplit,
+  restoreSidebarTabPlacement,
   selectSidebarTab,
   serializeSidebarSplitState,
   setSidebarPaneMaximized,
@@ -50,6 +52,7 @@ import {
   sidebarSplitStorageKey,
   toggleSidebarPaneMaximize,
   type SidebarSplitState,
+  type SidebarTabPlacement,
   type SidebarTabGroup,
 } from "./sidebarSplitLayout";
 import type { SecondaryPanelTabReorderRequest } from "./secondaryPanelTab";
@@ -131,6 +134,8 @@ export function SidebarSplitContainer({
     value: initialStorageValue,
   });
   const previousActiveTabId = useRef(activeTabId);
+  const previousAvailableTabIds = useRef(availableTabIds);
+  const removedTabPlacements = useRef(new Map<string, SidebarTabPlacement>());
   const previousFullScreen = useRef(isFullScreen);
   const dimsInactiveSplits = useAtomValue(dimInactiveSplitsAtom);
   const [resizeCursor, setResizeCursor] =
@@ -146,20 +151,38 @@ export function SidebarSplitContainer({
 
   useEffect(() => {
     const previousExternalActiveTabId = previousActiveTabId.current;
+    const previousAvailable = previousAvailableTabIds.current;
     const shouldFollowExternalSelection =
       previousExternalActiveTabId !== activeTabId;
     previousActiveTabId.current = activeTabId;
+    previousAvailableTabIds.current = availableTabIds;
     const current = stateRef.current;
+    const availableTabIdSet = new Set(availableTabIds);
+    for (const tabId of previousAvailable) {
+      if (availableTabIdSet.has(tabId)) continue;
+      const placement = getSidebarTabPlacement(current, tabId);
+      if (placement !== null) {
+        removedTabPlacements.current.set(tabId, placement);
+      }
+    }
     const withActiveTabReplacement =
       shouldFollowExternalSelection &&
       !availableTabIds.includes(previousExternalActiveTabId)
         ? replaceSidebarTab(current, previousExternalActiveTabId, activeTabId)
         : current;
-    const reconciled = reconcileSidebarSplitState(
+    let reconciled = reconcileSidebarSplitState(
       withActiveTabReplacement,
       availableTabIds,
       activeTabId,
     );
+    const previousAvailableTabIdSet = new Set(previousAvailable);
+    for (const tabId of availableTabIds) {
+      if (previousAvailableTabIdSet.has(tabId)) continue;
+      const placement = removedTabPlacements.current.get(tabId);
+      if (placement === undefined) continue;
+      reconciled = restoreSidebarTabPlacement(reconciled, tabId, placement);
+      removedTabPlacements.current.delete(tabId);
+    }
     const activePane = shouldFollowExternalSelection
       ? listPanes(reconciled.layout.root).find((pane) =>
           getSidebarGroupForPane(reconciled, pane.paneId)?.tabIds.includes(

--- a/apps/app/src/components/secondary-panel/sidebarSplitLayout.test.ts
+++ b/apps/app/src/components/secondary-panel/sidebarSplitLayout.test.ts
@@ -333,6 +333,40 @@ describe("sidebar split layout", () => {
     ).toContain("terminal-a");
   });
 
+  it("restores closed tabs to their canonical order", () => {
+    const firstTabId = "browser:first";
+    const secondTabId = "browser:second";
+    let state = createSidebarSplitState(
+      [SIDEBAR_FIXED_INFO_TAB_ID, firstTabId, secondTabId],
+      secondTabId,
+    );
+
+    state = reconcileSidebarSplitState(
+      state,
+      [SIDEBAR_FIXED_INFO_TAB_ID, secondTabId],
+      secondTabId,
+    );
+    state = reconcileSidebarSplitState(
+      state,
+      [SIDEBAR_FIXED_INFO_TAB_ID],
+      SIDEBAR_FIXED_INFO_TAB_ID,
+    );
+    state = reconcileSidebarSplitState(
+      state,
+      [SIDEBAR_FIXED_INFO_TAB_ID, secondTabId],
+      secondTabId,
+    );
+    state = reconcileSidebarSplitState(
+      state,
+      [SIDEBAR_FIXED_INFO_TAB_ID, firstTabId, secondTabId],
+      firstTabId,
+    );
+
+    expect(
+      getSidebarGroupForPane(state, state.layout.focusedPaneId)?.tabIds,
+    ).toEqual([SIDEBAR_FIXED_INFO_TAB_ID, firstTabId, secondTabId]);
+  });
+
   it("keeps a New Tab replacement in its existing split pane", () => {
     const newTabId = "new-tab:launcher";
     const terminalTabId = "terminal:term-a:none";

--- a/apps/app/src/components/secondary-panel/sidebarSplitLayout.test.ts
+++ b/apps/app/src/components/secondary-panel/sidebarSplitLayout.test.ts
@@ -10,6 +10,7 @@ import {
   SIDEBAR_FIXED_DIFF_TAB_ID,
   SIDEBAR_FIXED_INFO_TAB_ID,
   createSidebarSplitState,
+  getSidebarTabPlacement,
   focusSidebarPane,
   getSidebarGroupForPane,
   isCanonicalSidebarSplitState,
@@ -20,6 +21,7 @@ import {
   reconcileSidebarSplitState,
   removeSidebarSplit,
   reorderSidebarTab,
+  restoreSidebarTabPlacement,
   replaceSidebarTab,
   resizeSidebarSplit,
   selectSidebarTab,
@@ -333,33 +335,46 @@ describe("sidebar split layout", () => {
     ).toContain("terminal-a");
   });
 
-  it("restores closed tabs to their canonical order", () => {
+  it("restores closed tabs to their prior visible order", () => {
     const firstTabId = "browser:first";
     const secondTabId = "browser:second";
     let state = createSidebarSplitState(
       [SIDEBAR_FIXED_INFO_TAB_ID, firstTabId, secondTabId],
       secondTabId,
     );
+    const firstPlacement = getSidebarTabPlacement(state, firstTabId);
+    if (firstPlacement === null) throw new Error("Missing first tab placement");
 
     state = reconcileSidebarSplitState(
       state,
       [SIDEBAR_FIXED_INFO_TAB_ID, secondTabId],
       secondTabId,
     );
+    const secondPlacement = getSidebarTabPlacement(state, secondTabId);
+    if (secondPlacement === null)
+      throw new Error("Missing second tab placement");
     state = reconcileSidebarSplitState(
       state,
       [SIDEBAR_FIXED_INFO_TAB_ID],
       SIDEBAR_FIXED_INFO_TAB_ID,
     );
-    state = reconcileSidebarSplitState(
-      state,
-      [SIDEBAR_FIXED_INFO_TAB_ID, secondTabId],
+    state = restoreSidebarTabPlacement(
+      reconcileSidebarSplitState(
+        state,
+        [SIDEBAR_FIXED_INFO_TAB_ID, secondTabId],
+        secondTabId,
+      ),
       secondTabId,
+      secondPlacement,
     );
-    state = reconcileSidebarSplitState(
-      state,
-      [SIDEBAR_FIXED_INFO_TAB_ID, firstTabId, secondTabId],
+    state = restoreSidebarTabPlacement(
+      reconcileSidebarSplitState(
+        state,
+        [SIDEBAR_FIXED_INFO_TAB_ID, secondTabId, firstTabId],
+        firstTabId,
+      ),
       firstTabId,
+      firstPlacement,
     );
 
     expect(

--- a/apps/app/src/components/secondary-panel/sidebarSplitLayout.ts
+++ b/apps/app/src/components/secondary-panel/sidebarSplitLayout.ts
@@ -53,6 +53,13 @@ export interface SidebarSplitState {
   maximizedPaneId: string | null;
 }
 
+export interface SidebarTabPlacement {
+  followingTabId: string | null;
+  groupId: string;
+  index: number;
+  precedingTabId: string | null;
+}
+
 interface SidebarSplitIds {
   groupId: string;
   paneId: string;
@@ -169,6 +176,76 @@ function preserveSidebarSplitStateIdentity(
   next: SidebarSplitState,
 ): SidebarSplitState {
   return areSidebarSplitStatesEqual(current, next) ? current : next;
+}
+
+export function getSidebarTabPlacement(
+  state: SidebarSplitState,
+  tabId: string,
+): SidebarTabPlacement | null {
+  const group = Object.values(state.groups).find((candidate) =>
+    candidate.tabIds.includes(tabId),
+  );
+  if (group === undefined) return null;
+  const index = group.tabIds.indexOf(tabId);
+  return {
+    followingTabId: group.tabIds[index + 1] ?? null,
+    groupId: group.id,
+    index,
+    precedingTabId: group.tabIds[index - 1] ?? null,
+  };
+}
+
+export function restoreSidebarTabPlacement(
+  state: SidebarSplitState,
+  tabId: string,
+  placement: SidebarTabPlacement,
+): SidebarSplitState {
+  const currentGroup = Object.values(state.groups).find((group) =>
+    group.tabIds.includes(tabId),
+  );
+  if (currentGroup === undefined) return state;
+  const placedGroup = state.groups[placement.groupId];
+  const targetGroup =
+    placedGroup !== undefined &&
+    (placedGroup.id === currentGroup.id || currentGroup.tabIds.length > 1)
+      ? placedGroup
+      : currentGroup;
+  const groups = Object.fromEntries(
+    Object.entries(state.groups).map(([groupId, group]) => {
+      const tabIds = group.tabIds.filter((candidate) => candidate !== tabId);
+      return [
+        groupId,
+        {
+          ...group,
+          tabIds,
+          activeTabId:
+            group.activeTabId === tabId
+              ? (tabIds[0] ?? targetGroup.activeTabId)
+              : group.activeTabId,
+        },
+      ];
+    }),
+  );
+  const nextTargetGroup = groups[targetGroup.id];
+  if (nextTargetGroup === undefined) return state;
+  const followingIndex =
+    placement.followingTabId === null
+      ? -1
+      : nextTargetGroup.tabIds.indexOf(placement.followingTabId);
+  const precedingIndex =
+    placement.precedingTabId === null
+      ? -1
+      : nextTargetGroup.tabIds.indexOf(placement.precedingTabId);
+  const insertAt =
+    followingIndex >= 0
+      ? followingIndex
+      : precedingIndex >= 0
+        ? precedingIndex + 1
+        : Math.min(placement.index, nextTargetGroup.tabIds.length);
+  const tabIds = [...nextTargetGroup.tabIds];
+  tabIds.splice(insertAt, 0, tabId);
+  groups[targetGroup.id] = { ...nextTargetGroup, tabIds };
+  return { ...state, groups };
 }
 
 function insertMissingTabsInAvailableOrder(

--- a/apps/app/src/components/secondary-panel/sidebarSplitLayout.ts
+++ b/apps/app/src/components/secondary-panel/sidebarSplitLayout.ts
@@ -171,6 +171,34 @@ function preserveSidebarSplitStateIdentity(
   return areSidebarSplitStatesEqual(current, next) ? current : next;
 }
 
+function insertMissingTabsInAvailableOrder(
+  tabIds: readonly string[],
+  missingTabIds: readonly string[],
+  availableTabIds: readonly string[],
+): string[] {
+  const next = [...tabIds];
+  for (const missingTabId of missingTabIds) {
+    const availableIndex = availableTabIds.indexOf(missingTabId);
+    const followingTabId = availableTabIds
+      .slice(availableIndex + 1)
+      .find((tabId) => next.includes(tabId));
+    if (followingTabId !== undefined) {
+      next.splice(next.indexOf(followingTabId), 0, missingTabId);
+      continue;
+    }
+    const precedingTabId = availableTabIds
+      .slice(0, availableIndex)
+      .reverse()
+      .find((tabId) => next.includes(tabId));
+    const insertAt =
+      precedingTabId === undefined
+        ? next.length
+        : next.indexOf(precedingTabId) + 1;
+    next.splice(insertAt, 0, missingTabId);
+  }
+  return next;
+}
+
 export function isCanonicalSidebarSplitState(
   state: SidebarSplitState,
   availableTabIds: readonly string[],
@@ -610,7 +638,11 @@ export function reconcileSidebarSplitState(
         ...next.groups,
         [focusedGroup.id]: {
           ...focusedGroup,
-          tabIds: [...focusedGroup.tabIds, ...missing],
+          tabIds: insertMissingTabsInAvailableOrder(
+            focusedGroup.tabIds,
+            missing,
+            available,
+          ),
           activeTabId:
             focusedGroup.tabIds.length === 0
               ? activeTabId

--- a/apps/app/src/components/secondary-panel/useThreadFileTabs.test.ts
+++ b/apps/app/src/components/secondary-panel/useThreadFileTabs.test.ts
@@ -384,6 +384,16 @@ describe("useThreadFileTabs recently closed tabs", () => {
       didReopen = result.current.reopenClosedTab();
     });
     expect(didReopen).toBe(false);
+
+    act(() => {
+      environmentId = "env_2";
+      rerender();
+    });
+    act(() => {
+      didReopen = result.current.reopenClosedTab();
+    });
+    expect(didReopen).toBe(true);
+    expect(result.current.activeWorkspaceFilePath).toBe("src/env-two.ts");
   });
 });
 

--- a/apps/app/src/components/secondary-panel/useThreadFileTabs.test.ts
+++ b/apps/app/src/components/secondary-panel/useThreadFileTabs.test.ts
@@ -182,6 +182,73 @@ describe("useThreadFileTabs recently closed tabs", () => {
     });
     expect(result.current.reopenClosedTab()).toBe(false);
   });
+
+  it("skips deleted current-thread storage files while preserving owner-valid history", () => {
+    let storageFiles: readonly { path: string }[] = [
+      { path: "available.md" },
+      { path: "deleted.md" },
+    ];
+    const { result, rerender } = renderThreadHook(() =>
+      useThreadFileTabs({
+        panelStateId: "recently-closed-storage",
+        syncThreadId: "thr_current",
+        environmentId: "env_1",
+        storageFiles,
+        terminalSessions: undefined,
+      }),
+    );
+
+    let availableTabId = "";
+    let foreignTabId = "";
+    let deletedTabId = "";
+    act(() => {
+      availableTabId =
+        result.current.openTab({
+          kind: "thread-storage-file-preview",
+          tab: { lineRange: null, path: "available.md" },
+        })?.id ?? "";
+      foreignTabId =
+        result.current.openTab({
+          kind: "thread-storage-file-preview",
+          tab: { lineRange: null, path: "foreign.md" },
+          threadId: "thr_foreign",
+        })?.id ?? "";
+      deletedTabId =
+        result.current.openTab({
+          kind: "thread-storage-file-preview",
+          tab: { lineRange: null, path: "deleted.md" },
+        })?.id ?? "";
+    });
+    act(() => {
+      result.current.closeTab(availableTabId);
+      result.current.closeTab(foreignTabId);
+      result.current.closeTab(deletedTabId);
+    });
+    act(() => {
+      storageFiles = [{ path: "available.md" }];
+      rerender();
+    });
+
+    let didReopen = false;
+    act(() => {
+      didReopen = result.current.reopenClosedTab();
+    });
+    expect(didReopen).toBe(true);
+    expect(result.current.activeStorageFilePath).toBe("foreign.md");
+    expect(result.current.activeStorageFileThreadId).toBe("thr_foreign");
+
+    act(() => {
+      didReopen = result.current.reopenClosedTab();
+    });
+    expect(didReopen).toBe(true);
+    expect(result.current.activeStorageFilePath).toBe("available.md");
+    expect(result.current.activeStorageFileThreadId).toBe("thr_current");
+
+    act(() => {
+      didReopen = result.current.reopenClosedTab();
+    });
+    expect(didReopen).toBe(false);
+  });
 });
 
 describe("useThreadFileTabs terminal pruning", () => {

--- a/apps/app/src/components/secondary-panel/useThreadFileTabs.test.ts
+++ b/apps/app/src/components/secondary-panel/useThreadFileTabs.test.ts
@@ -16,7 +16,10 @@ import {
   FIXED_PANEL_TABS_STATE_STORAGE_VERSION,
 } from "@/lib/fixed-panel-tabs-state";
 import { buildFileOpenerPanelTab } from "@/components/plugin/file-opener-tabs";
-import { useThreadFileTabs } from "./useThreadFileTabs";
+import {
+  resetRecentlyClosedPanelTabsForTest,
+  useThreadFileTabs,
+} from "./useThreadFileTabs";
 import {
   resetPluginSlotStoreForTest,
   setPluginSlotRegistrations,
@@ -82,10 +85,103 @@ afterEach(() => {
   cleanup();
   queryClient.clear();
   window.localStorage.clear();
+  resetRecentlyClosedPanelTabsForTest();
   resetPluginSlotStoreForTest();
   syncMocks.scheduleLocalThreadTabsMigration.mockClear();
   syncMocks.scheduleThreadTabsPersistence.mockClear();
   syncMocks.useThreadTabs.mockClear();
+});
+
+describe("useThreadFileTabs recently closed tabs", () => {
+  it("reopens closed tabs in reverse close order and restores their positions", () => {
+    const { result } = renderThreadHook(() =>
+      useThreadFileTabs({
+        panelStateId: "recently-closed",
+        syncThreadId: null,
+        environmentId: "env_1",
+        storageFiles: undefined,
+        terminalSessions: undefined,
+      }),
+    );
+
+    let firstTabId = "";
+    let secondTabId = "";
+    act(() => {
+      firstTabId =
+        result.current.openTab({
+          kind: "browser",
+          url: "https://first.example",
+        })?.id ?? "";
+      secondTabId =
+        result.current.openTab({
+          kind: "browser",
+          url: "https://second.example",
+        })?.id ?? "";
+    });
+    act(() => {
+      result.current.closeTab(firstTabId);
+      result.current.closeTab(secondTabId);
+    });
+
+    expect(result.current.orderedSecondaryFileTabs).toHaveLength(0);
+    let didReopen = false;
+    act(() => {
+      didReopen = result.current.reopenClosedTab();
+    });
+    expect(didReopen).toBe(true);
+    expect(result.current.activeBrowserTab?.id).toBe(secondTabId);
+
+    act(() => {
+      didReopen = result.current.reopenClosedTab();
+    });
+    expect(didReopen).toBe(true);
+    expect(result.current.activeBrowserTab?.id).toBe(firstTabId);
+    expect(
+      result.current.orderedSecondaryFileTabs.map((tab) => tab.id),
+    ).toEqual([firstTabId, secondTabId]);
+
+    act(() => {
+      didReopen = result.current.reopenClosedTab();
+    });
+    expect(didReopen).toBe(false);
+  });
+
+  it("does not reopen a launcher tab or a file reopened another way", () => {
+    const { result } = renderThreadHook(() =>
+      useThreadFileTabs({
+        panelStateId: "recently-closed-launcher",
+        syncThreadId: null,
+        environmentId: "env_1",
+        storageFiles: undefined,
+        terminalSessions: undefined,
+      }),
+    );
+    const fileRequest = {
+      kind: "workspace-file-preview" as const,
+      tab: {
+        lineRange: null,
+        path: "src/index.ts",
+        source: { kind: "working-tree" as const },
+        statusLabel: null,
+      },
+    };
+
+    act(() => {
+      const launcher = result.current.openTab({ kind: "new-tab" });
+      result.current.closeTab(launcher?.id ?? "");
+    });
+    expect(result.current.reopenClosedTab()).toBe(false);
+
+    let fileTabId = "";
+    act(() => {
+      fileTabId = result.current.openTab(fileRequest)?.id ?? "";
+    });
+    act(() => result.current.closeTab(fileTabId));
+    act(() => {
+      result.current.openTab(fileRequest);
+    });
+    expect(result.current.reopenClosedTab()).toBe(false);
+  });
 });
 
 describe("useThreadFileTabs terminal pruning", () => {

--- a/apps/app/src/components/secondary-panel/useThreadFileTabs.test.ts
+++ b/apps/app/src/components/secondary-panel/useThreadFileTabs.test.ts
@@ -61,6 +61,16 @@ function renderThreadHook<Result>(hook: () => Result) {
   return renderHook(hook, { wrapper: QueryWrapper });
 }
 
+function createDeferred<T>() {
+  let resolve = (_value: T) => {
+    throw new Error("Deferred promise was not initialized");
+  };
+  const promise = new Promise<T>((nextResolve) => {
+    resolve = nextResolve;
+  });
+  return { promise, resolve };
+}
+
 function terminalSession(overrides: TerminalSessionOverrides): TerminalSession {
   return {
     id: "term_1",
@@ -184,10 +194,13 @@ describe("useThreadFileTabs recently closed tabs", () => {
   });
 
   it("skips storage history with a deleted path or different owner", () => {
-    let storageFiles: readonly { path: string }[] = [
-      { path: "available.md" },
-      { path: "deleted.md" },
-    ];
+    let storageFiles = {
+      files: [
+        { name: "available.md", path: "available.md" },
+        { name: "deleted.md", path: "deleted.md" },
+      ],
+      truncated: false,
+    };
     const { result, rerender } = renderThreadHook(() =>
       useThreadFileTabs({
         panelStateId: "recently-closed-storage",
@@ -225,7 +238,10 @@ describe("useThreadFileTabs recently closed tabs", () => {
       result.current.closeTab(deletedTabId);
     });
     act(() => {
-      storageFiles = [{ path: "available.md" }];
+      storageFiles = {
+        files: [{ name: "available.md", path: "available.md" }],
+        truncated: false,
+      };
       rerender();
     });
 
@@ -241,6 +257,154 @@ describe("useThreadFileTabs recently closed tabs", () => {
       didReopen = result.current.reopenClosedTab();
     });
     expect(didReopen).toBe(false);
+  });
+
+  it("does not consume or transiently restore storage history before exact validation", async () => {
+    const validation = createDeferred<boolean>();
+    const storageFileExists = vi.fn(() => validation.promise);
+    const { result } = renderThreadHook(() =>
+      useThreadFileTabs({
+        panelStateId: "recently-closed-storage-loading",
+        syncThreadId: "thr_current",
+        environmentId: "env_1",
+        storageFileExists,
+        storageFiles: undefined,
+        terminalSessions: undefined,
+      }),
+    );
+
+    let storageTabId = "";
+    act(() => {
+      storageTabId =
+        result.current.openTab({
+          kind: "thread-storage-file-preview",
+          tab: { lineRange: null, path: "still-here.md" },
+        })?.id ?? "";
+    });
+    act(() => result.current.closeTab(storageTabId));
+
+    let didHandle = false;
+    act(() => {
+      didHandle = result.current.reopenClosedTab();
+    });
+    expect(didHandle).toBe(true);
+    expect(result.current.orderedSecondaryFileTabs).toHaveLength(0);
+    expect(storageFileExists).toHaveBeenCalledWith("still-here.md");
+
+    await act(async () => {
+      validation.resolve(true);
+      await validation.promise;
+      await Promise.resolve();
+    });
+    expect(result.current.activeStorageFilePath).toBe("still-here.md");
+  });
+
+  it("checks a path omitted from a truncated inventory and skips it when deleted", async () => {
+    const storageFileExists = vi.fn(async () => false);
+    const { result } = renderThreadHook(() =>
+      useThreadFileTabs({
+        panelStateId: "recently-closed-storage-truncated",
+        syncThreadId: "thr_current",
+        environmentId: "env_1",
+        storageFileExists,
+        storageFiles: { files: [], truncated: true },
+        terminalSessions: undefined,
+      }),
+    );
+
+    let browserTabId = "";
+    let storageTabId = "";
+    act(() => {
+      browserTabId =
+        result.current.openTab({
+          kind: "browser",
+          url: "https://fallback.example",
+        })?.id ?? "";
+      storageTabId =
+        result.current.openTab({
+          kind: "thread-storage-file-preview",
+          tab: { lineRange: null, path: "deleted-after-close.md" },
+        })?.id ?? "";
+    });
+    act(() => {
+      result.current.closeTab(browserTabId);
+      result.current.closeTab(storageTabId);
+    });
+    act(() => {
+      result.current.reopenClosedTab();
+    });
+
+    await waitFor(() => {
+      expect(result.current.activeBrowserTab?.id).toBe(browserTabId);
+    });
+    expect(storageFileExists).toHaveBeenCalledWith("deleted-after-close.md");
+    expect(result.current.activeStorageFilePath).toBeNull();
+  });
+
+  it("restores a valid path omitted from a truncated inventory", async () => {
+    const storageFileExists = vi.fn(async () => true);
+    const { result } = renderThreadHook(() =>
+      useThreadFileTabs({
+        panelStateId: "recently-closed-storage-truncated-valid",
+        syncThreadId: "thr_current",
+        environmentId: "env_1",
+        storageFileExists,
+        storageFiles: { files: [], truncated: true },
+        terminalSessions: undefined,
+      }),
+    );
+
+    let storageTabId = "";
+    act(() => {
+      storageTabId =
+        result.current.openTab({
+          kind: "thread-storage-file-preview",
+          tab: { lineRange: null, path: "after-page-one.md" },
+        })?.id ?? "";
+    });
+    act(() => result.current.closeTab(storageTabId));
+    act(() => {
+      result.current.reopenClosedTab();
+    });
+
+    await waitFor(() => {
+      expect(result.current.activeStorageFilePath).toBe("after-page-one.md");
+    });
+    expect(storageFileExists).toHaveBeenCalledWith("after-page-one.md");
+  });
+
+  it("keeps an open storage tab when the inventory is truncated", () => {
+    const threadId = "storage-truncated-open-tab";
+    const storageTab = createThreadStorageFilePreviewFixedPanelTab({
+      environmentId: "env_1",
+      isPinned: false,
+      tab: { lineRange: null, path: "after-page-one.md" },
+      threadId,
+    });
+    const state = createEmptyFixedPanelTabsState({
+      secondary: {
+        activeTabId: storageTab.id,
+        isOpen: true,
+        tabs: [storageTab],
+      },
+      lastUsedAt: Date.now(),
+    });
+    window.localStorage.setItem(
+      getFixedPanelTabsStateStorageKey({ threadId }),
+      serializeFixedPanelTabsState({ state }),
+    );
+
+    const { result } = renderThreadHook(() =>
+      useThreadFileTabs({
+        panelStateId: threadId,
+        syncThreadId: threadId,
+        environmentId: "env_1",
+        storageFiles: { files: [], truncated: true },
+        terminalSessions: undefined,
+      }),
+    );
+
+    expect(result.current.activeStorageFilePath).toBe("after-page-one.md");
   });
 
   it.each([
@@ -1043,7 +1207,10 @@ describe("useThreadFileTabs file opener diversion", () => {
         panelStateId: "opener-storage-search",
         syncThreadId: "thr_storage_search",
         environmentId: "env_1",
-        storageFiles: [{ path: "artifacts/notes.md" }],
+        storageFiles: {
+          files: [{ name: "notes.md", path: "artifacts/notes.md" }],
+          truncated: false,
+        },
         terminalSessions: undefined,
       }),
     );

--- a/apps/app/src/components/secondary-panel/useThreadFileTabs.test.ts
+++ b/apps/app/src/components/secondary-panel/useThreadFileTabs.test.ts
@@ -183,7 +183,7 @@ describe("useThreadFileTabs recently closed tabs", () => {
     expect(result.current.reopenClosedTab()).toBe(false);
   });
 
-  it("skips deleted current-thread storage files while preserving owner-valid history", () => {
+  it("skips storage history with a deleted path or different owner", () => {
     let storageFiles: readonly { path: string }[] = [
       { path: "available.md" },
       { path: "deleted.md" },
@@ -234,13 +234,6 @@ describe("useThreadFileTabs recently closed tabs", () => {
       didReopen = result.current.reopenClosedTab();
     });
     expect(didReopen).toBe(true);
-    expect(result.current.activeStorageFilePath).toBe("foreign.md");
-    expect(result.current.activeStorageFileThreadId).toBe("thr_foreign");
-
-    act(() => {
-      didReopen = result.current.reopenClosedTab();
-    });
-    expect(didReopen).toBe(true);
     expect(result.current.activeStorageFilePath).toBe("available.md");
     expect(result.current.activeStorageFileThreadId).toBe("thr_current");
 
@@ -250,43 +243,133 @@ describe("useThreadFileTabs recently closed tabs", () => {
     expect(didReopen).toBe(false);
   });
 
-  it("skips workspace history from the previous environment", () => {
+  it.each([
+    {
+      changedContext: {
+        environmentId: "env_2",
+        fileOwnerThreadId: "thr_1",
+        projectHostId: "host_1",
+        projectId: "proj_1",
+      },
+      dimension: "environment",
+    },
+    {
+      changedContext: {
+        environmentId: "env_1",
+        fileOwnerThreadId: "thr_1",
+        projectHostId: "host_1",
+        projectId: "proj_2",
+      },
+      dimension: "project",
+    },
+    {
+      changedContext: {
+        environmentId: "env_1",
+        fileOwnerThreadId: "thr_2",
+        projectHostId: "host_1",
+        projectId: "proj_1",
+      },
+      dimension: "file owner",
+    },
+    {
+      changedContext: {
+        environmentId: "env_1",
+        fileOwnerThreadId: "thr_1",
+        projectHostId: "host_2",
+        projectId: "proj_1",
+      },
+      dimension: "project host",
+    },
+  ])(
+    "skips workspace history from a different $dimension",
+    ({ changedContext, dimension }) => {
+      let context = {
+        environmentId: "env_1",
+        fileOwnerThreadId: "thr_1",
+        projectHostId: "host_1",
+        projectId: "proj_1",
+      };
+      const { result, rerender } = renderThreadHook(() =>
+        useThreadFileTabs({
+          panelStateId: `recently-closed-${dimension}`,
+          syncThreadId: null,
+          environmentId: context.environmentId,
+          fileOwnerThreadId: context.fileOwnerThreadId,
+          projectHostId: context.projectHostId,
+          projectId: context.projectId,
+          storageFiles: undefined,
+          terminalSessions: undefined,
+        }),
+      );
+
+      let workspaceTabId = "";
+      act(() => {
+        workspaceTabId =
+          result.current.openTab({
+            kind: "workspace-file-preview",
+            tab: {
+              lineRange: null,
+              path: "src/index.ts",
+              source: { kind: "working-tree" },
+              statusLabel: null,
+            },
+          })?.id ?? "";
+      });
+      act(() => result.current.closeTab(workspaceTabId));
+      act(() => {
+        context = changedContext;
+        rerender();
+      });
+
+      let didReopen = false;
+      act(() => {
+        didReopen = result.current.reopenClosedTab();
+      });
+      expect(didReopen).toBe(false);
+      expect(result.current.activeWorkspaceFilePath).toBeNull();
+    },
+  );
+
+  it("restores the nearest history entry owned by the current context", () => {
     let environmentId = "env_1";
     const { result, rerender } = renderThreadHook(() =>
       useThreadFileTabs({
-        panelStateId: "recently-closed-environment-switch",
+        panelStateId: "recently-closed-context-order",
         syncThreadId: null,
         environmentId,
+        fileOwnerThreadId: "thr_1",
+        projectHostId: "host_1",
+        projectId: "proj_1",
         storageFiles: undefined,
         terminalSessions: undefined,
       }),
     );
 
-    let browserTabId = "";
-    let workspaceTabId = "";
-    act(() => {
-      browserTabId =
-        result.current.openTab({
-          kind: "browser",
-          url: "https://example.com",
-        })?.id ?? "";
-      workspaceTabId =
-        result.current.openTab({
-          kind: "workspace-file-preview",
-          tab: {
-            lineRange: null,
-            path: "src/index.ts",
-            source: { kind: "working-tree" },
-            statusLabel: null,
-          },
-        })?.id ?? "";
-    });
-    act(() => {
-      result.current.closeTab(browserTabId);
-      result.current.closeTab(workspaceTabId);
-    });
+    const openAndCloseWorkspaceFile = (path: string) => {
+      let tabId = "";
+      act(() => {
+        tabId =
+          result.current.openTab({
+            kind: "workspace-file-preview",
+            tab: {
+              lineRange: null,
+              path,
+              source: { kind: "working-tree" },
+              statusLabel: null,
+            },
+          })?.id ?? "";
+      });
+      act(() => result.current.closeTab(tabId));
+    };
+
+    openAndCloseWorkspaceFile("src/env-one.ts");
     act(() => {
       environmentId = "env_2";
+      rerender();
+    });
+    openAndCloseWorkspaceFile("src/env-two.ts");
+    act(() => {
+      environmentId = "env_1";
       rerender();
     });
 
@@ -295,8 +378,7 @@ describe("useThreadFileTabs recently closed tabs", () => {
       didReopen = result.current.reopenClosedTab();
     });
     expect(didReopen).toBe(true);
-    expect(result.current.activeBrowserTab?.id).toBe(browserTabId);
-    expect(result.current.activeWorkspaceFilePath).toBeNull();
+    expect(result.current.activeWorkspaceFilePath).toBe("src/env-one.ts");
 
     act(() => {
       didReopen = result.current.reopenClosedTab();

--- a/apps/app/src/components/secondary-panel/useThreadFileTabs.test.ts
+++ b/apps/app/src/components/secondary-panel/useThreadFileTabs.test.ts
@@ -62,9 +62,7 @@ function renderThreadHook<Result>(hook: () => Result) {
 }
 
 function createDeferred<T>() {
-  let resolve = (_value: T) => {
-    throw new Error("Deferred promise was not initialized");
-  };
+  let resolve!: (value: T) => void;
   const promise = new Promise<T>((nextResolve) => {
     resolve = nextResolve;
   });

--- a/apps/app/src/components/secondary-panel/useThreadFileTabs.test.ts
+++ b/apps/app/src/components/secondary-panel/useThreadFileTabs.test.ts
@@ -249,6 +249,60 @@ describe("useThreadFileTabs recently closed tabs", () => {
     });
     expect(didReopen).toBe(false);
   });
+
+  it("skips workspace history from the previous environment", () => {
+    let environmentId = "env_1";
+    const { result, rerender } = renderThreadHook(() =>
+      useThreadFileTabs({
+        panelStateId: "recently-closed-environment-switch",
+        syncThreadId: null,
+        environmentId,
+        storageFiles: undefined,
+        terminalSessions: undefined,
+      }),
+    );
+
+    let browserTabId = "";
+    let workspaceTabId = "";
+    act(() => {
+      browserTabId =
+        result.current.openTab({
+          kind: "browser",
+          url: "https://example.com",
+        })?.id ?? "";
+      workspaceTabId =
+        result.current.openTab({
+          kind: "workspace-file-preview",
+          tab: {
+            lineRange: null,
+            path: "src/index.ts",
+            source: { kind: "working-tree" },
+            statusLabel: null,
+          },
+        })?.id ?? "";
+    });
+    act(() => {
+      result.current.closeTab(browserTabId);
+      result.current.closeTab(workspaceTabId);
+    });
+    act(() => {
+      environmentId = "env_2";
+      rerender();
+    });
+
+    let didReopen = false;
+    act(() => {
+      didReopen = result.current.reopenClosedTab();
+    });
+    expect(didReopen).toBe(true);
+    expect(result.current.activeBrowserTab?.id).toBe(browserTabId);
+    expect(result.current.activeWorkspaceFilePath).toBeNull();
+
+    act(() => {
+      didReopen = result.current.reopenClosedTab();
+    });
+    expect(didReopen).toBe(false);
+  });
 });
 
 describe("useThreadFileTabs terminal pruning", () => {

--- a/apps/app/src/components/secondary-panel/useThreadFileTabs.ts
+++ b/apps/app/src/components/secondary-panel/useThreadFileTabs.ts
@@ -133,7 +133,83 @@ type SecondaryPanelTab =
   | NewTabFixedPanelTab
   | PluginPanelFixedPanelTab;
 
+type ReopenableSecondaryPanelTab = Exclude<
+  SecondaryPanelTab,
+  NewTabFixedPanelTab
+>;
+
+interface RecentlyClosedPanelTab {
+  index: number;
+  tab: ReopenableSecondaryPanelTab;
+}
+
 type OpenResolvedTabBehavior = "open" | "replace-new-tab";
+
+const MAX_RECENTLY_CLOSED_PANEL_TABS = 25;
+const recentlyClosedPanelTabs = new Map<string, RecentlyClosedPanelTab[]>();
+
+function isReopenableSecondaryPanelTab(
+  tab: FixedPanelTab,
+): tab is ReopenableSecondaryPanelTab {
+  switch (tab.kind) {
+    case "workspace-file-preview":
+    case "host-file-preview":
+    case "thread-storage-file-preview":
+    case "browser":
+    case "plugin-panel":
+      return true;
+    case "thread-info":
+    case "git-diff":
+    case "plugin-page-fixed":
+    case "new-tab":
+    case "terminal":
+      return false;
+  }
+}
+
+function rememberClosedPanelTab(
+  panelStateId: string,
+  entry: RecentlyClosedPanelTab,
+): void {
+  const stack = recentlyClosedPanelTabs.get(panelStateId) ?? [];
+  stack.push(entry);
+  if (stack.length > MAX_RECENTLY_CLOSED_PANEL_TABS) {
+    stack.splice(0, stack.length - MAX_RECENTLY_CLOSED_PANEL_TABS);
+  }
+  recentlyClosedPanelTabs.set(panelStateId, stack);
+}
+
+function forgetClosedPanelTab(panelStateId: string, tabId: string): void {
+  const stack = recentlyClosedPanelTabs.get(panelStateId);
+  if (stack === undefined) return;
+  const next = stack.filter((entry) => entry.tab.id !== tabId);
+  if (next.length === 0) {
+    recentlyClosedPanelTabs.delete(panelStateId);
+    return;
+  }
+  recentlyClosedPanelTabs.set(panelStateId, next);
+}
+
+function takeClosedPanelTab(
+  panelStateId: string,
+  openTabIds: ReadonlySet<string>,
+): RecentlyClosedPanelTab | null {
+  const stack = recentlyClosedPanelTabs.get(panelStateId);
+  if (stack === undefined) return null;
+  while (stack.length > 0) {
+    const entry = stack.pop();
+    if (entry !== undefined && !openTabIds.has(entry.tab.id)) {
+      if (stack.length === 0) recentlyClosedPanelTabs.delete(panelStateId);
+      return entry;
+    }
+  }
+  recentlyClosedPanelTabs.delete(panelStateId);
+  return null;
+}
+
+export function resetRecentlyClosedPanelTabsForTest(): void {
+  recentlyClosedPanelTabs.clear();
+}
 
 function createStorageTab(
   environmentId: string | null,
@@ -260,8 +336,11 @@ export function useThreadFileTabs({
     syncThreadId,
   );
   const recordRecentItem = useRecordThreadRecentItem(panelStateId);
-  const isPanelStateResolved =
-    panelStateId !== null && panelStateId !== undefined;
+  const resolvedPanelStateId =
+    typeof panelStateId === "string" && panelStateId.length > 0
+      ? panelStateId
+      : null;
+  const isPanelStateResolved = resolvedPanelStateId !== null;
   const resolvedFileOwnerThreadId =
     fileOwnerThreadId !== undefined
       ? fileOwnerThreadId
@@ -442,6 +521,10 @@ export function useThreadFileTabs({
         });
       if (tab === null) return null;
 
+      if (resolvedPanelStateId !== null) {
+        forgetClosedPanelTab(resolvedPanelStateId, tab.id);
+      }
+
       if (
         request.kind === "workspace-file-preview" &&
         request.tab.source.kind === "working-tree"
@@ -468,6 +551,7 @@ export function useThreadFileTabs({
       projectId,
       resolvedEnvironmentId,
       resolvedFileOwnerThreadId,
+      resolvedPanelStateId,
       updateFixedPanelTabsState,
     ],
   );
@@ -497,12 +581,54 @@ export function useThreadFileTabs({
 
   const closeTab = useCallback(
     (tabId: string) => {
-      updateFixedPanelTabsState((state) =>
-        closeSecondaryPanelTabInState(state, tabId),
-      );
+      updateFixedPanelTabsState((state) => {
+        const tabIndex = state.secondary.tabs.findIndex(
+          (tab) => tab.id === tabId,
+        );
+        const tab = state.secondary.tabs[tabIndex];
+        const next = closeSecondaryPanelTabInState(state, tabId);
+        if (
+          next !== state &&
+          resolvedPanelStateId !== null &&
+          tab !== undefined &&
+          isReopenableSecondaryPanelTab(tab)
+        ) {
+          rememberClosedPanelTab(resolvedPanelStateId, {
+            index: tabIndex,
+            tab,
+          });
+        }
+        return next;
+      });
     },
-    [updateFixedPanelTabsState],
+    [resolvedPanelStateId, updateFixedPanelTabsState],
   );
+
+  const reopenClosedTab = useCallback((): boolean => {
+    if (resolvedPanelStateId === null) return false;
+    let didReopen = false;
+    updateFixedPanelTabsState((state) => {
+      const entry = takeClosedPanelTab(
+        resolvedPanelStateId,
+        new Set(state.secondary.tabs.map((tab) => tab.id)),
+      );
+      if (entry === null) return state;
+      const index = Math.max(
+        0,
+        Math.min(entry.index, state.secondary.tabs.length),
+      );
+      const tabs = [...state.secondary.tabs];
+      tabs.splice(index, 0, entry.tab);
+      didReopen = true;
+      return setSecondaryPanelTabsInState({
+        activeTabId: entry.tab.id,
+        isOpen: true,
+        state,
+        tabs,
+      });
+    });
+    return didReopen;
+  }, [resolvedPanelStateId, updateFixedPanelTabsState]);
 
   const openPluginPanel = useCallback(
     ({ pluginId, actionId, title, paramsJson }: OpenPluginPanelArgs) => {
@@ -512,6 +638,9 @@ export function useThreadFileTabs({
         pluginId,
         title,
       });
+      if (resolvedPanelStateId !== null) {
+        forgetClosedPanelTab(resolvedPanelStateId, tab.id);
+      }
       updateFixedPanelTabsState((state) => {
         const existing = findSecondaryPanelTab(state.secondary.tabs, tab.id);
         if (existing !== null && existing.kind === "plugin-panel") {
@@ -527,7 +656,7 @@ export function useThreadFileTabs({
         return replaceNewTabWithSecondaryPanelTabInState({ state, tab });
       });
     },
-    [updateFixedPanelTabsState],
+    [resolvedPanelStateId, updateFixedPanelTabsState],
   );
 
   const selectFileSearchResult = useCallback(
@@ -680,6 +809,7 @@ export function useThreadFileTabs({
     openPluginPanel,
     openTab,
     orderedSecondaryFileTabs,
+    reopenClosedTab,
     reorderTab,
     selectFileSearchResult,
     updateBrowserTab,

--- a/apps/app/src/components/secondary-panel/useThreadFileTabs.ts
+++ b/apps/app/src/components/secondary-panel/useThreadFileTabs.ts
@@ -140,28 +140,31 @@ type ReopenableSecondaryPanelTab = Exclude<
 >;
 
 interface RecentlyClosedPanelTab {
-  context: RecentlyClosedPanelTabContext;
   index: number;
   tab: ReopenableSecondaryPanelTab;
 }
 
-interface RecentlyClosedPanelTabContext {
+interface RecentlyClosedPanelContext {
   environmentId: string | null | undefined;
   fileOwnerThreadId: string | null;
+  panelStateId: string;
   projectHostId: string | null;
   projectId: string | null;
 }
 
-interface IsRecentlyClosedPanelTabValidArgs {
-  currentContext: RecentlyClosedPanelTabContext;
-  entry: RecentlyClosedPanelTab;
-  knownStoragePaths: ReadonlySet<string> | null;
+interface IsReopenablePanelTabOwnedByContextArgs {
+  context: RecentlyClosedPanelContext;
+  tab: ReopenableSecondaryPanelTab;
 }
 
+type RecentlyClosedPanelContextKey = string;
 type OpenResolvedTabBehavior = "open" | "replace-new-tab";
 
 const MAX_RECENTLY_CLOSED_PANEL_TABS = 25;
-const recentlyClosedPanelTabs = new Map<string, RecentlyClosedPanelTab[]>();
+const recentlyClosedPanelTabs = new Map<
+  RecentlyClosedPanelContextKey,
+  RecentlyClosedPanelTab[]
+>();
 
 function isReopenableSecondaryPanelTab(
   tab: FixedPanelTab,
@@ -183,86 +186,88 @@ function isReopenableSecondaryPanelTab(
 }
 
 function rememberClosedPanelTab(
-  panelStateId: string,
+  contextKey: RecentlyClosedPanelContextKey,
   entry: RecentlyClosedPanelTab,
 ): void {
-  const stack = recentlyClosedPanelTabs.get(panelStateId) ?? [];
+  const stack = recentlyClosedPanelTabs.get(contextKey) ?? [];
   stack.push(entry);
   if (stack.length > MAX_RECENTLY_CLOSED_PANEL_TABS) {
     stack.splice(0, stack.length - MAX_RECENTLY_CLOSED_PANEL_TABS);
   }
-  recentlyClosedPanelTabs.set(panelStateId, stack);
+  recentlyClosedPanelTabs.set(contextKey, stack);
 }
 
-function forgetClosedPanelTab(panelStateId: string, tabId: string): void {
-  const stack = recentlyClosedPanelTabs.get(panelStateId);
+function forgetClosedPanelTab(
+  contextKey: RecentlyClosedPanelContextKey,
+  tabId: string,
+): void {
+  const stack = recentlyClosedPanelTabs.get(contextKey);
   if (stack === undefined) return;
   const next = stack.filter((entry) => entry.tab.id !== tabId);
   if (next.length === 0) {
-    recentlyClosedPanelTabs.delete(panelStateId);
+    recentlyClosedPanelTabs.delete(contextKey);
     return;
   }
-  recentlyClosedPanelTabs.set(panelStateId, next);
+  recentlyClosedPanelTabs.set(contextKey, next);
 }
 
-function areRecentlyClosedPanelTabContextsEqual(
-  first: RecentlyClosedPanelTabContext,
-  second: RecentlyClosedPanelTabContext,
-): boolean {
-  return (
-    first.environmentId === second.environmentId &&
-    first.fileOwnerThreadId === second.fileOwnerThreadId &&
-    first.projectHostId === second.projectHostId &&
-    first.projectId === second.projectId
-  );
+function buildRecentlyClosedPanelContextKey(
+  context: RecentlyClosedPanelContext,
+): RecentlyClosedPanelContextKey {
+  return JSON.stringify(context);
 }
 
-function isRecentlyClosedPanelTabValid({
-  currentContext,
-  entry,
-  knownStoragePaths,
-}: IsRecentlyClosedPanelTabValidArgs): boolean {
-  if (!areRecentlyClosedPanelTabContextsEqual(entry.context, currentContext)) {
-    return false;
-  }
+function isReopenablePanelTabOwnedByContext({
+  context,
+  tab: reopenableTab,
+}: IsReopenablePanelTabOwnedByContextArgs): boolean {
   const originalTab =
-    entry.tab.kind === "plugin-panel"
-      ? createFileOpenerOriginalTab(entry.tab)
+    reopenableTab.kind === "plugin-panel"
+      ? createFileOpenerOriginalTab(reopenableTab)
       : null;
-  const tab = originalTab ?? entry.tab;
+  const tab = originalTab ?? reopenableTab;
   switch (tab.kind) {
     case "workspace-file-preview":
       return (
-        tab.environmentId === currentContext.environmentId &&
+        tab.environmentId === context.environmentId &&
         tab.projectId ===
-          (currentContext.environmentId === null
-            ? currentContext.projectId
-            : null)
+          (context.environmentId === null ? context.projectId : null)
       );
     case "host-file-preview":
       return (
         tab.hostId !== null ||
-        (tab.environmentId === currentContext.environmentId &&
-          tab.threadId === currentContext.fileOwnerThreadId)
+        (tab.environmentId === context.environmentId &&
+          tab.threadId === context.fileOwnerThreadId)
       );
     case "thread-storage-file-preview":
-      return (
-        tab.threadId === currentContext.fileOwnerThreadId &&
-        (knownStoragePaths === null || knownStoragePaths.has(tab.path))
-      );
+      return tab.threadId === context.fileOwnerThreadId;
     case "browser":
-      return tab.environmentId === currentContext.environmentId;
+      return tab.environmentId === context.environmentId;
     case "plugin-panel":
       return true;
   }
 }
 
+function isRecentlyClosedPanelTabAvailable(
+  tab: ReopenableSecondaryPanelTab,
+  knownStoragePaths: ReadonlySet<string> | null,
+): boolean {
+  const originalTab =
+    tab.kind === "plugin-panel" ? createFileOpenerOriginalTab(tab) : null;
+  const resourceTab = originalTab ?? tab;
+  return (
+    resourceTab.kind !== "thread-storage-file-preview" ||
+    knownStoragePaths === null ||
+    knownStoragePaths.has(resourceTab.path)
+  );
+}
+
 function takeClosedPanelTab(
-  panelStateId: string,
+  contextKey: RecentlyClosedPanelContextKey,
   openTabIds: ReadonlySet<string>,
   isEntryValid?: (entry: RecentlyClosedPanelTab) => boolean,
 ): RecentlyClosedPanelTab | null {
-  const stack = recentlyClosedPanelTabs.get(panelStateId);
+  const stack = recentlyClosedPanelTabs.get(contextKey);
   if (stack === undefined) return null;
   while (stack.length > 0) {
     const entry = stack.pop();
@@ -271,11 +276,11 @@ function takeClosedPanelTab(
       !openTabIds.has(entry.tab.id) &&
       (isEntryValid === undefined || isEntryValid(entry))
     ) {
-      if (stack.length === 0) recentlyClosedPanelTabs.delete(panelStateId);
+      if (stack.length === 0) recentlyClosedPanelTabs.delete(contextKey);
       return entry;
     }
   }
-  recentlyClosedPanelTabs.delete(panelStateId);
+  recentlyClosedPanelTabs.delete(contextKey);
   return null;
 }
 
@@ -427,19 +432,31 @@ export function useThreadFileTabs({
         : new Set(storageFiles.map((file) => file.path)),
     [storageFiles],
   );
-  const recentlyClosedPanelTabContext = useMemo(
-    () => ({
-      environmentId: resolvedEnvironmentId,
-      fileOwnerThreadId: resolvedFileOwnerThreadId,
-      projectHostId,
-      projectId,
-    }),
+  const recentlyClosedPanelContext = useMemo(
+    () =>
+      resolvedPanelStateId === null
+        ? null
+        : {
+            environmentId: resolvedEnvironmentId,
+            fileOwnerThreadId: resolvedFileOwnerThreadId,
+            panelStateId: resolvedPanelStateId,
+            projectHostId,
+            projectId,
+          },
     [
       projectHostId,
       projectId,
       resolvedEnvironmentId,
       resolvedFileOwnerThreadId,
+      resolvedPanelStateId,
     ],
+  );
+  const recentlyClosedPanelContextKey = useMemo(
+    () =>
+      recentlyClosedPanelContext === null
+        ? null
+        : buildRecentlyClosedPanelContextKey(recentlyClosedPanelContext),
+    [recentlyClosedPanelContext],
   );
 
   useEffect(() => {
@@ -613,8 +630,8 @@ export function useThreadFileTabs({
         });
       if (tab === null) return null;
 
-      if (resolvedPanelStateId !== null) {
-        forgetClosedPanelTab(resolvedPanelStateId, tab.id);
+      if (recentlyClosedPanelContextKey !== null) {
+        forgetClosedPanelTab(recentlyClosedPanelContextKey, tab.id);
       }
 
       if (
@@ -643,7 +660,7 @@ export function useThreadFileTabs({
       projectId,
       resolvedEnvironmentId,
       resolvedFileOwnerThreadId,
-      resolvedPanelStateId,
+      recentlyClosedPanelContextKey,
       updateFixedPanelTabsState,
     ],
   );
@@ -681,12 +698,16 @@ export function useThreadFileTabs({
         const next = closeSecondaryPanelTabInState(state, tabId);
         if (
           next !== state &&
-          resolvedPanelStateId !== null &&
+          recentlyClosedPanelContext !== null &&
+          recentlyClosedPanelContextKey !== null &&
           tab !== undefined &&
-          isReopenableSecondaryPanelTab(tab)
+          isReopenableSecondaryPanelTab(tab) &&
+          isReopenablePanelTabOwnedByContext({
+            context: recentlyClosedPanelContext,
+            tab,
+          })
         ) {
-          rememberClosedPanelTab(resolvedPanelStateId, {
-            context: recentlyClosedPanelTabContext,
+          rememberClosedPanelTab(recentlyClosedPanelContextKey, {
             index: tabIndex,
             tab,
           });
@@ -695,25 +716,21 @@ export function useThreadFileTabs({
       });
     },
     [
-      recentlyClosedPanelTabContext,
-      resolvedPanelStateId,
+      recentlyClosedPanelContext,
+      recentlyClosedPanelContextKey,
       updateFixedPanelTabsState,
     ],
   );
 
   const reopenClosedTab = useCallback((): boolean => {
-    if (resolvedPanelStateId === null) return false;
+    if (recentlyClosedPanelContextKey === null) return false;
     let didReopen = false;
     updateFixedPanelTabsState((state) => {
       const entry = takeClosedPanelTab(
-        resolvedPanelStateId,
+        recentlyClosedPanelContextKey,
         new Set(state.secondary.tabs.map((tab) => tab.id)),
         (entry) =>
-          isRecentlyClosedPanelTabValid({
-            currentContext: recentlyClosedPanelTabContext,
-            entry,
-            knownStoragePaths,
-          }),
+          isRecentlyClosedPanelTabAvailable(entry.tab, knownStoragePaths),
       );
       if (entry === null) return state;
       const index = Math.max(
@@ -733,8 +750,7 @@ export function useThreadFileTabs({
     return didReopen;
   }, [
     knownStoragePaths,
-    recentlyClosedPanelTabContext,
-    resolvedPanelStateId,
+    recentlyClosedPanelContextKey,
     updateFixedPanelTabsState,
   ]);
 
@@ -746,8 +762,8 @@ export function useThreadFileTabs({
         pluginId,
         title,
       });
-      if (resolvedPanelStateId !== null) {
-        forgetClosedPanelTab(resolvedPanelStateId, tab.id);
+      if (recentlyClosedPanelContextKey !== null) {
+        forgetClosedPanelTab(recentlyClosedPanelContextKey, tab.id);
       }
       updateFixedPanelTabsState((state) => {
         const existing = findSecondaryPanelTab(state.secondary.tabs, tab.id);
@@ -764,7 +780,7 @@ export function useThreadFileTabs({
         return replaceNewTabWithSecondaryPanelTabInState({ state, tab });
       });
     },
-    [resolvedPanelStateId, updateFixedPanelTabsState],
+    [recentlyClosedPanelContextKey, updateFixedPanelTabsState],
   );
 
   const selectFileSearchResult = useCallback(

--- a/apps/app/src/components/secondary-panel/useThreadFileTabs.ts
+++ b/apps/app/src/components/secondary-panel/useThreadFileTabs.ts
@@ -193,12 +193,17 @@ function forgetClosedPanelTab(panelStateId: string, tabId: string): void {
 function takeClosedPanelTab(
   panelStateId: string,
   openTabIds: ReadonlySet<string>,
+  isTabValid?: (tab: ReopenableSecondaryPanelTab) => boolean,
 ): RecentlyClosedPanelTab | null {
   const stack = recentlyClosedPanelTabs.get(panelStateId);
   if (stack === undefined) return null;
   while (stack.length > 0) {
     const entry = stack.pop();
-    if (entry !== undefined && !openTabIds.has(entry.tab.id)) {
+    if (
+      entry !== undefined &&
+      !openTabIds.has(entry.tab.id) &&
+      (isTabValid === undefined || isTabValid(entry.tab))
+    ) {
       if (stack.length === 0) recentlyClosedPanelTabs.delete(panelStateId);
       return entry;
     }
@@ -348,6 +353,13 @@ export function useThreadFileTabs({
   const resolvedEnvironmentId = isPanelStateResolved
     ? environmentId
     : undefined;
+  const knownStoragePaths = useMemo(
+    () =>
+      storageFiles === undefined
+        ? null
+        : new Set(storageFiles.map((file) => file.path)),
+    [storageFiles],
+  );
 
   useEffect(() => {
     if (!resolvedFileOwnerThreadId) return;
@@ -442,13 +454,12 @@ export function useThreadFileTabs({
   ]);
 
   useEffect(() => {
-    if (!isPanelStateResolved || !storageFiles) return;
+    if (!isPanelStateResolved || knownStoragePaths === null) return;
     updateFixedPanelTabsState((state) => {
-      const knownPaths = new Set(storageFiles.map((file) => file.path));
       const pruned = setPrunedSecondaryTabs({
         activeTabId: state.secondary.activeTabId,
         tabs: pruneStorageTabs({
-          knownPaths,
+          knownPaths: knownStoragePaths,
           tabs: state.secondary.tabs,
           threadId: resolvedFileOwnerThreadId,
         }),
@@ -462,8 +473,8 @@ export function useThreadFileTabs({
     });
   }, [
     isPanelStateResolved,
+    knownStoragePaths,
     resolvedFileOwnerThreadId,
-    storageFiles,
     updateFixedPanelTabsState,
   ]);
 
@@ -611,6 +622,12 @@ export function useThreadFileTabs({
       const entry = takeClosedPanelTab(
         resolvedPanelStateId,
         new Set(state.secondary.tabs.map((tab) => tab.id)),
+        (tab) =>
+          tab.kind !== "thread-storage-file-preview" ||
+          knownStoragePaths === null ||
+          (tab.threadId !== null &&
+            tab.threadId !== resolvedFileOwnerThreadId) ||
+          knownStoragePaths.has(tab.path),
       );
       if (entry === null) return state;
       const index = Math.max(
@@ -628,7 +645,12 @@ export function useThreadFileTabs({
       });
     });
     return didReopen;
-  }, [resolvedPanelStateId, updateFixedPanelTabsState]);
+  }, [
+    knownStoragePaths,
+    resolvedFileOwnerThreadId,
+    resolvedPanelStateId,
+    updateFixedPanelTabsState,
+  ]);
 
   const openPluginPanel = useCallback(
     ({ pluginId, actionId, title, paramsJson }: OpenPluginPanelArgs) => {

--- a/apps/app/src/components/secondary-panel/useThreadFileTabs.ts
+++ b/apps/app/src/components/secondary-panel/useThreadFileTabs.ts
@@ -1,5 +1,8 @@
-import { useCallback, useEffect, useMemo } from "react";
-import type { TerminalSession } from "@bb/server-contract";
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import type {
+  TerminalSession,
+  ThreadStorageFileListResponse,
+} from "@bb/server-contract";
 import {
   useFixedPanelTabsState,
   useUpdateFixedPanelTabsState,
@@ -13,6 +16,7 @@ import {
   createWorkspaceFilePreviewFixedPanelTab,
   type BrowserFixedPanelTab,
   type FixedPanelTab,
+  type FixedPanelTabsState,
   type HostFilePreviewFixedPanelTab,
   type NewTabFixedPanelTab,
   type PluginPanelFixedPanelTab,
@@ -67,12 +71,11 @@ interface UseThreadFileTabsParams {
   projectHostId?: string | null;
   projectId?: string | null;
   retainedTerminalId?: string | null;
-  storageFiles: readonly ThreadStorageFileListItem[] | undefined;
+  storageFileExists?: (path: string) => Promise<boolean>;
+  storageFiles:
+    | Pick<ThreadStorageFileListResponse, "files" | "truncated">
+    | undefined;
   terminalSessions: readonly TerminalSession[] | undefined;
-}
-
-interface ThreadStorageFileListItem {
-  path: string;
 }
 
 interface FileSearchWorkspaceSelection {
@@ -157,6 +160,27 @@ interface IsReopenablePanelTabOwnedByContextArgs {
   tab: ReopenableSecondaryPanelTab;
 }
 
+interface StorageFileInventory {
+  knownPaths: ReadonlySet<string>;
+  truncated: boolean;
+}
+
+type RecentlyClosedPanelTabAvailability =
+  | "available"
+  | "missing"
+  | "unresolved";
+
+type TakeClosedPanelTabResult =
+  | { kind: "available"; entry: RecentlyClosedPanelTab }
+  | { kind: "unresolved"; entry: RecentlyClosedPanelTab }
+  | { kind: "empty" };
+
+function isRecentlyClosedPanelTab(
+  entry: RecentlyClosedPanelTab | null,
+): entry is RecentlyClosedPanelTab {
+  return entry !== null;
+}
+
 type RecentlyClosedPanelContextKey = string;
 type OpenResolvedTabBehavior = "open" | "replace-new-tab";
 
@@ -200,15 +224,17 @@ function rememberClosedPanelTab(
 function forgetClosedPanelTab(
   contextKey: RecentlyClosedPanelContextKey,
   tabId: string,
-): void {
+): boolean {
   const stack = recentlyClosedPanelTabs.get(contextKey);
-  if (stack === undefined) return;
+  if (stack === undefined) return false;
+  const wasTop = stack.at(-1)?.tab.id === tabId;
   const next = stack.filter((entry) => entry.tab.id !== tabId);
   if (next.length === 0) {
     recentlyClosedPanelTabs.delete(contextKey);
-    return;
+    return wasTop;
   }
   recentlyClosedPanelTabs.set(contextKey, next);
+  return wasTop;
 }
 
 function buildRecentlyClosedPanelContextKey(
@@ -248,40 +274,55 @@ function isReopenablePanelTabOwnedByContext({
   }
 }
 
-function isRecentlyClosedPanelTabAvailable(
+function storagePathForRecentlyClosedPanelTab(
   tab: ReopenableSecondaryPanelTab,
-  knownStoragePaths: ReadonlySet<string> | null,
-): boolean {
+): string | null {
   const originalTab =
     tab.kind === "plugin-panel" ? createFileOpenerOriginalTab(tab) : null;
   const resourceTab = originalTab ?? tab;
-  return (
-    resourceTab.kind !== "thread-storage-file-preview" ||
-    knownStoragePaths === null ||
-    knownStoragePaths.has(resourceTab.path)
-  );
+  return resourceTab.kind === "thread-storage-file-preview"
+    ? resourceTab.path
+    : null;
+}
+
+function recentlyClosedPanelTabAvailability(
+  tab: ReopenableSecondaryPanelTab,
+  storageInventory: StorageFileInventory | null,
+): RecentlyClosedPanelTabAvailability {
+  const storagePath = storagePathForRecentlyClosedPanelTab(tab);
+  if (storagePath === null) return "available";
+  if (storageInventory === null) return "unresolved";
+  if (storageInventory.knownPaths.has(storagePath)) return "available";
+  return storageInventory.truncated ? "unresolved" : "missing";
 }
 
 function takeClosedPanelTab(
   contextKey: RecentlyClosedPanelContextKey,
   openTabIds: ReadonlySet<string>,
-  isEntryValid?: (entry: RecentlyClosedPanelTab) => boolean,
-): RecentlyClosedPanelTab | null {
+  availability: (
+    entry: RecentlyClosedPanelTab,
+  ) => RecentlyClosedPanelTabAvailability,
+): TakeClosedPanelTabResult {
   const stack = recentlyClosedPanelTabs.get(contextKey);
-  if (stack === undefined) return null;
+  if (stack === undefined) return { kind: "empty" };
   while (stack.length > 0) {
-    const entry = stack.pop();
-    if (
-      entry !== undefined &&
-      !openTabIds.has(entry.tab.id) &&
-      (isEntryValid === undefined || isEntryValid(entry))
-    ) {
-      if (stack.length === 0) recentlyClosedPanelTabs.delete(contextKey);
-      return entry;
+    const entry = stack.at(-1);
+    if (entry === undefined) break;
+    if (openTabIds.has(entry.tab.id)) {
+      stack.pop();
+      continue;
     }
+    const entryAvailability = availability(entry);
+    if (entryAvailability === "unresolved") {
+      return { kind: "unresolved", entry };
+    }
+    stack.pop();
+    if (entryAvailability === "missing") continue;
+    if (stack.length === 0) recentlyClosedPanelTabs.delete(contextKey);
+    return { kind: "available", entry };
   }
   recentlyClosedPanelTabs.delete(contextKey);
-  return null;
+  return { kind: "empty" };
 }
 
 export function resetRecentlyClosedPanelTabsForTest(): void {
@@ -401,6 +442,7 @@ export function useThreadFileTabs({
   projectHostId = null,
   projectId = null,
   retainedTerminalId = null,
+  storageFileExists,
   storageFiles,
   terminalSessions,
 }: UseThreadFileTabsParams) {
@@ -425,11 +467,14 @@ export function useThreadFileTabs({
   const resolvedEnvironmentId = isPanelStateResolved
     ? environmentId
     : undefined;
-  const knownStoragePaths = useMemo(
+  const storageInventory = useMemo<StorageFileInventory | null>(
     () =>
       storageFiles === undefined
         ? null
-        : new Set(storageFiles.map((file) => file.path)),
+        : {
+            knownPaths: new Set(storageFiles.files.map((file) => file.path)),
+            truncated: storageFiles.truncated,
+          },
     [storageFiles],
   );
   const recentlyClosedPanelContext = useMemo(
@@ -458,6 +503,19 @@ export function useThreadFileTabs({
         : buildRecentlyClosedPanelContextKey(recentlyClosedPanelContext),
     [recentlyClosedPanelContext],
   );
+  const recentlyClosedPanelContextKeyRef = useRef(
+    recentlyClosedPanelContextKey,
+  );
+  const pendingStorageValidationRef = useRef<string | null>(null);
+  const isMountedRef = useRef(true);
+  recentlyClosedPanelContextKeyRef.current = recentlyClosedPanelContextKey;
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
 
   useEffect(() => {
     if (!resolvedFileOwnerThreadId) return;
@@ -552,12 +610,18 @@ export function useThreadFileTabs({
   ]);
 
   useEffect(() => {
-    if (!isPanelStateResolved || knownStoragePaths === null) return;
+    if (
+      !isPanelStateResolved ||
+      storageInventory === null ||
+      storageInventory.truncated
+    ) {
+      return;
+    }
     updateFixedPanelTabsState((state) => {
       const pruned = setPrunedSecondaryTabs({
         activeTabId: state.secondary.activeTabId,
         tabs: pruneStorageTabs({
-          knownPaths: knownStoragePaths,
+          knownPaths: storageInventory.knownPaths,
           tabs: state.secondary.tabs,
           threadId: resolvedFileOwnerThreadId,
         }),
@@ -571,8 +635,8 @@ export function useThreadFileTabs({
     });
   }, [
     isPanelStateResolved,
-    knownStoragePaths,
     resolvedFileOwnerThreadId,
+    storageInventory,
     updateFixedPanelTabsState,
   ]);
 
@@ -724,33 +788,98 @@ export function useThreadFileTabs({
 
   const reopenClosedTab = useCallback((): boolean => {
     if (recentlyClosedPanelContextKey === null) return false;
-    let didReopen = false;
-    updateFixedPanelTabsState((state) => {
-      const entry = takeClosedPanelTab(
-        recentlyClosedPanelContextKey,
-        new Set(state.secondary.tabs.map((tab) => tab.id)),
-        (entry) =>
-          isRecentlyClosedPanelTabAvailable(entry.tab, knownStoragePaths),
-      );
-      if (entry === null) return state;
+    const contextKey = recentlyClosedPanelContextKey;
+
+    const restoreEntry = (
+      state: FixedPanelTabsState,
+      entry: RecentlyClosedPanelTab,
+    ) => {
       const index = Math.max(
         0,
         Math.min(entry.index, state.secondary.tabs.length),
       );
       const tabs = [...state.secondary.tabs];
       tabs.splice(index, 0, entry.tab);
-      didReopen = true;
       return setSecondaryPanelTabsInState({
         activeTabId: entry.tab.id,
         isOpen: true,
         state,
         tabs,
       });
-    });
-    return didReopen;
+    };
+
+    const attemptReopen = (): boolean => {
+      let didReopen = false;
+      let unresolvedEntry: RecentlyClosedPanelTab | null = null;
+      updateFixedPanelTabsState((state) => {
+        const result = takeClosedPanelTab(
+          contextKey,
+          new Set(state.secondary.tabs.map((tab) => tab.id)),
+          (entry) =>
+            recentlyClosedPanelTabAvailability(entry.tab, storageInventory),
+        );
+        if (result.kind === "empty") return state;
+        if (result.kind === "unresolved") {
+          unresolvedEntry = result.entry;
+          return state;
+        }
+        didReopen = true;
+        return restoreEntry(state, result.entry);
+      });
+      if (didReopen) return true;
+      if (
+        !isRecentlyClosedPanelTab(unresolvedEntry) ||
+        storageFileExists === undefined
+      ) {
+        return false;
+      }
+
+      const entry = unresolvedEntry;
+      const storagePath = storagePathForRecentlyClosedPanelTab(entry.tab);
+      if (storagePath === null) return false;
+      const validationKey = `${contextKey}:${entry.tab.id}`;
+      if (pendingStorageValidationRef.current === validationKey) return true;
+      pendingStorageValidationRef.current = validationKey;
+      void storageFileExists(storagePath)
+        .then((exists) => {
+          if (
+            !isMountedRef.current ||
+            recentlyClosedPanelContextKeyRef.current !== contextKey ||
+            pendingStorageValidationRef.current !== validationKey
+          ) {
+            return;
+          }
+          pendingStorageValidationRef.current = null;
+          if (!exists) {
+            const wasTop = forgetClosedPanelTab(contextKey, entry.tab.id);
+            if (wasTop) attemptReopen();
+            return;
+          }
+          updateFixedPanelTabsState((state) => {
+            const result = takeClosedPanelTab(
+              contextKey,
+              new Set(state.secondary.tabs.map((tab) => tab.id)),
+              (candidate) =>
+                candidate.tab.id === entry.tab.id ? "available" : "unresolved",
+            );
+            return result.kind === "available"
+              ? restoreEntry(state, result.entry)
+              : state;
+          });
+        })
+        .catch(() => {
+          if (pendingStorageValidationRef.current === validationKey) {
+            pendingStorageValidationRef.current = null;
+          }
+        });
+      return true;
+    };
+
+    return attemptReopen();
   }, [
-    knownStoragePaths,
     recentlyClosedPanelContextKey,
+    storageFileExists,
+    storageInventory,
     updateFixedPanelTabsState,
   ]);
 

--- a/apps/app/src/components/secondary-panel/useThreadFileTabs.ts
+++ b/apps/app/src/components/secondary-panel/useThreadFileTabs.ts
@@ -623,11 +623,14 @@ export function useThreadFileTabs({
         resolvedPanelStateId,
         new Set(state.secondary.tabs.map((tab) => tab.id)),
         (tab) =>
-          tab.kind !== "thread-storage-file-preview" ||
-          knownStoragePaths === null ||
-          (tab.threadId !== null &&
-            tab.threadId !== resolvedFileOwnerThreadId) ||
-          knownStoragePaths.has(tab.path),
+          (tab.kind !== "workspace-file-preview" ||
+            preserveWorkspaceTabsAcrossContexts ||
+            tab.environmentId === resolvedEnvironmentId) &&
+          (tab.kind !== "thread-storage-file-preview" ||
+            knownStoragePaths === null ||
+            (tab.threadId !== null &&
+              tab.threadId !== resolvedFileOwnerThreadId) ||
+            knownStoragePaths.has(tab.path)),
       );
       if (entry === null) return state;
       const index = Math.max(
@@ -647,6 +650,8 @@ export function useThreadFileTabs({
     return didReopen;
   }, [
     knownStoragePaths,
+    preserveWorkspaceTabsAcrossContexts,
+    resolvedEnvironmentId,
     resolvedFileOwnerThreadId,
     resolvedPanelStateId,
     updateFixedPanelTabsState,

--- a/apps/app/src/components/secondary-panel/useThreadFileTabs.ts
+++ b/apps/app/src/components/secondary-panel/useThreadFileTabs.ts
@@ -22,6 +22,7 @@ import {
 import { usePluginSlots } from "@/lib/plugin-slots";
 import { useFileOpenerPreferenceValue } from "@/lib/file-opener-preference";
 import {
+  createFileOpenerOriginalTab,
   createFileOpenerTabForRequest,
   fileOpenerIdFromActionId,
   parseFileOpenerParams,
@@ -139,8 +140,22 @@ type ReopenableSecondaryPanelTab = Exclude<
 >;
 
 interface RecentlyClosedPanelTab {
+  context: RecentlyClosedPanelTabContext;
   index: number;
   tab: ReopenableSecondaryPanelTab;
+}
+
+interface RecentlyClosedPanelTabContext {
+  environmentId: string | null | undefined;
+  fileOwnerThreadId: string | null;
+  projectHostId: string | null;
+  projectId: string | null;
+}
+
+interface IsRecentlyClosedPanelTabValidArgs {
+  currentContext: RecentlyClosedPanelTabContext;
+  entry: RecentlyClosedPanelTab;
+  knownStoragePaths: ReadonlySet<string> | null;
 }
 
 type OpenResolvedTabBehavior = "open" | "replace-new-tab";
@@ -190,10 +205,62 @@ function forgetClosedPanelTab(panelStateId: string, tabId: string): void {
   recentlyClosedPanelTabs.set(panelStateId, next);
 }
 
+function areRecentlyClosedPanelTabContextsEqual(
+  first: RecentlyClosedPanelTabContext,
+  second: RecentlyClosedPanelTabContext,
+): boolean {
+  return (
+    first.environmentId === second.environmentId &&
+    first.fileOwnerThreadId === second.fileOwnerThreadId &&
+    first.projectHostId === second.projectHostId &&
+    first.projectId === second.projectId
+  );
+}
+
+function isRecentlyClosedPanelTabValid({
+  currentContext,
+  entry,
+  knownStoragePaths,
+}: IsRecentlyClosedPanelTabValidArgs): boolean {
+  if (!areRecentlyClosedPanelTabContextsEqual(entry.context, currentContext)) {
+    return false;
+  }
+  const originalTab =
+    entry.tab.kind === "plugin-panel"
+      ? createFileOpenerOriginalTab(entry.tab)
+      : null;
+  const tab = originalTab ?? entry.tab;
+  switch (tab.kind) {
+    case "workspace-file-preview":
+      return (
+        tab.environmentId === currentContext.environmentId &&
+        tab.projectId ===
+          (currentContext.environmentId === null
+            ? currentContext.projectId
+            : null)
+      );
+    case "host-file-preview":
+      return (
+        tab.hostId !== null ||
+        (tab.environmentId === currentContext.environmentId &&
+          tab.threadId === currentContext.fileOwnerThreadId)
+      );
+    case "thread-storage-file-preview":
+      return (
+        tab.threadId === currentContext.fileOwnerThreadId &&
+        (knownStoragePaths === null || knownStoragePaths.has(tab.path))
+      );
+    case "browser":
+      return tab.environmentId === currentContext.environmentId;
+    case "plugin-panel":
+      return true;
+  }
+}
+
 function takeClosedPanelTab(
   panelStateId: string,
   openTabIds: ReadonlySet<string>,
-  isTabValid?: (tab: ReopenableSecondaryPanelTab) => boolean,
+  isEntryValid?: (entry: RecentlyClosedPanelTab) => boolean,
 ): RecentlyClosedPanelTab | null {
   const stack = recentlyClosedPanelTabs.get(panelStateId);
   if (stack === undefined) return null;
@@ -202,7 +269,7 @@ function takeClosedPanelTab(
     if (
       entry !== undefined &&
       !openTabIds.has(entry.tab.id) &&
-      (isTabValid === undefined || isTabValid(entry.tab))
+      (isEntryValid === undefined || isEntryValid(entry))
     ) {
       if (stack.length === 0) recentlyClosedPanelTabs.delete(panelStateId);
       return entry;
@@ -359,6 +426,20 @@ export function useThreadFileTabs({
         ? null
         : new Set(storageFiles.map((file) => file.path)),
     [storageFiles],
+  );
+  const recentlyClosedPanelTabContext = useMemo(
+    () => ({
+      environmentId: resolvedEnvironmentId,
+      fileOwnerThreadId: resolvedFileOwnerThreadId,
+      projectHostId,
+      projectId,
+    }),
+    [
+      projectHostId,
+      projectId,
+      resolvedEnvironmentId,
+      resolvedFileOwnerThreadId,
+    ],
   );
 
   useEffect(() => {
@@ -605,6 +686,7 @@ export function useThreadFileTabs({
           isReopenableSecondaryPanelTab(tab)
         ) {
           rememberClosedPanelTab(resolvedPanelStateId, {
+            context: recentlyClosedPanelTabContext,
             index: tabIndex,
             tab,
           });
@@ -612,7 +694,11 @@ export function useThreadFileTabs({
         return next;
       });
     },
-    [resolvedPanelStateId, updateFixedPanelTabsState],
+    [
+      recentlyClosedPanelTabContext,
+      resolvedPanelStateId,
+      updateFixedPanelTabsState,
+    ],
   );
 
   const reopenClosedTab = useCallback((): boolean => {
@@ -622,15 +708,12 @@ export function useThreadFileTabs({
       const entry = takeClosedPanelTab(
         resolvedPanelStateId,
         new Set(state.secondary.tabs.map((tab) => tab.id)),
-        (tab) =>
-          (tab.kind !== "workspace-file-preview" ||
-            preserveWorkspaceTabsAcrossContexts ||
-            tab.environmentId === resolvedEnvironmentId) &&
-          (tab.kind !== "thread-storage-file-preview" ||
-            knownStoragePaths === null ||
-            (tab.threadId !== null &&
-              tab.threadId !== resolvedFileOwnerThreadId) ||
-            knownStoragePaths.has(tab.path)),
+        (entry) =>
+          isRecentlyClosedPanelTabValid({
+            currentContext: recentlyClosedPanelTabContext,
+            entry,
+            knownStoragePaths,
+          }),
       );
       if (entry === null) return state;
       const index = Math.max(
@@ -650,9 +733,7 @@ export function useThreadFileTabs({
     return didReopen;
   }, [
     knownStoragePaths,
-    preserveWorkspaceTabsAcrossContexts,
-    resolvedEnvironmentId,
-    resolvedFileOwnerThreadId,
+    recentlyClosedPanelTabContext,
     resolvedPanelStateId,
     updateFixedPanelTabsState,
   ]);

--- a/apps/app/src/components/secondary-panel/useThreadFileTabs.ts
+++ b/apps/app/src/components/secondary-panel/useThreadFileTabs.ts
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+} from "react";
 import type {
   TerminalSession,
   ThreadStorageFileListResponse,
@@ -174,12 +180,6 @@ type TakeClosedPanelTabResult =
   | { kind: "available"; entry: RecentlyClosedPanelTab }
   | { kind: "unresolved"; entry: RecentlyClosedPanelTab }
   | { kind: "empty" };
-
-function isRecentlyClosedPanelTab(
-  entry: RecentlyClosedPanelTab | null,
-): entry is RecentlyClosedPanelTab {
-  return entry !== null;
-}
 
 type RecentlyClosedPanelContextKey = string;
 type OpenResolvedTabBehavior = "open" | "replace-new-tab";
@@ -508,7 +508,11 @@ export function useThreadFileTabs({
   );
   const pendingStorageValidationRef = useRef<string | null>(null);
   const isMountedRef = useRef(true);
-  recentlyClosedPanelContextKeyRef.current = recentlyClosedPanelContextKey;
+
+  useLayoutEffect(() => {
+    recentlyClosedPanelContextKeyRef.current = recentlyClosedPanelContextKey;
+    pendingStorageValidationRef.current = null;
+  }, [recentlyClosedPanelContextKey]);
 
   useEffect(() => {
     isMountedRef.current = true;
@@ -810,7 +814,7 @@ export function useThreadFileTabs({
 
     const attemptReopen = (): boolean => {
       let didReopen = false;
-      let unresolvedEntry: RecentlyClosedPanelTab | null = null;
+      const unresolvedEntries: RecentlyClosedPanelTab[] = [];
       updateFixedPanelTabsState((state) => {
         const result = takeClosedPanelTab(
           contextKey,
@@ -820,21 +824,18 @@ export function useThreadFileTabs({
         );
         if (result.kind === "empty") return state;
         if (result.kind === "unresolved") {
-          unresolvedEntry = result.entry;
+          unresolvedEntries.push(result.entry);
           return state;
         }
         didReopen = true;
         return restoreEntry(state, result.entry);
       });
       if (didReopen) return true;
-      if (
-        !isRecentlyClosedPanelTab(unresolvedEntry) ||
-        storageFileExists === undefined
-      ) {
+      const entry = unresolvedEntries.at(0);
+      if (entry === undefined || storageFileExists === undefined) {
         return false;
       }
 
-      const entry = unresolvedEntry;
       const storagePath = storagePathForRecentlyClosedPanelTab(entry.tab);
       if (storagePath === null) return false;
       const validationKey = `${contextKey}:${entry.tab.id}`;

--- a/apps/app/src/components/secondary-panel/useThreadStorageViewer.ts
+++ b/apps/app/src/components/secondary-panel/useThreadStorageViewer.ts
@@ -1,4 +1,6 @@
+import { useCallback } from "react";
 import type { FixedPanelTab } from "@/lib/fixed-panel-tabs-state";
+import { sdk } from "@/lib/sdk";
 import { DEFAULT_THREAD_STORAGE_FILE_LIST_OPTIONS } from "@/lib/thread-storage-files";
 import { useThreadStorageFiles } from "../../hooks/queries/thread-queries";
 
@@ -24,8 +26,21 @@ export function useThreadStorageViewer({
       enabled: hasThread && fileListEnabled,
     },
   );
+  const checkThreadStorageFileExists = useCallback(
+    async (path: string): Promise<boolean> => {
+      if (!threadId) return false;
+      const result = await sdk.threads.storageFiles({
+        limit: "1",
+        query: path,
+        threadId,
+      });
+      return result.files.some((file) => file.path === path);
+    },
+    [threadId],
+  );
 
   return {
+    checkThreadStorageFileExists,
     isThreadStorageFilesLoading,
     threadStorageFilesError,
     threadStorageFiles,

--- a/apps/app/src/lib/app-command-metadata.ts
+++ b/apps/app/src/lib/app-command-metadata.ts
@@ -98,6 +98,11 @@ export const APP_COMMAND_GROUPS: readonly AppCommandGroup[] = [
         "Open a tab in the secondary panel.",
       ),
       command(
+        "panel.reopenClosedTab",
+        "Reopen closed panel tab",
+        "Reopen the most recently closed secondary panel tab.",
+      ),
+      command(
         "panel.close",
         "Close panel tab",
         "Close the active panel tab or terminal.",

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -950,16 +950,17 @@ function RootComposeSurface({
         : rootPanelHostPathTerminalTarget,
     [rootPanelEnvironmentId, rootPanelHostPathTerminalTarget],
   );
-  const { threadStorageFiles: rootThreadStorageFiles } = useThreadStorageViewer(
-    {
-      fileListEnabled: shouldLoadThreadStorageFileList({
-        hasThread: rootPanelThreadId !== null,
-        isSecondaryPanelOpen,
-        secondaryTabs: fixedPanelTabsState.secondary.tabs,
-      }),
-      threadId: rootPanelThreadId ?? undefined,
-    },
-  );
+  const {
+    checkThreadStorageFileExists: checkRootThreadStorageFileExists,
+    threadStorageFiles: rootThreadStorageFiles,
+  } = useThreadStorageViewer({
+    fileListEnabled: shouldLoadThreadStorageFileList({
+      hasThread: rootPanelThreadId !== null,
+      isSecondaryPanelOpen,
+      secondaryTabs: fixedPanelTabsState.secondary.tabs,
+    }),
+    threadId: rootPanelThreadId ?? undefined,
+  });
   const environmentTerminalsListQuery = useEnvironmentTerminals(
     rootPanelEnvironmentId ?? "",
     {
@@ -1031,7 +1032,8 @@ function RootComposeSurface({
     projectHostId: rootProjectHostId,
     projectId: isProjectless ? null : projectId,
     retainedTerminalId,
-    storageFiles: rootThreadStorageFiles?.files,
+    storageFileExists: checkRootThreadStorageFileExists,
+    storageFiles: rootThreadStorageFiles,
     terminalSessions: loadedTerminalSessions,
   });
   const rootPluginPanelActions = usePluginNewThreadPanelActions({

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -1018,6 +1018,7 @@ function RootComposeSurface({
     openPluginPanel,
     openTab,
     orderedSecondaryFileTabs,
+    reopenClosedTab,
     reorderTab,
     selectFileSearchResult,
     updateBrowserTab,
@@ -1356,6 +1357,11 @@ function RootComposeSurface({
   useAppCommandHandler("panel.newTab", () => {
     if (!isFocusedPane) return false;
     handleOpenNewTab();
+    return true;
+  });
+  useAppCommandHandler("panel.reopenClosedTab", () => {
+    if (!isFocusedPane || !reopenClosedTab()) return false;
+    openCompactDrawer();
     return true;
   });
   useAppCommandHandler("file.quickOpen", () => {

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -656,6 +656,7 @@ function ThreadDetailViewInternal(props: ThreadRoutePathArgs) {
     secondaryTabs: fixedPanelTabsState.secondary.tabs,
   });
   const {
+    checkThreadStorageFileExists,
     isThreadStorageFilesLoading,
     refetchThreadStorageFiles,
     threadStorageFiles,
@@ -690,7 +691,8 @@ function ThreadDetailViewInternal(props: ThreadRoutePathArgs) {
     syncThreadId: threadId,
     environmentId: thread?.environmentId,
     retainedTerminalId,
-    storageFiles: threadStorageFiles?.files,
+    storageFileExists: checkThreadStorageFileExists,
+    storageFiles: threadStorageFiles,
     terminalSessions: terminalsListQuery.data?.sessions,
   });
   const pluginPanelActions = usePluginPanelActions({

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -681,6 +681,7 @@ function ThreadDetailViewInternal(props: ThreadRoutePathArgs) {
     openTab,
     openPluginPanel,
     orderedSecondaryFileTabs,
+    reopenClosedTab,
     reorderTab,
     selectFileSearchResult,
     updateBrowserTab,
@@ -1552,6 +1553,11 @@ function ThreadDetailViewInternal(props: ThreadRoutePathArgs) {
   useAppCommandHandler("panel.newTab", () => {
     if (!isFocused) return false;
     handleOpenNewTab();
+    return true;
+  });
+  useAppCommandHandler("panel.reopenClosedTab", () => {
+    if (!isFocused || !reopenClosedTab()) return false;
+    openCompactDrawer();
     return true;
   });
   useAppCommandHandler("file.quickOpen", () => {

--- a/apps/desktop/src/desktop-browser-view.ts
+++ b/apps/desktop/src/desktop-browser-view.ts
@@ -157,6 +157,7 @@ export interface DesktopBrowserViewManager {
   ): void;
   beginWindowResize(hostWindow: DesktopBrowserHostWindow): void;
   endWindowResize(hostWindow: DesktopBrowserHostWindow): void;
+  prepareWindowReload(hostWindow: DesktopBrowserHostWindow): void;
   releaseWindow(hostWebContentsId: number): void;
   destroyAll(): void;
 }
@@ -803,6 +804,17 @@ export function createDesktopBrowserViewManager(
           tabId: key.slice(prefix.length),
           dataUrl: null,
         });
+      }
+    },
+    prepareWindowReload(hostWindow) {
+      resizingHostIds.delete(hostWindow.webContents.id);
+      const prefix = `${hostWindow.webContents.id}:`;
+      for (const [key, entry] of entries.entries()) {
+        if (!key.startsWith(prefix) || entry.view.webContents.isDestroyed()) {
+          continue;
+        }
+        entry.visible = false;
+        applyEntryVisibility(entry, hostWindow);
       }
     },
     releaseWindow(hostWebContentsId) {

--- a/apps/desktop/src/desktop-menu-shortcuts.ts
+++ b/apps/desktop/src/desktop-menu-shortcuts.ts
@@ -10,6 +10,7 @@ export interface ApplicationMenuAccelerators {
   openNewTab: string | undefined;
   openNewThread: string | undefined;
   openSettings: string | undefined;
+  reopenClosedTab: string | undefined;
 }
 
 export const DEFAULT_APPLICATION_MENU_ACCELERATORS: ApplicationMenuAccelerators =
@@ -19,6 +20,7 @@ export const DEFAULT_APPLICATION_MENU_ACCELERATORS: ApplicationMenuAccelerators 
     openNewTab: "CommandOrControl+T",
     openNewThread: "CommandOrControl+N",
     openSettings: "CommandOrControl+,",
+    reopenClosedTab: "CommandOrControl+Shift+T",
   };
 
 const ELECTRON_KEY_NAMES: Readonly<Record<string, string>> = {
@@ -92,5 +94,9 @@ export function resolveApplicationMenuAccelerators(
     openNewTab: acceleratorForCommand(keybindings, "panel.newTab"),
     openNewThread: acceleratorForCommand(keybindings, "thread.new"),
     openSettings: acceleratorForCommand(keybindings, "settings.open"),
+    reopenClosedTab: acceleratorForCommand(
+      keybindings,
+      "panel.reopenClosedTab",
+    ),
   };
 }

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -741,6 +741,16 @@ function installCurrentApplicationMenu(): void {
         );
       }
     },
+    reopenClosedTab() {
+      const browserWindow = getFocusedApplicationWindow();
+      if (browserWindow !== null) {
+        sendToApplicationRenderer(
+          browserWindow,
+          BB_DESKTOP_APP_COMMAND_CHANNEL,
+          "panel.reopenClosedTab",
+        );
+      }
+    },
     openSettings() {
       const browserWindow = getFocusedApplicationWindow();
       if (browserWindow !== null) {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -475,6 +475,10 @@ function registerApplicationRendererReloadShortcut(
       return;
     }
     event.preventDefault();
+    const browserWindow = resolveApplicationWindow(webContents);
+    if (browserWindow !== null) {
+      desktopBrowserViewManager?.prepareWindowReload(browserWindow);
+    }
     if (shortcut === "force-reload") {
       webContents.reloadIgnoringCache();
     } else {
@@ -765,6 +769,7 @@ function installCurrentApplicationMenu(): void {
       if (!(browserWindow instanceof BrowserWindow)) {
         return;
       }
+      desktopBrowserViewManager?.prepareWindowReload(browserWindow);
       if (ignoreCache) {
         browserWindow.webContents.reloadIgnoringCache();
       } else {

--- a/apps/desktop/src/menu.ts
+++ b/apps/desktop/src/menu.ts
@@ -9,6 +9,7 @@ import type { ConnectServerSyncSkipReason } from "./connect-server-sync.js";
 
 const SERVER_DAEMON_LOGS_MENU_LABEL = "Server & Daemon Logs";
 const OPEN_NEW_TAB_MENU_LABEL = "New Tab";
+const REOPEN_CLOSED_TAB_MENU_LABEL = "Reopen Closed Tab";
 const NEW_THREAD_MENU_LABEL = "New Thread";
 const NEW_WINDOW_MENU_LABEL = "New Window";
 const CLOSE_WINDOW_MENU_LABEL = "Close Window";
@@ -44,6 +45,7 @@ export interface InstallApplicationMenuArgs {
   openNewTab(): void;
   openNewThread(): void;
   openSettings(): void;
+  reopenClosedTab(): void;
   reloadWindow(
     browserWindow: BaseWindow | undefined,
     ignoreCache: boolean,
@@ -152,6 +154,13 @@ export function buildApplicationMenuTemplate(
             args.openNewTab();
           },
           label: OPEN_NEW_TAB_MENU_LABEL,
+        },
+        {
+          accelerator: args.accelerators.reopenClosedTab,
+          click() {
+            args.reopenClosedTab();
+          },
+          label: REOPEN_CLOSED_TAB_MENU_LABEL,
         },
         {
           accelerator: args.accelerators.openNewThread,

--- a/apps/desktop/test/desktop-browser-main-ipc.test.ts
+++ b/apps/desktop/test/desktop-browser-main-ipc.test.ts
@@ -125,6 +125,8 @@ class RecordingDesktopBrowserViewManager implements DesktopBrowserViewManager {
     this.beginWindowResizeCalls.push(hostWindow);
   }
 
+  prepareWindowReload(): void {}
+
   destroyAll(): void {
     this.destroyAllCalls.push("destroyAll");
   }

--- a/apps/desktop/test/desktop-browser-view-manager.test.ts
+++ b/apps/desktop/test/desktop-browser-view-manager.test.ts
@@ -1597,6 +1597,50 @@ describe("DesktopBrowserViewManager", () => {
     expect(focusedView.webContents.focusCalls).toBe(1);
   });
 
+  it("hides only the reloading window's browser views until they reattach", () => {
+    const manager = createDesktopBrowserViewManager({
+      partition: "persist:test",
+    });
+    const reloadingWindow = new FakeHostWindow({
+      contentBounds: { width: 900, height: 600 },
+      webContentsId: 83,
+    });
+    const otherWindow = new FakeHostWindow({
+      contentBounds: { width: 900, height: 600 },
+      webContentsId: 84,
+    });
+    attachBrowserTab({
+      manager,
+      hostWindow: reloadingWindow,
+      tabId: "browser:reloading",
+      url: "https://example.com/reloading",
+    });
+    attachBrowserTab({
+      manager,
+      hostWindow: otherWindow,
+      tabId: "browser:other",
+      url: "https://example.com/other",
+    });
+    const reloadingView = requireFakeView(0);
+    const otherView = requireFakeView(1);
+
+    manager.prepareWindowReload(reloadingWindow);
+
+    expect(reloadingView.visible).toBe(false);
+    expect(otherView.visible).toBe(true);
+    manager.attach({
+      hostWindow: reloadingWindow,
+      request: {
+        tabId: "browser:reloading",
+        url: "https://example.com/reloading",
+        bounds: { x: 100, y: 50, width: 500, height: 350 },
+        visible: true,
+      },
+    });
+    expect(electronMock.fakeViews).toHaveLength(2);
+    expect(reloadingView.visible).toBe(true);
+  });
+
   it("allows clipboard-sanitized-write but denies clipboard-read and device permissions", () => {
     expect(isAllowedBrowserPermission("clipboard-sanitized-write")).toBe(true);
     expect(isAllowedBrowserPermission("clipboard-read")).toBe(false);

--- a/apps/desktop/test/desktop-menu-shortcuts.test.ts
+++ b/apps/desktop/test/desktop-menu-shortcuts.test.ts
@@ -34,6 +34,7 @@ describe("desktop menu shortcuts", () => {
       openNewTab: "CommandOrControl+T",
       openNewThread: "CommandOrControl+N",
       openSettings: "CommandOrControl+,",
+      reopenClosedTab: "CommandOrControl+Shift+T",
     });
   });
 
@@ -55,9 +56,11 @@ describe("desktop menu shortcuts", () => {
       binding("thread.new", "n", { mod: true }),
       binding("thread.new", "u", { mod: true, shift: true }),
       binding("settings.open", ",", { mod: true }),
+      binding("panel.reopenClosedTab", "t", { mod: true, shift: true }),
     ]);
     expect(accelerators.openNewThread).toBe("CommandOrControl+Shift+U");
     expect(accelerators.openSettings).toBe("CommandOrControl+,");
+    expect(accelerators.reopenClosedTab).toBe("CommandOrControl+Shift+T");
     expect(accelerators.openNewTab).toBeUndefined();
   });
 });

--- a/apps/desktop/test/menu.test.ts
+++ b/apps/desktop/test/menu.test.ts
@@ -26,6 +26,7 @@ function menuArgs(
       openNewTab: undefined,
       openNewThread: undefined,
       openSettings: undefined,
+      reopenClosedTab: undefined,
     },
     closeWindowOrSideTab: () => {},
     connectServersSkipReason: null,
@@ -36,6 +37,7 @@ function menuArgs(
     openNewThread: () => {},
     openServerDaemonLogs: () => {},
     openSettings: () => {},
+    reopenClosedTab: () => {},
     reloadWindow,
     selectServer: () => {},
     serverDaemonLogsMenuEnabled: false,
@@ -55,6 +57,30 @@ function findServerSubmenu(
 }
 
 describe("application menu", () => {
+  it("reopens the last closed tab from the File menu", () => {
+    const reopenClosedTab = vi.fn();
+    const template = buildApplicationMenuTemplate(
+      menuArgs(() => {}, {
+        accelerators: {
+          closeWindowOrSideTab: undefined,
+          createNewWindow: undefined,
+          openNewTab: undefined,
+          openNewThread: undefined,
+          openSettings: undefined,
+          reopenClosedTab: "CommandOrControl+Shift+T",
+        },
+        reopenClosedTab,
+      }),
+    );
+    const fileMenu = template.find((item) => item.label === "File");
+    const submenu = fileMenu?.submenu as MenuItemConstructorOptions[];
+    const reopen = submenu.find((item) => item.label === "Reopen Closed Tab");
+
+    expect(reopen?.accelerator).toBe("CommandOrControl+Shift+T");
+    reopen?.click?.({} as never, {} as BaseWindow, {} as never);
+    expect(reopenClosedTab).toHaveBeenCalledTimes(1);
+  });
+
   it("closes a native panel when Electron omits its window", () => {
     vi.mocked(Menu.sendActionToFirstResponder).mockClear();
     const closeWindowOrSideTab = vi.fn();

--- a/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/references/frontend-core-slots.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/references/frontend-core-slots.md
@@ -87,7 +87,8 @@ Slot props contracts (versioned, additive-only):
   main body; it must not mount a second panel layout or register Browser and
   Terminal itself. BB owns the desktop split, compact drawer, header/panel
   toggle, resizing, tab strip, persistence, and the shared `panel.toggle`,
-  `panel.newTab`, and `terminal.open` keyboard commands.
+  `panel.newTab`, `panel.reopenClosedTab`, and `terminal.open` keyboard
+  commands.
 
   New tab is a transient host launcher. On a plugin page it offers Browser
   (when the desktop browser is available) and Terminal; it does not offer

--- a/apps/server/src/services/system/app-keybindings.ts
+++ b/apps/server/src/services/system/app-keybindings.ts
@@ -190,6 +190,15 @@ export const DEFAULT_APP_KEYBINDINGS: AppDefaultKeybindings = [
   ),
   binding("pane.close", "x", { mod: true, shift: true }, splitWithoutModal),
   binding("panel.newTab", "t", { mod: true }, mainWithoutModal),
+  binding(
+    "panel.reopenClosedTab",
+    "t",
+    { mod: true, shift: true },
+    {
+      ...mainWithoutModal,
+      desktopOnly: true,
+    },
+  ),
   binding("panel.close", "w", { mod: true }, mainWithoutModal),
   binding("panel.toggle", "j", { mod: true }, mainWithoutModal),
   binding("file.quickOpen", "p", { mod: true }, mainWithoutModal),
@@ -207,15 +216,6 @@ export const DEFAULT_APP_KEYBINDINGS: AppDefaultKeybindings = [
     "Enter",
     { mod: true, shift: true },
     mainWithoutModal,
-  ),
-  binding(
-    "terminal.open",
-    "t",
-    { mod: true, shift: true },
-    {
-      ...mainWithoutModal,
-      desktopOnly: true,
-    },
   ),
   binding(
     "composer.focus",

--- a/apps/server/test/system/app-keybindings.test.ts
+++ b/apps/server/test/system/app-keybindings.test.ts
@@ -294,7 +294,6 @@ describe("app keybindings", () => {
           })),
       ).toEqual([
         { desktopOnly: false, key: "Enter" },
-        { desktopOnly: true, key: "t" },
       ]);
       expect(
         assignedDefaultKeybindings.find(

--- a/apps/server/test/system/app-keybindings.test.ts
+++ b/apps/server/test/system/app-keybindings.test.ts
@@ -152,6 +152,24 @@ describe("app keybindings", () => {
         shortcut: { key: "n", mod: true, shift: true },
       });
       expect(
+        config.keybindings.find(
+          (binding) => binding.command === "panel.reopenClosedTab",
+        ),
+      ).toMatchObject({
+        desktopOnly: true,
+        shortcut: { key: "t", mod: true, shift: true },
+      });
+      expect(
+        config.keybindings.filter(
+          (binding) => binding.command === "terminal.open",
+        ),
+      ).toMatchObject([
+        {
+          desktopOnly: false,
+          shortcut: { key: "Enter", mod: true, shift: true },
+        },
+      ]);
+      expect(
         assignedDefaultKeybindings
           .filter((binding) => binding.command === "thread.previous")
           .map((binding) => ({
@@ -448,7 +466,7 @@ describe("app keybindings", () => {
         "thread.next",
         ...THREAD_JUMP_APP_COMMAND_IDS,
         ...PANE_FOCUS_APP_COMMAND_IDS,
-        "terminal.open",
+        "panel.reopenClosedTab",
         "browser.focusLocation",
         "browser.reload",
         "browser.find",

--- a/packages/domain/src/app-keybindings.ts
+++ b/packages/domain/src/app-keybindings.ts
@@ -54,6 +54,7 @@ export const APP_COMMAND_IDS = [
   "settings.openServers",
   "sidebar.toggle",
   "panel.newTab",
+  "panel.reopenClosedTab",
   "panel.close",
   "panel.toggle",
   "file.quickOpen",

--- a/packages/plugin-api-map/sdk-public-api.json
+++ b/packages/plugin-api-map/sdk-public-api.json
@@ -3,7 +3,7 @@
   "entries": {
     ".": {
       "types": "bundled-types/bb-plugin-sdk.d.ts",
-      "sha256": "70077a510684588d29816ecb221ca99476640c7972c31730025064904265535e"
+      "sha256": "0370a27a5dce9425889f1ee5952c8da3ed48f83390f5724cc3db1225cce3d71d"
     },
     "./ai-services": {
       "types": "bundled-types/bb-plugin-sdk-ai-services.d.ts",


### PR DESCRIPTION
## Human comments

## What was wrong

The secondary panel had no command or state for restoring a closed tab, and the desktop-only `Cmd+Shift+T` binding was assigned to opening a terminal instead of the platform-standard reopen gesture. The first implementation also treated incomplete storage inventories as authoritative, rebuilt restored tabs from canonical rather than visible placement, and left browser `WebContentsView`s visible while the host renderer reloaded.

## What changed

- Added the `panel.reopenClosedTab` app command, a desktop default of `Cmd+Shift+T`, and a matching native File menu item.
- Added a 25-entry LIFO history for closed file, browser, and plugin-panel tabs. Reopened tabs become active; launchers, fixed tabs, and destroyed terminal sessions are excluded.
- Keyed history by one canonical panel-context identity—panel state, environment, project, project host, and file-owner thread—so each context has an independent stack. Ownership is enforced when recording; restoration only pops the current stack and validates resource liveness.
- Preserved storage-inventory readiness and truncation. Restoration waits for an authoritative inventory, performs targeted existence checks when the inventory is truncated, skips deleted or foreign-owner entries, and continues to the next valid entry.
- Preserved each tab's visible split-panel placement when it is temporarily removed and restored, independent of canonical fixed-panel ordering.
- Hid browser `WebContentsView`s before native or keyboard renderer reloads so stale child views cannot cover or intercept the replacement renderer; the fresh renderer reattaches and shows them after startup.
- Kept terminal opening on its existing cross-platform `Cmd+Shift+Enter` binding and documented the shared panel command for plugin surfaces.
- Added focused regressions for history ordering and exclusions, environment/project/project-host/file-owner isolation, storage readiness and truncation, deleted and beyond-page storage files, visible tab placement, default bindings, native accelerators, the menu action, and desktop reload preparation.
- Refreshed the tracked public SDK inventory for the additive command-ID value. No host-daemon wire contract changed, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

### Before

The merge base has no reopen-closed-tab command.

<img src="https://gist.githubusercontent.com/brsbl/b680331f494f59963e1c1f0918f12cb8/raw/before-shortcut.svg" alt="Before: keyboard settings return no result for Reopen closed" width="720">

Native View → Reload with an open browser view could leave the host renderer blank.

<img src="https://gist.githubusercontent.com/brsbl/b680331f494f59963e1c1f0918f12cb8/raw/e761bc2677083cd9d721e2a22d1a94422755e644/final-07-reload-blank-renderer.svg" alt="Before: blank renderer after native reload" width="720">

### After

The exact PR branch exposes the desktop shortcut as `Cmd+Shift+T`.

<img src="https://gist.githubusercontent.com/brsbl/b680331f494f59963e1c1f0918f12cb8/raw/after-shortcut.svg" alt="After: keyboard settings show Reopen closed panel tab with Shift Command T" width="720">

Native View → Reload restores both the host renderer and embedded browser view.

<img src="https://gist.githubusercontent.com/brsbl/b680331f494f59963e1c1f0918f12cb8/raw/e72383943d487e6c5bed2602e01b9e3f9f18553b/final-08-reload-restored.svg" alt="After: host renderer and browser view restored after native reload" width="720">

## Exact-head desktop smoke evidence

Two browser tabs open:

<img src="https://gist.githubusercontent.com/brsbl/b680331f494f59963e1c1f0918f12cb8/raw/9f8f80cdab49f13a92b4508908ebe13dd0c1a0ad/final-01-open-tabs.svg" alt="Two browser tabs open" width="720">

Both browser tabs closed:

<img src="https://gist.githubusercontent.com/brsbl/b680331f494f59963e1c1f0918f12cb8/raw/7763cbb60bb8ba498fb8441954ed01ae35d03601/final-02-closed.svg" alt="Both browser tabs closed" width="720">

First `Cmd+Shift+T` restores the most recently closed tab and its URL:

<img src="https://gist.githubusercontent.com/brsbl/b680331f494f59963e1c1f0918f12cb8/raw/af895d88d32caf9ed16e1d16506f1648c770dabb/final-04-first-restore.svg" alt="First tab restoration" width="720">

Second `Cmd+Shift+T` restores the remaining tab:

<img src="https://gist.githubusercontent.com/brsbl/b680331f494f59963e1c1f0918f12cb8/raw/cd423f696d8cb99c59ffbff18a06d187416dcc36/final-05-second-restore.svg" alt="Second tab restoration" width="720">

A third `Cmd+Shift+T` is a no-op, and the original visible order remains `Browser · Example Domain`:

<img src="https://gist.githubusercontent.com/brsbl/b680331f494f59963e1c1f0918f12cb8/raw/76f9b4343c3b3c6c7e616dbd2cd99322c25f561c/final-09-restored-order.svg" alt="Restored tabs retain their original visible order" width="720">

A normally provisioned, environment-backed thread also restores a real file from the current worktree. After closing `README.md`, the literal `Cmd+Shift+T` gesture restores the active tab with its rendered repository content—not a skeleton:

<img src="https://gist.githubusercontent.com/brsbl/b680331f494f59963e1c1f0918f12cb8/raw/7301c7f3ff63eb33f8ec3a80ccbdc3cef4d4d4a2/real-environment-readme-restored.jpg" alt="README restored with rendered current-worktree content in an environment-backed desktop thread" width="720">

## How you verified

- Exact candidate: `e82f32cb5d961299d69be7f2f1bfde80b49a1270` in the branch desktop app, Electron 41.7.0.
- **Pass:** opened two browser tabs, closed both, and pressed the real `Cmd+Shift+T` gesture twice. The tabs returned in reverse close order, the URL was retained, the original visible placement was restored, and a third press was a no-op.
- **Pass:** opened the exact Electron app's native File menu and confirmed its accessibility tree exposes **Reopen Closed Tab**. The OS-level menu capture was discarded because an unrelated system prompt contaminated the frame; accessibility evidence is used instead of presenting misleading visual evidence.
- **Pass:** invoked native View → Reload with a live browser view. The replacement host renderer loaded, the child browser view reattached, and both remained interactive after settling.
- **Pass:** regression coverage switches across environments and also distinguishes project, project host, panel state, and file-owner thread before restoring only the nearest entry owned by the active context.
- **Pass:** storage regressions cover unresolved inventories, truncated inventories, valid paths beyond the first page, deleted files, foreign owners, and open storage tabs that must not be pruned from an incomplete inventory.
- **Pass:** provisioned a fresh thread through the official CLI against the branch dev server, confirmed its environment resolves to the exact current worktree, opened `README.md` through real file search, closed the tab, and pressed the literal `Cmd+Shift+T` gesture. The tab returned active with fully rendered file content and no persistent skeleton or 409 response.
- Reviewed every retained screenshot for clipping, layout shift, stale frames, and incorrect tab state. No visual defect remains in the captured flows.
- Per repository policy, tests, typechecks, and lint were not run locally. Pull-request CI is fully green: checks, app/server/package/integration tests, Linux/macOS package smoke, and version checks all passed.

## Final review and triage

One deliberate architecture and implementation review was run for this PR. Its findings were validated, then all confirmed product defects from the review and smoke pass were fixed:

- **P1 — fixed:** native desktop reload could leave a live browser child view covering and intercepting the replacement host renderer.
- **P1 — fixed:** closed-tab history could cross environment/checkout boundaries without using the complete panel, environment, project, project-host, and file-owner identity.
- **P2 — fixed:** unresolved or truncated storage inventories could transiently restore a deleted file or permanently discard a valid entry beyond the inventory page.
- **P2 — fixed:** the second restored tab could be appended instead of returning to its original visible split-panel placement.
- **P2 — fixed:** deleted or foreign-owner thread-storage entries are skipped while restoration continues to the next valid history entry.

No known product defect remains from the review, smoke test, or screenshot inspection. The earlier convenience fixture that populated nine tabs bypassed normal provisioning and produced an environment-less thread. It was discarded and is not used as merge evidence; the final file-tab pass used the normally provisioned environment-backed thread shown above. One QA-infrastructure observation remains outside this feature: on a cold desktop-dev launch, the launcher's fixed readiness window can expire while branch packaging is still completing, producing a temporary blank window. Logs and the later automatic load established that this was service readiness timing rather than a renderer crash.

BB-Thread-ID: thr_ufp89hj9ea

> AGENT GENERATED


