### PR TITLE
Fix side-chat interactions and mobile viewport layout

### DIFF
--- a/apps/app/src/components/layout/AppLayout.tsx
+++ b/apps/app/src/components/layout/AppLayout.tsx
@@ -1,8 +1,4 @@
-import {
-  type MouseEvent as ReactMouseEvent,
-  type Ref,
-  type ReactNode,
-} from "react";
+import { type MouseEvent as ReactMouseEvent, type ReactNode } from "react";
 import {
   useCallback,
   useEffect,
@@ -160,17 +156,13 @@ const sidebarOpenAtom = atomWithStorage<boolean>(
 );
 
 interface SidebarStateBridgeProps {
-  providerRef: Ref<HTMLDivElement>;
   children: ReactNode;
 }
 
 type SidebarResizeMouseEvent = ReactMouseEvent<HTMLDivElement>;
 type SidebarOpenChangeHandler = (open: boolean) => void;
 
-function SidebarStateBridge({
-  providerRef,
-  children,
-}: SidebarStateBridgeProps) {
+function SidebarStateBridge({ children }: SidebarStateBridgeProps) {
   const [open, setOpen] = useAtom(sidebarOpenAtom);
   const sidebarWidth = useAtomValue(sidebarWidthAtom);
   const sidebarLiveWidth = useAtomValue(sidebarLiveWidthAtom);
@@ -187,7 +179,6 @@ function SidebarStateBridge({
   });
   return (
     <SidebarProvider
-      ref={providerRef}
       width={`${sidebarLiveWidth ?? sidebarWidth}px`}
       data-testid="app-layout-root"
       open={open}
@@ -218,10 +209,7 @@ function SidebarTriggerOverlay({
     () => "closed",
   );
   const shortcut = useAppCommandShortcut("sidebar.toggle");
-  if (
-    isCompactViewport &&
-    compactSecondaryPanelPresentation !== "closed"
-  ) {
+  if (isCompactViewport && compactSecondaryPanelPresentation !== "closed") {
     return null;
   }
   const triggerProps = {
@@ -386,14 +374,12 @@ export function AppLayout({ children }: AppLayoutProps) {
   const isCompactViewport = useIsCompactViewport();
   const store = useStore();
   const contentShellRef = useRef<HTMLDivElement>(null);
-  const providerRef = useRef<HTMLDivElement>(null);
   const restoreIOSViewportOnKeyboardDismissal = useMemo(
     () => shouldRestoreIOSViewportOnKeyboardDismissal(navigator),
     [],
   );
   useMobileVisualViewportHeight(
     contentShellRef,
-    providerRef,
     isCompactViewport,
     restoreIOSViewportOnKeyboardDismissal,
   );
@@ -757,7 +743,7 @@ export function AppLayout({ children }: AppLayoutProps) {
     <ProjectActionsProvider>
       <ThreadTitleMentionResourcesProvider {...titleMentionResources}>
         <ThreadActionsProvider>
-          <SidebarStateBridge providerRef={providerRef}>
+          <SidebarStateBridge>
             <AppLayoutSidebar
               mode={
                 isGlobalSettingsView

--- a/apps/app/src/components/layout/useMobileVisualViewportHeight.test.tsx
+++ b/apps/app/src/components/layout/useMobileVisualViewportHeight.test.tsx
@@ -3,6 +3,7 @@
 import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import { useRef } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CompactSecondaryPanelShelf } from "@/components/secondary-panel/CompactSecondaryPanelShelf";
 import {
   KEYBOARD_OPEN_MIN_SHRINK_PX,
   SHELL_SAFE_AREA_BOTTOM_PROPERTY,
@@ -24,25 +25,35 @@ class FakeVisualViewport extends EventTarget implements VisualViewport {
 
 function VisualViewportShell({
   enabled,
+  portaledShelf = false,
   restoreImmediatelyOnKeyboardDismissal = true,
 }: {
   enabled: boolean;
+  portaledShelf?: boolean;
   restoreImmediatelyOnKeyboardDismissal?: boolean;
 }) {
   const shellRef = useRef<HTMLDivElement>(null);
-  const shellHeightRootRef = useRef<HTMLDivElement>(null);
   useMobileVisualViewportHeight(
     shellRef,
-    shellHeightRootRef,
     enabled,
     restoreImmediatelyOnKeyboardDismissal,
   );
   return (
-    <div ref={shellHeightRootRef} data-testid="shell-height-root">
+    <div>
       <div ref={shellRef} data-testid="shell">
         <textarea data-testid="editor" />
         <textarea data-testid="other-editor" />
       </div>
+      {portaledShelf ? (
+        <CompactSecondaryPanelShelf
+          open
+          onClose={vi.fn()}
+          presentation="full"
+          srLabel="Thread details"
+        >
+          <div />
+        </CompactSecondaryPanelShelf>
+      ) : null}
     </div>
   );
 }
@@ -130,33 +141,63 @@ afterEach(() => {
 });
 
 describe("useMobileVisualViewportHeight", () => {
+  it("publishes the corrected height where a body-portaled panel can inherit it", async () => {
+    const visualViewport = new FakeVisualViewport();
+    visualViewport.offsetTop = 0;
+    await withElementClientHeight(
+      document.body,
+      () => 560,
+      async () => {
+        await withFakeVisualViewport(visualViewport, async () => {
+          const { unmount } = render(
+            <VisualViewportShell enabled portaledShelf />,
+          );
+          const shelf = await screen.findByTestId("secondary-panel-shelf");
+
+          expect(shelf.parentElement).toBe(document.body);
+          expect(shelf.className).toContain("h-(--bb-shell-height)");
+          await waitFor(() =>
+            expect(
+              document.body.style.getPropertyValue("--bb-shell-height"),
+            ).toBe("500px"),
+          );
+
+          unmount();
+          expect(
+            document.body.style.getPropertyValue("--bb-shell-height"),
+          ).toBe("");
+        });
+      },
+    );
+  });
+
   it("keeps the app shell bottom aligned with visual viewport changes", async () => {
     const visualViewport = new FakeVisualViewport();
     await withFakeVisualViewport(visualViewport, async () => {
       const { rerender } = render(<VisualViewportShell enabled />);
       const shell = screen.getByTestId("shell");
-      const shellHeightRoot = screen.getByTestId("shell-height-root");
+      const viewportStyleRoot = document.body;
       expect(shell.style.top).toBe("20px");
       expect(shell.style.height).toBe("500px");
-      expect(shellHeightRoot.style.getPropertyValue("--bb-shell-height")).toBe(
-        "500px",
-      );
+      expect(
+        viewportStyleRoot.style.getPropertyValue("--bb-shell-height"),
+      ).toBe("500px");
 
       act(() => {
         visualViewport.height = 300;
         visualViewport.dispatchEvent(new Event("resize"));
       });
       await waitFor(() => expect(shell.style.height).toBe("300px"));
-      expect(shellHeightRoot.style.getPropertyValue("--bb-shell-height")).toBe(
-        "300px",
-      );
+      expect(
+        viewportStyleRoot.style.getPropertyValue("--bb-shell-height"),
+      ).toBe("300px");
 
       rerender(<VisualViewportShell enabled={false} />);
       expect(shell.style.top).toBe("");
       expect(shell.style.height).toBe("");
-      expect(shellHeightRoot.style.getPropertyValue("--bb-shell-height")).toBe(
-        "",
-      );
+      expect(
+        viewportStyleRoot.style.getPropertyValue("--bb-shell-height"),
+      ).toBe("");
     });
   });
 
@@ -180,12 +221,12 @@ describe("useMobileVisualViewportHeight", () => {
                 />,
               );
               const shell = screen.getByTestId("shell");
-              const shellHeightRoot = screen.getByTestId("shell-height-root");
+              const viewportStyleRoot = document.body;
               const editor = screen.getByTestId("editor");
               expect(shell.style.top).toBe("");
               expect(shell.style.height).toBe("");
               expect(
-                shellHeightRoot.style.getPropertyValue("--bb-shell-height"),
+                viewportStyleRoot.style.getPropertyValue("--bb-shell-height"),
               ).toBe("");
 
               act(() => {
@@ -195,7 +236,7 @@ describe("useMobileVisualViewportHeight", () => {
               await waitFor(() => expect(shell.style.height).toBe("500px"));
               expect(shell.style.top).toBe("0px");
               expect(
-                shellHeightRoot.style.getPropertyValue("--bb-shell-height"),
+                viewportStyleRoot.style.getPropertyValue("--bb-shell-height"),
               ).toBe("500px");
 
               act(() => {
@@ -204,7 +245,7 @@ describe("useMobileVisualViewportHeight", () => {
               });
               await waitFor(() => expect(shell.style.height).toBe(""));
               expect(
-                shellHeightRoot.style.getPropertyValue("--bb-shell-height"),
+                viewportStyleRoot.style.getPropertyValue("--bb-shell-height"),
               ).toBe("");
 
               act(() => {
@@ -214,7 +255,7 @@ describe("useMobileVisualViewportHeight", () => {
               await waitFor(() => expect(shell.style.height).toBe("300px"));
               expect(shell.style.top).toBe("0px");
               expect(
-                shellHeightRoot.style.getPropertyValue("--bb-shell-height"),
+                viewportStyleRoot.style.getPropertyValue("--bb-shell-height"),
               ).toBe("300px");
 
               act(() => editor.focus());
@@ -228,7 +269,7 @@ describe("useMobileVisualViewportHeight", () => {
               await waitFor(() => expect(shell.style.height).toBe(""));
               expect(shell.style.top).toBe("");
               expect(
-                shellHeightRoot.style.getPropertyValue("--bb-shell-height"),
+                viewportStyleRoot.style.getPropertyValue("--bb-shell-height"),
               ).toBe("");
             }),
         ),
@@ -308,10 +349,12 @@ describe("useMobileVisualViewportHeight", () => {
     visualViewport.offsetTop = 0;
     await withFakeVisualViewport(visualViewport, async () => {
       render(<VisualViewportShell enabled />);
-      const shellHeightRoot = screen.getByTestId("shell-height-root");
+      const viewportStyleRoot = document.body;
       const editor = screen.getByTestId("editor");
       expect(
-        shellHeightRoot.style.getPropertyValue(SHELL_SAFE_AREA_BOTTOM_PROPERTY),
+        viewportStyleRoot.style.getPropertyValue(
+          SHELL_SAFE_AREA_BOTTOM_PROPERTY,
+        ),
       ).toBe("");
 
       act(() => {
@@ -319,7 +362,9 @@ describe("useMobileVisualViewportHeight", () => {
       });
       await flushScheduledViewportPass();
       expect(
-        shellHeightRoot.style.getPropertyValue(SHELL_SAFE_AREA_BOTTOM_PROPERTY),
+        viewportStyleRoot.style.getPropertyValue(
+          SHELL_SAFE_AREA_BOTTOM_PROPERTY,
+        ),
       ).toBe("");
 
       act(() => {
@@ -328,7 +373,9 @@ describe("useMobileVisualViewportHeight", () => {
       });
       await flushScheduledViewportPass();
       expect(
-        shellHeightRoot.style.getPropertyValue(SHELL_SAFE_AREA_BOTTOM_PROPERTY),
+        viewportStyleRoot.style.getPropertyValue(
+          SHELL_SAFE_AREA_BOTTOM_PROPERTY,
+        ),
       ).toBe("0px");
 
       act(() => {
@@ -336,7 +383,9 @@ describe("useMobileVisualViewportHeight", () => {
       });
       await flushScheduledViewportPass();
       expect(
-        shellHeightRoot.style.getPropertyValue(SHELL_SAFE_AREA_BOTTOM_PROPERTY),
+        viewportStyleRoot.style.getPropertyValue(
+          SHELL_SAFE_AREA_BOTTOM_PROPERTY,
+        ),
       ).toBe("");
     });
   });
@@ -346,7 +395,7 @@ describe("useMobileVisualViewportHeight", () => {
     visualViewport.offsetTop = 0;
     await withFakeVisualViewport(visualViewport, async () => {
       render(<VisualViewportShell enabled />);
-      const shellHeightRoot = screen.getByTestId("shell-height-root");
+      const viewportStyleRoot = document.body;
       act(() => {
         screen.getByTestId("editor").focus();
       });
@@ -357,7 +406,9 @@ describe("useMobileVisualViewportHeight", () => {
       });
       await flushScheduledViewportPass();
       expect(
-        shellHeightRoot.style.getPropertyValue(SHELL_SAFE_AREA_BOTTOM_PROPERTY),
+        viewportStyleRoot.style.getPropertyValue(
+          SHELL_SAFE_AREA_BOTTOM_PROPERTY,
+        ),
       ).toBe("");
     });
   });
@@ -386,10 +437,10 @@ describe("useMobileVisualViewportHeight", () => {
     await withFakeVisualViewport(visualViewport, async () => {
       render(<VisualViewportShell enabled />);
       const shell = screen.getByTestId("shell");
-      const shellHeightRoot = screen.getByTestId("shell-height-root");
+      const viewportStyleRoot = document.body;
       expect(shell.style.height).toBe("500px");
       const setShellHeightProperty = vi.spyOn(
-        shellHeightRoot.style,
+        viewportStyleRoot.style,
         "setProperty",
       );
 

--- a/apps/app/src/components/layout/useMobileVisualViewportHeight.ts
+++ b/apps/app/src/components/layout/useMobileVisualViewportHeight.ts
@@ -38,15 +38,14 @@ export function isKeyboardFocusTarget(target: EventTarget | null): boolean {
 
 export function useMobileVisualViewportHeight(
   shellRef: RefObject<AppShellElement | null>,
-  shellHeightRootRef: RefObject<AppShellElement | null>,
   enabled: boolean,
   restoreImmediatelyOnKeyboardDismissal: boolean,
 ) {
   useEffect(() => {
     const shell = shellRef.current;
-    const shellHeightRoot = shellHeightRootRef.current;
     const visualViewport = window.visualViewport;
-    if (!shell || !shellHeightRoot || !enabled || !visualViewport) return;
+    if (!shell || !enabled || !visualViewport) return;
+    const viewportStyleRoot = shell.ownerDocument.body;
 
     let animationFrame: number | null = null;
     let appliedOverride: { top: number; height: number } | null = null;
@@ -58,12 +57,12 @@ export function useMobileVisualViewportHeight(
       if (open === appliedKeyboardInset) return;
       appliedKeyboardInset = open;
       if (open) {
-        shellHeightRoot.style.setProperty(
+        viewportStyleRoot.style.setProperty(
           SHELL_SAFE_AREA_BOTTOM_PROPERTY,
           "0px",
         );
       } else {
-        shellHeightRoot.style.removeProperty(SHELL_SAFE_AREA_BOTTOM_PROPERTY);
+        viewportStyleRoot.style.removeProperty(SHELL_SAFE_AREA_BOTTOM_PROPERTY);
       }
     };
     const updateKeyboardInset = () => {
@@ -84,7 +83,7 @@ export function useMobileVisualViewportHeight(
       appliedOverride = null;
       shell.style.removeProperty("top");
       shell.style.removeProperty("height");
-      shellHeightRoot.style.removeProperty("--bb-shell-height");
+      viewportStyleRoot.style.removeProperty("--bb-shell-height");
     };
     const updateHeight = () => {
       animationFrame = null;
@@ -123,7 +122,7 @@ export function useMobileVisualViewportHeight(
       appliedOverride = { top: shellTop, height: visualViewportHeight };
       shell.style.top = `${shellTop}px`;
       shell.style.height = `${visualViewportHeight}px`;
-      shellHeightRoot.style.setProperty(
+      viewportStyleRoot.style.setProperty(
         "--bb-shell-height",
         `${visualViewportHeight}px`,
       );
@@ -190,10 +189,5 @@ export function useMobileVisualViewportHeight(
       setKeyboardInset(false);
       clearViewportOverride();
     };
-  }, [
-    enabled,
-    restoreImmediatelyOnKeyboardDismissal,
-    shellHeightRootRef,
-    shellRef,
-  ]);
+  }, [enabled, restoreImmediatelyOnKeyboardDismissal, shellRef]);
 }

--- a/apps/app/src/components/promptbox/FollowUpPromptBox.stories.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.stories.tsx
@@ -772,6 +772,7 @@ function Row({
   const queueElement =
     initialQueuedMessages === undefined ? null : (
       <QueuedMessagesList
+        attachedToComposer={true}
         queuedMessages={storyQueuedMessages}
         inlineEditor={inlineEditor}
         sendDisabled={false}

--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.drag.test.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.drag.test.tsx
@@ -46,6 +46,7 @@ describe("QueuedMessagesList group-handle drag", () => {
     ];
     const { container, getByLabelText } = render(
       <QueuedMessagesList
+        attachedToComposer={true}
         queuedMessages={queuedMessages}
         sendDisabled={false}
         actionDisabled={false}

--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.stories.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.stories.tsx
@@ -350,6 +350,7 @@ function StaticQueuedMessagesList({
 }: StaticQueuedMessagesListProps) {
   return (
     <QueuedMessagesList
+      attachedToComposer={true}
       queuedMessages={queuedMessages}
       sendDisabled={sendDisabled}
       actionDisabled={actionDisabled}
@@ -386,6 +387,7 @@ function ReorderableQueuedMessagesList() {
 
   return (
     <QueuedMessagesList
+      attachedToComposer={true}
       queuedMessages={queuedMessages}
       sendDisabled={false}
       actionDisabled={false}

--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.test.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.test.tsx
@@ -12,13 +12,14 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ThreadQueuedMessage } from "@bb/domain";
 import type { Active, DroppableContainer } from "@dnd-kit/core";
 import {
-  QueuedMessagesList,
+  QueuedMessagesList as QueuedMessagesListComponent,
   clampQueuedMessageDragTransform,
   getInlineEditorSurfaceMaxHeight,
   queuedMessageCollisionDetection,
   queuedMessageSortingStrategy,
   resolveQueuedMessageDrag,
   snapGroupBoundaryDragTransform,
+  type QueuedMessagesListProps,
 } from "./QueuedMessagesList";
 import {
   QueuedEditorTypeaheadLayoutContext,
@@ -28,6 +29,20 @@ import {
 const bottomAnchorMocks = vi.hoisted(() => ({
   scrollElement: null as HTMLElement | null,
 }));
+
+function QueuedMessagesList({
+  attachedToComposer = true,
+  ...props
+}: Omit<QueuedMessagesListProps, "attachedToComposer"> & {
+  attachedToComposer?: boolean;
+}) {
+  return (
+    <QueuedMessagesListComponent
+      {...props}
+      attachedToComposer={attachedToComposer}
+    />
+  );
+}
 
 vi.mock("@/components/ui/bottom-anchored-scroll-body", () => ({
   useBottomAnchoredScroll: () =>
@@ -100,9 +115,13 @@ function rect({ top, bottom }: { top: number; bottom: number }) {
   return new DOMRect(0, top, 100, bottom - top);
 }
 
-function renderQueuedMessages(queuedMessages: readonly ThreadQueuedMessage[]) {
+function renderQueuedMessages(
+  queuedMessages: readonly ThreadQueuedMessage[],
+  attachedToComposer = true,
+) {
   return render(
     <QueuedMessagesList
+      attachedToComposer={attachedToComposer}
       queuedMessages={queuedMessages}
       sendDisabled={false}
       actionDisabled={false}
@@ -123,6 +142,7 @@ function renderQueuedMessagesWithOptions(
 ) {
   return render(
     <QueuedMessagesList
+      attachedToComposer={true}
       queuedMessages={queuedMessages}
       resolveMentionLink={options.resolveMentionLink}
       sendDisabled={false}
@@ -146,6 +166,21 @@ afterEach(() => {
 });
 
 describe("QueuedMessagesList", () => {
+  it("renders as a standalone card when it is not attached to the composer", () => {
+    const { container } = renderQueuedMessages(
+      [makeQueuedMessage("q_one", "First queued message")],
+      false,
+    );
+    const surface = container.querySelector<HTMLElement>(
+      'section[aria-label="Queued messages"]',
+    );
+
+    expect(surface?.classList.contains("mb-0")).toBe(true);
+    expect(surface?.classList.contains("-mb-5")).toBe(false);
+    expect(surface?.classList.contains("rounded-b-none")).toBe(false);
+    expect(surface?.classList.contains("border-b-0")).toBe(false);
+  });
+
   it("toggles a few messages between the fitted drawer and collapsed modes", () => {
     const { container, getByRole, getByText } = renderQueuedMessages([
       makeQueuedMessage("q_one", "First queued message"),

--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
@@ -120,6 +120,7 @@ export interface QueuedMessageInlineEditor {
 }
 
 export interface QueuedMessagesListProps {
+  attachedToComposer: boolean;
   queuedMessages: readonly ThreadQueuedMessage[];
   resolveMentionLink?: PromptMentionLinkResolver;
   sendDisabled: boolean;
@@ -1126,6 +1127,7 @@ export function QueuedMessagesPendingCard({
 }
 
 export function QueuedMessagesList({
+  attachedToComposer,
   queuedMessages,
   resolveMentionLink,
   sendDisabled,
@@ -1677,7 +1679,7 @@ export function QueuedMessagesList({
       style={{ height: surfaceHeight }}
       className={cn(
         "relative z-10 flex min-h-0 flex-col overflow-hidden bg-surface-raised-solid shadow-lift",
-        inlineEditor
+        inlineEditor || !attachedToComposer
           ? "mb-0 rounded-xl pb-4"
           : "-mb-5 rounded-xl rounded-b-none border-b-0 pb-3",
         !surfaceDragging &&

--- a/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.test.tsx
+++ b/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.test.tsx
@@ -13,11 +13,17 @@ const mocks = vi.hoisted(() => ({
   markThreadReadMutate: vi.fn(),
   onOpenLink: vi.fn(),
   onOpenLocalFileLink: vi.fn(),
-  pendingInteractions: [] as Array<{
-    id: string;
-    createdAt: number;
-    payload: { kind: string };
-  }>,
+  pendingInteractions: [] as
+    | Array<{
+        id: string;
+        createdAt: number;
+        payload: { kind: string };
+      }>
+    | undefined,
+  pendingInteractionsIsError: false,
+  pendingInteractionsIsFetching: false,
+  pendingInteractionsIsLoading: false,
+  pendingInteractionsRefetch: vi.fn(),
   queuedMessages: [] as Array<{ id: string }>,
   readTrackingThreads: [] as Array<unknown>,
   sendThreadMessageMutateAsync: vi.fn(),
@@ -66,7 +72,7 @@ vi.mock("@/components/promptbox/FollowUpPromptBox", async () => {
     }: {
       composer: Pick<
         FollowUpComposerProps,
-        "message" | "onChangeMessage" | "onSubmit"
+        "message" | "onChangeMessage" | "onSubmit" | "submitMode"
       >;
       pendingInteraction?: ReactNode;
       stack: ReactNode;
@@ -77,7 +83,15 @@ vi.mock("@/components/promptbox/FollowUpPromptBox", async () => {
         {pendingInteraction}
         <input
           data-testid="embedded-chat-composer"
-          hidden={pendingInteraction !== undefined && pendingInteraction !== null}
+          data-submit-mode={composer.submitMode.kind}
+          data-submit-reason={
+            composer.submitMode.kind === "blocked"
+              ? composer.submitMode.reason
+              : undefined
+          }
+          hidden={
+            pendingInteraction !== undefined && pendingInteraction !== null
+          }
           value={composer.message}
           onChange={(event) => composer.onChangeMessage(event.target.value, [])}
         />
@@ -225,7 +239,13 @@ vi.mock("@/hooks/queries/thread-queries", () => ({
         : undefined,
   }),
   useThreadQueuedMessages: () => ({ data: mocks.queuedMessages }),
-  useThreadPendingInteractions: () => ({ data: mocks.pendingInteractions }),
+  useThreadPendingInteractions: () => ({
+    data: mocks.pendingInteractions,
+    isError: mocks.pendingInteractionsIsError,
+    isFetching: mocks.pendingInteractionsIsFetching,
+    isLoading: mocks.pendingInteractionsIsLoading,
+    refetch: mocks.pendingInteractionsRefetch,
+  }),
   getLatestPendingInteraction: (
     interactions: readonly { createdAt: number }[] | undefined,
   ) => (interactions && interactions.length > 0 ? interactions[0] : null),
@@ -368,6 +388,10 @@ describe("EmbeddedThreadChat", () => {
     mocks.onOpenLink.mockReset();
     mocks.onOpenLocalFileLink.mockReset();
     mocks.pendingInteractions = [];
+    mocks.pendingInteractionsIsError = false;
+    mocks.pendingInteractionsIsFetching = false;
+    mocks.pendingInteractionsIsLoading = false;
+    mocks.pendingInteractionsRefetch.mockReset().mockResolvedValue({});
     mocks.queuedMessages = [];
     mocks.readTrackingThreads = [];
     mocks.threadRuntimeDisplayStatus = "idle";
@@ -553,6 +577,51 @@ describe("EmbeddedThreadChat", () => {
 
     expect(screen.queryByTestId("pending-interaction-banner")).toBeNull();
     expect(screen.getByTestId("embedded-chat-composer")).toBeTruthy();
+  });
+
+  it("keeps queued messages attached for a plugin-owned interaction", () => {
+    mocks.pendingInteractions = [
+      { id: "int_2", createdAt: 1, payload: { kind: "plugin" } },
+    ];
+    mocks.queuedMessages = [{ id: "q1" }];
+
+    renderEmbeddedChat({ threadId: "thr_side_chat" });
+
+    expect(
+      screen
+        .getByTestId("embedded-chat-queued-messages")
+        .getAttribute("data-attached-to-composer"),
+    ).toBe("true");
+  });
+
+  it("hides the composer while pending interactions are initially unknown", () => {
+    mocks.pendingInteractions = undefined;
+    mocks.pendingInteractionsIsFetching = true;
+    mocks.pendingInteractionsIsLoading = true;
+
+    renderEmbeddedChat({ threadId: "thr_side_chat" });
+
+    expect(screen.getByRole("status").textContent).toContain(
+      "Checking pending interactions",
+    );
+    expect(screen.getByTestId("embedded-chat-composer").hidden).toBe(true);
+    expect(
+      screen.getByTestId("embedded-chat-composer").dataset.submitReason,
+    ).toBe("loading-pending-interactions");
+  });
+
+  it("keeps the composer unavailable when pending interactions fail to load", () => {
+    mocks.pendingInteractions = undefined;
+    mocks.pendingInteractionsIsError = true;
+
+    renderEmbeddedChat({ threadId: "thr_side_chat" });
+
+    expect(screen.getByRole("alert").textContent).toContain(
+      "Couldn't check pending interactions",
+    );
+    expect(screen.getByTestId("embedded-chat-composer").hidden).toBe(true);
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(mocks.pendingInteractionsRefetch).toHaveBeenCalledOnce();
   });
 
   it("delivers the new thread's draft to host subscribers immediately on a thread switch", () => {

--- a/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.test.tsx
+++ b/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.test.tsx
@@ -60,6 +60,7 @@ vi.mock("@/components/promptbox/FollowUpPromptBox", async () => {
   return {
     FollowUpPromptBox: ({
       composer,
+      pendingInteraction,
       stack,
       pluginComposerHost,
     }: {
@@ -67,13 +68,16 @@ vi.mock("@/components/promptbox/FollowUpPromptBox", async () => {
         FollowUpComposerProps,
         "message" | "onChangeMessage" | "onSubmit"
       >;
+      pendingInteraction?: ReactNode;
       stack: ReactNode;
       pluginComposerHost?: PluginComposerHost | null;
     }) => (
       <div>
         {stack}
+        {pendingInteraction}
         <input
           data-testid="embedded-chat-composer"
+          hidden={pendingInteraction !== undefined && pendingInteraction !== null}
           value={composer.message}
           onChange={(event) => composer.onChangeMessage(event.target.value, [])}
         />
@@ -88,11 +92,19 @@ vi.mock("@/components/promptbox/FollowUpPromptBox", async () => {
 
 vi.mock("@/components/promptbox/banner/QueuedMessagesList", () => ({
   QueuedMessagesList: ({
+    attachedToComposer,
     queuedMessages,
+    sendDisabled,
   }: {
+    attachedToComposer: boolean;
     queuedMessages: readonly unknown[];
+    sendDisabled: boolean;
   }) => (
-    <div data-testid="embedded-chat-queued-messages">
+    <div
+      data-testid="embedded-chat-queued-messages"
+      data-attached-to-composer={String(attachedToComposer)}
+      data-send-disabled={sendDisabled ? "" : undefined}
+    >
       <span data-testid="queued-count">{queuedMessages.length}</span>
     </div>
   ),
@@ -496,7 +508,7 @@ describe("EmbeddedThreadChat", () => {
     expect(screen.getByTestId("queued-count").textContent).toBe("2");
   });
 
-  it("swaps the composer for a pending approval so it can be answered", () => {
+  it("shows a pending approval in place of the composer", () => {
     mocks.pendingInteractions = [
       { id: "int_1", createdAt: 1, payload: { kind: "approval" } },
     ];
@@ -506,7 +518,30 @@ describe("EmbeddedThreadChat", () => {
     expect(screen.getByTestId("pending-interaction-banner").textContent).toBe(
       "thr_side_chat",
     );
-    expect(screen.queryByTestId("embedded-chat-composer")).toBeNull();
+    expect(screen.getByTestId("embedded-chat-composer").hidden).toBe(true);
+  });
+
+  it("keeps held messages visible beside a pending side-chat question", () => {
+    mocks.pendingInteractions = [
+      { id: "int_1", createdAt: 1, payload: { kind: "user_question" } },
+    ];
+    mocks.queuedMessages = [{ id: "q1" }];
+
+    renderEmbeddedChat({ threadId: "thr_side_chat" });
+
+    expect(screen.getByTestId("pending-interaction-banner")).toBeTruthy();
+    expect(screen.getByTestId("queued-count").textContent).toBe("1");
+    expect(
+      screen
+        .getByTestId("embedded-chat-queued-messages")
+        .hasAttribute("data-send-disabled"),
+    ).toBe(true);
+    expect(
+      screen
+        .getByTestId("embedded-chat-queued-messages")
+        .getAttribute("data-attached-to-composer"),
+    ).toBe("false");
+    expect(screen.getByTestId("embedded-chat-composer").hidden).toBe(true);
   });
 
   it("keeps the composer for a plugin-owned interaction", () => {

--- a/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.tsx
+++ b/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.tsx
@@ -219,6 +219,7 @@ function EmbeddedThreadChatWithComposer({
   const activePendingInteraction = getLatestPendingInteraction(
     pendingInteractionsQuery.data,
   );
+  const hasPendingInteraction = activePendingInteraction !== null;
   useThreadReadTracking({
     markThreadRead,
     thread: threadQuery.data,
@@ -1028,10 +1029,15 @@ function EmbeddedThreadChatWithComposer({
     () =>
       queuedMessages.length > 0 ? (
         <QueuedMessagesList
+          attachedToComposer={!hasPendingInteraction}
           queuedMessages={queuedMessages}
           resolveMentionLink={resolveMentionLink}
           inlineEditor={inlineEditor}
-          sendDisabled={isProvisioning || queuedMessageActionPending}
+          sendDisabled={
+            isProvisioning ||
+            queuedMessageActionPending ||
+            hasPendingInteraction
+          }
           actionDisabled={queuedMessageActionPending}
           processingMessageId={processingQueuedMessage?.id ?? null}
           processingAction={processingQueuedMessage?.action ?? null}
@@ -1044,6 +1050,7 @@ function EmbeddedThreadChatWithComposer({
       ) : null,
     [
       beginEditQueuedMessage,
+      hasPendingInteraction,
       handleDeleteQueuedMessage,
       handleReorderQueuedMessage,
       handleSendQueuedImmediately,
@@ -1072,30 +1079,29 @@ function EmbeddedThreadChatWithComposer({
     <div className={cn("relative", surfaceClassName)}>
       <OverflowFade placement="above" tone={surfaceTone} />
       <div className="px-4 pb-4 pt-2">
-        {pendingInteractionBanner ?? (
-          <FollowUpPromptBox
-            attachments={bottomAttachmentsConfig}
-            stack={queuedMessagesStack}
-            composer={bottomComposerConfig}
-            pluginComposerHost={activeBottomPluginComposerHost}
-            pluginComposerScope={activeBottomPluginComposerHost?.scope ?? null}
-            textEffects={bottomComposerTextEffects}
-            environmentSummary={composer.environmentSummary}
-            contextWindowUsage={null}
-            execution={bottomExecutionConfig}
-            permission={bottomPermissionConfig}
-            permissionReadOnly={composer.permissionPolicy === "snapshot"}
-            typeahead={typeaheadConfig}
-            promptActions={promptActions}
-            collapseResetKey={surfaceKey}
-            focusEndKey={
-              composer.focusRequestKey === undefined
-                ? composerFocusNonce
-                : `${composerFocusNonce}:${composer.focusRequestKey}`
-            }
-            isPrimaryComposer={false}
-          />
-        )}
+        <FollowUpPromptBox
+          attachments={bottomAttachmentsConfig}
+          stack={queuedMessagesStack}
+          pendingInteraction={pendingInteractionBanner}
+          composer={bottomComposerConfig}
+          pluginComposerHost={activeBottomPluginComposerHost}
+          pluginComposerScope={activeBottomPluginComposerHost?.scope ?? null}
+          textEffects={bottomComposerTextEffects}
+          environmentSummary={composer.environmentSummary}
+          contextWindowUsage={null}
+          execution={bottomExecutionConfig}
+          permission={bottomPermissionConfig}
+          permissionReadOnly={composer.permissionPolicy === "snapshot"}
+          typeahead={typeaheadConfig}
+          promptActions={promptActions}
+          collapseResetKey={surfaceKey}
+          focusEndKey={
+            composer.focusRequestKey === undefined
+              ? composerFocusNonce
+              : `${composerFocusNonce}:${composer.focusRequestKey}`
+          }
+          isPrimaryComposer={false}
+        />
       </div>
     </div>
   );

--- a/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.tsx
+++ b/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.tsx
@@ -15,6 +15,7 @@ import type {
 } from "@/components/promptbox/PromptBoxInternal";
 import type { PromptMentionLinkResolver } from "@/components/promptbox/editor/prompt-mention-link";
 import { cn } from "@bb/shared-ui/lib/utils";
+import { Button } from "@bb/shared-ui/button";
 import { BottomAnchoredScrollBody } from "@/components/ui/bottom-anchored-scroll-body";
 import { PageShell } from "@/components/ui/page-shell.js";
 import {
@@ -105,6 +106,44 @@ const DEFAULT_LABELS: EmbeddedThreadChatLabels = {
   provisioning: "Provisioning thread...",
   sendError: "Failed to send message",
 };
+
+type PendingInteractionsQueryBannerProps =
+  | { state: "loading" }
+  | { state: "error"; isRetrying: boolean; onRetry: () => void };
+
+function PendingInteractionsQueryBanner(
+  props: PendingInteractionsQueryBannerProps,
+) {
+  const isError = props.state === "error";
+  return (
+    <div
+      className={cn(
+        "mb-2 flex min-w-0 max-w-full items-center justify-between gap-3 rounded-lg border border-border bg-surface-recessed px-4 py-3 text-xs text-muted-foreground",
+        isError &&
+          "border-surface-destructive-border bg-surface-destructive text-destructive-text",
+      )}
+      role={isError ? "alert" : "status"}
+    >
+      <span>
+        {isError
+          ? "Couldn't check pending interactions."
+          : "Checking pending interactions…"}
+      </span>
+      {props.state === "error" ? (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={props.isRetrying}
+          onClick={props.onRetry}
+          className="h-7 cursor-pointer px-2"
+        >
+          {props.isRetrying ? "Retrying…" : "Retry"}
+        </Button>
+      ) : null}
+    </div>
+  );
+}
 
 interface EmbeddedThreadChatComposerProps {
   draftScope: PromptDraftScope;
@@ -219,7 +258,19 @@ function EmbeddedThreadChatWithComposer({
   const activePendingInteraction = getLatestPendingInteraction(
     pendingInteractionsQuery.data,
   );
-  const hasPendingInteraction = activePendingInteraction !== null;
+  const hasComposerBlockingPendingInteraction =
+    activePendingInteraction !== null &&
+    activePendingInteraction.payload.kind !== "plugin";
+  const pendingInteractionsInitialLoading =
+    activePendingInteraction === null &&
+    pendingInteractionsQuery.data === undefined &&
+    (pendingInteractionsQuery.isLoading || pendingInteractionsQuery.isFetching);
+  const pendingInteractionsUnavailable =
+    activePendingInteraction === null && pendingInteractionsQuery.isError;
+  const pendingInteractionOccupiesComposer =
+    hasComposerBlockingPendingInteraction ||
+    pendingInteractionsInitialLoading ||
+    pendingInteractionsUnavailable;
   useThreadReadTracking({
     markThreadRead,
     thread: threadQuery.data,
@@ -406,16 +457,22 @@ function EmbeddedThreadChatWithComposer({
     () =>
       buildSideChatSubmitMode({
         childThreadId: threadId,
+        hasPendingInteraction: hasComposerBlockingPendingInteraction,
         isDefaultExecutionOptionsLoading,
+        isPendingInteractionsInitialLoading:
+          pendingInteractionsInitialLoading || pendingInteractionsUnavailable,
         isStopRequested,
         onStop: handleStopThread,
         runtimeDisplayStatus: displayStatus,
       }),
     [
       displayStatus,
+      hasComposerBlockingPendingInteraction,
       handleStopThread,
       isDefaultExecutionOptionsLoading,
       isStopRequested,
+      pendingInteractionsInitialLoading,
+      pendingInteractionsUnavailable,
       threadId,
     ],
   );
@@ -1029,14 +1086,14 @@ function EmbeddedThreadChatWithComposer({
     () =>
       queuedMessages.length > 0 ? (
         <QueuedMessagesList
-          attachedToComposer={!hasPendingInteraction}
+          attachedToComposer={!pendingInteractionOccupiesComposer}
           queuedMessages={queuedMessages}
           resolveMentionLink={resolveMentionLink}
           inlineEditor={inlineEditor}
           sendDisabled={
             isProvisioning ||
             queuedMessageActionPending ||
-            hasPendingInteraction
+            pendingInteractionOccupiesComposer
           }
           actionDisabled={queuedMessageActionPending}
           processingMessageId={processingQueuedMessage?.id ?? null}
@@ -1050,7 +1107,6 @@ function EmbeddedThreadChatWithComposer({
       ) : null,
     [
       beginEditQueuedMessage,
-      hasPendingInteraction,
       handleDeleteQueuedMessage,
       handleReorderQueuedMessage,
       handleSendQueuedImmediately,
@@ -1059,6 +1115,7 @@ function EmbeddedThreadChatWithComposer({
       isProvisioning,
       processingQueuedMessage?.action,
       processingQueuedMessage?.id,
+      pendingInteractionOccupiesComposer,
       queuedMessageActionPending,
       queuedMessages,
       resolveMentionLink,
@@ -1067,14 +1124,21 @@ function EmbeddedThreadChatWithComposer({
 
   const surfaceClassName =
     surfaceTone === "sidebar" ? "bg-sidebar" : "bg-background";
-  const pendingInteractionBanner =
-    activePendingInteraction === null ||
-    activePendingInteraction.payload.kind === "plugin" ? null : (
-      <ThreadPendingInteractionBanner
-        interaction={activePendingInteraction}
-        threadId={threadId}
-      />
-    );
+  const pendingInteractionBanner = pendingInteractionsUnavailable ? (
+    <PendingInteractionsQueryBanner
+      state="error"
+      isRetrying={pendingInteractionsQuery.isFetching}
+      onRetry={() => void pendingInteractionsQuery.refetch()}
+    />
+  ) : pendingInteractionsInitialLoading ? (
+    <PendingInteractionsQueryBanner state="loading" />
+  ) : activePendingInteraction !== null &&
+    activePendingInteraction.payload.kind !== "plugin" ? (
+    <ThreadPendingInteractionBanner
+      interaction={activePendingInteraction}
+      threadId={threadId}
+    />
+  ) : null;
   const footer = (
     <div className={cn("relative", surfaceClassName)}>
       <OverflowFade placement="above" tone={surfaceTone} />

--- a/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
@@ -1600,6 +1600,7 @@ export function ThreadDetailPromptArea({
           <QueuedMessagesPendingCard queuedMessageCount={queuedMessageCount} />
         ) : (
           <QueuedMessagesList
+            attachedToComposer={true}
             queuedMessages={queuedMessages}
             resolveMentionLink={resolveMentionLink}
             inlineEditor={queuedMessageEditor ?? undefined}

--- a/packages/client-core/src/prompt/threadDetailPromptSubmission.ts
+++ b/packages/client-core/src/prompt/threadDetailPromptSubmission.ts
@@ -92,7 +92,9 @@ interface BuildFollowUpSubmitModeArgs {
 
 interface BuildSideChatSubmitModeArgs {
   childThreadId: string | null;
+  hasPendingInteraction: boolean;
   isDefaultExecutionOptionsLoading: boolean;
+  isPendingInteractionsInitialLoading: boolean;
   isStopRequested: boolean;
   onStop: () => void;
   runtimeDisplayStatus: ThreadRuntimeDisplayStatus;
@@ -157,7 +159,9 @@ export function buildFollowUpSubmitMode({
 
 export function buildSideChatSubmitMode({
   childThreadId,
+  hasPendingInteraction,
   isDefaultExecutionOptionsLoading,
+  isPendingInteractionsInitialLoading,
   isStopRequested,
   onStop,
   runtimeDisplayStatus,
@@ -168,9 +172,9 @@ export function buildSideChatSubmitMode({
       : { kind: "ready" };
   }
   return buildFollowUpSubmitMode({
-    hasPendingInteraction: false,
+    hasPendingInteraction,
     isDefaultExecutionOptionsLoading,
-    isPendingInteractionsInitialLoading: false,
+    isPendingInteractionsInitialLoading,
     isStopRequested,
     onStop,
     runtimeDisplayStatus,

--- a/packages/client-core/test/threadDetailPromptSubmission.test.ts
+++ b/packages/client-core/test/threadDetailPromptSubmission.test.ts
@@ -362,7 +362,9 @@ describe("threadDetailPromptSubmission", () => {
     expect(
       buildSideChatSubmitMode({
         childThreadId: null,
+        hasPendingInteraction: false,
         isDefaultExecutionOptionsLoading: true,
+        isPendingInteractionsInitialLoading: false,
         isStopRequested: false,
         onStop,
         runtimeDisplayStatus: "provisioning",
@@ -372,7 +374,9 @@ describe("threadDetailPromptSubmission", () => {
     expect(
       buildSideChatSubmitMode({
         childThreadId: null,
+        hasPendingInteraction: false,
         isDefaultExecutionOptionsLoading: false,
+        isPendingInteractionsInitialLoading: false,
         isStopRequested: false,
         onStop,
         runtimeDisplayStatus: "idle",
@@ -386,11 +390,41 @@ describe("threadDetailPromptSubmission", () => {
     expect(
       buildSideChatSubmitMode({
         childThreadId: "thr_side",
+        hasPendingInteraction: false,
         isDefaultExecutionOptionsLoading: false,
+        isPendingInteractionsInitialLoading: false,
         isStopRequested: false,
         onStop,
         runtimeDisplayStatus: "active",
       }),
     ).toEqual({ kind: "queue", onStop });
+  });
+
+  it("blocks child side chats until pending interactions initially load", () => {
+    expect(
+      buildSideChatSubmitMode({
+        childThreadId: "thr_side",
+        hasPendingInteraction: false,
+        isDefaultExecutionOptionsLoading: false,
+        isPendingInteractionsInitialLoading: true,
+        isStopRequested: false,
+        onStop: () => undefined,
+        runtimeDisplayStatus: "active",
+      }),
+    ).toEqual({ kind: "blocked", reason: "loading-pending-interactions" });
+  });
+
+  it("blocks child side chats with a pending interaction", () => {
+    expect(
+      buildSideChatSubmitMode({
+        childThreadId: "thr_side",
+        hasPendingInteraction: true,
+        isDefaultExecutionOptionsLoading: false,
+        isPendingInteractionsInitialLoading: false,
+        isStopRequested: false,
+        onStop: () => undefined,
+        runtimeDisplayStatus: "active",
+      }),
+    ).toEqual({ kind: "blocked", reason: "pending-interaction" });
   });
 });


### PR DESCRIPTION
## Human comments

## What was wrong

The side-chat footer chose between the pending-interaction banner and the entire `FollowUpPromptBox`, so showing a question or approval also removed the queue stack that lived inside the prompt box. After rendering both surfaces, the queue card's composer-attached `-mb-5` treatment caused a second bug: it overlapped and clipped the pending-interaction card because no composer sat beneath it. This is the root cause of #2869.

Mobile side-chat sizing had a separate portal boundary bug. The visual-viewport hook published `--bb-shell-height` on the nested sidebar provider, but `CompactSecondaryPanelShelf` portals the compact side-chat drawer to `document.body`. The drawer therefore kept the full layout-viewport height while the keyboard reduced the visible viewport, leaving its prompt box below the screen.

Side chats also bypassed the main follow-up submission guard. `buildSideChatSubmitMode` hardcoded both pending-interaction inputs to `false`, while `EmbeddedThreadChat` treated an unresolved or failed interactions query as an empty list. A composer could therefore appear usable before bb knew whether the child thread was waiting for input; a submission made during that window was held by the server even though the pending interaction and queue were not visible.

## What changed

- Always render the side-chat `FollowUpPromptBox`, pass the pending interaction into its dedicated slot, and keep its queued-message stack mounted while the composer is hidden.
- Treat queued messages as disabled while the interaction is pending.
- Add an explicit `attachedToComposer` contract to `QueuedMessagesList`; side-chat queues use standalone card spacing during an interaction, while normal side-chat and main-thread queues retain the attached composer cap.
- Pass real pending-interaction and initial-loading state through `buildSideChatSubmitMode`, matching the main follow-up submission guard.
- Hide the side-chat composer behind a visible checking state until the first interaction request resolves. If it fails, keep the composer unavailable and show an inline Retry action.
- Keep queues attached to the visible composer for plugin-owned interactions, which deliberately do not replace that composer.
- Publish the mobile shell height and keyboard safe-area override on `document.body`, the common style ancestor for both the app shell and body-portaled compact drawers.
- Add regression coverage for the combined question-and-queue state, standalone queue-card styling, unknown and failed interaction state, plugin-owned interactions with queues, and the real body-portaled side-chat shelf inheriting the corrected viewport height.
- This is UI-only: there are no host-daemon wire, CLI, guide, or documentation changes, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

## How you verified

- Added focused submission-policy tests that failed before the fix because active child side chats still returned queue mode while pending-interaction state was loading or present, then passed once side chats reused the real guard.
- Added component regressions that failed before the fix because an unresolved or failed interactions request exposed the composer; they now pass with a checking state and retryable error state.
- Added the plugin-interaction-plus-queue regression requested in review; it failed before the fix because the queue used standalone styling above a visible composer, then passed after deriving placement from the composer-blocking condition.
- `pnpm exec turbo run test --filter=@bb/client-core -- --run test/threadDetailPromptSubmission.test.ts` — 17 tests passed.
- `pnpm exec turbo run test --filter=@bb/app -- --run src/components/thread/embedded-chat/EmbeddedThreadChat.test.tsx` — 15 tests passed.
- `pnpm exec turbo run test --force --filter=@bb/app -- --run src/components/promptbox/banner/QueuedMessagesList.test.tsx src/components/thread/embedded-chat/EmbeddedThreadChat.test.tsx` — 56 tests passed before the latest focused additions.
- `pnpm exec turbo run test --force --filter=@bb/app -- --run src/components/layout/useMobileVisualViewportHeight.test.tsx src/components/secondary-panel/CompactSecondaryPanelShelf.test.tsx src/components/layout/AppLayout.root-compose-project.test.tsx src/components/layout/AppLayout.sidebar-resize.test.tsx` — 32 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/client-core --filter=@bb/app` — passed.
- `pnpm exec turbo run lint --filter=@bb/client-core --filter=@bb/app` — passed with 0 errors and the existing warnings.
- `pnpm exec turbo run build --filter=@bb/app` — passed with existing Vite/chunk warnings.
- `git diff --check` and Prettier checks — passed.
- Reproduced the interaction states with a real Claude Code provider question and a CLI-confirmed queued message, then checked desktop (1440 x 1000) and mobile (390 x 844) views. Live geometry changed from a 12 px overlap to the intended 8 px gap, and the normal composer states remained unchanged.
- Confirmed the real QA sidechat still has the pending `user_question` at the server boundary while testing the fixed client policy.
- Reproduced the Android IME behavior in a target-SDK-36 System WebView harness. WebViews that report a reduced visual viewport now pass that height through to the body-portaled shelf. A host that consumes IME insets exposes no web-side keyboard geometry and must correct its native inset propagation.

Fixes #2869

> AGENT GENERATED
