### PR TITLE
Group non-configurable plugins in Settings

### DIFF
--- a/apps/app/.ladle/story-settings-chrome.tsx
+++ b/apps/app/.ladle/story-settings-chrome.tsx
@@ -60,6 +60,7 @@ export function SettingsStoryChrome({
         navigation={{
           activePluginId: null,
           activeSection: resolvedActiveSection,
+          otherPluginEntries: [],
           pluginEntries: [],
           sections: SETTINGS_NAV_SECTIONS,
         }}

--- a/apps/app/src/components/commands/CommandPalette.tsx
+++ b/apps/app/src/components/commands/CommandPalette.tsx
@@ -83,8 +83,9 @@ export function CommandPalette({ threadId, projectId }: CommandPaletteProps) {
     () =>
       buildPluginSettingsEntries({
         installedPlugins,
-      }),
-    [installedPlugins],
+        settingsSections: pluginSlots.settingsSections,
+      }).all,
+    [installedPlugins, pluginSlots.settingsSections],
   );
   const settingsActions = useMemo(
     () =>

--- a/apps/app/src/components/settings/SettingsSidebar.test.tsx
+++ b/apps/app/src/components/settings/SettingsSidebar.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it } from "vitest";
+import { SidebarProvider } from "@/components/ui/sidebar";
+import { SettingsSidebarContent } from "./SettingsSidebar";
+
+const configurablePlugin = {
+  icon: null,
+  id: "linear",
+  label: "Linear",
+};
+
+const otherPlugins = [
+  { icon: null, id: "disabled", label: "Disabled" },
+  { icon: null, id: "plain", label: "Plain" },
+];
+
+function renderSidebar(activePluginId: string | null = null) {
+  return render(
+    <MemoryRouter>
+      <SidebarProvider>
+        <SettingsSidebarContent
+          appRoutePath="/"
+          isResizing={false}
+          mobileHosted
+          navigation={{
+            activePluginId,
+            activeSection: activePluginId === null ? "general" : null,
+            otherPluginEntries: otherPlugins,
+            pluginEntries: [configurablePlugin],
+            sections: [],
+          }}
+          onResizeMouseDown={() => {}}
+          showTopReserve={false}
+        />
+      </SidebarProvider>
+    </MemoryRouter>,
+  );
+}
+
+afterEach(cleanup);
+
+describe("SettingsSidebarContent plugin groups", () => {
+  it("keeps configurable plugins visible and collapses other plugins", () => {
+    renderSidebar();
+
+    expect(screen.getByRole("link", { name: "Linear" })).toBeTruthy();
+    expect(screen.queryByRole("link", { name: "Disabled" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "Plain" })).toBeNull();
+
+    const disclosure = screen.getByRole("button", {
+      name: "Other installed plugins (2)",
+    });
+    expect(disclosure.getAttribute("aria-expanded")).toBe("false");
+
+    fireEvent.click(disclosure);
+
+    expect(disclosure.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByRole("link", { name: "Disabled" })).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Plain" })).toBeTruthy();
+  });
+
+  it("starts expanded when the active plugin is in the collapsed group", () => {
+    renderSidebar("disabled");
+
+    const disclosure = screen.getByRole("button", {
+      name: "Other installed plugins (2)",
+    });
+    const activePlugin = screen.getByRole("link", { name: "Disabled" });
+
+    expect(disclosure.getAttribute("aria-expanded")).toBe("true");
+    expect(activePlugin.getAttribute("aria-current")).toBe("page");
+  });
+});

--- a/apps/app/src/components/settings/SettingsSidebar.tsx
+++ b/apps/app/src/components/settings/SettingsSidebar.tsx
@@ -1,10 +1,11 @@
-import type { MouseEvent as ReactMouseEvent } from "react";
+import { useState, type MouseEvent as ReactMouseEvent } from "react";
 import { PluginIcon } from "@/components/plugin/PluginIcon";
 import {
   SectionSidebar,
   SectionSidebarIcon,
   SectionSidebarLabel,
   SectionSidebarActionRow,
+  SectionSidebarDisclosureRow,
   SectionSidebarRow,
 } from "@/components/sidebar/SectionSidebar";
 import { canOpenNativeScreen, shellOpenNative } from "@/lib/native-shell";
@@ -23,7 +24,11 @@ interface SettingsSidebarProps {
 
 type SettingsSidebarNavigation = Pick<
   SettingsNavState,
-  "activePluginId" | "activeSection" | "pluginEntries" | "sections"
+  | "activePluginId"
+  | "activeSection"
+  | "otherPluginEntries"
+  | "pluginEntries"
+  | "sections"
 >;
 
 interface SettingsSidebarContentProps extends SettingsSidebarProps {
@@ -40,7 +45,26 @@ export function SettingsSidebarContent({
   navigation,
   testIdPrefix = "settings",
 }: SettingsSidebarContentProps) {
-  const { activePluginId, activeSection, pluginEntries, sections } = navigation;
+  const {
+    activePluginId,
+    activeSection,
+    otherPluginEntries,
+    pluginEntries,
+    sections,
+  } = navigation;
+  const activePluginIsOther = otherPluginEntries.some(
+    (entry) => entry.id === activePluginId,
+  );
+  const disclosureContext = `${activePluginId ?? ""}:${activePluginIsOther}`;
+  const [otherPluginsDisclosure, setOtherPluginsDisclosure] = useState(() => ({
+    context: disclosureContext,
+    expanded: activePluginIsOther,
+  }));
+  const showOtherPlugins =
+    otherPluginsDisclosure.context === disclosureContext
+      ? otherPluginsDisclosure.expanded
+      : activePluginIsOther;
+  const hasPlugins = pluginEntries.length > 0 || otherPluginEntries.length > 0;
 
   return (
     <SectionSidebar
@@ -67,7 +91,7 @@ export function SettingsSidebarContent({
             </SectionSidebarRow>
           ))}
       </div>
-      {pluginEntries.length > 0 ? (
+      {hasPlugins ? (
         <>
           <div className="mt-4">
             <SectionSidebarLabel>Plugins</SectionSidebarLabel>
@@ -87,6 +111,38 @@ export function SettingsSidebarContent({
                 />
               </SectionSidebarRow>
             ))}
+            {otherPluginEntries.length > 0 ? (
+              <>
+                <SectionSidebarDisclosureRow
+                  expanded={showOtherPlugins}
+                  label={`Other installed plugins (${otherPluginEntries.length})`}
+                  onToggle={() =>
+                    setOtherPluginsDisclosure({
+                      context: disclosureContext,
+                      expanded: !showOtherPlugins,
+                    })
+                  }
+                />
+                {showOtherPlugins
+                  ? otherPluginEntries.map((entry) => (
+                      <SectionSidebarRow
+                        key={entry.id}
+                        active={activePluginId === entry.id}
+                        label={entry.label}
+                        to={getPluginConfigurationRoutePath({
+                          pluginId: entry.id,
+                        })}
+                      >
+                        <PluginIcon
+                          pluginId={entry.id}
+                          icon={entry.icon}
+                          className="size-4 shrink-0"
+                        />
+                      </SectionSidebarRow>
+                    ))
+                  : null}
+              </>
+            ) : null}
           </div>
         </>
       ) : null}

--- a/apps/app/src/components/settings/plugin-settings-entries.test.ts
+++ b/apps/app/src/components/settings/plugin-settings-entries.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { buildPluginSettingsEntries } from "./plugin-settings-entries";
 
 describe("buildPluginSettingsEntries", () => {
-  it("includes every installed plugin regardless of runtime configuration", () => {
+  it("separates configurable plugins while preserving the full catalog", () => {
     const installedPlugins = [
       {
         enabled: true,
@@ -33,13 +33,24 @@ describe("buildPluginSettingsEntries", () => {
         name: "Plain",
       },
     ];
-    const entries = buildPluginSettingsEntries({ installedPlugins });
+    const entries = buildPluginSettingsEntries({
+      installedPlugins,
+      settingsSections: [{ pluginId: "workflows" }],
+    });
 
-    expect(entries).toEqual([
+    expect(entries.all).toEqual([
       { icon: null, id: "disabled", label: "Disabled" },
       { icon: "linear-icon", id: "linear", label: "Linear" },
       { icon: null, id: "plain", label: "Plain" },
       { icon: null, id: "workflows", label: "workflows" },
+    ]);
+    expect(entries.configurable).toEqual([
+      { icon: "linear-icon", id: "linear", label: "Linear" },
+      { icon: null, id: "workflows", label: "workflows" },
+    ]);
+    expect(entries.other).toEqual([
+      { icon: null, id: "disabled", label: "Disabled" },
+      { icon: null, id: "plain", label: "Plain" },
     ]);
   });
 });

--- a/apps/app/src/components/settings/plugin-settings-entries.ts
+++ b/apps/app/src/components/settings/plugin-settings-entries.ts
@@ -1,7 +1,13 @@
 export interface PluginSettingsCandidate {
+  enabled: boolean;
+  hasSettings: boolean;
   icon: string | null;
   id: string;
   name: string | null;
+}
+
+interface PluginSettingsSectionOwner {
+  pluginId: string;
 }
 
 export interface PluginSettingsEntry {
@@ -12,16 +18,41 @@ export interface PluginSettingsEntry {
 
 interface BuildPluginSettingsEntriesArgs {
   installedPlugins: readonly PluginSettingsCandidate[];
+  settingsSections: readonly PluginSettingsSectionOwner[];
+}
+
+export interface PluginSettingsEntryGroups {
+  all: readonly PluginSettingsEntry[];
+  configurable: readonly PluginSettingsEntry[];
+  other: readonly PluginSettingsEntry[];
 }
 
 export function buildPluginSettingsEntries(
   args: BuildPluginSettingsEntriesArgs,
-): PluginSettingsEntry[] {
-  return args.installedPlugins
+): PluginSettingsEntryGroups {
+  const pluginsWithCustomSettings = new Set(
+    args.settingsSections.map((section) => section.pluginId),
+  );
+  const categorizedEntries = args.installedPlugins
     .map((plugin) => ({
-      id: plugin.id,
-      label: plugin.name ?? plugin.id,
-      icon: plugin.icon,
+      entry: {
+        id: plugin.id,
+        label: plugin.name ?? plugin.id,
+        icon: plugin.icon,
+      },
+      configurable:
+        plugin.enabled &&
+        (plugin.hasSettings || pluginsWithCustomSettings.has(plugin.id)),
     }))
-    .sort((left, right) => left.label.localeCompare(right.label));
+    .sort((left, right) => left.entry.label.localeCompare(right.entry.label));
+
+  return {
+    all: categorizedEntries.map(({ entry }) => entry),
+    configurable: categorizedEntries
+      .filter(({ configurable }) => configurable)
+      .map(({ entry }) => entry),
+    other: categorizedEntries
+      .filter(({ configurable }) => !configurable)
+      .map(({ entry }) => entry),
+  };
 }

--- a/apps/app/src/components/settings/settings-nav.test.tsx
+++ b/apps/app/src/components/settings/settings-nav.test.tsx
@@ -20,8 +20,7 @@ vi.mock("@/hooks/useHostDaemon", () => ({
 }));
 
 function wrapperFor(path: string, plugins: readonly InstalledPlugin[] = []) {
-  const { queryClient, wrapper: QueryWrapper } =
-    createQueryClientTestHarness();
+  const { queryClient, wrapper: QueryWrapper } = createQueryClientTestHarness();
   queryClient.setQueryData(pluginListQueryKey(true), plugins);
   return function Wrapper({ children }: { children: ReactNode }) {
     return (
@@ -122,12 +121,13 @@ describe("useSettingsNavState", () => {
     );
   });
 
-  it("keeps a disabled plugin reachable after its settings metadata unloads", () => {
+  it("keeps a disabled plugin reachable in the secondary plugin group", () => {
     const { result } = renderHook(() => useSettingsNavState(), {
       wrapper: wrapperFor("/settings", [disabledPlugin()]),
     });
 
-    expect(result.current.pluginEntries).toEqual([
+    expect(result.current.pluginEntries).toEqual([]);
+    expect(result.current.otherPluginEntries).toEqual([
       { icon: null, id: "linear", label: "Linear" },
     ]);
   });

--- a/apps/app/src/components/settings/settings-nav.tsx
+++ b/apps/app/src/components/settings/settings-nav.tsx
@@ -23,6 +23,7 @@ export interface SettingsNavState {
   activeSection: SettingsSectionId | null;
   hasUnknownSection: boolean;
   activePluginId: string | null;
+  otherPluginEntries: readonly PluginSettingsEntry[];
   pluginEntries: readonly PluginSettingsEntry[];
   sections: readonly SettingsNavSection[];
 }
@@ -48,7 +49,7 @@ export function useSettingsNavSections(
 
 export function useSettingsNavState(): SettingsNavState {
   const location = useLocation();
-  const { fileOpeners } = usePluginSlots();
+  const { fileOpeners, settingsSections } = usePluginSlots();
   const sections = useSettingsNavSections(fileOpeners);
   const pluginListQuery = usePluginList({ enabled: true });
 
@@ -76,15 +77,17 @@ export function useSettingsNavState(): SettingsNavState {
           : "general";
 
   const installedPlugins = pluginListQuery.data?.plugins ?? [];
-  const pluginEntries = buildPluginSettingsEntries({
+  const pluginEntryGroups = buildPluginSettingsEntries({
     installedPlugins,
+    settingsSections,
   });
 
   return {
     activePluginId,
     activeSection,
     hasUnknownSection,
-    pluginEntries,
+    otherPluginEntries: pluginEntryGroups.other,
+    pluginEntries: pluginEntryGroups.configurable,
     sections,
   };
 }

--- a/apps/app/src/components/sidebar/SectionSidebar.tsx
+++ b/apps/app/src/components/sidebar/SectionSidebar.tsx
@@ -93,6 +93,40 @@ export function SectionSidebarActionRow({
   );
 }
 
+export function SectionSidebarDisclosureRow({
+  expanded,
+  label,
+  onToggle,
+}: {
+  expanded: boolean;
+  label: string;
+  onToggle: () => void;
+}) {
+  return (
+    <Button
+      type="button"
+      size="sm"
+      variant="ghost"
+      aria-expanded={expanded}
+      className={cn(
+        PROJECT_LIST_ACTION_BUTTON_CLASS,
+        "w-full text-subtle-foreground/75",
+      )}
+      onClick={onToggle}
+    >
+      <Icon
+        name="ChevronRight"
+        className={cn(
+          "size-3 shrink-0 transition-transform duration-150",
+          expanded && "rotate-90",
+        )}
+        aria-hidden="true"
+      />
+      <span className="min-w-0 flex-1 truncate text-left">{label}</span>
+    </Button>
+  );
+}
+
 export function SectionSidebarLabel({ children }: { children: ReactNode }) {
   return (
     <div


### PR DESCRIPTION
## Human comments

## What was wrong

Settings navigation listed every installed plugin at the same level after plugin lifecycle pages were broadened to keep disabled plugins reachable. The flat list no longer distinguished plugins with currently available configuration from disabled plugins or enabled plugins without declarative or custom settings, so the sidebar became noisy even though many destinations contained only lifecycle controls and plugin details.

## What changed

- Partition plugin settings destinations into configurable and other installed groups. Enabled plugins with declarative fields or a registered custom settings section remain directly visible.
- Place disabled plugins and enabled plugins without available configuration under a collapsed Other installed plugins row, and automatically reveal that group when it contains the active route.
- Keep the complete installed-plugin catalog in Cmd-K so every lifecycle page remains searchable and reachable.
- Add focused classification and sidebar disclosure coverage, including active-route expansion.
- No host-daemon wire contract, server API contract, public Plugin SDK API, CLI, guide, or protocol version changed.

## How you verified

- pnpm exec turbo run test --filter=@bb/app -- --run src/components/settings/plugin-settings-entries.test.ts src/components/settings/SettingsSidebar.test.tsx src/components/settings/settings-nav.test.tsx src/components/commands/CommandPalette.test.tsx — 4 files passed, 29 tests passed.
- pnpm exec turbo run typecheck --filter=@bb/app — passed.
- pnpm exec turbo run lint --filter=@bb/app — passed with 0 errors and 174 existing warnings.
- pnpm exec oxfmt --check apps/app/.ladle/story-settings-chrome.tsx apps/app/src/components/commands/CommandPalette.tsx apps/app/src/components/settings/SettingsSidebar.test.tsx apps/app/src/components/settings/SettingsSidebar.tsx apps/app/src/components/settings/plugin-settings-entries.test.ts apps/app/src/components/settings/plugin-settings-entries.ts apps/app/src/components/settings/settings-nav.test.tsx apps/app/src/components/settings/settings-nav.tsx apps/app/src/components/sidebar/SectionSidebar.tsx — passed for all 9 authored files.
- git diff --check — passed.

> AGENT GENERATED