### PR TITLE
Fix Plugin SDK declaration build memory spikes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,7 @@
 
 ## Testing
 
+- Combine package filters into one Turbo invocation instead of running overlapping `--force` graphs in parallel; shared prerequisite tasks otherwise execute once per process and can multiply CPU and memory use.
 - Only write high quality tests that verify where there could be potential bugs. Avoid testing trivial getters/setters, framework wiring, or other code that is unlikely to break.
 - Pipe slow test output to a file, then read the file. Example: `pnpm exec turbo run test --filter=@bb/integration-tests --force > /tmp/test-out.txt 2>&1`.
 - Package `vitest.config.ts` files build their `projects` with `sharedWorkerProjects` from `vitest.shared.ts`. It runs node-environment test files in shared workers (`isolate: false`) and gives a file its own worker when it runs in a DOM environment (`jsdom`) or when the file, or a test helper it imports, mutates worker-global state (`vi.mock`, `vi.stubGlobal`, `process.env`, `globalThis.*` assignments, `Object.defineProperty` on a global). Re-importing the module graph per file was 80–90% of the big suites' CPU. Restore what a test changes anyway; the scan is a safety net, not a license.

--- a/packages/plugin-sdk/scripts/build-bundled-dts-concurrency.mjs
+++ b/packages/plugin-sdk/scripts/build-bundled-dts-concurrency.mjs
@@ -1,0 +1,13 @@
+const MEMORY_BYTES_PER_BUNDLE_WORKER = 8 * 1024 ** 3;
+
+export function computeBundleWorkerCount(
+  entryCount,
+  availableWorkers,
+  totalMemoryBytes,
+) {
+  const memoryWorkers = Math.max(
+    1,
+    Math.floor(totalMemoryBytes / MEMORY_BYTES_PER_BUNDLE_WORKER),
+  );
+  return Math.max(1, Math.min(entryCount, availableWorkers, memoryWorkers));
+}

--- a/packages/plugin-sdk/scripts/build-bundled-dts-concurrency.test.mjs
+++ b/packages/plugin-sdk/scripts/build-bundled-dts-concurrency.test.mjs
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { computeBundleWorkerCount } from "./build-bundled-dts-concurrency.mjs";
+
+const GIBIBYTE = 1024 ** 3;
+
+describe("computeBundleWorkerCount", () => {
+  it("scales declaration bundling concurrency with system memory", () => {
+    expect(computeBundleWorkerCount(15, 12, 24 * GIBIBYTE)).toBe(3);
+    expect(computeBundleWorkerCount(15, 8, 16 * GIBIBYTE)).toBe(2);
+  });
+
+  it("does not exceed the available workers", () => {
+    expect(computeBundleWorkerCount(15, 2, 64 * GIBIBYTE)).toBe(2);
+  });
+});

--- a/packages/plugin-sdk/scripts/build-bundled-dts.mjs
+++ b/packages/plugin-sdk/scripts/build-bundled-dts.mjs
@@ -24,7 +24,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { availableParallelism } from "node:os";
+import { availableParallelism, totalmem } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -36,6 +36,7 @@ import {
 import { rollup } from "rollup";
 import { dts } from "rollup-plugin-dts";
 
+import { computeBundleWorkerCount } from "./build-bundled-dts-concurrency.mjs";
 import { normalizeBundledDts } from "./normalize-bundled-dts.mjs";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
@@ -177,11 +178,6 @@ function generateBundle(entry) {
   );
 }
 
-// Each bundle builds its own TypeScript program, which is CPU-bound and
-// single-threaded inside rollup-plugin-dts; the six large entries take 2–7s
-// apiece. They are independent, so this file re-runs itself as a worker per
-// entry, as many at a time as there are cores, and the serial ~27s becomes
-// roughly the longest single bundle.
 if (!isMainThread) {
   parentPort.postMessage(await generateBundle(workerData.entry));
 } else {
@@ -191,7 +187,11 @@ if (!isMainThread) {
 async function main() {
   const generated = {};
   const queue = Object.entries(outputs);
-  const workers = Math.min(queue.length, availableParallelism());
+  const workers = computeBundleWorkerCount(
+    queue.length,
+    availableParallelism(),
+    totalmem(),
+  );
   await Promise.all(
     Array.from({ length: workers }, async () => {
       for (let next = queue.shift(); next; next = queue.shift()) {


### PR DESCRIPTION
## Human comments

## What was wrong

The Plugin SDK declaration bundler sized its worker pool only from available CPU parallelism. When separate forced Turbo graphs ran concurrently, each graph rebuilt the shared declaration task and each build spawned a full worker pool. Every worker creates an independent Rollup/TypeScript declaration program, so the duplicated pools multiplied memory use until Node processes were killed for running out of memory.

## What changed

- Size the declaration worker pool from bundle count, available CPU parallelism, and physical memory, budgeting one worker per 8 GiB.
- Cover the adaptive calculation for machines with different CPU and memory capacities.
- Tell agents to combine package filters into one Turbo invocation instead of launching overlapping forced graphs.
- No host-daemon wire, CLI, or Plugin SDK API change.

## How you verified

- Confirmed the new adaptive test failed against the fixed worker-count implementation: a 12-core, 24 GiB host returned 2 instead of 3.
- pnpm exec turbo run test typecheck --filter=@get-bb/plugin-sdk --force — passed 6/6 tasks, 23 test files, and 222 tests.
- pnpm exec oxfmt --check AGENTS.md packages/plugin-sdk/scripts/build-bundled-dts.mjs packages/plugin-sdk/scripts/build-bundled-dts-concurrency.mjs packages/plugin-sdk/scripts/build-bundled-dts-concurrency.test.mjs — passed.
- git diff --check — passed.
- Live host calculation: 12 available workers and 24 GiB physical memory select 3 declaration workers.

Fixes: N/A

> AGENT GENERATED
