### PR TITLE
Fix project selector scrolling on short screens

### DIFF
--- a/apps/app/src/components/pickers/ProjectSelector.test.tsx
+++ b/apps/app/src/components/pickers/ProjectSelector.test.tsx
@@ -1,0 +1,29 @@
+// @vitest-environment jsdom
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ProjectSelector } from "./ProjectSelector";
+
+describe("ProjectSelector", () => {
+  it("keeps the project menu inside a short viewport and scrolls it", () => {
+    render(
+      <ProjectSelector
+        projects={Array.from({ length: 20 }, (_, index) => ({
+          id: `proj_${index}`,
+          name: `Project ${index}`,
+        }))}
+        value="proj_0"
+        onChange={() => {}}
+        defaultOpen
+        modal={false}
+      />,
+    );
+
+    const menu = screen.getByRole("menu");
+    expect(menu.className).toContain(
+      "max-h-[min(var(--radix-dropdown-menu-content-available-height),calc(100dvh-0.5rem))]",
+    );
+    expect(menu.className).toContain("overflow-y-auto");
+    expect(menu.className).toContain("overscroll-contain");
+  });
+});

--- a/apps/app/src/components/pickers/ProjectSelector.tsx
+++ b/apps/app/src/components/pickers/ProjectSelector.tsx
@@ -113,7 +113,11 @@ export function ProjectSelector({
           )}
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" side="bottom" className="w-52">
+      <DropdownMenuContent
+        align="start"
+        side="bottom"
+        className="max-h-[min(var(--radix-dropdown-menu-content-available-height),calc(100dvh-0.5rem))] w-52 overflow-y-auto overscroll-contain"
+      >
         <DropdownMenuLabel>Project</DropdownMenuLabel>
         {projects.map((project) => (
           <DropdownMenuItem


### PR DESCRIPTION
## Human comments

## What was wrong

The project selector menu had no viewport-aware height limit or vertical scroll behavior. A long project list extended beyond short screens.

## What changed

The project selector menu now uses the available Radix height and the dynamic viewport height. It scrolls vertically and contains overscroll.

## How you verified

- `pnpm exec turbo run test --filter=@bb/app -- --run src/components/pickers/ProjectSelector.test.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- Browser test at 900 by 320 pixels with 20 projects. The 615-pixel list scrolled within a 190-pixel menu.

> AGENT GENERATED
