### PR TITLE
Surface and test AppImage owned runtime startup failures

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1490,6 +1490,11 @@ async function loadLoadingView(): Promise<void> {
 
 async function loadStartupError(args: LoadStartupErrorArgs): Promise<void> {
   bbAppLoaded = false;
+  createDesktopLogger().error(
+    [`${args.title}: ${args.details}`, args.logs.trim()]
+      .filter((part) => part.length > 0)
+      .join("\n"),
+  );
   await loadWindowUrl({
     url: createLocalViewUrl({
       viewModel: {

--- a/apps/desktop/test/bb-process.test.ts
+++ b/apps/desktop/test/bb-process.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
@@ -212,6 +212,53 @@ describe("bb app process", () => {
 
     expect(result.stdout).toBe("child mount\n");
   });
+
+  it.skipIf(process.platform !== "linux")(
+    "keeps the AppRun sandbox fallback out of Electron node mode",
+    async () => {
+      const appRun = await createTempScript({
+        contents: `#!/bin/sh
+has_no_sandbox=0
+for argument in "$@"; do
+  if [ "$argument" = "--no-sandbox" ]; then
+    has_no_sandbox=1
+  fi
+done
+if [ "$has_no_sandbox" -eq 0 ]; then
+  set -- --no-sandbox "$@"
+fi
+exec "$FAKE_APPIMAGE_NODE" "$@"
+`,
+      });
+      await chmod(appRun.path, 0o755);
+      const bridge = await createTempScript({
+        contents: 'process.stdout.write("bridge started\\n");\n',
+      });
+      const processEntry = startBbAppProcess({
+        bridgePath: bridge.path,
+        cwd: bridge.root,
+        env: {
+          ...process.env,
+          APPDIR: bridge.root,
+          FAKE_APPIMAGE_NODE: process.execPath,
+        },
+        logLineLimit: 20,
+        runtime: {
+          appDirPath: bridge.root,
+          executablePath: appRun.path,
+          kind: "appimage",
+          mode: "electron-node",
+        },
+      });
+      processes.push(processEntry);
+
+      await waitForLog({ process: processEntry, text: "bridge started" });
+      await expect(processEntry.exit).resolves.toEqual({
+        code: 0,
+        signal: null,
+      });
+    },
+  );
 
   it.skipIf(process.platform !== "linux")(
     "anchors the process group while supervising descendants after the bridge exits",


### PR DESCRIPTION
## Human comments

## What was wrong

Electron Builder's maintained AppImage `AppRun` prepends `--no-sandbox` when its unprivileged user-namespace probe fails. The desktop re-enters its AppImage with `ELECTRON_RUN_AS_NODE=1` to start the owned `bb-app` bridge, so that Electron-only fallback became a Node option and Node exited with code 9 after `owned-runtime.json` was written but before readiness. User-namespace availability made the failure intermittent. The startup error path rendered buffered child output in the window but did not write it to stderr, so Linux Package Smoke reported only that the owned PID died and hid `/tmp/.mount_*/bb: bad option: --no-sandbox`.

While this PR was waiting, #3127 independently landed the product launch fix by placing Node's `--` end-of-options marker before the bridge path and an AppRun-visible `--no-sandbox` sentinel after it. This rebased PR keeps the still-missing observability and behavioral regression coverage.

## What changed

- Write startup error details and buffered child output through the desktop logger before rendering the error view, so package-smoke stderr contains the actual child failure.
- Add a Linux regression test with an executable `AppRun` fixture that performs the real conditional fallback injection and proves Electron Node mode reaches the bridge without receiving a GUI-only Node option.

There is no host-daemon wire change, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged. This does not change a timeout, retry, port, readiness assertion, process-ownership check, FUSE behavior, or GUI sandbox policy.

## How you verified

- Before investigation, independently verified clean baseline `ab8e0a202c70525c3c935733300198dac617e3de` for `HEAD`, freshly fetched `origin/main`, and merge-base on Intel host `host_nwqfteeqz4`.
- Audited the complete failed logs for runs 33619578008 and 33567665395, both post-marker exits with no runtime failure text in captured stderr, and ruled out the already-merged port-reclaim and legacy-FUSE SIGTRAP fixes.
- On a bounded x86_64 Lima VM on the Intel host, a baseline AppImage reproduced the exact smoke signature. The added logging exposed exit code 9 and `/tmp/.mount_*/bb: bad option: --no-sandbox`; the extracted generated `AppRun` proved the user-namespace-dependent fallback that injected it.
- Red: `pnpm exec turbo run test --filter=@bb/desktop --concurrency=2 -- --run test/bb-process.test.ts` failed the new fixture before the launch fix with `/usr/bin/node: bad option: --no-sandbox` (8 passed, 1 failed).
- Green: the same focused Linux command passed all 9 tests after the fix.
- `pnpm exec turbo run desktop:build:linux --filter=@bb/desktop --concurrency=2` passed (14/14 Turbo tasks).
- `xvfb-run -a pnpm exec turbo run smoke:appimage-lifecycle --filter=@bb/desktop --force --concurrency=2` passed against the rebuilt AppImage in 30.129s, including separate GUI-mount removal and healthy owned-runtime-mount assertions.
- Original PR CI run 33658556550 passed every substantive check, including the exact Ubuntu Linux Package Smoke lifecycle step.
- After rebasing onto current `main` at `d2dc1cfe26f4aa0183686168eff63d4aafc915ff`: focused desktop process tests passed (7 passed, 2 platform skips), desktop typecheck passed (3/3 Turbo tasks), desktop build passed (13/13 Turbo tasks), formatting passed, and `git diff --check` passed.
- A pre-rebase full desktop suite reached 246 passing tests and 2 platform skips; the unrelated real-Electron preload smoke alone missed its existing fixed 15-second readiness ceiling on the Intel host. No timeout was changed and no rerun was used as root-cause evidence.
- After each Linux smoke, process, FUSE mount, and smoke-temp checks were empty. The isolated VM and its guest-local source, AppImages, build outputs, and traces were deleted; final Lima, process, and mount checks were empty.

> AGENT GENERATED: by GPT-5.6-Sol
