### PR TITLE
Add sidebar navigation replacement API

### DIFF
--- a/apps/app/src/components/plugin/docs-anatomy-manifest.test.tsx
+++ b/apps/app/src/components/plugin/docs-anatomy-manifest.test.tsx
@@ -181,8 +181,7 @@ describe("docs anatomy manifest", () => {
 
     const sectionSelectors: Record<string, string> = {
       "top-reserve": '[data-testid="app-sidebar-top-reserve-row"]',
-      "primary-actions": '[data-testid="app-sidebar-primary-actions"]',
-      "plugin-nav": '[data-testid="plugin-nav-sidebar-items"]',
+      "sidebar-navigation": '[data-testid="sidebar-navigation-region"]',
       "thread-list": '[data-sidebar="content"]',
       footer: '[data-sidebar="footer"]',
     };

--- a/apps/app/src/components/settings/SidebarNavigationSetting.test.tsx
+++ b/apps/app/src/components/settings/SidebarNavigationSetting.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { createStore, Provider } from "jotai";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  resetPluginSlotStoreForTest,
+  setPluginSlotRegistrations,
+} from "@/lib/plugin-slots";
+import { sidebarNavigationProviderAtom } from "@/components/sidebar/sidebarNavigationProvider";
+import {
+  AUTOMATIC_REPLACEMENT_PROVIDER,
+  BUILT_IN_REPLACEMENT_PROVIDER,
+} from "@/lib/plugin-replacement-preference";
+import { SidebarNavigationSetting } from "./SidebarNavigationSetting";
+
+afterEach(() => {
+  cleanup();
+  window.localStorage.clear();
+  resetPluginSlotStoreForTest();
+});
+
+describe("SidebarNavigationSetting", () => {
+  it("defaults to automatic and lets the user pin the built-in navigation", async () => {
+    setPluginSlotRegistrations("navbar", {
+      homepageSections: [],
+      settingsSections: [],
+      navPanels: [],
+      threadPanelActions: [],
+      sidebarFooterActions: [],
+      experimentalSidebarNavigations: [
+        {
+          id: "grid",
+          title: "Navigation grid",
+          component: () => null,
+        },
+      ],
+      fileOpeners: [],
+      messageDirectives: [],
+    });
+    const store = createStore();
+    render(
+      <Provider store={store}>
+        <SidebarNavigationSetting />
+      </Provider>,
+    );
+
+    expect(store.get(sidebarNavigationProviderAtom)).toBe(
+      AUTOMATIC_REPLACEMENT_PROVIDER,
+    );
+    const trigger = screen.getByRole("button", {
+      name: "Sidebar navigation",
+    });
+    fireEvent.pointerDown(trigger, { button: 0 });
+    fireEvent.click(await screen.findByRole("menuitem", { name: /built-in/u }));
+    expect(store.get(sidebarNavigationProviderAtom)).toBe(
+      BUILT_IN_REPLACEMENT_PROVIDER,
+    );
+  });
+});

--- a/apps/app/src/components/settings/SidebarNavigationSetting.tsx
+++ b/apps/app/src/components/settings/SidebarNavigationSetting.tsx
@@ -1,0 +1,96 @@
+import { useAtom } from "jotai";
+import { Icon } from "@bb/shared-ui/icon";
+import { cn } from "@bb/shared-ui/lib/utils";
+import { COARSE_POINTER_ICON_SIZE_CLASS } from "@bb/shared-ui/coarse-pointer-sizing";
+import { Button } from "@bb/shared-ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@bb/shared-ui/dropdown-menu";
+import { SettingsWithControl } from "@/components/ui/settings-section";
+import { sidebarNavigationProviderAtom } from "@/components/sidebar/sidebarNavigationProvider";
+import {
+  AUTOMATIC_REPLACEMENT_PROVIDER,
+  BUILT_IN_REPLACEMENT_PROVIDER,
+  replacementProviderKey,
+} from "@/lib/plugin-replacement-preference";
+import { usePluginSlots } from "@/lib/plugin-slots";
+
+const BUILT_IN_OPTION = {
+  key: BUILT_IN_REPLACEMENT_PROVIDER,
+  title: "bb (built-in)",
+  description: "Native New thread, Search, Extensions, and plugin panels.",
+} as const;
+
+export function SidebarNavigationSetting() {
+  const { experimentalSidebarNavigations } = usePluginSlots();
+  const [preference, setPreference] = useAtom(sidebarNavigationProviderAtom);
+
+  const automaticProvider = experimentalSidebarNavigations[0];
+  if (automaticProvider === undefined) return null;
+  const options = [
+    {
+      key: AUTOMATIC_REPLACEMENT_PROVIDER,
+      title: "Automatic",
+      description: `Currently using ${automaticProvider.title} from ${automaticProvider.pluginId}.`,
+    },
+    BUILT_IN_OPTION,
+    ...experimentalSidebarNavigations.map((slot) => ({
+      key: replacementProviderKey(slot),
+      title: slot.title,
+      description: slot.description ?? `From the ${slot.pluginId} plugin.`,
+    })),
+  ];
+  const selected =
+    options.find((option) => option.key === preference) ?? BUILT_IN_OPTION;
+
+  return (
+    <SettingsWithControl
+      label="Navigation"
+      description="Choose who arranges the host-owned sidebar destinations on this device."
+    >
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="outline"
+            size="sm"
+            className="min-w-40 justify-between"
+            aria-label="Sidebar navigation"
+          >
+            <span className="min-w-0 truncate">{selected.title}</span>
+            <Icon
+              name="ChevronDown"
+              className="size-3.5 text-muted-foreground"
+            />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-72">
+          {options.map((option) => (
+            <DropdownMenuItem
+              key={option.key}
+              onSelect={() => setPreference(option.key)}
+              className="flex items-start gap-2"
+            >
+              <span className="flex min-w-0 flex-col">
+                <span className="truncate">{option.title}</span>
+                <span className="truncate text-xs text-muted-foreground">
+                  {option.description}
+                </span>
+              </span>
+              <Icon
+                name="Check"
+                className={cn(
+                  "ml-auto mt-0.5",
+                  selected.key !== option.key && "opacity-0",
+                  COARSE_POINTER_ICON_SIZE_CLASS,
+                )}
+              />
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </SettingsWithControl>
+  );
+}

--- a/apps/app/src/components/sidebar/AppSidebar.tsx
+++ b/apps/app/src/components/sidebar/AppSidebar.tsx
@@ -14,10 +14,9 @@ import {
   SidebarMenuItem,
   useCloseMobileSidebar,
 } from "@/components/ui/sidebar.js";
-import { ProjectList, ProjectListActionButtons } from "./ProjectList";
+import { ProjectList } from "./ProjectList";
 import { PluginThreadList } from "./PluginThreadList";
 import { useThreadListReplacement } from "./threadListProvider";
-import { PluginNavSidebarItems } from "@/components/plugin/PluginNavSidebarItems";
 import { PluginSidebarFooterActions } from "@/components/plugin/PluginSidebarFooterActions";
 import { SidebarPluginAttentionGlyph } from "./SidebarPluginAttentionGlyph";
 import { SidebarUpdatesBadge } from "./SidebarUpdatesBadge";
@@ -49,6 +48,7 @@ import {
   useIndexedAppCommandHandlers,
 } from "@/components/commands/AppCommandProvider";
 import { useRouteState } from "@/hooks/useRouteState";
+import { SidebarNavigationRegion } from "./SidebarNavigationRegion";
 
 const NEW_THREAD_PANE_CONTENT = { kind: "new-thread" } as const;
 
@@ -227,21 +227,13 @@ export function AppSidebar({
           />
         </div>
       ) : null}
-      <div
-        data-testid="app-sidebar-primary-actions"
-        className="shrink-0 px-2 py-2 group-data-[collapsible=icon]:hidden"
-      >
-        <ProjectListActionButtons
-          splitEnabled
-          newThreadSplit={newThreadSplit}
-          onNewChat={handleNewChat}
-          onSearchThreads={closeOnMobile}
-        />
-      </div>
-      <PluginNavSidebarItems
+      <SidebarNavigationRegion
         onNavigate={closeOnMobile}
         splitEnabled
         toolsRoutePath={toolsRoutePath}
+        newThreadSplit={newThreadSplit}
+        onNewChat={handleNewChat}
+        onSearchThreads={closeOnMobile}
       />
       <SidebarContent>
         <PluginThreadList

--- a/apps/app/src/components/sidebar/BuiltInSidebarNavigation.tsx
+++ b/apps/app/src/components/sidebar/BuiltInSidebarNavigation.tsx
@@ -1,0 +1,38 @@
+import type { ComponentProps } from "react";
+import { PluginNavSidebarItems } from "@/components/plugin/PluginNavSidebarItems";
+import { ProjectListActionButtons } from "./ProjectList";
+
+export type BuiltInSidebarNavigationProps = ComponentProps<
+  typeof ProjectListActionButtons
+> &
+  ComponentProps<typeof PluginNavSidebarItems>;
+
+export function BuiltInSidebarNavigation({
+  newThreadSplit,
+  onNavigate,
+  onNewChat,
+  onSearchThreads,
+  splitEnabled,
+  toolsRoutePath,
+}: BuiltInSidebarNavigationProps) {
+  return (
+    <div className="contents" data-testid="built-in-sidebar-navigation">
+      <div
+        data-testid="app-sidebar-primary-actions"
+        className="shrink-0 px-2 py-2 group-data-[collapsible=icon]:hidden"
+      >
+        <ProjectListActionButtons
+          splitEnabled={splitEnabled}
+          newThreadSplit={newThreadSplit}
+          onNewChat={onNewChat}
+          onSearchThreads={onSearchThreads}
+        />
+      </div>
+      <PluginNavSidebarItems
+        onNavigate={onNavigate}
+        splitEnabled={splitEnabled}
+        toolsRoutePath={toolsRoutePath}
+      />
+    </div>
+  );
+}

--- a/apps/app/src/components/sidebar/SidebarNavigationRegion.test.tsx
+++ b/apps/app/src/components/sidebar/SidebarNavigationRegion.test.tsx
@@ -1,0 +1,209 @@
+// @vitest-environment jsdom
+
+import { useEffect, useState } from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { createStore, Provider } from "jotai";
+import { MemoryRouter, useLocation } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ExperimentalSidebarNavigationProps } from "@get-bb/plugin-sdk";
+import { SidebarProvider } from "@/components/ui/sidebar";
+import { resetAllCrashedPluginSlotsForTest } from "@/components/plugin/PluginSlotMount";
+import {
+  resetPluginSlotStoreForTest,
+  setPluginSlotRegistrations,
+  type PluginRegistrationSet,
+} from "@/lib/plugin-slots";
+import { SidebarNavigationRegion } from "./SidebarNavigationRegion";
+
+const mocks = vi.hoisted(() => ({
+  dispatch: vi.fn(),
+  onSearchThreads: vi.fn(),
+}));
+
+vi.mock("@/components/commands/AppCommandProvider", () => ({
+  useAppCommandRunner: () => ({
+    dispatch: mocks.dispatch,
+    isCommandAvailable: () => true,
+  }),
+  useAppCommandShortcut: () => null,
+  useIsAppCommandModifierHeld: () => false,
+}));
+vi.mock("@/components/plugin/PluginNavSidebarItems", () => ({
+  PluginNavSidebarItems: () => <div>BB plugin destinations</div>,
+}));
+vi.mock("./usePaneContentSplitDrag", () => ({
+  usePaneContentSplitActions: () => ({
+    beginDrag: vi.fn(),
+    isCompact: false,
+    openInSplit: vi.fn(),
+  }),
+}));
+
+function registrationSet(
+  overrides: Partial<PluginRegistrationSet>,
+): PluginRegistrationSet {
+  return {
+    homepageSections: [],
+    settingsSections: [],
+    navPanels: [],
+    threadPanelActions: [],
+    sidebarFooterActions: [],
+    fileOpeners: [],
+    messageDirectives: [],
+    ...overrides,
+  };
+}
+
+function Replacement({
+  experimental_Original: Original,
+  experimental_activate,
+  items,
+}: ExperimentalSidebarNavigationProps) {
+  const [delegate, setDelegate] = useState(false);
+  const [crash, setCrash] = useState(false);
+  if (crash) throw new Error("navigation fixture crash");
+  if (delegate) return <Original />;
+  return (
+    <div data-testid="replacement-navigation">
+      {items.map((item) => (
+        <button
+          key={item.id}
+          type="button"
+          {...item.experimental_splitProps}
+          onClick={(event) =>
+            experimental_activate(item.id, {
+              openInSplit: event.metaKey || event.ctrlKey,
+            })
+          }
+        >
+          {item.label}
+        </button>
+      ))}
+      <button type="button" onClick={() => setDelegate(true)}>
+        Delegate to BB
+      </button>
+      <button type="button" onClick={() => setCrash(true)}>
+        Crash replacement
+      </button>
+    </div>
+  );
+}
+
+function LocationProbe() {
+  return <output data-testid="pathname">{useLocation().pathname}</output>;
+}
+
+function RetainedOwner({ onMount }: { onMount: () => void }) {
+  useEffect(onMount, [onMount]);
+  return <div data-testid="retained-owner">Retained thread list</div>;
+}
+
+function Harness({ onOwnerMount }: { onOwnerMount: () => void }) {
+  return (
+    <>
+      <SidebarNavigationRegion
+        splitEnabled
+        newThreadSplit={{ openInSplit: vi.fn() }}
+        onNavigate={vi.fn()}
+        onNewChat={vi.fn()}
+        onSearchThreads={mocks.onSearchThreads}
+        toolsRoutePath="/tools/plugins"
+      />
+      <RetainedOwner onMount={onOwnerMount} />
+      <LocationProbe />
+    </>
+  );
+}
+
+function renderHarness(onOwnerMount = vi.fn()) {
+  return render(
+    <Provider store={createStore()}>
+      <MemoryRouter>
+        <SidebarProvider>
+          <Harness onOwnerMount={onOwnerMount} />
+        </SidebarProvider>
+      </MemoryRouter>
+    </Provider>,
+  );
+}
+
+function registerFixture() {
+  setPluginSlotRegistrations(
+    "garden",
+    registrationSet({
+      navPanels: [
+        {
+          id: "docs",
+          title: "Docs",
+          icon: "BookOpen",
+          path: "docs",
+          component: () => null,
+        },
+      ],
+      experimentalSidebarNavigations: [
+        {
+          id: "navbar",
+          title: "Garden Navbar",
+          component: Replacement,
+        },
+      ],
+    }),
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  resetAllCrashedPluginSlotsForTest();
+  resetPluginSlotStoreForTest();
+  window.localStorage.clear();
+  vi.restoreAllMocks();
+  mocks.dispatch.mockReset();
+  mocks.onSearchThreads.mockReset();
+});
+
+describe("SidebarNavigationRegion", () => {
+  it("routes Search through the quick palette without inline search UI", () => {
+    registerFixture();
+    renderHarness();
+
+    fireEvent.click(screen.getByRole("button", { name: "Search threads" }));
+
+    expect(mocks.onSearchThreads).toHaveBeenCalledOnce();
+    expect(mocks.dispatch).toHaveBeenCalledWith("thread.search", null);
+    expect(
+      screen.queryByRole("combobox", { name: "Search threads" }),
+    ).toBeNull();
+    expect(screen.getByTestId("replacement-navigation")).toBeDefined();
+  });
+
+  it("navigates to a current plugin destination through the host", () => {
+    registerFixture();
+    renderHarness();
+
+    fireEvent.click(screen.getByRole("button", { name: "Docs" }));
+
+    expect(screen.getByTestId("pathname").textContent).toBe(
+      "/plugins/garden/docs",
+    );
+  });
+
+  it("delegates and falls back after a crash without owner remounts", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    registerFixture();
+    const ownerMount = vi.fn();
+    renderHarness(ownerMount);
+    expect(ownerMount).toHaveBeenCalledOnce();
+
+    fireEvent.click(screen.getByRole("button", { name: "Delegate to BB" }));
+    expect(screen.getByTestId("built-in-sidebar-navigation")).toBeDefined();
+    expect(ownerMount).toHaveBeenCalledOnce();
+
+    cleanup();
+    resetAllCrashedPluginSlotsForTest();
+    renderHarness(ownerMount);
+    fireEvent.click(screen.getByRole("button", { name: "Crash replacement" }));
+    expect(screen.getByTestId("built-in-sidebar-navigation")).toBeDefined();
+    expect(ownerMount).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/app/src/components/sidebar/SidebarNavigationRegion.tsx
+++ b/apps/app/src/components/sidebar/SidebarNavigationRegion.tsx
@@ -1,0 +1,264 @@
+import {
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
+import type {
+  ExperimentalSidebarNavigationAction,
+  ExperimentalSidebarNavigationActivationOptions,
+  ExperimentalSidebarNavigationItem,
+} from "@get-bb/plugin-sdk";
+import { useLocation, useNavigate } from "react-router-dom";
+import { toast } from "sonner";
+import {
+  useAppCommandRunner,
+  useAppCommandShortcut,
+} from "@/components/commands/AppCommandProvider";
+import { PluginReplacementSlot } from "@/components/plugin/PluginReplacementSlot";
+import { useSidebar } from "@/components/ui/sidebar";
+import { usePluginSlots } from "@/lib/plugin-slots";
+import { getPluginPanelRoutePath } from "@/lib/route-paths";
+import {
+  BuiltInSidebarNavigation,
+  type BuiltInSidebarNavigationProps,
+} from "./BuiltInSidebarNavigation";
+import {
+  activateSidebarNavigationItem,
+  createSidebarNavigationItems,
+  resolveActiveSidebarNavigationItemId,
+} from "./sidebarNavigationItems";
+import { useSidebarNavigationReplacement } from "./sidebarNavigationProvider";
+import { usePaneContentSplitActions } from "./usePaneContentSplitDrag";
+
+const SIDEBAR_NAVIGATION_SLOT_KIND = "sidebarNavigation";
+const NEW_THREAD_CONTENT = { kind: "new-thread" } as const;
+
+function contentForAction(
+  action: ExperimentalSidebarNavigationAction,
+  navPanels: ReturnType<typeof usePluginSlots>["navPanels"],
+) {
+  if (action.kind === "new-thread") return NEW_THREAD_CONTENT;
+  if (action.kind !== "open-plugin-panel") return null;
+  const panel = navPanels.find(
+    (candidate) =>
+      candidate.pluginId === action.pluginId && candidate.id === action.panelId,
+  );
+  return panel
+    ? ({
+        kind: "plugin-panel",
+        pluginId: panel.pluginId,
+        panelPath: panel.path,
+        subPath: "",
+      } as const)
+    : null;
+}
+
+export function SidebarNavigationRegion(props: BuiltInSidebarNavigationProps) {
+  const { navPanels } = usePluginSlots();
+  const replacement = useSidebarNavigationReplacement();
+  const { isCompactViewport } = useSidebar();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const commandRunner = useAppCommandRunner();
+  const splitActions = usePaneContentSplitActions();
+  const newThreadShortcut = useAppCommandShortcut("thread.new");
+  const threadSearchShortcut = useAppCommandShortcut("thread.search");
+
+  const splitPropsFor = useCallback(
+    (
+      action: ExperimentalSidebarNavigationAction,
+      label: string,
+    ): ExperimentalSidebarNavigationItem["experimental_splitProps"] => {
+      const content = contentForAction(action, navPanels);
+      if (content === null || splitActions.isCompact) return {};
+      return {
+        onPointerDown: (event: ReactPointerEvent<HTMLElement>) =>
+          splitActions.beginDrag(event, {
+            content,
+            enabled: props.splitEnabled ?? false,
+            label,
+            onNavigate: props.onNavigate,
+          }),
+      };
+    },
+    [navPanels, props.onNavigate, props.splitEnabled, splitActions],
+  );
+  const items = useMemo(
+    () =>
+      createSidebarNavigationItems({
+        navPanels,
+        newThreadDisabled: props.onNewChat === undefined,
+        newThreadShortcut: newThreadShortcut
+          ? {
+              label: newThreadShortcut.label,
+              ariaKeyShortcuts: newThreadShortcut.ariaKeyshortcuts,
+            }
+          : null,
+        searchThreadsDisabled: !commandRunner.isCommandAvailable(
+          "thread.search",
+          null,
+        ),
+        searchThreadsShortcut: threadSearchShortcut
+          ? {
+              label: threadSearchShortcut.label,
+              ariaKeyShortcuts: threadSearchShortcut.ariaKeyshortcuts,
+            }
+          : null,
+        showExtensions: props.toolsRoutePath !== undefined,
+        splitPropsFor,
+      }),
+    [
+      commandRunner,
+      navPanels,
+      newThreadShortcut,
+      props.onNewChat,
+      props.toolsRoutePath,
+      splitPropsFor,
+      threadSearchShortcut,
+    ],
+  );
+  const activeItemId = resolveActiveSidebarNavigationItemId({
+    items,
+    pathname: location.pathname,
+    navPanels,
+  });
+  const replacementIdentity =
+    replacement.kind === "plugin"
+      ? `${replacement.registration.pluginId}/${replacement.registration.id}/${replacement.registration.generation}`
+      : "owner";
+  const activationRef = useRef({
+    replacementIdentity,
+    items,
+    navPanels,
+    props,
+    navigate,
+    commandRunner,
+    splitActions,
+  });
+  useLayoutEffect(() => {
+    activationRef.current = {
+      replacementIdentity,
+      items,
+      navPanels,
+      props,
+      navigate,
+      commandRunner,
+      splitActions,
+    };
+  }, [
+    commandRunner,
+    items,
+    navPanels,
+    navigate,
+    props,
+    replacementIdentity,
+    splitActions,
+  ]);
+
+  const handleActivate = useCallback(
+    (
+      identity: string,
+      itemId: string,
+      options: ExperimentalSidebarNavigationActivationOptions,
+    ) => {
+      const current = activationRef.current;
+      if (identity !== current.replacementIdentity) return;
+      activateSidebarNavigationItem(
+        current.items,
+        itemId,
+        options.openInSplit,
+        {
+          newThread: (openInSplit) => {
+            if (!openInSplit) {
+              current.props.onNewChat?.();
+              return;
+            }
+            current.splitActions.openInSplit({
+              content: NEW_THREAD_CONTENT,
+              enabled: current.props.splitEnabled ?? false,
+              label: "New thread",
+              onNavigate: current.props.onNavigate,
+            });
+          },
+          searchThreads: () => {
+            current.props.onSearchThreads?.();
+            current.commandRunner.dispatch("thread.search", null);
+          },
+          openExtensions: () => {
+            if (current.props.toolsRoutePath === undefined) return;
+            current.props.onNavigate?.();
+            void current.navigate(current.props.toolsRoutePath);
+          },
+          openPluginPanel: (action, openInSplit) => {
+            const panel = current.navPanels.find(
+              (candidate) =>
+                candidate.pluginId === action.pluginId &&
+                candidate.id === action.panelId,
+            );
+            if (!panel) return;
+            if (openInSplit) {
+              current.splitActions.openInSplit({
+                content: {
+                  kind: "plugin-panel",
+                  pluginId: panel.pluginId,
+                  panelPath: panel.path,
+                  subPath: "",
+                },
+                enabled: current.props.splitEnabled ?? false,
+                label: panel.title,
+                onNavigate: current.props.onNavigate,
+              });
+              return;
+            }
+            current.props.onNavigate?.();
+            void current.navigate(
+              getPluginPanelRoutePath({
+                pluginId: panel.pluginId,
+                path: panel.path,
+              }),
+            );
+          },
+        },
+      );
+    },
+    [],
+  );
+
+  const original = <BuiltInSidebarNavigation {...props} />;
+  const title =
+    replacement.kind === "plugin" ? replacement.registration.title : "Plugin";
+  return (
+    <nav
+      aria-label="Sidebar navigation"
+      data-testid="sidebar-navigation-region"
+    >
+      <PluginReplacementSlot
+        replacement={replacement}
+        original={original}
+        slotKind={SIDEBAR_NAVIGATION_SLOT_KIND}
+        onCrash={(pluginId) => {
+          toast.error("Sidebar navigation plugin crashed", {
+            description: `${title} (${pluginId}) stopped working, so bb's own navigation is back.`,
+          });
+        }}
+      >
+        {(slot, Original) => {
+          const identity = `${slot.pluginId}/${slot.id}/${slot.generation}`;
+          return (
+            <slot.component
+              items={items}
+              activeItemId={activeItemId}
+              isCompactViewport={isCompactViewport}
+              experimental_activate={(itemId, options) =>
+                handleActivate(identity, itemId, options)
+              }
+              experimental_Original={Original}
+            />
+          );
+        }}
+      </PluginReplacementSlot>
+    </nav>
+  );
+}

--- a/apps/app/src/components/sidebar/sidebarNavigationItems.ts
+++ b/apps/app/src/components/sidebar/sidebarNavigationItems.ts
@@ -1,0 +1,163 @@
+import type {
+  ExperimentalSidebarNavigationAction,
+  ExperimentalSidebarNavigationItem,
+  ExperimentalSidebarNavigationShortcut,
+} from "@get-bb/plugin-sdk";
+import type { PluginNavPanelSlot } from "@/lib/plugin-slots";
+import { getPluginPanelRoutePath, isToolsRoutePath } from "@/lib/route-paths";
+
+export const NEW_THREAD_NAVIGATION_ITEM_ID = "new-thread";
+export const SEARCH_THREADS_NAVIGATION_ITEM_ID = "search-threads";
+export const EXTENSIONS_NAVIGATION_ITEM_ID = "extensions";
+
+export function getPluginPanelNavigationItemId(
+  panel: Pick<PluginNavPanelSlot, "pluginId" | "id">,
+): string {
+  return `plugin-panel:${encodeURIComponent(panel.pluginId)}/${encodeURIComponent(panel.id)}`;
+}
+
+type SplitProps = ExperimentalSidebarNavigationItem["experimental_splitProps"];
+
+interface CreateSidebarNavigationItemsOptions {
+  navPanels: readonly PluginNavPanelSlot[];
+  newThreadDisabled: boolean;
+  newThreadShortcut: ExperimentalSidebarNavigationShortcut | null;
+  searchThreadsDisabled: boolean;
+  searchThreadsShortcut: ExperimentalSidebarNavigationShortcut | null;
+  showExtensions: boolean;
+  splitPropsFor(
+    action: ExperimentalSidebarNavigationAction,
+    label: string,
+  ): SplitProps;
+}
+
+export function createSidebarNavigationItems({
+  navPanels,
+  newThreadDisabled,
+  newThreadShortcut,
+  searchThreadsDisabled,
+  searchThreadsShortcut,
+  showExtensions,
+  splitPropsFor,
+}: CreateSidebarNavigationItemsOptions): readonly ExperimentalSidebarNavigationItem[] {
+  const newThreadAction = { kind: "new-thread" } as const;
+  const searchAction = { kind: "search-threads" } as const;
+  const extensionsAction = { kind: "open-extensions" } as const;
+  return [
+    {
+      id: NEW_THREAD_NAVIGATION_ITEM_ID,
+      label: "New thread",
+      icon: { kind: "host", name: "new-thread" },
+      action: newThreadAction,
+      isDisabled: newThreadDisabled,
+      shortcut: newThreadShortcut,
+      experimental_splitProps: splitPropsFor(newThreadAction, "New thread"),
+    },
+    {
+      id: SEARCH_THREADS_NAVIGATION_ITEM_ID,
+      label: "Search threads",
+      icon: { kind: "host", name: "search" },
+      action: searchAction,
+      isDisabled: searchThreadsDisabled,
+      shortcut: searchThreadsShortcut,
+      experimental_splitProps: {},
+    },
+    ...(showExtensions
+      ? [
+          {
+            id: EXTENSIONS_NAVIGATION_ITEM_ID,
+            label: "Extensions",
+            icon: { kind: "host", name: "extensions" },
+            action: extensionsAction,
+            isDisabled: false,
+            shortcut: null,
+            experimental_splitProps: {},
+          } satisfies ExperimentalSidebarNavigationItem,
+        ]
+      : []),
+    ...navPanels.map((panel): ExperimentalSidebarNavigationItem => {
+      const action = {
+        kind: "open-plugin-panel",
+        pluginId: panel.pluginId,
+        panelId: panel.id,
+      } as const;
+      return {
+        id: getPluginPanelNavigationItemId(panel),
+        label: panel.title,
+        icon: {
+          kind: "plugin",
+          pluginId: panel.pluginId,
+          icon: panel.icon,
+        },
+        action,
+        isDisabled: false,
+        shortcut: null,
+        experimental_splitProps: splitPropsFor(action, panel.title),
+      };
+    }),
+  ];
+}
+
+export function resolveActiveSidebarNavigationItemId({
+  items,
+  pathname,
+  navPanels,
+}: {
+  items: readonly ExperimentalSidebarNavigationItem[];
+  pathname: string;
+  navPanels: readonly PluginNavPanelSlot[];
+}): string | null {
+  if (pathname === "/") return NEW_THREAD_NAVIGATION_ITEM_ID;
+  if (isToolsRoutePath(pathname)) {
+    return items.some((item) => item.id === EXTENSIONS_NAVIGATION_ITEM_ID)
+      ? EXTENSIONS_NAVIGATION_ITEM_ID
+      : null;
+  }
+  for (const panel of navPanels) {
+    const path = getPluginPanelRoutePath({
+      pluginId: panel.pluginId,
+      path: panel.path,
+    });
+    if (pathname === path || pathname.startsWith(`${path}/`)) {
+      return getPluginPanelNavigationItemId(panel);
+    }
+  }
+  return null;
+}
+
+export interface SidebarNavigationActivationHandlers {
+  newThread(openInSplit: boolean): void;
+  searchThreads(): void;
+  openExtensions(): void;
+  openPluginPanel(
+    action: Extract<
+      ExperimentalSidebarNavigationAction,
+      { kind: "open-plugin-panel" }
+    >,
+    openInSplit: boolean,
+  ): void;
+}
+
+export function activateSidebarNavigationItem(
+  items: readonly ExperimentalSidebarNavigationItem[],
+  itemId: string,
+  openInSplit: boolean,
+  handlers: SidebarNavigationActivationHandlers,
+): void {
+  const item = items.find((candidate) => candidate.id === itemId);
+  if (!item || item.isDisabled) return;
+
+  switch (item.action.kind) {
+    case "new-thread":
+      handlers.newThread(openInSplit);
+      return;
+    case "search-threads":
+      handlers.searchThreads();
+      return;
+    case "open-extensions":
+      handlers.openExtensions();
+      return;
+    case "open-plugin-panel":
+      handlers.openPluginPanel(item.action, openInSplit);
+  }
+}

--- a/apps/app/src/components/sidebar/sidebarNavigationProvider.ts
+++ b/apps/app/src/components/sidebar/sidebarNavigationProvider.ts
@@ -1,0 +1,25 @@
+import { useAtomValue } from "jotai";
+import {
+  createReplacementPreferenceAtom,
+  resolvePreferredReplacement,
+} from "@/lib/plugin-replacement-preference";
+import type { ResolvedReplacement } from "@/lib/plugin-slot-resolvers";
+import {
+  usePluginSlots,
+  type ExperimentalSidebarNavigationSlot,
+} from "@/lib/plugin-slots";
+
+const SIDEBAR_NAVIGATION_PROVIDER_STORAGE_KEY = "bb.sidebar.navigationProvider";
+
+export const sidebarNavigationProviderAtom = createReplacementPreferenceAtom(
+  SIDEBAR_NAVIGATION_PROVIDER_STORAGE_KEY,
+);
+
+export function useSidebarNavigationReplacement(): ResolvedReplacement<ExperimentalSidebarNavigationSlot> {
+  const { experimentalSidebarNavigations } = usePluginSlots();
+  const preference = useAtomValue(sidebarNavigationProviderAtom);
+  return resolvePreferredReplacement(
+    experimentalSidebarNavigations,
+    preference,
+  );
+}

--- a/apps/app/src/components/sidebar/usePaneContentSplitDrag.ts
+++ b/apps/app/src/components/sidebar/usePaneContentSplitDrag.ts
@@ -1,4 +1,8 @@
-import { useCallback, type PointerEvent as ReactPointerEvent } from "react";
+import {
+  useCallback,
+  useMemo,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
 import { useStore } from "jotai";
 import { useNavigate } from "react-router-dom";
 import { useIsCompactViewport } from "@bb/shared-ui/hooks/use-compact-viewport";
@@ -44,32 +48,57 @@ function routeForContent(content: PaneContent): string {
   });
 }
 
-export function usePaneContentSplitDrag({
-  content,
-  enabled,
-  label,
-}: {
+export function usePaneContentSplitDrag(options: PaneContentSplitOptions) {
+  const actions = usePaneContentSplitActions();
+  const openInSplit = useCallback(
+    () => actions.openInSplit(options),
+    [actions, options],
+  );
+  const onPointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLElement>) =>
+      actions.beginDrag(event, options),
+    [actions, options],
+  );
+
+  return {
+    onPointerDown:
+      options.enabled && !actions.isCompact ? onPointerDown : undefined,
+    openInSplit,
+  };
+}
+
+interface PaneContentSplitOptions {
   content: PaneContent;
   enabled: boolean;
   label: string;
-}) {
+  onNavigate?: () => void;
+}
+
+export function usePaneContentSplitActions() {
   const store = useStore();
   const navigate = useNavigate();
   const isCompact = useIsCompactViewport();
 
-  const openInSplit = useCallback(() => {
-    openPaneContentInSplit({
-      store,
-      navigate,
-      content,
-      route: routeForContent(content),
-      enabled: enabled && !isCompact,
-    });
-  }, [content, enabled, isCompact, navigate, store]);
+  const openInSplit = useCallback(
+    ({ content, enabled, onNavigate }: PaneContentSplitOptions) => {
+      onNavigate?.();
+      openPaneContentInSplit({
+        store,
+        navigate,
+        content,
+        route: routeForContent(content),
+        enabled: enabled && !isCompact,
+      });
+    },
+    [isCompact, navigate, store],
+  );
 
   const onPointerDown = useCallback(
-    (event: ReactPointerEvent<HTMLElement>) => {
-      if (!enabled || event.button !== 0) return;
+    (
+      event: ReactPointerEvent<HTMLElement>,
+      { content, enabled, label, onNavigate }: PaneContentSplitOptions,
+    ) => {
+      if (!enabled || isCompact || event.button !== 0) return;
       const rowEl = event.currentTarget;
       const sidebarEl = rowEl.closest(SIDEBAR_SELECTOR);
       const sidebarRightEdge = (sidebarEl ?? rowEl).getBoundingClientRect()
@@ -111,6 +140,7 @@ export function usePaneContentSplitDrag({
                 ? replacePaneContent(layout, target.paneId, content)
                 : splitPane(layout, target.paneId, target.zone, content);
           if (next !== layout) store.set(splitLayoutAtom, next);
+          onNavigate?.();
           navigate(
             routeForContent(content),
             existing !== null ? { replace: true } : undefined,
@@ -118,13 +148,13 @@ export function usePaneContentSplitDrag({
         },
       });
     },
-    [content, enabled, label, navigate, store],
+    [isCompact, navigate, store],
   );
 
-  return {
-    onPointerDown: enabled && !isCompact ? onPointerDown : undefined,
-    openInSplit,
-  };
+  return useMemo(
+    () => ({ beginDrag: onPointerDown, isCompact, openInSplit }),
+    [isCompact, onPointerDown, openInSplit],
+  );
 }
 
 function singlePaneFallback(

--- a/apps/app/src/components/tools/PluginCapabilities.tsx
+++ b/apps/app/src/components/tools/PluginCapabilities.tsx
@@ -223,6 +223,13 @@ function pluginAppSurfaceItems(
     ),
     ...namedSlotItems(
       pluginId,
+      slots.experimentalSidebarNavigations,
+      "sidebar-navigation",
+      "Can replace the sidebar navigation controls; configured in Appearance.",
+      () => getSettingsRoutePath("appearance"),
+    ),
+    ...namedSlotItems(
+      pluginId,
       slots.sourceCodeRenderers,
       "source-code-renderer",
       "Replaces how source code is displayed everywhere in the app.",

--- a/apps/app/src/lib/plugin-slots.ts
+++ b/apps/app/src/lib/plugin-slots.ts
@@ -13,6 +13,7 @@ import type {
   PluginProviderIconRegistration,
   PluginSettingsSectionRegistration,
   PluginSidebarFooterActionRegistration,
+  ExperimentalSidebarNavigationRegistration,
   PluginSourceCodeRendererRegistration,
   PluginThreadHeaderActionRegistration,
   PluginThreadListRegistration,
@@ -29,6 +30,7 @@ export interface PluginRegistrationSet {
   composerCustomizations?: readonly ComposerCustomization[];
   pendingInteractions?: readonly PluginPendingInteractionRegistration[];
   sidebarFooterActions: readonly PluginSidebarFooterActionRegistration[];
+  experimentalSidebarNavigations?: readonly ExperimentalSidebarNavigationRegistration[];
   threadLists?: readonly PluginThreadListRegistration[];
   threadHeaderActions?: readonly PluginThreadHeaderActionRegistration[];
   fileOpeners: readonly PluginFileOpenerRegistration[];
@@ -62,6 +64,8 @@ export interface PluginPendingInteractionSlot
   extends PluginPendingInteractionRegistration, PluginSlotBase {}
 export interface PluginSidebarFooterActionSlot
   extends PluginSidebarFooterActionRegistration, PluginSlotBase {}
+export interface ExperimentalSidebarNavigationSlot
+  extends ExperimentalSidebarNavigationRegistration, PluginSlotBase {}
 export interface PluginThreadListSlot
   extends PluginThreadListRegistration, PluginSlotBase {}
 interface PluginThreadHeaderActionSlot
@@ -92,6 +96,7 @@ export interface PluginSlotSnapshot {
   composerCustomizations: readonly PluginComposerCustomizationSlot[];
   pendingInteractions: readonly PluginPendingInteractionSlot[];
   sidebarFooterActions: readonly PluginSidebarFooterActionSlot[];
+  experimentalSidebarNavigations: readonly ExperimentalSidebarNavigationSlot[];
   threadLists: readonly PluginThreadListSlot[];
   threadHeaderActions: readonly PluginThreadHeaderActionSlot[];
   fileOpeners: readonly PluginFileOpenerSlot[];
@@ -113,6 +118,7 @@ export const EMPTY_PLUGIN_SLOT_SNAPSHOT: PluginSlotSnapshot = {
   composerCustomizations: [],
   pendingInteractions: [],
   sidebarFooterActions: [],
+  experimentalSidebarNavigations: [],
   threadLists: [],
   threadHeaderActions: [],
   fileOpeners: [],
@@ -141,6 +147,7 @@ const SLOT_KINDS: readonly SlotKind[] = [
   "composerCustomizations",
   "pendingInteractions",
   "sidebarFooterActions",
+  "experimentalSidebarNavigations",
   "threadLists",
   "threadHeaderActions",
   "fileOpeners",
@@ -181,6 +188,7 @@ function flattenRegistrations(
     composerCustomizations: stamp(set.composerCustomizations),
     pendingInteractions: stamp(set.pendingInteractions),
     sidebarFooterActions: stamp(set.sidebarFooterActions),
+    experimentalSidebarNavigations: stamp(set.experimentalSidebarNavigations),
     threadLists: stamp(set.threadLists),
     threadHeaderActions: stamp(set.threadHeaderActions),
     fileOpeners: stamp(set.fileOpeners),

--- a/apps/app/src/views/SettingsView.tsx
+++ b/apps/app/src/views/SettingsView.tsx
@@ -41,6 +41,7 @@ import { UsageLimitsSettingsSection } from "@/components/settings/UsageLimitsSet
 import { ProvidersSettingsSection } from "@/components/settings/ProvidersSettingsSection";
 import { CodeRendererSettings } from "@/components/settings/CodeRendererSettings";
 import { SidebarThreadListSetting } from "@/components/settings/SidebarThreadListSetting";
+import { SidebarNavigationSetting } from "@/components/settings/SidebarNavigationSetting";
 import { SplitDimmingSetting } from "@/components/settings/SplitDimmingSetting";
 import { useSettingsNavState } from "@/components/settings/settings-nav";
 import { PluginSettingsPage } from "@/components/plugin/PluginSettings";
@@ -562,6 +563,7 @@ export function AppearanceSettingsSection({
     <SettingsSection title="Appearance">
       <div className="space-y-5">
         <SidebarThreadListSetting />
+        <SidebarNavigationSetting />
         <CodeRendererSettings />
         <SettingsWithControl label="Theme">
           <DropdownMenu>

--- a/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/references/frontend-api-index.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/references/frontend-api-index.md
@@ -43,6 +43,12 @@ Read the installed SDK declarations for the exact current signatures.
 - `PluginPendingInteractionView`
 - `PluginPendingInteractionProps`
 - `PluginSidebarFooterActionProps`
+- `ExperimentalSidebarNavigationShortcut`
+- `ExperimentalSidebarNavigationAction`
+- `ExperimentalSidebarNavigationIcon`
+- `ExperimentalSidebarNavigationItem`
+- `ExperimentalSidebarNavigationActivationOptions`
+- `ExperimentalSidebarNavigationProps`
 - `PluginThreadListProps`
 - `PluginThreadHeaderActionProps`
 - `PluginFileOpenerSource`
@@ -74,6 +80,7 @@ Read the installed SDK declarations for the exact current signatures.
 - `PluginPendingInteractionRegistration`
 - `PluginSidebarFooterActionContext`
 - `PluginSidebarFooterActionRegistration`
+- `ExperimentalSidebarNavigationRegistration`
 - `PluginSidebarThreadIndicator`
 - `PluginSidebarWorkspaceKind`
 - `PluginSidebarThreadActivity`

--- a/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/references/frontend-core-slots.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/references/frontend-core-slots.md
@@ -212,6 +212,13 @@ target? })`. Inside the fixed-tab component,
   (sync or async) are contained and logged,
   never breaking the sidebar. `title` is the tooltip + accessible label;
   `icon` is a BB icon-name hint (unknown names fall back to a generic bolt).
+- `experimental_sidebarNavigation` → replaces the bounded navigation controls
+  above the thread list. Registration:
+  `{ id, title, description?, component }`. The component receives semantic
+  host items, the active item id, the compact-viewport state,
+  `experimental_activate`, and `experimental_Original`. Search activation opens
+  the quick palette. No inline search field or query state exists. BB keeps the
+  drawer, thread list, footer, resize handle, and shortcut ownership.
 - `fileOpener` → `{ path: string, source, Original }` — register as a viewer/editor
   for file extensions: `{ id, title, extensions: ["md"], component }`.
   Matching files use the first applicable opener in deterministic slot order

--- a/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/references/frontend-registration.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/references/frontend-registration.md
@@ -118,6 +118,11 @@ export default definePluginApp((app) => {
     icon: "Smartphone",
     run: ({ openSettings }) => openSettings(),
   });
+  app.slots.experimental_sidebarNavigation({
+    id: "compact",
+    title: "Compact navigation",
+    component: CompactSidebarNavigation,
+  });
   app.slots.messageDirective({ id: "inline-vis", component: InlineVis });
   app.slots.experimental_threadList({
     id: "inbox",
@@ -152,6 +157,25 @@ state in the component, never in a module-level singleton.
 A common pairing with a replaced sidebar: hide child threads from the list and
 surface them here instead, filtering `experimental_useSidebarThreads()` by
 `parentThreadId === threadId`.
+
+### Replacing the sidebar navigation
+
+`app.slots.experimental_sidebarNavigation` replaces the navigation controls
+above the thread list. The component receives semantic items for New thread,
+Search threads, Extensions, and plugin panels. BB keeps the drawer, thread
+list, footer, resize handle, and hidden-body shortcut policy.
+
+Each item has an `id`, `label`, semantic `icon`, host `action`, disabled state,
+shortcut metadata, and `experimental_splitProps`. Spread the split props onto
+the interactive element. Call
+`experimental_activate(item.id, { openInSplit })` for activation. Search opens
+the host quick palette. The former inline sidebar search field and query state
+are not part of this API.
+
+The component also receives `experimental_Original`. Render it to delegate to
+BB without another replacement lookup. BB restores the original controls if
+the selected replacement is unavailable or crashes. Users can select
+Automatic, BB, or one plugin under Settings → Appearance → Navigation.
 
 ### Replacing the sidebar thread list
 

--- a/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/references/frontend-registration.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/references/frontend-registration.md
@@ -161,9 +161,10 @@ surface them here instead, filtering `experimental_useSidebarThreads()` by
 ### Replacing the sidebar navigation
 
 `app.slots.experimental_sidebarNavigation` replaces the navigation controls
-above the thread list. The component receives semantic items for New thread,
-Search threads, Extensions, and plugin panels. BB keeps the drawer, thread
-list, footer, resize handle, and hidden-body shortcut policy.
+above the thread list. The component receives `items`, `activeItemId`, and
+`isCompactViewport`. The items represent New thread, Search threads,
+Extensions, and plugin panels. BB keeps the drawer, thread list, footer,
+resize handle, and hidden-body shortcut policy.
 
 Each item has an `id`, `label`, semantic `icon`, host `action`, disabled state,
 shortcut metadata, and `experimental_splitProps`. Spread the split props onto

--- a/apps/server/test/services/plugins/plugin-authoring-docs.test.ts
+++ b/apps/server/test/services/plugins/plugin-authoring-docs.test.ts
@@ -27,6 +27,7 @@ import {
   type PluginSettingDescriptor,
   type PluginSettingsSectionProps,
   type PluginSidebarFooterActionProps,
+  type ExperimentalSidebarNavigationProps,
   type PluginSourceCodeRendererProps,
   type PluginThreadHeaderActionProps,
   type PluginThreadListProps,
@@ -244,6 +245,7 @@ type SlotPropsByName = {
   experimental_newThreadPanelAction: PluginNewThreadPanelProps;
   pendingInteraction: PluginPendingInteractionProps;
   sidebarFooterAction: PluginSidebarFooterActionProps;
+  experimental_sidebarNavigation: ExperimentalSidebarNavigationProps;
   experimental_threadList: PluginThreadListProps;
   experimental_threadHeaderAction: PluginThreadHeaderActionProps;
   fileOpener: PluginFileOpenerProps;
@@ -313,6 +315,13 @@ const FRONTEND_SLOT_PROP_FIELDS = {
   experimental_newThreadPanelAction: ["projectId", "params"],
   pendingInteraction: ["interaction", "submit", "cancel"],
   sidebarFooterAction: [],
+  experimental_sidebarNavigation: [
+    "items",
+    "activeItemId",
+    "isCompactViewport",
+    "experimental_activate",
+    "experimental_Original",
+  ],
   experimental_threadList: [
     "activeThreadId",
     "activeProjectId",

--- a/docs/api_to_audit.md
+++ b/docs/api_to_audit.md
@@ -1687,6 +1687,37 @@ Before stabilization, audit:
    re-litigate that in the stabilization audit; audit only whether the two
    _contexts_ should merge.
 
+## `app.slots.experimental_sidebarNavigation` (`@get-bb/plugin-sdk/app`)
+
+**What it does.** Replaces the bounded sidebar navigation controls for New
+thread, Search threads, Extensions, and plugin panel destinations. The plugin
+receives semantic items, split-drag bindings, and one host activation callback.
+BB retains the drawer, thread list, footer, resize handle, and hidden-body
+shortcut policy.
+
+Search activation opens the quick palette. The removed inline sidebar search
+field, query state, combobox, and result list do not form part of this API.
+`experimental_Original` bypasses replacement resolution. A crash restores only
+the bounded controls and leaves the retained sidebar regions mounted.
+
+**Audit before stabilizing.**
+
+1. **Boundary.** Verify plugins can express useful navigation without control
+   of the drawer, thread list, footer, resize handle, or shortcuts.
+2. **Semantic items.** Confirm the action and icon variants cover current
+   navigation without exposing routes or host React elements.
+3. **Split contract.** Audit `experimental_splitProps` and
+   `experimental_activate(..., { openInSplit })` for pointer, keyboard,
+   modifier-click, pane-cap, and compact behavior.
+4. **Search action.** Confirm a semantic quick-palette action remains useful
+   without the former inline query and result UI.
+5. **Crash and delegation.** Verify `experimental_Original` and crash fallback
+   never recurse or remount the thread list and footer.
+6. **Arbitration.** Confirm Automatic remains the correct default when several
+   navigation replacements exist.
+7. **Accessibility.** Validate labels, `aria-current`, shortcut metadata,
+   disabled state, and focus order in third-party markup.
+
 ## `app.slots.experimental_threadList` (`@get-bb/plugin-sdk/app`)
 
 **Kept experimental (2026-08-22).** examples only; no shipped consumer has tested the arbitration/fallback model or the accessibility contract.

--- a/examples/plugins/sidebar-navigation/.gitignore
+++ b/examples/plugins/sidebar-navigation/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/examples/plugins/sidebar-navigation/README.md
+++ b/examples/plugins/sidebar-navigation/README.md
@@ -1,0 +1,16 @@
+# Sidebar navigation example
+
+This plugin replaces the bounded navigation controls above the thread list. BB
+still owns the drawer, thread list, footer, resize handle, and shortcut policy.
+
+The example shows each semantic navigation item in a compact grid. Each button
+uses the host activation callback and the host split-drag binding. Search opens
+the quick palette. The plugin does not create an inline search field.
+
+Use **Use BB navigation** to render `experimental_Original`. Use **Test
+fallback** to verify that a component crash restores the built-in controls.
+
+```sh
+bb plugin build examples/plugins/sidebar-navigation
+bb plugin install examples/plugins/sidebar-navigation
+```

--- a/examples/plugins/sidebar-navigation/app.tsx
+++ b/examples/plugins/sidebar-navigation/app.tsx
@@ -1,0 +1,112 @@
+import { useState } from "react";
+import {
+  definePluginApp,
+  type ExperimentalSidebarNavigationItem,
+  type ExperimentalSidebarNavigationProps,
+} from "@get-bb/plugin-sdk/app";
+
+const HOST_ICON: Record<
+  Extract<ExperimentalSidebarNavigationItem["icon"], { kind: "host" }>["name"],
+  string
+> = {
+  "new-thread": "+",
+  search: "⌕",
+  extensions: "◇",
+};
+
+function itemGlyph(item: ExperimentalSidebarNavigationItem): string {
+  return item.icon.kind === "host" ? HOST_ICON[item.icon.name] : "◆";
+}
+
+function SidebarNavigation({
+  activeItemId,
+  experimental_Original: Original,
+  experimental_activate,
+  isCompactViewport,
+  items,
+}: ExperimentalSidebarNavigationProps) {
+  const [showOriginal, setShowOriginal] = useState(false);
+  const [shouldCrash, setShouldCrash] = useState(false);
+  if (shouldCrash) throw new Error("Example navigation crash");
+
+  if (showOriginal) {
+    return (
+      <section data-testid="sidebar-navigation-example-original">
+        <div className="px-2 pt-2">
+          <button
+            type="button"
+            className="w-full rounded-md border border-sidebar-border px-2 py-1.5 text-left text-xs text-sidebar-foreground hover:bg-sidebar-accent"
+            onClick={() => setShowOriginal(false)}
+          >
+            Return to custom navigation
+          </button>
+        </div>
+        <Original />
+      </section>
+    );
+  }
+
+  return (
+    <section
+      data-testid="sidebar-navigation-example"
+      aria-label="Custom sidebar navigation"
+      className="space-y-2 px-2 py-2 text-sidebar-foreground"
+    >
+      <div className="flex items-center gap-1 px-1 text-xs text-muted-foreground">
+        <strong className="mr-auto font-medium text-sidebar-foreground">
+          Garden navigation
+        </strong>
+        <span>{isCompactViewport ? "Compact" : "Desktop"}</span>
+      </div>
+      <div className="grid grid-cols-2 gap-1">
+        {items.map((item) => (
+          <button
+            key={item.id}
+            type="button"
+            disabled={item.isDisabled}
+            aria-current={item.id === activeItemId ? "page" : undefined}
+            aria-keyshortcuts={item.shortcut?.ariaKeyShortcuts}
+            title={item.shortcut?.label}
+            className="flex min-w-0 items-center gap-2 rounded-md border border-sidebar-border px-2 py-1.5 text-left text-xs hover:bg-sidebar-accent disabled:opacity-50 aria-[current=page]:bg-sidebar-accent aria-[current=page]:font-medium"
+            {...item.experimental_splitProps}
+            onClick={(event) =>
+              experimental_activate(item.id, {
+                openInSplit: event.metaKey || event.ctrlKey,
+              })
+            }
+          >
+            <span aria-hidden className="w-3 shrink-0 text-center">
+              {itemGlyph(item)}
+            </span>
+            <span className="min-w-0 truncate">{item.label}</span>
+          </button>
+        ))}
+      </div>
+      <div className="flex gap-1 border-t border-sidebar-border pt-2">
+        <button
+          type="button"
+          className="flex-1 rounded-md px-2 py-1 text-xs text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-foreground"
+          onClick={() => setShowOriginal(true)}
+        >
+          Use BB navigation
+        </button>
+        <button
+          type="button"
+          className="rounded-md px-2 py-1 text-xs text-muted-foreground hover:bg-sidebar-accent hover:text-destructive"
+          onClick={() => setShouldCrash(true)}
+        >
+          Test fallback
+        </button>
+      </div>
+    </section>
+  );
+}
+
+export default definePluginApp((app) => {
+  app.slots.experimental_sidebarNavigation({
+    id: "garden",
+    title: "Garden navigation",
+    description: "A compact grid for the host sidebar destinations.",
+    component: SidebarNavigation,
+  });
+});

--- a/examples/plugins/sidebar-navigation/package.json
+++ b/examples/plugins/sidebar-navigation/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "bb-plugin-sidebar-navigation",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "bbPluginSdk": ">=0.4.33"
+  },
+  "bb": {
+    "name": "Sidebar Navigation Example",
+    "description": "Replaces the bounded sidebar navigation controls with a compact grid.",
+    "branding": {
+      "icon": "PanelsTopLeft"
+    },
+    "server": "./server.ts",
+    "app": "./app.tsx"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@get-bb/plugin-sdk": "workspace:*",
+    "@types/react": "^19.0.0",
+    "react": "^19.0.0",
+    "typescript": "npm:@typescript/typescript6@^6.0.2"
+  }
+}

--- a/examples/plugins/sidebar-navigation/server.ts
+++ b/examples/plugins/sidebar-navigation/server.ts
@@ -1,0 +1,5 @@
+import type { BbPluginApi } from "@get-bb/plugin-sdk";
+
+export default function sidebarNavigationExample(bb: BbPluginApi) {
+  bb.log.info("Sidebar Navigation Example loaded");
+}

--- a/examples/plugins/sidebar-navigation/tsconfig.json
+++ b/examples/plugins/sidebar-navigation/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "lib": ["ES2022", "DOM"],
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["app.tsx", "server.ts"]
+}

--- a/packages/domain/src/plugin-sdk-version.ts
+++ b/packages/domain/src/plugin-sdk-version.ts
@@ -1,3 +1,3 @@
-export const PLUGIN_SDK_VERSION = "0.4.32";
+export const PLUGIN_SDK_VERSION = "0.4.33";
 
 export const PLUGIN_SDK_MAJOR = Number(PLUGIN_SDK_VERSION.split(".", 1)[0]);

--- a/packages/plugin-api-map/sdk-public-api.json
+++ b/packages/plugin-api-map/sdk-public-api.json
@@ -3,7 +3,7 @@
   "entries": {
     ".": {
       "types": "bundled-types/bb-plugin-sdk.d.ts",
-      "sha256": "edc32872dff37e9f9442c43796f6b5ad38b2856d495a4b8d71fbb9442e0aa5e2"
+      "sha256": "dc8088c81e6bd9487563bbc24ed8b7729b88a215a27603048c5703c9c7554700"
     },
     "./ai-services": {
       "types": "bundled-types/bb-plugin-sdk-ai-services.d.ts",
@@ -11,7 +11,7 @@
     },
     "./app": {
       "types": "bundled-types/bb-plugin-sdk-app.d.ts",
-      "sha256": "40829965310cc3d87c01ad6c15e5c091eb8a42ae6a5a184040b5b476abc7d21d"
+      "sha256": "6df302f5ba182bb44bafe5498253652165550d85941baa28b2ecafdf779c104c"
     },
     "./host": {
       "types": "bundled-types/bb-plugin-sdk-host.d.ts",
@@ -35,7 +35,7 @@
     },
     "./testing/app": {
       "types": "bundled-types/bb-plugin-sdk-testing-app.d.ts",
-      "sha256": "03ee2d241b823fdc421a9c5d2a3261a268de4aa751b1dc10d5c5a0e1d41e6907"
+      "sha256": "5e9d3cc86c2b186ae0e7b067c9a02af4e52650bbe2c0904ff16cbf0bc350d87b"
     },
     "./testing/host": {
       "types": "bundled-types/bb-plugin-sdk-testing-host.d.ts",

--- a/packages/plugin-api-map/src/anatomy-manifest.json
+++ b/packages/plugin-api-map/src/anatomy-manifest.json
@@ -1,12 +1,6 @@
 {
   "$comment": "Shared UI-anatomy contract between the Plugin Guide surface fixtures (wireframes.tsx) and the real app. Ordered regions are rendered by both sides. surfaceFixtures records authoritative source anchors plus the minimum deterministic fidelity and states for interaction-heavy fixtures.",
-  "appSidebar": [
-    "top-reserve",
-    "primary-actions",
-    "plugin-nav",
-    "thread-list",
-    "footer"
-  ],
+  "appSidebar": ["top-reserve", "sidebar-navigation", "thread-list", "footer"],
   "sidebarFooter": ["settings", "plugin-footer-actions", "bug-report"],
   "messageActionBar": [
     "copy",
@@ -70,6 +64,42 @@
             "fixed inset-0 z-50 bg-black/40",
             "bg-background p-6 shadow-sm",
             "sm:rounded-lg"
+          ]
+        }
+      ]
+    },
+    "sidebar-navigation": {
+      "groupId": "app-shell",
+      "fidelity": "state",
+      "responsiveStrategy": "scale-together",
+      "requiredStates": ["owner", "replacement", "fallback"],
+      "labels": {
+        "owner": ["New thread", "Search threads", "Extensions"],
+        "replacement": ["Custom navigation"],
+        "fallback": ["New thread", "Search threads", "Extensions"]
+      },
+      "fixtureClassAnchors": ["px-2 py-2", "px-2 pb-2"],
+      "sources": [
+        {
+          "path": "apps/app/src/components/sidebar/SidebarNavigationRegion.tsx",
+          "anchors": [
+            "data-testid=\"sidebar-navigation-region\"",
+            "PluginReplacementSlot",
+            "experimental_activate"
+          ]
+        },
+        {
+          "path": "apps/app/src/components/sidebar/BuiltInSidebarNavigation.tsx",
+          "anchors": [
+            "data-testid=\"app-sidebar-primary-actions\"",
+            "PluginNavSidebarItems"
+          ]
+        },
+        {
+          "path": "apps/app/src/components/sidebar/SidebarNavigationRegion.test.tsx",
+          "anchors": [
+            "routes Search through the quick palette without inline search UI",
+            "delegates and falls back after a crash without owner remounts"
           ]
         }
       ]

--- a/packages/plugin-api-map/src/surfaces.ts
+++ b/packages/plugin-api-map/src/surfaces.ts
@@ -58,6 +58,28 @@ export const SURFACE_GROUPS: SurfaceGroup[] = [
         firstParty: ["Automations", "Docs", "GitHub", "Tasks"],
       },
       {
+        id: "sidebar-navigation",
+        title: "Sidebar navigation",
+        summary:
+          "Replaces bb's navigation controls above the thread list with a component your plugin renders. With this, a plugin can:",
+        bullets: [
+          "Arrange New thread, Search, Extensions, and plugin destinations",
+          "Activate each destination through bb, including split placement for supported items",
+          "Render bb's original controls when the plugin wants to delegate",
+          "Leave the thread list, footer, drawer, and resize handle under bb's control",
+        ],
+        apiSymbols: [
+          "ExperimentalSidebarNavigationRegistration",
+          "ExperimentalSidebarNavigationProps",
+          "ExperimentalSidebarNavigationItem",
+          "ExperimentalSidebarNavigationAction",
+          "ExperimentalSidebarNavigationIcon",
+          "ExperimentalSidebarNavigationShortcut",
+          "ExperimentalSidebarNavigationActivationOptions",
+        ],
+        experimental: true,
+      },
+      {
         id: "thread-list",
         title: "The thread list",
         summary:

--- a/packages/plugin-api-map/src/wireframes.tsx
+++ b/packages/plugin-api-map/src/wireframes.tsx
@@ -71,6 +71,7 @@ export function useSurfaceMap(): SurfaceMapState {
 
 export const APP_SHELL_MARKS = [
   "nav-panel",
+  "sidebar-navigation",
   "thread-list",
   "thread-row-status",
   "sidebar-footer",
@@ -523,35 +524,39 @@ const SIDEBAR_SECTION_RENDERERS: Record<string, () => ReactNode> = {
       <MiniIcon icon={ArrowRight01Icon} className="ml-1.5 size-3.5" />
     </div>
   ),
-  "primary-actions": () => (
-    <div
-      data-guide-fixture="sidebar-primary-actions"
-      className="flex items-center gap-2 px-2.5 py-2.5"
-    >
-      <span className="flex h-6.5 flex-1 items-center gap-2 rounded-md px-2 text-foreground">
-        <MiniIcon icon={PlusSignIcon} className="text-foreground" />
-        New thread
-      </span>
-      <MiniIcon icon={Search01Icon} />
-    </div>
-  ),
-  "plugin-nav": () => (
-    <Mark
-      id="nav-panel"
-      label="Plugin nav panels, above the thread list"
-      className="mx-1.5 px-1.5 pb-2.5 pt-1"
+  "sidebar-navigation": () => (
+    <RegionMark
+      id="sidebar-navigation"
+      label="The sidebar navigation controls, replaceable by one plugin"
       showChip={false}
     >
-      <span className="flex h-6.5 items-center gap-2 rounded-md px-2">
-        <MiniIcon icon={ToolboxIcon} />
-        Extensions
-      </span>
-      {}
-      <span className="flex h-6.5 items-center gap-2 rounded-md bg-sidebar-accent px-2 font-medium text-sidebar-foreground">
-        <PluginGlyph />
-        Your panel
-      </span>
-    </Mark>
+      <div
+        data-guide-fixture="sidebar-navigation-primary-actions"
+        className="flex items-center gap-2 px-2 py-2"
+      >
+        <span className="flex h-6.5 flex-1 items-center gap-2 rounded-md px-2 text-foreground">
+          <MiniIcon icon={PlusSignIcon} className="text-foreground" />
+          New thread
+        </span>
+        <MiniIcon icon={Search01Icon} />
+        <span className="sr-only">Search threads</span>
+      </div>
+      <Mark
+        id="nav-panel"
+        label="Plugin nav panels, above the thread list"
+        className="mx-1.5 space-y-0.5 px-2 pb-2"
+        showChip={false}
+      >
+        <span className="flex h-6.5 items-center gap-2 rounded-md px-2">
+          <MiniIcon icon={ToolboxIcon} />
+          Extensions
+        </span>
+        <span className="flex h-6.5 items-center gap-2 rounded-md bg-sidebar-accent px-2 font-medium text-sidebar-foreground">
+          <PluginGlyph />
+          Your panel
+        </span>
+      </Mark>
+    </RegionMark>
   ),
   "thread-list": () => (
     <RegionMark
@@ -904,6 +909,12 @@ export function AppShellWireframe() {
         id="nav-panel"
         label="Plugin nav panels, above the thread list"
         anchor='[data-guide-region="nav-panel"]'
+        at="start"
+      />
+      <MeasuredBadge
+        id="sidebar-navigation"
+        label="The sidebar navigation controls, replaceable by one plugin"
+        anchor='[data-guide-region="sidebar-navigation"]'
         at="start"
       />
       <MeasuredBadge

--- a/packages/plugin-api-map/test/surfaces.test.ts
+++ b/packages/plugin-api-map/test/surfaces.test.ts
@@ -29,6 +29,7 @@ describe("product-map surfaces", () => {
   it("keeps app-window annotations in their stable sequential order", () => {
     const ordered = [
       "nav-panel",
+      "sidebar-navigation",
       "thread-list",
       "thread-row-status",
       "sidebar-footer",

--- a/packages/plugin-api-map/test/wireframes.test.ts
+++ b/packages/plugin-api-map/test/wireframes.test.ts
@@ -218,7 +218,7 @@ describe("guide fixture boundaries", () => {
       'data-guide-fixture="sidebar-top-reserve"',
     );
     const reserveEnd = markup.indexOf(
-      'data-guide-fixture="sidebar-primary-actions"',
+      'data-guide-fixture="sidebar-navigation-primary-actions"',
     );
 
     expect(markup).toContain('data-guide-fixture="sidebar-trigger-overlay"');
@@ -227,6 +227,28 @@ describe("guide fixture boundaries", () => {
     expect(markup.slice(reserveStart, reserveEnd)).not.toContain(
       'data-guide-fixture="sidebar-trigger-overlay"',
     );
+  });
+
+  it("shows the complete sidebar navigation replacement boundary", () => {
+    const markup = renderWireframe(createElement(AppShellWireframe));
+    const contract = anatomy.surfaceFixtures["sidebar-navigation"];
+
+    expect(contract.requiredStates).toEqual([
+      "owner",
+      "replacement",
+      "fallback",
+    ]);
+    for (const label of contract.labels.owner) {
+      expect(markup).toContain(label);
+    }
+    for (const classAnchor of contract.fixtureClassAnchors) {
+      expect(markup).toContain(classAnchor);
+    }
+    expect(markup).toContain('data-guide-region="sidebar-navigation"');
+    expect(markup).toContain(
+      'data-guide-fixture="sidebar-navigation-primary-actions"',
+    );
+    expect(markup).not.toContain("Custom navigation");
   });
 
   it("grows the app window within capped viewport-fit bounds while retaining loose timeline spacing", () => {

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@get-bb/plugin-sdk",
-  "version": "0.4.32",
+  "version": "0.4.33",
   "homepage": "https://github.com/get-bb/bb#readme",
   "bugs": {
     "url": "https://github.com/get-bb/bb/issues"

--- a/packages/plugin-sdk/src/app-contract.ts
+++ b/packages/plugin-sdk/src/app-contract.ts
@@ -105,6 +105,58 @@ export interface PluginPendingInteractionProps {
  */
 export interface PluginSidebarFooterActionProps {}
 
+/** Display and accessibility metadata for a host-owned sidebar shortcut. */
+export interface ExperimentalSidebarNavigationShortcut {
+  label: string;
+  ariaKeyShortcuts: string;
+}
+
+/** Host-owned behavior represented by one sidebar navigation item. */
+export type ExperimentalSidebarNavigationAction =
+  | { kind: "new-thread" }
+  | { kind: "search-threads" }
+  | { kind: "open-extensions" }
+  | {
+      kind: "open-plugin-panel";
+      pluginId: string;
+      panelId: string;
+    };
+
+/** Semantic icon identity for one sidebar navigation item. */
+export type ExperimentalSidebarNavigationIcon =
+  | { kind: "host"; name: "new-thread" | "search" | "extensions" }
+  | { kind: "plugin"; pluginId: string; icon: string | null };
+
+/** One host-owned destination or action a plugin may arrange. */
+export interface ExperimentalSidebarNavigationItem {
+  id: string;
+  label: string;
+  icon: ExperimentalSidebarNavigationIcon;
+  action: ExperimentalSidebarNavigationAction;
+  isDisabled: boolean;
+  shortcut: ExperimentalSidebarNavigationShortcut | null;
+  experimental_splitProps: {
+    onPointerDown?: (event: import("react").PointerEvent<HTMLElement>) => void;
+  };
+}
+
+/** How the host should activate a sidebar navigation item. */
+export interface ExperimentalSidebarNavigationActivationOptions {
+  openInSplit: boolean;
+}
+
+/** Props passed to an `experimental_sidebarNavigation` component. */
+export interface ExperimentalSidebarNavigationProps {
+  items: readonly ExperimentalSidebarNavigationItem[];
+  activeItemId: string | null;
+  isCompactViewport: boolean;
+  experimental_activate(
+    itemId: string,
+    options: ExperimentalSidebarNavigationActivationOptions,
+  ): void;
+  experimental_Original: ComponentType;
+}
+
 /**
  * Props passed to an `experimental_threadList` component — the sidebar's
  * scrolling thread area, replaced wholesale by one plugin.
@@ -965,6 +1017,17 @@ export interface PluginThreadListRegistration {
   component: ComponentType<PluginThreadListProps>;
 }
 
+/** Replace the bounded navigation controls above the sidebar thread list. */
+export interface ExperimentalSidebarNavigationRegistration {
+  /** Unique within the plugin; letters, digits, `-`, `_`. */
+  id: string;
+  /** Label shown in Settings → Appearance and capability details. */
+  title: string;
+  /** Optional one-line description shown with the provider choice. */
+  description?: string;
+  component: ComponentType<ExperimentalSidebarNavigationProps>;
+}
+
 /**
  * Register this plugin as a viewer/editor for file extensions. By default,
  * matching files render the first applicable opener in deterministic slot
@@ -1280,6 +1343,10 @@ export interface PluginAppSlots {
   pendingInteraction(registration: PluginPendingInteractionRegistration): void;
   sidebarFooterAction(
     registration: PluginSidebarFooterActionRegistration,
+  ): void;
+  /** Replace the bounded sidebar navigation controls. */
+  experimental_sidebarNavigation(
+    registration: ExperimentalSidebarNavigationRegistration,
   ): void;
   /**
    * Replace the sidebar's thread list (see

--- a/packages/plugin-sdk/src/internal/plugin-app-collector.ts
+++ b/packages/plugin-sdk/src/internal/plugin-app-collector.ts
@@ -14,6 +14,7 @@ import type {
   PluginProviderIconRegistration,
   PluginSettingsSectionRegistration,
   PluginSidebarFooterActionRegistration,
+  ExperimentalSidebarNavigationRegistration,
   PluginSourceCodeRendererRegistration,
   PluginThreadHeaderActionRegistration,
   PluginThreadListRegistration,
@@ -91,6 +92,7 @@ export interface CollectedPluginAppRegistrations {
   composerCustomizations: ComposerCustomization[];
   pendingInteractions: PluginPendingInteractionRegistration[];
   sidebarFooterActions: PluginSidebarFooterActionRegistration[];
+  experimentalSidebarNavigations: ExperimentalSidebarNavigationRegistration[];
   threadLists: PluginThreadListRegistration[];
   threadHeaderActions: PluginThreadHeaderActionRegistration[];
   fileOpeners: PluginFileOpenerRegistration[];
@@ -124,6 +126,7 @@ export function collectPluginAppRegistrations(
     composerCustomizations: [],
     pendingInteractions: [],
     sidebarFooterActions: [],
+    experimentalSidebarNavigations: [],
     threadLists: [],
     threadHeaderActions: [],
     fileOpeners: [],
@@ -145,6 +148,7 @@ export function collectPluginAppRegistrations(
     composerCustomization: new Set<string>(),
     pendingInteraction: new Set<string>(),
     sidebarFooterAction: new Set<string>(),
+    sidebarNavigation: new Set<string>(),
     threadList: new Set<string>(),
     threadHeaderAction: new Set<string>(),
     fileOpener: new Set<string>(),
@@ -383,6 +387,22 @@ export function collectPluginAppRegistrations(
           title: requireNonEmptyString(kind, "title", registration.title),
           icon: requireNonEmptyString(kind, "icon", registration.icon),
           run: registration.run,
+        });
+      },
+      experimental_sidebarNavigation(registration) {
+        const kind = "slots.experimental_sidebarNavigation";
+        const id = requireSlotId(kind, registration?.id);
+        requireUniqueId(kind, seenIds.sidebarNavigation, id);
+        const description = requireOptionalString(
+          kind,
+          "description",
+          registration.description,
+        );
+        collected.experimentalSidebarNavigations.push({
+          id,
+          title: requireNonEmptyString(kind, "title", registration.title),
+          ...(description !== undefined ? { description } : {}),
+          component: requireComponent(kind, registration.component),
         });
       },
       experimental_threadList(registration) {

--- a/packages/plugin-sdk/src/testing/__tests__/app-harness.test.tsx
+++ b/packages/plugin-sdk/src/testing/__tests__/app-harness.test.tsx
@@ -462,6 +462,46 @@ const app = await loadPluginApp(
 );
 
 describe("loadPluginApp", () => {
+  it("captures and validates sidebar navigation registrations", async () => {
+    const captured = await loadPluginApp(
+      definePluginApp((builder) => {
+        builder.slots.experimental_sidebarNavigation({
+          id: "compact",
+          title: "Compact navigation",
+          description: "Groups the sidebar destinations.",
+          component: () => null,
+        });
+      }),
+    );
+
+    expect(captured.experimentalSidebarNavigations).toEqual([
+      {
+        id: "compact",
+        title: "Compact navigation",
+        description: "Groups the sidebar destinations.",
+        component: expect.any(Function),
+      },
+    ]);
+    await expect(
+      loadPluginApp(
+        definePluginApp((builder) => {
+          builder.slots.experimental_sidebarNavigation({
+            id: "compact",
+            title: "One",
+            component: () => null,
+          });
+          builder.slots.experimental_sidebarNavigation({
+            id: "compact",
+            title: "Two",
+            component: () => null,
+          });
+        }),
+      ),
+    ).rejects.toThrow(
+      'slots.experimental_sidebarNavigation: duplicate id "compact"',
+    );
+  });
+
   it("captures and validates New thread panel action registrations", async () => {
     const run = () => {};
     const captured = await loadPluginApp(

--- a/packages/plugin-sdk/src/testing/app.tsx
+++ b/packages/plugin-sdk/src/testing/app.tsx
@@ -43,6 +43,7 @@ import {
   type PluginSettingsSectionRegistration,
   type PluginSettingsState,
   type PluginSidebarFooterActionRegistration,
+  type ExperimentalSidebarNavigationRegistration,
   type PluginSidebarPullRequest,
   type PluginSidebarThreadActions,
   type PluginSidebarThreadPullRequestState,
@@ -900,6 +901,7 @@ export interface CapturedPluginApp {
   composerCustomizations: ComposerCustomization[];
   pendingInteractions: PluginPendingInteractionRegistration[];
   sidebarFooterActions: PluginSidebarFooterActionRegistration[];
+  experimentalSidebarNavigations: ExperimentalSidebarNavigationRegistration[];
   threadLists: PluginThreadListRegistration[];
   threadHeaderActions: PluginThreadHeaderActionRegistration[];
   fileOpeners: PluginFileOpenerRegistration[];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1327,6 +1327,21 @@ importers:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
 
+  examples/plugins/sidebar-navigation:
+    devDependencies:
+      '@get-bb/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../../packages/plugin-sdk
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.13
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+      typescript:
+        specifier: npm:@typescript/typescript6@^6.0.2
+        version: '@typescript/typescript6@6.0.2'
+
   examples/plugins/slack-bot:
     devDependencies:
       '@get-bb/plugin-sdk':

--- a/turbo.json
+++ b/turbo.json
@@ -736,6 +736,9 @@
     "bb-plugin-replacement-lab-beta#typecheck": {
       "dependsOn": ["@get-bb/plugin-sdk#build:types", "topo"]
     },
+    "bb-plugin-sidebar-navigation#typecheck": {
+      "dependsOn": ["@get-bb/plugin-sdk#build:types", "topo"]
+    },
     "bb-plugin-thread-chat-demo#typecheck": {
       "dependsOn": ["@get-bb/plugin-sdk#build:types", "topo"]
     },


### PR DESCRIPTION
## Human comments

## What was wrong

Pull request #2443 combined the sidebar navigation API with other replacement surfaces. Its sidebar search contract also described UI that no longer exists.

## What changed

This change adds only `app.slots.experimental_sidebarNavigation`. Plugins receive semantic actions for New thread, Search, Extensions, and plugin panels.

Search opens the current quick palette. The API has no inline search field, query, combobox, or result list.

BB still owns routes, split rules, shortcuts, the thread list, the footer, and the responsive drawer. A crash restores BB navigation.

The change adds an Appearance setting, Plugin Guide coverage, authoring references, SDK 0.4.33, and a complete example plugin.

This change does not alter the host daemon protocol.

## How you verified

- `pnpm exec turbo run typecheck --filter=@get-bb/plugin-sdk --filter=@bb/app --filter=@bb/plugin-api-map --filter=bb-plugin-sidebar-navigation`
- `pnpm exec turbo run test --filter=@get-bb/plugin-sdk --filter=@bb/plugin-api-map --filter=@bb/app --force`
- `bb plugin build examples/plugins/sidebar-navigation`
- `bb plugin build plugins/plugin-api-docs`
- Installed the example plugin against the local development app.
- Used Doobie to test desktop, compact, search, provider choice, persistence, delegation, navigation, and crash fallback states.

Fixes: none. Extracted from #2443.

> AGENT GENERATED
