### PR TITLE
Position mobile toasts below app navigation

### DIFF
--- a/apps/app/src/app.css
+++ b/apps/app/src/app.css
@@ -27,6 +27,7 @@
    * variable is the single switch both they and the shell root read.
    */
   :root {
+    --bb-app-chrome-row-height: 3rem;
     --bb-shell-height: 100dvh;
     --secondary-panel-width-mobile: min(76vw, 320px);
   }

--- a/apps/app/src/app.css.test.ts
+++ b/apps/app/src/app.css.test.ts
@@ -8,6 +8,12 @@ const css = readFileSync(
   "utf8",
 );
 
+describe("app.css chrome geometry", () => {
+  it("owns the shared app chrome row height", () => {
+    expect(css).toMatch(/--bb-app-chrome-row-height:\s*3rem;/);
+  });
+});
+
 describe("app.css sidebar drag cursor", () => {
   it("scopes the grabbing cursor to the sidebar panel on fine pointers only", () => {
     expect(css).not.toMatch(/body\[data-sidebar-dragging="true"\]\s*\*/);

--- a/apps/app/src/components/AppToaster.test.tsx
+++ b/apps/app/src/components/AppToaster.test.tsx
@@ -36,6 +36,12 @@ describe("AppToaster", () => {
     const toaster = await renderToaster(true);
     expect(toaster?.getAttribute("data-x-position")).toBe("center");
     expect(toaster?.getAttribute("data-y-position")).toBe("top");
+    expect(toaster?.style.getPropertyValue("--offset-top")).toBe(
+      "calc(env(safe-area-inset-top) + 48px + 16px)",
+    );
+    expect(toaster?.style.getPropertyValue("--mobile-offset-top")).toBe(
+      "calc(env(safe-area-inset-top) + 48px + 16px)",
+    );
   });
 
   it("preserves the configured desktop toast position", async () => {

--- a/apps/app/src/components/AppToaster.test.tsx
+++ b/apps/app/src/components/AppToaster.test.tsx
@@ -25,7 +25,9 @@ async function renderToaster(isCompactViewport: boolean) {
   });
 
   return waitFor(() => {
-    const toaster = document.querySelector("[data-sonner-toaster]");
+    const toaster = document.querySelector<HTMLElement>(
+      "[data-sonner-toaster]",
+    );
     expect(toaster).not.toBeNull();
     return toaster;
   });

--- a/apps/app/src/components/AppToaster.test.tsx
+++ b/apps/app/src/components/AppToaster.test.tsx
@@ -39,10 +39,10 @@ describe("AppToaster", () => {
     expect(toaster?.getAttribute("data-x-position")).toBe("center");
     expect(toaster?.getAttribute("data-y-position")).toBe("top");
     expect(toaster?.style.getPropertyValue("--offset-top")).toBe(
-      "calc(env(safe-area-inset-top) + 48px + 16px)",
+      "calc(env(safe-area-inset-top) + var(--bb-app-chrome-row-height) + 16px)",
     );
     expect(toaster?.style.getPropertyValue("--mobile-offset-top")).toBe(
-      "calc(env(safe-area-inset-top) + 48px + 16px)",
+      "calc(env(safe-area-inset-top) + var(--bb-app-chrome-row-height) + 16px)",
     );
   });
 

--- a/apps/app/src/components/AppToaster.tsx
+++ b/apps/app/src/components/AppToaster.tsx
@@ -2,8 +2,27 @@ import { Toaster, type ToasterProps } from "sonner";
 import { useIsCompactViewport } from "@bb/shared-ui/hooks/use-compact-viewport";
 import { usePreferredTheme } from "@/hooks/useTheme";
 
+const COMPACT_TOAST_TOP_OFFSET =
+  "calc(env(safe-area-inset-top) + 48px + 16px)";
+
+function withCompactTopOffset(
+  offset: ToasterProps["offset"],
+): ToasterProps["offset"] {
+  if (typeof offset === "object") {
+    return { ...offset, top: COMPACT_TOAST_TOP_OFFSET };
+  }
+  return {
+    top: COMPACT_TOAST_TOP_OFFSET,
+    right: offset,
+    bottom: offset,
+    left: offset,
+  };
+}
+
 export function AppToaster({
   position = "bottom-right",
+  offset,
+  mobileOffset,
   ...props
 }: ToasterProps) {
   const theme = usePreferredTheme();
@@ -13,6 +32,12 @@ export function AppToaster({
       theme={theme}
       position={isCompactViewport ? "top-center" : position}
       {...props}
+      offset={isCompactViewport ? withCompactTopOffset(offset) : offset}
+      mobileOffset={
+        isCompactViewport
+          ? withCompactTopOffset(mobileOffset)
+          : mobileOffset
+      }
     />
   );
 }

--- a/apps/app/src/components/AppToaster.tsx
+++ b/apps/app/src/components/AppToaster.tsx
@@ -3,7 +3,7 @@ import { useIsCompactViewport } from "@bb/shared-ui/hooks/use-compact-viewport";
 import { usePreferredTheme } from "@/hooks/useTheme";
 
 const COMPACT_TOAST_TOP_OFFSET =
-  "calc(env(safe-area-inset-top) + 48px + 16px)";
+  "calc(env(safe-area-inset-top) + var(--bb-app-chrome-row-height) + 16px)";
 
 function withCompactTopOffset(
   offset: ToasterProps["offset"],

--- a/apps/app/src/lib/bb-desktop.test.ts
+++ b/apps/app/src/lib/bb-desktop.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { BbDesktopInfo } from "@bb/desktop-contract";
 import { createBbDesktopApi } from "@/test/bb-desktop-test-utils";
 import {
+  CHROME_ROW_HEIGHT_CLASS,
   MACOS_COLLAPSED_TOP_LEFT_RESERVE_CLASS,
   MACOS_TRAFFIC_LIGHT_RESERVE_OFFSET_CLASS,
   shouldReserveMacosTrafficLights,
@@ -18,6 +19,10 @@ const desktopInfo: BbDesktopInfo = {
 };
 
 describe("desktop chrome geometry", () => {
+  it("sizes chrome rows from the shared app chrome token", () => {
+    expect(CHROME_ROW_HEIGHT_CLASS).toBe("h-(--bb-app-chrome-row-height)");
+  });
+
   it("reserves macOS traffic-light space only when lights are visible", () => {
     const desktopApi = createBbDesktopApi(desktopInfo);
 

--- a/apps/app/src/lib/bb-desktop.ts
+++ b/apps/app/src/lib/bb-desktop.ts
@@ -16,7 +16,7 @@ export const MACOS_APP_REGION_NO_DRAG_CLASS =
   "[app-region:no-drag] [-webkit-app-region:no-drag]";
 export const MACOS_WINDOW_NO_DRAG_CLASS = `relative z-50 ${MACOS_APP_REGION_NO_DRAG_CLASS}`;
 
-export const CHROME_ROW_HEIGHT_CLASS = "h-[48px]";
+export const CHROME_ROW_HEIGHT_CLASS = "h-(--bb-app-chrome-row-height)";
 export const CHROME_ROW_CLASS = `flex ${CHROME_ROW_HEIGHT_CLASS} items-center`;
 
 export const MACOS_CHROME_CONTROL_AXIS_CLASS =


### PR DESCRIPTION
## Human comments

## What was wrong

The parent PR centers compact-viewport toasts at the top edge, where they cover the app's 48 px top navigation and its controls.

The first implementation also encoded that 48 px chrome height separately in the toaster offset and shared chrome-row class, allowing those two surfaces to drift if the navigation height changed later.

## What changed

- Inset compact toasts by the device top safe area, the shared app chrome row height, and the standard 16 px toast gap.
- Define `--bb-app-chrome-row-height: 3rem` as the single length owner used by both chrome rows and the toast calculation.
- Apply the inset to both Sonner's phone and wider compact layout modes while preserving configured offsets on the unaffected edges.
- Assert the shared token declaration and both consumers in focused regression tests.
- No wire, persistence, SDK, CLI, or daemon protocol behavior changed.

## Screenshots

The comparison uses the same disposable thread, archive interaction, open home composer, light theme, and 390×844 viewport. The before image is the parent PR behavior; the after image is exact head `168db15df`.

| Before — toast overlaps navigation | After — toast below navigation |
| --- | --- |
| ![Before: archive toast covers the app top navigation](https://img3.pixhost.cc/images/5396/765151641_after-final-head.png) | ![After: archive toast sits below the app top navigation](https://img3.pixhost.cc/images/5397/765166017_after.png) |

## How you verified

- Remote CI passed on exact head `168db15df`; all applicable checks succeeded and the two not-applicable checks were skipped.
- Chrome for Testing 151.0.7922.71 at 390×844 hard reloaded the seeded thread, archived it, navigated home, opened the composer, and completed the toast animation.
- The exact-head archive toast rendered centered at y=64–132, below the shared 48 px chrome row plus 16 px gap, with the composer clear, no horizontal overflow, and no console or page errors.

BB-Thread-ID: thr_mq2niw3uxf

> AGENT GENERATED
