### PR TITLE
Preserve newer plugin settings drafts

### DIFF
--- a/apps/app/src/components/plugin/PluginSettings.test.tsx
+++ b/apps/app/src/components/plugin/PluginSettings.test.tsx
@@ -129,6 +129,59 @@ describe("PluginSettingsForm", () => {
     );
   });
 
+  it("preserves text typed while an older save is pending", async () => {
+    const first = deferred<Response>();
+    const second = deferred<Response>();
+    const requests: RecordedRequest[] = [];
+    let saveCount = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init?: RequestInit) => {
+        requests.push({ url, init });
+        if (init?.method !== "PUT") return jsonOk(SETTINGS_VIEW);
+        saveCount += 1;
+        return saveCount === 1 ? first.promise : second.promise;
+      }),
+    );
+
+    const { wrapper } = createQueryClientTestHarness();
+    render(<PluginSettingsForm pluginId="demo" />, { wrapper });
+
+    const greeting = await screen.findByLabelText("Greeting");
+    fireEvent.change(greeting, { target: { value: "older" } });
+    fireEvent.blur(greeting);
+    await vi.waitFor(() => expect(saveCount).toBe(1));
+    fireEvent.change(greeting, { target: { value: "newer" } });
+
+    await act(async () => {
+      first.resolve(
+        jsonOk({
+          ...SETTINGS_VIEW,
+          values: { ...SETTINGS_VIEW.values, greeting: "older" },
+        }),
+      );
+      await first.promise;
+    });
+    expect((greeting as HTMLInputElement).value).toBe("newer");
+
+    fireEvent.blur(greeting);
+    await vi.waitFor(() => expect(saveCount).toBe(2));
+    expect(JSON.parse(String(requests.at(-1)?.init?.body))).toEqual({
+      values: { greeting: "newer" },
+    });
+
+    await act(async () => {
+      second.resolve(
+        jsonOk({
+          ...SETTINGS_VIEW,
+          values: { ...SETTINGS_VIEW.values, greeting: "newer" },
+        }),
+      );
+      await second.promise;
+    });
+    expect((greeting as HTMLInputElement).value).toBe("newer");
+  });
+
   it("renders an experimental_multiline string below its label and flushes it on blur", async () => {
     const view = {
       ok: true,

--- a/apps/app/src/components/plugin/PluginSettings.tsx
+++ b/apps/app/src/components/plugin/PluginSettings.tsx
@@ -277,27 +277,33 @@ function AutosavingPluginSetting({
   const queryClient = useQueryClient();
   const messageId = useId();
   const initialDraft = initialSettingDraft(descriptor, storedValue);
-  const [draft, setDraft] = useState<string | boolean>(initialDraft);
+  const [draftState, setDraftState] = useState({
+    value: initialDraft,
+    hasNewerDraft: false,
+  });
+  const draft = draftState.value;
   const save = useMutation({
     scope: { id: `plugin-setting:${pluginId}:${settingKey}` },
     mutationFn: (value: string | boolean) =>
       updatePluginSettings(fetch, pluginId, {
         [settingKey]: value,
       }),
-    onSuccess: (view, value) => {
+    onSuccess: (view) => {
       applyPluginSettingsView({ queryClient, pluginId, view });
-      if (descriptor.type === "string" && descriptor.secret === true) {
-        setDraft((current) => (current === value ? "" : current));
-      }
     },
   });
 
   useEffect(() => {
-    if (!save.isPending && !save.isError) setDraft(initialDraft);
-  }, [initialDraft, save.isError, save.isPending]);
+    if (!draftState.hasNewerDraft && !save.isPending && !save.isError) {
+      setDraftState({ value: initialDraft, hasNewerDraft: false });
+    }
+  }, [draftState.hasNewerDraft, initialDraft, save.isError, save.isPending]);
 
   function changeDraft(value: string | boolean): void {
-    setDraft(value);
+    setDraftState({
+      value,
+      hasNewerDraft: descriptor.type === "string",
+    });
     save.reset();
     if (descriptor.type !== "string") {
       save.mutate(value);
@@ -305,8 +311,12 @@ function AutosavingPluginSetting({
   }
 
   function saveDraft(): void {
-    if (descriptor.type !== "string" || draft === storedValue) return;
-    if (descriptor.secret === true && draft === "") return;
+    if (descriptor.type !== "string") return;
+    if (draft === storedValue || (descriptor.secret === true && draft === "")) {
+      setDraftState({ value: draft, hasNewerDraft: false });
+      return;
+    }
+    setDraftState({ value: draft, hasNewerDraft: false });
     save.mutate(draft);
   }
 


### PR DESCRIPTION
## Human comments

## What was wrong

After a text setting blurred and began a slow autosave, typing a newer draft before the request finished could be undone by the older response. The reconciliation effect replaced the newer unsaved text with the earlier stored value.

## What changed

- Track whether a string setting has a draft newer than its last blur.
- Reconcile stored values only when no newer local draft exists.
- Keep the shared behavior for regular, multiline, and secret string settings without changing validation or autosave semantics.
- Add a focused regression that completes the older request, preserves the newer draft, and then saves it normally.

No daemon wire contract, server API, public Plugin SDK API, CLI, documentation, or protocol version changed.

## How you verified

- `pnpm exec turbo run test --filter=@bb/app -- --run src/components/plugin/PluginSettings.test.tsx` — 12 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/app` — passed.
- `pnpm exec oxfmt --check apps/app/src/components/plugin/PluginSettings.tsx apps/app/src/components/plugin/PluginSettings.test.tsx` — passed.
- `git diff --check origin/main...HEAD` — passed.
- The original source thread also completed app build and matched slow-save browser QA.

> AGENT GENERATED