### PR TITLE
Add an opt-in PDF download opener

### DIFF
--- a/apps/app/src/components/plugin/ExperimentalFileLinkMenu.tsx
+++ b/apps/app/src/components/plugin/ExperimentalFileLinkMenu.tsx
@@ -47,9 +47,22 @@ export function ExperimentalFileLinkMenu({
 
   return (
     <>
-      <ContextMenuItem onSelect={() => navigation.openFilePreview(intent)}>
+      <ContextMenuItem
+        onSelect={() =>
+          navigation.openFilePreview({ ...intent, viewer: "builtin" })
+        }
+      >
         Open preview
       </ContextMenuItem>
+      {extension === "pdf" ? (
+        <ContextMenuItem
+          onSelect={() =>
+            navigation.openFilePreview({ ...intent, viewer: "download" })
+          }
+        >
+          Download PDF
+        </ContextMenuItem>
+      ) : null}
       {matchingOpeners.length > 0 ? (
         <ContextMenuSub>
           <ContextMenuSubTrigger>Open with</ContextMenuSubTrigger>

--- a/apps/app/src/components/plugin/ExperimentalFileLinkMenu.tsx
+++ b/apps/app/src/components/plugin/ExperimentalFileLinkMenu.tsx
@@ -54,15 +54,6 @@ export function ExperimentalFileLinkMenu({
       >
         Open preview
       </ContextMenuItem>
-      {extension === "pdf" ? (
-        <ContextMenuItem
-          onSelect={() =>
-            navigation.openFilePreview({ ...intent, viewer: "download" })
-          }
-        >
-          Download PDF
-        </ContextMenuItem>
-      ) : null}
       {matchingOpeners.length > 0 ? (
         <ContextMenuSub>
           <ContextMenuSubTrigger>Open with</ContextMenuSubTrigger>

--- a/apps/app/src/components/plugin/PluginPanelRightPanelHost.tsx
+++ b/apps/app/src/components/plugin/PluginPanelRightPanelHost.tsx
@@ -70,6 +70,8 @@ import { getBrowserUrlHost } from "@/lib/browser-url";
 import { isRoutePath } from "@/lib/route-paths";
 import { UrlOpenRoutingProvider } from "@/lib/url-open-routing";
 import { usePluginSlots } from "@/lib/plugin-slots";
+import { useFileOpenerPreferenceValue } from "@/lib/file-opener-preference";
+import { shouldDownloadWithFileOpenerPreference } from "@/lib/plugin-slot-resolvers";
 import {
   AppNavigationHostProvider,
   type AppFilePreviewIntent,
@@ -365,6 +367,7 @@ export function PluginPanelRightPanelHost({
     storageFiles: undefined,
     terminalSessions: undefined,
   });
+  const fileOpenerPreference = useFileOpenerPreferenceValue();
   const createTerminal = useCreateTerminal();
   const { mutateAsync: closeTerminal } = useCloseTerminal();
   const hostsQuery = useHosts();
@@ -512,6 +515,11 @@ export function PluginPanelRightPanelHost({
       selectPersistedPanelTab();
       const lineRange = toFilePreviewLineRange(normalized.location);
       const { target } = normalized;
+      const expectsDownload = shouldDownloadWithFileOpenerPreference({
+        path: target.path,
+        preference: fileOpenerPreference,
+        ...(intent.viewer !== undefined ? { override: intent.viewer } : {}),
+      });
       const tab =
         target.kind === "workspace"
           ? openTab(
@@ -544,11 +552,11 @@ export function PluginPanelRightPanelHost({
                 },
                 { viewer: intent.viewer },
               );
-      if (tab === null) return false;
+      if (tab === null) return expectsDownload;
       revealPanel();
       return true;
     },
-    [openTab, panel, revealPanel, selectPersistedPanelTab],
+    [fileOpenerPreference, openTab, panel, revealPanel, selectPersistedPanelTab],
   );
   const navigationCapabilities = useMemo(
     () => ({ openFilePreview, openFixedTab }),

--- a/apps/app/src/components/secondary-panel/useThreadFileTabs.test.ts
+++ b/apps/app/src/components/secondary-panel/useThreadFileTabs.test.ts
@@ -1436,8 +1436,18 @@ describe("useThreadFileTabs file opener diversion", () => {
     });
   });
 
-  it("downloads workspace, host, and thread-storage files without opening tabs", () => {
+  it("downloads workspace, host, and thread-storage files without opening tabs", async () => {
     const downloadUrls: string[] = [];
+    const fetchMock = vi.fn((_input: RequestInfo | URL) =>
+      Promise.resolve(new Response("%PDF", { status: 200 })),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const createObjectUrl = vi
+      .spyOn(URL, "createObjectURL")
+      .mockReturnValue("blob:download");
+    const revokeObjectUrl = vi
+      .spyOn(URL, "revokeObjectURL")
+      .mockImplementation(() => {});
     const click = vi
       .spyOn(HTMLAnchorElement.prototype, "click")
       .mockImplementation(function (this: HTMLAnchorElement) {
@@ -1488,8 +1498,8 @@ describe("useThreadFileTabs file opener diversion", () => {
     );
 
     expect(
-      downloadUrls.map((url) => {
-        const parsed = new URL(url);
+      fetchMock.mock.calls.map(([url]) => {
+        const parsed = new URL(String(url), window.location.origin);
         return `${parsed.pathname}?${parsed.searchParams.toString()}`;
       }),
     ).toEqual([
@@ -1497,13 +1507,32 @@ describe("useThreadFileTabs file opener diversion", () => {
       "/api/v1/threads/thr_download/host-files/content?disposition=attachment&path=%2Ftmp%2Fhost.pdf",
       "/api/v1/threads/thr_download/thread-storage/content?disposition=attachment&path=reports%2Fstorage.pdf",
     ]);
+    await waitFor(() => expect(downloadUrls).toHaveLength(3));
+    expect(downloadUrls).toEqual([
+      "blob:download",
+      "blob:download",
+      "blob:download",
+    ]);
     expect(result.current.orderedSecondaryFileTabs).toEqual([]);
     expect(document.querySelector("a[download]")).toBeNull();
     click.mockRestore();
+    createObjectUrl.mockRestore();
+    revokeObjectUrl.mockRestore();
+    vi.unstubAllGlobals();
   });
 
-  it("uses the saved PDF download opener while preserving explicit preview", () => {
+  it("uses the saved PDF download opener while preserving explicit preview", async () => {
     const downloadUrls: string[] = [];
+    const fetchMock = vi.fn((_input: RequestInfo | URL) =>
+      Promise.resolve(new Response("%PDF", { status: 200 })),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const createObjectUrl = vi
+      .spyOn(URL, "createObjectURL")
+      .mockReturnValue("blob:download-preference");
+    const revokeObjectUrl = vi
+      .spyOn(URL, "revokeObjectURL")
+      .mockImplementation(() => {});
     const click = vi
       .spyOn(HTMLAnchorElement.prototype, "click")
       .mockImplementation(function (this: HTMLAnchorElement) {
@@ -1538,7 +1567,7 @@ describe("useThreadFileTabs file opener diversion", () => {
         },
       }),
     );
-    expect(downloadUrls).toHaveLength(1);
+    await waitFor(() => expect(downloadUrls).toHaveLength(1));
     expect(result.current.tabs.orderedSecondaryFileTabs).toEqual([]);
 
     act(() =>
@@ -1560,6 +1589,9 @@ describe("useThreadFileTabs file opener diversion", () => {
       "reports/preview.pdf",
     );
     click.mockRestore();
+    createObjectUrl.mockRestore();
+    revokeObjectUrl.mockRestore();
+    vi.unstubAllGlobals();
   });
 });
 

--- a/apps/app/src/components/secondary-panel/useThreadFileTabs.test.ts
+++ b/apps/app/src/components/secondary-panel/useThreadFileTabs.test.ts
@@ -29,6 +29,10 @@ import {
 } from "@/lib/plugin-slots";
 import { makeTerminalSession as terminalSession } from "@/test/fixtures/terminal-sessions";
 import { makePluginRegistrationSet } from "@/test/fixtures/plugins";
+import {
+  DOWNLOAD_FILE_OPENER_PREFERENCE,
+  useFileOpenerPreference,
+} from "@/lib/file-opener-preference";
 
 const syncMocks = vi.hoisted(() => ({
   scheduleLocalThreadTabsMigration: vi.fn(),
@@ -1430,6 +1434,132 @@ describe("useThreadFileTabs file opener diversion", () => {
       actionId: "file-opener:editor",
       title: "other.md",
     });
+  });
+
+  it("downloads workspace, host, and thread-storage files without opening tabs", () => {
+    const downloadUrls: string[] = [];
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(function (this: HTMLAnchorElement) {
+        downloadUrls.push(this.href);
+      });
+    const { result } = renderThreadHook(() =>
+      useThreadFileTabs({
+        panelStateId: "download-opener",
+        syncThreadId: "thr_download",
+        environmentId: "env_download",
+        projectId: "proj_download",
+        storageFiles: undefined,
+        terminalSessions: undefined,
+      }),
+    );
+
+    act(() =>
+      result.current.openTab(
+        {
+          kind: "workspace-file-preview",
+          tab: {
+            lineRange: null,
+            path: "reports/workspace.pdf",
+            source: { kind: "working-tree" },
+            statusLabel: null,
+          },
+        },
+        { viewer: "download" },
+      ),
+    );
+    act(() =>
+      result.current.openTab(
+        {
+          kind: "host-file-preview",
+          tab: { lineRange: null, path: "/tmp/host.pdf" },
+        },
+        { viewer: "download" },
+      ),
+    );
+    act(() =>
+      result.current.openTab(
+        {
+          kind: "thread-storage-file-preview",
+          tab: { lineRange: null, path: "reports/storage.pdf" },
+        },
+        { viewer: "download" },
+      ),
+    );
+
+    expect(
+      downloadUrls.map((url) => {
+        const parsed = new URL(url);
+        return `${parsed.pathname}?${parsed.searchParams.toString()}`;
+      }),
+    ).toEqual([
+      "/api/v1/projects/proj_download/files/content?disposition=attachment&path=reports%2Fworkspace.pdf&environmentId=env_download",
+      "/api/v1/threads/thr_download/host-files/content?disposition=attachment&path=%2Ftmp%2Fhost.pdf",
+      "/api/v1/threads/thr_download/thread-storage/content?disposition=attachment&path=reports%2Fstorage.pdf",
+    ]);
+    expect(result.current.orderedSecondaryFileTabs).toEqual([]);
+    expect(document.querySelector("a[download]")).toBeNull();
+    click.mockRestore();
+  });
+
+  it("uses the saved PDF download opener while preserving explicit preview", () => {
+    const downloadUrls: string[] = [];
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(function (this: HTMLAnchorElement) {
+        downloadUrls.push(this.href);
+      });
+    const { result } = renderThreadHook(() => {
+      const [, setPreference] = useFileOpenerPreference();
+      const tabs = useThreadFileTabs({
+        panelStateId: "download-preference",
+        syncThreadId: "thr_download_preference",
+        environmentId: "env_download_preference",
+        projectId: "proj_download_preference",
+        storageFiles: undefined,
+        terminalSessions: undefined,
+      });
+      return { setPreference, tabs };
+    });
+
+    act(() => {
+      result.current.setPreference({
+        pdf: DOWNLOAD_FILE_OPENER_PREFERENCE,
+      });
+    });
+    act(() =>
+      result.current.tabs.openTab({
+        kind: "workspace-file-preview",
+        tab: {
+          lineRange: null,
+          path: "reports/default.pdf",
+          source: { kind: "working-tree" },
+          statusLabel: null,
+        },
+      }),
+    );
+    expect(downloadUrls).toHaveLength(1);
+    expect(result.current.tabs.orderedSecondaryFileTabs).toEqual([]);
+
+    act(() =>
+      result.current.tabs.openTab(
+        {
+          kind: "workspace-file-preview",
+          tab: {
+            lineRange: null,
+            path: "reports/preview.pdf",
+            source: { kind: "working-tree" },
+            statusLabel: null,
+          },
+        },
+        { viewer: "builtin" },
+      ),
+    );
+    expect(downloadUrls).toHaveLength(1);
+    expect(result.current.tabs.activeWorkspaceFilePath).toBe(
+      "reports/preview.pdf",
+    );
+    click.mockRestore();
   });
 });
 

--- a/apps/app/src/components/secondary-panel/useThreadFileTabs.ts
+++ b/apps/app/src/components/secondary-panel/useThreadFileTabs.ts
@@ -37,7 +37,14 @@ import {
   fileOpenerIdFromActionId,
   parseFileOpenerParams,
 } from "@/components/plugin/file-opener-tabs";
-import type { FileOpenerOverride } from "@/lib/plugin-slot-resolvers";
+import {
+  shouldDownloadWithFileOpenerPreference,
+  type FileOpenerOverride,
+} from "@/lib/plugin-slot-resolvers";
+import {
+  downloadFileForOpenRequest,
+  getFileOpenRequestPath,
+} from "@/lib/file-download";
 import type { OpenPluginPanelArgs } from "@/components/plugin/PluginPanelActions";
 import type {
   HostFileTabState,
@@ -635,6 +642,24 @@ export function useThreadFileTabs({
       behavior: OpenResolvedTabBehavior,
       viewer?: FileOpenerOverride,
     ): SecondaryPanelTab | null => {
+      const path = getFileOpenRequestPath(request);
+      if (
+        path !== null &&
+        shouldDownloadWithFileOpenerPreference({
+          path,
+          preference: fileOpenerPreference,
+          ...(viewer !== undefined ? { override: viewer } : {}),
+        }) &&
+        downloadFileForOpenRequest({
+          projectHostId,
+          projectId,
+          request,
+          resolvedEnvironmentId,
+          threadId: resolvedFileOwnerThreadId,
+        })
+      ) {
+        return null;
+      }
       const openerTab = createFileOpenerTabForRequest({
         fileOpeners,
         preference: fileOpenerPreference,

--- a/apps/app/src/components/settings/FileOpenersSettingsSection.test.tsx
+++ b/apps/app/src/components/settings/FileOpenersSettingsSection.test.tsx
@@ -6,7 +6,10 @@ import {
   resetPluginSlotStoreForTest,
   setPluginSlotRegistrations,
 } from "@/lib/plugin-slots";
-import { BUILT_IN_FILE_OPENER_PREFERENCE } from "@/lib/file-opener-preference";
+import {
+  BUILT_IN_FILE_OPENER_PREFERENCE,
+  DOWNLOAD_FILE_OPENER_PREFERENCE,
+} from "@/lib/file-opener-preference";
 import { FileOpenersSettingsSection } from "./FileOpenersSettingsSection";
 import { makePluginRegistrationSet } from "@/test/fixtures/plugins";
 
@@ -33,6 +36,20 @@ afterEach(() => {
 });
 
 describe("FileOpenersSettingsSection", () => {
+  it("offers preview and download for PDFs without requiring a plugin", async () => {
+    render(<FileOpenersSettingsSection />);
+
+    const trigger = screen.getByRole("button", {
+      name: "Default opener for .pdf files",
+    });
+    expect(trigger.textContent).toContain("Built-in preview");
+
+    await selectOption(trigger, /^Download$/u);
+    expect(storedPreference()).toEqual({
+      pdf: DOWNLOAD_FILE_OPENER_PREFERENCE,
+    });
+  });
+
   it("defaults to automatic and persists built-in, plugin, and automatic choices", async () => {
     registerNotesOpener();
     render(<FileOpenersSettingsSection />);

--- a/apps/app/src/components/settings/FileOpenersSettingsSection.tsx
+++ b/apps/app/src/components/settings/FileOpenersSettingsSection.tsx
@@ -49,7 +49,7 @@ export function FileOpenersSettingsSection() {
   return (
     <SettingsSection
       title="File openers"
-      description="Automatically use matching plugins, or choose a viewer for each file type. Right-click a file link for a one-off choice."
+      description="Automatically use matching plugins, or choose a viewer for each file type. Thread file links offer one-off choices."
     >
       <div className="space-y-5">
         {extensions.map((extension) => (

--- a/apps/app/src/components/settings/FileOpenersSettingsSection.tsx
+++ b/apps/app/src/components/settings/FileOpenersSettingsSection.tsx
@@ -14,6 +14,7 @@ import {
 import { COARSE_POINTER_ICON_SIZE_CLASS } from "@bb/shared-ui/coarse-pointer-sizing";
 import {
   BUILT_IN_FILE_OPENER_PREFERENCE,
+  DOWNLOAD_FILE_OPENER_PREFERENCE,
   buildFileOpenerRef,
   useFileOpenerPreference,
 } from "@/lib/file-opener-preference";
@@ -26,6 +27,7 @@ import {
 
 const AUTOMATIC_FILE_OPENER_PREFERENCE = "__automatic__";
 const BUILTIN_LABEL = "Built-in preview";
+const BUILT_IN_FILE_OPENER_EXTENSIONS = ["pdf"];
 
 export function FileOpenersSettingsSection() {
   const { fileOpeners } = usePluginSlots();
@@ -33,7 +35,12 @@ export function FileOpenersSettingsSection() {
 
   const extensions = useMemo(
     () =>
-      [...new Set(fileOpeners.flatMap((opener) => opener.extensions))].sort(),
+      [
+        ...new Set([
+          ...BUILT_IN_FILE_OPENER_EXTENSIONS,
+          ...fileOpeners.flatMap((opener) => opener.extensions),
+        ]),
+      ].sort(),
     [fileOpeners],
   );
 
@@ -53,7 +60,12 @@ export function FileOpenersSettingsSection() {
               opener.extensions.includes(extension),
             )}
             preference={
-              preference[extension] ?? AUTOMATIC_FILE_OPENER_PREFERENCE
+              preference[extension] ??
+              (fileOpeners.some((opener) =>
+                opener.extensions.includes(extension),
+              )
+                ? AUTOMATIC_FILE_OPENER_PREFERENCE
+                : BUILT_IN_FILE_OPENER_PREFERENCE)
             }
             onSelect={(selection) =>
               setPreference((previous) => {
@@ -85,21 +97,28 @@ function ExtensionOpenerControl({
   preference: string;
 }) {
   const automaticOpener = openers[0];
-  if (automaticOpener === undefined) return null;
 
   const options = [
-    {
-      key: AUTOMATIC_FILE_OPENER_PREFERENCE,
-      label: `Automatic (${automaticOpener.title})`,
-    },
+    ...(automaticOpener === undefined
+      ? []
+      : [
+          {
+            key: AUTOMATIC_FILE_OPENER_PREFERENCE,
+            label: `Automatic (${automaticOpener.title})`,
+          },
+        ]),
     { key: BUILT_IN_FILE_OPENER_PREFERENCE, label: BUILTIN_LABEL },
+    ...(extension === "pdf"
+      ? [{ key: DOWNLOAD_FILE_OPENER_PREFERENCE, label: "Download" }]
+      : []),
     ...openers.map((opener) => ({
       key: buildFileOpenerRef(opener),
       label: `${opener.title} (${opener.pluginId})`,
     })),
   ];
   const selected =
-    options.find((option) => option.key === preference) ?? options[1];
+    options.find((option) => option.key === preference) ??
+    options.find((option) => option.key === BUILT_IN_FILE_OPENER_PREFERENCE);
   if (selected === undefined) return null;
 
   return (

--- a/apps/app/src/lib/file-content-urls.ts
+++ b/apps/app/src/lib/file-content-urls.ts
@@ -21,11 +21,12 @@ export function buildProjectFileContentUrl(
   projectId: string,
   path: string,
   routing: { environmentId?: string; hostId?: string } = {},
+  disposition?: "attachment",
 ): string {
   return toRelativeUrl(
     apiClient.projects[":id"].files.content.$url({
       param: { id: projectId },
-      query: { path, ...routing },
+      query: { disposition, path, ...routing },
     }),
   );
 }
@@ -33,11 +34,12 @@ export function buildProjectFileContentUrl(
 export function buildThreadStorageContentUrl(
   threadId: string,
   path: string,
+  disposition?: "attachment",
 ): string {
   return toRelativeUrl(
     apiClient.threads[":id"]["thread-storage"].content.$url({
       param: { id: threadId },
-      query: { path },
+      query: { disposition, path },
     }),
   );
 }
@@ -56,11 +58,12 @@ export function buildThreadStorageRawContentUrl(
 export function buildThreadHostFileContentUrl(
   threadId: string,
   path: string,
+  disposition?: "attachment",
 ): string {
   return toRelativeUrl(
     apiClient.threads[":id"]["host-files"].content.$url({
       param: { id: threadId },
-      query: { path },
+      query: { disposition, path },
     }),
   );
 }

--- a/apps/app/src/lib/file-download.test.ts
+++ b/apps/app/src/lib/file-download.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+
+import { waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { downloadFileForOpenRequest } from "./file-download";
+
+const toastMocks = vi.hoisted(() => ({ error: vi.fn() }));
+
+vi.mock("@/components/ui/app-toast", () => ({
+  appToast: toastMocks,
+}));
+
+afterEach(() => {
+  toastMocks.error.mockReset();
+  vi.unstubAllGlobals();
+});
+
+describe("downloadFileForOpenRequest", () => {
+  it("reports an HTTP failure without saving the response body", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("too large", { status: 413 })),
+    );
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => {});
+
+    expect(
+      downloadFileForOpenRequest({
+        projectHostId: null,
+        projectId: null,
+        request: {
+          kind: "host-file-preview",
+          tab: { lineRange: null, path: "/tmp/report.pdf" },
+        },
+        resolvedEnvironmentId: "env_1",
+        threadId: "thr_1",
+      }),
+    ).toBe(true);
+
+    await waitFor(() =>
+      expect(toastMocks.error).toHaveBeenCalledWith("Failed to download file", {
+        description: "Download failed with status 413",
+      }),
+    );
+    expect(click).not.toHaveBeenCalled();
+    click.mockRestore();
+  });
+
+  it("refuses an unresolved workspace target instead of using the primary source", () => {
+    expect(
+      downloadFileForOpenRequest({
+        projectHostId: null,
+        projectId: "proj_1",
+        request: {
+          kind: "workspace-file-preview",
+          tab: {
+            lineRange: null,
+            path: "report.pdf",
+            source: { kind: "working-tree" },
+            statusLabel: null,
+          },
+        },
+        resolvedEnvironmentId: undefined,
+        threadId: "thr_1",
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/app/src/lib/file-download.test.ts
+++ b/apps/app/src/lib/file-download.test.ts
@@ -47,6 +47,28 @@ describe("downloadFileForOpenRequest", () => {
     click.mockRestore();
   });
 
+  it("explains why an explicit host target falls back to preview", () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    expect(
+      downloadFileForOpenRequest({
+        projectHostId: null,
+        projectId: null,
+        request: {
+          kind: "host-file-preview",
+          hostId: "host_other",
+          tab: { lineRange: null, path: "/tmp/report.pdf" },
+        },
+        resolvedEnvironmentId: "env_1",
+        threadId: "thr_1",
+      }),
+    ).toBe(false);
+    expect(fetch).not.toHaveBeenCalled();
+    expect(toastMocks.error).toHaveBeenCalledWith("Download unavailable", {
+      description: "This file location does not support downloads.",
+    });
+  });
+
   it("refuses an unresolved workspace target instead of using the primary source", () => {
     expect(
       downloadFileForOpenRequest({

--- a/apps/app/src/lib/file-download.ts
+++ b/apps/app/src/lib/file-download.ts
@@ -1,0 +1,92 @@
+import type { OpenSecondaryPanelTabRequest } from "@/components/secondary-panel/useThreadFileTabs";
+import {
+  buildProjectFileContentUrl,
+  buildThreadHostFileContentUrl,
+  buildThreadStorageContentUrl,
+} from "./file-content-urls";
+
+interface DownloadFileForOpenRequestArgs {
+  projectHostId: string | null;
+  projectId: string | null;
+  request: OpenSecondaryPanelTabRequest;
+  resolvedEnvironmentId: string | null | undefined;
+  threadId: string | null | undefined;
+}
+
+export function getFileOpenRequestPath(
+  request: OpenSecondaryPanelTabRequest,
+): string | null {
+  return request.kind === "workspace-file-preview" ||
+    request.kind === "host-file-preview" ||
+    request.kind === "thread-storage-file-preview"
+    ? request.tab.path
+    : null;
+}
+
+function buildFileDownloadUrl({
+  projectHostId,
+  projectId,
+  request,
+  resolvedEnvironmentId,
+  threadId,
+}: DownloadFileForOpenRequestArgs): string | null {
+  if (request.kind === "workspace-file-preview") {
+    if (
+      projectId === null ||
+      request.tab.source.kind !== "working-tree" ||
+      request.tab.statusLabel === "deleted"
+    ) {
+      return null;
+    }
+    const environmentId =
+      request.environmentId ?? resolvedEnvironmentId ?? null;
+    return buildProjectFileContentUrl(
+      projectId,
+      request.tab.path,
+      environmentId !== null
+        ? { environmentId }
+        : projectHostId === null
+          ? {}
+          : { hostId: projectHostId },
+      "attachment",
+    );
+  }
+
+  if (request.kind === "host-file-preview") {
+    if (request.hostId !== undefined || !threadId) return null;
+    return buildThreadHostFileContentUrl(
+      threadId,
+      request.tab.path,
+      "attachment",
+    );
+  }
+
+  if (request.kind === "thread-storage-file-preview") {
+    const storageThreadId = request.threadId ?? threadId;
+    return storageThreadId
+      ? buildThreadStorageContentUrl(
+          storageThreadId,
+          request.tab.path,
+          "attachment",
+        )
+      : null;
+  }
+
+  return null;
+}
+
+export function downloadFileForOpenRequest(
+  args: DownloadFileForOpenRequestArgs,
+): boolean {
+  const url = buildFileDownloadUrl(args);
+  const path = getFileOpenRequestPath(args.request);
+  if (url === null || path === null) return false;
+
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = path.split(/[\\/]/u).at(-1) ?? "download";
+  document.body.append(anchor);
+  anchor.click();
+  anchor.remove();
+  return true;
+}

--- a/apps/app/src/lib/file-download.ts
+++ b/apps/app/src/lib/file-download.ts
@@ -4,6 +4,7 @@ import {
   buildThreadHostFileContentUrl,
   buildThreadStorageContentUrl,
 } from "./file-content-urls";
+import { appToast } from "@/components/ui/app-toast";
 
 interface DownloadFileForOpenRequestArgs {
   projectHostId: string | null;
@@ -40,6 +41,7 @@ function buildFileDownloadUrl({
     }
     const environmentId =
       request.environmentId ?? resolvedEnvironmentId ?? null;
+    if (environmentId === null && projectHostId === null) return null;
     return buildProjectFileContentUrl(
       projectId,
       request.tab.path,
@@ -82,11 +84,26 @@ export function downloadFileForOpenRequest(
   const path = getFileOpenRequestPath(args.request);
   if (url === null || path === null) return false;
 
-  const anchor = document.createElement("a");
-  anchor.href = url;
-  anchor.download = path.split(/[\\/]/u).at(-1) ?? "download";
-  document.body.append(anchor);
-  anchor.click();
-  anchor.remove();
+  const filename = path.split(/[\\/]/u).at(-1) ?? "download";
+  void fetch(url)
+    .then(async (response) => {
+      if (!response.ok) {
+        throw new Error(`Download failed with status ${response.status}`);
+      }
+      const objectUrl = URL.createObjectURL(await response.blob());
+      const anchor = document.createElement("a");
+      anchor.href = objectUrl;
+      anchor.download = filename;
+      document.body.append(anchor);
+      anchor.click();
+      anchor.remove();
+      URL.revokeObjectURL(objectUrl);
+    })
+    .catch((error: unknown) => {
+      appToast.error("Failed to download file", {
+        description:
+          error instanceof Error ? error.message : "Unknown download error",
+      });
+    });
   return true;
 }

--- a/apps/app/src/lib/file-download.ts
+++ b/apps/app/src/lib/file-download.ts
@@ -82,7 +82,12 @@ export function downloadFileForOpenRequest(
 ): boolean {
   const url = buildFileDownloadUrl(args);
   const path = getFileOpenRequestPath(args.request);
-  if (url === null || path === null) return false;
+  if (url === null || path === null) {
+    appToast.error("Download unavailable", {
+      description: "This file location does not support downloads.",
+    });
+    return false;
+  }
 
   const filename = path.split(/[\\/]/u).at(-1) ?? "download";
   void fetch(url)

--- a/apps/app/src/lib/file-opener-preference.ts
+++ b/apps/app/src/lib/file-opener-preference.ts
@@ -3,12 +3,14 @@ import { useAtom, useAtomValue } from "jotai";
 import { createJsonLocalStorage } from "./browser-storage";
 import {
   BUILT_IN_FILE_OPENER_PREFERENCE,
+  DOWNLOAD_FILE_OPENER_PREFERENCE,
   buildFileOpenerRef,
   type FileOpenerPreferenceMap,
 } from "./plugin-slot-resolvers";
 
 export {
   BUILT_IN_FILE_OPENER_PREFERENCE,
+  DOWNLOAD_FILE_OPENER_PREFERENCE,
   buildFileOpenerRef,
   type FileOpenerPreferenceMap,
 };

--- a/apps/app/src/lib/plugin-slot-resolvers.test.ts
+++ b/apps/app/src/lib/plugin-slot-resolvers.test.ts
@@ -7,6 +7,7 @@ import type {
 } from "./plugin-slots";
 import {
   BUILT_IN_FILE_OPENER_PREFERENCE,
+  DOWNLOAD_FILE_OPENER_PREFERENCE,
   buildFileOpenerRef,
   resolveComposerActions,
   resolveComposerBanners,
@@ -17,6 +18,7 @@ import {
   resolveMessageDirectiveRegistry,
   resolvePendingInteraction,
   resolveReplacement,
+  shouldDownloadWithFileOpenerPreference,
 } from "./plugin-slot-resolvers";
 
 function Component() {
@@ -241,5 +243,30 @@ describe("replacement resolvers", () => {
         path: "README.md",
       }),
     ).toEqual({ kind: "owner" });
+  });
+
+  it("downloads only for the saved choice or an explicit one-off override", () => {
+    const preference = { pdf: DOWNLOAD_FILE_OPENER_PREFERENCE };
+
+    expect(
+      shouldDownloadWithFileOpenerPreference({
+        path: "report.PDF",
+        preference,
+      }),
+    ).toBe(true);
+    expect(
+      shouldDownloadWithFileOpenerPreference({
+        path: "report.pdf",
+        preference,
+        override: "builtin",
+      }),
+    ).toBe(false);
+    expect(
+      shouldDownloadWithFileOpenerPreference({
+        path: "notes.txt",
+        preference,
+        override: "download",
+      }),
+    ).toBe(true);
   });
 });

--- a/apps/app/src/lib/plugin-slot-resolvers.ts
+++ b/apps/app/src/lib/plugin-slot-resolvers.ts
@@ -266,11 +266,13 @@ export function resolveReplacement<Registration>(
 
 export type FileOpenerOverride =
   | "builtin"
+  | "download"
   | { pluginId: string; openerId: string };
 
 export type FileOpenerPreferenceMap = Record<string, string>;
 
 export const BUILT_IN_FILE_OPENER_PREFERENCE = "__builtin__";
+export const DOWNLOAD_FILE_OPENER_PREFERENCE = "__download__";
 
 export function getFileExtension(path: string): string | null {
   const name = path.split("/").at(-1) ?? path;
@@ -293,7 +295,9 @@ export function resolveFileOpenerReplacement(args: {
   override?: FileOpenerOverride;
 }): ResolvedReplacement<PluginFileOpenerSlot> {
   const override = args.override;
-  if (override === "builtin") return OWNER_REPLACEMENT;
+  if (override === "builtin" || override === "download") {
+    return OWNER_REPLACEMENT;
+  }
   if (override !== undefined) {
     return resolveReplacement(
       args.registrations,
@@ -306,7 +310,10 @@ export function resolveFileOpenerReplacement(args: {
   const extension = getFileExtension(args.path);
   if (extension === null) return OWNER_REPLACEMENT;
   const preference = args.preference?.[extension];
-  if (preference === BUILT_IN_FILE_OPENER_PREFERENCE) {
+  if (
+    preference === BUILT_IN_FILE_OPENER_PREFERENCE ||
+    preference === DOWNLOAD_FILE_OPENER_PREFERENCE
+  ) {
     return OWNER_REPLACEMENT;
   }
   return resolveReplacement(
@@ -315,5 +322,19 @@ export function resolveFileOpenerReplacement(args: {
       candidate.extensions.includes(extension) &&
       (preference === undefined ||
         buildFileOpenerRef(candidate) === preference),
+  );
+}
+
+export function shouldDownloadWithFileOpenerPreference(args: {
+  path: string;
+  preference: FileOpenerPreferenceMap;
+  override?: FileOpenerOverride;
+}): boolean {
+  if (args.override === "download") return true;
+  if (args.override !== undefined) return false;
+  const extension = getFileExtension(args.path);
+  return (
+    extension !== null &&
+    args.preference[extension] === DOWNLOAD_FILE_OPENER_PREFERENCE
   );
 }

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -2261,6 +2261,7 @@ function ThreadDetailViewInternal(props: ThreadRoutePathArgs) {
           : pluginFileOpeners.filter((opener) =>
               opener.extensions.includes(extension),
             );
+      const isPdf = extension === "pdf";
       const lineNumber = getFilePreviewLineRangeStart({
         lineRange: link.lineRange,
       });
@@ -2285,14 +2286,23 @@ function ThreadDetailViewInternal(props: ThreadRoutePathArgs) {
           type: "submenu",
         });
       }
-      if (matching.length > 0) {
+      if (isPdf || matching.length > 0) {
         if (items.length > 0) {
           items.push({ id: "open-with-separator", type: "separator" });
+        }
+        if (isPdf) {
+          items.push({
+            id: "download-pdf",
+            label: "Download PDF",
+            onSelect: () => {
+              handleOpenTimelineLocalFileLink(link, { viewer: "download" });
+            },
+          });
         }
         items.push(
           {
             id: "builtin",
-            label: "Open with built-in preview",
+            label: isPdf ? "Open preview" : "Open with built-in preview",
             onSelect: () => {
               handleOpenTimelineLocalFileLink(link, { viewer: "builtin" });
             },

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -711,6 +711,7 @@ function ThreadDetailViewInternal(props: ThreadRoutePathArgs) {
     syncThreadId: threadId,
     environmentId: thread?.environmentId,
     onCloseLastTab: secondaryPanelDrawerVisibility.closeDrawer,
+    projectId,
     retainedTerminalId,
     storageFileExists: checkThreadStorageFileExists,
     storageFiles: threadStorageFiles,

--- a/apps/server/src/routes/projects.ts
+++ b/apps/server/src/routes/projects.ts
@@ -610,9 +610,15 @@ export function registerProjectRoutes(app: Hono, deps: AppDeps): void {
       (result) =>
         createDaemonFileContentResponse(result, {
           headers: {
- ...(query.disposition === "attachment" ? { "content-disposition": buildAttachmentContentDisposition(query.path) } : {}),
- "x-bb-content-encoding": result.contentEncoding,
- },
+            ...(query.disposition === "attachment"
+              ? {
+                  "content-disposition": buildAttachmentContentDisposition(
+                    query.path,
+                  ),
+                }
+              : {}),
+            "x-bb-content-encoding": result.contentEncoding,
+          },
           ifNoneMatch: context.req.header("if-none-match"),
         }),
     );

--- a/apps/server/src/routes/projects.ts
+++ b/apps/server/src/routes/projects.ts
@@ -61,6 +61,7 @@ import {
   writeProjectSkill,
 } from "../services/skills/skill-listing.js";
 import {
+  buildAttachmentContentDisposition,
   createDaemonFileContentResponse,
   serveDaemonFileContent,
   requestMatchesEntityTag,
@@ -608,7 +609,10 @@ export function registerProjectRoutes(app: Hono, deps: AppDeps): void {
       },
       (result) =>
         createDaemonFileContentResponse(result, {
-          headers: { "x-bb-content-encoding": result.contentEncoding },
+          headers: {
+ ...(query.disposition === "attachment" ? { "content-disposition": buildAttachmentContentDisposition(query.path) } : {}),
+ "x-bb-content-encoding": result.contentEncoding,
+ },
           ifNoneMatch: context.req.header("if-none-match"),
         }),
     );

--- a/apps/server/src/routes/threads/data.ts
+++ b/apps/server/src/routes/threads/data.ts
@@ -43,6 +43,7 @@ import {
 } from "../../services/lib/lifecycle-api-errors.js";
 import { callHostRetryableOnlineRpc } from "../../services/hosts/online-rpc.js";
 import {
+  buildAttachmentContentDisposition,
   createDaemonFileContentResponse,
   type DaemonFileReadResult,
   serveDaemonFileContent,
@@ -761,6 +762,7 @@ export function registerThreadDataRoutes(app: Hono, deps: AppDeps): void {
       },
       (result) =>
         createDaemonFileContentResponse(result, {
+ headers: query.disposition === "attachment" ? { "content-disposition": buildAttachmentContentDisposition(query.path) } : undefined,
           ifNoneMatch: context.req.header("if-none-match"),
         }),
     );
@@ -784,6 +786,7 @@ export function registerThreadDataRoutes(app: Hono, deps: AppDeps): void {
       },
       (result) =>
         createDaemonFileContentResponse(result, {
+ headers: query.disposition === "attachment" ? { "content-disposition": buildAttachmentContentDisposition(query.path) } : undefined,
           ifNoneMatch: context.req.header("if-none-match"),
         }),
     );

--- a/apps/server/src/routes/threads/data.ts
+++ b/apps/server/src/routes/threads/data.ts
@@ -762,7 +762,14 @@ export function registerThreadDataRoutes(app: Hono, deps: AppDeps): void {
       },
       (result) =>
         createDaemonFileContentResponse(result, {
- headers: query.disposition === "attachment" ? { "content-disposition": buildAttachmentContentDisposition(query.path) } : undefined,
+          headers:
+            query.disposition === "attachment"
+              ? {
+                  "content-disposition": buildAttachmentContentDisposition(
+                    query.path,
+                  ),
+                }
+              : undefined,
           ifNoneMatch: context.req.header("if-none-match"),
         }),
     );
@@ -786,7 +793,14 @@ export function registerThreadDataRoutes(app: Hono, deps: AppDeps): void {
       },
       (result) =>
         createDaemonFileContentResponse(result, {
- headers: query.disposition === "attachment" ? { "content-disposition": buildAttachmentContentDisposition(query.path) } : undefined,
+          headers:
+            query.disposition === "attachment"
+              ? {
+                  "content-disposition": buildAttachmentContentDisposition(
+                    query.path,
+                  ),
+                }
+              : undefined,
           ifNoneMatch: context.req.header("if-none-match"),
         }),
     );

--- a/apps/server/src/services/hosts/daemon-file-response.ts
+++ b/apps/server/src/services/hosts/daemon-file-response.ts
@@ -77,7 +77,11 @@ export function buildAttachmentContentDisposition(path: string): string {
   const fallback = filename
     .replace(/[^\x20-\x7E]/gu, "_")
     .replace(/["\\]/gu, "_");
-  return `attachment; filename="${fallback}"; filename*=UTF-8''${encodeURIComponent(filename)}`;
+  const encoded = encodeURIComponent(filename).replace(
+    /[!'()*]/gu,
+    (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+  return `attachment; filename="${fallback}"; filename*=UTF-8''${encoded}`;
 }
 
 export function requestMatchesEntityTag(

--- a/apps/server/src/services/hosts/daemon-file-response.ts
+++ b/apps/server/src/services/hosts/daemon-file-response.ts
@@ -72,6 +72,14 @@ function daemonFileEntityTag(result: DaemonFileReadResult): string {
   return `"${result.sha256}"`;
 }
 
+export function buildAttachmentContentDisposition(path: string): string {
+  const filename = path.split(/[\\/]/u).at(-1) ?? "download";
+  const fallback = filename
+    .replace(/[^\x20-\x7E]/gu, "_")
+    .replace(/["\\]/gu, "_");
+  return `attachment; filename="${fallback}"; filename*=UTF-8''${encodeURIComponent(filename)}`;
+}
+
 export function requestMatchesEntityTag(
   ifNoneMatch: string | undefined,
   entityTag: string,

--- a/apps/server/test/hosts/daemon-file-response.test.ts
+++ b/apps/server/test/hosts/daemon-file-response.test.ts
@@ -1,10 +1,21 @@
 import { Buffer } from "node:buffer";
 import { describe, expect, it } from "vitest";
 import {
+  buildAttachmentContentDisposition,
   createDaemonFileContentResponse,
   requestMatchesEntityTag,
   type DaemonFileReadResult,
 } from "../../src/services/hosts/daemon-file-response.js";
+
+describe("buildAttachmentContentDisposition", () => {
+  it("provides safe ASCII and UTF-8 filenames", () => {
+    expect(
+      buildAttachmentContentDisposition('/tmp/quarterly "résumé".pdf'),
+    ).toBe(
+      "attachment; filename=\"quarterly _r_sum__.pdf\"; filename*=UTF-8''quarterly%20%22r%C3%A9sum%C3%A9%22.pdf",
+    );
+  });
+});
 
 const IMAGE_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a]);
 const IMAGE_RESULT: DaemonFileReadResult = {

--- a/apps/server/test/hosts/daemon-file-response.test.ts
+++ b/apps/server/test/hosts/daemon-file-response.test.ts
@@ -10,9 +10,9 @@ import {
 describe("buildAttachmentContentDisposition", () => {
   it("provides safe ASCII and UTF-8 filenames", () => {
     expect(
-      buildAttachmentContentDisposition('/tmp/quarterly "résumé".pdf'),
+      buildAttachmentContentDisposition('/tmp/quarterly "(résumé\'s)".pdf'),
     ).toBe(
-      "attachment; filename=\"quarterly _r_sum__.pdf\"; filename*=UTF-8''quarterly%20%22r%C3%A9sum%C3%A9%22.pdf",
+      "attachment; filename=\"quarterly _(r_sum_'s)_.pdf\"; filename*=UTF-8''quarterly%20%22%28r%C3%A9sum%C3%A9%27s%29%22.pdf",
     );
   });
 });

--- a/apps/server/test/public/public-projects-local-host.test.ts
+++ b/apps/server/test/public/public-projects-local-host.test.ts
@@ -293,7 +293,7 @@ describe("public project local host routes", () => {
       });
 
       const filePromise = harness.app.request(
-        `/api/v1/projects/${project.id}/files/content?path=${encodeURIComponent("src/app.ts")}`,
+        `/api/v1/projects/${project.id}/files/content?disposition=attachment&path=${encodeURIComponent("src/app.ts")}`,
       );
       const fileCommand = await waitForQueuedCommand(
         harness,
@@ -318,6 +318,9 @@ describe("public project local host routes", () => {
       expect(fileResponse.status).toBe(200);
       expect(fileResponse.headers.get("content-type")).toContain(
         "application/typescript",
+      );
+      expect(fileResponse.headers.get("content-disposition")).toBe(
+        `attachment; filename="app.ts"; filename*=UTF-8''app.ts`,
       );
       expect(fileResponse.headers.get("cache-control")).toBe(
         "private, no-cache",

--- a/apps/server/test/public/public-thread-data.test.ts
+++ b/apps/server/test/public/public-thread-data.test.ts
@@ -4409,7 +4409,7 @@ describe("public thread data routes", () => {
       const threadStorageFilePath = `${threadStorageRoot}/images/diagram.png`;
 
       const filePromise = harness.app.request(
-        `/api/v1/threads/${thread.id}/thread-storage/content?path=${encodeURIComponent("images/diagram.png")}`,
+        `/api/v1/threads/${thread.id}/thread-storage/content?disposition=attachment&path=${encodeURIComponent("images/diagram.png")}`,
       );
       const fileCommand = await waitForQueuedCommand(
         harness,
@@ -4432,6 +4432,9 @@ describe("public thread data routes", () => {
       const fileResponse = await filePromise;
       expect(fileResponse.status).toBe(200);
       expect(fileResponse.headers.get("content-type")).toBe("image/png");
+      expect(fileResponse.headers.get("content-disposition")).toBe(
+        `attachment; filename="diagram.png"; filename*=UTF-8''diagram.png`,
+      );
       expect(fileResponse.headers.get("x-bb-content-encoding")).toBeNull();
       expect(fileResponse.headers.get("x-bb-size-bytes")).toBeNull();
       expect(new Uint8Array(await fileResponse.arrayBuffer())).toEqual(
@@ -4766,7 +4769,7 @@ describe("public thread data routes", () => {
       const fileBytes = new TextEncoder().encode("# Plan\n");
 
       const filePromise = harness.app.request(
-        `/api/v1/threads/${thread.id}/host-files/content?path=${encodeURIComponent(hostFilePath)}`,
+        `/api/v1/threads/${thread.id}/host-files/content?disposition=attachment&path=${encodeURIComponent(hostFilePath)}`,
       );
       const fileCommand = await waitForQueuedCommand(
         harness,
@@ -4795,6 +4798,9 @@ describe("public thread data routes", () => {
       const fileResponse = await filePromise;
       expect(fileResponse.status).toBe(200);
       expect(fileResponse.headers.get("content-type")).toBe("text/markdown");
+      expect(fileResponse.headers.get("content-disposition")).toBe(
+        `attachment; filename="plan.md"; filename*=UTF-8''plan.md`,
+      );
       expect(new Uint8Array(await fileResponse.arrayBuffer())).toEqual(
         fileBytes,
       );

--- a/packages/server-contract/src/api/projects.ts
+++ b/packages/server-contract/src/api/projects.ts
@@ -189,6 +189,7 @@ export type ProjectPathsQuery = z.infer<typeof projectPathsQuerySchema>;
 export const projectFileContentQuerySchema = z
   .object({
     ...projectWorkspaceRoutingFields,
+    disposition: z.literal("attachment").optional(),
     path: z.string().min(1),
   })
   .partial({ hostId: true, environmentId: true })

--- a/packages/server-contract/src/api/threads.ts
+++ b/packages/server-contract/src/api/threads.ts
@@ -974,6 +974,7 @@ export type ThreadStoragePathsQuery = z.infer<
 >;
 
 export const threadStorageContentQuerySchema = z.object({
+  disposition: z.literal("attachment").optional(),
   path: z.string().min(1),
 });
 export type ThreadStorageContentQuery = z.infer<
@@ -991,6 +992,7 @@ export type ThreadStorageLocationResponse = z.infer<
 >;
 
 export const threadHostFileContentQuerySchema = z.object({
+  disposition: z.literal("attachment").optional(),
   path: z.string().min(1),
 });
 export type ThreadHostFileContentQuery = z.infer<

--- a/packages/server-contract/test/contract.test.ts
+++ b/packages/server-contract/test/contract.test.ts
@@ -1686,12 +1686,17 @@ describe("server-contract clients", () => {
         },
       }).pathname,
     ).toBe("/api/v1/projects/proj_123/paths");
+    const projectFileContentUrl = publicClient.projects[
+      ":id"
+    ].files.content.$url({
+      param: { id: "proj_123" },
+      query: { disposition: "attachment", path: "src/report.pdf" },
+    });
     expect(
-      publicClient.projects[":id"].files.content.$url({
-        param: { id: "proj_123" },
-        query: { path: "src/app.ts" },
-      }).pathname,
-    ).toBe("/api/v1/projects/proj_123/files/content");
+      `${projectFileContentUrl.pathname}${projectFileContentUrl.search}`,
+    ).toBe(
+      "/api/v1/projects/proj_123/files/content?disposition=attachment&path=src%2Freport.pdf",
+    );
     expect(
       publicClient.threads[":id"].timeline["turn-summary-details"].$url({
         param: { id: "thr_123" },
@@ -1721,18 +1726,27 @@ describe("server-contract clients", () => {
         },
       }).pathname,
     ).toBe("/api/v1/threads/thr_123/thread-storage/paths");
-    expect(
-      publicClient.threads[":id"]["thread-storage"].content.$url({
-        param: { id: "thr_123" },
-        query: { path: "notes/plan.md" },
-      }).pathname,
-    ).toBe("/api/v1/threads/thr_123/thread-storage/content");
-    expect(
-      publicClient.threads[":id"]["host-files"].content.$url({
-        param: { id: "thr_123" },
-        query: { path: "/Users/me/notes/plan.md" },
-      }).pathname,
-    ).toBe("/api/v1/threads/thr_123/host-files/content");
+    const storageContentUrl = publicClient.threads[":id"][
+      "thread-storage"
+    ].content.$url({
+      param: { id: "thr_123" },
+      query: { disposition: "attachment", path: "reports/result.pdf" },
+    });
+    expect(`${storageContentUrl.pathname}${storageContentUrl.search}`).toBe(
+      "/api/v1/threads/thr_123/thread-storage/content?disposition=attachment&path=reports%2Fresult.pdf",
+    );
+    const hostFileContentUrl = publicClient.threads[":id"][
+      "host-files"
+    ].content.$url({
+      param: { id: "thr_123" },
+      query: {
+        disposition: "attachment",
+        path: "/Users/me/reports/result.pdf",
+      },
+    });
+    expect(`${hostFileContentUrl.pathname}${hostFileContentUrl.search}`).toBe(
+      "/api/v1/threads/thr_123/host-files/content?disposition=attachment&path=%2FUsers%2Fme%2Freports%2Fresult.pdf",
+    );
     expect(
       publicClient.threads[":id"]["thread-storage"].files[":filePath{.+}"].$url(
         {


### PR DESCRIPTION
## Human comments

On my Android 13 eInk tablet (Boox Note Max), PDF links would open a side panel browser but wouldn't display, I assume due to platform limitations. The ideal flow on that device is to download the PDF, which sends it right into the Notes app where I can review and/or annotate it.

## What was wrong

The file-opener system could select the built-in preview or a plugin viewer, but it had no first-class download action. This left users dependent on the browser’s PDF preview support, which is unreliable on some tablet browsers, without a persistent or one-off way to download the file.

## What changed

- Added Download as a built-in opener choice for `.pdf` files under Settings → File openers.
- Preserved the existing built-in preview as the default when no PDF plugin is selected.
- Added one-off “Download PDF” and “Open preview” actions to thread file-link context menus, including long-press menus.
- Routed workspace, thread-storage, and host-file downloads through their existing content endpoints with an optional `disposition=attachment` query.
- Added safe `Content-Disposition` filenames with ASCII fallback and RFC 5987 UTF-8 encoding.
- Downloads now validate the HTTP response and show an error toast rather than saving an error response as a PDF.
- Explicit preview actions bypass the saved Download preference.
- No host-daemon protocol bump was needed because the server-to-daemon wire contract did not change.
- No new Plugin SDK surface or user-facing CLI setting was added. Existing agent file-reading commands remain unchanged.

## How you verified

Added focused coverage for:

- PDF opener preference persistence and default behavior.
- Saved and one-off download selection.
- Explicit preview overrides.
- Workspace, thread-storage, and host-file download routing.
- Failed-download error handling.
- Unresolved workspace routing.
- Attachment query contracts and `Content-Disposition` headers.

Commands run:

- `pnpm exec turbo run typecheck --filter=@bb/app --filter=@bb/server --filter=@bb/server-contract`
- `pnpm exec turbo run test --filter=@bb/app -- src/lib/file-download.test.ts src/components/secondary-panel/useThreadFileTabs.test.ts src/components/settings/FileOpenersSettingsSection.test.tsx src/lib/plugin-slot-resolvers.test.ts`
- `pnpm exec turbo run test --filter=@bb/server -- test/hosts/daemon-file-response.test.ts test/public/public-thread-data.test.ts test/public/public-projects-local-host.test.ts`
- `pnpm exec turbo run test --filter=@bb/server-contract -- test/contract.test.ts`
- `pnpm exec turbo run build`

The focused suites passed with 34 app tests, 90 server tests, and 35 server-contract tests. The full build completed successfully with 18/18 tasks.

Fixes #<issue-number>

> AGENT GENERATED