### PR TITLE
Remove branch discovery from thread show

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ The mobile app is now a WebView shell around the bb web app. One implementation 
 ### CLI
 
 - `bb thread spawn --help` describes `--base-branch` correctly. Every named base is an exact Git ref.
-- `bb thread show --merge-base-branches` keeps remote branch options.
+- `bb environment branches` keeps local and remote branch choices discoverable with query and limit controls.
 - `bb plugin new` creates a scaffold with a test that runs and a correct SDK example.
 - Command help and search results honor each command's help metadata.
 

--- a/apps/cli/src/__tests__/command-output/thread-show.test.ts
+++ b/apps/cli/src/__tests__/command-output/thread-show.test.ts
@@ -248,49 +248,6 @@ describe("bb thread show command output", () => {
     });
   });
 
-  it("bb thread show lists local and remote merge-base branches", async () => {
-    const thread: domain.Thread = fixtures.makeThread({
-      id: "thread-show-merge-bases",
-      projectId: "proj-1",
-      providerId: "codex",
-      environmentId: "env-show-merge-bases",
-    });
-    const environment = fixtures.makeEnvironment({
-      id: "env-show-merge-bases",
-      projectId: "proj-1",
-      hostId: "host-1",
-    });
-    const branchGet = vi.fn(async () => ({
-      branches: ["main"],
-      branchesTruncated: false,
-      remoteBranches: ["origin/main"],
-      remoteBranchesTruncated: false,
-      selectedBranch: null,
-    }));
-    stubServerApi({
-      "v1.environments.:id.$get": vi.fn(async () => environment),
-      "v1.environments.:id.diff.branches.$get": branchGet,
-      "v1.environments.:id.pull-request.$get": vi.fn(async () => ({
-        outcome: "absent",
-      })),
-      "v1.threads.:id.$get": vi.fn(async () => thread),
-      "v1.threads.:id.timeline.$get": fixtures.makeEmptyTimelineGetMock(),
-    });
-
-    await runCommand(
-      ["thread", "show", "thread-show-merge-bases", "--merge-base-branches"],
-      register,
-    );
-
-    expect(branchGet).toHaveBeenCalledWith({
-      param: { id: "env-show-merge-bases" },
-      query: {},
-    });
-    expect(collectLogLines(vi.mocked(console.log))).toEqual(
-      expect.arrayContaining(["  main", "  origin/main"]),
-    );
-  });
-
   it("bb thread show --git-diff renders an available uncommitted diff response", async () => {
     const thread: domain.Thread = fixtures.makeThread({
       id: "thread-show-uncommitted-diff",

--- a/apps/cli/src/commands/thread/show.ts
+++ b/apps/cli/src/commands/thread/show.ts
@@ -39,7 +39,6 @@ interface ThreadShowCommandOptions {
   diffTarget?: string;
   diffSha?: string;
   diffMergeBase?: string;
-  mergeBaseBranches?: boolean;
   json?: boolean;
 }
 
@@ -74,7 +73,6 @@ interface ThreadShowJsonPayload extends ThreadStatusPayload {
   pendingTodos: ThreadTimelinePendingTodos | null;
   workStatus?: WorkspaceStatus | null;
   gitDiff?: ThreadGitDiffResponse | null;
-  mergeBaseBranches?: string[];
 }
 
 interface ThreadShowPullRequestPayload {
@@ -207,10 +205,6 @@ export function registerShowCommand(
       "--diff-merge-base <branch>",
       "Merge base branch for --diff-target branch_committed or all",
     )
-    .option(
-      "--merge-base-branches",
-      "Include available local and remote merge-base branches in output",
-    )
     .action(
       action(async (id: string | undefined, opts: ThreadShowCommandOptions) => {
         const threadId = requireThreadIdOrSelf(id, opts);
@@ -302,17 +296,6 @@ export function registerShowCommand(
           });
         }
 
-        let mergeBaseBranches: string[] | undefined;
-        if (opts.mergeBaseBranches && thread.environmentId) {
-          const branchResponse = await sdk.environments.diffBranches({
-            environmentId: thread.environmentId,
-          });
-          mergeBaseBranches = [
-            ...branchResponse.branches,
-            ...branchResponse.remoteBranches,
-          ];
-        }
-
         const fetchedPullRequest = thread.environmentId
           ? await fetchPullRequest({
               environmentId: thread.environmentId,
@@ -351,9 +334,6 @@ export function registerShowCommand(
             jsonPayload.gitDiff = fetchedGitDiff.available
               ? fetchedGitDiff.diff
               : null;
-          }
-          if (mergeBaseBranches !== undefined) {
-            jsonPayload.mergeBaseBranches = mergeBaseBranches;
           }
           outputJson(opts, jsonPayload);
           return;
@@ -411,18 +391,6 @@ export function registerShowCommand(
             }
           } else {
             console.log(`Git diff: ${fetchedGitDiff.message}`);
-          }
-        }
-
-        if (mergeBaseBranches !== undefined) {
-          console.log("");
-          if (mergeBaseBranches.length === 0) {
-            console.log("Merge-base branches: none");
-          } else {
-            console.log("Merge-base branches:");
-            for (const branch of mergeBaseBranches) {
-              console.log(`  ${branch}`);
-            }
           }
         }
       }),

--- a/packages/templates/src/templates/bb-guide-threads.md
+++ b/packages/templates/src/templates/bb-guide-threads.md
@@ -151,7 +151,6 @@ Inspecting:
     --diff-target <type>                   Diff scope: uncommitted, branch_committed, all, commit
     --diff-sha <sha>                       Commit SHA (for --diff-target commit)
     --diff-merge-base <branch>             Override merge-base branch for diff
-    --merge-base-branches                  List available local and remote merge-base branches
 
   Shows pull request status for the attached environment branch when available.
 


### PR DESCRIPTION
## Human comments

## What was wrong

`bb thread show --merge-base-branches` mixed branch discovery into thread inspection even though `bb environment branches` already owns that workflow with query, limit, local/remote results, truncation metadata, and JSON. The duplicate flag was confusing and exposed an incomplete branch-list contract.

## What changed

- Remove `--merge-base-branches` and its human/JSON output from `bb thread show`.
- Keep branch discovery under `bb environment branches`.
- Remove the stale thread-show regression and Guide entry.
- Update the current changelog to point to the environment command.
- There are no server/daemon wire changes.

## How you verified

- 39 focused CLI tests passed.
- 7 template tests passed.
- Turbo CLI and templates typechecks passed.
- `git diff --check` passed.
- Live CLI verification confirms the removed flag is rejected and `bb environment branches --query/--limit` remains available.

> AGENT GENERATED
