### PR TITLE
Close compact panel after its final tab

### DIFF
--- a/apps/app/src/components/plugin/PluginPanelRightPanelHost.test.tsx
+++ b/apps/app/src/components/plugin/PluginPanelRightPanelHost.test.tsx
@@ -280,6 +280,7 @@ vi.mock("@/components/secondary-panel/ThreadSecondaryPanel", () => ({
     activeTab,
     tabs,
     fixedTabs,
+    isOpen,
     onClose,
     onOpenNewTab,
     renderBrowserDeck,
@@ -307,6 +308,7 @@ vi.mock("@/components/secondary-panel/ThreadSecondaryPanel", () => ({
         onFocusPane: () => void;
       }) => ReactNode;
     }>;
+    isOpen: boolean;
     onClose: () => void;
     onOpenNewTab: () => void;
     renderBrowserDeck?: (
@@ -361,6 +363,9 @@ vi.mock("@/components/secondary-panel/ThreadSecondaryPanel", () => ({
         {activeRenderableTab?.tab.kind === "browser"
           ? null
           : activeRenderableTab?.renderContent(pane)}
+        {isOpen && fixedTabs.length === 0 && tabs.length === 0 ? (
+          <div>This panel view is unavailable.</div>
+        ) : null}
         {renderBrowserDeck?.(
           activeRenderableTab?.tab.kind === "browser"
             ? activeRenderableTab.tab.id
@@ -682,6 +687,23 @@ describe("PluginPanelRightPanelHost", () => {
     expect(
       await screen.findByRole("button", { name: "Show right panel" }),
     ).toBeTruthy();
+  });
+
+  it("closes the compact drawer when its remaining tab closes", async () => {
+    viewportState.isCompactViewport = true;
+    renderHost();
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Show right panel" }),
+    );
+    expect(await screen.findByTestId("plugin-page-new-tab")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Close New tab" }));
+
+    expect(
+      await screen.findByRole("button", { name: "Show right panel" }),
+    ).toBeTruthy();
+    expect(screen.queryByText("This panel view is unavailable.")).toBeNull();
   });
 
   it("uses the shared panel state and chrome for plugin fixed tabs", async () => {

--- a/apps/app/src/components/plugin/PluginPanelRightPanelHost.tsx
+++ b/apps/app/src/components/plugin/PluginPanelRightPanelHost.tsx
@@ -249,6 +249,9 @@ export function PluginPanelRightPanelHost({
   const [isCompactDrawerOpen, setCompactDrawerOpen] = useAtom(
     compactDrawerOpenAtomFamily(panelStateId),
   );
+  const closeCompactDrawer = useCallback(() => {
+    setCompactDrawerOpen(false);
+  }, [setCompactDrawerOpen]);
   const isCompactViewport = useIsCompactViewport();
   const isOpen = isCompactViewport
     ? isCompactDrawerOpen
@@ -289,6 +292,7 @@ export function PluginPanelRightPanelHost({
     syncThreadId: null,
     environmentId: null,
     fileOwnerThreadId: null,
+    onCloseLastTab: closeCompactDrawer,
     preserveWorkspaceTabsAcrossContexts: true,
     storageFiles: undefined,
     terminalSessions: undefined,
@@ -332,8 +336,8 @@ export function PluginPanelRightPanelHost({
   ]);
 
   useEffect(() => {
-    setCompactDrawerOpen(false);
-  }, [setCompactDrawerOpen, subPath]);
+    closeCompactDrawer();
+  }, [closeCompactDrawer, subPath]);
 
   const revealPanel = useCallback(() => {
     if (isCompactViewport) {
@@ -463,11 +467,11 @@ export function PluginPanelRightPanelHost({
   );
   const hidePanel = useCallback(() => {
     if (isCompactViewport) {
-      setCompactDrawerOpen(false);
+      closeCompactDrawer();
       return;
     }
     closePersistedPanel();
-  }, [closePersistedPanel, isCompactViewport, setCompactDrawerOpen]);
+  }, [closeCompactDrawer, closePersistedPanel, isCompactViewport]);
   const openNewTab = useCallback(() => {
     openTab({ kind: "new-tab" });
     revealPanel();

--- a/apps/app/src/components/secondary-panel/useThreadFileTabs.ts
+++ b/apps/app/src/components/secondary-panel/useThreadFileTabs.ts
@@ -73,6 +73,7 @@ interface UseThreadFileTabsParams {
   syncThreadId: string | null | undefined;
   environmentId: string | null | undefined;
   fileOwnerThreadId?: string | null;
+  onCloseLastTab?: () => void;
   preserveWorkspaceTabsAcrossContexts?: boolean;
   projectHostId?: string | null;
   projectId?: string | null;
@@ -438,6 +439,7 @@ export function useThreadFileTabs({
   syncThreadId,
   environmentId,
   fileOwnerThreadId,
+  onCloseLastTab,
   preserveWorkspaceTabsAcrossContexts = false,
   projectHostId = null,
   projectId = null,
@@ -758,12 +760,14 @@ export function useThreadFileTabs({
 
   const closeTab = useCallback(
     (tabId: string) => {
+      let didCloseLastTab = false;
       updateFixedPanelTabsState((state) => {
         const tabIndex = state.secondary.tabs.findIndex(
           (tab) => tab.id === tabId,
         );
         const tab = state.secondary.tabs[tabIndex];
         const next = closeSecondaryPanelTabInState(state, tabId);
+        didCloseLastTab = next !== state && next.secondary.tabs.length === 0;
         if (
           next !== state &&
           recentlyClosedPanelContext !== null &&
@@ -782,8 +786,10 @@ export function useThreadFileTabs({
         }
         return next;
       });
+      if (didCloseLastTab) onCloseLastTab?.();
     },
     [
+      onCloseLastTab,
       recentlyClosedPanelContext,
       recentlyClosedPanelContextKey,
       updateFixedPanelTabsState,

--- a/apps/app/src/lib/fixed-panel-tabs.ts
+++ b/apps/app/src/lib/fixed-panel-tabs.ts
@@ -534,14 +534,20 @@ export function useSetFixedRightTerminalActiveTerminal(
 export function useRemoveFixedRightTerminalTab(
   panelStateId: FixedPanelTabsPanelStateId,
   syncThreadId: FixedPanelTabsSyncThreadId,
+  onCloseLastTab?: () => void,
 ): FixedPanelTerminalIdRemover {
   const updateState = useUpdateFixedPanelTabsState(panelStateId, syncThreadId);
   return useCallback(
     (terminalId: string) => {
-      updateState((current) =>
-        removeFixedRightTerminalTabInState(current, terminalId),
-      );
+      let didCloseLastTab = false;
+      updateState((current) => {
+        const next = removeFixedRightTerminalTabInState(current, terminalId);
+        didCloseLastTab =
+          next !== current && next.secondary.tabs.length === 0;
+        return next;
+      });
+      if (didCloseLastTab) onCloseLastTab?.();
     },
-    [updateState],
+    [onCloseLastTab, updateState],
   );
 }

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -928,6 +928,7 @@ function RootComposeSurface({
   const removeFixedTerminalTab = useRemoveFixedRightTerminalTab(
     ROOT_COMPOSE_FIXED_PANEL_STATE_ID,
     null,
+    secondaryPanelDrawerVisibility.closeDrawer,
   );
   const setRootSecondaryPanel = useSetThreadSecondaryPanelSelection(
     ROOT_COMPOSE_FIXED_PANEL_STATE_ID,
@@ -1057,6 +1058,7 @@ function RootComposeSurface({
     syncThreadId: null,
     environmentId: rootPanelEnvironmentId,
     fileOwnerThreadId: rootPanelThreadId,
+    onCloseLastTab: secondaryPanelDrawerVisibility.closeDrawer,
     preserveWorkspaceTabsAcrossContexts: true,
     projectHostId: rootProjectHostId,
     projectId: isProjectless ? null : projectId,

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -597,6 +597,7 @@ function ThreadDetailViewInternal(props: ThreadRoutePathArgs) {
   const removeFixedTerminalTab = useRemoveFixedRightTerminalTab(
     threadId,
     threadId,
+    secondaryPanelDrawerVisibility.closeDrawer,
   );
   const updateFixedPanelTabsState = useUpdateFixedPanelTabsState(
     threadId,
@@ -692,6 +693,7 @@ function ThreadDetailViewInternal(props: ThreadRoutePathArgs) {
     panelStateId: threadId,
     syncThreadId: threadId,
     environmentId: thread?.environmentId,
+    onCloseLastTab: secondaryPanelDrawerVisibility.closeDrawer,
     retainedTerminalId,
     storageFileExists: checkThreadStorageFileExists,
     storageFiles: threadStorageFiles,


### PR DESCRIPTION
## Human comments

## What was wrong

Compact right-panel visibility is owned separately from persisted tab state. Closing the final tab emptied and closed the tab model, but the compact drawer stayed visible and rendered the unavailable-view fallback.

## What changed

The shared file-tab and terminal-tab close paths now notify their panel host when a close removes the final tab. Root compose, thread detail, and plugin panel hosts use that notification to close compact drawer visibility immediately. A focused compact-viewport regression test verifies that closing the remaining tab restores the panel trigger without showing the unavailable fallback. There are no wire, CLI, guide, or public API changes.

## How you verified

- Confirmed the regression test failed twice before the fix with This panel view is unavailable.
- pnpm exec turbo run test --filter=@bb/app -- src/components/plugin/PluginPanelRightPanelHost.test.tsx src/components/secondary-panel/useThreadFileTabs.test.ts src/lib/fixed-panel-tabs.plugin-terminal.test.ts (50 tests passed)
- pnpm exec turbo run typecheck lint --filter=@bb/app (successful; lint reported 0 errors)
- Rebased cleanly onto origin/main at 46f23c4274 before final verification.

> AGENT GENERATED