### PR TITLE
Fix collapsed sidebar activity on mobile

### DIFF
--- a/apps/app/src/components/sidebar/ProjectListSectionHeader.test.tsx
+++ b/apps/app/src/components/sidebar/ProjectListSectionHeader.test.tsx
@@ -146,6 +146,44 @@ describe("TopLevelSidebarSection", () => {
     ).not.toBe(0);
   });
 
+  it("keeps collapsed activity inside the trailing controls slot", () => {
+    render(
+      <TopLevelSidebarSection
+        label="TODO"
+        actions={
+          <>
+            <button type="button">Display</button>
+            <button type="button">Actions</button>
+            <button type="button">New thread</button>
+          </>
+        }
+        actionsAlwaysVisible
+        actionsMobileAlways
+        collapsedActivity={{
+          ...NO_COLLAPSED_CHILD_ACTIVITY,
+          working: true,
+          runtimeWorking: true,
+        }}
+        collapseControl={{ isCollapsed: true, onToggleCollapsed: vi.fn() }}
+      >
+        <div>Active thread</div>
+      </TopLevelSidebarSection>,
+    );
+
+    const indicator = screen.getByLabelText("Thread working");
+    const activitySlot = indicator.closest(
+      "[data-sidebar-collapsed-activity-edge]",
+    );
+    const trailingControls = activitySlot?.parentElement;
+
+    expect(
+      trailingControls?.hasAttribute("data-sidebar-trailing-controls"),
+    ).toBe(true);
+    expect(trailingControls?.className).toContain("relative");
+    expect(activitySlot?.className).toContain("max-md:static");
+    expect(screen.queryByText("Active thread")).toBeNull();
+  });
+
   it("rolls a hidden split thread up to a collapsed top-level section", () => {
     const store = createStore();
     store.set(splitLayoutAtom, {

--- a/apps/app/src/components/sidebar/TopLevelSidebarSection.tsx
+++ b/apps/app/src/components/sidebar/TopLevelSidebarSection.tsx
@@ -89,6 +89,37 @@ export function TopLevelSidebarSection({
     collapseControl?.isCollapsed === true,
   );
   const pluginStatus = usePluginThreadRowStatusForThreads(collapsedThreads);
+  const showCollapsedActivity =
+    collapseControl?.isCollapsed === true &&
+    (collapsedSplitIndicator.miniMap !== null ||
+      collapsedActivity !== undefined ||
+      pluginStatus !== null);
+  const collapsedActivityIndicator = showCollapsedActivity ? (
+    <span
+      data-sidebar-collapsed-activity-edge=""
+      data-sidebar-hover-actions-open={actionsOpen ? "true" : undefined}
+      className={cn(
+        "pointer-events-none absolute right-0 top-1/2 z-20 inline-flex -translate-y-1/2 items-center justify-center text-subtle-foreground max-md:static max-md:shrink-0 max-md:translate-y-0",
+        COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
+        actions && SIDEBAR_HOVER_ACTIONS_FADE_CLASS,
+      )}
+    >
+      {collapsedSplitIndicator.miniMap ? (
+        <SplitPaneMiniMap
+          slots={collapsedSplitIndicator.miniMap}
+          label={`${label} — contains a thread open in split`}
+          isWorking={
+            collapsedActivity?.working || pluginStatus?.tone === "running"
+          }
+        />
+      ) : collapsedActivity || pluginStatus ? (
+        <CollapsedThreadStatusGlyph
+          activity={collapsedActivity ?? NO_COLLAPSED_CHILD_ACTIVITY}
+          pluginStatus={pluginStatus}
+        />
+      ) : null}
+    </span>
+  ) : null;
   const handleClickCapture = useCallback<MouseEventHandler<HTMLDivElement>>(
     (event) => {
       if (!consumeClickSuppression?.()) {
@@ -180,55 +211,32 @@ export function TopLevelSidebarSection({
             </button>
           ) : null}
         </span>
-        {collapseControl?.isCollapsed &&
-        (collapsedSplitIndicator.miniMap !== null ||
-          collapsedActivity ||
-          pluginStatus) ? (
+        {actions || collapsedActivityIndicator ? (
           <span
-            data-sidebar-collapsed-activity-edge=""
-            data-sidebar-hover-actions-open={actionsOpen ? "true" : undefined}
-            className={cn(
-              "pointer-events-none absolute right-0 top-1/2 z-20 inline-flex -translate-y-1/2 items-center justify-center text-subtle-foreground max-md:pointer-coarse:relative max-md:pointer-coarse:right-auto max-md:pointer-coarse:top-auto max-md:pointer-coarse:shrink-0 max-md:pointer-coarse:translate-y-0",
-              COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
-              actions && SIDEBAR_HOVER_ACTIONS_FADE_CLASS,
-            )}
-          >
-            {collapsedSplitIndicator.miniMap ? (
-              <SplitPaneMiniMap
-                slots={collapsedSplitIndicator.miniMap}
-                label={`${label} — contains a thread open in split`}
-                isWorking={
-                  collapsedActivity?.working || pluginStatus?.tone === "running"
-                }
-              />
-            ) : collapsedActivity || pluginStatus ? (
-              <CollapsedThreadStatusGlyph
-                activity={collapsedActivity ?? NO_COLLAPSED_CHILD_ACTIVITY}
-                pluginStatus={pluginStatus}
-              />
-            ) : null}
-          </span>
-        ) : null}
-        {actions ? (
-          <span
+            data-sidebar-trailing-controls=""
             className="relative z-20 inline-flex h-6 shrink-0 items-center"
-            onClick={stopActionsClick}
+            onClick={actions ? stopActionsClick : undefined}
           >
-            <span
-              data-sidebar-hover-actions-open={actionsOpen ? "true" : undefined}
-              data-sidebar-hover-actions-mobile={
-                actionsMobileAlways
-                  ? SIDEBAR_HOVER_ACTIONS_MOBILE_ALWAYS_VALUE
-                  : undefined
-              }
-              className={cn(
-                "inline-flex shrink-0 items-center",
-                SIDEBAR_HOVER_ACTIONS_GAP_CLASS,
-                !actionsAlwaysVisible && SIDEBAR_HOVER_ACTIONS_CLASS,
-              )}
-            >
-              {actions}
-            </span>
+            {collapsedActivityIndicator}
+            {actions ? (
+              <span
+                data-sidebar-hover-actions-open={
+                  actionsOpen ? "true" : undefined
+                }
+                data-sidebar-hover-actions-mobile={
+                  actionsMobileAlways
+                    ? SIDEBAR_HOVER_ACTIONS_MOBILE_ALWAYS_VALUE
+                    : undefined
+                }
+                className={cn(
+                  "inline-flex shrink-0 items-center",
+                  SIDEBAR_HOVER_ACTIONS_GAP_CLASS,
+                  !actionsAlwaysVisible && SIDEBAR_HOVER_ACTIONS_CLASS,
+                )}
+              >
+                {actions}
+              </span>
+            ) : null}
           </span>
         ) : null}
       </SidebarStickyTier>


### PR DESCRIPTION
## Human comments

## What was wrong

Top-level sidebar sections rendered collapsed child activity as an absolutely positioned sibling of the section actions. The indicator only switched into normal flow when both the compact breakpoint and a coarse pointer matched, so a mobile-width drawer with a fine or remote pointer kept the desktop overlay and allowed the activity glyph to collide with the trailing controls.

## What changed

The collapsed activity indicator now lives inside a stable, relatively positioned trailing-controls container. At compact widths it becomes an in-flow status cell regardless of pointer type; at desktop widths it remains pinned to the trailing edge and keeps the existing hover fade behavior. A regression test covers a collapsed working section with three visible actions. This is UI-only: there are no wire, CLI, guide, or documentation changes.

## How you verified

- `pnpm exec turbo run test --filter=@bb/app -- src/components/sidebar/ProjectListSectionHeader.test.tsx` (8 tests pass; the new containment assertion fails before the fix)
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run lint --filter=@bb/app` (0 errors)
- `dev-browser` before/after capture at a 376px compact viewport with a fine pointer
- `git diff --check origin/main...HEAD`

> AGENT GENERATED
