### PR TITLE
Add copy thread link action

### DIFF
--- a/apps/app/src/components/thread/ThreadActionsMenu.test.tsx
+++ b/apps/app/src/components/thread/ThreadActionsMenu.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { Thread } from "@bb/domain";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ThreadActionsMenu } from "./ThreadActionsMenu";
+
+const mocks = vi.hoisted(() => ({
+  copyToClipboardWithToast: vi.fn(),
+}));
+
+vi.mock("@/lib/clipboard", () => ({
+  copyToClipboardWithToast: mocks.copyToClipboardWithToast,
+}));
+
+vi.mock("./ThreadActionsProvider", () => ({
+  useThreadActions: () => ({
+    archiveThreadAndChildren: vi.fn(),
+    requestRename: vi.fn(),
+    requestDelete: vi.fn(),
+    togglePin: vi.fn(),
+    toggleRead: vi.fn(),
+    unarchiveThread: vi.fn(),
+  }),
+}));
+
+function createThread(): Thread {
+  return {
+    id: "thr_test",
+    archivedAt: null,
+    pinnedAt: null,
+  } as Thread;
+}
+
+afterEach(() => {
+  cleanup();
+  mocks.copyToClipboardWithToast.mockReset();
+});
+
+describe("ThreadActionsMenu", () => {
+  it("copies the thread URL from the header menu", () => {
+    const threadUrl =
+      "https://example.getbb.app/projects/proj_test/threads/thr_test";
+    render(<ThreadActionsMenu thread={createThread()} threadUrl={threadUrl} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Thread actions" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Copy thread link" }));
+
+    expect(mocks.copyToClipboardWithToast).toHaveBeenCalledWith(threadUrl, {
+      successMessage: "Thread link copied",
+      errorMessage: "Failed to copy thread link",
+    });
+  });
+
+  it("keeps the copy action out of menus without a thread URL", () => {
+    render(<ThreadActionsMenu thread={createThread()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Thread actions" }));
+
+    expect(
+      screen.queryByRole("menuitem", { name: "Copy thread link" }),
+    ).toBeNull();
+  });
+});

--- a/apps/app/src/components/thread/ThreadActionsMenu.test.tsx
+++ b/apps/app/src/components/thread/ThreadActionsMenu.test.tsx
@@ -27,6 +27,7 @@ vi.mock("./ThreadActionsProvider", () => ({
 function createThread(): Thread {
   return {
     id: "thr_test",
+    projectId: "proj_test",
     archivedAt: null,
     pinnedAt: null,
   } as Thread;
@@ -38,27 +39,18 @@ afterEach(() => {
 });
 
 describe("ThreadActionsMenu", () => {
-  it("copies the thread URL from the header menu", () => {
-    const threadUrl =
-      "https://example.getbb.app/projects/proj_test/threads/thr_test";
-    render(<ThreadActionsMenu thread={createThread()} threadUrl={threadUrl} />);
+  it("copies the canonical thread URL from every menu instance", () => {
+    render(<ThreadActionsMenu thread={createThread()} />);
 
     fireEvent.click(screen.getByRole("button", { name: "Thread actions" }));
     fireEvent.click(screen.getByRole("menuitem", { name: "Copy thread link" }));
 
-    expect(mocks.copyToClipboardWithToast).toHaveBeenCalledWith(threadUrl, {
-      successMessage: "Thread link copied",
-      errorMessage: "Failed to copy thread link",
-    });
-  });
-
-  it("keeps the copy action out of menus without a thread URL", () => {
-    render(<ThreadActionsMenu thread={createThread()} />);
-
-    fireEvent.click(screen.getByRole("button", { name: "Thread actions" }));
-
-    expect(
-      screen.queryByRole("menuitem", { name: "Copy thread link" }),
-    ).toBeNull();
+    expect(mocks.copyToClipboardWithToast).toHaveBeenCalledWith(
+      `${window.location.origin}/projects/proj_test/threads/thr_test`,
+      {
+        successMessage: "Thread link copied",
+        errorMessage: "Failed to copy thread link",
+      },
+    );
   });
 });

--- a/apps/app/src/components/thread/ThreadActionsMenu.test.tsx
+++ b/apps/app/src/components/thread/ThreadActionsMenu.test.tsx
@@ -42,7 +42,10 @@ describe("ThreadActionsMenu", () => {
   it("copies the canonical thread URL from every menu instance", () => {
     render(<ThreadActionsMenu thread={createThread()} />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Thread actions" }));
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: "Thread actions" }),
+      { button: 0 },
+    );
     fireEvent.click(screen.getByRole("menuitem", { name: "Copy thread link" }));
 
     expect(mocks.copyToClipboardWithToast).toHaveBeenCalledWith(

--- a/apps/app/src/components/thread/ThreadActionsMenu.tsx
+++ b/apps/app/src/components/thread/ThreadActionsMenu.tsx
@@ -22,6 +22,7 @@ import { useIsCompactViewport } from "@bb/shared-ui/hooks/use-compact-viewport";
 import { cn } from "@bb/shared-ui/lib/utils";
 import { CompactLongPressMenu } from "@/components/ui/compact-long-press-menu";
 import { isThreadRead } from "@bb/client-core";
+import { copyToClipboardWithToast } from "@/lib/clipboard";
 import { useThreadActions } from "./ThreadActionsProvider";
 
 interface ThreadActionsMenuBaseProps {
@@ -39,6 +40,7 @@ interface ThreadActionsMenuProps extends ThreadActionsMenuBaseProps {
   onOpenChange?: (open: boolean) => void;
   triggerClassName?: string;
   responsiveActions?: readonly ThreadActionsMenuResponsiveAction[];
+  threadUrl?: string;
 }
 
 interface ThreadActionsContextMenuProps extends ThreadActionsMenuBaseProps {
@@ -51,6 +53,7 @@ type ThreadActionsMenuSurface = "context" | "dropdown";
 interface ThreadActionsMenuItemsProps extends ThreadActionsMenuBaseProps {
   responsiveActions?: readonly ThreadActionsMenuResponsiveAction[];
   surface: ThreadActionsMenuSurface;
+  threadUrl?: string;
 }
 
 interface ThreadActionMenuItemProps {
@@ -120,6 +123,7 @@ function ThreadActionsMenuItems({
   onOpenInSplit,
   responsiveActions = [],
   surface,
+  threadUrl,
 }: ThreadActionsMenuItemsProps) {
   const {
     archiveThreadAndChildren,
@@ -174,6 +178,20 @@ function ThreadActionsMenuItems({
         </>
       ) : null}
       {}
+      {threadUrl ? (
+        <ThreadActionMenuItem
+          surface={surface}
+          icon="Copy"
+          onSelect={() => {
+            void copyToClipboardWithToast(threadUrl, {
+              successMessage: "Thread link copied",
+              errorMessage: "Failed to copy thread link",
+            });
+          }}
+        >
+          Copy thread link
+        </ThreadActionMenuItem>
+      ) : null}
       <ThreadActionMenuItem
         surface={surface}
         icon={isRead ? "Mail" : "MailOpen"}
@@ -279,6 +297,7 @@ export function ThreadActionsMenu({
   responsiveActions,
   onOpenChange,
   triggerClassName,
+  threadUrl,
 }: ThreadActionsMenuProps) {
   return (
     <DropdownMenu onOpenChange={onOpenChange}>
@@ -309,6 +328,7 @@ export function ThreadActionsMenu({
           onOpenInSplit={onOpenInSplit}
           responsiveActions={responsiveActions}
           surface="dropdown"
+          threadUrl={threadUrl}
         />
       </DropdownMenuContent>
     </DropdownMenu>

--- a/apps/app/src/components/thread/ThreadActionsMenu.tsx
+++ b/apps/app/src/components/thread/ThreadActionsMenu.tsx
@@ -23,6 +23,7 @@ import { cn } from "@bb/shared-ui/lib/utils";
 import { CompactLongPressMenu } from "@/components/ui/compact-long-press-menu";
 import { isThreadRead } from "@bb/client-core";
 import { copyToClipboardWithToast } from "@/lib/clipboard";
+import { getThreadRoutePath } from "@/lib/route-paths";
 import { useThreadActions } from "./ThreadActionsProvider";
 
 interface ThreadActionsMenuBaseProps {
@@ -40,7 +41,6 @@ interface ThreadActionsMenuProps extends ThreadActionsMenuBaseProps {
   onOpenChange?: (open: boolean) => void;
   triggerClassName?: string;
   responsiveActions?: readonly ThreadActionsMenuResponsiveAction[];
-  threadUrl?: string;
 }
 
 interface ThreadActionsContextMenuProps extends ThreadActionsMenuBaseProps {
@@ -53,7 +53,6 @@ type ThreadActionsMenuSurface = "context" | "dropdown";
 interface ThreadActionsMenuItemsProps extends ThreadActionsMenuBaseProps {
   responsiveActions?: readonly ThreadActionsMenuResponsiveAction[];
   surface: ThreadActionsMenuSurface;
-  threadUrl?: string;
 }
 
 interface ThreadActionMenuItemProps {
@@ -123,7 +122,6 @@ function ThreadActionsMenuItems({
   onOpenInSplit,
   responsiveActions = [],
   surface,
-  threadUrl,
 }: ThreadActionsMenuItemsProps) {
   const {
     archiveThreadAndChildren,
@@ -139,6 +137,10 @@ function ThreadActionsMenuItems({
   const isRead = isThreadRead(thread);
   const isArchived = thread.archivedAt != null;
   const isPinned = thread.pinnedAt !== null;
+  const threadUrl = new URL(
+    getThreadRoutePath({ projectId: thread.projectId, threadId: thread.id }),
+    window.location.origin,
+  ).toString();
 
   return (
     <>
@@ -177,21 +179,18 @@ function ThreadActionsMenuItems({
           ) : null}
         </>
       ) : null}
-      {}
-      {threadUrl ? (
-        <ThreadActionMenuItem
-          surface={surface}
-          icon="Copy"
-          onSelect={() => {
-            void copyToClipboardWithToast(threadUrl, {
-              successMessage: "Thread link copied",
-              errorMessage: "Failed to copy thread link",
-            });
-          }}
-        >
-          Copy thread link
-        </ThreadActionMenuItem>
-      ) : null}
+      <ThreadActionMenuItem
+        surface={surface}
+        icon="Copy"
+        onSelect={() => {
+          void copyToClipboardWithToast(threadUrl, {
+            successMessage: "Thread link copied",
+            errorMessage: "Failed to copy thread link",
+          });
+        }}
+      >
+        Copy thread link
+      </ThreadActionMenuItem>
       <ThreadActionMenuItem
         surface={surface}
         icon={isRead ? "Mail" : "MailOpen"}
@@ -297,7 +296,6 @@ export function ThreadActionsMenu({
   responsiveActions,
   onOpenChange,
   triggerClassName,
-  threadUrl,
 }: ThreadActionsMenuProps) {
   return (
     <DropdownMenu onOpenChange={onOpenChange}>
@@ -328,7 +326,6 @@ export function ThreadActionsMenu({
           onOpenInSplit={onOpenInSplit}
           responsiveActions={responsiveActions}
           surface="dropdown"
-          threadUrl={threadUrl}
         />
       </DropdownMenuContent>
     </DropdownMenu>

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -2391,10 +2391,6 @@ function ThreadDetailViewInternal(props: ThreadRoutePathArgs) {
     workspaceDeleted: isWorkspaceDeleted,
   });
   const threadTitle = getThreadDisplayTitle(thread);
-  const threadUrl = new URL(
-    getThreadRoutePath({ projectId: thread.projectId, threadId: thread.id }),
-    window.location.origin,
-  ).toString();
   const responsiveWorkspaceActions: ThreadActionsMenuResponsiveAction[] =
     workspaceOpenPath && preferredDirectoryTarget
       ? [
@@ -2464,7 +2460,6 @@ function ThreadDetailViewInternal(props: ThreadRoutePathArgs) {
           responsiveActions={
             includeResponsiveActions ? responsiveHeaderActions : undefined
           }
-          threadUrl={threadUrl}
         />
       )}
       childPillLabel={

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -2391,6 +2391,10 @@ function ThreadDetailViewInternal(props: ThreadRoutePathArgs) {
     workspaceDeleted: isWorkspaceDeleted,
   });
   const threadTitle = getThreadDisplayTitle(thread);
+  const threadUrl = new URL(
+    getThreadRoutePath({ projectId: thread.projectId, threadId: thread.id }),
+    window.location.origin,
+  ).toString();
   const responsiveWorkspaceActions: ThreadActionsMenuResponsiveAction[] =
     workspaceOpenPath && preferredDirectoryTarget
       ? [
@@ -2460,6 +2464,7 @@ function ThreadDetailViewInternal(props: ThreadRoutePathArgs) {
           responsiveActions={
             includeResponsiveActions ? responsiveHeaderActions : undefined
           }
+          threadUrl={threadUrl}
         />
       )}
       childPillLabel={


### PR DESCRIPTION
## Human comments

None.

## What was wrong

Thread action menus did not provide a reliable way to copy the current thread URL. The first implementation wired the URL only from the thread header, which allowed the header and sidebar `…` menus to drift.

## What changed

- Adds **Copy thread link** to the shared thread-action item set used by the header, sidebar dropdown, desktop context menu, and compact long-press menu.
- Derives the link from the active app origin and canonical project/thread route inside the shared menu, so every instance follows the current environment while excluding transient panel, split, and query state.
- Adds focused coverage that the shared menu copies its canonical thread URL with success and failure feedback.

## Screenshots

The comparison uses the same seeded thread, route, open-menu state, and 1440×1000 viewport, cropped identically to the header action area. The after evidence is from branch commit `8f0eef326`, which contains the final production code; final head `1b911180c` changes only the test interaction event.

| Before — merge base `720b3163d` | After — final production code `8f0eef326` |
| --- | --- |
| ![Before: thread actions menu without Copy thread link](https://gist.githubusercontent.com/brsbl/ec5a76b1a7c321d9ccf3429cbed8d9b2/raw/cf4fe9cd0ede18728c8a46bbe1f21bf38e2d9585/before-copy-thread-link.svg) | ![After: header thread actions menu with Copy thread link](https://gist.githubusercontent.com/brsbl/7a294c74da211bd2815126df53bbd89d/raw/9cb7466721ecb7f2380c7ec9618b337fc2f24067/after-header-copy-thread-link.svg) |

Sidebar parity on the same production-code revision:

![After: sidebar thread actions menu with Copy thread link](https://gist.githubusercontent.com/brsbl/7a294c74da211bd2815126df53bbd89d/raw/33d1d9400cc9a1fb28d190c085fce1b7b70a6092/after-sidebar-copy-thread-link.svg)

## How you verified

- Chrome for Testing 151.0.7922.71 against the branch web app at 1440×1000.
- Hard reloaded the seeded thread, opened both header and sidebar `…` menus, copied from each, verified the exact clipboard URL, and observed success feedback.
- Confirmed no console errors during the changed flow.
- CI: all required build, typecheck, lint, app, server, integration, package, and packaging smoke checks pass on final head `1b911180c`.
- `git diff --check origin/main...HEAD`
- Local CI-equivalent checks were not run per repository policy; PR CI is the validation path.

BB-Thread-ID: thr_dwsizgdy3q

> AGENT GENERATED
