### PR TITLE
Tolerate event-loop starvation in the connect tunnel heartbeat

### DIFF
--- a/packages/tunnel-client/src/session.ts
+++ b/packages/tunnel-client/src/session.ts
@@ -21,6 +21,7 @@ import type { TunnelClientLogger } from "./logger.js";
 
 const HEARTBEAT_INTERVAL_MS = 20_000;
 const HEARTBEAT_DEADLINE_MS = 60_000;
+const HEARTBEAT_STARVATION_GRACE_MS = 2 * HEARTBEAT_INTERVAL_MS;
 
 const UNREGISTERED_PORT_BODY = "this port is not shared";
 const textEncoder = new TextEncoder();
@@ -118,13 +119,16 @@ interface TunnelSessionOptions {
   resolveOrigin: (target: string | undefined) => StreamOriginResult;
   onRemoteClientsChange?: (remoteClients: number) => void;
   onActivity?: (at: number) => void;
+  onHeartbeatTimeout?: () => void;
 }
 
 export class TunnelSession {
   private readonly httpStreams = new Map<number, HttpStream>();
   private readonly wsStreams = new Map<number, WsStream>();
   private lastAck = Date.now();
+  private lastTickAt = 0;
   private heartbeat: ReturnType<typeof setInterval> | undefined;
+  private disposed = false;
   private remoteClientCount = 0;
   lastRemoteActivityAt: number | null = null;
 
@@ -136,10 +140,30 @@ export class TunnelSession {
 
   start(): void {
     const { tunnel } = this.options;
+    this.lastTickAt = Date.now();
     this.heartbeat = setInterval(() => {
-      if (Date.now() - this.lastAck > HEARTBEAT_DEADLINE_MS) {
-        this.options.log.warn("tunnel heartbeat missed; reconnecting");
-        tunnel.terminate();
+      const now = Date.now();
+      const tickGap = now - this.lastTickAt;
+      this.lastTickAt = now;
+      if (tickGap > HEARTBEAT_STARVATION_GRACE_MS) {
+        this.lastAck = now;
+        this.options.log.warn(
+          `tunnel heartbeat timer starved (${tickGap}ms); granting ack grace`,
+        );
+        tunnel.send(HEARTBEAT_REQUEST);
+        return;
+      }
+      if (now - this.lastAck > HEARTBEAT_DEADLINE_MS) {
+        setImmediate(() => {
+          if (this.disposed) return;
+          if (Date.now() - this.lastAck <= HEARTBEAT_DEADLINE_MS) {
+            tunnel.send(HEARTBEAT_REQUEST);
+            return;
+          }
+          this.options.log.warn("tunnel heartbeat missed; reconnecting");
+          tunnel.terminate();
+          this.options.onHeartbeatTimeout?.();
+        });
         return;
       }
       tunnel.send(HEARTBEAT_REQUEST);
@@ -160,6 +184,7 @@ export class TunnelSession {
   }
 
   dispose(): void {
+    this.disposed = true;
     if (this.heartbeat) clearInterval(this.heartbeat);
     for (const s of this.httpStreams.values()) s.abort.abort();
     for (const s of this.wsStreams.values())

--- a/packages/tunnel-client/test/session-heartbeat.test.ts
+++ b/packages/tunnel-client/test/session-heartbeat.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  HEARTBEAT_REQUEST,
+  HEARTBEAT_RESPONSE,
+} from "@bb/tunnel-contract";
+
+const socketSpies = vi.hoisted(() => ({
+  send: vi.fn(),
+  terminate: vi.fn(),
+}));
+
+vi.mock("ws", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("ws")>();
+  const { EventEmitter } = await import("node:events");
+
+  class FakeWebSocket extends EventEmitter {
+    static readonly OPEN = 1;
+    readyState = FakeWebSocket.OPEN;
+
+    send(data: string | Buffer): void {
+      socketSpies.send(data);
+    }
+
+    terminate(): void {
+      socketSpies.terminate();
+      this.readyState = 3;
+    }
+  }
+
+  return { ...actual, WebSocket: FakeWebSocket };
+});
+
+import { WebSocket } from "ws";
+import { TunnelSession } from "../src/session.js";
+
+const HEARTBEAT_INTERVAL_MS = 20_000;
+
+function createSession(onHeartbeatTimeout = vi.fn()) {
+  const tunnel = new WebSocket("ws://tunnel.test");
+  const session = new TunnelSession({
+    tunnel,
+    log: { warn: vi.fn() },
+    resolveOrigin: () => ({ kind: "unregistered" }),
+    onHeartbeatTimeout,
+  });
+  session.start();
+  return { onHeartbeatTimeout, session, tunnel };
+}
+
+function acknowledge(tunnel: WebSocket): void {
+  tunnel.emit("message", Buffer.from(HEARTBEAT_RESPONSE), false);
+}
+
+describe("TunnelSession heartbeat", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+    socketSpies.send.mockClear();
+    socketSpies.terminate.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("stays alive past the deadline when timely ticks receive acknowledgements", async () => {
+    const { session, tunnel } = createSession();
+
+    try {
+      for (let tick = 0; tick < 5; tick += 1) {
+        await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS);
+        acknowledge(tunnel);
+      }
+
+      expect(socketSpies.send).toHaveBeenCalledTimes(5);
+      expect(socketSpies.send).toHaveBeenLastCalledWith(HEARTBEAT_REQUEST);
+      expect(socketSpies.terminate).not.toHaveBeenCalled();
+    } finally {
+      session.dispose();
+    }
+  });
+
+  it("terminates and reports one genuine heartbeat miss", async () => {
+    const { onHeartbeatTimeout, session } = createSession();
+
+    try {
+      await vi.advanceTimersByTimeAsync(4 * HEARTBEAT_INTERVAL_MS);
+      await vi.advanceTimersToNextTimerAsync();
+
+      expect(socketSpies.terminate).toHaveBeenCalledOnce();
+      expect(onHeartbeatTimeout).toHaveBeenCalledOnce();
+    } finally {
+      session.dispose();
+    }
+  });
+
+  it("lets an acknowledgement queued at decision time rescue the tunnel", async () => {
+    const { onHeartbeatTimeout, session, tunnel } = createSession();
+
+    try {
+      vi.advanceTimersByTime(4 * HEARTBEAT_INTERVAL_MS);
+      acknowledge(tunnel);
+      await vi.advanceTimersToNextTimerAsync();
+
+      expect(socketSpies.terminate).not.toHaveBeenCalled();
+      expect(onHeartbeatTimeout).not.toHaveBeenCalled();
+      expect(socketSpies.send).toHaveBeenLastCalledWith(HEARTBEAT_REQUEST);
+    } finally {
+      session.dispose();
+    }
+  });
+
+  it("grants heartbeat grace when the timer was starved", async () => {
+    const { onHeartbeatTimeout, session } = createSession();
+
+    try {
+      vi.setSystemTime(Date.now() + 90_000);
+      await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS);
+
+      expect(socketSpies.terminate).not.toHaveBeenCalled();
+      expect(onHeartbeatTimeout).not.toHaveBeenCalled();
+      expect(socketSpies.send).toHaveBeenCalledOnce();
+      expect(socketSpies.send).toHaveBeenCalledWith(HEARTBEAT_REQUEST);
+    } finally {
+      session.dispose();
+    }
+  });
+
+  it("makes a deferred heartbeat decision inert after disposal", async () => {
+    const { onHeartbeatTimeout, session } = createSession();
+
+    vi.advanceTimersByTime(4 * HEARTBEAT_INTERVAL_MS);
+    session.dispose();
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(socketSpies.terminate).not.toHaveBeenCalled();
+    expect(onHeartbeatTimeout).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/connect/src/tunnel-lifecycle.test.ts
+++ b/plugins/connect/src/tunnel-lifecycle.test.ts
@@ -10,6 +10,7 @@ interface FakeWebSocketOptions {
 interface FakeTunnelSocket {
   readyState: number;
   emit(eventName: string, ...args: unknown[]): boolean;
+  send(): void;
   terminate(): void;
 }
 
@@ -34,6 +35,8 @@ vi.mock("ws", async (importOriginal) => {
     terminate(): void {
       this.readyState = 3;
     }
+
+    send(): void {}
   }
 
   return { ...actual, WebSocket: FakeWebSocket };
@@ -235,6 +238,35 @@ describe("ConnectTunnel socket lifecycle", () => {
           resume: vi.fn(),
         },
       );
+      const nextRetryAt = tunnel.status().nextRetryAt;
+      expect(nextRetryAt).not.toBeNull();
+
+      socket.emit("close", 1006, Buffer.from("late close"));
+
+      expect(tunnel.status().nextRetryAt).toBe(nextRetryAt);
+      await vi.advanceTimersByTimeAsync(nextRetryAt! - Date.now());
+      expect(fakeWebSockets.instances).toHaveLength(2);
+    } finally {
+      tunnel.stop();
+      vi.useRealTimers();
+      await fakeHost.harness.dispose();
+    }
+  });
+
+  it("schedules one retry on heartbeat timeout before close", async () => {
+    vi.useFakeTimers();
+    const { fakeHost, tunnel } = createTunnelFixture();
+
+    try {
+      await tunnel.start();
+      const socket = fakeWebSockets.instances[0]!;
+      socket.emit("open");
+      expect(tunnel.status().state).toBe("connected");
+
+      await vi.advanceTimersByTimeAsync(80_000);
+      await vi.advanceTimersToNextTimerAsync();
+
+      expect(tunnel.status().state).toBe("reconnecting");
       const nextRetryAt = tunnel.status().nextRetryAt;
       expect(nextRetryAt).not.toBeNull();
 

--- a/plugins/connect/src/tunnel.ts
+++ b/plugins/connect/src/tunnel.ts
@@ -466,6 +466,9 @@ export class ConnectTunnel {
         onActivity: (at) => {
           this.lastRemoteActivityAt = at;
         },
+        onHeartbeatTimeout: () => {
+          scheduleReconnect("tunnel heartbeat timed out");
+        },
       });
       this.session.start();
       this.publish();


### PR DESCRIPTION
## Human comments

## What was wrong

bb connect's tunnel client kills healthy tunnels when the bb server process is starved. The relay answers heartbeats at the Cloudflare edge via `setWebSocketAutoResponse` (`apps/connect/src/tunnel-do.ts`), so acks are essentially guaranteed while the link is up — but under host overload (load average 143–234 on 10 CPUs observed) the server event loop cannot process the queued ack messages within the 60s `HEARTBEAT_DEADLINE_MS`. The heartbeat tick then sees a stale `lastAck`, logs `tunnel heartbeat missed; reconnecting`, and terminates a live socket. Reconnection then waits for the ws `close` event, which under the same starvation was measured arriving 50–82 seconds later. During that window remote visitors get `bb connect: tunnel disconnected mid-request` and the offline interstitial even though bb is running. One affected machine logged 123 such false terminations in a single day (2026-08-29).

Node's event-loop phase ordering makes the false positive structural: expired timers run before poll-phase I/O, so on a recovering loop the heartbeat tick always observes `lastAck` as stale even when the acks are already sitting in the socket buffer.

## What changed

- `packages/tunnel-client/src/session.ts`
  - Starvation grace: the heartbeat tick now tracks its own cadence. When the tick itself ran more than 2× the interval late, ack staleness is self-inflicted (the process was starved or suspended), so the session grants ack grace and re-pings instead of terminating. A genuinely dead tunnel still dies within one deadline once ticks are timely again.
  - Drain-before-kill: when the deadline appears exceeded on a timely tick, the kill decision is deferred one `setImmediate` so acks already queued in the poll phase are counted first.
  - New optional `onHeartbeatTimeout` session callback; a `disposed` flag makes a pending deferred decision inert after `dispose()`.
- `plugins/connect/src/tunnel.ts`: on a genuine heartbeat timeout the tunnel now schedules its reconnect immediately via the existing idempotent `scheduleReconnect` instead of waiting for the delayed `close` event (which also disposes the session, stopping the repeated `heartbeat missed` warns). The later `close` remains a guarded no-op.

No wire or protocol change: `packages/tunnel-contract`, `apps/connect`, and `HOST_DAEMON_PROTOCOL_VERSION` are untouched.

## How you verified

- New `packages/tunnel-client/test/session-heartbeat.test.ts` (fake timers, fake ws): timely acks keep the session alive; a genuine miss terminates and reports exactly once; an ack queued at decision time rescues the tunnel; a starved timer grants grace instead of terminating; a deferred decision is inert after disposal. The four behavioral cases fail against the previous implementation.
- New case in `plugins/connect/src/tunnel-lifecycle.test.ts`: heartbeat timeout schedules the retry before any `close` event, and a later `close` does not double-schedule (fails before the change with the state stuck `connected`).
- `pnpm exec turbo run typecheck --filter=@bb/tunnel-client --filter=bb-plugin-connect` — clean.
- `pnpm exec turbo run test --filter=@bb/tunnel-client --filter=bb-plugin-connect --force` — 17/17 and 91/91 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> AGENT GENERATED