### PR TITLE
Fix completed Automations sweep listener cleanup

### DIFF
--- a/plugins/automations/src/sweep-abort-listeners.test.ts
+++ b/plugins/automations/src/sweep-abort-listeners.test.ts
@@ -1,0 +1,15 @@
+import { getEventListeners } from "node:events";
+import { expect, it } from "vitest";
+import { sleep } from "./sweep.js";
+
+it("does not retain abort listeners from completed sweep waits", async () => {
+  const controller = new AbortController();
+  for (let index = 0; index < 12; index += 1) {
+    await sleep(0, controller.signal);
+  }
+  const listenerCount = getEventListeners(controller.signal, "abort").length;
+
+  controller.abort();
+
+  expect(listenerCount).toBe(0);
+});

--- a/plugins/automations/src/sweep.ts
+++ b/plugins/automations/src/sweep.ts
@@ -187,14 +187,12 @@ export function sleep(ms: number, signal: AbortSignal): Promise<void> {
       resolve();
       return;
     }
-    const timeout = setTimeout(resolve, ms);
-    signal.addEventListener(
-      "abort",
-      () => {
-        clearTimeout(timeout);
-        resolve();
-      },
-      { once: true },
-    );
+    const settle = () => {
+      clearTimeout(timeout);
+      signal.removeEventListener("abort", settle);
+      resolve();
+    };
+    const timeout = setTimeout(settle, ms);
+    signal.addEventListener("abort", settle, { once: true });
   });
 }


### PR DESCRIPTION
## Human comments

## What was wrong

PR #2823 fixed completed Workflows waits that retained shutdown listeners, but the Automations sweep helper still resolved each completed 10-second wait without removing its abort listener. A long-running server with Automations enabled therefore accumulated one unused listener per sweep, preserving the same warning and slowdown risk described in the [original investigation](https://get-bb.github.io/reports/issues/2809.html).

## What changed

Automations now uses the proven Workflows settlement pattern: timeout and abort completion share one callback that clears the timer, removes the listener, and resolves. A focused regression completes twelve waits through the real helper and requires zero retained listeners. Workflows behavior is unchanged, there are no wire changes, and no host daemon protocol bump is needed.

## How you verified

- The regression failed before the production edit with `expected 12 to be 0` and passes after it.
- `pnpm exec turbo run test typecheck --filter=bb-plugin-automations --force` — 80/80 tests passed and all six Turbo tasks succeeded.
- `bb plugin build plugins/automations` — packaged server and app bundles built successfully.
- `git diff --check origin/main...HEAD` — passed after rebasing onto current `origin/main`.

Related to #2823

> AGENT GENERATED