### PR TITLE
Disable Electron spellcheck and background throttling

### DIFF
--- a/apps/desktop/src/desktop-context-menu.ts
+++ b/apps/desktop/src/desktop-context-menu.ts
@@ -156,7 +156,7 @@ function showDesktopContextMenu({
 export function registerDesktopContextMenu({
   webContents,
 }: RegisterDesktopContextMenuArgs): void {
-  webContents.session.setSpellCheckerEnabled(true);
+  webContents.session.setSpellCheckerEnabled(false);
   webContents.on("context-menu", (_event, params) => {
     showDesktopContextMenu({ params, webContents });
   });

--- a/apps/desktop/src/desktop-window-factory.ts
+++ b/apps/desktop/src/desktop-window-factory.ts
@@ -183,11 +183,12 @@ function createWindowOptions(
     show: false,
     title: "bb",
     webPreferences: {
+      backgroundThrottling: false,
       contextIsolation: true,
       nodeIntegration: false,
       preload: args.preloadPath,
       sandbox: true,
-      spellcheck: true,
+      spellcheck: false,
     },
     width: args.bounds.width,
     x: args.bounds.x,
@@ -241,7 +242,7 @@ export function createDesktopWindowFactory(
           preloadPath: args.preloadPath,
         }),
       );
-      browserWindow.webContents.session.setSpellCheckerEnabled(true);
+      browserWindow.webContents.session.setSpellCheckerEnabled(false);
 
       activeWindows.set(stateKey, browserWindow);
 

--- a/apps/desktop/test/desktop-context-menu.test.ts
+++ b/apps/desktop/test/desktop-context-menu.test.ts
@@ -276,7 +276,7 @@ describe("desktop context menu", () => {
 
     registerDesktopContextMenu({ webContents });
 
-    expect(webContents.spellCheckerEnabledValues).toEqual([true]);
+    expect(webContents.spellCheckerEnabledValues).toEqual([false]);
 
     const listener = webContents.on.mock.calls[0]?.[1];
     listener?.(

--- a/apps/desktop/test/desktop-window-factory.test.ts
+++ b/apps/desktop/test/desktop-window-factory.test.ts
@@ -266,9 +266,12 @@ describe("desktop window factory", () => {
     expect(createdWindows[0]?.options.minHeight).toBe(MIN_WINDOW_HEIGHT);
     expect(createdWindows[0]?.options.minWidth).toBe(MIN_WINDOW_WIDTH);
     expect(createdWindows[0]?.options.titleBarStyle).toBe("hiddenInset");
-    expect(createdWindows[0]?.options.webPreferences?.spellcheck).toBe(true);
+    expect(createdWindows[0]?.options.webPreferences?.spellcheck).toBe(false);
+    expect(
+      createdWindows[0]?.options.webPreferences?.backgroundThrottling,
+    ).toBe(false);
     expect(createdWindows[0]?.webContents.spellCheckerEnabledValues).toEqual([
-      true,
+      false,
     ]);
     expect(createdWindows[0]?.options.trafficLightPosition).toEqual({
       x: 18,


### PR DESCRIPTION
## Human comments

<!-- Agents: Do not fill in this section. This is for human users to fill in. -->

## What was wrong

Chromium's spellchecker walks the DOM on input, which is wasted work in a control-plane UI. With `backgroundThrottling` on, token streams, reconnect timers, and query refetch stall when the desktop window is occluded. Root cause of the main-thread cost in [#2693](https://github.com/get-bb/bb/issues/2693).

## What changed

- `webPreferences.spellcheck: false` and `session.setSpellCheckerEnabled(false)` on window create and context-menu register.
- `webPreferences.backgroundThrottling: false`.
- No `HOST_DAEMON_PROTOCOL_VERSION` change. Remote-first startup was already correct and is unchanged.

## How you verified

- `apps/desktop/test/desktop-window-factory.test.ts` and `desktop-context-menu.test.ts` fail before (spellcheck/throttling expected true) and pass after.
- Ran those two files with vitest: 17 passed.

Fixes #2693

> AGENT GENERATED