### PR TITLE
Pause queued messages after manual thread stops

### DIFF
--- a/apps/server/src/services/threads/queued-messages.ts
+++ b/apps/server/src/services/threads/queued-messages.ts
@@ -6,6 +6,7 @@ import {
   getQueuedThreadMessage,
   getEnvironment,
   getThread,
+  isThreadQueueAutoSendPaused,
   listIdleThreadsWithQueuedMessages,
   releaseQueuedMessageClaim,
   releaseStaleQueuedMessageClaims,
@@ -262,13 +263,15 @@ interface QueuedMessageAutoSendRequestArgs {
 }
 
 function isQueuedMessageAutoSendCandidate(
+  db: DbQueryConnection,
   thread: Thread | null,
 ): thread is Thread {
   return (
     thread !== null &&
     thread.archivedAt === null &&
     thread.deletedAt === null &&
-    thread.status !== "stopping"
+    thread.status !== "stopping" &&
+    !isThreadQueueAutoSendPaused(db, thread.id)
   );
 }
 
@@ -727,7 +730,13 @@ export async function sendQueuedMessage(
     return toThreadQueuedMessage(existing);
   }
   const thread = getThread(deps.db, args.threadId);
-  if (thread && isManualCompactionActive(deps, thread)) {
+  if (
+    thread &&
+    (isManualCompactionActive(deps, thread) ||
+      (args.mode === "auto" &&
+        !args.sendNow &&
+        isThreadQueueAutoSendPaused(deps.db, thread.id)))
+  ) {
     releaseQueuedMessageClaims(deps, queuedMessages);
     return toThreadQueuedMessage(queuedMessages[0]!);
   }
@@ -750,7 +759,12 @@ export async function sendNextQueuedMessageIfPresent(
   deps: LoggedPendingInteractionWorkSessionDeps,
   args: { threadId: string },
 ): Promise<boolean> {
-  if (!isQueuedMessageAutoSendCandidate(getThread(deps.db, args.threadId))) {
+  if (
+    !isQueuedMessageAutoSendCandidate(
+      deps.db,
+      getThread(deps.db, args.threadId),
+    )
+  ) {
     return false;
   }
 
@@ -765,7 +779,7 @@ export async function sendNextQueuedMessageIfPresent(
 
   const thread = getThread(deps.db, args.threadId);
   if (
-    !isQueuedMessageAutoSendCandidate(thread) ||
+    !isQueuedMessageAutoSendCandidate(deps.db, thread) ||
     isManualCompactionActive(deps, thread)
   ) {
     releaseQueuedMessageClaims(deps, nextQueuedMessages);

--- a/apps/server/test/public/public-thread-stop-runtime.test.ts
+++ b/apps/server/test/public/public-thread-stop-runtime.test.ts
@@ -1,8 +1,9 @@
-import { getThread, listEvents } from "@bb/db";
+import { getThread, listEvents, listQueuedThreadMessages } from "@bb/db";
 import { turnScope } from "@bb/domain";
 import { describe, expect, it } from "vitest";
 import {
   listQueuedCommands,
+  listQueuedThreadCommands,
   reportQueuedCommandError,
   reportQueuedCommandSuccess,
   waitForQueuedCommand,
@@ -17,6 +18,10 @@ import {
   seedThreadFixture,
 } from "../helpers/seed.js";
 import { withTestHarness } from "../helpers/test-app.js";
+import {
+  runQueuedMessageAutoSendSweep,
+  sendQueuedMessage,
+} from "../../src/services/threads/queued-messages.js";
 import { stopThreadForCurrentState } from "../../src/services/threads/thread-lifecycle.js";
 
 describe("thread runtime stop", () => {
@@ -136,6 +141,78 @@ describe("thread runtime stop", () => {
         listEvents(harness.db, { threadId: thread.id }).filter(
           (event) => event.type === "system/thread/interrupted",
         ),
+      ).toHaveLength(1);
+    });
+  });
+
+  it("keeps queued messages paused after a manual stop until explicitly sent", async () => {
+    await withTestHarness(async (harness) => {
+      const { thread } = seedThreadFixture(harness, {
+        thread: { status: "active", visibility: "hidden" },
+      });
+      const queueResponse = await harness.app.request(
+        `/api/v1/threads/${thread.id}/send`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            input: [{ type: "text", text: "Wait in the queue" }],
+            mode: "queue-if-active",
+            model: "gpt-5",
+            permissionMode: "full",
+            reasoningLevel: "medium",
+            serviceTier: "default",
+          }),
+        },
+      );
+      expect(queueResponse.status).toBe(200);
+      expect(listQueuedThreadMessages(harness.db, thread.id)).toHaveLength(1);
+
+      const stopResponsePromise = harness.app.request(
+        `/api/v1/threads/${thread.id}/stop`,
+        { method: "POST" },
+      );
+      const stop = await waitForQueuedCommand(
+        harness,
+        ({ command }) =>
+          command.type === "thread.stop" && command.threadId === thread.id,
+      );
+      await reportQueuedCommandSuccess(harness, stop, {
+        providerCheckpointId: null,
+      });
+      expect((await stopResponsePromise).status).toBe(200);
+
+      const queuedMessage = listQueuedThreadMessages(harness.db, thread.id)[0]!;
+      await sendQueuedMessage(harness.deps, {
+        mode: "auto",
+        queuedMessageId: queuedMessage.id,
+        sendNow: false,
+        threadId: thread.id,
+      });
+      await runQueuedMessageAutoSendSweep(harness.deps);
+
+      expect(getThread(harness.db, thread.id)?.status).toBe("idle");
+      expect(listQueuedThreadMessages(harness.db, thread.id)).toHaveLength(1);
+      expect(
+        listQueuedThreadCommands(harness, "thread.start", thread.id),
+      ).toEqual([]);
+      expect(
+        listQueuedThreadCommands(harness, "turn.submit", thread.id),
+      ).toEqual([]);
+
+      const sendResponse = await harness.app.request(
+        `/api/v1/threads/${thread.id}/queued-messages/${queuedMessage.id}/send`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ mode: "auto" }),
+        },
+      );
+      expect(sendResponse.status).toBe(200);
+      expect(listQueuedThreadMessages(harness.db, thread.id)).toEqual([]);
+      expect(getThread(harness.db, thread.id)?.status).toBe("active");
+      expect(
+        listQueuedThreadCommands(harness, "thread.start", thread.id),
       ).toHaveLength(1);
     });
   });

--- a/packages/db/src/data/index.ts
+++ b/packages/db/src/data/index.ts
@@ -382,6 +382,7 @@ export {
   getQueuedThreadMessage,
   hasQueuedRetryOfTurnRequest,
   hasQueuedThreadMessages,
+  isThreadQueueAutoSendPaused,
   listDueScheduledQueuedThreadMessages,
   listIdleThreadsWithQueuedMessages,
   listQueuedThreadMessageCountsByThreadIds,

--- a/packages/db/src/data/queued-thread-messages.ts
+++ b/packages/db/src/data/queued-thread-messages.ts
@@ -11,10 +11,12 @@ import {
   lt,
   lte,
   min,
+  notExists,
   notInArray,
   or,
   sql,
 } from "drizzle-orm";
+import { alias } from "drizzle-orm/sqlite-core";
 import { QUEUED_MESSAGE_PLUGIN_WAIT_HOLDER_PREFIX } from "@bb/domain";
 import type {
   PermissionMode,
@@ -31,7 +33,12 @@ import type {
   DbTransaction,
 } from "../connection.js";
 import type { DbNotifier } from "../notifier.js";
-import { environments, queuedThreadMessages, threads } from "../schema.js";
+import {
+  environments,
+  events,
+  queuedThreadMessages,
+  threads,
+} from "../schema.js";
 import { createQueuedThreadMessageClaimToken, createQueuedThreadMessageId } from "../ids.js";
 import {
   createOrderKeyAfter,
@@ -652,6 +659,58 @@ export function hasQueuedThreadMessages(
   );
 }
 
+function manuallyStoppedQueuePauseQuery(
+  db: DbQueryConnection,
+  threadId: string | typeof threads.id,
+) {
+  const interruption = alias(events, "queue_pause_interruption");
+  const laterInterruption = alias(events, "queue_pause_later_interruption");
+  const laterRootTurnStart = alias(events, "queue_pause_later_turn_start");
+  return db
+    .select({ sequence: interruption.sequence })
+    .from(interruption)
+    .where(
+      and(
+        sql`${interruption.threadId} = ${threadId}`,
+        eq(interruption.type, "system/thread/interrupted"),
+        sql`json_extract(${interruption.data}, '$.reason') = 'manual-stop'`,
+        notExists(
+          db
+            .select({ sequence: laterInterruption.sequence })
+            .from(laterInterruption)
+            .where(
+              and(
+                eq(laterInterruption.threadId, interruption.threadId),
+                eq(laterInterruption.type, "system/thread/interrupted"),
+                sql`${laterInterruption.sequence} > ${interruption.sequence}`,
+              ),
+            ),
+        ),
+        notExists(
+          db
+            .select({ sequence: laterRootTurnStart.sequence })
+            .from(laterRootTurnStart)
+            .where(
+              and(
+                eq(laterRootTurnStart.threadId, interruption.threadId),
+                eq(laterRootTurnStart.type, "turn/started"),
+                isNull(laterRootTurnStart.parentToolCallId),
+                sql`${laterRootTurnStart.sequence} > ${interruption.sequence}`,
+              ),
+            ),
+        ),
+      ),
+    )
+    .limit(1);
+}
+
+export function isThreadQueueAutoSendPaused(
+  db: DbQueryConnection,
+  threadId: string,
+): boolean {
+  return manuallyStoppedQueuePauseQuery(db, threadId).get() !== undefined;
+}
+
 /**
  * Threads a drain could move right now.
  *
@@ -676,6 +735,7 @@ export function listIdleThreadsWithQueuedMessages(
         inArray(threads.status, ["idle", "pending"]),
         isNull(threads.archivedAt),
         isNull(threads.deletedAt),
+        notExists(manuallyStoppedQueuePauseQuery(db, threads.id)),
         // A gone environment (destroying/destroyed) is never reprovisioned, so
         // its queued rows can never drain. Leave them out of the sweep instead
         // of failing the same send every cycle (#1789). A thread with NO


### PR DESCRIPTION
## Human comments

## What was wrong

A manual stop settled the thread back to idle while leaving its queued messages intact. The periodic idle-thread sweep treated that idle state like an ordinary completed turn, claimed the next queued row, and restarted the thread, so the queue continued draining after the user explicitly stopped it.

## What changed

Automatic queue dispatch now recognizes when the current idle period came from a manual stop and leaves queued rows paused until a later root turn starts. The idle sweep excludes paused threads at the query boundary, and direct automatic drain paths apply the same guard. Explicit Send now remains an override. There are no wire changes.

## How you verified

- Added an end-to-end regression covering queue while active, manual stop, direct automatic retry, periodic sweep, and explicit Send now. The test fails before the fix and passes after it.
- pnpm exec turbo run test --filter=@bb/server -- test/public/public-thread-stop-runtime.test.ts
- pnpm exec turbo run test --filter=@bb/server -- test/threads/requested-queue-drain.test.ts test/threads/thread-send-dispatch.test.ts test/threads/dispatch-hooks.test.ts test/public/public-thread-data.test.ts
- pnpm exec turbo run test --filter=@bb/db -- test/data/queued-thread-messages.test.ts test/query-plans.test.ts
- pnpm exec turbo run typecheck --filter=@bb/server --filter=@bb/db
- Confirmed the periodic sweep query uses the existing event indexes.
- Started the dev app and verified the local HTTP endpoint responds successfully; exposed the app through bb Connect for manual QA.

> AGENT GENERATED