### PR TITLE
Hide side-chat queues during pending interactions

### DIFF
--- a/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.test.tsx
+++ b/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.test.tsx
@@ -249,6 +249,10 @@ vi.mock("@/hooks/queries/thread-queries", () => ({
   getLatestPendingInteraction: (
     interactions: readonly { createdAt: number }[] | undefined,
   ) => (interactions && interactions.length > 0 ? interactions[0] : null),
+  isPendingInteractionStateUnknown: (
+    interactions: readonly { createdAt: number }[] | undefined,
+    isFetching: boolean,
+  ) => (!interactions || interactions.length === 0) && isFetching,
 }));
 
 vi.mock(
@@ -545,7 +549,7 @@ describe("EmbeddedThreadChat", () => {
     expect(screen.getByTestId("embedded-chat-composer").hidden).toBe(true);
   });
 
-  it("keeps held messages visible beside a pending side-chat question", () => {
+  it("hides held messages while a pending side-chat question is answered", () => {
     mocks.pendingInteractions = [
       { id: "int_1", createdAt: 1, payload: { kind: "user_question" } },
     ];
@@ -554,17 +558,7 @@ describe("EmbeddedThreadChat", () => {
     renderEmbeddedChat({ threadId: "thr_side_chat" });
 
     expect(screen.getByTestId("pending-interaction-banner")).toBeTruthy();
-    expect(screen.getByTestId("queued-count").textContent).toBe("1");
-    expect(
-      screen
-        .getByTestId("embedded-chat-queued-messages")
-        .hasAttribute("data-send-disabled"),
-    ).toBe(true);
-    expect(
-      screen
-        .getByTestId("embedded-chat-queued-messages")
-        .getAttribute("data-attached-to-composer"),
-    ).toBe("false");
+    expect(screen.queryByTestId("embedded-chat-queued-messages")).toBeNull();
     expect(screen.getByTestId("embedded-chat-composer").hidden).toBe(true);
   });
 
@@ -608,6 +602,20 @@ describe("EmbeddedThreadChat", () => {
     expect(
       screen.getByTestId("embedded-chat-composer").dataset.submitReason,
     ).toBe("loading-pending-interactions");
+  });
+
+  it("hides the composer while cached empty interactions refresh", () => {
+    mocks.pendingInteractions = [];
+    mocks.pendingInteractionsIsFetching = true;
+    mocks.queuedMessages = [{ id: "q1" }];
+
+    renderEmbeddedChat({ threadId: "thr_side_chat" });
+
+    expect(screen.getByRole("status").textContent).toContain(
+      "Checking pending interactions",
+    );
+    expect(screen.queryByTestId("embedded-chat-queued-messages")).toBeNull();
+    expect(screen.getByTestId("embedded-chat-composer").hidden).toBe(true);
   });
 
   it("keeps the composer unavailable when pending interactions fail to load", () => {

--- a/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.tsx
+++ b/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.tsx
@@ -48,6 +48,7 @@ import {
 import { useThreadCreationOptions } from "@/hooks/useThreadCreationOptions";
 import {
   getLatestPendingInteraction,
+  isPendingInteractionStateUnknown,
   useThread,
   useThreadPendingInteractions,
   useThreadQueuedMessages,
@@ -262,9 +263,10 @@ function EmbeddedThreadChatWithComposer({
     activePendingInteraction !== null &&
     activePendingInteraction.payload.kind !== "plugin";
   const pendingInteractionsInitialLoading =
-    activePendingInteraction === null &&
-    pendingInteractionsQuery.data === undefined &&
-    (pendingInteractionsQuery.isLoading || pendingInteractionsQuery.isFetching);
+    isPendingInteractionStateUnknown(
+      pendingInteractionsQuery.data,
+      pendingInteractionsQuery.isFetching,
+    );
   const pendingInteractionsUnavailable =
     activePendingInteraction === null && pendingInteractionsQuery.isError;
   const pendingInteractionOccupiesComposer =
@@ -1084,17 +1086,13 @@ function EmbeddedThreadChatWithComposer({
 
   const queuedMessagesStack = useMemo(
     () =>
-      queuedMessages.length > 0 ? (
+      queuedMessages.length > 0 && !pendingInteractionOccupiesComposer ? (
         <QueuedMessagesList
-          attachedToComposer={!pendingInteractionOccupiesComposer}
+          attachedToComposer
           queuedMessages={queuedMessages}
           resolveMentionLink={resolveMentionLink}
           inlineEditor={inlineEditor}
-          sendDisabled={
-            isProvisioning ||
-            queuedMessageActionPending ||
-            pendingInteractionOccupiesComposer
-          }
+          sendDisabled={isProvisioning || queuedMessageActionPending}
           actionDisabled={queuedMessageActionPending}
           processingMessageId={processingQueuedMessage?.id ?? null}
           processingAction={processingQueuedMessage?.action ?? null}

--- a/apps/app/src/hooks/queries/thread-queries.test.tsx
+++ b/apps/app/src/hooks/queries/thread-queries.test.tsx
@@ -26,6 +26,7 @@ import {
 import {
   COMPACT_THREAD_TIMELINE_SEGMENT_LIMIT,
   didThreadDetailBootstrapRefreshAfterMount,
+  isPendingInteractionStateUnknown,
   useArchivedThreads,
   useChildThreads,
   useThread,
@@ -449,6 +450,11 @@ describe("useThreadQueuedMessages", () => {
 });
 
 describe("useThreadPendingInteractions", () => {
+  it("keeps cached empty interactions unknown while their refresh is pending", () => {
+    expect(isPendingInteractionStateUnknown([], true)).toBe(true);
+    expect(isPendingInteractionStateUnknown([], false)).toBe(false);
+  });
+
   it("reuses the first owner's fresh baseline when a second owner mounts", async () => {
     const { queryClient, wrapper } = createQueryClientTestHarness();
     const first = renderHook(() => useThreadPendingInteractions("thread-1"), {

--- a/apps/app/src/hooks/queries/thread-queries.ts
+++ b/apps/app/src/hooks/queries/thread-queries.ts
@@ -1031,3 +1031,10 @@ export function getLatestPendingInteraction(
     firstInteraction,
   );
 }
+
+export function isPendingInteractionStateUnknown(
+  interactions: readonly PendingInteraction[] | undefined,
+  isFetching: boolean,
+): boolean {
+  return getLatestPendingInteraction(interactions) === null && isFetching;
+}

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -68,6 +68,7 @@ import {
 import {
   didThreadDetailBootstrapRefreshAfterMount,
   getLatestPendingInteraction,
+  isPendingInteractionStateUnknown,
   useChildThreads,
   useProjectThreadSubset,
   useThread,
@@ -630,8 +631,10 @@ function ThreadDetailViewInternal(props: ThreadRoutePathArgs) {
   );
   const pendingInteractions = pendingInteractionsQuery.data ?? [];
   const pendingInteractionsInitialLoading =
-    pendingInteractionsQuery.data === undefined &&
-    (pendingInteractionsQuery.isLoading || pendingInteractionsQuery.isFetching);
+    isPendingInteractionStateUnknown(
+      pendingInteractionsQuery.data,
+      pendingInteractionsQuery.isFetching,
+    );
   const hasPendingInteraction =
     getLatestPendingInteraction(pendingInteractions) !== null;
   const { data: queuedMessagesForEditEligibility = [] } =


### PR DESCRIPTION
## Human comments

## What was wrong

PR #2870 kept side-chat questions and queued messages visible together, but its pending-interaction policy covered only sending: queued-message editing and deletion remained available while a provider waited for an answer. Side-chat tabs also remount, and the interaction query could reuse cached empty data while its required refresh was still discovering a new question, briefly exposing the composer before the answer controls appeared.

## What changed

- Hide both the side-chat composer and queued-message stack while a normal provider question, interaction refresh, or interaction-load error owns the composer. Held messages return unchanged after the question is answered.
- Keep plugin-owned interactions unchanged; they continue to show both the composer and queue.
- Share one pending-interaction freshness rule between regular threads and side chats so cached empty data remains unknown while its refresh is in flight.
- Add regressions for provider questions, plugin-owned interactions, initially unknown state, and cached-empty refreshes with queued messages.
- This is UI-only: there are no host-daemon wire, CLI, guide, or documentation changes, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

## How you verified

- `pnpm exec turbo run test --filter=@bb/app -- --run src/components/thread/embedded-chat/EmbeddedThreadChat.test.tsx src/hooks/queries/thread-queries.test.tsx` — 39 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/app` — passed.
- `pnpm exec turbo run build --filter=@bb/app` — passed with existing build warnings.
- `pnpm exec turbo run lint --filter=@bb/app` — passed with 176 existing warnings and 0 errors.
- Real Claude Code browser QA passed at 1280×720 and 390×844 coarse-pointer/no-hover viewports: the question remained usable while the held queue and composer were absent.
- Delaying both interaction requests by eight seconds showed only the checking state until the real question appeared; neither the queue nor composer flashed.
- The final rebase preserved stable patch ID `1e29d4c56a82d1935cdbaa356b2d40a85d9a48d9`, and `git diff --check` passed.

Fixes #2869

> AGENT GENERATED
