### PR TITLE
Rework the mobile PWA home and compact shelves

### DIFF
--- a/apps/app/.ladle/story-fixtures.ts
+++ b/apps/app/.ladle/story-fixtures.ts
@@ -2,6 +2,7 @@ import type {
   Environment,
   Host,
   ProjectSource,
+  ProviderInfo,
   ReasoningLevel,
   Thread,
   ThreadListEntry,
@@ -94,6 +95,41 @@ function storyProviderIcon(providerId: string, glyph: string) {
   return getProviderIconInfo(providerId, { logoUrl: null, icon: { glyph } })
     ?.icon;
 }
+
+function makeStoryProvider(
+  id: string,
+  displayName: string,
+  glyph: string,
+): ProviderInfo {
+  return {
+    id,
+    pluginId: `provider-${id}`,
+    displayName,
+    logoUrl: null,
+    icon: { glyph },
+    available: true,
+    maintenance: { health: false, usage: false, installation: false },
+    composerActions: [],
+    capabilities: {
+      supportsThreadArchive: true,
+      supportsThreadRename: true,
+      supportsServiceTier: false,
+      supportsNativeUserQuestion: false,
+      supportsFork: true,
+      supportsSessionRewind: false,
+      modelCatalogScope: "workspace",
+      permissionModes: ["accept-edits", "auto", "full"],
+    },
+  };
+}
+
+export const STORY_PROVIDERS_BY_ID: ReadonlyMap<string, ProviderInfo> = new Map(
+  [
+    makeStoryProvider("codex", "Codex", "Code"),
+    makeStoryProvider("claude-code", "Claude Code", "Brain"),
+    makeStoryProvider("acp-cursor", "Cursor", "Zap"),
+  ].map((provider) => [provider.id, provider]),
+);
 
 export const STORY_PROVIDER_OPTIONS: readonly PickerOption<string>[] = [
   { value: "codex", label: "Codex", icon: storyProviderIcon("codex", "Code") },

--- a/apps/app/.ladle/story-fixtures.ts
+++ b/apps/app/.ladle/story-fixtures.ts
@@ -123,12 +123,22 @@ function makeStoryProvider(
   };
 }
 
+const storyCodexProvider = makeStoryProvider("codex", "Codex", "Code");
+const storyClaudeCodeProvider = makeStoryProvider(
+  "claude-code",
+  "Claude Code",
+  "Brain",
+);
+const storyCursorProvider = makeStoryProvider("acp-cursor", "Cursor", "Zap");
+
+export const STORY_CODEX_PROVIDER_ID = storyCodexProvider.id;
+export const STORY_CLAUDE_CODE_PROVIDER_ID = storyClaudeCodeProvider.id;
+export const STORY_CURSOR_PROVIDER_ID = storyCursorProvider.id;
+
 export const STORY_PROVIDERS_BY_ID: ReadonlyMap<string, ProviderInfo> = new Map(
-  [
-    makeStoryProvider("codex", "Codex", "Code"),
-    makeStoryProvider("claude-code", "Claude Code", "Brain"),
-    makeStoryProvider("acp-cursor", "Cursor", "Zap"),
-  ].map((provider) => [provider.id, provider]),
+  [storyCodexProvider, storyClaudeCodeProvider, storyCursorProvider].map(
+    (provider) => [provider.id, provider],
+  ),
 );
 
 export const STORY_PROVIDER_OPTIONS: readonly PickerOption<string>[] = [

--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -10,6 +10,7 @@ import { AppLayout } from "./components/layout/AppLayout";
 import { AuthCallbackView } from "./views/AuthCallbackView";
 import { QuickCreateProjectProvider } from "./hooks/useQuickCreateProject";
 import { RouteNavigationProvider } from "./components/ui/app-route-anchor";
+import { RouteNavigationIndicator } from "./components/ui/route-navigation-indicator";
 import { AppNavigationUrlHost } from "./lib/url-open-routing";
 import { NativeShellReporter } from "./lib/native-shell";
 import { AppFileExternalNavigationHost } from "./components/plugin/AppFileExternalNavigationHost";
@@ -339,6 +340,7 @@ export function App() {
     <QuickCreateProjectProvider>
       <AppCommandProvider>
         <RouteNavigationProvider>
+          <RouteNavigationIndicator />
           <AppNavigationUrlHost>
             <AppFileExternalNavigationHost>
               <HashNavigationScroll />

--- a/apps/app/src/app.css
+++ b/apps/app/src/app.css
@@ -647,6 +647,42 @@
   }
 
   /*
+   * Keep the compact sidebar drawer's scrollbar hidden at rest and reveal it
+   * on hover. Same shape as `.transient-scrollbar` above, but keyed to pointer
+   * hover instead of a scroll event: the drawer sits over an undimmed page, so
+   * a thumb at rest reads as chrome rather than an affordance. Scoped to the
+   * compact drawer only (the desktop panel has no `data-vaul-drawer-direction`)
+   * so the persistent sidebar keeps its resting scrollbar. Colors are all that
+   * change, so the scroll container, its hit area, and its width never move and
+   * content never reflows when the thumb appears.
+   */
+  [data-vaul-drawer-direction] [data-sidebar="content"] {
+    scrollbar-color: transparent transparent;
+  }
+
+  [data-vaul-drawer-direction]
+    [data-sidebar="content"]::-webkit-scrollbar-thumb,
+  [data-vaul-drawer-direction]
+    [data-sidebar="content"]::-webkit-scrollbar-thumb:hover {
+    background-color: transparent;
+  }
+
+  [data-vaul-drawer-direction] [data-sidebar="content"]:hover {
+    scrollbar-color: color-mix(in oklab, var(--foreground) 20%, transparent)
+      transparent;
+  }
+
+  [data-vaul-drawer-direction]
+    [data-sidebar="content"]:hover::-webkit-scrollbar-thumb {
+    background-color: color-mix(in oklab, var(--foreground) 20%, transparent);
+  }
+
+  [data-vaul-drawer-direction]
+    [data-sidebar="content"]:hover::-webkit-scrollbar-thumb:hover {
+    background-color: color-mix(in oklab, var(--foreground) 40%, transparent);
+  }
+
+  /*
    * Opt out of the global thin scrollbar into always-visible classic
    * scrollbars for two-axis data surfaces (e.g. the CSV table preview).
    * Native thin scrollbars render as macOS overlay bars that fade out and

--- a/apps/app/src/app.css
+++ b/apps/app/src/app.css
@@ -28,6 +28,9 @@
    */
   :root {
     --bb-shell-height: 100dvh;
+    /* Width of the compact right-panel shelf. Mirrors --sidebar-width-mobile
+       so the page displaces by the same amount whichever side opens. */
+    --secondary-panel-width-mobile: min(76vw, 320px);
   }
 
   html.bb-app-shell-root {

--- a/apps/app/src/components/layout/AppLayoutSidebar.test.tsx
+++ b/apps/app/src/components/layout/AppLayoutSidebar.test.tsx
@@ -88,6 +88,14 @@ function getMobilePanel(): HTMLElement {
   return panel;
 }
 
+function getShelfRevealTranslate(): string {
+  const backdrop = document.querySelector("[data-sidebar-mobile-backdrop]");
+  if (!(backdrop instanceof HTMLElement)) {
+    throw new Error("Expected the mobile sidebar backdrop");
+  }
+  return backdrop.style.translate;
+}
+
 function getAppSidebarBody(): HTMLElement {
   return screen.getByTestId("app-sidebar-body");
 }
@@ -167,7 +175,7 @@ describe("AppLayoutSidebar mobile mode transitions", () => {
     expect(getMobilePanel()).toBe(panel);
     expect(getAppSidebarBody().hidden).toBe(false);
     expect(screen.queryByTestId("settings-sidebar-body")).toBeNull();
-    expect(panel.style.translate).toBe("-100%");
+    expect(getShelfRevealTranslate()).toBe("0px");
 
     settleMobileToggle();
 
@@ -196,7 +204,7 @@ describe("AppLayoutSidebar mobile mode transitions", () => {
 
     expect(screen.getByTestId("tools-sidebar-body")).toBeTruthy();
     expect(getAppSidebarBody().hidden).toBe(true);
-    expect(getMobilePanel().style.translate).toBe("-100%");
+    expect(getShelfRevealTranslate()).toBe("0px");
 
     settleMobileToggle();
 

--- a/apps/app/src/components/plugin/PluginNewThreadComposer.test.tsx
+++ b/apps/app/src/components/plugin/PluginNewThreadComposer.test.tsx
@@ -128,6 +128,7 @@ vi.mock("@/hooks/queries/host-queries", () => ({
 }));
 
 vi.mock("@/hooks/queries/system-queries", () => ({
+  useSystemProviders: () => ({ data: undefined }),
   useSystemProviderStates: () => ({ data: undefined, isPending: false }),
   useKnownProviderModelCatalogScope: () => undefined,
   useHostProviderCliStatus: () => ({ data: undefined }),

--- a/apps/app/src/components/plugin/PluginPanelRightPanelHost.test.tsx
+++ b/apps/app/src/components/plugin/PluginPanelRightPanelHost.test.tsx
@@ -615,14 +615,14 @@ describe("PluginPanelRightPanelHost", () => {
     cleanup();
   });
 
-  it("shows the drawer glyph on the trigger for a compact viewport", async () => {
+  it("shows the side-panel glyph on the trigger for a compact viewport", async () => {
     viewportState.isCompactViewport = true;
     renderHost();
 
     const showButton = await screen.findByRole("button", {
       name: "Show right panel",
     });
-    expect(showButton.querySelector('[data-icon="PanelBottom"]')).toBeTruthy();
+    expect(showButton.querySelector('[data-icon="PanelRight"]')).toBeTruthy();
   });
 
   it("shows the side-panel glyph on the trigger for a wide viewport", async () => {

--- a/apps/app/src/components/plugin/PluginPanelRightPanelHost.tsx
+++ b/apps/app/src/components/plugin/PluginPanelRightPanelHost.tsx
@@ -21,7 +21,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@bb/shared-ui/tooltip";
 import { useAppCommandHandler } from "@/components/commands/AppCommandProvider";
 import { PluginIcon } from "@/components/plugin/PluginIcon";
 import { PluginSlotMount } from "@/components/plugin/PluginSlotMount";
-import { getRightPanelToggleIconName } from "@/components/secondary-panel/panelToggleControlState";
+import { RIGHT_PANEL_TOGGLE_ICON_NAME } from "@/components/secondary-panel/panelToggleControlState";
 import { SecondaryPanelLayout } from "@/components/secondary-panel/SecondaryPanelLayout";
 import {
   LazyBrowserTabDeck,
@@ -950,7 +950,7 @@ export function PluginPanelRightPanelHost({
   );
 
   const toggleLabel = isOpen ? "Hide right panel" : "Show right panel";
-  const toggleIconName = getRightPanelToggleIconName(isCompactViewport);
+  const toggleIconName = RIGHT_PANEL_TOGGLE_ICON_NAME;
   const page = (
     <div
       className={`flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden ${

--- a/apps/app/src/components/plugin/management/AddPluginDialog.tsx
+++ b/apps/app/src/components/plugin/management/AddPluginDialog.tsx
@@ -335,7 +335,7 @@ function AddPluginDialogContent({
             role="progressbar"
             aria-label="Installing plugin"
           >
-            <div className="h-full w-1/3 animate-plugin-install-progress rounded-full bg-muted-foreground" />
+            <div className="h-full w-1/3 animate-indeterminate-progress rounded-full bg-muted-foreground" />
           </div>
         ) : (
           <FullTrustWarning />

--- a/apps/app/src/components/promptbox/NewThreadComposer.tsx
+++ b/apps/app/src/components/promptbox/NewThreadComposer.tsx
@@ -114,6 +114,7 @@ interface NewThreadComposerPromptOptions {
   id?: string;
   placeholder?: string;
   autoFocus?: boolean;
+  allowSoftKeyboardAutoFocus?: boolean;
   banner?: ReactNode;
   header?: ReactNode;
   blockedReason?: string;
@@ -1200,6 +1201,7 @@ export function NewThreadComposer({
           disabledReason={disabledReason ?? undefined}
           placeholder={options.placeholder}
           autoFocus={options.autoFocus}
+          allowSoftKeyboardAutoFocus={options.allowSoftKeyboardAutoFocus}
           pluginComposerHost={options.pluginComposerHost ?? pluginComposerHost}
           textEffects={options.textEffects ?? textEffects}
           history={{

--- a/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
+++ b/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
@@ -153,6 +153,7 @@ interface NewThreadPromptBoxUIProps {
   disabled: boolean;
   disabledReason?: string;
   autoFocus?: boolean;
+  allowSoftKeyboardAutoFocus?: boolean;
   pluginComposerHost?: PluginComposerHost | null;
   textEffects?: readonly ComposerTextEffectSource[];
   placeholder?: string;
@@ -199,6 +200,7 @@ export const NewThreadPromptBoxUI = memo(function NewThreadPromptBoxUI({
   disabled,
   disabledReason,
   autoFocus,
+  allowSoftKeyboardAutoFocus,
   pluginComposerHost,
   textEffects,
   placeholder: placeholderOverride,
@@ -270,6 +272,7 @@ export const NewThreadPromptBoxUI = memo(function NewThreadPromptBoxUI({
           disabled={disabled}
           disabledReason={disabledReason}
           autoFocus={autoFocus}
+          allowSoftKeyboardAutoFocus={allowSoftKeyboardAutoFocus}
           textEffects={textEffects}
           placeholder={placeholderOverride}
           history={history}
@@ -307,6 +310,7 @@ const DefaultNewThreadComposer = memo(function DefaultNewThreadComposer({
   disabled,
   disabledReason,
   autoFocus,
+  allowSoftKeyboardAutoFocus,
   textEffects,
   placeholder: placeholderOverride,
   history,
@@ -378,6 +382,7 @@ const DefaultNewThreadComposer = memo(function DefaultNewThreadComposer({
           title: submitTitle,
         }}
         autoFocus={autoFocus}
+        allowSoftKeyboardAutoFocus={allowSoftKeyboardAutoFocus}
         editorLayout="root-compose"
         minHeight={NEW_THREAD_PROMPT_BOX_MIN_HEIGHT}
         placeholder={placeholder}

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -378,6 +378,7 @@ interface PromptBoxInternalProps {
   blurOnPointerSubmit?: boolean;
   placeholder?: string;
   autoFocus?: boolean;
+  allowSoftKeyboardAutoFocus?: boolean;
   className?: string;
   textEffects?: readonly ComposerTextEffectSource[];
   onComposerLayoutChange?: (layout: ComposerView["layout"]) => void;
@@ -1100,6 +1101,7 @@ export function PromptBoxInternal({
   blurOnPointerSubmit = false,
   placeholder = "Ask anything. @ to mention files, folders, or sections",
   autoFocus = true,
+  allowSoftKeyboardAutoFocus = false,
   className,
   textEffects,
   onComposerLayoutChange,
@@ -1163,7 +1165,8 @@ export function PromptBoxInternal({
   const isPointerCoarse = usePointerCoarse();
   const isIPadOSWebKitDevice = useMemo(isIPadOSWebKit, []);
   const editorEnterKeyHint = isPointerCoarse ? "enter" : "send";
-  const shouldAvoidSoftKeyboardAutofocus = isPointerCoarse;
+  const shouldAvoidSoftKeyboardAutofocus =
+    isPointerCoarse && !allowSoftKeyboardAutoFocus;
   const formRef = useRef<HTMLFormElement>(null);
   const typeaheadMenuRef = useRef<HTMLDivElement>(null);
   const reportQueuedEditorTypeaheadLayout = useContext(

--- a/apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.test.tsx
+++ b/apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.test.tsx
@@ -49,6 +49,16 @@ describe("CompactSecondaryPanelShelf", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  it("hides the closed shelf so it cannot cover the sidebar shelf", () => {
+    renderShelf(false);
+
+    const shelf = screen.getByTestId("secondary-panel-shelf");
+    expect(shelf.className).toContain("data-[state=closed]:invisible");
+    expect(shelf.className).toContain(
+      "data-[state=closed]:[transition:visibility_0s_linear_220ms]",
+    );
+  });
+
   it("marks the shelf inert while closed and interactive while open", () => {
     const { rerender } = renderShelf(false);
     expect(

--- a/apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.test.tsx
+++ b/apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CompactSecondaryPanelShelf } from "./CompactSecondaryPanelShelf";
+import { isCompactSecondaryPanelShelfShowing } from "@/components/ui/secondary-panel-shelf-visibility";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function renderShelf(open: boolean, onClose = vi.fn()) {
+  const view = render(
+    <CompactSecondaryPanelShelf
+      open={open}
+      onClose={onClose}
+      srLabel="Right panel"
+    >
+      <div data-testid="panel-body" />
+    </CompactSecondaryPanelShelf>,
+  );
+  return { ...view, onClose };
+}
+
+describe("CompactSecondaryPanelShelf", () => {
+  it("anchors to the right edge beneath the page rather than the bottom", () => {
+    renderShelf(true);
+
+    const shelf = screen.getByTestId("secondary-panel-shelf");
+    expect(shelf.className).toContain("right-0");
+    expect(shelf.className).toContain("inset-y-0");
+    expect(shelf.className).toContain("z-0");
+    expect(shelf.className).toContain("w-(--secondary-panel-width-mobile)");
+    expect(shelf.className).not.toContain("bottom-0");
+    expect(shelf.className).not.toContain("rounded-t-xl");
+  });
+
+  it("leaves the page undimmed and dismisses from the exposed strip", () => {
+    const { onClose } = renderShelf(true);
+
+    const dismiss = screen.getByTestId("secondary-panel-shelf-dismiss");
+    expect(dismiss.className).toContain("bg-transparent");
+    expect(dismiss.className).toContain(
+      "data-[state=open]:-translate-x-(--secondary-panel-width-mobile)",
+    );
+
+    fireEvent.click(dismiss);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks the shelf inert while closed and interactive while open", () => {
+    const { rerender } = renderShelf(false);
+    expect(
+      screen.getByTestId("secondary-panel-shelf").hasAttribute("inert"),
+    ).toBe(true);
+
+    rerender(
+      <CompactSecondaryPanelShelf open onClose={vi.fn()} srLabel="Right panel">
+        <div data-testid="panel-body" />
+      </CompactSecondaryPanelShelf>,
+    );
+    expect(
+      screen.getByTestId("secondary-panel-shelf").hasAttribute("inert"),
+    ).toBe(false);
+  });
+
+  it("publishes open state so the page knows to displace", () => {
+    const { rerender, unmount } = renderShelf(true);
+    expect(isCompactSecondaryPanelShelfShowing()).toBe(true);
+
+    rerender(
+      <CompactSecondaryPanelShelf
+        open={false}
+        onClose={vi.fn()}
+        srLabel="Right panel"
+      >
+        <div data-testid="panel-body" />
+      </CompactSecondaryPanelShelf>,
+    );
+    expect(isCompactSecondaryPanelShelfShowing()).toBe(false);
+
+    unmount();
+    expect(isCompactSecondaryPanelShelfShowing()).toBe(false);
+  });
+
+  it("closes on Escape only while open", () => {
+    const { onClose, rerender } = renderShelf(false);
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onClose).not.toHaveBeenCalled();
+
+    rerender(
+      <CompactSecondaryPanelShelf open onClose={onClose} srLabel="Right panel">
+        <div data-testid="panel-body" />
+      </CompactSecondaryPanelShelf>,
+    );
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders outside the transformed page so it does not slide with it", () => {
+    renderShelf(true);
+
+    const shelf = screen.getByTestId("secondary-panel-shelf");
+    expect(shelf.closest('[data-sidebar="inset"]')).toBeNull();
+    expect(shelf.parentElement).toBe(document.body);
+  });
+});

--- a/apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.tsx
+++ b/apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useId, useRef, useState, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+import { cn } from "@bb/shared-ui/lib/utils";
+import { setCompactSecondaryPanelShelfShowing } from "@/components/ui/secondary-panel-shelf-visibility";
+
+const SHELF_TRANSITION_CLASS =
+  "[transition:translate_220ms_cubic-bezier(0.32,0.72,0,1)]";
+const SHELF_SETTLE_MS = 220;
+
+interface CompactSecondaryPanelShelfProps {
+  children: ReactNode;
+  onClose: () => void;
+  onContentAnimationEnd?: (open: boolean) => void;
+  open: boolean;
+  srLabel?: string;
+}
+
+export function CompactSecondaryPanelShelf({
+  children,
+  onClose,
+  onContentAnimationEnd,
+  open,
+  srLabel,
+}: CompactSecondaryPanelShelfProps) {
+  const labelId = useId();
+  const panelRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    setCompactSecondaryPanelShelfShowing(open);
+    return () => setCompactSecondaryPanelShelfShowing(false);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || event.key !== "Escape") return;
+      onClose();
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [onClose, open]);
+
+  useEffect(() => {
+    if (onContentAnimationEnd === undefined) return;
+    const timer = window.setTimeout(
+      () => onContentAnimationEnd(open),
+      SHELF_SETTLE_MS,
+    );
+    return () => window.clearTimeout(timer);
+  }, [onContentAnimationEnd, open]);
+
+  const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
+  useEffect(() => {
+    setPortalTarget(document.body);
+  }, []);
+  if (portalTarget === null) {
+    return null;
+  }
+
+  return createPortal(
+    <>
+      <div
+        data-secondary-panel-shelf-dismiss=""
+        data-testid="secondary-panel-shelf-dismiss"
+        data-state={open ? "open" : "closed"}
+        aria-hidden="true"
+        className={cn(
+          "fixed inset-0 z-40 bg-transparent",
+          "data-[state=open]:-translate-x-(--secondary-panel-width-mobile)",
+          SHELF_TRANSITION_CLASS,
+          "data-[state=closed]:pointer-events-none",
+        )}
+        onClick={onClose}
+      />
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={srLabel === undefined ? undefined : labelId}
+        tabIndex={-1}
+        inert={!open}
+        data-secondary-panel-shelf=""
+        data-testid="secondary-panel-shelf"
+        data-state={open ? "open" : "closed"}
+        className="fixed inset-y-0 right-0 z-0 flex h-(--bb-shell-height) w-(--secondary-panel-width-mobile) select-none flex-col overflow-hidden border-l border-border-seam bg-background outline-none"
+      >
+        {srLabel === undefined ? null : (
+          <span id={labelId} className="sr-only">
+            {srLabel}
+          </span>
+        )}
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+          {children}
+        </div>
+      </div>
+    </>,
+    portalTarget,
+  );
+}

--- a/apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.tsx
+++ b/apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.tsx
@@ -82,7 +82,10 @@ export function CompactSecondaryPanelShelf({
         data-secondary-panel-shelf=""
         data-testid="secondary-panel-shelf"
         data-state={open ? "open" : "closed"}
-        className="fixed inset-y-0 right-0 z-0 flex h-(--bb-shell-height) w-(--secondary-panel-width-mobile) select-none flex-col overflow-hidden border-l border-border-seam bg-background outline-none"
+        className={cn(
+          "fixed inset-y-0 right-0 z-0 flex h-(--bb-shell-height) w-(--secondary-panel-width-mobile) select-none flex-col overflow-hidden border-l border-border-seam bg-background outline-none",
+          "[transition:visibility_0s_linear_0s] data-[state=closed]:invisible data-[state=closed]:[transition:visibility_0s_linear_220ms]",
+        )}
       >
         {srLabel === undefined ? null : (
           <span id={labelId} className="sr-only">

--- a/apps/app/src/components/secondary-panel/SecondaryPanelLayout.test.tsx
+++ b/apps/app/src/components/secondary-panel/SecondaryPanelLayout.test.tsx
@@ -66,12 +66,10 @@ vi.mock("react-resizable-panels", async () => {
   return { Panel, PanelGroup };
 });
 
-vi.mock("@bb/shared-ui/responsive-overlay", async (importOriginal) => {
+vi.mock("./CompactSecondaryPanelShelf", async () => {
   const React = await import("react");
-  const actual =
-    await importOriginal<typeof import("@bb/shared-ui/responsive-overlay")>();
 
-  const PersistentResponsiveDrawerShell = ({
+  const CompactSecondaryPanelShelf = ({
     children,
     onContentAnimationEnd,
     open,
@@ -91,7 +89,7 @@ vi.mock("@bb/shared-ui/responsive-overlay", async (importOriginal) => {
     );
   };
 
-  return { ...actual, PersistentResponsiveDrawerShell };
+  return { CompactSecondaryPanelShelf };
 });
 
 interface QueuedAnimationFrames {

--- a/apps/app/src/components/secondary-panel/SecondaryPanelLayout.tsx
+++ b/apps/app/src/components/secondary-panel/SecondaryPanelLayout.tsx
@@ -15,11 +15,9 @@ import {
   type ImperativePanelGroupHandle,
 } from "react-resizable-panels";
 import { useIsCompactViewport } from "@bb/shared-ui/hooks/use-compact-viewport";
-import {
-  PersistentResponsiveDrawerShell,
-  useResponsiveDrawerRealization,
-} from "@bb/shared-ui/responsive-overlay";
+import { useResponsiveDrawerRealization } from "@bb/shared-ui/responsive-overlay";
 import { cn } from "@bb/shared-ui/lib/utils";
+import { CompactSecondaryPanelShelf } from "./CompactSecondaryPanelShelf";
 import type { PluginComposerHost } from "@/components/plugin/plugin-composer-host";
 import { dispatchBrowserViewBoundsSync } from "@/lib/browser-view-bounds-sync";
 import {
@@ -345,21 +343,14 @@ export function SecondaryPanelLayout({
         </PanelGroup>
       </div>
       {renderAsDrawer ? (
-        <PersistentResponsiveDrawerShell
+        <CompactSecondaryPanelShelf
           open={open}
-          onOpenChange={(nextOpen) => {
-            if (!nextOpen) {
-              onClose();
-            }
-          }}
+          onClose={onClose}
           srLabel={drawerLabel}
-          contentClassName="h-[92dvh] max-h-[92dvh]"
           onContentAnimationEnd={handleDrawerContentAnimationEnd}
         >
-          <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-            {isPanelRealized ? drawerPanel : drawerFallback}
-          </div>
-        </PersistentResponsiveDrawerShell>
+          {isPanelRealized ? drawerPanel : drawerFallback}
+        </CompactSecondaryPanelShelf>
       ) : null}
     </>
   );

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.collapseControl.test.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.collapseControl.test.tsx
@@ -650,7 +650,7 @@ describe("ThreadSecondaryPanel Diff eligibility", () => {
 });
 
 describe("ThreadSecondaryPanel hide control glyph", () => {
-  it("shows the drawer glyph while the panel renders as a bottom drawer", () => {
+  it("shows the side-panel glyph while the panel renders as a shelf", () => {
     const view = renderPanel({
       isConversationCollapsed: false,
       onToggleConversationCollapse: noop,
@@ -658,7 +658,7 @@ describe("ThreadSecondaryPanel hide control glyph", () => {
     });
 
     const hideControl = view.getByRole("button", { name: "Hide right panel" });
-    expect(hideControl.querySelector('[data-icon="PanelBottom"]')).toBeTruthy();
+    expect(hideControl.querySelector('[data-icon="PanelRight"]')).toBeTruthy();
   });
 
   it("shows the side-panel glyph on a wide viewport", () => {

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.stories.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.stories.tsx
@@ -100,15 +100,17 @@ function createStoryFileTab(path: string): HostFilePreviewFixedPanelTab {
 function PanelStage({
   children,
   height = "compact",
+  width = "wide",
 }: {
   children: ReactNode;
   height?: "compact" | "info";
+  width?: "wide" | "shelf";
 }) {
   return (
     <div
-      className={`flex w-full max-w-[640px] min-w-0 flex-col overflow-hidden rounded-md border border-border bg-background ${
-        height === "info" ? "h-[520px]" : "h-[160px]"
-      }`}
+      className={`flex min-w-0 flex-col overflow-hidden rounded-md border border-border bg-background ${
+        width === "shelf" ? "w-[299px]" : "w-full max-w-[640px]"
+      } ${height === "info" ? "h-[520px]" : "h-[160px]"}`}
     >
       <PanelGroup direction="horizontal">{children}</PanelGroup>
     </div>
@@ -311,16 +313,41 @@ function RepresentativeTerminalContent({
   );
 }
 
+const MANY_TAB_FILENAMES: string[] = [
+  "ThreadSecondaryPanel.tsx",
+  "SecondaryPanelTabStrip.tsx",
+  "CompactSecondaryPanelShelf.tsx",
+  "useGitDiffPanelState.ts",
+  "api.ts",
+  "ThreadDetailHeader.tsx",
+  "ThreadStorageBrowser.tsx",
+  "RootComposeMobileRecents.tsx",
+  "sidebar.tsx",
+  "theme.css",
+  "app.css",
+  "package.json",
+  "README.md",
+  "use-compact-viewport.ts",
+  "provider-registry.ts",
+  "schema.sql",
+  "an-unusually-long-component-filename-that-must-truncate.tsx",
+  "index.ts",
+];
+
 interface FileTabsShellRowProps {
   filenames: string[];
   initialActiveFilename: string | null;
   pinnedFilename?: string;
+  renderAsDrawer?: boolean;
+  stage?: "wide" | "shelf";
 }
 
 function FileTabsShellInner({
   filenames,
   initialActiveFilename,
   pinnedFilename,
+  renderAsDrawer = false,
+  stage = "wide",
 }: FileTabsShellRowProps) {
   const [activeFixedTab, setActiveFixedTab] = useState<SecondaryFixedPanelTab>(
     createThreadInfoFixedPanelTab(),
@@ -365,7 +392,10 @@ function FileTabsShellInner({
   );
 
   return (
-    <PanelStage>
+    <PanelStage
+      width={stage}
+      height={stage === "shelf" ? "info" : "compact"}
+    >
       <ThreadSecondaryPanel
         activeTab={activeTab}
         canUseGitUi
@@ -385,7 +415,7 @@ function FileTabsShellInner({
         onOpenNewTab={noop}
         isConversationCollapsed={false}
         onToggleConversationCollapse={noop}
-        renderAsDrawer={false}
+        renderAsDrawer={renderAsDrawer}
         inlinePanelToggle="hidden"
         showConversationCollapseControl={false}
       />
@@ -617,6 +647,67 @@ export function SplitPanes() {
         hint="real right-panel tabs, pane focus, arrangement, maximize, close, and inner divider behavior"
       >
         <ProductionSplitPanesStory />
+      </StoryRow>
+    </StoryCard>
+  );
+}
+
+export function CompactShelfTabs() {
+  return (
+    <StoryCard>
+      <StoryRow
+        label="compact shelf — many tabs"
+        hint="phone-width shelf (299px, the --secondary-panel-width-mobile value at 393px); the tab row scrolls horizontally while Info and Diff stay fixed"
+      >
+        <FileTabsShellRow
+          filenames={MANY_TAB_FILENAMES}
+          initialActiveFilename="ThreadSecondaryPanel.tsx"
+          renderAsDrawer
+          stage="shelf"
+        />
+      </StoryRow>
+      <StoryRow
+        label="compact shelf — active tab far down the row"
+        hint="the strip should scroll the selected tab into view rather than leaving it offscreen"
+      >
+        <FileTabsShellRow
+          filenames={MANY_TAB_FILENAMES}
+          initialActiveFilename="an-unusually-long-component-filename-that-must-truncate.tsx"
+          renderAsDrawer
+          stage="shelf"
+        />
+      </StoryRow>
+      <StoryRow
+        label="compact shelf — pinned first tab"
+        hint="pinned tab keeps its slot with no close affordance while the rest scroll past it"
+      >
+        <FileTabsShellRow
+          filenames={MANY_TAB_FILENAMES}
+          pinnedFilename="ThreadSecondaryPanel.tsx"
+          initialActiveFilename="theme.css"
+          renderAsDrawer
+          stage="shelf"
+        />
+      </StoryRow>
+      <StoryRow
+        label="compact shelf — no file tab selected"
+        hint="Info stays active while the file tabs sit alongside as inactive pills"
+      >
+        <FileTabsShellRow
+          filenames={MANY_TAB_FILENAMES}
+          initialActiveFilename={null}
+          renderAsDrawer
+          stage="shelf"
+        />
+      </StoryRow>
+      <StoryRow
+        label="wide — the same tabs for comparison"
+        hint="same fixture at desktop width, so shelf-only truncation and scroll behavior is obvious"
+      >
+        <FileTabsShellRow
+          filenames={MANY_TAB_FILENAMES}
+          initialActiveFilename="ThreadSecondaryPanel.tsx"
+        />
       </StoryRow>
     </StoryCard>
   );

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
@@ -37,7 +37,7 @@ import {
   THREAD_SECONDARY_PANEL_MIN_SIZE_PERCENT,
 } from "./secondaryPanelSizing";
 import {
-  getRightPanelToggleIconName,
+  RIGHT_PANEL_TOGGLE_ICON_NAME,
   resolveConversationCollapseControl,
 } from "./panelToggleControlState";
 import { SecondaryPanelHostLayoutContext } from "./SecondaryPanelHostLayoutContext";
@@ -253,7 +253,7 @@ export function ThreadSecondaryPanel({
     [tabs],
   );
   const hasActiveRenderableTab = activeRenderableTab !== undefined;
-  const hidePanelIconName = getRightPanelToggleIconName(renderAsDrawer);
+  const hidePanelIconName = RIGHT_PANEL_TOGGLE_ICON_NAME;
   const conversationCollapseControl =
     renderAsDrawer || !showConversationCollapseControl
       ? null

--- a/apps/app/src/components/secondary-panel/panelToggleControlState.ts
+++ b/apps/app/src/components/secondary-panel/panelToggleControlState.ts
@@ -1,5 +1,3 @@
-import { useIsCompactViewport } from "@bb/shared-ui/hooks/use-compact-viewport";
-
 type PanelToggleAction = "enter-full-screen" | "exit-full-screen";
 
 type PanelToggleIconName = "Maximize2" | "Minimize2";
@@ -50,14 +48,4 @@ export function resolveConversationCollapseControl({
   };
 }
 
-type RightPanelToggleIconName = "PanelBottom" | "PanelRight";
-
-export function getRightPanelToggleIconName(
-  renderAsDrawer: boolean,
-): RightPanelToggleIconName {
-  return renderAsDrawer ? "PanelBottom" : "PanelRight";
-}
-
-export function useRightPanelToggleIconName(): RightPanelToggleIconName {
-  return getRightPanelToggleIconName(useIsCompactViewport());
-}
+export const RIGHT_PANEL_TOGGLE_ICON_NAME = "PanelRight";

--- a/apps/app/src/components/ui/overflow-fade.stories.tsx
+++ b/apps/app/src/components/ui/overflow-fade.stories.tsx
@@ -1,0 +1,101 @@
+import type { ReactNode } from "react";
+import { StoryCard, StoryRow } from "../../../.ladle/story-card";
+import { OverflowFade, type OverflowFadeTone } from "./overflow-fade";
+
+export default {
+  title: "ui/Overflow fade",
+};
+
+const TONE_SURFACE_CLASS: Record<OverflowFadeTone, string> = {
+  background: "bg-background",
+  sidebar: "bg-sidebar",
+  "surface-raised": "bg-surface-raised",
+};
+
+function FadeStage({
+  children,
+  tone,
+}: {
+  children: ReactNode;
+  tone: OverflowFadeTone;
+}) {
+  return (
+    <div
+      className={`relative h-32 w-[320px] overflow-hidden rounded-md border border-border ${TONE_SURFACE_CLASS[tone]}`}
+    >
+      <div className="flex flex-col gap-1 p-2">
+        {Array.from({ length: 8 }, (_, index) => (
+          <div
+            key={index}
+            className="h-6 shrink-0 rounded-sm border border-border-seam"
+          />
+        ))}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+export function Sizes() {
+  return (
+    <StoryCard labelWidth="150px">
+      <StoryRow
+        label="above — sm"
+        hint="h-8, used where a sticky label needs to separate from the rows under it"
+      >
+        <FadeStage tone="background">
+          <OverflowFade placement="above" tone="background" size="sm" />
+        </FadeStage>
+      </StoryRow>
+      <StoryRow label="above — default" hint="h-16, the standard scroll edge">
+        <FadeStage tone="background">
+          <OverflowFade placement="above" tone="background" />
+        </FadeStage>
+      </StoryRow>
+      <StoryRow
+        label="above — lg"
+        hint="h-24. Added for the compact home, where rows scroll behind the pinned composer and need to dissolve rather than stop at a hard edge"
+      >
+        <FadeStage tone="background">
+          <OverflowFade placement="above" tone="background" size="lg" />
+        </FadeStage>
+      </StoryRow>
+      <StoryRow label="below — lg" hint="the same size cast downward">
+        <FadeStage tone="background">
+          <OverflowFade placement="below" tone="background" size="lg" />
+        </FadeStage>
+      </StoryRow>
+      <StoryRow
+        label="left / right — lg"
+        hint="horizontal placements use w-24 at this size"
+      >
+        <FadeStage tone="background">
+          <OverflowFade placement="left" tone="background" size="lg" />
+          <OverflowFade placement="right" tone="background" size="lg" />
+        </FadeStage>
+      </StoryRow>
+    </StoryCard>
+  );
+}
+
+export function Tones() {
+  return (
+    <StoryCard labelWidth="150px">
+      <StoryRow label="background" hint="matches --background surfaces">
+        <FadeStage tone="background">
+          <OverflowFade placement="above" tone="background" size="lg" />
+        </FadeStage>
+      </StoryRow>
+      <StoryRow label="sidebar" hint="matches --sidebar surfaces">
+        <FadeStage tone="sidebar">
+          <OverflowFade placement="above" tone="sidebar" size="lg" />
+        </FadeStage>
+      </StoryRow>
+      <StoryRow label="surface-raised" hint="matches raised panel surfaces">
+        <FadeStage tone="surface-raised">
+          <OverflowFade placement="above" tone="surface-raised" size="lg" />
+        </FadeStage>
+      </StoryRow>
+    </StoryCard>
+  );
+}

--- a/apps/app/src/components/ui/overflow-fade.tsx
+++ b/apps/app/src/components/ui/overflow-fade.tsx
@@ -2,7 +2,7 @@ import { cn } from "@bb/shared-ui/lib/utils";
 
 type OverflowFadePlacement = "above" | "below" | "left" | "right";
 export type OverflowFadeTone = "background" | "sidebar" | "surface-raised";
-type OverflowFadeSize = "default" | "sm";
+type OverflowFadeSize = "default" | "sm" | "lg";
 
 interface OverflowFadeProps {
   className?: string;
@@ -32,11 +32,17 @@ const OVERFLOW_FADE_VERTICAL_SIZE_CLASSES: Record<
     aboveOffset: "-top-2",
     belowOffset: "-bottom-2",
   },
+  lg: {
+    height: "h-24",
+    aboveOffset: "-top-24",
+    belowOffset: "-bottom-24",
+  },
 };
 
 const OVERFLOW_FADE_HORIZONTAL_WIDTH_CLASS: Record<OverflowFadeSize, string> = {
   default: "w-6",
   sm: "w-2",
+  lg: "w-24",
 };
 
 function isHorizontalPlacement(

--- a/apps/app/src/components/ui/route-navigation-indicator.test.tsx
+++ b/apps/app/src/components/ui/route-navigation-indicator.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  ROUTE_NAVIGATION_INDICATOR_MIN_VISIBLE_MS,
+  ROUTE_NAVIGATION_INDICATOR_REVEAL_DELAY_MS,
+  useDelayedBusyIndicator,
+} from "./route-navigation-indicator";
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+function Probe({ busy }: { busy: boolean }) {
+  const visible = useDelayedBusyIndicator(busy);
+  return <div data-testid="probe">{visible ? "visible" : "hidden"}</div>;
+}
+
+function state(): string {
+  return screen.getByTestId("probe").textContent ?? "";
+}
+
+function advance(ms: number) {
+  act(() => {
+    vi.advanceTimersByTime(ms);
+  });
+}
+
+describe("useDelayedBusyIndicator", () => {
+  it("stays hidden for navigations that resolve before the reveal delay", () => {
+    vi.useFakeTimers();
+    const view = render(<Probe busy />);
+
+    advance(ROUTE_NAVIGATION_INDICATOR_REVEAL_DELAY_MS - 20);
+    expect(state()).toBe("hidden");
+
+    view.rerender(<Probe busy={false} />);
+    advance(1000);
+    expect(state()).toBe("hidden");
+  });
+
+  it("reveals once a navigation outlasts the delay", () => {
+    vi.useFakeTimers();
+    render(<Probe busy />);
+
+    expect(state()).toBe("hidden");
+    advance(ROUTE_NAVIGATION_INDICATOR_REVEAL_DELAY_MS);
+    expect(state()).toBe("visible");
+  });
+
+  it("holds the revealed indicator long enough to avoid a flash", () => {
+    vi.useFakeTimers();
+    const view = render(<Probe busy />);
+
+    advance(ROUTE_NAVIGATION_INDICATOR_REVEAL_DELAY_MS);
+    expect(state()).toBe("visible");
+
+    view.rerender(<Probe busy={false} />);
+    advance(ROUTE_NAVIGATION_INDICATOR_MIN_VISIBLE_MS - 20);
+    expect(state()).toBe("visible");
+
+    advance(40);
+    expect(state()).toBe("hidden");
+  });
+
+  it("hides immediately when the minimum visible window already elapsed", () => {
+    vi.useFakeTimers();
+    const view = render(<Probe busy />);
+
+    advance(ROUTE_NAVIGATION_INDICATOR_REVEAL_DELAY_MS);
+    advance(ROUTE_NAVIGATION_INDICATOR_MIN_VISIBLE_MS + 100);
+    expect(state()).toBe("visible");
+
+    view.rerender(<Probe busy={false} />);
+    advance(0);
+    expect(state()).toBe("hidden");
+  });
+});

--- a/apps/app/src/components/ui/route-navigation-indicator.tsx
+++ b/apps/app/src/components/ui/route-navigation-indicator.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useRef, useState } from "react";
+import { useIsRouteNavigationPending } from "./app-route-anchor";
+
+export const ROUTE_NAVIGATION_INDICATOR_REVEAL_DELAY_MS = 120;
+export const ROUTE_NAVIGATION_INDICATOR_MIN_VISIBLE_MS = 320;
+
+export function useDelayedBusyIndicator(
+  busy: boolean,
+  {
+    revealDelayMs = ROUTE_NAVIGATION_INDICATOR_REVEAL_DELAY_MS,
+    minVisibleMs = ROUTE_NAVIGATION_INDICATOR_MIN_VISIBLE_MS,
+  }: { revealDelayMs?: number; minVisibleMs?: number } = {},
+): boolean {
+  const [visible, setVisible] = useState(false);
+  const shownAtRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (busy) {
+      if (shownAtRef.current !== null) return;
+      const revealTimeout = window.setTimeout(() => {
+        shownAtRef.current = Date.now();
+        setVisible(true);
+      }, revealDelayMs);
+      return () => window.clearTimeout(revealTimeout);
+    }
+
+    const shownAt = shownAtRef.current;
+    if (shownAt === null) {
+      setVisible(false);
+      return;
+    }
+
+    const remainingMs = minVisibleMs - (Date.now() - shownAt);
+    if (remainingMs <= 0) {
+      shownAtRef.current = null;
+      setVisible(false);
+      return;
+    }
+
+    const hideTimeout = window.setTimeout(() => {
+      shownAtRef.current = null;
+      setVisible(false);
+    }, remainingMs);
+    return () => window.clearTimeout(hideTimeout);
+  }, [busy, minVisibleMs, revealDelayMs]);
+
+  return visible;
+}
+
+export function RouteNavigationIndicator() {
+  const isPending = useIsRouteNavigationPending();
+  const visible = useDelayedBusyIndicator(isPending);
+
+  if (!visible) return null;
+
+  return (
+    <div
+      data-testid="route-navigation-indicator"
+      role="progressbar"
+      aria-label="Loading page"
+      className="pointer-events-none fixed inset-x-0 top-[env(safe-area-inset-top)] z-100 h-0.5 overflow-hidden bg-transparent"
+    >
+      <div className="h-full w-1/3 animate-indeterminate-progress rounded-full bg-muted-foreground" />
+    </div>
+  );
+}

--- a/apps/app/src/components/ui/secondary-panel-shelf-visibility.ts
+++ b/apps/app/src/components/ui/secondary-panel-shelf-visibility.ts
@@ -1,0 +1,25 @@
+let compactSecondaryPanelShelfShowing = false;
+const listeners = new Set<() => void>();
+
+export function isCompactSecondaryPanelShelfShowing(): boolean {
+  return compactSecondaryPanelShelfShowing;
+}
+
+export function setCompactSecondaryPanelShelfShowing(showing: boolean): void {
+  if (compactSecondaryPanelShelfShowing === showing) {
+    return;
+  }
+  compactSecondaryPanelShelfShowing = showing;
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+export function subscribeCompactSecondaryPanelShelfShowing(
+  listener: () => void,
+): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}

--- a/apps/app/src/components/ui/sidebar.test.tsx
+++ b/apps/app/src/components/ui/sidebar.test.tsx
@@ -217,6 +217,19 @@ function getMobilePanel(): HTMLElement | null {
   return panel instanceof HTMLElement ? panel : null;
 }
 
+const SHELF_OPEN_TRANSLATE = "320px";
+const SHELF_CLOSED_TRANSLATE = "0px";
+
+function getShelfRevealTranslate(): string {
+  const backdrop = document.querySelector("[data-sidebar-mobile-backdrop]");
+  return backdrop instanceof HTMLElement ? backdrop.style.translate : "";
+}
+
+function getShelfInsetTranslate(): string {
+  const inset = document.querySelector('[data-sidebar="inset"]');
+  return inset instanceof HTMLElement ? inset.style.translate : "";
+}
+
 const MOBILE_REALIZE_TIMEOUT_MS = 1000;
 
 function settleMobileRealization() {
@@ -328,7 +341,8 @@ describe("mobile sidebar deferred realization", () => {
         trigger.click();
       });
       const panel = getMobilePanel();
-      panelStyledForSlideInTap = panel?.style.translate === "0%";
+      panelStyledForSlideInTap =
+        getShelfRevealTranslate() === SHELF_OPEN_TRANSLATE;
       realizedInTapFlush =
         panel?.textContent?.includes("Sidebar content") ?? false;
     });
@@ -374,6 +388,47 @@ describe("mobile sidebar deferred realization", () => {
   });
 });
 
+describe("mobile sidebar shelf stacking", () => {
+  it("keeps the panel beneath the page and moves the page to reveal it", () => {
+    vi.useFakeTimers();
+    renderCompactSidebarHarness();
+    settleMobileRealization();
+
+    const panel = getMobilePanel();
+    const inset = document.querySelector('[data-sidebar="inset"]');
+    if (!(inset instanceof HTMLElement) || panel === null) {
+      throw new Error("Expected a compact panel and page inset");
+    }
+
+    expect(panel.className).toContain("z-0");
+    expect(inset.className).toContain("max-md:z-30");
+    expect(inset.dataset.sidebarShelf).toBe("closed");
+
+    fireEvent.click(screen.getByRole("button", { name: "Toggle Sidebar" }));
+    settleMobileToggle();
+
+    expect(inset.dataset.sidebarShelf).toBe("open");
+    expect(getMobilePanel()?.style.translate).toBe("");
+  });
+
+  it("leaves the page untouched by the shelf on desktop", () => {
+    render(
+      <CompactViewportOverrideProvider isCompactViewport={false}>
+        <SidebarProvider>
+          <Sidebar>Sidebar content</Sidebar>
+          <SidebarInset>Main content</SidebarInset>
+        </SidebarProvider>
+      </CompactViewportOverrideProvider>,
+    );
+
+    const inset = document.querySelector('[data-sidebar="inset"]');
+    if (!(inset instanceof HTMLElement)) {
+      throw new Error("Expected a page inset");
+    }
+    expect(inset.dataset.sidebarShelf).toBeUndefined();
+  });
+});
+
 describe("mobile sidebar persistence", () => {
   it("keeps closed drawer content mounted, inert, and offscreen", () => {
     vi.useFakeTimers();
@@ -394,7 +449,7 @@ describe("mobile sidebar persistence", () => {
 
     const openingPanel = getMobilePanel();
     expect(openingPanel?.dataset.state).toBe("closed");
-    expect(openingPanel?.style.translate).toBe("0%");
+    expect(getShelfInsetTranslate()).toBe(SHELF_OPEN_TRANSLATE);
     settleMobileToggle();
 
     const openPanel = getMobilePanel();
@@ -411,7 +466,7 @@ describe("mobile sidebar persistence", () => {
     fireEvent.click(backdrop);
     const closingPanel = getMobilePanel();
     expect(closingPanel?.dataset.state).toBe("open");
-    expect(closingPanel?.style.translate).toBe("-100%");
+    expect(getShelfInsetTranslate()).toBe(SHELF_CLOSED_TRANSLATE);
 
     settleMobileToggle();
 
@@ -479,7 +534,7 @@ describe("mobile sidebar persistence", () => {
 
     fireEvent.click(trigger);
     expect(getMobilePanel()?.dataset.state).toBe("open");
-    expect(getMobilePanel()?.style.translate).toBe("-100%");
+    expect(getShelfRevealTranslate()).toBe(SHELF_CLOSED_TRANSLATE);
 
     settleMobileToggle();
     expect(getMobilePanel()?.dataset.state).toBe("closed");

--- a/apps/app/src/components/ui/sidebar.test.tsx
+++ b/apps/app/src/components/ui/sidebar.test.tsx
@@ -411,6 +411,23 @@ describe("mobile sidebar shelf stacking", () => {
     expect(getMobilePanel()?.style.translate).toBe("");
   });
 
+  it("lifts the revealed page on the shelf-facing edge for both shelves", () => {
+    vi.useFakeTimers();
+    renderCompactSidebarHarness();
+    settleMobileRealization();
+
+    const inset = document.querySelector('[data-sidebar="inset"]');
+    if (!(inset instanceof HTMLElement)) {
+      throw new Error("Expected a page inset");
+    }
+
+    expect(inset.className).toContain("data-[sidebar-shelf=open]:rounded-l-xl");
+    expect(inset.className).toContain("data-[panel-shelf=open]:rounded-r-xl");
+    expect(inset.className).toContain("data-[sidebar-shelf=open]:shadow-xl");
+    expect(inset.className).toContain("data-[panel-shelf=open]:shadow-xl");
+    expect(inset.className).not.toContain("shadow-2xl");
+  });
+
   it("leaves the page untouched by the shelf on desktop", () => {
     render(
       <CompactViewportOverrideProvider isCompactViewport={false}>

--- a/apps/app/src/components/ui/sidebar.tsx
+++ b/apps/app/src/components/ui/sidebar.tsx
@@ -17,7 +17,8 @@ import {
 import { setCompactSidebarDrawerShowing } from "./sidebar-mobile-drawer-visibility.js";
 
 const SIDEBAR_WIDTH = "16rem";
-const SIDEBAR_WIDTH_MOBILE = "min(90vw, 320px)";
+const SIDEBAR_MOBILE_VIEWPORT_FRACTION = 0.76;
+const SIDEBAR_WIDTH_MOBILE = `min(${SIDEBAR_MOBILE_VIEWPORT_FRACTION * 100}vw, 320px)`;
 const SIDEBAR_WIDTH_ICON = "3rem";
 const SIDEBAR_MOBILE_SWIPE_BROWSER_EDGE_GUARD_PX = 24;
 const SIDEBAR_MOBILE_SWIPE_OPEN_EDGE_ZONE_PX = 72;
@@ -72,7 +73,7 @@ function getSidebarMobilePanelWidth(): number {
     return 320;
   }
 
-  return Math.min(window.innerWidth * 0.9, 320);
+  return Math.min(window.innerWidth * SIDEBAR_MOBILE_VIEWPORT_FRACTION, 320);
 }
 
 function clampSidebarMobileSwipeProgress(value: number): number {
@@ -1297,7 +1298,7 @@ const SidebarMobilePanel = React.forwardRef<
           data-testid="sidebar-mobile-backdrop"
           data-state={open ? "open" : "closed"}
           className={cn(
-            "fixed inset-0 z-40 bg-black/40 will-change-[opacity,translate]",
+            "fixed inset-0 z-40 bg-transparent will-change-[opacity,translate]",
             "data-[state=open]:translate-x-(--sidebar-width-mobile)",
             SIDEBAR_MOBILE_BACKDROP_TRANSITION_CLASS,
             "data-[state=closed]:pointer-events-none data-[state=closed]:opacity-0",

--- a/apps/app/src/components/ui/sidebar.tsx
+++ b/apps/app/src/components/ui/sidebar.tsx
@@ -28,16 +28,16 @@ const SIDEBAR_MOBILE_SWIPE_OPEN_FLING_VELOCITY_PX_PER_SEC = 450;
 const SIDEBAR_MOBILE_DRAG_SETTLE_MS = 220;
 const SIDEBAR_MOBILE_REALIZE_TIMEOUT_MS = 1000;
 const SIDEBAR_MOBILE_DRAG_SETTLE_EASING = "cubic-bezier(0.32, 0.72, 0, 1)";
-const SIDEBAR_MOBILE_PANEL_SETTLE_TRANSITION = `translate ${SIDEBAR_MOBILE_DRAG_SETTLE_MS}ms ${SIDEBAR_MOBILE_DRAG_SETTLE_EASING}`;
-const SIDEBAR_MOBILE_BACKDROP_SETTLE_TRANSITION = `opacity ${SIDEBAR_MOBILE_DRAG_SETTLE_MS}ms ${SIDEBAR_MOBILE_DRAG_SETTLE_EASING}`;
+const SIDEBAR_MOBILE_SHELF_SETTLE_TRANSITION = `translate ${SIDEBAR_MOBILE_DRAG_SETTLE_MS}ms ${SIDEBAR_MOBILE_DRAG_SETTLE_EASING}`;
+const SIDEBAR_MOBILE_SHELF_BACKDROP_SETTLE_TRANSITION = `opacity ${SIDEBAR_MOBILE_DRAG_SETTLE_MS}ms ${SIDEBAR_MOBILE_DRAG_SETTLE_EASING}, translate ${SIDEBAR_MOBILE_DRAG_SETTLE_MS}ms ${SIDEBAR_MOBILE_DRAG_SETTLE_EASING}`;
 const SIDEBAR_MOBILE_WHEEL_SWIPE_OPEN_DISTANCE_PX = 90;
 const SIDEBAR_MOBILE_WHEEL_SWIPE_RESET_MS = 250;
 const SIDEBAR_MOBILE_DRAG_CLOSE_RATIO = 0.25;
 const SIDEBAR_MOBILE_DRAG_CLOSE_FLING_VELOCITY_PX_PER_SEC = 450;
-const SIDEBAR_MOBILE_PANEL_TRANSITION_CLASS =
-  "[transition:translate_220ms_cubic-bezier(0.32,0.72,0,1)]";
+const SIDEBAR_MOBILE_SHELF_INSET_TRANSITION_CLASS =
+  "max-md:[transition:translate_220ms_cubic-bezier(0.32,0.72,0,1)]";
 const SIDEBAR_MOBILE_BACKDROP_TRANSITION_CLASS =
-  "[transition:opacity_220ms_cubic-bezier(0.32,0.72,0,1)]";
+  "[transition:opacity_220ms_cubic-bezier(0.32,0.72,0,1),translate_220ms_cubic-bezier(0.32,0.72,0,1)]";
 const SIDEBAR_GROUP_LABEL_BASE_CLASS =
   "duration-200 flex shrink-0 items-center rounded-md px-1 text-xs font-medium text-sidebar-foreground/75 outline-none ring-sidebar-ring transition-[margin,opa] ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0";
 const SIDEBAR_GROUP_LABEL_COLLAPSED_CLASS =
@@ -82,25 +82,27 @@ function clampSidebarMobileSwipeProgress(value: number): number {
 function getSidebarMobileMotionNodes(): {
   panel: HTMLElement | null;
   backdrop: HTMLElement | null;
+  inset: HTMLElement | null;
 } {
   if (typeof document === "undefined") {
-    return { panel: null, backdrop: null };
+    return { panel: null, backdrop: null, inset: null };
   }
 
   const panel = document.querySelector(
     '[data-sidebar="panel"][data-vaul-drawer-direction]',
   );
   const backdrop = document.querySelector("[data-sidebar-mobile-backdrop]");
+  const inset = document.querySelector('[data-sidebar="inset"]');
 
   return {
     panel: panel instanceof HTMLElement ? panel : null,
     backdrop: backdrop instanceof HTMLElement ? backdrop : null,
+    inset: inset instanceof HTMLElement ? inset : null,
   };
 }
 
-function getSidebarMobilePanelTranslate(progress: number): string {
-  const hiddenPercent = (1 - progress) * 100;
-  return `-${hiddenPercent}%`;
+function getSidebarShelfRevealTranslate(progress: number): string {
+  return `${Math.round(getSidebarMobilePanelWidth() * progress)}px`;
 }
 
 function applySidebarMobileDragStyles({
@@ -110,43 +112,51 @@ function applySidebarMobileDragStyles({
   progress: number;
   settling: boolean;
 }) {
-  const { panel, backdrop } = getSidebarMobileMotionNodes();
+  const { panel, backdrop, inset } = getSidebarMobileMotionNodes();
+  const translate = getSidebarShelfRevealTranslate(progress);
 
-  if (panel !== null) {
-    panel.setAttribute("data-vaul-animate", "false");
-    panel.style.translate = getSidebarMobilePanelTranslate(progress);
-    panel.style.transition = settling
-      ? SIDEBAR_MOBILE_PANEL_SETTLE_TRANSITION
+  panel?.setAttribute("data-vaul-animate", "false");
+
+  if (inset !== null) {
+    inset.setAttribute("data-vaul-animate", "false");
+    inset.style.translate = translate;
+    inset.style.transition = settling
+      ? SIDEBAR_MOBILE_SHELF_SETTLE_TRANSITION
       : "none";
   }
 
   if (backdrop !== null) {
     backdrop.setAttribute("data-vaul-animate", "false");
+    backdrop.style.translate = translate;
     backdrop.style.opacity = String(progress);
     backdrop.style.transition = settling
-      ? SIDEBAR_MOBILE_BACKDROP_SETTLE_TRANSITION
+      ? SIDEBAR_MOBILE_SHELF_BACKDROP_SETTLE_TRANSITION
       : "none";
     backdrop.style.pointerEvents = progress > 0 ? "auto" : "";
   }
 }
 
 function clearSidebarMobileDragAttributes() {
-  const { panel, backdrop } = getSidebarMobileMotionNodes();
+  const { panel, backdrop, inset } = getSidebarMobileMotionNodes();
   panel?.removeAttribute("data-vaul-animate");
   backdrop?.removeAttribute("data-vaul-animate");
+  inset?.removeAttribute("data-vaul-animate");
 }
 
 function clearSidebarMobileDragStyles() {
-  const { panel, backdrop } = getSidebarMobileMotionNodes();
+  const { panel, backdrop, inset } = getSidebarMobileMotionNodes();
 
-  if (panel !== null) {
-    panel.removeAttribute("data-vaul-animate");
-    panel.style.translate = "";
-    panel.style.transition = "";
+  panel?.removeAttribute("data-vaul-animate");
+
+  if (inset !== null) {
+    inset.removeAttribute("data-vaul-animate");
+    inset.style.translate = "";
+    inset.style.transition = "";
   }
 
   if (backdrop !== null) {
     backdrop.removeAttribute("data-vaul-animate");
+    backdrop.style.translate = "";
     backdrop.style.opacity = "";
     backdrop.style.transition = "";
     backdrop.style.pointerEvents = "";
@@ -653,11 +663,12 @@ const SidebarProvider = React.forwardRef<
                 style={
                   {
                     "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
+                    ...sidebarMobileWidthStyle,
                     ...style,
                   } as React.CSSProperties
                 }
                 className={cn(
-                  "group/sidebar-wrapper flex h-full min-h-0 w-full has-[[data-variant=inset]]:bg-sidebar",
+                  "group/sidebar-wrapper flex h-full min-h-0 w-full has-[[data-variant=inset]]:bg-sidebar max-md:overflow-clip",
                   className,
                 )}
                 ref={ref}
@@ -707,24 +718,13 @@ const Sidebar = React.forwardRef<HTMLDivElement, React.ComponentProps<"div">>(
     );
     const shouldSuppressMobileCloseAnimation =
       !openMobile && suppressMobileCloseAnimation;
-    const mobilePanelMotionStyle = React.useMemo<
-      React.CSSProperties | undefined
-    >(() => {
-      if (shouldSuppressMobileCloseAnimation) {
-        return {
-          translate: "-100%",
-          transition: "none",
-        };
-      }
-
-      return undefined;
-    }, [shouldSuppressMobileCloseAnimation]);
     const mobileBackdropStyle = React.useMemo<
       React.CSSProperties | undefined
     >(() => {
       if (shouldSuppressMobileCloseAnimation) {
         return {
           opacity: 0,
+          translate: "0px",
           pointerEvents: "none",
           transition: "none",
         };
@@ -741,7 +741,6 @@ const Sidebar = React.forwardRef<HTMLDivElement, React.ComponentProps<"div">>(
           onOpenChange={handleOpenMobileChange}
           onDismiss={closeMobileSidebar}
           suppressOpenAnimation={suppressMobileOpenAnimation}
-          panelMotionStyle={mobilePanelMotionStyle}
           backdropStyle={mobileBackdropStyle}
           className={className}
           style={style}
@@ -833,7 +832,6 @@ interface SidebarMobilePanelProps extends React.ComponentProps<"div"> {
   onOpenChange: (open: boolean) => void;
   onDismiss: () => void;
   suppressOpenAnimation: boolean;
-  panelMotionStyle?: React.CSSProperties;
   backdropStyle?: React.CSSProperties;
 }
 
@@ -874,7 +872,6 @@ const SidebarMobilePanel = React.forwardRef<
       onOpenChange,
       onDismiss,
       suppressOpenAnimation,
-      panelMotionStyle,
       backdropStyle,
       className,
       style,
@@ -1300,7 +1297,8 @@ const SidebarMobilePanel = React.forwardRef<
           data-testid="sidebar-mobile-backdrop"
           data-state={open ? "open" : "closed"}
           className={cn(
-            "fixed inset-0 z-40 bg-black/80 will-change-[opacity]",
+            "fixed inset-0 z-40 bg-black/40 will-change-[opacity,translate]",
+            "data-[state=open]:translate-x-(--sidebar-width-mobile)",
             SIDEBAR_MOBILE_BACKDROP_TRANSITION_CLASS,
             "data-[state=closed]:pointer-events-none data-[state=closed]:opacity-0",
           )}
@@ -1322,9 +1320,7 @@ const SidebarMobilePanel = React.forwardRef<
           data-side="left"
           data-vaul-drawer-direction="left"
           className={cn(
-            "group fixed inset-y-0 z-40 flex h-(--bb-shell-height) w-(--sidebar-width-mobile) touch-pan-y select-none flex-col bg-sidebar text-sidebar-foreground outline-none will-change-[translate]",
-            SIDEBAR_MOBILE_PANEL_TRANSITION_CLASS,
-            "left-0 data-[state=closed]:-translate-x-full",
+            "group fixed inset-y-0 left-0 z-0 flex h-(--bb-shell-height) w-(--sidebar-width-mobile) touch-pan-y select-none flex-col bg-sidebar text-sidebar-foreground outline-none",
             "border-border-seam data-[side=left]:border-r data-[side=right]:border-l",
             className,
           )}
@@ -1332,8 +1328,6 @@ const SidebarMobilePanel = React.forwardRef<
             {
               ...sidebarMobileWidthStyle,
               ...style,
-              ...suppressedOpenTransitionStyle,
-              ...panelMotionStyle,
             } as SidebarMobileWidthStyle
           }
           onPointerDown={handlePanelPointerDown}
@@ -1393,6 +1387,7 @@ const SidebarInset = React.forwardRef<
     openMobile,
     setOpenMobile,
     openMobileSidebar,
+    suppressMobileOpenAnimation,
     setSuppressMobileOpenAnimation,
     setSuppressMobileCloseAnimation,
   } = useSidebar();
@@ -1891,12 +1886,26 @@ const SidebarInset = React.forwardRef<
     }
   }, [clearSwipeSession, isCompactViewport, openMobile]);
 
+  const shelfState = isCompactViewport
+    ? openMobile
+      ? "open"
+      : "closed"
+    : undefined;
+
   return (
     <main
       ref={ref}
       data-sidebar="inset"
+      data-sidebar-shelf={shelfState}
+      style={
+        openMobile && suppressMobileOpenAnimation
+          ? { transition: "none" }
+          : undefined
+      }
       className={cn(
-        "relative flex h-full min-h-0 min-w-0 flex-1 flex-col bg-background",
+        "relative flex h-full min-h-0 min-w-0 flex-1 flex-col bg-background max-md:z-30",
+        SIDEBAR_MOBILE_SHELF_INSET_TRANSITION_CLASS,
+        "data-[sidebar-shelf=open]:translate-x-(--sidebar-width-mobile) data-[sidebar-shelf=open]:rounded-l-xl data-[sidebar-shelf=open]:shadow-2xl data-[sidebar-shelf]:will-change-[translate]",
         "md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow",
         className,
       )}

--- a/apps/app/src/components/ui/sidebar.tsx
+++ b/apps/app/src/components/ui/sidebar.tsx
@@ -15,6 +15,10 @@ import {
   TooltipTrigger,
 } from "@bb/shared-ui/tooltip";
 import { setCompactSidebarDrawerShowing } from "./sidebar-mobile-drawer-visibility.js";
+import {
+  isCompactSecondaryPanelShelfShowing,
+  subscribeCompactSecondaryPanelShelfShowing,
+} from "./secondary-panel-shelf-visibility.js";
 
 const SIDEBAR_WIDTH = "16rem";
 const SIDEBAR_MOBILE_VIEWPORT_FRACTION = 0.76;
@@ -1887,17 +1891,29 @@ const SidebarInset = React.forwardRef<
     }
   }, [clearSwipeSession, isCompactViewport, openMobile]);
 
+  const secondaryPanelShelfShowing = React.useSyncExternalStore(
+    subscribeCompactSecondaryPanelShelfShowing,
+    isCompactSecondaryPanelShelfShowing,
+    () => false,
+  );
   const shelfState = isCompactViewport
     ? openMobile
       ? "open"
       : "closed"
     : undefined;
+  const panelShelfState =
+    isCompactViewport && !openMobile
+      ? secondaryPanelShelfShowing
+        ? "open"
+        : "closed"
+      : undefined;
 
   return (
     <main
       ref={ref}
       data-sidebar="inset"
       data-sidebar-shelf={shelfState}
+      data-panel-shelf={panelShelfState}
       style={
         openMobile && suppressMobileOpenAnimation
           ? { transition: "none" }
@@ -1907,6 +1923,7 @@ const SidebarInset = React.forwardRef<
         "relative flex h-full min-h-0 min-w-0 flex-1 flex-col bg-background max-md:z-30",
         SIDEBAR_MOBILE_SHELF_INSET_TRANSITION_CLASS,
         "data-[sidebar-shelf=open]:translate-x-(--sidebar-width-mobile) data-[sidebar-shelf=open]:rounded-l-xl data-[sidebar-shelf=open]:shadow-2xl data-[sidebar-shelf]:will-change-[translate]",
+        "data-[panel-shelf=open]:-translate-x-(--secondary-panel-width-mobile) data-[panel-shelf=open]:rounded-r-xl data-[panel-shelf=open]:shadow-2xl data-[panel-shelf]:will-change-[translate]",
         "md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow",
         className,
       )}

--- a/apps/app/src/components/ui/sidebar.tsx
+++ b/apps/app/src/components/ui/sidebar.tsx
@@ -1922,8 +1922,8 @@ const SidebarInset = React.forwardRef<
       className={cn(
         "relative flex h-full min-h-0 min-w-0 flex-1 flex-col bg-background max-md:z-30",
         SIDEBAR_MOBILE_SHELF_INSET_TRANSITION_CLASS,
-        "data-[sidebar-shelf=open]:translate-x-(--sidebar-width-mobile) data-[sidebar-shelf=open]:rounded-l-xl data-[sidebar-shelf=open]:shadow-2xl data-[sidebar-shelf]:will-change-[translate]",
-        "data-[panel-shelf=open]:-translate-x-(--secondary-panel-width-mobile) data-[panel-shelf=open]:rounded-r-xl data-[panel-shelf=open]:shadow-2xl data-[panel-shelf]:will-change-[translate]",
+        "data-[sidebar-shelf=open]:translate-x-(--sidebar-width-mobile) data-[sidebar-shelf=open]:rounded-l-xl data-[sidebar-shelf=open]:shadow-xl data-[sidebar-shelf]:will-change-[translate]",
+        "data-[panel-shelf=open]:-translate-x-(--secondary-panel-width-mobile) data-[panel-shelf=open]:rounded-r-xl data-[panel-shelf=open]:shadow-xl data-[panel-shelf]:will-change-[translate]",
         "md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow",
         className,
       )}

--- a/apps/app/src/components/ui/theme.css
+++ b/apps/app/src/components/ui/theme.css
@@ -1041,20 +1041,20 @@ body.sidebar-resizing [data-sidebar="panel"] {
   }
 
   /*
-   * Indeterminate progress sweep. Used while a plugin installs: the server does
-   * the work behind one blocking request, so the client can say that work is
-   * happening but not how far along it is. A first install on a machine also
-   * downloads the build toolchain, which is why this window can run ~17s.
+   * Indeterminate progress sweep, for work whose duration the client cannot
+   * predict: a plugin install (one blocking server request that can run ~17s on
+   * a machine's first install, because it also downloads the build toolchain),
+   * and route navigation that React has deprioritized behind a transition.
    */
-  .animate-plugin-install-progress {
-    animation: plugin-install-progress 1.5s ease-in-out infinite;
+  .animate-indeterminate-progress {
+    animation: indeterminate-progress 1.5s ease-in-out infinite;
   }
 
   /* Reduced motion: drop the shimmer sweep and render the active cue as plain
      full-strength foreground text/glyph instead of a frozen gradient/mask. */
   @media (prefers-reduced-motion: reduce) {
     /* A static half-width fill still reads as "busy" without the sweep. */
-    .animate-plugin-install-progress {
+    .animate-indeterminate-progress {
       animation: none;
       width: 50%;
     }
@@ -1084,7 +1084,7 @@ body.sidebar-resizing [data-sidebar="panel"] {
   }
 }
 
-@keyframes plugin-install-progress {
+@keyframes indeterminate-progress {
   0% {
     margin-inline-start: -35%;
   }

--- a/apps/app/src/hooks/cache-owners/query-cache.ts
+++ b/apps/app/src/hooks/cache-owners/query-cache.ts
@@ -11,6 +11,7 @@ import {
   iterateThreadListCacheEntries,
 } from "./thread-list-cache-data";
 import { bumpDiffPatchEvictionGeneration } from "./environment-diff-patch-cache-owner";
+import { readCachedSidebarBootstrap } from "@/lib/sidebar-bootstrap-cache";
 import type {
   SidebarBootstrapResponse,
   ThreadResponse,
@@ -363,6 +364,27 @@ export function getCachedSidebarNavigationThreads(
     return [];
   }
   return listSidebarNavigationThreads(navigation);
+}
+
+export function findSidebarNavigationThreadPlaceholder(
+  queryClient: QueryClient,
+  threadId: string,
+): ThreadListEntry | undefined {
+  if (!threadId) {
+    return undefined;
+  }
+  const cached = getCachedSidebarNavigationThreads(queryClient).find(
+    (thread) => thread.id === threadId,
+  );
+  if (cached !== undefined) {
+    return cached;
+  }
+  const persisted = readCachedSidebarBootstrap();
+  return persisted === null
+    ? undefined
+    : listSidebarNavigationThreads(persisted).find(
+        (thread) => thread.id === threadId,
+      );
 }
 
 export function snapshotCachedSidebarNavigation(

--- a/apps/app/src/hooks/cache-owners/sidebar-thread-placeholder.test.ts
+++ b/apps/app/src/hooks/cache-owners/sidebar-thread-placeholder.test.ts
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+
+import { QueryClient } from "@tanstack/react-query";
+import type { SidebarBootstrapResponse } from "@bb/server-contract";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { makeThreadListEntry } from "../../../.ladle/story-fixtures";
+import { sidebarNavigationQueryKey } from "@/hooks/queries/query-keys";
+
+const readCachedSidebarBootstrap = vi.fn<() => SidebarBootstrapResponse | null>(
+  () => null,
+);
+
+vi.mock("@/lib/sidebar-bootstrap-cache", () => ({
+  readCachedSidebarBootstrap: () => readCachedSidebarBootstrap(),
+}));
+
+const { findSidebarNavigationThreadPlaceholder } =
+  await import("./query-cache");
+
+const PROJECT_ID = "proj_bb";
+
+function bootstrap(threadIds: string[]): SidebarBootstrapResponse {
+  return {
+    sections: [],
+    projects: [
+      {
+        id: PROJECT_ID,
+        threads: threadIds.map((id) =>
+          makeThreadListEntry({ id, projectId: PROJECT_ID }),
+        ),
+      },
+    ],
+    personalProject: { id: "proj_personal", threads: [] },
+  } as unknown as SidebarBootstrapResponse;
+}
+
+afterEach(() => {
+  readCachedSidebarBootstrap.mockReset();
+  readCachedSidebarBootstrap.mockReturnValue(null);
+});
+
+describe("findSidebarNavigationThreadPlaceholder", () => {
+  it("resolves from the live sidebar navigation cache without touching storage", () => {
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(
+      sidebarNavigationQueryKey(),
+      bootstrap(["thr_live"]),
+    );
+
+    expect(
+      findSidebarNavigationThreadPlaceholder(queryClient, "thr_live")?.id,
+    ).toBe("thr_live");
+    expect(readCachedSidebarBootstrap).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the persisted bootstrap so a cold boot still resolves", () => {
+    readCachedSidebarBootstrap.mockReturnValue(bootstrap(["thr_persisted"]));
+
+    expect(
+      findSidebarNavigationThreadPlaceholder(new QueryClient(), "thr_persisted")
+        ?.id,
+    ).toBe("thr_persisted");
+    expect(readCachedSidebarBootstrap).toHaveBeenCalled();
+  });
+
+  it("returns nothing for an unknown or empty thread id", () => {
+    readCachedSidebarBootstrap.mockReturnValue(bootstrap(["thr_live"]));
+    const queryClient = new QueryClient();
+
+    expect(
+      findSidebarNavigationThreadPlaceholder(queryClient, "thr_missing"),
+    ).toBeUndefined();
+    expect(
+      findSidebarNavigationThreadPlaceholder(queryClient, ""),
+    ).toBeUndefined();
+  });
+});

--- a/apps/app/src/hooks/queries/system-queries.ts
+++ b/apps/app/src/hooks/queries/system-queries.ts
@@ -215,36 +215,38 @@ export function useSystemProviders(args: UseSystemProvidersArgs = {}) {
   const hostId = args.hostId ?? null;
   const enabled = args.enabled ?? true;
   useSystemRealtimeSubscription({ enabled });
+  const providersCacheKey = providerListCacheKey({ environmentId, hostId });
   return useQuery<ProviderInfo[]>({
     queryKey: systemProvidersQueryKey({ capability, environmentId, hostId }),
-    queryFn: ({ signal }) => {
-      if (args.environmentId !== undefined) {
-        return sdk.providers.list({
-          ...(args.capability === undefined
-            ? {}
-            : { capability: args.capability }),
-          environmentId: args.environmentId,
-          signal,
-        });
+    queryFn: async ({ signal }) => {
+      const capabilityFilter =
+        args.capability === undefined ? {} : { capability: args.capability };
+      const providers = await (args.environmentId !== undefined
+        ? sdk.providers.list({
+            ...capabilityFilter,
+            environmentId: args.environmentId,
+            signal,
+          })
+        : args.hostId !== undefined
+          ? sdk.providers.list({
+              ...capabilityFilter,
+              hostId: args.hostId,
+              signal,
+            })
+          : sdk.providers.list({ ...capabilityFilter, signal }));
+      if (capability === null) {
+        writeCachedProviderList(providersCacheKey, providers);
       }
-      if (args.hostId !== undefined) {
-        return sdk.providers.list({
-          ...(args.capability === undefined
-            ? {}
-            : { capability: args.capability }),
-          hostId: args.hostId,
-          signal,
-        });
-      }
-      return sdk.providers.list({
-        ...(args.capability === undefined
-          ? {}
-          : { capability: args.capability }),
-        signal,
-      });
+      return providers;
     },
     enabled,
     staleTime: 60_000,
+    placeholderData: () => {
+      const remembered = readCachedProviderList(providersCacheKey);
+      return remembered !== null && remembered.length > 0
+        ? remembered
+        : undefined;
+    },
   });
 }
 

--- a/apps/app/src/hooks/queries/thread-queries.ts
+++ b/apps/app/src/hooks/queries/thread-queries.ts
@@ -38,6 +38,7 @@ import {
 import {
   getCachedSidebarNavigationThreads,
   getCachedThreadListPlaceholder,
+  findSidebarNavigationThreadPlaceholder,
 } from "../cache-owners/query-cache";
 import { useSidebarNavigationThreadSelection } from "./sidebar-navigation-query";
 import {
@@ -630,7 +631,8 @@ export function useThread(id: string, options?: QueryOptions) {
     placeholderData: (previousData, previousQuery) =>
       resolveThreadPlaceholder(previousData, previousQuery?.queryKey, id) ??
       liftThreadListPlaceholder(
-        getCachedThreadListPlaceholder(queryClient, id),
+        getCachedThreadListPlaceholder(queryClient, id) ??
+          findSidebarNavigationThreadPlaceholder(queryClient, id),
       ),
   });
 }

--- a/apps/app/src/views/RootComposeCompactHome.stories.tsx
+++ b/apps/app/src/views/RootComposeCompactHome.stories.tsx
@@ -1,24 +1,96 @@
+import type { ReactNode } from "react";
+import type { ThreadListEntry } from "@bb/domain";
 import { StoryCard, StoryRow } from "../../.ladle/story-card";
-import { OverflowFade } from "@/components/ui/overflow-fade";
+import {
+  PROJECT_IDS,
+  PROJECT_NAMES,
+  STORY_PROVIDERS_BY_ID,
+  makeThreadListEntry,
+} from "../../.ladle/story-fixtures";
 import { RootComposeCompactHome } from "./RootComposeCompactHome";
-import { MOBILE_RECENT_ROW_HEIGHT_PX } from "./RootComposeMobileRecents";
+import { RootComposeMobileRecents } from "./RootComposeMobileRecents";
 
 export default {
   title: "views/Compact Home",
 };
 
-const RECENT_TITLES = [
-  "Rework folder model",
-  "Audit folder query paths",
-  "Migrate folder fixtures",
-  "Reduce style recalculation",
-  "Bisect plugin stylesheets",
-  "Wire up automations CLI",
-  "Debug host daemon reconnect",
-  "Ship theme preview panel",
-  "Trim sidebar re-renders",
-  "Draft release notes",
-  "Fix mobile keyboard inset",
+const projectNamesById = new Map<string, string>([
+  [PROJECT_IDS.bb, PROJECT_NAMES.bb],
+  [PROJECT_IDS.pierre, PROJECT_NAMES.pierre],
+]);
+
+const HOME_THREADS: ThreadListEntry[] = [
+  makeThreadListEntry({
+    id: "thr_home_parent",
+    title: "Rework folder model",
+    titleFallback: "Rework folder model",
+    latestAttentionAt: 900,
+  }),
+  makeThreadListEntry({
+    id: "thr_home_child_a",
+    parentThreadId: "thr_home_parent",
+    providerId: "claude-code",
+    title: "Audit folder query paths",
+    titleFallback: "Audit folder query paths",
+    latestAttentionAt: 880,
+  }),
+  makeThreadListEntry({
+    id: "thr_home_child_b",
+    parentThreadId: "thr_home_parent",
+    providerId: "acp-cursor",
+    title: "Migrate folder fixtures",
+    titleFallback: "Migrate folder fixtures",
+    latestAttentionAt: 870,
+  }),
+  makeThreadListEntry({
+    id: "thr_home_style",
+    providerId: "claude-code",
+    title: "Reduce style recalculation",
+    titleFallback: "Reduce style recalculation",
+    status: "starting",
+    latestAttentionAt: 860,
+    runtime: { displayStatus: "starting", hostReconnectGraceExpiresAt: null },
+  }),
+  makeThreadListEntry({
+    id: "thr_home_automations",
+    title: "Wire up automations CLI",
+    titleFallback: "Wire up automations CLI",
+    latestAttentionAt: 850,
+  }),
+  makeThreadListEntry({
+    id: "thr_home_daemon",
+    projectId: PROJECT_IDS.pierre,
+    providerId: "acp-cursor",
+    title: "Debug host daemon reconnect",
+    titleFallback: "Debug host daemon reconnect",
+    latestAttentionAt: 840,
+  }),
+  makeThreadListEntry({
+    id: "thr_home_theme",
+    title: "Ship theme preview panel",
+    titleFallback: "Ship theme preview panel",
+    latestAttentionAt: 830,
+  }),
+  makeThreadListEntry({
+    id: "thr_home_sidebar",
+    providerId: "claude-code",
+    title: "Trim sidebar re-renders",
+    titleFallback: "Trim sidebar re-renders",
+    latestAttentionAt: 820,
+  }),
+  makeThreadListEntry({
+    id: "thr_home_release",
+    title: "Draft release notes",
+    titleFallback: "Draft release notes",
+    latestAttentionAt: 810,
+  }),
+  makeThreadListEntry({
+    id: "thr_home_keyboard",
+    projectId: PROJECT_IDS.pierre,
+    title: "Fix mobile keyboard inset",
+    titleFallback: "Fix mobile keyboard inset",
+    latestAttentionAt: 800,
+  }),
 ];
 
 function StoryComposer() {
@@ -35,60 +107,53 @@ function StoryComposer() {
   );
 }
 
-function StoryRecents({ count }: { count: number }) {
+function PhoneFrame({ children }: { children: ReactNode }) {
   return (
-    <div>
-      <div className="sticky top-0 z-10 mb-1 bg-background px-2">
-        <span className="text-xs text-muted-foreground">Recent</span>
-        <OverflowFade placement="below" tone="background" size="sm" />
-      </div>
-      {RECENT_TITLES.slice(0, count).map((title, index) => (
-        <div
-          key={title}
-          className="flex items-center gap-2 px-2"
-          style={{ height: MOBILE_RECENT_ROW_HEIGHT_PX }}
-        >
-          <span className="mt-1 flex size-7 shrink-0 items-center justify-center self-start rounded-md border border-border-seam bg-surface-raised" />
-          <span className="flex min-w-0 flex-col">
-            <span className="truncate text-sm">{title}</span>
-            <span className="truncate text-xs text-muted-foreground">
-              bb · {index + 1}h ago
-            </span>
-          </span>
-        </div>
-      ))}
-    </div>
-  );
-}
-
-function PhoneFrame({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="flex h-[852px] w-[393px] min-h-0 flex-col overflow-hidden rounded-xl border border-border bg-background">
+    <div className="root-compose-compact-home-story flex h-[852px] w-[393px] min-h-0 flex-col overflow-hidden rounded-xl border border-border bg-background">
+      <style>{`
+        @media (min-width: 768px) {
+          .root-compose-compact-home-story [data-root-compose-mobile-recents] {
+            display: block;
+          }
+        }
+      `}</style>
       {children}
     </div>
   );
 }
 
+function HomeRecents({ threads }: { threads: ThreadListEntry[] }) {
+  return (
+    <RootComposeMobileRecents
+      highlightedThreadId={null}
+      projectNamesById={projectNamesById}
+      providersById={STORY_PROVIDERS_BY_ID}
+      showCreatingRow={false}
+      threads={threads}
+    />
+  );
+}
+
 export function Overview() {
   return (
-    <StoryCard>
+    <StoryCard labelWidth="170px">
       <StoryRow
         label="composer pinned, recents scroll behind it"
-        hint="393×852. The composer is an overlay at the bottom; the list runs underneath it and dissolves into a strong fade rather than stopping at a hard edge."
+        hint="393×852 with the real recents list. The composer is an overlay at the bottom; rows run underneath it and dissolve into a strong fade rather than stopping at a hard edge."
       >
         <PhoneFrame>
           <RootComposeCompactHome composer={<StoryComposer />}>
-            <StoryRecents count={RECENT_TITLES.length} />
+            <HomeRecents threads={HOME_THREADS} />
           </RootComposeCompactHome>
         </PhoneFrame>
       </StoryRow>
       <StoryRow
         label="short list"
-        hint="with only a few threads the list still rests above the composer instead of stretching"
+        hint="with only a few threads the list still rests above the composer instead of stretching to fill"
       >
         <PhoneFrame>
           <RootComposeCompactHome composer={<StoryComposer />}>
-            <StoryRecents count={3} />
+            <HomeRecents threads={HOME_THREADS.slice(0, 3)} />
           </RootComposeCompactHome>
         </PhoneFrame>
       </StoryRow>

--- a/apps/app/src/views/RootComposeCompactHome.stories.tsx
+++ b/apps/app/src/views/RootComposeCompactHome.stories.tsx
@@ -1,138 +1,13 @@
-import type { ReactNode } from "react";
-import type { ThreadListEntry } from "@bb/domain";
 import { StoryCard, StoryRow } from "../../.ladle/story-card";
 import {
-  PROJECT_IDS,
-  PROJECT_NAMES,
-  STORY_PROVIDERS_BY_ID,
-  makeThreadListEntry,
-} from "../../.ladle/story-fixtures";
-import { RootComposeCompactHome } from "./RootComposeCompactHome";
-import { RootComposeMobileRecents } from "./RootComposeMobileRecents";
+  CompactHomePage,
+  HOME_THREADS,
+  PhoneFrame,
+} from "./mobile-home-story-fixtures";
 
 export default {
   title: "views/Compact Home",
 };
-
-const projectNamesById = new Map<string, string>([
-  [PROJECT_IDS.bb, PROJECT_NAMES.bb],
-  [PROJECT_IDS.pierre, PROJECT_NAMES.pierre],
-]);
-
-const HOME_THREADS: ThreadListEntry[] = [
-  makeThreadListEntry({
-    id: "thr_home_parent",
-    title: "Rework folder model",
-    titleFallback: "Rework folder model",
-    latestAttentionAt: 900,
-  }),
-  makeThreadListEntry({
-    id: "thr_home_child_a",
-    parentThreadId: "thr_home_parent",
-    providerId: "claude-code",
-    title: "Audit folder query paths",
-    titleFallback: "Audit folder query paths",
-    latestAttentionAt: 880,
-  }),
-  makeThreadListEntry({
-    id: "thr_home_child_b",
-    parentThreadId: "thr_home_parent",
-    providerId: "acp-cursor",
-    title: "Migrate folder fixtures",
-    titleFallback: "Migrate folder fixtures",
-    latestAttentionAt: 870,
-  }),
-  makeThreadListEntry({
-    id: "thr_home_style",
-    providerId: "claude-code",
-    title: "Reduce style recalculation",
-    titleFallback: "Reduce style recalculation",
-    status: "starting",
-    latestAttentionAt: 860,
-    runtime: { displayStatus: "starting", hostReconnectGraceExpiresAt: null },
-  }),
-  makeThreadListEntry({
-    id: "thr_home_automations",
-    title: "Wire up automations CLI",
-    titleFallback: "Wire up automations CLI",
-    latestAttentionAt: 850,
-  }),
-  makeThreadListEntry({
-    id: "thr_home_daemon",
-    projectId: PROJECT_IDS.pierre,
-    providerId: "acp-cursor",
-    title: "Debug host daemon reconnect",
-    titleFallback: "Debug host daemon reconnect",
-    latestAttentionAt: 840,
-  }),
-  makeThreadListEntry({
-    id: "thr_home_theme",
-    title: "Ship theme preview panel",
-    titleFallback: "Ship theme preview panel",
-    latestAttentionAt: 830,
-  }),
-  makeThreadListEntry({
-    id: "thr_home_sidebar",
-    providerId: "claude-code",
-    title: "Trim sidebar re-renders",
-    titleFallback: "Trim sidebar re-renders",
-    latestAttentionAt: 820,
-  }),
-  makeThreadListEntry({
-    id: "thr_home_release",
-    title: "Draft release notes",
-    titleFallback: "Draft release notes",
-    latestAttentionAt: 810,
-  }),
-  makeThreadListEntry({
-    id: "thr_home_keyboard",
-    projectId: PROJECT_IDS.pierre,
-    title: "Fix mobile keyboard inset",
-    titleFallback: "Fix mobile keyboard inset",
-    latestAttentionAt: 800,
-  }),
-];
-
-function StoryComposer() {
-  return (
-    <div className="rounded-xl border border-border bg-background shadow-lift">
-      <div className="px-3 pt-3 pb-8 text-sm text-muted-foreground">
-        Ask anything.
-      </div>
-      <div className="flex items-center justify-between px-3 pb-3">
-        <span className="size-6 rounded-md border border-border-seam" />
-        <span className="size-6 rounded-md bg-foreground/80" />
-      </div>
-    </div>
-  );
-}
-
-function PhoneFrame({ children }: { children: ReactNode }) {
-  return (
-    <div className="root-compose-compact-home-story flex h-[852px] w-[393px] min-h-0 flex-col overflow-hidden rounded-xl border border-border bg-background">
-      <style>{`
-        @media (min-width: 768px) {
-          .root-compose-compact-home-story [data-root-compose-mobile-recents] {
-            display: block;
-          }
-        }
-      `}</style>
-      {children}
-    </div>
-  );
-}
-
-function HomeRecents({ threads }: { threads: ThreadListEntry[] }) {
-  return (
-    <RootComposeMobileRecents
-      highlightedThreadId={null}
-      projectNamesById={projectNamesById}
-      providersById={STORY_PROVIDERS_BY_ID}
-      showCreatingRow={false}
-      threads={threads}
-    />
-  );
-}
 
 export function Overview() {
   return (
@@ -142,9 +17,7 @@ export function Overview() {
         hint="393×852 with the real recents list. The composer is an overlay at the bottom; rows run underneath it and dissolve into a strong fade rather than stopping at a hard edge."
       >
         <PhoneFrame>
-          <RootComposeCompactHome composer={<StoryComposer />}>
-            <HomeRecents threads={HOME_THREADS} />
-          </RootComposeCompactHome>
+          <CompactHomePage />
         </PhoneFrame>
       </StoryRow>
       <StoryRow
@@ -152,9 +25,7 @@ export function Overview() {
         hint="with only a few threads the list still rests above the composer instead of stretching to fill"
       >
         <PhoneFrame>
-          <RootComposeCompactHome composer={<StoryComposer />}>
-            <HomeRecents threads={HOME_THREADS.slice(0, 3)} />
-          </RootComposeCompactHome>
+          <CompactHomePage threads={HOME_THREADS.slice(0, 3)} />
         </PhoneFrame>
       </StoryRow>
     </StoryCard>

--- a/apps/app/src/views/RootComposeCompactHome.stories.tsx
+++ b/apps/app/src/views/RootComposeCompactHome.stories.tsx
@@ -1,0 +1,97 @@
+import { StoryCard, StoryRow } from "../../.ladle/story-card";
+import { OverflowFade } from "@/components/ui/overflow-fade";
+import { RootComposeCompactHome } from "./RootComposeCompactHome";
+import { MOBILE_RECENT_ROW_HEIGHT_PX } from "./RootComposeMobileRecents";
+
+export default {
+  title: "views/Compact Home",
+};
+
+const RECENT_TITLES = [
+  "Rework folder model",
+  "Audit folder query paths",
+  "Migrate folder fixtures",
+  "Reduce style recalculation",
+  "Bisect plugin stylesheets",
+  "Wire up automations CLI",
+  "Debug host daemon reconnect",
+  "Ship theme preview panel",
+  "Trim sidebar re-renders",
+  "Draft release notes",
+  "Fix mobile keyboard inset",
+];
+
+function StoryComposer() {
+  return (
+    <div className="rounded-xl border border-border bg-background shadow-lift">
+      <div className="px-3 pt-3 pb-8 text-sm text-muted-foreground">
+        Ask anything.
+      </div>
+      <div className="flex items-center justify-between px-3 pb-3">
+        <span className="size-6 rounded-md border border-border-seam" />
+        <span className="size-6 rounded-md bg-foreground/80" />
+      </div>
+    </div>
+  );
+}
+
+function StoryRecents({ count }: { count: number }) {
+  return (
+    <div>
+      <div className="sticky top-0 z-10 mb-1 bg-background px-2">
+        <span className="text-xs text-muted-foreground">Recent</span>
+        <OverflowFade placement="below" tone="background" size="sm" />
+      </div>
+      {RECENT_TITLES.slice(0, count).map((title, index) => (
+        <div
+          key={title}
+          className="flex items-center gap-2 px-2"
+          style={{ height: MOBILE_RECENT_ROW_HEIGHT_PX }}
+        >
+          <span className="mt-1 flex size-7 shrink-0 items-center justify-center self-start rounded-md border border-border-seam bg-surface-raised" />
+          <span className="flex min-w-0 flex-col">
+            <span className="truncate text-sm">{title}</span>
+            <span className="truncate text-xs text-muted-foreground">
+              bb · {index + 1}h ago
+            </span>
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function PhoneFrame({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="h-[852px] w-[393px] overflow-hidden rounded-xl border border-border bg-background">
+      {children}
+    </div>
+  );
+}
+
+export function Overview() {
+  return (
+    <StoryCard>
+      <StoryRow
+        label="composer pinned, recents scroll behind it"
+        hint="393×852. The composer is an overlay at the bottom; the list runs underneath it and dissolves into a strong fade rather than stopping at a hard edge."
+      >
+        <PhoneFrame>
+          <RootComposeCompactHome composer={<StoryComposer />}>
+            <StoryRecents count={RECENT_TITLES.length} />
+          </RootComposeCompactHome>
+        </PhoneFrame>
+      </StoryRow>
+      <StoryRow
+        label="short list"
+        hint="with only a few threads the list still rests above the composer instead of stretching"
+      >
+        <PhoneFrame>
+          <RootComposeCompactHome composer={<StoryComposer />}>
+            <StoryRecents count={3} />
+          </RootComposeCompactHome>
+        </PhoneFrame>
+      </StoryRow>
+    </StoryCard>
+  );
+}

--- a/apps/app/src/views/RootComposeCompactHome.stories.tsx
+++ b/apps/app/src/views/RootComposeCompactHome.stories.tsx
@@ -63,7 +63,7 @@ function StoryRecents({ count }: { count: number }) {
 
 function PhoneFrame({ children }: { children: React.ReactNode }) {
   return (
-    <div className="h-[852px] w-[393px] overflow-hidden rounded-xl border border-border bg-background">
+    <div className="flex h-[852px] w-[393px] min-h-0 flex-col overflow-hidden rounded-xl border border-border bg-background">
       {children}
     </div>
   );

--- a/apps/app/src/views/RootComposeCompactHome.test.tsx
+++ b/apps/app/src/views/RootComposeCompactHome.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  getCompactHomeScrollViewportTop,
+  RootComposeCompactHome,
+} from "./RootComposeCompactHome";
+import {
+  MOBILE_RECENT_LABEL_HEIGHT_PX,
+  MOBILE_RECENT_ROW_HEIGHT_PX,
+} from "./RootComposeMobileRecents";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function renderCompactHome() {
+  return render(
+    <RootComposeCompactHome composer={<div data-testid="composer" />}>
+      <div data-testid="recents" />
+    </RootComposeCompactHome>,
+  );
+}
+
+describe("RootComposeCompactHome", () => {
+  it("keeps the composer above a scroll viewport that runs behind it", () => {
+    renderCompactHome();
+
+    const viewport = screen.getByTestId("root-compose-compact-scroll-viewport");
+    const composer = screen.getByTestId("root-compose-compact-composer");
+
+    expect(viewport.className).toContain("bottom-0");
+    expect(viewport.className).toContain("overflow-y-auto");
+    expect(composer.className).toContain("absolute");
+    expect(composer.className).toContain("bottom-0");
+    expect(composer.className).toContain("z-10");
+    expect(composer.contains(screen.getByTestId("composer"))).toBe(true);
+    expect(viewport.contains(screen.getByTestId("recents"))).toBe(true);
+  });
+
+  it("pins the scroll viewport so 5.5 rows show once the label sticks", () => {
+    const scrolledBandPx =
+      5.5 * MOBILE_RECENT_ROW_HEIGHT_PX + MOBILE_RECENT_LABEL_HEIGHT_PX;
+
+    expect(
+      getCompactHomeScrollViewportTop({
+        regionHeight: 852,
+        composerHeight: 188,
+      }),
+    ).toBe(852 - 188 - scrolledBandPx);
+  });
+
+  it("never lifts the scroll viewport above the app chrome row", () => {
+    expect(
+      getCompactHomeScrollViewportTop({
+        regionHeight: 420,
+        composerHeight: 188,
+      }),
+    ).toBe(56);
+  });
+
+  it("offsets the resting list by one row so 4.5 show before scrolling", () => {
+    renderCompactHome();
+
+    const offset = screen.getByTestId("root-compose-compact-recents-offset");
+    expect(offset.style.height).toBe(`${MOBILE_RECENT_ROW_HEIGHT_PX}px`);
+  });
+
+  it("pads the list tail so the last row can clear the composer", () => {
+    renderCompactHome();
+
+    const viewport = screen.getByTestId("root-compose-compact-scroll-viewport");
+    const bottomSpacer = viewport.lastElementChild;
+    if (!(bottomSpacer instanceof HTMLElement)) {
+      throw new Error("Expected a trailing composer spacer");
+    }
+    expect(bottomSpacer.style.height).toBe("0px");
+  });
+
+  it("renders a strong fade so rows dissolve into the composer", () => {
+    renderCompactHome();
+
+    const composer = screen.getByTestId("root-compose-compact-composer");
+    const fade = composer.querySelector('[data-overflow-fade="above"]');
+    if (!(fade instanceof HTMLElement)) {
+      throw new Error("Expected an above fade over the composer");
+    }
+    expect(fade.className).toContain("h-24");
+    expect(fade.className).toContain("-top-24");
+  });
+});

--- a/apps/app/src/views/RootComposeCompactHome.tsx
+++ b/apps/app/src/views/RootComposeCompactHome.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { OverflowFade } from "@/components/ui/overflow-fade";
+import {
+  MOBILE_RECENT_LABEL_HEIGHT_PX,
+  MOBILE_RECENT_ROW_HEIGHT_PX,
+} from "./RootComposeMobileRecents";
+
+const COMPACT_HOME_CHROME_OFFSET_PX = 56;
+const COMPACT_HOME_COLUMN_CLASS = "mx-auto w-full max-w-[760px] px-4";
+const COMPACT_HOME_REST_VISIBLE_ROWS = 4.5;
+const COMPACT_HOME_SCROLLED_VISIBLE_ROWS = 5.5;
+const COMPACT_HOME_SCROLLED_BAND_PX =
+  COMPACT_HOME_SCROLLED_VISIBLE_ROWS * MOBILE_RECENT_ROW_HEIGHT_PX +
+  MOBILE_RECENT_LABEL_HEIGHT_PX;
+const COMPACT_HOME_REST_OFFSET_PX =
+  (COMPACT_HOME_SCROLLED_VISIBLE_ROWS - COMPACT_HOME_REST_VISIBLE_ROWS) *
+  MOBILE_RECENT_ROW_HEIGHT_PX;
+
+export function getCompactHomeScrollViewportTop({
+  regionHeight,
+  composerHeight,
+}: {
+  regionHeight: number;
+  composerHeight: number;
+}): number {
+  return Math.max(
+    COMPACT_HOME_CHROME_OFFSET_PX,
+    regionHeight - composerHeight - COMPACT_HOME_SCROLLED_BAND_PX,
+  );
+}
+
+interface RootComposeCompactHomeProps {
+  children: ReactNode;
+  composer: ReactNode;
+}
+
+function useCompactHomeMetrics() {
+  const regionRef = useRef<HTMLDivElement>(null);
+  const composerRef = useRef<HTMLDivElement>(null);
+  const [metrics, setMetrics] = useState({
+    regionHeight: 0,
+    composerHeight: 0,
+  });
+
+  useEffect(() => {
+    const region = regionRef.current;
+    const composer = composerRef.current;
+    if (!region || !composer) return;
+    const measure = () => {
+      setMetrics((previous) =>
+        previous.regionHeight === region.offsetHeight &&
+        previous.composerHeight === composer.offsetHeight
+          ? previous
+          : {
+              regionHeight: region.offsetHeight,
+              composerHeight: composer.offsetHeight,
+            },
+      );
+    };
+    measure();
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(measure);
+    observer.observe(region);
+    observer.observe(composer);
+    return () => observer.disconnect();
+  }, []);
+
+  return { regionRef, composerRef, ...metrics };
+}
+
+export function RootComposeCompactHome({
+  children,
+  composer,
+}: RootComposeCompactHomeProps) {
+  const { regionRef, composerRef, regionHeight, composerHeight } =
+    useCompactHomeMetrics();
+
+  return (
+    <div
+      ref={regionRef}
+      data-testid="root-compose-compact-home"
+      className="relative min-h-0 flex-1"
+    >
+      <div
+        data-testid="root-compose-compact-scroll-viewport"
+        className="absolute inset-x-0 bottom-0 overflow-y-auto overscroll-contain"
+        style={{
+          top: getCompactHomeScrollViewportTop({
+            regionHeight,
+            composerHeight,
+          }),
+        }}
+      >
+        <div
+          aria-hidden
+          data-testid="root-compose-compact-recents-offset"
+          style={{ height: COMPACT_HOME_REST_OFFSET_PX }}
+        />
+        <div className={COMPACT_HOME_COLUMN_CLASS}>{children}</div>
+        <div aria-hidden style={{ height: composerHeight }} />
+      </div>
+      <div
+        ref={composerRef}
+        data-testid="root-compose-compact-composer"
+        className="absolute inset-x-0 bottom-0 z-10"
+      >
+        <OverflowFade placement="above" tone="background" size="lg" />
+        <div className="bg-background pb-4">
+          <div className={COMPACT_HOME_COLUMN_CLASS}>{composer}</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/views/RootComposeMobileRecents.stories.tsx
+++ b/apps/app/src/views/RootComposeMobileRecents.stories.tsx
@@ -1,9 +1,10 @@
 import type { ReactNode } from "react";
-import type { ProviderInfo, ThreadListEntry } from "@bb/domain";
+import type { ThreadListEntry } from "@bb/domain";
 import { StoryCard, StoryRow } from "../../.ladle/story-card";
 import {
   PROJECT_IDS,
   PROJECT_NAMES,
+  STORY_PROVIDERS_BY_ID,
   makeThreadListEntry,
 } from "../../.ladle/story-fixtures";
 import { RootComposeMobileRecents } from "./RootComposeMobileRecents";
@@ -48,6 +49,7 @@ const recentThreads: ThreadListEntry[] = [
   makeRecentThread({
     overrides: {
       id: "thr_mobile_just_starting",
+      providerId: "claude-code",
       title: "Trace mobile thread creation feedback",
       titleFallback: "Trace mobile thread creation feedback",
       status: "starting",
@@ -186,6 +188,7 @@ const hierarchyThreads: ThreadListEntry[] = [
   makeRecentThread({
     overrides: {
       id: "thr_mobile_child_a",
+      providerId: "claude-code",
       parentThreadId: "thr_mobile_parent",
       title: "Audit folder query paths",
       titleFallback: "Audit folder query paths",
@@ -208,6 +211,7 @@ const hierarchyThreads: ThreadListEntry[] = [
   makeRecentThread({
     overrides: {
       id: "thr_mobile_grandchild",
+      providerId: "acp-cursor",
       parentThreadId: "thr_mobile_child_a",
       title: "Backfill folder migration tests",
       titleFallback: "Backfill folder migration tests",
@@ -232,7 +236,7 @@ const projectNamesById = new Map<string, string>([
   [PROJECT_IDS.pierre, PROJECT_NAMES.pierre],
 ]);
 
-const providersById = new Map<string, ProviderInfo>();
+const providersById = STORY_PROVIDERS_BY_ID;
 
 export function Overview() {
   return (

--- a/apps/app/src/views/RootComposeMobileRecents.stories.tsx
+++ b/apps/app/src/views/RootComposeMobileRecents.stories.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import type { ThreadListEntry } from "@bb/domain";
+import type { ProviderInfo, ThreadListEntry } from "@bb/domain";
 import { StoryCard, StoryRow } from "../../.ladle/story-card";
 import {
   PROJECT_IDS,
@@ -132,10 +132,51 @@ const statusThreads: ThreadListEntry[] = [
   }),
 ];
 
+const metadataThreads: ThreadListEntry[] = [
+  makeRecentThread({
+    overrides: {
+      id: "thr_mobile_worktree",
+      title: "Anchor the mobile prompt box",
+      titleFallback: "Anchor the mobile prompt box",
+      environmentName: "mobile-home",
+      environmentBranchName: "bb/mobile-home",
+      environmentWorkspaceDisplayKind: "managed-worktree",
+      createdAt: 700,
+      latestAttentionAt: 700,
+    },
+  }),
+  makeRecentThread({
+    overrides: {
+      id: "thr_mobile_unread",
+      projectId: PROJECT_IDS.pierre,
+      title: "Finished while you were away",
+      titleFallback: "Finished while you were away",
+      status: "idle",
+      lastReadAt: 100,
+      createdAt: 650,
+      latestAttentionAt: 650,
+    },
+  }),
+  makeRecentThread({
+    overrides: {
+      id: "thr_mobile_long_title",
+      title:
+        "A deliberately long thread title that has to truncate on a narrow mobile row",
+      titleFallback: "A deliberately long thread title",
+      environmentBranchName: "bb/very-long-branch-name-for-truncation",
+      environmentWorkspaceDisplayKind: "unmanaged-worktree",
+      createdAt: 600,
+      latestAttentionAt: 600,
+    },
+  }),
+];
+
 const projectNamesById = new Map<string, string>([
   [PROJECT_IDS.bb, PROJECT_NAMES.bb],
   [PROJECT_IDS.pierre, PROJECT_NAMES.pierre],
 ]);
+
+const providersById = new Map<string, ProviderInfo>();
 
 export function Overview() {
   return (
@@ -145,6 +186,7 @@ export function Overview() {
           <RootComposeMobileRecents
             highlightedThreadId="thr_mobile_just_starting"
             projectNamesById={projectNamesById}
+            providersById={providersById}
             showCreatingRow={false}
             threads={recentThreads}
           />
@@ -155,8 +197,20 @@ export function Overview() {
           <RootComposeMobileRecents
             highlightedThreadId={null}
             projectNamesById={projectNamesById}
+            providersById={providersById}
             showCreatingRow
             threads={recentThreads.slice(1)}
+          />
+        </MobileStage>
+      </StoryRow>
+      <StoryRow label="row metadata">
+        <MobileStage>
+          <RootComposeMobileRecents
+            highlightedThreadId={null}
+            projectNamesById={projectNamesById}
+            providersById={providersById}
+            showCreatingRow={false}
+            threads={metadataThreads}
           />
         </MobileStage>
       </StoryRow>
@@ -165,6 +219,7 @@ export function Overview() {
           <RootComposeMobileRecents
             highlightedThreadId={null}
             projectNamesById={projectNamesById}
+            providersById={providersById}
             showCreatingRow={false}
             threads={statusThreads}
           />

--- a/apps/app/src/views/RootComposeMobileRecents.stories.tsx
+++ b/apps/app/src/views/RootComposeMobileRecents.stories.tsx
@@ -171,6 +171,62 @@ const metadataThreads: ThreadListEntry[] = [
   }),
 ];
 
+const hierarchyThreads: ThreadListEntry[] = [
+  makeRecentThread({
+    overrides: {
+      id: "thr_mobile_parent",
+      title: "Rework folder model",
+      titleFallback: "Rework folder model",
+      status: "active",
+      createdAt: 900,
+      latestAttentionAt: 900,
+      runtime: { displayStatus: "active", hostReconnectGraceExpiresAt: null },
+    },
+  }),
+  makeRecentThread({
+    overrides: {
+      id: "thr_mobile_child_a",
+      parentThreadId: "thr_mobile_parent",
+      title: "Audit folder query paths",
+      titleFallback: "Audit folder query paths",
+      status: "active",
+      createdAt: 880,
+      latestAttentionAt: 880,
+      runtime: { displayStatus: "active", hostReconnectGraceExpiresAt: null },
+    },
+  }),
+  makeRecentThread({
+    overrides: {
+      id: "thr_mobile_child_b",
+      parentThreadId: "thr_mobile_parent",
+      title: "Migrate folder fixtures",
+      titleFallback: "Migrate folder fixtures",
+      createdAt: 860,
+      latestAttentionAt: 860,
+    },
+  }),
+  makeRecentThread({
+    overrides: {
+      id: "thr_mobile_grandchild",
+      parentThreadId: "thr_mobile_child_a",
+      title: "Backfill folder migration tests",
+      titleFallback: "Backfill folder migration tests",
+      createdAt: 850,
+      latestAttentionAt: 850,
+    },
+  }),
+  makeRecentThread({
+    overrides: {
+      id: "thr_mobile_sibling",
+      projectId: PROJECT_IDS.pierre,
+      title: "Unrelated top-level thread",
+      titleFallback: "Unrelated top-level thread",
+      createdAt: 840,
+      latestAttentionAt: 840,
+    },
+  }),
+];
+
 const projectNamesById = new Map<string, string>([
   [PROJECT_IDS.bb, PROJECT_NAMES.bb],
   [PROJECT_IDS.pierre, PROJECT_NAMES.pierre],
@@ -200,6 +256,17 @@ export function Overview() {
             providersById={providersById}
             showCreatingRow
             threads={recentThreads.slice(1)}
+          />
+        </MobileStage>
+      </StoryRow>
+      <StoryRow label="parent / child">
+        <MobileStage>
+          <RootComposeMobileRecents
+            highlightedThreadId={null}
+            projectNamesById={projectNamesById}
+            providersById={providersById}
+            showCreatingRow={false}
+            threads={hierarchyThreads}
           />
         </MobileStage>
       </StoryRow>

--- a/apps/app/src/views/RootComposeMobileRecents.test.tsx
+++ b/apps/app/src/views/RootComposeMobileRecents.test.tsx
@@ -4,7 +4,10 @@ import type { ThreadListEntry } from "@bb/domain";
 import { cleanup, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it } from "vitest";
-import { RootComposeMobileRecents } from "./RootComposeMobileRecents";
+import {
+  getMobileRecentThreads,
+  RootComposeMobileRecents,
+} from "./RootComposeMobileRecents";
 
 function makeThread(overrides: Partial<ThreadListEntry> = {}): ThreadListEntry {
   return {
@@ -54,6 +57,183 @@ afterEach(() => {
   window.localStorage.clear();
 });
 
+describe("getMobileRecentThreads", () => {
+  it("returns every active thread newest-first instead of a capped window", () => {
+    const threads = Array.from({ length: 12 }, (_unused, index) =>
+      makeThread({
+        id: `thr_${index}`,
+        latestAttentionAt: index,
+        createdAt: index,
+      }),
+    );
+
+    const ordered = getMobileRecentThreads({
+      highlightedThreadId: null,
+      threads,
+    });
+
+    expect(ordered).toHaveLength(12);
+    expect(ordered.map((thread) => thread.id)).toEqual([
+      "thr_11",
+      "thr_10",
+      "thr_9",
+      "thr_8",
+      "thr_7",
+      "thr_6",
+      "thr_5",
+      "thr_4",
+      "thr_3",
+      "thr_2",
+      "thr_1",
+      "thr_0",
+    ]);
+  });
+
+  it("pins the highlighted thread first without dropping the rest", () => {
+    const threads = Array.from({ length: 5 }, (_unused, index) =>
+      makeThread({
+        id: `thr_${index}`,
+        latestAttentionAt: index,
+        createdAt: index,
+      }),
+    );
+
+    const ordered = getMobileRecentThreads({
+      highlightedThreadId: "thr_0",
+      threads,
+    });
+
+    expect(ordered.map((thread) => thread.id)).toEqual([
+      "thr_0",
+      "thr_4",
+      "thr_3",
+      "thr_2",
+      "thr_1",
+    ]);
+  });
+});
+
+describe("mobile recents section", () => {
+  it("keeps the Recent label pinned while the list scrolls under it", () => {
+    render(
+      <MemoryRouter>
+        <RootComposeMobileRecents
+          highlightedThreadId={null}
+          projectNamesById={new Map()}
+          providersById={new Map()}
+          showCreatingRow={false}
+          threads={[makeThread()]}
+        />
+      </MemoryRouter>,
+    );
+
+    const label = screen.getByText("Recent").parentElement;
+    if (!(label instanceof HTMLElement)) {
+      throw new Error("Expected a Recent label wrapper");
+    }
+    expect(label.className).toContain("sticky");
+    expect(label.className).toContain("top-0");
+    expect(label.className).toContain("bg-background");
+    expect(label.querySelector('[data-overflow-fade="below"]')).not.toBeNull();
+  });
+});
+
+describe("mobile recent thread rows", () => {
+  it("shows project and relative activity on a metadata line", () => {
+    render(
+      <MemoryRouter>
+        <RootComposeMobileRecents
+          highlightedThreadId={null}
+          projectNamesById={new Map([["proj_mobile", "bb"]])}
+          providersById={new Map()}
+          showCreatingRow={false}
+          threads={[
+            makeThread({
+              latestAttentionAt: Date.now() - 3 * 60 * 60 * 1000,
+              activity: {
+                activeWorkflowCount: 0,
+                activeBackgroundAgentCount: 0,
+                activeBackgroundCommandCount: 0,
+                activePlanModeCount: 0,
+                activeGoalCount: 0,
+              },
+            }),
+          ]}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("bb \u00b7 3h ago")).not.toBeNull();
+  });
+
+  it("includes the worktree branch when the thread has one", () => {
+    render(
+      <MemoryRouter>
+        <RootComposeMobileRecents
+          highlightedThreadId={null}
+          projectNamesById={new Map([["proj_mobile", "bb"]])}
+          providersById={new Map()}
+          showCreatingRow={false}
+          threads={[
+            makeThread({
+              environmentBranchName: "bb/mobile-home",
+              latestAttentionAt: Date.now() - 3 * 60 * 60 * 1000,
+              activity: {
+                activeWorkflowCount: 0,
+                activeBackgroundAgentCount: 0,
+                activeBackgroundCommandCount: 0,
+                activePlanModeCount: 0,
+                activeGoalCount: 0,
+              },
+            }),
+          ]}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByText("bb \u00b7 bb/mobile-home \u00b7 3h ago"),
+    ).not.toBeNull();
+  });
+
+  it("drops the status slot entirely when a thread has no indicator", () => {
+    render(
+      <MemoryRouter>
+        <RootComposeMobileRecents
+          highlightedThreadId={null}
+          projectNamesById={new Map()}
+          providersById={new Map()}
+          showCreatingRow={false}
+          threads={[
+            makeThread({
+              status: "idle",
+              lastReadAt: 10,
+              latestAttentionAt: 5,
+              runtime: {
+                displayStatus: "idle",
+                hostReconnectGraceExpiresAt: null,
+              },
+              activity: {
+                activeWorkflowCount: 0,
+                activeBackgroundAgentCount: 0,
+                activeBackgroundCommandCount: 0,
+                activePlanModeCount: 0,
+                activeGoalCount: 0,
+              },
+            }),
+          ]}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByLabelText("Plan mode active")).toBeNull();
+    expect(screen.queryByLabelText("Thread working")).toBeNull();
+    expect(
+      screen.getByRole("link").querySelectorAll("span.size-6"),
+    ).toHaveLength(0);
+  });
+});
+
 describe("RootComposeMobileRecents", () => {
   it("shows concurrent Plan activity before the runtime spinner", () => {
     render(
@@ -61,6 +241,7 @@ describe("RootComposeMobileRecents", () => {
         <RootComposeMobileRecents
           highlightedThreadId={null}
           projectNamesById={new Map()}
+          providersById={new Map()}
           showCreatingRow={false}
           threads={[makeThread()]}
         />
@@ -78,6 +259,7 @@ describe("RootComposeMobileRecents", () => {
         <RootComposeMobileRecents
           highlightedThreadId={null}
           projectNamesById={new Map()}
+          providersById={new Map()}
           showCreatingRow={false}
           threads={[
             makeThread({
@@ -109,6 +291,7 @@ describe("RootComposeMobileRecents", () => {
         <RootComposeMobileRecents
           highlightedThreadId={null}
           projectNamesById={new Map()}
+          providersById={new Map()}
           showCreatingRow={false}
           threads={[makeThread()]}
         />
@@ -133,6 +316,7 @@ describe("RootComposeMobileRecents", () => {
         <RootComposeMobileRecents
           highlightedThreadId={null}
           projectNamesById={new Map()}
+          providersById={new Map()}
           showCreatingRow={false}
           threads={[
             makeThread({

--- a/apps/app/src/views/RootComposeMobileRecents.test.tsx
+++ b/apps/app/src/views/RootComposeMobileRecents.test.tsx
@@ -335,7 +335,6 @@ describe("mobile recents hierarchy interaction", () => {
     expect(childTile.className).toContain("border-transparent");
     expect(childTile.className).not.toContain("bg-surface-raised");
 
-    // Footprint, alignment and hit target must be identical on both.
     for (const tile of [parentTile, childTile]) {
       expect(tile.className).toContain("size-7");
       expect(tile.className).toContain("self-start");

--- a/apps/app/src/views/RootComposeMobileRecents.test.tsx
+++ b/apps/app/src/views/RootComposeMobileRecents.test.tsx
@@ -233,6 +233,18 @@ describe("mobile recents hierarchy interaction", () => {
     expect(screen.getByText("Audit folder query paths")).not.toBeNull();
   });
 
+  it("anchors the provider tile to the title line, not the text block", () => {
+    renderTree();
+
+    const [parentRow] = screen.getAllByRole("link");
+    const tile = parentRow?.firstElementChild;
+    if (!(tile instanceof HTMLElement)) {
+      throw new Error("Expected a leading provider tile");
+    }
+    expect(tile.className).toContain("self-start");
+    expect(tile.className).toContain("mt-1");
+  });
+
   it("gives only the parent a toggle and indents the child", () => {
     renderTree();
 

--- a/apps/app/src/views/RootComposeMobileRecents.test.tsx
+++ b/apps/app/src/views/RootComposeMobileRecents.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import type { ThreadListEntry } from "@bb/domain";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it } from "vitest";
 import {
@@ -57,6 +57,8 @@ afterEach(() => {
   window.localStorage.clear();
 });
 
+const NONE: ReadonlySet<string> = new Set();
+
 describe("getMobileRecentThreads", () => {
   it("returns every active thread newest-first instead of a capped window", () => {
     const threads = Array.from({ length: 12 }, (_unused, index) =>
@@ -67,13 +69,13 @@ describe("getMobileRecentThreads", () => {
       }),
     );
 
-    const ordered = getMobileRecentThreads({
-      highlightedThreadId: null,
+    const rows = getMobileRecentThreads({
+      collapsedThreadIds: NONE,
       threads,
     });
 
-    expect(ordered).toHaveLength(12);
-    expect(ordered.map((thread) => thread.id)).toEqual([
+    expect(rows).toHaveLength(12);
+    expect(rows.map((row) => row.thread.id)).toEqual([
       "thr_11",
       "thr_10",
       "thr_9",
@@ -87,29 +89,160 @@ describe("getMobileRecentThreads", () => {
       "thr_1",
       "thr_0",
     ]);
+    expect(rows.every((row) => row.depth === 0)).toBe(true);
   });
 
-  it("pins the highlighted thread first without dropping the rest", () => {
-    const threads = Array.from({ length: 5 }, (_unused, index) =>
-      makeThread({
-        id: `thr_${index}`,
-        latestAttentionAt: index,
-        createdAt: index,
-      }),
-    );
+  it("nests a child under its parent instead of listing it as a peer", () => {
+    const rows = getMobileRecentThreads({
+      collapsedThreadIds: NONE,
+      threads: [
+        makeThread({ id: "thr_parent", latestAttentionAt: 10 }),
+        makeThread({
+          id: "thr_child",
+          parentThreadId: "thr_parent",
+          latestAttentionAt: 99,
+        }),
+        makeThread({ id: "thr_other", latestAttentionAt: 5 }),
+      ],
+    });
 
-    const ordered = getMobileRecentThreads({
-      highlightedThreadId: "thr_0",
+    expect(rows.map((row) => [row.thread.id, row.depth])).toEqual([
+      ["thr_parent", 0],
+      ["thr_child", 1],
+      ["thr_other", 0],
+    ]);
+    expect(rows[0]?.hasChildren).toBe(true);
+    expect(rows[1]?.hasChildren).toBe(false);
+  });
+
+  it("hides descendants of a collapsed parent but keeps the parent", () => {
+    const threads = [
+      makeThread({ id: "thr_parent", latestAttentionAt: 10 }),
+      makeThread({
+        id: "thr_child",
+        parentThreadId: "thr_parent",
+        latestAttentionAt: 9,
+      }),
+      makeThread({
+        id: "thr_grandchild",
+        parentThreadId: "thr_child",
+        latestAttentionAt: 8,
+      }),
+    ];
+
+    const rows = getMobileRecentThreads({
+      collapsedThreadIds: new Set(["thr_parent"]),
       threads,
     });
 
-    expect(ordered.map((thread) => thread.id)).toEqual([
-      "thr_0",
-      "thr_4",
-      "thr_3",
-      "thr_2",
-      "thr_1",
+    expect(rows.map((row) => row.thread.id)).toEqual(["thr_parent"]);
+    expect(rows[0]?.isCollapsed).toBe(true);
+    expect(rows[0]?.hasChildren).toBe(true);
+  });
+
+  it("promotes a child whose parent is absent to the top level", () => {
+    const rows = getMobileRecentThreads({
+      collapsedThreadIds: NONE,
+      threads: [
+        makeThread({
+          id: "thr_orphan",
+          parentThreadId: "thr_missing",
+          latestAttentionAt: 3,
+        }),
+      ],
+    });
+
+    expect(rows.map((row) => [row.thread.id, row.depth])).toEqual([
+      ["thr_orphan", 0],
     ]);
+  });
+
+  it("does not group worktree threads into environment rows", () => {
+    const rows = getMobileRecentThreads({
+      collapsedThreadIds: NONE,
+      threads: [
+        makeThread({
+          id: "thr_wt_a",
+          environmentId: "env_1",
+          environmentWorkspaceDisplayKind: "managed-worktree",
+          latestAttentionAt: 2,
+        }),
+        makeThread({
+          id: "thr_wt_b",
+          environmentId: "env_1",
+          environmentWorkspaceDisplayKind: "managed-worktree",
+          latestAttentionAt: 1,
+        }),
+      ],
+    });
+
+    expect(rows.map((row) => [row.thread.id, row.depth])).toEqual([
+      ["thr_wt_a", 0],
+      ["thr_wt_b", 0],
+    ]);
+  });
+});
+
+describe("mobile recents hierarchy interaction", () => {
+  function renderTree() {
+    return render(
+      <MemoryRouter>
+        <RootComposeMobileRecents
+          highlightedThreadId={null}
+          projectNamesById={new Map()}
+          providersById={new Map()}
+          showCreatingRow={false}
+          threads={[
+            makeThread({
+              id: "thr_parent",
+              title: "Rework folder model",
+              titleFallback: "Rework folder model",
+              latestAttentionAt: 10,
+            }),
+            makeThread({
+              id: "thr_child",
+              title: "Audit folder query paths",
+              titleFallback: "Audit folder query paths",
+              parentThreadId: "thr_parent",
+              latestAttentionAt: 9,
+            }),
+          ]}
+        />
+      </MemoryRouter>,
+    );
+  }
+
+  it("collapses and expands children from the parent row chevron", () => {
+    renderTree();
+
+    expect(screen.getByText("Audit folder query paths")).not.toBeNull();
+    const collapse = screen.getByRole("button", {
+      name: "Hide threads under Rework folder model",
+    });
+    expect(collapse.getAttribute("aria-expanded")).toBe("true");
+
+    fireEvent.click(collapse);
+
+    expect(screen.queryByText("Audit folder query paths")).toBeNull();
+    const expand = screen.getByRole("button", {
+      name: "Show threads under Rework folder model",
+    });
+    expect(expand.getAttribute("aria-expanded")).toBe("false");
+
+    fireEvent.click(expand);
+    expect(screen.getByText("Audit folder query paths")).not.toBeNull();
+  });
+
+  it("gives only the parent a toggle and indents the child", () => {
+    renderTree();
+
+    expect(screen.getAllByRole("button")).toHaveLength(1);
+    const [parentRow, childRow] = screen.getAllByRole("link");
+    if (!parentRow || !childRow) {
+      throw new Error("Expected a parent and a child row");
+    }
+    expect(parentRow.style.paddingLeft).toBe("8px");
+    expect(childRow.style.paddingLeft).toBe("32px");
   });
 });
 

--- a/apps/app/src/views/RootComposeMobileRecents.test.tsx
+++ b/apps/app/src/views/RootComposeMobileRecents.test.tsx
@@ -327,13 +327,13 @@ describe("mobile recents hierarchy interaction", () => {
       throw new Error("Expected a tile on both rows");
     }
 
-    expect(parentTile.className).toContain("border-border-seam");
-    expect(parentTile.className).toContain("bg-surface-raised");
-    expect(parentTile.className).not.toContain("opacity-70");
+    expect(parentTile.className).not.toContain("opacity-60");
+    expect(childTile.className).toContain("opacity-60");
 
-    expect(childTile.className).toContain("opacity-70");
-    expect(childTile.className).toContain("border-transparent");
-    expect(childTile.className).not.toContain("bg-surface-raised");
+    for (const tile of [parentTile, childTile]) {
+      expect(tile.className).toContain("border-border-seam");
+      expect(tile.className).toContain("bg-surface-raised");
+    }
 
     for (const tile of [parentTile, childTile]) {
       expect(tile.className).toContain("size-7");

--- a/apps/app/src/views/RootComposeMobileRecents.test.tsx
+++ b/apps/app/src/views/RootComposeMobileRecents.test.tsx
@@ -5,6 +5,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  getMobileRecentAncestorIds,
   getMobileRecentThreads,
   RootComposeMobileRecents,
 } from "./RootComposeMobileRecents";
@@ -183,6 +184,50 @@ describe("getMobileRecentThreads", () => {
   });
 });
 
+describe("getMobileRecentAncestorIds", () => {
+  const tree = [
+    makeThread({ id: "thr_root" }),
+    makeThread({ id: "thr_mid", parentThreadId: "thr_root" }),
+    makeThread({ id: "thr_leaf", parentThreadId: "thr_mid" }),
+  ];
+
+  it("walks the whole ancestor chain of a nested thread", () => {
+    expect(
+      getMobileRecentAncestorIds({ threadId: "thr_leaf", threads: tree }),
+    ).toEqual(["thr_mid", "thr_root"]);
+  });
+
+  it("returns nothing for a root thread or an unknown id", () => {
+    expect(
+      getMobileRecentAncestorIds({ threadId: "thr_root", threads: tree }),
+    ).toEqual([]);
+    expect(
+      getMobileRecentAncestorIds({ threadId: "thr_missing", threads: tree }),
+    ).toEqual([]);
+  });
+
+  it("stops at an absent parent instead of looping", () => {
+    expect(
+      getMobileRecentAncestorIds({
+        threadId: "thr_orphan",
+        threads: [makeThread({ id: "thr_orphan", parentThreadId: "thr_gone" })],
+      }),
+    ).toEqual([]);
+  });
+
+  it("terminates on a parent cycle", () => {
+    expect(
+      getMobileRecentAncestorIds({
+        threadId: "thr_a",
+        threads: [
+          makeThread({ id: "thr_a", parentThreadId: "thr_b" }),
+          makeThread({ id: "thr_b", parentThreadId: "thr_a" }),
+        ],
+      }).length,
+    ).toBeLessThanOrEqual(2);
+  });
+});
+
 describe("mobile recents hierarchy interaction", () => {
   function renderTree() {
     return render(
@@ -231,6 +276,42 @@ describe("mobile recents hierarchy interaction", () => {
 
     fireEvent.click(expand);
     expect(screen.getByText("Audit folder query paths")).not.toBeNull();
+  });
+
+  it("reveals a highlighted thread whose parent is collapsed", () => {
+    window.localStorage.setItem(
+      "bb.sidebar.collapsedThreads",
+      JSON.stringify(["thr_parent"]),
+    );
+
+    render(
+      <MemoryRouter>
+        <RootComposeMobileRecents
+          highlightedThreadId="thr_child"
+          projectNamesById={new Map()}
+          providersById={new Map()}
+          showCreatingRow={false}
+          threads={[
+            makeThread({
+              id: "thr_parent",
+              title: "Rework folder model",
+              titleFallback: "Rework folder model",
+            }),
+            makeThread({
+              id: "thr_child",
+              title: "Audit folder query paths",
+              titleFallback: "Audit folder query paths",
+              parentThreadId: "thr_parent",
+            }),
+          ]}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Audit folder query paths")).not.toBeNull();
+    expect(window.localStorage.getItem("bb.sidebar.collapsedThreads")).toBe(
+      "[]",
+    );
   });
 
   it("anchors the provider tile to the title line, not the text block", () => {

--- a/apps/app/src/views/RootComposeMobileRecents.test.tsx
+++ b/apps/app/src/views/RootComposeMobileRecents.test.tsx
@@ -314,6 +314,36 @@ describe("mobile recents hierarchy interaction", () => {
     );
   });
 
+  it("de-emphasizes the provider tile on child rows only", () => {
+    renderTree();
+
+    const [parentRow, childRow] = screen.getAllByRole("link");
+    const parentTile = parentRow?.firstElementChild;
+    const childTile = childRow?.firstElementChild;
+    if (
+      !(parentTile instanceof HTMLElement) ||
+      !(childTile instanceof HTMLElement)
+    ) {
+      throw new Error("Expected a tile on both rows");
+    }
+
+    expect(parentTile.className).toContain("border-border-seam");
+    expect(parentTile.className).toContain("bg-surface-raised");
+    expect(parentTile.className).not.toContain("opacity-70");
+
+    expect(childTile.className).toContain("opacity-70");
+    expect(childTile.className).toContain("border-transparent");
+    expect(childTile.className).not.toContain("bg-surface-raised");
+
+    // Footprint, alignment and hit target must be identical on both.
+    for (const tile of [parentTile, childTile]) {
+      expect(tile.className).toContain("size-7");
+      expect(tile.className).toContain("self-start");
+      expect(tile.className).toContain("mt-1");
+      expect(tile.className).toContain("border");
+    }
+  });
+
   it("anchors the provider tile to the title line, not the text block", () => {
     renderTree();
 

--- a/apps/app/src/views/RootComposeMobileRecents.tsx
+++ b/apps/app/src/views/RootComposeMobileRecents.tsx
@@ -1,11 +1,16 @@
 import { useMemo } from "react";
-import type { ThreadListEntry } from "@bb/domain";
+import type { ProviderInfo, ThreadListEntry } from "@bb/domain";
 import { RouteAnchor } from "@/components/ui/app-route-anchor";
 import { ThreadStatusGlyph } from "@/components/sidebar/ThreadRow";
 import { SIDEBAR_WORKING_STATUS_COLOR_CLASS } from "@/components/sidebar/sidebarRowClasses";
 import { CHROME_SECTION_LABEL_CLASS } from "@bb/shared-ui/chrome-style-tokens";
-import { COARSE_POINTER_ICON_SIZE_CLASS } from "@bb/shared-ui/coarse-pointer-sizing";
+import {
+  COARSE_POINTER_ICON_SIZE_CLASS,
+  COARSE_POINTER_TEXT_BASE_CLASS,
+  COARSE_POINTER_TEXT_SM_CLASS,
+} from "@bb/shared-ui/coarse-pointer-sizing";
 import { Icon } from "@bb/shared-ui/icon";
+import { OverflowFade } from "@/components/ui/overflow-fade";
 import { getThreadRoutePath, isProjectlessProjectId } from "@/lib/route-paths";
 import {
   hasActiveBackgroundAgentActivity,
@@ -20,10 +25,17 @@ import {
   type ThreadListIndicatorState,
 } from "@bb/client-core";
 import { getThreadDisplayTitle } from "@/lib/thread-title";
+import { formatRelativeTime } from "@/lib/relative-time";
+import { getEnvironmentWorkspaceDisplayIconName } from "@/lib/environment-workspace-display";
+import { getProviderIconInfo } from "@/lib/provider-icon";
+import { ProviderIconMark } from "@/components/settings/ProviderIconMark";
 import { cn } from "@bb/shared-ui/lib/utils";
 import { usePromptDraftHasInput } from "@/hooks/usePromptDraftStorage";
 
-const MOBILE_RECENT_THREAD_LIMIT = 3;
+export const MOBILE_RECENT_ROW_HEIGHT_PX = 60;
+export const MOBILE_RECENT_LABEL_HEIGHT_PX = 24;
+
+const MOBILE_RECENT_ROW_HEIGHT_CLASS = "h-15";
 
 type ThreadListEntryComparator = (
   left: ThreadListEntry,
@@ -38,12 +50,34 @@ interface GetMobileRecentThreadsArgs {
 interface MobileRecentThreadRowProps {
   highlighted: boolean;
   projectName: string | null;
+  provider: ProviderInfo | null;
   thread: ThreadListEntry;
+}
+
+function getMobileRecentThreadMetadata({
+  projectName,
+  thread,
+}: {
+  projectName: string | null;
+  thread: ThreadListEntry;
+}): string {
+  const workspaceName = thread.environmentBranchName ?? thread.environmentName;
+  return [
+    projectName,
+    workspaceName,
+    formatRelativeTime({
+      timestamp: thread.latestAttentionAt,
+      now: Date.now(),
+    }),
+  ]
+    .filter((part): part is string => part !== null && part.length > 0)
+    .join(" \u00b7 ");
 }
 
 interface RootComposeMobileRecentsProps {
   highlightedThreadId: string | null;
   projectNamesById: ReadonlyMap<string, string>;
+  providersById: ReadonlyMap<string, ProviderInfo>;
   showCreatingRow: boolean;
   threads: readonly ThreadListEntry[];
 }
@@ -63,33 +97,32 @@ const compareMobileRecentThreads: ThreadListEntryComparator = (left, right) => {
   return left.id.localeCompare(right.id);
 };
 
-function getMobileRecentThreads({
+export function getMobileRecentThreads({
   highlightedThreadId,
   threads,
 }: GetMobileRecentThreadsArgs): ThreadListEntry[] {
   const sortedThreads = [...threads].sort(compareMobileRecentThreads);
   if (highlightedThreadId === null) {
-    return sortedThreads.slice(0, MOBILE_RECENT_THREAD_LIMIT);
+    return sortedThreads;
   }
 
   const highlightedThread = sortedThreads.find(
     (thread) => thread.id === highlightedThreadId,
   );
   if (!highlightedThread) {
-    return sortedThreads.slice(0, MOBILE_RECENT_THREAD_LIMIT);
+    return sortedThreads;
   }
 
   return [
     highlightedThread,
-    ...sortedThreads
-      .filter((thread) => thread.id !== highlightedThreadId)
-      .slice(0, MOBILE_RECENT_THREAD_LIMIT - 1),
+    ...sortedThreads.filter((thread) => thread.id !== highlightedThreadId),
   ];
 }
 
 function MobileRecentThreadRow({
   highlighted,
   projectName,
+  provider,
   thread,
 }: MobileRecentThreadRowProps) {
   const threadTitle = getThreadDisplayTitle(thread);
@@ -112,9 +145,14 @@ function MobileRecentThreadRow({
     isRuntimeActive: isRuntimeBusyThread(thread),
     isWorkflowActive: hasActiveWorkflowActivity(thread),
   };
-  const indicatorLabel = getThreadListIndicatorLabel(
-    resolveThreadListIndicator(indicatorState),
+  const indicatorKind = resolveThreadListIndicator(indicatorState);
+  const indicatorLabel = getThreadListIndicatorLabel(indicatorKind);
+  const metadataText = getMobileRecentThreadMetadata({ projectName, thread });
+  const workspaceIconName = getEnvironmentWorkspaceDisplayIconName(
+    thread.environmentWorkspaceDisplayKind,
   );
+  const providerIcon = getProviderIconInfo(thread.providerId, provider);
+  const ProviderMark = providerIcon?.icon;
   return (
     <li>
       {}
@@ -125,21 +163,53 @@ function MobileRecentThreadRow({
         })}
         aria-label={`Open ${threadTitle}${indicatorLabel ? ` — ${indicatorLabel}` : ""}`}
         className={cn(
-          "flex h-8 items-center gap-2 rounded-md px-2 text-sm text-foreground/85 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
+          "flex items-center gap-2.5 rounded-md px-2 text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
+          MOBILE_RECENT_ROW_HEIGHT_CLASS,
           highlighted && "bg-surface-selected",
         )}
       >
-        <span className="flex min-w-0 flex-1 items-baseline gap-2">
-          <span className="min-w-0 truncate">{threadTitle}</span>
-          {projectName ? (
-            <span className="shrink-0 text-xs text-muted-foreground">
-              {projectName}
-            </span>
-          ) : null}
+        <span className="flex size-7 shrink-0 items-center justify-center rounded-md border border-border-seam bg-surface-raised">
+          {ProviderMark === undefined ? null : provider === null ? (
+            <ProviderMark className="size-4" />
+          ) : (
+            <ProviderIconMark
+              provider={provider}
+              icon={ProviderMark}
+              className="size-4"
+            />
+          )}
         </span>
-        <span className="flex size-6 shrink-0 items-center justify-center">
-          <ThreadStatusGlyph {...indicatorState} />
+        <span className="min-w-0 flex-1 space-y-0.5">
+          <span
+            className={cn(
+              "block min-w-0 truncate font-medium",
+              COARSE_POINTER_TEXT_BASE_CLASS,
+            )}
+          >
+            {threadTitle}
+          </span>
+          <span
+            className={cn(
+              "flex min-w-0 items-center gap-1.5 leading-4 text-muted-foreground",
+              COARSE_POINTER_TEXT_SM_CLASS,
+            )}
+            title={metadataText}
+          >
+            {workspaceIconName ? (
+              <Icon
+                name={workspaceIconName}
+                className="size-3.5 shrink-0"
+                aria-hidden="true"
+              />
+            ) : null}
+            <span className="min-w-0 truncate">{metadataText}</span>
+          </span>
         </span>
+        {indicatorKind !== "none" ? (
+          <span className="flex size-6 shrink-0 items-center justify-center">
+            <ThreadStatusGlyph {...indicatorState} />
+          </span>
+        ) : null}
       </RouteAnchor>
     </li>
   );
@@ -148,6 +218,7 @@ function MobileRecentThreadRow({
 export function RootComposeMobileRecents({
   highlightedThreadId,
   projectNamesById,
+  providersById,
   showCreatingRow,
   threads,
 }: RootComposeMobileRecentsProps) {
@@ -164,20 +235,24 @@ export function RootComposeMobileRecents({
     <section
       data-root-compose-mobile-recents=""
       aria-labelledby="root-compose-mobile-recents"
-      className="mt-4 md:hidden"
+      className="md:hidden"
     >
-      <div className="mb-1 px-2">
+      <div className="sticky top-0 z-10 mb-1 bg-background px-2">
         <h2
           id="root-compose-mobile-recents"
           className={CHROME_SECTION_LABEL_CLASS}
         >
           Recent
         </h2>
+        <OverflowFade placement="below" tone="background" size="sm" />
       </div>
       {showCreatingRow ? (
         <div
           role="status"
-          className="flex h-8 items-center gap-2 rounded-md px-2 text-sm text-muted-foreground"
+          className={cn(
+            "flex items-center gap-2.5 rounded-md px-2 text-sm text-muted-foreground",
+            MOBILE_RECENT_ROW_HEIGHT_CLASS,
+          )}
         >
           <span className="min-w-0 flex-1 truncate">Creating thread</span>
           <span className="flex size-6 shrink-0 items-center justify-center">
@@ -199,6 +274,7 @@ export function RootComposeMobileRecents({
             <MobileRecentThreadRow
               key={thread.id}
               highlighted={thread.id === highlightedThreadId}
+              provider={providersById.get(thread.providerId) ?? null}
               projectName={
                 isProjectlessProjectId(thread.projectId)
                   ? null

--- a/apps/app/src/views/RootComposeMobileRecents.tsx
+++ b/apps/app/src/views/RootComposeMobileRecents.tsx
@@ -267,10 +267,8 @@ function MobileRecentThreadRow({
       >
         <span
           className={cn(
-            "mt-1 flex size-7 shrink-0 items-center justify-center self-start rounded-md border",
-            depth === 0
-              ? "border-border-seam bg-surface-raised"
-              : "border-transparent bg-transparent opacity-70",
+            "mt-1 flex size-7 shrink-0 items-center justify-center self-start rounded-md border border-border-seam bg-surface-raised",
+            depth > 0 && "opacity-60",
           )}
         >
           {ProviderMark === undefined ? null : provider === null ? (

--- a/apps/app/src/views/RootComposeMobileRecents.tsx
+++ b/apps/app/src/views/RootComposeMobileRecents.tsx
@@ -1,7 +1,10 @@
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
+import { useAtom } from "jotai";
 import type { ProviderInfo, ThreadListEntry } from "@bb/domain";
 import { RouteAnchor } from "@/components/ui/app-route-anchor";
 import { ThreadStatusGlyph } from "@/components/sidebar/ThreadRow";
+import { SidebarChildToggleChevron } from "@/components/sidebar/SidebarChildToggleChevron";
+import { getSidebarThreadRowPaddingLeft } from "@/components/sidebar/sidebarRowClasses";
 import { SIDEBAR_WORKING_STATUS_COLOR_CLASS } from "@/components/sidebar/sidebarRowClasses";
 import { CHROME_SECTION_LABEL_CLASS } from "@bb/shared-ui/chrome-style-tokens";
 import {
@@ -22,6 +25,9 @@ import {
   isRuntimeBusyThread,
   isUnreadDoneThread,
   resolveThreadListIndicator,
+  buildChronologicalThreadList,
+  type CollapsedChildActivity,
+  type ProjectThreadItem,
   type ThreadListIndicatorState,
 } from "@bb/client-core";
 import { getThreadDisplayTitle } from "@/lib/thread-title";
@@ -31,6 +37,7 @@ import { getProviderIconInfo } from "@/lib/provider-icon";
 import { ProviderIconMark } from "@/components/settings/ProviderIconMark";
 import { cn } from "@bb/shared-ui/lib/utils";
 import { usePromptDraftHasInput } from "@/hooks/usePromptDraftStorage";
+import { collapsedThreadIdsAtom } from "@/components/sidebar/sidebarCollapsedAtoms";
 
 export const MOBILE_RECENT_ROW_HEIGHT_PX = 60;
 export const MOBILE_RECENT_LABEL_HEIGHT_PX = 24;
@@ -43,15 +50,16 @@ type ThreadListEntryComparator = (
 ) => number;
 
 interface GetMobileRecentThreadsArgs {
-  highlightedThreadId: string | null;
+  collapsedThreadIds: ReadonlySet<string>;
   threads: readonly ThreadListEntry[];
 }
 
 interface MobileRecentThreadRowProps {
   highlighted: boolean;
+  onToggleCollapsed: (threadId: string) => void;
   projectName: string | null;
   provider: ProviderInfo | null;
-  thread: ThreadListEntry;
+  row: MobileRecentThreadRow;
 }
 
 function getMobileRecentThreadMetadata({
@@ -97,34 +105,66 @@ const compareMobileRecentThreads: ThreadListEntryComparator = (left, right) => {
   return left.id.localeCompare(right.id);
 };
 
+export interface MobileRecentThreadRow {
+  thread: ThreadListEntry;
+  depth: number;
+  childActivity: CollapsedChildActivity;
+  hasChildren: boolean;
+  isCollapsed: boolean;
+}
+
+function flattenMobileRecentNodes({
+  collapsedThreadIds,
+  items,
+  rows,
+}: {
+  collapsedThreadIds: ReadonlySet<string>;
+  items: readonly ProjectThreadItem[];
+  rows: MobileRecentThreadRow[];
+}): void {
+  for (const item of items) {
+    if (item.kind !== "thread") continue;
+    const { node } = item;
+    const hasChildren = node.children.length > 0;
+    const isCollapsed = hasChildren && collapsedThreadIds.has(node.thread.id);
+    rows.push({
+      thread: node.thread,
+      depth: node.depth,
+      childActivity: node.stats.childActivity,
+      hasChildren,
+      isCollapsed,
+    });
+    if (hasChildren && !isCollapsed) {
+      flattenMobileRecentNodes({
+        collapsedThreadIds,
+        items: node.children,
+        rows,
+      });
+    }
+  }
+}
+
 export function getMobileRecentThreads({
-  highlightedThreadId,
+  collapsedThreadIds,
   threads,
-}: GetMobileRecentThreadsArgs): ThreadListEntry[] {
-  const sortedThreads = [...threads].sort(compareMobileRecentThreads);
-  if (highlightedThreadId === null) {
-    return sortedThreads;
-  }
-
-  const highlightedThread = sortedThreads.find(
-    (thread) => thread.id === highlightedThreadId,
-  );
-  if (!highlightedThread) {
-    return sortedThreads;
-  }
-
-  return [
-    highlightedThread,
-    ...sortedThreads.filter((thread) => thread.id !== highlightedThreadId),
-  ];
+}: GetMobileRecentThreadsArgs): MobileRecentThreadRow[] {
+  const rows: MobileRecentThreadRow[] = [];
+  flattenMobileRecentNodes({
+    collapsedThreadIds,
+    items: buildChronologicalThreadList(threads, compareMobileRecentThreads),
+    rows,
+  });
+  return rows;
 }
 
 function MobileRecentThreadRow({
   highlighted,
+  onToggleCollapsed,
   projectName,
   provider,
-  thread,
+  row,
 }: MobileRecentThreadRowProps) {
+  const { thread, depth, childActivity, hasChildren, isCollapsed } = row;
   const threadTitle = getThreadDisplayTitle(thread);
   const isUnreadDone = isUnreadDoneThread(thread);
   const isUnreadError = isUnreadDone && thread.status === "error";
@@ -145,7 +185,35 @@ function MobileRecentThreadRow({
     isRuntimeActive: isRuntimeBusyThread(thread),
     isWorkflowActive: hasActiveWorkflowActivity(thread),
   };
-  const indicatorKind = resolveThreadListIndicator(indicatorState);
+  const hasHiddenChildren = hasChildren && isCollapsed;
+  const trailingIndicatorState: ThreadListIndicatorState = hasHiddenChildren
+    ? {
+        hasPendingInteraction:
+          indicatorState.hasPendingInteraction || childActivity.pending,
+        hasUnsubmittedDraft:
+          indicatorState.hasUnsubmittedDraft ||
+          childActivity.hasUnsubmittedDraft,
+        hasUnreadError:
+          indicatorState.hasUnreadError || childActivity.unreadError,
+        hasUnreadSuccess:
+          indicatorState.hasUnreadSuccess ||
+          (childActivity.unread && !childActivity.unreadError),
+        isBackgroundAgentActive:
+          indicatorState.isBackgroundAgentActive ||
+          childActivity.backgroundAgent,
+        isBackgroundCommandActive:
+          indicatorState.isBackgroundCommandActive ||
+          childActivity.backgroundCommand,
+        isGoalActive: indicatorState.isGoalActive || childActivity.goal,
+        isPlanModeActive:
+          indicatorState.isPlanModeActive || childActivity.planMode,
+        isRuntimeActive:
+          indicatorState.isRuntimeActive || childActivity.runtimeWorking,
+        isWorkflowActive:
+          indicatorState.isWorkflowActive || childActivity.workflow,
+      }
+    : indicatorState;
+  const indicatorKind = resolveThreadListIndicator(trailingIndicatorState);
   const indicatorLabel = getThreadListIndicatorLabel(indicatorKind);
   const metadataText = getMobileRecentThreadMetadata({ projectName, thread });
   const workspaceIconName = getEnvironmentWorkspaceDisplayIconName(
@@ -162,8 +230,9 @@ function MobileRecentThreadRow({
           threadId: thread.id,
         })}
         aria-label={`Open ${threadTitle}${indicatorLabel ? ` — ${indicatorLabel}` : ""}`}
+        style={{ paddingLeft: getSidebarThreadRowPaddingLeft(depth) }}
         className={cn(
-          "flex items-center gap-2.5 rounded-md px-2 text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
+          "flex items-center gap-2.5 rounded-md pr-2 text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
           MOBILE_RECENT_ROW_HEIGHT_CLASS,
           highlighted && "bg-surface-selected",
         )}
@@ -180,13 +249,23 @@ function MobileRecentThreadRow({
           )}
         </span>
         <span className="min-w-0 flex-1 space-y-0.5">
-          <span
-            className={cn(
-              "block min-w-0 truncate font-medium",
-              COARSE_POINTER_TEXT_BASE_CLASS,
-            )}
-          >
-            {threadTitle}
+          <span className="flex min-w-0 items-center gap-1.5">
+            <span
+              className={cn(
+                "min-w-0 truncate font-medium",
+                COARSE_POINTER_TEXT_BASE_CLASS,
+              )}
+            >
+              {threadTitle}
+            </span>
+            {hasChildren ? (
+              <SidebarChildToggleChevron
+                isCollapsed={isCollapsed}
+                expandLabel={`Show threads under ${threadTitle}`}
+                collapseLabel={`Hide threads under ${threadTitle}`}
+                onToggle={() => onToggleCollapsed(thread.id)}
+              />
+            ) : null}
           </span>
           <span
             className={cn(
@@ -222,9 +301,26 @@ export function RootComposeMobileRecents({
   showCreatingRow,
   threads,
 }: RootComposeMobileRecentsProps) {
+  const [collapsedThreadIdList, setCollapsedThreadIdList] = useAtom(
+    collapsedThreadIdsAtom,
+  );
+  const collapsedThreadIds = useMemo(
+    () => new Set(collapsedThreadIdList),
+    [collapsedThreadIdList],
+  );
+  const toggleCollapsed = useCallback(
+    (threadId: string) => {
+      setCollapsedThreadIdList((current) =>
+        current.includes(threadId)
+          ? current.filter((id) => id !== threadId)
+          : [...current, threadId],
+      );
+    },
+    [setCollapsedThreadIdList],
+  );
   const recentThreads = useMemo(
-    () => getMobileRecentThreads({ highlightedThreadId, threads }),
-    [highlightedThreadId, threads],
+    () => getMobileRecentThreads({ collapsedThreadIds, threads }),
+    [collapsedThreadIds, threads],
   );
 
   if (!showCreatingRow && recentThreads.length === 0) {
@@ -270,17 +366,18 @@ export function RootComposeMobileRecents({
       ) : null}
       {recentThreads.length > 0 ? (
         <ul className="space-y-px">
-          {recentThreads.map((thread) => (
+          {recentThreads.map((row) => (
             <MobileRecentThreadRow
-              key={thread.id}
-              highlighted={thread.id === highlightedThreadId}
-              provider={providersById.get(thread.providerId) ?? null}
+              key={row.thread.id}
+              highlighted={row.thread.id === highlightedThreadId}
+              onToggleCollapsed={toggleCollapsed}
+              provider={providersById.get(row.thread.providerId) ?? null}
               projectName={
-                isProjectlessProjectId(thread.projectId)
+                isProjectlessProjectId(row.thread.projectId)
                   ? null
-                  : (projectNamesById.get(thread.projectId) ?? null)
+                  : (projectNamesById.get(row.thread.projectId) ?? null)
               }
-              thread={thread}
+              row={row}
             />
           ))}
         </ul>

--- a/apps/app/src/views/RootComposeMobileRecents.tsx
+++ b/apps/app/src/views/RootComposeMobileRecents.tsx
@@ -237,7 +237,7 @@ function MobileRecentThreadRow({
           highlighted && "bg-surface-selected",
         )}
       >
-        <span className="flex size-7 shrink-0 items-center justify-center rounded-md border border-border-seam bg-surface-raised">
+        <span className="mt-1 flex size-7 shrink-0 items-center justify-center self-start rounded-md border border-border-seam bg-surface-raised">
           {ProviderMark === undefined ? null : provider === null ? (
             <ProviderMark className="size-4" />
           ) : (

--- a/apps/app/src/views/RootComposeMobileRecents.tsx
+++ b/apps/app/src/views/RootComposeMobileRecents.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { useAtom } from "jotai";
 import type { ProviderInfo, ThreadListEntry } from "@bb/domain";
 import { RouteAnchor } from "@/components/ui/app-route-anchor";
@@ -142,6 +142,34 @@ function flattenMobileRecentNodes({
       });
     }
   }
+}
+
+export function getMobileRecentAncestorIds({
+  threadId,
+  threads,
+}: {
+  threadId: string;
+  threads: readonly ThreadListEntry[];
+}): string[] {
+  const byId = new Map(threads.map((thread) => [thread.id, thread]));
+  const selected = byId.get(threadId);
+  if (selected === undefined || selected.visibility === "hidden") {
+    return [];
+  }
+
+  const ancestorIds: string[] = [];
+  let current: ThreadListEntry | undefined = selected;
+  let remainingHops = byId.size;
+  while (current !== undefined && remainingHops > 0) {
+    const parentThreadId: string | null = current.parentThreadId;
+    if (parentThreadId === null) break;
+    const parent = byId.get(parentThreadId);
+    if (parent === undefined) break;
+    ancestorIds.push(parent.id);
+    current = parent;
+    remainingHops -= 1;
+  }
+  return ancestorIds;
 }
 
 export function getMobileRecentThreads({
@@ -318,6 +346,18 @@ export function RootComposeMobileRecents({
     },
     [setCollapsedThreadIdList],
   );
+  useEffect(() => {
+    if (highlightedThreadId === null) return;
+    const ancestorIds = getMobileRecentAncestorIds({
+      threadId: highlightedThreadId,
+      threads,
+    });
+    if (ancestorIds.length === 0) return;
+    setCollapsedThreadIdList((current) => {
+      const next = current.filter((id) => !ancestorIds.includes(id));
+      return next.length === current.length ? current : next;
+    });
+  }, [highlightedThreadId, setCollapsedThreadIdList, threads]);
   const recentThreads = useMemo(
     () => getMobileRecentThreads({ collapsedThreadIds, threads }),
     [collapsedThreadIds, threads],

--- a/apps/app/src/views/RootComposeMobileRecents.tsx
+++ b/apps/app/src/views/RootComposeMobileRecents.tsx
@@ -265,7 +265,14 @@ function MobileRecentThreadRow({
           highlighted && "bg-surface-selected",
         )}
       >
-        <span className="mt-1 flex size-7 shrink-0 items-center justify-center self-start rounded-md border border-border-seam bg-surface-raised">
+        <span
+          className={cn(
+            "mt-1 flex size-7 shrink-0 items-center justify-center self-start rounded-md border",
+            depth === 0
+              ? "border-border-seam bg-surface-raised"
+              : "border-transparent bg-transparent opacity-70",
+          )}
+        >
           {ProviderMark === undefined ? null : provider === null ? (
             <ProviderMark className="size-4" />
           ) : (

--- a/apps/app/src/views/RootComposeSecondaryContent.test.tsx
+++ b/apps/app/src/views/RootComposeSecondaryContent.test.tsx
@@ -196,6 +196,7 @@ function renderRootCompose(args: RenderRootComposeArgs) {
       isCompactViewport={renderArgs.isCompactViewport}
     >
       <RootComposeSecondaryContent
+        compactScrollContent={null}
         isSecondaryPanelOpen={renderArgs.isSecondaryPanelOpen}
         onToggleSecondaryPanel={() => undefined}
         secondaryPanel={createSecondaryPanel(renderArgs.isSecondaryPanelOpen)}
@@ -215,6 +216,7 @@ function renderRootCompose(args: RenderRootComposeArgs) {
           isCompactViewport={renderArgs.isCompactViewport}
         >
           <RootComposeSecondaryContent
+            compactScrollContent={null}
             isSecondaryPanelOpen={renderArgs.isSecondaryPanelOpen}
             onToggleSecondaryPanel={() => undefined}
             secondaryPanel={createSecondaryPanel(

--- a/apps/app/src/views/RootComposeSecondaryContent.tsx
+++ b/apps/app/src/views/RootComposeSecondaryContent.tsx
@@ -1,4 +1,5 @@
 import { useState, type ComponentProps, type ReactNode } from "react";
+import { useIsCompactViewport } from "@bb/shared-ui/hooks/use-compact-viewport";
 import { Skeleton } from "@bb/shared-ui/skeleton";
 import { COARSE_POINTER_HEADER_ICON_BUTTON_CLASS } from "@bb/shared-ui/coarse-pointer-sizing";
 import { cn } from "@bb/shared-ui/lib/utils";
@@ -14,6 +15,7 @@ import {
   MACOS_WINDOW_DRAG_CLASS,
   shouldUseMacosDesktopChrome,
 } from "@/lib/bb-desktop";
+import { RootComposeCompactHome } from "./RootComposeCompactHome";
 import { useOptionalPaneContext } from "./thread-detail/PaneContext";
 
 const ROOT_COMPOSE_MAX_WIDTH_CLASS = "max-w-[760px]";
@@ -40,6 +42,7 @@ type RootSecondaryPanelProps = Omit<
 
 interface RootComposeSecondaryContentProps {
   children: ReactNode;
+  compactScrollContent: ReactNode;
   contentClassName?: string;
   isSecondaryPanelOpen: boolean;
   onToggleSecondaryPanel: () => void;
@@ -61,6 +64,7 @@ function DrawerPanelLoadingSkeleton() {
 
 export function RootComposeSecondaryContent({
   children,
+  compactScrollContent,
   contentClassName,
   isSecondaryPanelOpen,
   onToggleSecondaryPanel,
@@ -74,6 +78,9 @@ export function RootComposeSecondaryContent({
   const rendersWindowDragStrip =
     usesDesktopChrome && paneContext?.isTopRow !== false;
   const { renderBrowserDeck, ...threadSecondaryPanelProps } = secondaryPanel;
+  const isCompactViewport = useIsCompactViewport();
+  const usesCompactHomeLayout =
+    isCompactViewport && compactScrollContent !== null;
 
   const mainContent = (
     <div className="relative flex h-full min-h-0 flex-1 flex-col overflow-hidden">
@@ -100,19 +107,32 @@ export function RootComposeSecondaryContent({
           ) : null}
         </div>
       ) : null}
-      <div className="@container/page min-h-0 flex-1 overflow-y-auto">
+      {usesCompactHomeLayout ? (
         <div
-          className={cn(
-            "mx-auto flex w-full flex-col px-4 pb-4 pt-2",
-            ROOT_COMPOSE_MAX_WIDTH_CLASS,
-            contentClassName,
-          )}
+          className="@container/page flex min-h-0 flex-1 flex-col"
           style={PAGE_SHELL_CONTENT_STYLE}
         >
-          {children}
-          <PluginHomepageSections />
+          <RootComposeCompactHome composer={children}>
+            {compactScrollContent}
+            <PluginHomepageSections />
+          </RootComposeCompactHome>
         </div>
-      </div>
+      ) : (
+        <div className="@container/page min-h-0 flex-1 overflow-y-auto">
+          <div
+            className={cn(
+              "mx-auto flex w-full flex-col px-4 pb-4 pt-2",
+              ROOT_COMPOSE_MAX_WIDTH_CLASS,
+              contentClassName,
+            )}
+            style={PAGE_SHELL_CONTENT_STYLE}
+          >
+            {children}
+            {compactScrollContent}
+            <PluginHomepageSections />
+          </div>
+        </div>
+      )}
     </div>
   );
 

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -40,7 +40,7 @@ import {
   type ProjectMachineSetupDialogTarget,
 } from "@/components/dialogs/ProjectMachineSetupDialog";
 import { HEADER_ICON_BUTTON_CLASS } from "@/components/layout/AppPageHeader";
-import { useRightPanelToggleIconName } from "@/components/secondary-panel/panelToggleControlState";
+import { RIGHT_PANEL_TOGGLE_ICON_NAME } from "@/components/secondary-panel/panelToggleControlState";
 import { AppCommandShortcutHint } from "@/components/commands/AppCommandShortcutHint";
 import type {
   SecondaryPanelPaneRenderContext,
@@ -269,7 +269,7 @@ export function RootComposeRightPanelToggle({
 }: RootComposeRightPanelToggleProps) {
   const shortcut = useAppCommandShortcut("panel.toggle");
   const rightPanelLabel = isOpen ? "Hide right panel" : "Show right panel";
-  const rightPanelIconName = useRightPanelToggleIconName();
+  const rightPanelIconName = RIGHT_PANEL_TOGGLE_ICON_NAME;
 
   return (
     <Button

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -1,11 +1,15 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
-import { findCachedProviderInfo } from "@/hooks/queries/system-queries";
+import {
+  findCachedProviderInfo,
+  useSystemProviders,
+} from "@/hooks/queries/system-queries";
 import {
   findLocalPathProjectSourceForHost,
   type EnvironmentStatus,
   type Host,
+  type ProviderInfo,
   type ReasoningLevel,
   type ServiceTier,
   type ThreadListEntry,
@@ -809,6 +813,14 @@ function RootComposeSurface({
     () => buildMobileRecentThreads({ sidebarNavigation }),
     [sidebarNavigation],
   );
+  const systemProviders = useSystemProviders().data;
+  const mobileRecentProvidersById = useMemo(() => {
+    const byId = new Map<string, ProviderInfo>();
+    for (const provider of systemProviders ?? []) {
+      byId.set(provider.id, provider);
+    }
+    return byId;
+  }, [systemProviders]);
   const mobileRecentProjectNamesById = useMemo(() => {
     const namesById = new Map<string, string>();
     if (!sidebarNavigation) return namesById;
@@ -870,13 +882,13 @@ function RootComposeSurface({
     [activeFixedSecondaryTab, isPersistedSecondaryPanelOpen],
   );
   const activeFixedSecondaryTabId = activeFixedSecondaryTab?.id ?? null;
-  const renderSecondaryPanelAsDrawer = useIsCompactViewport();
+  const isCompactViewport = useIsCompactViewport();
   const secondaryPanelDrawerVisibility =
     useThreadSecondaryPanelDrawerVisibility({
-      isCompactViewport: renderSecondaryPanelAsDrawer,
+      isCompactViewport,
       threadId: ROOT_COMPOSE_FIXED_PANEL_STATE_ID,
     });
-  const isSecondaryPanelOpen = renderSecondaryPanelAsDrawer
+  const isSecondaryPanelOpen = isCompactViewport
     ? secondaryPanelDrawerVisibility.isDrawerVisible
     : isPersistedSecondaryPanelOpen;
   const touchFixedPanelTabsState = useTouchFixedPanelTabsState(
@@ -1118,7 +1130,7 @@ function RootComposeSurface({
   } = useThreadSecondaryPanelVisibility({
     closePersistedPanel: closeRootSecondaryPanel,
     drawerVisibility: secondaryPanelDrawerVisibility,
-    isCompactViewport: renderSecondaryPanelAsDrawer,
+    isCompactViewport,
     isPersistedOpen: isPersistedSecondaryPanelOpen,
     openPersistedCommitDiff: () => undefined,
     openPersistedDiffFile: () => undefined,
@@ -1892,6 +1904,7 @@ function RootComposeSurface({
   const promptBox = renderPromptBox({
     id: "root-compose-prompt",
     autoFocus: !isProviderCliVersionBlocked,
+    allowSoftKeyboardAutoFocus: isCompactViewport,
     banner: promptBanner,
     header: promptHeader,
     blockedReason: isProviderCliVersionBlocked
@@ -1940,6 +1953,17 @@ function RootComposeSurface({
                   ? ROOT_COMPOSE_EMPTY_WELCOME_CONTENT_CLASS
                   : ROOT_COMPOSE_SIDEBAR_ACTION_ALIGNED_TOP_PADDING_CLASS
               }
+              compactScrollContent={
+                showEmptyWelcome ? null : (
+                  <RootComposeMobileRecents
+                    highlightedThreadId={lastCreatedThreadId}
+                    projectNamesById={mobileRecentProjectNamesById}
+                    providersById={mobileRecentProvidersById}
+                    showCreatingRow={isSubmitting}
+                    threads={mobileRecentThreads}
+                  />
+                )
+              }
               isSecondaryPanelOpen={isSecondaryPanelOpen}
               onToggleSecondaryPanel={handleToggleSecondaryPanel}
               secondaryPanel={{
@@ -1977,15 +2001,7 @@ function RootComposeSurface({
                   }
                 />
               ) : (
-                <>
-                  {promptBox}
-                  <RootComposeMobileRecents
-                    highlightedThreadId={lastCreatedThreadId}
-                    projectNamesById={mobileRecentProjectNamesById}
-                    showCreatingRow={isSubmitting}
-                    threads={mobileRecentThreads}
-                  />
-                </>
+                promptBox
               )}
             </RootComposeSecondaryContent>
           </AppNavigationHostProvider>

--- a/apps/app/src/views/mobile-home-story-fixtures.tsx
+++ b/apps/app/src/views/mobile-home-story-fixtures.tsx
@@ -14,6 +14,8 @@ import {
   PROJECT_IDS,
   PROJECT_NAMES,
   STORY_BRANCH_OPTIONS,
+  STORY_CLAUDE_CODE_PROVIDER_ID,
+  STORY_CURSOR_PROVIDER_ID,
   STORY_PROVIDERS_BY_ID,
   STORY_PROJECTS,
   STORY_PROJECT_SOURCES,
@@ -42,7 +44,7 @@ export const HOME_THREADS: ThreadListEntry[] = [
   makeThreadListEntry({
     id: "thr_home_child_a",
     parentThreadId: "thr_home_parent",
-    providerId: "claude-code",
+    providerId: STORY_CLAUDE_CODE_PROVIDER_ID,
     title: "Audit folder query paths",
     titleFallback: "Audit folder query paths",
     latestAttentionAt: 880,
@@ -50,14 +52,14 @@ export const HOME_THREADS: ThreadListEntry[] = [
   makeThreadListEntry({
     id: "thr_home_child_b",
     parentThreadId: "thr_home_parent",
-    providerId: "acp-cursor",
+    providerId: STORY_CURSOR_PROVIDER_ID,
     title: "Migrate folder fixtures",
     titleFallback: "Migrate folder fixtures",
     latestAttentionAt: 870,
   }),
   makeThreadListEntry({
     id: "thr_home_style",
-    providerId: "claude-code",
+    providerId: STORY_CLAUDE_CODE_PROVIDER_ID,
     title: "Reduce style recalculation",
     titleFallback: "Reduce style recalculation",
     status: "starting",
@@ -73,7 +75,7 @@ export const HOME_THREADS: ThreadListEntry[] = [
   makeThreadListEntry({
     id: "thr_home_daemon",
     projectId: PROJECT_IDS.pierre,
-    providerId: "acp-cursor",
+    providerId: STORY_CURSOR_PROVIDER_ID,
     title: "Debug host daemon reconnect",
     titleFallback: "Debug host daemon reconnect",
     latestAttentionAt: 840,
@@ -86,7 +88,7 @@ export const HOME_THREADS: ThreadListEntry[] = [
   }),
   makeThreadListEntry({
     id: "thr_home_sidebar",
-    providerId: "claude-code",
+    providerId: STORY_CLAUDE_CODE_PROVIDER_ID,
     title: "Trim sidebar re-renders",
     titleFallback: "Trim sidebar re-renders",
     latestAttentionAt: 820,

--- a/apps/app/src/views/mobile-home-story-fixtures.tsx
+++ b/apps/app/src/views/mobile-home-story-fixtures.tsx
@@ -1,10 +1,28 @@
-import type { ReactNode } from "react";
-import type { ThreadListEntry } from "@bb/domain";
+import { useState, type ReactNode } from "react";
+import type { PromptTextMention, ThreadListEntry } from "@bb/domain";
 import {
+  NewThreadPromptBoxUI,
+  type NewThreadBranchConfig,
+  type NewThreadEnvironmentConfig,
+  type NewThreadModeConfig,
+  type NewThreadProjectConfig,
+  type NewThreadWorktreeConfig,
+} from "@/components/promptbox/NewThreadPromptBox";
+import { ModelPickerStoryQueryProvider } from "../../.ladle/model-picker-query-provider";
+import {
+  HOST_IDS,
   PROJECT_IDS,
   PROJECT_NAMES,
+  STORY_BRANCH_OPTIONS,
   STORY_PROVIDERS_BY_ID,
+  STORY_PROJECTS,
+  STORY_PROJECT_SOURCES,
+  STORY_WORKTREE_OPTIONS,
+  makeAttachmentsConfig,
+  makeExecutionControlsProps,
+  makeHost,
   makeThreadListEntry,
+  makeTypeaheadConfig,
 } from "../../.ladle/story-fixtures";
 import { RootComposeCompactHome } from "./RootComposeCompactHome";
 import { RootComposeMobileRecents } from "./RootComposeMobileRecents";
@@ -90,6 +108,61 @@ export const HOME_THREADS: ThreadListEntry[] = [
 
 export const MOBILE_RECENTS_VISIBILITY_CLASS = "bb-mobile-story-stage";
 
+const noop = () => {};
+
+const storyEnvironment: NewThreadEnvironmentConfig = {
+  value: `host:${HOST_IDS.local}:local`,
+  onChange: noop,
+  sources: STORY_PROJECT_SOURCES,
+  host: makeHost({ id: HOST_IDS.local }),
+  isLocal: true,
+};
+
+const storyBranch: NewThreadBranchConfig = {
+  value: null,
+  currentBranch: "main",
+  isNew: false,
+  options: STORY_BRANCH_OPTIONS,
+  loading: false,
+  currentOptionLabel: "Current: main",
+  placeholder: "Current checkout",
+  triggerLabel: "Current (main)",
+  triggerTitle: "Current: main",
+  onChange: noop,
+  onClear: noop,
+  onCreate: noop,
+};
+
+const storyWorktree: NewThreadWorktreeConfig = {
+  options: STORY_WORKTREE_OPTIONS,
+  value: null,
+  onChange: noop,
+};
+
+const storyProject: NewThreadProjectConfig = {
+  projects: STORY_PROJECTS,
+  value: PROJECT_IDS.bb,
+  onChange: noop,
+};
+
+const storyModeConfig = {
+  environment: storyEnvironment,
+  branch: storyBranch,
+  worktree: storyWorktree,
+  permission: {
+    value: "auto",
+    options: [
+      { value: "accept-edits", label: "Accept Edits" },
+      { value: "auto", label: "Approve for me" },
+      { value: "full", label: "Full Access", tone: "warning" },
+    ],
+    onChange: noop,
+    supported: true,
+  },
+} satisfies NewThreadModeConfig;
+
+const storyExecution = makeExecutionControlsProps();
+
 export function MobileRecentsVisibilityStyle() {
   return (
     <style>{`
@@ -103,16 +176,33 @@ export function MobileRecentsVisibilityStyle() {
 }
 
 export function StoryComposer() {
+  const [value, setValue] = useState("");
+  const [mentionRanges, setMentionRanges] = useState<PromptTextMention[]>([]);
   return (
-    <div className="rounded-xl border border-border bg-background shadow-lift">
-      <div className="px-3 pt-3 pb-8 text-sm text-muted-foreground">
-        Ask anything.
-      </div>
-      <div className="flex items-center justify-between px-3 pb-3">
-        <span className="size-6 rounded-md border border-border-seam" />
-        <span className="size-6 rounded-md bg-foreground/80" />
-      </div>
-    </div>
+    <ModelPickerStoryQueryProvider>
+      <NewThreadPromptBoxUI
+        id="story-compact-home-composer"
+        value={value}
+        mentionRanges={mentionRanges}
+        onChange={(nextValue, nextMentionRanges) => {
+          setValue(nextValue);
+          setMentionRanges(nextMentionRanges);
+        }}
+        onSubmit={noop}
+        isSubmitting={false}
+        disabled={false}
+        history={{
+          currentDraft: { text: "", mentions: [], attachments: [] },
+          entries: [],
+          onSelectEntry: noop,
+        }}
+        typeahead={makeTypeaheadConfig()}
+        attachments={makeAttachmentsConfig()}
+        modeConfig={storyModeConfig}
+        project={storyProject}
+        execution={storyExecution}
+      />
+    </ModelPickerStoryQueryProvider>
   );
 }
 

--- a/apps/app/src/views/mobile-home-story-fixtures.tsx
+++ b/apps/app/src/views/mobile-home-story-fixtures.tsx
@@ -1,0 +1,152 @@
+import type { ReactNode } from "react";
+import type { ThreadListEntry } from "@bb/domain";
+import {
+  PROJECT_IDS,
+  PROJECT_NAMES,
+  STORY_PROVIDERS_BY_ID,
+  makeThreadListEntry,
+} from "../../.ladle/story-fixtures";
+import { RootComposeCompactHome } from "./RootComposeCompactHome";
+import { RootComposeMobileRecents } from "./RootComposeMobileRecents";
+
+export const projectNamesById = new Map<string, string>([
+  [PROJECT_IDS.bb, PROJECT_NAMES.bb],
+  [PROJECT_IDS.pierre, PROJECT_NAMES.pierre],
+]);
+
+export const HOME_THREADS: ThreadListEntry[] = [
+  makeThreadListEntry({
+    id: "thr_home_parent",
+    title: "Rework folder model",
+    titleFallback: "Rework folder model",
+    latestAttentionAt: 900,
+  }),
+  makeThreadListEntry({
+    id: "thr_home_child_a",
+    parentThreadId: "thr_home_parent",
+    providerId: "claude-code",
+    title: "Audit folder query paths",
+    titleFallback: "Audit folder query paths",
+    latestAttentionAt: 880,
+  }),
+  makeThreadListEntry({
+    id: "thr_home_child_b",
+    parentThreadId: "thr_home_parent",
+    providerId: "acp-cursor",
+    title: "Migrate folder fixtures",
+    titleFallback: "Migrate folder fixtures",
+    latestAttentionAt: 870,
+  }),
+  makeThreadListEntry({
+    id: "thr_home_style",
+    providerId: "claude-code",
+    title: "Reduce style recalculation",
+    titleFallback: "Reduce style recalculation",
+    status: "starting",
+    latestAttentionAt: 860,
+    runtime: { displayStatus: "starting", hostReconnectGraceExpiresAt: null },
+  }),
+  makeThreadListEntry({
+    id: "thr_home_automations",
+    title: "Wire up automations CLI",
+    titleFallback: "Wire up automations CLI",
+    latestAttentionAt: 850,
+  }),
+  makeThreadListEntry({
+    id: "thr_home_daemon",
+    projectId: PROJECT_IDS.pierre,
+    providerId: "acp-cursor",
+    title: "Debug host daemon reconnect",
+    titleFallback: "Debug host daemon reconnect",
+    latestAttentionAt: 840,
+  }),
+  makeThreadListEntry({
+    id: "thr_home_theme",
+    title: "Ship theme preview panel",
+    titleFallback: "Ship theme preview panel",
+    latestAttentionAt: 830,
+  }),
+  makeThreadListEntry({
+    id: "thr_home_sidebar",
+    providerId: "claude-code",
+    title: "Trim sidebar re-renders",
+    titleFallback: "Trim sidebar re-renders",
+    latestAttentionAt: 820,
+  }),
+  makeThreadListEntry({
+    id: "thr_home_release",
+    title: "Draft release notes",
+    titleFallback: "Draft release notes",
+    latestAttentionAt: 810,
+  }),
+  makeThreadListEntry({
+    id: "thr_home_keyboard",
+    projectId: PROJECT_IDS.pierre,
+    title: "Fix mobile keyboard inset",
+    titleFallback: "Fix mobile keyboard inset",
+    latestAttentionAt: 800,
+  }),
+];
+
+export const MOBILE_RECENTS_VISIBILITY_CLASS = "bb-mobile-story-stage";
+
+export function MobileRecentsVisibilityStyle() {
+  return (
+    <style>{`
+      @media (min-width: 768px) {
+        .${MOBILE_RECENTS_VISIBILITY_CLASS} [data-root-compose-mobile-recents] {
+          display: block;
+        }
+      }
+    `}</style>
+  );
+}
+
+export function StoryComposer() {
+  return (
+    <div className="rounded-xl border border-border bg-background shadow-lift">
+      <div className="px-3 pt-3 pb-8 text-sm text-muted-foreground">
+        Ask anything.
+      </div>
+      <div className="flex items-center justify-between px-3 pb-3">
+        <span className="size-6 rounded-md border border-border-seam" />
+        <span className="size-6 rounded-md bg-foreground/80" />
+      </div>
+    </div>
+  );
+}
+
+export function HomeRecents({ threads }: { threads: ThreadListEntry[] }) {
+  return (
+    <RootComposeMobileRecents
+      highlightedThreadId={null}
+      projectNamesById={projectNamesById}
+      providersById={STORY_PROVIDERS_BY_ID}
+      showCreatingRow={false}
+      threads={threads}
+    />
+  );
+}
+
+export function CompactHomePage({
+  threads = HOME_THREADS,
+}: {
+  threads?: ThreadListEntry[];
+}) {
+  return (
+    <RootComposeCompactHome composer={<StoryComposer />}>
+      <HomeRecents threads={threads} />
+    </RootComposeCompactHome>
+  );
+}
+
+export function PhoneFrame({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className={`${MOBILE_RECENTS_VISIBILITY_CLASS} flex h-[852px] w-[393px] min-h-0 flex-col overflow-hidden rounded-xl border border-border bg-background`}
+    >
+      <MobileRecentsVisibilityStyle />
+      {children}
+    </div>
+  );
+}

--- a/apps/app/src/views/thread-detail/SplitWorkspaceSecondaryPanelHost.tsx
+++ b/apps/app/src/views/thread-detail/SplitWorkspaceSecondaryPanelHost.tsx
@@ -33,7 +33,7 @@ import {
   SecondaryPanelHostLayoutContext,
   type SecondaryPanelHostLayout,
 } from "@/components/secondary-panel/SecondaryPanelHostLayoutContext";
-import { useRightPanelToggleIconName } from "@/components/secondary-panel/panelToggleControlState";
+import { RIGHT_PANEL_TOGGLE_ICON_NAME } from "@/components/secondary-panel/panelToggleControlState";
 import {
   getPanelCollapseTransitionStyle,
   PANEL_COLLAPSE_TRANSITION_CLASS,
@@ -181,7 +181,7 @@ export function SplitWorkspaceSecondaryPanelHost({
   };
 
   const toggleLabel = isOpen ? "Hide right panel" : "Show right panel";
-  const toggleIconName = useRightPanelToggleIconName();
+  const toggleIconName = RIGHT_PANEL_TOGGLE_ICON_NAME;
   const showsCornerToggle = !isPaneMaximized && !(isOpen && model !== null);
   const pinsCornerToggle = showsCornerToggle && !isOpen;
   const hostLayout = useMemo<SecondaryPanelHostLayout>(

--- a/apps/app/src/views/thread-detail/ThreadDetailHeader.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailHeader.test.tsx
@@ -100,7 +100,7 @@ describe("ThreadDetailHeader", () => {
   });
 
   it.each([
-    { expectedIcon: "PanelBottom", isCompactViewport: true },
+    { expectedIcon: "PanelRight", isCompactViewport: true },
     { expectedIcon: "PanelRight", isCompactViewport: false },
   ])(
     "shows the $expectedIcon glyph on the right-panel trigger",

--- a/apps/app/src/views/thread-detail/ThreadDetailHeader.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailHeader.tsx
@@ -12,7 +12,6 @@ import { useAtomValue } from "jotai";
 import { COARSE_POINTER_TOOLBAR_ACTION_BUTTON_CLASS } from "@bb/shared-ui/coarse-pointer-sizing";
 import { Icon } from "@bb/shared-ui/icon";
 import { Pill } from "@bb/shared-ui/pill";
-import { useIsCompactViewport } from "@bb/shared-ui/hooks/use-compact-viewport";
 import { SplitButton } from "@/components/ui/split-button.js";
 import {
   AppPageHeader,
@@ -89,7 +88,6 @@ export function ThreadDetailHeader({
     resetKey: threadId,
     title: threadTitle,
   });
-  const renderAsDrawer = useIsCompactViewport();
   const [desktopInfo] = useState(getBbDesktopInfo);
   const dimsInactiveSplits = useAtomValue(dimInactiveSplitsAtom);
   const panelShortcut = useAppCommandShortcut("panel.toggle");

--- a/apps/app/src/views/thread-detail/ThreadDetailHeader.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailHeader.tsx
@@ -32,7 +32,7 @@ import { useInlineThreadTitle } from "@/components/thread/InlineThreadTitle";
 import { useThreadActions } from "@/components/thread/ThreadActionsProvider";
 import { ThreadTitleMentions } from "@/components/thread/ThreadTitleMentions";
 import { SecondaryPanelHostLayoutContext } from "@/components/secondary-panel/SecondaryPanelHostLayoutContext";
-import { getRightPanelToggleIconName } from "@/components/secondary-panel/panelToggleControlState";
+import { RIGHT_PANEL_TOGGLE_ICON_NAME } from "@/components/secondary-panel/panelToggleControlState";
 import { CHROME_SUBTLE_ICON_BUTTON_FOREGROUND_CLASS } from "@bb/shared-ui/chrome-style-tokens";
 import { dimInactiveSplitsAtom } from "@/lib/split-layout/atoms";
 import {
@@ -147,7 +147,7 @@ export function ThreadDetailHeader({
   const rightPanelLabel = isSecondaryPanelOpen
     ? "Hide right panel"
     : "Show right panel";
-  const rightPanelIconName = getRightPanelToggleIconName(renderAsDrawer);
+  const rightPanelIconName = RIGHT_PANEL_TOGGLE_ICON_NAME;
   const showRightPanelToggle =
     secondaryPanelHost === null && !isSecondaryPanelOpen;
 

--- a/apps/server/src/routes/system.ts
+++ b/apps/server/src/routes/system.ts
@@ -285,7 +285,13 @@ export function registerSystemRoutes(
     const providerId = context.req.param("id");
     const registration = deps.providerRegistry.get(providerId);
     if (registration?.icon !== undefined) {
-      return pluginImageResponse(context, registration.icon, "no-store");
+      return pluginImageResponse(
+        context,
+        registration.icon,
+        context.req.query("h") === registration.icon.hash
+          ? "public, max-age=31536000, immutable"
+          : "no-store",
+      );
     }
     throw new ApiError(
       404,

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -559,8 +559,10 @@ export function createApp(
       ),
     callPluginHost: (args) => callPluginHostRpc(deps, args),
     disposePluginHost: (args) => disposePluginHostWorkers(deps, args),
-    onSettingsChanged: (pluginId) =>
-      deps.providerNativeRoots.invalidate(pluginId),
+    onSettingsChanged: (pluginId) => {
+      deps.providerNativeRoots.invalidate(pluginId);
+      deps.providerRegistry.forgetInstalled();
+    },
     watchBuiltinPluginSources:
       process.env.BB_MANAGED_DEV_BUILTIN_PLUGIN_HOT_RELOAD === "1",
   });

--- a/apps/server/src/services/plugins/app-bundle.ts
+++ b/apps/server/src/services/plugins/app-bundle.ts
@@ -73,7 +73,7 @@ export interface PluginBrandingAssetSet {
   icons: ReadonlyMap<string, PluginBrandingAssetSnapshot>;
 }
 
-function brandingAssetHash(bytes: Uint8Array): string {
+export function brandingAssetHash(bytes: Uint8Array): string {
   return createHash("sha256").update(bytes).digest("hex").slice(0, 16);
 }
 

--- a/apps/server/src/services/plugins/plugin-runtime.ts
+++ b/apps/server/src/services/plugins/plugin-runtime.ts
@@ -45,6 +45,7 @@ import {
 } from "@bb/db";
 import { toThreadResponseFromThread } from "../threads/thread-runtime-display.js";
 import {
+  brandingAssetHash,
   loadPluginAppBundle,
   loadPluginBrandingAssets,
   parsePluginAppBundleMeta,
@@ -166,7 +167,7 @@ const PROVIDER_ICON_CONTENT_TYPES: Record<string, string> = {
 export function readPluginProviderIcon(
   rootDir: string,
   icon: string | undefined,
-): { bytes: Uint8Array; contentType: string } | null {
+): { bytes: Uint8Array; contentType: string; hash: string } | null {
   if (icon === undefined || !isPluginOwnedIconPath(icon)) {
     return null;
   }
@@ -180,7 +181,8 @@ export function readPluginProviderIcon(
     return null;
   }
   try {
-    return { bytes: new Uint8Array(readFileSync(resolved)), contentType };
+    const bytes = new Uint8Array(readFileSync(resolved));
+    return { bytes, contentType, hash: brandingAssetHash(bytes) };
   } catch {
     return null;
   }
@@ -1102,7 +1104,7 @@ export function createPluginRuntime(context: PluginRuntimeContext) {
       args.declaration.icon === undefined
         ? null
         : parseNamespacedGlyph(args.declaration.icon);
-    let icon: { bytes: Uint8Array; contentType: string } | null;
+    let icon: { bytes: Uint8Array; contentType: string; hash: string } | null;
     if (declaredIcon !== null) {
       const asset =
         declaredIcon.pluginId === args.row.id
@@ -1113,7 +1115,11 @@ export function createPluginRuntime(context: PluginRuntimeContext) {
           `provider "${args.declaration.id}" icon "${args.declaration.icon}" is not an icon declared by plugin "${args.row.id}"`,
         );
       }
-      icon = { bytes: asset.bytes, contentType: asset.contentType };
+      icon = {
+        bytes: asset.bytes,
+        contentType: asset.contentType,
+        hash: asset.hash,
+      };
     } else {
       icon = readPluginProviderIcon(args.row.rootDir, args.declaration.icon);
     }
@@ -1122,6 +1128,7 @@ export function createPluginRuntime(context: PluginRuntimeContext) {
         available: args.available,
         pluginId: args.row.id,
         declaration: args.declaration,
+        iconHash: icon?.hash ?? null,
         readSettings: () =>
           readPluginSettingsValuesSync({
             db: deps.db,

--- a/apps/server/src/services/providers/plugin-provider-registration.ts
+++ b/apps/server/src/services/providers/plugin-provider-registration.ts
@@ -109,10 +109,19 @@ export function projectFallbackModels(
   }));
 }
 
+function buildProviderLogoUrl(
+  providerId: string,
+  iconHash: string | null,
+): string {
+  const path = `/api/v1/system/providers/${providerId}/logo`;
+  return iconHash === null ? path : `${path}?h=${iconHash}`;
+}
+
 export function buildPluginProviderRegistration(args: {
   available: boolean;
   pluginId: string;
   declaration: NormalizedPluginProviderDeclaration;
+  iconHash: string | null;
   readSettings: () => PluginProviderOptionsContext["settings"];
 }): Omit<ProviderRegistration, "pluginId" | "iconNames"> {
   const { declaration } = args;
@@ -157,7 +166,7 @@ export function buildPluginProviderRegistration(args: {
       declaration.icon !== undefined &&
       (isPluginOwnedIconPath(declaration.icon) ||
         isNamespacedGlyph(declaration.icon))
-        ? `/api/v1/system/providers/${declaration.id}/logo`
+        ? buildProviderLogoUrl(declaration.id, args.iconHash)
         : null,
     ...(declaration.icon !== undefined &&
     !isPluginOwnedIconPath(declaration.icon) &&

--- a/apps/server/src/services/providers/provider-health-cache.ts
+++ b/apps/server/src/services/providers/provider-health-cache.ts
@@ -1,0 +1,6 @@
+export function providerHealthCacheKey(args: {
+  hostId: string;
+  providerId: string;
+}): string {
+  return `${args.hostId} ${args.providerId}`;
+}

--- a/apps/server/src/services/providers/provider-registry.ts
+++ b/apps/server/src/services/providers/provider-registry.ts
@@ -49,11 +49,22 @@ export interface ProviderRegistration {
   iconNames: ReadonlySet<string>;
 }
 
+const PROVIDER_INSTALLED_CACHE_TTL_MS = 5 * 60_000;
+
 export interface ProviderRegistryService {
   list(): ProviderRegistration[];
   getUserDefaultProviderId(): string | null;
   get(providerId: string): ProviderRegistration | null;
   getRegistrationRevision(): number;
+  /**
+   * Installed-state answer for a provider on a host, cached against the
+   * registration revision. Probing costs a host RPC that spawns the provider
+   * bridge (~3s measured), and the provider list runs one per installed
+   * provider on every request.
+   */
+  lookupInstalled(key: string): Promise<boolean> | undefined;
+  rememberInstalled(key: string, value: Promise<boolean>): void;
+  forgetInstalled(providerId?: string): void;
   getServerCapabilities(providerId: string): ProviderServerCapabilities | null;
   getSupportedPermissionModes(
     providerId: string,
@@ -94,6 +105,15 @@ export function createProviderRegistryService(
   >();
   const providerRegistrationWaiters = new Map<string, Set<() => void>>();
   let registrationRevision = 0;
+  const installedByKey = new Map<
+    string,
+    {
+      providerId: string;
+      registrationRevision: number;
+      expiresAt: number;
+      value: Promise<boolean>;
+    }
+  >();
   let registrationSequence = 0;
 
   function compareInstallRank(
@@ -199,6 +219,38 @@ export function createProviderRegistryService(
 
     getRegistrationRevision() {
       return registrationRevision;
+    },
+
+    lookupInstalled(key) {
+      const entry = installedByKey.get(key);
+      if (entry === undefined) return undefined;
+      if (
+        entry.registrationRevision !== registrationRevision ||
+        entry.expiresAt <= Date.now()
+      ) {
+        installedByKey.delete(key);
+        return undefined;
+      }
+      return entry.value;
+    },
+
+    rememberInstalled(key, value) {
+      installedByKey.set(key, {
+        providerId: key.slice(key.indexOf(" ") + 1),
+        registrationRevision,
+        expiresAt: Date.now() + PROVIDER_INSTALLED_CACHE_TTL_MS,
+        value,
+      });
+    },
+
+    forgetInstalled(providerId) {
+      if (providerId === undefined) {
+        installedByKey.clear();
+        return;
+      }
+      for (const [key, entry] of installedByKey) {
+        if (entry.providerId === providerId) installedByKey.delete(key);
+      }
     },
 
     getServerCapabilities(providerId) {

--- a/apps/server/src/services/providers/provider-registry.ts
+++ b/apps/server/src/services/providers/provider-registry.ts
@@ -45,7 +45,7 @@ export interface ProviderRegistration {
   deriveProviderOptions: (
     context: Omit<PluginProviderOptionsContext, "settings">,
   ) => Readonly<Record<string, JsonValue>>;
-  icon?: { bytes: Uint8Array; contentType: string };
+  icon?: { bytes: Uint8Array; contentType: string; hash: string };
   iconNames: ReadonlySet<string>;
 }
 

--- a/apps/server/src/services/system/execution-options.ts
+++ b/apps/server/src/services/system/execution-options.ts
@@ -23,6 +23,7 @@ import { getHostPermissionCeiling } from "../hosts/permission-ceiling.js";
 import { requireEnvironment } from "../lib/entity-lookup.js";
 import { createProviderListingBudget } from "../providers/native-roots.js";
 import type { ProviderRegistryService } from "../providers/provider-registry.js";
+import { providerHealthCacheKey } from "../providers/provider-health-cache.js";
 import { getSupportedReasoningLevelsForProvider } from "../threads/thread-reasoning-policy.js";
 import { resolveSystemLookupHostId } from "./host-lookup.js";
 import {
@@ -180,20 +181,31 @@ async function listInstalledPluginProviderInfos(
         registration.info.id,
       );
       if (bridgeLaunch === null) return null;
+      const cacheKey = providerHealthCacheKey({
+        hostId,
+        providerId: registration.info.id,
+      });
+      const cached = deps.providerRegistry.lookupInstalled(cacheKey);
+      if (cached !== undefined) {
+        return (await cached) ? registration.info : null;
+      }
       try {
-        const result = await callHostRetryableOnlineRpc(deps, {
-          hostId,
-          timeoutMs: budget.remainingMs(),
-          command: {
-            type: "provider.health",
-            providerId: registration.info.id,
-            bridgeLaunch,
-          },
-        });
-        return result.supported && result.health.status !== "not_installed"
-          ? registration.info
-          : null;
+        const installed = (async () => {
+          const result = await callHostRetryableOnlineRpc(deps, {
+            hostId,
+            timeoutMs: budget.remainingMs(),
+            command: {
+              type: "provider.health",
+              providerId: registration.info.id,
+              bridgeLaunch,
+            },
+          });
+          return result.supported && result.health.status !== "not_installed";
+        })();
+        deps.providerRegistry.rememberInstalled(cacheKey, installed);
+        return (await installed) ? registration.info : null;
       } catch (error) {
+        deps.providerRegistry.forgetInstalled(registration.info.id);
         if (!canOmitProviderDiscoveryForError(error)) {
           throw error;
         }

--- a/apps/server/test/helpers/provider-registry.ts
+++ b/apps/server/test/helpers/provider-registry.ts
@@ -76,7 +76,7 @@ function providerIconSnapshot(args: {
   pluginId: string;
   icon: string | undefined;
   icons: ReadonlyMap<string, string>;
-}): { bytes: Uint8Array; contentType: string } | null {
+}): { bytes: Uint8Array; contentType: string; hash: string } | null {
   const namespaced =
     args.icon === undefined ? null : parseNamespacedGlyph(args.icon);
   const asset =
@@ -122,6 +122,7 @@ export async function registerFirstPartyProviders(
           available: !unavailable.has(pluginId),
           pluginId,
           declaration,
+          iconHash: null,
           readSettings: NO_PLUGIN_SETTINGS,
         }),
         ...(icon === null ? {} : { icon }),
@@ -293,6 +294,7 @@ export async function registerFakeProviders(
     const pluginId = `provider-${providerId}`;
     registry.register({
       ...buildPluginProviderRegistration({
+        iconHash: null,
         available: true,
         pluginId,
         declaration: validatePluginProviderDeclaration({
@@ -366,6 +368,7 @@ export async function registerConfiguredAcpProvider(
         available: true,
         pluginId,
         declaration,
+        iconHash: null,
         readSettings: NO_PLUGIN_SETTINGS,
       }),
       pluginId,

--- a/apps/server/test/helpers/test-app.ts
+++ b/apps/server/test/helpers/test-app.ts
@@ -157,6 +157,7 @@ export async function createTestAppHarness(
         available: true,
         pluginId: extra.pluginId,
         declaration: validatePluginProviderDeclaration(extra.declaration),
+        iconHash: null,
         readSettings: () => ({}),
       }),
       pluginId: extra.pluginId,

--- a/apps/server/test/internal/internal-extension-payloads.test.ts
+++ b/apps/server/test/internal/internal-extension-payloads.test.ts
@@ -43,6 +43,7 @@ function registerExtensionProvider(
 ) {
   harness.deps.providerRegistry.register({
     ...buildPluginProviderRegistration({
+      iconHash: null,
       available: true,
       pluginId: args.pluginId,
       declaration: validatePluginProviderDeclaration({

--- a/apps/server/test/internal/internal-presentation-icons.test.ts
+++ b/apps/server/test/internal/internal-presentation-icons.test.ts
@@ -28,6 +28,7 @@ async function setup() {
   const harness = await createTestAppHarness();
   harness.deps.providerRegistry.register({
     ...buildPluginProviderRegistration({
+      iconHash: null,
       available: true,
       pluginId: PLUGIN_ID,
       declaration: validatePluginProviderDeclaration({

--- a/apps/server/test/providers/plugin-provider-registration.test.ts
+++ b/apps/server/test/providers/plugin-provider-registration.test.ts
@@ -41,6 +41,7 @@ describe("buildPluginProviderRegistration", () => {
       available: true,
       pluginId: "acme-agent",
       declaration: normalized,
+      iconHash: null,
       readSettings: NO_SETTINGS,
     });
 
@@ -106,6 +107,7 @@ describe("buildPluginProviderRegistration", () => {
 
   it("projects the target-state declaration fields onto ProviderInfo", () => {
     const registration = buildPluginProviderRegistration({
+      iconHash: null,
       available: true,
       pluginId: "acme-agent",
       declaration: declaration({
@@ -160,6 +162,7 @@ describe("buildPluginProviderRegistration", () => {
 
   it("binds the options hook to the plugin's settings and validates its result", () => {
     const registration = buildPluginProviderRegistration({
+      iconHash: null,
       available: true,
       pluginId: "acme-agent",
       declaration: declaration({
@@ -218,6 +221,7 @@ describe("buildPluginProviderRegistration", () => {
 
   it("refuses a hook result that is not bounded plain JSON", () => {
     const registration = buildPluginProviderRegistration({
+      iconHash: null,
       available: true,
       pluginId: "acme-agent",
       declaration: declaration({
@@ -240,6 +244,7 @@ describe("buildPluginProviderRegistration", () => {
   it("projects each fork ladder rung onto the two client booleans", () => {
     const projection = (fork: "none" | "tip" | "checkpoint") => {
       const { capabilities } = buildPluginProviderRegistration({
+        iconHash: null,
         available: true,
         pluginId: "acme-agent",
         declaration: declaration({
@@ -268,6 +273,7 @@ describe("buildPluginProviderRegistration", () => {
 
   it("maps an icon-less declaration to a null logoUrl and skills-only actions", () => {
     const registration = buildPluginProviderRegistration({
+      iconHash: null,
       available: true,
       pluginId: "acme-plain",
       declaration: declaration({
@@ -295,6 +301,7 @@ describe("buildPluginProviderRegistration", () => {
       available: true,
       pluginId: "echo-provider",
       declaration: declaration({ id: "echo-agent", icon: "Zap" }),
+      iconHash: null,
       readSettings: NO_SETTINGS,
     });
     expect(glyph.info.icon).toStrictEqual({ glyph: "Zap" });
@@ -304,6 +311,7 @@ describe("buildPluginProviderRegistration", () => {
       available: true,
       pluginId: "acme-agent",
       declaration: declaration({ icon: "./icons/agent.svg" }),
+      iconHash: null,
       readSettings: NO_SETTINGS,
     });
     expect(path.info.icon).toBeUndefined();
@@ -320,6 +328,7 @@ describe("buildPluginProviderRegistration", () => {
           available: true,
           pluginId,
           declaration: declared,
+          iconHash: null,
           readSettings: NO_SETTINGS,
         });
         return { id: info.id, logoUrl: info.logoUrl, icon: info.icon };

--- a/apps/server/test/providers/provider-registry.test.ts
+++ b/apps/server/test/providers/provider-registry.test.ts
@@ -326,3 +326,51 @@ describe("provider registry", () => {
     expect(registry.get("acp-opencode")).not.toBeNull();
   });
 });
+
+describe("installed-state cache", () => {
+  it("serves a remembered answer and dedupes concurrent probes", async () => {
+    const registry = createProviderRegistryService({});
+    registerProvider(registry, "codex", "provider-codex");
+    const key = "host_1 codex";
+
+    expect(registry.lookupInstalled(key)).toBeUndefined();
+
+    let probes = 0;
+    const probe = () => {
+      probes += 1;
+      return Promise.resolve(true);
+    };
+    const inFlight = probe();
+    registry.rememberInstalled(key, inFlight);
+
+    expect(await registry.lookupInstalled(key)).toBe(true);
+    expect(await registry.lookupInstalled(key)).toBe(true);
+    expect(probes).toBe(1);
+  });
+
+  it("drops the answer when the registration revision moves", async () => {
+    const registry = createProviderRegistryService({});
+    registerProvider(registry, "codex", "provider-codex");
+    const key = "host_1 codex";
+    registry.rememberInstalled(key, Promise.resolve(true));
+    expect(await registry.lookupInstalled(key)).toBe(true);
+
+    registerProvider(registry, "claude-code", "provider-claude-code");
+
+    expect(registry.lookupInstalled(key)).toBeUndefined();
+  });
+
+  it("forgets one provider or all of them", async () => {
+    const registry = createProviderRegistryService({});
+    registerProvider(registry, "codex", "provider-codex");
+    registry.rememberInstalled("host_1 codex", Promise.resolve(true));
+    registry.rememberInstalled("host_1 pi", Promise.resolve(false));
+
+    registry.forgetInstalled("codex");
+    expect(registry.lookupInstalled("host_1 codex")).toBeUndefined();
+    expect(await registry.lookupInstalled("host_1 pi")).toBe(false);
+
+    registry.forgetInstalled();
+    expect(registry.lookupInstalled("host_1 pi")).toBeUndefined();
+  });
+});

--- a/apps/server/test/public/public-provider-installations.test.ts
+++ b/apps/server/test/public/public-provider-installations.test.ts
@@ -27,6 +27,7 @@ function registerInstallationProviders(
     const pluginId = `provider-${providerId}`;
     harness.deps.providerRegistry.register({
       ...buildPluginProviderRegistration({
+        iconHash: null,
         available: true,
         pluginId,
         declaration: validatePluginProviderDeclaration({

--- a/apps/server/test/services/plugins/first-party-provider-plugins.test.ts
+++ b/apps/server/test/services/plugins/first-party-provider-plugins.test.ts
@@ -119,8 +119,15 @@ const ALWAYS_VISIBLE_PROVIDER_IDS = FIRST_PARTY_PROVIDER_DECLARATIONS.filter(
   (plugin) => plugin.visibility === "always",
 ).map((plugin) => plugin.providerId);
 
-function expectedLogoUrl(providerId: string): string {
-  return `/api/v1/system/providers/${providerId}/logo`;
+function expectedLogoUrl(
+  registry: TestAppHarness["deps"]["providerRegistry"],
+  providerId: string,
+): string {
+  const hash = registry.get(providerId)?.icon?.hash;
+  if (hash === undefined) {
+    throw new Error(`${providerId} registered no icon hash`);
+  }
+  return `/api/v1/system/providers/${providerId}/logo?h=${hash}`;
 }
 
 async function installFirstPartyProviderPlugins(
@@ -161,7 +168,9 @@ describe("first-party provider plugins", () => {
           expect(registration.pluginId, label).toBe(plugin.pluginId);
           expect(registration.info.displayName, label).toBe(plugin.displayName);
           expect(registration.info.logoUrl, label).toBe(
-            plugin.hasLogo ? expectedLogoUrl(plugin.providerId) : null,
+            plugin.hasLogo
+              ? expectedLogoUrl(registry, plugin.providerId)
+              : null,
           );
           expect(registration.icon !== undefined, label).toBe(plugin.hasLogo);
           expect(registration.visibility, label).toBe(plugin.visibility);
@@ -191,7 +200,9 @@ describe("first-party provider plugins", () => {
           ALWAYS_VISIBLE_PROVIDER_IDS,
         );
         expect(infos.map((info) => info.logoUrl)).toEqual(
-          ALWAYS_VISIBLE_PROVIDER_IDS.map(expectedLogoUrl),
+          ALWAYS_VISIBLE_PROVIDER_IDS.map((providerId) =>
+            expectedLogoUrl(registry, providerId),
+          ),
         );
         expect(
           infos.map((info) => [info.id, info.capabilities.supportsFork]),
@@ -244,7 +255,7 @@ describe("first-party provider plugins", () => {
         expect(clientFields("codex")).toStrictEqual({
           id: "codex",
           displayName: "Codex",
-          logoUrl: expectedLogoUrl("codex"),
+          logoUrl: expectedLogoUrl(harness.deps.providerRegistry, "codex"),
           available: true,
           maintenance: { health: true, usage: true, installation: true },
           capabilities: {
@@ -262,7 +273,10 @@ describe("first-party provider plugins", () => {
         expect(clientFields("claude-code")).toStrictEqual({
           id: "claude-code",
           displayName: "Claude Code",
-          logoUrl: expectedLogoUrl("claude-code"),
+          logoUrl: expectedLogoUrl(
+            harness.deps.providerRegistry,
+            "claude-code",
+          ),
           available: true,
           maintenance: { health: true, usage: true, installation: true },
           capabilities: {
@@ -280,7 +294,7 @@ describe("first-party provider plugins", () => {
         expect(clientFields("pi")).toStrictEqual({
           id: "pi",
           displayName: "Pi",
-          logoUrl: expectedLogoUrl("pi"),
+          logoUrl: expectedLogoUrl(harness.deps.providerRegistry, "pi"),
           available: true,
           maintenance: { health: true, usage: false, installation: true },
           capabilities: {
@@ -298,7 +312,7 @@ describe("first-party provider plugins", () => {
         expect(clientFields("acp-cursor")).toStrictEqual({
           id: "acp-cursor",
           displayName: "Cursor",
-          logoUrl: expectedLogoUrl("acp-cursor"),
+          logoUrl: expectedLogoUrl(harness.deps.providerRegistry, "acp-cursor"),
           available: true,
           maintenance: { health: true, usage: true, installation: true },
           capabilities: {

--- a/apps/server/test/services/plugins/plugin-icons.test.ts
+++ b/apps/server/test/services/plugins/plugin-icons.test.ts
@@ -348,8 +348,10 @@ describe("plugin-declared icons", () => {
     expect(entry.status, entry.statusDetail ?? "").toBe("running");
 
     const registration = harness.deps.providerRegistry.get("marked-agent");
+    const iconHash = registration?.icon?.hash;
+    expect(iconHash).toBeTypeOf("string");
     expect(registration?.info.logoUrl).toBe(
-      "/api/v1/system/providers/marked-agent/logo",
+      `/api/v1/system/providers/marked-agent/logo?h=${iconHash}`,
     );
     expect(registration?.info.icon).toBeUndefined();
     expect(registration?.iconNames).toEqual(new Set(["agent"]));
@@ -365,6 +367,20 @@ describe("plugin-declared icons", () => {
     );
     expect(logo.headers.get("cache-control")).toBe("no-store");
     expect(await logo.text()).toBe(SVG);
+
+    const hashedLogo = await harness.app.request(
+      `${BASE}/api/v1/system/providers/marked-agent/logo?h=${iconHash}`,
+    );
+    expect(hashedLogo.status).toBe(200);
+    expect(hashedLogo.headers.get("cache-control")).toBe(
+      "public, max-age=31536000, immutable",
+    );
+    expect(await hashedLogo.text()).toBe(SVG);
+
+    const staleLogo = await harness.app.request(
+      `${BASE}/api/v1/system/providers/marked-agent/logo?h=stale`,
+    );
+    expect(staleLogo.headers.get("cache-control")).toBe("no-store");
   });
 
   it("fails the load when a provider icon names an icon the plugin did not declare", async () => {

--- a/apps/server/test/threads/thread-runtime-config.test.ts
+++ b/apps/server/test/threads/thread-runtime-config.test.ts
@@ -900,6 +900,7 @@ describe("thread runtime config", () => {
     await withTestHarness(async (harness) => {
       const pluginId = "provider-hooked";
       const registration = buildPluginProviderRegistration({
+        iconHash: null,
         available: true,
         pluginId,
         declaration: validatePluginProviderDeclaration({


### PR DESCRIPTION
## Human comments

## What was wrong

The compact home put a capped three-thread Recent list below the composer in one page scroller, so the composer moved away from the thumb, the list did not signal additional content, and thread rows omitted provider, hierarchy, worktree, branch, and activity context. Both compact side surfaces behaved as overlays: the left navigation drawer covered and dimmed the page, while the right panel rose as a bottom drawer. Cold thread navigation could begin with missing metadata, route transitions had no pending affordance, and provider discovery repeated seconds-long host probes and uncached logo work.

## What changed

- Compact home now anchors the production composer at the bottom while realistic recent-thread rows scroll behind it. A partial row signals more content and the `Recent` label stays pinned to the scroll viewport.
- Recent rows use production provider marks, parent/child hierarchy, status, project/worktree/branch metadata, and attention-time ordering.
- The compact left navigation becomes a 76vw shelf: the live page translates right, keeps its state, and remains undimmed instead of being covered by an overlay.
- The compact right panel moves from the bottom drawer to a right-side shelf: the live page translates left and remains visible. Layer 2 builds on this shelf for full-page tool tabs.
- Slow navigation now gets delayed, minimum-duration route feedback; cold thread boots reuse persisted sidebar metadata instead of beginning blank.
- Provider installed-state is cached for five minutes instead of re-probing provider bridges on every list, and hashed provider logos use immutable content-addressed URLs.
- Ladle renders the real `NewThreadPromptBoxUI` inside the real compact-home composition with populated production fixtures.

No wire changes; `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

## Screenshots

Chrome for Testing 151.0.7922.71, 393×852 at DPR 2, using the same seeded project, thread data, route, viewport, and settled-content state. Before is the merge base (`f4bbc2fe8`); after is this PR head (`04d18307f`).

| Before — composer occupies the top and Recent ends after three sparse rows | After — realistic recents scroll behind a bottom-anchored production composer |
| --- | --- |
| <img src="https://gist.githubusercontent.com/brsbl/d8363c420a5e5c2167498079a27162f0/raw/5904f796578a5112b80ec007db7176bfd8fb83d4/layer1-before.svg" width="393"> | <img src="https://gist.githubusercontent.com/brsbl/d8363c420a5e5c2167498079a27162f0/raw/e76f5d7672735517d6bb6040bfd7a695be6d5657/layer1-after.svg" width="393"> |

### Sticky header while scrolled

At the PR head, the compact-home viewport is scrolled to `scrollTop=360`. The `Recent` header remains exactly at the viewport top while rows continue underneath and the composer remains anchored at the bottom.

<img src="https://gist.githubusercontent.com/brsbl/d8363c420a5e5c2167498079a27162f0/raw/719970d4e7b583c61fdd66cd556673c357e541fe/layer1-sticky.svg" width="393">

## How you verified

- The exact-revision branch web app was driven from first paint through settled content in Chrome for Testing. The compact-home root measured 393×852 and the production composer measured 361×128 at the bottom.
- After scrolling, the compact-home viewport measured `top=318`, `height=534`, `scrollTop=360`; the production `Recent` header measured `top=318`, proving it remained pinned to its own scroll viewport rather than the document body.
- Ladle was restarted on port 61002. Compact Home renders two real production prompt boxes, each 359×128, inside non-zero 391×850 compact-home roots; the composer remains bottom-aligned after scrolling.
- Mobile Recents renders five real component subtrees with row counts `3, 2, 5, 3, 3`, provider glyphs for every row, and a working hierarchy collapse from five rows to two.
- Every affected story ID was loaded and measured through its production component subtree with zero runtime exceptions. All remote CI gates pass; no local CI-equivalent command was run.

The soft-keyboard rise still requires a real coarse-pointer device, and provider logo URLs require the bb server rather than standalone Ladle.

BB-Thread-ID: thr_wftu7bh9ez

> AGENT GENERATED
