### PR TITLE
Add Plugin Guide entry to My Plugins

### DIFF
--- a/apps/app/src/components/plugin/PluginsOverview.tsx
+++ b/apps/app/src/components/plugin/PluginsOverview.tsx
@@ -32,6 +32,7 @@ import { BrowsePluginsTab } from "@/components/plugin/management/BrowsePluginsTa
 import { CheckPluginUpdatesButton } from "@/components/plugin/management/CheckPluginUpdatesButton";
 import { InstalledPluginsTab } from "@/components/plugin/management/InstalledPluginsTab";
 import { MyPluginsTab } from "@/components/plugin/management/MyPluginsTab";
+import { OpenPluginGuideButton } from "@/components/plugin/management/OpenPluginGuideButton";
 import {
   PLUGIN_SOURCE_FILTER_OPTIONS,
   pluginSourceFilterId,
@@ -76,6 +77,7 @@ export function PluginsOverview({
     () => listQuery.data?.plugins ?? [],
     [listQuery.data?.plugins],
   );
+  const pluginGuide = plugins.find((plugin) => plugin.id === "plugin-api-docs");
   const activeMode = modeFromSearchParams(searchParams.get("view"));
   const [installedQuery, setInstalledQuery] = useState("");
   const [installedViewport, setInstalledViewport] =
@@ -366,6 +368,16 @@ export function PluginsOverview({
       <ResourceCollectionViewport
         scrollId="my-plugins-results"
         bandClassName={TOOLS_PAGE_BAND_CLASSES}
+        toolbar={
+          <div className="flex justify-end">
+            <OpenPluginGuideButton
+              plugin={pluginGuide}
+              pluginListLoading={
+                listQuery.data === undefined && listQuery.isFetching
+              }
+            />
+          </div>
+        }
       >
         <div className={cn("space-y-3", TOOLS_PAGE_BAND_CLASSES)}>
           <MyPluginsTab

--- a/apps/app/src/components/plugin/management/OpenPluginGuideButton.tsx
+++ b/apps/app/src/components/plugin/management/OpenPluginGuideButton.tsx
@@ -1,0 +1,130 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { MapsIcon, MapsLocation02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useNavigate } from "react-router-dom";
+import { Button } from "@bb/shared-ui/button";
+import { Icon } from "@bb/shared-ui/icon";
+import { appToast } from "@/components/ui/app-toast";
+import { invalidatePluginList } from "@/hooks/cache-owners/plugin-cache-owner";
+import {
+  setPluginEnabled,
+  type PluginListItem,
+} from "@/hooks/queries/plugin-settings-queries";
+import { schedulePluginFrontendReconcile } from "@/lib/plugin-frontend-lazy";
+import {
+  getPluginSlotSnapshot,
+  subscribePluginSlots,
+} from "@/lib/plugin-slots";
+import { getPluginPanelRoutePath } from "@/lib/route-paths";
+
+const PLUGIN_GUIDE_ID = "plugin-api-docs";
+const PLUGIN_GUIDE_PANEL_PATH = "plugin-api";
+const PLUGIN_GUIDE_LOAD_TIMEOUT_MS = 10_000;
+
+function isPluginGuidePanelRegistered(): boolean {
+  return getPluginSlotSnapshot().navPanels.some(
+    (panel) =>
+      panel.pluginId === PLUGIN_GUIDE_ID &&
+      panel.path === PLUGIN_GUIDE_PANEL_PATH,
+  );
+}
+
+function waitForPluginGuidePanel(): Promise<void> {
+  if (isPluginGuidePanelRegistered()) return Promise.resolve();
+
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const unsubscribe = subscribePluginSlots(() => {
+      if (!isPluginGuidePanelRegistered() || settled) return;
+      settled = true;
+      window.clearTimeout(timeoutId);
+      unsubscribe();
+      resolve();
+    });
+    const timeoutId = window.setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      unsubscribe();
+      reject(new Error("The guide did not finish loading. Try again."));
+    }, PLUGIN_GUIDE_LOAD_TIMEOUT_MS);
+
+    if (isPluginGuidePanelRegistered()) {
+      settled = true;
+      window.clearTimeout(timeoutId);
+      unsubscribe();
+      resolve();
+    }
+  });
+}
+
+export function OpenPluginGuideButton({
+  plugin,
+  pluginListLoading,
+}: {
+  plugin: PluginListItem | undefined;
+  pluginListLoading: boolean;
+}) {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const openGuide = useMutation({
+    mutationFn: async () => {
+      if (plugin === undefined) {
+        throw new Error("Plugin Guide is not installed.");
+      }
+
+      if (!plugin.enabled) {
+        await setPluginEnabled(fetch, PLUGIN_GUIDE_ID, true);
+        void invalidatePluginList({ queryClient });
+        schedulePluginFrontendReconcile();
+        await waitForPluginGuidePanel();
+      }
+
+      navigate(
+        getPluginPanelRoutePath({
+          pluginId: PLUGIN_GUIDE_ID,
+          path: PLUGIN_GUIDE_PANEL_PATH,
+        }),
+      );
+    },
+    onError: (error) => {
+      appToast.error("Couldn’t open Plugin Guide", {
+        description: error instanceof Error ? error.message : String(error),
+      });
+    },
+  });
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      className="group"
+      disabled={pluginListLoading || openGuide.isPending}
+      aria-busy={openGuide.isPending}
+      onClick={() => openGuide.mutate()}
+    >
+      {openGuide.isPending ? (
+        <Icon name="Spinner" className="animate-spin" aria-hidden />
+      ) : (
+        <span className="relative size-4 shrink-0" aria-hidden>
+          <HugeiconsIcon
+            icon={MapsIcon}
+            className="absolute inset-0 opacity-100 transition-opacity group-hover:opacity-0 group-focus-visible:opacity-0"
+          />
+          <HugeiconsIcon
+            icon={MapsLocation02Icon}
+            className="absolute inset-0 opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100"
+          />
+        </span>
+      )}
+      <span className="grid">
+        <span className="invisible col-start-1 row-start-1">
+          Open Plugin Guide
+        </span>
+        <span className="col-start-1 row-start-1">
+          {openGuide.isPending ? "Opening…" : "Open Plugin Guide"}
+        </span>
+      </span>
+    </Button>
+  );
+}


### PR DESCRIPTION
## Product intent and requirements

- Keep the Plugin Guide discoverable from My Plugins at every authored-plugin count.
- Open the guide from the plugin-authoring context without making users hunt through Installed Plugins.
- Use the map icon at rest and add only the pin on hover or keyboard focus without shifting the control.
- Enable a disabled bundled guide when needed, show compact progress and recoverable failure states, and preserve existing plugin policy.

## What was wrong

My Plugins rendered authored-plugin content but had no stable entry point for the bundled Plugin Guide. Because the guide is intentionally installed but disabled by default, prospective and active plugin developers could not discover or launch it from the page where they work.

## What changed

- Adds an always-visible **Open Plugin Guide** icon-and-label button to the My Plugins toolbar, including both the zero-plugin creation state and populated authored-plugin lists.
- Uses `MapsIcon` at rest and `MapsLocation02Icon` on hover or keyboard focus without changing button geometry.
- Opens an enabled guide immediately. When disabled, the action enables it without confirmation, waits for its frontend panel registration, then opens it.
- Keeps enable failures on My Plugins and shows recoverable feedback. The loading treatment reserves the resting label width, so the toolbar does not reflow.
- Leaves guide installation, authorship detection, permissions, lifecycle policy, and the host-daemon protocol unchanged.

## Before and after

Matched captures use the same path-installed `Agent enrichment` plugin, `/extensions/plugins?view=my` route, settled state, and 1440×900 Chrome for Testing viewport.

**Before — Extensions integration parent `7422881a73b734cb9e2848daf0e8f5f55b99d26c`**

<img src="https://gist.githubusercontent.com/brsbl/30d996198afdc244db74e13a9293769f/raw/2465a85a9976d5eef8bd015d208b813bf13cffd0/guide-before-7422881a7.svg" alt="Before: populated My Plugins has no Plugin Guide entry point" width="960">

**After — feature head `97c166e5561551532c11da76a8d16f15b1f70e18`**

<img src="https://gist.githubusercontent.com/brsbl/30d996198afdc244db74e13a9293769f/raw/2465a85a9976d5eef8bd015d208b813bf13cffd0/guide-after-97c166e55.svg" alt="After: populated My Plugins shows Open Plugin Guide in the toolbar" width="960">

### Zero-plugin creation state

Matched captures remove only the isolated path-installed fixture through the real plugin CLI, then use the same My Plugins URL and viewport. The head keeps the existing creation state intact and adds the same guide entry point.

| Before — empty My Plugins | After — empty My Plugins with guide entry |
| --- | --- |
| <img src="https://gist.githubusercontent.com/brsbl/30d996198afdc244db74e13a9293769f/raw/f880e8f4a16fafad60285de8f048c71e1ea7ad4b/guide-empty-before-7422881a7.svg" width="460" alt="Before: empty My Plugins creation state without a Plugin Guide action"> | <img src="https://gist.githubusercontent.com/brsbl/30d996198afdc244db74e13a9293769f/raw/f880e8f4a16fafad60285de8f048c71e1ea7ad4b/guide-empty-after-97c166e55.svg" width="460" alt="After: empty My Plugins creation state with Open Plugin Guide in the toolbar"> |

## How you verified

- Exact parent and head branch web apps launched with `scripts/bb-dev-app branch ...`, driven in Chrome for Testing 151.0.7922.71.
- Installed the same local `Agent enrichment` fixture into the isolated QA data directory and confirmed the only rendered difference is the Plugin Guide action.
- Confirmed both empty and populated states on the exact parent/head pair. Prior focused product QA also covered disabled-to-enabled progress and panel registration; enabled immediate open; recoverable failure; stable-width loading; and hover/keyboard icon transitions at 1440px and 768px.
- Pull-request CI is green on exact head `97c166e5561551532c11da76a8d16f15b1f70e18`; all required checks passed and the platform-inapplicable jobs were skipped. Per repository policy, tests, typechecks, and lint were not run locally.

BB-Thread-ID: thr_q5kiakrmeh

> AGENT GENERATED