### PR TITLE
Fix queued thread creation UI updates

### DIFF
--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
@@ -134,6 +134,10 @@ export interface QueuedMessagesListProps {
   onDelete: (id: string) => void;
 }
 
+interface QueuedMessagesPendingCardProps {
+  queuedMessageCount: number;
+}
+
 interface QueuedMessagePreviewText {
   mentions: PromptTextMention[];
   text: string;
@@ -196,6 +200,15 @@ function getDrawerHeight({
   return Math.min(
     DRAWER_HEIGHT,
     DRAWER_CHROME_HEIGHT + DRAWER_LIST_PADDING + rowsHeight,
+  );
+}
+
+function getPendingDrawerHeight(queuedMessageCount: number): number {
+  return Math.min(
+    DRAWER_HEIGHT,
+    DRAWER_CHROME_HEIGHT +
+      DRAWER_LIST_PADDING +
+      Math.max(1, queuedMessageCount) * DRAWER_ROW_HEIGHT,
   );
 }
 
@@ -1081,6 +1094,34 @@ function QueuedMessageInlineEditorSlot({
       </InlineMessageEditorFrame>
       <OverflowFade placement="below" tone="surface-raised" className="z-10" />
     </li>
+  );
+}
+
+export function QueuedMessagesPendingCard({
+  queuedMessageCount,
+}: QueuedMessagesPendingCardProps) {
+  return (
+    <PromptStackCard
+      ariaLabel="Queued messages"
+      style={{ height: getPendingDrawerHeight(queuedMessageCount) }}
+      className="relative z-10 -mb-5 flex min-h-0 flex-col overflow-hidden rounded-xl rounded-b-none border-b-0 bg-surface-raised-solid pb-3 shadow-lift"
+    >
+      <header className="flex h-8 shrink-0 items-center gap-2 border-b border-border/35 px-2">
+        <div className="flex min-w-16 items-baseline gap-1.5 pl-1">
+          <span className="text-xs font-medium text-foreground">Queue</span>
+          <span className="text-2xs tabular-nums text-subtle-foreground">
+            {queuedMessageCount}
+          </span>
+        </div>
+      </header>
+      <div
+        role="status"
+        className="flex min-h-0 flex-1 items-center gap-2 px-3 text-xs text-subtle-foreground"
+      >
+        <Icon name="Loading" className="size-3.5 animate-spin" aria-hidden />
+        <span>Loading queued message details…</span>
+      </div>
+    </PromptStackCard>
   );
 }
 

--- a/apps/app/src/hooks/cache-owners/query-cache.ts
+++ b/apps/app/src/hooks/cache-owners/query-cache.ts
@@ -3,7 +3,6 @@ import type {
   Thread,
   ThreadListEntry,
   ThreadStatusChangeMetadata,
-  ThreadWithRuntime,
 } from "@bb/domain";
 import {
   applyToCachedThreadLists,
@@ -572,8 +571,47 @@ function threadMatchesListFilters(
 
 export function optimisticallyInsertThread(
   queryClient: QueryClient,
-  thread: ThreadWithRuntime,
+  thread: ThreadResponse,
 ): void {
+  const queuedWork = thread.queuedMessageCount > 0 ? "waiting" : "none";
+  const insertedThread: ThreadListEntry = {
+    ...thread,
+    activity: {
+      activeWorkflowCount: 0,
+      activeBackgroundAgentCount: 0,
+      activeBackgroundCommandCount: 0,
+      activePlanModeCount: 0,
+      activeGoalCount: 0,
+    },
+    environmentBranchName: null,
+    environmentHostId: null,
+    environmentName: null,
+    runtime: thread.runtime,
+    hasPendingInteraction: false,
+    pinSortKey: null,
+    queuedWork,
+    environmentWorkspaceDisplayKind: "other",
+  };
+  const upsertThread = (threads: ThreadListEntry[]): ThreadListEntry[] => {
+    const existingIndex = threads.findIndex(
+      (candidate) => candidate.id === thread.id,
+    );
+    if (existingIndex === -1) {
+      return [insertedThread, ...threads];
+    }
+    return threads.map((candidate, index) =>
+      index === existingIndex
+        ? {
+            ...candidate,
+            queuedWork:
+              candidate.queuedWork === "none"
+                ? queuedWork
+                : candidate.queuedWork,
+          }
+        : candidate,
+    );
+  };
+
   for (const { queryKey, data } of getCachedThreadLists(queryClient, {
     queryKey: threadsQueryKey(),
   })) {
@@ -585,32 +623,33 @@ export function optimisticallyInsertThread(
     if (!threadMatchesListFilters(thread, filters)) {
       continue;
     }
-    if (data.some((candidate) => candidate.id === thread.id)) {
-      continue;
-    }
 
-    queryClient.setQueryData<ThreadListEntry[]>(queryKey, [
-      {
-        ...thread,
-        activity: {
-          activeWorkflowCount: 0,
-          activeBackgroundAgentCount: 0,
-          activeBackgroundCommandCount: 0,
-          activePlanModeCount: 0,
-          activeGoalCount: 0,
-        },
-        environmentBranchName: null,
-        environmentHostId: null,
-        environmentName: null,
-        runtime: thread.runtime,
-        hasPendingInteraction: false,
-        pinSortKey: null,
-        queuedWork: "none",
-        environmentWorkspaceDisplayKind: "other",
-      },
-      ...data,
-    ]);
+    queryClient.setQueryData<ThreadListEntry[]>(queryKey, upsertThread(data));
   }
+
+  if (thread.visibility === "hidden" || thread.archivedAt !== null) {
+    return;
+  }
+
+  queryClient.setQueryData<SidebarBootstrapResponse>(
+    sidebarNavigationQueryKey(),
+    (navigation) => {
+      if (!navigation) {
+        return navigation;
+      }
+      const updateProject = (
+        project: SidebarNavigationProject,
+      ): SidebarNavigationProject =>
+        project.id === thread.projectId
+          ? mapSidebarNavigationProjectThreads(project, upsertThread)
+          : project;
+      return {
+        sections: navigation.sections,
+        projects: navigation.projects.map(updateProject),
+        personalProject: updateProject(navigation.personalProject),
+      };
+    },
+  );
 }
 
 const updateEveryTimelineQuery: TimelineRowsUpdatePredicate = () => true;

--- a/apps/app/src/hooks/cache-owners/thread-runtime-cache-owner.ts
+++ b/apps/app/src/hooks/cache-owners/thread-runtime-cache-owner.ts
@@ -71,6 +71,10 @@ interface ThreadIdCacheArgs {
   threadId: string;
 }
 
+interface PrefetchThreadQueuedMessagesArgs extends ThreadIdCacheArgs {
+  load: (signal: AbortSignal) => Promise<ThreadQueuedMessageListResponse>;
+}
+
 type ThreadBannerActivityKind = "goal" | "plan";
 
 interface BeginCreateThreadTransactionArgs {
@@ -728,6 +732,17 @@ export async function beginCreateThreadTransaction({
   queryClient,
 }: BeginCreateThreadTransactionArgs): Promise<void> {
   await queryClient.cancelQueries({ queryKey: threadsQueryKey() });
+}
+
+export function prefetchThreadQueuedMessages({
+  load,
+  queryClient,
+  threadId,
+}: PrefetchThreadQueuedMessagesArgs): Promise<void> {
+  return queryClient.prefetchQuery<ThreadQueuedMessageListResponse>({
+    queryKey: threadQueuedMessagesQueryKey(threadId),
+    queryFn: ({ signal }) => load(signal),
+  });
 }
 
 export function applyCreateThreadResult({

--- a/apps/app/src/hooks/mutations/thread-runtime-mutations.test.tsx
+++ b/apps/app/src/hooks/mutations/thread-runtime-mutations.test.tsx
@@ -4,6 +4,7 @@ import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import type { ThreadQueuedMessage } from "@bb/domain";
 import type {
   ExistingThreadExecutionInputSources,
+  ThreadResponse,
   ThreadTimelineResponse,
 } from "@bb/server-contract";
 import { createDeferredPromise } from "@bb/test-helpers";
@@ -18,6 +19,7 @@ import {
 import {
   useCancelThreadPlan,
   useClearThreadGoal,
+  useCreateThread,
   useCreateThreadQueuedMessage,
   useDeleteThreadQueuedMessage,
   useEditThreadMessage,
@@ -37,9 +39,11 @@ vi.mock("@/lib/sdk", async (importOriginal) => {
         queuedMessages: {
           create: vi.fn(),
           delete: vi.fn(),
+          list: vi.fn(),
           setGroupBoundary: vi.fn(),
         },
         send: vi.fn(),
+        spawn: vi.fn(),
       },
     },
   };
@@ -71,6 +75,41 @@ function makeQueuedMessage(
     createdAt: 1,
     updatedAt: 1,
     ...message,
+  };
+}
+
+function makeThreadResponse(
+  thread: Partial<ThreadResponse> = {},
+): ThreadResponse {
+  return {
+    id: "thread-1",
+    projectId: "project-1",
+    providerId: "codex",
+    createdAt: 1,
+    status: "pending",
+    updatedAt: 1,
+    lastReadAt: null,
+    latestAttentionAt: 1,
+    environmentId: null,
+    title: null,
+    titleFallback: null,
+    sectionId: null,
+    parentThreadId: null,
+    sourceThreadId: null,
+    originKind: null,
+    originPluginId: null,
+    visibility: "visible",
+    archivedAt: null,
+    pinnedAt: null,
+    deletedAt: null,
+    runtime: {
+      displayStatus: "pending",
+      hostReconnectGraceExpiresAt: null,
+    },
+    activeBackgroundAgentCount: 0,
+    canSpawnChild: false,
+    queuedMessageCount: 1,
+    ...thread,
   };
 }
 
@@ -127,10 +166,14 @@ beforeEach(() => {
     ok: true,
     delivery: "sent",
   });
+  vi.mocked(sdk.threads.spawn).mockResolvedValue(makeThreadResponse());
   vi.mocked(sdk.threads.queuedMessages.create).mockResolvedValue(
     makeQueuedMessage(),
   );
   vi.mocked(sdk.threads.queuedMessages.delete).mockResolvedValue({ ok: true });
+  vi.mocked(sdk.threads.queuedMessages.list).mockResolvedValue([
+    makeQueuedMessage(),
+  ]);
   vi.mocked(sdk.threads.queuedMessages.setGroupBoundary).mockResolvedValue([]);
 });
 
@@ -140,6 +183,28 @@ afterEach(() => {
 });
 
 describe("thread runtime mutations", () => {
+  it("prefetches queued message detail as soon as a queued thread is created", async () => {
+    const { queryClient, wrapper } = createQueryClientTestHarness();
+    const { result } = renderHook(() => useCreateThread(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        projectId: "project-1",
+        environment: { type: "project-default" },
+        input: [{ type: "text", text: "Queued work", mentions: [] }],
+      });
+    });
+
+    await waitFor(() =>
+      expect(sdk.threads.queuedMessages.list).toHaveBeenCalledWith(
+        expect.objectContaining({ threadId: "thread-1" }),
+      ),
+    );
+    expect(
+      queryClient.getQueryData(threadQueuedMessagesQueryKey("thread-1")),
+    ).toEqual([makeQueuedMessage()]);
+  });
+
   it("keeps the existing timeline while an edit is pending and lets connected realtime own success", async () => {
     const { queryClient, wrapper } = createQueryClientTestHarness();
     const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");

--- a/apps/app/src/hooks/mutations/thread-runtime-mutations.ts
+++ b/apps/app/src/hooks/mutations/thread-runtime-mutations.ts
@@ -35,6 +35,7 @@ import {
   beginSendThreadMessageTransaction,
   beginStopThreadTransaction,
   beginUpdateQueuedMessageTransaction,
+  prefetchThreadQueuedMessages,
   rollbackCreateQueuedMessageTransaction,
   rollbackRemoveQueuedMessageTransaction,
   rollbackReorderQueuedMessageTransaction,
@@ -53,7 +54,6 @@ import {
   invalidateThreadBannerQueries,
   invalidateThreadHistoryRewriteQueries,
 } from "../cache-owners/mutation-cache-effects";
-import { threadQueuedMessagesQueryKey } from "../queries/query-keys";
 
 interface CreateThreadQueuedMessageMutationRequest extends CreateQueuedMessageRequest {
   id: string;
@@ -139,9 +139,10 @@ export function useCreateThread() {
     onMutate: async () => beginCreateThreadTransaction({ queryClient }),
     onSuccess: (thread, variables) => {
       if (thread.queuedMessageCount > 0) {
-        void queryClient.prefetchQuery<ThreadQueuedMessageListResponse>({
-          queryKey: threadQueuedMessagesQueryKey(thread.id),
-          queryFn: ({ signal }) =>
+        void prefetchThreadQueuedMessages({
+          queryClient,
+          threadId: thread.id,
+          load: (signal) =>
             sdk.threads.queuedMessages.list({
               threadId: thread.id,
               signal,

--- a/apps/app/src/hooks/mutations/thread-runtime-mutations.ts
+++ b/apps/app/src/hooks/mutations/thread-runtime-mutations.ts
@@ -53,6 +53,7 @@ import {
   invalidateThreadBannerQueries,
   invalidateThreadHistoryRewriteQueries,
 } from "../cache-owners/mutation-cache-effects";
+import { threadQueuedMessagesQueryKey } from "../queries/query-keys";
 
 interface CreateThreadQueuedMessageMutationRequest extends CreateQueuedMessageRequest {
   id: string;
@@ -137,6 +138,16 @@ export function useCreateThread() {
       }),
     onMutate: async () => beginCreateThreadTransaction({ queryClient }),
     onSuccess: (thread, variables) => {
+      if (thread.queuedMessageCount > 0) {
+        void queryClient.prefetchQuery<ThreadQueuedMessageListResponse>({
+          queryKey: threadQueuedMessagesQueryKey(thread.id),
+          queryFn: ({ signal }) =>
+            sdk.threads.queuedMessages.list({
+              threadId: thread.id,
+              signal,
+            }),
+        });
+      }
       applyCreateThreadResult({
         queryClient,
         request: variables,

--- a/apps/app/src/hooks/queries/query-helpers.test.ts
+++ b/apps/app/src/hooks/queries/query-helpers.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type {
-  ThreadListEntry,
-  ThreadWithRuntime,
-  WorkspaceStatus,
-} from "@bb/domain";
+import type { ThreadListEntry, WorkspaceStatus } from "@bb/domain";
 import {
   makeWorkspaceMergeBase,
   makeWorkspaceStatus,
@@ -13,6 +9,7 @@ import type {
   EnvironmentDiffBranchesResponse,
   EnvironmentStatusResponse,
   ProjectBranchesResponse,
+  SidebarBootstrapResponse,
   ThreadResponse,
   ThreadTimelineResponse,
 } from "@bb/server-contract";
@@ -25,6 +22,7 @@ import {
   environmentDiffFilesQueryKeyPrefix,
   environmentDiffPatchQueryKeyPrefix,
   environmentWorkStatusQueryKey,
+  sidebarNavigationQueryKey,
   threadListQueryKey,
   threadsQueryKey,
 } from "./query-keys";
@@ -143,9 +141,9 @@ function makeEnvironmentDiffBranchesResponse(): EnvironmentDiffBranchesResponse 
   };
 }
 
-function makeThreadWithRuntime(
-  thread: Partial<ThreadWithRuntime> = {},
-): ThreadWithRuntime {
+function makeThreadResponse(
+  thread: Partial<ThreadResponse> = {},
+): ThreadResponse {
   return {
     id: "thread-1",
     projectId: "project-1",
@@ -171,7 +169,40 @@ function makeThreadWithRuntime(
       displayStatus: "waiting-for-host",
       hostReconnectGraceExpiresAt: null,
     },
+    activeBackgroundAgentCount: 0,
+    canSpawnChild: false,
+    queuedMessageCount: 0,
     ...thread,
+  };
+}
+
+function makeSidebarNavigation(): SidebarBootstrapResponse {
+  return {
+    sections: [],
+    projects: [
+      {
+        id: "project-1",
+        kind: "standard",
+        name: "Project",
+        gitRemoteUrl: null,
+        createdAt: 1,
+        updatedAt: 1,
+        sources: [],
+        threads: [],
+        defaultExecutionOptions: null,
+      },
+    ],
+    personalProject: {
+      id: "proj_personal",
+      kind: "personal",
+      name: "Personal",
+      gitRemoteUrl: null,
+      createdAt: 1,
+      updatedAt: 1,
+      sources: [],
+      threads: [],
+      defaultExecutionOptions: null,
+    },
   };
 }
 
@@ -243,12 +274,7 @@ describe("resolveEnvironmentWorkStatusPlaceholder", () => {
 
 describe("resolveThreadPlaceholder", () => {
   it("reuses previous thread data only for the same thread query", () => {
-    const previousThread: ThreadResponse = {
-      ...makeThreadWithRuntime({ id: "thread-1" }),
-      activeBackgroundAgentCount: 0,
-      canSpawnChild: false,
-      queuedMessageCount: 0,
-    };
+    const previousThread = makeThreadResponse({ id: "thread-1" });
 
     expect(
       resolveThreadPlaceholder(
@@ -519,7 +545,7 @@ describe("optimisticallyInsertThread", () => {
     const { queryClient } = createQueryClientTestHarness();
     queryClient.setQueryData(threadsQueryKey(), []);
 
-    optimisticallyInsertThread(queryClient, makeThreadWithRuntime());
+    optimisticallyInsertThread(queryClient, makeThreadResponse());
 
     expect(
       queryClient.getQueryData<ThreadListEntry[]>(threadsQueryKey()),
@@ -534,7 +560,7 @@ describe("optimisticallyInsertThread", () => {
     });
     queryClient.setQueryData(threadListKey, []);
 
-    optimisticallyInsertThread(queryClient, makeThreadWithRuntime());
+    optimisticallyInsertThread(queryClient, makeThreadResponse());
 
     const [thread] =
       queryClient.getQueryData<ThreadListEntry[]>(threadListKey) ?? [];
@@ -542,6 +568,71 @@ describe("optimisticallyInsertThread", () => {
       displayStatus: "waiting-for-host",
       hostReconnectGraceExpiresAt: null,
     });
+  });
+
+  it("projects queued work into the thread list and sidebar immediately", () => {
+    const { queryClient } = createQueryClientTestHarness();
+    const threadListKey = threadListQueryKey({
+      archived: false,
+      projectId: "project-1",
+    });
+    queryClient.setQueryData(threadListKey, []);
+    queryClient.setQueryData(
+      sidebarNavigationQueryKey(),
+      makeSidebarNavigation(),
+    );
+
+    optimisticallyInsertThread(
+      queryClient,
+      makeThreadResponse({ queuedMessageCount: 1 }),
+    );
+
+    expect(
+      queryClient.getQueryData<ThreadListEntry[]>(threadListKey)?.[0]
+        ?.queuedWork,
+    ).toBe("waiting");
+    expect(
+      queryClient.getQueryData<SidebarBootstrapResponse>(
+        sidebarNavigationQueryKey(),
+      )?.projects[0]?.threads[0]?.queuedWork,
+    ).toBe("waiting");
+  });
+
+  it("adds queued work without replacing newer realtime row state", () => {
+    const { queryClient } = createQueryClientTestHarness();
+    const threadListKey = threadListQueryKey({
+      archived: false,
+      projectId: "project-1",
+    });
+    queryClient.setQueryData(threadListKey, []);
+    queryClient.setQueryData(
+      sidebarNavigationQueryKey(),
+      makeSidebarNavigation(),
+    );
+    optimisticallyInsertThread(
+      queryClient,
+      makeThreadResponse({
+        runtime: {
+          displayStatus: "active",
+          hostReconnectGraceExpiresAt: null,
+        },
+      }),
+    );
+
+    optimisticallyInsertThread(
+      queryClient,
+      makeThreadResponse({ queuedMessageCount: 1 }),
+    );
+
+    const listThread =
+      queryClient.getQueryData<ThreadListEntry[]>(threadListKey)?.[0];
+    const sidebarThread = queryClient.getQueryData<SidebarBootstrapResponse>(
+      sidebarNavigationQueryKey(),
+    )?.projects[0]?.threads[0];
+    expect(listThread?.runtime.displayStatus).toBe("active");
+    expect(listThread?.queuedWork).toBe("waiting");
+    expect(sidebarThread?.runtime.displayStatus).toBe("active");
+    expect(sidebarThread?.queuedWork).toBe("waiting");
   });
 
   it("respects the originKind filter when inserting source-derived threads", () => {
@@ -556,7 +647,7 @@ describe("optimisticallyInsertThread", () => {
 
     optimisticallyInsertThread(
       queryClient,
-      makeThreadWithRuntime({
+      makeThreadResponse({
         id: "side-chat-1",
         sourceThreadId: "source-1",
         originKind: "fork",
@@ -569,7 +660,7 @@ describe("optimisticallyInsertThread", () => {
 
     optimisticallyInsertThread(
       queryClient,
-      makeThreadWithRuntime({
+      makeThreadResponse({
         id: "fork-1",
         sourceThreadId: "source-1",
         originKind: "fork",

--- a/apps/app/src/views/thread-detail/ThreadDetailPromptArea.keystrokes.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailPromptArea.keystrokes.test.tsx
@@ -387,6 +387,7 @@ function buildPromptArea({
         parentThreadSection={null}
         pendingInteractions={pendingInteractions}
         pendingInteractionsInitialLoading={false}
+        queuedMessageCount={0}
         pendingTodos={null}
         projectId={PROJECT_ID}
         pullRequest={null}

--- a/apps/app/src/views/thread-detail/ThreadDetailPromptArea.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailPromptArea.test.tsx
@@ -59,7 +59,7 @@ const mocks = vi.hoisted(() => ({
     subscribe: vi.fn(() => () => {}),
     text: "",
   },
-  queuedMessages: [] as ThreadQueuedMessage[],
+  queuedMessages: [] as ThreadQueuedMessage[] | undefined,
   reorderQueuedMessageMutateAsync: vi.fn(),
   sendQueuedMessageMutateAsync: vi.fn(),
   setQueuedMessageGroupBoundaryMutateAsync: vi.fn(),
@@ -282,46 +282,52 @@ vi.mock("@/components/promptbox/ThreadEnvironmentSummary", () => ({
   ThreadEnvironmentSummary: () => <div />,
 }));
 
-vi.mock("@/components/promptbox/banner/QueuedMessagesList", () => ({
-  QueuedMessagesList: ({
-    inlineEditor,
-    queuedMessages,
-    onEdit,
-  }: {
-    inlineEditor?: { content: ReactNode; onDismiss: () => void };
-    queuedMessages: readonly ThreadQueuedMessage[];
-    onEdit: (request: {
-      queuedMessageId: string;
-      queuedMessageIndex: number;
-    }) => void;
-  }) => (
-    <div data-testid="queued-message-list">
-      <div data-testid="queued-message-count">{queuedMessages.length}</div>
-      {queuedMessages.map((message, index) => (
-        <button
-          key={message.id}
-          type="button"
-          onClick={() =>
-            onEdit({
-              queuedMessageId: message.id,
-              queuedMessageIndex: index,
-            })
-          }
-        >
-          Edit queued message {index + 1}
-        </button>
-      ))}
-      {inlineEditor ? (
-        <div data-testid="inline-queued-message-editor">
-          {inlineEditor.content}
-          <button type="button" onClick={inlineEditor.onDismiss}>
-            Cancel queued edit
+vi.mock(
+  "@/components/promptbox/banner/QueuedMessagesList",
+  async (importOriginal) => ({
+    ...(await importOriginal<
+      typeof import("@/components/promptbox/banner/QueuedMessagesList")
+    >()),
+    QueuedMessagesList: ({
+      inlineEditor,
+      queuedMessages,
+      onEdit,
+    }: {
+      inlineEditor?: { content: ReactNode; onDismiss: () => void };
+      queuedMessages: readonly ThreadQueuedMessage[];
+      onEdit: (request: {
+        queuedMessageId: string;
+        queuedMessageIndex: number;
+      }) => void;
+    }) => (
+      <div data-testid="queued-message-list">
+        <div data-testid="queued-message-count">{queuedMessages.length}</div>
+        {queuedMessages.map((message, index) => (
+          <button
+            key={message.id}
+            type="button"
+            onClick={() =>
+              onEdit({
+                queuedMessageId: message.id,
+                queuedMessageIndex: index,
+              })
+            }
+          >
+            Edit queued message {index + 1}
           </button>
-        </div>
-      ) : null}
-    </div>
-  ),
-}));
+        ))}
+        {inlineEditor ? (
+          <div data-testid="inline-queued-message-editor">
+            {inlineEditor.content}
+            <button type="button" onClick={inlineEditor.onDismiss}>
+              Cancel queued edit
+            </button>
+          </div>
+        ) : null}
+      </div>
+    ),
+  }),
+);
 
 vi.mock("@/components/promptbox/banner/ThreadBackgroundCommandsCard", () => ({
   ThreadBackgroundCommandsCard: () => null,
@@ -677,6 +683,7 @@ interface RenderPromptAreaOptions {
   pendingInteractions?: readonly PendingInteraction[];
   childPendingInteractions?: readonly ChildThreadPendingAttention[];
   pendingInteractionsInitialLoading?: boolean;
+  queuedMessageCount?: number;
   sentMessageEdit?: ThreadDetailSentMessageEdit;
   thread?: ThreadWithRuntime;
 }
@@ -689,6 +696,7 @@ function buildPromptAreaElement({
   pendingInteractions = [],
   childPendingInteractions = [],
   pendingInteractionsInitialLoading = false,
+  queuedMessageCount = 0,
   sentMessageEdit,
   thread = makeThread(),
 }: RenderPromptAreaOptions = {}) {
@@ -711,6 +719,7 @@ function buildPromptAreaElement({
       parentThreadSection={null}
       pendingInteractions={pendingInteractions}
       pendingInteractionsInitialLoading={pendingInteractionsInitialLoading}
+      queuedMessageCount={queuedMessageCount}
       pendingTodos={null}
       projectId="proj_1"
       pullRequest={null}
@@ -760,6 +769,19 @@ afterEach(() => {
 });
 
 describe("ThreadDetailPromptArea", () => {
+  it("shows queued work while its message details are loading", () => {
+    mocks.queuedMessages = undefined;
+
+    renderPromptArea({ queuedMessageCount: 1 });
+
+    expect(screen.getByRole("status").textContent).toContain(
+      "Loading queued message details",
+    );
+    expect(screen.getByLabelText("Queued messages").textContent).toContain(
+      "Queue1",
+    );
+  });
+
   it("keeps sent-message edit submission out of the normal send path", () => {
     mocks.defaultExecutionOptions = {
       model: "gpt-5",

--- a/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
@@ -61,6 +61,7 @@ import type {
 } from "@/components/workspace/workspace-change-summary";
 import {
   QueuedMessagesList,
+  QueuedMessagesPendingCard,
   type QueuedMessageInlineEditor,
 } from "@/components/promptbox/banner/QueuedMessagesList";
 import { ThreadEnvironmentSummary } from "@/components/promptbox/ThreadEnvironmentSummary";
@@ -141,6 +142,7 @@ export interface ThreadDetailSentMessageEdit {
 }
 
 const THREAD_DETAIL_COMPOSER_TEXTAREA_ID = "thread-detail-follow-up-composer";
+const EMPTY_QUEUED_MESSAGES: readonly ThreadQueuedMessage[] = [];
 
 interface ThreadDetailPromptAreaProps {
   activeBackgroundAgentCount: number;
@@ -164,6 +166,7 @@ interface ThreadDetailPromptAreaProps {
   isEnvironmentActionPending: boolean;
   pendingInteractions: readonly PendingInteraction[];
   pendingInteractionsInitialLoading: boolean;
+  queuedMessageCount: number;
   onChangedFileClick: (selection: WorkspaceChangedFileSelection) => void;
   projectId: string;
   resolveMentionLink: PromptMentionLinkResolver;
@@ -356,6 +359,7 @@ export function ThreadDetailPromptArea({
   isEnvironmentActionPending,
   pendingInteractions,
   pendingInteractionsInitialLoading,
+  queuedMessageCount,
   onChangedFileClick,
   projectId,
   resolveMentionLink,
@@ -402,9 +406,12 @@ export function ThreadDetailPromptArea({
   });
   const isDefaultExecutionOptionsLoading =
     defaultExecutionOptionsState === "loading";
-  const { data: queuedMessages = [] } = useThreadQueuedMessages(thread.id, {
+  const queuedMessagesQuery = useThreadQueuedMessages(thread.id, {
     enabled: true,
   });
+  const queuedMessages = queuedMessagesQuery.data ?? EMPTY_QUEUED_MESSAGES;
+  const queuedMessagesPending =
+    queuedMessagesQuery.data === undefined && queuedMessageCount > 0;
   const queuedMessagesRef =
     useLatestRef<readonly ThreadQueuedMessage[]>(queuedMessages);
   const [bottomPluginFocusNonce, setBottomPluginFocusNonce] = useState(0);
@@ -1589,7 +1596,9 @@ export function ThreadDetailPromptArea({
             threadId={thread.id}
           />
         ) : null}
-        {shouldHideComposer ? null : (
+        {shouldHideComposer ? null : queuedMessagesPending ? (
+          <QueuedMessagesPendingCard queuedMessageCount={queuedMessageCount} />
+        ) : (
           <QueuedMessagesList
             queuedMessages={queuedMessages}
             resolveMentionLink={resolveMentionLink}
@@ -1646,7 +1655,9 @@ export function ThreadDetailPromptArea({
       pullRequestSection,
       pendingTodos,
       displayedProcessingQueuedMessage,
+      queuedMessageCount,
       queuedMessages,
+      queuedMessagesPending,
       resolveMentionLink,
       runtimeDisplayStatus,
       shouldHideComposer,

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -2531,6 +2531,7 @@ function ThreadDetailViewInternal(props: ThreadRoutePathArgs) {
       }
       pendingInteractions={pendingInteractions}
       pendingInteractionsInitialLoading={pendingInteractionsInitialLoading}
+      queuedMessageCount={thread.queuedMessageCount}
       pendingTodos={pendingTodos}
       activePromptMode={activePromptMode}
       goal={goal}


### PR DESCRIPTION
## Human comments

## What was wrong

New-thread creation already returned the authoritative `queuedMessageCount`, but the app projected every create response into list caches with `queuedWork: "none"` and did not update the sidebar cache. Queue details and sidebar state therefore arrived through separate later reads, producing a blank interval followed by the queue drawer and then the sidebar clock.

## What changed

- Derive the initial list-row queue state from `ThreadResponse.queuedMessageCount` and synchronously upsert it into matching thread-list and sidebar caches.
- Preserve a newer realtime row if it arrived before the create mutation settled, while adding the missing queued-work signal.
- Start fetching queued-message details as soon as queued creation succeeds.
- Render a temporary queue-details loading surface only when the authoritative count is positive and detail data is not available yet.
- Keep this app-only: no API, database, host-daemon protocol, CLI, or persisted-data changes.

## How you verified

- Added regressions for immediate list/sidebar queue projection, realtime reconciliation, queued-detail prefetch, and the temporary pending surface.
- `pnpm exec turbo run test --filter=@bb/app -- --run src/hooks/queries/query-helpers.test.ts src/hooks/mutations/thread-runtime-mutations.test.tsx src/views/thread-detail/ThreadDetailPromptArea.test.tsx src/views/thread-detail/ThreadDetailPromptArea.keystrokes.test.tsx` — 59 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run lint --filter=@bb/app` — 0 errors.
- Manually created threads against the dev server before and after a clean restart.

> AGENT GENERATED
