### PR TITLE
Retry sidebar bootstrap until a warming server answers

### DIFF
--- a/apps/app/src/components/promptbox/NewThreadComposer.tsx
+++ b/apps/app/src/components/promptbox/NewThreadComposer.tsx
@@ -135,6 +135,7 @@ export interface NewThreadComposerState {
   projects: readonly SidebarProject[] | undefined;
   sidebarNavigation: SidebarBootstrapResponse | undefined;
   sidebarNavigationError: boolean;
+  retrySidebarNavigation: () => void;
   currentProject: SidebarProject | undefined;
   projectSources: SidebarProject["sources"];
   connectedHostIds: ReadonlySet<string>;
@@ -373,6 +374,9 @@ export function NewThreadComposer({
   const promptBoxRef = useRef<PromptBoxHandle>(null);
 
   const sidebarNavigationQuery = useSidebarNavigation();
+  const retrySidebarNavigation = useCallback(() => {
+    void sidebarNavigationQuery.refetch();
+  }, [sidebarNavigationQuery.refetch]);
   const projects = useMemo(
     () => sidebarNavigationQuery.data?.projects.map(stripProjectThreads),
     [sidebarNavigationQuery.data],
@@ -1425,6 +1429,7 @@ export function NewThreadComposer({
     projects,
     sidebarNavigation: sidebarNavigationQuery.data,
     sidebarNavigationError: sidebarNavigationQuery.isError,
+    retrySidebarNavigation,
     currentProject,
     projectSources,
     connectedHostIds,

--- a/apps/app/src/hooks/queries/query-helpers.test.ts
+++ b/apps/app/src/hooks/queries/query-helpers.test.ts
@@ -38,7 +38,16 @@ import {
 import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
 import { HttpError } from "@/lib/api";
 import { BbHttpError } from "@/lib/sdk";
-import { isTransientReadError, requireEnabledQueryArg } from "./query-helpers";
+import {
+  isSidebarBootstrapRetryableError,
+  isTransientReadError,
+  requireEnabledQueryArg,
+  shouldRetrySidebarBootstrapQuery,
+  shouldRetryTransientReadQuery,
+  sidebarBootstrapRetryDelay,
+  SIDEBAR_BOOTSTRAP_RETRY_BASE_DELAY_MS,
+  SIDEBAR_BOOTSTRAP_RETRY_MAX_DELAY_MS,
+} from "./query-helpers";
 
 describe("requireEnabledQueryArg", () => {
   it("returns the value when present", () => {
@@ -94,6 +103,81 @@ describe("isTransientReadError", () => {
     ).toBe(false);
     expect(isTransientReadError(new Error("Unexpected parse error"))).toBe(
       false,
+    );
+  });
+});
+
+describe("sidebar bootstrap retry policy", () => {
+  it("retries transport failures, 408, 429, and 5xx, but not 401 or parse errors", () => {
+    expect(
+      isSidebarBootstrapRetryableError(new TypeError("Failed to fetch")),
+    ).toBe(true);
+    expect(
+      isSidebarBootstrapRetryableError(
+        new HttpError({ status: 503, message: "warming up" }),
+      ),
+    ).toBe(true);
+    expect(
+      isSidebarBootstrapRetryableError(
+        new HttpError({ status: 408, message: "timeout" }),
+      ),
+    ).toBe(true);
+    expect(
+      isSidebarBootstrapRetryableError(
+        new HttpError({ status: 429, message: "rate limited" }),
+      ),
+    ).toBe(true);
+    expect(
+      isSidebarBootstrapRetryableError(
+        new BbHttpError({
+          status: 502,
+          message: "bad gateway",
+          body: { error: "bad gateway" },
+          code: null,
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isSidebarBootstrapRetryableError(
+        new HttpError({ status: 401, message: "unauthorized" }),
+      ),
+    ).toBe(false);
+    expect(
+      isSidebarBootstrapRetryableError(
+        new HttpError({ status: 404, message: "not found" }),
+      ),
+    ).toBe(false);
+    expect(
+      isSidebarBootstrapRetryableError(new Error("Unexpected parse error")),
+    ).toBe(false);
+    expect(isSidebarBootstrapRetryableError({ name: "AbortError" })).toBe(
+      false,
+    );
+  });
+
+  it("keeps retrying retryable errors after the generic two-retry budget", () => {
+    const transport = new TypeError("Failed to fetch");
+    expect(shouldRetryTransientReadQuery(2, transport)).toBe(false);
+    expect(shouldRetrySidebarBootstrapQuery(2, transport)).toBe(true);
+    expect(shouldRetrySidebarBootstrapQuery(12, transport)).toBe(true);
+    expect(
+      shouldRetrySidebarBootstrapQuery(
+        0,
+        new HttpError({ status: 401, message: "unauthorized" }),
+      ),
+    ).toBe(false);
+  });
+
+  it("backs off from 250ms to a 4s cap", () => {
+    expect(sidebarBootstrapRetryDelay(0)).toBe(
+      SIDEBAR_BOOTSTRAP_RETRY_BASE_DELAY_MS,
+    );
+    expect(sidebarBootstrapRetryDelay(1)).toBe(500);
+    expect(sidebarBootstrapRetryDelay(4)).toBe(
+      SIDEBAR_BOOTSTRAP_RETRY_MAX_DELAY_MS,
+    );
+    expect(sidebarBootstrapRetryDelay(8)).toBe(
+      SIDEBAR_BOOTSTRAP_RETRY_MAX_DELAY_MS,
     );
   });
 });

--- a/apps/app/src/hooks/queries/query-helpers.ts
+++ b/apps/app/src/hooks/queries/query-helpers.ts
@@ -5,6 +5,8 @@ import { BbHttpError } from "@/lib/sdk";
 export const PROMPT_HISTORY_STALE_TIME_MS = 10_000;
 const TRANSIENT_READ_RETRY_COUNT = 2;
 export const TRANSIENT_READ_RETRY_DELAY_MS = 250;
+export const SIDEBAR_BOOTSTRAP_RETRY_BASE_DELAY_MS = 250;
+export const SIDEBAR_BOOTSTRAP_RETRY_MAX_DELAY_MS = 4_000;
 
 export interface QueryOptions {
   enabled?: boolean;
@@ -78,4 +80,39 @@ export function shouldRetryTransientReadQuery(
   }
 
   return isTransientReadError(error);
+}
+
+function readHttpStatus(error: unknown): number | undefined {
+  if (error instanceof HttpError || error instanceof BbHttpError) {
+    return error.status;
+  }
+  return undefined;
+}
+
+export function isSidebarBootstrapRetryableError(error: unknown): boolean {
+  if (toRecord(error)?.name === "AbortError") {
+    return false;
+  }
+  if (isTransientReadError(error)) {
+    return true;
+  }
+  const status = readHttpStatus(error);
+  if (status === undefined) {
+    return false;
+  }
+  return status === 408 || status === 429 || status >= 500;
+}
+
+export function shouldRetrySidebarBootstrapQuery(
+  _failureCount: number,
+  error: unknown,
+): boolean {
+  return isSidebarBootstrapRetryableError(error);
+}
+
+export function sidebarBootstrapRetryDelay(attemptIndex: number): number {
+  return Math.min(
+    SIDEBAR_BOOTSTRAP_RETRY_MAX_DELAY_MS,
+    SIDEBAR_BOOTSTRAP_RETRY_BASE_DELAY_MS * 2 ** attemptIndex,
+  );
 }

--- a/apps/app/src/hooks/queries/sidebar-navigation-query.test.tsx
+++ b/apps/app/src/hooks/queries/sidebar-navigation-query.test.tsx
@@ -180,4 +180,67 @@ describe("useSidebarNavigation", () => {
       vi.useRealTimers();
     }
   });
+
+  it("recovers from an 8s transport outage instead of leaving the query terminal", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      let calls = 0;
+      vi.mocked(request).mockImplementation(() => {
+        calls += 1;
+        if (calls <= 6) {
+          return Promise.reject(new TypeError("Failed to fetch"));
+        }
+        return Promise.resolve(BOOTSTRAP);
+      });
+      const harness = createQueryClientTestHarness();
+      const { result } = renderHook(() => useSidebarNavigation(), {
+        wrapper: harness.wrapper,
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(12_000);
+      });
+      await waitFor(() => expect(result.current.data).toEqual(BOOTSTRAP));
+      expect(result.current.isError).toBe(false);
+      expect(calls).toBeGreaterThan(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("retries a temporary 503 and does not retry a 401", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const { HttpError } = await import("@/lib/api");
+      vi.mocked(request)
+        .mockRejectedValueOnce(
+          new HttpError({ status: 503, message: "warming up" }),
+        )
+        .mockResolvedValueOnce(BOOTSTRAP);
+      const successHarness = createQueryClientTestHarness();
+      const success = renderHook(() => useSidebarNavigation(), {
+        wrapper: successHarness.wrapper,
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1_000);
+      });
+      await waitFor(() => expect(success.result.current.data).toEqual(BOOTSTRAP));
+      success.unmount();
+
+      vi.mocked(request).mockReset();
+      vi.mocked(request).mockRejectedValue(
+        new HttpError({ status: 401, message: "unauthorized" }),
+      );
+      const errorHarness = createQueryClientTestHarness();
+      const failed = renderHook(() => useSidebarNavigation(), {
+        wrapper: errorHarness.wrapper,
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1_000);
+      });
+      await waitFor(() => expect(failed.result.current.isError).toBe(true));
+      expect(vi.mocked(request)).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/apps/app/src/hooks/queries/sidebar-navigation-query.ts
+++ b/apps/app/src/hooks/queries/sidebar-navigation-query.ts
@@ -11,13 +11,23 @@ import {
   useProjectListRealtimeSubscription,
   useThreadListRealtimeSubscription,
 } from "@/hooks/useRealtimeSubscription";
-import type { QueryOptions } from "./query-helpers";
+import {
+  type QueryOptions,
+  shouldRetrySidebarBootstrapQuery,
+  sidebarBootstrapRetryDelay,
+} from "./query-helpers";
 import { sidebarNavigationQueryKey } from "./query-keys";
 import { REALTIME_OWNED_STATIC_CACHE_QUERY_POLICY } from "./query-policies";
 import {
   readCachedSidebarBootstrap,
   writeCachedSidebarBootstrap,
 } from "@/lib/sidebar-bootstrap-cache";
+
+const SIDEBAR_BOOTSTRAP_QUERY_OPTIONS = {
+  ...REALTIME_OWNED_STATIC_CACHE_QUERY_POLICY,
+  retry: shouldRetrySidebarBootstrapQuery,
+  retryDelay: sidebarBootstrapRetryDelay,
+} as const;
 
 function fetchSidebarNavigation(
   signal?: AbortSignal,
@@ -42,7 +52,7 @@ export function useSidebarNavigation(options?: QueryOptions) {
       return response;
     },
     enabled,
-    ...REALTIME_OWNED_STATIC_CACHE_QUERY_POLICY,
+    ...SIDEBAR_BOOTSTRAP_QUERY_OPTIONS,
     placeholderData: () => readCachedSidebarBootstrap() ?? undefined,
   });
 }
@@ -53,7 +63,7 @@ export function useProjectDisplayName(
   const { data } = useQuery<SidebarBootstrapResponse>({
     queryKey: sidebarNavigationQueryKey(),
     queryFn: ({ signal }) => fetchSidebarNavigation(signal),
-    ...REALTIME_OWNED_STATIC_CACHE_QUERY_POLICY,
+    ...SIDEBAR_BOOTSTRAP_QUERY_OPTIONS,
     enabled: Boolean(projectId),
   });
   if (!data || !projectId) {
@@ -81,7 +91,7 @@ export function useSidebarNavigationThreadSelection<T>(
   const result = useQuery<SidebarBootstrapResponse, Error, T>({
     queryKey: sidebarNavigationQueryKey(),
     queryFn: ({ signal }) => fetchSidebarNavigation(signal),
-    ...REALTIME_OWNED_STATIC_CACHE_QUERY_POLICY,
+    ...SIDEBAR_BOOTSTRAP_QUERY_OPTIONS,
     enabled: false,
     select: selectFromNavigation,
   });

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -636,6 +636,7 @@ function RootComposeSurface({
     projects,
     sidebarNavigation,
     sidebarNavigationError,
+    retrySidebarNavigation,
     currentProject,
     projectSources,
     connectedHostIds,
@@ -1872,9 +1873,19 @@ function RootComposeSurface({
   if (!projects && sidebarNavigationError) {
     return (
       <PageShell contentClassName="min-h-full items-center justify-center">
-        <p className="py-12 text-center text-sm text-destructive">
-          Failed to load projects.
-        </p>
+        <div className="flex flex-col items-center gap-2 py-12">
+          <p className="text-center text-sm text-destructive">
+            Failed to load projects.
+          </p>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={retrySidebarNavigation}
+          >
+            Retry
+          </Button>
+        </div>
       </PageShell>
     );
   }


### PR DESCRIPTION
## Human comments

<!-- Agents: Do not fill in this section. This is for human users to fill in. -->

## What was wrong

Desktop cold start can open the window as soon as `/health` answers, while `GET /api/v1/sidebar-bootstrap` still fails. That query used the generic read retry (two attempts, 250ms, transport-only), so an HTTP 5xx from a warming server got zero retries. After the budget ran out the query was terminal (`staleTime: Infinity`, no focus/reconnect refetch while the socket is connected), and the compose error screen had no Retry. The shell stayed on "Failed to load projects." until an unrelated realtime invalidation. See [#2533](https://github.com/get-bb/bb/issues/2533) and https://get-bb.github.io/reports/issues/2533.html.

## What changed

- `query-helpers.ts`: sidebar-specific retry for transport failures plus 408/429/5xx, exponential backoff from 250ms capped at 4s, keep retrying while the error is retryable. Do not retry 401/403/404, parse errors, or `AbortError`.
- `sidebar-navigation-query.ts`: apply that policy on every observer of the sidebar bootstrap key so a later mount cannot overwrite it with the generic two-retry default.
- `RootComposeView.tsx`: add a Retry button on the "Failed to load projects." screen that refetches the bootstrap.

No `HOST_DAEMON_PROTOCOL_VERSION` bump, no CLI/guide changes. Deviation from the issue's original six-retry sketch: retryable errors keep retrying at the 4s cap instead of stopping after ~12s, matching the expected "retries continue while the server is unreachable" behavior. The Retry button was listed as a follow-up in the issue and included here because the confirmed-repro report asked for it.

## How you verified

- Added unit tests for retry classification, infinite retry vs the generic two-retry budget, and backoff.
- Added hook tests: recover after six `Failed to fetch` failures; retry a temporary 503; do not retry a 401.
- `pnpm exec turbo run test --filter=@bb/app -- src/hooks/queries/query-helpers.test.ts src/hooks/queries/sidebar-navigation-query.test.tsx` — 25 passed (red before the policy, green after).
- `pnpm exec turbo run typecheck --filter=@bb/app` — passed.

Fixes #2533

> AGENT GENERATED

Made with [Cursor](https://cursor.com)