### PR TITLE
Evict Claude queries after terminal auth failures

### DIFF
--- a/plugins/provider-claude-code/src/bridge/__tests__/bridge.test.ts
+++ b/plugins/provider-claude-code/src/bridge/__tests__/bridge.test.ts
@@ -46,7 +46,10 @@ import {
 } from "@get-bb/plugin-sdk/provider-bridge/testing";
 import type { BridgeJsonRpcOutputMessage } from "@get-bb/plugin-sdk/provider-bridge/testing";
 
-import { BRIDGE_INBOUND_REQUEST_METHODS } from "@bb/provider-bridge-protocol";
+import {
+  BRIDGE_INBOUND_REQUEST_METHODS,
+  THREAD_DELTA_NOTIFICATION_METHOD,
+} from "@bb/provider-bridge-protocol";
 
 type BridgeSessionOptions = ReturnType<typeof buildSessionOptions>;
 type BridgeSessionHooks = NonNullable<BridgeSessionOptions["hooks"]>;
@@ -56,6 +59,11 @@ type BridgeJsonRpcTestHarness = ReturnType<
   typeof createBridgeJsonRpcTestHarness
 >;
 type SdkResultUsage = Extract<SDKMessage, { type: "result" }>["usage"];
+type AuthenticationFailureError = Extract<
+  SDKMessage,
+  { type: "assistant" }
+>["error"] &
+  ("authentication_failed" | "oauth_org_not_allowed");
 
 async function flushFakeTimerBridgeWork(
   bridge: BridgeJsonRpcTestHarness,
@@ -443,10 +451,13 @@ function createStaleResumeErrorMessage(
   };
 }
 
-function createAuthenticationErrorMessage(sessionId: string): SDKMessage {
+function createAuthenticationErrorMessage(
+  sessionId: string,
+  error: AuthenticationFailureError = "authentication_failed",
+): SDKMessage {
   return {
     type: "assistant",
-    error: "authentication_failed",
+    error,
     message: {
       id: "authentication-error-message",
       type: "message",
@@ -468,6 +479,27 @@ function createAuthenticationErrorMessage(sessionId: string): SDKMessage {
     },
     parent_tool_use_id: null,
     uuid: "00000000-0000-4000-8000-000000000002",
+    session_id: sessionId,
+  };
+}
+
+function createAuthenticationFailureResult(sessionId: string): SDKMessage {
+  return {
+    type: "result",
+    subtype: "error_during_execution",
+    duration_ms: 0,
+    duration_api_ms: 0,
+    is_error: true,
+    num_turns: 0,
+    stop_reason: null,
+    total_cost_usd: 0,
+    usage: createResultUsage(),
+    modelUsage: {},
+    permission_denials: [],
+    errors: [
+      "Failed to authenticate: OAuth session expired and could not be refreshed",
+    ],
+    uuid: "00000000-0000-4000-8000-000000000003",
     session_id: sessionId,
   };
 }
@@ -681,6 +713,19 @@ function interactionPayload(
 
 function isApprovalInteraction(message: BridgeJsonRpcOutputMessage): boolean {
   return interactionPayload(message)?.kind === "approval";
+}
+
+function isSessionResetMessage(message: BridgeJsonRpcOutputMessage): boolean {
+  if (
+    message.method !== THREAD_DELTA_NOTIFICATION_METHOD ||
+    !isRecord(message.params) ||
+    !Array.isArray(message.params.deltas)
+  ) {
+    return false;
+  }
+  return message.params.deltas.some(
+    (delta) => isRecord(delta) && delta.kind === "session.reset",
+  );
 }
 
 function isUserQuestionInteraction(
@@ -4369,7 +4414,135 @@ describe("bridge", () => {
     }
   });
 
-  it("restarts a Claude session before the next turn after an authentication failure", async () => {
+  it.each(["authentication_failed", "oauth_org_not_allowed"] as const)(
+    "evicts a %s Claude query after settling the turn",
+    async (error) => {
+      const bridge = createBridgeJsonRpcTestHarness(handleLine);
+      const queries: ControlledClaudeQuery[] = [];
+      let failedTurnsBeforeClose = 0;
+      let recoveryNotificationsBeforeClose = 0;
+      queryMock.mockImplementation(() => {
+        const query = createControlledClaudeQuery();
+        query.close.mockImplementation(() => {
+          failedTurnsBeforeClose = getFailedTurns(bridge.messages).length;
+          recoveryNotificationsBeforeClose = bridge.messages.filter(
+            (message) => message.method === "provider/recovery",
+          ).length;
+          query.finish();
+        });
+        queries.push(query);
+        return query;
+      });
+
+      try {
+        const threadId = "thread-authentication-failure";
+        const providerThreadId = "provider-thread-authentication-failure";
+        sendResumeThread({
+          bridge,
+          providerThreadId,
+          requestId: 1,
+          threadId,
+        });
+        await bridge.waitForResponse(1);
+
+        bridge.sendRequest(
+          2,
+          "turn/start",
+          canonicalTurnParams({
+            threadId,
+            providerThreadId,
+            input: [{ type: "text", text: "before reauthentication" }],
+          }),
+        );
+        await expect(readNextPromptText(getLatestQueryCall())).resolves.toBe(
+          "before reauthentication",
+        );
+        await bridge.waitForResponse(2);
+
+        const messagesBeforeFailure = bridge.messages.length;
+        queries[0]?.emit(
+          createAuthenticationErrorMessage(providerThreadId, error),
+        );
+        queries[0]?.emit(createAuthenticationFailureResult(providerThreadId));
+        await bridge.flushWork();
+
+        expect(getFailedTurns(bridge.messages)).toHaveLength(1);
+        expect(queries).toHaveLength(1);
+        expect(queries[0]?.close).toHaveBeenCalledOnce();
+        expect(failedTurnsBeforeClose).toBe(1);
+        expect(recoveryNotificationsBeforeClose).toBe(1);
+        expect(
+          bridge.messages
+            .filter((message) => message.method === "provider/recovery")
+            .map((message) => message.params),
+        ).toEqual([
+          {
+            threadId,
+            kind: "authRequired",
+            message: expect.stringContaining("authenticate"),
+            retryable: false,
+          },
+        ]);
+        expect(
+          bridge.messages
+            .slice(messagesBeforeFailure)
+            .some((message) => message.method === "session/replaced"),
+        ).toBe(false);
+        expect(
+          bridge.messages
+            .slice(messagesBeforeFailure)
+            .some(isSessionResetMessage),
+        ).toBe(false);
+
+        const messagesBeforeReplacement = bridge.messages.length;
+        bridge.sendRequest(
+          3,
+          "turn/start",
+          canonicalTurnParams({
+            threadId,
+            providerThreadId,
+            input: [{ type: "text", text: "after reauthentication" }],
+          }),
+        );
+        await bridge.flushWork();
+
+        expect(queries).toHaveLength(2);
+        expect(queries[0]?.close).toHaveBeenCalledOnce();
+        expect(getLatestQueryOptions()).toMatchObject({
+          resume: providerThreadId,
+        });
+        const replacementMessages = bridge.messages.slice(
+          messagesBeforeReplacement,
+        );
+        const replacementIndex = replacementMessages.findIndex(
+          (message) => message.method === "session/replaced",
+        );
+        const resetIndex = replacementMessages.findIndex(isSessionResetMessage);
+        expect(replacementIndex).toBeGreaterThanOrEqual(0);
+        expect(resetIndex).toBeGreaterThan(replacementIndex);
+        await expect(readNextPromptText(getLatestQueryCall())).resolves.toBe(
+          "after reauthentication",
+        );
+        await bridge.waitForResponse(3);
+
+        bridge.sendRequest(4, "thread/stop", {
+          threadId,
+          providerThreadId,
+          intent: "interrupt",
+          activeTurnId: null,
+        });
+        await bridge.flushWork();
+        queries[1]?.finish();
+        await bridge.waitForResponse(4);
+        expect(queries[0]?.close).toHaveBeenCalledOnce();
+      } finally {
+        queries.forEach((query) => query.finish());
+        bridge.restore();
+      }
+    },
+  );
+
+  it("waits for interactions and background work before auth-failure eviction", async () => {
     const bridge = createBridgeJsonRpcTestHarness(handleLine);
     const queries: ControlledClaudeQuery[] = [];
     queryMock.mockImplementation(() => {
@@ -4379,8 +4552,10 @@ describe("bridge", () => {
     });
 
     try {
-      const threadId = "thread-authentication-failure";
-      const providerThreadId = "provider-thread-authentication-failure";
+      const threadId = "thread-authentication-failure-work";
+      const providerThreadId = "session-1";
+      const backgroundToolUseId = "tool-background-auth-failure";
+      const backgroundTaskId = "task-auth-failure";
       sendResumeThread({
         bridge,
         providerThreadId,
@@ -4395,81 +4570,88 @@ describe("bridge", () => {
         canonicalTurnParams({
           threadId,
           providerThreadId,
-          input: [{ type: "text", text: "before reauthentication" }],
+          input: [{ type: "text", text: "start background work" }],
         }),
       );
-      await expect(readNextPromptText(getLatestQueryCall())).resolves.toBe(
-        "before reauthentication",
-      );
+      await readNextPromptText(getLatestQueryCall());
       await bridge.waitForResponse(2);
 
-      queries[0]?.emit(createAuthenticationErrorMessage(providerThreadId));
+      queries[0]?.emit(
+        createAssistantToolUseMessage({
+          parentToolUseId: null,
+          toolInput: { prompt: "continue in the background" },
+          toolName: "Agent",
+          toolUseId: backgroundToolUseId,
+        }),
+      );
       queries[0]?.emit({
-        type: "result",
-        subtype: "error_during_execution",
-        duration_ms: 0,
-        duration_api_ms: 0,
-        is_error: true,
-        num_turns: 0,
-        stop_reason: null,
-        total_cost_usd: 0,
-        usage: createResultUsage(),
-        modelUsage: {},
-        permission_denials: [],
-        errors: [
-          "Failed to authenticate: OAuth session expired and could not be refreshed",
-        ],
-        uuid: "00000000-0000-4000-8000-000000000003",
+        type: "system",
+        subtype: "task_started",
+        task_id: backgroundTaskId,
+        tool_use_id: backgroundToolUseId,
+        description: "Continue in the background",
+        subagent_type: "general-purpose",
+        is_backgrounded: true,
+        task_type: "local_agent",
+        prompt: "continue in the background",
+        uuid: "00000000-0000-4000-8000-000000000004",
+        session_id: providerThreadId,
+      });
+      const { questionRequest, resultPromise } = await forwardAskUserQuestion({
+        bridge,
+        toolUseID: "tool-question-auth-failure",
+      });
+
+      queries[0]?.emit(createAuthenticationErrorMessage(providerThreadId));
+      queries[0]?.emit(createAuthenticationFailureResult(providerThreadId));
+      await bridge.flushWork();
+
+      expect(getFailedTurns(bridge.messages)).toHaveLength(1);
+      expect(queries[0]?.close).not.toHaveBeenCalled();
+
+      handleLine(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: questionRequest.id,
+          result: {
+            kind: "user_answer",
+            answers: {
+              "tool-question-auth-failure:question-1": {
+                selected: ["tool-question-auth-failure:question-1:option-1"],
+              },
+            },
+          },
+        }),
+      );
+      await expect(resultPromise).resolves.toMatchObject({ behavior: "allow" });
+      await bridge.flushWork();
+
+      expect(queries[0]?.close).not.toHaveBeenCalled();
+
+      queries[0]?.emit({
+        type: "system",
+        subtype: "task_notification",
+        task_id: backgroundTaskId,
+        tool_use_id: backgroundToolUseId,
+        status: "completed",
+        output_file: "",
+        summary: "Background work completed",
+        usage: { total_tokens: 10, tool_uses: 0, duration_ms: 1 },
+        uuid: "00000000-0000-4000-8000-000000000005",
         session_id: providerThreadId,
       });
       await bridge.flushWork();
 
-      expect(getFailedTurns(bridge.messages)).toHaveLength(1);
-      expect(queries).toHaveLength(1);
-      expect(queries[0]?.close).not.toHaveBeenCalled();
-      expect(
-        bridge.messages
-          .filter((message) => message.method === "provider/recovery")
-          .map((message) => message.params),
-      ).toEqual([
-        {
-          threadId,
-          kind: "authRequired",
-          message: expect.stringContaining("authenticate"),
-          retryable: false,
-        },
-      ]);
-
-      bridge.sendRequest(
-        3,
-        "turn/start",
-        canonicalTurnParams({
-          threadId,
-          providerThreadId,
-          input: [{ type: "text", text: "after reauthentication" }],
-        }),
-      );
-      await bridge.flushWork();
-
-      expect(queries).toHaveLength(2);
       expect(queries[0]?.close).toHaveBeenCalledOnce();
-      expect(getLatestQueryOptions()).toMatchObject({
-        resume: providerThreadId,
-      });
-      await expect(readNextPromptText(getLatestQueryCall())).resolves.toBe(
-        "after reauthentication",
-      );
-      await bridge.waitForResponse(3);
 
-      bridge.sendRequest(4, "thread/stop", {
+      bridge.sendRequest(3, "thread/stop", {
         threadId,
         providerThreadId,
         intent: "interrupt",
         activeTurnId: null,
       });
-      await bridge.flushWork();
-      queries[1]?.finish();
-      await bridge.waitForResponse(4);
+      await bridge.waitForResponse(3);
+      expect(queries[0]?.close).toHaveBeenCalledOnce();
     } finally {
       queries.forEach((query) => query.finish());
       bridge.restore();

--- a/plugins/provider-claude-code/src/bridge/bridge.ts
+++ b/plugins/provider-claude-code/src/bridge/bridge.ts
@@ -226,6 +226,7 @@ interface ThreadAttachment {
   closing: boolean;
   residentSession: ThreadSession | null;
   idleTimer: ReturnType<typeof setTimeout> | null;
+  dormantWakeReason: string;
   residencyGeneration: number;
   wakePromise: Promise<ThreadSession | undefined> | null;
   idleQueryReleaseEnabled: boolean;
@@ -384,6 +385,7 @@ function requireSkillPluginsRoot(): string {
 
 const THREAD_STOP_CLOSE_TIMEOUT_MS = 4_000;
 export const CLAUDE_IDLE_QUERY_GRACE_MS = 30_000;
+const CLAUDE_IDLE_QUERY_WAKE_REASON = "Claude query resumed after idle release";
 
 const { send, sendResult, sendError } = createBridgeIo<
   SdkMessageNotification | BridgeEventNotification | BridgeToolCallRequest
@@ -421,6 +423,27 @@ function isThreadSessionQuiescent(
   );
 }
 
+function releaseResidentQuery(args: {
+  attachment: ThreadAttachment;
+  reason: string;
+  threadId: string;
+  threadSession: ThreadSession;
+}): void {
+  if (
+    args.attachment.closing ||
+    args.threadSession.closing ||
+    threadAttachments.get(args.threadId) !== args.attachment ||
+    args.attachment.residentSession !== args.threadSession
+  ) {
+    return;
+  }
+  cancelIdleQueryRelease(args.attachment);
+  args.threadSession.closing = true;
+  args.attachment.residentSession = null;
+  args.attachment.dormantWakeReason = args.reason;
+  args.threadSession.session.stop();
+}
+
 function scheduleIdleQueryRelease(
   threadSession: ThreadSession,
   threadId: string,
@@ -454,10 +477,12 @@ function scheduleIdleQueryRelease(
       scheduleIdleQueryRelease(threadSession, threadId);
       return;
     }
-    threadSession.closing = true;
-    attachment.residentSession = null;
-    attachment.residencyGeneration += 1;
-    threadSession.session.stop();
+    releaseResidentQuery({
+      attachment,
+      reason: CLAUDE_IDLE_QUERY_WAKE_REASON,
+      threadId,
+      threadSession,
+    });
   }, CLAUDE_IDLE_QUERY_GRACE_MS);
 }
 
@@ -509,6 +534,7 @@ function createForwardToolCall(getThreadId: () => string): ToolCallForwarder {
     }).finally(() => {
       threadSession.pendingForwardedToolCalls -= 1;
       refreshIdleQueryRelease(threadSession, threadId);
+      scheduleAuthenticationFailureEviction(threadSession);
     });
   };
 }
@@ -1006,6 +1032,7 @@ function createThreadAttachment(
     closing: false,
     residentSession: null,
     idleTimer: null,
+    dormantWakeReason: CLAUDE_IDLE_QUERY_WAKE_REASON,
     residencyGeneration: 0,
     wakePromise: null,
     idleQueryReleaseEnabled: args.idleQueryReleaseEnabled,
@@ -1427,7 +1454,7 @@ async function getWritableThreadSession(
 
   const threadSession = attachment.residentSession;
   const replacementReason = !threadSession
-    ? "Claude query resumed after idle release"
+    ? attachment.dormantWakeReason
     : threadSession.streamEnded
       ? "Thread session replaced after Claude SDK stream ended"
       : intent === "new-turn"
@@ -1476,7 +1503,7 @@ async function getWritableThreadSession(
       params: {
         threadId,
         providerThreadId,
-        reason: "Claude query resumed after idle release",
+        reason: attachment.dormantWakeReason,
         contextLost: false,
       },
     });
@@ -1508,6 +1535,33 @@ function getAuthenticationFailureRestartReason(
     default:
       return null;
   }
+}
+
+function evictAuthenticationFailedQueryIfQuiescent(
+  threadSession: ThreadSession,
+): void {
+  const reason = threadSession.restartBeforeNextTurnReason;
+  if (reason === null) {
+    return;
+  }
+  const threadId = threadSession.attachment.threadIdRef.current;
+  if (!isThreadSessionQuiescent(threadSession, threadId)) {
+    return;
+  }
+  releaseResidentQuery({
+    attachment: threadSession.attachment,
+    reason,
+    threadId,
+    threadSession,
+  });
+}
+
+function scheduleAuthenticationFailureEviction(
+  threadSession: ThreadSession,
+): void {
+  queueMicrotask(() => {
+    evictAuthenticationFailedQueryIfQuiescent(threadSession);
+  });
 }
 
 function getCurrentThreadSession(
@@ -1562,6 +1616,7 @@ function createOnSdkMessage(
       );
     }
     refreshIdleQueryRelease(threadSession, args.threadIdRef.current);
+    scheduleAuthenticationFailureEviction(threadSession);
   };
 }
 
@@ -1801,6 +1856,7 @@ function createForwardInteractiveRequest(
         args.signal.removeEventListener("abort", onAbort);
         resolve(result);
         refreshIdleQueryRelease(threadSession, threadIdRef.current);
+        scheduleAuthenticationFailureEviction(threadSession);
       };
 
       const onAbort = (): void => {
@@ -1866,6 +1922,7 @@ function createForwardUserQuestionRequest(
         args.signal.removeEventListener("abort", onAbort);
         resolve(result);
         refreshIdleQueryRelease(threadSession, threadIdRef.current);
+        scheduleAuthenticationFailureEviction(threadSession);
       };
 
       const onAbort = (): void => {


### PR DESCRIPTION
## Human comments

## What was wrong

#2098 records `restartBeforeNextTurnReason` when Claude emits terminal `authentication_failed` or `oauth_org_not_allowed` errors, but the bridge only consumed that marker from the next `turn/start`. Even after the failed result settled, the stale SDK query therefore stayed resident with failed credentials until another user turn arrived.

## What changed

- Build this focused change on the attachment dormancy and `isThreadSessionQuiescent` path merged in #2808; no duplicate pending-work counters or task predicates are added.
- Release a terminal-auth-failed resident query as soon as its failed turn has settled and the shared quiescence check confirms there is no pending interaction, forwarded tool call, or provider-native background task.
- Preserve the attachment and `providerThreadId`; the next normal turn creates a fresh query, resumes that provider thread, emits `session/replaced`, then emits thread identity and `session.reset` in the established order.
- Preserve the typed `provider/recovery` notification with `kind: "authRequired"` and `retryable: false` before closing the stale query.
- Share the exact-once resident-to-dormant release operation between idle release and auth-failure release.

Auth-failure eviction is independent of #2808's `idleQueryReleaseEnabled` setting: terminally failed queries still close when ordinary idle release is left at its default-off value.

This remains entirely within the Claude provider plugin. It does not add credential locking and makes no host-daemon wire, public Plugin API, CLI, configuration, or documentation change. `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

## How you verified

The focused bridge regression fails before the implementation because the stale query has zero `close` calls after the terminal failure result. It now covers both terminal authentication error codes, verifies failed-turn content and typed recovery are emitted before close, verifies eviction itself emits no replacement/reset, confirms the next turn resumes the same provider thread with replacement before reset, and checks exact-once close. A race test verifies eviction waits for both a pending user interaction and provider-native background task. These auth tests leave idle release disabled, covering the independence described above.

After rebasing directly onto current `origin/main`:

- `pnpm exec turbo run test --filter=bb-plugin-provider-claude-code --force -- src/bridge/__tests__/bridge.test.ts` — 83 tests passed
- `pnpm exec turbo run test typecheck --filter=bb-plugin-provider-claude-code --force` — 24 test files and 351 tests passed; typecheck passed
- `git diff --check origin/main...HEAD`

Builds on #2808. Related to #2097 and #2098.

> AGENT GENERATED
