### PR TITLE
Serialize Claude credential initialization by store

### DIFF
--- a/plugins/provider-claude-code/package.json
+++ b/plugins/provider-claude-code/package.json
@@ -35,6 +35,7 @@
     "@anthropic-ai/claude-agent-sdk": "^0.3.245",
     "@get-bb/plugin-sdk": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "proper-lockfile": "^4.1.2",
     "zod": "^4.3.6"
   }
 }

--- a/plugins/provider-claude-code/src/bridge/__tests__/credential-initialization-lock.child.ts
+++ b/plugins/provider-claude-code/src/bridge/__tests__/credential-initialization-lock.child.ts
@@ -1,0 +1,38 @@
+import process from "node:process";
+import { setTimeout as sleep } from "node:timers/promises";
+import { createClaudeCredentialInitializationCoordinator } from "../credential-initialization-lock.js";
+
+const [lockRoot, homeDir, configDir, platform] = process.argv.slice(2);
+if (
+  lockRoot === undefined ||
+  homeDir === undefined ||
+  configDir === undefined ||
+  platform === undefined
+) {
+  throw new Error(
+    "Expected lock root, home directory, and Claude config directory",
+  );
+}
+
+const coordinator = createClaudeCredentialInitializationCoordinator({
+  lockRoot,
+  platform: platform as NodeJS.Platform,
+  retryIntervalMs: 25,
+  staleMs: 500,
+  updateMs: 100,
+});
+
+await coordinator.run(
+  { HOME: homeDir, CLAUDE_CONFIG_DIR: configDir },
+  async () => {
+    process.send?.({ type: "entered" });
+    await new Promise<void>((resolve) => {
+      process.on("message", (message) => {
+        if (message === "release") resolve();
+      });
+    });
+    process.send?.({ type: "leaving" });
+    await sleep(10);
+  },
+);
+process.disconnect?.();

--- a/plugins/provider-claude-code/src/bridge/__tests__/credential-initialization-lock.test.ts
+++ b/plugins/provider-claude-code/src/bridge/__tests__/credential-initialization-lock.test.ts
@@ -1,0 +1,250 @@
+import { fork, type ChildProcess } from "node:child_process";
+import { mkdtemp, mkdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createClaudeCredentialInitializationCoordinator } from "../credential-initialization-lock.js";
+
+const CHILD_PATH = fileURLToPath(
+  new URL("./credential-initialization-lock.child.ts", import.meta.url),
+);
+const ENTER_TIMEOUT_MS = 5_000;
+
+interface LockWorker {
+  child: ChildProcess;
+  entered: Promise<void>;
+}
+
+function waitForMessage(
+  child: ChildProcess,
+  expectedType: string,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error(`Timed out waiting for child message ${expectedType}`));
+    }, ENTER_TIMEOUT_MS);
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      cleanup();
+      reject(
+        new Error(
+          `Lock worker exited before ${expectedType} (code=${String(code)}, signal=${String(signal)})`,
+        ),
+      );
+    };
+    const onMessage = (message: unknown) => {
+      if (
+        typeof message === "object" &&
+        message !== null &&
+        "type" in message &&
+        message.type === expectedType
+      ) {
+        cleanup();
+        resolve();
+      }
+    };
+    const cleanup = () => {
+      clearTimeout(timeout);
+      child.off("error", onError);
+      child.off("exit", onExit);
+      child.off("message", onMessage);
+    };
+    child.on("error", onError);
+    child.on("exit", onExit);
+    child.on("message", onMessage);
+  });
+}
+
+function startWorker(args: {
+  configDir: string;
+  homeDir: string;
+  lockRoot: string;
+  platform?: NodeJS.Platform;
+}): LockWorker {
+  const child = fork(
+    CHILD_PATH,
+    [args.lockRoot, args.homeDir, args.configDir, args.platform ?? "linux"],
+    {
+      execArgv: ["--import", "tsx"],
+      stdio: ["ignore", "ignore", "pipe", "ipc"],
+    },
+  );
+  return { child, entered: waitForMessage(child, "entered") };
+}
+
+function settlesWithin(
+  promise: Promise<void>,
+  durationMs: number,
+): Promise<boolean> {
+  return Promise.race([
+    promise.then(() => true),
+    new Promise<boolean>((resolve) =>
+      setTimeout(() => resolve(false), durationMs),
+    ),
+  ]);
+}
+
+async function releaseWorker(worker: LockWorker): Promise<void> {
+  const leaving = waitForMessage(worker.child, "leaving");
+  worker.child.send("release");
+  await leaving;
+  await new Promise<void>((resolve) =>
+    worker.child.once("exit", () => resolve()),
+  );
+}
+
+describe("Claude credential initialization coordination", () => {
+  let tempRoot: string;
+  const workers: LockWorker[] = [];
+
+  beforeEach(async () => {
+    tempRoot = await mkdtemp(join(tmpdir(), "bb-claude-credential-lock-"));
+  });
+
+  afterEach(async () => {
+    for (const worker of workers) {
+      if (!worker.child.killed) worker.child.kill("SIGKILL");
+    }
+    await Promise.all(
+      workers.map(
+        (worker) =>
+          new Promise<void>((resolve) => {
+            if (
+              worker.child.exitCode !== null ||
+              worker.child.signalCode !== null
+            ) {
+              resolve();
+              return;
+            }
+            worker.child.once("exit", () => resolve());
+          }),
+      ),
+    );
+    await rm(tempRoot, { recursive: true, force: true });
+  });
+
+  it("serializes separate workers that share a credential store", async () => {
+    const homeDir = join(tempRoot, "home");
+    const configDir = join(homeDir, ".claude");
+    const lockRoot = join(tempRoot, "locks");
+    await mkdir(configDir, { recursive: true });
+
+    const first = startWorker({ configDir: ".claude", homeDir, lockRoot });
+    workers.push(first);
+    await first.entered;
+
+    const second = startWorker({ configDir, homeDir, lockRoot });
+    workers.push(second);
+    expect(await settlesWithin(second.entered, 250)).toBe(false);
+
+    await releaseWorker(first);
+    await second.entered;
+    await releaseWorker(second);
+  });
+
+  it("does not serialize separate credential stores", async () => {
+    const homeDir = join(tempRoot, "home");
+    const firstConfigDir = join(tempRoot, "claude-a");
+    const secondConfigDir = join(tempRoot, "claude-b");
+    const lockRoot = join(tempRoot, "locks");
+    await Promise.all([
+      mkdir(firstConfigDir, { recursive: true }),
+      mkdir(secondConfigDir, { recursive: true }),
+    ]);
+
+    const first = startWorker({ configDir: firstConfigDir, homeDir, lockRoot });
+    const second = startWorker({
+      configDir: secondConfigDir,
+      homeDir,
+      lockRoot,
+    });
+    workers.push(first, second);
+    await Promise.all([first.entered, second.entered]);
+    await Promise.all([releaseWorker(first), releaseWorker(second)]);
+  });
+
+  it("does not coordinate sessions with explicit credentials", async () => {
+    const coordinator = createClaudeCredentialInitializationCoordinator({
+      lockRoot: join(tempRoot, "locks"),
+      platform: "linux",
+    });
+    let releaseFirst: (() => void) | undefined;
+    let reportFirstEntered: (() => void) | undefined;
+    const firstEntered = new Promise<void>((resolve) => {
+      reportFirstEntered = resolve;
+    });
+    const first = coordinator.run(
+      { HOME: join(tempRoot, "home"), ANTHROPIC_API_KEY: "test-api-key-a" },
+      async () => {
+        reportFirstEntered?.();
+        await new Promise<void>((resolve) => {
+          releaseFirst = resolve;
+        });
+      },
+    );
+    await firstEntered;
+
+    let secondEntered = false;
+    await coordinator.run(
+      { HOME: join(tempRoot, "home"), ANTHROPIC_API_KEY: "test-api-key-b" },
+      async () => {
+        secondEntered = true;
+      },
+    );
+    expect(secondEntered).toBe(true);
+
+    releaseFirst?.();
+    await first;
+  });
+
+  it("treats the macOS Keychain as one store across config directories", async () => {
+    const homeDir = join(tempRoot, "home");
+    const lockRoot = join(tempRoot, "locks");
+    const first = startWorker({
+      configDir: join(tempRoot, "claude-a"),
+      homeDir,
+      lockRoot,
+      platform: "darwin",
+    });
+    workers.push(first);
+    await first.entered;
+
+    const second = startWorker({
+      configDir: join(tempRoot, "claude-b"),
+      homeDir,
+      lockRoot,
+      platform: "darwin",
+    });
+    workers.push(second);
+    expect(await settlesWithin(second.entered, 250)).toBe(false);
+
+    await releaseWorker(first);
+    await second.entered;
+    await releaseWorker(second);
+  });
+
+  it("recovers a stale lock after a worker crashes", async () => {
+    const homeDir = join(tempRoot, "home");
+    const configDir = join(homeDir, ".claude");
+    const lockRoot = join(tempRoot, "locks");
+    await mkdir(configDir, { recursive: true });
+
+    const crashed = startWorker({ configDir, homeDir, lockRoot });
+    workers.push(crashed);
+    await crashed.entered;
+    crashed.child.kill("SIGKILL");
+    await new Promise<void>((resolve) =>
+      crashed.child.once("exit", () => resolve()),
+    );
+
+    const replacement = startWorker({ configDir, homeDir, lockRoot });
+    workers.push(replacement);
+    await replacement.entered;
+    await releaseWorker(replacement);
+  });
+});

--- a/plugins/provider-claude-code/src/bridge/__tests__/sdk-session.test.ts
+++ b/plugins/provider-claude-code/src/bridge/__tests__/sdk-session.test.ts
@@ -8,6 +8,7 @@ import type {
 const mockQueryInstance = {
   applyFlagSettings: vi.fn(),
   close: vi.fn(),
+  initializationResult: vi.fn(),
   interrupt: vi.fn(),
   setModel: vi.fn(),
   setPermissionMode: vi.fn(),
@@ -89,6 +90,7 @@ describe("SdkSession", () => {
     mockQueryInstance.applyFlagSettings.mockResolvedValue(undefined);
     mockQueryInstance.setModel.mockResolvedValue(undefined);
     mockQueryInstance.setPermissionMode.mockResolvedValue(undefined);
+    mockQueryInstance.initializationResult.mockResolvedValue({});
     mockQueryInstance[Symbol.asyncIterator].mockReturnValue({
       next: vi.fn().mockResolvedValue({ value: undefined, done: true }),
       return: vi.fn().mockResolvedValue({ value: undefined, done: true }),
@@ -104,6 +106,56 @@ describe("SdkSession", () => {
     const onDone = vi.fn();
     const session = new SdkSession(defaultOptions, onMessage, onDone);
     expect(session.getSessionId()).toBeUndefined();
+  });
+
+  it("holds credential coordination through SDK initialization", async () => {
+    keepSdkStreamOpen();
+    let allowAcquisition: (() => void) | undefined;
+    const acquisitionAllowed = new Promise<void>((resolve) => {
+      allowAcquisition = resolve;
+    });
+    let finishInitialization: (() => void) | undefined;
+    mockQueryInstance.initializationResult.mockReturnValue(
+      new Promise<void>((resolve) => {
+        finishInitialization = resolve;
+      }),
+    );
+    let coordinationReleased = false;
+    const coordinator = {
+      async run<T>(
+        _env: NodeJS.ProcessEnv,
+        work: () => Promise<T>,
+      ): Promise<T> {
+        await acquisitionAllowed;
+        try {
+          return await work();
+        } finally {
+          coordinationReleased = true;
+        }
+      },
+    };
+    const session = new SdkSession(
+      {
+        ...defaultOptions,
+        credentialInitializationCoordinator: coordinator,
+      },
+      vi.fn(),
+      vi.fn(),
+    );
+
+    session.start();
+    await waitForAsyncWork();
+    expect(queryMock).not.toHaveBeenCalled();
+
+    allowAcquisition?.();
+    await waitForAsyncWork();
+    expect(queryMock).toHaveBeenCalledOnce();
+    expect(coordinationReleased).toBe(false);
+
+    finishInitialization?.();
+    await waitForAsyncWork();
+    expect(coordinationReleased).toBe(true);
+    session.stop();
   });
 
   it("applies model and mutable flag settings to the live query", async () => {

--- a/plugins/provider-claude-code/src/bridge/bridge.ts
+++ b/plugins/provider-claude-code/src/bridge/bridge.ts
@@ -53,7 +53,14 @@ import {
   type ClaudeCodeSkillRoot,
 } from "../session-params.js";
 import { SdkSession, type SdkSessionOptions } from "./sdk-session.js";
-import { createClaudeCodeBridgeModelListMemo } from "./model-list.js";
+import {
+  createClaudeCodeBridgeModelListMemo,
+  listClaudeCodeBridgeModels,
+} from "./model-list.js";
+import {
+  createClaudeCredentialInitializationCoordinator,
+  type ClaudeCredentialInitializationCoordinator,
+} from "./credential-initialization-lock.js";
 import {
   claudeThreadForkParamsSchema,
   claudeThreadResumeParamsSchema,
@@ -335,6 +342,8 @@ function nextInteractiveRequestId(): string {
 let configuredSkillRoots: ClaudeCodeSkillRoot[] | null = null;
 let skillPluginsRoot: string | null = null;
 let bridgeTempDir: string | null = null;
+let credentialInitializationCoordinator: ClaudeCredentialInitializationCoordinator | null =
+  null;
 
 function assembleSkillPlugins(
   roots: readonly { id: string; path: string }[],
@@ -592,6 +601,11 @@ async function applyLiveSessionSettings(
 
 const MODEL_LIST_MEMO_TTL_MS = 2 * 60_000;
 const listModelsMemoized = createClaudeCodeBridgeModelListMemo({
+  list: () =>
+    listClaudeCodeBridgeModels(
+      process.env,
+      credentialInitializationCoordinator ?? undefined,
+    ),
   ttlMs: MODEL_LIST_MEMO_TTL_MS,
 });
 
@@ -1162,6 +1176,10 @@ function buildTrackedSessionOptions(
   );
   addPermissionEscalationTrackingHooks(sessionOptions, threadIdRef);
   sessionOptions.recordThreadId = () => threadIdRef.current;
+  if (credentialInitializationCoordinator !== null) {
+    sessionOptions.credentialInitializationCoordinator =
+      credentialInitializationCoordinator;
+  }
   return sessionOptions;
 }
 
@@ -2475,6 +2493,13 @@ export const experimental_providerBridge = experimental_defineProviderBridge({
   handleLine,
   start: (context) => {
     bridgeTempDir = context.tempDir;
+    credentialInitializationCoordinator =
+      createClaudeCredentialInitializationCoordinator({
+        lockRoot: joinPath(
+          context.dataDir,
+          "claude-credential-initialization-locks",
+        ),
+      });
   },
   onSigterm: () => {
     shutdownGracefully(

--- a/plugins/provider-claude-code/src/bridge/credential-initialization-lock.ts
+++ b/plugins/provider-claude-code/src/bridge/credential-initialization-lock.ts
@@ -1,0 +1,118 @@
+import { createHash } from "node:crypto";
+import { mkdir, open, realpath } from "node:fs/promises";
+import { homedir } from "node:os";
+import { isAbsolute, join, resolve } from "node:path";
+import lockfile from "proper-lockfile";
+
+export interface ClaudeCredentialInitializationCoordinator {
+  run<T>(env: NodeJS.ProcessEnv, work: () => Promise<T>): Promise<T>;
+}
+
+interface CreateClaudeCredentialInitializationCoordinatorArgs {
+  lockRoot: string;
+  platform?: NodeJS.Platform;
+  retryIntervalMs?: number;
+  staleMs?: number;
+  updateMs?: number;
+}
+
+const DEFAULT_STALE_MS = 30_000;
+const DEFAULT_UPDATE_MS = 10_000;
+const DEFAULT_RETRY_INTERVAL_MS = 100;
+const MAX_WAIT_MS = 15 * 60_000;
+
+function resolveClaudeConfigDir(env: NodeJS.ProcessEnv): string {
+  const homeDir = env.HOME?.trim() || homedir();
+  const configured = env.CLAUDE_CONFIG_DIR?.trim();
+  if (!configured) {
+    return join(homeDir, ".claude");
+  }
+  if (configured === "~") {
+    return homeDir;
+  }
+  if (configured.startsWith("~/") || configured.startsWith("~\\")) {
+    return resolve(homeDir, configured.slice(2));
+  }
+  return isAbsolute(configured)
+    ? resolve(configured)
+    : resolve(homeDir, configured);
+}
+
+async function canonicalCredentialStorePath(
+  env: NodeJS.ProcessEnv,
+): Promise<string> {
+  const configDir = resolveClaudeConfigDir(env);
+  try {
+    return await realpath(configDir);
+  } catch {
+    return configDir;
+  }
+}
+
+function isEnabled(value: string | undefined): boolean {
+  const normalized = value?.trim().toLowerCase();
+  return normalized === "1" || normalized === "true";
+}
+
+async function credentialStoreLockName(
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform,
+): Promise<string | null> {
+  if (
+    isEnabled(env.CLAUDE_CODE_USE_BEDROCK) ||
+    isEnabled(env.CLAUDE_CODE_USE_VERTEX) ||
+    isEnabled(env.CLAUDE_CODE_USE_FOUNDRY) ||
+    env.ANTHROPIC_AUTH_TOKEN?.trim() ||
+    env.ANTHROPIC_API_KEY?.trim() ||
+    env.CLAUDE_CODE_OAUTH_TOKEN?.trim()
+  ) {
+    return null;
+  }
+  if (platform === "darwin") {
+    return createHash("sha256").update("macos-keychain").digest("hex");
+  }
+  const credentialStorePath = await canonicalCredentialStorePath(env);
+  return createHash("sha256")
+    .update(`credentials-file\0${credentialStorePath}`)
+    .digest("hex");
+}
+
+export function createClaudeCredentialInitializationCoordinator(
+  args: CreateClaudeCredentialInitializationCoordinatorArgs,
+): ClaudeCredentialInitializationCoordinator {
+  const staleMs = args.staleMs ?? DEFAULT_STALE_MS;
+  const updateMs = args.updateMs ?? DEFAULT_UPDATE_MS;
+  const retryIntervalMs = args.retryIntervalMs ?? DEFAULT_RETRY_INTERVAL_MS;
+  const retries = Math.ceil(MAX_WAIT_MS / retryIntervalMs);
+  const platform = args.platform ?? process.platform;
+
+  return {
+    async run(env, work) {
+      const lockName = await credentialStoreLockName(env, platform);
+      if (lockName === null) {
+        return work();
+      }
+      await mkdir(args.lockRoot, { recursive: true, mode: 0o700 });
+      const lockPath = join(args.lockRoot, lockName);
+      const handle = await open(lockPath, "a", 0o600);
+      await handle.close();
+
+      const release = await lockfile.lock(lockPath, {
+        realpath: false,
+        stale: staleMs,
+        update: updateMs,
+        retries: {
+          retries,
+          factor: 1,
+          minTimeout: retryIntervalMs,
+          maxTimeout: retryIntervalMs,
+        },
+      });
+      try {
+        return await work();
+      } finally {
+        await release();
+      }
+    },
+  };
+}

--- a/plugins/provider-claude-code/src/bridge/model-list.ts
+++ b/plugins/provider-claude-code/src/bridge/model-list.ts
@@ -3,6 +3,7 @@ import { query, type Options } from "@anthropic-ai/claude-agent-sdk";
 import { buildClaudeCodeModels } from "../model-list.js";
 import { translateMissingClaudeCliError } from "./missing-cli-error.js";
 import { resolveClaudeCodeExecutable } from "./session-options.js";
+import type { ClaudeCredentialInitializationCoordinator } from "./credential-initialization-lock.js";
 
 function buildModelProbeOptions(env: NodeJS.ProcessEnv): Options {
   const pathToClaudeCodeExecutable = resolveClaudeCodeExecutable({ env });
@@ -19,28 +20,32 @@ function buildModelProbeOptions(env: NodeJS.ProcessEnv): Options {
 
 export async function listClaudeCodeBridgeModels(
   env: NodeJS.ProcessEnv = process.env,
+  coordinator?: ClaudeCredentialInitializationCoordinator,
 ): Promise<{
   models: AvailableModel[];
   selectedOnlyModels: AvailableModel[];
 }> {
-  let session: ReturnType<typeof query>;
-  try {
-    session = query({
-      prompt: ".",
-      options: buildModelProbeOptions(env),
-    });
-  } catch (error) {
-    throw translateMissingClaudeCliError(error);
-  }
+  const probe = async () => {
+    let session: ReturnType<typeof query>;
+    try {
+      session = query({
+        prompt: ".",
+        options: buildModelProbeOptions(env),
+      });
+    } catch (error) {
+      throw translateMissingClaudeCliError(error);
+    }
 
-  try {
-    const initialization = await session.initializationResult();
-    return buildClaudeCodeModels(initialization.models);
-  } catch (error) {
-    throw translateMissingClaudeCliError(error);
-  } finally {
-    session.close();
-  }
+    try {
+      const initialization = await session.initializationResult();
+      return buildClaudeCodeModels(initialization.models);
+    } catch (error) {
+      throw translateMissingClaudeCliError(error);
+    } finally {
+      session.close();
+    }
+  };
+  return coordinator === undefined ? probe() : coordinator.run(env, probe);
 }
 
 interface ClaudeCodeBridgeModelListMemoOptions {

--- a/plugins/provider-claude-code/src/bridge/sdk-session.ts
+++ b/plugins/provider-claude-code/src/bridge/sdk-session.ts
@@ -15,6 +15,7 @@ import {
   experimental_recordProviderChildIo,
 } from "@get-bb/plugin-sdk/provider-bridge";
 import type { ClaudePermissionMode } from "../interactive-contract.js";
+import type { ClaudeCredentialInitializationCoordinator } from "./credential-initialization-lock.js";
 import {
   isMissingClaudeCliMessage,
   missingClaudeCliGuidance,
@@ -41,6 +42,7 @@ export interface SdkSessionOptions {
   thinking?: Options["thinking"];
   settings?: Options["settings"];
   recordThreadId?: () => string;
+  credentialInitializationCoordinator?: ClaudeCredentialInitializationCoordinator;
 }
 
 export type ClaudeSdkReasoningEffort =
@@ -216,79 +218,123 @@ export class SdkSession {
     }
 
     this.stderrTail = "";
-    const permissionOptions = buildSdkPermissionOptions({
-      permissionMode: this.options.permissionMode,
-    });
     const onStderr = (data: string): void => {
       this.stderrTail = appendBoundedText({
         current: this.stderrTail,
         chunk: data,
       });
     };
-    const recordThreadId = this.options.recordThreadId;
-    const sdkOptions: Options = {
-      abortController: this.abortController,
-      cwd: this.options.cwd,
-      systemPrompt: this.options.systemPrompt,
-      ...permissionOptions,
-      ...(experimental_isProviderBridgeRecording()
-        ? {
-            spawnClaudeCodeProcess: (spawnOptions: SpawnOptions) =>
-              spawnRecordedClaudeProcess({
-                onStderr,
-                spawnOptions,
-                threadId: recordThreadId?.() ?? null,
-              }),
-          }
-        : {}),
-      includePartialMessages: true,
-      settingSources: ["user", "project", "local"],
-      persistSession: true,
-      env: this.options.env ?? process.env,
-      stderr: onStderr,
-      ...(this.options.mcpServers
-        ? { mcpServers: this.options.mcpServers }
-        : {}),
-      ...(this.options.allowedTools
-        ? { allowedTools: this.options.allowedTools }
-        : {}),
-      ...(this.options.disallowedTools
-        ? { disallowedTools: this.options.disallowedTools }
-        : {}),
-      ...(this.options.canUseTool
-        ? { canUseTool: this.options.canUseTool }
-        : {}),
-      ...(this.options.sandbox ? { sandbox: this.options.sandbox } : {}),
-      ...(this.options.hooks ? { hooks: this.options.hooks } : {}),
-      ...(resumeSessionId ? { resume: resumeSessionId } : {}),
-      ...(!resumeSessionId && this.options.sessionId
-        ? { sessionId: this.options.sessionId }
-        : {}),
-      ...(this.options.model ? { model: this.options.model } : {}),
-      ...(this.options.additionalDirectories
-        ? { additionalDirectories: [...this.options.additionalDirectories] }
-        : {}),
-      ...(this.options.effort ? { effort: this.options.effort } : {}),
-      ...(this.options.pathToClaudeCodeExecutable
-        ? {
-            pathToClaudeCodeExecutable: this.options.pathToClaudeCodeExecutable,
-          }
-        : {}),
-      ...(this.options.plugins ? { plugins: this.options.plugins } : {}),
-      ...(this.options.thinking ? { thinking: this.options.thinking } : {}),
-      ...(this.options.settings ? { settings: this.options.settings } : {}),
+    const buildSdkOptions = (): Options => {
+      const permissionOptions = buildSdkPermissionOptions({
+        permissionMode: this.options.permissionMode,
+      });
+      const recordThreadId = this.options.recordThreadId;
+      return {
+        abortController: this.abortController,
+        cwd: this.options.cwd,
+        systemPrompt: this.options.systemPrompt,
+        ...permissionOptions,
+        ...(experimental_isProviderBridgeRecording()
+          ? {
+              spawnClaudeCodeProcess: (spawnOptions: SpawnOptions) =>
+                spawnRecordedClaudeProcess({
+                  onStderr,
+                  spawnOptions,
+                  threadId: recordThreadId?.() ?? null,
+                }),
+            }
+          : {}),
+        includePartialMessages: true,
+        settingSources: ["user", "project", "local"],
+        persistSession: true,
+        env: this.options.env ?? process.env,
+        stderr: onStderr,
+        ...(this.options.mcpServers
+          ? { mcpServers: this.options.mcpServers }
+          : {}),
+        ...(this.options.allowedTools
+          ? { allowedTools: this.options.allowedTools }
+          : {}),
+        ...(this.options.disallowedTools
+          ? { disallowedTools: this.options.disallowedTools }
+          : {}),
+        ...(this.options.canUseTool
+          ? { canUseTool: this.options.canUseTool }
+          : {}),
+        ...(this.options.sandbox ? { sandbox: this.options.sandbox } : {}),
+        ...(this.options.hooks ? { hooks: this.options.hooks } : {}),
+        ...(resumeSessionId ? { resume: resumeSessionId } : {}),
+        ...(!resumeSessionId && this.options.sessionId
+          ? { sessionId: this.options.sessionId }
+          : {}),
+        ...(this.options.model ? { model: this.options.model } : {}),
+        ...(this.options.additionalDirectories
+          ? { additionalDirectories: [...this.options.additionalDirectories] }
+          : {}),
+        ...(this.options.effort ? { effort: this.options.effort } : {}),
+        ...(this.options.pathToClaudeCodeExecutable
+          ? {
+              pathToClaudeCodeExecutable:
+                this.options.pathToClaudeCodeExecutable,
+            }
+          : {}),
+        ...(this.options.plugins ? { plugins: this.options.plugins } : {}),
+        ...(this.options.thinking ? { thinking: this.options.thinking } : {}),
+        ...(this.options.settings ? { settings: this.options.settings } : {}),
+      };
     };
 
-    try {
-      this.query = query({
-        prompt: this.createInputIterable(),
-        options: sdkOptions,
-      });
-    } catch (error) {
-      throw translateMissingClaudeCliError(error);
+    let queryStarted = false;
+    const startQuery = (): Promise<void> => {
+      if (this.abortController.signal.aborted) {
+        return Promise.resolve();
+      }
+      try {
+        this.query = query({
+          prompt: this.createInputIterable(),
+          options: buildSdkOptions(),
+        });
+      } catch (error) {
+        throw translateMissingClaudeCliError(error);
+      }
+      queryStarted = true;
+      const activeQuery = this.query;
+      void this.consumeStream(activeQuery);
+      return Promise.race([
+        activeQuery.initializationResult().then(() => undefined),
+        this.completion,
+      ]);
+    };
+
+    const coordinator = this.options.credentialInitializationCoordinator;
+    if (coordinator === undefined) {
+      try {
+        this.query = query({
+          prompt: this.createInputIterable(),
+          options: buildSdkOptions(),
+        });
+      } catch (error) {
+        throw translateMissingClaudeCliError(error);
+      }
+      void this.consumeStream(this.query);
+      return;
     }
 
-    void this.consumeStream();
+    void coordinator
+      .run(this.options.env ?? process.env, startQuery)
+      .catch((error: unknown) => {
+        if (queryStarted || this.abortController.signal.aborted) {
+          return;
+        }
+        this.inputDone = true;
+        this.rejectQueuedInputs(
+          "Claude SDK session failed before input consumed",
+        );
+        this.resolveInputDone();
+        this.onDone(error);
+        this.complete?.();
+        this.complete = null;
+      });
   }
 
   pushInput(
@@ -423,10 +469,7 @@ export class SdkSession {
     }
   }
 
-  private async consumeStream(): Promise<void> {
-    const q = this.query;
-    if (!q) return;
-
+  private async consumeStream(q: Query): Promise<void> {
     try {
       for await (const message of q) {
         this.captureSessionId(message);

--- a/plugins/provider-claude-code/src/proper-lockfile.d.ts
+++ b/plugins/provider-claude-code/src/proper-lockfile.d.ts
@@ -1,0 +1,27 @@
+declare module "proper-lockfile" {
+  export interface LockRetryOptions {
+    retries?: number;
+    factor?: number;
+    minTimeout?: number;
+    maxTimeout?: number;
+    randomize?: boolean;
+  }
+
+  export interface LockOptions {
+    realpath?: boolean;
+    retries?: number | LockRetryOptions;
+    stale?: number;
+    update?: number;
+    lockfilePath?: string;
+    onCompromised?: (error: Error) => void;
+  }
+
+  export type ReleaseFn = () => Promise<void>;
+
+  export function lock(file: string, options?: LockOptions): Promise<ReleaseFn>;
+
+  const lockfile: {
+    lock: typeof lock;
+  };
+  export default lockfile;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3448,6 +3448,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.3.6)
+      proper-lockfile:
+        specifier: ^4.1.2
+        version: 4.1.2
       zod:
         specifier: 4.3.6
         version: 4.3.6


### PR DESCRIPTION
## Human comments

## What was wrong

Separate bb Claude bridge workers could construct Agent SDK queries and run Claude's startup/auth initialization concurrently even when they resolved to the same credential store. Because Claude OAuth refresh credentials can rotate, that unnecessarily increases bb's exposure to the upstream concurrent-refresh race tracked in [anthropics/claude-code#88583](https://github.com/anthropics/claude-code/issues/88583).

## What changed

- Add a Claude-provider-owned, cross-process file-lock coordinator keyed by a SHA-256 digest of the effective credential scope: the canonical `CLAUDE_CONFIG_DIR`/default Claude config directory on Linux and Windows, or the macOS Claude Keychain scope.
- Hold that lock from Agent SDK query construction until `initializationResult()` settles (or the query ends first), for both thread sessions and the bridge model-discovery probe.
- Keep unrelated credential stores concurrent. Explicit API/token credentials and Bedrock, Vertex, or Foundry modes bypass this OAuth-store coordination.
- Heartbeat held locks and reclaim them after staleness so a crashed bridge worker cannot block future initialization indefinitely. Credential values and paths are not logged or used as lock filenames.

This serializes only bb-managed Claude startup/auth initialization among bridge workers sharing one host daemon's Claude-plugin data directory. It does not serialize ongoing work or later mid-session refreshes, standalone Claude CLI/Desktop processes, bridge workers belonging to another bb daemon data directory, explicit credential modes, or unrelated credential stores. It does not add general idle-session residency or auth-failure query eviction.

No host-daemon protocol or public plugin API changed, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

## How you verified

- Added a cross-process harness first. Before the coordinator implementation, its same-store test failed because the second worker entered the initialization section while the first still held it.
- The harness now verifies same-store serialization, independent-store concurrency, macOS Keychain scoping, explicit-credential bypass, and recovery after a lock holder is killed.
- Added an SDK-session test proving query construction waits for acquisition and the lock remains held through `initializationResult()`.
- `pnpm exec turbo run test --filter=bb-plugin-provider-claude-code --force` — 24 files, 342 tests passed.
- `pnpm exec turbo run typecheck --filter=bb-plugin-provider-claude-code --force` — 4 tasks passed.
- `bb plugin build plugins/provider-claude-code` — passed.
- `git diff --check origin/main...HEAD` — passed.

Related to [anthropics/claude-code#88583](https://github.com/anthropics/claude-code/issues/88583).

> AGENT GENERATED: by GPT-5
