### PR TITLE
Add a configurable worktree branch prefix

### DIFF
--- a/apps/app/src/views/SettingsView.branch-prefix.test.tsx
+++ b/apps/app/src/views/SettingsView.branch-prefix.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen, fireEvent } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GeneralSettingsSection } from "./SettingsView";
+
+afterEach(cleanup);
+
+function renderSection(overrides?: {
+  managedBranchPrefix?: string;
+  onManagedBranchPrefixChange?: (prefix: string) => void;
+}) {
+  return render(
+    <GeneralSettingsSection
+      desktopBrowserAvailable={false}
+      managedBranchPrefix={overrides?.managedBranchPrefix ?? "bb/"}
+      managedBranchPrefixDisabled={false}
+      navigateToThreadAfterCreate={false}
+      onManagedBranchPrefixChange={
+        overrides?.onManagedBranchPrefixChange ?? vi.fn()
+      }
+      onNavigateToThreadAfterCreateChange={vi.fn()}
+      onOpenLinksInAppBrowserChange={vi.fn()}
+      onRewriteLocalhostLinksChange={vi.fn()}
+      onRichTextEditingChange={vi.fn()}
+      onSteerActiveThreadOnEnterChange={vi.fn()}
+      onStreamerModeChange={vi.fn()}
+      openLinksInAppBrowser={false}
+      rewriteLocalhostLinks={false}
+      richTextEditing={false}
+      steerActiveThreadOnEnter={false}
+      steerActiveThreadOnEnterDisabled={false}
+      streamerMode={false}
+      streamerModeDisabled={false}
+    />,
+  );
+}
+
+function branchPrefixInput() {
+  const input = screen.getByLabelText("Worktree branch prefix");
+  if (!(input instanceof HTMLInputElement)) {
+    throw new Error("Worktree branch prefix control is not an input");
+  }
+  return input;
+}
+
+describe("worktree branch prefix setting", () => {
+  it("saves a valid prefix on Enter", () => {
+    const onChange = vi.fn();
+    renderSection({ onManagedBranchPrefixChange: onChange });
+    const input = branchPrefixInput();
+    fireEvent.change(input, { target: { value: "sawyer/wt-" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onChange).toHaveBeenCalledWith("sawyer/wt-");
+  });
+
+  it("saves an empty prefix", () => {
+    const onChange = vi.fn();
+    renderSection({ onManagedBranchPrefixChange: onChange });
+    const input = branchPrefixInput();
+    fireEvent.change(input, { target: { value: "" } });
+    fireEvent.blur(input);
+    expect(onChange).toHaveBeenCalledWith("");
+  });
+
+  it("refuses an invalid prefix and restores the saved value", () => {
+    const onChange = vi.fn();
+    renderSection({ onManagedBranchPrefixChange: onChange });
+    const input = branchPrefixInput();
+    fireEvent.change(input, { target: { value: "bad prefix/" } });
+    expect(input.getAttribute("aria-invalid")).toBe("true");
+    fireEvent.blur(input);
+    expect(onChange).not.toHaveBeenCalled();
+    expect(input.value).toBe("bb/");
+  });
+
+  it("reverts the draft on Escape", () => {
+    const onChange = vi.fn();
+    renderSection({ onManagedBranchPrefixChange: onChange });
+    const input = branchPrefixInput();
+    fireEvent.change(input, { target: { value: "sawyer/" } });
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(input.value).toBe("bb/");
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/apps/app/src/views/SettingsView.stories.tsx
+++ b/apps/app/src/views/SettingsView.stories.tsx
@@ -206,6 +206,9 @@ function useSettingsStoryState() {
   const [steerActiveThreadOnEnter, setSteerActiveThreadOnEnter] =
     useState(false);
   const [streamerMode, setStreamerMode] = useState(false);
+  const [managedBranchPrefix, setManagedBranchPrefix] = useState(
+    defaultAppSettings.managedBranchPrefix,
+  );
   const [showUnhandledProviderEvents, setShowUnhandledProviderEvents] =
     useState(false);
   const [preferredAudioInputDeviceId, setPreferredAudioInputDeviceId] =
@@ -222,6 +225,7 @@ function useSettingsStoryState() {
     directoryTargetId,
     experiments,
     fileTargetId,
+    managedBranchPrefix,
     navigateToThreadAfterCreate,
     openLinksInAppBrowser,
     preferredAudioInputDeviceId,
@@ -234,6 +238,7 @@ function useSettingsStoryState() {
     setDirectoryTargetId,
     setExperiments,
     setFileTargetId,
+    setManagedBranchPrefix,
     setNavigateToThreadAfterCreate,
     setOpenLinksInAppBrowser,
     setPreferredAudioInputDeviceId,
@@ -274,6 +279,9 @@ function GeneralSettingsStory({
     <>
       <GeneralSettingsSection
         desktopBrowserAvailable={desktopBrowserAvailable}
+        managedBranchPrefix={state.managedBranchPrefix}
+        managedBranchPrefixDisabled={false}
+        onManagedBranchPrefixChange={state.setManagedBranchPrefix}
         navigateToThreadAfterCreate={state.navigateToThreadAfterCreate}
         onNavigateToThreadAfterCreateChange={
           state.setNavigateToThreadAfterCreate

--- a/apps/app/src/views/SettingsView.tsx
+++ b/apps/app/src/views/SettingsView.tsx
@@ -6,6 +6,7 @@ import {
   defaultAppSettings,
   defaultAppTheme,
   defaultExperiments,
+  managedBranchPrefixSchema,
   type AppTheme,
   type FaviconColorPreference,
   type PluginThemeMeta,
@@ -16,6 +17,7 @@ import type {
 } from "@bb/host-daemon-contract";
 import { Button } from "@bb/shared-ui/button";
 import { Icon } from "@bb/shared-ui/icon";
+import { Input } from "@bb/shared-ui/input";
 import { Switch } from "@bb/shared-ui/switch";
 import { COARSE_POINTER_ICON_SIZE_CLASS } from "@bb/shared-ui/coarse-pointer-sizing";
 import {
@@ -145,7 +147,10 @@ interface AppearanceSettingsSectionProps {
 
 interface GeneralSettingsSectionProps {
   desktopBrowserAvailable: boolean;
+  managedBranchPrefix: string;
+  managedBranchPrefixDisabled: boolean;
   navigateToThreadAfterCreate: boolean;
+  onManagedBranchPrefixChange: (prefix: string) => void;
   onNavigateToThreadAfterCreateChange: (enabled: boolean) => void;
   onOpenLinksInAppBrowserChange: (enabled: boolean) => void;
   onRewriteLocalhostLinksChange: (enabled: boolean) => void;
@@ -546,6 +551,76 @@ const FOLLOW_UP_BEHAVIOR_OPTIONS = [
   },
 ] as const;
 const STREAMER_MODE_SETTING_LABEL = "Streamer mode";
+const MANAGED_BRANCH_PREFIX_SETTING_LABEL = "Worktree branch prefix";
+const MANAGED_BRANCH_PREFIX_EXAMPLE_SLUG = "fix-login-flow-thr_ab12cd34ef";
+
+interface ManagedBranchPrefixSettingProps {
+  disabled: boolean;
+  onChange: (prefix: string) => void;
+  value: string;
+}
+
+function ManagedBranchPrefixSetting({
+  disabled,
+  onChange,
+  value,
+}: ManagedBranchPrefixSettingProps) {
+  const [draft, setDraft] = useState(value);
+  const [committedValue, setCommittedValue] = useState(value);
+  if (value !== committedValue) {
+    setCommittedValue(value);
+    setDraft(value);
+  }
+
+  const valid = managedBranchPrefixSchema.safeParse(draft).success;
+  const commit = () => {
+    if (!valid) {
+      setDraft(value);
+      return;
+    }
+    if (draft !== value) onChange(draft);
+  };
+
+  return (
+    <SettingsWithControl
+      label={MANAGED_BRANCH_PREFIX_SETTING_LABEL}
+      description={
+        valid ? (
+          `bb puts this in front of every branch it creates for a worktree, such as ${draft}${MANAGED_BRANCH_PREFIX_EXAMPLE_SLUG}. Leave it empty for no prefix.`
+        ) : (
+          <span className="text-destructive" role="alert">
+            This prefix cannot start a valid git branch name.
+          </span>
+        )
+      }
+      controlPlacement="below"
+    >
+      <Input
+        value={draft}
+        aria-label={MANAGED_BRANCH_PREFIX_SETTING_LABEL}
+        aria-invalid={!valid}
+        disabled={disabled}
+        placeholder="No prefix"
+        className={cn(
+          "h-8 font-mono text-xs",
+          !valid && "border-destructive focus-visible:ring-destructive",
+        )}
+        onChange={(event) => setDraft(event.target.value)}
+        onBlur={commit}
+        onKeyDown={(event) => {
+          if (event.key === "Enter") {
+            event.preventDefault();
+            commit();
+          }
+          if (event.key === "Escape") {
+            event.preventDefault();
+            setDraft(value);
+          }
+        }}
+      />
+    </SettingsWithControl>
+  );
+}
 
 export function AppearanceSettingsSection({
   appearance,
@@ -704,7 +779,10 @@ export function AppearanceSettingsSection({
 
 export function GeneralSettingsSection({
   desktopBrowserAvailable,
+  managedBranchPrefix,
+  managedBranchPrefixDisabled,
   navigateToThreadAfterCreate,
+  onManagedBranchPrefixChange,
   onNavigateToThreadAfterCreateChange,
   onOpenLinksInAppBrowserChange,
   onRewriteLocalhostLinksChange,
@@ -816,6 +894,12 @@ export function GeneralSettingsSection({
             aria-label={REWRITE_LOCALHOST_LINKS_SETTING_LABEL}
           />
         </SettingsWithControl>
+
+        <ManagedBranchPrefixSetting
+          value={managedBranchPrefix}
+          disabled={managedBranchPrefixDisabled}
+          onChange={onManagedBranchPrefixChange}
+        />
 
         <SettingsWithControl
           label={STREAMER_MODE_SETTING_LABEL}
@@ -1089,6 +1173,17 @@ export function SettingsView() {
       <>
         <GeneralSettingsSection
           desktopBrowserAvailable={desktopBrowserAvailable}
+          managedBranchPrefix={generalSettings.managedBranchPrefix}
+          managedBranchPrefixDisabled={
+            systemConfigQuery.data === undefined ||
+            updateGeneralSettingsMutation.isPending
+          }
+          onManagedBranchPrefixChange={(prefix) =>
+            updateGeneralSettingsMutation.mutate({
+              ...generalSettings,
+              managedBranchPrefix: prefix,
+            })
+          }
           navigateToThreadAfterCreate={navigateToThreadAfterCreate}
           openLinksInAppBrowser={openLinksInAppBrowser}
           rewriteLocalhostLinks={rewriteLocalhostLinks}

--- a/apps/server/src/services/environments/environment-provisioning-internal.ts
+++ b/apps/server/src/services/environments/environment-provisioning-internal.ts
@@ -5,6 +5,7 @@ import {
   type DbNotifier,
   type DbQueryConnection,
   type DbTransaction,
+  getAppSettings,
   getEnvironment,
   getThread,
   listStoredThreadProvisioningRowsByProvisioningId,
@@ -1036,7 +1037,10 @@ export async function dispatchManagedEnvironmentReprovision(
             });
           const branchName =
             args.environment.branchName ??
-            buildManagedBranchName({ threadId: args.threadId });
+            buildManagedBranchName({
+              branchPrefix: getAppSettings(deps.db).managedBranchPrefix,
+              threadId: args.threadId,
+            });
           const baseBranch = storedBaseBranchNameToSpec(
             args.environment.baseBranch,
           );

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/references/app-settings.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/references/app-settings.md
@@ -65,6 +65,21 @@ every window and client sees the same value.
   provider default, and the next send records that default. Select the custom
   model again after you turn streamer mode off.
 
+## Worktree branch prefix
+
+- `managedBranchPrefix` defaults to `bb/`. Set it with
+  `bb settings general managedBranchPrefix <prefix>`.
+- bb puts the prefix in front of every branch name it creates for a managed
+  worktree or a new checkout branch, so the default gives
+  `bb/fix-login-flow-thr_ab12cd34ef`.
+- A prefix does not need a trailing slash. `sawyer/wt-` gives
+  `sawyer/wt-fix-login-flow-thr_ab12cd34ef`, and an empty prefix gives
+  `fix-login-flow-thr_ab12cd34ef`.
+- bb rejects a prefix that cannot start a valid git branch name, such as one
+  with a space or a leading `-`. The maximum length is 64 characters.
+- The new prefix applies to branches bb creates after the change. It does not
+  rename an existing branch or worktree.
+
 ## Provider order and default
 
 - `providerOrder` defaults to `[]`. Set it to a JSON array of provider IDs.

--- a/apps/server/src/services/threads/thread-create-helpers.ts
+++ b/apps/server/src/services/threads/thread-create-helpers.ts
@@ -36,6 +36,7 @@ type EnvironmentProvisionCommandInitiator =
   EnvironmentProvisionCommand["initiator"];
 
 interface ManagedBranchNameArgs {
+  branchPrefix: string;
   branchSlug?: string | null;
   threadId: string;
 }
@@ -45,8 +46,8 @@ export function buildManagedBranchName(args: ManagedBranchNameArgs): string {
     ? sanitizeGeneratedBranchSlug(args.branchSlug)
     : null;
   return branchSlug
-    ? `bb/${branchSlug}-${args.threadId}`
-    : `bb/${args.threadId}`;
+    ? `${args.branchPrefix}${branchSlug}-${args.threadId}`
+    : `${args.branchPrefix}${args.threadId}`;
 }
 
 export function requirePublicProjectForThreadCreate(

--- a/apps/server/src/services/threads/thread-provisioning-environment.ts
+++ b/apps/server/src/services/threads/thread-provisioning-environment.ts
@@ -1,5 +1,6 @@
 import {
   createEnvironment,
+  getAppSettings,
   getEnvironment,
   getThread,
   type CreateEnvironmentInput,
@@ -144,6 +145,7 @@ interface BuildEnvironmentProvisionRequestArgs {
 
 interface BuildUnmanagedCheckoutArgs {
   branch: UnmanagedBranchSpec;
+  branchPrefix: string;
   context: ThreadProvisionEnvironmentProvisioningContext;
   thread: Thread;
 }
@@ -183,6 +185,7 @@ interface RequestPreparedEnvironmentProvisionArgs {
 }
 
 interface DirectUnmanagedEnvironmentPlanArgs {
+  branchPrefix: string;
   intent: DirectUnmanagedIntent;
   thread: Thread;
 }
@@ -217,6 +220,7 @@ type CheckoutUnmanagedEnvironmentProvisionResult =
   | { kind: "active-provision" };
 
 interface ManagedEnvironmentPlanArgs {
+  branchPrefix: string;
   dataDir: string;
   hostId: string;
   sourcePath: string;
@@ -710,6 +714,7 @@ function buildUnmanagedCheckout(
   return {
     kind: "new",
     name: buildManagedBranchName({
+      branchPrefix: args.branchPrefix,
       branchSlug: args.context.request.branchSlug,
       threadId: args.thread.id,
     }),
@@ -719,12 +724,14 @@ function buildUnmanagedCheckout(
 
 function buildCheckoutUnmanagedEnvironmentProvisionRequest(
   args: BuildEnvironmentProvisionRequestArgs & {
+    branchPrefix: string;
     intent: CheckoutUnmanagedIntent;
     thread: Thread;
   },
 ): EnvironmentProvisionRequest {
   const checkout = buildUnmanagedCheckout({
     branch: args.intent.branch,
+    branchPrefix: args.branchPrefix,
     context: args.context,
     thread: args.thread,
   });
@@ -758,6 +765,7 @@ function buildDirectUnmanagedEnvironmentPlan(
       const checkout = args.intent.branch
         ? buildUnmanagedCheckout({
             branch: args.intent.branch,
+            branchPrefix: args.branchPrefix,
             context,
             thread: args.thread,
           })
@@ -794,6 +802,7 @@ function buildManagedEnvironmentPlan(
     buildRequest: ({ context, environment }) => {
       const command = buildEnvironmentProvisionCommand({
         branchName: buildManagedBranchName({
+          branchPrefix: args.branchPrefix,
           branchSlug: context.request.branchSlug,
           threadId: args.thread.id,
         }),
@@ -855,6 +864,7 @@ async function resolveEnvironmentCreationPlan(
   switch (args.intent.type) {
     case "direct-unmanaged":
       return buildDirectUnmanagedEnvironmentPlan({
+        branchPrefix: getAppSettings(deps.db).managedBranchPrefix,
         intent: args.intent,
         thread: args.thread,
       });
@@ -863,6 +873,7 @@ async function resolveEnvironmentCreationPlan(
         hostId: args.intent.hostId,
       });
       return buildManagedEnvironmentPlan({
+        branchPrefix: getAppSettings(deps.db).managedBranchPrefix,
         dataDir: hostSession.dataDir,
         hostId: args.intent.hostId,
         sourcePath: args.intent.sourcePath,
@@ -891,6 +902,7 @@ function requestCheckoutUnmanagedEnvironmentProvision(
   deps: ThreadProvisionWriteDeps,
   args: RequestCheckoutUnmanagedEnvironmentProvisionArgs,
 ): CheckoutUnmanagedEnvironmentProvisionResult {
+  const branchPrefix = getAppSettings(deps.db).managedBranchPrefix;
   return deps.db.transaction(
     (tx) => {
       if (hasActiveEnvironmentProvision(args.environment)) {
@@ -926,6 +938,7 @@ function requestCheckoutUnmanagedEnvironmentProvision(
             ),
           });
       const request = buildCheckoutUnmanagedEnvironmentProvisionRequest({
+        branchPrefix,
         context,
         environment: args.environment,
         intent: args.intent,

--- a/apps/server/test/threads/generated-branch-names.test.ts
+++ b/apps/server/test/threads/generated-branch-names.test.ts
@@ -1,4 +1,11 @@
-import { createThread, getEnvironment, getThread, listEvents } from "@bb/db";
+import {
+  createThread,
+  getAppSettings,
+  getEnvironment,
+  getThread,
+  listEvents,
+  setAppSettings,
+} from "@bb/db";
 import {
   type ResolvedThreadExecutionOptions,
   systemThreadProvisioningEventDataSchema,
@@ -144,6 +151,59 @@ describe("generated managed branch names", () => {
         `bb/improve-branch-names-${thread.id}`,
       );
       expect(piAiMocks.complete).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("applies the configured managed branch prefix", async () => {
+    mockThreadMetadata({
+      branchSlug: "unrelated-slug",
+      title: "Custom Prefix Branch",
+    });
+    await withTestHarness(async (harness) => {
+      const { host } = seedHostSession(harness.deps, {
+        id: "host-custom-branch-prefix",
+      });
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.id,
+        path: "/tmp/custom-branch-prefix-project",
+      });
+      setAppSettings(harness.db, {
+        ...getAppSettings(harness.db),
+        managedBranchPrefix: "sawyer/wt-",
+      });
+
+      const response = await harness.app.request("/api/v1/threads", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          origin: "app",
+          projectId: project.id,
+          providerId: "codex",
+          model: "gpt-5",
+          input: [{ type: "text", text: "Use the configured branch prefix" }],
+          environment: {
+            type: "host",
+            hostId: host.id,
+            workspace: {
+              type: "managed-worktree",
+              baseBranch: { kind: "default" },
+            },
+          },
+        }),
+      });
+
+      expect(response.status).toBe(201);
+      const thread = threadSchema.parse(await readJson(response));
+
+      const queued = await waitForQueuedCommand(
+        harness,
+        ({ command }) => command.type === "environment.provision",
+      );
+      const managedCommand =
+        requireManagedWorktreeEnvironmentProvisionLiveCommand(queued);
+      expect(managedCommand.command.branchName).toBe(
+        `sawyer/wt-custom-prefix-branch-${thread.id}`,
+      );
     });
   });
 

--- a/apps/server/test/threads/thread-create-helpers.test.ts
+++ b/apps/server/test/threads/thread-create-helpers.test.ts
@@ -9,6 +9,7 @@ import {
   noopNotifier,
   upsertHost,
 } from "@bb/db";
+import { DEFAULT_MANAGED_BRANCH_PREFIX } from "@bb/domain";
 import { ApiError } from "../../src/errors.js";
 import {
   baseBranchSpecToStoredName,
@@ -35,14 +36,18 @@ describe("sanitizeGeneratedBranchSlug", () => {
 
 describe("buildManagedBranchName", () => {
   it("falls back to the full thread ID", () => {
-    expect(buildManagedBranchName({ threadId: "thr_abc123def456" })).toBe(
-      "bb/thr_abc123def456",
-    );
+    expect(
+      buildManagedBranchName({
+        branchPrefix: DEFAULT_MANAGED_BRANCH_PREFIX,
+        threadId: "thr_abc123def456",
+      }),
+    ).toBe("bb/thr_abc123def456");
   });
 
   it("includes a sanitized slug before the full thread ID", () => {
     expect(
       buildManagedBranchName({
+        branchPrefix: DEFAULT_MANAGED_BRANCH_PREFIX,
         branchSlug: "Fix login flow!",
         threadId: "thr_abc123def456",
       }),
@@ -52,6 +57,7 @@ describe("buildManagedBranchName", () => {
   it("falls back to the full thread ID when the slug is empty after sanitizing", () => {
     expect(
       buildManagedBranchName({
+        branchPrefix: DEFAULT_MANAGED_BRANCH_PREFIX,
         branchSlug: "!!!",
         threadId: "thr_abc123def456",
       }),
@@ -60,14 +66,42 @@ describe("buildManagedBranchName", () => {
 
   it("produces unique names for threads with the same slug", () => {
     const a = buildManagedBranchName({
+      branchPrefix: DEFAULT_MANAGED_BRANCH_PREFIX,
       branchSlug: "same task",
       threadId: "thr_abc123def456",
     });
     const b = buildManagedBranchName({
+      branchPrefix: DEFAULT_MANAGED_BRANCH_PREFIX,
       branchSlug: "same task",
       threadId: "thr_abc123xyz789",
     });
     expect(a).not.toBe(b);
+  });
+
+  it("applies a configured prefix to both branch name shapes", () => {
+    expect(
+      buildManagedBranchName({
+        branchPrefix: "sawyer/wt-",
+        branchSlug: "Fix login flow!",
+        threadId: "thr_abc123def456",
+      }),
+    ).toBe("sawyer/wt-fix-login-flow-thr_abc123def456");
+    expect(
+      buildManagedBranchName({
+        branchPrefix: "sawyer/wt-",
+        threadId: "thr_abc123def456",
+      }),
+    ).toBe("sawyer/wt-thr_abc123def456");
+  });
+
+  it("omits the prefix when it is empty", () => {
+    expect(
+      buildManagedBranchName({
+        branchPrefix: "",
+        branchSlug: "Fix login flow!",
+        threadId: "thr_abc123def456",
+      }),
+    ).toBe("fix-login-flow-thr_abc123def456");
   });
 });
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -221,6 +221,17 @@ and falls back to the provider default; the next send records that default, so
 select the custom model again after you turn streamer mode off. Set it with
 `bb settings general streamerMode <true|false>`.
 
+The "Worktree branch prefix" field in Settings → General sets the text bb puts
+in front of every branch name it creates for a managed worktree or a new
+checkout branch. It defaults to `bb/`, which produces
+`bb/fix-login-flow-thr_ab12cd34ef`. Change it to `sawyer/` to group your branches
+under your own namespace, or clear the field to create
+`fix-login-flow-thr_ab12cd34ef` with no prefix. bb rejects a prefix that cannot
+start a valid git branch name, such as one with a space or a leading `-`, and
+the prefix is at most 64 characters. The prefix applies to branches bb creates
+after you change it; it does not rename an existing branch or worktree. Set it
+with `bb settings general managedBranchPrefix <prefix>`.
+
 Settings → Providers lists every registered agent provider in picker order.
 Move a provider up or down to change the order and choose the default for new
 threads. Both are persisted preferences: `providerOrder` is the list of ids

--- a/packages/db/test/migrate.test.ts
+++ b/packages/db/test/migrate.test.ts
@@ -1604,7 +1604,8 @@ describe("migrate", () => {
         providerOrder: [],
         defaultProviderId: null,
         streamerMode: false,
-          });
+        managedBranchPrefix: "bb/",
+      });
       expect(
         db.$client
           .prepare<[], { key: string; value: string }>(
@@ -2053,7 +2054,7 @@ describe("migrate", () => {
         permissionMode: "full",
         reasoningLevel: "medium",
         serviceTier: "default",
-          waitingOn: null,
+        waitingOn: null,
         sendAt: null,
         payload: { kind: "inline" },
         systemNotice: null,
@@ -2065,7 +2066,7 @@ describe("migrate", () => {
         permissionMode: "full",
         reasoningLevel: "medium",
         serviceTier: "default",
-          waitingOn: null,
+        waitingOn: null,
         sendAt: null,
         payload: { kind: "inline" },
         systemNotice: null,
@@ -2077,7 +2078,7 @@ describe("migrate", () => {
         permissionMode: "full",
         reasoningLevel: "medium",
         serviceTier: "default",
-          waitingOn: null,
+        waitingOn: null,
         sendAt: null,
         payload: { kind: "inline" },
         systemNotice: null,

--- a/packages/domain/src/app-settings.ts
+++ b/packages/domain/src/app-settings.ts
@@ -1,4 +1,16 @@
 import { z } from "zod";
+import { isValidGitBranchName } from "./git-checkout.js";
+
+export const MANAGED_BRANCH_PREFIX_MAX_LENGTH = 64;
+
+export const DEFAULT_MANAGED_BRANCH_PREFIX = "bb/";
+
+export const managedBranchPrefixSchema = z
+  .string()
+  .max(MANAGED_BRANCH_PREFIX_MAX_LENGTH)
+  .refine((prefix) => isValidGitBranchName(`${prefix}slug-thr_id`), {
+    message: "Prefix must start a valid git branch name",
+  });
 
 export const appSettingsSchema = z
   .object({
@@ -8,6 +20,7 @@ export const appSettingsSchema = z
     providerOrder: z.array(z.string().min(1)),
     defaultProviderId: z.string().min(1).nullable(),
     streamerMode: z.boolean(),
+    managedBranchPrefix: managedBranchPrefixSchema,
   })
   .strict();
 export type AppSettings = z.infer<typeof appSettingsSchema>;
@@ -19,4 +32,5 @@ export const defaultAppSettings: AppSettings = {
   providerOrder: [],
   defaultProviderId: null,
   streamerMode: false,
+  managedBranchPrefix: DEFAULT_MANAGED_BRANCH_PREFIX,
 };

--- a/packages/domain/src/git-checkout.ts
+++ b/packages/domain/src/git-checkout.ts
@@ -15,7 +15,7 @@ const gitReservedBranchNames = new Set([
   "REVERT_HEAD",
 ]);
 
-function isValidGitBranchName(name: GitBranchNameCandidate) {
+export function isValidGitBranchName(name: GitBranchNameCandidate) {
   const components = name.split("/");
   return (
     name.length > 0 &&

--- a/packages/domain/test/app-settings.test.ts
+++ b/packages/domain/test/app-settings.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+  appSettingsSchema,
+  defaultAppSettings,
+  managedBranchPrefixSchema,
+  MANAGED_BRANCH_PREFIX_MAX_LENGTH,
+} from "../src/app-settings.js";
+
+describe("managedBranchPrefixSchema", () => {
+  it("accepts prefixes that start a valid branch name", () => {
+    for (const prefix of ["bb/", "", "sawyer/wt-", "team/bb/", "wip_"]) {
+      expect(managedBranchPrefixSchema.safeParse(prefix).success).toBe(true);
+    }
+  });
+
+  it("rejects prefixes that cannot start a valid branch name", () => {
+    for (const prefix of [
+      " bb/",
+      "bb //",
+      "-bb/",
+      "/bb/",
+      "bb//",
+      "bb../",
+      "bb:",
+      "bb~",
+      "bb\\",
+      "bb@{",
+      ".bb/",
+      "a".repeat(MANAGED_BRANCH_PREFIX_MAX_LENGTH + 1),
+    ]) {
+      expect(managedBranchPrefixSchema.safeParse(prefix).success).toBe(false);
+    }
+  });
+
+  it("defaults to the bb namespace", () => {
+    expect(defaultAppSettings.managedBranchPrefix).toBe("bb/");
+    expect(appSettingsSchema.parse(defaultAppSettings)).toEqual(
+      defaultAppSettings,
+    );
+  });
+});

--- a/packages/plugin-api-map/sdk-public-api.json
+++ b/packages/plugin-api-map/sdk-public-api.json
@@ -3,7 +3,7 @@
   "entries": {
     ".": {
       "types": "bundled-types/bb-plugin-sdk.d.ts",
-      "sha256": "68c7a753f527b17a8cef9c6f35aa28349d8b55cfdb8b508280c949b466af453f"
+      "sha256": "2cca1010915b6b3e2c409312c5e1f8bf77d29be452add4ce7bb56e3d9f492c94"
     },
     "./ai-services": {
       "types": "bundled-types/bb-plugin-sdk-ai-services.d.ts",

--- a/packages/templates/src/templates/bb-guide-customization.md
+++ b/packages/templates/src/templates/bb-guide-customization.md
@@ -100,6 +100,13 @@ it on to hide every `customModels` entry from `~/.bb/config.json` in all model
 lists (pickers, `bb provider models`, and the SDK) during a screen share. The
 entries stay in the config file.
 
+Settings → General also includes `managedBranchPrefix`, which defaults to
+`bb/`. bb puts it in front of every branch name it creates for a worktree, so
+the default gives `bb/fix-login-flow-thr_ab12cd34ef`. Set `sawyer/wt-` to get
+`sawyer/wt-fix-login-flow-thr_ab12cd34ef`, or clear it for no prefix. bb rejects
+a prefix that cannot start a valid git branch name. The new prefix applies to
+branches bb creates after the change.
+
   bb settings show
   bb settings ai-services
   bb settings general <key> <value>


### PR DESCRIPTION
## Human comments

## What was wrong

Every branch bb creates for a managed worktree or a new checkout branch was hardcoded to `bb/<slug>-<threadId>` in `buildManagedBranchName`. Nothing consumed `bb/` as a marker; it was simply a literal with no way to change it. Users who share a repository with teammates, or who want their agent branches under their own namespace, were stuck with it.

## What changed

**Setting.** `packages/domain/src/app-settings.ts` adds `managedBranchPrefix`, default `bb/`. `managedBranchPrefixSchema` validates a candidate by synthesizing a branch name from it and running the existing `isValidGitBranchName`, which is now exported from `git-checkout.ts`. Max length 64. `app_settings_values` is a key/value table, so there is no migration; the key falls back to `defaultAppSettings`.

**Server.** `buildManagedBranchName` takes an explicit `branchPrefix` instead of the literal. The three call sites (`thread-provisioning-environment.ts` ×2, `environment-provisioning-internal.ts`) resolve it once from `getAppSettings(deps.db)` at the boundary and pass the explicit value down through the provisioning plan args. The prefix does not need a trailing slash: `sawyer/wt-` gives `sawyer/wt-<slug>-<threadId>`, and an empty prefix gives `<slug>-<threadId>`. A new prefix applies to branches bb creates after the change; it renames nothing.

**UI.** A text field in Settings → General that commits on Enter or blur, reverts on Escape, previews the branch name your prefix produces, and marks an invalid prefix with a destructive border plus a `role="alert"` message. Empty shows a `No prefix` placeholder.

**Agent surfaces.** `bb settings general managedBranchPrefix <prefix>` and `sdk.system.updateGeneralSettings` both work through the existing generic settings surface with no new code. Documented in `docs/configuration.md`, the bb-cli skill reference `app-settings.md`, and the customization guide chapter.

No `HOST_DAEMON_PROTOCOL_VERSION` bump: `branchName` in `environment.provision` already carried an arbitrary branch string, and its type, requiredness, and meaning are unchanged. `AppSettings` is a published SDK type, so the new field changes `bundled-types/bb-plugin-sdk.d.ts` and `packages/plugin-api-map/sdk-public-api.json` is regenerated to match; main's own bump to `@get-bb/plugin-sdk` 0.4.35 is unpublished, so it carries this change too and no further bump is needed.

## How you verified

**Tests added** (each fails against the hardcoded literal, passes now):

- `packages/domain/test/app-settings.test.ts` — accepted and rejected prefixes, default round trip.
- `apps/app/src/views/SettingsView.branch-prefix.test.tsx` — commit on Enter, empty prefix, invalid revert on blur, Escape.
- `apps/server/test/threads/thread-create-helpers.test.ts` — configured prefix on both branch-name shapes, empty prefix.
- `apps/server/test/threads/generated-branch-names.test.ts` — sets the setting, then asserts the queued `environment.provision` command carries `sawyer/wt-custom-prefix-branch-<threadId>`.

**Commands.** `pnpm exec turbo run typecheck` 83/83. `pnpm exec turbo run test` 80/80. `node packages/plugin-sdk/scripts/check-npm-version-guard.mjs` passes at 0.4.35.

**Live end-to-end** against the dev app, with a scratch git repo as the project:

| Prefix set | Branch git actually created |
| --- | --- |
| `sawyer/wt-` | `sawyer/wt-add-a-greeting-helper-thr_ffm22h8kku` |
| `""` (empty) | `no-prefix-at-all-thr_tstep2ffyh` |

`git worktree list` confirmed a real checkout on the prefixed branch. Also verified the value round-trips through the UI and survives a reload, `/api/v1/system/config` reports it, `bb settings general managedBranchPrefix ""` works, and the CLI rejects `bad prefix/` with a named error.

The live run caught two UI defects the unit tests did not, both fixed here: the invalid state had no visual signal (the shared `Input` has no `aria-invalid` styling), and the empty-field placeholder showed `bb/`, which reads as though the field holds `bb/` when empty means no prefix.

> AGENT GENERATED
