### PR TITLE
Improve Updates download controls

### DIFF
--- a/apps/app/.ladle/settings-story-fixtures.tsx
+++ b/apps/app/.ladle/settings-story-fixtures.tsx
@@ -1,7 +1,7 @@
 import { useState, type ReactNode } from "react";
 import { useNavigate } from "react-router-dom";
 import { QueryClientProvider } from "@tanstack/react-query";
-import { PERSONAL_PROJECT_ID } from "@bb/domain";
+import { PERSONAL_PROJECT_ID, type ProviderInfo } from "@bb/domain";
 import { UPDATE_ACTION_ICON } from "@bb/domain/update-state";
 import type {
   SidebarBootstrapResponse,
@@ -15,6 +15,7 @@ import {
   pluginMarketplacesQueryKey,
   sidebarNavigationQueryKey,
   systemConfigQueryKey,
+  systemProvidersQueryKey,
   systemVersionQueryKey,
 } from "../src/hooks/queries/query-keys";
 import {
@@ -23,6 +24,7 @@ import {
 } from "../src/hooks/useUpdateInventory";
 import { createAppQueryClient } from "../src/lib/query-client";
 import { makeSystemConfig } from "../src/test/fixtures/system-config";
+import { makeProviderInfo } from "../src/test/provider-info-fixture";
 import { getSettingsRoutePath } from "../src/lib/route-paths";
 import {
   BbAppUpdateRows,
@@ -39,6 +41,9 @@ import {
   makeProject,
   makeProviderCliStatus,
 } from "./story-fixtures";
+import codexLogoUrl from "../../../plugins/provider-codex/icons/codex.svg";
+import claudeCodeLogoUrl from "../../../plugins/provider-claude-code/icons/claude-code.svg";
+import cursorLogoUrl from "../../../plugins/provider-acp/icons/cursor.svg";
 
 const SETTINGS_STORY_NOW = Date.parse("2026-08-19T08:00:00.000Z");
 
@@ -140,6 +145,24 @@ const systemVersion = {
   upgradeCommand: "npx bb-app@latest",
 } satisfies SystemVersionResponse;
 
+const systemProviders = [
+  makeProviderInfo({
+    id: "codex",
+    displayName: "Codex",
+    logoUrl: codexLogoUrl,
+  }),
+  makeProviderInfo({
+    id: "claude-code",
+    displayName: "Claude Code",
+    logoUrl: claudeCodeLogoUrl,
+  }),
+  makeProviderInfo({
+    id: "acp-cursor",
+    displayName: "Cursor",
+    logoUrl: cursorLogoUrl,
+  }),
+] satisfies ProviderInfo[];
+
 const settingsUpdateMachine = {
   host: SETTINGS_STORY_PRIMARY_HOST,
   isPrimary: true,
@@ -167,7 +190,6 @@ export function SettingsUpdatesStory() {
               label="Update all 1 CLI tool"
               tooltipLabel="Update all"
               icon={UPDATE_ACTION_ICON}
-              iconPosition="end"
               visibleLabel="Update all"
               variant="default"
               onClick={noop}
@@ -208,6 +230,7 @@ function createSettingsStoryQueryClient() {
   });
   queryClient.setQueryData(hostsQueryKey(), SETTINGS_STORY_HOSTS);
   queryClient.setQueryData(systemConfigQueryKey(), systemConfig);
+  queryClient.setQueryData(systemProvidersQueryKey(), systemProviders);
   queryClient.setQueryData(systemVersionQueryKey(), systemVersion);
   queryClient.setQueryData(sidebarNavigationQueryKey(), sidebarNavigation);
   queryClient.setQueryData(pluginMarketplacesQueryKey(), []);

--- a/apps/app/src/components/settings/UpdatesSettingsSection.stories.tsx
+++ b/apps/app/src/components/settings/UpdatesSettingsSection.stories.tsx
@@ -551,7 +551,6 @@ export function MultiMachine() {
               label="Update all 3 CLI tools"
               tooltipLabel="Update all"
               icon={UPDATE_ACTION_ICON}
-              iconPosition="end"
               visibleLabel="Update all"
               variant="default"
               onClick={noop}

--- a/apps/app/src/components/settings/UpdatesSettingsSection.test.tsx
+++ b/apps/app/src/components/settings/UpdatesSettingsSection.test.tsx
@@ -370,7 +370,7 @@ describe("UpdatesSettingsSection", () => {
     expect(updateAll?.className).toContain("bg-foreground");
     expect(updateAll?.className).toContain("text-background");
     expect(updateAll?.textContent).toBe("Update all");
-    expect(updateAll?.lastElementChild?.getAttribute("data-icon")).toBe(
+    expect(updateAll?.firstElementChild?.getAttribute("data-icon")).toBe(
       "Download",
     );
     const workstationHeading = screen.getByRole("heading", {
@@ -1480,7 +1480,9 @@ The canonical release summary.
       name: "Update all 2 CLI tools",
     });
     expect(updateAll.textContent).toBe("Update all");
-    expect(updateAll.querySelector('[data-icon="Download"]')).not.toBeNull();
+    expect(updateAll.firstElementChild?.getAttribute("data-icon")).toBe(
+      "Download",
+    );
 
     fireEvent.click(updateAll);
     expect(startInstallMock).toHaveBeenCalledTimes(2);

--- a/apps/app/src/components/settings/UpdatesSettingsSection.tsx
+++ b/apps/app/src/components/settings/UpdatesSettingsSection.tsx
@@ -1329,7 +1329,6 @@ export function UpdatesSettingsSection({
         label={`Update all ${actionableIssues.length} CLI tools`}
         tooltipLabel="Update all"
         icon={UPDATE_ACTION_ICON}
-        iconPosition="end"
         visibleLabel="Update all"
         variant="default"
         onClick={() => {

--- a/apps/app/src/components/sidebar/SidebarUpdatesBadge.stories.tsx
+++ b/apps/app/src/components/sidebar/SidebarUpdatesBadge.stories.tsx
@@ -1,0 +1,87 @@
+import { useEffect, type ReactNode } from "react";
+import type { ProviderCliInstallAction } from "@bb/host-daemon-contract";
+import { SettingsStoryFixtures } from "../../../.ladle/settings-story-fixtures";
+import {
+  HOST_IDS,
+  makeProviderCliStatus,
+} from "../../../.ladle/story-fixtures";
+import type { ProviderCliActionableIssue } from "@/components/provider-cli/provider-cli-install";
+import { startProviderCliInstall } from "@/components/provider-cli/provider-cli-install-store";
+import { SidebarMenu } from "@/components/ui/sidebar";
+import { sdk } from "@/lib/sdk";
+import { SidebarUpdatesBadge } from "./SidebarUpdatesBadge";
+
+export default { title: "sidebar/Updates badge" };
+
+const action: ProviderCliInstallAction = {
+  kind: "update",
+  label: "Update",
+  command: "codex update",
+};
+const status = makeProviderCliStatus("codex", {
+  currentVersion: "0.150.0",
+  latestVersion: "0.151.0",
+  needsUpdate: true,
+  installAction: action,
+});
+const issue: ProviderCliActionableIssue = {
+  provider: "codex",
+  status,
+  action,
+  title: "Codex update available",
+  description: "0.150.0 -> 0.151.0",
+  fingerprint: "codex:story",
+};
+
+function BadgeStage({ children }: { children?: ReactNode }) {
+  return (
+    <SettingsStoryFixtures>
+      <div className="flex min-h-32 w-80 flex-col rounded-md border border-sidebar-border bg-sidebar p-4 text-sidebar-foreground">
+        {children}
+        <SidebarMenu className="mt-auto">
+          <SidebarUpdatesBadge />
+        </SidebarMenu>
+      </div>
+    </SettingsStoryFixtures>
+  );
+}
+
+function ActiveProviderUpdate() {
+  useEffect(() => {
+    const originalInstallProviderCli = sdk.hosts.installProviderCli;
+    let finishInstall: (() => void) | null = null;
+    const startTimer = window.setTimeout(() => {
+      sdk.hosts.installProviderCli = () =>
+        new Promise((resolve) => {
+          finishInstall = () => {
+            resolve([
+              {
+                type: "completed",
+                provider: "codex",
+                exitCode: 0,
+                signal: null,
+                success: true,
+              },
+            ]);
+          };
+        });
+      startProviderCliInstall({ hostId: HOST_IDS.local, issue });
+    }, 0);
+
+    return () => {
+      window.clearTimeout(startTimer);
+      sdk.hosts.installProviderCli = originalInstallProviderCli;
+      finishInstall?.();
+    };
+  }, []);
+
+  return <BadgeStage />;
+}
+
+export function ProviderUpdateAvailable() {
+  return <BadgeStage />;
+}
+
+export function ProviderUpdateDownloading() {
+  return <ActiveProviderUpdate />;
+}

--- a/apps/app/src/components/sidebar/SidebarUpdatesBadge.test.tsx
+++ b/apps/app/src/components/sidebar/SidebarUpdatesBadge.test.tsx
@@ -15,9 +15,18 @@ import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
 import { SidebarUpdatesBadge } from "./SidebarUpdatesBadge";
 
 const useUpdateInventoryMock = vi.hoisted(() => vi.fn());
+const providerCliInstallRunnerState = vi.hoisted(() => ({
+  runningJobKey: null as string | null,
+}));
 
 vi.mock("@/hooks/useUpdateInventory", () => ({
   useUpdateInventory: useUpdateInventoryMock,
+}));
+
+vi.mock("@/components/provider-cli/provider-cli-install", () => ({
+  useProviderCliInstallRunner: () => ({
+    runningJobKey: providerCliInstallRunnerState.runningJobKey,
+  }),
 }));
 
 vi.mock("@/lib/sdk", async () => {
@@ -41,6 +50,7 @@ vi.mock("@/lib/ws", () => ({
 
 afterEach(() => {
   cleanup();
+  providerCliInstallRunnerState.runningJobKey = null;
   useUpdateInventoryMock.mockReset();
 });
 
@@ -143,13 +153,16 @@ function renderBadge(inventory: Partial<UpdateInventory>) {
     ...inventory,
   });
   const { wrapper } = createQueryClientTestHarness();
-  return render(
+  return render(<BadgeHarness />, { wrapper });
+}
+
+function BadgeHarness() {
+  return (
     <MemoryRouter>
       <TooltipProvider>
         <SidebarUpdatesBadge />
       </TooltipProvider>
-    </MemoryRouter>,
-    { wrapper },
+    </MemoryRouter>
   );
 }
 
@@ -186,6 +199,27 @@ describe("SidebarUpdatesBadge", () => {
         .getByTestId("sidebar-updates-badge-providers")
         .getAttribute("aria-label"),
     ).toBe("Claude Code update available");
+  });
+
+  it("shows loading while a provider update runs and restores the download icon when it settles", () => {
+    providerCliInstallRunnerState.runningJobKey = "host-1:claude-code";
+    const result = renderBadge({
+      machines: [
+        machine({ issues: [providerIssue("claude-code", "Claude Code")] }),
+      ],
+    });
+
+    const providerChip = screen.getByTestId("sidebar-updates-badge-providers");
+    const loadingIcon = providerChip.querySelector('[data-icon="Loading"]');
+    expect(loadingIcon).toBeTruthy();
+    expect(loadingIcon?.classList.contains("animate-spin")).toBe(true);
+    expect(providerChip.querySelector('[data-icon="Download"]')).toBeNull();
+
+    providerCliInstallRunnerState.runningJobKey = null;
+    result.rerender(<BadgeHarness />);
+
+    expect(providerChip.querySelector('[data-icon="Loading"]')).toBeNull();
+    expect(providerChip.querySelector('[data-icon="Download"]')).toBeTruthy();
   });
 
   it("renders no provider chip when a CLI is not installed", () => {

--- a/apps/app/src/components/sidebar/SidebarUpdatesBadge.tsx
+++ b/apps/app/src/components/sidebar/SidebarUpdatesBadge.tsx
@@ -3,6 +3,8 @@ import type { ProviderCliKey } from "@bb/host-daemon-contract";
 import { Icon } from "@bb/shared-ui/icon";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@bb/shared-ui/tooltip";
 import { cn } from "@bb/shared-ui/lib/utils";
+import { useProviderCliInstallRunner } from "@/components/provider-cli/provider-cli-install";
+import { providerCliJobKey } from "@/components/provider-cli/provider-cli-install-store";
 import { SidebarMenuItem } from "@/components/ui/sidebar.js";
 import { useSystemProviders } from "@/hooks/queries/system-queries";
 import { useUpdateInventory } from "@/hooks/useUpdateInventory";
@@ -34,6 +36,7 @@ interface StaleProvider {
 export function SidebarUpdatesBadge({ onNavigate }: SidebarUpdatesBadgeProps) {
   const inventory = useUpdateInventory();
   const providers = useSystemProviders().data;
+  const { runningJobKey } = useProviderCliInstallRunner();
 
   const stuckDaemonCount = inventory.machines.filter(
     (machine) => machine.canRetryDaemonUpdate,
@@ -58,6 +61,13 @@ export function SidebarUpdatesBadge({ onNavigate }: SidebarUpdatesBadgeProps) {
     }
   }
   const staleProviders = [...staleProvidersByKey.values()];
+  const providerUpdateRunning = inventory.machines.some((machine) =>
+    machine.issues.some(
+      (issue) =>
+        issue.status.installed &&
+        runningJobKey === providerCliJobKey(machine.host.id, issue.provider),
+    ),
+  );
 
   if (bbUpdateCount === 0 && staleProviders.length === 0) {
     return null;
@@ -99,7 +109,13 @@ export function SidebarUpdatesBadge({ onNavigate }: SidebarUpdatesBadgeProps) {
               data-testid="sidebar-updates-badge-providers"
               className={CHIP_CLASS}
             >
-              <Icon name="Download" className="size-3 text-muted-foreground" />
+              <Icon
+                name={providerUpdateRunning ? "Loading" : "Download"}
+                className={cn(
+                  "size-3 text-muted-foreground",
+                  providerUpdateRunning && "animate-spin",
+                )}
+              />
               <span className="flex items-center gap-1">
                 {staleProviders.map((stale) => {
                   const providerId = stale.provider;


### PR DESCRIPTION
## Human comments

## What was wrong

The Updates header explicitly positioned the Update all download glyph after its label, while the sidebar update badge only reflected provider-version status and never observed an active CLI install. The Updates story fixture also copied provider metadata without seeding the real logo assets, so installed-provider marks could render without their provider icon in Ladle.

## What changed

- Keep the existing Update all control intact while using its standard icon-first order.
- Subscribe the sidebar update badge to the existing install runner and replace its download glyph with the existing loading glyph only while an installed provider is actively downloading; restore the download glyph after success or failure.
- Seed provider-logo assets in the existing Updates story fixture and add focused available/downloading sidebar stories.
- Preserve the existing actions, styles, spacing, tooltips, and accessible names.

## How you verified

- Chrome for Testing, exact branch web app: compared merge base `9c170fdbb` with head `56bafa392` using the same provider-status fixture, route, and 1440×900 viewport.
- Confirmed the Update all glyph is first at 1440×900 and 767×900 and retains `aria-label="Update all 2 CLI tools"`.
- Exercised Update all and the individual Codex update action.
- During a controlled install failure, confirmed the sidebar shows the animated loading glyph with both Codex and Claude provider marks, then restores the download glyph after the install settles.
- Remote CI: 13 required checks passed; 2 not-applicable checks skipped.

## Screenshots

### Update all icon order

Before — merge base, 1440×900:

![Before: Update all download icon follows the label](https://img3.pixhost.cc/images/5324/763945924_before-update-all.webp)

After — PR head, 1440×900:

![After: Update all download icon precedes the label](https://img3.pixhost.cc/images/5324/763945951_after-update-all.webp)

After — PR head, 767×900:

![After at narrow width: Update all keeps the icon-first order](https://img3.pixhost.cc/images/5324/763945954_after-update-all-narrow.webp)

### Sidebar active install state

Before — merge base during the controlled install, 1440×900:

![Before: sidebar footer keeps the download icon during an active install](https://img3.pixhost.cc/images/5324/763945959_before-sidebar-active.webp)

After — PR head during the same controlled install, 1440×900:

![After: sidebar footer replaces download with loading and preserves provider marks](https://img3.pixhost.cc/images/5324/763945963_after-sidebar-active.webp)

After — PR head after the controlled failure settles, 1440×900:

![After settled: sidebar footer restores the download icon](https://img3.pixhost.cc/images/5324/763945967_after-sidebar-cleared.webp)

BB-Thread-ID: thr_m57exaav4m

> AGENT GENERATED
