### PR TITLE
Drain mixed-wait queued message groups

### DIFF
--- a/apps/server/src/internal/events.ts
+++ b/apps/server/src/internal/events.ts
@@ -41,6 +41,7 @@ import {
 import { queueChildThreadTurnNotificationBestEffort } from "../services/threads/child-thread-notifications.js";
 import { isParentNotifiableChildThread } from "../services/threads/thread-parent.js";
 import {
+  createAutomaticQueuedMessageGroupEligibility,
   runQueuedMessageAutoSendForThread,
   sendQueuedMessage,
 } from "../services/threads/queued-messages.js";
@@ -510,9 +511,16 @@ async function executeEventFollowUpBestEffort(
         });
         return;
       case "turn-starting-queued-messages":
+        const thread = getThread(deps.db, followUp.threadId);
+        if (!thread) return;
+        const isGroupEligible = createAutomaticQueuedMessageGroupEligibility(
+          deps,
+          { now: Date.now(), thread },
+        );
         for (const queuedMessageId of followUp.queuedMessageIds) {
           try {
             await sendQueuedMessage(deps, {
+              isGroupEligible,
               mode: "auto",
               queuedMessageId,
               sendNow: false,

--- a/apps/server/src/services/threads/queue-drains.ts
+++ b/apps/server/src/services/threads/queue-drains.ts
@@ -17,6 +17,7 @@ import { isDispatchRequeuedRecently } from "./dispatch-hooks.js";
 import { clearQueuedMessageWait } from "./queue-waits.js";
 import { recordQueuedMessageDrainFailure } from "./queue-drain-failure.js";
 import {
+  createAutomaticQueuedMessageGroupEligibility,
   runQueuedMessageAutoSendForThread,
   sendQueuedMessage,
 } from "./queued-messages.js";
@@ -206,7 +207,7 @@ async function dispatchDueQueuedMessage(
     // satisfied and every other wait is re-decided from scratch — including
     // the plugin pass, which is what makes a scheduled send still respect a
     // limiter at 9am rather than jumping it.
-    await attemptEligibleQueuedMessage(deps, row, now);
+    await attemptEligibleQueuedMessage(deps, row, thread, now);
   } catch (error) {
     // A background attempt has no caller left to report to, so the row carries
     // the outcome itself — as a `host-offline` wait when the machine is simply
@@ -228,14 +229,14 @@ async function dispatchDueQueuedMessage(
 async function attemptEligibleQueuedMessage(
   deps: QueueDrainDeps,
   row: QueuedMessageDispatchRef,
+  thread: NonNullable<ReturnType<typeof getThread>>,
   now: number,
 ): Promise<void> {
   await sendQueuedMessage(deps, {
-    isGroupEligible: (group) =>
-      group.every((member) =>
-        member.waitHolder !== null ||
-        (member.sendAt !== null && member.sendAt <= now),
-      ),
+    isGroupEligible: createAutomaticQueuedMessageGroupEligibility(deps, {
+      now,
+      thread,
+    }),
     mode: "auto",
     queuedMessageId: row.id,
     threadId: row.threadId,
@@ -300,7 +301,7 @@ export async function runRequestedQueueDrain(
     const thread = getThread(deps.db, row.threadId);
     if (!thread || thread.deletedAt !== null) continue;
     try {
-      await attemptEligibleQueuedMessage(deps, row, Date.now());
+      await attemptEligibleQueuedMessage(deps, row, thread, Date.now());
     } catch (error) {
       // Same posture as the due sweep: nobody is listening, so the outcome
       // lands on the row rather than propagating and stopping the walk.

--- a/apps/server/src/services/threads/queue-drains.ts
+++ b/apps/server/src/services/threads/queue-drains.ts
@@ -228,14 +228,13 @@ async function dispatchDueQueuedMessage(
 async function attemptEligibleQueuedMessage(
   deps: QueueDrainDeps,
   row: QueuedMessageDispatchRef,
-  eligibility: number | "plugin",
+  now: number,
 ): Promise<void> {
   await sendQueuedMessage(deps, {
     isGroupEligible: (group) =>
       group.every((member) =>
-        eligibility === "plugin"
-          ? member.waitHolder !== null
-          : member.sendAt !== null && member.sendAt <= eligibility,
+        member.waitHolder !== null ||
+        (member.sendAt !== null && member.sendAt <= now),
       ),
     mode: "auto",
     queuedMessageId: row.id,
@@ -301,7 +300,7 @@ export async function runRequestedQueueDrain(
     const thread = getThread(deps.db, row.threadId);
     if (!thread || thread.deletedAt !== null) continue;
     try {
-      await attemptEligibleQueuedMessage(deps, row, "plugin");
+      await attemptEligibleQueuedMessage(deps, row, Date.now());
     } catch (error) {
       // Same posture as the due sweep: nobody is listening, so the outcome
       // lands on the row rather than propagating and stopping the walk.

--- a/apps/server/src/services/threads/queued-messages.ts
+++ b/apps/server/src/services/threads/queued-messages.ts
@@ -42,7 +42,10 @@ import {
   isCommandTimeoutError,
   runtimeErrorLogFields,
 } from "../lib/error-log-fields.js";
-import { toThreadQueuedMessage } from "./thread-queued-messages.js";
+import {
+  parseStoredQueuedThreadMessageWaitingOn,
+  toThreadQueuedMessage,
+} from "./thread-queued-messages.js";
 import {
   addRequestIdToTurnSubmitCommandPayload,
   buildExecutionOptions,
@@ -56,6 +59,7 @@ import {
 } from "./deferred-first-turn-context.js";
 import { appendClientTurnEventInTransaction } from "./thread-events.js";
 import {
+  getActiveTurnId,
   getLastProviderThreadId,
   isManualCompactionActive,
 } from "./thread-events.js";
@@ -119,6 +123,39 @@ interface SendClaimedQueuedMessageForThreadArgs {
 
 interface QueuedMessageAutoSendArgs {
   threadId: string;
+}
+
+type QueuedMessageGroupEligibility = NonNullable<
+  Parameters<typeof claimQueuedThreadMessageGroup>[3]
+>;
+
+export function createAutomaticQueuedMessageGroupEligibility(
+  deps: Pick<AppDeps, "db">,
+  args: { now: number; thread: Thread },
+): QueuedMessageGroupEligibility {
+  const activeTurnId = getActiveTurnId(deps, args.thread.id);
+  return (group) =>
+    group.every((member) => {
+      if (member.failureReason !== null) return false;
+      const waitingOn = parseStoredQueuedThreadMessageWaitingOn(member);
+      switch (waitingOn?.kind) {
+        case undefined:
+        case "plugin":
+          return true;
+        case "time":
+          return member.sendAt !== null && member.sendAt <= args.now;
+        case "thread-busy":
+          return (
+            args.thread.status === "idle" || args.thread.status === "pending"
+          );
+        case "turn-starting":
+          return args.thread.status === "active" && activeTurnId !== null;
+        case "provisioning":
+        case "host-offline":
+        case "interaction":
+          return false;
+      }
+    });
 }
 
 async function requireReadyQueuedMessageEnvironment(
@@ -759,12 +796,8 @@ export async function sendNextQueuedMessageIfPresent(
   deps: LoggedPendingInteractionWorkSessionDeps,
   args: { threadId: string },
 ): Promise<boolean> {
-  if (
-    !isQueuedMessageAutoSendCandidate(
-      deps.db,
-      getThread(deps.db, args.threadId),
-    )
-  ) {
+  const initialThread = getThread(deps.db, args.threadId);
+  if (!isQueuedMessageAutoSendCandidate(deps.db, initialThread)) {
     return false;
   }
 
@@ -772,6 +805,10 @@ export async function sendNextQueuedMessageIfPresent(
     deps.db,
     deps.hub,
     args.threadId,
+    createAutomaticQueuedMessageGroupEligibility(deps, {
+      now: Date.now(),
+      thread: initialThread,
+    }),
   );
   if (!nextQueuedMessages) {
     return false;

--- a/apps/server/src/services/threads/thread-queued-messages.ts
+++ b/apps/server/src/services/threads/thread-queued-messages.ts
@@ -61,7 +61,7 @@ function parseStoredQueuedThreadMessageContent(
   return parsed.data;
 }
 
-function parseStoredQueuedThreadMessageWaitingOn(
+export function parseStoredQueuedThreadMessageWaitingOn(
   row: Pick<StoredQueuedThreadMessageRow, "id" | "threadId" | "waitingOn">,
 ): QueuedMessageWaitingOn | null {
   if (row.waitingOn === null) return null;

--- a/apps/server/test/threads/requested-queue-drain.test.ts
+++ b/apps/server/test/threads/requested-queue-drain.test.ts
@@ -140,6 +140,65 @@ describe("the requested queue drain", () => {
     });
   });
 
+  it("drains a group after its mixed plugin and timer waits clear", async () => {
+    await withTestHarness(async (harness) => {
+      vi.useFakeTimers();
+      let released = false;
+      let attempts = 0;
+      installHooks({
+        "message.dispatch": [
+          {
+            pluginId: "limiter",
+            handler: () => {
+              attempts += 1;
+              return released
+                ? ({ action: "proceed" } as const)
+                : ({ action: "wait", reason: "At capacity" } as const);
+            },
+          },
+        ],
+      });
+      const { thread } = seedRunnableThread(harness, {
+        hostId: "host-mixed-group",
+        status: "idle",
+      });
+      await acceptThreadSendRequest(harness.deps, {
+        payload: { input: textInput("plugin-held lead"), mode: "auto" },
+        thread,
+      });
+      await acceptThreadSendRequest(harness.deps, {
+        payload: {
+          input: textInput("scheduled tail"),
+          mode: "auto",
+          sendAt: Date.now() + 1_000,
+        },
+        thread,
+      });
+      const queued = listQueuedThreadMessages(harness.db, thread.id);
+      setQueuedThreadMessageGroupBoundary({
+        db: harness.db,
+        notifier: harness.deps.hub,
+        threadId: thread.id,
+        expectedGroupedPrefixQueuedMessageIds: queued.map((row) => row.id),
+        groupBoundaryQueuedMessageId: queued[1]!.id,
+      });
+      const turnsBefore = turnRequests(harness, thread.id).length;
+
+      released = true;
+      await runRequestedQueueDrain(harness.deps);
+
+      expect(attempts).toBe(1);
+      expect(listQueuedThreadMessages(harness.db, thread.id)).toHaveLength(2);
+
+      vi.advanceTimersByTime(1_000);
+      await runDueScheduledQueueSweep(harness.deps, Date.now());
+
+      expect(attempts).toBe(2);
+      expect(listQueuedThreadMessages(harness.db, thread.id)).toHaveLength(0);
+      expect(turnRequests(harness, thread.id)).toHaveLength(turnsBefore + 1);
+    });
+  });
+
   it("re-attempts a plugin-queued row once the hook lets it through", async () => {
     // The release path that replaced a plugin releasing its own wait: core
     // re-attempts, the hook re-decides, and a row that is still blocked simply

--- a/apps/server/test/threads/requested-queue-drain.test.ts
+++ b/apps/server/test/threads/requested-queue-drain.test.ts
@@ -15,6 +15,8 @@ import {
   runDueScheduledQueueSweep,
   runRequestedQueueDrain,
 } from "../../src/services/threads/queue-drains.js";
+import { applyLoggedThreadLifecycleEvent } from "../../src/services/threads/lifecycle-outcome.js";
+import { runQueuedMessageAutoSendForThread } from "../../src/services/threads/queued-messages.js";
 import { acceptThreadSendRequest } from "../../src/services/threads/thread-send-request.js";
 import { textInput } from "../helpers/prompt-input.js";
 import {
@@ -198,6 +200,93 @@ describe("the requested queue drain", () => {
       expect(turnRequests(harness, thread.id)).toHaveLength(turnsBefore + 1);
     });
   });
+
+  it.each(["plugin-first", "thread-first"] as const)(
+    "drains a plugin and thread-busy group when %s clears",
+    async (first) => {
+      await withTestHarness(async (harness) => {
+        vi.useFakeTimers();
+        let released = first === "plugin-first";
+        let attempts = 0;
+        installHooks({
+          "message.dispatch": [
+            {
+              pluginId: "limiter",
+              handler: () => {
+                attempts += 1;
+                return released
+                  ? ({ action: "proceed" } as const)
+                  : ({ action: "wait", reason: "At capacity" } as const);
+              },
+            },
+          ],
+        });
+        const { thread } = seedRunnableThread(harness, {
+          hostId: `host-plugin-thread-${first}`,
+          status: "active",
+        });
+        const pluginHeld = seedQueuedMessage(harness.deps, {
+          threadId: thread.id,
+          content: textInput("plugin-held lead"),
+          waitingOn: {
+            kind: "plugin",
+            pluginId: "limiter",
+            reason: "At capacity",
+          },
+        });
+        const threadBusy = seedQueuedMessage(harness.deps, {
+          threadId: thread.id,
+          content: textInput("thread-busy tail"),
+          waitingOn: { kind: "thread-busy" },
+        });
+        setQueuedThreadMessageGroupBoundary({
+          db: harness.db,
+          notifier: harness.deps.hub,
+          threadId: thread.id,
+          expectedGroupedPrefixQueuedMessageIds: [
+            pluginHeld.id,
+            threadBusy.id,
+          ],
+          groupBoundaryQueuedMessageId: threadBusy.id,
+        });
+        const turnsBefore = turnRequests(harness, thread.id).length;
+
+        if (first === "plugin-first") {
+          await runRequestedQueueDrain(harness.deps);
+          expect(attempts).toBe(0);
+          expect(listQueuedThreadMessages(harness.db, thread.id)).toHaveLength(
+            2,
+          );
+        }
+
+        applyLoggedThreadLifecycleEvent(harness.deps, {
+          event: { type: "run.succeeded" },
+          threadId: thread.id,
+        });
+        await runQueuedMessageAutoSendForThread(harness.deps, {
+          threadId: thread.id,
+        });
+
+        if (first === "thread-first") {
+          expect(attempts).toBe(1);
+          expect(listQueuedThreadMessages(harness.db, thread.id)).toHaveLength(
+            2,
+          );
+          await runQueuedMessageAutoSendForThread(harness.deps, {
+            threadId: thread.id,
+          });
+          expect(attempts).toBe(1);
+          released = true;
+          vi.advanceTimersByTime(1_001);
+          await runRequestedQueueDrain(harness.deps);
+        }
+
+        expect(attempts).toBe(first === "plugin-first" ? 1 : 2);
+        expect(listQueuedThreadMessages(harness.db, thread.id)).toHaveLength(0);
+        expect(turnRequests(harness, thread.id)).toHaveLength(turnsBefore + 1);
+      });
+    },
+  );
 
   it("re-attempts a plugin-queued row once the hook lets it through", async () => {
     // The release path that replaced a plugin releasing its own wait: core

--- a/apps/server/test/threads/thread-send-dispatch.test.ts
+++ b/apps/server/test/threads/thread-send-dispatch.test.ts
@@ -5,6 +5,7 @@ import {
   listEvents,
   listQueuedThreadMessages,
   markThreadDeleted,
+  setQueuedThreadMessageGroupBoundary,
 } from "@bb/db";
 import {
   changedMessageSchema,
@@ -308,8 +309,18 @@ describe("turn-starting queue wait", () => {
         status: "active",
         value: 6,
       });
+      const pluginInput = textInput("plugin-held lead");
       const input = textInput("steer when ready");
       const secondInput = textInput("also steer when ready");
+      const pluginHeld = seedQueuedMessage(harness.deps, {
+        content: pluginInput,
+        threadId: thread.id,
+        waitingOn: {
+          kind: "plugin",
+          pluginId: "limiter",
+          reason: "At capacity",
+        },
+      });
 
       await expect(
         acceptThreadSendRequest(harness.deps, {
@@ -343,6 +354,17 @@ describe("turn-starting queue wait", () => {
         delivery: "queued",
         waitingOn: { kind: "turn-starting" },
       });
+      const queued = listQueuedThreadMessages(harness.db, thread.id);
+      setQueuedThreadMessageGroupBoundary({
+        db: harness.db,
+        notifier: harness.deps.hub,
+        threadId: thread.id,
+        expectedGroupedPrefixQueuedMessageIds: [
+          pluginHeld.id,
+          queued[1]!.id,
+        ],
+        groupBoundaryQueuedMessageId: queued[1]!.id,
+      });
       expect(
         listQueuedThreadCommands(harness, "turn.submit", thread.id),
       ).toHaveLength(0);
@@ -353,6 +375,14 @@ describe("turn-starting queue wait", () => {
           waitingOn: JSON.parse(row.waitingOn!),
         })),
       ).toEqual([
+        {
+          content: pluginInput,
+          waitingOn: {
+            kind: "plugin",
+            pluginId: "limiter",
+            reason: "At capacity",
+          },
+        },
         { content: input, waitingOn: { kind: "turn-starting" } },
         { content: secondInput, waitingOn: { kind: "turn-starting" } },
       ]);
@@ -391,7 +421,7 @@ describe("turn-starting queue wait", () => {
         listQueuedThreadCommands(harness, "turn.submit", thread.id),
       ).toEqual([
         expect.objectContaining({
-          input,
+          inputGroups: [pluginInput, input],
           target: { mode: "auto", expectedTurnId: "turn-ready" },
         }),
         expect.objectContaining({

--- a/packages/db/src/data/queued-thread-messages.ts
+++ b/packages/db/src/data/queued-thread-messages.ts
@@ -891,6 +891,7 @@ export function claimNextQueuedThreadMessageGroup(
   db: DbConnection,
   notifier: DbNotifier,
   threadId: string,
+  isGroupEligible?: (rows: readonly QueuedThreadMessageRow[]) => boolean,
 ): ClaimedQueuedThreadMessageRow[] | null {
   const claimedQueuedMessages = db.transaction(
     (tx) => {
@@ -901,9 +902,14 @@ export function claimNextQueuedThreadMessageGroup(
       // behind it: the queue is a queue, not a pipeline.
       const queuedMessages = listQueuedThreadMessages(tx, threadId);
       const group =
-        partitionQueuedMessageGroups(queuedMessages).find((rows) =>
-          rows.every(isIdleDrainableQueuedMessage),
-        ) ?? null;
+        partitionQueuedMessageGroups(queuedMessages).find((rows) => {
+          if (!isGroupEligible) {
+            return rows.every(isIdleDrainableQueuedMessage);
+          }
+          return (
+            rows.some(isIdleDrainableQueuedMessage) && isGroupEligible(rows)
+          );
+        }) ?? null;
       if (group === null) {
         return null;
       }


### PR DESCRIPTION
## Human comments

## What was wrong

[The atomic grouped-queue landing](https://github.com/get-bb/bb/pull/2821) correctly stopped automatic drains from splitting a grouped prompt. The follow-up eligibility predicates were still sweep-specific, though: every member had to look plugin-held or scheduled. That stranded plugin + timer groups, and the same split model stranded plugin + core groups such as plugin + `thread-busy`, because neither the plugin sweep nor the idle drain could claim the complete group.

## What changed

Automatic drains now use one shared per-member eligibility model for plugin, timer, and core waits. A timer must be due, `thread-busy` must observe an idle/pending thread, and `turn-starting` must observe an active turn; waits released by provisioning, host reconnect, and interaction settlement retain their existing clear-and-drain paths. The triggering sweep still supplies the candidate, then the complete group is validated and claimed in one immediate transaction. The idle path additionally requires an idle-drainable member, so a standalone plugin wait is not repeatedly retried just because its thread is idle.

The result preserves atomic dispatch while allowing different members' release signals to compose in either order. Explicit Send now, retries, pacing, queue ordering, requeueing, and concurrency behavior remain intact.

There are no wire, schema, CLI, SDK, guide, or documentation contract changes, so no host-daemon protocol bump is needed.

## How you verified

Before the complete fix, the real server/DB plugin + core reproduction made zero hook attempts and left both grouped rows queued. The focused regressions also failed for both core/plugin signal orders and the grouped `turn-starting` follow-up. After the fix, both real-path reproductions empty the queue and create exactly one new turn; the focused coverage also proves a still-blocked plugin group does not churn in the idle drain.

- `pnpm exec turbo run test --filter=@bb/server -- --run test/threads/requested-queue-drain.test.ts test/threads/thread-send-dispatch.test.ts test/threads/turn-failed-retry.test.ts test/threads/queue-drain-failure.test.ts test/public/public-thread-stop-runtime.test.ts` — 49 passed
- `pnpm exec turbo run test --filter=@bb/server -- --run test/public/public-thread-data.test.ts -t "sends the contiguous lead queued-message group as one turn request"` — 1 selected test passed
- `pnpm exec turbo run test --filter=@bb/db -- --run test/data/queued-thread-messages.test.ts test/data/queued-message-waits.test.ts` — 44 passed
- `pnpm exec turbo run typecheck --filter=@bb/server --filter=@bb/db`
- `pnpm exec turbo run build --filter=@bb/server`
- Production-path server/DB plugin + timer reproduction — 1 passed after the final rebase
- Production-path server/DB plugin + core reproduction — 1 passed after the final rebase
- `git diff --check`

@slopcop

> AGENT GENERATED
