### PR TITLE
Show Offline when host capacity is unknown

### DIFF
--- a/plugins/concurrency-limit/app.test.tsx
+++ b/plugins/concurrency-limit/app.test.tsx
@@ -84,7 +84,7 @@ describe("Concurrency limit settings", () => {
       slot.getByText("Auto uses half the available processors, up to 8."),
     ).toBeTruthy();
     expect(slot.getByText("8 processors")).toBeTruthy();
-    expect(slot.getByText("Detect when connected")).toBeTruthy();
+    expect(slot.getByText("Offline")).toBeTruthy();
     expect(
       slot
         .getByRole("spinbutton", { name: "Laptop thread limit" })

--- a/plugins/concurrency-limit/app.tsx
+++ b/plugins/concurrency-limit/app.tsx
@@ -212,13 +212,13 @@ function ConcurrencyLimitSettings() {
                       {host.name}
                     </div>
                     <div className="text-xs text-muted-foreground">
-                      {host.availableParallelism === null
-                        ? host.status === "connected"
+                      {host.status === "disconnected"
+                        ? host.availableParallelism === null
+                          ? "Offline"
+                          : `${host.availableParallelism} processors · Offline`
+                        : host.availableParallelism === null
                           ? "Detecting processors…"
-                          : "Detect when connected"
-                        : host.status === "connected"
-                          ? `${host.availableParallelism} processors`
-                          : `${host.availableParallelism} processors · Offline`}
+                          : `${host.availableParallelism} processors`}
                     </div>
                   </div>
                   <Input


### PR DESCRIPTION
## Human comments

## What was wrong

PR #2811 simplified concurrency-limit host status copy by branching on processor capacity before connection state. For a disconnected host with no cached availableParallelism value, that ordering rendered “Detect when connected” even though the host was already known to be offline.

## What changed

- Give disconnected status precedence over processor-capacity wording in the concurrency-limit settings row.
- Keep the polished layout and all connected/cached-capacity wording unchanged.
- Update the focused frontend regression to require “Offline” for a disconnected host with unknown capacity.
- No host-daemon protocol, CLI, guide, or public Plugin SDK changes.

## How you verified

- The focused regression reproduced the old “Detect when connected” result before the implementation and passes afterward.
- pnpm exec turbo run test typecheck --filter=bb-plugin-concurrency-limit --force — 28 tests passed and typecheck passed after rebasing.
- env -u BB_CLI pnpm bb:dev plugin build plugins/concurrency-limit — production server, app, CSS, and host artifacts built successfully.
- Formatting and git diff checks passed.

Fixes #2810

> AGENT GENERATED