### PR TITLE
Queue existing-thread follow-ups while host is offline

### DIFF
--- a/apps/server/src/services/threads/dispatch-attempt.ts
+++ b/apps/server/src/services/threads/dispatch-attempt.ts
@@ -28,9 +28,13 @@ import { z } from "zod";
 import { ApiError } from "../../errors.js";
 import type { LoggedPendingInteractionWorkSessionDeps } from "../../types.js";
 import { requirePublicProject } from "../lib/entity-lookup.js";
-import { throwThreadNotWritable } from "../lib/lifecycle-api-errors.js";
+import {
+  goneThreadEnvironmentDetails,
+  throwThreadNotWritable,
+} from "../lib/lifecycle-api-errors.js";
 import { validatePromptAttachmentReferences } from "../projects/attachments.js";
 import {
+  dispatchEnvironmentAndHost,
   dispatchExecutionSources,
   dispatchWaitReasonForPass,
   hasMessageDispatchHooks,
@@ -315,6 +319,16 @@ async function runDispatchAttempt(
   const sendAt = payload.sendAt ?? null;
   if (!sendNow && sendAt !== null && sendAt > Date.now()) {
     return waitOn({ kind: "time" }, sendAt);
+  }
+
+  const { environment: dispatchEnvironment, host: dispatchHost } =
+    dispatchEnvironmentAndHost(deps, thread.environmentId);
+  if (
+    dispatchEnvironment !== null &&
+    goneThreadEnvironmentDetails(dispatchEnvironment) === null &&
+    dispatchHost?.status === "disconnected"
+  ) {
+    return waitOn({ kind: "host-offline", hostName: dispatchHost.name }, null);
   }
 
   if (thread.status === "active" && attempt === "start-turn") {

--- a/apps/server/test/public/public-thread-offline-followup.test.ts
+++ b/apps/server/test/public/public-thread-offline-followup.test.ts
@@ -1,0 +1,129 @@
+import { listEvents, listQueuedThreadMessages } from "@bb/db";
+import { queuedMessageWaitingOnSchema } from "@bb/domain";
+import { sendMessageResponseSchema } from "@bb/server-contract";
+import { describe, expect, it } from "vitest";
+import { onDaemonSocketOpen } from "../../src/ws/daemon-protocol.js";
+import {
+  registerTestHostRpcCapture,
+  waitForQueuedCommand,
+} from "../helpers/commands.js";
+import { readJson } from "../helpers/json.js";
+import {
+  seedEnvironment,
+  seedHost,
+  seedProjectWithSource,
+  seedSession,
+  seedThread,
+  seedThreadRuntimeState,
+} from "../helpers/seed.js";
+import { withTestHarness } from "../helpers/test-app.js";
+
+describe("offline host follow-ups", () => {
+  it("queues a follow-up to an existing idle thread until its host reconnects", async () => {
+    await withTestHarness(async (harness) => {
+      const host = seedHost(harness.deps, {
+        id: "host-offline-followup",
+        name: "M5",
+      });
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.id,
+      });
+      const environment = seedEnvironment(harness.deps, {
+        hostId: host.id,
+        projectId: project.id,
+        path: "/tmp/offline-followup",
+        workspaceProvisionType: "unmanaged",
+      });
+      const thread = seedThread(harness.deps, {
+        projectId: project.id,
+        environmentId: environment.id,
+        status: "idle",
+      });
+      seedThreadRuntimeState(harness.deps, {
+        threadId: thread.id,
+        environmentId: environment.id,
+        providerThreadId: "provider-offline-followup",
+      });
+      const input = [
+        {
+          type: "text" as const,
+          text: "Continue when M5 reconnects",
+          mentions: [],
+        },
+      ];
+      const eventCountBeforeSend = listEvents(harness.db, {
+        threadId: thread.id,
+      }).length;
+
+      const response = await harness.app.request(
+        `/api/v1/threads/${thread.id}/send`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            input,
+            mode: "steer-if-active",
+            model: "gpt-5",
+            permissionMode: "full",
+            reasoningLevel: "medium",
+            serviceTier: "default",
+          }),
+        },
+      );
+
+      expect(response.status).toBe(200);
+      const body = sendMessageResponseSchema.parse(await readJson(response));
+      expect(body).toMatchObject({
+        delivery: "queued",
+        waitingOn: { kind: "host-offline", hostName: "M5" },
+        sendAt: null,
+      });
+      if (body.delivery !== "queued") {
+        throw new Error("expected the offline follow-up to queue");
+      }
+
+      const queued = listQueuedThreadMessages(harness.db, thread.id);
+      expect(queued).toHaveLength(1);
+      expect(queued[0]).toMatchObject({
+        id: body.queuedMessageId,
+        sendAt: null,
+        failureReason: null,
+      });
+      expect(
+        queuedMessageWaitingOnSchema.parse(JSON.parse(queued[0]!.waitingOn!)),
+      ).toEqual({ kind: "host-offline", hostName: "M5" });
+      expect(listEvents(harness.db, { threadId: thread.id })).toHaveLength(
+        eventCountBeforeSend,
+      );
+
+      const reconnectSession = seedSession(harness.deps, host.id);
+      const reconnectSocket = registerTestHostRpcCapture(harness.deps, {
+        hostId: host.id,
+        sessionId: reconnectSession.id,
+      });
+      onDaemonSocketOpen(harness.deps, {
+        hostId: host.id,
+        sessionId: reconnectSession.id,
+        socket: reconnectSocket,
+      });
+
+      const dispatched = await waitForQueuedCommand(
+        harness,
+        ({ command }) =>
+          command.type === "turn.submit" && command.threadId === thread.id,
+      );
+      if (dispatched.command.type !== "turn.submit") {
+        throw new Error("expected the queued follow-up to dispatch");
+      }
+      expect(dispatched.command).toMatchObject({
+        threadId: thread.id,
+        input,
+        target: { mode: "start" },
+      });
+      expect(listQueuedThreadMessages(harness.db, thread.id)).toEqual([]);
+      expect(listEvents(harness.db, { threadId: thread.id })).toHaveLength(
+        eventCountBeforeSend + 1,
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Human comments

## What was wrong

The dispatch checkpoint handled scheduled sends, busy threads, provisioning, and pending interactions, but it did not treat a disconnected host as a core wait. A follow-up to an existing idle thread therefore continued into live host dispatch and could fail with a 502 instead of becoming durable queued work.

## What changed

The dispatch checkpoint now resolves the attached environment and its live host status before dispatching. When a usable thread environment belongs to a disconnected host, the message is persisted with the existing `host-offline` wait reason.

The public-route regression test covers the normal `steer-if-active` follow-up path on an existing idle thread. It then reconnects that same host through the real daemon socket-open handler and the centralized queued-message dispatch path from #2886, verifies the wait is released and the row is consumed, and verifies a `turn.submit` carrying the original input is issued on the original thread.

This changes no server/daemon wire contract, CLI command, or user-facing setting, so no protocol version or documentation update is needed.

## How you verified

- `pnpm exec turbo run test --filter=@bb/server -- test/public/public-thread-offline-followup.test.ts test/threads/queue-drain-failure.test.ts test/threads/requested-queue-drain.test.ts test/threads/thread-send-dispatch.test.ts`
- All 43 focused queue, reconnect, and dispatch tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/server`
- Prettier and `git diff --check` passed.
- Live dev CLI: created an existing idle thread, held its host offline, and ran default `bb thread tell`. The command returned `delivery: queued` with `waitingOn.kind: host-offline`; `bb thread queue list` showed the same row. After reconnect, the queue emptied and `bb thread output` returned the queued prompt response on the original thread.

Fixes: N/A (no linked issue)

> AGENT GENERATED