### PR TITLE
Refactor sidebar rows around shared rails

### DIFF
--- a/apps/app/src/components/commands/AppCommandShortcutHint.stories.tsx
+++ b/apps/app/src/components/commands/AppCommandShortcutHint.stories.tsx
@@ -3,11 +3,13 @@ import { Button } from "@bb/shared-ui/button";
 import { Icon } from "@bb/shared-ui/icon";
 import { cn } from "@bb/shared-ui/lib/utils";
 import type { AppShortcutPresentation } from "@/lib/app-keybindings";
+import { SIDEBAR_ROW_INTERACTIVE_STATE_CLASS } from "@/components/sidebar/sidebarRowClasses";
 import {
-  SIDEBAR_ROW_BASE_CLASS,
-  SIDEBAR_ROW_INTERACTIVE_STATE_CLASS,
-  SIDEBAR_STANDARD_ROW_PADDING_CLASS,
-} from "@/components/sidebar/sidebarRowClasses";
+  SidebarRow,
+  SidebarRowAccessory,
+  SidebarRowContent,
+  SidebarRowIdentityRail,
+} from "@/components/sidebar/SidebarRow";
 import { StoryCard, StoryRow } from "../../../.ladle/story-card";
 import { AppCommandShortcutPill } from "./AppCommandShortcutHint";
 
@@ -122,25 +124,23 @@ function SidebarRowExample({
 }) {
   return (
     <div className="w-80 rounded-md bg-sidebar p-2 text-sidebar-foreground">
-      <div
-        className={cn(
-          SIDEBAR_ROW_BASE_CLASS,
-          SIDEBAR_STANDARD_ROW_PADDING_CLASS,
-          SIDEBAR_ROW_INTERACTIVE_STATE_CLASS,
-          "min-h-8",
-        )}
+      <SidebarRow
+        anatomy="navigation"
+        className={cn(SIDEBAR_ROW_INTERACTIVE_STATE_CLASS, "min-h-8")}
       >
-        <Icon
-          name="MessageSquare"
-          className="size-4 shrink-0 text-subtle-foreground"
-        />
-        <span className="min-w-0 flex-1 truncate">
+        <SidebarRowIdentityRail>
+          <Icon
+            name="MessageSquare"
+            className="size-4 shrink-0 text-subtle-foreground"
+          />
+        </SidebarRowIdentityRail>
+        <SidebarRowContent className="truncate">
           Storybook pass for shortcut alignment
-        </span>
-        <span className="flex shrink-0 items-center gap-0.5">
+        </SidebarRowContent>
+        <SidebarRowAccessory className="flex shrink-0 items-center gap-0.5">
           <AppCommandShortcutPill shortcut={shortcut} />
-        </span>
-      </div>
+        </SidebarRowAccessory>
+      </SidebarRow>
     </div>
   );
 }

--- a/apps/app/src/components/plugin/PluginNavSidebarItems.test.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.test.tsx
@@ -15,6 +15,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { CompactViewportOverrideProvider } from "@bb/shared-ui/hooks/use-compact-viewport";
 import { AUTOMATIONS_PLUGIN_ID } from "@/lib/route-paths";
+import type { PluginNavPanelChromeEntry } from "@/lib/plugin-nav-panel-chrome";
 import { SidebarProvider } from "@/components/ui/sidebar.js";
 import {
   resetPluginSlotStoreForTest,
@@ -124,6 +125,7 @@ function renderSidebarItems(
   options: {
     storedOrder?: string[];
     compactViewport?: boolean;
+    entries?: readonly PluginNavPanelChromeEntry[];
     initialEntry?: string;
     splitEnabled?: boolean;
   } = {},
@@ -145,6 +147,7 @@ function renderSidebarItems(
             <SidebarProvider>
               <PluginNavSidebarItems
                 splitEnabled={options.splitEnabled ?? false}
+                {...(options.entries ? { entries: options.entries } : {})}
               />
               <LocationPath />
             </SidebarProvider>
@@ -160,7 +163,7 @@ function panelRowNames(labels: readonly string[]): string[] {
   const rowLabels = new Set(labels);
   return screen
     .getAllByRole("button")
-    .map((button) => button.textContent?.trim() ?? "")
+    .map((button) => button.getAttribute("aria-label") ?? "")
     .filter((label) => rowLabels.has(label));
 }
 
@@ -182,20 +185,43 @@ afterEach(() => {
 });
 
 describe("PluginNavSidebarItems", () => {
+  it("renders the same classified entry snapshot used by the sidebar region", () => {
+    renderSidebarItems({
+      entries: [
+        {
+          chrome: {
+            pluginId: "docs",
+            id: "main",
+            title: "Docs",
+            icon: "Puzzle",
+            path: "main",
+          },
+          panel: null,
+        },
+      ],
+    });
+
+    expect(screen.getByRole("button", { name: "Docs" })).toBeDefined();
+  });
+
   it("keeps an accessory-less plugin row unchanged", () => {
     registerPanel("docs", "Docs");
 
     const view = renderSidebarItems();
+    const rowButton = screen.getByRole("button", { name: "Docs" });
+    const row = rowButton.closest("[data-sidebar-row]");
 
-    expect(screen.getByRole("button", { name: "Docs" }).textContent).toBe(
-      "Docs",
-    );
+    expect(rowButton.getAttribute("aria-label")).toBe("Docs");
     expect(
-      screen.getByRole("button", { name: "Docs" }).classList.contains("pr-7"),
-    ).toBe(true);
+      row?.querySelector('[data-sidebar-row-slot="content"]')?.textContent,
+    ).toBe("Docs");
+    expect(row?.getAttribute("data-sidebar-row-anatomy")).toBe("navigation");
     expect(
-      screen.getByRole("button", { name: "Docs" }).classList.contains("pr-18"),
-    ).toBe(false);
+      row?.querySelector('[data-sidebar-row-slot="identity"]'),
+    ).not.toBeNull();
+    expect(
+      row?.querySelector('[data-sidebar-row-slot="actions"]'),
+    ).not.toBeNull();
     expect(
       screen.queryByRole("button", { name: "Docs panel options" }),
     ).not.toBeNull();
@@ -229,12 +255,12 @@ describe("PluginNavSidebarItems", () => {
 
     expect(accessory?.textContent).toBe("123456789012345678901234567890");
     expect(screen.getByRole("button", { name: "Tasks" })).not.toBeNull();
-    expect(
-      screen.getByRole("button", { name: "Tasks" }).classList.contains("pr-18"),
-    ).toBe(true);
+    expect(accessory?.getAttribute("data-sidebar-row-slot")).toBe(
+      "accessory",
+    );
+    expect((accessory as HTMLElement | null)?.style.gridArea).toBe("actions");
     for (const className of [
       "bb-sidebar-hover-actions-fade",
-      "right-1",
       "min-w-5",
       "max-h-5",
       "max-w-16",
@@ -300,7 +326,7 @@ describe("PluginNavSidebarItems", () => {
     const dropdownMenu = await screen.findByRole("menu");
     const expected = [
       ["Open in split", "Columns2"],
-      ["Detail page", "Info"],
+      ["View details", "Info"],
       ["Move to top", "ArrowUp"],
       ["Move to overflow", "ArrowDown"],
       ["Disable", "Unavailable"],
@@ -345,7 +371,7 @@ describe("PluginNavSidebarItems", () => {
       screen.queryByRole("menuitem", { name: "Open in split" }),
     ).toBeNull();
     fireEvent.click(
-      await screen.findByRole("menuitem", { name: "Detail page" }),
+      await screen.findByRole("menuitem", { name: "View details" }),
     );
     expect(screen.getByTestId("location-path").textContent).toBe(
       "/extensions/plugins/docs",
@@ -498,17 +524,14 @@ describe("PluginNavSidebarItems", () => {
     const toggle = screen.getByTestId("plugin-nav-sidebar-overflow-toggle");
     expect(toggle.textContent).toBe("More plugins");
     expect(toggle.textContent).not.toMatch(/\d/);
-    expect(toggle.lastElementChild?.getAttribute("data-icon")).toBe(
-      "ChevronRight",
-    );
-    expect(toggle.lastElementChild?.classList.contains("rotate-90")).toBe(
-      false,
-    );
+    const disclosure = toggle.querySelector('[data-icon="ChevronRight"]');
+    expect(disclosure).not.toBeNull();
+    expect(disclosure?.classList.contains("rotate-90")).toBe(false);
 
     fireEvent.click(toggle);
     await waitFor(() => expect(panelRowNames(labels)).toEqual(labels));
     expect(toggle.textContent).toBe("Show fewer");
-    expect(toggle.lastElementChild?.classList.contains("rotate-90")).toBe(true);
+    expect(disclosure?.classList.contains("rotate-90")).toBe(true);
   });
 
   it("keeps every overflow row in the same order when a long list is toggled", async () => {

--- a/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
@@ -41,6 +41,13 @@ import { PluginIcon } from "@/components/plugin/PluginIcon";
 import { PluginSlotMount } from "@/components/plugin/PluginSlotMount";
 import { PROJECT_LIST_ACTION_BUTTON_CLASS } from "@/components/sidebar/ProjectList";
 import {
+  SidebarRow,
+  SidebarRowAccessory,
+  SidebarRowActions,
+  SidebarRowContent,
+  SidebarRowIdentityRail,
+} from "@/components/sidebar/SidebarRow";
+import {
   AUTOMATIONS_PLUGIN_ID,
   getPluginDetailRoutePath,
   getPluginPanelRoutePath,
@@ -50,6 +57,7 @@ import {
 import {
   usePluginNavPanelChrome,
   type PluginNavPanelChrome,
+  type PluginNavPanelChromeEntry,
 } from "@/lib/plugin-nav-panel-chrome";
 import { cn } from "@bb/shared-ui/lib/utils";
 import type { PluginNavPanelSlot } from "@/lib/plugin-slots";
@@ -57,7 +65,10 @@ import { usePaneContentSplitDrag } from "@/components/sidebar/usePaneContentSpli
 import { usePaneContentSplitIndicator } from "@/components/sidebar/paneContentSplitIndicator";
 import type { MiniMapSlot } from "@/components/sidebar/paneContentSplitIndicator";
 import { SplitPaneMiniMap } from "@/components/sidebar/SplitPaneMiniMap";
-import { SIDEBAR_MORE_ACTION_TRIGGER_CLASS } from "@/components/sidebar/sidebarRowClasses";
+import {
+  SIDEBAR_LEADING_GLYPH_SLOT_CLASS,
+  SIDEBAR_MORE_ACTION_TRIGGER_CLASS,
+} from "@/components/sidebar/sidebarRowClasses";
 import {
   SIDEBAR_HOVER_ACTIONS_CLASS,
   SIDEBAR_HOVER_ACTIONS_FADE_CLASS,
@@ -89,11 +100,21 @@ type SidebarNavRow = {
   panel: PluginNavPanelSlot | null;
 };
 
+export function getTraditionalPluginNavPanelEntries(
+  entries: readonly PluginNavPanelChromeEntry[],
+): PluginNavPanelChromeEntry[] {
+  return entries.filter(
+    ({ chrome }) => chrome.pluginId !== AUTOMATIONS_PLUGIN_ID,
+  );
+}
+
 export function PluginNavSidebarItems(props: {
+  entries?: readonly PluginNavPanelChromeEntry[];
   onNavigate?: () => void;
   splitEnabled?: boolean;
 }) {
-  const navPanels = usePluginNavPanelChrome();
+  const discoveredEntries = usePluginNavPanelChrome();
+  const navPanels = props.entries ?? discoveredEntries;
   const rows = useMemo<SidebarNavRow[]>(
     () =>
       navPanels.flatMap(({ chrome, panel }) =>
@@ -112,7 +133,13 @@ export function PluginNavSidebarItems(props: {
     [navPanels],
   );
   if (rows.length === 0) return null;
-  return <PluginNavSidebarItemList {...props} rows={rows} />;
+  return (
+    <PluginNavSidebarItemList
+      rows={rows}
+      splitEnabled={props.splitEnabled ?? false}
+      {...(props.onNavigate ? { onNavigate: props.onNavigate } : {})}
+    />
+  );
 }
 
 function PluginNavSidebarItemList({
@@ -279,30 +306,34 @@ function PluginNavSidebarOverflowToggle({
   onToggle: () => void;
 }) {
   return (
-    <Button
-      type="button"
-      size="sm"
-      variant="ghost"
-      aria-expanded={isOpen}
-      className={cn(
-        PROJECT_LIST_ACTION_BUTTON_CLASS,
-        "w-full text-subtle-foreground/75",
-      )}
-      onClick={onToggle}
-      data-testid="plugin-nav-sidebar-overflow-toggle"
-    >
-      <span className="min-w-0 flex-1 truncate text-left">
-        {isOpen ? "Show fewer" : "More plugins"}
-      </span>
-      <Icon
-        name="ChevronRight"
+    <SidebarRow asChild anatomy="navigation" variant="groupLabel">
+      <Button
+        type="button"
+        size="sm"
+        variant="ghost"
+        aria-expanded={isOpen}
         className={cn(
-          "size-3 shrink-0 transition-transform duration-150",
-          isOpen && "rotate-90",
+          PROJECT_LIST_ACTION_BUTTON_CLASS,
+          "w-full text-subtle-foreground/75",
         )}
-        aria-hidden="true"
-      />
-    </Button>
+        onClick={onToggle}
+        data-testid="plugin-nav-sidebar-overflow-toggle"
+      >
+        <SidebarRowContent className="truncate text-left">
+          {isOpen ? "Show fewer" : "More plugins"}
+        </SidebarRowContent>
+        <SidebarRowAccessory>
+          <Icon
+            name="ChevronRight"
+            className={cn(
+              "size-3 shrink-0 transition-transform duration-150",
+              isOpen && "rotate-90",
+            )}
+            aria-hidden="true"
+          />
+        </SidebarRowAccessory>
+      </Button>
+    </SidebarRow>
   );
 }
 
@@ -445,7 +476,7 @@ function PluginNavRowMenuItems({
         icon="Info"
         onSelect={onOpenDetails}
       >
-        Detail page
+        View details
       </PluginNavRowMenuItem>
       <PluginNavRowMenuSeparator surface={surface} />
       <PluginNavRowMenuItem
@@ -479,9 +510,23 @@ function PluginNavRowMenuItems({
 
 function ToolsNavSidebarItemIcon() {
   return (
-    <span className="bb-sidebar-row-icon-swap shrink-0" aria-hidden="true">
-      <Icon name="Toolbox" className="bb-sidebar-row-icon-rest" />
-      <Icon name="ToolCase" className="bb-sidebar-row-icon-hover" />
+    <span className={SIDEBAR_LEADING_GLYPH_SLOT_CLASS} aria-hidden="true">
+      <span className="bb-sidebar-row-icon-swap shrink-0">
+        <Icon
+          name="Toolbox"
+          className={cn(
+            "bb-sidebar-row-icon-rest",
+            COARSE_POINTER_ICON_SIZE_CLASS,
+          )}
+        />
+        <Icon
+          name="ToolCase"
+          className={cn(
+            "bb-sidebar-row-icon-hover",
+            COARSE_POINTER_ICON_SIZE_CLASS,
+          )}
+        />
+      </span>
     </span>
   );
 }
@@ -495,19 +540,25 @@ export function ExtensionsNavSidebarItem({
 }) {
   const navigate = useNavigate();
   return (
-    <Button
-      type="button"
-      size="sm"
-      variant="ghost"
-      className={cn(PROJECT_LIST_ACTION_BUTTON_CLASS, "w-full")}
-      onClick={() => {
-        onNavigate?.();
-        void navigate(routePath);
-      }}
-    >
-      <ToolsNavSidebarItemIcon />
-      <span className="min-w-0 flex-1 truncate text-left">Extensions</span>
-    </Button>
+    <SidebarRow asChild anatomy="navigation" variant="item">
+      <Button
+        type="button"
+        size="sm"
+        variant="ghost"
+        className={cn(PROJECT_LIST_ACTION_BUTTON_CLASS, "w-full")}
+        onClick={() => {
+          onNavigate?.();
+          void navigate(routePath);
+        }}
+      >
+        <SidebarRowIdentityRail>
+          <ToolsNavSidebarItemIcon />
+        </SidebarRowIdentityRail>
+        <SidebarRowContent className="truncate text-left">
+          Extensions
+        </SidebarRowContent>
+      </Button>
+    </SidebarRow>
   );
 }
 
@@ -528,24 +579,30 @@ export function AutomationsNavSidebarItem({
     location.pathname === path || location.pathname.startsWith(`${path}/`);
 
   return (
-    <Button
-      type="button"
-      size="sm"
-      variant="ghost"
-      className={cn(
-        PROJECT_LIST_ACTION_BUTTON_CLASS,
-        "w-full",
-        isActive && "bg-sidebar-accent text-sidebar-foreground",
-      )}
-      aria-current={isActive ? "page" : undefined}
-      onClick={() => {
-        onNavigate?.();
-        void navigate(path);
-      }}
-    >
-      <PluginIcon pluginId={chrome.pluginId} icon={chrome.icon} />
-      <span className="min-w-0 flex-1 truncate text-left">{chrome.title}</span>
-    </Button>
+    <SidebarRow asChild anatomy="navigation" variant="item">
+      <Button
+        type="button"
+        size="sm"
+        variant="ghost"
+        className={cn(
+          PROJECT_LIST_ACTION_BUTTON_CLASS,
+          "w-full",
+          isActive && "bg-sidebar-accent text-sidebar-foreground",
+        )}
+        aria-current={isActive ? "page" : undefined}
+        onClick={() => {
+          onNavigate?.();
+          void navigate(path);
+        }}
+      >
+        <SidebarRowIdentityRail>
+          <PluginIcon pluginId={chrome.pluginId} icon={chrome.icon} />
+        </SidebarRowIdentityRail>
+        <SidebarRowContent className="truncate text-left">
+          {chrome.title}
+        </SidebarRowContent>
+      </Button>
+    </SidebarRow>
   );
 }
 
@@ -687,61 +744,66 @@ function SidebarNavRowChrome({
   return (
     <ContextMenu onOpenChange={setIsActionsOpen}>
       <ContextMenuTrigger asChild>
-        <div
+        <SidebarRow
           ref={rowRef}
           style={rowStyle}
-          className={cn(SIDEBAR_HOVER_ACTIONS_ROW_CLASS, "relative")}
+          anatomy="navigation"
+          variant="item"
+          className={cn(
+            "relative",
+            SIDEBAR_HOVER_ACTIONS_ROW_CLASS,
+            PROJECT_LIST_ACTION_BUTTON_CLASS,
+            isActive && "bg-sidebar-accent text-sidebar-foreground",
+          )}
         >
           <Button
             type="button"
             size="sm"
             variant="ghost"
-            className={cn(
-              PROJECT_LIST_ACTION_BUTTON_CLASS,
-              "w-full pr-7",
-              accessory && "pr-18",
-              isActive && "bg-sidebar-accent text-sidebar-foreground",
-            )}
+            className="absolute inset-0 w-full rounded-md bg-transparent p-0 ring-sidebar-ring hover:bg-sidebar-accent focus-visible:ring-2"
+            aria-label={title}
             aria-current={isActive ? "page" : undefined}
             ref={dragBindings?.setActivatorNodeRef}
             {...dragBindings?.attributes}
             {...pointerDragListeners}
             onPointerDown={onPointerDown}
             onClick={onSelect}
-          >
+          />
+          <SidebarRowIdentityRail className="pointer-events-none relative z-10">
             {icon}
-            <span className="flex min-w-0 flex-1 items-center gap-1.5 text-left">
-              <span className="min-w-0 truncate">{title}</span>
-              {splitMiniMap ? (
-                <SplitPaneMiniMap
-                  slots={splitMiniMap}
-                  label={`${title} — open in split`}
-                />
-              ) : null}
-            </span>
-          </Button>
+          </SidebarRowIdentityRail>
+          <SidebarRowContent className="pointer-events-none relative z-10 flex items-center gap-1.5 text-left">
+            <span className="min-w-0 truncate">{title}</span>
+            {splitMiniMap ? (
+              <SplitPaneMiniMap
+                slots={splitMiniMap}
+                label={`${title} — open in split`}
+              />
+            ) : null}
+          </SidebarRowContent>
           {accessory ? (
-            <span
+            <SidebarRowAccessory
               data-plugin-nav-sidebar-accessory=""
+              style={{ gridArea: "actions" }}
               data-sidebar-hover-actions-open={
                 isActionsOpen ? "true" : undefined
               }
               className={cn(
                 SIDEBAR_HOVER_ACTIONS_FADE_CLASS,
-                "pointer-events-none absolute right-1 top-1/2 block min-w-5 max-h-5 max-w-16 -translate-y-1/2 overflow-hidden text-xs text-ellipsis whitespace-nowrap text-center leading-5",
+                "pointer-events-none relative z-10 block min-w-5 max-h-5 max-w-16 overflow-hidden text-xs text-ellipsis whitespace-nowrap text-center leading-5",
               )}
             >
               {accessory}
-            </span>
+            </SidebarRowAccessory>
           ) : null}
-          <div
+          <SidebarRowActions
             data-sidebar-hover-actions-open={isActionsOpen ? "true" : undefined}
             data-sidebar-hover-actions-mobile={
               SIDEBAR_HOVER_ACTIONS_MOBILE_ALWAYS_VALUE
             }
             className={cn(
               SIDEBAR_HOVER_ACTIONS_CLASS,
-              "absolute inset-y-0 right-0 flex items-center",
+              "relative z-20 flex items-center",
             )}
           >
             <DropdownMenu onOpenChange={setIsActionsOpen}>
@@ -767,8 +829,8 @@ function SidebarNavRowChrome({
                 {menuItems("dropdown")}
               </DropdownMenuContent>
             </DropdownMenu>
-          </div>
-        </div>
+          </SidebarRowActions>
+        </SidebarRow>
       </ContextMenuTrigger>
       <ContextMenuContent aria-label={`${title} panel options`}>
         {menuItems("context")}

--- a/apps/app/src/components/plugin/plugin-slot-mounts.test.tsx
+++ b/apps/app/src/components/plugin/plugin-slot-mounts.test.tsx
@@ -1328,7 +1328,7 @@ describe("PluginNavSidebarItems + PluginPanelView", () => {
         </Routes>
       </MemoryRouter>,
     );
-    fireEvent.click(screen.getByText("Demo board"));
+    fireEvent.click(screen.getByRole("button", { name: "Demo board" }));
     expect(screen.getByText("board panel body")).toBeDefined();
   });
 

--- a/apps/app/src/components/sidebar/AppSidebar.tsx
+++ b/apps/app/src/components/sidebar/AppSidebar.tsx
@@ -28,6 +28,7 @@ import { useThreadListReplacement } from "./threadListProvider";
 import {
   AutomationsNavSidebarItem,
   ExtensionsNavSidebarItem,
+  getTraditionalPluginNavPanelEntries,
   PluginNavSidebarItems,
 } from "@/components/plugin/PluginNavSidebarItems";
 import { PluginSidebarFooterActions } from "@/components/plugin/PluginSidebarFooterActions";
@@ -194,8 +195,8 @@ export function AppSidebar({
   const automationsNavPanel = pluginNavPanels.find(
     ({ chrome }) => chrome.pluginId === AUTOMATIONS_PLUGIN_ID,
   );
-  const hasTraditionalPluginPanels = pluginNavPanels.some(
-    ({ chrome }) => chrome.pluginId !== AUTOMATIONS_PLUGIN_ID,
+  const traditionalPluginNavPanels = getTraditionalPluginNavPanelEntries(
+    pluginNavPanels,
   );
 
   const handleNewChat = useCallback(() => {
@@ -377,8 +378,12 @@ export function AppSidebar({
                   {visibleTopRegionItems}
                 </div>
               ) : null,
-            "plugin-pages": hasTraditionalPluginPanels ? (
-              <PluginNavSidebarItems onNavigate={closeOnMobile} splitEnabled />
+            "plugin-pages": traditionalPluginNavPanels.length > 0 ? (
+              <PluginNavSidebarItems
+                entries={traditionalPluginNavPanels}
+                onNavigate={closeOnMobile}
+                splitEnabled
+              />
             ) : null,
             "thread-list": (
               <PluginThreadList

--- a/apps/app/src/components/sidebar/BuiltInSidebarSection.test.tsx
+++ b/apps/app/src/components/sidebar/BuiltInSidebarSection.test.tsx
@@ -146,7 +146,7 @@ describe("built-in sidebar section renderer", () => {
     expect(screen.getAllByLabelText("Goal active")).not.toHaveLength(0);
   });
 
-  it("renders loose Threads after a stable divider without a collapse caret", () => {
+  it("renders loose threads without a label, divider, or collapse control", () => {
     const { container } = render(
       renderBuiltInSidebarSection({
         collapsedSectionIds: new Set(),
@@ -157,8 +157,8 @@ describe("built-in sidebar section renderer", () => {
           ...SECTIONS,
           threads: {
             ...SECTIONS.threads,
+            actions: <button type="button">Loose threads action</button>,
             presentation: "loose",
-            showLooseHeading: true,
           },
         },
         showPinnedSection: false,
@@ -168,7 +168,13 @@ describe("built-in sidebar section renderer", () => {
     expect(
       container.querySelector("[data-sidebar-loose-thread-group]"),
     ).not.toBeNull();
-    expect(screen.getByText("Threads")).not.toBeNull();
+    expect(screen.queryByText("Threads")).toBeNull();
+    expect(
+      container.querySelector("[data-sidebar-loose-thread-divider]"),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Loose threads action" }),
+    ).toBeNull();
     expect(container.querySelector("[data-sidebar-collapse-caret]")).toBeNull();
   });
 });

--- a/apps/app/src/components/sidebar/BuiltInSidebarSection.tsx
+++ b/apps/app/src/components/sidebar/BuiltInSidebarSection.tsx
@@ -26,7 +26,6 @@ export interface BuiltInSidebarSectionOptions {
   isDropTargetActive?: boolean;
   label: string;
   presentation?: "section" | "loose";
-  showLooseHeading?: boolean;
 }
 
 interface BuiltInSidebarSectionProps extends BuiltInSidebarSectionOptions {
@@ -91,21 +90,10 @@ function BuiltInSidebarSection({
   label,
   onToggleCollapsed,
   presentation = "section",
-  showLooseHeading = false,
 }: BuiltInSidebarSectionProps) {
   if (presentation === "loose") {
     return (
-      <div
-        data-sidebar-loose-thread-group=""
-        className={
-          showLooseHeading ? "mt-1 border-t border-border/70 pt-1" : "mt-1"
-        }
-      >
-        {showLooseHeading ? (
-          <div className="flex h-8 items-center px-3 text-xs font-medium text-subtle-foreground">
-            {label}
-          </div>
-        ) : null}
+      <div data-sidebar-loose-thread-group="" className="mt-1">
         {content}
       </div>
     );

--- a/apps/app/src/components/sidebar/ProjectList.modes.test.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.modes.test.tsx
@@ -249,14 +249,18 @@ describe("sidebar organization mode sections", () => {
     ]);
   });
 
-  it("preserves each persisted order while switching modes", async () => {
+  it("keeps Pinned first while preserving each mode's remaining order", async () => {
     const store = createStore();
-    const projectOrder = ["threads", "project:a", "pinned"];
-    const sectionOrder = ["section:a", "pinned", "threads"];
-    const machineOrder = ["threads", "pinned"];
-    store.set(sidebarSectionOrderAtom, projectOrder);
-    store.set(sidebarManualSectionOrderAtom, sectionOrder);
-    store.set(sidebarMachineSectionOrderAtom, machineOrder);
+    const projectOrder = ["pinned", "threads", "project:a"];
+    const sectionOrder = ["pinned", "section:a", "threads"];
+    const machineOrder = ["pinned", "threads"];
+    store.set(sidebarSectionOrderAtom, ["threads", "project:a", "pinned"]);
+    store.set(sidebarManualSectionOrderAtom, [
+      "section:a",
+      "pinned",
+      "threads",
+    ]);
+    store.set(sidebarMachineSectionOrderAtom, ["threads", "pinned"]);
     store.set(sidebarOrganizationModeAtom, "project");
     render(
       <JotaiProvider store={store}>

--- a/apps/app/src/components/sidebar/ProjectList.modes.test.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.modes.test.tsx
@@ -314,21 +314,4 @@ describe("sidebar organization mode sections", () => {
     expect(screen.getByLabelText("Plan mode active")).not.toBeNull();
     expect(screen.queryByLabelText("Thread working")).toBeNull();
   });
-
-  it("indents a machine thread by one semantic depth step", () => {
-    const store = createStore();
-    store.set(sidebarMachineSectionOrderAtom, ["machine:no-machine"]);
-    store.set(sidebarCollapsedMachinesAtom, []);
-
-    const { container } = render(
-      <JotaiProvider store={store}>
-        <MachineModeProbe threads={[makeThread()]} />
-      </JotaiProvider>,
-    );
-
-    const threadRow = container
-      .querySelector('[data-sidebar-thread-id="thr_machine"]')
-      ?.closest("[data-sidebar-row]");
-    expect(threadRow?.getAttribute("data-sidebar-row-depth")).toBe("1");
-  });
 });

--- a/apps/app/src/components/sidebar/ProjectList.modes.test.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.modes.test.tsx
@@ -314,4 +314,21 @@ describe("sidebar organization mode sections", () => {
     expect(screen.getByLabelText("Plan mode active")).not.toBeNull();
     expect(screen.queryByLabelText("Thread working")).toBeNull();
   });
+
+  it("indents a machine thread by one semantic depth step", () => {
+    const store = createStore();
+    store.set(sidebarMachineSectionOrderAtom, ["machine:no-machine"]);
+    store.set(sidebarCollapsedMachinesAtom, []);
+
+    const { container } = render(
+      <JotaiProvider store={store}>
+        <MachineModeProbe threads={[makeThread()]} />
+      </JotaiProvider>,
+    );
+
+    const threadRow = container
+      .querySelector('[data-sidebar-thread-id="thr_machine"]')
+      ?.closest("[data-sidebar-row]");
+    expect(threadRow?.getAttribute("data-sidebar-row-depth")).toBe("1");
+  });
 });

--- a/apps/app/src/components/sidebar/ProjectList.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.tsx
@@ -1405,6 +1405,7 @@ function ProjectModeSections({
       content: (
         <ProjectThreadTree
           projectId={PERSONAL_PROJECT_ID}
+          rootDepth={0}
           threadListState={getProjectThreadListState({
             status,
             threads: personalThreads,
@@ -1734,6 +1735,7 @@ export function MachineModeSections({
       collapsedThreads: nonPinnedThreads,
       content: (
         <ProjectThreadTree
+          rootDepth={0}
           threadListState={allThreadsListState}
           compareThreads={compareThreads}
           variant="section"
@@ -1785,6 +1787,7 @@ export function MachineModeSections({
             consumeClickSuppression={consumeClickSuppression}
           >
             <ProjectThreadTree
+              rootDepth={1}
               threadListState={section.threadListState}
               compareThreads={compareThreads}
               variant="section"

--- a/apps/app/src/components/sidebar/ProjectList.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.tsx
@@ -80,7 +80,6 @@ import {
 import {
   COARSE_POINTER_ICON_SIZE_CLASS,
   COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
-  COARSE_POINTER_ROW_HEIGHT_CLASS,
 } from "@bb/shared-ui/coarse-pointer-sizing";
 import {
   ChronologicalSectionThreadSections,
@@ -149,9 +148,7 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from "@bb/shared-ui/tooltip";
 import {
   SIDEBAR_MORE_ACTION_TRIGGER_CLASS,
-  SIDEBAR_ROW_BASE_CLASS,
   SIDEBAR_ROW_INTERACTIVE_STATE_CLASS,
-  SIDEBAR_STANDARD_ROW_PADDING_CLASS,
 } from "./sidebarRowClasses";
 export { TopLevelSidebarSection } from "./TopLevelSidebarSection";
 import { useAppCommandShortcut } from "@/components/commands/AppCommandProvider";
@@ -214,16 +211,10 @@ interface ProjectListThreadsSectionActionsProps {
   onNewThread: () => void;
 }
 
-interface ProjectListProjectsSectionActionsProps {
-  isCreatingProject: boolean;
-  onNewProject: () => void;
-}
-
 interface SidebarThreadListMenuProps {
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
 }
-
 
 interface ProjectListNavigationLoadingRowProps {
   textWidthClassName: string;
@@ -235,12 +226,9 @@ interface LocalSourcePathTarget {
 }
 
 export const PROJECT_LIST_ACTION_BUTTON_CLASS = cn(
-  SIDEBAR_ROW_BASE_CLASS,
   LIST_HOVER_TRANSITION,
-  SIDEBAR_STANDARD_ROW_PADDING_CLASS,
   SIDEBAR_ROW_INTERACTIVE_STATE_CLASS,
-  COARSE_POINTER_ROW_HEIGHT_CLASS,
-  "min-w-0 cursor-pointer justify-start overflow-hidden font-normal ring-sidebar-ring focus-visible:ring-2 disabled:cursor-default disabled:opacity-70 max-md:pointer-coarse:[&_svg]:size-5",
+  "min-w-0 cursor-pointer overflow-hidden font-normal ring-sidebar-ring focus-visible:ring-2 disabled:cursor-default disabled:opacity-70 max-md:pointer-coarse:[&_svg]:size-5",
 );
 
 const PROJECT_LIST_ACTION_ICON_BUTTON_CLASS = cn(
@@ -557,23 +545,6 @@ export function ProjectListSectionIconButton({
   );
 }
 
-function ProjectListProjectsSectionActions({
-  isCreatingProject,
-  onNewProject,
-}: ProjectListProjectsSectionActionsProps) {
-  return (
-    <ProjectListSectionIconButton
-      ariaLabel="New project"
-      title="New project"
-      disabled={isCreatingProject}
-      icon={
-        <Icon name="FolderPlus" className={COARSE_POINTER_ICON_SIZE_CLASS} />
-      }
-      onClick={onNewProject}
-    />
-  );
-}
-
 function ProjectListThreadsSectionActions({
   isCreatingSection,
   onNewSection,
@@ -870,23 +841,6 @@ interface SidebarThreadListToolbarProps {
   isCreatingProject: boolean;
   onNewProject?: () => void;
   onNewThread: () => void;
-  label: "Threads" | "Projects" | "Machines" | "Sections";
-}
-
-interface SidebarThreadListLabelOptions {
-  hasProjects: boolean;
-  hasSections: boolean;
-  mode: SidebarOrganizationMode;
-}
-
-export function getSidebarThreadListLabel({
-  hasProjects,
-  hasSections,
-  mode,
-}: SidebarThreadListLabelOptions): SidebarThreadListToolbarProps["label"] {
-  if (mode === "machine") return "Machines";
-  if (mode === "manual") return hasSections ? "Sections" : "Threads";
-  return hasProjects ? "Projects" : "Threads";
 }
 
 export function SidebarThreadListToolbar({
@@ -895,92 +849,120 @@ export function SidebarThreadListToolbar({
   isCreatingProject,
   onNewProject,
   onNewThread,
-  label,
 }: SidebarThreadListToolbarProps) {
-  const hasMultipleOverflowActions =
-    onNewSection !== undefined && onNewProject !== undefined;
-
   return (
     <SidebarStickyTier
       tier="toolbar"
       data-sidebar-thread-list-toolbar=""
-      className="flex items-center gap-0.5 rounded-md pl-1 pr-0"
+      className="flex items-center justify-end gap-0.5 rounded-md pl-1 pr-0"
     >
-      <span className="min-w-0 flex-1 truncate text-xs font-semibold text-muted-foreground">
-        {label}
-      </span>
-      <span className="inline-flex shrink-0 items-center gap-0.5">
-        <SidebarOrganizeMenu />
-        <SidebarFilterSortMenu />
-        <ProjectListThreadsSectionActions
-          isCreatingSection={false}
-          onNewThread={onNewThread}
-        />
-        {hasMultipleOverflowActions ? (
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                aria-label="More thread actions"
-                className={cn(
-                  "rounded-md p-0 text-muted-foreground hover:bg-transparent hover:text-sidebar-foreground data-[state=open]:bg-state-active data-[state=open]:text-sidebar-foreground",
-                  SIDEBAR_MORE_ACTION_TRIGGER_CLASS,
-                )}
-              >
-                <Icon
-                  name="MoreHorizontal"
-                  className={COARSE_POINTER_ICON_SIZE_CLASS}
-                />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent
-              align="end"
-              className={SIDEBAR_COMPACT_MENU_CONTENT_CLASS}
-            >
-              {onNewSection ? (
-                <DropdownMenuItem
-                  disabled={isCreatingSection}
-                  onSelect={onNewSection}
-                >
-                  <Icon name="SectionAdd" aria-hidden="true" />
-                  New section
-                </DropdownMenuItem>
-              ) : null}
-              {onNewProject ? (
-                <DropdownMenuItem
-                  disabled={isCreatingProject}
-                  onSelect={onNewProject}
-                >
-                  <Icon name="FolderPlus" aria-hidden="true" />
-                  New project
-                </DropdownMenuItem>
-              ) : null}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        ) : onNewSection ? (
-          <ProjectListSectionIconButton
-            ariaLabel="New section"
-            title="New section"
-            disabled={isCreatingSection}
-            icon={
-              <Icon
-                name="SectionAdd"
-                className={COARSE_POINTER_ICON_SIZE_CLASS}
-              />
-            }
-            onClick={onNewSection}
-          />
-        ) : onNewProject ? (
-          <ProjectListProjectsSectionActions
-            isCreatingProject={isCreatingProject}
-            onNewProject={onNewProject}
-          />
-        ) : null}
-      </span>
+      <SidebarThreadListActions
+        isCreatingSection={isCreatingSection}
+        isCreatingProject={isCreatingProject}
+        onNewThread={onNewThread}
+        {...(onNewSection ? { onNewSection } : {})}
+        {...(onNewProject ? { onNewProject } : {})}
+      />
       <OverflowFade placement="below" tone="sidebar" size="sm" />
     </SidebarStickyTier>
+  );
+}
+
+function SidebarThreadListActions({
+  isCreatingSection,
+  onNewSection,
+  isCreatingProject,
+  onNewProject,
+  onNewThread,
+}: SidebarThreadListToolbarProps) {
+  const hasMultipleAdditionalActions =
+    onNewSection !== undefined && onNewProject !== undefined;
+  const hasOnlyNewSection =
+    onNewSection !== undefined && onNewProject === undefined;
+  const hasOnlyNewProject =
+    onNewProject !== undefined && onNewSection === undefined;
+
+  return (
+    <span className="inline-flex shrink-0 items-center gap-0.5">
+      <SidebarOrganizeMenu />
+      <SidebarFilterSortMenu />
+      <ProjectListThreadsSectionActions
+        isCreatingSection={false}
+        onNewThread={onNewThread}
+      />
+      {hasOnlyNewSection && onNewSection ? (
+        <ProjectListSectionIconButton
+          ariaLabel="New section"
+          title="New section"
+          disabled={isCreatingSection}
+          icon={
+            <Icon
+              name="SectionAdd"
+              className={COARSE_POINTER_ICON_SIZE_CLASS}
+            />
+          }
+          onClick={onNewSection}
+        />
+      ) : null}
+      {hasOnlyNewProject && onNewProject ? (
+        <ProjectListSectionIconButton
+          ariaLabel="New project"
+          title="New project"
+          disabled={isCreatingProject}
+          icon={
+            <Icon
+              name="FolderPlus"
+              className={COARSE_POINTER_ICON_SIZE_CLASS}
+            />
+          }
+          onClick={onNewProject}
+        />
+      ) : null}
+      {hasMultipleAdditionalActions ? (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label="More thread actions"
+              className={cn(
+                "rounded-md p-0 text-muted-foreground hover:bg-transparent hover:text-sidebar-foreground data-[state=open]:bg-state-active data-[state=open]:text-sidebar-foreground",
+                SIDEBAR_MORE_ACTION_TRIGGER_CLASS,
+              )}
+            >
+              <Icon
+                name="MoreHorizontal"
+                className={COARSE_POINTER_ICON_SIZE_CLASS}
+              />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            align="end"
+            className={SIDEBAR_COMPACT_MENU_CONTENT_CLASS}
+          >
+            {onNewSection ? (
+              <DropdownMenuItem
+                disabled={isCreatingSection}
+                onSelect={onNewSection}
+              >
+                <Icon name="SectionAdd" aria-hidden="true" />
+                New section
+              </DropdownMenuItem>
+            ) : null}
+            {onNewProject ? (
+              <DropdownMenuItem
+                disabled={isCreatingProject}
+                onSelect={onNewProject}
+              >
+                <Icon name="FolderPlus" aria-hidden="true" />
+                New project
+              </DropdownMenuItem>
+            ) : null}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      ) : null}
+    </span>
   );
 }
 
@@ -1218,6 +1200,7 @@ interface ProjectModeSectionsProps extends BuiltInSectionRenderState {
   status: ConnectionAwareQueryStatus;
   threads: ThreadListEntry[];
   threadsSection: Omit<BuiltInSidebarSectionOptions, "content">;
+  threadListLead?: ReactNode;
 }
 
 function ProjectModeSections({
@@ -1240,6 +1223,7 @@ function ProjectModeSections({
   status,
   threads,
   threadsSection,
+  threadListLead,
 }: ProjectModeSectionsProps) {
   const [collapsedProjectIdList, setCollapsedProjectIdList] = useAtom(
     collapsedProjectIdsAtom,
@@ -1383,7 +1367,6 @@ function ProjectModeSections({
       ...threadsSection,
       label: "Threads",
       presentation: "loose",
-      showLooseHeading: projectRows.length > 0,
       activity: getCollapsedChildActivity(personalThreads, draftThreadIds),
       collapsedThreads: personalThreads,
       content: (
@@ -1411,6 +1394,7 @@ function ProjectModeSections({
       order={order}
       reorderOrder={persistedOrder}
       onOrderChange={onOrderChange}
+      pinnedTrailingContent={threadListLead}
     >
       {(sectionId, consumeClickSuppression) => {
         const builtInSection = renderBuiltInSidebarSection({
@@ -1475,6 +1459,7 @@ interface SectionModeSectionsProps extends BuiltInSectionRenderState {
   threads: ThreadListEntry[];
   threadsSection: Omit<BuiltInSidebarSectionOptions, "content">;
   effectivePinnedThreadIds: ReadonlySet<string>;
+  threadListLead?: ReactNode;
 }
 
 function SectionModeSections({
@@ -1501,6 +1486,7 @@ function SectionModeSections({
   status,
   threads,
   threadsSection,
+  threadListLead,
 }: SectionModeSectionsProps) {
   const nonPinnedThreads = useMemo(
     () => threads.filter((thread) => !effectivePinnedThreadIds.has(thread.id)),
@@ -1521,13 +1507,6 @@ function SectionModeSections({
     () =>
       nonPinnedThreads.filter(
         (thread) => thread.sectionId === null && isSidebarProjectThread(thread),
-      ),
-    [nonPinnedThreads],
-  );
-  const hasPopulatedSections = useMemo(
-    () =>
-      nonPinnedThreads.some(
-        (thread) => thread.sectionId !== null && isSidebarProjectThread(thread),
       ),
     [nonPinnedThreads],
   );
@@ -1592,6 +1571,7 @@ function SectionModeSections({
         pinnedReorderPending={pinnedReorderPending}
         pinnedThreads={pinnedThreads}
         onReorderPinnedThread={onReorderPinnedThread}
+        threadListLead={threadListLead}
         builtInSections={{
           pinned: {
             ...pinnedSection,
@@ -1599,7 +1579,6 @@ function SectionModeSections({
           threads: {
             ...threadsSection,
             presentation: "loose",
-            showLooseHeading: hasPopulatedSections,
           },
           collapsedSectionIds,
           onToggleCollapsed,
@@ -1623,6 +1602,7 @@ interface MachineModeSectionsProps extends BuiltInSectionRenderState {
   selectedThreadId?: string;
   status: ConnectionAwareQueryStatus;
   threads: ThreadListEntry[];
+  threadListLead?: ReactNode;
 }
 
 export function MachineModeSections({
@@ -1642,6 +1622,7 @@ export function MachineModeSections({
   showPinnedSection,
   status,
   threads,
+  threadListLead,
 }: MachineModeSectionsProps) {
   const { data: hosts } = useHosts();
   const [collapsedMachineKeyList, setCollapsedMachineKeyList] = useAtom(
@@ -1739,6 +1720,7 @@ export function MachineModeSections({
       order={order}
       reorderOrder={persistedOrder}
       onOrderChange={onOrderChange}
+      pinnedTrailingContent={threadListLead}
     >
       {(sectionId, consumeClickSuppression) => {
         const builtInSection = renderBuiltInSidebarSection({
@@ -2237,8 +2219,18 @@ function ProjectListComponent({
     label: "Pinned",
     content: pinnedSectionContent,
   };
+  const threadListActionProps = {
+    isCreatingSection: isCreateThreadSectionPending,
+    isCreatingProject,
+    onNewThread: handleCreateProjectlessThread,
+    ...(isSectionOrganizationMode
+      ? { onNewSection: handleOpenCreateSectionDialog }
+      : {}),
+    ...(onNewProject ? { onNewProject } : {}),
+  } satisfies SidebarThreadListToolbarProps;
   const threadsSection = {
     label: "Threads",
+    actions: <SidebarThreadListActions {...threadListActionProps} />,
   } satisfies Omit<BuiltInSidebarSectionOptions, "content">;
   const sectionCreateDialog = (
     <ThreadSectionCreateDialog
@@ -2286,21 +2278,6 @@ function ProjectListComponent({
       selection: lifecycleSelection,
     });
   const showActiveContent = showActiveModeSections && threads.length > 0;
-  const unpinnedSidebarThreads = threads.filter(
-    (thread) =>
-      !pinnedSidebarState.effectivePinnedThreadIds.has(thread.id) &&
-      isSidebarProjectThread(thread),
-  );
-  const threadToolbarLabel = getSidebarThreadListLabel({
-    hasProjects:
-      showActiveContent &&
-      unpinnedSidebarThreads.some(
-        (thread) =>
-          resolveSidebarProjectId(thread, threadById) !== PERSONAL_PROJECT_ID,
-      ),
-    hasSections: sections.length > 0,
-    mode: organizationMode,
-  });
   const archivedContentPending =
     showArchivedThreads && archivedThreadsQuery.isPending;
   const hasVisibleLifecycleRows =
@@ -2314,16 +2291,16 @@ function ProjectListComponent({
     <SidebarThreadListEmptyState filtered={showFilteredEmptyState} />
   ) : null;
   const threadToolbar = (
-    <SidebarThreadListToolbar
-      label={threadToolbarLabel}
-      isCreatingSection={isCreateThreadSectionPending}
-      onNewSection={
-        isSectionOrganizationMode ? handleOpenCreateSectionDialog : undefined
-      }
-      isCreatingProject={isCreatingProject}
-      onNewProject={onNewProject}
-      onNewThread={handleCreateProjectlessThread}
-    />
+    <SidebarThreadListToolbar {...threadListActionProps} />
+  );
+  const draftRows = showDrafts ? (
+    <SidebarDraftRows drafts={newThreadDrafts} onOpenDraft={handleOpenDraft} />
+  ) : null;
+  const activeThreadListLead = (
+    <div data-sidebar-thread-list-lead="">
+      {threadToolbar}
+      {draftRows}
+    </div>
   );
 
   if (projectsState.status === "loading") {
@@ -2337,15 +2314,8 @@ function ProjectListComponent({
   return (
     <ProjectListShell hasThreadToolbar>
       <BuiltInSidebarLifecycleSections
-        toolbar={threadToolbar}
-        draftRows={
-          showDrafts ? (
-            <SidebarDraftRows
-              drafts={newThreadDrafts}
-              onOpenDraft={handleOpenDraft}
-            />
-          ) : null
-        }
+        toolbar={showActiveContent ? null : threadToolbar}
+        draftRows={showActiveContent ? null : draftRows}
         activeModeSections={
           showActiveContent ? (
             <ActiveSidebarModeSections
@@ -2370,6 +2340,7 @@ function ProjectListComponent({
                   onToggleCollapsed={toggleSidebarSectionCollapsed}
                   onToggleThreadCollapsed={toggleThreadCollapsed}
                   onToggleEnvironmentCollapsed={toggleEnvironmentCollapsed}
+                  threadListLead={activeThreadListLead}
                 />
               )}
               renderManual={() => (
@@ -2399,6 +2370,7 @@ function ProjectListComponent({
                   onToggleCollapsed={toggleSidebarSectionCollapsed}
                   onToggleThreadCollapsed={toggleThreadCollapsed}
                   onToggleEnvironmentCollapsed={toggleEnvironmentCollapsed}
+                  threadListLead={activeThreadListLead}
                 />
               )}
               renderProject={() => (
@@ -2424,6 +2396,7 @@ function ProjectListComponent({
                   onToggleCollapsed={toggleSidebarSectionCollapsed}
                   onToggleThreadCollapsed={toggleThreadCollapsed}
                   onToggleEnvironmentCollapsed={toggleEnvironmentCollapsed}
+                  threadListLead={activeThreadListLead}
                 />
               )}
             />

--- a/apps/app/src/components/sidebar/ProjectList.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.tsx
@@ -582,12 +582,29 @@ function ProjectListThreadsSectionActions({
 }
 
 const SIDEBAR_ORGANIZE_OPTIONS = [
-  { label: "By project", mode: "project" },
-  { label: "By machine", mode: "machine" },
-  { label: "Custom", mode: "manual" },
+  {
+    iconName: "Folder",
+    label: "By project",
+    mode: "project",
+    triggerLabel: "Projects",
+  },
+  {
+    iconName: "Laptop",
+    label: "By machine",
+    mode: "machine",
+    triggerLabel: "Machines",
+  },
+  {
+    iconName: "Section",
+    label: "Custom",
+    mode: "manual",
+    triggerLabel: "Custom",
+  },
 ] as const satisfies readonly {
+  iconName: IconName;
   label: string;
   mode: SidebarOrganizationMode;
+  triggerLabel: string;
 }[];
 
 const SIDEBAR_SORT_OPTIONS = [
@@ -618,12 +635,14 @@ function SidebarDisplayMenuTrigger({
   fillIcon = false,
   iconName,
   pressed,
+  showChevron = false,
   tooltip,
 }: {
   ariaLabel: string;
   fillIcon?: boolean;
   iconName: IconName;
   pressed?: boolean;
+  showChevron?: boolean;
   tooltip: string;
 }) {
   return (
@@ -644,15 +663,26 @@ function SidebarDisplayMenuTrigger({
               "data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-foreground",
               LIST_HOVER_TRANSITION,
               COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
+              showChevron && "gap-0",
             )}
           >
             <Icon
               name={iconName}
               className={cn(
-                COARSE_POINTER_ICON_SIZE_CLASS,
+                showChevron
+                  ? "!size-3.5 max-md:pointer-coarse:!size-5"
+                  : COARSE_POINTER_ICON_SIZE_CLASS,
                 fillIcon && "[&_path]:fill-current",
               )}
+              aria-hidden="true"
             />
+            {showChevron ? (
+              <Icon
+                name="ChevronDown"
+                className="!size-2.5 max-md:pointer-coarse:!size-3"
+                aria-hidden="true"
+              />
+            ) : null}
           </Button>
         </DropdownMenuTrigger>
       </TooltipTrigger>
@@ -670,16 +700,19 @@ export function SidebarOrganizeMenu({
   const [organizationMode, setOrganizationMode] = useAtom(
     sidebarOrganizationModeAtom,
   );
-  const selectedLabel =
-    SIDEBAR_ORGANIZE_OPTIONS.find((option) => option.mode === organizationMode)
-      ?.label ?? "Custom";
+  const selectedOption =
+    SIDEBAR_ORGANIZE_OPTIONS.find(
+      (option) => option.mode === organizationMode,
+    ) ?? SIDEBAR_ORGANIZE_OPTIONS[2];
+  const currentViewLabel = `View: ${selectedOption.triggerLabel}`;
 
   return (
     <DropdownMenu open={open} onOpenChange={onOpenChange}>
       <SidebarDisplayMenuTrigger
-        ariaLabel={`Organize: ${selectedLabel}`}
-        iconName="Layers"
-        tooltip="Organize"
+        ariaLabel={currentViewLabel}
+        iconName={selectedOption.iconName}
+        showChevron
+        tooltip={currentViewLabel}
       />
       <DropdownMenuContent
         align="end"

--- a/apps/app/src/components/sidebar/ProjectListSectionHeader.test.tsx
+++ b/apps/app/src/components/sidebar/ProjectListSectionHeader.test.tsx
@@ -85,7 +85,6 @@ describe("SidebarThreadListToolbar", () => {
       <Provider>
         <TooltipProvider>
           <SidebarThreadListToolbar
-            label="Projects"
             isCreatingSection={false}
             isCreatingProject={false}
             onNewProject={onNewProject}
@@ -101,6 +100,7 @@ describe("SidebarThreadListToolbar", () => {
     expect(
       screen.queryByRole("button", { name: "More thread actions" }),
     ).toBeNull();
+    expect(screen.queryByText("Projects")).toBeNull();
   });
 });
 
@@ -172,8 +172,8 @@ describe("TopLevelSidebarSection", () => {
     const trailingControls = row?.querySelector(
       "[data-sidebar-collapsible-trailing-controls]",
     );
-    const mobileStatusSlot = trailingControls?.querySelector(
-      "[data-sidebar-mobile-status-slot]",
+    const statusSlot = row?.querySelector(
+      '[data-sidebar-row-slot="status"]',
     );
     const action = screen.getByRole("button", { name: "Section action" });
 
@@ -189,12 +189,14 @@ describe("TopLevelSidebarSection", () => {
     expect(
       disclosure.classList.contains("hover:text-sidebar-accent-foreground"),
     ).toBe(true);
-    expect(caretSlot?.classList.contains("w-6")).toBe(true);
+    expect(caretSlot?.getAttribute("data-sidebar-row-slot")).toBe(
+      "disclosure",
+    );
     expect(row?.lastElementChild).toBe(caretSlot);
     expect(trailingControls?.nextElementSibling).toBe(caretSlot);
-    expect(mobileStatusSlot).not.toBeNull();
+    expect(statusSlot).not.toBeNull();
     expect(
-      mobileStatusSlot!.compareDocumentPosition(action) &
+      statusSlot!.compareDocumentPosition(action) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).not.toBe(0);
   });

--- a/apps/app/src/components/sidebar/ProjectRow.interactions.test.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.interactions.test.tsx
@@ -165,7 +165,7 @@ function expectCollapsedActivityAtSidebarEdge(label: string) {
   const edgeSlot = screen
     .getAllByLabelText(label)
     .map((indicator) =>
-      indicator.closest("[data-sidebar-collapsed-activity-edge]"),
+      indicator.closest('[data-sidebar-row-slot="status"]'),
     )
     .find((slot) => slot !== null);
 
@@ -196,6 +196,9 @@ describe("ProjectRow interactions", () => {
       "[data-sidebar-sticky-project-item]",
     );
     const projectIcon = projectGroup?.querySelector('[data-icon="Folder"]');
+    const projectStatusSlot = projectGroup?.querySelector(
+      "[data-sidebar-group-status-slot]",
+    );
     const newThread = screen.getByRole("button", {
       name: "New thread in Test project",
     });
@@ -208,15 +211,23 @@ describe("ProjectRow interactions", () => {
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).not.toBe(0);
     expect(
-      (threadLink?.parentElement as HTMLElement | null)?.style.paddingLeft,
-    ).toBe("8px");
+      threadLink?.parentElement?.getAttribute("data-sidebar-row-depth"),
+    ).toBe("0");
     expect(projectGroup?.getAttribute("data-sidebar-project-id")).toBe(
       "proj_test",
     );
     expect(projectIcon).not.toBeNull();
+    expect(projectStatusSlot).not.toBeNull();
+    expect(projectStatusSlot?.getAttribute("data-sidebar-row-slot")).toBe(
+      "status",
+    );
+    expect(
+      projectIcon?.closest('[data-sidebar-row-slot="identity"]'),
+    ).not.toBeNull();
     expect(projectGroup?.hasAttribute("data-sidebar-section-id")).toBe(false);
     expect(
-      newThread.compareDocumentPosition(more) & Node.DOCUMENT_POSITION_FOLLOWING,
+      newThread.compareDocumentPosition(more) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
     ).not.toBe(0);
     expect(newThread.classList.contains("max-md:pointer-coarse:hidden")).toBe(
       true,
@@ -419,7 +430,8 @@ describe("ProjectRow interactions", () => {
       name: "Collapse Active work section",
     });
     expect(
-      newThread.compareDocumentPosition(more) & Node.DOCUMENT_POSITION_FOLLOWING,
+      newThread.compareDocumentPosition(more) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
     ).not.toBe(0);
     expect(newThread.classList.contains("max-md:pointer-coarse:hidden")).toBe(
       true,
@@ -434,9 +446,7 @@ describe("ProjectRow interactions", () => {
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).not.toBe(0);
 
-    fireEvent.click(
-      disclosure,
-    );
+    fireEvent.click(disclosure);
 
     expect(
       screen
@@ -616,14 +626,15 @@ describe("ProjectRow interactions", () => {
     const trailingControls = row?.querySelector(
       "[data-sidebar-collapsible-trailing-controls]",
     );
-    const mobileActions = row?.querySelector(
+    const mobileActions = trailingControls?.querySelector(
       "[data-sidebar-mobile-row-actions]",
     );
 
-    expect(caretSlot?.classList.contains("w-6")).toBe(true);
+    expect(caretSlot?.getAttribute("data-sidebar-row-slot")).toBe(
+      "disclosure",
+    );
     expect(row?.lastElementChild).toBe(caretSlot);
-    expect(trailingControls?.nextElementSibling).toBe(mobileActions);
-    expect(mobileActions?.nextElementSibling).toBe(caretSlot);
+    expect(trailingControls?.nextElementSibling).toBe(caretSlot);
     expect(
       mobileActions?.getAttribute("data-sidebar-hover-actions-mobile"),
     ).toBe("always");

--- a/apps/app/src/components/sidebar/ProjectRow.interactions.test.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.interactions.test.tsx
@@ -193,6 +193,15 @@ describe("ProjectRow interactions", () => {
           environmentBranchName: "feat/sidebar-depth",
           environmentWorkspaceDisplayKind: "managed-worktree",
         }),
+        makeThread({
+          id: "thr_worktree_sibling",
+          title: "Worktree sibling",
+          titleFallback: "Worktree sibling",
+          environmentId: "env_test",
+          environmentName: "Feature workspace",
+          environmentBranchName: "feat/sidebar-depth",
+          environmentWorkspaceDisplayKind: "managed-worktree",
+        }),
       ],
     });
 

--- a/apps/app/src/components/sidebar/ProjectRow.interactions.test.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.interactions.test.tsx
@@ -179,10 +179,21 @@ describe("ProjectRow interactions", () => {
     vi.clearAllMocks();
   });
 
-  it("places the project disclosure after its label and keeps root threads flush", () => {
+  it("uses one depth step for each project and worktree boundary", () => {
     const result = renderProjectRow(vi.fn(), {
       status: "ready",
-      threads: [makeThread()],
+      threads: [
+        makeThread(),
+        makeThread({
+          id: "thr_worktree",
+          title: "Worktree child",
+          titleFallback: "Worktree child",
+          environmentId: "env_test",
+          environmentName: "Feature workspace",
+          environmentBranchName: "feat/sidebar-depth",
+          environmentWorkspaceDisplayKind: "managed-worktree",
+        }),
+      ],
     });
 
     const disclosure = screen.getByRole("button", {
@@ -192,6 +203,12 @@ describe("ProjectRow interactions", () => {
     const threadLink = result.container.querySelector(
       '[data-sidebar-thread-id="thr_test"]',
     );
+    const worktreeRow = screen
+      .getByText("Feature workspace")
+      .closest("[data-sidebar-row]");
+    const worktreeThreadRow = result.container
+      .querySelector('[data-sidebar-thread-id="thr_worktree"]')
+      ?.closest("[data-sidebar-row]");
     const projectGroup = result.container.querySelector(
       "[data-sidebar-sticky-project-item]",
     );
@@ -211,8 +228,19 @@ describe("ProjectRow interactions", () => {
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).not.toBe(0);
     expect(
-      threadLink?.parentElement?.getAttribute("data-sidebar-row-depth"),
+      label
+        .closest("[data-sidebar-row]")
+        ?.getAttribute("data-sidebar-row-depth"),
     ).toBe("0");
+    expect(
+      threadLink
+        ?.closest("[data-sidebar-row]")
+        ?.getAttribute("data-sidebar-row-depth"),
+    ).toBe("1");
+    expect(worktreeRow?.getAttribute("data-sidebar-row-depth")).toBe("1");
+    expect(worktreeThreadRow?.getAttribute("data-sidebar-row-depth")).toBe(
+      "2",
+    );
     expect(projectGroup?.getAttribute("data-sidebar-project-id")).toBe(
       "proj_test",
     );
@@ -390,7 +418,7 @@ describe("ProjectRow interactions", () => {
       },
     });
 
-    render(
+    const result = render(
       <TooltipProvider>
         <Provider store={store}>
           <QueryClientProvider client={queryClient}>
@@ -429,6 +457,16 @@ describe("ProjectRow interactions", () => {
     const disclosure = screen.getByRole("button", {
       name: "Collapse Active work section",
     });
+    const sectionRow = screen
+      .getByTitle("Active work")
+      .closest("[data-sidebar-row]");
+    const sectionThreadRow = result.container
+      .querySelector('[data-sidebar-thread-id="thr_section_active"]')
+      ?.closest("[data-sidebar-row]");
+    expect(sectionRow?.getAttribute("data-sidebar-row-depth")).toBe("0");
+    expect(sectionThreadRow?.getAttribute("data-sidebar-row-depth")).toBe(
+      "1",
+    );
     expect(
       newThread.compareDocumentPosition(more) &
         Node.DOCUMENT_POSITION_FOLLOWING,

--- a/apps/app/src/components/sidebar/ProjectRow.stories.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.stories.tsx
@@ -357,7 +357,7 @@ export function Overview() {
       </StoryRow>
       <StoryRow
         label="collapsed project — child working"
-        hint="collapsed project header right-aligns the hidden child activity in the trailing slot"
+        hint="collapsed project header aligns hidden child activity in the leading status column"
       >
         {singleProject({
           initialCollapsed: true,
@@ -378,7 +378,7 @@ export function Overview() {
       </StoryRow>
       <StoryRow
         label="collapsed project — child plan mode"
-        hint="collapsed project header right-aligns the hidden child plan-mode glyph"
+        hint="collapsed project header aligns the hidden child plan-mode glyph in the leading status column"
       >
         {singleProject({
           initialCollapsed: true,
@@ -484,7 +484,7 @@ export function Overview() {
       </StoryRow>
       <StoryRow
         label="collapsed parent — child needs input"
-        hint="trailing grey question icon surfaces a hidden child blocked on the user"
+        hint="the leading grey question icon surfaces a hidden child blocked on the user"
       >
         {singleProject({
           initialCollapsedThreadIds: new Set([parentThread.id]),
@@ -500,7 +500,7 @@ export function Overview() {
       </StoryRow>
       <StoryRow
         label="collapsed parent — needs input + working"
-        hint="one child blocked, another running: input needed wins, trailing slot shows the grey question icon"
+        hint="one child blocked, another running: input needed wins in the leading status column"
       >
         {singleProject({
           initialCollapsedThreadIds: new Set([parentThread.id]),
@@ -516,7 +516,7 @@ export function Overview() {
       </StoryRow>
       <StoryRow
         label="collapsed worktree — child working"
-        hint="trailing slot shows the Loading03 working spinner when a hidden child is working"
+        hint="leading status column shows the Loading03 spinner when a hidden child is working"
       >
         {singleProject({
           initialCollapsedEnvironmentIds: new Set(["env_collapsed_busy"]),
@@ -539,7 +539,7 @@ export function Overview() {
       </StoryRow>
       <StoryRow
         label="collapsed worktree — child goal"
-        hint="trailing slot shows the target glyph when a hidden child has an active goal banner"
+        hint="leading status column shows the target glyph when a hidden child has an active goal banner"
       >
         {singleProject({
           initialCollapsedEnvironmentIds: new Set(["env_collapsed_goal"]),
@@ -565,7 +565,7 @@ export function Overview() {
       </StoryRow>
       <StoryRow
         label="collapsed worktree — unread child"
-        hint="surfaces like a regular unread thread — the trailing slot shows the done dot"
+        hint="surfaces like a regular unread thread in the aligned leading status column"
       >
         {singleProject({
           initialCollapsedEnvironmentIds: new Set(["env_collapsed_unread"]),

--- a/apps/app/src/components/sidebar/ProjectRow.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.tsx
@@ -51,16 +51,12 @@ import {
   type EnvironmentRenameDialogTarget,
 } from "@/components/dialogs/EnvironmentRenameDialog";
 import {
-  COARSE_POINTER_COMPACT_ROW_HEIGHT_CLASS,
-  COARSE_POINTER_GLYPH_BOX_CLASS,
   COARSE_POINTER_ICON_SIZE_CLASS,
   COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
 } from "@bb/shared-ui/coarse-pointer-sizing";
 import {
   SIDEBAR_COLLAPSIBLE_TRAILING_CONTROLS_CLASS,
-  SIDEBAR_COLLAPSE_CARET_SLOT_CLASS,
   SIDEBAR_HOVER_ACTIONS_CLASS,
-  SIDEBAR_HOVER_ACTIONS_FADE_CLASS,
   SIDEBAR_HOVER_ACTIONS_GAP_CLASS,
   SIDEBAR_HOVER_ACTIONS_MOBILE_ALWAYS_VALUE,
   SIDEBAR_HOVER_ACTIONS_ROW_CLASS,
@@ -111,9 +107,8 @@ import {
 import {
   SIDEBAR_PROJECT_GROUP_LINE_CLASS,
   SIDEBAR_MORE_ACTION_TRIGGER_CLASS,
-  SIDEBAR_ROW_BASE_CLASS,
-  getSidebarThreadGroupLineLeft,
-  getSidebarThreadRowPaddingLeft,
+  SIDEBAR_TERTIARY_MORE_ACTION_TRIGGER_CLASS,
+  SIDEBAR_TERTIARY_ROW_ACTION_SIZE_CLASS,
 } from "./sidebarRowClasses";
 import {
   SIDEBAR_DRAG_OVERLAY_DROP_ANIMATION,
@@ -124,6 +119,7 @@ import type { ConsumeDragClickSuppression } from "@/components/ui/use-drag-click
 import type { NeighborReorderRequest } from "@bb/client-core";
 import { SidebarChildToggleChevron } from "./SidebarChildToggleChevron";
 import { SidebarSectionOrderList } from "./SidebarSectionOrderList";
+import { SidebarItemStatusSlot } from "./SidebarItemStatus";
 import {
   collectSectionThreadDndLookup,
   PINNED_THREAD_PARENT_KEY,
@@ -138,6 +134,14 @@ import {
   type BuiltInSidebarSectionOptionsById,
 } from "./BuiltInSidebarSection";
 import { SectionThreadDndProvider } from "./SectionThreadDndContext";
+import {
+  SidebarRow,
+  SidebarRowActions,
+  SidebarRowContent,
+  SidebarRowDisclosureRail,
+  SidebarRowIdentityRail,
+  SidebarRowStatusRail,
+} from "./SidebarRow";
 
 const SIDEBAR_STICKY_PARENT_DEPTH_CAP = 4;
 
@@ -236,6 +240,7 @@ interface ChronologicalSectionThreadSectionsProps extends SectionThreadTreeProps
     content: ReactNode,
     consumeClickSuppression?: ConsumeDragClickSuppression,
   ) => ReactNode;
+  threadListLead?: ReactNode;
 }
 
 type ProjectThreadTreeVariant = "project" | "section";
@@ -578,8 +583,12 @@ function getThreadNodeStickyLevel({
 function ThreadTreeGroupLine({ parentRowDepth }: ThreadTreeGroupLineProps) {
   return (
     <span
-      className="pointer-events-none absolute bottom-0 top-0 z-30 w-px bg-border-hairline opacity-70"
-      style={{ left: getSidebarThreadGroupLineLeft(parentRowDepth) }}
+      className="pointer-events-none absolute bottom-0 top-0 left-[calc(var(--sidebar-row-inline-padding)+var(--sidebar-row-line-depth)*var(--sidebar-row-depth-step)+0.5rem)] z-30 w-px bg-border-hairline opacity-70"
+      style={
+        {
+          "--sidebar-row-line-depth": parentRowDepth,
+        } as CSSProperties
+      }
       aria-hidden="true"
     />
   );
@@ -590,8 +599,12 @@ function ThreadTreeLineContinuation({
 }: ThreadTreeLineContinuationProps) {
   return (
     <span
-      className="pointer-events-none absolute -bottom-0.5 top-0 z-[1] w-px bg-border-hairline opacity-70"
-      style={{ left: getSidebarThreadGroupLineLeft(parentRowDepth) }}
+      className="pointer-events-none absolute -bottom-0.5 top-0 left-[calc(var(--sidebar-row-inline-padding)+var(--sidebar-row-line-depth)*var(--sidebar-row-depth-step)+0.5rem)] z-[1] w-px bg-border-hairline opacity-70"
+      style={
+        {
+          "--sidebar-row-line-depth": parentRowDepth,
+        } as CSSProperties
+      }
       aria-hidden="true"
     />
   );
@@ -924,22 +937,26 @@ function EnvironmentThreadGroupHeader({
   const className = cn(
     SIDEBAR_HOVER_ACTIONS_ROW_CLASS,
     stickyLevel === undefined && "relative",
-    SIDEBAR_ROW_BASE_CLASS,
-    COARSE_POINTER_COMPACT_ROW_HEIGHT_CLASS,
   );
-  const style = {
-    paddingLeft: getSidebarThreadRowPaddingLeft(rowDepth),
-  };
   const content = (
     <>
       {parentLineDepth === undefined ? null : (
         <ThreadTreeLineContinuation parentRowDepth={parentLineDepth} />
       )}
-      <span
-        className={cn(
-          "pointer-events-none relative z-10 inline-flex shrink-0 items-center justify-center text-subtle-foreground/75",
-          COARSE_POINTER_GLYPH_BOX_CLASS,
-        )}
+      <SidebarRowStatusRail
+        data-sidebar-group-status-slot=""
+        className="relative z-10"
+      >
+        <SidebarItemStatusSlot
+          status={showRollupGlyph ? "collapsed-rollup" : "none"}
+        >
+          {showRollupGlyph ? (
+            <CollapsedThreadStatusGlyph activity={childActivity} />
+          ) : null}
+        </SidebarItemStatusSlot>
+      </SidebarRowStatusRail>
+      <SidebarRowIdentityRail
+        className="pointer-events-none relative z-10 text-subtle-foreground/75"
         aria-hidden="true"
       >
         <Icon
@@ -947,13 +964,13 @@ function EnvironmentThreadGroupHeader({
           className={COARSE_POINTER_ICON_SIZE_CLASS}
           aria-hidden="true"
         />
-      </span>
-      <span className="pointer-events-none relative z-10 flex min-w-0 flex-1 items-center text-left text-subtle-foreground/80">
+      </SidebarRowIdentityRail>
+      <SidebarRowContent className="pointer-events-none relative z-10 flex items-center text-left text-subtle-foreground/80">
         <span className="min-w-0 truncate">
           <span>{displayName}</span>
         </span>
-      </span>
-      <span
+      </SidebarRowContent>
+      <SidebarRowActions
         data-sidebar-collapsible-trailing-controls=""
         className={cn(
           SIDEBAR_COLLAPSIBLE_TRAILING_CONTROLS_CLASS,
@@ -961,42 +978,27 @@ function EnvironmentThreadGroupHeader({
           COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
         )}
       >
-        {showRollupGlyph ? (
-          <span
-            data-sidebar-mobile-status=""
-            data-sidebar-hover-actions-open={isActionsOpen ? "true" : undefined}
-            className={cn(
-              SIDEBAR_HOVER_ACTIONS_FADE_CLASS,
-              "pointer-events-none absolute inset-0 flex items-center justify-end text-subtle-foreground max-md:pointer-coarse:!opacity-100",
-            )}
-          >
-            <CollapsedThreadStatusGlyph activity={childActivity} />
-          </span>
-        ) : null}
-      </span>
-      <div
-        data-sidebar-mobile-row-actions=""
-        data-sidebar-hover-actions-open={isActionsOpen ? "true" : undefined}
-        data-sidebar-hover-actions-mobile={
-          SIDEBAR_HOVER_ACTIONS_MOBILE_ALWAYS_VALUE
-        }
-        className={cn(
-          SIDEBAR_HOVER_ACTIONS_CLASS,
-          "absolute inset-y-0 right-6 z-10 flex items-center justify-end max-md:pointer-coarse:relative max-md:pointer-coarse:inset-auto",
-        )}
-      >
-        <EnvironmentThreadGroupHeaderActions
-          archiveThreadsPending={archiveThreadsPending}
-          onArchiveThreads={onArchiveThreads}
-          onCreateNewThread={onCreateNewThread}
-          onRenameEnvironment={onRenameEnvironment}
-          onOpenChange={setIsActionsOpen}
-        />
-      </div>
-      <span
-        data-sidebar-collapse-caret-slot=""
-        className={SIDEBAR_COLLAPSE_CARET_SLOT_CLASS}
-      >
+        <div
+          data-sidebar-mobile-row-actions=""
+          data-sidebar-hover-actions-open={isActionsOpen ? "true" : undefined}
+          data-sidebar-hover-actions-mobile={
+            SIDEBAR_HOVER_ACTIONS_MOBILE_ALWAYS_VALUE
+          }
+          className={cn(
+            SIDEBAR_HOVER_ACTIONS_CLASS,
+            "absolute inset-0 flex items-center justify-end max-md:pointer-coarse:relative",
+          )}
+        >
+          <EnvironmentThreadGroupHeaderActions
+            archiveThreadsPending={archiveThreadsPending}
+            onArchiveThreads={onArchiveThreads}
+            onCreateNewThread={onCreateNewThread}
+            onRenameEnvironment={onRenameEnvironment}
+            onOpenChange={setIsActionsOpen}
+          />
+        </div>
+      </SidebarRowActions>
+      <SidebarRowDisclosureRail data-sidebar-collapse-caret-slot="">
         <SidebarChildToggleChevron
           isCollapsed={isCollapsed}
           expandLabel={`Expand ${displayName} threads`}
@@ -1004,27 +1006,38 @@ function EnvironmentThreadGroupHeader({
           onToggle={() => onToggleCollapsed(environmentId)}
           revealOnHover
         />
-      </span>
+      </SidebarRowDisclosureRail>
     </>
   );
 
   if (stickyLevel !== undefined) {
     return (
-      <SidebarStickyTier
-        tier="parent"
-        level={stickyLevel}
-        className={className}
-        style={style}
+      <SidebarRow
+        asChild
+        depth={rowDepth}
+        density="compact"
+        variant="groupLabel"
       >
-        {content}
-      </SidebarStickyTier>
+        <SidebarStickyTier
+          tier="parent"
+          level={stickyLevel}
+          className={className}
+        >
+          {content}
+        </SidebarStickyTier>
+      </SidebarRow>
     );
   }
 
   return (
-    <div className={className} style={style}>
-      {content}
-    </div>
+    <SidebarRow
+      asChild
+      depth={rowDepth}
+      density="compact"
+      variant="groupLabel"
+    >
+      <div className={className}>{content}</div>
+    </SidebarRow>
   );
 }
 
@@ -1119,7 +1132,6 @@ const EnvironmentThreadGroupRow = memo(function EnvironmentThreadGroupRow({
         />
         {!isCollapsed ? (
           <div className="relative space-y-px">
-            <ThreadTreeGroupLine parentRowDepth={rowDepth} />
             <SidebarWindowedItems
               itemKeys={itemKeys}
               estimateRows={estimateRows}
@@ -1257,44 +1269,36 @@ export function DropPreviewRow({
   visible?: boolean;
 }) {
   return (
-    <div
-      aria-hidden="true"
-      data-sidebar-section-drop-preview="true"
-      data-visible={visible ? "true" : "false"}
-      style={{
-        paddingLeft: getSidebarThreadRowPaddingLeft(depth),
-        marginTop: visible ? undefined : 0,
-      }}
-      className={cn(
-        SIDEBAR_ROW_BASE_CLASS,
-        "pointer-events-none overflow-hidden transition-[height,margin,opacity,border-width] duration-150 ease-out",
-        visible
-          ? cn(
-              COARSE_POINTER_COMPACT_ROW_HEIGHT_CLASS,
-              "border border-dashed border-sidebar-border bg-sidebar-accent/40 opacity-100",
-            )
-          : "h-0 border-0 opacity-0 max-md:pointer-coarse:h-0",
-      )}
-    />
+    <SidebarRow asChild depth={depth} density="compact" variant="item">
+      <div
+        aria-hidden="true"
+        data-sidebar-section-drop-preview="true"
+        data-visible={visible ? "true" : "false"}
+        style={{ marginTop: visible ? undefined : 0 }}
+        className={cn(
+          "pointer-events-none overflow-hidden transition-[height,margin,opacity,border-width] duration-150 ease-out",
+          visible
+            ? "border border-dashed border-sidebar-border bg-sidebar-accent/40 opacity-100"
+            : "h-0 border-0 opacity-0 max-md:pointer-coarse:h-0",
+        )}
+      />
+    </SidebarRow>
   );
 }
 
 function SectionThreadDragOverlay({ thread }: { thread: ThreadListEntry }) {
   return (
-    <div
-      aria-hidden="true"
-      data-sidebar-section-drag-overlay="true"
-      style={{ paddingLeft: getSidebarThreadRowPaddingLeft(0) }}
-      className={cn(
-        SIDEBAR_ROW_BASE_CLASS,
-        COARSE_POINTER_COMPACT_ROW_HEIGHT_CLASS,
-        "pointer-events-none bg-sidebar-accent text-sidebar-accent-foreground shadow-sm ring-1 ring-sidebar-border",
-      )}
-    >
-      <span className="min-w-0 flex-1 truncate">
-        {getThreadDisplayTitle(thread)}
-      </span>
-    </div>
+    <SidebarRow asChild density="compact" variant="item">
+      <div
+        aria-hidden="true"
+        data-sidebar-section-drag-overlay="true"
+        className="pointer-events-none bg-sidebar-accent text-sidebar-accent-foreground shadow-sm ring-1 ring-sidebar-border"
+      >
+        <SidebarRowContent className="truncate">
+          {getThreadDisplayTitle(thread)}
+        </SidebarRowContent>
+      </div>
+    </SidebarRow>
   );
 }
 
@@ -1431,7 +1435,7 @@ const SectionTreeItemRow = memo(function SectionTreeItemRow({
             onClick={() => onCreateThreadInSection(section.id)}
             className={cn(
               "rounded-md p-0 text-subtle-foreground hover:bg-transparent hover:text-foreground max-md:pointer-coarse:hidden",
-              COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
+              SIDEBAR_TERTIARY_ROW_ACTION_SIZE_CLASS,
             )}
           >
             <Icon
@@ -1451,6 +1455,7 @@ const SectionTreeItemRow = memo(function SectionTreeItemRow({
                 className={cn(
                   "rounded-md p-0 text-subtle-foreground hover:bg-transparent hover:text-foreground",
                   SIDEBAR_MORE_ACTION_TRIGGER_CLASS,
+                  SIDEBAR_TERTIARY_MORE_ACTION_TRIGGER_CLASS,
                 )}
               >
                 <Icon
@@ -1512,6 +1517,7 @@ const SectionTreeItemRow = memo(function SectionTreeItemRow({
     return (
       <TopLevelSidebarSection
         label={section.name}
+        rowVariant="item"
         sectionId={section.id}
         actions={topLevelActions}
         actionsAlwaysVisible
@@ -1952,6 +1958,7 @@ export const ChronologicalSectionThreadSections = memo(
     onReorderPinnedThread,
     renderPinnedSection,
     renderThreadsSection,
+    threadListLead,
   }: ChronologicalSectionThreadSectionsProps) {
     const threads =
       threadListState.status === "ready"
@@ -2167,7 +2174,10 @@ export const ChronologicalSectionThreadSections = memo(
       threads: renderThreadsSection?.(threadsContent, consumeClickSuppression),
     };
     const orderedSections = (
-      <SidebarSectionOrderList order={topLevelSectionOrder}>
+      <SidebarSectionOrderList
+        order={topLevelSectionOrder}
+        pinnedTrailingContent={threadListLead}
+      >
         {(sectionId) => {
           const builtInSection =
             builtInSections && configuredBuiltInSections
@@ -2322,7 +2332,7 @@ function ProjectRowComponent({
             }}
             className={cn(
               "rounded-md p-0 text-subtle-foreground hover:bg-transparent hover:text-foreground max-md:pointer-coarse:hidden",
-              COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
+              SIDEBAR_TERTIARY_ROW_ACTION_SIZE_CLASS,
             )}
           >
             <Icon
@@ -2339,6 +2349,7 @@ function ProjectRowComponent({
             triggerClassName={cn(
               "relative z-10 text-subtle-foreground hover:bg-transparent hover:text-foreground",
               SIDEBAR_MORE_ACTION_TRIGGER_CLASS,
+              SIDEBAR_TERTIARY_MORE_ACTION_TRIGGER_CLASS,
             )}
           />
         </span>
@@ -2361,6 +2372,7 @@ function ProjectRowComponent({
         <TopLevelSidebarSection
           label={project.name}
           leadingIcon="Folder"
+          rowVariant="groupLabel"
           actions={projectActions}
           actionsAlwaysVisible
           actionsMobileAlways

--- a/apps/app/src/components/sidebar/ProjectRow.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.tsx
@@ -183,6 +183,7 @@ export interface ProjectRowProps {
 
 interface ProjectThreadTreeProps {
   projectId?: string;
+  rootDepth: number;
   threadListState: ProjectThreadListState;
   compareThreads: ThreadComparator;
   selectedThreadId?: string;
@@ -498,18 +499,11 @@ function getProjectThreadTreeGroupLineClassName(
   return undefined;
 }
 
-function getProjectThreadTreeRootDepthOffset(
-  variant: ProjectThreadTreeVariant,
-): number {
-  return variant === "section" ? 0 : 1;
-}
-
 function getThreadRowDepth({
   depthOffset,
   nodeDepth,
-  variant,
 }: GetThreadRowDepthArgs): number {
-  return getProjectThreadTreeRootDepthOffset(variant) + nodeDepth + depthOffset;
+  return nodeDepth + depthOffset;
 }
 
 function getThreadRowOptions({
@@ -524,9 +518,8 @@ function getThreadRowOptions({
   nodeDepth,
   onToggleThreadCollapsed,
   stickyLevel,
-  variant,
 }: GetThreadRowOptionsArgs): ThreadRowOptions {
-  const depth = getThreadRowDepth({ depthOffset, nodeDepth, variant });
+  const depth = getThreadRowDepth({ depthOffset, nodeDepth });
   const baseOptions = {
     depth,
     isCompact: nodeDepth > 0 || isEnvGrouped,
@@ -564,13 +557,11 @@ interface GetThreadRowOptionsArgs {
   nodeDepth: number;
   onToggleThreadCollapsed: (threadId: string) => void;
   stickyLevel?: number;
-  variant: ProjectThreadTreeVariant;
 }
 
 interface GetThreadRowDepthArgs {
   depthOffset: number;
   nodeDepth: number;
-  variant: ProjectThreadTreeVariant;
 }
 
 function getThreadNodeStickyLevel({
@@ -1063,14 +1054,12 @@ const EnvironmentThreadGroupRow = memo(function EnvironmentThreadGroupRow({
   const rowDepth = getThreadRowDepth({
     depthOffset,
     nodeDepth,
-    variant,
   });
   const parentLineDepth =
     nodeDepth > 0
       ? getThreadRowDepth({
           depthOffset,
           nodeDepth: nodeDepth - 1,
-          variant,
         })
       : undefined;
   const createThreadInWorktree = useCreateThreadInWorktree({
@@ -1340,7 +1329,7 @@ const SectionTreeItemRow = memo(function SectionTreeItemRow({
     );
   }, [sectionKey, setCollapsedSections]);
 
-  const headerDepth = getThreadRowDepth({ depthOffset, nodeDepth: 0, variant });
+  const headerDepth = getThreadRowDepth({ depthOffset, nodeDepth: 0 });
   const stickyLevel =
     depthOffset < SIDEBAR_STICKY_PARENT_DEPTH_CAP ? depthOffset : undefined;
   const showDropPreview = sectionDnd?.dragOverParentKey === sectionKey;
@@ -1381,11 +1370,7 @@ const SectionTreeItemRow = memo(function SectionTreeItemRow({
                   key={getItemKey(item)}
                   projectId={getItemProjectId(item)}
                   item={item}
-                  depthOffset={
-                    variant === "section" && depthOffset === 0
-                      ? 0
-                      : depthOffset + 1
-                  }
+                  depthOffset={depthOffset + 1}
                   selectedThreadId={selectedThreadId}
                   collapsedThreadIds={collapsedThreadIds}
                   collapsedEnvironmentIds={collapsedEnvironmentIds}
@@ -1407,10 +1392,8 @@ const SectionTreeItemRow = memo(function SectionTreeItemRow({
         <DropPreviewRow
           visible={showDropPreview}
           depth={getThreadRowDepth({
-            depthOffset:
-              variant === "section" && depthOffset === 0 ? 0 : depthOffset + 1,
+            depthOffset: depthOffset + 1,
             nodeDepth: 0,
-            variant,
           })}
         />
       ) : null}
@@ -1603,7 +1586,6 @@ export const ThreadTreeNodeRow = memo(function ThreadTreeNodeRow({
   const parentRowDepth = getThreadRowDepth({
     depthOffset,
     nodeDepth: node.depth,
-    variant,
   });
   const options = useMemo<ThreadRowOptions>(
     () =>
@@ -1621,7 +1603,6 @@ export const ThreadTreeNodeRow = memo(function ThreadTreeNodeRow({
         stickyLevel: hasChildren
           ? getThreadNodeStickyLevel({ depthOffset, node })
           : undefined,
-        variant,
       }),
     [
       consumeClickSuppression,
@@ -1633,7 +1614,6 @@ export const ThreadTreeNodeRow = memo(function ThreadTreeNodeRow({
       hasChildren,
       node,
       onToggleThreadCollapsed,
-      variant,
     ],
   );
   const showChildren = !isCollapsed && hasChildren;
@@ -1871,6 +1851,7 @@ function SectionThreadTreeItems({
 
 export const ProjectThreadTree = memo(function ProjectThreadTree({
   projectId,
+  rootDepth,
   threadListState,
   compareThreads,
   selectedThreadId,
@@ -1928,6 +1909,7 @@ export const ProjectThreadTree = memo(function ProjectThreadTree({
       sectionDnd={null}
       variant={variant}
       projectId={projectId}
+      depthOffset={rootDepth}
       sortableParentKey={projectId}
       selectedThreadId={selectedThreadId}
       collapsedThreadIds={collapsedThreadIds}
@@ -2139,7 +2121,6 @@ export const ChronologicalSectionThreadSections = memo(
             depth={getThreadRowDepth({
               depthOffset: 0,
               nodeDepth: 0,
-              variant: "section",
             })}
           />
         ) : null}
@@ -2394,6 +2375,7 @@ function ProjectRowComponent({
         >
           <ProjectThreadTree
             projectId={project.id}
+            rootDepth={1}
             threadListState={threadListState}
             selectedThreadId={selectedThreadId}
             collapsedThreadIds={collapsedThreadIds}

--- a/apps/app/src/components/sidebar/ProjectRow.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.tsx
@@ -137,6 +137,7 @@ import { SectionThreadDndProvider } from "./SectionThreadDndContext";
 import {
   SidebarRow,
   SidebarRowActions,
+  SidebarRowBody,
   SidebarRowContent,
   SidebarRowDisclosureRail,
   SidebarRowIdentityRail,
@@ -955,21 +956,23 @@ function EnvironmentThreadGroupHeader({
           ) : null}
         </SidebarItemStatusSlot>
       </SidebarRowStatusRail>
-      <SidebarRowIdentityRail
-        className="pointer-events-none relative z-10 text-subtle-foreground/75"
-        aria-hidden="true"
-      >
-        <Icon
-          name={iconName}
-          className={COARSE_POINTER_ICON_SIZE_CLASS}
+      <SidebarRowBody>
+        <SidebarRowIdentityRail
+          className="pointer-events-none relative z-10 text-subtle-foreground/75"
           aria-hidden="true"
-        />
-      </SidebarRowIdentityRail>
-      <SidebarRowContent className="pointer-events-none relative z-10 flex items-center text-left text-subtle-foreground/80">
-        <span className="min-w-0 truncate">
-          <span>{displayName}</span>
-        </span>
-      </SidebarRowContent>
+        >
+          <Icon
+            name={iconName}
+            className={COARSE_POINTER_ICON_SIZE_CLASS}
+            aria-hidden="true"
+          />
+        </SidebarRowIdentityRail>
+        <SidebarRowContent className="pointer-events-none relative z-10 flex items-center text-left text-subtle-foreground/80">
+          <span className="min-w-0 truncate">
+            <span>{displayName}</span>
+          </span>
+        </SidebarRowContent>
+      </SidebarRowBody>
       <SidebarRowActions
         data-sidebar-collapsible-trailing-controls=""
         className={cn(
@@ -1004,7 +1007,6 @@ function EnvironmentThreadGroupHeader({
           expandLabel={`Expand ${displayName} threads`}
           collapseLabel={`Collapse ${displayName} threads`}
           onToggle={() => onToggleCollapsed(environmentId)}
-          revealOnHover
         />
       </SidebarRowDisclosureRail>
     </>
@@ -1294,9 +1296,11 @@ function SectionThreadDragOverlay({ thread }: { thread: ThreadListEntry }) {
         data-sidebar-section-drag-overlay="true"
         className="pointer-events-none bg-sidebar-accent text-sidebar-accent-foreground shadow-sm ring-1 ring-sidebar-border"
       >
-        <SidebarRowContent className="truncate">
-          {getThreadDisplayTitle(thread)}
-        </SidebarRowContent>
+        <SidebarRowBody>
+          <SidebarRowContent className="truncate">
+            {getThreadDisplayTitle(thread)}
+          </SidebarRowContent>
+        </SidebarRowBody>
       </div>
     </SidebarRow>
   );

--- a/apps/app/src/components/sidebar/ReorderableSidebarSectionOrderList.tsx
+++ b/apps/app/src/components/sidebar/ReorderableSidebarSectionOrderList.tsx
@@ -13,6 +13,7 @@ interface ReorderableSidebarSectionOrderListProps {
   ) => ReactNode;
   onOrderChange: (order: SidebarSectionId[]) => void;
   order: readonly SidebarSectionId[];
+  pinnedTrailingContent?: ReactNode;
   reorderOrder?: readonly SidebarSectionId[];
 }
 
@@ -20,6 +21,7 @@ export function ReorderableSidebarSectionOrderList({
   children,
   onOrderChange,
   order,
+  pinnedTrailingContent,
   reorderOrder = order,
 }: ReorderableSidebarSectionOrderListProps) {
   const handleDragEnd = useCallback(
@@ -45,7 +47,11 @@ export function ReorderableSidebarSectionOrderList({
   });
 
   return (
-    <SidebarSectionOrderList order={order} dndContextProps={dndContextProps}>
+    <SidebarSectionOrderList
+      order={order}
+      dndContextProps={dndContextProps}
+      pinnedTrailingContent={pinnedTrailingContent}
+    >
       {(sectionId) => children(sectionId, consumeClickSuppression)}
     </SidebarSectionOrderList>
   );

--- a/apps/app/src/components/sidebar/SectionSidebar.tsx
+++ b/apps/app/src/components/sidebar/SectionSidebar.tsx
@@ -15,6 +15,11 @@ import {
 } from "@/components/ui/sidebar.js";
 import { SidebarHistoryNavigationControls } from "@/components/sidebar/SidebarHistoryNavigationControls";
 import { PROJECT_LIST_ACTION_BUTTON_CLASS } from "@/components/sidebar/ProjectList";
+import {
+  SidebarRow,
+  SidebarRowContent,
+  SidebarRowIdentityRail,
+} from "@/components/sidebar/SidebarRow";
 import { SIDEBAR_STANDARD_ROW_PADDING_CLASS } from "@/components/sidebar/sidebarRowClasses";
 import { CHROME_SECTION_LABEL_CLASS } from "@bb/shared-ui/chrome-style-tokens";
 import {
@@ -42,25 +47,29 @@ export function SectionSidebarRow({
 }) {
   const closeOnMobile = useCloseMobileSidebar();
   return (
-    <Button
-      asChild
-      size="sm"
-      variant="ghost"
-      className={cn(
-        PROJECT_LIST_ACTION_BUTTON_CLASS,
-        "w-full",
-        active && "bg-sidebar-accent text-sidebar-foreground",
-      )}
-    >
-      <Link
-        to={to}
-        onClick={closeOnMobile}
-        aria-current={active ? "page" : undefined}
+    <SidebarRow asChild anatomy="navigation" variant="item">
+      <Button
+        asChild
+        size="sm"
+        variant="ghost"
+        className={cn(
+          PROJECT_LIST_ACTION_BUTTON_CLASS,
+          "w-full",
+          active && "bg-sidebar-accent text-sidebar-foreground",
+        )}
       >
-        {children}
-        <span className="min-w-0 flex-1 truncate text-left">{label}</span>
-      </Link>
-    </Button>
+        <Link
+          to={to}
+          onClick={closeOnMobile}
+          aria-current={active ? "page" : undefined}
+        >
+          <SidebarRowIdentityRail>{children}</SidebarRowIdentityRail>
+          <SidebarRowContent className="truncate text-left">
+            {label}
+          </SidebarRowContent>
+        </Link>
+      </Button>
+    </SidebarRow>
   );
 }
 
@@ -77,19 +86,23 @@ export function SectionSidebarActionRow({
 }) {
   const closeOnMobile = useCloseMobileSidebar();
   return (
-    <Button
-      size="sm"
-      variant="ghost"
-      data-testid={testId}
-      className={cn(PROJECT_LIST_ACTION_BUTTON_CLASS, "w-full")}
-      onClick={() => {
-        closeOnMobile();
-        onClick();
-      }}
-    >
-      {children}
-      <span className="min-w-0 flex-1 truncate text-left">{label}</span>
-    </Button>
+    <SidebarRow asChild anatomy="navigation" variant="item">
+      <Button
+        size="sm"
+        variant="ghost"
+        data-testid={testId}
+        className={cn(PROJECT_LIST_ACTION_BUTTON_CLASS, "w-full")}
+        onClick={() => {
+          closeOnMobile();
+          onClick();
+        }}
+      >
+        <SidebarRowIdentityRail>{children}</SidebarRowIdentityRail>
+        <SidebarRowContent className="truncate text-left">
+          {label}
+        </SidebarRowContent>
+      </Button>
+    </SidebarRow>
   );
 }
 

--- a/apps/app/src/components/sidebar/SidebarDisplayOptionsMenu.test.tsx
+++ b/apps/app/src/components/sidebar/SidebarDisplayOptionsMenu.test.tsx
@@ -48,7 +48,21 @@ function openMenu(name: RegExp) {
 describe("sidebar thread-list menus", () => {
   it("separates organization from filtering and uses the approved labels", async () => {
     const store = renderMenus();
-    openMenu(/^Organize:/);
+    const projectViewTrigger = screen.getByRole("button", {
+      name: "View: Projects",
+    });
+    expect(
+      projectViewTrigger.querySelector('[data-icon="Folder"]'),
+    ).not.toBeNull();
+    expect(
+      projectViewTrigger.querySelector('[data-icon="ChevronDown"]'),
+    ).not.toBeNull();
+    fireEvent.focus(projectViewTrigger);
+    expect((await screen.findByRole("tooltip")).textContent).toBe(
+      "View: Projects",
+    );
+    fireEvent.blur(projectViewTrigger);
+    openMenu(/^View: Projects$/);
 
     const group = await screen.findByRole("group", { name: "Organize" });
     expect(
@@ -69,6 +83,20 @@ describe("sidebar thread-list menus", () => {
     await waitFor(() =>
       expect(screen.queryByRole("group", { name: "Organize" })).toBeNull(),
     );
+    const customViewTrigger = screen.getByRole("button", {
+      name: "View: Custom",
+    });
+    expect(
+      customViewTrigger.querySelector('[data-icon="Section"]'),
+    ).not.toBeNull();
+
+    act(() => store.set(sidebarOrganizationModeAtom, "machine"));
+    const machineViewTrigger = screen.getByRole("button", {
+      name: "View: Machines",
+    });
+    expect(
+      machineViewTrigger.querySelector('[data-icon="Laptop"]'),
+    ).not.toBeNull();
   });
 
   it("orders status above sort, keeps changes open, and toggles sort direction", async () => {

--- a/apps/app/src/components/sidebar/SidebarDisplayOptionsMenu.test.tsx
+++ b/apps/app/src/components/sidebar/SidebarDisplayOptionsMenu.test.tsx
@@ -13,7 +13,6 @@ import { createStore, Provider } from "jotai";
 import { afterEach, describe, expect, it } from "vitest";
 import { TooltipProvider } from "@bb/shared-ui/tooltip";
 import {
-  getSidebarThreadListLabel,
   SidebarFilterSortMenu,
   SidebarOrganizeMenu,
 } from "./ProjectList";
@@ -47,46 +46,6 @@ function openMenu(name: RegExp) {
 }
 
 describe("sidebar thread-list menus", () => {
-  it.each([
-    {
-      expected: "Machines",
-      hasProjects: false,
-      hasSections: false,
-      mode: "machine",
-    },
-    {
-      expected: "Projects",
-      hasProjects: true,
-      hasSections: false,
-      mode: "project",
-    },
-    {
-      expected: "Threads",
-      hasProjects: false,
-      hasSections: false,
-      mode: "project",
-    },
-    {
-      expected: "Sections",
-      hasProjects: false,
-      hasSections: true,
-      mode: "manual",
-    },
-    {
-      expected: "Threads",
-      hasProjects: false,
-      hasSections: false,
-      mode: "manual",
-    },
-  ] as const)(
-    "uses $expected for $mode mode with projects=$hasProjects and sections=$hasSections",
-    ({ expected, hasProjects, hasSections, mode }) => {
-      expect(
-        getSidebarThreadListLabel({ hasProjects, hasSections, mode }),
-      ).toBe(expected);
-    },
-  );
-
   it("separates organization from filtering and uses the approved labels", async () => {
     const store = renderMenus();
     openMenu(/^Organize:/);

--- a/apps/app/src/components/sidebar/SidebarItemStatus.tsx
+++ b/apps/app/src/components/sidebar/SidebarItemStatus.tsx
@@ -1,0 +1,92 @@
+import type { MouseEvent, ReactNode } from "react";
+import { COARSE_POINTER_GLYPH_BOX_CLASS } from "@bb/shared-ui/coarse-pointer-sizing";
+import { cn } from "@bb/shared-ui/lib/utils";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@bb/shared-ui/tooltip";
+import {
+  SIDEBAR_HOVER_ACTIONS_CLASS,
+  SIDEBAR_HOVER_ACTIONS_FADE_CLASS,
+} from "@/components/ui/sidebar-hover-actions";
+import { SIDEBAR_ROW_GLYPH_SLOT_CLASS } from "./sidebarRowClasses";
+
+interface SidebarItemStatusSlotProps {
+  children?: ReactNode;
+  hoverAction?: ReactNode;
+  onActivate?: () => void;
+  status?: string;
+  tooltip?: string;
+}
+
+export function SidebarItemStatusSlot({
+  children,
+  hoverAction,
+  onActivate,
+  status,
+  tooltip,
+}: SidebarItemStatusSlotProps) {
+  const className = cn(
+    SIDEBAR_ROW_GLYPH_SLOT_CLASS,
+    COARSE_POINTER_GLYPH_BOX_CLASS,
+    "relative z-10",
+  );
+
+  const statusContent =
+    tooltip === undefined ? (
+      <span
+        data-sidebar-item-status-slot=""
+        data-sidebar-item-status={status}
+        className={cn(className, "pointer-events-none")}
+        aria-hidden={
+          children === null || children === undefined ? "true" : undefined
+        }
+      >
+        {children}
+      </span>
+    ) : (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            data-sidebar-item-status-slot=""
+            data-sidebar-item-status={status}
+            role="img"
+            aria-label={tooltip}
+            className={className}
+            onClick={(event: MouseEvent<HTMLSpanElement>) => {
+              event.preventDefault();
+              event.stopPropagation();
+              onActivate?.();
+            }}
+          >
+            {children}
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="top">{tooltip}</TooltipContent>
+      </Tooltip>
+    );
+
+  if (hoverAction === undefined) return statusContent;
+
+  return (
+    <span
+      data-sidebar-item-status-action-slot=""
+      className="relative z-10 inline-flex shrink-0"
+    >
+      <span
+        className={cn(
+          SIDEBAR_HOVER_ACTIONS_FADE_CLASS,
+          "inline-flex max-md:pointer-coarse:!opacity-100",
+        )}
+      >
+        {statusContent}
+      </span>
+      <span
+        data-sidebar-item-status-hover-action=""
+        className={cn(
+          SIDEBAR_HOVER_ACTIONS_CLASS,
+          "absolute inset-0 z-20 flex items-center justify-center max-md:pointer-coarse:hidden",
+        )}
+      >
+        {hoverAction}
+      </span>
+    </span>
+  );
+}

--- a/apps/app/src/components/sidebar/SidebarLifecycleRows.test.tsx
+++ b/apps/app/src/components/sidebar/SidebarLifecycleRows.test.tsx
@@ -142,9 +142,9 @@ describe("SidebarDraftRows", () => {
     expect(container.querySelector('[data-icon="EditFile"]')).toBeNull();
     expect(screen.getByText("Drafts")).not.toBeNull();
     expect(
-      container.querySelectorAll("[data-sidebar-draft-state]"),
+      container.querySelectorAll('[data-sidebar-item-status="draft"]'),
     ).toHaveLength(2);
-    expect(screen.getAllByText("Draft")).toHaveLength(2);
+    expect(screen.getAllByLabelText("Draft")).toHaveLength(2);
 
     fireEvent.click(
       screen.getByRole("button", { name: "Open draft Older draft" }),
@@ -297,10 +297,12 @@ describe("SidebarArchivedThreadGroup", () => {
       "second",
       "third",
     ]);
-    expect(container.querySelector('[data-icon="Archive"]')).toBeNull();
     expect(
-      container.querySelectorAll("[data-sidebar-archived-state]"),
+      container.querySelectorAll('[data-sidebar-item-status="archived"]'),
     ).toHaveLength(3);
+    expect(container.querySelectorAll('[data-icon="Archive"]')).toHaveLength(
+      3,
+    );
     const secondLink = screen.getByRole("link", {
       name: "Open archived thread Second archived",
     });
@@ -311,7 +313,7 @@ describe("SidebarArchivedThreadGroup", () => {
     expect(onNavigate).toHaveBeenCalledOnce();
   });
 
-  it("replaces the right-edge state with quick Unarchive and keeps it in both menus", () => {
+  it("keeps the archived state in the fixed status rail and offers Unarchive from both menus", () => {
     const { container } = renderLifecycleRows(
       <SidebarArchivedThreadGroup
         threads={[archivedThreads[0]!]}
@@ -322,12 +324,12 @@ describe("SidebarArchivedThreadGroup", () => {
     );
 
     const archivedState = container.querySelector<HTMLElement>(
-      "[data-sidebar-archived-state]",
+      '[data-sidebar-item-status="archived"]',
     );
-    expect(archivedState?.textContent).toBe("Archived");
-    expect(archivedState?.className).toContain(
-      "group-focus-within/archived-thread-row:opacity-0",
-    );
+    expect(archivedState?.getAttribute("aria-label")).toBe("Archived");
+    expect(
+      archivedState?.closest('[data-sidebar-row-slot="status"]'),
+    ).not.toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Unarchive thread" }));
     expect(threadActions.unarchiveThread).toHaveBeenCalledWith(
       archivedThreads[0],

--- a/apps/app/src/components/sidebar/SidebarLifecycleRows.test.tsx
+++ b/apps/app/src/components/sidebar/SidebarLifecycleRows.test.tsx
@@ -145,6 +145,14 @@ describe("SidebarDraftRows", () => {
       container.querySelectorAll('[data-sidebar-item-status="draft"]'),
     ).toHaveLength(2);
     expect(screen.getAllByLabelText("Draft")).toHaveLength(2);
+    expect(
+      rows.every(
+        (row) =>
+          row.querySelector('[data-sidebar-row-slot="status"]') !== null &&
+          row.querySelector('[data-sidebar-row-slot="body"]') !== null &&
+          row.querySelector('[data-sidebar-row-slot="actions"]') !== null,
+      ),
+    ).toBe(true);
 
     fireEvent.click(
       screen.getByRole("button", { name: "Open draft Older draft" }),
@@ -329,6 +337,15 @@ describe("SidebarArchivedThreadGroup", () => {
     expect(archivedState?.getAttribute("aria-label")).toBe("Archived");
     expect(
       archivedState?.closest('[data-sidebar-row-slot="status"]'),
+    ).not.toBeNull();
+    const archivedRow = archivedState?.closest(
+      "[data-sidebar-archived-thread-id]",
+    );
+    expect(
+      archivedRow?.querySelector('[data-sidebar-row-slot="body"]'),
+    ).not.toBeNull();
+    expect(
+      archivedRow?.querySelector('[data-sidebar-row-slot="actions"]'),
     ).not.toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Unarchive thread" }));
     expect(threadActions.unarchiveThread).toHaveBeenCalledWith(

--- a/apps/app/src/components/sidebar/SidebarLifecycleRows.tsx
+++ b/apps/app/src/components/sidebar/SidebarLifecycleRows.tsx
@@ -6,10 +6,7 @@ import {
   ContextMenuItem,
   ContextMenuTrigger,
 } from "@bb/shared-ui/context-menu";
-import {
-  COARSE_POINTER_ICON_SIZE_CLASS,
-  COARSE_POINTER_ROW_HEIGHT_CLASS,
-} from "@bb/shared-ui/coarse-pointer-sizing";
+import { COARSE_POINTER_ICON_SIZE_CLASS } from "@bb/shared-ui/coarse-pointer-sizing";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -42,14 +39,19 @@ import { getThreadRoutePath } from "@/lib/route-paths";
 import { useSplitWorkspaceActive } from "@/hooks/useSplitWorkspaceActive";
 import {
   SIDEBAR_MORE_ACTION_TRIGGER_CLASS,
-  SIDEBAR_ROW_BASE_CLASS,
+  SIDEBAR_IDLE_STATUS_COLOR_CLASS,
   SIDEBAR_ROW_INTERACTIVE_STATE_CLASS,
   SIDEBAR_ROW_SELECTED_STATE_CLASS,
-  SIDEBAR_STANDARD_ROW_PADDING_CLASS,
 } from "./sidebarRowClasses";
 import { SidebarWindowedItems } from "./SidebarWindowedItems";
 import { TopLevelSidebarSection } from "./TopLevelSidebarSection";
 import { usePaneContentSplitDrag } from "./usePaneContentSplitDrag";
+import { SidebarItemStatusSlot } from "./SidebarItemStatus";
+import {
+  SidebarRow,
+  SidebarRowContent,
+  SidebarRowStatusRail,
+} from "./SidebarRow";
 
 export interface SidebarDraftRowItem {
   id: string;
@@ -213,6 +215,7 @@ function SidebarDraftRow({
 }) {
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [contextOpen, setContextOpen] = useState(false);
+  const rowTargetRef = useRef<HTMLButtonElement>(null);
   const actionsOpen = dropdownOpen || contextOpen;
   const draftSplit = usePaneContentSplitDrag({
     content: { kind: "new-thread", draftSlotId: draft.id },
@@ -221,55 +224,65 @@ function SidebarDraftRow({
   });
 
   const row = (
-    <div
-      data-sidebar-draft-id={draft.id}
-      className={cn(
-        SIDEBAR_HOVER_ACTIONS_ROW_CLASS,
-        SIDEBAR_ROW_BASE_CLASS,
-        SIDEBAR_ROW_INTERACTIVE_STATE_CLASS,
-        SIDEBAR_STANDARD_ROW_PADDING_CLASS,
-        COARSE_POINTER_ROW_HEIGHT_CLASS,
-        LIST_HOVER_TRANSITION,
-        "group/draft-row relative min-w-0",
-        "has-[[data-state=open]]:bg-sidebar-accent",
-      )}
-    >
-      <button
-        type="button"
-        className="absolute inset-0 rounded-md outline-none ring-sidebar-ring focus-visible:ring-2"
-        aria-label={`Open draft ${draft.title}`}
-        onClick={() => onOpenDraft(draft.id)}
-      />
-      <span
+    <SidebarRow asChild density="standard" variant="item">
+      <div
+        data-sidebar-draft-id={draft.id}
         className={cn(
-          SIDEBAR_HOVER_ACTIONS_INSET_CLASS,
-          "flex min-w-0 flex-1 items-center gap-2",
+          SIDEBAR_HOVER_ACTIONS_ROW_CLASS,
+          SIDEBAR_ROW_INTERACTIVE_STATE_CLASS,
+          LIST_HOVER_TRANSITION,
+          "group/draft-row relative min-w-0",
+          "has-[[data-state=open]]:bg-sidebar-accent",
         )}
       >
-        <span className="min-w-0 truncate" title={draft.title}>
-          {draft.title}
-        </span>
-        <span
-          data-sidebar-draft-state=""
-          className="ml-auto shrink-0 text-xs text-muted-foreground transition-opacity group-hover/draft-row:opacity-0 group-focus-within/draft-row:opacity-0"
-        >
-          Draft
-        </span>
-      </span>
-      <span
-        data-sidebar-hover-actions-open={actionsOpen ? "true" : undefined}
-        className={cn(
-          SIDEBAR_HOVER_ACTIONS_CLASS,
-          "absolute inset-y-0 right-0 z-10 flex items-center justify-end max-md:pointer-coarse:hidden",
-        )}
-      >
-        <DraftActionsMenu
-          onDelete={draft.delete}
-          onOpenInSplit={splitEnabled ? draftSplit.openInSplit : undefined}
-          onOpenChange={setDropdownOpen}
+        <button
+          ref={rowTargetRef}
+          type="button"
+          className="absolute inset-0 rounded-md outline-none ring-sidebar-ring focus-visible:ring-2"
+          aria-label={`Open draft ${draft.title}`}
+          onClick={() => onOpenDraft(draft.id)}
         />
-      </span>
-    </div>
+        <SidebarRowStatusRail>
+          <SidebarItemStatusSlot
+            status="draft"
+            tooltip="Draft"
+            onActivate={() => rowTargetRef.current?.click()}
+          >
+            <Icon
+              name="Edit"
+              className={cn(
+                COARSE_POINTER_ICON_SIZE_CLASS,
+                SIDEBAR_IDLE_STATUS_COLOR_CLASS,
+              )}
+              aria-hidden="true"
+            />
+          </SidebarItemStatusSlot>
+        </SidebarRowStatusRail>
+        <SidebarRowContent
+          className={cn(
+            SIDEBAR_HOVER_ACTIONS_INSET_CLASS,
+            "flex min-w-0 flex-1 items-center gap-2",
+          )}
+        >
+          <span className="min-w-0 truncate" title={draft.title}>
+            {draft.title}
+          </span>
+        </SidebarRowContent>
+        <span
+          data-sidebar-hover-actions-open={actionsOpen ? "true" : undefined}
+          className={cn(
+            SIDEBAR_HOVER_ACTIONS_CLASS,
+            "absolute inset-y-0 right-0 z-10 flex items-center justify-end max-md:pointer-coarse:hidden",
+          )}
+        >
+          <DraftActionsMenu
+            onDelete={draft.delete}
+            onOpenInSplit={splitEnabled ? draftSplit.openInSplit : undefined}
+            onOpenChange={setDropdownOpen}
+          />
+        </span>
+      </div>
+    </SidebarRow>
   );
 
   return (
@@ -333,77 +346,88 @@ function SidebarArchivedThreadRow({
 }) {
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [contextOpen, setContextOpen] = useState(false);
+  const rowTargetRef = useRef<HTMLAnchorElement>(null);
   const actionsOpen = dropdownOpen || contextOpen;
   const title = getThreadDisplayTitle(thread);
 
   const row = (
-    <div
-      data-sidebar-archived-thread-id={thread.id}
-      className={cn(
-        SIDEBAR_HOVER_ACTIONS_ROW_CLASS,
-        SIDEBAR_ROW_BASE_CLASS,
-        SIDEBAR_STANDARD_ROW_PADDING_CLASS,
-        COARSE_POINTER_ROW_HEIGHT_CLASS,
-        LIST_HOVER_TRANSITION,
-        "group/archived-thread-row relative min-w-0",
-        isActive
-          ? SIDEBAR_ROW_SELECTED_STATE_CLASS
-          : [
-              SIDEBAR_ROW_INTERACTIVE_STATE_CLASS,
-              "text-sidebar-foreground/60 dark:text-sidebar-foreground/60",
-            ],
-        !isActive && "has-[[data-state=open]]:bg-sidebar-accent",
-      )}
-    >
-      <NavLink
-        to={getThreadRoutePath({
-          projectId: thread.projectId,
-          threadId: thread.id,
-        })}
-        data-sidebar-thread-shortcut-target=""
-        data-sidebar-thread-id={thread.id}
-        className="absolute inset-0 rounded-md outline-none ring-sidebar-ring focus-visible:ring-2"
-        aria-label={`Open archived thread ${title}`}
-        onClick={onNavigate}
-      />
-      <span
+    <SidebarRow asChild density="standard" variant="item">
+      <div
+        data-sidebar-archived-thread-id={thread.id}
         className={cn(
-          SIDEBAR_HOVER_ACTIONS_INSET_CLASS,
-          "flex min-w-0 flex-1 items-center gap-2",
+          SIDEBAR_HOVER_ACTIONS_ROW_CLASS,
+          LIST_HOVER_TRANSITION,
+          "group/archived-thread-row relative min-w-0",
+          isActive
+            ? SIDEBAR_ROW_SELECTED_STATE_CLASS
+            : [
+                SIDEBAR_ROW_INTERACTIVE_STATE_CLASS,
+                "text-sidebar-foreground/60 dark:text-sidebar-foreground/60",
+              ],
+          !isActive && "has-[[data-state=open]]:bg-sidebar-accent",
         )}
       >
-        <span className="min-w-0 truncate" title={title}>
-          {title}
-        </span>
-        <span
-          data-sidebar-archived-state=""
-          className="ml-auto shrink-0 text-xs text-muted-foreground transition-opacity group-hover/archived-thread-row:opacity-0 group-focus-within/archived-thread-row:opacity-0"
-        >
-          Archived
-        </span>
-      </span>
-      <span
-        data-sidebar-hover-actions-open={actionsOpen ? "true" : undefined}
-        className={cn(
-          SIDEBAR_HOVER_ACTIONS_CLASS,
-          "absolute inset-y-0 right-0 z-10 flex items-center justify-end max-md:pointer-coarse:hidden",
-        )}
-      >
-        <ThreadArchiveQuickAction
-          thread={thread}
-          showLabel
-          className="h-6 px-1.5 text-xs text-muted-foreground hover:bg-transparent hover:text-foreground"
+        <NavLink
+          ref={rowTargetRef}
+          to={getThreadRoutePath({
+            projectId: thread.projectId,
+            threadId: thread.id,
+          })}
+          data-sidebar-thread-shortcut-target=""
+          data-sidebar-thread-id={thread.id}
+          className="absolute inset-0 rounded-md outline-none ring-sidebar-ring focus-visible:ring-2"
+          aria-label={`Open archived thread ${title}`}
+          onClick={onNavigate}
         />
-        <ThreadActionsMenu
-          thread={thread}
-          triggerClassName={cn(
-            "text-subtle-foreground hover:bg-transparent hover:text-foreground",
-            SIDEBAR_MORE_ACTION_TRIGGER_CLASS,
+        <SidebarRowStatusRail>
+          <SidebarItemStatusSlot
+            status="archived"
+            tooltip="Archived"
+            onActivate={() => rowTargetRef.current?.click()}
+          >
+            <Icon
+              name="Archive"
+              className={cn(
+                COARSE_POINTER_ICON_SIZE_CLASS,
+                SIDEBAR_IDLE_STATUS_COLOR_CLASS,
+              )}
+              aria-hidden="true"
+            />
+          </SidebarItemStatusSlot>
+        </SidebarRowStatusRail>
+        <SidebarRowContent
+          className={cn(
+            SIDEBAR_HOVER_ACTIONS_INSET_CLASS,
+            "flex min-w-0 flex-1 items-center gap-2",
           )}
-          onOpenChange={setDropdownOpen}
-        />
-      </span>
-    </div>
+        >
+          <span className="min-w-0 truncate" title={title}>
+            {title}
+          </span>
+        </SidebarRowContent>
+        <span
+          data-sidebar-hover-actions-open={actionsOpen ? "true" : undefined}
+          className={cn(
+            SIDEBAR_HOVER_ACTIONS_CLASS,
+            "absolute inset-y-0 right-0 z-10 flex items-center justify-end max-md:pointer-coarse:hidden",
+          )}
+        >
+          <ThreadArchiveQuickAction
+            thread={thread}
+            showLabel
+            className="h-6 px-1.5 text-xs text-muted-foreground hover:bg-transparent hover:text-foreground"
+          />
+          <ThreadActionsMenu
+            thread={thread}
+            triggerClassName={cn(
+              "text-subtle-foreground hover:bg-transparent hover:text-foreground",
+              SIDEBAR_MORE_ACTION_TRIGGER_CLASS,
+            )}
+            onOpenChange={setDropdownOpen}
+          />
+        </span>
+      </div>
+    </SidebarRow>
   );
 
   return (

--- a/apps/app/src/components/sidebar/SidebarLifecycleRows.tsx
+++ b/apps/app/src/components/sidebar/SidebarLifecycleRows.tsx
@@ -31,7 +31,6 @@ import {
 } from "@/components/ui/sidebar.js";
 import {
   SIDEBAR_HOVER_ACTIONS_CLASS,
-  SIDEBAR_HOVER_ACTIONS_INSET_CLASS,
   SIDEBAR_HOVER_ACTIONS_ROW_CLASS,
 } from "@/components/ui/sidebar-hover-actions.js";
 import { getThreadDisplayTitle } from "@/lib/thread-title";
@@ -49,6 +48,8 @@ import { usePaneContentSplitDrag } from "./usePaneContentSplitDrag";
 import { SidebarItemStatusSlot } from "./SidebarItemStatus";
 import {
   SidebarRow,
+  SidebarRowActions,
+  SidebarRowBody,
   SidebarRowContent,
   SidebarRowStatusRail,
 } from "./SidebarRow";
@@ -258,29 +259,28 @@ function SidebarDraftRow({
             />
           </SidebarItemStatusSlot>
         </SidebarRowStatusRail>
-        <SidebarRowContent
-          className={cn(
-            SIDEBAR_HOVER_ACTIONS_INSET_CLASS,
-            "flex min-w-0 flex-1 items-center gap-2",
-          )}
-        >
-          <span className="min-w-0 truncate" title={draft.title}>
-            {draft.title}
+        <SidebarRowBody>
+          <SidebarRowContent className="flex min-w-0 flex-1 items-center gap-2">
+            <span className="min-w-0 truncate" title={draft.title}>
+              {draft.title}
+            </span>
+          </SidebarRowContent>
+        </SidebarRowBody>
+        <SidebarRowActions>
+          <span
+            data-sidebar-hover-actions-open={actionsOpen ? "true" : undefined}
+            className={cn(
+              SIDEBAR_HOVER_ACTIONS_CLASS,
+              "relative z-10 flex items-center justify-end max-md:pointer-coarse:hidden",
+            )}
+          >
+            <DraftActionsMenu
+              onDelete={draft.delete}
+              onOpenInSplit={splitEnabled ? draftSplit.openInSplit : undefined}
+              onOpenChange={setDropdownOpen}
+            />
           </span>
-        </SidebarRowContent>
-        <span
-          data-sidebar-hover-actions-open={actionsOpen ? "true" : undefined}
-          className={cn(
-            SIDEBAR_HOVER_ACTIONS_CLASS,
-            "absolute inset-y-0 right-0 z-10 flex items-center justify-end max-md:pointer-coarse:hidden",
-          )}
-        >
-          <DraftActionsMenu
-            onDelete={draft.delete}
-            onOpenInSplit={splitEnabled ? draftSplit.openInSplit : undefined}
-            onOpenChange={setDropdownOpen}
-          />
-        </span>
+        </SidebarRowActions>
       </div>
     </SidebarRow>
   );
@@ -395,37 +395,36 @@ function SidebarArchivedThreadRow({
             />
           </SidebarItemStatusSlot>
         </SidebarRowStatusRail>
-        <SidebarRowContent
-          className={cn(
-            SIDEBAR_HOVER_ACTIONS_INSET_CLASS,
-            "flex min-w-0 flex-1 items-center gap-2",
-          )}
-        >
-          <span className="min-w-0 truncate" title={title}>
-            {title}
-          </span>
-        </SidebarRowContent>
-        <span
-          data-sidebar-hover-actions-open={actionsOpen ? "true" : undefined}
-          className={cn(
-            SIDEBAR_HOVER_ACTIONS_CLASS,
-            "absolute inset-y-0 right-0 z-10 flex items-center justify-end max-md:pointer-coarse:hidden",
-          )}
-        >
-          <ThreadArchiveQuickAction
-            thread={thread}
-            showLabel
-            className="h-6 px-1.5 text-xs text-muted-foreground hover:bg-transparent hover:text-foreground"
-          />
-          <ThreadActionsMenu
-            thread={thread}
-            triggerClassName={cn(
-              "text-subtle-foreground hover:bg-transparent hover:text-foreground",
-              SIDEBAR_MORE_ACTION_TRIGGER_CLASS,
+        <SidebarRowBody>
+          <SidebarRowContent className="flex min-w-0 flex-1 items-center gap-2">
+            <span className="min-w-0 truncate" title={title}>
+              {title}
+            </span>
+          </SidebarRowContent>
+        </SidebarRowBody>
+        <SidebarRowActions>
+          <span
+            data-sidebar-hover-actions-open={actionsOpen ? "true" : undefined}
+            className={cn(
+              SIDEBAR_HOVER_ACTIONS_CLASS,
+              "relative z-10 flex items-center justify-end max-md:pointer-coarse:hidden",
             )}
-            onOpenChange={setDropdownOpen}
-          />
-        </span>
+          >
+            <ThreadArchiveQuickAction
+              thread={thread}
+              showLabel
+              className="h-6 px-1.5 text-xs text-muted-foreground hover:bg-transparent hover:text-foreground"
+            />
+            <ThreadActionsMenu
+              thread={thread}
+              triggerClassName={cn(
+                "text-subtle-foreground hover:bg-transparent hover:text-foreground",
+                SIDEBAR_MORE_ACTION_TRIGGER_CLASS,
+              )}
+              onOpenChange={setDropdownOpen}
+            />
+          </span>
+        </SidebarRowActions>
       </div>
     </SidebarRow>
   );

--- a/apps/app/src/components/sidebar/SidebarOverview.stories.tsx
+++ b/apps/app/src/components/sidebar/SidebarOverview.stories.tsx
@@ -82,7 +82,14 @@ const personalProject = makeProject({
 });
 
 const loadedSidebarNavigation = {
-  sections: [],
+  sections: [
+    {
+      id: "sec_story_review",
+      name: "Review queue",
+      createdAt: 1,
+      updatedAt: 1,
+    },
+  ],
   personalProject: {
     ...personalProject,
     defaultExecutionOptions: null,
@@ -212,6 +219,7 @@ const loadedSidebarNavigation = {
         makeThreadListEntry({
           id: "thr_story_docs",
           projectId: docsProject.id,
+          sectionId: "sec_story_review",
           title: "Refresh onboarding docs",
           titleFallback: "Refresh onboarding docs",
           latestAttentionAt: 120,
@@ -569,6 +577,53 @@ export function OrganizationModes() {
           hosts={machineStoryHosts}
           navigation={emptySidebarNavigation}
         />
+      </StoryRow>
+    </StoryCard>
+  );
+}
+
+export function RowLayoutContract() {
+  return (
+    <StoryCard
+      labelWidth="120px"
+      columns={["Wide", "Compact width"]}
+      className="min-w-max items-start"
+    >
+      <StoryRow
+        label="Project tree"
+        hint="Production rows at the two representative sidebar widths"
+      >
+        <div className="w-[320px]">
+          <OrganizationSidebar
+            mode="project"
+            navigation={loadedSidebarNavigation}
+          />
+        </div>
+        <div className="w-[240px]">
+          <OrganizationSidebar
+            mode="project"
+            navigation={loadedSidebarNavigation}
+          />
+        </div>
+      </StoryRow>
+      <StoryRow
+        label="Machine tree"
+        hint="The same status, identity, content, action, and disclosure rails"
+      >
+        <div className="w-[320px]">
+          <OrganizationSidebar
+            mode="machine"
+            hosts={machineStoryHosts}
+            navigation={machineSidebarNavigation}
+          />
+        </div>
+        <div className="w-[240px]">
+          <OrganizationSidebar
+            mode="machine"
+            hosts={machineStoryHosts}
+            navigation={machineSidebarNavigation}
+          />
+        </div>
       </StoryRow>
     </StoryCard>
   );

--- a/apps/app/src/components/sidebar/SidebarOverview.stories.tsx
+++ b/apps/app/src/components/sidebar/SidebarOverview.stories.tsx
@@ -99,6 +99,7 @@ const loadedSidebarNavigation = {
         projectId: PERSONAL_PROJECT_ID,
         title: "Sketch launch checklist",
         titleFallback: "Sketch launch checklist",
+        lastReadAt: 0,
         latestAttentionAt: 85,
         createdAt: 85,
         updatedAt: 85,
@@ -556,7 +557,7 @@ export function OrganizationModes() {
           navigation={emptySidebarNavigation}
         />
       </StoryRow>
-      <StoryRow label="Manual">
+      <StoryRow label="Custom">
         <OrganizationSidebar
           mode="manual"
           navigation={loadedSidebarNavigation}
@@ -586,12 +587,12 @@ export function RowLayoutContract() {
   return (
     <StoryCard
       labelWidth="120px"
-      columns={["Wide", "Compact width"]}
+      columns={["Standard width", "Compact width"]}
       className="min-w-max items-start"
     >
       <StoryRow
         label="Project tree"
-        hint="Production rows at the two representative sidebar widths"
+        hint="Loose, project, worktree, parent, nested, unread, working, and attention rows; use the production carets to compare expanded and collapsed geometry"
       >
         <div className="w-[320px]">
           <OrganizationSidebar
@@ -607,8 +608,25 @@ export function RowLayoutContract() {
         </div>
       </StoryRow>
       <StoryRow
+        label="Custom tree"
+        hint="Sections and loose threads use the same fixed status and disclosure rails"
+      >
+        <div className="w-[320px]">
+          <OrganizationSidebar
+            mode="manual"
+            navigation={loadedSidebarNavigation}
+          />
+        </div>
+        <div className="w-[240px]">
+          <OrganizationSidebar
+            mode="manual"
+            navigation={loadedSidebarNavigation}
+          />
+        </div>
+      </StoryRow>
+      <StoryRow
         label="Machine tree"
-        hint="The same status, identity, content, action, and disclosure rails"
+        hint="Machine groups preserve the same compact row contract at both widths"
       >
         <div className="w-[320px]">
           <OrganizationSidebar

--- a/apps/app/src/components/sidebar/SidebarRow.test.tsx
+++ b/apps/app/src/components/sidebar/SidebarRow.test.tsx
@@ -85,10 +85,19 @@ describe("SidebarRow", () => {
       "[grid-template-areas:'status_body_actions_disclosure']",
     );
     expect(row?.className).toContain("[--sidebar-row-depth-step:0.75rem]");
+    expect(row?.className).toContain(
+      "[--sidebar-row-body-inset:calc(var(--sidebar-row-depth)*var(--sidebar-row-depth-step))]",
+    );
     expect(status?.childElementCount).toBe(0);
     expect(status?.classList.contains("[grid-area:status]")).toBe(true);
     expect(status?.className).not.toContain("translate");
     expect(body?.classList.contains("[grid-area:body]")).toBe(true);
+    expect(body?.className).toContain(
+      "[grid-template-areas:'identity_content_accessory']",
+    );
+    expect(body?.className).toContain(
+      "[grid-template-columns:var(--sidebar-row-identity-rail)_minmax(0,1fr)_auto]",
+    );
     expect(body?.className).toContain("pl-[var(--sidebar-row-body-inset)]");
     expect(content?.classList.contains("[grid-area:content]")).toBe(true);
     expect(disclosure?.childElementCount).toBe(0);
@@ -130,6 +139,12 @@ describe("SidebarRow", () => {
     const disclosure = collapsibleRow.querySelector(
       '[data-sidebar-row-slot="disclosure"]',
     );
+    const plainBody = plainRow.querySelector(
+      '[data-sidebar-row-slot="body"]',
+    );
+    const collapsibleBody = collapsibleRow.querySelector(
+      '[data-sidebar-row-slot="body"]',
+    );
 
     expect(plainRow.className).toContain(
       "[grid-template-columns:var(--sidebar-row-status-rail)_minmax(0,1fr)_auto_var(--sidebar-row-disclosure-rail)]",
@@ -138,6 +153,10 @@ describe("SidebarRow", () => {
       "[grid-template-columns:var(--sidebar-row-status-rail)_minmax(0,1fr)_auto_var(--sidebar-row-disclosure-rail)]",
     );
     expect(plainStatus?.className).toBe(collapsibleStatus?.className);
+    expect(plainBody?.className).toBe(collapsibleBody?.className);
+    expect(plainBody?.className).toContain(
+      "[grid-template-columns:var(--sidebar-row-identity-rail)_minmax(0,1fr)_auto]",
+    );
     expect(disclosure?.classList.contains("justify-center")).toBe(true);
     expect(container.querySelectorAll("[data-sidebar-row]")).toHaveLength(2);
   });

--- a/apps/app/src/components/sidebar/SidebarRow.test.tsx
+++ b/apps/app/src/components/sidebar/SidebarRow.test.tsx
@@ -152,12 +152,14 @@ describe("SidebarRow", () => {
     expect(
       screen
         .getByText("Projects")
-        .parentElement?.getAttribute("data-sidebar-row-variant"),
+        .closest("[data-sidebar-row]")
+        ?.getAttribute("data-sidebar-row-variant"),
     ).toBe("viewHeader");
     expect(
       screen
         .getByText("Projects")
-        .parentElement?.getAttribute("data-sidebar-row-density"),
+        .closest("[data-sidebar-row]")
+        ?.getAttribute("data-sidebar-row-density"),
     ).toBe("label");
 
     rerender(
@@ -172,12 +174,14 @@ describe("SidebarRow", () => {
     expect(
       screen
         .getByText("Thread")
-        .parentElement?.getAttribute("data-sidebar-row-variant"),
+        .closest("[data-sidebar-row]")
+        ?.getAttribute("data-sidebar-row-variant"),
     ).toBe("item");
     expect(
       screen
         .getByText("Thread")
-        .parentElement?.getAttribute("data-sidebar-row-density"),
+        .closest("[data-sidebar-row]")
+        ?.getAttribute("data-sidebar-row-density"),
     ).toBe("standard");
   });
 });

--- a/apps/app/src/components/sidebar/SidebarRow.test.tsx
+++ b/apps/app/src/components/sidebar/SidebarRow.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+
+import { createRef } from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  SidebarRow,
+  SidebarRowAccessory,
+  SidebarRowActions,
+  SidebarRowContent,
+  SidebarRowDisclosureRail,
+  SidebarRowIdentityRail,
+  SidebarRowStatusRail,
+} from "./SidebarRow";
+
+afterEach(cleanup);
+
+describe("SidebarRow", () => {
+  it("preserves an asChild semantic element, attributes, focus, and ref", () => {
+    const ref = createRef<HTMLDivElement>();
+
+    render(
+      <SidebarRow
+        ref={ref}
+        asChild
+        anatomy="navigation"
+        density="compact"
+        depth={2}
+        variant="groupLabel"
+      >
+        <button type="button" aria-label="Open tools" data-domain-row="tools">
+          <SidebarRowIdentityRail>Icon</SidebarRowIdentityRail>
+          <SidebarRowContent>Tools</SidebarRowContent>
+        </button>
+      </SidebarRow>,
+    );
+
+    const button = screen.getByRole("button", { name: "Open tools" });
+    button.focus();
+
+    expect(button.tagName).toBe("BUTTON");
+    expect(button.getAttribute("data-domain-row")).toBe("tools");
+    expect(button.getAttribute("data-sidebar-row-anatomy")).toBe(
+      "navigation",
+    );
+    expect(button.getAttribute("data-sidebar-row-density")).toBe("compact");
+    expect(button.getAttribute("data-sidebar-row-depth")).toBe("2");
+    expect(button.getAttribute("data-sidebar-row-variant")).toBe(
+      "groupLabel",
+    );
+    expect(button.style.getPropertyValue("--sidebar-row-depth")).toBe("2");
+    expect(document.activeElement).toBe(button);
+    expect(ref.current).toBe(button);
+  });
+
+  it("maps tree anatomy to stable semantic rails without per-row transforms", () => {
+    const { container } = render(
+      <SidebarRow anatomy="tree" depth={3}>
+        <SidebarRowStatusRail />
+        <SidebarRowIdentityRail>Icon</SidebarRowIdentityRail>
+        <SidebarRowContent>Nested thread</SidebarRowContent>
+        <SidebarRowAccessory>Meta</SidebarRowAccessory>
+        <SidebarRowActions>Actions</SidebarRowActions>
+        <SidebarRowDisclosureRail />
+      </SidebarRow>,
+    );
+
+    const row = container.querySelector("[data-sidebar-row]");
+    const status = container.querySelector('[data-sidebar-row-slot="status"]');
+    const content = container.querySelector(
+      '[data-sidebar-row-slot="content"]',
+    );
+    const disclosure = container.querySelector(
+      '[data-sidebar-row-slot="disclosure"]',
+    );
+
+    expect(row?.getAttribute("data-sidebar-row-anatomy")).toBe("tree");
+    expect(row?.getAttribute("data-sidebar-row-depth")).toBe("3");
+    expect(row?.classList.contains("relative")).toBe(false);
+    expect(status?.childElementCount).toBe(0);
+    expect(status?.classList.contains("[grid-area:status]")).toBe(true);
+    expect(status?.className).not.toContain("translate");
+    expect(content?.classList.contains("[grid-area:content]")).toBe(true);
+    expect(disclosure?.childElementCount).toBe(0);
+    expect(disclosure?.classList.contains("[grid-area:disclosure]")).toBe(
+      true,
+    );
+  });
+
+  it("keeps recipe and density choices orthogonal to anatomy", () => {
+    const { rerender } = render(
+      <SidebarRow anatomy="navigation" density="label" variant="viewHeader">
+        <SidebarRowContent>Projects</SidebarRowContent>
+      </SidebarRow>,
+    );
+
+    expect(
+      screen
+        .getByText("Projects")
+        .parentElement?.getAttribute("data-sidebar-row-variant"),
+    ).toBe("viewHeader");
+    expect(
+      screen
+        .getByText("Projects")
+        .parentElement?.getAttribute("data-sidebar-row-density"),
+    ).toBe("label");
+
+    rerender(
+      <SidebarRow anatomy="tree" density="standard" variant="item">
+        <SidebarRowStatusRail />
+        <SidebarRowContent>Thread</SidebarRowContent>
+      </SidebarRow>,
+    );
+
+    expect(
+      screen
+        .getByText("Thread")
+        .parentElement?.getAttribute("data-sidebar-row-variant"),
+    ).toBe("item");
+    expect(
+      screen
+        .getByText("Thread")
+        .parentElement?.getAttribute("data-sidebar-row-density"),
+    ).toBe("standard");
+  });
+});

--- a/apps/app/src/components/sidebar/SidebarRow.test.tsx
+++ b/apps/app/src/components/sidebar/SidebarRow.test.tsx
@@ -7,6 +7,7 @@ import {
   SidebarRow,
   SidebarRowAccessory,
   SidebarRowActions,
+  SidebarRowBody,
   SidebarRowContent,
   SidebarRowDisclosureRail,
   SidebarRowIdentityRail,
@@ -57,9 +58,11 @@ describe("SidebarRow", () => {
     const { container } = render(
       <SidebarRow anatomy="tree" depth={3}>
         <SidebarRowStatusRail />
-        <SidebarRowIdentityRail>Icon</SidebarRowIdentityRail>
-        <SidebarRowContent>Nested thread</SidebarRowContent>
-        <SidebarRowAccessory>Meta</SidebarRowAccessory>
+        <SidebarRowBody>
+          <SidebarRowIdentityRail>Icon</SidebarRowIdentityRail>
+          <SidebarRowContent>Nested thread</SidebarRowContent>
+          <SidebarRowAccessory>Meta</SidebarRowAccessory>
+        </SidebarRowBody>
         <SidebarRowActions>Actions</SidebarRowActions>
         <SidebarRowDisclosureRail />
       </SidebarRow>,
@@ -70,6 +73,7 @@ describe("SidebarRow", () => {
     const content = container.querySelector(
       '[data-sidebar-row-slot="content"]',
     );
+    const body = container.querySelector('[data-sidebar-row-slot="body"]');
     const disclosure = container.querySelector(
       '[data-sidebar-row-slot="disclosure"]',
     );
@@ -77,14 +81,65 @@ describe("SidebarRow", () => {
     expect(row?.getAttribute("data-sidebar-row-anatomy")).toBe("tree");
     expect(row?.getAttribute("data-sidebar-row-depth")).toBe("3");
     expect(row?.classList.contains("relative")).toBe(false);
+    expect(row?.className).toContain(
+      "[grid-template-areas:'status_body_actions_disclosure']",
+    );
+    expect(row?.className).toContain("[--sidebar-row-depth-step:0.75rem]");
     expect(status?.childElementCount).toBe(0);
     expect(status?.classList.contains("[grid-area:status]")).toBe(true);
     expect(status?.className).not.toContain("translate");
+    expect(body?.classList.contains("[grid-area:body]")).toBe(true);
+    expect(body?.className).toContain("pl-[var(--sidebar-row-body-inset)]");
     expect(content?.classList.contains("[grid-area:content]")).toBe(true);
     expect(disclosure?.childElementCount).toBe(0);
     expect(disclosure?.classList.contains("[grid-area:disclosure]")).toBe(
       true,
     );
+    expect(disclosure?.classList.contains("justify-center")).toBe(true);
+  });
+
+  it("does not move the fixed tree rails when optional row content changes", () => {
+    const { container } = render(
+      <>
+        <SidebarRow anatomy="tree" data-testid="plain-row">
+          <SidebarRowStatusRail />
+          <SidebarRowBody>
+            <SidebarRowContent>Plain thread</SidebarRowContent>
+          </SidebarRowBody>
+        </SidebarRow>
+        <SidebarRow anatomy="tree" data-testid="collapsible-row">
+          <SidebarRowStatusRail />
+          <SidebarRowBody>
+            <SidebarRowIdentityRail>Icon</SidebarRowIdentityRail>
+            <SidebarRowContent>Parent thread</SidebarRowContent>
+          </SidebarRowBody>
+          <SidebarRowActions>Actions</SidebarRowActions>
+          <SidebarRowDisclosureRail>Disclosure</SidebarRowDisclosureRail>
+        </SidebarRow>
+      </>,
+    );
+
+    const plainRow = screen.getByTestId("plain-row");
+    const collapsibleRow = screen.getByTestId("collapsible-row");
+    const plainStatus = plainRow.querySelector(
+      '[data-sidebar-row-slot="status"]',
+    );
+    const collapsibleStatus = collapsibleRow.querySelector(
+      '[data-sidebar-row-slot="status"]',
+    );
+    const disclosure = collapsibleRow.querySelector(
+      '[data-sidebar-row-slot="disclosure"]',
+    );
+
+    expect(plainRow.className).toContain(
+      "[grid-template-columns:var(--sidebar-row-status-rail)_minmax(0,1fr)_auto_var(--sidebar-row-disclosure-rail)]",
+    );
+    expect(collapsibleRow.className).toContain(
+      "[grid-template-columns:var(--sidebar-row-status-rail)_minmax(0,1fr)_auto_var(--sidebar-row-disclosure-rail)]",
+    );
+    expect(plainStatus?.className).toBe(collapsibleStatus?.className);
+    expect(disclosure?.classList.contains("justify-center")).toBe(true);
+    expect(container.querySelectorAll("[data-sidebar-row]")).toHaveLength(2);
   });
 
   it("keeps recipe and density choices orthogonal to anatomy", () => {
@@ -108,7 +163,9 @@ describe("SidebarRow", () => {
     rerender(
       <SidebarRow anatomy="tree" density="standard" variant="item">
         <SidebarRowStatusRail />
-        <SidebarRowContent>Thread</SidebarRowContent>
+        <SidebarRowBody>
+          <SidebarRowContent>Thread</SidebarRowContent>
+        </SidebarRowBody>
       </SidebarRow>,
     );
 

--- a/apps/app/src/components/sidebar/SidebarRow.tsx
+++ b/apps/app/src/components/sidebar/SidebarRow.tsx
@@ -17,7 +17,7 @@ import {
 } from "./sidebarRowClasses";
 
 const SIDEBAR_ROW_GEOMETRY_CLASS =
-  "[--sidebar-row-accessory-margin:var(--sidebar-row-column-gap)] [--sidebar-row-action-gap:0.125rem] [--sidebar-row-body-inset:calc(var(--sidebar-row-column-gap)+var(--sidebar-row-depth)*var(--sidebar-row-depth-step))] [--sidebar-row-column-gap:0.5rem] [--sidebar-row-content-inset:0px] [--sidebar-row-depth:0] [--sidebar-row-depth-step:0.75rem] [--sidebar-row-disclosure-rail:1.5rem] [--sidebar-row-identity-inset:0px] [--sidebar-row-identity-justify:flex-end] [--sidebar-row-identity-padding:var(--sidebar-row-identity-inset)] [--sidebar-row-identity-rail:1rem] [--sidebar-row-identity-slot-width:100%] [--sidebar-row-inline-padding:0.5rem] [--sidebar-row-status-rail:0.875rem] max-md:pointer-coarse:[--sidebar-row-identity-rail:1.25rem] max-md:pointer-coarse:[--sidebar-row-status-rail:1.25rem]";
+  "[--sidebar-row-accessory-margin:var(--sidebar-row-column-gap)] [--sidebar-row-action-gap:0.125rem] [--sidebar-row-body-inset:calc(var(--sidebar-row-depth)*var(--sidebar-row-depth-step))] [--sidebar-row-column-gap:0.5rem] [--sidebar-row-content-inset:0px] [--sidebar-row-depth:0] [--sidebar-row-depth-step:0.75rem] [--sidebar-row-disclosure-rail:1.5rem] [--sidebar-row-identity-inset:0px] [--sidebar-row-identity-justify:flex-end] [--sidebar-row-identity-padding:var(--sidebar-row-identity-inset)] [--sidebar-row-identity-rail:1rem] [--sidebar-row-identity-slot-width:100%] [--sidebar-row-inline-padding:0.5rem] [--sidebar-row-status-rail:0.875rem] max-md:pointer-coarse:[--sidebar-row-identity-rail:1.25rem] max-md:pointer-coarse:[--sidebar-row-status-rail:1.25rem]";
 
 const SIDEBAR_TREE_ROW_GRID_CLASS =
   "!grid [grid-template-areas:'status_body_actions_disclosure'] [grid-template-columns:var(--sidebar-row-status-rail)_minmax(0,1fr)_auto_var(--sidebar-row-disclosure-rail)]";
@@ -148,7 +148,7 @@ export function SidebarRowBody({ className, ...props }: SidebarRowRailProps) {
     <SidebarRowRail
       data-sidebar-row-slot="body"
       className={cn(
-        "[--sidebar-row-accessory-margin:0px] [--sidebar-row-content-inset:0px] [--sidebar-row-identity-justify:center] [--sidebar-row-identity-padding:0px] [--sidebar-row-identity-slot-width:var(--sidebar-row-identity-rail)] [grid-area:body] inline-flex h-full min-w-0 items-center gap-[var(--sidebar-row-column-gap)] pl-[var(--sidebar-row-body-inset)]",
+        "[--sidebar-row-accessory-margin:0px] [--sidebar-row-content-inset:0px] [--sidebar-row-identity-justify:center] [--sidebar-row-identity-padding:0px] [--sidebar-row-identity-slot-width:var(--sidebar-row-identity-rail)] [grid-area:body] [grid-template-areas:'identity_content_accessory'] [grid-template-columns:var(--sidebar-row-identity-rail)_minmax(0,1fr)_auto] inline-grid h-full min-w-0 items-center gap-[var(--sidebar-row-column-gap)] pl-[var(--sidebar-row-body-inset)]",
         className,
       )}
       {...props}

--- a/apps/app/src/components/sidebar/SidebarRow.tsx
+++ b/apps/app/src/components/sidebar/SidebarRow.tsx
@@ -1,0 +1,228 @@
+import {
+  type ComponentPropsWithoutRef,
+  type CSSProperties,
+  forwardRef,
+  type ReactNode,
+} from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+import {
+  COARSE_POINTER_COMPACT_ROW_HEIGHT_CLASS,
+  COARSE_POINTER_ROW_HEIGHT_CLASS,
+} from "@bb/shared-ui/coarse-pointer-sizing";
+import { cn } from "@bb/shared-ui/lib/utils";
+import {
+  SIDEBAR_GROUP_LABEL_CLASS,
+  SIDEBAR_VIEW_HEADER_LABEL_CLASS,
+} from "./sidebarRowClasses";
+
+const SIDEBAR_ROW_GEOMETRY_CLASS =
+  "[--sidebar-row-action-gap:0.125rem] [--sidebar-row-column-gap:0.5rem] [--sidebar-row-content-inset:calc(var(--sidebar-row-column-gap)+var(--sidebar-row-depth)*var(--sidebar-row-depth-step))] [--sidebar-row-depth:0] [--sidebar-row-depth-step:1.5rem] [--sidebar-row-disclosure-rail:1.5rem] [--sidebar-row-identity-inset:calc(var(--sidebar-row-column-gap)+var(--sidebar-row-depth)*var(--sidebar-row-depth-step))] [--sidebar-row-identity-rail:1rem] [--sidebar-row-inline-padding:0.5rem] [--sidebar-row-status-rail:0.875rem] has-[[data-sidebar-row-slot=identity]]:[--sidebar-row-content-inset:var(--sidebar-row-column-gap)] max-md:pointer-coarse:[--sidebar-row-identity-rail:1.25rem] max-md:pointer-coarse:[--sidebar-row-status-rail:1.25rem]";
+
+const SIDEBAR_TREE_ROW_GRID_CLASS =
+  "!grid [grid-template-areas:'status_content_accessory_actions'] [grid-template-columns:var(--sidebar-row-status-rail)_minmax(0,1fr)_auto_auto] has-[[data-sidebar-row-slot=identity]]:[grid-template-areas:'status_identity_content_accessory_actions'] has-[[data-sidebar-row-slot=identity]]:[grid-template-columns:var(--sidebar-row-status-rail)_calc(var(--sidebar-row-identity-inset)+var(--sidebar-row-identity-rail))_minmax(0,1fr)_auto_auto] has-[[data-sidebar-row-slot=disclosure]]:[grid-template-areas:'status_content_accessory_actions_disclosure'] has-[[data-sidebar-row-slot=disclosure]]:[grid-template-columns:var(--sidebar-row-status-rail)_minmax(0,1fr)_auto_auto_calc(var(--sidebar-row-column-gap)+var(--sidebar-row-disclosure-rail))] has-[[data-sidebar-row-slot=identity]]:has-[[data-sidebar-row-slot=disclosure]]:[grid-template-areas:'status_identity_content_accessory_actions_disclosure'] has-[[data-sidebar-row-slot=identity]]:has-[[data-sidebar-row-slot=disclosure]]:[grid-template-columns:var(--sidebar-row-status-rail)_calc(var(--sidebar-row-identity-inset)+var(--sidebar-row-identity-rail))_minmax(0,1fr)_auto_auto_calc(var(--sidebar-row-column-gap)+var(--sidebar-row-disclosure-rail))]";
+
+const SIDEBAR_NAVIGATION_ROW_GRID_CLASS =
+  "!grid [--sidebar-row-content-inset:0px] [--sidebar-row-identity-inset:0px] [grid-template-areas:'content_accessory_actions'] [grid-template-columns:minmax(0,1fr)_auto_auto] has-[[data-sidebar-row-slot=identity]]:[--sidebar-row-content-inset:var(--sidebar-row-column-gap)] has-[[data-sidebar-row-slot=identity]]:[grid-template-areas:'identity_content_accessory_actions'] has-[[data-sidebar-row-slot=identity]]:[grid-template-columns:var(--sidebar-row-identity-rail)_minmax(0,1fr)_auto_auto]";
+
+export const sidebarRowVariants = cva(
+  cn(
+    "w-full min-w-0 items-center !gap-0 rounded-md !pr-0 !pl-[var(--sidebar-row-inline-padding)] transition-colors",
+    SIDEBAR_ROW_GEOMETRY_CLASS,
+  ),
+  {
+    variants: {
+      anatomy: {
+        tree: SIDEBAR_TREE_ROW_GRID_CLASS,
+        navigation: SIDEBAR_NAVIGATION_ROW_GRID_CLASS,
+      },
+      variant: {
+        item: "text-sm",
+        viewHeader: SIDEBAR_VIEW_HEADER_LABEL_CLASS,
+        groupLabel: SIDEBAR_GROUP_LABEL_CLASS,
+      },
+      density: {
+        standard: COARSE_POINTER_ROW_HEIGHT_CLASS,
+        compact: COARSE_POINTER_COMPACT_ROW_HEIGHT_CLASS,
+        label: "h-6 max-md:pointer-coarse:h-9",
+      },
+    },
+    defaultVariants: {
+      anatomy: "tree",
+      variant: "item",
+      density: "standard",
+    },
+  },
+);
+
+export type SidebarRowVariant = NonNullable<
+  VariantProps<typeof sidebarRowVariants>["variant"]
+>;
+
+export type SidebarRowAnatomy = NonNullable<
+  VariantProps<typeof sidebarRowVariants>["anatomy"]
+>;
+
+type SidebarRowDepthStyle = CSSProperties & {
+  "--sidebar-row-depth": number;
+};
+
+interface SidebarRowProps
+  extends
+    ComponentPropsWithoutRef<"div">,
+    VariantProps<typeof sidebarRowVariants> {
+  asChild?: boolean;
+  depth?: number;
+}
+
+export const SidebarRow = forwardRef<HTMLDivElement, SidebarRowProps>(
+  function SidebarRow(
+    {
+      asChild = false,
+      anatomy,
+      className,
+      density,
+      depth = 0,
+      style,
+      variant,
+      ...props
+    },
+    ref,
+  ) {
+    const Component = asChild ? Slot : "div";
+    const rowStyle = {
+      ...style,
+      "--sidebar-row-depth": depth,
+    } satisfies SidebarRowDepthStyle;
+
+    return (
+      <Component
+        ref={ref}
+        data-sidebar-row=""
+        data-sidebar-row-anatomy={anatomy ?? "tree"}
+        data-sidebar-row-density={density ?? "standard"}
+        data-sidebar-row-depth={depth}
+        data-sidebar-row-variant={variant ?? "item"}
+        className={cn(
+          sidebarRowVariants({ anatomy, density, variant }),
+          className,
+        )}
+        style={rowStyle}
+        {...props}
+      />
+    );
+  },
+);
+
+interface SidebarRowRailProps extends ComponentPropsWithoutRef<"span"> {
+  asChild?: boolean;
+}
+
+function SidebarRowRail({
+  asChild = false,
+  className,
+  ...props
+}: SidebarRowRailProps) {
+  const Component = asChild ? Slot : "span";
+  return <Component className={className} {...props} />;
+}
+
+export function SidebarRowStatusRail({
+  className,
+  ...props
+}: SidebarRowRailProps) {
+  return (
+    <SidebarRowRail
+      data-sidebar-row-slot="status"
+      className={cn(
+        "[grid-area:status] inline-flex h-full w-[var(--sidebar-row-status-rail)] shrink-0 items-center justify-center",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function SidebarRowIdentityRail({
+  className,
+  ...props
+}: SidebarRowRailProps) {
+  return (
+    <SidebarRowRail
+      data-sidebar-row-slot="identity"
+      className={cn(
+        "[grid-area:identity] inline-flex h-full w-full shrink-0 items-center justify-end pl-[var(--sidebar-row-identity-inset)]",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+interface SidebarRowContentProps extends SidebarRowRailProps {
+  children: ReactNode;
+}
+
+export function SidebarRowContent({
+  className,
+  ...props
+}: SidebarRowContentProps) {
+  return (
+    <SidebarRowRail
+      data-sidebar-row-slot="content"
+      className={cn(
+        "[grid-area:content] min-w-0 pl-[var(--sidebar-row-content-inset)]",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function SidebarRowAccessory({
+  className,
+  ...props
+}: SidebarRowRailProps) {
+  return (
+    <SidebarRowRail
+      data-sidebar-row-slot="accessory"
+      className={cn(
+        "[grid-area:accessory] ml-[var(--sidebar-row-column-gap)] min-w-0 shrink",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function SidebarRowActions({
+  className,
+  ...props
+}: SidebarRowRailProps) {
+  return (
+    <SidebarRowRail
+      data-sidebar-row-slot="actions"
+      className={cn(
+        "[grid-area:actions] ml-[var(--sidebar-row-column-gap)] inline-flex shrink-0 items-center gap-[var(--sidebar-row-action-gap)]",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function SidebarRowDisclosureRail({
+  className,
+  ...props
+}: SidebarRowRailProps) {
+  return (
+    <SidebarRowRail
+      data-sidebar-row-slot="disclosure"
+      className={cn(
+        "[grid-area:disclosure] inline-flex h-full w-full shrink-0 items-center justify-end pl-[var(--sidebar-row-column-gap)]",
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/apps/app/src/components/sidebar/SidebarRow.tsx
+++ b/apps/app/src/components/sidebar/SidebarRow.tsx
@@ -17,10 +17,10 @@ import {
 } from "./sidebarRowClasses";
 
 const SIDEBAR_ROW_GEOMETRY_CLASS =
-  "[--sidebar-row-action-gap:0.125rem] [--sidebar-row-column-gap:0.5rem] [--sidebar-row-content-inset:calc(var(--sidebar-row-column-gap)+var(--sidebar-row-depth)*var(--sidebar-row-depth-step))] [--sidebar-row-depth:0] [--sidebar-row-depth-step:1.5rem] [--sidebar-row-disclosure-rail:1.5rem] [--sidebar-row-identity-inset:calc(var(--sidebar-row-column-gap)+var(--sidebar-row-depth)*var(--sidebar-row-depth-step))] [--sidebar-row-identity-rail:1rem] [--sidebar-row-inline-padding:0.5rem] [--sidebar-row-status-rail:0.875rem] has-[[data-sidebar-row-slot=identity]]:[--sidebar-row-content-inset:var(--sidebar-row-column-gap)] max-md:pointer-coarse:[--sidebar-row-identity-rail:1.25rem] max-md:pointer-coarse:[--sidebar-row-status-rail:1.25rem]";
+  "[--sidebar-row-accessory-margin:var(--sidebar-row-column-gap)] [--sidebar-row-action-gap:0.125rem] [--sidebar-row-body-inset:calc(var(--sidebar-row-column-gap)+var(--sidebar-row-depth)*var(--sidebar-row-depth-step))] [--sidebar-row-column-gap:0.5rem] [--sidebar-row-content-inset:0px] [--sidebar-row-depth:0] [--sidebar-row-depth-step:0.75rem] [--sidebar-row-disclosure-rail:1.5rem] [--sidebar-row-identity-inset:0px] [--sidebar-row-identity-justify:flex-end] [--sidebar-row-identity-padding:var(--sidebar-row-identity-inset)] [--sidebar-row-identity-rail:1rem] [--sidebar-row-identity-slot-width:100%] [--sidebar-row-inline-padding:0.5rem] [--sidebar-row-status-rail:0.875rem] max-md:pointer-coarse:[--sidebar-row-identity-rail:1.25rem] max-md:pointer-coarse:[--sidebar-row-status-rail:1.25rem]";
 
 const SIDEBAR_TREE_ROW_GRID_CLASS =
-  "!grid [grid-template-areas:'status_content_accessory_actions'] [grid-template-columns:var(--sidebar-row-status-rail)_minmax(0,1fr)_auto_auto] has-[[data-sidebar-row-slot=identity]]:[grid-template-areas:'status_identity_content_accessory_actions'] has-[[data-sidebar-row-slot=identity]]:[grid-template-columns:var(--sidebar-row-status-rail)_calc(var(--sidebar-row-identity-inset)+var(--sidebar-row-identity-rail))_minmax(0,1fr)_auto_auto] has-[[data-sidebar-row-slot=disclosure]]:[grid-template-areas:'status_content_accessory_actions_disclosure'] has-[[data-sidebar-row-slot=disclosure]]:[grid-template-columns:var(--sidebar-row-status-rail)_minmax(0,1fr)_auto_auto_calc(var(--sidebar-row-column-gap)+var(--sidebar-row-disclosure-rail))] has-[[data-sidebar-row-slot=identity]]:has-[[data-sidebar-row-slot=disclosure]]:[grid-template-areas:'status_identity_content_accessory_actions_disclosure'] has-[[data-sidebar-row-slot=identity]]:has-[[data-sidebar-row-slot=disclosure]]:[grid-template-columns:var(--sidebar-row-status-rail)_calc(var(--sidebar-row-identity-inset)+var(--sidebar-row-identity-rail))_minmax(0,1fr)_auto_auto_calc(var(--sidebar-row-column-gap)+var(--sidebar-row-disclosure-rail))]";
+  "!grid [grid-template-areas:'status_body_actions_disclosure'] [grid-template-columns:var(--sidebar-row-status-rail)_minmax(0,1fr)_auto_var(--sidebar-row-disclosure-rail)]";
 
 const SIDEBAR_NAVIGATION_ROW_GRID_CLASS =
   "!grid [--sidebar-row-content-inset:0px] [--sidebar-row-identity-inset:0px] [grid-template-areas:'content_accessory_actions'] [grid-template-columns:minmax(0,1fr)_auto_auto] has-[[data-sidebar-row-slot=identity]]:[--sidebar-row-content-inset:var(--sidebar-row-column-gap)] has-[[data-sidebar-row-slot=identity]]:[grid-template-areas:'identity_content_accessory_actions'] has-[[data-sidebar-row-slot=identity]]:[grid-template-columns:var(--sidebar-row-identity-rail)_minmax(0,1fr)_auto_auto]";
@@ -143,6 +143,19 @@ export function SidebarRowStatusRail({
   );
 }
 
+export function SidebarRowBody({ className, ...props }: SidebarRowRailProps) {
+  return (
+    <SidebarRowRail
+      data-sidebar-row-slot="body"
+      className={cn(
+        "[--sidebar-row-accessory-margin:0px] [--sidebar-row-content-inset:0px] [--sidebar-row-identity-justify:center] [--sidebar-row-identity-padding:0px] [--sidebar-row-identity-slot-width:var(--sidebar-row-identity-rail)] [grid-area:body] inline-flex h-full min-w-0 items-center gap-[var(--sidebar-row-column-gap)] pl-[var(--sidebar-row-body-inset)]",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
 export function SidebarRowIdentityRail({
   className,
   ...props
@@ -151,7 +164,7 @@ export function SidebarRowIdentityRail({
     <SidebarRowRail
       data-sidebar-row-slot="identity"
       className={cn(
-        "[grid-area:identity] inline-flex h-full w-full shrink-0 items-center justify-end pl-[var(--sidebar-row-identity-inset)]",
+        "[grid-area:identity] inline-flex h-full w-[var(--sidebar-row-identity-slot-width)] shrink-0 items-center justify-[var(--sidebar-row-identity-justify)] pl-[var(--sidebar-row-identity-padding)]",
         className,
       )}
       {...props}
@@ -171,7 +184,7 @@ export function SidebarRowContent({
     <SidebarRowRail
       data-sidebar-row-slot="content"
       className={cn(
-        "[grid-area:content] min-w-0 pl-[var(--sidebar-row-content-inset)]",
+        "[grid-area:content] min-w-0 flex-1 pl-[var(--sidebar-row-content-inset)]",
         className,
       )}
       {...props}
@@ -187,7 +200,7 @@ export function SidebarRowAccessory({
     <SidebarRowRail
       data-sidebar-row-slot="accessory"
       className={cn(
-        "[grid-area:accessory] ml-[var(--sidebar-row-column-gap)] min-w-0 shrink",
+        "[grid-area:accessory] ml-[var(--sidebar-row-accessory-margin)] min-w-0 shrink",
         className,
       )}
       {...props}
@@ -219,7 +232,7 @@ export function SidebarRowDisclosureRail({
     <SidebarRowRail
       data-sidebar-row-slot="disclosure"
       className={cn(
-        "[grid-area:disclosure] inline-flex h-full w-full shrink-0 items-center justify-end pl-[var(--sidebar-row-column-gap)]",
+        "[grid-area:disclosure] inline-flex h-full w-full shrink-0 items-center justify-center",
         className,
       )}
       {...props}

--- a/apps/app/src/components/sidebar/SidebarSectionOrderList.tsx
+++ b/apps/app/src/components/sidebar/SidebarSectionOrderList.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { Fragment, type ReactNode } from "react";
 import { DndContext } from "@dnd-kit/core";
 import {
   SortableContext,
@@ -11,16 +11,27 @@ interface SidebarSectionOrderListProps {
   children: (sectionId: SidebarSectionId) => ReactNode;
   dndContextProps?: SidebarReorderDndContextProps;
   order: readonly SidebarSectionId[];
+  pinnedTrailingContent?: ReactNode;
 }
 
 export function SidebarSectionOrderList({
   children,
   dndContextProps,
   order,
+  pinnedTrailingContent,
 }: SidebarSectionOrderListProps) {
+  const hasPinnedSection = order.includes("pinned");
   const content = (
     <SortableContext items={[...order]} strategy={verticalListSortingStrategy}>
-      <div className="space-y-4">{order.map(children)}</div>
+      <div className="space-y-4">
+        {!hasPinnedSection ? pinnedTrailingContent : null}
+        {order.map((sectionId) => (
+          <Fragment key={sectionId}>
+            {children(sectionId)}
+            {sectionId === "pinned" ? pinnedTrailingContent : null}
+          </Fragment>
+        ))}
+      </div>
     </SortableContext>
   );
 

--- a/apps/app/src/components/sidebar/SidebarSectionRow.stories.tsx
+++ b/apps/app/src/components/sidebar/SidebarSectionRow.stories.tsx
@@ -144,7 +144,7 @@ export function Overview() {
       </StoryRow>
       <StoryRow
         label="collapsed plan mode"
-        hint="hidden plan-mode banner rolls up to the right-aligned plan glyph"
+        hint="hidden plan-mode banner rolls up to the leading plan glyph"
       >
         <SidebarStage>
           <SectionRow
@@ -156,7 +156,7 @@ export function Overview() {
       </StoryRow>
       <StoryRow
         label="collapsed goal"
-        hint="hidden active-goal banner rolls up to the right-aligned target glyph"
+        hint="hidden active-goal banner rolls up to the leading target glyph"
       >
         <SidebarStage>
           <SectionRow

--- a/apps/app/src/components/sidebar/SidebarSectionRow.test.tsx
+++ b/apps/app/src/components/sidebar/SidebarSectionRow.test.tsx
@@ -57,35 +57,37 @@ describe("SidebarSectionRow", () => {
     const trailingControls = row?.querySelector(
       "[data-sidebar-collapsible-trailing-controls]",
     );
-    const mobileStatusSlot = trailingControls?.querySelector(
-      "[data-sidebar-mobile-status-slot]",
+    const statusSlot = row?.querySelector(
+      '[data-sidebar-row-slot="status"]',
     );
-    const mobileActions = more.closest(
-      "[data-sidebar-hover-actions-mobile]",
-    );
+    const mobileActions = more.closest("[data-sidebar-hover-actions-mobile]");
 
     expect(icon).toBeNull();
     expect(
       label.compareDocumentPosition(disclosure) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).not.toBe(0);
-    expect(row?.style.paddingLeft).toBe("32px");
-    expect(caretSlot?.classList.contains("w-6")).toBe(true);
+    expect(row?.getAttribute("data-sidebar-row-depth")).toBe("1");
+    expect(row?.style.getPropertyValue("--sidebar-row-depth")).toBe("1");
+    expect(caretSlot?.getAttribute("data-sidebar-row-slot")).toBe(
+      "disclosure",
+    );
     expect(row?.lastElementChild).toBe(caretSlot);
     expect(trailingControls?.nextElementSibling).toBe(caretSlot);
-    expect(mobileStatusSlot).not.toBeNull();
+    expect(statusSlot).not.toBeNull();
     expect(
-      mobileStatusSlot!.compareDocumentPosition(more) &
+      statusSlot!.compareDocumentPosition(more) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).not.toBe(0);
     expect(newThread.classList.contains("max-md:pointer-coarse:hidden")).toBe(
       true,
     );
-    expect(mobileActions?.getAttribute("data-sidebar-hover-actions-mobile")).toBe(
-      "always",
-    );
     expect(
-      newThread.compareDocumentPosition(more) & Node.DOCUMENT_POSITION_FOLLOWING,
+      mobileActions?.getAttribute("data-sidebar-hover-actions-mobile"),
+    ).toBe("always");
+    expect(
+      newThread.compareDocumentPosition(more) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
     ).not.toBe(0);
     expect(
       more.compareDocumentPosition(disclosure) &

--- a/apps/app/src/components/sidebar/SidebarSectionRow.test.tsx
+++ b/apps/app/src/components/sidebar/SidebarSectionRow.test.tsx
@@ -46,7 +46,7 @@ describe("SidebarSectionRow", () => {
     });
     const icon = result.container.querySelector('[data-icon="ListView"]');
     const label = screen.getByText("Nested work");
-    const row = label.parentElement?.parentElement as HTMLElement | null;
+    const row = label.closest("[data-sidebar-row]") as HTMLElement | null;
     const caretSlot = disclosure.closest("[data-sidebar-collapse-caret-slot]");
     const newThread = screen.getByRole("button", {
       name: "New thread in Nested work",

--- a/apps/app/src/components/sidebar/SidebarSectionRow.tsx
+++ b/apps/app/src/components/sidebar/SidebarSectionRow.tsx
@@ -2,7 +2,6 @@ import {
   memo,
   useCallback,
   useState,
-  type CSSProperties,
   type MouseEvent,
   type MouseEventHandler,
 } from "react";
@@ -18,16 +17,13 @@ import { Icon } from "@bb/shared-ui/icon";
 import { SidebarStickyTier } from "@/components/ui/sidebar.js";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@bb/shared-ui/tooltip";
 import {
-  COARSE_POINTER_COMPACT_ROW_HEIGHT_CLASS,
   COARSE_POINTER_ICON_SIZE_CLASS,
   COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
 } from "@bb/shared-ui/coarse-pointer-sizing";
 import { LIST_HOVER_TRANSITION } from "@bb/shared-ui/motion";
 import {
   SIDEBAR_COLLAPSIBLE_TRAILING_CONTROLS_CLASS,
-  SIDEBAR_COLLAPSE_CARET_SLOT_CLASS,
   SIDEBAR_HOVER_ACTIONS_CLASS,
-  SIDEBAR_HOVER_ACTIONS_FADE_CLASS,
   SIDEBAR_HOVER_ACTIONS_GAP_CLASS,
   SIDEBAR_HOVER_ACTIONS_MOBILE_ALWAYS_VALUE,
   SIDEBAR_HOVER_ACTIONS_ROW_CLASS,
@@ -36,9 +32,7 @@ import { cn } from "@bb/shared-ui/lib/utils";
 import type { CollapsedChildActivity } from "@bb/client-core";
 import {
   SIDEBAR_MORE_ACTION_TRIGGER_CLASS,
-  SIDEBAR_ROW_BASE_CLASS,
   SIDEBAR_ROW_STATIC_STATE_CLASS,
-  getSidebarThreadRowPaddingLeft,
 } from "./sidebarRowClasses";
 import { SidebarChildToggleChevron } from "./SidebarChildToggleChevron";
 import { CollapsedThreadStatusGlyph } from "./ThreadRow";
@@ -50,6 +44,14 @@ import {
 } from "./paneContentSplitIndicator";
 import { SplitPaneMiniMap } from "./SplitPaneMiniMap";
 import { usePluginThreadRowStatusForThreads } from "@/lib/plugin-thread-row-status";
+import { SidebarItemStatusSlot } from "./SidebarItemStatus";
+import {
+  SidebarRow,
+  SidebarRowActions,
+  SidebarRowContent,
+  SidebarRowDisclosureRail,
+  SidebarRowStatusRail,
+} from "./SidebarRow";
 
 const EMPTY_SPLIT_INDICATOR_THREADS: readonly ThreadSplitIndicatorTarget[] = [];
 
@@ -123,16 +125,11 @@ function SidebarSectionRowComponent({
   const className = cn(
     SIDEBAR_HOVER_ACTIONS_ROW_CLASS,
     stickyLevel === undefined && "relative",
-    SIDEBAR_ROW_BASE_CLASS,
     LIST_HOVER_TRANSITION,
     SIDEBAR_ROW_STATIC_STATE_CLASS,
-    COARSE_POINTER_COMPACT_ROW_HEIGHT_CLASS,
     dragBindings && !dragBindings.disabled && "select-none",
     isDropTargetActive && "bg-sidebar-accent text-sidebar-accent-foreground",
   );
-  const style: CSSProperties = {
-    paddingLeft: getSidebarThreadRowPaddingLeft(depth),
-  };
   const handleClickCapture = useCallback<MouseEventHandler<HTMLElement>>(
     (event) => {
       if (!consumeClickSuppression?.()) {
@@ -145,7 +142,6 @@ function SidebarSectionRowComponent({
   );
   const content = (
     <>
-      {}
       <button
         type="button"
         aria-hidden="true"
@@ -153,32 +149,27 @@ function SidebarSectionRowComponent({
         onClick={onToggleCollapsed}
         className="absolute inset-0 rounded-md outline-none ring-sidebar-ring focus-visible:ring-2"
       />
-      <span className="relative z-10 flex min-w-0 flex-1 items-center text-left">
-        <span className="min-w-0 truncate">{name}</span>
-      </span>
-      <span
-        data-sidebar-collapsible-trailing-controls=""
-        className={cn(
-          SIDEBAR_COLLAPSIBLE_TRAILING_CONTROLS_CLASS,
-          "relative z-10 shrink-0",
-          hasActions
-            ? "inline-flex items-center"
-            : COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
-        )}
+      <SidebarRowStatusRail
+        data-sidebar-group-status-slot=""
+        className="relative z-10"
       >
-        {showRollupIndicator ? (
-          <span
-            data-sidebar-collapsed-activity-edge=""
-            data-sidebar-hover-actions-open={isActionsOpen ? "true" : undefined}
-            className={cn(
-              "pointer-events-none absolute inset-0 inline-flex items-center justify-end text-subtle-foreground max-md:pointer-coarse:hidden",
-              hasActions && SIDEBAR_HOVER_ACTIONS_FADE_CLASS,
-            )}
-          >
-            {renderRollupIndicator()}
-          </span>
-        ) : null}
-        {hasActions ? (
+        <SidebarItemStatusSlot
+          status={showRollupIndicator ? "collapsed-rollup" : "none"}
+        >
+          {showRollupIndicator ? renderRollupIndicator() : null}
+        </SidebarItemStatusSlot>
+      </SidebarRowStatusRail>
+      <SidebarRowContent className="relative z-10 flex items-center text-left">
+        <span className="min-w-0 truncate">{name}</span>
+      </SidebarRowContent>
+      {hasActions ? (
+        <SidebarRowActions
+          data-sidebar-collapsible-trailing-controls=""
+          className={cn(
+            SIDEBAR_COLLAPSIBLE_TRAILING_CONTROLS_CLASS,
+            "relative z-10 inline-flex shrink-0 items-center",
+          )}
+        >
           <span
             data-sidebar-hover-actions-open={isActionsOpen ? "true" : undefined}
             data-sidebar-hover-actions-mobile={
@@ -191,12 +182,6 @@ function SidebarSectionRowComponent({
             )}
             onClick={stopActionsClick}
           >
-            <span
-              data-sidebar-mobile-status-slot=""
-              className="hidden h-full w-5 shrink-0 items-center justify-center text-subtle-foreground max-md:pointer-coarse:inline-flex"
-            >
-              {showRollupIndicator ? renderRollupIndicator() : null}
-            </span>
             {onCreateThread ? (
               <Tooltip>
                 <TooltipTrigger asChild>
@@ -268,34 +253,54 @@ function SidebarSectionRowComponent({
               </DropdownMenu>
             ) : null}
           </span>
-        ) : showRollupIndicator ? (
-          <span className="hidden size-full items-center justify-center text-subtle-foreground max-md:pointer-coarse:inline-flex">
-            {renderRollupIndicator()}
-          </span>
-        ) : null}
-      </span>
-      <span
-        data-sidebar-collapse-caret-slot=""
-        className={SIDEBAR_COLLAPSE_CARET_SLOT_CLASS}
-      >
+        </SidebarRowActions>
+      ) : null}
+      <SidebarRowDisclosureRail data-sidebar-collapse-caret-slot="">
         <SidebarChildToggleChevron
           isCollapsed={isCollapsed}
           expandLabel={`Expand ${label} section`}
           collapseLabel={`Collapse ${label} section`}
           onToggle={onToggleCollapsed}
         />
-      </span>
+      </SidebarRowDisclosureRail>
     </>
   );
 
   if (stickyLevel !== undefined) {
     return (
-      <SidebarStickyTier
+      <SidebarRow
+        asChild
+        depth={depth}
+        density="compact"
+        variant="groupLabel"
+      >
+        <SidebarStickyTier
+          ref={dragBindings?.setActivatorNodeRef}
+          tier="parent"
+          level={stickyLevel}
+          className={className}
+          {...dragBindings?.attributes}
+          {...(dragBindings?.listeners ?? {})}
+          onClickCapture={
+            consumeClickSuppression ? handleClickCapture : undefined
+          }
+        >
+          {content}
+        </SidebarStickyTier>
+      </SidebarRow>
+    );
+  }
+
+  return (
+    <SidebarRow
+      asChild
+      depth={depth}
+      density="compact"
+      variant="groupLabel"
+    >
+      <div
         ref={dragBindings?.setActivatorNodeRef}
-        tier="parent"
-        level={stickyLevel}
         className={className}
-        style={style}
         {...dragBindings?.attributes}
         {...(dragBindings?.listeners ?? {})}
         onClickCapture={
@@ -303,21 +308,8 @@ function SidebarSectionRowComponent({
         }
       >
         {content}
-      </SidebarStickyTier>
-    );
-  }
-
-  return (
-    <div
-      ref={dragBindings?.setActivatorNodeRef}
-      className={className}
-      style={style}
-      {...dragBindings?.attributes}
-      {...(dragBindings?.listeners ?? {})}
-      onClickCapture={consumeClickSuppression ? handleClickCapture : undefined}
-    >
-      {content}
-    </div>
+      </div>
+    </SidebarRow>
   );
 }
 

--- a/apps/app/src/components/sidebar/SidebarSectionRow.tsx
+++ b/apps/app/src/components/sidebar/SidebarSectionRow.tsx
@@ -48,6 +48,7 @@ import { SidebarItemStatusSlot } from "./SidebarItemStatus";
 import {
   SidebarRow,
   SidebarRowActions,
+  SidebarRowBody,
   SidebarRowContent,
   SidebarRowDisclosureRail,
   SidebarRowStatusRail,
@@ -159,9 +160,11 @@ function SidebarSectionRowComponent({
           {showRollupIndicator ? renderRollupIndicator() : null}
         </SidebarItemStatusSlot>
       </SidebarRowStatusRail>
-      <SidebarRowContent className="relative z-10 flex items-center text-left">
-        <span className="min-w-0 truncate">{name}</span>
-      </SidebarRowContent>
+      <SidebarRowBody>
+        <SidebarRowContent className="relative z-10 flex items-center text-left">
+          <span className="min-w-0 truncate">{name}</span>
+        </SidebarRowContent>
+      </SidebarRowBody>
       {hasActions ? (
         <SidebarRowActions
           data-sidebar-collapsible-trailing-controls=""

--- a/apps/app/src/components/sidebar/SidebarTopRegionCustomizeMenu.test.tsx
+++ b/apps/app/src/components/sidebar/SidebarTopRegionCustomizeMenu.test.tsx
@@ -90,7 +90,12 @@ describe("SidebarTopRegionCustomizeMenu", () => {
     )) {
       expect(dragIcon.classList.contains("size-4")).toBe(true);
     }
-    expect(screen.getByText("Sidebar order")).toBeDefined();
+    const sidebarOrderLabel = screen.getByText("Sidebar order");
+    expect(sidebarOrderLabel.classList.contains("text-xs")).toBe(true);
+    expect(sidebarOrderLabel.classList.contains("font-normal")).toBe(true);
+    expect(
+      sidebarOrderLabel.classList.contains("text-subtle-foreground/75"),
+    ).toBe(true);
     expect(
       Array.from(
         document.querySelectorAll("[data-sidebar-customize-region]"),

--- a/apps/app/src/components/sidebar/SidebarTopRegionCustomizeMenu.tsx
+++ b/apps/app/src/components/sidebar/SidebarTopRegionCustomizeMenu.tsx
@@ -62,6 +62,8 @@ const REGION_LABELS: Record<SidebarRegionId, string> = {
 const COMPACT_MENU_CONTENT_CLASS =
   "w-44 min-w-44 p-1 [&_[role=menuitem]]:!py-1 [&_[role=menuitemcheckbox]]:!py-1 [&_[role=separator]]:!my-0.5";
 const COMPACT_MENU_LABEL_CLASS = "!px-2 !py-1";
+const CUSTOMIZE_MENU_TITLE_CLASS =
+  "text-sm font-medium leading-5 text-popover-foreground";
 const SORTABLE_ITEM_CLASS = "gap-2 !px-2 !py-1";
 
 const restrictDragToVerticalAxis: Modifier = ({ transform }) => ({
@@ -274,7 +276,10 @@ export function SidebarTopRegionCustomizeMenu({
         mobileTitle="Customize"
       >
         <DropdownMenuLabel
-          className={cn(CHROME_SECTION_LABEL_CLASS, COMPACT_MENU_LABEL_CLASS)}
+          className={cn(
+            CUSTOMIZE_MENU_TITLE_CLASS,
+            COMPACT_MENU_LABEL_CLASS,
+          )}
         >
           Customize
         </DropdownMenuLabel>
@@ -297,10 +302,7 @@ export function SidebarTopRegionCustomizeMenu({
         </div>
         <DropdownMenuSeparator />
         <DropdownMenuLabel
-          className={cn(
-            "text-xs font-medium text-muted-foreground",
-            COMPACT_MENU_LABEL_CLASS,
-          )}
+          className={cn(CHROME_SECTION_LABEL_CLASS, COMPACT_MENU_LABEL_CLASS)}
         >
           Sidebar order
         </DropdownMenuLabel>

--- a/apps/app/src/components/sidebar/SidebarViewOptionsMenu.stories.tsx
+++ b/apps/app/src/components/sidebar/SidebarViewOptionsMenu.stories.tsx
@@ -171,7 +171,17 @@ function usePrototypeSelection(initialGrouping: Grouping = "project") {
 
 type PrototypeSelection = ReturnType<typeof usePrototypeSelection>;
 
-function IconTrigger({ icon, label }: { icon: IconName; label: string }) {
+function IconTrigger({
+  fillIcon = false,
+  icon,
+  label,
+  pressed,
+}: {
+  fillIcon?: boolean;
+  icon: IconName;
+  label: string;
+  pressed?: boolean;
+}) {
   return (
     <DropdownMenuTrigger asChild>
       <Button
@@ -179,13 +189,20 @@ function IconTrigger({ icon, label }: { icon: IconName; label: string }) {
         variant="ghost"
         size="icon"
         aria-label={label}
+        aria-pressed={pressed}
         className={cn(
           "rounded-md p-0 data-[state=open]:bg-sidebar-accent",
           PROTOTYPE_ACTION_TONE_CLASS,
           COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
         )}
       >
-        <Icon name={icon} className={COARSE_POINTER_ICON_SIZE_CLASS} />
+        <Icon
+          name={icon}
+          className={cn(
+            COARSE_POINTER_ICON_SIZE_CLASS,
+            fillIcon && "[&_path]:fill-current",
+          )}
+        />
       </Button>
     </DropdownMenuTrigger>
   );
@@ -675,7 +692,7 @@ function CustomizeSidebarMenu({
       >
         <DropdownMenuLabel
           className={cn(
-            CHROME_SECTION_LABEL_CLASS,
+            "text-sm font-medium leading-5 text-popover-foreground",
             PROTOTYPE_COMPACT_MENU_LABEL_CLASS,
           )}
         >
@@ -709,7 +726,7 @@ function CustomizeSidebarMenu({
         <DropdownMenuSeparator />
         <DropdownMenuLabel
           className={cn(
-            "text-xs font-medium text-muted-foreground",
+            CHROME_SECTION_LABEL_CLASS,
             PROTOTYPE_COMPACT_MENU_LABEL_CLASS,
           )}
         >
@@ -914,7 +931,7 @@ function PluginSidebarRow({
             </DropdownMenuItem>
             <DropdownMenuItem>
               <Icon name="Info" aria-hidden="true" />
-              Detail page
+              View details
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem disabled={index === 0}>
@@ -954,7 +971,11 @@ function PluginsSection() {
   );
 }
 
-function ThreadToolbarOverflow({ grouping }: { grouping: Grouping }) {
+function ThreadToolbarAdditionalActions({ grouping }: { grouping: Grouping }) {
+  if (grouping !== "manual") {
+    return <RowActionIcon icon="FolderPlus" label="New project" />;
+  }
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -979,15 +1000,11 @@ function ThreadToolbarOverflow({ grouping }: { grouping: Grouping }) {
         align="end"
         className={PROTOTYPE_COMPACT_MENU_CONTENT_CLASS}
       >
-        {grouping === "manual" ? (
-          <>
-            <DropdownMenuItem>
-              <Icon name="SectionAdd" aria-hidden="true" />
-              New section
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-          </>
-        ) : null}
+        <DropdownMenuItem>
+          <Icon name="SectionAdd" aria-hidden="true" />
+          New section
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
         <DropdownMenuItem>
           <Icon name="FolderPlus" aria-hidden="true" />
           New project
@@ -1402,7 +1419,7 @@ function ThreadListSection({
             </DropdownMenuContent>
           </DropdownMenu>
           <RowActionIcon icon="MessageSquarePlus" label="New thread" />
-          <ThreadToolbarOverflow grouping={state.grouping} />
+          <ThreadToolbarAdditionalActions grouping={state.grouping} />
         </span>
         {stickyToolbar ? (
           <OverflowFade placement="below" tone="sidebar" size="sm" />

--- a/apps/app/src/components/sidebar/ThreadRow.stories.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.stories.tsx
@@ -281,7 +281,7 @@ const childThread = makeThread({
 export function Overview() {
   return (
     <StoryCard>
-      <StoryRow label="idle" hint="quiet thread, title then trailing slot">
+      <StoryRow label="idle" hint="quiet thread reserves its leading status slot">
         <SidebarStage>
           <StoryThreadRow
             projectId="proj_demo"
@@ -523,7 +523,7 @@ export function Overview() {
       </StoryRow>
       <StoryRow
         label="draft + unread"
-        hint="the persistent draft pencil owns the trailing slot instead of the unread dot"
+        hint="the persistent draft pencil owns the leading status slot instead of the unread dot"
       >
         <SidebarStage>
           <StoryThreadRow
@@ -580,7 +580,7 @@ export function Overview() {
       </StoryRow>
       <StoryRow
         label="long title + draft"
-        hint="title truncates before the right-aligned draft icon"
+        hint="title truncates while the leading draft icon stays fixed"
       >
         <SidebarStage>
           <StoryThreadRow
@@ -733,7 +733,7 @@ export function Overview() {
       </StoryRow>
       <StoryRow
         label="parent, collapsed — child working"
-        hint="trailing slot shows the Loading03 working spinner when a hidden child is working"
+        hint="leading status slot shows the Loading03 working spinner when a hidden child is working"
       >
         <SidebarStage>
           <StoryThreadRow
@@ -751,7 +751,7 @@ export function Overview() {
       </StoryRow>
       <StoryRow
         label="parent, collapsed — child needs input"
-        hint="trailing slot shows the grey question icon when a hidden child is blocked on the user"
+        hint="leading status slot shows the grey question icon when a hidden child is blocked on the user"
       >
         <SidebarStage>
           <StoryThreadRow
@@ -769,7 +769,7 @@ export function Overview() {
       </StoryRow>
       <StoryRow
         label="parent, collapsed — needs input + working"
-        hint="input needed wins priority over working: the trailing slot shows the grey question icon, not the spinner"
+        hint="input needed wins priority over working: the leading status slot shows the grey question icon, not the spinner"
       >
         <SidebarStage>
           <StoryThreadRow
@@ -893,7 +893,7 @@ export function SplitViewStatus() {
       <StoryCard>
         <StoryRow
           label="idle split"
-          hint="pane mini-map occupies the trailing status slot"
+          hint="pane mini-map occupies the leading status slot"
         >
           <SidebarStage>
             <StoryThreadRow
@@ -911,7 +911,7 @@ export function SplitViewStatus() {
         </StoryRow>
         <StoryRow
           label="working split"
-          hint="the same trailing pane mini-map shimmers while work is active"
+          hint="the same leading pane mini-map shimmers while work is active"
         >
           <SidebarStage>
             <StoryThreadRow

--- a/apps/app/src/components/sidebar/ThreadRow.test.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.test.tsx
@@ -915,8 +915,12 @@ describe("ThreadRow", () => {
     const disclosure = screen.getByRole("button", {
       name: "Collapse Parent thread threads",
     });
-    expect(disclosure.getAttribute("data-sidebar-hover-actions-mobile")).toBe(
-      "always",
+    expect(
+      disclosure.getAttribute("data-sidebar-hover-actions-mobile"),
+    ).toBeNull();
+    expect(disclosure.classList.contains("pointer-events-auto")).toBe(true);
+    expect(disclosure.classList.contains("bb-sidebar-hover-actions")).toBe(
+      false,
     );
     expect(disclosure.classList.contains("text-subtle-foreground/75")).toBe(
       true,

--- a/apps/app/src/components/sidebar/ThreadRow.test.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.test.tsx
@@ -356,7 +356,7 @@ describe("ThreadRow", () => {
       const splitMap = screen.getByRole("img", { name: /open in split/ });
       expect(Array.from(splitMap.classList)).toContain("animate-shine-icon");
       expect(
-        splitMap.closest("[data-sidebar-thread-trailing-indicator]"),
+        splitMap.closest("[data-sidebar-item-status-slot]"),
       ).not.toBeNull();
       expect(container.querySelector('[data-icon="Loading"]')).toBeNull();
     },
@@ -422,13 +422,13 @@ describe("ThreadRow", () => {
     },
   );
 
-  it("puts the draft icon in the trailing status slot", () => {
+  it("puts the draft icon in the fixed status rail", () => {
     const { container } = renderThreadRow({ hasComposerDraft: true });
 
     const draftIcon = container.querySelector('[data-icon="Edit"]');
     expect(draftIcon).not.toBeNull();
     expect(
-      draftIcon?.closest("[data-sidebar-thread-trailing-indicator]"),
+      draftIcon?.closest('[data-sidebar-row-slot="status"]'),
     ).not.toBeNull();
     expect(
       screen.getByRole("link", { name: "Open Thread (unsubmitted draft)" }),
@@ -553,7 +553,7 @@ describe("ThreadRow", () => {
     expect(Array.from(runningIcon.classList)).toContain("animate-spin");
     expect(screen.queryByLabelText("Plugin improving draft")).toBeNull();
     expect(
-      container.querySelector("[data-sidebar-thread-trailing-indicator]"),
+      container.querySelector('[data-sidebar-item-status="runtime"]'),
     ).not.toBeNull();
   });
 
@@ -776,7 +776,7 @@ describe("ThreadRow", () => {
     expect(marker?.classList.contains("text-muted-foreground/75")).toBe(true);
     expect(marker?.classList.contains("text-muted-foreground")).toBe(false);
     expect(
-      marker?.closest("[data-sidebar-thread-trailing-indicator]"),
+      marker?.closest('[data-sidebar-row-slot="status"]'),
     ).toBeNull();
     expect(
       screen.getByRole("link", { name: "Open Thread" }).getAttribute("href"),
@@ -927,27 +927,20 @@ describe("ThreadRow", () => {
     ).toBe(true);
     const caretSlot = disclosure.closest("[data-sidebar-collapse-caret-slot]");
     const row = caretSlot?.parentElement;
-    const trailingControls = row?.querySelector(
-      "[data-sidebar-thread-trailing-controls]",
-    );
-    const statusSlot = trailingControls?.querySelector(
-      "[data-sidebar-thread-status-slot]",
-    );
-    const mobileActions = trailingControls?.querySelector(
+    const statusSlot = row?.querySelector('[data-sidebar-row-slot="status"]');
+    const mobileActions = row?.querySelector(
       "[data-sidebar-mobile-row-actions]",
     );
     const titleRegion = screen
       .getByTitle("Parent thread")
-      .closest(".bb-sidebar-collapsible-hover-actions-inset");
+      .closest('[data-sidebar-row-slot="content"]');
 
-    expect(caretSlot?.classList.contains("w-6")).toBe(true);
+    expect(caretSlot?.getAttribute("data-sidebar-row-slot")).toBe(
+      "disclosure",
+    );
     expect(row?.lastElementChild).toBe(caretSlot);
-    expect(trailingControls?.nextElementSibling).toBe(caretSlot);
     expect(
-      statusSlot?.classList.contains("bb-sidebar-collapsible-status-slot"),
-    ).toBe(true);
-    expect(
-      statusSlot!.compareDocumentPosition(mobileActions!) &
+      statusSlot!.compareDocumentPosition(caretSlot!) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).not.toBe(0);
     expect(
@@ -957,14 +950,14 @@ describe("ThreadRow", () => {
       mobileActions?.querySelector('[aria-label="Thread actions"]'),
     ).not.toBeNull();
     expect(
-      mobileActions
-        ?.querySelector('[aria-label="Archive thread"]')
+      statusSlot
+        ?.querySelector("[data-sidebar-item-status-hover-action]")
         ?.classList.contains("max-md:pointer-coarse:hidden"),
     ).toBe(true);
     expect(titleRegion).not.toBeNull();
-    expect(
-      titleRegion?.classList.contains("bb-sidebar-hover-actions-inset"),
-    ).toBe(false);
+    expect(titleRegion?.getAttribute("data-sidebar-row-slot")).toBe(
+      "content",
+    );
   });
 
   it("shows its desktop Command shortcut while preserving the mobile active indicator", () => {

--- a/apps/app/src/components/sidebar/ThreadRow.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.tsx
@@ -82,6 +82,7 @@ import { SidebarItemStatusSlot } from "./SidebarItemStatus";
 import {
   SidebarRow,
   SidebarRowActions,
+  SidebarRowBody,
   SidebarRowContent,
   SidebarRowDisclosureRail,
   SidebarRowStatusRail,
@@ -740,41 +741,43 @@ function ThreadRowComponent({
           )}
         </SidebarItemStatusSlot>
       </SidebarRowStatusRail>
-      <SidebarRowContent className="flex items-center gap-1.5">
-        {isEditing ? (
-          <span className="relative z-10 min-w-0 flex-1 overflow-visible">
-            {editor}
-          </span>
-        ) : (
-          <span
-            className="min-w-0 truncate"
-            title={labelTitle}
-            onDoubleClick={startTitleEditing}
-          >
-            <ThreadTitleMentions title={threadTitle} />
-          </span>
-        )}
-        {crossProjectLabel !== null ? (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span
-                data-sidebar-thread-cross-project=""
-                role="img"
-                aria-label={crossProjectLabel}
-                className="relative top-px z-10 flex shrink-0 items-center text-muted-foreground/75"
-                onClick={(event) => {
-                  event.preventDefault();
-                  event.stopPropagation();
-                  rowLinkRef.current?.click();
-                }}
-              >
-                <Icon name="FolderExport" className="size-3.5" aria-hidden />
-              </span>
-            </TooltipTrigger>
-            <TooltipContent side="top">{crossProjectLabel}</TooltipContent>
-          </Tooltip>
-        ) : null}
-      </SidebarRowContent>
+      <SidebarRowBody>
+        <SidebarRowContent className="flex items-center gap-1.5">
+          {isEditing ? (
+            <span className="relative z-10 min-w-0 flex-1 overflow-visible">
+              {editor}
+            </span>
+          ) : (
+            <span
+              className="min-w-0 truncate"
+              title={labelTitle}
+              onDoubleClick={startTitleEditing}
+            >
+              <ThreadTitleMentions title={threadTitle} />
+            </span>
+          )}
+          {crossProjectLabel !== null ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span
+                  data-sidebar-thread-cross-project=""
+                  role="img"
+                  aria-label={crossProjectLabel}
+                  className="relative top-px z-10 flex shrink-0 items-center text-muted-foreground/75"
+                  onClick={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    rowLinkRef.current?.click();
+                  }}
+                >
+                  <Icon name="FolderExport" className="size-3.5" aria-hidden />
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="top">{crossProjectLabel}</TooltipContent>
+            </Tooltip>
+          ) : null}
+        </SidebarRowContent>
+      </SidebarRowBody>
       <SidebarRowActions
         data-sidebar-thread-trailing-controls=""
         className="relative flex shrink-0 items-center"
@@ -826,7 +829,6 @@ function ThreadRowComponent({
             expandLabel={`Expand ${labelTitle} threads`}
             collapseLabel={`Collapse ${labelTitle} threads`}
             onToggle={() => parentOptions.onToggleCollapsed(thread.id)}
-            revealOnHover
           />
         </SidebarRowDisclosureRail>
       ) : null}

--- a/apps/app/src/components/sidebar/ThreadRow.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.tsx
@@ -2,7 +2,6 @@ import {
   memo,
   useCallback,
   useState,
-  type CSSProperties,
   type MouseEventHandler,
   type PointerEventHandler,
   type ReactNode,
@@ -28,15 +27,9 @@ import {
   COARSE_POINTER_GLYPH_BOX_CLASS,
   COARSE_POINTER_ICON_SIZE_CLASS,
   COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
-  COARSE_POINTER_ROW_HEIGHT_CLASS,
 } from "@bb/shared-ui/coarse-pointer-sizing";
 import {
-  SIDEBAR_COLLAPSIBLE_HOVER_ACTIONS_INSET_CLASS,
-  SIDEBAR_COLLAPSIBLE_STATUS_SLOT_CLASS,
-  SIDEBAR_COLLAPSE_CARET_SLOT_CLASS,
   SIDEBAR_HOVER_ACTIONS_CLASS,
-  SIDEBAR_HOVER_ACTIONS_FADE_CLASS,
-  SIDEBAR_HOVER_ACTIONS_INSET_CLASS,
   SIDEBAR_HOVER_ACTIONS_MOBILE_ALWAYS_VALUE,
   SIDEBAR_HOVER_ACTIONS_ROW_CLASS,
 } from "@/components/ui/sidebar-hover-actions.js";
@@ -60,18 +53,15 @@ import { getThreadRoutePath } from "@/lib/route-paths";
 import { cn } from "@bb/shared-ui/lib/utils";
 import { LIST_HOVER_TRANSITION } from "@bb/shared-ui/motion";
 import {
-  SIDEBAR_ROW_BASE_CLASS,
   SIDEBAR_ROW_GLYPH_SLOT_CLASS,
   SIDEBAR_ROW_INTERACTIVE_STATE_CLASS,
   SIDEBAR_ROW_SELECTED_STATE_CLASS,
   SIDEBAR_MORE_ACTION_TRIGGER_CLASS,
-  SIDEBAR_PAIRED_ACTION_LEADING_TARGET_CLASS,
-  SIDEBAR_PAIRED_ACTION_TRAILING_TARGET_CLASS,
   SIDEBAR_ROW_OPEN_IN_SPLIT_STATE_CLASS,
+  SIDEBAR_IDLE_STATUS_COLOR_CLASS,
   SIDEBAR_SUCCESS_STATUS_COLOR_CLASS,
   SIDEBAR_SUCCESS_STATUS_DOT_CLASS,
   SIDEBAR_WORKING_STATUS_COLOR_CLASS,
-  getSidebarThreadRowPaddingLeft,
 } from "./sidebarRowClasses";
 import type { ConsumeDragClickSuppression } from "@/components/ui/use-drag-click-suppression";
 import type { SidebarSortableDragBindings } from "./sortableMotion";
@@ -88,6 +78,14 @@ import {
 } from "@/components/thread/ThreadTitleMentions";
 import { pluginIconName } from "@/components/plugin/PluginIcon";
 import { usePluginThreadRowStatus } from "@/lib/plugin-thread-row-status";
+import { SidebarItemStatusSlot } from "./SidebarItemStatus";
+import {
+  SidebarRow,
+  SidebarRowActions,
+  SidebarRowContent,
+  SidebarRowDisclosureRail,
+  SidebarRowStatusRail,
+} from "./SidebarRow";
 
 const SIDEBAR_TITLE_DOUBLE_CLICK_MS = 400;
 
@@ -143,11 +141,12 @@ type ThreadRowClickCaptureHandler = MouseEventHandler<HTMLDivElement>;
 interface ThreadRowContainerArgs {
   children: ReactNode;
   className: string;
+  depth: number;
   dragBindings?: SidebarSortableDragBindings;
+  isCompact: boolean;
   onClickCapture?: ThreadRowClickCaptureHandler;
   onSplitDragPointerDown?: PointerEventHandler<HTMLElement>;
   stickyLevel?: number;
-  style: CSSProperties;
 }
 
 function ThreadDraftIndicator({
@@ -168,7 +167,7 @@ function ThreadDraftIndicator({
         COARSE_POINTER_ICON_SIZE_CLASS,
         isWorking
           ? ["animate-shine-icon", SIDEBAR_WORKING_STATUS_COLOR_CLASS]
-          : "text-muted-foreground",
+          : SIDEBAR_IDLE_STATUS_COLOR_CLASS,
       )}
       {...(!isWorking && hideIdleLabel
         ? { "aria-hidden": true }
@@ -221,51 +220,58 @@ function PluginThreadRowStatusIndicator({
   );
 }
 
-function getThreadRowStyle(depth: number): CSSProperties {
-  return {
-    paddingLeft: getSidebarThreadRowPaddingLeft(depth),
-  };
-}
-
 function renderThreadRowContainer({
   children,
   className,
+  depth,
   dragBindings,
+  isCompact,
   onClickCapture,
   onSplitDragPointerDown,
   stickyLevel,
-  style,
 }: ThreadRowContainerArgs) {
   if (stickyLevel !== undefined) {
     return (
-      <SidebarStickyTier
+      <SidebarRow
+        asChild
+        depth={depth}
+        density={isCompact ? "compact" : "standard"}
+        variant="item"
+      >
+        <SidebarStickyTier
+          ref={dragBindings?.setActivatorNodeRef}
+          tier="parent"
+          level={stickyLevel}
+          className={className}
+          {...dragBindings?.attributes}
+          {...(dragBindings?.listeners ?? {})}
+          onClickCapture={onClickCapture}
+          onPointerDown={onSplitDragPointerDown}
+        >
+          {children}
+        </SidebarStickyTier>
+      </SidebarRow>
+    );
+  }
+
+  return (
+    <SidebarRow
+      asChild
+      depth={depth}
+      density={isCompact ? "compact" : "standard"}
+      variant="item"
+    >
+      <div
         ref={dragBindings?.setActivatorNodeRef}
-        tier="parent"
-        level={stickyLevel}
         className={className}
-        style={style}
         {...dragBindings?.attributes}
         {...(dragBindings?.listeners ?? {})}
         onClickCapture={onClickCapture}
         onPointerDown={onSplitDragPointerDown}
       >
         {children}
-      </SidebarStickyTier>
-    );
-  }
-
-  return (
-    <div
-      ref={dragBindings?.setActivatorNodeRef}
-      className={className}
-      style={style}
-      {...dragBindings?.attributes}
-      {...(dragBindings?.listeners ?? {})}
-      onClickCapture={onClickCapture}
-      onPointerDown={onSplitDragPointerDown}
-    >
-      {children}
-    </div>
+      </div>
+    </SidebarRow>
   );
 }
 
@@ -433,7 +439,7 @@ export function CollapsedThreadStatusGlyph({
     isRuntimeActive: activity.runtimeWorking,
     isWorkflowActive: activity.workflow,
   };
-  const { pluginStatusIsVisible } = resolveThreadTrailingIndicatorStatus(
+  const { pluginStatusIsVisible } = resolveThreadRowIndicatorStatus(
     statusProps,
     pluginStatus,
   );
@@ -444,20 +450,20 @@ export function CollapsedThreadStatusGlyph({
 
   return <ThreadStatusGlyph {...statusProps} />;
 }
-type ThreadTrailingIndicatorProps = ThreadStatusGlyphProps & {
+type ThreadRowIndicatorProps = ThreadStatusGlyphProps & {
   pluginStatus: PluginComposerThreadRowStatus | null;
 };
 
-interface ThreadTrailingIndicatorResolution {
+interface ThreadRowIndicatorResolution {
   accessibleLabel: string | null;
   indicatorKind: ReturnType<typeof resolveThreadListIndicator>;
   pluginStatusIsVisible: boolean;
 }
 
-function resolveThreadTrailingIndicatorStatus(
+function resolveThreadRowIndicatorStatus(
   statusProps: ThreadStatusGlyphProps,
   pluginStatus: PluginComposerThreadRowStatus | null,
-): ThreadTrailingIndicatorResolution {
+): ThreadRowIndicatorResolution {
   const indicatorKind = resolveThreadListIndicator(statusProps);
   const pluginStatusIsVisible =
     pluginStatus !== null &&
@@ -474,12 +480,12 @@ function resolveThreadTrailingIndicatorStatus(
   };
 }
 
-function ThreadTrailingIndicator({
+function ThreadRowIndicator({
   pluginStatus,
   ...statusProps
-}: ThreadTrailingIndicatorProps) {
+}: ThreadRowIndicatorProps) {
   const { indicatorKind, pluginStatusIsVisible } =
-    resolveThreadTrailingIndicatorStatus(statusProps, pluginStatus);
+    resolveThreadRowIndicatorStatus(statusProps, pluginStatus);
 
   if (indicatorKind === "none" && !pluginStatusIsVisible) {
     return null;
@@ -487,7 +493,7 @@ function ThreadTrailingIndicator({
 
   return (
     <span
-      data-sidebar-thread-trailing-indicator=""
+      data-sidebar-thread-status-indicator=""
       className={cn(
         SIDEBAR_ROW_GLYPH_SLOT_CLASS,
         COARSE_POINTER_GLYPH_BOX_CLASS,
@@ -578,59 +584,59 @@ function ThreadRowComponent({
     parentOptions?.childActivity ?? NO_COLLAPSED_CHILD_ACTIVITY;
   const hasChildren = childCount > 0;
   const hasHiddenChildren = isParentRow && isParentCollapsed && hasChildren;
-  const trailingHasPendingInteraction = hasHiddenChildren
+  const rowHasPendingInteraction = hasHiddenChildren
     ? hasPendingInteraction || childActivity.pending
     : hasPendingInteraction;
-  const trailingRuntimeBusy = hasHiddenChildren
+  const rowRuntimeBusy = hasHiddenChildren
     ? threadRuntimeBusy || childActivity.runtimeWorking
     : threadRuntimeBusy;
-  const trailingIsWorkflowActive = hasHiddenChildren
+  const rowIsWorkflowActive = hasHiddenChildren
     ? threadWorkflowActive || childActivity.workflow
     : threadWorkflowActive;
-  const trailingBackgroundAgentActive = hasHiddenChildren
+  const rowBackgroundAgentActive = hasHiddenChildren
     ? threadBackgroundAgentActive || childActivity.backgroundAgent
     : threadBackgroundAgentActive;
-  const trailingBackgroundCommandActive = hasHiddenChildren
+  const rowBackgroundCommandActive = hasHiddenChildren
     ? threadBackgroundCommandActive || childActivity.backgroundCommand
     : threadBackgroundCommandActive;
-  const trailingPlanModeActive = hasHiddenChildren
+  const rowPlanModeActive = hasHiddenChildren
     ? threadPlanModeActive || childActivity.planMode
     : threadPlanModeActive;
-  const trailingGoalActive = hasHiddenChildren
+  const rowGoalActive = hasHiddenChildren
     ? threadGoalActive || childActivity.goal
     : threadGoalActive;
-  const trailingHasUnreadError = hasHiddenChildren
+  const rowHasUnreadError = hasHiddenChildren
     ? threadUnreadError || childActivity.unreadError
     : threadUnreadError;
-  const trailingHasUnreadSuccess = hasHiddenChildren
+  const rowHasUnreadSuccess = hasHiddenChildren
     ? threadUnreadSuccess || childActivity.unread
     : threadUnreadSuccess;
-  const trailingHasUnsubmittedDraft = hasHiddenChildren
+  const rowHasUnsubmittedDraft = hasHiddenChildren
     ? hasComposerDraft || childActivity.hasUnsubmittedDraft
     : hasComposerDraft;
-  const trailingIndicatorState: ThreadListIndicatorState = {
-    hasPendingInteraction: trailingHasPendingInteraction,
-    hasUnsubmittedDraft: trailingHasUnsubmittedDraft,
-    hasUnreadError: trailingHasUnreadError,
-    hasUnreadSuccess: trailingHasUnreadSuccess,
-    isBackgroundAgentActive: trailingBackgroundAgentActive,
-    isBackgroundCommandActive: trailingBackgroundCommandActive,
-    isGoalActive: trailingGoalActive,
-    isPlanModeActive: trailingPlanModeActive,
-    isRuntimeActive: trailingRuntimeBusy,
-    isWorkflowActive: trailingIsWorkflowActive,
+  const rowIndicatorState: ThreadListIndicatorState = {
+    hasPendingInteraction: rowHasPendingInteraction,
+    hasUnsubmittedDraft: rowHasUnsubmittedDraft,
+    hasUnreadError: rowHasUnreadError,
+    hasUnreadSuccess: rowHasUnreadSuccess,
+    isBackgroundAgentActive: rowBackgroundAgentActive,
+    isBackgroundCommandActive: rowBackgroundCommandActive,
+    isGoalActive: rowGoalActive,
+    isPlanModeActive: rowPlanModeActive,
+    isRuntimeActive: rowRuntimeBusy,
+    isWorkflowActive: rowIsWorkflowActive,
   };
-  const trailingIndicatorResolution = resolveThreadTrailingIndicatorStatus(
-    trailingIndicatorState,
+  const rowIndicatorResolution = resolveThreadRowIndicatorStatus(
+    rowIndicatorState,
     pluginThreadRowStatus,
   );
-  const trailingIndicatorKind = trailingIndicatorResolution.indicatorKind;
+  const rowIndicatorKind = rowIndicatorResolution.indicatorKind;
   const splitIndicatorIsWorking = hasThreadListWorkingActivity(
-    trailingIndicatorState,
+    rowIndicatorState,
     pluginThreadRowStatus?.tone === "running",
   );
-  const splitIndicatorLabel = trailingIndicatorResolution.accessibleLabel
-    ? `${labelTitle} — open in split; ${trailingIndicatorResolution.accessibleLabel}`
+  const splitIndicatorLabel = rowIndicatorResolution.accessibleLabel
+    ? `${labelTitle} — open in split; ${rowIndicatorResolution.accessibleLabel}`
     : `${labelTitle} — open in split`;
   const linkLabel = hasComposerDraft
     ? `Open ${labelTitle} (unsubmitted draft)`
@@ -639,12 +645,8 @@ function ThreadRowComponent({
   const rowClassName = cn(
     SIDEBAR_HOVER_ACTIONS_ROW_CLASS,
     "group/thread-row",
-    SIDEBAR_ROW_BASE_CLASS,
     LIST_HOVER_TRANSITION,
     parentOptions?.stickyLevel === undefined && "relative",
-    options.isCompact
-      ? COARSE_POINTER_COMPACT_ROW_HEIGHT_CLASS
-      : COARSE_POINTER_ROW_HEIGHT_CLASS,
     showActive
       ? SIDEBAR_ROW_SELECTED_STATE_CLASS
       : SIDEBAR_ROW_INTERACTIVE_STATE_CLASS,
@@ -654,7 +656,6 @@ function ThreadRowComponent({
     !showActive && "has-[[data-state=open]]:bg-sidebar-accent",
     rowDragBindings && !rowDragBindings.disabled && "select-none",
   );
-  const rowStyle = getThreadRowStyle(options.depth);
   const isActionsOpen = isDropdownActionsOpen || isContextActionsOpen;
   const handleRowClickCapture = useCallback<ThreadRowClickCaptureHandler>(
     (event) => {
@@ -700,22 +701,53 @@ function ThreadRowComponent({
         aria-keyshortcuts={shortcut?.ariaKeyshortcuts}
         className="absolute inset-0 rounded-md outline-none ring-sidebar-ring focus-visible:ring-2"
       />
-      <span
-        className={cn(
-          "flex min-w-0 flex-1 items-center gap-1.5",
-          !shortcut &&
-            (parentOptions && hasChildren
-              ? SIDEBAR_COLLAPSIBLE_HOVER_ACTIONS_INSET_CLASS
-              : SIDEBAR_HOVER_ACTIONS_INSET_CLASS),
-        )}
-      >
+      <SidebarRowStatusRail data-sidebar-thread-status-column="">
+        <SidebarItemStatusSlot
+          status={
+            splitIndicator.miniMap
+              ? "split"
+              : rowIndicatorResolution.pluginStatusIsVisible
+                ? "plugin"
+                : rowIndicatorKind
+          }
+          tooltip={
+            !splitIndicator.miniMap &&
+            !rowIndicatorResolution.pluginStatusIsVisible &&
+            rowIndicatorKind === "draft"
+              ? "Draft"
+              : undefined
+          }
+          onActivate={() => rowLinkRef.current?.click()}
+          hoverAction={
+            <ThreadArchiveQuickAction
+              thread={thread}
+              className="size-4 rounded-sm text-subtle-foreground hover:bg-transparent hover:text-foreground [&_svg]:size-3.5"
+            />
+          }
+        >
+          {splitIndicator.miniMap ? (
+            <SplitPaneMiniMap
+              slots={splitIndicator.miniMap}
+              label={splitIndicatorLabel}
+              isWorking={splitIndicatorIsWorking}
+            />
+          ) : (
+            <ThreadRowIndicator
+              {...rowIndicatorState}
+              hideIdleDraftLabel={rowIndicatorKind === "draft"}
+              pluginStatus={pluginThreadRowStatus}
+            />
+          )}
+        </SidebarItemStatusSlot>
+      </SidebarRowStatusRail>
+      <SidebarRowContent className="flex items-center gap-1.5">
         {isEditing ? (
           <span className="relative z-10 min-w-0 flex-1 overflow-visible">
             {editor}
           </span>
         ) : (
           <span
-            className="bb-sidebar-thread-title min-w-0 truncate"
+            className="min-w-0 truncate"
             title={labelTitle}
             onDoubleClick={startTitleEditing}
           >
@@ -742,97 +774,25 @@ function ThreadRowComponent({
             <TooltipContent side="top">{crossProjectLabel}</TooltipContent>
           </Tooltip>
         ) : null}
-      </span>
-      <span
+      </SidebarRowContent>
+      <SidebarRowActions
         data-sidebar-thread-trailing-controls=""
-        className="relative flex shrink-0 items-center gap-0.5"
+        className="relative flex shrink-0 items-center"
       >
         {shortcut ? (
-          <>
-            <span className="max-md:pointer-coarse:hidden">
-              <AppCommandShortcutPill shortcut={shortcut} />
-            </span>
-            <span
-              data-sidebar-thread-status-slot=""
-              className="hidden h-9 w-5 shrink-0 items-center justify-center max-md:pointer-coarse:flex"
-            >
-              {splitIndicator.miniMap ? (
-                <span
-                  data-sidebar-thread-trailing-indicator=""
-                  className={cn(
-                    SIDEBAR_ROW_GLYPH_SLOT_CLASS,
-                    COARSE_POINTER_GLYPH_BOX_CLASS,
-                  )}
-                >
-                  <SplitPaneMiniMap
-                    slots={splitIndicator.miniMap}
-                    label={splitIndicatorLabel}
-                    isWorking={splitIndicatorIsWorking}
-                  />
-                </span>
-              ) : (
-                <ThreadTrailingIndicator
-                  {...trailingIndicatorState}
-                  hideIdleDraftLabel={
-                    !hasHiddenChildren && trailingIndicatorKind === "draft"
-                  }
-                  pluginStatus={pluginThreadRowStatus}
-                />
-              )}
-            </span>
-          </>
+          <span className="max-md:pointer-coarse:hidden">
+            <AppCommandShortcutPill shortcut={shortcut} />
+          </span>
         ) : (
           <span
-            data-sidebar-thread-status-slot=""
+            data-sidebar-thread-action-slot=""
             className={cn(
-              "flex shrink-0 items-center justify-end",
+              "shrink-0",
               COARSE_POINTER_COMPACT_ROW_HEIGHT_CLASS,
-              parentOptions &&
-                hasChildren &&
-                SIDEBAR_COLLAPSIBLE_STATUS_SLOT_CLASS,
+              COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
             )}
-          >
-            <span
-              className={cn(
-                "relative shrink-0",
-                COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
-              )}
-            >
-              <span
-                data-sidebar-hover-actions-open={
-                  isActionsOpen ? "true" : undefined
-                }
-                className={cn(
-                  SIDEBAR_HOVER_ACTIONS_FADE_CLASS,
-                  "absolute inset-0 flex items-center justify-center max-md:pointer-coarse:!opacity-100",
-                )}
-              >
-                {splitIndicator.miniMap ? (
-                  <span
-                    data-sidebar-thread-trailing-indicator=""
-                    className={cn(
-                      SIDEBAR_ROW_GLYPH_SLOT_CLASS,
-                      COARSE_POINTER_GLYPH_BOX_CLASS,
-                    )}
-                  >
-                    <SplitPaneMiniMap
-                      slots={splitIndicator.miniMap}
-                      label={splitIndicatorLabel}
-                      isWorking={splitIndicatorIsWorking}
-                    />
-                  </span>
-                ) : (
-                  <ThreadTrailingIndicator
-                    {...trailingIndicatorState}
-                    hideIdleDraftLabel={
-                      !hasHiddenChildren && trailingIndicatorKind === "draft"
-                    }
-                    pluginStatus={pluginThreadRowStatus}
-                  />
-                )}
-              </span>
-            </span>
-          </span>
+            aria-hidden="true"
+          />
         )}
         <div
           data-sidebar-mobile-row-actions=""
@@ -848,32 +808,19 @@ function ThreadRowComponent({
               "absolute inset-y-0 right-0 z-10 flex items-center justify-end max-md:pointer-coarse:relative max-md:pointer-coarse:inset-auto",
           )}
         >
-          <ThreadArchiveQuickAction
-            thread={thread}
-            className={cn(
-              "text-subtle-foreground hover:bg-transparent hover:text-foreground max-md:pointer-coarse:hidden",
-              SIDEBAR_MORE_ACTION_TRIGGER_CLASS,
-              "-mr-0.5",
-              SIDEBAR_PAIRED_ACTION_LEADING_TARGET_CLASS,
-            )}
-          />
           <ThreadActionsMenu
             thread={thread}
             triggerClassName={cn(
               "text-subtle-foreground hover:bg-transparent hover:text-foreground",
               SIDEBAR_MORE_ACTION_TRIGGER_CLASS,
-              SIDEBAR_PAIRED_ACTION_TRAILING_TARGET_CLASS,
             )}
             onOpenInSplit={splitAvailable ? openInSplit : undefined}
             onOpenChange={setIsDropdownActionsOpen}
           />
         </div>
-      </span>
+      </SidebarRowActions>
       {parentOptions && hasChildren ? (
-        <span
-          data-sidebar-collapse-caret-slot=""
-          className={SIDEBAR_COLLAPSE_CARET_SLOT_CLASS}
-        >
+        <SidebarRowDisclosureRail data-sidebar-collapse-caret-slot="">
           <SidebarChildToggleChevron
             isCollapsed={isParentCollapsed}
             expandLabel={`Expand ${labelTitle} threads`}
@@ -881,7 +828,7 @@ function ThreadRowComponent({
             onToggle={() => parentOptions.onToggleCollapsed(thread.id)}
             revealOnHover
           />
-        </span>
+        </SidebarRowDisclosureRail>
       ) : null}
     </>
   );
@@ -889,13 +836,14 @@ function ThreadRowComponent({
   const row = renderThreadRowContainer({
     children: rowContent,
     className: rowClassName,
+    depth: options.depth,
     dragBindings: rowDragBindings,
+    isCompact: options.isCompact,
     onClickCapture: options.consumeClickSuppression
       ? handleRowClickCapture
       : undefined,
     onSplitDragPointerDown,
     stickyLevel: parentOptions?.stickyLevel,
-    style: rowStyle,
   });
 
   return (

--- a/apps/app/src/components/sidebar/TopLevelSidebarSection.tsx
+++ b/apps/app/src/components/sidebar/TopLevelSidebarSection.tsx
@@ -11,25 +11,18 @@ import { cn } from "@bb/shared-ui/lib/utils";
 import { Icon, type IconName } from "@bb/shared-ui/icon";
 import { COARSE_POINTER_ICON_SIZE_CLASS } from "@bb/shared-ui/coarse-pointer-sizing";
 import { LIST_HOVER_TRANSITION } from "@bb/shared-ui/motion";
-import { CHROME_SECTION_LABEL_CLASS } from "@bb/shared-ui/chrome-style-tokens";
 import {
   SidebarStickyGroup,
   SidebarStickyTier,
 } from "@/components/ui/sidebar.js";
 import {
   SIDEBAR_COLLAPSIBLE_TRAILING_CONTROLS_CLASS,
-  SIDEBAR_COLLAPSE_CARET_SLOT_CLASS,
   SIDEBAR_HOVER_ACTIONS_CLASS,
-  SIDEBAR_HOVER_ACTIONS_FADE_CLASS,
   SIDEBAR_HOVER_ACTIONS_GAP_CLASS,
   SIDEBAR_HOVER_ACTIONS_MOBILE_ALWAYS_VALUE,
   SIDEBAR_HOVER_ACTIONS_ROW_CLASS,
 } from "@/components/ui/sidebar-hover-actions.js";
 import type { ConsumeDragClickSuppression } from "@/components/ui/use-drag-click-suppression";
-import {
-  SIDEBAR_LEADING_GLYPH_SLOT_CLASS,
-  SIDEBAR_STANDARD_ROW_PADDING_CLASS,
-} from "./sidebarRowClasses";
 import type { SidebarSortableDragBindings } from "./sortableMotion";
 import {
   NO_COLLAPSED_CHILD_ACTIVITY,
@@ -42,6 +35,16 @@ import {
 } from "./paneContentSplitIndicator";
 import { SplitPaneMiniMap } from "./SplitPaneMiniMap";
 import { usePluginThreadRowStatusForThreads } from "@/lib/plugin-thread-row-status";
+import { SidebarItemStatusSlot } from "./SidebarItemStatus";
+import {
+  SidebarRow,
+  SidebarRowActions,
+  SidebarRowContent,
+  SidebarRowDisclosureRail,
+  SidebarRowIdentityRail,
+  SidebarRowStatusRail,
+  type SidebarRowVariant,
+} from "./SidebarRow";
 
 const EMPTY_SPLIT_INDICATOR_THREADS: readonly ThreadSplitIndicatorTarget[] = [];
 
@@ -71,6 +74,7 @@ export interface TopLevelSidebarSectionProps {
   sectionStyle?: CSSProperties;
   consumeClickSuppression?: ConsumeDragClickSuppression;
   isDropTargetActive?: boolean;
+  rowVariant?: SidebarRowVariant;
 }
 
 export function TopLevelSidebarSection({
@@ -90,6 +94,7 @@ export function TopLevelSidebarSection({
   sectionStyle,
   consumeClickSuppression,
   isDropTargetActive = false,
+  rowVariant = "groupLabel",
 }: TopLevelSidebarSectionProps) {
   const collapsedSplitIndicator = useThreadGroupSplitIndicator(
     collapsedThreads,
@@ -158,136 +163,108 @@ export function TopLevelSidebarSection({
       )}
       onClickCapture={handleClickCapture}
     >
-      <SidebarStickyTier
-        ref={dragBindings?.setActivatorNodeRef}
-        tier="label"
-        className={cn(
-          SIDEBAR_HOVER_ACTIONS_ROW_CLASS,
-          CHROME_SECTION_LABEL_CLASS,
-          SIDEBAR_STANDARD_ROW_PADDING_CLASS,
-          "rounded-md pr-0 font-medium transition-colors",
-          dragBindings && !dragBindings.disabled && "select-none",
-        )}
-        {...dragBindings?.attributes}
-        {...(dragBindings?.listeners ?? {})}
-      >
-        <span className="relative z-10 flex min-w-0 flex-1 items-center gap-2 text-left">
+      <SidebarRow asChild density="label" variant={rowVariant}>
+        <SidebarStickyTier
+          ref={dragBindings?.setActivatorNodeRef}
+          tier="label"
+          className={cn(
+            SIDEBAR_HOVER_ACTIONS_ROW_CLASS,
+            "rounded-md pr-0 transition-colors",
+            dragBindings && !dragBindings.disabled && "select-none",
+          )}
+          {...dragBindings?.attributes}
+          {...(dragBindings?.listeners ?? {})}
+        >
           {leadingIcon ? (
-            <span
-              className={cn(
-                SIDEBAR_LEADING_GLYPH_SLOT_CLASS,
-                "text-subtle-foreground",
-              )}
-            >
+            <SidebarRowIdentityRail className="relative z-10 text-subtle-foreground">
               <Icon
                 name={leadingIcon}
                 className={COARSE_POINTER_ICON_SIZE_CLASS}
                 aria-hidden="true"
               />
-            </span>
+            </SidebarRowIdentityRail>
           ) : null}
-          <span className="min-w-0 truncate" title={label}>
-            {label}
-          </span>
-        </span>
-        {actions || showCollapsedIndicator ? (
-          <span
-            data-sidebar-collapsible-trailing-controls=""
-            className={cn(
-              SIDEBAR_COLLAPSIBLE_TRAILING_CONTROLS_CLASS,
-              "relative z-20 h-6",
-              !actions && "w-7",
-            )}
-            onClick={stopActionsClick}
+          <SidebarRowContent className="relative z-10 flex items-center text-left">
+            <span className="min-w-0 truncate" title={label}>
+              {label}
+            </span>
+          </SidebarRowContent>
+          <SidebarRowStatusRail
+            data-sidebar-group-status-slot=""
+            className="relative z-20 inline-flex shrink-0 items-center"
           >
-            {showCollapsedIndicator ? (
+            {collapseControl ? (
+              <SidebarItemStatusSlot
+                status={showCollapsedIndicator ? "collapsed-rollup" : "none"}
+              >
+                {showCollapsedIndicator ? renderCollapsedIndicator() : null}
+              </SidebarItemStatusSlot>
+            ) : null}
+          </SidebarRowStatusRail>
+          {actions ? (
+            <SidebarRowActions
+              data-sidebar-collapsible-trailing-controls=""
+              className={cn(
+                SIDEBAR_COLLAPSIBLE_TRAILING_CONTROLS_CLASS,
+                "relative z-20 h-6",
+              )}
+              onClick={stopActionsClick}
+            >
               <span
-                data-sidebar-collapsed-activity-edge=""
                 data-sidebar-hover-actions-open={
                   actionsOpen ? "true" : undefined
                 }
+                data-sidebar-hover-actions-mobile={
+                  actionsMobileAlways
+                    ? SIDEBAR_HOVER_ACTIONS_MOBILE_ALWAYS_VALUE
+                    : undefined
+                }
                 className={cn(
-                  "pointer-events-none absolute inset-0 z-20 inline-flex items-center justify-end text-subtle-foreground",
-                  actions
-                    ? "max-md:pointer-coarse:hidden"
-                    : "max-md:pointer-coarse:relative max-md:pointer-coarse:inset-auto max-md:pointer-coarse:shrink-0 max-md:pointer-coarse:justify-center",
-                  actions && SIDEBAR_HOVER_ACTIONS_FADE_CLASS,
+                  "inline-flex shrink-0 items-center",
+                  SIDEBAR_HOVER_ACTIONS_GAP_CLASS,
+                  !actionsAlwaysVisible && SIDEBAR_HOVER_ACTIONS_CLASS,
                 )}
               >
-                {renderCollapsedIndicator()}
+                {actions}
               </span>
-            ) : null}
-            {actions ? (
-              <>
-                {collapseControl ? (
-                  <span
-                    data-sidebar-mobile-status-slot=""
-                    className="hidden h-full w-5 shrink-0 items-center justify-center text-subtle-foreground max-md:pointer-coarse:inline-flex"
-                  >
-                    {showCollapsedIndicator
-                      ? renderCollapsedIndicator()
-                      : null}
-                  </span>
-                ) : null}
-                <span
-                  data-sidebar-hover-actions-open={
-                    actionsOpen ? "true" : undefined
-                  }
-                  data-sidebar-hover-actions-mobile={
-                    actionsMobileAlways
-                      ? SIDEBAR_HOVER_ACTIONS_MOBILE_ALWAYS_VALUE
-                      : undefined
-                  }
-                  className={cn(
-                    "inline-flex shrink-0 items-center",
-                    SIDEBAR_HOVER_ACTIONS_GAP_CLASS,
-                    !actionsAlwaysVisible && SIDEBAR_HOVER_ACTIONS_CLASS,
-                  )}
-                >
-                  {actions}
-                </span>
-              </>
-            ) : null}
-          </span>
-        ) : null}
-        {collapseControl ? (
-          <span
-            data-sidebar-collapse-caret-slot=""
-            className={SIDEBAR_COLLAPSE_CARET_SLOT_CLASS}
-          >
-            <button
-              type="button"
-              data-sidebar-collapse-caret=""
-              aria-expanded={!collapseControl.isCollapsed}
-              data-sidebar-hover-actions-mobile={
-                SIDEBAR_HOVER_ACTIONS_MOBILE_ALWAYS_VALUE
-              }
-              aria-label={
-                collapseControl.isCollapsed
-                  ? `Expand ${label} section`
-                  : `Collapse ${label} section`
-              }
-              className={cn(
-                !collapseControl.isCollapsed && SIDEBAR_HOVER_ACTIONS_CLASS,
-                "relative z-20 inline-flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-md text-subtle-foreground/75 outline-none ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2",
-                LIST_HOVER_TRANSITION,
-              )}
-              onClick={handleCollapseControlClick}
-              onPointerDown={stopCollapseControlPointerDown}
-              onKeyDown={stopCollapseControlKeyDown}
-            >
-              <Icon
-                name="ChevronRight"
+            </SidebarRowActions>
+          ) : null}
+          {collapseControl ? (
+            <SidebarRowDisclosureRail data-sidebar-collapse-caret-slot="">
+              <button
+                type="button"
+                data-sidebar-collapse-caret=""
+                aria-expanded={!collapseControl.isCollapsed}
+                data-sidebar-hover-actions-mobile={
+                  SIDEBAR_HOVER_ACTIONS_MOBILE_ALWAYS_VALUE
+                }
+                aria-label={
+                  collapseControl.isCollapsed
+                    ? `Expand ${label} section`
+                    : `Collapse ${label} section`
+                }
                 className={cn(
-                  "size-3 transition-transform duration-150",
-                  !collapseControl.isCollapsed && "rotate-90",
+                  !collapseControl.isCollapsed && SIDEBAR_HOVER_ACTIONS_CLASS,
+                  "relative z-20 inline-flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-md text-subtle-foreground/75 outline-none ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2",
+                  LIST_HOVER_TRANSITION,
                 )}
-                aria-hidden="true"
-              />
-            </button>
-          </span>
-        ) : null}
-      </SidebarStickyTier>
+                onClick={handleCollapseControlClick}
+                onPointerDown={stopCollapseControlPointerDown}
+                onKeyDown={stopCollapseControlKeyDown}
+              >
+                <Icon
+                  name="ChevronRight"
+                  className={cn(
+                    "size-3 transition-transform duration-150",
+                    !collapseControl.isCollapsed && "rotate-90",
+                  )}
+                  aria-hidden="true"
+                />
+              </button>
+            </SidebarRowDisclosureRail>
+          ) : null}
+        </SidebarStickyTier>
+      </SidebarRow>
       {collapseControl?.isCollapsed || children == null ? null : (
         <div className="mt-1">{children}</div>
       )}

--- a/apps/app/src/components/sidebar/TopLevelSidebarSection.tsx
+++ b/apps/app/src/components/sidebar/TopLevelSidebarSection.tsx
@@ -39,6 +39,7 @@ import { SidebarItemStatusSlot } from "./SidebarItemStatus";
 import {
   SidebarRow,
   SidebarRowActions,
+  SidebarRowBody,
   SidebarRowContent,
   SidebarRowDisclosureRail,
   SidebarRowIdentityRail,
@@ -175,20 +176,6 @@ export function TopLevelSidebarSection({
           {...dragBindings?.attributes}
           {...(dragBindings?.listeners ?? {})}
         >
-          {leadingIcon ? (
-            <SidebarRowIdentityRail className="relative z-10 text-subtle-foreground">
-              <Icon
-                name={leadingIcon}
-                className={COARSE_POINTER_ICON_SIZE_CLASS}
-                aria-hidden="true"
-              />
-            </SidebarRowIdentityRail>
-          ) : null}
-          <SidebarRowContent className="relative z-10 flex items-center text-left">
-            <span className="min-w-0 truncate" title={label}>
-              {label}
-            </span>
-          </SidebarRowContent>
           <SidebarRowStatusRail
             data-sidebar-group-status-slot=""
             className="relative z-20 inline-flex shrink-0 items-center"
@@ -201,6 +188,22 @@ export function TopLevelSidebarSection({
               </SidebarItemStatusSlot>
             ) : null}
           </SidebarRowStatusRail>
+          <SidebarRowBody>
+            {leadingIcon ? (
+              <SidebarRowIdentityRail className="relative z-10 text-subtle-foreground">
+                <Icon
+                  name={leadingIcon}
+                  className={COARSE_POINTER_ICON_SIZE_CLASS}
+                  aria-hidden="true"
+                />
+              </SidebarRowIdentityRail>
+            ) : null}
+            <SidebarRowContent className="relative z-10 flex items-center text-left">
+              <span className="min-w-0 truncate" title={label}>
+                {label}
+              </span>
+            </SidebarRowContent>
+          </SidebarRowBody>
           {actions ? (
             <SidebarRowActions
               data-sidebar-collapsible-trailing-controls=""
@@ -244,7 +247,6 @@ export function TopLevelSidebarSection({
                     : `Collapse ${label} section`
                 }
                 className={cn(
-                  !collapseControl.isCollapsed && SIDEBAR_HOVER_ACTIONS_CLASS,
                   "relative z-20 inline-flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-md text-subtle-foreground/75 outline-none ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2",
                   LIST_HOVER_TRANSITION,
                 )}

--- a/apps/app/src/components/sidebar/sidebarRowClasses.ts
+++ b/apps/app/src/components/sidebar/sidebarRowClasses.ts
@@ -1,8 +1,11 @@
 import { COARSE_POINTER_DOT_SIZE_CLASS } from "@bb/shared-ui/coarse-pointer-sizing";
 import { CONTEXT_SELECTION_SURFACE_CLASS } from "@/components/ui/context-selection";
 
-export const SIDEBAR_ROW_BASE_CLASS =
-  "flex w-full items-center gap-2 rounded-md pr-0 text-sm transition-colors";
+export const SIDEBAR_VIEW_HEADER_LABEL_CLASS =
+  "text-xs font-semibold text-muted-foreground";
+
+export const SIDEBAR_GROUP_LABEL_CLASS =
+  "text-xs font-medium leading-5 text-subtle-foreground/75";
 
 export const SIDEBAR_ROW_GLYPH_SLOT_CLASS =
   "inline-flex shrink-0 items-center justify-center text-subtle-foreground";
@@ -16,28 +19,13 @@ export const SIDEBAR_SUCCESS_STATUS_COLOR_CLASS = "text-success-foreground";
 export const SIDEBAR_SUCCESS_STATUS_DOT_CLASS =
   "size-[5px] rounded-full bg-muted-foreground/60 max-md:pointer-coarse:size-1.5";
 
+export const SIDEBAR_IDLE_STATUS_COLOR_CLASS = "text-muted-foreground/60";
+
 export const SIDEBAR_LEADING_GLYPH_SLOT_CLASS =
-  "inline-flex w-4 shrink-0 items-center justify-center";
+  "inline-flex w-[var(--sidebar-row-identity-rail,1rem)] shrink-0 items-center justify-center max-md:pointer-coarse:w-[var(--sidebar-row-identity-rail,1.25rem)]";
 
-const SIDEBAR_THREAD_ROW_BASE_PADDING_PX = 8;
-const SIDEBAR_THREAD_ROW_DEPTH_STEP_PX = 24;
-const SIDEBAR_THREAD_ROW_GLYPH_CENTER_OFFSET_PX = 8;
-
-export const SIDEBAR_STANDARD_ROW_PADDING_CLASS = "pl-2";
-
-export function getSidebarThreadRowPaddingLeft(depth: number): number {
-  return (
-    SIDEBAR_THREAD_ROW_BASE_PADDING_PX +
-    depth * SIDEBAR_THREAD_ROW_DEPTH_STEP_PX
-  );
-}
-
-export function getSidebarThreadGroupLineLeft(depth: number): number {
-  return (
-    getSidebarThreadRowPaddingLeft(depth) +
-    SIDEBAR_THREAD_ROW_GLYPH_CENTER_OFFSET_PX
-  );
-}
+export const SIDEBAR_STANDARD_ROW_PADDING_CLASS =
+  "pl-[var(--sidebar-row-inline-padding,0.5rem)]";
 
 export const SIDEBAR_ROW_INTERACTIVE_STATE_CLASS =
   "cursor-pointer text-sidebar-foreground/85 dark:text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground";
@@ -53,11 +41,11 @@ export const SIDEBAR_ROW_OPEN_IN_SPLIT_STATE_CLASS =
 export const SIDEBAR_MORE_ACTION_TRIGGER_CLASS =
   "relative m-1 h-5 w-5 after:absolute after:left-1/2 after:top-1/2 after:h-7 after:w-7 after:-translate-x-1/2 after:-translate-y-1/2 after:content-[''] max-md:pointer-coarse:m-0 max-md:pointer-coarse:h-9 max-md:pointer-coarse:w-9 max-md:pointer-coarse:after:hidden";
 
-export const SIDEBAR_PAIRED_ACTION_LEADING_TARGET_CLASS =
-  "after:-left-1 after:-right-px after:w-auto after:translate-x-0";
+export const SIDEBAR_TERTIARY_ROW_ACTION_SIZE_CLASS =
+  "h-6 w-6 max-md:pointer-coarse:h-9 max-md:pointer-coarse:w-9";
 
-export const SIDEBAR_PAIRED_ACTION_TRAILING_TARGET_CLASS =
-  "after:-left-px after:-right-1 after:w-auto after:translate-x-0";
+export const SIDEBAR_TERTIARY_MORE_ACTION_TRIGGER_CLASS =
+  "m-0 h-6 w-6 max-md:pointer-coarse:h-9 max-md:pointer-coarse:w-9";
 
 export const SIDEBAR_PROJECT_GROUP_LINE_CLASS =
   "before:pointer-events-none before:absolute before:bottom-0 before:left-4 before:top-0 before:z-[45] before:w-px before:bg-border-hairline before:opacity-70 before:content-[''] max-md:pointer-coarse:before:left-5";

--- a/apps/app/src/components/ui/sidebar-hover-actions.ts
+++ b/apps/app/src/components/ui/sidebar-hover-actions.ts
@@ -2,13 +2,14 @@ export const SIDEBAR_HOVER_ACTIONS_ROW_CLASS = "bb-sidebar-hover-actions-row";
 
 export const SIDEBAR_HOVER_ACTIONS_CLASS = "bb-sidebar-hover-actions";
 
-export const SIDEBAR_HOVER_ACTIONS_GAP_CLASS = "gap-0.5";
+export const SIDEBAR_HOVER_ACTIONS_GAP_CLASS =
+  "gap-[var(--sidebar-row-action-gap,0.125rem)]";
 
 export const SIDEBAR_COLLAPSIBLE_TRAILING_CONTROLS_CLASS =
   "bb-sidebar-collapsible-trailing-controls inline-flex shrink-0 items-center";
 
 export const SIDEBAR_COLLAPSE_CARET_SLOT_CLASS =
-  "bb-sidebar-collapse-caret-slot inline-flex h-full w-6 shrink-0 items-center justify-center";
+  "bb-sidebar-collapse-caret-slot inline-flex h-full w-[var(--sidebar-row-disclosure-rail,1.5rem)] shrink-0 items-center justify-center";
 
 export const SIDEBAR_COLLAPSIBLE_HOVER_ACTIONS_INSET_CLASS =
   "bb-sidebar-collapsible-hover-actions-inset";

--- a/apps/app/src/lib/plugin-nav-panel-chrome.ts
+++ b/apps/app/src/lib/plugin-nav-panel-chrome.ts
@@ -17,7 +17,7 @@ const pluginNavPanelChromeSchema = z.object({
 
 export type PluginNavPanelChrome = z.infer<typeof pluginNavPanelChromeSchema>;
 
-interface PluginNavPanelChromeEntry {
+export interface PluginNavPanelChromeEntry {
   chrome: PluginNavPanelChrome;
   panel: PluginNavPanelSlot | null;
 }

--- a/packages/client-core/src/sidebar/sidebarSectionOrder.ts
+++ b/packages/client-core/src/sidebar/sidebarSectionOrder.ts
@@ -71,6 +71,11 @@ export function normalizeSidebarSectionOrder({
   const normalized: SidebarSectionId[] = [];
   let expandedLegacyAnchor = false;
 
+  if (hasPinnedSection) {
+    seen.add("pinned");
+    normalized.push("pinned");
+  }
+
   const append = (sectionId: SidebarSectionId) => {
     if (!available.has(sectionId) || seen.has(sectionId)) {
       return;
@@ -90,11 +95,6 @@ export function normalizeSidebarSectionOrder({
     if (isSidebarSectionId(storedId)) {
       append(storedId);
     }
-  }
-
-  if (hasPinnedSection && !seen.has("pinned")) {
-    normalized.unshift("pinned");
-    seen.add("pinned");
   }
 
   const missingEntities = entitySectionIds.filter(

--- a/packages/client-core/test/sidebarSectionOrder.test.ts
+++ b/packages/client-core/test/sidebarSectionOrder.test.ts
@@ -9,7 +9,7 @@ describe("normalizeSidebarSectionOrder", () => {
   const projectA = buildSidebarEntitySectionId("project", "a");
   const projectB = buildSidebarEntitySectionId("project", "b");
 
-  it("expands the legacy aggregate section without changing its placement", () => {
+  it("expands the legacy aggregate section while keeping Pinned first", () => {
     expect(
       normalizeSidebarSectionOrder({
         storedOrder: ["threads", "projects", "pinned"],
@@ -17,10 +17,10 @@ describe("normalizeSidebarSectionOrder", () => {
         legacyEntityAnchor: "projects",
         hasPinnedSection: true,
       }),
-    ).toEqual(["threads", projectA, projectB, "pinned"]);
+    ).toEqual(["pinned", "threads", projectA, projectB]);
   });
 
-  it("preserves a free mixed order of built-ins and entities", () => {
+  it("keeps Pinned first while preserving the remaining mixed order", () => {
     expect(
       normalizeSidebarSectionOrder({
         storedOrder: [projectB, "pinned", "threads", projectA],
@@ -28,7 +28,7 @@ describe("normalizeSidebarSectionOrder", () => {
         legacyEntityAnchor: "projects",
         hasPinnedSection: true,
       }),
-    ).toEqual([projectB, "pinned", "threads", projectA]);
+    ).toEqual(["pinned", projectB, "threads", projectA]);
   });
 
   it("drops removed entities and appends new ones after existing entities", () => {


### PR DESCRIPTION
## Human comments

## What was wrong

Sidebar rows independently owned status, identity, action, and disclosure placement. That made equivalent icons drift between project, machine, worktree, section, and lifecycle rows; it also let hover actions compete with the thread title's natural open target. Even after the outer rails were standardized, rows with folder/worktree icons consumed an identity slot while plain thread rows skipped it, allowing a nested thread title to begin left of its parent label. The thread-list view switcher was icon-only and therefore did not communicate which organization mode was active.

## What changed

- Standardized tree rows on one presentation-only `SidebarRow` geometry: `status | body | actions | disclosure`.
- Kept status in one fixed left rail and disclosure carets in one fixed right rail across row types and collapsed states; identity and depth now belong to the body column.
- Reserved the same identity track in every tree-row body, including rows without an identity glyph, so title alignment depends only on depth rather than optional content.
- Reduced the shared nesting step from 24px to 12px so nested lists stay compact without moving either fixed rail.
- Moved the thread archive quick action into the fixed status rail and moved lifecycle hover actions into the action rail, avoiding hover-time title movement.
- Made disclosure carets persistent and quiet rather than changing row anatomy on hover.
- Updated the existing view trigger to identify the current organization mode with the matching Projects, Machines, or Custom icon plus a chevron, accessible label, and tooltip; menu behavior and labels are unchanged.
- Expanded the production `ProjectList` story matrix across Project, Custom, and Machine views at 320px and 240px widths.

## Before

_Screenshot upload pending._

## After

_Screenshot upload pending._

## How you verified

- Chrome for Testing 151.0.7922.71 against the exact branch web app at 1280×1000.
- Exercised Project, Machine, and Custom views; collapsed and expanded project/worktree groups; unread/status rows; thread hover/archive; hard reload and persisted view selection; and light, dark, and system-dark themes.
- DOM geometry inspection confirmed every rendered status rail at `x=16` with a 14px layout width and every rendered disclosure rail at `x=287` with a 24px layout width. Carets remained visible, row heights remained 24/28px, and the archive hover control occupied the status rail without shifting the title.
- Reproduced the optional-identity indentation defect in the live seeded sidebar, then recaptured the corrected state: project, worktree, and direct-thread titles use one body spine, while genuinely nested worktree threads advance by the shared 12px depth step.
- Confirmed the view trigger reports `View: Projects` to accessibility APIs and changes icon/label with the selected view. No runtime exceptions or console errors were observed in the changed flows.
- Remote CI run 33482308631 passed all app, package, integration, and server tests; build, typecheck, lint, version guards, and Linux/macOS package smoke checks.
- Mobile E2E was skipped by workflow path filtering because this layer does not change the compact drawer implementation.
- Local Ladle launch was attempted twice through the repository's story command but stopped at `EMFILE: too many open files, watch`; story registration therefore remains covered by source review and remote build/typecheck rather than a local rendered Ladle pass.

Fixes: N/A — stacked follow-up to the sidebar/navigation work.

BB-Thread-ID: thr_ccffp4w2p2

> AGENT GENERATED
