### PR TITLE
Make deferred mobile navigation feel immediate

### DIFF
--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -10,6 +10,7 @@ import { AppLayout } from "./components/layout/AppLayout";
 import { AuthCallbackView } from "./views/AuthCallbackView";
 import { QuickCreateProjectProvider } from "./hooks/useQuickCreateProject";
 import { RouteNavigationProvider } from "./components/ui/app-route-anchor";
+import { RouteNavigationIndicator } from "./components/ui/route-navigation-indicator";
 import { AppNavigationUrlHost } from "./lib/url-open-routing";
 import { NativeShellReporter } from "./lib/native-shell";
 import { AppFileExternalNavigationHost } from "./components/plugin/AppFileExternalNavigationHost";
@@ -339,6 +340,7 @@ export function App() {
     <QuickCreateProjectProvider>
       <AppCommandProvider>
         <RouteNavigationProvider>
+          <RouteNavigationIndicator />
           <AppNavigationUrlHost>
             <AppFileExternalNavigationHost>
               <HashNavigationScroll />

--- a/apps/app/src/components/plugin/management/AddPluginDialog.tsx
+++ b/apps/app/src/components/plugin/management/AddPluginDialog.tsx
@@ -335,7 +335,7 @@ function AddPluginDialogContent({
             role="progressbar"
             aria-label="Installing plugin"
           >
-            <div className="h-full w-1/3 animate-plugin-install-progress rounded-full bg-muted-foreground" />
+            <div className="h-full w-1/3 animate-indeterminate-progress rounded-full bg-muted-foreground" />
           </div>
         ) : (
           <FullTrustWarning />

--- a/apps/app/src/components/ui/route-navigation-indicator.test.tsx
+++ b/apps/app/src/components/ui/route-navigation-indicator.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  ROUTE_NAVIGATION_INDICATOR_MIN_VISIBLE_MS,
+  ROUTE_NAVIGATION_INDICATOR_REVEAL_DELAY_MS,
+  useDelayedBusyIndicator,
+} from "./route-navigation-indicator";
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+function Probe({ busy }: { busy: boolean }) {
+  const visible = useDelayedBusyIndicator(busy);
+  return <div data-testid="probe">{visible ? "visible" : "hidden"}</div>;
+}
+
+function state(): string {
+  return screen.getByTestId("probe").textContent ?? "";
+}
+
+function advance(ms: number) {
+  act(() => {
+    vi.advanceTimersByTime(ms);
+  });
+}
+
+describe("useDelayedBusyIndicator", () => {
+  it("stays hidden for navigations that resolve before the reveal delay", () => {
+    vi.useFakeTimers();
+    const view = render(<Probe busy />);
+
+    advance(ROUTE_NAVIGATION_INDICATOR_REVEAL_DELAY_MS - 20);
+    expect(state()).toBe("hidden");
+
+    view.rerender(<Probe busy={false} />);
+    advance(1000);
+    expect(state()).toBe("hidden");
+  });
+
+  it("reveals once a navigation outlasts the delay", () => {
+    vi.useFakeTimers();
+    render(<Probe busy />);
+
+    expect(state()).toBe("hidden");
+    advance(ROUTE_NAVIGATION_INDICATOR_REVEAL_DELAY_MS);
+    expect(state()).toBe("visible");
+  });
+
+  it("holds the revealed indicator long enough to avoid a flash", () => {
+    vi.useFakeTimers();
+    const view = render(<Probe busy />);
+
+    advance(ROUTE_NAVIGATION_INDICATOR_REVEAL_DELAY_MS);
+    expect(state()).toBe("visible");
+
+    view.rerender(<Probe busy={false} />);
+    advance(ROUTE_NAVIGATION_INDICATOR_MIN_VISIBLE_MS - 20);
+    expect(state()).toBe("visible");
+
+    advance(40);
+    expect(state()).toBe("hidden");
+  });
+
+  it("hides immediately when the minimum visible window already elapsed", () => {
+    vi.useFakeTimers();
+    const view = render(<Probe busy />);
+
+    advance(ROUTE_NAVIGATION_INDICATOR_REVEAL_DELAY_MS);
+    advance(ROUTE_NAVIGATION_INDICATOR_MIN_VISIBLE_MS + 100);
+    expect(state()).toBe("visible");
+
+    view.rerender(<Probe busy={false} />);
+    advance(0);
+    expect(state()).toBe("hidden");
+  });
+});

--- a/apps/app/src/components/ui/route-navigation-indicator.tsx
+++ b/apps/app/src/components/ui/route-navigation-indicator.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useRef, useState } from "react";
+import { useIsRouteNavigationPending } from "./app-route-anchor";
+
+export const ROUTE_NAVIGATION_INDICATOR_REVEAL_DELAY_MS = 120;
+export const ROUTE_NAVIGATION_INDICATOR_MIN_VISIBLE_MS = 320;
+
+export function useDelayedBusyIndicator(
+  busy: boolean,
+  {
+    revealDelayMs = ROUTE_NAVIGATION_INDICATOR_REVEAL_DELAY_MS,
+    minVisibleMs = ROUTE_NAVIGATION_INDICATOR_MIN_VISIBLE_MS,
+  }: { revealDelayMs?: number; minVisibleMs?: number } = {},
+): boolean {
+  const [visible, setVisible] = useState(false);
+  const shownAtRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (busy) {
+      if (shownAtRef.current !== null) return;
+      const revealTimeout = window.setTimeout(() => {
+        shownAtRef.current = Date.now();
+        setVisible(true);
+      }, revealDelayMs);
+      return () => window.clearTimeout(revealTimeout);
+    }
+
+    const shownAt = shownAtRef.current;
+    if (shownAt === null) {
+      setVisible(false);
+      return;
+    }
+
+    const remainingMs = minVisibleMs - (Date.now() - shownAt);
+    if (remainingMs <= 0) {
+      shownAtRef.current = null;
+      setVisible(false);
+      return;
+    }
+
+    const hideTimeout = window.setTimeout(() => {
+      shownAtRef.current = null;
+      setVisible(false);
+    }, remainingMs);
+    return () => window.clearTimeout(hideTimeout);
+  }, [busy, minVisibleMs, revealDelayMs]);
+
+  return visible;
+}
+
+export function RouteNavigationIndicator() {
+  const isPending = useIsRouteNavigationPending();
+  const visible = useDelayedBusyIndicator(isPending);
+
+  if (!visible) return null;
+
+  return (
+    <div
+      data-testid="route-navigation-indicator"
+      role="progressbar"
+      aria-label="Loading page"
+      className="pointer-events-none fixed inset-x-0 top-[env(safe-area-inset-top)] z-100 h-0.5 overflow-hidden bg-transparent"
+    >
+      <div className="h-full w-1/3 animate-indeterminate-progress rounded-full bg-muted-foreground" />
+    </div>
+  );
+}

--- a/apps/app/src/components/ui/theme.css
+++ b/apps/app/src/components/ui/theme.css
@@ -1041,20 +1041,20 @@ body.sidebar-resizing [data-sidebar="panel"] {
   }
 
   /*
-   * Indeterminate progress sweep. Used while a plugin installs: the server does
-   * the work behind one blocking request, so the client can say that work is
-   * happening but not how far along it is. A first install on a machine also
-   * downloads the build toolchain, which is why this window can run ~17s.
+   * Indeterminate progress sweep, for work whose duration the client cannot
+   * predict: a plugin install (one blocking server request that can run ~17s on
+   * a machine's first install, because it also downloads the build toolchain),
+   * and route navigation that React has deprioritized behind a transition.
    */
-  .animate-plugin-install-progress {
-    animation: plugin-install-progress 1.5s ease-in-out infinite;
+  .animate-indeterminate-progress {
+    animation: indeterminate-progress 1.5s ease-in-out infinite;
   }
 
   /* Reduced motion: drop the shimmer sweep and render the active cue as plain
      full-strength foreground text/glyph instead of a frozen gradient/mask. */
   @media (prefers-reduced-motion: reduce) {
     /* A static half-width fill still reads as "busy" without the sweep. */
-    .animate-plugin-install-progress {
+    .animate-indeterminate-progress {
       animation: none;
       width: 50%;
     }
@@ -1084,7 +1084,7 @@ body.sidebar-resizing [data-sidebar="panel"] {
   }
 }
 
-@keyframes plugin-install-progress {
+@keyframes indeterminate-progress {
   0% {
     margin-inline-start: -35%;
   }

--- a/apps/app/src/hooks/cache-owners/query-cache.ts
+++ b/apps/app/src/hooks/cache-owners/query-cache.ts
@@ -11,6 +11,7 @@ import {
   iterateThreadListCacheEntries,
 } from "./thread-list-cache-data";
 import { bumpDiffPatchEvictionGeneration } from "./environment-diff-patch-cache-owner";
+import { readCachedSidebarBootstrap } from "@/lib/sidebar-bootstrap-cache";
 import type {
   SidebarBootstrapResponse,
   ThreadResponse,
@@ -363,6 +364,27 @@ export function getCachedSidebarNavigationThreads(
     return [];
   }
   return listSidebarNavigationThreads(navigation);
+}
+
+export function findSidebarNavigationThreadPlaceholder(
+  queryClient: QueryClient,
+  threadId: string,
+): ThreadListEntry | undefined {
+  if (!threadId) {
+    return undefined;
+  }
+  const cached = getCachedSidebarNavigationThreads(queryClient).find(
+    (thread) => thread.id === threadId,
+  );
+  if (cached !== undefined) {
+    return cached;
+  }
+  const persisted = readCachedSidebarBootstrap();
+  return persisted === null
+    ? undefined
+    : listSidebarNavigationThreads(persisted).find(
+        (thread) => thread.id === threadId,
+      );
 }
 
 export function snapshotCachedSidebarNavigation(

--- a/apps/app/src/hooks/cache-owners/sidebar-thread-placeholder.test.ts
+++ b/apps/app/src/hooks/cache-owners/sidebar-thread-placeholder.test.ts
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+
+import { QueryClient } from "@tanstack/react-query";
+import type { SidebarBootstrapResponse } from "@bb/server-contract";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { makeThreadListEntry } from "../../../.ladle/story-fixtures";
+import { sidebarNavigationQueryKey } from "@/hooks/queries/query-keys";
+
+const readCachedSidebarBootstrap = vi.fn<() => SidebarBootstrapResponse | null>(
+  () => null,
+);
+
+vi.mock("@/lib/sidebar-bootstrap-cache", () => ({
+  readCachedSidebarBootstrap: () => readCachedSidebarBootstrap(),
+}));
+
+const { findSidebarNavigationThreadPlaceholder } =
+  await import("./query-cache");
+
+const PROJECT_ID = "proj_bb";
+
+function bootstrap(threadIds: string[]): SidebarBootstrapResponse {
+  return {
+    sections: [],
+    projects: [
+      {
+        id: PROJECT_ID,
+        threads: threadIds.map((id) =>
+          makeThreadListEntry({ id, projectId: PROJECT_ID }),
+        ),
+      },
+    ],
+    personalProject: { id: "proj_personal", threads: [] },
+  } as unknown as SidebarBootstrapResponse;
+}
+
+afterEach(() => {
+  readCachedSidebarBootstrap.mockReset();
+  readCachedSidebarBootstrap.mockReturnValue(null);
+});
+
+describe("findSidebarNavigationThreadPlaceholder", () => {
+  it("resolves from the live sidebar navigation cache without touching storage", () => {
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(
+      sidebarNavigationQueryKey(),
+      bootstrap(["thr_live"]),
+    );
+
+    expect(
+      findSidebarNavigationThreadPlaceholder(queryClient, "thr_live")?.id,
+    ).toBe("thr_live");
+    expect(readCachedSidebarBootstrap).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the persisted bootstrap so a cold boot still resolves", () => {
+    readCachedSidebarBootstrap.mockReturnValue(bootstrap(["thr_persisted"]));
+
+    expect(
+      findSidebarNavigationThreadPlaceholder(new QueryClient(), "thr_persisted")
+        ?.id,
+    ).toBe("thr_persisted");
+    expect(readCachedSidebarBootstrap).toHaveBeenCalled();
+  });
+
+  it("returns nothing for an unknown or empty thread id", () => {
+    readCachedSidebarBootstrap.mockReturnValue(bootstrap(["thr_live"]));
+    const queryClient = new QueryClient();
+
+    expect(
+      findSidebarNavigationThreadPlaceholder(queryClient, "thr_missing"),
+    ).toBeUndefined();
+    expect(
+      findSidebarNavigationThreadPlaceholder(queryClient, ""),
+    ).toBeUndefined();
+  });
+});

--- a/apps/app/src/hooks/queries/thread-queries.ts
+++ b/apps/app/src/hooks/queries/thread-queries.ts
@@ -38,6 +38,7 @@ import {
 import {
   getCachedSidebarNavigationThreads,
   getCachedThreadListPlaceholder,
+  findSidebarNavigationThreadPlaceholder,
 } from "../cache-owners/query-cache";
 import { useSidebarNavigationThreadSelection } from "./sidebar-navigation-query";
 import {
@@ -630,7 +631,8 @@ export function useThread(id: string, options?: QueryOptions) {
     placeholderData: (previousData, previousQuery) =>
       resolveThreadPlaceholder(previousData, previousQuery?.queryKey, id) ??
       liftThreadListPlaceholder(
-        getCachedThreadListPlaceholder(queryClient, id),
+        getCachedThreadListPlaceholder(queryClient, id) ??
+          findSidebarNavigationThreadPlaceholder(queryClient, id),
       ),
   });
 }


### PR DESCRIPTION
## Human comments

## What was wrong

Deferred route navigation could appear inert, and a cold thread route could begin without metadata even though the persisted sidebar bootstrap already contained a usable thread placeholder.

## What changed

- Show route-progress feedback only after a 120ms delay, then keep it visible for at least 320ms so quick routes do not flash and slow routes do not feel ignored.
- Seed cold thread queries from the in-memory or persisted sidebar bootstrap before the full response arrives.
- Keep indicator colors derived from the active theme anchors.

No mobile-home layout, compact shelf, provider-discovery, or right-panel presentation changes in this layer.

## How you verified

- The original behavior capture used Chrome for Testing 151.0.7922.71 at 393×852 CSS px, DPR 2, against exact feature revisions `e1b749660fb19ecc402799cfbbaa1cd887ac0188` and `ac97a215cb1db1640f11a2de60e9bf2b97d3a70a`. The direct layer remains unchanged at current exact base `0eb3bef25c3589f2b3f40cdcb80b20cff131512a` and exact head `1b8c66d38227299d70e3033bac8a2f2af35c294d`.
- Held the real thread/environment requests pending, clicked the same production recent-thread anchor, and captured at 220ms. The base route had only an anonymous skeleton; the head had already reconstructed the real `Wire up automations CLI` header and production follow-up composer from persisted sidebar data.
- Assertions and captures targeted the routed header/composer subtrees, not `document.body.innerText`.
- Remote CI passed the timing tests, typecheck, lint, package smokes, and version gates on the exact final head. No local CI-equivalent command was run.

| Before — no cold-route identity | After — immediate production placeholder |
| --- | --- |
| <img src="https://gist.githubusercontent.com/brsbl/d8363c420a5e5c2167498079a27162f0/raw/d2ad95502b764fe32cef1e834a34838db73036f6/pr2-before-nav.svg" width="393" alt="Before: anonymous cold route skeleton" /> | <img src="https://gist.githubusercontent.com/brsbl/d8363c420a5e5c2167498079a27162f0/raw/90c46b9e1fad5c7546b259c0033a1f971fd5e6d3/pr2-after-nav.svg" width="393" alt="After: real title and production composer while the route request remains pending" /> |

BB-Thread-ID: thr_wftu7bh9ez

> AGENT GENERATED


