### PR TITLE
Add search to project picker

### DIFF
--- a/apps/app/src/components/pickers/ProjectSelector.test.tsx
+++ b/apps/app/src/components/pickers/ProjectSelector.test.tsx
@@ -1,11 +1,140 @@
 // @vitest-environment jsdom
 
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { ProjectSelector } from "./ProjectSelector";
 
+const PROJECTS = [
+  { id: "proj_alpha", name: "Alpha Web" },
+  { id: "proj_bravo", name: "Bravo API" },
+  { id: "proj_charlie", name: "Charlie Docs" },
+  { id: "proj_delta", name: "Delta Mobile" },
+  { id: "proj_echo", name: "Echo Infra" },
+  { id: "proj_foxtrot", name: "Foxtrot Design" },
+] as const;
+
+afterEach(cleanup);
+
 describe("ProjectSelector", () => {
-  it("keeps the project menu inside a short viewport and scrolls it", () => {
+  it("shows search only when there are more than five projects", () => {
+    const result = render(
+      <ProjectSelector
+        projects={PROJECTS.slice(0, 5)}
+        value="proj_alpha"
+        onChange={() => {}}
+        defaultOpen
+        modal={false}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("combobox", { name: "Search projects" }),
+    ).toBeNull();
+
+    result.rerender(
+      <ProjectSelector
+        projects={PROJECTS}
+        value="proj_alpha"
+        onChange={() => {}}
+        defaultOpen
+        modal={false}
+      />,
+    );
+
+    expect(
+      screen.getByRole("combobox", { name: "Search projects" }),
+    ).toBeTruthy();
+  });
+
+  it("filters projects case-insensitively and selects the match", () => {
+    const onChange = vi.fn();
+    render(
+      <ProjectSelector
+        projects={PROJECTS}
+        value="proj_alpha"
+        onChange={onChange}
+        defaultOpen
+        modal={false}
+      />,
+    );
+
+    fireEvent.change(
+      screen.getByRole("combobox", { name: "Search projects" }),
+      { target: { value: "CHARLIE" } },
+    );
+
+    expect(screen.queryByRole("option", { name: "Alpha Web" })).toBeNull();
+    expect(screen.getByRole("option", { name: "Charlie Docs" })).toBeTruthy();
+    fireEvent.keyDown(
+      screen.getByRole("combobox", { name: "Search projects" }),
+      { key: "Enter" },
+    );
+
+    expect(onChange).toHaveBeenCalledWith("proj_charlie");
+    expect(screen.queryByRole("dialog", { name: "Project" })).toBeNull();
+  });
+
+  it("keeps keyboard selection for short project lists", () => {
+    const onChange = vi.fn();
+    render(
+      <ProjectSelector
+        projects={PROJECTS.slice(0, 5)}
+        value="proj_alpha"
+        onChange={onChange}
+        defaultOpen
+        modal={false}
+      />,
+    );
+
+    const command = document.querySelector<HTMLElement>("[cmdk-root]");
+    expect(command).not.toBeNull();
+    expect(document.activeElement).toBe(command);
+
+    if (command === null) return;
+    fireEvent.keyDown(command, { key: "ArrowDown" });
+    fireEvent.keyDown(command, { key: "Enter" });
+
+    expect(onChange).toHaveBeenCalledWith("proj_bravo");
+  });
+
+  it("keeps project actions visible and resets search after closing", () => {
+    const onCreate = vi.fn();
+    render(
+      <ProjectSelector
+        projects={PROJECTS}
+        value="proj_alpha"
+        onChange={() => {}}
+        allowNoProject
+        createProject={{ onCreate }}
+        defaultOpen
+        modal={false}
+      />,
+    );
+
+    fireEvent.change(
+      screen.getByRole("combobox", { name: "Search projects" }),
+      { target: { value: "missing" } },
+    );
+
+    expect(screen.getByText("No projects found")).toBeTruthy();
+    expect(screen.getByRole("option", { name: "New project" })).toBeTruthy();
+    expect(
+      screen.getByRole("option", { name: "Don't work in a project" }),
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("option", { name: "New project" }));
+    expect(onCreate).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Project" }));
+    expect(
+      screen.getByRole<HTMLInputElement>("combobox", {
+        name: "Search projects",
+      }).value,
+    ).toBe("");
+    expect(screen.getByRole("option", { name: "Alpha Web" })).toBeTruthy();
+  });
+
+  it("keeps the search fixed while the project results scroll", () => {
     render(
       <ProjectSelector
         projects={Array.from({ length: 20 }, (_, index) => ({
@@ -19,11 +148,23 @@ describe("ProjectSelector", () => {
       />,
     );
 
-    const menu = screen.getByRole("menu");
-    expect(menu.className).toContain(
-      "max-h-[min(var(--radix-dropdown-menu-content-available-height),calc(100dvh-0.5rem))]",
+    const dialog = screen.getByRole("dialog", { name: "Project" });
+    expect(dialog.className).toContain(
+      "max-h-[min(var(--radix-popover-content-available-height),calc(100dvh-0.5rem))]",
     );
-    expect(menu.className).toContain("overflow-y-auto");
-    expect(menu.className).toContain("overscroll-contain");
+    expect(dialog.className).toContain("overflow-hidden");
+
+    const list = document.querySelector<HTMLElement>("[cmdk-list]");
+    expect(list).not.toBeNull();
+    expect(list?.className).toContain("overflow-y-auto");
+    expect(list?.className).toContain("overscroll-contain");
+
+    if (list === null) return;
+    list.scrollTop = 120;
+    fireEvent.change(
+      screen.getByRole("combobox", { name: "Search projects" }),
+      { target: { value: "Project 19" } },
+    );
+    expect(list.scrollTop).toBe(0);
   });
 });

--- a/apps/app/src/components/pickers/ProjectSelector.tsx
+++ b/apps/app/src/components/pickers/ProjectSelector.tsx
@@ -1,21 +1,26 @@
+import { useMemo, useRef, useState } from "react";
 import { Button } from "@bb/shared-ui/button";
 import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@bb/shared-ui/dropdown-menu";
+  Command,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@bb/shared-ui/command";
 import { Icon } from "@bb/shared-ui/icon";
 import { cn } from "@bb/shared-ui/lib/utils";
 import {
   OPTION_BASE_CLASS_NAME,
   OPTION_INTERACTIVE_CLASS_NAME,
-  OPTION_MENU_CONTENT_CLASS_NAME,
   OPTION_MUTED_CLASS_NAME,
   OPTION_TRIGGER_CONTENT_CLASS_NAME,
 } from "@bb/shared-ui/option-display";
+import { Popover, PopoverContent, PopoverTrigger } from "@bb/shared-ui/popover";
+import { useResetPickerScroll } from "./useResetPickerScroll";
+
+const PROJECT_SEARCH_MIN_OPTIONS = 5;
+const PROJECT_PICKER_ITEM_CLASS_NAME = "py-[0.3125rem] text-xs max-md:py-2";
 
 export interface ProjectSelectorOption {
   id: string;
@@ -53,9 +58,25 @@ export function ProjectSelector({
   showChevronWhenDisabled = false,
   className,
   defaultOpen,
-  modal,
+  modal = true,
 }: ProjectSelectorProps) {
+  const [open, setOpen] = useState(defaultOpen ?? false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const commandRef = useRef<HTMLDivElement>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const listRef = useResetPickerScroll<HTMLDivElement>(searchQuery);
   const disabled = disabledProp || isLoading;
+  const showSearch = projects.length > PROJECT_SEARCH_MIN_OPTIONS;
+  const normalizedSearchQuery = searchQuery.trim().toLocaleLowerCase();
+  const filteredProjects = useMemo(
+    () =>
+      showSearch && normalizedSearchQuery.length > 0
+        ? projects.filter((project) =>
+            project.name.toLocaleLowerCase().includes(normalizedSearchQuery),
+          )
+        : projects,
+    [normalizedSearchQuery, projects, showSearch],
+  );
   const selected = value !== null ? projects.find((p) => p.id === value) : null;
   const fallback = !allowNoProject && !selected ? projects[0] : null;
   const triggerLabel = isLoading
@@ -72,10 +93,20 @@ export function ProjectSelector({
     : "New project";
   const showActionSeparator =
     projects.length > 0 && (Boolean(createProjectAction) || allowNoProject);
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (!nextOpen) {
+      setSearchQuery("");
+    }
+  };
+  const selectProject = (projectId: string | null) => {
+    onChange(projectId);
+    handleOpenChange(false);
+  };
 
   return (
-    <DropdownMenu defaultOpen={defaultOpen} modal={modal}>
-      <DropdownMenuTrigger asChild disabled={disabled}>
+    <Popover open={open} onOpenChange={handleOpenChange} modal={modal}>
+      <PopoverTrigger asChild disabled={disabled}>
         <Button
           type="button"
           variant="ghost"
@@ -113,67 +144,122 @@ export function ProjectSelector({
             />
           )}
         </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent
+      </PopoverTrigger>
+      <PopoverContent
         align="start"
-        side="bottom"
-        className={cn(OPTION_MENU_CONTENT_CLASS_NAME, "w-52")}
+        aria-label="Project"
+        mobileTitle="Project"
+        onOpenAutoFocus={(event) => {
+          event.preventDefault();
+          if (showSearch) {
+            searchInputRef.current?.focus();
+          } else {
+            commandRef.current?.focus();
+          }
+        }}
+        className="flex max-h-[min(var(--radix-popover-content-available-height),calc(100dvh-0.5rem))] w-52 flex-col overflow-hidden p-0 max-md:min-h-0 max-md:w-full max-md:flex-1"
       >
-        <DropdownMenuLabel>Project</DropdownMenuLabel>
-        {projects.map((project) => (
-          <DropdownMenuItem
-            key={project.id}
-            onSelect={() => onChange(project.id)}
+        <Command
+          ref={commandRef}
+          label="Search projects"
+          shouldFilter={false}
+          className="min-h-0"
+        >
+          {showSearch ? (
+            <CommandInput
+              ref={searchInputRef}
+              aria-label="Search projects"
+              placeholder="Search projects"
+              value={searchQuery}
+              onValueChange={setSearchQuery}
+              className="h-8 text-xs"
+            />
+          ) : null}
+          <CommandList
+            ref={listRef}
+            className="min-h-0 max-h-none flex-1 overscroll-contain"
           >
-            <Icon
-              name="Folder"
-              className="size-4 text-muted-foreground"
-              aria-hidden
-            />
-            {project.name}
-            <Icon
-              name="Check"
-              className={cn(
-                "ml-auto size-4",
-                project.id === value ? "opacity-100" : "opacity-0",
-              )}
-              aria-hidden
-            />
-          </DropdownMenuItem>
-        ))}
-        {showActionSeparator ? <DropdownMenuSeparator /> : null}
-        {createProjectAction ? (
-          <DropdownMenuItem
-            disabled={createProjectAction.disabled}
-            onSelect={() => createProjectAction.onCreate()}
-          >
-            <Icon
-              name="FolderPlus"
-              className="size-4 text-muted-foreground"
-              aria-hidden
-            />
-            {createProjectLabel}
-          </DropdownMenuItem>
-        ) : null}
-        {allowNoProject ? (
-          <DropdownMenuItem onSelect={() => onChange(null)}>
-            <Icon
-              name="FolderMinus"
-              className="size-4 text-muted-foreground"
-              aria-hidden
-            />
-            Don&apos;t work in a project
-            <Icon
-              name="Check"
-              className={cn(
-                "ml-auto size-4",
-                value === null ? "opacity-100" : "opacity-0",
-              )}
-              aria-hidden
-            />
-          </DropdownMenuItem>
-        ) : null}
-      </DropdownMenuContent>
-    </DropdownMenu>
+            <CommandGroup heading="Project">
+              {filteredProjects.map((project) => (
+                <CommandItem
+                  key={project.id}
+                  value={project.id}
+                  keywords={[project.name]}
+                  onSelect={() => selectProject(project.id)}
+                  className={PROJECT_PICKER_ITEM_CLASS_NAME}
+                >
+                  <Icon
+                    name="Folder"
+                    className="size-4 text-muted-foreground"
+                    aria-hidden
+                  />
+                  <span className="min-w-0 flex-1 truncate">
+                    {project.name}
+                  </span>
+                  <Icon
+                    name="Check"
+                    className={cn(
+                      "ml-auto size-4",
+                      project.id === value ? "opacity-100" : "opacity-0",
+                    )}
+                    aria-hidden
+                  />
+                </CommandItem>
+              ))}
+              {showSearch && filteredProjects.length === 0 ? (
+                <div className="px-2 py-1.5 text-xs text-muted-foreground max-md:py-2">
+                  No projects found
+                </div>
+              ) : null}
+            </CommandGroup>
+            {showActionSeparator ? <CommandSeparator /> : null}
+            {createProjectAction || allowNoProject ? (
+              <CommandGroup>
+                {createProjectAction ? (
+                  <CommandItem
+                    disabled={createProjectAction.disabled}
+                    value="new-project"
+                    onSelect={() => {
+                      createProjectAction.onCreate();
+                      handleOpenChange(false);
+                    }}
+                    className={PROJECT_PICKER_ITEM_CLASS_NAME}
+                  >
+                    <Icon
+                      name="FolderPlus"
+                      className="size-4 text-muted-foreground"
+                      aria-hidden
+                    />
+                    {createProjectLabel}
+                  </CommandItem>
+                ) : null}
+                {allowNoProject ? (
+                  <CommandItem
+                    value="no-project"
+                    onSelect={() => selectProject(null)}
+                    className={PROJECT_PICKER_ITEM_CLASS_NAME}
+                  >
+                    <Icon
+                      name="FolderMinus"
+                      className="size-4 text-muted-foreground"
+                      aria-hidden
+                    />
+                    Don&apos;t work in a project
+                    <Icon
+                      name="Check"
+                      className={cn(
+                        "ml-auto size-4",
+                        value === null ? "opacity-100" : "opacity-0",
+                      )}
+                      aria-hidden
+                    />
+                  </CommandItem>
+                ) : null}
+              </CommandGroup>
+            ) : null}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
   );
 }


### PR DESCRIPTION
## Human comments

## What was wrong

The project picker rendered every project as a static dropdown list, so workspaces with many projects required scanning the entire menu to find a target. This addresses #2696.

## What changed

Replaced the project dropdown with the shared responsive Popover and Command primitives. When more than five projects exist, the picker now shows a focused search input and filters names case-insensitively. Project creation and no-project actions stay visible for no-match queries, search resets after close, short lists preserve keyboard navigation, and only the results region scrolls. No wire, CLI, guide, or protocol changes.

## How you verified

- pnpm exec turbo run test --filter=@bb/app --force -- src/components/pickers/ProjectSelector.test.tsx (5 passed)
- pnpm exec turbo run typecheck --filter=@bb/app --force
- pnpm exec turbo run test --filter=@bb/app --force (467 files, 3,741 passed, 4 skipped)
- Desktop and mobile manual QA with Doobie, including filtered results and empty-search states

Fixes #2696

> AGENT GENERATED