### PR TITLE
Rework the compact mobile home and recents

### DIFF
--- a/apps/app/.ladle/story-fixtures.ts
+++ b/apps/app/.ladle/story-fixtures.ts
@@ -2,6 +2,7 @@ import type {
   Environment,
   Host,
   ProjectSource,
+  ProviderInfo,
   ReasoningLevel,
   Thread,
   ThreadListEntry,
@@ -94,6 +95,51 @@ function storyProviderIcon(providerId: string, glyph: string) {
   return getProviderIconInfo(providerId, { logoUrl: null, icon: { glyph } })
     ?.icon;
 }
+
+function makeStoryProvider(
+  id: string,
+  displayName: string,
+  glyph: string,
+): ProviderInfo {
+  return {
+    id,
+    pluginId: `provider-${id}`,
+    displayName,
+    logoUrl: null,
+    icon: { glyph },
+    available: true,
+    maintenance: { health: false, usage: false, installation: false },
+    composerActions: [],
+    capabilities: {
+      supportsThreadArchive: true,
+      supportsThreadRename: true,
+      supportsServiceTier: false,
+      supportsNativeUserQuestion: false,
+      supportsFork: true,
+      supportsSessionRewind: false,
+      modelCatalogScope: "workspace",
+      permissionModes: ["accept-edits", "auto", "full"],
+    },
+  };
+}
+
+const storyCodexProvider = makeStoryProvider("codex", "Codex", "Code");
+const storyClaudeCodeProvider = makeStoryProvider(
+  "claude-code",
+  "Claude Code",
+  "Brain",
+);
+const storyCursorProvider = makeStoryProvider("acp-cursor", "Cursor", "Zap");
+
+export const STORY_CODEX_PROVIDER_ID = storyCodexProvider.id;
+export const STORY_CLAUDE_CODE_PROVIDER_ID = storyClaudeCodeProvider.id;
+export const STORY_CURSOR_PROVIDER_ID = storyCursorProvider.id;
+
+export const STORY_PROVIDERS_BY_ID: ReadonlyMap<string, ProviderInfo> = new Map(
+  [storyCodexProvider, storyClaudeCodeProvider, storyCursorProvider].map(
+    (provider) => [provider.id, provider],
+  ),
+);
 
 export const STORY_PROVIDER_OPTIONS: readonly PickerOption<string>[] = [
   { value: "codex", label: "Codex", icon: storyProviderIcon("codex", "Code") },

--- a/apps/app/src/components/plugin/PluginNewThreadComposer.test.tsx
+++ b/apps/app/src/components/plugin/PluginNewThreadComposer.test.tsx
@@ -128,6 +128,7 @@ vi.mock("@/hooks/queries/host-queries", () => ({
 }));
 
 vi.mock("@/hooks/queries/system-queries", () => ({
+  useSystemProviders: () => ({ data: undefined }),
   useSystemProviderStates: () => ({ data: undefined, isPending: false }),
   useKnownProviderModelCatalogScope: () => undefined,
   useHostProviderCliStatus: () => ({ data: undefined }),

--- a/apps/app/src/components/promptbox/NewThreadComposer.tsx
+++ b/apps/app/src/components/promptbox/NewThreadComposer.tsx
@@ -114,6 +114,7 @@ interface NewThreadComposerPromptOptions {
   id?: string;
   placeholder?: string;
   autoFocus?: boolean;
+  allowSoftKeyboardAutoFocus?: boolean;
   banner?: ReactNode;
   header?: ReactNode;
   blockedReason?: string;
@@ -1201,6 +1202,7 @@ export function NewThreadComposer({
           disabledReason={disabledReason ?? undefined}
           placeholder={options.placeholder}
           autoFocus={options.autoFocus}
+          allowSoftKeyboardAutoFocus={options.allowSoftKeyboardAutoFocus}
           pluginComposerHost={options.pluginComposerHost ?? pluginComposerHost}
           textEffects={options.textEffects ?? textEffects}
           history={{

--- a/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
+++ b/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
@@ -153,6 +153,7 @@ interface NewThreadPromptBoxUIProps {
   disabled: boolean;
   disabledReason?: string;
   autoFocus?: boolean;
+  allowSoftKeyboardAutoFocus?: boolean;
   pluginComposerHost?: PluginComposerHost | null;
   textEffects?: readonly ComposerTextEffectSource[];
   placeholder?: string;
@@ -199,6 +200,7 @@ export const NewThreadPromptBoxUI = memo(function NewThreadPromptBoxUI({
   disabled,
   disabledReason,
   autoFocus,
+  allowSoftKeyboardAutoFocus,
   pluginComposerHost,
   textEffects,
   placeholder: placeholderOverride,
@@ -270,6 +272,7 @@ export const NewThreadPromptBoxUI = memo(function NewThreadPromptBoxUI({
           disabled={disabled}
           disabledReason={disabledReason}
           autoFocus={autoFocus}
+          allowSoftKeyboardAutoFocus={allowSoftKeyboardAutoFocus}
           textEffects={textEffects}
           placeholder={placeholderOverride}
           history={history}
@@ -307,6 +310,7 @@ const DefaultNewThreadComposer = memo(function DefaultNewThreadComposer({
   disabled,
   disabledReason,
   autoFocus,
+  allowSoftKeyboardAutoFocus,
   textEffects,
   placeholder: placeholderOverride,
   history,
@@ -378,6 +382,7 @@ const DefaultNewThreadComposer = memo(function DefaultNewThreadComposer({
           title: submitTitle,
         }}
         autoFocus={autoFocus}
+        allowSoftKeyboardAutoFocus={allowSoftKeyboardAutoFocus}
         editorLayout="root-compose"
         minHeight={NEW_THREAD_PROMPT_BOX_MIN_HEIGHT}
         placeholder={placeholder}

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -378,6 +378,7 @@ interface PromptBoxInternalProps {
   blurOnPointerSubmit?: boolean;
   placeholder?: string;
   autoFocus?: boolean;
+  allowSoftKeyboardAutoFocus?: boolean;
   className?: string;
   textEffects?: readonly ComposerTextEffectSource[];
   onComposerLayoutChange?: (layout: ComposerView["layout"]) => void;
@@ -1100,6 +1101,7 @@ export function PromptBoxInternal({
   blurOnPointerSubmit = false,
   placeholder = "Ask anything. @ to mention files, folders, or sections",
   autoFocus = true,
+  allowSoftKeyboardAutoFocus = false,
   className,
   textEffects,
   onComposerLayoutChange,
@@ -1163,7 +1165,8 @@ export function PromptBoxInternal({
   const isPointerCoarse = usePointerCoarse();
   const isIPadOSWebKitDevice = useMemo(isIPadOSWebKit, []);
   const editorEnterKeyHint = isPointerCoarse ? "enter" : "send";
-  const shouldAvoidSoftKeyboardAutofocus = isPointerCoarse;
+  const shouldAvoidSoftKeyboardAutofocus =
+    isPointerCoarse && !allowSoftKeyboardAutoFocus;
   const formRef = useRef<HTMLFormElement>(null);
   const typeaheadMenuRef = useRef<HTMLDivElement>(null);
   const reportQueuedEditorTypeaheadLayout = useContext(

--- a/apps/app/src/components/ui/overflow-fade.stories.tsx
+++ b/apps/app/src/components/ui/overflow-fade.stories.tsx
@@ -1,0 +1,101 @@
+import type { ReactNode } from "react";
+import { StoryCard, StoryRow } from "../../../.ladle/story-card";
+import { OverflowFade, type OverflowFadeTone } from "./overflow-fade";
+
+export default {
+  title: "ui/Overflow fade",
+};
+
+const TONE_SURFACE_CLASS: Record<OverflowFadeTone, string> = {
+  background: "bg-background",
+  sidebar: "bg-sidebar",
+  "surface-raised": "bg-surface-raised",
+};
+
+function FadeStage({
+  children,
+  tone,
+}: {
+  children: ReactNode;
+  tone: OverflowFadeTone;
+}) {
+  return (
+    <div
+      className={`relative h-32 w-[320px] overflow-hidden rounded-md border border-border ${TONE_SURFACE_CLASS[tone]}`}
+    >
+      <div className="flex flex-col gap-1 p-2">
+        {Array.from({ length: 8 }, (_, index) => (
+          <div
+            key={index}
+            className="h-6 shrink-0 rounded-sm border border-border-seam"
+          />
+        ))}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+export function Sizes() {
+  return (
+    <StoryCard labelWidth="150px">
+      <StoryRow
+        label="above — sm"
+        hint="h-8, used where a sticky label needs to separate from the rows under it"
+      >
+        <FadeStage tone="background">
+          <OverflowFade placement="above" tone="background" size="sm" />
+        </FadeStage>
+      </StoryRow>
+      <StoryRow label="above — default" hint="h-16, the standard scroll edge">
+        <FadeStage tone="background">
+          <OverflowFade placement="above" tone="background" />
+        </FadeStage>
+      </StoryRow>
+      <StoryRow
+        label="above — lg"
+        hint="h-24. Added for the compact home, where rows scroll behind the pinned composer and need to dissolve rather than stop at a hard edge"
+      >
+        <FadeStage tone="background">
+          <OverflowFade placement="above" tone="background" size="lg" />
+        </FadeStage>
+      </StoryRow>
+      <StoryRow label="below — lg" hint="the same size cast downward">
+        <FadeStage tone="background">
+          <OverflowFade placement="below" tone="background" size="lg" />
+        </FadeStage>
+      </StoryRow>
+      <StoryRow
+        label="left / right — lg"
+        hint="horizontal placements use w-24 at this size"
+      >
+        <FadeStage tone="background">
+          <OverflowFade placement="left" tone="background" size="lg" />
+          <OverflowFade placement="right" tone="background" size="lg" />
+        </FadeStage>
+      </StoryRow>
+    </StoryCard>
+  );
+}
+
+export function Tones() {
+  return (
+    <StoryCard labelWidth="150px">
+      <StoryRow label="background" hint="matches --background surfaces">
+        <FadeStage tone="background">
+          <OverflowFade placement="above" tone="background" size="lg" />
+        </FadeStage>
+      </StoryRow>
+      <StoryRow label="sidebar" hint="matches --sidebar surfaces">
+        <FadeStage tone="sidebar">
+          <OverflowFade placement="above" tone="sidebar" size="lg" />
+        </FadeStage>
+      </StoryRow>
+      <StoryRow label="surface-raised" hint="matches raised panel surfaces">
+        <FadeStage tone="surface-raised">
+          <OverflowFade placement="above" tone="surface-raised" size="lg" />
+        </FadeStage>
+      </StoryRow>
+    </StoryCard>
+  );
+}

--- a/apps/app/src/components/ui/overflow-fade.tsx
+++ b/apps/app/src/components/ui/overflow-fade.tsx
@@ -2,7 +2,7 @@ import { cn } from "@bb/shared-ui/lib/utils";
 
 type OverflowFadePlacement = "above" | "below" | "left" | "right";
 export type OverflowFadeTone = "background" | "sidebar" | "surface-raised";
-type OverflowFadeSize = "default" | "sm";
+type OverflowFadeSize = "default" | "sm" | "lg";
 
 interface OverflowFadeProps {
   className?: string;
@@ -32,11 +32,17 @@ const OVERFLOW_FADE_VERTICAL_SIZE_CLASSES: Record<
     aboveOffset: "-top-2",
     belowOffset: "-bottom-2",
   },
+  lg: {
+    height: "h-24",
+    aboveOffset: "-top-24",
+    belowOffset: "-bottom-24",
+  },
 };
 
 const OVERFLOW_FADE_HORIZONTAL_WIDTH_CLASS: Record<OverflowFadeSize, string> = {
   default: "w-6",
   sm: "w-2",
+  lg: "w-24",
 };
 
 function isHorizontalPlacement(

--- a/apps/app/src/views/RootComposeCompactHome.stories.tsx
+++ b/apps/app/src/views/RootComposeCompactHome.stories.tsx
@@ -1,0 +1,33 @@
+import { StoryCard, StoryRow } from "../../.ladle/story-card";
+import {
+  CompactHomePage,
+  HOME_THREADS,
+  PhoneFrame,
+} from "./mobile-home-story-fixtures";
+
+export default {
+  title: "views/Compact Home",
+};
+
+export function Overview() {
+  return (
+    <StoryCard labelWidth="170px">
+      <StoryRow
+        label="composer pinned, recents scroll behind it"
+        hint="393×852 with the real recents list. The composer is an overlay at the bottom; rows run underneath it and dissolve into a strong fade rather than stopping at a hard edge."
+      >
+        <PhoneFrame>
+          <CompactHomePage />
+        </PhoneFrame>
+      </StoryRow>
+      <StoryRow
+        label="short list"
+        hint="with only a few threads the list still rests above the composer instead of stretching to fill"
+      >
+        <PhoneFrame>
+          <CompactHomePage threads={HOME_THREADS.slice(0, 3)} />
+        </PhoneFrame>
+      </StoryRow>
+    </StoryCard>
+  );
+}

--- a/apps/app/src/views/RootComposeCompactHome.test.tsx
+++ b/apps/app/src/views/RootComposeCompactHome.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  getCompactHomeScrollViewportTop,
+  RootComposeCompactHome,
+} from "./RootComposeCompactHome";
+import {
+  MOBILE_RECENT_LABEL_HEIGHT_PX,
+  MOBILE_RECENT_ROW_HEIGHT_PX,
+} from "./RootComposeMobileRecents";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function renderCompactHome() {
+  return render(
+    <RootComposeCompactHome composer={<div data-testid="composer" />}>
+      <div data-testid="recents" />
+    </RootComposeCompactHome>,
+  );
+}
+
+describe("RootComposeCompactHome", () => {
+  it("keeps the composer above a scroll viewport that runs behind it", () => {
+    renderCompactHome();
+
+    const viewport = screen.getByTestId("root-compose-compact-scroll-viewport");
+    const composer = screen.getByTestId("root-compose-compact-composer");
+
+    expect(viewport.className).toContain("bottom-0");
+    expect(viewport.className).toContain("overflow-y-auto");
+    expect(composer.className).toContain("absolute");
+    expect(composer.className).toContain("bottom-0");
+    expect(composer.className).toContain("z-10");
+    expect(composer.contains(screen.getByTestId("composer"))).toBe(true);
+    expect(viewport.contains(screen.getByTestId("recents"))).toBe(true);
+  });
+
+  it("pins the scroll viewport so 5.5 rows show once the label sticks", () => {
+    const scrolledBandPx =
+      5.5 * MOBILE_RECENT_ROW_HEIGHT_PX + MOBILE_RECENT_LABEL_HEIGHT_PX;
+
+    expect(
+      getCompactHomeScrollViewportTop({
+        regionHeight: 852,
+        composerHeight: 188,
+      }),
+    ).toBe(852 - 188 - scrolledBandPx);
+  });
+
+  it("never lifts the scroll viewport above the app chrome row", () => {
+    expect(
+      getCompactHomeScrollViewportTop({
+        regionHeight: 420,
+        composerHeight: 188,
+      }),
+    ).toBe(56);
+  });
+
+  it("offsets the resting list by one row so 4.5 show before scrolling", () => {
+    renderCompactHome();
+
+    const offset = screen.getByTestId("root-compose-compact-recents-offset");
+    expect(offset.style.height).toBe(`${MOBILE_RECENT_ROW_HEIGHT_PX}px`);
+  });
+
+  it("pads the list tail so the last row can clear the composer", () => {
+    renderCompactHome();
+
+    const viewport = screen.getByTestId("root-compose-compact-scroll-viewport");
+    const bottomSpacer = viewport.lastElementChild;
+    if (!(bottomSpacer instanceof HTMLElement)) {
+      throw new Error("Expected a trailing composer spacer");
+    }
+    expect(bottomSpacer.style.height).toBe("0px");
+  });
+
+  it("renders a strong fade so rows dissolve into the composer", () => {
+    renderCompactHome();
+
+    const composer = screen.getByTestId("root-compose-compact-composer");
+    const fade = composer.querySelector('[data-overflow-fade="above"]');
+    if (!(fade instanceof HTMLElement)) {
+      throw new Error("Expected an above fade over the composer");
+    }
+    expect(fade.className).toContain("h-24");
+    expect(fade.className).toContain("-top-24");
+  });
+});

--- a/apps/app/src/views/RootComposeCompactHome.test.tsx
+++ b/apps/app/src/views/RootComposeCompactHome.test.tsx
@@ -1,6 +1,12 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   getCompactHomeScrollViewportTop,
@@ -40,6 +46,27 @@ describe("RootComposeCompactHome", () => {
     expect(viewport.contains(screen.getByTestId("recents"))).toBe(true);
   });
 
+  it("hides the transient scrollbar shortly after scrolling stops", () => {
+    vi.useFakeTimers();
+    renderCompactHome();
+
+    const viewport = screen.getByTestId("root-compose-compact-scroll-viewport");
+    expect(viewport.className).toContain("transient-scrollbar");
+
+    fireEvent.scroll(viewport);
+    expect(viewport.dataset.scrollbarScrolling).toBe("true");
+
+    act(() => {
+      vi.advanceTimersByTime(179);
+    });
+    expect(viewport.dataset.scrollbarScrolling).toBe("true");
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(viewport.hasAttribute("data-scrollbar-scrolling")).toBe(false);
+  });
+
   it("pins the scroll viewport so 5.5 rows show once the label sticks", () => {
     const scrolledBandPx =
       5.5 * MOBILE_RECENT_ROW_HEIGHT_PX + MOBILE_RECENT_LABEL_HEIGHT_PX;
@@ -50,6 +77,28 @@ describe("RootComposeCompactHome", () => {
         composerHeight: 188,
       }),
     ).toBe(852 - 188 - scrolledBandPx);
+  });
+
+  it("writes measured geometry directly before the compact home paints", () => {
+    vi.spyOn(HTMLElement.prototype, "offsetHeight", "get").mockImplementation(
+      function (this: HTMLElement) {
+        if (this.dataset.testid === "root-compose-compact-home") return 852;
+        if (this.dataset.testid === "root-compose-compact-composer") {
+          return 188;
+        }
+        return 0;
+      },
+    );
+
+    renderCompactHome();
+
+    const viewport = screen.getByTestId("root-compose-compact-scroll-viewport");
+    const bottomSpacer = viewport.lastElementChild;
+    if (!(bottomSpacer instanceof HTMLElement)) {
+      throw new Error("Expected a trailing composer spacer");
+    }
+    expect(viewport.style.top).toBe("310px");
+    expect(bottomSpacer.style.height).toBe("188px");
   });
 
   it("never lifts the scroll viewport above the app chrome row", () => {

--- a/apps/app/src/views/RootComposeCompactHome.test.tsx
+++ b/apps/app/src/views/RootComposeCompactHome.test.tsx
@@ -1,12 +1,6 @@
 // @vitest-environment jsdom
 
-import {
-  act,
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-} from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   getCompactHomeScrollViewportTop,
@@ -44,27 +38,6 @@ describe("RootComposeCompactHome", () => {
     expect(composer.className).toContain("z-10");
     expect(composer.contains(screen.getByTestId("composer"))).toBe(true);
     expect(viewport.contains(screen.getByTestId("recents"))).toBe(true);
-  });
-
-  it("hides the transient scrollbar shortly after scrolling stops", () => {
-    vi.useFakeTimers();
-    renderCompactHome();
-
-    const viewport = screen.getByTestId("root-compose-compact-scroll-viewport");
-    expect(viewport.className).toContain("transient-scrollbar");
-
-    fireEvent.scroll(viewport);
-    expect(viewport.dataset.scrollbarScrolling).toBe("true");
-
-    act(() => {
-      vi.advanceTimersByTime(179);
-    });
-    expect(viewport.dataset.scrollbarScrolling).toBe("true");
-
-    act(() => {
-      vi.advanceTimersByTime(1);
-    });
-    expect(viewport.hasAttribute("data-scrollbar-scrolling")).toBe(false);
   });
 
   it("pins the scroll viewport so 5.5 rows show once the label sticks", () => {

--- a/apps/app/src/views/RootComposeCompactHome.tsx
+++ b/apps/app/src/views/RootComposeCompactHome.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { OverflowFade } from "@/components/ui/overflow-fade";
+import {
+  MOBILE_RECENT_LABEL_HEIGHT_PX,
+  MOBILE_RECENT_ROW_HEIGHT_PX,
+} from "./RootComposeMobileRecents";
+
+const COMPACT_HOME_CHROME_OFFSET_PX = 56;
+const COMPACT_HOME_COLUMN_CLASS = "mx-auto w-full max-w-[760px] px-4";
+const COMPACT_HOME_REST_VISIBLE_ROWS = 4.5;
+const COMPACT_HOME_SCROLLED_VISIBLE_ROWS = 5.5;
+const COMPACT_HOME_SCROLLED_BAND_PX =
+  COMPACT_HOME_SCROLLED_VISIBLE_ROWS * MOBILE_RECENT_ROW_HEIGHT_PX +
+  MOBILE_RECENT_LABEL_HEIGHT_PX;
+const COMPACT_HOME_REST_OFFSET_PX =
+  (COMPACT_HOME_SCROLLED_VISIBLE_ROWS - COMPACT_HOME_REST_VISIBLE_ROWS) *
+  MOBILE_RECENT_ROW_HEIGHT_PX;
+
+export function getCompactHomeScrollViewportTop({
+  regionHeight,
+  composerHeight,
+}: {
+  regionHeight: number;
+  composerHeight: number;
+}): number {
+  return Math.max(
+    COMPACT_HOME_CHROME_OFFSET_PX,
+    regionHeight - composerHeight - COMPACT_HOME_SCROLLED_BAND_PX,
+  );
+}
+
+interface RootComposeCompactHomeProps {
+  children: ReactNode;
+  composer: ReactNode;
+}
+
+function useCompactHomeMetrics() {
+  const regionRef = useRef<HTMLDivElement>(null);
+  const composerRef = useRef<HTMLDivElement>(null);
+  const [metrics, setMetrics] = useState({
+    regionHeight: 0,
+    composerHeight: 0,
+  });
+
+  useEffect(() => {
+    const region = regionRef.current;
+    const composer = composerRef.current;
+    if (!region || !composer) return;
+    const measure = () => {
+      setMetrics((previous) =>
+        previous.regionHeight === region.offsetHeight &&
+        previous.composerHeight === composer.offsetHeight
+          ? previous
+          : {
+              regionHeight: region.offsetHeight,
+              composerHeight: composer.offsetHeight,
+            },
+      );
+    };
+    measure();
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(measure);
+    observer.observe(region);
+    observer.observe(composer);
+    return () => observer.disconnect();
+  }, []);
+
+  return { regionRef, composerRef, ...metrics };
+}
+
+export function RootComposeCompactHome({
+  children,
+  composer,
+}: RootComposeCompactHomeProps) {
+  const { regionRef, composerRef, regionHeight, composerHeight } =
+    useCompactHomeMetrics();
+
+  return (
+    <div
+      ref={regionRef}
+      data-testid="root-compose-compact-home"
+      className="relative min-h-0 flex-1"
+    >
+      <div
+        data-testid="root-compose-compact-scroll-viewport"
+        className="absolute inset-x-0 bottom-0 overflow-y-auto overscroll-contain"
+        style={{
+          top: getCompactHomeScrollViewportTop({
+            regionHeight,
+            composerHeight,
+          }),
+        }}
+      >
+        <div
+          aria-hidden
+          data-testid="root-compose-compact-recents-offset"
+          style={{ height: COMPACT_HOME_REST_OFFSET_PX }}
+        />
+        <div className={COMPACT_HOME_COLUMN_CLASS}>{children}</div>
+        <div aria-hidden style={{ height: composerHeight }} />
+      </div>
+      <div
+        ref={composerRef}
+        data-testid="root-compose-compact-composer"
+        className="absolute inset-x-0 bottom-0 z-10"
+      >
+        <OverflowFade placement="above" tone="background" size="lg" />
+        <div className="bg-background pb-4">
+          <div className={COMPACT_HOME_COLUMN_CLASS}>{composer}</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/views/RootComposeCompactHome.tsx
+++ b/apps/app/src/views/RootComposeCompactHome.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useLayoutEffect, useRef, useState, type ReactNode } from "react";
 import { OverflowFade } from "@/components/ui/overflow-fade";
 import {
   MOBILE_RECENT_LABEL_HEIGHT_PX,
@@ -42,7 +42,7 @@ function useCompactHomeMetrics() {
     composerHeight: 0,
   });
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const region = regionRef.current;
     const composer = composerRef.current;
     if (!region || !composer) return;

--- a/apps/app/src/views/RootComposeCompactHome.tsx
+++ b/apps/app/src/views/RootComposeCompactHome.tsx
@@ -97,7 +97,7 @@ export function RootComposeCompactHome({
       }
       scrollViewport.removeAttribute("data-scrollbar-scrolling");
     };
-  }, []);
+  }, [scrollViewportRef]);
 
   return (
     <div

--- a/apps/app/src/views/RootComposeCompactHome.tsx
+++ b/apps/app/src/views/RootComposeCompactHome.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef, useState, type ReactNode } from "react";
+import { useEffect, useLayoutEffect, useRef, type ReactNode } from "react";
 import { OverflowFade } from "@/components/ui/overflow-fade";
 import {
   MOBILE_RECENT_LABEL_HEIGHT_PX,
@@ -15,6 +15,7 @@ const COMPACT_HOME_SCROLLED_BAND_PX =
 const COMPACT_HOME_REST_OFFSET_PX =
   (COMPACT_HOME_SCROLLED_VISIBLE_ROWS - COMPACT_HOME_REST_VISIBLE_ROWS) *
   MOBILE_RECENT_ROW_HEIGHT_PX;
+const COMPACT_HOME_SCROLLBAR_IDLE_DELAY_MS = 180;
 
 export function getCompactHomeScrollViewportTop({
   regionHeight,
@@ -37,25 +38,22 @@ interface RootComposeCompactHomeProps {
 function useCompactHomeMetrics() {
   const regionRef = useRef<HTMLDivElement>(null);
   const composerRef = useRef<HTMLDivElement>(null);
-  const [metrics, setMetrics] = useState({
-    regionHeight: 0,
-    composerHeight: 0,
-  });
+  const scrollViewportRef = useRef<HTMLDivElement>(null);
+  const bottomSpacerRef = useRef<HTMLDivElement>(null);
 
   useLayoutEffect(() => {
     const region = regionRef.current;
     const composer = composerRef.current;
-    if (!region || !composer) return;
+    const scrollViewport = scrollViewportRef.current;
+    const bottomSpacer = bottomSpacerRef.current;
+    if (!region || !composer || !scrollViewport || !bottomSpacer) return;
     const measure = () => {
-      setMetrics((previous) =>
-        previous.regionHeight === region.offsetHeight &&
-        previous.composerHeight === composer.offsetHeight
-          ? previous
-          : {
-              regionHeight: region.offsetHeight,
-              composerHeight: composer.offsetHeight,
-            },
-      );
+      const composerHeight = composer.offsetHeight;
+      scrollViewport.style.top = `${getCompactHomeScrollViewportTop({
+        regionHeight: region.offsetHeight,
+        composerHeight,
+      })}px`;
+      bottomSpacer.style.height = `${composerHeight}px`;
     };
     measure();
     if (typeof ResizeObserver === "undefined") return;
@@ -65,15 +63,41 @@ function useCompactHomeMetrics() {
     return () => observer.disconnect();
   }, []);
 
-  return { regionRef, composerRef, ...metrics };
+  return { regionRef, composerRef, scrollViewportRef, bottomSpacerRef };
 }
 
 export function RootComposeCompactHome({
   children,
   composer,
 }: RootComposeCompactHomeProps) {
-  const { regionRef, composerRef, regionHeight, composerHeight } =
+  const { regionRef, composerRef, scrollViewportRef, bottomSpacerRef } =
     useCompactHomeMetrics();
+
+  useEffect(() => {
+    const scrollViewport = scrollViewportRef.current;
+    if (scrollViewport === null) return;
+
+    let idleTimeout: number | null = null;
+    const handleScroll = () => {
+      scrollViewport.dataset.scrollbarScrolling = "true";
+      if (idleTimeout !== null) {
+        window.clearTimeout(idleTimeout);
+      }
+      idleTimeout = window.setTimeout(() => {
+        idleTimeout = null;
+        scrollViewport.removeAttribute("data-scrollbar-scrolling");
+      }, COMPACT_HOME_SCROLLBAR_IDLE_DELAY_MS);
+    };
+
+    scrollViewport.addEventListener("scroll", handleScroll, { passive: true });
+    return () => {
+      scrollViewport.removeEventListener("scroll", handleScroll);
+      if (idleTimeout !== null) {
+        window.clearTimeout(idleTimeout);
+      }
+      scrollViewport.removeAttribute("data-scrollbar-scrolling");
+    };
+  }, []);
 
   return (
     <div
@@ -82,14 +106,10 @@ export function RootComposeCompactHome({
       className="relative min-h-0 flex-1"
     >
       <div
+        ref={scrollViewportRef}
         data-testid="root-compose-compact-scroll-viewport"
-        className="absolute inset-x-0 bottom-0 overflow-y-auto overscroll-contain"
-        style={{
-          top: getCompactHomeScrollViewportTop({
-            regionHeight,
-            composerHeight,
-          }),
-        }}
+        className="transient-scrollbar absolute inset-x-0 bottom-0 overflow-y-auto overscroll-contain"
+        style={{ top: COMPACT_HOME_CHROME_OFFSET_PX }}
       >
         <div
           aria-hidden
@@ -97,7 +117,7 @@ export function RootComposeCompactHome({
           style={{ height: COMPACT_HOME_REST_OFFSET_PX }}
         />
         <div className={COMPACT_HOME_COLUMN_CLASS}>{children}</div>
-        <div aria-hidden style={{ height: composerHeight }} />
+        <div ref={bottomSpacerRef} aria-hidden />
       </div>
       <div
         ref={composerRef}

--- a/apps/app/src/views/RootComposeCompactHome.tsx
+++ b/apps/app/src/views/RootComposeCompactHome.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, type ReactNode } from "react";
+import { useLayoutEffect, useRef, type ReactNode } from "react";
 import { OverflowFade } from "@/components/ui/overflow-fade";
 import {
   MOBILE_RECENT_LABEL_HEIGHT_PX,
@@ -15,7 +15,6 @@ const COMPACT_HOME_SCROLLED_BAND_PX =
 const COMPACT_HOME_REST_OFFSET_PX =
   (COMPACT_HOME_SCROLLED_VISIBLE_ROWS - COMPACT_HOME_REST_VISIBLE_ROWS) *
   MOBILE_RECENT_ROW_HEIGHT_PX;
-const COMPACT_HOME_SCROLLBAR_IDLE_DELAY_MS = 180;
 
 export function getCompactHomeScrollViewportTop({
   regionHeight,
@@ -73,32 +72,6 @@ export function RootComposeCompactHome({
   const { regionRef, composerRef, scrollViewportRef, bottomSpacerRef } =
     useCompactHomeMetrics();
 
-  useEffect(() => {
-    const scrollViewport = scrollViewportRef.current;
-    if (scrollViewport === null) return;
-
-    let idleTimeout: number | null = null;
-    const handleScroll = () => {
-      scrollViewport.dataset.scrollbarScrolling = "true";
-      if (idleTimeout !== null) {
-        window.clearTimeout(idleTimeout);
-      }
-      idleTimeout = window.setTimeout(() => {
-        idleTimeout = null;
-        scrollViewport.removeAttribute("data-scrollbar-scrolling");
-      }, COMPACT_HOME_SCROLLBAR_IDLE_DELAY_MS);
-    };
-
-    scrollViewport.addEventListener("scroll", handleScroll, { passive: true });
-    return () => {
-      scrollViewport.removeEventListener("scroll", handleScroll);
-      if (idleTimeout !== null) {
-        window.clearTimeout(idleTimeout);
-      }
-      scrollViewport.removeAttribute("data-scrollbar-scrolling");
-    };
-  }, [scrollViewportRef]);
-
   return (
     <div
       ref={regionRef}
@@ -108,7 +81,7 @@ export function RootComposeCompactHome({
       <div
         ref={scrollViewportRef}
         data-testid="root-compose-compact-scroll-viewport"
-        className="transient-scrollbar absolute inset-x-0 bottom-0 overflow-y-auto overscroll-contain"
+        className="absolute inset-x-0 bottom-0 overflow-y-auto overscroll-contain"
         style={{ top: COMPACT_HOME_CHROME_OFFSET_PX }}
       >
         <div

--- a/apps/app/src/views/RootComposeMobileRecents.stories.tsx
+++ b/apps/app/src/views/RootComposeMobileRecents.stories.tsx
@@ -4,6 +4,7 @@ import { StoryCard, StoryRow } from "../../.ladle/story-card";
 import {
   PROJECT_IDS,
   PROJECT_NAMES,
+  STORY_PROVIDERS_BY_ID,
   makeThreadListEntry,
 } from "../../.ladle/story-fixtures";
 import { RootComposeMobileRecents } from "./RootComposeMobileRecents";
@@ -48,6 +49,7 @@ const recentThreads: ThreadListEntry[] = [
   makeRecentThread({
     overrides: {
       id: "thr_mobile_just_starting",
+      providerId: "claude-code",
       title: "Trace mobile thread creation feedback",
       titleFallback: "Trace mobile thread creation feedback",
       status: "starting",
@@ -132,10 +134,109 @@ const statusThreads: ThreadListEntry[] = [
   }),
 ];
 
+const metadataThreads: ThreadListEntry[] = [
+  makeRecentThread({
+    overrides: {
+      id: "thr_mobile_worktree",
+      title: "Anchor the mobile prompt box",
+      titleFallback: "Anchor the mobile prompt box",
+      environmentName: "mobile-home",
+      environmentBranchName: "bb/mobile-home",
+      environmentWorkspaceDisplayKind: "managed-worktree",
+      createdAt: 700,
+      latestAttentionAt: 700,
+    },
+  }),
+  makeRecentThread({
+    overrides: {
+      id: "thr_mobile_unread",
+      projectId: PROJECT_IDS.pierre,
+      title: "Finished while you were away",
+      titleFallback: "Finished while you were away",
+      status: "idle",
+      lastReadAt: 100,
+      createdAt: 650,
+      latestAttentionAt: 650,
+    },
+  }),
+  makeRecentThread({
+    overrides: {
+      id: "thr_mobile_long_title",
+      title:
+        "A deliberately long thread title that has to truncate on a narrow mobile row",
+      titleFallback: "A deliberately long thread title",
+      environmentBranchName: "bb/very-long-branch-name-for-truncation",
+      environmentWorkspaceDisplayKind: "unmanaged-worktree",
+      createdAt: 600,
+      latestAttentionAt: 600,
+    },
+  }),
+];
+
+const hierarchyThreads: ThreadListEntry[] = [
+  makeRecentThread({
+    overrides: {
+      id: "thr_mobile_parent",
+      title: "Rework folder model",
+      titleFallback: "Rework folder model",
+      status: "active",
+      createdAt: 900,
+      latestAttentionAt: 900,
+      runtime: { displayStatus: "active", hostReconnectGraceExpiresAt: null },
+    },
+  }),
+  makeRecentThread({
+    overrides: {
+      id: "thr_mobile_child_a",
+      providerId: "claude-code",
+      parentThreadId: "thr_mobile_parent",
+      title: "Audit folder query paths",
+      titleFallback: "Audit folder query paths",
+      status: "active",
+      createdAt: 880,
+      latestAttentionAt: 880,
+      runtime: { displayStatus: "active", hostReconnectGraceExpiresAt: null },
+    },
+  }),
+  makeRecentThread({
+    overrides: {
+      id: "thr_mobile_child_b",
+      parentThreadId: "thr_mobile_parent",
+      title: "Migrate folder fixtures",
+      titleFallback: "Migrate folder fixtures",
+      createdAt: 860,
+      latestAttentionAt: 860,
+    },
+  }),
+  makeRecentThread({
+    overrides: {
+      id: "thr_mobile_grandchild",
+      providerId: "acp-cursor",
+      parentThreadId: "thr_mobile_child_a",
+      title: "Backfill folder migration tests",
+      titleFallback: "Backfill folder migration tests",
+      createdAt: 850,
+      latestAttentionAt: 850,
+    },
+  }),
+  makeRecentThread({
+    overrides: {
+      id: "thr_mobile_sibling",
+      projectId: PROJECT_IDS.pierre,
+      title: "Unrelated top-level thread",
+      titleFallback: "Unrelated top-level thread",
+      createdAt: 840,
+      latestAttentionAt: 840,
+    },
+  }),
+];
+
 const projectNamesById = new Map<string, string>([
   [PROJECT_IDS.bb, PROJECT_NAMES.bb],
   [PROJECT_IDS.pierre, PROJECT_NAMES.pierre],
 ]);
+
+const providersById = STORY_PROVIDERS_BY_ID;
 
 export function Overview() {
   return (
@@ -145,6 +246,7 @@ export function Overview() {
           <RootComposeMobileRecents
             highlightedThreadId="thr_mobile_just_starting"
             projectNamesById={projectNamesById}
+            providersById={providersById}
             showCreatingRow={false}
             threads={recentThreads}
           />
@@ -155,8 +257,31 @@ export function Overview() {
           <RootComposeMobileRecents
             highlightedThreadId={null}
             projectNamesById={projectNamesById}
+            providersById={providersById}
             showCreatingRow
             threads={recentThreads.slice(1)}
+          />
+        </MobileStage>
+      </StoryRow>
+      <StoryRow label="parent / child">
+        <MobileStage>
+          <RootComposeMobileRecents
+            highlightedThreadId={null}
+            projectNamesById={projectNamesById}
+            providersById={providersById}
+            showCreatingRow={false}
+            threads={hierarchyThreads}
+          />
+        </MobileStage>
+      </StoryRow>
+      <StoryRow label="row metadata">
+        <MobileStage>
+          <RootComposeMobileRecents
+            highlightedThreadId={null}
+            projectNamesById={projectNamesById}
+            providersById={providersById}
+            showCreatingRow={false}
+            threads={metadataThreads}
           />
         </MobileStage>
       </StoryRow>
@@ -165,6 +290,7 @@ export function Overview() {
           <RootComposeMobileRecents
             highlightedThreadId={null}
             projectNamesById={projectNamesById}
+            providersById={providersById}
             showCreatingRow={false}
             threads={statusThreads}
           />

--- a/apps/app/src/views/RootComposeMobileRecents.test.tsx
+++ b/apps/app/src/views/RootComposeMobileRecents.test.tsx
@@ -1,10 +1,14 @@
 // @vitest-environment jsdom
 
 import type { ThreadListEntry } from "@bb/domain";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it } from "vitest";
-import { RootComposeMobileRecents } from "./RootComposeMobileRecents";
+import {
+  getMobileRecentAncestorIds,
+  getMobileRecentThreads,
+  RootComposeMobileRecents,
+} from "./RootComposeMobileRecents";
 
 function makeThread(overrides: Partial<ThreadListEntry> = {}): ThreadListEntry {
   return {
@@ -54,6 +58,437 @@ afterEach(() => {
   window.localStorage.clear();
 });
 
+const NONE: ReadonlySet<string> = new Set();
+
+describe("getMobileRecentThreads", () => {
+  it("returns every active thread newest-first instead of a capped window", () => {
+    const threads = Array.from({ length: 12 }, (_unused, index) =>
+      makeThread({
+        id: `thr_${index}`,
+        latestAttentionAt: index,
+        createdAt: index,
+      }),
+    );
+
+    const rows = getMobileRecentThreads({
+      collapsedThreadIds: NONE,
+      threads,
+    });
+
+    expect(rows).toHaveLength(12);
+    expect(rows.map((row) => row.thread.id)).toEqual([
+      "thr_11",
+      "thr_10",
+      "thr_9",
+      "thr_8",
+      "thr_7",
+      "thr_6",
+      "thr_5",
+      "thr_4",
+      "thr_3",
+      "thr_2",
+      "thr_1",
+      "thr_0",
+    ]);
+    expect(rows.every((row) => row.depth === 0)).toBe(true);
+  });
+
+  it("nests a child under its parent instead of listing it as a peer", () => {
+    const rows = getMobileRecentThreads({
+      collapsedThreadIds: NONE,
+      threads: [
+        makeThread({ id: "thr_parent", latestAttentionAt: 10 }),
+        makeThread({
+          id: "thr_child",
+          parentThreadId: "thr_parent",
+          latestAttentionAt: 99,
+        }),
+        makeThread({ id: "thr_other", latestAttentionAt: 5 }),
+      ],
+    });
+
+    expect(rows.map((row) => [row.thread.id, row.depth])).toEqual([
+      ["thr_parent", 0],
+      ["thr_child", 1],
+      ["thr_other", 0],
+    ]);
+    expect(rows[0]?.hasChildren).toBe(true);
+    expect(rows[1]?.hasChildren).toBe(false);
+  });
+
+  it("hides descendants of a collapsed parent but keeps the parent", () => {
+    const threads = [
+      makeThread({ id: "thr_parent", latestAttentionAt: 10 }),
+      makeThread({
+        id: "thr_child",
+        parentThreadId: "thr_parent",
+        latestAttentionAt: 9,
+      }),
+      makeThread({
+        id: "thr_grandchild",
+        parentThreadId: "thr_child",
+        latestAttentionAt: 8,
+      }),
+    ];
+
+    const rows = getMobileRecentThreads({
+      collapsedThreadIds: new Set(["thr_parent"]),
+      threads,
+    });
+
+    expect(rows.map((row) => row.thread.id)).toEqual(["thr_parent"]);
+    expect(rows[0]?.isCollapsed).toBe(true);
+    expect(rows[0]?.hasChildren).toBe(true);
+  });
+
+  it("promotes a child whose parent is absent to the top level", () => {
+    const rows = getMobileRecentThreads({
+      collapsedThreadIds: NONE,
+      threads: [
+        makeThread({
+          id: "thr_orphan",
+          parentThreadId: "thr_missing",
+          latestAttentionAt: 3,
+        }),
+      ],
+    });
+
+    expect(rows.map((row) => [row.thread.id, row.depth])).toEqual([
+      ["thr_orphan", 0],
+    ]);
+  });
+
+  it("does not group worktree threads into environment rows", () => {
+    const rows = getMobileRecentThreads({
+      collapsedThreadIds: NONE,
+      threads: [
+        makeThread({
+          id: "thr_wt_a",
+          environmentId: "env_1",
+          environmentWorkspaceDisplayKind: "managed-worktree",
+          latestAttentionAt: 2,
+        }),
+        makeThread({
+          id: "thr_wt_b",
+          environmentId: "env_1",
+          environmentWorkspaceDisplayKind: "managed-worktree",
+          latestAttentionAt: 1,
+        }),
+      ],
+    });
+
+    expect(rows.map((row) => [row.thread.id, row.depth])).toEqual([
+      ["thr_wt_a", 0],
+      ["thr_wt_b", 0],
+    ]);
+  });
+});
+
+describe("getMobileRecentAncestorIds", () => {
+  const tree = [
+    makeThread({ id: "thr_root" }),
+    makeThread({ id: "thr_mid", parentThreadId: "thr_root" }),
+    makeThread({ id: "thr_leaf", parentThreadId: "thr_mid" }),
+  ];
+
+  it("walks the whole ancestor chain of a nested thread", () => {
+    expect(
+      getMobileRecentAncestorIds({ threadId: "thr_leaf", threads: tree }),
+    ).toEqual(["thr_mid", "thr_root"]);
+  });
+
+  it("returns nothing for a root thread or an unknown id", () => {
+    expect(
+      getMobileRecentAncestorIds({ threadId: "thr_root", threads: tree }),
+    ).toEqual([]);
+    expect(
+      getMobileRecentAncestorIds({ threadId: "thr_missing", threads: tree }),
+    ).toEqual([]);
+  });
+
+  it("stops at an absent parent instead of looping", () => {
+    expect(
+      getMobileRecentAncestorIds({
+        threadId: "thr_orphan",
+        threads: [makeThread({ id: "thr_orphan", parentThreadId: "thr_gone" })],
+      }),
+    ).toEqual([]);
+  });
+
+  it("terminates on a parent cycle", () => {
+    expect(
+      getMobileRecentAncestorIds({
+        threadId: "thr_a",
+        threads: [
+          makeThread({ id: "thr_a", parentThreadId: "thr_b" }),
+          makeThread({ id: "thr_b", parentThreadId: "thr_a" }),
+        ],
+      }).length,
+    ).toBeLessThanOrEqual(2);
+  });
+});
+
+describe("mobile recents hierarchy interaction", () => {
+  function renderTree() {
+    return render(
+      <MemoryRouter>
+        <RootComposeMobileRecents
+          highlightedThreadId={null}
+          projectNamesById={new Map()}
+          providersById={new Map()}
+          showCreatingRow={false}
+          threads={[
+            makeThread({
+              id: "thr_parent",
+              title: "Rework folder model",
+              titleFallback: "Rework folder model",
+              latestAttentionAt: 10,
+            }),
+            makeThread({
+              id: "thr_child",
+              title: "Audit folder query paths",
+              titleFallback: "Audit folder query paths",
+              parentThreadId: "thr_parent",
+              latestAttentionAt: 9,
+            }),
+          ]}
+        />
+      </MemoryRouter>,
+    );
+  }
+
+  it("collapses and expands children from the parent row chevron", () => {
+    renderTree();
+
+    expect(screen.getByText("Audit folder query paths")).not.toBeNull();
+    const collapse = screen.getByRole("button", {
+      name: "Hide threads under Rework folder model",
+    });
+    expect(collapse.getAttribute("aria-expanded")).toBe("true");
+
+    fireEvent.click(collapse);
+
+    expect(screen.queryByText("Audit folder query paths")).toBeNull();
+    const expand = screen.getByRole("button", {
+      name: "Show threads under Rework folder model",
+    });
+    expect(expand.getAttribute("aria-expanded")).toBe("false");
+
+    fireEvent.click(expand);
+    expect(screen.getByText("Audit folder query paths")).not.toBeNull();
+  });
+
+  it("reveals a highlighted thread whose parent is collapsed", () => {
+    window.localStorage.setItem(
+      "bb.sidebar.collapsedThreads",
+      JSON.stringify(["thr_parent"]),
+    );
+
+    render(
+      <MemoryRouter>
+        <RootComposeMobileRecents
+          highlightedThreadId="thr_child"
+          projectNamesById={new Map()}
+          providersById={new Map()}
+          showCreatingRow={false}
+          threads={[
+            makeThread({
+              id: "thr_parent",
+              title: "Rework folder model",
+              titleFallback: "Rework folder model",
+            }),
+            makeThread({
+              id: "thr_child",
+              title: "Audit folder query paths",
+              titleFallback: "Audit folder query paths",
+              parentThreadId: "thr_parent",
+            }),
+          ]}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Audit folder query paths")).not.toBeNull();
+    expect(window.localStorage.getItem("bb.sidebar.collapsedThreads")).toBe(
+      "[]",
+    );
+  });
+
+  it("de-emphasizes the provider tile on child rows only", () => {
+    renderTree();
+
+    const [parentRow, childRow] = screen.getAllByRole("link");
+    const parentTile = parentRow?.firstElementChild;
+    const childTile = childRow?.firstElementChild;
+    if (
+      !(parentTile instanceof HTMLElement) ||
+      !(childTile instanceof HTMLElement)
+    ) {
+      throw new Error("Expected a tile on both rows");
+    }
+
+    expect(parentTile.className).not.toContain("opacity-60");
+    expect(childTile.className).toContain("opacity-60");
+
+    for (const tile of [parentTile, childTile]) {
+      expect(tile.className).toContain("border-border-seam");
+      expect(tile.className).toContain("bg-surface-raised");
+    }
+
+    for (const tile of [parentTile, childTile]) {
+      expect(tile.className).toContain("size-7");
+      expect(tile.className).toContain("self-start");
+      expect(tile.className).toContain("mt-1");
+      expect(tile.className).toContain("border");
+    }
+  });
+
+  it("anchors the provider tile to the title line, not the text block", () => {
+    renderTree();
+
+    const [parentRow] = screen.getAllByRole("link");
+    const tile = parentRow?.firstElementChild;
+    if (!(tile instanceof HTMLElement)) {
+      throw new Error("Expected a leading provider tile");
+    }
+    expect(tile.className).toContain("self-start");
+    expect(tile.className).toContain("mt-1");
+  });
+
+  it("gives only the parent a toggle and indents the child", () => {
+    renderTree();
+
+    expect(screen.getAllByRole("button")).toHaveLength(1);
+    const [parentRow, childRow] = screen.getAllByRole("link");
+    if (!parentRow || !childRow) {
+      throw new Error("Expected a parent and a child row");
+    }
+    expect(parentRow.style.paddingLeft).toBe("8px");
+    expect(childRow.style.paddingLeft).toBe("32px");
+  });
+});
+
+describe("mobile recents section", () => {
+  it("keeps the Recent label pinned while the list scrolls under it", () => {
+    render(
+      <MemoryRouter>
+        <RootComposeMobileRecents
+          highlightedThreadId={null}
+          projectNamesById={new Map()}
+          providersById={new Map()}
+          showCreatingRow={false}
+          threads={[makeThread()]}
+        />
+      </MemoryRouter>,
+    );
+
+    const label = screen.getByText("Recent").parentElement;
+    if (!(label instanceof HTMLElement)) {
+      throw new Error("Expected a Recent label wrapper");
+    }
+    expect(label.className).toContain("sticky");
+    expect(label.className).toContain("top-0");
+    expect(label.className).toContain("bg-background");
+    expect(label.querySelector('[data-overflow-fade="below"]')).not.toBeNull();
+  });
+});
+
+describe("mobile recent thread rows", () => {
+  it("shows project and relative activity on a metadata line", () => {
+    render(
+      <MemoryRouter>
+        <RootComposeMobileRecents
+          highlightedThreadId={null}
+          projectNamesById={new Map([["proj_mobile", "bb"]])}
+          providersById={new Map()}
+          showCreatingRow={false}
+          threads={[
+            makeThread({
+              latestAttentionAt: Date.now() - 3 * 60 * 60 * 1000,
+              activity: {
+                activeWorkflowCount: 0,
+                activeBackgroundAgentCount: 0,
+                activeBackgroundCommandCount: 0,
+                activePlanModeCount: 0,
+                activeGoalCount: 0,
+              },
+            }),
+          ]}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("bb \u00b7 3h ago")).not.toBeNull();
+  });
+
+  it("includes the worktree branch when the thread has one", () => {
+    render(
+      <MemoryRouter>
+        <RootComposeMobileRecents
+          highlightedThreadId={null}
+          projectNamesById={new Map([["proj_mobile", "bb"]])}
+          providersById={new Map()}
+          showCreatingRow={false}
+          threads={[
+            makeThread({
+              environmentBranchName: "bb/mobile-home",
+              latestAttentionAt: Date.now() - 3 * 60 * 60 * 1000,
+              activity: {
+                activeWorkflowCount: 0,
+                activeBackgroundAgentCount: 0,
+                activeBackgroundCommandCount: 0,
+                activePlanModeCount: 0,
+                activeGoalCount: 0,
+              },
+            }),
+          ]}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByText("bb \u00b7 bb/mobile-home \u00b7 3h ago"),
+    ).not.toBeNull();
+  });
+
+  it("drops the status slot entirely when a thread has no indicator", () => {
+    render(
+      <MemoryRouter>
+        <RootComposeMobileRecents
+          highlightedThreadId={null}
+          projectNamesById={new Map()}
+          providersById={new Map()}
+          showCreatingRow={false}
+          threads={[
+            makeThread({
+              status: "idle",
+              lastReadAt: 10,
+              latestAttentionAt: 5,
+              runtime: {
+                displayStatus: "idle",
+                hostReconnectGraceExpiresAt: null,
+              },
+              activity: {
+                activeWorkflowCount: 0,
+                activeBackgroundAgentCount: 0,
+                activeBackgroundCommandCount: 0,
+                activePlanModeCount: 0,
+                activeGoalCount: 0,
+              },
+            }),
+          ]}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByLabelText("Plan mode active")).toBeNull();
+    expect(screen.queryByLabelText("Thread working")).toBeNull();
+    expect(
+      screen.getByRole("link").querySelectorAll("span.size-6"),
+    ).toHaveLength(0);
+  });
+});
+
 describe("RootComposeMobileRecents", () => {
   it("shows concurrent Plan activity before the runtime spinner", () => {
     render(
@@ -61,6 +496,7 @@ describe("RootComposeMobileRecents", () => {
         <RootComposeMobileRecents
           highlightedThreadId={null}
           projectNamesById={new Map()}
+          providersById={new Map()}
           showCreatingRow={false}
           threads={[makeThread()]}
         />
@@ -78,6 +514,7 @@ describe("RootComposeMobileRecents", () => {
         <RootComposeMobileRecents
           highlightedThreadId={null}
           projectNamesById={new Map()}
+          providersById={new Map()}
           showCreatingRow={false}
           threads={[
             makeThread({
@@ -109,6 +546,7 @@ describe("RootComposeMobileRecents", () => {
         <RootComposeMobileRecents
           highlightedThreadId={null}
           projectNamesById={new Map()}
+          providersById={new Map()}
           showCreatingRow={false}
           threads={[makeThread()]}
         />
@@ -133,6 +571,7 @@ describe("RootComposeMobileRecents", () => {
         <RootComposeMobileRecents
           highlightedThreadId={null}
           projectNamesById={new Map()}
+          providersById={new Map()}
           showCreatingRow={false}
           threads={[
             makeThread({

--- a/apps/app/src/views/RootComposeMobileRecents.test.tsx
+++ b/apps/app/src/views/RootComposeMobileRecents.test.tsx
@@ -337,22 +337,23 @@ describe("mobile recents hierarchy interaction", () => {
 
     for (const tile of [parentTile, childTile]) {
       expect(tile.className).toContain("size-7");
-      expect(tile.className).toContain("self-start");
-      expect(tile.className).toContain("mt-1");
       expect(tile.className).toContain("border");
     }
   });
 
-  it("anchors the provider tile to the title line, not the text block", () => {
+  it("centers provider tiles against the title and metadata block", () => {
     renderTree();
 
-    const [parentRow] = screen.getAllByRole("link");
-    const tile = parentRow?.firstElementChild;
-    if (!(tile instanceof HTMLElement)) {
-      throw new Error("Expected a leading provider tile");
+    const rows = screen.getAllByRole("link");
+    for (const row of rows) {
+      const tile = row.firstElementChild;
+      if (!(tile instanceof HTMLElement)) {
+        throw new Error("Expected a leading provider tile");
+      }
+      expect(row.className).toContain("items-center");
+      expect(tile.className).not.toContain("self-start");
+      expect(tile.className).not.toContain("mt-1");
     }
-    expect(tile.className).toContain("self-start");
-    expect(tile.className).toContain("mt-1");
   });
 
   it("gives only the parent a toggle and indents the child", () => {

--- a/apps/app/src/views/RootComposeMobileRecents.test.tsx
+++ b/apps/app/src/views/RootComposeMobileRecents.test.tsx
@@ -53,6 +53,28 @@ function makeThread(overrides: Partial<ThreadListEntry> = {}): ThreadListEntry {
   };
 }
 
+const IDLE_ACTIVITY: ThreadListEntry["activity"] = {
+  activeWorkflowCount: 0,
+  activeBackgroundAgentCount: 0,
+  activeBackgroundCommandCount: 0,
+  activePlanModeCount: 0,
+  activeGoalCount: 0,
+};
+
+function makeIdleThread(
+  overrides: Partial<ThreadListEntry> = {},
+): ThreadListEntry {
+  return makeThread({
+    status: "idle",
+    runtime: {
+      displayStatus: "idle",
+      hostReconnectGraceExpiresAt: null,
+    },
+    activity: IDLE_ACTIVITY,
+    ...overrides,
+  });
+}
+
 afterEach(() => {
   cleanup();
   window.localStorage.clear();
@@ -258,7 +280,9 @@ describe("mobile recents hierarchy interaction", () => {
   }
 
   it("collapses and expands children from the parent row chevron", () => {
-    renderTree();
+    const { container } = renderTree();
+
+    expect(container.querySelector("a button")).toBeNull();
 
     expect(screen.getByText("Audit folder query paths")).not.toBeNull();
     const collapse = screen.getByRole("button", {
@@ -277,6 +301,78 @@ describe("mobile recents hierarchy interaction", () => {
     fireEvent.click(expand);
     expect(screen.getByText("Audit folder query paths")).not.toBeNull();
   });
+
+  it.each([
+    {
+      label: "Thread needs user input",
+      child: makeIdleThread({
+        id: "thr_child",
+        parentThreadId: "thr_parent",
+        hasPendingInteraction: true,
+      }),
+    },
+    {
+      label: "Plan mode active",
+      child: makeIdleThread({
+        id: "thr_child",
+        parentThreadId: "thr_parent",
+        activity: {
+          ...IDLE_ACTIVITY,
+          activePlanModeCount: 1,
+        },
+      }),
+    },
+    {
+      label: "Thread working",
+      child: makeThread({
+        id: "thr_child",
+        parentThreadId: "thr_parent",
+        activity: IDLE_ACTIVITY,
+      }),
+    },
+    {
+      label: "Unread thread failed",
+      child: makeIdleThread({
+        id: "thr_child",
+        parentThreadId: "thr_parent",
+        status: "error",
+      }),
+    },
+  ])(
+    "renders child-only $label state on a collapsed parent",
+    ({ child, label }) => {
+      window.localStorage.setItem(
+        "bb.sidebar.collapsedThreads",
+        JSON.stringify(["thr_parent"]),
+      );
+
+      render(
+        <MemoryRouter>
+          <RootComposeMobileRecents
+            highlightedThreadId={null}
+            projectNamesById={new Map()}
+            providersById={new Map()}
+            showCreatingRow={false}
+            threads={[
+              makeIdleThread({
+                id: "thr_parent",
+                lastReadAt: 10,
+                latestAttentionAt: 5,
+              }),
+              child,
+            ]}
+          />
+        </MemoryRouter>,
+      );
+
+      expect(screen.getByLabelText(label)).not.toBeNull();
+      expect(
+        screen.getByRole("link", {
+          name: `Open Mobile activity — ${label}`,
+        }),
+      ).not.toBeNull();
+    },
+  );
 
   it("reveals a highlighted thread whose parent is collapsed", () => {
     window.localStorage.setItem(

--- a/apps/app/src/views/RootComposeMobileRecents.test.tsx
+++ b/apps/app/src/views/RootComposeMobileRecents.test.tsx
@@ -330,14 +330,6 @@ describe("mobile recents hierarchy interaction", () => {
         activity: IDLE_ACTIVITY,
       }),
     },
-    {
-      label: "Unread thread failed",
-      child: makeIdleThread({
-        id: "thr_child",
-        parentThreadId: "thr_parent",
-        status: "error",
-      }),
-    },
   ])(
     "renders child-only $label state on a collapsed parent",
     ({ child, label }) => {

--- a/apps/app/src/views/RootComposeMobileRecents.test.tsx
+++ b/apps/app/src/views/RootComposeMobileRecents.test.tsx
@@ -94,6 +94,7 @@ describe("getMobileRecentThreads", () => {
 
     const rows = getMobileRecentThreads({
       collapsedThreadIds: NONE,
+      draftThreadIds: NONE,
       threads,
     });
 
@@ -118,6 +119,7 @@ describe("getMobileRecentThreads", () => {
   it("nests a child under its parent instead of listing it as a peer", () => {
     const rows = getMobileRecentThreads({
       collapsedThreadIds: NONE,
+      draftThreadIds: NONE,
       threads: [
         makeThread({ id: "thr_parent", latestAttentionAt: 10 }),
         makeThread({
@@ -155,6 +157,7 @@ describe("getMobileRecentThreads", () => {
 
     const rows = getMobileRecentThreads({
       collapsedThreadIds: new Set(["thr_parent"]),
+      draftThreadIds: NONE,
       threads,
     });
 
@@ -166,6 +169,7 @@ describe("getMobileRecentThreads", () => {
   it("promotes a child whose parent is absent to the top level", () => {
     const rows = getMobileRecentThreads({
       collapsedThreadIds: NONE,
+      draftThreadIds: NONE,
       threads: [
         makeThread({
           id: "thr_orphan",
@@ -183,6 +187,7 @@ describe("getMobileRecentThreads", () => {
   it("does not group worktree threads into environment rows", () => {
     const rows = getMobileRecentThreads({
       collapsedThreadIds: NONE,
+      draftThreadIds: NONE,
       threads: [
         makeThread({
           id: "thr_wt_a",
@@ -365,6 +370,46 @@ describe("mobile recents hierarchy interaction", () => {
       ).not.toBeNull();
     },
   );
+
+  it("renders a child-only draft state on a collapsed parent", () => {
+    window.localStorage.setItem(
+      "bb.promptbox.contents-proj_mobile-thr_child-3",
+      JSON.stringify({ text: "Continue child work", attachments: [] }),
+    );
+    window.localStorage.setItem(
+      "bb.sidebar.collapsedThreads",
+      JSON.stringify(["thr_parent"]),
+    );
+
+    render(
+      <MemoryRouter>
+        <RootComposeMobileRecents
+          highlightedThreadId={null}
+          projectNamesById={new Map()}
+          providersById={new Map()}
+          showCreatingRow={false}
+          threads={[
+            makeIdleThread({
+              id: "thr_parent",
+              lastReadAt: 10,
+              latestAttentionAt: 5,
+            }),
+            makeIdleThread({
+              id: "thr_child",
+              parentThreadId: "thr_parent",
+            }),
+          ]}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByLabelText("Thread has unsubmitted draft")).not.toBeNull();
+    expect(
+      screen.getByRole("link", {
+        name: "Open Mobile activity — Thread has unsubmitted draft",
+      }),
+    ).not.toBeNull();
+  });
 
   it("reveals a highlighted thread whose parent is collapsed", () => {
     window.localStorage.setItem(

--- a/apps/app/src/views/RootComposeMobileRecents.tsx
+++ b/apps/app/src/views/RootComposeMobileRecents.tsx
@@ -1,11 +1,19 @@
-import { useMemo } from "react";
-import type { ThreadListEntry } from "@bb/domain";
+import { useCallback, useEffect, useMemo } from "react";
+import { useAtom } from "jotai";
+import type { ProviderInfo, ThreadListEntry } from "@bb/domain";
 import { RouteAnchor } from "@/components/ui/app-route-anchor";
 import { ThreadStatusGlyph } from "@/components/sidebar/ThreadRow";
+import { SidebarChildToggleChevron } from "@/components/sidebar/SidebarChildToggleChevron";
+import { getSidebarThreadRowPaddingLeft } from "@/components/sidebar/sidebarRowClasses";
 import { SIDEBAR_WORKING_STATUS_COLOR_CLASS } from "@/components/sidebar/sidebarRowClasses";
 import { CHROME_SECTION_LABEL_CLASS } from "@bb/shared-ui/chrome-style-tokens";
-import { COARSE_POINTER_ICON_SIZE_CLASS } from "@bb/shared-ui/coarse-pointer-sizing";
+import {
+  COARSE_POINTER_ICON_SIZE_CLASS,
+  COARSE_POINTER_TEXT_BASE_CLASS,
+  COARSE_POINTER_TEXT_SM_CLASS,
+} from "@bb/shared-ui/coarse-pointer-sizing";
 import { Icon } from "@bb/shared-ui/icon";
+import { OverflowFade } from "@/components/ui/overflow-fade";
 import { getThreadRoutePath, isProjectlessProjectId } from "@/lib/route-paths";
 import {
   hasActiveBackgroundAgentActivity,
@@ -17,13 +25,24 @@ import {
   isRuntimeBusyThread,
   isUnreadDoneThread,
   resolveThreadListIndicator,
+  buildChronologicalThreadList,
+  type CollapsedChildActivity,
+  type ProjectThreadItem,
   type ThreadListIndicatorState,
 } from "@bb/client-core";
 import { getThreadDisplayTitle } from "@/lib/thread-title";
+import { formatRelativeTime } from "@/lib/relative-time";
+import { getEnvironmentWorkspaceDisplayIconName } from "@/lib/environment-workspace-display";
+import { getProviderIconInfo } from "@/lib/provider-icon";
+import { ProviderIconMark } from "@/components/settings/ProviderIconMark";
 import { cn } from "@bb/shared-ui/lib/utils";
 import { usePromptDraftHasInput } from "@/hooks/usePromptDraftStorage";
+import { collapsedThreadIdsAtom } from "@/components/sidebar/sidebarCollapsedAtoms";
 
-const MOBILE_RECENT_THREAD_LIMIT = 3;
+export const MOBILE_RECENT_ROW_HEIGHT_PX = 60;
+export const MOBILE_RECENT_LABEL_HEIGHT_PX = 24;
+
+const MOBILE_RECENT_ROW_HEIGHT_CLASS = "h-15";
 
 type ThreadListEntryComparator = (
   left: ThreadListEntry,
@@ -31,19 +50,42 @@ type ThreadListEntryComparator = (
 ) => number;
 
 interface GetMobileRecentThreadsArgs {
-  highlightedThreadId: string | null;
+  collapsedThreadIds: ReadonlySet<string>;
   threads: readonly ThreadListEntry[];
 }
 
 interface MobileRecentThreadRowProps {
   highlighted: boolean;
+  onToggleCollapsed: (threadId: string) => void;
+  projectName: string | null;
+  provider: ProviderInfo | null;
+  row: MobileRecentThreadRow;
+}
+
+function getMobileRecentThreadMetadata({
+  projectName,
+  thread,
+}: {
   projectName: string | null;
   thread: ThreadListEntry;
+}): string {
+  const workspaceName = thread.environmentBranchName ?? thread.environmentName;
+  return [
+    projectName,
+    workspaceName,
+    formatRelativeTime({
+      timestamp: thread.latestAttentionAt,
+      now: Date.now(),
+    }),
+  ]
+    .filter((part): part is string => part !== null && part.length > 0)
+    .join(" \u00b7 ");
 }
 
 interface RootComposeMobileRecentsProps {
   highlightedThreadId: string | null;
   projectNamesById: ReadonlyMap<string, string>;
+  providersById: ReadonlyMap<string, ProviderInfo>;
   showCreatingRow: boolean;
   threads: readonly ThreadListEntry[];
 }
@@ -63,35 +105,94 @@ const compareMobileRecentThreads: ThreadListEntryComparator = (left, right) => {
   return left.id.localeCompare(right.id);
 };
 
-function getMobileRecentThreads({
-  highlightedThreadId,
+export interface MobileRecentThreadRow {
+  thread: ThreadListEntry;
+  depth: number;
+  childActivity: CollapsedChildActivity;
+  hasChildren: boolean;
+  isCollapsed: boolean;
+}
+
+function flattenMobileRecentNodes({
+  collapsedThreadIds,
+  items,
+  rows,
+}: {
+  collapsedThreadIds: ReadonlySet<string>;
+  items: readonly ProjectThreadItem[];
+  rows: MobileRecentThreadRow[];
+}): void {
+  for (const item of items) {
+    if (item.kind !== "thread") continue;
+    const { node } = item;
+    const hasChildren = node.children.length > 0;
+    const isCollapsed = hasChildren && collapsedThreadIds.has(node.thread.id);
+    rows.push({
+      thread: node.thread,
+      depth: node.depth,
+      childActivity: node.stats.childActivity,
+      hasChildren,
+      isCollapsed,
+    });
+    if (hasChildren && !isCollapsed) {
+      flattenMobileRecentNodes({
+        collapsedThreadIds,
+        items: node.children,
+        rows,
+      });
+    }
+  }
+}
+
+export function getMobileRecentAncestorIds({
+  threadId,
   threads,
-}: GetMobileRecentThreadsArgs): ThreadListEntry[] {
-  const sortedThreads = [...threads].sort(compareMobileRecentThreads);
-  if (highlightedThreadId === null) {
-    return sortedThreads.slice(0, MOBILE_RECENT_THREAD_LIMIT);
+}: {
+  threadId: string;
+  threads: readonly ThreadListEntry[];
+}): string[] {
+  const byId = new Map(threads.map((thread) => [thread.id, thread]));
+  const selected = byId.get(threadId);
+  if (selected === undefined || selected.visibility === "hidden") {
+    return [];
   }
 
-  const highlightedThread = sortedThreads.find(
-    (thread) => thread.id === highlightedThreadId,
-  );
-  if (!highlightedThread) {
-    return sortedThreads.slice(0, MOBILE_RECENT_THREAD_LIMIT);
+  const ancestorIds: string[] = [];
+  let current: ThreadListEntry | undefined = selected;
+  let remainingHops = byId.size;
+  while (current !== undefined && remainingHops > 0) {
+    const parentThreadId: string | null = current.parentThreadId;
+    if (parentThreadId === null) break;
+    const parent = byId.get(parentThreadId);
+    if (parent === undefined) break;
+    ancestorIds.push(parent.id);
+    current = parent;
+    remainingHops -= 1;
   }
+  return ancestorIds;
+}
 
-  return [
-    highlightedThread,
-    ...sortedThreads
-      .filter((thread) => thread.id !== highlightedThreadId)
-      .slice(0, MOBILE_RECENT_THREAD_LIMIT - 1),
-  ];
+export function getMobileRecentThreads({
+  collapsedThreadIds,
+  threads,
+}: GetMobileRecentThreadsArgs): MobileRecentThreadRow[] {
+  const rows: MobileRecentThreadRow[] = [];
+  flattenMobileRecentNodes({
+    collapsedThreadIds,
+    items: buildChronologicalThreadList(threads, compareMobileRecentThreads),
+    rows,
+  });
+  return rows;
 }
 
 function MobileRecentThreadRow({
   highlighted,
+  onToggleCollapsed,
   projectName,
-  thread,
+  provider,
+  row,
 }: MobileRecentThreadRowProps) {
+  const { thread, depth, childActivity, hasChildren, isCollapsed } = row;
   const threadTitle = getThreadDisplayTitle(thread);
   const isUnreadDone = isUnreadDoneThread(thread);
   const isUnreadError = isUnreadDone && thread.status === "error";
@@ -112,9 +213,42 @@ function MobileRecentThreadRow({
     isRuntimeActive: isRuntimeBusyThread(thread),
     isWorkflowActive: hasActiveWorkflowActivity(thread),
   };
-  const indicatorLabel = getThreadListIndicatorLabel(
-    resolveThreadListIndicator(indicatorState),
+  const hasHiddenChildren = hasChildren && isCollapsed;
+  const trailingIndicatorState: ThreadListIndicatorState = hasHiddenChildren
+    ? {
+        hasPendingInteraction:
+          indicatorState.hasPendingInteraction || childActivity.pending,
+        hasUnsubmittedDraft:
+          indicatorState.hasUnsubmittedDraft ||
+          childActivity.hasUnsubmittedDraft,
+        hasUnreadError:
+          indicatorState.hasUnreadError || childActivity.unreadError,
+        hasUnreadSuccess:
+          indicatorState.hasUnreadSuccess ||
+          (childActivity.unread && !childActivity.unreadError),
+        isBackgroundAgentActive:
+          indicatorState.isBackgroundAgentActive ||
+          childActivity.backgroundAgent,
+        isBackgroundCommandActive:
+          indicatorState.isBackgroundCommandActive ||
+          childActivity.backgroundCommand,
+        isGoalActive: indicatorState.isGoalActive || childActivity.goal,
+        isPlanModeActive:
+          indicatorState.isPlanModeActive || childActivity.planMode,
+        isRuntimeActive:
+          indicatorState.isRuntimeActive || childActivity.runtimeWorking,
+        isWorkflowActive:
+          indicatorState.isWorkflowActive || childActivity.workflow,
+      }
+    : indicatorState;
+  const indicatorKind = resolveThreadListIndicator(trailingIndicatorState);
+  const indicatorLabel = getThreadListIndicatorLabel(indicatorKind);
+  const metadataText = getMobileRecentThreadMetadata({ projectName, thread });
+  const workspaceIconName = getEnvironmentWorkspaceDisplayIconName(
+    thread.environmentWorkspaceDisplayKind,
   );
+  const providerIcon = getProviderIconInfo(thread.providerId, provider);
+  const ProviderMark = providerIcon?.icon;
   return (
     <li>
       {}
@@ -124,22 +258,70 @@ function MobileRecentThreadRow({
           threadId: thread.id,
         })}
         aria-label={`Open ${threadTitle}${indicatorLabel ? ` — ${indicatorLabel}` : ""}`}
+        style={{ paddingLeft: getSidebarThreadRowPaddingLeft(depth) }}
         className={cn(
-          "flex h-8 items-center gap-2 rounded-md px-2 text-sm text-foreground/85 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
+          "flex items-center gap-2.5 rounded-md pr-2 text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
+          MOBILE_RECENT_ROW_HEIGHT_CLASS,
           highlighted && "bg-surface-selected",
         )}
       >
-        <span className="flex min-w-0 flex-1 items-baseline gap-2">
-          <span className="min-w-0 truncate">{threadTitle}</span>
-          {projectName ? (
-            <span className="shrink-0 text-xs text-muted-foreground">
-              {projectName}
+        <span
+          className={cn(
+            "mt-1 flex size-7 shrink-0 items-center justify-center self-start rounded-md border border-border-seam bg-surface-raised",
+            depth > 0 && "opacity-60",
+          )}
+        >
+          {ProviderMark === undefined ? null : provider === null ? (
+            <ProviderMark className="size-4" />
+          ) : (
+            <ProviderIconMark
+              provider={provider}
+              icon={ProviderMark}
+              className="size-4"
+            />
+          )}
+        </span>
+        <span className="min-w-0 flex-1 space-y-0.5">
+          <span className="flex min-w-0 items-center gap-1.5">
+            <span
+              className={cn(
+                "min-w-0 truncate font-medium",
+                COARSE_POINTER_TEXT_BASE_CLASS,
+              )}
+            >
+              {threadTitle}
             </span>
-          ) : null}
+            {hasChildren ? (
+              <SidebarChildToggleChevron
+                isCollapsed={isCollapsed}
+                expandLabel={`Show threads under ${threadTitle}`}
+                collapseLabel={`Hide threads under ${threadTitle}`}
+                onToggle={() => onToggleCollapsed(thread.id)}
+              />
+            ) : null}
+          </span>
+          <span
+            className={cn(
+              "flex min-w-0 items-center gap-1.5 leading-4 text-muted-foreground",
+              COARSE_POINTER_TEXT_SM_CLASS,
+            )}
+            title={metadataText}
+          >
+            {workspaceIconName ? (
+              <Icon
+                name={workspaceIconName}
+                className="size-3.5 shrink-0"
+                aria-hidden="true"
+              />
+            ) : null}
+            <span className="min-w-0 truncate">{metadataText}</span>
+          </span>
         </span>
-        <span className="flex size-6 shrink-0 items-center justify-center">
-          <ThreadStatusGlyph {...indicatorState} />
-        </span>
+        {indicatorKind !== "none" ? (
+          <span className="flex size-6 shrink-0 items-center justify-center">
+            <ThreadStatusGlyph {...indicatorState} />
+          </span>
+        ) : null}
       </RouteAnchor>
     </li>
   );
@@ -148,12 +330,42 @@ function MobileRecentThreadRow({
 export function RootComposeMobileRecents({
   highlightedThreadId,
   projectNamesById,
+  providersById,
   showCreatingRow,
   threads,
 }: RootComposeMobileRecentsProps) {
+  const [collapsedThreadIdList, setCollapsedThreadIdList] = useAtom(
+    collapsedThreadIdsAtom,
+  );
+  const collapsedThreadIds = useMemo(
+    () => new Set(collapsedThreadIdList),
+    [collapsedThreadIdList],
+  );
+  const toggleCollapsed = useCallback(
+    (threadId: string) => {
+      setCollapsedThreadIdList((current) =>
+        current.includes(threadId)
+          ? current.filter((id) => id !== threadId)
+          : [...current, threadId],
+      );
+    },
+    [setCollapsedThreadIdList],
+  );
+  useEffect(() => {
+    if (highlightedThreadId === null) return;
+    const ancestorIds = getMobileRecentAncestorIds({
+      threadId: highlightedThreadId,
+      threads,
+    });
+    if (ancestorIds.length === 0) return;
+    setCollapsedThreadIdList((current) => {
+      const next = current.filter((id) => !ancestorIds.includes(id));
+      return next.length === current.length ? current : next;
+    });
+  }, [highlightedThreadId, setCollapsedThreadIdList, threads]);
   const recentThreads = useMemo(
-    () => getMobileRecentThreads({ highlightedThreadId, threads }),
-    [highlightedThreadId, threads],
+    () => getMobileRecentThreads({ collapsedThreadIds, threads }),
+    [collapsedThreadIds, threads],
   );
 
   if (!showCreatingRow && recentThreads.length === 0) {
@@ -164,20 +376,24 @@ export function RootComposeMobileRecents({
     <section
       data-root-compose-mobile-recents=""
       aria-labelledby="root-compose-mobile-recents"
-      className="mt-4 md:hidden"
+      className="md:hidden"
     >
-      <div className="mb-1 px-2">
+      <div className="sticky top-0 z-10 mb-1 bg-background px-2">
         <h2
           id="root-compose-mobile-recents"
           className={CHROME_SECTION_LABEL_CLASS}
         >
           Recent
         </h2>
+        <OverflowFade placement="below" tone="background" size="sm" />
       </div>
       {showCreatingRow ? (
         <div
           role="status"
-          className="flex h-8 items-center gap-2 rounded-md px-2 text-sm text-muted-foreground"
+          className={cn(
+            "flex items-center gap-2.5 rounded-md px-2 text-sm text-muted-foreground",
+            MOBILE_RECENT_ROW_HEIGHT_CLASS,
+          )}
         >
           <span className="min-w-0 flex-1 truncate">Creating thread</span>
           <span className="flex size-6 shrink-0 items-center justify-center">
@@ -195,16 +411,18 @@ export function RootComposeMobileRecents({
       ) : null}
       {recentThreads.length > 0 ? (
         <ul className="space-y-px">
-          {recentThreads.map((thread) => (
+          {recentThreads.map((row) => (
             <MobileRecentThreadRow
-              key={thread.id}
-              highlighted={thread.id === highlightedThreadId}
+              key={row.thread.id}
+              highlighted={row.thread.id === highlightedThreadId}
+              onToggleCollapsed={toggleCollapsed}
+              provider={providersById.get(row.thread.providerId) ?? null}
               projectName={
-                isProjectlessProjectId(thread.projectId)
+                isProjectlessProjectId(row.thread.projectId)
                   ? null
-                  : (projectNamesById.get(thread.projectId) ?? null)
+                  : (projectNamesById.get(row.thread.projectId) ?? null)
               }
-              thread={thread}
+              row={row}
             />
           ))}
         </ul>

--- a/apps/app/src/views/RootComposeMobileRecents.tsx
+++ b/apps/app/src/views/RootComposeMobileRecents.tsx
@@ -250,8 +250,13 @@ function MobileRecentThreadRow({
   const providerIcon = getProviderIconInfo(thread.providerId, provider);
   const ProviderMark = providerIcon?.icon;
   return (
-    <li>
-      {}
+    <li
+      className={cn(
+        "flex items-center rounded-md pr-2",
+        MOBILE_RECENT_ROW_HEIGHT_CLASS,
+        highlighted && "bg-surface-selected",
+      )}
+    >
       <RouteAnchor
         href={getThreadRoutePath({
           projectId: thread.projectId,
@@ -260,9 +265,8 @@ function MobileRecentThreadRow({
         aria-label={`Open ${threadTitle}${indicatorLabel ? ` — ${indicatorLabel}` : ""}`}
         style={{ paddingLeft: getSidebarThreadRowPaddingLeft(depth) }}
         className={cn(
-          "flex items-center gap-2.5 rounded-md pr-2 text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
+          "flex min-w-0 flex-1 items-center gap-2.5 rounded-md text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
           MOBILE_RECENT_ROW_HEIGHT_CLASS,
-          highlighted && "bg-surface-selected",
         )}
       >
         <span
@@ -291,14 +295,6 @@ function MobileRecentThreadRow({
             >
               {threadTitle}
             </span>
-            {hasChildren ? (
-              <SidebarChildToggleChevron
-                isCollapsed={isCollapsed}
-                expandLabel={`Show threads under ${threadTitle}`}
-                collapseLabel={`Hide threads under ${threadTitle}`}
-                onToggle={() => onToggleCollapsed(thread.id)}
-              />
-            ) : null}
           </span>
           <span
             className={cn(
@@ -319,10 +315,18 @@ function MobileRecentThreadRow({
         </span>
         {indicatorKind !== "none" ? (
           <span className="flex size-6 shrink-0 items-center justify-center">
-            <ThreadStatusGlyph {...indicatorState} />
+            <ThreadStatusGlyph {...trailingIndicatorState} />
           </span>
         ) : null}
       </RouteAnchor>
+      {hasChildren ? (
+        <SidebarChildToggleChevron
+          isCollapsed={isCollapsed}
+          expandLabel={`Show threads under ${threadTitle}`}
+          collapseLabel={`Hide threads under ${threadTitle}`}
+          onToggle={() => onToggleCollapsed(thread.id)}
+        />
+      ) : null}
     </li>
   );
 }

--- a/apps/app/src/views/RootComposeMobileRecents.tsx
+++ b/apps/app/src/views/RootComposeMobileRecents.tsx
@@ -36,7 +36,7 @@ import { getEnvironmentWorkspaceDisplayIconName } from "@/lib/environment-worksp
 import { getProviderIconInfo } from "@/lib/provider-icon";
 import { ProviderIconMark } from "@/components/settings/ProviderIconMark";
 import { cn } from "@bb/shared-ui/lib/utils";
-import { usePromptDraftHasInput } from "@/hooks/usePromptDraftStorage";
+import { usePromptDraftInputThreadIds } from "@/hooks/usePromptDraftStorage";
 import { collapsedThreadIdsAtom } from "@/components/sidebar/sidebarCollapsedAtoms";
 
 export const MOBILE_RECENT_ROW_HEIGHT_PX = 60;
@@ -51,6 +51,7 @@ type ThreadListEntryComparator = (
 
 interface GetMobileRecentThreadsArgs {
   collapsedThreadIds: ReadonlySet<string>;
+  draftThreadIds: ReadonlySet<string>;
   threads: readonly ThreadListEntry[];
 }
 
@@ -109,16 +110,19 @@ export interface MobileRecentThreadRow {
   thread: ThreadListEntry;
   depth: number;
   childActivity: CollapsedChildActivity;
+  hasUnsubmittedDraft: boolean;
   hasChildren: boolean;
   isCollapsed: boolean;
 }
 
 function flattenMobileRecentNodes({
   collapsedThreadIds,
+  draftThreadIds,
   items,
   rows,
 }: {
   collapsedThreadIds: ReadonlySet<string>;
+  draftThreadIds: ReadonlySet<string>;
   items: readonly ProjectThreadItem[];
   rows: MobileRecentThreadRow[];
 }): void {
@@ -131,12 +135,14 @@ function flattenMobileRecentNodes({
       thread: node.thread,
       depth: node.depth,
       childActivity: node.stats.childActivity,
+      hasUnsubmittedDraft: draftThreadIds.has(node.thread.id),
       hasChildren,
       isCollapsed,
     });
     if (hasChildren && !isCollapsed) {
       flattenMobileRecentNodes({
         collapsedThreadIds,
+        draftThreadIds,
         items: node.children,
         rows,
       });
@@ -174,12 +180,18 @@ export function getMobileRecentAncestorIds({
 
 export function getMobileRecentThreads({
   collapsedThreadIds,
+  draftThreadIds,
   threads,
 }: GetMobileRecentThreadsArgs): MobileRecentThreadRow[] {
   const rows: MobileRecentThreadRow[] = [];
   flattenMobileRecentNodes({
     collapsedThreadIds,
-    items: buildChronologicalThreadList(threads, compareMobileRecentThreads),
+    draftThreadIds,
+    items: buildChronologicalThreadList(
+      threads,
+      compareMobileRecentThreads,
+      draftThreadIds,
+    ),
     rows,
   });
   return rows;
@@ -192,15 +204,17 @@ function MobileRecentThreadRow({
   provider,
   row,
 }: MobileRecentThreadRowProps) {
-  const { thread, depth, childActivity, hasChildren, isCollapsed } = row;
+  const {
+    thread,
+    depth,
+    childActivity,
+    hasUnsubmittedDraft,
+    hasChildren,
+    isCollapsed,
+  } = row;
   const threadTitle = getThreadDisplayTitle(thread);
   const isUnreadDone = isUnreadDoneThread(thread);
   const isUnreadError = isUnreadDone && thread.status === "error";
-  const hasUnsubmittedDraft = usePromptDraftHasInput({
-    kind: "thread",
-    projectId: thread.projectId,
-    threadId: thread.id,
-  });
   const indicatorState: ThreadListIndicatorState = {
     hasPendingInteraction: thread.hasPendingInteraction,
     hasUnsubmittedDraft,
@@ -345,6 +359,7 @@ export function RootComposeMobileRecents({
     () => new Set(collapsedThreadIdList),
     [collapsedThreadIdList],
   );
+  const draftThreadIds = usePromptDraftInputThreadIds(threads);
   const toggleCollapsed = useCallback(
     (threadId: string) => {
       setCollapsedThreadIdList((current) =>
@@ -368,8 +383,13 @@ export function RootComposeMobileRecents({
     });
   }, [highlightedThreadId, setCollapsedThreadIdList, threads]);
   const recentThreads = useMemo(
-    () => getMobileRecentThreads({ collapsedThreadIds, threads }),
-    [collapsedThreadIds, threads],
+    () =>
+      getMobileRecentThreads({
+        collapsedThreadIds,
+        draftThreadIds,
+        threads,
+      }),
+    [collapsedThreadIds, draftThreadIds, threads],
   );
 
   if (!showCreatingRow && recentThreads.length === 0) {

--- a/apps/app/src/views/RootComposeMobileRecents.tsx
+++ b/apps/app/src/views/RootComposeMobileRecents.tsx
@@ -267,7 +267,7 @@ function MobileRecentThreadRow({
       >
         <span
           className={cn(
-            "mt-1 flex size-7 shrink-0 items-center justify-center self-start rounded-md border border-border-seam bg-surface-raised",
+            "flex size-7 shrink-0 items-center justify-center rounded-md border border-border-seam bg-surface-raised",
             depth > 0 && "opacity-60",
           )}
         >

--- a/apps/app/src/views/RootComposeSecondaryContent.test.tsx
+++ b/apps/app/src/views/RootComposeSecondaryContent.test.tsx
@@ -196,6 +196,7 @@ function renderRootCompose(args: RenderRootComposeArgs) {
       isCompactViewport={renderArgs.isCompactViewport}
     >
       <RootComposeSecondaryContent
+        compactScrollContent={null}
         isSecondaryPanelOpen={renderArgs.isSecondaryPanelOpen}
         onToggleSecondaryPanel={() => undefined}
         secondaryPanel={createSecondaryPanel(renderArgs.isSecondaryPanelOpen)}
@@ -215,6 +216,7 @@ function renderRootCompose(args: RenderRootComposeArgs) {
           isCompactViewport={renderArgs.isCompactViewport}
         >
           <RootComposeSecondaryContent
+            compactScrollContent={null}
             isSecondaryPanelOpen={renderArgs.isSecondaryPanelOpen}
             onToggleSecondaryPanel={() => undefined}
             secondaryPanel={createSecondaryPanel(

--- a/apps/app/src/views/RootComposeSecondaryContent.tsx
+++ b/apps/app/src/views/RootComposeSecondaryContent.tsx
@@ -1,4 +1,5 @@
 import { useState, type ComponentProps, type ReactNode } from "react";
+import { useIsCompactViewport } from "@bb/shared-ui/hooks/use-compact-viewport";
 import { Skeleton } from "@bb/shared-ui/skeleton";
 import { COARSE_POINTER_HEADER_ICON_BUTTON_CLASS } from "@bb/shared-ui/coarse-pointer-sizing";
 import { cn } from "@bb/shared-ui/lib/utils";
@@ -14,6 +15,7 @@ import {
   MACOS_WINDOW_DRAG_CLASS,
   shouldUseMacosDesktopChrome,
 } from "@/lib/bb-desktop";
+import { RootComposeCompactHome } from "./RootComposeCompactHome";
 import { useOptionalPaneContext } from "./thread-detail/PaneContext";
 
 const ROOT_COMPOSE_MAX_WIDTH_CLASS = "max-w-[760px]";
@@ -40,6 +42,7 @@ type RootSecondaryPanelProps = Omit<
 
 interface RootComposeSecondaryContentProps {
   children: ReactNode;
+  compactScrollContent: ReactNode;
   contentClassName?: string;
   isSecondaryPanelOpen: boolean;
   onToggleSecondaryPanel: () => void;
@@ -61,6 +64,7 @@ function DrawerPanelLoadingSkeleton() {
 
 export function RootComposeSecondaryContent({
   children,
+  compactScrollContent,
   contentClassName,
   isSecondaryPanelOpen,
   onToggleSecondaryPanel,
@@ -74,6 +78,9 @@ export function RootComposeSecondaryContent({
   const rendersWindowDragStrip =
     usesDesktopChrome && paneContext?.isTopRow !== false;
   const { renderBrowserDeck, ...threadSecondaryPanelProps } = secondaryPanel;
+  const isCompactViewport = useIsCompactViewport();
+  const usesCompactHomeLayout =
+    isCompactViewport && compactScrollContent !== null;
 
   const mainContent = (
     <div className="relative flex h-full min-h-0 flex-1 flex-col overflow-hidden">
@@ -100,19 +107,32 @@ export function RootComposeSecondaryContent({
           ) : null}
         </div>
       ) : null}
-      <div className="@container/page min-h-0 flex-1 overflow-y-auto">
+      {usesCompactHomeLayout ? (
         <div
-          className={cn(
-            "mx-auto flex w-full flex-col px-4 pb-4 pt-2",
-            ROOT_COMPOSE_MAX_WIDTH_CLASS,
-            contentClassName,
-          )}
+          className="@container/page flex min-h-0 flex-1 flex-col"
           style={PAGE_SHELL_CONTENT_STYLE}
         >
-          {children}
-          <PluginHomepageSections />
+          <RootComposeCompactHome composer={children}>
+            {compactScrollContent}
+            <PluginHomepageSections />
+          </RootComposeCompactHome>
         </div>
-      </div>
+      ) : (
+        <div className="@container/page min-h-0 flex-1 overflow-y-auto">
+          <div
+            className={cn(
+              "mx-auto flex w-full flex-col px-4 pb-4 pt-2",
+              ROOT_COMPOSE_MAX_WIDTH_CLASS,
+              contentClassName,
+            )}
+            style={PAGE_SHELL_CONTENT_STYLE}
+          >
+            {children}
+            {compactScrollContent}
+            <PluginHomepageSections />
+          </div>
+        </div>
+      )}
     </div>
   );
 

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -1,11 +1,15 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
-import { findCachedProviderInfo } from "@/hooks/queries/system-queries";
+import {
+  findCachedProviderInfo,
+  useSystemProviders,
+} from "@/hooks/queries/system-queries";
 import {
   findLocalPathProjectSourceForHost,
   type EnvironmentStatus,
   type Host,
+  type ProviderInfo,
   type ReasoningLevel,
   type ServiceTier,
   type ThreadListEntry,
@@ -809,6 +813,14 @@ function RootComposeSurface({
     () => buildMobileRecentThreads({ sidebarNavigation }),
     [sidebarNavigation],
   );
+  const systemProviders = useSystemProviders().data;
+  const mobileRecentProvidersById = useMemo(() => {
+    const byId = new Map<string, ProviderInfo>();
+    for (const provider of systemProviders ?? []) {
+      byId.set(provider.id, provider);
+    }
+    return byId;
+  }, [systemProviders]);
   const mobileRecentProjectNamesById = useMemo(() => {
     const namesById = new Map<string, string>();
     if (!sidebarNavigation) return namesById;
@@ -870,13 +882,13 @@ function RootComposeSurface({
     [activeFixedSecondaryTab, isPersistedSecondaryPanelOpen],
   );
   const activeFixedSecondaryTabId = activeFixedSecondaryTab?.id ?? null;
-  const renderSecondaryPanelAsDrawer = useIsCompactViewport();
+  const isCompactViewport = useIsCompactViewport();
   const secondaryPanelDrawerVisibility =
     useThreadSecondaryPanelDrawerVisibility({
-      isCompactViewport: renderSecondaryPanelAsDrawer,
+      isCompactViewport,
       threadId: ROOT_COMPOSE_FIXED_PANEL_STATE_ID,
     });
-  const isSecondaryPanelOpen = renderSecondaryPanelAsDrawer
+  const isSecondaryPanelOpen = isCompactViewport
     ? secondaryPanelDrawerVisibility.isDrawerVisible
     : isPersistedSecondaryPanelOpen;
   const touchFixedPanelTabsState = useTouchFixedPanelTabsState(
@@ -1118,7 +1130,7 @@ function RootComposeSurface({
   } = useThreadSecondaryPanelVisibility({
     closePersistedPanel: closeRootSecondaryPanel,
     drawerVisibility: secondaryPanelDrawerVisibility,
-    isCompactViewport: renderSecondaryPanelAsDrawer,
+    isCompactViewport,
     isPersistedOpen: isPersistedSecondaryPanelOpen,
     openPersistedCommitDiff: () => undefined,
     openPersistedDiffFile: () => undefined,
@@ -1892,6 +1904,7 @@ function RootComposeSurface({
   const promptBox = renderPromptBox({
     id: "root-compose-prompt",
     autoFocus: !isProviderCliVersionBlocked,
+    allowSoftKeyboardAutoFocus: isCompactViewport,
     banner: promptBanner,
     header: promptHeader,
     blockedReason: isProviderCliVersionBlocked
@@ -1940,6 +1953,17 @@ function RootComposeSurface({
                   ? ROOT_COMPOSE_EMPTY_WELCOME_CONTENT_CLASS
                   : ROOT_COMPOSE_SIDEBAR_ACTION_ALIGNED_TOP_PADDING_CLASS
               }
+              compactScrollContent={
+                showEmptyWelcome ? null : (
+                  <RootComposeMobileRecents
+                    highlightedThreadId={lastCreatedThreadId}
+                    projectNamesById={mobileRecentProjectNamesById}
+                    providersById={mobileRecentProvidersById}
+                    showCreatingRow={isSubmitting}
+                    threads={mobileRecentThreads}
+                  />
+                )
+              }
               isSecondaryPanelOpen={isSecondaryPanelOpen}
               onToggleSecondaryPanel={handleToggleSecondaryPanel}
               secondaryPanel={{
@@ -1977,15 +2001,7 @@ function RootComposeSurface({
                   }
                 />
               ) : (
-                <>
-                  {promptBox}
-                  <RootComposeMobileRecents
-                    highlightedThreadId={lastCreatedThreadId}
-                    projectNamesById={mobileRecentProjectNamesById}
-                    showCreatingRow={isSubmitting}
-                    threads={mobileRecentThreads}
-                  />
-                </>
+                promptBox
               )}
             </RootComposeSecondaryContent>
           </AppNavigationHostProvider>

--- a/apps/app/src/views/mobile-home-story-fixtures.tsx
+++ b/apps/app/src/views/mobile-home-story-fixtures.tsx
@@ -1,0 +1,244 @@
+import { useState, type ReactNode } from "react";
+import type { PromptTextMention, ThreadListEntry } from "@bb/domain";
+import {
+  NewThreadPromptBoxUI,
+  type NewThreadBranchConfig,
+  type NewThreadEnvironmentConfig,
+  type NewThreadModeConfig,
+  type NewThreadProjectConfig,
+  type NewThreadWorktreeConfig,
+} from "@/components/promptbox/NewThreadPromptBox";
+import { ModelPickerStoryQueryProvider } from "../../.ladle/model-picker-query-provider";
+import {
+  HOST_IDS,
+  PROJECT_IDS,
+  PROJECT_NAMES,
+  STORY_BRANCH_OPTIONS,
+  STORY_CLAUDE_CODE_PROVIDER_ID,
+  STORY_CURSOR_PROVIDER_ID,
+  STORY_PROVIDERS_BY_ID,
+  STORY_PROJECTS,
+  STORY_PROJECT_SOURCES,
+  STORY_WORKTREE_OPTIONS,
+  makeAttachmentsConfig,
+  makeExecutionControlsProps,
+  makeHost,
+  makeThreadListEntry,
+  makeTypeaheadConfig,
+} from "../../.ladle/story-fixtures";
+import { RootComposeCompactHome } from "./RootComposeCompactHome";
+import { RootComposeMobileRecents } from "./RootComposeMobileRecents";
+
+export const projectNamesById = new Map<string, string>([
+  [PROJECT_IDS.bb, PROJECT_NAMES.bb],
+  [PROJECT_IDS.pierre, PROJECT_NAMES.pierre],
+]);
+
+export const HOME_THREADS: ThreadListEntry[] = [
+  makeThreadListEntry({
+    id: "thr_home_parent",
+    title: "Rework folder model",
+    titleFallback: "Rework folder model",
+    latestAttentionAt: 900,
+  }),
+  makeThreadListEntry({
+    id: "thr_home_child_a",
+    parentThreadId: "thr_home_parent",
+    providerId: STORY_CLAUDE_CODE_PROVIDER_ID,
+    title: "Audit folder query paths",
+    titleFallback: "Audit folder query paths",
+    latestAttentionAt: 880,
+  }),
+  makeThreadListEntry({
+    id: "thr_home_child_b",
+    parentThreadId: "thr_home_parent",
+    providerId: STORY_CURSOR_PROVIDER_ID,
+    title: "Migrate folder fixtures",
+    titleFallback: "Migrate folder fixtures",
+    latestAttentionAt: 870,
+  }),
+  makeThreadListEntry({
+    id: "thr_home_style",
+    providerId: STORY_CLAUDE_CODE_PROVIDER_ID,
+    title: "Reduce style recalculation",
+    titleFallback: "Reduce style recalculation",
+    status: "starting",
+    latestAttentionAt: 860,
+    runtime: { displayStatus: "starting", hostReconnectGraceExpiresAt: null },
+  }),
+  makeThreadListEntry({
+    id: "thr_home_automations",
+    title: "Wire up automations CLI",
+    titleFallback: "Wire up automations CLI",
+    latestAttentionAt: 850,
+  }),
+  makeThreadListEntry({
+    id: "thr_home_daemon",
+    projectId: PROJECT_IDS.pierre,
+    providerId: STORY_CURSOR_PROVIDER_ID,
+    title: "Debug host daemon reconnect",
+    titleFallback: "Debug host daemon reconnect",
+    latestAttentionAt: 840,
+  }),
+  makeThreadListEntry({
+    id: "thr_home_theme",
+    title: "Ship theme preview panel",
+    titleFallback: "Ship theme preview panel",
+    latestAttentionAt: 830,
+  }),
+  makeThreadListEntry({
+    id: "thr_home_sidebar",
+    providerId: STORY_CLAUDE_CODE_PROVIDER_ID,
+    title: "Trim sidebar re-renders",
+    titleFallback: "Trim sidebar re-renders",
+    latestAttentionAt: 820,
+  }),
+  makeThreadListEntry({
+    id: "thr_home_release",
+    title: "Draft release notes",
+    titleFallback: "Draft release notes",
+    latestAttentionAt: 810,
+  }),
+  makeThreadListEntry({
+    id: "thr_home_keyboard",
+    projectId: PROJECT_IDS.pierre,
+    title: "Fix mobile keyboard inset",
+    titleFallback: "Fix mobile keyboard inset",
+    latestAttentionAt: 800,
+  }),
+];
+
+export const MOBILE_RECENTS_VISIBILITY_CLASS = "bb-mobile-story-stage";
+
+const noop = () => {};
+
+const storyEnvironment: NewThreadEnvironmentConfig = {
+  value: `host:${HOST_IDS.local}:local`,
+  onChange: noop,
+  sources: STORY_PROJECT_SOURCES,
+  host: makeHost({ id: HOST_IDS.local }),
+  isLocal: true,
+};
+
+const storyBranch: NewThreadBranchConfig = {
+  value: null,
+  currentBranch: "main",
+  isNew: false,
+  options: STORY_BRANCH_OPTIONS,
+  loading: false,
+  currentOptionLabel: "Current: main",
+  placeholder: "Current checkout",
+  triggerLabel: "Current (main)",
+  triggerTitle: "Current: main",
+  onChange: noop,
+  onClear: noop,
+  onCreate: noop,
+};
+
+const storyWorktree: NewThreadWorktreeConfig = {
+  options: STORY_WORKTREE_OPTIONS,
+  value: null,
+  onChange: noop,
+};
+
+const storyProject: NewThreadProjectConfig = {
+  projects: STORY_PROJECTS,
+  value: PROJECT_IDS.bb,
+  onChange: noop,
+};
+
+const storyModeConfig = {
+  environment: storyEnvironment,
+  branch: storyBranch,
+  worktree: storyWorktree,
+  permission: {
+    value: "auto",
+    options: [
+      { value: "accept-edits", label: "Accept Edits" },
+      { value: "auto", label: "Approve for me" },
+      { value: "full", label: "Full Access", tone: "warning" },
+    ],
+    onChange: noop,
+    supported: true,
+  },
+} satisfies NewThreadModeConfig;
+
+const storyExecution = makeExecutionControlsProps();
+
+export function MobileRecentsVisibilityStyle() {
+  return (
+    <style>{`
+      @media (min-width: 768px) {
+        .${MOBILE_RECENTS_VISIBILITY_CLASS} [data-root-compose-mobile-recents] {
+          display: block;
+        }
+      }
+    `}</style>
+  );
+}
+
+export function StoryComposer() {
+  const [value, setValue] = useState("");
+  const [mentionRanges, setMentionRanges] = useState<PromptTextMention[]>([]);
+  return (
+    <ModelPickerStoryQueryProvider>
+      <NewThreadPromptBoxUI
+        id="story-compact-home-composer"
+        value={value}
+        mentionRanges={mentionRanges}
+        onChange={(nextValue, nextMentionRanges) => {
+          setValue(nextValue);
+          setMentionRanges(nextMentionRanges);
+        }}
+        onSubmit={noop}
+        isSubmitting={false}
+        disabled={false}
+        history={{
+          currentDraft: { text: "", mentions: [], attachments: [] },
+          entries: [],
+          onSelectEntry: noop,
+        }}
+        typeahead={makeTypeaheadConfig()}
+        attachments={makeAttachmentsConfig()}
+        modeConfig={storyModeConfig}
+        project={storyProject}
+        execution={storyExecution}
+      />
+    </ModelPickerStoryQueryProvider>
+  );
+}
+
+export function HomeRecents({ threads }: { threads: ThreadListEntry[] }) {
+  return (
+    <RootComposeMobileRecents
+      highlightedThreadId={null}
+      projectNamesById={projectNamesById}
+      providersById={STORY_PROVIDERS_BY_ID}
+      showCreatingRow={false}
+      threads={threads}
+    />
+  );
+}
+
+export function CompactHomePage({
+  threads = HOME_THREADS,
+}: {
+  threads?: ThreadListEntry[];
+}) {
+  return (
+    <RootComposeCompactHome composer={<StoryComposer />}>
+      <HomeRecents threads={threads} />
+    </RootComposeCompactHome>
+  );
+}
+
+export function PhoneFrame({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className={`${MOBILE_RECENTS_VISIBILITY_CLASS} flex h-[852px] w-[393px] min-h-0 flex-col overflow-hidden rounded-xl border border-border bg-background`}
+    >
+      <MobileRecentsVisibilityStyle />
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
## Human comments

## What was wrong

The compact New Thread page placed a capped three-row Recent list below the composer in one page scroller. The composer moved away from the thumb, the list looked complete even when more work existed, and rows omitted provider, hierarchy, workspace, branch, and activity context.

## What changed

- Anchor the production composer at the bottom while realistic recents scroll behind it.
- Leave the recents viewport on native overflow behavior; the imperceptible product-managed scrollbar timer and state were removed.
- Keep the `Recent` label sticky and leave a partial row visible to signal more content.
- Render every active thread with production provider marks, hierarchy, status, workspace, branch, and attention-time metadata.
- Vertically center each provider tile against its thread title and metadata block.
- Preserve highlighted descendants by expanding collapsed ancestors.
- Render the real production compact-home, recents, prompt box, and overflow-fade components in Ladle with populated fixtures.

No compact drawer, panel, route-feedback, or server-cache behavior changes in this layer.

## How you verified

- Original geometry and alignment evidence used Chrome for Testing 151.0.7922.71 at 393×852 CSS px, DPR 2, against exact base `f4bbc2fe81a9b7639ff9a7396e172bddd89109e4` and feature head `df613809d7080cbc145913355958478de5733245`. The current exact head is `0eb3bef25c3589f2b3f40cdcb80b20cff131512a`.
- Measured the production compact-home subtree itself: 393×852; production composer subtree: y=672, h=180; scroll viewport: y=318, h=534; 23 production recent rows rendered.
- Measured provider-tile center alignment on representative parent, child, and ordinary rows: the prior head placed every tile 12px above its title/metadata center; the final head measures 0px center delta before and after client navigation.
- Hard reload and thread navigation back to the compact home preserved the alignment; no console errors.
- Scrolled that viewport to 360px and measured the `Recent` heading at y=318, exactly pinned to the viewport's top edge.
- On the exact current head, the viewport has no product scroll listener, idle timeout, `data-scrollbar-scrolling` state, or `transient-scrollbar` class; the browser owns scrollbar presentation.
- Verified collapsed parents whose only activity came from a child: the glyph and accessible label report the same aggregated state. Child-only pending, plan, runtime, and unsubmitted-draft states have regression coverage.
- On the exact current head, a realistic hidden child draft produced `Thread has unsubmitted draft` on both the parent link and production status glyph; the child stayed collapsed and the recents subtree contained zero nested interactive pairs.
- The hierarchy toggle is now a sibling of the thread link; the production recents subtree contained zero nested `a button` or `button a` pairs.
- Compact-home geometry now uses `useLayoutEffect`, not `useEffect`. Across 143 requestAnimationFrame samples from first real content, the scroll viewport stayed at y=310 with no post-paint geometry jump.
- Remote CI passed all required tests, checks, package smokes, and version gates on the exact final head. No local CI-equivalent command was run.

<table>
  <tr>
    <th>Before — <code>main</code></th>
    <th>After — compact production home</th>
  </tr>
  <tr>
    <td><img src="https://gist.githubusercontent.com/brsbl/d8363c420a5e5c2167498079a27162f0/raw/5904f796578a5112b80ec007db7176bfd8fb83d4/layer1-before.svg" width="393" alt="Before: main compact home" /></td>
    <td><img src="https://gist.githubusercontent.com/brsbl/d8363c420a5e5c2167498079a27162f0/raw/234f625398536ff1b4dc4af74c1027698d99cfa0/pr2758-after-scrollbar-removal.svg" width="393" alt="Exact final head: compact production home after removing imperceptible scrollbar bookkeeping" /></td>
  </tr>
  <tr>
    <th colspan="2">After — sticky header while scrolled</th>
  </tr>
  <tr>
    <td colspan="2" align="center"><img src="https://gist.githubusercontent.com/brsbl/d8363c420a5e5c2167498079a27162f0/raw/f3574205a70ba781f588d9ac17fc9fd703a34610/pr2758-sticky.svg" width="393" alt="After: Recent header remains sticky after scrolling" /></td>
  </tr>
</table>

### Child-only draft aggregation

| Feature head `62c4c6d40` — collapsed parent reflects its hidden child draft |
| --- |
| <img src="https://gist.githubusercontent.com/brsbl/d8363c420a5e5c2167498079a27162f0/raw/9add1f52c7d662561b0f93eba3f8733d0574835a/pr2758-child-draft-final-head.svg" width="393" alt="Feature head: production compact recents show a draft glyph on a collapsed parent whose hidden child owns the draft" /> |

BB-Thread-ID: thr_wftu7bh9ez

> AGENT GENERATED


