### PR TITLE
Hide uninstalled providers from usage settings

### DIFF
--- a/apps/app/src/components/settings/UsageLimitsSettingsSection.test.tsx
+++ b/apps/app/src/components/settings/UsageLimitsSettingsSection.test.tsx
@@ -122,7 +122,7 @@ describe("UsageLimitsSettingsSectionContent", () => {
     expect(screen.getByText("$5.00 / $50")).toBeDefined();
   });
 
-  it("keeps an uninstalled provider visible with its status", () => {
+  it("hides an uninstalled provider", () => {
     renderContent({
       usage: {
         codex: { status: "unauthenticated" },
@@ -134,8 +134,8 @@ describe("UsageLimitsSettingsSectionContent", () => {
       onRefresh: vi.fn(),
     });
 
-    expect(screen.getByRole("heading", { name: "Cursor" })).toBeDefined();
-    expect(screen.getByText("Not installed on this machine.")).toBeDefined();
+    expect(screen.queryByRole("heading", { name: "Cursor" })).toBeNull();
+    expect(screen.queryByText("Not installed on this machine.")).toBeNull();
     expect(screen.getByRole("heading", { name: "Codex" })).toBeDefined();
   });
 

--- a/apps/app/src/components/settings/UsageLimitsSettingsSection.tsx
+++ b/apps/app/src/components/settings/UsageLimitsSettingsSection.tsx
@@ -378,9 +378,11 @@ export function UsageLimitsSettingsSectionContent({
       (providerId) => !providerById.has(providerId),
     ),
   ];
-  const providerConfigs = orderedProviderIds.map((providerId) =>
-    providerConfig(providerId, providerById.get(providerId)),
-  );
+  const providerConfigs = orderedProviderIds
+    .filter((providerId) => usage[providerId]?.status !== "not_installed")
+    .map((providerId) =>
+      providerConfig(providerId, providerById.get(providerId)),
+    );
   const emptyMessage =
     isLoading || isProviderListLoading
       ? "Loading providers and usage…"


### PR DESCRIPTION
## Human comments

## What was wrong

The Usage settings page rendered every provider registered for usage, including providers whose usage probe returned `not_installed`. Cursor is globally discoverable even when its CLI is absent, so it showed a persistent irrelevant row while installed-only providers did not.

## What changed

- Filter `not_installed` results only from the Usage settings provider list.
- Preserve Cursor and other providers on their existing global discovery and CLI-management surfaces.
- Keep initial loading, authentication, expiration, error, and reported-usage states unchanged.
- Update the focused regression to require the uninstalled row to be absent while other provider rows remain visible.

No daemon wire contract, server API, public Plugin SDK API, CLI, documentation, or protocol version changed.

## How you verified

- `pnpm exec turbo run test --filter=@bb/app --force -- --run src/components/settings/UsageLimitsSettingsSection.test.tsx` — 12 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/app` — passed.
- App lint passed with 0 errors; existing repository warnings remain.
- `pnpm exec oxfmt --check apps/app/src/components/settings/UsageLimitsSettingsSection.tsx apps/app/src/components/settings/UsageLimitsSettingsSection.test.tsx` — passed.
- `git diff --check origin/main...HEAD` — passed.

> AGENT GENERATED
