### PR TITLE
Replace the compact right drawer with full-page tool tabs

### DIFF
--- a/apps/app/src/components/plugin/PluginPanelRightPanelHost.tsx
+++ b/apps/app/src/components/plugin/PluginPanelRightPanelHost.tsx
@@ -21,7 +21,10 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@bb/shared-ui/tooltip";
 import { useAppCommandHandler } from "@/components/commands/AppCommandProvider";
 import { PluginIcon } from "@/components/plugin/PluginIcon";
 import { PluginSlotMount } from "@/components/plugin/PluginSlotMount";
-import { RIGHT_PANEL_TOGGLE_ICON_NAME } from "@/components/secondary-panel/panelToggleControlState";
+import {
+  getCompactPanelPresentation,
+  RIGHT_PANEL_TOGGLE_ICON_NAME,
+} from "@/components/secondary-panel/panelToggleControlState";
 import { SecondaryPanelLayout } from "@/components/secondary-panel/SecondaryPanelLayout";
 import {
   LazyBrowserTabDeck,
@@ -971,6 +974,7 @@ export function PluginPanelRightPanelHost({
         mainPanelId={`plugin-panel-main-${panelHostId}`}
         main={children}
         composerHost={null}
+        compactPresentation={getCompactPanelPresentation(activeTab?.kind)}
         renderPanel={renderPanel}
       />
     </div>

--- a/apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.stories.tsx
+++ b/apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.stories.tsx
@@ -1,5 +1,6 @@
 import { useState, type ReactNode } from "react";
 import { Icon } from "@bb/shared-ui/icon";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   createGitDiffFixedPanelTab,
   createThreadInfoFixedPanelTab,
@@ -18,6 +19,9 @@ import {
 } from "./ThreadSecondaryPanel";
 import { ThreadMetadataContent } from "./ThreadMetadataContent";
 import { baseProps as baseMetadataProps } from "./ThreadMetadataContent.fixtures";
+import { FilePreview } from "./FilePreview";
+import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
+import { threadListQueryKey } from "@/hooks/queries/query-keys";
 
 export default {
   title: "right-panel/Compact shelf",
@@ -26,6 +30,18 @@ export default {
 const noop = () => {};
 
 const STORY_FILE_PATH = "apps/app/src/views/RootComposeCompactHome.tsx";
+const STORY_FILE_SOURCE = `export function RootComposeCompactHome({
+  children,
+  composer,
+}: RootComposeCompactHomeProps) {
+  const { regionRef, composerRef } = useCompactHomeMetrics();
+  return (
+    <div ref={regionRef} className="relative min-h-0 flex-1">
+      {children}
+      <div ref={composerRef}>{composer}</div>
+    </div>
+  );
+}`;
 
 function createStoryFileTab(path: string): HostFilePreviewFixedPanelTab {
   return {
@@ -55,50 +71,52 @@ const MANY_TAB_PATHS: string[] = [
   "an-unusually-long-component-filename-that-must-truncate.tsx",
 ]
 
-function StoryFileContent() {
+function StoryFileContent({ path }: { path: string }) {
   return (
-    <div className="flex h-full min-h-0 flex-col overflow-auto p-3 font-mono text-xs">
-      <p className="text-muted-foreground">{STORY_FILE_PATH}</p>
-      <pre className="pt-2 whitespace-pre-wrap">{`export function RootComposeCompactHome({
-  children,
-  composer,
-}: RootComposeCompactHomeProps) {
-  const { regionRef, composerRef } = useCompactHomeMetrics();
-  return (
-    <div ref={regionRef} className="relative min-h-0 flex-1">
-      …
-    </div>
-  );
-}`}</pre>
-    </div>
+    <FilePreview
+      path={path}
+      state={{
+        kind: "ready",
+        lineRange: null,
+        textPreviewKind: null,
+        file: {
+          cacheKey: `compact-shelf-story:${path}`,
+          name: path.split("/").at(-1) ?? path,
+          contents: STORY_FILE_SOURCE,
+        },
+      }}
+    />
   );
 }
 
 interface ShelfPanelProps {
   activeTab: SecondaryFixedPanelTab;
-  onSelectInfo: () => void;
-  onSelectFile: () => void;
+  onSelectTab: (tab: SecondaryFixedPanelTab) => void;
   onClose: () => void;
   filePaths?: string[];
 }
 
 function ShelfPanel({
   activeTab,
-  onSelectInfo,
-  onSelectFile,
+  onSelectTab,
   onClose,
   filePaths = [STORY_FILE_PATH],
 }: ShelfPanelProps) {
-  const tabs: SecondaryPanelRenderableTab[] = filePaths.map((path, index) => ({
-    label: path.split("/").at(-1) ?? path,
-    isPinned: index === 0 && filePaths.length > 1,
-    leadingVisual: <Icon name="File" className="size-3.5" aria-hidden />,
-    statusLabel: null,
-    onSelect: onSelectFile,
-    onClose: noop,
-    renderContent: () => <StoryFileContent />,
-    tab: path === STORY_FILE_PATH ? fileTab : createStoryFileTab(path),
-  }));
+  const tabs: SecondaryPanelRenderableTab[] = filePaths.map((path, index) => {
+    const tab = path === STORY_FILE_PATH ? fileTab : createStoryFileTab(path);
+    return {
+      label: path.split("/").at(-1) ?? path,
+      isPinned: index === 0 && filePaths.length > 1,
+      leadingVisual: <Icon name="File" className="size-3.5" aria-hidden />,
+      statusLabel: null,
+      onSelect: () => onSelectTab(tab),
+      onClose: noop,
+      renderContent: () => <StoryFileContent path={path} />,
+      tab,
+    };
+  });
+  const infoTab = createThreadInfoFixedPanelTab();
+  const diffTab = createGitDiffFixedPanelTab();
 
   return (
     <ThreadSecondaryPanel
@@ -114,16 +132,16 @@ function ShelfPanel({
           ariaLabel: "Show thread info panel",
           label: "Info",
           leadingVisual: <Icon name="Info" />,
-          onSelect: onSelectInfo,
-          tab: createThreadInfoFixedPanelTab(),
+          onSelect: () => onSelectTab(infoTab),
+          tab: infoTab,
           title: "Thread info",
         },
         {
           ariaLabel: "Show diff panel",
           label: "Diff",
           leadingVisual: <Icon name="FileDiff" />,
-          onSelect: onSelectInfo,
-          tab: createGitDiffFixedPanelTab(),
+          onSelect: () => onSelectTab(diffTab),
+          tab: diffTab,
           title: "Diff",
         },
       ]}
@@ -131,7 +149,7 @@ function ShelfPanel({
       onCollapse={noop}
       onClose={onClose}
       onTabReorder={noop}
-      onOpenNewTab={onSelectFile}
+      onOpenNewTab={noop}
       isConversationCollapsed={false}
       onToggleConversationCollapse={noop}
       renderAsDrawer
@@ -142,14 +160,35 @@ function ShelfPanel({
 }
 
 function Stage({ children }: { children: ReactNode }) {
+  const [queryClient] = useState(() => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+    client.setQueryData(
+      threadListQueryKey({
+        projectId: baseMetadataProps.thread.projectId,
+        sourceThreadId: baseMetadataProps.thread.id,
+        originKind: "fork",
+        archived: false,
+      }),
+      [],
+    );
+    return client;
+  });
   return (
-    <div
-      className={`${MOBILE_RECENTS_VISIBILITY_CLASS} fixed inset-0 flex flex-col bg-background`}
-    >
-      <MobileRecentsVisibilityStyle />
-      <CompactHomePage />
-      {children}
-    </div>
+    <QueryClientProvider client={queryClient}>
+      <div
+        className={`${MOBILE_RECENTS_VISIBILITY_CLASS} fixed inset-0 flex flex-col bg-background`}
+      >
+        <MobileRecentsVisibilityStyle />
+        <SidebarProvider defaultOpen={false} className="min-h-0">
+          <SidebarInset className="min-h-0 overflow-hidden">
+            <CompactHomePage />
+          </SidebarInset>
+          {children}
+        </SidebarProvider>
+      </div>
+    </QueryClientProvider>
   );
 }
 
@@ -174,8 +213,7 @@ function ShelfStory({
       >
         <ShelfPanel
           activeTab={activeTab}
-          onSelectInfo={() => setActiveTab(createThreadInfoFixedPanelTab())}
-          onSelectFile={() => setActiveTab(fileTab)}
+          onSelectTab={setActiveTab}
           onClose={() => setOpen(false)}
         />
       </CompactSecondaryPanelShelf>
@@ -205,8 +243,7 @@ export function ManyTabs() {
         <ShelfPanel
           activeTab={activeTab}
           filePaths={MANY_TAB_PATHS}
-          onSelectInfo={() => setActiveTab(createThreadInfoFixedPanelTab())}
-          onSelectFile={() => setActiveTab(fileTab)}
+          onSelectTab={setActiveTab}
           onClose={noop}
         />
       </CompactSecondaryPanelShelf>
@@ -225,8 +262,7 @@ export function Closed() {
       >
         <ShelfPanel
           activeTab={createThreadInfoFixedPanelTab()}
-          onSelectInfo={noop}
-          onSelectFile={noop}
+          onSelectTab={noop}
           onClose={noop}
         />
       </CompactSecondaryPanelShelf>

--- a/apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.stories.tsx
+++ b/apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.stories.tsx
@@ -41,6 +41,20 @@ function createStoryFileTab(path: string): HostFilePreviewFixedPanelTab {
 
 const fileTab = createStoryFileTab(STORY_FILE_PATH);
 
+const MANY_TAB_PATHS: string[] = [
+  STORY_FILE_PATH,
+  "apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.tsx",
+  "apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.tsx",
+  "apps/app/src/hooks/queries/thread-queries.ts",
+  "apps/app/src/components/ui/sidebar.tsx",
+  "apps/app/src/components/ui/theme.css",
+  "apps/app/src/app.css",
+  "package.json",
+  "README.md",
+  "apps/server/src/services/providers/provider-registry.ts",
+  "an-unusually-long-component-filename-that-must-truncate.tsx",
+]
+
 function StoryFileContent() {
   return (
     <div className="flex h-full min-h-0 flex-col overflow-auto p-3 font-mono text-xs">
@@ -65,6 +79,7 @@ interface ShelfPanelProps {
   onSelectInfo: () => void;
   onSelectFile: () => void;
   onClose: () => void;
+  filePaths?: string[];
 }
 
 function ShelfPanel({
@@ -72,19 +87,18 @@ function ShelfPanel({
   onSelectInfo,
   onSelectFile,
   onClose,
+  filePaths = [STORY_FILE_PATH],
 }: ShelfPanelProps) {
-  const tabs: SecondaryPanelRenderableTab[] = [
-    {
-      label: "RootComposeCompactHome.tsx",
-      isPinned: false,
-      leadingVisual: <Icon name="File" className="size-3.5" aria-hidden />,
-      statusLabel: null,
-      onSelect: onSelectFile,
-      onClose: noop,
-      renderContent: () => <StoryFileContent />,
-      tab: fileTab,
-    },
-  ];
+  const tabs: SecondaryPanelRenderableTab[] = filePaths.map((path, index) => ({
+    label: path.split("/").at(-1) ?? path,
+    isPinned: index === 0 && filePaths.length > 1,
+    leadingVisual: <Icon name="File" className="size-3.5" aria-hidden />,
+    statusLabel: null,
+    onSelect: onSelectFile,
+    onClose: noop,
+    renderContent: () => <StoryFileContent />,
+    tab: path === STORY_FILE_PATH ? fileTab : createStoryFileTab(path),
+  }));
 
   return (
     <ThreadSecondaryPanel
@@ -175,6 +189,29 @@ export function Shelf() {
 
 export function FullPage() {
   return <ShelfStory initialPresentation="full" />;
+}
+
+export function ManyTabs() {
+  const [activeTab, setActiveTab] = useState<SecondaryFixedPanelTab>(fileTab);
+  const presentation = activeTab.kind === "thread-info" ? "shelf" : "full";
+  return (
+    <Stage>
+      <CompactSecondaryPanelShelf
+        open
+        onClose={noop}
+        presentation={presentation}
+        srLabel="Right panel"
+      >
+        <ShelfPanel
+          activeTab={activeTab}
+          filePaths={MANY_TAB_PATHS}
+          onSelectInfo={() => setActiveTab(createThreadInfoFixedPanelTab())}
+          onSelectFile={() => setActiveTab(fileTab)}
+          onClose={noop}
+        />
+      </CompactSecondaryPanelShelf>
+    </Stage>
+  );
 }
 
 export function Closed() {

--- a/apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.stories.tsx
+++ b/apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.stories.tsx
@@ -1,0 +1,129 @@
+import { useState, type ReactNode } from "react";
+import { CompactSecondaryPanelShelf } from "./CompactSecondaryPanelShelf";
+
+export default {
+  title: "right-panel/Compact shelf",
+};
+
+const noop = () => {};
+
+function PanelBody({ label }: { label: string }) {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-3 p-3">
+      <div className="flex items-center gap-2">
+        <span className="flex size-7 items-center justify-center rounded-md border border-border-seam bg-surface-raised text-xs">
+          i
+        </span>
+        <span className="text-sm font-medium">{label}</span>
+      </div>
+      <div className="h-9 rounded-md border border-border bg-surface-raised" />
+      <div className="h-9 rounded-md border border-border bg-surface-raised" />
+      <div className="h-9 rounded-md border border-border bg-surface-raised" />
+    </div>
+  );
+}
+
+function PageBehind({ children }: { children: ReactNode }) {
+  return (
+    <div className="fixed inset-0 flex flex-col bg-background">
+      <div className="flex h-14 shrink-0 items-center gap-3 border-b border-border-seam px-4">
+        <span className="flex size-7 items-center justify-center rounded-md border border-border-seam text-xs">
+          ☰
+        </span>
+        <span className="text-sm font-medium">Rework folder model</span>
+      </div>
+      <div className="flex-1 p-4 text-sm text-muted-foreground">
+        Thread timeline sits here. When the shelf is open this page stays
+        visible; when a tab goes full page it is fully displaced.
+      </div>
+      {children}
+    </div>
+  );
+}
+
+export function Shelf() {
+  return (
+    <PageBehind>
+      <CompactSecondaryPanelShelf
+        open
+        onClose={noop}
+        presentation="shelf"
+        srLabel="Right panel"
+      >
+        <PanelBody label="Thread info" />
+      </CompactSecondaryPanelShelf>
+    </PageBehind>
+  );
+}
+
+export function FullPage() {
+  return (
+    <PageBehind>
+      <CompactSecondaryPanelShelf
+        open
+        onClose={noop}
+        presentation="full"
+        srLabel="Right panel"
+      >
+        <PanelBody label="New tab" />
+      </CompactSecondaryPanelShelf>
+    </PageBehind>
+  );
+}
+
+export function Closed() {
+  return (
+    <PageBehind>
+      <CompactSecondaryPanelShelf
+        open={false}
+        onClose={noop}
+        presentation="shelf"
+        srLabel="Right panel"
+      >
+        <PanelBody label="Thread info" />
+      </CompactSecondaryPanelShelf>
+    </PageBehind>
+  );
+}
+
+export function ShelfToFullPage() {
+  const [presentation, setPresentation] = useState<"shelf" | "full">("shelf");
+  const [open, setOpen] = useState(true);
+  return (
+    <PageBehind>
+      <div className="absolute inset-x-0 bottom-0 z-100 flex gap-2 p-3">
+        <button
+          type="button"
+          className="rounded-md border border-border bg-background px-3 py-1.5 text-xs"
+          onClick={() => setPresentation("shelf")}
+        >
+          Info (shelf)
+        </button>
+        <button
+          type="button"
+          className="rounded-md border border-border bg-background px-3 py-1.5 text-xs"
+          onClick={() => setPresentation("full")}
+        >
+          Open tab (full page)
+        </button>
+        <button
+          type="button"
+          className="rounded-md border border-border bg-background px-3 py-1.5 text-xs"
+          onClick={() => setOpen((value) => !value)}
+        >
+          {open ? "Close" : "Open"}
+        </button>
+      </div>
+      <CompactSecondaryPanelShelf
+        open={open}
+        onClose={() => setOpen(false)}
+        presentation={presentation}
+        srLabel="Right panel"
+      >
+        <PanelBody
+          label={presentation === "shelf" ? "Thread info" : "New tab"}
+        />
+      </CompactSecondaryPanelShelf>
+    </PageBehind>
+  );
+}

--- a/apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.stories.tsx
+++ b/apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.stories.tsx
@@ -1,5 +1,23 @@
 import { useState, type ReactNode } from "react";
+import { Icon } from "@bb/shared-ui/icon";
+import {
+  createGitDiffFixedPanelTab,
+  createThreadInfoFixedPanelTab,
+  type HostFilePreviewFixedPanelTab,
+  type SecondaryFixedPanelTab,
+} from "@/lib/fixed-panel-tabs-state";
+import {
+  CompactHomePage,
+  MOBILE_RECENTS_VISIBILITY_CLASS,
+  MobileRecentsVisibilityStyle,
+} from "@/views/mobile-home-story-fixtures";
 import { CompactSecondaryPanelShelf } from "./CompactSecondaryPanelShelf";
+import {
+  ThreadSecondaryPanel,
+  type SecondaryPanelRenderableTab,
+} from "./ThreadSecondaryPanel";
+import { ThreadMetadataContent } from "./ThreadMetadataContent";
+import { baseProps as baseMetadataProps } from "./ThreadMetadataContent.fixtures";
 
 export default {
   title: "right-panel/Compact shelf",
@@ -7,123 +25,174 @@ export default {
 
 const noop = () => {};
 
-function PanelBody({ label }: { label: string }) {
+const STORY_FILE_PATH = "apps/app/src/views/RootComposeCompactHome.tsx";
+
+function createStoryFileTab(path: string): HostFilePreviewFixedPanelTab {
+  return {
+    environmentId: "env_story",
+    hostId: "host_story",
+    id: `host-file-preview:${encodeURIComponent(path)}:thread%3Athr_story%3Aenvironment%3Aenv_story`,
+    kind: "host-file-preview",
+    lineRange: null,
+    path,
+    threadId: "thr_story",
+  };
+}
+
+const fileTab = createStoryFileTab(STORY_FILE_PATH);
+
+function StoryFileContent() {
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-3 p-3">
-      <div className="flex items-center gap-2">
-        <span className="flex size-7 items-center justify-center rounded-md border border-border-seam bg-surface-raised text-xs">
-          i
-        </span>
-        <span className="text-sm font-medium">{label}</span>
-      </div>
-      <div className="h-9 rounded-md border border-border bg-surface-raised" />
-      <div className="h-9 rounded-md border border-border bg-surface-raised" />
-      <div className="h-9 rounded-md border border-border bg-surface-raised" />
+    <div className="flex h-full min-h-0 flex-col overflow-auto p-3 font-mono text-xs">
+      <p className="text-muted-foreground">{STORY_FILE_PATH}</p>
+      <pre className="pt-2 whitespace-pre-wrap">{`export function RootComposeCompactHome({
+  children,
+  composer,
+}: RootComposeCompactHomeProps) {
+  const { regionRef, composerRef } = useCompactHomeMetrics();
+  return (
+    <div ref={regionRef} className="relative min-h-0 flex-1">
+      …
+    </div>
+  );
+}`}</pre>
     </div>
   );
 }
 
-function PageBehind({ children }: { children: ReactNode }) {
+interface ShelfPanelProps {
+  activeTab: SecondaryFixedPanelTab;
+  onSelectInfo: () => void;
+  onSelectFile: () => void;
+  onClose: () => void;
+}
+
+function ShelfPanel({
+  activeTab,
+  onSelectInfo,
+  onSelectFile,
+  onClose,
+}: ShelfPanelProps) {
+  const tabs: SecondaryPanelRenderableTab[] = [
+    {
+      label: "RootComposeCompactHome.tsx",
+      isPinned: false,
+      leadingVisual: <Icon name="File" className="size-3.5" aria-hidden />,
+      statusLabel: null,
+      onSelect: onSelectFile,
+      onClose: noop,
+      renderContent: () => <StoryFileContent />,
+      tab: fileTab,
+    },
+  ];
+
   return (
-    <div className="fixed inset-0 flex flex-col bg-background">
-      <div className="flex h-14 shrink-0 items-center gap-3 border-b border-border-seam px-4">
-        <span className="flex size-7 items-center justify-center rounded-md border border-border-seam text-xs">
-          ☰
-        </span>
-        <span className="text-sm font-medium">Rework folder model</span>
-      </div>
-      <div className="flex-1 p-4 text-sm text-muted-foreground">
-        Thread timeline sits here. When the shelf is open this page stays
-        visible; when a tab goes full page it is fully displaced.
-      </div>
+    <ThreadSecondaryPanel
+      activeTab={activeTab}
+      canUseGitUi
+      requestedMergeBaseBranch="main"
+      environmentId={undefined}
+      isOpen
+      metadataContent={<ThreadMetadataContent {...baseMetadataProps} />}
+      tabs={tabs}
+      fixedTabs={[
+        {
+          ariaLabel: "Show thread info panel",
+          label: "Info",
+          leadingVisual: <Icon name="Info" />,
+          onSelect: onSelectInfo,
+          tab: createThreadInfoFixedPanelTab(),
+          title: "Thread info",
+        },
+        {
+          ariaLabel: "Show diff panel",
+          label: "Diff",
+          leadingVisual: <Icon name="FileDiff" />,
+          onSelect: onSelectInfo,
+          tab: createGitDiffFixedPanelTab(),
+          title: "Diff",
+        },
+      ]}
+      onPanelFocus={noop}
+      onCollapse={noop}
+      onClose={onClose}
+      onTabReorder={noop}
+      onOpenNewTab={onSelectFile}
+      isConversationCollapsed={false}
+      onToggleConversationCollapse={noop}
+      renderAsDrawer
+      inlinePanelToggle="hidden"
+      showConversationCollapseControl={false}
+    />
+  );
+}
+
+function Stage({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className={`${MOBILE_RECENTS_VISIBILITY_CLASS} fixed inset-0 flex flex-col bg-background`}
+    >
+      <MobileRecentsVisibilityStyle />
+      <CompactHomePage />
       {children}
     </div>
   );
 }
 
-export function Shelf() {
-  return (
-    <PageBehind>
-      <CompactSecondaryPanelShelf
-        open
-        onClose={noop}
-        presentation="shelf"
-        srLabel="Right panel"
-      >
-        <PanelBody label="Thread info" />
-      </CompactSecondaryPanelShelf>
-    </PageBehind>
+function ShelfStory({
+  initialPresentation,
+}: {
+  initialPresentation: "shelf" | "full";
+}) {
+  const [activeTab, setActiveTab] = useState<SecondaryFixedPanelTab>(
+    initialPresentation === "shelf" ? createThreadInfoFixedPanelTab() : fileTab,
   );
-}
-
-export function FullPage() {
-  return (
-    <PageBehind>
-      <CompactSecondaryPanelShelf
-        open
-        onClose={noop}
-        presentation="full"
-        srLabel="Right panel"
-      >
-        <PanelBody label="New tab" />
-      </CompactSecondaryPanelShelf>
-    </PageBehind>
-  );
-}
-
-export function Closed() {
-  return (
-    <PageBehind>
-      <CompactSecondaryPanelShelf
-        open={false}
-        onClose={noop}
-        presentation="shelf"
-        srLabel="Right panel"
-      >
-        <PanelBody label="Thread info" />
-      </CompactSecondaryPanelShelf>
-    </PageBehind>
-  );
-}
-
-export function ShelfToFullPage() {
-  const [presentation, setPresentation] = useState<"shelf" | "full">("shelf");
   const [open, setOpen] = useState(true);
+  const presentation = activeTab.kind === "thread-info" ? "shelf" : "full";
+
   return (
-    <PageBehind>
-      <div className="absolute inset-x-0 bottom-0 z-100 flex gap-2 p-3">
-        <button
-          type="button"
-          className="rounded-md border border-border bg-background px-3 py-1.5 text-xs"
-          onClick={() => setPresentation("shelf")}
-        >
-          Info (shelf)
-        </button>
-        <button
-          type="button"
-          className="rounded-md border border-border bg-background px-3 py-1.5 text-xs"
-          onClick={() => setPresentation("full")}
-        >
-          Open tab (full page)
-        </button>
-        <button
-          type="button"
-          className="rounded-md border border-border bg-background px-3 py-1.5 text-xs"
-          onClick={() => setOpen((value) => !value)}
-        >
-          {open ? "Close" : "Open"}
-        </button>
-      </div>
+    <Stage>
       <CompactSecondaryPanelShelf
         open={open}
         onClose={() => setOpen(false)}
         presentation={presentation}
         srLabel="Right panel"
       >
-        <PanelBody
-          label={presentation === "shelf" ? "Thread info" : "New tab"}
+        <ShelfPanel
+          activeTab={activeTab}
+          onSelectInfo={() => setActiveTab(createThreadInfoFixedPanelTab())}
+          onSelectFile={() => setActiveTab(fileTab)}
+          onClose={() => setOpen(false)}
         />
       </CompactSecondaryPanelShelf>
-    </PageBehind>
+    </Stage>
+  );
+}
+
+export function Shelf() {
+  return <ShelfStory initialPresentation="shelf" />;
+}
+
+export function FullPage() {
+  return <ShelfStory initialPresentation="full" />;
+}
+
+export function Closed() {
+  return (
+    <Stage>
+      <CompactSecondaryPanelShelf
+        open={false}
+        onClose={noop}
+        presentation="shelf"
+        srLabel="Right panel"
+      >
+        <ShelfPanel
+          activeTab={createThreadInfoFixedPanelTab()}
+          onSelectInfo={noop}
+          onSelectFile={noop}
+          onClose={noop}
+        />
+      </CompactSecondaryPanelShelf>
+    </Stage>
   );
 }

--- a/apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.test.tsx
+++ b/apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.test.tsx
@@ -3,18 +3,26 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { CompactSecondaryPanelShelf } from "./CompactSecondaryPanelShelf";
-import { isCompactSecondaryPanelShelfShowing } from "@/components/ui/secondary-panel-shelf-visibility";
+import {
+  getCompactSecondaryPanelPresentation,
+  isCompactSecondaryPanelShelfShowing,
+} from "@/components/ui/secondary-panel-shelf-visibility";
 
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
 });
 
-function renderShelf(open: boolean, onClose = vi.fn()) {
+function renderShelf(
+  open: boolean,
+  presentation: "shelf" | "full" = "shelf",
+  onClose = vi.fn(),
+) {
   const view = render(
     <CompactSecondaryPanelShelf
       open={open}
       onClose={onClose}
+      presentation={presentation}
       srLabel="Right panel"
     >
       <div data-testid="panel-body" />
@@ -33,7 +41,37 @@ describe("CompactSecondaryPanelShelf", () => {
     expect(shelf.className).toContain("z-0");
     expect(shelf.className).toContain("w-(--secondary-panel-width-mobile)");
     expect(shelf.className).not.toContain("bottom-0");
-    expect(shelf.className).not.toContain("rounded-t-xl");
+  });
+
+  it("fills the viewport for a full-page tab and keeps the shelf width otherwise", () => {
+    const { rerender } = renderShelf(true, "shelf");
+    const shelf = screen.getByTestId("secondary-panel-shelf");
+    expect(shelf.dataset.state).toBe("shelf");
+    expect(shelf.className).toContain("data-[state=full]:w-full");
+
+    rerender(
+      <CompactSecondaryPanelShelf
+        open
+        onClose={vi.fn()}
+        presentation="full"
+        srLabel="Right panel"
+      >
+        <div data-testid="panel-body" />
+      </CompactSecondaryPanelShelf>,
+    );
+    expect(screen.getByTestId("secondary-panel-shelf").dataset.state).toBe(
+      "full",
+    );
+  });
+
+  it("stops the dismiss layer from swallowing taps once the panel is full page", () => {
+    renderShelf(true, "full");
+
+    const dismiss = screen.getByTestId("secondary-panel-shelf-dismiss");
+    expect(dismiss.className).toContain(
+      "data-[state=full]:pointer-events-none",
+    );
+    expect(dismiss.className).toContain("data-[state=full]:-translate-x-full");
   });
 
   it("leaves the page undimmed and dismisses from the exposed strip", () => {
@@ -42,7 +80,7 @@ describe("CompactSecondaryPanelShelf", () => {
     const dismiss = screen.getByTestId("secondary-panel-shelf-dismiss");
     expect(dismiss.className).toContain("bg-transparent");
     expect(dismiss.className).toContain(
-      "data-[state=open]:-translate-x-(--secondary-panel-width-mobile)",
+      "data-[state=shelf]:-translate-x-(--secondary-panel-width-mobile)",
     );
 
     fireEvent.click(dismiss);
@@ -53,6 +91,7 @@ describe("CompactSecondaryPanelShelf", () => {
     renderShelf(false);
 
     const shelf = screen.getByTestId("secondary-panel-shelf");
+    expect(shelf.dataset.state).toBe("closed");
     expect(shelf.className).toContain("data-[state=closed]:invisible");
     expect(shelf.className).toContain(
       "data-[state=closed]:[transition:visibility_0s_linear_220ms]",
@@ -66,7 +105,12 @@ describe("CompactSecondaryPanelShelf", () => {
     ).toBe(true);
 
     rerender(
-      <CompactSecondaryPanelShelf open onClose={vi.fn()} srLabel="Right panel">
+      <CompactSecondaryPanelShelf
+        open
+        onClose={vi.fn()}
+        presentation="shelf"
+        srLabel="Right panel"
+      >
         <div data-testid="panel-body" />
       </CompactSecondaryPanelShelf>,
     );
@@ -75,23 +119,38 @@ describe("CompactSecondaryPanelShelf", () => {
     ).toBe(false);
   });
 
-  it("publishes open state so the page knows to displace", () => {
-    const { rerender, unmount } = renderShelf(true);
+  it("publishes the presentation so the page knows how far to displace", () => {
+    const { rerender, unmount } = renderShelf(true, "shelf");
+    expect(getCompactSecondaryPanelPresentation()).toBe("shelf");
     expect(isCompactSecondaryPanelShelfShowing()).toBe(true);
 
     rerender(
       <CompactSecondaryPanelShelf
-        open={false}
+        open
         onClose={vi.fn()}
+        presentation="full"
         srLabel="Right panel"
       >
         <div data-testid="panel-body" />
       </CompactSecondaryPanelShelf>,
     );
+    expect(getCompactSecondaryPanelPresentation()).toBe("full");
+
+    rerender(
+      <CompactSecondaryPanelShelf
+        open={false}
+        onClose={vi.fn()}
+        presentation="full"
+        srLabel="Right panel"
+      >
+        <div data-testid="panel-body" />
+      </CompactSecondaryPanelShelf>,
+    );
+    expect(getCompactSecondaryPanelPresentation()).toBe("closed");
     expect(isCompactSecondaryPanelShelfShowing()).toBe(false);
 
     unmount();
-    expect(isCompactSecondaryPanelShelfShowing()).toBe(false);
+    expect(getCompactSecondaryPanelPresentation()).toBe("closed");
   });
 
   it("closes on Escape only while open", () => {
@@ -100,7 +159,12 @@ describe("CompactSecondaryPanelShelf", () => {
     expect(onClose).not.toHaveBeenCalled();
 
     rerender(
-      <CompactSecondaryPanelShelf open onClose={onClose} srLabel="Right panel">
+      <CompactSecondaryPanelShelf
+        open
+        onClose={onClose}
+        presentation="shelf"
+        srLabel="Right panel"
+      >
         <div data-testid="panel-body" />
       </CompactSecondaryPanelShelf>,
     );

--- a/apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.test.tsx
+++ b/apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.test.tsx
@@ -64,6 +64,14 @@ describe("CompactSecondaryPanelShelf", () => {
     );
   });
 
+  it("lifts the full page panel over the fixed app chrome so its icons cannot collide", () => {
+    renderShelf(true, "full");
+
+    const shelf = screen.getByTestId("secondary-panel-shelf");
+    expect(shelf.className).toContain("z-0");
+    expect(shelf.className).toContain("data-[state=full]:z-60");
+  });
+
   it("stops the dismiss layer from swallowing taps once the panel is full page", () => {
     renderShelf(true, "full");
 

--- a/apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.tsx
+++ b/apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.tsx
@@ -1,10 +1,13 @@
 import { useEffect, useId, useRef, useState, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { cn } from "@bb/shared-ui/lib/utils";
-import { setCompactSecondaryPanelShelfShowing } from "@/components/ui/secondary-panel-shelf-visibility";
+import {
+  setCompactSecondaryPanelPresentation,
+  type CompactSecondaryPanelPresentation,
+} from "@/components/ui/secondary-panel-shelf-visibility";
 
 const SHELF_TRANSITION_CLASS =
-  "[transition:translate_220ms_cubic-bezier(0.32,0.72,0,1)]";
+  "[transition:translate_220ms_cubic-bezier(0.32,0.72,0,1),width_220ms_cubic-bezier(0.32,0.72,0,1)]";
 const SHELF_SETTLE_MS = 220;
 
 interface CompactSecondaryPanelShelfProps {
@@ -12,6 +15,7 @@ interface CompactSecondaryPanelShelfProps {
   onClose: () => void;
   onContentAnimationEnd?: (open: boolean) => void;
   open: boolean;
+  presentation: Exclude<CompactSecondaryPanelPresentation, "closed">;
   srLabel?: string;
 }
 
@@ -20,15 +24,17 @@ export function CompactSecondaryPanelShelf({
   onClose,
   onContentAnimationEnd,
   open,
+  presentation,
   srLabel,
 }: CompactSecondaryPanelShelfProps) {
   const labelId = useId();
   const panelRef = useRef<HTMLDivElement | null>(null);
+  const state = !open ? "closed" : presentation;
 
   useEffect(() => {
-    setCompactSecondaryPanelShelfShowing(open);
-    return () => setCompactSecondaryPanelShelfShowing(false);
-  }, [open]);
+    setCompactSecondaryPanelPresentation(state);
+    return () => setCompactSecondaryPanelPresentation("closed");
+  }, [state]);
 
   useEffect(() => {
     if (!open) return;
@@ -62,13 +68,14 @@ export function CompactSecondaryPanelShelf({
       <div
         data-secondary-panel-shelf-dismiss=""
         data-testid="secondary-panel-shelf-dismiss"
-        data-state={open ? "open" : "closed"}
+        data-state={state}
         aria-hidden="true"
         className={cn(
           "fixed inset-0 z-40 bg-transparent",
-          "data-[state=open]:-translate-x-(--secondary-panel-width-mobile)",
+          "data-[state=shelf]:-translate-x-(--secondary-panel-width-mobile)",
+          "data-[state=full]:-translate-x-full",
           SHELF_TRANSITION_CLASS,
-          "data-[state=closed]:pointer-events-none",
+          "data-[state=closed]:pointer-events-none data-[state=full]:pointer-events-none",
         )}
         onClick={onClose}
       />
@@ -81,10 +88,12 @@ export function CompactSecondaryPanelShelf({
         inert={!open}
         data-secondary-panel-shelf=""
         data-testid="secondary-panel-shelf"
-        data-state={open ? "open" : "closed"}
+        data-state={state}
         className={cn(
-          "fixed inset-y-0 right-0 z-0 flex h-(--bb-shell-height) w-(--secondary-panel-width-mobile) select-none flex-col overflow-hidden border-l border-border-seam bg-background outline-none",
-          "[transition:visibility_0s_linear_0s] data-[state=closed]:invisible data-[state=closed]:[transition:visibility_0s_linear_220ms]",
+          "fixed inset-y-0 right-0 z-0 flex h-(--bb-shell-height) select-none flex-col overflow-hidden border-l border-border-seam bg-background outline-none",
+          "w-(--secondary-panel-width-mobile) data-[state=full]:w-full data-[state=full]:border-l-0",
+          SHELF_TRANSITION_CLASS,
+          "data-[state=closed]:invisible data-[state=closed]:[transition:visibility_0s_linear_220ms]",
         )}
       >
         {srLabel === undefined ? null : (

--- a/apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.tsx
+++ b/apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.tsx
@@ -92,6 +92,7 @@ export function CompactSecondaryPanelShelf({
         className={cn(
           "fixed inset-y-0 right-0 z-0 flex h-(--bb-shell-height) select-none flex-col overflow-hidden border-l border-border-seam bg-background outline-none",
           "w-(--secondary-panel-width-mobile) data-[state=full]:w-full data-[state=full]:border-l-0",
+          "data-[state=full]:z-60",
           SHELF_TRANSITION_CLASS,
           "data-[state=closed]:invisible data-[state=closed]:[transition:visibility_0s_linear_220ms]",
         )}

--- a/apps/app/src/components/secondary-panel/SecondaryPanelLayout.test.tsx
+++ b/apps/app/src/components/secondary-panel/SecondaryPanelLayout.test.tsx
@@ -5,6 +5,7 @@ import { act, cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CompactViewportOverrideProvider } from "@bb/shared-ui/hooks/use-compact-viewport";
 import { dispatchBrowserViewBoundsSync } from "@/lib/browser-view-bounds-sync";
+import { setCompactSidebarDrawerShowing } from "@/components/ui/sidebar-mobile-drawer-visibility";
 import {
   PaneContext,
   type PaneContextValue,
@@ -103,6 +104,7 @@ interface RenderLayoutArgs {
   collapseActive?: boolean;
   compactPresentation?: "shelf" | "full";
   isCompactViewport: boolean;
+  onClose?: () => void;
   isFocusedHosted?: boolean;
   open: boolean;
   panelGroupKey?: string;
@@ -155,7 +157,7 @@ function renderLayout(args: RenderLayoutArgs) {
         <SecondaryPanelLayout
           open={renderArgs.open}
           onToggle={noop}
-          onClose={noop}
+          onClose={renderArgs.onClose ?? noop}
           panelGroupKey={renderArgs.panelGroupKey}
           resetKey={renderArgs.resetKey}
           contentKey={renderArgs.resetKey}
@@ -668,5 +670,57 @@ describe("SecondaryPanelLayout", () => {
 
     expect(unmountFrames.cancelAnimationFrame).toHaveBeenCalledWith(3);
     expect(dispatchBrowserViewBoundsSync).not.toHaveBeenCalled();
+  });
+});
+
+describe("compact sidebar and right panel", () => {
+  it("closes the right panel when the sidebar drawer opens so only one shelf is engaged", () => {
+    const onClose = vi.fn();
+    renderLayout({
+      isCompactViewport: true,
+      onClose,
+      open: true,
+      renderPanel: createPanelRenderer(),
+      resetKey: "thread-1",
+    });
+
+    expect(onClose).not.toHaveBeenCalled();
+
+    act(() => setCompactSidebarDrawerShowing(true));
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    act(() => setCompactSidebarDrawerShowing(false));
+  });
+
+  it("leaves a closed right panel alone when the sidebar drawer opens", () => {
+    const onClose = vi.fn();
+    renderLayout({
+      isCompactViewport: true,
+      onClose,
+      open: false,
+      renderPanel: createPanelRenderer(),
+      resetKey: "thread-1",
+    });
+
+    act(() => setCompactSidebarDrawerShowing(true));
+    expect(onClose).not.toHaveBeenCalled();
+
+    act(() => setCompactSidebarDrawerShowing(false));
+  });
+
+  it("keeps the desktop panel open when the sidebar drawer flag flips", () => {
+    const onClose = vi.fn();
+    renderLayout({
+      isCompactViewport: false,
+      onClose,
+      open: true,
+      renderPanel: createPanelRenderer(),
+      resetKey: "thread-1",
+    });
+
+    act(() => setCompactSidebarDrawerShowing(true));
+    expect(onClose).not.toHaveBeenCalled();
+
+    act(() => setCompactSidebarDrawerShowing(false));
   });
 });

--- a/apps/app/src/components/secondary-panel/SecondaryPanelLayout.test.tsx
+++ b/apps/app/src/components/secondary-panel/SecondaryPanelLayout.test.tsx
@@ -101,6 +101,7 @@ interface QueuedAnimationFrames {
 
 interface RenderLayoutArgs {
   collapseActive?: boolean;
+  compactPresentation?: "shelf" | "full";
   isCompactViewport: boolean;
   isFocusedHosted?: boolean;
   open: boolean;
@@ -169,6 +170,7 @@ function renderLayout(args: RenderLayoutArgs) {
           }
           renderPanel={renderArgs.renderPanel}
           composerHost={null}
+          compactPresentation={renderArgs.compactPresentation ?? "shelf"}
         />
       </CompactViewportOverrideProvider>,
       renderArgs.isFocusedHosted,

--- a/apps/app/src/components/secondary-panel/SecondaryPanelLayout.tsx
+++ b/apps/app/src/components/secondary-panel/SecondaryPanelLayout.tsx
@@ -5,6 +5,7 @@ import {
   useMemo,
   useRef,
   useState,
+  useSyncExternalStore,
   type Key,
   type ReactNode,
 } from "react";
@@ -31,6 +32,10 @@ import {
   usePanelCollapseTransitionsReady,
 } from "./panelTransitionTokens";
 import { secondaryPanelWidthPercentAtom } from "./threadSecondaryPanelAtoms";
+import {
+  isCompactSidebarDrawerShowing,
+  subscribeCompactSidebarDrawerShowing,
+} from "@/components/ui/sidebar-mobile-drawer-visibility";
 
 const FULL_PANEL_SIZE_PERCENT = 100;
 const MAIN_PANEL_MIN_SIZE_PERCENT = 30;
@@ -88,6 +93,15 @@ export function SecondaryPanelLayout({
   const paneContext = useOptionalPaneContext();
   const secondaryPanelHost = paneContext?.secondaryPanelHost ?? null;
   const renderAsDrawer = useIsCompactViewport();
+  const sidebarDrawerShowing = useSyncExternalStore(
+    subscribeCompactSidebarDrawerShowing,
+    isCompactSidebarDrawerShowing,
+    () => false,
+  );
+  useEffect(() => {
+    if (!renderAsDrawer || !open || !sidebarDrawerShowing) return;
+    onClose();
+  }, [onClose, open, renderAsDrawer, sidebarDrawerShowing]);
   const transitionsReady = usePanelCollapseTransitionsReady(
     resetKey,
     !renderAsDrawer,

--- a/apps/app/src/components/secondary-panel/SecondaryPanelLayout.tsx
+++ b/apps/app/src/components/secondary-panel/SecondaryPanelLayout.tsx
@@ -64,6 +64,7 @@ interface SecondaryPanelLayoutProps {
   renderPanel: (args: SecondaryPanelRenderArgs) => ReactNode;
   renderHostedPanel?: (panel: ReactNode) => ReactNode;
   composerHost: PluginComposerHost | null;
+  compactPresentation: "shelf" | "full";
 }
 
 export function SecondaryPanelLayout({
@@ -82,6 +83,7 @@ export function SecondaryPanelLayout({
   renderPanel,
   renderHostedPanel,
   composerHost,
+  compactPresentation,
 }: SecondaryPanelLayoutProps) {
   const paneContext = useOptionalPaneContext();
   const secondaryPanelHost = paneContext?.secondaryPanelHost ?? null;
@@ -346,6 +348,7 @@ export function SecondaryPanelLayout({
         <CompactSecondaryPanelShelf
           open={open}
           onClose={onClose}
+          presentation={compactPresentation}
           srLabel={drawerLabel}
           onContentAnimationEnd={handleDrawerContentAnimationEnd}
         >

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.stories.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.stories.tsx
@@ -14,6 +14,7 @@ import {
 import type { ThreadSecondaryPanel as ThreadSecondaryPanelTab } from "@/lib/thread-secondary-panel";
 import { Icon } from "@bb/shared-ui/icon";
 import { TooltipProvider } from "@bb/shared-ui/tooltip";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { SidebarProvider } from "@/components/ui/sidebar";
 import {
   createGitDiffFixedPanelTab,
@@ -42,6 +43,8 @@ import {
 } from "./ThreadMetadataContent.fixtures";
 import { resolveRightPanelFileVisual } from "./rightPanelFileVisuals";
 import { useThreadStorageBrowser } from "./useThreadStorageBrowser";
+import { FilePreview } from "./FilePreview";
+import { threadListQueryKey } from "@/hooks/queries/query-keys";
 
 export default {
   title: "right-panel/Tabbed shell",
@@ -229,8 +232,27 @@ function RepresentativeInfoContent() {
     },
     onCommitClick: noop,
   };
+  const [queryClient] = useState(() => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+    client.setQueryData(
+      threadListQueryKey({
+        projectId: props.thread.projectId,
+        sourceThreadId: props.thread.id,
+        originKind: "fork",
+        archived: false,
+      }),
+      [],
+    );
+    return client;
+  });
 
-  return <ThreadMetadataContent {...props} />;
+  return (
+    <QueryClientProvider client={queryClient}>
+      <ThreadMetadataContent {...props} />
+    </QueryClientProvider>
+  );
 }
 
 interface ShellArgs {
@@ -274,14 +296,27 @@ function ShellRow({
   );
 }
 
-const representativeFileContent = (
-  <div className="space-y-3 px-4 py-3 font-mono text-xs text-foreground">
-    <p className="text-muted-foreground">ThreadSecondaryPanel.tsx</p>
-    <pre className="whitespace-pre-wrap">{`export function ThreadSecondaryPanel() {
+const REPRESENTATIVE_FILE_SOURCE = `export function ThreadSecondaryPanel() {
   return <Panel className="bg-sidebar">…</Panel>;
-}`}</pre>
-  </div>
-);
+}`;
+
+function RepresentativeFileContent({ path }: { path: string }) {
+  return (
+    <FilePreview
+      path={path}
+      state={{
+        kind: "ready",
+        lineRange: null,
+        textPreviewKind: null,
+        file: {
+          cacheKey: `thread-secondary-panel-story:${path}`,
+          name: path.split("/").at(-1) ?? path,
+          contents: REPRESENTATIVE_FILE_SOURCE,
+        },
+      }}
+    />
+  );
+}
 
 interface TerminalTabFixture {
   terminalId: string;
@@ -384,7 +419,7 @@ function FileTabsShellInner({
           statusLabel: null,
           onSelect: () => setActiveFilename(filename),
           onClose: () => handleCloseFile(filename),
-          renderContent: () => representativeFileContent,
+          renderContent: () => <RepresentativeFileContent path={filename} />,
           tab,
         };
       }),
@@ -599,7 +634,7 @@ function ProductionSplitPanesStory() {
           tab.kind === "terminal" ? (
             <RepresentativeTerminalContent title="pnpm dev" />
           ) : (
-            representativeFileContent
+            <RepresentativeFileContent path="ThreadSecondaryPanel.tsx" />
           ),
         tab,
       })),

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.stories.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.stories.tsx
@@ -652,12 +652,12 @@ export function SplitPanes() {
   );
 }
 
-export function CompactShelfTabs() {
+export function PhoneWidthTabs() {
   return (
     <StoryCard>
       <StoryRow
-        label="compact shelf — many tabs"
-        hint="phone-width shelf (299px, the --secondary-panel-width-mobile value at 393px); the tab row scrolls horizontally while Info and Diff stay fixed"
+        label="phone-width panel — many tabs"
+        hint="the panel body at 299px, the --secondary-panel-width-mobile value at a 393px viewport. Shelf and full-page geometry live in right-panel/Compact shelf; this row isolates the tab strip, which scrolls horizontally while Info and Diff stay fixed"
       >
         <FileTabsShellRow
           filenames={MANY_TAB_FILENAMES}
@@ -667,7 +667,7 @@ export function CompactShelfTabs() {
         />
       </StoryRow>
       <StoryRow
-        label="compact shelf — active tab far down the row"
+        label="phone-width panel — active tab far down the row"
         hint="the strip should scroll the selected tab into view rather than leaving it offscreen"
       >
         <FileTabsShellRow
@@ -678,7 +678,7 @@ export function CompactShelfTabs() {
         />
       </StoryRow>
       <StoryRow
-        label="compact shelf — pinned first tab"
+        label="phone-width panel — pinned first tab"
         hint="pinned tab keeps its slot with no close affordance while the rest scroll past it"
       >
         <FileTabsShellRow
@@ -690,7 +690,7 @@ export function CompactShelfTabs() {
         />
       </StoryRow>
       <StoryRow
-        label="compact shelf — no file tab selected"
+        label="phone-width panel — no file tab selected"
         hint="Info stays active while the file tabs sit alongside as inactive pills"
       >
         <FileTabsShellRow

--- a/apps/app/src/components/secondary-panel/panelToggleControlState.test.ts
+++ b/apps/app/src/components/secondary-panel/panelToggleControlState.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import { resolveConversationCollapseControl } from "./panelToggleControlState";
+import {
+  getCompactPanelPresentation,
+  resolveConversationCollapseControl,
+} from "./panelToggleControlState";
 
 describe("resolveConversationCollapseControl", () => {
   it("collapses the conversation when it is shown", () => {
@@ -32,5 +35,29 @@ describe("resolveConversationCollapseControl", () => {
 
     state.onClick();
     expect(onToggleConversationCollapse).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("getCompactPanelPresentation", () => {
+  it("keeps thread info in the shelf so the thread stays visible beside it", () => {
+    expect(getCompactPanelPresentation("thread-info")).toBe("shelf");
+  });
+
+  it("falls back to the shelf when no tab is active yet", () => {
+    expect(getCompactPanelPresentation(undefined)).toBe("shelf");
+  });
+
+  it.each([
+    "git-diff",
+    "terminal",
+    "host-file-preview",
+    "workspace-file-preview",
+    "thread-storage-file-preview",
+    "browser",
+    "new-tab",
+    "plugin-page-fixed",
+    "plugin-panel",
+  ])("gives %s the full page, where its content is usable", (kind) => {
+    expect(getCompactPanelPresentation(kind)).toBe("full");
   });
 });

--- a/apps/app/src/components/secondary-panel/panelToggleControlState.ts
+++ b/apps/app/src/components/secondary-panel/panelToggleControlState.ts
@@ -49,3 +49,11 @@ export function resolveConversationCollapseControl({
 }
 
 export const RIGHT_PANEL_TOGGLE_ICON_NAME = "PanelRight";
+
+export function getCompactPanelPresentation(
+  activeTabKind: string | undefined,
+): "shelf" | "full" {
+  return activeTabKind === undefined || activeTabKind === "thread-info"
+    ? "shelf"
+    : "full";
+}

--- a/apps/app/src/components/ui/secondary-panel-shelf-visibility.ts
+++ b/apps/app/src/components/ui/secondary-panel-shelf-visibility.ts
@@ -1,15 +1,24 @@
-let compactSecondaryPanelShelfShowing = false;
+export type CompactSecondaryPanelPresentation = "closed" | "shelf" | "full";
+
+let compactSecondaryPanelPresentation: CompactSecondaryPanelPresentation =
+  "closed";
 const listeners = new Set<() => void>();
 
-export function isCompactSecondaryPanelShelfShowing(): boolean {
-  return compactSecondaryPanelShelfShowing;
+export function getCompactSecondaryPanelPresentation(): CompactSecondaryPanelPresentation {
+  return compactSecondaryPanelPresentation;
 }
 
-export function setCompactSecondaryPanelShelfShowing(showing: boolean): void {
-  if (compactSecondaryPanelShelfShowing === showing) {
+export function isCompactSecondaryPanelShelfShowing(): boolean {
+  return compactSecondaryPanelPresentation !== "closed";
+}
+
+export function setCompactSecondaryPanelPresentation(
+  presentation: CompactSecondaryPanelPresentation,
+): void {
+  if (compactSecondaryPanelPresentation === presentation) {
     return;
   }
-  compactSecondaryPanelShelfShowing = showing;
+  compactSecondaryPanelPresentation = presentation;
   for (const listener of listeners) {
     listener();
   }

--- a/apps/app/src/components/ui/sidebar.test.tsx
+++ b/apps/app/src/components/ui/sidebar.test.tsx
@@ -422,9 +422,9 @@ describe("mobile sidebar shelf stacking", () => {
     }
 
     expect(inset.className).toContain("data-[sidebar-shelf=open]:rounded-l-xl");
-    expect(inset.className).toContain("data-[panel-shelf=open]:rounded-r-xl");
+    expect(inset.className).toContain("data-[panel-shelf=shelf]:rounded-r-xl");
     expect(inset.className).toContain("data-[sidebar-shelf=open]:shadow-xl");
-    expect(inset.className).toContain("data-[panel-shelf=open]:shadow-xl");
+    expect(inset.className).toContain("data-[panel-shelf=shelf]:shadow-xl");
     expect(inset.className).not.toContain("shadow-2xl");
   });
 

--- a/apps/app/src/components/ui/sidebar.tsx
+++ b/apps/app/src/components/ui/sidebar.tsx
@@ -16,7 +16,7 @@ import {
 } from "@bb/shared-ui/tooltip";
 import { setCompactSidebarDrawerShowing } from "./sidebar-mobile-drawer-visibility.js";
 import {
-  isCompactSecondaryPanelShelfShowing,
+  getCompactSecondaryPanelPresentation,
   subscribeCompactSecondaryPanelShelfShowing,
 } from "./secondary-panel-shelf-visibility.js";
 
@@ -1891,10 +1891,10 @@ const SidebarInset = React.forwardRef<
     }
   }, [clearSwipeSession, isCompactViewport, openMobile]);
 
-  const secondaryPanelShelfShowing = React.useSyncExternalStore(
+  const secondaryPanelPresentation = React.useSyncExternalStore(
     subscribeCompactSecondaryPanelShelfShowing,
-    isCompactSecondaryPanelShelfShowing,
-    () => false,
+    getCompactSecondaryPanelPresentation,
+    () => "closed" as const,
   );
   const shelfState = isCompactViewport
     ? openMobile
@@ -1903,9 +1903,7 @@ const SidebarInset = React.forwardRef<
     : undefined;
   const panelShelfState =
     isCompactViewport && !openMobile
-      ? secondaryPanelShelfShowing
-        ? "open"
-        : "closed"
+      ? secondaryPanelPresentation
       : undefined;
 
   return (
@@ -1923,7 +1921,8 @@ const SidebarInset = React.forwardRef<
         "relative flex h-full min-h-0 min-w-0 flex-1 flex-col bg-background max-md:z-30",
         SIDEBAR_MOBILE_SHELF_INSET_TRANSITION_CLASS,
         "data-[sidebar-shelf=open]:translate-x-(--sidebar-width-mobile) data-[sidebar-shelf=open]:rounded-l-xl data-[sidebar-shelf=open]:shadow-xl data-[sidebar-shelf]:will-change-[translate]",
-        "data-[panel-shelf=open]:-translate-x-(--secondary-panel-width-mobile) data-[panel-shelf=open]:rounded-r-xl data-[panel-shelf=open]:shadow-xl data-[panel-shelf]:will-change-[translate]",
+        "data-[panel-shelf=shelf]:-translate-x-(--secondary-panel-width-mobile) data-[panel-shelf=shelf]:rounded-r-xl data-[panel-shelf=shelf]:shadow-xl data-[panel-shelf]:will-change-[translate]",
+        "data-[panel-shelf=full]:-translate-x-full",
         "md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow",
         className,
       )}

--- a/apps/app/src/views/RootComposeSecondaryContent.tsx
+++ b/apps/app/src/views/RootComposeSecondaryContent.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/lib/bb-desktop";
 import { RootComposeCompactHome } from "./RootComposeCompactHome";
 import { useOptionalPaneContext } from "./thread-detail/PaneContext";
+import { getCompactPanelPresentation } from "@/components/secondary-panel/panelToggleControlState";
 
 const ROOT_COMPOSE_MAX_WIDTH_CLASS = "max-w-[760px]";
 
@@ -149,6 +150,9 @@ export function RootComposeSecondaryContent({
         mainPanelId="root-compose-main-panel"
         main={mainContent}
         composerHost={composerHost}
+        compactPresentation={getCompactPanelPresentation(
+          threadSecondaryPanelProps.activeTab?.kind,
+        )}
         renderPanel={({
           presentation,
           canShowNativeBrowserView,

--- a/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.tsx
@@ -16,6 +16,7 @@ import {
 import { DETAIL_GRID_CLASS } from "@/components/ui/detail-card.js";
 import { useThreads } from "@/hooks/queries/thread-queries";
 import { ThreadTimelinePane } from "./ThreadTimelinePane";
+import { getCompactPanelPresentation } from "@/components/secondary-panel/panelToggleControlState";
 
 type ThreadTimelinePaneProps = Omit<
   ComponentProps<typeof ThreadTimelinePane>,
@@ -130,6 +131,9 @@ function ThreadDetailSecondaryContentBody({
           onToggle: onToggleConversationCollapse,
         }}
         composerHost={composerHost}
+        compactPresentation={getCompactPanelPresentation(
+          threadSecondaryPanelProps.activeTab?.kind,
+        )}
         renderHostedPanel={renderHostedPanel}
         renderPanel={({
           presentation,


### PR DESCRIPTION
## Human comments

## Stack outcome relative to `main`

The compact right panel no longer rises as a dimmed 92dvh bottom drawer. The stack replaces it with a right-side system: Info uses a compact shelf that translates the live page left, while every tool tab—including New Tab—expands from the right to a full-width surface. New Tab also selects and renders its own production content instead of leaving the prior Info content visible.

Layer 1 also contains the compact-home/recents redesign, sticky `Recent` header, left-sidebar shelf, route-progress feedback, cold-navigation placeholders, provider-health caching, and immutable provider-logo caching. This PR is the focused second layer that adds full-page non-Info tabs and fixes the New Tab selection/content transition.

## What was wrong in this layer

Layer 1 moved the right panel from the bottom drawer to a right shelf, but all tabs were still constrained to the shelf's 298.67px width. Selecting New Tab could change the tab strip without changing the rendered Info content, leaving file search and other tool surfaces without a usable phone-width canvas.

## What changed

- Info remains a 298.67px right shelf so the underlying page stays visible.
- Every non-Info tab transitions to a 393px full-page surface above fixed app chrome.
- New Tab now selects and renders the production New Tab actions after its loading skeleton settles.
- Opening the left sidebar closes the right panel so the two compact shelves cannot compete for the page.
- Compact shelf stories mount the real `CompactSecondaryPanelShelf`, `ThreadSecondaryPanel`, `FilePreview`, `RootComposeCompactHome`, `SidebarProvider`, and `SidebarInset` composition; no substitute file markup or generic product wrapper remains.

No wire changes; `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

## Screenshots

Chrome for Testing 151.0.7922.71, 393×852 at DPR 2, using the same dev database, route, viewport, interaction, and settled-content state.

### Cumulative behavior versus `main`

Before is the stack merge base (`f4bbc2fe8`); after is this PR head (`6d031d265`).

| `main` — New Tab in a dimmed bottom drawer | Layer 2 — New Tab as a full-page surface from the right |
| --- | --- |
| <img src="https://gist.githubusercontent.com/brsbl/d8363c420a5e5c2167498079a27162f0/raw/65315ab6945f2cdb42a0508475d7c41acc07c1ff/main-right-panel.svg" width="393"> | <img src="https://gist.githubusercontent.com/brsbl/d8363c420a5e5c2167498079a27162f0/raw/dea1e142f62d31f0ccf871472f0ea54e4645a354/layer2-after.svg" width="393"> |

### This layer's New Tab fix

Before is the final parent head (`04d18307f`); after is this PR head (`6d031d265`).

| Parent — New Tab remains in the 298.67px shelf and Info content remains visible | This layer — New Tab expands to 393px and renders its production actions |
| --- | --- |
| <img src="https://gist.githubusercontent.com/brsbl/d8363c420a5e5c2167498079a27162f0/raw/f1d0adb52480b8b100f50cb97fa929ec2cb93670/layer2-before.svg" width="393"> | <img src="https://gist.githubusercontent.com/brsbl/d8363c420a5e5c2167498079a27162f0/raw/dea1e142f62d31f0ccf871472f0ea54e4645a354/layer2-after.svg" width="393"> |

## How you verified

- On the exact merge base, the settled production New Tab dialog measured `top=68.17`, `width=393`, `height=783.83` with an 80% black backdrop—the old bottom-drawer presentation.
- On the exact PR head, the same production flow measured parent `state=open`, `width=298.671875`; head `state=full`, `width=393`, with `new-tab-actions` present after the content skeleton cleared.
- Ladle was restarted on port 61002 and the compact shelf stories were exercised at 393×852: closed returns the page to `left=0`; shelf translates the production page by `-298.68px`; Full page fills 393px; Many tabs selects `sidebar.tsx` and renders real `FilePreview` controls.
- Every affected story ID loaded through its production component subtree with zero runtime exceptions. All remote CI gates pass; no local CI-equivalent command was run.

BB-Thread-ID: thr_wftu7bh9ez

> AGENT GENERATED
