### PR TITLE
Retry structured provider overload failures

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -796,10 +796,12 @@ the plugin so it can be surfaced as needing attention.
 
 The builtin Provider retry plugin is enabled on fresh installations. When a turn
 fails on a structured Codex or Claude Code subscription-window limit that
-reports a reset time, it queues that turn to be re-sent after the window opens.
-Prior output or tool activity does not block recovery. The retry re-sends the
-original message verbatim, marked agent-only so the timeline does not show it
-twice. Disable it under Extensions → Plugins or with
+reports a reset time, it queues that turn after the window opens. It also
+retries structured provider overloads with exponential backoff and jitter.
+Prior output or tool activity does not block recovery. If the provider accepted
+the failed input, core sends an agent-only continuation; if it rejected the
+input before starting, core re-sends the original message as agent-only. Disable
+the plugin under Extensions → Plugins or with
 `bb plugin disable provider-retry`.
 
 It never blocks a send. A remembered rate limit is a stale picture of the
@@ -807,7 +809,8 @@ provider's state, so the plugin never refuses a dispatch on one — if you raise
 your plan or the window opened early, the next send simply works. The cost is
 that several threads on one exhausted subscription each fail once before each
 schedules its own retry; the retries are jittered so they do not all wake in the
-same instant.
+same instant. Overload retries start after 5–10 seconds, double their delay
+after each failure, and share the five-total-attempt cap with limit retries.
 The `maximumWait` setting defaults to `6 hours`; resets beyond that horizon are
 not scheduled. Choose `24 hours` or `No limit` under the plugin settings, or
 configure it from the CLI:

--- a/packages/templates/src/templates/bb-guide-plugins.md
+++ b/packages/templates/src/templates/bb-guide-plugins.md
@@ -51,12 +51,12 @@ bb concurrency-limit global [unlimited|<limit>] [--json]
 bb concurrency-limit host <host-id> [auto|<limit>] [--json]
 ```
 
-The builtin Provider retry plugin is enabled on fresh installations. It
-continues Codex and Claude Code turns after a structured subscription window
-resets. A pending retry is a queued row on the thread, so a server restart does
-not lose it, and that row — on the queue card above the composer, with its
-reason, its time and its own Cancel — is the only place the wait is narrated.
-Inspect it with `bb provider-retry status`. See
+The builtin Provider retry plugin is enabled on fresh installations. It retries
+Codex and Claude Code turns after structured provider overloads and subscription
+window limits. A pending retry is a queued row on the thread, so a server
+restart does not lose it, and that row — on the queue card above the composer,
+with its reason, its time and its own Cancel — is the only place the wait is
+narrated. Inspect it with `bb provider-retry status`. See
 `bb guide providers` for the eligibility rules. The plugin only reacts to a
 failed turn — it never blocks a send. Prior output or tool activity does not
 block recovery. Its `maximumWait` setting defaults to `6 hours`; choose

--- a/packages/templates/src/templates/bb-guide-providers.md
+++ b/packages/templates/src/templates/bb-guide-providers.md
@@ -40,21 +40,24 @@ removes the native Task tool. The preferences default off and apply
 when a provider thread is started, resumed, or forked; they do not modify the
 provider's global configuration.
 
-Subscription limit recovery
+Provider failure recovery
 
 The builtin Provider retry plugin is enabled on fresh installations and
-recognizes structured Codex and Claude Code subscription windows. When a turn
-fails on one, the plugin queues that turn to be re-sent after the reported reset
-plus a short buffer and some jitter. The retry re-sends the original message
-verbatim, marked agent-only so the timeline does not show it twice. Prior output
-or tool activity does not block recovery. Provider-native retries remain
-authoritative while the provider reports that it will retry on its own.
+recognizes structured Codex and Claude Code subscription windows and provider
+overloads. Subscription limits wait for the reported reset plus a short buffer
+and jitter. Overloads use exponential backoff and jitter, starting after 5–10
+seconds. If the provider accepted the failed input, core sends an agent-only
+continuation; if it rejected the input before starting, core re-sends the
+original message as agent-only. Prior output or tool activity does not block
+recovery. Provider-native retries remain authoritative while the provider
+reports that it will retry on its own.
 
 The plugin never blocks a send. It only reacts to a failure, because a
 remembered rate limit is a stale picture of the provider's state: if you raised
 your plan or the window opened early, the next send simply works. Several
 threads on one exhausted subscription therefore each fail once, then each
-schedule their own jittered retry.
+schedule their own jittered retry. Automatic recovery stops after five total
+attempts for the turn.
 
 Automatic waits default to a maximum of six hours. Longer reset windows are not
 scheduled. Set `maximumWait` to `24 hours` or `No limit` under the plugin

--- a/plugins/provider-retry/package.json
+++ b/plugins/provider-retry/package.json
@@ -3,13 +3,13 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "description": "Continue turns after Codex and Claude Code subscription limits reset.",
+  "description": "Retry turns after transient provider overloads and subscription limits reset.",
   "engines": {
     "bb": ">=0.0"
   },
   "bb": {
     "name": "Provider retry",
-    "description": "Continue turns after Codex and Claude Code subscription limits reset.",
+    "description": "Retry turns after transient provider overloads and subscription limits reset.",
     "branding": {
       "icon": "ArrowReloadHorizontal"
     },

--- a/plugins/provider-retry/server.test.ts
+++ b/plugins/provider-retry/server.test.ts
@@ -9,6 +9,7 @@ import type { PluginTurnFailedEvent } from "@get-bb/plugin-sdk";
 import plugin from "./server.js";
 import {
   MAX_RETRY_ATTEMPTS,
+  OVERLOAD_RETRY_BASE_MS,
   RESET_BUFFER_MS,
   RESET_JITTER_MS,
   decideRetry,
@@ -57,6 +58,20 @@ function failure(
       httpStatusCode: 429,
     },
     rateLimits: rateLimits(),
+    ...overrides,
+  });
+}
+
+function overloadedFailure(
+  overrides: Partial<PluginTurnFailedEvent> = {},
+): PluginTurnFailedEvent {
+  return failure({
+    errorInfo: {
+      category: "overloaded",
+      providerCode: "serverOverloaded",
+      httpStatusCode: 529,
+    },
+    rateLimits: null,
     ...overrides,
   });
 }
@@ -155,6 +170,7 @@ describe("provider retry policy", () => {
     expect(earliest).toEqual({
       kind: "retry",
       sendAt: RESET_AT_MS + RESET_BUFFER_MS,
+      reason: "Rate limited",
     });
     expect(latest.kind).toBe("retry");
     if (latest.kind !== "retry") return;
@@ -185,6 +201,7 @@ describe("provider retry policy", () => {
     expect(decision).toEqual({
       kind: "retry",
       sendAt: NOW_MS + RESET_BUFFER_MS,
+      reason: "Rate limited",
     });
   });
 
@@ -216,6 +233,7 @@ describe("provider retry policy", () => {
     expect(decision).toEqual({
       kind: "retry",
       sendAt: weekly + RESET_BUFFER_MS,
+      reason: "Rate limited",
     });
   });
 
@@ -239,7 +257,34 @@ describe("provider retry policy", () => {
     ).toBe("retry");
   });
 
-  it("declines failures that are not rate limits, and limits that do not reset", () => {
+  it("retries overloads with exponential backoff and bounded jitter", () => {
+    const overloaded = overloadedFailure();
+    expect(
+      decideRetry({
+        failure: overloaded,
+        maximumWaitMs: null,
+        now: NOW_MS,
+        random: 0,
+      }),
+    ).toEqual({
+      kind: "retry",
+      sendAt: NOW_MS + OVERLOAD_RETRY_BASE_MS,
+      reason: "Provider overloaded",
+    });
+    const fourthAttempt = decideRetry({
+      failure: { ...overloaded, attemptNumber: 4 },
+      maximumWaitMs: null,
+      now: NOW_MS,
+      random: 0.999_999,
+    });
+    expect(fourthAttempt.kind).toBe("retry");
+    if (fourthAttempt.kind !== "retry") return;
+    const fourthDelay = OVERLOAD_RETRY_BASE_MS * 2 ** 3;
+    expect(fourthAttempt.sendAt).toBeGreaterThan(NOW_MS + fourthDelay);
+    expect(fourthAttempt.sendAt).toBeLessThan(NOW_MS + fourthDelay * 2);
+  });
+
+  it("declines failures that are not retryable, and limits that do not reset", () => {
     expect(
       decideRetry({
         failure: failure({
@@ -253,7 +298,7 @@ describe("provider retry policy", () => {
         now: NOW_MS,
         random: 0,
       }),
-    ).toEqual({ kind: "decline", reason: "not-rate-limited" });
+    ).toEqual({ kind: "decline", reason: "not-retryable" });
     expect(
       decideRetry({
         failure: failure({ rateLimits: null }),
@@ -290,6 +335,14 @@ describe("provider retry policy", () => {
         random: 0,
       }).kind,
     ).toBe("retry");
+    expect(
+      decideRetry({
+        failure: overloadedFailure({ attemptNumber: MAX_RETRY_ATTEMPTS }),
+        maximumWaitMs: null,
+        now: NOW_MS,
+        random: 0,
+      }),
+    ).toEqual({ kind: "decline", reason: "attempts-exhausted" });
   });
 });
 
@@ -317,12 +370,14 @@ describe("provider retry plugin", () => {
         type: "select",
         label: "Maximum automatic wait",
         description:
-          "Do not schedule a retry when the reported reset is farther away than this.",
+          "Do not schedule a subscription-limit retry when its reset is farther away than this.",
         options: ["6 hours", "24 hours", "No limit"],
         default: "6 hours",
       },
     });
-    expect(host.harness.registrations.threadEventHandlers["turn.failed"]).toBe(1);
+    expect(host.harness.registrations.threadEventHandlers["turn.failed"]).toBe(
+      1,
+    );
     expect(host.harness.registrations.hooks["message.dispatch"]).toBeNull();
     expect(
       host.harness.registrations.cli?.commands.map((command) => command.name),
@@ -350,6 +405,31 @@ describe("provider retry plugin", () => {
     // Just the cause, no time: every surface renders the row's `sendAt`
     // itself, so a time here shows up twice on the card and in the queue list.
     expect(retry?.reason).toBe("Rate limited");
+    await host.harness.dispose();
+  });
+
+  it("asks core to retry an overloaded turn after backoff", async () => {
+    const host = createHost();
+    await plugin(host.bb);
+
+    const { errors } = await host.harness.behavior.emitThreadEvent(
+      "turn.failed",
+      overloadedFailure(),
+    );
+
+    expect(errors).toEqual([]);
+    expect(host.retries).toHaveLength(1);
+    expect(host.retries[0]).toMatchObject({
+      threadId: THREAD_ID,
+      turnRequestId: REQUEST_ID,
+      reason: "Provider overloaded",
+    });
+    expect(host.retries[0]?.sendAt).toBeGreaterThanOrEqual(
+      NOW_MS + OVERLOAD_RETRY_BASE_MS,
+    );
+    expect(host.retries[0]?.sendAt).toBeLessThan(
+      NOW_MS + OVERLOAD_RETRY_BASE_MS * 2,
+    );
     await host.harness.dispose();
   });
 

--- a/plugins/provider-retry/server.ts
+++ b/plugins/provider-retry/server.ts
@@ -1,32 +1,3 @@
-// bb-plugin-provider-retry — continue a turn once a subscription window resets.
-//
-// The entire plugin is one listener on `turn.failed`: if the failure is a rate
-// limit that reports a reset, ask core for a retry at that time. Buffer,
-// jitter, maximum wait and the attempt cap are the only policy it owns.
-//
-// **It never intercepts a send.** An earlier version answered the dispatch
-// checkpoint too: once one thread proved an account exhausted, it queued every
-// other dispatch into that account until the window it remembered had passed.
-// That is wrong on principle. A rate-limit record is a stale cache of provider
-// state — the provider is the only thing that knows whether the limit still
-// binds. A user who fixed it out of band (upgraded the plan, had the window
-// reset early, swapped the credentials behind the provider) would be refused
-// without an attempt, on this plugin's memory of a failure that no longer
-// applied, with no way to tell that the refusal was ours and not theirs. The
-// only authoritative check is trying.
-//
-// The cost of that is accepted rather than engineered around: N threads sharing
-// one exhausted account each fail once, instead of the first failing and the
-// rest queueing behind it. One honest failure per thread — visible, explained,
-// and immediately followed by a scheduled retry — is cheaper than one wrong
-// refusal, and it is the only version of this plugin that cannot be wrong about
-// the present.
-//
-// It also narrates nothing. A scheduled retry IS a queued row, and that row
-// already says what it is waiting on and when it will go, on the card above the
-// composer and in `bb thread queue list`. A note repeating it could only go
-// stale when the row is cancelled, sent now or re-queued.
-
 import type { BbPluginApi } from "@get-bb/plugin-sdk";
 import { registerProviderRetryCli } from "./src/cli.js";
 import { DEFAULT_MAXIMUM_WAIT_MS, decideRetry } from "./src/retry-policy.js";
@@ -48,22 +19,13 @@ function maximumWaitMs(value: string | boolean | undefined): number | null {
   }
 }
 
-/**
- * What a rate-limited row is waiting for. Deliberately just the cause: the time
- * rides the row's `sendAt`, and every surface that shows a queued row renders
- * that itself — the card above the composer puts the clock next to the reason,
- * `bb thread queue list` gives it its own Send-at column. Formatting it into
- * the reason as well printed it twice in both.
- */
-const RATE_LIMITED_WAIT_REASON = "Rate limited";
-
 export default async function plugin(bb: BbPluginApi) {
   const settings = bb.settings.define({
     maximumWait: {
       type: "select",
       label: "Maximum automatic wait",
       description:
-        "Do not schedule a retry when the reported reset is farther away than this.",
+        "Do not schedule a subscription-limit retry when its reset is farther away than this.",
       options: [...MAXIMUM_WAIT_OPTIONS],
       default: "6 hours",
     },
@@ -96,7 +58,7 @@ export default async function plugin(bb: BbPluginApi) {
       threadId: event.threadId,
       turnRequestId: event.requestId,
       sendAt: decision.sendAt,
-      reason: RATE_LIMITED_WAIT_REASON,
+      reason: decision.reason,
     });
   });
 

--- a/plugins/provider-retry/src/cli.ts
+++ b/plugins/provider-retry/src/cli.ts
@@ -48,7 +48,7 @@ export function registerProviderRetryCli(bb: BbPluginApi): void {
       },
       {
         name: "retry",
-        summary: "Retry a rate-limited turn now instead of waiting",
+        summary: "Send a pending provider retry now instead of waiting",
         usage: "bb provider-retry retry <thread-id> [--json]",
       },
     ],

--- a/plugins/provider-retry/src/retry-policy.ts
+++ b/plugins/provider-retry/src/retry-policy.ts
@@ -21,6 +21,8 @@ export const RESET_JITTER_MS = 30_000;
 
 export const DEFAULT_MAXIMUM_WAIT_MS = 6 * 60 * 60 * 1_000;
 
+export const OVERLOAD_RETRY_BASE_MS = 5_000;
+
 /**
  * The cap on a turn's TOTAL attempts: the original dispatch plus at most four
  * retries, since `attemptNumber` counts from 1 on the original.
@@ -33,7 +35,7 @@ export const DEFAULT_MAXIMUM_WAIT_MS = 6 * 60 * 60 * 1_000;
 export const MAX_RETRY_ATTEMPTS = 5;
 
 export type RetryDeclineReason =
-  | "not-rate-limited"
+  | "not-retryable"
   | "no-rate-limit-state"
   | "not-resettable"
   | "beyond-maximum-wait"
@@ -41,7 +43,11 @@ export type RetryDeclineReason =
 
 export type RetryDecision =
   | { kind: "decline"; reason: RetryDeclineReason }
-  | { kind: "retry"; sendAt: number };
+  | {
+      kind: "retry";
+      sendAt: number;
+      reason: "Rate limited" | "Provider overloaded";
+    };
 
 export interface RetryPolicyInput {
   failure: PluginTurnFailedEvent;
@@ -82,6 +88,15 @@ export function sendAtMs(args: {
   return base + RESET_BUFFER_MS + Math.floor(args.random * RESET_JITTER_MS);
 }
 
+export function overloadedSendAtMs(args: {
+  attemptNumber: number;
+  now: number;
+  random: number;
+}): number {
+  const delay = OVERLOAD_RETRY_BASE_MS * 2 ** (args.attemptNumber - 1);
+  return args.now + delay + Math.floor(args.random * delay);
+}
+
 /**
  * Whether this failure earns a retry, and when.
  *
@@ -100,8 +115,19 @@ export function decideRetry(input: RetryPolicyInput): RetryDecision {
   if (failure.attemptNumber >= MAX_RETRY_ATTEMPTS) {
     return { kind: "decline", reason: "attempts-exhausted" };
   }
+  if (failure.errorInfo?.category === "overloaded") {
+    return {
+      kind: "retry",
+      sendAt: overloadedSendAtMs({
+        attemptNumber: failure.attemptNumber,
+        now: input.now,
+        random: input.random,
+      }),
+      reason: "Provider overloaded",
+    };
+  }
   if (failure.errorInfo?.category !== "rate-limit") {
-    return { kind: "decline", reason: "not-rate-limited" };
+    return { kind: "decline", reason: "not-retryable" };
   }
   const rateLimits = failure.rateLimits;
   if (rateLimits === null || rateLimits.status !== "blocked") {
@@ -129,5 +155,6 @@ export function decideRetry(input: RetryPolicyInput): RetryDecision {
       now: input.now,
       random: input.random,
     }),
+    reason: "Rate limited",
   };
 }


### PR DESCRIPTION
## Human comments

## What was wrong

The provider-retry policy treated every structured failure other than a resettable subscription rate limit as ineligible. Structured `overloaded` failures are transient and retryable, but the plugin had no independent delay policy for failures that do not report a rate-limit reset window.

## What changed

The retry policy now schedules `overloaded` failures with exponential backoff and bounded jitter: 5–10 seconds, 10–20 seconds, 20–40 seconds, then 40–80 seconds. Overload recovery shares the existing five-total-attempt cap, identifies queued work as `Provider overloaded`, and continues to delegate accepted-versus-unaccepted input handling to core through `threads.retry`. Subscription-window behavior is unchanged. Plugin metadata, CLI wording, configuration documentation, and the generated BB guide sources now describe both recovery modes. There are no host-daemon protocol or wire changes.

## How you verified

The new overload policy and plugin-handler tests fail against the previous implementation because it declines the `overloaded` category. Verification commands:

- `pnpm exec turbo run test typecheck --filter=bb-plugin-provider-retry --force` — 15 tests passed and typecheck passed
- `pnpm exec turbo run test --filter=@bb/server --force -- --run test/threads/turn-failed-retry.test.ts` — 12 tests passed
- `pnpm exec turbo run test --filter=@bb/server --force -- --run test/services/plugins/plugin-authoring-docs.test.ts test/services/plugins/builtin-plugins.test.ts` — 47 tests passed
- `bb plugin build plugins/provider-retry`
- `git diff --check`

Fixes # (no tracking issue was filed)

> AGENT GENERATED