### PR TITLE
Fix touch icon sizing in file and attachment previews

### DIFF
--- a/apps/app/src/components/promptbox/AttachmentPreview.test.tsx
+++ b/apps/app/src/components/promptbox/AttachmentPreview.test.tsx
@@ -81,4 +81,57 @@ describe("AttachmentPreview", () => {
     expect(onRemoveAttachment).toHaveBeenCalledWith("photo-1-abc.png");
     expect(revoked).toEqual(["blob:local-1"]);
   });
+
+  it("separates compact touch targets from attachment remove visuals", () => {
+    const { getByRole } = render(
+      <AttachmentPreview
+        attachments={[
+          {
+            type: "localImage",
+            path: "screenshot.png",
+            name: "screenshot.png",
+            mimeType: "image/png",
+            sizeBytes: 3,
+          },
+          {
+            type: "localFile",
+            path: "diff.patch",
+            name: "diff.patch",
+            mimeType: "text/plain",
+            sizeBytes: 3,
+          },
+        ]}
+        expandedImageIndex={null}
+        onExpandedImageIndexChange={() => {}}
+        onRemoveAttachment={() => {}}
+      />,
+    );
+
+    const imageRemoveButton = getByRole("button", {
+      name: "Remove screenshot.png",
+    });
+    expect(
+      imageRemoveButton.classList.contains("max-md:pointer-coarse:size-7"),
+    ).toBe(true);
+    expect(imageRemoveButton.classList.contains("bg-black/55")).toBe(false);
+    expect(
+      imageRemoveButton.firstElementChild?.classList.contains("size-4"),
+    ).toBe(true);
+    expect(
+      imageRemoveButton.firstElementChild?.classList.contains("bg-black/55"),
+    ).toBe(true);
+
+    const fileRemoveButton = getByRole("button", {
+      name: "Remove diff.patch",
+    });
+    expect(
+      fileRemoveButton.classList.contains("max-md:pointer-coarse:size-7"),
+    ).toBe(true);
+    expect(fileRemoveButton.parentElement?.classList.contains("size-4")).toBe(
+      true,
+    );
+    expect(
+      fileRemoveButton.firstElementChild?.classList.contains("size-4"),
+    ).toBe(true);
+  });
 });

--- a/apps/app/src/components/promptbox/AttachmentPreview.tsx
+++ b/apps/app/src/components/promptbox/AttachmentPreview.tsx
@@ -95,10 +95,12 @@ export function AttachmentPreview({
                       releaseLocalAttachmentPreview(attachment.path);
                       onRemoveAttachment(attachment.path);
                     }}
-                    className="absolute right-1 top-1 z-10 rounded-full bg-black/55 p-0.5 text-white transition-colors hover:bg-black/70"
+                    className="group/attachment-remove-image absolute right-1 top-1 z-10 inline-flex size-4 items-center justify-center rounded-full text-white focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring max-md:pointer-coarse:-right-1 max-md:pointer-coarse:-top-1 max-md:pointer-coarse:size-7"
                     aria-label={`Remove ${attachment.name}`}
                   >
-                    <Icon name="X" className="size-3" />
+                    <span className="inline-flex size-4 items-center justify-center rounded-full bg-black/55 transition-colors group-hover/attachment-remove-image:bg-black/70">
+                      <Icon name="X" className="size-3" />
+                    </span>
                   </button>
                 ) : null}
               </div>
@@ -115,14 +117,18 @@ export function AttachmentPreview({
               >
                 <span className="truncate">{attachment.name}</span>
                 {onRemoveAttachment ? (
-                  <button
-                    type="button"
-                    onClick={() => onRemoveAttachment(attachment.path)}
-                    className="rounded p-0.5 hover:bg-state-hover"
-                    title={`Remove ${attachment.name}`}
-                  >
-                    <Icon name="X" className="size-3" />
-                  </button>
+                  <span className="relative size-4 shrink-0">
+                    <button
+                      type="button"
+                      onClick={() => onRemoveAttachment(attachment.path)}
+                      className="group/attachment-remove-file absolute left-1/2 top-1/2 inline-flex size-4 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-md focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring max-md:pointer-coarse:size-7"
+                      aria-label={`Remove ${attachment.name}`}
+                    >
+                      <span className="inline-flex size-4 items-center justify-center rounded transition-colors group-hover/attachment-remove-file:bg-state-hover">
+                        <Icon name="X" className="size-3" />
+                      </span>
+                    </button>
+                  </span>
                 ) : null}
               </span>
             ))}

--- a/apps/app/src/components/secondary-panel/FilePreview.test.tsx
+++ b/apps/app/src/components/secondary-panel/FilePreview.test.tsx
@@ -542,6 +542,42 @@ describe("FilePreview", () => {
     openSpy.mockRestore();
   });
 
+  it("enlarges the HTML file actions for narrow coarse pointers", () => {
+    render(
+      <FilePreview
+        path="docs/progress-vis.html"
+        onOpenInEditor={vi.fn()}
+        state={{
+          kind: "html",
+          file: { name: "progress-vis.html", contents: "<p>chart</p>" },
+          iframe: {
+            sandbox: "allow-scripts",
+            title: "docs/progress-vis.html",
+            url: "/api/v1/threads/thr_1/worktree/files/docs/progress-vis.html",
+          },
+          lineRange: null,
+        }}
+      />,
+    );
+
+    const actionButtons = [
+      screen.getByRole("button", { name: "Copy HTML source" }),
+      screen.getByRole("button", { name: /Open in editor/ }),
+    ];
+
+    for (const actionButton of actionButtons) {
+      expect(actionButton.classList.contains("max-md:pointer-coarse:h-9")).toBe(
+        true,
+      );
+      expect(actionButton.classList.contains("max-md:pointer-coarse:w-9")).toBe(
+        true,
+      );
+      expect(
+        actionButton.classList.contains("max-md:pointer-coarse:[&_svg]:size-5"),
+      ).toBe(true);
+    }
+  });
+
   it("hands the desktop shell an absolute preview url", () => {
     const openExternalUrl = vi.fn();
     (window as unknown as { bbDesktop: unknown }).bbDesktop = {

--- a/apps/app/src/components/secondary-panel/FilePreview.tsx
+++ b/apps/app/src/components/secondary-panel/FilePreview.tsx
@@ -667,7 +667,10 @@ function FilePreviewHeader({
                   <CopyButton
                     text={rawContents}
                     label={copyFileContentsLabel}
-                    className="shrink-0 rounded-md hover:bg-state-hover hover:text-foreground"
+                    className={cn(
+                      FILE_PREVIEW_HEADER_ICON_BUTTON_CLASS,
+                      "shrink-0 rounded-md hover:bg-state-hover hover:text-foreground",
+                    )}
                   />
                 </TooltipTrigger>
                 <TooltipContent side="bottom">
@@ -708,6 +711,7 @@ function FilePreviewHeader({
                   <TooltipTrigger asChild>
                     <OpenInEditorButton
                       onClick={() => onOpenInEditor(path)}
+                      className={FILE_PREVIEW_HEADER_ICON_BUTTON_CLASS}
                       label={
                         openShortcut
                           ? `Open in editor (${openShortcut.label})`

--- a/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.test.ts
+++ b/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.test.ts
@@ -46,6 +46,65 @@ describe("secondary panel tab-strip edge fades", () => {
     ).not.toContain("app-region");
   });
 
+  it("enlarges coarse-pointer close targets only for file previews", () => {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        disconnect() {}
+      },
+    );
+    const { getByRole } = render(
+      createElement(SecondaryPanelTabStrip, {
+        activeTabId: "file-preview",
+        tabs: [
+          {
+            label: "preview.html",
+            isPinned: false,
+            leadingVisual: null,
+            statusLabel: null,
+            onSelect: vi.fn(),
+            onClose: vi.fn(),
+            renderContent: () => null,
+            tab: {
+              environmentId: null,
+              hostId: null,
+              id: "file-preview",
+              kind: "host-file-preview" as const,
+              lineRange: null,
+              path: "preview.html",
+              threadId: null,
+            },
+          },
+          {
+            label: "Browser",
+            isPinned: false,
+            leadingVisual: null,
+            statusLabel: null,
+            onSelect: vi.fn(),
+            onClose: vi.fn(),
+            renderContent: () => null,
+            tab: { id: "browser", kind: "new-tab" as const },
+          },
+        ],
+        onReorderTab: vi.fn(),
+        usesDesktopChrome: false,
+        isPanelOpen: true,
+      }),
+    );
+
+    expect(
+      getByRole("button", { name: "Close preview.html" }).classList.contains(
+        "max-md:pointer-coarse:min-h-9",
+      ),
+    ).toBe(true);
+    expect(
+      getByRole("button", { name: "Close Browser" }).classList.contains(
+        "max-md:pointer-coarse:min-h-9",
+      ),
+    ).toBe(false);
+  });
+
   it("observes the intrinsic tab row so async title changes refresh overflow", () => {
     const observed: Element[] = [];
     let resizeCallback: ResizeObserverCallback | undefined;

--- a/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.tsx
+++ b/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.tsx
@@ -565,6 +565,11 @@ function PanelTab({
       isActive={isActive}
       onSelect={tab.onSelect}
       labelMaxWidthClass="max-w-[160px]"
+      enlargeCloseTargetOnCoarsePointer={
+        tab.tab.kind === "workspace-file-preview" ||
+        tab.tab.kind === "host-file-preview" ||
+        tab.tab.kind === "thread-storage-file-preview"
+      }
       closeAction={
         tab.isPinned
           ? null

--- a/apps/app/src/components/ui/tab-pill.test.tsx
+++ b/apps/app/src/components/ui/tab-pill.test.tsx
@@ -69,4 +69,30 @@ describe("TabPill", () => {
     expect(onClose).toHaveBeenCalledOnce();
     expect(onSelect).not.toHaveBeenCalled();
   });
+
+  it("enlarges the close target for narrow coarse pointers", () => {
+    render(
+      <TabPill
+        label="File preview"
+        title="File preview"
+        isActive
+        onSelect={vi.fn()}
+        enlargeCloseTargetOnCoarsePointer
+        closeAction={{
+          closeLabel: "Close File preview",
+          onClose: vi.fn(),
+        }}
+      />,
+    );
+
+    const closeButton = screen.getByRole("button", {
+      name: "Close File preview",
+    });
+    expect(
+      closeButton.classList.contains("max-md:pointer-coarse:min-h-9"),
+    ).toBe(true);
+    expect(
+      closeButton.classList.contains("max-md:pointer-coarse:min-w-9"),
+    ).toBe(true);
+  });
 });

--- a/apps/app/src/components/ui/tab-pill.tsx
+++ b/apps/app/src/components/ui/tab-pill.tsx
@@ -10,6 +10,8 @@ const TAB_PILL_AFFORDANCE_BUTTON_BASE_CLASS =
   "inline-flex size-4 shrink-0 items-center justify-center rounded-sm hover:bg-muted-foreground/15 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none max-md:pointer-coarse:size-5";
 const TAB_PILL_AFFORDANCE_ICON_CLASS = "size-3.5 max-md:pointer-coarse:size-5";
 const TAB_PILL_CLOSE_BUTTON_CLASS = `pointer-events-none absolute left-1.5 top-1/2 z-10 -translate-y-1/2 ${TAB_PILL_AFFORDANCE_BUTTON_BASE_CLASS} opacity-0 hover:opacity-100 group-hover/tab-pill:pointer-events-auto group-hover/tab-pill:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100 disabled:opacity-30 max-md:pointer-coarse:pointer-events-auto max-md:pointer-coarse:opacity-100`;
+const TAB_PILL_LARGE_COARSE_POINTER_CLOSE_BUTTON_CLASS =
+  "max-md:pointer-coarse:min-h-9 max-md:pointer-coarse:min-w-9";
 const TAB_PILL_LEADING_VISUAL_CLASS =
   "inline-flex size-4 shrink-0 items-center justify-center [&_svg]:size-3.5 max-md:pointer-coarse:size-5 max-md:pointer-coarse:[&_svg]:size-5";
 
@@ -32,6 +34,7 @@ interface TabPillProps {
   onSelect: () => void;
   labelMaxWidthClass?: string;
   closeAction: TabPillCloseAction | null;
+  enlargeCloseTargetOnCoarsePointer?: boolean;
 }
 
 export function TabPill({
@@ -47,6 +50,7 @@ export function TabPill({
   onSelect,
   labelMaxWidthClass = TAB_PILL_DEFAULT_LABEL_MAX_WIDTH_CLASS,
   closeAction,
+  enlargeCloseTargetOnCoarsePointer = false,
 }: TabPillProps) {
   return (
     <div
@@ -119,7 +123,11 @@ export function TabPill({
           disabled={closeAction.isClosing}
           aria-label={closeAction.closeLabel}
           data-tab-pill-close
-          className={TAB_PILL_CLOSE_BUTTON_CLASS}
+          className={cn(
+            TAB_PILL_CLOSE_BUTTON_CLASS,
+            enlargeCloseTargetOnCoarsePointer &&
+              TAB_PILL_LARGE_COARSE_POINTER_CLOSE_BUTTON_CLASS,
+          )}
         >
           {closeAction.isClosing ? (
             <Icon


### PR DESCRIPTION
## Human comments

## What was wrong

Narrow coarse-pointer layouts did not have surface-specific icon sizing. The File Preview copy action remained a 20px target with a 12px glyph beside existing 36px/20px header actions, while attachment remove controls coupled their visible treatment and layout footprint to their hit target. A global icon-sizing rule would overcorrect dense surfaces and require unrelated core and plugin controls to opt into or out of that policy.

## What changed

- Size the File Preview copy and open-in-editor actions to the existing 36px target and 20px glyph treatment on narrow coarse pointers.
- Enlarge the tab close target only for the three core file-preview tab kinds; browser, terminal, and plugin tabs retain their existing behavior.
- Give image and file attachment remove controls a compact 28px coarse-pointer hit target while preserving the 16px visible affordance and file-chip layout footprint.
- Keep the change app-core only. There are no plugin, Plugin SDK, shared global sizing, host protocol, CLI, guide, or documentation changes.

## How you verified

- Added focused regression coverage that fails without the surface-specific classes and file-preview opt-in.
- `pnpm exec turbo run test --filter=@bb/app -- --run src/components/promptbox/AttachmentPreview.test.tsx src/components/secondary-panel/FilePreview.test.tsx src/components/secondary-panel/SecondaryPanelTabStrip.test.ts src/components/ui/tab-pill.test.tsx` (34 tests passed).
- `pnpm exec turbo run typecheck --filter=@bb/app`.
- `pnpm exec turbo run lint --filter=@bb/app` (0 errors; 173 pre-existing warnings).
- `git diff --check origin/main...HEAD`.
- Used the dev browser at a narrow coarse-pointer viewport and captured honest before/after screenshots for both affected surfaces. File Preview moved from a 20px/12px copy control to 36px/20px, matching its neighboring actions; attachment removal moved from a 16px target to a 28px target while keeping a 16px visible control and unchanged chip layout.

Fixes: no linked issue.

> AGENT GENERATED

