### PR TITLE
Enable idle provider session release by default

### DIFF
--- a/apps/app/src/components/layout/AppLayout.plugin-panel-header.test.tsx
+++ b/apps/app/src/components/layout/AppLayout.plugin-panel-header.test.tsx
@@ -26,7 +26,6 @@ vi.mock("@/hooks/queries/system-queries", () => ({
         changelogPreview: false,
         editMessages: false,
         mobileApp: false,
-        providerSessionReaping: false,
         timelineWindowing: false,
       },
     },

--- a/apps/app/src/components/layout/AppLayout.root-compose-project.test.tsx
+++ b/apps/app/src/components/layout/AppLayout.root-compose-project.test.tsx
@@ -36,7 +36,6 @@ vi.mock("@/hooks/queries/system-queries", () => ({
         changelogPreview: false,
         editMessages: false,
         mobileApp: false,
-        providerSessionReaping: false,
         timelineWindowing: false,
       },
     },

--- a/apps/app/src/components/layout/AppLayout.sidebar-resize.test.tsx
+++ b/apps/app/src/components/layout/AppLayout.sidebar-resize.test.tsx
@@ -42,7 +42,6 @@ vi.mock("@/hooks/queries/system-queries", () => ({
     data: {
       experiments: {
         editMessages: false,
-        providerSessionReaping: false,
       },
     },
   }),

--- a/apps/app/src/lib/system-config-atoms.ts
+++ b/apps/app/src/lib/system-config-atoms.ts
@@ -24,7 +24,6 @@ const unavailableSystemConfig: SystemConfigResponse = {
     changelogPreview: false,
     editMessages: false,
     mobileApp: false,
-    providerSessionReaping: false,
     timelineWindowing: false,
   },
   appearance: defaultAppTheme,

--- a/apps/app/src/views/SettingsView.experiments.test.tsx
+++ b/apps/app/src/views/SettingsView.experiments.test.tsx
@@ -8,7 +8,6 @@ afterEach(cleanup);
 function renderSection(overrides?: {
   onChangelogPreviewEnabledChange?: (enabled: boolean) => void;
   onMobileAppEnabledChange?: (enabled: boolean) => void;
-  onProviderSessionReapingEnabledChange?: (enabled: boolean) => void;
   onTimelineWindowingEnabledChange?: (enabled: boolean) => void;
 }) {
   return render(
@@ -17,16 +16,12 @@ function renderSection(overrides?: {
       disabled={false}
       editMessagesEnabled={false}
       mobileAppEnabled={false}
-      providerSessionReapingEnabled={false}
       timelineWindowingEnabled={false}
       onChangelogPreviewEnabledChange={
         overrides?.onChangelogPreviewEnabledChange ?? vi.fn()
       }
       onEditMessagesEnabledChange={vi.fn()}
       onMobileAppEnabledChange={overrides?.onMobileAppEnabledChange ?? vi.fn()}
-      onProviderSessionReapingEnabledChange={
-        overrides?.onProviderSessionReapingEnabledChange ?? vi.fn()
-      }
       onTimelineWindowingEnabledChange={
         overrides?.onTimelineWindowingEnabledChange ?? vi.fn()
       }
@@ -46,13 +41,6 @@ describe("ExperimentsSettingsSection", () => {
     const onChange = vi.fn();
     renderSection({ onMobileAppEnabledChange: onChange });
     fireEvent.click(screen.getByLabelText("Mobile app"));
-    expect(onChange).toHaveBeenCalledWith(true);
-  });
-
-  it("reports idle provider session release changes", () => {
-    const onChange = vi.fn();
-    renderSection({ onProviderSessionReapingEnabledChange: onChange });
-    fireEvent.click(screen.getByLabelText("Idle provider session release"));
     expect(onChange).toHaveBeenCalledWith(true);
   });
 

--- a/apps/app/src/views/SettingsView.stories.tsx
+++ b/apps/app/src/views/SettingsView.stories.tsx
@@ -357,7 +357,6 @@ function ExperimentsStory() {
       disabled={false}
       editMessagesEnabled={state.experiments.editMessages}
       mobileAppEnabled={state.experiments.mobileApp}
-      providerSessionReapingEnabled={state.experiments.providerSessionReaping}
       timelineWindowingEnabled={state.experiments.timelineWindowing}
       onChangelogPreviewEnabledChange={(enabled) =>
         state.setExperiments((current) => ({
@@ -375,12 +374,6 @@ function ExperimentsStory() {
         state.setExperiments((current) => ({
           ...current,
           mobileApp: enabled,
-        }))
-      }
-      onProviderSessionReapingEnabledChange={(enabled) =>
-        state.setExperiments((current) => ({
-          ...current,
-          providerSessionReaping: enabled,
         }))
       }
       onTimelineWindowingEnabledChange={(enabled) =>

--- a/apps/app/src/views/SettingsView.tsx
+++ b/apps/app/src/views/SettingsView.tsx
@@ -183,12 +183,10 @@ interface ExperimentsSettingsSectionProps {
   changelogPreviewEnabled: boolean;
   editMessagesEnabled: boolean;
   mobileAppEnabled: boolean;
-  providerSessionReapingEnabled: boolean;
   timelineWindowingEnabled: boolean;
   onChangelogPreviewEnabledChange: (enabled: boolean) => void;
   onEditMessagesEnabledChange: (enabled: boolean) => void;
   onMobileAppEnabledChange: (enabled: boolean) => void;
-  onProviderSessionReapingEnabledChange: (enabled: boolean) => void;
   onTimelineWindowingEnabledChange: (enabled: boolean) => void;
 }
 
@@ -858,20 +856,16 @@ export function DebugSettingsSection({
 const CHANGELOG_PREVIEW_EXPERIMENT_LABEL = "Changelog preview";
 const EDIT_MESSAGES_EXPERIMENT_LABEL = "Edit messages";
 const MOBILE_APP_EXPERIMENT_LABEL = "Mobile app";
-const PROVIDER_SESSION_REAPING_EXPERIMENT_LABEL =
-  "Idle provider session release";
 const TIMELINE_WINDOWING_EXPERIMENT_LABEL = "Timeline windowing";
 export function ExperimentsSettingsSection({
   changelogPreviewEnabled,
   disabled,
   editMessagesEnabled,
   mobileAppEnabled,
-  providerSessionReapingEnabled,
   timelineWindowingEnabled,
   onChangelogPreviewEnabledChange,
   onEditMessagesEnabledChange,
   onMobileAppEnabledChange,
-  onProviderSessionReapingEnabledChange,
   onTimelineWindowingEnabledChange,
 }: ExperimentsSettingsSectionProps) {
   return (
@@ -913,18 +907,6 @@ export function ExperimentsSettingsSection({
             disabled={disabled}
             onCheckedChange={onMobileAppEnabledChange}
             aria-label={MOBILE_APP_EXPERIMENT_LABEL}
-          />
-        </SettingsWithControl>
-
-        <SettingsWithControl
-          label={PROVIDER_SESSION_REAPING_EXPERIMENT_LABEL}
-          description="Release restorable provider sessions after 30 idle minutes. A change can take up to five minutes."
-        >
-          <Switch
-            checked={providerSessionReapingEnabled}
-            disabled={disabled}
-            onCheckedChange={onProviderSessionReapingEnabledChange}
-            aria-label={PROVIDER_SESSION_REAPING_EXPERIMENT_LABEL}
           />
         </SettingsWithControl>
 
@@ -1083,13 +1065,6 @@ export function SettingsView() {
           updateExperimentsMutation.mutate({
             ...experiments,
             mobileApp: enabled,
-          })
-        }
-        providerSessionReapingEnabled={experiments.providerSessionReaping}
-        onProviderSessionReapingEnabledChange={(enabled) =>
-          updateExperimentsMutation.mutate({
-            ...experiments,
-            providerSessionReaping: enabled,
           })
         }
         timelineWindowingEnabled={experiments.timelineWindowing}

--- a/apps/desktop/scripts/smoke-packaged-app.mjs
+++ b/apps/desktop/scripts/smoke-packaged-app.mjs
@@ -147,7 +147,6 @@ async function startSmokeServer({
         dataDir,
         experiments: {
           mobileApp: false,
-          providerSessionReaping: false,
         },
         featureFlags: {
           placeholder: false,

--- a/apps/desktop/test/preload-build.test.ts
+++ b/apps/desktop/test/preload-build.test.ts
@@ -130,7 +130,6 @@ async function startDesktopSmokeServer(
             changelogPreview: false,
             editMessages: false,
             mobileApp: false,
-            providerSessionReaping: false,
             timelineWindowing: false,
           },
           featureFlags: {

--- a/apps/host-daemon/src/app.test.ts
+++ b/apps/host-daemon/src/app.test.ts
@@ -642,7 +642,6 @@ describe("createHostDaemonApp", () => {
     const reaper = startIdleProviderSessionReaper({
       logger,
       nowMs: () => nowMs,
-      resolveProviderSessionReapingEnabled: async () => true,
       runtimeManager: {
         reapIdleProviderSessions,
       },
@@ -658,7 +657,6 @@ describe("createHostDaemonApp", () => {
     expect(reapIdleProviderSessions).toHaveBeenNthCalledWith(1, {
       idleForMs: 1_800_000,
       nowMs: 1_000,
-      providerSessionReapingEnabled: true,
     });
 
     nowMs = 2_000;
@@ -698,7 +696,6 @@ describe("createHostDaemonApp", () => {
     expect(reapIdleProviderSessions).toHaveBeenNthCalledWith(2, {
       idleForMs: 1_800_000,
       nowMs: 2_000,
-      providerSessionReapingEnabled: true,
     });
     expect(logger.warn).toHaveBeenCalledWith(
       {

--- a/apps/host-daemon/src/app.ts
+++ b/apps/host-daemon/src/app.ts
@@ -96,7 +96,6 @@ interface IdleProviderSessionReaperRuntimeManager {
 interface StartIdleProviderSessionReaperArgs {
   logger: HostDaemonLogger;
   nowMs: () => number;
-  resolveProviderSessionReapingEnabled: () => Promise<boolean>;
   runtimeManager: IdleProviderSessionReaperRuntimeManager;
   setIntervalFn: IdleProviderSessionReaperIntervalFn;
 }
@@ -160,22 +159,11 @@ export function startIdleProviderSessionReaper(
       return;
     }
     running = true;
-    void args
-      .resolveProviderSessionReapingEnabled()
-      .catch((error) => {
-        args.logger.warn(
-          { ...runtimeErrorLogFields(error) },
-          "Failed to read idle provider session experiment policy",
-        );
-        return false;
+    void args.runtimeManager
+      .reapIdleProviderSessions({
+        idleForMs: IDLE_PROVIDER_SESSION_REAP_AFTER_MS,
+        nowMs: args.nowMs(),
       })
-      .then((providerSessionReapingEnabled) =>
-        args.runtimeManager.reapIdleProviderSessions({
-          idleForMs: IDLE_PROVIDER_SESSION_REAP_AFTER_MS,
-          nowMs: args.nowMs(),
-          providerSessionReapingEnabled,
-        }),
-      )
       .then((result) => {
         if (result.reapedSessions.length === 0) {
           return;
@@ -695,8 +683,6 @@ export async function createHostDaemonApp(
   const idleProviderSessionReaper = startIdleProviderSessionReaper({
     logger: options.logger,
     nowMs: Date.now,
-    resolveProviderSessionReapingEnabled: async () =>
-      (await serverClient.getRuntimePolicy()).providerSessionReaping,
     runtimeManager,
     setIntervalFn: (callback, intervalMs) => {
       const timer = setInterval(callback, intervalMs);

--- a/apps/host-daemon/src/runtime-manager.test.ts
+++ b/apps/host-daemon/src/runtime-manager.test.ts
@@ -421,7 +421,6 @@ describe("RuntimeManager", () => {
       manager.reapIdleProviderSessions({
         idleForMs: 1_000,
         nowMs: 5_000,
-        providerSessionReapingEnabled: false,
       }),
     ).resolves.toEqual({
       reapedSessions: [
@@ -444,13 +443,11 @@ describe("RuntimeManager", () => {
     expect(firstRuntime.reapIdleProviderSessions).toHaveBeenCalledWith({
       idleForMs: 1_000,
       nowMs: 5_000,
-      providerSessionReapingEnabled: false,
       runThreadExclusive: expect.any(Function),
     });
     expect(secondRuntime.reapIdleProviderSessions).toHaveBeenCalledWith({
       idleForMs: 1_000,
       nowMs: 5_000,
-      providerSessionReapingEnabled: false,
       runThreadExclusive: expect.any(Function),
     });
   });
@@ -486,7 +483,6 @@ describe("RuntimeManager", () => {
     const result = await manager.reapIdleProviderSessions({
       idleForMs: 1_000,
       nowMs: 5_000,
-      providerSessionReapingEnabled: true,
     });
 
     expect(result.reapedSessions).toEqual([]);

--- a/apps/host-daemon/src/runtime-manager.ts
+++ b/apps/host-daemon/src/runtime-manager.ts
@@ -205,7 +205,6 @@ export interface RuntimeManagerOptions {
 export interface RuntimeManagerReapIdleProviderSessionsArgs {
   idleForMs: number;
   nowMs: number;
-  providerSessionReapingEnabled: boolean;
 }
 
 interface RuntimeManagerReapedIdleProviderSession extends ReapedIdleProviderSession {

--- a/apps/host-daemon/src/server-client.test.ts
+++ b/apps/host-daemon/src/server-client.test.ts
@@ -42,27 +42,6 @@ function createInteractiveRequest(): PendingInteractionCreate {
 }
 
 describe("createServerClient", () => {
-  it("reads the current runtime policy", async () => {
-    const fetchFn = vi.fn<FetchFn>(async (input, init) => {
-      expect(String(input)).toBe(
-        "https://bb.example.test/internal/runtime-policy",
-      );
-      expect(init?.method).toBe("GET");
-      return Response.json({ providerSessionReaping: true });
-    });
-    const client = createServerClient({
-      fetchFn,
-      getSessionId: () => "session-1",
-      hostKey: "host-key",
-      logger: createLogger(),
-      serverUrl: "https://bb.example.test",
-    });
-
-    await expect(client.getRuntimePolicy()).resolves.toEqual({
-      providerSessionReaping: true,
-    });
-  });
-
   it("narrows a protocol update retry request from error details", async () => {
     const fetchFn = vi.fn<FetchFn>(async () =>
       Response.json(

--- a/apps/host-daemon/src/server-client.ts
+++ b/apps/host-daemon/src/server-client.ts
@@ -4,7 +4,6 @@ import {
   hostDaemonEventBatchResponseSchema,
   hostDaemonInteractiveInterruptResponseSchema,
   hostDaemonInteractiveRequestResponseSchema,
-  hostDaemonRuntimePolicySchema,
   hostDaemonSessionOpenResponseSchema,
   hostDaemonSkillTreeSchema,
   hostDaemonToolCallResponseSchema,
@@ -17,7 +16,6 @@ import {
   type HostDaemonInteractiveInterruptRequest,
   type HostDaemonInteractiveRequest,
   type HostDaemonLoadedEnvironment,
-  type HostDaemonRuntimePolicy,
   type HostDaemonProjectAttachmentContentQuery,
   type HostDaemonSessionOpenRequest,
   type HostDaemonSessionOpenResponse,
@@ -178,7 +176,6 @@ interface OpenSessionArgs {
 }
 
 export interface ServerClient {
-  getRuntimePolicy(): Promise<HostDaemonRuntimePolicy>;
   openSession(args: OpenSessionArgs): Promise<HostDaemonSessionOpenResponse>;
   fetchProjectAttachment(
     args: FetchProjectAttachmentArgs,
@@ -435,17 +432,6 @@ export function createServerClient(
   }
 
   return {
-    async getRuntimePolicy(): Promise<HostDaemonRuntimePolicy> {
-      const response = await fetchFn(buildInternalUrl("/runtime-policy"), {
-        method: "GET",
-        headers: headers(),
-      });
-      if (!response.ok) {
-        throw await createResponseError("get runtime policy", response);
-      }
-      return hostDaemonRuntimePolicySchema.parse(await response.json());
-    },
-
     async openSession(
       args: OpenSessionArgs,
     ): Promise<HostDaemonSessionOpenResponse> {

--- a/apps/host-daemon/src/server-connection.test.ts
+++ b/apps/host-daemon/src/server-connection.test.ts
@@ -84,7 +84,6 @@ function createServerClientFixture(args: CreateServerClientFixtureArgs = {}) {
   };
   const serverClient = {
     openSession,
-    getRuntimePolicy: unused,
     fetchProjectAttachment: unused,
     fetchSkillTree: unused,
     fetchPluginHostArtifact: unused,

--- a/apps/server/src/internal/session.ts
+++ b/apps/server/src/internal/session.ts
@@ -1,6 +1,5 @@
 import {
   getLatestSessionForHost,
-  getExperiments,
   listRetiredLoadedEnvironmentIdsOnHost,
   openSession,
   upsertHost,
@@ -35,13 +34,6 @@ export function registerInternalSessionRoutes(
 ): void {
   const { get, post } = typedRoutes<HostDaemonInternalSchema>(app, {
     onValidationError: (msg) => new ApiError(400, "invalid_request", msg),
-  });
-
-  get("/runtime-policy", (context) => {
-    getAuthenticatedDaemon(context);
-    return context.json({
-      providerSessionReaping: getExperiments(deps.db).providerSessionReaping,
-    });
   });
 
   post(

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/references/app-settings.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/references/app-settings.md
@@ -77,8 +77,7 @@ every window and client sees the same value.
 
 ## Provider session release
 
-- The `providerSessionReaping` experiment defaults to false. When enabled, BB
-  releases restorable provider sessions after 30 idle minutes.
+- BB releases restorable provider sessions after 30 idle minutes.
 - Active turns, commands, agents, workflows, and monitors keep sessions loaded.
 
 ## Mobile app

--- a/apps/server/test/system/experiments.test.ts
+++ b/apps/server/test/system/experiments.test.ts
@@ -3,8 +3,6 @@ import { getExperiments } from "@bb/db";
 import { experimentsSchema } from "@bb/domain";
 import { systemConfigResponseSchema } from "@bb/server-contract";
 import { readJson } from "../helpers/json.js";
-import { internalAuthHeaders } from "../helpers/commands.js";
-import { seedHostSession } from "../helpers/seed.js";
 import { withTestHarness } from "../helpers/test-app.js";
 
 describe("experiments settings", () => {
@@ -17,7 +15,6 @@ describe("experiments settings", () => {
         changelogPreview: false,
         editMessages: true,
         mobileApp: false,
-        providerSessionReaping: false,
         timelineWindowing: false,
       });
     });
@@ -32,7 +29,6 @@ describe("experiments settings", () => {
           changelogPreview: true,
           editMessages: true,
           mobileApp: true,
-          providerSessionReaping: true,
           timelineWindowing: true,
         }),
       });
@@ -41,14 +37,12 @@ describe("experiments settings", () => {
         changelogPreview: true,
         editMessages: true,
         mobileApp: true,
-        providerSessionReaping: true,
         timelineWindowing: true,
       });
       expect(getExperiments(harness.db)).toEqual({
         changelogPreview: true,
         editMessages: true,
         mobileApp: true,
-        providerSessionReaping: true,
         timelineWindowing: true,
       });
 
@@ -59,42 +53,7 @@ describe("experiments settings", () => {
         changelogPreview: true,
         editMessages: true,
         mobileApp: true,
-        providerSessionReaping: true,
         timelineWindowing: true,
-      });
-    });
-  });
-
-  it("serves the current provider session policy to the daemon", async () => {
-    await withTestHarness(async (harness) => {
-      const { host } = seedHostSession(harness.deps, {
-        id: "host-runtime-policy",
-      });
-      const headers = internalAuthHeaders(harness, { hostId: host.id });
-
-      const initial = await harness.app.request("/internal/runtime-policy", {
-        headers,
-      });
-      expect(initial.status).toBe(200);
-      await expect(readJson(initial)).resolves.toEqual({
-        providerSessionReaping: false,
-      });
-      await harness.app.request("/api/v1/settings/experiments", {
-        method: "PUT",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({
-          changelogPreview: false,
-          editMessages: true,
-          mobileApp: false,
-          providerSessionReaping: true,
-          timelineWindowing: false,
-        }),
-      });
-      const updated = await harness.app.request("/internal/runtime-policy", {
-        headers,
-      });
-      await expect(readJson(updated)).resolves.toEqual({
-        providerSessionReaping: true,
       });
     });
   });
@@ -111,7 +70,6 @@ describe("experiments settings", () => {
           changelogPreview: false,
           editMessages: false,
           mobileApp: false,
-          providerSessionReaping: false,
           timelineWindowing: false,
         }),
       });

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -646,12 +646,9 @@ The `mobileApp` experiment turns on pairing for the bb mobile app: the
 `bb connect machine-code` command (see "Pairing the bb mobile app" above). It
 is off by default while the app is in early access.
 
-The `providerSessionReaping` experiment extends idle session release to every
-restorable provider. BB releases those sessions after 30 idle minutes. The
-daemon reads the setting before each five-minute maintenance pass. Active
-turns, commands, agents, workflows, and monitors keep their sessions loaded.
-The experiment does not gate release: BB releases idle Codex sessions with the
-experiment off, which is the behavior it had before this setting.
+BB releases restorable provider sessions after 30 idle minutes. The daemon
+checks for these sessions every five minutes. Active turns, commands, agents,
+workflows, and monitors keep their sessions loaded.
 
 The `timelineWindowing` experiment is off by default. When enabled, long
 timelines and large expanded timeline details retain stable height-preserving

--- a/packages/agent-runtime/src/runtime.process-lifecycle.test.ts
+++ b/packages/agent-runtime/src/runtime.process-lifecycle.test.ts
@@ -44,7 +44,10 @@ interface CreateProviderProcessManagerArgs {
   workspacePath: string;
 }
 
-const CODEX_SCRIPT: ScriptedEchoLaunchScript = { identifyProcess: true };
+const CODEX_SCRIPT: ScriptedEchoLaunchScript = {
+  identifyProcess: true,
+  sessionRestorable: true,
+};
 
 const MANAGER_BRIDGE_LAUNCH = createScriptedEchoLaunch();
 
@@ -929,7 +932,6 @@ describe("createAgentRuntime process lifecycle", () => {
       const result = await runtime.reapIdleProviderSessions({
         idleForMs: 0,
         nowMs: Date.now() + 60 * 60 * 1000,
-        providerSessionReapingEnabled: false,
       });
       expect(result.reapedSessions).toEqual([
         expect.objectContaining({
@@ -980,7 +982,6 @@ describe("createAgentRuntime process lifecycle", () => {
       const belowThresholdResult = await runtime.reapIdleProviderSessions({
         idleForMs: 30 * 60 * 1000,
         nowMs: Date.now() + 29 * 60 * 1000,
-        providerSessionReapingEnabled: false,
       });
       expect(belowThresholdResult.reapedSessions).toEqual([]);
       expect(runtime.hasThread("t1")).toBe(true);
@@ -991,7 +992,6 @@ describe("createAgentRuntime process lifecycle", () => {
       const result = await runtime.reapIdleProviderSessions({
         idleForMs: 30 * 60 * 1000,
         nowMs: Date.now() + 31 * 60 * 1000,
-        providerSessionReapingEnabled: false,
       });
       const reapedSession = result.reapedSessions[0];
       if (!reapedSession) {
@@ -1075,12 +1075,10 @@ describe("createAgentRuntime process lifecycle", () => {
       const firstResult = await runtime.reapIdleProviderSessions({
         idleForMs: 0,
         nowMs: Date.now() + 60 * 60 * 1000,
-        providerSessionReapingEnabled: false,
       });
       const secondResult = await runtime.reapIdleProviderSessions({
         idleForMs: 0,
         nowMs: Date.now() + 60 * 60 * 1000,
-        providerSessionReapingEnabled: false,
       });
       expect(firstResult.reapedSessions).toEqual([]);
       expect(secondResult.reapedSessions).toEqual([]);
@@ -1093,7 +1091,7 @@ describe("createAgentRuntime process lifecycle", () => {
     }
   });
 
-  it("reaps a restorable non-Codex session only when the experiment is on", async () => {
+  it("reaps a restorable non-Codex session", async () => {
     const events: ThreadEvent[] = [];
     const runtime = createScriptedEchoRuntime({
       runtime: {
@@ -1113,18 +1111,9 @@ describe("createAgentRuntime process lifecycle", () => {
         providerId: "claude-code",
         options: fullRuntimeOptions,
       });
-      await expect(
-        runtime.reapIdleProviderSessions({
-          idleForMs: 0,
-          nowMs: Date.now(),
-          providerSessionReapingEnabled: false,
-        }),
-      ).resolves.toEqual({ reapedSessions: [] });
-      expect(runtime.hasThread("t1")).toBe(true);
       const result = await runtime.reapIdleProviderSessions({
         idleForMs: 0,
         nowMs: Date.now(),
-        providerSessionReapingEnabled: true,
       });
       expect(result.reapedSessions).toEqual([
         expect.objectContaining({
@@ -1159,7 +1148,6 @@ describe("createAgentRuntime process lifecycle", () => {
       const result = await runtime.reapIdleProviderSessions({
         idleForMs: 0,
         nowMs: Date.now(),
-        providerSessionReapingEnabled: true,
       });
       expect(result.reapedSessions).toEqual([
         expect.objectContaining({ providerId: "claude-code", threadId: "t1" }),
@@ -1191,7 +1179,6 @@ describe("createAgentRuntime process lifecycle", () => {
         runtime.reapIdleProviderSessions({
           idleForMs: 0,
           nowMs: Date.now(),
-          providerSessionReapingEnabled: true,
         }),
       ).resolves.toEqual({ reapedSessions: [] });
       expect(runtime.hasThread("t1")).toBe(true);
@@ -1228,7 +1215,6 @@ describe("createAgentRuntime process lifecycle", () => {
       const result = await runtime.reapIdleProviderSessions({
         idleForMs: 0,
         nowMs: Date.now(),
-        providerSessionReapingEnabled: true,
       });
       expect(result.reapedSessions).toEqual([
         expect.objectContaining({ threadId: "t2" }),

--- a/packages/agent-runtime/src/runtime.ts
+++ b/packages/agent-runtime/src/runtime.ts
@@ -107,7 +107,6 @@ interface ReapIdleProviderSessionCandidate {
 interface FindReapableIdleProviderSessionArgs {
   idleForMs: number;
   nowMs: number;
-  providerSessionReapingEnabled: boolean;
   threadId: string;
 }
 
@@ -210,7 +209,6 @@ interface RequireProviderRequestPlanArgs {
   providerId: string;
 }
 
-const CODEX_PROVIDER_ID = "codex";
 const DEFAULT_THREAD_CREATION_REQUEST_TIMEOUT_MS = 2 * 60_000;
 const FAILED_CONSTRUCTION_RELEASE_TIMEOUT_MS = 5_000;
 
@@ -829,12 +827,7 @@ export function createAgentRuntime(options: AgentRuntimeOptions): AgentRuntime {
     }
 
     const runtimeConfig = threadRuntimeConfigs.get(args.threadId);
-    if (
-      !runtimeConfig ||
-      (args.providerSessionReapingEnabled
-        ? !runtimeConfig.sessionRestorable
-        : runtimeConfig.providerId !== CODEX_PROVIDER_ID)
-    ) {
+    if (!runtimeConfig?.sessionRestorable) {
       return null;
     }
 
@@ -2296,7 +2289,6 @@ export function createAgentRuntime(options: AgentRuntimeOptions): AgentRuntime {
     async reapIdleProviderSessions({
       idleForMs,
       nowMs,
-      providerSessionReapingEnabled,
       runThreadExclusive,
     }) {
       const reapedSessions: ReapedIdleProviderSession[] = [];
@@ -2305,7 +2297,6 @@ export function createAgentRuntime(options: AgentRuntimeOptions): AgentRuntime {
           const candidate = findReapableIdleProviderSession({
             idleForMs,
             nowMs,
-            providerSessionReapingEnabled,
             threadId,
           });
           if (!candidate) {

--- a/packages/agent-runtime/src/types.ts
+++ b/packages/agent-runtime/src/types.ts
@@ -223,7 +223,6 @@ export interface WaitForActiveTurnArgs {
 export interface ReapIdleProviderSessionsArgs {
   idleForMs: number;
   nowMs: number;
-  providerSessionReapingEnabled: boolean;
   runThreadExclusive?: (
     threadId: string,
     work: () => Promise<ReapedIdleProviderSession | null>,

--- a/packages/db/test/experiments.test.ts
+++ b/packages/db/test/experiments.test.ts
@@ -39,7 +39,6 @@ describe("experiments", () => {
         "editMessages",
         "futureExperiment",
         "mobileApp",
-        "providerSessionReaping",
         "timelineWindowing",
       ]);
     } finally {

--- a/packages/domain/src/experiments.ts
+++ b/packages/domain/src/experiments.ts
@@ -4,7 +4,6 @@ export const experimentKeys = [
   "changelogPreview",
   "editMessages",
   "mobileApp",
-  "providerSessionReaping",
   "timelineWindowing",
 ] as const;
 export const experimentKeySchema = z.enum(experimentKeys);
@@ -17,6 +16,5 @@ export const defaultExperiments: Experiments = {
   changelogPreview: false,
   editMessages: true,
   mobileApp: false,
-  providerSessionReaping: false,
   timelineWindowing: false,
 };

--- a/packages/domain/src/plugin-sdk-version.ts
+++ b/packages/domain/src/plugin-sdk-version.ts
@@ -1,3 +1,3 @@
-export const PLUGIN_SDK_VERSION = "0.4.29";
+export const PLUGIN_SDK_VERSION = "0.4.30";
 
 export const PLUGIN_SDK_MAJOR = Number(PLUGIN_SDK_VERSION.split(".", 1)[0]);

--- a/packages/host-daemon-contract/src/protocol.ts
+++ b/packages/host-daemon-contract/src/protocol.ts
@@ -1,3 +1,3 @@
-export const HOST_DAEMON_PROTOCOL_VERSION = 174 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 175 as const;
 
 export const HOST_ARTIFACT_MAX_BYTES = 256 * 1024 * 1024;

--- a/packages/host-daemon-contract/src/session.ts
+++ b/packages/host-daemon-contract/src/session.ts
@@ -47,15 +47,6 @@ export type HostDaemonLoadedEnvironment = z.infer<
   typeof hostDaemonLoadedEnvironmentSchema
 >;
 
-export const hostDaemonRuntimePolicySchema = z
-  .object({
-    providerSessionReaping: z.boolean(),
-  })
-  .strict();
-export type HostDaemonRuntimePolicy = z.infer<
-  typeof hostDaemonRuntimePolicySchema
->;
-
 const hostDaemonWatchSetWorkspaceTargetSchema = z
   .object({
     environmentId: z.string().min(1),
@@ -796,9 +787,6 @@ export const hostDaemonSkillTreeSchema = z
 export type HostDaemonSkillTree = z.infer<typeof hostDaemonSkillTreeSchema>;
 
 export type HostDaemonInternalSchema = {
-  "/runtime-policy": {
-    $get: Endpoint<Record<never, never>, HostDaemonRuntimePolicy, 200>;
-  };
   "/skills/tree/:hash": {
     $get: Endpoint<Record<never, never>, HostDaemonSkillTree, 200>;
   };

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -935,7 +935,7 @@ const ACP_BRIDGE_LAUNCH = {
 
 describe("host-daemon command schemas", () => {
   it("uses the current host-daemon protocol version", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(174);
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(175);
     expect(HOST_ARTIFACT_MAX_BYTES).toBe(256 * 1024 * 1024);
   });
 

--- a/packages/plugin-api-map/sdk-public-api.json
+++ b/packages/plugin-api-map/sdk-public-api.json
@@ -3,7 +3,7 @@
   "entries": {
     ".": {
       "types": "bundled-types/bb-plugin-sdk.d.ts",
-      "sha256": "fa4442250761eb37dc2cff041754f44277fbfae68afa35eb6743a8b252675720"
+      "sha256": "ba1eaa28fc58a0166127c8c13173ec51f52728df1771350d81d9a1d016d1ea5b"
     },
     "./ai-services": {
       "types": "bundled-types/bb-plugin-sdk-ai-services.d.ts",

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@get-bb/plugin-sdk",
-  "version": "0.4.29",
+  "version": "0.4.30",
   "homepage": "https://github.com/get-bb/bb#readme",
   "bugs": {
     "url": "https://github.com/get-bb/bb/issues"

--- a/packages/templates/src/templates/bb-guide-customization.md
+++ b/packages/templates/src/templates/bb-guide-customization.md
@@ -119,11 +119,9 @@ client-local; submitting stops and settles a running thread, then replaces the
 selected turn and all later conversation history while retaining workspace side
 effects. Grouped multi-message requests are not yet editable.
 
-The default-off `providerSessionReaping` experiment extends idle release to
-every restorable provider. BB releases those sessions after 30 idle minutes.
-The daemon applies a changed value within five minutes. Active turns, commands,
-agents, workflows, and monitors keep their sessions loaded. BB releases idle
-Codex sessions with the experiment off as well.
+BB releases restorable provider sessions after 30 idle minutes. The daemon
+checks for these sessions every five minutes. Active turns, commands, agents,
+workflows, and monitors keep their sessions loaded.
 
 The default-off `timelineWindowing` experiment mounts only nearby rows in long
 timelines and large expanded timeline details. Enable it with

--- a/plans/bb-mobile-research/settings-features.md
+++ b/plans/bb-mobile-research/settings-features.md
@@ -5,7 +5,7 @@ Settings buckets are declared in `apps/app/src/components/settings/settings-nav.
 ### Server-persisted (visible to any client)
 All served by `GET /system/config` (`packages/server-contract/src/api/system.ts:197-233`) and written by `PUT /settings/general|keyboard|experiments|appearance` (`packages/server-contract/src/public-api.ts:1332-1358`; SDK `packages/sdk/src/areas/system.ts:207-217`, `theme.ts:53`):
 - `AppSettings` (`packages/domain/src/app-settings.ts:7-51`): showKeyboardHints, steerActiveThreadOnEnter, showUnhandledProviderEvents, codexMemoryEnabled, claudeCodeMemoryEnabled, codexSubagentsDisabled, claudeCodeSubagentsDisabled, claudeCodeWorkflowsDisabled, onboardingCompletedAt. Used by General (`SettingsView.tsx:1256-1299`), Provider pages (`:930-991, 1107-1150`), Debug (`:903-917`).
-- Experiments (`packages/domain/src/experiments.ts:13-34`): claudeCodeMockCliTraffic, editMessages, newOnboarding, providerSessionReaping (`SettingsView.tsx:998-1066`).
+- Experiments (`packages/domain/src/experiments.ts`): changelogPreview, editMessages, mobileApp, timelineWindowing.
 - Appearance palette + favicon color (`packages/domain/src/app-theme.ts:122-134, 145-160`); custom themes are server-resolved CSS strings; built-ins are CSS-with-`color-mix` in `apps/app/src/lib/themes/*.ts` (e.g. `nord.ts:9-45`).
 - Keybinding overrides (`packages/domain/src/app-keybindings.ts:232-249`; `KeyboardSettingsSection.tsx`, uses `navigator.platform` at `:63-65`).
 - Hosts: `GET/PATCH/DELETE /hosts/:id`, `PATCH /hosts/:id/permission-ceiling`, `POST /hosts/:id/retry-update`, `POST /hosts/join-codes` (`packages/server-contract/src/api/hosts.ts:59-100`; `MachinesSettingsSection.tsx:200-375`; `MachineSettingsView.tsx:165-471`).

--- a/scripts/provider-literal-baseline.json
+++ b/scripts/provider-literal-baseline.json
@@ -1,11 +1,10 @@
 {
   "_comment": "Provider-literal ratchet (G1). Per-file occurrence count of provider-ID references in core. May only go DOWN. Regenerate: node scripts/check-provider-literal-ratchet.mjs --write. Every counted file must have an `allowlist` entry (count, reason, owner, diesAt); the entries are authored by hand and survive --write. Delete this file and the guard when empty.",
-  "total": 18,
+  "total": 15,
   "files": {
     "apps/demo-server/src/fixtures/providers.ts": 3,
     "apps/demo-server/src/fixtures/world.ts": 2,
     "apps/server/src/services/threads/thread-edit-message.ts": 1,
-    "packages/agent-runtime/src/runtime.ts": 3,
     "packages/config/src/bb-app-managed-config.ts": 4,
     "packages/scripts/src/commands/archive-codex-tmp-bb-sessions.ts": 1,
     "packages/scripts/src/lib/seed-perf-fixture.ts": 3,
@@ -29,12 +28,6 @@
       "reason": "legacy persisted data: pre-v3 codex timelines recorded the native turn id with no checkpoint; the fallback reads them.",
       "owner": "provider-codex",
       "diesAt": "legacy-tool-item-backfill migration (stamps the checkpoint onto old rows)"
-    },
-    "packages/agent-runtime/src/runtime.ts": {
-      "count": 3,
-      "reason": "the pre-experiment idle-session release policy: with `providerSessionReapingEnabled` off, only codex idle sessions are released (the behaviour bb shipped). The experiment reads `sessionRestorable` instead.",
-      "owner": "provider-codex / runtime",
-      "diesAt": "when `providerSessionReapingEnabled` graduates and the flag is deleted"
     },
     "packages/config/src/bb-app-managed-config.ts": {
       "count": 4,


### PR DESCRIPTION
## Human comments

## What was wrong

Idle session release remained behind the `providerSessionReaping` experiment after the provider restorability contract became available. Users had to enable the experiment before BB released restorable non-Codex sessions.

## What changed

BB now releases every restorable provider session after 30 idle minutes. The change removes the experiment key, Settings toggle, server policy route, and host-daemon policy request. It also removes the legacy Codex-only fallback. The host-daemon protocol version increases to 175 because the internal server contract changed. The Plugin SDK version increases to 0.4.30, and the Plugin Guide inventory includes the changed declaration hash. The configuration guide, built-in CLI skill reference, generated guide source, fixtures, and tests now describe the standard behavior.

## How you verified

- `pnpm exec turbo run typecheck --filter=@bb/agent-runtime --filter=@bb/host-daemon --filter=@bb/server --filter=@bb/app --filter=@bb/db --filter=@bb/host-daemon-contract`
- `pnpm exec turbo run test --filter=@bb/agent-runtime --force` passed 318 tests.
- `pnpm exec turbo run test --filter=@bb/host-daemon --filter=@bb/server --filter=@bb/app --filter=@bb/db --filter=@bb/host-daemon-contract --force` passed all affected suites.
- `pnpm exec turbo run test typecheck --filter=@get-bb/plugin-sdk --filter=@bb/plugin-api-map --filter=@bb/app --filter=bb-plugin-plugin-api-docs`
- `node packages/plugin-sdk/scripts/check-npm-version-guard.mjs`
- `bb plugin build plugins/plugin-api-docs`
- `node scripts/check-provider-literal-ratchet.mjs`
- `git diff --check`

Fixes #1604

> AGENT GENERATED
