### PR TITLE
feat: event-driven thread wait coordinator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All built-in agent providers now use the provider API. You can use the same API 
 
 ### CLI
 
+- Follow one thread with `bb thread wait <id> --output`. Follow several threads in one process with `bb thread wait-many`.
 - Use `--plan` with `bb thread tell` or `bb thread spawn` to enter Plan mode.
 - Use `bb thread log --all` to read the full thread history.
 - Move a local plugin with `bb plugin install path:<new directory>`. bb keeps its data and settings.
@@ -40,6 +41,7 @@ All built-in agent providers now use the provider API. You can use the same API 
 
 ### Performance
 
+- Thread status waits now use one server-side event subscription for duplicate conditions instead of 250 ms client polling.
 - A thread now opens with about half as many requests.
 - Smaller bundles reduce the initial load time for the app and plugins.
 - Long threads use less server work and load timeline pages faster.
@@ -50,6 +52,8 @@ All built-in agent providers now use the provider API. You can use the same API 
 - Large prompt drafts respond faster to a paste or a key press.
 - The app restores recent panel data after a reload. This change removes several blank states.
 - The `timelineWindowing` experiment renders only visible timeline rows.
+
+New clients retain polling for one release when an older server returns `404 not_found` for the status-wait route. New servers remain compatible with old clients.
 
 ### Experimental iOS app
 

--- a/apps/cli/src/__tests__/command-output/thread-actions.test.ts
+++ b/apps/cli/src/__tests__/command-output/thread-actions.test.ts
@@ -9,7 +9,7 @@ import {
 } from "../helpers/command-output-harness.js";
 import type { CommandRegistrar } from "../helpers/command-output-harness.js";
 import * as fixtures from "../helpers/command-output-fixtures.js";
-import { registerThreadCommands } from "../../commands/thread/index.js";
+import { registerThreadCommands } from "../../commands/thread/register-all.js";
 
 describe("bb thread action command output", () => {
   setupCommandOutputTestEnvironment();

--- a/apps/cli/src/__tests__/command-output/thread-fork.test.ts
+++ b/apps/cli/src/__tests__/command-output/thread-fork.test.ts
@@ -7,7 +7,7 @@ import {
 } from "../helpers/command-output-harness.js";
 import type { CommandRegistrar } from "../helpers/command-output-harness.js";
 import * as fixtures from "../helpers/command-output-fixtures.js";
-import { registerThreadCommands } from "../../commands/thread/index.js";
+import { registerThreadCommands } from "../../commands/thread/register-all.js";
 
 describe("bb thread fork command output", () => {
   setupCommandOutputTestEnvironment();

--- a/apps/cli/src/__tests__/command-output/thread-interactions.test.ts
+++ b/apps/cli/src/__tests__/command-output/thread-interactions.test.ts
@@ -8,7 +8,7 @@ import {
 } from "../helpers/command-output-harness.js";
 import type { CommandRegistrar } from "../helpers/command-output-harness.js";
 import * as fixtures from "../helpers/command-output-fixtures.js";
-import { registerThreadCommands } from "../../commands/thread/index.js";
+import { registerThreadCommands } from "../../commands/thread/register-all.js";
 
 describe("bb thread interactions command output", () => {
   setupCommandOutputTestEnvironment();

--- a/apps/cli/src/__tests__/command-output/thread-list.test.ts
+++ b/apps/cli/src/__tests__/command-output/thread-list.test.ts
@@ -8,7 +8,7 @@ import {
 } from "../helpers/command-output-harness.js";
 import type { CommandRegistrar } from "../helpers/command-output-harness.js";
 import * as fixtures from "../helpers/command-output-fixtures.js";
-import { registerThreadCommands } from "../../commands/thread/index.js";
+import { registerThreadCommands } from "../../commands/thread/register-all.js";
 
 describe("bb thread list command output", () => {
   setupCommandOutputTestEnvironment();

--- a/apps/cli/src/__tests__/command-output/thread-log.test.ts
+++ b/apps/cli/src/__tests__/command-output/thread-log.test.ts
@@ -8,7 +8,7 @@ import {
 } from "../helpers/command-output-harness.js";
 import type { CommandRegistrar } from "../helpers/command-output-harness.js";
 import * as fixtures from "../helpers/command-output-fixtures.js";
-import { registerThreadCommands } from "../../commands/thread/index.js";
+import { registerThreadCommands } from "../../commands/thread/register-all.js";
 
 describe("bb thread log command output", () => {
   setupCommandOutputTestEnvironment();

--- a/apps/cli/src/__tests__/command-output/thread-open.test.ts
+++ b/apps/cli/src/__tests__/command-output/thread-open.test.ts
@@ -10,7 +10,7 @@ import {
 } from "../helpers/command-output-harness.js";
 import type { CommandRegistrar } from "../helpers/command-output-harness.js";
 import * as fixtures from "../helpers/command-output-fixtures.js";
-import { registerThreadCommands } from "../../commands/thread/index.js";
+import { registerThreadCommands } from "../../commands/thread/register-all.js";
 
 type OpenThreadHandler = (
   request: unknown,

--- a/apps/cli/src/__tests__/command-output/thread-organization.test.ts
+++ b/apps/cli/src/__tests__/command-output/thread-organization.test.ts
@@ -5,7 +5,7 @@ import {
   stubServerApi,
 } from "../helpers/command-output-harness.js";
 import type { CommandRegistrar } from "../helpers/command-output-harness.js";
-import { registerThreadCommands } from "../../commands/thread/index.js";
+import { registerThreadCommands } from "../../commands/thread/register-all.js";
 
 describe("bb thread organization commands", () => {
   setupCommandOutputTestEnvironment();

--- a/apps/cli/src/__tests__/command-output/thread-output.test.ts
+++ b/apps/cli/src/__tests__/command-output/thread-output.test.ts
@@ -6,7 +6,7 @@ import {
   stubServerApi,
 } from "../helpers/command-output-harness.js";
 import type { CommandRegistrar } from "../helpers/command-output-harness.js";
-import { registerThreadCommands } from "../../commands/thread/index.js";
+import { registerThreadCommands } from "../../commands/thread/register-all.js";
 
 describe("bb thread output command output", () => {
   setupCommandOutputTestEnvironment();

--- a/apps/cli/src/__tests__/command-output/thread-pane.test.ts
+++ b/apps/cli/src/__tests__/command-output/thread-pane.test.ts
@@ -6,7 +6,7 @@ import {
   stubServerApi,
   type CommandRegistrar,
 } from "../helpers/command-output-harness.js";
-import { registerThreadCommands } from "../../commands/thread/index.js";
+import { registerThreadCommands } from "../../commands/thread/register-all.js";
 
 describe("bb thread pane command output", () => {
   setupCommandOutputTestEnvironment();

--- a/apps/cli/src/__tests__/command-output/thread-show.test.ts
+++ b/apps/cli/src/__tests__/command-output/thread-show.test.ts
@@ -10,7 +10,7 @@ import {
 } from "../helpers/command-output-harness.js";
 import type { CommandRegistrar } from "../helpers/command-output-harness.js";
 import * as fixtures from "../helpers/command-output-fixtures.js";
-import { registerThreadCommands } from "../../commands/thread/index.js";
+import { registerThreadCommands } from "../../commands/thread/register-all.js";
 
 describe("bb thread show command output", () => {
   setupCommandOutputTestEnvironment();

--- a/apps/cli/src/__tests__/command-output/thread-spawn.test.ts
+++ b/apps/cli/src/__tests__/command-output/thread-spawn.test.ts
@@ -10,7 +10,7 @@ import {
 } from "../helpers/command-output-harness.js";
 import type { CommandRegistrar } from "../helpers/command-output-harness.js";
 import * as fixtures from "../helpers/command-output-fixtures.js";
-import { registerThreadCommands } from "../../commands/thread/index.js";
+import { registerThreadCommands } from "../../commands/thread/register-all.js";
 
 describe("bb thread spawn command output", () => {
   setupCommandOutputTestEnvironment();

--- a/apps/cli/src/__tests__/command-output/thread-tell.test.ts
+++ b/apps/cli/src/__tests__/command-output/thread-tell.test.ts
@@ -5,7 +5,7 @@ import {
   stubServerApi,
 } from "../helpers/command-output-harness.js";
 import type { CommandRegistrar } from "../helpers/command-output-harness.js";
-import { registerThreadCommands } from "../../commands/thread/index.js";
+import { registerThreadCommands } from "../../commands/thread/register-all.js";
 
 describe("bb thread tell command output", () => {
   setupCommandOutputTestEnvironment();

--- a/apps/cli/src/__tests__/command-output/thread-update.test.ts
+++ b/apps/cli/src/__tests__/command-output/thread-update.test.ts
@@ -8,7 +8,7 @@ import {
 } from "../helpers/command-output-harness.js";
 import type { CommandRegistrar } from "../helpers/command-output-harness.js";
 import * as fixtures from "../helpers/command-output-fixtures.js";
-import { registerThreadCommands } from "../../commands/thread/index.js";
+import { registerThreadCommands } from "../../commands/thread/register-all.js";
 
 describe("bb thread update command output", () => {
   setupCommandOutputTestEnvironment();

--- a/apps/cli/src/__tests__/command-output/thread-wait.test.ts
+++ b/apps/cli/src/__tests__/command-output/thread-wait.test.ts
@@ -8,7 +8,7 @@ import {
 } from "../helpers/command-output-harness.js";
 import type { CommandRegistrar } from "../helpers/command-output-harness.js";
 import * as fixtures from "../helpers/command-output-fixtures.js";
-import { registerThreadCommands } from "../../commands/thread/index.js";
+import { registerThreadCommands } from "../../commands/thread/register-all.js";
 
 describe("bb thread wait command output", () => {
   setupCommandOutputTestEnvironment();
@@ -27,7 +27,7 @@ describe("bb thread wait command output", () => {
         updatedAt: 2,
       }),
     );
-    stubServerApi({ "v1.threads.:id.$get": get });
+    stubServerApi({ "v1.threads.:id.wait.$get": get });
 
     await runCommand(["thread", "wait", "thread-wait-default"], register);
 
@@ -47,7 +47,7 @@ describe("bb thread wait command output", () => {
         updatedAt: 2,
       }),
     );
-    stubServerApi({ "v1.threads.:id.$get": get });
+    stubServerApi({ "v1.threads.:id.wait.$get": get });
 
     await runCommand(
       ["thread", "wait", "thread-wait", "--status", "idle"],
@@ -56,6 +56,37 @@ describe("bb thread wait command output", () => {
 
     expect(collectLogLines(vi.mocked(console.log))).toContain(
       "Thread thread-wait reached status idle.",
+    );
+  });
+
+  it("bb thread wait preserves the existing JSON bytes", async () => {
+    const get = vi.fn(async () =>
+      fixtures.makeThread({
+        id: "thread-wait-json",
+        projectId: "proj-1",
+        providerId: "codex",
+        status: "idle",
+        createdAt: 1,
+        updatedAt: 2,
+      }),
+    );
+    stubServerApi({ "v1.threads.:id.wait.$get": get });
+
+    await runCommand(
+      ["thread", "wait", "thread-wait-json", "--json"],
+      register,
+    );
+
+    expect(String(vi.mocked(console.log).mock.calls[0]?.[0])).toBe(
+      JSON.stringify(
+        {
+          threadId: "thread-wait-json",
+          matched: true,
+          target: { kind: "status", status: "idle" },
+        },
+        null,
+        2,
+      ),
     );
   });
 
@@ -70,7 +101,7 @@ describe("bb thread wait command output", () => {
         updatedAt: 2,
       }),
     );
-    stubServerApi({ "v1.threads.:id.$get": get });
+    stubServerApi({ "v1.threads.:id.wait.$get": get });
 
     await expect(
       runCommand(
@@ -99,7 +130,7 @@ describe("bb thread wait command output", () => {
         updatedAt: 2,
       }),
     );
-    stubServerApi({ "v1.threads.:id.$get": get });
+    stubServerApi({ "v1.threads.:id.wait.$get": get });
 
     await expect(
       runCommand(
@@ -112,6 +143,32 @@ describe("bb thread wait command output", () => {
       "Error: Thread thread-wait-error is in status error and will not reach idle by waiting alone. Inspect it with 'bb thread show thread-wait-error' and recover by sending a follow-up.",
     );
     expect(get).toHaveBeenCalledTimes(1);
+  });
+
+  it("bb thread wait --output preserves unreachable exit without fetching output", async () => {
+    const get = vi.fn(async () =>
+      fixtures.makeThread({
+        id: "thread-wait-output-error",
+        projectId: "proj-1",
+        providerId: "codex",
+        status: "error",
+        createdAt: 1,
+        updatedAt: 2,
+      }),
+    );
+    const outputGet = vi.fn(async () => ({ output: "PARTIAL" }));
+    stubServerApi({
+      "v1.threads.:id.wait.$get": get,
+      "v1.threads.:id.output.$get": outputGet,
+    });
+
+    await expect(
+      runCommand(
+        ["thread", "wait", "thread-wait-output-error", "--output"],
+        register,
+      ),
+    ).rejects.toThrow("process.exit:4");
+    expect(outputGet).not.toHaveBeenCalled();
   });
 
   it("bb thread wait --event reports server errors instead of schema errors", async () => {
@@ -193,6 +250,192 @@ describe("bb thread wait command output", () => {
 
     expect(collectLogLines(vi.mocked(console.log))).toContain(
       "Thread thread-t0 observed event turn/completed at seq 3.",
+    );
+  });
+
+  it("bb thread wait --output waits once and then gets output once", async () => {
+    const waitGet = vi.fn(async () =>
+      fixtures.makeThread({
+        id: "thread-follow",
+        projectId: "proj-1",
+        providerId: "codex",
+        status: "idle",
+        createdAt: 1,
+        updatedAt: 2,
+      }),
+    );
+    const outputGet = vi.fn(async () => ({ output: "FINAL" }));
+    stubServerApi({
+      "v1.threads.:id.wait.$get": waitGet,
+      "v1.threads.:id.output.$get": outputGet,
+    });
+
+    await runCommand(["thread", "wait", "thread-follow", "--output"], register);
+
+    expect(collectLogLines(vi.mocked(console.log))).toEqual([
+      "Thread thread-follow reached status idle.",
+      "FINAL",
+    ]);
+    expect(waitGet).toHaveBeenCalledTimes(1);
+    expect(outputGet).toHaveBeenCalledTimes(1);
+    expect(waitGet.mock.invocationCallOrder[0]).toBeLessThan(
+      outputGet.mock.invocationCallOrder[0] ?? 0,
+    );
+  });
+
+  it("bb thread wait --output --json returns the terminal result shape", async () => {
+    const waitGet = vi.fn(async () =>
+      fixtures.makeThread({
+        id: "thread-follow-json",
+        projectId: "proj-1",
+        providerId: "codex",
+        status: "idle",
+        createdAt: 1,
+        updatedAt: 2,
+      }),
+    );
+    const outputGet = vi.fn(async () => ({ output: "FINAL" }));
+    stubServerApi({
+      "v1.threads.:id.wait.$get": waitGet,
+      "v1.threads.:id.output.$get": outputGet,
+    });
+
+    await runCommand(
+      ["thread", "wait", "thread-follow-json", "--output", "--json"],
+      register,
+    );
+
+    expect(
+      JSON.parse(String(vi.mocked(console.log).mock.calls[0]?.[0])),
+    ).toEqual({
+      output: "FINAL",
+      status: "idle",
+      threadId: "thread-follow-json",
+    });
+  });
+
+  it("bb thread wait rejects --output with --event before any request", async () => {
+    const waitGet = vi.fn();
+    stubServerApi({ "v1.threads.:id.events.wait.$get": waitGet });
+
+    await expect(
+      runCommand(
+        [
+          "thread",
+          "wait",
+          "thread-event-output",
+          "--event",
+          "turn/completed",
+          "--output",
+        ],
+        register,
+      ),
+    ).rejects.toThrow("process.exit:3");
+    expect(waitGet).not.toHaveBeenCalled();
+  });
+
+  it("bb thread wait-many emits one JSON line for each completed output", async () => {
+    const waitGet = vi.fn(async (input: { param: { id: string } }) =>
+      fixtures.makeThread({
+        id: input.param.id,
+        projectId: "proj-1",
+        providerId: "codex",
+        status: "idle",
+        createdAt: 1,
+        updatedAt: 2,
+      }),
+    );
+    const outputGet = vi.fn(async (input: { param: { id: string } }) => ({
+      output: `FINAL ${input.param.id}`,
+    }));
+    stubServerApi({
+      "v1.threads.:id.wait.$get": waitGet,
+      "v1.threads.:id.output.$get": outputGet,
+    });
+
+    await runCommand(
+      ["thread", "wait-many", "thread-a", "thread-b", "--output", "--json"],
+      register,
+    );
+
+    const payloads = vi
+      .mocked(console.log)
+      .mock.calls.map((call) => JSON.parse(String(call[0])));
+    expect(payloads).toEqual([
+      { output: "FINAL thread-a", status: "idle", threadId: "thread-a" },
+      { output: "FINAL thread-b", status: "idle", threadId: "thread-b" },
+    ]);
+    expect(waitGet).toHaveBeenCalledTimes(2);
+    expect(outputGet).toHaveBeenCalledTimes(2);
+  });
+
+  it("bb thread wait-many exits with the worst outcome", async () => {
+    const waitGet = vi.fn(async (input: { param: { id: string } }) =>
+      fixtures.makeThread({
+        id: input.param.id,
+        projectId: "proj-1",
+        providerId: "codex",
+        status: input.param.id === "thread-error" ? "error" : "idle",
+        createdAt: 1,
+        updatedAt: 2,
+      }),
+    );
+    stubServerApi({ "v1.threads.:id.wait.$get": waitGet });
+
+    await expect(
+      runCommand(
+        ["thread", "wait-many", "thread-ok", "thread-error", "--json"],
+        register,
+      ),
+    ).rejects.toThrow("process.exit:4");
+
+    const payloads = vi
+      .mocked(console.log)
+      .mock.calls.map((call) => JSON.parse(String(call[0])));
+    expect(payloads).toEqual([
+      {
+        matched: true,
+        target: { kind: "status", status: "idle" },
+        threadId: "thread-ok",
+      },
+      {
+        error: expect.stringContaining("will not reach idle"),
+        exitCode: 4,
+        threadId: "thread-error",
+      },
+    ]);
+  });
+
+  it("keeps JSON stdout clean when --poll-interval is explicit", async () => {
+    const waitGet = vi.fn(async () =>
+      fixtures.makeThread({
+        id: "thread-poll-warning",
+        projectId: "proj-1",
+        providerId: "codex",
+        status: "idle",
+        createdAt: 1,
+        updatedAt: 2,
+      }),
+    );
+    stubServerApi({ "v1.threads.:id.wait.$get": waitGet });
+
+    await runCommand(
+      [
+        "thread",
+        "wait",
+        "thread-poll-warning",
+        "--poll-interval",
+        "10",
+        "--json",
+      ],
+      register,
+    );
+
+    expect(() =>
+      JSON.parse(String(vi.mocked(console.log).mock.calls[0]?.[0])),
+    ).not.toThrow();
+    expect(collectLogLines(vi.mocked(console.error))).toContain(
+      "Warning: --poll-interval is deprecated on event-driven servers. It now controls fallback polling and pauses between long-poll rounds.",
     );
   });
 });

--- a/apps/cli/src/__tests__/helpers/command-output-harness.ts
+++ b/apps/cli/src/__tests__/helpers/command-output-harness.ts
@@ -67,6 +67,15 @@ type MockTransportPromise = Promise<MockTransportResolved>;
 type ConsoleLogArgs = Parameters<typeof console.log>;
 export type CommandRegistrar = (program: Command) => void;
 
+function toStubResponse(resolved: MockTransportResolved): Response {
+  return resolved instanceof Response
+    ? resolved
+    : new Response(JSON.stringify(resolved), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+}
+
 interface ServerClientOverride {
   api: object;
 }
@@ -137,7 +146,9 @@ export function stubServerApi(handlers: Record<string, ApiStubHandler>): void {
       node[segment] = child;
       node = child;
     }
-    node[segments[segments.length - 1]] = handler;
+    node[segments[segments.length - 1]] = path.endsWith(".wait.$get")
+      ? async (...args: never[]) => toStubResponse(await handler(...args))
+      : handler;
   }
   createClientMock.mockReturnValue(asServerClient({ api }));
 }

--- a/apps/cli/src/__tests__/json-flag-enforcement.test.ts
+++ b/apps/cli/src/__tests__/json-flag-enforcement.test.ts
@@ -6,7 +6,7 @@ import { registerProjectCommands } from "../commands/project.js";
 import { registerProviderCommands } from "../commands/provider.js";
 import { registerManagerCommands } from "../commands/manager.js";
 import { registerMachineCommands } from "../commands/machine.js";
-import { registerThreadCommands } from "../commands/thread/index.js";
+import { registerThreadCommands } from "../commands/thread/register-all.js";
 const EXCLUDED_COMMANDS = new Set<string>();
 
 function collectLeafCommands(

--- a/apps/cli/src/command-groups.ts
+++ b/apps/cli/src/command-groups.ts
@@ -66,11 +66,14 @@ export const CORE_COMMAND_GROUPS: readonly CommandGroup[] = [
     () => import("./commands/terminal.js"),
     (m) => (program, deps) => m.registerTerminalCommands(program, deps.getUrl),
   ),
-  group(
-    "thread",
-    () => import("./commands/thread/index.js"),
-    (m) => (program, deps) => m.registerThreadCommands(program, deps.getUrl),
-  ),
+  {
+    name: "thread",
+    load: async () => {
+      const module = await import("./commands/thread/index.js");
+      const register = await module.loadThreadCommandRegistrar(process.argv[3]);
+      return (program, deps) => register(program, deps.getUrl);
+    },
+  },
   group(
     "environment",
     () => import("./commands/environment.js"),

--- a/apps/cli/src/commands/thread/index.test.ts
+++ b/apps/cli/src/commands/thread/index.test.ts
@@ -1,0 +1,39 @@
+import { Command } from "commander";
+import { describe, expect, it } from "vitest";
+import { loadThreadCommandRegistrar } from "./index.js";
+
+async function registeredThreadCommandNames(
+  commandName: string,
+): Promise<string[]> {
+  const program = new Command();
+  const register = await loadThreadCommandRegistrar(commandName);
+  register(program, () => "http://server");
+  const thread = program.commands.find(
+    (command) => command.name() === "thread",
+  );
+  if (thread === undefined) {
+    throw new Error("The thread command was not registered.");
+  }
+  return thread.commands.map((command) => command.name());
+}
+
+describe("thread command lazy loading", () => {
+  it("loads only the wait module for wait and wait-many", async () => {
+    await expect(registeredThreadCommandNames("wait")).resolves.toEqual([
+      "wait",
+      "wait-many",
+    ]);
+    await expect(registeredThreadCommandNames("wait-many")).resolves.toEqual([
+      "wait",
+      "wait-many",
+    ]);
+  });
+
+  it("loads only the show module for output", async () => {
+    await expect(registeredThreadCommandNames("output")).resolves.toEqual([
+      "show",
+      "log",
+      "output",
+    ]);
+  });
+});

--- a/apps/cli/src/commands/thread/index.ts
+++ b/apps/cli/src/commands/thread/index.ts
@@ -1,28 +1,89 @@
-import { Command } from "commander";
-import { registerActionsCommands } from "./actions.js";
-import { registerInteractionCommands } from "./interactions.js";
-import { registerListCommand } from "./list.js";
-import { registerOpenCommand } from "./open.js";
-import { registerPaneCommand } from "./pane.js";
-import { registerOrganizationCommands } from "./organization.js";
-import { registerShowCommand } from "./show.js";
-import { registerSpawnCommand } from "./spawn.js";
-import { registerForkCommand } from "./fork.js";
-import { registerWaitCommand } from "./wait.js";
+import type { Command } from "commander";
 
-export function registerThreadCommands(
-  program: Command,
-  getUrl: () => string,
-): void {
-  const thread = program.command("thread").description("Manage threads");
-  registerWaitCommand(thread, getUrl);
-  registerSpawnCommand(thread, getUrl);
-  registerForkCommand(thread, getUrl);
-  registerListCommand(thread, getUrl);
-  registerShowCommand(thread, getUrl);
-  registerOpenCommand(thread, getUrl);
-  registerPaneCommand(thread, getUrl);
-  registerOrganizationCommands(thread, getUrl);
-  registerActionsCommands(thread, getUrl);
-  registerInteractionCommands(thread, getUrl);
+type ThreadCommandRegistrar = (parent: Command, getUrl: () => string) => void;
+
+type ThreadCommandLoader = () => Promise<ThreadCommandRegistrar>;
+
+const waitLoader: ThreadCommandLoader = async () =>
+  (await import("./wait.js")).registerWaitCommand;
+const spawnLoader: ThreadCommandLoader = async () =>
+  (await import("./spawn.js")).registerSpawnCommand;
+const forkLoader: ThreadCommandLoader = async () =>
+  (await import("./fork.js")).registerForkCommand;
+const listLoader: ThreadCommandLoader = async () =>
+  (await import("./list.js")).registerListCommand;
+const showLoader: ThreadCommandLoader = async () =>
+  (await import("./show.js")).registerShowCommand;
+const openLoader: ThreadCommandLoader = async () =>
+  (await import("./open.js")).registerOpenCommand;
+const paneLoader: ThreadCommandLoader = async () =>
+  (await import("./pane.js")).registerPaneCommand;
+const organizationLoader: ThreadCommandLoader = async () =>
+  (await import("./organization.js")).registerOrganizationCommands;
+const actionsLoader: ThreadCommandLoader = async () =>
+  (await import("./actions.js")).registerActionsCommands;
+const interactionsLoader: ThreadCommandLoader = async () =>
+  (await import("./interactions.js")).registerInteractionCommands;
+
+const allLoaders: readonly ThreadCommandLoader[] = [
+  waitLoader,
+  spawnLoader,
+  forkLoader,
+  listLoader,
+  showLoader,
+  openLoader,
+  paneLoader,
+  organizationLoader,
+  actionsLoader,
+  interactionsLoader,
+];
+
+const loaderByCommand = new Map<string, ThreadCommandLoader>([
+  ["wait", waitLoader],
+  ["wait-many", waitLoader],
+  ["spawn", spawnLoader],
+  ["fork", forkLoader],
+  ["list", listLoader],
+  ["show", showLoader],
+  ["log", showLoader],
+  ["output", showLoader],
+  ["open", openLoader],
+  ["pane", paneLoader],
+  ["section", organizationLoader],
+  ["search", organizationLoader],
+  ["history", organizationLoader],
+  ["read", organizationLoader],
+  ["unread", organizationLoader],
+  ["reorder-pinned", organizationLoader],
+  ["queue", organizationLoader],
+  ["tabs", organizationLoader],
+  ["update", actionsLoader],
+  ["archive", actionsLoader],
+  ["unarchive", actionsLoader],
+  ["pin", actionsLoader],
+  ["unpin", actionsLoader],
+  ["delete", actionsLoader],
+  ["edit-message", actionsLoader],
+  ["tell", actionsLoader],
+  ["stop", actionsLoader],
+  ["compact", actionsLoader],
+  ["cancel-plan", actionsLoader],
+  ["clear-goal", actionsLoader],
+  ["interactions", interactionsLoader],
+]);
+
+export async function loadThreadCommandRegistrar(
+  commandName: string | undefined,
+): Promise<(program: Command, getUrl: () => string) => void> {
+  const selectedLoader =
+    commandName === undefined ? undefined : loaderByCommand.get(commandName);
+  const registrars = await Promise.all(
+    selectedLoader === undefined
+      ? allLoaders.map((load) => load())
+      : [selectedLoader()],
+  );
+  return (program, getUrl) => {
+    const thread = program.command("thread").description("Manage threads");
+    for (const register of registrars) register(thread, getUrl);
+  };
 }

--- a/apps/cli/src/commands/thread/register-all.ts
+++ b/apps/cli/src/commands/thread/register-all.ts
@@ -1,0 +1,28 @@
+import { Command } from "commander";
+import { registerActionsCommands } from "./actions.js";
+import { registerInteractionCommands } from "./interactions.js";
+import { registerListCommand } from "./list.js";
+import { registerOpenCommand } from "./open.js";
+import { registerPaneCommand } from "./pane.js";
+import { registerOrganizationCommands } from "./organization.js";
+import { registerShowCommand } from "./show.js";
+import { registerSpawnCommand } from "./spawn.js";
+import { registerForkCommand } from "./fork.js";
+import { registerWaitCommand } from "./wait.js";
+
+export function registerThreadCommands(
+  program: Command,
+  getUrl: () => string,
+): void {
+  const thread = program.command("thread").description("Manage threads");
+  registerWaitCommand(thread, getUrl);
+  registerSpawnCommand(thread, getUrl);
+  registerForkCommand(thread, getUrl);
+  registerListCommand(thread, getUrl);
+  registerShowCommand(thread, getUrl);
+  registerOpenCommand(thread, getUrl);
+  registerPaneCommand(thread, getUrl);
+  registerOrganizationCommands(thread, getUrl);
+  registerActionsCommands(thread, getUrl);
+  registerInteractionCommands(thread, getUrl);
+}

--- a/apps/cli/src/commands/thread/wait.ts
+++ b/apps/cli/src/commands/thread/wait.ts
@@ -8,7 +8,7 @@ import {
 } from "@bb/sdk";
 import { action, CliExitError } from "../../action.js";
 import { createCliBbSdk } from "../../client.js";
-import { outputJson, requireThreadId } from "../helpers.js";
+import { getErrorMessage, outputJson, requireThreadId } from "../helpers.js";
 import {
   DEFAULT_THREAD_WAIT_TIMEOUT_SECONDS,
   parseThreadWaitPollIntervalMs,
@@ -23,7 +23,24 @@ interface ThreadWaitCommandOptions {
   event?: string;
   timeout?: string;
   pollInterval?: string;
+  output?: boolean;
   json?: boolean;
+}
+
+type CliBbSdk = ReturnType<typeof createCliBbSdk>;
+
+interface ParsedThreadWaitOptions {
+  output: boolean;
+  pollIntervalMs: number;
+  target: ThreadWaitTarget;
+  timeoutMs: number;
+}
+
+interface SuccessfulThreadWait {
+  output: string | null | undefined;
+  result: Awaited<ReturnType<CliBbSdk["threads"]["wait"]>>;
+  target: ThreadWaitTarget;
+  threadId: string;
 }
 
 export function registerWaitCommand(
@@ -48,53 +65,177 @@ export function registerWaitCommand(
       "--poll-interval <ms>",
       `Polling interval in milliseconds (default: ${DEFAULT_THREAD_WAIT_POLL_INTERVAL_MS})`,
     )
+    .option("--output", "Get the final thread output after a status match")
     .option("--json", "Print machine-readable JSON output")
     .action(
       action(async (id: string | undefined, opts: ThreadWaitCommandOptions) => {
         const sdk = createCliBbSdk(getUrl());
         const threadId = requireThreadId(id);
-        const target = parseThreadWaitTarget(opts);
-        const timeoutSeconds = parseThreadWaitTimeoutSeconds(opts.timeout);
-        const pollIntervalMs = parseThreadWaitPollIntervalMs(opts.pollInterval);
-        const waitArgs = {
-          threadId,
-          timeoutMs: timeoutSeconds * 1000,
-          pollIntervalMs,
-          ...(target.kind === "status"
-            ? { status: target.status }
-            : { event: target.eventType }),
-        };
-        let result: Awaited<ReturnType<typeof sdk.threads.wait>>;
+        const parsed = parseThreadWaitOptions(opts);
+        printPollIntervalDeprecation(opts);
+        let success: SuccessfulThreadWait;
         try {
-          result = await sdk.threads.wait(waitArgs);
+          success = await executeThreadWait(sdk, threadId, parsed);
         } catch (error) {
-          if (error instanceof ThreadWaitTimeoutError) {
-            throw new CliExitError(
-              error.message,
-              THREAD_WAIT_EXIT_CODE_TIMEOUT,
-            );
-          }
-          if (error instanceof ThreadWaitUnreachableError) {
-            throw new CliExitError(
-              error.message,
-              THREAD_WAIT_EXIT_CODE_UNREACHABLE,
-            );
-          }
-          throw error;
+          throw toThreadWaitCliError(error);
         }
-
-        if (outputJson(opts, { threadId, matched: true, target })) return;
-        if (!("event" in result)) {
-          console.log(
-            `Thread ${threadId} reached status ${result.target.status}.`,
-          );
-          return;
-        }
-        console.log(
-          `Thread ${threadId} observed event ${result.target.eventType} at seq ${result.event.seq}.`,
-        );
+        printSuccessfulWait(success, opts);
       }),
     );
+
+  parent
+    .command("wait-many <ids...>")
+    .description("Wait for several threads in one process")
+    .option("--status <status>", "Wait until each thread reaches this status")
+    .option(
+      "--event <type>",
+      "Wait until each thread log includes this event type",
+    )
+    .option(
+      "--timeout <seconds>",
+      `Timeout in seconds (default: ${DEFAULT_THREAD_WAIT_TIMEOUT_SECONDS})`,
+    )
+    .option(
+      "--poll-interval <ms>",
+      `Polling interval in milliseconds (default: ${DEFAULT_THREAD_WAIT_POLL_INTERVAL_MS})`,
+    )
+    .option("--output", "Get final output after each status match")
+    .option("--json", "Print one JSON line per completed wait")
+    .action(
+      action(async (ids: string[], opts: ThreadWaitCommandOptions) => {
+        const sdk = createCliBbSdk(getUrl());
+        const parsed = parseThreadWaitOptions(opts);
+        printPollIntervalDeprecation(opts);
+        const exitCodes = await Promise.all(
+          ids.map(async (threadId) => {
+            try {
+              const success = await executeThreadWait(sdk, threadId, parsed);
+              printSuccessfulWait(success, opts, true);
+              return 0;
+            } catch (error) {
+              const cliError = toThreadWaitCliError(error);
+              printFailedWait(threadId, cliError, opts);
+              return cliError.exitCode;
+            }
+          }),
+        );
+        const worstExitCode = Math.max(...exitCodes);
+        if (worstExitCode > 0) process.exit(worstExitCode);
+      }),
+    );
+}
+
+async function executeThreadWait(
+  sdk: CliBbSdk,
+  threadId: string,
+  options: ParsedThreadWaitOptions,
+): Promise<SuccessfulThreadWait> {
+  const result = await sdk.threads.wait({
+    threadId,
+    timeoutMs: options.timeoutMs,
+    pollIntervalMs: options.pollIntervalMs,
+    ...(options.target.kind === "status"
+      ? { status: options.target.status }
+      : { event: options.target.eventType }),
+  });
+  const output = options.output
+    ? (await sdk.threads.output({ threadId })).output
+    : undefined;
+  return { output, result, target: options.target, threadId };
+}
+
+function parseThreadWaitOptions(
+  opts: ThreadWaitCommandOptions,
+): ParsedThreadWaitOptions {
+  const target = parseThreadWaitTarget(opts);
+  const output = opts.output === true;
+  if (output && target.kind === "event") {
+    throw new CliExitError(
+      "Cannot combine --output with --event because the event may precede final output.",
+      THREAD_WAIT_EXIT_CODE_INVALID_REQUEST,
+    );
+  }
+  return {
+    output,
+    pollIntervalMs: parseThreadWaitPollIntervalMs(opts.pollInterval),
+    target,
+    timeoutMs: parseThreadWaitTimeoutSeconds(opts.timeout) * 1000,
+  };
+}
+
+function printFailedWait(
+  threadId: string,
+  error: CliExitError,
+  opts: ThreadWaitCommandOptions,
+): void {
+  if (opts.json) {
+    console.log(
+      JSON.stringify({
+        threadId,
+        error: error.message,
+        exitCode: error.exitCode,
+      }),
+    );
+    return;
+  }
+  console.error(`Error: ${error.message}`);
+}
+
+function printPollIntervalDeprecation(opts: ThreadWaitCommandOptions): void {
+  if (opts.pollInterval === undefined) return;
+  console.error(
+    "Warning: --poll-interval is deprecated on event-driven servers. It now controls fallback polling and pauses between long-poll rounds.",
+  );
+}
+
+function printSuccessfulWait(
+  success: SuccessfulThreadWait,
+  opts: ThreadWaitCommandOptions,
+  compactJson = false,
+): void {
+  if (opts.json) {
+    const payload =
+      success.output !== undefined && !("event" in success.result)
+        ? {
+            threadId: success.threadId,
+            status: success.result.thread.status,
+            output: success.output,
+          }
+        : {
+            threadId: success.threadId,
+            matched: true,
+            target: success.target,
+          };
+    if (compactJson) {
+      console.log(JSON.stringify(payload));
+      return;
+    }
+    outputJson(opts, payload);
+    return;
+  }
+  if (!("event" in success.result)) {
+    console.log(
+      `Thread ${success.threadId} reached status ${success.result.target.status}.`,
+    );
+  } else {
+    console.log(
+      `Thread ${success.threadId} observed event ${success.result.target.eventType} at seq ${success.result.event.seq}.`,
+    );
+  }
+  if (success.output !== undefined) {
+    console.log(success.output || "(no output)");
+  }
+}
+
+function toThreadWaitCliError(error: unknown): CliExitError {
+  if (error instanceof CliExitError) return error;
+  if (error instanceof ThreadWaitTimeoutError) {
+    return new CliExitError(error.message, THREAD_WAIT_EXIT_CODE_TIMEOUT);
+  }
+  if (error instanceof ThreadWaitUnreachableError) {
+    return new CliExitError(error.message, THREAD_WAIT_EXIT_CODE_UNREACHABLE);
+  }
+  return new CliExitError(getErrorMessage(error), 1);
 }
 
 function parseThreadWaitTarget(

--- a/apps/server/src/routes/threads/data.ts
+++ b/apps/server/src/routes/threads/data.ts
@@ -9,6 +9,7 @@ import type { Hono } from "hono";
 import {
   PROMPT_HISTORY_ENTRY_LIMIT,
   threadEventTypeSchema,
+  type Thread,
   type ThreadEventType,
 } from "@bb/domain";
 import {
@@ -16,6 +17,7 @@ import {
   typedRoutes,
   type PublicApiSchema,
   type ThreadConversationOutlineResponse,
+  type ThreadResponse,
   type ThreadTimelineQuery,
 } from "@bb/server-contract";
 import type {
@@ -67,12 +69,18 @@ import {
 import { previewTimelineResponseOutputs } from "../../services/threads/timeline-output-preview.js";
 import { computeTimelineRowDelta } from "@bb/server-contract";
 import {
-  findThreadEvent,
   getLastThreadOutput,
   listThreadEventRows,
 } from "../../services/threads/thread-data.js";
 import { listThreadPromptHistory } from "../../services/prompt-history.js";
 import { tryResolveExistingThreadExecutionPlan } from "../../services/threads/thread-execution-plan.js";
+import {
+  ThreadWaitCoordinatorLimitError,
+  type ThreadWaitCoordinator,
+  type ThreadWaitCoordinatorResult,
+  type ThreadWaitCoordinatorTarget,
+} from "../../services/threads/wait-coordinator.js";
+import { toThreadResponseFromThread } from "../../services/threads/thread-runtime-display.js";
 import {
   parseBoundedPositiveOptionalInteger,
   parseInteger,
@@ -291,7 +299,11 @@ async function serveThreadWorktreeRawFile(
   }
 }
 
-export function registerThreadDataRoutes(app: Hono, deps: AppDeps): void {
+export function registerThreadDataRoutes(
+  app: Hono,
+  deps: AppDeps,
+  waitCoordinator: ThreadWaitCoordinator,
+): void {
   const { get } = typedRoutes<PublicApiSchema>(app, {
     onValidationError: (msg) => new ApiError(400, "invalid_request", msg),
   });
@@ -306,6 +318,15 @@ export function registerThreadDataRoutes(app: Hono, deps: AppDeps): void {
     ThreadConversationOutlineResponse["items"]
   >();
   const CONVERSATION_OUTLINE_CACHE_MAX_ENTRIES = 128;
+  const waitThreadResponseCache = new WeakMap<Thread, ThreadResponse>();
+
+  const getWaitThreadResponse = (thread: Thread): ThreadResponse => {
+    const cached = waitThreadResponseCache.get(thread);
+    if (cached !== undefined) return cached;
+    const response = toThreadResponseFromThread(deps, { thread });
+    waitThreadResponseCache.set(thread, response);
+    return response;
+  };
 
   get(routes.timeline, (context, query) => {
     const thread = requirePublicThread(deps.db, context.req.param("id"));
@@ -489,11 +510,56 @@ export function registerThreadDataRoutes(app: Hono, deps: AppDeps): void {
     );
   });
 
+  const waitForThread = async (args: {
+    signal: AbortSignal;
+    target: ThreadWaitCoordinatorTarget;
+    threadId: string;
+    waitMs: number;
+  }): Promise<ThreadWaitCoordinatorResult> => {
+    try {
+      return await waitCoordinator.wait({
+        signal: args.signal,
+        target: args.target,
+        threadId: args.threadId,
+        timeoutMs: args.waitMs,
+      });
+    } catch (error) {
+      if (error instanceof ThreadWaitCoordinatorLimitError) {
+        throw new ApiError(429, "too_many_waiters", error.message, {
+          retryable: true,
+        });
+      }
+      throw error;
+    }
+  };
+
+  get(routes.wait, async (context, query) => {
+    const threadId = context.req.param("id");
+    requirePublicThread(deps.db, threadId);
+    const waitMs = Math.min(
+      parseOptionalInteger(query.waitMs, "waitMs") ?? 30_000,
+      60_000,
+    );
+    const result = await waitForThread({
+      signal: context.req.raw.signal,
+      target: { kind: "status", status: query.status },
+      threadId,
+      waitMs,
+    });
+    if (result.kind === "timeout" || result.kind === "closed") {
+      return new Response(null, { status: 204 });
+    }
+    if (result.kind !== "status") {
+      throw new Error("A status wait received an event result.");
+    }
+    return context.json(getWaitThreadResponse(result.thread));
+  });
+
   get(routes.eventWait, async (context, query) => {
     const threadId = context.req.param("id");
     requirePublicThread(deps.db, threadId);
 
-    const afterSeq = parseOptionalInteger(query.afterSeq, "afterSeq");
+    const afterSeq = parseOptionalInteger(query.afterSeq, "afterSeq") ?? 0;
     const waitMs = Math.min(
       parseOptionalInteger(query.waitMs, "waitMs") ?? 30_000,
       60_000,
@@ -502,31 +568,23 @@ export function registerThreadDataRoutes(app: Hono, deps: AppDeps): void {
     if (!parsedEventType.success) {
       throw new ApiError(400, "invalid_request", "Invalid event type");
     }
-    const eventType = parsedEventType.data;
-
-    const findMatch = () =>
-      findThreadEvent(deps.db, { threadId, type: eventType, afterSeq });
-
-    const deadline = Date.now() + waitMs;
-    let match = findMatch();
-    while (!match) {
-      const remaining = deadline - Date.now();
-      if (remaining <= 0) break;
-      const waiter = deps.hub.registerThreadEventWaiter(threadId, remaining);
-      match = findMatch();
-      if (match) {
-        waiter.cancel();
-        break;
-      }
-      await waiter.promise;
-      match = findMatch();
-    }
-
-    if (!match) {
+    const result = await waitForThread({
+      signal: context.req.raw.signal,
+      target: {
+        afterSeq,
+        eventType: parsedEventType.data,
+        kind: "event",
+      },
+      threadId,
+      waitMs,
+    });
+    if (result.kind === "timeout" || result.kind === "closed") {
       return new Response(null, { status: 204 });
     }
-
-    return context.json(match);
+    if (result.kind !== "event") {
+      throw new Error("An event wait received a status result.");
+    }
+    return context.json(result.event);
   });
 
   get(routes.defaultExecutionOptions, async (context) => {

--- a/apps/server/src/routes/threads/index.ts
+++ b/apps/server/src/routes/threads/index.ts
@@ -5,11 +5,24 @@ import { registerThreadBaseRoutes } from "./base.js";
 import { registerThreadDataRoutes } from "./data.js";
 import { registerThreadInteractionRoutes } from "./interactions.js";
 import { registerThreadTabRoutes } from "./tabs.js";
+import {
+  createThreadWaitCoordinator,
+  type ThreadWaitCoordinator,
+} from "../../services/threads/wait-coordinator.js";
 
-export function registerThreadRoutes(app: Hono, deps: AppDeps): void {
+export function registerThreadRoutes(
+  app: Hono,
+  deps: AppDeps,
+): ThreadWaitCoordinator {
+  const waitCoordinator = createThreadWaitCoordinator({
+    db: deps.db,
+    hub: deps.hub,
+    logger: deps.logger,
+  });
   registerThreadBaseRoutes(app, deps);
   registerThreadActionRoutes(app, deps);
-  registerThreadDataRoutes(app, deps);
+  registerThreadDataRoutes(app, deps, waitCoordinator);
   registerThreadInteractionRoutes(app, deps);
   registerThreadTabRoutes(app, deps);
+  return waitCoordinator;
 }

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -18,6 +18,7 @@ import { registerThreadSectionRoutes } from "./routes/thread-sections.js";
 import { registerSystemRoutes } from "./routes/system.js";
 import { registerTerminalRoutes } from "./routes/terminals.js";
 import { registerThreadRoutes } from "./routes/threads/index.js";
+import type { ThreadWaitCoordinator } from "./services/threads/wait-coordinator.js";
 import { registerPluginRoutes } from "./routes/plugins.js";
 import { registerPluginCatalogRoutes } from "./routes/plugin-catalog.js";
 import { registerSkillsRegistryRoutes } from "./routes/skills-registry.js";
@@ -95,6 +96,7 @@ interface ServerApp {
   injectWebSocket: ReturnType<typeof createNodeWebSocket>["injectWebSocket"];
   pluginService: PluginService;
   pluginCatalogService: PluginCatalogService;
+  threadWaitCoordinator: ThreadWaitCoordinator;
 }
 
 interface CloseWebSocketServerArgs {
@@ -144,8 +146,8 @@ const SLOW_API_REQUEST_LOG_THRESHOLD_MS = 1_000;
 const INSTALL_MACHINE_SCRIPT_PATH = fileURLToPath(
   new URL("./assets/install-machine.sh", import.meta.url),
 );
-const THREAD_EVENT_WAIT_PATH_PATTERN =
-  /^\/api\/v1\/threads\/[^/]+\/events\/wait$/u;
+const THREAD_WAIT_PATH_PATTERN =
+  /^\/api\/v1\/threads\/[^/]+\/(?:events\/)?wait$/u;
 const PLUGIN_APP_ASSET_PATH_PATTERN =
   /^\/api\/v1\/plugins\/[^/]+\/assets\/app\.(?:js|css)$/u;
 const PRECOMPRESSED_STATIC_FILES = [
@@ -163,7 +165,7 @@ function shouldLogSlowApiRequest(args: ShouldLogSlowApiRequestArgs): boolean {
   if (args.durationMs < args.thresholdMs) {
     return false;
   }
-  return !THREAD_EVENT_WAIT_PATH_PATTERN.test(args.path);
+  return !THREAD_WAIT_PATH_PATTERN.test(args.path);
 }
 
 function staticCacheControlForPath(urlPath: string): string {
@@ -595,7 +597,7 @@ export function createApp(
   registerHostRoutes(publicApi, deps, pluginService);
   registerTerminalRoutes(publicApi, deps);
   registerEnvironmentRoutes(publicApi, deps);
-  registerThreadRoutes(publicApi, deps);
+  const threadWaitCoordinator = registerThreadRoutes(publicApi, deps);
   registerSystemRoutes(publicApi, deps, pluginService);
   registerPluginCatalogRoutes(publicApi, pluginCatalogService);
   registerPluginRoutes(publicApi, deps, pluginService);
@@ -723,14 +725,17 @@ export function createApp(
 
   return {
     app,
-    closeWebSockets: () =>
-      closeWebSocketServer({
+    closeWebSockets: async () => {
+      threadWaitCoordinator.close();
+      await closeWebSocketServer({
         forceCloseAfterMs: WEB_SOCKET_SHUTDOWN_FORCE_CLOSE_MS,
         reason: WEB_SOCKET_SHUTDOWN_REASON,
         server: wss,
-      }),
+      });
+    },
     injectWebSocket,
     pluginService,
     pluginCatalogService,
+    threadWaitCoordinator,
   };
 }

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
@@ -49,6 +49,10 @@ BB_HOST_DAEMON_PORT only for an intentional non-default target.
 - Pass an environment or machine selector when the default host is uncertain.
 - Query provider models on the machine that will run the thread.
 - Prefer non-interactive commands and machine-readable output for automation.
+- Follow one thread with one `bb thread wait <id> --output` command.
+- Follow a batch with one `bb thread wait-many <id...> --output` command.
+- Never alternate `bb thread log` and `bb thread wait` in a loop.
+- Treat successful thread output as terminal. Do not wait for that thread again.
 - Pass `--yes` for a confirmed destructive command in a non-interactive shell.
 - Treat plugin commands as normal top-level commands after installation.
 - Inspect real status, logs, API results, or diffs instead of assumptions.

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/references/command-index.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/references/command-index.md
@@ -99,6 +99,7 @@ This index lists every command path that the core CLI registers. Read the task-s
 
 - `bb thread`
 - `bb thread wait`
+- `bb thread wait-many`
 - `bb thread spawn`
 - `bb thread fork`
 - `bb thread list`

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/references/thread-operation.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/references/thread-operation.md
@@ -6,10 +6,17 @@
 - Spawn independent tasks separately when parallel work is useful.
 - Let threads work after spawning. Do not poll with shell sleeps, repeated log
   reads, or repeated status reads.
-- Use `bb thread wait <thread-id>` when you explicitly need to block until a
-  thread finishes. It defaults to waiting for `idle` for up to 20 minutes;
-  pass `--status` or `--event` for a different target, and `--timeout
-<seconds>` when you need a shorter or longer budget.
+- Follow one thread with one `bb thread wait <thread-id> --output` command.
+  Follow a batch with one `bb thread wait-many <thread-id...> --output`
+  command. The command defaults to `idle` and waits for up to 20 minutes.
+- Never alternate `bb thread log` and `bb thread wait` in a loop. Treat
+  successful thread output as terminal. Do not wait for that thread again.
+- Retry a transient wait error with backoff. Confirm that the prior wait
+  process exited before the retry.
+- Server plugins and in-server orchestration must call `sdk.threads.wait`
+  directly. They must not create a `bb thread wait` process.
+- Use `--event` only when an event is the terminal condition. `--output`
+  cannot be combined with `--event`.
 - Use `bb thread tell <thread-id> "..."` when requirements change, a blocker
   needs clarification, or follow-up work is needed.
 - Add `--plan` to `bb thread spawn` or `bb thread tell` to send the prompt as

--- a/apps/server/src/services/skills/builtin-skills/skill-creator/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/skill-creator/SKILL.md
@@ -89,11 +89,13 @@ Spawn a fresh thread for every test:
 
 ```sh
 bb thread spawn --project "$BB_PROJECT_ID" --prompt "<test prompt>" --json
-bb thread wait <thread-id>
-bb thread output <thread-id>
+bb thread wait <thread-id> --output
 bb thread log <thread-id>
 bb thread show <thread-id> --git-diff
 ```
+
+Use one wait command for each test thread. Never alternate log and wait
+commands. Treat the successful output as terminal. Do not wait again.
 
 Read the transcript, not only the final answer. Check whether the skill
 triggered, whether the agent read only relevant resources, and whether the

--- a/apps/server/src/services/threads/wait-coordinator.ts
+++ b/apps/server/src/services/threads/wait-coordinator.ts
@@ -1,0 +1,523 @@
+import { getThread, type DbConnection } from "@bb/db";
+import {
+  isThreadWaitTargetUnreachable,
+  type Thread,
+  type ThreadEventRow,
+  type ThreadEventType,
+  type ThreadStatus,
+} from "@bb/domain";
+import type { ServerLogger } from "../../types.js";
+import type { NotificationHub } from "../../ws/hub.js";
+import { findThreadEvent as findPublicThreadEvent } from "./thread-data.js";
+
+export const THREAD_WAIT_COORDINATOR_MAX_CALLERS = 1_000;
+export const THREAD_WAIT_COORDINATOR_MAX_ENTRIES = 200;
+
+const WATCHER_TIMEOUT_MS = 60_000;
+const SUMMARY_INTERVAL_MS = 60_000;
+const DURATION_BUCKET_MAXIMUMS_MS = [
+  10,
+  100,
+  1_000,
+  10_000,
+  30_000,
+  60_000,
+  300_000,
+  1_200_000,
+  Number.POSITIVE_INFINITY,
+] as const;
+
+export type ThreadWaitCoordinatorTarget =
+  | { kind: "status"; status: ThreadStatus }
+  | {
+      afterSeq: number;
+      eventType: ThreadEventType;
+      kind: "event";
+    };
+
+export type ThreadWaitCoordinatorResult =
+  | { kind: "closed" }
+  | { event: ThreadEventRow; kind: "event" }
+  | { kind: "status"; thread: Thread; unreachable: boolean }
+  | { kind: "timeout" };
+
+export interface ThreadWaitCoordinatorStats {
+  activeCallers: number;
+  activeEntries: number;
+  checkCount: number;
+  cleanupFailureCount: number;
+  deduplicatedJoinCount: number;
+  deduplicationRatio: number;
+  durationMs: {
+    count: number;
+    max: number;
+    min: number;
+    p50: number;
+    p95: number;
+  };
+  entryCreateCount: number;
+  joinCount: number;
+  limitRejectionCount: number;
+  timeoutCount: number;
+  unreachableCount: number;
+}
+
+interface ThreadWaitCoordinatorOptions {
+  db: DbConnection;
+  hub: Pick<NotificationHub, "registerThreadEventWaiter">;
+  logger: ServerLogger;
+  maxCallers?: number;
+  maxEntries?: number;
+  now?: () => number;
+  summaryIntervalMs?: number;
+  watcherTimeoutMs?: number;
+}
+
+interface ThreadWaitCaller {
+  abortListener: (() => void) | null;
+  id: number;
+  reject: (error: Error) => void;
+  resolve: (result: ThreadWaitCoordinatorResult) => void;
+  signal: AbortSignal | undefined;
+  startedAt: number;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+interface ThreadWaitEntry {
+  callers: Map<number, ThreadWaitCaller>;
+  checkRequested: boolean;
+  checkScheduled: boolean;
+  checking: boolean;
+  createdAt: number;
+  key: string;
+  target: ThreadWaitCoordinatorTarget;
+  threadId: string;
+  watcher: { cancel: () => void; promise: Promise<boolean> } | undefined;
+}
+
+interface DurationState {
+  bucketCounts: number[];
+  count: number;
+  max: number;
+  min: number;
+}
+
+export class ThreadWaitCoordinatorLimitError extends Error {
+  constructor() {
+    super("The server has reached its thread waiter limit.");
+    this.name = "ThreadWaitCoordinatorLimitError";
+  }
+}
+
+export class ThreadWaitCoordinator {
+  private readonly db: DbConnection;
+  private readonly entries = new Map<string, ThreadWaitEntry>();
+  private readonly hub: Pick<NotificationHub, "registerThreadEventWaiter">;
+  private readonly logger: ServerLogger;
+  private readonly maxCallers: number;
+  private readonly maxEntries: number;
+  private readonly now: () => number;
+  private readonly summaryIntervalMs: number;
+  private readonly watcherTimeoutMs: number;
+  private activeCallers = 0;
+  private checkCount = 0;
+  private cleanupFailureCount = 0;
+  private closed = false;
+  private deduplicatedJoinCount = 0;
+  private durationState: DurationState = {
+    bucketCounts: DURATION_BUCKET_MAXIMUMS_MS.map(() => 0),
+    count: 0,
+    max: 0,
+    min: 0,
+  };
+  private entryCreateCount = 0;
+  private joinCount = 0;
+  private limitRejectionCount = 0;
+  private nextCallerId = 1;
+  private summaryTimer: ReturnType<typeof setInterval> | undefined;
+  private timeoutCount = 0;
+  private unreachableCount = 0;
+
+  constructor(options: ThreadWaitCoordinatorOptions) {
+    this.db = options.db;
+    this.hub = options.hub;
+    this.logger = options.logger;
+    this.maxCallers = options.maxCallers ?? THREAD_WAIT_COORDINATOR_MAX_CALLERS;
+    this.maxEntries = options.maxEntries ?? THREAD_WAIT_COORDINATOR_MAX_ENTRIES;
+    this.now = options.now ?? Date.now;
+    this.summaryIntervalMs = options.summaryIntervalMs ?? SUMMARY_INTERVAL_MS;
+    this.watcherTimeoutMs = options.watcherTimeoutMs ?? WATCHER_TIMEOUT_MS;
+  }
+
+  getStats(): ThreadWaitCoordinatorStats {
+    return {
+      activeCallers: this.activeCallers,
+      activeEntries: this.entries.size,
+      checkCount: this.checkCount,
+      cleanupFailureCount: this.cleanupFailureCount,
+      deduplicatedJoinCount: this.deduplicatedJoinCount,
+      deduplicationRatio:
+        this.entryCreateCount === 0
+          ? 0
+          : this.joinCount / this.entryCreateCount,
+      durationMs: this.getDurationStats(),
+      entryCreateCount: this.entryCreateCount,
+      joinCount: this.joinCount,
+      limitRejectionCount: this.limitRejectionCount,
+      timeoutCount: this.timeoutCount,
+      unreachableCount: this.unreachableCount,
+    };
+  }
+
+  wait(args: {
+    signal?: AbortSignal;
+    target: ThreadWaitCoordinatorTarget;
+    threadId: string;
+    timeoutMs: number;
+  }): Promise<ThreadWaitCoordinatorResult> {
+    if (this.closed) {
+      return Promise.resolve({ kind: "closed" });
+    }
+    if (args.signal?.aborted) {
+      return Promise.reject(this.createAbortError());
+    }
+
+    const key = this.buildKey(args.threadId, args.target);
+    let entry = this.entries.get(key);
+    if (this.activeCallers >= this.maxCallers) {
+      this.limitRejectionCount += 1;
+      return Promise.reject(new ThreadWaitCoordinatorLimitError());
+    }
+    if (entry === undefined && this.entries.size >= this.maxEntries) {
+      this.limitRejectionCount += 1;
+      return Promise.reject(new ThreadWaitCoordinatorLimitError());
+    }
+
+    this.joinCount += 1;
+    if (entry === undefined) {
+      entry = {
+        callers: new Map(),
+        checkRequested: false,
+        checkScheduled: false,
+        checking: false,
+        createdAt: this.now(),
+        key,
+        target: args.target,
+        threadId: args.threadId,
+        watcher: undefined,
+      };
+      this.entries.set(key, entry);
+      this.entryCreateCount += 1;
+      this.ensureSummaryTimer();
+      this.logger.info(
+        {
+          activeEntries: this.entries.size,
+          key,
+          threadId: args.threadId,
+        },
+        "Thread wait coordinator entry created",
+      );
+    } else {
+      this.deduplicatedJoinCount += 1;
+    }
+
+    const selectedEntry = entry;
+    return new Promise<ThreadWaitCoordinatorResult>((resolve, reject) => {
+      const callerId = this.nextCallerId;
+      this.nextCallerId += 1;
+      const caller: ThreadWaitCaller = {
+        abortListener: null,
+        id: callerId,
+        reject,
+        resolve,
+        signal: args.signal,
+        startedAt: this.now(),
+        timer: setTimeout(
+          () => {
+            this.finishCaller(
+              selectedEntry,
+              caller,
+              { kind: "timeout" },
+              "timeout",
+            );
+          },
+          Math.max(0, args.timeoutMs),
+        ),
+      };
+      if (args.signal !== undefined) {
+        caller.abortListener = () => {
+          this.failCaller(
+            selectedEntry,
+            caller,
+            this.createAbortError(),
+            "abort",
+          );
+        };
+        args.signal.addEventListener("abort", caller.abortListener, {
+          once: true,
+        });
+      }
+      selectedEntry.callers.set(callerId, caller);
+      this.activeCallers += 1;
+      this.scheduleCheck(selectedEntry);
+    });
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    for (const entry of [...this.entries.values()]) {
+      for (const caller of [...entry.callers.values()]) {
+        this.finishCaller(entry, caller, { kind: "closed" }, "closed");
+      }
+    }
+    this.stopSummaryTimer();
+  }
+
+  private armWatcher(entry: ThreadWaitEntry): void {
+    if (entry.watcher !== undefined || entry.callers.size === 0) return;
+    const watcher = this.hub.registerThreadEventWaiter(
+      entry.threadId,
+      this.watcherTimeoutMs,
+    );
+    entry.watcher = watcher;
+    void watcher.promise.then(() => {
+      if (entry.watcher !== watcher) return;
+      entry.watcher = undefined;
+      if (!this.entries.has(entry.key) || entry.callers.size === 0) return;
+      entry.checkRequested = true;
+      this.scheduleCheck(entry);
+    });
+  }
+
+  private buildKey(
+    threadId: string,
+    target: ThreadWaitCoordinatorTarget,
+  ): string {
+    if (target.kind === "status") {
+      return `${threadId}|status|${target.status}`;
+    }
+    return `${threadId}|event|${target.eventType}|${target.afterSeq}`;
+  }
+
+  private checkTarget(
+    entry: ThreadWaitEntry,
+  ): ThreadWaitCoordinatorResult | null {
+    this.checkCount += 1;
+    if (entry.target.kind === "event") {
+      const event = findPublicThreadEvent(this.db, {
+        afterSeq: entry.target.afterSeq,
+        threadId: entry.threadId,
+        type: entry.target.eventType,
+      });
+      return event === null ? null : { event, kind: "event" };
+    }
+
+    const thread = getThread(this.db, entry.threadId);
+    if (thread === null) {
+      throw new Error(`Thread ${entry.threadId} disappeared during a wait.`);
+    }
+    const unreachable = isThreadWaitTargetUnreachable(
+      thread.status,
+      entry.target.status,
+    );
+    if (thread.status !== entry.target.status && !unreachable) {
+      return null;
+    }
+    return { kind: "status", thread, unreachable };
+  }
+
+  private cleanupEntry(entry: ThreadWaitEntry, reason: string): void {
+    if (this.entries.get(entry.key) !== entry) return;
+    this.entries.delete(entry.key);
+    if (entry.watcher !== undefined) {
+      try {
+        entry.watcher.cancel();
+      } catch (error) {
+        this.cleanupFailureCount += 1;
+        this.logger.warn(
+          { err: error, key: entry.key, threadId: entry.threadId },
+          "Thread wait coordinator cleanup failed",
+        );
+      }
+      entry.watcher = undefined;
+    }
+    this.logger.info(
+      {
+        activeEntries: this.entries.size,
+        durationMs: this.now() - entry.createdAt,
+        key: entry.key,
+        reason,
+        threadId: entry.threadId,
+      },
+      "Thread wait coordinator entry removed",
+    );
+    if (this.entries.size === 0) {
+      this.stopSummaryTimer();
+    }
+  }
+
+  private createAbortError(): Error {
+    return new DOMException("The thread wait was aborted.", "AbortError");
+  }
+
+  private async checkEntry(entry: ThreadWaitEntry): Promise<void> {
+    if (this.entries.get(entry.key) !== entry || entry.callers.size === 0) {
+      return;
+    }
+    if (entry.checking) {
+      entry.checkRequested = true;
+      return;
+    }
+    entry.checking = true;
+    entry.checkRequested = false;
+    this.armWatcher(entry);
+    try {
+      const result = this.checkTarget(entry);
+      if (result !== null) {
+        if (result.kind === "status" && result.unreachable) {
+          this.unreachableCount += entry.callers.size;
+        }
+        for (const caller of [...entry.callers.values()]) {
+          this.finishCaller(entry, caller, result, result.kind);
+        }
+        return;
+      }
+    } catch (error) {
+      const resolvedError =
+        error instanceof Error ? error : new Error(String(error));
+      for (const caller of [...entry.callers.values()]) {
+        this.failCaller(entry, caller, resolvedError, "error");
+      }
+      return;
+    } finally {
+      entry.checking = false;
+    }
+
+    if (entry.checkRequested) {
+      entry.checkRequested = false;
+      this.scheduleCheck(entry);
+    }
+  }
+
+  private ensureSummaryTimer(): void {
+    if (this.summaryTimer !== undefined) return;
+    this.summaryTimer = setInterval(() => {
+      if (this.entries.size === 0) return;
+      this.logger.info(this.getStats(), "Thread wait coordinator summary");
+    }, this.summaryIntervalMs);
+    this.summaryTimer.unref();
+  }
+
+  private failCaller(
+    entry: ThreadWaitEntry,
+    caller: ThreadWaitCaller,
+    error: Error,
+    reason: string,
+  ): void {
+    if (!entry.callers.delete(caller.id)) return;
+    this.releaseCaller(caller);
+    caller.reject(error);
+    if (entry.callers.size === 0) {
+      this.cleanupEntry(entry, reason);
+    }
+  }
+
+  private finishCaller(
+    entry: ThreadWaitEntry,
+    caller: ThreadWaitCaller,
+    result: ThreadWaitCoordinatorResult,
+    reason: string,
+  ): void {
+    if (!entry.callers.delete(caller.id)) return;
+    this.releaseCaller(caller);
+    if (result.kind === "timeout") {
+      this.timeoutCount += 1;
+    }
+    caller.resolve(result);
+    if (entry.callers.size === 0) {
+      this.cleanupEntry(entry, reason);
+    }
+  }
+
+  private getDurationStats(): ThreadWaitCoordinatorStats["durationMs"] {
+    if (this.durationState.count === 0) {
+      return { count: 0, max: 0, min: 0, p50: 0, p95: 0 };
+    }
+    return {
+      count: this.durationState.count,
+      max: this.durationState.max,
+      min: this.durationState.min,
+      p50: this.getDurationPercentile(0.5),
+      p95: this.getDurationPercentile(0.95),
+    };
+  }
+
+  private getDurationPercentile(percentile: number): number {
+    const targetCount = Math.ceil(this.durationState.count * percentile);
+    let observedCount = 0;
+    for (const [index, count] of this.durationState.bucketCounts.entries()) {
+      observedCount += count;
+      if (observedCount >= targetCount) {
+        const maximum = DURATION_BUCKET_MAXIMUMS_MS[index];
+        if (maximum === undefined || !Number.isFinite(maximum)) {
+          return this.durationState.max;
+        }
+        return maximum;
+      }
+    }
+    return this.durationState.max;
+  }
+
+  private recordDuration(durationMs: number): void {
+    const duration = Math.max(0, durationMs);
+    this.durationState.count += 1;
+    this.durationState.max = Math.max(this.durationState.max, duration);
+    this.durationState.min =
+      this.durationState.count === 1
+        ? duration
+        : Math.min(this.durationState.min, duration);
+    const bucketIndex = DURATION_BUCKET_MAXIMUMS_MS.findIndex(
+      (maximum) => duration <= maximum,
+    );
+    const currentBucketCount = this.durationState.bucketCounts[bucketIndex];
+    if (currentBucketCount === undefined) {
+      throw new Error("Thread wait duration did not match a histogram bucket.");
+    }
+    this.durationState.bucketCounts[bucketIndex] = currentBucketCount + 1;
+  }
+
+  private releaseCaller(caller: ThreadWaitCaller): void {
+    clearTimeout(caller.timer);
+    if (caller.signal !== undefined && caller.abortListener !== null) {
+      caller.signal.removeEventListener("abort", caller.abortListener);
+    }
+    this.activeCallers -= 1;
+    this.recordDuration(this.now() - caller.startedAt);
+  }
+
+  private scheduleCheck(entry: ThreadWaitEntry): void {
+    if (entry.checking) {
+      entry.checkRequested = true;
+      return;
+    }
+    if (entry.checkScheduled) return;
+    entry.checkScheduled = true;
+    queueMicrotask(() => {
+      entry.checkScheduled = false;
+      void this.checkEntry(entry);
+    });
+  }
+
+  private stopSummaryTimer(): void {
+    if (this.summaryTimer === undefined) return;
+    clearInterval(this.summaryTimer);
+    this.summaryTimer = undefined;
+  }
+}
+
+export function createThreadWaitCoordinator(
+  options: ThreadWaitCoordinatorOptions,
+): ThreadWaitCoordinator {
+  return new ThreadWaitCoordinator(options);
+}

--- a/apps/server/test/helpers/test-app.ts
+++ b/apps/server/test/helpers/test-app.ts
@@ -45,6 +45,7 @@ export interface TestAppHarness {
   hub: NotificationHub;
   pluginService: ReturnType<typeof createApp>["pluginService"];
   pluginCatalogService: ReturnType<typeof createApp>["pluginCatalogService"];
+  threadWaitCoordinator: ReturnType<typeof createApp>["threadWaitCoordinator"];
   cleanup(): Promise<void>;
 }
 
@@ -269,7 +270,8 @@ export async function createTestAppHarness(
     sharedPorts,
     workspaceReadCaches,
   };
-  const { app, pluginCatalogService, pluginService } = createApp(deps);
+  const { app, pluginCatalogService, pluginService, threadWaitCoordinator } =
+    createApp(deps);
 
   return {
     app,
@@ -279,7 +281,9 @@ export async function createTestAppHarness(
     hub,
     pluginService,
     pluginCatalogService,
+    threadWaitCoordinator,
     async cleanup(): Promise<void> {
+      threadWaitCoordinator.close();
       await pluginService.stop();
       await rm(dataDir, { recursive: true, force: true });
     },
@@ -318,9 +322,13 @@ export async function startTestServer(
 ): Promise<RunningTestServer> {
   const harness = await createTestAppHarness(overrides);
   let addressInfo: AddressInfo | null = null;
-  const { app, closeWebSockets, injectWebSocket, pluginService } = createApp(
-    harness.deps,
-  );
+  const {
+    app,
+    closeWebSockets,
+    injectWebSocket,
+    pluginService,
+    threadWaitCoordinator,
+  } = createApp(harness.deps);
   const server = serve(
     {
       hostname: TEST_SERVER_HOST,
@@ -343,6 +351,7 @@ export async function startTestServer(
     ...harness,
     app,
     pluginService,
+    threadWaitCoordinator,
     baseUrl: `http://${TEST_SERVER_HOST}:${resolvedAddress.port}`,
     async close(): Promise<void> {
       const closeServer = new Promise<void>((resolve, reject) => {

--- a/apps/server/test/public/public-thread-wait.test.ts
+++ b/apps/server/test/public/public-thread-wait.test.ts
@@ -1,0 +1,213 @@
+import { eq } from "drizzle-orm";
+import { threads } from "@bb/db";
+import { turnScope } from "@bb/domain";
+import { describe, expect, it, vi } from "vitest";
+import { readJson } from "../helpers/json.js";
+import { seedEvent, seedThreadFixture } from "../helpers/seed.js";
+import { startTestServer, withTestHarness } from "../helpers/test-app.js";
+
+describe("public thread wait route", () => {
+  it("returns the matching status and preserves thread_not_found", async () => {
+    await withTestHarness(async (harness) => {
+      const { thread } = seedThreadFixture(harness, {
+        thread: { status: "idle" },
+      });
+      const response = await harness.app.request(
+        `/api/v1/threads/${thread.id}/wait?status=idle&waitMs=0`,
+      );
+      expect(response.status).toBe(200);
+      await expect(readJson(response)).resolves.toMatchObject({
+        id: thread.id,
+        status: "idle",
+      });
+
+      const missing = await harness.app.request(
+        "/api/v1/threads/missing-thread/wait?status=idle&waitMs=0",
+      );
+      expect(missing.status).toBe(404);
+      await expect(readJson(missing)).resolves.toMatchObject({
+        code: "thread_not_found",
+      });
+    });
+  });
+
+  it("returns an error thread when idle is unreachable", async () => {
+    await withTestHarness(async (harness) => {
+      const { thread } = seedThreadFixture(harness, {
+        thread: { status: "error" },
+      });
+      const response = await harness.app.request(
+        `/api/v1/threads/${thread.id}/wait?status=idle&waitMs=1000`,
+      );
+      expect(response.status).toBe(200);
+      await expect(readJson(response)).resolves.toMatchObject({
+        id: thread.id,
+        status: "error",
+      });
+      expect(harness.threadWaitCoordinator.getStats()).toMatchObject({
+        activeCallers: 0,
+        activeEntries: 0,
+        unreachableCount: 1,
+      });
+    });
+  });
+
+  it("shares one status check across 100 route callers", async () => {
+    await withTestHarness(async (harness) => {
+      const { thread } = seedThreadFixture(harness, {
+        thread: { status: "active" },
+      });
+      const requests = Array.from({ length: 100 }, () =>
+        harness.app.request(
+          `/api/v1/threads/${thread.id}/wait?status=idle&waitMs=10000`,
+        ),
+      );
+      await vi.waitFor(() => {
+        expect(harness.threadWaitCoordinator.getStats()).toMatchObject({
+          activeCallers: 100,
+          activeEntries: 1,
+          checkCount: 1,
+        });
+      });
+
+      harness.db
+        .update(threads)
+        .set({ status: "idle", updatedAt: Date.now() })
+        .where(eq(threads.id, thread.id))
+        .run();
+      harness.hub.notifyThread(thread.id, ["status-changed"]);
+
+      const responses = await Promise.all(requests);
+      expect(responses.every((response) => response.status === 200)).toBe(true);
+      expect(harness.threadWaitCoordinator.getStats()).toMatchObject({
+        activeCallers: 0,
+        activeEntries: 0,
+        checkCount: 2,
+      });
+    });
+  });
+
+  it("normalizes absent and zero event cursors into one entry", async () => {
+    await withTestHarness(async (harness) => {
+      const { environment, thread } = seedThreadFixture(harness);
+      const requests = Array.from({ length: 100 }, (_, index) =>
+        harness.app.request(
+          `/api/v1/threads/${thread.id}/events/wait?type=item/completed&waitMs=10000${index % 2 === 0 ? "" : "&afterSeq=0"}`,
+        ),
+      );
+      await vi.waitFor(() => {
+        expect(harness.threadWaitCoordinator.getStats()).toMatchObject({
+          activeCallers: 100,
+          activeEntries: 1,
+          checkCount: 1,
+        });
+      });
+
+      seedEvent(harness.deps, {
+        data: {
+          item: { id: "msg-1", text: "Reply", type: "agentMessage" },
+        },
+        environmentId: environment.id,
+        providerThreadId: "provider-thread-1",
+        scope: turnScope("turn-1"),
+        sequence: 1,
+        threadId: thread.id,
+        type: "item/completed",
+      });
+
+      const responses = await Promise.all(requests);
+      expect(responses.every((response) => response.status === 200)).toBe(true);
+      expect(harness.threadWaitCoordinator.getStats()).toMatchObject({
+        activeCallers: 0,
+        activeEntries: 0,
+        checkCount: 2,
+      });
+    });
+  });
+
+  it("removes a disconnected route caller", async () => {
+    await withTestHarness(async (harness) => {
+      const { thread } = seedThreadFixture(harness, {
+        thread: { status: "active" },
+      });
+      const controller = new AbortController();
+      const request = harness.app.request(
+        `/api/v1/threads/${thread.id}/wait?status=idle&waitMs=10000`,
+        { signal: controller.signal },
+      );
+      await vi.waitFor(() => {
+        expect(harness.threadWaitCoordinator.getStats().activeCallers).toBe(1);
+      });
+      controller.abort();
+      await request;
+      expect(harness.threadWaitCoordinator.getStats()).toMatchObject({
+        activeCallers: 0,
+        activeEntries: 0,
+      });
+    });
+  });
+
+  it("returns 429 when unique wait entries reach the server limit", async () => {
+    await withTestHarness(async (harness) => {
+      const { thread } = seedThreadFixture(harness);
+      const controllers = Array.from(
+        { length: 200 },
+        () => new AbortController(),
+      );
+      const requests = controllers.map((controller, index) =>
+        harness.app.request(
+          `/api/v1/threads/${thread.id}/events/wait?type=turn/completed&afterSeq=${index + 1}&waitMs=10000`,
+          { signal: controller.signal },
+        ),
+      );
+      await vi.waitFor(() => {
+        expect(harness.threadWaitCoordinator.getStats().activeEntries).toBe(
+          200,
+        );
+      });
+
+      const rejected = await harness.app.request(
+        `/api/v1/threads/${thread.id}/events/wait?type=turn/completed&afterSeq=201&waitMs=10000`,
+      );
+      expect(rejected.status).toBe(429);
+      await expect(readJson(rejected)).resolves.toMatchObject({
+        code: "too_many_waiters",
+        retryable: true,
+      });
+
+      for (const controller of controllers) controller.abort();
+      await Promise.all(requests);
+      expect(harness.threadWaitCoordinator.getStats()).toMatchObject({
+        activeCallers: 0,
+        activeEntries: 0,
+        limitRejectionCount: 1,
+      });
+    });
+  });
+
+  it("returns 204 and clears waits during server shutdown", async () => {
+    const server = await startTestServer();
+    let closed = false;
+    try {
+      const { thread } = seedThreadFixture(server, {
+        thread: { status: "active" },
+      });
+      const responsePromise = fetch(
+        `${server.baseUrl}/api/v1/threads/${thread.id}/wait?status=idle&waitMs=60000`,
+      );
+      await vi.waitFor(() => {
+        expect(server.threadWaitCoordinator.getStats().activeCallers).toBe(1);
+      });
+      await server.close();
+      closed = true;
+      const response = await responsePromise;
+      expect(response.status).toBe(204);
+      expect(server.threadWaitCoordinator.getStats()).toMatchObject({
+        activeCallers: 0,
+        activeEntries: 0,
+      });
+    } finally {
+      if (!closed) await server.close();
+    }
+  });
+});

--- a/apps/server/test/services/plugins/plugin-sdk.test.ts
+++ b/apps/server/test/services/plugins/plugin-sdk.test.ts
@@ -535,6 +535,31 @@ describe("plugin bb.sdk against a running server", () => {
           timeoutMs: 100,
         }),
       ).resolves.toMatchObject({ matched: true });
+      const waiting = seedThread(server.deps, {
+        environmentId: environment.id,
+        originPluginId: "spawner",
+        projectId: project.id,
+        status: "active",
+        visibility: "hidden",
+      });
+      const waitController = new AbortController();
+      const canceledWait = api.sdk.threads.wait({
+        signal: waitController.signal,
+        status: "idle",
+        threadId: waiting.id,
+        timeoutMs: 10_000,
+      });
+      await vi.waitFor(() => {
+        expect(server.threadWaitCoordinator.getStats().activeCallers).toBe(1);
+      });
+      waitController.abort();
+      await expect(canceledWait).rejects.toMatchObject({ name: "AbortError" });
+      await vi.waitFor(() => {
+        expect(server.threadWaitCoordinator.getStats()).toMatchObject({
+          activeCallers: 0,
+          activeEntries: 0,
+        });
+      });
       await expect(
         api.sdk.threads.send({
           threadId: operable.id,

--- a/apps/server/test/services/threads/wait-coordinator.test.ts
+++ b/apps/server/test/services/threads/wait-coordinator.test.ts
@@ -1,0 +1,360 @@
+import { eq } from "drizzle-orm";
+import {
+  createConnection,
+  createProject,
+  createThread,
+  migrate,
+  noopNotifier,
+  threads,
+  upsertHost,
+  type DbConnection,
+} from "@bb/db";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  ThreadWaitCoordinator,
+  ThreadWaitCoordinatorLimitError,
+} from "../../../src/services/threads/wait-coordinator.js";
+import { NotificationHub } from "../../../src/ws/hub.js";
+
+interface SetupResult {
+  coordinator: ThreadWaitCoordinator;
+  db: DbConnection;
+  hub: NotificationHub;
+  threadId: string;
+  warn: ReturnType<typeof vi.fn>;
+}
+
+function setup(
+  args: {
+    maxCallers?: number;
+    maxEntries?: number;
+    status?: "active" | "error";
+  } = {},
+): SetupResult {
+  const db = createConnection(":memory:");
+  migrate(db);
+  const hub = new NotificationHub();
+  const host = upsertHost(db, noopNotifier, {
+    name: "wait-test-host",
+    type: "persistent",
+  });
+  const { project } = createProject(db, noopNotifier, {
+    name: "wait-test-project",
+    source: {
+      hostId: host.id,
+      path: "/tmp/wait-test",
+      type: "local_path",
+    },
+  });
+  const thread = createThread(db, noopNotifier, {
+    projectId: project.id,
+    providerId: "codex",
+    status: args.status ?? "active",
+  });
+  const warn = vi.fn();
+  const coordinator = new ThreadWaitCoordinator({
+    db,
+    hub,
+    logger: {
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      warn,
+    },
+    maxCallers: args.maxCallers,
+    maxEntries: args.maxEntries,
+  });
+  return { coordinator, db, hub, threadId: thread.id, warn };
+}
+
+function setThreadStatus(
+  db: DbConnection,
+  threadId: string,
+  status: "active" | "idle",
+): void {
+  db.update(threads)
+    .set({ status, updatedAt: Date.now() })
+    .where(eq(threads.id, threadId))
+    .run();
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("ThreadWaitCoordinator", () => {
+  it("shares one active entry and one watcher across 100 identical waits", async () => {
+    const { coordinator, db, hub, threadId } = setup();
+    const registerWatcher = vi.spyOn(hub, "registerThreadEventWaiter");
+    const waits = Array.from({ length: 100 }, () =>
+      coordinator.wait({
+        target: { kind: "status", status: "idle" },
+        threadId,
+        timeoutMs: 10_000,
+      }),
+    );
+
+    await vi.waitFor(() => {
+      expect(coordinator.getStats()).toMatchObject({
+        activeCallers: 100,
+        activeEntries: 1,
+        checkCount: 1,
+        deduplicatedJoinCount: 99,
+        entryCreateCount: 1,
+        joinCount: 100,
+      });
+      expect(registerWatcher).toHaveBeenCalledTimes(1);
+    });
+
+    hub.notifyThread(threadId, ["title-changed"]);
+    await vi.waitFor(() => {
+      expect(coordinator.getStats().checkCount).toBe(2);
+    });
+    setThreadStatus(db, threadId, "idle");
+    hub.notifyThread(threadId, ["status-changed"]);
+
+    const results = await Promise.all(waits);
+    expect(results).toHaveLength(100);
+    expect(results.every((result) => result.kind === "status")).toBe(true);
+    expect(coordinator.getStats()).toMatchObject({
+      activeCallers: 0,
+      activeEntries: 0,
+      checkCount: 3,
+    });
+    db.$client.close();
+  });
+
+  it("keeps different threads, targets, and cursors in separate entries", async () => {
+    const { coordinator, db, hub, threadId } = setup();
+    const secondThread = createThread(db, noopNotifier, {
+      projectId: db.select().from(threads).get()?.projectId ?? "",
+      providerId: "codex",
+      status: "active",
+    });
+    const controllers = Array.from({ length: 5 }, () => new AbortController());
+    const waits = [
+      coordinator.wait({
+        signal: controllers[0]?.signal,
+        target: { kind: "status", status: "idle" },
+        threadId,
+        timeoutMs: 10_000,
+      }),
+      coordinator.wait({
+        signal: controllers[1]?.signal,
+        target: { kind: "status", status: "idle" },
+        threadId: secondThread.id,
+        timeoutMs: 10_000,
+      }),
+      coordinator.wait({
+        signal: controllers[2]?.signal,
+        target: { kind: "status", status: "error" },
+        threadId,
+        timeoutMs: 10_000,
+      }),
+      coordinator.wait({
+        signal: controllers[3]?.signal,
+        target: {
+          afterSeq: 0,
+          eventType: "turn/completed",
+          kind: "event",
+        },
+        threadId,
+        timeoutMs: 10_000,
+      }),
+      coordinator.wait({
+        signal: controllers[4]?.signal,
+        target: {
+          afterSeq: 1,
+          eventType: "turn/completed",
+          kind: "event",
+        },
+        threadId,
+        timeoutMs: 10_000,
+      }),
+    ];
+
+    await vi.waitFor(() => {
+      expect(coordinator.getStats().activeEntries).toBe(5);
+    });
+    for (const controller of controllers) controller.abort();
+    await Promise.allSettled(waits);
+    expect(coordinator.getStats()).toMatchObject({
+      activeCallers: 0,
+      activeEntries: 0,
+    });
+    coordinator.close();
+    hub.notifyThread(threadId, ["status-changed"]);
+    db.$client.close();
+  });
+
+  it("keeps remaining callers after one abort and cancels after the final abort", async () => {
+    const { coordinator, db, threadId } = setup();
+    const controllers = Array.from({ length: 3 }, () => new AbortController());
+    const waits = controllers.map((controller) =>
+      coordinator.wait({
+        signal: controller.signal,
+        target: { kind: "status", status: "idle" },
+        threadId,
+        timeoutMs: 10_000,
+      }),
+    );
+
+    controllers[0]?.abort();
+    await expect(waits[0]).rejects.toMatchObject({ name: "AbortError" });
+    expect(coordinator.getStats()).toMatchObject({
+      activeCallers: 2,
+      activeEntries: 1,
+    });
+
+    controllers[1]?.abort();
+    controllers[2]?.abort();
+    await Promise.allSettled(waits.slice(1));
+    expect(coordinator.getStats()).toMatchObject({
+      activeCallers: 0,
+      activeEntries: 0,
+    });
+    db.$client.close();
+  });
+
+  it("cleans timeout, reached, unreachable, and close outcomes", async () => {
+    const timeoutSetup = setup();
+    await expect(
+      timeoutSetup.coordinator.wait({
+        target: { kind: "status", status: "idle" },
+        threadId: timeoutSetup.threadId,
+        timeoutMs: 0,
+      }),
+    ).resolves.toEqual({ kind: "timeout" });
+    expect(timeoutSetup.coordinator.getStats()).toMatchObject({
+      activeCallers: 0,
+      activeEntries: 0,
+      timeoutCount: 1,
+    });
+    timeoutSetup.db.$client.close();
+
+    const reachedSetup = setup();
+    const reached = reachedSetup.coordinator.wait({
+      target: { kind: "status", status: "idle" },
+      threadId: reachedSetup.threadId,
+      timeoutMs: 10_000,
+    });
+    setThreadStatus(reachedSetup.db, reachedSetup.threadId, "idle");
+    reachedSetup.hub.notifyThread(reachedSetup.threadId, ["status-changed"]);
+    await expect(reached).resolves.toMatchObject({ kind: "status" });
+    expect(reachedSetup.coordinator.getStats().activeEntries).toBe(0);
+    reachedSetup.db.$client.close();
+
+    const unreachableSetup = setup({ status: "error" });
+    await expect(
+      unreachableSetup.coordinator.wait({
+        target: { kind: "status", status: "idle" },
+        threadId: unreachableSetup.threadId,
+        timeoutMs: 10_000,
+      }),
+    ).resolves.toMatchObject({ kind: "status", unreachable: true });
+    expect(unreachableSetup.coordinator.getStats()).toMatchObject({
+      activeEntries: 0,
+      unreachableCount: 1,
+    });
+    unreachableSetup.db.$client.close();
+
+    const closeSetup = setup();
+    const closed = closeSetup.coordinator.wait({
+      target: { kind: "status", status: "idle" },
+      threadId: closeSetup.threadId,
+      timeoutMs: 10_000,
+    });
+    closeSetup.coordinator.close();
+    await expect(closed).resolves.toEqual({ kind: "closed" });
+    expect(closeSetup.coordinator.getStats()).toMatchObject({
+      activeCallers: 0,
+      activeEntries: 0,
+    });
+    closeSetup.db.$client.close();
+  });
+
+  it("rejects caller and entry limits without leaking state", async () => {
+    const callerSetup = setup({ maxCallers: 1, maxEntries: 10 });
+    const controller = new AbortController();
+    const first = callerSetup.coordinator.wait({
+      signal: controller.signal,
+      target: { kind: "status", status: "idle" },
+      threadId: callerSetup.threadId,
+      timeoutMs: 10_000,
+    });
+    await expect(
+      callerSetup.coordinator.wait({
+        target: { kind: "status", status: "idle" },
+        threadId: callerSetup.threadId,
+        timeoutMs: 10_000,
+      }),
+    ).rejects.toBeInstanceOf(ThreadWaitCoordinatorLimitError);
+    controller.abort();
+    await Promise.allSettled([first]);
+    expect(callerSetup.coordinator.getStats()).toMatchObject({
+      activeCallers: 0,
+      activeEntries: 0,
+      limitRejectionCount: 1,
+    });
+    callerSetup.db.$client.close();
+
+    const entrySetup = setup({ maxCallers: 10, maxEntries: 1 });
+    const entryController = new AbortController();
+    const entryFirst = entrySetup.coordinator.wait({
+      signal: entryController.signal,
+      target: { kind: "status", status: "idle" },
+      threadId: entrySetup.threadId,
+      timeoutMs: 10_000,
+    });
+    await expect(
+      entrySetup.coordinator.wait({
+        target: { kind: "status", status: "error" },
+        threadId: entrySetup.threadId,
+        timeoutMs: 10_000,
+      }),
+    ).rejects.toBeInstanceOf(ThreadWaitCoordinatorLimitError);
+    entryController.abort();
+    await Promise.allSettled([entryFirst]);
+    expect(entrySetup.coordinator.getStats()).toMatchObject({
+      activeCallers: 0,
+      activeEntries: 0,
+      limitRejectionCount: 1,
+    });
+    entrySetup.db.$client.close();
+  });
+
+  it("counts and logs watcher cleanup failures", async () => {
+    const { coordinator, db, hub, threadId, warn } = setup();
+    const registerWatcher = hub.registerThreadEventWaiter.bind(hub);
+    vi.spyOn(hub, "registerThreadEventWaiter").mockImplementation(
+      (registeredThreadId, timeoutMs) => {
+        const watcher = registerWatcher(registeredThreadId, timeoutMs);
+        return {
+          promise: watcher.promise,
+          cancel: () => {
+            watcher.cancel();
+            throw new Error("cancel failed");
+          },
+        };
+      },
+    );
+
+    await expect(
+      coordinator.wait({
+        target: { kind: "status", status: "idle" },
+        threadId,
+        timeoutMs: 0,
+      }),
+    ).resolves.toEqual({ kind: "timeout" });
+    expect(coordinator.getStats()).toMatchObject({
+      activeCallers: 0,
+      activeEntries: 0,
+      cleanupFailureCount: 1,
+    });
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({ threadId }),
+      "Thread wait coordinator cleanup failed",
+    );
+    db.$client.close();
+  });
+});

--- a/docs/debugging-and-qa.md
+++ b/docs/debugging-and-qa.md
@@ -47,6 +47,31 @@ eval "$(scripts/bb-dev-app env)"
 pnpm bb:dev thread spawn --project proj_personal --provider codex --permission-mode accept-edits --title "Smoke test" --prompt "Reply only with ok." --json
 ```
 
+## Thread Wait Resource QA
+
+Start an active test thread before this check. Use one CLI process for 100
+duplicate logical waits:
+
+```bash
+eval "$(scripts/bb-dev-app env)"
+thread_id=<active-thread-id>
+wait_ids=()
+for _ in {1..100}; do wait_ids+=("$thread_id"); done
+pnpm bb:dev thread wait-many "${wait_ids[@]}" --output &
+wait_pid=$!
+rg '^(Pss|Private_Dirty):' "/proc/$wait_pid/smaps_rollup"
+pgrep -af '[b]b.*thread wait'
+wait "$wait_pid"
+```
+
+Confirm these results:
+
+- One Node CLI process serves the batch.
+- No second process waits for the same thread and target.
+- The server log reports 100 callers and one unique wait.
+- PSS and private dirty memory remain near one CLI process.
+- The process exits after it prints final output.
+
 ## Record Provider Bridge Traffic
 
 Export `BB_PROVIDER_BRIDGE_RECORD_DIR` before you start the dev app and every

--- a/packages/domain/src/thread-status.ts
+++ b/packages/domain/src/thread-status.ts
@@ -9,3 +9,10 @@ export const threadStatusValues = [
 ] as const;
 export const threadStatusSchema = z.enum(threadStatusValues);
 export type ThreadStatus = z.infer<typeof threadStatusSchema>;
+
+export function isThreadWaitTargetUnreachable(
+  currentStatus: ThreadStatus,
+  targetStatus: ThreadStatus,
+): boolean {
+  return targetStatus === "idle" && currentStatus === "error";
+}

--- a/packages/domain/src/thread.ts
+++ b/packages/domain/src/thread.ts
@@ -10,7 +10,11 @@ import {
 import { threadStatusSchema, threadStatusValues } from "./thread-status.js";
 import { threadOriginKindSchema } from "./thread-origin-kind.js";
 import { threadVisibilitySchema } from "./thread-visibility.js";
-export { threadStatusSchema, threadStatusValues } from "./thread-status.js";
+export {
+  isThreadWaitTargetUnreachable,
+  threadStatusSchema,
+  threadStatusValues,
+} from "./thread-status.js";
 export type { ThreadStatus } from "./thread-status.js";
 export {
   threadOriginKindSchema,

--- a/packages/sdk/src/areas/threads.ts
+++ b/packages/sdk/src/areas/threads.ts
@@ -1,5 +1,6 @@
 import {
   parseThreadEventRow,
+  isThreadWaitTargetUnreachable,
   type PromptInput,
   type PendingInteraction,
   type PendingInteractionResolution,
@@ -51,6 +52,7 @@ import type {
   SetQueuedMessageGroupBoundaryRequest,
   ThreadEventsQuery,
   ThreadEventWaitQuery,
+  ThreadStatusWaitQuery,
   ThreadGetQuery,
   ThreadListQuery,
   ThreadSearchQuery,
@@ -63,6 +65,7 @@ import type {
   UpdateQueuedMessageRequest,
 } from "@bb/server-contract";
 import { signalRequestArgs, type CreateSdkAreaArgs } from "./common.js";
+import { BbHttpError } from "../response.js";
 
 export const DEFAULT_THREAD_WAIT_TIMEOUT_MS = 20 * 60 * 1000;
 export const DEFAULT_THREAD_WAIT_POLL_INTERVAL_MS = 250;
@@ -283,6 +286,13 @@ export interface ThreadEventWaitArgs {
   signal?: AbortSignal;
   threadId: string;
   type: string;
+  waitMs: string;
+}
+
+interface ThreadStatusWaitArgs {
+  signal?: AbortSignal;
+  status: ThreadStatus;
+  threadId: string;
   waitMs: string;
 }
 
@@ -580,6 +590,13 @@ function eventWaitQuery(args: ThreadEventWaitArgs): ThreadEventWaitQuery {
   };
 }
 
+function statusWaitQuery(args: ThreadStatusWaitArgs): ThreadStatusWaitQuery {
+  return {
+    status: args.status,
+    waitMs: args.waitMs,
+  };
+}
+
 function searchQuery(args: ThreadSearchArgs): ThreadSearchQuery {
   return {
     limitPerGroup: args.limitPerGroup,
@@ -610,8 +627,26 @@ function timelineQuery(args: ThreadTimelineArgs): ThreadTimelineQuery {
   };
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) {
+    return Promise.reject(
+      new DOMException("The thread wait was aborted.", "AbortError"),
+    );
+  }
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      if (signal !== undefined) {
+        signal.removeEventListener("abort", onAbort);
+      }
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+      reject(new DOMException("The thread wait was aborted.", "AbortError"));
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 function resolveThreadWaitTarget(args: ThreadWaitArgs): ThreadWaitTarget {
@@ -661,14 +696,11 @@ function formatThreadWaitTimeoutMessage(args: {
   return `Timed out waiting for thread ${args.threadId} event ${args.target.eventType}.`;
 }
 
-function isThreadWaitTargetUnreachable(
-  currentStatus: ThreadStatus,
-  target: ThreadWaitTarget,
-): target is Extract<ThreadWaitTarget, { kind: "status" }> {
+function isMissingStatusWaitRoute(error: Error): boolean {
   return (
-    target.kind === "status" &&
-    target.status === "idle" &&
-    currentStatus === "error"
+    error instanceof BbHttpError &&
+    error.status === 404 &&
+    error.code === "not_found"
   );
 }
 
@@ -714,6 +746,22 @@ export function createThreadsArea(args: CreateSdkAreaArgs): ThreadsArea {
       }
       return parseThreadEventRow(await response.json());
     },
+  };
+  const waitForStatus = async (
+    input: ThreadStatusWaitArgs,
+  ): Promise<ThreadGetResult | null> => {
+    const response = await transport.resolve(
+      transport.api.v1.threads[":id"].wait.$get(
+        {
+          param: { id: input.threadId },
+          query: statusWaitQuery(input),
+        },
+        ...signalRequestArgs(input.signal),
+      ),
+    );
+    const statusCode: number = response.status;
+    if (statusCode === 204) return null;
+    return response.json();
   };
   const interactions: ThreadInteractionsArea = {
     async cancel(input) {
@@ -1182,8 +1230,53 @@ export function createThreadsArea(args: CreateSdkAreaArgs): ThreadsArea {
       const { pollIntervalMs, target, timeoutMs } =
         validateThreadWaitArgs(input);
       const deadline = Date.now() + timeoutMs;
-      while (true) {
-        if (target.kind === "status") {
+      if (target.kind === "status") {
+        let useLegacyPolling = false;
+        while (!useLegacyPolling) {
+          const remainingMs = Math.max(0, deadline - Date.now());
+          const waitMs = Math.floor(Math.min(remainingMs, 30_000));
+          let thread: ThreadGetResult | null;
+          try {
+            thread = await waitForStatus({
+              signal: input.signal,
+              status: target.status,
+              threadId: input.threadId,
+              waitMs: String(waitMs),
+            });
+          } catch (error) {
+            if (error instanceof Error && isMissingStatusWaitRoute(error)) {
+              useLegacyPolling = true;
+              break;
+            }
+            throw error;
+          }
+          if (thread !== null) {
+            if (thread.status === target.status) {
+              return {
+                matched: true,
+                target,
+                thread,
+                threadId: input.threadId,
+              };
+            }
+            if (isThreadWaitTargetUnreachable(thread.status, target.status)) {
+              throw new ThreadWaitUnreachableError({
+                currentStatus: thread.status,
+                target,
+                threadId: input.threadId,
+              });
+            }
+          }
+          if (Date.now() >= deadline) {
+            throw new ThreadWaitTimeoutError({
+              target,
+              threadId: input.threadId,
+            });
+          }
+          await sleep(pollIntervalMs, input.signal);
+        }
+
+        while (true) {
           const thread = await getThread({
             signal: input.signal,
             threadId: input.threadId,
@@ -1196,7 +1289,7 @@ export function createThreadsArea(args: CreateSdkAreaArgs): ThreadsArea {
               threadId: input.threadId,
             };
           }
-          if (isThreadWaitTargetUnreachable(thread.status, target)) {
+          if (isThreadWaitTargetUnreachable(thread.status, target.status)) {
             throw new ThreadWaitUnreachableError({
               currentStatus: thread.status,
               target,
@@ -1209,10 +1302,11 @@ export function createThreadsArea(args: CreateSdkAreaArgs): ThreadsArea {
               threadId: input.threadId,
             });
           }
-          await sleep(pollIntervalMs);
-          continue;
+          await sleep(pollIntervalMs, input.signal);
         }
+      }
 
+      while (true) {
         const remainingMs = Math.max(0, deadline - Date.now());
         const waitMs = Math.floor(Math.min(remainingMs, 30_000));
         const event = await events.wait({
@@ -1235,7 +1329,7 @@ export function createThreadsArea(args: CreateSdkAreaArgs): ThreadsArea {
             threadId: input.threadId,
           });
         }
-        await sleep(pollIntervalMs);
+        await sleep(pollIntervalMs, input.signal);
       }
     },
   };

--- a/packages/sdk/test/sdk.test.ts
+++ b/packages/sdk/test/sdk.test.ts
@@ -1,10 +1,13 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import type { Environment, JsonValue } from "@bb/domain";
 import { createBbSdk } from "../src/core.js";
 import { createHttpTransport } from "../src/transport-http.js";
-import { ThreadWaitTimeoutError } from "../src/areas/threads.js";
-import type { FetchImplementation } from "../src/response.js";
+import {
+  ThreadWaitTimeoutError,
+  ThreadWaitUnreachableError,
+} from "../src/areas/threads.js";
+import { BbHttpError, type FetchImplementation } from "../src/response.js";
 
 interface CapturedRequest {
   bodyText: string | undefined;
@@ -1586,7 +1589,7 @@ describe("@bb/sdk", () => {
 
   it("waits for a thread status through the shared SDK loop", async () => {
     const queue = createFetchQueue([
-      { body: { id: "thr_wait", status: "active" } },
+      { body: null, status: 204 },
       { body: { id: "thr_wait", status: "idle" } },
     ]);
     const sdk = createBbSdk({
@@ -1610,16 +1613,18 @@ describe("@bb/sdk", () => {
       threadId: "thr_wait",
     });
 
-    expect(queue.requests.map((request) => request.url)).toEqual([
-      "http://bb.test/api/v1/threads/thr_wait",
-      "http://bb.test/api/v1/threads/thr_wait",
-    ]);
+    expect(queue.requests).toHaveLength(2);
+    expect(
+      queue.requests.every((request) =>
+        request.url.startsWith(
+          "http://bb.test/api/v1/threads/thr_wait/wait?status=idle&waitMs=",
+        ),
+      ),
+    ).toBe(true);
   });
 
   it("throws a typed timeout error from thread wait", async () => {
-    const queue = createFetchQueue([
-      { body: { id: "thr_wait", status: "active" } },
-    ]);
+    const queue = createFetchQueue([{ body: null, status: 204 }]);
     const sdk = createBbSdk({
       transport: createHttpTransport({
         baseUrl: "http://bb.test",
@@ -1636,6 +1641,136 @@ describe("@bb/sdk", () => {
         pollIntervalMs: 1,
       }),
     ).rejects.toBeInstanceOf(ThreadWaitTimeoutError);
+  });
+
+  it("falls back to status polling only when the status wait route is absent", async () => {
+    const queue = createFetchQueue([
+      {
+        body: { code: "not_found", message: "Not found" },
+        status: 404,
+      },
+      { body: { id: "thr_wait", status: "active" } },
+      { body: { id: "thr_wait", status: "idle" } },
+    ]);
+    const sdk = createBbSdk({
+      transport: createHttpTransport({
+        baseUrl: "http://bb.test",
+        fetch: queue.fetch,
+        runtime: "node",
+      }),
+    });
+
+    await expect(
+      sdk.threads.wait({
+        pollIntervalMs: 1,
+        status: "idle",
+        threadId: "thr_wait",
+        timeoutMs: 1_000,
+      }),
+    ).resolves.toMatchObject({
+      matched: true,
+      target: { kind: "status", status: "idle" },
+    });
+    expect(queue.requests.map((request) => request.url)).toEqual([
+      expect.stringContaining("/threads/thr_wait/wait?status=idle&waitMs="),
+      "http://bb.test/api/v1/threads/thr_wait",
+      "http://bb.test/api/v1/threads/thr_wait",
+    ]);
+  });
+
+  it.each([
+    { code: "thread_not_found", status: 404 },
+    { code: "internal_error", status: 500 },
+  ])("does not poll after $status $code", async ({ code, status }) => {
+    const queue = createFetchQueue([
+      { body: { code, message: "Wait failed" }, status },
+    ]);
+    const sdk = createBbSdk({
+      transport: createHttpTransport({
+        baseUrl: "http://bb.test",
+        fetch: queue.fetch,
+        runtime: "node",
+      }),
+    });
+
+    await expect(
+      sdk.threads.wait({
+        pollIntervalMs: 1,
+        status: "idle",
+        threadId: "thr_wait",
+        timeoutMs: 1_000,
+      }),
+    ).rejects.toBeInstanceOf(BbHttpError);
+    expect(queue.requests).toHaveLength(1);
+  });
+
+  it("does not poll after a generic transport failure", async () => {
+    const failure = new TypeError("socket closed");
+    const fetchMock = vi.fn<FetchImplementation>(async () => {
+      throw failure;
+    });
+    const sdk = createBbSdk({
+      transport: createHttpTransport({
+        baseUrl: "http://bb.test",
+        fetch: fetchMock,
+        runtime: "node",
+      }),
+    });
+
+    await expect(
+      sdk.threads.wait({
+        pollIntervalMs: 1,
+        status: "idle",
+        threadId: "thr_wait",
+        timeoutMs: 1_000,
+      }),
+    ).rejects.toBe(failure);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves unreachable status semantics on the long-poll route", async () => {
+    const queue = createFetchQueue([
+      { body: { id: "thr_wait", status: "error" } },
+    ]);
+    const sdk = createBbSdk({
+      transport: createHttpTransport({
+        baseUrl: "http://bb.test",
+        fetch: queue.fetch,
+        runtime: "node",
+      }),
+    });
+
+    await expect(
+      sdk.threads.wait({
+        status: "idle",
+        threadId: "thr_wait",
+        timeoutMs: 1_000,
+      }),
+    ).rejects.toBeInstanceOf(ThreadWaitUnreachableError);
+  });
+
+  it("aborts during the pause between status long-poll rounds", async () => {
+    const queue = createFetchQueue([{ body: null, status: 204 }]);
+    const sdk = createBbSdk({
+      transport: createHttpTransport({
+        baseUrl: "http://bb.test",
+        fetch: queue.fetch,
+        runtime: "node",
+      }),
+    });
+    const controller = new AbortController();
+    const wait = sdk.threads.wait({
+      pollIntervalMs: 10_000,
+      signal: controller.signal,
+      status: "idle",
+      threadId: "thr_wait",
+      timeoutMs: 60_000,
+    });
+    await vi.waitFor(() => expect(queue.requests).toHaveLength(1));
+    controller.abort();
+
+    await expect(wait).rejects.toMatchObject({ name: "AbortError" });
+    expect(queue.requests).toHaveLength(1);
   });
 
   it("exposes installed skills and canonical registry installation", async () => {

--- a/packages/server-contract/src/api/threads.ts
+++ b/packages/server-contract/src/api/threads.ts
@@ -16,6 +16,7 @@ import {
   threadListEntrySchema,
   threadQueuedMessageSchema,
   threadSearchSourceKindSchema,
+  threadStatusSchema,
   threadTimelineActivePromptModeSchema,
   threadTimelineGoalSchema,
   threadTimelineModelFallbackSchema,
@@ -661,6 +662,12 @@ export const threadEventWaitQuerySchema = z.object({
   waitMs: z.string().regex(/^\d+$/).optional(),
 });
 export type ThreadEventWaitQuery = z.infer<typeof threadEventWaitQuerySchema>;
+
+export const threadStatusWaitQuerySchema = z.object({
+  status: threadStatusSchema,
+  waitMs: z.string().regex(/^\d+$/).optional(),
+});
+export type ThreadStatusWaitQuery = z.infer<typeof threadStatusWaitQuerySchema>;
 
 export const threadStorageFilesQuerySchema = z
   .object({

--- a/packages/server-contract/src/public-api.ts
+++ b/packages/server-contract/src/public-api.ts
@@ -168,6 +168,7 @@ import type {
   ThreadArchiveAllResponse,
   ThreadChildSummaryResponse,
   ThreadEventWaitQuery,
+  ThreadStatusWaitQuery,
   ThreadEventsQuery,
   ThreadSectionMutationResponse,
   ThreadSectionResponse,
@@ -279,6 +280,7 @@ import {
   systemUsageLimitsQuerySchema,
   systemVersionQuerySchema,
   threadEventWaitQuerySchema,
+  threadStatusWaitQuerySchema,
   threadEventsQuerySchema,
   threadFilesRawQuerySchema,
   threadGetQuerySchema,
@@ -1225,6 +1227,14 @@ export const publicApiRoutes = {
         threadEventWaitQuerySchema,
       ),
       response: jsonResponse<ThreadEventRow | null>(),
+    }),
+    wait: defineRoute({
+      path: "/threads/:id/wait",
+      method: "get",
+      request: queryRequest<PathId, ThreadStatusWaitQuery>(
+        threadStatusWaitQuerySchema,
+      ),
+      response: jsonResponse<ThreadResponse | null>(),
     }),
     defaultExecutionOptions: defineRoute({
       path: "/threads/:id/default-execution-options",

--- a/packages/templates/src/templates/bb-guide-threads.md
+++ b/packages/templates/src/templates/bb-guide-threads.md
@@ -156,7 +156,16 @@ Inspecting:
     --status <status>                      Wait for this status
     --event <type>                         Wait for this event type
     --timeout <seconds>                    Timeout in seconds (default: 1200 / 20 min)
-    --poll-interval <ms>                   Polling interval in milliseconds
+    --poll-interval <ms>                   Legacy polling and long-poll pause in milliseconds
+    --output                               Get final output after a status match
+
+  bb thread wait-many <id...>              Wait for several threads in one process
+    --status <status>                      Apply one status target to every thread
+    --event <type>                         Apply one event target to every thread
+    --timeout <seconds>                    Timeout for each thread
+    --poll-interval <ms>                   Legacy polling and long-poll pause in milliseconds
+    --output                               Get final output after each status match
+    --json                                 Print one JSON line for each completed wait
 
 Opening threads and files in the app:
 


### PR DESCRIPTION
## Summary

Fixes excessive memory and request load from `bb thread wait`.

- **Server**: new reference-counted wait coordinator keyed by `(threadId, target, cursor)`. Identical waits share one `NotificationHub` subscription and one coalesced DB re-check. Per-caller deadlines, abort cleanup, caller limits, pino observability with an `unref()`ed summary timer, and a stats accessor.
- **Route**: new `GET /api/v1/threads/:id/wait?status=...` long-poll (404 `thread_not_found` for missing threads). The existing `events/wait` route is refactored onto the coordinator with its response contract preserved.
- **SDK**: status waits long-poll the new route instead of client-side 250 ms polling. Fallback to the legacy polling loop triggers only on `BbHttpError` `status 404` + `code not_found` (route absent on older servers). The wait sleep is now abort-aware. `pollIntervalMs` governs only the fallback path.
- **CLI**: `bb thread wait --output` (one blocking follow returning terminal status + final output), `bb thread wait-many` (many logical waits in one process), and lazy-loaded thread subcommands. Existing wait messages, JSON shapes, and exit codes unchanged.
- **Guidance/docs**: builtin skills no longer teach log/wait alternation; changelog documents rollout compatibility; QA runbook adds PSS measurement.

## Motivation & measured impact

On a production host, orchestration bursts spawned duplicate `bb thread wait` processes, each a full Node/V8 runtime polling every 250 ms:

- Old CLI waiter: 150–174 MiB RSS / 99–122 MiB PSS each (mostly private dirty), 4 status GETs/s per waiter, each ~6 DB operations.
- New CLI waiter: 48 MiB RSS / 12 MiB PSS (standalone measurement).
- Live end-to-end demo against this branch: 20 concurrent CLI waiters → 1 coordinator entry, 20 total HTTP requests for the whole wait, one shared DB re-check on the status flip, all 20 resolved within 77–133 ms, zero leaked callers/entries. Old CLI in the same harness: 3.8 GETs/s per waiter.

## Compatibility

- Old CLI + new server: keeps working (route addition only).
- New CLI + old server: degrades to the legacy polling loop via the narrow 404 fallback.
- Timeout semantics, `--status`/`--event` targets, JSON output, and exit codes are preserved.

## Testing

- apps/server: 2083 passed / packages/sdk: 102 passed / apps/cli: 513 passed, 0 failed, no new skips.
- Five deliberate mutations (broken dedup, shared abort, broad fallback, non-abortable sleep, wait-after-output) are each caught by the new tests.
- 100-duplicate-wait stress tests assert one coordinator entry, bounded checks, and full cleanup across timeout, cancellation, disconnect, unreachable, and error paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)