### PR TITLE
Reset searchable picker scroll position when filtering

### DIFF
--- a/apps/app/src/components/pickers/BranchPicker.scroll.test.tsx
+++ b/apps/app/src/components/pickers/BranchPicker.scroll.test.tsx
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { BranchPicker } from "./BranchPicker";
+
+afterEach(cleanup);
+
+describe("BranchPicker search scrolling", () => {
+  it("returns the results viewport to the top when searching", () => {
+    render(
+      <BranchPicker
+        value="main"
+        options={[
+          "main",
+          "develop",
+          "feature/one",
+          "feature/two",
+          "feature/three",
+        ]}
+        onChange={vi.fn()}
+        modal={false}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("combobox", { name: "Branch" }));
+    const search = screen.getByPlaceholderText("Search branches");
+    const scrollArea = search.parentElement?.parentElement?.nextElementSibling;
+    expect(scrollArea).toBeInstanceOf(HTMLElement);
+    if (!(scrollArea instanceof HTMLElement)) return;
+    scrollArea.scrollTop = 120;
+
+    fireEvent.change(search, { target: { value: "feature/three" } });
+
+    expect(scrollArea.scrollTop).toBe(0);
+  });
+});

--- a/apps/app/src/components/pickers/BranchPicker.tsx
+++ b/apps/app/src/components/pickers/BranchPicker.tsx
@@ -35,6 +35,7 @@ import {
 } from "@bb/shared-ui/option-display";
 import { cn } from "@bb/shared-ui/lib/utils";
 import type { GitBranchRefClassification } from "@bb/domain";
+import { useResetPickerScroll } from "./useResetPickerScroll";
 
 interface GetMergeBaseBranchCandidatesArgs {
   mergeBaseBranch?: string;
@@ -702,6 +703,7 @@ export function BranchPicker({
 }: BranchPickerProps) {
   const [open, setOpen] = useState(defaultOpen);
   const [query, setQuery] = useState("");
+  const optionsScrollRef = useResetPickerScroll<HTMLDivElement>(query);
   const isCompactViewport = useIsCompactViewport();
   const isPointerCoarse = usePointerCoarse();
   const selectedCheckoutIntent = resolveCheckoutIntent({
@@ -993,6 +995,7 @@ export function BranchPicker({
             />
           ) : null}
           <div
+            ref={optionsScrollRef}
             className="min-h-0 max-h-[60vh] overflow-y-auto overscroll-contain px-1 pb-1 pt-0 md:max-h-80"
             onWheel={(event) => {
               event.stopPropagation();

--- a/apps/app/src/components/pickers/ModelReasoningPicker.test.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.test.tsx
@@ -633,6 +633,22 @@ describe("ModelReasoningPicker", () => {
     expect(onModelChange).toHaveBeenCalledWith("o4-mini");
   });
 
+  it("returns the results viewport to the top when searching", () => {
+    renderPicker({ modelOptions: manyCodexModels });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Provider, model and reasoning" }),
+    );
+
+    const search = screen.getByPlaceholderText("Search models");
+    const list = screen.getByRole("listbox", { name: "Models" });
+    list.scrollTop = 120;
+
+    fireEvent.change(search, { target: { value: "o4" } });
+
+    expect(list.scrollTop).toBe(0);
+  });
+
   it("resets retained mobile browse state after the drawer closes", () => {
     const frames: FrameRequestCallback[] = [];
     vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {

--- a/apps/app/src/components/pickers/ModelReasoningPicker.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.tsx
@@ -55,6 +55,7 @@ import {
 } from "@bb/shared-ui/option-display";
 import { type PickerOption } from "./OptionPicker";
 import type { ModelPickerOption } from "./model-picker-option";
+import { useResetPickerScroll } from "./useResetPickerScroll";
 import {
   formatModelLoadErrorText,
   ModelLoadErrorMessage,
@@ -267,6 +268,7 @@ export function ModelReasoningPicker({
     ? registeredToggleShortcut
     : null;
   const [searchQuery, setSearchQuery] = useState("");
+  const listRef = useResetPickerScroll<HTMLDivElement>(searchQuery);
   const [activeIndex, setActiveIndex] = useState(-1);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const normalizedQuery = searchQuery.trim().toLowerCase();
@@ -966,6 +968,7 @@ export function ModelReasoningPicker({
             )}
           >
             <div
+              ref={listRef}
               key={activeProviderId || "no-provider"}
               role={showSearchInput ? "listbox" : undefined}
               id={showSearchInput ? listboxId : undefined}

--- a/apps/app/src/components/pickers/ParentThreadPicker.test.tsx
+++ b/apps/app/src/components/pickers/ParentThreadPicker.test.tsx
@@ -73,4 +73,21 @@ describe("ParentThreadPicker", () => {
       screen.queryByRole("combobox", { name: "Search parent threads" }),
     ).toBeNull();
   });
+
+  it("returns the results viewport to the top when searching", async () => {
+    render(picker());
+
+    fireEvent.click(screen.getByRole("button"));
+    const search = await screen.findByRole("combobox", {
+      name: "Search parent threads",
+    });
+    const list = document.querySelector<HTMLElement>("[cmdk-list]");
+    expect(list).not.toBeNull();
+    if (list === null) return;
+    list.scrollTop = 120;
+
+    fireEvent.change(search, { target: { value: "frontend" } });
+
+    expect(list.scrollTop).toBe(0);
+  });
 });

--- a/apps/app/src/components/pickers/ParentThreadPicker.tsx
+++ b/apps/app/src/components/pickers/ParentThreadPicker.tsx
@@ -15,6 +15,7 @@ import {
 import { Icon } from "@bb/shared-ui/icon";
 import { cn } from "@bb/shared-ui/lib/utils";
 import { Popover, PopoverContent, PopoverTrigger } from "@bb/shared-ui/popover";
+import { useResetPickerScroll } from "./useResetPickerScroll";
 
 export interface ParentThreadPickerOption {
   label: string;
@@ -46,6 +47,7 @@ export function ParentThreadPicker({
 }: ParentThreadPickerProps) {
   const [open, setOpen] = useState(defaultOpen ?? false);
   const [searchQuery, setSearchQuery] = useState("");
+  const listRef = useResetPickerScroll<HTMLDivElement>(searchQuery);
   const selectedLabel =
     options.find((option) => option.value === value)?.label ?? "None";
   const handleOpenChange = useCallback(
@@ -99,7 +101,7 @@ export function ParentThreadPicker({
             value={searchQuery}
             onValueChange={setSearchQuery}
           />
-          <CommandList className="max-h-72">
+          <CommandList ref={listRef} className="max-h-72">
             {isLoading ? (
               <div className="px-3 py-2 text-sm text-muted-foreground">
                 Loading threads…

--- a/apps/app/src/components/pickers/useResetPickerScroll.ts
+++ b/apps/app/src/components/pickers/useResetPickerScroll.ts
@@ -1,0 +1,13 @@
+import { useLayoutEffect, useRef } from "react";
+
+export function useResetPickerScroll<T extends HTMLElement>(query: string) {
+  const scrollRef = useRef<T>(null);
+
+  useLayoutEffect(() => {
+    if (scrollRef.current !== null) {
+      scrollRef.current.scrollTop = 0;
+    }
+  }, [query]);
+
+  return scrollRef;
+}


### PR DESCRIPTION
## Human comments

## What was wrong

Searchable pickers retained their results container's `scrollTop` when the query changed. After scrolling down and narrowing the options, the highest-ranked filtered result could render above the retained viewport, forcing the user to scroll back up to see it.

## What changed

Added a shared query-driven scroll reset and applied it to the branch, model/reasoning, and parent-thread pickers. The reset runs during layout so the filtered result list is at the top before paint. No wire, CLI, or documentation surfaces changed.

## How you verified

- Added regression coverage for all three searchable pickers; each test sets a nonzero scroll position, changes the query, and verifies the results viewport returns to zero.
- `pnpm exec turbo run test --filter=@bb/app --force -- src/components/pickers/BranchPicker.scroll.test.tsx src/components/pickers/ModelReasoningPicker.test.tsx src/components/pickers/ParentThreadPicker.test.tsx` — 35 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/app --filter=@bb/server` — passed.
- `pnpm exec turbo run lint --filter=@bb/app --filter=@bb/server` — 0 errors.
- In the running app, used dev-browser to set the branch results viewport to `scrollTop = 1200`, searched for `fix-searchable-picker-scrolling`, and observed `scrollTop = 0` with the matching branch visible.

Reported directly in a bb thread; no GitHub issue exists.

> AGENT GENERATED
