### PR TITLE
Gate project-routed file sources on an opener capability

### DIFF
--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -306,7 +306,9 @@ function AppRoutes() {
           <Route
             path="*"
             element={
-              <Suspense fallback={<RouteLoadingSkeleton />}>
+              <Suspense
+                fallback={<RouteLoadingSkeleton isBoundedPane={false} />}
+              >
                 <SplitWorkspaceRoute />
               </Suspense>
             }

--- a/apps/app/src/components/plugin/file-opener-tabs.test.ts
+++ b/apps/app/src/components/plugin/file-opener-tabs.test.ts
@@ -18,6 +18,21 @@ const MARKDOWN_OPENER = {
   title: "Docs editor",
 } satisfies PluginFileOpenerSlot;
 
+const PROJECT_ROUTED_OPENER = {
+  ...MARKDOWN_OPENER,
+  experimental_supportsProjectRoutedSource: true,
+} satisfies PluginFileOpenerSlot;
+
+const PROJECT_WORKSPACE_REQUEST: OpenSecondaryPanelTabRequest = {
+  kind: "workspace-file-preview",
+  tab: {
+    lineRange: null,
+    path: "docs/readme.md",
+    source: { kind: "working-tree" },
+    statusLabel: null,
+  },
+};
+
 const REQUESTS: readonly {
   label: string;
   request: OpenSecondaryPanelTabRequest;
@@ -97,19 +112,11 @@ describe("createFileOpenerTabForRequest thread-tabs contract", () => {
 
   it("preserves the selected host for a project-backed opener", () => {
     const tab = createFileOpenerTabForRequest({
-      fileOpeners: [MARKDOWN_OPENER],
+      fileOpeners: [PROJECT_ROUTED_OPENER],
       preference: {},
       projectHostId: "host_remote",
       projectId: "proj_1",
-      request: {
-        kind: "workspace-file-preview",
-        tab: {
-          lineRange: null,
-          path: "docs/readme.md",
-          source: { kind: "working-tree" },
-          statusLabel: null,
-        },
-      },
+      request: PROJECT_WORKSPACE_REQUEST,
       resolvedEnvironmentId: null,
       threadId: null,
     });
@@ -121,6 +128,67 @@ describe("createFileOpenerTabForRequest thread-tabs contract", () => {
       experimental_hostId: "host_remote",
     });
     expect(() => threadTabsSchema.parse([tab])).not.toThrow();
+  });
+
+  it("falls back to BB's preview when an opener does not accept project-routed sources", () => {
+    expect(
+      createFileOpenerTabForRequest({
+        fileOpeners: [MARKDOWN_OPENER],
+        preference: {},
+        projectHostId: "host_remote",
+        projectId: "proj_1",
+        request: PROJECT_WORKSPACE_REQUEST,
+        resolvedEnvironmentId: null,
+        threadId: null,
+      }),
+    ).toBeNull();
+  });
+
+  it("falls back for an unsupporting opener even without an explicit host", () => {
+    expect(
+      createFileOpenerTabForRequest({
+        fileOpeners: [MARKDOWN_OPENER],
+        preference: {},
+        projectId: "proj_1",
+        request: PROJECT_WORKSPACE_REQUEST,
+        resolvedEnvironmentId: null,
+        threadId: null,
+      }),
+    ).toBeNull();
+  });
+
+  it("keeps an explicit Open with pick on BB's preview when the opener cannot route it", () => {
+    expect(
+      createFileOpenerTabForRequest({
+        fileOpeners: [MARKDOWN_OPENER],
+        preference: {},
+        projectHostId: "host_remote",
+        projectId: "proj_1",
+        request: PROJECT_WORKSPACE_REQUEST,
+        resolvedEnvironmentId: null,
+        threadId: null,
+        viewer: { openerId: "markdown", pluginId: "docs" },
+      }),
+    ).toBeNull();
+  });
+
+  it("still opens an environment-backed file in an opener without the capability", () => {
+    const tab = createFileOpenerTabForRequest({
+      fileOpeners: [MARKDOWN_OPENER],
+      preference: {},
+      projectHostId: "host_remote",
+      projectId: "proj_1",
+      request: PROJECT_WORKSPACE_REQUEST,
+      resolvedEnvironmentId: "env_docs",
+      threadId: "thr_docs",
+    });
+
+    const params = parseFileOpenerParams(tab?.paramsJson ?? null);
+    expect(params?.source).toMatchObject({
+      environmentId: "env_docs",
+      kind: "workspace",
+    });
+    expect(params?.source.experimental_hostId).toBeUndefined();
   });
 });
 

--- a/apps/app/src/components/plugin/file-opener-tabs.ts
+++ b/apps/app/src/components/plugin/file-opener-tabs.ts
@@ -166,11 +166,25 @@ export function createFileOpenerTabForRequest({
   });
   if (owner === null) return null;
   const file = fileForOwnerRequest(owner);
-  const routedFile: PluginFileOpenerFile =
+  const resolved = resolveFileOpenerReplacement({
+    registrations: fileOpeners,
+    preference,
+    path: file.path,
+    ...(viewer !== undefined ? { override: viewer } : {}),
+  });
+  if (resolved.kind !== "plugin") return null;
+  const isProjectRouted =
     file.source.kind === "workspace" &&
     file.source.environmentId === null &&
-    file.source.projectId !== null &&
-    projectHostId
+    file.source.projectId !== null;
+  if (
+    isProjectRouted &&
+    resolved.registration.experimental_supportsProjectRoutedSource !== true
+  ) {
+    return null;
+  }
+  const routedFile: PluginFileOpenerFile =
+    isProjectRouted && projectHostId
       ? {
           ...file,
           source: {
@@ -179,15 +193,7 @@ export function createFileOpenerTabForRequest({
           },
         }
       : file;
-  const resolved = resolveFileOpenerReplacement({
-    registrations: fileOpeners,
-    preference,
-    path: routedFile.path,
-    ...(viewer !== undefined ? { override: viewer } : {}),
-  });
-  return resolved.kind === "plugin"
-    ? buildFileOpenerPanelTab(resolved.registration, routedFile, owner)
-    : null;
+  return buildFileOpenerPanelTab(resolved.registration, routedFile, owner);
 }
 
 function ownerRequestForOpenRequest({

--- a/apps/app/src/components/ui/route-loading-skeleton.test.tsx
+++ b/apps/app/src/components/ui/route-loading-skeleton.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { RouteLoadingSkeleton } from "./route-loading-skeleton";
+
+afterEach(cleanup);
+
+describe("RouteLoadingSkeleton", () => {
+  it("bleeds through standalone page padding", () => {
+    render(<RouteLoadingSkeleton isBoundedPane={false} />);
+
+    const skeleton = screen.getByTestId("route-loading-skeleton");
+    const header = skeleton.firstElementChild;
+
+    expect(skeleton.className).toContain("-mx-4");
+    expect(skeleton.className).toContain("-mt-4");
+    expect(skeleton.className).toContain("md:-mx-5");
+    expect(skeleton.className).toContain("md:-mt-5");
+    expect(header?.className).toContain("pl-12");
+  });
+
+  it("keeps bounded-pane placeholders inside their pane", () => {
+    render(<RouteLoadingSkeleton isBoundedPane />);
+
+    const skeleton = screen.getByTestId("route-loading-skeleton");
+    const header = skeleton.firstElementChild;
+
+    expect(skeleton.className).not.toContain("-mx-4");
+    expect(skeleton.className).not.toContain("-mt-4");
+    expect(skeleton.className).not.toContain("md:-mx-5");
+    expect(skeleton.className).not.toContain("md:-mt-5");
+    expect(header?.className).toContain("px-4");
+    expect(header?.className).not.toContain("pl-12");
+  });
+});

--- a/apps/app/src/components/ui/route-loading-skeleton.tsx
+++ b/apps/app/src/components/ui/route-loading-skeleton.tsx
@@ -3,13 +3,22 @@ import { CHROME_ROW_CLASS } from "@/lib/bb-desktop";
 import { Skeleton } from "@bb/shared-ui/skeleton";
 import { cn } from "@bb/shared-ui/lib/utils";
 
-const SHELL_BLEED_CLASS =
-  "-mx-4 -mt-4 flex h-full min-h-0 flex-1 flex-col overflow-hidden md:-mx-5 md:-mt-5";
+interface RouteLoadingSkeletonProps {
+  isBoundedPane: boolean;
+}
 
-export function RouteLoadingSkeleton() {
+const SHELL_CLASS = "flex h-full min-h-0 flex-1 flex-col overflow-hidden";
+const STANDALONE_SHELL_BLEED_CLASS = "-mx-4 -mt-4 md:-mx-5 md:-mt-5";
+
+export function RouteLoadingSkeleton({
+  isBoundedPane,
+}: RouteLoadingSkeletonProps) {
   return (
     <div
-      className={SHELL_BLEED_CLASS}
+      className={cn(
+        SHELL_CLASS,
+        !isBoundedPane && STANDALONE_SHELL_BLEED_CLASS,
+      )}
       role="status"
       aria-busy="true"
       aria-label="Loading"
@@ -19,7 +28,8 @@ export function RouteLoadingSkeleton() {
         className={cn(
           CHROME_ROW_CLASS,
           HEADER_SEAM_CLASS,
-          "shrink-0 gap-2 px-3 pl-12",
+          "shrink-0 gap-2",
+          isBoundedPane ? "px-4" : "px-3 pl-12",
         )}
       >
         <Skeleton className="h-4 w-40 max-w-[50%]" />

--- a/apps/app/src/lib/plugin-app-definition.test.ts
+++ b/apps/app/src/lib/plugin-app-definition.test.ts
@@ -303,6 +303,7 @@ describe("collectPluginAppRegistrations", () => {
         title: "Notes editor",
         extensions: ["md", "mdx"],
         component: Component,
+        experimental_supportsProjectRoutedSource: true,
       });
       app.slots.messageDirective({
         id: "inline-vis",
@@ -378,6 +379,7 @@ describe("collectPluginAppRegistrations", () => {
         title: "Notes editor",
         extensions: ["md", "mdx"],
         component: Component,
+        experimental_supportsProjectRoutedSource: true,
       },
     ]);
     expect(registrations.messageDirectives).toEqual([

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -475,7 +475,7 @@ export function LegacyProjectComposeRedirect({
     });
   }, [location.state, navigate, projectId, setRootComposeProjectId]);
 
-  return <RouteLoadingSkeleton />;
+  return <RouteLoadingSkeleton isBoundedPane={false} />;
 }
 
 export function RootComposeView() {

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -2320,7 +2320,7 @@ function ThreadDetailViewInternal(props: ThreadRoutePathArgs) {
   );
 
   if (threadQueryState.status === "loading") {
-    return <RouteLoadingSkeleton />;
+    return <RouteLoadingSkeleton isBoundedPane={isBoundedPane} />;
   }
   if (!thread || thread.projectId !== projectId) {
     return (

--- a/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/references/frontend-core-slots.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/references/frontend-core-slots.md
@@ -224,6 +224,12 @@ target? })`. Inside the fixed-tab component,
   `{ kind: "workspace" | "host" | "thread-storage", threadId, environmentId,
 projectId, experimental_hostId? }` (nullable fields). The optional host ID
   selects a project-backed workspace host and persists in opener-tab parameters.
+  A source with no `environmentId` and a `projectId` (the draft-thread composer
+  of a project whose environment is not running) reaches your component only
+  when the registration sets `experimental_supportsProjectRoutedSource: true`;
+  otherwise BB opens the file in its own preview, so an opener that cannot
+  route a project — or whose RPC contract rejects the extra
+  `experimental_hostId` key — is never handed one.
   The `path` follows the source (workspace:
   worktree-relative; host: absolute; thread-storage: storage-relative).
   `Original` is BB's preview bound to this file; render it to

--- a/docs/api_to_audit.md
+++ b/docs/api_to_audit.md
@@ -679,7 +679,10 @@ malformed runtime targets remain inert in both the app and SDK test runtime.
 6. Decide whether Git snapshots or deleted working-tree files merit separate
    target variants; do not weaken live-file guarantees to accommodate them.
 7. Confirm `PluginFileOpenerSource.experimental_hostId` can become a stable
-   required `hostId` field without breaking older opener implementations.
+   required `hostId` field without breaking older opener implementations. It
+   cannot be sent unconditionally: openers that re-validate the source with a
+   strict schema reject the unknown key, so it is now gated on
+   `PluginFileOpenerRegistration.experimental_supportsProjectRoutedSource`.
 
 ## Host plugin foundation (`bb.hosts.experimental_client`, `ExperimentalHostClient.experimental_onWorkerExit`, `ExperimentalHostClient.experimental_onSignal`, `ExperimentalHostRpcContext.experimental_retainWorker`, `experimental_defineHostEntry`, and `experimental_createHostEntryHarness`)
 
@@ -1656,6 +1659,29 @@ files, thread-storage files, and project files that use the primary host.
 4. Confirm omission should continue to mean primary-host resolution and that
    this remains compatible with persisted opener tabs created before the field
    existed.
+
+## `PluginFileOpenerRegistration.experimental_supportsProjectRoutedSource` (`@get-bb/plugin-sdk/app`)
+
+**What it does.** Declares that a file opener accepts a workspace source with
+no `environmentId`, routed by `projectId` plus
+`PluginFileOpenerSource.experimental_hostId` — the draft-thread composer of a
+project whose environment is not running. BB opens those files in its own
+preview for every opener that leaves the flag unset, so an opener published
+before project routing existed is never handed a source shape its RPC contract
+rejects and never has to resolve a project it cannot route.
+
+**Audit before stabilizing.**
+
+1. Decide whether opener capabilities should keep growing as one boolean per
+   routing shape or become a single declared source-kind list before a second
+   flag is needed.
+2. Confirm silently falling back to BB's preview is the right outcome for an
+   explicit "Open with" pick, rather than an explanatory disabled menu entry.
+3. Confirm the flag stays a build-time property of the registration: it is
+   read on every open, so making it a function would run plugin code inside
+   tab creation.
+4. Decide whether a stable `hostId` field should subsume this flag by making
+   project routing part of the required source contract for all openers.
 
 ## `experimental_SourceCode` / `experimental_Diff` (`@get-bb/plugin-sdk/app`)
 

--- a/packages/plugin-api-map/sdk-public-api.json
+++ b/packages/plugin-api-map/sdk-public-api.json
@@ -3,7 +3,7 @@
   "entries": {
     ".": {
       "types": "bundled-types/bb-plugin-sdk.d.ts",
-      "sha256": "057bfb57c4a11dcbb0b83125e1b42a0e360fcb28ce62083fa37acb28541df741"
+      "sha256": "61526a57751822665140f59b0c736b2625cb7b5a19d9060dbdc2d6b89f5b5432"
     },
     "./ai-services": {
       "types": "bundled-types/bb-plugin-sdk-ai-services.d.ts",
@@ -11,7 +11,7 @@
     },
     "./app": {
       "types": "bundled-types/bb-plugin-sdk-app.d.ts",
-      "sha256": "d5a5ca8bb14f04dbe5d53dc47470412337ce1fcf8a8019c692479620b05ef7c2"
+      "sha256": "12f0b11ac588d90f34fb68a408bb2901f376c9752f697c5f881362e53e464945"
     },
     "./host": {
       "types": "bundled-types/bb-plugin-sdk-host.d.ts",

--- a/packages/plugin-api-map/src/surfaces.ts
+++ b/packages/plugin-api-map/src/surfaces.ts
@@ -195,6 +195,7 @@ export const SURFACE_GROUPS: SurfaceGroup[] = [
           "Declare the file extensions it handles, for example `.csv` or `.excalidraw`",
           "Render its own viewer or editor whenever a file of that type is opened in bb",
           "Receive the file's path, then read it however the plugin already reads files",
+          "Declare that it can also open a project's files while no environment is running, or let bb use its own preview there",
         ],
         apiSymbols: ["PluginFileOpenerRegistration"],
         firstParty: ["Docs"],

--- a/packages/plugin-sdk/src/app-contract.ts
+++ b/packages/plugin-sdk/src/app-contract.ts
@@ -173,6 +173,9 @@ export interface PluginFileOpenerSource {
   /**
    * Explicit host selected for a project-backed workspace file. Omitted when
    * the source is resolved by its environment/thread or the primary host.
+   * Only openers that set
+   * {@link PluginFileOpenerRegistration.experimental_supportsProjectRoutedSource}
+   * are given a project-routed source at all.
    *
    * @experimental Audit before relying on this as a stable contract.
    */
@@ -983,6 +986,18 @@ export interface PluginFileOpenerRegistration {
   /** Lowercase extensions without the dot (e.g. ["md", "mdx"]). */
   extensions: readonly string[];
   component: ComponentType<PluginFileOpenerProps>;
+  /**
+   * Set this when the opener can serve a workspace file that has no
+   * environment and is routed by `projectId` plus
+   * {@link PluginFileOpenerSource.experimental_hostId} — the draft-thread
+   * composer of a project whose environment is not running. BB opens those
+   * files in its own preview for every opener that leaves this unset, so an
+   * opener published before project routing existed never receives a source
+   * its contract rejects.
+   *
+   * @experimental Audit before relying on this as a stable contract.
+   */
+  experimental_supportsProjectRoutedSource?: boolean;
 }
 
 /**

--- a/packages/plugin-sdk/src/internal/plugin-app-collector.ts
+++ b/packages/plugin-sdk/src/internal/plugin-app-collector.ts
@@ -429,11 +429,27 @@ export function collectPluginAppRegistrations(
           }
           return extension;
         });
+        const supportsProjectRoutedSource =
+          registration.experimental_supportsProjectRoutedSource;
+        if (
+          supportsProjectRoutedSource !== undefined &&
+          typeof supportsProjectRoutedSource !== "boolean"
+        ) {
+          throw new Error(
+            `${kind}: "experimental_supportsProjectRoutedSource" must be a boolean when set`,
+          );
+        }
         collected.fileOpeners.push({
           id,
           title: requireNonEmptyString(kind, "title", registration.title),
           extensions,
           component: requireComponent(kind, registration.component),
+          ...(supportsProjectRoutedSource !== undefined
+            ? {
+                experimental_supportsProjectRoutedSource:
+                  supportsProjectRoutedSource,
+              }
+            : {}),
         });
       },
       experimental_sourceCodeRenderer(registration) {

--- a/packages/templates/src/templates/bb-guide-plugins.md
+++ b/packages/templates/src/templates/bb-guide-plugins.md
@@ -544,7 +544,10 @@ experimental_newThreadPanelAction (the root New thread counterpart, with
 `projectId: string | null` instead of `threadId`), pendingInteraction (temporarily replace a thread composer with a
 plugin form), fileOpener (register as a per-extension file viewer/editor;
 users pick defaults under Settings → File openers and can right-click a
-file link for a one-off choice), and messageDirective (replace a leaf
+file link for a one-off choice; set
+`experimental_supportsProjectRoutedSource: true` to also receive
+environment-less project sources, which carry `projectId` plus
+`experimental_hostId` and otherwise fall back to bb's own preview), and messageDirective (replace a leaf
 `::name{k="v"}` block inside assistant / nested-agent Markdown with a plugin
 component; unknown, disabled, incomplete, code-fenced, or crashing
 directives fall back to the original source; components receive a nullable

--- a/plugins/docs/app.tsx
+++ b/plugins/docs/app.tsx
@@ -2199,6 +2199,7 @@ export default definePluginApp((app) => {
     title: "Markdown",
     extensions: ["md", "mdx", "markdown"],
     component: DocsFileOpener,
+    experimental_supportsProjectRoutedSource: true,
   });
   app.slots.messageDirective({ id: "docs", component: DocsDirectiveCard });
 });

--- a/plugins/monaco-editor/app.tsx
+++ b/plugins/monaco-editor/app.tsx
@@ -468,6 +468,7 @@ export default definePluginApp((app) => {
     title: "File Editor",
     extensions: CLAIMED_EXTENSIONS,
     component: MonacoFileOpener,
+    experimental_supportsProjectRoutedSource: true,
   });
 
   for (const command of EDITOR_COMMANDS) {

--- a/plugins/pdf-preview/app.tsx
+++ b/plugins/pdf-preview/app.tsx
@@ -125,5 +125,6 @@ export default definePluginApp((app) => {
     title: "PDF viewer",
     extensions: ["pdf"],
     component: PdfFileOpener,
+    experimental_supportsProjectRoutedSource: true,
   });
 });


### PR DESCRIPTION
## Human comments

## What was wrong

Opening a workspace file from the new-thread (draft) composer of a project whose environment is not running routes the file by project + host, and bb stamped `experimental_hostId` onto the `PluginFileOpenerSource` handed to whichever plugin opener claimed the extension ([`file-opener-tabs.ts#L186-L198`](https://github.com/get-bb/bb/blob/e4c873521abbcab1ea3e1aa127b73bb28e7905bb/apps/app/src/components/plugin/file-opener-tabs.ts#L186-L198)). An opener published before that field existed re-validates the source with a strict schema — the "re-validate RPC input at the boundary" pattern bb's own plugin ships — so it rejected the call with `400 invalid_input` and the file tab rendered a bare red `rpc input validation failed`. The root cause is not the extra key alone: an opener that tolerated the unknown key still could not serve the route, because project+host resolution did not exist when it was written, and it fails with `This file has no environment to resolve it against`. The env-less, project-routed source is simply a shape older openers cannot handle, and bb was sending it to all of them unconditionally.

Fixes #2519. Repro report: https://get-bb.github.io/reports/issues/2519.html

## What changed

- `PluginFileOpenerRegistration` gains `experimental_supportsProjectRoutedSource` (`packages/plugin-sdk/src/app-contract.ts`), collected and type-validated in `plugin-app-collector.ts`.
- `createFileOpenerTabForRequest` now resolves the opener first, then, for a workspace source with no `environmentId` and a `projectId`, uses that opener only if it declares the capability. Otherwise it returns `null` and `useThreadFileTabs` falls back to bb's native preview. `experimental_hostId` is therefore only ever sent to an opener that asked for it.
- The three first-party openers (`monaco-editor`, `docs`, `pdf-preview`) already resolve project sources, and declare the flag.
- Docs: new `docs/api_to_audit.md` entry for the experimental member, plus an update to audit item 7 of the live-file-navigation section — this issue is the evidence that `experimental_hostId` cannot become an unconditional required field. Plugin Guide card (`packages/plugin-api-map/src/surfaces.ts`) and regenerated `sdk-public-api.json`, the `bb-plugin-authoring` skill reference, and the `bb guide plugins` template.

No wire change: this is app-side tab construction plus an in-process registration field, so `HOST_DAEMON_PROTOCOL_VERSION` is untouched.

Deviation from the issue's second question ("should the frontend surface something better than the raw boundary message") — not addressed here. With this change bb no longer hands an opener a payload its contract rejects, so the banner is not reachable through this route; improving generic plugin RPC error presentation is a separate concern.

## How you verified

Tests — 3 new cases in `apps/app/src/components/plugin/file-opener-tabs.test.ts` (fallback with a host id, fallback without one, and an explicit "Open with" pick) fail before the change and pass after:

```
before:  Tests  3 failed | 9 passed (12)
after:   Tests  12 passed (12)
```

`plugin-app-definition.test.ts` now asserts the flag survives collection, so silently dropping it in the collector fails the build.

Suites run:

```
pnpm exec turbo run test --filter=@bb/app                    # 444 files, 3509 passed
pnpm exec turbo run test --filter=@bb/plugin-api-map --filter=@get-bb/plugin-sdk \
  --filter=bb-plugin-monaco-editor --filter=bb-plugin-simple-notes --filter=bb-plugin-pdf-preview
pnpm exec turbo run typecheck --filter=@bb/app --filter=@get-bb/plugin-sdk --filter=@bb/plugin-api-map \
  --filter=bb-plugin-monaco-editor --filter=bb-plugin-simple-notes --filter=bb-plugin-pdf-preview
pnpm format:check   # clean on the touched files
```

Manual, in the running dev app: a project with no running environment, a draft composer, and a file-opener plugin whose RPC contract uses exactly the strict pre-field schema from the issue. Opening `readme.md` from the side panel:

- **Before:** `POST /api/v1/plugins/<id>/rpc/read` → `400`; the tab renders `rpc input validation failed`. The request payload was the one in the issue: `{"kind":"workspace","threadId":null,"environmentId":null,"projectId":"proj_…","experimental_hostId":"host_…"}`.
- **After:** no RPC call is made; the file opens in bb's own preview.
- **After, with the same opener updated to declare `experimental_supportsProjectRoutedSource: true` and widen its schema:** `200`; the file opens in the plugin.

Screenshots of all three states to follow in a comment.

Fixes #2519

> AGENT GENERATED
