### PR TITLE
Remove stale provider-retry install explanation

### DIFF
--- a/plugins/provider-retry/server.test.ts
+++ b/plugins/provider-retry/server.test.ts
@@ -359,9 +359,7 @@ describe("provider retry plugin", () => {
     // The load-bearing half is the empty hook slot. This plugin must never
     // intercept a send: a remembered rate limit is a stale cache of provider
     // state, and refusing an attempt on it strands a user who fixed the limit
-    // out of band. It is also what keeps a stock install free of
-    // `message.dispatch` handlers entirely, since the only other one ships
-    // disabled by default.
+    // out of band.
     const host = createHost();
     await plugin(host.bb);
 


### PR DESCRIPTION
## Human comments

## What was wrong

PR #2815 correctly enabled Send later and concurrency control for fresh installs while preserving existing choices, but `plugins/provider-retry/server.test.ts` still claimed that a stock install had no `message.dispatch` handler because the other handler shipped disabled. That explanation became false after #2815; runtime behavior and the test itself were already correct.

## What changed

- Remove only the stale stock-install explanation.
- Preserve the accurate rationale for why provider-retry must not intercept sends.
- Leave assertions, runtime behavior, and protocol unchanged.

## How you verified

- `pnpm exec turbo run test --filter=bb-plugin-provider-retry --force` — 15/15 passed after rebasing onto current `main`.
- `pnpm exec turbo run typecheck --filter=bb-plugin-provider-retry --force` — passed after rebasing.
- `pnpm exec oxfmt plugins/provider-retry/server.test.ts --check` — passed.
- `git diff --check origin/main...HEAD` — passed.

Follow-up to #2815.

> AGENT GENERATED
