### PR TITLE
Preserve restored plugin setting during pending save

### DIFF
--- a/apps/app/src/components/plugin/PluginSettings.test.tsx
+++ b/apps/app/src/components/plugin/PluginSettings.test.tsx
@@ -182,6 +182,65 @@ describe("PluginSettingsForm", () => {
     expect((greeting as HTMLInputElement).value).toBe("newer");
   });
 
+  it("preserves restored saved text while an older save is pending", async () => {
+    const first = deferred<Response>();
+    const second = deferred<Response>();
+    const requests: RecordedRequest[] = [];
+    let saveCount = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init?: RequestInit) => {
+        requests.push({ url, init });
+        if (init?.method !== "PUT") return jsonOk(SETTINGS_VIEW);
+        saveCount += 1;
+        return saveCount === 1 ? first.promise : second.promise;
+      }),
+    );
+
+    const { wrapper } = createQueryClientTestHarness();
+    render(<PluginSettingsForm pluginId="demo" />, { wrapper });
+
+    const greeting = await screen.findByLabelText("Greeting");
+    const enabled = screen.getByRole("switch", { name: "Enabled" });
+    fireEvent.change(greeting, { target: { value: "temporary" } });
+    fireEvent.blur(greeting);
+    await vi.waitFor(() => expect(saveCount).toBe(1));
+
+    fireEvent.change(greeting, { target: { value: "hello" } });
+    fireEvent.blur(greeting);
+    expect(saveCount).toBe(1);
+
+    await act(async () => {
+      first.resolve(
+        jsonOk({
+          ...SETTINGS_VIEW,
+          values: {
+            ...SETTINGS_VIEW.values,
+            greeting: "temporary",
+            enabled: false,
+          },
+        }),
+      );
+      await first.promise;
+    });
+    await vi.waitFor(() => expect(saveCount).toBe(2));
+    expect(JSON.parse(String(requests.at(-1)?.init?.body))).toEqual({
+      values: { greeting: "hello" },
+    });
+    await vi.waitFor(() =>
+      expect(enabled.getAttribute("data-state")).toBe("unchecked"),
+    );
+
+    await act(async () => {
+      second.resolve(jsonOk(SETTINGS_VIEW));
+      await second.promise;
+    });
+    await vi.waitFor(() =>
+      expect(enabled.getAttribute("data-state")).toBe("checked"),
+    );
+    expect((greeting as HTMLInputElement).value).toBe("hello");
+  });
+
   it("renders an experimental_multiline string below its label and flushes it on blur", async () => {
     const view = {
       ok: true,

--- a/apps/app/src/components/plugin/PluginSettings.tsx
+++ b/apps/app/src/components/plugin/PluginSettings.tsx
@@ -304,7 +304,7 @@ function AutosavingPluginSetting({
       value,
       hasNewerDraft: descriptor.type === "string",
     });
-    save.reset();
+    if (!save.isPending) save.reset();
     if (descriptor.type !== "string") {
       save.mutate(value);
     }
@@ -312,7 +312,10 @@ function AutosavingPluginSetting({
 
   function saveDraft(): void {
     if (descriptor.type !== "string") return;
-    if (draft === storedValue || (descriptor.secret === true && draft === "")) {
+    if (
+      (draft === storedValue && !save.isPending) ||
+      (descriptor.secret === true && draft === "")
+    ) {
       setDraftState({ value: draft, hasNewerDraft: false });
       return;
     }


### PR DESCRIPTION
## Human comments

## What was wrong

The earlier autosave fix preserved text typed while an older plugin-setting save was pending, but still lost a later choice when that choice equaled the previously stored value. Blur treated it as a no-op even though the older request was about to replace the stored value.

## What changed

- Keep the active mutation observable while a string draft changes.
- Suppress an equal-value blur only when no save is pending.
- Queue the restored choice behind the older request so the final saved value matches the user choice.
- Preserve the existing behavior for ordinary newer drafts, validation errors, multiline settings, and secret empty values.
- Add focused race coverage through the shared PluginSettings form.

No daemon wire contract, server API, public Plugin SDK API, CLI, documentation, or protocol version changed.

## How you verified

- `pnpm exec turbo run test --filter=@bb/app -- --run src/components/plugin/PluginSettings.test.tsx` — 13 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/app` — passed.
- `pnpm exec oxfmt --check apps/app/src/components/plugin/PluginSettings.tsx apps/app/src/components/plugin/PluginSettings.test.tsx` — passed.
- `git diff --check origin/main...HEAD` — passed.
- The source thread also completed the full app suite, app build, and matching before/after browser QA.

> AGENT GENERATED