### PR TITLE
Coordinate provider starts with bridge retirement

### DIFF
--- a/packages/agent-runtime/src/runtime-provider-process.ts
+++ b/packages/agent-runtime/src/runtime-provider-process.ts
@@ -134,6 +134,7 @@ export class RuntimeProviderProcessManager {
   private readonly args: RuntimeProviderProcessManagerArgs;
   private readonly processes = new Map<string, RuntimeProviderProcess>();
   private readonly providerStarting = new Map<string, Promise<void>>();
+  private readonly providerRetiring = new Map<string, Promise<void>>();
   private readonly currentProcessKeyByProviderId = new Map<string, string>();
   private shuttingDown = false;
 
@@ -142,6 +143,11 @@ export class RuntimeProviderProcessManager {
   }
 
   async ensureProvider(args: EnsureRuntimeProviderArgs): Promise<void> {
+    const retirement = this.providerRetiring.get(args.processKey);
+    if (retirement !== undefined) {
+      await retirement;
+    }
+
     const existing = this.providerStarting.get(args.processKey);
     if (existing) {
       await existing;
@@ -279,6 +285,12 @@ export class RuntimeProviderProcessManager {
   }
 
   async shutdownProvider(args: ShutdownRuntimeProviderArgs): Promise<void> {
+    const existingRetirement = this.providerRetiring.get(args.processKey);
+    if (existingRetirement !== undefined) {
+      await existingRetirement;
+      return;
+    }
+
     const providerProcess = this.processes.get(args.processKey);
     if (!providerProcess) {
       return;
@@ -290,12 +302,22 @@ export class RuntimeProviderProcessManager {
     }
 
     providerProcess.expectedShutdownExpectations += 1;
-    await this.terminateProviderProcess({
-      providerProcess,
-      timeoutMs: args.timeoutMs,
-    });
-    if (hasChildProcessExited(providerProcess.child)) {
-      await providerProcess.exitFinalized;
+    const retirement = (async () => {
+      await this.terminateProviderProcess({
+        providerProcess,
+        timeoutMs: args.timeoutMs,
+      });
+      if (hasChildProcessExited(providerProcess.child)) {
+        await providerProcess.exitFinalized;
+      }
+    })();
+    this.providerRetiring.set(args.processKey, retirement);
+    try {
+      await retirement;
+    } finally {
+      if (this.providerRetiring.get(args.processKey) === retirement) {
+        this.providerRetiring.delete(args.processKey);
+      }
     }
   }
 

--- a/packages/agent-runtime/src/runtime-provider-process.ts
+++ b/packages/agent-runtime/src/runtime-provider-process.ts
@@ -322,6 +322,16 @@ export class RuntimeProviderProcessManager {
   }
 
   async shutdown(): Promise<void> {
+    const retiringProcessKeys = [...this.providerRetiring.keys()];
+    if (retiringProcessKeys.length > 0) {
+      await Promise.allSettled(this.providerRetiring.values());
+      await Promise.allSettled(
+        retiringProcessKeys.flatMap((processKey) => {
+          const start = this.providerStarting.get(processKey);
+          return start === undefined ? [] : [start];
+        }),
+      );
+    }
     this.shuttingDown = true;
     const shutdownPromises: Promise<void>[] = [];
 

--- a/packages/agent-runtime/src/runtime-provider-process.ts
+++ b/packages/agent-runtime/src/runtime-provider-process.ts
@@ -143,9 +143,11 @@ export class RuntimeProviderProcessManager {
   }
 
   async ensureProvider(args: EnsureRuntimeProviderArgs): Promise<void> {
+    if (this.shuttingDown) return;
     const retirement = this.providerRetiring.get(args.processKey);
     if (retirement !== undefined) {
       await retirement;
+      if (this.shuttingDown) return;
     }
 
     const existing = this.providerStarting.get(args.processKey);
@@ -158,6 +160,7 @@ export class RuntimeProviderProcessManager {
     if (existingProcess !== undefined) {
       if (!hasChildProcessExited(existingProcess.child)) return;
       await existingProcess.exitFinalized;
+      if (this.shuttingDown) return;
 
       const concurrentStart = this.providerStarting.get(args.processKey);
       if (concurrentStart !== undefined) {
@@ -197,6 +200,7 @@ export class RuntimeProviderProcessManager {
             });
             request.onResult(result);
           } catch (error) {
+            if (this.shuttingDown) return;
             if (request.required) throw error;
           }
         }
@@ -217,6 +221,7 @@ export class RuntimeProviderProcessManager {
           }
         }
       } catch (startupError) {
+        if (this.shuttingDown) return;
         await this.cleanupFailedStartup({
           processKey: args.processKey,
           providerId: args.providerId,
@@ -286,10 +291,7 @@ export class RuntimeProviderProcessManager {
 
   async shutdownProvider(args: ShutdownRuntimeProviderArgs): Promise<void> {
     const existingRetirement = this.providerRetiring.get(args.processKey);
-    if (existingRetirement !== undefined) {
-      await existingRetirement;
-      return;
-    }
+    if (existingRetirement !== undefined) return existingRetirement;
 
     const providerProcess = this.processes.get(args.processKey);
     if (!providerProcess) {
@@ -302,36 +304,23 @@ export class RuntimeProviderProcessManager {
     }
 
     providerProcess.expectedShutdownExpectations += 1;
-    const retirement = (async () => {
-      await this.terminateProviderProcess({
-        providerProcess,
-        timeoutMs: args.timeoutMs,
-      });
+    const retirement = this.terminateProviderProcess({
+      providerProcess,
+      timeoutMs: args.timeoutMs,
+    }).then(async () => {
       if (hasChildProcessExited(providerProcess.child)) {
         await providerProcess.exitFinalized;
       }
-    })();
+    });
     this.providerRetiring.set(args.processKey, retirement);
-    try {
-      await retirement;
-    } finally {
+    await retirement.finally(() => {
       if (this.providerRetiring.get(args.processKey) === retirement) {
         this.providerRetiring.delete(args.processKey);
       }
-    }
+    });
   }
 
   async shutdown(): Promise<void> {
-    const retiringProcessKeys = [...this.providerRetiring.keys()];
-    if (retiringProcessKeys.length > 0) {
-      await Promise.allSettled(this.providerRetiring.values());
-      await Promise.allSettled(
-        retiringProcessKeys.flatMap((processKey) => {
-          const start = this.providerStarting.get(processKey);
-          return start === undefined ? [] : [start];
-        }),
-      );
-    }
     this.shuttingDown = true;
     const shutdownPromises: Promise<void>[] = [];
 

--- a/packages/agent-runtime/src/runtime.process-lifecycle.test.ts
+++ b/packages/agent-runtime/src/runtime.process-lifecycle.test.ts
@@ -41,6 +41,7 @@ interface CreateProviderProcessManagerArgs {
   onStderr?: NonNullable<AgentRuntimeOptions["onStderr"]>;
   onProcessExit: NonNullable<AgentRuntimeOptions["onProcessExit"]>;
   rawScriptPath?: string;
+  skipPostInitializeRequests?: boolean;
   workspacePath: string;
 }
 
@@ -66,7 +67,7 @@ describe("createAgentRuntime process lifecycle", () => {
   function createManagerAdapter(
     args: Pick<
       CreateProviderProcessManagerArgs,
-      "adapterProcessEnv" | "rawScriptPath"
+      "adapterProcessEnv" | "rawScriptPath" | "skipPostInitializeRequests"
     >,
   ): BridgeProtocolAdapter {
     const adapter = createProviderForId("fake", {
@@ -79,6 +80,9 @@ describe("createAgentRuntime process lifecycle", () => {
         : { command: adapter.process.command, args: [args.rawScriptPath] };
     return {
       ...adapter,
+      ...(args.skipPostInitializeRequests
+        ? { buildPostInitializeRequests: () => [] }
+        : {}),
       process: {
         ...process,
         ...(args.adapterProcessEnv !== undefined
@@ -277,36 +281,46 @@ describe("createAgentRuntime process lifecycle", () => {
       onProcessExit: vi.fn(),
       workspacePath: tmpDir,
     });
-
-    await manager.ensureProvider({
+    const provider = {
       bridgeLaunch: MANAGER_BRIDGE_LAUNCH,
       processKey: "fake",
       providerId: "fake",
-    });
-    const retiringProcess = manager.requireProviderProcess({
-      processKey: "fake",
-      providerId: "fake",
-    });
+    };
 
-    const retirement = manager.shutdownProvider({
-      processKey: "fake",
-      providerId: "fake",
-    });
-    await manager.ensureProvider({
-      bridgeLaunch: MANAGER_BRIDGE_LAUNCH,
-      processKey: "fake",
-      providerId: "fake",
-    });
+    await manager.ensureProvider(provider);
+    const retiringProcess = manager.requireProviderProcess(provider);
+    const retirement = manager.shutdownProvider(provider);
+    await manager.ensureProvider(provider);
     await retirement;
 
-    const replacementProcess = manager.requireProviderProcess({
-      processKey: "fake",
-      providerId: "fake",
-    });
+    const replacementProcess = manager.requireProviderProcess(provider);
     expect(replacementProcess).not.toBe(retiringProcess);
     expect(retiringProcess.child.killed).toBe(true);
 
     await manager.shutdown();
+  });
+
+  it("finishes a retirement-blocked ensure before full shutdown", async () => {
+    const manager = createProviderProcessManager({
+      onProcessExit: vi.fn(),
+      skipPostInitializeRequests: true,
+      workspacePath: tmpDir,
+    });
+    const provider = {
+      bridgeLaunch: MANAGER_BRIDGE_LAUNCH,
+      processKey: "fake",
+      providerId: "fake",
+    };
+
+    await manager.ensureProvider(provider);
+    const retirement = manager.shutdownProvider(provider);
+    const replacementStart = manager.ensureProvider(provider);
+    const fullShutdown = manager.shutdown();
+
+    await expect(
+      Promise.all([retirement, replacementStart, fullShutdown]),
+    ).resolves.toEqual([undefined, undefined, undefined]);
+    expect(manager.listRunningProviders()).toEqual([]);
   });
 
   it("bounds provider stderr while data arrives without a newline", async () => {

--- a/packages/agent-runtime/src/runtime.process-lifecycle.test.ts
+++ b/packages/agent-runtime/src/runtime.process-lifecycle.test.ts
@@ -272,6 +272,43 @@ describe("createAgentRuntime process lifecycle", () => {
     await manager.shutdown();
   });
 
+  it("waits for provider retirement before starting a same-key replacement", async () => {
+    const manager = createProviderProcessManager({
+      onProcessExit: vi.fn(),
+      workspacePath: tmpDir,
+    });
+
+    await manager.ensureProvider({
+      bridgeLaunch: MANAGER_BRIDGE_LAUNCH,
+      processKey: "fake",
+      providerId: "fake",
+    });
+    const retiringProcess = manager.requireProviderProcess({
+      processKey: "fake",
+      providerId: "fake",
+    });
+
+    const retirement = manager.shutdownProvider({
+      processKey: "fake",
+      providerId: "fake",
+    });
+    await manager.ensureProvider({
+      bridgeLaunch: MANAGER_BRIDGE_LAUNCH,
+      processKey: "fake",
+      providerId: "fake",
+    });
+    await retirement;
+
+    const replacementProcess = manager.requireProviderProcess({
+      processKey: "fake",
+      providerId: "fake",
+    });
+    expect(replacementProcess).not.toBe(retiringProcess);
+    expect(retiringProcess.child.killed).toBe(true);
+
+    await manager.shutdown();
+  });
+
   it("bounds provider stderr while data arrives without a newline", async () => {
     const exitInfo = vi.fn<NonNullable<AgentRuntimeOptions["onProcessExit"]>>();
     const stderrLines: string[] = [];

--- a/packages/agent-runtime/src/runtime.process-lifecycle.test.ts
+++ b/packages/agent-runtime/src/runtime.process-lifecycle.test.ts
@@ -298,9 +298,10 @@ describe("createAgentRuntime process lifecycle", () => {
 
   it("does not wait for stalled replacement initialization during full shutdown", async () => {
     const stalledBridge = join(tmpDir, "stalled-provider.cjs");
+    const stalledBridgeStarted = join(tmpDir, "stalled-provider-started");
     writeFileSync(
       stalledBridge,
-      `require("readline").createInterface({input:process.stdin}).once("line",line=>setTimeout(()=>console.log(JSON.stringify({jsonrpc:"2.0",id:JSON.parse(line).id,result:{protocolVersion:2,capabilities:{grammarVersions:[3,3]}}})),3000));`,
+      `require("readline").createInterface({input:process.stdin}).once("line",line=>{require("fs").writeFileSync(${JSON.stringify(stalledBridgeStarted)},"");setTimeout(()=>console.log(JSON.stringify({jsonrpc:"2.0",id:JSON.parse(line).id,result:{protocolVersion:2,capabilities:{grammarVersions:[3,3]}}})),3000)});`,
     );
     let starts = 0;
     const manager = createProviderProcessManager({
@@ -312,21 +313,37 @@ describe("createAgentRuntime process lifecycle", () => {
       workspacePath: tmpDir,
     });
     await manager.ensureProvider(MANAGER_PROVIDER);
+    const retirement = manager.shutdownProvider(MANAGER_PROVIDER);
+    const replacementStart = manager.ensureProvider(MANAGER_PROVIDER);
+    await waitForRuntimeState({
+      label: "the replacement bridge to begin initialization",
+      predicate: () => existsSync(stalledBridgeStarted),
+      timeoutMs: 1_000,
+    });
+    expect(starts).toBe(2);
+    const replacementProcess = manager.requireProviderProcess(MANAGER_PROVIDER);
+    const fullShutdown = manager.shutdown();
     const operations = Promise.all([
-      manager.shutdownProvider(MANAGER_PROVIDER),
-      manager.ensureProvider(MANAGER_PROVIDER),
-      manager.shutdown(),
+      retirement,
+      replacementStart,
+      fullShutdown,
     ]);
+    let completionTimer: ReturnType<typeof setTimeout> | undefined;
     const completedPromptly = await Promise.race([
       operations.then(() => true),
-      new Promise<false>((resolve) => setTimeout(() => resolve(false), 1000)),
+      new Promise<false>((resolve) => {
+        completionTimer = setTimeout(() => resolve(false), 1_000);
+        completionTimer.unref();
+      }),
     ]);
+    if (completionTimer !== undefined) clearTimeout(completionTimer);
     await expect(operations).resolves.toEqual([
       undefined,
       undefined,
       undefined,
     ]);
     expect(completedPromptly).toBe(true);
+    expect(replacementProcess.child.killed).toBe(true);
     await manager.ensureProvider(MANAGER_PROVIDER);
     expect(manager.listRunningProviders()).toEqual([]);
   });

--- a/packages/agent-runtime/src/runtime.process-lifecycle.test.ts
+++ b/packages/agent-runtime/src/runtime.process-lifecycle.test.ts
@@ -36,12 +36,12 @@ import type { AgentRuntimeBridgeLaunch, AgentRuntimeOptions } from "./types.js";
 
 interface CreateProviderProcessManagerArgs {
   adapterProcessEnv?: Record<string, string>;
+  createAdapter?: () => BridgeProtocolAdapter;
   env?: Record<string, string>;
   handleStdoutLine?: (line: string, childPid: number | undefined) => void;
   onStderr?: NonNullable<AgentRuntimeOptions["onStderr"]>;
   onProcessExit: NonNullable<AgentRuntimeOptions["onProcessExit"]>;
   rawScriptPath?: string;
-  skipPostInitializeRequests?: boolean;
   workspacePath: string;
 }
 
@@ -51,6 +51,11 @@ const CODEX_SCRIPT: ScriptedEchoLaunchScript = {
 };
 
 const MANAGER_BRIDGE_LAUNCH = createScriptedEchoLaunch();
+const MANAGER_PROVIDER = {
+  bridgeLaunch: MANAGER_BRIDGE_LAUNCH,
+  processKey: "fake",
+  providerId: "fake",
+};
 
 describe("createAgentRuntime process lifecycle", () => {
   let tmpDir: string;
@@ -67,7 +72,7 @@ describe("createAgentRuntime process lifecycle", () => {
   function createManagerAdapter(
     args: Pick<
       CreateProviderProcessManagerArgs,
-      "adapterProcessEnv" | "rawScriptPath" | "skipPostInitializeRequests"
+      "adapterProcessEnv" | "rawScriptPath"
     >,
   ): BridgeProtocolAdapter {
     const adapter = createProviderForId("fake", {
@@ -80,9 +85,6 @@ describe("createAgentRuntime process lifecycle", () => {
         : { command: adapter.process.command, args: [args.rawScriptPath] };
     return {
       ...adapter,
-      ...(args.skipPostInitializeRequests
-        ? { buildPostInitializeRequests: () => [] }
-        : {}),
       process: {
         ...process,
         ...(args.adapterProcessEnv !== undefined
@@ -100,7 +102,7 @@ describe("createAgentRuntime process lifecycle", () => {
     const adapter = createManagerAdapter(args);
     return new RuntimeProviderProcessManager({
       additionalWorkspaceWriteRoots: [],
-      createAdapter: () => adapter,
+      createAdapter: args.createAdapter ?? (() => adapter),
       bridgeBundleDir: undefined,
       bridgeNodeExecutablePath: process.execPath,
       captureThreadExitState: (threadId) => ({
@@ -281,45 +283,51 @@ describe("createAgentRuntime process lifecycle", () => {
       onProcessExit: vi.fn(),
       workspacePath: tmpDir,
     });
-    const provider = {
-      bridgeLaunch: MANAGER_BRIDGE_LAUNCH,
-      processKey: "fake",
-      providerId: "fake",
-    };
+    await manager.ensureProvider(MANAGER_PROVIDER);
+    const retiringProcess = manager.requireProviderProcess(MANAGER_PROVIDER);
+    await Promise.all([
+      manager.shutdownProvider(MANAGER_PROVIDER),
+      manager.ensureProvider(MANAGER_PROVIDER),
+    ]);
 
-    await manager.ensureProvider(provider);
-    const retiringProcess = manager.requireProviderProcess(provider);
-    const retirement = manager.shutdownProvider(provider);
-    await manager.ensureProvider(provider);
-    await retirement;
-
-    const replacementProcess = manager.requireProviderProcess(provider);
-    expect(replacementProcess).not.toBe(retiringProcess);
-    expect(retiringProcess.child.killed).toBe(true);
-
+    expect(manager.requireProviderProcess(MANAGER_PROVIDER)).not.toBe(
+      retiringProcess,
+    );
     await manager.shutdown();
   });
 
-  it("finishes a retirement-blocked ensure before full shutdown", async () => {
+  it("does not wait for stalled replacement initialization during full shutdown", async () => {
+    const stalledBridge = join(tmpDir, "stalled-provider.cjs");
+    writeFileSync(
+      stalledBridge,
+      `require("readline").createInterface({input:process.stdin}).once("line",line=>setTimeout(()=>console.log(JSON.stringify({jsonrpc:"2.0",id:JSON.parse(line).id,result:{protocolVersion:2,capabilities:{grammarVersions:[3,3]}}})),3000));`,
+    );
+    let starts = 0;
     const manager = createProviderProcessManager({
+      createAdapter: () =>
+        createManagerAdapter(
+          starts++ === 0 ? {} : { rawScriptPath: stalledBridge },
+        ),
       onProcessExit: vi.fn(),
-      skipPostInitializeRequests: true,
       workspacePath: tmpDir,
     });
-    const provider = {
-      bridgeLaunch: MANAGER_BRIDGE_LAUNCH,
-      processKey: "fake",
-      providerId: "fake",
-    };
-
-    await manager.ensureProvider(provider);
-    const retirement = manager.shutdownProvider(provider);
-    const replacementStart = manager.ensureProvider(provider);
-    const fullShutdown = manager.shutdown();
-
-    await expect(
-      Promise.all([retirement, replacementStart, fullShutdown]),
-    ).resolves.toEqual([undefined, undefined, undefined]);
+    await manager.ensureProvider(MANAGER_PROVIDER);
+    const operations = Promise.all([
+      manager.shutdownProvider(MANAGER_PROVIDER),
+      manager.ensureProvider(MANAGER_PROVIDER),
+      manager.shutdown(),
+    ]);
+    const completedPromptly = await Promise.race([
+      operations.then(() => true),
+      new Promise<false>((resolve) => setTimeout(() => resolve(false), 1000)),
+    ]);
+    await expect(operations).resolves.toEqual([
+      undefined,
+      undefined,
+      undefined,
+    ]);
+    expect(completedPromptly).toBe(true);
+    await manager.ensureProvider(MANAGER_PROVIDER);
     expect(manager.listRunningProviders()).toEqual([]);
   });
 


### PR DESCRIPTION
## Human comments

## What was wrong

PR #2773 correctly retires a provider bridge after its final thread ends, but the shared process manager did not record that retirement while it was in progress. A same-key `ensureProvider` could therefore reuse the bridge being terminated; the new thread would reject immediately or briefly start and then lose its provider when the old bridge exited.

Review exposed two full-shutdown ordering cases: a retirement-blocked start could spawn after the shutdown sweep, and waiting for that replacement to finish initialization could exceed the daemon's 15-second exit grace because provider RPC initialization waits up to 30 seconds.

## What changed

The provider process manager now memoizes same-key retirement promises. New starts wait for retirement before selecting or spawning a bridge, and concurrent shutdown callers share the active retirement. Full runtime shutdown becomes terminal before any lifecycle wait: retirement-blocked or later ensures fulfill without spawning, while already-initializing starts treat shutdown as superseding their internal RPC wait. Shutdown then terminates every process already visible to its sweep.

Final-thread retirement, bridge reuse while another thread remains, and later cold resume remain unchanged. The change is internal to `@bb/agent-runtime`; no daemon wire contract, protocol version, public API, CLI, or configuration changed.

## How you verified

- Added a regression that overlaps same-key provider shutdown and ensure. It failed before the production change with `Provider "fake" is not running` and passes afterward with a distinct surviving replacement process.
- Added a regression that overlaps retirement, a same-key ensure with a three-second delayed initialization response, and full shutdown. It was red because shutdown took the full initialization delay; it is green within the one-second bound, all calls fulfill, and no provider remains. A post-shutdown ensure also fulfills without recreating a provider.
- `pnpm exec turbo run test typecheck --filter=@bb/agent-runtime --force` — 22 files / 318 tests passed; typecheck passed.
- GitHub CI run `33459198901` — all non-skipped jobs passed, including Linux AppImage lifecycle smoke.
- `git diff --check origin/main...HEAD` — passed.
- Rebased and reran validation on `origin/main` at `fb05e93ff5ad4f58831e804b973f2de790557afa`.

Completes the lifecycle coordination missed by #2773.

Tagging @slopcop for re-review of head `0ab3801d24d4d8c04e9cc1bff808357cb0f07d70`.

> AGENT GENERATED
