### PR TITLE
Restore saved branch prefix after failed save

### DIFF
--- a/apps/app/src/views/SettingsView.branch-prefix.test.tsx
+++ b/apps/app/src/views/SettingsView.branch-prefix.test.tsx
@@ -1,5 +1,11 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen, fireEvent } from "@testing-library/react";
+import {
+  cleanup,
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { GeneralSettingsSection } from "./SettingsView";
 
@@ -60,6 +66,17 @@ describe("worktree branch prefix setting", () => {
     fireEvent.change(input, { target: { value: "" } });
     fireEvent.blur(input);
     expect(onChange).toHaveBeenCalledWith("");
+  });
+
+  it("restores the saved value when saving fails", async () => {
+    const failedSave = Promise.reject(new Error("write failed"));
+    void failedSave.catch(() => undefined);
+    const onChange = vi.fn(() => failedSave);
+    renderSection({ onManagedBranchPrefixChange: onChange });
+    const input = branchPrefixInput();
+    fireEvent.change(input, { target: { value: "team/" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    await waitFor(() => expect(input.value).toBe("bb/"));
   });
 
   it("refuses an invalid prefix and restores the saved value", () => {

--- a/apps/app/src/views/SettingsView.tsx
+++ b/apps/app/src/views/SettingsView.tsx
@@ -150,7 +150,7 @@ interface GeneralSettingsSectionProps {
   managedBranchPrefix: string;
   managedBranchPrefixDisabled: boolean;
   navigateToThreadAfterCreate: boolean;
-  onManagedBranchPrefixChange: (prefix: string) => void;
+  onManagedBranchPrefixChange: (prefix: string) => Promise<void> | void;
   onNavigateToThreadAfterCreateChange: (enabled: boolean) => void;
   onOpenLinksInAppBrowserChange: (enabled: boolean) => void;
   onRewriteLocalhostLinksChange: (enabled: boolean) => void;
@@ -556,7 +556,7 @@ const MANAGED_BRANCH_PREFIX_EXAMPLE_SLUG = "fix-login-flow-thr_ab12cd34ef";
 
 interface ManagedBranchPrefixSettingProps {
   disabled: boolean;
-  onChange: (prefix: string) => void;
+  onChange: (prefix: string) => Promise<void> | void;
   value: string;
 }
 
@@ -578,7 +578,9 @@ function ManagedBranchPrefixSetting({
       setDraft(value);
       return;
     }
-    if (draft !== value) onChange(draft);
+    if (draft !== value) {
+      void Promise.resolve(onChange(draft)).catch(() => setDraft(value));
+    }
   };
 
   return (
@@ -1178,12 +1180,12 @@ export function SettingsView() {
             systemConfigQuery.data === undefined ||
             updateGeneralSettingsMutation.isPending
           }
-          onManagedBranchPrefixChange={(prefix) =>
-            updateGeneralSettingsMutation.mutate({
+          onManagedBranchPrefixChange={async (prefix) => {
+            await updateGeneralSettingsMutation.mutateAsync({
               ...generalSettings,
               managedBranchPrefix: prefix,
-            })
-          }
+            });
+          }}
           navigateToThreadAfterCreate={navigateToThreadAfterCreate}
           openLinksInAppBrowser={openLinksInAppBrowser}
           rewriteLocalhostLinks={rewriteLocalhostLinks}


### PR DESCRIPTION
## Human comments

## What was wrong

When saving a new managed worktree branch prefix failed, the Settings input continued displaying the rejected draft even though bb retained the previously saved value. Users could therefore see one prefix while new branches still used another.

## What changed

- Await the existing settings mutation from the branch-prefix field.
- Restore the authoritative saved prefix when that mutation rejects.
- Preserve successful Enter and blur saves, validation, dirty drafts, the default `bb/`, and branch creation behavior.
- Add a focused regression for the failed-save path.

No daemon wire contract, server API, SDK API, CLI, documentation, or protocol version changed.

## How you verified

- `pnpm exec turbo run test --filter=@bb/app -- --run src/views/SettingsView.branch-prefix.test.tsx` — 5 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/app` — passed.
- `pnpm exec oxfmt --check apps/app/src/views/SettingsView.tsx apps/app/src/views/SettingsView.branch-prefix.test.tsx` — passed.
- `git diff --check origin/main...HEAD` — passed.
- The original source thread also completed full app tests, app build, and matched desktop failure/success QA.

> AGENT GENERATED