### PR TITLE
fix: queue steers while turns start

### DIFF
--- a/apps/app/src/lib/queued-message-wait.test.ts
+++ b/apps/app/src/lib/queued-message-wait.test.ts
@@ -47,6 +47,9 @@ describe("describeQueuedMessageWait", () => {
   });
 
   it("names each core wait a reader cannot otherwise explain", () => {
+    expect(describeWait({ kind: "turn-starting" })).toBe(
+      "Waiting for turn to start",
+    );
     expect(describeWait({ kind: "provisioning" })).toBe(
       "Waiting for workspace",
     );
@@ -151,6 +154,7 @@ describe("queuedMessageWaitIcon", () => {
       });
 
     expect(icon({ kind: "time" })).toBe("TimeSchedule");
+    expect(icon({ kind: "turn-starting" })).toBe("TimeSchedule");
     expect(icon({ kind: "provisioning" })).toBe("Folder");
     expect(icon({ kind: "host-offline", hostName: "M4" })).toBe("CloudOff");
     expect(icon({ kind: "interaction" })).toBe("CircleQuestion");
@@ -206,6 +210,9 @@ describe("isQueuedMessageSendNowAllowed", () => {
       }),
     ).toBe(true);
     expect(isQueuedMessageSendNowAllowed({ kind: "thread-busy" })).toBe(true);
+    expect(isQueuedMessageSendNowAllowed({ kind: "turn-starting" })).toBe(
+      false,
+    );
     expect(isQueuedMessageSendNowAllowed(null)).toBe(true);
     expect(isQueuedMessageSendNowAllowed({ kind: "provisioning" })).toBe(false);
     expect(isQueuedMessageSendNowAllowed({ kind: "interaction" })).toBe(false);

--- a/apps/app/src/lib/queued-message-wait.ts
+++ b/apps/app/src/lib/queued-message-wait.ts
@@ -30,6 +30,7 @@ export function isQueuedMessageSendNowAllowed(
     case "provisioning":
     case "host-offline":
     case "interaction":
+    case "turn-starting":
       return false;
     case "time":
     case "plugin":
@@ -60,6 +61,8 @@ export function queuedMessageWaitIcon(args: {
   switch (args.waitingOn.kind) {
     case "thread-busy":
       return null;
+    case "turn-starting":
+      return "TimeSchedule";
     case "time":
       return "TimeSchedule";
     case "provisioning":
@@ -120,6 +123,8 @@ export function describeQueuedMessageWait(
   switch (args.waitingOn.kind) {
     case "thread-busy":
       return null;
+    case "turn-starting":
+      return "Waiting for turn to start";
     case "time":
       return args.sendAt === null
         ? "Scheduled"

--- a/apps/cli/src/commands/thread/actions.ts
+++ b/apps/cli/src/commands/thread/actions.ts
@@ -441,7 +441,10 @@ export function registerActionsCommands(
       "Reasoning level: low, medium, high, xhigh, max (provider-dependent)",
     )
     .option("--permission-mode <mode>", PERMISSION_MODE_HELP)
-    .option("--mode <mode>", "Message mode: steer (default), queue, or auto")
+    .option(
+      "--mode <mode>",
+      "Message mode: steer (default), queue, or auto (steer a live turn, else start one)",
+    )
     .option("--send-at <when>", SEND_AT_HELP)
     .option("--plan", PLAN_HELP)
     .option(
@@ -642,6 +645,8 @@ export function describeQueueWait(row: {
         : `scheduled for ${new Date(row.sendAt).toLocaleString()}`;
     case "thread-busy":
       return "waiting for the current turn to finish";
+    case "turn-starting":
+      return "waiting for the current turn to start";
     case "provisioning":
       return "waiting for the workspace";
     case "host-offline":

--- a/apps/server/src/internal/events.ts
+++ b/apps/server/src/internal/events.ts
@@ -4,6 +4,7 @@ import {
   deriveStoredEventItemFields,
   getThread,
   listCompletedTurnsByThreadIds,
+  listQueuedThreadMessagesWaitingOnKind,
   listThreadEnvironmentAssignmentsOnHost,
   MissingStoredTurnStartedError,
   events as storedEvents,
@@ -39,7 +40,10 @@ import {
 } from "../services/system/event-pruning.js";
 import { queueChildThreadTurnNotificationBestEffort } from "../services/threads/child-thread-notifications.js";
 import { isParentNotifiableChildThread } from "../services/threads/thread-parent.js";
-import { runQueuedMessageAutoSendForThread } from "../services/threads/queued-messages.js";
+import {
+  runQueuedMessageAutoSendForThread,
+  sendQueuedMessage,
+} from "../services/threads/queued-messages.js";
 import { deferAfterResponse } from "../services/lib/response-deferral.js";
 import {
   isCommandTimeoutError,
@@ -194,9 +198,16 @@ interface QueuedMessageAutoSendFollowUp {
   threadId: string;
 }
 
+interface TurnStartingQueuedMessagesFollowUp {
+  kind: "turn-starting-queued-messages";
+  queuedMessageIds: string[];
+  threadId: string;
+}
+
 type EventEffectFollowUp =
   | ParentTurnNotificationFollowUp
-  | QueuedMessageAutoSendFollowUp;
+  | QueuedMessageAutoSendFollowUp
+  | TurnStartingQueuedMessagesFollowUp;
 
 function isRootTurnStartedEvent(
   event: Extract<HostDaemonEventEnvelope["event"], { type: "turn/started" }>,
@@ -358,10 +369,24 @@ async function applyEventEffects(
         ) {
           continue;
         }
-        if (hasThreadAlreadyStartedRun(deps, entry.threadId)) {
+        if (!isRootTurnStartedEvent(event)) {
           continue;
         }
-        if (!isRootTurnStartedEvent(event)) {
+        const queuedMessageIds = listQueuedThreadMessagesWaitingOnKind(
+          deps.db,
+          {
+            kind: "turn-starting",
+            threadId: entry.threadId,
+          },
+        ).map((row) => row.id);
+        if (queuedMessageIds.length > 0) {
+          followUps.push({
+            kind: "turn-starting-queued-messages",
+            queuedMessageIds,
+            threadId: entry.threadId,
+          });
+        }
+        if (hasThreadAlreadyStartedRun(deps, entry.threadId)) {
           continue;
         }
         applyLoggedThreadLifecycleEvent(deps, {
@@ -483,6 +508,27 @@ async function executeEventFollowUpBestEffort(
         await runQueuedMessageAutoSendForThread(deps, {
           threadId: followUp.threadId,
         });
+        return;
+      case "turn-starting-queued-messages":
+        for (const queuedMessageId of followUp.queuedMessageIds) {
+          try {
+            await sendQueuedMessage(deps, {
+              mode: "auto",
+              queuedMessageId,
+              sendNow: false,
+              threadId: followUp.threadId,
+            });
+          } catch (error) {
+            deps.logger.warn(
+              {
+                queuedMessageId,
+                threadId: followUp.threadId,
+                ...runtimeErrorLogFields(deps.config, error),
+              },
+              "Failed to dispatch a message waiting for its turn to start",
+            );
+          }
+        }
         return;
     }
   } catch (error) {

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/references/thread-operation.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/references/thread-operation.md
@@ -71,6 +71,9 @@
   agent can finish its current work first. Steer is especially important for a
   wrong direction, hard stop, or critical clarification.
   Example: `bb thread tell <thread-id> "Stop and use approach B" --mode steer`.
+- Input sent while a turn is starting stays queued with
+  `waitingOn.kind: "turn-starting"`. The `turn/started` event wakes it and
+  steers it into that turn. Do not resend it.
 - If the target thread is awaiting user interaction (an open question or
   approval), `bb thread tell` cannot interrupt it. The message joins the
   thread's queue with `waitingOn.kind: "interaction"` and dispatches once the

--- a/apps/server/src/services/threads/dispatch-attempt.ts
+++ b/apps/server/src/services/threads/dispatch-attempt.ts
@@ -43,7 +43,7 @@ import {
 } from "./queue-waits.js";
 import { applyLoggedThreadLifecycleEventInTransaction } from "./lifecycle-outcome.js";
 import { buildExecutionOptions } from "./thread-commands.js";
-import { isManualCompactionActive } from "./thread-events.js";
+import { getActiveTurnId, isManualCompactionActive } from "./thread-events.js";
 import { requireThreadCommandEnvironment } from "./thread-command-environment.js";
 import {
   advanceThreadProvisioning,
@@ -326,6 +326,14 @@ async function runDispatchAttempt(
   }
   if (payload.mode !== "start" && isManualCompactionActive(deps, thread)) {
     return waitOn({ kind: "thread-busy" }, null);
+  }
+  const currentThread = getThread(deps.db, thread.id);
+  if (
+    currentThread?.status === "active" &&
+    resolveDispatchAttemptKind(currentThread, payload.mode) === "join-turn" &&
+    getActiveTurnId(deps, thread.id) === null
+  ) {
+    return waitOn({ kind: "turn-starting" }, null);
   }
   if (!firstDispatch && isPreStartThreadStatus(thread.status)) {
     // A follow-up or steer sent while the workspace is being (re)provisioned.

--- a/apps/server/src/services/threads/parent-system-messages.ts
+++ b/apps/server/src/services/threads/parent-system-messages.ts
@@ -46,6 +46,7 @@ import {
   LIVE_DAEMON_COMMAND_TIMEOUT_MS,
   startLiveHostCommand,
 } from "../hosts/live-command.js";
+import { queueInputForStartingTurn } from "./thread-turn-starting.js";
 
 const PARENT_SYSTEM_MESSAGE_SOURCE = "tell";
 
@@ -243,6 +244,22 @@ async function queueActiveParentSystemMessage(
   args: QueueReadyParentSystemMessageArgs,
 ): Promise<boolean> {
   const expectedSteerTurnId = getActiveTurnId(deps, args.thread.id);
+  if (expectedSteerTurnId === null) {
+    queueInputForStartingTurn(deps, {
+      input: {
+        content: args.input,
+        execution: args.execution,
+        payload: { kind: "inline" },
+        senderThreadId: null,
+        systemNotice: {
+          kind: args.systemMessageKind,
+          subject: args.systemMessageSubject,
+        },
+      },
+      threadId: args.thread.id,
+    });
+    return true;
+  }
   const permissionEscalation = resolvePermissionEscalation({
     initiator: "system",
   });

--- a/apps/server/src/services/threads/queued-messages.ts
+++ b/apps/server/src/services/threads/queued-messages.ts
@@ -701,6 +701,8 @@ function describeCoreWait(waitingOn: QueuedMessageWaitingOn | null): string {
       return `the "${waitingOn.hostName}" host is not connected`;
     case "interaction":
       return "the thread is waiting for you to answer a pending interaction";
+    case "turn-starting":
+      return "the current turn is still starting";
     case "plugin":
       return `it is waiting on the "${waitingOn.pluginId}" plugin`;
     case "time":

--- a/apps/server/src/services/threads/thread-turn-starting.ts
+++ b/apps/server/src/services/threads/thread-turn-starting.ts
@@ -1,0 +1,54 @@
+import { createQueuedThreadMessageInTransaction, getThread } from "@bb/db";
+import type {
+  PromptInput,
+  QueuedMessagePayload,
+  QueuedMessageSystemNotice,
+  ResolvedThreadExecutionOptions,
+} from "@bb/domain";
+import type { AppDeps } from "../../types.js";
+import { emitPluginMessageQueued } from "../plugins/plugin-thread-events.js";
+import { toThreadQueuedMessage } from "./thread-queued-messages.js";
+
+interface TurnStartingQueuedInput {
+  content: PromptInput[];
+  execution: ResolvedThreadExecutionOptions;
+  payload: QueuedMessagePayload;
+  senderThreadId: string | null;
+  systemNotice: QueuedMessageSystemNotice | null;
+}
+
+type TurnStartingDeps = Pick<AppDeps, "db" | "hub" | "logger">;
+
+export function queueInputForStartingTurn(
+  deps: TurnStartingDeps,
+  args: { input: TurnStartingQueuedInput; threadId: string },
+): void {
+  if (args.input.content.length === 0) return;
+  const queued = deps.db.transaction(
+    (tx) => {
+      const thread = getThread(tx, args.threadId);
+      if (!thread || thread.deletedAt !== null) return null;
+      return createQueuedThreadMessageInTransaction(tx, {
+        threadId: args.threadId,
+        content: args.input.content,
+        senderThreadId: args.input.senderThreadId,
+        model: args.input.execution.model,
+        reasoningLevel: args.input.execution.reasoningLevel,
+        permissionMode: args.input.execution.permissionMode,
+        serviceTier: args.input.execution.serviceTier,
+        waitingOn: { kind: "turn-starting" },
+        sendAt: null,
+        payload: args.input.payload,
+        systemNotice: args.input.systemNotice,
+      });
+    },
+    { behavior: "immediate" },
+  );
+  if (queued === null) return;
+  emitPluginMessageQueued(toThreadQueuedMessage(queued));
+  deps.hub.notifyThread(args.threadId, ["queue-changed"]);
+  deps.logger.info(
+    { queuedMessageId: queued.id, threadId: args.threadId },
+    "Queued input until the current turn starts",
+  );
+}

--- a/apps/server/test/public/public-thread-fork.test.ts
+++ b/apps/server/test/public/public-thread-fork.test.ts
@@ -460,6 +460,15 @@ describe("public thread fork route", () => {
       if (firstTurn.command.type !== "turn.submit") {
         throw new Error("Expected turn.submit");
       }
+      const lastSequence =
+        listEvents(harness.db, { threadId: fork.id }).at(-1)?.sequence ?? 0;
+      seedTurnStarted(harness.deps, {
+        environmentId: fork.environmentId,
+        providerThreadId: "provider-started-seeded-fork",
+        sequence: lastSequence + 1,
+        threadId: fork.id,
+        turnId: "turn-started-seeded-fork",
+      });
       const rapidInput = textInput("Rapid follow-up");
       const rapidResponse = await harness.app.request(
         `/api/v1/threads/${fork.id}/send`,
@@ -481,15 +490,6 @@ describe("public thread fork route", () => {
           command.type === "turn.submit" && command.threadId === fork.id,
       );
       expect(rapidTurn.command).toMatchObject({ input: rapidInput });
-      const lastSequence =
-        listEvents(harness.db, { threadId: fork.id }).at(-1)?.sequence ?? 0;
-      seedTurnStarted(harness.deps, {
-        environmentId: fork.environmentId,
-        providerThreadId: "provider-started-seeded-fork",
-        sequence: lastSequence + 1,
-        threadId: fork.id,
-        turnId: "turn-started-seeded-fork",
-      });
       await reportQueuedCommandError(harness, firstTurn, {
         errorCode: "provider_error",
         errorMessage: "Provider turn failed after starting",

--- a/apps/server/test/threads/dispatch-hooks.test.ts
+++ b/apps/server/test/threads/dispatch-hooks.test.ts
@@ -490,7 +490,7 @@ describe("message.dispatch hook admission visibility", () => {
         },
       });
       installHooks(registry);
-      const { thread } = seedRunnableThread(harness, {
+      const { environment, thread } = seedRunnableThread(harness, {
         hostId: "host-warm-admission",
         status: "idle",
       });
@@ -507,6 +507,12 @@ describe("message.dispatch hook admission visibility", () => {
       expect(listRunningThreads(harness.db).map((row) => row.id)).toEqual([
         thread.id,
       ]);
+      seedTurnStarted(harness.deps, {
+        environmentId: environment.id,
+        providerThreadId: "provider-host-warm-admission",
+        threadId: thread.id,
+        turnId: "turn-host-warm-admission",
+      });
 
       await acceptThreadSendRequest(harness.deps, {
         payload: { input: textInput("a steer"), mode: "steer" },

--- a/apps/server/test/threads/thread-send-dispatch.test.ts
+++ b/apps/server/test/threads/thread-send-dispatch.test.ts
@@ -13,12 +13,16 @@ import {
   type Thread,
   type ThreadChangedMessage,
 } from "@bb/domain";
+import { groupHostDaemonEvents } from "@bb/host-daemon-contract";
 import { describe, expect, it, vi } from "vitest";
 import type { TelemetryService } from "../../src/services/system/telemetry.js";
 import { sendQueuedMessage } from "../../src/services/threads/queued-messages.js";
+import { queueParentSystemMessage } from "../../src/services/threads/parent-system-messages.js";
+import { acceptThreadSendRequest } from "../../src/services/threads/thread-send-request.js";
 import { handleUpdateEnvironmentDirectoryToolCall } from "../../src/services/threads/thread-environment-directory.js";
 import { sendThreadMessage } from "../../src/services/threads/thread-send.js";
 import {
+  internalAuthHeaders,
   listQueuedThreadCommands,
   reportQueuedCommandError,
   waitForQueuedCommand,
@@ -39,6 +43,7 @@ import { withTestHarness, type TestAppHarness } from "../helpers/test-app.js";
 
 interface IdleThreadFixture {
   environment: Environment;
+  sessionId: string;
   thread: Thread;
 }
 
@@ -54,7 +59,7 @@ interface SeedProviderThreadFixtureArgs extends SeedIdleThreadFixtureArgs {
 function seedProviderThreadFixture(
   args: SeedProviderThreadFixtureArgs,
 ): IdleThreadFixture {
-  const { host } = seedHostSession(args.harness.deps, {
+  const { host, session } = seedHostSession(args.harness.deps, {
     id: `host-send-dispatch-${args.value}`,
   });
   const { project } = seedProjectWithSource(args.harness.deps, {
@@ -78,13 +83,13 @@ function seedProviderThreadFixture(
     threadId: thread.id,
   });
 
-  return { environment, thread };
+  return { environment, sessionId: session.id, thread };
 }
 
 function seedColdIdleThreadFixture(
   args: SeedIdleThreadFixtureArgs,
 ): IdleThreadFixture {
-  const { host } = seedHostSession(args.harness.deps, {
+  const { host, session } = seedHostSession(args.harness.deps, {
     id: `host-send-dispatch-${args.value}`,
   });
   const { project } = seedProjectWithSource(args.harness.deps, {
@@ -103,7 +108,7 @@ function seedColdIdleThreadFixture(
     status: "idle",
   });
 
-  return { environment, thread };
+  return { environment, sessionId: session.id, thread };
 }
 
 function installTelemetryCaptureSpy(harness: TestAppHarness) {
@@ -291,6 +296,196 @@ describe("user message telemetry", () => {
       });
 
       expect(capture).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("turn-starting queue wait", () => {
+  it("parks a steer until turn/started and then steers it into that turn", async () => {
+    await withTestHarness(async (harness) => {
+      const { sessionId, thread } = seedProviderThreadFixture({
+        harness,
+        status: "active",
+        value: 6,
+      });
+      const input = textInput("steer when ready");
+      const secondInput = textInput("also steer when ready");
+
+      await expect(
+        acceptThreadSendRequest(harness.deps, {
+          payload: {
+            input,
+            mode: "steer",
+            model: "gpt-5",
+            permissionMode: "full",
+            reasoningLevel: "medium",
+            serviceTier: "default",
+          },
+          thread,
+        }),
+      ).resolves.toMatchObject({
+        delivery: "queued",
+        waitingOn: { kind: "turn-starting" },
+      });
+      await expect(
+        acceptThreadSendRequest(harness.deps, {
+          payload: {
+            input: secondInput,
+            mode: "auto",
+            model: "gpt-5",
+            permissionMode: "full",
+            reasoningLevel: "medium",
+            serviceTier: "default",
+          },
+          thread,
+        }),
+      ).resolves.toMatchObject({
+        delivery: "queued",
+        waitingOn: { kind: "turn-starting" },
+      });
+      expect(
+        listQueuedThreadCommands(harness, "turn.submit", thread.id),
+      ).toHaveLength(0);
+
+      expect(
+        listQueuedThreadMessages(harness.db, thread.id).map((row) => ({
+          content: JSON.parse(row.content),
+          waitingOn: JSON.parse(row.waitingOn!),
+        })),
+      ).toEqual([
+        { content: input, waitingOn: { kind: "turn-starting" } },
+        { content: secondInput, waitingOn: { kind: "turn-starting" } },
+      ]);
+      const busy = seedQueuedMessage(harness.deps, {
+        content: textInput("wait for idle"),
+        threadId: thread.id,
+        waitingOn: { kind: "thread-busy" },
+      });
+
+      const response = await harness.app.request("/internal/session/events", {
+        method: "POST",
+        headers: internalAuthHeaders(harness),
+        body: JSON.stringify({
+          sessionId,
+          eventGroups: groupHostDaemonEvents([
+            {
+              threadId: thread.id,
+              event: {
+                type: "turn/started",
+                threadId: thread.id,
+                providerThreadId: "provider-send-dispatch-6",
+                scope: turnScope("turn-ready"),
+              },
+            },
+          ]),
+        }),
+      });
+      expect(response.status).toBe(200);
+
+      await vi.waitFor(() => {
+        expect(
+          listQueuedThreadCommands(harness, "turn.submit", thread.id),
+        ).toHaveLength(2);
+      });
+      expect(
+        listQueuedThreadCommands(harness, "turn.submit", thread.id),
+      ).toEqual([
+        expect.objectContaining({
+          input,
+          target: { mode: "auto", expectedTurnId: "turn-ready" },
+        }),
+        expect.objectContaining({
+          input: secondInput,
+          target: { mode: "auto", expectedTurnId: "turn-ready" },
+        }),
+      ]);
+      expect(
+        listQueuedThreadMessages(harness.db, thread.id).map((row) => row.id),
+      ).toEqual([busy.id]);
+      expect(
+        JSON.parse(
+          listQueuedThreadMessages(harness.db, thread.id)[0]!.waitingOn!,
+        ),
+      ).toEqual({ kind: "thread-busy" });
+    });
+  });
+
+  it("parks a parent system notice with its taxonomy while a turn starts", async () => {
+    await withTestHarness(async (harness) => {
+      const { sessionId, thread } = seedProviderThreadFixture({
+        harness,
+        status: "active",
+        value: 62,
+      });
+      const input = textInput("child finished");
+
+      await expect(
+        queueParentSystemMessage(harness.deps, {
+          input,
+          parentThreadId: thread.id,
+          systemMessageKind: "child-completed",
+          systemMessageSubject: {
+            kind: "thread",
+            threadId: "child-1",
+            threadName: "Child",
+          },
+        }),
+      ).resolves.toBe(true);
+
+      expect(
+        listQueuedThreadCommands(harness, "turn.submit", thread.id),
+      ).toHaveLength(0);
+      const parked = listQueuedThreadMessages(harness.db, thread.id)[0]!;
+      expect(JSON.parse(parked.content)).toEqual(input);
+      expect(JSON.parse(parked.waitingOn!)).toEqual({
+        kind: "turn-starting",
+      });
+      expect(JSON.parse(parked.systemNotice!)).toEqual({
+        kind: "child-completed",
+        subject: {
+          kind: "thread",
+          threadId: "child-1",
+          threadName: "Child",
+        },
+      });
+
+      const response = await harness.app.request("/internal/session/events", {
+        method: "POST",
+        headers: internalAuthHeaders(harness),
+        body: JSON.stringify({
+          sessionId,
+          eventGroups: groupHostDaemonEvents([
+            {
+              threadId: thread.id,
+              event: {
+                type: "turn/started",
+                threadId: thread.id,
+                providerThreadId: "provider-send-dispatch-62",
+                scope: turnScope("turn-system-notice-ready"),
+              },
+            },
+          ]),
+        }),
+      });
+      expect(response.status).toBe(200);
+
+      await vi.waitFor(() => {
+        expect(
+          listQueuedThreadCommands(harness, "turn.submit", thread.id),
+        ).toHaveLength(1);
+      });
+      expect(
+        listQueuedThreadCommands(harness, "turn.submit", thread.id),
+      ).toEqual([
+        expect.objectContaining({
+          input,
+          target: {
+            mode: "auto",
+            expectedTurnId: "turn-system-notice-ready",
+          },
+        }),
+      ]);
+      expect(listQueuedThreadMessages(harness.db, thread.id)).toEqual([]);
     });
   });
 });

--- a/packages/db/test/data/queued-message-waits.test.ts
+++ b/packages/db/test/data/queued-message-waits.test.ts
@@ -383,6 +383,7 @@ describe("wait lookups", () => {
     for (const kind of [
       "time",
       "thread-busy",
+      "turn-starting",
       "provisioning",
       "interaction",
       "plugin",

--- a/packages/domain/src/plugin-sdk-version.ts
+++ b/packages/domain/src/plugin-sdk-version.ts
@@ -1,3 +1,3 @@
-export const PLUGIN_SDK_VERSION = "0.4.33";
+export const PLUGIN_SDK_VERSION = "0.4.34";
 
 export const PLUGIN_SDK_MAJOR = Number(PLUGIN_SDK_VERSION.split(".", 1)[0]);

--- a/packages/domain/src/queued-message.ts
+++ b/packages/domain/src/queued-message.ts
@@ -48,6 +48,7 @@ import {
 export const queuedMessageWaitingOnKindValues = [
   "time",
   "thread-busy",
+  "turn-starting",
   "provisioning",
   "host-offline",
   "interaction",
@@ -80,6 +81,7 @@ export const queuedMessageWaitReasonSchema = z
 export const queuedMessageWaitingOnSchema = z.discriminatedUnion("kind", [
   z.object({ kind: z.literal("time") }),
   z.object({ kind: z.literal("thread-busy") }),
+  z.object({ kind: z.literal("turn-starting") }),
   z.object({ kind: z.literal("provisioning") }),
   z.object({
     kind: z.literal("host-offline"),
@@ -214,5 +216,3 @@ export const queuedMessageSystemNoticeSchema = z.object({
 export type QueuedMessageSystemNotice = z.infer<
   typeof queuedMessageSystemNoticeSchema
 >;
-
-

--- a/packages/plugin-api-map/sdk-public-api.json
+++ b/packages/plugin-api-map/sdk-public-api.json
@@ -3,7 +3,7 @@
   "entries": {
     ".": {
       "types": "bundled-types/bb-plugin-sdk.d.ts",
-      "sha256": "dc8088c81e6bd9487563bbc24ed8b7729b88a215a27603048c5703c9c7554700"
+      "sha256": "57c76534333fe579bcce5d5e949b4cb2c9a690a73ad17f0663d7179f8be54583"
     },
     "./ai-services": {
       "types": "bundled-types/bb-plugin-sdk-ai-services.d.ts",

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@get-bb/plugin-sdk",
-  "version": "0.4.33",
+  "version": "0.4.34",
   "homepage": "https://github.com/get-bb/bb#readme",
   "bugs": {
     "url": "https://github.com/get-bb/bb/issues"

--- a/packages/plugin-sdk/src/backend-contract.ts
+++ b/packages/plugin-sdk/src/backend-contract.ts
@@ -245,7 +245,8 @@ export interface PluginThreadEventPayloads {
   /**
    * Fired after a dispatch attempt is queued as a row — by a `message.dispatch`
    * hook's `wait` decision, by a `sendAt` in the future, or by a core wait (the
-   * thread is busy, provisioning, or awaiting an interaction).
+   * thread is busy, its turn is still starting, provisioning, or awaiting an
+   * interaction).
    *
    * Every listener sees every queued row, not just the ones it is holding: an
    * observer that only wants its own filters on

--- a/packages/templates/src/templates/bb-guide-threads.md
+++ b/packages/templates/src/templates/bb-guide-threads.md
@@ -208,7 +208,10 @@ Messaging:
 
   Tell steers by default, delivering the message immediately into the active
   turn. Use --mode queue for non-urgent follow-ups that can wait until the agent
-  is free. A target that is awaiting user interaction (an open question or
+  is free; --mode auto steers a live turn and starts a new one on an idle
+  thread. Input sent while a turn is starting stays in the queue with
+  `waitingOn: turn-starting`; `turn/started` wakes it and steers it into that
+  turn. A target that is awaiting user interaction (an open question or
   approval) cannot take a prompt; tell then adds the message to the thread's
   queue and dispatches it once the interaction settles. That outcome is not a
   failure, so do not resend. `--json` reports `delivery` as `sent` or `queued`,


### PR DESCRIPTION
## Human comments

## What was wrong

The server marks a thread active when its first turn is accepted, before the provider's root `turn/started` event records the active turn id. An immediate `steer`, `steer-if-active`, or active-thread `auto` send therefore tried to submit while startup was still in flight. The daemon could reject it as a competing turn, and the follow-up was not reliably delivered. The existing `thread-busy` wait cannot represent this state because it intentionally waits for the current turn to finish and dispatches the message as a later turn.

## What changed

- Added the distinct persisted queue wait `waitingOn.kind: "turn-starting"` for join-turn sends against an active thread that has no recorded root turn id yet.
- Root `turn/started` events wake those rows in queue order and re-attempt them as steers into the newly identified turn. Ordinary `thread-busy` rows remain untouched and continue waiting for the turn to finish.
- Parent system notices use the same startup wait while preserving their execution settings and system-message taxonomy.
- Added the queue label, icon, Send-now restriction, CLI description, built-in bb-cli skill guidance, and thread guide documentation.
- Added regressions for multiple ordered startup steers, the real event wakeup, separation from `thread-busy`, and parent-system-message delivery. Updated older fixtures that previously modeled a live steer without recording `turn/started`.
- Bumped the Plugin SDK to `0.4.34` and refreshed its public API inventory because the queued-message DTO exposes the new wait kind.
- No host-daemon wire contract changed, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged. The solution is provider-agnostic and adds no Pi-specific behavior or held daemon command.

This covers the startup-race portion investigated in closed PR #2417 with a server-owned persistent queue. It does not port #2417's separate provider-busy/compaction refusal handling.

## How you verified

On the final rebase against `origin/main` (`026572964`):

- `pnpm exec turbo run test typecheck --filter=@get-bb/plugin-sdk --filter=@bb/plugin-api-map --filter=@bb/app --filter=bb-plugin-plugin-api-docs` — 11/11 tasks passed; the app suite passed 3,688 tests and the Plugin Guide suite passed 74 tests.
- `pnpm exec turbo run test --filter=@bb/server --force -- test/threads/thread-send-dispatch.test.ts test/threads/dispatch-hooks.test.ts test/public/public-thread-fork.test.ts` — 43/43 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/server --filter=@bb/domain --filter=@bb/db --filter=@bb/cli --filter=@bb/templates` — 8/8 tasks passed.
- `bb plugin build plugins/plugin-api-docs` — backend and app artifacts built successfully.
- Plugin SDK version guard and `git diff --check` passed.
- Manual QA with `sawyerhood/dev-browser` rendered a real queued row showing `Waiting for turn to start`, with the thread still working and Send now unavailable.

Related to #2370

> AGENT GENERATED
