### PR TITLE
Prefetch timeline, queue, and approvals with thread bootstrap

### DIFF
--- a/apps/app/src/components/layout/AppLayout.tsx
+++ b/apps/app/src/components/layout/AppLayout.tsx
@@ -513,7 +513,6 @@ export function AppLayout({ children }: AppLayoutProps) {
   );
   const threadDetailBootstrapQuery = useThreadDetailBootstrap(threadId ?? "", {
     enabled: isThreadView && Boolean(threadId),
-    timelinePrefetch: isThreadView && Boolean(threadId),
   });
   const hasThreadDetailBootstrapSettled =
     threadDetailBootstrapQuery.isSuccess || threadDetailBootstrapQuery.isError;

--- a/apps/app/src/hooks/queries/thread-queries.test.tsx
+++ b/apps/app/src/hooks/queries/thread-queries.test.tsx
@@ -186,7 +186,7 @@ beforeEach(() => {
 });
 
 describe("useThreadDetailBootstrap", () => {
-  it("starts the timeline request before the thread bootstrap settles", async () => {
+  it("starts timeline, queued, and pending-interaction reads before the thread bootstrap settles", async () => {
     let resolveThread:
       | ((thread: ThreadWithIncludesResponse) => void)
       | undefined;
@@ -196,17 +196,15 @@ describe("useThreadDetailBootstrap", () => {
     vi.mocked(sdk.threads.get).mockReturnValue(threadPromise);
     const { wrapper } = createQueryClientTestHarness();
 
-    const result = renderHook(
-      () =>
-        useThreadDetailBootstrap("thread-1", {
-          timelinePrefetch: true,
-        }),
-      { wrapper },
-    );
+    const result = renderHook(() => useThreadDetailBootstrap("thread-1"), {
+      wrapper,
+    });
 
     await waitFor(() => {
       expect(sdk.threads.get).toHaveBeenCalledTimes(1);
       expect(sdk.threads.timeline).toHaveBeenCalledTimes(1);
+      expect(sdk.threads.queuedMessages.list).toHaveBeenCalledTimes(1);
+      expect(sdk.threads.interactions.list).toHaveBeenCalledTimes(1);
     });
     expect(result.result.current.isPending).toBe(true);
 
@@ -263,13 +261,7 @@ describe("useThreadDetailBootstrap", () => {
       { updatedAt: 1 },
     );
 
-    renderHook(
-      () =>
-        useThreadDetailBootstrap("thread-1", {
-          timelinePrefetch: true,
-        }),
-      { wrapper },
-    );
+    renderHook(() => useThreadDetailBootstrap("thread-1"), { wrapper });
 
     await waitFor(() => {
       expect(sdk.threads.timeline).toHaveBeenCalledWith({

--- a/apps/app/src/hooks/queries/thread-queries.ts
+++ b/apps/app/src/hooks/queries/thread-queries.ts
@@ -100,9 +100,7 @@ const THREAD_SEARCH_DEBOUNCE_MS = 150;
 export const THREAD_SEARCH_LIMIT_PER_GROUP = 20;
 const THREAD_SEARCH_MIN_NON_WHITESPACE_CHARS = 2;
 
-interface ThreadDetailBootstrapQueryOptions extends QueryOptions {
-  timelinePrefetch?: boolean;
-}
+type ThreadDetailBootstrapQueryOptions = QueryOptions;
 
 export function didThreadDetailBootstrapRefreshAfterMount(query: {
   dataUpdatedAt: number;
@@ -663,19 +661,31 @@ export function useThreadDetailBootstrap(
     queryKey: threadDetailBootstrapQueryKey(id),
     queryFn: async ({ signal }) => {
       const threadId = requireThreadId(id, "useThreadDetailBootstrap");
-      const timelinePrefetch = options?.timelinePrefetch ?? false;
-
-      if (timelinePrefetch) {
-        void queryClient.prefetchQuery({
-          queryKey: threadTimelineQueryKey(threadId),
-          queryFn: ({ signal: timelineSignal }) =>
-            fetchThreadTimeline({
-              queryClient,
-              signal: timelineSignal,
-              threadId,
-            }),
-        });
-      }
+      void queryClient.prefetchQuery({
+        queryKey: threadTimelineQueryKey(threadId),
+        queryFn: () =>
+          fetchThreadTimeline({
+            queryClient,
+            signal,
+            threadId,
+          }),
+      });
+      void queryClient.prefetchQuery({
+        queryKey: threadQueuedMessagesQueryKey(threadId),
+        queryFn: () =>
+          sdk.threads.queuedMessages.list({
+            threadId,
+            signal,
+          }),
+      });
+      void queryClient.prefetchQuery({
+        queryKey: threadPendingInteractionsQueryKey(threadId),
+        queryFn: () =>
+          sdk.threads.interactions.list({
+            threadId,
+            signal,
+          }),
+      });
 
       const thread = await sdk.threads.get({
         include: "environment,host",


### PR DESCRIPTION
## Human comments

<!-- Agents: Do not fill in this section. This is for human users to fill in. -->

## What was wrong

Opening a thread waited for `GET /threads/:id?include=environment,host` to settle before starting timeline, queued messages, and pending interactions. That serial waterfall is the request-cost half of [#1303](https://github.com/get-bb/bb/issues/1303). Git work-status and pull-request reads still need environment, so they stay after bootstrap.

## What changed

- `useThreadDetailBootstrap` always starts timeline, queued-message, and pending-interaction reads in the same turn as the bootstrap GET.
- Removed the optional `timelinePrefetch` flag. AppLayout no longer has to opt in; ThreadDetailView gets the same prefetch.
- Not a `GET /threads/:id/open` payload. Wire shape is unchanged.

## How you verified

- `apps/app/src/hooks/queries/thread-queries.test.tsx` now asserts timeline, queued messages, and pending interactions are requested before bootstrap settles.
- Ran that file with vitest: 22 passed.

Fixes #1303

> AGENT GENERATED