### PR TITLE
Delete managed worktree branches on cleanup

### DIFF
--- a/docs/worktrees.md
+++ b/docs/worktrees.md
@@ -117,6 +117,10 @@ it. If you
 want to keep work the agent did, commit and push (or open a PR) from inside
 the worktree before letting the thread go.
 
+If Git refuses to delete the branch, bb reports the failure in the destroy
+transcript and leaves the branch for manual cleanup. The worktree is still
+removed.
+
 Before bb removes the directory, it stops every process whose working
 directory is inside the worktree — the agent's provider process, its
 background jobs (dev servers, MCP servers, `nohup` jobs), and any process

--- a/packages/host-workspace/src/provisioning.ts
+++ b/packages/host-workspace/src/provisioning.ts
@@ -928,6 +928,74 @@ export async function runTeardownScript(
   }
 }
 
+async function deleteWorktreeBranch(args: {
+  branchName: string;
+  commonDir: string;
+  cwd: string;
+  onProgress: ProgressCallback | undefined;
+  shellPath: string | undefined;
+}): Promise<void> {
+  const startedAt = Date.now();
+  emitStep({
+    onProgress: args.onProgress,
+    key: "branch-delete-started",
+    text: `Deleting branch ${args.branchName}`,
+    status: "started",
+    startedAt,
+  });
+  try {
+    const result = await withGitRefMutationLock(args.commonDir, () =>
+      runGit(
+        [
+          "--git-dir",
+          args.commonDir,
+          "branch",
+          "--delete",
+          "--force",
+          "--",
+          args.branchName,
+        ],
+        {
+          cwd: args.cwd,
+          ...(args.shellPath !== undefined
+            ? { shellPath: args.shellPath }
+            : {}),
+          allowFailure: true,
+        },
+      ),
+    );
+    emitGitOutput(args.onProgress, "branch-delete", result);
+    emitStep({
+      onProgress: args.onProgress,
+      key:
+        result.exitCode === 0
+          ? "branch-delete-completed"
+          : "branch-delete-failed",
+      text:
+        result.exitCode === 0
+          ? `Deleted branch ${args.branchName}`
+          : `Failed to delete branch ${args.branchName}`,
+      status: result.exitCode === 0 ? "completed" : "failed",
+      startedAt,
+      metadata: { durationMs: Date.now() - startedAt },
+    });
+  } catch (error) {
+    emitStep({
+      onProgress: args.onProgress,
+      key: "branch-delete-failed",
+      text: `Failed to delete branch ${args.branchName}`,
+      status: "failed",
+      startedAt,
+      metadata: { durationMs: Date.now() - startedAt },
+    });
+    emitOutput(
+      args.onProgress,
+      "branch-delete-error",
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+}
+
 export async function removeWorktree(args: RemoveWorktreeArgs): Promise<void> {
   const force = args.force !== false;
   const workspacePath = path.resolve(args.path);
@@ -960,8 +1028,20 @@ export async function removeWorktree(args: RemoveWorktreeArgs): Promise<void> {
     await tryWithCheckoutMutationLock(
       workspacePath,
       () =>
-        withWorktreeMetadataLock(commonDir, () =>
-          runGit(
+        withWorktreeMetadataLock(commonDir, async () => {
+          const branchResult = await runGit(
+            ["symbolic-ref", "--short", "-q", "HEAD"],
+            {
+              cwd: workspacePath,
+              ...(args.shellPath !== undefined
+                ? { shellPath: args.shellPath }
+                : {}),
+              allowFailure: true,
+            },
+          );
+          const branchName =
+            branchResult.exitCode === 0 ? branchResult.stdout.trim() : "";
+          const removeResult = await runGit(
             [
               "--git-dir",
               commonDir,
@@ -977,8 +1057,17 @@ export async function removeWorktree(args: RemoveWorktreeArgs): Promise<void> {
                 : {}),
               allowFailure: true,
             },
-          ),
-        ),
+          );
+          if (removeResult.exitCode === 0 && branchName) {
+            await deleteWorktreeBranch({
+              branchName,
+              commonDir,
+              cwd: path.dirname(workspacePath),
+              onProgress: args.onProgress,
+              shellPath: args.shellPath,
+            });
+          }
+        }),
       undefined,
       args.shellPath === undefined ? {} : { shellPath: args.shellPath },
     );

--- a/packages/host-workspace/test/provisioning.test.ts
+++ b/packages/host-workspace/test/provisioning.test.ts
@@ -651,6 +651,11 @@ describe("workspace provisioning", () => {
     ).rejects.toThrow(/Setup script failed/u);
 
     await expect(fs.stat(targetPath)).rejects.toThrow();
+    const branch = await runGit(
+      ["show-ref", "--verify", "--quiet", "refs/heads/broken"],
+      { cwd: sourceRepo, allowFailure: true },
+    );
+    expect(branch.exitCode).not.toBe(0);
   });
 
   it("runs worktree setup scripts concurrently after creating worktrees", async () => {
@@ -1145,6 +1150,131 @@ describe("workspace provisioning", () => {
     expect(worktrees.stdout).not.toContain(targetPath);
   });
 
+  it("deletes the worktree branch after removal and recreates it during reprovision", async () => {
+    const sourceRepo = await initRepoWithOptionalSetup();
+    const parentDir = await makeTempDir("bb-remove-branch-parent-");
+    const targetPath = path.join(parentDir, "feature");
+    const branchName = "feature-delete-and-recreate";
+
+    await createWorktree({
+      sourcePath: sourceRepo,
+      targetPath,
+      branchName,
+      baseBranch: "main",
+      timeoutMs: 900000,
+    });
+    await removeWorktree({ path: targetPath, timeoutMs: 900000, force: true });
+
+    const deletedBranch = await runGit(
+      ["show-ref", "--verify", "--quiet", `refs/heads/${branchName}`],
+      { cwd: sourceRepo, allowFailure: true },
+    );
+    expect(deletedBranch.exitCode).not.toBe(0);
+
+    await expect(
+      createWorktree({
+        sourcePath: sourceRepo,
+        targetPath,
+        branchName,
+        baseBranch: "main",
+        timeoutMs: 900000,
+      }),
+    ).resolves.toEqual({ path: targetPath });
+    expect(await new Workspace(targetPath).currentBranch).toBe(branchName);
+  });
+
+  it("keeps the branch when the worktree has detached HEAD", async () => {
+    const sourceRepo = await initRepoWithOptionalSetup();
+    const parentDir = await makeTempDir("bb-remove-detached-parent-");
+    const targetPath = path.join(parentDir, "feature");
+    const branchName = "feature-detached";
+
+    await createWorktree({
+      sourcePath: sourceRepo,
+      targetPath,
+      branchName,
+      baseBranch: "main",
+      timeoutMs: 900000,
+    });
+    await runGit(["checkout", "--detach"], { cwd: targetPath });
+
+    await expect(
+      removeWorktree({ path: targetPath, timeoutMs: 900000, force: true }),
+    ).resolves.toBeUndefined();
+
+    const branch = await runGit(
+      ["show-ref", "--verify", "--quiet", `refs/heads/${branchName}`],
+      { cwd: sourceRepo, allowFailure: true },
+    );
+    expect(branch.exitCode).toBe(0);
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "reports checked-out branch deletion failures and still removes the worktree",
+    async () => {
+      const sourceRepo = await initRepoWithOptionalSetup();
+      const parentDir = await makeTempDir("bb-remove-branch-failure-parent-");
+      const binPath = await makeTempDir("bb-remove-branch-failure-bin-");
+      const targetPath = path.join(parentDir, "feature");
+      const checkedOutElsewherePath = path.join(
+        await makeTempDir("bb-remove-branch-failure-checkout-"),
+        "feature",
+      );
+      const branchName = "feature-delete-failure";
+      const gitWrapperPath = path.join(binPath, "git");
+      const systemPath = process.env.PATH ?? "";
+      await fs.writeFile(
+        gitWrapperPath,
+        [
+          "#!/bin/sh",
+          "set -eu",
+          `system_path=${shellSingleQuote(systemPath)}`,
+          `checked_out_elsewhere=${shellSingleQuote(checkedOutElsewherePath)}`,
+          'if [ "$#" -ge 3 ] && [ "$1" = "--git-dir" ] && [ "$3" = "branch" ]; then',
+          '  PATH="$system_path" git --git-dir "$2" worktree add "$checked_out_elsewhere" "$7"',
+          "fi",
+          'PATH="$system_path" exec git "$@"',
+        ].join("\n") + "\n",
+        "utf8",
+      );
+      await fs.chmod(gitWrapperPath, 0o755);
+      await createWorktree({
+        sourcePath: sourceRepo,
+        targetPath,
+        branchName,
+        baseBranch: "main",
+        timeoutMs: 900000,
+      });
+      const entries: string[] = [];
+
+      await expect(
+        removeWorktree({
+          path: targetPath,
+          timeoutMs: 900000,
+          force: true,
+          shellPath: `${binPath}${path.delimiter}${systemPath}`,
+          onProgress: (entry) => entries.push(`${entry.key}:${entry.text}`),
+        }),
+      ).resolves.toBeUndefined();
+
+      expect(entries).toContain(
+        `branch-delete-failed:Failed to delete branch ${branchName}`,
+      );
+      expect(
+        entries.some((entry) => entry.includes("used by worktree at")),
+      ).toBe(true);
+      await expect(fs.stat(targetPath)).rejects.toThrow();
+      expect(await new Workspace(checkedOutElsewherePath).currentBranch).toBe(
+        branchName,
+      );
+      const branch = await runGit(
+        ["show-ref", "--verify", "--quiet", `refs/heads/${branchName}`],
+        { cwd: sourceRepo, allowFailure: true },
+      );
+      expect(branch.exitCode).toBe(0);
+    },
+  );
+
   it("removes orphaned worktree directories after the .git file is gone", async () => {
     const sourceRepo = await initRepoWithOptionalSetup();
     const parentDir = await makeTempDir("bb-remove-orphan-gitfile-");
@@ -1190,5 +1320,15 @@ describe("workspace provisioning", () => {
     await removeWorktree({ path: targetPath, timeoutMs: 900000, force: false });
 
     await expect(fs.stat(targetPath)).rejects.toThrow();
+    const branch = await runGit(
+      [
+        "show-ref",
+        "--verify",
+        "--quiet",
+        "refs/heads/feature-metadata-failure",
+      ],
+      { cwd: sourceRepo, allowFailure: true },
+    );
+    expect(branch.exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
## Human comments

Like #2725, this was discovered by Fable while I had it onboarding me to the codebase and assessing the route to some adjustments/plugins I was curious about making for myself.

Since this bug *also* seemed to check out, I had Codex verify and then open this PR, too.

## What was wrong

`removeWorktree` removed managed checkout metadata and the directory but never deleted the branch created by `git worktree add -B`. Successful cleanup therefore left every generated `bb/<slug>-<threadId>` branch in the source repository, contrary to the worktree guide's cleanup contract reported in #2724.

## What changed

- Read the worktree's symbolic HEAD immediately before removal while holding the existing checkout and worktree-metadata locks.
- After a successful `git worktree remove`, delete that branch against the resolved common Git directory while also coordinating through the shared Git-ref mutation lock.
- Skip branch deletion for detached HEAD or failed symbolic-ref lookup, and never delete the branch when worktree removal itself fails.
- Report branch deletion failures and Git diagnostics in the environment destroy transcript without failing worktree destruction.
- Cover successful cleanup and same-name reprovision, detached HEAD, a branch checked out by another worktree, failed setup rollback, and failed worktree removal.
- Document the non-fatal branch-deletion failure behavior.

The server↔daemon command and result schemas did not change, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

## How you verified

- Fail-before: the new successful-destroy/reprovision test, failed-setup rollback assertion, and deletion-failure transcript test failed against the old implementation; detached-HEAD and failed-worktree-removal guard tests passed as safety invariants. All pass with this change.
- `TMPDIR=/private/tmp pnpm exec turbo run test --filter=@bb/host-workspace --force --env-mode=loose` — 9 files, 233 tests passed. Loose env mode forwards the normalized macOS temp path around the existing `/tmp` vs `/private/tmp` assertion on `main`.
- `pnpm exec turbo run typecheck --filter=@bb/host-workspace --force` — passed.
- `pnpm exec turbo run test --filter=@bb/server --force -- --run test/environments/environment-provisioning.test.ts` — 11 tests passed, including preservation of the stored branch name during managed reprovision.
- Live source QA on `origin/main`: after managed environment destruction, the worktree disappeared but `git branch --list` still returned `bb/branch-cleanup-repro-thr_wzberxex69`.
- Live source QA with this branch: after the same spawn/archive/destroy flow, both the worktree and `bb/branch-cleanup-fixed-thr_x4z2wru6gz` were gone.
- `pnpm exec oxfmt --check docs/worktrees.md packages/host-workspace/src/provisioning.ts packages/host-workspace/test/provisioning.test.ts`
- `git diff origin/main...HEAD --check`

Fixes #2724

> AGENT GENERATED
