### PR TITLE
Add GitHub issue search typeahead

### DIFF
--- a/apps/cli/src/__tests__/github-official-plugin-bundle.test.ts
+++ b/apps/cli/src/__tests__/github-official-plugin-bundle.test.ts
@@ -23,6 +23,11 @@ interface SlotRegistration {
   headerContent?: unknown;
 }
 
+interface ComposerRegistration {
+  id: string;
+  actions?: { id: string; component: unknown }[];
+}
+
 describe("GitHub official plugin frontend bundle", () => {
   let root: string;
 
@@ -61,8 +66,10 @@ describe("GitHub official plugin frontend bundle", () => {
       homepageSection: [],
       navPanel: [],
       threadPanelAction: [],
+      experimental_newThreadPanelAction: [],
       sidebarFooterAction: [],
     };
+    const composerCustomizations: ComposerRegistration[] = [];
     const componentStub: unknown = new Proxy(function stub() {}, {
       get: (target, prop) =>
         prop === "prototype"
@@ -84,8 +91,10 @@ describe("GitHub official plugin frontend bundle", () => {
       },
       sonner: componentStub,
       vaul: componentStub,
+      radixDialog: componentStub,
       radixDropdownMenu: componentStub,
       radixSelect: componentStub,
+      radixTooltip: componentStub,
       pierreDiffs: componentStub,
       pierreDiffsReact: componentStub,
       clsx: componentStub,
@@ -100,6 +109,9 @@ describe("GitHub official plugin frontend bundle", () => {
         __bbPluginApp: boolean;
         setup: (app: {
           slots: Record<string, (registration: SlotRegistration) => void>;
+          composer: {
+            customize(registration: ComposerRegistration): void;
+          };
         }) => void;
       };
     };
@@ -109,7 +121,13 @@ describe("GitHub official plugin frontend bundle", () => {
         homepageSection: (r) => registered.homepageSection.push(r),
         navPanel: (r) => registered.navPanel.push(r),
         threadPanelAction: (r) => registered.threadPanelAction.push(r),
+        experimental_newThreadPanelAction: (r) =>
+          registered.experimental_newThreadPanelAction.push(r),
         sidebarFooterAction: (r) => registered.sidebarFooterAction.push(r),
+      },
+      composer: {
+        customize: (registration) =>
+          composerCustomizations.push(registration),
       },
     });
 
@@ -123,13 +141,31 @@ describe("GitHub official plugin frontend bundle", () => {
     expect(typeof registered.navPanel[0]?.component).toBe("function");
     expect(typeof registered.navPanel[0]?.headerContent).toBe("function");
 
-    expect(registered.threadPanelAction).toHaveLength(1);
+    expect(registered.threadPanelAction).toHaveLength(2);
     expect(registered.threadPanelAction[0]).toMatchObject({
       id: "pull",
       title: "GitHub PR",
       icon: "Github",
     });
     expect(typeof registered.threadPanelAction[0]?.component).toBe("function");
+    expect(registered.threadPanelAction[1]).toMatchObject({
+      id: "add-item",
+      title: "Add GitHub item",
+      icon: "Github",
+    });
+
+    expect(registered.experimental_newThreadPanelAction).toHaveLength(1);
+    expect(registered.experimental_newThreadPanelAction[0]).toMatchObject({
+      id: "add-item",
+      title: "Add GitHub item",
+      icon: "Github",
+    });
+
+    expect(composerCustomizations).toHaveLength(1);
+    expect(composerCustomizations[0]).toMatchObject({
+      id: "github-item",
+      actions: [{ id: "add", component: expect.any(Function) }],
+    });
 
     expect(registered.homepageSection).toHaveLength(0);
     expect(registered.sidebarFooterAction).toHaveLength(0);

--- a/plugins/github/README.md
+++ b/plugins/github/README.md
@@ -22,8 +22,12 @@ bb plugin install github
 - **Homepage section**: recent open issues with the same Send agent buttons.
 - **Mentions**: `@` or `#` in any composer completes GitHub issues and PRs; the
   selected item's title/body/state is attached as agent context at send time.
-- **`bb github` CLI**: `repos`, `issues [repo]`, `prs [repo]`, `sync` — also
-  discoverable by agents through the plugin-commands skill.
+- **Search and attach**: the composer action and New thread panel provide a
+  debounced, keyboard-navigable search across cached issues and pull requests.
+  Selecting a result adds the existing durable GitHub mention to the prompt so
+  it can be used with any skill.
+- **`bb github` CLI**: `repos`, `issues [repo]`, `prs [repo]`, `search <query>`,
+  `sync` — also discoverable by agents through the plugin-commands skill.
 
 ## Auth
 

--- a/plugins/github/app.test.tsx
+++ b/plugins/github/app.test.tsx
@@ -1,12 +1,118 @@
 // @vitest-environment jsdom
 
-import { describe, expect, it } from "vitest";
+import { fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 import { act } from "react";
 import { loadPluginApp, renderSlot } from "@get-bb/plugin-sdk/testing/app";
 
 const app = await loadPluginApp(() => import("./app"));
 
 describe("GitHub app navigation", () => {
+  it("debounces GitHub search and adds a keyboard-selected result to the composer", async () => {
+    vi.useFakeTimers();
+    const listItems = vi.fn(() => ({
+      items: [
+        {
+          repo: "get-bb/bb",
+          number: 694,
+          kind: "pr" as const,
+          title: "Accessible GitHub search",
+          state: "OPEN",
+          author: "octocat",
+          labels: [],
+          assignees: [],
+          url: "https://github.com/get-bb/bb/pull/694",
+          body: "",
+          updatedAt: "2026-08-20T00:00:00.000Z",
+        },
+      ],
+    }));
+    const slot = renderSlot(
+      app.newThreadPanelActions[0]!,
+      { projectId: "proj-1", params: null },
+      {
+        composer: {
+          text: "/slop-cop ",
+          scope: { kind: "new-thread", projectId: "proj-1" },
+        },
+        rpc: { listItems },
+      },
+    );
+
+    try {
+      const input = slot.getByRole("combobox", {
+        name: "Search GitHub issues and pull requests",
+      });
+      fireEvent.change(input, { target: { value: "accessible" } });
+      expect(
+        slot.getByRole("status", { name: "Searching GitHub" }),
+      ).toBeTruthy();
+
+      await act(async () => vi.advanceTimersByTimeAsync(249));
+      expect(listItems).not.toHaveBeenCalled();
+      await act(async () => vi.advanceTimersByTimeAsync(1));
+
+      expect(listItems).toHaveBeenCalledWith({
+        query: "accessible",
+        limit: 12,
+      });
+      expect(slot.getByText("Accessible GitHub search")).toBeTruthy();
+      expect(slot.getByText("get-bb/bb")).toBeTruthy();
+      expect(slot.getByText("#694")).toBeTruthy();
+      expect(slot.getByText("open")).toBeTruthy();
+      expect(slot.getByText("@octocat")).toBeTruthy();
+
+      fireEvent.keyDown(input, { key: "ArrowDown" });
+      fireEvent.keyDown(input, { key: "Enter" });
+      expect(slot.composer.mentions).toEqual([
+        {
+          provider: "pr",
+          id: "get-bb/bb#694",
+          label: "get-bb/bb#694",
+        },
+      ]);
+      expect(slot.composer.text).toBe("/slop-cop get-bb/bb#694 ");
+    } finally {
+      slot.lifecycle.unmount();
+      vi.useRealTimers();
+    }
+  });
+
+  it("shows a recoverable error and an actionable empty search state", async () => {
+    vi.useFakeTimers();
+    const listItems = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("GitHub is unavailable"))
+      .mockResolvedValueOnce({ items: [] });
+    const slot = renderSlot(
+      app.newThreadPanelActions[0]!,
+      { projectId: null, params: null },
+      { rpc: { listItems } },
+    );
+
+    try {
+      fireEvent.change(
+        slot.getByRole("combobox", {
+          name: "Search GitHub issues and pull requests",
+        }),
+        { target: { value: "missing" } },
+      );
+      await act(async () => vi.advanceTimersByTimeAsync(250));
+      expect(slot.getByRole("alert").textContent).toContain(
+        "GitHub search failed: GitHub is unavailable",
+      );
+
+      fireEvent.click(slot.getByRole("button", { name: "Try again" }));
+      await act(async () => vi.advanceTimersByTimeAsync(250));
+      expect(slot.getByRole("status").textContent).toContain(
+        "No cached items match",
+      );
+    } finally {
+      slot.lifecycle.unmount();
+      vi.useRealTimers();
+    }
+  });
+
   it("opens issue details in the URL-backed page instead of a fixed tab", async () => {
     const panel = app.navPanels[0]!;
     expect(panel.fixedTabs).toBeUndefined();

--- a/plugins/github/app.test.tsx
+++ b/plugins/github/app.test.tsx
@@ -1,9 +1,19 @@
 // @vitest-environment jsdom
 
 import { fireEvent } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { act } from "react";
 import { loadPluginApp, renderSlot } from "@get-bb/plugin-sdk/testing/app";
+
+class ResizeObserverStub implements ResizeObserver {
+  observe: ResizeObserver["observe"] = vi.fn();
+  unobserve: ResizeObserver["unobserve"] = vi.fn();
+  disconnect: ResizeObserver["disconnect"] = vi.fn();
+}
+
+vi.stubGlobal("ResizeObserver", ResizeObserverStub);
+
+afterEach(() => vi.useRealTimers());
 
 const app = await loadPluginApp(() => import("./app"));
 

--- a/plugins/github/app.tsx
+++ b/plugins/github/app.tsx
@@ -5,9 +5,12 @@ import {
   experimental_FileLink as FileLink,
   UrlLink as UrlLink,
   useBbNavigate,
+  useComposer,
   useRealtime,
   useRpc,
+  type PluginComposerApi,
   type PluginNavPanelProps,
+  type PluginNewThreadPanelProps,
   type PluginThreadPanelProps,
 } from "@get-bb/plugin-sdk/app";
 import {
@@ -25,7 +28,21 @@ import type { githubRpcContract } from "./server.js";
 import { toast } from "sonner";
 import { Badge } from "@bb/shared-ui/badge";
 import { Button } from "@bb/shared-ui/button";
+import {
+  Command,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@bb/shared-ui/command";
 import { DelayedLoading } from "@bb/shared-ui/delayed-loading";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@bb/shared-ui/dialog";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -36,6 +53,7 @@ import {
   DropdownMenuTrigger,
 } from "@bb/shared-ui/dropdown-menu";
 import { Input } from "@bb/shared-ui/input";
+import { Icon } from "@bb/shared-ui/icon";
 import {
   Select,
   SelectContent,
@@ -46,6 +64,11 @@ import {
 import { Skeleton } from "@bb/shared-ui/skeleton";
 import { Tabs, TabsList, TabsTrigger } from "@bb/shared-ui/tabs";
 import { Textarea } from "@bb/shared-ui/textarea";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@bb/shared-ui/tooltip";
 import { EmptyState } from "@/components/empty-state";
 import { Markdown } from "@/components/markdown-lite";
 
@@ -337,6 +360,259 @@ function StateBadge({ kind, state }: { kind: "issue" | "pr"; state: string }) {
       <StateDot kind={kind} state={state} />
       {state.toLowerCase()}
     </Badge>
+  );
+}
+
+type GithubSearchState =
+  | { status: "idle"; items: Item[] }
+  | { status: "loading"; items: Item[] }
+  | { status: "ready"; items: Item[] }
+  | { status: "error"; items: Item[]; message: string };
+
+const GITHUB_SEARCH_DEBOUNCE_MS = 250;
+
+function useGithubSearch(query: string): {
+  state: GithubSearchState;
+  retry: () => void;
+} {
+  const rpc = useRpc<typeof githubRpcContract>();
+  const requestId = useRef(0);
+  const [revision, setRevision] = useState(0);
+  const [state, setState] = useState<GithubSearchState>({
+    status: "idle",
+    items: [],
+  });
+
+  useEffect(() => {
+    const trimmed = query.trim();
+    const currentRequestId = ++requestId.current;
+    if (trimmed.length === 0) {
+      setState({ status: "idle", items: [] });
+      return;
+    }
+    setState({ status: "loading", items: [] });
+    const timeout = window.setTimeout(() => {
+      rpc.call("listItems", { query: trimmed, limit: 12 }).then(
+        (result) => {
+          if (requestId.current !== currentRequestId) return;
+          setState({ status: "ready", items: asItems(result) });
+        },
+        (error: unknown) => {
+          if (requestId.current !== currentRequestId) return;
+          setState({
+            status: "error",
+            items: [],
+            message: errorText(error),
+          });
+        },
+      );
+    }, GITHUB_SEARCH_DEBOUNCE_MS);
+    return () => window.clearTimeout(timeout);
+  }, [query, revision, rpc]);
+
+  return {
+    state,
+    retry: () => setRevision((current) => current + 1),
+  };
+}
+
+function GithubSearchLoading() {
+  return (
+    <div
+      className="space-y-3 px-3 py-4"
+      role="status"
+      aria-label="Searching GitHub"
+    >
+      {[0, 1, 2].map((row) => (
+        <div key={row} className="space-y-2">
+          <Skeleton className="h-4 w-4/5" />
+          <Skeleton className="h-3 w-2/5" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function GithubSearchMessage({
+  children,
+  role = "status",
+}: {
+  children: React.ReactNode;
+  role?: "status" | "alert";
+}) {
+  return (
+    <div
+      className="flex min-h-32 flex-col items-center justify-center gap-3 px-6 py-8 text-center text-sm text-muted-foreground"
+      role={role}
+    >
+      {children}
+    </div>
+  );
+}
+
+function GithubSearchResult({ item }: { item: Item }) {
+  const noun = item.kind === "pr" ? "Pull request" : "Issue";
+  return (
+    <div className="flex min-w-0 flex-1 items-start gap-3 py-1">
+      <Icon
+        name={item.kind === "pr" ? "GitPullRequest" : "Circle"}
+        className="mt-0.5 size-4 shrink-0 text-muted-foreground"
+        aria-hidden="true"
+      />
+      <span className="min-w-0 flex-1 space-y-1">
+        <span className="block truncate font-medium text-foreground">
+          {item.title}
+        </span>
+        <span className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-xs text-muted-foreground">
+          <span>{item.repo}</span>
+          <span aria-hidden="true">·</span>
+          <span>#{item.number}</span>
+          <span aria-hidden="true">·</span>
+          <span>{noun}</span>
+          <span aria-hidden="true">·</span>
+          <span>@{item.author}</span>
+        </span>
+      </span>
+      <StateBadge kind={item.kind} state={item.state} />
+    </div>
+  );
+}
+
+function GithubResourceSearch({
+  onSelect,
+}: {
+  onSelect: (item: Item) => void;
+}) {
+  const [query, setQuery] = useState("");
+  const { state, retry } = useGithubSearch(query);
+
+  return (
+    <Command
+      shouldFilter={false}
+      className="min-h-0 rounded-lg border border-border bg-card"
+    >
+      <CommandInput
+        value={query}
+        onValueChange={setQuery}
+        placeholder="Search title, number, repository, or author"
+        aria-label="Search GitHub issues and pull requests"
+        autoFocus
+      />
+      <CommandList
+        className="max-h-[min(26rem,55dvh)]"
+        aria-busy={state.status === "loading"}
+        aria-label="GitHub search results"
+      >
+        {state.status === "idle" ? (
+          <GithubSearchMessage>
+            Search issues and pull requests in tracked repositories.
+          </GithubSearchMessage>
+        ) : null}
+        {state.status === "loading" ? <GithubSearchLoading /> : null}
+        {state.status === "error" ? (
+          <GithubSearchMessage role="alert">
+            <span>GitHub search failed: {state.message}</span>
+            <Button type="button" size="sm" variant="outline" onClick={retry}>
+              Try again
+            </Button>
+          </GithubSearchMessage>
+        ) : null}
+        {state.status === "ready" && state.items.length === 0 ? (
+          <GithubSearchMessage>
+            No cached items match. Try another title, number, repository, or
+            author.
+          </GithubSearchMessage>
+        ) : null}
+        {state.status === "ready" && state.items.length > 0 ? (
+          <CommandGroup heading={`${state.items.length} results`}>
+            {state.items.map((item) => (
+              <CommandItem
+                key={`${item.kind}:${item.repo}#${item.number}`}
+                value={`${item.kind}:${item.repo}#${item.number}`}
+                className="px-3 py-2.5"
+                onSelect={() => onSelect(item)}
+              >
+                <GithubSearchResult item={item} />
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        ) : null}
+      </CommandList>
+    </Command>
+  );
+}
+
+function addGithubItemToComposer(composer: PluginComposerApi, item: Item) {
+  composer.insertMention({
+    provider: item.kind,
+    id: `${item.repo}#${item.number}`,
+    label: `${item.repo}#${item.number}`,
+  });
+}
+
+function GithubSearchPanel(
+  _props: PluginThreadPanelProps | PluginNewThreadPanelProps,
+) {
+  const composer = useComposer();
+  return (
+    <div className="space-y-4">
+      <div className="space-y-1">
+        <h2 className="text-base font-semibold text-foreground">
+          Add GitHub item
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          Select an issue or pull request to add it to the current prompt, then
+          choose any skill in the composer.
+        </p>
+      </div>
+      <GithubResourceSearch
+        onSelect={(item) => {
+          addGithubItemToComposer(composer, item);
+          toast.success(`Added ${item.repo}#${item.number} to the prompt`);
+        }}
+      />
+    </div>
+  );
+}
+
+function GithubSearchComposerAction() {
+  const composer = useComposer();
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            aria-label="Add GitHub issue or pull request"
+            onClick={() => setOpen(true)}
+          >
+            <Icon name="Github" className="size-4" aria-hidden="true" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>Add GitHub item</TooltipContent>
+      </Tooltip>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="gap-4 p-4 sm:max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>Add GitHub item</DialogTitle>
+            <DialogDescription>
+              Search tracked repositories and add an issue or pull request to
+              this prompt.
+            </DialogDescription>
+          </DialogHeader>
+          <GithubResourceSearch
+            onSelect={(item) => {
+              addGithubItemToComposer(composer, item);
+              setOpen(false);
+              toast.success(`Added ${item.repo}#${item.number} to the prompt`);
+            }}
+          />
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }
 
@@ -644,6 +920,7 @@ function StatusCell({ item }: { item: Item }) {
 
 function RowMenu({ item }: { item: Item }) {
   const navigate = useBbNavigate();
+  const composer = useComposer();
   const viewer = useViewer();
   const { setIssueState, setAssignees } = useIssueMutations();
   const assignedToMe = viewer !== null && item.assignees.includes(viewer);
@@ -695,7 +972,15 @@ function RowMenu({ item }: { item: Item }) {
             {item.state === "OPEN" ? "Close issue" : "Reopen issue"}
           </DropdownMenuItem>
         ) : null}
-        {item.kind === "issue" ? <DropdownMenuSeparator /> : null}
+        <DropdownMenuItem
+          onSelect={() => {
+            addGithubItemToComposer(composer, item);
+            navigate.toCompose({ focusPrompt: true });
+          }}
+        >
+          Add to agent prompt
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
         <DropdownMenuItem
           onSelect={() => {
             navigate.openUrl(item.url);
@@ -2345,6 +2630,11 @@ function GithubPanelBody({
 }
 
 export default definePluginApp((app) => {
+  app.composer.customize({
+    id: "github-item",
+    scopes: ["new-thread", "thread", "queued-message", "side-chat"],
+    actions: [{ id: "add", component: GithubSearchComposerAction }],
+  });
   app.slots.navPanel({
     id: "github",
     title: "GitHub",
@@ -2358,5 +2648,17 @@ export default definePluginApp((app) => {
     title: "GitHub PR",
     icon: "Github",
     component: PullPanelTab,
+  });
+  app.slots.threadPanelAction({
+    id: "add-item",
+    title: "Add GitHub item",
+    icon: "Github",
+    component: GithubSearchPanel,
+  });
+  app.slots.experimental_newThreadPanelAction({
+    id: "add-item",
+    title: "Add GitHub item",
+    icon: "Github",
+    component: GithubSearchPanel,
   });
 });

--- a/plugins/github/app.tsx
+++ b/plugins/github/app.tsx
@@ -1,11 +1,4 @@
-import {
-  useCallback,
-  useEffect,
-  useId,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   definePluginApp,
   experimental_Diff as Diff,
@@ -490,23 +483,19 @@ function GithubResourceSearch({
 }: {
   onSelect: (item: Item) => void;
 }) {
-  const inputLabelId = useId();
   const [query, setQuery] = useState("");
   const { state, retry } = useGithubSearch(query);
 
   return (
     <Command
+      label="Search GitHub issues and pull requests"
       shouldFilter={false}
       className="min-h-0 rounded-lg border border-border bg-card"
     >
-      <span id={inputLabelId} className="sr-only">
-        Search GitHub issues and pull requests
-      </span>
       <CommandInput
         value={query}
         onValueChange={setQuery}
         placeholder="Search title, number, repository, or author"
-        aria-labelledby={inputLabelId}
         autoFocus
       />
       <CommandList

--- a/plugins/github/app.tsx
+++ b/plugins/github/app.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   definePluginApp,
   experimental_Diff as Diff,
@@ -483,6 +490,7 @@ function GithubResourceSearch({
 }: {
   onSelect: (item: Item) => void;
 }) {
+  const inputLabelId = useId();
   const [query, setQuery] = useState("");
   const { state, retry } = useGithubSearch(query);
 
@@ -491,11 +499,14 @@ function GithubResourceSearch({
       shouldFilter={false}
       className="min-h-0 rounded-lg border border-border bg-card"
     >
+      <span id={inputLabelId} className="sr-only">
+        Search GitHub issues and pull requests
+      </span>
       <CommandInput
         value={query}
         onValueChange={setQuery}
         placeholder="Search title, number, repository, or author"
-        aria-label="Search GitHub issues and pull requests"
+        aria-labelledby={inputLabelId}
         autoFocus
       />
       <CommandList

--- a/plugins/github/package.json
+++ b/plugins/github/package.json
@@ -46,6 +46,7 @@
     "@get-bb/plugin-sdk": "workspace:*",
     "@radix-ui/react-dialog": "^1.1.19",
     "@radix-ui/react-dropdown-menu": "^2.1.20",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/plugins/github/server.rpc.test.ts
+++ b/plugins/github/server.rpc.test.ts
@@ -315,6 +315,13 @@ describe("github plugin RPC behavior", () => {
       stdout: "acme/widgets#7\t[OPEN]\tCache mutations",
       stderr: "",
     });
+    await expect(harness.runCli(["search", "cache", "mutations"]))
+      .resolves.toEqual({
+        exitCode: 0,
+        stdout:
+          "issue\tacme/widgets#7\t[OPEN]\tCache mutations\t@alice",
+        stderr: "",
+      });
     const issueProvider = harness.registrations.mentionProviders.find(
       (provider) => provider.id === "issue",
     );

--- a/plugins/github/server.test.ts
+++ b/plugins/github/server.test.ts
@@ -161,6 +161,10 @@ describe("GitHub RPC contract", () => {
     expect(validateGithubCliArgs(["repos", "--json"])).toContain(
       "does not accept arguments",
     );
+    expect(
+      validateGithubCliArgs(["search", "cache", "mutation"]),
+    ).toBeNull();
+    expect(validateGithubCliArgs(["search"])).toContain("requires a query");
   });
 
   it("infers parsed handler inputs and frontend results", () => {

--- a/plugins/github/server.ts
+++ b/plugins/github/server.ts
@@ -145,6 +145,7 @@ export const githubRpcContract = defineRpcContract({
         query: z.string().optional(),
         state: z.enum(["open", "closed"]).optional(),
         mine: z.boolean().optional(),
+        limit: z.number().int().min(1).max(50).optional(),
       })
       .strict(),
     output: z.object({ items: z.array(itemSchema) }).strict(),
@@ -398,20 +399,30 @@ export function parsePaginatedGhApi(raw: string): Record<string, unknown>[] {
 
 export function validateGithubCliArgs(argv: string[]): string | null {
   const [sub, arg, ...rest] = argv;
-  if (rest.length > 0) return `Unexpected argument "${rest[0]}".`;
   if (sub === undefined) return null;
   if (sub === "help" || sub === "--help") {
-    return arg === undefined ? null : `Unexpected argument "${arg}".`;
+    const unexpected = arg ?? rest[0];
+    return unexpected === undefined
+      ? null
+      : `Unexpected argument "${unexpected}".`;
   }
   if (sub === "repos" || sub === "sync") {
-    return arg === undefined
+    const unexpected = arg ?? rest[0];
+    return unexpected === undefined
       ? null
       : `Subcommand "${sub}" does not accept arguments.`;
   }
-  if ((sub === "issues" || sub === "prs") && arg !== undefined) {
-    return isRepoName(arg)
+  if (sub === "issues" || sub === "prs") {
+    if (rest.length > 0) return `Unexpected argument "${rest[0]}".`;
+    if (arg !== undefined && !isRepoName(arg)) {
+      return `Invalid repository "${arg}"; expected owner/repo.`;
+    }
+    return null;
+  }
+  if (sub === "search") {
+    return argv.slice(1).join(" ").trim().length > 0
       ? null
-      : `Invalid repository "${arg}"; expected owner/repo.`;
+      : "Search requires a query.";
   }
   return null;
 }
@@ -700,6 +711,7 @@ export default async function plugin(bb: BbPluginApi) {
     query?: string;
     state?: "open" | "closed";
     assignee?: string;
+    limit?: number;
   }): CachedItem[] {
     const clauses: string[] = [];
     const params: unknown[] = [];
@@ -723,14 +735,16 @@ export default async function plugin(bb: BbPluginApi) {
     const query = options.query?.trim() ?? "";
     if (query.length > 0) {
       clauses.push(
-        "(title LIKE ? OR CAST(number AS TEXT) LIKE ? OR repo LIKE ?)",
+        "(title LIKE ? OR CAST(number AS TEXT) LIKE ? OR repo LIKE ? OR author LIKE ?)",
       );
       const like = `%${query.replace(/^#/, "")}%`;
-      params.push(like, like, like);
+      params.push(like, like, like, like);
     }
     const where = clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "";
+    const limit = options.limit === undefined ? "" : " LIMIT ?";
+    if (options.limit !== undefined) params.push(options.limit);
     const rows = db
-      .prepare(`SELECT * FROM items ${where} ORDER BY updated_at DESC`)
+      .prepare(`SELECT * FROM items ${where} ORDER BY updated_at DESC${limit}`)
       .all(...params) as Record<string, unknown>[];
     return rows.map(rowToItem);
   }
@@ -1074,6 +1088,7 @@ export default async function plugin(bb: BbPluginApi) {
           query: input.query,
           state: input.state,
           assignee: input.mine === true ? await getViewer() : undefined,
+          limit: input.limit,
         }),
       };
     },
@@ -1506,8 +1521,7 @@ export default async function plugin(bb: BbPluginApi) {
   });
 
   function mentionItems(kind: "issue" | "pr", query: string) {
-    return listCachedItems({ kind, query, state: "open" })
-      .slice(0, 8)
+    return listCachedItems({ kind, query, state: "open", limit: 8 })
       .map((item) => ({
         id: `${item.repo}#${item.number}`,
         title: `#${item.number} ${item.title}`,
@@ -1611,6 +1625,7 @@ export default async function plugin(bb: BbPluginApi) {
     "  bb github repos              List tracked repositories",
     "  bb github issues [repo]      List cached open issues",
     "  bb github prs [repo]         List cached open pull requests",
+    "  bb github search <query>     Search cached issues and pull requests",
     "  bb github sync               Refresh the cache from GitHub now",
   ].join("\n");
 
@@ -1632,6 +1647,11 @@ export default async function plugin(bb: BbPluginApi) {
         name: "prs",
         summary: "List cached open pull requests",
         usage: "bb github prs [owner/repo]",
+      },
+      {
+        name: "search",
+        summary: "Search cached issues and pull requests",
+        usage: "bb github search <query>",
       },
       {
         name: "sync",
@@ -1692,6 +1712,25 @@ export default async function plugin(bb: BbPluginApi) {
               .map(
                 (item) =>
                   `${item.repo}#${item.number}\t[${item.state}]\t${item.title}`,
+              )
+              .join("\n"),
+          };
+        }
+        if (sub === "search") {
+          const query = argv.slice(1).join(" ");
+          const items = listCachedItems({ query, limit: 50 });
+          if (items.length === 0) {
+            return {
+              exitCode: 0,
+              stdout: `No cached GitHub items match "${query}".`,
+            };
+          }
+          return {
+            exitCode: 0,
+            stdout: items
+              .map(
+                (item) =>
+                  `${item.kind}\t${item.repo}#${item.number}\t[${item.state}]\t${item.title}\t@${item.author}`,
               )
               .join("\n"),
           };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3066,6 +3066,9 @@ importers:
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.1.20
         version: 2.1.20(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.10


### PR DESCRIPTION
## Human comments

## What was wrong

The bundled GitHub plugin exposed cached issues and pull requests in its panel and mention provider, but the composer had no searchable, keyboard-accessible way to discover and attach one. Agents therefore needed a pre-known `owner/repo#number` or a separate navigation flow before a skill such as `/slop-cop` could receive a durable GitHub reference.

## What changed

- Adds a debounced GitHub issue and pull-request typeahead to every composer scope, existing-thread actions, and new-thread actions.
- Uses the host's responsive dialog/drawer, command-list keyboard behavior, theme tokens, loading skeletons, actionable empty/error states, and accessible labels.
- Shows title, repository, number, resource kind, author, and state for each result, then inserts a durable issue or PR mention into the current prompt so any skill can consume it.
- Adds **Add to agent prompt** to existing GitHub result menus and `bb github search <query>` for the same agent-accessible discovery path.
- Keeps the existing GitHub authentication boundary and cached-data model; no public Plugin SDK or host-daemon wire contract changed.
- Adds focused app, RPC, CLI, and official-bundle regression coverage and updates the bundled plugin documentation.

## Before and after

Both captures use the same dev data, installed bundled GitHub plugin, root compose route, light theme, settled state, and 1440×1000 Chrome for Testing viewport. Before is the exact merge base `f4bbc2fe81a9b7639ff9a7396e172bddd89109e4`; after is the exact PR head `4e370f668d347286b454e309f4e5b7337b6368c1`.

**Before — no GitHub resource picker in the composer**

<img src="https://gist.githubusercontent.com/brsbl/a03672d608e79a404527eb0682f3975d/raw/3ba600d3f0a3114c3c2aef0119993ef7666ad06f/before.svg" alt="Before: the bundled GitHub plugin is installed but the composer has no GitHub resource picker" width="960">

**After — populated GitHub issue and pull-request typeahead**

<img src="https://gist.githubusercontent.com/brsbl/a03672d608e79a404527eb0682f3975d/raw/e5bac6a15779d9f3261991cf466dc04c3ff848e2/after.svg" alt="After: the composer GitHub action opens a populated issue and pull-request typeahead" width="960">

## How you verified

- The exact branch web app at `4e370f668d347286b454e309f4e5b7337b6368c1` built and loaded the bundled GitHub plugin through the real plugin installation path.
- Google Chrome for Testing 151.0.7922.71: hard reload, open from the composer action, debounced search over live cached `get-bb/bb` data, result metadata, `ArrowDown`/`Enter` selection, dialog close, toast confirmation, and durable composer reference all passed.
- Exercised the populated picker at 1440×1000 and 390×844, plus host light and dark color schemes. The compact host rendered the shared bottom drawer without clipping or overflow.
- Rechecked the exact final head's combobox relationship in the real host: cmdk's connected label resolves to **Search GitHub issues and pull requests**, 12 results render for `plugin`, and the browser console remains clear.
- [Remote CI at the exact final head](https://github.com/get-bb/bb/actions/runs/33388078474) passes checks, app/server/package/integration tests, and Linux/macOS package smoke. No tests, typechecks, or lint were run locally.
- The earlier empty-composer selection exposed a pre-existing host TipTap `flushSync` console warning from the voice-action layout effect. Selection and persistence succeed, and the warning stack does not enter the GitHub plugin.

## Slop Cop review

One cumulative Slop Cop review covered exact base `f4bbc2fe81a9b7639ff9a7396e172bddd89109e4` through exact head `4e370f668d347286b454e309f4e5b7337b6368c1`.

Verdict: **PASS WITH FOLLOW-UPS** — 0 P0/P1 findings. Security passed with 0 findings; architecture was correct with 0 findings. Three validated P2 follow-ups were intentionally not added to this PR:

- Refresh active search state when GitHub cache data changes.
- Give multi-token search term semantics and treat SQL `LIKE` metacharacters literally.
- Return summary-shaped typeahead payloads instead of complete cached issue bodies.

No linked issue.

BB-Thread-ID: thr_rnzd38cjs9

> AGENT GENERATED
