### PR TITLE
Fix OAuth popups in the desktop browser

### DIFF
--- a/apps/desktop/src/desktop-browser-view.ts
+++ b/apps/desktop/src/desktop-browser-view.ts
@@ -1,4 +1,13 @@
-import { Menu, WebContentsView, session, type Session } from "electron";
+import {
+  BrowserWindow,
+  Menu,
+  WebContentsView,
+  session,
+  type BrowserWindowConstructorOptions,
+  type Session,
+  type WebContents,
+  type WebPreferences,
+} from "electron";
 import {
   BB_DESKTOP_BROWSER_MAX_TITLE_LENGTH,
   BB_DESKTOP_BROWSER_MAX_URL_LENGTH,
@@ -242,6 +251,7 @@ export function createDesktopBrowserViewManager(
   const partition = args.partition ?? BB_BROWSER_PARTITION;
   const entries = new Map<string, BrowserViewEntry>();
   const entriesByWebContentsId = new Map<number, BrowserViewEntry>();
+  const popupWindows = new Set<BrowserWindow>();
   const resizingHostIds = new Set<number>();
   let hardenedSession: Session | null = null;
 
@@ -374,6 +384,59 @@ export function createDesktopBrowserViewManager(
     );
   }
 
+  function hardenedPopupWebPreferences(
+    webPreferences: WebPreferences | undefined,
+  ): WebPreferences {
+    const inheritedPreferences = { ...webPreferences };
+    delete inheritedPreferences.preload;
+    return {
+      ...inheritedPreferences,
+      allowRunningInsecureContent: false,
+      contextIsolation: true,
+      nodeIntegration: false,
+      nodeIntegrationInSubFrames: false,
+      nodeIntegrationInWorker: false,
+      partition,
+      sandbox: true,
+      webSecurity: true,
+      webviewTag: false,
+    };
+  }
+
+  function createHardenedPopupWindow(
+    options: BrowserWindowConstructorOptions,
+  ): WebContents {
+    options.show = true;
+    options.webPreferences = hardenedPopupWebPreferences(
+      options.webPreferences,
+    );
+    const popupWindow = new BrowserWindow(options);
+    popupWindows.add(popupWindow);
+    popupWindow.once("closed", () => {
+      popupWindows.delete(popupWindow);
+    });
+    const popupContents = popupWindow.webContents;
+    const isAllowedPopupNavigationUrl = (url: string): boolean =>
+      url === "about:blank" || isAllowedBrowserUrl(url);
+    popupContents.on("will-frame-navigate", (event) => {
+      if (event.isMainFrame && !isAllowedPopupNavigationUrl(event.url)) {
+        event.preventDefault();
+      }
+    });
+    popupContents.on("will-navigate", (event, url) => {
+      if (!isAllowedPopupNavigationUrl(url)) {
+        event.preventDefault();
+      }
+    });
+    popupContents.on("will-redirect", (event, url, _isInPlace, isMainFrame) => {
+      if (isMainFrame && !isAllowedPopupNavigationUrl(url)) {
+        event.preventDefault();
+      }
+    });
+    popupContents.setWindowOpenHandler(() => ({ action: "deny" }));
+    return popupContents;
+  }
+
   function wireWebContents(
     hostWindow: DesktopBrowserHostWindow,
     tabId: string,
@@ -436,24 +499,39 @@ export function createDesktopBrowserViewManager(
 
     webContents.setWindowOpenHandler((details) => {
       const { openTabUrl } = resolveWindowOpenAction(details.url);
-      if (openTabUrl !== null) {
-        const decision = evaluatePopupRate({
-          timestamps: entry.popupTimestamps,
-          now: Date.now(),
-          windowMs: POPUP_RATE_WINDOW_MS,
-          maxInWindow: POPUP_RATE_MAX_IN_WINDOW,
-        });
-        entry.popupTimestamps = decision.timestamps;
-        if (decision.allowed) {
-          send(hostWindow, BB_DESKTOP_BROWSER_OPEN_TAB_CHANNEL, {
-            url: openTabUrl,
-          });
-          send(hostWindow, BB_DESKTOP_BROWSER_SCOPED_OPEN_TAB_CHANNEL, {
-            tabId,
-            url: openTabUrl,
-          });
-        }
+      if (openTabUrl === null) {
+        return { action: "deny" };
       }
+      const decision = evaluatePopupRate({
+        timestamps: entry.popupTimestamps,
+        now: Date.now(),
+        windowMs: POPUP_RATE_WINDOW_MS,
+        maxInWindow: POPUP_RATE_MAX_IN_WINDOW,
+      });
+      entry.popupTimestamps = decision.timestamps;
+      if (!decision.allowed) {
+        return { action: "deny" };
+      }
+      const opensNamedPopup =
+        details.features.length > 0 ||
+        (details.frameName.length > 0 && details.frameName !== "_blank");
+      if (opensNamedPopup) {
+        return {
+          action: "allow",
+          createWindow: createHardenedPopupWindow,
+          overrideBrowserWindowOptions: {
+            show: true,
+            webPreferences: hardenedPopupWebPreferences(undefined),
+          },
+        };
+      }
+      send(hostWindow, BB_DESKTOP_BROWSER_OPEN_TAB_CHANNEL, {
+        url: openTabUrl,
+      });
+      send(hostWindow, BB_DESKTOP_BROWSER_SCOPED_OPEN_TAB_CHANNEL, {
+        tabId,
+        url: openTabUrl,
+      });
       return { action: "deny" };
     });
 
@@ -834,6 +912,12 @@ export function createDesktopBrowserViewManager(
     },
     destroyAll() {
       resizingHostIds.clear();
+      for (const popupWindow of [...popupWindows]) {
+        if (!popupWindow.isDestroyed()) {
+          popupWindow.close();
+        }
+      }
+      popupWindows.clear();
       for (const [key, entry] of [...entries.entries()]) {
         entries.delete(key);
         entriesByWebContentsId.delete(entry.view.webContents.id);

--- a/apps/desktop/test/desktop-browser-view-manager.test.ts
+++ b/apps/desktop/test/desktop-browser-view-manager.test.ts
@@ -173,11 +173,38 @@ type FakePermissionCheckHandler = (
 ) => boolean;
 
 interface FakeWindowOpenDetails {
+  features: string;
+  frameName: string;
   url: string;
 }
 
+interface FakeBrowserWindowOptions {
+  show?: boolean;
+  webPreferences?: {
+    allowRunningInsecureContent?: boolean;
+    contextIsolation?: boolean;
+    nodeIntegration?: boolean;
+    nodeIntegrationInSubFrames?: boolean;
+    nodeIntegrationInWorker?: boolean;
+    partition?: string;
+    preload?: string;
+    sandbox?: boolean;
+    webSecurity?: boolean;
+    webviewTag?: boolean;
+  };
+}
+
+interface FakePopupWebContents {
+  emitWindowOpen(
+    url: string,
+    details?: Partial<Omit<FakeWindowOpenDetails, "url">>,
+  ): FakeWindowOpenDecision;
+}
+
 interface FakeWindowOpenDecision {
-  action: "deny";
+  action: "allow" | "deny";
+  createWindow?: (options: FakeBrowserWindowOptions) => FakePopupWebContents;
+  overrideBrowserWindowOptions?: FakeBrowserWindowOptions;
 }
 
 type FakeWindowOpenHandler = (
@@ -471,11 +498,19 @@ const electronMock = vi.hoisted(() => {
       return event.defaultPrevented;
     }
 
-    emitWindowOpen(url: string): FakeWindowOpenDecision {
+    emitWindowOpen(
+      url: string,
+      details: Partial<Omit<FakeWindowOpenDetails, "url">> = {},
+    ): FakeWindowOpenDecision {
       if (this.windowOpenHandler === null) {
         throw new Error("Expected a window open handler to be registered.");
       }
-      return this.windowOpenHandler({ url });
+      return this.windowOpenHandler({
+        features: "",
+        frameName: "",
+        ...details,
+        url,
+      });
     }
   }
 
@@ -500,6 +535,19 @@ const electronMock = vi.hoisted(() => {
     }
   }
 
+  class FakeBrowserWindow {
+    public readonly options: FakeBrowserWindowOptions;
+    public readonly webContents: FakeWebContents;
+
+    constructor(options: FakeBrowserWindowOptions) {
+      this.options = options;
+      this.webContents = new FakeWebContents(nextWebContentsId);
+      nextWebContentsId += 1;
+    }
+
+    once(_eventName: "closed", _listener: () => void): void {}
+  }
+
   class FakeSession {
     public readonly willDownloadListeners: FakeSessionListener[] = [];
     public permissionCheckHandler: FakePermissionCheckHandler | null = null;
@@ -519,11 +567,19 @@ const electronMock = vi.hoisted(() => {
 
   const fakeSessions: FakeSession[] = [];
   const fakeViews: FakeWebContentsView[] = [];
+  const fakeWindows: FakeBrowserWindow[] = [];
 
   return {
     fakeCapturedImage,
     fakeSessions,
     fakeViews,
+    fakeWindows,
+    FakeBrowserWindow: class extends FakeBrowserWindow {
+      constructor(options: FakeBrowserWindowOptions) {
+        super(options);
+        fakeWindows.push(this);
+      }
+    },
     FakeWebContentsView: class extends FakeWebContentsView {
       constructor() {
         super();
@@ -541,6 +597,7 @@ const electronMock = vi.hoisted(() => {
 });
 
 vi.mock("electron", () => ({
+  BrowserWindow: electronMock.FakeBrowserWindow,
   WebContentsView: electronMock.FakeWebContentsView,
   session: electronMock.session,
 }));
@@ -607,6 +664,7 @@ beforeEach(() => {
   vi.useRealTimers();
   electronMock.fakeSessions.length = 0;
   electronMock.fakeViews.length = 0;
+  electronMock.fakeWindows.length = 0;
 });
 
 async function settlePendingCaptures(
@@ -934,7 +992,11 @@ describe("DesktopBrowserViewManager", () => {
     });
     const view = requireFakeView(0);
 
-    expect(view.webContents.emitWindowOpen("http://localhost:38886/")).toEqual({
+    expect(
+      view.webContents.emitWindowOpen("http://localhost:38886/", {
+        frameName: "_blank",
+      }),
+    ).toEqual({
       action: "deny",
     });
     expect(openTabPushesOf(hostWindow)).toEqual(["http://localhost:38886/"]);
@@ -960,11 +1022,13 @@ describe("DesktopBrowserViewManager", () => {
     });
     const view = requireFakeView(0);
 
-    expect(view.webContents.emitWindowOpen("https://example.com/docs")).toEqual(
-      {
-        action: "deny",
-      },
-    );
+    expect(
+      view.webContents.emitWindowOpen("https://example.com/docs", {
+        frameName: "_blank",
+      }),
+    ).toEqual({
+      action: "deny",
+    });
     expect(openTabPushesOf(hostWindow)).toEqual(["https://example.com/docs"]);
     expect(scopedOpenTabPushesOf(hostWindow)).toEqual([
       {
@@ -972,6 +1036,88 @@ describe("DesktopBrowserViewManager", () => {
         url: "https://example.com/docs",
       },
     ]);
+  });
+
+  it("opens named popup flows in a hardened native window", () => {
+    const manager = createDesktopBrowserViewManager({
+      partition: "persist:test",
+    });
+    const hostWindow = new FakeHostWindow({
+      contentBounds: { width: 700, height: 450 },
+      webContentsId: 62,
+    });
+
+    attachBrowserTab({
+      manager,
+      hostWindow,
+      tabId: "browser:a",
+      url: "https://www.notion.so/",
+    });
+    const view = requireFakeView(0);
+    const decision = view.webContents.emitWindowOpen(
+      "https://accounts.google.com/o/oauth2/auth",
+      {
+        features: "width=520,height=700",
+        frameName: "oauth",
+      },
+    );
+
+    expect(decision.action).toBe("allow");
+    expect(openTabPushesOf(hostWindow)).toEqual([]);
+    expect(scopedOpenTabPushesOf(hostWindow)).toEqual([]);
+    expect(decision.overrideBrowserWindowOptions).toEqual({
+      show: true,
+      webPreferences: {
+        allowRunningInsecureContent: false,
+        contextIsolation: true,
+        nodeIntegration: false,
+        nodeIntegrationInSubFrames: false,
+        nodeIntegrationInWorker: false,
+        partition: "persist:test",
+        sandbox: true,
+        webSecurity: true,
+        webviewTag: false,
+      },
+    });
+    if (decision.createWindow === undefined) {
+      throw new Error("Expected the popup decision to create a window.");
+    }
+
+    const options: FakeBrowserWindowOptions = {
+      show: false,
+      webPreferences: {
+        allowRunningInsecureContent: true,
+        contextIsolation: false,
+        nodeIntegration: true,
+        partition: "persist:untrusted",
+        preload: "/tmp/untrusted-preload.cjs",
+        sandbox: false,
+        webSecurity: false,
+      },
+    };
+    const popupContents = decision.createWindow(options);
+    const popupWindow = electronMock.fakeWindows[0];
+    expect(popupWindow).toBeDefined();
+    if (popupWindow === undefined) {
+      throw new Error("Expected a popup window to be created.");
+    }
+
+    expect(popupWindow.options).toBe(options);
+    expect(options.show).toBe(true);
+    expect(options.webPreferences).toEqual({
+      allowRunningInsecureContent: false,
+      contextIsolation: true,
+      nodeIntegration: false,
+      nodeIntegrationInSubFrames: false,
+      nodeIntegrationInWorker: false,
+      partition: "persist:test",
+      sandbox: true,
+      webSecurity: true,
+      webviewTag: false,
+    });
+    expect(popupContents.emitWindowOpen("https://example.com/nested")).toEqual({
+      action: "deny",
+    });
   });
 
   it("snapshots then hides visible views on resize, revealing them clamped to the shrunken window", async () => {


### PR DESCRIPTION
## Human comments

## What was wrong

The desktop browser handled every allowed `window.open()` request by creating an in-panel tab and returning `{ action: "deny" }`. Named or sized OAuth popups therefore returned `null` to the opener, lost `window.opener`, and could not complete their `postMessage` handshake.

## What changed

- Keep bare `target="_blank"` navigation in the existing in-panel tab flow.
- Allow named or sized popup flows to create a native `BrowserWindow`.
- Preserve the desktop browser partition while forcing sandboxing, context isolation, web security, and Node integration off.
- Restrict popup navigation to the same allowed URL schemes and deny nested popups.
- Track and close popup windows during manager teardown.
- Add regression coverage for both the native OAuth popup path and the existing in-panel `_blank` path.

## How you verified

- Added the regression test first; it failed on `f4bbc2fe81a9b7639ff9a7396e172bddd89109e4` with `expected "allow", received "deny"`.
- `pnpm exec turbo run typecheck test --filter=@bb/desktop --force`
  - 38 test files passed
  - 248 tests passed, 1 skipped
  - desktop TypeScript check passed
- `pnpm exec oxfmt --check apps/desktop/src/desktop-browser-view.ts apps/desktop/test/desktop-browser-view-manager.test.ts`
- `pnpm exec oxlint apps/desktop/src/desktop-browser-view.ts apps/desktop/test/desktop-browser-view-manager.test.ts`
- `git diff --check`
- Ran a real Electron 41.7.0 cross-origin popup probe against the changed handler. It returned:

```json
{"opened":true,"message":{"kind":"oauth-complete","hasOpener":true,"nestedBlocked":true,"sharedCookie":true},"timeout":false}
```

Fixes #2754

> AGENT GENERATED
