### PR TITLE
Organize sidebar regions and plugin overflow

### DIFF
--- a/apps/app/src/components/plugin/PluginNavSidebarItems.test.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.test.tsx
@@ -11,6 +11,7 @@ import { useEffect, type ComponentType } from "react";
 import { createStore, Provider } from "jotai";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { CompactViewportOverrideProvider } from "@bb/shared-ui/hooks/use-compact-viewport";
 import { SidebarProvider } from "@/components/ui/sidebar.js";
 import {
@@ -22,7 +23,10 @@ import {
   resetAllCrashedPluginSlotsForTest,
   resetCrashedPluginSlots,
 } from "./PluginSlotMount";
-import { PluginNavSidebarItems } from "./PluginNavSidebarItems";
+import {
+  ExtensionsNavSidebarItem,
+  PluginNavSidebarItems,
+} from "./PluginNavSidebarItems";
 import { pluginNavPanelOrderAtom } from "./pluginNavSidebarAtoms";
 
 function registrationSet(
@@ -68,12 +72,14 @@ function registerPanel(
 
 function renderSidebarItems(
   options: {
-    toolsRoutePath?: string;
     storedOrder?: string[];
     compactViewport?: boolean;
   } = {},
 ) {
   const store = createStore();
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
   if (options.storedOrder) {
     store.set(pluginNavPanelOrderAtom, options.storedOrder);
   }
@@ -81,24 +87,25 @@ function renderSidebarItems(
     <CompactViewportOverrideProvider
       isCompactViewport={options.compactViewport ?? false}
     >
-      <Provider store={store}>
-        <MemoryRouter initialEntries={["/"]}>
-          <SidebarProvider>
-            <PluginNavSidebarItems toolsRoutePath={options.toolsRoutePath} />
-          </SidebarProvider>
-        </MemoryRouter>
-      </Provider>
+      <QueryClientProvider client={queryClient}>
+        <Provider store={store}>
+          <MemoryRouter initialEntries={["/"]}>
+            <SidebarProvider>
+              <PluginNavSidebarItems />
+            </SidebarProvider>
+          </MemoryRouter>
+        </Provider>
+      </QueryClientProvider>
     </CompactViewportOverrideProvider>,
   );
 }
 
-const ROW_LABELS = new Set(["Extensions", "Docs", "GitHub"]);
-
-function panelRowNames(): string[] {
+function panelRowNames(labels: readonly string[] = ["Docs", "GitHub"]): string[] {
+  const rowLabels = new Set(labels);
   return screen
     .getAllByRole("button")
     .map((button) => button.textContent?.trim() ?? "")
-    .filter((label) => ROW_LABELS.has(label));
+    .filter((label) => rowLabels.has(label));
 }
 
 beforeEach(() => {
@@ -212,7 +219,7 @@ describe("PluginNavSidebarItems", () => {
       { button: 0 },
     );
     expect(
-      await screen.findByRole("menuitem", { name: "Hide from sidebar" }),
+      await screen.findByRole("menuitem", { name: "Move to top" }),
     ).not.toBeNull();
 
     expect(accessory?.getAttribute("data-sidebar-hover-actions-open")).toBe(
@@ -257,158 +264,68 @@ describe("PluginNavSidebarItems", () => {
     expect(screen.queryByText("plugin tasks crashed")).toBeNull();
   });
 
-  it("moves a hidden panel into an expanded More disclosure and back", async () => {
-    registerPanel("docs", "Docs");
-    registerPanel("github", "GitHub");
+  it("puts the sixth plugin behind a count-free disclosure", async () => {
+    const labels = ["One", "Two", "Three", "Four", "Five", "Six"];
+    labels.forEach((label, index) => registerPanel(`plugin-${index}`, label));
 
     renderSidebarItems();
 
-    expect(panelRowNames()).toEqual(["Docs", "GitHub"]);
-    expect(
-      screen.queryByTestId("plugin-nav-sidebar-overflow-toggle"),
-    ).toBeNull();
-
-    fireEvent.pointerDown(
-      screen.getByRole("button", { name: "Docs panel options" }),
-      { button: 0 },
-    );
-    fireEvent.click(
-      await screen.findByRole("menuitem", { name: "Hide from sidebar" }),
-    );
-
-    await waitFor(() => {
-      expect(
-        screen.getByTestId("plugin-nav-sidebar-overflow-toggle").textContent,
-      ).toContain("More (1)");
-    });
-    expect(panelRowNames()).toEqual(["GitHub"]);
-    expect(
-      window.localStorage.getItem("bb.sidebar.hiddenPluginPanels"),
-    ).toContain("docs/main");
-
-    fireEvent.click(screen.getByTestId("plugin-nav-sidebar-overflow-toggle"));
-    await waitFor(() => {
-      expect(panelRowNames()).toEqual(["GitHub", "Docs"]);
-    });
-
-    fireEvent.pointerDown(
-      screen.getByRole("button", { name: "Docs panel options" }),
-      { button: 0 },
-    );
-    fireEvent.click(
-      await screen.findByRole("menuitem", { name: "Show in sidebar" }),
-    );
-
-    await waitFor(() => {
-      expect(
-        screen.queryByTestId("plugin-nav-sidebar-overflow-toggle"),
-      ).toBeNull();
-    });
-    expect(panelRowNames()).toEqual(["Docs", "GitHub"]);
-  });
-
-  it("collapses hidden panels behind the More toggle on a later mount", async () => {
-    registerPanel("docs", "Docs");
-    registerPanel("github", "GitHub");
-    window.localStorage.setItem(
-      "bb.sidebar.hiddenPluginPanels",
-      JSON.stringify(["docs/main"]),
-    );
-
-    renderSidebarItems();
-
-    expect(panelRowNames()).toEqual(["GitHub"]);
+    expect(panelRowNames(labels)).toEqual(labels.slice(0, 5));
     const toggle = screen.getByTestId("plugin-nav-sidebar-overflow-toggle");
-    expect(toggle.textContent).toContain("More (1)");
+    expect(toggle.textContent).toBe("More plugins");
+    expect(toggle.textContent).not.toMatch(/\d/);
 
     fireEvent.click(toggle);
-    await waitFor(() => {
-      expect(panelRowNames()).toEqual(["GitHub", "Docs"]);
-    });
+    await waitFor(() => expect(panelRowNames(labels)).toEqual(labels));
+    expect(toggle.textContent).toBe("Show fewer");
   });
 
-  it("hides the built-in Extensions row like a plugin row", async () => {
-    registerPanel("docs", "Docs");
-
-    renderSidebarItems({ toolsRoutePath: "/extensions/skills" });
-
-    expect(panelRowNames()).toEqual(["Extensions", "Docs"]);
+  it("moves a visible row to overflow and back to top", async () => {
+    const labels = ["One", "Two", "Three", "Four", "Five", "Six"];
+    labels.forEach((label, index) => registerPanel(`plugin-${index}`, label));
+    renderSidebarItems();
 
     fireEvent.pointerDown(
-      screen.getByRole("button", { name: "Extensions panel options" }),
+      screen.getByRole("button", { name: "One panel options" }),
       { button: 0 },
     );
     fireEvent.click(
-      await screen.findByRole("menuitem", { name: "Hide from sidebar" }),
+      await screen.findByRole("menuitem", { name: "Move to overflow" }),
     );
 
-    await waitFor(() => {
-      expect(panelRowNames()).toEqual(["Docs"]);
-    });
-    expect(
-      screen.getByTestId("plugin-nav-sidebar-overflow-toggle").textContent,
-    ).toContain("More (1)");
-    expect(
-      window.localStorage.getItem("bb.sidebar.hiddenPluginPanels"),
-    ).toContain("__builtin__/tools");
+    await waitFor(() =>
+      expect(panelRowNames(labels)).toEqual([
+        "Two",
+        "Three",
+        "Four",
+        "Five",
+        "Six",
+      ]),
+    );
+    fireEvent.click(screen.getByTestId("plugin-nav-sidebar-overflow-toggle"));
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: "One panel options" }),
+      { button: 0 },
+    );
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: "Move to top" }),
+    );
+    await waitFor(() => expect(panelRowNames(labels)).toEqual(labels));
   });
+});
 
-  it("keeps Extensions on top for users who already reordered their plugin rows", () => {
-    registerPanel("docs", "Docs");
-    registerPanel("github", "GitHub");
+describe("ExtensionsNavSidebarItem", () => {
+  it("is host-owned and has no plugin-panel options menu", () => {
+    render(
+      <MemoryRouter>
+        <ExtensionsNavSidebarItem routePath="/extensions/plugins" />
+      </MemoryRouter>,
+    );
 
-    renderSidebarItems({
-      toolsRoutePath: "/extensions/skills",
-      storedOrder: ["github/main", "docs/main"],
-    });
-
-    expect(panelRowNames()).toEqual(["Extensions", "GitHub", "Docs"]);
-  });
-
-  it("keeps a saved order when plugin frontends register after the first render", async () => {
-    renderSidebarItems({
-      toolsRoutePath: "/extensions/skills",
-      storedOrder: ["github/main", "__builtin__/tools", "docs/main"],
-    });
-
-    expect(panelRowNames()).toEqual(["Extensions"]);
-
-    registerPanel("docs", "Docs");
-    registerPanel("github", "GitHub");
-
-    await waitFor(() => {
-      expect(panelRowNames()).toEqual(["GitHub", "Extensions", "Docs"]);
-    });
-  });
-
-  it("saves no Extensions key while the row is absent", async () => {
-    registerPanel("docs", "Docs");
-
-    renderSidebarItems({ storedOrder: ["docs/main"] });
-
-    await waitFor(() => {
-      expect(panelRowNames()).toEqual(["Docs"]);
-    });
+    const row = screen.getByRole("button", { name: "Extensions" });
+    expect(row.querySelector(".bb-sidebar-row-icon-swap")).not.toBeNull();
     expect(
-      window.localStorage.getItem("bb.sidebar.pluginPanelOrder") ?? "",
-    ).not.toContain("__builtin__/tools");
-  });
-
-  it("carries both Extensions glyphs so hover swaps without reflow", () => {
-    renderSidebarItems({ toolsRoutePath: "/extensions/plugins" });
-
-    const extensionsRow = screen
-      .getAllByRole("button")
-      .find((button) => button.textContent?.trim() === "Extensions");
-    expect(extensionsRow).toBeTruthy();
-
-    const swap = extensionsRow?.querySelector(".bb-sidebar-row-icon-swap");
-    expect(swap).toBeTruthy();
-    expect(
-      swap?.querySelector('.bb-sidebar-row-icon-rest[data-icon="Toolbox"]'),
-    ).toBeTruthy();
-    expect(
-      swap?.querySelector('.bb-sidebar-row-icon-hover[data-icon="ToolCase"]'),
-    ).toBeTruthy();
+      screen.queryByRole("button", { name: "Extensions panel options" }),
+    ).toBeNull();
   });
 });

--- a/apps/app/src/components/plugin/PluginNavSidebarItems.test.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.test.tsx
@@ -294,7 +294,7 @@ describe("PluginNavSidebarItems", () => {
     expect(
       screen
         .getByTestId("plugin-nav-sidebar-overflow-count")
-        .classList.contains("text-subtle-foreground/60"),
+        .classList.contains("text-subtle-foreground/50"),
     ).toBe(true);
 
     fireEvent.click(toggle);

--- a/apps/app/src/components/plugin/PluginNavSidebarItems.test.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.test.tsx
@@ -292,10 +292,8 @@ describe("PluginNavSidebarItems", () => {
     const toggle = screen.getByTestId("plugin-nav-sidebar-overflow-toggle");
     expect(toggle.textContent).toBe("1 more plugin");
     expect(
-      screen
-        .getByTestId("plugin-nav-sidebar-overflow-count")
-        .classList.contains("text-subtle-foreground/50"),
-    ).toBe(true);
+      screen.getByTestId("plugin-nav-sidebar-overflow-count").className,
+    ).toBe("tabular-nums");
 
     fireEvent.click(toggle);
     await waitFor(() => expect(panelRowNames(labels)).toEqual(labels));

--- a/apps/app/src/components/plugin/PluginNavSidebarItems.test.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.test.tsx
@@ -282,22 +282,25 @@ describe("PluginNavSidebarItems", () => {
     expect(screen.queryByText("plugin tasks crashed")).toBeNull();
   });
 
-  it("shows the overflow count when the fifth plugin is hidden", async () => {
-    const labels = ["One", "Two", "Three", "Four", "Five"];
+  it("uses a minimal exact-count disclosure after the third plugin", async () => {
+    const labels = ["One", "Two", "Three", "Four", "Five", "Six"];
     labels.forEach((label, index) => registerPanel(`plugin-${index}`, label));
 
     renderSidebarItems();
 
-    expect(panelRowNames(labels)).toEqual(labels.slice(0, 4));
+    expect(panelRowNames(labels)).toEqual(labels.slice(0, 3));
     const toggle = screen.getByTestId("plugin-nav-sidebar-overflow-toggle");
-    expect(toggle.textContent).toBe("1 more plugin");
+    expect(toggle.textContent).toBe("Show 3 more");
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(toggle.querySelector("svg")).toBeNull();
     expect(
       screen.getByTestId("plugin-nav-sidebar-overflow-count").className,
     ).toBe("tabular-nums");
 
     fireEvent.click(toggle);
     await waitFor(() => expect(panelRowNames(labels)).toEqual(labels));
-    expect(toggle.textContent).toBe("Show fewer");
+    expect(toggle.textContent).toBe("Show less");
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
   });
 
   it("moves a visible row to overflow and back to top", async () => {
@@ -318,7 +321,6 @@ describe("PluginNavSidebarItems", () => {
         "Two",
         "Three",
         "Four",
-        "Five",
       ]),
     );
     fireEvent.click(screen.getByTestId("plugin-nav-sidebar-overflow-toggle"));

--- a/apps/app/src/components/plugin/PluginNavSidebarItems.test.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.test.tsx
@@ -282,13 +282,13 @@ describe("PluginNavSidebarItems", () => {
     expect(screen.queryByText("plugin tasks crashed")).toBeNull();
   });
 
-  it("puts the sixth plugin behind a count-free disclosure", async () => {
-    const labels = ["One", "Two", "Three", "Four", "Five", "Six"];
+  it("puts the fifth plugin behind a count-free disclosure", async () => {
+    const labels = ["One", "Two", "Three", "Four", "Five"];
     labels.forEach((label, index) => registerPanel(`plugin-${index}`, label));
 
     renderSidebarItems();
 
-    expect(panelRowNames(labels)).toEqual(labels.slice(0, 5));
+    expect(panelRowNames(labels)).toEqual(labels.slice(0, 4));
     const toggle = screen.getByTestId("plugin-nav-sidebar-overflow-toggle");
     expect(toggle.textContent).toBe("More plugins");
     expect(toggle.textContent).not.toMatch(/\d/);
@@ -317,7 +317,6 @@ describe("PluginNavSidebarItems", () => {
         "Three",
         "Four",
         "Five",
-        "Six",
       ]),
     );
     fireEvent.click(screen.getByTestId("plugin-nav-sidebar-overflow-toggle"));

--- a/apps/app/src/components/plugin/PluginNavSidebarItems.test.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.test.tsx
@@ -282,7 +282,7 @@ describe("PluginNavSidebarItems", () => {
     expect(screen.queryByText("plugin tasks crashed")).toBeNull();
   });
 
-  it("puts the fifth plugin behind a count-free disclosure", async () => {
+  it("shows the overflow count when the fifth plugin is hidden", async () => {
     const labels = ["One", "Two", "Three", "Four", "Five"];
     labels.forEach((label, index) => registerPanel(`plugin-${index}`, label));
 
@@ -290,8 +290,12 @@ describe("PluginNavSidebarItems", () => {
 
     expect(panelRowNames(labels)).toEqual(labels.slice(0, 4));
     const toggle = screen.getByTestId("plugin-nav-sidebar-overflow-toggle");
-    expect(toggle.textContent).toBe("More plugins");
-    expect(toggle.textContent).not.toMatch(/\d/);
+    expect(toggle.textContent).toBe("1 more plugin");
+    expect(
+      screen
+        .getByTestId("plugin-nav-sidebar-overflow-count")
+        .classList.contains("text-subtle-foreground/60"),
+    ).toBe(true);
 
     fireEvent.click(toggle);
     await waitFor(() => expect(panelRowNames(labels)).toEqual(labels));

--- a/apps/app/src/components/plugin/PluginNavSidebarItems.test.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.test.tsx
@@ -124,6 +124,24 @@ afterEach(() => {
 });
 
 describe("PluginNavSidebarItems", () => {
+  it("collapses the entire subsection with zero traditional plugins", () => {
+    renderSidebarItems();
+
+    expect(screen.queryByTestId("plugin-nav-sidebar-items")).toBeNull();
+    expect(screen.queryByText("Plugins")).toBeNull();
+  });
+
+  it("shows the subsection label without a disclosure for one plugin", () => {
+    registerPanel("docs", "Docs");
+    renderSidebarItems();
+
+    expect(screen.getByText("Plugins")).toBeDefined();
+    expect(panelRowNames(["Docs"])).toEqual(["Docs"]);
+    expect(
+      screen.queryByTestId("plugin-nav-sidebar-overflow-toggle"),
+    ).toBeNull();
+  });
+
   it("keeps an accessory-less plugin row unchanged", () => {
     registerPanel("docs", "Docs");
 

--- a/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
@@ -244,7 +244,7 @@ function PluginNavSidebarItemList({
       <div
         aria-hidden="true"
         data-sidebar-navigation-divider="plugins"
-        className="mx-2 h-px shrink-0 bg-sidebar-border"
+        className="mx-2 h-px shrink-0 bg-sidebar-border/40"
       />
       <div
         className="shrink-0 space-y-0.5 px-2 py-2 group-data-[collapsible=icon]:hidden"

--- a/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
@@ -80,7 +80,7 @@ import {
   reorderPluginNavPanels,
 } from "./pluginNavSidebarOrder";
 
-export const PLUGIN_NAV_VISIBLE_LIMIT = 5;
+export const PLUGIN_NAV_VISIBLE_LIMIT = 4;
 
 type SidebarNavRow = {
   pluginId: string;

--- a/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
@@ -327,7 +327,7 @@ function PluginNavSidebarOverflowToggle({
         ) : (
           <>
             <span
-              className="tabular-nums text-subtle-foreground/60"
+              className="tabular-nums text-subtle-foreground/50"
               data-testid="plugin-nav-sidebar-overflow-count"
             >
               {overflowCount}

--- a/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
@@ -327,7 +327,7 @@ function PluginNavSidebarOverflowToggle({
         ) : (
           <>
             <span
-              className="tabular-nums text-subtle-foreground/50"
+              className="tabular-nums"
               data-testid="plugin-nav-sidebar-overflow-count"
             >
               {overflowCount}

--- a/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
@@ -80,7 +80,7 @@ import {
   reorderPluginNavPanels,
 } from "./pluginNavSidebarOrder";
 
-export const PLUGIN_NAV_VISIBLE_LIMIT = 4;
+export const PLUGIN_NAV_VISIBLE_LIMIT = 3;
 
 type SidebarNavRow = {
   pluginId: string;
@@ -313,26 +313,20 @@ function PluginNavSidebarOverflowToggle({
       onClick={onToggle}
       data-testid="plugin-nav-sidebar-overflow-toggle"
     >
-      <Icon
-        name="ChevronRight"
-        className={cn(
-          "size-3 shrink-0 transition-transform duration-150",
-          isOpen && "rotate-90",
-        )}
-        aria-hidden="true"
-      />
+      <span className="w-4 shrink-0" aria-hidden="true" />
       <span className="min-w-0 truncate text-left">
         {isOpen ? (
-          "Show fewer"
+          "Show less"
         ) : (
           <>
+            Show{" "}
             <span
               className="tabular-nums"
               data-testid="plugin-nav-sidebar-overflow-count"
             >
               {overflowCount}
             </span>{" "}
-            more {overflowCount === 1 ? "plugin" : "plugins"}
+            more
           </>
         )}
       </span>

--- a/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
@@ -269,6 +269,7 @@ function PluginNavSidebarItemList({
               <>
                 <PluginNavSidebarOverflowToggle
                   isOpen={isOverflowOpen}
+                  overflowCount={overflow.length}
                   onToggle={() => setIsOverflowOpen((open) => !open)}
                 />
                 {isOverflowOpen
@@ -292,9 +293,11 @@ function PluginNavSidebarItemList({
 
 function PluginNavSidebarOverflowToggle({
   isOpen,
+  overflowCount,
   onToggle,
 }: {
   isOpen: boolean;
+  overflowCount: number;
   onToggle: () => void;
 }) {
   return (
@@ -319,7 +322,19 @@ function PluginNavSidebarOverflowToggle({
         aria-hidden="true"
       />
       <span className="min-w-0 truncate text-left">
-        {isOpen ? "Show fewer" : "More plugins"}
+        {isOpen ? (
+          "Show fewer"
+        ) : (
+          <>
+            <span
+              className="tabular-nums text-subtle-foreground/60"
+              data-testid="plugin-nav-sidebar-overflow-count"
+            >
+              {overflowCount}
+            </span>{" "}
+            more {overflowCount === 1 ? "plugin" : "plugins"}
+          </>
+        )}
       </span>
     </Button>
   );

--- a/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
@@ -11,6 +11,8 @@ import {
 import { useLocation, useNavigate } from "react-router-dom";
 import { useAtom } from "jotai";
 import { DndContext, type DragEndEvent } from "@dnd-kit/core";
+import { UnavailableIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import {
   SortableContext,
   verticalListSortingStrategy,
@@ -21,12 +23,14 @@ import {
   ContextMenu,
   ContextMenuContent,
   ContextMenuItem,
+  ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@bb/shared-ui/context-menu";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@bb/shared-ui/dropdown-menu";
 import { COARSE_POINTER_ICON_SIZE_CLASS } from "@bb/shared-ui/coarse-pointer-sizing";
@@ -34,10 +38,17 @@ import { useIsCompactViewport } from "@bb/shared-ui/hooks/use-compact-viewport";
 import { PluginIcon } from "@/components/plugin/PluginIcon";
 import { PluginSlotMount } from "@/components/plugin/PluginSlotMount";
 import { PROJECT_LIST_ACTION_BUTTON_CLASS } from "@/components/sidebar/ProjectList";
-import { getPluginPanelRoutePath } from "@/lib/route-paths";
+import {
+  AUTOMATIONS_PLUGIN_ID,
+  getPluginDetailRoutePath,
+  getPluginPanelRoutePath,
+  getPluginPanelRoutePluginId,
+  getPluginsRoutePath,
+} from "@/lib/route-paths";
 import {
   usePluginNavPanelChrome,
   type PluginNavPanelChrome,
+  type PluginNavPanelChromeEntry,
 } from "@/lib/plugin-nav-panel-chrome";
 import { cn } from "@bb/shared-ui/lib/utils";
 import type { PluginNavPanelSlot } from "@/lib/plugin-slots";
@@ -55,76 +66,65 @@ import {
 import { useSidebarSortable } from "@/components/sidebar/sortableMotion";
 import { useSidebarReorderDnd } from "@/components/sidebar/useSidebarReorderDnd";
 import type { SidebarSortableDragBindings } from "@/components/sidebar/sortableMotion";
-import {
-  hiddenPluginNavPanelsAtom,
-  pluginNavPanelOrderAtom,
-} from "./pluginNavSidebarAtoms";
+import { appToast } from "@/components/ui/app-toast";
+import { invalidatePluginList } from "@/hooks/cache-owners/plugin-cache-owner";
+import { setPluginEnabled } from "@/hooks/queries/plugin-settings-queries";
+import { appQueryClient } from "@/lib/app-query-client";
+import { pluginNavPanelOrderAtom } from "./pluginNavSidebarAtoms";
 import {
   arrangePluginNavPanels,
   getPluginNavPanelKey,
   havePluginNavPanelOrdersDiverged,
-  hidePluginNavPanel,
+  movePluginNavPanelToTop,
   reorderPluginNavPanels,
-  seedLeadingNavPanelKeys,
-  showPluginNavPanel,
 } from "./pluginNavSidebarOrder";
 
-const BUILTIN_NAV_ROW_PLUGIN_ID = "__builtin__";
+export const PLUGIN_NAV_VISIBLE_LIMIT = 5;
 
-const TOOLS_NAV_ROW_KEY = getPluginNavPanelKey({
-  pluginId: BUILTIN_NAV_ROW_PLUGIN_ID,
-  id: "tools",
-});
+type SidebarNavRow = {
+  pluginId: string;
+  id: string;
+  title: string;
+  chrome: PluginNavPanelChrome;
+  panel: PluginNavPanelSlot | null;
+};
 
-type SidebarNavRow =
-  | {
-      kind: "tools";
-      pluginId: string;
-      id: string;
-      title: string;
-      routePath: string;
-    }
-  | {
-      kind: "plugin";
-      pluginId: string;
-      id: string;
-      title: string;
-      chrome: PluginNavPanelChrome;
-      panel: PluginNavPanelSlot | null;
-    };
+export function getTraditionalPluginNavPanelEntries(
+  entries: readonly PluginNavPanelChromeEntry[],
+): PluginNavPanelChromeEntry[] {
+  return entries.filter(
+    ({ chrome }) => chrome.pluginId !== AUTOMATIONS_PLUGIN_ID,
+  );
+}
 
-export function PluginNavSidebarItems({
-  toolsRoutePath,
-  ...props
-}: {
+export function PluginNavSidebarItems(props: {
+  entries?: readonly PluginNavPanelChromeEntry[];
   onNavigate?: () => void;
   splitEnabled?: boolean;
-  toolsRoutePath?: string;
 }) {
-  const navPanels = usePluginNavPanelChrome();
-  const rows = useMemo<SidebarNavRow[]>(() => {
-    const pluginRows = navPanels.map<SidebarNavRow>(({ chrome, panel }) => ({
-      kind: "plugin",
-      pluginId: chrome.pluginId,
-      id: chrome.id,
-      title: chrome.title,
-      chrome,
-      panel,
-    }));
-    if (toolsRoutePath === undefined) return pluginRows;
-    return [
-      {
-        kind: "tools",
-        pluginId: BUILTIN_NAV_ROW_PLUGIN_ID,
-        id: "tools",
-        title: "Extensions",
-        routePath: toolsRoutePath,
-      },
-      ...pluginRows,
-    ];
-  }, [navPanels, toolsRoutePath]);
+  const discoveredEntries = usePluginNavPanelChrome();
+  const entries = props.entries ?? discoveredEntries;
+  const rows = useMemo<SidebarNavRow[]>(
+    () =>
+      getTraditionalPluginNavPanelEntries(entries).map(
+        ({ chrome, panel }) => ({
+          pluginId: chrome.pluginId,
+          id: chrome.id,
+          title: chrome.title,
+          chrome,
+          panel,
+        }),
+      ),
+    [entries],
+  );
   if (rows.length === 0) return null;
-  return <PluginNavSidebarItemList {...props} rows={rows} />;
+  return (
+    <PluginNavSidebarItemList
+      rows={rows}
+      splitEnabled={props.splitEnabled ?? false}
+      {...(props.onNavigate ? { onNavigate: props.onNavigate } : {})}
+    />
+  );
 }
 
 function PluginNavSidebarItemList({
@@ -137,29 +137,49 @@ function PluginNavSidebarItemList({
   splitEnabled?: boolean;
 }) {
   const location = useLocation();
+  const navigate = useNavigate();
   const [storedOrder, setStoredOrder] = useAtom(pluginNavPanelOrderAtom);
-  const [hiddenKeys, setHiddenKeys] = useAtom(hiddenPluginNavPanelsAtom);
   const [isOverflowOpen, setIsOverflowOpen] = useState(false);
+  const [disablePendingPluginId, setDisablePendingPluginId] = useState<
+    string | null
+  >(null);
+  const handleDisable = useCallback(
+    async (row: SidebarNavRow) => {
+      setDisablePendingPluginId(row.pluginId);
+      try {
+        await setPluginEnabled(fetch, row.pluginId, false);
+        appToast.success(`${row.title} disabled`);
+        if (getPluginPanelRoutePluginId(location.pathname) === row.pluginId) {
+          onNavigate?.();
+          void navigate(getPluginsRoutePath());
+        }
+      } catch (error) {
+        appToast.error(`Failed to disable ${row.title}`, {
+          description: error instanceof Error ? error.message : String(error),
+        });
+      } finally {
+        await invalidatePluginList({ queryClient: appQueryClient });
+        setDisablePendingPluginId(null);
+      }
+    },
+    [location.pathname, navigate, onNavigate],
+  );
 
-  const { visible, hidden, normalizedOrder } = useMemo(() => {
-    const leadingKeys = rows.some((row) => row.kind === "tools")
-      ? [TOOLS_NAV_ROW_KEY]
-      : [];
-    return arrangePluginNavPanels({
-      panels: rows,
-      storedOrder: seedLeadingNavPanelKeys(storedOrder, leadingKeys),
-      hiddenKeys,
-    });
-  }, [hiddenKeys, rows, storedOrder]);
+  const { ordered, normalizedOrder } = useMemo(
+    () => arrangePluginNavPanels({ panels: rows, storedOrder }),
+    [rows, storedOrder],
+  );
+  const visible = ordered.slice(0, PLUGIN_NAV_VISIBLE_LIMIT);
+  const overflow = ordered.slice(PLUGIN_NAV_VISIBLE_LIMIT);
 
   useEffect(() => {
     if (!havePluginNavPanelOrdersDiverged(storedOrder, normalizedOrder)) return;
     setStoredOrder(normalizedOrder);
   }, [normalizedOrder, setStoredOrder, storedOrder]);
 
-  const visibleKeys = useMemo(
-    () => visible.map(getPluginNavPanelKey),
-    [visible],
+  const orderedKeys = useMemo(
+    () => ordered.map(getPluginNavPanelKey),
+    [ordered],
   );
 
   const handleDragEnd = useCallback(
@@ -175,88 +195,103 @@ function PluginNavSidebarItemList({
         activeKey: event.active.id,
         overKey: event.over.id,
         order: normalizedOrder,
-        visibleKeys,
+        visibleKeys: orderedKeys,
       });
       if (nextOrder) setStoredOrder(nextOrder);
     },
-    [normalizedOrder, setStoredOrder, visibleKeys],
+    [normalizedOrder, orderedKeys, setStoredOrder],
   );
   const { dndContextProps, onClickCapture } = useSidebarReorderDnd({
     onDragEnd: handleDragEnd,
   });
 
-  const handleHide = useCallback(
+  const handleMoveToTop = useCallback(
     (key: string) => {
-      setHiddenKeys((current) => hidePluginNavPanel(current, key));
+      setStoredOrder(movePluginNavPanelToTop(normalizedOrder, key));
     },
-    [setHiddenKeys],
+    [normalizedOrder, setStoredOrder],
   );
-  const handleShow = useCallback(
+  const handleMoveToOverflow = useCallback(
     (key: string) => {
-      setHiddenKeys((current) => showPluginNavPanel(current, key));
+      const overflowTarget = orderedKeys[PLUGIN_NAV_VISIBLE_LIMIT];
+      if (!overflowTarget) return;
+      const nextOrder = reorderPluginNavPanels({
+        activeKey: key,
+        overKey: overflowTarget,
+        order: normalizedOrder,
+        visibleKeys: orderedKeys,
+      });
+      if (nextOrder) setStoredOrder(nextOrder);
     },
-    [setHiddenKeys],
+    [normalizedOrder, orderedKeys, setStoredOrder],
   );
 
-  const reorderDisabled = visible.length < 2;
+  const reorderDisabled = ordered.length < 2;
   const rowProps = {
     onNavigate,
     pathname: location.pathname,
     splitEnabled,
+    orderedKeys,
+    onMoveToTop: handleMoveToTop,
+    onMoveToOverflow: handleMoveToOverflow,
+    disablePending: disablePendingPluginId !== null,
+    onDisable: (row: SidebarNavRow) => void handleDisable(row),
   };
 
   return (
-    <div
-      className="-mt-1.5 shrink-0 space-y-0.5 px-2 pb-2 group-data-[collapsible=icon]:hidden"
-      data-testid="plugin-nav-sidebar-items"
-      onClickCapture={onClickCapture}
-    >
-      <DndContext {...dndContextProps}>
-        <SortableContext
-          items={visibleKeys}
-          strategy={verticalListSortingStrategy}
-        >
-          {visible.map((row) => (
-            <SortableSidebarNavRow
-              key={getPluginNavPanelKey(row)}
-              row={row}
-              reorderDisabled={reorderDisabled}
-              onHide={handleHide}
-              {...rowProps}
-            />
-          ))}
-        </SortableContext>
-      </DndContext>
-      {hidden.length > 0 ? (
-        <>
-          <PluginNavSidebarOverflowToggle
-            count={hidden.length}
-            isOpen={isOverflowOpen}
-            onToggle={() => setIsOverflowOpen((open) => !open)}
-          />
-          {isOverflowOpen
-            ? hidden.map((row) => (
-                <SidebarNavRowItem
-                  key={getPluginNavPanelKey(row)}
-                  row={row}
-                  isHidden
-                  onShow={handleShow}
-                  {...rowProps}
+    <>
+      <div
+        aria-hidden="true"
+        data-sidebar-navigation-divider="plugins"
+        className="mx-2 h-px shrink-0 bg-sidebar-border"
+      />
+      <div
+        className="shrink-0 space-y-0.5 px-2 py-2 group-data-[collapsible=icon]:hidden"
+        data-testid="plugin-nav-sidebar-items"
+        onClickCapture={onClickCapture}
+      >
+        <DndContext {...dndContextProps}>
+          <SortableContext
+            items={orderedKeys}
+            strategy={verticalListSortingStrategy}
+          >
+            {visible.map((row) => (
+              <SortableSidebarNavRow
+                key={getPluginNavPanelKey(row)}
+                row={row}
+                reorderDisabled={reorderDisabled}
+                {...rowProps}
+              />
+            ))}
+            {overflow.length > 0 ? (
+              <>
+                <PluginNavSidebarOverflowToggle
+                  isOpen={isOverflowOpen}
+                  onToggle={() => setIsOverflowOpen((open) => !open)}
                 />
-              ))
-            : null}
-        </>
-      ) : null}
-    </div>
+                {isOverflowOpen
+                  ? overflow.map((row) => (
+                      <SortableSidebarNavRow
+                        key={getPluginNavPanelKey(row)}
+                        row={row}
+                        reorderDisabled={reorderDisabled}
+                        {...rowProps}
+                      />
+                    ))
+                  : null}
+              </>
+            ) : null}
+          </SortableContext>
+        </DndContext>
+      </div>
+    </>
   );
 }
 
 function PluginNavSidebarOverflowToggle({
-  count,
   isOpen,
   onToggle,
 }: {
-  count: number;
   isOpen: boolean;
   onToggle: () => void;
 }) {
@@ -281,7 +316,9 @@ function PluginNavSidebarOverflowToggle({
         )}
         aria-hidden="true"
       />
-      <span className="min-w-0 truncate text-left">{`More (${count})`}</span>
+      <span className="min-w-0 truncate text-left">
+        {isOpen ? "Show fewer" : "More plugins"}
+      </span>
     </Button>
   );
 }
@@ -311,9 +348,11 @@ interface SidebarNavRowItemProps {
   pathname: string;
   onNavigate?: () => void;
   splitEnabled: boolean;
-  isHidden?: boolean;
-  onHide?: (key: string) => void;
-  onShow?: (key: string) => void;
+  orderedKeys: readonly string[];
+  onMoveToTop: (key: string) => void;
+  onMoveToOverflow: (key: string) => void;
+  disablePending: boolean;
+  onDisable: (row: SidebarNavRow) => void;
   dragBindings?: SidebarSortableDragBindings;
   rowRef?: (element: HTMLElement | null) => void;
   rowStyle?: CSSProperties;
@@ -324,34 +363,127 @@ function SidebarNavRowItem({
   splitEnabled,
   ...props
 }: SidebarNavRowItemProps) {
-  return row.kind === "tools" ? (
-    <ToolsNavSidebarItem {...props} row={row} />
-  ) : (
+  return (
     <PluginNavSidebarItem {...props} row={row} splitEnabled={splitEnabled} />
   );
 }
 
 type PluginNavRowMenuSurface = "context" | "dropdown";
 
-function PluginNavRowVisibilityMenuItem({
-  isHidden,
+function PluginNavRowMenuItem({
+  children,
+  disabled = false,
+  icon,
   onSelect,
   surface,
 }: {
-  isHidden: boolean;
+  children: ReactNode;
+  disabled?: boolean;
+  icon: "ArrowDown" | "ArrowUp" | "Columns2" | "Info" | "Unavailable";
   onSelect: () => void;
   surface: PluginNavRowMenuSurface;
 }) {
   const content = (
     <>
-      <Icon name={isHidden ? "Eye" : "EyeOff"} aria-hidden="true" />
-      {isHidden ? "Show in sidebar" : "Hide from sidebar"}
+      {icon === "Unavailable" ? (
+        <HugeiconsIcon icon={UnavailableIcon} aria-hidden="true" />
+      ) : (
+        <Icon name={icon} aria-hidden="true" />
+      )}
+      {children}
     </>
   );
   return surface === "context" ? (
-    <ContextMenuItem onSelect={onSelect}>{content}</ContextMenuItem>
+    <ContextMenuItem disabled={disabled} onSelect={onSelect}>
+      {content}
+    </ContextMenuItem>
   ) : (
-    <DropdownMenuItem onSelect={onSelect}>{content}</DropdownMenuItem>
+    <DropdownMenuItem disabled={disabled} onSelect={onSelect}>
+      {content}
+    </DropdownMenuItem>
+  );
+}
+
+function PluginNavRowMenuSeparator({
+  surface,
+}: {
+  surface: PluginNavRowMenuSurface;
+}) {
+  return surface === "context" ? (
+    <ContextMenuSeparator />
+  ) : (
+    <DropdownMenuSeparator />
+  );
+}
+
+function PluginNavRowMenuItems({
+  canMoveToTop,
+  canMoveToOverflow,
+  canOpenInSplit,
+  disablePending,
+  onDisable,
+  onOpenInSplit,
+  onOpenDetails,
+  onMoveToTop,
+  onMoveToOverflow,
+  surface,
+}: {
+  canMoveToTop: boolean;
+  canMoveToOverflow: boolean;
+  canOpenInSplit: boolean;
+  disablePending: boolean;
+  onDisable: () => void;
+  onOpenInSplit: () => void;
+  onOpenDetails: () => void;
+  onMoveToTop: () => void;
+  onMoveToOverflow: () => void;
+  surface: PluginNavRowMenuSurface;
+}) {
+  return (
+    <>
+      {canOpenInSplit ? (
+        <PluginNavRowMenuItem
+          surface={surface}
+          icon="Columns2"
+          onSelect={onOpenInSplit}
+        >
+          Open in split
+        </PluginNavRowMenuItem>
+      ) : null}
+      <PluginNavRowMenuItem
+        surface={surface}
+        icon="Info"
+        onSelect={onOpenDetails}
+      >
+        View details
+      </PluginNavRowMenuItem>
+      <PluginNavRowMenuSeparator surface={surface} />
+      <PluginNavRowMenuItem
+        surface={surface}
+        icon="ArrowUp"
+        disabled={!canMoveToTop}
+        onSelect={onMoveToTop}
+      >
+        Move to top
+      </PluginNavRowMenuItem>
+      <PluginNavRowMenuItem
+        surface={surface}
+        icon="ArrowDown"
+        disabled={!canMoveToOverflow}
+        onSelect={onMoveToOverflow}
+      >
+        Move to overflow
+      </PluginNavRowMenuItem>
+      <PluginNavRowMenuSeparator surface={surface} />
+      <PluginNavRowMenuItem
+        surface={surface}
+        icon="Unavailable"
+        disabled={disablePending}
+        onSelect={onDisable}
+      >
+        Disable
+      </PluginNavRowMenuItem>
+    </>
   );
 }
 
@@ -364,27 +496,65 @@ function ToolsNavSidebarItemIcon() {
   );
 }
 
-function ToolsNavSidebarItem({
-  row,
-  pathname: _pathname,
+export function ExtensionsNavSidebarItem({
+  routePath,
   onNavigate,
-  ...props
-}: Omit<SidebarNavRowItemProps, "row" | "splitEnabled"> & {
-  row: Extract<SidebarNavRow, { kind: "tools" }>;
+}: {
+  routePath: string;
+  onNavigate?: () => void;
 }) {
   const navigate = useNavigate();
   return (
-    <SidebarNavRowChrome
-      {...props}
-      rowKey={getPluginNavPanelKey(row)}
-      title={row.title}
-      icon={<ToolsNavSidebarItemIcon />}
-      isActive={false}
-      onSelect={() => {
+    <Button
+      type="button"
+      size="sm"
+      variant="ghost"
+      className={cn(PROJECT_LIST_ACTION_BUTTON_CLASS, "w-full")}
+      onClick={() => {
         onNavigate?.();
-        void navigate(row.routePath);
+        void navigate(routePath);
       }}
-    />
+    >
+      <ToolsNavSidebarItemIcon />
+      <span className="min-w-0 truncate text-left">Extensions</span>
+    </Button>
+  );
+}
+
+export function AutomationsNavSidebarItem({
+  chrome,
+  onNavigate,
+}: {
+  chrome: PluginNavPanelChrome;
+  onNavigate?: () => void;
+}) {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const path = getPluginPanelRoutePath({
+    pluginId: chrome.pluginId,
+    path: chrome.path,
+  });
+  const isActive =
+    location.pathname === path || location.pathname.startsWith(`${path}/`);
+  return (
+    <Button
+      type="button"
+      size="sm"
+      variant="ghost"
+      className={cn(
+        PROJECT_LIST_ACTION_BUTTON_CLASS,
+        "w-full",
+        isActive && "bg-sidebar-accent text-sidebar-foreground",
+      )}
+      aria-current={isActive ? "page" : undefined}
+      onClick={() => {
+        onNavigate?.();
+        void navigate(path);
+      }}
+    >
+      <PluginIcon pluginId={chrome.pluginId} icon={chrome.icon} />
+      <span className="min-w-0 truncate text-left">{chrome.title}</span>
+    </Button>
   );
 }
 
@@ -392,10 +562,11 @@ function PluginNavSidebarItem({
   row,
   pathname,
   onNavigate,
+  onDisable,
   splitEnabled,
   ...props
 }: Omit<SidebarNavRowItemProps, "row"> & {
-  row: Extract<SidebarNavRow, { kind: "plugin" }>;
+  row: SidebarNavRow;
 }) {
   const { chrome, panel } = row;
   const navigate = useNavigate();
@@ -440,6 +611,12 @@ function PluginNavSidebarItem({
       splitMiniMap={splitIndicator.miniMap}
       accessory={sidebarAccessory}
       onPointerDown={onPointerDown}
+      onOpenInSplit={splitEnabled ? openInSplit : undefined}
+      onOpenDetails={() => {
+        onNavigate?.();
+        void navigate(getPluginDetailRoutePath({ pluginId: chrome.pluginId }));
+      }}
+      onDisable={() => onDisable(row)}
       onSelect={(event) => {
         onNavigate?.();
         if (event.metaKey || event.ctrlKey) {
@@ -459,11 +636,15 @@ interface SidebarNavRowChromeProps {
   isActive: boolean;
   onSelect: (event: ReactMouseEvent<HTMLButtonElement>) => void;
   onPointerDown?: PointerEventHandler<HTMLElement>;
+  onOpenInSplit?: () => void;
+  onOpenDetails: () => void;
+  onDisable: () => void;
+  disablePending: boolean;
   splitMiniMap?: MiniMapSlot[] | null;
   accessory?: ReactNode;
-  isHidden?: boolean;
-  onHide?: (key: string) => void;
-  onShow?: (key: string) => void;
+  orderedKeys: readonly string[];
+  onMoveToTop: (key: string) => void;
+  onMoveToOverflow: (key: string) => void;
   dragBindings?: SidebarSortableDragBindings;
   rowRef?: (element: HTMLElement | null) => void;
   rowStyle?: CSSProperties;
@@ -476,11 +657,15 @@ function SidebarNavRowChrome({
   isActive,
   onSelect,
   onPointerDown,
+  onOpenInSplit,
+  onOpenDetails,
+  onDisable,
+  disablePending,
   splitMiniMap = null,
   accessory,
-  isHidden = false,
-  onHide,
-  onShow,
+  orderedKeys,
+  onMoveToTop,
+  onMoveToOverflow,
   dragBindings,
   rowRef,
   rowStyle,
@@ -488,11 +673,23 @@ function SidebarNavRowChrome({
   const [isActionsOpen, setIsActionsOpen] = useState(false);
   const { onKeyDown: _keyboardDragActivator, ...pointerDragListeners } =
     dragBindings?.listeners ?? {};
-  const visibilityItem = (surface: PluginNavRowMenuSurface): ReactNode => (
-    <PluginNavRowVisibilityMenuItem
+  const rowIndex = orderedKeys.indexOf(rowKey);
+  const menuItems = (surface: PluginNavRowMenuSurface): ReactNode => (
+    <PluginNavRowMenuItems
       surface={surface}
-      isHidden={isHidden}
-      onSelect={() => (isHidden ? onShow?.(rowKey) : onHide?.(rowKey))}
+      canMoveToTop={rowIndex > 0}
+      canMoveToOverflow={
+        orderedKeys.length > PLUGIN_NAV_VISIBLE_LIMIT &&
+        rowIndex >= 0 &&
+        rowIndex < PLUGIN_NAV_VISIBLE_LIMIT
+      }
+      canOpenInSplit={onOpenInSplit !== undefined}
+      disablePending={disablePending}
+      onDisable={onDisable}
+      onOpenInSplit={() => onOpenInSplit?.()}
+      onOpenDetails={onOpenDetails}
+      onMoveToTop={() => onMoveToTop(rowKey)}
+      onMoveToOverflow={() => onMoveToOverflow(rowKey)}
     />
   );
 
@@ -513,7 +710,6 @@ function SidebarNavRowChrome({
               "w-full pr-7",
               accessory && "pr-18",
               isActive && "bg-sidebar-accent text-sidebar-foreground",
-              isHidden && "text-subtle-foreground",
             )}
             aria-current={isActive ? "page" : undefined}
             ref={dragBindings?.setActivatorNodeRef}
@@ -577,14 +773,14 @@ function SidebarNavRowChrome({
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
-                {visibilityItem("dropdown")}
+                {menuItems("dropdown")}
               </DropdownMenuContent>
             </DropdownMenu>
           </div>
         </div>
       </ContextMenuTrigger>
       <ContextMenuContent aria-label={`${title} panel options`}>
-        {visibilityItem("context")}
+        {menuItems("context")}
       </ContextMenuContent>
     </ContextMenu>
   );

--- a/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
@@ -18,6 +18,7 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { Button } from "@bb/shared-ui/button";
+import { CHROME_SECTION_LABEL_CLASS } from "@bb/shared-ui/chrome-style-tokens";
 import { Icon } from "@bb/shared-ui/icon";
 import {
   ContextMenu,
@@ -250,6 +251,7 @@ function PluginNavSidebarItemList({
         data-testid="plugin-nav-sidebar-items"
         onClickCapture={onClickCapture}
       >
+        <div className={cn(CHROME_SECTION_LABEL_CLASS, "px-2")}>Plugins</div>
         <DndContext {...dndContextProps}>
           <SortableContext
             items={orderedKeys}

--- a/apps/app/src/components/plugin/plugin-slot-mounts.test.tsx
+++ b/apps/app/src/components/plugin/plugin-slot-mounts.test.tsx
@@ -1336,7 +1336,7 @@ describe("PluginNavSidebarItems + PluginPanelView", () => {
     );
   }
 
-  it("keeps the Automations row in the nav list", () => {
+  it("keeps Automations out of the traditional plugin rows", () => {
     registerAutomationsPanel();
 
     render(
@@ -1345,7 +1345,9 @@ describe("PluginNavSidebarItems + PluginPanelView", () => {
       </MemoryRouter>,
     );
 
-    expect(screen.getByRole("button", { name: "Automations" })).toBeDefined();
+    expect(
+      screen.queryByRole("button", { name: "Automations" }),
+    ).toBeNull();
   });
 
   it("renders a sidebar entry that routes to the plugin panel", () => {

--- a/apps/app/src/components/plugin/pluginNavSidebarAtoms.test.ts
+++ b/apps/app/src/components/plugin/pluginNavSidebarAtoms.test.ts
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+
+import { createStore } from "jotai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+afterEach(() => {
+  window.localStorage.clear();
+  vi.resetModules();
+});
+
+describe("pluginNavPanelOrderAtom migration", () => {
+  it("converts legacy hidden keys into positional overflow order", async () => {
+    window.localStorage.setItem(
+      "bb.sidebar.pluginPanelOrder",
+      JSON.stringify(["docs/main", "tasks/main", "github/main"]),
+    );
+    window.localStorage.setItem(
+      "bb.sidebar.hiddenPluginPanels",
+      JSON.stringify(["tasks/main", "docs/main"]),
+    );
+
+    const { pluginNavPanelOrderAtom } = await import("./pluginNavSidebarAtoms");
+    const store = createStore();
+
+    expect(store.get(pluginNavPanelOrderAtom)).toEqual([
+      "github/main",
+      "docs/main",
+      "tasks/main",
+    ]);
+    expect(
+      window.localStorage.getItem("bb.sidebar.hiddenPluginPanels"),
+    ).toBeNull();
+  });
+
+  it("preserves a hidden Automations key for customize migration", async () => {
+    window.localStorage.setItem(
+      "bb.sidebar.pluginPanelOrder",
+      JSON.stringify(["docs/main"]),
+    );
+    window.localStorage.setItem(
+      "bb.sidebar.hiddenPluginPanels",
+      JSON.stringify(["docs/main", "automations/main"]),
+    );
+
+    const { pluginNavPanelOrderAtom } = await import("./pluginNavSidebarAtoms");
+    const store = createStore();
+
+    expect(store.get(pluginNavPanelOrderAtom)).toEqual(["docs/main"]);
+    expect(
+      window.localStorage.getItem("bb.sidebar.hiddenPluginPanels"),
+    ).toBe(JSON.stringify(["automations/main"]));
+  });
+});

--- a/apps/app/src/components/plugin/pluginNavSidebarAtoms.ts
+++ b/apps/app/src/components/plugin/pluginNavSidebarAtoms.ts
@@ -1,19 +1,86 @@
 import { atomWithStorage } from "jotai/utils";
-import { createJsonLocalStorage } from "@/lib/browser-storage";
+import {
+  createJsonLocalStorage,
+  type SyncStorage,
+} from "@/lib/browser-storage";
+import { AUTOMATIONS_PLUGIN_ID } from "@/lib/route-paths";
+import { migrateLegacyHiddenPluginNavPanelOrder } from "./pluginNavSidebarOrder";
 
 const PLUGIN_NAV_PANEL_ORDER_STORAGE_KEY = "bb.sidebar.pluginPanelOrder";
 const HIDDEN_PLUGIN_NAV_PANELS_STORAGE_KEY = "bb.sidebar.hiddenPluginPanels";
 
+function normalizeStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return [
+    ...new Set(
+      value.filter((item): item is string => typeof item === "string"),
+    ),
+  ];
+}
+
+function isAutomationsPanelKey(key: string): boolean {
+  return key.startsWith(`${AUTOMATIONS_PLUGIN_ID}/`);
+}
+
+function preserveLegacyAutomationsHiddenKeys(
+  storage: SyncStorage<unknown>,
+  hiddenKeys: readonly string[],
+): void {
+  const automationsKeys = hiddenKeys.filter(isAutomationsPanelKey);
+  if (automationsKeys.length === 0) {
+    storage.removeItem(HIDDEN_PLUGIN_NAV_PANELS_STORAGE_KEY);
+  } else {
+    storage.setItem(HIDDEN_PLUGIN_NAV_PANELS_STORAGE_KEY, automationsKeys);
+  }
+}
+
+function createPluginNavPanelOrderStorage(): SyncStorage<string[]> {
+  const storage = createJsonLocalStorage<unknown>();
+  return {
+    getItem(key, initialValue) {
+      const order = normalizeStringArray(storage.getItem(key, initialValue));
+      const legacyHidden = normalizeStringArray(
+        storage.getItem(HIDDEN_PLUGIN_NAV_PANELS_STORAGE_KEY, []),
+      );
+      const traditionalHidden = legacyHidden.filter(
+        (panelKey) => !isAutomationsPanelKey(panelKey),
+      );
+      if (traditionalHidden.length === 0) return order;
+
+      const migrated = migrateLegacyHiddenPluginNavPanelOrder(
+        order,
+        traditionalHidden,
+      );
+      storage.setItem(key, migrated);
+      preserveLegacyAutomationsHiddenKeys(storage, legacyHidden);
+      return migrated;
+    },
+    setItem(key, value) {
+      storage.setItem(key, normalizeStringArray(value));
+      const legacyHidden = normalizeStringArray(
+        storage.getItem(HIDDEN_PLUGIN_NAV_PANELS_STORAGE_KEY, []),
+      );
+      preserveLegacyAutomationsHiddenKeys(storage, legacyHidden);
+    },
+    removeItem(key) {
+      storage.removeItem(key);
+      const legacyHidden = normalizeStringArray(
+        storage.getItem(HIDDEN_PLUGIN_NAV_PANELS_STORAGE_KEY, []),
+      );
+      preserveLegacyAutomationsHiddenKeys(storage, legacyHidden);
+    },
+    subscribe: (key, callback, initialValue) =>
+      storage.subscribe?.(
+        key,
+        (value) => callback(normalizeStringArray(value)),
+        initialValue,
+      ),
+  };
+}
+
 export const pluginNavPanelOrderAtom = atomWithStorage<string[]>(
   PLUGIN_NAV_PANEL_ORDER_STORAGE_KEY,
   [],
-  createJsonLocalStorage<string[]>(),
-  { getOnInit: true },
-);
-
-export const hiddenPluginNavPanelsAtom = atomWithStorage<string[]>(
-  HIDDEN_PLUGIN_NAV_PANELS_STORAGE_KEY,
-  [],
-  createJsonLocalStorage<string[]>(),
+  createPluginNavPanelOrderStorage(),
   { getOnInit: true },
 );

--- a/apps/app/src/components/plugin/pluginNavSidebarOrder.test.ts
+++ b/apps/app/src/components/plugin/pluginNavSidebarOrder.test.ts
@@ -2,8 +2,9 @@ import { describe, expect, it } from "vitest";
 import {
   arrangePluginNavPanels,
   getPluginNavPanelKey,
+  migrateLegacyHiddenPluginNavPanelOrder,
+  movePluginNavPanelToTop,
   reorderPluginNavPanels,
-  seedLeadingNavPanelKeys,
 } from "./pluginNavSidebarOrder";
 
 function panel(pluginId: string, id: string) {
@@ -16,13 +17,12 @@ const tasks = panel("tasks", "board");
 
 describe("arrangePluginNavPanels", () => {
   it("falls back to registry order before the user has reordered anything", () => {
-    const { visible, normalizedOrder } = arrangePluginNavPanels({
+    const { ordered, normalizedOrder } = arrangePluginNavPanels({
       panels: [github, docs, tasks],
       storedOrder: [],
-      hiddenKeys: [],
     });
 
-    expect(visible.map(getPluginNavPanelKey)).toEqual([
+    expect(ordered.map(getPluginNavPanelKey)).toEqual([
       "github/pulls",
       "docs/vault",
       "tasks/board",
@@ -34,28 +34,26 @@ describe("arrangePluginNavPanels", () => {
     ]);
   });
 
-  it("appends newly installed panels last instead of at the top of a customized list", () => {
-    const { visible } = arrangePluginNavPanels({
+  it("appends newly installed panels last", () => {
+    const { ordered } = arrangePluginNavPanels({
       panels: [github, docs, tasks],
       storedOrder: ["tasks/board", "github/pulls"],
-      hiddenKeys: [],
     });
 
-    expect(visible.map(getPluginNavPanelKey)).toEqual([
+    expect(ordered.map(getPluginNavPanelKey)).toEqual([
       "tasks/board",
       "github/pulls",
       "docs/vault",
     ]);
   });
 
-  it("renders no row for an unregistered key but keeps its slot in the order", () => {
-    const { visible, normalizedOrder } = arrangePluginNavPanels({
+  it("keeps unregistered keys in the normalized order", () => {
+    const { ordered, normalizedOrder } = arrangePluginNavPanels({
       panels: [github, docs],
       storedOrder: ["strudel/repl", "docs/vault", "github/pulls"],
-      hiddenKeys: [],
     });
 
-    expect(visible.map(getPluginNavPanelKey)).toEqual([
+    expect(ordered.map(getPluginNavPanelKey)).toEqual([
       "docs/vault",
       "github/pulls",
     ]);
@@ -65,70 +63,65 @@ describe("arrangePluginNavPanels", () => {
       "github/pulls",
     ]);
   });
+});
 
-  it("returns a late-registering panel to its stored slot", () => {
-    const { visible } = arrangePluginNavPanels({
-      panels: [github, docs, tasks],
-      storedOrder: ["tasks/board", "docs/vault", "github/pulls"],
-      hiddenKeys: [],
-    });
-
-    expect(visible.map(getPluginNavPanelKey)).toEqual([
-      "tasks/board",
-      "docs/vault",
-      "github/pulls",
-    ]);
+describe("legacy hidden-panel migration", () => {
+  it("moves hidden keys behind visible keys while preserving both orders", () => {
+    expect(
+      migrateLegacyHiddenPluginNavPanelOrder(
+        ["tasks/board", "docs/vault", "github/pulls", "docs/vault"],
+        ["tasks/board", "docs/vault"],
+      ),
+    ).toEqual(["github/pulls", "tasks/board", "docs/vault"]);
   });
 
-  it("splits hidden panels out while both lists keep the user's order", () => {
-    const { visible, hidden } = arrangePluginNavPanels({
-      panels: [github, docs, tasks],
-      storedOrder: ["tasks/board", "docs/vault", "github/pulls"],
-      hiddenKeys: ["docs/vault", "tasks/board"],
-    });
-
-    expect(visible.map(getPluginNavPanelKey)).toEqual(["github/pulls"]);
-    expect(hidden.map(getPluginNavPanelKey)).toEqual([
-      "tasks/board",
-      "docs/vault",
-    ]);
+  it("retains a hidden key missing from the stored order", () => {
+    expect(
+      migrateLegacyHiddenPluginNavPanelOrder(
+        ["github/pulls"],
+        ["docs/vault"],
+      ),
+    ).toEqual(["github/pulls", "docs/vault"]);
   });
 
-  it("ignores duplicate stored keys so a corrupted list can't render a panel twice", () => {
-    const { visible } = arrangePluginNavPanels({
-      panels: [github, docs],
-      storedOrder: ["github/pulls", "github/pulls", "docs/vault"],
-      hiddenKeys: [],
-    });
-
-    expect(visible.map(getPluginNavPanelKey)).toEqual([
-      "github/pulls",
-      "docs/vault",
-    ]);
+  it("moves a panel to the top without duplicating it", () => {
+    expect(
+      movePluginNavPanelToTop(
+        ["github/pulls", "docs/vault", "tasks/board"],
+        "tasks/board",
+      ),
+    ).toEqual(["tasks/board", "github/pulls", "docs/vault"]);
   });
 });
 
 describe("reorderPluginNavPanels", () => {
-  it("moves a visible row to the target slot", () => {
-    expect(
-      reorderPluginNavPanels({
-        activeKey: "tasks/board",
-        overKey: "github/pulls",
-        order: ["github/pulls", "docs/vault", "tasks/board"],
-        visibleKeys: ["github/pulls", "docs/vault", "tasks/board"],
-      }),
-    ).toEqual(["tasks/board", "github/pulls", "docs/vault"]);
-  });
+  it("moves a row across the five-row overflow boundary", () => {
+    const order = [
+      "one/main",
+      "two/main",
+      "three/main",
+      "four/main",
+      "five/main",
+      "six/main",
+      "seven/main",
+    ];
 
-  it("keeps hidden panels pinned to their index in the stored order", () => {
     expect(
       reorderPluginNavPanels({
-        activeKey: "tasks/board",
-        overKey: "github/pulls",
-        order: ["github/pulls", "docs/vault", "tasks/board"],
-        visibleKeys: ["github/pulls", "tasks/board"],
+        activeKey: "one/main",
+        overKey: "six/main",
+        order,
+        visibleKeys: order,
       }),
-    ).toEqual(["tasks/board", "docs/vault", "github/pulls"]);
+    ).toEqual([
+      "two/main",
+      "three/main",
+      "four/main",
+      "five/main",
+      "six/main",
+      "one/main",
+      "seven/main",
+    ]);
   });
 
   it("returns null when the drag lands where it started", () => {
@@ -140,40 +133,5 @@ describe("reorderPluginNavPanels", () => {
         visibleKeys: ["github/pulls", "docs/vault"],
       }),
     ).toBeNull();
-  });
-
-  it("returns null when the drop target is not a visible row", () => {
-    expect(
-      reorderPluginNavPanels({
-        activeKey: "github/pulls",
-        overKey: "docs/vault",
-        order: ["github/pulls", "docs/vault"],
-        visibleKeys: ["github/pulls"],
-      }),
-    ).toBeNull();
-  });
-});
-
-describe("seedLeadingNavPanelKeys", () => {
-  it("leaves an untouched order empty so registry order still wins", () => {
-    expect(seedLeadingNavPanelKeys([], ["__builtin__/tools"])).toEqual([]);
-  });
-
-  it("prepends a built-in key that a customized order predates", () => {
-    expect(
-      seedLeadingNavPanelKeys(
-        ["github/pulls", "docs/vault"],
-        ["__builtin__/tools"],
-      ),
-    ).toEqual(["__builtin__/tools", "github/pulls", "docs/vault"]);
-  });
-
-  it("keeps the user's slot for a built-in key they already moved", () => {
-    expect(
-      seedLeadingNavPanelKeys(
-        ["github/pulls", "__builtin__/tools"],
-        ["__builtin__/tools"],
-      ),
-    ).toEqual(["github/pulls", "__builtin__/tools"]);
   });
 });

--- a/apps/app/src/components/plugin/pluginNavSidebarOrder.test.ts
+++ b/apps/app/src/components/plugin/pluginNavSidebarOrder.test.ts
@@ -95,7 +95,7 @@ describe("legacy hidden-panel migration", () => {
 });
 
 describe("reorderPluginNavPanels", () => {
-  it("moves a row across the five-row overflow boundary", () => {
+  it("moves a row across an overflow boundary", () => {
     const order = [
       "one/main",
       "two/main",

--- a/apps/app/src/components/plugin/pluginNavSidebarOrder.ts
+++ b/apps/app/src/components/plugin/pluginNavSidebarOrder.ts
@@ -10,19 +10,16 @@ export function getPluginNavPanelKey(panel: PluginNavPanelIdentity): string {
 interface ArrangePluginNavPanelsArgs<TPanel extends PluginNavPanelIdentity> {
   panels: readonly TPanel[];
   storedOrder: readonly string[];
-  hiddenKeys: readonly string[];
 }
 
 interface ArrangedPluginNavPanels<TPanel extends PluginNavPanelIdentity> {
-  visible: TPanel[];
-  hidden: TPanel[];
+  ordered: TPanel[];
   normalizedOrder: string[];
 }
 
 export function arrangePluginNavPanels<TPanel extends PluginNavPanelIdentity>({
   panels,
   storedOrder,
-  hiddenKeys,
 }: ArrangePluginNavPanelsArgs<TPanel>): ArrangedPluginNavPanels<TPanel> {
   const byKey = new Map(
     panels.map((panel) => [getPluginNavPanelKey(panel), panel]),
@@ -45,15 +42,7 @@ export function arrangePluginNavPanels<TPanel extends PluginNavPanelIdentity>({
     ordered.push(panel);
   }
 
-  const hiddenSet = new Set(hiddenKeys);
-  const visible: TPanel[] = [];
-  const hidden: TPanel[] = [];
-  for (const panel of ordered) {
-    if (hiddenSet.has(getPluginNavPanelKey(panel))) hidden.push(panel);
-    else visible.push(panel);
-  }
-
-  return { visible, hidden, normalizedOrder };
+  return { ordered, normalizedOrder };
 }
 
 interface ReorderPluginNavPanelsArgs {
@@ -84,28 +73,26 @@ export function reorderPluginNavPanels({
   );
 }
 
-export function seedLeadingNavPanelKeys(
+export function migrateLegacyHiddenPluginNavPanelOrder(
   order: readonly string[],
-  leadingKeys: readonly string[],
+  hiddenKeys: readonly string[],
 ): string[] {
-  const next = [...order];
-  if (next.length === 0) return next;
-  const missing = leadingKeys.filter((key) => !next.includes(key));
-  return missing.length === 0 ? next : [...missing, ...next];
+  const uniqueOrder = [
+    ...new Set([...order, ...hiddenKeys].filter((key) => key.length > 0)),
+  ];
+  const hidden = new Set(hiddenKeys);
+  return [
+    ...uniqueOrder.filter((key) => !hidden.has(key)),
+    ...uniqueOrder.filter((key) => hidden.has(key)),
+  ];
 }
 
-export function hidePluginNavPanel(
-  hiddenKeys: readonly string[],
+export function movePluginNavPanelToTop(
+  order: readonly string[],
   key: string,
 ): string[] {
-  return hiddenKeys.includes(key) ? [...hiddenKeys] : [...hiddenKeys, key];
-}
-
-export function showPluginNavPanel(
-  hiddenKeys: readonly string[],
-  key: string,
-): string[] {
-  return hiddenKeys.filter((hiddenKey) => hiddenKey !== key);
+  if (order[0] === key) return [...order];
+  return [key, ...order.filter((candidate) => candidate !== key)];
 }
 
 export function havePluginNavPanelOrdersDiverged(

--- a/apps/app/src/components/sidebar/AppSidebar.tsx
+++ b/apps/app/src/components/sidebar/AppSidebar.tsx
@@ -238,7 +238,7 @@ export function AppSidebar({
       <div
         aria-hidden="true"
         data-sidebar-navigation-divider="threads"
-        className="mx-2 h-px shrink-0 bg-sidebar-border"
+        className="mx-2 h-px shrink-0 bg-sidebar-border/40"
       />
       <SidebarContent>
         <PluginThreadList

--- a/apps/app/src/components/sidebar/AppSidebar.tsx
+++ b/apps/app/src/components/sidebar/AppSidebar.tsx
@@ -235,6 +235,11 @@ export function AppSidebar({
         onNewChat={handleNewChat}
         onSearchThreads={closeOnMobile}
       />
+      <div
+        aria-hidden="true"
+        data-sidebar-navigation-divider="threads"
+        className="mx-2 h-px shrink-0 bg-sidebar-border"
+      />
       <SidebarContent>
         <PluginThreadList
           replacement={threadListReplacement}

--- a/apps/app/src/components/sidebar/BuiltInSidebarNavigation.tsx
+++ b/apps/app/src/components/sidebar/BuiltInSidebarNavigation.tsx
@@ -1,11 +1,20 @@
 import type { ComponentProps } from "react";
-import { PluginNavSidebarItems } from "@/components/plugin/PluginNavSidebarItems";
+import {
+  AutomationsNavSidebarItem,
+  ExtensionsNavSidebarItem,
+  getTraditionalPluginNavPanelEntries,
+  PluginNavSidebarItems,
+} from "@/components/plugin/PluginNavSidebarItems";
+import { usePluginNavPanelChrome } from "@/lib/plugin-nav-panel-chrome";
+import { AUTOMATIONS_PLUGIN_ID } from "@/lib/route-paths";
 import { ProjectListActionButtons } from "./ProjectList";
 
 export type BuiltInSidebarNavigationProps = ComponentProps<
   typeof ProjectListActionButtons
 > &
-  ComponentProps<typeof PluginNavSidebarItems>;
+  ComponentProps<typeof PluginNavSidebarItems> & {
+    toolsRoutePath?: string;
+  };
 
 export function BuiltInSidebarNavigation({
   newThreadSplit,
@@ -15,6 +24,14 @@ export function BuiltInSidebarNavigation({
   splitEnabled,
   toolsRoutePath,
 }: BuiltInSidebarNavigationProps) {
+  const pluginNavPanels = usePluginNavPanelChrome();
+  const automationsNavPanel = pluginNavPanels.find(
+    ({ chrome }) => chrome.pluginId === AUTOMATIONS_PLUGIN_ID,
+  );
+  const traditionalPluginNavPanels = getTraditionalPluginNavPanelEntries(
+    pluginNavPanels,
+  );
+
   return (
     <div className="contents" data-testid="built-in-sidebar-navigation">
       <div
@@ -27,11 +44,23 @@ export function BuiltInSidebarNavigation({
           onNewChat={onNewChat}
           onSearchThreads={onSearchThreads}
         />
+        {toolsRoutePath ? (
+          <ExtensionsNavSidebarItem
+            routePath={toolsRoutePath}
+            onNavigate={onNavigate}
+          />
+        ) : null}
+        {automationsNavPanel ? (
+          <AutomationsNavSidebarItem
+            chrome={automationsNavPanel.chrome}
+            onNavigate={onNavigate}
+          />
+        ) : null}
       </div>
       <PluginNavSidebarItems
+        entries={traditionalPluginNavPanels}
         onNavigate={onNavigate}
         splitEnabled={splitEnabled}
-        toolsRoutePath={toolsRoutePath}
       />
     </div>
   );

--- a/apps/app/src/components/sidebar/SidebarNavigationRegion.test.tsx
+++ b/apps/app/src/components/sidebar/SidebarNavigationRegion.test.tsx
@@ -29,6 +29,9 @@ vi.mock("@/components/commands/AppCommandProvider", () => ({
   useIsAppCommandModifierHeld: () => false,
 }));
 vi.mock("@/components/plugin/PluginNavSidebarItems", () => ({
+  AutomationsNavSidebarItem: () => <div>Automations</div>,
+  ExtensionsNavSidebarItem: () => <div>Extensions</div>,
+  getTraditionalPluginNavPanelEntries: () => [],
   PluginNavSidebarItems: () => <div>BB plugin destinations</div>,
 }));
 vi.mock("./usePaneContentSplitDrag", () => ({

--- a/apps/app/src/components/sidebar/SidebarOverview.stories.tsx
+++ b/apps/app/src/components/sidebar/SidebarOverview.stories.tsx
@@ -35,7 +35,10 @@ import {
   sidebarNavigationQueryKey,
 } from "@/hooks/queries/query-keys";
 import { StoryCard, StoryRow } from "../../../.ladle/story-card";
-import { PluginNavSidebarItems } from "@/components/plugin/PluginNavSidebarItems";
+import {
+  ExtensionsNavSidebarItem,
+  PluginNavSidebarItems,
+} from "@/components/plugin/PluginNavSidebarItems";
 import {
   removePluginSlotRegistrations,
   setPluginSlotRegistrations,
@@ -265,9 +268,9 @@ function SidebarFrame({ children }: SidebarFrameProps) {
         <div className="flex h-[680px] w-full max-w-[320px] min-w-0 flex-col overflow-hidden rounded-md border border-sidebar-border bg-sidebar text-sidebar-foreground shadow-sm">
           <div className="shrink-0 px-2 py-2">
             <ProjectListActionButtons onNewChat={noop} />
+            <ExtensionsNavSidebarItem routePath={getSkillsRoutePath()} />
           </div>
-          {}
-          <PluginNavSidebarItems toolsRoutePath={getSkillsRoutePath()} />
+          <PluginNavSidebarItems />
           <div className="min-h-0 flex-1 overflow-y-auto">{children}</div>
           <div className="shrink-0 border-t border-sidebar-border/70 px-2 py-2">
             <button

--- a/apps/app/src/lib/plugin-nav-panel-chrome.ts
+++ b/apps/app/src/lib/plugin-nav-panel-chrome.ts
@@ -17,7 +17,7 @@ const pluginNavPanelChromeSchema = z.object({
 
 export type PluginNavPanelChrome = z.infer<typeof pluginNavPanelChromeSchema>;
 
-interface PluginNavPanelChromeEntry {
+export interface PluginNavPanelChromeEntry {
   chrome: PluginNavPanelChrome;
   panel: PluginNavPanelSlot | null;
 }


### PR DESCRIPTION
## Human comments

## What was wrong

Plugin-provided pages had no clear home in the sidebar. They were mixed into the navigation without a label or region boundary, and legacy hidden-state preferences could prevent installed plugin pages from appearing at all.

## What changed

Installed plugin pages now appear in a predictable, compact **Plugins** region:

- The **Plugins** label appears only when plugin pages exist.
- The first three plugin pages stay visible; additional pages collapse behind a quiet, exact-count **Show 3 more** row.
- Expanding the disclosure reveals every remaining page in place, with **Show less** returning to the compact state.
- The disclosure deliberately uses no icon, border, or resting fill, so it reads as simplification rather than another sidebar control.
- Subtle dividers separate BB controls, Plugins, and Threads without adding heavy visual chrome.

This layer also preserves installed pages when migrating legacy navigation preferences and keeps plugin actions consistent across surfaces: open in split, view details, move between visible and overflow positions, and disable.

No public or wire contracts changed.

## Screenshots

Both sides use the same dev data, route, light theme, and 1440×900 viewport. Captures were taken after all plugin frontend modules had registered.

| Before — exact merge base `5a74c9731` | After — exact PR head `379f5d51c` |
| --- | --- |
| All six plugin pages are mixed directly into the unlabeled sidebar navigation. | Three pages remain visible under **Plugins**, with the other three summarized by **Show 3 more**. |
| ![Before — plugin pages mixed into the unlabeled sidebar navigation](https://github.com/user-attachments/assets/eb98b8fe-1ff8-4488-9672-0182f84389d6) | ![After — three plugin pages with a minimal Show 3 more disclosure](https://github.com/user-attachments/assets/451e7907-402d-446c-8cb8-d0285082f094) |

| Collapsed — three visible pages | Expanded — all six pages |
| --- | --- |
| **Show 3 more** reports the exact number of hidden pages without an icon or extra chrome. | The remaining pages appear below **Show less** without moving the surrounding regions. |
| ![Collapsed — three plugin pages and a minimal Show 3 more disclosure](https://github.com/user-attachments/assets/451e7907-402d-446c-8cb8-d0285082f094) | ![Expanded — all six plugin pages and Show less](https://github.com/user-attachments/assets/1ab06b3f-2228-44e8-981c-4dbd49365f26) |

## How you verified

- Chrome for Testing 151.0.7922.71 at 1440×900 on exact head `379f5d51c`: confirmed three visible pages, **Show 3 more**, six expanded pages, **Show less**, stable surrounding layout, transparent resting background, zero-width border, no disclosure icon, and no rendered alerts.
- Recaptured the exact merge base only after all six plugin frontend pages rendered, keeping the fixture, route, theme, and viewport comparable to the after state.
- Focused regression coverage asserts the three-page threshold, exact count, disclosure accessibility state, icon absence, expansion, and move-to-overflow boundary.
- All 13 required remote checks passed on exact head `379f5d51c`, including app/server/package/integration tests and Ubuntu/macOS package smoke jobs; Node compatibility and iOS simulator jobs were skipped by workflow conditions.
- Rebased onto `main` at `5a74c9731`; `git range-diff` confirmed all eight PR commits retained their original patches.
- Per repository policy, CI-equivalent checks ran through remote CI rather than being rerun locally.

Fixes #

BB-Thread-ID: thr_ccffp4w2p2

> AGENT GENERATED
