### PR TITLE
Make variable picker menus viewport-safe

### DIFF
--- a/apps/app/src/components/pickers/MachinePicker.test.tsx
+++ b/apps/app/src/components/pickers/MachinePicker.test.tsx
@@ -37,12 +37,13 @@ afterEach(() => {
 });
 
 function renderMachineMenu(overrides?: {
+  hosts?: readonly Host[];
   selectedHostId?: string | null;
   onChange?: (hostId: string) => void;
 }) {
   render(
     <MachinePickerUI
-      hosts={[thisMachine, studio, devVm]}
+      hosts={overrides?.hosts ?? [thisMachine, studio, devVm]}
       localDaemonHostId={thisMachine.id}
       primaryHostId={thisMachine.id}
       selectedHostId={overrides?.selectedHostId ?? thisMachine.id}
@@ -56,6 +57,23 @@ function renderMachineMenu(overrides?: {
 }
 
 describe("MachinePickerUI", () => {
+  it("keeps a long machine menu inside a short viewport and scrolls it", () => {
+    renderMachineMenu({
+      hosts: Array.from({ length: 20 }, (_, index) => ({
+        ...thisMachine,
+        id: `host_${index}`,
+        name: `Machine ${index}`,
+      })),
+    });
+
+    const menu = screen.getByRole("menu");
+    expect(menu.className).toContain(
+      "max-h-[min(var(--radix-dropdown-menu-content-available-height),calc(100dvh-0.5rem))]",
+    );
+    expect(menu.className).toContain("overflow-y-auto");
+    expect(menu.className).toContain("overscroll-contain");
+  });
+
   it("names the selected machine in the trigger and badges this machine in the menu", () => {
     renderMachineMenu({ selectedHostId: studio.id });
 

--- a/apps/app/src/components/pickers/ProjectSelector.tsx
+++ b/apps/app/src/components/pickers/ProjectSelector.tsx
@@ -12,6 +12,7 @@ import { cn } from "@bb/shared-ui/lib/utils";
 import {
   OPTION_BASE_CLASS_NAME,
   OPTION_INTERACTIVE_CLASS_NAME,
+  OPTION_MENU_CONTENT_CLASS_NAME,
   OPTION_MUTED_CLASS_NAME,
   OPTION_TRIGGER_CONTENT_CLASS_NAME,
 } from "@bb/shared-ui/option-display";
@@ -116,7 +117,7 @@ export function ProjectSelector({
       <DropdownMenuContent
         align="start"
         side="bottom"
-        className="max-h-[min(var(--radix-dropdown-menu-content-available-height),calc(100dvh-0.5rem))] w-52 overflow-y-auto overscroll-contain"
+        className={cn(OPTION_MENU_CONTENT_CLASS_NAME, "w-52")}
       >
         <DropdownMenuLabel>Project</DropdownMenuLabel>
         {projects.map((project) => (

--- a/packages/shared-ui/src/components/ui/option-display.tsx
+++ b/packages/shared-ui/src/components/ui/option-display.tsx
@@ -8,7 +8,8 @@ export const OPTION_INTERACTIVE_CLASS_NAME =
   "border-none bg-transparent shadow-none";
 export const OPTION_CONTENT_CLASS_NAME = "flex min-w-0 items-center gap-1.5";
 export const OPTION_TRIGGER_CONTENT_CLASS_NAME = "contents";
-export const OPTION_MENU_CONTENT_CLASS_NAME = "w-max min-w-0 max-w-96";
+export const OPTION_MENU_CONTENT_CLASS_NAME =
+  "max-h-[min(var(--radix-dropdown-menu-content-available-height),calc(100dvh-0.5rem))] w-max min-w-0 max-w-96 overflow-y-auto overscroll-contain";
 export const OPTION_MUTED_CLASS_NAME =
   "text-muted-foreground hover:text-muted-foreground";
 


### PR DESCRIPTION
## Human comments

## What was wrong

The Project picker fix from #2894 capped and scrolled only that menu locally. Other variable pickers still used a shared menu class with width rules alone, so a long Machine list in a short window could extend above the viewport and make earlier machines unreachable.

## What changed

- Move the existing viewport-height cap, vertical scrolling, and overscroll containment into the shared variable-picker menu class.
- Make Project consume that shared class instead of carrying a local copy.
- Cover Project, Machine, Environment, Worktree, and generic option pickers while leaving compact drawer behavior unchanged.
- Add a focused 20-machine regression for the short-window class contract.

No daemon wire contract, server API, public Plugin SDK API, CLI, documentation, or protocol version changed.

## How you verified

- The focused Machine regression failed before the implementation and passed afterward.
- `pnpm exec turbo run test --filter=@bb/app --force -- --run src/components/pickers/MachinePicker.test.tsx src/components/pickers/ProjectSelector.test.tsx` — 6 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/app --filter=@bb/shared-ui` — passed.
- Relevant full Turbo test/typecheck/build/lint validation passed with 3,731 app tests passed, 3 skipped, and 0 lint errors.
- `pnpm exec oxfmt --check apps/app/src/components/pickers/MachinePicker.test.tsx apps/app/src/components/pickers/ProjectSelector.tsx packages/shared-ui/src/components/ui/option-display.tsx` — passed.
- `git diff --check origin/main...HEAD` — passed.
- Matching 900×320 desktop QA showed Project and Machine capped at 192px and scrollable; 390×320 compact QA preserved the persistent drawer without making the app root inert or `aria-hidden`.

> AGENT GENERATED
