### PR TITLE
Preserve user questions across daemon reconnects

### DIFF
--- a/apps/server/src/internal/session-owner-side-effects.ts
+++ b/apps/server/src/internal/session-owner-side-effects.ts
@@ -104,14 +104,11 @@ export async function handleHostSessionOpened(
       });
     }
 
-    interruptPendingInteractionsForHostThreads(deps, {
-      hostId: args.hostId,
-      reason: sameDaemonInstance
-        ? DAEMON_DISCONNECTED_PENDING_INTERACTION_REASON
-        : DAEMON_RESTARTED_PENDING_INTERACTION_REASON,
-    });
-
     if (!sameDaemonInstance) {
+      interruptPendingInteractionsForHostThreads(deps, {
+        hostId: args.hostId,
+        reason: DAEMON_RESTARTED_PENDING_INTERACTION_REASON,
+      });
       interruptActiveThreadsForHost(deps, {
         hostId: args.hostId,
         reason: "host-daemon-restarted",

--- a/apps/server/test/services/pending-interactions.test.ts
+++ b/apps/server/test/services/pending-interactions.test.ts
@@ -638,7 +638,7 @@ describe("pending interaction lifecycle", () => {
     });
   });
 
-  it("interrupts resolving interactions when a replacement session reuses the same instance id", async () => {
+  it("preserves pending interactions when the same daemon instance reconnects", async () => {
     await withTestHarness(async (harness) => {
       const { host, session } = seedHostSession(harness.deps, {
         id: "host-pending-interaction-same-instance-reconnect",
@@ -671,14 +671,6 @@ describe("pending interaction lifecycle", () => {
           `Expected interaction registration to succeed: ${created.reason}`,
         );
       }
-      harness.deps.pendingInteractions.resolvePendingInteraction({
-        threadId: thread.id,
-        interactionId: created.interaction.id,
-        resolution: createUserAnswerResolution({
-          freeText: "Use the existing branch.",
-        }),
-      });
-
       const replacementSession = seedSession(harness.deps, host.id);
       await handleHostSessionOpened(harness.deps, {
         activeThreads: [],
@@ -693,9 +685,8 @@ describe("pending interaction lifecycle", () => {
         .where(eq(pendingInteractionTable.id, created.interaction.id))
         .get();
       expect(row).toMatchObject({
-        status: "interrupted",
-        statusReason:
-          "Host daemon disconnected while awaiting user interaction; retry the thread to continue",
+        status: "pending",
+        statusReason: null,
       });
     });
   });


### PR DESCRIPTION
## What was wrong

A transient same-process host-daemon reconnect interrupted every pending provider interaction in the server database. The daemon intentionally keeps its in-memory provider waiter across that reconnect, so the server hid the question while the provider continued waiting forever. The thread then looked active with no command and no pending interaction.

This was reproduced after Connect tunnel outages returned heartbeat timeouts and upstream 502/503/504 responses without restarting the local daemon.

## What changed

Same-daemon replacement sessions now preserve pending interactions. A genuinely new daemon instance still interrupts them and performs the existing terminal cleanup. The ordinary disconnect grace still interrupts when no daemon returns.

## Verification

- Regression test: red before the policy change, green after
- Focused pending-interaction suite: 30 passed
- Server typecheck: passed
- Full server suite: 2081 passed; one unrelated install-script timeout passed immediately when rerun in isolation (17 passed)
- Changed-file format check and git diff check: passed