### PR TITLE
Preserve next-turn queueing across offline reconnects

### DIFF
--- a/apps/server/src/services/threads/dispatch-attempt.ts
+++ b/apps/server/src/services/threads/dispatch-attempt.ts
@@ -321,16 +321,6 @@ async function runDispatchAttempt(
     return waitOn({ kind: "time" }, sendAt);
   }
 
-  const { environment: dispatchEnvironment, host: dispatchHost } =
-    dispatchEnvironmentAndHost(deps, thread.environmentId);
-  if (
-    dispatchEnvironment !== null &&
-    goneThreadEnvironmentDetails(dispatchEnvironment) === null &&
-    dispatchHost?.status === "disconnected"
-  ) {
-    return waitOn({ kind: "host-offline", hostName: dispatchHost.name }, null);
-  }
-
   if (thread.status === "active" && attempt === "start-turn") {
     if (payload.mode === "start") {
       // `start` asks for a FRESH turn specifically, so a running one is a
@@ -343,6 +333,17 @@ async function runDispatchAttempt(
     }
     return waitOn({ kind: "thread-busy" }, null);
   }
+
+  const { environment: dispatchEnvironment, host: dispatchHost } =
+    dispatchEnvironmentAndHost(deps, thread.environmentId);
+  if (
+    dispatchEnvironment !== null &&
+    goneThreadEnvironmentDetails(dispatchEnvironment) === null &&
+    dispatchHost?.status === "disconnected"
+  ) {
+    return waitOn({ kind: "host-offline", hostName: dispatchHost.name }, null);
+  }
+
   if (payload.mode !== "start" && isManualCompactionActive(deps, thread)) {
     return waitOn({ kind: "thread-busy" }, null);
   }

--- a/apps/server/test/public/public-thread-offline-followup.test.ts
+++ b/apps/server/test/public/public-thread-offline-followup.test.ts
@@ -2,8 +2,11 @@ import { listEvents, listQueuedThreadMessages } from "@bb/db";
 import { queuedMessageWaitingOnSchema } from "@bb/domain";
 import { sendMessageResponseSchema } from "@bb/server-contract";
 import { describe, expect, it } from "vitest";
+import { applyLoggedThreadLifecycleEvent } from "../../src/services/threads/lifecycle-outcome.js";
+import { runQueuedMessageDispatch } from "../../src/services/threads/queued-message-dispatch.js";
 import { onDaemonSocketOpen } from "../../src/ws/daemon-protocol.js";
 import {
+  listQueuedThreadCommands,
   registerTestHostRpcCapture,
   waitForQueuedCommand,
 } from "../helpers/commands.js";
@@ -15,11 +18,23 @@ import {
   seedSession,
   seedThread,
   seedThreadRuntimeState,
+  seedTurnStarted,
 } from "../helpers/seed.js";
 import { withTestHarness } from "../helpers/test-app.js";
 
 describe("offline host follow-ups", () => {
-  it("queues a follow-up to an existing idle thread until its host reconnects", async () => {
+  it.each([
+    {
+      mode: "steer-if-active",
+      status: "idle",
+      waitingOn: { kind: "host-offline", hostName: "M5" },
+    },
+    {
+      mode: "queue-if-active",
+      status: "active",
+      waitingOn: { kind: "thread-busy" },
+    },
+  ] as const)("queues an offline $status follow-up", async (testCase) => {
     await withTestHarness(async (harness) => {
       const host = seedHost(harness.deps, {
         id: "host-offline-followup",
@@ -37,13 +52,21 @@ describe("offline host follow-ups", () => {
       const thread = seedThread(harness.deps, {
         projectId: project.id,
         environmentId: environment.id,
-        status: "idle",
+        status: testCase.status,
       });
       seedThreadRuntimeState(harness.deps, {
         threadId: thread.id,
         environmentId: environment.id,
         providerThreadId: "provider-offline-followup",
       });
+      if (testCase.status === "active") {
+        seedTurnStarted(harness.deps, {
+          environmentId: environment.id,
+          providerThreadId: "provider-offline-followup",
+          threadId: thread.id,
+          turnId: "turn-current",
+        });
+      }
       const input = [
         {
           type: "text" as const,
@@ -62,7 +85,7 @@ describe("offline host follow-ups", () => {
           headers: { "content-type": "application/json" },
           body: JSON.stringify({
             input,
-            mode: "steer-if-active",
+            mode: testCase.mode,
             model: "gpt-5",
             permissionMode: "full",
             reasoningLevel: "medium",
@@ -75,7 +98,6 @@ describe("offline host follow-ups", () => {
       const body = sendMessageResponseSchema.parse(await readJson(response));
       expect(body).toMatchObject({
         delivery: "queued",
-        waitingOn: { kind: "host-offline", hostName: "M5" },
         sendAt: null,
       });
       if (body.delivery !== "queued") {
@@ -89,9 +111,6 @@ describe("offline host follow-ups", () => {
         sendAt: null,
         failureReason: null,
       });
-      expect(
-        queuedMessageWaitingOnSchema.parse(JSON.parse(queued[0]!.waitingOn!)),
-      ).toEqual({ kind: "host-offline", hostName: "M5" });
       expect(listEvents(harness.db, { threadId: thread.id })).toHaveLength(
         eventCountBeforeSend,
       );
@@ -106,6 +125,28 @@ describe("offline host follow-ups", () => {
         sessionId: reconnectSession.id,
         socket: reconnectSocket,
       });
+
+      if (testCase.status === "active") {
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        expect(
+          listQueuedThreadCommands(harness, "turn.submit", thread.id),
+        ).toEqual([]);
+      }
+      expect(body).toMatchObject({ waitingOn: testCase.waitingOn });
+      expect(
+        queuedMessageWaitingOnSchema.parse(JSON.parse(queued[0]!.waitingOn!)),
+      ).toEqual(testCase.waitingOn);
+
+      if (testCase.status === "active") {
+        applyLoggedThreadLifecycleEvent(harness.deps, {
+          event: { type: "run.succeeded" },
+          threadId: thread.id,
+        });
+        await runQueuedMessageDispatch(harness.deps, {
+          kind: "thread-ready",
+          threadId: thread.id,
+        });
+      }
 
       const dispatched = await waitForQueuedCommand(
         harness,


### PR DESCRIPTION
## Human comments

## What was wrong

An active thread receiving `queue-if-active` while its host was offline was recorded as waiting on the host instead of waiting on the current turn. If the host reconnected before that turn ended, reconnect dispatch could steer the queued message into the current turn, violating the requested next-turn semantics introduced in #2891.

## What changed

- Apply active-thread `start-turn` queue semantics before host-offline handling at the shared dispatch boundary.
- Keep idle-thread offline messages waiting on their host.
- Preserve `steer-if-active`, explicit `start`, Send now, and centralized queued-message dispatch behavior.
- Extend the public-route reconnect test to cover both idle offline delivery and active next-turn delivery.

No daemon wire contract, public API, CLI, documentation, or protocol version changed.

## How you verified

- The new active-thread case failed before the implementation by submitting to `turn-current`, then passed after the change with a fresh `start` target.
- `pnpm exec turbo run test --filter=@bb/server --force -- test/public/public-thread-offline-followup.test.ts` — 2 tests passed.
- Affected server matrix covering offline follow-ups, stop runtime, queue-drain failure, requested queue drain, and thread send dispatch — 52 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/server` — passed.
- `pnpm exec turbo run build --filter=@bb/server` — passed.
- `pnpm exec oxfmt --check apps/server/src/services/threads/dispatch-attempt.ts apps/server/test/public/public-thread-offline-followup.test.ts` — passed.
- `git diff --check origin/main...HEAD` — passed.

> AGENT GENERATED
