### PR TITLE
Fix mobile secondary panel overlapping device safe areas

### DIFF
--- a/apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.test.tsx
+++ b/apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.test.tsx
@@ -72,6 +72,18 @@ describe("CompactSecondaryPanelShelf", () => {
     expect(shelf.className).not.toContain("bottom-0");
   });
 
+  it("keeps portaled panel controls inside the device safe area", () => {
+    renderShelf(true);
+
+    const shelf = screen.getByTestId("secondary-panel-shelf");
+    expect(shelf.className).toContain("pt-[env(safe-area-inset-top)]");
+    expect(shelf.className).toContain("pr-[env(safe-area-inset-right)]");
+    expect(shelf.className).toContain(
+      "pb-[var(--bb-safe-area-bottom,env(safe-area-inset-bottom))]",
+    );
+    expect(shelf.className).toContain("pl-[env(safe-area-inset-left)]");
+  });
+
   it("fills the viewport for a full-page tab and keeps the shelf width otherwise", () => {
     const { rerender } = renderShelf(true, "shelf");
     const shelf = screen.getByTestId("secondary-panel-shelf");

--- a/apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.tsx
+++ b/apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.tsx
@@ -172,7 +172,7 @@ export function CompactSecondaryPanelShelf({
               : APP_OVERLAY_LAYER.secondaryPanel,
         }}
         className={cn(
-          "fixed inset-y-0 right-0 flex h-(--bb-shell-height) touch-pan-y select-none flex-col overflow-hidden border-l border-border-seam bg-background outline-none",
+          "fixed inset-y-0 right-0 flex h-(--bb-shell-height) touch-pan-y select-none flex-col overflow-hidden border-l border-border-seam bg-background pt-[env(safe-area-inset-top)] pr-[env(safe-area-inset-right)] pb-[var(--bb-safe-area-bottom,env(safe-area-inset-bottom))] pl-[env(safe-area-inset-left)] outline-none",
           "w-(--secondary-panel-width-mobile) data-[state=full]:w-full data-[state=full]:border-l-0",
           SHELF_TRANSITION_CLASS,
           "data-[state=closed]:invisible data-[state=closed]:[transition:visibility_0s_linear_220ms]",


### PR DESCRIPTION
Fixes #2908

## Problem

On iPhone PWAs (`viewport-fit=cover`), the compact secondary right panel renders through a body portal with `fixed inset-y-0`, so it never inherits the safe-area padding `AppLayout` applies. Top controls land under the status bar and their touch targets conflict with system UI.

## Fix

Reuse the exact same four-side safe-area padding classes `AppLayout` already uses on the shelf container:

```ts
"fixed inset-y-0 right-0 flex h-(--bb-shell-height) touch-pan-y select-none flex-col overflow-hidden border-l border-border-seam bg-background pt-[env(safe-area-inset-top)] pr-[env(safe-area-inset-right)] pb-[var(--bb-safe-area-bottom,env(safe-area-inset-bottom))] pl-[env(safe-area-inset-left)] outline-none",
```

The background still extends edge to edge; only interactive content is pushed inside the safe area.

## Testing

- Added a regression test asserting the shelf carries all four safe-area padding classes: `apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.test.tsx`
- `CompactSecondaryPanelShelf.test.tsx`: 14/14 passing on current `main`