### PR TITLE
Retire provider bridges after their final thread ends

### DIFF
--- a/packages/agent-runtime/src/runtime-provider-process.ts
+++ b/packages/agent-runtime/src/runtime-provider-process.ts
@@ -253,24 +253,6 @@ export class RuntimeProviderProcessManager {
     }
   }
 
-  async retireSupersededBridgeProcessIfIdle(
-    providerProcess: RuntimeProviderProcess,
-  ): Promise<void> {
-    if (providerProcess.identity.threadIds.size > 0) {
-      return;
-    }
-    const currentKey = this.currentProcessKeyByProviderId.get(
-      providerProcess.providerId,
-    );
-    if (currentKey === undefined || currentKey === providerProcess.processKey) {
-      return;
-    }
-    await this.shutdownProvider({
-      processKey: providerProcess.processKey,
-      providerId: providerProcess.providerId,
-    });
-  }
-
   requireProviderProcess(
     args: RequireRuntimeProviderProcessArgs,
   ): RuntimeProviderProcess {

--- a/packages/agent-runtime/src/runtime.acp-topology.test.ts
+++ b/packages/agent-runtime/src/runtime.acp-topology.test.ts
@@ -89,6 +89,6 @@ describe("acp process topology", () => {
       timeoutMs: 10_000,
     });
     expect(readFileSync(signalFile, "utf8")).toContain("SIGTERM");
-    expect(runtime.listRunningProviders()).toEqual(["acp"]);
+    expect(runtime.listRunningProviders()).toEqual([]);
   }, 30_000);
 });

--- a/packages/agent-runtime/src/runtime.codex-topology.test.ts
+++ b/packages/agent-runtime/src/runtime.codex-topology.test.ts
@@ -281,8 +281,8 @@ describe("codex process topology", () => {
       predicate: () => topology.exited() === 1,
       timeoutMs: 5_000,
     });
-    expect(runtime.listRunningProviders()).toEqual(["codex"]);
-    expect(topology.bridgeExits).toEqual([]);
+    expect(runtime.listRunningProviders()).toEqual([]);
+    expect(topology.bridgeExits).toEqual([{ expected: true }]);
   }, 30_000);
 
   it("releases the thread on the bridge when a construction times out on the runtime's side", async () => {
@@ -298,7 +298,8 @@ describe("codex process topology", () => {
       predicate: () => topology.spawned() === 1 && topology.exited() === 1,
       timeoutMs: 10_000,
     });
-    expect(runtime.listRunningProviders()).toEqual(["codex"]);
+    expect(runtime.listRunningProviders()).toEqual([]);
+    expect(topology.bridgeExits).toEqual([{ expected: true }]);
   }, 30_000);
 
   it("sweeps every app-server child when the bridge dies unexpectedly", async () => {

--- a/packages/agent-runtime/src/runtime.command-contract.test.ts
+++ b/packages/agent-runtime/src/runtime.command-contract.test.ts
@@ -197,7 +197,7 @@ describe("createAgentRuntime command contracts", () => {
       const requests = record.read();
       expect(
         requests.filter((entry) => entry.method === "initialize"),
-      ).toHaveLength(1);
+      ).toHaveLength(2);
       expect(requests).toContainEqual({
         method: "thread/archive",
         params: {

--- a/packages/agent-runtime/src/runtime.lifecycle.test.ts
+++ b/packages/agent-runtime/src/runtime.lifecycle.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ThreadEvent } from "@bb/domain";
 import { promptTextInput } from "./test/prompt-input.js";
 import {
+  createScriptedEchoLaunch,
   createScriptedEchoRequestRecord,
   createScriptedEchoRuntime,
   fullRuntimeOptions,
@@ -219,9 +220,14 @@ describe("createAgentRuntime lifecycle", () => {
           intent: "release",
         });
 
-        await expect(runtime.resumeThread(resume)).resolves.toEqual({
-          providerThreadId: "old-prov-123",
-        });
+        await expect(
+          runtime.resumeThread({
+            ...resume,
+            bridgeLaunch: createScriptedEchoLaunch({
+              digest: "resume-success",
+            }),
+          }),
+        ).resolves.toEqual({ providerThreadId: "old-prov-123" });
         expect(runtime.hasThread("t1")).toBe(true);
       } finally {
         await runtime.shutdown();
@@ -855,7 +861,7 @@ describe("createAgentRuntime lifecycle", () => {
       await runtime.shutdown();
     });
 
-    it("keeps the provider running after thread stop", async () => {
+    it("retires the provider after thread stop and starts it for resume", async () => {
       const events: ThreadEvent[] = [];
       const runtime = createScriptedEchoRuntime({
         runtime: {
@@ -879,7 +885,7 @@ describe("createAgentRuntime lifecycle", () => {
       });
 
       await runtime.stopThread({ threadId: "t1" });
-      expect(runtime.listRunningProviders()).toEqual(["fake"]);
+      expect(runtime.listRunningProviders()).toEqual([]);
       expect(runtime.hasThread("t1")).toBe(false);
       expect(runtime.getProviderSession("t1")).toBeNull();
       expect(runtime.getActiveTurnId("t1")).toBeNull();

--- a/packages/agent-runtime/src/runtime.process-lifecycle.test.ts
+++ b/packages/agent-runtime/src/runtime.process-lifecycle.test.ts
@@ -272,64 +272,6 @@ describe("createAgentRuntime process lifecycle", () => {
     await manager.shutdown();
   });
 
-  it("retires an old-hash bridge process when it loses its last thread", async () => {
-    const manager = createProviderProcessManager({
-      onProcessExit: vi.fn(),
-      workspacePath: tmpDir,
-    });
-
-    const staleKey = "fake#bridge:aaaaaaaaaaaaaaaa";
-    await manager.ensureProvider({
-      bridgeLaunch: MANAGER_BRIDGE_LAUNCH,
-      processKey: staleKey,
-      providerId: "fake",
-    });
-    const staleProcess = manager.requireProviderProcess({
-      processKey: staleKey,
-      providerId: "fake",
-    });
-    staleProcess.identity.threadIds.add("thread-live");
-
-    await manager.ensureProvider({
-      bridgeLaunch: MANAGER_BRIDGE_LAUNCH,
-      processKey: "fake#bridge:bbbbbbbbbbbbbbbb",
-      providerId: "fake",
-    });
-    expect(staleProcess.child.killed).toBe(false);
-
-    await manager.retireSupersededBridgeProcessIfIdle(staleProcess);
-    expect(staleProcess.child.killed).toBe(false);
-
-    staleProcess.identity.threadIds.delete("thread-live");
-    await manager.retireSupersededBridgeProcessIfIdle(staleProcess);
-    expect(staleProcess.child.killed).toBe(true);
-
-    await manager.shutdown();
-  });
-
-  it("keeps the current-hash bridge process when a thread is released", async () => {
-    const manager = createProviderProcessManager({
-      onProcessExit: vi.fn(),
-      workspacePath: tmpDir,
-    });
-
-    const currentKey = "fake#bridge:aaaaaaaaaaaaaaaa";
-    await manager.ensureProvider({
-      bridgeLaunch: MANAGER_BRIDGE_LAUNCH,
-      processKey: currentKey,
-      providerId: "fake",
-    });
-    const providerProcess = manager.requireProviderProcess({
-      processKey: currentKey,
-      providerId: "fake",
-    });
-
-    await manager.retireSupersededBridgeProcessIfIdle(providerProcess);
-    expect(providerProcess.child.killed).toBe(false);
-
-    await manager.shutdown();
-  });
-
   it("bounds provider stderr while data arrives without a newline", async () => {
     const exitInfo = vi.fn<NonNullable<AgentRuntimeOptions["onProcessExit"]>>();
     const stderrLines: string[] = [];
@@ -814,7 +756,7 @@ describe("createAgentRuntime process lifecycle", () => {
     await runtime.shutdown();
   });
 
-  it("keeps the codex provider process when one session construction fails", async () => {
+  it("retires the provider process when session construction fails", async () => {
     const events: ThreadEvent[] = [];
     const { processLog, runtime } = createCodexRuntime({
       events,
@@ -834,10 +776,10 @@ describe("createAgentRuntime process lifecycle", () => {
       }),
     ).rejects.toThrow("no rollout found");
     expect(runtime.getProviderSession("t1")).toBeNull();
-    expect(runtime.listRunningProviders()).toEqual(["codex"]);
+    expect(runtime.listRunningProviders()).toEqual([]);
     expect(
       processLog.read().filter((line) => line.startsWith("exit:")),
-    ).toHaveLength(0);
+    ).toHaveLength(1);
     await runtime.shutdown();
   });
 
@@ -941,16 +883,16 @@ describe("createAgentRuntime process lifecycle", () => {
         }),
       ]);
       expect(runtime.getProviderSession("t1")).toBeNull();
-      expect(runtime.listRunningProviders()).toEqual(["codex"]);
+      expect(runtime.listRunningProviders()).toEqual([]);
       expect(
         processLog.read().filter((line) => line.startsWith("exit:")),
-      ).toHaveLength(0);
+      ).toHaveLength(1);
     } finally {
       await runtime.shutdown();
     }
   });
 
-  it("reaps an idle codex session and resumes it later on the same process", async () => {
+  it("reaps an idle codex session and resumes it on a new process", async () => {
     const events: ThreadEvent[] = [];
     const { processLog, runtime } = createCodexRuntime({ events });
     try {
@@ -1006,7 +948,7 @@ describe("createAgentRuntime process lifecycle", () => {
       expect(reapedSession.idleForMs).toBeGreaterThanOrEqual(30 * 60 * 1000);
       expect(runtime.hasThread("t1")).toBe(false);
       expect(runtime.getProviderSession("t1")).toBeNull();
-      expect(runtime.listRunningProviders()).toEqual(["codex"]);
+      expect(runtime.listRunningProviders()).toEqual([]);
 
       await runtime.resumeThread({
         environmentId: "env-1",
@@ -1031,10 +973,10 @@ describe("createAgentRuntime process lifecycle", () => {
       });
       const logLines = processLog.read();
       expect(logLines.filter((line) => line.startsWith("spawn:"))).toHaveLength(
-        1,
+        2,
       );
       expect(logLines.filter((line) => line.startsWith("exit:"))).toHaveLength(
-        0,
+        1,
       );
       expect(
         logLines.some(
@@ -1093,8 +1035,10 @@ describe("createAgentRuntime process lifecycle", () => {
 
   it("reaps a restorable non-Codex session", async () => {
     const events: ThreadEvent[] = [];
+    const processLog = createScriptedEchoProcessLog();
     const runtime = createScriptedEchoRuntime({
       runtime: {
+        env: processLog.env,
         workspacePath: tmpDir,
         onEvent: (event) => events.push(event),
       },
@@ -1122,6 +1066,10 @@ describe("createAgentRuntime process lifecycle", () => {
         }),
       ]);
       expect(runtime.hasThread("t1")).toBe(false);
+      expect(runtime.listRunningProviders()).toEqual([]);
+      expect(
+        processLog.read().filter((line) => line.startsWith("exit:")),
+      ).toHaveLength(1);
     } finally {
       await runtime.shutdown();
     }

--- a/packages/agent-runtime/src/runtime.ts
+++ b/packages/agent-runtime/src/runtime.ts
@@ -377,7 +377,13 @@ export function createAgentRuntime(options: AgentRuntimeOptions): AgentRuntime {
   async function releaseIdleProviderProcess(
     proc: ProviderProcess,
   ): Promise<void> {
-    await providerProcesses.retireSupersededBridgeProcessIfIdle(proc);
+    if (proc.identity.threadIds.size > 0) {
+      return;
+    }
+    await providerProcesses.shutdownProvider({
+      processKey: proc.processKey,
+      providerId: proc.providerId,
+    });
   }
 
   async function abandonFailedSessionConstruction(args: {


### PR DESCRIPTION
## Human comments

## What was wrong

The runtime retired only a superseded provider bridge after its final thread ended. It kept the current bridge active with no threads.

## What changed

The runtime now stops each provider bridge after its final thread ends. It keeps a shared bridge active while another thread uses it. A later request starts a new bridge and restores the session. This change also removes the superseded-only retirement method. The stale bridge check remains for bridges that never owned a thread. This change does not alter the host daemon protocol.

## How you verified

The lifecycle tests now cover final-thread stop, failed session creation, idle session release, ACP, Codex, and replacement bridge resume. These checks failed before the change because the current bridge stayed active.

- `pnpm exec turbo run test --filter=@bb/agent-runtime --force` (316 tests passed)
- `pnpm exec turbo run typecheck --filter=@bb/agent-runtime`
- `git diff --check`

Fixes #2308

> AGENT GENERATED
