### PR TITLE
Rename unorganized thread group to Threads

### DIFF
--- a/apps/app/src/components/sidebar/ProjectList.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.tsx
@@ -1829,7 +1829,7 @@ function ProjectListComponent({
     actionsOpen: isSectionDisplayOptionsOpen("pinned"),
   };
   const threadsSection = {
-    label: organizationMode === "chronological" ? "Unorganized" : "Threads",
+    label: "Threads",
     actions: threadsSectionActions,
     actionsOpen: threadsDisplayOptionsMenuOpen,
   } satisfies Omit<BuiltInSidebarSectionOptions, "content">;
@@ -1859,7 +1859,7 @@ function ProjectListComponent({
       {sectionDeleteDialog.target ? (
         <ConfirmDeleteDialogContent
           title="Remove section?"
-          description="Threads in this section will move back to Unorganized."
+          description="Threads in this section will move back to Threads."
           confirmLabel="Remove section"
           pending={isDeleteThreadSectionPending}
           onConfirm={handleConfirmRemoveThreadSection}

--- a/apps/app/src/components/sidebar/SidebarSectionRow.stories.tsx
+++ b/apps/app/src/components/sidebar/SidebarSectionRow.stories.tsx
@@ -220,7 +220,7 @@ export function DragInto() {
       </StoryRow>
       <StoryRow
         label="loose-list drop"
-        hint="dragging a thread out of a section previews the same slot at root depth in Unorganized"
+        hint="dragging a thread out of a section previews the same slot at root depth in Threads"
       >
         <SidebarStage>
           <DropPreviewRow depth={0} />


### PR DESCRIPTION
## What was wrong

The manually organized sidebar called its root thread group `Unorganized`, while the same content group is called `Threads` in the other sidebar views. The view-dependent name made one stable destination sound like an error state and created unnecessary sidebar terminology.

## What changed

- Use `Threads` for the loose-thread group in every organization mode.
- Update the remove-section confirmation to say that released threads move back to `Threads`.
- Keep grouping, ordering, drag-and-drop, status, and thread behavior unchanged.

No public or wire contracts changed.

## Screenshots

Both screenshots use the same dev database, route, chronological organization mode, light theme, and 1440×900 viewport.

### Before — main (`b4628ade6`)

![Before — loose thread group labeled Unorganized](https://github.com/user-attachments/assets/4f81a6f6-8509-49a7-beab-6c43d9b1dfb5)

### After — this PR (`551ccd018`)

![After — loose thread group labeled Threads](https://github.com/user-attachments/assets/143777f2-5736-464c-91ef-fce936363bee)

## How you verified

- `git diff --check`
- Chrome for Testing 151 at 1440×900 against the exact main and PR-head branch web apps.
- Confirmed the same chronological sidebar fixture renders `Unorganized` on main and `Threads` on this PR without changing row order or content.
- Remote CI passed the required checks, app/server/package/integration tests, and Linux/macOS package smoke on the current head; iOS simulator and Node Compatibility Smoke were intentionally skipped by workflow configuration.
- Per repository policy, no CI-equivalent checks were run locally.

Fixes #

BB-Thread-ID: thr_ccffp4w2p2

> AGENT GENERATED
