### PR TITLE
Fix inconsistent sidebar row backgrounds

### DIFF
--- a/apps/app/src/components/ui/sidebar.test.tsx
+++ b/apps/app/src/components/ui/sidebar.test.tsx
@@ -14,6 +14,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { CompactViewportOverrideProvider } from "@bb/shared-ui/hooks/use-compact-viewport";
 import {
   Sidebar,
+  SidebarContent,
   SidebarInset,
   SidebarProvider,
   SidebarTrigger,
@@ -209,6 +210,14 @@ describe("SidebarTrigger", () => {
     expect(markup).not.toContain('data-icon="AlignLeft"');
     expect(markup).toContain('aria-expanded="true"');
     expect(markup).not.toContain('aria-pressed="');
+  });
+});
+
+describe("SidebarContent", () => {
+  it("owns the sidebar surface used behind transparent and sticky rows", () => {
+    render(<SidebarContent data-testid="content">Rows</SidebarContent>);
+
+    expect(screen.getByTestId("content").classList).toContain("bg-sidebar");
   });
 });
 

--- a/apps/app/src/components/ui/sidebar.tsx
+++ b/apps/app/src/components/ui/sidebar.tsx
@@ -1945,7 +1945,7 @@ const SidebarContent = React.forwardRef<
       ref={setContentRef}
       data-sidebar="content"
       className={cn(
-        "flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+        "flex min-h-0 flex-1 flex-col gap-2 overflow-auto bg-sidebar group-data-[collapsible=icon]:overflow-hidden",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Human comments

## What was wrong

Sticky section headers and parent thread rows explicitly used `bg-sidebar`, while transparent leaf rows inherited the sidebar content scroll surface. When that surface was rendered over the canvas, the two paths resolved to visibly different backgrounds.

## What changed

Added `bg-sidebar` to `SidebarContent` so transparent rows and sticky rows share the same theme-derived surface. Added a focused component regression test for that styling contract. This is UI-only and introduces no host daemon protocol or wire changes.

## How you verified

- `pnpm exec turbo run test --filter=@bb/app -- --run src/components/ui/sidebar.test.tsx` — 22 tests passed.
- `pnpm exec turbo run typecheck lint --filter=@bb/app` — typecheck passed; lint completed with 0 errors and 173 existing warnings.
- Dev-browser visual and computed-style checks confirmed parent, child, and standalone rows resolve to the same sidebar surface.

No linked issue.

> AGENT GENERATED