### PR TITLE
Fix AppImage lifecycle smoke port allocation race

### DIFF
--- a/apps/desktop/scripts/smoke-linux-appimage-lifecycle.mjs
+++ b/apps/desktop/scripts/smoke-linux-appimage-lifecycle.mjs
@@ -71,26 +71,83 @@ async function waitFor({
   throw new Error(`Timed out waiting for ${describe}.${detail}`);
 }
 
-async function allocateTcpPort() {
-  const server = createServer();
-  await new Promise((resolvePromise, rejectPromise) => {
-    server.once("error", rejectPromise);
-    server.listen(0, "127.0.0.1", resolvePromise);
-  });
-  const address = server.address();
-  if (address === null || typeof address === "string") {
-    throw new Error("Expected an ephemeral TCP listener");
+function parseEphemeralTcpPortRange(rawRange) {
+  const ports = rawRange.trim().split(/\s+/u).map(Number);
+  const [firstPort, lastPort] = ports;
+  if (
+    ports.length !== 2 ||
+    !Number.isInteger(firstPort) ||
+    !Number.isInteger(lastPort) ||
+    firstPort < 1 ||
+    lastPort > 65_535 ||
+    firstPort > lastPort
+  ) {
+    throw new Error("Invalid Linux ephemeral TCP port range");
   }
-  await new Promise((resolvePromise, rejectPromise) => {
-    server.close((error) => {
-      if (error) {
-        rejectPromise(error);
+  return { firstPort, lastPort };
+}
+
+async function reserveTcpPort(port) {
+  const server = createServer();
+  const reserved = await new Promise((resolvePromise, rejectPromise) => {
+    const handleError = (error) => {
+      if (error.code === "EADDRINUSE") {
+        resolvePromise(null);
         return;
       }
-      resolvePromise();
+      rejectPromise(error);
+    };
+    server.once("error", handleError);
+    server.listen(port, "127.0.0.1", () => {
+      server.off("error", handleError);
+      resolvePromise(server);
     });
   });
-  return address.port;
+  return reserved;
+}
+
+async function allocateNonEphemeralTcpPorts(count) {
+  const range = parseEphemeralTcpPortRange(
+    await readFile("/proc/sys/net/ipv4/ip_local_port_range", "utf8"),
+  );
+  const candidateRanges = [
+    { firstPort: 65_535, lastPort: range.lastPort + 1 },
+    { firstPort: range.firstPort - 1, lastPort: 1_024 },
+  ];
+  const reservations = [];
+  try {
+    for (const candidateRange of candidateRanges) {
+      for (
+        let port = candidateRange.firstPort;
+        port >= candidateRange.lastPort && reservations.length < count;
+        port -= 1
+      ) {
+        const server = await reserveTcpPort(port);
+        if (server !== null) {
+          reservations.push({ port, server });
+        }
+      }
+    }
+    if (reservations.length !== count) {
+      throw new Error(`Unable to reserve ${String(count)} non-ephemeral ports`);
+    }
+    return reservations.map((reservation) => reservation.port);
+  } finally {
+    await Promise.all(
+      reservations.map(
+        (reservation) =>
+          new Promise((resolvePromise, rejectPromise) => {
+            reservation.server.close((error) => {
+              if (error) {
+                rejectPromise(error);
+                return;
+              }
+              resolvePromise();
+            });
+          }),
+      ),
+    );
+  }
 }
 
 async function resolveAppImage() {
@@ -455,11 +512,7 @@ async function smokeLinuxAppImageLifecycle() {
   let runtime = null;
 
   try {
-    const serverPort = await allocateTcpPort();
-    let daemonPort = await allocateTcpPort();
-    while (serverPort === daemonPort) {
-      daemonPort = await allocateTcpPort();
-    }
+    const [serverPort, daemonPort] = await allocateNonEphemeralTcpPorts(2);
 
     const childEnv = {
       ...process.env,


### PR DESCRIPTION
## Human comments

## What was wrong

The Linux AppImage lifecycle smoke asked the kernel for two ephemeral ports with `listen(0)`, closed those listeners, and only then launched the packaged GUI and its nested owned runtime. Both ports therefore stayed eligible for immediate reuse by unrelated loopback listeners or outbound connections during the multi-process startup window. If either port was claimed before the server or daemon bound it, the nested runtime failed after `owned-runtime.json` publication, producing the observed `The owned runtime exited before bb became ready.` signature while its useful listener error remained in the GUI's in-memory child log. A targeted collision reproduced that exact signature in 8.3 seconds, and an uncoordinated ephemeral-listener churn reproduced it naturally at the same boundary and timing.

## What changed

The AppImage lifecycle smoke now reads Linux's IPv4 ephemeral range from `/proc/sys/net/ipv4/ip_local_port_range`, selects two currently free ports outside that range while holding the reservations as a set, and releases them immediately before launching the packaged app. Kernel-assigned client and listener ports can no longer steal the smoke's server or daemon ports. No timeout, polling budget, retry, readiness assertion, product wire contract, CLI, or daemon behavior changed.

## How you verified

- Verified and built from merge-base `431f71032ce071af96d4c94a0847517e298f7ce4` on an x86_64 Ubuntu 24.04.4 guest with real FUSE, hosted only on Intel machine `host_nwqfteeqz4`.
- Red: the unchanged real AppImage smoke under 1,000 uncoordinated `bind(0)` loopback listeners failed 4/10 runs. Runs 3 and 6 exited in 6.8–7.0 seconds with the exact owned-runtime-before-ready signature and updater-only stderr; runs 5 and 7 reached the unchanged readiness deadline.
- Green: the same bounded listener-churn loop passed 10/10 complete AppImage lifecycle smokes after the change, including GUI mount removal and owned-runtime health verification. Final audit: 0 AppImage processes, 0 churn processes, 0 FUSE mounts, and 0 smoke roots.
- Ruled out scheduler pressure as the root cause: 10/10 unchanged full smokes passed with eight CPU load workers on four vCPUs, and the nested real-FUSE AppImage launch stage passed 100/100 unloaded plus 100/100 at the same 2x CPU oversubscription. No clock was changed.
- `BB_DESKTOP_COMMIT=431f71032ce071af96d4c94a0847517e298f7ce4 pnpm exec turbo run desktop:build:linux --filter=@bb/desktop --cache-dir=.turbo/cache --output-logs=new-only`
- `pnpm exec turbo run build --filter=@bb/desktop --output-logs=new-only` (12/12 tasks)
- `pnpm exec turbo run typecheck --filter=@bb/desktop --output-logs=new-only` (3/3 tasks)
- `pnpm exec turbo run test --filter=@bb/desktop --force` (38 files; 247 passed, 1 skipped)
- `node --check apps/desktop/scripts/smoke-linux-appimage-lifecycle.mjs`
- `pnpm exec prettier --check apps/desktop/scripts/smoke-linux-appimage-lifecycle.mjs`

> AGENT GENERATED: by GPT-5.6-Sol
