### PR TITLE
Polish concurrency limit settings layout

### DIFF
--- a/plugins/concurrency-limit/app.test.tsx
+++ b/plugins/concurrency-limit/app.test.tsx
@@ -83,7 +83,7 @@ describe("Concurrency limit settings", () => {
     expect(
       slot.getByText("Auto uses half the available processors, up to 8."),
     ).toBeTruthy();
-    expect(slot.getByText("8 processors · Connected")).toBeTruthy();
+    expect(slot.getByText("8 processors")).toBeTruthy();
     expect(slot.getByText("Detect when connected")).toBeTruthy();
     expect(
       slot

--- a/plugins/concurrency-limit/app.tsx
+++ b/plugins/concurrency-limit/app.tsx
@@ -165,7 +165,7 @@ function ConcurrencyLimitSettings() {
       <div className="flex items-start justify-between gap-6">
         <div className="min-w-0">
           <h3 className="text-sm font-medium text-foreground">Overall limit</h3>
-          <p className="mt-1 text-xs text-muted-foreground">
+          <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
             Leave blank for no overall limit. Use 0 to pause new work.
           </p>
         </div>
@@ -191,21 +191,21 @@ function ConcurrencyLimitSettings() {
 
       <div className="border-t border-border/60 pt-4">
         <h3 className="text-sm font-medium text-foreground">Host limits</h3>
-        <p className="mt-1 text-xs text-muted-foreground">
+        <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
           Auto uses half the available processors, up to {MAX_AUTOMATIC_LIMIT}.
         </p>
 
-        <div className="mt-3 overflow-hidden rounded-md border border-border/60">
+        <div className="ml-2 mt-2 border-l border-border/60 pl-2">
           {view.hosts.length === 0 ? (
-            <p className="px-3 py-4 text-sm text-muted-foreground">
+            <p className="px-2 py-2 text-sm text-muted-foreground">
               No hosts available.
             </p>
           ) : (
-            <div className="divide-y divide-border/60">
+            <div className="space-y-1">
               {view.hosts.map((host) => (
                 <div
                   key={host.id}
-                  className="flex min-h-14 items-center gap-3 px-3 py-2"
+                  className="flex min-h-14 items-center gap-3 rounded-md px-2 py-2 hover:bg-accent/50"
                 >
                   <div className="min-w-0 flex-1">
                     <div className="truncate text-sm font-medium text-foreground">
@@ -216,11 +216,9 @@ function ConcurrencyLimitSettings() {
                         ? host.status === "connected"
                           ? "Detecting processors…"
                           : "Detect when connected"
-                        : `${host.availableParallelism} processors · ${
-                            host.status === "connected"
-                              ? "Connected"
-                              : "Offline"
-                          }`}
+                        : host.status === "connected"
+                          ? `${host.availableParallelism} processors`
+                          : `${host.availableParallelism} processors · Offline`}
                     </div>
                   </div>
                   <Input


### PR DESCRIPTION
## Human comments

## What was wrong

The concurrency-limit plugin rendered its machine overrides as a rounded, bordered list with a divider between every row inside BB's existing recessed plugin-settings surface. That locally recreated container made the page read as nested cards, while the per-row “Connected” suffix repeated information already implied by a detected processor count.

## What changed

The machine overrides now use the lighter built-in plugin treatment: spaced hoverable rows nested beneath Host limits with one subtle left hairline instead of another card and row dividers. Connected machines show only their processor count, while disconnected machines retain the useful “Offline” state. The existing frontend harness expectation was updated to match. This is frontend-only: no wire, CLI, guide, plugin API, settings contract, or concurrency-policy changes.

## How you verified

- `pnpm exec turbo run test --filter=bb-plugin-concurrency-limit --force -- --run app.test.tsx` — 3 frontend harness tests passed.
- `pnpm exec turbo run test --filter=bb-plugin-concurrency-limit --force` — 28 plugin tests passed.
- `pnpm exec turbo run typecheck --filter=bb-plugin-concurrency-limit --force` — passed.
- `env -u BB_CLI pnpm bb:dev plugin build plugins/concurrency-limit` — production server, app, CSS, and host artifacts built against Plugin SDK 0.4.33.
- Manually reviewed the settings page through the checkout-specific dev server and BB Connect share before cleanup.

Fixes #2810

> AGENT GENERATED
