### PR TITLE
fix(pi): accept image-only prompts

### DIFF
--- a/plugins/provider-pi/src/bridge/bridge.lifecycle.test.ts
+++ b/plugins/provider-pi/src/bridge/bridge.lifecycle.test.ts
@@ -4,6 +4,7 @@ import {
   mkdirSync,
   readFileSync,
   readdirSync,
+  writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
@@ -219,6 +220,29 @@ async function expectScratchFilesGone(): Promise<void> {
     await new Promise((resolve) => setTimeout(resolve, 25));
   }
 }
+
+it("accepts a prompt containing only a local image", async () => {
+  const threadId = "thr_image_only";
+  await harness.startThread(threadId);
+  const imagePath = join(harness.workspaceDir, "screenshot.png");
+  writeFileSync(imagePath, Buffer.from("fake png data"));
+
+  const response = await harness.request(2, "turn/start", {
+    threadId,
+    providerThreadId: threadId,
+    clientRequestId: "creq_234567abcd",
+    input: [{ type: "localImage", path: imagePath, mimeType: "image/png" }],
+    options: FULL_PERMISSION_OPTIONS,
+  });
+
+  expect(response.result).toEqual({ threadId });
+  await harness.waitForTurnBoundary(threadId);
+  expect(
+    harness.deltasOf(threadId).some(
+      (delta) => delta.kind === "item.textDelta" && delta.text === "Response to: ",
+    ),
+  ).toBe(true);
+});
 
 it("a child's tool and prompt files go with the child after release and failed construction", async () => {
   await harness.startThread("thr_lc_scratch", {

--- a/plugins/provider-pi/src/bridge/bridge.ts
+++ b/plugins/provider-pi/src/bridge/bridge.ts
@@ -1064,12 +1064,12 @@ async function handleTurnStart(
     return;
   }
   const { text, images } = extractInput(params.input);
-  if (!text) {
+  if (!text && images.length === 0) {
     sendError(id, BRIDGE_JSON_RPC_ERRORS.INVALID_PARAMS, "Missing input text");
     return;
   }
   try {
-    await startPiPrompt(threadSession, params.threadId, text, images);
+    await startPiPrompt(threadSession, params.threadId, text ?? "", images);
     recordAcceptedTurnInput(params);
     sendResult(id, { threadId: params.threadId });
   } catch (error) {
@@ -1091,7 +1091,7 @@ async function handleTurnSteer(
     return;
   }
   const { text, images } = extractInput(params.input);
-  if (!text) {
+  if (!text && images.length === 0) {
     sendError(id, BRIDGE_JSON_RPC_ERRORS.INVALID_PARAMS, "Missing input text");
     return;
   }
@@ -1101,7 +1101,7 @@ async function handleTurnSteer(
   }
   try {
     await threadSession.session.steer(
-      text,
+      text ?? "",
       images.length > 0 ? images : undefined,
     );
     sendThreadDeltas(params.threadId, [


### PR DESCRIPTION
## Human comments

Fix for thsi:

<img width="400" src="https://github.com/user-attachments/assets/caddb865-26b2-428d-83fb-8ca0bc5f713a" />


## What was wrong

Pi's provider bridge rejected a turn whenever its extracted text was empty, even when the request contained a valid local image attachment. As a result, sending a screenshot without accompanying text returned `Missing input text`.

## What changed

The Pi bridge now accepts a prompt or steer request when it contains either text or images. Image-only requests are forwarded to Pi with an empty text payload, while completely empty requests remain invalid. Added lifecycle coverage for a local image-only prompt.

No wire protocol, CLI, or documentation changes were required.

## How you verified

- `cd plugins/provider-pi && pnpm exec vitest run --config vitest.config.ts src/bridge/bridge.lifecycle.test.ts --reporter=dot`
- 1 test file passed, 9 tests passed.
- The new test failed initially because its test request ID did not match the repository's allowed format; after correcting the fixture, it passed.

> AGENT GENERATED