### PR TITLE
fix: make turn-start queue wake race-safe

### DIFF
--- a/apps/server/src/services/threads/dispatch-attempt.ts
+++ b/apps/server/src/services/threads/dispatch-attempt.ts
@@ -333,7 +333,19 @@ async function runDispatchAttempt(
     resolveDispatchAttemptKind(currentThread, payload.mode) === "join-turn" &&
     getActiveTurnId(deps, thread.id) === null
   ) {
-    return waitOn({ kind: "turn-starting" }, null);
+    const outcome = deps.db.transaction(
+      (tx) => {
+        const lockedThread = getThread(tx, thread.id);
+        if (!lockedThread) return null;
+        if (lockedThread.status !== "active") {
+          return waitOn({ kind: "thread-busy" }, null);
+        }
+        if (getActiveTurnId({ db: tx }, thread.id) !== null) return null;
+        return waitOn({ kind: "turn-starting" }, null);
+      },
+      { behavior: "immediate" },
+    );
+    if (outcome !== null) return outcome;
   }
   if (!firstDispatch && isPreStartThreadStatus(thread.status)) {
     // A follow-up or steer sent while the workspace is being (re)provisioned.

--- a/apps/server/src/services/threads/dispatch-attempt.ts
+++ b/apps/server/src/services/threads/dispatch-attempt.ts
@@ -40,6 +40,7 @@ import {
 import {
   recordQueuedMessageWait,
   settleQueueRowDispatched,
+  type QueuedDispatchMessage,
 } from "./queue-waits.js";
 import { applyLoggedThreadLifecycleEventInTransaction } from "./lifecycle-outcome.js";
 import { buildExecutionOptions } from "./thread-commands.js";
@@ -61,6 +62,7 @@ import {
 } from "./thread-runtime-display.js";
 import { toThreadQueuedMessage } from "./thread-queued-messages.js";
 import { isPreStartThreadStatus } from "./thread-status.js";
+import { queueInputForStartingTurn } from "./thread-turn-starting.js";
 import {
   ensureThreadIsWritable,
   resolveMessageSenderThreadId,
@@ -280,6 +282,13 @@ async function runDispatchAttempt(
     args.executionDefaults ?? { threadId: thread.id },
   );
   const resolvedPayload = resolveExecutionIntoPayload(payload, execution);
+  const queuedMessage: QueuedDispatchMessage = {
+    input: payload.input,
+    execution,
+    senderThreadId,
+    payload: args.queuePayload,
+    systemNotice: null,
+  };
 
   const waitOn = (
     waitingOn: QueuedMessageWaitingOn,
@@ -287,15 +296,7 @@ async function runDispatchAttempt(
   ): DispatchAttemptOutcome => {
     const entry = recordQueuedMessageWait(deps, {
       thread,
-      message: {
-        input: payload.input,
-        execution,
-        senderThreadId,
-        payload: args.queuePayload,
-        // Only core queues a system notice, and it does so directly rather
-        // than through a send request, so an attempt never carries one.
-        systemNotice: null,
-      },
+      message: queuedMessage,
       waitingOn,
       sendAt,
       claimed,
@@ -320,7 +321,11 @@ async function runDispatchAttempt(
     if (payload.mode === "start") {
       // `start` asks for a FRESH turn specifically, so a running one is a
       // conflict rather than something to wait behind. Unchanged 409.
-      throwThreadNotWritable(thread, "already_active", "Thread is already active");
+      throwThreadNotWritable(
+        thread,
+        "already_active",
+        "Thread is already active",
+      );
     }
     return waitOn({ kind: "thread-busy" }, null);
   }
@@ -333,19 +338,21 @@ async function runDispatchAttempt(
     resolveDispatchAttemptKind(currentThread, payload.mode) === "join-turn" &&
     getActiveTurnId(deps, thread.id) === null
   ) {
-    const outcome = deps.db.transaction(
-      (tx) => {
-        const lockedThread = getThread(tx, thread.id);
-        if (!lockedThread) return null;
-        if (lockedThread.status !== "active") {
-          return waitOn({ kind: "thread-busy" }, null);
-        }
-        if (getActiveTurnId({ db: tx }, thread.id) !== null) return null;
-        return waitOn({ kind: "turn-starting" }, null);
-      },
-      { behavior: "immediate" },
-    );
-    if (outcome !== null) return outcome;
+    const outcome = queueInputForStartingTurn(deps, {
+      claimed,
+      fallbackWaitingOn: { kind: "thread-busy" },
+      input: queuedMessage,
+      threadId: thread.id,
+    });
+    if (outcome.kind === "queued" || outcome.kind === "dispatched") {
+      return outcome;
+    }
+    if (outcome.kind === "thread-changed") {
+      if (outcome.thread === null) {
+        throw new ApiError(404, "thread_not_found", "Thread not found");
+      }
+      ensureThreadIsWritable(outcome.thread);
+    }
   }
   if (!firstDispatch && isPreStartThreadStatus(thread.status)) {
     // A follow-up or steer sent while the workspace is being (re)provisioned.

--- a/apps/server/src/services/threads/parent-system-messages.ts
+++ b/apps/server/src/services/threads/parent-system-messages.ts
@@ -245,9 +245,11 @@ async function queueActiveParentSystemMessage(
 ): Promise<boolean> {
   const expectedSteerTurnId = getActiveTurnId(deps, args.thread.id);
   if (expectedSteerTurnId === null) {
-    const queued = queueInputForStartingTurn(deps, {
+    const outcome = queueInputForStartingTurn(deps, {
+      claimed: null,
+      fallbackWaitingOn: null,
       input: {
-        content: args.input,
+        input: args.input,
         execution: args.execution,
         payload: { kind: "inline" },
         senderThreadId: null,
@@ -258,20 +260,24 @@ async function queueActiveParentSystemMessage(
       },
       threadId: args.thread.id,
     });
-    if (queued) return true;
-    const currentThread = getThread(deps.db, args.thread.id);
-    if (
-      !currentThread ||
-      currentThread.archivedAt !== null ||
-      currentThread.deletedAt !== null
-    ) {
-      return false;
-    }
-    if (currentThread.status !== "active") {
-      return queueReadyParentSystemMessage(deps, {
-        ...args,
-        thread: currentThread,
-      });
+    if (outcome.kind === "queued") return true;
+    if (outcome.kind === "dispatched") return false;
+    if (outcome.kind === "thread-changed") {
+      const currentThread = outcome.thread;
+      if (
+        currentThread === null ||
+        currentThread.archivedAt !== null ||
+        currentThread.deletedAt !== null ||
+        currentThread.status === "stopping"
+      ) {
+        return false;
+      }
+      if (currentThread.status !== "active") {
+        return queueReadyParentSystemMessage(deps, {
+          ...args,
+          thread: currentThread,
+        });
+      }
     }
   }
   const permissionEscalation = resolvePermissionEscalation({
@@ -431,9 +437,13 @@ export async function queueParentSystemMessage(
     // queues on the thread's queue like every other blocked dispatch, carrying
     // its own taxonomy so the turn it eventually becomes is the same turn it
     // would have been a moment earlier.
-    const execution = await buildExecutionOptions(deps, {}, {
-      threadId: parentThread.id,
-    });
+    const execution = await buildExecutionOptions(
+      deps,
+      {},
+      {
+        threadId: parentThread.id,
+      },
+    );
     createQueuedThreadMessage(deps.db, deps.hub, {
       threadId: parentThread.id,
       content: args.input,

--- a/apps/server/src/services/threads/parent-system-messages.ts
+++ b/apps/server/src/services/threads/parent-system-messages.ts
@@ -245,7 +245,7 @@ async function queueActiveParentSystemMessage(
 ): Promise<boolean> {
   const expectedSteerTurnId = getActiveTurnId(deps, args.thread.id);
   if (expectedSteerTurnId === null) {
-    queueInputForStartingTurn(deps, {
+    const queued = queueInputForStartingTurn(deps, {
       input: {
         content: args.input,
         execution: args.execution,
@@ -258,7 +258,21 @@ async function queueActiveParentSystemMessage(
       },
       threadId: args.thread.id,
     });
-    return true;
+    if (queued) return true;
+    const currentThread = getThread(deps.db, args.thread.id);
+    if (
+      !currentThread ||
+      currentThread.archivedAt !== null ||
+      currentThread.deletedAt !== null
+    ) {
+      return false;
+    }
+    if (currentThread.status !== "active") {
+      return queueReadyParentSystemMessage(deps, {
+        ...args,
+        thread: currentThread,
+      });
+    }
   }
   const permissionEscalation = resolvePermissionEscalation({
     initiator: "system",

--- a/apps/server/src/services/threads/queue-waits.ts
+++ b/apps/server/src/services/threads/queue-waits.ts
@@ -3,6 +3,9 @@ import {
   createQueuedThreadMessageInTransaction,
   requeueClaimedQueuedThreadMessages,
   type ClaimedQueuedThreadMessageRow,
+  type DbConnection,
+  type DbNotifier,
+  type DbQueryConnection,
   type QueuedThreadMessageRow,
 } from "@bb/db";
 import type {
@@ -14,14 +17,13 @@ import type {
   Thread,
   ThreadQueuedMessage,
 } from "@bb/domain";
-import type { AppDeps } from "../../types.js";
 import {
   emitPluginMessageDispatched,
   emitPluginMessageQueued,
 } from "../plugins/plugin-thread-events.js";
 import { toThreadQueuedMessage } from "./thread-queued-messages.js";
 
-type QueueWaitDeps = Pick<AppDeps, "db" | "hub">;
+type QueueWaitDeps = { db: DbQueryConnection; hub: DbNotifier };
 
 /**
  * A settling row, for the plugin event its transition raises.
@@ -139,7 +141,7 @@ export function settleQueueRowDispatched(args: SettleQueueRowArgs): void {
  * where it is in the queue; only its eligibility changes.
  */
 export function clearQueuedMessageWait(
-  deps: QueueWaitDeps,
+  deps: { db: DbConnection; hub: DbNotifier },
   args: { queuedMessageId: string; threadId: string },
 ): QueuedThreadMessageRow | null {
   return clearQueuedThreadMessageWaitingOn(deps.db, deps.hub, {

--- a/apps/server/src/services/threads/thread-turn-starting.ts
+++ b/apps/server/src/services/threads/thread-turn-starting.ts
@@ -7,6 +7,7 @@ import type {
 } from "@bb/domain";
 import type { AppDeps } from "../../types.js";
 import { emitPluginMessageQueued } from "../plugins/plugin-thread-events.js";
+import { getActiveTurnId } from "./thread-events.js";
 import { toThreadQueuedMessage } from "./thread-queued-messages.js";
 
 interface TurnStartingQueuedInput {
@@ -22,12 +23,19 @@ type TurnStartingDeps = Pick<AppDeps, "db" | "hub" | "logger">;
 export function queueInputForStartingTurn(
   deps: TurnStartingDeps,
   args: { input: TurnStartingQueuedInput; threadId: string },
-): void {
-  if (args.input.content.length === 0) return;
+): boolean {
+  if (args.input.content.length === 0) return false;
   const queued = deps.db.transaction(
     (tx) => {
       const thread = getThread(tx, args.threadId);
-      if (!thread || thread.deletedAt !== null) return null;
+      if (
+        !thread ||
+        thread.status !== "active" ||
+        thread.deletedAt !== null ||
+        getActiveTurnId({ db: tx }, args.threadId) !== null
+      ) {
+        return null;
+      }
       return createQueuedThreadMessageInTransaction(tx, {
         threadId: args.threadId,
         content: args.input.content,
@@ -44,11 +52,12 @@ export function queueInputForStartingTurn(
     },
     { behavior: "immediate" },
   );
-  if (queued === null) return;
+  if (queued === null) return false;
   emitPluginMessageQueued(toThreadQueuedMessage(queued));
   deps.hub.notifyThread(args.threadId, ["queue-changed"]);
   deps.logger.info(
     { queuedMessageId: queued.id, threadId: args.threadId },
     "Queued input until the current turn starts",
   );
+  return true;
 }

--- a/apps/server/src/services/threads/thread-turn-starting.ts
+++ b/apps/server/src/services/threads/thread-turn-starting.ts
@@ -1,63 +1,80 @@
-import { createQueuedThreadMessageInTransaction, getThread } from "@bb/db";
+import { getThread, type ClaimedQueuedThreadMessageRow } from "@bb/db";
 import type {
-  PromptInput,
-  QueuedMessagePayload,
-  QueuedMessageSystemNotice,
-  ResolvedThreadExecutionOptions,
+  QueuedMessageWaitingOn,
+  Thread,
+  ThreadQueuedMessage,
 } from "@bb/domain";
 import type { AppDeps } from "../../types.js";
-import { emitPluginMessageQueued } from "../plugins/plugin-thread-events.js";
+import { NotificationBuffer } from "../lib/notification-buffer.js";
+import {
+  recordQueuedMessageWait,
+  type QueuedDispatchMessage,
+} from "./queue-waits.js";
 import { getActiveTurnId } from "./thread-events.js";
-import { toThreadQueuedMessage } from "./thread-queued-messages.js";
-
-interface TurnStartingQueuedInput {
-  content: PromptInput[];
-  execution: ResolvedThreadExecutionOptions;
-  payload: QueuedMessagePayload;
-  senderThreadId: string | null;
-  systemNotice: QueuedMessageSystemNotice | null;
-}
 
 type TurnStartingDeps = Pick<AppDeps, "db" | "hub" | "logger">;
 
+export type QueueInputForStartingTurnResult =
+  | { kind: "continue" }
+  | { kind: "dispatched" }
+  | { kind: "queued"; entry: ThreadQueuedMessage }
+  | { kind: "thread-changed"; thread: Thread | null };
+
 export function queueInputForStartingTurn(
   deps: TurnStartingDeps,
-  args: { input: TurnStartingQueuedInput; threadId: string },
-): boolean {
-  if (args.input.content.length === 0) return false;
-  const queued = deps.db.transaction(
+  args: {
+    claimed: readonly ClaimedQueuedThreadMessageRow[] | null;
+    fallbackWaitingOn: QueuedMessageWaitingOn | null;
+    input: QueuedDispatchMessage;
+    threadId: string;
+  },
+): QueueInputForStartingTurnResult {
+  if (args.input.input.length === 0) return { kind: "dispatched" };
+  const notifications = new NotificationBuffer();
+  const outcome: QueueInputForStartingTurnResult = deps.db.transaction(
     (tx) => {
       const thread = getThread(tx, args.threadId);
       if (
         !thread ||
-        thread.status !== "active" ||
+        thread.archivedAt !== null ||
         thread.deletedAt !== null ||
-        getActiveTurnId({ db: tx }, args.threadId) !== null
+        thread.status === "stopping"
       ) {
-        return null;
+        return { kind: "thread-changed", thread };
       }
-      return createQueuedThreadMessageInTransaction(tx, {
-        threadId: args.threadId,
-        content: args.input.content,
-        senderThreadId: args.input.senderThreadId,
-        model: args.input.execution.model,
-        reasoningLevel: args.input.execution.reasoningLevel,
-        permissionMode: args.input.execution.permissionMode,
-        serviceTier: args.input.execution.serviceTier,
-        waitingOn: { kind: "turn-starting" },
-        sendAt: null,
-        payload: args.input.payload,
-        systemNotice: args.input.systemNotice,
-      });
+      const waitingOn =
+        thread.status === "active"
+          ? getActiveTurnId({ db: tx }, args.threadId) === null
+            ? { kind: "turn-starting" as const }
+            : null
+          : args.fallbackWaitingOn;
+      if (waitingOn === null) {
+        return thread.status === "active"
+          ? { kind: "continue" }
+          : { kind: "thread-changed", thread };
+      }
+      const entry = recordQueuedMessageWait(
+        { db: tx, hub: notifications },
+        {
+          thread,
+          message: args.input,
+          waitingOn,
+          sendAt: null,
+          claimed: args.claimed,
+        },
+      );
+      return entry === null
+        ? { kind: "dispatched" }
+        : { kind: "queued", entry };
     },
     { behavior: "immediate" },
   );
-  if (queued === null) return false;
-  emitPluginMessageQueued(toThreadQueuedMessage(queued));
-  deps.hub.notifyThread(args.threadId, ["queue-changed"]);
-  deps.logger.info(
-    { queuedMessageId: queued.id, threadId: args.threadId },
-    "Queued input until the current turn starts",
-  );
-  return true;
+  notifications.flushInto(deps.hub);
+  if (outcome.kind === "queued") {
+    deps.logger.info(
+      { queuedMessageId: outcome.entry.id, threadId: args.threadId },
+      "Queued input until the current turn starts",
+    );
+  }
+  return outcome;
 }

--- a/apps/server/test/threads/thread-send-dispatch.test.ts
+++ b/apps/server/test/threads/thread-send-dispatch.test.ts
@@ -14,8 +14,9 @@ import {
   type ThreadChangedMessage,
 } from "@bb/domain";
 import { groupHostDaemonEvents } from "@bb/host-daemon-contract";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { TelemetryService } from "../../src/services/system/telemetry.js";
+import * as threadEvents from "../../src/services/threads/thread-events.js";
 import { sendQueuedMessage } from "../../src/services/threads/queued-messages.js";
 import { queueParentSystemMessage } from "../../src/services/threads/parent-system-messages.js";
 import { acceptThreadSendRequest } from "../../src/services/threads/thread-send-request.js";
@@ -55,6 +56,8 @@ interface SeedIdleThreadFixtureArgs {
 interface SeedProviderThreadFixtureArgs extends SeedIdleThreadFixtureArgs {
   status?: "active" | "idle";
 }
+
+afterEach(() => vi.restoreAllMocks());
 
 function seedProviderThreadFixture(
   args: SeedProviderThreadFixtureArgs,
@@ -407,6 +410,21 @@ describe("turn-starting queue wait", () => {
           listQueuedThreadMessages(harness.db, thread.id)[0]!.waitingOn!,
         ),
       ).toEqual({ kind: "thread-busy" });
+
+      vi.spyOn(threadEvents, "getActiveTurnId").mockReturnValueOnce(null);
+      await expect(
+        acceptThreadSendRequest(harness.deps, {
+          payload: {
+            input: textInput("send after the wake scan"),
+            mode: "steer",
+            model: "gpt-5",
+            permissionMode: "full",
+            reasoningLevel: "medium",
+            serviceTier: "default",
+          },
+          thread,
+        }),
+      ).resolves.toEqual({ ok: true, delivery: "sent" });
     });
   });
 
@@ -486,6 +504,21 @@ describe("turn-starting queue wait", () => {
         }),
       ]);
       expect(listQueuedThreadMessages(harness.db, thread.id)).toEqual([]);
+
+      vi.spyOn(threadEvents, "getActiveTurnId").mockReturnValueOnce(null);
+      await expect(
+        queueParentSystemMessage(harness.deps, {
+          input,
+          parentThreadId: thread.id,
+          systemMessageKind: "child-completed",
+          systemMessageSubject: {
+            kind: "thread",
+            threadId: "child-2",
+            threadName: "Other child",
+          },
+        }),
+      ).resolves.toBe(true);
+      expect(listQueuedThreadMessages(harness.db, thread.id)).toHaveLength(0);
     });
   });
 });

--- a/apps/server/test/threads/thread-send-dispatch.test.ts
+++ b/apps/server/test/threads/thread-send-dispatch.test.ts
@@ -304,6 +304,50 @@ describe("user message telemetry", () => {
 });
 
 describe("turn-starting queue wait", () => {
+  it.each([
+    ["archive", "archived"],
+    ["delete", "deleted"],
+  ] as const)(
+    "does not queue an ordinary follow-up after %s wins before admission",
+    async (operation, reason) => {
+      await withTestHarness(async (harness) => {
+        const { thread } = seedProviderThreadFixture({
+          harness,
+          status: "active",
+          value: operation === "archive" ? 63 : 64,
+        });
+        if (operation === "archive") {
+          archiveThread(harness.db, harness.hub, thread.id);
+        } else {
+          markThreadDeleted(harness.db, harness.hub, {
+            threadId: thread.id,
+          });
+        }
+
+        await expect(
+          acceptThreadSendRequest(harness.deps, {
+            payload: {
+              input: textInput(`follow-up after ${operation}`),
+              mode: "steer",
+              model: "gpt-5",
+              permissionMode: "full",
+              reasoningLevel: "medium",
+              serviceTier: "default",
+            },
+            thread,
+          }),
+        ).rejects.toMatchObject({
+          body: {
+            code: "thread_not_writable",
+            details: { reason },
+          },
+          status: 409,
+        });
+        expect(listQueuedThreadMessages(harness.db, thread.id)).toEqual([]);
+      });
+    },
+  );
+
   it("parks a steer until turn/started and then steers it into that turn", async () => {
     await withTestHarness(async (harness) => {
       const { sessionId, thread } = seedProviderThreadFixture({
@@ -313,6 +357,16 @@ describe("turn-starting queue wait", () => {
       });
       const input = textInput("steer when ready");
       const secondInput = textInput("also steer when ready");
+      const queueChangedInTransactions: boolean[] = [];
+      const notifyThread = harness.hub.notifyThread.bind(harness.hub);
+      vi.spyOn(harness.hub, "notifyThread").mockImplementation(
+        (threadId, changes, metadata) => {
+          if (changes.includes("queue-changed")) {
+            queueChangedInTransactions.push(harness.db.$client.inTransaction);
+          }
+          notifyThread(threadId, changes, metadata);
+        },
+      );
 
       await expect(
         acceptThreadSendRequest(harness.deps, {
@@ -346,6 +400,7 @@ describe("turn-starting queue wait", () => {
         delivery: "queued",
         waitingOn: { kind: "turn-starting" },
       });
+      expect(queueChangedInTransactions).toEqual([false, false]);
       expect(
         listQueuedThreadCommands(harness, "turn.submit", thread.id),
       ).toHaveLength(0);
@@ -519,6 +574,27 @@ describe("turn-starting queue wait", () => {
         }),
       ).resolves.toBe(true);
       expect(listQueuedThreadMessages(harness.db, thread.id)).toHaveLength(0);
+    });
+  });
+
+  it("does not queue a parent notice when archive wins during preparation", async () => {
+    await withTestHarness(async (harness) => {
+      const { thread } = seedProviderThreadFixture({
+        harness,
+        status: "active",
+        value: 65,
+      });
+
+      const delivered = queueParentSystemMessage(harness.deps, {
+        input: textInput("child finished after archive"),
+        parentThreadId: thread.id,
+        systemMessageKind: "child-completed",
+        systemMessageSubject: null,
+      });
+      archiveThread(harness.db, harness.hub, thread.id);
+
+      await expect(delivered).resolves.toBe(false);
+      expect(listQueuedThreadMessages(harness.db, thread.id)).toEqual([]);
     });
   });
 });

--- a/packages/db/src/data/queued-thread-messages.ts
+++ b/packages/db/src/data/queued-thread-messages.ts
@@ -261,7 +261,7 @@ function isIdleDrainableQueuedMessage(row: QueuedThreadMessageRow): boolean {
   if (row.waitingOn === null) return true;
   try {
     const parsed = JSON.parse(row.waitingOn) as { kind?: unknown };
-    return parsed.kind === "thread-busy";
+    return parsed.kind === "thread-busy" || parsed.kind === "turn-starting";
   } catch {
     return false;
   }
@@ -1367,7 +1367,7 @@ function automaticallyDrainableQueuedThreadMessage() {
 
 /**
  * Rows the IDLE drain may claim: a row with no wait at all, or one waiting
- * only on the thread being busy — which is exactly the wait an idle thread
+ * on the thread being busy or its turn starting — waits an idle thread
  * clears.
  *
  * Every other wait belongs to a different drain and must be invisible here, or
@@ -1385,6 +1385,7 @@ function drainableQueuedThreadMessage() {
     or(
       isNull(queuedThreadMessages.waitingOn),
       sql`json_extract(${queuedThreadMessages.waitingOn}, '$.kind') = 'thread-busy'`,
+      sql`json_extract(${queuedThreadMessages.waitingOn}, '$.kind') = 'turn-starting'`,
     ),
   );
 }

--- a/packages/db/src/data/queued-thread-messages.ts
+++ b/packages/db/src/data/queued-thread-messages.ts
@@ -251,6 +251,8 @@ function partitionQueuedMessageGroups(
   return groups;
 }
 
+const IDLE_DRAINABLE_WAIT_KINDS = ["thread-busy", "turn-starting"] as const;
+
 /**
  * The JS mirror of {@link drainableQueuedThreadMessage}'s wait condition, for
  * deciding whole-group eligibility over rows already in hand. Kept next to a
@@ -261,7 +263,9 @@ function isIdleDrainableQueuedMessage(row: QueuedThreadMessageRow): boolean {
   if (row.waitingOn === null) return true;
   try {
     const parsed = JSON.parse(row.waitingOn) as { kind?: unknown };
-    return parsed.kind === "thread-busy" || parsed.kind === "turn-starting";
+    return IDLE_DRAINABLE_WAIT_KINDS.some(
+      (waitKind) => waitKind === parsed.kind,
+    );
   } catch {
     return false;
   }
@@ -1138,7 +1142,7 @@ export interface RequeueClaimedQueuedThreadMessagesArgs {
 }
 
 export function requeueClaimedQueuedThreadMessages(
-  db: DbConnection,
+  db: DbQueryConnection,
   notifier: DbNotifier,
   args: RequeueClaimedQueuedThreadMessagesArgs,
 ): QueuedThreadMessageRow | null {
@@ -1384,8 +1388,10 @@ function drainableQueuedThreadMessage() {
     automaticallyDrainableQueuedThreadMessage(),
     or(
       isNull(queuedThreadMessages.waitingOn),
-      sql`json_extract(${queuedThreadMessages.waitingOn}, '$.kind') = 'thread-busy'`,
-      sql`json_extract(${queuedThreadMessages.waitingOn}, '$.kind') = 'turn-starting'`,
+      ...IDLE_DRAINABLE_WAIT_KINDS.map(
+        (waitKind) =>
+          sql`json_extract(${queuedThreadMessages.waitingOn}, '$.kind') = ${waitKind}`,
+      ),
     ),
   );
 }

--- a/packages/db/test/data/queued-thread-messages.test.ts
+++ b/packages/db/test/data/queued-thread-messages.test.ts
@@ -516,7 +516,7 @@ describe("queued thread messages", () => {
         reasoningLevel: "medium",
         permissionMode: "full",
         serviceTier: "default",
-        waitingOn: null,
+        waitingOn: { kind: "turn-starting" },
         sendAt: null,
         payload: { kind: "inline" },
         systemNotice: null,

--- a/packages/db/test/data/queued-thread-messages.test.ts
+++ b/packages/db/test/data/queued-thread-messages.test.ts
@@ -10,6 +10,7 @@ import {
   deleteClaimedQueuedThreadMessageBatchInTransaction,
   deleteQueuedThreadMessage,
   getQueuedThreadMessage,
+  listIdleThreadsWithQueuedMessages,
   listQueuedThreadMessages,
   releaseQueuedMessageClaim,
   releaseStaleQueuedMessageClaims,
@@ -119,6 +120,31 @@ describe("queued thread messages", () => {
     });
 
     expect(listQueuedThreadMessages(db, thread.id)).toHaveLength(2);
+  });
+
+  it("lists an idle thread waiting for its turn to start", () => {
+    const { db, project } = setup();
+    const thread = createThread(db, noopNotifier, {
+      projectId: project.id,
+      providerId: "codex",
+      status: "idle",
+    });
+    createQueuedThreadMessage(db, noopNotifier, {
+      threadId: thread.id,
+      content: defaultInput,
+      model: "gpt-5",
+      reasoningLevel: "medium",
+      permissionMode: "full",
+      serviceTier: "default",
+      waitingOn: { kind: "turn-starting" },
+      sendAt: null,
+      payload: { kind: "inline" },
+      systemNotice: null,
+    });
+
+    expect(
+      listIdleThreadsWithQueuedMessages(db).map((row) => row.threadId),
+    ).toContain(thread.id);
   });
 
   it("updates queued message content without changing its identity or position", () => {


### PR DESCRIPTION
## Human comments

## What was wrong

A follow-up message sent at exactly the wrong moment during turn startup could be added after startup's only queue scan. The turn could then finish without ever seeing the message, leaving it queued forever.

The first fix still allowed archive or soft delete to win after an earlier stale read, which could strand the newly queued row on a thread the idle scan deliberately excludes. It also notified the hub while SQLite still held its writer lock.

## What changed

- Make the active-turn recheck, complete writable-thread check, and startup-wait write one immediate SQLite transaction for ordinary sends, queued retries, and parent system notices.
- Return explicit outcomes from the shared transaction helper so both callers handle state changes consistently.
- Buffer queue notifications until the outer transaction commits.
- Let idle draining recover startup-wait rows when turn settlement wins, with one shared wait-kind list for the JavaScript and SQL predicates.
- Keep the existing queue claim guard, so recovery cannot dispatch a message twice.

No host-daemon wire contract changed, so no protocol bump is required.

## How you verified

- Added ordered regressions for archive and soft delete winning before ordinary queue admission, plus archive winning during parent-notice preparation.
- Added a regression proving queue notifications happen after the SQLite transaction.
- Added a direct SQL idle-scan regression for a `turn-starting` row.
- Focused server tests: 15/15 passed.
- Focused DB tests: 31/31 passed.
- Turbo typechecks for `@bb/server` and `@bb/db`, the server build, and `git diff --check` passed after rebasing onto current `origin/main`.
- The complete GitHub CI matrix is green, including server, packages, integration, app shards, and Linux/macOS package smoke.

Follow-up to #2816.

@slopcop

> AGENT GENERATED
