### PR TITLE
Retain large completed event outputs in sidecars

### DIFF
--- a/apps/server/src/services/system/periodic-sweeps.ts
+++ b/apps/server/src/services/system/periodic-sweeps.ts
@@ -11,6 +11,7 @@ import {
   DEFAULT_COMPLETED_EVENT_OUTPUT_TRUNCATION_BATCH_SIZE,
   DEFAULT_DESTROYED_ENVIRONMENT_PRUNE_BATCH_SIZE,
   DESTROYED_ENVIRONMENT_TTL_MS,
+  deleteExpiredRetainedEventOutputs,
   dropDeferredLegacyTables,
   getDatabaseAutoVacuumMode,
   getDatabaseCompactionStats,
@@ -72,6 +73,7 @@ const DATABASE_MAINTENANCE_CHECK_INTERVAL_MS = 60 * 60_000;
 const MANAGED_ENVIRONMENT_ARCHIVE_CLEANUP_RECOVERY_INTERVAL_MS = 15 * 60_000;
 const ORPHANED_ENVIRONMENT_DESTROY_RECOVERY_DELAY_MS =
   LIVE_DAEMON_COMMAND_TIMEOUT_MS;
+const RETAINED_EVENT_OUTPUT_EXPIRY_BATCH_SIZE = 1;
 
 type PeriodicSweepJobCategory =
   | "retention"
@@ -479,6 +481,18 @@ function runCompletedEventOutputTruncationSweep(
   });
 }
 
+function runRetainedEventOutputExpirySweep(
+  deps: LoggedPendingInteractionWorkSessionDeps,
+  now: number,
+): void {
+  runEventLoopWorkSync("sweep:retained-event-output-expiry:delete", () =>
+    deleteExpiredRetainedEventOutputs(deps.db, {
+      expiredAtOrBefore: now,
+      limit: RETAINED_EVENT_OUTPUT_EXPIRY_BATCH_SIZE,
+    }),
+  );
+}
+
 function runClosedSessionPruneSweep(
   deps: LoggedPendingInteractionWorkSessionDeps,
   now: number,
@@ -525,6 +539,12 @@ const PERIODIC_SWEEP_JOBS: PeriodicSweepJob[] = [
     category: "retention",
     name: "completed-event-output-truncation",
     run: runCompletedEventOutputTruncationSweep,
+  },
+  {
+    cadenceMs: 0,
+    category: "retention",
+    name: "retained-event-output-expiry",
+    run: runRetainedEventOutputExpirySweep,
   },
   {
     cadenceMs: 0,

--- a/apps/server/src/services/threads/thread-data.ts
+++ b/apps/server/src/services/threads/thread-data.ts
@@ -2,6 +2,7 @@ import {
   findStoredEventRow as findStoredEventRowRecord,
   getLatestThreadOutputEventRow,
   getLatestThreadSystemErrorEventRow,
+  hydrateRetainedEventOutputRows,
   listStoredEventRows as listStoredEventRowRecords,
 } from "@bb/db";
 import type { DbConnection, StoredEventRow } from "@bb/db";
@@ -117,7 +118,9 @@ export function listThreadEventRows(
     threadId: args.threadId,
     types: args.types,
   });
-  return rows.map((row) => parseStoredEventRow(row));
+  return hydrateRetainedEventOutputRows(db, rows).map((row) =>
+    parseStoredEventRow(row),
+  );
 }
 
 export function findThreadEvent(
@@ -129,7 +132,11 @@ export function findThreadEvent(
     threadId: args.threadId,
     type: args.type,
   });
-  return row ? parseStoredEventRow(row) : null;
+  if (!row) {
+    return null;
+  }
+  const [hydrated] = hydrateRetainedEventOutputRows(db, [row]);
+  return parseStoredEventRow(hydrated ?? row);
 }
 
 export function getLastThreadOutput(

--- a/apps/server/src/services/threads/timeline.ts
+++ b/apps/server/src/services/threads/timeline.ts
@@ -28,6 +28,7 @@ import {
   findStoredTimelineWindowByteBudgetFloor,
   findTimelineWindowBudgetFloorSequence,
   getStoredEventRowsByParentToolCallIdsDataBytes,
+  hydrateRetainedEventOutputRows,
   getEnvironment,
   getThreadConversationOutlineRecord,
   findUnfinishedTurnCoveringSequence,
@@ -1425,7 +1426,7 @@ function buildThreadTimelineInternal(
   const includeNestedRows = options.includeNestedRows ?? false;
   const includeProviderUnhandledOperations =
     options.includeProviderUnhandledOperations;
-  const eventSelection = measureThreadTimelineStage(
+  const storedEventSelection = measureThreadTimelineStage(
     profile,
     "event-query",
     () =>
@@ -1437,6 +1438,13 @@ function buildThreadTimelineInternal(
         options.maxInlineOutputChars,
       ),
   );
+  const eventSelection =
+    options.maxInlineOutputChars === null
+      ? {
+          ...storedEventSelection,
+          rows: hydrateRetainedEventOutputRows(db, storedEventSelection.rows),
+        }
+      : storedEventSelection;
   const rawEventRows = eventSelection.rows;
   if (profile) {
     profile.eventDataBytes = byteLengthOfStoredEventRows(rawEventRows);
@@ -1915,6 +1923,15 @@ export function buildTimelineTurnSummaryDetails(
       threadId: thread.id,
       rows: eventRowsWithTurnStarts,
     });
+  const hydratedEventRows =
+    detailsInlineOutputLimit === null
+      ? hydrateRetainedEventOutputRows(db, eventRowsWithBackgroundTaskState)
+      : eventRowsWithBackgroundTaskState;
+  const projectionEventRows =
+    byteLengthOfStoredEventRows(hydratedEventRows) <=
+    THREAD_TIMELINE_EVENT_DATA_BYTE_LIMIT
+      ? hydratedEventRows
+      : eventRowsWithBackgroundTaskState;
   const projectionSourceSeqStart = eventRowsWithTurnStarts.reduce(
     (sourceSeqStart, row) =>
       row.type === "turn/started" && row.turnId === options.turnId
@@ -1923,9 +1940,7 @@ export function buildTimelineTurnSummaryDetails(
     sourceRange.sourceSeqStart,
   );
   const children = buildThreadTimelineTurnDetailsFromEvents({
-    events: eventRowsWithBackgroundTaskState.map((row) =>
-      toThreadEventWithMeta(row),
-    ),
+    events: projectionEventRows.map((row) => toThreadEventWithMeta(row)),
     options: {
       includeProviderUnhandledOperations,
       sourceSeqEnd: sourceRange.sourceSeqEnd,

--- a/apps/server/test/public/public-thread-timeline-output-preview.test.ts
+++ b/apps/server/test/public/public-thread-timeline-output-preview.test.ts
@@ -1,5 +1,7 @@
+import { eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
-import { turnScope } from "@bb/domain";
+import { threadEventRowSchema, turnScope } from "@bb/domain";
+import { events } from "@bb/db";
 import {
   threadTimelineResponseSchema,
   timelineTurnSummaryDetailsResponseSchema,
@@ -259,6 +261,111 @@ describe("GET /threads/:id/timeline inline output preview (tool rows)", () => {
         TIMELINE_INLINE_OUTPUT_PREVIEW_THRESHOLD_CHARS,
       );
       expect(full.output).toContain(BIG_OUTPUT.slice(0, 64));
+    });
+  });
+});
+
+describe("GET /threads/:id/events retained output", () => {
+  it("hydrates a retained output in the raw event response", async () => {
+    await withTestHarness(async (harness) => {
+      const { environment, thread } = seedThreadFixture(harness);
+      const output = "raw-" + "r".repeat(50_000);
+      seedEvent(harness.deps, {
+        data: {
+          item: {
+            aggregatedOutput: output,
+            approvalStatus: null,
+            command: "cat retained",
+            cwd: "/tmp",
+            exitCode: 0,
+            id: "retained-raw-command",
+            status: "completed",
+            type: "commandExecution",
+          },
+        },
+        environmentId: environment.id,
+        providerThreadId: "provider-retained",
+        scope: turnScope("turn-retained"),
+        sequence: 1,
+        threadId: thread.id,
+        type: "item/completed",
+      });
+      const stored = harness.db
+        .select({ data: events.data })
+        .from(events)
+        .where(eq(events.threadId, thread.id))
+        .get();
+      expect(stored?.data).not.toContain(output);
+
+      const response = await harness.app.request(
+        `/api/v1/threads/${thread.id}/events?types=item%2Fcompleted`,
+      );
+      expect(response.status).toBe(200);
+      const rows = threadEventRowSchema.array().parse(await readJson(response));
+      const [row] = rows;
+      if (
+        row?.type !== "item/completed" ||
+        row.data.item.type !== "commandExecution"
+      ) {
+        throw new Error("Expected completed command event");
+      }
+      expect(row.data.item.aggregatedOutput).toBe(output);
+      expect(row.data.item.truncation).toBeUndefined();
+    });
+  });
+});
+
+describe("GET /threads/:id/timeline retained output details", () => {
+  it("hydrates a retained output in row-scoped details", async () => {
+    await withTestHarness(async (harness) => {
+      const { environment, thread } = seedThreadFixture(harness);
+      const turn = {
+        environmentId: environment.id,
+        providerThreadId: "provider-retained-details",
+        scope: turnScope("turn-retained-details"),
+        threadId: thread.id,
+      } as const;
+      const output = "details-" + "d".repeat(50_000);
+      seedEvent(harness.deps, {
+        ...turn,
+        data: {},
+        sequence: 1,
+        type: "turn/started",
+      });
+      seedEvent(harness.deps, {
+        ...turn,
+        data: {
+          item: {
+            aggregatedOutput: output,
+            approvalStatus: null,
+            command: "cat retained details",
+            cwd: "/tmp",
+            exitCode: 0,
+            id: "retained-details-command",
+            status: "completed",
+            type: "commandExecution",
+          },
+        },
+        sequence: 2,
+        type: "item/completed",
+      });
+
+      const response = await harness.app.request(
+        `/api/v1/threads/${thread.id}/timeline/turn-summary-details?turnId=turn-retained-details&sourceSeqStart=2&sourceSeqEnd=2`,
+      );
+      expect(response.status).toBe(200);
+      const details = timelineTurnSummaryDetailsResponseSchema.parse(
+        await readJson(response),
+      );
+      const row = details.rows.find(
+        (candidate) =>
+          candidate.kind === "work" && candidate.workKind === "command",
+      );
+      if (row?.kind !== "work" || row.workKind !== "command") {
+        throw new Error("Expected retained details command row");
+      }
+      expect(row.output).toBe(output);
+      expect(row.outputPreview).toBeUndefined();
     });
   });
 });

--- a/apps/server/test/services/periodic-sweeps.test.ts
+++ b/apps/server/test/services/periodic-sweeps.test.ts
@@ -1,10 +1,13 @@
 import { eq } from "drizzle-orm";
 import {
   CLOSED_SESSION_ROW_RETENTION_MS,
+  COMPLETED_EVENT_OUTPUT_RETENTION_MS,
   DESTROYED_ENVIRONMENT_TTL_MS,
   environments,
+  events,
   hostDaemonSessions,
   listQueuedThreadMessages,
+  retainedEventOutputs,
 } from "@bb/db";
 import type { PluginHookName } from "@get-bb/plugin-sdk";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -26,7 +29,9 @@ import {
   seedHostSession,
   seedProjectWithSource,
   seedQueuedMessage,
+  seedEvent,
   seedThread,
+  seedThreadFixture,
   seedThreadRuntimeState,
 } from "../helpers/seed.js";
 import { textInput } from "../helpers/prompt-input.js";
@@ -79,6 +84,7 @@ function seedRunnableThread(harness: TestAppHarness, hostId: string) {
 
 afterEach(() => {
   setPluginHookProvider(undefined);
+  vi.useRealTimers();
 });
 
 function releaseRunningJob(release: ReleaseCallback | null): void {
@@ -89,6 +95,59 @@ function releaseRunningJob(release: ReleaseCallback | null): void {
 }
 
 describe("runPeriodicSweeps", () => {
+  it("deletes one expired retained output without changing its event preview", async () => {
+    const now = 1_800_000_000_000;
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    await withTestHarness(async (harness) => {
+      const { environment, thread } = seedThreadFixture(harness);
+      seedEvent(harness.deps, {
+        createdAt: now - COMPLETED_EVENT_OUTPUT_RETENTION_MS,
+        data: {
+          item: {
+            aggregatedOutput: "x".repeat(50_000),
+            approvalStatus: null,
+            command: "cat expired",
+            cwd: "/tmp",
+            exitCode: 0,
+            id: "expired-retained-command",
+            status: "completed",
+            type: "commandExecution",
+          },
+        },
+        environmentId: environment.id,
+        providerThreadId: "provider-expired-retained",
+        scope: { kind: "turn", turnId: "turn-expired-retained" },
+        sequence: 1,
+        threadId: thread.id,
+        type: "item/completed",
+      });
+      const preview = harness.db
+        .select({ data: events.data })
+        .from(events)
+        .where(eq(events.threadId, thread.id))
+        .get();
+      expect(harness.db.select().from(retainedEventOutputs).all()).toHaveLength(
+        1,
+      );
+
+      await runPeriodicSweeps({
+        ...harness.deps,
+        pluginSchedules: harness.pluginService,
+        plugins: harness.pluginService,
+      });
+
+      expect(harness.db.select().from(retainedEventOutputs).all()).toEqual([]);
+      expect(
+        harness.db
+          .select({ data: events.data })
+          .from(events)
+          .where(eq(events.threadId, thread.id))
+          .get(),
+      ).toEqual(preview);
+    });
+  });
+
   it("dispatches due messages from an overlapping tick while idle recovery is still running", async () => {
     await withTestHarness(async (harness) => {
       let releaseIdleRecovery: ReleaseCallback | null = null;

--- a/apps/server/test/services/threads/timeline-in-turn-window.test.ts
+++ b/apps/server/test/services/threads/timeline-in-turn-window.test.ts
@@ -890,7 +890,7 @@ describe("in-turn timeline windows", () => {
     }
   });
 
-  it("caps stored outputs before it expands a byte-budget slice", () => {
+  it("uses bounded retained previews while it expands a byte-budget slice", () => {
     const { db, thread } = setup();
     seedTurns(db, thread, {
       completeLastTurn: true,
@@ -914,12 +914,11 @@ describe("in-turn timeline windows", () => {
       row.kind === "work" && row.workKind === "command" ? [row.output] : [],
     );
 
-    expect(commandOutputs.length).toBeGreaterThan(0);
-    expect(commandOutputs.length).toBeLessThan(150);
+    expect(commandOutputs).toHaveLength(150);
     expect(commandOutputs.every((output) => output.length < 33_000)).toBe(true);
     expect(
       commandOutputs.some((output) =>
-        output.includes("more characters truncated"),
+        output.includes("output truncated by retention policy"),
       ),
     ).toBe(true);
   });
@@ -1271,9 +1270,79 @@ describe("timeline inline output reads", () => {
       throw new Error("expected command rows");
     }
     expect(uncappedRow.output).toBe(output);
-    expect(cappedRow.output).toBe(
-      `${"x".repeat(32_000)}\n…[18,000 more characters truncated]`,
+    expect(cappedRow.output).not.toBe(output);
+    expect(cappedRow.output.length).toBeLessThan(5_000);
+    expect(cappedRow.output.startsWith(output.slice(0, 2_048))).toBe(true);
+    expect(cappedRow.output.endsWith(output.slice(-2_048))).toBe(true);
+    expect(cappedRow.output).toContain("output truncated by retention policy");
+  });
+});
+
+describe("timeline retained output reads", () => {
+  it("keeps capped reads bounded and hydrates uncapped reads", () => {
+    const { db, thread } = setup();
+    seedTurns(db, thread, { completeLastTurn: false, itemsPerTurn: [1] });
+    const output = "x".repeat(50_000);
+    insertEvents(db, noopNotifier, [
+      {
+        threadId: thread.id,
+        sequence: 500,
+        type: "item/completed",
+        scope: turnScope("turn-1"),
+        providerThreadId,
+        itemId: "retained-command",
+        itemKind: "commandExecution",
+        parentToolCallId: null,
+        data: JSON.stringify({
+          item: {
+            type: "commandExecution",
+            id: "retained-command",
+            command: "cat large",
+            cwd: "/tmp/test",
+            status: "completed",
+            approvalStatus: null,
+            exitCode: 0,
+            aggregatedOutput: output,
+          },
+        }),
+      },
+    ]);
+
+    const capped = buildThreadTimeline(db, thread, {
+      eventBudget: LARGE_BUDGET,
+      includeProviderUnhandledOperations: false,
+      includeNestedRows: false,
+      maxInlineOutputChars: 32_000,
+      maxSeq: 500,
+      page: { kind: "latest", segmentLimit: 20 },
+    });
+    const uncapped = buildThreadTimeline(db, thread, {
+      eventBudget: LARGE_BUDGET,
+      includeProviderUnhandledOperations: false,
+      includeNestedRows: false,
+      maxInlineOutputChars: null,
+      maxSeq: 500,
+      page: { kind: "latest", segmentLimit: 20 },
+    });
+    const cappedRow = capped.rows.find(
+      (row) => row.kind === "work" && row.id.endsWith("retained-command"),
     );
+    const uncappedRow = uncapped.rows.find(
+      (row) => row.kind === "work" && row.id.endsWith("retained-command"),
+    );
+    if (
+      cappedRow?.kind !== "work" ||
+      cappedRow.workKind !== "command" ||
+      uncappedRow?.kind !== "work" ||
+      uncappedRow.workKind !== "command"
+    ) {
+      throw new Error("Expected retained command rows");
+    }
+    expect(cappedRow.output.length).toBeLessThan(5_000);
+    expect(cappedRow.output).toContain("output truncated by retention policy");
+    expect(uncappedRow.output).toBe(output);
+
+    db.$client.close();
   });
 });
 

--- a/packages/db/drizzle/0113_graceful_mojo.sql
+++ b/packages/db/drizzle/0113_graceful_mojo.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `retained_event_outputs` (
+	`event_id` text PRIMARY KEY NOT NULL,
+	`output_path` text NOT NULL,
+	`value` text NOT NULL,
+	`expires_at` integer NOT NULL,
+	FOREIGN KEY (`event_id`) REFERENCES `events`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `retained_event_outputs_expiry_idx` ON `retained_event_outputs` (`expires_at`,`event_id`);

--- a/packages/db/drizzle/meta/0113_snapshot.json
+++ b/packages/db/drizzle/meta/0113_snapshot.json
@@ -1,0 +1,3924 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "e78241ea-8533-4a8f-afe9-8d59994a8df7",
+  "prevId": "1372ccec-3fb1-4472-968f-5db67682af56",
+  "tables": {
+    "app_settings": {
+      "name": "app_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caffeinate": {
+          "name": "caffeinate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "show_keyboard_hints": {
+          "name": "show_keyboard_hints",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "steer_active_thread_on_enter": {
+          "name": "steer_active_thread_on_enter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "show_unhandled_provider_events": {
+          "name": "show_unhandled_provider_events",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "codex_memory_enabled": {
+          "name": "codex_memory_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "claude_code_memory_enabled": {
+          "name": "claude_code_memory_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "codex_subagents_disabled": {
+          "name": "codex_subagents_disabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "claude_code_subagents_disabled": {
+          "name": "claude_code_subagents_disabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "claude_code_workflows_disabled": {
+          "name": "claude_code_workflows_disabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "keybinding_overrides": {
+          "name": "keybinding_overrides",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_settings_values": {
+      "name": "app_settings_values",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_theme": {
+      "name": "app_theme",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "theme_id": {
+          "name": "theme_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "favicon_color": {
+          "name": "favicon_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apikey": {
+      "name": "apikey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "referenceId": {
+          "name": "referenceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refillInterval": {
+          "name": "refillInterval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refillAmount": {
+          "name": "refillAmount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lastRefillAt": {
+          "name": "lastRefillAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rateLimitEnabled": {
+          "name": "rateLimitEnabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rateLimitTimeWindow": {
+          "name": "rateLimitTimeWindow",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rateLimitMax": {
+          "name": "rateLimitMax",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requestCount": {
+          "name": "requestCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lastRequest": {
+          "name": "lastRequest",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "configId": {
+          "name": "configId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "apikey_key_unique": {
+          "name": "apikey_key_unique",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        },
+        "apikey_reference_id_idx": {
+          "name": "apikey_reference_id_idx",
+          "columns": [
+            "referenceId"
+          ],
+          "isUnique": false
+        },
+        "apikey_config_id_idx": {
+          "name": "apikey_config_id_idx",
+          "columns": [
+            "configId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "apikey_referenceId_user_id_fk": {
+          "name": "apikey_referenceId_user_id_fk",
+          "tableFrom": "apikey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "referenceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "environments": {
+      "name": "environments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "managed": {
+          "name": "managed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_git_repo": {
+          "name": "is_git_repo",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_worktree": {
+          "name": "is_worktree",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "branch_name": {
+          "name": "branch_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "merge_base_branch": {
+          "name": "merge_base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "destroy_attempt_id": {
+          "name": "destroy_attempt_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retire_requested_at": {
+          "name": "retire_requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_provision_type": {
+          "name": "workspace_provision_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'provisioning'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "environments_project_host_path_idx": {
+          "name": "environments_project_host_path_idx",
+          "columns": [
+            "project_id",
+            "host_id",
+            "path"
+          ],
+          "isUnique": true
+        },
+        "environments_host_path_lookup_idx": {
+          "name": "environments_host_path_lookup_idx",
+          "columns": [
+            "host_id",
+            "path"
+          ],
+          "isUnique": false
+        },
+        "environments_project_idx": {
+          "name": "environments_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "environments_status_idx": {
+          "name": "environments_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "environments_project_id_projects_id_fk": {
+          "name": "environments_project_id_projects_id_fk",
+          "tableFrom": "environments",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "environments_host_id_hosts_id_fk": {
+          "name": "environments_host_id_hosts_id_fk",
+          "tableFrom": "environments",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope_kind": {
+          "name": "scope_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_thread_id": {
+          "name": "provider_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "item_kind": {
+          "name": "item_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_tool_call_id": {
+          "name": "parent_tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "events_thread_sequence_idx": {
+          "name": "events_thread_sequence_idx",
+          "columns": [
+            "thread_id",
+            "sequence"
+          ],
+          "isUnique": true
+        },
+        "events_delegating_item_lookup_idx": {
+          "name": "events_delegating_item_lookup_idx",
+          "columns": [
+            "thread_id",
+            "item_id",
+            "sequence",
+            "item_kind"
+          ],
+          "isUnique": false,
+          "where": "\"events\".\"item_kind\" IN ('toolCall', 'delegation')"
+        },
+        "events_plan_steps_thread_sequence_idx": {
+          "name": "events_plan_steps_thread_sequence_idx",
+          "columns": [
+            "thread_id",
+            "sequence"
+          ],
+          "isUnique": false,
+          "where": "(\"events\".\"item_kind\" = 'planSteps' AND \"events\".\"type\" = 'item/completed') OR \"events\".\"type\" = 'turn/plan/updated'"
+        },
+        "events_parent_tool_call_thread_parent_sequence_idx": {
+          "name": "events_parent_tool_call_thread_parent_sequence_idx",
+          "columns": [
+            "thread_id",
+            "parent_tool_call_id",
+            "sequence"
+          ],
+          "isUnique": false,
+          "where": "\"events\".\"parent_tool_call_id\" IS NOT NULL"
+        },
+        "events_thread_type_item_kind_sequence_idx": {
+          "name": "events_thread_type_item_kind_sequence_idx",
+          "columns": [
+            "thread_id",
+            "type",
+            "item_kind",
+            "sequence"
+          ],
+          "isUnique": false
+        },
+        "events_background_task_thread_type_item_sequence_idx": {
+          "name": "events_background_task_thread_type_item_sequence_idx",
+          "columns": [
+            "thread_id",
+            "type",
+            "item_id",
+            "sequence"
+          ],
+          "isUnique": false,
+          "where": "\"events\".\"item_kind\" = 'backgroundTask'"
+        },
+        "events_thread_type_sequence_idx": {
+          "name": "events_thread_type_sequence_idx",
+          "columns": [
+            "thread_id",
+            "type",
+            "sequence"
+          ],
+          "isUnique": false
+        },
+        "events_thread_turn_type_item_sequence_idx": {
+          "name": "events_thread_turn_type_item_sequence_idx",
+          "columns": [
+            "thread_id",
+            "turn_id",
+            "type",
+            "item_id",
+            "sequence"
+          ],
+          "isUnique": false
+        },
+        "events_item_lifecycle_thread_item_sequence_idx": {
+          "name": "events_item_lifecycle_thread_item_sequence_idx",
+          "columns": [
+            "thread_id",
+            "item_id",
+            "sequence"
+          ],
+          "isUnique": false,
+          "where": "\"events\".\"type\" IN ('item/started', 'item/completed', 'item/backgroundTask/completed')"
+        },
+        "events_environment_idx": {
+          "name": "events_environment_idx",
+          "columns": [
+            "environment_id"
+          ],
+          "isUnique": false
+        },
+        "events_completed_item_truncation_idx": {
+          "name": "events_completed_item_truncation_idx",
+          "columns": [
+            "item_kind",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false,
+          "where": "\"events\".\"type\" = 'item/completed'"
+        },
+        "events_thread_state_thread_sequence_idx": {
+          "name": "events_thread_state_thread_sequence_idx",
+          "columns": [
+            "thread_id",
+            "sequence"
+          ],
+          "isUnique": false,
+          "where": "\"events\".\"type\" IN ('thread/goal/updated', 'thread/goal/cleared', 'thread/extensionState/updated')"
+        }
+      },
+      "foreignKeys": {
+        "events_thread_id_threads_id_fk": {
+          "name": "events_thread_id_threads_id_fk",
+          "tableFrom": "events",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "events_environment_id_environments_id_fk": {
+          "name": "events_environment_id_environments_id_fk",
+          "tableFrom": "events",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "events_scope_shape_check": {
+          "name": "events_scope_shape_check",
+          "value": "(\n        (\"events\".\"scope_kind\" = 'turn' AND \"events\".\"turn_id\" IS NOT NULL)\n        OR\n        (\"events\".\"scope_kind\" = 'thread' AND \"events\".\"turn_id\" IS NULL)\n      )"
+        }
+      }
+    },
+    "host_daemon_sessions": {
+      "name": "host_daemon_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_name": {
+          "name": "host_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_type": {
+          "name": "host_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data_dir": {
+          "name": "data_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "protocol_version": {
+          "name": "protocol_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "heartbeat_interval_ms": {
+          "name": "heartbeat_interval_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lease_timeout_ms": {
+          "name": "lease_timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "close_reason": {
+          "name": "close_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "host_daemon_sessions_host_status_idx": {
+          "name": "host_daemon_sessions_host_status_idx",
+          "columns": [
+            "host_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "host_daemon_sessions_host_latest_idx": {
+          "name": "host_daemon_sessions_host_latest_idx",
+          "columns": [
+            "host_id",
+            "updated_at",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "host_daemon_sessions_closed_prune_idx": {
+          "name": "host_daemon_sessions_closed_prune_idx",
+          "columns": [
+            "status",
+            "closed_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "host_daemon_sessions_host_id_hosts_id_fk": {
+          "name": "host_daemon_sessions_host_id_hosts_id_fk",
+          "tableFrom": "host_daemon_sessions",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "hosts": {
+      "name": "hosts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connect_machine_id": {
+          "name": "connect_machine_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_permission_mode": {
+          "name": "max_permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'full'"
+        },
+        "destroyed_at": {
+          "name": "destroyed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_rejected_protocol_version": {
+          "name": "last_rejected_protocol_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "hosts_last_seen_idx": {
+          "name": "hosts_last_seen_idx",
+          "columns": [
+            "last_seen_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plugins": {
+      "name": "plugins",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'direct'"
+        },
+        "catalog_entry_id": {
+          "name": "catalog_entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "catalog_marketplace_name": {
+          "name": "catalog_marketplace_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'path'"
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_builtin_name": {
+          "name": "source_builtin_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_npm_package": {
+          "name": "source_npm_package",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_npm_registry": {
+          "name": "source_npm_registry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_npm_requested_spec": {
+          "name": "source_npm_requested_spec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_npm_spec_kind": {
+          "name": "source_npm_spec_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_git_url": {
+          "name": "source_git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_git_subdirectory": {
+          "name": "source_git_subdirectory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_git_requested_ref": {
+          "name": "source_git_requested_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_git_ref_kind": {
+          "name": "source_git_ref_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_git_range": {
+          "name": "source_git_range",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_git_tag_prefix": {
+          "name": "source_git_tag_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_git_resolved_tag": {
+          "name": "source_git_resolved_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "npm_resolved_version": {
+          "name": "npm_resolved_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "npm_integrity": {
+          "name": "npm_integrity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "git_resolved_commit": {
+          "name": "git_resolved_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_update_check_at": {
+          "name": "last_update_check_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "available_compatible_version": {
+          "name": "available_compatible_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "newest_incompatible_version": {
+          "name": "newest_incompatible_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "update_status_detail": {
+          "name": "update_status_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_failure_version": {
+          "name": "last_failure_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_failure_at": {
+          "name": "last_failure_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_failure_detail": {
+          "name": "last_failure_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_artifact_id": {
+          "name": "active_artifact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "normalization_version": {
+          "name": "normalization_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "root_dir": {
+          "name": "root_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plugins_active_artifact_id_plugin_artifacts_id_fk": {
+          "name": "plugins_active_artifact_id_plugin_artifacts_id_fk",
+          "tableFrom": "plugins",
+          "tableTo": "plugin_artifacts",
+          "columnsFrom": [
+            "active_artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "maintenance_scan_cursors": {
+      "name": "maintenance_scan_cursors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_kind": {
+          "name": "item_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_path": {
+          "name": "output_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_created_at": {
+          "name": "last_created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "maintenance_scan_cursors_path_idx": {
+          "name": "maintenance_scan_cursors_path_idx",
+          "columns": [
+            "policy",
+            "version",
+            "item_kind",
+            "output_path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pending_interactions": {
+      "name": "pending_interactions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin_kind": {
+          "name": "origin_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'provider'"
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_thread_id": {
+          "name": "provider_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_request_id": {
+          "name": "provider_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "renderer_id": {
+          "name": "renderer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pending_interactions_provider_request_idx": {
+          "name": "pending_interactions_provider_request_idx",
+          "columns": [
+            "provider_id",
+            "provider_thread_id",
+            "provider_request_id"
+          ],
+          "isUnique": true
+        },
+        "pending_interactions_thread_created_idx": {
+          "name": "pending_interactions_thread_created_idx",
+          "columns": [
+            "thread_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "pending_interactions_thread_status_created_idx": {
+          "name": "pending_interactions_thread_status_created_idx",
+          "columns": [
+            "thread_id",
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "pending_interactions_status_created_idx": {
+          "name": "pending_interactions_status_created_idx",
+          "columns": [
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "pending_interactions_plugin_status_created_idx": {
+          "name": "pending_interactions_plugin_status_created_idx",
+          "columns": [
+            "plugin_id",
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pending_interactions_thread_id_threads_id_fk": {
+          "name": "pending_interactions_thread_id_threads_id_fk",
+          "tableFrom": "pending_interactions",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plugin_artifacts": {
+      "name": "plugin_artifacts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "npm_resolved_version": {
+          "name": "npm_resolved_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "git_resolved_commit": {
+          "name": "git_resolved_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "git_checkout_root": {
+          "name": "git_checkout_root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "integrity": {
+          "name": "integrity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validation_result": {
+          "name": "validation_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "validated_at": {
+          "name": "validated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "plugin_artifacts_plugin_idx": {
+          "name": "plugin_artifacts_plugin_idx",
+          "columns": [
+            "plugin_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plugin_kv": {
+      "name": "plugin_kv",
+      "columns": {
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "plugin_kv_plugin_id_key_pk": {
+          "columns": [
+            "plugin_id",
+            "key"
+          ],
+          "name": "plugin_kv_plugin_id_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plugin_marketplace_icons": {
+      "name": "plugin_marketplace_icons",
+      "columns": {
+        "marketplace_name": {
+          "name": "marketplace_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "etag": {
+          "name": "etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "plugin_marketplace_icons_marketplace_name_entry_id_pk": {
+          "columns": [
+            "marketplace_name",
+            "entry_id"
+          ],
+          "name": "plugin_marketplace_icons_marketplace_name_entry_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plugin_marketplaces": {
+      "name": "plugin_marketplaces",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'https'"
+        },
+        "manifest_url": {
+          "name": "manifest_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_git_ref": {
+          "name": "source_git_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_git_commit": {
+          "name": "source_git_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "manifest_json": {
+          "name": "manifest_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stats_json": {
+          "name": "stats_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "etag": {
+          "name": "etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_successful_refresh_at": {
+          "name": "last_successful_refresh_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_attempted_refresh_at": {
+          "name": "last_attempted_refresh_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plugin_schedules": {
+      "name": "plugin_schedules",
+      "columns": {
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cron": {
+          "name": "cron",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "plugin_schedules_plugin_id_name_pk": {
+          "columns": [
+            "plugin_id",
+            "name"
+          ],
+          "name": "plugin_schedules_plugin_id_name_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plugin_settings": {
+      "name": "plugin_settings",
+      "columns": {
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "plugin_settings_plugin_id_key_pk": {
+          "columns": [
+            "plugin_id",
+            "key"
+          ],
+          "name": "plugin_settings_plugin_id_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plugin_state_snapshots": {
+      "name": "plugin_state_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_artifact_id": {
+          "name": "from_artifact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "to_artifact_id": {
+          "name": "to_artifact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_path": {
+          "name": "snapshot_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "database_path": {
+          "name": "database_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_path": {
+          "name": "state_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secrets_path": {
+          "name": "secrets_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "registration_path": {
+          "name": "registration_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rollback_candidate_version": {
+          "name": "rollback_candidate_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rollback_source_fingerprint": {
+          "name": "rollback_source_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rollback_bb_version": {
+          "name": "rollback_bb_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rollback_sdk_version": {
+          "name": "rollback_sdk_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rollback_detail": {
+          "name": "rollback_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "retained_until": {
+          "name": "retained_until",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "plugin_state_snapshots_plugin_idx": {
+          "name": "plugin_state_snapshots_plugin_idx",
+          "columns": [
+            "plugin_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_state_snapshots_retention_idx": {
+          "name": "plugin_state_snapshots_retention_idx",
+          "columns": [
+            "retained_until"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_execution_defaults": {
+      "name": "project_execution_defaults",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service_tier": {
+          "name": "service_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reasoning_level": {
+          "name": "reasoning_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permission_mode": {
+          "name": "permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "project_execution_defaults_project_idx": {
+          "name": "project_execution_defaults_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "project_execution_defaults_project_id_projects_id_fk": {
+          "name": "project_execution_defaults_project_id_projects_id_fk",
+          "tableFrom": "project_execution_defaults",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_sources": {
+      "name": "project_sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "project_sources_project_idx": {
+          "name": "project_sources_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "project_sources_host_idx": {
+          "name": "project_sources_host_idx",
+          "columns": [
+            "host_id"
+          ],
+          "isUnique": false
+        },
+        "project_sources_project_host_idx": {
+          "name": "project_sources_project_host_idx",
+          "columns": [
+            "project_id",
+            "host_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "project_sources_project_id_projects_id_fk": {
+          "name": "project_sources_project_id_projects_id_fk",
+          "tableFrom": "project_sources",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_sources_host_id_hosts_id_fk": {
+          "name": "project_sources_host_id_hosts_id_fk",
+          "tableFrom": "project_sources",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "project_sources_shape_check": {
+          "name": "project_sources_shape_check",
+          "value": "(\n        \"project_sources\".\"type\" = 'local_path' AND \"project_sources\".\"host_id\" IS NOT NULL AND \"project_sources\".\"path\" IS NOT NULL\n      )"
+        }
+      }
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'standard'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "git_remote_url": {
+          "name": "git_remote_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_key": {
+          "name": "sort_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'V'"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_updated_idx": {
+          "name": "projects_updated_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "projects_deleted_idx": {
+          "name": "projects_deleted_idx",
+          "columns": [
+            "deleted_at"
+          ],
+          "isUnique": false
+        },
+        "projects_sort_idx": {
+          "name": "projects_sort_idx",
+          "columns": [
+            "sort_key",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "projects_personal_singleton_idx": {
+          "name": "projects_personal_singleton_idx",
+          "columns": [
+            "kind"
+          ],
+          "isUnique": true,
+          "where": "\"projects\".\"kind\" = 'personal'"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_history_entries": {
+      "name": "prompt_history_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_sequence": {
+          "name": "request_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "prompt_history_entries_thread_request_idx": {
+          "name": "prompt_history_entries_thread_request_idx",
+          "columns": [
+            "thread_id",
+            "request_sequence"
+          ],
+          "isUnique": true
+        },
+        "prompt_history_entries_project_scope_created_idx": {
+          "name": "prompt_history_entries_project_scope_created_idx",
+          "columns": [
+            "project_id",
+            "scope",
+            "created_at",
+            "request_sequence",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "prompt_history_entries_thread_scope_created_idx": {
+          "name": "prompt_history_entries_thread_scope_created_idx",
+          "columns": [
+            "thread_id",
+            "scope",
+            "created_at",
+            "request_sequence",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "prompt_history_entries_project_id_projects_id_fk": {
+          "name": "prompt_history_entries_project_id_projects_id_fk",
+          "tableFrom": "prompt_history_entries",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "prompt_history_entries_thread_id_threads_id_fk": {
+          "name": "prompt_history_entries_thread_id_threads_id_fk",
+          "tableFrom": "prompt_history_entries",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "queued_thread_messages": {
+      "name": "queued_thread_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "system_notice": {
+          "name": "system_notice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sender_thread_id": {
+          "name": "sender_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reasoning_level": {
+          "name": "reasoning_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permission_mode": {
+          "name": "permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service_tier": {
+          "name": "service_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_with_next": {
+          "name": "group_with_next",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "send_at": {
+          "name": "send_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "waiting_on": {
+          "name": "waiting_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "wait_holder": {
+          "name": "wait_holder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload_kind": {
+          "name": "payload_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'inline'"
+        },
+        "retry_of_turn_request_id": {
+          "name": "retry_of_turn_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retry_attempt": {
+          "name": "retry_attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retry_reason": {
+          "name": "retry_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claim_token": {
+          "name": "claim_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_key": {
+          "name": "sort_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "queued_thread_messages_thread_created_idx": {
+          "name": "queued_thread_messages_thread_created_idx",
+          "columns": [
+            "thread_id",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "queued_thread_messages_thread_sort_idx": {
+          "name": "queued_thread_messages_thread_sort_idx",
+          "columns": [
+            "thread_id",
+            "sort_key",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "queued_thread_messages_due_idx": {
+          "name": "queued_thread_messages_due_idx",
+          "columns": [
+            "send_at",
+            "id"
+          ],
+          "isUnique": false,
+          "where": "\"queued_thread_messages\".\"send_at\" IS NOT NULL AND \"queued_thread_messages\".\"claimed_at\" IS NULL AND \"queued_thread_messages\".\"claim_token\" IS NULL"
+        },
+        "queued_thread_messages_wait_holder_idx": {
+          "name": "queued_thread_messages_wait_holder_idx",
+          "columns": [
+            "wait_holder",
+            "id"
+          ],
+          "isUnique": false,
+          "where": "\"queued_thread_messages\".\"wait_holder\" IS NOT NULL"
+        }
+      },
+      "foreignKeys": {
+        "queued_thread_messages_thread_id_threads_id_fk": {
+          "name": "queued_thread_messages_thread_id_threads_id_fk",
+          "tableFrom": "queued_thread_messages",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "retained_event_outputs": {
+      "name": "retained_event_outputs",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_path": {
+          "name": "output_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "retained_event_outputs_expiry_idx": {
+          "name": "retained_event_outputs_expiry_idx",
+          "columns": [
+            "expires_at",
+            "event_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "retained_event_outputs_event_id_events_id_fk": {
+          "name": "retained_event_outputs_event_id_events_id_fk",
+          "tableFrom": "retained_event_outputs",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "system_experiments": {
+      "name": "system_experiments",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "terminal_sessions": {
+      "name": "terminal_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "daemon_session_id": {
+          "name": "daemon_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "initial_cwd": {
+          "name": "initial_cwd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cols": {
+          "name": "cols",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rows": {
+          "name": "rows",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "close_reason": {
+          "name": "close_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_user_input_at": {
+          "name": "last_user_input_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "terminal_sessions_thread_status_updated_idx": {
+          "name": "terminal_sessions_thread_status_updated_idx",
+          "columns": [
+            "thread_id",
+            "status",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "terminal_sessions_environment_status_idx": {
+          "name": "terminal_sessions_environment_status_idx",
+          "columns": [
+            "environment_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "terminal_sessions_host_status_idx": {
+          "name": "terminal_sessions_host_status_idx",
+          "columns": [
+            "host_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "terminal_sessions_daemon_session_idx": {
+          "name": "terminal_sessions_daemon_session_idx",
+          "columns": [
+            "daemon_session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "terminal_sessions_thread_id_threads_id_fk": {
+          "name": "terminal_sessions_thread_id_threads_id_fk",
+          "tableFrom": "terminal_sessions",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "terminal_sessions_environment_id_environments_id_fk": {
+          "name": "terminal_sessions_environment_id_environments_id_fk",
+          "tableFrom": "terminal_sessions",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "terminal_sessions_host_id_hosts_id_fk": {
+          "name": "terminal_sessions_host_id_hosts_id_fk",
+          "tableFrom": "terminal_sessions",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "terminal_sessions_daemon_session_id_host_daemon_sessions_id_fk": {
+          "name": "terminal_sessions_daemon_session_id_host_daemon_sessions_id_fk",
+          "tableFrom": "terminal_sessions",
+          "tableTo": "host_daemon_sessions",
+          "columnsFrom": [
+            "daemon_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thread_conversation_outlines": {
+      "name": "thread_conversation_outlines",
+      "columns": {
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projection_key": {
+          "name": "projection_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "items_json": {
+          "name": "items_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "thread_conversation_outlines_thread_id_threads_id_fk": {
+          "name": "thread_conversation_outlines_thread_id_threads_id_fk",
+          "tableFrom": "thread_conversation_outlines",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thread_dynamic_context_file_states": {
+      "name": "thread_dynamic_context_file_states",
+      "columns": {
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_status": {
+          "name": "content_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shown_at": {
+          "name": "shown_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "thread_dynamic_context_file_states_thread_file_idx": {
+          "name": "thread_dynamic_context_file_states_thread_file_idx",
+          "columns": [
+            "thread_id",
+            "file_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "thread_dynamic_context_file_states_thread_id_threads_id_fk": {
+          "name": "thread_dynamic_context_file_states_thread_id_threads_id_fk",
+          "tableFrom": "thread_dynamic_context_file_states",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thread_search_segments": {
+      "name": "thread_search_segments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_seq": {
+          "name": "source_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "thread_search_segments_source_idx": {
+          "name": "thread_search_segments_source_idx",
+          "columns": [
+            "thread_id",
+            "source_kind",
+            "source_key"
+          ],
+          "isUnique": true
+        },
+        "thread_search_segments_thread_source_seq_idx": {
+          "name": "thread_search_segments_thread_source_seq_idx",
+          "columns": [
+            "thread_id",
+            "source_seq"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "thread_search_segments_thread_id_threads_id_fk": {
+          "name": "thread_search_segments_thread_id_threads_id_fk",
+          "tableFrom": "thread_search_segments",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thread_sections": {
+      "name": "thread_sections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "thread_sections_name_idx": {
+          "name": "thread_sections_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thread_tabs": {
+      "name": "thread_tabs",
+      "columns": {
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tabs_json": {
+          "name": "tabs_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "thread_tabs_thread_id_threads_id_fk": {
+          "name": "thread_tabs_thread_id_threads_id_fk",
+          "tableFrom": "thread_tabs",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "threads": {
+      "name": "threads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_override": {
+          "name": "model_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reasoning_level_override": {
+          "name": "reasoning_level_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title_fallback": {
+          "name": "title_fallback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'starting'"
+        },
+        "pending_start_context": {
+          "name": "pending_start_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_thread_id": {
+          "name": "parent_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_thread_id": {
+          "name": "source_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "origin_kind": {
+          "name": "origin_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "origin_plugin_id": {
+          "name": "origin_plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'visible'"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pin_sort_key": {
+          "name": "pin_sort_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latest_attention_at": {
+          "name": "latest_attention_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "threads_project_updated_idx": {
+          "name": "threads_project_updated_idx",
+          "columns": [
+            "project_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "threads_project_archived_deleted_idx": {
+          "name": "threads_project_archived_deleted_idx",
+          "columns": [
+            "project_id",
+            "archived_at",
+            "deleted_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "threads_pin_sort_idx": {
+          "name": "threads_pin_sort_idx",
+          "columns": [
+            "archived_at",
+            "deleted_at",
+            "pin_sort_key",
+            "id"
+          ],
+          "isUnique": false,
+          "where": "\"threads\".\"pinned_at\" IS NOT NULL"
+        },
+        "threads_environment_idx": {
+          "name": "threads_environment_idx",
+          "columns": [
+            "environment_id"
+          ],
+          "isUnique": false
+        },
+        "threads_parent_idx": {
+          "name": "threads_parent_idx",
+          "columns": [
+            "parent_thread_id"
+          ],
+          "isUnique": false
+        },
+        "threads_source_origin_idx": {
+          "name": "threads_source_origin_idx",
+          "columns": [
+            "source_thread_id",
+            "origin_kind"
+          ],
+          "isUnique": false
+        },
+        "threads_origin_plugin_archived_idx": {
+          "name": "threads_origin_plugin_archived_idx",
+          "columns": [
+            "origin_plugin_id",
+            "archived_at"
+          ],
+          "isUnique": false
+        },
+        "threads_section_archived_deleted_idx": {
+          "name": "threads_section_archived_deleted_idx",
+          "columns": [
+            "section_id",
+            "archived_at",
+            "deleted_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "threads_archived_status_idx": {
+          "name": "threads_archived_status_idx",
+          "columns": [
+            "archived_at",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "threads_environment_archived_deleted_idx": {
+          "name": "threads_environment_archived_deleted_idx",
+          "columns": [
+            "environment_id",
+            "archived_at",
+            "deleted_at"
+          ],
+          "isUnique": false
+        },
+        "threads_active_maintenance_idx": {
+          "name": "threads_active_maintenance_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false,
+          "where": "\"threads\".\"deleted_at\" IS NULL"
+        }
+      },
+      "foreignKeys": {
+        "threads_project_id_projects_id_fk": {
+          "name": "threads_project_id_projects_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "threads_environment_id_environments_id_fk": {
+          "name": "threads_environment_id_environments_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "threads_section_id_thread_sections_id_fk": {
+          "name": "threads_section_id_thread_sections_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "thread_sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "threads_parent_thread_id_threads_id_fk": {
+          "name": "threads_parent_thread_id_threads_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "parent_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "threads_source_thread_id_threads_id_fk": {
+          "name": "threads_source_thread_id_threads_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "source_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -792,6 +792,13 @@
       "when": 1788280102293,
       "tag": "0112_steer_on_enter_default",
       "breakpoints": true
+    },
+    {
+      "idx": 113,
+      "version": "6",
+      "when": 1788333780337,
+      "tag": "0113_graceful_mojo",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/data/events.ts
+++ b/packages/db/src/data/events.ts
@@ -59,6 +59,11 @@ import {
   upsertThreadSearchSegments,
   type UpsertThreadSearchSegmentInput,
 } from "./threads.js";
+import {
+  hydrateRetainedEventOutputRows,
+  insertPreparedRetainedEventOutput,
+  prepareCompletedEventOutputData,
+} from "./retained-event-outputs.js";
 
 const STORED_EVENT_SEQUENCE_LOOKUP_CHUNK_SIZE = 250;
 export const STORED_TIMELINE_BYTE_PREFLIGHT_EVENT_LIMIT = 2_000;
@@ -360,6 +365,68 @@ export interface ThreadTurnInterruptionEventState {
   threadId: string;
 }
 
+interface InsertStoredEventRowArgs {
+  conflict: "error" | "ignore";
+  createdAt: number;
+  data: string;
+  environmentId: string | null;
+  itemId: string | null;
+  itemKind: ThreadEventItemType | null;
+  parentToolCallId: string | null;
+  providerThreadId: string | null;
+  scopeKind: ThreadEventScopeKind;
+  sequence: number;
+  threadId: string;
+  turnId: string | null;
+  type: ThreadEventType;
+}
+
+interface InsertStoredEventRowResult {
+  inserted: boolean;
+}
+
+function insertStoredEventRow(
+  db: DbQueryConnection,
+  args: InsertStoredEventRowArgs,
+): InsertStoredEventRowResult {
+  const id = createEventId();
+  const prepared = prepareCompletedEventOutputData({
+    createdAt: args.createdAt,
+    data: args.data,
+    itemKind: args.itemKind,
+    type: args.type,
+  });
+  const insert =
+    args.conflict === "ignore" ? sql`INSERT OR IGNORE` : sql`INSERT`;
+  const result = db.run(sql`${insert} INTO events
+    (id, thread_id, environment_id, scope_kind, turn_id, provider_thread_id, sequence, type, item_id, item_kind, parent_tool_call_id, data, created_at)
+    VALUES (
+      ${id},
+      ${args.threadId},
+      ${args.environmentId},
+      ${args.scopeKind},
+      ${args.turnId},
+      ${args.providerThreadId},
+      ${args.sequence},
+      ${args.type},
+      ${args.itemId},
+      ${args.itemKind},
+      ${args.parentToolCallId},
+      ${prepared.data},
+      ${args.createdAt}
+    )`);
+  if (result.changes === 0) {
+    return { inserted: false };
+  }
+  if (prepared.retainedOutput !== null) {
+    insertPreparedRetainedEventOutput(db, {
+      eventId: id,
+      output: prepared.retainedOutput,
+    });
+  }
+  return { inserted: true };
+}
+
 export function insertEvents(
   db: DbQueryConnection,
   notifier: DbNotifier,
@@ -378,14 +445,24 @@ export function insertEvents(
   const eventTypesByThreadId = new Map<string, Set<ThreadEventType>>();
 
   for (const [index, input] of eventInputs.entries()) {
-    const id = createEventId();
     const createdAt = input.createdAt ?? Date.now();
     const turnId = getThreadEventScopeTurnId(input.scope) ?? null;
-    const result = db.run(
-      sql`INSERT OR IGNORE INTO events (id, thread_id, environment_id, scope_kind, turn_id, provider_thread_id, sequence, type, item_id, item_kind, parent_tool_call_id, data, created_at)
-          VALUES (${id}, ${input.threadId}, ${input.environmentId ?? null}, ${input.scope.kind}, ${turnId}, ${input.providerThreadId ?? null}, ${input.sequence}, ${input.type}, ${input.itemId}, ${input.itemKind}, ${input.parentToolCallId}, ${input.data}, ${createdAt})`,
-    );
-    if (result.changes > 0) {
+    const result = insertStoredEventRow(db, {
+      conflict: "ignore",
+      createdAt,
+      data: input.data,
+      environmentId: input.environmentId ?? null,
+      itemId: input.itemId,
+      itemKind: input.itemKind,
+      parentToolCallId: input.parentToolCallId,
+      providerThreadId: input.providerThreadId ?? null,
+      scopeKind: input.scope.kind,
+      sequence: input.sequence,
+      threadId: input.threadId,
+      turnId,
+      type: input.type,
+    });
+    if (result.inserted) {
       insertedCount++;
       insertedInputIndexes.push(index);
       const eventTypes = eventTypesByThreadId.get(input.threadId);
@@ -697,25 +774,21 @@ export function appendDaemonEventsInTransaction(
     if (sequence === undefined) {
       throw new Error(`Missing event sequence for thread: ${input.threadId}`);
     }
-    db.run(
-      sql`INSERT INTO events
-        (id, thread_id, environment_id, scope_kind, turn_id, provider_thread_id, sequence, type, item_id, item_kind, parent_tool_call_id, data, created_at)
-        VALUES (
-          ${createEventId()},
-          ${input.threadId},
-          ${input.environmentId},
-          ${input.scope.kind},
-          ${turnId},
-          ${input.providerThreadId},
-          ${sequence},
-          ${input.type},
-          ${input.itemId},
-          ${input.itemKind},
-          ${input.parentToolCallId},
-          ${input.data},
-          ${now}
-        )`,
-    );
+    insertStoredEventRow(db, {
+      conflict: "error",
+      createdAt: now,
+      data: input.data,
+      environmentId: input.environmentId,
+      itemId: input.itemId,
+      itemKind: input.itemKind,
+      parentToolCallId: input.parentToolCallId,
+      providerThreadId: input.providerThreadId,
+      scopeKind: input.scope.kind,
+      sequence,
+      threadId: input.threadId,
+      turnId,
+      type: input.type,
+    });
     const event = parseDaemonThreadEvent(input);
     if (event !== null) {
       upsertThreadSearchSegments(db, {
@@ -767,26 +840,23 @@ export function copyStoredThreadEventsInTransaction(
   const highWaterMarks = getHighWaterMarks(db, [args.targetThreadId]);
   let sequence = (highWaterMarks[args.targetThreadId] ?? 0) + 1;
   const now = Date.now();
-  for (const row of args.rows) {
-    db.run(
-      sql`INSERT INTO events
-        (id, thread_id, environment_id, scope_kind, turn_id, provider_thread_id, sequence, type, item_id, item_kind, parent_tool_call_id, data, created_at)
-        VALUES (
-          ${createEventId()},
-          ${args.targetThreadId},
-          ${args.targetEnvironmentId},
-          ${row.scopeKind},
-          ${row.turnId},
-          ${row.providerThreadId},
-          ${sequence},
-          ${row.type},
-          ${row.itemId},
-          ${row.itemKind},
-          ${row.parentToolCallId},
-          ${row.data},
-          ${row.createdAt}
-        )`,
-    );
+  const hydratedRows = hydrateRetainedEventOutputRows(db, args.rows, now);
+  for (const row of hydratedRows) {
+    insertStoredEventRow(db, {
+      conflict: "error",
+      createdAt: row.createdAt,
+      data: row.data,
+      environmentId: args.targetEnvironmentId,
+      itemId: row.itemId,
+      itemKind: row.itemKind,
+      parentToolCallId: row.parentToolCallId,
+      providerThreadId: row.providerThreadId,
+      scopeKind: row.scopeKind,
+      sequence,
+      threadId: args.targetThreadId,
+      turnId: row.turnId,
+      type: row.type,
+    });
     const event = parseDaemonThreadEvent({
       data: row.data,
       environmentId: args.targetEnvironmentId,
@@ -865,25 +935,21 @@ export function appendStoredThreadEventsInTransaction(
     });
     const turnId = getThreadEventScopeTurnId(args.scope) ?? null;
 
-    db.run(
-      sql`INSERT INTO events
-        (id, thread_id, environment_id, scope_kind, turn_id, provider_thread_id, sequence, type, item_id, item_kind, parent_tool_call_id, data, created_at)
-        VALUES (
-          ${createEventId()},
-          ${args.threadId},
-          ${args.environmentId ?? null},
-          ${args.scope.kind},
-          ${turnId},
-          ${args.providerThreadId ?? null},
-          ${sequence},
-          ${args.type},
-          ${itemFields.itemId},
-          ${itemFields.itemKind},
-          ${itemFields.parentToolCallId},
-          ${JSON.stringify(args.data)},
-          ${now}
-        )`,
-    );
+    insertStoredEventRow(db, {
+      conflict: "error",
+      createdAt: now,
+      data: JSON.stringify(args.data),
+      environmentId: args.environmentId ?? null,
+      itemId: itemFields.itemId,
+      itemKind: itemFields.itemKind,
+      parentToolCallId: itemFields.parentToolCallId,
+      providerThreadId: args.providerThreadId ?? null,
+      scopeKind: args.scope.kind,
+      sequence,
+      threadId: args.threadId,
+      turnId,
+      type: args.type,
+    });
     upsertThreadSearchSegments(db, {
       updatedAt: now,
       segments: listThreadSearchSegmentsForStoredEventArgs({

--- a/packages/db/src/data/index.ts
+++ b/packages/db/src/data/index.ts
@@ -312,8 +312,12 @@ export {
 export {
   deleteExpiredRetainedEventOutputs,
   hydrateRetainedEventOutputRows,
+  RETAINED_EVENT_OUTPUT_TARGETS,
 } from "./retained-event-outputs.js";
-export type { DeleteExpiredRetainedEventOutputsResult } from "./retained-event-outputs.js";
+export type {
+  DeleteExpiredRetainedEventOutputsResult,
+  RetainedEventOutputTarget,
+} from "./retained-event-outputs.js";
 export type {
   AcceptedDaemonEvent,
   AppendDaemonEventInput,

--- a/packages/db/src/data/index.ts
+++ b/packages/db/src/data/index.ts
@@ -309,6 +309,11 @@ export {
   pruneResolvedItemDeltas,
   pruneThreadEventsBeforeSequence,
 } from "./events.js";
+export {
+  deleteExpiredRetainedEventOutputs,
+  hydrateRetainedEventOutputRows,
+} from "./retained-event-outputs.js";
+export type { DeleteExpiredRetainedEventOutputsResult } from "./retained-event-outputs.js";
 export type {
   AcceptedDaemonEvent,
   AppendDaemonEventInput,

--- a/packages/db/src/data/retained-event-outputs.ts
+++ b/packages/db/src/data/retained-event-outputs.ts
@@ -1,0 +1,266 @@
+import { and, gt, inArray, lte } from "drizzle-orm";
+import type { ThreadEventItemType, ThreadEventType } from "@bb/domain";
+import type { DbQueryConnection } from "../connection.js";
+import type {
+  RetainedEventOutputItemKind,
+  RetainedEventOutputPath,
+} from "../retained-event-output.js";
+import { retainedEventOutputs } from "../schema.js";
+import {
+  COMPLETED_EVENT_OUTPUT_RETAINED_HEAD_CHARS,
+  COMPLETED_EVENT_OUTPUT_RETAINED_TAIL_CHARS,
+  COMPLETED_EVENT_OUTPUT_RETENTION_MS,
+  COMPLETED_EVENT_OUTPUT_TRUNCATION_THRESHOLD_CHARS,
+} from "./sweeps.js";
+
+const COMPLETED_EVENT_OUTPUT_TRUNCATION_MARKER =
+  "\n\n[... output truncated by retention policy; showing beginning and end ...]\n\n";
+const RETAINED_EVENT_OUTPUT_LOOKUP_BATCH_SIZE = 100;
+
+export interface RetainedEventOutputTarget {
+  itemKind: RetainedEventOutputItemKind;
+  outputPath: RetainedEventOutputPath;
+}
+
+export const RETAINED_EVENT_OUTPUT_TARGETS = [
+  { itemKind: "commandExecution", outputPath: "aggregatedOutput" },
+  { itemKind: "toolCall", outputPath: "result" },
+  { itemKind: "webFetch", outputPath: "resultText" },
+  { itemKind: "webSearch", outputPath: "resultText" },
+] as const satisfies readonly RetainedEventOutputTarget[];
+
+interface PreparedRetainedEventOutput {
+  expiresAt: number;
+  outputPath: RetainedEventOutputPath;
+  value: string;
+}
+
+export interface PreparedCompletedEventOutputData {
+  data: string;
+  retainedOutput: PreparedRetainedEventOutput | null;
+}
+
+interface PrepareCompletedEventOutputDataArgs {
+  createdAt: number;
+  data: string;
+  itemKind: ThreadEventItemType | null;
+  type: ThreadEventType;
+}
+
+interface InsertPreparedRetainedEventOutputArgs {
+  eventId: string;
+  output: PreparedRetainedEventOutput;
+}
+
+interface HydratableStoredEventRow {
+  data: string;
+  id: string;
+}
+
+interface RetainedEventOutputHydrationRow {
+  eventId: string;
+  outputPath: RetainedEventOutputPath;
+  value: string;
+}
+
+interface DeleteExpiredRetainedEventOutputsArgs {
+  expiredAtOrBefore: number;
+  limit: number;
+}
+
+export interface DeleteExpiredRetainedEventOutputsResult {
+  deleted: number;
+}
+
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function targetForItemKind(
+  itemKind: ThreadEventItemType | null,
+): RetainedEventOutputTarget | null {
+  return (
+    RETAINED_EVENT_OUTPUT_TARGETS.find(
+      (target) => target.itemKind === itemKind,
+    ) ?? null
+  );
+}
+
+function truncateOutput(value: string): string {
+  return (
+    value.slice(0, COMPLETED_EVENT_OUTPUT_RETAINED_HEAD_CHARS) +
+    COMPLETED_EVENT_OUTPUT_TRUNCATION_MARKER +
+    value.slice(-COMPLETED_EVENT_OUTPUT_RETAINED_TAIL_CHARS)
+  );
+}
+
+export function prepareCompletedEventOutputData(
+  args: PrepareCompletedEventOutputDataArgs,
+): PreparedCompletedEventOutputData {
+  const target =
+    args.type === "item/completed" ? targetForItemKind(args.itemKind) : null;
+  if (
+    target === null ||
+    args.data.length <= COMPLETED_EVENT_OUTPUT_TRUNCATION_THRESHOLD_CHARS
+  ) {
+    return { data: args.data, retainedOutput: null };
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(args.data);
+  } catch {
+    return { data: args.data, retainedOutput: null };
+  }
+  if (!isJsonObject(payload) || !isJsonObject(payload.item)) {
+    return { data: args.data, retainedOutput: null };
+  }
+  const item = payload.item;
+  const value = item[target.outputPath];
+  if (
+    item.type !== target.itemKind ||
+    typeof value !== "string" ||
+    value.length <= COMPLETED_EVENT_OUTPUT_TRUNCATION_THRESHOLD_CHARS
+  ) {
+    return { data: args.data, retainedOutput: null };
+  }
+  const existingTruncation = item.truncation;
+  if (
+    isJsonObject(existingTruncation) &&
+    existingTruncation[target.outputPath] !== undefined
+  ) {
+    return { data: args.data, retainedOutput: null };
+  }
+
+  const expiresAt = args.createdAt + COMPLETED_EVENT_OUTPUT_RETENTION_MS;
+  const truncation = isJsonObject(existingTruncation) ? existingTruncation : {};
+  item[target.outputPath] = truncateOutput(value);
+  truncation[target.outputPath] = {
+    originalLength: value.length,
+    retainedHeadLength: COMPLETED_EVENT_OUTPUT_RETAINED_HEAD_CHARS,
+    retainedTailLength: COMPLETED_EVENT_OUTPUT_RETAINED_TAIL_CHARS,
+    truncatedAt: expiresAt,
+  };
+  item.truncation = truncation;
+
+  return {
+    data: JSON.stringify(payload),
+    retainedOutput: {
+      expiresAt,
+      outputPath: target.outputPath,
+      value,
+    },
+  };
+}
+
+export function insertPreparedRetainedEventOutput(
+  db: DbQueryConnection,
+  args: InsertPreparedRetainedEventOutputArgs,
+): void {
+  db.insert(retainedEventOutputs)
+    .values({
+      eventId: args.eventId,
+      expiresAt: args.output.expiresAt,
+      outputPath: args.output.outputPath,
+      value: args.output.value,
+    })
+    .onConflictDoNothing()
+    .run();
+}
+
+function hydrateEventData(
+  data: string,
+  output: RetainedEventOutputHydrationRow,
+): string {
+  const payload: unknown = JSON.parse(data);
+  if (!isJsonObject(payload) || !isJsonObject(payload.item)) {
+    throw new Error("Retained output event payload is not an item object");
+  }
+  const item = payload.item;
+  item[output.outputPath] = output.value;
+  const truncation = item.truncation;
+  if (isJsonObject(truncation)) {
+    delete truncation[output.outputPath];
+    if (Object.keys(truncation).length === 0) {
+      delete item.truncation;
+    }
+  }
+  return JSON.stringify(payload);
+}
+
+export function hydrateRetainedEventOutputRows<
+  TRow extends HydratableStoredEventRow,
+>(
+  db: DbQueryConnection,
+  rows: readonly TRow[],
+  now: number = Date.now(),
+): TRow[] {
+  if (rows.length === 0) {
+    return [];
+  }
+  const eventIds = [...new Set(rows.map((row) => row.id))];
+  const outputs: RetainedEventOutputHydrationRow[] = [];
+  for (
+    let start = 0;
+    start < eventIds.length;
+    start += RETAINED_EVENT_OUTPUT_LOOKUP_BATCH_SIZE
+  ) {
+    outputs.push(
+      ...db
+        .select({
+          eventId: retainedEventOutputs.eventId,
+          outputPath: retainedEventOutputs.outputPath,
+          value: retainedEventOutputs.value,
+        })
+        .from(retainedEventOutputs)
+        .where(
+          and(
+            inArray(
+              retainedEventOutputs.eventId,
+              eventIds.slice(
+                start,
+                start + RETAINED_EVENT_OUTPUT_LOOKUP_BATCH_SIZE,
+              ),
+            ),
+            gt(retainedEventOutputs.expiresAt, now),
+          ),
+        )
+        .all(),
+    );
+  }
+  if (outputs.length === 0) {
+    return [...rows];
+  }
+  const outputsByEventId = new Map(
+    outputs.map((output) => [output.eventId, output]),
+  );
+  return rows.map((row) => {
+    const output = outputsByEventId.get(row.id);
+    return output ? { ...row, data: hydrateEventData(row.data, output) } : row;
+  });
+}
+
+export function deleteExpiredRetainedEventOutputs(
+  db: DbQueryConnection,
+  args: DeleteExpiredRetainedEventOutputsArgs,
+): DeleteExpiredRetainedEventOutputsResult {
+  if (args.limit <= 0) {
+    return { deleted: 0 };
+  }
+  const eventIds = db
+    .select({ eventId: retainedEventOutputs.eventId })
+    .from(retainedEventOutputs)
+    .where(lte(retainedEventOutputs.expiresAt, args.expiredAtOrBefore))
+    .orderBy(retainedEventOutputs.expiresAt, retainedEventOutputs.eventId)
+    .limit(args.limit)
+    .all()
+    .map((row) => row.eventId);
+  if (eventIds.length === 0) {
+    return { deleted: 0 };
+  }
+  const result = db
+    .delete(retainedEventOutputs)
+    .where(inArray(retainedEventOutputs.eventId, eventIds))
+    .run();
+  return { deleted: result.changes };
+}

--- a/packages/db/src/retained-event-output.ts
+++ b/packages/db/src/retained-event-output.ts
@@ -1,0 +1,11 @@
+import type { ThreadEventItemType } from "@bb/domain";
+
+export type RetainedEventOutputItemKind = Extract<
+  ThreadEventItemType,
+  "commandExecution" | "toolCall" | "webFetch" | "webSearch"
+>;
+
+export type RetainedEventOutputPath =
+  | "aggregatedOutput"
+  | "result"
+  | "resultText";

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -35,6 +35,7 @@ import type {
   WorkspaceProvisionType,
   ProjectKind,
 } from "@bb/domain";
+import type { RetainedEventOutputPath } from "./retained-event-output.js";
 
 export const authUsers = sqliteTable(
   "user",
@@ -737,6 +738,24 @@ export const events = sqliteTable(
         OR
         (${table.scopeKind} = 'thread' AND ${table.turnId} IS NULL)
       )`,
+    ),
+  ],
+);
+
+export const retainedEventOutputs = sqliteTable(
+  "retained_event_outputs",
+  {
+    eventId: text("event_id")
+      .primaryKey()
+      .references(() => events.id, { onDelete: "cascade" }),
+    outputPath: text("output_path").$type<RetainedEventOutputPath>().notNull(),
+    value: text("value").notNull(),
+    expiresAt: integer("expires_at").notNull(),
+  },
+  (table) => [
+    index("retained_event_outputs_expiry_idx").on(
+      table.expiresAt,
+      table.eventId,
     ),
   ],
 );

--- a/packages/db/test/data/retained-event-outputs.test.ts
+++ b/packages/db/test/data/retained-event-outputs.test.ts
@@ -1,0 +1,228 @@
+import { turnScope } from "@bb/domain";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  copyStoredThreadEventsInTransaction,
+  insertEvents,
+  listStoredEventRows,
+} from "../../src/data/events.js";
+import type { InsertEventInput } from "../../src/data/events.js";
+import { upsertHost } from "../../src/data/hosts.js";
+import { createProject } from "../../src/data/projects.js";
+import {
+  deleteExpiredRetainedEventOutputs,
+  hydrateRetainedEventOutputRows,
+} from "../../src/data/retained-event-outputs.js";
+import {
+  COMPLETED_EVENT_OUTPUT_RETAINED_HEAD_CHARS,
+  COMPLETED_EVENT_OUTPUT_RETAINED_TAIL_CHARS,
+  COMPLETED_EVENT_OUTPUT_RETENTION_MS,
+  COMPLETED_EVENT_OUTPUT_TRUNCATION_THRESHOLD_CHARS,
+} from "../../src/data/sweeps.js";
+import { createThread } from "../../src/data/threads.js";
+import { noopNotifier } from "../../src/notifier.js";
+import { createMigratedConnection } from "../helpers/migrated-connection.js";
+
+function setup() {
+  const db = createMigratedConnection();
+  const host = upsertHost(db, noopNotifier, {
+    name: "retained-output-host",
+    type: "persistent",
+  });
+  const { project } = createProject(db, noopNotifier, {
+    name: "retained-output-project",
+    source: {
+      type: "local_path",
+      hostId: host.id,
+      path: "/tmp/retained-output",
+    },
+  });
+  const source = createThread(db, noopNotifier, {
+    projectId: project.id,
+    providerId: "codex",
+  });
+  const target = createThread(db, noopNotifier, {
+    projectId: project.id,
+    providerId: "codex",
+  });
+  return { db, source, target };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readOutput(data: string, path: string): string {
+  const parsed: unknown = JSON.parse(data);
+  if (!isRecord(parsed) || !isRecord(parsed.item)) {
+    throw new Error(`Expected string output at ${path}`);
+  }
+  const output = parsed.item[path];
+  if (typeof output !== "string") {
+    throw new Error(`Expected string output at ${path}`);
+  }
+  return output;
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("retained completed-event outputs", () => {
+  it("stores a bounded preview and hydrates the full output until expiry", () => {
+    const now = 1_800_000_000_000;
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    const { db, source } = setup();
+    const output =
+      "head-" +
+      "x".repeat(COMPLETED_EVENT_OUTPUT_TRUNCATION_THRESHOLD_CHARS) +
+      "-tail";
+
+    insertEvents(db, noopNotifier, [
+      {
+        createdAt: now,
+        data: JSON.stringify({
+          item: {
+            aggregatedOutput: output,
+            approvalStatus: null,
+            command: "cat large",
+            cwd: "/tmp/retained-output",
+            exitCode: 0,
+            id: "command-1",
+            status: "completed",
+            type: "commandExecution",
+          },
+        }),
+        itemId: "command-1",
+        itemKind: "commandExecution",
+        parentToolCallId: null,
+        scope: turnScope("turn-1"),
+        sequence: 1,
+        threadId: source.id,
+        type: "item/completed",
+      },
+    ]);
+
+    const [stored] = listStoredEventRows(db, { threadId: source.id });
+    if (!stored) {
+      throw new Error("Expected stored event");
+    }
+    const preview = readOutput(stored.data, "aggregatedOutput");
+    expect(preview).not.toBe(output);
+    expect(preview.startsWith(output.slice(0, 2_048))).toBe(true);
+    expect(preview.endsWith(output.slice(-2_048))).toBe(true);
+    expect(preview.length).toBe(
+      COMPLETED_EVENT_OUTPUT_RETAINED_HEAD_CHARS +
+        COMPLETED_EVENT_OUTPUT_RETAINED_TAIL_CHARS +
+        77,
+    );
+
+    const [hydrated] = hydrateRetainedEventOutputRows(db, [stored], now);
+    expect(hydrated && readOutput(hydrated.data, "aggregatedOutput")).toBe(
+      output,
+    );
+    expect(JSON.parse(hydrated?.data ?? "{}").item.truncation).toBeUndefined();
+
+    const [expired] = hydrateRetainedEventOutputRows(
+      db,
+      [stored],
+      now + COMPLETED_EVENT_OUTPUT_RETENTION_MS,
+    );
+    expect(expired?.data).toBe(stored.data);
+    db.$client.close();
+  });
+
+  it("copies a retained output without losing the full value", () => {
+    const now = 1_800_000_000_000;
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    const { db, source, target } = setup();
+    const output = "copy-" + "y".repeat(50_000);
+    insertEvents(db, noopNotifier, [
+      {
+        createdAt: now,
+        data: JSON.stringify({
+          item: {
+            id: "tool-1",
+            result: output,
+            status: "completed",
+            tool: "read_many",
+            type: "toolCall",
+          },
+        }),
+        itemId: "tool-1",
+        itemKind: "toolCall",
+        parentToolCallId: null,
+        scope: turnScope("turn-1"),
+        sequence: 1,
+        threadId: source.id,
+        type: "item/completed",
+      },
+    ]);
+    const sourceRows = listStoredEventRows(db, { threadId: source.id });
+
+    db.transaction(
+      (tx) =>
+        copyStoredThreadEventsInTransaction(tx, {
+          rows: sourceRows,
+          targetEnvironmentId: null,
+          targetThreadId: target.id,
+        }),
+      { behavior: "immediate" },
+    );
+
+    const targetRows = listStoredEventRows(db, { threadId: target.id });
+    const [hydratedTarget] = hydrateRetainedEventOutputRows(
+      db,
+      targetRows,
+      now,
+    );
+    expect(hydratedTarget && readOutput(hydratedTarget.data, "result")).toBe(
+      output,
+    );
+    expect(targetRows[0]?.data).not.toContain(output);
+    db.$client.close();
+  });
+
+  it("deletes a bounded number of expired sidecars without deleting previews", () => {
+    const now = 1_800_000_000_000;
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    const { db, source } = setup();
+    const output = "z".repeat(50_000);
+    const eventInputs: InsertEventInput[] = [1, 2].map((sequence) => ({
+      createdAt: now,
+      data: JSON.stringify({
+        item: {
+          aggregatedOutput: output,
+          id: `command-${sequence}`,
+          type: "commandExecution",
+        },
+      }),
+      itemId: `command-${sequence}`,
+      itemKind: "commandExecution",
+      parentToolCallId: null,
+      scope: turnScope("turn-1"),
+      sequence,
+      threadId: source.id,
+      type: "item/completed",
+    }));
+    insertEvents(db, noopNotifier, eventInputs);
+    const previews = listStoredEventRows(db, { threadId: source.id });
+
+    expect(
+      deleteExpiredRetainedEventOutputs(db, {
+        expiredAtOrBefore: now + COMPLETED_EVENT_OUTPUT_RETENTION_MS,
+        limit: 1,
+      }),
+    ).toEqual({ deleted: 1 });
+    expect(listStoredEventRows(db, { threadId: source.id })).toEqual(previews);
+    const hydrated = hydrateRetainedEventOutputRows(db, previews, now);
+    expect(
+      hydrated.filter(
+        (row) => readOutput(row.data, "aggregatedOutput") === output,
+      ),
+    ).toHaveLength(1);
+    db.$client.close();
+  });
+});

--- a/packages/db/test/migrate.test.ts
+++ b/packages/db/test/migrate.test.ts
@@ -206,6 +206,13 @@ interface TableInfoRow {
   notnull: number;
 }
 
+interface ForeignKeyRow {
+  childColumn: string;
+  onDelete: string;
+  parentColumn: string;
+  parentTable: string;
+}
+
 interface ReadIndexNamesArgs {
   db: DbConnection;
   tableName: string;
@@ -453,6 +460,12 @@ const steerOnEnterDefaultMigrationPath = resolve(
   "drizzle",
   "0112_steer_on_enter_default.sql",
 );
+const retainedEventOutputsMigrationPath = resolve(
+  __dirname,
+  "..",
+  "drizzle",
+  "0113_graceful_mojo.sql",
+);
 const providerSettingsToPluginsMigrationPath = resolve(
   __dirname,
   "..",
@@ -646,6 +659,7 @@ function dropMarketplaceCatalogSchema(db: DbConnection): void {
 }
 
 function dropEventToolNameColumn(db: DbConnection): void {
+  db.$client.prepare("DROP TABLE IF EXISTS retained_event_outputs").run();
   dropThreadConversationOutlinesTable(db);
   db.$client.exec("DROP INDEX IF EXISTS events_delegating_item_lookup_idx");
   db.$client.exec("DROP INDEX IF EXISTS events_plan_steps_thread_sequence_idx");
@@ -1430,6 +1444,79 @@ function deleteDeferredCleanupMigrationRows(db: DbConnection): void {
 describe("migrate", () => {
   beforeAll(() => {
     prepareMigratedConnectionTemplate();
+  });
+
+  it("adds retained event outputs without rewriting existing events", () => {
+    const db = createMigratedConnection();
+
+    try {
+      const host = upsertHost(db, noopNotifier, {
+        id: "host-retained-output-migration",
+        name: "Migration Host",
+        type: "persistent",
+      });
+      const { project } = createProject(db, noopNotifier, {
+        name: "Migration Project",
+        source: {
+          type: "local_path",
+          hostId: host.id,
+          path: "/tmp/retained-output-migration",
+        },
+      });
+      const thread = createThread(db, noopNotifier, {
+        projectId: project.id,
+        providerId: "codex",
+      });
+      const eventData = JSON.stringify({ message: "existing event" });
+
+      db.$client.prepare("DROP TABLE retained_event_outputs").run();
+      db.$client
+        .prepare<[string, string, string]>(
+          `
+            INSERT INTO events (
+              id, thread_id, scope_kind, sequence, type, data, created_at
+            ) VALUES (?, ?, 'thread', 1, 'system/error', ?, 1234)
+          `,
+        )
+        .run("evt-retained-output-migration", thread.id, eventData);
+
+      runMigrationFile({
+        db,
+        migrationPath: retainedEventOutputsMigrationPath,
+      });
+
+      expect(
+        db.$client
+          .prepare<[], MigratedEventDataRow>(
+            "SELECT data FROM events WHERE id = 'evt-retained-output-migration'",
+          )
+          .get(),
+      ).toEqual({ data: eventData });
+      expect(
+        readIndexNames({ db, tableName: "retained_event_outputs" }),
+      ).toContain("retained_event_outputs_expiry_idx");
+      expect(
+        db.$client
+          .prepare<[], ForeignKeyRow>(
+            `
+              SELECT
+                "table" AS parentTable,
+                "from" AS childColumn,
+                "to" AS parentColumn,
+                on_delete AS onDelete
+              FROM pragma_foreign_key_list('retained_event_outputs')
+            `,
+          )
+          .get(),
+      ).toEqual({
+        childColumn: "event_id",
+        onDelete: "CASCADE",
+        parentColumn: "id",
+        parentTable: "events",
+      });
+    } finally {
+      closeConnection(db);
+    }
   });
 
   it("backfills the first checkout commit component for every artifact shape", () => {

--- a/packages/db/test/query-plans.test.ts
+++ b/packages/db/test/query-plans.test.ts
@@ -31,6 +31,10 @@ import {
   pruneClosedSessions,
   truncateCompletedEventItemOutputs,
 } from "../src/data/sweeps.js";
+import {
+  deleteExpiredRetainedEventOutputs,
+  hydrateRetainedEventOutputRows,
+} from "../src/data/retained-event-outputs.js";
 import { getDatabaseMaintenanceActivity } from "../src/data/maintenance.js";
 import { openSession } from "../src/data/sessions.js";
 import {
@@ -870,6 +874,120 @@ describe("slow query index plans", () => {
       debugLog,
       indexName: "events_completed_item_truncation_idx",
       params: ["item/completed", "commandExecution", createdBefore, 0, "", 10],
+    });
+
+    db.$client.close();
+  });
+
+  it("uses the retained-output primary key for hydration", () => {
+    const { db, logger, thread } = setup();
+    const now = 1_800_000_000_000;
+    insertEvents(db, noopNotifier, [
+      {
+        createdAt: now,
+        data: JSON.stringify({
+          item: {
+            aggregatedOutput: "x".repeat(
+              COMPLETED_EVENT_OUTPUT_TRUNCATION_THRESHOLD_CHARS + 1,
+            ),
+            id: "retained-hydration-plan",
+            type: "commandExecution",
+          },
+        }),
+        itemId: "retained-hydration-plan",
+        itemKind: "commandExecution",
+        parentToolCallId: null,
+        scope: turnScope("turn_retained_hydration_plan"),
+        sequence: 1,
+        threadId: thread.id,
+        type: "item/completed",
+      },
+    ]);
+    const [stored] = listStoredEventRows(db, { threadId: thread.id });
+    if (!stored) {
+      throw new Error("Expected retained hydration event");
+    }
+    logger.clear();
+
+    hydrateRetainedEventOutputRows(db, [stored], now);
+
+    const debugLog = findOnlyDebugLog({
+      logger,
+      predicate: (fields) =>
+        fields.operation === "all" &&
+        fields.sql.includes('from "retained_event_outputs"') &&
+        fields.sql.includes('"event_id" in'),
+    });
+    assertEmittedQueryPlanUsesIndex({
+      db,
+      debugLog,
+      indexName: "sqlite_autoindex_retained_event_outputs_1",
+      params: [stored.id, now],
+    });
+
+    db.$client.close();
+  });
+
+  it("uses the expiry and primary-key indexes for bounded cleanup", () => {
+    const { db, logger, thread } = setup();
+    const now = 1_800_000_000_000;
+    insertEvents(db, noopNotifier, [
+      {
+        createdAt: now,
+        data: JSON.stringify({
+          item: {
+            aggregatedOutput: "x".repeat(
+              COMPLETED_EVENT_OUTPUT_TRUNCATION_THRESHOLD_CHARS + 1,
+            ),
+            id: "retained-expiry-plan",
+            type: "commandExecution",
+          },
+        }),
+        itemId: "retained-expiry-plan",
+        itemKind: "commandExecution",
+        parentToolCallId: null,
+        scope: turnScope("turn_retained_expiry_plan"),
+        sequence: 1,
+        threadId: thread.id,
+        type: "item/completed",
+      },
+    ]);
+    const [stored] = listStoredEventRows(db, { threadId: thread.id });
+    if (!stored) {
+      throw new Error("Expected retained expiry event");
+    }
+    const expiredAtOrBefore = Number.MAX_SAFE_INTEGER;
+    logger.clear();
+
+    deleteExpiredRetainedEventOutputs(db, {
+      expiredAtOrBefore,
+      limit: 1,
+    });
+
+    const selection = findOnlyDebugLog({
+      logger,
+      predicate: (fields) =>
+        fields.operation === "all" &&
+        fields.sql.includes('from "retained_event_outputs"') &&
+        fields.sql.includes('order by "retained_event_outputs"."expires_at"'),
+    });
+    assertEmittedQueryPlanUsesIndex({
+      db,
+      debugLog: selection,
+      indexName: "retained_event_outputs_expiry_idx",
+      params: [expiredAtOrBefore, 1],
+    });
+    const deletion = findOnlyDebugLog({
+      logger,
+      predicate: (fields) =>
+        fields.operation === "run" &&
+        fields.sql.startsWith('delete from "retained_event_outputs"'),
+    });
+    assertEmittedQueryPlanUsesIndex({
+      db,
+      debugLog: deletion,
+      indexName: "sqlite_autoindex_retained_event_outputs_1",
+      params: [stored.id],
     });
 
     db.$client.close();


### PR DESCRIPTION
## Human comments

## What was wrong

Completed command and tool outputs were stored inline in `events.data`, so every ordinary timeline/event-row scan had to read and transform large values even though the normal product surface only renders a bounded preview. The existing delayed truncation sweep eventually reduced old rows, but new large completions still imposed their full materialization and main-event-loop cost throughout the retention window, while there was no separate short-lived source from which explicit raw/detail reads or event copies could recover the complete value.

## What changed

- New large `item/completed` outputs for `commandExecution.aggregatedOutput`, `toolCall.result`, and `webFetch`/`webSearch.resultText` now store a 2 KiB head + 2 KiB tail preview in the ordinary event row and the full string in a one-row-per-event sidecar for seven days. The existing 32 KiB eligibility threshold and retention constants are shared with the current storage policy.
- A single insertion seam covers direct event inserts, daemon appends, and stored event appends. It only creates a sidecar after the event insert succeeds, so ignored sequence duplicates do not leave orphan data.
- Raw event reads, explicit uncapped timeline reads, and turn-summary details hydrate retained values. Detail hydration keeps the existing 4 MiB response guard. Fork/copy insertion hydrates the source and re-applies the original event timestamp, so copying is lossless while retained without extending expiry.
- Expiry selects by `(expires_at, event_id)` and deletes one sidecar per periodic retention tick. It never rewrites or deletes the ordinary event preview. Hydration uses bounded batches of 100 IDs and the event-ID primary key.
- `RetainedEventOutputTarget` and the authoritative four-entry `RETAINED_EVENT_OUTPUT_TARGETS` are exported from the local data module for the separately scoped legacy-migration work, without expanding the root `@bb/db` API.
- Drizzle generated `0113_graceful_mojo.sql` and its snapshot from current `origin/main`; the migration only creates the sidecar and expiry index and does not migrate legacy inline values.

No host-daemon wire contract changed. This deliberately excludes legacy inline-output migration, destroyed-environment cleanup, watchers, outlines, timeline projection redesign, and background workers; all measured and production code remains synchronous on the Node main event loop.

## How you verified

The focused regressions were run red before their implementation and green afterward: the storage integration initially found the full value in `events.data`; uncapped timeline, raw-event, and detail reads initially returned the retained preview; copying initially lost the full value; and the periodic sweep initially left the expired sidecar in place.

- `pnpm exec turbo run test --filter=@bb/db --force` — 32 files, 450 tests passed, including in-memory SQLite storage/copy/expiry integration, the direct migration preservation/FK/index test, historical migration rewinds, and query-plan assertions for hydration selection, expiry selection, and primary-key deletion.
- `pnpm exec turbo run test --filter=@bb/server -- --run test/services/threads/timeline-in-turn-window.test.ts test/public/public-thread-timeline-output-preview.test.ts test/services/periodic-sweeps.test.ts` — 3 files, 42 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/db --filter=@bb/server` — passed.
- `pnpm exec turbo run build --filter=@bb/db --filter=@bb/server` — passed (`@bb/server` built; `@bb/db` has no build task).
- `git diff --check` and `origin/main...HEAD` scope inspection — clean, 17 files, only this PR.
- GitHub CI — build/typecheck/lint, server, package, integration, all three app shards, and Linux/macOS package smoke jobs passed.

### Controlled same-machine benchmark

The deterministic production-shaped fixture has 95 event rows over 12 turns (11 completed, one running), including 72 completed 65,536-character outputs (4,718,592 output characters). Reads used 12 warmups + 60 measured iterations; writes used eight warmups + 40 measured immediate transactions of four large completions. Both revisions ran the byte-identical harness (SHA-256 `16f0062baf584b30dde86e3777289b763bacec01ddd8b105c819c2175414dc07`) on the same arm64 macOS host under Node v22.23.1, with separate disposable SQLite databases and the repository's production WAL/cache/mmap settings. Percentiles use nearest rank.

| Main-loop workload latency, ms | origin/main p50/p95/max | branch p50/p95/max |
| --- | ---: | ---: |
| Normal bounded event read | 12.740 / 42.382 / 166.079 | 0.556 / 0.902 / 1.273 |
| Normal bounded timeline read | 29.161 / 42.752 / 47.202 | 2.441 / 5.857 / 7.343 |
| Raw event hydration read | 4.128 / 7.127 / 28.982 | 16.035 / 26.562 / 49.142 |
| Detail hydration read | 1.074 / 1.794 / 2.516 | 1.702 / 3.110 / 3.507 |
| Four-row write transaction | 1.787 / 10.157 / 11.006 | 1.423 / 5.929 / 6.215 |

| Zero-delay timer delay, ms | origin/main p50/p95/max | branch p50/p95/max |
| --- | ---: | ---: |
| Normal bounded event read | 13.191 / 42.412 / 169.818 | 0.960 / 1.970 / 4.080 |
| Normal bounded timeline read | 29.395 / 44.008 / 48.866 | 2.720 / 6.738 / 8.088 |
| Raw event hydration read | 4.230 / 7.474 / 29.023 | 16.527 / 26.618 / 49.178 |
| Detail hydration read | 1.343 / 2.789 / 3.074 | 1.912 / 3.524 / 4.890 |
| Four-row write transaction | 1.843 / 10.354 / 11.076 | 1.464 / 5.972 / 6.269 |

Bounded event/timeline selection held row/work counts at 95/6 while selected/materialized event data fell from 2,327,734 to 331,678 bytes (85.8% less); the timeline response fell from 198,652 to 31,480 bytes. Raw reads materialized 95 rows / 4,755,746 bytes / 4,718,592 output chars on both revisions. Detail reads materialized six work rows / 396,190 bytes / 393,216 output chars on both. Fixture event-row data fell from 4,739,518 to 331,678 bytes; the branch sidecar held 72 rows / 4,718,592 bytes, and the checkpointed DB grew from 5,414,912 to 5,771,264 bytes (6.6%) while both full and preview values coexist.

Raw, detail, and written full-output hashes exactly matched their deterministic expected hashes on both revisions (`dc1df...40a0`, `4b640e...68cb`, `e88059...35cf`). Bounded timeline identity hashes also matched (`7e5f41...fb5a`); preview hashes intentionally differ because the branch returns the storage contract's head-and-tail preview instead of the old prefix-only SQL cap.

Raw BB thread-storage artifacts: [comparison](https://ymichael.getbb.app/api/v1/threads/thr_pkwpa3qag4/thread-storage/files/benchmarks/comparison.md), [origin/main JSON](https://ymichael.getbb.app/api/v1/threads/thr_pkwpa3qag4/thread-storage/files/benchmarks/origin-main.json), [branch JSON](https://ymichael.getbb.app/api/v1/threads/thr_pkwpa3qag4/thread-storage/files/benchmarks/branch.json), [byte-identical harness](https://ymichael.getbb.app/api/v1/threads/thr_pkwpa3qag4/thread-storage/files/benchmarks/retained-event-output-benchmark.mjs), and [SHA-256 manifest](https://ymichael.getbb.app/api/v1/threads/thr_pkwpa3qag4/thread-storage/files/benchmarks/SHA256SUMS). They are also browsable from the [BB benchmark thread](https://ymichael.getbb.app/projects/proj_qrv2s45kmq/threads/thr_pkwpa3qag4).

Fixes: no linked issue.

> AGENT GENERATED
