### PR TITLE
Contain late tunnel frames and sync origin failures in TunnelSession

### DIFF
--- a/packages/tunnel-client/src/session.ts
+++ b/packages/tunnel-client/src/session.ts
@@ -21,6 +21,7 @@ import type { TunnelClientLogger } from "./logger.js";
 
 const HEARTBEAT_INTERVAL_MS = 20_000;
 const HEARTBEAT_DEADLINE_MS = 60_000;
+const HEARTBEAT_STARVATION_GRACE_MS = 2 * HEARTBEAT_INTERVAL_MS;
 
 const UNREGISTERED_PORT_BODY = "this port is not shared";
 const textEncoder = new TextEncoder();
@@ -118,13 +119,16 @@ interface TunnelSessionOptions {
   resolveOrigin: (target: string | undefined) => StreamOriginResult;
   onRemoteClientsChange?: (remoteClients: number) => void;
   onActivity?: (at: number) => void;
+  onHeartbeatTimeout?: () => void;
 }
 
 export class TunnelSession {
   private readonly httpStreams = new Map<number, HttpStream>();
   private readonly wsStreams = new Map<number, WsStream>();
   private lastAck = Date.now();
+  private lastTickAt = 0;
   private heartbeat: ReturnType<typeof setInterval> | undefined;
+  private disposed = false;
   private remoteClientCount = 0;
   lastRemoteActivityAt: number | null = null;
 
@@ -136,10 +140,30 @@ export class TunnelSession {
 
   start(): void {
     const { tunnel } = this.options;
+    this.lastTickAt = Date.now();
     this.heartbeat = setInterval(() => {
-      if (Date.now() - this.lastAck > HEARTBEAT_DEADLINE_MS) {
-        this.options.log.warn("tunnel heartbeat missed; reconnecting");
-        tunnel.terminate();
+      const now = Date.now();
+      const tickGap = now - this.lastTickAt;
+      this.lastTickAt = now;
+      if (tickGap > HEARTBEAT_STARVATION_GRACE_MS) {
+        this.lastAck = now;
+        this.options.log.warn(
+          `tunnel heartbeat timer starved (${tickGap}ms); granting ack grace`,
+        );
+        tunnel.send(HEARTBEAT_REQUEST);
+        return;
+      }
+      if (now - this.lastAck > HEARTBEAT_DEADLINE_MS) {
+        setImmediate(() => {
+          if (this.disposed) return;
+          if (Date.now() - this.lastAck <= HEARTBEAT_DEADLINE_MS) {
+            tunnel.send(HEARTBEAT_REQUEST);
+            return;
+          }
+          this.options.log.warn("tunnel heartbeat missed; reconnecting");
+          tunnel.terminate();
+          this.options.onHeartbeatTimeout?.();
+        });
         return;
       }
       tunnel.send(HEARTBEAT_REQUEST);
@@ -160,6 +184,7 @@ export class TunnelSession {
   }
 
   dispose(): void {
+    this.disposed = true;
     if (this.heartbeat) clearInterval(this.heartbeat);
     for (const s of this.httpStreams.values()) s.abort.abort();
     for (const s of this.wsStreams.values())

--- a/packages/tunnel-client/src/session.ts
+++ b/packages/tunnel-client/src/session.ts
@@ -170,6 +170,7 @@ export class TunnelSession {
     }, HEARTBEAT_INTERVAL_MS);
 
     tunnel.on("message", (data: Buffer, isBinary: boolean) => {
+      if (this.disposed) return;
       if (!isBinary) {
         if (data.toString() === HEARTBEAT_RESPONSE) this.lastAck = Date.now();
         return;
@@ -219,6 +220,7 @@ export class TunnelSession {
   }
 
   private onFrame(frame: Frame): void {
+    if (this.disposed) return;
     this.noteActivity();
     switch (frame.type) {
       case "open-http": {
@@ -298,19 +300,18 @@ export class TunnelSession {
     stream: HttpStream,
   ): Promise<void> {
     const { meta } = stream;
-    const originResult = this.options.resolveOrigin(meta.target);
-    if (originResult.kind === "unregistered") {
-      this.rejectUnregisteredHttp(streamId);
-      this.httpStreams.delete(streamId);
-      return;
-    }
-    const { resolved } = originResult;
-    const headers = headersForLoopbackRequest(meta.headers, {
-      publicOrigin: resolved.publicOrigin,
-      loopbackOrigin: new URL(resolved.origin).origin,
-      ...(resolved.host !== undefined ? { host: resolved.host } : {}),
-    });
     try {
+      const originResult = this.options.resolveOrigin(meta.target);
+      if (originResult.kind === "unregistered") {
+        this.rejectUnregisteredHttp(streamId);
+        return;
+      }
+      const { resolved } = originResult;
+      const headers = headersForLoopbackRequest(meta.headers, {
+        publicOrigin: resolved.publicOrigin,
+        loopbackOrigin: new URL(resolved.origin).origin,
+        ...(resolved.host !== undefined ? { host: resolved.host } : {}),
+      });
       const startedAt = performance.now();
       const body = meta.hasBody ? Buffer.concat(stream.chunks) : undefined;
       const res = await requestOriginHttp({

--- a/packages/tunnel-client/test/session-dispose.test.ts
+++ b/packages/tunnel-client/test/session-dispose.test.ts
@@ -1,0 +1,125 @@
+import {
+  HEARTBEAT_RESPONSE,
+  decodeFrame,
+  encodeFrame,
+} from "@bb/tunnel-contract";
+import { describe, expect, it, vi } from "vitest";
+
+const socketState = vi.hoisted(() => {
+  const sent: Array<string | Buffer | Uint8Array> = [];
+  return {
+    sent,
+    terminate: vi.fn(),
+  };
+});
+
+vi.mock("ws", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("ws")>();
+  const { EventEmitter: MockEventEmitter } = await import("node:events");
+
+  class FakeWebSocket extends MockEventEmitter {
+    static readonly OPEN = 1;
+    readyState = FakeWebSocket.OPEN;
+
+    send(data: string | Buffer | Uint8Array): void {
+      socketState.sent.push(data);
+    }
+
+    terminate(): void {
+      socketState.terminate();
+      this.readyState = 3;
+    }
+  }
+
+  return { ...actual, WebSocket: FakeWebSocket };
+});
+
+import { WebSocket } from "ws";
+import {
+  type StreamOriginResult,
+  TunnelSession,
+} from "../src/session.js";
+
+function createSession(
+  resolveOrigin: (target: string | undefined) => StreamOriginResult,
+): { session: TunnelSession; tunnel: WebSocket } {
+  socketState.sent.length = 0;
+  socketState.terminate.mockClear();
+  const tunnel = new WebSocket("ws://tunnel.test");
+  const session = new TunnelSession({
+    tunnel,
+    log: { warn: vi.fn() },
+    resolveOrigin,
+  });
+  session.start();
+  return { session, tunnel };
+}
+
+function emitOpenHttp(tunnel: WebSocket): void {
+  const frame = encodeFrame({
+    type: "open-http",
+    streamId: 7,
+    method: "GET",
+    path: "/health",
+    headers: [],
+    hasBody: false,
+  });
+  tunnel.emit("message", Buffer.from(frame), true);
+}
+
+describe("TunnelSession disposal", () => {
+  it("ignores a binary open-http frame delivered after disposal", () => {
+    const resolveOrigin = vi.fn(
+      (_target: string | undefined): StreamOriginResult => ({
+        kind: "unregistered",
+      }),
+    );
+    const { session, tunnel } = createSession(resolveOrigin);
+
+    session.dispose();
+    emitOpenHttp(tunnel);
+
+    expect(resolveOrigin).not.toHaveBeenCalled();
+    expect(socketState.sent).toEqual([]);
+  });
+
+  it("closes the stream when resolveOrigin throws synchronously", async () => {
+    const resolveOrigin = vi.fn(
+      (_target: string | undefined): StreamOriginResult => {
+        throw new Error("plugin context stale");
+      },
+    );
+    const { session, tunnel } = createSession(resolveOrigin);
+
+    try {
+      emitOpenHttp(tunnel);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(socketState.sent).toHaveLength(1);
+      const sent = socketState.sent[0];
+      if (sent === undefined || typeof sent === "string") {
+        throw new Error("expected one binary tunnel frame");
+      }
+      expect(decodeFrame(sent)).toEqual({
+        type: "close-stream",
+        streamId: 7,
+        code: 1011,
+        reason: "Error: plugin context stale",
+      });
+    } finally {
+      session.dispose();
+    }
+  });
+
+  it("ignores a heartbeat response delivered after disposal", () => {
+    const { session, tunnel } = createSession(() => ({
+      kind: "unregistered",
+    }));
+
+    session.dispose();
+
+    expect(() => {
+      tunnel.emit("message", Buffer.from(HEARTBEAT_RESPONSE), false);
+    }).not.toThrow();
+  });
+});

--- a/packages/tunnel-client/test/session-heartbeat.test.ts
+++ b/packages/tunnel-client/test/session-heartbeat.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  HEARTBEAT_REQUEST,
+  HEARTBEAT_RESPONSE,
+} from "@bb/tunnel-contract";
+
+const socketSpies = vi.hoisted(() => ({
+  send: vi.fn(),
+  terminate: vi.fn(),
+}));
+
+vi.mock("ws", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("ws")>();
+  const { EventEmitter } = await import("node:events");
+
+  class FakeWebSocket extends EventEmitter {
+    static readonly OPEN = 1;
+    readyState = FakeWebSocket.OPEN;
+
+    send(data: string | Buffer): void {
+      socketSpies.send(data);
+    }
+
+    terminate(): void {
+      socketSpies.terminate();
+      this.readyState = 3;
+    }
+  }
+
+  return { ...actual, WebSocket: FakeWebSocket };
+});
+
+import { WebSocket } from "ws";
+import { TunnelSession } from "../src/session.js";
+
+const HEARTBEAT_INTERVAL_MS = 20_000;
+
+function createSession(onHeartbeatTimeout = vi.fn()) {
+  const tunnel = new WebSocket("ws://tunnel.test");
+  const session = new TunnelSession({
+    tunnel,
+    log: { warn: vi.fn() },
+    resolveOrigin: () => ({ kind: "unregistered" }),
+    onHeartbeatTimeout,
+  });
+  session.start();
+  return { onHeartbeatTimeout, session, tunnel };
+}
+
+function acknowledge(tunnel: WebSocket): void {
+  tunnel.emit("message", Buffer.from(HEARTBEAT_RESPONSE), false);
+}
+
+describe("TunnelSession heartbeat", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+    socketSpies.send.mockClear();
+    socketSpies.terminate.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("stays alive past the deadline when timely ticks receive acknowledgements", async () => {
+    const { session, tunnel } = createSession();
+
+    try {
+      for (let tick = 0; tick < 5; tick += 1) {
+        await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS);
+        acknowledge(tunnel);
+      }
+
+      expect(socketSpies.send).toHaveBeenCalledTimes(5);
+      expect(socketSpies.send).toHaveBeenLastCalledWith(HEARTBEAT_REQUEST);
+      expect(socketSpies.terminate).not.toHaveBeenCalled();
+    } finally {
+      session.dispose();
+    }
+  });
+
+  it("terminates and reports one genuine heartbeat miss", async () => {
+    const { onHeartbeatTimeout, session } = createSession();
+
+    try {
+      await vi.advanceTimersByTimeAsync(4 * HEARTBEAT_INTERVAL_MS);
+      await vi.advanceTimersToNextTimerAsync();
+
+      expect(socketSpies.terminate).toHaveBeenCalledOnce();
+      expect(onHeartbeatTimeout).toHaveBeenCalledOnce();
+    } finally {
+      session.dispose();
+    }
+  });
+
+  it("lets an acknowledgement queued at decision time rescue the tunnel", async () => {
+    const { onHeartbeatTimeout, session, tunnel } = createSession();
+
+    try {
+      vi.advanceTimersByTime(4 * HEARTBEAT_INTERVAL_MS);
+      acknowledge(tunnel);
+      await vi.advanceTimersToNextTimerAsync();
+
+      expect(socketSpies.terminate).not.toHaveBeenCalled();
+      expect(onHeartbeatTimeout).not.toHaveBeenCalled();
+      expect(socketSpies.send).toHaveBeenLastCalledWith(HEARTBEAT_REQUEST);
+    } finally {
+      session.dispose();
+    }
+  });
+
+  it("grants heartbeat grace when the timer was starved", async () => {
+    const { onHeartbeatTimeout, session } = createSession();
+
+    try {
+      vi.setSystemTime(Date.now() + 90_000);
+      await vi.advanceTimersByTimeAsync(HEARTBEAT_INTERVAL_MS);
+
+      expect(socketSpies.terminate).not.toHaveBeenCalled();
+      expect(onHeartbeatTimeout).not.toHaveBeenCalled();
+      expect(socketSpies.send).toHaveBeenCalledOnce();
+      expect(socketSpies.send).toHaveBeenCalledWith(HEARTBEAT_REQUEST);
+    } finally {
+      session.dispose();
+    }
+  });
+
+  it("makes a deferred heartbeat decision inert after disposal", async () => {
+    const { onHeartbeatTimeout, session } = createSession();
+
+    vi.advanceTimersByTime(4 * HEARTBEAT_INTERVAL_MS);
+    session.dispose();
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(socketSpies.terminate).not.toHaveBeenCalled();
+    expect(onHeartbeatTimeout).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/connect/src/tunnel-lifecycle.test.ts
+++ b/plugins/connect/src/tunnel-lifecycle.test.ts
@@ -10,6 +10,7 @@ interface FakeWebSocketOptions {
 interface FakeTunnelSocket {
   readyState: number;
   emit(eventName: string, ...args: unknown[]): boolean;
+  send(): void;
   terminate(): void;
 }
 
@@ -34,6 +35,8 @@ vi.mock("ws", async (importOriginal) => {
     terminate(): void {
       this.readyState = 3;
     }
+
+    send(): void {}
   }
 
   return { ...actual, WebSocket: FakeWebSocket };
@@ -235,6 +238,35 @@ describe("ConnectTunnel socket lifecycle", () => {
           resume: vi.fn(),
         },
       );
+      const nextRetryAt = tunnel.status().nextRetryAt;
+      expect(nextRetryAt).not.toBeNull();
+
+      socket.emit("close", 1006, Buffer.from("late close"));
+
+      expect(tunnel.status().nextRetryAt).toBe(nextRetryAt);
+      await vi.advanceTimersByTimeAsync(nextRetryAt! - Date.now());
+      expect(fakeWebSockets.instances).toHaveLength(2);
+    } finally {
+      tunnel.stop();
+      vi.useRealTimers();
+      await fakeHost.harness.dispose();
+    }
+  });
+
+  it("schedules one retry on heartbeat timeout before close", async () => {
+    vi.useFakeTimers();
+    const { fakeHost, tunnel } = createTunnelFixture();
+
+    try {
+      await tunnel.start();
+      const socket = fakeWebSockets.instances[0]!;
+      socket.emit("open");
+      expect(tunnel.status().state).toBe("connected");
+
+      await vi.advanceTimersByTimeAsync(80_000);
+      await vi.advanceTimersToNextTimerAsync();
+
+      expect(tunnel.status().state).toBe("reconnecting");
       const nextRetryAt = tunnel.status().nextRetryAt;
       expect(nextRetryAt).not.toBeNull();
 

--- a/plugins/connect/src/tunnel.ts
+++ b/plugins/connect/src/tunnel.ts
@@ -466,6 +466,9 @@ export class ConnectTunnel {
         onActivity: (at) => {
           this.lastRemoteActivityAt = at;
         },
+        onHeartbeatTimeout: () => {
+          scheduleReconnect("tunnel heartbeat timed out");
+        },
       });
       this.session.start();
       this.publish();


### PR DESCRIPTION
## Human comments

## What was wrong

On 2026-08-28 the connect plugin killed the bb server six times in two seconds with `PluginContextStaleError` (uncaught-exception dumps attached the full chain). When a plugin reload/disable stops the tunnel background service, `ConnectTunnel.stop()` disposes the `TunnelSession` and terminates the websocket — but frames already received and still decompressing through permessage-deflate are delivered by zlib callbacks afterwards. `TunnelSession.dispose()` neither detached nor gated the `message` listener, so the disposed session still processed an `open-http` frame. `executeHttp` calls `resolveOrigin` synchronously outside its try block, that call reached the plugin's now-stale `bb.server.loopbackBaseUrl` handle (`assertLive` throws), and because the caller runs `void this.executeHttp(...)`, the synchronous throw escaped as an unhandled rejection that Node escalated to a process-level uncaught exception (stack: `Zlib.processCallback → receiverOnMessage → onFrame → executeHttp → resolveStreamOrigin → get loopbackBaseUrl → assertLive`).

## What changed

`packages/tunnel-client/src/session.ts` only:

- Frame processing is gated on the existing `disposed` flag, both in the tunnel `message` handler and at the top of `onFrame` (the second gate also covers the buffered-frame replay in `openOriginWs`'s open handler).
- `executeHttp` now performs origin resolution, unregistered-origin handling, and header construction inside its existing try block, so a synchronous failure follows the established catch path (a `close-stream` frame with code 1011 and the error text as reason) instead of escaping the voided promise. The unregistered path is behavior-identical; its stream cleanup now flows through the existing `finally`.

No wire, protocol, signature, or heartbeat changes.

Stacked on #2718, which touches the same file — review only the last commit here (`Contain late tunnel frames and sync origin failures in TunnelSession`); the first commit is that PR.

## How you verified

- New `packages/tunnel-client/test/session-dispose.test.ts`: a binary `open-http` frame after `dispose()` is ignored (no `resolveOrigin` call, nothing sent); a synchronously-throwing `resolveOrigin` yields a `close-stream` code-1011 frame with no unhandled rejection; a heartbeat response after disposal is ignored. Before the source change the focused suite exited 1 with 2/3 failing and Vitest reporting the exact production crash shape — one unhandled rejection from `TunnelSession.executeHttp`; after the change it passes 3/3.
- `pnpm exec turbo run typecheck --filter=@bb/tunnel-client --filter=bb-plugin-connect` — clean.
- `pnpm exec turbo run test --filter=@bb/tunnel-client --filter=bb-plugin-connect --force` — 20/20 and 91/91 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> AGENT GENERATED