### PR TITLE
Preserve execution models through initial thread dispatch

### DIFF
--- a/apps/server/src/services/threads/dispatch-attempt.ts
+++ b/apps/server/src/services/threads/dispatch-attempt.ts
@@ -669,5 +669,12 @@ function resolveExecutionIntoPayload(
     reasoningLevel: execution.reasoningLevel,
     serviceTier: execution.serviceTier,
     permissionMode: execution.permissionMode,
+    executionInputSources: {
+      ...(payload.executionInputSources ?? {}),
+      model: "explicit",
+      reasoningLevel: "explicit",
+      serviceTier: "explicit",
+      permissionMode: "explicit",
+    },
   };
 }

--- a/apps/server/src/services/threads/thread-create.ts
+++ b/apps/server/src/services/threads/thread-create.ts
@@ -445,13 +445,16 @@ async function createPendingThreadAndAttemptFirstDispatch(
         sourceThreadId: args.fork.sourceThreadId,
       });
     }
-    execution = await buildExecutionOptions(deps, args.request, {
-      ...(args.executionDefaults
-        ? { projectDefaults: args.executionDefaults }
-        : {}),
+    const executionPlanArgs = {
+      projectDefaults: args.executionDefaults,
       hostId: intentHostId(deps, args.environmentIntent),
       threadId: thread.id,
-    });
+    };
+    execution = await buildExecutionOptions(
+      deps,
+      args.request,
+      executionPlanArgs,
+    );
 
     const startContext: PendingThreadStartContext = {
       environmentIntent: args.environmentIntent,
@@ -488,6 +491,7 @@ async function createPendingThreadAndAttemptFirstDispatch(
       source: { kind: "inline" },
       queuePayload: { kind: "inline" },
       startContext,
+      executionDefaults: executionPlanArgs,
       origin: args.request.origin,
       originPluginId: args.request.originPluginId ?? null,
       startedOnBehalfOf: args.request.startedOnBehalfOf,

--- a/apps/server/test/public/public-threads.defaults.test.ts
+++ b/apps/server/test/public/public-threads.defaults.test.ts
@@ -409,6 +409,79 @@ describe("public thread default routes", () => {
     });
   });
 
+  it("creates from displayed execution values when only the provider has a client source", async () => {
+    await withTestHarness(async (harness) => {
+      const { host, session } = seedHostSession(harness.deps);
+      registerProviderHostRpcResponder(harness, {
+        hostId: host.id,
+        sessionId: session.id,
+        restoreCommandCaptureAfterResponse: true,
+        modelsByProviderId: {
+          codex: {
+            models: [
+              availableModelFixture({
+                model: "gpt-provider-default",
+                isDefault: true,
+              }),
+            ],
+            selectedOnlyModels: [],
+          },
+        },
+      });
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.id,
+        path: "/tmp/thread-defaults-client-provider",
+      });
+      const environment = seedEnvironment(harness.deps, {
+        hostId: host.id,
+        projectId: project.id,
+        path: "/tmp/thread-defaults-client-provider",
+      });
+
+      const response = await harness.app.request("/api/v1/threads", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          origin: "app",
+          projectId: project.id,
+          providerId: "codex",
+          model: "gpt-provider-default",
+          reasoningLevel: "medium",
+          permissionMode: "auto",
+          executionInputSources: {
+            providerId: "client-preference",
+          },
+          input: [
+            { type: "text", text: "Create from the new thread composer" },
+          ],
+          environment: {
+            type: "reuse",
+            environmentId: environment.id,
+          },
+        }),
+      });
+
+      expect(response.status).toBe(201);
+      const createdThread = threadSchema.parse(await readJson(response));
+      const queuedStart = await waitForQueuedCommand(
+        harness,
+        ({ command }) =>
+          command.type === "thread.start" &&
+          command.threadId === createdThread.id,
+      );
+      expect(queuedStart.command).toMatchObject({
+        providerId: "codex",
+        options: {
+          model: "gpt-provider-default",
+          reasoningLevel: "medium",
+          permissionMode: "auto",
+        },
+      });
+    });
+  });
+
   it("returns an actionable error when the default model catalog cannot be loaded", async () => {
     await withTestHarness(async (harness) => {
       const { host, session } = seedHostSession(harness.deps);


### PR DESCRIPTION
## Human comments

## What was wrong

The dispatch-queue rework in `49dadc363` made initial thread creation resolve execution options twice. Creation found the provider catalog's default model, but did not pass those defaults into the dispatch checkpoint. The resolved payload also retained sparse caller source metadata, so admission treated the displayed model as unowned and discarded it during the second resolution. Fresh projects could therefore fail with `Thread <id> has no stored execution model` even though the request included a valid model.

## What changed

Creation now passes the same execution-plan arguments into the dispatch checkpoint, and internally resolved execution fields are marked explicit before any subsequent resolution. This keeps immediate and queued initial dispatches idempotent. No host-daemon wire contract changed, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

## How you verified

- Added a public-route regression test matching the browser request shape: a client-sourced provider, displayed model/reasoning/permission values, and no stored project defaults.
- `pnpm exec turbo run test --filter=@bb/server --force -- test/public/public-threads.defaults.test.ts test/threads/dispatch-hooks.test.ts test/threads/requested-queue-drain.test.ts` — 29 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/app --filter=@bb/server` — passed.
- Reproduced the exact request with dev-browser before the change (`500 internal_error`) and repeated it after the change (`201`, navigating to the created thread).

Reported directly in a bb thread; no GitHub issue exists.

> AGENT GENERATED
