### PR TITLE
Clarify thread rename action label

### DIFF
--- a/apps/app/src/components/thread/ThreadActionsMenu.stories.tsx
+++ b/apps/app/src/components/thread/ThreadActionsMenu.stories.tsx
@@ -39,7 +39,7 @@ export function Overview() {
     <StoryCard>
       <StoryRow
         label="read · unpinned"
-        hint="Mark unread · Pin — Rename — Archive · Delete"
+        hint="Mark unread · Pin — Rename thread — Archive · Delete"
       >
         <Stage>
           <ThreadActionsMenu thread={readThread} />

--- a/apps/app/src/components/thread/ThreadActionsMenu.test.tsx
+++ b/apps/app/src/components/thread/ThreadActionsMenu.test.tsx
@@ -1,22 +1,36 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import type { Thread } from "@bb/domain";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { ThreadActionsMenu } from "./ThreadActionsMenu";
+import {
+  ThreadActionsContextMenu,
+  ThreadActionsMenu,
+} from "./ThreadActionsMenu";
 
 const mocks = vi.hoisted(() => ({
   copyToClipboardWithToast: vi.fn(),
+  requestRename: vi.fn(),
 }));
 
 vi.mock("@/lib/clipboard", () => ({
   copyToClipboardWithToast: mocks.copyToClipboardWithToast,
 }));
 
+vi.mock("@bb/shared-ui/hooks/use-compact-viewport", () => ({
+  useIsCompactViewport: () => false,
+}));
+
 vi.mock("./ThreadActionsProvider", () => ({
   useThreadActions: () => ({
     archiveThreadAndChildren: vi.fn(),
-    requestRename: vi.fn(),
+    requestRename: mocks.requestRename,
     requestDelete: vi.fn(),
     togglePin: vi.fn(),
     toggleRead: vi.fn(),
@@ -35,7 +49,7 @@ function createThread(): Thread {
 
 afterEach(() => {
   cleanup();
-  mocks.copyToClipboardWithToast.mockReset();
+  vi.clearAllMocks();
 });
 
 describe("ThreadActionsMenu", () => {
@@ -54,6 +68,24 @@ describe("ThreadActionsMenu", () => {
         successMessage: "Thread link copied",
         errorMessage: "Failed to copy thread link",
       },
+    );
+  });
+
+  it("offers an explicit rename action from a thread row context menu", async () => {
+    const thread = createThread();
+    render(
+      <ThreadActionsContextMenu thread={thread}>
+        <button type="button">Test thread</button>
+      </ThreadActionsContextMenu>,
+    );
+
+    fireEvent.contextMenu(screen.getByRole("button", { name: "Test thread" }));
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: "Rename thread" }),
+    );
+
+    await waitFor(() =>
+      expect(mocks.requestRename).toHaveBeenCalledWith(thread),
     );
   });
 });

--- a/apps/app/src/components/thread/ThreadActionsMenu.tsx
+++ b/apps/app/src/components/thread/ThreadActionsMenu.tsx
@@ -218,7 +218,7 @@ function ThreadActionsMenuItems({
           }, 0);
         }}
       >
-        Rename
+        Rename thread
       </ThreadActionMenuItem>
       {showSeparators ? <ThreadActionMenuSeparator surface={surface} /> : null}
       <ThreadActionMenuItem


### PR DESCRIPTION
## Summary

- label the thread action explicitly as “Rename thread”
- keep the action available from the thread row context menu
- add coverage that selecting the context-menu item opens the rename flow

## Testing

- `pnpm --filter @bb/app exec vitest run --config vitest.config.ts src/components/thread/ThreadActionsMenu.test.tsx`
- `pnpm --filter @bb/app typecheck`

> AGENT GENERATED: by GPT-5.6