### PR TITLE
Fix custom toast icon alignment

### DIFF
--- a/apps/app/src/components/ui/app-toast.test.tsx
+++ b/apps/app/src/components/ui/app-toast.test.tsx
@@ -53,6 +53,20 @@ describe("AppToastContent", () => {
     expect(container.querySelector('[data-icon="Loading"]')).not.toBeNull();
   });
 
+  it("neutralizes Sonner margins on custom toast icons", () => {
+    const { container } = render(
+      <AppToastContent title="Thread Archived" tone="success" />,
+    );
+
+    expect(
+      container.querySelector<SVGElement>('[data-icon="CircleCheck"]')?.style
+        .margin,
+    ).toBe("0px");
+    expect(
+      container.querySelector<SVGElement>('[data-icon="X"]')?.style.margin,
+    ).toBe("0px");
+  });
+
   it("dismisses from the visible close control", () => {
     const onDismiss = vi.fn();
     render(

--- a/apps/app/src/components/ui/app-toast.tsx
+++ b/apps/app/src/components/ui/app-toast.tsx
@@ -141,6 +141,7 @@ export function AppToastContent({
           <Icon
             name={iconForTone(tone)}
             className={cn("size-4", tone === "loading" && "animate-spin")}
+            style={{ margin: 0 }}
             aria-hidden
           />
         </div>
@@ -168,7 +169,12 @@ export function AppToastContent({
             aria-label="Dismiss notification"
             onClick={() => (onDismiss ? onDismiss() : dismissToast(id))}
           >
-            <Icon name="X" className="size-3.5" aria-hidden />
+            <Icon
+              name="X"
+              className="size-3.5"
+              style={{ margin: 0 }}
+              aria-hidden
+            />
           </Button>
         ) : null}
       </div>


### PR DESCRIPTION
## Human comments

## What was wrong

Sonner's built-in toast stylesheet targets every descendant with a `data-icon` attribute and adds asymmetric icon margins. bb's shared `Icon` component uses the same attribute inside custom toast content, so the close glyph sat 3.5px left of its hover background's center; the leading status glyph inherited the same displacement.

## What changed

Neutralized Sonner's inherited margins on the custom toast status and close icons. Added focused regression coverage for both glyphs. This has no wire, protocol, CLI, guide, or documentation impact.

## How you verified

- `pnpm exec turbo run test --filter=@bb/app --force -- src/components/ui/app-toast.test.tsx` (4 tests passed)
- `pnpm exec turbo run typecheck --filter=@bb/app --force`
- `pnpm exec oxfmt apps/app/src/components/ui/app-toast.tsx apps/app/src/components/ui/app-toast.test.tsx --check`
- `git diff --check origin/main...HEAD`
- Doobie hover-state capture confirmed that the close glyph and its hover background now share the same horizontal center.

> AGENT GENERATED
