### PR TITLE
Fix first-tap submit on iOS and touch PWAs

### DIFF
--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -2231,33 +2231,43 @@ describe("PromptBoxInternal compact layout", () => {
     }
   });
 
-  it("keeps the editor focused through a pointer submit", async () => {
+  it("keeps the editor focused through a pointer submit", () => {
+    const restoreMatchMedia = mockPointerCoarse(true);
     const onSubmit = vi.fn();
-    render(
-      <PromptBoxInternal
-        {...createPromptBoxProps({
-          value: "Send this follow-up",
-          onSubmit,
-          compact: {
-            isCompact: true,
-            placeholder: "Ask a follow-up",
-          },
-        })}
-      />,
-    );
+    try {
+      render(
+        <PromptBoxInternal
+          {...createPromptBoxProps({
+            value: "Send this follow-up",
+            onSubmit,
+            compact: {
+              isCompact: true,
+              placeholder: "Ask a follow-up",
+            },
+          })}
+        />,
+      );
 
-    await waitForPromptFocus();
-    const editor = getPromptEditorElement();
-    const submit = screen.getByRole("button", { name: "Submit (Enter)" });
+      const editor = getPromptEditorElement();
+      act(() => editor.focus());
+      const submit = screen.getByRole("button", { name: "Submit (Enter)" });
 
-    expect(
-      fireEvent.pointerDown(submit, { button: 0, pointerType: "touch" }),
-    ).toBe(false);
-    expect(document.activeElement).toBe(editor);
+      expect(
+        fireEvent.pointerDown(submit, { button: 0, pointerType: "touch" }),
+      ).toBe(false);
+      expect(document.activeElement).toBe(editor);
 
-    fireEvent.click(submit, { detail: 1 });
-    expect(onSubmit).toHaveBeenCalledOnce();
-    expect(document.activeElement).toBe(editor);
+      expect(
+        fireEvent.pointerUp(submit, { button: 0, pointerType: "touch" }),
+      ).toBe(false);
+      expect(onSubmit).toHaveBeenCalledOnce();
+
+      fireEvent.click(submit, { detail: 1 });
+      expect(onSubmit).toHaveBeenCalledOnce();
+      expect(document.activeElement).toBe(editor);
+    } finally {
+      restoreMatchMedia();
+    }
   });
 
   it("keeps DOM focus through submit when TipTap focus state is stale", async () => {

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -231,6 +231,7 @@ interface PromptSubmitButtonProps {
   isSubmitting: boolean;
   onClick: (event: ReactMouseEvent<HTMLButtonElement>) => void;
   onPointerDown: (event: ReactPointerEvent<HTMLButtonElement>) => void;
+  onPointerUp: (event: ReactPointerEvent<HTMLButtonElement>) => void;
   title: string;
 }
 
@@ -242,6 +243,7 @@ function PromptSubmitButton({
   isSubmitting,
   onClick,
   onPointerDown,
+  onPointerUp,
   title,
 }: PromptSubmitButtonProps) {
   const button = (
@@ -253,6 +255,7 @@ function PromptSubmitButton({
       aria-label={title}
       disabled={!canSubmit}
       onPointerDown={onPointerDown}
+      onPointerUp={onPointerUp}
       onClick={onClick}
       className={className}
     >
@@ -1170,6 +1173,7 @@ export function PromptBoxInternal({
     QueuedEditorTypeaheadLayoutContext,
   );
   const blurAfterPointerSubmitRef = useRef(false);
+  const suppressTouchSubmitClickRef = useRef(false);
   const heightAnimationFromRef = useRef<number | null>(null);
   const capturePromptBoxHeight = useCallback(() => {
     const formElement = formRef.current;
@@ -2579,6 +2583,11 @@ export function PromptBoxInternal({
 
   const handleSubmitClick = useCallback(
     (event: ReactMouseEvent<HTMLButtonElement>) => {
+      if (suppressTouchSubmitClickRef.current) {
+        suppressTouchSubmitClickRef.current = false;
+        event.preventDefault();
+        return;
+      }
       blurAfterPointerSubmitRef.current =
         blurOnPointerSubmit && event.detail > 0;
     },
@@ -2606,6 +2615,23 @@ export function PromptBoxInternal({
       event.preventDefault();
     },
     [isPointerCoarse],
+  );
+
+  const handleSubmitPointerUp = useCallback(
+    (event: ReactPointerEvent<HTMLButtonElement>) => {
+      if (!isPointerCoarse || event.pointerType !== "touch") return;
+      const form = event.currentTarget.form;
+      if (!form) return;
+
+      event.preventDefault();
+      suppressTouchSubmitClickRef.current = true;
+      blurAfterPointerSubmitRef.current = blurOnPointerSubmit;
+      form.requestSubmit(event.currentTarget);
+      window.setTimeout(() => {
+        suppressTouchSubmitClickRef.current = false;
+      }, 0);
+    },
+    [blurOnPointerSubmit, isPointerCoarse],
   );
 
   const [pendingCommandSubmit, setPendingCommandSubmit] = useState(false);
@@ -3264,6 +3290,7 @@ export function PromptBoxInternal({
                         isCompact={showCompactLayout}
                         isSubmitting={isSubmitting}
                         onPointerDown={handleSubmitPointerDown}
+                        onPointerUp={handleSubmitPointerUp}
                         onClick={handleSubmitClick}
                         title={effectiveSubmitTitle}
                       />


### PR DESCRIPTION
## Summary

- submit on touch pointer-up so iOS/PWA users do not need a second tap after the keyboard closes
- suppress the compatibility click to prevent duplicate sends
- leave keyboard Enter handling unchanged, including software-keyboard newlines on iPadOS

## Testing

- `pnpm --filter @bb/app exec vitest run --config vitest.config.ts src/components/promptbox/PromptBoxInternal.test.tsx src/components/promptbox/PromptBoxInternal.ipados.test.tsx` (114 tests)
- `pnpm --filter @bb/app typecheck`
- `pnpm --filter @bb/app lint` (existing warnings only)

> AGENT GENERATED: by GPT-5.6