### PR TITLE
Retry a refused turn on another model

### DIFF
--- a/apps/cli/src/__tests__/bb-cli-skill-coverage.test.ts
+++ b/apps/cli/src/__tests__/bb-cli-skill-coverage.test.ts
@@ -64,7 +64,7 @@ describe("bb-cli skill command index", () => {
   it("leaves shipped plugin commands to their plugin skills", () => {
     const skill = readMarkdownTree(BB_CLI_SKILL_ROOT);
     expect(skill).not.toMatch(
-      /\bbb (?:automation|connect|instructions|github|keep-awake|provider-retry|memory|secret|docs|tasks|workflows)\b/,
+      /\bbb (?:automation|connect|instructions|github|keep-awake|provider-retry|refusal-fallback|memory|secret|docs|tasks|workflows)\b/,
     );
     expect(skill).not.toMatch(/\b(?:built-in|builtin|official) plugins?\b/i);
   });

--- a/apps/server/src/services/plugins/builtin-registry.ts
+++ b/apps/server/src/services/plugins/builtin-registry.ts
@@ -124,6 +124,12 @@ export const BUILTIN_PLUGINS = [
     category: "Agent interaction",
   },
   {
+    name: "provider-refusal-fallback",
+    pluginId: "provider-refusal-fallback",
+    defaultEnabled: true,
+    category: "Agent interaction",
+  },
+  {
     name: "secrets",
     pluginId: "secrets",
     defaultEnabled: true,

--- a/apps/server/test/services/plugins/builtin-plugins.test.ts
+++ b/apps/server/test/services/plugins/builtin-plugins.test.ts
@@ -231,6 +231,7 @@ describe("builtin plugin reconciliation", () => {
       ["provider-claude-code", "./icons/claude-code.svg"],
       ["provider-codex", "./icons/codex.svg"],
       ["provider-pi", "./icons/pi.svg"],
+      ["provider-refusal-fallback", "SecurityCheck"],
       ["provider-retry", "ArrowReloadHorizontal"],
       ["secrets", "Lock"],
       ["side-chat", "SideChat"],

--- a/apps/server/test/services/plugins/official-plugins.test.ts
+++ b/apps/server/test/services/plugins/official-plugins.test.ts
@@ -107,6 +107,7 @@ describe("official plugin registry invariants", () => {
       "provider-claude-code": "Agent interaction",
       "provider-codex": "Agent interaction",
       "provider-pi": "Agent interaction",
+      "provider-refusal-fallback": "Agent interaction",
       "provider-retry": "Agent interaction",
       secrets: "Developer tools",
       "side-chat": "Agent interaction",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -810,6 +810,27 @@ banner or with `bb provider-retry cancel <thread-id>`. Run
 `bb provider-retry retry <thread-id>` for a manual recovery, including credit
 or spend-control limits that do not report a reset time.
 
+### Refusal fallback plugin
+
+The builtin Refusal fallback plugin is enabled on fresh installations. When a
+provider's safety policy refuses a message and the provider has no fallback of
+its own, bb offers the models listed below the refused one in that provider's
+catalog, switches the thread to the chosen model, and sends one agent-only
+`Please continue.` turn. Declining leaves the thread on the refused model.
+Because only lower catalog entries are offered, a repeatedly refused thread
+runs out of alternatives instead of switching forever. Disable it under
+Extensions → Plugins or with `bb plugin disable provider-refusal-fallback`.
+
+Ticking "Switch automatically next time, do not ask again" stores the chosen
+model for that provider and skips the prompt afterwards. The choice is per
+provider, not per thread. Inspect and clear it with:
+
+```bash
+bb refusal-fallback status [--json]
+bb refusal-fallback forget <provider-id>
+bb refusal-fallback retry [thread-id]
+```
+
 ### Workflows plugin
 
 The builtin Workflows plugin is disabled on fresh installations. Enable it

--- a/packages/plugin-api-map/src/plugin-icons.ts
+++ b/packages/plugin-api-map/src/plugin-icons.ts
@@ -16,6 +16,7 @@ import {
   MessageAdd02Icon,
   MessageQuestionIcon,
   SmartPhone01Icon,
+  SecurityCheckIcon,
   SourceCodeIcon,
   SparklesIcon,
   TerminalIcon,
@@ -40,6 +41,10 @@ const FIRST_PARTY_PLUGINS: Record<string, FirstPartyPlugin> = {
   "Keep Awake": { id: "keep-awake", icon: Coffee01Icon },
   Memory: { id: "memory", icon: BrainIcon },
   "Provider retry": { id: "provider-retry", icon: ArrowReloadHorizontalIcon },
+  "Refusal fallback": {
+    id: "provider-refusal-fallback",
+    icon: SecurityCheckIcon,
+  },
   "Remote access": { id: "connect", icon: SmartPhone01Icon },
   Secrets: { id: "secrets", icon: LockIcon },
   "Side chat": { id: "side-chat", icon: MessageAdd02Icon },

--- a/packages/templates/src/templates/bb-guide-plugins.md
+++ b/packages/templates/src/templates/bb-guide-plugins.md
@@ -53,6 +53,16 @@ setting defaults to `6 hours`; choose `24 hours` or `No limit` from the plugin
 detail page, or configure it with
 `bb plugin config provider-retry set maximumWait <value>`.
 
+The builtin Refusal fallback plugin is enabled on fresh installations. When a
+provider refuses a message on safety grounds and offers no fallback of its own,
+it asks which model to retry on, switches the thread, and sends one agent-only
+`Please continue.` turn. Only models below the refused one in the provider's
+catalog are offered, so retries run out instead of looping.
+
+  bb refusal-fallback status [--json]           Show automatic switches
+  bb refusal-fallback forget <provider-id>      Ask again after a refusal
+  bb refusal-fallback retry [thread-id]         Re-check a thread
+
 The builtin Workflows plugin runs durable provider-independent JavaScript
 orchestration. It is disabled on fresh installations; enable `workflows` under
 Extensions → Plugins or run `bb plugin enable workflows` before using:

--- a/packages/templates/src/templates/bb-guide-providers.md
+++ b/packages/templates/src/templates/bb-guide-providers.md
@@ -67,6 +67,15 @@ running. Disabling/reloading the plugin or restarting the server clears them;
 the original failed thread remains available for `bb provider-retry retry`.
 Credit and spend-control exhaustion without a reset time is manual-only.
 
+A safety refusal is different from a rate limit: the provider reports that the
+selected model will not answer this message at all. bb surfaces it as a policy
+provider error, and the Refusal fallback plugin offers the models listed below
+the refused one for that provider, then retries on the chosen one.
+
+  bb refusal-fallback status [--json]           Show automatic switches
+  bb refusal-fallback forget <provider-id>      Ask again after a refusal
+  bb refusal-fallback retry [thread-id]         Re-check a thread
+
 Claude Code's native Workflow tool can be disabled separately on its provider
 page. This preference also defaults off and applies to newly started, resumed,
 or forked provider sessions.

--- a/plugins/provider-claude-code/src/delta-translation.test.ts
+++ b/plugins/provider-claude-code/src/delta-translation.test.ts
@@ -1569,21 +1569,50 @@ describe("claude model refusals", () => {
     expect(detailedEvents).toEqual([]);
   });
 
-  it("surfaces refusal without fallback as a warning", () => {
+  it("surfaces refusal without fallback as a policy provider error", () => {
     const harness = createClaudeDeltaHarness();
     const events = harness.translate({
       type: "system",
       subtype: "model_refusal_no_fallback",
+      original_model: "claude-opus-5[1m]",
+      api_refusal_category: "cyber",
       content: "The model refused and no fallback was configured.",
       session_id: "sess-1",
     });
 
     expect(events).toEqual([
       expect.objectContaining({
-        type: "provider/warning",
-        category: "general",
-        summary: "Model refused the request",
-        details: "The model refused and no fallback was configured.",
+        type: "provider/error",
+        message: "Provider error",
+        detail: "The model refused and no fallback was configured.",
+        errorInfo: {
+          category: "policy",
+          providerCode: "cyber",
+          httpStatusCode: null,
+        },
+      }),
+    ]);
+  });
+
+  it("names the refusing model when the refusal carries no content", () => {
+    const harness = createClaudeDeltaHarness();
+    const events = harness.translate({
+      type: "system",
+      subtype: "model_refusal_no_fallback",
+      original_model: "claude-opus-5[1m]",
+      session_id: "sess-1",
+    });
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: "provider/error",
+        detail:
+          "claude-opus-5[1m] refused the request and no fallback model was available.",
+        errorInfo: {
+          category: "policy",
+          providerCode: "model_refusal_no_fallback",
+          httpStatusCode: null,
+        },
       }),
     ]);
   });

--- a/plugins/provider-claude-code/src/delta-translation.ts
+++ b/plugins/provider-claude-code/src/delta-translation.ts
@@ -42,7 +42,10 @@ import {
   type ClaudeRateLimitEvent,
   type ClaudeResultMessage,
 } from "./schemas.js";
-import { buildClaudeProviderErrorInfo } from "./error-info.js";
+import {
+  buildClaudeModelRefusalErrorInfo,
+  buildClaudeProviderErrorInfo,
+} from "./error-info.js";
 import {
   foldClaudeTaskToolResult,
   type ClaudeTaskPlanState,
@@ -351,6 +354,17 @@ function isHardClaudeRateLimitRejection(
 
 function isClaudeResultFailure(message: ClaudeResultMessage): boolean {
   return message.is_error === true || message.subtype.startsWith("error");
+}
+
+function buildClaudeModelRefusalDetail(refusal: {
+  original_model?: string | undefined;
+  content?: string | undefined;
+}): string {
+  if (refusal.content !== undefined) {
+    return refusal.content;
+  }
+  const model = refusal.original_model ?? "The selected model";
+  return `${model} refused the request and no fallback model was available.`;
 }
 
 function getClaudeResultErrorDetail(message: ClaudeResultMessage): string {
@@ -694,14 +708,15 @@ export function createClaudeDeltaTranslator(
     const noFallbackMessage =
       claudeModelRefusalNoFallbackSystemMessageSchema.safeParse(event);
     if (noFallbackMessage.success) {
+      const refusal = noFallbackMessage.data;
       return [
         {
-          kind: "provider.warning",
-          summary: "Model refused the request",
-          details:
-            noFallbackMessage.data.content ??
-            "The selected model refused the request and no fallback model was available.",
-          vouchedTurn: true,
+          kind: "provider.error",
+          message: "Provider error",
+          detail: buildClaudeModelRefusalDetail(refusal),
+          errorInfo: buildClaudeModelRefusalErrorInfo(
+            refusal.api_refusal_category ?? null,
+          ),
         },
       ];
     }

--- a/plugins/provider-claude-code/src/error-info.ts
+++ b/plugins/provider-claude-code/src/error-info.ts
@@ -111,6 +111,18 @@ function getClaudeProviderCode(
   return null;
 }
 
+export const CLAUDE_MODEL_REFUSAL_PROVIDER_CODE = "model_refusal_no_fallback";
+
+export function buildClaudeModelRefusalErrorInfo(
+  apiRefusalCategory: string | null,
+): ProviderErrorInfo {
+  return {
+    category: "policy",
+    providerCode: apiRefusalCategory ?? CLAUDE_MODEL_REFUSAL_PROVIDER_CODE,
+    httpStatusCode: null,
+  };
+}
+
 export function buildClaudeProviderErrorInfo(
   args: BuildClaudeProviderErrorInfoArgs,
 ): ProviderErrorInfo | null {

--- a/plugins/provider-claude-code/src/schemas.ts
+++ b/plugins/provider-claude-code/src/schemas.ts
@@ -215,6 +215,8 @@ export const claudeModelRefusalNoFallbackSystemMessageSchema =
   claudeSystemMessageSchema
     .extend({
       subtype: z.literal("model_refusal_no_fallback"),
+      original_model: z.string().min(1).optional(),
+      api_refusal_category: z.string().nullish(),
       content: z.string().optional(),
     })
     .passthrough();

--- a/plugins/provider-refusal-fallback/app.test.tsx
+++ b/plugins/provider-refusal-fallback/app.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { loadPluginApp, renderSlot } from "@get-bb/plugin-sdk/testing/app";
+import type {
+  RefusalFallbackPayload,
+  RefusalFallbackResponse,
+} from "./src/contracts";
+
+const app = await loadPluginApp(() => import("./app"));
+
+afterEach(cleanup);
+
+const payload: RefusalFallbackPayload = {
+  refusedModelLabel: "Opus 5 (1M)",
+  detail: "Opus 5 (1M)'s safeguards flagged this message.",
+  options: [
+    {
+      model: "claude-opus-4-8[1m]",
+      label: "Opus 4.8 (1M)",
+      description: "Opus 4.8 with 1M context",
+    },
+    { model: "claude-sonnet-5", label: "Sonnet 5" },
+  ],
+};
+
+function render(handlers: { submit?: (value: unknown) => Promise<void> } = {}) {
+  return renderSlot(app.pendingInteractions[0]!, {
+    interaction: {
+      id: "pint_test",
+      threadId: "thr_test",
+      title: "Opus 5 (1M) refused this message",
+      payload: payload as never,
+      createdAt: 0,
+      expiresAt: null,
+    },
+    submit: handlers.submit ?? (async () => undefined),
+    cancel: async () => undefined,
+  });
+}
+
+function buttonByText(
+  slot: ReturnType<typeof render>,
+  text: string,
+): HTMLButtonElement {
+  const button = slot.getByText(text).closest("button");
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error(`${text} is not rendered inside a button`);
+  }
+  return button;
+}
+
+describe("choosing a fallback model", () => {
+  it("switches to the first offered model without remembering the choice", () => {
+    const submit = vi.fn(async (_value: unknown) => undefined);
+    const slot = render({ submit });
+
+    fireEvent.click(buttonByText(slot, "Switch and retry"));
+
+    expect(submit).toHaveBeenCalledTimes(1);
+    expect(submit.mock.calls[0]?.[0]).toEqual({
+      model: "claude-opus-4-8[1m]",
+      remember: false,
+    } satisfies RefusalFallbackResponse);
+  });
+
+  it("remembers the chosen model when the user opts out of the prompt", () => {
+    const submit = vi.fn(async (_value: unknown) => undefined);
+    const slot = render({ submit });
+
+    fireEvent.click(buttonByText(slot, "Sonnet 5"));
+    fireEvent.click(
+      slot.getByLabelText("Switch automatically next time, do not ask again"),
+    );
+    fireEvent.click(buttonByText(slot, "Switch and retry"));
+
+    expect(submit.mock.calls[0]?.[0]).toEqual({
+      model: "claude-sonnet-5",
+      remember: true,
+    } satisfies RefusalFallbackResponse);
+  });
+
+  it("keeps the refused model when the user declines", () => {
+    const submit = vi.fn(async (_value: unknown) => undefined);
+    const slot = render({ submit });
+
+    fireEvent.click(buttonByText(slot, "Keep Opus 5 (1M)"));
+
+    expect(submit.mock.calls[0]?.[0]).toEqual({
+      model: null,
+      remember: false,
+    } satisfies RefusalFallbackResponse);
+  });
+});

--- a/plugins/provider-refusal-fallback/app.tsx
+++ b/plugins/provider-refusal-fallback/app.tsx
@@ -1,0 +1,167 @@
+import { useMemo, useState } from "react";
+import {
+  definePluginApp,
+  type PluginPendingInteractionProps,
+} from "@get-bb/plugin-sdk/app";
+import { Button } from "@bb/shared-ui/button";
+import { Icon } from "@bb/shared-ui/icon";
+import { cn } from "@bb/shared-ui/lib/utils";
+import {
+  REFUSAL_FALLBACK_RENDERER_ID,
+  refusalFallbackPayloadSchema,
+  type RefusalFallbackOption,
+  type RefusalFallbackResponse,
+} from "./src/contracts.js";
+
+interface ModelRowProps {
+  checked: boolean;
+  option: RefusalFallbackOption;
+  onSelect: () => void;
+}
+
+function ModelRow({ checked, option, onSelect }: ModelRowProps) {
+  return (
+    <button
+      type="button"
+      aria-pressed={checked}
+      onClick={onSelect}
+      className={cn(
+        "flex w-full items-start gap-2.5 rounded-md px-2.5 py-1.5 text-left transition-colors",
+        checked ? "bg-surface-selected" : "hover:bg-state-hover",
+      )}
+    >
+      <span
+        className={cn(
+          "mt-0.5 flex size-4 shrink-0 items-center justify-center rounded-full border",
+          checked
+            ? "border-primary bg-primary text-primary-foreground"
+            : "border-input",
+        )}
+      >
+        {checked ? <Icon name="Check" className="size-3" aria-hidden /> : null}
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block text-sm font-medium text-foreground">
+          {option.label}
+        </span>
+        {option.description ? (
+          <span className="mt-0.5 block text-xs leading-snug text-muted-foreground">
+            {option.description}
+          </span>
+        ) : null}
+      </span>
+    </button>
+  );
+}
+
+function RefusalFallbackInteraction({
+  interaction,
+  submit,
+  cancel,
+}: PluginPendingInteractionProps) {
+  const parsed = useMemo(
+    () => refusalFallbackPayloadSchema.safeParse(interaction.payload),
+    [interaction.payload],
+  );
+  const options = parsed.success ? parsed.data.options : [];
+  const [selected, setSelected] = useState(() => options[0]?.model ?? null);
+  const [remember, setRemember] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  const finish = (response: RefusalFallbackResponse): void => {
+    if (busy) return;
+    setBusy(true);
+    void (async () => {
+      try {
+        await submit(response);
+      } catch {
+      } finally {
+        setBusy(false);
+      }
+    })();
+  };
+
+  const handleCancel = (): void => {
+    void (async () => {
+      try {
+        await cancel();
+      } catch {}
+    })();
+  };
+
+  if (!parsed.success) {
+    return (
+      <div className="space-y-3">
+        <p className="text-sm text-muted-foreground">
+          This refusal could not be displayed.
+        </p>
+        <Button type="button" variant="outline" onClick={handleCancel}>
+          Cancel
+        </Button>
+      </div>
+    );
+  }
+
+  const payload = parsed.data;
+
+  return (
+    <div className="flex min-h-0 flex-col text-xs text-muted-foreground">
+      <div className="text-sm font-semibold text-foreground">
+        {payload.refusedModelLabel} refused this message
+      </div>
+      <p className="mt-1 leading-snug">{payload.detail}</p>
+      <div className="mt-2 space-y-0.5">
+        {payload.options.map((option) => (
+          <ModelRow
+            key={option.model}
+            checked={selected === option.model}
+            option={option}
+            onSelect={() => setSelected(option.model)}
+          />
+        ))}
+      </div>
+      <label className="mt-2 flex items-center gap-2 px-2.5 text-xs text-muted-foreground">
+        <input
+          type="checkbox"
+          checked={remember}
+          disabled={busy}
+          onChange={(event) => setRemember(event.target.checked)}
+        />
+        Switch automatically next time, do not ask again
+      </label>
+      <div className="mt-3 flex shrink-0 items-center justify-between gap-2">
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          disabled={busy}
+          onClick={() => finish({ model: null, remember: false })}
+        >
+          Keep {payload.refusedModelLabel}
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          disabled={busy || selected === null}
+          onClick={() =>
+            selected === null
+              ? undefined
+              : finish({ model: selected, remember })
+          }
+        >
+          {busy ? (
+            <Icon name="Spinner" className="size-3 animate-spin" />
+          ) : null}
+          Switch and retry
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export default definePluginApp((app) => {
+  app.slots.pendingInteraction({
+    id: REFUSAL_FALLBACK_RENDERER_ID,
+    component: RefusalFallbackInteraction,
+  });
+});

--- a/plugins/provider-refusal-fallback/package.json
+++ b/plugins/provider-refusal-fallback/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "bb-plugin-provider-refusal-fallback",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Retry a turn on another model when the provider's safety policy refuses it.",
+  "engines": {
+    "bb": ">=0.0"
+  },
+  "bb": {
+    "name": "Refusal fallback",
+    "description": "Retry a turn on another model when the provider's safety policy refuses it.",
+    "branding": {
+      "icon": "SecurityCheck"
+    },
+    "server": "./server.ts",
+    "app": "./app.tsx"
+  },
+  "keywords": [
+    "bb-plugin"
+  ],
+  "scripts": {
+    "test": "vitest run --config vitest.config.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@bb/shared-ui": "workspace:*",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@get-bb/plugin-sdk": "workspace:*",
+    "@testing-library/react": "^16.3.2",
+    "@types/node": "^22.0.0",
+    "@types/react": "^19.0.0",
+    "jsdom": "^29.0.1",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "typescript": "npm:@typescript/typescript6@^6.0.2",
+    "typescript-7": "npm:typescript@^7.0.2",
+    "vitest": "^4.1.1"
+  }
+}

--- a/plugins/provider-refusal-fallback/server.test.ts
+++ b/plugins/provider-refusal-fallback/server.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from "vitest";
+import { classifyRefusalFallback } from "./src/recovery.js";
+import { alternativeModels, autoChoiceKey } from "./src/service.js";
+
+type Events = Parameters<typeof classifyRefusalFallback>[0]["events"];
+type Models = Parameters<typeof alternativeModels>[0];
+
+const THREAD_ID = "thr_1";
+const TURN_ID = "turn_1";
+const REQUEST_ID = "req_1";
+
+function model(id: string, displayName: string) {
+  return {
+    id,
+    model: id,
+    displayName,
+    description: "",
+    supportedReasoningEfforts: [],
+    defaultReasoningEffort: "medium",
+    isDefault: false,
+  };
+}
+
+const CATALOG = [
+  model("claude-opus-5[1m]", "Opus 5 (1M)"),
+  model("claude-opus-4-8[1m]", "Opus 4.8 (1M)"),
+  model("claude-opus-4-7[1m]", "Opus 4.7 (1M)"),
+  model("claude-sonnet-5", "Sonnet 5"),
+] as unknown as Models;
+
+function turnScope() {
+  return { kind: "turn", turnId: TURN_ID } as const;
+}
+
+function requested(seq: number, modelId: string) {
+  return {
+    seq,
+    type: "client/turn/requested",
+    threadId: THREAD_ID,
+    scope: { kind: "thread" },
+    data: {
+      requestId: REQUEST_ID,
+      execution: {
+        model: modelId,
+        permissionMode: "auto",
+        reasoningLevel: "high",
+        serviceTier: "default",
+      },
+    },
+  };
+}
+
+function accepted(seq: number) {
+  return {
+    seq,
+    type: "turn/input/accepted",
+    threadId: THREAD_ID,
+    scope: turnScope(),
+    data: { clientRequestId: REQUEST_ID },
+  };
+}
+
+function policyError(seq: number, detail: string) {
+  return {
+    seq,
+    type: "provider/error",
+    threadId: THREAD_ID,
+    scope: turnScope(),
+    data: {
+      message: "Provider error",
+      detail,
+      errorInfo: {
+        category: "policy",
+        providerCode: "model_refusal_no_fallback",
+        httpStatusCode: null,
+      },
+    },
+  };
+}
+
+function completed(seq: number, status: "completed" | "failed") {
+  return {
+    seq,
+    type: "turn/completed",
+    threadId: THREAD_ID,
+    scope: turnScope(),
+    data: { status },
+  };
+}
+
+function events(rows: unknown[]): Events {
+  return rows as Events;
+}
+
+describe("classifyRefusalFallback", () => {
+  it("returns the refused model and detail for a finished refused turn", () => {
+    const inspection = classifyRefusalFallback({
+      environmentId: "env_1",
+      providerId: "claude-code",
+      events: events([
+        requested(1, "claude-opus-5[1m]"),
+        accepted(2),
+        policyError(3, "safeguards flagged this message"),
+        completed(4, "completed"),
+      ]),
+    });
+
+    expect(inspection.reason).toBe("eligible");
+    expect(inspection.candidate).toEqual({
+      detail: "safeguards flagged this message",
+      refusedModel: "claude-opus-5[1m]",
+      turnId: TURN_ID,
+    });
+  });
+
+  it("ignores a turn whose provider error is not a policy refusal", () => {
+    const rateLimited = {
+      seq: 3,
+      type: "provider/error",
+      threadId: THREAD_ID,
+      scope: turnScope(),
+      data: {
+        message: "Provider error",
+        errorInfo: {
+          category: "rate-limit",
+          providerCode: "rate_limit",
+          httpStatusCode: 429,
+        },
+      },
+    };
+
+    const inspection = classifyRefusalFallback({
+      environmentId: "env_1",
+      providerId: "claude-code",
+      events: events([
+        requested(1, "claude-opus-5[1m]"),
+        accepted(2),
+        rateLimited,
+        completed(4, "failed"),
+      ]),
+    });
+
+    expect(inspection.candidate).toBeNull();
+    expect(inspection.reason).toBe("no-refusal");
+  });
+
+  it("does not offer a fallback while the refused turn is still running", () => {
+    const inspection = classifyRefusalFallback({
+      environmentId: "env_1",
+      providerId: "claude-code",
+      events: events([
+        requested(1, "claude-opus-5[1m]"),
+        accepted(2),
+        policyError(3, "refused"),
+      ]),
+    });
+
+    expect(inspection.candidate).toBeNull();
+    expect(inspection.reason).toBe("turn-not-finished");
+  });
+
+  it("does not offer a fallback once the user stopped the thread", () => {
+    const interrupted = {
+      seq: 5,
+      type: "system/thread/interrupted",
+      threadId: THREAD_ID,
+      scope: { kind: "thread" },
+      data: { reason: "manual-stop" },
+    };
+
+    const inspection = classifyRefusalFallback({
+      environmentId: "env_1",
+      providerId: "claude-code",
+      events: events([
+        requested(1, "claude-opus-5[1m]"),
+        accepted(2),
+        policyError(3, "refused"),
+        completed(4, "completed"),
+        interrupted,
+      ]),
+    });
+
+    expect(inspection.candidate).toBeNull();
+    expect(inspection.reason).toBe("superseded");
+  });
+
+  it("reports the environment as unavailable rather than offering a fallback", () => {
+    const inspection = classifyRefusalFallback({
+      environmentId: null,
+      providerId: "claude-code",
+      events: events([
+        requested(1, "claude-opus-5[1m]"),
+        accepted(2),
+        policyError(3, "refused"),
+        completed(4, "completed"),
+      ]),
+    });
+
+    expect(inspection.candidate).toBeNull();
+    expect(inspection.reason).toBe("environment-unavailable");
+  });
+});
+
+describe("alternativeModels", () => {
+  it("offers the catalog entries below the refused model", () => {
+    expect(
+      alternativeModels(CATALOG, "claude-opus-5[1m]").map(
+        (entry) => entry.displayName,
+      ),
+    ).toEqual(["Opus 4.8 (1M)", "Opus 4.7 (1M)", "Sonnet 5"]);
+  });
+
+  it("runs out of alternatives at the bottom of the catalog so retries terminate", () => {
+    expect(alternativeModels(CATALOG, "claude-sonnet-5")).toEqual([]);
+  });
+
+  it("offers the whole catalog when the refused model is no longer listed", () => {
+    expect(alternativeModels(CATALOG, "claude-opus-4-6[1m]")).toHaveLength(3);
+  });
+});
+
+describe("autoChoiceKey", () => {
+  it("scopes the remembered choice to one provider", () => {
+    expect(autoChoiceKey("claude-code")).toBe("auto:claude-code");
+    expect(autoChoiceKey("codex")).toBe("auto:codex");
+  });
+});

--- a/plugins/provider-refusal-fallback/server.test.ts
+++ b/plugins/provider-refusal-fallback/server.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from "vitest";
+import {
+  createFakePluginHost,
+  makeThreadResponse,
+} from "@get-bb/plugin-sdk/testing";
 import { classifyRefusalFallback } from "./src/recovery.js";
-import { alternativeModels, autoChoiceKey } from "./src/service.js";
+import {
+  alternativeModels,
+  autoChoiceKey,
+  RefusalFallbackService,
+} from "./src/service.js";
 
 type Events = Parameters<typeof classifyRefusalFallback>[0]["events"];
 type Models = Parameters<typeof alternativeModels>[0];
@@ -8,6 +16,8 @@ type Models = Parameters<typeof alternativeModels>[0];
 const THREAD_ID = "thr_1";
 const TURN_ID = "turn_1";
 const REQUEST_ID = "req_1";
+const ENVIRONMENT_ID = "env_1";
+const PROVIDER_ID = "claude-code";
 
 function model(id: string, displayName: string) {
   return {
@@ -28,18 +38,18 @@ const CATALOG = [
   model("claude-sonnet-5", "Sonnet 5"),
 ] as unknown as Models;
 
-function turnScope() {
-  return { kind: "turn", turnId: TURN_ID } as const;
+function turnScope(turnId = TURN_ID) {
+  return { kind: "turn", turnId } as const;
 }
 
-function requested(seq: number, modelId: string) {
+function requested(seq: number, modelId: string, requestId = REQUEST_ID) {
   return {
     seq,
     type: "client/turn/requested",
     threadId: THREAD_ID,
     scope: { kind: "thread" },
     data: {
-      requestId: REQUEST_ID,
+      requestId,
       execution: {
         model: modelId,
         permissionMode: "auto",
@@ -50,22 +60,22 @@ function requested(seq: number, modelId: string) {
   };
 }
 
-function accepted(seq: number) {
+function accepted(seq: number, turnId = TURN_ID, requestId = REQUEST_ID) {
   return {
     seq,
     type: "turn/input/accepted",
     threadId: THREAD_ID,
-    scope: turnScope(),
-    data: { clientRequestId: REQUEST_ID },
+    scope: turnScope(turnId),
+    data: { clientRequestId: requestId },
   };
 }
 
-function policyError(seq: number, detail: string) {
+function policyError(seq: number, detail: string, turnId = TURN_ID) {
   return {
     seq,
     type: "provider/error",
     threadId: THREAD_ID,
-    scope: turnScope(),
+    scope: turnScope(turnId),
     data: {
       message: "Provider error",
       detail,
@@ -78,14 +88,32 @@ function policyError(seq: number, detail: string) {
   };
 }
 
-function completed(seq: number, status: "completed" | "failed") {
+function completed(
+  seq: number,
+  status: "completed" | "failed",
+  turnId = TURN_ID,
+) {
   return {
     seq,
     type: "turn/completed",
     threadId: THREAD_ID,
-    scope: turnScope(),
+    scope: turnScope(turnId),
     data: { status },
   };
+}
+
+function refusedTurn(
+  modelId: string,
+  turnId = TURN_ID,
+  requestId = REQUEST_ID,
+) {
+  const base = turnId === TURN_ID ? 0 : 10;
+  return [
+    requested(base + 1, modelId, requestId),
+    accepted(base + 2, turnId, requestId),
+    policyError(base + 3, "safeguards flagged this message", turnId),
+    completed(base + 4, "completed", turnId),
+  ];
 }
 
 function events(rows: unknown[]): Events {
@@ -223,5 +251,162 @@ describe("autoChoiceKey", () => {
   it("scopes the remembered choice to one provider", () => {
     expect(autoChoiceKey("claude-code")).toBe("auto:claude-code");
     expect(autoChoiceKey("codex")).toBe("auto:codex");
+  });
+});
+
+function createHost(rows: unknown[]) {
+  let events = rows;
+  const host = createFakePluginHost({
+    pluginId: "provider-refusal-fallback",
+    sdk: {
+      threads: {
+        get: async ({ threadId }) =>
+          makeThreadResponse({
+            id: threadId,
+            environmentId: ENVIRONMENT_ID,
+            providerId: PROVIDER_ID,
+            status: "idle",
+          }),
+        events: {
+          list: async ({ afterSeq, limit, order, types }) => {
+            const after = afterSeq === undefined ? 0 : Number(afterSeq);
+            const wanted = types === undefined ? null : new Set<string>(types);
+            const matching = (events as { seq: number; type: string }[]).filter(
+              (row) =>
+                row.seq > after && (wanted === null || wanted.has(row.type)),
+            );
+            matching.sort((left, right) =>
+              order === "desc" ? right.seq - left.seq : left.seq - right.seq,
+            );
+            return matching.slice(
+              0,
+              limit === undefined ? undefined : Number(limit),
+            );
+          },
+        },
+        update: async () => ({ ok: true }),
+        send: async () => ({ ok: true }),
+      },
+      providers: {
+        models: async () => ({
+          providers: [],
+          permissionCeiling: "auto",
+          models: CATALOG,
+          selectedOnlyModels: [],
+          modelLoadError: null,
+        }),
+      },
+    },
+  });
+  return {
+    host,
+    setEvents(next: unknown[]) {
+      events = next;
+    },
+  };
+}
+
+async function nextInteraction(host: ReturnType<typeof createHost>["host"]) {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    const pending = host.harness.pendingInteractions[0];
+    if (pending !== undefined) return pending;
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  throw new Error("no interaction was requested");
+}
+
+describe("RefusalFallbackService", () => {
+  it("offers the next model down, switches on accept, and continues the turn", async () => {
+    const { host } = createHost(refusedTurn("claude-opus-5[1m]"));
+    const service = new RefusalFallbackService(host.bb);
+
+    const outcome = service.reconcile(THREAD_ID);
+    const interaction = await nextInteraction(host);
+
+    expect(interaction.title).toBe("Opus 5 (1M) refused this message");
+    expect(interaction.payload).toMatchObject({
+      refusedModelLabel: "Opus 5 (1M)",
+      detail: "safeguards flagged this message",
+      options: [
+        { model: "claude-opus-4-8[1m]", label: "Opus 4.8 (1M)" },
+        { model: "claude-opus-4-7[1m]", label: "Opus 4.7 (1M)" },
+        { model: "claude-sonnet-5", label: "Sonnet 5" },
+      ],
+    });
+
+    host.harness.submitInteraction(interaction.id, {
+      model: "claude-opus-4-8[1m]",
+      remember: false,
+    });
+
+    expect(await outcome).toBe("switched");
+    expect(host.harness.sdk.callsTo("threads.update")).toEqual([
+      [{ threadId: THREAD_ID, model: "claude-opus-4-8[1m]" }],
+    ]);
+    expect(host.harness.sdk.callsTo("threads.send")).toHaveLength(1);
+    expect(await service.autoChoice(PROVIDER_ID)).toBeUndefined();
+  });
+
+  it("skips the prompt on the next refusal once the user opts out of it", async () => {
+    const harness = createHost(refusedTurn("claude-opus-5[1m]"));
+    const service = new RefusalFallbackService(harness.host.bb);
+
+    const first = service.reconcile(THREAD_ID);
+    const interaction = await nextInteraction(harness.host);
+    harness.host.harness.submitInteraction(interaction.id, {
+      model: "claude-opus-4-8[1m]",
+      remember: true,
+    });
+    expect(await first).toBe("switched");
+    expect(await service.autoChoice(PROVIDER_ID)).toEqual({
+      model: "claude-opus-4-8[1m]",
+    });
+
+    harness.setEvents(refusedTurn("claude-opus-5[1m]", "turn_2", "req_2"));
+    expect(await service.reconcile(THREAD_ID)).toBe("switched");
+
+    expect(harness.host.harness.pendingInteractions).toHaveLength(0);
+    expect(harness.host.harness.sdk.callsTo("threads.update")).toHaveLength(2);
+  });
+
+  it("leaves the thread on the refused model when the user declines", async () => {
+    const { host } = createHost(refusedTurn("claude-opus-5[1m]"));
+    const service = new RefusalFallbackService(host.bb);
+
+    const outcome = service.reconcile(THREAD_ID);
+    const interaction = await nextInteraction(host);
+    host.harness.submitInteraction(interaction.id, {
+      model: null,
+      remember: false,
+    });
+
+    expect(await outcome).toBe("declined");
+    expect(host.harness.sdk.callsTo("threads.update")).toEqual([]);
+    expect(host.harness.sdk.callsTo("threads.send")).toEqual([]);
+  });
+
+  it("does not prompt when the refused model is already the last alternative", async () => {
+    const { host } = createHost(refusedTurn("claude-sonnet-5"));
+    const service = new RefusalFallbackService(host.bb);
+
+    expect(await service.reconcile(THREAD_ID)).toBe("no-alternative");
+    expect(host.harness.pendingInteractions).toHaveLength(0);
+    expect(host.harness.sdk.callsTo("threads.send")).toEqual([]);
+  });
+
+  it("does not act twice on the same refused turn", async () => {
+    const { host } = createHost(refusedTurn("claude-opus-5[1m]"));
+    const service = new RefusalFallbackService(host.bb);
+
+    const outcome = service.reconcile(THREAD_ID);
+    const interaction = await nextInteraction(host);
+    host.harness.submitInteraction(interaction.id, {
+      model: "claude-opus-4-8[1m]",
+      remember: false,
+    });
+    await outcome;
+
+    expect(await service.reconcile(THREAD_ID)).toBe("already-handled");
+    expect(host.harness.sdk.callsTo("threads.send")).toHaveLength(1);
   });
 });

--- a/plugins/provider-refusal-fallback/server.ts
+++ b/plugins/provider-refusal-fallback/server.ts
@@ -1,0 +1,29 @@
+import type { BbPluginApi } from "@get-bb/plugin-sdk";
+import { registerRefusalFallbackCli } from "./src/cli.js";
+import { RefusalFallbackService } from "./src/service.js";
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export default function plugin(bb: BbPluginApi) {
+  const service = new RefusalFallbackService(bb);
+  registerRefusalFallbackCli(bb, service);
+
+  const reconcile = async (threadId: string): Promise<void> => {
+    try {
+      await service.reconcile(threadId);
+    } catch (error) {
+      bb.log.warn(
+        `Refusal fallback for thread ${threadId} failed: ${errorMessage(error)}`,
+      );
+    }
+  };
+
+  bb.events.on("thread.failed", async ({ thread }) => {
+    await reconcile(thread.id);
+  });
+  bb.events.on("thread.idle", async ({ thread }) => {
+    await reconcile(thread.id);
+  });
+}

--- a/plugins/provider-refusal-fallback/src/cli.ts
+++ b/plugins/provider-refusal-fallback/src/cli.ts
@@ -1,0 +1,111 @@
+import type { BbPluginApi, PluginCliResult } from "@get-bb/plugin-sdk";
+import { autoChoiceKey, type RefusalFallbackService } from "./service.js";
+
+interface RememberedChoice {
+  providerId: string;
+  model: string;
+}
+
+function textView(choices: readonly RememberedChoice[]): string {
+  if (choices.length === 0) {
+    return "No provider is set to switch models automatically after a refusal.";
+  }
+  return choices
+    .map((choice) => `${choice.providerId} switches to ${choice.model}`)
+    .join("\n");
+}
+
+async function listRememberedChoices(
+  bb: BbPluginApi,
+  service: RefusalFallbackService,
+): Promise<RememberedChoice[]> {
+  const keys = await bb.storage.kv.list("auto:");
+  const choices: RememberedChoice[] = [];
+  for (const key of keys) {
+    const providerId = key.slice("auto:".length);
+    if (providerId === "") continue;
+    const stored = await service.autoChoice(providerId);
+    if (stored === undefined) continue;
+    choices.push({ providerId, model: stored.model });
+  }
+  return choices;
+}
+
+export function registerRefusalFallbackCli(
+  bb: BbPluginApi,
+  service: RefusalFallbackService,
+): void {
+  bb.cli.register({
+    name: "refusal-fallback",
+    summary: "Inspect and clear automatic model switches after a refusal.",
+    commands: [
+      {
+        name: "status",
+        summary: "Show which providers switch models automatically.",
+        usage: "bb refusal-fallback status [--json]",
+      },
+      {
+        name: "forget",
+        summary: "Ask again the next time this provider refuses a message.",
+        usage: "bb refusal-fallback forget <providerId>",
+      },
+      {
+        name: "retry",
+        summary: "Re-check a thread for a refusal that can fall back.",
+        usage: "bb refusal-fallback retry [threadId]",
+      },
+    ],
+    async run(argv, context): Promise<PluginCliResult> {
+      const [command, ...args] = argv;
+      const json = args.includes("--json");
+
+      if (command === "status") {
+        const choices = await listRememberedChoices(bb, service);
+        return {
+          exitCode: 0,
+          stdout: json ? JSON.stringify({ choices }) : textView(choices),
+        };
+      }
+
+      if (command === "forget") {
+        const providerId = args.find((arg) => !arg.startsWith("-"));
+        if (providerId === undefined) {
+          return {
+            exitCode: 1,
+            stderr: "Usage: bb refusal-fallback forget <providerId>",
+          };
+        }
+        await service.forget(providerId);
+        return {
+          exitCode: 0,
+          stdout: json
+            ? JSON.stringify({ forgotten: providerId })
+            : `${providerId} will ask again after the next refusal.`,
+        };
+      }
+
+      if (command === "retry") {
+        const threadId =
+          args.find((arg) => !arg.startsWith("-")) ?? context.threadId;
+        if (threadId === undefined) {
+          return {
+            exitCode: 1,
+            stderr: "Usage: bb refusal-fallback retry <threadId>",
+          };
+        }
+        const outcome = await service.reconcile(threadId);
+        return {
+          exitCode: 0,
+          stdout: json
+            ? JSON.stringify({ threadId, outcome })
+            : `${threadId}: ${outcome}`,
+        };
+      }
+
+      return {
+        exitCode: 1,
+        stderr: "Unknown command. Try status, forget, or retry.",
+      };
+    },
+  });
+}

--- a/plugins/provider-refusal-fallback/src/contracts.ts
+++ b/plugins/provider-refusal-fallback/src/contracts.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+
+export const REFUSAL_FALLBACK_RENDERER_ID = "refusal-fallback";
+
+export const refusalFallbackOptionSchema = z.object({
+  model: z.string().min(1),
+  label: z.string().min(1),
+  description: z.string().optional(),
+});
+export type RefusalFallbackOption = z.infer<typeof refusalFallbackOptionSchema>;
+
+export const refusalFallbackPayloadSchema = z.object({
+  refusedModelLabel: z.string().min(1),
+  detail: z.string(),
+  options: z.array(refusalFallbackOptionSchema).min(1),
+});
+export type RefusalFallbackPayload = z.infer<
+  typeof refusalFallbackPayloadSchema
+>;
+
+export const refusalFallbackResponseSchema = z.object({
+  model: z.string().min(1).nullable(),
+  remember: z.boolean(),
+});
+export type RefusalFallbackResponse = z.infer<
+  typeof refusalFallbackResponseSchema
+>;

--- a/plugins/provider-refusal-fallback/src/recovery.ts
+++ b/plugins/provider-refusal-fallback/src/recovery.ts
@@ -1,0 +1,276 @@
+import type { BbPluginApi } from "@get-bb/plugin-sdk";
+
+type ThreadEventRows = Awaited<
+  ReturnType<BbPluginApi["sdk"]["threads"]["events"]["list"]>
+>;
+type ThreadEventRow = ThreadEventRows[number];
+type TurnRequestEventRow = Extract<
+  ThreadEventRow,
+  { type: "client/turn/requested" }
+>;
+type ProviderErrorEventRow = Extract<
+  ThreadEventRow,
+  { type: "provider/error" }
+>;
+type TurnCompletedEventRow = Extract<
+  ThreadEventRow,
+  { type: "turn/completed" }
+>;
+type TurnInputAcceptedEventRow = Extract<
+  ThreadEventRow,
+  { type: "turn/input/accepted" }
+>;
+
+export type RefusalFallbackReason =
+  | "eligible"
+  | "environment-unavailable"
+  | "input-not-accepted"
+  | "no-refusal"
+  | "superseded"
+  | "turn-not-finished";
+
+export interface RefusalFallbackCandidate {
+  detail: string;
+  refusedModel: string;
+  turnId: string;
+}
+
+export type RefusalFallbackInspection =
+  | {
+      candidate: RefusalFallbackCandidate;
+      environmentId: string;
+      providerId: string;
+      reason: "eligible";
+    }
+  | {
+      candidate: null;
+      environmentId: null;
+      providerId: null;
+      reason: Exclude<RefusalFallbackReason, "eligible">;
+    };
+
+const EVENT_PAGE_SIZE = 500;
+const REFUSAL_EVENT_TYPES = [
+  "client/turn/requested",
+  "provider/error",
+  "system/thread/interrupted",
+  "turn/completed",
+  "turn/input/accepted",
+] as const satisfies readonly [
+  ThreadEventRow["type"],
+  ...ThreadEventRow["type"][],
+];
+const REQUEST_EVENT_TYPES = [
+  "client/turn/requested",
+] as const satisfies readonly [
+  ThreadEventRow["type"],
+  ...ThreadEventRow["type"][],
+];
+
+function emptyInspection(
+  reason: Exclude<RefusalFallbackReason, "eligible">,
+): RefusalFallbackInspection {
+  return {
+    candidate: null,
+    environmentId: null,
+    providerId: null,
+    reason,
+  };
+}
+
+function isPolicyRefusal(row: ThreadEventRow): row is ProviderErrorEventRow {
+  return (
+    row.type === "provider/error" && row.data.errorInfo?.category === "policy"
+  );
+}
+
+function belongsToTurn(row: ThreadEventRow, turnId: string): boolean {
+  return row.scope.kind === "turn" && row.scope.turnId === turnId;
+}
+
+interface FinishedTurn {
+  completedSeq: number;
+  refusedModel: string;
+  turnId: string;
+}
+
+type FinishedTurnInspection =
+  | { turn: FinishedTurn; reason: "eligible" }
+  | {
+      turn: null;
+      reason: Exclude<
+        RefusalFallbackReason,
+        "eligible" | "environment-unavailable" | "no-refusal"
+      >;
+    };
+
+function inspectFinishedTurn(events: ThreadEventRows): FinishedTurnInspection {
+  const requests: TurnRequestEventRow[] = [];
+  const acceptedByRequestId = new Map<
+    TurnInputAcceptedEventRow["data"]["clientRequestId"],
+    TurnInputAcceptedEventRow
+  >();
+  const completedByTurnId = new Map<string, TurnCompletedEventRow>();
+  for (const row of events) {
+    if (row.type === "client/turn/requested") {
+      requests.push(row);
+      continue;
+    }
+    if (row.type === "turn/input/accepted" && row.scope.kind === "turn") {
+      if (!acceptedByRequestId.has(row.data.clientRequestId)) {
+        acceptedByRequestId.set(row.data.clientRequestId, row);
+      }
+      continue;
+    }
+    if (row.type === "turn/completed" && row.scope.kind === "turn") {
+      completedByTurnId.set(row.scope.turnId, row);
+    }
+  }
+
+  const latestRequest = requests.at(-1);
+  if (latestRequest === undefined) {
+    return { turn: null, reason: "input-not-accepted" };
+  }
+
+  let latest:
+    | { completed: TurnCompletedEventRow; request: TurnRequestEventRow }
+    | undefined;
+  for (const request of requests) {
+    const accepted = acceptedByRequestId.get(request.data.requestId);
+    if (
+      accepted === undefined ||
+      accepted.seq <= request.seq ||
+      accepted.scope.kind !== "turn"
+    ) {
+      continue;
+    }
+    const completed = completedByTurnId.get(accepted.scope.turnId);
+    if (completed === undefined || completed.seq <= accepted.seq) continue;
+    if (latest === undefined || completed.seq > latest.completed.seq) {
+      latest = { completed, request };
+    }
+  }
+  if (latest === undefined) {
+    return { turn: null, reason: "turn-not-finished" };
+  }
+
+  const { completed, request } = latest;
+  if (request.seq !== latestRequest.seq) {
+    return { turn: null, reason: "superseded" };
+  }
+  if (completed.scope.kind !== "turn") {
+    return { turn: null, reason: "turn-not-finished" };
+  }
+
+  const manuallyStopped = events.some(
+    (row) =>
+      row.seq > request.seq &&
+      row.type === "system/thread/interrupted" &&
+      row.data.reason === "manual-stop",
+  );
+  if (manuallyStopped) {
+    return { turn: null, reason: "superseded" };
+  }
+
+  return {
+    turn: {
+      completedSeq: completed.seq,
+      refusedModel: request.data.execution.model,
+      turnId: completed.scope.turnId,
+    },
+    reason: "eligible",
+  };
+}
+
+export function classifyRefusalFallback(args: {
+  environmentId: string | null;
+  events: ThreadEventRows;
+  providerId: string;
+}): RefusalFallbackInspection {
+  const inspection = inspectFinishedTurn(args.events);
+  if (inspection.turn === null) {
+    return emptyInspection(inspection.reason);
+  }
+  const turn = inspection.turn;
+
+  const refusal = args.events
+    .filter(
+      (row): row is ProviderErrorEventRow =>
+        row.seq <= turn.completedSeq &&
+        belongsToTurn(row, turn.turnId) &&
+        isPolicyRefusal(row),
+    )
+    .at(-1);
+  if (refusal === undefined) {
+    return emptyInspection("no-refusal");
+  }
+  if (args.environmentId === null) {
+    return emptyInspection("environment-unavailable");
+  }
+
+  return {
+    candidate: {
+      detail: refusal.data.detail ?? refusal.data.message,
+      refusedModel: turn.refusedModel,
+      turnId: turn.turnId,
+    },
+    environmentId: args.environmentId,
+    providerId: args.providerId,
+    reason: "eligible",
+  };
+}
+
+async function findLatestRequestEvent(
+  bb: BbPluginApi,
+  threadId: string,
+): Promise<TurnRequestEventRow | undefined> {
+  const rows = await bb.sdk.threads.events.list({
+    threadId,
+    limit: "1",
+    order: "desc",
+    types: REQUEST_EVENT_TYPES,
+  });
+  return rows.find(
+    (row): row is TurnRequestEventRow => row.type === "client/turn/requested",
+  );
+}
+
+async function listRequestWindowEvents(
+  bb: BbPluginApi,
+  threadId: string,
+  request: TurnRequestEventRow,
+): Promise<ThreadEventRow[]> {
+  const events: ThreadEventRow[] = [request];
+  let afterSeq = String(request.seq);
+  while (true) {
+    const page = await bb.sdk.threads.events.list({
+      threadId,
+      afterSeq,
+      limit: String(EVENT_PAGE_SIZE),
+      order: "asc",
+      types: REFUSAL_EVENT_TYPES,
+    });
+    events.push(...page);
+    if (page.length < EVENT_PAGE_SIZE) return events;
+    const newestRow = page.at(-1);
+    if (newestRow === undefined) return events;
+    afterSeq = String(newestRow.seq);
+  }
+}
+
+export async function inspectRefusalFallback(
+  bb: BbPluginApi,
+  threadId: string,
+): Promise<RefusalFallbackInspection> {
+  const thread = await bb.sdk.threads.get({ threadId });
+  const request = await findLatestRequestEvent(bb, threadId);
+  if (request === undefined) {
+    return emptyInspection("input-not-accepted");
+  }
+  const events = await listRequestWindowEvents(bb, threadId, request);
+  return classifyRefusalFallback({
+    environmentId: thread.environmentId,
+    events,
+    providerId: thread.providerId,
+  });
+}

--- a/plugins/provider-refusal-fallback/src/service.ts
+++ b/plugins/provider-refusal-fallback/src/service.ts
@@ -1,0 +1,188 @@
+import type { BbPluginApi } from "@get-bb/plugin-sdk";
+import { z } from "zod";
+import {
+  REFUSAL_FALLBACK_RENDERER_ID,
+  refusalFallbackResponseSchema,
+  type RefusalFallbackOption,
+  type RefusalFallbackPayload,
+} from "./contracts.js";
+import {
+  inspectRefusalFallback,
+  type RefusalFallbackCandidate,
+} from "./recovery.js";
+
+type ProviderModels = Awaited<
+  ReturnType<BbPluginApi["sdk"]["providers"]["models"]>
+>;
+type AvailableModel = ProviderModels["models"][number];
+
+export const MAX_OFFERED_MODELS = 3;
+const PROMPT_TIMEOUT_MS = 10 * 60 * 1_000;
+
+export type RefusalFallbackOutcome =
+  | "declined"
+  | "no-alternative"
+  | "not-eligible"
+  | "already-handled"
+  | "switched";
+
+const autoChoiceSchema = z.object({ model: z.string().min(1) });
+export type RefusalFallbackAutoChoice = z.infer<typeof autoChoiceSchema>;
+
+export function alternativeModels(
+  models: readonly AvailableModel[],
+  refusedModel: string,
+): AvailableModel[] {
+  const refusedIndex = models.findIndex((model) => model.id === refusedModel);
+  const after = refusedIndex === -1 ? models : models.slice(refusedIndex + 1);
+  return after
+    .filter((model) => model.id !== refusedModel)
+    .slice(0, MAX_OFFERED_MODELS);
+}
+
+export function modelLabel(
+  models: readonly AvailableModel[],
+  modelId: string,
+): string {
+  return models.find((model) => model.id === modelId)?.displayName ?? modelId;
+}
+
+function toOption(model: AvailableModel): RefusalFallbackOption {
+  return {
+    model: model.id,
+    label: model.displayName,
+    ...(model.description === "" ? {} : { description: model.description }),
+  };
+}
+
+export function autoChoiceKey(providerId: string): string {
+  return `auto:${providerId}`;
+}
+
+export class RefusalFallbackService {
+  private readonly handledTurns = new Set<string>();
+  private readonly inFlight = new Set<string>();
+
+  constructor(private readonly bb: BbPluginApi) {}
+
+  async forget(providerId: string): Promise<void> {
+    await this.bb.storage.kv.delete(autoChoiceKey(providerId));
+  }
+
+  async autoChoice(
+    providerId: string,
+  ): Promise<RefusalFallbackAutoChoice | undefined> {
+    const stored = await this.bb.storage.kv.get(autoChoiceKey(providerId));
+    const parsed = autoChoiceSchema.safeParse(stored);
+    return parsed.success ? parsed.data : undefined;
+  }
+
+  async reconcile(threadId: string): Promise<RefusalFallbackOutcome> {
+    if (this.inFlight.has(threadId)) return "already-handled";
+    this.inFlight.add(threadId);
+    try {
+      return await this.run(threadId);
+    } finally {
+      this.inFlight.delete(threadId);
+    }
+  }
+
+  private async run(threadId: string): Promise<RefusalFallbackOutcome> {
+    const inspection = await inspectRefusalFallback(this.bb, threadId);
+    if (inspection.candidate === null) return "not-eligible";
+    const { candidate, environmentId, providerId } = inspection;
+    if (this.handledTurns.has(candidate.turnId)) return "already-handled";
+
+    const catalog = await this.bb.sdk.providers.models({
+      environmentId,
+      providerId,
+    });
+    const alternatives = alternativeModels(
+      catalog.models,
+      candidate.refusedModel,
+    );
+    if (alternatives.length === 0) {
+      this.handledTurns.add(candidate.turnId);
+      this.bb.log.warn(
+        `No fallback model is available after ${candidate.refusedModel} refused a turn in thread ${threadId}.`,
+      );
+      return "no-alternative";
+    }
+
+    const remembered = await this.autoChoice(providerId);
+    const automatic =
+      remembered !== undefined &&
+      alternatives.some((model) => model.id === remembered.model)
+        ? remembered.model
+        : null;
+
+    this.handledTurns.add(candidate.turnId);
+
+    if (automatic !== null) {
+      await this.switchAndContinue(threadId, automatic);
+      return "switched";
+    }
+
+    const chosen = await this.ask(
+      threadId,
+      providerId,
+      candidate,
+      catalog.models,
+      alternatives,
+    );
+    if (chosen === null) return "declined";
+    await this.switchAndContinue(threadId, chosen);
+    return "switched";
+  }
+
+  private async ask(
+    threadId: string,
+    providerId: string,
+    candidate: RefusalFallbackCandidate,
+    models: readonly AvailableModel[],
+    alternatives: readonly AvailableModel[],
+  ): Promise<string | null> {
+    const payload: RefusalFallbackPayload = {
+      refusedModelLabel: modelLabel(models, candidate.refusedModel),
+      detail: candidate.detail,
+      options: alternatives.map(toOption),
+    };
+    const result = await this.bb.ui.requestInput({
+      threadId,
+      rendererId: REFUSAL_FALLBACK_RENDERER_ID,
+      title: `${payload.refusedModelLabel} refused this message`,
+      payload,
+      timeoutMs: PROMPT_TIMEOUT_MS,
+    });
+    if (result.outcome !== "submitted") return null;
+
+    const parsed = refusalFallbackResponseSchema.safeParse(result.value);
+    if (!parsed.success) return null;
+    const { model, remember } = parsed.data;
+    if (model === null) return null;
+    if (!alternatives.some((entry) => entry.id === model)) return null;
+    if (remember) {
+      await this.bb.storage.kv.set(autoChoiceKey(providerId), { model });
+    }
+    return model;
+  }
+
+  private async switchAndContinue(
+    threadId: string,
+    model: string,
+  ): Promise<void> {
+    await this.bb.sdk.threads.update({ threadId, model });
+    await this.bb.sdk.threads.send({
+      threadId,
+      mode: "start",
+      input: [
+        {
+          type: "text",
+          text: "Please continue.",
+          mentions: [],
+          visibility: "agent-only",
+        },
+      ],
+    });
+  }
+}

--- a/plugins/provider-refusal-fallback/tsconfig.json
+++ b/plugins/provider-refusal-fallback/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "lib": ["ES2022", "DOM"],
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": [
+    "server.ts",
+    "server.test.ts",
+    "app.tsx",
+    "app.test.tsx",
+    "src/**/*.ts",
+    "vitest.config.ts"
+  ]
+}

--- a/plugins/provider-refusal-fallback/vitest.config.ts
+++ b/plugins/provider-refusal-fallback/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineWorkspaceTestConfig } from "../../vitest.shared.js";
+
+export default defineWorkspaceTestConfig({
+  test: {
+    silent: "passed-only",
+    name: "bb-plugin-provider-refusal-fallback",
+    include: ["**/*.test.{ts,tsx}"],
+    exclude: ["node_modules/**"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3502,6 +3502,46 @@ importers:
         specifier: ^4.1.1
         version: 4.1.1(@opentelemetry/api@1.9.1)(@types/node@22.19.10)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@22.19.10)(@typescript/typescript6@6.0.2))(vite@8.0.12(@types/node@22.19.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.1)(yaml@2.9.0))
 
+  plugins/provider-refusal-fallback:
+    dependencies:
+      '@bb/shared-ui':
+        specifier: workspace:*
+        version: link:../../packages/shared-ui
+      zod:
+        specifier: 4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@get-bb/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.10
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.13
+      jsdom:
+        specifier: ^29.0.1
+        version: 29.0.1(@noble/hashes@2.0.1)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.4(react@19.2.4)
+      typescript:
+        specifier: npm:@typescript/typescript6@^6.0.2
+        version: '@typescript/typescript6@6.0.2'
+      typescript-7:
+        specifier: npm:typescript@^7.0.2
+        version: typescript@7.0.2
+      vitest:
+        specifier: ^4.1.1
+        version: 4.1.1(@opentelemetry/api@1.9.1)(@types/node@22.19.10)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@22.19.10)(@typescript/typescript6@6.0.2))(vite@8.0.12(@types/node@22.19.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.1)(yaml@2.9.0))
+
   plugins/provider-retry:
     dependencies:
       '@bb/shared-ui':

--- a/turbo.json
+++ b/turbo.json
@@ -790,6 +790,9 @@
     "bb-plugin-provider-pi#typecheck": {
       "dependsOn": ["@get-bb/plugin-sdk#build:types", "topo"]
     },
+    "bb-plugin-provider-refusal-fallback#typecheck": {
+      "dependsOn": ["@get-bb/plugin-sdk#build:types", "topo"]
+    },
     "bb-plugin-provider-retry#typecheck": {
       "dependsOn": ["@get-bb/plugin-sdk#build:types", "topo"]
     },


### PR DESCRIPTION
## Human comments

## What was wrong

Claude Code emits a `model_refusal_no_fallback` system message when the stream ends with `stop_reason: "refusal"` and no fallback model is configured — and bb never configures one, so that is the message bb sees for every safeguards refusal. `delta-translation.ts` turned it into a generic `provider/warning` with the free-text summary "Model refused the request", which made the failure both untyped in the timeline and invisible to automation: `policy` is a real `providerErrorCategory` with its own title in thread-view, but no Claude Code path could produce it, so a plugin had nothing to match the way `provider-retry` matches `rate-limit`. With nothing typed to react to, the only recovery was to open the model picker, switch by hand, and resend — once per refusal, even though the refusal is model-specific and "retry on another model" is the single useful action.

Fixes #2733

## What changed

**`plugins/provider-claude-code` — type the refusal.** `model_refusal_no_fallback` now translates to a `provider/error` with `errorInfo.category: "policy"`, the CLI's own explanation as `detail`, and the refusal category (`cyber`, `bio`, …) as `providerCode` when the CLI reports one. This reaches an existing category rather than adding one, so there is no domain or wire change and no `HOST_DAEMON_PROTOCOL_VERSION` bump. `original_model` and `api_refusal_category` are optional in the schema because the SDK documents both as absent from older CLIs. The timeline now titles it "Provider policy blocked request".

**`plugins/provider-refusal-fallback` — a new builtin plugin (enabled by default).** It reconciles a finished turn the way `provider-retry` does, but keyed on a `policy` provider error. It offers the models listed *below* the refused one in that provider's catalog, switches the thread with `sdk.threads.update`, and sends one agent-only `Please continue.` turn. Offering only lower catalog entries is what makes a repeatedly refused thread terminate rather than switch forever. "Switch automatically next time, do not ask again" stores the chosen model per provider in the plugin's KV storage and skips the prompt from then on.

It reads the catalog through `sdk.providers.models` and never names a model or a provider, so Codex's `policy` errors get the same treatment.

No new plugin API: it consumes `bb.ui.requestInput`, `bb.storage.kv`, `bb.events.on`, `bb.cli.register`, and `app.slots.pendingInteraction`, all already stable — so no `experimental_` prefix and no `docs/api_to_audit.md` entry.

**CLI and docs, per `docs/cli-guide-and-skill.md`.** `bb refusal-fallback status|forget|retry` gives agents the same feature as the UI. Documented in `docs/configuration.md`, `bb-guide-plugins.md`, and `bb-guide-providers.md`; registered in `builtin-registry.ts`, `plugin-icons.ts`, `turbo.json`, and the builtin/official plugin test fixtures.

Deliberately not done: passing the SDK's own `fallbackModel` through `buildClaudeSessionParams`. It is less code, but it decides for the user, its documented purpose is overload/unavailability rather than refusal, and it swaps the session's model behind bb's back so `modelOverride` and the live session drift apart.

## How you verified

Node 22.23.1, macOS.

```
pnpm exec turbo run test --filter=bb-plugin-provider-claude-code
  → 23 files, 337 passed (336 on main; the refusal test was replaced by two)

pnpm exec turbo run typecheck test --filter=bb-plugin-provider-refusal-fallback
  → 2 files, 12 passed; typecheck clean

pnpm exec turbo run test --filter=@bb/server -- --run test/services/plugins
  → 38 files, 444 passed  (builtin-plugins.test.ts reads the new manifest from disk)

pnpm exec turbo run test --filter=@bb/cli --filter=@bb/templates --continue
  → 503 + 43 passed

pnpm exec turbo run test --filter=@bb/plugin-api-map --filter=@bb/host-daemon-contract
  → 73 + 51 passed

pnpm exec turbo run typecheck --filter=@bb/server --filter=@bb/cli   → clean
pnpm exec oxlint plugins/provider-refusal-fallback plugins/provider-claude-code/src  → clean
```

New tests that fail before and pass after:

- `delta-translation.test.ts` — "surfaces refusal without fallback as a policy provider error" and "names the refusing model when the refusal carries no content". Both fail on `main`, which emits a `provider/warning`.
- `plugins/provider-refusal-fallback/server.test.ts` — `classifyRefusalFallback` returns the refused model only for a *finished* turn carrying a policy error; a rate-limit error, an unfinished turn, a manual stop, and a null environment each return no candidate. `alternativeModels` runs out at the bottom of the catalog, which is the termination guarantee.
- `plugins/provider-refusal-fallback/app.test.tsx` — the prompt submits the first offered model by default, carries `remember: true` only when the checkbox is ticked, and submits `model: null` when declined.

Not verified: I did not exercise this against a live refusal from the API. The translation is driven by the SDK's documented `SDKModelRefusalNoFallbackMessage` shape (`@anthropic-ai/claude-agent-sdk@0.3.251`) and tested through the existing delta harness, but a real end-to-end refusal has not been observed.

Pre-existing and unrelated: two `@bb/plugin-build` tests ("names the unbuilt SDK dist…") fail identically on `f4bbc2fe8` with no changes applied — the expected error string is compared against a macOS `/private/tmp` path.

Opened per CONTRIBUTING as the prototype for #2733 rather than as a merge request — happy to land only the first commit, or to reshape the second, on sign-off.

> AGENT GENERATED
