### PR TITLE
Invalidate provider discovery after successful install

### DIFF
--- a/apps/server/src/routes/hosts.ts
+++ b/apps/server/src/routes/hosts.ts
@@ -304,6 +304,14 @@ export function registerHostRoutes(
         bridgeLaunch,
       },
     });
+    if (
+      result.events.some((event) => event.type === "completed" && event.success)
+    ) {
+      deps.providerRegistry.forgetInstalledKey({
+        hostId,
+        providerId: payload.provider,
+      });
+    }
     return new Response(providerCliInstallEventsToNdjson(result.events), {
       headers: {
         "content-type": "application/x-ndjson; charset=utf-8",

--- a/apps/server/test/public/public-provider-installations.test.ts
+++ b/apps/server/test/public/public-provider-installations.test.ts
@@ -2,6 +2,7 @@ import type {
   HostDaemonOnlineRpcRequestMessage,
   ProviderCliStatusResponse,
 } from "@bb/host-daemon-contract";
+import { systemProviderInfoSchema } from "@bb/server-contract";
 import { DEFAULT_BB_REQUEST_TIMEOUT_MS } from "@bb/sdk";
 import { validatePluginProviderDeclaration } from "@get-bb/plugin-sdk/internal/host-policy";
 import { describe, expect, it, vi } from "vitest";
@@ -18,6 +19,7 @@ const API = "/api/v1";
 function registerInstallationProviders(
   harness: TestAppHarness,
   providerIds: readonly string[],
+  visibility: "always" | "installed" = "always",
 ): void {
   const bridgeArtifact = harness.deps.pluginHostArtifacts.get("provider-acp");
   if (bridgeArtifact === undefined) {
@@ -33,7 +35,12 @@ function registerInstallationProviders(
         declaration: validatePluginProviderDeclaration({
           id: providerId,
           displayName: providerId,
-          maintenance: { health: false, usage: false, installation: true },
+          experimental_visibility: visibility,
+          maintenance: {
+            health: visibility === "installed",
+            usage: false,
+            installation: true,
+          },
           capabilities: {
             supportsServiceTier: false,
             supportsNativeUserQuestion: false,
@@ -86,6 +93,7 @@ function installationStatus(providerId: string) {
 
 function handleProviderInstallationRpc(
   request: HostDaemonOnlineRpcRequestMessage,
+  installed = false,
 ) {
   const { command } = request;
   if (command.type === "provider.health") {
@@ -94,7 +102,7 @@ function handleProviderInstallationRpc(
       result: {
         supported: true as const,
         health: {
-          status: "not_installed" as const,
+          status: installed ? ("ready" as const) : ("not_installed" as const),
           statusMessage: null,
           accountEmail: null,
           planLabel: null,
@@ -366,6 +374,62 @@ describe("public provider installation routes", () => {
       expect(await readJson(unsupported)).toMatchObject({
         code: "provider_installation_unavailable",
       });
+    });
+  });
+
+  it("refreshes an installed-only provider after a successful install", async () => {
+    await withTestHarness(async (harness) => {
+      registerInstallationProviders(
+        harness,
+        ["installable-agent"],
+        "installed",
+      );
+      const { host, session } = seedHostSession(harness.deps, {
+        id: "provider-installation-refresh-host",
+      });
+      let installed = false;
+      const responder = registerHostRpcResponder(harness, {
+        hostId: host.id,
+        sessionId: session.id,
+        handle: (request) => {
+          if (request.command.type === "provider.installation.run") {
+            installed = true;
+          }
+          return handleProviderInstallationRpc(request, installed);
+        },
+      });
+      const listProviderIds = async (): Promise<string[]> => {
+        const response = await harness.app.request(
+          `${API}/system/providers?hostId=${host.id}`,
+        );
+        expect(response.status).toBe(200);
+        return systemProviderInfoSchema
+          .array()
+          .parse(await readJson(response))
+          .map((provider) => provider.id);
+      };
+      const installProvider = () =>
+        harness.app.request(`${API}/hosts/${host.id}/provider-clis/install`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            provider: "installable-agent",
+            actionKind: "install",
+          }),
+        });
+      const providerHealthRequests = () =>
+        responder.requests.filter(
+          (request) =>
+            request.command.type === "provider.health" &&
+            request.command.providerId === "installable-agent",
+        );
+
+      expect(await listProviderIds()).not.toContain("installable-agent");
+      const installResponse = await installProvider();
+      expect(installResponse.status).toBe(200);
+      expect(await installResponse.text()).toContain('"success":true');
+      expect(await listProviderIds()).toContain("installable-agent");
+      expect(providerHealthRequests()).toHaveLength(2);
     });
   });
 });


### PR DESCRIPTION
## Human comments

## What was wrong

Provider discovery correctly cached installed state for five minutes, but the successful provider-installation route did not invalidate an earlier negative answer. After installing an installed-only plugin provider, the provider could therefore remain hidden until the cache expired. This was the remaining correctness gap from [the provider discovery caching change](https://github.com/get-bb/bb/pull/2760).

## What changed

- Invalidate only the installed-state entry for the target host and provider when installation events contain a successful completion.
- Add a public-route regression that caches the provider as absent, installs it successfully, then verifies the next provider listing probes again and includes it.
- Preserve discovery caching, retries, persisted provider roster behavior, and immutable logo URLs. There are no server/daemon wire changes, CLI changes, or documentation changes.

## How you verified

- Confirmed the regression failed before the fix: installation returned HTTP 200 with `success:true`, but the installed-only provider remained absent and was not probed again.
- `pnpm exec turbo run test --filter=@bb/server -- --run test/public/public-provider-installations.test.ts test/system/execution-options.test.ts test/providers/provider-registry.test.ts` — 3 files, 61 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/server` — passed.
- `git diff --check origin/main...HEAD` — passed after rebasing onto current `origin/main`.

> AGENT GENERATED
