### PR TITLE
Restore mobile sidebar swipe dismissal

### DIFF
--- a/apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.test.tsx
+++ b/apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.test.tsx
@@ -7,6 +7,36 @@ import { CompactSecondaryPanelShelf } from "./CompactSecondaryPanelShelf";
 import { APP_OVERLAY_LAYER } from "@/components/ui/app-overlay-layers";
 import { getCompactSecondaryPanelPresentation } from "@/components/ui/secondary-panel-shelf-visibility";
 
+function createTouch(clientX: number, clientY: number): Touch {
+  return { identifier: 1, clientX, clientY } as Touch;
+}
+
+function createTouchList(...touches: Touch[]): TouchList {
+  const touchList = {
+    length: touches.length,
+    item: (index: number) => touches[index] ?? null,
+  };
+  touches.forEach((touch, index) => {
+    Object.defineProperty(touchList, index, { value: touch });
+  });
+  return touchList as unknown as TouchList;
+}
+
+function fireTouch(
+  target: Element | Window,
+  type: "touchstart" | "touchmove" | "touchend",
+  touch: Touch,
+) {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  Object.defineProperties(event, {
+    touches: {
+      value: type === "touchend" ? createTouchList() : createTouchList(touch),
+    },
+    changedTouches: { value: createTouchList(touch) },
+  });
+  fireEvent(target, event);
+}
+
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
@@ -105,6 +135,32 @@ describe("CompactSecondaryPanelShelf", () => {
 
     fireEvent.click(dismiss);
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes from a right swipe that starts on the exposed main content", () => {
+    const { onClose } = renderShelf(true);
+    const shelf = screen.getByTestId("secondary-panel-shelf");
+    const dismiss = screen.getByTestId("secondary-panel-shelf-dismiss");
+    Object.defineProperty(shelf, "clientWidth", { value: 300 });
+
+    fireTouch(dismiss, "touchstart", createTouch(60, 160));
+    fireTouch(window, "touchmove", createTouch(240, 164));
+    fireTouch(window, "touchend", createTouch(240, 164));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores a closing swipe from the left browser edge", () => {
+    const { onClose } = renderShelf(true);
+    const shelf = screen.getByTestId("secondary-panel-shelf");
+    const dismiss = screen.getByTestId("secondary-panel-shelf-dismiss");
+    Object.defineProperty(shelf, "clientWidth", { value: 300 });
+
+    fireTouch(dismiss, "touchstart", createTouch(12, 160));
+    fireTouch(window, "touchmove", createTouch(180, 164));
+    fireTouch(window, "touchend", createTouch(180, 164));
+
+    expect(onClose).not.toHaveBeenCalled();
   });
 
   it("hides the closed shelf so it cannot cover the sidebar shelf", () => {

--- a/apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.tsx
+++ b/apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.tsx
@@ -11,6 +11,7 @@ import { createPortal } from "react-dom";
 import { cn } from "@bb/shared-ui/lib/utils";
 import { usePersistentOverlayFocus } from "@bb/shared-ui/responsive-overlay";
 import { APP_OVERLAY_LAYER } from "@/components/ui/app-overlay-layers";
+import { useHorizontalDismissDrag } from "@/components/ui/use-horizontal-dismiss-drag";
 import {
   setCompactSecondaryPanelPresentation,
   type CompactSecondaryPanelPresentation,
@@ -19,6 +20,8 @@ import {
 const SHELF_TRANSITION_CLASS =
   "[transition:translate_220ms_cubic-bezier(0.32,0.72,0,1),width_220ms_cubic-bezier(0.32,0.72,0,1)]";
 const SHELF_SETTLE_MS = 220;
+const SHELF_DRAG_SETTLE_TRANSITION =
+  "translate 220ms cubic-bezier(0.32, 0.72, 0, 1)";
 
 interface CompactSecondaryPanelShelfProps {
   children: ReactNode;
@@ -39,12 +42,69 @@ export function CompactSecondaryPanelShelf({
 }: CompactSecondaryPanelShelfProps) {
   const labelId = useId();
   const panelRef = useRef<HTMLDivElement | null>(null);
+  const dismissRef = useRef<HTMLDivElement | null>(null);
+  const draggedInsetRef = useRef<HTMLElement | null>(null);
   const state = !open ? "closed" : presentation;
   const onCloseRef = useRef(onClose);
   useLayoutEffect(() => {
     onCloseRef.current = onClose;
   }, [onClose]);
   const requestClose = useCallback(() => onCloseRef.current(), []);
+
+  const clearDragStyles = useCallback(() => {
+    const inset = draggedInsetRef.current;
+    if (inset !== null) {
+      inset.style.translate = "";
+      inset.style.transition = "";
+      draggedInsetRef.current = null;
+    }
+    const dismiss = dismissRef.current;
+    if (dismiss !== null) {
+      dismiss.style.translate = "";
+      dismiss.style.transition = "";
+    }
+  }, []);
+
+  const applyDragProgress = useCallback(
+    ({
+      progress,
+      width,
+      settling,
+    }: {
+      progress: number;
+      width: number;
+      settling: boolean;
+    }) => {
+      const panel = panelRef.current;
+      const dismiss = dismissRef.current;
+      if (panel === null || dismiss === null) {
+        return;
+      }
+      const inset = panel.ownerDocument.querySelector('[data-sidebar="inset"]');
+      const translate = `${-width * progress}px`;
+      const transition = settling ? SHELF_DRAG_SETTLE_TRANSITION : "none";
+      if (inset instanceof HTMLElement) {
+        draggedInsetRef.current = inset;
+        inset.style.translate = translate;
+        inset.style.transition = transition;
+      }
+      dismiss.style.translate = translate;
+      dismiss.style.transition = transition;
+    },
+    [],
+  );
+  const { beginPointerDrag, beginTouchDrag } = useHorizontalDismissDrag({
+    direction: "right",
+    dismissTiming: "immediate",
+    enabled: open,
+    getWidth: () => panelRef.current?.clientWidth ?? 0,
+    onClear: clearDragStyles,
+    onDismiss: requestClose,
+    onProgress: applyDragProgress,
+    resetKey: presentation,
+    suppressClick: false,
+  });
+
   const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
   useEffect(() => {
     setPortalTarget(document.body);
@@ -77,6 +137,7 @@ export function CompactSecondaryPanelShelf({
   return createPortal(
     <>
       <div
+        ref={dismissRef}
         data-secondary-panel-shelf-dismiss=""
         data-testid="secondary-panel-shelf-dismiss"
         data-state={state}
@@ -90,6 +151,8 @@ export function CompactSecondaryPanelShelf({
           "data-[state=closed]:pointer-events-none data-[state=full]:pointer-events-none",
         )}
         onClick={requestClose}
+        onPointerDown={beginPointerDrag}
+        onTouchStart={beginTouchDrag}
       />
       <div
         ref={panelRef}
@@ -109,11 +172,13 @@ export function CompactSecondaryPanelShelf({
               : APP_OVERLAY_LAYER.secondaryPanel,
         }}
         className={cn(
-          "fixed inset-y-0 right-0 flex h-(--bb-shell-height) select-none flex-col overflow-hidden border-l border-border-seam bg-background outline-none",
+          "fixed inset-y-0 right-0 flex h-(--bb-shell-height) touch-pan-y select-none flex-col overflow-hidden border-l border-border-seam bg-background outline-none",
           "w-(--secondary-panel-width-mobile) data-[state=full]:w-full data-[state=full]:border-l-0",
           SHELF_TRANSITION_CLASS,
           "data-[state=closed]:invisible data-[state=closed]:[transition:visibility_0s_linear_220ms]",
         )}
+        onPointerDown={beginPointerDrag}
+        onTouchStart={beginTouchDrag}
       >
         {srLabel === undefined ? null : (
           <span id={labelId} className="sr-only">

--- a/apps/app/src/components/ui/sidebar.test.tsx
+++ b/apps/app/src/components/ui/sidebar.test.tsx
@@ -65,6 +65,15 @@ function fireTouch(
   fireEvent(target, event);
 }
 
+function fireTouchEnd(target: Element | Document | Window, touch: Touch) {
+  const event = new Event("touchend", { bubbles: true, cancelable: true });
+  Object.defineProperties(event, {
+    touches: { value: createTouchList() },
+    changedTouches: { value: createTouchList(touch) },
+  });
+  fireEvent(target, event);
+}
+
 function firePointer(
   target: Element | Document | Window,
   type: "pointerdown" | "pointermove",
@@ -467,6 +476,47 @@ describe("mobile sidebar shelf stacking", () => {
 });
 
 describe("mobile sidebar persistence", () => {
+  it("closes from a left swipe that starts on the exposed main content", () => {
+    vi.useFakeTimers();
+    renderCompactSidebarHarness();
+
+    fireEvent.click(screen.getByRole("button", { name: "Toggle Sidebar" }));
+    settleMobileToggle();
+
+    const panel = getMobilePanel();
+    const backdrop = screen.getByTestId("sidebar-mobile-backdrop");
+    expect(panel?.dataset.state).toBe("open");
+
+    fireTouch(backdrop, "touchstart", createTouch(360, 160));
+    fireTouch(window, "touchmove", createTouch(180, 164));
+    fireTouchEnd(window, createTouch(180, 164));
+    settleMobileToggle();
+
+    expect(panel?.dataset.state).toBe("closed");
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+  });
+
+  it("ignores a closing swipe from the right browser edge", () => {
+    vi.useFakeTimers();
+    renderCompactSidebarHarness();
+
+    fireEvent.click(screen.getByRole("button", { name: "Toggle Sidebar" }));
+    settleMobileToggle();
+
+    const panel = getMobilePanel();
+    const backdrop = screen.getByTestId("sidebar-mobile-backdrop");
+    const startX = window.innerWidth - 12;
+
+    fireTouch(backdrop, "touchstart", createTouch(startX, 160));
+    fireTouch(window, "touchmove", createTouch(startX - 180, 164));
+    fireTouchEnd(window, createTouch(startX - 180, 164));
+    settleMobileToggle();
+
+    expect(panel?.dataset.state).toBe("open");
+  });
+
   it("keeps closed drawer content mounted, inert, and offscreen", () => {
     vi.useFakeTimers();
     renderCompactSidebarHarness();

--- a/apps/app/src/components/ui/sidebar.tsx
+++ b/apps/app/src/components/ui/sidebar.tsx
@@ -19,6 +19,7 @@ import {
   getCompactSecondaryPanelPresentation,
   subscribeCompactSecondaryPanelShelfShowing,
 } from "./secondary-panel-shelf-visibility.js";
+import { useHorizontalDismissDrag } from "./use-horizontal-dismiss-drag.js";
 
 const SIDEBAR_WIDTH = "16rem";
 const SIDEBAR_MOBILE_VIEWPORT_FRACTION = 0.76;
@@ -37,8 +38,6 @@ const SIDEBAR_MOBILE_SHELF_SETTLE_TRANSITION = `translate ${SIDEBAR_MOBILE_DRAG_
 const SIDEBAR_MOBILE_SHELF_BACKDROP_SETTLE_TRANSITION = `opacity ${SIDEBAR_MOBILE_DRAG_SETTLE_MS}ms ${SIDEBAR_MOBILE_DRAG_SETTLE_EASING}, translate ${SIDEBAR_MOBILE_DRAG_SETTLE_MS}ms ${SIDEBAR_MOBILE_DRAG_SETTLE_EASING}`;
 const SIDEBAR_MOBILE_WHEEL_SWIPE_OPEN_DISTANCE_PX = 90;
 const SIDEBAR_MOBILE_WHEEL_SWIPE_RESET_MS = 250;
-const SIDEBAR_MOBILE_DRAG_CLOSE_RATIO = 0.25;
-const SIDEBAR_MOBILE_DRAG_CLOSE_FLING_VELOCITY_PX_PER_SEC = 450;
 const SIDEBAR_MOBILE_SHELF_INSET_TRANSITION_CLASS =
   "max-md:[transition:translate_220ms_cubic-bezier(0.32,0.72,0,1)]";
 const SIDEBAR_MOBILE_BACKDROP_TRANSITION_CLASS =
@@ -797,37 +796,6 @@ const Sidebar = React.forwardRef<HTMLDivElement, React.ComponentProps<"div">>(
 );
 Sidebar.displayName = "Sidebar";
 
-type SidebarPanelDragSession = {
-  kind: "pointer" | "touch";
-  id: number;
-  startX: number;
-  startY: number;
-  panelWidth: number;
-  lastProgress: number;
-  lastClientX: number;
-  lastTimeMs: number;
-  velocityX: number;
-  isDragging: boolean;
-  startTarget: Element | null;
-};
-
-function suppressNextSidebarPanelDragClick() {
-  const cleanup = () => {
-    window.removeEventListener("click", suppressClick, { capture: true });
-    window.clearTimeout(timeout);
-  };
-  const suppressClick = (event: MouseEvent) => {
-    event.preventDefault();
-    event.stopPropagation();
-    cleanup();
-  };
-  const timeout = window.setTimeout(cleanup, 400);
-  window.addEventListener("click", suppressClick, {
-    capture: true,
-    once: true,
-  });
-}
-
 interface SidebarMobilePanelProps extends React.ComponentProps<"div"> {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -896,26 +864,6 @@ const SidebarMobilePanel = React.forwardRef<
       },
       [ref],
     );
-    const dragSessionRef = React.useRef<SidebarPanelDragSession | null>(null);
-    const removeDragListenersRef = React.useRef<(() => void) | null>(null);
-    const settleTimeoutRef = React.useRef<number | null>(null);
-
-    const clearDragSession = React.useCallback(() => {
-      removeDragListenersRef.current?.();
-      removeDragListenersRef.current = null;
-      dragSessionRef.current = null;
-    }, []);
-
-    const clearSettleTimeout = React.useCallback(() => {
-      if (settleTimeoutRef.current !== null) {
-        window.clearTimeout(settleTimeoutRef.current);
-        settleTimeoutRef.current = null;
-      }
-    }, []);
-
-    React.useLayoutEffect(() => {
-      clearSidebarMobileDragStyles();
-    }, [open]);
 
     React.useEffect(() => {
       if (!open) {
@@ -995,294 +943,30 @@ const SidebarMobilePanel = React.forwardRef<
       };
     }, [open, onDismiss]);
 
-    React.useEffect(
-      () => () => {
-        clearDragSession();
-        clearSettleTimeout();
-        clearSidebarMobileDragStyles();
+    const { beginPointerDrag, beginTouchDrag } = useHorizontalDismissDrag({
+      direction: "left",
+      dismissTiming: "settled",
+      enabled: open,
+      getWidth: getSidebarMobilePanelWidth,
+      onClear: clearSidebarMobileDragStyles,
+      onDismiss: () => onOpenChange(false),
+      onProgress: ({ progress, settling }) => {
+        applySidebarMobileDragStyles({ progress, settling });
       },
-      [clearDragSession, clearSettleTimeout],
-    );
+      resetKey: open ? "open" : "closed",
+      suppressClick: true,
+    });
 
-    const restoreOpenAfterCancelledDrag = () => {
-      clearSettleTimeout();
-      applySidebarMobileDragStyles({ progress: 1, settling: true });
-      settleTimeoutRef.current = window.setTimeout(() => {
-        settleTimeoutRef.current = null;
-        clearSidebarMobileDragStyles();
-      }, SIDEBAR_MOBILE_DRAG_SETTLE_MS);
-    };
-
-    const continuePanelDrag = (
-      clientX: number,
-      clientY: number,
-      event: PointerEvent | TouchEvent,
-    ) => {
-      const session = dragSessionRef.current;
-      if (session === null) {
-        return;
-      }
-
-      const deltaX = clientX - session.startX;
-      const deltaY = clientY - session.startY;
-      const closeDelta = -deltaX;
-      const absDeltaX = Math.abs(deltaX);
-      const absDeltaY = Math.abs(deltaY);
-
-      if (!session.isDragging) {
-        if (
-          absDeltaY > SIDEBAR_MOBILE_SWIPE_OPEN_INTENT_PX &&
-          absDeltaY > absDeltaX * 1.15
-        ) {
-          clearDragSession();
-          return;
-        }
-        if (
-          closeDelta < SIDEBAR_MOBILE_SWIPE_OPEN_INTENT_PX ||
-          absDeltaX <= absDeltaY * 1.25
-        ) {
-          return;
-        }
-        if (
-          session.startTarget !== null &&
-          (!session.startTarget.isConnected ||
-            isInsideHorizontalScrollRegion(session.startTarget))
-        ) {
-          clearDragSession();
-          return;
-        }
-        session.isDragging = true;
-        clearSettleTimeout();
-      }
-
-      if (event.cancelable) {
-        event.preventDefault();
-      }
-
-      const nowMs = Date.now();
-      const elapsedMs = nowMs - session.lastTimeMs;
-      if (elapsedMs > 0) {
-        session.velocityX =
-          ((clientX - session.lastClientX) / elapsedMs) * 1000;
-        session.lastClientX = clientX;
-        session.lastTimeMs = nowMs;
-      }
-      const progress = clampSidebarMobileSwipeProgress(
-        1 - closeDelta / session.panelWidth,
-      );
-      session.lastProgress = progress;
-      applySidebarMobileDragStyles({ progress, settling: false });
-    };
-
-    const finishPanelDrag = (event: PointerEvent | TouchEvent) => {
-      const session = dragSessionRef.current;
-      if (session === null) {
-        return;
-      }
-
-      clearDragSession();
-      if (!session.isDragging) {
-        return;
-      }
-      if (event.cancelable) {
-        event.preventDefault();
-      }
-      suppressNextSidebarPanelDragClick();
-
-      const closeVelocity = -session.velocityX;
-      const shouldClose =
-        session.lastProgress <= 1 - SIDEBAR_MOBILE_DRAG_CLOSE_RATIO ||
-        (session.lastProgress <=
-          1 - SIDEBAR_MOBILE_SWIPE_OPEN_FLING_MIN_RATIO &&
-          closeVelocity >= SIDEBAR_MOBILE_DRAG_CLOSE_FLING_VELOCITY_PX_PER_SEC);
-
-      clearSettleTimeout();
-      applySidebarMobileDragStyles({
-        progress: shouldClose ? 0 : 1,
-        settling: true,
-      });
-      settleTimeoutRef.current = window.setTimeout(() => {
-        settleTimeoutRef.current = null;
-        if (shouldClose) {
-          onOpenChange(false);
-        } else {
-          clearSidebarMobileDragStyles();
-        }
-      }, SIDEBAR_MOBILE_DRAG_SETTLE_MS);
-    };
-
-    const cancelPanelDrag = () => {
-      const wasDragging = dragSessionRef.current?.isDragging ?? false;
-      clearDragSession();
-      if (wasDragging) {
-        restoreOpenAfterCancelledDrag();
-      }
-    };
-
-    const isIgnoredPanelDragTarget = (target: EventTarget | null) =>
-      target instanceof Element &&
-      target.closest(
-        'input, textarea, select, [contenteditable="true"], [role="slider"], [data-vaul-no-drag], [data-no-sidebar-swipe]',
-      ) !== null;
-
-    const beginPanelDragSession = (
-      kind: "pointer" | "touch",
-      id: number,
-      clientX: number,
-      clientY: number,
-      target: EventTarget | null,
-    ) => {
-      dragSessionRef.current = {
-        kind,
-        id,
-        startX: clientX,
-        startY: clientY,
-        panelWidth: getSidebarMobilePanelWidth(),
-        lastProgress: 1,
-        lastClientX: clientX,
-        lastTimeMs: Date.now(),
-        velocityX: 0,
-        isDragging: false,
-        startTarget: target instanceof Element ? target : null,
-      };
-    };
-
-    const handlePanelPointerDown = (
+    const beginPanelPointerDrag = (
       event: React.PointerEvent<HTMLDivElement>,
     ) => {
       onPointerDown?.(event);
-      if (
-        !open ||
-        event.defaultPrevented ||
-        event.pointerType !== "touch" ||
-        event.button !== 0 ||
-        dragSessionRef.current !== null ||
-        isIgnoredPanelDragTarget(event.target)
-      ) {
-        return;
-      }
-
-      beginPanelDragSession(
-        "pointer",
-        event.pointerId,
-        event.clientX,
-        event.clientY,
-        event.target,
-      );
-
-      const handleMove = (moveEvent: PointerEvent) => {
-        const session = dragSessionRef.current;
-        if (session?.kind !== "pointer" || moveEvent.pointerId !== session.id) {
-          return;
-        }
-        continuePanelDrag(moveEvent.clientX, moveEvent.clientY, moveEvent);
-      };
-      const handleEnd = (endEvent: PointerEvent) => {
-        const session = dragSessionRef.current;
-        if (session?.kind !== "pointer" || endEvent.pointerId !== session.id) {
-          return;
-        }
-        finishPanelDrag(endEvent);
-      };
-      const handleCancel = (cancelEvent: PointerEvent) => {
-        const session = dragSessionRef.current;
-        if (
-          session?.kind !== "pointer" ||
-          cancelEvent.pointerId !== session.id
-        ) {
-          return;
-        }
-        cancelPanelDrag();
-      };
-
-      const removeListeners = () => {
-        window.removeEventListener("pointermove", handleMove);
-        window.removeEventListener("pointerup", handleEnd);
-        window.removeEventListener("pointercancel", handleCancel);
-      };
-      window.addEventListener("pointermove", handleMove, { passive: false });
-      window.addEventListener("pointerup", handleEnd);
-      window.addEventListener("pointercancel", handleCancel);
-      removeDragListenersRef.current = removeListeners;
+      beginPointerDrag(event);
     };
 
-    const handlePanelTouchStart = (event: React.TouchEvent<HTMLDivElement>) => {
+    const beginPanelTouchDrag = (event: React.TouchEvent<HTMLDivElement>) => {
       onTouchStart?.(event);
-      if (
-        !open ||
-        event.defaultPrevented ||
-        event.touches.length !== 1 ||
-        isIgnoredPanelDragTarget(event.target)
-      ) {
-        return;
-      }
-      const currentSession = dragSessionRef.current;
-      if (currentSession !== null) {
-        if (currentSession.kind !== "pointer") {
-          return;
-        }
-        clearDragSession();
-      }
-      const touch = event.touches.item(0);
-      if (touch === null) {
-        return;
-      }
-
-      beginPanelDragSession(
-        "touch",
-        touch.identifier,
-        touch.clientX,
-        touch.clientY,
-        event.target,
-      );
-
-      const handleTouchMove = (moveEvent: TouchEvent) => {
-        const session = dragSessionRef.current;
-        if (session?.kind !== "touch") {
-          return;
-        }
-        const trackedTouch = getTrackedSwipeTouch(moveEvent, session.id);
-        if (trackedTouch === null) {
-          return;
-        }
-        continuePanelDrag(
-          trackedTouch.clientX,
-          trackedTouch.clientY,
-          moveEvent,
-        );
-      };
-      const handleTouchEnd = (endEvent: TouchEvent) => {
-        const session = dragSessionRef.current;
-        if (
-          session?.kind !== "touch" ||
-          getTrackedSwipeTouch(endEvent, session.id) === null
-        ) {
-          return;
-        }
-        finishPanelDrag(endEvent);
-      };
-      const handleTouchCancel = (cancelEvent: TouchEvent) => {
-        const session = dragSessionRef.current;
-        if (
-          session?.kind !== "touch" ||
-          getTrackedSwipeTouch(cancelEvent, session.id) === null
-        ) {
-          return;
-        }
-        cancelPanelDrag();
-      };
-
-      const removeListeners = () => {
-        window.removeEventListener("touchmove", handleTouchMove);
-        window.removeEventListener("touchend", handleTouchEnd);
-        window.removeEventListener("touchcancel", handleTouchCancel);
-      };
-      window.addEventListener("touchmove", handleTouchMove, {
-        passive: false,
-      });
-      window.addEventListener("touchend", handleTouchEnd);
-      window.addEventListener("touchcancel", handleTouchCancel);
-      removeDragListenersRef.current = removeListeners;
+      beginTouchDrag(event);
     };
 
     const suppressedOpenTransitionStyle =
@@ -1305,6 +989,8 @@ const SidebarMobilePanel = React.forwardRef<
           )}
           style={{ ...suppressedOpenTransitionStyle, ...backdropStyle }}
           onClick={onDismiss}
+          onPointerDown={beginPointerDrag}
+          onTouchStart={beginTouchDrag}
         />
         <div
           ref={setPanelRef}
@@ -1331,8 +1017,8 @@ const SidebarMobilePanel = React.forwardRef<
               ...style,
             } as SidebarMobileWidthStyle
           }
-          onPointerDown={handlePanelPointerDown}
-          onTouchStart={handlePanelTouchStart}
+          onPointerDown={beginPanelPointerDrag}
+          onTouchStart={beginPanelTouchDrag}
           {...props}
         >
           <div

--- a/apps/app/src/components/ui/use-horizontal-dismiss-drag.ts
+++ b/apps/app/src/components/ui/use-horizontal-dismiss-drag.ts
@@ -1,0 +1,371 @@
+import * as React from "react";
+
+import { useLatestRef } from "@/hooks/useLatestRef";
+
+const DRAG_INTENT_PX = 12;
+const DRAG_SETTLE_MS = 220;
+const DRAG_CLICK_SUPPRESSION_MS = 400;
+const BROWSER_NAVIGATION_EDGE_PX = 24;
+const IGNORED_TARGET_SELECTOR =
+  'input, textarea, select, [contenteditable="true"], [role="slider"], [data-vaul-no-drag], [data-no-sidebar-swipe], [data-no-secondary-panel-swipe]';
+
+type DragInput = "pointer" | "touch";
+
+type DragSession = {
+  input: DragInput;
+  id: number;
+  startX: number;
+  startY: number;
+  width: number;
+  progress: number;
+  lastX: number;
+  lastTime: number;
+  velocityX: number;
+  dragging: boolean;
+  target: Element | null;
+  boundary: Element;
+};
+
+type DragProgress = {
+  progress: number;
+  settling: boolean;
+  width: number;
+};
+
+type Options = {
+  direction: "left" | "right";
+  dismissTiming: "immediate" | "settled";
+  enabled: boolean;
+  getWidth: () => number;
+  onClear: () => void;
+  onDismiss: () => void;
+  onProgress: (progress: DragProgress) => void;
+  resetKey: string;
+  suppressClick: boolean;
+};
+
+type Point = { x: number; y: number };
+
+function getTouch(touches: TouchList, id: number): Touch | null {
+  for (let index = 0; index < touches.length; index += 1) {
+    const touch = touches.item(index);
+    if (touch?.identifier === id) return touch;
+  }
+  return null;
+}
+
+function isTouchEvent(event: Event): event is TouchEvent {
+  return "touches" in event && "changedTouches" in event;
+}
+
+function trackedPoint(event: Event, session: DragSession): Point | null {
+  if (session.input === "touch") {
+    if (!isTouchEvent(event)) return null;
+    const touch =
+      getTouch(event.touches, session.id) ??
+      getTouch(event.changedTouches, session.id);
+    return touch === null ? null : { x: touch.clientX, y: touch.clientY };
+  }
+  if (
+    !("pointerId" in event) ||
+    event.pointerId !== session.id ||
+    !("clientX" in event) ||
+    typeof event.clientX !== "number" ||
+    !("clientY" in event) ||
+    typeof event.clientY !== "number"
+  ) {
+    return null;
+  }
+  return { x: event.clientX, y: event.clientY };
+}
+
+function isScrollable(element: Element): boolean {
+  const view = element.ownerDocument.defaultView;
+  if (view === null || !(element instanceof view.HTMLElement)) return false;
+  const overflow = view.getComputedStyle(element).overflowX;
+  return (
+    (overflow === "auto" || overflow === "scroll" || overflow === "overlay") &&
+    element.scrollWidth > element.clientWidth + 1
+  );
+}
+
+function startsInHorizontalScroller(session: DragSession): boolean {
+  let element = session.target;
+  while (element !== null) {
+    if (isScrollable(element)) return true;
+    if (element === session.boundary) return false;
+    element = element.parentElement;
+  }
+  return false;
+}
+
+function suppressNextClick() {
+  const cleanup = () => {
+    window.removeEventListener("click", suppress, { capture: true });
+    window.clearTimeout(timeout);
+  };
+  const suppress = (event: MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    cleanup();
+  };
+  const timeout = window.setTimeout(cleanup, DRAG_CLICK_SUPPRESSION_MS);
+  window.addEventListener("click", suppress, { capture: true, once: true });
+}
+
+export function useHorizontalDismissDrag(options: Options) {
+  const optionsRef = useLatestRef(options);
+  const sessionRef = React.useRef<DragSession | null>(null);
+  const removeListenersRef = React.useRef<(() => void) | null>(null);
+  const settleTimeoutRef = React.useRef<number | null>(null);
+
+  const clearSession = React.useCallback(() => {
+    removeListenersRef.current?.();
+    removeListenersRef.current = null;
+    sessionRef.current = null;
+  }, []);
+
+  const clearSettle = React.useCallback(() => {
+    if (settleTimeoutRef.current === null) return;
+    window.clearTimeout(settleTimeoutRef.current);
+    settleTimeoutRef.current = null;
+  }, []);
+
+  const settle = React.useCallback(
+    (progress: number, session: DragSession, dismiss: boolean) => {
+      clearSettle();
+      const current = optionsRef.current;
+      current.onProgress({ progress, settling: true, width: session.width });
+      if (dismiss && current.dismissTiming === "immediate") {
+        current.onDismiss();
+      }
+      settleTimeoutRef.current = window.setTimeout(() => {
+        settleTimeoutRef.current = null;
+        if (dismiss && current.dismissTiming === "settled") {
+          optionsRef.current.onDismiss();
+        }
+        optionsRef.current.onClear();
+      }, DRAG_SETTLE_MS);
+    },
+    [clearSettle, optionsRef],
+  );
+
+  const move = React.useCallback(
+    (event: Event) => {
+      const session = sessionRef.current;
+      if (session === null) return;
+      const point = trackedPoint(event, session);
+      if (point === null) return;
+      const direction = optionsRef.current.direction === "left" ? -1 : 1;
+      const deltaX = point.x - session.startX;
+      const deltaY = point.y - session.startY;
+      const absX = Math.abs(deltaX);
+      const absY = Math.abs(deltaY);
+      if (!session.dragging) {
+        if (absY > DRAG_INTENT_PX && absY > absX * 1.15) {
+          clearSession();
+          return;
+        }
+        if (deltaX * direction < DRAG_INTENT_PX || absX <= absY * 1.25) {
+          return;
+        }
+        if (
+          session.target !== null &&
+          (!session.target.isConnected || startsInHorizontalScroller(session))
+        ) {
+          clearSession();
+          return;
+        }
+        session.dragging = true;
+        clearSettle();
+      }
+      if (event.cancelable) event.preventDefault();
+      const now = Date.now();
+      const elapsed = now - session.lastTime;
+      if (elapsed > 0) {
+        session.velocityX = ((point.x - session.lastX) / elapsed) * 1000;
+        session.lastX = point.x;
+        session.lastTime = now;
+      }
+      session.progress = Math.min(
+        1,
+        Math.max(0, 1 - (deltaX * direction) / session.width),
+      );
+      optionsRef.current.onProgress({
+        progress: session.progress,
+        settling: false,
+        width: session.width,
+      });
+    },
+    [clearSession, clearSettle, optionsRef],
+  );
+
+  const finish = React.useCallback(
+    (event: Event) => {
+      const session = sessionRef.current;
+      if (session === null || trackedPoint(event, session) === null) return;
+      clearSession();
+      if (!session.dragging) return;
+      if (event.cancelable) event.preventDefault();
+      if (optionsRef.current.suppressClick) suppressNextClick();
+      const direction = optionsRef.current.direction === "left" ? -1 : 1;
+      const dismiss =
+        session.progress <= 0.75 ||
+        (session.progress <= 0.88 && session.velocityX * direction >= 450);
+      settle(dismiss ? 0 : 1, session, dismiss);
+    },
+    [clearSession, optionsRef, settle],
+  );
+
+  const cancel = React.useCallback(
+    (event: Event) => {
+      const session = sessionRef.current;
+      if (session === null || trackedPoint(event, session) === null) return;
+      clearSession();
+      if (session.dragging) settle(1, session, false);
+    },
+    [clearSession, settle],
+  );
+
+  const listen = React.useCallback(
+    (session: DragSession) => {
+      const prefix = session.input;
+      const moveType = `${prefix}move`;
+      const endType = prefix === "pointer" ? "pointerup" : "touchend";
+      const cancelType = `${prefix}cancel`;
+      const remove = () => {
+        window.removeEventListener(moveType, move);
+        window.removeEventListener(endType, finish);
+        window.removeEventListener(cancelType, cancel);
+      };
+      window.addEventListener(moveType, move, { passive: false });
+      window.addEventListener(endType, finish);
+      window.addEventListener(cancelType, cancel);
+      removeListenersRef.current = remove;
+    },
+    [cancel, finish, move],
+  );
+
+  const start = React.useCallback(
+    (
+      input: DragInput,
+      id: number,
+      x: number,
+      y: number,
+      target: EventTarget | null,
+      boundary: Element,
+    ) => {
+      const view = boundary.ownerDocument.defaultView;
+      if (
+        (optionsRef.current.direction === "left" &&
+          view !== null &&
+          x > view.innerWidth - BROWSER_NAVIGATION_EDGE_PX) ||
+        (optionsRef.current.direction === "right" &&
+          x < BROWSER_NAVIGATION_EDGE_PX)
+      ) {
+        return;
+      }
+      const session: DragSession = {
+        input,
+        id,
+        startX: x,
+        startY: y,
+        width: Math.max(optionsRef.current.getWidth(), 1),
+        progress: 1,
+        lastX: x,
+        lastTime: Date.now(),
+        velocityX: 0,
+        dragging: false,
+        target: target instanceof Element ? target : null,
+        boundary,
+      };
+      sessionRef.current = session;
+      listen(session);
+    },
+    [listen, optionsRef],
+  );
+
+  const beginPointerDrag = React.useCallback<
+    React.PointerEventHandler<HTMLDivElement>
+  >(
+    (event) => {
+      if (
+        !optionsRef.current.enabled ||
+        event.defaultPrevented ||
+        event.pointerType !== "touch" ||
+        event.button !== 0 ||
+        sessionRef.current !== null ||
+        (event.target instanceof Element &&
+          event.target.closest(IGNORED_TARGET_SELECTOR) !== null)
+      ) {
+        return;
+      }
+      start(
+        "pointer",
+        event.pointerId,
+        event.clientX,
+        event.clientY,
+        event.target,
+        event.currentTarget,
+      );
+    },
+    [optionsRef, start],
+  );
+
+  const beginTouchDrag = React.useCallback<
+    React.TouchEventHandler<HTMLDivElement>
+  >(
+    (event) => {
+      if (
+        !optionsRef.current.enabled ||
+        event.defaultPrevented ||
+        event.touches.length !== 1 ||
+        (event.target instanceof Element &&
+          event.target.closest(IGNORED_TARGET_SELECTOR) !== null)
+      ) {
+        return;
+      }
+      if (sessionRef.current !== null) {
+        if (sessionRef.current.input !== "pointer") return;
+        clearSession();
+      }
+      const touch = event.touches.item(0);
+      if (touch === null) return;
+      start(
+        "touch",
+        touch.identifier,
+        touch.clientX,
+        touch.clientY,
+        event.target,
+        event.currentTarget,
+      );
+    },
+    [clearSession, optionsRef, start],
+  );
+
+  React.useLayoutEffect(() => {
+    if (options.enabled || options.dismissTiming === "settled") {
+      clearSession();
+      clearSettle();
+      optionsRef.current.onClear();
+    }
+  }, [
+    clearSession,
+    clearSettle,
+    options.dismissTiming,
+    options.enabled,
+    options.resetKey,
+    optionsRef,
+  ]);
+
+  React.useEffect(
+    () => () => {
+      clearSession();
+      clearSettle();
+      optionsRef.current.onClear();
+    },
+    [clearSession, clearSettle, optionsRef],
+  );
+
+  return { beginPointerDrag, beginTouchDrag };
+}


### PR DESCRIPTION
## Human comments

## What was wrong

The compact left sidebar tracked closing gestures only from inside its panel, while the backdrop covering the exposed main-content strip handled clicks only. The compact right shelf had no swipe-dismiss controller after its shelf conversion, so neither its panel nor its exposed-content dismiss layer could track a closing swipe. A dismiss controller without an edge reservation would also compete with browser history navigation gestures.

## What changed

Added one shared horizontal-dismiss hook for pointer/touch tracking, intent and velocity arbitration, nested horizontal-scroll protection, settling, and cleanup. The left and right shelf adapters now attach it to both the panel and their exposed-content dismiss layer, configure their direction and visual transforms, and reserve the corresponding 24px browser-navigation edge. No wire, CLI, guide, or protocol changes.

## How you verified

- Added red-to-green regressions for closing both shelves from the remaining exposed-content strip.
- Added red-to-green regressions proving both corresponding 24px browser edges are ignored.
- pnpm exec turbo run test --filter=@bb/app -- --run src/components/ui/sidebar.test.tsx src/components/secondary-panel/CompactSecondaryPanelShelf.test.tsx src/components/secondary-panel/SecondaryPanelLayout.test.tsx (56 passed)
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run lint --filter=@bb/app (0 errors)
- Manually verified the left exposed-strip gesture at a 390x844 Chromium viewport before shutting down the requested dev share.

Reported directly; no linked GitHub issue.

> AGENT GENERATED
