### PR TITLE
Fix Codex resumed child correlation

### DIFF
--- a/apps/server/src/services/threads/timeline.ts
+++ b/apps/server/src/services/threads/timeline.ts
@@ -286,6 +286,18 @@ function tryReadClientTurnRequestedRequestId(
   return event.requestId;
 }
 
+function isExternalUserNewTurnBoundary(row: StoredEventRow): boolean {
+  if (row.type !== "client/turn/requested") {
+    return false;
+  }
+  const event = parseStoredEvent(row);
+  return (
+    event.type === "client/turn/requested" &&
+    event.initiator === "user" &&
+    event.target.kind === "new-turn"
+  );
+}
+
 function tryReadSteerClientTurnRequestedRequestId(
   row: StoredEventRow,
 ): ClientTurnRequestId | null {
@@ -558,13 +570,46 @@ function filterExactEventRowsForRequestedTurn(
   const rows: StoredEventRow[] = [];
   let removedRows = false;
   const openToolCallIds = new Set<string>();
+  const externalUserNewTurnRequestIds = new Set<ClientTurnRequestId>();
+  const hasRequestedTurnCompletedRow = args.exactEventRows.some(
+    (row) =>
+      row.type === "turn/completed" &&
+      row.scopeKind === "turn" &&
+      row.turnId === args.turnId,
+  );
+  for (const [index, row] of args.exactEventRows.entries()) {
+    if (!hasRequestedTurnCompletedRow || !isExternalUserNewTurnBoundary(row)) {
+      continue;
+    }
+    const requestId = tryReadClientTurnRequestedRequestId(row);
+    if (
+      requestId === null ||
+      !args.acceptedClientRequestIdsForOtherTurns.has(requestId)
+    ) {
+      continue;
+    }
+    const hasLaterRequestedTurnRow = args.exactEventRows
+      .slice(index + 1)
+      .some(
+        (laterRow) =>
+          laterRow.scopeKind === "turn" && laterRow.turnId === args.turnId,
+      );
+    if (hasLaterRequestedTurnRow) {
+      externalUserNewTurnRequestIds.add(requestId);
+    }
+  }
   for (const row of args.exactEventRows) {
     if (row.scopeKind === "turn" && row.turnId !== args.turnId) {
       const continuesOpenToolCall =
         row.itemId !== null &&
         row.type.startsWith("item/") &&
         openToolCallIds.has(row.itemId);
-      if (!continuesOpenToolCall) {
+      const acceptsExternalUserNewTurn =
+        row.type === "turn/input/accepted" &&
+        externalUserNewTurnRequestIds.has(
+          parseAcceptedInputClientRequestId(row),
+        );
+      if (!continuesOpenToolCall && !acceptsExternalUserNewTurn) {
         removedRows = true;
         continue;
       }
@@ -583,7 +628,8 @@ function filterExactEventRowsForRequestedTurn(
     const requestId = tryReadClientTurnRequestedRequestId(row);
     if (
       requestId !== null &&
-      args.acceptedClientRequestIdsForOtherTurns.has(requestId)
+      args.acceptedClientRequestIdsForOtherTurns.has(requestId) &&
+      !externalUserNewTurnRequestIds.has(requestId)
     ) {
       removedRows = true;
       continue;
@@ -772,6 +818,21 @@ function ensureSequenceWindowWholeItemRows(
     return [...args.rows];
   }
 
+  const completedWindowItemKeys = new Set<string>();
+  const reopenedWindowItemKeys = new Set<string>();
+  for (const row of args.rows) {
+    if (row.itemId === null) {
+      continue;
+    }
+    const key = scopedItemRefKey(storedEventRowItemRef(row));
+    if (row.type === "item/started" && completedWindowItemKeys.has(key)) {
+      reopenedWindowItemKeys.add(key);
+    }
+    if (row.type === "item/completed") {
+      completedWindowItemKeys.add(key);
+    }
+  }
+
   const spans = listItemEventSpansByItems(db, {
     items: [...windowItems.values()],
     threadId: args.threadId,
@@ -782,7 +843,8 @@ function ensureSequenceWindowWholeItemRows(
     const key = scopedItemRefKey(span);
     if (
       args.beforeSequence !== undefined &&
-      span.maxSequence >= args.beforeSequence
+      span.maxSequence >= args.beforeSequence &&
+      !reopenedWindowItemKeys.has(key)
     ) {
       itemKeysOwnedByNewerWindow.add(key);
       continue;
@@ -1922,18 +1984,37 @@ export function buildTimelineTurnSummaryDetails(
         : sourceSeqStart,
     sourceRange.sourceSeqStart,
   );
-  const children = buildThreadTimelineTurnDetailsFromEvents({
-    events: eventRowsWithBackgroundTaskState.map((row) =>
-      toThreadEventWithMeta(row),
-    ),
+  const events = eventRowsWithBackgroundTaskState.map((row) =>
+    toThreadEventWithMeta(row),
+  );
+  const detailOptions = {
+    includeProviderUnhandledOperations,
+    providerDisplayName: options.providerDisplayName,
+    threadStatus: thread.status,
+    threadName: thread.title ?? thread.titleFallback ?? "",
+    turnId: options.turnId,
+    workspaceRoot: resolveThreadWorkspaceRoot(db, thread),
+  };
+  const exactChildren = buildThreadTimelineTurnDetailsFromEvents({
+    events,
     options: {
-      includeProviderUnhandledOperations,
+      ...detailOptions,
+      sourceSeqEnd: options.sourceSeqEnd,
+      sourceSeqStart: options.sourceSeqStart,
+    },
+  });
+  if (exactChildren.kind !== "missing-match") {
+    return {
+      rows: exactChildren.rows,
+    };
+  }
+
+  const children = buildThreadTimelineTurnDetailsFromEvents({
+    events,
+    options: {
+      ...detailOptions,
       sourceSeqEnd: sourceRange.sourceSeqEnd,
       sourceSeqStart: projectionSourceSeqStart,
-      providerDisplayName: options.providerDisplayName,
-      threadStatus: thread.status,
-      threadName: thread.title ?? thread.titleFallback ?? "",
-      workspaceRoot: resolveThreadWorkspaceRoot(db, thread),
     },
   });
 

--- a/apps/server/src/services/threads/timeline.ts
+++ b/apps/server/src/services/threads/timeline.ts
@@ -577,25 +577,25 @@ function filterExactEventRowsForRequestedTurn(
       row.scopeKind === "turn" &&
       row.turnId === args.turnId,
   );
-  for (const [index, row] of args.exactEventRows.entries()) {
-    if (!hasRequestedTurnCompletedRow || !isExternalUserNewTurnBoundary(row)) {
-      continue;
-    }
-    const requestId = tryReadClientTurnRequestedRequestId(row);
+  let hasLaterRequestedTurnRow = false;
+  for (let index = args.exactEventRows.length - 1; index >= 0; index -= 1) {
+    const row = args.exactEventRows[index];
     if (
-      requestId === null ||
-      !args.acceptedClientRequestIdsForOtherTurns.has(requestId)
+      hasRequestedTurnCompletedRow &&
+      hasLaterRequestedTurnRow &&
+      row !== undefined &&
+      isExternalUserNewTurnBoundary(row)
     ) {
-      continue;
+      const requestId = tryReadClientTurnRequestedRequestId(row);
+      if (
+        requestId !== null &&
+        args.acceptedClientRequestIdsForOtherTurns.has(requestId)
+      ) {
+        externalUserNewTurnRequestIds.add(requestId);
+      }
     }
-    const hasLaterRequestedTurnRow = args.exactEventRows
-      .slice(index + 1)
-      .some(
-        (laterRow) =>
-          laterRow.scopeKind === "turn" && laterRow.turnId === args.turnId,
-      );
-    if (hasLaterRequestedTurnRow) {
-      externalUserNewTurnRequestIds.add(requestId);
+    if (row?.scopeKind === "turn" && row.turnId === args.turnId) {
+      hasLaterRequestedTurnRow = true;
     }
   }
   for (const row of args.exactEventRows) {
@@ -1995,26 +1995,17 @@ export function buildTimelineTurnSummaryDetails(
     turnId: options.turnId,
     workspaceRoot: resolveThreadWorkspaceRoot(db, thread),
   };
-  const exactChildren = buildThreadTimelineTurnDetailsFromEvents({
-    events,
-    options: {
-      ...detailOptions,
-      sourceSeqEnd: options.sourceSeqEnd,
-      sourceSeqStart: options.sourceSeqStart,
-    },
-  });
-  if (exactChildren.kind !== "missing-match") {
-    return {
-      rows: exactChildren.rows,
-    };
-  }
-
   const children = buildThreadTimelineTurnDetailsFromEvents({
     events,
     options: {
       ...detailOptions,
-      sourceSeqEnd: sourceRange.sourceSeqEnd,
-      sourceSeqStart: projectionSourceSeqStart,
+      fallbackSelection: {
+        sourceSeqEnd: sourceRange.sourceSeqEnd,
+        sourceSeqStart: projectionSourceSeqStart,
+        turnId: options.turnId,
+      },
+      sourceSeqEnd: options.sourceSeqEnd,
+      sourceSeqStart: options.sourceSeqStart,
     },
   });
 

--- a/apps/server/test/services/threads/timeline-in-turn-window.test.ts
+++ b/apps/server/test/services/threads/timeline-in-turn-window.test.ts
@@ -1591,3 +1591,165 @@ describe("turn details for an item that finishes in a later turn", () => {
     }
   });
 });
+
+describe("turn details for a reopened delegation", () => {
+  it("matches the summary range after an accepted new turn", () => {
+    const { db, thread } = setup();
+    const events: EventInput[] = [];
+    let sequence = 0;
+    const push = (event: Omit<EventInput, "sequence" | "threadId">): void => {
+      sequence += 1;
+      events.push({ ...event, sequence, threadId: thread.id });
+    };
+    const turnLifecycle = (
+      turnId: string,
+      type: "turn/started" | "turn/completed",
+      parentToolCallId: string | null = null,
+    ): Omit<EventInput, "sequence" | "threadId"> => ({
+      type,
+      scope: turnScope(turnId),
+      providerThreadId,
+      itemId: null,
+      itemKind: null,
+      parentToolCallId,
+      data: JSON.stringify(
+        type === "turn/started"
+          ? {
+              ...(parentToolCallId === null ? {} : { parentToolCallId }),
+            }
+          : { status: "completed", providerThreadId },
+      ),
+    });
+    const delegation = (
+      type: "item/started" | "item/completed",
+    ): Omit<EventInput, "sequence" | "threadId"> => ({
+      type,
+      scope: turnScope("turn-1"),
+      providerThreadId,
+      itemId: "delegation-1",
+      itemKind: "delegation",
+      parentToolCallId: null,
+      data: JSON.stringify({
+        providerThreadId,
+        item: {
+          type: "delegation",
+          id: "delegation-1",
+          childRef: "child-alpha",
+          label: "/root/alpha",
+          status: type === "item/started" ? "pending" : "completed",
+          background: false,
+        },
+      }),
+    });
+    const agentMessage = (
+      turnId: string,
+      itemId: string,
+      text: string,
+      parentToolCallId: string | null,
+    ): Omit<EventInput, "sequence" | "threadId"> => ({
+      type: "item/completed",
+      scope: turnScope(turnId),
+      providerThreadId,
+      itemId,
+      itemKind: "agentMessage",
+      parentToolCallId,
+      data: JSON.stringify({
+        providerThreadId,
+        item: {
+          type: "agentMessage",
+          id: itemId,
+          text,
+          ...(parentToolCallId === null ? {} : { parentToolCallId }),
+        },
+      }),
+    });
+    const clientTurn = (
+      value: number,
+      text: string,
+      target: { kind: "thread-start" } | { kind: "new-turn" },
+    ): Omit<EventInput, "sequence" | "threadId"> => ({
+      type: "client/turn/requested",
+      scope: threadScope(),
+      itemId: null,
+      itemKind: null,
+      parentToolCallId: null,
+      data: JSON.stringify({
+        direction: "outbound",
+        source: "tell",
+        initiator: "user",
+        request: { method: "turn/start", params: {} },
+        requestId: requestId(value),
+        senderThreadId: null,
+        input: [{ type: "text", text, mentions: [] }],
+        target,
+        execution,
+      }),
+    });
+    const acceptedInput = (
+      turnId: string,
+      value: number,
+    ): Omit<EventInput, "sequence" | "threadId"> => ({
+      type: "turn/input/accepted",
+      scope: turnScope(turnId),
+      providerThreadId,
+      itemId: null,
+      itemKind: null,
+      parentToolCallId: null,
+      data: JSON.stringify({ clientRequestId: requestId(value) }),
+    });
+
+    push(clientTurn(1, "Start alpha", { kind: "thread-start" }));
+    push(turnLifecycle("turn-1", "turn/started"));
+    push(acceptedInput("turn-1", 1));
+    push(delegation("item/started"));
+    push(turnLifecycle("turn-2", "turn/started", "delegation-1"));
+    push(
+      agentMessage(
+        "turn-2",
+        "alpha-original",
+        "ALPHA ORIGINAL",
+        "delegation-1",
+      ),
+    );
+    push(turnLifecycle("turn-2", "turn/completed"));
+    push(delegation("item/completed"));
+    push(agentMessage("turn-1", "root-original", "Alpha finished", null));
+    push(turnLifecycle("turn-1", "turn/completed"));
+    push(clientTurn(2, "Resume alpha", { kind: "new-turn" }));
+    push(turnLifecycle("turn-3", "turn/started"));
+    push(acceptedInput("turn-3", 2));
+    push(agentMessage("turn-3", "root-follow-up", "Resuming alpha", null));
+    push(delegation("item/started"));
+    push(turnLifecycle("turn-4", "turn/started", "delegation-1"));
+    push(
+      agentMessage("turn-4", "alpha-resumed", "ALPHA RESUMED", "delegation-1"),
+    );
+    push(turnLifecycle("turn-4", "turn/completed"));
+    push(delegation("item/completed"));
+    push(agentMessage("turn-3", "root-completed", "Alpha resumed", null));
+    push(turnLifecycle("turn-3", "turn/completed"));
+    insertEvents(db, noopNotifier, events);
+
+    const turnRows = buildNestedPage(
+      db,
+      thread,
+      LARGE_BUDGET,
+      null,
+    ).response.rows.filter(
+      (row): row is Extract<TimelineRow, { kind: "turn" }> =>
+        row.kind === "turn" && row.turnId === "turn-1",
+    );
+    expect(turnRows.length).toBeGreaterThan(0);
+    expect(JSON.stringify(turnRows)).toContain("ALPHA RESUMED");
+    for (const row of turnRows) {
+      expect(
+        buildTimelineTurnSummaryDetails(db, thread, {
+          includeProviderUnhandledOperations: false,
+          sourceSeqEnd: row.sourceSeqEnd,
+          sourceSeqStart: row.sourceSeqStart,
+          turnId: row.turnId,
+        }).rows,
+      ).toEqual(row.children ?? []);
+    }
+  });
+});

--- a/packages/host-daemon-contract/src/protocol.ts
+++ b/packages/host-daemon-contract/src/protocol.ts
@@ -1,3 +1,3 @@
-export const HOST_DAEMON_PROTOCOL_VERSION = 178 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 179 as const;
 
 export const HOST_ARTIFACT_MAX_BYTES = 256 * 1024 * 1024;

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -930,7 +930,7 @@ const ACP_BRIDGE_LAUNCH = {
 
 describe("host-daemon command schemas", () => {
   it("uses the current host-daemon protocol version", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(178);
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(179);
     expect(HOST_ARTIFACT_MAX_BYTES).toBe(256 * 1024 * 1024);
   });
 

--- a/packages/thread-view/src/build-thread-timeline.ts
+++ b/packages/thread-view/src/build-thread-timeline.ts
@@ -113,7 +113,11 @@ interface ThreadTimelineSourceSeqRange {
   sourceSeqStart: number;
 }
 
-interface BuildThreadTimelineTurnDetailsFromEventsOptions extends ThreadTimelineSourceSeqRange {
+interface ThreadTimelineTurnSummarySelection extends ThreadTimelineSourceSeqRange {
+  turnId: string;
+}
+
+interface BuildThreadTimelineTurnDetailsFromEventsOptions extends ThreadTimelineTurnSummarySelection {
   includeProviderUnhandledOperations: boolean;
   providerDisplayName?: string;
   threadStatus: Thread["status"];
@@ -1216,14 +1220,15 @@ type TimelineTurnSummaryRow = Extract<TimelineRow, { kind: "turn" }>;
 
 function findMatchingTurnSummaryRow(
   rows: TimelineRow[],
-  range: ThreadTimelineSourceSeqRange,
+  selection: ThreadTimelineTurnSummarySelection,
 ): TimelineTurnSummaryRow | null {
   return (
     rows.find(
       (row): row is TimelineTurnSummaryRow =>
         row.kind === "turn" &&
-        row.sourceSeqStart === range.sourceSeqStart &&
-        row.sourceSeqEnd === range.sourceSeqEnd,
+        row.turnId === selection.turnId &&
+        row.sourceSeqStart === selection.sourceSeqStart &&
+        row.sourceSeqEnd === selection.sourceSeqEnd,
     ) ?? null
   );
 }

--- a/packages/thread-view/src/build-thread-timeline.ts
+++ b/packages/thread-view/src/build-thread-timeline.ts
@@ -118,6 +118,7 @@ interface ThreadTimelineTurnSummarySelection extends ThreadTimelineSourceSeqRang
 }
 
 interface BuildThreadTimelineTurnDetailsFromEventsOptions extends ThreadTimelineTurnSummarySelection {
+  fallbackSelection?: ThreadTimelineTurnSummarySelection;
   includeProviderUnhandledOperations: boolean;
   providerDisplayName?: string;
   threadStatus: Thread["status"];
@@ -1419,10 +1420,11 @@ export function buildThreadTimelineTurnDetailsFromEvents(
     rowIdPrefix: ROOT_TIMELINE_ROW_ID_PREFIX,
     workspaceRoot: args.options.workspaceRoot,
   });
-  const matchingTurnSummary = findMatchingTurnSummaryRow(
-    nestedRows,
-    args.options,
-  );
+  const matchingTurnSummary =
+    findMatchingTurnSummaryRow(nestedRows, args.options) ??
+    (args.options.fallbackSelection
+      ? findMatchingTurnSummaryRow(nestedRows, args.options.fallbackSelection)
+      : null);
   if (matchingTurnSummary) {
     return {
       kind: "matched",

--- a/plugins/provider-codex/src/bridge/bridge.resume-hydration.test.ts
+++ b/plugins/provider-codex/src/bridge/bridge.resume-hydration.test.ts
@@ -1,9 +1,4 @@
-import {
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -72,4 +67,7 @@ it("excludes turn history when it resumes a Codex thread", async () => {
     method: "thread/resume",
     params: expect.objectContaining({ excludeTurns: true }),
   });
+  expect(requests.map((request) => request.method)).not.toContain(
+    "thread/read",
+  );
 });

--- a/plugins/provider-codex/src/bridge/bridge.subagent-history.test.ts
+++ b/plugins/provider-codex/src/bridge/bridge.subagent-history.test.ts
@@ -1,0 +1,194 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import type { ThreadDelta } from "@get-bb/plugin-sdk/provider-bridge";
+import { experimental_createBridgeJsonRpcTestHarness as createBridgeJsonRpcTestHarness } from "@get-bb/plugin-sdk/provider-bridge/testing";
+import { handleLine } from "./bridge.js";
+
+const THREAD_ID = "thr_subagent_history";
+const PROVIDER_THREAD_ID = "provider-subagent-history";
+const fakeAppServerPath = fileURLToPath(
+  new URL("./fake-codex-app-server.mjs", import.meta.url),
+);
+const sessionOptions = {
+  permissionMode: "full",
+  permissionScope: "full",
+  approvalReviewer: null,
+  permissionEscalation: null,
+} as const;
+
+let harness: ReturnType<typeof createBridgeJsonRpcTestHarness>;
+let workspaceDir: string;
+
+function capturedDeltas(): ThreadDelta[] {
+  const deltas: ThreadDelta[] = [];
+  for (const message of harness.messages) {
+    if (message.method !== "thread/delta") {
+      continue;
+    }
+    const params = message.params as
+      | { threadId?: unknown; deltas?: unknown }
+      | undefined;
+    if (params?.threadId !== THREAD_ID || !Array.isArray(params.deltas)) {
+      continue;
+    }
+    deltas.push(...(params.deltas as ThreadDelta[]));
+  }
+  return deltas;
+}
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "bb-codex-history-ws-"));
+  const scriptPath = join(workspaceDir, "app-server-script.json");
+  writeFileSync(
+    scriptPath,
+    JSON.stringify({
+      forkThread: {
+        turns: [
+          {
+            id: "original-parent-turn",
+            items: [
+              {
+                type: "subAgentActivity",
+                id: "original-spawn-call",
+                kind: "started",
+                agentThreadId: "historical-child-thread",
+                agentPath: "/root/historical_child",
+              },
+            ],
+          },
+        ],
+      },
+      resumeThread: {
+        turns: [
+          {
+            id: "original-parent-turn",
+            items: [
+              {
+                type: "subAgentActivity",
+                id: "original-spawn-call",
+                kind: "started",
+                agentThreadId: "historical-child-thread",
+                agentPath: "/root/historical_child",
+              },
+            ],
+          },
+        ],
+      },
+      turns: [
+        [
+          {
+            method: "rawResponseItem/completed",
+            params: {
+              threadId: PROVIDER_THREAD_ID,
+              turnId: "live-parent-turn",
+              item: {
+                type: "function_call",
+                name: "followup_task",
+                arguments: "{}",
+                call_id: "live-followup-call",
+              },
+            },
+          },
+          {
+            method: "item/completed",
+            params: {
+              threadId: PROVIDER_THREAD_ID,
+              turnId: "live-parent-turn",
+              item: {
+                type: "subAgentActivity",
+                id: "live-followup-call",
+                kind: "interacted",
+                agentThreadId: "historical-child-thread",
+                agentPath: "/root/historical_child",
+              },
+            },
+          },
+        ],
+      ],
+    }),
+  );
+  vi.stubEnv("BB_CODEX_BRIDGE_APP_SERVER_COMMAND", process.execPath);
+  vi.stubEnv(
+    "BB_CODEX_BRIDGE_APP_SERVER_ARGS",
+    JSON.stringify([fakeAppServerPath, scriptPath]),
+  );
+  harness = createBridgeJsonRpcTestHarness(handleLine);
+});
+
+afterEach(async () => {
+  harness.sendRequest(9001, "thread/stop", {
+    threadId: THREAD_ID,
+    providerThreadId: PROVIDER_THREAD_ID,
+    intent: "release",
+    activeTurnId: null,
+  });
+  await harness.waitForResponse(9001).catch(() => undefined);
+  harness.restore();
+  vi.unstubAllEnvs();
+  rmSync(workspaceDir, { recursive: true, force: true });
+});
+
+it.each(["resume", "fork"] as const)(
+  "primes original child ownership from %s history without replaying it",
+  async (construction) => {
+    if (construction === "resume") {
+      harness.sendRequest(1, "thread/resume", {
+        threadId: THREAD_ID,
+        providerThreadId: PROVIDER_THREAD_ID,
+        cwd: workspaceDir,
+        instructionMode: "append",
+        options: { ...sessionOptions },
+      });
+    } else {
+      harness.sendRequest(1, "thread/fork", {
+        threadId: THREAD_ID,
+        sourceProviderThreadId: PROVIDER_THREAD_ID,
+        cwd: workspaceDir,
+        instructionMode: "append",
+        options: { ...sessionOptions },
+      });
+    }
+    const constructed = await harness.waitForResponse(1);
+    expect(constructed.error).toBeUndefined();
+    const liveProviderThreadId =
+      construction === "resume"
+        ? PROVIDER_THREAD_ID
+        : (constructed.result as { providerThreadId: string }).providerThreadId;
+    expect(
+      capturedDeltas().filter((delta) => delta.kind === "item.open"),
+    ).toEqual([]);
+
+    harness.sendRequest(2, "turn/start", {
+      threadId: THREAD_ID,
+      providerThreadId: liveProviderThreadId,
+      clientRequestId: "creq_23456789ab",
+      input: [{ type: "text", text: "resume child", mentions: [] }],
+      options: { ...sessionOptions },
+    });
+    expect((await harness.waitForResponse(2)).error).toBeUndefined();
+
+    expect(
+      capturedDeltas().filter((delta) => delta.kind === "item.open"),
+    ).toContainEqual(
+      expect.objectContaining({
+        key: expect.objectContaining({ providerItemId: "original-spawn-call" }),
+        item: expect.objectContaining({
+          type: "delegation",
+          childRef: "historical-child-thread",
+        }),
+        providerTurnId: "original-parent-turn",
+      }),
+    );
+    expect(
+      capturedDeltas().filter(
+        (delta) =>
+          delta.kind === "item.open" &&
+          delta.key.providerItemId === "live-followup-call",
+      ),
+    ).toEqual([]);
+  },
+  30_000,
+);

--- a/plugins/provider-codex/src/bridge/bridge.subagent-history.test.ts
+++ b/plugins/provider-codex/src/bridge/bridge.subagent-history.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -21,6 +21,7 @@ const sessionOptions = {
 
 let harness: ReturnType<typeof createBridgeJsonRpcTestHarness>;
 let workspaceDir: string;
+let requestLogPath: string;
 
 function capturedDeltas(): ThreadDelta[] {
   const deltas: ThreadDelta[] = [];
@@ -41,10 +42,12 @@ function capturedDeltas(): ThreadDelta[] {
 
 beforeEach(() => {
   workspaceDir = mkdtempSync(join(tmpdir(), "bb-codex-history-ws-"));
+  requestLogPath = join(workspaceDir, "requests.jsonl");
   const scriptPath = join(workspaceDir, "app-server-script.json");
   writeFileSync(
     scriptPath,
     JSON.stringify({
+      requestLogPath,
       forkThread: {
         turns: [
           {
@@ -80,6 +83,16 @@ beforeEach(() => {
       turns: [
         [
           {
+            method: "turn/started",
+            params: {
+              threadId: PROVIDER_THREAD_ID,
+              turn: {
+                id: "live-parent-turn",
+                status: "inProgress",
+              },
+            },
+          },
+          {
             method: "rawResponseItem/completed",
             params: {
               threadId: PROVIDER_THREAD_ID,
@@ -103,6 +116,16 @@ beforeEach(() => {
                 kind: "interacted",
                 agentThreadId: "historical-child-thread",
                 agentPath: "/root/historical_child",
+              },
+            },
+          },
+          {
+            method: "turn/started",
+            params: {
+              threadId: PROVIDER_THREAD_ID,
+              turn: {
+                id: "live-resumed-child-turn",
+                status: "inProgress",
               },
             },
           },
@@ -170,16 +193,39 @@ it.each(["resume", "fork"] as const)(
     });
     expect((await harness.waitForResponse(2)).error).toBeUndefined();
 
+    if (construction === "resume") {
+      await vi.waitFor(() => {
+        expect(readFileSync(requestLogPath, "utf8")).toContain(
+          '"method":"thread/read"',
+        );
+      });
+    }
+
+    await vi.waitFor(() => {
+      expect(
+        capturedDeltas().filter((delta) => delta.kind === "item.open"),
+      ).toContainEqual(
+        expect.objectContaining({
+          key: expect.objectContaining({
+            providerItemId: "original-spawn-call",
+          }),
+          item: expect.objectContaining({
+            type: "delegation",
+            childRef: "historical-child-thread",
+          }),
+          providerTurnId: "original-parent-turn",
+        }),
+      );
+    });
     expect(
-      capturedDeltas().filter((delta) => delta.kind === "item.open"),
+      capturedDeltas().filter(
+        (delta) =>
+          delta.kind === "turn.open" &&
+          delta.providerTurnId === "live-resumed-child-turn",
+      ),
     ).toContainEqual(
       expect.objectContaining({
-        key: expect.objectContaining({ providerItemId: "original-spawn-call" }),
-        item: expect.objectContaining({
-          type: "delegation",
-          childRef: "historical-child-thread",
-        }),
-        providerTurnId: "original-parent-turn",
+        parentRef: "original-spawn-call",
       }),
     );
     expect(

--- a/plugins/provider-codex/src/bridge/bridge.ts
+++ b/plugins/provider-codex/src/bridge/bridge.ts
@@ -79,6 +79,7 @@ import {
   codexThreadIdentityResultSchema,
   extractCodexSubAgentHistory,
 } from "../subagent-history.js";
+import { codexSubAgentActivityItemSchema } from "../schemas.js";
 import {
   createCodexAppServerConnection,
   CodexAppServerExitedError,
@@ -363,6 +364,16 @@ interface CodexSessionConstruction {
   dynamicTools: DynamicTool[] | undefined;
 }
 
+interface CodexBufferedNotification {
+  method: string;
+  params: unknown;
+}
+
+type CodexSubAgentHistoryHydration =
+  | { state: "ready" }
+  | { state: "deferred" }
+  | { state: "loading"; notifications: CodexBufferedNotification[] };
+
 interface CodexBridgeSession {
   bbThreadId: string;
   codexThreadId: string | null;
@@ -377,6 +388,7 @@ interface CodexBridgeSession {
   identityAnnounced: boolean;
   pendingPreIdentityDeltas: ThreadDelta[];
   rebuildBeforeNextTurnReason: string | null;
+  subAgentHistoryHydration: CodexSubAgentHistoryHydration;
   closing: boolean;
 }
 
@@ -534,6 +546,9 @@ function announceSessionIdentity(
 const codexThreadStartedNotificationSchema = z
   .object({ thread: z.object({ id: z.string().min(1) }).passthrough() })
   .passthrough();
+const codexSubAgentActivityNotificationSchema = z
+  .object({ item: codexSubAgentActivityItemSchema })
+  .passthrough();
 
 function toProviderRuntimeEvent(
   method: string,
@@ -546,16 +561,11 @@ function toProviderRuntimeEvent(
   } as ProviderRuntimeEvent;
 }
 
-function handleChildNotification(
-  bbThreadId: string,
-  serial: number,
+function translateChildNotification(
+  session: CodexBridgeSession,
   method: string,
   params: unknown,
 ): void {
-  const session = currentSession(bbThreadId, serial);
-  if (!session) {
-    return;
-  }
   if (method === "thread/started") {
     const parsed = codexThreadStartedNotificationSchema.safeParse(params);
     if (parsed.success) {
@@ -571,6 +581,90 @@ function handleChildNotification(
       emitTerminalAccountErrorHint(session, delta);
     }
   }
+}
+
+function isCodexSubAgentInteractionNotification(
+  method: string,
+  params: unknown,
+): boolean {
+  if (method !== "item/completed") {
+    return false;
+  }
+  const parsed = codexSubAgentActivityNotificationSchema.safeParse(params);
+  return parsed.success && parsed.data.item.kind === "interacted";
+}
+
+async function hydrateDeferredSubAgentHistory(args: {
+  bbThreadId: string;
+  codexThreadId: string;
+  connection: CodexAppServerConnection;
+  serial: number;
+}): Promise<void> {
+  let history: ReturnType<typeof extractCodexSubAgentHistory> = [];
+  try {
+    const result = await args.connection.request({
+      method: "thread/read",
+      params: { includeTurns: true, threadId: args.codexThreadId },
+      resultSchema: codexThreadIdentityResultSchema,
+      timeoutMs: CHILD_REQUEST_TIMEOUT_MS,
+    });
+    history = extractCodexSubAgentHistory(result.thread);
+  } catch {
+    history = [];
+  }
+  const session = currentSession(args.bbThreadId, args.serial);
+  if (!session || session.connection !== args.connection) {
+    return;
+  }
+  const hydration = session.subAgentHistoryHydration;
+  if (hydration.state !== "loading") {
+    return;
+  }
+  session.translator.primeSubAgentHistory(history);
+  session.subAgentHistoryHydration = { state: "ready" };
+  for (const notification of hydration.notifications) {
+    translateChildNotification(
+      session,
+      notification.method,
+      notification.params,
+    );
+  }
+}
+
+function handleChildNotification(
+  bbThreadId: string,
+  serial: number,
+  method: string,
+  params: unknown,
+): void {
+  const session = currentSession(bbThreadId, serial);
+  if (!session) {
+    return;
+  }
+  const hydration = session.subAgentHistoryHydration;
+  if (hydration.state === "loading") {
+    hydration.notifications.push({ method, params });
+    return;
+  }
+  if (
+    hydration.state === "deferred" &&
+    isCodexSubAgentInteractionNotification(method, params) &&
+    session.connection !== null &&
+    session.codexThreadId !== null
+  ) {
+    session.subAgentHistoryHydration = {
+      state: "loading",
+      notifications: [{ method, params }],
+    };
+    void hydrateDeferredSubAgentHistory({
+      bbThreadId,
+      codexThreadId: session.codexThreadId,
+      connection: session.connection,
+      serial,
+    });
+    return;
+  }
+  translateChildNotification(session, method, params);
 }
 
 function emitTerminalAccountErrorHint(
@@ -885,6 +979,7 @@ async function constructThreadSession(
     identityAnnounced: false,
     pendingPreIdentityDeltas: [],
     rebuildBeforeNextTurnReason: null,
+    subAgentHistoryHydration: { state: "ready" },
     closing: false,
   };
   sessionsByBbThreadId.set(args.threadId, session);
@@ -931,10 +1026,7 @@ async function constructThreadSession(
     };
 
     let method: string;
-    let params:
-      | BbThreadStartParams
-      | BbThreadResumeParams
-      | BbThreadForkParams;
+    let params: BbThreadStartParams | BbThreadResumeParams | BbThreadForkParams;
     switch (args.request.kind) {
       case "start": {
         method = "thread/start";
@@ -983,9 +1075,11 @@ async function constructThreadSession(
     const codexThreadId = result.thread.id;
     session.codexThreadId = codexThreadId;
     if (args.request.kind !== "start") {
-      translator.primeSubAgentHistory(
-        extractCodexSubAgentHistory(result.thread),
-      );
+      const history = extractCodexSubAgentHistory(result.thread);
+      translator.primeSubAgentHistory(history);
+      if (result.thread.turns.length === 0) {
+        session.subAgentHistoryHydration = { state: "deferred" };
+      }
     }
     translator.activateThreadGitWritableRoots({
       providerThreadId: codexThreadId,
@@ -1033,6 +1127,7 @@ function registerResumableSession(session: CodexBridgeSession): void {
     identityAnnounced: session.identityAnnounced,
     pendingPreIdentityDeltas: [],
     rebuildBeforeNextTurnReason: null,
+    subAgentHistoryHydration: { state: "ready" },
     closing: false,
   });
 }

--- a/plugins/provider-codex/src/bridge/bridge.ts
+++ b/plugins/provider-codex/src/bridge/bridge.ts
@@ -76,6 +76,10 @@ import {
   type CodexEventTranslator,
 } from "../translator.js";
 import {
+  codexThreadIdentityResultSchema,
+  extractCodexSubAgentHistory,
+} from "../subagent-history.js";
+import {
   createCodexAppServerConnection,
   CodexAppServerExitedError,
   type CodexAppServerConnection,
@@ -814,10 +818,6 @@ async function initializeChild(
   }
 }
 
-const codexThreadIdentityResultSchema = z
-  .object({ thread: z.object({ id: z.string().min(1) }).passthrough() })
-  .passthrough();
-
 type CodexSessionConstructionRequest =
   | { kind: "start" }
   | { kind: "resume"; providerThreadId: string }
@@ -982,6 +982,11 @@ async function constructThreadSession(
     });
     const codexThreadId = result.thread.id;
     session.codexThreadId = codexThreadId;
+    if (args.request.kind !== "start") {
+      translator.primeSubAgentHistory(
+        extractCodexSubAgentHistory(result.thread),
+      );
+    }
     translator.activateThreadGitWritableRoots({
       providerThreadId: codexThreadId,
       threadId: args.threadId,

--- a/plugins/provider-codex/src/bridge/fake-codex-app-server.mjs
+++ b/plugins/provider-codex/src/bridge/fake-codex-app-server.mjs
@@ -378,11 +378,28 @@ async function handleRequest(message) {
       if (String(params.threadId).startsWith("usage-replay-")) {
         replayLastTurnUsage(params.threadId);
       }
+      const resumedThread =
+        resumeThread === null
+          ? { id: params.threadId }
+          : { ...resumeThread, id: params.threadId };
       respond(id, {
         thread:
-          resumeThread === null
-            ? { id: params.threadId }
-            : { ...resumeThread, id: params.threadId },
+          params.excludeTurns === true
+            ? { ...resumedThread, turns: [] }
+            : resumedThread,
+      });
+      return;
+    }
+    case "thread/read": {
+      const readThread =
+        resumeThread === null
+          ? { id: params.threadId }
+          : { ...resumeThread, id: params.threadId };
+      respond(id, {
+        thread:
+          params.includeTurns === true
+            ? readThread
+            : { ...readThread, turns: [] },
       });
       return;
     }

--- a/plugins/provider-codex/src/bridge/fake-codex-app-server.mjs
+++ b/plugins/provider-codex/src/bridge/fake-codex-app-server.mjs
@@ -151,6 +151,8 @@ const modelListFailOnceMarkerPath = script?.modelListFailOnceMarkerPath ?? null;
  * child on archive and resumes on a fresh one.
  */
 const archiveStatePath = script?.archiveStatePath ?? null;
+const forkThread = script?.forkThread ?? null;
+const resumeThread = script?.resumeThread ?? null;
 /**
  * `renameEmptyRolloutFailures`: how many `thread/name/set` calls fail with the
  * real app-server's "rollout … is empty" error before one succeeds — the
@@ -376,7 +378,12 @@ async function handleRequest(message) {
       if (String(params.threadId).startsWith("usage-replay-")) {
         replayLastTurnUsage(params.threadId);
       }
-      respond(id, { thread: { id: params.threadId } });
+      respond(id, {
+        thread:
+          resumeThread === null
+            ? { id: params.threadId }
+            : { ...resumeThread, id: params.threadId },
+      });
       return;
     }
     case "thread/fork": {
@@ -398,7 +405,12 @@ async function handleRequest(message) {
       const threadId = replaysUsage
         ? `usage-replay-fork-${process.pid}-${threadCounter}`
         : `codex-fx-${process.pid}-fork-${threadCounter}`;
-      respond(id, { thread: { id: threadId } });
+      respond(id, {
+        thread:
+          forkThread === null
+            ? { id: threadId }
+            : { ...forkThread, id: threadId },
+      });
       // thread/fork replays the source rollout's last-turn usage the same way,
       // after the response, under the NEW thread id but the SOURCE turn id
       // (#1727).

--- a/plugins/provider-codex/src/subagent-history.test.ts
+++ b/plugins/provider-codex/src/subagent-history.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import {
+  codexThreadIdentityResultSchema,
+  extractCodexSubAgentHistory,
+} from "./subagent-history.js";
+
+describe("Codex subagent history", () => {
+  it("restores the original delegation identity for each child", () => {
+    const result = codexThreadIdentityResultSchema.parse({
+      thread: {
+        id: "root-thread",
+        turns: [
+          {
+            id: "parent-turn-a",
+            items: [
+              {
+                type: "subAgentActivity",
+                id: "spawn-a-old",
+                kind: "started",
+                agentThreadId: "child-a",
+                agentPath: "/root/child_a",
+              },
+              {
+                type: "subAgentActivity",
+                id: "message-a",
+                kind: "interacted",
+                agentThreadId: "child-a",
+                agentPath: "/root/child_a",
+              },
+            ],
+          },
+          {
+            id: "parent-turn-b",
+            items: [
+              {
+                type: "subAgentActivity",
+                id: "spawn-b",
+                kind: "started",
+                agentThreadId: "child-b",
+                agentPath: "/root/child_b",
+              },
+              {
+                type: "subAgentActivity",
+                id: "spawn-a",
+                kind: "started",
+                agentThreadId: "child-a",
+                agentPath: "/root/child_a",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(extractCodexSubAgentHistory(result.thread)).toEqual([
+      {
+        agentPath: "/root/child_a",
+        agentThreadId: "child-a",
+        callId: "spawn-a-old",
+        parentProviderThreadId: "root-thread",
+        parentTurnId: "parent-turn-a",
+      },
+      {
+        agentPath: "/root/child_b",
+        agentThreadId: "child-b",
+        callId: "spawn-b",
+        parentProviderThreadId: "root-thread",
+        parentTurnId: "parent-turn-b",
+      },
+    ]);
+  });
+
+  it("defaults missing history and ignores malformed activity items", () => {
+    const empty = codexThreadIdentityResultSchema.parse({
+      thread: { id: "root-thread" },
+    });
+    expect(extractCodexSubAgentHistory(empty.thread)).toEqual([]);
+
+    const malformed = codexThreadIdentityResultSchema.parse({
+      thread: {
+        id: "root-thread",
+        turns: [
+          {
+            id: "parent-turn",
+            items: [
+              {
+                type: "subAgentActivity",
+                id: "spawn-a",
+                kind: "started",
+                agentThreadId: null,
+                agentPath: "/root/child_a",
+              },
+            ],
+          },
+        ],
+      },
+    });
+    expect(extractCodexSubAgentHistory(malformed.thread)).toEqual([]);
+  });
+});

--- a/plugins/provider-codex/src/subagent-history.ts
+++ b/plugins/provider-codex/src/subagent-history.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+import type { CodexSubAgentHistoryEntry } from "./translator.js";
+
+const subAgentActivitySchema = z
+  .object({
+    agentPath: z.string(),
+    agentThreadId: z.string().min(1),
+    id: z.string().min(1),
+    kind: z.enum(["started", "interacted", "interrupted"]),
+    type: z.literal("subAgentActivity"),
+  })
+  .passthrough();
+
+const historyTurnSchema = z
+  .object({
+    id: z.string().min(1),
+    items: z.array(z.unknown()).default([]),
+  })
+  .passthrough();
+
+export const codexThreadIdentityResultSchema = z
+  .object({
+    thread: z
+      .object({
+        id: z.string().min(1),
+        turns: z.array(historyTurnSchema).default([]),
+      })
+      .passthrough(),
+  })
+  .passthrough();
+
+export type CodexThreadIdentityResult = z.infer<
+  typeof codexThreadIdentityResultSchema
+>;
+
+export function extractCodexSubAgentHistory(
+  thread: CodexThreadIdentityResult["thread"],
+): CodexSubAgentHistoryEntry[] {
+  const entriesByChildThreadId = new Map<string, CodexSubAgentHistoryEntry>();
+  for (const turn of thread.turns) {
+    for (const candidate of turn.items) {
+      const item = subAgentActivitySchema.safeParse(candidate);
+      if (!item.success || item.data.kind !== "started") {
+        continue;
+      }
+      if (!entriesByChildThreadId.has(item.data.agentThreadId)) {
+        entriesByChildThreadId.set(item.data.agentThreadId, {
+          agentPath: item.data.agentPath,
+          agentThreadId: item.data.agentThreadId,
+          callId: item.data.id,
+          parentProviderThreadId: thread.id,
+          parentTurnId: turn.id,
+        });
+      }
+    }
+  }
+  return [...entriesByChildThreadId.values()];
+}

--- a/plugins/provider-codex/src/subagent-history.ts
+++ b/plugins/provider-codex/src/subagent-history.ts
@@ -1,15 +1,6 @@
 import { z } from "zod";
+import { codexSubAgentActivityItemSchema } from "./schemas.js";
 import type { CodexSubAgentHistoryEntry } from "./translator.js";
-
-const subAgentActivitySchema = z
-  .object({
-    agentPath: z.string(),
-    agentThreadId: z.string().min(1),
-    id: z.string().min(1),
-    kind: z.enum(["started", "interacted", "interrupted"]),
-    type: z.literal("subAgentActivity"),
-  })
-  .passthrough();
 
 const historyTurnSchema = z
   .object({
@@ -39,8 +30,18 @@ export function extractCodexSubAgentHistory(
   const entriesByChildThreadId = new Map<string, CodexSubAgentHistoryEntry>();
   for (const turn of thread.turns) {
     for (const candidate of turn.items) {
-      const item = subAgentActivitySchema.safeParse(candidate);
-      if (!item.success || item.data.kind !== "started") {
+      if (
+        typeof candidate !== "object" ||
+        candidate === null ||
+        !("type" in candidate) ||
+        candidate.type !== "subAgentActivity" ||
+        !("kind" in candidate) ||
+        candidate.kind !== "started"
+      ) {
+        continue;
+      }
+      const item = codexSubAgentActivityItemSchema.safeParse(candidate);
+      if (!item.success) {
         continue;
       }
       if (!entriesByChildThreadId.has(item.data.agentThreadId)) {

--- a/plugins/provider-codex/src/translator.test.ts
+++ b/plugins/provider-codex/src/translator.test.ts
@@ -827,7 +827,9 @@ describe("codex subagent activity correlation", () => {
       ),
     ).toEqual([]);
 
-    expect(harness.translate(childTurnStarted("child-turn-2"))).toEqual([
+    expect(
+      harness.translate(childTurnStarted("child-turn-2", "agent-thread-1")),
+    ).toEqual([
       expect.objectContaining({
         type: "item/started",
         scope: turnScope(harness.turnId("parent-turn")),
@@ -845,7 +847,7 @@ describe("codex subagent activity correlation", () => {
     ]);
 
     const resumedTurnCompleted = harness.translate(
-      childTurnCompleted("child-turn-2"),
+      childTurnCompleted("child-turn-2", "agent-thread-1"),
     );
     expect(resumedTurnCompleted).toEqual([
       expect.objectContaining({
@@ -917,6 +919,42 @@ describe("codex subagent activity correlation", () => {
     );
   });
 
+  it("reuses the original delegation restored from resume history", () => {
+    const harness = createHarness();
+    harness.translator.primeSubAgentHistory([
+      {
+        agentPath: "/root/lifecycle_child",
+        agentThreadId: "agent-thread-1",
+        callId: "original-subagent-call",
+        parentProviderThreadId: rootProviderThreadId,
+        parentTurnId: "original-parent-turn",
+      },
+    ]);
+    harness.translate(
+      subAgentActivity({ id: "rawless-followup", kind: "interacted" }),
+    );
+
+    expect(
+      harness.translate(
+        childTurnStarted("resumed-child-turn", "agent-thread-1"),
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        type: "item/started",
+        scope: turnScope(harness.turnId("original-parent-turn")),
+        item: expect.objectContaining({
+          type: "delegation",
+          id: harness.itemId("original-subagent-call"),
+          childRef: "agent-thread-1",
+        }),
+      }),
+      expect.objectContaining({
+        type: "turn/started",
+        parentToolCallId: harness.itemId("original-subagent-call"),
+      }),
+    ]);
+  });
+
   it("does not reopen a known terminal subagent for send_message", () => {
     const harness = createHarness();
     harness.translate(
@@ -956,7 +994,7 @@ describe("codex subagent activity correlation", () => {
     ).toEqual([]);
 
     const resumedEvents = harness.translate(
-      childTurnStarted("rawless-child-turn"),
+      childTurnStarted("rawless-child-turn", "agent-thread-1"),
     );
     expect(resumedEvents).toEqual([
       expect.objectContaining({
@@ -976,6 +1014,165 @@ describe("codex subagent activity correlation", () => {
     ]);
     expect(resumedEvents[0]).not.toHaveProperty("parentToolCallId");
     expect(resumedEvents[0]).not.toHaveProperty("item.parentToolCallId");
+  });
+
+  it("keeps rawless child ownership across the parent boundary", () => {
+    const harness = createHarness();
+    harness.translate(
+      subAgentActivity({
+        agentThreadId: "agent-thread-a",
+        id: "interaction-a",
+        kind: "interacted",
+      }),
+    );
+    harness.translate(childTurnCompleted("parent-turn"));
+
+    const events = harness.translate(
+      childTurnStarted("child-a-turn", "agent-thread-a"),
+    );
+    const delegation = events.find((event) => event.type === "item/started");
+    expect(delegation?.item).toMatchObject({
+      type: "delegation",
+      childRef: "agent-thread-a",
+    });
+    expect(events.find((event) => event.type === "turn/started")).toMatchObject(
+      {
+        parentToolCallId: delegation?.item.id,
+      },
+    );
+  });
+
+  it("correlates unknown rawless children by exact child identity", () => {
+    const harness = createHarness();
+    for (const suffix of ["a", "b"]) {
+      harness.translate(
+        subAgentActivity({
+          agentThreadId: `agent-thread-${suffix}`,
+          id: `interaction-${suffix}`,
+          kind: "interacted",
+        }),
+      );
+    }
+
+    for (const suffix of ["a", "b"]) {
+      const events = harness.translate(
+        childTurnStarted(`child-${suffix}-turn`, `agent-thread-${suffix}`),
+      );
+      const delegation = events.find((event) => event.type === "item/started");
+      expect(delegation?.item).toMatchObject({
+        type: "delegation",
+        childRef: `agent-thread-${suffix}`,
+      });
+      expect(
+        events.find((event) => event.type === "turn/started"),
+      ).toMatchObject({ parentToolCallId: delegation?.item.id });
+    }
+  });
+
+  it("does not guess between unknown rawless children on root turns", () => {
+    const harness = createHarness();
+    for (const suffix of ["a", "b"]) {
+      harness.translate(
+        subAgentActivity({
+          agentThreadId: `agent-thread-${suffix}`,
+          id: `interaction-${suffix}`,
+          kind: "interacted",
+        }),
+      );
+    }
+
+    for (const turnId of ["unrelated-root-turn-a", "unrelated-root-turn-b"]) {
+      const events = harness.translate(childTurnStarted(turnId));
+      expect(
+        events.find((event) => event.type === "item/started"),
+      ).toBeUndefined();
+      expect(
+        events.find((event) => event.type === "turn/started"),
+      ).not.toHaveProperty("parentToolCallId");
+    }
+  });
+
+  it("does not materialize an interaction before late message intent", () => {
+    const harness = createHarness();
+    const events = [
+      ...harness.translate(
+        subAgentActivity({
+          agentThreadId: "agent-thread-a",
+          id: "message-call",
+          kind: "interacted",
+        }),
+      ),
+      ...harness.translate(childTurnStarted("unrelated-root-turn")),
+      ...harness.translate(
+        rawCollaborationCall({ callId: "message-call", name: "send_message" }),
+      ),
+    ];
+
+    expect(
+      events.find((event) => event.type === "item/started"),
+    ).toBeUndefined();
+    expect(
+      events.find((event) => event.type === "turn/started"),
+    ).not.toHaveProperty("parentToolCallId");
+  });
+
+  it("purges raw-only interaction intent at its parent boundary", () => {
+    const harness = createHarness();
+    harness.translate(
+      rawCollaborationCall({ callId: "followup-call", name: "followup_task" }),
+    );
+    harness.translate(childTurnCompleted("parent-turn"));
+
+    expect(
+      harness.translate(
+        subAgentActivity({
+          agentThreadId: "agent-thread-a",
+          id: "followup-call",
+          kind: "interacted",
+        }),
+      ),
+    ).toEqual([]);
+    const laterChildTurn = harness
+      .translate(childTurnStarted("late-child-turn", "agent-thread-a"))
+      .find((event) => event.type === "turn/started");
+    expect(laterChildTurn).not.toHaveProperty("parentToolCallId");
+  });
+
+  it("bounds unmatched activity to the next parent lifecycle", () => {
+    const harness = createHarness();
+    harness.translate(
+      subAgentActivity({
+        agentThreadId: "agent-thread-a",
+        id: "unmatched-activity",
+        kind: "interacted",
+      }),
+    );
+    harness.translate(childTurnCompleted("unrelated-parent-turn-a"));
+    harness.translate(childTurnCompleted("unrelated-parent-turn-b"));
+
+    const laterChildTurn = harness
+      .translate(childTurnStarted("late-child-turn", "agent-thread-a"))
+      .find((event) => event.type === "turn/started");
+    expect(laterChildTurn).not.toHaveProperty("parentToolCallId");
+  });
+
+  it("clears unmatched activity when its provider thread closes", () => {
+    const harness = createHarness();
+    harness.translate(
+      subAgentActivity({
+        agentThreadId: "agent-thread-a",
+        id: "unmatched-activity",
+        kind: "interacted",
+      }),
+    );
+    harness.translate(
+      codexEvent("thread/closed", { threadId: rootProviderThreadId }),
+    );
+
+    const laterChildTurn = harness
+      .translate(childTurnStarted("late-child-turn", "agent-thread-a"))
+      .find((event) => event.type === "turn/started");
+    expect(laterChildTurn).not.toHaveProperty("parentToolCallId");
   });
 
   it("keeps root input correlation independent from a rawless resumed child thread", () => {
@@ -1130,7 +1327,9 @@ describe("codex subagent activity correlation", () => {
 
     for (const index of [2, 3]) {
       expect(
-        harness.translate(childTurnStarted(`child-turn-${index}`)),
+        harness.translate(
+          childTurnStarted(`child-turn-${index}`, "agent-thread-1"),
+        ),
       ).toEqual([
         expect.objectContaining({
           type: "item/started",
@@ -1147,7 +1346,9 @@ describe("codex subagent activity correlation", () => {
       ]);
       expect(
         harness
-          .translate(childTurnCompleted(`child-turn-${index}`))
+          .translate(
+            childTurnCompleted(`child-turn-${index}`, "agent-thread-1"),
+          )
           .map((event) => event.type),
       ).toEqual(["turn/completed", "item/completed"]);
     }
@@ -1182,7 +1383,9 @@ describe("codex subagent activity correlation", () => {
     );
     expect(humanTurnStarted).not.toHaveProperty("parentToolCallId");
 
-    expect(harness.translate(childTurnStarted("child-turn-2"))).toContainEqual(
+    expect(
+      harness.translate(childTurnStarted("child-turn-2", "agent-thread-1")),
+    ).toContainEqual(
       expect.objectContaining({
         type: "turn/started",
         scope: turnScope(harness.turnId("child-turn-2")),
@@ -1236,7 +1439,9 @@ describe("codex subagent activity correlation", () => {
       subAgentActivity({ id: "interaction-1", kind: "interacted" }),
     );
 
-    expect(harness.translate(childTurnStarted("child-turn-2"))).toContainEqual(
+    expect(
+      harness.translate(childTurnStarted("child-turn-2", "agent-thread-1")),
+    ).toContainEqual(
       expect.objectContaining({
         type: "turn/started",
         scope: turnScope(harness.turnId("child-turn-2")),
@@ -1291,7 +1496,7 @@ describe("codex subagent activity correlation", () => {
     );
 
     expect(
-      harness.translate(childTurnStarted("resumed-turn-1")),
+      harness.translate(childTurnStarted("resumed-turn-1", "agent-thread-1")),
     ).toContainEqual(
       expect.objectContaining({
         type: "turn/started",

--- a/plugins/provider-codex/src/translator.test.ts
+++ b/plugins/provider-codex/src/translator.test.ts
@@ -934,11 +934,7 @@ describe("codex subagent activity correlation", () => {
       subAgentActivity({ id: "rawless-followup", kind: "interacted" }),
     );
 
-    expect(
-      harness.translate(
-        childTurnStarted("resumed-child-turn", "agent-thread-1"),
-      ),
-    ).toEqual([
+    expect(harness.translate(childTurnStarted("resumed-child-turn"))).toEqual([
       expect.objectContaining({
         type: "item/started",
         scope: turnScope(harness.turnId("original-parent-turn")),
@@ -1090,6 +1086,68 @@ describe("codex subagent activity correlation", () => {
         events.find((event) => event.type === "turn/started"),
       ).not.toHaveProperty("parentToolCallId");
     }
+  });
+
+  it("does not guess between known resumed children on multiplexed root turns", () => {
+    const harness = createHarness();
+    harness.translator.primeSubAgentHistory(
+      ["a", "b"].map((suffix) => ({
+        agentPath: `/root/child_${suffix}`,
+        agentThreadId: `agent-thread-${suffix}`,
+        callId: `original-call-${suffix}`,
+        parentProviderThreadId: rootProviderThreadId,
+        parentTurnId: `original-turn-${suffix}`,
+      })),
+    );
+    for (const suffix of ["a", "b"]) {
+      harness.translate(
+        subAgentActivity({
+          agentThreadId: `agent-thread-${suffix}`,
+          id: `interaction-${suffix}`,
+          kind: "interacted",
+        }),
+      );
+    }
+
+    const events = harness.translate(childTurnStarted("multiplexed-turn"));
+    expect(
+      events.find((event) => event.type === "item/started"),
+    ).toBeUndefined();
+    expect(
+      events.find((event) => event.type === "turn/started"),
+    ).not.toHaveProperty("parentToolCallId");
+  });
+
+  it("keeps a native root turn ahead of one known resumed-child candidate", () => {
+    const harness = createHarness();
+    harness.translator.primeSubAgentHistory([
+      {
+        agentPath: "/root/child_a",
+        agentThreadId: "agent-thread-a",
+        callId: "original-call-a",
+        parentProviderThreadId: rootProviderThreadId,
+        parentTurnId: "original-turn-a",
+      },
+    ]);
+    harness.translate(
+      subAgentActivity({
+        agentThreadId: "agent-thread-a",
+        id: "interaction-a",
+        kind: "interacted",
+      }),
+    );
+    harness.translator.prepareTurnStart({
+      clientRequestId: "creq_native_root",
+      providerThreadId: rootProviderThreadId,
+    });
+
+    const events = harness.translate(childTurnStarted("native-root-turn"));
+    expect(
+      events.find((event) => event.type === "item/started"),
+    ).toBeUndefined();
+    expect(
+      events.find((event) => event.type === "turn/started"),
+    ).not.toHaveProperty("parentToolCallId");
   });
 
   it("does not materialize an interaction before late message intent", () => {

--- a/plugins/provider-codex/src/translator.ts
+++ b/plugins/provider-codex/src/translator.ts
@@ -89,6 +89,33 @@ interface CodexPendingDelegationTurnLink {
 
 type CodexInteractionKind = "followup" | "message";
 
+interface CodexPendingInteractionBase {
+  callId: string;
+  parentBoundaryPassed: boolean;
+  parentProviderThreadId: string;
+  parentTurnId: string;
+}
+
+interface CodexRawInteraction extends CodexPendingInteractionBase {
+  intent: CodexInteractionKind;
+  state: "raw";
+}
+
+interface CodexActivityInteraction extends CodexPendingInteractionBase {
+  activity: CodexSubAgentActivityEvent;
+  state: "activity";
+}
+
+interface CodexSettledInteraction extends CodexPendingInteractionBase {
+  childThreadId: string | null;
+  state: "settled";
+}
+
+type CodexPendingInteraction =
+  | CodexRawInteraction
+  | CodexActivityInteraction
+  | CodexSettledInteraction;
+
 const codexDelegationArgsSchema = z
   .object({
     receiverThreadIds: z.array(z.string()).optional(),
@@ -368,6 +395,14 @@ export type CodexEventTranslator = ReturnType<
   typeof createCodexEventTranslator
 >;
 
+export interface CodexSubAgentHistoryEntry {
+  agentPath: string;
+  agentThreadId: string;
+  callId: string;
+  parentProviderThreadId: string;
+  parentTurnId: string;
+}
+
 export function createCodexEventTranslator(
   options: CreateCodexEventTranslatorOptions,
 ) {
@@ -398,14 +433,9 @@ export function createCodexEventTranslator(
   >();
   const pendingDelegationCallIds = new Set<string>();
   const pendingDelegationProviderThreadIdByCallId = new Map<string, string>();
-  const processedSubAgentInteractionIds = new Set<string>();
-  const interactionKindsByProviderThreadId = new Map<
+  const pendingInteractionsByCallId = new Map<
     string,
-    Map<string, CodexInteractionKind>
-  >();
-  const unclassifiedInteractionsByProviderThreadId = new Map<
-    string,
-    CodexSubAgentActivityEvent[]
+    CodexPendingInteraction
   >();
   const trackedSubAgentsByCallId = new Map<string, CodexTrackedSubAgent>();
   const trackedSubAgentCallIdsByAgentThreadId = new Map<string, string>();
@@ -561,8 +591,20 @@ export function createCodexEventTranslator(
   function clearCodexDelegationParentState(
     providerThreadId: string,
   ): ThreadDelta[] {
-    interactionKindsByProviderThreadId.delete(providerThreadId);
-    unclassifiedInteractionsByProviderThreadId.delete(providerThreadId);
+    for (const [callId, interaction] of pendingInteractionsByCallId) {
+      const childThreadId =
+        interaction.state === "activity"
+          ? interaction.activity.item.agentThreadId
+          : interaction.state === "settled"
+            ? interaction.childThreadId
+            : null;
+      if (
+        interaction.parentProviderThreadId === providerThreadId ||
+        childThreadId === providerThreadId
+      ) {
+        pendingInteractionsByCallId.delete(callId);
+      }
+    }
     delegationParentToolCallIdsByProviderThreadId.delete(providerThreadId);
     pendingDelegationTurnLinksByProviderThreadId.delete(providerThreadId);
     const closes: ThreadDelta[] = [];
@@ -590,6 +632,29 @@ export function createCodexEventTranslator(
       trackedSubAgentsByCallId.delete(callId);
     }
     return closes;
+  }
+
+  function primeSubAgentHistory(
+    entries: readonly CodexSubAgentHistoryEntry[],
+  ): void {
+    for (const entry of entries) {
+      if (
+        trackedSubAgentsByCallId.has(entry.callId) ||
+        findTrackedSubAgentByAgentThreadId(entry.agentThreadId)
+      ) {
+        continue;
+      }
+      const tracked: CodexTrackedSubAgent = {
+        ...entry,
+        pendingFollowups: 0,
+        terminal: true,
+      };
+      trackedSubAgentsByCallId.set(entry.callId, tracked);
+      trackedSubAgentCallIdsByAgentThreadId.set(
+        entry.agentThreadId,
+        entry.callId,
+      );
+    }
   }
 
   function queueNativeTurnStartClientRequestId(args: {
@@ -987,24 +1052,6 @@ export function createCodexEventTranslator(
     return openDelta ? [openDelta] : [];
   }
 
-  function consumeCodexInteractionKind(args: {
-    callId: string;
-    providerThreadId: string;
-  }): CodexInteractionKind | undefined {
-    const interactionKinds = interactionKindsByProviderThreadId.get(
-      args.providerThreadId,
-    );
-    const kind = interactionKinds?.get(args.callId);
-    if (!kind || !interactionKinds) {
-      return undefined;
-    }
-    interactionKinds.delete(args.callId);
-    if (interactionKinds.size === 0) {
-      interactionKindsByProviderThreadId.delete(args.providerThreadId);
-    }
-    return kind;
-  }
-
   function rearmTrackedSubAgent(tracked: CodexTrackedSubAgent): void {
     trackedSubAgentCallIdsByAgentThreadId.set(
       tracked.agentThreadId,
@@ -1021,82 +1068,6 @@ export function createCodexEventTranslator(
       parentTurnId: tracked.parentTurnId,
       providerThreadId: tracked.parentProviderThreadId,
     });
-  }
-
-  function queueUnclassifiedCodexInteraction(
-    activity: CodexSubAgentActivityEvent,
-  ): void {
-    const pending =
-      unclassifiedInteractionsByProviderThreadId.get(
-        activity.providerThreadId,
-      ) ?? [];
-    pending.push(activity);
-    unclassifiedInteractionsByProviderThreadId.set(
-      activity.providerThreadId,
-      pending,
-    );
-  }
-
-  function takeUnclassifiedCodexInteraction(args: {
-    callId?: string;
-    providerThreadId: string;
-    startedTurnId?: string;
-  }): CodexSubAgentActivityEvent | undefined {
-    let interactionProviderThreadId = args.providerThreadId;
-    let pending = unclassifiedInteractionsByProviderThreadId.get(
-      interactionProviderThreadId,
-    );
-    if (!pending && args.callId === undefined) {
-      for (const [
-        candidateProviderThreadId,
-        candidates,
-      ] of unclassifiedInteractionsByProviderThreadId) {
-        if (
-          candidates.some(
-            (activity) => activity.item.agentThreadId === args.providerThreadId,
-          )
-        ) {
-          interactionProviderThreadId = candidateProviderThreadId;
-          pending = candidates;
-          break;
-        }
-      }
-    }
-    if (!pending) {
-      return undefined;
-    }
-    let index =
-      args.callId !== undefined
-        ? pending.findIndex((activity) => activity.item.id === args.callId)
-        : -1;
-    if (args.callId === undefined) {
-      for (
-        let candidateIndex = pending.length - 1;
-        candidateIndex >= 0;
-        --candidateIndex
-      ) {
-        const activity = pending[candidateIndex];
-        if (
-          activity &&
-          activity.turnId !== args.startedTurnId &&
-          (interactionProviderThreadId === args.providerThreadId ||
-            activity.item.agentThreadId === args.providerThreadId)
-        ) {
-          index = candidateIndex;
-          break;
-        }
-      }
-    }
-    if (index === -1) {
-      return undefined;
-    }
-    const [activity] = pending.splice(index, 1);
-    if (pending.length === 0) {
-      unclassifiedInteractionsByProviderThreadId.delete(
-        interactionProviderThreadId,
-      );
-    }
-    return activity;
   }
 
   function materializeCodexFollowup(
@@ -1117,18 +1088,105 @@ export function createCodexEventTranslator(
     return wasOpen ? [] : [buildCodexSubAgentOpenDelta(tracked)];
   }
 
-  function hasConsumablePendingDelegationLink(args: {
-    providerThreadId: string;
-    startedTurnId: string;
-  }): boolean {
-    return (
-      pendingDelegationTurnLinksByProviderThreadId
-        .get(args.providerThreadId)
-        ?.some((link) => link.parentTurnId !== args.startedTurnId) ?? false
-    );
+  function settleCodexInteraction(
+    interaction: CodexPendingInteractionBase,
+    childThreadId: string | null,
+  ): void {
+    pendingInteractionsByCallId.set(interaction.callId, {
+      ...interaction,
+      childThreadId,
+      state: "settled",
+    });
   }
 
-  function materializeUnclassifiedCodexInteractions(
+  function correlateCodexInteraction(args: {
+    activity: CodexSubAgentActivityEvent;
+    intent: CodexInteractionKind;
+  }): ThreadDelta[] {
+    if (args.intent === "message") {
+      return [];
+    }
+    const tracked = findTrackedSubAgentByAgentThreadId(
+      args.activity.item.agentThreadId,
+    );
+    return tracked && !tracked.terminal
+      ? []
+      : materializeCodexFollowup(args.activity);
+  }
+
+  function consumeExactCodexInteraction(
+    providerThreadId: string,
+  ): ThreadDelta[] {
+    for (const interaction of pendingInteractionsByCallId.values()) {
+      if (
+        interaction.state !== "activity" ||
+        interaction.activity.item.agentThreadId !== providerThreadId
+      ) {
+        continue;
+      }
+      settleCodexInteraction(interaction, providerThreadId);
+      return correlateCodexInteraction({
+        activity: interaction.activity,
+        intent: "followup",
+      });
+    }
+    return [];
+  }
+
+  function advanceCodexInteractionBoundaries(args: {
+    providerThreadId: string;
+    turnId: string;
+  }): void {
+    for (const [callId, interaction] of pendingInteractionsByCallId) {
+      const childThreadId =
+        interaction.state === "activity"
+          ? interaction.activity.item.agentThreadId
+          : interaction.state === "settled"
+            ? interaction.childThreadId
+            : null;
+      if (
+        childThreadId === args.providerThreadId &&
+        interaction.state === "settled"
+      ) {
+        pendingInteractionsByCallId.delete(callId);
+        continue;
+      }
+      if (interaction.parentProviderThreadId !== args.providerThreadId) {
+        continue;
+      }
+      if (interaction.parentTurnId === args.turnId) {
+        if (!interaction.parentBoundaryPassed) {
+          if (interaction.state === "raw") {
+            settleCodexInteraction(
+              { ...interaction, parentBoundaryPassed: true },
+              null,
+            );
+          } else {
+            pendingInteractionsByCallId.set(callId, {
+              ...interaction,
+              parentBoundaryPassed: true,
+            });
+          }
+        }
+        continue;
+      }
+      if (interaction.parentBoundaryPassed) {
+        pendingInteractionsByCallId.delete(callId);
+      } else if (interaction.state === "raw") {
+        settleCodexInteraction(
+          { ...interaction, parentBoundaryPassed: true },
+          null,
+        );
+      } else {
+        pendingInteractionsByCallId.set(callId, {
+          ...interaction,
+          parentBoundaryPassed: true,
+        });
+      }
+    }
+  }
+
+  function correlatePendingCodexInteractions(
     deltas: ThreadDelta[],
     providerThreadId: string | undefined,
   ): ThreadDelta[] {
@@ -1140,19 +1198,9 @@ export function createCodexEventTranslator(
       if (
         delta.kind === "turn.open" &&
         delta.providerTurnId !== undefined &&
-        !hasPendingNativeTurnStart(providerThreadId) &&
-        !hasConsumablePendingDelegationLink({
-          providerThreadId,
-          startedTurnId: delta.providerTurnId,
-        })
+        !hasPendingNativeTurnStart(providerThreadId)
       ) {
-        const activity = takeUnclassifiedCodexInteraction({
-          providerThreadId,
-          startedTurnId: delta.providerTurnId,
-        });
-        if (activity) {
-          materialized.push(...materializeCodexFollowup(activity));
-        }
+        materialized.push(...consumeExactCodexInteraction(providerThreadId));
       }
       materialized.push(
         ...attachCodexDelegationParentLinks([delta], providerThreadId),
@@ -1161,21 +1209,10 @@ export function createCodexEventTranslator(
         delta.kind === "turn.boundary" &&
         delta.providerTurnId !== undefined
       ) {
-        const pending =
-          unclassifiedInteractionsByProviderThreadId.get(providerThreadId);
-        if (pending) {
-          const remaining = pending.filter(
-            (activity) => activity.turnId !== delta.providerTurnId,
-          );
-          if (remaining.length === 0) {
-            unclassifiedInteractionsByProviderThreadId.delete(providerThreadId);
-          } else if (remaining.length !== pending.length) {
-            unclassifiedInteractionsByProviderThreadId.set(
-              providerThreadId,
-              remaining,
-            );
-          }
-        }
+        advanceCodexInteractionBoundaries({
+          providerThreadId,
+          turnId: delta.providerTurnId,
+        });
       }
     }
     return materialized;
@@ -1221,30 +1258,72 @@ export function createCodexEventTranslator(
         return beginCodexTrackedSubAgent(activity);
       }
       case "interacted": {
-        if (processedSubAgentInteractionIds.has(activity.item.id)) {
+        const existing = pendingInteractionsByCallId.get(activity.item.id);
+        if (existing?.state === "settled") {
           return [];
         }
-        processedSubAgentInteractionIds.add(activity.item.id);
-        const interactionKind = consumeCodexInteractionKind({
-          callId: activity.item.id,
-          providerThreadId: activity.providerThreadId,
-        });
-        if (interactionKind === "message") {
+        if (existing?.state === "activity") {
+          if (
+            existing.parentProviderThreadId !== activity.providerThreadId ||
+            existing.parentTurnId !== activity.turnId ||
+            existing.activity.item.agentThreadId !== activity.item.agentThreadId
+          ) {
+            settleCodexInteraction(existing, null);
+          }
           return [];
         }
         const tracked = findTrackedSubAgentByAgentThreadId(
           activity.item.agentThreadId,
         );
+        if (existing?.state === "raw") {
+          const sameParent =
+            existing.parentProviderThreadId === activity.providerThreadId &&
+            existing.parentTurnId === activity.turnId;
+          settleCodexInteraction(
+            existing,
+            sameParent ? activity.item.agentThreadId : null,
+          );
+          return sameParent
+            ? correlateCodexInteraction({
+                activity,
+                intent: existing.intent,
+              })
+            : [];
+        }
         if (tracked && !tracked.terminal) {
+          settleCodexInteraction(
+            {
+              callId: activity.item.id,
+              parentBoundaryPassed: false,
+              parentProviderThreadId: activity.providerThreadId,
+              parentTurnId: activity.turnId,
+            },
+            activity.item.agentThreadId,
+          );
           return [];
         }
-        if (interactionKind === "followup") {
-          return materializeCodexFollowup(activity);
-        }
-        queueUnclassifiedCodexInteraction(activity);
+        pendingInteractionsByCallId.set(activity.item.id, {
+          activity,
+          callId: activity.item.id,
+          parentBoundaryPassed: false,
+          parentProviderThreadId: activity.providerThreadId,
+          parentTurnId: activity.turnId,
+          state: "activity",
+        });
         return [];
       }
       case "interrupted": {
+        for (const [callId, interaction] of pendingInteractionsByCallId) {
+          const childThreadId =
+            interaction.state === "activity"
+              ? interaction.activity.item.agentThreadId
+              : interaction.state === "settled"
+                ? interaction.childThreadId
+                : null;
+          if (childThreadId === activity.item.agentThreadId) {
+            pendingInteractionsByCallId.delete(callId);
+          }
+        }
         const callId = trackedSubAgentCallIdsByAgentThreadId.get(
           activity.item.agentThreadId,
         );
@@ -1312,27 +1391,42 @@ export function createCodexEventTranslator(
 
     if (item.type === "function_call") {
       if (item.name === "followup_task" || item.name === "send_message") {
-        const pendingActivity = takeUnclassifiedCodexInteraction({
-          callId: item.call_id,
-          providerThreadId,
-        });
-        if (pendingActivity) {
-          return item.name === "followup_task"
-            ? materializeCodexFollowup(pendingActivity)
+        const intent = item.name === "followup_task" ? "followup" : "message";
+        const existing = pendingInteractionsByCallId.get(item.call_id);
+        if (existing?.state === "activity") {
+          const sameParent =
+            existing.parentProviderThreadId === providerThreadId &&
+            existing.parentTurnId === paramsResult.data.turnId;
+          settleCodexInteraction(
+            existing,
+            sameParent ? existing.activity.item.agentThreadId : null,
+          );
+          return sameParent
+            ? correlateCodexInteraction({
+                activity: existing.activity,
+                intent,
+              })
             : [];
         }
-        if (!processedSubAgentInteractionIds.has(item.call_id)) {
-          const interactionKinds =
-            interactionKindsByProviderThreadId.get(providerThreadId) ??
-            new Map<string, CodexInteractionKind>();
-          interactionKinds.set(
-            item.call_id,
-            item.name === "followup_task" ? "followup" : "message",
-          );
-          interactionKindsByProviderThreadId.set(
-            providerThreadId,
-            interactionKinds,
-          );
+        if (existing?.state === "raw") {
+          if (
+            existing.intent !== intent ||
+            existing.parentProviderThreadId !== providerThreadId ||
+            existing.parentTurnId !== paramsResult.data.turnId
+          ) {
+            settleCodexInteraction(existing, null);
+          }
+          return [];
+        }
+        if (existing === undefined) {
+          pendingInteractionsByCallId.set(item.call_id, {
+            callId: item.call_id,
+            intent,
+            parentBoundaryPassed: false,
+            parentProviderThreadId: providerThreadId,
+            parentTurnId: paramsResult.data.turnId,
+            state: "raw",
+          });
         }
         return [];
       }
@@ -1552,7 +1646,7 @@ export function createCodexEventTranslator(
       );
     }
 
-    const parentLinkedDeltas = materializeUnclassifiedCodexInteractions(
+    const parentLinkedDeltas = correlatePendingCodexInteractions(
       translateCodexEventToDeltas(event, eventTranslationState),
       providerThreadId,
     );
@@ -1577,6 +1671,7 @@ export function createCodexEventTranslator(
     clearExitedChildThreadState,
     configureInjectedTools,
     getThreadGitWritableRoots,
+    primeSubAgentHistory,
     prepareTurnStart: queueNativeTurnStartClientRequestId,
     prepareWorkspaceWriteGitRoots,
     translateEvent,

--- a/plugins/provider-codex/src/translator.ts
+++ b/plugins/provider-codex/src/translator.ts
@@ -1114,23 +1114,47 @@ export function createCodexEventTranslator(
       : materializeCodexFollowup(args.activity);
   }
 
-  function consumeExactCodexInteraction(
+  function consumeCodexInteractionForTurnStart(
     providerThreadId: string,
   ): ThreadDelta[] {
+    let exactInteraction: CodexActivityInteraction | undefined;
+    let fallbackInteraction: CodexActivityInteraction | undefined;
+    let fallbackIsAmbiguous = false;
     for (const interaction of pendingInteractionsByCallId.values()) {
+      if (interaction.state !== "activity") {
+        continue;
+      }
+      if (interaction.activity.item.agentThreadId === providerThreadId) {
+        exactInteraction = interaction;
+        break;
+      }
+      const tracked = findTrackedSubAgentByAgentThreadId(
+        interaction.activity.item.agentThreadId,
+      );
       if (
-        interaction.state !== "activity" ||
-        interaction.activity.item.agentThreadId !== providerThreadId
+        interaction.parentProviderThreadId !== providerThreadId ||
+        !tracked?.terminal
       ) {
         continue;
       }
-      settleCodexInteraction(interaction, providerThreadId);
-      return correlateCodexInteraction({
-        activity: interaction.activity,
-        intent: "followup",
-      });
+      if (fallbackInteraction) {
+        fallbackIsAmbiguous = true;
+      } else {
+        fallbackInteraction = interaction;
+      }
     }
-    return [];
+    const interaction =
+      exactInteraction ??
+      (fallbackIsAmbiguous ? undefined : fallbackInteraction);
+    if (!interaction) {
+      return [];
+    }
+    const childThreadId = interaction.activity.item.agentThreadId;
+    settleCodexInteraction(interaction, childThreadId);
+    return correlateCodexInteraction({
+      activity: interaction.activity,
+      intent: "followup",
+    });
   }
 
   function advanceCodexInteractionBoundaries(args: {
@@ -1200,7 +1224,9 @@ export function createCodexEventTranslator(
         delta.providerTurnId !== undefined &&
         !hasPendingNativeTurnStart(providerThreadId)
       ) {
-        materialized.push(...consumeExactCodexInteraction(providerThreadId));
+        materialized.push(
+          ...consumeCodexInteractionForTurnStart(providerThreadId),
+        );
       }
       materialized.push(
         ...attachCodexDelegationParentLinks([delta], providerThreadId),


### PR DESCRIPTION
## Human comments

## What was wrong

When a parent Codex thread resumes or forks and continues working with an existing child agent, BB can attach that follow-up to the wrong child or fail to show it under the original delegation. Users expect the resumed child’s messages and results to remain attached to the task that originally spawned it. #2539 added relinking for this goal, but ownership still depended on event timing and candidate order, and current Codex versions can report a resumed child turn on the root provider thread rather than the child thread.

The provider could therefore complete the resumed child correctly while the app showed only “Worked for … / Failed to load turn details.” The timeline details path also projected the full event window twice on a range fallback and repeatedly scanned row suffixes, making the failure path unnecessarily expensive.

## What changed

- Restore each historical child’s original delegation identity from typed resume/fork history without replaying historical work.
- Preserve fast Codex resume with `excludeTurns: true`; when the first resumed-child interaction arrives, lazily read full history once, buffer intervening notifications, prime ownership, and replay those notifications in order.
- Replace the separate raw-intent, activity, and processed-ID caches plus LIFO candidate scan with one bounded call-ID correlation lifecycle.
- Match the exact child thread first, then allow a root-thread fallback only when exactly one eligible terminal child exists; ambiguous root turns fail closed, and native root turns retain priority.
- Preserve an accepted human new-turn boundary when a completed old turn emits reopened work, while keeping other turns’ prompts out of details.
- Treat an explicit completed-then-started lifecycle as a reopen for whole-item ownership, and search exact and stale ranges against one timeline projection.
- Replace repeated suffix scans with one reverse pass and prefilter historical items before schema parsing.
- Increment `HOST_DAEMON_PROTOCOL_VERSION` from 178 to 179 for the changed daemon-emitted delegation and `parentToolCallId` semantics.

This preserves and completes #2539: resumed and forked threads still reconstruct historical child ownership, the unique root-multiplexed Codex case is supported without guessing between children, and the intended follow-up remains expandable in the UI.

## How you verified

- `pnpm exec turbo run typecheck --filter=@bb/server --filter=@bb/thread-view --filter=bb-plugin-provider-codex --filter=@bb/host-daemon-contract` — 9/9 tasks passed.
- `pnpm exec turbo run test --filter=bb-plugin-provider-codex --force` — 27 files and 272 tests passed.
- `pnpm exec turbo run test --filter=@bb/thread-view --force` — 23 files and 368 tests passed.
- `pnpm exec turbo run test --filter=@bb/host-daemon-contract --force` — 3 files and 51 tests passed.
- `pnpm --dir apps/server exec vitest run test/services/threads/timeline-in-turn-window.test.ts` — 27/27 tests passed.
- The root-multiplexed resumed-child regression, ambiguity/native-root guards, lazy resume-history bridge regression, and reopened-delegation details regression pass after failing during the red/green cycle.
- Live repro `thr_z4637w8sxf`: the formerly failing `18-83` details request returns HTTP 200, exactly matches the inline children, and contains `ALPHA RESUMED`.
- `git range-diff` reports the original two patches unchanged after rebasing onto `2c57aa3919a2689ac6a155162f4b0f5bcca7dd66`; the review fixes are the third commit `aa175a877bfdd1024212bce09198a8cb3cb901e2`.
- `git diff --check` and formatting checks pass.
- Fresh GitHub CI passed all 13 executed checks for `aa175a877bfdd1024212bce09198a8cb3cb901e2`; mobile and Node-compatibility jobs were skipped by workflow policy.

Fixes #2538

> AGENT GENERATED
