### PR TITLE
Bump plugin SDK after reopen tab command

### DIFF
--- a/packages/domain/src/plugin-sdk-version.ts
+++ b/packages/domain/src/plugin-sdk-version.ts
@@ -1,3 +1,3 @@
-export const PLUGIN_SDK_VERSION = "0.4.28";
+export const PLUGIN_SDK_VERSION = "0.4.29";
 
 export const PLUGIN_SDK_MAJOR = Number(PLUGIN_SDK_VERSION.split(".", 1)[0]);

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@get-bb/plugin-sdk",
-  "version": "0.4.28",
+  "version": "0.4.29",
   "homepage": "https://github.com/get-bb/bb#readme",
   "bugs": {
     "url": "https://github.com/get-bb/bb/issues"


### PR DESCRIPTION
## Human comments

## What was wrong

PR #2686 added `panel.reopenClosedTab` to the public Plugin SDK declaration while the package remained at `0.4.28`. That version is already published with different bundled types, so the post-merge npm version guard correctly failed on `main`.

## What changed

Bumped `@get-bb/plugin-sdk` and the shared domain version constant together from `0.4.28` to `0.4.29`. No host-daemon wire contract changed.

## How you verified

- Used the repository-provided `node scripts/bump-plugin-sdk.mjs --patch` command.
- Per repository policy, CI-equivalent checks were not run locally; pull-request CI is the verification gate.

Follow-up to #2686

BB-Thread-ID: thr_ufp89hj9ea

> AGENT GENERATED