### PR TITLE
Fix mobile file tab close spacing

### DIFF
--- a/apps/app/src/components/ui/tab-pill.test.tsx
+++ b/apps/app/src/components/ui/tab-pill.test.tsx
@@ -95,4 +95,27 @@ describe("TabPill", () => {
       closeButton.classList.contains("max-md:pointer-coarse:min-w-9"),
     ).toBe(true);
   });
+
+  it("separates an enlarged coarse-pointer close target from the label", () => {
+    render(
+      <TabPill
+        label="rabbits.md"
+        title="rabbits.md"
+        isActive
+        onSelect={vi.fn()}
+        leadingVisual={<span aria-hidden>file</span>}
+        enlargeCloseTargetOnCoarsePointer
+        closeAction={{
+          closeLabel: "Close rabbits.md",
+          onClose: vi.fn(),
+        }}
+      />,
+    );
+
+    expect(
+      screen
+        .getByRole("button", { name: "rabbits.md" })
+        .classList.contains("max-md:pointer-coarse:pl-3.5"),
+    ).toBe(true);
+  });
 });

--- a/apps/app/src/components/ui/tab-pill.tsx
+++ b/apps/app/src/components/ui/tab-pill.tsx
@@ -83,6 +83,11 @@ export function TabPill({
         className={cn(
           "flex h-full min-w-0 items-center rounded-md focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
           iconOnly ? "px-1.5" : "pl-1.5 pr-2",
+          !iconOnly &&
+            closeAction !== null &&
+            enlargeCloseTargetOnCoarsePointer
+            ? "max-md:pointer-coarse:pl-3.5"
+            : null,
         )}
       >
         {leadingVisual ? (


### PR DESCRIPTION
## Human comments

## What was wrong

File-preview tabs enlarge their close target to 36px on narrow coarse-pointer screens, but the selectable tab trigger retained its 6px desktop left inset. Centering the close glyph in that wider target moved it over the filename: the glyph ended at x=122 while the label began at x=120, producing a 2px overlap.

## What changed

- Add a coarse-pointer left inset to non-icon tab triggers only when they have a close action with the enlarged touch target.
- Preserve the 36×36px close target while restoring 6px of visible space before the filename.
- Add focused regression coverage for the conditional file-tab spacing.
- No wire, CLI, guide, or documentation behavior changed.

## How you verified

- Dev Browser at a 480×700 viewport with coarse-pointer emulation: the close-glyph-to-label gap changed from -2px to 6px while the close target remained 36×36px.
- The focused regression test failed before the fix and passed afterward.
- Post-rebase: `pnpm exec turbo run test --filter=@bb/app --force -- --run src/components/ui/tab-pill.test.tsx` (5 tests passed).
- Post-rebase: `pnpm exec turbo run typecheck --filter=@bb/app --force`.
- Full app verification before the no-op rebase: 456 test files passed, 3,643 tests passed, 4 skipped.

BB-Thread-ID: thr_q2ws2irggv

> AGENT GENERATED
