### PR TITLE
Hide unavailable Files settings from Cmd-K

### DIFF
--- a/apps/app/src/components/commands/CommandPalette.test.tsx
+++ b/apps/app/src/components/commands/CommandPalette.test.tsx
@@ -80,6 +80,7 @@ function defaults(...commands: AppCommandId[]): AppDefaultKeybinding[] {
 
 const testState = vi.hoisted(() => ({
   calls: [] as string[],
+  filesAvailable: false,
   plugins: [] as Array<{
     enabled: boolean;
     hasSettings: boolean;
@@ -113,6 +114,15 @@ vi.mock("@/hooks/queries/system-queries", () => ({
 
 vi.mock("@/lib/bb-desktop", () => ({
   getBbDesktopInfo: () => null,
+}));
+
+vi.mock("@/hooks/useHostDaemon", () => ({
+  useHostDaemon: () => ({ hasDaemon: false }),
+  useLocalHostDaemonAccess: () => ({
+    accessState: testState.filesAvailable
+      ? "permission-required"
+      : "unavailable",
+  }),
 }));
 
 vi.mock("@/lib/app-query-client", () => ({
@@ -223,7 +233,7 @@ function openThreadSearch(): KeyboardEvent {
 
 const searchField = () => screen.getByRole("combobox");
 const optionTitles = () =>
-  screen.getAllByRole("option").map((option) => option.textContent);
+  screen.queryAllByRole("option").map((option) => option.textContent);
 const selectedOption = () =>
   screen
     .getAllByRole("option")
@@ -234,6 +244,7 @@ afterEach(() => {
   removePluginSlotRegistrations("linear");
   removePluginSlotRegistrations("automations");
   testState.calls.length = 0;
+  testState.filesAvailable = false;
   testState.plugins.length = 0;
   window.localStorage.clear();
 });
@@ -247,7 +258,7 @@ describe("CommandPalette", () => {
     expect((searchField() as HTMLInputElement).value).toBe(">");
     const titles = optionTitles();
     expect(titles?.[0]).toContain("New thread");
-    expect(titles).toHaveLength(17);
+    expect(titles).toHaveLength(16);
   });
 
   it("filters as the user types and keeps the selection on a live row", async () => {
@@ -476,6 +487,40 @@ describe("CommandPalette", () => {
       expect(screen.getByTestId("location").textContent).toContain(
         "/settings/keyboard",
       ),
+    );
+  });
+
+  it.each([false, true])(
+    "excludes Files settings when Settings has no local opener (compact: %s)",
+    async (compact) => {
+      renderPalette(compact);
+      openThreadSearch();
+      await waitFor(() => expect(searchField()).toBeTruthy());
+
+      fireEvent.change(searchField(), {
+        target: { value: ">files settings" },
+      });
+
+      await waitFor(() =>
+        expect(optionTitles()).not.toContainEqual(
+          expect.stringContaining("Files settings"),
+        ),
+      );
+    },
+  );
+
+  it("keeps Files settings when local helper access can be enabled", async () => {
+    testState.filesAvailable = true;
+    renderPalette();
+    openThreadSearch();
+    await waitFor(() => expect(searchField()).toBeTruthy());
+
+    fireEvent.change(searchField(), {
+      target: { value: ">files settings" },
+    });
+
+    await waitFor(() =>
+      expect(selectedOption()?.textContent).toContain("Files settings"),
     );
   });
 

--- a/apps/app/src/components/commands/CommandPalette.tsx
+++ b/apps/app/src/components/commands/CommandPalette.tsx
@@ -43,6 +43,7 @@ import {
   buildPluginSettingsEntries,
   type PluginSettingsCandidate,
 } from "@/components/settings/plugin-settings-entries";
+import { useSettingsNavSections } from "@/components/settings/settings-nav";
 import { appQueryClient } from "@/lib/app-query-client";
 import {
   ThreadPaletteResults,
@@ -77,6 +78,7 @@ export function CommandPalette({ threadId, projectId }: CommandPaletteProps) {
     readonly PluginSettingsCandidate[]
   >([]);
   const pluginSlots = usePluginSlots();
+  const sections = useSettingsNavSections(pluginSlots.fileOpeners);
   const pluginSettingsEntries = useMemo(
     () =>
       buildPluginSettingsEntries({
@@ -92,8 +94,9 @@ export function CommandPalette({ threadId, projectId }: CommandPaletteProps) {
           void navigate(path);
         },
         pluginEntries: pluginSettingsEntries,
+        sections,
       }),
-    [navigate, pluginSettingsEntries],
+    [navigate, pluginSettingsEntries, sections],
   );
   const pluginPageActions = useMemo(
     () =>

--- a/apps/app/src/components/layout/AppLayout.plugin-panel-header.test.tsx
+++ b/apps/app/src/components/layout/AppLayout.plugin-panel-header.test.tsx
@@ -34,9 +34,15 @@ vi.mock("@/hooks/queries/system-queries", () => ({
   }),
 }));
 
+vi.mock("@/hooks/useHostDaemon", () => ({
+  useHostDaemon: () => ({ hasDaemon: false }),
+  useLocalHostDaemonAccess: () => ({ accessState: "unavailable" }),
+}));
+
 vi.mock("@/lib/plugin-slots", () => ({
   usePluginSlots: () => ({
     commandPaletteActions: [],
+    fileOpeners: [],
     navPanels: [
       {
         pluginId: "helm-wiki",

--- a/apps/app/src/components/layout/AppLayout.root-compose-project.test.tsx
+++ b/apps/app/src/components/layout/AppLayout.root-compose-project.test.tsx
@@ -42,6 +42,11 @@ vi.mock("@/hooks/queries/system-queries", () => ({
   }),
 }));
 
+vi.mock("@/hooks/useHostDaemon", () => ({
+  useHostDaemon: () => ({ hasDaemon: false }),
+  useLocalHostDaemonAccess: () => ({ accessState: "unavailable" }),
+}));
+
 vi.mock("@/components/project/ProjectActionsProvider", () => ({
   ProjectActionsProvider: ({ children }: { children: ReactNode }) => (
     <>{children}</>

--- a/apps/app/src/components/layout/AppLayout.sidebar-resize.test.tsx
+++ b/apps/app/src/components/layout/AppLayout.sidebar-resize.test.tsx
@@ -47,6 +47,11 @@ vi.mock("@/hooks/queries/system-queries", () => ({
   }),
 }));
 
+vi.mock("@/hooks/useHostDaemon", () => ({
+  useHostDaemon: () => ({ hasDaemon: false }),
+  useLocalHostDaemonAccess: () => ({ accessState: "unavailable" }),
+}));
+
 vi.mock("@/components/project/ProjectActionsProvider", () => ({
   ProjectActionsProvider: ({ children }: { children: ReactNode }) => (
     <>{children}</>

--- a/apps/app/src/components/settings/settings-nav.tsx
+++ b/apps/app/src/components/settings/settings-nav.tsx
@@ -1,6 +1,7 @@
+import { useMemo } from "react";
 import { matchPath, useLocation } from "react-router-dom";
 import { useHostDaemon, useLocalHostDaemonAccess } from "@/hooks/useHostDaemon";
-import { usePluginSlots } from "@/lib/plugin-slots";
+import { usePluginSlots, type PluginFileOpenerSlot } from "@/lib/plugin-slots";
 import { usePluginList } from "@/hooks/queries/plugin-settings-queries";
 import {
   SETTINGS_MACHINE_ROUTE_PATH,
@@ -26,11 +27,29 @@ export interface SettingsNavState {
   sections: readonly SettingsNavSection[];
 }
 
-export function useSettingsNavState(): SettingsNavState {
-  const location = useLocation();
+export function useSettingsNavSections(
+  fileOpeners: readonly PluginFileOpenerSlot[],
+): readonly SettingsNavSection[] {
   const { hasDaemon } = useHostDaemon();
   const { accessState } = useLocalHostDaemonAccess();
+
+  return useMemo(
+    () =>
+      SETTINGS_NAV_SECTIONS.filter(
+        (section) =>
+          section.id !== "files" ||
+          hasDaemon ||
+          accessState !== "unavailable" ||
+          fileOpeners.length > 0,
+      ),
+    [accessState, fileOpeners.length, hasDaemon],
+  );
+}
+
+export function useSettingsNavState(): SettingsNavState {
+  const location = useLocation();
   const { fileOpeners, settingsSections } = usePluginSlots();
+  const sections = useSettingsNavSections(fileOpeners);
   const pluginListQuery = usePluginList({ enabled: true });
 
   const sectionMatch = matchPath(
@@ -57,14 +76,6 @@ export function useSettingsNavState(): SettingsNavState {
           : "general";
 
   const installedPlugins = pluginListQuery.data?.plugins ?? [];
-  const sections = SETTINGS_NAV_SECTIONS.filter((section) => {
-    if (section.id === "files") {
-      return (
-        hasDaemon || accessState !== "unavailable" || fileOpeners.length > 0
-      );
-    }
-    return true;
-  });
   const pluginEntries = buildPluginSettingsEntries({
     installedPlugins,
     settingsSections,

--- a/apps/app/src/lib/command-palette/palette-settings-actions.ts
+++ b/apps/app/src/lib/command-palette/palette-settings-actions.ts
@@ -1,6 +1,6 @@
 import {
   getSettingsSectionRoutePath,
-  SETTINGS_NAV_SECTIONS,
+  type SettingsNavSection,
 } from "@/components/settings/settings-sections";
 import type { PluginSettingsEntry } from "@/components/settings/plugin-settings-entries";
 import { getPluginConfigurationRoutePath } from "@/lib/route-paths";
@@ -9,13 +9,14 @@ import type { PaletteAction } from "./palette-action";
 interface BuildSettingsPaletteActionsArgs {
   navigate: (path: string) => void;
   pluginEntries: readonly PluginSettingsEntry[];
+  sections: readonly SettingsNavSection[];
 }
 
 export function buildSettingsPaletteActions(
   args: BuildSettingsPaletteActionsArgs,
 ): PaletteAction[] {
   return [
-    ...SETTINGS_NAV_SECTIONS.map((section) => ({
+    ...args.sections.map((section) => ({
       id: `settings:${section.id}`,
       group: "Settings",
       title: `${section.label} settings`,


### PR DESCRIPTION
## Human comments

## What was wrong

PR #2812 built Cmd-K's built-in settings destinations from the static settings catalog, bypassing the Settings navigation owner's availability filtering. When BB had no local helper or registered file opener, Settings correctly hid Files but Cmd-K still offered “Files settings” and navigated to a blank page.

The first implementation also mounted Settings' plugin-list query in the always-present command palette, making plugin loading eager and breaking AppLayout fixtures without a QueryClient.

## What changed

- Share the Settings-owned section availability hook with Cmd-K so both surfaces apply the same Files eligibility rule.
- Preserve the command palette's lazy plugin-settings fetch instead of mounting the Settings query owner.
- Preserve all available built-in settings, plugin settings, plugin pages, and the existing command-mode interaction.
- Add regressions for unavailable Files on wide and compact layouts plus the available local-helper path.
- Update the three AppLayout fixtures that mock the palette's new host-availability dependency.
- No host-daemon protocol, CLI, guide, or public Plugin SDK changes.

## How you verified

- The no-helper regression reproduced the stale Files destination before the implementation and passes afterward.
- `pnpm exec turbo run test --filter=@bb/app --force -- --run src/components/commands/CommandPalette.test.tsx src/components/settings/settings-nav.test.tsx src/components/layout/AppLayout.sidebar-resize.test.tsx src/components/layout/AppLayout.root-compose-project.test.tsx src/components/layout/AppLayout.plugin-panel-header.test.tsx` — 32 tests passed after rebasing.
- `pnpm exec turbo run typecheck --filter=@bb/app --force` — passed after rebasing.
- `pnpm exec turbo run lint --filter=@bb/app --force` — 0 errors.
- Targeted oxfmt and `git diff --check` passed.
- DevBrowser verified ordinary Keyboard settings navigation and compact no-helper Cmd-K behavior.

Follow-up to #2812.

> AGENT GENERATED
