### PR TITLE
Default concurrency to available processor count

### DIFF
--- a/apps/server/src/services/skills/builtin-skills/bb-cli/references/plugins.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/references/plugins.md
@@ -10,7 +10,7 @@
   `bb concurrency-limit status [--json]`,
   `bb concurrency-limit global [unlimited|<limit>] [--json]`, and
   `bb concurrency-limit host <host-id> [auto|<limit>] [--json]`. Automatic
-  host limits use half the available processors, from 1 to 8.
+  host limits allow one thread per available processor.
 - **BB plugin catalog** (store under `/api/v1/plugin-catalog`):
   - The store lists the **BB Community marketplace** catalog: a manifest
     the server re-reads at startup and every two hours from

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -181,7 +181,7 @@ bb keep-awake hosts <host-id>...
 
 The builtin Concurrency limit plugin has an autosaving page under Extensions
 → Plugins. Its overall limit is unlimited by default. Each host defaults to
-Auto: half its available processors, from 1 to 8. A blank host field restores
+Auto: one thread per available processor. A blank host field restores
 Auto, and 0 pauses new work for that scope. Configure it from an agent or
 terminal with:
 

--- a/packages/templates/src/templates/bb-guide-customization.md
+++ b/packages/templates/src/templates/bb-guide-customization.md
@@ -74,8 +74,8 @@ choosing Sleep still sleeps the Mac.
 
 Concurrency limit is also owned by its builtin plugin. Its autosaving page
 under Extensions → Plugins leaves the overall limit unlimited by default and
-uses an automatic per-host limit equal to half the available processors, from
-1 to 8. Use `bb concurrency-limit global [unlimited|<limit>]` and `bb
+uses an automatic per-host limit of one thread per available processor. Use
+`bb concurrency-limit global [unlimited|<limit>]` and `bb
 concurrency-limit host <host-id> [auto|<limit>]`; 0 pauses new work.
 
 Settings → Keyboard also includes `showKeyboardHints`, which defaults to true.

--- a/packages/templates/src/templates/bb-guide-plugins.md
+++ b/packages/templates/src/templates/bb-guide-plugins.md
@@ -41,7 +41,7 @@ workers and their child processes.
 
 The builtin Concurrency limit plugin controls how many threads run at once.
 Its settings page has an optional overall limit and one limit per host. Host
-limits default to Auto: half the host's available processors, from 1 to 8.
+limits default to Auto: one thread per available processor.
 Leave an override blank to return it to Auto; use 0 to pause new work. The CLI
 equivalents are:
 

--- a/plugins/concurrency-limit/app.test.tsx
+++ b/plugins/concurrency-limit/app.test.tsx
@@ -13,8 +13,8 @@ const hosts = [
     name: "Laptop",
     status: "connected" as const,
     availableParallelism: 8,
-    automaticLimit: 4,
-    effectiveLimit: 4,
+    automaticLimit: 8,
+    effectiveLimit: 8,
     override: null,
   },
   {
@@ -81,7 +81,7 @@ describe("Concurrency limit settings", () => {
 
     expect(await slot.findByText("Host limits")).toBeTruthy();
     expect(
-      slot.getByText("Auto uses half the available processors, up to 8."),
+      slot.getByText("Auto allows one thread per available processor."),
     ).toBeTruthy();
     expect(slot.getByText("8 processors")).toBeTruthy();
     expect(slot.getByText("Offline")).toBeTruthy();
@@ -89,7 +89,7 @@ describe("Concurrency limit settings", () => {
       slot
         .getByRole("spinbutton", { name: "Laptop thread limit" })
         .getAttribute("placeholder"),
-    ).toBe("Auto (4)");
+    ).toBe("Auto (8)");
   });
 
   it("saves overall and per-host limits without accepting invalid numbers", async () => {

--- a/plugins/concurrency-limit/app.tsx
+++ b/plugins/concurrency-limit/app.tsx
@@ -6,7 +6,7 @@ import {
   type StandardSchemaV1InferOutput,
 } from "@get-bb/plugin-sdk/app";
 import { Input } from "@bb/shared-ui/input";
-import { MAX_AUTOMATIC_LIMIT, MAX_LIMIT_VALUE } from "./limits.js";
+import { MAX_LIMIT_VALUE } from "./limits.js";
 import type { concurrencyLimitRpcContract } from "./server.js";
 
 type ConfigurationView = StandardSchemaV1InferOutput<
@@ -192,7 +192,7 @@ function ConcurrencyLimitSettings() {
       <div className="border-t border-border/60 pt-4">
         <h3 className="text-sm font-medium text-foreground">Host limits</h3>
         <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-          Auto uses half the available processors, up to {MAX_AUTOMATIC_LIMIT}.
+          Auto allows one thread per available processor.
         </p>
 
         <div className="ml-2 mt-2 border-l border-border/60 pl-2">

--- a/plugins/concurrency-limit/limits.test.ts
+++ b/plugins/concurrency-limit/limits.test.ts
@@ -5,11 +5,11 @@ describe("automaticHostLimit", () => {
   it.each([
     [null, 1],
     [1, 1],
-    [2, 1],
-    [4, 2],
-    [8, 4],
-    [16, 8],
-    [32, 8],
+    [2, 2],
+    [4, 4],
+    [8, 8],
+    [16, 16],
+    [32, 32],
   ])("maps %s available processors to %s threads", (processors, limit) => {
     expect(automaticHostLimit(processors)).toBe(limit);
   });
@@ -20,11 +20,11 @@ describe("resolveHostLimit", () => {
     const configuration = { globalLimit: null, hostOverrides: [] };
 
     expect(resolveHostLimit(configuration, "host-a", 8)).toEqual({
-      limit: 4,
+      limit: 8,
       mode: "automatic",
     });
     expect(resolveHostLimit(configuration, "host-b", 16)).toEqual({
-      limit: 8,
+      limit: 16,
       mode: "automatic",
     });
   });

--- a/plugins/concurrency-limit/limits.ts
+++ b/plugins/concurrency-limit/limits.ts
@@ -1,5 +1,4 @@
 export const MAX_LIMIT_VALUE = 10_000;
-export const MAX_AUTOMATIC_LIMIT = 8;
 
 export interface HostLimitOverride {
   readonly hostId: string;
@@ -20,10 +19,7 @@ export function automaticHostLimit(
   availableParallelism: number | null,
 ): number {
   if (availableParallelism === null) return 1;
-  return Math.min(
-    MAX_AUTOMATIC_LIMIT,
-    Math.max(1, Math.floor(availableParallelism / 2)),
-  );
+  return availableParallelism;
 }
 
 export function resolveHostLimit(

--- a/plugins/concurrency-limit/server.test.ts
+++ b/plugins/concurrency-limit/server.test.ts
@@ -212,8 +212,8 @@ describe("configuration", () => {
             name: "Laptop",
             status: "connected",
             availableParallelism: 8,
-            automaticLimit: 4,
-            effectiveLimit: 4,
+            automaticLimit: 8,
+            effectiveLimit: 8,
             override: null,
           },
           {
@@ -221,8 +221,8 @@ describe("configuration", () => {
             name: "Studio",
             status: "disconnected",
             availableParallelism: 16,
-            automaticLimit: 8,
-            effectiveLimit: 8,
+            automaticLimit: 16,
+            effectiveLimit: 16,
             override: null,
           },
         ],
@@ -285,8 +285,8 @@ describe("configuration", () => {
         {
           id: "host-a",
           availableParallelism: 12,
-          automaticLimit: 6,
-          effectiveLimit: 6,
+          automaticLimit: 12,
+          effectiveLimit: 12,
         },
       ],
     });
@@ -340,7 +340,7 @@ describe("configuration", () => {
       harness.behavior.runCli(["host", "host-a", "auto"]),
     ).resolves.toMatchObject({
       exitCode: 0,
-      stdout: "Laptop: auto, 4 (8 processors, connected)",
+      stdout: "Laptop: auto, 8 (8 processors, connected)",
     });
     await expect(
       harness.behavior.runCli(["global", "1.5"]),
@@ -366,12 +366,16 @@ describe("message.dispatch", () => {
         running({ id: "b" }),
         running({ id: "c" }),
         running({ id: "d" }),
+        running({ id: "e" }),
+        running({ id: "f" }),
+        running({ id: "g" }),
+        running({ id: "h" }),
       ],
     });
 
     await expect(hook(dispatchContext())).resolves.toEqual({
       action: "wait",
-      reason: "4 of 4 running on host host-a",
+      reason: "8 of 8 running on host host-a",
     });
   });
 

--- a/plugins/concurrency-limit/server.ts
+++ b/plugins/concurrency-limit/server.ts
@@ -8,7 +8,6 @@ import { z } from "zod";
 import { concurrencyLimitHostContract } from "./contract.js";
 import {
   automaticHostLimit,
-  MAX_AUTOMATIC_LIMIT,
   MAX_LIMIT_VALUE,
   resolveHostLimit,
   type HostLimitOverride,
@@ -290,7 +289,7 @@ export default async function concurrencyLimitPlugin(
             ? JSON.stringify(view)
             : [
                 `Overall: ${view.globalLimit === null ? "unlimited" : view.globalLimit}`,
-                `Automatic host limit: half of available processors, up to ${MAX_AUTOMATIC_LIMIT}`,
+                "Automatic host limit: one thread per available processor",
                 ...view.hosts.map(formatHostLine),
               ].join("\n"),
         };


### PR DESCRIPTION
## Human comments

## What was wrong

The automatic per-host concurrency policy divided detected processor capacity by two and capped the result at eight, so hosts defaulted to less concurrency than their available processor count.

## What changed

The Concurrency limit plugin now maps each detected host capacity directly to its automatic thread limit. The settings UI, CLI status text, built-in agent reference, configuration docs, and generated guide sources describe the new default, and backend/frontend tests cover the resulting values. Explicit global and per-host overrides are unchanged. No server-to-host daemon wire contract changed, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

## How you verified

- `pnpm exec turbo run test typecheck --filter=bb-plugin-concurrency-limit` (28 tests passed)
- `bb plugin build plugins/concurrency-limit`
- `pnpm exec turbo run test typecheck --filter=@bb/templates` (43 tests passed)
- `pnpm exec oxfmt --check` on all changed files
- `git diff --check`

> AGENT GENERATED