### PR TITLE
Keep disabled plugins reachable in Settings

### DIFF
--- a/apps/app/src/components/commands/CommandPalette.tsx
+++ b/apps/app/src/components/commands/CommandPalette.tsx
@@ -83,9 +83,8 @@ export function CommandPalette({ threadId, projectId }: CommandPaletteProps) {
     () =>
       buildPluginSettingsEntries({
         installedPlugins,
-        settingsSections: pluginSlots.settingsSections,
       }),
-    [installedPlugins, pluginSlots.settingsSections],
+    [installedPlugins],
   );
   const settingsActions = useMemo(
     () =>

--- a/apps/app/src/components/plugin/PluginSettings.test.tsx
+++ b/apps/app/src/components/plugin/PluginSettings.test.tsx
@@ -1,13 +1,19 @@
 // @vitest-environment jsdom
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { InstalledPlugin } from "@bb/server-contract";
 import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
 import {
   resetPluginSlotStoreForTest,
   setPluginSlotRegistrations,
 } from "@/lib/plugin-slots";
-import { PluginSettingsDetail, PluginSettingsForm } from "./PluginSettings";
+import {
+  PluginSettingsDetail,
+  PluginSettingsForm,
+  PluginSettingsPage,
+} from "./PluginSettings";
 import {
   EMPTY_PLUGIN_UPDATE_STATE,
   type PluginListItem,
@@ -226,6 +232,154 @@ function rowPlugin(
     updateState: EMPTY_PLUGIN_UPDATE_STATE,
   };
 }
+
+function installedPlugin(
+  enabled: boolean,
+  hasSettings: boolean = enabled,
+): InstalledPlugin {
+  return {
+    id: "linear",
+    source: "path:/plugins/linear",
+    rootDir: "/plugins/linear",
+    version: "0.1.0",
+    enabled,
+    status: enabled ? "running" : "disabled",
+    statusDetail: null,
+    description: "Linear integration",
+    name: "Linear",
+    icon: null,
+    iconUrl: null,
+    logoUrl: null,
+    logoDarkUrl: null,
+    hasSettings,
+    handlerStats: { count: 0, totalMs: 0, maxMs: 0, errorCount: 0 },
+    services: [],
+    schedules: [],
+    cliCommand: null,
+    capabilities: [],
+    app: { hasApp: false, bundle: null },
+    provenance: "direct",
+    isOrphanedBuiltin: false,
+    publisherLabel: null,
+    sourceDisplay: "path · /plugins/linear",
+    updateState: {},
+    providerIds: [],
+    icons: {},
+  };
+}
+
+describe("PluginSettingsPage", () => {
+  it("lets users disable and enable a plugin from the settings header", async () => {
+    const requests: RecordedRequest[] = [];
+    let enabled = true;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init?: RequestInit) => {
+        requests.push({ url, init });
+        if (url === "/api/v1/plugins/linear/disable") {
+          enabled = false;
+          return jsonOk({ ok: true, plugin: installedPlugin(enabled) });
+        }
+        if (url === "/api/v1/plugins/linear/enable") {
+          enabled = true;
+          return jsonOk({ ok: true, plugin: installedPlugin(enabled) });
+        }
+        if (url === "/api/v1/plugins/linear/settings") {
+          return jsonOk(SETTINGS_VIEW);
+        }
+        return jsonOk({ plugins: [installedPlugin(enabled)] });
+      }),
+    );
+
+    const { wrapper: QueryClientWrapper } = createQueryClientTestHarness();
+    const { container } = render(
+      <MemoryRouter>
+        <QueryClientWrapper>
+          <PluginSettingsPage pluginId="linear" />
+        </QueryClientWrapper>
+      </MemoryRouter>,
+    );
+
+    const disable = await screen.findByRole("switch", {
+      name: "Disable linear",
+    });
+    expect(screen.getByRole("heading", { name: "Linear" }).closest("header"))
+      .toContain(disable);
+    expect(
+      screen.getByRole("heading", { name: "Configuration" }),
+    ).toBeTruthy();
+
+    fireEvent.click(disable);
+
+    await vi.waitFor(() => {
+      expect(
+        requests.some(
+          (request) =>
+            request.url === "/api/v1/plugins/linear/disable" &&
+            request.init?.method === "POST",
+        ),
+      ).toBe(true);
+    });
+    const enable = await screen.findByRole("switch", {
+      name: "Enable linear",
+    });
+    expect(
+      screen.queryByRole("heading", { name: "Configuration" }),
+    ).toBeNull();
+    expect(
+      container.querySelector('[data-resource-detail-section="configuration"]'),
+    ).toBeNull();
+    expect(
+      container.querySelectorAll("[data-resource-detail-section]"),
+    ).toHaveLength(1);
+
+    fireEvent.click(enable);
+
+    await vi.waitFor(() => {
+      expect(
+        requests.some(
+          (request) =>
+            request.url === "/api/v1/plugins/linear/enable" &&
+            request.init?.method === "POST",
+        ),
+      ).toBe(true);
+    });
+    expect(
+      await screen.findByRole("switch", { name: "Disable linear" }),
+    ).toBeTruthy();
+    expect(
+      await screen.findByRole("heading", { name: "Configuration" }),
+    ).toBeTruthy();
+  });
+
+  it("omits Configuration for an enabled plugin with no available settings", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonOk({ plugins: [installedPlugin(true, false)] }),
+      ),
+    );
+
+    const { wrapper: QueryClientWrapper } = createQueryClientTestHarness();
+    const { container } = render(
+      <MemoryRouter>
+        <QueryClientWrapper>
+          <PluginSettingsPage pluginId="linear" />
+        </QueryClientWrapper>
+      </MemoryRouter>,
+    );
+
+    expect(
+      await screen.findByRole("switch", { name: "Disable linear" }),
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole("heading", { name: "Configuration" }),
+    ).toBeNull();
+    expect(
+      container.querySelectorAll("[data-resource-detail-section]"),
+    ).toHaveLength(1);
+  });
+});
 
 describe("PluginSettingsDetail settings gating", () => {
   it("clears plugin-scoped drafts and isolates an in-flight save after navigation", async () => {

--- a/apps/app/src/components/plugin/PluginSettings.tsx
+++ b/apps/app/src/components/plugin/PluginSettings.tsx
@@ -23,8 +23,12 @@ import {
   ResourceDetailStack,
 } from "@bb/shared-ui/resource-detail";
 import { PluginIcon } from "@/components/plugin/PluginIcon";
-import { applyPluginSettingsView } from "@/hooks/cache-owners/plugin-cache-owner";
 import {
+  applyPluginSettingsView,
+  invalidatePluginList,
+} from "@/hooks/cache-owners/plugin-cache-owner";
+import {
+  setPluginEnabled,
   updatePluginSettings,
   usePluginList,
   usePluginSettingsView,
@@ -330,37 +334,70 @@ export function PluginSettingsPage({ pluginId }: { pluginId: string }) {
       </p>
     );
   }
+  return <PluginSettingsContent key={plugin.id} plugin={plugin} />;
+}
+
+function PluginSettingsContent({ plugin }: { plugin: PluginListItem }) {
+  const queryClient = useQueryClient();
+  const { settingsSections } = usePluginSlots();
+  const toggle = useMutation({
+    mutationFn: (enabled: boolean) =>
+      setPluginEnabled(fetch, plugin.id, enabled),
+    onError: (error, enabled) => {
+      appToast.error(
+        `${enabled ? "Enabling" : "Disabling"} ${plugin.id} failed`,
+        {
+          description: error instanceof Error ? error.message : String(error),
+        },
+      );
+    },
+    onSettled: () => invalidatePluginList({ queryClient }),
+  });
+  const enabled = toggle.isPending ? toggle.variables : plugin.enabled;
+  const hasAvailableSettings =
+    plugin.hasSettings ||
+    settingsSections.some((section) => section.pluginId === plugin.id);
   return (
     <div className="mx-auto w-full max-w-5xl">
-      <div className="flex items-center gap-3">
-        <div className="size-9 shrink-0">
-          <PluginIcon
-            pluginId={plugin.id}
-            icon={plugin.icon}
-            className="size-full"
-          />
+      <header className="flex items-center justify-between gap-4">
+        <div className="flex min-w-0 items-center gap-3">
+          <div className="size-9 shrink-0">
+            <PluginIcon
+              pluginId={plugin.id}
+              icon={plugin.icon}
+              className="size-full"
+            />
+          </div>
+          <div className="min-w-0">
+            <h1 className="truncate text-lg font-semibold text-foreground">
+              {plugin.name ?? plugin.id}
+            </h1>
+            {plugin.description ? (
+              <p className="truncate text-xs text-subtle-foreground">
+                {plugin.description}
+              </p>
+            ) : null}
+          </div>
         </div>
-        <div className="min-w-0">
-          <h1 className="truncate text-lg font-semibold text-foreground">
-            {plugin.name ?? plugin.id}
-          </h1>
-          {plugin.description ? (
-            <p className="truncate text-xs text-subtle-foreground">
-              {plugin.description}
-            </p>
-          ) : null}
-        </div>
-      </div>
+        <Switch
+          checked={enabled}
+          disabled={toggle.isPending}
+          onCheckedChange={(next) => toggle.mutate(next)}
+          aria-label={`${enabled ? "Disable" : "Enable"} ${plugin.id}`}
+        />
+      </header>
       <ResourceDetailStack className="mt-6">
-        <ResourceDetailConfigurationSection label="Configuration">
-          <PluginSettingsDetail plugin={plugin} />
-        </ResourceDetailConfigurationSection>
+        {enabled && plugin.enabled && hasAvailableSettings ? (
+          <ResourceDetailConfigurationSection label="Configuration">
+            <PluginSettingsDetail plugin={plugin} />
+          </ResourceDetailConfigurationSection>
+        ) : null}
         <ResourceDetailOverviewSection label="Plugin details">
           <p className="max-w-none text-sm leading-relaxed text-muted-foreground">
             Release, capabilities, and health live on{" "}
             <Link
               to={getPluginDetailRoutePath({
-                pluginId,
+                pluginId: plugin.id,
                 view: "installed",
               })}
               className="inline-flex items-center gap-0.5 rounded-sm underline underline-offset-2 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"

--- a/apps/app/src/components/settings/plugin-settings-entries.test.ts
+++ b/apps/app/src/components/settings/plugin-settings-entries.test.ts
@@ -2,36 +2,43 @@ import { describe, expect, it } from "vitest";
 import { buildPluginSettingsEntries } from "./plugin-settings-entries";
 
 describe("buildPluginSettingsEntries", () => {
-  it("includes enabled plugins with declarative or custom settings", () => {
-    const entries = buildPluginSettingsEntries({
-      installedPlugins: [
-        {
-          enabled: true,
-          hasSettings: false,
-          icon: null,
-          id: "workflows",
-          name: null,
-        },
-        {
-          enabled: false,
-          hasSettings: true,
-          icon: null,
-          id: "disabled",
-          name: "Disabled",
-        },
-        {
-          enabled: true,
-          hasSettings: true,
-          icon: "linear-icon",
-          id: "linear",
-          name: "Linear",
-        },
-      ],
-      settingsSections: [{ pluginId: "workflows" }],
-    });
+  it("includes every installed plugin regardless of runtime configuration", () => {
+    const installedPlugins = [
+      {
+        enabled: true,
+        hasSettings: false,
+        icon: null,
+        id: "workflows",
+        name: null,
+      },
+      {
+        enabled: false,
+        hasSettings: false,
+        icon: null,
+        id: "disabled",
+        name: "Disabled",
+      },
+      {
+        enabled: true,
+        hasSettings: true,
+        icon: "linear-icon",
+        id: "linear",
+        name: "Linear",
+      },
+      {
+        enabled: true,
+        hasSettings: false,
+        icon: null,
+        id: "plain",
+        name: "Plain",
+      },
+    ];
+    const entries = buildPluginSettingsEntries({ installedPlugins });
 
     expect(entries).toEqual([
+      { icon: null, id: "disabled", label: "Disabled" },
       { icon: "linear-icon", id: "linear", label: "Linear" },
+      { icon: null, id: "plain", label: "Plain" },
       { icon: null, id: "workflows", label: "workflows" },
     ]);
   });

--- a/apps/app/src/components/settings/plugin-settings-entries.ts
+++ b/apps/app/src/components/settings/plugin-settings-entries.ts
@@ -1,13 +1,7 @@
 export interface PluginSettingsCandidate {
-  enabled: boolean;
-  hasSettings: boolean;
   icon: string | null;
   id: string;
   name: string | null;
-}
-
-interface PluginSettingsSectionOwner {
-  pluginId: string;
 }
 
 export interface PluginSettingsEntry {
@@ -18,21 +12,12 @@ export interface PluginSettingsEntry {
 
 interface BuildPluginSettingsEntriesArgs {
   installedPlugins: readonly PluginSettingsCandidate[];
-  settingsSections: readonly PluginSettingsSectionOwner[];
 }
 
 export function buildPluginSettingsEntries(
   args: BuildPluginSettingsEntriesArgs,
 ): PluginSettingsEntry[] {
-  const pluginsWithCustomSettings = new Set(
-    args.settingsSections.map((section) => section.pluginId),
-  );
   return args.installedPlugins
-    .filter(
-      (plugin) =>
-        plugin.enabled &&
-        (plugin.hasSettings || pluginsWithCustomSettings.has(plugin.id)),
-    )
     .map((plugin) => ({
       id: plugin.id,
       label: plugin.name ?? plugin.id,

--- a/apps/app/src/components/settings/settings-nav.test.tsx
+++ b/apps/app/src/components/settings/settings-nav.test.tsx
@@ -4,8 +4,10 @@ import { cleanup, renderHook } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { InstalledPlugin } from "@bb/server-contract";
 import { resetPluginSlotStoreForTest } from "@/lib/plugin-slots";
 import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
+import { pluginListQueryKey } from "@/hooks/queries/query-keys";
 import { useSettingsNavState } from "./settings-nav";
 
 const mocks = vi.hoisted(() => ({
@@ -17,14 +19,48 @@ vi.mock("@/hooks/useHostDaemon", () => ({
   useLocalHostDaemonAccess: () => ({ accessState: mocks.accessState }),
 }));
 
-function wrapperFor(path: string) {
-  const { wrapper: QueryWrapper } = createQueryClientTestHarness();
+function wrapperFor(path: string, plugins: readonly InstalledPlugin[] = []) {
+  const { queryClient, wrapper: QueryWrapper } =
+    createQueryClientTestHarness();
+  queryClient.setQueryData(pluginListQueryKey(true), plugins);
   return function Wrapper({ children }: { children: ReactNode }) {
     return (
       <QueryWrapper>
         <MemoryRouter initialEntries={[path]}>{children}</MemoryRouter>
       </QueryWrapper>
     );
+  };
+}
+
+function disabledPlugin(): InstalledPlugin {
+  return {
+    id: "linear",
+    source: "path:/plugins/linear",
+    rootDir: "/plugins/linear",
+    version: "0.1.0",
+    enabled: false,
+    status: "disabled",
+    statusDetail: null,
+    description: "Linear integration",
+    name: "Linear",
+    icon: null,
+    iconUrl: null,
+    logoUrl: null,
+    logoDarkUrl: null,
+    hasSettings: false,
+    handlerStats: { count: 0, totalMs: 0, maxMs: 0, errorCount: 0 },
+    services: [],
+    schedules: [],
+    cliCommand: null,
+    capabilities: [],
+    app: { hasApp: false, bundle: null },
+    provenance: "direct",
+    isOrphanedBuiltin: false,
+    publisherLabel: null,
+    sourceDisplay: "path · /plugins/linear",
+    updateState: {},
+    providerIds: [],
+    icons: {},
   };
 }
 
@@ -84,5 +120,15 @@ describe("useSettingsNavState", () => {
     expect(result.current.sections.map((section) => section.id)).not.toContain(
       "plugins",
     );
+  });
+
+  it("keeps a disabled plugin reachable after its settings metadata unloads", () => {
+    const { result } = renderHook(() => useSettingsNavState(), {
+      wrapper: wrapperFor("/settings", [disabledPlugin()]),
+    });
+
+    expect(result.current.pluginEntries).toEqual([
+      { icon: null, id: "linear", label: "Linear" },
+    ]);
   });
 });

--- a/apps/app/src/components/settings/settings-nav.tsx
+++ b/apps/app/src/components/settings/settings-nav.tsx
@@ -48,7 +48,7 @@ export function useSettingsNavSections(
 
 export function useSettingsNavState(): SettingsNavState {
   const location = useLocation();
-  const { fileOpeners, settingsSections } = usePluginSlots();
+  const { fileOpeners } = usePluginSlots();
   const sections = useSettingsNavSections(fileOpeners);
   const pluginListQuery = usePluginList({ enabled: true });
 
@@ -78,7 +78,6 @@ export function useSettingsNavState(): SettingsNavState {
   const installedPlugins = pluginListQuery.data?.plugins ?? [];
   const pluginEntries = buildPluginSettingsEntries({
     installedPlugins,
-    settingsSections,
   });
 
   return {


### PR DESCRIPTION
## Human comments

## What was wrong

Settings navigation only exposed plugins whose configuration was currently discoverable. Disabled plugin list rows report `hasSettings: false`, and disabling also unloads custom settings sections, so the post-mutation inventory refresh removed the plugin from Settings and left no route back to re-enable it.

## What changed

Every installed plugin now receives a Settings lifecycle entry and command-palette action. Plugin settings pages expose enable/disable in the header, while Configuration renders only when the plugin is enabled and declarative or custom configuration is currently available. Disabled plugins and enabled plugins without configuration show only Plugin details, without an empty section or divider. No wire contracts or daemon protocol behavior changed.

## How you verified

- Added a regression for a realistic disabled plugin row with `hasSettings: false` and no active settings slot remaining reachable after inventory reload.
- Added lifecycle coverage for disabling, re-enabling, Configuration removal while disabled, and restoration when configuration becomes available.
- `pnpm exec turbo run test --filter=@bb/app -- --run src/components/plugin/PluginSettings.test.tsx src/components/settings/plugin-settings-entries.test.ts src/components/settings/settings-nav.test.tsx src/components/commands/CommandPalette.test.tsx` (36 passed)
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run lint --filter=@bb/app` (0 errors; 174 existing warnings)

> AGENT GENERATED