### PR TITLE
Decode hex-encoded Claude Code Keychain credentials

### DIFF
--- a/plugins/provider-claude-code/src/bridge/provider-maintenance.test.ts
+++ b/plugins/provider-claude-code/src/bridge/provider-maintenance.test.ts
@@ -80,4 +80,25 @@ describe("Claude Code provider maintenance", () => {
       "https://claude.ai/install.sh",
     );
   });
+
+  it("decodes hex-encoded Claude Code keychain credentials", () => {
+    const credentials = {
+      claudeAiOauth: {
+        accessToken: "sk-ant-test",
+        expiresAt: 1_788_350_959_477,
+        subscriptionType: "team",
+        rateLimitTier: "default_claude_max_5x",
+      },
+    };
+    const hex = Buffer.from(JSON.stringify(credentials), "utf8").toString(
+      "hex",
+    );
+    expect(__testing.parseClaudeCredentials(hex)).toEqual(
+      credentials.claudeAiOauth,
+    );
+    expect(
+      __testing.parseClaudeCredentials(JSON.stringify(credentials)),
+    ).toEqual(credentials.claudeAiOauth);
+    expect(__testing.parseClaudeCredentials("not-credentials")).toBeNull();
+  });
 });

--- a/plugins/provider-claude-code/src/bridge/provider-maintenance.ts
+++ b/plugins/provider-claude-code/src/bridge/provider-maintenance.ts
@@ -257,21 +257,39 @@ async function readKeychainCredentials(): Promise<string | null> {
   return null;
 }
 
-async function readCredentials(): Promise<ClaudeCredentials | null> {
-  let raw = await readKeychainCredentials();
-  if (raw === null) {
+function decodeCredentialBlob(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    if (raw.length === 0 || raw.length % 2 !== 0 || /[^0-9a-f]/i.test(raw)) {
+      return null;
+    }
     try {
-      raw = await fs.readFile(
-        path.join(os.homedir(), ".claude", ".credentials.json"),
-        "utf8",
-      );
+      return JSON.parse(Buffer.from(raw, "hex").toString("utf8"));
     } catch {
       return null;
     }
   }
+}
+
+function parseClaudeCredentials(raw: string): ClaudeCredentials | null {
+  const parsed = claudeCredentialsSchema.safeParse(decodeCredentialBlob(raw));
+  return parsed.success ? parsed.data.claudeAiOauth : null;
+}
+
+async function readCredentials(): Promise<ClaudeCredentials | null> {
+  const keychain = await readKeychainCredentials();
+  if (keychain !== null) {
+    const fromKeychain = parseClaudeCredentials(keychain);
+    if (fromKeychain !== null) return fromKeychain;
+  }
   try {
-    const parsed = claudeCredentialsSchema.safeParse(JSON.parse(raw));
-    return parsed.success ? parsed.data.claudeAiOauth : null;
+    return parseClaudeCredentials(
+      await fs.readFile(
+        path.join(os.homedir(), ".claude", ".credentials.json"),
+        "utf8",
+      ),
+    );
   } catch {
     return null;
   }
@@ -524,4 +542,5 @@ export async function getClaudeProviderUsage(): Promise<ProviderUsageResult> {
 export const __testing = {
   buildProviderInstallationRun: buildClaudeProviderInstallationRun,
   normalizeUsage,
+  parseClaudeCredentials,
 };


### PR DESCRIPTION
## Human comments

## What was wrong

Claude Code 2.1.x stores the macOS Keychain item `Claude Code-credentials` as hex-encoded JSON (`7b…` = `{`). `provider-maintenance` parsed that blob with `JSON.parse` as UTF-8, failed, and never fell through to `~/.claude/.credentials.json` because the Keychain read had already succeeded. Settings → Usage limits then reported Claude as `unauthenticated` while the CLI was logged in.

## What changed

- Decode the Keychain secret as JSON first, then as hex JSON.
- If the Keychain blob still does not parse, read `~/.claude/.credentials.json`.
- Unit test covers hex, UTF-8 JSON, and garbage input.
- No `HOST_DAEMON_PROTOCOL_VERSION` bump: this is local credential parsing, not a wire change.

## How you verified

- `pnpm exec vitest run --config vitest.config.ts src/bridge/provider-maintenance.test.ts` in `plugins/provider-claude-code` (3 passed, including the new hex fixture).
- Live: after this decode, `GET /api/v1/system/usage-limits` returns Claude session/weekly windows instead of `unauthenticated`.

Fixes #2928

> AGENT GENERATED
