### PR TITLE
Offer Fable 5.1 in the Claude Code model picker

### DIFF
--- a/apps/server/test/system/execution-options.test.ts
+++ b/apps/server/test/system/execution-options.test.ts
@@ -905,7 +905,7 @@ describe("resolveSystemExecutionOptions", () => {
           code: "failed",
         });
         expect(response.models.map((model) => model.model)).toEqual([
-          "claude-fable-5",
+          "claude-fable-5-1",
           "claude-opus-5[1m]",
           "claude-opus-4-8[1m]",
           "claude-opus-4-7[1m]",
@@ -1037,7 +1037,7 @@ describe("resolveSystemExecutionOptions", () => {
         code: "timeout",
       });
       expect(response.models.map((model) => model.model)).toEqual([
-        "claude-fable-5",
+        "claude-fable-5-1",
         "claude-opus-5[1m]",
         "claude-opus-4-8[1m]",
         "claude-opus-4-7[1m]",

--- a/plugins/provider-claude-code/src/bridge/__tests__/bridge.test.ts
+++ b/plugins/provider-claude-code/src/bridge/__tests__/bridge.test.ts
@@ -2482,7 +2482,7 @@ describe("bridge", () => {
       PATH: binDir,
     });
     expect(models.map((model) => model.model)).toEqual([
-      "claude-fable-5",
+      "claude-fable-5-1",
       "claude-opus-5[1m]",
       "claude-opus-4-8[1m]",
       "claude-opus-4-7[1m]",

--- a/plugins/provider-claude-code/src/model-catalog-data.ts
+++ b/plugins/provider-claude-code/src/model-catalog-data.ts
@@ -37,10 +37,10 @@ export const DEFAULT_CLAUDE_CODE_MODEL = "claude-opus-5[1m]";
 export const CLAUDE_CODE_ACTIVE_CATALOG_DATA: readonly ClaudeCodeCatalogEntryData[] =
   [
     {
-      model: "claude-fable-5",
-      displayName: "Fable 5",
+      model: "claude-fable-5-1",
+      displayName: "Fable 5.1",
       description:
-        "Fable 5 for demanding reasoning; requires Claude Code v2.1.170+",
+        "Fable 5.1 for demanding reasoning; requires Claude Code v2.1.257+",
       defaultReasoningEffort: "high",
     },
     {

--- a/plugins/provider-claude-code/src/model-list.test.ts
+++ b/plugins/provider-claude-code/src/model-list.test.ts
@@ -16,10 +16,10 @@ const DISCOVERED_MODELS: ModelInfo[] = [
     description: "Opus 5 with 1M context",
   },
   {
-    value: "claude-fable-5[1m]",
-    resolvedModel: "claude-fable-5",
+    value: "claude-fable-5-1[1m]",
+    resolvedModel: "claude-fable-5-1",
     displayName: "Fable",
-    description: "Fable 5",
+    description: "Fable 5.1",
   },
   {
     value: "sonnet",
@@ -36,7 +36,7 @@ const DISCOVERED_MODELS: ModelInfo[] = [
 ];
 
 const CURATED_MODELS = [
-  "claude-fable-5",
+  "claude-fable-5-1",
   "claude-opus-5[1m]",
   "claude-opus-4-8[1m]",
   "claude-opus-4-7[1m]",

--- a/plugins/provider-claude-code/src/model-list.ts
+++ b/plugins/provider-claude-code/src/model-list.ts
@@ -102,7 +102,7 @@ const CLAUDE_CODE_SELECTED_ONLY_CATALOG: readonly ClaudeCodeCatalogEntry[] = [
     model: "best",
     displayName: "Best Alias",
     description:
-      "Moving best alias retained for existing selections; resolves to Fable 5 where available",
+      "Moving best alias retained for existing selections; resolves to the current Fable model where available",
     supportedReasoningEfforts: CLAUDE_XHIGH_CAPABLE_REASONING_EFFORTS,
     defaultReasoningEffort: "high",
   },
@@ -111,7 +111,7 @@ const CLAUDE_CODE_SELECTED_ONLY_CATALOG: readonly ClaudeCodeCatalogEntry[] = [
     model: "fable",
     displayName: "Fable Alias",
     description:
-      "Moving Fable alias retained for existing selections; resolves to Claude Fable 5",
+      "Moving Fable alias retained for existing selections; resolves to the current Claude Fable model",
     supportedReasoningEfforts: CLAUDE_XHIGH_CAPABLE_REASONING_EFFORTS,
     defaultReasoningEffort: "high",
   },

--- a/plugins/provider-claude-code/src/sdk-extraction.test.ts
+++ b/plugins/provider-claude-code/src/sdk-extraction.test.ts
@@ -2,12 +2,16 @@ import { describe, expect, it } from "vitest";
 import { resolveClaudeModelContextWindowHint } from "./sdk-extraction.js";
 
 describe("resolveClaudeModelContextWindowHint", () => {
-  it.each(["claude-fable-5", "fable", "best"])(
-    "treats %s as a 1M-context Fable model",
-    (model) => {
-      expect(resolveClaudeModelContextWindowHint(model)).toBe(1_000_000);
-    },
-  );
+  it.each([
+    "claude-fable-5",
+    "claude-fable-5-1",
+    "claude-mythos-5",
+    "claude-mythos-5-1",
+    "fable",
+    "best",
+  ])("treats %s as a 1M-context model", (model) => {
+    expect(resolveClaudeModelContextWindowHint(model)).toBe(1_000_000);
+  });
 
   it("keeps the ambiguous default model context unknown", () => {
     expect(resolveClaudeModelContextWindowHint("default")).toBeNull();

--- a/plugins/provider-claude-code/src/sdk-extraction.ts
+++ b/plugins/provider-claude-code/src/sdk-extraction.ts
@@ -78,6 +78,9 @@ const LARGE_CLAUDE_CONTEXT_WINDOW = 1_000_000;
 const LARGE_CLAUDE_CONTEXT_MODELS = new Set([
   "best",
   "claude-fable-5",
+  "claude-fable-5-1",
+  "claude-mythos-5",
+  "claude-mythos-5-1",
   "fable",
 ]);
 


### PR DESCRIPTION
## Human comments

## What was wrong

Claude Code 2.1.257 replaced `claude-fable-5` with `claude-fable-5-1`. BB's curated Claude catalog is hardcoded and unconditional (`CLAUDE_CODE_ACTIVE_CATALOG_DATA`), so the picker kept offering the retired `claude-fable-5` row, which the CLI now rejects, while Fable 5.1 reached the list only through the additive discovery path in `buildClaudeCodeModels` — appended below Sonnet 5, carrying the CLI's own bare `displayName`, "Fable". `LARGE_CLAUDE_CONTEXT_MODELS` also missed the new ids; Fable and Mythos carry a native 1M window with no `[1m]` suffix to fall back on, so `resolveClaudeModelContextWindowHint` returned 200k and the context meter under-reported by 5x.

I confirmed the rename directly against both binaries on this machine. Claude Code 2.1.252 reports `claude-fable-5[1m]` → `claude-fable-5`; 2.1.257 reports `claude-fable-5-1[1m]` → `claude-fable-5-1`. The CLI's own baked-in catalog gives `claude-fable-5-1` `display_name: "Fable 5.1"` and `context: {window: 1e6, native_1m: true}` with no `supports_1m_suffix`, and `claude-mythos-5-1` the same shape.

## What changed

- `plugins/provider-claude-code/src/model-catalog-data.ts` — `claude-fable-5-1` / "Fable 5.1" replaces the retired `claude-fable-5` entry in the curated catalog. This also fixes the server-side fallback list, because `plugins/provider-claude-code/server.ts` projects `models.fallback` from the same data.
- `plugins/provider-claude-code/src/sdk-extraction.ts` — `claude-fable-5-1`, `claude-mythos-5-1`, and `claude-mythos-5` join `LARGE_CLAUDE_CONTEXT_MODELS`.
- `plugins/provider-claude-code/src/model-list.ts` — the `best` and `fable` alias descriptions no longer pin Fable to version 5.

No wire change, so `HOST_DAEMON_PROTOCOL_VERSION` stays put: the model list's shape is unchanged and only its values move. No CLI, guide, or plugin API surface changed.

Two deviations from the issue's proposed fix:

1. **Fable 5 is not added to the selected-only catalog.** That list is discovery-gated (`modelIsDiscovered(entry.model, …) && !models.some(…)`), and on a CLI that still offers Fable 5 the discovery loop already pushes `claude-fable-5` into `models`, which filters the selected-only row out. The entry would be unreachable in every case, and the case it was meant to cover — an existing selection while the CLI still offers the model — is already covered by discovery.
2. **Mythos is not added to the selected-only catalog either**, for the same unreachability reason. `buildClaudeCodeModels` already surfaces it through the discovered-passthrough path with Anthropic's own label for entitled accounts, and the existing test asserting BB never invents a Mythos row still passes. `claude-mythos-5` joins the 1M set alongside `claude-mythos-5-1`, since it carries the identical native 1M window and the same latent 5x under-report.

The issue's closing note — reading display names, context windows, and effort levels from the probe instead of restating them — is the design change that would retire this class of drift. It is deliberately out of scope here; the issue flags it as a separate decision.

## How you verified

- `pnpm exec turbo run test typecheck --filter=bb-plugin-provider-claude-code` — 337 tests pass, typecheck clean. `model-list.test.ts`, `sdk-extraction.test.ts`, and `bridge.test.ts` carried the old `claude-fable-5` expectations and fail before this change.
- `pnpm exec turbo run test typecheck --filter=@bb/server` — 2120 tests pass, typecheck clean. `execution-options.test.ts` pins the fallback catalog and fails before this change.
- Fed the real 2.1.257 probe output through `buildClaudeCodeModels`: the list now starts `claude-fable-5-1 | Fable 5.1`, with no duplicate row for the discovered entry, and `resolveClaudeModelContextWindowHint("claude-fable-5-1")` returns 1000000.
- Ran a real one-turn session against 2.1.257 with `model: "claude-fable-5-1"`. The init message echoes `claude-fable-5-1` and the turn completes, so the promoted id is one the CLI accepts.

Fixes #2825

> AGENT GENERATED
