### PR TITLE
fix: make queued-message dispatch atomic and composable

### DIFF
--- a/apps/server/src/internal/events.ts
+++ b/apps/server/src/internal/events.ts
@@ -41,6 +41,7 @@ import {
 import { queueChildThreadTurnNotificationBestEffort } from "../services/threads/child-thread-notifications.js";
 import { isParentNotifiableChildThread } from "../services/threads/thread-parent.js";
 import {
+  createAutomaticQueuedMessageGroupEligibility,
   runQueuedMessageAutoSendForThread,
   sendQueuedMessage,
 } from "../services/threads/queued-messages.js";
@@ -510,9 +511,16 @@ async function executeEventFollowUpBestEffort(
         });
         return;
       case "turn-starting-queued-messages":
+        const thread = getThread(deps.db, followUp.threadId);
+        if (!thread) return;
+        const isGroupEligible = createAutomaticQueuedMessageGroupEligibility(
+          deps,
+          { now: Date.now(), thread },
+        );
         for (const queuedMessageId of followUp.queuedMessageIds) {
           try {
             await sendQueuedMessage(deps, {
+              isGroupEligible,
               mode: "auto",
               queuedMessageId,
               sendNow: false,

--- a/apps/server/src/internal/events.ts
+++ b/apps/server/src/internal/events.ts
@@ -520,10 +520,9 @@ async function executeEventFollowUpBestEffort(
         for (const queuedMessageId of followUp.queuedMessageIds) {
           try {
             await sendQueuedMessage(deps, {
-              isGroupEligible,
+              claimPolicy: { kind: "automatic", isGroupEligible },
               mode: "auto",
               queuedMessageId,
-              sendNow: false,
               threadId: followUp.threadId,
             });
           } catch (error) {

--- a/apps/server/src/routes/threads/actions.ts
+++ b/apps/server/src/routes/threads/actions.ts
@@ -267,11 +267,9 @@ export function registerThreadActionRoutes(app: Hono, deps: AppDeps): void {
     ensureThreadIsWritable(thread);
     ensureThreadIsNotAwaitingUserInteraction(deps, thread.id);
     const queuedMessage = await sendQueuedMessage(deps, {
+      claimPolicy: { kind: "explicit-send" },
       queuedMessageId: context.req.param("queuedMessageId"),
       mode: payload.mode,
-      // The route IS "Send now": the user is overriding every plugin wait and
-      // the row's own schedule. Core waits still apply.
-      sendNow: true,
       threadId: context.req.param("id"),
     });
     return context.json({ ok: true, queuedMessage });

--- a/apps/server/src/services/threads/dispatch-attempt.ts
+++ b/apps/server/src/services/threads/dispatch-attempt.ts
@@ -333,7 +333,19 @@ async function runDispatchAttempt(
     resolveDispatchAttemptKind(currentThread, payload.mode) === "join-turn" &&
     getActiveTurnId(deps, thread.id) === null
   ) {
-    return waitOn({ kind: "turn-starting" }, null);
+    const outcome = deps.db.transaction(
+      (tx) => {
+        const lockedThread = getThread(tx, thread.id);
+        if (!lockedThread) return null;
+        if (lockedThread.status !== "active") {
+          return waitOn({ kind: "thread-busy" }, null);
+        }
+        if (getActiveTurnId({ db: tx }, thread.id) !== null) return null;
+        return waitOn({ kind: "turn-starting" }, null);
+      },
+      { behavior: "immediate" },
+    );
+    if (outcome !== null) return outcome;
   }
   if (!firstDispatch && isPreStartThreadStatus(thread.status)) {
     // A follow-up or steer sent while the workspace is being (re)provisioned.

--- a/apps/server/src/services/threads/dispatch-attempt.ts
+++ b/apps/server/src/services/threads/dispatch-attempt.ts
@@ -40,6 +40,7 @@ import {
 import {
   recordQueuedMessageWait,
   settleQueueRowDispatched,
+  type QueuedDispatchMessage,
 } from "./queue-waits.js";
 import { applyLoggedThreadLifecycleEventInTransaction } from "./lifecycle-outcome.js";
 import { buildExecutionOptions } from "./thread-commands.js";
@@ -61,6 +62,7 @@ import {
 } from "./thread-runtime-display.js";
 import { toThreadQueuedMessage } from "./thread-queued-messages.js";
 import { isPreStartThreadStatus } from "./thread-status.js";
+import { queueInputForStartingTurn } from "./thread-turn-starting.js";
 import {
   ensureThreadIsWritable,
   resolveMessageSenderThreadId,
@@ -280,6 +282,13 @@ async function runDispatchAttempt(
     args.executionDefaults ?? { threadId: thread.id },
   );
   const resolvedPayload = resolveExecutionIntoPayload(payload, execution);
+  const queuedMessage: QueuedDispatchMessage = {
+    input: payload.input,
+    execution,
+    senderThreadId,
+    payload: args.queuePayload,
+    systemNotice: null,
+  };
 
   const waitOn = (
     waitingOn: QueuedMessageWaitingOn,
@@ -287,15 +296,7 @@ async function runDispatchAttempt(
   ): DispatchAttemptOutcome => {
     const entry = recordQueuedMessageWait(deps, {
       thread,
-      message: {
-        input: payload.input,
-        execution,
-        senderThreadId,
-        payload: args.queuePayload,
-        // Only core queues a system notice, and it does so directly rather
-        // than through a send request, so an attempt never carries one.
-        systemNotice: null,
-      },
+      message: queuedMessage,
       waitingOn,
       sendAt,
       claimed,
@@ -320,7 +321,11 @@ async function runDispatchAttempt(
     if (payload.mode === "start") {
       // `start` asks for a FRESH turn specifically, so a running one is a
       // conflict rather than something to wait behind. Unchanged 409.
-      throwThreadNotWritable(thread, "already_active", "Thread is already active");
+      throwThreadNotWritable(
+        thread,
+        "already_active",
+        "Thread is already active",
+      );
     }
     return waitOn({ kind: "thread-busy" }, null);
   }
@@ -333,19 +338,21 @@ async function runDispatchAttempt(
     resolveDispatchAttemptKind(currentThread, payload.mode) === "join-turn" &&
     getActiveTurnId(deps, thread.id) === null
   ) {
-    const outcome = deps.db.transaction(
-      (tx) => {
-        const lockedThread = getThread(tx, thread.id);
-        if (!lockedThread) return null;
-        if (lockedThread.status !== "active") {
-          return waitOn({ kind: "thread-busy" }, null);
-        }
-        if (getActiveTurnId({ db: tx }, thread.id) !== null) return null;
-        return waitOn({ kind: "turn-starting" }, null);
-      },
-      { behavior: "immediate" },
-    );
-    if (outcome !== null) return outcome;
+    const outcome = queueInputForStartingTurn(deps, {
+      claimed,
+      fallbackWaitingOn: { kind: "thread-busy" },
+      input: queuedMessage,
+      threadId: thread.id,
+    });
+    if (outcome.kind === "queued" || outcome.kind === "dispatched") {
+      return outcome;
+    }
+    if (outcome.kind === "thread-changed") {
+      if (outcome.thread === null) {
+        throw new ApiError(404, "thread_not_found", "Thread not found");
+      }
+      ensureThreadIsWritable(outcome.thread);
+    }
   }
   if (!firstDispatch && isPreStartThreadStatus(thread.status)) {
     // A follow-up or steer sent while the workspace is being (re)provisioned.

--- a/apps/server/src/services/threads/dispatch-attempt.ts
+++ b/apps/server/src/services/threads/dispatch-attempt.ts
@@ -3,6 +3,7 @@ import {
   getEnvironment,
   getThread,
   getThreadPendingStartContext,
+  isThreadQueueAutoSendPaused,
   listRunningThreads,
   setThreadPendingStartContext,
   type ClaimedQueuedThreadMessageRow,
@@ -160,6 +161,7 @@ export type DispatchAttemptSource =
   | {
       kind: "drain";
       claimed: ClaimedQueuedThreadMessageRow[];
+      respectManualStopPause: boolean;
       /**
        * Send-now. Bypasses every plugin wait AND the row's own `sendAt`; core
        * waits are NOT overridable, because they guard invariants rather than
@@ -274,6 +276,8 @@ async function runDispatchAttempt(
   const firstDispatch = thread.status === "pending";
   const claimed = args.source.kind === "drain" ? args.source.claimed : null;
   const sendNow = args.source.kind === "drain" && args.source.sendNow;
+  const respectManualStopPause =
+    args.source.kind === "drain" && args.source.respectManualStopPause;
   const attempt = resolveDispatchAttemptKind(thread, payload.mode);
 
   const execution = await buildExecutionOptions(
@@ -418,6 +422,7 @@ async function runDispatchAttempt(
               admitted.value = await admitPendingThread(deps, {
                 claimed,
                 payload: resolvedPayload,
+                respectManualStopPause,
                 startContext: args.startContext ?? null,
                 thread,
               });
@@ -450,6 +455,7 @@ async function runDispatchAttempt(
       : await admitPendingThread(deps, {
           claimed,
           payload: resolvedPayload,
+          respectManualStopPause,
           startContext: args.startContext ?? null,
           thread,
         });
@@ -486,7 +492,13 @@ async function runDispatchAttempt(
     ...(args.retryOf !== undefined ? { retryOf: args.retryOf } : {}),
     ...(claimed === null
       ? {}
-      : { beforeAppendInTransaction: consumeClaimedRows(claimed) }),
+      : {
+          beforeAppendInTransaction: consumeClaimedRows(
+            claimed,
+            thread.id,
+            respectManualStopPause,
+          ),
+        }),
   });
   if (claimed !== null) {
     settleQueueRowDispatched({ row: claimed[0]! });
@@ -502,8 +514,17 @@ async function runDispatchAttempt(
  */
 function consumeClaimedRows(
   claimed: readonly ClaimedQueuedThreadMessageRow[],
+  threadId: string,
+  respectManualStopPause: boolean,
 ): SendThreadMessageTransactionPreflight {
   return ({ tx }) => {
+    if (respectManualStopPause && isThreadQueueAutoSendPaused(tx, threadId)) {
+      throw new ApiError(
+        409,
+        "queued_message_auto_send_paused",
+        "Queued message auto-send was paused by a manual stop",
+      );
+    }
     const consumed = deleteClaimedQueuedThreadMessageBatchInTransaction(tx, {
       queuedMessages: claimed,
     });
@@ -520,6 +541,7 @@ function consumeClaimedRows(
 interface AdmitPendingThreadArgs {
   claimed: ClaimedQueuedThreadMessageRow[] | null;
   payload: SendMessageRequest & { inputGroups?: PromptInput[][] };
+  respectManualStopPause: boolean;
   /** Creation's own record; null on a re-attempt, which reads it back. */
   startContext: PendingThreadStartContext | null;
   thread: Thread;
@@ -593,7 +615,11 @@ async function admitPendingThread(
         // so the row stays claimed for the caller to hand back rather than
         // being deleted under a message that never dispatched.
         if (args.claimed !== null && args.claimed.length > 0) {
-          consumeClaimedRows(args.claimed)({ tx });
+          consumeClaimedRows(
+            args.claimed,
+            args.thread.id,
+            args.respectManualStopPause,
+          )({ tx });
         }
         const prepared = applyLoggedThreadLifecycleEventInTransaction(
           { db: tx, logger: deps.logger },

--- a/apps/server/src/services/threads/dispatch-attempt.ts
+++ b/apps/server/src/services/threads/dispatch-attempt.ts
@@ -246,10 +246,6 @@ export function attemptDispatch(
   return runDispatchAttempt(deps, args, false);
 }
 
-/**
- * `reattempted` is true on the one re-entry a lost pending admission makes,
- * against the re-read thread; a second loss is a bug, not a race.
- */
 async function runDispatchAttempt(
   deps: LoggedPendingInteractionWorkSessionDeps,
   args: DispatchAttemptArgs,
@@ -337,25 +333,41 @@ async function runDispatchAttempt(
     return waitOn({ kind: "thread-busy" }, null);
   }
   const currentThread = getThread(deps.db, thread.id);
+  if (currentThread === null) {
+    throw new ApiError(404, "thread_not_found", "Thread not found");
+  }
   if (
-    currentThread?.status === "active" &&
+    currentThread.status !== thread.status ||
+    currentThread.archivedAt !== thread.archivedAt ||
+    currentThread.deletedAt !== thread.deletedAt
+  ) {
+    return reattemptDispatchForThreadChange(
+      deps,
+      args,
+      currentThread,
+      reattempted,
+    );
+  }
+  if (
+    currentThread.status === "active" &&
     resolveDispatchAttemptKind(currentThread, payload.mode) === "join-turn" &&
     getActiveTurnId(deps, thread.id) === null
   ) {
     const outcome = queueInputForStartingTurn(deps, {
       claimed,
-      fallbackWaitingOn: { kind: "thread-busy" },
       input: queuedMessage,
       threadId: thread.id,
     });
     if (outcome.kind === "queued" || outcome.kind === "dispatched") {
       return outcome;
     }
-    if (outcome.kind === "thread-changed") {
-      if (outcome.thread === null) {
-        throw new ApiError(404, "thread_not_found", "Thread not found");
-      }
-      ensureThreadIsWritable(outcome.thread);
+    if (outcome.kind === "retry") {
+      return reattemptDispatchForThreadChange(
+        deps,
+        args,
+        outcome.thread,
+        reattempted,
+      );
     }
   }
   if (!firstDispatch && isPreStartThreadStatus(thread.status)) {
@@ -466,18 +478,8 @@ async function runDispatchAttempt(
       // it is now: it queues behind the winner's cold start, or is refused
       // for a thread that is gone. Reporting a dispatch here would tell the
       // caller their message went when it went nowhere.
-      if (reattempted) {
-        throw new ApiError(
-          500,
-          "internal_error",
-          `Thread ${thread.id} left pending twice under one dispatch attempt`,
-        );
-      }
       const current = getThread(deps.db, thread.id);
-      if (!current) {
-        throw new ApiError(404, "thread_not_found", "Thread not found");
-      }
-      return runDispatchAttempt(deps, { ...args, thread: current }, true);
+      return reattemptDispatchForThreadChange(deps, args, current, reattempted);
     }
     await launchAdmittedThread(deps, admission);
     return { kind: "dispatched" };
@@ -504,6 +506,25 @@ async function runDispatchAttempt(
     settleQueueRowDispatched({ row: claimed[0]! });
   }
   return { kind: "dispatched" };
+}
+
+function reattemptDispatchForThreadChange(
+  deps: LoggedPendingInteractionWorkSessionDeps,
+  args: DispatchAttemptArgs,
+  thread: Thread | null,
+  reattempted: boolean,
+): Promise<DispatchAttemptOutcome> {
+  if (thread === null) {
+    throw new ApiError(404, "thread_not_found", "Thread not found");
+  }
+  if (reattempted) {
+    throw new ApiError(
+      500,
+      "internal_error",
+      `Thread ${thread.id} changed twice under one dispatch attempt`,
+    );
+  }
+  return runDispatchAttempt(deps, { ...args, thread }, true);
 }
 
 /**

--- a/apps/server/src/services/threads/parent-system-messages.ts
+++ b/apps/server/src/services/threads/parent-system-messages.ts
@@ -245,9 +245,11 @@ async function queueActiveParentSystemMessage(
 ): Promise<boolean> {
   const expectedSteerTurnId = getActiveTurnId(deps, args.thread.id);
   if (expectedSteerTurnId === null) {
-    const queued = queueInputForStartingTurn(deps, {
+    const outcome = queueInputForStartingTurn(deps, {
+      claimed: null,
+      fallbackWaitingOn: null,
       input: {
-        content: args.input,
+        input: args.input,
         execution: args.execution,
         payload: { kind: "inline" },
         senderThreadId: null,
@@ -258,20 +260,24 @@ async function queueActiveParentSystemMessage(
       },
       threadId: args.thread.id,
     });
-    if (queued) return true;
-    const currentThread = getThread(deps.db, args.thread.id);
-    if (
-      !currentThread ||
-      currentThread.archivedAt !== null ||
-      currentThread.deletedAt !== null
-    ) {
-      return false;
-    }
-    if (currentThread.status !== "active") {
-      return queueReadyParentSystemMessage(deps, {
-        ...args,
-        thread: currentThread,
-      });
+    if (outcome.kind === "queued") return true;
+    if (outcome.kind === "dispatched") return false;
+    if (outcome.kind === "thread-changed") {
+      const currentThread = outcome.thread;
+      if (
+        currentThread === null ||
+        currentThread.archivedAt !== null ||
+        currentThread.deletedAt !== null ||
+        currentThread.status === "stopping"
+      ) {
+        return false;
+      }
+      if (currentThread.status !== "active") {
+        return queueReadyParentSystemMessage(deps, {
+          ...args,
+          thread: currentThread,
+        });
+      }
     }
   }
   const permissionEscalation = resolvePermissionEscalation({
@@ -431,9 +437,13 @@ export async function queueParentSystemMessage(
     // queues on the thread's queue like every other blocked dispatch, carrying
     // its own taxonomy so the turn it eventually becomes is the same turn it
     // would have been a moment earlier.
-    const execution = await buildExecutionOptions(deps, {}, {
-      threadId: parentThread.id,
-    });
+    const execution = await buildExecutionOptions(
+      deps,
+      {},
+      {
+        threadId: parentThread.id,
+      },
+    );
     createQueuedThreadMessage(deps.db, deps.hub, {
       threadId: parentThread.id,
       content: args.input,

--- a/apps/server/src/services/threads/parent-system-messages.ts
+++ b/apps/server/src/services/threads/parent-system-messages.ts
@@ -245,7 +245,7 @@ async function queueActiveParentSystemMessage(
 ): Promise<boolean> {
   const expectedSteerTurnId = getActiveTurnId(deps, args.thread.id);
   if (expectedSteerTurnId === null) {
-    queueInputForStartingTurn(deps, {
+    const queued = queueInputForStartingTurn(deps, {
       input: {
         content: args.input,
         execution: args.execution,
@@ -258,7 +258,21 @@ async function queueActiveParentSystemMessage(
       },
       threadId: args.thread.id,
     });
-    return true;
+    if (queued) return true;
+    const currentThread = getThread(deps.db, args.thread.id);
+    if (
+      !currentThread ||
+      currentThread.archivedAt !== null ||
+      currentThread.deletedAt !== null
+    ) {
+      return false;
+    }
+    if (currentThread.status !== "active") {
+      return queueReadyParentSystemMessage(deps, {
+        ...args,
+        thread: currentThread,
+      });
+    }
   }
   const permissionEscalation = resolvePermissionEscalation({
     initiator: "system",

--- a/apps/server/src/services/threads/parent-system-messages.ts
+++ b/apps/server/src/services/threads/parent-system-messages.ts
@@ -247,7 +247,6 @@ async function queueActiveParentSystemMessage(
   if (expectedSteerTurnId === null) {
     const outcome = queueInputForStartingTurn(deps, {
       claimed: null,
-      fallbackWaitingOn: null,
       input: {
         input: args.input,
         execution: args.execution,
@@ -262,7 +261,7 @@ async function queueActiveParentSystemMessage(
     });
     if (outcome.kind === "queued") return true;
     if (outcome.kind === "dispatched") return false;
-    if (outcome.kind === "thread-changed") {
+    if (outcome.kind === "retry") {
       const currentThread = outcome.thread;
       if (
         currentThread === null ||
@@ -272,12 +271,10 @@ async function queueActiveParentSystemMessage(
       ) {
         return false;
       }
-      if (currentThread.status !== "active") {
-        return queueReadyParentSystemMessage(deps, {
-          ...args,
-          thread: currentThread,
-        });
-      }
+      return queueReadyParentSystemMessage(deps, {
+        ...args,
+        thread: currentThread,
+      });
     }
   }
   const permissionEscalation = resolvePermissionEscalation({

--- a/apps/server/src/services/threads/queue-drains.ts
+++ b/apps/server/src/services/threads/queue-drains.ts
@@ -17,6 +17,7 @@ import { isDispatchRequeuedRecently } from "./dispatch-hooks.js";
 import { clearQueuedMessageWait } from "./queue-waits.js";
 import { recordQueuedMessageDrainFailure } from "./queue-drain-failure.js";
 import {
+  createAutomaticQueuedMessageGroupEligibility,
   runQueuedMessageAutoSendForThread,
   sendQueuedMessage,
 } from "./queued-messages.js";
@@ -206,7 +207,7 @@ async function dispatchDueQueuedMessage(
     // satisfied and every other wait is re-decided from scratch — including
     // the plugin pass, which is what makes a scheduled send still respect a
     // limiter at 9am rather than jumping it.
-    await attemptEligibleQueuedMessage(deps, row, now);
+    await attemptEligibleQueuedMessage(deps, row, thread, now);
   } catch (error) {
     // A background attempt has no caller left to report to, so the row carries
     // the outcome itself — as a `host-offline` wait when the machine is simply
@@ -228,14 +229,14 @@ async function dispatchDueQueuedMessage(
 async function attemptEligibleQueuedMessage(
   deps: QueueDrainDeps,
   row: QueuedMessageDispatchRef,
+  thread: NonNullable<ReturnType<typeof getThread>>,
   now: number,
 ): Promise<void> {
   await sendQueuedMessage(deps, {
-    isGroupEligible: (group) =>
-      group.every((member) =>
-        member.waitHolder !== null ||
-        (member.sendAt !== null && member.sendAt <= now),
-      ),
+    isGroupEligible: createAutomaticQueuedMessageGroupEligibility(deps, {
+      now,
+      thread,
+    }),
     mode: "auto",
     queuedMessageId: row.id,
     threadId: row.threadId,
@@ -300,7 +301,7 @@ export async function runRequestedQueueDrain(
     const thread = getThread(deps.db, row.threadId);
     if (!thread || thread.deletedAt !== null) continue;
     try {
-      await attemptEligibleQueuedMessage(deps, row, Date.now());
+      await attemptEligibleQueuedMessage(deps, row, thread, Date.now());
     } catch (error) {
       // Same posture as the due sweep: nobody is listening, so the outcome
       // lands on the row rather than propagating and stopping the walk.

--- a/apps/server/src/services/threads/queue-drains.ts
+++ b/apps/server/src/services/threads/queue-drains.ts
@@ -228,14 +228,13 @@ async function dispatchDueQueuedMessage(
 async function attemptEligibleQueuedMessage(
   deps: QueueDrainDeps,
   row: QueuedMessageDispatchRef,
-  eligibility: number | "plugin",
+  now: number,
 ): Promise<void> {
   await sendQueuedMessage(deps, {
     isGroupEligible: (group) =>
       group.every((member) =>
-        eligibility === "plugin"
-          ? member.waitHolder !== null
-          : member.sendAt !== null && member.sendAt <= eligibility,
+        member.waitHolder !== null ||
+        (member.sendAt !== null && member.sendAt <= now),
       ),
     mode: "auto",
     queuedMessageId: row.id,
@@ -301,7 +300,7 @@ export async function runRequestedQueueDrain(
     const thread = getThread(deps.db, row.threadId);
     if (!thread || thread.deletedAt !== null) continue;
     try {
-      await attemptEligibleQueuedMessage(deps, row, "plugin");
+      await attemptEligibleQueuedMessage(deps, row, Date.now());
     } catch (error) {
       // Same posture as the due sweep: nobody is listening, so the outcome
       // lands on the row rather than propagating and stopping the walk.

--- a/apps/server/src/services/threads/queue-drains.ts
+++ b/apps/server/src/services/threads/queue-drains.ts
@@ -232,17 +232,15 @@ async function attemptEligibleQueuedMessage(
   thread: NonNullable<ReturnType<typeof getThread>>,
   now: number,
 ): Promise<void> {
+  const isGroupEligible = createAutomaticQueuedMessageGroupEligibility(deps, {
+    now,
+    thread,
+  });
   await sendQueuedMessage(deps, {
-    isGroupEligible: createAutomaticQueuedMessageGroupEligibility(deps, {
-      now,
-      thread,
-    }),
+    claimPolicy: { kind: "automatic", isGroupEligible },
     mode: "auto",
     queuedMessageId: row.id,
     threadId: row.threadId,
-    // A due row is eligible, not overridden: the plugin pass runs. Send-now is
-    // the only thing that bypasses it, and a timer is not a user.
-    sendNow: false,
   });
 }
 
@@ -361,7 +359,8 @@ export async function clearQueueWaitsForUnregisteredPlugin(
   deps: QueueDrainDeps,
   pluginId: string,
 ): Promise<void> {
-  const holder = `${QUEUED_MESSAGE_PLUGIN_WAIT_HOLDER_PREFIX}${pluginId}` as const;
+  const holder =
+    `${QUEUED_MESSAGE_PLUGIN_WAIT_HOLDER_PREFIX}${pluginId}` as const;
   const threadIds = new Set<string>();
   for (const row of listQueuedThreadMessagesByWaitHolder(deps.db, holder)) {
     deps.logger.info(

--- a/apps/server/src/services/threads/queue-waits.ts
+++ b/apps/server/src/services/threads/queue-waits.ts
@@ -3,6 +3,9 @@ import {
   createQueuedThreadMessageInTransaction,
   requeueClaimedQueuedThreadMessages,
   type ClaimedQueuedThreadMessageRow,
+  type DbConnection,
+  type DbNotifier,
+  type DbQueryConnection,
   type QueuedThreadMessageRow,
 } from "@bb/db";
 import type {
@@ -14,14 +17,13 @@ import type {
   Thread,
   ThreadQueuedMessage,
 } from "@bb/domain";
-import type { AppDeps } from "../../types.js";
 import {
   emitPluginMessageDispatched,
   emitPluginMessageQueued,
 } from "../plugins/plugin-thread-events.js";
 import { toThreadQueuedMessage } from "./thread-queued-messages.js";
 
-type QueueWaitDeps = Pick<AppDeps, "db" | "hub">;
+type QueueWaitDeps = { db: DbQueryConnection; hub: DbNotifier };
 
 /**
  * A settling row, for the plugin event its transition raises.
@@ -139,7 +141,7 @@ export function settleQueueRowDispatched(args: SettleQueueRowArgs): void {
  * where it is in the queue; only its eligibility changes.
  */
 export function clearQueuedMessageWait(
-  deps: QueueWaitDeps,
+  deps: { db: DbConnection; hub: DbNotifier },
   args: { queuedMessageId: string; threadId: string },
 ): QueuedThreadMessageRow | null {
   return clearQueuedThreadMessageWaitingOn(deps.db, deps.hub, {

--- a/apps/server/src/services/threads/queued-messages.ts
+++ b/apps/server/src/services/threads/queued-messages.ts
@@ -42,7 +42,10 @@ import {
   isCommandTimeoutError,
   runtimeErrorLogFields,
 } from "../lib/error-log-fields.js";
-import { toThreadQueuedMessage } from "./thread-queued-messages.js";
+import {
+  parseStoredQueuedThreadMessageWaitingOn,
+  toThreadQueuedMessage,
+} from "./thread-queued-messages.js";
 import {
   addRequestIdToTurnSubmitCommandPayload,
   buildExecutionOptions,
@@ -56,6 +59,7 @@ import {
 } from "./deferred-first-turn-context.js";
 import { appendClientTurnEventInTransaction } from "./thread-events.js";
 import {
+  getActiveTurnId,
   getLastProviderThreadId,
   isManualCompactionActive,
 } from "./thread-events.js";
@@ -119,6 +123,39 @@ interface SendClaimedQueuedMessageForThreadArgs {
 
 interface QueuedMessageAutoSendArgs {
   threadId: string;
+}
+
+type QueuedMessageGroupEligibility = NonNullable<
+  Parameters<typeof claimQueuedThreadMessageGroup>[3]
+>;
+
+export function createAutomaticQueuedMessageGroupEligibility(
+  deps: Pick<AppDeps, "db">,
+  args: { now: number; thread: Thread },
+): QueuedMessageGroupEligibility {
+  const activeTurnId = getActiveTurnId(deps, args.thread.id);
+  return (group) =>
+    group.every((member) => {
+      if (member.failureReason !== null) return false;
+      const waitingOn = parseStoredQueuedThreadMessageWaitingOn(member);
+      switch (waitingOn?.kind) {
+        case undefined:
+        case "plugin":
+          return true;
+        case "time":
+          return member.sendAt !== null && member.sendAt <= args.now;
+        case "thread-busy":
+          return (
+            args.thread.status === "idle" || args.thread.status === "pending"
+          );
+        case "turn-starting":
+          return args.thread.status === "active" && activeTurnId !== null;
+        case "provisioning":
+        case "host-offline":
+        case "interaction":
+          return false;
+      }
+    });
 }
 
 async function requireReadyQueuedMessageEnvironment(
@@ -759,12 +796,8 @@ export async function sendNextQueuedMessageIfPresent(
   deps: LoggedPendingInteractionWorkSessionDeps,
   args: { threadId: string },
 ): Promise<boolean> {
-  if (
-    !isQueuedMessageAutoSendCandidate(
-      deps.db,
-      getThread(deps.db, args.threadId),
-    )
-  ) {
+  const initialThread = getThread(deps.db, args.threadId);
+  if (!isQueuedMessageAutoSendCandidate(deps.db, initialThread)) {
     return false;
   }
 
@@ -772,6 +805,10 @@ export async function sendNextQueuedMessageIfPresent(
     deps.db,
     deps.hub,
     args.threadId,
+    createAutomaticQueuedMessageGroupEligibility(deps, {
+      now: Date.now(),
+      thread: initialThread,
+    }),
   );
   if (!nextQueuedMessages) {
     return false;

--- a/apps/server/src/services/threads/queued-messages.ts
+++ b/apps/server/src/services/threads/queued-messages.ts
@@ -6,6 +6,7 @@ import {
   getQueuedThreadMessage,
   getEnvironment,
   getThread,
+  isOrdinaryTurnEndQueuedMessage,
   isThreadQueueAutoSendPaused,
   listIdleThreadsWithQueuedMessages,
   releaseQueuedMessageClaim,
@@ -300,15 +301,13 @@ interface QueuedMessageAutoSendRequestArgs {
 }
 
 function isQueuedMessageAutoSendCandidate(
-  db: DbQueryConnection,
   thread: Thread | null,
 ): thread is Thread {
   return (
     thread !== null &&
     thread.archivedAt === null &&
     thread.deletedAt === null &&
-    thread.status !== "stopping" &&
-    !isThreadQueueAutoSendPaused(db, thread.id)
+    thread.status !== "stopping"
   );
 }
 
@@ -319,7 +318,18 @@ interface FormatQueuedMessageInputForSenderArgs {
 
 const STALE_QUEUED_MESSAGE_CLAIM_MS = 5 * 60 * 1000;
 const QUEUED_MESSAGE_CLAIM_LOST_CODE = "queued_message_claim_lost";
+const QUEUED_MESSAGE_AUTO_SEND_PAUSED_CODE = "queued_message_auto_send_paused";
 const activeQueuedMessageClaimTokens = new Set<string>();
+
+function respectsManualStopPause(
+  args: SendClaimedQueuedMessageForThreadArgs,
+): boolean {
+  return (
+    args.mode === "auto" &&
+    !args.sendNow &&
+    args.queuedMessages.every(isOrdinaryTurnEndQueuedMessage)
+  );
+}
 
 function sendQueuedMessagePayload(
   queuedMessage: ThreadQueuedMessage,
@@ -430,6 +440,21 @@ function isQueuedMessageClaimLostError(error: unknown): boolean {
   return (
     error instanceof ApiError &&
     error.body.code === QUEUED_MESSAGE_CLAIM_LOST_CODE
+  );
+}
+
+function createQueuedMessageAutoSendPausedError(): ApiError {
+  return new ApiError(
+    409,
+    QUEUED_MESSAGE_AUTO_SEND_PAUSED_CODE,
+    "Queued message auto-send was paused by a manual stop",
+  );
+}
+
+function isQueuedMessageAutoSendPausedError(error: unknown): boolean {
+  return (
+    error instanceof ApiError &&
+    error.body.code === QUEUED_MESSAGE_AUTO_SEND_PAUSED_CODE
   );
 }
 
@@ -544,6 +569,12 @@ async function sendClaimedQueuedMessageForIdleProviderThread(
 
   const { activeThread, command } = deps.db.transaction(
     (tx) => {
+      if (
+        respectsManualStopPause(args) &&
+        isThreadQueueAutoSendPaused(tx, thread.id)
+      ) {
+        throw createQueuedMessageAutoSendPausedError();
+      }
       if (deferredFirstTurnContext) {
         requireDeferredFirstTurnContextCurrent(tx, {
           requestSequence: deferredFirstTurnContext.requestSequence,
@@ -706,6 +737,7 @@ async function sendClaimedQueuedMessageForThread(
     source: {
       kind: "drain",
       claimed: args.queuedMessages,
+      respectManualStopPause: respectsManualStopPause(args),
       sendNow: args.sendNow,
     },
     queuePayload: queuedMessage.payload,
@@ -773,6 +805,7 @@ export async function sendQueuedMessage(
     (isManualCompactionActive(deps, thread) ||
       (args.mode === "auto" &&
         !args.sendNow &&
+        queuedMessages.every(isOrdinaryTurnEndQueuedMessage) &&
         isThreadQueueAutoSendPaused(deps.db, thread.id)))
   ) {
     releaseQueuedMessageClaims(deps, queuedMessages);
@@ -789,6 +822,9 @@ export async function sendQueuedMessage(
     );
   } catch (error) {
     releaseQueuedMessageClaims(deps, queuedMessages);
+    if (isQueuedMessageAutoSendPausedError(error)) {
+      return toThreadQueuedMessage(queuedMessages[0]!);
+    }
     throw error;
   }
 }
@@ -798,7 +834,7 @@ export async function sendNextQueuedMessageIfPresent(
   args: { threadId: string },
 ): Promise<boolean> {
   const initialThread = getThread(deps.db, args.threadId);
-  if (!isQueuedMessageAutoSendCandidate(deps.db, initialThread)) {
+  if (!isQueuedMessageAutoSendCandidate(initialThread)) {
     return false;
   }
 
@@ -817,7 +853,7 @@ export async function sendNextQueuedMessageIfPresent(
 
   const thread = getThread(deps.db, args.threadId);
   if (
-    !isQueuedMessageAutoSendCandidate(deps.db, thread) ||
+    !isQueuedMessageAutoSendCandidate(thread) ||
     isManualCompactionActive(deps, thread)
   ) {
     releaseQueuedMessageClaims(deps, nextQueuedMessages);
@@ -835,7 +871,10 @@ export async function sendNextQueuedMessageIfPresent(
     );
   } catch (error) {
     releaseQueuedMessageClaims(deps, nextQueuedMessages);
-    if (isQueuedMessageClaimLostError(error)) {
+    if (
+      isQueuedMessageClaimLostError(error) ||
+      isQueuedMessageAutoSendPausedError(error)
+    ) {
       return false;
     }
     // Nobody is listening to this attempt, so the row itself has to carry what

--- a/apps/server/src/services/threads/queued-messages.ts
+++ b/apps/server/src/services/threads/queued-messages.ts
@@ -90,7 +90,7 @@ import {
 import { validatePromptAttachmentReferences } from "../projects/attachments.js";
 
 interface SendQueuedMessageArgs {
-  isGroupEligible?: Parameters<typeof claimQueuedThreadMessageGroup>[3];
+  isGroupEligible?: Parameters<typeof claimQueuedThreadMessageGroup>[4];
   mode: SendQueuedMessageMode;
   queuedMessageId: string;
   /**
@@ -396,6 +396,7 @@ function claimQueuedThreadMessageForSend(
     deps.db,
     deps.hub,
     args.queuedMessageId,
+    args.sendNow,
     args.isGroupEligible,
   );
   if (claimedQueuedMessages) {

--- a/apps/server/src/services/threads/queued-messages.ts
+++ b/apps/server/src/services/threads/queued-messages.ts
@@ -12,10 +12,10 @@ import {
   releaseQueuedMessageClaim,
   releaseStaleQueuedMessageClaims,
   type DbQueryConnection,
+  type QueuedThreadMessageGroupClaimPolicy,
+  type QueuedThreadMessageGroupEligibility,
 } from "@bb/db";
-import {
-  queuedMessageSystemNoticeSchema,
-} from "@bb/domain";
+import { queuedMessageSystemNoticeSchema } from "@bb/domain";
 import type {
   PromptInput,
   QueuedMessageWaitingOn,
@@ -91,14 +91,9 @@ import {
 import { validatePromptAttachmentReferences } from "../projects/attachments.js";
 
 interface SendQueuedMessageArgs {
-  isGroupEligible?: Parameters<typeof claimQueuedThreadMessageGroup>[4];
+  claimPolicy: QueuedThreadMessageGroupClaimPolicy;
   mode: SendQueuedMessageMode;
   queuedMessageId: string;
-  /**
-   * True for the user's explicit "Send now", false for a timer that made the
-   * row eligible. Both address one row by id; only the first is an override.
-   */
-  sendNow: boolean;
   threadId: string;
 }
 
@@ -126,14 +121,10 @@ interface QueuedMessageAutoSendArgs {
   threadId: string;
 }
 
-type QueuedMessageGroupEligibility = NonNullable<
-  Parameters<typeof claimQueuedThreadMessageGroup>[3]
->;
-
 export function createAutomaticQueuedMessageGroupEligibility(
   deps: Pick<AppDeps, "db">,
   args: { now: number; thread: Thread },
-): QueuedMessageGroupEligibility {
+): QueuedThreadMessageGroupEligibility {
   const activeTurnId = getActiveTurnId(deps, args.thread.id);
   return (group) =>
     group.every((member) => {
@@ -150,7 +141,10 @@ export function createAutomaticQueuedMessageGroupEligibility(
             args.thread.status === "idle" || args.thread.status === "pending"
           );
         case "turn-starting":
-          return args.thread.status === "active" && activeTurnId !== null;
+          return (
+            args.thread.status === "idle" ||
+            (args.thread.status === "active" && activeTurnId !== null)
+          );
         case "provisioning":
         case "host-offline":
         case "interaction":
@@ -327,7 +321,7 @@ function respectsManualStopPause(
   return (
     args.mode === "auto" &&
     !args.sendNow &&
-    args.queuedMessages.every(isOrdinaryTurnEndQueuedMessage)
+    args.queuedMessages.some(isOrdinaryTurnEndQueuedMessage)
   );
 }
 
@@ -406,13 +400,12 @@ function claimQueuedThreadMessageForSend(
     deps.db,
     deps.hub,
     args.queuedMessageId,
-    args.sendNow,
-    args.isGroupEligible,
+    args.claimPolicy,
   );
   if (claimedQueuedMessages) {
     return claimedQueuedMessages;
   }
-  if (args.isGroupEligible) return [];
+  if (args.claimPolicy.kind === "automatic") return [];
 
   const latestQueuedMessage = getQueuedThreadMessage(
     deps.db,
@@ -792,6 +785,7 @@ export async function sendQueuedMessage(
   deps: LoggedPendingInteractionWorkSessionDeps,
   args: SendQueuedMessageArgs,
 ): Promise<ThreadQueuedMessage> {
+  const sendNow = args.claimPolicy.kind === "explicit-send";
   const queuedMessages = claimQueuedThreadMessageForSend(deps, args);
   if (queuedMessages.length === 0) {
     const existing = getQueuedThreadMessage(deps.db, args.queuedMessageId);
@@ -804,8 +798,8 @@ export async function sendQueuedMessage(
     thread &&
     (isManualCompactionActive(deps, thread) ||
       (args.mode === "auto" &&
-        !args.sendNow &&
-        queuedMessages.every(isOrdinaryTurnEndQueuedMessage) &&
+        !sendNow &&
+        queuedMessages.some(isOrdinaryTurnEndQueuedMessage) &&
         isThreadQueueAutoSendPaused(deps.db, thread.id)))
   ) {
     releaseQueuedMessageClaims(deps, queuedMessages);
@@ -816,7 +810,7 @@ export async function sendQueuedMessage(
       sendClaimedQueuedMessage(deps, {
         mode: args.mode,
         queuedMessages,
-        sendNow: args.sendNow,
+        sendNow,
         threadId: args.threadId,
       }),
     );

--- a/apps/server/src/services/threads/thread-queued-messages.ts
+++ b/apps/server/src/services/threads/thread-queued-messages.ts
@@ -61,7 +61,7 @@ function parseStoredQueuedThreadMessageContent(
   return parsed.data;
 }
 
-function parseStoredQueuedThreadMessageWaitingOn(
+export function parseStoredQueuedThreadMessageWaitingOn(
   row: Pick<StoredQueuedThreadMessageRow, "id" | "threadId" | "waitingOn">,
 ): QueuedMessageWaitingOn | null {
   if (row.waitingOn === null) return null;

--- a/apps/server/src/services/threads/thread-turn-starting.ts
+++ b/apps/server/src/services/threads/thread-turn-starting.ts
@@ -7,6 +7,7 @@ import type {
 } from "@bb/domain";
 import type { AppDeps } from "../../types.js";
 import { emitPluginMessageQueued } from "../plugins/plugin-thread-events.js";
+import { getActiveTurnId } from "./thread-events.js";
 import { toThreadQueuedMessage } from "./thread-queued-messages.js";
 
 interface TurnStartingQueuedInput {
@@ -22,12 +23,19 @@ type TurnStartingDeps = Pick<AppDeps, "db" | "hub" | "logger">;
 export function queueInputForStartingTurn(
   deps: TurnStartingDeps,
   args: { input: TurnStartingQueuedInput; threadId: string },
-): void {
-  if (args.input.content.length === 0) return;
+): boolean {
+  if (args.input.content.length === 0) return false;
   const queued = deps.db.transaction(
     (tx) => {
       const thread = getThread(tx, args.threadId);
-      if (!thread || thread.deletedAt !== null) return null;
+      if (
+        !thread ||
+        thread.status !== "active" ||
+        thread.deletedAt !== null ||
+        getActiveTurnId({ db: tx }, args.threadId) !== null
+      ) {
+        return null;
+      }
       return createQueuedThreadMessageInTransaction(tx, {
         threadId: args.threadId,
         content: args.input.content,
@@ -44,11 +52,12 @@ export function queueInputForStartingTurn(
     },
     { behavior: "immediate" },
   );
-  if (queued === null) return;
+  if (queued === null) return false;
   emitPluginMessageQueued(toThreadQueuedMessage(queued));
   deps.hub.notifyThread(args.threadId, ["queue-changed"]);
   deps.logger.info(
     { queuedMessageId: queued.id, threadId: args.threadId },
     "Queued input until the current turn starts",
   );
+  return true;
 }

--- a/apps/server/src/services/threads/thread-turn-starting.ts
+++ b/apps/server/src/services/threads/thread-turn-starting.ts
@@ -1,63 +1,80 @@
-import { createQueuedThreadMessageInTransaction, getThread } from "@bb/db";
+import { getThread, type ClaimedQueuedThreadMessageRow } from "@bb/db";
 import type {
-  PromptInput,
-  QueuedMessagePayload,
-  QueuedMessageSystemNotice,
-  ResolvedThreadExecutionOptions,
+  QueuedMessageWaitingOn,
+  Thread,
+  ThreadQueuedMessage,
 } from "@bb/domain";
 import type { AppDeps } from "../../types.js";
-import { emitPluginMessageQueued } from "../plugins/plugin-thread-events.js";
+import { NotificationBuffer } from "../lib/notification-buffer.js";
+import {
+  recordQueuedMessageWait,
+  type QueuedDispatchMessage,
+} from "./queue-waits.js";
 import { getActiveTurnId } from "./thread-events.js";
-import { toThreadQueuedMessage } from "./thread-queued-messages.js";
-
-interface TurnStartingQueuedInput {
-  content: PromptInput[];
-  execution: ResolvedThreadExecutionOptions;
-  payload: QueuedMessagePayload;
-  senderThreadId: string | null;
-  systemNotice: QueuedMessageSystemNotice | null;
-}
 
 type TurnStartingDeps = Pick<AppDeps, "db" | "hub" | "logger">;
 
+export type QueueInputForStartingTurnResult =
+  | { kind: "continue" }
+  | { kind: "dispatched" }
+  | { kind: "queued"; entry: ThreadQueuedMessage }
+  | { kind: "thread-changed"; thread: Thread | null };
+
 export function queueInputForStartingTurn(
   deps: TurnStartingDeps,
-  args: { input: TurnStartingQueuedInput; threadId: string },
-): boolean {
-  if (args.input.content.length === 0) return false;
-  const queued = deps.db.transaction(
+  args: {
+    claimed: readonly ClaimedQueuedThreadMessageRow[] | null;
+    fallbackWaitingOn: QueuedMessageWaitingOn | null;
+    input: QueuedDispatchMessage;
+    threadId: string;
+  },
+): QueueInputForStartingTurnResult {
+  if (args.input.input.length === 0) return { kind: "dispatched" };
+  const notifications = new NotificationBuffer();
+  const outcome: QueueInputForStartingTurnResult = deps.db.transaction(
     (tx) => {
       const thread = getThread(tx, args.threadId);
       if (
         !thread ||
-        thread.status !== "active" ||
+        thread.archivedAt !== null ||
         thread.deletedAt !== null ||
-        getActiveTurnId({ db: tx }, args.threadId) !== null
+        thread.status === "stopping"
       ) {
-        return null;
+        return { kind: "thread-changed", thread };
       }
-      return createQueuedThreadMessageInTransaction(tx, {
-        threadId: args.threadId,
-        content: args.input.content,
-        senderThreadId: args.input.senderThreadId,
-        model: args.input.execution.model,
-        reasoningLevel: args.input.execution.reasoningLevel,
-        permissionMode: args.input.execution.permissionMode,
-        serviceTier: args.input.execution.serviceTier,
-        waitingOn: { kind: "turn-starting" },
-        sendAt: null,
-        payload: args.input.payload,
-        systemNotice: args.input.systemNotice,
-      });
+      const waitingOn =
+        thread.status === "active"
+          ? getActiveTurnId({ db: tx }, args.threadId) === null
+            ? { kind: "turn-starting" as const }
+            : null
+          : args.fallbackWaitingOn;
+      if (waitingOn === null) {
+        return thread.status === "active"
+          ? { kind: "continue" }
+          : { kind: "thread-changed", thread };
+      }
+      const entry = recordQueuedMessageWait(
+        { db: tx, hub: notifications },
+        {
+          thread,
+          message: args.input,
+          waitingOn,
+          sendAt: null,
+          claimed: args.claimed,
+        },
+      );
+      return entry === null
+        ? { kind: "dispatched" }
+        : { kind: "queued", entry };
     },
     { behavior: "immediate" },
   );
-  if (queued === null) return false;
-  emitPluginMessageQueued(toThreadQueuedMessage(queued));
-  deps.hub.notifyThread(args.threadId, ["queue-changed"]);
-  deps.logger.info(
-    { queuedMessageId: queued.id, threadId: args.threadId },
-    "Queued input until the current turn starts",
-  );
-  return true;
+  notifications.flushInto(deps.hub);
+  if (outcome.kind === "queued") {
+    deps.logger.info(
+      { queuedMessageId: outcome.entry.id, threadId: args.threadId },
+      "Queued input until the current turn starts",
+    );
+  }
+  return outcome;
 }

--- a/apps/server/src/services/threads/thread-turn-starting.ts
+++ b/apps/server/src/services/threads/thread-turn-starting.ts
@@ -1,9 +1,5 @@
 import { getThread, type ClaimedQueuedThreadMessageRow } from "@bb/db";
-import type {
-  QueuedMessageWaitingOn,
-  Thread,
-  ThreadQueuedMessage,
-} from "@bb/domain";
+import type { Thread, ThreadQueuedMessage } from "@bb/domain";
 import type { AppDeps } from "../../types.js";
 import { NotificationBuffer } from "../lib/notification-buffer.js";
 import {
@@ -15,16 +11,14 @@ import { getActiveTurnId } from "./thread-events.js";
 type TurnStartingDeps = Pick<AppDeps, "db" | "hub" | "logger">;
 
 export type QueueInputForStartingTurnResult =
-  | { kind: "continue" }
   | { kind: "dispatched" }
   | { kind: "queued"; entry: ThreadQueuedMessage }
-  | { kind: "thread-changed"; thread: Thread | null };
+  | { kind: "retry"; thread: Thread | null };
 
 export function queueInputForStartingTurn(
   deps: TurnStartingDeps,
   args: {
     claimed: readonly ClaimedQueuedThreadMessageRow[] | null;
-    fallbackWaitingOn: QueuedMessageWaitingOn | null;
     input: QueuedDispatchMessage;
     threadId: string;
   },
@@ -38,27 +32,19 @@ export function queueInputForStartingTurn(
         !thread ||
         thread.archivedAt !== null ||
         thread.deletedAt !== null ||
-        thread.status === "stopping"
+        thread.status !== "active"
       ) {
-        return { kind: "thread-changed", thread };
+        return { kind: "retry", thread };
       }
-      const waitingOn =
-        thread.status === "active"
-          ? getActiveTurnId({ db: tx }, args.threadId) === null
-            ? { kind: "turn-starting" as const }
-            : null
-          : args.fallbackWaitingOn;
-      if (waitingOn === null) {
-        return thread.status === "active"
-          ? { kind: "continue" }
-          : { kind: "thread-changed", thread };
+      if (getActiveTurnId({ db: tx }, args.threadId) !== null) {
+        return { kind: "retry", thread };
       }
       const entry = recordQueuedMessageWait(
         { db: tx, hub: notifications },
         {
           thread,
           message: args.input,
-          waitingOn,
+          waitingOn: { kind: "turn-starting" },
           sendAt: null,
           claimed: args.claimed,
         },

--- a/apps/server/test/public/public-thread-fork.test.ts
+++ b/apps/server/test/public/public-thread-fork.test.ts
@@ -609,10 +609,13 @@ describe("public thread fork route", () => {
       ).toBe("updated");
 
       await sendQueuedMessage(harness.deps, {
+        claimPolicy: {
+          kind: "automatic",
+          isGroupEligible: () => true,
+        },
         threadId: fork.id,
         queuedMessageId: first.id,
         mode: "auto",
-        sendNow: false,
       });
 
       const turn = await waitForQueuedCommandAfter(

--- a/apps/server/test/public/public-thread-stop-runtime.test.ts
+++ b/apps/server/test/public/public-thread-stop-runtime.test.ts
@@ -1,9 +1,16 @@
-import { getThread, listEvents, listQueuedThreadMessages } from "@bb/db";
+import {
+  getThread,
+  isThreadQueueAutoSendPaused,
+  listEvents,
+  listQueuedThreadMessages,
+} from "@bb/db";
 import { turnScope } from "@bb/domain";
+import { groupHostDaemonEvents } from "@bb/host-daemon-contract";
 import { describe, expect, it } from "vitest";
 import {
   listQueuedCommands,
   listQueuedThreadCommands,
+  internalAuthHeaders,
   reportQueuedCommandError,
   reportQueuedCommandSuccess,
   waitForQueuedCommand,
@@ -147,7 +154,7 @@ describe("thread runtime stop", () => {
 
   it("keeps queued messages paused after a manual stop until explicitly sent", async () => {
     await withTestHarness(async (harness) => {
-      const { thread } = seedThreadFixture(harness, {
+      const { session, thread } = seedThreadFixture(harness, {
         thread: { status: "active", visibility: "hidden" },
       });
       const queueResponse = await harness.app.request(
@@ -200,6 +207,34 @@ describe("thread runtime stop", () => {
         listQueuedThreadCommands(harness, "turn.submit", thread.id),
       ).toEqual([]);
 
+      const staleStart = await harness.app.request("/internal/session/events", {
+        method: "POST",
+        headers: internalAuthHeaders(harness),
+        body: JSON.stringify({
+          sessionId: session.id,
+          eventGroups: groupHostDaemonEvents([
+            {
+              threadId: thread.id,
+              event: {
+                type: "turn/started",
+                threadId: thread.id,
+                providerThreadId: "provider-stopped-runtime",
+                scope: turnScope("turn-stopped-runtime"),
+              },
+            },
+          ]),
+        }),
+      });
+      expect(staleStart.status).toBe(200);
+      expect(getThread(harness.db, thread.id)?.status).toBe("idle");
+      expect(isThreadQueueAutoSendPaused(harness.db, thread.id)).toBe(true);
+
+      await runQueuedMessageAutoSendSweep(harness.deps);
+      expect(listQueuedThreadMessages(harness.db, thread.id)).toHaveLength(1);
+      expect(
+        listQueuedThreadCommands(harness, "turn.submit", thread.id),
+      ).toEqual([]);
+
       const sendResponse = await harness.app.request(
         `/api/v1/threads/${thread.id}/queued-messages/${queuedMessage.id}/send`,
         {
@@ -212,8 +247,32 @@ describe("thread runtime stop", () => {
       expect(listQueuedThreadMessages(harness.db, thread.id)).toEqual([]);
       expect(getThread(harness.db, thread.id)?.status).toBe("active");
       expect(
-        listQueuedThreadCommands(harness, "thread.start", thread.id),
+        listQueuedThreadCommands(harness, "turn.submit", thread.id),
       ).toHaveLength(1);
+
+      const acceptedStart = await harness.app.request(
+        "/internal/session/events",
+        {
+          method: "POST",
+          headers: internalAuthHeaders(harness),
+          body: JSON.stringify({
+            sessionId: session.id,
+            eventGroups: groupHostDaemonEvents([
+              {
+                threadId: thread.id,
+                event: {
+                  type: "turn/started",
+                  threadId: thread.id,
+                  providerThreadId: "provider-stopped-runtime",
+                  scope: turnScope("turn-deliberate-resume"),
+                },
+              },
+            ]),
+          }),
+        },
+      );
+      expect(acceptedStart.status).toBe(200);
+      expect(isThreadQueueAutoSendPaused(harness.db, thread.id)).toBe(false);
     });
   });
 

--- a/apps/server/test/public/public-thread-stop-runtime.test.ts
+++ b/apps/server/test/public/public-thread-stop-runtime.test.ts
@@ -191,9 +191,12 @@ describe("thread runtime stop", () => {
 
       const queuedMessage = listQueuedThreadMessages(harness.db, thread.id)[0]!;
       await sendQueuedMessage(harness.deps, {
+        claimPolicy: {
+          kind: "automatic",
+          isGroupEligible: () => true,
+        },
         mode: "auto",
         queuedMessageId: queuedMessage.id,
-        sendNow: false,
         threadId: thread.id,
       });
       await runQueuedMessageAutoSendSweep(harness.deps);

--- a/apps/server/test/services/plugins/plugin-mention-providers.test.ts
+++ b/apps/server/test/services/plugins/plugin-mention-providers.test.ts
@@ -396,10 +396,13 @@ describe("plugin mention providers (bb.ui.registerMentionProvider)", () => {
     });
 
     await sendQueuedMessage(harness.deps, {
+      claimPolicy: {
+        kind: "automatic",
+        isGroupEligible: () => true,
+      },
       threadId: thread.id,
       queuedMessageId: queued.id,
       mode: "auto",
-      sendNow: false,
     });
 
     const dispatched = await waitForQueuedCommand(

--- a/apps/server/test/threads/dispatch-hooks.test.ts
+++ b/apps/server/test/threads/dispatch-hooks.test.ts
@@ -6,6 +6,7 @@ import {
   listRunningThreads,
 } from "@bb/db";
 import type { ThreadQueuedMessage } from "@bb/domain";
+import { createDeferredPromise } from "@bb/test-helpers";
 import type { PluginHookName } from "@get-bb/plugin-sdk";
 import { afterEach, describe, expect, it } from "vitest";
 import { ApiError } from "../../src/errors.js";
@@ -22,6 +23,11 @@ import { attemptDispatch } from "../../src/services/threads/dispatch-attempt.js"
 import { createThreadFromRequest } from "../../src/services/threads/thread-create.js";
 import { toThreadQueuedMessage } from "../../src/services/threads/thread-queued-messages.js";
 import { textInput } from "../helpers/prompt-input.js";
+import {
+  listQueuedThreadCommands,
+  reportQueuedCommandSuccess,
+  waitForQueuedCommand,
+} from "../helpers/commands.js";
 import {
   seedEnvironment,
   seedHostSession,
@@ -613,6 +619,64 @@ describe("message.dispatch hooks on the queue drain", () => {
         reason: "at capacity",
       });
       expect(turnRequests(harness, thread.id)).toHaveLength(turnsBefore);
+    });
+  });
+
+  it("returns an ordinary row when its hook pass crosses a manual stop", async () => {
+    await withTestHarness(async (harness) => {
+      const entered = createDeferredPromise<void>();
+      const release = createDeferredPromise<void>();
+      const registry = emptyRegistry();
+      registry["message.dispatch"].push({
+        pluginId: "limiter",
+        handler: async () => {
+          entered.resolve();
+          await release.promise;
+          return { action: "proceed" } as const;
+        },
+      });
+      installHooks(registry);
+      const { thread } = seedRunnableThread(harness, {
+        hostId: "host-hook-stop-race",
+        status: "active",
+      });
+      const queued = await createQueuedMessageForThread(harness.deps, {
+        payload: { input: textInput("stay paused") },
+        thread,
+      });
+      const turnsBefore = turnRequests(harness, thread.id).length;
+
+      const draining = sendNextQueuedMessageIfPresent(harness.deps, {
+        threadId: thread.id,
+      });
+      await entered.promise;
+      try {
+        const stopResponse = harness.app.request(
+          `/api/v1/threads/${thread.id}/stop`,
+          { method: "POST" },
+        );
+        const stop = await waitForQueuedCommand(
+          harness,
+          ({ command }) =>
+            command.type === "thread.stop" && command.threadId === thread.id,
+        );
+        await reportQueuedCommandSuccess(harness, stop, {
+          providerCheckpointId: null,
+        });
+        expect((await stopResponse).status).toBe(200);
+      } finally {
+        release.resolve();
+      }
+
+      await expect(draining).resolves.toBe(false);
+      expect(getThread(harness.db, thread.id)?.status).toBe("idle");
+      expect(listQueuedThreadMessages(harness.db, thread.id)).toMatchObject([
+        { id: queued.id },
+      ]);
+      expect(turnRequests(harness, thread.id)).toHaveLength(turnsBefore);
+      expect(
+        listQueuedThreadCommands(harness, "turn.submit", thread.id),
+      ).toEqual([]);
     });
   });
 });

--- a/apps/server/test/threads/dispatch-hooks.test.ts
+++ b/apps/server/test/threads/dispatch-hooks.test.ts
@@ -21,6 +21,7 @@ import {
 import { acceptThreadSendRequest } from "../../src/services/threads/thread-send-request.js";
 import { attemptDispatch } from "../../src/services/threads/dispatch-attempt.js";
 import { createThreadFromRequest } from "../../src/services/threads/thread-create.js";
+import { applyLoggedThreadLifecycleEvent } from "../../src/services/threads/lifecycle-outcome.js";
 import { toThreadQueuedMessage } from "../../src/services/threads/thread-queued-messages.js";
 import { textInput } from "../helpers/prompt-input.js";
 import {
@@ -184,9 +185,7 @@ function seedRunnableThread(
   return { environment, project, thread };
 }
 
-async function expectApiError(
-  run: () => Promise<unknown>,
-): Promise<ApiError> {
+async function expectApiError(run: () => Promise<unknown>): Promise<ApiError> {
   try {
     await run();
   } catch (error) {
@@ -382,7 +381,10 @@ describe("message.dispatch hook composition", () => {
         },
       );
       installHooks(registry);
-      const { host, project } = seedDispatchFixture(harness, "host-hook-reject");
+      const { host, project } = seedDispatchFixture(
+        harness,
+        "host-hook-reject",
+      );
 
       const error = await expectApiError(() =>
         createHookedThread(harness, { hostId: host.id, projectId: project.id }),
@@ -447,7 +449,10 @@ describe("message.dispatch hook admission visibility", () => {
           const running = listRunningThreads(harness.db);
           seen.push(running.map((row) => row.id));
           return running.length >= 1
-            ? ({ action: "wait", reason: "1 of 1 running on all hosts" } as const)
+            ? ({
+                action: "wait",
+                reason: "1 of 1 running on all hosts",
+              } as const)
             : ({ action: "proceed" } as const);
         },
       });
@@ -561,7 +566,10 @@ describe("dispatch hooks and the no-hook path", () => {
         pluginId: "limiter",
         handler: (context) => {
           attempts.push(context.attempt);
-          return { action: "reject", message: "no steering right now" } as const;
+          return {
+            action: "reject",
+            message: "no steering right now",
+          } as const;
         },
       });
       installHooks(registry);
@@ -638,7 +646,7 @@ describe("message.dispatch hooks on the queue drain", () => {
       installHooks(registry);
       const { thread } = seedRunnableThread(harness, {
         hostId: "host-hook-stop-race",
-        status: "active",
+        status: "idle",
       });
       const queued = await createQueuedMessageForThread(harness.deps, {
         payload: { input: textInput("stay paused") },
@@ -651,6 +659,16 @@ describe("message.dispatch hooks on the queue drain", () => {
       });
       await entered.promise;
       try {
+        applyLoggedThreadLifecycleEvent(harness.deps, {
+          event: { type: "run.started" },
+          threadId: thread.id,
+        });
+        seedTurnStarted(harness.deps, {
+          environmentId: thread.environmentId,
+          providerThreadId: "provider-host-hook-stop-race",
+          threadId: thread.id,
+          turnId: "turn-host-hook-stop-race",
+        });
         const stopResponse = harness.app.request(
           `/api/v1/threads/${thread.id}/stop`,
           { method: "POST" },

--- a/apps/server/test/threads/queue-drain-failure.test.ts
+++ b/apps/server/test/threads/queue-drain-failure.test.ts
@@ -145,7 +145,12 @@ describe("recordQueuedMessageDrainFailure", () => {
 
         expect(attempts).toBe(1);
         expect(
-          claimQueuedThreadMessageGroup(harness.db, harness.deps.hub, row.id),
+          claimQueuedThreadMessageGroup(
+            harness.db,
+            harness.deps.hub,
+            row.id,
+            true,
+          ),
         ).not.toBeNull();
       } finally {
         setPluginHookProvider(undefined);

--- a/apps/server/test/threads/queue-drain-failure.test.ts
+++ b/apps/server/test/threads/queue-drain-failure.test.ts
@@ -145,12 +145,9 @@ describe("recordQueuedMessageDrainFailure", () => {
 
         expect(attempts).toBe(1);
         expect(
-          claimQueuedThreadMessageGroup(
-            harness.db,
-            harness.deps.hub,
-            row.id,
-            true,
-          ),
+          claimQueuedThreadMessageGroup(harness.db, harness.deps.hub, row.id, {
+            kind: "explicit-send",
+          }),
         ).not.toBeNull();
       } finally {
         setPluginHookProvider(undefined);

--- a/apps/server/test/threads/requested-queue-drain.test.ts
+++ b/apps/server/test/threads/requested-queue-drain.test.ts
@@ -140,6 +140,65 @@ describe("the requested queue drain", () => {
     });
   });
 
+  it("drains a group after its mixed plugin and timer waits clear", async () => {
+    await withTestHarness(async (harness) => {
+      vi.useFakeTimers();
+      let released = false;
+      let attempts = 0;
+      installHooks({
+        "message.dispatch": [
+          {
+            pluginId: "limiter",
+            handler: () => {
+              attempts += 1;
+              return released
+                ? ({ action: "proceed" } as const)
+                : ({ action: "wait", reason: "At capacity" } as const);
+            },
+          },
+        ],
+      });
+      const { thread } = seedRunnableThread(harness, {
+        hostId: "host-mixed-group",
+        status: "idle",
+      });
+      await acceptThreadSendRequest(harness.deps, {
+        payload: { input: textInput("plugin-held lead"), mode: "auto" },
+        thread,
+      });
+      await acceptThreadSendRequest(harness.deps, {
+        payload: {
+          input: textInput("scheduled tail"),
+          mode: "auto",
+          sendAt: Date.now() + 1_000,
+        },
+        thread,
+      });
+      const queued = listQueuedThreadMessages(harness.db, thread.id);
+      setQueuedThreadMessageGroupBoundary({
+        db: harness.db,
+        notifier: harness.deps.hub,
+        threadId: thread.id,
+        expectedGroupedPrefixQueuedMessageIds: queued.map((row) => row.id),
+        groupBoundaryQueuedMessageId: queued[1]!.id,
+      });
+      const turnsBefore = turnRequests(harness, thread.id).length;
+
+      released = true;
+      await runRequestedQueueDrain(harness.deps);
+
+      expect(attempts).toBe(1);
+      expect(listQueuedThreadMessages(harness.db, thread.id)).toHaveLength(2);
+
+      vi.advanceTimersByTime(1_000);
+      await runDueScheduledQueueSweep(harness.deps, Date.now());
+
+      expect(attempts).toBe(2);
+      expect(listQueuedThreadMessages(harness.db, thread.id)).toHaveLength(0);
+      expect(turnRequests(harness, thread.id)).toHaveLength(turnsBefore + 1);
+    });
+  });
+
   it("re-attempts a plugin-queued row once the hook lets it through", async () => {
     // The release path that replaced a plugin releasing its own wait: core
     // re-attempts, the hook re-decides, and a row that is still blocked simply

--- a/apps/server/test/threads/requested-queue-drain.test.ts
+++ b/apps/server/test/threads/requested-queue-drain.test.ts
@@ -15,6 +15,8 @@ import {
   runDueScheduledQueueSweep,
   runRequestedQueueDrain,
 } from "../../src/services/threads/queue-drains.js";
+import { applyLoggedThreadLifecycleEvent } from "../../src/services/threads/lifecycle-outcome.js";
+import { runQueuedMessageAutoSendForThread } from "../../src/services/threads/queued-messages.js";
 import { acceptThreadSendRequest } from "../../src/services/threads/thread-send-request.js";
 import { textInput } from "../helpers/prompt-input.js";
 import {
@@ -198,6 +200,93 @@ describe("the requested queue drain", () => {
       expect(turnRequests(harness, thread.id)).toHaveLength(turnsBefore + 1);
     });
   });
+
+  it.each(["plugin-first", "thread-first"] as const)(
+    "drains a plugin and thread-busy group when %s clears",
+    async (first) => {
+      await withTestHarness(async (harness) => {
+        vi.useFakeTimers();
+        let released = first === "plugin-first";
+        let attempts = 0;
+        installHooks({
+          "message.dispatch": [
+            {
+              pluginId: "limiter",
+              handler: () => {
+                attempts += 1;
+                return released
+                  ? ({ action: "proceed" } as const)
+                  : ({ action: "wait", reason: "At capacity" } as const);
+              },
+            },
+          ],
+        });
+        const { thread } = seedRunnableThread(harness, {
+          hostId: `host-plugin-thread-${first}`,
+          status: "active",
+        });
+        const pluginHeld = seedQueuedMessage(harness.deps, {
+          threadId: thread.id,
+          content: textInput("plugin-held lead"),
+          waitingOn: {
+            kind: "plugin",
+            pluginId: "limiter",
+            reason: "At capacity",
+          },
+        });
+        const threadBusy = seedQueuedMessage(harness.deps, {
+          threadId: thread.id,
+          content: textInput("thread-busy tail"),
+          waitingOn: { kind: "thread-busy" },
+        });
+        setQueuedThreadMessageGroupBoundary({
+          db: harness.db,
+          notifier: harness.deps.hub,
+          threadId: thread.id,
+          expectedGroupedPrefixQueuedMessageIds: [
+            pluginHeld.id,
+            threadBusy.id,
+          ],
+          groupBoundaryQueuedMessageId: threadBusy.id,
+        });
+        const turnsBefore = turnRequests(harness, thread.id).length;
+
+        if (first === "plugin-first") {
+          await runRequestedQueueDrain(harness.deps);
+          expect(attempts).toBe(0);
+          expect(listQueuedThreadMessages(harness.db, thread.id)).toHaveLength(
+            2,
+          );
+        }
+
+        applyLoggedThreadLifecycleEvent(harness.deps, {
+          event: { type: "run.succeeded" },
+          threadId: thread.id,
+        });
+        await runQueuedMessageAutoSendForThread(harness.deps, {
+          threadId: thread.id,
+        });
+
+        if (first === "thread-first") {
+          expect(attempts).toBe(1);
+          expect(listQueuedThreadMessages(harness.db, thread.id)).toHaveLength(
+            2,
+          );
+          await runQueuedMessageAutoSendForThread(harness.deps, {
+            threadId: thread.id,
+          });
+          expect(attempts).toBe(1);
+          released = true;
+          vi.advanceTimersByTime(1_001);
+          await runRequestedQueueDrain(harness.deps);
+        }
+
+        expect(attempts).toBe(first === "plugin-first" ? 1 : 2);
+        expect(listQueuedThreadMessages(harness.db, thread.id)).toHaveLength(0);
+        expect(turnRequests(harness, thread.id)).toHaveLength(turnsBefore + 1);
+      });
+    },
+  );
 
   it("re-attempts a plugin-queued row once the hook lets it through", async () => {
     // The release path that replaced a plugin releasing its own wait: core

--- a/apps/server/test/threads/requested-queue-drain.test.ts
+++ b/apps/server/test/threads/requested-queue-drain.test.ts
@@ -262,10 +262,7 @@ describe("the requested queue drain", () => {
           db: harness.db,
           notifier: harness.deps.hub,
           threadId: thread.id,
-          expectedGroupedPrefixQueuedMessageIds: [
-            pluginHeld.id,
-            threadBusy.id,
-          ],
+          expectedGroupedPrefixQueuedMessageIds: [pluginHeld.id, threadBusy.id],
           groupBoundaryQueuedMessageId: threadBusy.id,
         });
         const turnsBefore = turnRequests(harness, thread.id).length;

--- a/apps/server/test/threads/requested-queue-drain.test.ts
+++ b/apps/server/test/threads/requested-queue-drain.test.ts
@@ -20,6 +20,10 @@ import { runQueuedMessageAutoSendForThread } from "../../src/services/threads/qu
 import { acceptThreadSendRequest } from "../../src/services/threads/thread-send-request.js";
 import { textInput } from "../helpers/prompt-input.js";
 import {
+  reportQueuedCommandSuccess,
+  waitForQueuedCommand,
+} from "../helpers/commands.js";
+import {
   seedEnvironment,
   seedHostSession,
   seedProjectWithSource,
@@ -91,6 +95,21 @@ function turnRequests(harness: TestAppHarness, threadId: string) {
   return listEvents(harness.db, { threadId }).filter(
     (event) => event.type === "client/turn/requested",
   );
+}
+
+async function stopThread(harness: TestAppHarness, threadId: string) {
+  const response = harness.app.request(`/api/v1/threads/${threadId}/stop`, {
+    method: "POST",
+  });
+  const stop = await waitForQueuedCommand(
+    harness,
+    ({ command }) =>
+      command.type === "thread.stop" && command.threadId === threadId,
+  );
+  await reportQueuedCommandSuccess(harness, stop, {
+    providerCheckpointId: null,
+  });
+  expect((await response).status).toBe(200);
 }
 
 describe("the requested queue drain", () => {
@@ -326,6 +345,46 @@ describe("the requested queue drain", () => {
       expect(turnRequests(harness, thread.id)).toHaveLength(turnsBefore + 1);
     });
   });
+
+  it.each(["scheduled", "plugin"] as const)(
+    "dispatches independently %s work after a manual stop",
+    async (kind) => {
+      await withTestHarness(async (harness) => {
+        installHooks({
+          "message.dispatch": [
+            {
+              pluginId: "limiter",
+              handler: () => ({ action: "proceed" }) as const,
+            },
+          ],
+        });
+        const { thread } = seedRunnableThread(harness, {
+          hostId: `host-stopped-${kind}`,
+          status: "active",
+        });
+        seedQueuedMessage(harness.deps, {
+          threadId: thread.id,
+          content: textInput(`${kind} work`),
+          waitingOn:
+            kind === "scheduled"
+              ? { kind: "time" }
+              : { kind: "plugin", pluginId: "limiter", reason: "held" },
+          sendAt: kind === "scheduled" ? Date.now() - 1_000 : null,
+        });
+        const turnsBefore = turnRequests(harness, thread.id).length;
+        await stopThread(harness, thread.id);
+
+        if (kind === "scheduled") {
+          await runDueScheduledQueueSweep(harness.deps, Date.now());
+        } else {
+          await runRequestedQueueDrain(harness.deps);
+        }
+
+        expect(listQueuedThreadMessages(harness.db, thread.id)).toEqual([]);
+        expect(turnRequests(harness, thread.id)).toHaveLength(turnsBefore + 1);
+      });
+    },
+  );
 
   it.each(["scheduled", "plugin"] as const)(
     "does not dispatch a %s group containing a failed row",

--- a/apps/server/test/threads/thread-send-dispatch.test.ts
+++ b/apps/server/test/threads/thread-send-dispatch.test.ts
@@ -14,8 +14,9 @@ import {
   type ThreadChangedMessage,
 } from "@bb/domain";
 import { groupHostDaemonEvents } from "@bb/host-daemon-contract";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { TelemetryService } from "../../src/services/system/telemetry.js";
+import * as threadEvents from "../../src/services/threads/thread-events.js";
 import { sendQueuedMessage } from "../../src/services/threads/queued-messages.js";
 import { queueParentSystemMessage } from "../../src/services/threads/parent-system-messages.js";
 import { acceptThreadSendRequest } from "../../src/services/threads/thread-send-request.js";
@@ -55,6 +56,8 @@ interface SeedIdleThreadFixtureArgs {
 interface SeedProviderThreadFixtureArgs extends SeedIdleThreadFixtureArgs {
   status?: "active" | "idle";
 }
+
+afterEach(() => vi.restoreAllMocks());
 
 function seedProviderThreadFixture(
   args: SeedProviderThreadFixtureArgs,
@@ -407,6 +410,21 @@ describe("turn-starting queue wait", () => {
           listQueuedThreadMessages(harness.db, thread.id)[0]!.waitingOn!,
         ),
       ).toEqual({ kind: "thread-busy" });
+
+      vi.spyOn(threadEvents, "getActiveTurnId").mockReturnValueOnce(null);
+      await expect(
+        acceptThreadSendRequest(harness.deps, {
+          payload: {
+            input: textInput("send after the wake scan"),
+            mode: "steer",
+            model: "gpt-5",
+            permissionMode: "full",
+            reasoningLevel: "medium",
+            serviceTier: "default",
+          },
+          thread,
+        }),
+      ).resolves.toEqual({ ok: true, delivery: "sent" });
     });
   });
 
@@ -486,6 +504,21 @@ describe("turn-starting queue wait", () => {
         }),
       ]);
       expect(listQueuedThreadMessages(harness.db, thread.id)).toEqual([]);
+
+      vi.spyOn(threadEvents, "getActiveTurnId").mockReturnValueOnce(null);
+      await expect(
+        queueParentSystemMessage(harness.deps, {
+          input,
+          parentThreadId: thread.id,
+          systemMessageKind: "child-completed",
+          systemMessageSubject: {
+            kind: "thread",
+            threadId: "child-2",
+            threadName: "Other child",
+          },
+        }),
+      ).resolves.toBe(true);
+      expect(listQueuedThreadMessages(harness.db, thread.id)).toHaveLength(0);
     });
   });
 });

--- a/apps/server/test/threads/thread-send-dispatch.test.ts
+++ b/apps/server/test/threads/thread-send-dispatch.test.ts
@@ -304,6 +304,50 @@ describe("user message telemetry", () => {
 });
 
 describe("turn-starting queue wait", () => {
+  it.each([
+    ["archive", "archived"],
+    ["delete", "deleted"],
+  ] as const)(
+    "does not queue an ordinary follow-up after %s wins before admission",
+    async (operation, reason) => {
+      await withTestHarness(async (harness) => {
+        const { thread } = seedProviderThreadFixture({
+          harness,
+          status: "active",
+          value: operation === "archive" ? 63 : 64,
+        });
+        if (operation === "archive") {
+          archiveThread(harness.db, harness.hub, thread.id);
+        } else {
+          markThreadDeleted(harness.db, harness.hub, {
+            threadId: thread.id,
+          });
+        }
+
+        await expect(
+          acceptThreadSendRequest(harness.deps, {
+            payload: {
+              input: textInput(`follow-up after ${operation}`),
+              mode: "steer",
+              model: "gpt-5",
+              permissionMode: "full",
+              reasoningLevel: "medium",
+              serviceTier: "default",
+            },
+            thread,
+          }),
+        ).rejects.toMatchObject({
+          body: {
+            code: "thread_not_writable",
+            details: { reason },
+          },
+          status: 409,
+        });
+        expect(listQueuedThreadMessages(harness.db, thread.id)).toEqual([]);
+      });
+    },
+  );
+
   it("parks a steer until turn/started and then steers it into that turn", async () => {
     await withTestHarness(async (harness) => {
       const { sessionId, thread } = seedProviderThreadFixture({
@@ -313,6 +357,16 @@ describe("turn-starting queue wait", () => {
       });
       const input = textInput("steer when ready");
       const secondInput = textInput("also steer when ready");
+      const queueChangedInTransactions: boolean[] = [];
+      const notifyThread = harness.hub.notifyThread.bind(harness.hub);
+      vi.spyOn(harness.hub, "notifyThread").mockImplementation(
+        (threadId, changes, metadata) => {
+          if (changes.includes("queue-changed")) {
+            queueChangedInTransactions.push(harness.db.$client.inTransaction);
+          }
+          notifyThread(threadId, changes, metadata);
+        },
+      );
 
       await expect(
         acceptThreadSendRequest(harness.deps, {
@@ -346,6 +400,7 @@ describe("turn-starting queue wait", () => {
         delivery: "queued",
         waitingOn: { kind: "turn-starting" },
       });
+      expect(queueChangedInTransactions).toEqual([false, false]);
       expect(
         listQueuedThreadCommands(harness, "turn.submit", thread.id),
       ).toHaveLength(0);
@@ -519,6 +574,27 @@ describe("turn-starting queue wait", () => {
         }),
       ).resolves.toBe(true);
       expect(listQueuedThreadMessages(harness.db, thread.id)).toHaveLength(0);
+    });
+  });
+
+  it("does not queue a parent notice when archive wins during preparation", async () => {
+    await withTestHarness(async (harness) => {
+      const { thread } = seedProviderThreadFixture({
+        harness,
+        status: "active",
+        value: 65,
+      });
+
+      const delivered = queueParentSystemMessage(harness.deps, {
+        input: textInput("child finished after archive"),
+        parentThreadId: thread.id,
+        systemMessageKind: "child-completed",
+        systemMessageSubject: null,
+      });
+      archiveThread(harness.db, harness.hub, thread.id);
+
+      await expect(delivered).resolves.toBe(false);
+      expect(listQueuedThreadMessages(harness.db, thread.id)).toEqual([]);
     });
   });
 });

--- a/apps/server/test/threads/thread-send-dispatch.test.ts
+++ b/apps/server/test/threads/thread-send-dispatch.test.ts
@@ -5,6 +5,7 @@ import {
   listEvents,
   listQueuedThreadMessages,
   markThreadDeleted,
+  setQueuedThreadMessageFailureReason,
   setQueuedThreadMessageGroupBoundary,
 } from "@bb/db";
 import {
@@ -380,6 +381,67 @@ describe("turn-starting queue wait", () => {
       });
     },
   );
+
+  it("keeps a failed grouped sibling out of the automatic turn-start send", async () => {
+    await withTestHarness(async (harness) => {
+      const { sessionId, thread } = seedProviderThreadFixture({
+        harness,
+        status: "active",
+        value: 66,
+      });
+      const lead = seedQueuedMessage(harness.deps, {
+        content: textInput("clean turn-starting lead"),
+        threadId: thread.id,
+        waitingOn: { kind: "turn-starting" },
+      });
+      const failed = seedQueuedMessage(harness.deps, {
+        content: textInput("failed scheduled sibling"),
+        threadId: thread.id,
+        waitingOn: { kind: "time" },
+        sendAt: Date.now() - 1_000,
+      });
+      setQueuedThreadMessageFailureReason(harness.db, harness.hub, {
+        id: failed.id,
+        threadId: thread.id,
+        failureReason: "Terminal failure",
+      });
+      setQueuedThreadMessageGroupBoundary({
+        db: harness.db,
+        notifier: harness.hub,
+        threadId: thread.id,
+        expectedGroupedPrefixQueuedMessageIds: [lead.id, failed.id],
+        groupBoundaryQueuedMessageId: failed.id,
+      });
+
+      const response = await harness.app.request("/internal/session/events", {
+        method: "POST",
+        headers: internalAuthHeaders(harness),
+        body: JSON.stringify({
+          sessionId,
+          eventGroups: groupHostDaemonEvents([
+            {
+              threadId: thread.id,
+              event: {
+                type: "turn/started",
+                threadId: thread.id,
+                providerThreadId: "provider-send-dispatch-66",
+                scope: turnScope("turn-failed-group"),
+              },
+            },
+          ]),
+        }),
+      });
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(response.status).toBe(200);
+      expect(
+        listQueuedThreadCommands(harness, "turn.submit", thread.id),
+      ).toHaveLength(0);
+      expect(
+        listQueuedThreadMessages(harness.db, thread.id).map((row) => row.id),
+      ).toEqual([lead.id, failed.id]);
+    });
+  });
 
   it("parks a steer until turn/started and then steers it into that turn", async () => {
     await withTestHarness(async (harness) => {

--- a/apps/server/test/threads/thread-send-dispatch.test.ts
+++ b/apps/server/test/threads/thread-send-dispatch.test.ts
@@ -18,7 +18,10 @@ import { groupHostDaemonEvents } from "@bb/host-daemon-contract";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { TelemetryService } from "../../src/services/system/telemetry.js";
 import * as threadEvents from "../../src/services/threads/thread-events.js";
-import { sendQueuedMessage } from "../../src/services/threads/queued-messages.js";
+import {
+  runQueuedMessageAutoSendForThread,
+  sendQueuedMessage,
+} from "../../src/services/threads/queued-messages.js";
 import { queueParentSystemMessage } from "../../src/services/threads/parent-system-messages.js";
 import { acceptThreadSendRequest } from "../../src/services/threads/thread-send-request.js";
 import { handleUpdateEnvironmentDirectoryToolCall } from "../../src/services/threads/thread-environment-directory.js";
@@ -305,6 +308,35 @@ describe("user message telemetry", () => {
 });
 
 describe("turn-starting queue wait", () => {
+  it("starts a new turn when startup settles before its queued wake", async () => {
+    await withTestHarness(async (harness) => {
+      const { thread } = seedProviderThreadFixture({
+        harness,
+        status: "idle",
+        value: 66,
+      });
+      seedQueuedMessage(harness.deps, {
+        content: textInput("follow-up after startup settled"),
+        threadId: thread.id,
+        waitingOn: { kind: "turn-starting" },
+      });
+
+      await runQueuedMessageAutoSendForThread(harness.deps, {
+        threadId: thread.id,
+      });
+
+      expect(listQueuedThreadMessages(harness.db, thread.id)).toEqual([]);
+      expect(
+        listQueuedThreadCommands(harness, "turn.submit", thread.id),
+      ).toEqual([
+        expect.objectContaining({
+          input: textInput("follow-up after startup settled"),
+          target: { mode: "start" },
+        }),
+      ]);
+    });
+  });
+
   it.each([
     ["archive", "archived"],
     ["delete", "deleted"],

--- a/apps/server/test/threads/thread-send-dispatch.test.ts
+++ b/apps/server/test/threads/thread-send-dispatch.test.ts
@@ -27,6 +27,7 @@ import {
 import { queueParentSystemMessage } from "../../src/services/threads/parent-system-messages.js";
 import { acceptThreadSendRequest } from "../../src/services/threads/thread-send-request.js";
 import { handleUpdateEnvironmentDirectoryToolCall } from "../../src/services/threads/thread-environment-directory.js";
+import { applyLoggedThreadLifecycleEvent } from "../../src/services/threads/lifecycle-outcome.js";
 import { sendThreadMessage } from "../../src/services/threads/thread-send.js";
 import {
   internalAuthHeaders,
@@ -401,6 +402,82 @@ describe("turn-starting queue wait", () => {
     },
   );
 
+  it("rejects a steer when the thread fails during startup admission", async () => {
+    await withTestHarness(async (harness) => {
+      const { thread } = seedProviderThreadFixture({
+        harness,
+        status: "active",
+        value: 67,
+      });
+      vi.spyOn(threadEvents, "getActiveTurnId").mockImplementationOnce(() => {
+        applyLoggedThreadLifecycleEvent(harness.deps, {
+          event: { type: "run.failed" },
+          threadId: thread.id,
+        });
+        return null;
+      });
+
+      await expect(
+        acceptThreadSendRequest(harness.deps, {
+          payload: {
+            input: textInput("do not strand this steer"),
+            mode: "steer",
+            model: "gpt-5",
+            permissionMode: "full",
+            reasoningLevel: "medium",
+            serviceTier: "default",
+          },
+          thread,
+        }),
+      ).rejects.toMatchObject({
+        body: {
+          code: "thread_not_writable",
+          details: { reason: "errored", threadStatus: "error" },
+        },
+        status: 409,
+      });
+      expect(listQueuedThreadMessages(harness.db, thread.id)).toEqual([]);
+    });
+  });
+
+  it("starts a turn when steer-if-active observes a startup failure", async () => {
+    await withTestHarness(async (harness) => {
+      const { thread } = seedProviderThreadFixture({
+        harness,
+        status: "active",
+        value: 68,
+      });
+      const input = textInput("recover this send as a new turn");
+      vi.spyOn(threadEvents, "getActiveTurnId").mockImplementationOnce(() => {
+        applyLoggedThreadLifecycleEvent(harness.deps, {
+          event: { type: "run.failed" },
+          threadId: thread.id,
+        });
+        return null;
+      });
+
+      await expect(
+        acceptThreadSendRequest(harness.deps, {
+          payload: {
+            input,
+            mode: "steer-if-active",
+            model: "gpt-5",
+            permissionMode: "full",
+            reasoningLevel: "medium",
+            serviceTier: "default",
+          },
+          thread,
+        }),
+      ).resolves.toEqual({ ok: true, delivery: "sent" });
+      expect(
+        listQueuedThreadCommands(harness, "turn.submit", thread.id),
+      ).toEqual([
+        expect.objectContaining({ input, target: { mode: "start" } }),
+      ]);
+      expect(listQueuedThreadMessages(harness.db, thread.id)).toEqual([]);
+    });
+  });
+
   it("keeps a failed grouped sibling out of the automatic turn-start send", async () => {
     await withTestHarness(async (harness) => {
       const { sessionId, thread } = seedProviderThreadFixture({
@@ -714,6 +791,14 @@ describe("turn-starting queue wait", () => {
         }),
       ).resolves.toBe(true);
       expect(listQueuedThreadMessages(harness.db, thread.id)).toHaveLength(0);
+      expect(
+        listQueuedThreadCommands(harness, "turn.submit", thread.id),
+      ).toHaveLength(2);
+      expect(
+        listQueuedThreadCommands(harness, "turn.submit", thread.id)[1],
+      ).toMatchObject({
+        target: { mode: "auto", expectedTurnId: "turn-system-notice-ready" },
+      });
     });
   });
 

--- a/apps/server/test/threads/thread-send-dispatch.test.ts
+++ b/apps/server/test/threads/thread-send-dispatch.test.ts
@@ -20,6 +20,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { TelemetryService } from "../../src/services/system/telemetry.js";
 import * as threadEvents from "../../src/services/threads/thread-events.js";
 import {
+  createAutomaticQueuedMessageGroupEligibility,
   runQueuedMessageAutoSendForThread,
   sendQueuedMessage,
 } from "../../src/services/threads/queued-messages.js";
@@ -151,10 +152,16 @@ describe("queued message dispatch hook", () => {
 
       await expect(
         sendQueuedMessage(harness.deps, {
+          claimPolicy: {
+            kind: "automatic",
+            isGroupEligible: createAutomaticQueuedMessageGroupEligibility(
+              harness.deps,
+              { now: Date.now(), thread },
+            ),
+          },
           threadId: thread.id,
           queuedMessageId: queued.id,
           mode: "auto",
-          sendNow: false,
         }),
       ).rejects.toMatchObject({
         body: { code: "queued_message_claim_lost" },
@@ -188,10 +195,16 @@ describe("queued message dispatch hook", () => {
 
       await expect(
         sendQueuedMessage(harness.deps, {
+          claimPolicy: {
+            kind: "automatic",
+            isGroupEligible: createAutomaticQueuedMessageGroupEligibility(
+              harness.deps,
+              { now: Date.now(), thread },
+            ),
+          },
           threadId: thread.id,
           queuedMessageId: queued.id,
           mode: "auto",
-          sendNow: false,
         }),
       ).rejects.toMatchObject({
         body: { code: "queued_message_claim_lost" },
@@ -220,10 +233,16 @@ describe("queued message auto-send notification", () => {
       harness.hub.subscribe(socket, { kind: "thread-list" });
 
       await sendQueuedMessage(harness.deps, {
+        claimPolicy: {
+          kind: "automatic",
+          isGroupEligible: createAutomaticQueuedMessageGroupEligibility(
+            harness.deps,
+            { now: Date.now(), thread },
+          ),
+        },
         threadId: thread.id,
         queuedMessageId: queued.id,
         mode: "auto",
-        sendNow: false,
       });
 
       const statusMessages = parseThreadMessages(socket.messages).filter(
@@ -511,10 +530,7 @@ describe("turn-starting queue wait", () => {
         db: harness.db,
         notifier: harness.deps.hub,
         threadId: thread.id,
-        expectedGroupedPrefixQueuedMessageIds: [
-          pluginHeld.id,
-          queued[1]!.id,
-        ],
+        expectedGroupedPrefixQueuedMessageIds: [pluginHeld.id, queued[1]!.id],
         groupBoundaryQueuedMessageId: queued[1]!.id,
       });
       expect(

--- a/apps/server/test/threads/thread-send-dispatch.test.ts
+++ b/apps/server/test/threads/thread-send-dispatch.test.ts
@@ -5,6 +5,7 @@ import {
   listEvents,
   listQueuedThreadMessages,
   markThreadDeleted,
+  setQueuedThreadMessageGroupBoundary,
 } from "@bb/db";
 import {
   changedMessageSchema,
@@ -355,8 +356,18 @@ describe("turn-starting queue wait", () => {
         status: "active",
         value: 6,
       });
+      const pluginInput = textInput("plugin-held lead");
       const input = textInput("steer when ready");
       const secondInput = textInput("also steer when ready");
+      const pluginHeld = seedQueuedMessage(harness.deps, {
+        content: pluginInput,
+        threadId: thread.id,
+        waitingOn: {
+          kind: "plugin",
+          pluginId: "limiter",
+          reason: "At capacity",
+        },
+      });
       const queueChangedInTransactions: boolean[] = [];
       const notifyThread = harness.hub.notifyThread.bind(harness.hub);
       vi.spyOn(harness.hub, "notifyThread").mockImplementation(
@@ -401,6 +412,17 @@ describe("turn-starting queue wait", () => {
         waitingOn: { kind: "turn-starting" },
       });
       expect(queueChangedInTransactions).toEqual([false, false]);
+      const queued = listQueuedThreadMessages(harness.db, thread.id);
+      setQueuedThreadMessageGroupBoundary({
+        db: harness.db,
+        notifier: harness.deps.hub,
+        threadId: thread.id,
+        expectedGroupedPrefixQueuedMessageIds: [
+          pluginHeld.id,
+          queued[1]!.id,
+        ],
+        groupBoundaryQueuedMessageId: queued[1]!.id,
+      });
       expect(
         listQueuedThreadCommands(harness, "turn.submit", thread.id),
       ).toHaveLength(0);
@@ -411,6 +433,14 @@ describe("turn-starting queue wait", () => {
           waitingOn: JSON.parse(row.waitingOn!),
         })),
       ).toEqual([
+        {
+          content: pluginInput,
+          waitingOn: {
+            kind: "plugin",
+            pluginId: "limiter",
+            reason: "At capacity",
+          },
+        },
         { content: input, waitingOn: { kind: "turn-starting" } },
         { content: secondInput, waitingOn: { kind: "turn-starting" } },
       ]);
@@ -449,7 +479,7 @@ describe("turn-starting queue wait", () => {
         listQueuedThreadCommands(harness, "turn.submit", thread.id),
       ).toEqual([
         expect.objectContaining({
-          input,
+          inputGroups: [pluginInput, input],
           target: { mode: "auto", expectedTurnId: "turn-ready" },
         }),
         expect.objectContaining({

--- a/apps/server/test/threads/turn-failed-retry.test.ts
+++ b/apps/server/test/threads/turn-failed-retry.test.ts
@@ -715,6 +715,7 @@ describe("retrying a failed turn", () => {
         harness.db,
         harness.deps.hub,
         onlyQueuedRow(harness, thread.id).id,
+        true,
       );
       expect(claimed).toHaveLength(1);
       await expect(retry(requestId)).rejects.toMatchObject({

--- a/apps/server/test/threads/turn-failed-retry.test.ts
+++ b/apps/server/test/threads/turn-failed-retry.test.ts
@@ -163,7 +163,8 @@ function seedRateLimitFailure(
     threadId: args.threadId,
     environmentId: args.environmentId,
     providerThreadId,
-    sequence: getLatestThreadSequence(harness.db, { threadId: args.threadId }) + 1,
+    sequence:
+      getLatestThreadSequence(harness.db, { threadId: args.threadId }) + 1,
     type: "provider/rateLimits/updated",
     scope: { kind: "thread" },
     data: {
@@ -190,7 +191,8 @@ function seedRateLimitFailure(
     threadId: args.threadId,
     environmentId: args.environmentId,
     providerThreadId,
-    sequence: getLatestThreadSequence(harness.db, { threadId: args.threadId }) + 1,
+    sequence:
+      getLatestThreadSequence(harness.db, { threadId: args.threadId }) + 1,
     type: "provider/error",
     scope: { kind: "thread" },
     data: {
@@ -218,7 +220,8 @@ function seedInputAccepted(
     threadId: args.threadId,
     environmentId: args.environmentId,
     providerThreadId,
-    sequence: getLatestThreadSequence(harness.db, { threadId: args.threadId }) + 1,
+    sequence:
+      getLatestThreadSequence(harness.db, { threadId: args.threadId }) + 1,
     type: "turn/input/accepted",
     scope: { kind: "turn", turnId: "turn-1" },
     data: {
@@ -245,7 +248,8 @@ function seedDoorRejection(
   seedEvent(harness.deps, {
     threadId: args.threadId,
     environmentId: args.environmentId,
-    sequence: getLatestThreadSequence(harness.db, { threadId: args.threadId }) + 1,
+    sequence:
+      getLatestThreadSequence(harness.db, { threadId: args.threadId }) + 1,
     type: "client/turn/rejected",
     scope: { kind: "thread" },
     data: {
@@ -496,7 +500,11 @@ describe("retrying a failed turn", () => {
 
       const result = await retryFailedTurn(harness.deps, {
         thread: requireThread(harness, thread.id),
-        request: { turnRequestId: requestId, sendAt: null, reason: "Rate limited" },
+        request: {
+          turnRequestId: requestId,
+          sendAt: null,
+          reason: "Rate limited",
+        },
       });
       expect(result.delivery).toBe("sent");
 
@@ -595,7 +603,10 @@ describe("retrying a failed turn", () => {
 
   it("counts a retry's own failure as a later attempt of the same original", async () => {
     await withTestHarness(async (harness) => {
-      const { requestId, thread } = seedFailableThread(harness, "host-attempts");
+      const { requestId, thread } = seedFailableThread(
+        harness,
+        "host-attempts",
+      );
       failThread(harness, thread.id);
       await retryFailedTurn(harness.deps, {
         thread: requireThread(harness, thread.id),
@@ -685,7 +696,11 @@ describe("retrying a failed turn", () => {
       const retry = (turnRequestId: string | null) =>
         retryFailedTurn(harness.deps, {
           thread: requireThread(harness, thread.id),
-          request: { turnRequestId, sendAt: Date.now() + 60_000, reason: "Retry" },
+          request: {
+            turnRequestId,
+            sendAt: Date.now() + 60_000,
+            reason: "Retry",
+          },
         });
 
       // Still running: there is no failed turn to re-submit.
@@ -715,7 +730,7 @@ describe("retrying a failed turn", () => {
         harness.db,
         harness.deps.hub,
         onlyQueuedRow(harness, thread.id).id,
-        true,
+        { kind: "explicit-send" },
       );
       expect(claimed).toHaveLength(1);
       await expect(retry(requestId)).rejects.toMatchObject({

--- a/packages/db/src/data/index.ts
+++ b/packages/db/src/data/index.ts
@@ -39,9 +39,7 @@ export {
   listStoredProjectPromptHistoryRows,
   listStoredThreadPromptHistoryRows,
 } from "./prompt-history.js";
-export type {
-  StoredPromptHistoryEntryRow,
-} from "./prompt-history.js";
+export type { StoredPromptHistoryEntryRow } from "./prompt-history.js";
 
 export {
   getProjectExecutionDefaults,
@@ -227,9 +225,7 @@ export {
   listRetiredLoadedEnvironmentIdsOnHost,
   updateEnvironmentMetadata,
 } from "./environments.js";
-export type {
-  CreateEnvironmentInput,
-} from "./environments.js";
+export type { CreateEnvironmentInput } from "./environments.js";
 
 export {
   upsertHost,
@@ -354,9 +350,7 @@ export {
   setPendingInteractionResolving,
   setPendingInteractionResolved,
 } from "./pending-interactions.js";
-export type {
-  PendingInteractionRow,
-} from "./pending-interactions.js";
+export type { PendingInteractionRow } from "./pending-interactions.js";
 
 export {
   openSession,
@@ -366,9 +360,7 @@ export {
   heartbeatSession,
   listLatestSessionsForHosts,
 } from "./sessions.js";
-export type {
-  HostDaemonSessionRow,
-} from "./sessions.js";
+export type { HostDaemonSessionRow } from "./sessions.js";
 
 export {
   claimQueuedThreadMessage,
@@ -407,6 +399,8 @@ export type {
   ClearQueuedThreadMessageWaitingOnArgs,
   ListQueuedThreadMessagesForApiArgs,
   ListQueuedThreadMessagesWaitingOnKindArgs,
+  QueuedThreadMessageGroupClaimPolicy,
+  QueuedThreadMessageGroupEligibility,
   QueuedThreadMessagePluginWaitRef,
   QueuedThreadMessageRow,
   ReorderQueuedThreadMessageResult,

--- a/packages/db/src/data/index.ts
+++ b/packages/db/src/data/index.ts
@@ -382,6 +382,7 @@ export {
   getQueuedThreadMessage,
   hasQueuedRetryOfTurnRequest,
   hasQueuedThreadMessages,
+  isOrdinaryTurnEndQueuedMessage,
   isThreadQueueAutoSendPaused,
   listDueScheduledQueuedThreadMessages,
   listIdleThreadsWithQueuedMessages,

--- a/packages/db/src/data/queued-thread-messages.ts
+++ b/packages/db/src/data/queued-thread-messages.ts
@@ -261,7 +261,7 @@ function isIdleDrainableQueuedMessage(row: QueuedThreadMessageRow): boolean {
   if (row.waitingOn === null) return true;
   try {
     const parsed = JSON.parse(row.waitingOn) as { kind?: unknown };
-    return parsed.kind === "thread-busy";
+    return parsed.kind === "thread-busy" || parsed.kind === "turn-starting";
   } catch {
     return false;
   }
@@ -1367,7 +1367,7 @@ function automaticallyDrainableQueuedThreadMessage() {
 
 /**
  * Rows the IDLE drain may claim: a row with no wait at all, or one waiting
- * only on the thread being busy — which is exactly the wait an idle thread
+ * on the thread being busy or its turn starting — waits an idle thread
  * clears.
  *
  * Every other wait belongs to a different drain and must be invisible here, or
@@ -1385,6 +1385,7 @@ function drainableQueuedThreadMessage() {
     or(
       isNull(queuedThreadMessages.waitingOn),
       sql`json_extract(${queuedThreadMessages.waitingOn}, '$.kind') = 'thread-busy'`,
+      sql`json_extract(${queuedThreadMessages.waitingOn}, '$.kind') = 'turn-starting'`,
     ),
   );
 }

--- a/packages/db/src/data/queued-thread-messages.ts
+++ b/packages/db/src/data/queued-thread-messages.ts
@@ -251,6 +251,8 @@ function partitionQueuedMessageGroups(
   return groups;
 }
 
+const IDLE_DRAINABLE_WAIT_KINDS = ["thread-busy", "turn-starting"] as const;
+
 /**
  * The JS mirror of {@link drainableQueuedThreadMessage}'s wait condition, for
  * deciding whole-group eligibility over rows already in hand. Kept next to a
@@ -261,7 +263,9 @@ function isIdleDrainableQueuedMessage(row: QueuedThreadMessageRow): boolean {
   if (row.waitingOn === null) return true;
   try {
     const parsed = JSON.parse(row.waitingOn) as { kind?: unknown };
-    return parsed.kind === "thread-busy" || parsed.kind === "turn-starting";
+    return IDLE_DRAINABLE_WAIT_KINDS.some(
+      (waitKind) => waitKind === parsed.kind,
+    );
   } catch {
     return false;
   }
@@ -1138,7 +1142,7 @@ export interface RequeueClaimedQueuedThreadMessagesArgs {
 }
 
 export function requeueClaimedQueuedThreadMessages(
-  db: DbConnection,
+  db: DbQueryConnection,
   notifier: DbNotifier,
   args: RequeueClaimedQueuedThreadMessagesArgs,
 ): QueuedThreadMessageRow | null {
@@ -1384,8 +1388,10 @@ function drainableQueuedThreadMessage() {
     automaticallyDrainableQueuedThreadMessage(),
     or(
       isNull(queuedThreadMessages.waitingOn),
-      sql`json_extract(${queuedThreadMessages.waitingOn}, '$.kind') = 'thread-busy'`,
-      sql`json_extract(${queuedThreadMessages.waitingOn}, '$.kind') = 'turn-starting'`,
+      ...IDLE_DRAINABLE_WAIT_KINDS.map(
+        (waitKind) =>
+          sql`json_extract(${queuedThreadMessages.waitingOn}, '$.kind') = ${waitKind}`,
+      ),
     ),
   );
 }

--- a/packages/db/src/data/queued-thread-messages.ts
+++ b/packages/db/src/data/queued-thread-messages.ts
@@ -845,6 +845,7 @@ export function claimQueuedThreadMessageGroup(
   db: DbConnection,
   notifier: DbNotifier,
   id: string,
+  explicitSend: boolean,
   isGroupEligible?: (rows: readonly QueuedThreadMessageRow[]) => boolean,
 ): ClaimedQueuedThreadMessageRow[] | null {
   const claimedQueuedMessages = db.transaction(
@@ -863,9 +864,9 @@ export function claimQueuedThreadMessageGroup(
         return null;
       }
       if (
-        isGroupEligible &&
-        (!group.every((row) => row.failureReason === null) ||
-          !isGroupEligible(group))
+        (!explicitSend &&
+          !group.every((row) => row.failureReason === null)) ||
+        (isGroupEligible && !isGroupEligible(group))
       ) {
         return null;
       }

--- a/packages/db/src/data/queued-thread-messages.ts
+++ b/packages/db/src/data/queued-thread-messages.ts
@@ -253,6 +253,22 @@ function partitionQueuedMessageGroups(
 
 const IDLE_DRAINABLE_WAIT_KINDS = ["thread-busy", "turn-starting"] as const;
 
+function hasOrdinaryTurnEndWait(row: QueuedThreadMessageRow): boolean {
+  if (row.waitingOn === null) return true;
+  try {
+    const parsed = JSON.parse(row.waitingOn) as { kind?: unknown };
+    return parsed.kind === "thread-busy";
+  } catch {
+    return false;
+  }
+}
+
+export function isOrdinaryTurnEndQueuedMessage(
+  row: QueuedThreadMessageRow,
+): boolean {
+  return row.systemNotice === null && hasOrdinaryTurnEndWait(row);
+}
+
 /**
  * The JS mirror of {@link drainableQueuedThreadMessage}'s wait condition, for
  * deciding whole-group eligibility over rows already in hand. Kept next to a
@@ -671,6 +687,7 @@ function manuallyStoppedQueuePauseQuery(
   const interruption = alias(events, "queue_pause_interruption");
   const laterInterruption = alias(events, "queue_pause_later_interruption");
   const laterRootTurnStart = alias(events, "queue_pause_later_turn_start");
+  const laterTurnRequest = alias(events, "queue_pause_later_turn_request");
   return db
     .select({ sequence: interruption.sequence })
     .from(interruption)
@@ -701,6 +718,19 @@ function manuallyStoppedQueuePauseQuery(
                 eq(laterRootTurnStart.type, "turn/started"),
                 isNull(laterRootTurnStart.parentToolCallId),
                 sql`${laterRootTurnStart.sequence} > ${interruption.sequence}`,
+                exists(
+                  db
+                    .select({ sequence: laterTurnRequest.sequence })
+                    .from(laterTurnRequest)
+                    .where(
+                      and(
+                        eq(laterTurnRequest.threadId, interruption.threadId),
+                        eq(laterTurnRequest.type, "client/turn/requested"),
+                        sql`${laterTurnRequest.sequence} > ${interruption.sequence}`,
+                        sql`${laterTurnRequest.sequence} < ${laterRootTurnStart.sequence}`,
+                      ),
+                    ),
+                ),
               ),
             ),
         ),
@@ -740,7 +770,10 @@ export function listIdleThreadsWithQueuedMessages(
         inArray(threads.status, ["idle", "pending"]),
         isNull(threads.archivedAt),
         isNull(threads.deletedAt),
-        notExists(manuallyStoppedQueuePauseQuery(db, threads.id)),
+        or(
+          notExists(manuallyStoppedQueuePauseQuery(db, threads.id)),
+          isNotNull(queuedThreadMessages.systemNotice),
+        ),
         // A gone environment (destroying/destroyed) is never reprovisioned, so
         // its queued rows can never drain. Leave them out of the sweep instead
         // of failing the same send every cycle (#1789). A thread with NO
@@ -906,13 +939,16 @@ export function claimNextQueuedThreadMessageGroup(
       // one prompt — and skipping it does not block the independent rows
       // behind it: the queue is a queue, not a pipeline.
       const queuedMessages = listQueuedThreadMessages(tx, threadId);
+      const pauseOrdinaryMessages = isThreadQueueAutoSendPaused(tx, threadId);
       const group =
         partitionQueuedMessageGroups(queuedMessages).find((rows) => {
-          if (!isGroupEligible) {
-            return rows.every(isIdleDrainableQueuedMessage);
-          }
+          const eligible = isGroupEligible
+            ? rows.some(isIdleDrainableQueuedMessage) && isGroupEligible(rows)
+            : rows.every(isIdleDrainableQueuedMessage);
           return (
-            rows.some(isIdleDrainableQueuedMessage) && isGroupEligible(rows)
+            eligible &&
+            (!pauseOrdinaryMessages ||
+              rows.every((row) => !isOrdinaryTurnEndQueuedMessage(row)))
           );
         }) ?? null;
       if (group === null) {

--- a/packages/db/src/data/queued-thread-messages.ts
+++ b/packages/db/src/data/queued-thread-messages.ts
@@ -1474,9 +1474,9 @@ function drainableQueuedThreadMessage() {
     automaticallyDrainableQueuedThreadMessage(),
     or(
       isNull(queuedThreadMessages.waitingOn),
-      ...IDLE_DRAINABLE_WAIT_KINDS.map(
-        (waitKind) =>
-          sql`json_extract(${queuedThreadMessages.waitingOn}, '$.kind') = ${waitKind}`,
+      inArray(
+        sql<string>`json_extract(${queuedThreadMessages.waitingOn}, '$.kind')`,
+        [...IDLE_DRAINABLE_WAIT_KINDS],
       ),
     ),
   );

--- a/packages/db/src/data/queued-thread-messages.ts
+++ b/packages/db/src/data/queued-thread-messages.ts
@@ -895,6 +895,7 @@ export function claimNextQueuedThreadMessageGroup(
   db: DbConnection,
   notifier: DbNotifier,
   threadId: string,
+  isGroupEligible?: (rows: readonly QueuedThreadMessageRow[]) => boolean,
 ): ClaimedQueuedThreadMessageRow[] | null {
   const claimedQueuedMessages = db.transaction(
     (tx) => {
@@ -905,9 +906,14 @@ export function claimNextQueuedThreadMessageGroup(
       // behind it: the queue is a queue, not a pipeline.
       const queuedMessages = listQueuedThreadMessages(tx, threadId);
       const group =
-        partitionQueuedMessageGroups(queuedMessages).find((rows) =>
-          rows.every(isIdleDrainableQueuedMessage),
-        ) ?? null;
+        partitionQueuedMessageGroups(queuedMessages).find((rows) => {
+          if (!isGroupEligible) {
+            return rows.every(isIdleDrainableQueuedMessage);
+          }
+          return (
+            rows.some(isIdleDrainableQueuedMessage) && isGroupEligible(rows)
+          );
+        }) ?? null;
       if (group === null) {
         return null;
       }

--- a/packages/db/src/data/queued-thread-messages.ts
+++ b/packages/db/src/data/queued-thread-messages.ts
@@ -39,11 +39,11 @@ import {
   queuedThreadMessages,
   threads,
 } from "../schema.js";
-import { createQueuedThreadMessageClaimToken, createQueuedThreadMessageId } from "../ids.js";
 import {
-  createOrderKeyAfter,
-  createOrderKeyBetween,
-} from "./order-keys.js";
+  createQueuedThreadMessageClaimToken,
+  createQueuedThreadMessageId,
+} from "../ids.js";
+import { createOrderKeyAfter, createOrderKeyBetween } from "./order-keys.js";
 import { queryInSqliteVariableBatches } from "./events.js";
 
 export interface CreateQueuedThreadMessageInput {
@@ -201,7 +201,8 @@ export type UpdateQueuedThreadMessageResult =
   | { kind: "claimed" }
   | { kind: "stale" };
 
-export type ReleaseQueuedMessageClaimArgs = ClaimedQueuedThreadMessageMutationArgs;
+export type ReleaseQueuedMessageClaimArgs =
+  ClaimedQueuedThreadMessageMutationArgs;
 
 class ReorderQueuedThreadMessageRollback extends Error {
   constructor(readonly result: ReorderQueuedThreadMessageResult) {
@@ -220,7 +221,10 @@ function collectLeadGroupIds(
     const nextQueuedMessage = queuedMessages[index + 1];
     if (
       !nextQueuedMessage ||
-      !queuedMessageGroupingEnvelopeMatches(firstQueuedMessage, nextQueuedMessage)
+      !queuedMessageGroupingEnvelopeMatches(
+        firstQueuedMessage,
+        nextQueuedMessage,
+      )
     ) {
       break;
     }
@@ -315,7 +319,9 @@ function isQueuedThreadMessageClaimed(row: QueuedThreadMessageRow): boolean {
   return row.claimedAt !== null || row.claimToken !== null;
 }
 
-function requireClaimedQueuedThreadMessage(row: QueuedThreadMessageRow | null): ClaimedQueuedThreadMessageRow | null {
+function requireClaimedQueuedThreadMessage(
+  row: QueuedThreadMessageRow | null,
+): ClaimedQueuedThreadMessageRow | null {
   if (!row || row.claimedAt === null || row.claimToken === null) {
     return null;
   }
@@ -366,7 +372,10 @@ function getLastQueuedThreadMessage(
       .select()
       .from(queuedThreadMessages)
       .where(eq(queuedThreadMessages.threadId, threadId))
-      .orderBy(desc(queuedThreadMessages.sortKey), desc(queuedThreadMessages.id))
+      .orderBy(
+        desc(queuedThreadMessages.sortKey),
+        desc(queuedThreadMessages.id),
+      )
       .limit(1)
       .get() ?? null
   );
@@ -394,7 +403,10 @@ function getPreviousUnclaimedQueuedThreadMessage(
           ),
         ),
       )
-      .orderBy(desc(queuedThreadMessages.sortKey), desc(queuedThreadMessages.id))
+      .orderBy(
+        desc(queuedThreadMessages.sortKey),
+        desc(queuedThreadMessages.id),
+      )
       .limit(1)
       .get() ?? null
   );
@@ -498,7 +510,10 @@ function applyQueuedThreadMessageGroupBoundary(
     }
     const hasMixedExecutionOptions = groupedMessages.some(
       (queuedMessage) =>
-        !queuedMessageGroupingEnvelopeMatches(firstQueuedMessage, queuedMessage),
+        !queuedMessageGroupingEnvelopeMatches(
+          firstQueuedMessage,
+          queuedMessage,
+        ),
     );
     if (hasMixedExecutionOptions) {
       return { kind: "invalid_execution_options" };
@@ -553,9 +568,7 @@ function applyPreservedLeadGroupAfterReorder(
       .run();
   }
 
-  return changed
-    ? listQueuedThreadMessages(db, threadId)
-    : queuedMessages;
+  return changed ? listQueuedThreadMessages(db, threadId) : queuedMessages;
 }
 
 export function createQueuedThreadMessageInTransaction(
@@ -588,8 +601,11 @@ export function createQueuedThreadMessageInTransaction(
         input.systemNotice === null ? null : JSON.stringify(input.systemNotice),
       payloadKind: input.payload.kind,
       retryOfTurnRequestId:
-        input.payload.kind === "retry" ? input.payload.retryOfTurnRequestId : null,
-      retryAttempt: input.payload.kind === "retry" ? input.payload.attempt : null,
+        input.payload.kind === "retry"
+          ? input.payload.retryOfTurnRequestId
+          : null,
+      retryAttempt:
+        input.payload.kind === "retry" ? input.payload.attempt : null,
       retryReason: input.payload.kind === "retry" ? input.payload.reason : null,
       groupWithNext: false,
       claimedAt: null,
@@ -806,7 +822,11 @@ export function claimQueuedThreadMessage(
         .from(queuedThreadMessages)
         .where(eq(queuedThreadMessages.id, id))
         .get();
-      if (!existing || existing.claimedAt !== null || existing.claimToken !== null) {
+      if (
+        !existing ||
+        existing.claimedAt !== null ||
+        existing.claimToken !== null
+      ) {
         return null;
       }
 
@@ -874,12 +894,33 @@ function claimQueuedThreadMessageIdsInTransaction(
   return claimedRows;
 }
 
+export type QueuedThreadMessageGroupEligibility = (
+  rows: readonly QueuedThreadMessageRow[],
+) => boolean;
+
+export type QueuedThreadMessageGroupClaimPolicy =
+  | {
+      kind: "automatic";
+      isGroupEligible: QueuedThreadMessageGroupEligibility;
+    }
+  | { kind: "explicit-send" };
+
+function isAutomaticQueuedThreadMessageGroupClaimAllowed(
+  rows: readonly QueuedThreadMessageRow[],
+  pauseOrdinaryMessages: boolean,
+): boolean {
+  return (
+    rows.every((row) => row.failureReason === null) &&
+    (!pauseOrdinaryMessages ||
+      rows.every((row) => !isOrdinaryTurnEndQueuedMessage(row)))
+  );
+}
+
 export function claimQueuedThreadMessageGroup(
   db: DbConnection,
   notifier: DbNotifier,
   id: string,
-  explicitSend: boolean,
-  isGroupEligible?: (rows: readonly QueuedThreadMessageRow[]) => boolean,
+  policy: QueuedThreadMessageGroupClaimPolicy,
 ): ClaimedQueuedThreadMessageRow[] | null {
   const claimedQueuedMessages = db.transaction(
     (tx) => {
@@ -897,13 +938,16 @@ export function claimQueuedThreadMessageGroup(
         return null;
       }
       if (
-        (!explicitSend &&
-          !group.every((row) => row.failureReason === null)) ||
-        (isGroupEligible && !isGroupEligible(group))
+        (policy.kind === "automatic" &&
+          !isAutomaticQueuedThreadMessageGroupClaimAllowed(
+            group,
+            isThreadQueueAutoSendPaused(tx, existing.threadId),
+          )) ||
+        (policy.kind === "automatic" && !policy.isGroupEligible(group))
       ) {
         return null;
       }
-      if (!isGroupEligible && group[0]?.id !== id) {
+      if (policy.kind === "explicit-send" && group[0]?.id !== id) {
         const now = Date.now();
         clearPreviousQueuedMessageGroupEdgeInTransaction(tx, existing, now);
         clearQueuedMessageGroupEdgeInTransaction(tx, existing, now);
@@ -929,7 +973,7 @@ export function claimNextQueuedThreadMessageGroup(
   db: DbConnection,
   notifier: DbNotifier,
   threadId: string,
-  isGroupEligible?: (rows: readonly QueuedThreadMessageRow[]) => boolean,
+  isGroupEligible?: QueuedThreadMessageGroupEligibility,
 ): ClaimedQueuedThreadMessageRow[] | null {
   const claimedQueuedMessages = db.transaction(
     (tx) => {
@@ -947,8 +991,10 @@ export function claimNextQueuedThreadMessageGroup(
             : rows.every(isIdleDrainableQueuedMessage);
           return (
             eligible &&
-            (!pauseOrdinaryMessages ||
-              rows.every((row) => !isOrdinaryTurnEndQueuedMessage(row)))
+            isAutomaticQueuedThreadMessageGroupClaimAllowed(
+              rows,
+              pauseOrdinaryMessages,
+            )
           );
         }) ?? null;
       if (group === null) {
@@ -1013,10 +1059,7 @@ export function reorderQueuedThreadMessage({
           return { kind: "invalid_neighbor_order" };
         }
 
-        const currentQueuedMessages = listQueuedThreadMessages(
-          tx,
-          threadId,
-        );
+        const currentQueuedMessages = listQueuedThreadMessages(tx, threadId);
         const originalLeadGroupIds = collectLeadGroupIds(currentQueuedMessages);
         const currentIndex = currentQueuedMessages.findIndex(
           (queuedMessage) => queuedMessage.id === queuedMessageId,
@@ -1846,7 +1889,10 @@ export function hasQueuedRetryOfTurnRequest(
       .where(
         and(
           eq(queuedThreadMessages.threadId, args.threadId),
-          eq(queuedThreadMessages.retryOfTurnRequestId, args.retryOfTurnRequestId),
+          eq(
+            queuedThreadMessages.retryOfTurnRequestId,
+            args.retryOfTurnRequestId,
+          ),
         ),
       )
       .limit(1)
@@ -1892,7 +1938,9 @@ export function deleteQueuedThreadMessage(
       const existing = getQueuedThreadMessageForMutation(tx, id);
       if (!existing) return null;
       clearPreviousQueuedMessageGroupEdgeInTransaction(tx, existing);
-      tx.delete(queuedThreadMessages).where(eq(queuedThreadMessages.id, id)).run();
+      tx.delete(queuedThreadMessages)
+        .where(eq(queuedThreadMessages.id, id))
+        .run();
       return existing;
     },
     { behavior: "immediate" },

--- a/packages/db/test/data/queued-thread-messages.test.ts
+++ b/packages/db/test/data/queued-thread-messages.test.ts
@@ -516,7 +516,7 @@ describe("queued thread messages", () => {
         reasoningLevel: "medium",
         permissionMode: "full",
         serviceTier: "default",
-        waitingOn: null,
+        waitingOn: { kind: "turn-starting" },
         sendAt: null,
         payload: { kind: "inline" },
         systemNotice: null,

--- a/packages/db/test/data/queued-thread-messages.test.ts
+++ b/packages/db/test/data/queued-thread-messages.test.ts
@@ -10,6 +10,7 @@ import {
   deleteClaimedQueuedThreadMessageBatchInTransaction,
   deleteQueuedThreadMessage,
   getQueuedThreadMessage,
+  listIdleThreadsWithQueuedMessages,
   listQueuedThreadMessages,
   releaseQueuedMessageClaim,
   releaseStaleQueuedMessageClaims,
@@ -119,6 +120,31 @@ describe("queued thread messages", () => {
     });
 
     expect(listQueuedThreadMessages(db, thread.id)).toHaveLength(2);
+  });
+
+  it("lists an idle thread waiting for its turn to start", () => {
+    const { db, project } = setup();
+    const thread = createThread(db, noopNotifier, {
+      projectId: project.id,
+      providerId: "codex",
+      status: "idle",
+    });
+    createQueuedThreadMessage(db, noopNotifier, {
+      threadId: thread.id,
+      content: defaultInput,
+      model: "gpt-5",
+      reasoningLevel: "medium",
+      permissionMode: "full",
+      serviceTier: "default",
+      waitingOn: { kind: "turn-starting" },
+      sendAt: null,
+      payload: { kind: "inline" },
+      systemNotice: null,
+    });
+
+    expect(
+      listIdleThreadsWithQueuedMessages(db).map((row) => row.threadId),
+    ).toContain(thread.id);
   });
 
   it("updates queued message content without changing its identity or position", () => {

--- a/packages/db/test/data/queued-thread-messages.test.ts
+++ b/packages/db/test/data/queued-thread-messages.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
-import type { PromptInput } from "@bb/domain";
+import { threadScope, type PromptInput } from "@bb/domain";
 import { noopNotifier } from "../../src/notifier.js";
+import { insertEvents } from "../../src/data/events.js";
 import {
   claimNextQueuedThreadMessageGroup,
   claimQueuedThreadMessage,
@@ -769,6 +770,70 @@ describe("queued thread messages", () => {
     expect(listQueuedThreadMessages(db, thread.id).map((queuedMessage) => queuedMessage.id)).toEqual([
       thirdQueuedMessage.id,
     ]);
+  });
+
+  it("pauses ordinary turn-end rows without pausing system notices", () => {
+    const { db, project } = setup();
+    const thread = createThread(db, noopNotifier, {
+      projectId: project.id,
+      providerId: "codex",
+      status: "idle",
+    });
+    const ordinary = createQueuedThreadMessage(db, noopNotifier, {
+      threadId: thread.id,
+      content: defaultInput,
+      model: "gpt-5",
+      reasoningLevel: "medium",
+      permissionMode: "full",
+      serviceTier: "default",
+      waitingOn: { kind: "thread-busy" },
+      sendAt: null,
+      payload: { kind: "inline" },
+      systemNotice: null,
+    });
+    const notice = createQueuedThreadMessage(db, noopNotifier, {
+      threadId: thread.id,
+      content: altInput,
+      model: "gpt-5",
+      reasoningLevel: "medium",
+      permissionMode: "full",
+      serviceTier: "default",
+      waitingOn: { kind: "thread-busy" },
+      sendAt: null,
+      payload: { kind: "inline" },
+      systemNotice: {
+        kind: "child-completed",
+        subject: {
+          kind: "thread",
+          threadId: "thr_child",
+          threadName: "Child",
+        },
+      },
+    });
+    insertEvents(db, noopNotifier, [
+      {
+        threadId: thread.id,
+        sequence: 1,
+        type: "system/thread/interrupted",
+        scope: threadScope(),
+        itemId: null,
+        itemKind: null,
+        parentToolCallId: null,
+        data: JSON.stringify({ reason: "manual-stop" }),
+      },
+    ]);
+
+    expect(
+      listIdleThreadsWithQueuedMessages(db).map((row) => row.threadId),
+    ).toContain(thread.id);
+    expect(
+      claimNextQueuedThreadMessageGroup(db, noopNotifier, thread.id)?.map(
+        (row) => row.id,
+      ),
+    ).toEqual([notice.id]);
+    expect(
+      listQueuedThreadMessages(db, thread.id).map((row) => row.id),
+    ).toEqual([ordinary.id]);
   });
 
   it("does not split a requeued group: the tail waits with its blocked lead", () => {

--- a/packages/db/test/data/queued-thread-messages.test.ts
+++ b/packages/db/test/data/queued-thread-messages.test.ts
@@ -898,7 +898,7 @@ describe("queued thread messages", () => {
     // The requested drain clears the lead's wait and claims by id; the claim
     // is a claim on the batch, so the tail dispatches with it.
     expect(
-      claimQueuedThreadMessageGroup(db, noopNotifier, lead.id)?.map(
+      claimQueuedThreadMessageGroup(db, noopNotifier, lead.id, true)?.map(
         (queuedMessage) => queuedMessage.id,
       ),
     ).toEqual([lead.id, tail.id]);
@@ -957,6 +957,7 @@ describe("queued thread messages", () => {
       db,
       noopNotifier,
       thirdQueuedMessage.id,
+      true,
     );
 
     expect(claimedQueuedMessages?.map((queuedMessage) => queuedMessage.id)).toEqual([
@@ -1087,7 +1088,12 @@ describe("queued thread messages", () => {
     });
 
     expect(
-      claimQueuedThreadMessageGroup(db, noopNotifier, secondQueuedMessage.id)?.map(
+      claimQueuedThreadMessageGroup(
+        db,
+        noopNotifier,
+        secondQueuedMessage.id,
+        true,
+      )?.map(
         (queuedMessage) => queuedMessage.id,
       ),
     ).toEqual([secondQueuedMessage.id]);
@@ -1157,6 +1163,7 @@ describe("queued thread messages", () => {
       db,
       noopNotifier,
       secondQueuedMessage.id,
+      true,
     );
     expect(claimed?.map((queuedMessage) => queuedMessage.id)).toEqual([
       secondQueuedMessage.id,

--- a/packages/db/test/data/queued-thread-messages.test.ts
+++ b/packages/db/test/data/queued-thread-messages.test.ts
@@ -191,9 +191,9 @@ describe("queued thread messages", () => {
     });
 
     expect(result.kind).toBe("updated");
-    expect(listQueuedThreadMessages(db, thread.id).map((row) => row.id)).toEqual(
-      [first.id, second.id],
-    );
+    expect(
+      listQueuedThreadMessages(db, thread.id).map((row) => row.id),
+    ).toEqual([first.id, second.id]);
     expect(getQueuedThreadMessage(db, first.id)).toMatchObject({
       content: JSON.stringify(textInput("edited in place")),
       createdAt: before?.createdAt,
@@ -321,9 +321,13 @@ describe("queued thread messages", () => {
       systemNotice: null,
     });
 
-    expect(deleteQueuedThreadMessage(db, noopNotifier, queuedMessage.id)).toBe(true);
+    expect(deleteQueuedThreadMessage(db, noopNotifier, queuedMessage.id)).toBe(
+      true,
+    );
     expect(listQueuedThreadMessages(db, thread.id)).toHaveLength(0);
-    expect(deleteQueuedThreadMessage(db, noopNotifier, queuedMessage.id)).toBe(false);
+    expect(deleteQueuedThreadMessage(db, noopNotifier, queuedMessage.id)).toBe(
+      false,
+    );
   });
 
   it("claims a queued message and hides it from the queue until the claim is released", () => {
@@ -341,7 +345,11 @@ describe("queued thread messages", () => {
       systemNotice: null,
     });
 
-    const claimedQueuedMessage = claimQueuedThreadMessage(db, noopNotifier, queuedMessage.id);
+    const claimedQueuedMessage = claimQueuedThreadMessage(
+      db,
+      noopNotifier,
+      queuedMessage.id,
+    );
     expect(claimedQueuedMessage?.id).toBe(queuedMessage.id);
     expect(claimedQueuedMessage?.claimToken).toMatch(/^qclaim_/);
     expect(listQueuedThreadMessages(db, thread.id)).toHaveLength(0);
@@ -372,7 +380,11 @@ describe("queued thread messages", () => {
       payload: { kind: "inline" },
       systemNotice: null,
     });
-    const firstClaim = claimQueuedThreadMessage(db, noopNotifier, queuedMessage.id);
+    const firstClaim = claimQueuedThreadMessage(
+      db,
+      noopNotifier,
+      queuedMessage.id,
+    );
     if (!firstClaim) {
       throw new Error("Expected first queued message claim");
     }
@@ -382,11 +394,15 @@ describe("queued thread messages", () => {
         claimToken: "qclaim_staleowner",
       }),
     ).toBe(false);
-    expect(getQueuedThreadMessage(db, queuedMessage.id)?.claimToken).toBe(firstClaim.claimToken);
+    expect(getQueuedThreadMessage(db, queuedMessage.id)?.claimToken).toBe(
+      firstClaim.claimToken,
+    );
     expect(
       db.transaction((tx) =>
         deleteClaimedQueuedThreadMessageBatchInTransaction(tx, {
-          queuedMessages: [{ id: queuedMessage.id, claimToken: "qclaim_staleowner" }],
+          queuedMessages: [
+            { id: queuedMessage.id, claimToken: "qclaim_staleowner" },
+          ],
         }),
       ),
     ).toBe(false);
@@ -397,7 +413,11 @@ describe("queued thread messages", () => {
         claimToken: firstClaim.claimToken,
       }),
     ).toBe(true);
-    const secondClaim = claimQueuedThreadMessage(db, noopNotifier, queuedMessage.id);
+    const secondClaim = claimQueuedThreadMessage(
+      db,
+      noopNotifier,
+      queuedMessage.id,
+    );
     if (!secondClaim) {
       throw new Error("Expected second queued message claim");
     }
@@ -405,15 +425,21 @@ describe("queued thread messages", () => {
     expect(
       db.transaction((tx) =>
         deleteClaimedQueuedThreadMessageBatchInTransaction(tx, {
-          queuedMessages: [{ id: queuedMessage.id, claimToken: firstClaim.claimToken }],
+          queuedMessages: [
+            { id: queuedMessage.id, claimToken: firstClaim.claimToken },
+          ],
         }),
       ),
     ).toBe(false);
-    expect(getQueuedThreadMessage(db, queuedMessage.id)?.claimToken).toBe(secondClaim.claimToken);
+    expect(getQueuedThreadMessage(db, queuedMessage.id)?.claimToken).toBe(
+      secondClaim.claimToken,
+    );
     expect(
       db.transaction((tx) =>
         deleteClaimedQueuedThreadMessageBatchInTransaction(tx, {
-          queuedMessages: [{ id: queuedMessage.id, claimToken: secondClaim.claimToken }],
+          queuedMessages: [
+            { id: queuedMessage.id, claimToken: secondClaim.claimToken },
+          ],
         }),
       ),
     ).toBe(true);
@@ -437,7 +463,11 @@ describe("queued thread messages", () => {
         payload: { kind: "inline" },
         systemNotice: null,
       });
-      const claimedQueuedMessage = claimQueuedThreadMessage(db, noopNotifier, queuedMessage.id);
+      const claimedQueuedMessage = claimQueuedThreadMessage(
+        db,
+        noopNotifier,
+        queuedMessage.id,
+      );
       expect(claimedQueuedMessage?.claimedAt).toBe(1_000);
       expect(claimedQueuedMessage?.claimToken).toMatch(/^qclaim_/);
       expect(listQueuedThreadMessages(db, thread.id)).toHaveLength(0);
@@ -449,10 +479,12 @@ describe("queued thread messages", () => {
           protectedClaimTokens: [],
         }),
       ).toBe(1);
-      expect(listQueuedThreadMessages(db, thread.id).map((row) => row.id)).toEqual([
-        queuedMessage.id,
-      ]);
-      expect(getQueuedThreadMessage(db, queuedMessage.id)?.claimToken).toBeNull();
+      expect(
+        listQueuedThreadMessages(db, thread.id).map((row) => row.id),
+      ).toEqual([queuedMessage.id]);
+      expect(
+        getQueuedThreadMessage(db, queuedMessage.id)?.claimToken,
+      ).toBeNull();
     } finally {
       nowSpy.mockRestore();
     }
@@ -523,9 +555,9 @@ describe("queued thread messages", () => {
       expect(
         getQueuedThreadMessage(db, releasableQueuedMessage.id)?.claimToken,
       ).toBeNull();
-      expect(listQueuedThreadMessages(db, thread.id).map((row) => row.id)).toEqual([
-        releasableQueuedMessage.id,
-      ]);
+      expect(
+        listQueuedThreadMessages(db, thread.id).map((row) => row.id),
+      ).toEqual([releasableQueuedMessage.id]);
     } finally {
       nowSpy.mockRestore();
     }
@@ -562,11 +594,17 @@ describe("queued thread messages", () => {
         systemNotice: null,
       });
 
-      const claimedQueuedMessage = claimNextQueuedThreadMessageGroup(db, noopNotifier, thread.id)?.[0];
+      const claimedQueuedMessage = claimNextQueuedThreadMessageGroup(
+        db,
+        noopNotifier,
+        thread.id,
+      )?.[0];
       expect(claimedQueuedMessage?.id).toBe(firstQueuedMessage.id);
-      expect(listQueuedThreadMessages(db, thread.id).map((queuedMessage) => queuedMessage.id)).toEqual([
-        secondQueuedMessage.id,
-      ]);
+      expect(
+        listQueuedThreadMessages(db, thread.id).map(
+          (queuedMessage) => queuedMessage.id,
+        ),
+      ).toEqual([secondQueuedMessage.id]);
     } finally {
       nowSpy.mockRestore();
     }
@@ -763,13 +801,14 @@ describe("queued thread messages", () => {
       thread.id,
     );
 
-    expect(claimedQueuedMessages?.map((queuedMessage) => queuedMessage.id)).toEqual([
-      firstQueuedMessage.id,
-      secondQueuedMessage.id,
-    ]);
-    expect(listQueuedThreadMessages(db, thread.id).map((queuedMessage) => queuedMessage.id)).toEqual([
-      thirdQueuedMessage.id,
-    ]);
+    expect(
+      claimedQueuedMessages?.map((queuedMessage) => queuedMessage.id),
+    ).toEqual([firstQueuedMessage.id, secondQueuedMessage.id]);
+    expect(
+      listQueuedThreadMessages(db, thread.id).map(
+        (queuedMessage) => queuedMessage.id,
+      ),
+    ).toEqual([thirdQueuedMessage.id]);
   });
 
   it("pauses ordinary turn-end rows without pausing system notices", () => {
@@ -826,6 +865,12 @@ describe("queued thread messages", () => {
     expect(
       listIdleThreadsWithQueuedMessages(db).map((row) => row.threadId),
     ).toContain(thread.id);
+    expect(
+      claimQueuedThreadMessageGroup(db, noopNotifier, ordinary.id, {
+        kind: "automatic",
+        isGroupEligible: () => true,
+      }),
+    ).toBeNull();
     expect(
       claimNextQueuedThreadMessageGroup(db, noopNotifier, thread.id)?.map(
         (row) => row.id,
@@ -963,9 +1008,9 @@ describe("queued thread messages", () => {
     // The requested drain clears the lead's wait and claims by id; the claim
     // is a claim on the batch, so the tail dispatches with it.
     expect(
-      claimQueuedThreadMessageGroup(db, noopNotifier, lead.id, true)?.map(
-        (queuedMessage) => queuedMessage.id,
-      ),
+      claimQueuedThreadMessageGroup(db, noopNotifier, lead.id, {
+        kind: "explicit-send",
+      })?.map((queuedMessage) => queuedMessage.id),
     ).toEqual([lead.id, tail.id]);
   });
 
@@ -1022,16 +1067,17 @@ describe("queued thread messages", () => {
       db,
       noopNotifier,
       thirdQueuedMessage.id,
-      true,
+      { kind: "explicit-send" },
     );
 
-    expect(claimedQueuedMessages?.map((queuedMessage) => queuedMessage.id)).toEqual([
-      thirdQueuedMessage.id,
-    ]);
-    expect(listQueuedThreadMessages(db, thread.id).map((queuedMessage) => queuedMessage.id)).toEqual([
-      firstQueuedMessage.id,
-      secondQueuedMessage.id,
-    ]);
+    expect(
+      claimedQueuedMessages?.map((queuedMessage) => queuedMessage.id),
+    ).toEqual([thirdQueuedMessage.id]);
+    expect(
+      listQueuedThreadMessages(db, thread.id).map(
+        (queuedMessage) => queuedMessage.id,
+      ),
+    ).toEqual([firstQueuedMessage.id, secondQueuedMessage.id]);
   });
 
   it("clears the previous group edge when deleting a grouped follower", () => {
@@ -1153,14 +1199,9 @@ describe("queued thread messages", () => {
     });
 
     expect(
-      claimQueuedThreadMessageGroup(
-        db,
-        noopNotifier,
-        secondQueuedMessage.id,
-        true,
-      )?.map(
-        (queuedMessage) => queuedMessage.id,
-      ),
+      claimQueuedThreadMessageGroup(db, noopNotifier, secondQueuedMessage.id, {
+        kind: "explicit-send",
+      })?.map((queuedMessage) => queuedMessage.id),
     ).toEqual([secondQueuedMessage.id]);
 
     expect(
@@ -1228,7 +1269,7 @@ describe("queued thread messages", () => {
       db,
       noopNotifier,
       secondQueuedMessage.id,
-      true,
+      { kind: "explicit-send" },
     );
     expect(claimed?.map((queuedMessage) => queuedMessage.id)).toEqual([
       secondQueuedMessage.id,
@@ -1467,7 +1508,9 @@ describe("queued thread messages", () => {
       nextQueuedMessageId: firstQueuedMessage.id,
     });
     expect(moveToFront.kind).toBe("reordered");
-    expect(listQueuedThreadMessages(db, thread.id).map((row) => row.id)).toEqual([
+    expect(
+      listQueuedThreadMessages(db, thread.id).map((row) => row.id),
+    ).toEqual([
       thirdQueuedMessage.id,
       firstQueuedMessage.id,
       secondQueuedMessage.id,
@@ -1482,7 +1525,9 @@ describe("queued thread messages", () => {
       nextQueuedMessageId: firstQueuedMessage.id,
     });
     expect(moveToMiddle.kind).toBe("reordered");
-    expect(listQueuedThreadMessages(db, thread.id).map((row) => row.id)).toEqual([
+    expect(
+      listQueuedThreadMessages(db, thread.id).map((row) => row.id),
+    ).toEqual([
       thirdQueuedMessage.id,
       secondQueuedMessage.id,
       firstQueuedMessage.id,
@@ -1497,7 +1542,9 @@ describe("queued thread messages", () => {
       nextQueuedMessageId: null,
     });
     expect(moveToEnd.kind).toBe("reordered");
-    expect(listQueuedThreadMessages(db, thread.id).map((row) => row.id)).toEqual([
+    expect(
+      listQueuedThreadMessages(db, thread.id).map((row) => row.id),
+    ).toEqual([
       secondQueuedMessage.id,
       firstQueuedMessage.id,
       thirdQueuedMessage.id,
@@ -1548,9 +1595,9 @@ describe("queued thread messages", () => {
       thread.id,
     )?.[0];
     expect(claimedQueuedMessage?.id).toBe(secondQueuedMessage.id);
-    expect(listQueuedThreadMessages(db, thread.id).map((row) => row.id)).toEqual([
-      firstQueuedMessage.id,
-    ]);
+    expect(
+      listQueuedThreadMessages(db, thread.id).map((row) => row.id),
+    ).toEqual([firstQueuedMessage.id]);
   });
 
   it("rolls back a reorder when the requested group boundary is invalid", () => {


### PR DESCRIPTION
## Human comments

## What was wrong

Queued-message readiness was decided independently by startup events, idle sweeps, plugin/timer drains, failed-row handling, and manual Stop handling. Each fix could pass alone while their predicates disagreed when composed: a settled `turn-starting` row could be discovered but rejected, a failed grouped sibling could ride with a healthy row, and a stale runtime event or in-flight hook could cross a manual Stop. Startup admission also trusted a stale active thread after it changed to error, which could strand a row or change `steer` semantics.

## What changed

- Made startup admission atomic: it either queues against the still-active startup or retries once from the current thread state.
- Centralized automatic whole-group readiness across plugin, time, `thread-busy`, and `turn-starting` waits.
- Replaced the positional `sendNow`/optional-callback claim API with an explicit `automatic` versus `explicit-send` policy.
- Enforced failed-row exclusion and manual-Stop pause inside the group claim transaction. Explicit Send now remains the override; independent scheduled, plugin-held, and system-notice rows remain drainable.
- Required a post-Stop client request before a later root turn can clear the pause, and rechecked the pause at final dispatch consumption.
- Used one SQL `IN` predicate for idle-drainable wait kinds.

This supersedes #2866 and #2867 and includes the failed-group and Stop-boundary follow-ups. There is no host-daemon wire, schema, CLI, SDK, migration, or documentation contract change.

## How you verified

- Added deterministic regressions for the settled-startup lost wake, mixed-wait groups, failed grouped siblings, stale post-Stop starts, hook-held Stop races, and active-to-error startup admission for both `steer` modes.
- Focused Turbo server matrix: 70/70 passed.
- Focused Turbo DB/query-plan matrix: 68/68 passed.
- Standalone production-path Stop race harness: both races passed.
- Full DB suite: 444/444 passed.
- Full server suite: 2,131 passed; 10 unrelated `install-machine-script` tests failed because their fake host daemon did not connect.
- `pnpm exec turbo run typecheck --filter=@bb/server --filter=@bb/db` passed.
- `pnpm exec turbo run build --filter=@bb/server` passed.
- `git diff --check` passed.

> AGENT GENERATED
