### PR TITLE
Enable send plugins by default

### DIFF
--- a/apps/server/src/services/plugins/builtin-registry.ts
+++ b/apps/server/src/services/plugins/builtin-registry.ts
@@ -132,18 +132,13 @@ export const BUILTIN_PLUGINS = [
   {
     name: "scheduled-send",
     pluginId: "scheduled-send",
-    // Off by default: it adds a row to every thread composer's + menu, which
-    // is not a change to make on a user's behalf.
-    defaultEnabled: false,
+    defaultEnabled: true,
     category: "Workflow management",
   },
   {
     name: "concurrency-limit",
     pluginId: "concurrency-limit",
-    // Off by default: it hooks every thread create and follow-up send, so
-    // enabling it on a user's behalf would put a dispatch decision in the hot
-    // path of a server that never asked for admission control.
-    defaultEnabled: false,
+    defaultEnabled: true,
     category: "Workflow management",
   },
   {

--- a/apps/server/src/services/threads/dispatch-hooks.ts
+++ b/apps/server/src/services/threads/dispatch-hooks.ts
@@ -172,16 +172,6 @@ export function isDispatchRequeuedRecently(threadId: string): boolean {
  * checks this first: with no handler the dispatch path must be byte-for-byte
  * what it was before hooks existed — no lock, no context assembly, no queued
  * row.
- *
- * That is not a hypothetical — it is what a stock install actually does.
- * Exactly one bundled plugin answers the hook, `concurrency-limit`, and it
- * ships `defaultEnabled: false`; a disabled plugin never loads, so it never
- * reaches `listHooks`. (`provider-retry` ships enabled but answers no hook at
- * all: it listens for `turn.failed` and deliberately never intercepts a send,
- * because a remembered rate limit is a stale cache of provider state.) So on a
- * fresh install every send takes the untouched pre-hooks path, and a user pays
- * for admission control only by asking for it.
- * `builtin-plugins.test.ts` pins both halves.
  */
 export function hasMessageDispatchHooks(): boolean {
   const provider = pluginHookProvider();

--- a/apps/server/test/services/plugins/builtin-plugins.test.ts
+++ b/apps/server/test/services/plugins/builtin-plugins.test.ts
@@ -519,19 +519,20 @@ describe("builtin plugin reconciliation", () => {
     ]);
   });
 
-  it("ships the only message.dispatch hook disabled on a fresh database", async () => {
-    // `concurrency-limit` is the sole bundled plugin that answers the
-    // `message.dispatch` hook, and `provider-retry` only listens for the
-    // `turn.failed` event. So this flag is what makes
-    // `hasMessageDispatchHooks()` false on a stock install, which is what keeps
-    // every send on the untouched pre-hooks path. Flipping it to true would
-    // silently put a hook pass, and its server-wide evaluation lock, in front
-    // of every dispatch on every fresh machine.
+  it("ships Concurrency limit enabled on a fresh database", () => {
     const limiter = BUILTIN_PLUGINS.find(
       (builtin) => builtin.name === "concurrency-limit",
     );
     expect(limiter).toBeDefined();
-    expect(limiter?.defaultEnabled).toBe(false);
+    expect(limiter?.defaultEnabled).toBe(true);
+  });
+
+  it("ships Send later enabled on a fresh database", () => {
+    const scheduledSend = BUILTIN_PLUGINS.find(
+      (builtin) => builtin.name === "scheduled-send",
+    );
+    expect(scheduledSend).toBeDefined();
+    expect(scheduledSend?.defaultEnabled).toBe(true);
   });
 
   it("ships Provider retry enabled on a fresh database", async () => {

--- a/packages/bb-app/scripts/smoke-tarball.mjs
+++ b/packages/bb-app/scripts/smoke-tarball.mjs
@@ -24,6 +24,7 @@ const HOST_PLUGIN_WORKER_TIMEOUT_MS = 60_000;
 // every builtin unable to resolve @get-bb/plugin-sdk at import time).
 const EXPECTED_RUNNING_BUILTIN_PLUGINS = [
   "automations",
+  "concurrency-limit",
   // Providers whose bridge ships as a plugin artifact: if the plugin does not
   // load, its provider disappears from the install entirely.
   "provider-acp",
@@ -35,6 +36,7 @@ const EXPECTED_RUNNING_BUILTIN_PLUGINS = [
   "keep-awake",
   "pdf-preview",
   "provider-retry",
+  "scheduled-send",
   "secrets",
 ];
 // The smoke drives every bridge as a canonical Provider Bridge Protocol


### PR DESCRIPTION
## Human comments

## What was wrong

The bundled scheduled-send and concurrency-limit plugins were marked disabled by default, so fresh installations omitted the built-in Send later workflow and concurrency admission controls even though both plugins ship with the app. The hook-path documentation and packaged-app smoke inventory encoded those old defaults.

## What changed

- Enable scheduled-send and concurrency-limit by default for fresh plugin reconciliation.
- Preserve existing installations because reconciliation continues to prefer each installed plugin record’s explicit enabled state.
- Remove stale documentation that described concurrency-limit as disabled on stock installs.
- Update registry tests and packaged-app smoke expectations for both running built-ins.
- No host-daemon protocol, CLI, guide, or public Plugin SDK changes.

## How you verified

- Added registry expectations for both fresh-install defaults; the new expectations fail against the previous defaults and pass after this change.
- pnpm exec turbo run test --filter=@bb/server --force -- --run test/services/plugins/builtin-plugins.test.ts test/threads/dispatch-hooks.test.ts — 40 tests passed after rebasing.
- pnpm exec turbo run typecheck --filter=@bb/server --filter=bb-app --force — passed after rebasing.
- Production builds for both bundled plugins passed.
- git diff --check passed.

> AGENT GENERATED