### PR TITLE
Correct provider bridge environment documentation

### DIFF
--- a/docs/provider-bridge-protocol.md
+++ b/docs/provider-bridge-protocol.md
@@ -530,9 +530,16 @@ bridge-internal and invisible to the runtime. Bridges that spawn children
 own the exit-race lessons the runtime learned (#1402): finalize on `close`
 not `exit` with a bounded grace, verify currency in stream callbacks, and
 never let a descendant holding an inherited pipe inject into a fresh
-session. The bridge's own environment is constructed by the runtime from an
-allowlist; bridges construct their children's environments the same way and
-must not leak their own inherited env downward (#1366, #1545).
+session. Before spawning a bridge, the runtime drops inherited `NODE_ENV` and
+every `BB_*` name (#1366), pins `PATH` to the login-shell value, adds
+`BB_PROVIDER_BRIDGE_RECORD_DIR` in record mode and `ELECTRON_RUN_AS_NODE` when
+needed, and re-adds each nonempty value named by the provider declaration's
+validated `env.passthrough` list. This is a denylist, not a general inherited-
+environment barrier: ordinary provider auth, proxy, and platform variables
+remain, as does the Volta guard in #1545. Provider child builders retain that
+ordinary inherited environment, with per-session overrides where applicable;
+`withoutBridgeRuntimeEnv` removes the bridge-only `ELECTRON_RUN_AS_NODE` and
+`BB_PROVIDER_BRIDGE_RECORD_DIR`, and individual bridges may sanitize further.
 
 ## Record mode
 
@@ -561,9 +568,8 @@ answer. Nothing buffers: each line is appended as it crosses.
 
 The daemon forwards the variable to the bridges it spawns and the runtime
 appends the provider id, so a daemon started with it writes
-`<dir>/<providerId>/<threadId>/…`. `withoutBridgeRuntimeEnv` and the
-`BB_*` allowlist both strip the variable from provider children, so a
-recorded provider never records itself.
+`<dir>/<providerId>/<threadId>/…`. `withoutBridgeRuntimeEnv` strips the
+variable from provider children, so a recorded provider never records itself.
 
 Recordings are the input of the parity harness
 (`packages/provider-bridge-protocol/src/testing/parity.ts`): the provider

--- a/packages/plugin-sdk/src/provider-bridge.ts
+++ b/packages/plugin-sdk/src/provider-bridge.ts
@@ -252,9 +252,8 @@ export type {
 } from "@bb/provider-bridge-protocol/bridge-kit";
 
 /**
- * A bridge that supervises child processes builds their environment with this
- * one allowlist function rather than handing them the daemon's own env
- * (incident rule: ambient env leaks).
+ * Removes inherited `NODE_ENV` and `BB_*` names while preserving every other
+ * defined value; callers may overlay child-specific bb variables afterward.
  */
 export { sanitizeInheritedChildProcessEnv } from "@bb/process-utils";
 


### PR DESCRIPTION
## Human comments

This was discovered by Fable while I had it onboarding me to the codebase and assessing the route to some adjustments/plugins I was curious about making for myself.

Since the bug seemed to check out, I had Codex verify and then open this PR.

## What was wrong

The provider-bridge protocol and the Plugin SDK export documentation said bridge environments were built from an allowlist and should not inherit ambient environment variables. Blame and `git log -p` trace that wording to [`c5b53caab5`](https://github.com/get-bb/bb/commit/c5b53caab56fecf24ab42c53ed4d9ce61f455e19) in #1640, even though that commit's bridge spawn path used the existing denylist: `sanitizeInheritedChildProcessEnv` removes `NODE_ENV` and `BB_*` and retains other defined values. The referenced history is narrower than the prose: #1366 established removal of inherited bb thread context from long-lived processes, #1402 concerns pipe-drain and replacement races, and #1545 records a non-bb Volta guard continuing to pass through. This documentation drift is tracked in #2723.

## What changed

- Replaced the allowlist claim with the shipped merge order: strip inherited `NODE_ENV`/`BB_*`, pin the login-shell `PATH`, add record/Electron bridge variables, and re-add nonempty values named by the validated `env.passthrough` list.
- Documented that ordinary provider auth, proxy, and platform variables remain inherited; provider-child builders remove `ELECTRON_RUN_AS_NODE` and `BB_PROVIDER_BRIDGE_RECORD_DIR`, apply overrides, and may sanitize further.
- Removed the duplicate allowlist claim from the record-mode paragraph and corrected the public Plugin SDK declaration comment for `sanitizeInheritedChildProcessEnv`.

This changes documentation only. It does not change executable behavior, a wire contract, or `HOST_DAEMON_PROTOCOL_VERSION`.

**Open question / unconfirmed hypothesis:** a true environment allowlist might be desirable as a separate hardening proposal, but I found no decision to adopt one in #1366, #1402, #1545, #1640, or their linked history. Such a change would need separate design and compatibility work because provider CLIs rely on inherited auth, proxy, and platform environment variables.

## How you verified

- Re-read the final paragraph against `sanitizeInheritedChildProcessEnv`, `providerProcessEnvFromShellEnv`, `defaultBridgeNodeEnv`, `spawnProvider`, `pickDeclaredEnv`, `validateProviderEnvPassthrough`, and `withoutBridgeRuntimeEnv`.
- Re-read the Claude Code, Codex, Pi, and ACP provider-child environment builders and the Claude custom-endpoint regression.
- Ran `grep -rn "allowlist" docs/ packages/provider-bridge-protocol packages/plugin-sdk`; every remaining hit is an unrelated parity/import-policy/contract-test allowlist or recorded provider output.
- `git diff --check`
- `pnpm exec prettier --check docs/provider-bridge-protocol.md packages/plugin-sdk/src/provider-bridge.ts` could not start because `pnpm` is not available on this workspace's `PATH`.
- Tests were not run because the diff changes only Markdown and a Plugin SDK declaration comment.

Fixes #2723

> AGENT GENERATED
