### PR TITLE
Fix Plugin Guide annotation layout

### DIFF
--- a/.bb/skills/plugin-guide-maintenance/SKILL.md
+++ b/.bb/skills/plugin-guide-maintenance/SKILL.md
@@ -64,6 +64,27 @@ Complete the applicable changes:
 - Keep Guide annotations separate from the product interface.
 - Add focused tests for the entry, source anchors, trigger, and outcome.
 
+## Redraw annotation order
+
+Annotation numbers express the rendered fixture's spatial reading order, not
+API registration or source order. Read rows from top to bottom, then read the
+annotations within each row from left to right.
+
+Whenever a visible surface is added, removed, or moved:
+
+1. Build and reload the Plugin Guide, then open the real affected fixture at
+   each relevant viewport.
+2. Inspect the rendered badge positions and redraw the full affected sequence.
+   Do not append or insert only the new annotation.
+3. Rewrite the affected group's order in `surfaces.ts` and its matching
+   `*_MARKS` order in `wireframes.tsx` as the same complete sequence.
+4. Update the focused order test with that complete sequence.
+5. Verify that badge numbers, cards, and previous/next navigation agree; every
+   annotation appears exactly once; and no badge clips or obscures its target.
+
+If responsive layouts produce conflicting spatial orders, fix the layout or
+define one stable readable sequence before shipping.
+
 ## Refresh the SDK inventory
 
 Refresh the inventory after the Guide represents the API change:

--- a/.bb/skills/plugin-guide-maintenance/SKILL.md
+++ b/.bb/skills/plugin-guide-maintenance/SKILL.md
@@ -86,6 +86,31 @@ Whenever a visible surface is added, removed, or moved:
 If responsive layouts produce conflicting spatial orders, fix the layout or
 define one stable readable sequence before shipping.
 
+## Validate annotation overlay areas
+
+Treat a badge's position, its visible target, and its interactive overlay as
+separate layout contracts. An annotation overlay must trace only the surface it
+describes: it must not extend into an adjacent annotation's surface, cover that
+surface's label or content, or capture its hover, focus, or click behavior.
+
+When annotated surfaces are intentionally nested, the child surface must own
+interaction across its full visible target and remain readable when either
+annotation is active. Do not rely on DOM order or a parent overlay's `z-index`
+to arbitrate overlapping targets; partition or layer the overlays so the
+rendered behavior matches the visible surfaces.
+
+Whenever an annotation target or its surrounding layout changes:
+
+1. At each relevant viewport, inspect the rendered bounds of every affected
+   target and overlay, including their shared edges and nested areas.
+2. Hover, focus, and click both the badge and the visible target for each
+   annotation. Confirm that only the matching annotation activates and that
+   the complete intended target remains reachable.
+3. Check sibling overlays for intersections and hit-test nested overlays to
+   confirm that a parent or neighbor cannot steal the child's interaction.
+4. Add or update a focused test for the overlay boundary or ownership rule that
+   could regress. A DOM-nesting assertion alone is not sufficient.
+
 ## Refresh the SDK inventory
 
 Refresh the inventory after the Guide represents the API change:

--- a/.bb/skills/plugin-guide-maintenance/SKILL.md
+++ b/.bb/skills/plugin-guide-maintenance/SKILL.md
@@ -64,52 +64,35 @@ Complete the applicable changes:
 - Keep Guide annotations separate from the product interface.
 - Add focused tests for the entry, source anchors, trigger, and outcome.
 
-## Redraw annotation order
+## Maintain annotation layout
 
-Annotation numbers express the rendered fixture's spatial reading order, not
-API registration or source order. Read the fixture's columns from left to
-right, then read the annotations within each column from top to bottom. When
-annotations share a row within one column, read them from left to right.
+Annotation numbers follow the rendered fixture: columns from left to right,
+then annotations within each column from top to bottom. Read annotations that
+share a row from left to right.
 
-Whenever a visible surface is added, removed, or moved:
+Treat each annotation's badge, visible target, and interactive overlay as
+separate layout contracts. Whenever an annotation is added, removed, moved, or
+renumbered, or its target or surrounding layout changes:
 
-1. Build and reload the Plugin Guide, then open the real affected fixture at
-   each relevant viewport.
-2. Inspect the rendered badge positions and redraw the full affected sequence.
-   Do not append or insert only the new annotation.
-3. Rewrite the affected group's order in `surfaces.ts` and its matching
-   `*_MARKS` order in `wireframes.tsx` as the same complete sequence.
-4. Update the focused order test with that complete sequence.
-5. Verify that badge numbers, cards, and previous/next navigation agree; every
-   annotation appears exactly once; and no badge clips or obscures its target.
+1. Build and reload the real Plugin Guide at each relevant viewport. Redraw the
+   complete affected sequence, then update `surfaces.ts`, the matching
+   `*_MARKS` order in `wireframes.tsx`, and the focused order test.
+2. Inspect each rendered badge footprint, including its outline, ring, and
+   hover scaling. It must remain inside its container, not intersect another
+   badge, and leave its annotated content readable.
+3. Inspect target and overlay bounds, including shared edges and nested areas.
+   An overlay must not enter a sibling surface, cover its content, or capture
+   its hover, focus, or click behavior. A nested child must own its full visible
+   target; do not rely on DOM order or `z-index` to resolve ownership.
+4. Hover, focus, and click every affected badge and visible target. Confirm
+   that only the matching annotation activates, the full target is reachable,
+   and badge numbers, cards, and previous/next navigation agree.
+5. Add or update focused tests for the order and any boundary or ownership rule
+   that could regress. Every annotation must appear exactly once; DOM nesting
+   alone does not prove correct overlay ownership.
 
-If responsive layouts produce conflicting spatial orders, fix the layout or
-define one stable readable sequence before shipping.
-
-## Validate annotation overlay areas
-
-Treat a badge's position, its visible target, and its interactive overlay as
-separate layout contracts. An annotation overlay must trace only the surface it
-describes: it must not extend into an adjacent annotation's surface, cover that
-surface's label or content, or capture its hover, focus, or click behavior.
-
-When annotated surfaces are intentionally nested, the child surface must own
-interaction across its full visible target and remain readable when either
-annotation is active. Do not rely on DOM order or a parent overlay's `z-index`
-to arbitrate overlapping targets; partition or layer the overlays so the
-rendered behavior matches the visible surfaces.
-
-Whenever an annotation target or its surrounding layout changes:
-
-1. At each relevant viewport, inspect the rendered bounds of every affected
-   target and overlay, including their shared edges and nested areas.
-2. Hover, focus, and click both the badge and the visible target for each
-   annotation. Confirm that only the matching annotation activates and that
-   the complete intended target remains reachable.
-3. Check sibling overlays for intersections and hit-test nested overlays to
-   confirm that a parent or neighbor cannot steal the child's interaction.
-4. Add or update a focused test for the overlay boundary or ownership rule that
-   could regress. A DOM-nesting assertion alone is not sufficient.
+If responsive layouts cannot share one spatial order, fix the layout or define
+one stable readable sequence before shipping.
 
 ## Refresh the SDK inventory
 

--- a/.bb/skills/plugin-guide-maintenance/SKILL.md
+++ b/.bb/skills/plugin-guide-maintenance/SKILL.md
@@ -1,14 +1,16 @@
 ---
 name: plugin-guide-maintenance
-description: Keep the Plugin Guide aligned with public Plugin SDK changes that affect its documented contract. Use this skill when an addition, change, rename, stabilization, or removal in @get-bb/plugin-sdk, app.slots.*, or BbPluginApi changes a Guide card, API symbol list, fixture, or SDK inventory. Do not use it for internal API work or interface-only changes that leave the Guide accurate.
+description: Keep the Plugin Guide accurate when a public Plugin SDK change affects its documented contract or an existing Guide annotation changes order, placement, target, or overlay ownership. Use for additions, changes, renames, stabilizations, or removals in @get-bb/plugin-sdk, app.slots.*, or BbPluginApi that affect a Guide card, fixture, symbol list, or SDK inventory, and for annotation-only maintenance. Do not use for internal implementation or API work that leaves the Guide accurate.
 ---
 
-# Maintain the Plugin Guide for a public API change
+# Maintain the Plugin Guide
 
-The Plugin Guide is bb's public Plugin SDK reference. Use this workflow only
-when a public API change affects its documented contract.
+The Plugin Guide is bb's public Plugin SDK reference. For a public API change,
+follow the full workflow. For annotation-only maintenance, start at Maintain
+annotation layout, skip the public-API and SDK-inventory sections, and then
+follow the annotation-only verification path.
 
-## Confirm the trigger
+## Confirm a public API change
 
 Build the declarations and inspect the SDK change:
 
@@ -96,7 +98,7 @@ one stable readable sequence before shipping.
 
 ## Refresh the SDK inventory
 
-Refresh the inventory after the Guide represents the API change:
+Refresh the inventory after the Guide represents a public API change:
 
 ```sh
 pnpm exec turbo run update:sdk-inventory --filter=@bb/plugin-api-map
@@ -105,6 +107,8 @@ pnpm exec turbo run update:sdk-inventory --filter=@bb/plugin-api-map
 Review `packages/plugin-api-map/sdk-public-api.json`. Do not edit its hashes.
 
 ## Verify the result
+
+For a public API change, run:
 
 ```sh
 pnpm exec turbo run test typecheck \
@@ -115,5 +119,8 @@ pnpm exec turbo run test typecheck \
 bb plugin build plugins/plugin-api-docs
 ```
 
-For a visible API change, start `scripts/bb-dev-app current`. Inspect the
-affected entry and each reachable action.
+For annotation-only maintenance, use the affected package and Plugin Guide
+checks required by repository validation policy. Start
+`scripts/bb-dev-app current`; inspect the affected entry and reachable actions
+for a public API change, or the affected annotations and adjacent interactive
+surfaces for annotation-only maintenance.

--- a/.bb/skills/plugin-guide-maintenance/SKILL.md
+++ b/.bb/skills/plugin-guide-maintenance/SKILL.md
@@ -67,8 +67,9 @@ Complete the applicable changes:
 ## Redraw annotation order
 
 Annotation numbers express the rendered fixture's spatial reading order, not
-API registration or source order. Read rows from top to bottom, then read the
-annotations within each row from left to right.
+API registration or source order. Read the fixture's columns from left to
+right, then read the annotations within each column from top to bottom. When
+annotations share a row within one column, read them from left to right.
 
 Whenever a visible surface is added, removed, or moved:
 

--- a/.bb/skills/plugin-guide-maintenance/SKILL.md
+++ b/.bb/skills/plugin-guide-maintenance/SKILL.md
@@ -87,9 +87,9 @@ renumbered, or its target or surrounding layout changes:
 4. Hover, focus, and click every affected badge and visible target. Confirm
    that only the matching annotation activates, the full target is reachable,
    and badge numbers, cards, and previous/next navigation agree.
-5. Add or update focused tests for the order and any boundary or ownership rule
-   that could regress. Every annotation must appear exactly once; DOM nesting
-   alone does not prove correct overlay ownership.
+5. Add or update a focused test for any boundary or ownership rule that could
+   regress. Every annotation must appear exactly once; DOM nesting alone does
+   not prove correct overlay ownership.
 
 If responsive layouts cannot share one spatial order, fix the layout or define
 one stable readable sequence before shipping.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,6 @@
 
 - Any new public plugin API member (a `@get-bb/plugin-sdk/app` export, an `app.slots.*` method, or a `BbPluginApi` property) ships with an `experimental_` name prefix and an entry in [docs/api_to_audit.md](docs/api_to_audit.md) describing what it does and what to audit before stabilizing. Dropping the prefix is the deliberate stabilization step: audit the entry, rename project-wide, and remove it from the doc in the same change.
 - The Plugin Guide (the `plugin-api-docs` plugin, rendering `packages/plugin-api-map`) is bb's only plugin API documentation. A new surface needs a card in `packages/plugin-api-map/src/surfaces.ts` naming its SDK symbols in the same change; `packages/plugin-api-map/test/api-sync.test.ts` fails the build when the map and the SDK drift apart.
-- Plugin Guide annotation numbers follow the rendered fixture's spatial reading order: rows from top to bottom, then annotations within each row from left to right. When a visible surface is added, removed, or moved, rebuild and reload the real Guide, redraw the full affected annotation sequence from the rendered positions, and update the surface order, matching `*_MARKS` order, and focused order test together. Never append or insert a number based only on API registration or source order.
 
 ## Data Access
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@
 
 - Any new public plugin API member (a `@get-bb/plugin-sdk/app` export, an `app.slots.*` method, or a `BbPluginApi` property) ships with an `experimental_` name prefix and an entry in [docs/api_to_audit.md](docs/api_to_audit.md) describing what it does and what to audit before stabilizing. Dropping the prefix is the deliberate stabilization step: audit the entry, rename project-wide, and remove it from the doc in the same change.
 - The Plugin Guide (the `plugin-api-docs` plugin, rendering `packages/plugin-api-map`) is bb's only plugin API documentation. A new surface needs a card in `packages/plugin-api-map/src/surfaces.ts` naming its SDK symbols in the same change; `packages/plugin-api-map/test/api-sync.test.ts` fails the build when the map and the SDK drift apart.
+- Plugin Guide annotation numbers follow the rendered fixture's spatial reading order: rows from top to bottom, then annotations within each row from left to right. When a visible surface is added, removed, or moved, rebuild and reload the real Guide, redraw the full affected annotation sequence from the rendered positions, and update the surface order, matching `*_MARKS` order, and focused order test together. Never append or insert a number based only on API registration or source order.
 
 ## Data Access
 

--- a/packages/plugin-api-map/src/surfaces.ts
+++ b/packages/plugin-api-map/src/surfaces.ts
@@ -45,6 +45,88 @@ export const SURFACE_GROUPS: SurfaceGroup[] = [
       "The main bb window, containing the sidebar, the conversation, and the side panel. A plugin can add rows, controls, panel tabs, and message content to the numbered regions.",
     surfaces: [
       {
+        id: "sidebar-navigation",
+        title: "Sidebar navigation",
+        summary:
+          "Replaces bb's navigation controls above the thread list with a component your plugin renders. With this, a plugin can:",
+        bullets: [
+          "Arrange New thread, Search, Extensions, and plugin destinations",
+          "Activate each destination through bb, including split placement for supported items",
+          "Render bb's original controls when the plugin wants to delegate",
+          "Leave the thread list, footer, drawer, and resize handle under bb's control",
+        ],
+        apiSymbols: [
+          "ExperimentalSidebarNavigationRegistration",
+          "ExperimentalSidebarNavigationProps",
+          "ExperimentalSidebarNavigationItem",
+          "ExperimentalSidebarNavigationAction",
+          "ExperimentalSidebarNavigationIcon",
+          "ExperimentalSidebarNavigationShortcut",
+          "ExperimentalSidebarNavigationActivationOptions",
+        ],
+        experimental: true,
+      },
+      {
+        id: "nav-panel",
+        title: "Full-page panels",
+        summary:
+          "Adds a row to bb's sidebar that opens a page your plugin renders where threads normally appear. With this, a plugin can:",
+        bullets: [
+          "Render any React you write across that whole area",
+          "Get its own URL, so the page can be linked to and bb's back and forward buttons work",
+          "Register tabs in the panel to the right of its page, beside bb's own Browser and Terminal tabs",
+        ],
+        apiSymbols: ["PluginNavPanelRegistration"],
+        firstParty: ["Automations", "Docs", "GitHub", "Tasks"],
+      },
+      {
+        id: "thread-row-status",
+        title: "Thread row status",
+        summary:
+          "A small status bb can draw on a thread's row in the sidebar. With this, a plugin can:",
+        bullets: [
+          "Give the status an icon and a label",
+          "Mark a thread as running while it works on it, and bb shimmers the icon",
+          "Mark it succeeded or failed when the work ends, and bb settles the icon",
+          "Set it only from an [app-wide script](content-scripts). A status needs an owner that outlives any single screen, and those scripts are the only plugin code that does",
+          "Rely on bb to clear it when the script unmounts",
+        ],
+        apiSymbols: [
+          "PluginComposerThreadRowStatus",
+          "PluginContentScriptContext",
+        ],
+        experimental: true,
+      },
+      {
+        id: "thread-list",
+        title: "The thread list",
+        summary:
+          "Replaces the list of threads in bb's sidebar with a component your plugin renders. With this, a plugin can:",
+        bullets: [
+          "Render every row, and decide the grouping, the ordering, and what each row shows",
+          "Read the same live thread data and run statuses bb's own list reads",
+          "Replace only the list. The New thread button, the search action, the plugin rows, and the sidebar footer stay bb's",
+        ],
+        apiSymbols: [
+          "PluginThreadListRegistration",
+          "PluginSidebarThreadsState",
+        ],
+        experimental: true,
+      },
+      {
+        id: "sidebar-footer",
+        title: "Sidebar footer buttons",
+        summary:
+          "Adds an icon button to the row at the bottom of bb's sidebar, beside the Settings button. With this, a plugin can:",
+        bullets: [
+          "Supply the button's icon and its hover tooltip",
+          "Run a callback when the button is clicked",
+          "Stay reachable wherever bb's sidebar is showing",
+        ],
+        apiSymbols: ["PluginSidebarFooterActionRegistration"],
+        firstParty: ["Remote access"],
+      },
+      {
         id: "thread-header",
         title: "Thread header controls",
         summary:
@@ -56,6 +138,61 @@ export const SURFACE_GROUPS: SurfaceGroup[] = [
         ],
         apiSymbols: ["PluginThreadHeaderActionRegistration"],
         experimental: true,
+      },
+      {
+        id: "timeline-renderers",
+        title: "Timeline entry content",
+        summary:
+          "Renders the expanded content of plugin-owned timeline entries while bb keeps each entry's header and controls. With this, a plugin can:",
+        bullets: [
+          "Draw the expanded content beneath timeline entries created by the plugin's own provider",
+          "Receive the entry data and plugin payload, plus bb's default content as `Original`",
+          "Fall back to bb's default content automatically when the plugin is unavailable or crashes",
+        ],
+        apiSymbols: [
+          "PluginTimelineRendererRegistration",
+          "PluginTimelineRendererProps",
+        ],
+        experimental: true,
+      },
+      {
+        id: "message-directives",
+        title: "Rich message embeds",
+        summary:
+          "Renders your component inside an agent's reply, in place of a marker the agent writes into its message. With this, a plugin can:",
+        bullets: [
+          "Claim a directive name; an agent writes `::name` in a message to invoke it",
+          "Replace that marker with a live component, inline in the conversation",
+          "Open a file from the workspace when someone interacts with the embed",
+        ],
+        apiSymbols: ["PluginMessageDirectiveRegistration"],
+        firstParty: ["Docs", "Inline visualizations", "Tasks", "Workflows"],
+      },
+      {
+        id: "message-actions",
+        title: "Message actions",
+        summary:
+          "Adds an action to individual messages in a thread. With this, a plugin can:",
+        bullets: [
+          "Appear in the row that shows under messages on hover, or in the toolbar that appears when text in an agent's message is selected",
+          "Receive the message, plus the selected text when the action was run from a selection",
+          "Open one of the plugin's own [side-panel tabs](thread-panel) with what it received",
+        ],
+        apiSymbols: ["PluginMessageActionRegistration"],
+        firstParty: ["Side chat"],
+      },
+      {
+        id: "pending-interaction",
+        title: "In-thread forms",
+        summary:
+          "Pauses an agent mid-turn to ask the person a question, and hands their answer back to the agent. With this, a plugin can:",
+        bullets: [
+          "Replace the prompt box with a form while the agent waits for an answer",
+          "Receive the submitted answer, or a cancellation and its reason",
+          "Supply the component that draws the form",
+        ],
+        apiSymbols: ["PluginUi", "PluginPendingInteractionRegistration"],
+        firstParty: ["Ask User Question", "Secrets"],
       },
       {
         id: "code-renderers",
@@ -99,143 +236,6 @@ export const SURFACE_GROUPS: SurfaceGroup[] = [
         ],
         apiSymbols: ["PluginFileOpenerRegistration"],
         firstParty: ["Docs"],
-      },
-      {
-        id: "sidebar-navigation",
-        title: "Sidebar navigation",
-        summary:
-          "Replaces bb's navigation controls above the thread list with a component your plugin renders. With this, a plugin can:",
-        bullets: [
-          "Arrange New thread, Search, Extensions, and plugin destinations",
-          "Activate each destination through bb, including split placement for supported items",
-          "Render bb's original controls when the plugin wants to delegate",
-          "Leave the thread list, footer, drawer, and resize handle under bb's control",
-        ],
-        apiSymbols: [
-          "ExperimentalSidebarNavigationRegistration",
-          "ExperimentalSidebarNavigationProps",
-          "ExperimentalSidebarNavigationItem",
-          "ExperimentalSidebarNavigationAction",
-          "ExperimentalSidebarNavigationIcon",
-          "ExperimentalSidebarNavigationShortcut",
-          "ExperimentalSidebarNavigationActivationOptions",
-        ],
-        experimental: true,
-      },
-      {
-        id: "nav-panel",
-        title: "Full-page panels",
-        summary:
-          "Adds a row to bb's sidebar that opens a page your plugin renders where threads normally appear. With this, a plugin can:",
-        bullets: [
-          "Render any React you write across that whole area",
-          "Get its own URL, so the page can be linked to and bb's back and forward buttons work",
-          "Register tabs in the panel to the right of its page, beside bb's own Browser and Terminal tabs",
-        ],
-        apiSymbols: ["PluginNavPanelRegistration"],
-        firstParty: ["Automations", "Docs", "GitHub", "Tasks"],
-      },
-      {
-        id: "timeline-renderers",
-        title: "Timeline entry content",
-        summary:
-          "Renders the expanded content of plugin-owned timeline entries while bb keeps each entry's header and controls. With this, a plugin can:",
-        bullets: [
-          "Draw the expanded content beneath timeline entries created by the plugin's own provider",
-          "Receive the entry data and plugin payload, plus bb's default content as `Original`",
-          "Fall back to bb's default content automatically when the plugin is unavailable or crashes",
-        ],
-        apiSymbols: [
-          "PluginTimelineRendererRegistration",
-          "PluginTimelineRendererProps",
-        ],
-        experimental: true,
-      },
-      {
-        id: "thread-row-status",
-        title: "Thread row status",
-        summary:
-          "A small status bb can draw on a thread's row in the sidebar. With this, a plugin can:",
-        bullets: [
-          "Give the status an icon and a label",
-          "Mark a thread as running while it works on it, and bb shimmers the icon",
-          "Mark it succeeded or failed when the work ends, and bb settles the icon",
-          "Set it only from an [app-wide script](content-scripts). A status needs an owner that outlives any single screen, and those scripts are the only plugin code that does",
-          "Rely on bb to clear it when the script unmounts",
-        ],
-        apiSymbols: [
-          "PluginComposerThreadRowStatus",
-          "PluginContentScriptContext",
-        ],
-        experimental: true,
-      },
-      {
-        id: "message-directives",
-        title: "Rich message embeds",
-        summary:
-          "Renders your component inside an agent's reply, in place of a marker the agent writes into its message. With this, a plugin can:",
-        bullets: [
-          "Claim a directive name; an agent writes `::name` in a message to invoke it",
-          "Replace that marker with a live component, inline in the conversation",
-          "Open a file from the workspace when someone interacts with the embed",
-        ],
-        apiSymbols: ["PluginMessageDirectiveRegistration"],
-        firstParty: ["Docs", "Inline visualizations", "Tasks", "Workflows"],
-      },
-      {
-        id: "message-actions",
-        title: "Message actions",
-        summary:
-          "Adds an action to individual messages in a thread. With this, a plugin can:",
-        bullets: [
-          "Appear in the row that shows under messages on hover, or in the toolbar that appears when text in an agent's message is selected",
-          "Receive the message, plus the selected text when the action was run from a selection",
-          "Open one of the plugin's own [side-panel tabs](thread-panel) with what it received",
-        ],
-        apiSymbols: ["PluginMessageActionRegistration"],
-        firstParty: ["Side chat"],
-      },
-      {
-        id: "thread-list",
-        title: "The thread list",
-        summary:
-          "Replaces the list of threads in bb's sidebar with a component your plugin renders. With this, a plugin can:",
-        bullets: [
-          "Render every row, and decide the grouping, the ordering, and what each row shows",
-          "Read the same live thread data and run statuses bb's own list reads",
-          "Replace only the list. The New thread button, the search action, the plugin rows, and the sidebar footer stay bb's",
-        ],
-        apiSymbols: [
-          "PluginThreadListRegistration",
-          "PluginSidebarThreadsState",
-        ],
-        experimental: true,
-      },
-      {
-        id: "pending-interaction",
-        title: "In-thread forms",
-        summary:
-          "Pauses an agent mid-turn to ask the person a question, and hands their answer back to the agent. With this, a plugin can:",
-        bullets: [
-          "Replace the prompt box with a form while the agent waits for an answer",
-          "Receive the submitted answer, or a cancellation and its reason",
-          "Supply the component that draws the form",
-        ],
-        apiSymbols: ["PluginUi", "PluginPendingInteractionRegistration"],
-        firstParty: ["Ask User Question", "Secrets"],
-      },
-      {
-        id: "sidebar-footer",
-        title: "Sidebar footer buttons",
-        summary:
-          "Adds an icon button to the row at the bottom of bb's sidebar, beside the Settings button. With this, a plugin can:",
-        bullets: [
-          "Supply the button's icon and its hover tooltip",
-          "Run a callback when the button is clicked",
-          "Stay reachable wherever bb's sidebar is showing",
-        ],
-        apiSymbols: ["PluginSidebarFooterActionRegistration"],
-        firstParty: ["Remote access"],
       },
       {
         id: "content-scripts",

--- a/packages/plugin-api-map/src/surfaces.ts
+++ b/packages/plugin-api-map/src/surfaces.ts
@@ -45,88 +45,6 @@ export const SURFACE_GROUPS: SurfaceGroup[] = [
       "The main bb window, containing the sidebar, the conversation, and the side panel. A plugin can add rows, controls, panel tabs, and message content to the numbered regions.",
     surfaces: [
       {
-        id: "nav-panel",
-        title: "Full-page panels",
-        summary:
-          "Adds a row to bb's sidebar that opens a page your plugin renders where threads normally appear. With this, a plugin can:",
-        bullets: [
-          "Render any React you write across that whole area",
-          "Get its own URL, so the page can be linked to and bb's back and forward buttons work",
-          "Register tabs in the panel to the right of its page, beside bb's own Browser and Terminal tabs",
-        ],
-        apiSymbols: ["PluginNavPanelRegistration"],
-        firstParty: ["Automations", "Docs", "GitHub", "Tasks"],
-      },
-      {
-        id: "sidebar-navigation",
-        title: "Sidebar navigation",
-        summary:
-          "Replaces bb's navigation controls above the thread list with a component your plugin renders. With this, a plugin can:",
-        bullets: [
-          "Arrange New thread, Search, Extensions, and plugin destinations",
-          "Activate each destination through bb, including split placement for supported items",
-          "Render bb's original controls when the plugin wants to delegate",
-          "Leave the thread list, footer, drawer, and resize handle under bb's control",
-        ],
-        apiSymbols: [
-          "ExperimentalSidebarNavigationRegistration",
-          "ExperimentalSidebarNavigationProps",
-          "ExperimentalSidebarNavigationItem",
-          "ExperimentalSidebarNavigationAction",
-          "ExperimentalSidebarNavigationIcon",
-          "ExperimentalSidebarNavigationShortcut",
-          "ExperimentalSidebarNavigationActivationOptions",
-        ],
-        experimental: true,
-      },
-      {
-        id: "thread-list",
-        title: "The thread list",
-        summary:
-          "Replaces the list of threads in bb's sidebar with a component your plugin renders. With this, a plugin can:",
-        bullets: [
-          "Render every row, and decide the grouping, the ordering, and what each row shows",
-          "Read the same live thread data and run statuses bb's own list reads",
-          "Replace only the list. The New thread button, the search action, the plugin rows, and the sidebar footer stay bb's",
-        ],
-        apiSymbols: [
-          "PluginThreadListRegistration",
-          "PluginSidebarThreadsState",
-        ],
-        experimental: true,
-      },
-      {
-        id: "thread-row-status",
-        title: "Thread row status",
-        summary:
-          "A small status bb can draw on a thread's row in the sidebar. With this, a plugin can:",
-        bullets: [
-          "Give the status an icon and a label",
-          "Mark a thread as running while it works on it, and bb shimmers the icon",
-          "Mark it succeeded or failed when the work ends, and bb settles the icon",
-          "Set it only from an [app-wide script](content-scripts). A status needs an owner that outlives any single screen, and those scripts are the only plugin code that does",
-          "Rely on bb to clear it when the script unmounts",
-        ],
-        apiSymbols: [
-          "PluginComposerThreadRowStatus",
-          "PluginContentScriptContext",
-        ],
-        experimental: true,
-      },
-      {
-        id: "sidebar-footer",
-        title: "Sidebar footer buttons",
-        summary:
-          "Adds an icon button to the row at the bottom of bb's sidebar, beside the Settings button. With this, a plugin can:",
-        bullets: [
-          "Supply the button's icon and its hover tooltip",
-          "Run a callback when the button is clicked",
-          "Stay reachable wherever bb's sidebar is showing",
-        ],
-        apiSymbols: ["PluginSidebarFooterActionRegistration"],
-        firstParty: ["Remote access"],
-      },
-      {
         id: "thread-header",
         title: "Thread header controls",
         summary:
@@ -138,45 +56,6 @@ export const SURFACE_GROUPS: SurfaceGroup[] = [
         ],
         apiSymbols: ["PluginThreadHeaderActionRegistration"],
         experimental: true,
-      },
-      {
-        id: "message-directives",
-        title: "Rich message embeds",
-        summary:
-          "Renders your component inside an agent's reply, in place of a marker the agent writes into its message. With this, a plugin can:",
-        bullets: [
-          "Claim a directive name; an agent writes `::name` in a message to invoke it",
-          "Replace that marker with a live component, inline in the conversation",
-          "Open a file from the workspace when someone interacts with the embed",
-        ],
-        apiSymbols: ["PluginMessageDirectiveRegistration"],
-        firstParty: ["Docs", "Inline visualizations", "Tasks", "Workflows"],
-      },
-      {
-        id: "message-actions",
-        title: "Message actions",
-        summary:
-          "Adds an action to individual messages in a thread. With this, a plugin can:",
-        bullets: [
-          "Appear in the row that shows under messages on hover, or in the toolbar that appears when text in an agent's message is selected",
-          "Receive the message, plus the selected text when the action was run from a selection",
-          "Open one of the plugin's own [side-panel tabs](thread-panel) with what it received",
-        ],
-        apiSymbols: ["PluginMessageActionRegistration"],
-        firstParty: ["Side chat"],
-      },
-      {
-        id: "pending-interaction",
-        title: "In-thread forms",
-        summary:
-          "Pauses an agent mid-turn to ask the person a question, and hands their answer back to the agent. With this, a plugin can:",
-        bullets: [
-          "Replace the prompt box with a form while the agent waits for an answer",
-          "Receive the submitted answer, or a cancellation and its reason",
-          "Supply the component that draws the form",
-        ],
-        apiSymbols: ["PluginUi", "PluginPendingInteractionRegistration"],
-        firstParty: ["Ask User Question", "Secrets"],
       },
       {
         id: "code-renderers",
@@ -222,6 +101,41 @@ export const SURFACE_GROUPS: SurfaceGroup[] = [
         firstParty: ["Docs"],
       },
       {
+        id: "sidebar-navigation",
+        title: "Sidebar navigation",
+        summary:
+          "Replaces bb's navigation controls above the thread list with a component your plugin renders. With this, a plugin can:",
+        bullets: [
+          "Arrange New thread, Search, Extensions, and plugin destinations",
+          "Activate each destination through bb, including split placement for supported items",
+          "Render bb's original controls when the plugin wants to delegate",
+          "Leave the thread list, footer, drawer, and resize handle under bb's control",
+        ],
+        apiSymbols: [
+          "ExperimentalSidebarNavigationRegistration",
+          "ExperimentalSidebarNavigationProps",
+          "ExperimentalSidebarNavigationItem",
+          "ExperimentalSidebarNavigationAction",
+          "ExperimentalSidebarNavigationIcon",
+          "ExperimentalSidebarNavigationShortcut",
+          "ExperimentalSidebarNavigationActivationOptions",
+        ],
+        experimental: true,
+      },
+      {
+        id: "nav-panel",
+        title: "Full-page panels",
+        summary:
+          "Adds a row to bb's sidebar that opens a page your plugin renders where threads normally appear. With this, a plugin can:",
+        bullets: [
+          "Render any React you write across that whole area",
+          "Get its own URL, so the page can be linked to and bb's back and forward buttons work",
+          "Register tabs in the panel to the right of its page, beside bb's own Browser and Terminal tabs",
+        ],
+        apiSymbols: ["PluginNavPanelRegistration"],
+        firstParty: ["Automations", "Docs", "GitHub", "Tasks"],
+      },
+      {
         id: "timeline-renderers",
         title: "Timeline entry content",
         summary:
@@ -236,6 +150,92 @@ export const SURFACE_GROUPS: SurfaceGroup[] = [
           "PluginTimelineRendererProps",
         ],
         experimental: true,
+      },
+      {
+        id: "thread-row-status",
+        title: "Thread row status",
+        summary:
+          "A small status bb can draw on a thread's row in the sidebar. With this, a plugin can:",
+        bullets: [
+          "Give the status an icon and a label",
+          "Mark a thread as running while it works on it, and bb shimmers the icon",
+          "Mark it succeeded or failed when the work ends, and bb settles the icon",
+          "Set it only from an [app-wide script](content-scripts). A status needs an owner that outlives any single screen, and those scripts are the only plugin code that does",
+          "Rely on bb to clear it when the script unmounts",
+        ],
+        apiSymbols: [
+          "PluginComposerThreadRowStatus",
+          "PluginContentScriptContext",
+        ],
+        experimental: true,
+      },
+      {
+        id: "message-directives",
+        title: "Rich message embeds",
+        summary:
+          "Renders your component inside an agent's reply, in place of a marker the agent writes into its message. With this, a plugin can:",
+        bullets: [
+          "Claim a directive name; an agent writes `::name` in a message to invoke it",
+          "Replace that marker with a live component, inline in the conversation",
+          "Open a file from the workspace when someone interacts with the embed",
+        ],
+        apiSymbols: ["PluginMessageDirectiveRegistration"],
+        firstParty: ["Docs", "Inline visualizations", "Tasks", "Workflows"],
+      },
+      {
+        id: "message-actions",
+        title: "Message actions",
+        summary:
+          "Adds an action to individual messages in a thread. With this, a plugin can:",
+        bullets: [
+          "Appear in the row that shows under messages on hover, or in the toolbar that appears when text in an agent's message is selected",
+          "Receive the message, plus the selected text when the action was run from a selection",
+          "Open one of the plugin's own [side-panel tabs](thread-panel) with what it received",
+        ],
+        apiSymbols: ["PluginMessageActionRegistration"],
+        firstParty: ["Side chat"],
+      },
+      {
+        id: "thread-list",
+        title: "The thread list",
+        summary:
+          "Replaces the list of threads in bb's sidebar with a component your plugin renders. With this, a plugin can:",
+        bullets: [
+          "Render every row, and decide the grouping, the ordering, and what each row shows",
+          "Read the same live thread data and run statuses bb's own list reads",
+          "Replace only the list. The New thread button, the search action, the plugin rows, and the sidebar footer stay bb's",
+        ],
+        apiSymbols: [
+          "PluginThreadListRegistration",
+          "PluginSidebarThreadsState",
+        ],
+        experimental: true,
+      },
+      {
+        id: "pending-interaction",
+        title: "In-thread forms",
+        summary:
+          "Pauses an agent mid-turn to ask the person a question, and hands their answer back to the agent. With this, a plugin can:",
+        bullets: [
+          "Replace the prompt box with a form while the agent waits for an answer",
+          "Receive the submitted answer, or a cancellation and its reason",
+          "Supply the component that draws the form",
+        ],
+        apiSymbols: ["PluginUi", "PluginPendingInteractionRegistration"],
+        firstParty: ["Ask User Question", "Secrets"],
+      },
+      {
+        id: "sidebar-footer",
+        title: "Sidebar footer buttons",
+        summary:
+          "Adds an icon button to the row at the bottom of bb's sidebar, beside the Settings button. With this, a plugin can:",
+        bullets: [
+          "Supply the button's icon and its hover tooltip",
+          "Run a callback when the button is clicked",
+          "Stay reachable wherever bb's sidebar is showing",
+        ],
+        apiSymbols: ["PluginSidebarFooterActionRegistration"],
+        firstParty: ["Remote access"],
       },
       {
         id: "content-scripts",

--- a/packages/plugin-api-map/src/wireframes.tsx
+++ b/packages/plugin-api-map/src/wireframes.tsx
@@ -70,19 +70,19 @@ export function useSurfaceMap(): SurfaceMapState {
 }
 
 export const APP_SHELL_MARKS = [
+  "sidebar-navigation",
+  "nav-panel",
+  "thread-row-status",
+  "thread-list",
+  "sidebar-footer",
   "thread-header",
+  "timeline-renderers",
+  "message-directives",
+  "message-actions",
+  "pending-interaction",
   "code-renderers",
   "thread-panel",
   "file-opener",
-  "sidebar-navigation",
-  "nav-panel",
-  "timeline-renderers",
-  "thread-row-status",
-  "message-directives",
-  "message-actions",
-  "thread-list",
-  "pending-interaction",
-  "sidebar-footer",
   "content-scripts",
 ] as const;
 

--- a/packages/plugin-api-map/src/wireframes.tsx
+++ b/packages/plugin-api-map/src/wireframes.tsx
@@ -70,19 +70,19 @@ export function useSurfaceMap(): SurfaceMapState {
 }
 
 export const APP_SHELL_MARKS = [
-  "nav-panel",
-  "sidebar-navigation",
-  "thread-list",
-  "thread-row-status",
-  "sidebar-footer",
   "thread-header",
-  "message-directives",
-  "message-actions",
-  "pending-interaction",
   "code-renderers",
   "thread-panel",
   "file-opener",
+  "sidebar-navigation",
+  "nav-panel",
   "timeline-renderers",
+  "thread-row-status",
+  "message-directives",
+  "message-actions",
+  "thread-list",
+  "pending-interaction",
+  "sidebar-footer",
   "content-scripts",
 ] as const;
 
@@ -295,6 +295,7 @@ function MeasuredBadge({
   anchor,
   at,
   align = "center",
+  flush = false,
   onActivate,
 }: {
   id: string;
@@ -302,6 +303,7 @@ function MeasuredBadge({
   anchor: string;
   at: "start" | "end" | "above" | "lane";
   align?: "center" | "end";
+  flush?: boolean;
   onActivate?: () => void;
 }) {
   const { setActiveId, numberOf, onSelect } = useSurfaceMap();
@@ -341,7 +343,10 @@ function MeasuredBadge({
         Number(strategy?.dataset.guideScale ?? "1"),
       );
       const chipBox = CHIP_SIZE * counterScale;
-      const chipGap = CHIP_GAP * counterScale;
+      const edgeGap = flush
+        ? parseFloat(getComputedStyle(container).borderLeftWidth || "0")
+        : CHIP_GAP;
+      const chipGap = edgeGap * counterScale;
       const chipTuck = 4 * counterScale;
       const recenter = (chipBox - CHIP_SIZE) / 2;
       const containerOrigin = layoutOrigin(container);
@@ -377,6 +382,8 @@ function MeasuredBadge({
                   left: local.left + local.width / 2 - chipBox / 2,
                   top: Math.max(0, (frameLocal.top - chipBox) / 2),
                 };
+      const clamp = (value: number, extent: number) =>
+        Math.max(0, Math.min(value, Math.max(0, extent - chipBox)));
       const clippingFrame =
         container.closest<HTMLElement>("[data-guide-frame]");
       if (clippingFrame) {
@@ -387,9 +394,9 @@ function MeasuredBadge({
           clipLeft + clippingFrame.offsetWidth - chipBox - chipTuck,
         );
       }
-      const clamp = (value: number, extent: number) =>
-        Math.max(0, Math.min(value, Math.max(0, extent - chipBox)));
-      next.left = clamp(next.left, container.offsetWidth);
+      if (!flush) {
+        next.left = clamp(next.left, container.offsetWidth);
+      }
       next.top = clamp(next.top, container.offsetHeight);
       next.left += recenter;
       next.top += recenter;
@@ -411,7 +418,7 @@ function MeasuredBadge({
     );
     if (scaleWrapper) observer.observe(scaleWrapper);
     return () => observer.disconnect();
-  }, [anchor, at, align]);
+  }, [anchor, at, align, flush]);
 
   return (
     <a
@@ -877,6 +884,7 @@ export function CommandPaletteWireframe() {
                   label="Plugin actions in bb's quick command palette"
                   anchor='[data-guide-region="command-palette-actions"]'
                   at="start"
+                  flush
                 />
               </div>
             </div>
@@ -955,7 +963,7 @@ function AppShellWireframeBody({
     assistantMessageHovered || messageActionsSelected;
 
   return (
-    <WindowFrame className="relative">
+    <WindowFrame className="relative overflow-visible">
       {}
       <span
         aria-hidden

--- a/packages/plugin-api-map/src/wireframes.tsx
+++ b/packages/plugin-api-map/src/wireframes.tsx
@@ -302,7 +302,7 @@ function MeasuredBadge({
   label: string;
   anchor: string;
   at: "start" | "end" | "above" | "lane";
-  align?: "center" | "end";
+  align?: "start" | "center" | "end";
   flush?: boolean;
   onActivate?: () => void;
 }) {
@@ -359,7 +359,11 @@ function MeasuredBadge({
       };
       const centerY = local.top + local.height / 2 - chipBox / 2;
       const anchoredY =
-        align === "end" ? local.top + local.height - chipBox : centerY;
+        align === "start"
+          ? local.top
+          : align === "end"
+            ? local.top + local.height - chipBox
+            : centerY;
       const frame = container.querySelector<HTMLElement>("[data-guide-frame]");
       const frameOrigin = frame ? layoutOrigin(frame) : containerOrigin;
       const frameWidth = frame ? frame.offsetWidth : container.offsetWidth;
@@ -425,6 +429,7 @@ function MeasuredBadge({
       ref={ref}
       data-guide-badge={id}
       data-guide-badge-placement={at}
+      data-guide-badge-align={align}
       href={`#surface-${id}`}
       aria-label={`${label} — jump to details`}
       onClick={(event) => {
@@ -551,7 +556,7 @@ const SIDEBAR_SECTION_RENDERERS: Record<string, () => ReactNode> = {
       <Mark
         id="nav-panel"
         label="Plugin nav panels, above the thread list"
-        className="mx-1.5 space-y-0.5 px-2 pb-2"
+        className="mx-1.5 z-[2] block space-y-0.5 px-2 pb-2"
         showChip={false}
       >
         <span className="flex h-6.5 items-center gap-2 rounded-md px-2">
@@ -924,12 +929,19 @@ export function AppShellWireframe() {
         label="The sidebar navigation controls, replaceable by one plugin"
         anchor='[data-guide-region="sidebar-navigation"]'
         at="start"
+        align="start"
       />
       <MeasuredBadge
         id="thread-list"
         label="The thread list, replaceable by one plugin"
         anchor='[data-guide-region="thread-list"]'
         at="start"
+      />
+      <MeasuredBadge
+        id="thread-header"
+        label="Plugin thread-header control, left end of the action row"
+        anchor='[data-guide-region="thread-header"]'
+        at="above"
       />
       {}
       <MeasuredBadge
@@ -1003,6 +1015,7 @@ function AppShellWireframeBody({
               id="thread-header"
               label="Plugin thread-header control, left end of the action row"
               className="flex h-6.5 items-center gap-1 px-2"
+              showChip={false}
             >
               <PluginGlyph className="size-3.5" />
             </Mark>

--- a/packages/plugin-api-map/test/surfaces.test.ts
+++ b/packages/plugin-api-map/test/surfaces.test.ts
@@ -26,21 +26,21 @@ function surfaceIds(groupId: string): string[] {
 }
 
 describe("product-map surfaces", () => {
-  it("keeps app-window annotations in visual reading order", () => {
+  it("keeps app-window annotations in column-major visual reading order", () => {
     const ordered = [
+      "sidebar-navigation",
+      "nav-panel",
+      "thread-row-status",
+      "thread-list",
+      "sidebar-footer",
       "thread-header",
+      "timeline-renderers",
+      "message-directives",
+      "message-actions",
+      "pending-interaction",
       "code-renderers",
       "thread-panel",
       "file-opener",
-      "sidebar-navigation",
-      "nav-panel",
-      "timeline-renderers",
-      "thread-row-status",
-      "message-directives",
-      "message-actions",
-      "thread-list",
-      "pending-interaction",
-      "sidebar-footer",
       "content-scripts",
     ];
     expect(surfaceIds("app-shell")).toEqual(ordered);

--- a/packages/plugin-api-map/test/surfaces.test.ts
+++ b/packages/plugin-api-map/test/surfaces.test.ts
@@ -26,21 +26,21 @@ function surfaceIds(groupId: string): string[] {
 }
 
 describe("product-map surfaces", () => {
-  it("keeps app-window annotations in their stable sequential order", () => {
+  it("keeps app-window annotations in visual reading order", () => {
     const ordered = [
-      "nav-panel",
-      "sidebar-navigation",
-      "thread-list",
-      "thread-row-status",
-      "sidebar-footer",
       "thread-header",
-      "message-directives",
-      "message-actions",
-      "pending-interaction",
       "code-renderers",
       "thread-panel",
       "file-opener",
+      "sidebar-navigation",
+      "nav-panel",
       "timeline-renderers",
+      "thread-row-status",
+      "message-directives",
+      "message-actions",
+      "thread-list",
+      "pending-interaction",
+      "sidebar-footer",
       "content-scripts",
     ];
     expect(surfaceIds("app-shell")).toEqual(ordered);

--- a/packages/plugin-api-map/test/wireframes.test.ts
+++ b/packages/plugin-api-map/test/wireframes.test.ts
@@ -199,6 +199,9 @@ describe("guide fixture boundaries", () => {
       /data-guide-badge="nav-panel"[\s\S]*?data-guide-badge-placement="start"/,
     );
     expect(markup).toMatch(
+      /data-guide-badge="sidebar-navigation"[^>]*data-guide-badge-placement="start"[^>]*data-guide-badge-align="start"/,
+    );
+    expect(markup).toMatch(
       /data-guide-badge="thread-list"[\s\S]*?data-guide-badge-placement="start"/,
     );
     expect(markup).toMatch(
@@ -210,6 +213,18 @@ describe("guide fixture boundaries", () => {
     expect(markup).toMatch(
       /data-guide-target="content-scripts"[^>]*class="[^"]*absolute inset-0/,
     );
+  });
+
+  it("keeps nested sidebar targets reachable and the thread-header badge outside its control", () => {
+    const markup = renderWireframe(createElement(AppShellWireframe));
+
+    expect(markup).toMatch(
+      /data-guide-region="nav-panel"[^>]*class="[^"]*z-\[2\][^"]*block/,
+    );
+    expect(markup).toMatch(
+      /data-guide-badge="thread-header"[^>]*data-guide-badge-placement="above"/,
+    );
+    expect(markup.match(/data-guide-badge="thread-header"/g)).toHaveLength(1);
   });
 
   it("keeps the sidebar trigger in app-owned overlay chrome", () => {


### PR DESCRIPTION
## Human comments

## What was wrong

The Plugin Guide had several annotation layout problems:

- An annotation at the app-window edge could be clipped.
- Command Palette annotation 1 sat over the result it described.
- App-window badges 1 and 2 overlapped at compact widths.
- Annotation 1 captured annotation 2's target, and annotation 2's inline bounds spilled into annotation 4.
- Annotation 6 covered the thread-header plugin control.

The first-page numbers also followed insertion order instead of the diagram's spatial reading order.

**This PR adds no annotations.** The merge base already contains the same 14 app-window surfaces after [#2802](https://github.com/get-bb/bb/pull/2802).

## What changed

- Renumbered the app-window annotations by column: columns left-to-right, then top-to-bottom within each column.
- Let edge annotations render outside the app-window frame without clipping.
- Moved Command Palette annotation 1 flush against the palette's left side.
- Gave annotation 2 block-level bounds and explicit ownership above its intentionally nested parent overlay.
- Anchored annotation 1's exterior badge to the top of its region so it stays separate from annotation 2 at compact widths.
- Moved annotation 6 into the measured space above its control.
- Added focused tests and one compact maintenance checklist for spatial order, badge collisions, overlay bounds, and pointer ownership; annotation-only work now routes through that checklist.

## Before and after

### App-window annotations — 1440×900

| Before — insertion order | After — spatial order and corrected placement |
| --- | --- |
| ![Before: app-window annotations follow insertion order](https://img3.pixhost.to/images/5402/765249867_before-app-shell-1440.png) | ![After: app-window annotations follow column-major reading order without collisions](https://img3.pixhost.to/images/5404/765291623_final-app-shell-1440.png) |

### Command Palette annotation — 1200×800

| Before — annotation covers the result | After — annotation sits beside the palette |
| --- | --- |
| ![Before: Command Palette annotation 1 overlaps its annotated result](https://img3.pixhost.to/images/5402/765249932_before-command-palette-1200.png) | ![After: Command Palette annotation 1 sits outside the content flush to the left edge](https://img3.pixhost.to/images/5402/765249943_after-command-palette-1200.png) |

### Sidebar annotations 1 and 2 — 1200×800

| Before — badges overlap | After — badges and targets are separated |
| --- | --- |
| ![Before: app-window annotations 1 and 2 overlap](https://img3.pixhost.to/images/5403/765266449_compact-app-shell-1-sidebar-navigation.png) | ![After: app-window annotations 1 and 2 are separated](https://img3.pixhost.to/images/5404/765291619_final-sidebar-1200.png) |

### Thread-header annotation 6 — 1200×800

| Before — badge covers the control | After — badge sits above the control |
| --- | --- |
| ![Before: annotation 6 covers the thread-header control](https://img3.pixhost.to/images/5404/765291931_compact-app-shell-6-thread-header.png) | ![After: annotation 6 sits above the thread-header control](https://img3.pixhost.to/images/5404/765291618_after-thread-header-1200.png) |

## How you verified

- Tested the exact PR branch in the branch web app with Chrome for Testing 151.0.7922.71.
- Checked the app-window fixture at 1440×900 and 1200×800 after initial load, hard reload, and client navigation away and back.
- Confirmed badges 1 and 2 have no rendered intersection at either viewport.
- Confirmed annotation 2 owns every sampled point in its visible target and has no intersection with annotation 4.
- Confirmed annotation 6 has no intersection with its thread-header control.
- Focused the changed target and external badge through the real UI; no console errors occurred.
- Built and reloaded the real `plugin-api-docs` plugin bundle used for QA.
- Evaluated the annotation-only match and internal-refactor near miss in fresh read-only threads.
- `git diff --check` and GitHub CI pass on the current head.

Fixes: no linked issue.

BB-Thread-ID: thr_pqa3x7rwny

> AGENT GENERATED