### PR TITLE
Keep right panel border visible while loading

### DIFF
--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.collapseControl.test.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.collapseControl.test.tsx
@@ -715,6 +715,23 @@ describe("ThreadSecondaryPanel hide control glyph", () => {
   });
 });
 
+describe("ThreadSecondaryPanel resize boundary", () => {
+  it("keeps the panel seam visible while the clipped panel surface moves", () => {
+    const view = renderPanel({
+      isConversationCollapsed: false,
+      onToggleConversationCollapse: noop,
+    });
+
+    const boundary = view.getByRole("separator", {
+      name: "Resize thread and right panel",
+    });
+    const seam = boundary.querySelector(
+      "span:not([data-panel-resize-hit-target])",
+    );
+    expect(seam?.className).toContain("bg-border-seam");
+  });
+});
+
 describe("ThreadSecondaryPanel full-screen control", () => {
   it("keeps Full Screen before Hide right panel in the trailing toolbar", () => {
     const view = renderPanel({

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
@@ -1206,7 +1206,7 @@ function SecondaryPanelResizeHandle({
             "pointer-events-none absolute inset-y-0 left-full z-10 w-px transition-colors",
             isResizing
               ? "bg-accent-foreground/50"
-              : "bg-transparent group-hover:bg-accent-foreground/35",
+              : "bg-border-seam group-hover:bg-accent-foreground/35",
           )}
         />
       )}

--- a/apps/app/src/components/secondary-panel/lazySecondaryPanelComponents.test.tsx
+++ b/apps/app/src/components/secondary-panel/lazySecondaryPanelComponents.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { PanelGroup } from "react-resizable-panels";
+import { LazyThreadSecondaryPanel } from "./lazySecondaryPanelComponents";
+
+vi.mock("./ThreadSecondaryPanel", () => new Promise(() => {}));
+
+afterEach(cleanup);
+
+const noop = () => {};
+
+function renderLoadingPanel({
+  isConversationCollapsed = false,
+  isOpen = true,
+}: {
+  isConversationCollapsed?: boolean;
+  isOpen?: boolean;
+} = {}) {
+  return render(
+    <PanelGroup direction="horizontal">
+      <LazyThreadSecondaryPanel
+        activeTab={null}
+        canUseGitUi={false}
+        drawerFallback={null}
+        fixedTabs={[]}
+        isConversationCollapsed={isConversationCollapsed}
+        isOpen={isOpen}
+        metadataContent={null}
+        onClose={noop}
+        onCollapse={noop}
+        onOpenNewTab={noop}
+        onPanelFocus={noop}
+        onTabReorder={noop}
+        onToggleConversationCollapse={noop}
+        renderAsDrawer={false}
+        tabs={[]}
+      />
+    </PanelGroup>,
+  );
+}
+
+describe("LazyThreadSecondaryPanel", () => {
+  it("keeps the panel seam visible while inline content loads", () => {
+    renderLoadingPanel();
+
+    const placeholder = screen.getByTestId(
+      "thread-secondary-panel-placeholder",
+    );
+    expect(placeholder.className).toContain("border-l");
+    expect(placeholder.className).toContain("border-border-seam");
+  });
+
+  it("does not show the loading seam when the panel is closed or full screen", () => {
+    const view = renderLoadingPanel({ isOpen: false });
+
+    expect(
+      screen.getByTestId("thread-secondary-panel-placeholder").className,
+    ).not.toContain("border-l");
+
+    view.unmount();
+    renderLoadingPanel({ isConversationCollapsed: true });
+
+    expect(
+      screen.getByTestId("thread-secondary-panel-placeholder").className,
+    ).not.toContain("border-l");
+  });
+});

--- a/apps/app/src/components/secondary-panel/lazySecondaryPanelComponents.tsx
+++ b/apps/app/src/components/secondary-panel/lazySecondaryPanelComponents.tsx
@@ -147,6 +147,7 @@ function ThreadSecondaryPanelInlinePlaceholder({
       className={cn(
         "min-w-0 overflow-clip",
         `relative transition-[flex-grow,flex-basis] ${PANEL_COLLAPSE_TRANSITION_CLASS}`,
+        isOpen && !isConversationCollapsed && "border-l border-border-seam",
       )}
       data-testid="thread-secondary-panel-placeholder"
     >


### PR DESCRIPTION
## Human comments

## What was wrong

The inline right-panel Suspense placeholder did not render the panel seam. Once the outer module resolved, the normal seam lived on an absolutely positioned panel surface that begins outside its animated clipping container, so the boundary could also disappear briefly while inner panel content was still loading.

## What changed

- Render the standard border seam on the open, non-full-screen inline loading placeholder.
- Paint the same seam on the existing resize boundary so it remains visible while the clipped panel surface moves into place.
- Add regression coverage for the lazy placeholder's open, closed, and full-screen states and for the animated resize boundary.
- No server, host-daemon protocol, CLI, guide, SDK, or data changes.

## How you verified

- Added focused tests that failed before the fix and pass after it.
- `pnpm exec turbo run test --filter=@bb/app --only --concurrency=1 -- --run src/components/secondary-panel/ThreadSecondaryPanel.collapseControl.test.tsx src/components/secondary-panel/lazySecondaryPanelComponents.test.tsx src/components/secondary-panel/SecondaryPanelLayout.test.tsx src/views/RootComposeSecondaryContent.test.tsx src/views/thread-detail/ThreadDetailSecondaryContent.test.tsx` — 5 files, 52 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/app` — passed.
- `pnpm exec turbo run lint --filter=@bb/app` — passed with 0 errors; existing warnings remain outside this change.
- `git diff --check` — passed.
- Dev Browser QA delayed both the outer panel module and inner New Tab content module; the loading skeleton retained a 1px non-transparent seam throughout both phases.

Fixes no issue.

> AGENT GENERATED
