### PR TITLE
Stop automatic retries of failed queued messages

### DIFF
--- a/apps/server/test/threads/queue-drain-failure.test.ts
+++ b/apps/server/test/threads/queue-drain-failure.test.ts
@@ -170,7 +170,10 @@ describe("recordQueuedMessageDrainFailure", () => {
       });
 
       const queued = reread(harness, row.id);
-      expect(queued.waitingOn).toEqual({ kind: "host-offline", hostName: "M4" });
+      expect(queued.waitingOn).toEqual({
+        kind: "host-offline",
+        hostName: "M4",
+      });
       expect(queued.sendAt).toBeNull();
       // An absent machine is a wait, not a failure: the row recovers by itself
       // when the host comes back, so presenting it as an error would be wrong.
@@ -247,7 +250,10 @@ describe("recordQueuedMessageDrainFailure", () => {
       // fresh statement of why the row is waiting supersedes the stale failure
       // instead of showing the reader two contradictory explanations.
       const queued = reread(harness, row.id);
-      expect(queued.waitingOn).toEqual({ kind: "host-offline", hostName: "M4" });
+      expect(queued.waitingOn).toEqual({
+        kind: "host-offline",
+        hostName: "M4",
+      });
       expect(queued.failureReason).toBeNull();
     });
   });

--- a/apps/server/test/threads/queue-drain-failure.test.ts
+++ b/apps/server/test/threads/queue-drain-failure.test.ts
@@ -1,12 +1,19 @@
 import {
+  claimQueuedThreadMessageGroup,
   getQueuedThreadMessage,
   listEvents,
   setQueuedThreadMessageFailureReason,
 } from "@bb/db";
+import type { PluginHookName } from "@get-bb/plugin-sdk";
 import { describe, expect, it } from "vitest";
 import { ApiError } from "../../src/errors.js";
+import {
+  setPluginHookProvider,
+  type PluginHookRegistration,
+} from "../../src/services/plugins/plugin-hook-registry.js";
 import { recordQueuedMessageDrainFailure } from "../../src/services/threads/queue-drain-failure.js";
 import { drainThreadQueueOnHostReconnect } from "../../src/services/threads/queue-drains.js";
+import { runQueuedMessageAutoSendSweep } from "../../src/services/threads/queued-messages.js";
 import { toThreadQueuedMessage } from "../../src/services/threads/thread-queued-messages.js";
 import { textInput } from "../helpers/prompt-input.js";
 import {
@@ -20,6 +27,10 @@ import {
 import { withTestHarness, type TestAppHarness } from "../helpers/test-app.js";
 
 const WORKSPACE_PATH = "/tmp/queue-drain-failure-project";
+
+type HookRegistry = {
+  [K in PluginHookName]: PluginHookRegistration<K>[];
+};
 
 /**
  * A thread with a queued row on a host that is either connected or not.
@@ -98,6 +109,50 @@ describe("drainThreadQueueOnHostReconnect", () => {
 });
 
 describe("recordQueuedMessageDrainFailure", () => {
+  it("does not automatically re-attempt a terminally failed row", async () => {
+    await withTestHarness(async (harness) => {
+      let attempts = 0;
+      const registry: HookRegistry = { "message.dispatch": [] };
+      registry["message.dispatch"].push({
+        pluginId: "rejector",
+        handler: () => {
+          attempts += 1;
+          return { action: "reject", message: "Rejected for testing" } as const;
+        },
+      });
+      setPluginHookProvider({
+        listHooks: (hook) => registry[hook],
+        invokeHook: async (_pluginId, _label, run) => ({
+          ok: true,
+          value: await run(),
+        }),
+        decisionTimeoutMs: 10_000,
+      });
+
+      try {
+        const { row } = seedQueuedRow(harness, {
+          hostConnected: true,
+          hostName: "M4",
+        });
+
+        await runQueuedMessageAutoSendSweep(harness.deps);
+        expect(reread(harness, row.id).failureReason).toBe(
+          "Rejected for testing",
+        );
+
+        await runQueuedMessageAutoSendSweep(harness.deps);
+        await runQueuedMessageAutoSendSweep(harness.deps);
+
+        expect(attempts).toBe(1);
+        expect(
+          claimQueuedThreadMessageGroup(harness.db, harness.deps.hub, row.id),
+        ).not.toBeNull();
+      } finally {
+        setPluginHookProvider(undefined);
+      }
+    });
+  });
+
   it("re-queues on the named host when the machine is the thing that is missing", async () => {
     await withTestHarness(async (harness) => {
       const { thread, row } = seedQueuedRow(harness, {

--- a/apps/server/test/threads/requested-queue-drain.test.ts
+++ b/apps/server/test/threads/requested-queue-drain.test.ts
@@ -1,4 +1,4 @@
-import { listEvents, listQueuedThreadMessages, setQueuedThreadMessageGroupBoundary } from "@bb/db";
+import { listEvents, listQueuedThreadMessages, setQueuedThreadMessageFailureReason, setQueuedThreadMessageGroupBoundary } from "@bb/db";
 import type { PluginHookName } from "@get-bb/plugin-sdk";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
@@ -142,6 +142,26 @@ describe("the requested queue drain", () => {
 
       expect(listQueuedThreadMessages(harness.db, thread.id)).toHaveLength(0);
       expect(turnRequests(harness, thread.id)).toHaveLength(turnsBefore + 1);
+    });
+  });
+
+  it.each(["scheduled", "plugin"] as const)("does not dispatch a %s group containing a failed row", async (drain) => {
+    await withTestHarness(async (harness) => {
+      let attempts = 0;
+      installHooks({ "message.dispatch": [{ pluginId: "limiter", handler: () => { attempts += 1; return { action: "wait", reason: "At capacity" } as const; } }] });
+      const { thread } = seedRunnableThread(harness, { hostId: `host-failed-${drain}-group`, status: "idle" });
+      const waitingOn = drain === "scheduled" ? ({ kind: "time" } as const) : ({ kind: "plugin", pluginId: "limiter", reason: "At capacity" } as const);
+      const sendAt = drain === "scheduled" ? Date.now() - 1_000 : null;
+      const lead = seedQueuedMessage(harness.deps, { threadId: thread.id, content: textInput("lead"), waitingOn, sendAt });
+      const failed = seedQueuedMessage(harness.deps, { threadId: thread.id, content: textInput("failed"), waitingOn, sendAt });
+      setQueuedThreadMessageGroupBoundary({ db: harness.db, notifier: harness.deps.hub, threadId: thread.id, expectedGroupedPrefixQueuedMessageIds: [lead.id, failed.id], groupBoundaryQueuedMessageId: failed.id });
+      setQueuedThreadMessageFailureReason(harness.db, harness.deps.hub, { id: failed.id, threadId: thread.id, failureReason: "Terminal failure" });
+
+      if (drain === "scheduled") await runDueScheduledQueueSweep(harness.deps, Date.now());
+      else await runRequestedQueueDrain(harness.deps);
+
+      expect(attempts).toBe(0);
+      expect(listQueuedThreadMessages(harness.db, thread.id)).toHaveLength(2);
     });
   });
 

--- a/apps/server/test/threads/requested-queue-drain.test.ts
+++ b/apps/server/test/threads/requested-queue-drain.test.ts
@@ -1,4 +1,9 @@
-import { listEvents, listQueuedThreadMessages, setQueuedThreadMessageFailureReason, setQueuedThreadMessageGroupBoundary } from "@bb/db";
+import {
+  listEvents,
+  listQueuedThreadMessages,
+  setQueuedThreadMessageFailureReason,
+  setQueuedThreadMessageGroupBoundary,
+} from "@bb/db";
 import type { PluginHookName } from "@get-bb/plugin-sdk";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
@@ -91,14 +96,40 @@ describe("the requested queue drain", () => {
     await withTestHarness(async (harness) => {
       vi.useFakeTimers();
       let attempts = 0;
-      installHooks({ "message.dispatch": [{ pluginId: "limiter", handler: () => ++attempts === 1 ? ({ action: "wait", reason: "At capacity" } as const) : { action: "proceed" } }] });
+      installHooks({
+        "message.dispatch": [
+          {
+            pluginId: "limiter",
+            handler: () =>
+              ++attempts === 1
+                ? ({ action: "wait", reason: "At capacity" } as const)
+                : { action: "proceed" },
+          },
+        ],
+      });
       const { thread } = seedRunnableThread(harness, {
         hostId: "host-scheduled-group",
         status: "idle",
       });
-      const lead = seedQueuedMessage(harness.deps, { threadId: thread.id, content: textInput("lead"), waitingOn: { kind: "time" }, sendAt: Date.now() - 2_000 });
-      const tail = seedQueuedMessage(harness.deps, { threadId: thread.id, content: textInput("tail"), waitingOn: { kind: "time" }, sendAt: Date.now() - 1_000 });
-      setQueuedThreadMessageGroupBoundary({ db: harness.db, notifier: harness.deps.hub, threadId: thread.id, expectedGroupedPrefixQueuedMessageIds: [lead.id, tail.id], groupBoundaryQueuedMessageId: tail.id });
+      const lead = seedQueuedMessage(harness.deps, {
+        threadId: thread.id,
+        content: textInput("lead"),
+        waitingOn: { kind: "time" },
+        sendAt: Date.now() - 2_000,
+      });
+      const tail = seedQueuedMessage(harness.deps, {
+        threadId: thread.id,
+        content: textInput("tail"),
+        waitingOn: { kind: "time" },
+        sendAt: Date.now() - 1_000,
+      });
+      setQueuedThreadMessageGroupBoundary({
+        db: harness.db,
+        notifier: harness.deps.hub,
+        threadId: thread.id,
+        expectedGroupedPrefixQueuedMessageIds: [lead.id, tail.id],
+        groupBoundaryQueuedMessageId: tail.id,
+      });
 
       await runDueScheduledQueueSweep(harness.deps, Date.now());
       vi.advanceTimersByTime(1_001);
@@ -120,7 +151,10 @@ describe("the requested queue drain", () => {
         pluginId: "limiter",
         handler: () =>
           full
-            ? ({ action: "wait", reason: "1 of 1 running on all hosts" } as const)
+            ? ({
+                action: "wait",
+                reason: "1 of 1 running on all hosts",
+              } as const)
             : ({ action: "proceed" } as const),
       });
       installHooks(registry);
@@ -145,25 +179,69 @@ describe("the requested queue drain", () => {
     });
   });
 
-  it.each(["scheduled", "plugin"] as const)("does not dispatch a %s group containing a failed row", async (drain) => {
-    await withTestHarness(async (harness) => {
-      let attempts = 0;
-      installHooks({ "message.dispatch": [{ pluginId: "limiter", handler: () => { attempts += 1; return { action: "wait", reason: "At capacity" } as const; } }] });
-      const { thread } = seedRunnableThread(harness, { hostId: `host-failed-${drain}-group`, status: "idle" });
-      const waitingOn = drain === "scheduled" ? ({ kind: "time" } as const) : ({ kind: "plugin", pluginId: "limiter", reason: "At capacity" } as const);
-      const sendAt = drain === "scheduled" ? Date.now() - 1_000 : null;
-      const lead = seedQueuedMessage(harness.deps, { threadId: thread.id, content: textInput("lead"), waitingOn, sendAt });
-      const failed = seedQueuedMessage(harness.deps, { threadId: thread.id, content: textInput("failed"), waitingOn, sendAt });
-      setQueuedThreadMessageGroupBoundary({ db: harness.db, notifier: harness.deps.hub, threadId: thread.id, expectedGroupedPrefixQueuedMessageIds: [lead.id, failed.id], groupBoundaryQueuedMessageId: failed.id });
-      setQueuedThreadMessageFailureReason(harness.db, harness.deps.hub, { id: failed.id, threadId: thread.id, failureReason: "Terminal failure" });
+  it.each(["scheduled", "plugin"] as const)(
+    "does not dispatch a %s group containing a failed row",
+    async (drain) => {
+      await withTestHarness(async (harness) => {
+        let attempts = 0;
+        installHooks({
+          "message.dispatch": [
+            {
+              pluginId: "limiter",
+              handler: () => {
+                attempts += 1;
+                return { action: "wait", reason: "At capacity" } as const;
+              },
+            },
+          ],
+        });
+        const { thread } = seedRunnableThread(harness, {
+          hostId: `host-failed-${drain}-group`,
+          status: "idle",
+        });
+        const waitingOn =
+          drain === "scheduled"
+            ? ({ kind: "time" } as const)
+            : ({
+                kind: "plugin",
+                pluginId: "limiter",
+                reason: "At capacity",
+              } as const);
+        const sendAt = drain === "scheduled" ? Date.now() - 1_000 : null;
+        const lead = seedQueuedMessage(harness.deps, {
+          threadId: thread.id,
+          content: textInput("lead"),
+          waitingOn,
+          sendAt,
+        });
+        const failed = seedQueuedMessage(harness.deps, {
+          threadId: thread.id,
+          content: textInput("failed"),
+          waitingOn,
+          sendAt,
+        });
+        setQueuedThreadMessageGroupBoundary({
+          db: harness.db,
+          notifier: harness.deps.hub,
+          threadId: thread.id,
+          expectedGroupedPrefixQueuedMessageIds: [lead.id, failed.id],
+          groupBoundaryQueuedMessageId: failed.id,
+        });
+        setQueuedThreadMessageFailureReason(harness.db, harness.deps.hub, {
+          id: failed.id,
+          threadId: thread.id,
+          failureReason: "Terminal failure",
+        });
 
-      if (drain === "scheduled") await runDueScheduledQueueSweep(harness.deps, Date.now());
-      else await runRequestedQueueDrain(harness.deps);
+        if (drain === "scheduled")
+          await runDueScheduledQueueSweep(harness.deps, Date.now());
+        else await runRequestedQueueDrain(harness.deps);
 
-      expect(attempts).toBe(0);
-      expect(listQueuedThreadMessages(harness.db, thread.id)).toHaveLength(2);
-    });
-  });
+        expect(attempts).toBe(0);
+        expect(listQueuedThreadMessages(harness.db, thread.id)).toHaveLength(2);
+      });
+    },
+  );
 
   it("leaves rows on core waits alone", async () => {
     // A `thread-busy` row is waiting on its own thread's turn ending, not on
@@ -177,7 +255,10 @@ describe("the requested queue drain", () => {
         status: "active",
       });
       await acceptThreadSendRequest(harness.deps, {
-        payload: { input: textInput("after this turn"), mode: "queue-if-active" },
+        payload: {
+          input: textInput("after this turn"),
+          mode: "queue-if-active",
+        },
         thread,
       });
       const queued = listQueuedThreadMessages(harness.db, thread.id);

--- a/packages/db/src/data/queued-thread-messages.ts
+++ b/packages/db/src/data/queued-thread-messages.ts
@@ -858,7 +858,11 @@ export function claimQueuedThreadMessageGroup(
       if (group === null) {
         return null;
       }
-      if (isGroupEligible && !isGroupEligible(group)) {
+      if (
+        isGroupEligible &&
+        (!group.every((row) => row.failureReason === null) ||
+          !isGroupEligible(group))
+      ) {
         return null;
       }
       if (!isGroupEligible && group[0]?.id !== id) {

--- a/packages/db/src/data/queued-thread-messages.ts
+++ b/packages/db/src/data/queued-thread-messages.ts
@@ -257,6 +257,7 @@ function partitionQueuedMessageGroups(
  * pointer at the SQL so the two cannot drift silently.
  */
 function isIdleDrainableQueuedMessage(row: QueuedThreadMessageRow): boolean {
+  if (row.failureReason !== null) return false;
   if (row.waitingOn === null) return true;
   try {
     const parsed = JSON.parse(row.waitingOn) as { kind?: unknown };
@@ -1353,6 +1354,13 @@ function liveQueuedThreadMessage() {
   );
 }
 
+function automaticallyDrainableQueuedThreadMessage() {
+  return and(
+    liveQueuedThreadMessage(),
+    isNull(queuedThreadMessages.failureReason),
+  );
+}
+
 /**
  * Rows the IDLE drain may claim: a row with no wait at all, or one waiting
  * only on the thread being busy — which is exactly the wait an idle thread
@@ -1369,7 +1377,7 @@ function liveQueuedThreadMessage() {
  */
 function drainableQueuedThreadMessage() {
   return and(
-    liveQueuedThreadMessage(),
+    automaticallyDrainableQueuedThreadMessage(),
     or(
       isNull(queuedThreadMessages.waitingOn),
       sql`json_extract(${queuedThreadMessages.waitingOn}, '$.kind') = 'thread-busy'`,
@@ -1635,7 +1643,7 @@ export function listDueScheduledQueuedThreadMessages(
       and(
         isNotNull(queuedThreadMessages.sendAt),
         lte(queuedThreadMessages.sendAt, now),
-        liveQueuedThreadMessage(),
+        automaticallyDrainableQueuedThreadMessage(),
         exists(
           db
             .select({ live: sql`1` })
@@ -1675,7 +1683,7 @@ export function listQueuedThreadMessagesByWaitHolder(
     .where(
       and(
         eq(queuedThreadMessages.waitHolder, waitHolder),
-        liveQueuedThreadMessage(),
+        automaticallyDrainableQueuedThreadMessage(),
       ),
     )
     .orderBy(
@@ -1726,7 +1734,7 @@ export function listQueuedThreadMessagePluginWaitRefs(
     .where(
       and(
         isNotNull(queuedThreadMessages.waitHolder),
-        liveQueuedThreadMessage(),
+        automaticallyDrainableQueuedThreadMessage(),
       ),
     )
     .orderBy(
@@ -1757,7 +1765,7 @@ export function listQueuedThreadMessagesWaitingOnKind(
       and(
         eq(queuedThreadMessages.threadId, args.threadId),
         sql`json_extract(${queuedThreadMessages.waitingOn}, '$.kind') = ${args.kind}`,
-        liveQueuedThreadMessage(),
+        automaticallyDrainableQueuedThreadMessage(),
       ),
     )
     .orderBy(asc(queuedThreadMessages.sortKey), asc(queuedThreadMessages.id))
@@ -1813,7 +1821,7 @@ export function listThreadIdsWithHostOfflineQueueWaits(
       and(
         eq(environments.hostId, hostId),
         sql`json_extract(${queuedThreadMessages.waitingOn}, '$.kind') = 'host-offline'`,
-        liveQueuedThreadMessage(),
+        automaticallyDrainableQueuedThreadMessage(),
       ),
     )
     .all()


### PR DESCRIPTION
## Human comments

## What was wrong

The durable queue introduced in #2779 records a background dispatch failure on the queued row. Automatic selectors did not exclude that failed state, so later sweeps could keep running plugin hooks and dispatch preparation without an explicit retry.

There was also a grouped-message race: even after filtering failed rows from the selectors, a clean member could enter the atomic claim and pull a failed member from the same group back into an automatic attempt.

## What changed

The shared database selectors exclude terminally failed rows from automatic drains. The atomic grouped-claim boundary now also requires every group member to have no failure whenever an automatic eligibility callback is present. This closes both the clean-member bypass and a failure recorded after selection.

Explicit Send now claims without that automatic callback, so users can still retry failed messages deliberately. Failed rows remain visible through the API and UI.

Normal temporary conditions such as a busy thread, future schedule, provisioning, pending interaction, plugin wait, disconnected host, and host-command timeout do not enter the failed state and still recover automatically.

There are no schema, migration, host-daemon protocol, CLI, configuration, SDK, or documentation changes.

## How you verified

- Added a production database/server sweep regression that failed before the fix with three hook attempts instead of one, then passed after the fix while proving the failed row remained explicitly claimable by ID.
- Added grouped scheduled and requested-plugin service regressions. Before the transactional guard, each incorrectly invoked the dispatch hook once; afterward, both leave the two-row group untouched with zero attempts.
- `pnpm exec turbo run test typecheck build --filter=@bb/db --filter=@bb/server --force` on the rebased tree — DB 442 tests passed, server 2124 tests passed, and typechecks/builds passed.

Fixes #2779

> AGENT GENERATED
