### PR TITLE
Fix OAuth popups in the desktop browser

### DIFF
--- a/apps/desktop/src/desktop-browser-view.ts
+++ b/apps/desktop/src/desktop-browser-view.ts
@@ -1,4 +1,13 @@
-import { Menu, WebContentsView, session, type Session } from "electron";
+import {
+  BrowserWindow,
+  Menu,
+  WebContentsView,
+  session,
+  type BrowserWindowConstructorOptions,
+  type Session,
+  type WebContents,
+  type WebPreferences,
+} from "electron";
 import {
   BB_DESKTOP_BROWSER_MAX_TITLE_LENGTH,
   BB_DESKTOP_BROWSER_MAX_URL_LENGTH,
@@ -35,6 +44,14 @@ import {
 
 const POPUP_RATE_WINDOW_MS = 10_000;
 const POPUP_RATE_MAX_IN_WINDOW = 3;
+const POPUP_MAX_OPEN_PER_TAB = 3;
+const POPUP_MAX_OPEN_GLOBAL = 8;
+const POPUP_DEFAULT_WIDTH = 520;
+const POPUP_DEFAULT_HEIGHT = 700;
+const POPUP_MIN_WIDTH = 320;
+const POPUP_MIN_HEIGHT = 240;
+const POPUP_MAX_WIDTH = 960;
+const POPUP_MAX_HEIGHT = 900;
 
 const RESIZE_SNAPSHOT_HIDE_CAP_MS = 80;
 const RESIZE_SNAPSHOT_JPEG_QUALITY = 70;
@@ -43,6 +60,84 @@ const RENDERER_RECOVERY_MAX_ATTEMPTS = 2;
 
 function truncate(value: string, max: number): string {
   return value.length > max ? value.slice(0, max) : value;
+}
+
+function clampPopupDimension(
+  value: number | undefined,
+  fallback: number,
+  min: number,
+  max: number,
+): number {
+  if (value === undefined || !Number.isFinite(value)) {
+    return fallback;
+  }
+  return Math.min(max, Math.max(min, Math.round(value)));
+}
+
+function hasPopupWindowFeatures(features: string): boolean {
+  const nonPopupFeatures = new Set([
+    "attributionsrc",
+    "noopener",
+    "noreferrer",
+  ]);
+  return features
+    .split(/[,\s]+/)
+    .map((feature) => feature.split("=", 1)[0]?.trim().toLowerCase())
+    .some(
+      (feature) =>
+        feature !== undefined &&
+        feature.length > 0 &&
+        !nonPopupFeatures.has(feature),
+    );
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  return (
+    hostname === "localhost" ||
+    hostname.endsWith(".localhost") ||
+    hostname === "[::1]" ||
+    /^127(?:\.\d{1,3}){3}$/.test(hostname)
+  );
+}
+
+function isAllowedPopupNavigationUrl(url: string): boolean {
+  if (url === "about:blank") {
+    return true;
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+  return (
+    parsed.protocol === "https:" ||
+    (parsed.protocol === "http:" && isLoopbackHostname(parsed.hostname))
+  );
+}
+
+function popupWindowTitle(url: string | null): string {
+  if (url === null || url === "about:blank" || url.length === 0) {
+    return "bb browser popup";
+  }
+  try {
+    return `bb browser — ${new URL(url).origin}`;
+  } catch {
+    return "bb browser popup";
+  }
+}
+
+function isPopupWebContents(value: unknown): value is WebContents {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "id" in value &&
+    typeof value.id === "number" &&
+    "isDestroyed" in value &&
+    typeof value.isDestroyed === "function" &&
+    "on" in value &&
+    typeof value.on === "function"
+  );
 }
 
 const BB_BROWSER_PARTITION = "persist:bb-browser";
@@ -54,6 +149,7 @@ interface BrowserViewEntry {
   lastErrorText: string | null;
   desiredBounds: BbDesktopBrowserViewBounds;
   popupTimestamps: number[];
+  popupWindows: Set<BrowserWindow>;
   rendererRecoveryAttempts: number;
   rendererRecoveryState: "healthy" | "pending" | "blocked";
   rendererRecoveryTimer: ReturnType<typeof setTimeout> | null;
@@ -242,6 +338,7 @@ export function createDesktopBrowserViewManager(
   const partition = args.partition ?? BB_BROWSER_PARTITION;
   const entries = new Map<string, BrowserViewEntry>();
   const entriesByWebContentsId = new Map<number, BrowserViewEntry>();
+  const popupWindows = new Set<BrowserWindow>();
   const resizingHostIds = new Set<number>();
   let hardenedSession: Session | null = null;
 
@@ -374,6 +471,104 @@ export function createDesktopBrowserViewManager(
     );
   }
 
+  function hardenedPopupWebPreferences(
+    webPreferences: WebPreferences | undefined,
+  ): WebPreferences {
+    const inheritedPreferences = { ...webPreferences };
+    delete inheritedPreferences.preload;
+    return {
+      ...inheritedPreferences,
+      allowRunningInsecureContent: false,
+      contextIsolation: true,
+      javascript: true,
+      nodeIntegration: false,
+      nodeIntegrationInSubFrames: false,
+      nodeIntegrationInWorker: false,
+      partition,
+      sandbox: true,
+      webSecurity: true,
+      webviewTag: false,
+      zoomFactor: 1,
+    };
+  }
+
+  function createHardenedPopupWindow(
+    options: BrowserWindowConstructorOptions,
+    entry: BrowserViewEntry,
+  ): WebContents {
+    const width = clampPopupDimension(
+      options.width,
+      POPUP_DEFAULT_WIDTH,
+      POPUP_MIN_WIDTH,
+      POPUP_MAX_WIDTH,
+    );
+    const height = clampPopupDimension(
+      options.height,
+      POPUP_DEFAULT_HEIGHT,
+      POPUP_MIN_HEIGHT,
+      POPUP_MAX_HEIGHT,
+    );
+    const safeOptions: BrowserWindowConstructorOptions = {
+      center: true,
+      frame: true,
+      height,
+      show: true,
+      transparent: false,
+      webPreferences: hardenedPopupWebPreferences(options.webPreferences),
+      width,
+    };
+    const childWebContents: unknown = Reflect.get(options, "webContents");
+    if (childWebContents !== undefined) {
+      if (!isPopupWebContents(childWebContents)) {
+        throw new Error("Invalid popup webContents");
+      }
+      Reflect.set(safeOptions, "webContents", childWebContents);
+    }
+    const popupWindow = new BrowserWindow(safeOptions);
+    popupWindows.add(popupWindow);
+    entry.popupWindows.add(popupWindow);
+    popupWindow.once("closed", () => {
+      popupWindows.delete(popupWindow);
+      entry.popupWindows.delete(popupWindow);
+    });
+    const popupContents = popupWindow.webContents;
+    const updatePopupTitle = (url: string | null): void => {
+      if (!popupWindow.isDestroyed()) {
+        popupWindow.setTitle(popupWindowTitle(url));
+      }
+    };
+    updatePopupTitle(popupContents.getURL());
+    popupContents.on("will-frame-navigate", (event) => {
+      if (event.isMainFrame && !isAllowedPopupNavigationUrl(event.url)) {
+        event.preventDefault();
+      }
+    });
+    popupContents.on("will-navigate", (event, url) => {
+      if (!isAllowedPopupNavigationUrl(url)) {
+        event.preventDefault();
+      }
+    });
+    popupContents.on("will-redirect", (event, url, _isInPlace, isMainFrame) => {
+      if (isMainFrame && !isAllowedPopupNavigationUrl(url)) {
+        event.preventDefault();
+      }
+    });
+    popupContents.on("did-navigate", (_event, url) => {
+      updatePopupTitle(url);
+    });
+    popupContents.on("did-navigate-in-page", (_event, url, isMainFrame) => {
+      if (isMainFrame) {
+        updatePopupTitle(url);
+      }
+    });
+    popupContents.on("page-title-updated", (event) => {
+      event.preventDefault();
+      updatePopupTitle(popupContents.getURL());
+    });
+    popupContents.setWindowOpenHandler(() => ({ action: "deny" }));
+    return popupContents;
+  }
+
   function wireWebContents(
     hostWindow: DesktopBrowserHostWindow,
     tabId: string,
@@ -435,25 +630,52 @@ export function createDesktopBrowserViewManager(
     });
 
     webContents.setWindowOpenHandler((details) => {
+      const opensNamedPopup =
+        hasPopupWindowFeatures(details.features) ||
+        (details.frameName.length > 0 && details.frameName !== "_blank");
       const { openTabUrl } = resolveWindowOpenAction(details.url);
-      if (openTabUrl !== null) {
-        const decision = evaluatePopupRate({
-          timestamps: entry.popupTimestamps,
-          now: Date.now(),
-          windowMs: POPUP_RATE_WINDOW_MS,
-          maxInWindow: POPUP_RATE_MAX_IN_WINDOW,
-        });
-        entry.popupTimestamps = decision.timestamps;
-        if (decision.allowed) {
-          send(hostWindow, BB_DESKTOP_BROWSER_OPEN_TAB_CHANNEL, {
-            url: openTabUrl,
-          });
-          send(hostWindow, BB_DESKTOP_BROWSER_SCOPED_OPEN_TAB_CHANNEL, {
-            tabId,
-            url: openTabUrl,
-          });
-        }
+      const opensAllowedNativePopup =
+        opensNamedPopup && isAllowedPopupNavigationUrl(details.url);
+      if (openTabUrl === null && !opensAllowedNativePopup) {
+        return { action: "deny" };
       }
+      if (
+        opensAllowedNativePopup &&
+        (entry.popupWindows.size >= POPUP_MAX_OPEN_PER_TAB ||
+          popupWindows.size >= POPUP_MAX_OPEN_GLOBAL)
+      ) {
+        return { action: "deny" };
+      }
+      const decision = evaluatePopupRate({
+        timestamps: entry.popupTimestamps,
+        now: Date.now(),
+        windowMs: POPUP_RATE_WINDOW_MS,
+        maxInWindow: POPUP_RATE_MAX_IN_WINDOW,
+      });
+      entry.popupTimestamps = decision.timestamps;
+      if (!decision.allowed) {
+        return { action: "deny" };
+      }
+      if (opensAllowedNativePopup) {
+        return {
+          action: "allow",
+          createWindow: (options) => createHardenedPopupWindow(options, entry),
+          overrideBrowserWindowOptions: {
+            show: true,
+            webPreferences: hardenedPopupWebPreferences(undefined),
+          },
+        };
+      }
+      if (openTabUrl === null) {
+        return { action: "deny" };
+      }
+      send(hostWindow, BB_DESKTOP_BROWSER_OPEN_TAB_CHANNEL, {
+        url: openTabUrl,
+      });
+      send(hostWindow, BB_DESKTOP_BROWSER_SCOPED_OPEN_TAB_CHANNEL, {
+        tabId,
+        url: openTabUrl,
+      });
       return { action: "deny" };
     });
 
@@ -570,6 +792,7 @@ export function createDesktopBrowserViewManager(
       lastErrorText: null,
       desiredBounds: args.desiredBounds,
       popupTimestamps: [],
+      popupWindows: new Set(),
       rendererRecoveryAttempts: 0,
       rendererRecoveryState: "healthy",
       rendererRecoveryTimer: null,
@@ -827,6 +1050,12 @@ export function createDesktopBrowserViewManager(
         entries.delete(key);
         entriesByWebContentsId.delete(entry.view.webContents.id);
         clearEntryRendererRecoveryTimer(entry);
+        for (const popupWindow of [...entry.popupWindows]) {
+          if (!popupWindow.isDestroyed()) {
+            popupWindow.destroy();
+          }
+        }
+        entry.popupWindows.clear();
         if (!entry.view.webContents.isDestroyed()) {
           entry.view.webContents.close();
         }
@@ -834,6 +1063,12 @@ export function createDesktopBrowserViewManager(
     },
     destroyAll() {
       resizingHostIds.clear();
+      for (const popupWindow of [...popupWindows]) {
+        if (!popupWindow.isDestroyed()) {
+          popupWindow.destroy();
+        }
+      }
+      popupWindows.clear();
       for (const [key, entry] of [...entries.entries()]) {
         entries.delete(key);
         entriesByWebContentsId.delete(entry.view.webContents.id);

--- a/apps/desktop/test/desktop-browser-view-manager.test.ts
+++ b/apps/desktop/test/desktop-browser-view-manager.test.ts
@@ -64,6 +64,11 @@ type FakeDidNavigateInPageListener = (
   isMainFrame: boolean,
 ) => void;
 
+type FakePageTitleUpdatedListener = (
+  event: FakePreventableEvent,
+  title: string,
+) => void;
+
 type FakeDidFailLoadListener = (
   event: FakeWebContentsEvent,
   errorCode: number,
@@ -144,7 +149,7 @@ interface FakeWebContentsEventMap {
   "did-navigate": FakeDidNavigateListener;
   "did-navigate-in-page": FakeDidNavigateInPageListener;
   "did-start-navigation": FakeVoidWebContentsListener;
-  "page-title-updated": FakeVoidWebContentsListener;
+  "page-title-updated": FakePageTitleUpdatedListener;
   "did-fail-load": FakeDidFailLoadListener;
   "context-menu": FakeContextMenuListener;
   "render-process-gone": FakeRenderProcessGoneListener;
@@ -173,11 +178,48 @@ type FakePermissionCheckHandler = (
 ) => boolean;
 
 interface FakeWindowOpenDetails {
+  features: string;
+  frameName: string;
   url: string;
 }
 
+interface FakeBrowserWindowOptions {
+  alwaysOnTop?: boolean;
+  center?: boolean;
+  frame?: boolean;
+  height?: number;
+  show?: boolean;
+  title?: string;
+  transparent?: boolean;
+  width?: number;
+  webContents?: FakePopupWebContents;
+  x?: number;
+  y?: number;
+  webPreferences?: {
+    allowRunningInsecureContent?: boolean;
+    contextIsolation?: boolean;
+    nodeIntegration?: boolean;
+    nodeIntegrationInSubFrames?: boolean;
+    nodeIntegrationInWorker?: boolean;
+    partition?: string;
+    preload?: string;
+    sandbox?: boolean;
+    webSecurity?: boolean;
+    webviewTag?: boolean;
+  };
+}
+
+interface FakePopupWebContents {
+  emitWindowOpen(
+    url: string,
+    details?: Partial<Omit<FakeWindowOpenDetails, "url">>,
+  ): FakeWindowOpenDecision;
+}
+
 interface FakeWindowOpenDecision {
-  action: "deny";
+  action: "allow" | "deny";
+  createWindow?: (options: FakeBrowserWindowOptions) => FakePopupWebContents;
+  overrideBrowserWindowOptions?: FakeBrowserWindowOptions;
 }
 
 type FakeWindowOpenHandler = (
@@ -427,6 +469,14 @@ const electronMock = vi.hoisted(() => {
       }
     }
 
+    emitPageTitleUpdated(title: string): boolean {
+      const event = new FakePreventableEventImpl();
+      for (const listener of this.listeners["page-title-updated"]) {
+        listener(event, title);
+      }
+      return event.defaultPrevented;
+    }
+
     emitWillFrameNavigate(
       url: string,
       isMainFrame: boolean,
@@ -471,11 +521,19 @@ const electronMock = vi.hoisted(() => {
       return event.defaultPrevented;
     }
 
-    emitWindowOpen(url: string): FakeWindowOpenDecision {
+    emitWindowOpen(
+      url: string,
+      details: Partial<Omit<FakeWindowOpenDetails, "url">> = {},
+    ): FakeWindowOpenDecision {
       if (this.windowOpenHandler === null) {
         throw new Error("Expected a window open handler to be registered.");
       }
-      return this.windowOpenHandler({ url });
+      return this.windowOpenHandler({
+        features: "",
+        frameName: "",
+        ...details,
+        url,
+      });
     }
   }
 
@@ -500,6 +558,48 @@ const electronMock = vi.hoisted(() => {
     }
   }
 
+  class FakeBrowserWindow {
+    public readonly options: FakeBrowserWindowOptions;
+    public readonly webContents: FakePopupWebContents;
+    public closeCalls = 0;
+    public destroyCalls = 0;
+    public readonly titleCalls: string[] = [];
+    private closedListener: (() => void) | null = null;
+    private destroyed = false;
+
+    constructor(options: FakeBrowserWindowOptions) {
+      this.options = options;
+      if (options.webContents === undefined) {
+        this.webContents = new FakeWebContents(nextWebContentsId);
+        nextWebContentsId += 1;
+      } else {
+        this.webContents = options.webContents;
+      }
+    }
+
+    close(): void {
+      this.closeCalls += 1;
+    }
+
+    destroy(): void {
+      this.destroyCalls += 1;
+      this.destroyed = true;
+      this.closedListener?.();
+    }
+
+    isDestroyed(): boolean {
+      return this.destroyed;
+    }
+
+    once(_eventName: "closed", listener: () => void): void {
+      this.closedListener = listener;
+    }
+
+    setTitle(title: string): void {
+      this.titleCalls.push(title);
+    }
+  }
+
   class FakeSession {
     public readonly willDownloadListeners: FakeSessionListener[] = [];
     public permissionCheckHandler: FakePermissionCheckHandler | null = null;
@@ -519,11 +619,24 @@ const electronMock = vi.hoisted(() => {
 
   const fakeSessions: FakeSession[] = [];
   const fakeViews: FakeWebContentsView[] = [];
+  const fakeWindows: FakeBrowserWindow[] = [];
 
   return {
     fakeCapturedImage,
     fakeSessions,
     fakeViews,
+    fakeWindows,
+    createFakeWebContents() {
+      const contents = new FakeWebContents(nextWebContentsId);
+      nextWebContentsId += 1;
+      return contents;
+    },
+    FakeBrowserWindow: class extends FakeBrowserWindow {
+      constructor(options: FakeBrowserWindowOptions) {
+        super(options);
+        fakeWindows.push(this);
+      }
+    },
     FakeWebContentsView: class extends FakeWebContentsView {
       constructor() {
         super();
@@ -541,6 +654,7 @@ const electronMock = vi.hoisted(() => {
 });
 
 vi.mock("electron", () => ({
+  BrowserWindow: electronMock.FakeBrowserWindow,
   WebContentsView: electronMock.FakeWebContentsView,
   session: electronMock.session,
 }));
@@ -607,6 +721,7 @@ beforeEach(() => {
   vi.useRealTimers();
   electronMock.fakeSessions.length = 0;
   electronMock.fakeViews.length = 0;
+  electronMock.fakeWindows.length = 0;
 });
 
 async function settlePendingCaptures(
@@ -934,7 +1049,11 @@ describe("DesktopBrowserViewManager", () => {
     });
     const view = requireFakeView(0);
 
-    expect(view.webContents.emitWindowOpen("http://localhost:38886/")).toEqual({
+    expect(
+      view.webContents.emitWindowOpen("http://localhost:38886/", {
+        frameName: "_blank",
+      }),
+    ).toEqual({
       action: "deny",
     });
     expect(openTabPushesOf(hostWindow)).toEqual(["http://localhost:38886/"]);
@@ -960,11 +1079,13 @@ describe("DesktopBrowserViewManager", () => {
     });
     const view = requireFakeView(0);
 
-    expect(view.webContents.emitWindowOpen("https://example.com/docs")).toEqual(
-      {
-        action: "deny",
-      },
-    );
+    expect(
+      view.webContents.emitWindowOpen("https://example.com/docs", {
+        frameName: "_blank",
+      }),
+    ).toEqual({
+      action: "deny",
+    });
     expect(openTabPushesOf(hostWindow)).toEqual(["https://example.com/docs"]);
     expect(scopedOpenTabPushesOf(hostWindow)).toEqual([
       {
@@ -972,6 +1093,277 @@ describe("DesktopBrowserViewManager", () => {
         url: "https://example.com/docs",
       },
     ]);
+  });
+
+  it("keeps noopener blank links in the browser panel", () => {
+    const manager = createDesktopBrowserViewManager({
+      partition: "persist:test",
+    });
+    const hostWindow = new FakeHostWindow({
+      contentBounds: { width: 700, height: 450 },
+      webContentsId: 63,
+    });
+
+    attachBrowserTab({
+      manager,
+      hostWindow,
+      tabId: "browser:a",
+      url: "https://example.com/",
+    });
+    const view = requireFakeView(0);
+
+    expect(
+      view.webContents.emitWindowOpen("https://example.com/docs", {
+        features:
+          "noopener,noreferrer,attributionsrc=https%3A%2F%2Fexample.com",
+        frameName: "_blank",
+      }),
+    ).toEqual({ action: "deny" });
+    expect(electronMock.fakeWindows).toEqual([]);
+    expect(openTabPushesOf(hostWindow)).toEqual(["https://example.com/docs"]);
+    expect(scopedOpenTabPushesOf(hostWindow)).toEqual([
+      {
+        tabId: "browser:a",
+        url: "https://example.com/docs",
+      },
+    ]);
+  });
+
+  it("opens named popup flows in a hardened native window", () => {
+    const manager = createDesktopBrowserViewManager({
+      partition: "persist:test",
+    });
+    const hostWindow = new FakeHostWindow({
+      contentBounds: { width: 700, height: 450 },
+      webContentsId: 62,
+    });
+
+    attachBrowserTab({
+      manager,
+      hostWindow,
+      tabId: "browser:a",
+      url: "https://www.notion.so/",
+    });
+    const view = requireFakeView(0);
+    const decision = view.webContents.emitWindowOpen(
+      "https://accounts.google.com/o/oauth2/auth",
+      {
+        features: "width=520,height=700",
+        frameName: "oauth",
+      },
+    );
+
+    expect(decision.action).toBe("allow");
+    expect(openTabPushesOf(hostWindow)).toEqual([]);
+    expect(scopedOpenTabPushesOf(hostWindow)).toEqual([]);
+    expect(decision.overrideBrowserWindowOptions).toEqual({
+      show: true,
+      webPreferences: {
+        allowRunningInsecureContent: false,
+        contextIsolation: true,
+        javascript: true,
+        nodeIntegration: false,
+        nodeIntegrationInSubFrames: false,
+        nodeIntegrationInWorker: false,
+        partition: "persist:test",
+        sandbox: true,
+        webSecurity: true,
+        webviewTag: false,
+        zoomFactor: 1,
+      },
+    });
+    if (decision.createWindow === undefined) {
+      throw new Error("Expected the popup decision to create a window.");
+    }
+
+    const childContents = electronMock.createFakeWebContents();
+    const options: FakeBrowserWindowOptions = {
+      alwaysOnTop: true,
+      frame: false,
+      height: 4_000,
+      show: false,
+      title: "bb sign in",
+      transparent: true,
+      width: 10,
+      webContents: childContents,
+      x: 0,
+      y: 0,
+      webPreferences: {
+        allowRunningInsecureContent: true,
+        contextIsolation: false,
+        nodeIntegration: true,
+        partition: "persist:untrusted",
+        preload: "/tmp/untrusted-preload.cjs",
+        sandbox: false,
+        webSecurity: false,
+      },
+    };
+    const popupContents = decision.createWindow(options);
+    const popupWindow = electronMock.fakeWindows[0];
+    expect(popupWindow).toBeDefined();
+    if (popupWindow === undefined) {
+      throw new Error("Expected a popup window to be created.");
+    }
+
+    expect(popupWindow.options).not.toBe(options);
+    expect(popupContents).toBe(childContents);
+    expect(popupWindow.options).toEqual({
+      center: true,
+      frame: true,
+      height: 900,
+      show: true,
+      transparent: false,
+      width: 320,
+      webContents: childContents,
+      webPreferences: {
+        allowRunningInsecureContent: false,
+        contextIsolation: true,
+        javascript: true,
+        nodeIntegration: false,
+        nodeIntegrationInSubFrames: false,
+        nodeIntegrationInWorker: false,
+        partition: "persist:test",
+        sandbox: true,
+        webSecurity: true,
+        webviewTag: false,
+        zoomFactor: 1,
+      },
+    });
+    expect(options).toEqual({
+      alwaysOnTop: true,
+      frame: false,
+      height: 4_000,
+      show: false,
+      title: "bb sign in",
+      transparent: true,
+      width: 10,
+      webContents: childContents,
+      x: 0,
+      y: 0,
+      webPreferences: {
+        allowRunningInsecureContent: true,
+        contextIsolation: false,
+        nodeIntegration: true,
+        partition: "persist:untrusted",
+        preload: "/tmp/untrusted-preload.cjs",
+        sandbox: false,
+        webSecurity: false,
+      },
+    });
+    expect(popupWindow.options.webPreferences).toEqual({
+      allowRunningInsecureContent: false,
+      contextIsolation: true,
+      javascript: true,
+      nodeIntegration: false,
+      nodeIntegrationInSubFrames: false,
+      nodeIntegrationInWorker: false,
+      partition: "persist:test",
+      sandbox: true,
+      webSecurity: true,
+      webviewTag: false,
+      zoomFactor: 1,
+    });
+    expect(popupWindow.titleCalls).toEqual(["bb browser popup"]);
+    childContents.emitDidNavigate("https://accounts.google.com/oauth2/auth");
+    expect(popupWindow.titleCalls.at(-1)).toBe(
+      "bb browser — https://accounts.google.com",
+    );
+    expect(childContents.emitPageTitleUpdated("Google Sign In")).toBe(true);
+    expect(popupWindow.titleCalls.at(-1)).toBe(
+      "bb browser — https://accounts.google.com",
+    );
+    expect(popupContents.emitWindowOpen("https://example.com/nested")).toEqual({
+      action: "deny",
+    });
+    manager.destroyAll();
+    expect(popupWindow.closeCalls).toBe(0);
+    expect(popupWindow.destroyCalls).toBe(1);
+  });
+
+  it("supports blank-first OAuth navigation with secure remote URLs", () => {
+    const manager = createDesktopBrowserViewManager({
+      partition: "persist:test",
+    });
+    const hostWindow = new FakeHostWindow({
+      contentBounds: { width: 700, height: 450 },
+      webContentsId: 64,
+    });
+
+    attachBrowserTab({
+      manager,
+      hostWindow,
+      tabId: "browser:a",
+      url: "https://example.com/",
+    });
+    const view = requireFakeView(0);
+    const decision = view.webContents.emitWindowOpen("about:blank", {
+      features: "width=520,height=700",
+      frameName: "oauth",
+    });
+
+    expect(decision.action).toBe("allow");
+    if (decision.createWindow === undefined) {
+      throw new Error("Expected the blank OAuth popup to create a window.");
+    }
+    const childContents = electronMock.createFakeWebContents();
+    decision.createWindow({ webContents: childContents });
+
+    expect(
+      childContents.emitWillNavigate(
+        "https://accounts.google.com/o/oauth2/auth",
+      ),
+    ).toBe(false);
+    expect(
+      childContents.emitWillNavigate("http://accounts.google.com/oauth2/auth"),
+    ).toBe(true);
+    expect(
+      childContents.emitWillNavigate("http://127.0.0.1:38886/callback"),
+    ).toBe(false);
+  });
+
+  it("caps live native popups across successive rate windows", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-09-03T12:00:00Z"));
+    const manager = createDesktopBrowserViewManager({
+      partition: "persist:test",
+    });
+    const hostWindow = new FakeHostWindow({
+      contentBounds: { width: 700, height: 450 },
+      webContentsId: 65,
+    });
+
+    attachBrowserTab({
+      manager,
+      hostWindow,
+      tabId: "browser:a",
+      url: "https://example.com/",
+    });
+    const view = requireFakeView(0);
+    const openPopup = (): FakeWindowOpenDecision => {
+      const decision = view.webContents.emitWindowOpen(
+        "https://accounts.google.com/o/oauth2/auth",
+        {
+          features: "width=520,height=700",
+          frameName: "oauth",
+        },
+      );
+      if (decision.createWindow !== undefined) {
+        decision.createWindow({
+          webContents: electronMock.createFakeWebContents(),
+        });
+      }
+      return decision;
+    };
+
+    expect(openPopup().action).toBe("allow");
+    expect(openPopup().action).toBe("allow");
+    expect(openPopup().action).toBe("allow");
+    vi.advanceTimersByTime(10_001);
+    expect(openPopup()).toEqual({ action: "deny" });
+
+    electronMock.fakeWindows[0]?.destroy();
+    expect(openPopup().action).toBe("allow");
+    manager.destroyAll();
   });
 
   it("snapshots then hides visible views on resize, revealing them clamped to the shrunken window", async () => {


### PR DESCRIPTION
## Human comments

## What was wrong

The desktop browser handled every allowed `window.open()` request by creating an in-panel tab and returning `{ action: "deny" }`. Named or sized OAuth popups therefore returned `null` to the opener, lost `window.opener`, and could not complete their `postMessage` handshake.

## What changed

- Keep bare `target="_blank"` navigation in the existing in-panel tab flow.
- Allow named or sized popup flows to create a native `BrowserWindow`.
- Preserve the desktop browser partition while forcing sandboxing, context isolation, web security, and Node integration off.
- Restrict popup navigation to the same allowed URL schemes and deny nested popups.
- Track and close popup windows during manager teardown.
- Add regression coverage for both the native OAuth popup path and the existing in-panel `_blank` path.

## How you verified

- Added the regression test first; it failed on `f4bbc2fe81a9b7639ff9a7396e172bddd89109e4` with `expected "allow", received "deny"`.
- `pnpm exec turbo run typecheck test --filter=@bb/desktop --force`
  - 38 test files passed
  - 248 tests passed, 1 skipped
  - desktop TypeScript check passed
- `pnpm exec oxfmt --check apps/desktop/src/desktop-browser-view.ts apps/desktop/test/desktop-browser-view-manager.test.ts`
- `pnpm exec oxlint apps/desktop/src/desktop-browser-view.ts apps/desktop/test/desktop-browser-view-manager.test.ts`
- `git diff --check`
- Ran a real Electron 41.7.0 cross-origin popup probe against the changed handler. It returned:

```json
{"opened":true,"message":{"kind":"oauth-complete","hasOpener":true,"nestedBlocked":true,"sharedCookie":true},"timeout":false}
```

Fixes #2754

> AGENT GENERATED
