### PR TITLE
Keep collapsed parent thread chevrons visible

### DIFF
--- a/apps/app/src/components/sidebar/ThreadRow.test.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.test.tsx
@@ -962,6 +962,34 @@ describe("ThreadRow", () => {
     ).toBe("always");
   });
 
+  it.each([
+    { isCollapsed: true, expectedHoverReveal: false },
+    { isCollapsed: false, expectedHoverReveal: true },
+  ])(
+    "sets parent-thread disclosure hover reveal to $expectedHoverReveal when collapsed is $isCollapsed",
+    ({ expectedHoverReveal, isCollapsed }) => {
+      renderThreadRow({
+        thread: createThread({ title: "Parent thread" }),
+        options: {
+          kind: "parent",
+          depth: 1,
+          isCompact: false,
+          isCollapsed,
+          childCount: 1,
+          childActivity: NO_COLLAPSED_CHILD_ACTIVITY,
+          onToggleCollapsed: vi.fn(),
+        },
+      });
+
+      const toggle = screen.getByRole("button", {
+        name: `${isCollapsed ? "Expand" : "Collapse"} Parent thread threads`,
+      });
+      expect(toggle.classList.contains("bb-sidebar-hover-actions")).toBe(
+        expectedHoverReveal,
+      );
+    },
+  );
+
   it("shows its Command shortcut in place of an active indicator", () => {
     renderThreadRow({
       shortcutKey: "3",

--- a/apps/app/src/components/sidebar/ThreadRow.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.tsx
@@ -757,7 +757,7 @@ function ThreadRowComponent({
             expandLabel={`Expand ${labelTitle} threads`}
             collapseLabel={`Collapse ${labelTitle} threads`}
             onToggle={() => parentOptions.onToggleCollapsed(thread.id)}
-            revealOnHover
+            revealOnHover={!isParentCollapsed}
           />
         ) : null}
       </span>


### PR DESCRIPTION
## Human comments

## What was wrong

`ThreadRow` always enabled hover-only reveal behavior for parent-thread disclosure chevrons. That behavior was correct for expanded parents, where the child rows already communicate the hierarchy, but it also hid the chevron for collapsed parents and removed the only persistent visual indication that hidden children could be expanded.

## What changed

- Keep the disclosure chevron persistently visible while a parent thread is collapsed.
- Preserve hover-only reveal behavior for expanded parent threads.
- Add regression coverage for both collapsed and expanded states.

There are no wire-protocol, CLI, guide, or documentation changes.

## How you verified

- Added a regression test that failed before the fix and passes after it.
- `pnpm exec turbo run test --filter=@bb/app --force -- src/components/sidebar/ThreadRow.test.tsx` (76 tests passed)
- `pnpm exec turbo run typecheck --filter=@bb/app`
- Captured matching before and after screenshots of the collapsed-parent Ladle story with Doobie v0.1.2, with the pointer moved away from the row. The after state reports `aria-expanded=false`, `opacity: 1`, and `visibility: visible`.

> AGENT GENERATED
