### PR TITLE
fix(app): avoid blank lines when copying composer text

### DIFF
--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -427,6 +427,29 @@ function pasteClipboard({
   });
 }
 
+function createMutableClipboardData() {
+  const values = new Map<string, string>();
+  return {
+    values,
+    clipboardData: {
+      items: [],
+      clearData(type?: string) {
+        if (type) {
+          values.delete(type);
+        } else {
+          values.clear();
+        }
+      },
+      getData(type: string) {
+        return values.get(type) ?? "";
+      },
+      setData(type: string, value: string) {
+        values.set(type, value);
+      },
+    },
+  };
+}
+
 function mockPointerCoarse(matches: boolean): () => void {
   const originalMatchMedia = window.matchMedia;
   window.matchMedia = vi.fn().mockImplementation((query: string) => ({
@@ -3244,6 +3267,73 @@ describe("PromptBoxInternal prompt actions", () => {
 
     await waitFor(() => expect(latestValue(changes)).toBe("> quoted"));
     expect(getPromptEditorElement().querySelector("blockquote")).not.toBeNull();
+  });
+
+  it("preserves mentions and line breaks when copying between composers", async () => {
+    const serializedMention = "@thread:thr_1";
+    const initialValue = `first\nask ${serializedMention}\nthird`;
+    const mentionStart = initialValue.indexOf(serializedMention);
+    const initialMentions: PromptTextMention[] = [
+      {
+        start: mentionStart,
+        end: mentionStart + serializedMention.length,
+        resource: {
+          kind: "thread",
+          threadId: "thr_1",
+          projectId: "proj_1",
+          label: "Thread one",
+        },
+      },
+    ];
+    const source = renderPromptBox(initialValue, {
+      initialMentionRanges: initialMentions,
+    });
+
+    await focusPromptEnd(source.promptBoxRef);
+    await waitFor(() =>
+      expect(
+        getPromptEditorElement().querySelectorAll(".prompt-mention-pill"),
+      ).toHaveLength(1),
+    );
+
+    const { clipboardData, values } = createMutableClipboardData();
+    const sourceEditor = getPromptEditorElement();
+    fireEvent.keyDown(sourceEditor, {
+      key: "a",
+      code: "KeyA",
+      ctrlKey: true,
+    });
+    fireEvent.copy(sourceEditor, { clipboardData });
+
+    const plainText = values.get("text/plain") ?? "";
+    const html = values.get("text/html") ?? "";
+    const copiedDocument = new DOMParser().parseFromString(html, "text/html");
+    expect(plainText).toBe(initialValue);
+    expect(
+      [...copiedDocument.body.children].map((element) => element.tagName),
+    ).toEqual(["DIV"]);
+    expect(copiedDocument.body.querySelectorAll("br")).toHaveLength(2);
+    expect(copiedDocument.body.querySelector("p")).toBeNull();
+    expect(
+      copiedDocument
+        .querySelector("[data-prompt-mention]")
+        ?.getAttribute("data-prompt-mention-serialized-text"),
+    ).toBe(serializedMention);
+
+    cleanup();
+    const destination = renderPromptBox("");
+    await focusPromptEnd(destination.promptBoxRef);
+    pasteClipboard({ html, plainText });
+
+    await waitFor(() =>
+      expect(latestValue(destination.changes)).toBe(initialValue),
+    );
+    expect(latestChange(destination.changes)?.mentions).toEqual(
+      initialMentions,
+    );
+    expect(
+      getPromptEditorElement().querySelectorAll(".prompt-mention-pill"),
+    ).toHaveLength(1);
   });
 
   it("keeps multiple pasted plugin references as distinct pills", async () => {

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -98,6 +98,7 @@ import {
   type PromptDraftObserver,
 } from "./editor/prompt-decoration-extension";
 import type { ComposerTextEffectSource } from "@/lib/composer-text-effects";
+import { promptEditorClipboardSerializer } from "./editor/prompt-editor-clipboard";
 import { promptEditorExtensions } from "./editor/prompt-editor-extensions";
 import {
   promptCommandResourceFromSuggestion,
@@ -1602,6 +1603,7 @@ export function PromptBoxInternal({
           ...(id ? { id } : {}),
           role: "textbox",
         },
+        clipboardSerializer: promptEditorClipboardSerializer,
         clipboardTextSerializer: (slice, view) =>
           promptEditorClipboardTextFromSlice(slice, view.state.schema),
         handleDOMEvents: {

--- a/apps/app/src/components/promptbox/editor/prompt-editor-clipboard.test.ts
+++ b/apps/app/src/components/promptbox/editor/prompt-editor-clipboard.test.ts
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from "vitest";
+import { getSchema } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import { PromptMentionExtension } from "./prompt-mention-extension";
+import { promptEditorClipboardSerializer } from "./prompt-editor-clipboard";
+
+const schema = getSchema([StarterKit, PromptMentionExtension]);
+
+describe("prompt editor clipboard HTML serialization", () => {
+  it("copies prompt lines as single-line-break blocks", () => {
+    const doc = schema.node("doc", null, [
+      schema.node(
+        "paragraph",
+        null,
+        schema.text("first", [schema.mark("bold")]),
+      ),
+      schema.node("paragraph", null, schema.text("second")),
+      schema.node("paragraph", null, schema.text("third")),
+    ]);
+    const container = document.createElement("div");
+
+    container.append(
+      promptEditorClipboardSerializer.serializeFragment(doc.content, {
+        document,
+      }),
+    );
+
+    expect(
+      [...container.children].map((child) => [
+        child.tagName,
+        child.textContent,
+      ]),
+    ).toEqual([
+      ["DIV", "first"],
+      ["DIV", "second"],
+      ["DIV", "third"],
+    ]);
+    expect(container.querySelector("p")).toBeNull();
+    expect(container.querySelector("strong")?.textContent).toBe("first");
+  });
+});

--- a/apps/app/src/components/promptbox/editor/prompt-editor-clipboard.ts
+++ b/apps/app/src/components/promptbox/editor/prompt-editor-clipboard.ts
@@ -1,0 +1,29 @@
+import {
+  DOMSerializer,
+  type DOMOutputSpec,
+  type Fragment,
+} from "@tiptap/pm/model";
+
+class PromptEditorClipboardSerializer extends DOMSerializer {
+  override serializeFragment(
+    fragment: Fragment,
+    options: { document?: Document } = {},
+    target?: HTMLElement | DocumentFragment,
+  ): DocumentFragment | HTMLElement {
+    const firstChild = fragment.firstChild;
+    if (firstChild === null) {
+      return super.serializeFragment(fragment, options, target);
+    }
+
+    const schema = firstChild.type.schema;
+    const nodes = DOMSerializer.nodesFromSchema(schema);
+    nodes.paragraph = (): DOMOutputSpec => ["div", 0];
+    return new DOMSerializer(
+      nodes,
+      DOMSerializer.marksFromSchema(schema),
+    ).serializeFragment(fragment, options, target);
+  }
+}
+
+export const promptEditorClipboardSerializer =
+  new PromptEditorClipboardSerializer({}, {});


### PR DESCRIPTION
## Human comments

## What was wrong

The composer used the default ProseMirror HTML serializer. It encoded each editor line as a paragraph. Rich-text destinations apply paragraph margins, so a copied multi-line prompt gained blank lines when pasted.

## What changed

The prompt editor now uses a clipboard serializer that emits `div` blocks for paragraph nodes. It keeps ProseMirror mark serializers and slice metadata. The existing plain-text serialization remains unchanged.

Added regression coverage for single-line-break blocks and a composer-to-composer clipboard round trip that preserves mention resources and exact line breaks.

## How you verified

- `pnpm exec turbo run test --filter=@bb/app --force -- --run src/components/promptbox/PromptBoxInternal.test.tsx src/components/promptbox/editor/prompt-editor-clipboard.test.ts src/components/promptbox/editor/prompt-editor-serialization.test.ts` (145 tests passed)
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run lint --filter=@bb/app`
- `pnpm exec oxfmt apps/app/src/components/promptbox/PromptBoxInternal.tsx apps/app/src/components/promptbox/PromptBoxInternal.test.tsx apps/app/src/components/promptbox/editor/prompt-editor-clipboard.ts apps/app/src/components/promptbox/editor/prompt-editor-clipboard.test.ts --check`
- `git diff --check`
- Live dev-app check with a three-line prompt. Cmd+A and Cmd+C produced three lines in `text/plain` and three `div` blocks in `text/html`.

> AGENT GENERATED