### PR TITLE
Add public plugin marketplace and guide

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -32,7 +32,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "tailwind-merge": "^3.4.0",
-    "zod": "^4.3.6"
+    "zod": "4.3.6"
   },
   "devDependencies": {
     "@bb/tsconfig": "workspace:*",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,7 +13,10 @@
     "preview": "vite preview --host 0.0.0.0"
   },
   "dependencies": {
+    "@bb/client-core": "workspace:*",
     "@bb/connect-db": "workspace:*",
+    "@bb/domain": "workspace:*",
+    "@bb/plugin-api-map": "workspace:*",
     "@better-auth/drizzle-adapter": "^1.6.23",
     "@fontsource-variable/inter": "^5.2.8",
     "@hugeicons/core-free-icons": "^4.1.3",
@@ -28,7 +31,8 @@
     "posthog-js": "^1.386.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "tailwind-merge": "^3.4.0"
+    "tailwind-merge": "^3.4.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@bb/tsconfig": "workspace:*",

--- a/apps/web/public/schemas/marketplace-v2.schema.json
+++ b/apps/web/public/schemas/marketplace-v2.schema.json
@@ -1,0 +1,274 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://getbb.app/schemas/marketplace-v2.schema.json",
+  "title": "BB plugin marketplace manifest (v2)",
+  "description": "The discovery catalog. Every v1 field keeps its v1 meaning; v2 adds category, screenshots, publication dates, release dates, and the ordered New & notable shelf.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "name",
+    "displayName",
+    "newAndNotable",
+    "plugins"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "https://getbb.app/schemas/marketplace-v2.schema.json"
+    },
+    "schemaVersion": {
+      "const": 2
+    },
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]*$"
+    },
+    "displayName": {
+      "type": "string",
+      "minLength": 1
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1
+    },
+    "newAndNotable": {
+      "type": "array",
+      "uniqueItems": true,
+      "$comment": "Ordered from most to least notable. Every id must name an entry in plugins.",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z0-9][a-z0-9-]*$"
+      }
+    },
+    "plugins": {
+      "type": "array",
+      "maxItems": 256,
+      "$comment": "Entry ids must also be unique within one manifest.",
+      "items": {
+        "$ref": "#/$defs/entry"
+      }
+    }
+  },
+  "$defs": {
+    "entry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "displayName",
+        "description",
+        "icon",
+        "category",
+        "author",
+        "source"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "$comment": "The plugin id this entry installs; BB refuses an install whose manifest declares another id.",
+          "pattern": "^[a-z0-9][a-z0-9-]*$"
+        },
+        "displayName": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "icon": {
+          "oneOf": [
+            {
+              "type": "string",
+              "$comment": "A host icon name such as ZoomIn.",
+              "pattern": "^[A-Za-z][A-Za-z0-9]*$"
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["url"],
+              "properties": {
+                "url": {
+                  "type": "string",
+                  "$comment": "Absolute https URL, or a URL relative to this manifest. Must end in .svg, .png, or .webp.",
+                  "pattern": "^(?:(?![A-Za-z][A-Za-z0-9+.-]*:)|(?=[Hh][Tt][Tt][Pp][Ss]:))[^\\s]*\\.(?:[Ss][Vv][Gg]|[Pp][Nn][Gg]|[Ww][Ee][Bb][Pp])(?:[?#][^\\s]*)?$"
+                }
+              }
+            }
+          ]
+        },
+        "category": {
+          "$comment": "One of BB's 15 canonical category ids. The list is closed: there is no Other.",
+          "enum": [
+            "themes-and-appearance",
+            "thread-lists-and-navigation",
+            "thread-content",
+            "memory-and-context",
+            "security",
+            "agents-and-providers",
+            "token-usage-and-cost",
+            "notifications-and-attention",
+            "code-and-reviews",
+            "files-and-viewers",
+            "remote-development",
+            "terminals",
+            "system-management",
+            "plugin-development",
+            "tasks-workflows"
+          ]
+        },
+        "screenshots": {
+          "type": "array",
+          "maxItems": 6,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "$comment": "An https URL or a relative .png, .jpg, .jpeg, or .webp asset in this repository.",
+            "pattern": "^(?:(?![A-Za-z][A-Za-z0-9+.-]*:)|(?=[Hh][Tt][Tt][Pp][Ss]:))[^\\s]*\\.(?:[Pp][Nn][Gg]|[Jj][Pp][Ee]?[Gg]|[Ww][Ee][Bb][Pp])(?:[?#][^\\s]*)?$"
+          }
+        },
+        "publishedAt": {
+          "type": "string",
+          "format": "date-time",
+          "$comment": "Derived by the registry from the first commit of this entry file. Not author-supplied."
+        },
+        "updatedAt": {
+          "type": "string",
+          "format": "date-time",
+          "$comment": "Derived from the plugin's latest release when available. Not author-supplied."
+        },
+        "tags": {
+          "type": "array",
+          "maxItems": 10,
+          "items": {
+            "type": "string",
+            "maxLength": 32,
+            "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+          }
+        },
+        "author": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["name"],
+          "$comment": "Never put an email address here: the manifest is public and mirrored.",
+          "properties": {
+            "name": {
+              "type": "string",
+              "minLength": 1
+            },
+            "github": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9](?:-?[A-Za-z0-9]){0,38}$"
+            },
+            "url": {
+              "type": "string",
+              "pattern": "^https://"
+            }
+          }
+        },
+        "source": {
+          "oneOf": [
+            { "$ref": "#/$defs/npmSource" },
+            { "$ref": "#/$defs/gitRefSource" },
+            { "$ref": "#/$defs/gitRangeSource" }
+          ]
+        }
+      }
+    },
+    "npmSource": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["npm"],
+      "properties": {
+        "npm": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["package"],
+          "$comment": "range and tag are mutually exclusive.",
+          "not": { "required": ["range", "tag"] },
+          "properties": {
+            "package": {
+              "type": "string",
+              "pattern": "^(?:@[a-z0-9][a-z0-9._~-]*/)?[a-z0-9][a-z0-9._~-]*$"
+            },
+            "range": {
+              "type": "string",
+              "minLength": 1
+            },
+            "tag": {
+              "type": "string",
+              "pattern": "^[A-Za-z][A-Za-z0-9._-]*$"
+            },
+            "registry": {
+              "type": "string",
+              "pattern": "^https://"
+            }
+          }
+        }
+      }
+    },
+    "gitSubdir": {
+      "type": "string",
+      "$comment": "Repository-relative directory; absolute paths, empty segments, .. and .git are rejected.",
+      "pattern": "^(?![A-Za-z]:)(?!/)(?!(?:[^/]+/)*(?:\\.|\\.\\.|\\.git)(?:/|$))[^/\\\\]+(?:/[^/\\\\]+)*$"
+    },
+    "gitRefSource": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["git"],
+      "$comment": "One branch, tag, or commit. Mutually exclusive with the range form.",
+      "properties": {
+        "git": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["url", "ref"],
+          "properties": {
+            "url": {
+              "type": "string",
+              "pattern": "^https://"
+            },
+            "subdir": {
+              "$ref": "#/$defs/gitSubdir"
+            },
+            "ref": {
+              "type": "string",
+              "$comment": "Must round-trip through BB's git:<url>@<ref> install syntax, so colon is rejected.",
+              "pattern": "^(?!-)(?![\\s\\S]*\\.\\.)(?![\\s\\S]*@)(?![\\s\\S]*:)[\\s\\S]+$"
+            }
+          }
+        }
+      }
+    },
+    "gitRangeSource": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["git"],
+      "$comment": "A semver range resolved over the repository's [tagPrefix]vX.Y.Z release tags.",
+      "properties": {
+        "git": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["url", "range"],
+          "properties": {
+            "url": {
+              "type": "string",
+              "pattern": "^https://"
+            },
+            "subdir": {
+              "$ref": "#/$defs/gitSubdir"
+            },
+            "range": {
+              "type": "string",
+              "minLength": 1
+            },
+            "tagPrefix": {
+              "type": "string",
+              "maxLength": 128,
+              "pattern": "^(?!.*\\.\\.)(?!.*//)(?!.*/\\.)(?![^/]*\\.lock(?:/|$))(?!.*/[^/]*\\.lock(?:/|$))(?!.*\\.$)[A-Za-z0-9][A-Za-z0-9._/-]*$"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/web/src/components/ui/theme.css
+++ b/apps/web/src/components/ui/theme.css
@@ -1,6 +1,7 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 @source "../..";
+@source "../../../../../packages/plugin-api-map/src";
 
 @custom-variant dark (&:is(.dark *));
 
@@ -49,6 +50,7 @@
   --color-surface-recessed: var(--surface-recessed);
   --color-surface-recessed-solid: var(--surface-recessed-solid);
   --color-surface-raised: var(--surface-raised);
+  --color-surface-raised-solid: var(--surface-raised-solid);
   --color-surface-scrim: var(--surface-scrim);
   --color-surface-destructive: var(--surface-destructive);
   --color-surface-destructive-border: var(--surface-destructive-border);
@@ -383,6 +385,7 @@
      queued-list scroll fades) that must not double the translucent tint. */
   --surface-recessed-solid: color-mix(in oklab, var(--ink) 6%, var(--canvas));
   --surface-raised: color-mix(in oklab, var(--ink) 2.5%, transparent);
+  --surface-raised-solid: color-mix(in oklab, var(--ink) 2.5%, var(--canvas));
   --surface-scrim: color-mix(in oklab, var(--canvas) 92%, transparent);
   --surface-destructive: color-mix(
     in oklab,
@@ -578,6 +581,7 @@
      queued-list scroll fades) that must not double the translucent tint. */
   --surface-recessed-solid: color-mix(in oklab, var(--ink) 6%, var(--canvas));
   --surface-raised: color-mix(in oklab, var(--ink) 2.5%, transparent);
+  --surface-raised-solid: color-mix(in oklab, var(--ink) 2.5%, var(--canvas));
   --surface-scrim: color-mix(in oklab, var(--canvas) 92%, transparent);
   --surface-destructive: color-mix(
     in oklab,

--- a/apps/web/src/landing/cta.tsx
+++ b/apps/web/src/landing/cta.tsx
@@ -1,17 +1,37 @@
 import { CheckmarkCircle02Icon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
+import { HugeiconsIcon, type IconSvgElement } from "@hugeicons/react";
 import { useEffect, useState } from "react";
 import type { FormEvent, ReactNode } from "react";
 
 import { trackLandingEvent } from "./analytics";
 import type { CtaPlacement } from "./site";
 import {
+  CLI_COMMAND,
   DISCORD_URL,
   GITHUB_URL,
   X_URL,
   SUBSCRIBE_PATH,
   downloadMacosHref,
 } from "./site";
+
+const AppleSolidIcon: IconSvgElement = [
+  [
+    "path",
+    {
+      d: "M12 5.75C12 3.75 13.5 1.75 15.5 1.75C15.5 3.75 14 5.75 12 5.75Z",
+      fill: "currentColor",
+      key: "0",
+    },
+  ],
+  [
+    "path",
+    {
+      d: "M12.5 8.09001C11.9851 8.09001 11.5867 7.92646 11.1414 7.74368C10.5776 7.51225 9.93875 7.25 8.89334 7.25C7.02235 7.25 4 8.74945 4 12.7495C4 17.4016 7.10471 22.25 9.10471 22.25C9.77426 22.25 10.3775 21.9871 10.954 21.7359C11.4815 21.5059 11.9868 21.2857 12.5 21.2857C13.0132 21.2857 13.5185 21.5059 14.046 21.7359C14.6225 21.9871 15.2257 22.25 15.8953 22.25C17.2879 22.25 18.9573 19.8992 20 16.9008C18.3793 16.2202 17.338 14.618 17.338 12.75C17.338 11.121 18.2036 10.0398 19.5 9.25C18.5 7.75 17.0134 7.25 15.9447 7.25C14.8993 7.25 14.2604 7.51225 13.6966 7.74368C13.2514 7.92646 13.0149 8.09001 12.5 8.09001Z",
+      fill: "currentColor",
+      key: "1",
+    },
+  ],
+];
 
 type CtaLinkProps = {
   placement: CtaPlacement;
@@ -24,6 +44,66 @@ export function DownloadLink({ placement, className, children }: CtaLinkProps) {
     <a className={className} href={downloadMacosHref(placement)}>
       {children}
     </a>
+  );
+}
+
+function RunCommandButton({ placement }: { placement: CtaPlacement }) {
+  const [copied, setCopied] = useState(false);
+  const copy = () => {
+    trackLandingEvent({
+      name: "landing_cli_command_copied",
+      properties: { placement, command: CLI_COMMAND },
+    });
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+    navigator.clipboard.writeText(CLI_COMMAND).catch(() => {});
+  };
+  return (
+    <button
+      type="button"
+      className={
+        copied
+          ? "btn btn-ghost btn-install cmd-btn copied"
+          : "btn btn-ghost btn-install cmd-btn"
+      }
+      onClick={copy}
+      aria-label={`Copy browser install command: ${CLI_COMMAND}`}
+    >
+      <span className="cmd-dollar">$</span>
+      <span className="cmd-text">{CLI_COMMAND}</span>
+      <span className="cmd-copy">Copy</span>
+      <span
+        className={copied ? "cmd-toast show" : "cmd-toast"}
+        aria-hidden="true"
+      >
+        Copied to clipboard
+      </span>
+    </button>
+  );
+}
+
+export function InstallOptions({ placement }: { placement: CtaPlacement }) {
+  return (
+    <div className="install-options">
+      <div className="install-actions">
+        <span className="install-choice">
+          <DownloadLink
+            placement={placement}
+            className="btn btn-primary btn-install"
+          >
+            <HugeiconsIcon icon={AppleSolidIcon} className="btn-ic" />
+            Download for macOS
+          </DownloadLink>
+          <span className="install-note">One-click, no terminal</span>
+        </span>
+        <span className="install-choice">
+          <RunCommandButton placement={placement} />
+          <span className="install-note">
+            Windows (via WSL), Linux &amp; remote machines
+          </span>
+        </span>
+      </div>
+    </div>
   );
 }
 

--- a/apps/web/src/landing/landing.css
+++ b/apps/web/src/landing/landing.css
@@ -3106,8 +3106,8 @@ html.js .mock[data-construct]:not(.constructing):not(.constructed) {
 /* Give the remaining utility links a little more room on narrow phones. */
 @media (max-width: 430px) {
   .nav-links {
-    gap: 12px;
-    font-size: 13px;
+    gap: 8px;
+    font-size: 12.5px;
   }
 
   .updates-label {

--- a/apps/web/src/landing/site-chrome.tsx
+++ b/apps/web/src/landing/site-chrome.tsx
@@ -18,7 +18,7 @@ import {
 } from "../lib/theme";
 import { DiscordLink, DownloadLink, GitHubLink, XLink } from "./cta";
 
-type SiteNavPage = "blog" | "changelog";
+type SiteNavPage = "blog" | "changelog" | "plugins";
 
 const THEME_OPTIONS: ReadonlyArray<{
   value: ThemePreference;
@@ -132,6 +132,12 @@ export function SiteNav({ current }: { current?: SiteNavPage }) {
       </a>
       <div className="nav-links">
         <a
+          className={current === "plugins" ? "nav-current" : undefined}
+          href="/marketplace"
+        >
+          Plugins
+        </a>
+        <a
           className={current === "blog" ? "nav-current" : undefined}
           href="/blog"
         >
@@ -160,6 +166,10 @@ export function SiteFooter() {
     <footer className="footer">
       <span>bb is free and open source (MIT)</span>
       <span>
+        <a href="/marketplace">Marketplace</a>
+        {" · "}
+        <a href="/docs">Plugin Guide</a>
+        {" · "}
         <a href="/blog">Blog</a>
         {" · "}
         <a href="/changelog">Changelog</a>

--- a/apps/web/src/landing/site.ts
+++ b/apps/web/src/landing/site.ts
@@ -16,6 +16,7 @@ export type CtaPlacement =
   | "cli"
   | "loops"
   | "local"
+  | "plugin-guide"
   | "closer"
   | "footer";
 

--- a/apps/web/src/lib/copy-plain-text.ts
+++ b/apps/web/src/lib/copy-plain-text.ts
@@ -1,0 +1,47 @@
+function copyWithEditingCommand(text: string): boolean {
+  if (
+    typeof document === "undefined" ||
+    document.body === null ||
+    typeof document.execCommand !== "function"
+  ) {
+    return false;
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.readOnly = true;
+  textarea.setAttribute("aria-hidden", "true");
+  Object.assign(textarea.style, {
+    height: "1px",
+    opacity: "0",
+    pointerEvents: "none",
+    position: "fixed",
+    width: "1px",
+  });
+  document.body.appendChild(textarea);
+
+  try {
+    textarea.select();
+    return document.execCommand("copy");
+  } catch {
+    return false;
+  } finally {
+    textarea.remove();
+  }
+}
+
+export async function copyPlainText(text: string): Promise<boolean> {
+  if (
+    typeof navigator !== "undefined" &&
+    typeof navigator.clipboard?.writeText === "function"
+  ) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      return copyWithEditingCommand(text);
+    }
+  }
+
+  return copyWithEditingCommand(text);
+}

--- a/apps/web/src/marketplace/marketplace-data.ts
+++ b/apps/web/src/marketplace/marketplace-data.ts
@@ -1,0 +1,38 @@
+import {
+  parseMarketplaceV2Manifest,
+  type MarketplaceV2Manifest,
+} from "./marketplace-v2.js";
+import {
+  parseMarketplaceStats,
+  type MarketplaceStats,
+} from "./marketplace-stats.js";
+
+export const MARKETPLACE_V2_MANIFEST_PATH = "/marketplace/v2/marketplace.json";
+export const MARKETPLACE_STATS_PATH = "/marketplace/v1/stats.json";
+
+export type PublicMarketplaceData =
+  | {
+      status: "available";
+      manifest: MarketplaceV2Manifest;
+      stats: MarketplaceStats | null;
+    }
+  | { status: "unavailable" };
+
+export async function loadPublicMarketplace(
+  readJson: (path: string) => Promise<unknown>,
+): Promise<PublicMarketplaceData> {
+  try {
+    const manifest = parseMarketplaceV2Manifest(
+      await readJson(MARKETPLACE_V2_MANIFEST_PATH),
+    );
+    let stats: MarketplaceStats | null = null;
+    try {
+      stats = parseMarketplaceStats(await readJson(MARKETPLACE_STATS_PATH));
+    } catch {
+      stats = null;
+    }
+    return { status: "available", manifest, stats };
+  } catch {
+    return { status: "unavailable" };
+  }
+}

--- a/apps/web/src/marketplace/marketplace-server.test.ts
+++ b/apps/web/src/marketplace/marketplace-server.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  loadPublicMarketplace,
+  MARKETPLACE_STATS_PATH,
+  MARKETPLACE_V2_MANIFEST_PATH,
+} from "./marketplace-data.js";
+import {
+  MARKETPLACE_STATS_FIXTURE,
+  MARKETPLACE_V2_FIXTURE,
+} from "./marketplace-v2.fixture.js";
+
+describe("loadPublicMarketplace", () => {
+  it("returns an explicit unavailable state when v2 cannot load", async () => {
+    await expect(
+      loadPublicMarketplace(async () => {
+        throw new Error("offline");
+      }),
+    ).resolves.toEqual({ status: "unavailable" });
+  });
+
+  it("keeps the catalog available when only stats fail", async () => {
+    await expect(
+      loadPublicMarketplace(async (path) => {
+        if (path === MARKETPLACE_V2_MANIFEST_PATH) {
+          return MARKETPLACE_V2_FIXTURE;
+        }
+        throw new Error("stats offline");
+      }),
+    ).resolves.toEqual({
+      status: "available",
+      manifest: MARKETPLACE_V2_FIXTURE,
+      stats: null,
+    });
+  });
+
+  it("loads v2 and the install-count sidecar from separate paths", async () => {
+    const paths: string[] = [];
+    const data = await loadPublicMarketplace(async (path) => {
+      paths.push(path);
+      return path === MARKETPLACE_STATS_PATH
+        ? MARKETPLACE_STATS_FIXTURE
+        : MARKETPLACE_V2_FIXTURE;
+    });
+    expect(paths).toEqual([
+      MARKETPLACE_V2_MANIFEST_PATH,
+      MARKETPLACE_STATS_PATH,
+    ]);
+    expect(data).toEqual({
+      status: "available",
+      manifest: MARKETPLACE_V2_FIXTURE,
+      stats: MARKETPLACE_STATS_FIXTURE,
+    });
+  });
+});

--- a/apps/web/src/marketplace/marketplace-server.ts
+++ b/apps/web/src/marketplace/marketplace-server.ts
@@ -1,0 +1,24 @@
+import { createServerFn } from "@tanstack/react-start";
+
+import { getEnv } from "../server/env.js";
+import { serveMarketplaceObject } from "../server/marketplace.js";
+import {
+  loadPublicMarketplace,
+  type PublicMarketplaceData,
+} from "./marketplace-data.js";
+
+async function marketplaceJson(path: string): Promise<unknown> {
+  const response = await serveMarketplaceObject({
+    bucket: getEnv().MARKETPLACE,
+    request: new Request(`https://getbb.app${path}`),
+  });
+  if (!response.ok) {
+    throw new Error(`Marketplace resource unavailable: ${response.status}`);
+  }
+  return response.json();
+}
+
+export const getPublicMarketplace = createServerFn({ method: "GET" }).handler(
+  async (): Promise<PublicMarketplaceData> =>
+    loadPublicMarketplace(marketplaceJson),
+);

--- a/apps/web/src/marketplace/marketplace-stats.test.ts
+++ b/apps/web/src/marketplace/marketplace-stats.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  MARKETPLACE_STATS_FIXTURE,
+  MARKETPLACE_V2_FIXTURE,
+} from "./marketplace-v2.fixture.js";
+import {
+  marketplaceEntryInstalls,
+  parseMarketplaceStats,
+} from "./marketplace-stats.js";
+
+describe("marketplace install stats", () => {
+  it("reads install counts only from the stats sidecar", () => {
+    const [counted, uncounted] = MARKETPLACE_V2_FIXTURE.plugins;
+    expect(marketplaceEntryInstalls(counted!, MARKETPLACE_STATS_FIXTURE)).toBe(
+      1_204,
+    );
+    expect(
+      marketplaceEntryInstalls(uncounted!, MARKETPLACE_STATS_FIXTURE),
+    ).toBeUndefined();
+    expect(counted).not.toHaveProperty("installCount");
+  });
+
+  it("drops malformed plugin ids and rejects invalid counts", () => {
+    expect(
+      parseMarketplaceStats({
+        ...MARKETPLACE_STATS_FIXTURE,
+        plugins: {
+          ...MARKETPLACE_STATS_FIXTURE.plugins,
+          "future-plugin": { installs: 2, futureField: true },
+          "Bad Plugin": { installs: 99 },
+        },
+      }),
+    ).toMatchObject({
+      plugins: {
+        "prompt-library": { installs: 1_204 },
+        "future-plugin": { installs: 2 },
+      },
+    });
+    expect(() =>
+      parseMarketplaceStats({
+        ...MARKETPLACE_STATS_FIXTURE,
+        plugins: { "prompt-library": { installs: -1 } },
+      }),
+    ).toThrow();
+  });
+});

--- a/apps/web/src/marketplace/marketplace-stats.ts
+++ b/apps/web/src/marketplace/marketplace-stats.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+
+import type { MarketplaceV2Entry } from "./marketplace-v2.js";
+
+const ENTRY_ID_PATTERN = /^[a-z0-9][a-z0-9-]*$/u;
+
+const marketplaceStatsSchema = z.object({
+  schemaVersion: z.literal(1),
+  generatedAt: z.string(),
+  plugins: z.record(
+    z.string(),
+    z.object({ installs: z.number().int().nonnegative() }),
+  ),
+});
+
+export type MarketplaceStats = z.infer<typeof marketplaceStatsSchema>;
+
+export function parseMarketplaceStats(input: unknown): MarketplaceStats {
+  const parsed = marketplaceStatsSchema.parse(input);
+  return {
+    ...parsed,
+    plugins: Object.fromEntries(
+      Object.entries(parsed.plugins).filter(([entryId]) =>
+        ENTRY_ID_PATTERN.test(entryId),
+      ),
+    ),
+  };
+}
+
+export function marketplaceEntryInstalls(
+  entry: MarketplaceV2Entry,
+  stats: MarketplaceStats | null,
+): number | undefined {
+  return stats?.plugins[entry.id]?.installs;
+}

--- a/apps/web/src/marketplace/marketplace-v2.fixture.ts
+++ b/apps/web/src/marketplace/marketplace-v2.fixture.ts
@@ -1,0 +1,57 @@
+import {
+  MARKETPLACE_V2_SCHEMA_URL,
+  type MarketplaceV2Manifest,
+} from "./marketplace-v2.js";
+import type { MarketplaceStats } from "./marketplace-stats.js";
+
+export const MARKETPLACE_V2_FIXTURE: MarketplaceV2Manifest = {
+  $schema: MARKETPLACE_V2_SCHEMA_URL,
+  schemaVersion: 2,
+  name: "bb-community",
+  displayName: "BB Community",
+  description: "Plugins published by the bb community.",
+  newAndNotable: ["review-companion", "prompt-library"],
+  plugins: [
+    {
+      id: "prompt-library",
+      displayName: "Prompt Library",
+      description: "Save and reuse project prompts from the composer.",
+      icon: "FileText",
+      category: "thread-content",
+      screenshots: ["screenshots/prompt-library.png"],
+      publishedAt: "2026-07-14T09:30:00Z",
+      updatedAt: "2026-08-24T16:45:00+02:00",
+      tags: ["prompts", "templates"],
+      author: { name: "BB Labs", github: "get-bb" },
+      source: {
+        npm: {
+          package: "@get-bb/plugin-prompt-library",
+          range: "^1.2.0",
+        },
+      },
+    },
+    {
+      id: "review-companion",
+      displayName: "Review Companion",
+      description: "Keep pull request checks and review context together.",
+      icon: { url: "icons/review-companion.svg" },
+      category: "code-and-reviews",
+      tags: ["github", "code-review"],
+      author: { name: "Acme", github: "acme-tools" },
+      source: {
+        git: {
+          url: "https://github.com/acme/bb-plugins.git",
+          subdir: "plugins/review-companion",
+          range: ">=1.0.0 <2.0.0",
+          tagPrefix: "review-companion/",
+        },
+      },
+    },
+  ],
+};
+
+export const MARKETPLACE_STATS_FIXTURE: MarketplaceStats = {
+  schemaVersion: 1,
+  generatedAt: "2026-08-25T06:17:00.000Z",
+  plugins: { "prompt-library": { installs: 1_204 } },
+};

--- a/apps/web/src/marketplace/marketplace-v2.test.ts
+++ b/apps/web/src/marketplace/marketplace-v2.test.ts
@@ -1,0 +1,84 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { MARKETPLACE_V2_FIXTURE } from "./marketplace-v2.fixture.js";
+import {
+  MARKETPLACE_CATEGORY_IDS,
+  MARKETPLACE_V2_SCHEMA_URL,
+  parseMarketplaceV2Manifest,
+} from "./marketplace-v2.js";
+
+const publishedSchemaShape = z.object({
+  $id: z.string(),
+  $defs: z.object({
+    entry: z.object({
+      properties: z.object({
+        category: z.object({ enum: z.array(z.string()) }),
+      }),
+    }),
+  }),
+});
+
+describe("parseMarketplaceV2Manifest", () => {
+  it("preserves the strict v2 contract", () => {
+    expect(parseMarketplaceV2Manifest(MARKETPLACE_V2_FIXTURE)).toEqual(
+      MARKETPLACE_V2_FIXTURE,
+    );
+  });
+
+  it("rejects missing categories, duplicate ids, and uncontracted fields", () => {
+    const [entry] = MARKETPLACE_V2_FIXTURE.plugins;
+    const { category: _category, ...withoutCategory } = entry!;
+    expect(() =>
+      parseMarketplaceV2Manifest({
+        ...MARKETPLACE_V2_FIXTURE,
+        newAndNotable: [],
+        plugins: [withoutCategory],
+      }),
+    ).toThrow(/category/u);
+    expect(() =>
+      parseMarketplaceV2Manifest({
+        ...MARKETPLACE_V2_FIXTURE,
+        newAndNotable: [entry!.id],
+        plugins: [entry, entry],
+      }),
+    ).toThrow(/duplicate plugin id/u);
+    expect(() =>
+      parseMarketplaceV2Manifest({
+        ...MARKETPLACE_V2_FIXTURE,
+        telemetry: true,
+      }),
+    ).toThrow(/telemetry/u);
+  });
+
+  it("requires New & notable ids to exist in the catalog", () => {
+    expect(() =>
+      parseMarketplaceV2Manifest({
+        ...MARKETPLACE_V2_FIXTURE,
+        newAndNotable: ["missing-plugin"],
+      }),
+    ).toThrow(/unknown plugin id/u);
+  });
+
+  it("keeps the public JSON Schema aligned with the runtime category contract", () => {
+    const schema = publishedSchemaShape.parse(
+      JSON.parse(
+        readFileSync(
+          fileURLToPath(
+            new URL(
+              "../../public/schemas/marketplace-v2.schema.json",
+              import.meta.url,
+            ),
+          ),
+          "utf8",
+        ),
+      ),
+    );
+    expect(schema.$id).toBe(MARKETPLACE_V2_SCHEMA_URL);
+    expect(schema.$defs.entry.properties.category.enum).toEqual(
+      MARKETPLACE_CATEGORY_IDS,
+    );
+  });
+});

--- a/apps/web/src/marketplace/marketplace-v2.ts
+++ b/apps/web/src/marketplace/marketplace-v2.ts
@@ -1,0 +1,93 @@
+import {
+  MARKETPLACE_SEMVER_RANGE_PATTERN,
+  PLUGIN_CATALOG_CATEGORY_IDS,
+  marketplaceEntryV2Schema,
+  type MarketplaceEntrySource,
+  type MarketplaceEntryV2,
+  type PluginCatalogCategoryId,
+} from "@bb/domain";
+import { z } from "zod";
+
+export const MARKETPLACE_V2_SCHEMA_URL =
+  "https://getbb.app/schemas/marketplace-v2.schema.json";
+
+export const MARKETPLACE_CATEGORY_IDS = PLUGIN_CATALOG_CATEGORY_IDS;
+export { MARKETPLACE_SEMVER_RANGE_PATTERN };
+
+const MARKETPLACE_MAX_ENTRIES = 256;
+const NAME_PATTERN = /^[a-z0-9][a-z0-9-]*$/u;
+export const marketplaceV2EntrySchema = marketplaceEntryV2Schema;
+
+function rejectDuplicateEntries(
+  entries: MarketplaceV2Entry[],
+  context: z.RefinementCtx,
+): void {
+  const seen = new Set<string>();
+  entries.forEach((entry, index) => {
+    if (seen.has(entry.id)) {
+      context.addIssue({
+        code: "custom",
+        path: [index, "id"],
+        message: `duplicate plugin id ${JSON.stringify(entry.id)}`,
+      });
+    }
+    seen.add(entry.id);
+  });
+}
+
+export const marketplaceV2ManifestSchema = z
+  .object({
+    $schema: z.literal(MARKETPLACE_V2_SCHEMA_URL).optional(),
+    schemaVersion: z.literal(2),
+    name: z.string().max(64).regex(NAME_PATTERN),
+    displayName: z.string().min(1),
+    description: z.string().min(1).optional(),
+    newAndNotable: z.array(z.string().regex(NAME_PATTERN)),
+    plugins: z
+      .array(marketplaceV2EntrySchema)
+      .max(MARKETPLACE_MAX_ENTRIES)
+      .superRefine(rejectDuplicateEntries),
+  })
+  .strict()
+  .superRefine((manifest, context) => {
+    const seen = new Set<string>();
+    const entryIds = new Set(manifest.plugins.map((entry) => entry.id));
+    manifest.newAndNotable.forEach((entryId, index) => {
+      if (seen.has(entryId)) {
+        context.addIssue({
+          code: "custom",
+          path: ["newAndNotable", index],
+          message: `duplicate plugin id ${JSON.stringify(entryId)}`,
+        });
+      } else if (!entryIds.has(entryId)) {
+        context.addIssue({
+          code: "custom",
+          path: ["newAndNotable", index],
+          message: `unknown plugin id ${JSON.stringify(entryId)}`,
+        });
+      }
+      seen.add(entryId);
+    });
+  });
+
+export type MarketplaceCategoryId = PluginCatalogCategoryId;
+export type MarketplaceV2Entry = MarketplaceEntryV2;
+export type MarketplaceV2Source = MarketplaceEntrySource;
+export type MarketplaceV2Manifest = z.infer<typeof marketplaceV2ManifestSchema>;
+
+export function parseMarketplaceV2Manifest(
+  input: unknown,
+): MarketplaceV2Manifest {
+  const parsed = marketplaceV2ManifestSchema.safeParse(input);
+  if (!parsed.success) {
+    const issues = parsed.error.issues
+      .map((issue) => {
+        const path =
+          issue.path.length === 0 ? "manifest" : issue.path.join(".");
+        return `${path}: ${issue.message}`;
+      })
+      .join("; ");
+    throw new Error(`Invalid marketplace v2 manifest: ${issues}`);
+  }
+  return parsed.data;
+}

--- a/apps/web/src/marketplace/marketplace-view-model.test.ts
+++ b/apps/web/src/marketplace/marketplace-view-model.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  MARKETPLACE_STATS_FIXTURE,
+  MARKETPLACE_V2_FIXTURE,
+} from "./marketplace-v2.fixture.js";
+import {
+  filterMarketplaceEntries,
+  marketplaceAssetUrl,
+  marketplaceInstallCommand,
+  marketplaceShelves,
+  newAndNotableEntries,
+  sortMarketplaceEntries,
+} from "./marketplace-view-model.js";
+
+describe("public marketplace view model", () => {
+  it("orders shelves and preserves the curated New & notable order", () => {
+    expect(marketplaceShelves(MARKETPLACE_V2_FIXTURE.plugins)).toHaveLength(2);
+    expect(
+      newAndNotableEntries(MARKETPLACE_V2_FIXTURE).map((entry) => entry.id),
+    ).toEqual(MARKETPLACE_V2_FIXTURE.newAndNotable);
+  });
+
+  it("searches plugin copy, authors, tags, and category labels", () => {
+    const entries = MARKETPLACE_V2_FIXTURE.plugins;
+    expect(filterMarketplaceEntries(entries, "Acme")).toEqual([entries[1]]);
+    expect(filterMarketplaceEntries(entries, "Code & Reviews")).toEqual([
+      entries[1],
+    ]);
+    expect(filterMarketplaceEntries(entries, "templates")).toEqual([
+      entries[0],
+    ]);
+  });
+
+  it("sorts unknown install counts after known counts", () => {
+    const [known, unknown] = MARKETPLACE_V2_FIXTURE.plugins;
+    expect(
+      sortMarketplaceEntries(
+        [unknown!, known!],
+        "most-installed",
+        MARKETPLACE_STATS_FIXTURE,
+      ).map((entry) => entry.id),
+    ).toEqual([known!.id, unknown!.id]);
+  });
+
+  it("exposes only the CLI install command and resolves v2 assets", () => {
+    expect(marketplaceInstallCommand("prompt-library")).toBe(
+      "bb plugin install prompt-library",
+    );
+    expect(marketplaceAssetUrl("icons/prompt.svg")).toBe(
+      "/marketplace/v2/icons/prompt.svg",
+    );
+  });
+});

--- a/apps/web/src/marketplace/marketplace-view-model.ts
+++ b/apps/web/src/marketplace/marketplace-view-model.ts
@@ -1,0 +1,157 @@
+import {
+  PLUGIN_CATALOG_CATEGORIES,
+  pluginDiscoveryNewAndNotableEntries,
+  pluginDiscoveryShelves,
+  sortPluginDiscoveryEntries,
+  type PluginDiscoveryEntryAccessors,
+  type PluginDiscoverySort,
+} from "@bb/domain";
+import type {
+  MarketplaceCategoryId,
+  MarketplaceV2Entry,
+  MarketplaceV2Manifest,
+} from "./marketplace-v2.js";
+import {
+  marketplaceEntryInstalls,
+  type MarketplaceStats,
+} from "./marketplace-stats.js";
+
+export type MarketplaceSort = PluginDiscoverySort;
+
+export const MARKETPLACE_CATEGORIES: ReadonlyArray<{
+  id: MarketplaceCategoryId;
+  label: string;
+  description: string;
+}> = PLUGIN_CATALOG_CATEGORIES.map((category) => ({
+  id: category.id,
+  label: category.displayName,
+  description: category.description,
+}));
+
+const CATEGORY_BY_ID = new Map(
+  MARKETPLACE_CATEGORIES.map((category) => [category.id, category]),
+);
+
+type MarketplaceCategory = (typeof MARKETPLACE_CATEGORIES)[number];
+
+export interface MarketplaceShelf {
+  category: MarketplaceCategory;
+  entries: MarketplaceV2Entry[];
+}
+
+export function marketplaceCategory(
+  id: MarketplaceCategoryId,
+): MarketplaceCategory {
+  const category = CATEGORY_BY_ID.get(id);
+  if (category === undefined) {
+    throw new Error(`unknown marketplace category ${JSON.stringify(id)}`);
+  }
+  return category;
+}
+
+function discoveryAccessors(stats: MarketplaceStats | null) {
+  return {
+    entryId: (entry: MarketplaceV2Entry) => entry.id,
+    displayName: (entry: MarketplaceV2Entry) => entry.displayName,
+    category: (entry: MarketplaceV2Entry) =>
+      marketplaceCategory(entry.category),
+    categoryId: (category: MarketplaceCategory) => category.id,
+    installs: (entry: MarketplaceV2Entry) =>
+      marketplaceEntryInstalls(entry, stats),
+    publishedAt: (entry: MarketplaceV2Entry) => entry.publishedAt,
+  } satisfies PluginDiscoveryEntryAccessors<
+    MarketplaceV2Entry,
+    MarketplaceCategory
+  >;
+}
+
+export function marketplaceShelves(
+  entries: readonly MarketplaceV2Entry[],
+): MarketplaceShelf[] {
+  return pluginDiscoveryShelves(entries, discoveryAccessors(null));
+}
+
+export function newAndNotableEntries(
+  manifest: MarketplaceV2Manifest,
+): MarketplaceV2Entry[] {
+  const curatedOrder = new Map(
+    manifest.newAndNotable.map((entryId, index) => [entryId, index]),
+  );
+  return pluginDiscoveryNewAndNotableEntries(manifest.plugins, {
+    ...discoveryAccessors(null),
+    newAndNotableRank: (entry) => curatedOrder.get(entry.id),
+  });
+}
+
+export function filterMarketplaceEntries(
+  entries: readonly MarketplaceV2Entry[],
+  query: string,
+): MarketplaceV2Entry[] {
+  const normalized = query.trim().toLocaleLowerCase();
+  if (normalized.length === 0) return [...entries];
+  return entries.filter((entry) => {
+    const category = marketplaceCategory(entry.category);
+    return [
+      entry.displayName,
+      entry.description,
+      entry.id,
+      entry.category,
+      entry.author.name,
+      entry.author.github,
+      category.label,
+      ...(entry.tags ?? []),
+    ]
+      .filter((value) => value !== undefined)
+      .some((value) => value.toLocaleLowerCase().includes(normalized));
+  });
+}
+
+export function sortMarketplaceEntries(
+  entries: readonly MarketplaceV2Entry[],
+  sort: MarketplaceSort,
+  stats: MarketplaceStats | null,
+): MarketplaceV2Entry[] {
+  return sortPluginDiscoveryEntries(entries, sort, discoveryAccessors(stats));
+}
+
+export function marketplaceDetailPath(entryId: string): string {
+  return `/marketplace/${encodeURIComponent(entryId)}`;
+}
+
+export function marketplaceAssetUrl(declared: string): string {
+  if (/^[A-Za-z][A-Za-z0-9+.-]*:/u.test(declared)) return declared;
+  return new URL(declared, "https://getbb.app/marketplace/v2/marketplace.json")
+    .pathname;
+}
+
+export function marketplaceInstallCommand(entryId: string): string {
+  return `bb plugin install ${entryId}`;
+}
+
+export function marketplaceRepositoryUrl(
+  entry: MarketplaceV2Entry,
+): string | null {
+  if ("npm" in entry.source) {
+    return entry.source.npm.registry === undefined
+      ? `https://www.npmjs.com/package/${entry.source.npm.package}`
+      : null;
+  }
+  return entry.source.git.url.replace(/\.git$/u, "");
+}
+
+export function formatInstalls(value: number | undefined): string | null {
+  if (value === undefined) return null;
+  return new Intl.NumberFormat("en-US", { notation: "compact" }).format(value);
+}
+
+export function formatMarketplaceDate(
+  value: string | undefined,
+): string | null {
+  if (value === undefined) return null;
+  return new Intl.DateTimeFormat("en-US", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(new Date(value));
+}

--- a/apps/web/src/marketplace/marketplace.css
+++ b/apps/web/src/marketplace/marketplace.css
@@ -428,12 +428,21 @@
 
 .marketplace-detail-layout {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 300px;
-  gap: 64px;
+  grid-template-areas:
+    "content aside"
+    "sections aside";
+  grid-template-columns: minmax(0, 1fr) 340px;
+  column-gap: 56px;
   margin-top: 36px;
 }
 
 .marketplace-detail-content {
+  grid-area: content;
+  min-width: 0;
+}
+
+.marketplace-detail-sections {
+  grid-area: sections;
   min-width: 0;
 }
 
@@ -515,6 +524,7 @@
 }
 
 .marketplace-detail-aside {
+  grid-area: aside;
   min-width: 0;
 }
 
@@ -626,8 +636,15 @@
   }
 
   .marketplace-detail-layout {
-    grid-template-columns: minmax(0, 1fr) 280px;
-    gap: 36px;
+    grid-template-areas:
+      "content"
+      "aside"
+      "sections";
+    grid-template-columns: 1fr;
+  }
+
+  .marketplace-detail-aside {
+    margin-top: 36px;
   }
 }
 
@@ -655,14 +672,6 @@
 
   .marketplace-select select {
     min-width: 0;
-  }
-
-  .marketplace-detail-layout {
-    grid-template-columns: 1fr;
-  }
-
-  .marketplace-detail-aside {
-    order: -1;
   }
 }
 

--- a/apps/web/src/marketplace/marketplace.css
+++ b/apps/web/src/marketplace/marketplace.css
@@ -1,0 +1,700 @@
+.plugin-pages-wrap {
+  max-width: 1120px;
+}
+
+.marketplace-main,
+.marketplace-detail-main {
+  padding-bottom: 88px;
+}
+
+.plugin-page-head {
+  max-width: 760px;
+  padding: 72px 0 48px;
+  border-bottom: 1px solid var(--border-soft);
+}
+
+.plugin-page-head h1 {
+  color: var(--heading);
+  font-size: clamp(38px, 6vw, 54px);
+  font-weight: 700;
+  letter-spacing: -0.045em;
+  line-height: 1.04;
+}
+
+.plugin-page-head > p {
+  max-width: 650px;
+  margin-top: 18px;
+  color: var(--dim);
+  font-size: 17px;
+}
+
+.marketplace-browser {
+  padding-top: 32px;
+}
+
+.marketplace-toolbar {
+  display: grid;
+  grid-template-columns: minmax(240px, 1fr) auto auto;
+  gap: 10px;
+  align-items: center;
+}
+
+.marketplace-search,
+.marketplace-select {
+  position: relative;
+  display: flex;
+  align-items: center;
+  height: 40px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg);
+  color: var(--dim);
+}
+
+.marketplace-search:focus-within,
+.marketplace-select:focus-within {
+  border-color: color-mix(in oklab, var(--ink) 42%, var(--bg));
+}
+
+.marketplace-search > svg {
+  width: 16px;
+  height: 16px;
+  margin-left: 12px;
+  flex: 0 0 auto;
+}
+
+.marketplace-search input,
+.marketplace-select select {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--ink);
+  font: inherit;
+  font-size: 13.5px;
+}
+
+.marketplace-search input {
+  min-width: 0;
+  padding: 0 8px;
+}
+
+.marketplace-search input::placeholder {
+  color: var(--subtle);
+}
+
+.marketplace-search button {
+  display: inline-grid;
+  place-items: center;
+  width: 34px;
+  height: 100%;
+  flex: 0 0 auto;
+  border: 0;
+  background: transparent;
+  color: var(--subtle);
+  cursor: pointer;
+}
+
+.marketplace-search button:hover {
+  color: var(--ink);
+}
+
+.marketplace-search button svg {
+  width: 14px;
+  height: 14px;
+}
+
+.marketplace-select select {
+  min-width: 154px;
+  padding: 0 34px 0 12px;
+  appearance: none;
+  cursor: pointer;
+}
+
+.marketplace-select > svg {
+  position: absolute;
+  right: 10px;
+  width: 14px;
+  height: 14px;
+  pointer-events: none;
+}
+
+.marketplace-visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.marketplace-results {
+  padding-top: 42px;
+}
+
+.marketplace-shelf + .marketplace-shelf {
+  margin-top: 54px;
+  padding-top: 48px;
+  border-top: 1px solid var(--border-soft);
+}
+
+.marketplace-section-head {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 18px;
+}
+
+.marketplace-section-head > div {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+
+.marketplace-section-head h2 {
+  color: var(--heading-sub);
+  font-size: 20px;
+  font-weight: 650;
+  letter-spacing: -0.02em;
+}
+
+.marketplace-section-head span,
+.marketplace-section-head p {
+  color: var(--subtle);
+  font-size: 12.5px;
+}
+
+.marketplace-section-head > a {
+  flex: 0 0 auto;
+  color: var(--dim);
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.marketplace-section-head > a:hover {
+  color: var(--ink);
+}
+
+.marketplace-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.marketplace-card {
+  min-width: 0;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--bg);
+}
+
+.marketplace-card:hover {
+  border-color: color-mix(in oklab, var(--ink) 28%, var(--bg));
+  background: var(--surface);
+}
+
+.marketplace-card-link {
+  display: flex;
+  min-height: 182px;
+  height: 100%;
+  flex-direction: column;
+  padding: 18px;
+}
+
+.marketplace-card-topline {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  min-width: 0;
+}
+
+.marketplace-card-topline strong {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--heading-sub);
+  font-size: 15px;
+  font-weight: 650;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.marketplace-artwork {
+  display: inline-grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  flex: 0 0 auto;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--surface-recessed);
+  color: var(--dim);
+}
+
+.marketplace-artwork svg {
+  width: 18px;
+  height: 18px;
+}
+
+.marketplace-artwork img {
+  display: block;
+  width: 22px;
+  height: 22px;
+  object-fit: contain;
+}
+
+.marketplace-artwork.is-large {
+  width: 58px;
+  height: 58px;
+  border-radius: 12px;
+}
+
+.marketplace-artwork.is-large svg,
+.marketplace-artwork.is-large img {
+  width: 30px;
+  height: 30px;
+}
+
+.marketplace-card-description {
+  display: -webkit-box;
+  margin-top: 14px;
+  overflow: hidden;
+  color: var(--dim);
+  font-size: 13.5px;
+  line-height: 1.5;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.marketplace-card-meta {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 10px;
+  min-width: 0;
+  margin-top: auto;
+  padding-top: 16px;
+}
+
+.marketplace-card-author {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--subtle);
+  font-size: 11.5px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.marketplace-card-secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 7px;
+  min-width: 0;
+}
+
+.marketplace-category-pill {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+  max-width: 150px;
+  padding: 3px 7px;
+  overflow: hidden;
+  border: 1px solid var(--border-soft);
+  border-radius: 999px;
+  background: var(--surface-recessed);
+  color: var(--dim);
+  font-size: 10.5px;
+  font-weight: 500;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.marketplace-card-installs {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex: 0 0 auto;
+  color: var(--subtle);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.marketplace-card-installs svg {
+  width: 12px;
+  height: 12px;
+}
+
+.marketplace-flat-results .marketplace-section-head {
+  align-items: baseline;
+}
+
+.marketplace-flat-results .marketplace-section-head > p {
+  max-width: 540px;
+  text-align: right;
+}
+
+.marketplace-state {
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  margin: 52px 0 0;
+  padding: 64px 24px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--surface);
+  text-align: center;
+}
+
+.marketplace-state > span {
+  display: inline-grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--bg);
+  color: var(--subtle);
+}
+
+.marketplace-state svg {
+  width: 21px;
+  height: 21px;
+}
+
+.marketplace-state h2 {
+  margin-top: 16px;
+  color: var(--heading-sub);
+  font-size: 18px;
+  font-weight: 650;
+}
+
+.marketplace-state p {
+  max-width: 420px;
+  margin-top: 6px;
+  color: var(--dim);
+  font-size: 13.5px;
+}
+
+.marketplace-cross-link {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  margin-top: 64px;
+  padding: 20px 22px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--surface);
+  color: var(--dim);
+  font-size: 13.5px;
+}
+
+.marketplace-cross-link a {
+  color: var(--ink);
+  font-weight: 500;
+}
+
+.marketplace-cross-link a:hover {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.marketplace-detail-main {
+  padding-top: 50px;
+}
+
+.marketplace-back-link {
+  display: inline-flex;
+  color: var(--dim);
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.marketplace-back-link::before {
+  content: "←";
+  margin-right: 7px;
+}
+
+.marketplace-back-link:hover {
+  color: var(--ink);
+}
+
+.marketplace-detail-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 300px;
+  gap: 64px;
+  margin-top: 36px;
+}
+
+.marketplace-detail-content {
+  min-width: 0;
+}
+
+.marketplace-detail-head {
+  display: flex;
+  align-items: flex-start;
+  gap: 18px;
+}
+
+.marketplace-detail-head > div {
+  min-width: 0;
+}
+
+.marketplace-detail-head h1 {
+  margin-top: 9px;
+  color: var(--heading);
+  font-size: clamp(32px, 5vw, 46px);
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  line-height: 1.06;
+}
+
+.marketplace-detail-head p {
+  margin-top: 8px;
+  color: var(--subtle);
+  font-size: 13px;
+}
+
+.marketplace-detail-head p a {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--dim);
+}
+
+.marketplace-detail-head p a:hover {
+  color: var(--ink);
+}
+
+.marketplace-detail-head p svg {
+  width: 13px;
+  height: 13px;
+}
+
+.marketplace-detail-description {
+  max-width: 680px;
+  margin-top: 30px;
+  color: var(--dim);
+  font-size: 17px;
+  line-height: 1.65;
+}
+
+.marketplace-detail-section {
+  margin-top: 48px;
+  padding-top: 40px;
+  border-top: 1px solid var(--border-soft);
+}
+
+.marketplace-detail-section h2 {
+  margin-bottom: 18px;
+  color: var(--heading-sub);
+  font-size: 20px;
+  font-weight: 650;
+  letter-spacing: -0.02em;
+}
+
+.marketplace-screenshots {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.marketplace-screenshots img {
+  display: block;
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--surface);
+}
+
+.marketplace-detail-aside {
+  min-width: 0;
+}
+
+.marketplace-install-command {
+  padding: 18px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--surface);
+}
+
+.marketplace-install-command > span {
+  color: var(--dim);
+  font-size: 12.5px;
+  font-weight: 500;
+}
+
+.marketplace-install-command > div {
+  display: flex;
+  align-items: stretch;
+  min-width: 0;
+  margin-top: 10px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg);
+}
+
+.marketplace-install-command code {
+  flex: 1;
+  min-width: 0;
+  padding: 9px 10px;
+  overflow: hidden;
+  color: var(--ink);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.marketplace-install-command button {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 0 10px;
+  border: 0;
+  border-left: 1px solid var(--border);
+  background: transparent;
+  color: var(--dim);
+  font: inherit;
+  font-size: 11.5px;
+  cursor: pointer;
+}
+
+.marketplace-install-command button:hover {
+  background: var(--state-hover);
+  color: var(--ink);
+}
+
+.marketplace-install-command button svg {
+  width: 13px;
+  height: 13px;
+}
+
+.marketplace-detail-aside dl {
+  margin-top: 20px;
+  border-top: 1px solid var(--border-soft);
+}
+
+.marketplace-detail-aside dl > div {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 11px 0;
+  border-bottom: 1px solid var(--border-soft);
+  font-size: 12.5px;
+}
+
+.marketplace-detail-aside dt {
+  color: var(--subtle);
+}
+
+.marketplace-detail-aside dd {
+  color: var(--ink);
+  text-align: right;
+}
+
+.marketplace-source-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  margin-top: 18px;
+  color: var(--dim);
+  font-size: 12.5px;
+  font-weight: 500;
+}
+
+.marketplace-source-link:hover {
+  color: var(--ink);
+}
+
+.marketplace-source-link svg {
+  width: 14px;
+  height: 14px;
+}
+
+@media (max-width: 900px) {
+  .marketplace-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .marketplace-detail-layout {
+    grid-template-columns: minmax(0, 1fr) 280px;
+    gap: 36px;
+  }
+}
+
+@media (max-width: 720px) {
+  .plugin-pages-wrap {
+    padding-inline: 20px;
+  }
+
+  .plugin-pages-wrap .nav-links {
+    gap: 10px;
+    font-size: 13px;
+  }
+
+  .plugin-page-head {
+    padding-top: 52px;
+  }
+
+  .marketplace-toolbar {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .marketplace-search {
+    grid-column: 1 / -1;
+  }
+
+  .marketplace-select select {
+    min-width: 0;
+  }
+
+  .marketplace-detail-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .marketplace-detail-aside {
+    order: -1;
+  }
+}
+
+@media (max-width: 520px) {
+  .plugin-pages-wrap .nav-links a[href="/changelog"] {
+    display: none;
+  }
+
+  .marketplace-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .marketplace-toolbar {
+    grid-template-columns: 1fr;
+  }
+
+  .marketplace-search {
+    grid-column: auto;
+  }
+
+  .marketplace-section-head,
+  .marketplace-section-head > div,
+  .marketplace-cross-link {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .marketplace-section-head > p {
+    text-align: left;
+  }
+
+  .marketplace-screenshots {
+    grid-template-columns: 1fr;
+  }
+}

--- a/apps/web/src/marketplace/public-marketplace.test.tsx
+++ b/apps/web/src/marketplace/public-marketplace.test.tsx
@@ -1,0 +1,34 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import {
+  MARKETPLACE_STATS_FIXTURE,
+  MARKETPLACE_V2_FIXTURE,
+} from "./marketplace-v2.fixture.js";
+import {
+  PublicMarketplacePage,
+  PublicMarketplaceUnavailablePage,
+} from "./public-marketplace.js";
+
+describe("public marketplace rendering", () => {
+  it("renders author artwork as an image without a recoloring mask", () => {
+    const html = renderToStaticMarkup(
+      <PublicMarketplacePage
+        manifest={MARKETPLACE_V2_FIXTURE}
+        stats={MARKETPLACE_STATS_FIXTURE}
+        state={{}}
+        onStateChange={() => {}}
+      />,
+    );
+    expect(html).toContain("/marketplace/v2/icons/review-companion.svg");
+    expect(html).toContain("<img");
+    expect(html).not.toContain("mask-image");
+    expect(html).not.toContain("Aug 24, 2026");
+  });
+
+  it("renders a stated unavailable page instead of throwing", () => {
+    const html = renderToStaticMarkup(<PublicMarketplaceUnavailablePage />);
+    expect(html).toContain("The Marketplace is temporarily unavailable");
+    expect(html).toContain("Try again in a little while");
+  });
+});

--- a/apps/web/src/marketplace/public-marketplace.tsx
+++ b/apps/web/src/marketplace/public-marketplace.tsx
@@ -1,0 +1,681 @@
+import {
+  AiContentGenerator01Icon,
+  AlertCircleIcon,
+  Archive03Icon,
+  ArrowDown01Icon,
+  Cancel01Icon,
+  ChartColumnIcon,
+  CheckListIcon,
+  Clock01Icon,
+  CloudIcon,
+  ComputerTerminal01Icon,
+  Copy01Icon,
+  Download01Icon,
+  File01Icon,
+  Folder02Icon,
+  FolderGitTwoIcon,
+  GithubIcon,
+  GitBranchIcon,
+  Layers01Icon,
+  LinkSquare01Icon,
+  LockIcon,
+  Mail02Icon,
+  PackageIcon,
+  PuzzleIcon,
+  Search01Icon,
+  SidebarLeftIcon,
+  SlidersHorizontalIcon,
+  Tick02Icon,
+  WorkflowCircle03Icon,
+  ZapIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon, type IconSvgElement } from "@hugeicons/react";
+import { useEffect, useState } from "react";
+
+import { initAnalytics } from "../landing/analytics.js";
+import { SiteFooter, SiteNav } from "../landing/site-chrome.js";
+import { copyPlainText } from "../lib/copy-plain-text.js";
+import type {
+  MarketplaceCategoryId,
+  MarketplaceV2Entry,
+  MarketplaceV2Manifest,
+} from "./marketplace-v2.js";
+import {
+  marketplaceEntryInstalls,
+  type MarketplaceStats,
+} from "./marketplace-stats.js";
+import {
+  filterMarketplaceEntries,
+  formatInstalls,
+  formatMarketplaceDate,
+  marketplaceAssetUrl,
+  marketplaceCategory,
+  MARKETPLACE_CATEGORIES,
+  marketplaceInstallCommand,
+  marketplaceRepositoryUrl,
+  marketplaceShelves,
+  newAndNotableEntries,
+  sortMarketplaceEntries,
+  type MarketplaceShelf,
+  type MarketplaceSort,
+} from "./marketplace-view-model.js";
+
+const SORT_LABELS: Record<MarketplaceSort, string> = {
+  "recently-added": "Recently added",
+  "most-installed": "Most installed",
+  name: "Name",
+};
+
+const PLUGIN_ICONS: Readonly<Record<string, IconSvgElement | undefined>> = {
+  AiContentGenerator01: AiContentGenerator01Icon,
+  AlertCircle: AlertCircleIcon,
+  Archive: Archive03Icon,
+  ChartColumn: ChartColumnIcon,
+  ClipboardCheck: CheckListIcon,
+  Clock: Clock01Icon,
+  Cloud: CloudIcon,
+  Copy: Copy01Icon,
+  FileText: File01Icon,
+  FolderGit: FolderGitTwoIcon,
+  FolderOpen: Folder02Icon,
+  GitBranch: GitBranchIcon,
+  Layers: Layers01Icon,
+  Lock: LockIcon,
+  Mail: Mail02Icon,
+  PanelLeft: SidebarLeftIcon,
+  Puzzle: PuzzleIcon,
+  SlidersHorizontal: SlidersHorizontalIcon,
+  Terminal: ComputerTerminal01Icon,
+  Workflow: WorkflowCircle03Icon,
+  Zap: ZapIcon,
+};
+
+export interface MarketplaceIndexState {
+  category?: MarketplaceCategoryId;
+  sort?: MarketplaceSort;
+}
+
+function PluginArtwork({
+  entry,
+  large = false,
+}: {
+  entry: MarketplaceV2Entry;
+  large?: boolean;
+}) {
+  if (typeof entry.icon === "string") {
+    return (
+      <span
+        className={
+          large ? "marketplace-artwork is-large" : "marketplace-artwork"
+        }
+        aria-hidden
+      >
+        <HugeiconsIcon icon={PLUGIN_ICONS[entry.icon] ?? PuzzleIcon} />
+      </span>
+    );
+  }
+  return (
+    <span
+      className={large ? "marketplace-artwork is-large" : "marketplace-artwork"}
+    >
+      <img src={marketplaceAssetUrl(entry.icon.url)} alt="" />
+    </span>
+  );
+}
+
+function InstallCount({
+  entry,
+  stats,
+}: {
+  entry: MarketplaceV2Entry;
+  stats: MarketplaceStats | null;
+}) {
+  const total = marketplaceEntryInstalls(entry, stats);
+  if (total === undefined) return null;
+  const formatted = formatInstalls(total) ?? total.toLocaleString("en-US");
+  return (
+    <span
+      className="marketplace-card-installs"
+      aria-label={`${total.toLocaleString("en-US")} installs`}
+    >
+      <HugeiconsIcon icon={Download01Icon} aria-hidden />
+      {formatted}
+    </span>
+  );
+}
+
+function PluginCard({
+  entry,
+  stats,
+  showCategory = false,
+}: {
+  entry: MarketplaceV2Entry;
+  stats: MarketplaceStats | null;
+  showCategory?: boolean;
+}) {
+  return (
+    <article className="marketplace-card">
+      <a
+        className="marketplace-card-link"
+        href={`/marketplace/${encodeURIComponent(entry.id)}`}
+      >
+        <span className="marketplace-card-topline">
+          <PluginArtwork entry={entry} />
+          <strong>{entry.displayName}</strong>
+        </span>
+        <span className="marketplace-card-description">
+          {entry.description}
+        </span>
+        <span className="marketplace-card-meta">
+          <span className="marketplace-card-author">
+            By {entry.author.name}
+          </span>
+          <span className="marketplace-card-secondary">
+            {showCategory ? (
+              <span className="marketplace-category-pill">
+                {marketplaceCategory(entry.category).label}
+              </span>
+            ) : null}
+            <InstallCount entry={entry} stats={stats} />
+          </span>
+        </span>
+      </a>
+    </article>
+  );
+}
+
+function PluginGrid({
+  entries,
+  stats,
+  showCategory = false,
+}: {
+  entries: readonly MarketplaceV2Entry[];
+  stats: MarketplaceStats | null;
+  showCategory?: boolean;
+}) {
+  return (
+    <div className="marketplace-grid">
+      {entries.map((entry) => (
+        <PluginCard
+          key={entry.id}
+          entry={entry}
+          stats={stats}
+          showCategory={showCategory}
+        />
+      ))}
+    </div>
+  );
+}
+
+function Shelf({
+  shelf,
+  stats,
+  onSelect,
+}: {
+  shelf: MarketplaceShelf;
+  stats: MarketplaceStats | null;
+  onSelect: (category: MarketplaceCategoryId) => void;
+}) {
+  const href = `/marketplace?category=${encodeURIComponent(shelf.category.id)}`;
+  return (
+    <section className="marketplace-shelf">
+      <div className="marketplace-section-head">
+        <div>
+          <h2>{shelf.category.label}</h2>
+          <span>{shelf.entries.length} plugins</span>
+        </div>
+        <a
+          href={href}
+          onClick={(event) => {
+            event.preventDefault();
+            onSelect(shelf.category.id);
+          }}
+        >
+          View all
+        </a>
+      </div>
+      <PluginGrid entries={shelf.entries.slice(0, 3)} stats={stats} />
+    </section>
+  );
+}
+
+function MarketplaceState({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="marketplace-state" role="status">
+      <span aria-hidden>
+        <HugeiconsIcon icon={PackageIcon} />
+      </span>
+      <h2>{title}</h2>
+      <p>{description}</p>
+    </div>
+  );
+}
+
+export function PublicMarketplaceUnavailablePage() {
+  useEffect(() => {
+    initAnalytics();
+  }, []);
+  return (
+    <div className="wrap plugin-pages-wrap">
+      <SiteNav current="plugins" />
+      <main className="marketplace-main">
+        <header className="plugin-page-head marketplace-page-head">
+          <h1>Plugin Marketplace</h1>
+          <p>Discover extensions that add new capabilities to bb.</p>
+        </header>
+        <MarketplaceState
+          title="The Marketplace is temporarily unavailable"
+          description="The catalog could not be loaded. Try again in a little while."
+        />
+        <aside className="marketplace-cross-link">
+          <span>Want to build your own plugin?</span>
+          <a href="/docs">Read the Plugin Guide</a>
+        </aside>
+      </main>
+      <SiteFooter />
+    </div>
+  );
+}
+
+export function PublicMarketplacePage({
+  manifest,
+  stats,
+  state,
+  onStateChange,
+}: {
+  manifest: MarketplaceV2Manifest;
+  stats: MarketplaceStats | null;
+  state: MarketplaceIndexState;
+  onStateChange: (state: MarketplaceIndexState) => void;
+}) {
+  const [query, setQuery] = useState("");
+  useEffect(() => {
+    initAnalytics();
+  }, []);
+
+  const allShelves = marketplaceShelves(manifest.plugins);
+  const hasInstallCounts = manifest.plugins.some(
+    (entry) => marketplaceEntryInstalls(entry, stats) !== undefined,
+  );
+  const activeSort =
+    state.sort === "most-installed" && !hasInstallCounts
+      ? undefined
+      : state.sort;
+  const searched = filterMarketplaceEntries(manifest.plugins, query);
+  const filtered =
+    state.category === undefined
+      ? searched
+      : searched.filter((entry) => entry.category === state.category);
+  const category =
+    state.category === undefined
+      ? undefined
+      : marketplaceCategory(state.category);
+  const isFlat =
+    query.trim().length > 0 ||
+    activeSort !== undefined ||
+    category !== undefined;
+  const displayed =
+    activeSort === undefined
+      ? filtered
+      : sortMarketplaceEntries(filtered, activeSort, stats);
+
+  const changeState = (next: MarketplaceIndexState) => {
+    onStateChange(next);
+  };
+
+  return (
+    <div className="wrap plugin-pages-wrap">
+      <SiteNav current="plugins" />
+      <main className="marketplace-main">
+        <header className="plugin-page-head marketplace-page-head">
+          <h1>Plugin Marketplace</h1>
+          <p>
+            Discover extensions that add new capabilities to bb, built by bb and
+            the community.
+          </p>
+        </header>
+
+        {manifest.plugins.length === 0 ? (
+          <MarketplaceState
+            title="No plugins are published yet"
+            description="The Marketplace is ready. Published plugins will appear here."
+          />
+        ) : (
+          <section className="marketplace-browser" aria-label="Browse plugins">
+            <div className="marketplace-toolbar">
+              <label className="marketplace-search">
+                <span className="marketplace-visually-hidden">
+                  Search plugins
+                </span>
+                <HugeiconsIcon icon={Search01Icon} aria-hidden />
+                <input
+                  type="search"
+                  value={query}
+                  onChange={(event) => setQuery(event.currentTarget.value)}
+                  placeholder="Search plugins"
+                />
+                {query.length > 0 ? (
+                  <button
+                    type="button"
+                    aria-label="Clear search"
+                    onClick={() => setQuery("")}
+                  >
+                    <HugeiconsIcon icon={Cancel01Icon} aria-hidden />
+                  </button>
+                ) : null}
+              </label>
+
+              <label className="marketplace-select">
+                <span className="marketplace-visually-hidden">Category</span>
+                <select
+                  value={state.category ?? ""}
+                  onChange={(event) => {
+                    const value = event.currentTarget.value;
+                    changeState({
+                      category: isMarketplaceCategoryId(value)
+                        ? value
+                        : undefined,
+                      sort: activeSort,
+                    });
+                  }}
+                >
+                  <option value="">All categories</option>
+                  {allShelves.map((shelf) => (
+                    <option key={shelf.category.id} value={shelf.category.id}>
+                      {shelf.category.label}
+                    </option>
+                  ))}
+                </select>
+                <HugeiconsIcon icon={ArrowDown01Icon} aria-hidden />
+              </label>
+
+              <label className="marketplace-select">
+                <span className="marketplace-visually-hidden">
+                  Sort plugins
+                </span>
+                <select
+                  value={activeSort ?? ""}
+                  onChange={(event) => {
+                    const value = event.currentTarget.value;
+                    changeState({
+                      category: state.category,
+                      sort: isMarketplaceSort(value) ? value : undefined,
+                    });
+                  }}
+                >
+                  <option value="">Featured</option>
+                  <option value="recently-added">Recently added</option>
+                  {hasInstallCounts ? (
+                    <option value="most-installed">Most installed</option>
+                  ) : null}
+                  <option value="name">Name</option>
+                </select>
+                <HugeiconsIcon icon={ArrowDown01Icon} aria-hidden />
+              </label>
+            </div>
+
+            <div className="marketplace-results" aria-live="polite">
+              {displayed.length === 0 ? (
+                <MarketplaceState
+                  title="No plugins found"
+                  description="Try a different search or category."
+                />
+              ) : isFlat ? (
+                <section className="marketplace-flat-results">
+                  <div className="marketplace-section-head">
+                    <div>
+                      <h2>
+                        {query.trim().length > 0
+                          ? "Search results"
+                          : activeSort === undefined
+                            ? category?.label
+                            : SORT_LABELS[activeSort]}
+                      </h2>
+                      <span>{displayed.length} plugins</span>
+                    </div>
+                    {category !== undefined ? (
+                      <p>{category.description}</p>
+                    ) : null}
+                  </div>
+                  <PluginGrid
+                    entries={displayed}
+                    stats={stats}
+                    showCategory={category === undefined}
+                  />
+                </section>
+              ) : (
+                <>
+                  <section className="marketplace-shelf marketplace-notable">
+                    <div className="marketplace-section-head">
+                      <div>
+                        <h2>New &amp; notable</h2>
+                        <span>Selected from the latest additions</span>
+                      </div>
+                    </div>
+                    <PluginGrid
+                      entries={newAndNotableEntries(manifest).slice(0, 3)}
+                      stats={stats}
+                      showCategory
+                    />
+                  </section>
+                  {allShelves.map((shelf) => (
+                    <Shelf
+                      key={shelf.category.id}
+                      shelf={shelf}
+                      stats={stats}
+                      onSelect={(nextCategory) =>
+                        changeState({ category: nextCategory })
+                      }
+                    />
+                  ))}
+                </>
+              )}
+            </div>
+          </section>
+        )}
+
+        <aside className="marketplace-cross-link">
+          <span>Want to build your own plugin?</span>
+          <a href="/docs">Read the Plugin Guide</a>
+        </aside>
+      </main>
+      <SiteFooter />
+    </div>
+  );
+}
+
+function InstallCommand({ entry }: { entry: MarketplaceV2Entry }) {
+  const [status, setStatus] = useState<CopyStatus>("idle");
+  const command = marketplaceInstallCommand(entry.id);
+  const copy = async () => {
+    setStatus((await copyPlainText(command)) ? "copied" : "failed");
+  };
+  return (
+    <div className="marketplace-install-command">
+      <span>Install from your terminal</span>
+      <div>
+        <code>{command}</code>
+        <button
+          type="button"
+          onClick={() => void copy()}
+          aria-label={`Copy ${command}`}
+        >
+          <HugeiconsIcon
+            icon={status === "copied" ? Tick02Icon : Copy01Icon}
+            aria-hidden
+          />
+          {status === "copied"
+            ? "Copied"
+            : status === "failed"
+              ? "Copy failed"
+              : "Copy"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+type CopyStatus = "idle" | "copied" | "failed";
+
+export function PublicMarketplaceDetailPage({
+  manifest,
+  entry,
+  stats,
+}: {
+  manifest: MarketplaceV2Manifest;
+  entry: MarketplaceV2Entry;
+  stats: MarketplaceStats | null;
+}) {
+  useEffect(() => {
+    initAnalytics();
+  }, []);
+  const category = marketplaceCategory(entry.category);
+  const installs = marketplaceEntryInstalls(entry, stats);
+  const published = formatMarketplaceDate(entry.publishedAt);
+  const updated = formatMarketplaceDate(entry.updatedAt);
+  const repository = marketplaceRepositoryUrl(entry);
+  const moreFromAuthor = manifest.plugins.filter(
+    (candidate) =>
+      candidate.id !== entry.id &&
+      candidate.author.name.toLocaleLowerCase() ===
+        entry.author.name.toLocaleLowerCase(),
+  );
+  const authorUrl =
+    entry.author.url ??
+    (entry.author.github === undefined
+      ? undefined
+      : `https://github.com/${entry.author.github}`);
+
+  return (
+    <div className="wrap plugin-pages-wrap">
+      <SiteNav current="plugins" />
+      <main className="marketplace-detail-main">
+        <a className="marketplace-back-link" href="/marketplace">
+          Marketplace
+        </a>
+        <div className="marketplace-detail-layout">
+          <article className="marketplace-detail-content">
+            <header className="marketplace-detail-head">
+              <PluginArtwork entry={entry} large />
+              <div>
+                <span className="marketplace-category-pill">
+                  {category.label}
+                </span>
+                <h1>{entry.displayName}</h1>
+                <p>
+                  By{" "}
+                  {authorUrl === undefined ? (
+                    entry.author.name
+                  ) : (
+                    <a href={authorUrl} target="_blank" rel="noreferrer">
+                      {entry.author.name}
+                      {entry.author.github === undefined ? null : (
+                        <HugeiconsIcon icon={GithubIcon} aria-hidden />
+                      )}
+                    </a>
+                  )}
+                </p>
+              </div>
+            </header>
+
+            <p className="marketplace-detail-description">
+              {entry.description}
+            </p>
+
+            {entry.screenshots?.length ? (
+              <section className="marketplace-detail-section">
+                <h2>Screenshots</h2>
+                <div className="marketplace-screenshots">
+                  {entry.screenshots.map((screenshot, index) => (
+                    <img
+                      key={screenshot}
+                      src={marketplaceAssetUrl(screenshot)}
+                      alt={`${entry.displayName} screenshot ${index + 1}`}
+                    />
+                  ))}
+                </div>
+              </section>
+            ) : null}
+
+            {moreFromAuthor.length > 0 ? (
+              <section className="marketplace-detail-section">
+                <h2>More from {entry.author.name}</h2>
+                <PluginGrid
+                  entries={moreFromAuthor}
+                  stats={stats}
+                  showCategory
+                />
+              </section>
+            ) : null}
+          </article>
+
+          <aside className="marketplace-detail-aside">
+            <InstallCommand entry={entry} />
+            <dl>
+              <div>
+                <dt>Category</dt>
+                <dd>{category.label}</dd>
+              </div>
+              {installs === undefined ? null : (
+                <div>
+                  <dt>Installs</dt>
+                  <dd>{installs.toLocaleString("en-US")}</dd>
+                </div>
+              )}
+              {published === null ? null : (
+                <div>
+                  <dt>Published</dt>
+                  <dd>{published}</dd>
+                </div>
+              )}
+              {updated === null ? null : (
+                <div>
+                  <dt>Updated</dt>
+                  <dd>{updated}</dd>
+                </div>
+              )}
+            </dl>
+            {repository === null ? null : (
+              <a
+                className="marketplace-source-link"
+                href={repository}
+                target="_blank"
+                rel="noreferrer"
+              >
+                <HugeiconsIcon icon={LinkSquare01Icon} aria-hidden />
+                View source
+              </a>
+            )}
+          </aside>
+        </div>
+
+        <aside className="marketplace-cross-link">
+          <span>Building a plugin?</span>
+          <a href="/docs">Read the Plugin Guide</a>
+        </aside>
+      </main>
+      <SiteFooter />
+    </div>
+  );
+}
+
+export function isMarketplaceCategoryId(
+  value: unknown,
+): value is MarketplaceCategoryId {
+  return (
+    typeof value === "string" &&
+    MARKETPLACE_CATEGORIES.some((category) => category.id === value)
+  );
+}
+
+export function isMarketplaceSort(value: unknown): value is MarketplaceSort {
+  return (
+    value === "recently-added" || value === "most-installed" || value === "name"
+  );
+}

--- a/apps/web/src/marketplace/public-marketplace.tsx
+++ b/apps/web/src/marketplace/public-marketplace.tsx
@@ -587,32 +587,6 @@ export function PublicMarketplaceDetailPage({
             <p className="marketplace-detail-description">
               {entry.description}
             </p>
-
-            {entry.screenshots?.length ? (
-              <section className="marketplace-detail-section">
-                <h2>Screenshots</h2>
-                <div className="marketplace-screenshots">
-                  {entry.screenshots.map((screenshot, index) => (
-                    <img
-                      key={screenshot}
-                      src={marketplaceAssetUrl(screenshot)}
-                      alt={`${entry.displayName} screenshot ${index + 1}`}
-                    />
-                  ))}
-                </div>
-              </section>
-            ) : null}
-
-            {moreFromAuthor.length > 0 ? (
-              <section className="marketplace-detail-section">
-                <h2>More from {entry.author.name}</h2>
-                <PluginGrid
-                  entries={moreFromAuthor}
-                  stats={stats}
-                  showCategory
-                />
-              </section>
-            ) : null}
           </article>
 
           <aside className="marketplace-detail-aside">
@@ -653,6 +627,34 @@ export function PublicMarketplaceDetailPage({
               </a>
             )}
           </aside>
+
+          <div className="marketplace-detail-sections">
+            {entry.screenshots?.length ? (
+              <section className="marketplace-detail-section">
+                <h2>Screenshots</h2>
+                <div className="marketplace-screenshots">
+                  {entry.screenshots.map((screenshot, index) => (
+                    <img
+                      key={screenshot}
+                      src={marketplaceAssetUrl(screenshot)}
+                      alt={`${entry.displayName} screenshot ${index + 1}`}
+                    />
+                  ))}
+                </div>
+              </section>
+            ) : null}
+
+            {moreFromAuthor.length > 0 ? (
+              <section className="marketplace-detail-section">
+                <h2>More from {entry.author.name}</h2>
+                <PluginGrid
+                  entries={moreFromAuthor}
+                  stats={stats}
+                  showCategory
+                />
+              </section>
+            ) : null}
+          </div>
         </div>
 
         <aside className="marketplace-cross-link">

--- a/apps/web/src/plugin-guide/copy-surface-reference.test.ts
+++ b/apps/web/src/plugin-guide/copy-surface-reference.test.ts
@@ -1,0 +1,14 @@
+import { SURFACE_GROUPS } from "@bb/plugin-api-map";
+import { describe, expect, it } from "vitest";
+
+import { pluginSurfaceReferenceText } from "./copy-surface-reference.js";
+
+describe("plugin surface references", () => {
+  it("copies the package's plain-text agent reference", () => {
+    const surface = SURFACE_GROUPS[0]!.surfaces[0]!;
+    const text = pluginSurfaceReferenceText(surface);
+    expect(text).toContain(surface.title);
+    expect(text).toContain(surface.apiSymbols[0]!);
+    expect(text).not.toContain("<");
+  });
+});

--- a/apps/web/src/plugin-guide/copy-surface-reference.ts
+++ b/apps/web/src/plugin-guide/copy-surface-reference.ts
@@ -6,7 +6,8 @@ import {
 import { copyPlainText } from "../lib/copy-plain-text.js";
 
 export function pluginSurfaceReferenceText(surface: PluginSurface): string {
-  return createPluginSurfaceAgentReference(surface).clipboard.text;
+  const reference = createPluginSurfaceAgentReference(surface);
+  return `${reference.clipboard.text.trim()}\n\n${reference.context}`;
 }
 
 export function copyPluginSurfaceReferenceText(

--- a/apps/web/src/plugin-guide/copy-surface-reference.ts
+++ b/apps/web/src/plugin-guide/copy-surface-reference.ts
@@ -1,0 +1,16 @@
+import {
+  createPluginSurfaceAgentReference,
+  type PluginSurface,
+} from "@bb/plugin-api-map";
+
+import { copyPlainText } from "../lib/copy-plain-text.js";
+
+export function pluginSurfaceReferenceText(surface: PluginSurface): string {
+  return createPluginSurfaceAgentReference(surface).clipboard.text;
+}
+
+export function copyPluginSurfaceReferenceText(
+  surface: PluginSurface,
+): Promise<boolean> {
+  return copyPlainText(pluginSurfaceReferenceText(surface));
+}

--- a/apps/web/src/plugin-guide/plugin-guide-page.tsx
+++ b/apps/web/src/plugin-guide/plugin-guide-page.tsx
@@ -1,0 +1,242 @@
+import { CREATE_PLUGIN_PROMPT } from "@bb/client-core";
+import {
+  renderSurfaceCopy,
+  SURFACE_GROUPS,
+  type PluginSurface,
+} from "@bb/plugin-api-map";
+import { Copy01Icon, Tick02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { lazy, Suspense, useEffect, useState } from "react";
+
+import { initAnalytics } from "../landing/analytics.js";
+import { InstallOptions } from "../landing/cta.js";
+import { SiteFooter, SiteNav } from "../landing/site-chrome.js";
+import { copyPlainText } from "../lib/copy-plain-text.js";
+import {
+  copyPluginSurfaceReferenceText,
+  pluginSurfaceReferenceText,
+} from "./copy-surface-reference.js";
+
+type CopyStatus = "idle" | "copied" | "failed";
+
+const LazyProductMap = lazy(() =>
+  import("@bb/plugin-api-map").then((module) => ({
+    default: module.ProductMap,
+  })),
+);
+
+function SurfaceReference({ surface }: { surface: PluginSurface }) {
+  const [status, setStatus] = useState<CopyStatus>("idle");
+  const reference = pluginSurfaceReferenceText(surface);
+
+  const copyReference = async () => {
+    setStatus(
+      (await copyPluginSurfaceReferenceText(surface)) ? "copied" : "failed",
+    );
+  };
+
+  return (
+    <div className="guide-reference">
+      <code className="guide-reference-text">{reference}</code>
+      <button
+        type="button"
+        onClick={() => void copyReference()}
+        aria-label={`Copy agent reference for ${surface.title}`}
+      >
+        <HugeiconsIcon
+          icon={status === "copied" ? Tick02Icon : Copy01Icon}
+          aria-hidden
+        />
+        {status === "copied"
+          ? "Copied"
+          : status === "failed"
+            ? "Copy failed"
+            : "Copy"}
+      </button>
+    </div>
+  );
+}
+
+function SurfaceArticle({ surface }: { surface: PluginSurface }) {
+  return (
+    <article id={`surface-${surface.id}`} className="guide-surface-card">
+      <div className="guide-surface-title-row">
+        <h3>{surface.title}</h3>
+        {surface.experimental ? (
+          <span className="guide-experimental">Experimental</span>
+        ) : null}
+      </div>
+      <p>{renderSurfaceCopy(surface.summary)}</p>
+      <SurfaceReference surface={surface} />
+      <div className="guide-symbols">
+        <span>SDK symbols</span>
+        <ul aria-label={`SDK symbols for ${surface.title}`}>
+          {surface.apiSymbols.map((symbol) => (
+            <li key={symbol}>
+              <code>{symbol}</code>
+            </li>
+          ))}
+        </ul>
+      </div>
+      {surface.bullets.length > 0 || surface.firstParty?.length ? (
+        <details>
+          <summary>How it works</summary>
+          {surface.bullets.length > 0 ? (
+            <ul className="guide-surface-bullets">
+              {surface.bullets.map((bullet) => (
+                <li key={bullet}>{renderSurfaceCopy(bullet)}</li>
+              ))}
+            </ul>
+          ) : null}
+          {surface.firstParty?.length ? (
+            <p className="guide-used-by">
+              <strong>Used by:</strong> {surface.firstParty.join(", ")}
+            </p>
+          ) : null}
+        </details>
+      ) : null}
+    </article>
+  );
+}
+
+export function PluginSurfaceDocument() {
+  return (
+    <section id="plugin-surfaces" className="guide-document">
+      <header className="guide-document-head">
+        <h2>Every surface a plugin can use</h2>
+        <p>
+          Organized by where each surface appears. Copy an agent reference to
+          give any coding agent the exact SDK context in plain text.
+        </p>
+      </header>
+
+      {SURFACE_GROUPS.map((group) => (
+        <section
+          key={group.id}
+          id={`surface-group-${group.id}`}
+          className="guide-group"
+        >
+          <header>
+            <h2>{group.title}</h2>
+            <p>{group.blurb}</p>
+          </header>
+          <div className="guide-surface-grid">
+            {group.surfaces.map((surface) => (
+              <SurfaceArticle key={surface.id} surface={surface} />
+            ))}
+          </div>
+        </section>
+      ))}
+    </section>
+  );
+}
+
+export function PluginGuidePage() {
+  const [promptStatus, setPromptStatus] = useState<CopyStatus>("idle");
+  useEffect(() => {
+    initAnalytics();
+  }, []);
+
+  const copyCreatePrompt = async () => {
+    setPromptStatus(
+      (await copyPlainText(CREATE_PLUGIN_PROMPT)) ? "copied" : "failed",
+    );
+  };
+
+  return (
+    <div className="wrap plugin-pages-wrap">
+      <SiteNav current="plugins" />
+      <main className="guide-main">
+        <header className="plugin-page-head">
+          <h1>Build plugins for bb</h1>
+          <p>
+            Extend the app, the command line, and the agents inside bb. This is
+            the complete reference to the product surfaces plugins can use.
+          </p>
+          <div className="plugin-page-actions">
+            <button
+              type="button"
+              className="btn btn-primary"
+              onClick={() => void copyCreatePrompt()}
+            >
+              {promptStatus === "copied"
+                ? "Build prompt copied"
+                : "Build a plugin"}
+            </button>
+            <a className="btn btn-ghost" href="#get-bb">
+              Get bb
+            </a>
+            <a className="plugin-text-link" href="/marketplace">
+              Browse the Marketplace
+            </a>
+          </div>
+          <p className="guide-prompt-status" role="status" aria-live="polite">
+            {promptStatus === "copied"
+              ? "Copied as plain text. Paste it into any coding agent."
+              : promptStatus === "failed"
+                ? "Copy failed. Select the prompt below and copy it manually."
+                : "Copies the same plain-text prompt bb uses to start a plugin."}
+          </p>
+          <code className="guide-create-prompt">{CREATE_PLUGIN_PROMPT}</code>
+        </header>
+
+        <nav className="guide-index" aria-label="Plugin surface groups">
+          {SURFACE_GROUPS.map((group) => (
+            <a key={group.id} href={`#surface-group-${group.id}`}>
+              {group.title}
+              <span>{group.surfaces.length}</span>
+            </a>
+          ))}
+        </nav>
+
+        <section
+          className="guide-map-section"
+          aria-labelledby="guide-map-title"
+        >
+          <div className="guide-map-viewport" data-guide-stage-viewport>
+            <Suspense
+              fallback={
+                <div className="guide-map-loading" role="status">
+                  Loading the interactive surface map…
+                </div>
+              }
+            >
+              <LazyProductMap
+                tone="primary"
+                onCopyForAgent={copyPluginSurfaceReferenceText}
+                header={
+                  <header className="guide-map-head">
+                    <h2 id="guide-map-title">See where plugins plug in</h2>
+                    <p>
+                      Move through bb one product surface at a time, then open a
+                      marker to inspect the SDK capability behind it.
+                    </p>
+                  </header>
+                }
+              />
+            </Suspense>
+          </div>
+        </section>
+
+        <PluginSurfaceDocument />
+
+        <section id="get-bb" className="guide-install">
+          <h2>Get bb</h2>
+          <p>Free, open source, and local-first. Install in under a minute.</p>
+          <InstallOptions placement="plugin-guide" />
+        </section>
+
+        <aside className="plugin-cross-link">
+          <div>
+            <strong>Looking for something ready-made?</strong>
+            <span>Explore plugins built by the bb community.</span>
+          </div>
+          <a className="btn btn-ghost" href="/marketplace">
+            Browse the Marketplace
+          </a>
+        </aside>
+      </main>
+      <SiteFooter />
+    </div>
+  );
+}

--- a/apps/web/src/plugin-guide/plugin-guide.css
+++ b/apps/web/src/plugin-guide/plugin-guide.css
@@ -1,0 +1,436 @@
+@import "../components/ui/theme.css";
+
+.plugin-pages-wrap {
+  max-width: 1120px;
+}
+
+.guide-main {
+  padding-bottom: 88px;
+}
+
+.plugin-page-head {
+  max-width: 760px;
+  padding: 72px 0 48px;
+  border-bottom: 1px solid var(--border-soft);
+}
+
+.plugin-page-head h1 {
+  color: var(--heading);
+  font-size: clamp(38px, 6vw, 54px);
+  font-weight: 700;
+  letter-spacing: -0.045em;
+  line-height: 1.04;
+}
+
+.plugin-page-head > p {
+  max-width: 650px;
+  margin-top: 18px;
+  color: var(--dim);
+  font-size: 17px;
+}
+
+.plugin-page-actions {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  margin-top: 30px;
+}
+
+.plugin-page-actions button {
+  font-family: inherit;
+}
+
+.plugin-text-link {
+  color: var(--dim);
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.plugin-text-link:hover {
+  color: var(--ink);
+}
+
+.guide-prompt-status {
+  min-height: 20px;
+  margin-top: 12px;
+  color: var(--subtle);
+  font-size: 12.5px;
+}
+
+.guide-create-prompt {
+  display: block;
+  width: fit-content;
+  max-width: 100%;
+  margin-top: 7px;
+  padding: 7px 10px;
+  overflow-wrap: anywhere;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--ink);
+  font-size: 11.5px;
+}
+
+.guide-index {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 32px 0 56px;
+}
+
+.guide-index a {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 7px 11px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--bg);
+  color: var(--dim);
+  font-size: 13px;
+}
+
+.guide-index a:hover {
+  background: var(--state-hover);
+  color: var(--ink);
+}
+
+.guide-index span {
+  color: var(--subtle);
+  font-variant-numeric: tabular-nums;
+}
+
+.guide-map-section {
+  margin-bottom: 88px;
+}
+
+.guide-map-viewport {
+  padding: 28px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--bg);
+  container-type: inline-size;
+  --guide-stage-gap: clamp(8px, 2vw, 24px);
+}
+
+.guide-map-head {
+  max-width: 700px;
+}
+
+.guide-map-head h2,
+.guide-install h2 {
+  color: var(--heading);
+  font-size: clamp(28px, 4vw, 36px);
+  font-weight: 700;
+  letter-spacing: -0.025em;
+}
+
+.guide-map-head p,
+.guide-install > p {
+  max-width: 640px;
+  margin-top: 10px;
+  color: var(--dim);
+}
+
+.guide-map-loading {
+  display: grid;
+  padding: 80px 0;
+  place-items: center;
+  color: var(--subtle);
+  font-size: 13px;
+}
+
+.guide-document-head {
+  max-width: 640px;
+  padding-bottom: 40px;
+}
+
+.guide-document-head h2,
+.guide-group > header h2 {
+  color: var(--heading);
+  font-weight: 700;
+  letter-spacing: -0.025em;
+}
+
+.guide-document-head h2 {
+  font-size: clamp(28px, 4vw, 36px);
+}
+
+.guide-document-head p,
+.guide-group > header p {
+  margin-top: 10px;
+  color: var(--dim);
+}
+
+.guide-group {
+  padding: 48px 0 8px;
+  border-top: 1px solid var(--border-soft);
+  scroll-margin-top: 24px;
+}
+
+.guide-group > header {
+  max-width: 680px;
+  margin-bottom: 24px;
+}
+
+.guide-group > header h2 {
+  font-size: 24px;
+}
+
+.guide-surface-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.guide-surface-card {
+  min-width: 0;
+  padding: 22px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--bg);
+  scroll-margin-top: 24px;
+}
+
+.guide-surface-title-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.guide-surface-title-row h3 {
+  min-width: 0;
+  color: var(--heading-sub);
+  font-size: 17px;
+  font-weight: 650;
+  letter-spacing: -0.012em;
+  line-height: 1.3;
+}
+
+.guide-experimental {
+  flex: 0 0 auto;
+  padding: 2px 7px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--subtle);
+  font-size: 10.5px;
+  font-weight: 500;
+}
+
+.guide-surface-card > p {
+  margin-top: 10px;
+  color: var(--dim);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.guide-surface-card p code,
+.guide-surface-bullets code {
+  padding: 1px 4px;
+  border-radius: 4px;
+  background: var(--surface-recessed);
+  color: var(--ink);
+  font-size: 0.88em;
+}
+
+.guide-reference {
+  display: flex;
+  align-items: stretch;
+  min-width: 0;
+  margin-top: 18px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface);
+  overflow: hidden;
+}
+
+.guide-reference-text {
+  flex: 1;
+  min-width: 0;
+  padding: 9px 10px;
+  overflow: hidden;
+  color: var(--dim);
+  font-size: 11px;
+  line-height: 1.4;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.guide-reference button {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 0 10px;
+  border: 0;
+  border-left: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--dim);
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.guide-reference button:hover {
+  background: var(--state-hover);
+  color: var(--ink);
+}
+
+.guide-reference button svg {
+  width: 13px;
+  height: 13px;
+}
+
+.guide-symbols {
+  margin-top: 18px;
+}
+
+.guide-symbols > span {
+  color: var(--subtle);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.guide-symbols ul {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 7px;
+  list-style: none;
+}
+
+.guide-symbols li {
+  min-width: 0;
+}
+
+.guide-symbols code {
+  display: block;
+  max-width: 100%;
+  padding: 3px 7px;
+  border-radius: 6px;
+  background: var(--surface-recessed);
+  color: var(--ink);
+  font-size: 10.5px;
+  overflow-wrap: anywhere;
+}
+
+.guide-surface-card details {
+  margin-top: 18px;
+  padding-top: 14px;
+  border-top: 1px solid var(--border-soft);
+}
+
+.guide-surface-card summary {
+  color: var(--dim);
+  font-size: 12.5px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.guide-surface-bullets {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 12px;
+  padding-left: 18px;
+  color: var(--dim);
+  font-size: 13px;
+}
+
+.guide-used-by {
+  margin-top: 12px;
+  color: var(--subtle);
+  font-size: 12.5px;
+}
+
+.guide-used-by strong {
+  color: var(--dim);
+  font-weight: 600;
+}
+
+.plugin-cross-link {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  margin-top: 64px;
+  padding: 24px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--surface);
+}
+
+.guide-install {
+  margin-top: 64px;
+  padding: 52px 24px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--surface);
+  text-align: center;
+}
+
+.guide-install > p {
+  margin-inline: auto;
+}
+
+.guide-install .install-options {
+  margin-top: 28px;
+}
+
+.plugin-cross-link div {
+  display: flex;
+  flex-direction: column;
+}
+
+.plugin-cross-link strong {
+  color: var(--heading-sub);
+  font-size: 15px;
+  font-weight: 650;
+}
+
+.plugin-cross-link span {
+  margin-top: 3px;
+  color: var(--dim);
+  font-size: 13.5px;
+}
+
+@media (max-width: 720px) {
+  .plugin-pages-wrap {
+    padding-inline: 20px;
+  }
+
+  .plugin-pages-wrap .nav-links {
+    gap: 10px;
+    font-size: 13px;
+  }
+
+  .plugin-page-head {
+    padding-top: 52px;
+  }
+
+  .guide-surface-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 520px) {
+  .plugin-pages-wrap .nav-links a[href="/changelog"] {
+    display: none;
+  }
+
+  .plugin-page-actions,
+  .plugin-cross-link {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .plugin-page-actions .btn,
+  .plugin-cross-link .btn {
+    width: 100%;
+    text-align: center;
+  }
+
+  .guide-surface-card {
+    padding: 18px;
+  }
+}

--- a/apps/web/src/plugin-guide/surface-document.test.tsx
+++ b/apps/web/src/plugin-guide/surface-document.test.tsx
@@ -1,0 +1,21 @@
+import { SURFACE_GROUPS } from "@bb/plugin-api-map";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { PluginSurfaceDocument } from "./plugin-guide-page.js";
+
+describe("PluginSurfaceDocument", () => {
+  it("server-renders every title, summary, reference, and SDK symbol", () => {
+    const html = renderToStaticMarkup(<PluginSurfaceDocument />);
+    for (const group of SURFACE_GROUPS) {
+      expect(html).toContain(group.title);
+      for (const surface of group.surfaces) {
+        expect(html).toContain(surface.title);
+        expect(html).toContain(
+          surface.summary.split(" ").slice(0, 4).join(" "),
+        );
+        for (const symbol of surface.apiSymbols) expect(html).toContain(symbol);
+      }
+    }
+  });
+});

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -5,13 +5,13 @@
 import { Route as rootRouteImport } from "./routes/__root";
 import { Route as PrivacyRouteImport } from "./routes/privacy";
 import { Route as MarketplaceRouteImport } from "./routes/marketplace_";
+import { Route as DocsRouteImport } from "./routes/docs";
 import { Route as DashboardRouteImport } from "./routes/dashboard";
 import { Route as ChangelogRouteImport } from "./routes/changelog";
 import { Route as BlogRouteImport } from "./routes/blog";
 import { Route as IndexRouteImport } from "./routes/index";
 import { Route as MarketplacePluginIdRouteImport } from "./routes/marketplace_.$pluginId";
 import { Route as DownloadMacosRouteImport } from "./routes/download.macos";
-import { Route as DocsRouteImport } from "./routes/docs";
 import { Route as BlogSlugRouteImport } from "./routes/blog_.$slug";
 import { Route as ApiSubscribeRouteImport } from "./routes/api.subscribe";
 import { Route as DotwellKnownAssetlinksDotjsonRouteImport } from "./routes/[.]well-known.assetlinks[.]json";
@@ -32,6 +32,11 @@ const PrivacyRoute = PrivacyRouteImport.update({
 const MarketplaceRoute = MarketplaceRouteImport.update({
   id: "/marketplace_",
   path: "/marketplace",
+  getParentRoute: () => rootRouteImport,
+} as any);
+const DocsRoute = DocsRouteImport.update({
+  id: "/docs",
+  path: "/docs",
   getParentRoute: () => rootRouteImport,
 } as any);
 const DashboardRoute = DashboardRouteImport.update({
@@ -62,11 +67,6 @@ const MarketplacePluginIdRoute = MarketplacePluginIdRouteImport.update({
 const DownloadMacosRoute = DownloadMacosRouteImport.update({
   id: "/download/macos",
   path: "/download/macos",
-  getParentRoute: () => rootRouteImport,
-} as any);
-const DocsRoute = DocsRouteImport.update({
-  id: "/docs",
-  path: "/docs",
   getParentRoute: () => rootRouteImport,
 } as any);
 const BlogSlugRoute = BlogSlugRouteImport.update({
@@ -132,13 +132,13 @@ export interface FileRoutesByFullPath {
   "/blog": typeof BlogRoute;
   "/changelog": typeof ChangelogRoute;
   "/dashboard": typeof DashboardRoute;
+  "/docs": typeof DocsRoute;
   "/marketplace": typeof MarketplaceRouteWithChildren;
   "/privacy": typeof PrivacyRoute;
   "/.well-known/apple-app-site-association": typeof DotwellKnownAppleAppSiteAssociationRoute;
   "/.well-known/assetlinks.json": typeof DotwellKnownAssetlinksDotjsonRoute;
   "/api/subscribe": typeof ApiSubscribeRoute;
   "/blog/$slug": typeof BlogSlugRoute;
-  "/docs": typeof DocsRoute;
   "/download/macos": typeof DownloadMacosRoute;
   "/marketplace/$pluginId": typeof MarketplacePluginIdRoute;
   "/api/auth/$": typeof ApiAuthSplatRoute;
@@ -154,13 +154,13 @@ export interface FileRoutesByTo {
   "/blog": typeof BlogRoute;
   "/changelog": typeof ChangelogRoute;
   "/dashboard": typeof DashboardRoute;
+  "/docs": typeof DocsRoute;
   "/marketplace": typeof MarketplaceRouteWithChildren;
   "/privacy": typeof PrivacyRoute;
   "/.well-known/apple-app-site-association": typeof DotwellKnownAppleAppSiteAssociationRoute;
   "/.well-known/assetlinks.json": typeof DotwellKnownAssetlinksDotjsonRoute;
   "/api/subscribe": typeof ApiSubscribeRoute;
   "/blog/$slug": typeof BlogSlugRoute;
-  "/docs": typeof DocsRoute;
   "/download/macos": typeof DownloadMacosRoute;
   "/marketplace/$pluginId": typeof MarketplacePluginIdRoute;
   "/api/auth/$": typeof ApiAuthSplatRoute;
@@ -177,13 +177,13 @@ export interface FileRoutesById {
   "/blog": typeof BlogRoute;
   "/changelog": typeof ChangelogRoute;
   "/dashboard": typeof DashboardRoute;
+  "/docs": typeof DocsRoute;
   "/marketplace_": typeof MarketplaceRouteWithChildren;
   "/privacy": typeof PrivacyRoute;
   "/.well-known/apple-app-site-association": typeof DotwellKnownAppleAppSiteAssociationRoute;
   "/.well-known/assetlinks.json": typeof DotwellKnownAssetlinksDotjsonRoute;
   "/api/subscribe": typeof ApiSubscribeRoute;
   "/blog_/$slug": typeof BlogSlugRoute;
-  "/docs": typeof DocsRoute;
   "/download/macos": typeof DownloadMacosRoute;
   "/marketplace_/$pluginId": typeof MarketplacePluginIdRoute;
   "/api/auth/$": typeof ApiAuthSplatRoute;
@@ -201,13 +201,13 @@ export interface FileRouteTypes {
     | "/blog"
     | "/changelog"
     | "/dashboard"
+    | "/docs"
     | "/marketplace"
     | "/privacy"
     | "/.well-known/apple-app-site-association"
     | "/.well-known/assetlinks.json"
     | "/api/subscribe"
     | "/blog/$slug"
-    | "/docs"
     | "/download/macos"
     | "/marketplace/$pluginId"
     | "/api/auth/$"
@@ -223,13 +223,13 @@ export interface FileRouteTypes {
     | "/blog"
     | "/changelog"
     | "/dashboard"
+    | "/docs"
     | "/marketplace"
     | "/privacy"
     | "/.well-known/apple-app-site-association"
     | "/.well-known/assetlinks.json"
     | "/api/subscribe"
     | "/blog/$slug"
-    | "/docs"
     | "/download/macos"
     | "/marketplace/$pluginId"
     | "/api/auth/$"
@@ -245,13 +245,13 @@ export interface FileRouteTypes {
     | "/blog"
     | "/changelog"
     | "/dashboard"
+    | "/docs"
     | "/marketplace_"
     | "/privacy"
     | "/.well-known/apple-app-site-association"
     | "/.well-known/assetlinks.json"
     | "/api/subscribe"
     | "/blog_/$slug"
-    | "/docs"
     | "/download/macos"
     | "/marketplace_/$pluginId"
     | "/api/auth/$"
@@ -268,13 +268,13 @@ export interface RootRouteChildren {
   BlogRoute: typeof BlogRoute;
   ChangelogRoute: typeof ChangelogRoute;
   DashboardRoute: typeof DashboardRoute;
+  DocsRoute: typeof DocsRoute;
   MarketplaceRoute: typeof MarketplaceRouteWithChildren;
   PrivacyRoute: typeof PrivacyRoute;
   DotwellKnownAppleAppSiteAssociationRoute: typeof DotwellKnownAppleAppSiteAssociationRoute;
   DotwellKnownAssetlinksDotjsonRoute: typeof DotwellKnownAssetlinksDotjsonRoute;
   ApiSubscribeRoute: typeof ApiSubscribeRoute;
   BlogSlugRoute: typeof BlogSlugRoute;
-  DocsRoute: typeof DocsRoute;
   DownloadMacosRoute: typeof DownloadMacosRoute;
   ApiAuthSplatRoute: typeof ApiAuthSplatRoute;
   ApiConnectMachineCodeRoute: typeof ApiConnectMachineCodeRoute;
@@ -299,6 +299,13 @@ declare module "@tanstack/react-router" {
       path: "/marketplace";
       fullPath: "/marketplace";
       preLoaderRoute: typeof MarketplaceRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/docs": {
+      id: "/docs";
+      path: "/docs";
+      fullPath: "/docs";
+      preLoaderRoute: typeof DocsRouteImport;
       parentRoute: typeof rootRouteImport;
     };
     "/dashboard": {
@@ -341,13 +348,6 @@ declare module "@tanstack/react-router" {
       path: "/download/macos";
       fullPath: "/download/macos";
       preLoaderRoute: typeof DownloadMacosRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/docs": {
-      id: "/docs";
-      path: "/docs";
-      fullPath: "/docs";
-      preLoaderRoute: typeof DocsRouteImport;
       parentRoute: typeof rootRouteImport;
     };
     "/blog_/$slug": {
@@ -447,6 +447,7 @@ const rootRouteChildren: RootRouteChildren = {
   BlogRoute: BlogRoute,
   ChangelogRoute: ChangelogRoute,
   DashboardRoute: DashboardRoute,
+  DocsRoute: DocsRoute,
   MarketplaceRoute: MarketplaceRouteWithChildren,
   PrivacyRoute: PrivacyRoute,
   DotwellKnownAppleAppSiteAssociationRoute:
@@ -454,7 +455,6 @@ const rootRouteChildren: RootRouteChildren = {
   DotwellKnownAssetlinksDotjsonRoute: DotwellKnownAssetlinksDotjsonRoute,
   ApiSubscribeRoute: ApiSubscribeRoute,
   BlogSlugRoute: BlogSlugRoute,
-  DocsRoute: DocsRoute,
   DownloadMacosRoute: DownloadMacosRoute,
   ApiAuthSplatRoute: ApiAuthSplatRoute,
   ApiConnectMachineCodeRoute: ApiConnectMachineCodeRoute,

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -4,15 +4,19 @@
 
 import { Route as rootRouteImport } from "./routes/__root";
 import { Route as PrivacyRouteImport } from "./routes/privacy";
+import { Route as MarketplaceRouteImport } from "./routes/marketplace_";
 import { Route as DashboardRouteImport } from "./routes/dashboard";
 import { Route as ChangelogRouteImport } from "./routes/changelog";
 import { Route as BlogRouteImport } from "./routes/blog";
 import { Route as IndexRouteImport } from "./routes/index";
+import { Route as MarketplacePluginIdRouteImport } from "./routes/marketplace_.$pluginId";
 import { Route as DownloadMacosRouteImport } from "./routes/download.macos";
+import { Route as DocsRouteImport } from "./routes/docs";
 import { Route as BlogSlugRouteImport } from "./routes/blog_.$slug";
 import { Route as ApiSubscribeRouteImport } from "./routes/api.subscribe";
 import { Route as DotwellKnownAssetlinksDotjsonRouteImport } from "./routes/[.]well-known.assetlinks[.]json";
 import { Route as DotwellKnownAppleAppSiteAssociationRouteImport } from "./routes/[.]well-known.apple-app-site-association";
+import { Route as MarketplaceV2SplatRouteImport } from "./routes/marketplace.v2.$";
 import { Route as MarketplaceV1SplatRouteImport } from "./routes/marketplace.v1.$";
 import { Route as ApiConnectRevokeMachineRouteImport } from "./routes/api.connect.revoke-machine";
 import { Route as ApiConnectRedeemMachineRouteImport } from "./routes/api.connect.redeem-machine";
@@ -23,6 +27,11 @@ import { Route as ApiAuthSplatRouteImport } from "./routes/api.auth.$";
 const PrivacyRoute = PrivacyRouteImport.update({
   id: "/privacy",
   path: "/privacy",
+  getParentRoute: () => rootRouteImport,
+} as any);
+const MarketplaceRoute = MarketplaceRouteImport.update({
+  id: "/marketplace_",
+  path: "/marketplace",
   getParentRoute: () => rootRouteImport,
 } as any);
 const DashboardRoute = DashboardRouteImport.update({
@@ -45,9 +54,19 @@ const IndexRoute = IndexRouteImport.update({
   path: "/",
   getParentRoute: () => rootRouteImport,
 } as any);
+const MarketplacePluginIdRoute = MarketplacePluginIdRouteImport.update({
+  id: "/$pluginId",
+  path: "/$pluginId",
+  getParentRoute: () => MarketplaceRoute,
+} as any);
 const DownloadMacosRoute = DownloadMacosRouteImport.update({
   id: "/download/macos",
   path: "/download/macos",
+  getParentRoute: () => rootRouteImport,
+} as any);
+const DocsRoute = DocsRouteImport.update({
+  id: "/docs",
+  path: "/docs",
   getParentRoute: () => rootRouteImport,
 } as any);
 const BlogSlugRoute = BlogSlugRouteImport.update({
@@ -72,6 +91,11 @@ const DotwellKnownAppleAppSiteAssociationRoute =
     path: "/.well-known/apple-app-site-association",
     getParentRoute: () => rootRouteImport,
   } as any);
+const MarketplaceV2SplatRoute = MarketplaceV2SplatRouteImport.update({
+  id: "/marketplace/v2/$",
+  path: "/marketplace/v2/$",
+  getParentRoute: () => rootRouteImport,
+} as any);
 const MarketplaceV1SplatRoute = MarketplaceV1SplatRouteImport.update({
   id: "/marketplace/v1/$",
   path: "/marketplace/v1/$",
@@ -108,36 +132,44 @@ export interface FileRoutesByFullPath {
   "/blog": typeof BlogRoute;
   "/changelog": typeof ChangelogRoute;
   "/dashboard": typeof DashboardRoute;
+  "/marketplace": typeof MarketplaceRouteWithChildren;
   "/privacy": typeof PrivacyRoute;
   "/.well-known/apple-app-site-association": typeof DotwellKnownAppleAppSiteAssociationRoute;
   "/.well-known/assetlinks.json": typeof DotwellKnownAssetlinksDotjsonRoute;
   "/api/subscribe": typeof ApiSubscribeRoute;
   "/blog/$slug": typeof BlogSlugRoute;
+  "/docs": typeof DocsRoute;
   "/download/macos": typeof DownloadMacosRoute;
+  "/marketplace/$pluginId": typeof MarketplacePluginIdRoute;
   "/api/auth/$": typeof ApiAuthSplatRoute;
   "/api/connect/machine-code": typeof ApiConnectMachineCodeRoute;
   "/api/connect/redeem": typeof ApiConnectRedeemRoute;
   "/api/connect/redeem-machine": typeof ApiConnectRedeemMachineRoute;
   "/api/connect/revoke-machine": typeof ApiConnectRevokeMachineRoute;
   "/marketplace/v1/$": typeof MarketplaceV1SplatRoute;
+  "/marketplace/v2/$": typeof MarketplaceV2SplatRoute;
 }
 export interface FileRoutesByTo {
   "/": typeof IndexRoute;
   "/blog": typeof BlogRoute;
   "/changelog": typeof ChangelogRoute;
   "/dashboard": typeof DashboardRoute;
+  "/marketplace": typeof MarketplaceRouteWithChildren;
   "/privacy": typeof PrivacyRoute;
   "/.well-known/apple-app-site-association": typeof DotwellKnownAppleAppSiteAssociationRoute;
   "/.well-known/assetlinks.json": typeof DotwellKnownAssetlinksDotjsonRoute;
   "/api/subscribe": typeof ApiSubscribeRoute;
   "/blog/$slug": typeof BlogSlugRoute;
+  "/docs": typeof DocsRoute;
   "/download/macos": typeof DownloadMacosRoute;
+  "/marketplace/$pluginId": typeof MarketplacePluginIdRoute;
   "/api/auth/$": typeof ApiAuthSplatRoute;
   "/api/connect/machine-code": typeof ApiConnectMachineCodeRoute;
   "/api/connect/redeem": typeof ApiConnectRedeemRoute;
   "/api/connect/redeem-machine": typeof ApiConnectRedeemMachineRoute;
   "/api/connect/revoke-machine": typeof ApiConnectRevokeMachineRoute;
   "/marketplace/v1/$": typeof MarketplaceV1SplatRoute;
+  "/marketplace/v2/$": typeof MarketplaceV2SplatRoute;
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport;
@@ -145,18 +177,22 @@ export interface FileRoutesById {
   "/blog": typeof BlogRoute;
   "/changelog": typeof ChangelogRoute;
   "/dashboard": typeof DashboardRoute;
+  "/marketplace_": typeof MarketplaceRouteWithChildren;
   "/privacy": typeof PrivacyRoute;
   "/.well-known/apple-app-site-association": typeof DotwellKnownAppleAppSiteAssociationRoute;
   "/.well-known/assetlinks.json": typeof DotwellKnownAssetlinksDotjsonRoute;
   "/api/subscribe": typeof ApiSubscribeRoute;
   "/blog_/$slug": typeof BlogSlugRoute;
+  "/docs": typeof DocsRoute;
   "/download/macos": typeof DownloadMacosRoute;
+  "/marketplace_/$pluginId": typeof MarketplacePluginIdRoute;
   "/api/auth/$": typeof ApiAuthSplatRoute;
   "/api/connect/machine-code": typeof ApiConnectMachineCodeRoute;
   "/api/connect/redeem": typeof ApiConnectRedeemRoute;
   "/api/connect/redeem-machine": typeof ApiConnectRedeemMachineRoute;
   "/api/connect/revoke-machine": typeof ApiConnectRevokeMachineRoute;
   "/marketplace/v1/$": typeof MarketplaceV1SplatRoute;
+  "/marketplace/v2/$": typeof MarketplaceV2SplatRoute;
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath;
@@ -165,54 +201,66 @@ export interface FileRouteTypes {
     | "/blog"
     | "/changelog"
     | "/dashboard"
+    | "/marketplace"
     | "/privacy"
     | "/.well-known/apple-app-site-association"
     | "/.well-known/assetlinks.json"
     | "/api/subscribe"
     | "/blog/$slug"
+    | "/docs"
     | "/download/macos"
+    | "/marketplace/$pluginId"
     | "/api/auth/$"
     | "/api/connect/machine-code"
     | "/api/connect/redeem"
     | "/api/connect/redeem-machine"
     | "/api/connect/revoke-machine"
-    | "/marketplace/v1/$";
+    | "/marketplace/v1/$"
+    | "/marketplace/v2/$";
   fileRoutesByTo: FileRoutesByTo;
   to:
     | "/"
     | "/blog"
     | "/changelog"
     | "/dashboard"
+    | "/marketplace"
     | "/privacy"
     | "/.well-known/apple-app-site-association"
     | "/.well-known/assetlinks.json"
     | "/api/subscribe"
     | "/blog/$slug"
+    | "/docs"
     | "/download/macos"
+    | "/marketplace/$pluginId"
     | "/api/auth/$"
     | "/api/connect/machine-code"
     | "/api/connect/redeem"
     | "/api/connect/redeem-machine"
     | "/api/connect/revoke-machine"
-    | "/marketplace/v1/$";
+    | "/marketplace/v1/$"
+    | "/marketplace/v2/$";
   id:
     | "__root__"
     | "/"
     | "/blog"
     | "/changelog"
     | "/dashboard"
+    | "/marketplace_"
     | "/privacy"
     | "/.well-known/apple-app-site-association"
     | "/.well-known/assetlinks.json"
     | "/api/subscribe"
     | "/blog_/$slug"
+    | "/docs"
     | "/download/macos"
+    | "/marketplace_/$pluginId"
     | "/api/auth/$"
     | "/api/connect/machine-code"
     | "/api/connect/redeem"
     | "/api/connect/redeem-machine"
     | "/api/connect/revoke-machine"
-    | "/marketplace/v1/$";
+    | "/marketplace/v1/$"
+    | "/marketplace/v2/$";
   fileRoutesById: FileRoutesById;
 }
 export interface RootRouteChildren {
@@ -220,11 +268,13 @@ export interface RootRouteChildren {
   BlogRoute: typeof BlogRoute;
   ChangelogRoute: typeof ChangelogRoute;
   DashboardRoute: typeof DashboardRoute;
+  MarketplaceRoute: typeof MarketplaceRouteWithChildren;
   PrivacyRoute: typeof PrivacyRoute;
   DotwellKnownAppleAppSiteAssociationRoute: typeof DotwellKnownAppleAppSiteAssociationRoute;
   DotwellKnownAssetlinksDotjsonRoute: typeof DotwellKnownAssetlinksDotjsonRoute;
   ApiSubscribeRoute: typeof ApiSubscribeRoute;
   BlogSlugRoute: typeof BlogSlugRoute;
+  DocsRoute: typeof DocsRoute;
   DownloadMacosRoute: typeof DownloadMacosRoute;
   ApiAuthSplatRoute: typeof ApiAuthSplatRoute;
   ApiConnectMachineCodeRoute: typeof ApiConnectMachineCodeRoute;
@@ -232,6 +282,7 @@ export interface RootRouteChildren {
   ApiConnectRedeemMachineRoute: typeof ApiConnectRedeemMachineRoute;
   ApiConnectRevokeMachineRoute: typeof ApiConnectRevokeMachineRoute;
   MarketplaceV1SplatRoute: typeof MarketplaceV1SplatRoute;
+  MarketplaceV2SplatRoute: typeof MarketplaceV2SplatRoute;
 }
 
 declare module "@tanstack/react-router" {
@@ -241,6 +292,13 @@ declare module "@tanstack/react-router" {
       path: "/privacy";
       fullPath: "/privacy";
       preLoaderRoute: typeof PrivacyRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/marketplace_": {
+      id: "/marketplace_";
+      path: "/marketplace";
+      fullPath: "/marketplace";
+      preLoaderRoute: typeof MarketplaceRouteImport;
       parentRoute: typeof rootRouteImport;
     };
     "/dashboard": {
@@ -271,11 +329,25 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof IndexRouteImport;
       parentRoute: typeof rootRouteImport;
     };
+    "/marketplace_/$pluginId": {
+      id: "/marketplace_/$pluginId";
+      path: "/$pluginId";
+      fullPath: "/marketplace/$pluginId";
+      preLoaderRoute: typeof MarketplacePluginIdRouteImport;
+      parentRoute: typeof MarketplaceRoute;
+    };
     "/download/macos": {
       id: "/download/macos";
       path: "/download/macos";
       fullPath: "/download/macos";
       preLoaderRoute: typeof DownloadMacosRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/docs": {
+      id: "/docs";
+      path: "/docs";
+      fullPath: "/docs";
+      preLoaderRoute: typeof DocsRouteImport;
       parentRoute: typeof rootRouteImport;
     };
     "/blog_/$slug": {
@@ -304,6 +376,13 @@ declare module "@tanstack/react-router" {
       path: "/.well-known/apple-app-site-association";
       fullPath: "/.well-known/apple-app-site-association";
       preLoaderRoute: typeof DotwellKnownAppleAppSiteAssociationRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/marketplace/v2/$": {
+      id: "/marketplace/v2/$";
+      path: "/marketplace/v2/$";
+      fullPath: "/marketplace/v2/$";
+      preLoaderRoute: typeof MarketplaceV2SplatRouteImport;
       parentRoute: typeof rootRouteImport;
     };
     "/marketplace/v1/$": {
@@ -351,17 +430,31 @@ declare module "@tanstack/react-router" {
   }
 }
 
+interface MarketplaceRouteChildren {
+  MarketplacePluginIdRoute: typeof MarketplacePluginIdRoute;
+}
+
+const MarketplaceRouteChildren: MarketplaceRouteChildren = {
+  MarketplacePluginIdRoute: MarketplacePluginIdRoute,
+};
+
+const MarketplaceRouteWithChildren = MarketplaceRoute._addFileChildren(
+  MarketplaceRouteChildren,
+);
+
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   BlogRoute: BlogRoute,
   ChangelogRoute: ChangelogRoute,
   DashboardRoute: DashboardRoute,
+  MarketplaceRoute: MarketplaceRouteWithChildren,
   PrivacyRoute: PrivacyRoute,
   DotwellKnownAppleAppSiteAssociationRoute:
     DotwellKnownAppleAppSiteAssociationRoute,
   DotwellKnownAssetlinksDotjsonRoute: DotwellKnownAssetlinksDotjsonRoute,
   ApiSubscribeRoute: ApiSubscribeRoute,
   BlogSlugRoute: BlogSlugRoute,
+  DocsRoute: DocsRoute,
   DownloadMacosRoute: DownloadMacosRoute,
   ApiAuthSplatRoute: ApiAuthSplatRoute,
   ApiConnectMachineCodeRoute: ApiConnectMachineCodeRoute,
@@ -369,6 +462,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiConnectRedeemMachineRoute: ApiConnectRedeemMachineRoute,
   ApiConnectRevokeMachineRoute: ApiConnectRevokeMachineRoute,
   MarketplaceV1SplatRoute: MarketplaceV1SplatRoute,
+  MarketplaceV2SplatRoute: MarketplaceV2SplatRoute,
 };
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/web/src/routes/docs.tsx
+++ b/apps/web/src/routes/docs.tsx
@@ -1,0 +1,35 @@
+import interWoff2 from "@fontsource-variable/inter/files/inter-latin-wght-normal.woff2?url";
+import { createFileRoute } from "@tanstack/react-router";
+
+import landingCss from "../landing/landing.css?url";
+import { unfurlMeta } from "../landing/site.js";
+import { PluginGuidePage } from "../plugin-guide/plugin-guide-page.js";
+import pluginGuideCss from "../plugin-guide/plugin-guide.css?url";
+
+const PAGE_TITLE = "Plugin Guide — bb";
+const PAGE_DESCRIPTION =
+  "Build bb plugins with a complete reference to every app surface, command, service, setting, and agent capability you can extend.";
+
+export const Route = createFileRoute("/docs")({
+  head: () => ({
+    meta: [
+      { title: PAGE_TITLE },
+      { name: "description", content: PAGE_DESCRIPTION },
+      { name: "robots", content: "index, follow" },
+      ...unfurlMeta(PAGE_TITLE, PAGE_DESCRIPTION, "/docs"),
+    ],
+    links: [
+      {
+        rel: "preload",
+        href: interWoff2,
+        as: "font",
+        type: "font/woff2",
+        crossOrigin: "anonymous",
+      },
+      { rel: "canonical", href: "https://getbb.app/docs" },
+      { rel: "stylesheet", href: pluginGuideCss },
+      { rel: "stylesheet", href: landingCss },
+    ],
+  }),
+  component: PluginGuidePage,
+});

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -26,13 +26,13 @@ import {
   SidebarRightIcon,
   Tick02Icon,
 } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon, type IconSvgElement } from "@hugeicons/react";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { createFileRoute } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, ReactNode } from "react";
 
 import changelogMd from "../../../../CHANGELOG.md?raw";
-import { initAnalytics, trackLandingEvent } from "../landing/analytics";
+import { initAnalytics } from "../landing/analytics";
 import blackstoneLogo from "../assets/company-logos/blackstone.png";
 import datadogLogo from "../assets/company-logos/datadog.svg";
 import figmaLogo from "../assets/company-logos/figma.svg";
@@ -49,9 +49,9 @@ import vscodeIcon from "../assets/vscode.png";
 import { RELEASE_META, parseChangelog } from "../landing/changelog";
 import {
   DiscordLink,
-  DownloadLink,
   EmailSignup,
   GitHubLink,
+  InstallOptions,
 } from "../landing/cta";
 import { SiteFooter, SiteNav } from "../landing/site-chrome";
 import {
@@ -64,9 +64,7 @@ import {
   OpencodeIcon,
   PiIcon,
 } from "../landing/icons";
-import type { CtaPlacement } from "../landing/site";
 import {
-  CLI_COMMAND,
   OG_DESCRIPTION,
   SITE_DESCRIPTION,
   SITE_TITLE,
@@ -146,86 +144,6 @@ function LandingRoute() {
     initAnalytics();
   }, []);
   return <LandingPage />;
-}
-
-const AppleSolidIcon: IconSvgElement = [
-  [
-    "path",
-    {
-      d: "M12 5.75C12 3.75 13.5 1.75 15.5 1.75C15.5 3.75 14 5.75 12 5.75Z",
-      fill: "currentColor",
-      key: "0",
-    },
-  ],
-  [
-    "path",
-    {
-      d: "M12.5 8.09001C11.9851 8.09001 11.5867 7.92646 11.1414 7.74368C10.5776 7.51225 9.93875 7.25 8.89334 7.25C7.02235 7.25 4 8.74945 4 12.7495C4 17.4016 7.10471 22.25 9.10471 22.25C9.77426 22.25 10.3775 21.9871 10.954 21.7359C11.4815 21.5059 11.9868 21.2857 12.5 21.2857C13.0132 21.2857 13.5185 21.5059 14.046 21.7359C14.6225 21.9871 15.2257 22.25 15.8953 22.25C17.2879 22.25 18.9573 19.8992 20 16.9008C18.3793 16.2202 17.338 14.618 17.338 12.75C17.338 11.121 18.2036 10.0398 19.5 9.25C18.5 7.75 17.0134 7.25 15.9447 7.25C14.8993 7.25 14.2604 7.51225 13.6966 7.74368C13.2514 7.92646 13.0149 8.09001 12.5 8.09001Z",
-      fill: "currentColor",
-      key: "1",
-    },
-  ],
-];
-
-function RunCommandButton({ placement }: { placement: CtaPlacement }) {
-  const [copied, setCopied] = useState(false);
-  const copy = () => {
-    trackLandingEvent({
-      name: "landing_cli_command_copied",
-      properties: { placement, command: CLI_COMMAND },
-    });
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1500);
-    navigator.clipboard.writeText(CLI_COMMAND).catch(() => {});
-  };
-  return (
-    <button
-      type="button"
-      className={
-        copied
-          ? "btn btn-ghost btn-install cmd-btn copied"
-          : "btn btn-ghost btn-install cmd-btn"
-      }
-      onClick={copy}
-      aria-label={`Copy browser install command: ${CLI_COMMAND}`}
-    >
-      <span className="cmd-dollar">$</span>
-      <span className="cmd-text">{CLI_COMMAND}</span>
-      <span className="cmd-copy">Copy</span>
-      {}
-      <span
-        className={copied ? "cmd-toast show" : "cmd-toast"}
-        aria-hidden="true"
-      >
-        Copied to clipboard
-      </span>
-    </button>
-  );
-}
-
-function InstallOptions({ placement }: { placement: CtaPlacement }) {
-  return (
-    <div className="install-options">
-      <div className="install-actions">
-        <span className="install-choice">
-          <DownloadLink
-            placement={placement}
-            className="btn btn-primary btn-install"
-          >
-            <HugeiconsIcon icon={AppleSolidIcon} className="btn-ic" />
-            Download for macOS
-          </DownloadLink>
-          <span className="install-note">One-click, no terminal</span>
-        </span>
-        <span className="install-choice">
-          <RunCommandButton placement={placement} />
-          <span className="install-note">
-            Windows (via WSL), Linux &amp; remote machines
-          </span>
-        </span>
-      </div>
-    </div>
-  );
 }
 
 function useScrollReveal() {

--- a/apps/web/src/routes/marketplace.v2.$.tsx
+++ b/apps/web/src/routes/marketplace.v2.$.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { getEnv } from "@/server/env";
+import { serveMarketplaceObject } from "@/server/marketplace";
+
+const handle = ({ request }: { request: Request }) =>
+  serveMarketplaceObject({ bucket: getEnv().MARKETPLACE, request });
+
+export const Route = createFileRoute("/marketplace/v2/$")({
+  server: { handlers: { GET: handle, HEAD: handle } },
+});

--- a/apps/web/src/routes/marketplace_.$pluginId.tsx
+++ b/apps/web/src/routes/marketplace_.$pluginId.tsx
@@ -1,0 +1,67 @@
+import interWoff2 from "@fontsource-variable/inter/files/inter-latin-wght-normal.woff2?url";
+import { createFileRoute, notFound } from "@tanstack/react-router";
+
+import landingCss from "../landing/landing.css?url";
+import { unfurlMeta } from "../landing/site.js";
+import marketplaceCss from "../marketplace/marketplace.css?url";
+import { getPublicMarketplace } from "../marketplace/marketplace-server.js";
+import {
+  PublicMarketplaceDetailPage,
+  PublicMarketplaceUnavailablePage,
+} from "../marketplace/public-marketplace.js";
+
+export const Route = createFileRoute("/marketplace_/$pluginId")({
+  loader: async ({ params }) => {
+    const marketplace = await getPublicMarketplace();
+    if (marketplace.status === "unavailable") return marketplace;
+    const entry = marketplace.manifest.plugins.find(
+      (candidate) => candidate.id === params.pluginId,
+    );
+    if (entry === undefined) throw notFound();
+    return { ...marketplace, entry };
+  },
+  head: ({ loaderData, params }) => {
+    const entry = loaderData?.status === "available" ? loaderData.entry : null;
+    const title = entry
+      ? `${entry.displayName} — bb Plugin Marketplace`
+      : "Plugin Marketplace — bb";
+    const description =
+      entry?.description ?? "Discover community plugins for bb.";
+    const path = `/marketplace/${encodeURIComponent(params.pluginId)}`;
+    return {
+      meta: [
+        { title },
+        { name: "description", content: description },
+        { name: "robots", content: entry ? "index, follow" : "noindex" },
+        ...unfurlMeta(title, description, path),
+      ],
+      links: [
+        {
+          rel: "preload",
+          href: interWoff2,
+          as: "font",
+          type: "font/woff2",
+          crossOrigin: "anonymous",
+        },
+        { rel: "canonical", href: `https://getbb.app${path}` },
+        { rel: "stylesheet", href: landingCss },
+        { rel: "stylesheet", href: marketplaceCss },
+      ],
+    };
+  },
+  component: MarketplaceDetailRoute,
+});
+
+function MarketplaceDetailRoute() {
+  const marketplace = Route.useLoaderData();
+  if (marketplace.status === "unavailable") {
+    return <PublicMarketplaceUnavailablePage />;
+  }
+  return (
+    <PublicMarketplaceDetailPage
+      manifest={marketplace.manifest}
+      entry={marketplace.entry}
+      stats={marketplace.stats}
+    />
+  );
+}

--- a/apps/web/src/routes/marketplace_.tsx
+++ b/apps/web/src/routes/marketplace_.tsx
@@ -1,0 +1,72 @@
+import interWoff2 from "@fontsource-variable/inter/files/inter-latin-wght-normal.woff2?url";
+import {
+  createFileRoute,
+  Outlet,
+  useRouterState,
+} from "@tanstack/react-router";
+
+import landingCss from "../landing/landing.css?url";
+import { unfurlMeta } from "../landing/site.js";
+import marketplaceCss from "../marketplace/marketplace.css?url";
+import { getPublicMarketplace } from "../marketplace/marketplace-server.js";
+import {
+  isMarketplaceCategoryId,
+  isMarketplaceSort,
+  PublicMarketplacePage,
+  PublicMarketplaceUnavailablePage,
+  type MarketplaceIndexState,
+} from "../marketplace/public-marketplace.js";
+
+const PAGE_TITLE = "Plugin Marketplace — bb";
+const PAGE_DESCRIPTION =
+  "Discover community plugins that add new capabilities to bb.";
+
+export const Route = createFileRoute("/marketplace_")({
+  validateSearch: (search: Record<string, unknown>): MarketplaceIndexState => ({
+    ...(isMarketplaceCategoryId(search.category)
+      ? { category: search.category }
+      : {}),
+    ...(isMarketplaceSort(search.sort) ? { sort: search.sort } : {}),
+  }),
+  loader: () => getPublicMarketplace(),
+  head: () => ({
+    meta: [
+      { title: PAGE_TITLE },
+      { name: "description", content: PAGE_DESCRIPTION },
+      { name: "robots", content: "index, follow" },
+      ...unfurlMeta(PAGE_TITLE, PAGE_DESCRIPTION, "/marketplace"),
+    ],
+    links: [
+      {
+        rel: "preload",
+        href: interWoff2,
+        as: "font",
+        type: "font/woff2",
+        crossOrigin: "anonymous",
+      },
+      { rel: "canonical", href: "https://getbb.app/marketplace" },
+      { rel: "stylesheet", href: landingCss },
+      { rel: "stylesheet", href: marketplaceCss },
+    ],
+  }),
+  component: MarketplaceRoute,
+});
+
+function MarketplaceRoute() {
+  const path = useRouterState({ select: (state) => state.location.pathname });
+  const marketplace = Route.useLoaderData();
+  const search = Route.useSearch();
+  const navigate = Route.useNavigate();
+  if (path !== "/marketplace" && path !== "/marketplace/") return <Outlet />;
+  if (marketplace.status === "unavailable") {
+    return <PublicMarketplaceUnavailablePage />;
+  }
+  return (
+    <PublicMarketplacePage
+      manifest={marketplace.manifest}
+      stats={marketplace.stats}
+      state={search}
+      onStateChange={(next) => void navigate({ search: next })}
+    />
+  );
+}

--- a/apps/web/src/server/marketplace.test.ts
+++ b/apps/web/src/server/marketplace.test.ts
@@ -36,6 +36,11 @@ const bucket = bucketOf({
     etag: "v1",
     contentType: "application/json",
   },
+  "v2/marketplace.json": {
+    body: '{"schemaVersion":2}',
+    etag: "v2",
+    contentType: "application/json",
+  },
   "icons/widgets.svg": { body: "<svg/>", etag: "icon-1" },
 });
 
@@ -51,6 +56,9 @@ describe("marketplaceObjectKey", () => {
     expect(marketplaceObjectKey("/marketplace/v1/icons/a.svg")).toBe(
       "icons/a.svg",
     );
+    expect(marketplaceObjectKey("/marketplace/v2/marketplace.json")).toBe(
+      "v2/marketplace.json",
+    );
   });
 
   it("refuses traversal, empty segments, and other paths", () => {
@@ -58,6 +66,7 @@ describe("marketplaceObjectKey", () => {
     expect(marketplaceObjectKey("/marketplace/v1/../secrets")).toBe(null);
     expect(marketplaceObjectKey("/marketplace/v1/icons//a.svg")).toBe(null);
     expect(marketplaceObjectKey("/marketplace/v1/%2e%2e/secrets")).toBe(null);
+    expect(marketplaceObjectKey("/marketplace/v2/%2e%2e/secrets")).toBe(null);
     expect(marketplaceObjectKey("/marketplace/v1/icons/%broken.svg")).toBe(
       null,
     );

--- a/apps/web/src/server/marketplace.ts
+++ b/apps/web/src/server/marketplace.ts
@@ -1,4 +1,7 @@
-const MARKETPLACE_PATH_PREFIX = "/marketplace/v1/";
+const MARKETPLACE_PATHS = [
+  { prefix: "/marketplace/v1/", objectPrefix: "" },
+  { prefix: "/marketplace/v2/", objectPrefix: "v2/" },
+] as const;
 
 const MANIFEST_CACHE_CONTROL = "public, max-age=300, must-revalidate";
 const ICON_CACHE_CONTROL = "public, max-age=31536000, immutable";
@@ -11,10 +14,13 @@ const CONTENT_TYPES: Record<string, string> = {
 };
 
 export function marketplaceObjectKey(pathname: string): string | null {
-  if (!pathname.startsWith(MARKETPLACE_PATH_PREFIX)) return null;
+  const route = MARKETPLACE_PATHS.find(({ prefix }) =>
+    pathname.startsWith(prefix),
+  );
+  if (route === undefined) return null;
   let key: string;
   try {
-    key = decodeURIComponent(pathname.slice(MARKETPLACE_PATH_PREFIX.length));
+    key = decodeURIComponent(pathname.slice(route.prefix.length));
   } catch {
     return null;
   }
@@ -24,7 +30,7 @@ export function marketplaceObjectKey(pathname: string): string | null {
   if (segments.some((segment) => segment.length === 0 || segment === "..")) {
     return null;
   }
-  return key;
+  return `${route.objectPrefix}${key}`;
 }
 
 function contentTypeFor(key: string): string {

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -51,10 +51,6 @@
       },
     ],
   },
-  // BB Official plugin marketplace. The registry repo (get-bb/marketplace)
-  // uploads the v1 and v2 registry assets here; /marketplace/v1/* and
-  // /marketplace/v2/* serve them. The routes answer 404 until the bucket
-  // exists, so this binding can land before the bucket is provisioned.
   "r2_buckets": [
     {
       "binding": "MARKETPLACE",

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -52,9 +52,9 @@
     ],
   },
   // BB Official plugin marketplace. The registry repo (get-bb/marketplace)
-  // uploads marketplace.json + icons here; /marketplace/v1/* serves them.
-  // The route answers 404 until the bucket exists, so this binding can land
-  // before the bucket is provisioned.
+  // uploads the v1 and v2 registry assets here; /marketplace/v1/* and
+  // /marketplace/v2/* serve them. The routes answer 404 until the bucket
+  // exists, so this binding can land before the bucket is provisioned.
   "r2_buckets": [
     {
       "binding": "MARKETPLACE",

--- a/packages/plugin-api-map/src/agent-reference.ts
+++ b/packages/plugin-api-map/src/agent-reference.ts
@@ -102,7 +102,7 @@ function copyWithEditingCommand(
     position: "fixed",
     width: "1px",
   });
-  document.body.append(textarea);
+  document.body.appendChild(textarea);
   let richClipboardHandled = false;
   const onCopy = (event: ClipboardEvent) => {
     if (event.clipboardData === null) return;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1208,7 +1208,7 @@ importers:
         specifier: ^3.4.0
         version: 3.4.0
       zod:
-        specifier: ^4.3.6
+        specifier: 4.3.6
         version: 4.3.6
     devDependencies:
       '@bb/tsconfig':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1150,9 +1150,18 @@ importers:
 
   apps/web:
     dependencies:
+      '@bb/client-core':
+        specifier: workspace:*
+        version: link:../../packages/client-core
       '@bb/connect-db':
         specifier: workspace:*
         version: link:../../packages/connect-db
+      '@bb/domain':
+        specifier: workspace:*
+        version: link:../../packages/domain
+      '@bb/plugin-api-map':
+        specifier: workspace:*
+        version: link:../../packages/plugin-api-map
       '@better-auth/drizzle-adapter':
         specifier: ^1.6.23
         version: 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/react@19.2.13)(better-sqlite3@12.10.0)(kysely@0.29.3)(react@19.2.4))
@@ -1198,6 +1207,9 @@ importers:
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@bb/tsconfig':
         specifier: workspace:*


### PR DESCRIPTION
## Product intent and requirements

- Make the Plugin Marketplace and Plugin Guide publicly discoverable on getbb.app instead of requiring an installed bb app.
- Add Marketplace and Plugin Guide navigation as one coherent Plugins destination, with clear cross-links between discovery and authoring.
- Give the public marketplace the same category-led Browse model, search, filtering, sorting, plugin details, and trust metadata as the product.
- Publish richer marketplace v2 data additively while leaving the released v1 contract unchanged.
- Keep the public pages responsive, accessible, theme-aware, and faithful to supplied plugin artwork.

## What was wrong

The public plugin discovery and authoring pages had been removed, leaving `/marketplace` and `/docs` without a rendered product surface even though the app-side discovery model now depends on the same category and registry concepts. The web app also had no additive v2 registry boundary for richer listing metadata while preserving the released strict v1 contract.

## What changed

- Adds the public marketplace, category shelves, search, category filtering, sorting, unavailable state, and plugin detail pages.
- Adds detail-only screenshots, install metadata sourced from `stats.json`, published/updated dates, source links, and more plugins from the same author.
- Adds the complete `/docs` Plugin Guide with the shared product-surface map, copyable build prompt and agent references, and installation options.
- Adds the public v2 schema and `/marketplace/v2/*` R2 route while leaving `/marketplace/v1/*` unchanged.
- Adds one Plugins navigation entry plus Marketplace and Plugin Guide cross-links.
- Keeps author artwork neutral and unmasked so supplied glyphs and brand colors are never repainted.

### Before and after

Each pair uses the same route, stable two-plugin marketplace fixture, settled state, and 1440×900 viewport. Before is the exact parent head (`97c166e5561551532c11da76a8d16f15b1f70e18`); after is the exact PR head (`1090cc67f44d99e4b99e9a73eecdf540d33a48d6`).

| Home before — no Plugins navigation | Home after — Plugins navigation |
| --- | --- |
| <img src="https://gist.githubusercontent.com/brsbl/30d996198afdc244db74e13a9293769f/raw/f880e8f4a16fafad60285de8f048c71e1ea7ad4b/marketing-before-home-97c166e55.svg" width="460" alt="Homepage on exact parent head without the Plugins navigation entry"> | <img src="https://gist.githubusercontent.com/brsbl/30d996198afdc244db74e13a9293769f/raw/f880e8f4a16fafad60285de8f048c71e1ea7ad4b/marketing-after-home-1090cc67f.svg" width="460" alt="Homepage on exact PR head with the Plugins navigation entry"> |

| `/marketplace` before — route missing | `/marketplace` after — browse shelves |
| --- | --- |
| <img src="https://gist.githubusercontent.com/brsbl/30d996198afdc244db74e13a9293769f/raw/71350664a76c8ca3d8c88488f7e60f08ccb123a2/marketing-before-marketplace-97c166e55.svg" width="460" alt="Marketplace route missing on exact parent head"> | <img src="https://gist.githubusercontent.com/brsbl/30d996198afdc244db74e13a9293769f/raw/71350664a76c8ca3d8c88488f7e60f08ccb123a2/marketing-after-marketplace-1090cc67f.svg" width="460" alt="Marketplace browse on exact PR head"> |

| `/marketplace/prompt-library` before — route missing | Plugin detail after — install and trust metadata |
| --- | --- |
| <img src="https://gist.githubusercontent.com/brsbl/30d996198afdc244db74e13a9293769f/raw/71350664a76c8ca3d8c88488f7e60f08ccb123a2/marketing-before-detail-97c166e55.svg" width="460" alt="Marketplace detail route missing on exact parent head"> | <img src="https://gist.githubusercontent.com/brsbl/30d996198afdc244db74e13a9293769f/raw/71350664a76c8ca3d8c88488f7e60f08ccb123a2/marketing-after-detail-1090cc67f.svg" width="460" alt="Marketplace plugin detail on exact PR head"> |

| `/docs` before — route missing | `/docs` after — Plugin Guide |
| --- | --- |
| <img src="https://gist.githubusercontent.com/brsbl/30d996198afdc244db74e13a9293769f/raw/71350664a76c8ca3d8c88488f7e60f08ccb123a2/marketing-before-docs-97c166e55.svg" width="460" alt="Plugin Guide route missing on exact parent head"> | <img src="https://gist.githubusercontent.com/brsbl/30d996198afdc244db74e13a9293769f/raw/71350664a76c8ca3d8c88488f7e60f08ccb123a2/marketing-after-docs-1090cc67f.svg" width="460" alt="Plugin Guide on exact PR head"> |

## How you verified

- Google Chrome for Testing 151.0.7922.71: recaptured `/`, `/marketplace`, `/marketplace/prompt-library`, and `/docs` from the exact current parent and exact current PR head at 1440×900 using the same local R2 fixture. The current head rendered without page errors.
- Google Chrome for Testing 151.0.7922.71 and Safari 26.5.2 (21624.2.5.11.8): hard reload, search flattening, client-side detail navigation, Plugin Guide rendering, and 430px layout were previously exercised on product commit `b9105c6c2`. The marketing product subtree is byte-identical at the current head (`git diff b9105c6c2..1090cc67f -- apps/web packages/plugin-api-map pnpm-lock.yaml` is empty).
- Remote CI run [33358223389](https://github.com/get-bb/bb/actions/runs/33358223389) is green on exact head `1090cc67f44d99e4b99e9a73eecdf540d33a48d6`: checks, all test shards, version guards, and Linux/macOS package smokes passed. No CI-equivalent tests, typechecks, or lint were run locally.

BB-Thread-ID: thr_9tmqez22hd

> AGENT GENERATED