### PR TITLE
Add persistent sidebar customize menu

### DIFF
--- a/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
@@ -123,6 +123,7 @@ export function PluginNavSidebarItems(props: {
   return (
     <PluginNavSidebarItemList
       rows={rows}
+      showDivider={props.showDivider}
       splitEnabled={props.splitEnabled ?? false}
       {...(props.onNavigate ? { onNavigate: props.onNavigate } : {})}
     />
@@ -132,10 +133,12 @@ export function PluginNavSidebarItems(props: {
 function PluginNavSidebarItemList({
   onNavigate,
   rows,
+  showDivider = true,
   splitEnabled = false,
 }: {
   onNavigate?: () => void;
   rows: readonly SidebarNavRow[];
+  showDivider?: boolean;
   splitEnabled?: boolean;
 }) {
   const location = useLocation();
@@ -242,13 +245,13 @@ function PluginNavSidebarItemList({
 
   return (
     <>
-      {props.showDivider === false ? null : (
+      {showDivider ? (
         <div
           aria-hidden="true"
           data-sidebar-navigation-divider="plugins"
           className="mx-2 h-px shrink-0 bg-sidebar-border/40"
         />
-      )}
+      ) : null}
       <div
         className="shrink-0 space-y-0.5 px-2 py-2 group-data-[collapsible=icon]:hidden"
         data-testid="plugin-nav-sidebar-items"

--- a/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
@@ -101,6 +101,7 @@ export function getTraditionalPluginNavPanelEntries(
 export function PluginNavSidebarItems(props: {
   entries?: readonly PluginNavPanelChromeEntry[];
   onNavigate?: () => void;
+  showDivider?: boolean;
   splitEnabled?: boolean;
 }) {
   const discoveredEntries = usePluginNavPanelChrome();
@@ -241,11 +242,13 @@ function PluginNavSidebarItemList({
 
   return (
     <>
-      <div
-        aria-hidden="true"
-        data-sidebar-navigation-divider="plugins"
-        className="mx-2 h-px shrink-0 bg-sidebar-border/40"
-      />
+      {props.showDivider === false ? null : (
+        <div
+          aria-hidden="true"
+          data-sidebar-navigation-divider="plugins"
+          className="mx-2 h-px shrink-0 bg-sidebar-border/40"
+        />
+      )}
       <div
         className="shrink-0 space-y-0.5 px-2 py-2 group-data-[collapsible=icon]:hidden"
         data-testid="plugin-nav-sidebar-items"

--- a/apps/app/src/components/sidebar/AppSidebar.tsx
+++ b/apps/app/src/components/sidebar/AppSidebar.tsx
@@ -49,6 +49,7 @@ import {
 } from "@/components/commands/AppCommandProvider";
 import { useRouteState } from "@/hooks/useRouteState";
 import { SidebarNavigationRegion } from "./SidebarNavigationRegion";
+import { SidebarTopRegionCustomizeMenu } from "./SidebarTopRegionCustomizeMenu";
 
 const NEW_THREAD_PANE_CONTENT = { kind: "new-thread" } as const;
 
@@ -206,7 +207,6 @@ export function AppSidebar({
       isCreatingProject={quickCreateProject.isCreating}
     />
   );
-
   const body = (
     <>
       {showTopReserve ? (
@@ -218,15 +218,21 @@ export function AppSidebar({
             usesDesktopChrome && MACOS_WINDOW_DRAG_CLASS,
           )}
         >
-          <SidebarHistoryNavigationControls
-            onNavigate={closeOnMobile}
+          <div
             className={cn(
-              "group-data-[collapsible=icon]:hidden",
+              "flex items-center gap-1 group-data-[collapsible=icon]:hidden",
               usesDesktopChrome && MACOS_CHROME_CONTROL_NO_DRAG_CLASS,
             )}
-          />
+          >
+            <SidebarHistoryNavigationControls onNavigate={closeOnMobile} />
+            <SidebarTopRegionCustomizeMenu />
+          </div>
         </div>
-      ) : null}
+      ) : (
+        <div className="flex h-8 shrink-0 items-center justify-end px-2 group-data-[collapsible=icon]:hidden">
+          <SidebarTopRegionCustomizeMenu />
+        </div>
+      )}
       <SidebarNavigationRegion
         onNavigate={closeOnMobile}
         splitEnabled

--- a/apps/app/src/components/sidebar/BuiltInSidebarNavigation.tsx
+++ b/apps/app/src/components/sidebar/BuiltInSidebarNavigation.tsx
@@ -1,4 +1,5 @@
-import type { ComponentProps } from "react";
+import { Fragment, type ComponentProps, type ReactNode } from "react";
+import { useAtomValue } from "jotai";
 import {
   AutomationsNavSidebarItem,
   ExtensionsNavSidebarItem,
@@ -7,11 +8,23 @@ import {
 } from "@/components/plugin/PluginNavSidebarItems";
 import { usePluginNavPanelChrome } from "@/lib/plugin-nav-panel-chrome";
 import { AUTOMATIONS_PLUGIN_ID } from "@/lib/route-paths";
-import { ProjectListActionButtons } from "./ProjectList";
+import {
+  ProjectListNewThreadAction,
+  ProjectListSearchThreadsAction,
+} from "./ProjectList";
+import {
+  sidebarTopRegionItemPreferencesAtom,
+  type SidebarTopRegionItemId,
+} from "./sidebarTopRegionItemPreferences";
+import {
+  normalizeSidebarRegionOrder,
+  sidebarRegionOrderAtom,
+} from "./sidebarRegionOrderPreferences";
 
 export type BuiltInSidebarNavigationProps = ComponentProps<
-  typeof ProjectListActionButtons
+  typeof ProjectListNewThreadAction
 > &
+  ComponentProps<typeof ProjectListSearchThreadsAction> &
   ComponentProps<typeof PluginNavSidebarItems> & {
     toolsRoutePath?: string;
   };
@@ -24,6 +37,10 @@ export function BuiltInSidebarNavigation({
   splitEnabled,
   toolsRoutePath,
 }: BuiltInSidebarNavigationProps) {
+  const topRegionPreferences = useAtomValue(
+    sidebarTopRegionItemPreferencesAtom,
+  );
+  const regionOrder = useAtomValue(sidebarRegionOrderAtom);
   const pluginNavPanels = usePluginNavPanelChrome();
   const automationsNavPanel = pluginNavPanels.find(
     ({ chrome }) => chrome.pluginId === AUTOMATIONS_PLUGIN_ID,
@@ -31,37 +48,81 @@ export function BuiltInSidebarNavigation({
   const traditionalPluginNavPanels = getTraditionalPluginNavPanelEntries(
     pluginNavPanels,
   );
+  const topRegionItemNodes: Record<SidebarTopRegionItemId, ReactNode | null> = {
+    "new-thread": (
+      <ProjectListNewThreadAction
+        splitEnabled={splitEnabled}
+        newThreadSplit={newThreadSplit}
+        onNewChat={onNewChat}
+      />
+    ),
+    search: (
+      <ProjectListSearchThreadsAction onSearchThreads={onSearchThreads} />
+    ),
+    extensions: toolsRoutePath ? (
+      <ExtensionsNavSidebarItem
+        routePath={toolsRoutePath}
+        onNavigate={onNavigate}
+      />
+    ) : null,
+    automations: automationsNavPanel ? (
+      <AutomationsNavSidebarItem
+        chrome={automationsNavPanel.chrome}
+        onNavigate={onNavigate}
+      />
+    ) : null,
+  };
+  const visibleTopRegionItems = topRegionPreferences.order.flatMap((id) => {
+    const node = topRegionItemNodes[id];
+    return node === null || topRegionPreferences.hiddenIds.includes(id)
+      ? []
+      : [
+          <div key={id} data-sidebar-top-region-item={id}>
+            {node}
+          </div>,
+        ];
+  });
+  const regions = {
+    "bb-controls":
+      visibleTopRegionItems.length === 0 ? null : (
+        <div
+          data-testid="app-sidebar-primary-actions"
+          className="shrink-0 space-y-1 px-2 py-2 group-data-[collapsible=icon]:hidden"
+        >
+          {visibleTopRegionItems}
+        </div>
+      ),
+    plugins:
+      traditionalPluginNavPanels.length === 0 ? null : (
+        <PluginNavSidebarItems
+          entries={traditionalPluginNavPanels}
+          onNavigate={onNavigate}
+          showDivider={false}
+          splitEnabled={splitEnabled}
+        />
+      ),
+  } as const;
+  const visibleRegions = normalizeSidebarRegionOrder(regionOrder).flatMap(
+    (id) =>
+      id === "threads" || regions[id] === null
+        ? []
+        : ([[id, regions[id]]] as const),
+  );
 
   return (
     <div className="contents" data-testid="built-in-sidebar-navigation">
-      <div
-        data-testid="app-sidebar-primary-actions"
-        className="shrink-0 px-2 py-2 group-data-[collapsible=icon]:hidden"
-      >
-        <ProjectListActionButtons
-          splitEnabled={splitEnabled}
-          newThreadSplit={newThreadSplit}
-          onNewChat={onNewChat}
-          onSearchThreads={onSearchThreads}
-        />
-        {toolsRoutePath ? (
-          <ExtensionsNavSidebarItem
-            routePath={toolsRoutePath}
-            onNavigate={onNavigate}
-          />
-        ) : null}
-        {automationsNavPanel ? (
-          <AutomationsNavSidebarItem
-            chrome={automationsNavPanel.chrome}
-            onNavigate={onNavigate}
-          />
-        ) : null}
-      </div>
-      <PluginNavSidebarItems
-        entries={traditionalPluginNavPanels}
-        onNavigate={onNavigate}
-        splitEnabled={splitEnabled}
-      />
+      {visibleRegions.map(([id, region], index) => (
+        <Fragment key={id}>
+          {index > 0 ? (
+            <div
+              aria-hidden="true"
+              data-sidebar-navigation-divider={id}
+              className="mx-2 h-px shrink-0 bg-sidebar-border"
+            />
+          ) : null}
+          {region}
+        </Fragment>
+      ))}
     </div>
   );
 }

--- a/apps/app/src/components/sidebar/BuiltInSidebarNavigation.tsx
+++ b/apps/app/src/components/sidebar/BuiltInSidebarNavigation.tsx
@@ -102,12 +102,14 @@ export function BuiltInSidebarNavigation({
         />
       ),
   } as const;
-  const visibleRegions = normalizeSidebarRegionOrder(regionOrder).flatMap(
-    (id) =>
-      id === "threads" || regions[id] === null
-        ? []
-        : ([[id, regions[id]]] as const),
-  );
+  const visibleRegions: Array<
+    readonly ["bb-controls" | "plugins", ReactNode]
+  > = [];
+  for (const id of normalizeSidebarRegionOrder(regionOrder)) {
+    if (id === "threads") continue;
+    const region = regions[id];
+    if (region !== null) visibleRegions.push([id, region]);
+  }
 
   return (
     <div className="contents" data-testid="built-in-sidebar-navigation">

--- a/apps/app/src/components/sidebar/ProjectList.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.tsx
@@ -157,15 +157,23 @@ interface ProjectListProps {
   isCreatingProject?: boolean;
 }
 
-interface ProjectListActionButtonsProps {
+interface ProjectListNewThreadActionProps {
   splitEnabled?: boolean;
   newThreadSplit?: {
     onPointerDown?: PointerEventHandler<HTMLElement>;
     openInSplit(): void;
   };
   onNewChat?: () => void;
+}
+
+interface ProjectListSearchThreadsActionProps {
   onSearchThreads?: () => void;
 }
+
+interface ProjectListActionButtonsProps
+  extends
+    ProjectListNewThreadActionProps,
+    ProjectListSearchThreadsActionProps {}
 
 interface ProjectListShellProps {
   children: ReactNode;
@@ -211,11 +219,6 @@ export const PROJECT_LIST_ACTION_BUTTON_CLASS = cn(
   SIDEBAR_ROW_INTERACTIVE_STATE_CLASS,
   COARSE_POINTER_ROW_HEIGHT_CLASS,
   "min-w-0 cursor-pointer justify-start overflow-hidden font-normal ring-sidebar-ring focus-visible:ring-2 disabled:cursor-default disabled:opacity-70 max-md:pointer-coarse:[&_svg]:size-5",
-);
-
-const PROJECT_LIST_ACTION_ICON_BUTTON_CLASS = cn(
-  "inline-flex shrink-0 cursor-pointer items-center justify-center rounded-md text-sidebar-foreground/85 outline-none ring-sidebar-ring transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 disabled:cursor-default disabled:opacity-50",
-  COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
 );
 
 const PROJECT_LIST_SECTION_ACTION_BUTTON_CLASS = cn(
@@ -754,79 +757,103 @@ function ProjectListNavigationLoadingRow({
   );
 }
 
-export function ProjectListActionButtons({
+export function ProjectListNewThreadAction({
   splitEnabled = false,
   newThreadSplit,
   onNewChat,
-  onSearchThreads,
-}: ProjectListActionButtonsProps) {
-  const commandRunner = useAppCommandRunner();
+}: ProjectListNewThreadActionProps) {
   const isNewChatDisabled = !onNewChat;
   const newThreadShortcut = useAppCommandShortcut("thread.new");
-  const threadSearchShortcut = useAppCommandShortcut("thread.search");
   const newThreadSplitIndicator = usePaneContentSplitIndicator(
     { kind: "new-thread" },
     splitEnabled,
   );
 
   return (
-    <div className="space-y-1">
-      <div className="flex min-w-0 items-center gap-0.5">
-        <Button
-          type="button"
-          size="sm"
-          variant="ghost"
-          className={cn(PROJECT_LIST_ACTION_BUTTON_CLASS, "flex-1")}
-          onPointerDown={newThreadSplit?.onPointerDown}
-          onClick={(event) => {
-            if (event.metaKey || event.ctrlKey) {
-              newThreadSplit?.openInSplit();
-              return;
-            }
-            onNewChat?.();
-          }}
-          disabled={isNewChatDisabled}
-          aria-label={
-            newThreadShortcut
-              ? `New thread (${newThreadShortcut.label})`
-              : "New thread"
-          }
-          aria-keyshortcuts={newThreadShortcut?.ariaKeyshortcuts}
-        >
-          <Icon name="MessageSquarePlus" />
-          <span className="flex min-w-0 flex-1 items-center gap-1.5">
-            <span className="min-w-0 truncate text-left">New thread</span>
-            {newThreadSplitIndicator.miniMap ? (
-              <SplitPaneMiniMap
-                slots={newThreadSplitIndicator.miniMap}
-                label="New thread — open in split"
-              />
-            ) : null}
-            <AppCommandShortcutHint shortcut={newThreadShortcut} />
-          </span>
-        </Button>
-        <span className="flex shrink-0 items-center gap-1">
-          <AppCommandShortcutHint shortcut={threadSearchShortcut} />
-          <Button
-            type="button"
-            size="icon"
-            variant="ghost"
-            aria-label={
-              threadSearchShortcut
-                ? `Search threads (${threadSearchShortcut.label})`
-                : "Search threads"
-            }
-            aria-keyshortcuts={threadSearchShortcut?.ariaKeyshortcuts}
-            className={PROJECT_LIST_ACTION_ICON_BUTTON_CLASS}
-            onClick={(event) => {
-              onSearchThreads?.();
-              commandRunner.dispatch("thread.search", event.currentTarget);
-            }}
-          >
-            <Icon name="Search" className={COARSE_POINTER_ICON_SIZE_CLASS} />
-          </Button>
+    <Button
+      type="button"
+      size="sm"
+      variant="ghost"
+      className={cn(PROJECT_LIST_ACTION_BUTTON_CLASS, "w-full")}
+      onPointerDown={newThreadSplit?.onPointerDown}
+      onClick={(event) => {
+        if (event.metaKey || event.ctrlKey) {
+          newThreadSplit?.openInSplit();
+          return;
+        }
+        onNewChat?.();
+      }}
+      disabled={isNewChatDisabled}
+      aria-label={
+        newThreadShortcut
+          ? `New thread (${newThreadShortcut.label})`
+          : "New thread"
+      }
+      aria-keyshortcuts={newThreadShortcut?.ariaKeyshortcuts}
+    >
+      <Icon name="MessageSquarePlus" />
+      <span className="flex min-w-0 flex-1 items-center gap-1.5">
+        <span className="min-w-0 flex-1 truncate text-left">New thread</span>
+        {newThreadSplitIndicator.miniMap ? (
+          <SplitPaneMiniMap
+            slots={newThreadSplitIndicator.miniMap}
+            label="New thread — open in split"
+          />
+        ) : null}
+        <AppCommandShortcutHint shortcut={newThreadShortcut} />
+      </span>
+    </Button>
+  );
+}
+
+export function ProjectListSearchThreadsAction({
+  onSearchThreads,
+}: ProjectListSearchThreadsActionProps) {
+  const commandRunner = useAppCommandRunner();
+  const threadSearchShortcut = useAppCommandShortcut("thread.search");
+
+  return (
+    <Button
+      type="button"
+      size="sm"
+      variant="ghost"
+      className={cn(PROJECT_LIST_ACTION_BUTTON_CLASS, "w-full")}
+      onClick={(event) => {
+        onSearchThreads?.();
+        commandRunner.dispatch("thread.search", event.currentTarget);
+      }}
+      aria-label={
+        threadSearchShortcut
+          ? `Search threads (${threadSearchShortcut.label})`
+          : "Search threads"
+      }
+      aria-keyshortcuts={threadSearchShortcut?.ariaKeyshortcuts}
+    >
+      <Icon name="Search" />
+      <span className="flex min-w-0 flex-1 items-center gap-1.5">
+        <span className="min-w-0 flex-1 truncate text-left">
+          Search threads
         </span>
-      </div>
+        <AppCommandShortcutHint shortcut={threadSearchShortcut} />
+      </span>
+    </Button>
+  );
+}
+
+export function ProjectListActionButtons({
+  splitEnabled = false,
+  newThreadSplit,
+  onNewChat,
+  onSearchThreads,
+}: ProjectListActionButtonsProps) {
+  return (
+    <div className="space-y-1">
+      <ProjectListNewThreadAction
+        splitEnabled={splitEnabled}
+        newThreadSplit={newThreadSplit}
+        onNewChat={onNewChat}
+      />
+      <ProjectListSearchThreadsAction onSearchThreads={onSearchThreads} />
     </div>
   );
 }

--- a/apps/app/src/components/sidebar/SidebarTopRegionCustomizeMenu.test.tsx
+++ b/apps/app/src/components/sidebar/SidebarTopRegionCustomizeMenu.test.tsx
@@ -127,10 +127,10 @@ describe("SidebarTopRegionCustomizeMenu", () => {
       Array.from(
         document.querySelectorAll("[data-sidebar-customize-region]"),
       ).map((item) => item.textContent),
-    ).toEqual(["BB controls", "Plugins"]);
+    ).toEqual(["Threads", "BB controls", "Plugins"]);
     expect(
       document.querySelectorAll("[data-sidebar-customize-region-drag-handle]"),
-    ).toHaveLength(2);
+    ).toHaveLength(3);
     expect(screen.getByRole("group", { name: "BB controls" })).toBeDefined();
     expect(screen.queryByRole("menuitem", { name: "Add action" })).toBeNull();
     for (const label of [
@@ -140,6 +140,7 @@ describe("SidebarTopRegionCustomizeMenu", () => {
       "Automations",
       "BB controls",
       "Plugins",
+      "Threads",
     ]) {
       const handle = screen.getByLabelText(`Reorder ${label}`);
       expect(handle.getAttribute("tabindex")).toBe("0");

--- a/apps/app/src/components/sidebar/SidebarTopRegionCustomizeMenu.test.tsx
+++ b/apps/app/src/components/sidebar/SidebarTopRegionCustomizeMenu.test.tsx
@@ -18,6 +18,13 @@ afterEach(() => {
   cleanup();
   window.localStorage.clear();
 });
+
+function expectClasses(element: Element, ...classNames: string[]): void {
+  for (const className of classNames) {
+    expect(element.classList.contains(className)).toBe(true);
+  }
+}
+
 function renderMenu() {
   const store = createStore();
   render(
@@ -44,9 +51,11 @@ describe("SidebarTopRegionCustomizeMenu", () => {
       </TooltipProvider>,
     );
 
-    expect(
+    expectClasses(
       screen.getByRole("button", { name: "Customize sidebar" }),
-    ).toHaveClass("text-subtle-foreground", "opacity-60");
+      "text-subtle-foreground",
+      "opacity-60",
+    );
   });
 
   it("shows exactly the four host-owned rows in stored order", async () => {
@@ -79,7 +88,8 @@ describe("SidebarTopRegionCustomizeMenu", () => {
     expect(
       document.querySelectorAll("[data-sidebar-customize-drag-handle]"),
     ).toHaveLength(4);
-    expect(screen.getByText("Customize")).toHaveClass(
+    expectClasses(
+      screen.getByText("Customize"),
       "text-sm",
       "font-medium",
       "text-popover-foreground",
@@ -107,7 +117,8 @@ describe("SidebarTopRegionCustomizeMenu", () => {
     )) {
       expect(dragIcon.classList.contains("size-4")).toBe(true);
     }
-    expect(screen.getByText("Sidebar order")).toHaveClass(
+    expectClasses(
+      screen.getByText("Sidebar order"),
       "text-xs",
       "font-normal",
       "text-subtle-foreground/75",

--- a/apps/app/src/components/sidebar/SidebarTopRegionCustomizeMenu.test.tsx
+++ b/apps/app/src/components/sidebar/SidebarTopRegionCustomizeMenu.test.tsx
@@ -1,0 +1,169 @@
+// @vitest-environment jsdom
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
+import { createStore, Provider } from "jotai";
+import { afterEach, describe, expect, it } from "vitest";
+import { TooltipProvider } from "@bb/shared-ui/tooltip";
+import { SidebarTopRegionCustomizeMenu } from "./SidebarTopRegionCustomizeMenu";
+import { sidebarTopRegionItemPreferencesAtom } from "./sidebarTopRegionItemPreferences";
+import { sidebarRegionOrderAtom } from "./sidebarRegionOrderPreferences";
+
+afterEach(() => {
+  cleanup();
+  window.localStorage.clear();
+});
+function renderMenu() {
+  const store = createStore();
+  render(
+    <Provider store={store}>
+      <TooltipProvider>
+        <SidebarTopRegionCustomizeMenu />
+      </TooltipProvider>
+    </Provider>,
+  );
+  fireEvent.pointerDown(
+    screen.getByRole("button", { name: "Customize sidebar" }),
+    {
+      button: 0,
+    },
+  );
+  return store;
+}
+
+describe("SidebarTopRegionCustomizeMenu", () => {
+  it("uses the persistent shortcut-muted treatment for its trigger", () => {
+    render(
+      <TooltipProvider>
+        <SidebarTopRegionCustomizeMenu />
+      </TooltipProvider>,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Customize sidebar" }),
+    ).toHaveClass("text-subtle-foreground", "opacity-60");
+  });
+
+  it("shows exactly the four host-owned rows in stored order", async () => {
+    const store = createStore();
+    store.set(sidebarTopRegionItemPreferencesAtom, {
+      order: ["automations", "new-thread", "search", "extensions"],
+      hiddenIds: ["extensions"],
+    });
+    store.set(sidebarRegionOrderAtom, ["threads", "bb-controls", "plugins"]);
+    render(
+      <Provider store={store}>
+        <TooltipProvider>
+          <SidebarTopRegionCustomizeMenu />
+        </TooltipProvider>
+      </Provider>,
+    );
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: "Customize sidebar" }),
+      { button: 0 },
+    );
+
+    const items = await screen.findAllByRole("menuitemcheckbox");
+    expect(items.map((item) => item.textContent)).toEqual([
+      "Automations",
+      "New thread",
+      "Search threads",
+      "Extensions",
+    ]);
+    expect(items[3]?.getAttribute("data-state")).toBe("unchecked");
+    expect(
+      document.querySelectorAll("[data-sidebar-customize-drag-handle]"),
+    ).toHaveLength(4);
+    expect(screen.getByText("Customize")).toHaveClass(
+      "text-sm",
+      "font-medium",
+      "text-popover-foreground",
+    );
+    expect(screen.queryByText("Sidebar items")).toBeNull();
+    expect(screen.queryByText("Drag to reorder. Uncheck to hide.")).toBeNull();
+    expect(
+      document.querySelectorAll("[data-sidebar-customize-checkbox]"),
+    ).toHaveLength(4);
+    expect(
+      document
+        .querySelector('[data-sidebar-customize-checkbox="extensions"]')
+        ?.getAttribute("data-state"),
+    ).toBe("unchecked");
+    const checkedBox = document.querySelector(
+      '[data-sidebar-customize-checkbox="automations"]',
+    );
+    expect(checkedBox?.classList.contains("bg-foreground")).toBe(false);
+    expect(checkedBox?.classList.contains("border-primary")).toBe(true);
+    expect(checkedBox?.classList.contains("text-primary")).toBe(true);
+    expect(screen.getByRole("menu").classList.contains("w-44")).toBe(true);
+    expect(screen.getByRole("menu").classList.contains("p-2")).toBe(true);
+    for (const dragIcon of document.querySelectorAll(
+      "[data-sidebar-customize-drag-handle] svg",
+    )) {
+      expect(dragIcon.classList.contains("size-4")).toBe(true);
+    }
+    expect(screen.getByText("Sidebar order")).toHaveClass(
+      "text-xs",
+      "font-normal",
+      "text-subtle-foreground/75",
+    );
+    expect(
+      Array.from(
+        document.querySelectorAll("[data-sidebar-customize-region]"),
+      ).map((item) => item.textContent),
+    ).toEqual(["BB controls", "Plugins"]);
+    expect(
+      document.querySelectorAll("[data-sidebar-customize-region-drag-handle]"),
+    ).toHaveLength(2);
+    expect(screen.getByRole("group", { name: "BB controls" })).toBeDefined();
+    expect(screen.queryByRole("menuitem", { name: "Add action" })).toBeNull();
+    for (const label of [
+      "New thread",
+      "Search threads",
+      "Extensions",
+      "Automations",
+      "BB controls",
+      "Plugins",
+    ]) {
+      const handle = screen.getByLabelText(`Reorder ${label}`);
+      expect(handle.getAttribute("tabindex")).toBe("0");
+    }
+  });
+
+  it("updates visibility live, stays open, and can restore from all hidden", async () => {
+    const store = renderMenu();
+    const menu = await screen.findByRole("menu");
+
+    for (const label of [
+      "New thread",
+      "Search threads",
+      "Extensions",
+      "Automations",
+    ]) {
+      fireEvent.click(
+        within(menu).getByRole("menuitemcheckbox", { name: label }),
+      );
+    }
+    expect(store.get(sidebarTopRegionItemPreferencesAtom).hiddenIds).toEqual([
+      "new-thread",
+      "search",
+      "extensions",
+      "automations",
+    ]);
+    expect(screen.getByRole("menu")).toBeDefined();
+
+    fireEvent.click(
+      within(menu).getByRole("menuitemcheckbox", { name: "New thread" }),
+    );
+    expect(store.get(sidebarTopRegionItemPreferencesAtom).hiddenIds).toEqual([
+      "search",
+      "extensions",
+      "automations",
+    ]);
+  });
+});

--- a/apps/app/src/components/sidebar/SidebarTopRegionCustomizeMenu.tsx
+++ b/apps/app/src/components/sidebar/SidebarTopRegionCustomizeMenu.tsx
@@ -1,0 +1,329 @@
+import { useMemo, type CSSProperties } from "react";
+import { useAtom } from "jotai";
+import {
+  closestCenter,
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type Modifier,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { Button } from "@bb/shared-ui/button";
+import { CHROME_SECTION_LABEL_CLASS } from "@bb/shared-ui/chrome-style-tokens";
+import {
+  COARSE_POINTER_HEADER_ICON_BUTTON_CLASS,
+  COARSE_POINTER_ICON_SIZE_CLASS,
+} from "@bb/shared-ui/coarse-pointer-sizing";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@bb/shared-ui/dropdown-menu";
+import { Icon } from "@bb/shared-ui/icon";
+import { cn } from "@bb/shared-ui/lib/utils";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@bb/shared-ui/tooltip";
+import {
+  reorderSidebarTopRegionItems,
+  setSidebarTopRegionItemVisible,
+  sidebarTopRegionItemPreferencesAtom,
+  type SidebarTopRegionItemId,
+} from "./sidebarTopRegionItemPreferences";
+import {
+  normalizeSidebarRegionOrder,
+  reorderSidebarRegions,
+  sidebarRegionOrderAtom,
+  type SidebarRegionId,
+} from "./sidebarRegionOrderPreferences";
+const ITEM_LABELS: Record<SidebarTopRegionItemId, string> = {
+  "new-thread": "New thread",
+  search: "Search threads",
+  extensions: "Extensions",
+  automations: "Automations",
+};
+
+const REGION_LABELS: Record<SidebarRegionId, string> = {
+  "bb-controls": "BB controls",
+  plugins: "Plugins",
+  threads: "Threads",
+};
+
+const COMPACT_MENU_CONTENT_CLASS =
+  "w-44 min-w-44 p-2 [&_[role=menuitem]]:!py-1 [&_[role=menuitemcheckbox]]:!py-1 [&_[role=separator]]:!my-0.5";
+const COMPACT_MENU_LABEL_CLASS = "!px-2 !py-1";
+const CUSTOMIZE_MENU_TITLE_CLASS =
+  "text-sm font-medium leading-5 text-popover-foreground";
+const SORTABLE_ITEM_CLASS = "gap-2 !px-2 !py-1";
+
+const restrictDragToVerticalAxis: Modifier = ({ transform }) => ({
+  ...transform,
+  x: 0,
+});
+
+const dragModifiers: Modifier[] = [restrictDragToVerticalAxis];
+
+function SortableTopRegionItem({ id }: { id: SidebarTopRegionItemId }) {
+  const [preferences, setPreferences] = useAtom(
+    sidebarTopRegionItemPreferencesAtom,
+  );
+  const {
+    attributes,
+    isDragging,
+    listeners,
+    setActivatorNodeRef,
+    setNodeRef,
+    transform,
+    transition,
+  } = useSortable({ id });
+  const style = useMemo<CSSProperties>(
+    () => ({
+      transform: CSS.Translate.toString(transform),
+      transition,
+    }),
+    [transform, transition],
+  );
+  const visible = !preferences.hiddenIds.includes(id);
+
+  return (
+    <DropdownMenuCheckboxItem
+      ref={setNodeRef}
+      style={style}
+      checked={visible}
+      textValue={ITEM_LABELS[id]}
+      onSelect={(event) => event.preventDefault()}
+      onCheckedChange={(checked) =>
+        setPreferences((current) =>
+          setSidebarTopRegionItemVisible(current, id, checked === true),
+        )
+      }
+      className={cn(
+        SORTABLE_ITEM_CLASS,
+        "!pr-2 [&>span.absolute]:hidden",
+        isDragging && "relative z-10 bg-state-hover opacity-90 shadow-sm",
+      )}
+      data-sidebar-customize-item={id}
+    >
+      <span
+        ref={setActivatorNodeRef}
+        {...attributes}
+        {...listeners}
+        aria-label={`Reorder ${ITEM_LABELS[id]}`}
+        title={`Reorder ${ITEM_LABELS[id]}`}
+        className={cn(
+          "flex size-4 shrink-0 cursor-grab touch-none items-center justify-center rounded-sm text-subtle-foreground/60 active:cursor-grabbing",
+          "hover:text-sidebar-foreground focus-visible:text-sidebar-foreground",
+          "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+        )}
+        onClick={(event) => event.stopPropagation()}
+        data-sidebar-customize-drag-handle={id}
+      >
+        <Icon
+          name="DragDropVertical"
+          className={COARSE_POINTER_ICON_SIZE_CLASS}
+        />
+      </span>
+      <span className="min-w-0 flex-1 truncate">{ITEM_LABELS[id]}</span>
+      <span
+        aria-hidden="true"
+        data-sidebar-customize-checkbox={id}
+        data-state={visible ? "checked" : "unchecked"}
+        className={cn(
+          "flex size-4 shrink-0 items-center justify-center rounded-sm border border-input shadow-xs",
+          visible && "border-primary text-primary",
+        )}
+      >
+        {visible ? <Icon name="Check" className="size-3.5" /> : null}
+      </span>
+    </DropdownMenuCheckboxItem>
+  );
+}
+function SortableSidebarRegionItem({ id }: { id: SidebarRegionId }) {
+  const {
+    attributes,
+    isDragging,
+    listeners,
+    setActivatorNodeRef,
+    setNodeRef,
+    transform,
+    transition,
+  } = useSortable({ id });
+  const style = useMemo<CSSProperties>(
+    () => ({
+      transform: CSS.Translate.toString(transform),
+      transition,
+    }),
+    [transform, transition],
+  );
+  const label = REGION_LABELS[id];
+
+  return (
+    <DropdownMenuItem
+      ref={setNodeRef}
+      style={style}
+      textValue={label}
+      onSelect={(event) => event.preventDefault()}
+      className={cn(
+        SORTABLE_ITEM_CLASS,
+        isDragging && "relative z-10 bg-state-hover opacity-90 shadow-sm",
+      )}
+      data-sidebar-customize-region={id}
+    >
+      <span
+        ref={setActivatorNodeRef}
+        {...attributes}
+        {...listeners}
+        aria-label={`Reorder ${label}`}
+        title={`Reorder ${label}`}
+        className={cn(
+          "flex size-4 shrink-0 cursor-grab touch-none items-center justify-center rounded-sm text-subtle-foreground/60 active:cursor-grabbing",
+          "hover:text-sidebar-foreground focus-visible:text-sidebar-foreground",
+          "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+        )}
+        onClick={(event) => event.stopPropagation()}
+        data-sidebar-customize-region-drag-handle={id}
+      >
+        <Icon
+          name="DragDropVertical"
+          className={COARSE_POINTER_ICON_SIZE_CLASS}
+        />
+      </span>
+      <span className="min-w-0 flex-1 truncate">{label}</span>
+    </DropdownMenuItem>
+  );
+}
+
+export function SidebarTopRegionCustomizeMenu({
+  className,
+}: {
+  className?: string;
+}) {
+  const [preferences, setPreferences] = useAtom(
+    sidebarTopRegionItemPreferencesAtom,
+  );
+  const [regionOrder, setRegionOrder] = useAtom(sidebarRegionOrderAtom);
+  const reorderableRegionOrder = normalizeSidebarRegionOrder(
+    regionOrder,
+  ).filter((id) => id !== "threads");
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+  const handleTopRegionItemDragEnd = (event: DragEndEvent) => {
+    if (
+      typeof event.active.id !== "string" ||
+      typeof event.over?.id !== "string"
+    ) {
+      return;
+    }
+    const activeId = event.active.id as SidebarTopRegionItemId;
+    const overId = event.over.id as SidebarTopRegionItemId;
+    setPreferences((current) =>
+      reorderSidebarTopRegionItems(current, activeId, overId),
+    );
+  };
+  const handleRegionDragEnd = (event: DragEndEvent) => {
+    if (
+      typeof event.active.id !== "string" ||
+      typeof event.over?.id !== "string"
+    ) {
+      return;
+    }
+    const activeId = event.active.id as SidebarRegionId;
+    const overId = event.over.id as SidebarRegionId;
+    setRegionOrder((current) =>
+      reorderSidebarRegions(current, activeId, overId),
+    );
+  };
+
+  return (
+    <DropdownMenu>
+      <Tooltip delayDuration={350} disableHoverableContent>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label="Customize sidebar"
+              className={cn(
+                COARSE_POINTER_HEADER_ICON_BUTTON_CLASS,
+                "text-subtle-foreground opacity-60 ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-foreground hover:opacity-100 focus-visible:ring-2 focus-visible:opacity-100 data-[state=open]:opacity-100",
+                className,
+              )}
+            >
+              <Icon name="SlidersHorizontal" aria-hidden />
+            </Button>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" className="px-2 py-1">
+          Customize sidebar
+        </TooltipContent>
+      </Tooltip>
+      <DropdownMenuContent
+        side="right"
+        align="start"
+        sideOffset={8}
+        className={COMPACT_MENU_CONTENT_CLASS}
+        mobileTitle="Customize"
+      >
+        <DropdownMenuLabel
+          className={cn(CUSTOMIZE_MENU_TITLE_CLASS, COMPACT_MENU_LABEL_CLASS)}
+        >
+          Customize
+        </DropdownMenuLabel>
+        <div role="group" aria-label="BB controls">
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            modifiers={dragModifiers}
+            onDragEnd={handleTopRegionItemDragEnd}
+          >
+            <SortableContext
+              items={preferences.order}
+              strategy={verticalListSortingStrategy}
+            >
+              {preferences.order.map((id) => (
+                <SortableTopRegionItem key={id} id={id} />
+              ))}
+            </SortableContext>
+          </DndContext>
+        </div>
+        <DropdownMenuSeparator />
+        <DropdownMenuLabel
+          className={cn(CHROME_SECTION_LABEL_CLASS, COMPACT_MENU_LABEL_CLASS)}
+        >
+          Sidebar order
+        </DropdownMenuLabel>
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          modifiers={dragModifiers}
+          onDragEnd={handleRegionDragEnd}
+        >
+          <SortableContext
+            items={reorderableRegionOrder}
+            strategy={verticalListSortingStrategy}
+          >
+            {reorderableRegionOrder.map((id) => (
+              <SortableSidebarRegionItem key={id} id={id} />
+            ))}
+          </SortableContext>
+        </DndContext>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/app/src/components/sidebar/SidebarTopRegionCustomizeMenu.tsx
+++ b/apps/app/src/components/sidebar/SidebarTopRegionCustomizeMenu.tsx
@@ -120,7 +120,6 @@ function SortableTopRegionItem({ id }: { id: SidebarTopRegionItemId }) {
         {...attributes}
         {...listeners}
         aria-label={`Reorder ${ITEM_LABELS[id]}`}
-        title={`Reorder ${ITEM_LABELS[id]}`}
         className={cn(
           "flex size-4 shrink-0 cursor-grab touch-none items-center justify-center rounded-sm text-subtle-foreground/60 active:cursor-grabbing",
           "hover:text-sidebar-foreground focus-visible:text-sidebar-foreground",
@@ -185,7 +184,6 @@ function SortableSidebarRegionItem({ id }: { id: SidebarRegionId }) {
         {...attributes}
         {...listeners}
         aria-label={`Reorder ${label}`}
-        title={`Reorder ${label}`}
         className={cn(
           "flex size-4 shrink-0 cursor-grab touch-none items-center justify-center rounded-sm text-subtle-foreground/60 active:cursor-grabbing",
           "hover:text-sidebar-foreground focus-visible:text-sidebar-foreground",

--- a/apps/app/src/components/sidebar/SidebarTopRegionCustomizeMenu.tsx
+++ b/apps/app/src/components/sidebar/SidebarTopRegionCustomizeMenu.tsx
@@ -211,9 +211,7 @@ export function SidebarTopRegionCustomizeMenu({
     sidebarTopRegionItemPreferencesAtom,
   );
   const [regionOrder, setRegionOrder] = useAtom(sidebarRegionOrderAtom);
-  const reorderableRegionOrder = normalizeSidebarRegionOrder(
-    regionOrder,
-  ).filter((id) => id !== "threads");
+  const reorderableRegionOrder = normalizeSidebarRegionOrder(regionOrder);
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
     useSensor(KeyboardSensor, {

--- a/apps/app/src/components/sidebar/sidebarRegionOrderPreferences.test.ts
+++ b/apps/app/src/components/sidebar/sidebarRegionOrderPreferences.test.ts
@@ -32,14 +32,14 @@ describe("sidebar region order preferences", () => {
         "threads",
         "bb-controls",
       ]),
-    ).toEqual(["bb-controls", "plugins", "threads"]);
+    ).toEqual(["threads", "bb-controls", "plugins"]);
     expect(
       normalizeSidebarRegionOrder([
         "thread-list",
         "new-thread-extensions",
         "plugin-pages",
       ]),
-    ).toEqual(["bb-controls", "plugins", "threads"]);
+    ).toEqual(["threads", "bb-controls", "plugins"]);
     expect(normalizeSidebarRegionOrder({ order: ["threads"] })).toEqual([
       "bb-controls",
       "plugins",
@@ -57,16 +57,16 @@ describe("sidebar region order preferences", () => {
     const store = createStore();
 
     expect(store.get(reloadedModule.sidebarRegionOrderAtom)).toEqual([
+      "threads",
       "bb-controls",
       "plugins",
-      "threads",
     ]);
     expect(window.localStorage.getItem(SIDEBAR_REGION_ORDER_STORAGE_KEY)).toBe(
-      JSON.stringify(["new-thread-extensions", "plugin-pages", "thread-list"]),
+      JSON.stringify(["thread-list", "new-thread-extensions", "plugin-pages"]),
     );
   });
 
-  it("moves reorderable regions but keeps Threads last", () => {
+  it("moves every sidebar region, including Threads", () => {
     expect(
       reorderSidebarRegions(
         ["bb-controls", "plugins", "threads"],
@@ -80,6 +80,6 @@ describe("sidebar region order preferences", () => {
         "threads",
         "bb-controls",
       ),
-    ).toEqual(["bb-controls", "plugins", "threads"]);
+    ).toEqual(["threads", "bb-controls", "plugins"]);
   });
 });

--- a/apps/app/src/components/sidebar/sidebarRegionOrderPreferences.test.ts
+++ b/apps/app/src/components/sidebar/sidebarRegionOrderPreferences.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+
+import { createStore } from "jotai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  normalizeSidebarRegionOrder,
+  reorderSidebarRegions,
+  SIDEBAR_REGION_ORDER_STORAGE_KEY,
+  sidebarRegionOrderAtom,
+} from "./sidebarRegionOrderPreferences";
+
+afterEach(() => {
+  window.localStorage.clear();
+  vi.resetModules();
+});
+describe("sidebar region order preferences", () => {
+  it("defaults to BB controls, Plugins, then Threads", () => {
+    const store = createStore();
+
+    expect(store.get(sidebarRegionOrderAtom)).toEqual([
+      "bb-controls",
+      "plugins",
+      "threads",
+    ]);
+  });
+
+  it("drops unknown and duplicate ids and appends missing regions", () => {
+    expect(
+      normalizeSidebarRegionOrder([
+        "threads",
+        "unknown",
+        "threads",
+        "bb-controls",
+      ]),
+    ).toEqual(["bb-controls", "plugins", "threads"]);
+    expect(
+      normalizeSidebarRegionOrder([
+        "thread-list",
+        "new-thread-extensions",
+        "plugin-pages",
+      ]),
+    ).toEqual(["bb-controls", "plugins", "threads"]);
+    expect(normalizeSidebarRegionOrder({ order: ["threads"] })).toEqual([
+      "bb-controls",
+      "plugins",
+      "threads",
+    ]);
+  });
+
+  it("normalizes and rewrites legacy stored order when the atom reads it", async () => {
+    window.localStorage.setItem(
+      SIDEBAR_REGION_ORDER_STORAGE_KEY,
+      JSON.stringify(["thread-list", "thread-list", "unknown"]),
+    );
+    vi.resetModules();
+    const reloadedModule = await import("./sidebarRegionOrderPreferences");
+    const store = createStore();
+
+    expect(store.get(reloadedModule.sidebarRegionOrderAtom)).toEqual([
+      "bb-controls",
+      "plugins",
+      "threads",
+    ]);
+    expect(window.localStorage.getItem(SIDEBAR_REGION_ORDER_STORAGE_KEY)).toBe(
+      JSON.stringify(["new-thread-extensions", "plugin-pages", "thread-list"]),
+    );
+  });
+
+  it("moves reorderable regions but keeps Threads last", () => {
+    expect(
+      reorderSidebarRegions(
+        ["bb-controls", "plugins", "threads"],
+        "plugins",
+        "bb-controls",
+      ),
+    ).toEqual(["plugins", "bb-controls", "threads"]);
+    expect(
+      reorderSidebarRegions(
+        ["bb-controls", "plugins", "threads"],
+        "threads",
+        "bb-controls",
+      ),
+    ).toEqual(["bb-controls", "plugins", "threads"]);
+  });
+});

--- a/apps/app/src/components/sidebar/sidebarRegionOrderPreferences.ts
+++ b/apps/app/src/components/sidebar/sidebarRegionOrderPreferences.ts
@@ -45,11 +45,6 @@ function toSidebarRegionId(value: unknown): SidebarRegionId | null {
   return REGION_BY_LEGACY_SECTION_ID[value] ?? null;
 }
 
-/**
- * Keeps every code-owned region exactly once. Unknown and duplicate ids are
- * discarded, while regions introduced after a preference was written append
- * in their default relative order.
- */
 export function normalizeSidebarRegionOrder(value: unknown): SidebarRegionId[] {
   const presentOrder: SidebarRegionId[] = [];
   if (Array.isArray(value)) {

--- a/apps/app/src/components/sidebar/sidebarRegionOrderPreferences.ts
+++ b/apps/app/src/components/sidebar/sidebarRegionOrderPreferences.ts
@@ -1,0 +1,124 @@
+import { atomWithStorage } from "jotai/utils";
+import {
+  createJsonLocalStorage,
+  type SyncStorage,
+} from "@/lib/browser-storage";
+
+export const SIDEBAR_REGION_ORDER_STORAGE_KEY =
+  "bb.sidebar.topLevelSectionOrder";
+
+export const SIDEBAR_REGION_IDS = [
+  "bb-controls",
+  "plugins",
+  "threads",
+] as const;
+
+const SIDEBAR_REORDERABLE_REGION_IDS = ["bb-controls", "plugins"] as const;
+
+export type SidebarRegionId = (typeof SIDEBAR_REGION_IDS)[number];
+
+const LEGACY_SECTION_ID_BY_REGION: Readonly<Record<SidebarRegionId, string>> = {
+  "bb-controls": "new-thread-extensions",
+  plugins: "plugin-pages",
+  threads: "thread-list",
+};
+
+const REGION_BY_LEGACY_SECTION_ID: Readonly<
+  Partial<Record<string, SidebarRegionId>>
+> = {
+  "new-thread-extensions": "bb-controls",
+  "plugin-pages": "plugins",
+  "thread-list": "threads",
+};
+
+export const DEFAULT_SIDEBAR_REGION_ORDER: SidebarRegionId[] = [
+  ...SIDEBAR_REGION_IDS,
+];
+
+function isSidebarRegionId(value: unknown): value is SidebarRegionId {
+  return SIDEBAR_REGION_IDS.some((id) => id === value);
+}
+
+function toSidebarRegionId(value: unknown): SidebarRegionId | null {
+  if (isSidebarRegionId(value)) return value;
+  if (typeof value !== "string") return null;
+  return REGION_BY_LEGACY_SECTION_ID[value] ?? null;
+}
+
+/**
+ * Keeps every code-owned region exactly once. Unknown and duplicate ids are
+ * discarded, while regions introduced after a preference was written append
+ * in their default relative order.
+ */
+export function normalizeSidebarRegionOrder(value: unknown): SidebarRegionId[] {
+  const presentOrder: SidebarRegionId[] = [];
+  if (Array.isArray(value)) {
+    for (const candidate of value) {
+      const id = toSidebarRegionId(candidate);
+      if (id !== null && id !== "threads" && !presentOrder.includes(id)) {
+        presentOrder.push(id);
+      }
+    }
+  }
+  return [
+    ...presentOrder,
+    ...SIDEBAR_REORDERABLE_REGION_IDS.filter(
+      (id) => !presentOrder.includes(id),
+    ),
+    "threads",
+  ];
+}
+
+export function reorderSidebarRegions(
+  current: readonly SidebarRegionId[],
+  activeId: SidebarRegionId,
+  overId: SidebarRegionId,
+): SidebarRegionId[] {
+  const normalized = normalizeSidebarRegionOrder(current);
+  if (activeId === "threads" || overId === "threads") return normalized;
+  const activeIndex = normalized.indexOf(activeId);
+  const overIndex = normalized.indexOf(overId);
+  if (activeIndex === -1 || overIndex === -1 || activeIndex === overIndex) {
+    return normalized;
+  }
+
+  const order = [...normalized];
+  const [moved] = order.splice(activeIndex, 1);
+  if (moved === undefined) return normalized;
+  order.splice(overIndex, 0, moved);
+  return order;
+}
+
+const jsonStorage = createJsonLocalStorage<unknown>();
+function serializeRegionOrder(value: unknown): string[] {
+  return normalizeSidebarRegionOrder(value).map(
+    (id) => LEGACY_SECTION_ID_BY_REGION[id],
+  );
+}
+
+const regionOrderStorage: SyncStorage<SidebarRegionId[]> = {
+  getItem: (key, initialValue) => {
+    const order = normalizeSidebarRegionOrder(
+      jsonStorage.getItem(key, initialValue),
+    );
+    jsonStorage.setItem(key, serializeRegionOrder(order));
+    return order;
+  },
+  setItem: (key, value) => {
+    jsonStorage.setItem(key, serializeRegionOrder(value));
+  },
+  removeItem: jsonStorage.removeItem,
+  subscribe: (key, callback, initialValue) =>
+    jsonStorage.subscribe?.(
+      key,
+      (value) => callback(normalizeSidebarRegionOrder(value)),
+      initialValue,
+    ),
+};
+
+export const sidebarRegionOrderAtom = atomWithStorage<SidebarRegionId[]>(
+  SIDEBAR_REGION_ORDER_STORAGE_KEY,
+  DEFAULT_SIDEBAR_REGION_ORDER,
+  regionOrderStorage,
+  { getOnInit: true },
+);

--- a/apps/app/src/components/sidebar/sidebarRegionOrderPreferences.ts
+++ b/apps/app/src/components/sidebar/sidebarRegionOrderPreferences.ts
@@ -13,8 +13,6 @@ export const SIDEBAR_REGION_IDS = [
   "threads",
 ] as const;
 
-const SIDEBAR_REORDERABLE_REGION_IDS = ["bb-controls", "plugins"] as const;
-
 export type SidebarRegionId = (typeof SIDEBAR_REGION_IDS)[number];
 
 const LEGACY_SECTION_ID_BY_REGION: Readonly<Record<SidebarRegionId, string>> = {
@@ -50,17 +48,14 @@ export function normalizeSidebarRegionOrder(value: unknown): SidebarRegionId[] {
   if (Array.isArray(value)) {
     for (const candidate of value) {
       const id = toSidebarRegionId(candidate);
-      if (id !== null && id !== "threads" && !presentOrder.includes(id)) {
+      if (id !== null && !presentOrder.includes(id)) {
         presentOrder.push(id);
       }
     }
   }
   return [
     ...presentOrder,
-    ...SIDEBAR_REORDERABLE_REGION_IDS.filter(
-      (id) => !presentOrder.includes(id),
-    ),
-    "threads",
+    ...SIDEBAR_REGION_IDS.filter((id) => !presentOrder.includes(id)),
   ];
 }
 
@@ -70,7 +65,6 @@ export function reorderSidebarRegions(
   overId: SidebarRegionId,
 ): SidebarRegionId[] {
   const normalized = normalizeSidebarRegionOrder(current);
-  if (activeId === "threads" || overId === "threads") return normalized;
   const activeIndex = normalized.indexOf(activeId);
   const overIndex = normalized.indexOf(overId);
   if (activeIndex === -1 || overIndex === -1 || activeIndex === overIndex) {

--- a/apps/app/src/components/sidebar/sidebarTopRegionItemPreferences.test.ts
+++ b/apps/app/src/components/sidebar/sidebarTopRegionItemPreferences.test.ts
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+
+import { createStore } from "jotai";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  DEFAULT_SIDEBAR_TOP_REGION_ITEM_PREFERENCES,
+  migrateLegacySidebarTopRegionItems,
+  normalizeSidebarTopRegionItemPreferences,
+  reorderSidebarTopRegionItems,
+  setSidebarTopRegionItemVisible,
+  sidebarTopRegionItemPreferencesAtom,
+} from "./sidebarTopRegionItemPreferences";
+
+class MemoryStorage {
+  readonly values = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+}
+
+afterEach(() => {
+  window.localStorage.clear();
+});
+describe("top-region sidebar item preferences", () => {
+  it("defaults to all four host-owned items in approved order", () => {
+    const store = createStore();
+
+    expect(store.get(sidebarTopRegionItemPreferencesAtom)).toEqual({
+      order: ["new-thread", "search", "extensions", "automations"],
+      hiddenIds: [],
+    });
+  });
+
+  it("normalizes duplicate, unknown, and missing ids without losing hidden choices", () => {
+    expect(
+      normalizeSidebarTopRegionItemPreferences({
+        order: ["automations", "unknown", "automations"],
+        hiddenIds: ["extensions", "unknown", "extensions"],
+      }),
+    ).toEqual({
+      order: ["automations", "new-thread", "search", "extensions"],
+      hiddenIds: ["extensions"],
+    });
+  });
+
+  it("migrates both booleans and legacy hidden built-in panels atomically", () => {
+    const storage = new MemoryStorage();
+    storage.setItem("bb.sidebar.newThreadVisible", "false");
+    storage.setItem("bb.sidebar.extensionsVisible", "true");
+    storage.setItem(
+      "bb.sidebar.hiddenPluginPanels",
+      JSON.stringify(["docs/main", "__builtin__/tools", "automations/main"]),
+    );
+
+    expect(migrateLegacySidebarTopRegionItems(storage)).toEqual({
+      order: ["new-thread", "search", "extensions", "automations"],
+      hiddenIds: ["new-thread", "extensions", "automations"],
+    });
+    expect(storage.getItem("bb.sidebar.hiddenPluginPanels")).toBe(
+      JSON.stringify(["docs/main"]),
+    );
+    expect(storage.getItem("bb.sidebar.newThreadVisible")).toBeNull();
+    expect(storage.getItem("bb.sidebar.extensionsVisible")).toBeNull();
+    expect(
+      JSON.parse(storage.getItem("bb.sidebar.topRegionItems") ?? "{}"),
+    ).toEqual({
+      order: ["new-thread", "search", "extensions", "automations"],
+      hiddenIds: ["new-thread", "extensions", "automations"],
+    });
+  });
+
+  it("preserves an existing combined preference and only consumes owned legacy keys", () => {
+    const storage = new MemoryStorage();
+    storage.setItem(
+      "bb.sidebar.topRegionItems",
+      JSON.stringify({
+        order: ["automations", "extensions", "new-thread"],
+        hiddenIds: ["extensions"],
+      }),
+    );
+    storage.setItem(
+      "bb.sidebar.hiddenPluginPanels",
+      JSON.stringify(["automations/main", "docs/main"]),
+    );
+
+    expect(migrateLegacySidebarTopRegionItems(storage)).toEqual({
+      order: ["automations", "extensions", "new-thread", "search"],
+      hiddenIds: ["extensions"],
+    });
+    expect(storage.getItem("bb.sidebar.hiddenPluginPanels")).toBe(
+      JSON.stringify(["docs/main"]),
+    );
+  });
+
+  it("reorders live and can hide then restore every item", () => {
+    const reordered = reorderSidebarTopRegionItems(
+      DEFAULT_SIDEBAR_TOP_REGION_ITEM_PREFERENCES,
+      "automations",
+      "new-thread",
+    );
+    expect(reordered.order).toEqual([
+      "automations",
+      "new-thread",
+      "search",
+      "extensions",
+    ]);
+
+    let next = reordered;
+    for (const id of reordered.order) {
+      next = setSidebarTopRegionItemVisible(next, id, false);
+    }
+    expect(next.hiddenIds).toEqual([
+      "automations",
+      "new-thread",
+      "search",
+      "extensions",
+    ]);
+    next = setSidebarTopRegionItemVisible(next, "new-thread", true);
+    expect(next.hiddenIds).toEqual(["automations", "search", "extensions"]);
+  });
+
+});

--- a/apps/app/src/components/sidebar/sidebarTopRegionItemPreferences.ts
+++ b/apps/app/src/components/sidebar/sidebarTopRegionItemPreferences.ts
@@ -138,12 +138,6 @@ function consumeLegacyBooleanPreferences(
   storage.removeItem(LEGACY_EXTENSIONS_VISIBLE_STORAGE_KEY);
 }
 
-/**
- * Moves the stack's two booleans and the shipped plugin-hide choices into the
- * one top-region preference. The combined value wins once it exists, while
- * owned legacy keys are still consumed so the plugin-page migration cannot
- * reintroduce Automations as a traditional row.
- */
 export function migrateLegacySidebarTopRegionItems(
   storage: SidebarItemMigrationStorage,
 ): SidebarTopRegionItemPreferences {

--- a/apps/app/src/components/sidebar/sidebarTopRegionItemPreferences.ts
+++ b/apps/app/src/components/sidebar/sidebarTopRegionItemPreferences.ts
@@ -1,0 +1,246 @@
+import { atomWithStorage } from "jotai/utils";
+import {
+  createJsonLocalStorage,
+  type SyncStorage,
+} from "@/lib/browser-storage";
+import { AUTOMATIONS_PLUGIN_ID } from "@/lib/route-paths";
+
+export const SIDEBAR_TOP_REGION_ITEMS_STORAGE_KEY = "bb.sidebar.topRegionItems";
+export const LEGACY_NEW_THREAD_VISIBLE_STORAGE_KEY =
+  "bb.sidebar.newThreadVisible";
+export const LEGACY_EXTENSIONS_VISIBLE_STORAGE_KEY =
+  "bb.sidebar.extensionsVisible";
+export const LEGACY_HIDDEN_PLUGIN_NAV_PANELS_STORAGE_KEY =
+  "bb.sidebar.hiddenPluginPanels";
+export const LEGACY_EXTENSIONS_NAV_ROW_KEY = "__builtin__/tools";
+
+export const SIDEBAR_TOP_REGION_ITEM_IDS = [
+  "new-thread",
+  "search",
+  "extensions",
+  "automations",
+] as const;
+
+export type SidebarTopRegionItemId =
+  (typeof SIDEBAR_TOP_REGION_ITEM_IDS)[number];
+
+export interface SidebarTopRegionItemPreferences {
+  order: SidebarTopRegionItemId[];
+  hiddenIds: SidebarTopRegionItemId[];
+}
+
+export const DEFAULT_SIDEBAR_TOP_REGION_ITEM_PREFERENCES: SidebarTopRegionItemPreferences =
+  {
+    order: [...SIDEBAR_TOP_REGION_ITEM_IDS],
+    hiddenIds: [],
+  };
+
+interface SidebarItemMigrationStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+function isSidebarTopRegionItemId(
+  value: unknown,
+): value is SidebarTopRegionItemId {
+  return SIDEBAR_TOP_REGION_ITEM_IDS.some((id) => id === value);
+}
+
+function normalizeIds(value: unknown): SidebarTopRegionItemId[] {
+  if (!Array.isArray(value)) return [];
+  return [...new Set(value.filter(isSidebarTopRegionItemId))];
+}
+
+export function normalizeSidebarTopRegionItemPreferences(
+  value: unknown,
+): SidebarTopRegionItemPreferences {
+  const candidate =
+    typeof value === "object" && value !== null
+      ? (value as { order?: unknown; hiddenIds?: unknown })
+      : {};
+  const presentOrder = normalizeIds(candidate.order);
+  const orderWithoutNewSearch = [
+    ...presentOrder,
+    ...SIDEBAR_TOP_REGION_ITEM_IDS.filter(
+      (id) => id !== "search" && !presentOrder.includes(id),
+    ),
+  ];
+  const newThreadIndex = orderWithoutNewSearch.indexOf("new-thread");
+  const order = orderWithoutNewSearch.includes("search")
+    ? orderWithoutNewSearch
+    : [
+        ...orderWithoutNewSearch.slice(0, newThreadIndex + 1),
+        "search" as const,
+        ...orderWithoutNewSearch.slice(newThreadIndex + 1),
+      ];
+  const hiddenIds = normalizeIds(candidate.hiddenIds).filter((id) =>
+    order.includes(id),
+  );
+  return { order, hiddenIds };
+}
+
+function readJson(storage: SidebarItemMigrationStorage, key: string): unknown {
+  const value = storage.getItem(key);
+  if (value === null) return undefined;
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+function readStoredBoolean(
+  storage: SidebarItemMigrationStorage,
+  key: string,
+): boolean | null {
+  const value = readJson(storage, key);
+  return typeof value === "boolean" ? value : null;
+}
+
+function readLegacyHiddenKeys(
+  storage: SidebarItemMigrationStorage,
+): unknown[] | null {
+  const value = readJson(storage, LEGACY_HIDDEN_PLUGIN_NAV_PANELS_STORAGE_KEY);
+  return Array.isArray(value) ? value : null;
+}
+
+function isLegacyAutomationsPanelKey(value: unknown): value is string {
+  return (
+    typeof value === "string" && value.startsWith(`${AUTOMATIONS_PLUGIN_ID}/`)
+  );
+}
+
+function consumeOwnedLegacyHiddenKeys(
+  storage: SidebarItemMigrationStorage,
+  legacyHiddenKeys: readonly unknown[] | null,
+): void {
+  if (legacyHiddenKeys === null) return;
+  const remaining = legacyHiddenKeys.filter(
+    (key) =>
+      key !== LEGACY_EXTENSIONS_NAV_ROW_KEY &&
+      !isLegacyAutomationsPanelKey(key),
+  );
+  if (remaining.length === 0) {
+    storage.removeItem(LEGACY_HIDDEN_PLUGIN_NAV_PANELS_STORAGE_KEY);
+  } else {
+    storage.setItem(
+      LEGACY_HIDDEN_PLUGIN_NAV_PANELS_STORAGE_KEY,
+      JSON.stringify(remaining),
+    );
+  }
+}
+
+function consumeLegacyBooleanPreferences(
+  storage: SidebarItemMigrationStorage,
+): void {
+  storage.removeItem(LEGACY_NEW_THREAD_VISIBLE_STORAGE_KEY);
+  storage.removeItem(LEGACY_EXTENSIONS_VISIBLE_STORAGE_KEY);
+}
+
+/**
+ * Moves the stack's two booleans and the shipped plugin-hide choices into the
+ * one top-region preference. The combined value wins once it exists, while
+ * owned legacy keys are still consumed so the plugin-page migration cannot
+ * reintroduce Automations as a traditional row.
+ */
+export function migrateLegacySidebarTopRegionItems(
+  storage: SidebarItemMigrationStorage,
+): SidebarTopRegionItemPreferences {
+  const legacyHiddenKeys = readLegacyHiddenKeys(storage);
+  const storedValue = readJson(storage, SIDEBAR_TOP_REGION_ITEMS_STORAGE_KEY);
+  if (storedValue !== undefined) {
+    const normalized = normalizeSidebarTopRegionItemPreferences(storedValue);
+    storage.setItem(
+      SIDEBAR_TOP_REGION_ITEMS_STORAGE_KEY,
+      JSON.stringify(normalized),
+    );
+    consumeOwnedLegacyHiddenKeys(storage, legacyHiddenKeys);
+    consumeLegacyBooleanPreferences(storage);
+    return normalized;
+  }
+
+  const hiddenIds: SidebarTopRegionItemId[] = [];
+  if (
+    readStoredBoolean(storage, LEGACY_NEW_THREAD_VISIBLE_STORAGE_KEY) === false
+  ) {
+    hiddenIds.push("new-thread");
+  }
+  if (
+    readStoredBoolean(storage, LEGACY_EXTENSIONS_VISIBLE_STORAGE_KEY) ===
+      false ||
+    legacyHiddenKeys?.includes(LEGACY_EXTENSIONS_NAV_ROW_KEY)
+  ) {
+    hiddenIds.push("extensions");
+  }
+  if (legacyHiddenKeys?.some(isLegacyAutomationsPanelKey)) {
+    hiddenIds.push("automations");
+  }
+
+  const migrated = normalizeSidebarTopRegionItemPreferences({
+    order: SIDEBAR_TOP_REGION_ITEM_IDS,
+    hiddenIds,
+  });
+  storage.setItem(
+    SIDEBAR_TOP_REGION_ITEMS_STORAGE_KEY,
+    JSON.stringify(migrated),
+  );
+  consumeOwnedLegacyHiddenKeys(storage, legacyHiddenKeys);
+  consumeLegacyBooleanPreferences(storage);
+  return migrated;
+}
+
+export function reorderSidebarTopRegionItems(
+  current: SidebarTopRegionItemPreferences,
+  activeId: SidebarTopRegionItemId,
+  overId: SidebarTopRegionItemId,
+): SidebarTopRegionItemPreferences {
+  const activeIndex = current.order.indexOf(activeId);
+  const overIndex = current.order.indexOf(overId);
+  if (activeIndex === -1 || overIndex === -1 || activeIndex === overIndex) {
+    return current;
+  }
+  const order = [...current.order];
+  const [moved] = order.splice(activeIndex, 1);
+  if (moved === undefined) return current;
+  order.splice(overIndex, 0, moved);
+  return { ...current, order };
+}
+
+export function setSidebarTopRegionItemVisible(
+  current: SidebarTopRegionItemPreferences,
+  id: SidebarTopRegionItemId,
+  visible: boolean,
+): SidebarTopRegionItemPreferences {
+  if (!current.order.includes(id)) return current;
+  const hiddenIds = visible
+    ? current.hiddenIds.filter((candidate) => candidate !== id)
+    : [...new Set([...current.hiddenIds, id])];
+  return { ...current, hiddenIds };
+}
+
+const jsonStorage = createJsonLocalStorage<unknown>();
+const topRegionItemStorage: SyncStorage<SidebarTopRegionItemPreferences> = {
+  getItem: (_key, initialValue) => {
+    if (typeof window === "undefined") return initialValue;
+    return migrateLegacySidebarTopRegionItems(window.localStorage);
+  },
+  setItem: (key, value) => {
+    jsonStorage.setItem(key, normalizeSidebarTopRegionItemPreferences(value));
+  },
+  removeItem: jsonStorage.removeItem,
+  subscribe: (key, callback, initialValue) =>
+    jsonStorage.subscribe?.(
+      key,
+      (value) => callback(normalizeSidebarTopRegionItemPreferences(value)),
+      initialValue,
+    ),
+};
+
+export const sidebarTopRegionItemPreferencesAtom =
+  atomWithStorage<SidebarTopRegionItemPreferences>(
+    SIDEBAR_TOP_REGION_ITEMS_STORAGE_KEY,
+    DEFAULT_SIDEBAR_TOP_REGION_ITEM_PREFERENCES,
+    topRegionItemStorage,
+    { getOnInit: true },
+  );


### PR DESCRIPTION
## Human comments

## What was wrong

The sidebar's top navigation controls had no persistent, single place to change their visibility and order, while region ordering was stored separately from the controls that edit it.

## What changed

- Add a persistent Customize icon beside sidebar history controls.
- Add the Customize menu for New thread, Search threads, Extensions, and Automations with existing drag and checkbox conventions.
- Add ordering controls for all three sidebar regions: BB controls, Plugins, and Threads.
- Preserve replacement-region behavior and migrate existing visibility and region-order preferences.
- Add focused coverage for visibility, ordering, persistence, migration, the persistent trigger, and reordering Threads.

No public or wire contracts changed.

## Screenshots

The pair uses the same dev data, route, light theme, and 1440×900 viewport.

### Before — parent head `95c409c4d`

![Before — sidebar without the persistent Customize trigger](https://github.com/user-attachments/assets/b39d31e2-86d3-4558-b4af-defb5dbb25ed)

### After — current PR head `fe144ca51`

![After — persistent Customize trigger in the sidebar top region](https://github.com/user-attachments/assets/2def4d50-b3ac-449b-b21a-a86dc5df36a5)

### After — Customize menu with Threads in Sidebar order

![After — Customize menu with BB controls, Plugins, and Threads as reorderable regions](https://github.com/user-attachments/assets/b3722b9b-e652-4a75-9019-5d59cd3c4b3b)

## How you verified

- `git diff --check`
- Chrome for Testing 151 at 1440×900 against the exact current PR-head branch web app.
- Confirmed the trigger remains visible at rest and opens the Customize menu with Threads, BB controls, and Plugins in the same reorderable list.
- Remote CI passed the required checks, app/server/package/integration tests, and Linux/macOS package smoke on the current head; iOS simulator and Node Compatibility Smoke were intentionally skipped by workflow configuration.
- Per repository policy, no CI-equivalent tests, typechecks, lint, or builds were run locally.

Fixes #

BB-Thread-ID: thr_ccffp4w2p2

> AGENT GENERATED
