### PR TITLE
Make project branch freshness implicit

### DIFF
--- a/apps/app/src/hooks/queries/project-queries.test.tsx
+++ b/apps/app/src/hooks/queries/project-queries.test.tsx
@@ -2,6 +2,7 @@
 
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import type { ProjectBranchesResponse } from "@bb/server-contract";
+import { readProjectBranchOptions } from "@/lib/project-branch-options";
 import { sdk } from "@/lib/sdk";
 import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -10,6 +11,10 @@ import { projectSourceBranchesQueryKeyPrefix } from "./query-keys";
 
 vi.mock("@/lib/sdk", () => ({
   sdk: { projects: { branches: vi.fn() } },
+}));
+
+vi.mock("@/lib/project-branch-options", () => ({
+  readProjectBranchOptions: vi.fn(),
 }));
 
 vi.mock("@/hooks/useRealtimeSubscription", () => ({
@@ -37,26 +42,30 @@ describe("useProjectSourceBranches", () => {
     vi.clearAllMocks();
   });
 
-  it("starts with cached refs and exposes an explicit blocking remote refresh", async () => {
+  it("starts with cached branch options and refreshes through the blocking SDK operation", async () => {
     const { wrapper, queryClient } = createQueryClientTestHarness();
-    vi.mocked(sdk.projects.branches)
-      .mockResolvedValueOnce(INITIAL_BRANCHES)
-      .mockResolvedValueOnce({
-        ...INITIAL_BRANCHES,
-        remoteBranches: ["origin/main", "origin/new"],
-      });
+    vi.mocked(readProjectBranchOptions).mockResolvedValueOnce(INITIAL_BRANCHES);
+    vi.mocked(sdk.projects.branches).mockResolvedValueOnce({
+      ...INITIAL_BRANCHES,
+      remoteBranches: ["origin/main", "origin/new"],
+    });
 
     const { result } = renderHook(
       () => useProjectSourceBranches("project-1", "host-1"),
       { wrapper },
     );
     await waitFor(() => {
-      expect(sdk.projects.branches).toHaveBeenCalledTimes(1);
+      expect(readProjectBranchOptions).toHaveBeenCalledTimes(1);
     });
-    expect(sdk.projects.branches).toHaveBeenNthCalledWith(
+    expect(readProjectBranchOptions).toHaveBeenNthCalledWith(
       1,
-      expect.objectContaining({ refresh: "background" }),
+      expect.objectContaining({
+        hostId: "host-1",
+        limit: "50",
+        projectId: "project-1",
+      }),
     );
+    expect(sdk.projects.branches).not.toHaveBeenCalled();
 
     await act(async () => {
       await result.current.refreshFromRemote();
@@ -68,15 +77,14 @@ describe("useProjectSourceBranches", () => {
       ]);
     });
     expect(sdk.projects.branches).toHaveBeenNthCalledWith(
-      2,
+      1,
       expect.objectContaining({
         hostId: "host-1",
         limit: "50",
         projectId: "project-1",
-        refresh: "blocking",
       }),
     );
-    expect(vi.mocked(sdk.projects.branches).mock.calls[1]?.[0]).toHaveProperty(
+    expect(vi.mocked(sdk.projects.branches).mock.calls[0]?.[0]).toHaveProperty(
       "signal",
     );
 
@@ -91,18 +99,18 @@ describe("useProjectSourceBranches", () => {
     );
   });
 
-  it("reports fetching while the blocking refresh waits, then reverts to cached reads", async () => {
+  it("reports fetching while the blocking read waits, then reverts to cached reads", async () => {
     const { wrapper } = createQueryClientTestHarness();
     let releaseBlocking: ((value: ProjectBranchesResponse) => void) | undefined;
-    vi.mocked(sdk.projects.branches)
+    vi.mocked(readProjectBranchOptions)
       .mockResolvedValueOnce(INITIAL_BRANCHES)
-      .mockImplementationOnce(
-        () =>
-          new Promise<ProjectBranchesResponse>((resolve) => {
-            releaseBlocking = resolve;
-          }),
-      )
       .mockResolvedValueOnce(INITIAL_BRANCHES);
+    vi.mocked(sdk.projects.branches).mockImplementationOnce(
+      () =>
+        new Promise<ProjectBranchesResponse>((resolve) => {
+          releaseBlocking = resolve;
+        }),
+    );
 
     const { result } = renderHook(
       () => useProjectSourceBranches("project-1", "host-1"),
@@ -131,34 +139,31 @@ describe("useProjectSourceBranches", () => {
     await act(async () => {
       await result.current.refetch();
     });
-    expect(sdk.projects.branches).toHaveBeenNthCalledWith(
-      3,
-      expect.objectContaining({ refresh: "background" }),
-    );
+    expect(readProjectBranchOptions).toHaveBeenCalledTimes(2);
   });
 
   it("still reaches the daemon when the picker opens during the initial cached fetch", async () => {
     const { wrapper } = createQueryClientTestHarness();
     let releaseInitial: ((value: ProjectBranchesResponse) => void) | undefined;
-    vi.mocked(sdk.projects.branches)
+    vi.mocked(readProjectBranchOptions)
       .mockImplementationOnce(
         () =>
           new Promise<ProjectBranchesResponse>((resolve) => {
             releaseInitial = resolve;
           }),
       )
-      .mockResolvedValueOnce({
-        ...INITIAL_BRANCHES,
-        remoteBranches: ["origin/main", "origin/new"],
-      })
       .mockResolvedValueOnce(INITIAL_BRANCHES);
+    vi.mocked(sdk.projects.branches).mockResolvedValueOnce({
+      ...INITIAL_BRANCHES,
+      remoteBranches: ["origin/main", "origin/new"],
+    });
 
     const { result } = renderHook(
       () => useProjectSourceBranches("project-1", "host-1"),
       { wrapper },
     );
     await waitFor(() => {
-      expect(sdk.projects.branches).toHaveBeenCalledTimes(1);
+      expect(readProjectBranchOptions).toHaveBeenCalledTimes(1);
     });
 
     let refreshed: Promise<void> | undefined;
@@ -171,11 +176,11 @@ describe("useProjectSourceBranches", () => {
     });
 
     await waitFor(() => {
-      expect(sdk.projects.branches).toHaveBeenCalledTimes(2);
+      expect(sdk.projects.branches).toHaveBeenCalledTimes(1);
     });
     expect(sdk.projects.branches).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({ refresh: "blocking" }),
+      1,
+      expect.objectContaining({ projectId: "project-1" }),
     );
     await waitFor(() => {
       expect(result.current.data?.remoteBranches).toEqual([
@@ -187,18 +192,15 @@ describe("useProjectSourceBranches", () => {
     await act(async () => {
       await result.current.refetch();
     });
-    expect(sdk.projects.branches).toHaveBeenNthCalledWith(
-      3,
-      expect.objectContaining({ refresh: "background" }),
-    );
+    expect(readProjectBranchOptions).toHaveBeenCalledTimes(2);
   });
 
-  it("keeps every retry of a blocking refresh blocking", async () => {
+  it("keeps every retry of a blocking read on the public operation", async () => {
     const { wrapper } = createQueryClientTestHarness({
       queries: { retry: 1, retryDelay: 0 },
     });
+    vi.mocked(readProjectBranchOptions).mockResolvedValueOnce(INITIAL_BRANCHES);
     vi.mocked(sdk.projects.branches)
-      .mockResolvedValueOnce(INITIAL_BRANCHES)
       .mockRejectedValueOnce(new Error("Failed to fetch"))
       .mockResolvedValueOnce({
         ...INITIAL_BRANCHES,
@@ -210,7 +212,7 @@ describe("useProjectSourceBranches", () => {
       { wrapper },
     );
     await waitFor(() => {
-      expect(sdk.projects.branches).toHaveBeenCalledTimes(1);
+      expect(readProjectBranchOptions).toHaveBeenCalledTimes(1);
     });
 
     await act(async () => {
@@ -218,15 +220,15 @@ describe("useProjectSourceBranches", () => {
     });
 
     await waitFor(() => {
-      expect(sdk.projects.branches).toHaveBeenCalledTimes(3);
+      expect(sdk.projects.branches).toHaveBeenCalledTimes(2);
     });
     expect(sdk.projects.branches).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({ refresh: "blocking" }),
+      1,
+      expect.objectContaining({ projectId: "project-1" }),
     );
     expect(sdk.projects.branches).toHaveBeenNthCalledWith(
-      3,
-      expect.objectContaining({ refresh: "blocking" }),
+      2,
+      expect.objectContaining({ projectId: "project-1" }),
     );
   });
 });

--- a/apps/app/src/hooks/queries/project-queries.ts
+++ b/apps/app/src/hooks/queries/project-queries.ts
@@ -14,6 +14,7 @@ import {
 } from "@bb/client-core";
 import { decodeBase64Bytes } from "@/lib/base64-bytes";
 import { buildProjectFileContentUrl } from "@/lib/file-content-urls";
+import { readProjectBranchOptions } from "@/lib/project-branch-options";
 import { sdk } from "@/lib/sdk";
 import { useProjectDetailRealtimeSubscription } from "@/hooks/useRealtimeSubscription";
 import {
@@ -111,21 +112,21 @@ export function useProjectSourceBranches(
       const remoteRefresh = remoteRefreshRef.current;
       const startsBlockingRefresh =
         remoteRefresh.requested && remoteRefresh.blockingSignal === null;
-      const refresh =
-        startsBlockingRefresh || remoteRefresh.blockingSignal === signal
-          ? "blocking"
-          : "background";
+      const blocking =
+        startsBlockingRefresh || remoteRefresh.blockingSignal === signal;
       if (startsBlockingRefresh) {
         remoteRefresh.requested = false;
         remoteRefresh.blockingSignal = signal;
       }
-      return sdk.projects.branches({
+      const readBranches = blocking
+        ? sdk.projects.branches
+        : readProjectBranchOptions;
+      return readBranches({
         projectId: requireProjectId(projectId, "useProjectSourceBranches"),
         hostId: hostId ?? "",
         ...(query ? { query } : {}),
         ...(selectedBranch ? { selectedBranch } : {}),
         limit: String(limit),
-        refresh,
         signal,
       });
     },

--- a/apps/app/src/lib/project-branch-options.ts
+++ b/apps/app/src/lib/project-branch-options.ts
@@ -1,0 +1,21 @@
+import type {
+  ProjectBranchesArgs,
+  ProjectBranchesResult,
+} from "@bb/sdk/browser";
+import { request, requestOptions } from "./api";
+import { apiClient } from "./api-server";
+
+export function readProjectBranchOptions(
+  input: ProjectBranchesArgs,
+): Promise<ProjectBranchesResult> {
+  const { projectId, signal, ...query } = input;
+  return request<ProjectBranchesResult>(
+    apiClient.projects[":id"]["branch-options"].$get(
+      {
+        param: { id: projectId },
+        query,
+      },
+      requestOptions(signal),
+    ),
+  );
+}

--- a/apps/cli/src/__tests__/command-output/project.test.ts
+++ b/apps/cli/src/__tests__/command-output/project.test.ts
@@ -232,27 +232,19 @@ describe("bb project command output", () => {
     ).toEqual(projects);
   });
 
-  it("bb project branches can wait for remote refs", async () => {
+  it("bb project branches waits for remote refs implicitly", async () => {
     const branches = { branches: ["main"], remoteBranches: ["origin/main"] };
     const get = vi.fn(async () => branches);
     stubServerApi({ "v1.projects.:id.branches.$get": get });
 
     await runCommand(
-      [
-        "project",
-        "branches",
-        "proj-1",
-        "--host",
-        "host-1",
-        "--refresh",
-        "--json",
-      ],
+      ["project", "branches", "proj-1", "--host", "host-1", "--json"],
       register,
     );
 
     expect(get).toHaveBeenCalledWith({
       param: { id: "proj-1" },
-      query: { hostId: "host-1", refresh: "blocking" },
+      query: { hostId: "host-1" },
     });
     expect(
       JSON.parse(String(vi.mocked(console.log).mock.calls[0]?.[0])),

--- a/apps/cli/src/commands/project.ts
+++ b/apps/cli/src/commands/project.ts
@@ -53,7 +53,6 @@ interface ProjectDiscoveryCommandOptions {
   limit?: string;
   provider?: string;
   query?: string;
-  refresh?: boolean;
 }
 
 function addProjectWorkspaceRoutingOptions(command: Command): Command {
@@ -391,7 +390,6 @@ export function registerProjectCommands(
     .requiredOption("--host <id>", "Source machine ID")
     .option("--query <query>", "Branch-name filter")
     .option("--limit <count>", "Maximum branches")
-    .option("--refresh", "Wait for remote refs before listing")
     .option("--json", "Print machine-readable JSON output")
     .action(
       action(async (id: string, opts: ProjectDiscoveryCommandOptions) => {
@@ -400,7 +398,6 @@ export function registerProjectCommands(
           hostId: opts.host ?? "",
           ...(opts.query ? { query: opts.query } : {}),
           ...(opts.limit ? { limit: opts.limit } : {}),
-          ...(opts.refresh ? { refresh: "blocking" as const } : {}),
         });
         if (outputJson(opts, result)) return;
         console.log(JSON.stringify(result, null, 2));

--- a/apps/server/src/routes/projects.ts
+++ b/apps/server/src/routes/projects.ts
@@ -26,6 +26,7 @@ import {
   publicApiRoutes,
   typedRoutes,
   type ProjectListIncludeOption,
+  type ProjectBranchesQuery,
   type ProjectListQuery,
   type ProjectResponse,
   type ProjectWithThreadsResponse,
@@ -839,8 +840,11 @@ export function registerProjectRoutes(app: Hono, deps: AppDeps): void {
     return context.json(result);
   });
 
-  get(routes.branches, async (context, query) => {
-    const projectId = context.req.param("id");
+  const readProjectBranches = async (
+    projectId: string,
+    query: ProjectBranchesQuery,
+    remoteRefresh: "background" | "blocking",
+  ) => {
     requirePublicStandardProject(deps.db, projectId);
 
     const source = resolveProjectWorkspaceTarget(deps, {
@@ -849,7 +853,6 @@ export function registerProjectRoutes(app: Hono, deps: AppDeps): void {
     });
     const branchQuery = normalizeBranchQuery(query.query);
     const selectedBranch = normalizeBranchQuery(query.selectedBranch);
-    const remoteRefresh = query.refresh ?? "background";
     const inspectionPromise = callHostRetryableOnlineRpc(deps, {
       hostId: source.hostId,
       timeoutMs: COMMAND_TIMEOUT_MS,
@@ -881,11 +884,22 @@ export function registerProjectRoutes(app: Hono, deps: AppDeps): void {
       branchOptionsPromise,
     ]);
     const result = { ...inspection, ...branchOptions };
-    return context.json({
+    return {
       ...result,
       defaultWorktreeBaseBranch: resolveDefaultWorktreeBaseBranch(result),
-    });
-  });
+    };
+  };
+
+  get(routes.branches, async (context, query) =>
+    context.json(
+      await readProjectBranches(context.req.param("id"), query, "blocking"),
+    ),
+  );
+  get(routes.branchOptions, async (context, query) =>
+    context.json(
+      await readProjectBranches(context.req.param("id"), query, "background"),
+    ),
+  );
 
   post(routes.uploadAttachment, async (context) => {
     requirePublicProject(deps.db, context.req.param("id"));

--- a/apps/server/test/public/public-project-workspace-routing.test.ts
+++ b/apps/server/test/public/public-project-workspace-routing.test.ts
@@ -26,7 +26,7 @@ const primaryCommand: HostProviderCommand = {
 };
 
 describe("public project workspace routing", () => {
-  it("reads cached branch metadata while refreshing project remotes in the background", async () => {
+  it("keeps app branch options cache-first and public branch listing blocking", async () => {
     await withTestHarness(async (harness) => {
       const { host, session } = seedHostSession(harness.deps, {
         id: "host-project-branches",
@@ -87,7 +87,7 @@ describe("public project workspace routing", () => {
       });
 
       const responsePromise = harness.app.request(
-        `/api/v1/projects/${project.id}/branches?hostId=${host.id}&limit=50`,
+        `/api/v1/projects/${project.id}/branch-options?hostId=${host.id}&limit=50`,
       );
 
       try {
@@ -136,7 +136,7 @@ describe("public project workspace routing", () => {
 
       responder.requests.length = 0;
       const refreshedResponsePromise = harness.app.request(
-        `/api/v1/projects/${project.id}/branches?hostId=${host.id}&limit=50&refresh=blocking`,
+        `/api/v1/projects/${project.id}/branches?hostId=${host.id}&limit=50`,
       );
       try {
         await vi.waitFor(() => expect(responder.requests).toHaveLength(1));

--- a/packages/plugin-api-map/sdk-public-api.json
+++ b/packages/plugin-api-map/sdk-public-api.json
@@ -3,7 +3,7 @@
   "entries": {
     ".": {
       "types": "bundled-types/bb-plugin-sdk.d.ts",
-      "sha256": "ba1eaa28fc58a0166127c8c13173ec51f52728df1771350d81d9a1d016d1ea5b"
+      "sha256": "b08f0613ace1049779887ef3a1099cd718cb5985a684b7d2d8f0f0cbda6946eb"
     },
     "./ai-services": {
       "types": "bundled-types/bb-plugin-sdk-ai-services.d.ts",

--- a/packages/server-contract/src/api/projects.ts
+++ b/packages/server-contract/src/api/projects.ts
@@ -208,11 +208,12 @@ export type ProjectFileContentQuery = z.infer<
   typeof projectFileContentQuerySchema
 >;
 
-export const projectBranchesQuerySchema = branchListQuerySchema.extend({
-  hostId: z.string().min(1),
-  refresh: z.enum(["background", "blocking"]).optional(),
-  selectedBranch: gitBranchNameSchema.optional(),
-});
+export const projectBranchesQuerySchema = branchListQuerySchema
+  .extend({
+    hostId: z.string().min(1),
+    selectedBranch: gitBranchNameSchema.optional(),
+  })
+  .strict();
 export type ProjectBranchesQuery = z.infer<typeof projectBranchesQuerySchema>;
 
 export const projectBranchesResponseSchema = projectSourceCheckoutSchema.extend(

--- a/packages/server-contract/src/public-api.ts
+++ b/packages/server-contract/src/public-api.ts
@@ -486,6 +486,14 @@ export const publicApiRoutes = {
       ),
       response: jsonResponse<ProjectBranchesResponse>(),
     }),
+    branchOptions: defineRoute({
+      path: "/projects/:id/branch-options",
+      method: "get",
+      request: queryRequest<PathProjectId, ProjectBranchesQuery>(
+        projectBranchesQuerySchema,
+      ),
+      response: jsonResponse<ProjectBranchesResponse>(),
+    }),
     uploadAttachment: defineRoute({
       path: "/projects/:id/attachments",
       method: "post",

--- a/packages/server-contract/test/contract.test.ts
+++ b/packages/server-contract/test/contract.test.ts
@@ -483,14 +483,13 @@ describe("git branch name contract", () => {
     expect(
       contract.projectBranchesQuerySchema.safeParse({
         hostId: "host_123",
-        refresh: "blocking",
         selectedBranch: "upstream/main",
       }).success,
     ).toBe(true);
     expect(
       contract.projectBranchesQuerySchema.safeParse({
         hostId: "host_123",
-        refresh: "eager",
+        refresh: "blocking",
       }).success,
     ).toBe(false);
     expect(

--- a/packages/templates/src/templates/bb-guide-projects.md
+++ b/packages/templates/src/templates/bb-guide-projects.md
@@ -34,7 +34,6 @@ A project maps to a code repository. All threads belong to a project.
 Discovery:
 
   bb project branches <id> --host <id>   List branches for a machine source
-    --refresh                            Wait for remote refs before listing
   bb project paths <id>                   Search workspace paths
   bb project files <id>                   List workspace files
   bb project content <id> <path>          Read file content (binary is base64)


### PR DESCRIPTION
## Human comments

## What was wrong

Project branch listing exposed the app cache policy as a public `refresh` choice. Plain `bb project branches` and `sdk.projects.branches()` therefore defaulted to cached refs and could omit a newly pushed remote branch unless callers knew to request a blocking refresh.

## What changed

Make the public CLI/SDK branch operation always wait for the existing bounded best-effort remote fetch, remove `--refresh` and its request field, and add a fixed cache-first branch-options route for app initialization. The app still initializes responsively and switches to the public blocking operation when the branch picker requests fresh remotes. The generated CLI Guide was updated; the bb-cli skill already documents only the now-canonical plain command. The checked-in Plugin SDK declaration inventory was regenerated for the intentional nested `BbSdk` type change; its existing generic SDK Guide card remains accurate. No host-daemon wire shape changed, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

## How you verified

- `pnpm exec turbo run test typecheck --filter=@bb/app --filter=@bb/cli --filter=@bb/server --filter=@bb/server-contract --filter=@bb/sdk --force` (734 test files; 6,284 passed, 3 skipped; all typechecks passed)
- `pnpm exec turbo run build --filter=@bb/app --filter=@bb/cli --filter=@bb/server --filter=@bb/server-contract --filter=@bb/sdk --force` (7 tasks passed)
- `pnpm exec turbo run lint --filter=@bb/app --force` (0 errors)
- `pnpm exec turbo run test --filter=@bb/plugin-api-map --force` (73 passed; reproduces the inventory failure before regeneration and passes after)
- Plugin Guide required test/typecheck workflow (11 tasks passed; Plugin SDK 220, Plugin API Map 73, app 3,551 passed / 3 skipped)
- `bb plugin build plugins/plugin-api-docs`
- `pnpm exec oxfmt --check` on all changed supported files
- `git diff --check origin/main...HEAD`

Fixes: no linked issue.

> AGENT GENERATED