### PR TITLE
Fix recovered task thread failure comments

### DIFF
--- a/plugins/tasks/lifecycle/index.ts
+++ b/plugins/tasks/lifecycle/index.ts
@@ -36,11 +36,13 @@ function trackedThreads(store: TasksApiStore, threadId?: string): TaskThread[] {
   return tracked;
 }
 
-function terminalCommentBody(
+function statusCommentBody(
   thread: TaskThread,
   liveStatus: Extract<TaskThreadLiveStatus, "completed" | "failed">,
 ): string {
-  return `Thread "${thread.title}" ${liveStatus} — final message posted · ${thread.threadId}`;
+  const outcome =
+    liveStatus === "completed" ? "completed — final message posted" : "failed";
+  return `Thread "${thread.title}" ${outcome} · ${thread.threadId}`;
 }
 
 function sdkErrorCode(error: unknown): string | undefined {
@@ -70,7 +72,7 @@ function transitionThread(
         taskId: thread.taskId,
         presetName: thread.presetName,
         threadId: thread.threadId,
-        body: terminalCommentBody(thread, liveStatus),
+        body: statusCommentBody(thread, liveStatus),
       });
     }
   });

--- a/plugins/tasks/lifecycle/lifecycle.test.ts
+++ b/plugins/tasks/lifecycle/lifecycle.test.ts
@@ -95,7 +95,7 @@ describe("task thread lifecycle", () => {
     await fixture.harness.dispose();
   });
 
-  it("moves a working thread to failed, comments, and publishes", async () => {
+  it("recovers a failed thread without recording failure as terminal", async () => {
     const fixture = trackedThreadFixture("working", "active");
     await registerLifecycle(fixture.bb, fixture.store);
 
@@ -111,35 +111,19 @@ describe("task thread lifecycle", () => {
     expect(
       fixture.store.tasks.getTaskThread(fixture.taskThreadId)?.liveStatus,
     ).toBe("failed");
-    expect(fixture.store.tasks.listComments(fixture.taskId)).toContainEqual(
+    const commentsAfterFailure = fixture.store.tasks.listComments(
+      fixture.taskId,
+    );
+    expect(commentsAfterFailure).toContainEqual(
       expect.objectContaining({
         kind: "system",
-        body: 'Thread "Lifecycle worker" failed — final message posted · thr_worker',
+        body: 'Thread "Lifecycle worker" failed · thr_worker',
       }),
     );
     expect(fixture.harness.realtimeSignals).toEqual([
       { channel: "threads:changed", payload: { taskId: fixture.taskId } },
       { channel: "comments:changed", payload: { taskId: fixture.taskId } },
     ]);
-
-    await fixture.harness.dispose();
-  });
-
-  it("restores activity after a failed turn", async () => {
-    const fixture = trackedThreadFixture("working", "active");
-    await registerLifecycle(fixture.bb, fixture.store);
-
-    await fixture.harness.emitThreadEvent("thread.failed", {
-      thread: makeThreadResponse({
-        id: "thr_worker",
-        title: "Lifecycle worker",
-        status: "error",
-      }),
-      error: "provider exited",
-    });
-    expect(
-      fixture.store.tasks.getTaskThread(fixture.taskThreadId)?.liveStatus,
-    ).toBe("failed");
 
     await fixture.harness.emitThreadEvent("thread.active", {
       thread: makeThreadResponse({
@@ -151,6 +135,9 @@ describe("task thread lifecycle", () => {
     expect(
       fixture.store.tasks.getTaskThread(fixture.taskThreadId)?.liveStatus,
     ).toBe("working");
+    expect(fixture.store.tasks.listComments(fixture.taskId)).toEqual(
+      commentsAfterFailure,
+    );
 
     await fixture.harness.dispose();
   });


### PR DESCRIPTION
## Human comments

## What was wrong

The Tasks lifecycle correctly lets a failed thread return to working, but its shared comment formatter still described every failure as terminal with “final message posted.” A recovered, actively working thread could therefore retain contradictory terminal history.

## What changed

Failures now post a factual non-terminal failure comment, while completed threads retain “completed — final message posted.” Focused lifecycle coverage drives failure and recovery together and verifies that recovery changes status without adding another comment. Existing recovery, active views, completed semantics, and task status updates remain unchanged. This is plugin-local behavior with no SDK, wire, CLI, or documentation changes.

## How you verified

- `pnpm exec turbo run test typecheck build --filter=bb-plugin-tasks --force` (364 tests)
- `pnpm exec oxfmt --check plugins/tasks/lifecycle/index.ts plugins/tasks/lifecycle/lifecycle.test.ts`
- `git diff --check origin/main...HEAD`

Follow-up to #2694.

> AGENT GENERATED