### PR TITLE
Fix iOS link confirmation in Mobile E2E

### DIFF
--- a/apps/mobile/e2e/flows/shell-deep-link.yaml
+++ b/apps/mobile/e2e/flows/shell-deep-link.yaml
@@ -12,14 +12,20 @@ env:
 - runFlow: ../subflows/pair-direct-server.yaml
 
 # A scheme link into a page surface.
-- openLink: "bb://threads"
+- runFlow:
+    file: ../subflows/open-bb-link.yaml
+    env:
+      LINK: "bb://threads"
 - extendedWaitUntil:
     visible:
       id: "shell-webview"
     timeout: 30000
 
 # A scheme link carrying a page path lands on that page.
-- openLink: "bb://"
+- runFlow:
+    file: ../subflows/open-bb-link.yaml
+    env:
+      LINK: "bb://"
 - extendedWaitUntil:
     visible:
       id: "shell-webview"
@@ -45,7 +51,10 @@ env:
 
 # Connect enrolment holds the Keychain credential, so it can never move into
 # the page. It stays native even while the shell is on.
-- openLink: "bb://connect"
+- runFlow:
+    file: ../subflows/open-bb-link.yaml
+    env:
+      LINK: "bb://connect"
 - extendedWaitUntil:
     visible:
       id: "connect-screen"

--- a/apps/mobile/e2e/flows/shell-deep-link.yaml
+++ b/apps/mobile/e2e/flows/shell-deep-link.yaml
@@ -35,7 +35,10 @@ env:
     timeout: 60000
 - takeScreenshot: shell-deep-link-page
 
-- openLink: "bb://settings/notifications"
+- runFlow:
+    file: ../subflows/open-bb-link.yaml
+    env:
+      LINK: "bb://settings/notifications"
 - extendedWaitUntil:
     visible:
       id: "notifications-settings-screen"

--- a/apps/mobile/e2e/flows/shell-launch.yaml
+++ b/apps/mobile/e2e/flows/shell-launch.yaml
@@ -13,25 +13,7 @@ env:
   SERVER_URL: "http://127.0.0.1:41999"
 ---
 - runFlow: ../subflows/launch-app.yaml
-# No profiles yet, so the entry route redirects to add-server.
-- extendedWaitUntil:
-    visible: "Connect to a bb server"
-    timeout: 30000
-- tapOn:
-    id: "server-url-input"
-- inputText: "${SERVER_URL}"
-- tapOn:
-    id: "server-label-input"
-- inputText: "E2E backend"
-# Tapping static text dismisses the keyboard.
-- tapOn: "Server URL"
-- tapOn:
-    id: "add-server-submit"
-# Saving activates the profile, and the entry route sends it to the shell.
-- extendedWaitUntil:
-    visible:
-      id: "shell-webview"
-    timeout: 30000
+- runFlow: ../subflows/pair-direct-server.yaml
 # Page content, not native chrome: the shell is really rendering the server's
 # web interface.
 - extendedWaitUntil:

--- a/apps/mobile/e2e/flows/shell-send.yaml
+++ b/apps/mobile/e2e/flows/shell-send.yaml
@@ -31,7 +31,10 @@ env:
     id: "add-server-submit"
 # Pairing lands in the shell, which loads the page the server serves. The
 # composer is page content.
-- openLink: "bb://"
+- runFlow:
+    file: ../subflows/open-bb-link.yaml
+    env:
+      LINK: "bb://"
 - extendedWaitUntil:
     visible:
       id: "shell-webview"
@@ -43,7 +46,10 @@ env:
 
 # A deep link resolves to one shell route carrying a web path; the page's own
 # router takes it from there.
-- openLink: "bb://threads"
+- runFlow:
+    file: ../subflows/open-bb-link.yaml
+    env:
+      LINK: "bb://threads"
 - extendedWaitUntil:
     visible:
       id: "shell-webview"
@@ -51,7 +57,10 @@ env:
 
 # Reach a thread and send a message, the plan's acceptance test. The seeded
 # "Idle thread" echoes through the fake provider adapter.
-- openLink: "bb://"
+- runFlow:
+    file: ../subflows/open-bb-link.yaml
+    env:
+      LINK: "bb://"
 - extendedWaitUntil:
     visible: ".*Idle thread.*"
     timeout: 60000
@@ -81,7 +90,10 @@ env:
 # discoverable entry; the failure screen and the Home Screen quick action are
 # the two that still work when the page will not load. Match on the row's text:
 # a WebView exposes no test ids to the accessibility tree.
-- openLink: "bb://settings"
+- runFlow:
+    file: ../subflows/open-bb-link.yaml
+    env:
+      LINK: "bb://settings"
 - extendedWaitUntil:
     visible:
       id: "shell-webview"

--- a/apps/mobile/e2e/flows/shell-send.yaml
+++ b/apps/mobile/e2e/flows/shell-send.yaml
@@ -17,28 +17,15 @@ env:
   SERVER_URL: "http://127.0.0.1:41999"
 ---
 - runFlow: ../subflows/launch-app.yaml
-- extendedWaitUntil:
-    visible: "Connect to a bb server"
-    timeout: 30000
-- tapOn:
-    id: "server-url-input"
-- inputText: "${SERVER_URL}"
-- tapOn:
-    id: "server-label-input"
-- inputText: "E2E backend"
-- tapOn: "Server URL"
-- tapOn:
-    id: "add-server-submit"
+- runFlow: ../subflows/pair-direct-server.yaml
 # Pairing lands in the shell, which loads the page the server serves. The
 # composer is page content.
 - runFlow:
     file: ../subflows/open-bb-link.yaml
     env:
       LINK: "bb://"
-- extendedWaitUntil:
-    visible:
-      id: "shell-webview"
-    timeout: 30000
+- assertVisible:
+    id: "shell-webview"
 - extendedWaitUntil:
     visible: ".*Ask anything.*"
     timeout: 60000

--- a/apps/mobile/e2e/manual/phase7-plugins-devserver.yaml
+++ b/apps/mobile/e2e/manual/phase7-plugins-devserver.yaml
@@ -16,7 +16,10 @@ env:
 # the dev-client launcher) and sitting on a screen that survives losing the
 # profile (home), so: launch, reset, launch again → first run → add server.
 - runFlow: ../subflows/launch-app.yaml
-- openLink: "bb://e2e/reset"
+- runFlow:
+    file: ../subflows/open-bb-link.yaml
+    env:
+      LINK: "bb://e2e/reset"
 - extendedWaitUntil:
     visible: ".*Connect to a bb server.*"
     timeout: 60000
@@ -129,7 +132,10 @@ env:
 - takeScreenshot: p7-plugins-dev-browse
 # Leave the simulator at first run again for the harness flows.
 - runFlow: ../subflows/launch-app.yaml
-- openLink: "bb://e2e/reset"
+- runFlow:
+    file: ../subflows/open-bb-link.yaml
+    env:
+      LINK: "bb://e2e/reset"
 - extendedWaitUntil:
     visible: ".*Connect to a bb server.*"
     timeout: 60000

--- a/apps/mobile/e2e/scripts/ci-run-flows.sh
+++ b/apps/mobile/e2e/scripts/ci-run-flows.sh
@@ -67,6 +67,20 @@ for flow in "${FLOWS[@]}"; do
     # A failed flow can leave the app on any screen; the next flow cold-starts
     # it, but keep a screenshot of where this one ended.
     xcrun simctl io "$UDID" screenshot "$out/final-screen.png" >/dev/null 2>&1 || true
+    cleanup="$out/cleanup"
+    mkdir -p "$cleanup"
+    if maestro --device "$UDID" test \
+        ${LAUNCH_ENV[@]+"${LAUNCH_ENV[@]}"} \
+        --format junit --output "$cleanup/junit.xml" \
+        --test-output-dir "$cleanup" \
+        ${MAESTRO_FLAGS:-} \
+        "subflows/clear-open-confirmation.yaml" 2>&1 | tee "$cleanup/maestro.log"; then
+      echo "RESET after $flow"
+    else
+      echo "Failed to clear native state after $flow; stopping before the next flow" >&2
+      echo "::endgroup::"
+      break
+    fi
   fi
   echo "::endgroup::"
 done

--- a/apps/mobile/e2e/subflows/clear-open-confirmation.yaml
+++ b/apps/mobile/e2e/subflows/clear-open-confirmation.yaml
@@ -1,0 +1,10 @@
+appId: app.getbb.mobile
+---
+- runFlow:
+    when:
+      platform: iOS
+      visible: "Open in.*bb.*"
+    commands:
+      - tapOn: "Cancel"
+- stopApp
+- assertNotVisible: "Open in.*bb.*"

--- a/apps/mobile/e2e/subflows/open-bb-link.yaml
+++ b/apps/mobile/e2e/subflows/open-bb-link.yaml
@@ -1,0 +1,10 @@
+appId: app.getbb.mobile
+---
+- openLink: "${LINK}"
+- runFlow:
+    when:
+      platform: iOS
+      visible: "Open in.*bb.*"
+    commands:
+      - tapOn: "Open"
+- assertNotVisible: "Open in.*bb.*"

--- a/apps/mobile/e2e/subflows/pair-direct-server.yaml
+++ b/apps/mobile/e2e/subflows/pair-direct-server.yaml
@@ -22,6 +22,13 @@ appId: app.getbb.mobile
       - tapOn:
           id: "add-server-submit"
 - extendedWaitUntil:
-    visible:
-      id: "shell-webview"
+    visible: ".*(Not now|Ask anything).*"
     timeout: 30000
+- runFlow:
+    when:
+      visible: "Not now"
+    commands:
+      - tapOn: "Not now"
+- assertNotVisible: "Not now"
+- assertVisible:
+    id: "shell-webview"

--- a/apps/mobile/src/lib/e2e/ci-run-flows.test.ts
+++ b/apps/mobile/src/lib/e2e/ci-run-flows.test.ts
@@ -1,0 +1,109 @@
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const runner = fileURLToPath(
+  new URL("../../../e2e/scripts/ci-run-flows.sh", import.meta.url),
+);
+
+function runFixture({ cleanupFails }: { cleanupFails: boolean }) {
+  const root = mkdtempSync(join(tmpdir(), "bb-mobile-flow-runner-"));
+  const bin = join(root, "bin");
+  const artifacts = join(root, "artifacts");
+  const trace = join(root, "trace.log");
+  mkdirSync(bin);
+
+  const maestro = join(bin, "maestro");
+  writeFileSync(
+    maestro,
+    `#!/usr/bin/env bash
+set -u
+flow="\${!#}"
+printf '%s\\n' "$flow" >> "$TRACE_FILE"
+if [ "$flow" = "flows/fails.yaml" ]; then
+  exit 1
+fi
+if [ "$flow" = "subflows/clear-open-confirmation.yaml" ] && [ "$CLEANUP_FAILS" = "1" ]; then
+  exit 1
+fi
+exit 0
+`,
+  );
+  chmodSync(maestro, 0o755);
+
+  const xcrun = join(bin, "xcrun");
+  writeFileSync(
+    xcrun,
+    `#!/usr/bin/env bash
+set -u
+printf 'xcrun %s\\n' "$*" >> "$TRACE_FILE"
+exit 0
+`,
+  );
+  chmodSync(xcrun, 0o755);
+
+  const result = spawnSync(
+    "bash",
+    [runner, "simulator", artifacts, "fails", "passes"],
+    {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${bin}:${process.env.PATH ?? ""}`,
+        TRACE_FILE: trace,
+        CLEANUP_FAILS: cleanupFails ? "1" : "0",
+      },
+      killSignal: "SIGKILL",
+      timeout: 5_000,
+    },
+  );
+
+  return {
+    dispose: () => rmSync(root, { force: true, recursive: true }),
+    result,
+    trace: readFileSync(trace, "utf8").trim().split("\n"),
+  };
+}
+
+describe("ci-run-flows", () => {
+  it("clears native confirmation state before continuing after a failed flow", () => {
+    const fixture = runFixture({ cleanupFails: false });
+    try {
+      expect(fixture.result.status).toBe(1);
+      expect(fixture.trace).toEqual([
+        "flows/fails.yaml",
+        expect.stringMatching(/^xcrun simctl io simulator screenshot /),
+        "subflows/clear-open-confirmation.yaml",
+        "flows/passes.yaml",
+      ]);
+      expect(fixture.result.stderr).toContain("Failed flows: fails");
+    } finally {
+      fixture.dispose();
+    }
+  });
+
+  it("stops before a later flow when native-state cleanup cannot be verified", () => {
+    const fixture = runFixture({ cleanupFails: true });
+    try {
+      expect(fixture.result.status).toBe(1);
+      expect(fixture.trace).toEqual([
+        "flows/fails.yaml",
+        expect.stringMatching(/^xcrun simctl io simulator screenshot /),
+        "subflows/clear-open-confirmation.yaml",
+      ]);
+      expect(fixture.result.stderr).toContain("stopping before the next flow");
+    } finally {
+      fixture.dispose();
+    }
+  });
+});

--- a/apps/mobile/src/lib/e2e/mobile-e2e-flows.test.ts
+++ b/apps/mobile/src/lib/e2e/mobile-e2e-flows.test.ts
@@ -1,0 +1,46 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const e2eRoot = fileURLToPath(new URL("../../../e2e", import.meta.url));
+
+function yamlFiles(root: string): string[] {
+  return readdirSync(root, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(root, entry.name);
+    if (entry.isDirectory()) return yamlFiles(path);
+    return entry.name.endsWith(".yaml") ? [path] : [];
+  });
+}
+
+function flowSource(path: string): string {
+  return readFileSync(join(e2eRoot, path), "utf8");
+}
+
+describe("Mobile E2E flow boundaries", () => {
+  it("routes every bb scheme link through the native-confirmation helper", () => {
+    for (const path of yamlFiles(e2eRoot)) {
+      expect(readFileSync(path, "utf8"), path).not.toMatch(
+        /^\s*- openLink: "bb:\/\//mu,
+      );
+    }
+  });
+
+  it("uses one direct-server pairing boundary in every shell flow", () => {
+    for (const flow of [
+      "flows/shell-launch.yaml",
+      "flows/shell-deep-link.yaml",
+      "flows/shell-send.yaml",
+    ]) {
+      expect(flowSource(flow), flow).toContain(
+        "- runFlow: ../subflows/pair-direct-server.yaml",
+      );
+    }
+
+    const pairing = flowSource("subflows/pair-direct-server.yaml");
+    expect(pairing).toContain('visible: ".*(Not now|Ask anything).*"');
+    expect(pairing).toContain('- tapOn: "Not now"');
+    expect(pairing).toContain('- assertNotVisible: "Not now"');
+    expect(pairing).toContain('id: "shell-webview"');
+  });
+});


### PR DESCRIPTION
## Human comments

## What was wrong

On a fresh iOS simulator, Maestro reports `openLink: "bb://threads"` complete before the operating system's first custom-scheme confirmation has been accepted. The app remains behind the native `Open in “bb”?` dialog while `shell-deep-link` waits for `shell-webview`; that simulator-owned dialog survives the next flow's app stop and launch, so later flows cannot see their native screens. The original and prior scheduled evidence show that exact sequence: [run 33637452626](https://github.com/get-bb/bb/actions/runs/33637452626) and [run 33517924818](https://github.com/get-bb/bb/actions/runs/33517924818).

After this PR was labeled, [run 34273156200](https://github.com/get-bb/bb/actions/runs/34273156200) checked out the PR merged with newer main and exposed a second deterministic blocker introduced by #2881: the first-run `Get notified when a thread needs you?` action sheet covered an otherwise rendered shell after every direct-server pairing. That explains why `shell-launch` now failed before any deep link. Its artifact shows the sheet in all three failed-flow screenshots; `clear-open-confirmation` passed after each failure and `shell-unreachable-server` passed, proving the PR's fail-closed cleanup prevented native state from leaking. Every scheduled main run since #2881 merged shows the same new `shell-launch` failure, so this recurrence is current-main flow orchestration, not infrastructure.

## What changed

- Route every Mobile E2E `bb://` action through one parameterized Maestro subflow. It preserves the real custom-scheme invocation, conditionally accepts the native confirmation only when visible on iOS, and proves the dialog is absent before route assertions continue.
- Make the existing direct-server pairing subflow own the post-connect UI boundary. It uses the unchanged 30-second readiness budget to wait for either the notification opt-out or rendered page content, conditionally chooses `Not now`, proves the sheet is absent, and keeps the `shell-webview` assertion.
- Have `shell-launch`, `shell-deep-link`, and `shell-send` use that one pairing boundary instead of duplicating pairing. The notifications deep-link added by #2881 also uses the custom-scheme helper.
- After a failed CI flow, preserve the original final screenshot, cancel and verify removal of the native confirmation, and stop the app before continuing. If cleanup cannot establish isolation, the runner stops before the next flow.
- Add regression coverage for cleanup-before-continuation, fail-closed cleanup failure, shared pairing, and the absence of direct `bb://` Maestro commands.
- No assertion, timeout, polling budget, or retry budget increased. No server/host-daemon wire, CLI, SDK, or user-facing configuration changed, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

## How you verified

- Mandatory initial fresh-main gate: clean worktree; `HEAD`, `origin/main`, and merge-base all independently verified as `ab8e0a202c70525c3c935733300198dac617e3de` before task inspection.
- Before the follow-up edit, fetched and recorded live `origin/main` as `06047280e04e6ce57554052ec788a1c5defe7d1e`, with PR head `5f2f960c2c289518b8493dece775f4f22103f722` and retained merge-base `ab8e0a202c70525c3c935733300198dac617e3de`; then rebased cleanly. Current PR merge-base is `06047280e04e6ce57554052ec788a1c5defe7d1e`.
- Native red: run 34273156200 failed `shell-launch`, `shell-deep-link`, and `shell-send` at `shell-webview`; its screenshots show the notification action sheet over the rendered shell. The new cleanup passed after every failure, and `shell-unreachable-server` passed.
- Original focused runner red on pre-fix main: 2/2 tests failed because cleanup was never invoked and the next flow always ran.
- Focused green: `pnpm exec turbo run test --filter=@bb/mobile --force --concurrency=2 -- --run src/lib/e2e/mobile-e2e-flows.test.ts src/lib/e2e/ci-run-flows.test.ts` — 2 files, 4 tests passed.
- `pnpm exec turbo run test --filter=@bb/mobile --force --concurrency=2` — 46 files, 331 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/mobile --force --concurrency=2` — passed.
- `pnpm exec turbo run lint --filter=@bb/mobile --force --concurrency=2` — passed with two pre-existing React warnings and zero errors.
- `pnpm exec turbo run build --filter=@bb/app --force --concurrency=2` — passed after a frozen-lockfile install refreshed dependencies for current main; 439 files precompressed.
- `bash -n`, Ruby YAML parsing for every changed Maestro file, targeted `oxfmt --check`, `git diff --check`, and the no-direct-`bb://` scan passed. ShellCheck is unavailable on this host.
- [Ordinary CI run 34277221769](https://github.com/get-bb/bb/actions/runs/34277221769) passed on commit `1594a59a2b2ccf1c17645200f2fb0db522e8861c`, including build/typecheck/lint, package tests, all app test shards, server, integration, and Linux/macOS package smoke.
- All local build, test, typecheck, lint, and install commands ran with explicit process-group deadlines on Intel host `host_nwqfteeqz4` (`x86_64`, Intel Core i5-1038NG7). A final cwd audit found one stale earlier Xcode-discovery process group, terminated it, and then proved no task build, test, backend, fixture, Maestro, or simulator process remained. Temporary artifacts and logs were moved recoverably to Trash.
- This host has Command Line Tools only, with no Xcode app, iOS runtime, or Maestro, so no after-change simulator result is claimed. The `mobile-e2e` label was removed before the updated push; [run 34277221938](https://github.com/get-bb/bb/actions/runs/34277221938) therefore skipped without starting a simulator.

> AGENT GENERATED: by GPT-5.6-Sol.
