### PR TITLE
Fix duplicate mutation toasts and retain sidebar crash alerts

### DIFF
--- a/apps/app/src/components/plugin/PluginSettings.tsx
+++ b/apps/app/src/components/plugin/PluginSettings.tsx
@@ -475,6 +475,7 @@ function PluginSettingsContent({ plugin }: { plugin: PluginListItem }) {
   const queryClient = useQueryClient();
   const { settingsSections } = usePluginSlots();
   const toggle = useMutation({
+    meta: { showErrorToast: false },
     mutationFn: (enabled: boolean) =>
       setPluginEnabled(fetch, plugin.id, enabled),
     onError: (error, enabled) => {

--- a/apps/app/src/components/plugin/management/AddPluginDialog.tsx
+++ b/apps/app/src/components/plugin/management/AddPluginDialog.tsx
@@ -248,6 +248,7 @@ function AddPluginDialogContent({
   const plan = planQuery.data;
 
   const install = useMutation({
+    meta: { showErrorToast: false },
     mutationFn: (body: NonNullable<typeof request>) =>
       body.kind === "catalog"
         ? installCatalogPlugin(fetch, {

--- a/apps/app/src/components/plugin/management/CheckPluginUpdatesButton.tsx
+++ b/apps/app/src/components/plugin/management/CheckPluginUpdatesButton.tsx
@@ -72,6 +72,7 @@ export function CheckPluginUpdatesButton({
 }) {
   const queryClient = useQueryClient();
   const check = useMutation({
+    meta: { showErrorToast: false },
     mutationFn: () =>
       checkPluginUpdates(fetch, pluginId === undefined ? {} : { id: pluginId }),
     onSuccess: (results) => {

--- a/apps/app/src/components/plugin/management/InstalledPluginsTab.tsx
+++ b/apps/app/src/components/plugin/management/InstalledPluginsTab.tsx
@@ -79,6 +79,7 @@ export function InstalledPluginRow({
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const toggle = useMutation({
+    meta: { showErrorToast: false },
     mutationFn: (enabled: boolean) =>
       setPluginEnabled(fetch, plugin.id, enabled),
     onError: (error, enabled) => {

--- a/apps/app/src/components/plugin/management/PluginUpdatesCard.tsx
+++ b/apps/app/src/components/plugin/management/PluginUpdatesCard.tsx
@@ -42,6 +42,7 @@ export function PluginDetailReleaseControl({
   const availableVersion = plugin.updateState.availableVersion;
   const failure = plugin.updateState.lastFailure;
   const retry = useMutation({
+    meta: { showErrorToast: false },
     mutationFn: () => applyPluginUpdate(fetch, plugin.id),
     onSuccess: (result) => {
       invalidatePluginList({ queryClient });

--- a/apps/app/src/components/plugin/management/UpdatePluginDialog.test.tsx
+++ b/apps/app/src/components/plugin/management/UpdatePluginDialog.test.tsx
@@ -8,6 +8,10 @@ import {
   type PluginListItem,
   type PluginUpdateState,
 } from "@/hooks/queries/plugin-settings-queries";
+import {
+  getNotifications,
+  resetNotificationStore,
+} from "@/lib/notifications/notification-store";
 import { UpdatePluginDialog } from "./UpdatePluginDialog";
 import { makePluginListItem } from "@/test/fixtures/plugins";
 
@@ -35,6 +39,7 @@ function jsonResponse(body: unknown, status = 200): Response {
 
 afterEach(() => {
   cleanup();
+  resetNotificationStore();
   vi.unstubAllGlobals();
 });
 
@@ -193,6 +198,35 @@ describe("UpdatePluginDialog", () => {
         "The plugin is marked “Update failed” in the installed list until an update succeeds.",
       ),
     ).toBeTruthy();
+  });
+
+  it("records one alert when an update request fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse({ error: "plugin source is unavailable" }, 502),
+      ),
+    );
+    const { wrapper } = createQueryClientTestHarness();
+    render(
+      <UpdatePluginDialog
+        plugin={plugin({ availableVersion: "1.7.0" })}
+        open
+        onOpenChange={() => {}}
+      />,
+      { wrapper },
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Update" }));
+
+    await vi.waitFor(() => {
+      expect(getNotifications()).toEqual([
+        expect.objectContaining({
+          title: "Updating Linear failed",
+          description: "plugin source is unavailable",
+        }),
+      ]);
+    });
   });
 
   it("treats a malformed 2xx update response as an error, never success", async () => {

--- a/apps/app/src/components/plugin/management/UpdatePluginDialog.tsx
+++ b/apps/app/src/components/plugin/management/UpdatePluginDialog.tsx
@@ -66,6 +66,7 @@ function UpdatePluginDialogContent({
   const [rolledBack, setRolledBack] = useState<PluginUpdateResult | null>(null);
 
   const update = useMutation({
+    meta: { showErrorToast: false },
     mutationFn: () => applyPluginUpdate(fetch, plugin.id),
     onSuccess: (result) => {
       invalidatePluginList({ queryClient });

--- a/apps/app/src/components/settings/MarketplacesSettingsSection.test.tsx
+++ b/apps/app/src/components/settings/MarketplacesSettingsSection.test.tsx
@@ -2,6 +2,10 @@
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  getNotifications,
+  resetNotificationStore,
+} from "@/lib/notifications/notification-store";
 import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
 import { MarketplacesSettingsSection } from "./MarketplacesSettingsSection";
 
@@ -40,7 +44,10 @@ interface RecordedRequest {
   init: RequestInit | undefined;
 }
 
-function stubFetch(marketplaces: unknown[]): RecordedRequest[] {
+function stubFetch(
+  marketplaces: unknown[],
+  addResponse = jsonResponse({ ok: true, marketplace: ACME }),
+): RecordedRequest[] {
   const requests: RecordedRequest[] = [];
   vi.stubGlobal(
     "fetch",
@@ -50,7 +57,7 @@ function stubFetch(marketplaces: unknown[]): RecordedRequest[] {
         return jsonResponse({ marketplaces });
       }
       if (url === "/api/v1/marketplaces") {
-        return jsonResponse({ ok: true, marketplace: ACME });
+        return addResponse;
       }
       if (
         url.startsWith("/api/v1/marketplaces/") &&
@@ -66,6 +73,7 @@ function stubFetch(marketplaces: unknown[]): RecordedRequest[] {
 
 afterEach(() => {
   cleanup();
+  resetNotificationStore();
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
 });
@@ -90,6 +98,29 @@ describe("MarketplacesSettingsSection", () => {
       expect(JSON.parse(String(post?.init?.body))).toEqual({
         source: "https://acme.test/marketplace.json",
       });
+    });
+  });
+
+  it("retains one alert when adding a marketplace fails", async () => {
+    stubFetch(
+      [OFFICIAL],
+      jsonResponse({ error: "marketplace directory does not exist" }, 400),
+    );
+    const { wrapper } = createQueryClientTestHarness();
+    render(<MarketplacesSettingsSection />, { wrapper });
+
+    fireEvent.change(screen.getByLabelText("Marketplace source"), {
+      target: { value: "path:/missing-marketplace" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add" }));
+
+    await vi.waitFor(() => {
+      expect(getNotifications()).toEqual([
+        expect.objectContaining({
+          title: "Adding the marketplace failed",
+          description: "marketplace directory does not exist",
+        }),
+      ]);
     });
   });
 

--- a/apps/app/src/components/settings/MarketplacesSettingsSection.tsx
+++ b/apps/app/src/components/settings/MarketplacesSettingsSection.tsx
@@ -39,6 +39,7 @@ export function MarketplacesSettingsSection() {
   const invalidate = () => invalidatePluginMarketplaces({ queryClient });
 
   const add = useMutation({
+    meta: { showErrorToast: false },
     mutationFn: (value: string) => addPluginMarketplace(fetch, value),
     onSuccess: (marketplace) => {
       setSource("");
@@ -55,6 +56,7 @@ export function MarketplacesSettingsSection() {
   });
 
   const refresh = useMutation({
+    meta: { showErrorToast: false },
     mutationFn: (name: string) => refreshPluginMarketplaces(fetch, name),
     onSuccess: (results) => {
       invalidate();
@@ -75,6 +77,7 @@ export function MarketplacesSettingsSection() {
   });
 
   const remove = useMutation({
+    meta: { showErrorToast: false },
     mutationFn: (name: string) => removePluginMarketplace(fetch, name),
     onSuccess: (result) => {
       setRemoving(null);

--- a/apps/app/src/components/sidebar/SidebarNavigationRegion.test.tsx
+++ b/apps/app/src/components/sidebar/SidebarNavigationRegion.test.tsx
@@ -12,6 +12,10 @@ import {
   resetPluginSlotStoreForTest,
   setPluginSlotRegistrations,
 } from "@/lib/plugin-slots";
+import {
+  getNotifications,
+  resetNotificationStore,
+} from "@/lib/notifications/notification-store";
 import { SidebarNavigationRegion } from "./SidebarNavigationRegion";
 import { makePluginRegistrationSet as registrationSet } from "@/test/fixtures/plugins";
 
@@ -165,6 +169,7 @@ afterEach(() => {
   cleanup();
   resetAllCrashedPluginSlotsForTest();
   resetPluginSlotStoreForTest();
+  resetNotificationStore();
   window.localStorage.clear();
   vi.restoreAllMocks();
   mocks.dispatch.mockReset();
@@ -248,5 +253,12 @@ describe("SidebarNavigationRegion", () => {
     fireEvent.click(screen.getByRole("button", { name: "Crash replacement" }));
     expect(screen.getByTestId("built-in-sidebar-navigation")).toBeDefined();
     expect(ownerMount).toHaveBeenCalledTimes(2);
+    expect(getNotifications()).toEqual([
+      expect.objectContaining({
+        title: "Sidebar navigation plugin crashed",
+        description:
+          "Garden Navbar (garden) stopped working, so bb's own navigation is back.",
+      }),
+    ]);
   });
 });

--- a/apps/app/src/components/sidebar/SidebarNavigationRegion.tsx
+++ b/apps/app/src/components/sidebar/SidebarNavigationRegion.tsx
@@ -11,13 +11,13 @@ import type {
   ExperimentalSidebarNavigationItem,
 } from "@get-bb/plugin-sdk";
 import { useLocation, useNavigate } from "react-router-dom";
-import { toast } from "sonner";
 import { cn } from "@bb/shared-ui/lib/utils";
 import {
   useAppCommandRunner,
   useAppCommandShortcut,
 } from "@/components/commands/AppCommandProvider";
 import { PluginReplacementSlot } from "@/components/plugin/PluginReplacementSlot";
+import { appToast } from "@/components/ui/app-toast";
 import { useSidebar } from "@/components/ui/sidebar";
 import { usePluginSlots } from "@/lib/plugin-slots";
 import { getPluginPanelRoutePath } from "@/lib/route-paths";
@@ -243,7 +243,7 @@ export function SidebarNavigationRegion(props: BuiltInSidebarNavigationProps) {
         original={original}
         slotKind={SIDEBAR_NAVIGATION_SLOT_KIND}
         onCrash={(pluginId) => {
-          toast.error("Sidebar navigation plugin crashed", {
+          appToast.error("Sidebar navigation plugin crashed", {
             description: `${title} (${pluginId}) stopped working, so bb's own navigation is back.`,
           });
         }}

--- a/apps/app/src/components/tools/PluginCapabilities.tsx
+++ b/apps/app/src/components/tools/PluginCapabilities.tsx
@@ -550,6 +550,7 @@ export function PluginHealthBanner({
 }) {
   const queryClient = useQueryClient();
   const reload = useMutation({
+    meta: { showErrorToast: false },
     mutationFn: () => reloadPlugin(fetch, plugin.id),
     onSuccess: () => invalidatePluginList({ queryClient }),
     onError: (error) => {

--- a/apps/app/src/views/ToolsView.tsx
+++ b/apps/app/src/views/ToolsView.tsx
@@ -181,6 +181,7 @@ function PluginDetailToolView({ pluginId }: { pluginId: string }) {
     ),
   });
   const pluginToggle = useMutation({
+    meta: { showErrorToast: false },
     mutationFn: async (plugin: PluginListItem) => {
       const action = plugin.enabled ? "disable" : "enable";
       try {
@@ -195,6 +196,7 @@ function PluginDetailToolView({ pluginId }: { pluginId: string }) {
     },
   });
   const pluginDelete = useMutation({
+    meta: { showErrorToast: false },
     mutationFn: async (plugin: PluginListItem) => {
       try {
         await removePlugin(fetch, plugin.id);


### PR DESCRIPTION
## Human comments

## What was wrong

The global React Query mutation handler already owned generic error toasts when [PR #1582](https://github.com/get-bb/bb/pull/1582) added marketplace and plugin mutations with their own specific `onError` toasts but no global-handler opt-out. One failed action therefore had two toast owners; [PR #2882](https://github.com/get-bb/bb/pull/2882) made both alerts durable in notification history and separately missed a raw Sonner toast in the sidebar plugin-crash fallback.

## What changed

All 12 current first-party mutations with bespoke local error toasts now opt out of the global mutation error toast, establishing one error-toast owner per mutation without content-deduplicating distinct events. `SidebarNavigationRegion` now routes its plugin-crash alert through the recorded `appToast` helper. Focused regression coverage verifies that a failed plugin update and a failed marketplace action each retain one alert, and that the sidebar crash alert is retained. There are no wire, CLI, guide, or documentation contract changes.

## How you verified

The new plugin-update assertion failed before the fix with two retained notifications and passed after the fix with one contextual notification. The rebased focused suite passed 16/16 tests with `pnpm exec turbo run test --filter=@bb/app --force -- --run src/components/plugin/management/UpdatePluginDialog.test.tsx src/components/settings/MarketplacesSettingsSection.test.tsx src/components/sidebar/SidebarNavigationRegion.test.tsx`. `pnpm exec turbo run typecheck --filter=@bb/app --force` also passed. Earlier DevBrowser verification reproduced the marketplace flow changing from two visible/two retained alerts to one visible/one retained alert, and the sidebar crash from zero retained alerts to one.

Fixes: no issue — post-merge follow-up

> AGENT GENERATED
