### PR TITLE
Fix OSC 8 terminal links and wrapped selection copying

### DIFF
--- a/apps/app/src/components/thread/terminal/TerminalLinkOpenDialog.test.tsx
+++ b/apps/app/src/components/thread/terminal/TerminalLinkOpenDialog.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TerminalLinkOpenDialog } from "./TerminalLinkOpenDialog";
+
+const TARGET = {
+  source: "osc8" as const,
+  uri: "https://example.com/hidden-target?token=visible",
+};
+
+afterEach(cleanup);
+
+describe("TerminalLinkOpenDialog", () => {
+  it("discloses the exact target and cancels without opening it", () => {
+    const onConfirm = vi.fn();
+    const onOpenChange = vi.fn();
+
+    render(
+      <TerminalLinkOpenDialog
+        target={TARGET}
+        onConfirm={onConfirm}
+        onOpenChange={onOpenChange}
+      />,
+    );
+
+    expect(screen.getByRole("dialog")).toBeTruthy();
+    expect(screen.getByLabelText("Link target").textContent).toBe(TARGET.uri);
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("confirms the exact disclosed target", () => {
+    const onConfirm = vi.fn();
+
+    render(
+      <TerminalLinkOpenDialog
+        target={TARGET}
+        onConfirm={onConfirm}
+        onOpenChange={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open" }));
+
+    expect(onConfirm).toHaveBeenCalledOnce();
+    expect(onConfirm).toHaveBeenCalledWith(TARGET);
+  });
+});

--- a/apps/app/src/components/thread/terminal/TerminalLinkOpenDialog.tsx
+++ b/apps/app/src/components/thread/terminal/TerminalLinkOpenDialog.tsx
@@ -1,0 +1,58 @@
+import { Button } from "@bb/shared-ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@bb/shared-ui/dialog";
+import type { TerminalLinkTarget } from "./terminal-links";
+
+interface TerminalLinkOpenDialogProps {
+  onConfirm: (target: TerminalLinkTarget) => void;
+  onOpenChange: (open: boolean) => void;
+  target: TerminalLinkTarget | null;
+}
+
+export function TerminalLinkOpenDialog({
+  onConfirm,
+  onOpenChange,
+  target,
+}: TerminalLinkOpenDialogProps) {
+  return (
+    <Dialog open={target !== null} onOpenChange={onOpenChange}>
+      <DialogContent>
+        {target ? (
+          <>
+            <DialogHeader>
+              <DialogTitle>Open terminal link?</DialogTitle>
+              <DialogDescription>
+                Terminal output can disguise a link destination. Check the
+                address before opening it.
+              </DialogDescription>
+            </DialogHeader>
+            <div
+              aria-label="Link target"
+              className="max-h-40 overflow-y-auto break-all rounded-md border bg-muted/40 p-3 font-mono text-xs text-foreground"
+            >
+              {target.uri}
+            </div>
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+              >
+                Cancel
+              </Button>
+              <Button type="button" onClick={() => onConfirm(target)}>
+                Open
+              </Button>
+            </DialogFooter>
+          </>
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/app/src/components/thread/terminal/ThreadTerminalView.context-menu.test.tsx
+++ b/apps/app/src/components/thread/terminal/ThreadTerminalView.context-menu.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { captureTerminalContextMenuState } from "./ThreadTerminalView";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("terminal context menu", () => {
+  it("captures the logical selection before xterm replaces it on macOS", async () => {
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue({
+      measureText: (text: string) => ({ width: text.length * 9 }),
+    } as unknown as CanvasRenderingContext2D);
+    vi.spyOn(HTMLElement.prototype, "offsetWidth", "get").mockImplementation(
+      function offsetWidth(this: HTMLElement) {
+        return this.classList.contains("xterm-char-measure-element")
+          ? 288
+          : 108;
+      },
+    );
+    vi.spyOn(HTMLElement.prototype, "offsetHeight", "get").mockImplementation(
+      function offsetHeight(this: HTMLElement) {
+        return this.classList.contains("xterm-char-measure-element") ? 18 : 90;
+      },
+    );
+    const { Terminal } = await import("@xterm/xterm");
+    const terminal = new Terminal({
+      cols: 12,
+      rightClickSelectsWord: true,
+      rows: 5,
+    });
+    let capturedSelection = "";
+
+    render(
+      <div
+        onContextMenuCapture={() => {
+          capturedSelection = captureTerminalContextMenuState({
+            link: null,
+            terminal,
+          }).selectionText;
+        }}
+      >
+        <div data-testid="terminal-host" />
+      </div>,
+    );
+    terminal.open(screen.getByTestId("terminal-host"));
+    await new Promise<void>((resolve) => {
+      terminal.write("alpha bravo charlie", resolve);
+    });
+    terminal.select(0, 0, 5);
+
+    const terminalScreen = screen
+      .getByTestId("terminal-host")
+      .querySelector<HTMLElement>(".xterm-screen");
+    if (terminalScreen === null) {
+      throw new Error("Expected xterm screen");
+    }
+    terminalScreen.style.padding = "0";
+    vi.spyOn(terminalScreen, "getBoundingClientRect").mockReturnValue(
+      new DOMRect(0, 0, 108, 90),
+    );
+    fireEvent.contextMenu(terminalScreen, {
+      button: 2,
+      clientX: 18,
+      clientY: 27,
+    });
+
+    expect(capturedSelection).toBe("alpha");
+    expect(terminal.getSelection()).toBe("charlie");
+    terminal.dispose();
+  });
+});

--- a/apps/app/src/components/thread/terminal/ThreadTerminalView.test.ts
+++ b/apps/app/src/components/thread/terminal/ThreadTerminalView.test.ts
@@ -3,6 +3,7 @@ import { Terminal } from "@xterm/xterm";
 import { describe, expect, it, vi } from "vitest";
 import {
   buildTerminalThemeFromCssColors,
+  captureTerminalContextMenuState,
   decodeTerminalOutputBytes,
   encodeTerminalInputChunks,
   focusTerminalFromTouchRelease,
@@ -17,6 +18,106 @@ import {
   writeTerminalOutput,
   updateTerminalTouchFocusGesture,
 } from "./ThreadTerminalView";
+import {
+  createTerminalOsc8LinkHandler,
+  requestTerminalLinkOpen,
+} from "./terminal-links";
+
+describe("terminal hyperlinks", () => {
+  it("preserves OSC-8 provenance through hover and primary activation", () => {
+    const onActivate = vi.fn();
+    const onHover = vi.fn();
+    const handler = createTerminalOsc8LinkHandler({
+      onActivate,
+      onHover,
+    });
+    const event = { button: 0 } as MouseEvent;
+    const range = {
+      start: { x: 1, y: 1 },
+      end: { x: 1, y: 1 },
+    };
+
+    handler.hover?.(event, "https://example.com/authorize", range);
+    handler.activate(event, "https://example.com/authorize", range);
+    handler.leave?.(event, "https://example.com/authorize", range);
+
+    expect(onActivate).toHaveBeenCalledWith({
+      source: "osc8",
+      uri: "https://example.com/authorize",
+    });
+    expect(onHover).toHaveBeenNthCalledWith(1, {
+      source: "osc8",
+      uri: "https://example.com/authorize",
+    });
+    expect(onHover).toHaveBeenNthCalledWith(2, null);
+  });
+
+  it("does not activate OSC-8 links from a secondary click", () => {
+    const onActivate = vi.fn();
+    const handler = createTerminalOsc8LinkHandler({
+      onActivate,
+      onHover: vi.fn(),
+    });
+    const range = {
+      start: { x: 1, y: 1 },
+      end: { x: 1, y: 1 },
+    };
+
+    handler.activate(
+      { button: 2 } as MouseEvent,
+      "https://example.com/right-click",
+      range,
+    );
+
+    expect(onActivate).not.toHaveBeenCalled();
+  });
+
+  it("confirms concealed targets and directly opens detected URLs", () => {
+    const openLink = vi.fn();
+    const requestConfirmation = vi.fn();
+
+    requestTerminalLinkOpen({
+      openLink,
+      requestConfirmation,
+      target: { source: "osc8", uri: "https://example.com/concealed" },
+    });
+    requestTerminalLinkOpen({
+      openLink,
+      requestConfirmation,
+      target: {
+        source: "detected-url",
+        uri: "https://example.com/visible",
+      },
+    });
+
+    expect(requestConfirmation).toHaveBeenCalledOnce();
+    expect(requestConfirmation).toHaveBeenCalledWith({
+      source: "osc8",
+      uri: "https://example.com/concealed",
+    });
+    expect(openLink).toHaveBeenCalledOnce();
+    expect(openLink).toHaveBeenCalledWith("https://example.com/visible");
+  });
+
+  it("preserves link actions while copying the exact xterm selection", () => {
+    const getSelection = vi.fn(() => "  wrapped terminal selection\n");
+    const link = {
+      source: "detected-url" as const,
+      uri: "https://example.com/visible",
+    };
+
+    expect(
+      captureTerminalContextMenuState({
+        link,
+        terminal: { getSelection },
+      }),
+    ).toEqual({
+      link,
+      selectionText: "  wrapped terminal selection\n",
+    });
+    expect(getSelection).toHaveBeenCalledOnce();
+  });
+});
 
 function startTouchFocusGesture() {
   const gesture = startTerminalTouchFocusGesture(

--- a/apps/app/src/components/thread/terminal/ThreadTerminalView.tsx
+++ b/apps/app/src/components/thread/terminal/ThreadTerminalView.tsx
@@ -14,6 +14,13 @@ import type {
   Terminal as XTermTerminal,
 } from "@xterm/xterm";
 import type { FitAddon } from "@xterm/addon-fit";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from "@bb/shared-ui/context-menu";
 import { TERMINAL_DATA_MAX_BYTES } from "@bb/domain";
 import type {
   TerminalServerMessage,
@@ -24,10 +31,17 @@ import { usePreferredTheme } from "@/hooks/useTheme";
 import type { MarkdownPreviewLinkHandler } from "@/components/ui/markdown-link";
 import { openUrlInExternalBrowser } from "@/lib/url-open-routing";
 import { useAppNavigationHost } from "@/lib/app-navigation-host";
+import { copyToClipboardWithToast } from "@/lib/clipboard";
 import type { MessageProseSelection } from "@/components/thread/timeline/SelectableMessageProse.js";
 import { TimelineSelectionMenu } from "@/components/thread/timeline/TimelineSelectionMenu.js";
 import { buildTerminalWebSocketUrl } from "./terminal-websocket-url";
 import { TerminalWebSocketTransport } from "@bb/client-core";
+import { TerminalLinkOpenDialog } from "./TerminalLinkOpenDialog";
+import {
+  createTerminalOsc8LinkHandler,
+  requestTerminalLinkOpen,
+  type TerminalLinkTarget,
+} from "./terminal-links";
 
 export const TERMINAL_FONT_FAMILY =
   '"JetBrainsMono Nerd Font Mono", "MesloLGS NF", "Symbols Nerd Font Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace';
@@ -323,9 +337,18 @@ interface ForwardTerminalDataArgs {
 }
 
 interface OpenTerminalWebLinkArgs {
-  event: MouseEvent;
   onOpenLink: MarkdownPreviewLinkHandler;
   uri: string;
+}
+
+interface TerminalContextMenuState {
+  link: TerminalLinkTarget | null;
+  selectionText: string;
+}
+
+interface CaptureTerminalContextMenuStateArgs {
+  link: TerminalLinkTarget | null;
+  terminal: Pick<XTermTerminal, "getSelection"> | null;
 }
 
 interface TerminalReplayWriteState {
@@ -511,15 +534,23 @@ function writeTerminalSessionStatusNotice({
 }
 
 function openTerminalWebLink({
-  event,
   onOpenLink,
   uri,
 }: OpenTerminalWebLinkArgs): void {
   if (onOpenLink({ href: uri })) {
-    event.preventDefault();
     return;
   }
   openUrlInExternalBrowser(uri);
+}
+
+export function captureTerminalContextMenuState({
+  link,
+  terminal,
+}: CaptureTerminalContextMenuStateArgs): TerminalContextMenuState {
+  return {
+    link,
+    selectionText: terminal?.getSelection() ?? "",
+  };
 }
 
 export function writeTerminalOutput({
@@ -597,8 +628,18 @@ export function ThreadTerminalView({
 }: ThreadTerminalViewProps) {
   const [activeSelection, setActiveSelection] =
     useState<MessageProseSelection | null>(null);
+  const [hoveredTerminalLink, setHoveredTerminalLink] =
+    useState<TerminalLinkTarget | null>(null);
+  const [pendingTerminalLink, setPendingTerminalLink] =
+    useState<TerminalLinkTarget | null>(null);
+  const [contextMenuState, setContextMenuState] =
+    useState<TerminalContextMenuState>({
+      link: null,
+      selectionText: "",
+    });
   const containerRef = useRef<HTMLDivElement | null>(null);
   const terminalRef = useRef<XTermTerminal | null>(null);
+  const hoveredTerminalLinkRef = useRef<TerminalLinkTarget | null>(null);
   const pointerIsDownRef = useRef(false);
   const pointerStartPointRef = useRef<TerminalSelectionAnchorPoint | null>(
     null,
@@ -666,6 +707,59 @@ export function ThreadTerminalView({
     terminalRef.current?.clearSelection();
     setActiveSelection(null);
   }, []);
+
+  const updateHoveredTerminalLink = useCallback(
+    (target: TerminalLinkTarget | null) => {
+      hoveredTerminalLinkRef.current = target;
+      setHoveredTerminalLink(target);
+    },
+    [],
+  );
+
+  const openTerminalLink = useCallback((uri: string) => {
+    openTerminalWebLink({
+      onOpenLink: onOpenLinkRef.current,
+      uri,
+    });
+  }, []);
+
+  const confirmTerminalLinkOpen = useCallback(
+    (target: TerminalLinkTarget) => {
+      setPendingTerminalLink(null);
+      openTerminalLink(target.uri);
+    },
+    [openTerminalLink],
+  );
+
+  const requestOpenTerminalLink = useCallback(
+    (target: TerminalLinkTarget) => {
+      requestTerminalLinkOpen({
+        openLink: openTerminalLink,
+        requestConfirmation: setPendingTerminalLink,
+        target,
+      });
+    },
+    [openTerminalLink],
+  );
+
+  const captureTerminalContextMenu = useCallback(() => {
+    setContextMenuState(
+      captureTerminalContextMenuState({
+        link: hoveredTerminalLinkRef.current,
+        terminal: terminalRef.current,
+      }),
+    );
+  }, []);
+
+  const copyTerminalContextValue = useCallback(
+    (text: string, successMessage: string) => {
+      void copyToClipboardWithToast(text, {
+        successMessage,
+        errorMessage: "Failed to copy",
+      });
+    },
+    [],
+  );
 
   const handleSelectionAddToChat = useCallback(
     (text: string) => {
@@ -750,7 +844,10 @@ export function ThreadTerminalView({
   useEffect(() => {
     touchFocusGestureRef.current = null;
     setActiveSelection(null);
-  }, [session.id]);
+    updateHoveredTerminalLink(null);
+    setPendingTerminalLink(null);
+    setContextMenuState({ link: null, selectionText: "" });
+  }, [session.id, updateHoveredTerminalLink]);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -796,12 +893,22 @@ export function ThreadTerminalView({
         return;
       }
 
+      const osc8LinkHandler = createTerminalOsc8LinkHandler({
+        onActivate: requestOpenTerminalLink,
+        onHover: (target) => {
+          if (!disposed) {
+            updateHoveredTerminalLink(target);
+          }
+        },
+      });
+
       terminal = new Terminal({
         allowProposedApi: TERMINAL_ALLOW_PROPOSED_API,
         convertEol: true,
         cursorBlink: true,
         fontFamily: TERMINAL_FONT_FAMILY,
         fontSize: 12,
+        linkHandler: osc8LinkHandler,
         scrollback: 10_000,
         theme: buildTerminalTheme(),
       });
@@ -811,13 +918,22 @@ export function ThreadTerminalView({
       terminal.loadAddon(new Unicode11Addon());
       terminal.unicode.activeVersion = TERMINAL_UNICODE_VERSION;
       terminal.loadAddon(
-        new WebLinksAddon((event, uri) => {
-          openTerminalWebLink({
-            event,
-            onOpenLink: onOpenLinkRef.current,
-            uri,
-          });
-        }),
+        new WebLinksAddon(
+          (event, uri) => {
+            if (event.button !== 0) {
+              return;
+            }
+            requestOpenTerminalLink({ source: "detected-url", uri });
+          },
+          {
+            hover: (_event, uri) => {
+              updateHoveredTerminalLink({ source: "detected-url", uri });
+            },
+            leave: () => {
+              updateHoveredTerminalLink(null);
+            },
+          },
+        ),
       );
       if (webglAddonModule !== null) {
         loadTerminalWebglRenderer(
@@ -997,7 +1113,13 @@ export function ThreadTerminalView({
       terminalRef.current = null;
       scheduleFitRef.current = null;
     };
-  }, [reportTerminalSelection, session.id, session.threadId]);
+  }, [
+    reportTerminalSelection,
+    requestOpenTerminalLink,
+    session.id,
+    session.threadId,
+    updateHoveredTerminalLink,
+  ]);
 
   useEffect(() => {
     if (!isPanelOpen || !autoFocus) {
@@ -1031,21 +1153,70 @@ export function ThreadTerminalView({
     terminal.options.theme = buildTerminalTheme();
   }, [preferredTheme, appThemeEpoch]);
 
+  const contextMenuLink = contextMenuState.link;
+  const contextMenuSelectionText = contextMenuState.selectionText;
+  const hasTerminalContextMenuTarget =
+    hoveredTerminalLink !== null || activeSelection !== null;
+
   return (
-    <div
-      className="h-full min-h-0 w-full overflow-hidden bg-sidebar p-2"
-      onPointerDown={handleTerminalPointerDown}
-      onPointerUp={handleTerminalPointerRelease}
-      onPointerCancel={handleTerminalPointerCancel}
-      onTouchStart={handleTerminalTouchStart}
-      onTouchMove={handleTerminalTouchMove}
-      onTouchEnd={handleTerminalTouchEnd}
-      onTouchCancel={handleTerminalTouchCancel}
+    <ContextMenu
+      onOpenChange={(open) => {
+        if (!open) {
+          setContextMenuState({ link: null, selectionText: "" });
+        }
+      }}
     >
-      <div
-        ref={containerRef}
-        className="h-full min-h-0 w-full overflow-hidden"
-      />
+      <ContextMenuTrigger asChild disabled={!hasTerminalContextMenuTarget}>
+        <div
+          className="h-full min-h-0 w-full overflow-hidden bg-sidebar p-2"
+          onContextMenuCapture={captureTerminalContextMenu}
+          onPointerDown={handleTerminalPointerDown}
+          onPointerUp={handleTerminalPointerRelease}
+          onPointerCancel={handleTerminalPointerCancel}
+          onTouchStart={handleTerminalTouchStart}
+          onTouchMove={handleTerminalTouchMove}
+          onTouchEnd={handleTerminalTouchEnd}
+          onTouchCancel={handleTerminalTouchCancel}
+        >
+          <div
+            ref={containerRef}
+            className="h-full min-h-0 w-full overflow-hidden"
+          />
+        </div>
+      </ContextMenuTrigger>
+      <ContextMenuContent className="min-w-36">
+        {contextMenuLink !== null ? (
+          <>
+            <ContextMenuItem
+              onSelect={() => requestOpenTerminalLink(contextMenuLink)}
+            >
+              Open Link
+            </ContextMenuItem>
+            <ContextMenuItem
+              onSelect={() =>
+                copyTerminalContextValue(contextMenuLink.uri, "Link copied")
+              }
+            >
+              Copy Link
+            </ContextMenuItem>
+          </>
+        ) : null}
+        {contextMenuLink !== null && contextMenuSelectionText.length > 0 ? (
+          <ContextMenuSeparator />
+        ) : null}
+        {contextMenuSelectionText.length > 0 ? (
+          <ContextMenuItem
+            onSelect={() =>
+              copyTerminalContextValue(
+                contextMenuSelectionText,
+                "Selection copied",
+              )
+            }
+          >
+            Copy
+          </ContextMenuItem>
+        ) : null}
+      </ContextMenuContent>
       <TimelineSelectionMenu
         selection={activeSelection}
         onAddToChat={
@@ -1055,6 +1226,15 @@ export function ThreadTerminalView({
         }
         onDismiss={clearTerminalSelection}
       />
-    </div>
+      <TerminalLinkOpenDialog
+        target={pendingTerminalLink}
+        onConfirm={confirmTerminalLinkOpen}
+        onOpenChange={(open) => {
+          if (!open) {
+            setPendingTerminalLink(null);
+          }
+        }}
+      />
+    </ContextMenu>
   );
 }

--- a/apps/app/src/components/thread/terminal/terminal-links.ts
+++ b/apps/app/src/components/thread/terminal/terminal-links.ts
@@ -1,0 +1,49 @@
+import type { ILinkHandler } from "@xterm/xterm";
+
+export interface TerminalLinkTarget {
+  source: "detected-url" | "osc8";
+  uri: string;
+}
+
+interface CreateTerminalOsc8LinkHandlerArgs {
+  onActivate: (target: TerminalLinkTarget) => void;
+  onHover: (target: TerminalLinkTarget | null) => void;
+}
+
+interface RequestTerminalLinkOpenArgs {
+  openLink: (uri: string) => void;
+  requestConfirmation: (target: TerminalLinkTarget) => void;
+  target: TerminalLinkTarget;
+}
+
+export function createTerminalOsc8LinkHandler({
+  onActivate,
+  onHover,
+}: CreateTerminalOsc8LinkHandlerArgs): ILinkHandler {
+  return {
+    activate: (event, uri) => {
+      if (event.button !== 0) {
+        return;
+      }
+      onActivate({ source: "osc8", uri });
+    },
+    hover: (_event, uri) => {
+      onHover({ source: "osc8", uri });
+    },
+    leave: () => {
+      onHover(null);
+    },
+  };
+}
+
+export function requestTerminalLinkOpen({
+  openLink,
+  requestConfirmation,
+  target,
+}: RequestTerminalLinkOpenArgs): void {
+  if (target.source === "osc8") {
+    requestConfirmation(target);
+    return;
+  }
+  openLink(target.uri);
+}

--- a/apps/host-daemon/src/terminals/terminal-manager.test.ts
+++ b/apps/host-daemon/src/terminals/terminal-manager.test.ts
@@ -416,6 +416,7 @@ describe("TerminalManager", () => {
       BB_TERMINAL_SESSION_ID: "term-1",
       COLORTERM: "truecolor",
       DISABLE_AUTO_TITLE: "true",
+      FORCE_HYPERLINK: "1",
       PROMPT_EOL_MARK: "",
       TERM: "xterm-256color",
     });

--- a/apps/host-daemon/src/terminals/terminal-manager.ts
+++ b/apps/host-daemon/src/terminals/terminal-manager.ts
@@ -351,6 +351,7 @@ function buildTerminalEnv(args: BuildTerminalEnvArgs): NodeJS.ProcessEnv {
     BB_TERMINAL_SESSION_ID: args.terminalId,
     COLORTERM: "truecolor",
     DISABLE_AUTO_TITLE: "true",
+    FORCE_HYPERLINK: "1",
     PROMPT_EOL_MARK: "",
     TERM: "xterm-256color",
   };


### PR DESCRIPTION
## Human comments

## What was wrong

The host terminal environment did not advertise OSC 8 support, so programs using hyperlink capability detection could flatten named hyperlinks into display text and discard the target. The shared terminal also did not install an OSC 8 activation handler. Its context menu did not snapshot xterm's logical selection before xterm handled a macOS secondary click, so xterm could replace a soft-wrapped selection with the clicked word before Copy read it. See #2469 and the [reproduction and root-cause report](https://get-bb.github.io/reports/issues/2469.html).

## What changed

- Advertise hyperlink support to spawned terminal processes with `FORCE_HYPERLINK=1`.
- Route shared-app OSC 8 activation through bb's URL navigation after disclosing and confirming the exact target in bb's responsive dialog; visibly detected URLs retain direct activation.
- Add terminal context-menu actions for opening/copying links and copying the exact xterm selection across soft-wrapped rows.
- Snapshot the logical selection during context-menu capture, before xterm's nested macOS handler can replace it.
- Add regression coverage for the host environment, shared-app handlers, dialog behavior, and the real xterm context-menu event sequence.
- Keep the implementation in the host daemon and shared app. There are no native mobile terminal changes because mobile now uses the shared app terminal UI.
- No `HOST_DAEMON_PROTOCOL_VERSION` bump is needed because this changes only the environment of newly spawned PTYs; no server/daemon wire field or message changed.
- `FORCE_HYPERLINK` is the available opt-in for programs that do not recognize bb as a terminal. Programs that treat it as an unconditional override may also emit OSC 8 when their output is redirected; callers requiring plain redirected output can set `FORCE_HYPERLINK=0` for that command.

## How you verified

- `pnpm --filter @bb/app exec vitest run --config vitest.config.ts src/components/thread/terminal` — 42 tests passed across 7 files.
- `pnpm --filter @bb/host-daemon exec vitest run --config vitest.config.ts src/terminals/terminal-manager.test.ts` — 29 tests passed.
- `pnpm exec turbo run typecheck lint --filter=@bb/app --filter=@bb/host-daemon` — all tasks passed; lint reported 0 errors.
- `pnpm run build` — all 12 production build tasks passed.
- Oxfmt and `git diff --check` passed for the changed source files.
- Exercised the flow with Computer Use against an isolated worktree instance: a concealed OSC 8 label disclosed its exact target in bb's confirmation dialog, Open launched that target in a new browser tab, and a multi-row soft-wrapped selection copied and pasted back as one continuous logical value.

Fixes #2469

> AGENT GENERATED
