### PR TITLE
Add search to the parent thread picker

### DIFF
--- a/apps/app/src/components/pickers/ParentThreadPicker.test.tsx
+++ b/apps/app/src/components/pickers/ParentThreadPicker.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  ParentThreadPicker,
+  type ParentThreadPickerProps,
+} from "./ParentThreadPicker";
+
+const OPTIONS = [
+  { value: "none", label: "None" },
+  { value: "thr_codex_parent", label: "Codex Parent" },
+  { value: "thr_frontend_parent", label: "Frontend Parent" },
+] as const;
+
+function picker(overrides: Partial<ParentThreadPickerProps> = {}) {
+  return (
+    <ParentThreadPicker
+      value="none"
+      options={OPTIONS}
+      isLoading={false}
+      isError={false}
+      onChange={vi.fn()}
+      onOpenChange={vi.fn()}
+      onRetry={vi.fn()}
+      {...overrides}
+    />
+  );
+}
+
+afterEach(cleanup);
+
+describe("ParentThreadPicker", () => {
+  it("requests candidates only when opened", async () => {
+    const onOpenChange = vi.fn();
+    render(picker({ isLoading: true, onOpenChange }));
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+    expect(await screen.findByText("Loading threads…")).toBeTruthy();
+  });
+
+  it("offers a retry after candidate loading fails and shows recovered results", async () => {
+    const onRetry = vi.fn();
+    const result = render(picker({ isError: true, options: [], onRetry }));
+
+    fireEvent.click(screen.getByRole("button"));
+    fireEvent.click(await screen.findByText("Retry loading threads"));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+
+    result.rerender(picker());
+    fireEvent.click(screen.getByRole("button"));
+    expect(await screen.findByText("Codex Parent")).toBeTruthy();
+  });
+
+  it("searches candidates by title and selects the match", async () => {
+    const onChange = vi.fn();
+    render(picker({ onChange }));
+
+    fireEvent.click(screen.getByRole("button"));
+    const search = await screen.findByRole("combobox", {
+      name: "Search parent threads",
+    });
+    fireEvent.change(search, { target: { value: "frontend" } });
+
+    expect(screen.queryByRole("option", { name: /Codex Parent/u })).toBeNull();
+    fireEvent.click(screen.getByRole("option", { name: /Frontend Parent/u }));
+
+    expect(onChange).toHaveBeenCalledWith("thr_frontend_parent");
+    expect(
+      screen.queryByRole("combobox", { name: "Search parent threads" }),
+    ).toBeNull();
+  });
+});

--- a/apps/app/src/components/pickers/ParentThreadPicker.tsx
+++ b/apps/app/src/components/pickers/ParentThreadPicker.tsx
@@ -1,0 +1,155 @@
+import { useCallback, useState } from "react";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@bb/shared-ui/command";
+import {
+  COARSE_POINTER_COMPACT_ICON_SIZE_SHRINK_CLASS,
+  COARSE_POINTER_ICON_SIZE_CLASS,
+  COARSE_POINTER_TEXT_SM_CLASS,
+} from "@bb/shared-ui/coarse-pointer-sizing";
+import { Icon } from "@bb/shared-ui/icon";
+import { cn } from "@bb/shared-ui/lib/utils";
+import { Popover, PopoverContent, PopoverTrigger } from "@bb/shared-ui/popover";
+
+export interface ParentThreadPickerOption {
+  label: string;
+  value: string;
+}
+
+export interface ParentThreadPickerProps {
+  value: string;
+  options: readonly ParentThreadPickerOption[];
+  isLoading: boolean;
+  isError: boolean;
+  disabled?: boolean;
+  onChange: (value: string) => void;
+  onOpenChange: (open: boolean) => void;
+  onRetry: () => void;
+  defaultOpen?: boolean;
+}
+
+export function ParentThreadPicker({
+  value,
+  options,
+  isLoading,
+  isError,
+  disabled = false,
+  onChange,
+  onOpenChange,
+  onRetry,
+  defaultOpen,
+}: ParentThreadPickerProps) {
+  const [open, setOpen] = useState(defaultOpen ?? false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const selectedLabel =
+    options.find((option) => option.value === value)?.label ?? "None";
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      setOpen(nextOpen);
+      if (!nextOpen) {
+        setSearchQuery("");
+      }
+      onOpenChange(nextOpen);
+    },
+    [onOpenChange],
+  );
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          disabled={disabled}
+          className={cn(
+            "-mx-1 inline-flex h-5 w-fit max-w-full min-w-0 items-center gap-1 rounded-sm px-1 leading-tight text-foreground outline-none ring-sidebar-ring transition-colors hover:bg-state-hover data-[state=open]:bg-state-hover focus-visible:ring-2 disabled:cursor-default",
+            COARSE_POINTER_TEXT_SM_CLASS,
+          )}
+        >
+          <span
+            className={cn(
+              "min-w-0 truncate text-foreground",
+              COARSE_POINTER_TEXT_SM_CLASS,
+            )}
+          >
+            {selectedLabel}
+          </span>
+          <Icon
+            name="ChevronDown"
+            className={cn(
+              COARSE_POINTER_COMPACT_ICON_SIZE_SHRINK_CLASS,
+              "text-muted-foreground",
+            )}
+          />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className="w-72 p-0 max-md:w-full"
+        mobileTitle="Assign parent thread"
+      >
+        <Command label="Search parent threads">
+          <CommandInput
+            aria-label="Search parent threads"
+            placeholder="Search threads…"
+            value={searchQuery}
+            onValueChange={setSearchQuery}
+          />
+          <CommandList className="max-h-72">
+            {isLoading ? (
+              <div className="px-3 py-2 text-sm text-muted-foreground">
+                Loading threads…
+              </div>
+            ) : isError ? (
+              <CommandGroup>
+                <CommandItem
+                  forceMount
+                  value="retry"
+                  onSelect={() => {
+                    onRetry();
+                    handleOpenChange(false);
+                  }}
+                >
+                  Retry loading threads
+                </CommandItem>
+              </CommandGroup>
+            ) : (
+              <>
+                <CommandEmpty>No matching threads.</CommandEmpty>
+                <CommandGroup heading="Assign parent thread">
+                  {options.map((option) => (
+                    <CommandItem
+                      key={option.value}
+                      value={option.value}
+                      keywords={[option.label]}
+                      onSelect={() => {
+                        onChange(option.value);
+                        handleOpenChange(false);
+                      }}
+                      className="flex items-center justify-between gap-3"
+                    >
+                      <span className="truncate" title={option.label}>
+                        {option.label}
+                      </span>
+                      <Icon
+                        name="Check"
+                        className={cn(
+                          COARSE_POINTER_ICON_SIZE_CLASS,
+                          value === option.value ? "opacity-100" : "opacity-0",
+                        )}
+                      />
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/app/src/components/secondary-panel/ThreadMetadataContent.test.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadMetadataContent.test.tsx
@@ -12,12 +12,7 @@ import { MemoryRouter } from "react-router-dom";
 import type { Environment, Thread } from "@bb/domain";
 import { TooltipProvider } from "@bb/shared-ui/tooltip";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  EnvironmentRow,
-  ParentSelectorRow,
-  ThreadMetadataCard,
-} from "./ThreadMetadataContent";
-import { parentThreads } from "./ThreadMetadataContent.fixtures";
+import { EnvironmentRow, ThreadMetadataCard } from "./ThreadMetadataContent";
 
 const localHost = { locality: "local", identity: null } as const;
 
@@ -167,84 +162,5 @@ describe("EnvironmentRow", () => {
     );
 
     expect(markup).not.toContain('aria-label="Create thread in worktree"');
-  });
-});
-
-describe("ParentSelectorRow", () => {
-  it("requests candidates only when the parent menu opens", async () => {
-    const onOpenChange = vi.fn();
-    render(
-      <MemoryRouter>
-        <ParentSelectorRow
-          thread={makeThread({ environmentId: null })}
-          projectId="proj_test"
-          parentThreadProjectId={null}
-          parentThreadDisplayName={null}
-          parentThreads={[]}
-          canAssignToParent
-          canTakeOverThread={false}
-          isLoadingParentThreads
-          isParentThreadsError={false}
-          updateThreadPending={false}
-          onAssignParent={vi.fn()}
-          onParentSelectorOpenChange={onOpenChange}
-          onRetryParentThreads={vi.fn()}
-        />
-      </MemoryRouter>,
-    );
-
-    expect(onOpenChange).not.toHaveBeenCalled();
-    fireEvent.pointerDown(screen.getByRole("button"), {
-      button: 0,
-      ctrlKey: false,
-    });
-
-    expect(onOpenChange).toHaveBeenCalledWith(true);
-    expect(await screen.findByText("Loading threads…")).toBeTruthy();
-  });
-
-  it("offers a retry after candidate loading fails and shows recovered results", async () => {
-    const onRetry = vi.fn();
-    const row = (isError: boolean, candidates = parentThreads) => (
-      <MemoryRouter>
-        <ParentSelectorRow
-          thread={makeThread({ environmentId: null })}
-          projectId="proj_test"
-          parentThreadProjectId={null}
-          parentThreadDisplayName={null}
-          parentThreads={candidates}
-          canAssignToParent
-          canTakeOverThread={false}
-          isLoadingParentThreads={false}
-          isParentThreadsError={isError}
-          updateThreadPending={false}
-          onAssignParent={vi.fn()}
-          onParentSelectorOpenChange={vi.fn()}
-          onRetryParentThreads={onRetry}
-        />
-      </MemoryRouter>
-    );
-    const result = render(row(true, []));
-
-    fireEvent.pointerDown(screen.getByRole("button"), {
-      button: 0,
-      ctrlKey: false,
-    });
-    fireEvent.click(await screen.findByText("Retry loading threads"));
-    expect(onRetry).toHaveBeenCalledTimes(1);
-
-    result.rerender(row(false));
-    const trigger = screen
-      .getAllByRole("button")
-      .reverse()
-      .find((candidate) => candidate.getAttribute("aria-haspopup") === "menu");
-    if (!trigger) {
-      throw new Error("missing parent selector trigger");
-    }
-    fireEvent.pointerDown(trigger, {
-      button: 0,
-      ctrlKey: false,
-    });
-    expect(await screen.findByText("Codex Parent")).toBeTruthy();
   });
 });

--- a/apps/app/src/components/secondary-panel/ThreadMetadataContent.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadMetadataContent.tsx
@@ -30,8 +30,6 @@ import { formatWorkspaceCheckoutDisplay } from "@/lib/workspace-checkout-display
 import { Button } from "@bb/shared-ui/button";
 import {
   COARSE_POINTER_COMPACT_ICON_BUTTON_CLASS,
-  COARSE_POINTER_COMPACT_ICON_SIZE_SHRINK_CLASS,
-  COARSE_POINTER_ICON_SIZE_CLASS,
   COARSE_POINTER_TEXT_SM_CLASS,
 } from "@bb/shared-ui/coarse-pointer-sizing";
 import { CopyableInlineLabel } from "@/components/ui/copy-button.js";
@@ -43,13 +41,6 @@ import {
 } from "@/components/ui/detail-card.js";
 import { CHROME_SECTION_LABEL_CLASS } from "@bb/shared-ui/chrome-style-tokens";
 import { useCreateThreadInWorktree } from "@/hooks/useCreateThreadInWorktree";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuTrigger,
-} from "@bb/shared-ui/dropdown-menu";
 import { Icon } from "@bb/shared-ui/icon";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@bb/shared-ui/tooltip";
 import {
@@ -82,6 +73,7 @@ import {
 } from "@/components/pull-request/PullRequestStatusPill";
 import { GithubFaviconIcon } from "@/components/pull-request/GithubFaviconIcon";
 import { useUrlAnchorClickHandler } from "@/lib/url-open-routing";
+import { ParentThreadPicker } from "@/components/pickers/ParentThreadPicker";
 
 interface ParentSelectorRowProps {
   thread: Thread;
@@ -175,71 +167,19 @@ export function ParentSelectorRow({
           </Button>
         </div>
       ) : (
-        <DropdownMenu
-          defaultOpen={defaultOpen}
+        <ParentThreadPicker
+          value={parentSelectorValue}
+          options={parentSelectorOptions}
+          isLoading={isLoadingParentThreads}
+          isError={isParentThreadsError}
+          disabled={updateThreadPending}
+          onChange={(value) => {
+            onAssignParent(value === "none" ? null : value);
+          }}
           onOpenChange={onParentSelectorOpenChange}
-        >
-          <DropdownMenuTrigger asChild>
-            <div
-              role="button"
-              tabIndex={updateThreadPending ? -1 : 0}
-              className={cn(
-                "-mx-1 inline-flex h-5 w-fit max-w-full min-w-0 items-center gap-1 rounded-sm px-1 leading-tight text-foreground outline-none ring-sidebar-ring transition-colors hover:bg-state-hover data-[state=open]:bg-state-hover focus-visible:ring-2",
-                COARSE_POINTER_TEXT_SM_CLASS,
-              )}
-            >
-              <span
-                className={cn(
-                  "min-w-0 truncate text-foreground",
-                  COARSE_POINTER_TEXT_SM_CLASS,
-                )}
-              >
-                {selectedParentOptionLabel ?? "None"}
-              </span>
-              <Icon
-                name="ChevronDown"
-                className={cn(
-                  COARSE_POINTER_COMPACT_ICON_SIZE_SHRINK_CLASS,
-                  "text-muted-foreground",
-                )}
-              />
-            </div>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="start" className="min-w-40 max-w-72">
-            <DropdownMenuLabel>Assign parent thread</DropdownMenuLabel>
-            {isLoadingParentThreads ? (
-              <DropdownMenuItem disabled>Loading threads…</DropdownMenuItem>
-            ) : isParentThreadsError ? (
-              <DropdownMenuItem onSelect={onRetryParentThreads}>
-                Retry loading threads
-              </DropdownMenuItem>
-            ) : (
-              parentSelectorOptions.map((option) => (
-                <DropdownMenuItem
-                  key={option.value}
-                  onSelect={() => {
-                    onAssignParent(
-                      option.value === "none" ? null : option.value,
-                    );
-                  }}
-                  className="flex items-center justify-between gap-3"
-                >
-                  <span className="truncate" title={option.label}>
-                    {option.label}
-                  </span>
-                  <Icon
-                    name="Check"
-                    className={
-                      parentSelectorValue === option.value
-                        ? cn("opacity-100", COARSE_POINTER_ICON_SIZE_CLASS)
-                        : cn("opacity-0", COARSE_POINTER_ICON_SIZE_CLASS)
-                    }
-                  />
-                </DropdownMenuItem>
-              ))
-            )}
-          </DropdownMenuContent>
-        </DropdownMenu>
+          onRetry={onRetryParentThreads}
+          defaultOpen={defaultOpen}
+        />
       )}
     </DetailRow>
   );


### PR DESCRIPTION
## Human comments

## What was wrong

The parent-thread selector rendered every eligible thread in an unsearchable dropdown. As projects accumulated threads, locating a parent by title or ID became slow and error-prone.

## What changed

Extract the selector into a dedicated `ParentThreadPicker` and add title/ID search, keyboard-friendly command navigation, empty results, loading and retry states, and query reset on close. The metadata row now only composes the picker and translates its selected value. Existing lazy loading, candidate ordering, eligibility filtering, selection, and responsive drawer behavior remain intact. This is app-only behavior with no wire, CLI, or documentation changes.

## How you verified

- `pnpm exec turbo run test typecheck lint --filter=@bb/app --force` (449 files; 3,541 passed, 4 skipped)
- `pnpm exec oxfmt --check` on all four changed files
- `git diff --check`
- Manual QA against parent candidates by title, ID, empty results, selection, and clearing

Fixes: no linked issue.

> AGENT GENERATED