### PR TITLE
Replace plugin Browse with category shelves

### DIFF
--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -295,7 +295,10 @@ function AppRoutes() {
             path={TOOLS_REGISTRY_SKILL_DETAIL_ROUTE_PATH}
             element={<ToolsView />}
           />
-          <Route path={TOOLS_PLUGINS_ROUTE_PATH} element={<ToolsView />} />
+          <Route
+            path={`${TOOLS_PLUGINS_ROUTE_PATH}/*`}
+            element={<ToolsPluginsRoute />}
+          />
           <Route
             path={TOOLS_PLUGIN_BROWSE_ROUTE_PATH}
             element={<ExtensionsLandingRedirect />}
@@ -326,6 +329,11 @@ function RouteContentPaintSignal() {
     markRouteContentPainted();
   }, []);
   return null;
+}
+
+function ToolsPluginsRoute() {
+  const { "*": pluginId } = useParams<"*">();
+  return <ToolsView pluginId={pluginId || undefined} />;
 }
 
 export function App() {

--- a/apps/app/src/app.css
+++ b/apps/app/src/app.css
@@ -407,6 +407,26 @@
  * The mobile path still owns its React state so software-keyboard expansion
  * remains synchronized with visualViewport changes.
  */
+[data-plugin-shelf] {
+  container: plugin-shelf / inline-size;
+}
+
+[data-plugin-shelf-grid] {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+@container plugin-shelf (min-width: 32.5rem) {
+  [data-plugin-shelf-grid] {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@container plugin-shelf (min-width: 49rem) {
+  [data-plugin-shelf-grid] {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
 @container promptbox-shell (max-width: 30rem) {
   [data-follow-up-composer] {
     --follow-up-composer-container-compact: true;

--- a/apps/app/src/components/plugin/PluginPanelRightPanelHost.test.tsx
+++ b/apps/app/src/components/plugin/PluginPanelRightPanelHost.test.tsx
@@ -140,23 +140,26 @@ vi.mock("@/hooks/queries/plugin-catalog-queries", () => ({
   usePluginCatalogSearch: (pluginId: string, options: { enabled: boolean }) => {
     catalogQueryState.queries = options.enabled ? [pluginId] : [];
     return {
-      data: [
-        {
-          pluginId,
-          displayName:
-            pluginId === "secrets"
-              ? "Secrets"
-              : pluginId === "automations"
-                ? "Automations"
-                : pluginId,
-          icon:
-            pluginId === "secrets"
-              ? "Key"
-              : pluginId === "automations"
-                ? "Bot"
-                : null,
-        },
-      ],
+      data: {
+        entries: [
+          {
+            pluginId,
+            displayName:
+              pluginId === "secrets"
+                ? "Secrets"
+                : pluginId === "automations"
+                  ? "Automations"
+                  : pluginId,
+            icon:
+              pluginId === "secrets"
+                ? "Key"
+                : pluginId === "automations"
+                  ? "Bot"
+                  : null,
+          },
+        ],
+        collections: [],
+      },
     };
   },
 }));

--- a/apps/app/src/components/plugin/PluginPanelRightPanelHost.tsx
+++ b/apps/app/src/components/plugin/PluginPanelRightPanelHost.tsx
@@ -301,7 +301,7 @@ export function PluginPanelRightPanelHost({
   );
   useEffect(() => {
     if (activePluginDetailId === null) return;
-    const catalogEntry = activePluginCatalogQuery.data?.find(
+    const catalogEntry = activePluginCatalogQuery.data?.entries.find(
       (entry) => entry.pluginId === activePluginDetailId,
     );
     if (catalogEntry === undefined) return;

--- a/apps/app/src/components/plugin/PluginsOverview.test.tsx
+++ b/apps/app/src/components/plugin/PluginsOverview.test.tsx
@@ -83,6 +83,7 @@ const GITHUB_CATALOG_ENTRY = {
   description: "Browse GitHub issues and pull requests in BB.",
   icon: "Github",
   iconUrl: null,
+  categoryId: "code-and-reviews",
   category: "Developer tools",
   source: "builtin:github",
   marketplace: "bb-official",
@@ -103,6 +104,7 @@ const AUTOMATIONS_CATALOG_ENTRY = {
   displayName: "Automations",
   description: AUTOMATIONS_PLUGIN.description,
   icon: AUTOMATIONS_PLUGIN.icon,
+  categoryId: "tasks-and-workflows",
   category: "Workflow management",
   source: AUTOMATIONS_PLUGIN.source,
   installed: true,
@@ -115,6 +117,7 @@ const DOCS_CATALOG_ENTRY = {
   displayName: "Docs",
   description: "Create and edit Markdown documents.",
   icon: "NotebookText",
+  categoryId: "memory-and-context",
   category: "Context & knowledge",
   source: "builtin:docs",
   installed: true,
@@ -153,6 +156,7 @@ function installFetch(plugins: readonly unknown[] = [AUTOMATIONS_PLUGIN]) {
             DOCS_CATALOG_ENTRY,
             GITHUB_CATALOG_ENTRY,
           ],
+          collections: [],
         });
       }
       if (url.pathname === "/api/v1/plugin-catalog/install") {
@@ -302,11 +306,13 @@ describe("PluginsOverview", () => {
     );
 
     expect(await screen.findByText("GitHub")).toBeTruthy();
-    const categoryTrigger = screen.getByRole("button", { name: "Category" });
+    const categoryTrigger = screen.getByRole("button", {
+      name: "Filter plugins by category: All categories",
+    });
     expect(screen.queryByRole("button", { name: "Type" })).toBeNull();
-    fireEvent.pointerDown(categoryTrigger);
+    fireEvent.click(categoryTrigger);
     fireEvent.click(
-      screen.getByRole("menuitemcheckbox", { name: "Context & knowledge" }),
+      screen.getByRole("option", { name: /Context & knowledge/u }),
     );
     fireEvent.keyDown(document, { key: "Escape" });
     expect(screen.getByText("Docs")).toBeTruthy();
@@ -374,11 +380,16 @@ describe("PluginsOverview", () => {
     ).toBeNull();
     const search = screen.getByRole("textbox", { name: "Search plugins" });
     const toolbar = search.parentElement?.parentElement as HTMLElement;
-    const category = screen.getByRole("button", { name: "Category" });
+    const category = screen.getByRole("button", {
+      name: "Filter plugins by category: All categories",
+    });
     const sort = screen.getByRole("button", { name: /^Sort:/ });
     expect(toolbar.contains(category)).toBe(true);
     expect(toolbar.contains(sort)).toBe(true);
-    const heroHeading = screen.getByRole("heading", { level: 2 });
+    const heroHeading = screen.getByRole("heading", {
+      level: 2,
+      name: /^Turn bb into/,
+    });
     expect(
       heroHeading.compareDocumentPosition(toolbar) &
         Node.DOCUMENT_POSITION_FOLLOWING,

--- a/apps/app/src/components/plugin/PluginsOverview.tsx
+++ b/apps/app/src/components/plugin/PluginsOverview.tsx
@@ -42,7 +42,11 @@ function modeFromSearchParams(value: string | null): PluginsCollectionMode {
   return "browse";
 }
 
-export function PluginsOverview() {
+export function PluginsOverview({
+  onOpenPlugin,
+}: {
+  onOpenPlugin?: (pluginId: string, trigger: HTMLButtonElement) => void;
+} = {}) {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const listQuery = usePluginList({ enabled: true });
@@ -165,8 +169,9 @@ export function PluginsOverview() {
     content = (
       <BrowsePluginsTab
         onInstall={(initial) => setAddDialog({ open: true, initial })}
-        onOpenPlugin={(pluginId) =>
-          navigate(getPluginDetailRoutePath({ pluginId }))
+        onOpenPlugin={
+          onOpenPlugin ??
+          ((pluginId) => navigate(getPluginDetailRoutePath({ pluginId })))
         }
         onInstallFromSource={() => setAddDialog({ open: true, initial: null })}
       />

--- a/apps/app/src/components/plugin/management/BrowsePluginsTab.test.tsx
+++ b/apps/app/src/components/plugin/management/BrowsePluginsTab.test.tsx
@@ -2,8 +2,11 @@
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { MemoryRouter } from "react-router-dom";
-import type { PluginCatalogSearchEntry } from "@/hooks/queries/plugin-catalog-queries";
+import { MemoryRouter, useLocation } from "react-router-dom";
+import type {
+  PluginCatalogSearchData,
+  PluginCatalogSearchEntry,
+} from "@/hooks/queries/plugin-catalog-queries";
 import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
 import { BrowsePluginsTab } from "./BrowsePluginsTab";
 
@@ -13,6 +16,57 @@ vi.mock("@/components/plugin/PluginNewThreadComposer", () => ({
   ),
 }));
 
+const MEMORY_ENTRY: PluginCatalogSearchEntry = {
+  entryId: "memory",
+  pluginId: "memory",
+  displayName: "Memory",
+  description: "Durable memory for agents.",
+  icon: "Brain",
+  iconUrl: null,
+  iconTinted: false,
+  categoryId: "memory-and-context",
+  category: "Memory & Context",
+  screenshots: [],
+  collections: [],
+  publishedAt: "2026-08-20T00:00:00Z",
+  source: "builtin:memory",
+  repositoryUrl: null,
+  marketplace: "bb-official",
+  marketplaceDisplayName: "BB Official",
+  publisherKey: "bb-official",
+  publisherLabel: "BB Official",
+  official: true,
+  author: { name: "BB", url: "https://github.com/get-bb" },
+  installed: false,
+  installs: 4_210,
+  compatible: true,
+  incompatibleReason: null,
+};
+
+const SECURITY_ENTRY: PluginCatalogSearchEntry = {
+  ...MEMORY_ENTRY,
+  entryId: "security",
+  pluginId: "security",
+  displayName: "Security",
+  description: "Protect agent work.",
+  categoryId: "security",
+  category: "Security",
+  publishedAt: undefined,
+  installs: 900,
+};
+
+const TASKS_ENTRY: PluginCatalogSearchEntry = {
+  ...MEMORY_ENTRY,
+  entryId: "tasks",
+  pluginId: "tasks",
+  displayName: "Tasks",
+  description: "Track work.",
+  categoryId: "tasks-and-workflows",
+  category: "Tasks & Workflows",
+  publishedAt: "2026-08-25T00:00:00Z",
+  installs: null,
+};
+
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
     status,
@@ -20,605 +74,430 @@ function jsonResponse(body: unknown, status = 200): Response {
   });
 }
 
-const MEMORY_ENTRY: PluginCatalogSearchEntry = {
-  entryId: "memory",
-  marketplace: "bb-official",
-  pluginId: "memory",
-  displayName: "Memory",
-  description: "Provider-independent durable memory for agents.",
-  icon: "Brain",
-  iconUrl: null,
-  iconTinted: false,
-  category: "Context & knowledge",
-  source: "builtin:memory",
-  repositoryUrl: null,
-  marketplaceDisplayName: "BB Official",
-  publisherKey: "bb-official",
-  publisherLabel: "BB Official",
-  official: true,
-  author: null,
-  installed: false,
-  installs: null,
-  compatible: true,
-  incompatibleReason: null,
-};
+function stubCatalog(data: PluginCatalogSearchData) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.startsWith("/api/v1/plugin-catalog/search")) {
+        return jsonResponse({
+          results: data.entries,
+          collections: data.collections,
+        });
+      }
+      return jsonResponse({ error: "not found" }, 404);
+    }),
+  );
+}
 
-const CATALOG_STATUS = {
-  pluginCount: 13,
-  includedPluginCount: 8,
-  optionalPluginCount: 5,
-};
+function LocationProbe() {
+  const location = useLocation();
+  return <output data-testid="location-search">{location.search}</output>;
+}
 
-const INCOMPATIBLE_ENTRY: PluginCatalogSearchEntry = {
-  ...MEMORY_ENTRY,
-  entryId: "future-memory",
-  marketplace: "bb-official",
-  pluginId: "future-memory",
-  displayName: "Future Memory",
-  compatible: false,
-  incompatibleReason: "Requires a newer BB version",
-};
+function renderBrowse(
+  data: PluginCatalogSearchData,
+  initialEntry = "/extensions/plugins",
+  onInstall = vi.fn(),
+  onOpenPlugin = vi.fn(),
+) {
+  stubCatalog(data);
+  const { wrapper } = createQueryClientTestHarness();
+  render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <BrowsePluginsTab
+        onInstall={onInstall}
+        onOpenPlugin={onOpenPlugin}
+        onInstallFromSource={() => undefined}
+      />
+      <LocationProbe />
+    </MemoryRouter>,
+    { wrapper },
+  );
+  return { onInstall, onOpenPlugin };
+}
 
-const GITHUB_ENTRY: PluginCatalogSearchEntry = {
-  ...MEMORY_ENTRY,
-  entryId: "github",
-  marketplace: "bb-official",
-  pluginId: "github",
-  displayName: "GitHub",
-  description: "Browse GitHub issues and pull requests in BB.",
-  icon: "Github",
-  iconUrl: null,
-  iconTinted: false,
-  category: "Developer tools",
-  source: "builtin:github",
-};
-
-const INSTALLED_MEMORY_PLUGIN = {
-  id: "memory",
-  source: "builtin:memory",
-  rootDir: "/plugins/memory",
-  version: "0.1.0",
-  provenance: "catalog",
-  isOrphanedBuiltin: false,
-  catalogEntryId: "memory",
-  catalogMarketplaceName: "bb-official",
-  publisherKey: "bb-official",
-  publisherLabel: "BB Official",
-  sourceDisplay: "BB Official · Memory",
-  updateState: {},
-  enabled: true,
-  description: MEMORY_ENTRY.description,
-  name: MEMORY_ENTRY.displayName,
-  icon: MEMORY_ENTRY.icon,
-  status: "running",
-  statusDetail: null,
-  handlerStats: { count: 0, totalMs: 0, maxMs: 0, errorCount: 0 },
-  services: [],
-  schedules: [],
-  cliCommand: null,
-  hasSettings: false,
-  app: { hasApp: false, bundle: null },
-  logoUrl: null,
-  logoDarkUrl: null,
-};
+function cardOrder(): string[] {
+  return [
+    ...document.querySelectorAll<HTMLButtonElement>(
+      'button[aria-label^="Open "][aria-label$=" details"]',
+    ),
+  ].map((button) => button.getAttribute("aria-label") ?? "");
+}
 
 afterEach(() => {
   cleanup();
-  vi.unstubAllGlobals();
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
 describe("BrowsePluginsTab", () => {
-  it("sorts by plugin name across the grid and reverses direction", async () => {
-    const entries = [
-      { ...MEMORY_ENTRY, displayName: "Zulu" },
-      { ...GITHUB_ENTRY, displayName: "Alpha" },
-      { ...INCOMPATIBLE_ENTRY, displayName: "Middle" },
-    ];
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (url: string) => {
-        if (url === "/api/v1/plugin-catalog") {
-          return jsonResponse({ catalog: CATALOG_STATUS });
-        }
-        if (url === "/api/v1/plugin-catalog/search?q=") {
-          return jsonResponse({ results: entries });
-        }
-        if (url === "/api/v1/plugins") {
-          return jsonResponse({ enabled: true, plugins: [] });
-        }
-        return jsonResponse({ error: "not found" }, 404);
-      }),
-    );
-
-    const { wrapper } = createQueryClientTestHarness();
-    render(
-      <MemoryRouter>
-        <BrowsePluginsTab
-          onInstall={() => {}}
-          onOpenPlugin={() => {}}
-          onInstallFromSource={() => {}}
-        />
-      </MemoryRouter>,
-      {
-        wrapper,
-      },
-    );
-
-    expect(await screen.findByText("Alpha")).toBeTruthy();
-    const cardOrder = () =>
-      [
-        ...document.querySelectorAll<HTMLButtonElement>(
-          'button[aria-label^="Open "][aria-label$=" details"]',
-        ),
-      ].map((button) => button.getAttribute("aria-label"));
-    expect(cardOrder()).toEqual(["Open Alpha details", "Open Zulu details"]);
-
-    const sortTrigger = screen.getByRole("button", {
-      name: "Sort: Plugin name, ascending",
+  it("shows collection shelves before category shelves", async () => {
+    renderBrowse({
+      entries: [
+        {
+          ...MEMORY_ENTRY,
+          collections: [{ id: "new-and-notable", rank: 1 }],
+        },
+        SECURITY_ENTRY,
+        {
+          ...TASKS_ENTRY,
+          collections: [{ id: "new-and-notable", rank: 0 }],
+        },
+      ],
+      collections: [
+        {
+          id: "new-and-notable",
+          displayName: "New & notable",
+          pluginIds: ["tasks", "memory"],
+        },
+      ],
     });
-    expect(sortTrigger.querySelector('[data-icon="ArrowUpDown"]')).toBeTruthy();
-    fireEvent.pointerDown(sortTrigger);
-    fireEvent.click(screen.getByRole("menuitemradio", { name: "Plugin name" }));
-    expect(cardOrder()).toEqual(["Open Zulu details", "Open Alpha details"]);
-    expect(screen.queryByText("Context & knowledge")).toBeNull();
-    expect(screen.queryByText("Developer tools")).toBeNull();
+
+    await screen.findByRole("heading", { name: "New & notable" });
+    const labels = [
+      ...document.querySelectorAll("[data-testid='plugin-browse-shelves'] h2"),
+    ].map((heading) => heading.textContent);
+    expect(labels).toEqual([
+      "New & notable",
+      "Memory & Context",
+      "Security",
+      "Tasks & Workflows",
+    ]);
+    expect(screen.getAllByText("Memory")).toHaveLength(2);
+    expect(screen.queryByText("BB Official plugins")).toBeNull();
   });
 
-  it("groups entries by marketplace and names third-party origins on cards", async () => {
-    const entries = [
-      { ...MEMORY_ENTRY, displayName: "Memory" },
-      {
-        ...MEMORY_ENTRY,
-        entryId: "notes",
-        pluginId: "notes",
-        displayName: "Acme Notes",
-        category: "Git Tools",
-        marketplace: "acme-plugins",
-        marketplaceDisplayName: "Acme Plugins",
-        publisherKey: "acme-plugins",
-        publisherLabel: "Acme Plugins",
-        official: false,
-        author: { name: "Acme", url: "https://github.com/acme" },
-        repositoryUrl: "https://github.com/acme/notes",
-      },
-    ];
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (url: string) => {
-        if (url === "/api/v1/plugin-catalog") {
-          return jsonResponse({ catalog: CATALOG_STATUS });
-        }
-        if (url === "/api/v1/plugin-catalog/search?q=") {
-          return jsonResponse({ results: entries });
-        }
-        if (url === "/api/v1/plugins") {
-          return jsonResponse({ enabled: true, plugins: [] });
-        }
-        return jsonResponse({ error: "not found" }, 404);
-      }),
+  it("round trips the search parameter", async () => {
+    renderBrowse(
+      { entries: [MEMORY_ENTRY], collections: [] },
+      "/extensions/plugins?query=Mem",
     );
 
-    const { wrapper } = createQueryClientTestHarness();
-    render(
-      <MemoryRouter>
-        <BrowsePluginsTab
-          onInstall={() => {}}
-          onOpenPlugin={() => {}}
-          onInstallFromSource={() => {}}
-        />
-      </MemoryRouter>,
-      { wrapper },
-    );
-
-    await screen.findByText("Acme Notes");
-    expect(screen.getByText("BB Official")).toBeTruthy();
-    expect(screen.getAllByText("Acme Plugins").length).toBeGreaterThan(0);
-    expect(screen.getByText("third-party marketplace")).toBeTruthy();
-    expect(screen.getByText("By: Acme")).toBeTruthy();
-    const repositoryLink = screen.getByRole("link", {
-      name: "Open Acme Notes repository",
+    const search = await screen.findByRole("textbox", {
+      name: "Search plugins",
     });
-    expect(repositoryLink.getAttribute("href")).toBe(
-      "https://github.com/acme/notes",
+    expect((search as HTMLInputElement).value).toBe("Mem");
+    fireEvent.change(search, { target: { value: "Memory" } });
+
+    const params = new URLSearchParams(
+      screen.getByTestId("location-search").textContent ?? "",
+    );
+    expect(params.get("query")).toBe("Memory");
+  });
+
+  it("round trips repeatable category parameters", async () => {
+    renderBrowse(
+      { entries: [MEMORY_ENTRY, SECURITY_ENTRY, TASKS_ENTRY], collections: [] },
+      "/extensions/plugins?category=memory-and-context&category=security",
+    );
+
+    const trigger = await screen.findByRole("button", {
+      name: "Filter plugins by category: Memory & Context, Security",
+    });
+    expect(trigger.textContent).toContain("2 categories");
+    fireEvent.click(trigger);
+    fireEvent.click(
+      await screen.findByRole("option", { name: /Tasks & Workflows/u }),
+    );
+
+    const params = new URLSearchParams(
+      screen.getByTestId("location-search").textContent ?? "",
+    );
+    expect(params.getAll("category")).toEqual([
+      "memory-and-context",
+      "security",
+      "tasks-and-workflows",
+    ]);
+    fireEvent.click(screen.getByRole("option", { name: /Security/u }));
+    const nextParams = new URLSearchParams(
+      screen.getByTestId("location-search").textContent ?? "",
+    );
+    expect(nextParams.getAll("category")).toEqual([
+      "memory-and-context",
+      "tasks-and-workflows",
+    ]);
+  });
+
+  it("orders category options by the shelf category order", async () => {
+    renderBrowse({
+      entries: [
+        TASKS_ENTRY,
+        {
+          ...MEMORY_ENTRY,
+          entryId: "unknown",
+          pluginId: "unknown",
+          displayName: "Unknown",
+          categoryId: "unknown-category",
+          category: "Unknown Category",
+        },
+        {
+          ...MEMORY_ENTRY,
+          entryId: "uncategorized",
+          pluginId: "uncategorized",
+          displayName: "Uncategorized",
+          categoryId: undefined,
+          category: undefined,
+        },
+        SECURITY_ENTRY,
+        MEMORY_ENTRY,
+      ],
+      collections: [],
+    });
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "Filter plugins by category: All categories",
+      }),
     );
     expect(
-      screen.queryByRole("link", { name: "Open Memory repository" }),
-    ).toBeNull();
-  });
-
-  it("shows a compact install count beside the other card footer facts", async () => {
-    const entries = [
-      { ...MEMORY_ENTRY, displayName: "Memory", installs: 4_210 },
-      {
-        ...MEMORY_ENTRY,
-        entryId: "notes",
-        pluginId: "notes",
-        displayName: "Acme Notes",
-        marketplace: "acme-plugins",
-        marketplaceDisplayName: "Acme Plugins",
-        publisherKey: "acme-plugins",
-        publisherLabel: "Acme Plugins",
-        official: false,
-        installs: null,
-      },
-      {
-        ...MEMORY_ENTRY,
-        entryId: "solo",
-        pluginId: "solo",
-        displayName: "Solo",
-        installs: 1,
-      },
-    ];
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (url: string) => {
-        if (url === "/api/v1/plugin-catalog") {
-          return jsonResponse({ catalog: CATALOG_STATUS });
-        }
-        if (url === "/api/v1/plugin-catalog/search?q=") {
-          return jsonResponse({ results: entries });
-        }
-        if (url === "/api/v1/plugins") {
-          return jsonResponse({ enabled: true, plugins: [] });
-        }
-        return jsonResponse({ error: "not found" }, 404);
-      }),
-    );
-
-    const { wrapper } = createQueryClientTestHarness();
-    render(
-      <MemoryRouter>
-        <BrowsePluginsTab
-          onInstall={() => {}}
-          onOpenPlugin={() => {}}
-          onInstallFromSource={() => {}}
-        />
-      </MemoryRouter>,
-      { wrapper },
-    );
-
-    await screen.findByText("Acme Notes");
-    const count = screen.getByText("4.2K installs");
-    expect(count.getAttribute("title")).toBe("4,210 installs");
-    expect(screen.getByText("1 install")).toBeTruthy();
-    expect(screen.getAllByText("Acme Plugins").length).toBeGreaterThan(0);
-    expect(screen.queryByText("0 installs")).toBeNull();
-  });
-
-  it("sorts by install count, sinking uncounted entries in both directions", async () => {
-    const entries = [
-      {
-        ...MEMORY_ENTRY,
-        entryId: "mid",
-        pluginId: "mid",
-        displayName: "Mid",
-        installs: 50,
-      },
-      {
-        ...MEMORY_ENTRY,
-        entryId: "top",
-        pluginId: "top",
-        displayName: "Top",
-        installs: 900,
-      },
-      {
-        ...MEMORY_ENTRY,
-        entryId: "unknown",
-        pluginId: "unknown",
-        displayName: "Unknown",
-        installs: null,
-      },
-    ];
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (url: string) => {
-        if (url === "/api/v1/plugin-catalog") {
-          return jsonResponse({ catalog: CATALOG_STATUS });
-        }
-        if (url === "/api/v1/plugin-catalog/search?q=") {
-          return jsonResponse({ results: entries });
-        }
-        if (url === "/api/v1/plugins") {
-          return jsonResponse({ enabled: true, plugins: [] });
-        }
-        return jsonResponse({ error: "not found" }, 404);
-      }),
-    );
-
-    const { wrapper } = createQueryClientTestHarness();
-    render(
-      <MemoryRouter>
-        <BrowsePluginsTab
-          onInstall={() => {}}
-          onOpenPlugin={() => {}}
-          onInstallFromSource={() => {}}
-        />
-      </MemoryRouter>,
-      { wrapper },
-    );
-
-    await screen.findByText("Top");
-    const cardOrder = () =>
-      [
-        ...document.querySelectorAll<HTMLButtonElement>(
-          'button[aria-label^="Open "][aria-label$=" details"]',
-        ),
-      ].map((button) => button.getAttribute("aria-label"));
-
-    const sortTrigger = screen.getByRole("button", { name: /^Sort: / });
-    expect(sortTrigger.getAttribute("aria-label")).toBe(
-      "Sort: Installs, descending",
-    );
-    expect(cardOrder()).toEqual([
-      "Open Top details",
-      "Open Mid details",
-      "Open Unknown details",
+      (await screen.findAllByRole("option")).map(
+        (option) => option.textContent,
+      ),
+    ).toEqual([
+      expect.stringContaining("Memory & Context"),
+      expect.stringContaining("Security"),
+      expect.stringContaining("Tasks & Workflows"),
+      expect.stringContaining("Unknown Category"),
+      expect.stringContaining("Uncategorized"),
     ]);
-
-    fireEvent.pointerDown(sortTrigger);
-    const selectSort = (name: string) => {
-      fireEvent.click(screen.getByRole("menuitemradio", { name }));
-    };
-
-    selectSort("Installs");
-    expect(cardOrder()).toEqual([
-      "Open Mid details",
-      "Open Top details",
-      "Open Unknown details",
-    ]);
-
-    selectSort("Plugin name");
-    expect(cardOrder()).toEqual([
-      "Open Mid details",
-      "Open Top details",
-      "Open Unknown details",
-    ]);
-    expect(sortTrigger.getAttribute("aria-label")).toBe(
-      "Sort: Plugin name, ascending",
-    );
   });
 
   it("disables the install sort when no listing publishes a count", async () => {
-    const entries = [
-      { ...MEMORY_ENTRY, displayName: "Memory" },
-      { ...GITHUB_ENTRY, displayName: "GitHub" },
-    ];
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (url: string) => {
-        if (url === "/api/v1/plugin-catalog") {
-          return jsonResponse({ catalog: CATALOG_STATUS });
-        }
-        if (url === "/api/v1/plugin-catalog/search?q=") {
-          return jsonResponse({ results: entries });
-        }
-        if (url === "/api/v1/plugins") {
-          return jsonResponse({ enabled: true, plugins: [] });
-        }
-        return jsonResponse({ error: "not found" }, 404);
-      }),
-    );
+    renderBrowse({
+      entries: [
+        { ...MEMORY_ENTRY, installs: null },
+        { ...SECURITY_ENTRY, installs: null },
+      ],
+      collections: [],
+    });
 
-    const { wrapper } = createQueryClientTestHarness();
-    render(
-      <MemoryRouter>
-        <BrowsePluginsTab
-          onInstall={() => {}}
-          onOpenPlugin={() => {}}
-          onInstallFromSource={() => {}}
-        />
-      </MemoryRouter>,
-      { wrapper },
+    const sortTrigger = await screen.findByRole("button", {
+      name: "Sort: Featured",
+    });
+    fireEvent.pointerDown(sortTrigger);
+    expect(
+      screen
+        .getByRole("menuitemradio", { name: "Most installed" })
+        .getAttribute("aria-disabled"),
+    ).toBe("true");
+  });
+
+  it("sorts by install count and sinks uncounted entries in both directions", async () => {
+    renderBrowse(
+      { entries: [MEMORY_ENTRY, SECURITY_ENTRY, TASKS_ENTRY], collections: [] },
+      "/extensions/plugins?sort=most-installed",
     );
 
     await screen.findByText("Memory");
-    const sortTrigger = screen.getByRole("button", { name: /^Sort: / });
-    fireEvent.pointerDown(sortTrigger);
-    const installsItem = screen.getByRole("menuitemradio", {
-      name: "Installs",
+    expect(cardOrder()).toEqual([
+      "Open Memory details",
+      "Open Security details",
+      "Open Tasks details",
+    ]);
+    const trigger = screen.getByRole("button", {
+      name: "Sort: Most installed, descending",
     });
-    expect(installsItem.getAttribute("aria-disabled")).toBe("true");
-    fireEvent.click(installsItem);
-    expect(sortTrigger.getAttribute("aria-label")).toBe(
-      "Sort: Plugin name, ascending",
+    fireEvent.pointerDown(trigger);
+    fireEvent.click(
+      screen.getByRole("menuitemradio", { name: "Most installed" }),
     );
+    expect(cardOrder()).toEqual([
+      "Open Security details",
+      "Open Memory details",
+      "Open Tasks details",
+    ]);
+    expect(screen.getByText("Memory & Context")).toBeTruthy();
   });
 
-  it("keeps a marketplace that copies a publisher label in its own group", async () => {
-    const entries = [
-      { ...MEMORY_ENTRY, displayName: "Memory" },
-      {
-        ...MEMORY_ENTRY,
-        entryId: "notes",
-        pluginId: "notes",
-        displayName: "Acme Notes",
-        marketplace: "acme-plugins",
-        marketplaceDisplayName: "BB Official",
-        publisherKey: "acme-plugins",
-        publisherLabel: "acme-plugins",
-        official: false,
-        author: { name: "Acme", url: "https://github.com/acme" },
-      },
-    ];
+  it("puts entries without a published date last in both directions", async () => {
+    renderBrowse(
+      { entries: [MEMORY_ENTRY, SECURITY_ENTRY, TASKS_ENTRY], collections: [] },
+      "/extensions/plugins?sort=recently-added",
+    );
+
+    await screen.findByText("Memory");
+    expect(cardOrder()).toEqual([
+      "Open Tasks details",
+      "Open Memory details",
+      "Open Security details",
+    ]);
+    const trigger = screen.getByRole("button", {
+      name: "Sort: Recently added, descending",
+    });
+    fireEvent.pointerDown(trigger);
+    fireEvent.click(
+      screen.getByRole("menuitemradio", { name: "Recently added" }),
+    );
+    expect(cardOrder()).toEqual([
+      "Open Memory details",
+      "Open Tasks details",
+      "Open Security details",
+    ]);
+  });
+
+  it("clears a flat sort and restores the shelves", async () => {
+    renderBrowse(
+      { entries: [MEMORY_ENTRY, SECURITY_ENTRY], collections: [] },
+      "/extensions/plugins?sort=most-installed",
+    );
+
+    const trigger = await screen.findByRole("button", {
+      name: "Sort: Most installed, descending",
+    });
+    expect(screen.queryByTestId("plugin-browse-shelves")).toBeNull();
+    fireEvent.pointerDown(trigger);
+    fireEvent.click(screen.getByRole("menuitemradio", { name: "Featured" }));
+    expect(await screen.findByTestId("plugin-browse-shelves")).toBeTruthy();
+    const params = new URLSearchParams(
+      screen.getByTestId("location-search").textContent ?? "",
+    );
+    expect(params.has("sort")).toBe(false);
+    expect(params.has("direction")).toBe(false);
+  });
+
+  it("expands a shelf beyond the six-entry limit", async () => {
+    const entries = Array.from({ length: 8 }, (_, index) => ({
+      ...MEMORY_ENTRY,
+      entryId: `memory-${index}`,
+      pluginId: `memory-${index}`,
+      displayName: `Memory ${index}`,
+    }));
+    renderBrowse({ entries, collections: [] });
+
+    await screen.findByTestId("plugin-browse-shelves");
+    expect(cardOrder()).toHaveLength(6);
+    fireEvent.click(screen.getByRole("button", { name: "See all" }));
+    expect(cardOrder()).toHaveLength(8);
+  });
+
+  it("shows all five cards in a narrow shelf", async () => {
+    const originalWidth = window.innerWidth;
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 700,
+    });
+    const entries = Array.from({ length: 5 }, (_, index) => ({
+      ...MEMORY_ENTRY,
+      entryId: `memory-${index}`,
+      pluginId: `memory-${index}`,
+      displayName: `Memory ${index}`,
+    }));
+    renderBrowse({ entries, collections: [] });
+
+    await screen.findByTestId("plugin-browse-shelves");
+    expect(cardOrder()).toHaveLength(5);
+    expect(screen.queryByRole("button", { name: "See all" })).toBeNull();
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: originalWidth,
+    });
+  });
+
+  it("uses the shared error state and retries catalog searches", async () => {
+    let searchAttempts = 0;
     vi.stubGlobal(
       "fetch",
-      vi.fn(async (url: string) => {
-        if (url === "/api/v1/plugin-catalog") {
-          return jsonResponse({ catalog: CATALOG_STATUS });
-        }
-        if (url === "/api/v1/plugin-catalog/search?q=") {
-          return jsonResponse({ results: entries });
-        }
-        if (url === "/api/v1/plugins") {
-          return jsonResponse({ enabled: true, plugins: [] });
+      vi.fn(async (input: RequestInfo | URL) => {
+        if (String(input).startsWith("/api/v1/plugin-catalog/search")) {
+          searchAttempts += 1;
+          return searchAttempts === 1
+            ? jsonResponse({ error: "unavailable" }, 503)
+            : jsonResponse({ results: [MEMORY_ENTRY], collections: [] });
         }
         return jsonResponse({ error: "not found" }, 404);
       }),
     );
-
     const { wrapper } = createQueryClientTestHarness();
     render(
       <MemoryRouter>
         <BrowsePluginsTab
-          onInstall={() => {}}
-          onOpenPlugin={() => {}}
-          onInstallFromSource={() => {}}
+          onInstall={() => undefined}
+          onOpenPlugin={() => undefined}
+          onInstallFromSource={() => undefined}
         />
       </MemoryRouter>,
       { wrapper },
     );
 
-    await screen.findByText("Acme Notes");
-    expect(screen.getByText("BB Official")).toBeTruthy();
-    expect(screen.getByText("third-party marketplace")).toBeTruthy();
+    expect((await screen.findByRole("alert")).textContent).toContain(
+      "The plugin catalog is not available.",
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(await screen.findByText("Memory")).toBeTruthy();
+    expect(searchAttempts).toBe(2);
   });
 
-  it("renders every catalog entry once and filters the grid by category", async () => {
-    const entries = Array.from(
-      { length: CATALOG_STATUS.pluginCount },
-      (_, index) => ({
-        ...MEMORY_ENTRY,
-        entryId: `official-${index + 1}`,
-        pluginId: `official-${index + 1}`,
-        displayName: `Official ${index + 1}`,
-        category: index % 2 === 0 ? "Context & knowledge" : "Developer tools",
-      }),
-    );
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (url: string) => {
-        if (url === "/api/v1/plugin-catalog") {
-          return jsonResponse({ catalog: CATALOG_STATUS });
-        }
-        if (url === "/api/v1/plugin-catalog/search?q=") {
-          return jsonResponse({ results: entries });
-        }
-        if (url === "/api/v1/plugins") {
-          return jsonResponse({ enabled: true, plugins: [] });
-        }
-        return jsonResponse({ error: "not found" }, 404);
-      }),
-    );
+  it("marks installed entries instead of offering install", async () => {
+    renderBrowse({
+      entries: [{ ...MEMORY_ENTRY, installed: true }],
+      collections: [],
+    });
 
-    const { wrapper } = createQueryClientTestHarness();
-    const { container } = render(
-      <MemoryRouter>
-        <BrowsePluginsTab
-          onInstall={() => {}}
-          onOpenPlugin={() => {}}
-          onInstallFromSource={() => {}}
-        />
-      </MemoryRouter>,
-      { wrapper },
-    );
-
-    const cardCount = () =>
-      container.querySelectorAll('[aria-label^="Open Official "]').length;
-
-    expect(await screen.findByText("Official 1")).toBeTruthy();
-    expect(cardCount()).toBe(CATALOG_STATUS.pluginCount);
+    const installed = await screen.findByLabelText("Installed");
+    expect(installed.textContent).toContain("Installed");
+    expect(installed.querySelector('[data-icon="Check"]')).toBeTruthy();
+    expect(screen.getByLabelText("4,210 installs")).toBeTruthy();
+    expect(installed.tagName).toBe("SPAN");
     expect(
-      screen.queryByRole("radiogroup", { name: "Filter plugins by category" }),
+      screen.queryByRole("button", { name: /Install Memory/u }),
     ).toBeNull();
-    const categoryTrigger = screen.getByRole("button", { name: "Category" });
-    fireEvent.pointerDown(categoryTrigger);
-    expect(screen.queryByRole("menuitemcheckbox", { name: "All" })).toBeNull();
-
-    fireEvent.click(
-      screen.getByRole("menuitemcheckbox", { name: "Developer tools" }),
-    );
-    expect(cardCount()).toBe(6);
-    expect(
-      container.querySelector('[aria-label="Open Official 1 details"]'),
-    ).toBeNull();
-
-    fireEvent.click(
-      screen.getByRole("menuitemcheckbox", { name: "Context & knowledge" }),
-    );
-    expect(cardCount()).toBe(CATALOG_STATUS.pluginCount);
-
-    fireEvent.click(
-      screen.getByRole("menuitemcheckbox", { name: "Developer tools" }),
-    );
-    fireEvent.click(
-      screen.getByRole("menuitemcheckbox", { name: "Context & knowledge" }),
-    );
-    expect(cardCount()).toBe(CATALOG_STATUS.pluginCount);
-    expect(screen.queryByText("BB Official plugins")).toBeNull();
   });
 
-  it("shows the official plugins and entries", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (url: string) => {
-        if (url === "/api/v1/plugin-catalog") {
-          return jsonResponse({ catalog: CATALOG_STATUS });
-        }
-        if (url === "/api/v1/plugin-catalog/search?q=") {
-          return jsonResponse({
-            results: [MEMORY_ENTRY, INCOMPATIBLE_ENTRY, GITHUB_ENTRY],
-          });
-        }
-        if (url === "/api/v1/plugins") {
-          return jsonResponse({ enabled: true, plugins: [] });
-        }
-        return jsonResponse({ error: "not found" }, 404);
-      }),
-    );
+  it("swaps the browse body for examples while composing", async () => {
+    renderBrowse({ entries: [MEMORY_ENTRY], collections: [] });
 
+    expect(
+      await screen.findByRole("button", { name: "Open Memory details" }),
+    ).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Create a plugin" }));
+    expect(await screen.findByText("Start from an example")).toBeTruthy();
+    expect(screen.getByText("Explore plugin capabilities")).toBeTruthy();
+    expect(
+      screen.queryByRole("textbox", { name: "Search plugins" }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Open Memory details" }),
+    ).toBeNull();
+  });
+
+  it("routes every create affordance into the inline composer", async () => {
+    renderBrowse({ entries: [MEMORY_ENTRY], collections: [] });
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Create a plugin" }),
+    );
+    expect((await screen.findByTestId("inline-composer")).textContent).toBe(
+      "Create a new bb plugin that ",
+    );
+    fireEvent.click(
+      screen.getByText(
+        "Ship a board your agents move cards across while they work.",
+      ),
+    );
+    expect(
+      (await screen.findByTestId("inline-composer")).textContent,
+    ).toContain("kanban board panel");
+    fireEvent.click(screen.getByText("CLI command"));
+    expect(
+      (await screen.findByTestId("inline-composer")).textContent,
+    ).toContain("deploys the current branch to staging");
+  });
+
+  it("shows compact install data and reports the card trigger", async () => {
     const onInstall = vi.fn();
     const onOpenPlugin = vi.fn();
-    const { wrapper } = createQueryClientTestHarness();
-    render(
-      <MemoryRouter>
-        <BrowsePluginsTab
-          onInstall={onInstall}
-          onOpenPlugin={onOpenPlugin}
-          onInstallFromSource={() => {}}
-        />
-      </MemoryRouter>,
-      { wrapper },
+    renderBrowse(
+      { entries: [MEMORY_ENTRY], collections: [] },
+      "/extensions/plugins?sort=most-installed",
+      onInstall,
+      onOpenPlugin,
     );
 
-    expect(await screen.findByText("Memory")).toBeTruthy();
-    const memoryCard = (await screen.findByText("Memory")).closest("div");
-    expect(memoryCard).not.toBeNull();
-    expect(
-      (memoryCard as HTMLElement).querySelector('[data-icon="Brain"]'),
-    ).not.toBeNull();
-    expect(
-      screen.getByRole("textbox", { name: "Search plugins" }),
-    ).toBeTruthy();
-    expect(
-      screen.getAllByText(MEMORY_ENTRY.description).length,
-    ).toBeGreaterThan(0);
-    expect(screen.getByText(GITHUB_ENTRY.description)).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Category" })).toBeTruthy();
-    expect(
-      screen.queryByRole("heading", { name: /BB Official plugins/i }),
-    ).toBeNull();
-    expect(screen.getByRole("heading", { level: 2 }).textContent).toContain(
-      "Turn bb into",
-    );
-    expect(screen.getByRole("button", { name: "Install Memory" })).toBeTruthy();
-    expect(screen.queryByText("BB Official plugins")).toBeNull();
-
-    expect(screen.queryByText(MEMORY_ENTRY.source)).toBeNull();
-    expect(screen.queryByText("Future Memory")).toBeNull();
-    expect(screen.queryByText("Requires a newer BB version")).toBeNull();
-    expect(
-      screen.queryByRole("button", { name: "Install Future Memory" }),
-    ).toBeNull();
-
-    expect(screen.queryByRole("button", { name: "Refresh" })).toBeNull();
-
-    const install = screen.getByRole("button", { name: "Install Memory" });
-    expect(install.querySelector('[data-icon="Download"]')).not.toBeNull();
-    fireEvent.pointerMove(install);
-    expect((await screen.findByRole("tooltip")).textContent).toBe(
-      "Install Memory",
-    );
+    const install = await screen.findByRole("button", {
+      name: "Install Memory — 4,210 installs",
+    });
+    expect(install.textContent).toContain("4.2K");
     fireEvent.click(install);
     expect(onInstall).toHaveBeenCalledWith({
       entryId: "memory",
@@ -630,292 +509,10 @@ describe("BrowsePluginsTab", () => {
       iconTinted: false,
       source: "builtin:memory",
     });
-    fireEvent.click(
-      screen.getByRole("button", { name: "Open Memory details" }),
-    );
-    expect(onOpenPlugin).toHaveBeenCalledWith("memory");
-  });
-
-  it("uses the shared error state and retries catalog searches", async () => {
-    let searchAttempts = 0;
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (url: string) => {
-        if (url === "/api/v1/plugin-catalog") {
-          return jsonResponse({ catalog: CATALOG_STATUS });
-        }
-        if (url === "/api/v1/plugin-catalog/search?q=") {
-          searchAttempts += 1;
-          return searchAttempts === 1
-            ? jsonResponse({ error: "unavailable" }, 503)
-            : jsonResponse({ results: [MEMORY_ENTRY] });
-        }
-        if (url === "/api/v1/plugins") {
-          return jsonResponse({ enabled: true, plugins: [] });
-        }
-        return jsonResponse({ error: "not found" }, 404);
-      }),
-    );
-
-    const { wrapper } = createQueryClientTestHarness();
-    render(
-      <MemoryRouter>
-        <BrowsePluginsTab
-          onInstall={() => {}}
-          onOpenPlugin={() => {}}
-          onInstallFromSource={() => {}}
-        />
-      </MemoryRouter>,
-      {
-        wrapper,
-      },
-    );
-
-    expect((await screen.findByRole("alert")).textContent).toContain(
-      "BB's official plugins are unavailable.",
-    );
-    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
-
-    expect(await screen.findByText("Memory")).toBeTruthy();
-    expect(searchAttempts).toBe(2);
-  });
-
-  it("marks installed entries instead of offering install", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (url: string) => {
-        if (url === "/api/v1/plugin-catalog") {
-          return jsonResponse({ catalog: CATALOG_STATUS });
-        }
-        if (url === "/api/v1/plugin-catalog/search?q=") {
-          return jsonResponse({
-            results: [{ ...MEMORY_ENTRY, installed: true }],
-          });
-        }
-        if (url === "/api/v1/plugins") {
-          return jsonResponse({
-            enabled: true,
-            plugins: [INSTALLED_MEMORY_PLUGIN],
-          });
-        }
-        return jsonResponse({ error: "not found" }, 404);
-      }),
-    );
-
-    const { wrapper } = createQueryClientTestHarness();
-    const onOpenPlugin = vi.fn();
-    render(
-      <MemoryRouter>
-        <BrowsePluginsTab
-          onInstall={() => {}}
-          onOpenPlugin={onOpenPlugin}
-          onInstallFromSource={() => {}}
-        />
-      </MemoryRouter>,
-      { wrapper },
-    );
-
-    const installed = await screen.findByRole("button", {
-      name: "Uninstall Memory",
+    const open = screen.getByRole("button", {
+      name: "Open Memory details",
     });
-    fireEvent.pointerMove(installed);
-    expect((await screen.findByRole("tooltip")).textContent).toBe(
-      "Installed — uninstall Memory",
-    );
-    expect(installed.querySelector('[data-icon="Check"]')).not.toBeNull();
-    expect(installed.querySelector('[data-icon="Download"]')).toBeNull();
-    const installedClasses = new Set(installed.className.split(/\s+/));
-    for (const restingClass of ["border-transparent", "bg-transparent"]) {
-      expect(installedClasses.has(restingClass)).toBe(true);
-    }
-    for (const variantClass of [
-      "hover:border-transparent",
-      "hover:bg-transparent",
-      "focus-visible:border-transparent",
-      "focus-visible:bg-transparent",
-    ]) {
-      expect(installedClasses.has(variantClass)).toBe(true);
-    }
-    const successTint =
-      "text-[color:color-mix(in_oklab,var(--success)_72%,var(--ink))]";
-    expect(installedClasses.has(successTint)).toBe(true);
-    expect(installedClasses.has(`hover:${successTint}`)).toBe(true);
-    expect(installedClasses.has(`focus-visible:${successTint}`)).toBe(true);
-    expect(installedClasses.has("text-success-foreground")).toBe(false);
-    expect(installedClasses.has("hover:text-foreground")).toBe(false);
-    expect(screen.queryByRole("button", { name: "Install" })).toBeNull();
-    fireEvent.click(installed);
-    expect(
-      screen.getByRole("heading", { name: "Uninstall Memory?" }),
-    ).toBeTruthy();
-    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
-
-    fireEvent.click(
-      screen.getByRole("button", { name: "Open Memory details" }),
-    );
-    expect(onOpenPlugin).toHaveBeenCalledWith("memory");
-  });
-
-  it("uses the catalog's canonical plugin id for uninstall", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (url: string) => {
-        if (url === "/api/v1/plugin-catalog") {
-          return jsonResponse({ catalog: CATALOG_STATUS });
-        }
-        if (url === "/api/v1/plugin-catalog/search?q=") {
-          return jsonResponse({
-            results: [
-              {
-                ...MEMORY_ENTRY,
-                entryId: "docs",
-                marketplace: "bb-official",
-                pluginId: "simple-notes",
-                displayName: "Docs",
-                source: "builtin:docs",
-                installed: true,
-              },
-            ],
-          });
-        }
-        if (url === "/api/v1/plugins") {
-          return jsonResponse({
-            enabled: true,
-            plugins: [
-              {
-                ...INSTALLED_MEMORY_PLUGIN,
-                id: "simple-notes",
-                source: "npm:bb-plugin-simple-notes@^0.1.0",
-                catalogEntryId: "simple-notes",
-              },
-            ],
-          });
-        }
-        return jsonResponse({ error: "not found" }, 404);
-      }),
-    );
-
-    const { wrapper } = createQueryClientTestHarness();
-    const onOpenPlugin = vi.fn();
-    render(
-      <MemoryRouter>
-        <BrowsePluginsTab
-          onInstall={() => {}}
-          onOpenPlugin={onOpenPlugin}
-          onInstallFromSource={() => {}}
-        />
-      </MemoryRouter>,
-      { wrapper },
-    );
-
-    expect(
-      await screen.findByRole("button", { name: "Uninstall Docs" }),
-    ).toBeTruthy();
-
-    fireEvent.click(screen.getByRole("button", { name: "Open Docs details" }));
-    expect(onOpenPlugin).toHaveBeenCalledWith("simple-notes");
-  });
-
-  it("swaps the browse body for examples while composing", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (url: string) => {
-        if (url === "/api/v1/plugin-catalog") {
-          return jsonResponse({ catalog: CATALOG_STATUS });
-        }
-        if (url.startsWith("/api/v1/plugin-catalog/search")) {
-          return jsonResponse({ results: [MEMORY_ENTRY, GITHUB_ENTRY] });
-        }
-        if (url === "/api/v1/plugins") {
-          return jsonResponse({ enabled: true, plugins: [] });
-        }
-        return jsonResponse({ error: "not found" }, 404);
-      }),
-    );
-
-    const { wrapper } = createQueryClientTestHarness();
-    render(
-      <MemoryRouter>
-        <BrowsePluginsTab
-          onInstallFromSource={() => {}}
-          onInstall={() => {}}
-          onOpenPlugin={() => {}}
-        />
-      </MemoryRouter>,
-      { wrapper },
-    );
-
-    expect(
-      await screen.findByRole("button", { name: "Open Memory details" }),
-    ).toBeTruthy();
-    expect(
-      screen.getByRole("textbox", { name: "Search plugins" }),
-    ).toBeTruthy();
-    expect(screen.queryByText("Start from an example")).toBeNull();
-
-    fireEvent.click(screen.getByRole("button", { name: "Create a plugin" }));
-    expect(await screen.findByText("Start from an example")).toBeTruthy();
-    expect(screen.getByText("Explore plugin capabilities")).toBeTruthy();
-    expect(
-      screen.queryByRole("textbox", { name: "Search plugins" }),
-    ).toBeNull();
-    expect(
-      screen.queryByRole("button", { name: "Open Memory details" }),
-    ).toBeNull();
-
-    fireEvent.click(screen.getByRole("button", { name: "Create a plugin" }));
-    expect(await screen.findByText("Start from an example")).toBeTruthy();
-    expect(
-      screen.queryByRole("button", { name: "Open Memory details" }),
-    ).toBeNull();
-  });
-
-  it("routes every create affordance into the inline composer", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (url: string) => {
-        if (url === "/api/v1/plugin-catalog") {
-          return jsonResponse({ catalog: CATALOG_STATUS });
-        }
-        if (url.startsWith("/api/v1/plugin-catalog/search")) {
-          return jsonResponse({ results: [MEMORY_ENTRY] });
-        }
-        if (url === "/api/v1/plugins") {
-          return jsonResponse({ enabled: true, plugins: [] });
-        }
-        return jsonResponse({ error: "not found" }, 404);
-      }),
-    );
-
-    const { wrapper } = createQueryClientTestHarness();
-    render(
-      <MemoryRouter>
-        <BrowsePluginsTab
-          onInstallFromSource={() => {}}
-          onInstall={() => {}}
-          onOpenPlugin={() => {}}
-        />
-      </MemoryRouter>,
-      { wrapper },
-    );
-
-    fireEvent.click(
-      await screen.findByRole("button", { name: "Create a plugin" }),
-    );
-    const blank = await screen.findByTestId("inline-composer");
-    expect(blank.textContent).toBe("Create a new bb plugin that ");
-
-    fireEvent.click(
-      screen.getByText(
-        "Ship a board your agents move cards across while they work.",
-      ),
-    );
-    const seeded = await screen.findByTestId("inline-composer");
-    expect(seeded.textContent).toContain("kanban board panel");
-
-    fireEvent.click(screen.getByText("CLI command"));
-    expect(
-      (await screen.findByTestId("inline-composer")).textContent,
-    ).toContain("deploys the current branch to staging");
+    fireEvent.click(open);
+    expect(onOpenPlugin).toHaveBeenCalledWith("memory", open);
   });
 });

--- a/apps/app/src/components/plugin/management/BrowsePluginsTab.tsx
+++ b/apps/app/src/components/plugin/management/BrowsePluginsTab.tsx
@@ -1,22 +1,8 @@
-import { Fragment, useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "react-router-dom";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useDebounceValue } from "usehooks-ts";
-import {
-  ResourceBrowseCard,
-  ResourceBrowseGrid,
-  ResourceCollectionViewport,
-  ResourceInstallControl,
-  ResourceListState,
-  ResourceMultiSelectMenu,
-  ResourceSortMenu,
-  ResourceToolbar,
-} from "@bb/shared-ui/resource-list";
-import {
-  ConfirmDeleteDialog,
-  ConfirmDeleteDialogContent,
-} from "@/components/dialogs/ConfirmDeleteDialog";
 import { Button } from "@bb/shared-ui/button";
+import { PLUGIN_CATALOG_CATEGORIES, pluginCatalogCategory } from "@bb/domain";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -25,22 +11,50 @@ import {
 } from "@bb/shared-ui/dropdown-menu";
 import { Icon } from "@bb/shared-ui/icon";
 import { cn } from "@bb/shared-ui/lib/utils";
-import { appToast } from "@/components/ui/app-toast";
-import { TOOLS_PAGE_BAND_CLASSES } from "@/components/tools/tools-navigation";
-import { BrowseArchetypeCards } from "@/components/plugin/browse-hero/BrowseArchetypeCards";
-import { nextComposerRequestNonce } from "@/components/plugin/browse-hero/browse-hero-archetypes";
-import { BrowseHeroCarousel } from "@/components/plugin/browse-hero/BrowseHeroCarousel";
 import {
-  invalidatePluginCatalogSearch,
-  invalidatePluginList,
-} from "@/hooks/cache-owners/plugin-cache-owner";
+  ResourceBrowseCard,
+  ResourceBrowseGrid,
+  ResourceCollectionViewport,
+  ResourceInstallControl,
+  ResourceInstalledControl,
+  ResourceListState,
+  ResourceShelfSeeAllAction,
+  ResourceSortMenu,
+  ResourceSourceShelf,
+  ResourceToolbar,
+} from "@bb/shared-ui/resource-list";
+import { BrowseArchetypeCards } from "@/components/plugin/browse-hero/BrowseArchetypeCards";
+import { BrowseHeroCarousel } from "@/components/plugin/browse-hero/BrowseHeroCarousel";
+import { nextComposerRequestNonce } from "@/components/plugin/browse-hero/browse-hero-archetypes";
+import { TOOLS_PAGE_BAND_CLASSES } from "@/components/tools/tools-navigation";
 import {
   usePluginCatalogSearch,
   type PluginCatalogSearchEntry,
 } from "@/hooks/queries/plugin-catalog-queries";
-import { removePlugin } from "@/hooks/queries/plugin-settings-queries";
 import type { AddPluginInitial } from "./AddPluginDialog";
-import { CatalogEntryIcon } from "./plugin-ui";
+import { PluginAuthorAvatar, pluginAuthorGithub } from "./PluginAuthorAvatar";
+import {
+  PluginBrowseCategoryFilter,
+  pluginBrowseSort,
+  pluginBrowseSortDirection,
+  pluginBrowseSortOptions,
+  type PluginBrowseCategoryOption,
+} from "./PluginBrowseControls";
+import {
+  UNCATEGORIZED_PLUGIN_CATEGORY_ID,
+  pluginBrowseShelves,
+  pluginCategoryFilterId,
+  sortPluginEntries,
+  type PluginBrowseShelf,
+} from "./plugin-browse-discovery";
+import {
+  CatalogEntryIconChip,
+  formatPluginInstallCount,
+  PluginCategoryLabel,
+  pluginCatalogCategoryMutedAccentStyle,
+} from "./plugin-ui";
+
+const SHELF_ENTRY_LIMIT = 6;
 
 export function BrowsePluginsTab({
   onInstall,
@@ -48,12 +62,16 @@ export function BrowsePluginsTab({
   onInstallFromSource,
 }: {
   onInstall: (initial: AddPluginInitial) => void;
-  onOpenPlugin: (pluginId: string) => void;
+  onOpenPlugin: (pluginId: string, trigger: HTMLButtonElement) => void;
   onInstallFromSource: () => void;
 }) {
-  const [query, setQuery] = useState("");
   const [searchParams, setSearchParams] = useSearchParams();
+  const query = searchParams.get("query") ?? "";
   const creationViewActive = searchParams.get("view") === "create";
+  const selectedCategories = searchParams.getAll("category");
+  const requestedSort = pluginBrowseSort(searchParams.get("sort"));
+  const sortDirection =
+    pluginBrowseSortDirection(searchParams.get("direction")) ?? "desc";
   const [heroRequest, setHeroRequest] = useState<{
     nonce: number;
     seed?: string;
@@ -64,6 +82,54 @@ export function BrowsePluginsTab({
   const [requestedCreationView, setRequestedCreationView] =
     useState(creationViewActive);
   const [composing, setComposing] = useState(false);
+  const [expandedShelves, setExpandedShelves] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const [debouncedQuery] = useDebounceValue(query.trim(), 300);
+  const searchQuery = usePluginCatalogSearch(debouncedQuery, { enabled: true });
+  const catalog = searchQuery.data ?? { entries: [], collections: [] };
+  const entries = useMemo(
+    () => catalog.entries.filter((entry) => entry.compatible),
+    [catalog.entries],
+  );
+  const installsKnown = entries.some((entry) => entry.installs !== null);
+  const sort =
+    requestedSort === "most-installed" && !installsKnown ? null : requestedSort;
+  const categoryOptions = useMemo(
+    () => categoryFilterOptions(entries, selectedCategories),
+    [entries, selectedCategories],
+  );
+  const filteredEntries = useMemo(() => {
+    if (selectedCategories.length === 0) return entries;
+    const selected = new Set(selectedCategories);
+    return entries.filter((entry) =>
+      selected.has(pluginCategoryFilterId(entry)),
+    );
+  }, [entries, selectedCategories]);
+  const shelves = useMemo(
+    () =>
+      pluginBrowseShelves({
+        entries: filteredEntries,
+        collections: catalog.collections,
+      }),
+    [catalog.collections, filteredEntries],
+  );
+  const flatEntries = useMemo(
+    () =>
+      sort === null
+        ? []
+        : sortPluginEntries(filteredEntries, sort, sortDirection),
+    [filteredEntries, sort, sortDirection],
+  );
+
+  const changeSearchParams = (
+    change: (next: URLSearchParams) => void,
+    replace = true,
+  ) => {
+    const next = new URLSearchParams(searchParams);
+    change(next);
+    setSearchParams(next, { replace });
+  };
   const openComposer = (seed?: string) =>
     setHeroRequest({
       nonce: nextComposerRequestNonce(),
@@ -86,67 +152,17 @@ export function BrowsePluginsTab({
         : "smooth",
     });
   }, [heroRequest]);
-  const [categories, setCategories] = useState<string[]>([]);
-  const [sortMode, setSortMode] = useState<BrowseSortMode>("installs");
-  const [sortDirection, setSortDirection] = useState<"asc" | "desc">("desc");
-  const [debouncedQuery] = useDebounceValue(query.trim(), 300);
-  const searchQuery = usePluginCatalogSearch(debouncedQuery, { enabled: true });
-  const entries = (searchQuery.data ?? []).filter((entry) => entry.compatible);
-  const availableCategories: string[] = [];
-  for (const entry of entries) {
-    if (!availableCategories.includes(entry.category)) {
-      availableCategories.push(entry.category);
-    }
-  }
-  for (const selected of categories) {
-    if (!availableCategories.includes(selected)) {
-      availableCategories.push(selected);
-    }
-  }
-  const categoryOptions = availableCategories.map((name) => ({
-    id: name,
-    label: name,
-  }));
-  const installsKnown = entries.some((entry) => entry.installs !== null);
-  const effectiveSortMode =
-    sortMode === "installs" && !installsKnown ? "alpha" : sortMode;
-  const effectiveSortDirection =
-    effectiveSortMode === sortMode ? sortDirection : "asc";
-  const changeSort = (next: string) => {
-    if (next !== "alpha" && next !== "installs") return;
-    if (next === effectiveSortMode) {
-      setSortDirection(effectiveSortDirection === "asc" ? "desc" : "asc");
-      setSortMode(next);
-      return;
-    }
-    setSortMode(next);
-    setSortDirection(next === "installs" ? "desc" : "asc");
-  };
-  const visibleEntries =
-    categories.length === 0
-      ? entries
-      : entries.filter((entry) => categories.includes(entry.category));
-  const groups = groupByPublisher(
-    visibleEntries,
-    effectiveSortMode,
-    effectiveSortDirection,
-  );
-  const showPublisherHeadings = groups.length > 1;
 
   return (
     <ResourceCollectionViewport scrollId="plugins-browse-results">
-      {}
-      <div className={cn("space-y-7", TOOLS_PAGE_BAND_CLASSES)}>
-        {}
+      <div className={cn("space-y-7 pb-8", TOOLS_PAGE_BAND_CLASSES)}>
         <div className="flex items-center justify-end gap-3">
           <div className="flex items-stretch">
             <Button
               className="rounded-r-none"
               onClick={() => {
                 if (creationViewActive) return;
-                const nextSearchParams = new URLSearchParams(searchParams);
-                nextSearchParams.set("view", "create");
-                setSearchParams(nextSearchParams);
+                changeSearchParams((next) => next.set("view", "create"), false);
               }}
             >
               <Icon name="MessageSquarePlus" className="size-3.5" />
@@ -179,109 +195,116 @@ export function BrowsePluginsTab({
         {composing ? (
           <BrowseArchetypeCards onCreate={openComposer} />
         ) : (
-          <section>
-            {}
-            <div className="mx-auto w-full max-w-[32rem]">
+          <section className="space-y-6">
+            <div className="mx-auto w-full max-w-3xl">
               <ResourceToolbar
                 searchValue={query}
                 searchPlaceholder="Search plugins"
-                onSearchChange={setQuery}
+                onSearchChange={(value) =>
+                  changeSearchParams((next) => {
+                    if (value === "") next.delete("query");
+                    else next.set("query", value);
+                  })
+                }
                 controls={
                   <>
-                    {categoryOptions.length > 0 ? (
-                      <ResourceMultiSelectMenu
-                        label="Category"
-                        icon="SlidersHorizontal"
-                        compact
-                        selectedValues={categories}
-                        options={categoryOptions}
-                        onChange={setCategories}
-                      />
-                    ) : null}
+                    <PluginBrowseCategoryFilter
+                      selectionMode="multiple"
+                      value={selectedCategories}
+                      options={categoryOptions}
+                      onChange={(values) =>
+                        changeSearchParams((next) => {
+                          next.delete("category");
+                          for (const value of values) {
+                            next.append("category", value);
+                          }
+                        })
+                      }
+                    />
                     <ResourceSortMenu
-                      value={effectiveSortMode}
-                      direction={effectiveSortDirection}
+                      value={sort}
+                      direction={sortDirection}
                       compact
-                      options={[
-                        { id: "alpha", label: "Plugin name" },
-                        {
-                          id: "installs",
-                          label: "Installs",
-                          disabled: !installsKnown,
-                        },
-                      ]}
-                      onChange={changeSort}
+                      placeholderLabel="Featured"
+                      options={pluginBrowseSortOptions(installsKnown)}
+                      onChange={(value) =>
+                        changeSearchParams((next) => {
+                          if (value === sort) {
+                            next.set(
+                              "direction",
+                              sortDirection === "asc" ? "desc" : "asc",
+                            );
+                          } else {
+                            next.set("sort", value);
+                            next.set("direction", "desc");
+                          }
+                        })
+                      }
+                      onClear={() =>
+                        changeSearchParams((next) => {
+                          next.delete("sort");
+                          next.delete("direction");
+                        })
+                      }
                     />
                   </>
                 }
               />
             </div>
 
-            <div className="mt-7 space-y-3">
-              {searchQuery.isError && entries.length > 0 ? (
-                <p className="text-xs text-warning-text" role="status">
-                  Showing cached catalog results because the latest search
-                  failed.
-                </p>
-              ) : null}
-
-              {searchQuery.isPending ? (
-                <ResourceListState state="loading" message="Loading plugins" />
-              ) : entries.length === 0 ? (
-                <ResourceListState
-                  state={searchQuery.isError ? "error" : "empty"}
-                  message={
-                    searchQuery.isError
-                      ? "BB's official plugins are unavailable."
-                      : "No plugins match this search."
-                  }
-                  onRetry={
-                    searchQuery.isError
-                      ? () => {
-                          void searchQuery.refetch();
-                        }
-                      : undefined
-                  }
-                />
-              ) : (
-                <div className="space-y-3">
-                  {groups.length === 0 ? (
-                    <ResourceListState
-                      state="empty"
-                      message="No plugins match these filters."
-                    />
-                  ) : (
-                    groups.map((group) => (
-                      <section key={group.key} className="space-y-3">
-                        {showPublisherHeadings ? (
-                          <h2 className="flex items-baseline gap-2 text-sm font-medium text-foreground">
-                            {group.label}
-                            {group.thirdParty ? (
-                              <span className="text-2xs font-normal text-subtle-foreground">
-                                third-party marketplace
-                              </span>
-                            ) : null}
-                          </h2>
-                        ) : null}
-                        <ResourceBrowseGrid className="grid-cols-[repeat(auto-fill,minmax(min(100%,18rem),1fr))] gap-2">
-                          {group.entries.map((entry) => (
-                            <BrowseCard
-                              key={`${entry.marketplace}/${entry.entryId}`}
-                              entry={entry}
-                              installedPluginId={
-                                entry.installed ? entry.pluginId : null
-                              }
-                              onInstall={onInstall}
-                              onOpenPlugin={onOpenPlugin}
-                            />
-                          ))}
-                        </ResourceBrowseGrid>
-                      </section>
-                    ))
-                  )}
-                </div>
-              )}
-            </div>
+            {searchQuery.isError && entries.length > 0 ? (
+              <p className="text-xs text-warning-text" role="status">
+                The latest search failed. The page shows saved catalog results.
+              </p>
+            ) : null}
+            {searchQuery.isPending ? (
+              <ResourceListState state="loading" message="Loading plugins" />
+            ) : entries.length === 0 ? (
+              <ResourceListState
+                state={searchQuery.isError ? "error" : "empty"}
+                message={
+                  searchQuery.isError
+                    ? "The plugin catalog is not available."
+                    : "No plugins match this search."
+                }
+                onRetry={
+                  searchQuery.isError
+                    ? () => {
+                        void searchQuery.refetch();
+                      }
+                    : undefined
+                }
+              />
+            ) : filteredEntries.length === 0 ? (
+              <ResourceListState
+                state="empty"
+                message="No plugins match these category filters."
+              />
+            ) : sort === null ? (
+              <div className="space-y-8" data-testid="plugin-browse-shelves">
+                {shelves.map((shelf) => (
+                  <BrowseShelf
+                    key={shelf.key}
+                    shelf={shelf}
+                    expanded={expandedShelves.has(shelf.key)}
+                    onExpand={() =>
+                      setExpandedShelves((current) =>
+                        new Set(current).add(shelf.key),
+                      )
+                    }
+                    onInstall={onInstall}
+                    onOpenPlugin={onOpenPlugin}
+                  />
+                ))}
+              </div>
+            ) : (
+              <PluginCatalogGrid
+                entries={flatEntries}
+                showCategory
+                onInstall={onInstall}
+                onOpenPlugin={onOpenPlugin}
+              />
+            )}
           </section>
         )}
       </div>
@@ -289,212 +312,216 @@ export function BrowsePluginsTab({
   );
 }
 
-type BrowseSortMode = "alpha" | "installs";
-
-interface PublisherGroup {
-  key: string;
-  label: string;
-  thirdParty: boolean;
-  entries: PluginCatalogSearchEntry[];
-}
-
-function groupByPublisher(
+function categoryFilterOptions(
   entries: readonly PluginCatalogSearchEntry[],
-  sortMode: BrowseSortMode,
-  sortDirection: "asc" | "desc",
-): PublisherGroup[] {
-  const groups: PublisherGroup[] = [];
+  selected: readonly string[],
+): PluginBrowseCategoryOption[] {
+  const labels = new Map<string, string>();
+  const counts = new Map<string, number>();
+  const unknownIds: string[] = [];
   for (const entry of entries) {
-    let group = groups.find((item) => item.key === entry.publisherKey);
-    if (group === undefined) {
-      group = {
-        key: entry.publisherKey,
-        label: entry.publisherLabel,
-        thirdParty: !entry.official,
-        entries: [],
-      };
-      groups.push(group);
-    }
-    group.entries.push(entry);
-  }
-  for (const group of groups) {
-    group.entries.sort((left, right) => {
-      if (sortMode === "installs") {
-        if (left.installs === null || right.installs === null) {
-          if (left.installs !== null) return -1;
-          if (right.installs !== null) return 1;
-        } else if (left.installs !== right.installs) {
-          const result = left.installs - right.installs;
-          return sortDirection === "asc" ? result : -result;
-        }
-      } else {
-        const result = left.displayName.localeCompare(right.displayName);
-        if (result !== 0) return sortDirection === "asc" ? result : -result;
+    const id = pluginCategoryFilterId(entry);
+    if (!labels.has(id)) {
+      labels.set(
+        id,
+        id === UNCATEGORIZED_PLUGIN_CATEGORY_ID
+          ? "Uncategorized"
+          : (entry.category ?? id),
+      );
+      if (
+        id !== UNCATEGORIZED_PLUGIN_CATEGORY_ID &&
+        pluginCatalogCategory(id) === undefined
+      ) {
+        unknownIds.push(id);
       }
-      const byName = left.displayName.localeCompare(right.displayName);
-      if (byName !== 0) return byName;
-      return left.entryId.localeCompare(right.entryId);
-    });
+    }
+    counts.set(id, (counts.get(id) ?? 0) + 1);
   }
-  return groups;
+  for (const id of selected) {
+    if (labels.has(id)) continue;
+    const category = pluginCatalogCategory(id);
+    labels.set(
+      id,
+      id === UNCATEGORIZED_PLUGIN_CATEGORY_ID
+        ? "Uncategorized"
+        : (category?.displayName ?? id),
+    );
+    if (id !== UNCATEGORIZED_PLUGIN_CATEGORY_ID && category === undefined) {
+      unknownIds.push(id);
+    }
+  }
+  const orderedIds = [
+    ...PLUGIN_CATALOG_CATEGORIES.map((category) => category.id).filter((id) =>
+      labels.has(id),
+    ),
+    ...unknownIds,
+    ...(labels.has(UNCATEGORIZED_PLUGIN_CATEGORY_ID)
+      ? [UNCATEGORIZED_PLUGIN_CATEGORY_ID]
+      : []),
+  ];
+  return orderedIds.map((id) => ({
+    id,
+    label: labels.get(id) ?? id,
+    count: counts.get(id) ?? 0,
+  }));
 }
 
-const INSTALL_COUNT_FORMATTER = new Intl.NumberFormat(undefined, {
-  notation: "compact",
-  maximumFractionDigits: 1,
-});
-
-export function formatInstallCount(installs: number): string {
-  return `${INSTALL_COUNT_FORMATTER.format(installs)} ${installs === 1 ? "install" : "installs"}`;
+function BrowseShelf({
+  shelf,
+  expanded,
+  onExpand,
+  onInstall,
+  onOpenPlugin,
+}: {
+  shelf: PluginBrowseShelf;
+  expanded: boolean;
+  onExpand: () => void;
+  onInstall: (initial: AddPluginInitial) => void;
+  onOpenPlugin: (pluginId: string, trigger: HTMLButtonElement) => void;
+}) {
+  const visible = expanded
+    ? shelf.entries
+    : shelf.entries.slice(0, SHELF_ENTRY_LIMIT);
+  return (
+    <ResourceSourceShelf
+      label={shelf.label}
+      description={shelf.description}
+      contentMode="panel"
+      contentSurface="plain"
+      leading={
+        <span
+          className="size-2 rounded-full"
+          style={pluginCatalogCategoryMutedAccentStyle(shelf.categoryId)}
+          aria-hidden
+        />
+      }
+      browseAction={
+        visible.length < shelf.entries.length ? (
+          <ResourceShelfSeeAllAction type="button" onClick={onExpand} />
+        ) : undefined
+      }
+    >
+      <div data-plugin-shelf>
+        <div data-plugin-shelf-grid className="grid gap-2">
+          {visible.map((entry) => (
+            <PluginCatalogCard
+              key={`${entry.marketplace}/${entry.entryId}`}
+              entry={entry}
+              showCategory={false}
+              onInstall={onInstall}
+              onOpenPlugin={onOpenPlugin}
+            />
+          ))}
+        </div>
+      </div>
+    </ResourceSourceShelf>
+  );
 }
 
-function BrowseCard({
+function PluginCatalogGrid({
+  entries,
+  showCategory,
+  onInstall,
+  onOpenPlugin,
+}: {
+  entries: readonly PluginCatalogSearchEntry[];
+  showCategory: boolean;
+  onInstall: (initial: AddPluginInitial) => void;
+  onOpenPlugin: (pluginId: string, trigger: HTMLButtonElement) => void;
+}) {
+  return (
+    <ResourceBrowseGrid className="mx-auto w-full max-w-3xl grid-cols-[repeat(auto-fill,minmax(min(100%,18rem),1fr))] gap-2">
+      {entries.map((entry) => (
+        <PluginCatalogCard
+          key={`${entry.marketplace}/${entry.entryId}`}
+          entry={entry}
+          showCategory={showCategory}
+          onInstall={onInstall}
+          onOpenPlugin={onOpenPlugin}
+        />
+      ))}
+    </ResourceBrowseGrid>
+  );
+}
+
+function PluginCatalogCard({
   entry,
-  installedPluginId,
+  showCategory,
   onInstall,
   onOpenPlugin,
 }: {
   entry: PluginCatalogSearchEntry;
-  installedPluginId: string | null;
+  showCategory: boolean;
   onInstall: (initial: AddPluginInitial) => void;
-  onOpenPlugin: (pluginId: string) => void;
+  onOpenPlugin: (pluginId: string, trigger: HTMLButtonElement) => void;
 }) {
-  const queryClient = useQueryClient();
-  const [confirmingUninstall, setConfirmingUninstall] = useState(false);
-  const uninstall = useMutation({
-    mutationFn: () => {
-      if (installedPluginId === null) {
-        throw new Error("Installed plugin id is unavailable");
-      }
-      return removePlugin(fetch, installedPluginId);
-    },
-    onSuccess: () => {
-      setConfirmingUninstall(false);
-      invalidatePluginList({ queryClient });
-      invalidatePluginCatalogSearch({ queryClient });
-      appToast.success(`${entry.displayName} uninstalled`);
-    },
-    onError: (error) => {
-      appToast.error(`Uninstalling ${entry.displayName} failed`, {
-        description: error instanceof Error ? error.message : String(error),
-      });
-    },
-  });
-
-  const leading = <CatalogEntryIcon entry={entry} className="size-6" />;
-  const description =
-    entry.description.length > 0 ? entry.description : undefined;
-  const descriptionArea = (
-    <span className="block min-h-[2lh]">{description}</span>
-  );
-  const byline =
-    !entry.compatible && entry.incompatibleReason !== null ? (
-      <span className="text-warning-text">{entry.incompatibleReason}</span>
-    ) : entry.author !== null ? (
-      <span>By: {entry.author.name}</span>
-    ) : undefined;
-  const repositoryLink =
-    entry.repositoryUrl === null ? null : (
-      <a
-        href={entry.repositoryUrl}
-        target="_blank"
-        rel="noreferrer"
-        aria-label={`Open ${entry.displayName} repository`}
-        className="pointer-events-auto inline-flex items-center gap-0.5 leading-none underline underline-offset-2 hover:text-foreground"
-      >
-        repo
-        {}
-        <Icon
-          name="ExternalLink"
-          className="size-2.5 shrink-0 translate-y-px"
-          aria-hidden
-        />
-      </a>
-    );
-  const installs =
-    entry.installs === null ? null : (
-      <span
-        title={`${entry.installs.toLocaleString()} ${entry.installs === 1 ? "install" : "installs"}`}
-      >
-        {formatInstallCount(entry.installs)}
-      </span>
-    );
-  const footerParts = [
-    entry.official ? null : entry.publisherLabel,
-    installs,
-    repositoryLink,
-  ].filter((part) => part !== null);
-  const footerMeta =
-    footerParts.length === 0 ? undefined : (
-      <span className="text-2xs text-subtle-foreground">
-        {footerParts.map((part, index) => (
-          <Fragment key={index}>
-            {index > 0 ? " · " : null}
-            {part}
-          </Fragment>
-        ))}
-      </span>
-    );
-  const headerAction =
-    installedPluginId !== null ? (
-      <ResourceInstallControl
-        accessibleLabel={`Uninstall ${entry.displayName}`}
-        icon="Check"
-        pending={uninstall.isPending}
-        presentation="icon"
-        tooltip={`Installed — uninstall ${entry.displayName}`}
-        className="border-transparent bg-transparent text-[color:color-mix(in_oklab,var(--success)_72%,var(--ink))] shadow-none hover:border-transparent hover:bg-transparent hover:text-[color:color-mix(in_oklab,var(--success)_72%,var(--ink))] focus-visible:border-transparent focus-visible:bg-transparent focus-visible:text-[color:color-mix(in_oklab,var(--success)_72%,var(--ink))]"
-        onAction={() => setConfirmingUninstall(true)}
-      />
-    ) : (
-      <ResourceInstallControl
-        accessibleLabel={`Install ${entry.displayName}`}
-        disabled={!entry.compatible}
-        presentation="icon"
-        tooltip={`Install ${entry.displayName}`}
-        onAction={() =>
-          onInstall({
-            entryId: entry.entryId,
-            marketplace: entry.marketplace,
-            publisherLabel: entry.publisherLabel,
-            displayName: entry.displayName,
-            icon: entry.icon,
-            iconUrl: entry.iconUrl,
-            iconTinted: entry.iconTinted,
-            source: entry.source,
-          })
-        }
-      />
-    );
-
+  const count =
+    entry.installs === null
+      ? undefined
+      : {
+          display: formatPluginInstallCount(entry.installs),
+          accessibleLabel: `${entry.installs.toLocaleString()} ${entry.installs === 1 ? "install" : "installs"}`,
+        };
+  const authorName = entry.author?.name ?? entry.publisherLabel;
   return (
-    <>
-      <ResourceBrowseCard
-        className="min-h-20 gap-x-2 gap-y-1.5 p-2.5"
-        leading={leading}
-        title={entry.displayName}
-        description={descriptionArea}
-        byline={byline}
-        footerMeta={footerMeta}
-        headerAction={headerAction}
-        openLabel={`Open ${entry.displayName} details`}
-        onOpen={() => onOpenPlugin(entry.pluginId)}
-      />
-      <ConfirmDeleteDialog
-        open={confirmingUninstall}
-        onOpenChange={(open) => {
-          if (!uninstall.isPending) setConfirmingUninstall(open);
-        }}
-      >
-        <ConfirmDeleteDialogContent
-          title={`Uninstall ${entry.displayName}?`}
-          description="The plugin, its installed files, and its settings, secrets, and schedules are removed from this BB host."
-          confirmLabel={uninstall.isPending ? "Uninstalling…" : "Uninstall"}
-          pending={uninstall.isPending}
-          onConfirm={() => uninstall.mutate()}
-          onCancel={() => setConfirmingUninstall(false)}
-        />
-      </ConfirmDeleteDialog>
-    </>
+    <ResourceBrowseCard
+      className="min-h-28 gap-x-2 gap-y-1.5 p-3"
+      leading={<CatalogEntryIconChip entry={entry} />}
+      leadingClassName="size-10"
+      title={entry.displayName}
+      description={entry.description || undefined}
+      byline={
+        <span className="flex items-center gap-1.5">
+          <PluginAuthorAvatar
+            name={authorName}
+            github={pluginAuthorGithub(entry.author)}
+            size="detail"
+          />
+          <span className="truncate">By {authorName}</span>
+        </span>
+      }
+      footerMeta={
+        showCategory && entry.category !== undefined ? (
+          <PluginCategoryLabel
+            categoryId={entry.categoryId}
+            label={entry.category}
+          />
+        ) : undefined
+      }
+      headerAction={
+        entry.installed ? (
+          <ResourceInstalledControl
+            accessibleLabel="Installed"
+            presentation="compact"
+            count={count}
+          />
+        ) : (
+          <ResourceInstallControl
+            accessibleLabel={`Install ${entry.displayName}${
+              count === undefined ? "" : ` — ${count.accessibleLabel}`
+            }`}
+            disabled={!entry.compatible}
+            presentation="compact"
+            tooltip={`Install ${entry.displayName}`}
+            count={count}
+            className="border-border/80 bg-background text-foreground shadow-none hover:bg-state-hover"
+            onAction={() =>
+              onInstall({
+                entryId: entry.entryId,
+                marketplace: entry.marketplace,
+                publisherLabel: entry.publisherLabel,
+                displayName: entry.displayName,
+                icon: entry.icon,
+                iconUrl: entry.iconUrl,
+                iconTinted: entry.iconTinted,
+                source: entry.source,
+              })
+            }
+          />
+        )
+      }
+      openLabel={`Open ${entry.displayName} details`}
+      onOpen={(trigger) => onOpenPlugin(entry.pluginId, trigger)}
+    />
   );
 }

--- a/apps/app/src/components/plugin/management/PluginAuthorAvatar.tsx
+++ b/apps/app/src/components/plugin/management/PluginAuthorAvatar.tsx
@@ -1,0 +1,69 @@
+import { Avatar, AvatarFallback, AvatarImage } from "@bb/shared-ui/avatar";
+import { cn } from "@bb/shared-ui/lib/utils";
+import type { PluginCatalogAuthor } from "@bb/server-contract";
+
+export function pluginAuthorGithub(
+  author: PluginCatalogAuthor | null,
+): string | null {
+  if (author?.url === null || author?.url === undefined) return null;
+  try {
+    const url = new URL(author.url);
+    if (url.hostname !== "github.com" && url.hostname !== "www.github.com") {
+      return null;
+    }
+    const [github] = url.pathname.split("/").filter(Boolean);
+    return github ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function authorInitials(name: string): string {
+  const initials = name
+    .trim()
+    .split(/\s+/u)
+    .slice(0, 2)
+    .map((part) => part[0]?.toLocaleUpperCase() ?? "")
+    .join("");
+  return initials === "" ? "?" : initials;
+}
+
+export function PluginAuthorAvatar({
+  name,
+  github,
+  size,
+}: {
+  name: string;
+  github: string | null;
+  size: "detail" | "page";
+}) {
+  return (
+    <Avatar
+      role="img"
+      aria-label={
+        github === null ? `${name}'s avatar` : `${name}'s GitHub avatar`
+      }
+      className={cn(
+        "border border-border bg-muted",
+        size === "detail" ? "size-5" : "size-10",
+      )}
+    >
+      {github === null ? null : (
+        <AvatarImage
+          src={`https://github.com/${github}.png?size=${size === "detail" ? 40 : 80}`}
+          alt=""
+          loading="lazy"
+        />
+      )}
+      <AvatarFallback
+        aria-hidden
+        className={cn(
+          "font-semibold text-subtle-foreground",
+          size === "detail" ? "text-2xs" : "text-xs",
+        )}
+      >
+        {authorInitials(name)}
+      </AvatarFallback>
+    </Avatar>
+  );
+}

--- a/apps/app/src/components/plugin/management/PluginBrowseControls.test.tsx
+++ b/apps/app/src/components/plugin/management/PluginBrowseControls.test.tsx
@@ -1,0 +1,162 @@
+// @vitest-environment jsdom
+
+import { useState } from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  PluginBrowseCategoryFilter,
+  type PluginBrowseCategoryOption,
+} from "./PluginBrowseControls";
+
+const OPTIONS: PluginBrowseCategoryOption[] = [
+  { id: "memory-and-context", label: "Memory & Context", count: 4 },
+  { id: "security", label: "Security", count: 2 },
+  { id: "tasks-and-workflows", label: "Tasks & Workflows", count: 7 },
+];
+
+function openMenu(selectionLabel: string) {
+  fireEvent.click(
+    screen.getByRole("button", {
+      name: `Filter plugins by category: ${selectionLabel}`,
+    }),
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("PluginBrowseCategoryFilter", () => {
+  it("shows searchable counts and checkboxes", () => {
+    render(
+      <PluginBrowseCategoryFilter
+        selectionMode="multiple"
+        options={OPTIONS}
+        value={[]}
+        onChange={() => undefined}
+      />,
+    );
+    openMenu("All categories");
+
+    expect(screen.getAllByRole("option")).toHaveLength(3);
+    const security = screen.getByRole("option", { name: /Security/u });
+    expect(
+      security.querySelector("[data-category-option-count]")?.textContent,
+    ).toBe("2");
+    expect(
+      security
+        .querySelector("[data-category-option-checkbox]")
+        ?.getAttribute("data-state"),
+    ).toBe("disabled");
+    const search = screen.getByRole("combobox", {
+      name: "Search plugin categories",
+    });
+    fireEvent.change(search, { target: { value: "work" } });
+    expect(screen.getAllByRole("option")).toHaveLength(1);
+    expect(screen.getByRole("option").textContent).toContain(
+      "Tasks & Workflows",
+    );
+  });
+
+  it("keeps the menu open for multiple selections", () => {
+    function Harness() {
+      const [value, setValue] = useState<string[]>([]);
+      return (
+        <PluginBrowseCategoryFilter
+          selectionMode="multiple"
+          options={OPTIONS}
+          value={value}
+          onChange={setValue}
+        />
+      );
+    }
+    render(<Harness />);
+    openMenu("All categories");
+    fireEvent.click(screen.getByRole("option", { name: /Security/u }));
+    fireEvent.click(screen.getByRole("option", { name: /Tasks & Workflows/u }));
+
+    expect(
+      screen
+        .getByRole("listbox", { name: "Plugin categories" })
+        .getAttribute("aria-multiselectable"),
+    ).toBe("true");
+    expect(
+      screen.getByRole("button", {
+        name: "Filter plugins by category: Security, Tasks & Workflows",
+      }).textContent,
+    ).toContain("2 categories");
+    fireEvent.click(screen.getByRole("button", { name: "Clear filter" }));
+    expect(
+      screen.getByRole("button", {
+        name: "Filter plugins by category: All categories",
+      }),
+    ).toBeTruthy();
+  });
+
+  it("moves focus through options with the keyboard", () => {
+    const onChange = vi.fn();
+    render(
+      <PluginBrowseCategoryFilter
+        selectionMode="single"
+        options={OPTIONS}
+        value="tasks-and-workflows"
+        onChange={onChange}
+      />,
+    );
+    openMenu("Tasks & Workflows");
+    const search = screen.getByRole("combobox", {
+      name: "Search plugin categories",
+    });
+    fireEvent.keyDown(search, { key: "ArrowDown" });
+    expect(document.activeElement?.textContent).toContain("Memory & Context");
+    fireEvent.keyDown(document.activeElement as HTMLElement, { key: "End" });
+    expect(document.activeElement?.textContent).toContain("Tasks & Workflows");
+    fireEvent.click(document.activeElement as HTMLElement);
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it("keeps keyboard focus inside each filter instance", () => {
+    render(
+      <>
+        <PluginBrowseCategoryFilter
+          selectionMode="multiple"
+          options={OPTIONS}
+          value={[]}
+          onChange={() => undefined}
+        />
+        <PluginBrowseCategoryFilter
+          selectionMode="multiple"
+          options={OPTIONS}
+          value={[]}
+          onChange={() => undefined}
+        />
+      </>,
+    );
+    const triggers = screen.getAllByRole("button", {
+      name: "Filter plugins by category: All categories",
+    });
+    fireEvent.click(triggers[0] as HTMLButtonElement);
+    const firstSearch = screen.getByRole("combobox", {
+      name: "Search plugin categories",
+    });
+    const firstList = screen.getByRole("listbox", {
+      name: "Plugin categories",
+    });
+    expect(firstSearch.getAttribute("aria-controls")).toBe(firstList.id);
+    fireEvent.click(triggers[0] as HTMLButtonElement);
+    fireEvent.click(triggers[1] as HTMLButtonElement);
+    const secondSearch = screen.getByRole("combobox", {
+      name: "Search plugin categories",
+    });
+    const secondList = screen.getByRole("listbox", {
+      name: "Plugin categories",
+    });
+    expect(secondSearch.getAttribute("aria-controls")).toBe(secondList.id);
+    expect(firstList.id).not.toBe(secondList.id);
+
+    fireEvent.keyDown(secondSearch, { key: "ArrowDown" });
+    expect(secondList.contains(document.activeElement)).toBe(true);
+    expect(firstList.contains(document.activeElement)).toBe(false);
+  });
+});

--- a/apps/app/src/components/plugin/management/PluginBrowseControls.tsx
+++ b/apps/app/src/components/plugin/management/PluginBrowseControls.tsx
@@ -1,0 +1,396 @@
+import { useCallback, useEffect, useId, useRef, useState } from "react";
+import { Button } from "@bb/shared-ui/button";
+import { Icon, type IconName } from "@bb/shared-ui/icon";
+import { Input } from "@bb/shared-ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@bb/shared-ui/popover";
+import { cn } from "@bb/shared-ui/lib/utils";
+import { useScrollOverflowState } from "@/components/thread/timeline/useScrollOverflowState";
+import type {
+  PluginBrowseSort,
+  PluginBrowseSortDirection,
+} from "./plugin-browse-discovery";
+
+const PLUGIN_BROWSE_SORTS = [
+  "recently-added",
+  "most-installed",
+] as const satisfies readonly PluginBrowseSort[];
+
+const PLUGIN_BROWSE_SORT_LABELS: Record<PluginBrowseSort, string> = {
+  "recently-added": "Recently added",
+  "most-installed": "Most installed",
+};
+
+const PLUGIN_BROWSE_SORT_ICONS: Record<PluginBrowseSort, IconName> = {
+  "recently-added": "Clock",
+  "most-installed": "Download",
+};
+
+export function pluginBrowseSort(
+  value: string | null,
+): PluginBrowseSort | null {
+  return PLUGIN_BROWSE_SORTS.find((sort) => sort === value) ?? null;
+}
+
+export function pluginBrowseSortDirection(
+  value: string | null,
+): PluginBrowseSortDirection | null {
+  return value === "asc" || value === "desc" ? value : null;
+}
+
+export function pluginBrowseSortOptions(hasInstallCounts: boolean) {
+  return PLUGIN_BROWSE_SORTS.map((sort) => ({
+    id: sort,
+    label: PLUGIN_BROWSE_SORT_LABELS[sort],
+    leading: <Icon name={PLUGIN_BROWSE_SORT_ICONS[sort]} className="size-4" />,
+    disabled: sort === "most-installed" && !hasInstallCounts,
+  }));
+}
+
+export interface PluginBrowseCategoryOption {
+  id: string;
+  label: string;
+  count: number;
+}
+
+type PluginBrowseCategoryFilterSelection =
+  | {
+      selectionMode: "single";
+      value: string | null;
+      onChange: (value: string | null) => void;
+    }
+  | {
+      selectionMode: "multiple";
+      value: readonly string[];
+      onChange: (value: string[]) => void;
+    };
+
+const ENGAGED_CONTROL_CLASS =
+  "bg-state-active text-foreground hover:bg-state-active";
+
+const SCROLLBAR_IDLE_DELAY_MS = 600;
+
+function CategoryOptionCheckbox({ enabled }: { enabled: boolean }) {
+  return (
+    <span
+      data-category-option-checkbox
+      data-state={enabled ? "enabled" : "disabled"}
+      className={cn(
+        "grid size-4 shrink-0 place-items-center rounded-sm border shadow-xs",
+        enabled
+          ? "border-foreground bg-foreground text-background"
+          : "border-input bg-background text-transparent",
+      )}
+      aria-hidden
+    >
+      <Icon name="Check" className="size-3.5" />
+    </span>
+  );
+}
+
+export function PluginBrowseCategoryFilter(
+  props: {
+    options: readonly PluginBrowseCategoryOption[];
+  } & PluginBrowseCategoryFilterSelection,
+) {
+  const { options } = props;
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const [showKeyboardFocus, setShowKeyboardFocus] = useState(false);
+  const [scrollbarScrolling, setScrollbarScrolling] = useState(false);
+  const listboxId = useId();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const keyboardFocusRef = useRef(false);
+  const selectedValues =
+    props.selectionMode === "multiple"
+      ? props.value
+      : props.value === null
+        ? []
+        : [props.value];
+  const selected = new Set(selectedValues);
+  const selectedOptions = selectedValues.flatMap((value) => {
+    const option = options.find((candidate) => candidate.id === value);
+    return option === undefined ? [] : [option];
+  });
+  const selectionLabel =
+    selectedOptions.length === 0
+      ? "All categories"
+      : selectedOptions.length === 1
+        ? (selectedOptions[0]?.label ?? "Category")
+        : `${selectedOptions.length} categories`;
+  const accessibleSelectionLabel =
+    selectedOptions.length === 0
+      ? "All categories"
+      : selectedOptions.map((option) => option.label).join(", ");
+  const normalizedSearch = search.trim().toLocaleLowerCase();
+  const filteredOptions = options.filter((option) =>
+    `${option.label} ${option.id}`
+      .toLocaleLowerCase()
+      .includes(normalizedSearch),
+  );
+  const [listElement, setListElement] = useState<HTMLDivElement | null>(null);
+  const {
+    scrollRef: listRef,
+    topSentinelRef,
+    bottomSentinelRef,
+    belowOverflow,
+  } = useScrollOverflowState<HTMLDivElement>({
+    enabled: listElement !== null,
+    measureOverflow: true,
+  });
+  const attachList = useCallback(
+    (node: HTMLDivElement | null) => {
+      listRef.current = node;
+      setListElement(node);
+    },
+    [listRef],
+  );
+  const scrollbarIdleRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const animationFrame = requestAnimationFrame(() =>
+      inputRef.current?.focus(),
+    );
+    return () => cancelAnimationFrame(animationFrame);
+  }, [open]);
+
+  useEffect(
+    () => () => {
+      if (scrollbarIdleRef.current !== null) {
+        window.clearTimeout(scrollbarIdleRef.current);
+      }
+    },
+    [],
+  );
+
+  const revealScrollbarWhileScrolling = (
+    _event: React.UIEvent<HTMLDivElement>,
+  ) => {
+    setScrollbarScrolling(true);
+    if (scrollbarIdleRef.current !== null) {
+      window.clearTimeout(scrollbarIdleRef.current);
+    }
+    scrollbarIdleRef.current = window.setTimeout(() => {
+      scrollbarIdleRef.current = null;
+      setScrollbarScrolling(false);
+    }, SCROLLBAR_IDLE_DELAY_MS);
+  };
+
+  const closeAfterSelection = () => {
+    setOpen(false);
+    setSearch("");
+  };
+
+  const clearSelection = () => {
+    if (props.selectionMode === "multiple") {
+      props.onChange([]);
+      return;
+    }
+    props.onChange(null);
+    closeAfterSelection();
+  };
+
+  const toggle = (optionId: string) => {
+    if (props.selectionMode === "multiple") {
+      const next = new Set(props.value);
+      if (next.has(optionId)) next.delete(optionId);
+      else next.add(optionId);
+      props.onChange([...next]);
+      return;
+    }
+    props.onChange(optionId === props.value ? null : optionId);
+    closeAfterSelection();
+  };
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(nextOpen) => {
+        setOpen(nextOpen);
+        if (!nextOpen) setSearch("");
+      }}
+    >
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          className={cn(
+            "h-8 max-w-52 gap-2 px-2.5 text-xs font-normal",
+            (open || selectedValues.length > 0) && ENGAGED_CONTROL_CLASS,
+          )}
+          aria-label={`Filter plugins by category: ${accessibleSelectionLabel}`}
+          aria-expanded={open}
+          onPointerDown={() => {
+            keyboardFocusRef.current = false;
+            setShowKeyboardFocus(false);
+          }}
+          onKeyDown={(event) => {
+            if (
+              event.key === "Enter" ||
+              event.key === " " ||
+              event.key === "ArrowDown"
+            ) {
+              keyboardFocusRef.current = true;
+              setShowKeyboardFocus(true);
+            }
+          }}
+        >
+          <Icon
+            name="SlidersHorizontal"
+            className="size-3.5 shrink-0"
+            aria-hidden
+          />
+          <span className="min-w-0 truncate">{selectionLabel}</span>
+          <Icon name="ChevronDown" className="size-3 shrink-0" aria-hidden />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        mobileTitle="Filter plugins by category"
+        className="w-72 p-1.5 md:p-0.5"
+      >
+        <div className="relative mx-2.5 mt-1.5">
+          <Icon
+            name="Search"
+            className="pointer-events-none absolute left-2 top-1/2 size-3 -translate-y-1/2 text-muted-foreground"
+            aria-hidden
+          />
+          <Input
+            ref={inputRef}
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder="Search categories"
+            aria-label="Search plugin categories"
+            role="combobox"
+            aria-controls={listboxId}
+            aria-expanded={open}
+            aria-autocomplete="list"
+            className={cn(
+              "h-7 border-transparent bg-surface-recessed pl-7 pr-2 text-xs focus-visible:ring-0",
+              showKeyboardFocus && "ring-1 ring-ring",
+            )}
+            onFocus={() => setShowKeyboardFocus(keyboardFocusRef.current)}
+            onBlur={() => setShowKeyboardFocus(false)}
+            onPointerDown={() => {
+              keyboardFocusRef.current = false;
+              setShowKeyboardFocus(false);
+            }}
+            onKeyDown={(event) => {
+              keyboardFocusRef.current = true;
+              setShowKeyboardFocus(true);
+              if (event.key === "ArrowDown") {
+                event.preventDefault();
+                categoryOptionElements(listElement)[0]?.focus();
+              } else if (event.key === "ArrowUp") {
+                event.preventDefault();
+                categoryOptionElements(listElement).at(-1)?.focus();
+              } else if (event.key !== "Escape" && event.key !== "Tab") {
+                event.stopPropagation();
+              }
+            }}
+          />
+        </div>
+        <div className="relative isolate mt-1.5">
+          <div
+            id={listboxId}
+            ref={attachList}
+            data-scrollbar-scrolling={scrollbarScrolling ? "true" : undefined}
+            role="listbox"
+            aria-label="Plugin categories"
+            aria-multiselectable={
+              props.selectionMode === "multiple" ? true : undefined
+            }
+            className="transient-scrollbar max-h-64 overflow-y-auto"
+            onScroll={revealScrollbarWhileScrolling}
+          >
+            <div ref={topSentinelRef} aria-hidden className="h-px w-full" />
+            {filteredOptions.length === 0 ? (
+              <p
+                className="px-2 py-6 text-center text-xs text-muted-foreground"
+                role="status"
+              >
+                {options.length === 0
+                  ? "No categories are available."
+                  : "No categories match your search."}
+              </p>
+            ) : (
+              filteredOptions.map((option) => {
+                return (
+                  <button
+                    key={option.id}
+                    type="button"
+                    role="option"
+                    aria-label={`${option.label}, ${option.count.toLocaleString()} ${option.count === 1 ? "plugin" : "plugins"}`}
+                    aria-selected={selected.has(option.id)}
+                    onClick={() => toggle(option.id)}
+                    className="flex w-full items-center gap-2 rounded-sm px-1.5 py-1 text-left text-xs outline-none hover:bg-state-hover focus-visible:bg-state-hover focus-visible:text-foreground md:gap-1.5"
+                    onKeyDown={(event) =>
+                      focusCategoryOption(event, listElement)
+                    }
+                  >
+                    <span className="flex w-8 shrink-0 justify-center">
+                      <span
+                        data-category-option-count
+                        className="rounded-full bg-surface-recessed p-1.5 text-center text-2xs font-medium leading-none tabular-nums text-subtle-foreground"
+                      >
+                        {option.count.toLocaleString()}
+                      </span>
+                    </span>
+                    <span className="min-w-0 flex-1 truncate font-medium text-foreground">
+                      {option.label}
+                    </span>
+                    <CategoryOptionCheckbox enabled={selected.has(option.id)} />
+                  </button>
+                );
+              })
+            )}
+            <div ref={bottomSentinelRef} aria-hidden className="h-px w-full" />
+          </div>
+          {belowOverflow ? (
+            <div
+              aria-hidden
+              data-category-list-fade="below"
+              className="pointer-events-none absolute inset-x-0 bottom-0 z-10 h-8 bg-gradient-to-t from-popover/90 via-popover/60 to-transparent"
+            />
+          ) : null}
+        </div>
+        {selectedValues.length > 0 ? (
+          <div className="mt-0.5 border-t border-border-seam pt-0.5">
+            <button
+              type="button"
+              onClick={clearSelection}
+              className="flex w-full items-center rounded-sm px-2 py-1 text-left text-xs text-muted-foreground outline-none hover:bg-state-hover hover:text-foreground focus-visible:bg-state-hover focus-visible:text-foreground"
+            >
+              Clear filter
+            </button>
+          </div>
+        ) : null}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function focusCategoryOption(
+  event: React.KeyboardEvent<HTMLButtonElement>,
+  listbox: HTMLDivElement | null,
+) {
+  const options = categoryOptionElements(listbox);
+  const index = options.indexOf(event.currentTarget);
+  if (index < 0) return;
+  let nextIndex: number | null = null;
+  if (event.key === "ArrowDown")
+    nextIndex = Math.min(index + 1, options.length - 1);
+  else if (event.key === "ArrowUp") nextIndex = Math.max(index - 1, 0);
+  else if (event.key === "Home") nextIndex = 0;
+  else if (event.key === "End") nextIndex = options.length - 1;
+  if (nextIndex === null) return;
+  event.preventDefault();
+  options[nextIndex]?.focus();
+}
+
+function categoryOptionElements(
+  listbox: HTMLDivElement | null,
+): HTMLButtonElement[] {
+  if (listbox === null) return [];
+  return [...listbox.querySelectorAll<HTMLButtonElement>('[role="option"]')];
+}

--- a/apps/app/src/components/plugin/management/PluginMarketplaceListing.tsx
+++ b/apps/app/src/components/plugin/management/PluginMarketplaceListing.tsx
@@ -1,0 +1,245 @@
+import { useEffect, useState, type ReactNode } from "react";
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+  type CarouselApi,
+} from "@bb/shared-ui/carousel";
+import { Icon } from "@bb/shared-ui/icon";
+import { cn } from "@bb/shared-ui/lib/utils";
+import { ResourceDefinitionSection } from "@bb/shared-ui/resource-list";
+import type { PluginCatalogSearchEntry } from "@/hooks/queries/plugin-catalog-queries";
+import { PluginCategoryLabel } from "./plugin-ui";
+import { PluginAuthorAvatar, pluginAuthorGithub } from "./PluginAuthorAvatar";
+
+function repositoryLinkLabel(url: string): string {
+  return url.replace(/^https?:\/\//u, "").replace(/\/+$/u, "");
+}
+
+export function PluginMarketplaceHeaderMetadata({
+  entry,
+}: {
+  entry: PluginCatalogSearchEntry;
+}) {
+  if (entry.author === null) return null;
+  const author = entry.author;
+  return (
+    <span className="inline-flex min-w-0 items-center gap-1.5">
+      <PluginAuthorAvatar
+        name={author.name}
+        github={pluginAuthorGithub(author)}
+        size="detail"
+      />
+      <span className="min-w-0">
+        By{" "}
+        {author.url === null ? (
+          author.name
+        ) : (
+          <a
+            href={author.url}
+            target="_blank"
+            rel="noreferrer"
+            className="rounded-sm underline underline-offset-2 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          >
+            {author.name}
+          </a>
+        )}
+      </span>
+    </span>
+  );
+}
+
+export function PluginMarketplaceCategoryPill({
+  entry,
+}: {
+  entry: PluginCatalogSearchEntry;
+}) {
+  return entry.category === undefined ? null : (
+    <PluginCategoryLabel categoryId={entry.categoryId} label={entry.category} />
+  );
+}
+
+function PluginMarketplaceDetail({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="min-w-0 space-y-1">
+      <dt className="text-2xs font-medium text-subtle-foreground">{label}</dt>
+      <dd className="min-w-0 text-xs text-muted-foreground">{children}</dd>
+    </div>
+  );
+}
+
+function PluginMarketplaceDetails({
+  entry,
+}: {
+  entry: PluginCatalogSearchEntry;
+}) {
+  return (
+    <ResourceDefinitionSection label="Details">
+      <dl className="grid gap-x-6 gap-y-4 sm:grid-cols-2">
+        {entry.publishedAt === undefined ? null : (
+          <PluginMarketplaceDetail label="Listed">
+            <time dateTime={entry.publishedAt}>
+              {new Date(entry.publishedAt).toLocaleDateString(undefined, {
+                month: "short",
+                day: "numeric",
+                year: "numeric",
+              })}
+            </time>
+          </PluginMarketplaceDetail>
+        )}
+        <PluginMarketplaceDetail label="Marketplace">
+          {entry.marketplaceDisplayName}
+        </PluginMarketplaceDetail>
+      </dl>
+    </ResourceDefinitionSection>
+  );
+}
+
+function PluginMarketplaceSource({
+  entry,
+}: {
+  entry: PluginCatalogSearchEntry;
+}) {
+  if (entry.repositoryUrl === null) return null;
+  return (
+    <ResourceDefinitionSection label="Source">
+      <a
+        href={entry.repositoryUrl}
+        target="_blank"
+        rel="noreferrer"
+        className="inline-flex max-w-full items-center gap-1.5 rounded-sm text-sm text-muted-foreground underline underline-offset-2 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+      >
+        <span className="truncate">
+          {repositoryLinkLabel(entry.repositoryUrl)}
+        </span>
+        <Icon name="ExternalLink" className="size-3.5 shrink-0" aria-hidden />
+        <span className="sr-only">Opens in a new tab</span>
+      </a>
+    </ResourceDefinitionSection>
+  );
+}
+
+const SCREENSHOT_ROW_HEIGHT = 420;
+
+function PluginScreenshotGallery({
+  entry,
+}: {
+  entry: PluginCatalogSearchEntry;
+}) {
+  const [api, setApi] = useState<CarouselApi>();
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  useEffect(() => {
+    if (api === undefined) return;
+    const updateSelection = () => setSelectedIndex(api.selectedScrollSnap());
+    updateSelection();
+    api.on("select", updateSelection);
+    api.on("reInit", updateSelection);
+    return () => {
+      api.off("select", updateSelection);
+      api.off("reInit", updateSelection);
+    };
+  }, [api]);
+  if (entry.screenshots.length === 0) return null;
+  return (
+    <>
+      <Carousel
+        setApi={setApi}
+        opts={{ align: "start", containScroll: "trimSnaps" }}
+        aria-label={`${entry.displayName} screenshots`}
+        className={cn("w-full", entry.screenshots.length > 1 && "px-11")}
+      >
+        <CarouselContent
+          className="-ml-3 items-center"
+          style={{ minHeight: `${SCREENSHOT_ROW_HEIGHT}px` }}
+        >
+          {entry.screenshots.map((screenshot, index) => (
+            <CarouselItem key={screenshot} className="basis-auto pl-3">
+              <img
+                src={screenshot}
+                alt={`${entry.displayName} screenshot ${index + 1}`}
+                referrerPolicy="no-referrer"
+                loading="lazy"
+                className="h-auto w-auto rounded-md border border-border object-contain"
+                style={{
+                  maxHeight: `${SCREENSHOT_ROW_HEIGHT}px`,
+                  maxWidth: `${SCREENSHOT_ROW_HEIGHT * 2}px`,
+                }}
+              />
+            </CarouselItem>
+          ))}
+        </CarouselContent>
+        {entry.screenshots.length > 1 ? (
+          <>
+            <CarouselPrevious className="left-0 size-8" />
+            <CarouselNext className="right-0 size-8" />
+          </>
+        ) : null}
+      </Carousel>
+      {entry.screenshots.length > 1 ? (
+        <div
+          className="flex justify-center gap-1.5"
+          aria-label={`Screenshot ${selectedIndex + 1} of ${entry.screenshots.length}`}
+          role="status"
+        >
+          {entry.screenshots.map((screenshot, index) => (
+            <span
+              key={screenshot}
+              aria-hidden
+              className={cn(
+                "h-1 rounded-full transition-[width,background-color]",
+                index === selectedIndex
+                  ? "w-4 bg-foreground/70"
+                  : "w-2 bg-border",
+              )}
+            />
+          ))}
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+function PluginMarketplaceOverview({
+  entry,
+}: {
+  entry: PluginCatalogSearchEntry;
+}) {
+  if (entry.screenshots.length === 0 && entry.description.length === 0) {
+    return null;
+  }
+  return (
+    <section className="space-y-6" data-resource-detail-section="overview">
+      <PluginScreenshotGallery entry={entry} />
+      {entry.description.length === 0 ? null : (
+        <div className="space-y-3">
+          <h2 className="text-sm font-medium text-foreground">About</h2>
+          <p className="max-w-none text-sm leading-relaxed text-muted-foreground">
+            {entry.description}
+          </p>
+        </div>
+      )}
+    </section>
+  );
+}
+
+export function PluginMarketplaceListingSections({
+  entry,
+}: {
+  entry: PluginCatalogSearchEntry;
+}) {
+  return (
+    <>
+      <PluginMarketplaceOverview entry={entry} />
+      <PluginMarketplaceSource entry={entry} />
+      <PluginMarketplaceDetails entry={entry} />
+    </>
+  );
+}

--- a/apps/app/src/components/plugin/management/plugin-browse-discovery.test.ts
+++ b/apps/app/src/components/plugin/management/plugin-browse-discovery.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "vitest";
+import type {
+  PluginCatalogSearchData,
+  PluginCatalogSearchEntry,
+} from "@/hooks/queries/plugin-catalog-queries";
+import {
+  pluginBrowseShelves,
+  sortPluginEntries,
+} from "./plugin-browse-discovery";
+
+function entry(
+  id: string,
+  overrides: Partial<PluginCatalogSearchEntry> = {},
+): PluginCatalogSearchEntry {
+  return {
+    entryId: id,
+    pluginId: id,
+    displayName: id,
+    description: `${id} description`,
+    icon: null,
+    iconUrl: null,
+    iconTinted: false,
+    categoryId: "thread-content",
+    category: "Thread Content",
+    screenshots: [],
+    collections: [],
+    source: `builtin:${id}`,
+    repositoryUrl: null,
+    marketplace: "bb-official",
+    marketplaceDisplayName: "BB Official",
+    publisherKey: "bb-official",
+    publisherLabel: "BB Official",
+    official: true,
+    author: null,
+    installed: false,
+    installs: null,
+    compatible: true,
+    incompatibleReason: null,
+    ...overrides,
+  };
+}
+
+describe("plugin browse shelves", () => {
+  it("keeps the server collection order before category shelves", () => {
+    const official = entry("official", {
+      collections: [{ id: "z-server-first", rank: 0 }],
+    });
+    const notable = entry("notable", {
+      collections: [{ id: "a-server-second", rank: 0 }],
+    });
+
+    const shelves = pluginBrowseShelves({
+      entries: [official, notable],
+      collections: [
+        {
+          id: "z-server-first",
+          displayName: "BB Official",
+          pluginIds: ["official"],
+        },
+        {
+          id: "a-server-second",
+          displayName: "New & notable",
+          pluginIds: ["notable"],
+        },
+      ],
+    });
+
+    expect(shelves.map((shelf) => shelf.label)).toEqual([
+      "BB Official",
+      "New & notable",
+      "Thread Content",
+    ]);
+    expect(shelves[2]?.entries).toEqual([official, notable]);
+  });
+
+  it("orders collections, built-in categories, unknown categories, and More plugins", () => {
+    const data: PluginCatalogSearchData = {
+      entries: [
+        entry("unknown-first", {
+          categoryId: "observability",
+          category: "Observability",
+          collections: [{ id: "new-and-notable", rank: 1 }],
+        }),
+        entry("uncategorized", {
+          categoryId: undefined,
+          category: undefined,
+        }),
+        entry("thread", {
+          categoryId: "thread-management",
+          category: "A server alias",
+        }),
+        entry("theme", {
+          categoryId: "themes-and-appearance",
+          category: "Themes & Appearance",
+          collections: [{ id: "new-and-notable", rank: 0 }],
+        }),
+        entry("unknown-second", {
+          categoryId: "data-tools",
+          category: "Data Tools",
+        }),
+      ],
+      collections: [
+        {
+          id: "new-and-notable",
+          displayName: "New & notable",
+          pluginIds: ["theme", "unknown-first"],
+        },
+      ],
+    };
+
+    expect(
+      pluginBrowseShelves(data).map((shelf) => [
+        shelf.label,
+        shelf.entries.map((candidate) => candidate.pluginId),
+      ]),
+    ).toEqual([
+      ["New & notable", ["theme", "unknown-first"]],
+      ["Themes & Appearance", ["theme"]],
+      ["Thread Management", ["thread"]],
+      ["Observability", ["unknown-first"]],
+      ["Data Tools", ["unknown-second"]],
+      ["More plugins", ["uncategorized"]],
+    ]);
+  });
+
+  it("uses collection membership when plugin ids match across marketplaces", () => {
+    const first = entry("shared", {
+      marketplace: "first",
+      collections: [{ id: "new-and-notable", rank: 0 }],
+    });
+    const second = entry("shared", {
+      marketplace: "second",
+      collections: [],
+    });
+
+    const shelves = pluginBrowseShelves({
+      entries: [first, second],
+      collections: [
+        {
+          id: "new-and-notable",
+          displayName: "New & notable",
+          pluginIds: ["shared"],
+        },
+      ],
+    });
+
+    expect(shelves[0]?.entries).toEqual([first]);
+  });
+});
+
+describe("plugin browse sorting", () => {
+  it("puts entries without a published date last in both directions", () => {
+    const entries = [
+      entry("unknown", { publishedAt: undefined }),
+      entry("older", { publishedAt: "2026-01-05T00:00:00Z" }),
+      entry("newer", { publishedAt: "2026-08-20T00:00:00Z" }),
+    ];
+
+    expect(
+      sortPluginEntries(entries, "recently-added", "desc").map(
+        (candidate) => candidate.pluginId,
+      ),
+    ).toEqual(["newer", "older", "unknown"]);
+    expect(
+      sortPluginEntries(entries, "recently-added", "asc").map(
+        (candidate) => candidate.pluginId,
+      ),
+    ).toEqual(["older", "newer", "unknown"]);
+  });
+
+  it("sorts by install count and sinks uncounted entries in both directions", () => {
+    const entries = [
+      entry("unknown", { installs: null }),
+      entry("popular", { installs: 20 }),
+      entry("new", { installs: 2 }),
+    ];
+
+    expect(
+      sortPluginEntries(entries, "most-installed", "desc").map(
+        (candidate) => candidate.pluginId,
+      ),
+    ).toEqual(["popular", "new", "unknown"]);
+    expect(
+      sortPluginEntries(entries, "most-installed", "asc").map(
+        (candidate) => candidate.pluginId,
+      ),
+    ).toEqual(["new", "popular", "unknown"]);
+  });
+});

--- a/apps/app/src/components/plugin/management/plugin-browse-discovery.ts
+++ b/apps/app/src/components/plugin/management/plugin-browse-discovery.ts
@@ -1,0 +1,162 @@
+import { PLUGIN_CATALOG_CATEGORIES, pluginCatalogCategory } from "@bb/domain";
+import type { PluginCatalogCollection } from "@bb/server-contract";
+import type {
+  PluginCatalogSearchEntry,
+  PluginCatalogSearchData,
+} from "@/hooks/queries/plugin-catalog-queries";
+
+export const UNCATEGORIZED_PLUGIN_CATEGORY_ID = "uncategorized";
+
+export type PluginBrowseSort = "recently-added" | "most-installed";
+export type PluginBrowseSortDirection = "asc" | "desc";
+
+export interface PluginBrowseShelf {
+  key: string;
+  categoryId?: string;
+  label: string;
+  description?: string;
+  entries: PluginCatalogSearchEntry[];
+  kind: "collection" | "category" | "uncategorized";
+}
+
+function isCategorized(entry: PluginCatalogSearchEntry): boolean {
+  return entry.categoryId !== undefined && entry.category !== undefined;
+}
+
+function collectionEntries(
+  entries: readonly PluginCatalogSearchEntry[],
+  collection: PluginCatalogCollection,
+): PluginCatalogSearchEntry[] {
+  const rankByEntryId = new Map(
+    collection.pluginIds.map((entryId, rank) => [entryId, rank]),
+  );
+  return entries
+    .filter(
+      (entry) =>
+        rankByEntryId.has(entry.entryId) &&
+        entry.collections.some((membership) => membership.id === collection.id),
+    )
+    .sort(
+      (left, right) =>
+        (rankByEntryId.get(left.entryId) ?? Number.MAX_SAFE_INTEGER) -
+        (rankByEntryId.get(right.entryId) ?? Number.MAX_SAFE_INTEGER),
+    );
+}
+
+export function pluginBrowseShelves({
+  entries,
+  collections,
+}: PluginCatalogSearchData): PluginBrowseShelf[] {
+  const shelves: PluginBrowseShelf[] = collections.flatMap((collection) => {
+    const shelfEntries = collectionEntries(entries, collection);
+    return shelfEntries.length === 0
+      ? []
+      : [
+          {
+            key: `collection:${collection.id}`,
+            label: collection.displayName,
+            entries: shelfEntries,
+            kind: "collection" as const,
+          },
+        ];
+  });
+  const entriesByCategory = new Map<string, PluginCatalogSearchEntry[]>();
+  const categoryLabels = new Map<string, string>();
+  const unknownCategoryOrder: string[] = [];
+  for (const entry of entries) {
+    if (!isCategorized(entry)) continue;
+    const categoryId = entry.categoryId;
+    const categoryLabel = entry.category;
+    if (categoryId === undefined || categoryLabel === undefined) continue;
+    const categoryEntries = entriesByCategory.get(categoryId);
+    if (categoryEntries === undefined) {
+      entriesByCategory.set(categoryId, [entry]);
+      categoryLabels.set(categoryId, categoryLabel);
+      if (pluginCatalogCategory(categoryId) === undefined) {
+        unknownCategoryOrder.push(categoryId);
+      }
+    } else {
+      categoryEntries.push(entry);
+    }
+  }
+  const categoryOrder = [
+    ...PLUGIN_CATALOG_CATEGORIES.map((category) => category.id),
+    ...unknownCategoryOrder,
+  ];
+  for (const categoryId of categoryOrder) {
+    const shelfEntries = entriesByCategory.get(categoryId);
+    if (shelfEntries === undefined || shelfEntries.length === 0) continue;
+    const builtInCategory = pluginCatalogCategory(categoryId);
+    shelves.push({
+      key: `category:${categoryId}`,
+      categoryId,
+      label:
+        builtInCategory?.displayName ??
+        categoryLabels.get(categoryId) ??
+        categoryId,
+      ...(builtInCategory === undefined
+        ? {}
+        : { description: builtInCategory.description }),
+      entries: shelfEntries,
+      kind: "category",
+    });
+  }
+  const uncategorizedEntries = entries.filter((entry) => !isCategorized(entry));
+  if (uncategorizedEntries.length > 0) {
+    shelves.push({
+      key: "category:uncategorized",
+      categoryId: UNCATEGORIZED_PLUGIN_CATEGORY_ID,
+      label: "More plugins",
+      entries: uncategorizedEntries,
+      kind: "uncategorized",
+    });
+  }
+  return shelves;
+}
+
+export function pluginCategoryFilterId(
+  entry: PluginCatalogSearchEntry,
+): string {
+  return isCategorized(entry)
+    ? (entry.categoryId ?? UNCATEGORIZED_PLUGIN_CATEGORY_ID)
+    : UNCATEGORIZED_PLUGIN_CATEGORY_ID;
+}
+
+function compareOptionalNumbers(
+  left: number | undefined,
+  right: number | undefined,
+  direction: PluginBrowseSortDirection,
+): number {
+  if (left === undefined) return right === undefined ? 0 : 1;
+  if (right === undefined) return -1;
+  const result = left - right;
+  return direction === "asc" ? result : -result;
+}
+
+export function sortPluginEntries(
+  entries: readonly PluginCatalogSearchEntry[],
+  sort: PluginBrowseSort,
+  direction: PluginBrowseSortDirection = "desc",
+): PluginCatalogSearchEntry[] {
+  return [...entries].sort((left, right) => {
+    const sortResult =
+      sort === "recently-added"
+        ? compareOptionalNumbers(
+            left.publishedAt === undefined
+              ? undefined
+              : Date.parse(left.publishedAt),
+            right.publishedAt === undefined
+              ? undefined
+              : Date.parse(right.publishedAt),
+            direction,
+          )
+        : compareOptionalNumbers(
+            left.installs ?? undefined,
+            right.installs ?? undefined,
+            direction,
+          );
+    if (sortResult !== 0) return sortResult;
+    const nameResult = left.displayName.localeCompare(right.displayName);
+    return nameResult || left.entryId.localeCompare(right.entryId);
+  });
+}

--- a/apps/app/src/components/plugin/management/plugin-ui.test.tsx
+++ b/apps/app/src/components/plugin/management/plugin-ui.test.tsx
@@ -2,7 +2,12 @@
 
 import { cleanup, render } from "@testing-library/react";
 import { afterEach, expect, it } from "vitest";
-import { CatalogEntryIcon } from "./plugin-ui";
+import { PLUGIN_CATALOG_CATEGORIES } from "@bb/domain";
+import {
+  CatalogEntryIcon,
+  CatalogEntryIconChip,
+  pluginCatalogCategoryPillStyle,
+} from "./plugin-ui";
 
 afterEach(cleanup);
 
@@ -24,6 +29,16 @@ it("masks a tinted icon instead of embedding it as an image", () => {
   expect(
     view.container.querySelector(`[data-plugin-icon-asset="${iconUrl}"]`),
   ).toBeTruthy();
+  expect(
+    view.container
+      .querySelector("[data-catalog-entry-icon-glyph]")
+      ?.classList.contains("size-6"),
+  ).toBe(true);
+  expect(
+    view.container
+      .querySelector(`[data-plugin-icon-asset="${iconUrl}"]`)
+      ?.classList.contains("size-full"),
+  ).toBe(true);
 });
 
 it("embeds a marketplace listing's logo as an image", () => {
@@ -37,5 +52,54 @@ it("embeds a marketplace listing's logo as an image", () => {
 
   expect(view.container.querySelector("img")?.getAttribute("src")).toBe(
     iconUrl,
+  );
+  expect(
+    view.container.querySelector("img")?.classList.contains("size-full"),
+  ).toBe(true);
+});
+
+it("uses one glyph box for host and marketplace catalog icons", () => {
+  const view = render(
+    <>
+      <CatalogEntryIconChip
+        entry={{
+          displayName: "Push notifications",
+          icon: "BellDot",
+          iconUrl: null,
+          iconTinted: false,
+        }}
+      />
+      <CatalogEntryIconChip
+        entry={{
+          displayName: "Community notifications",
+          icon: null,
+          iconUrl: "/community-notifications.svg",
+          iconTinted: false,
+        }}
+      />
+    </>,
+  );
+
+  const glyphs = view.container.querySelectorAll(
+    "[data-catalog-entry-icon-glyph]",
+  );
+  expect(glyphs).toHaveLength(2);
+  for (const glyph of glyphs) {
+    expect(glyph.classList.contains("size-6")).toBe(true);
+    expect(glyph.parentElement?.classList.contains("size-10")).toBe(true);
+    expect(glyph.firstElementChild?.classList.contains("size-full")).toBe(true);
+  }
+});
+
+it("uses theme accents for all built-in categories and neutral unknowns", () => {
+  for (const category of PLUGIN_CATALOG_CATEGORIES) {
+    const style = pluginCatalogCategoryPillStyle(category.id);
+    expect(String(style.background)).toContain("color-mix(in oklch");
+    expect(String(style.background)).toContain("var(--");
+    expect(String(style.background)).not.toContain("var(--ink) 8%");
+  }
+  const unknown = pluginCatalogCategoryPillStyle("future-category");
+  expect(unknown.background).toBe(
+    "color-mix(in oklch, var(--ink) 8%, var(--canvas))",
   );
 });

--- a/apps/app/src/components/plugin/management/plugin-ui.tsx
+++ b/apps/app/src/components/plugin/management/plugin-ui.tsx
@@ -1,6 +1,7 @@
-import { useState, type ReactNode } from "react";
-import { Icon, type IconName } from "@bb/shared-ui/icon";
+import { useState, type CSSProperties, type ReactNode } from "react";
+import { Icon } from "@bb/shared-ui/icon";
 import { cn } from "@bb/shared-ui/lib/utils";
+import { ResourceIconFrame } from "@bb/shared-ui/resource-list";
 import {
   PluginCompactIconMask,
   PluginIcon,
@@ -24,6 +25,89 @@ export function displayPluginVersion(version: string): string {
 export const SUCCESS_TEXT_STYLE = {
   color: "color-mix(in oklab, var(--success) 80%, var(--ink))",
 } as const;
+
+const PLUGIN_INSTALL_COUNT_FORMATTER = new Intl.NumberFormat(undefined, {
+  notation: "compact",
+  maximumFractionDigits: 1,
+});
+
+export function formatPluginInstallCount(installs: number): string {
+  return PLUGIN_INSTALL_COUNT_FORMATTER.format(installs);
+}
+
+const PLUGIN_CATEGORY_ACCENT_TOKENS: Record<string, string> = {
+  "themes-and-appearance": "--file-accent",
+  "thread-management": "--file-accent",
+  "thread-content": "--file-accent",
+  "memory-and-context": "--success",
+  security: "--warning",
+  "agents-and-providers": "--success",
+  "token-usage-and-limits": "--warning",
+  notifications: "--warning",
+  "code-and-reviews": "--pr-merged",
+  "file-viewers-and-editors": "--pr-merged",
+  "cloud-and-remote": "--attention",
+  "command-line": "--attention",
+  utilities: "--attention",
+  "plugin-development": "--pr-merged",
+  "tasks-and-workflows": "--success",
+};
+
+function neutral(percent: number): string {
+  return `color-mix(in oklch, var(--ink) ${percent}%, var(--canvas))`;
+}
+
+function accentTint(token: string, percent: number): string {
+  return `color-mix(in oklch, var(${token}) ${percent}%, var(--canvas))`;
+}
+
+function accentInk(token: string, percent: number): string {
+  return `color-mix(in oklch, var(${token}) ${percent}%, var(--ink))`;
+}
+
+function pluginCatalogCategoryAccentToken(
+  categoryId: string | undefined,
+): string | undefined {
+  return categoryId === undefined
+    ? undefined
+    : PLUGIN_CATEGORY_ACCENT_TOKENS[categoryId];
+}
+
+export function pluginCatalogCategoryPillStyle(
+  categoryId: string | undefined,
+): CSSProperties {
+  const accentToken = pluginCatalogCategoryAccentToken(categoryId);
+  return accentToken === undefined
+    ? {
+        background: neutral(8),
+        borderColor: neutral(16),
+        color: neutral(55),
+      }
+    : {
+        background: accentTint(accentToken, 16),
+        borderColor: accentTint(accentToken, 24),
+        color: accentInk(accentToken, 52),
+      };
+}
+
+export function pluginCatalogCategoryMutedAccentStyle(
+  categoryId: string | undefined,
+): CSSProperties {
+  const accentToken = pluginCatalogCategoryAccentToken(categoryId);
+  return {
+    background:
+      accentToken === undefined ? neutral(36) : accentTint(accentToken, 55),
+  };
+}
+
+export function pluginCatalogCategoryAccentStyle(
+  categoryId: string | undefined,
+): CSSProperties {
+  const accentToken = pluginCatalogCategoryAccentToken(categoryId);
+  return {
+    background: accentToken === undefined ? neutral(58) : `var(${accentToken})`,
+  };
+}
 
 export function PluginLogo({
   plugin,
@@ -81,45 +165,68 @@ export function CatalogEntryIcon({
   className: string;
 }) {
   const [failedIconUrl, setFailedIconUrl] = useState<string | null>(null);
-  if (entry.iconUrl !== null && entry.iconTinted) {
-    return <PluginCompactIconMask url={entry.iconUrl} className={className} />;
-  }
-  if (entry.iconUrl === null || entry.iconUrl === failedIconUrl) {
-    return (
-      <PlaceholderBadge
-        className={className}
-        iconName={pluginIconName(entry.icon)}
-      />
-    );
-  }
-  return (
-    <img
-      src={entry.iconUrl}
-      alt=""
-      aria-hidden="true"
-      className={cn("rounded-sm object-contain", className)}
-      onError={() => setFailedIconUrl(entry.iconUrl)}
-    />
-  );
-}
-
-function PlaceholderBadge({
-  className,
-  iconName = "Zap",
-}: {
-  className?: string;
-  iconName?: IconName;
-}) {
   return (
     <span
       aria-hidden="true"
-      className={cn(
-        "grid shrink-0 place-items-center text-muted-foreground",
-        className,
-      )}
+      data-catalog-entry-icon-glyph=""
+      className={cn("grid shrink-0 place-items-center", className)}
     >
-      <Icon name={iconName} className="size-5" />
+      {entry.iconUrl !== null && entry.iconTinted ? (
+        <PluginCompactIconMask url={entry.iconUrl} className="size-full" />
+      ) : entry.iconUrl === null || entry.iconUrl === failedIconUrl ? (
+        <Icon name={pluginIconName(entry.icon)} className="size-full" />
+      ) : (
+        <img
+          src={entry.iconUrl}
+          alt=""
+          className="size-full rounded-sm object-contain"
+          onError={() => setFailedIconUrl(entry.iconUrl)}
+        />
+      )}
     </span>
+  );
+}
+
+export function PluginCategoryLabel({
+  categoryId,
+  label,
+}: {
+  categoryId: string | undefined;
+  label: string;
+}) {
+  return (
+    <span
+      className="shrink-0 truncate rounded border px-2 py-1 text-2xs leading-none"
+      style={pluginCatalogCategoryPillStyle(categoryId)}
+    >
+      {label}
+    </span>
+  );
+}
+
+export function CatalogEntryIconChip({
+  entry,
+  className,
+}: {
+  entry: {
+    displayName: string;
+    icon: string | null;
+    iconUrl: string | null;
+    iconTinted: boolean;
+  };
+  className?: string;
+}) {
+  return (
+    <ResourceIconFrame
+      className={cn("size-10 rounded-md border", className)}
+      style={{
+        background: neutral(5),
+        borderColor: neutral(14),
+        color: neutral(55),
+      }}
+    >
+      {() => <CatalogEntryIcon entry={entry} className="size-6" />}
+    </ResourceIconFrame>
   );
 }
 

--- a/apps/app/src/components/showcase-hero/ShowcaseHeroCarousel.tsx
+++ b/apps/app/src/components/showcase-hero/ShowcaseHeroCarousel.tsx
@@ -209,7 +209,7 @@ export function ShowcaseHeroCarousel({
       </p>
 
       {}
-      <div className="relative mt-5 grid w-full max-w-[58rem] grid-cols-1 grid-rows-1">
+      <div className="@container relative mt-5 grid w-full max-w-[58rem] grid-cols-1 grid-rows-1">
         <div
           className={cn(
             "relative [grid-area:1/1]",
@@ -250,7 +250,7 @@ export function ShowcaseHeroCarousel({
                 }
                 className={cn(
                   "bb-hero-chip absolute z-10 hidden max-w-[9rem] cursor-pointer items-center gap-1.5",
-                  "rounded-lg border px-2 py-1.5 text-2xs font-medium shadow-sm lg:flex",
+                  "rounded-lg border px-2 py-1.5 text-2xs font-medium shadow-sm @[50rem]:flex",
                   "transition-[opacity,transform,background-color,border-color] duration-500",
                   isActive ? "opacity-100" : "opacity-70 hover:opacity-100",
                 )}
@@ -269,7 +269,7 @@ export function ShowcaseHeroCarousel({
             badge={copy.frameBadge}
             rail={rail}
             reducedMotion={reducedMotion}
-            className="mx-auto h-[13rem] w-full max-w-[38rem] lg:w-[66%]"
+            className="mx-auto h-[13rem] w-full max-w-[38rem] @[50rem]:w-[66%]"
           />
         </div>
 

--- a/apps/app/src/components/tools/ExtensionsDetailStates.stories.tsx
+++ b/apps/app/src/components/tools/ExtensionsDetailStates.stories.tsx
@@ -519,6 +519,8 @@ const UNINSTALLED_CATALOG_PLUGIN = {
   iconUrl: null,
   iconTinted: false,
   category: "Developer tools",
+  screenshots: [],
+  collections: [],
   source: "builtin:github",
   repositoryUrl: null,
   marketplaceDisplayName: "BB Official",

--- a/apps/app/src/components/tools/PluginDetail.tsx
+++ b/apps/app/src/components/tools/PluginDetail.tsx
@@ -29,12 +29,17 @@ import {
   pluginHasUpdateSurfaces,
 } from "@/components/plugin/management/PluginUpdatesCard";
 import {
-  CatalogEntryIcon,
+  CatalogEntryIconChip,
   formatAbsoluteDate,
+  formatPluginInstallCount,
   PluginLogo,
 } from "@/components/plugin/management/plugin-ui";
+import {
+  PluginMarketplaceCategoryPill,
+  PluginMarketplaceHeaderMetadata,
+  PluginMarketplaceListingSections,
+} from "@/components/plugin/management/PluginMarketplaceListing";
 import { pluginRuntimeStatusPresentation } from "@/components/plugin/management/plugin-status";
-import { PluginUrlLink } from "@/components/plugin/PluginUrlLink";
 import {
   PluginHealthBanner,
   PluginIncludes,
@@ -111,10 +116,6 @@ function PluginPath({ path }: { path: string }) {
   );
 }
 
-function repositoryLinkLabel(url: string): string {
-  return url.replace(/^https?:\/\//u, "").replace(/\/+$/u, "");
-}
-
 export function CatalogPluginDetail({
   entry,
   onInstall,
@@ -122,61 +123,32 @@ export function CatalogPluginDetail({
   entry: PluginCatalogSearchEntry;
   onInstall: (entry: PluginCatalogSearchEntry) => void;
 }) {
+  const count =
+    entry.installs === null
+      ? undefined
+      : {
+          display: formatPluginInstallCount(entry.installs),
+          accessibleLabel: `${entry.installs.toLocaleString()} ${entry.installs === 1 ? "install" : "installs"}`,
+        };
   return (
     <ResourceDetailPage
       maxWidthClassName="max-w-5xl"
-      leading={<CatalogEntryIcon entry={entry} className="size-full" />}
+      leading={<CatalogEntryIconChip entry={entry} />}
+      leadingClassName="size-10"
       title={entry.displayName}
-      titleMeta={<ProvenancePill label={entry.publisherLabel} />}
-      metadata={
-        <>
-          <span>{entry.category}</span>
-          {entry.author === null ? null : (
-            <span>
-              {" · By: "}
-              {entry.author.url === null ? (
-                entry.author.name
-              ) : (
-                <PluginUrlLink
-                  href={entry.author.url}
-                  className="underline underline-offset-2"
-                >
-                  {entry.author.name}
-                </PluginUrlLink>
-              )}
-            </span>
-          )}
-          {entry.repositoryUrl === null ? null : (
-            <span>
-              {" · "}
-              <a
-                href={entry.repositoryUrl}
-                target="_blank"
-                rel="noreferrer"
-                className="underline underline-offset-2"
-              >
-                {repositoryLinkLabel(entry.repositoryUrl)}
-              </a>
-            </span>
-          )}
-        </>
-      }
+      titleMeta={<PluginMarketplaceCategoryPill entry={entry} />}
+      metadata={<PluginMarketplaceHeaderMetadata entry={entry} />}
       actions={
         <ResourceInstallControl
           accessibleLabel={`Install ${entry.displayName}`}
           disabled={!entry.compatible}
+          count={count}
           onAction={() => onInstall(entry)}
         />
       }
     >
       <ResourceDetailStack>
-        <ResourceDetailOverviewSection label="About">
-          <p className="max-w-none text-sm leading-relaxed text-muted-foreground">
-            {entry.description.length > 0
-              ? entry.description
-              : "This plugin does not describe itself."}
-          </p>
-        </ResourceDetailOverviewSection>
+        <PluginMarketplaceListingSections entry={entry} />
       </ResourceDetailStack>
     </ResourceDetailPage>
   );
@@ -249,6 +221,7 @@ export function PluginDetail({
   onEdit,
   onOpenSource,
   onDelete,
+  catalogEntry,
 }: {
   isLoading: boolean;
   plugin: PluginListItem | null;
@@ -258,6 +231,7 @@ export function PluginDetail({
   onEdit: (plugin: PluginListItem) => void;
   onOpenSource: (plugin: PluginListItem) => void;
   onDelete: (plugin: PluginListItem) => void;
+  catalogEntry?: PluginCatalogSearchEntry;
 }) {
   const { settingsSections } = usePluginSlots();
   const sourceQuery = usePluginSource(plugin?.id ?? "", {
@@ -345,8 +319,22 @@ export function PluginDetail({
       maxWidthClassName="max-w-5xl"
       leading={<PluginLogo plugin={plugin} className="size-4" />}
       title={pluginName}
-      titleMeta={<PluginProvenancePill plugin={plugin} />}
-      metadata={<PluginPath path={plugin.rootDir} />}
+      titleMeta={
+        <span className="flex flex-wrap items-center gap-1.5">
+          <PluginProvenancePill plugin={plugin} />
+          {catalogEntry === undefined ? null : (
+            <PluginMarketplaceCategoryPill entry={catalogEntry} />
+          )}
+        </span>
+      }
+      metadata={
+        <div className="space-y-1">
+          {catalogEntry === undefined ? null : (
+            <PluginMarketplaceHeaderMetadata entry={catalogEntry} />
+          )}
+          <PluginPath path={plugin.rootDir} />
+        </div>
+      }
       lifecycleControl={
         <Switch
           checked={plugin.enabled}
@@ -363,11 +351,15 @@ export function PluginDetail({
       }
     >
       <ResourceDetailStack>
-        <ResourceDetailOverviewSection label="About">
-          <p className="max-w-none text-sm leading-relaxed text-muted-foreground">
-            {plugin.description ?? "This plugin does not describe itself."}
-          </p>
-        </ResourceDetailOverviewSection>
+        {catalogEntry === undefined ? (
+          <ResourceDetailOverviewSection label="About">
+            <p className="max-w-none text-sm leading-relaxed text-muted-foreground">
+              {plugin.description ?? "This plugin does not describe itself."}
+            </p>
+          </ResourceDetailOverviewSection>
+        ) : (
+          <PluginMarketplaceListingSections entry={catalogEntry} />
+        )}
         {hasConfiguration ? (
           <ResourceDetailConfigurationSection
             id="configuration"

--- a/apps/app/src/hooks/queries/plugin-catalog-queries.test.ts
+++ b/apps/app/src/hooks/queries/plugin-catalog-queries.test.ts
@@ -117,8 +117,8 @@ describe("plugin installs", () => {
 });
 
 describe("plugin catalog queries", () => {
-  it("preserves canonical identity and labels an absent category", async () => {
-    const entries = await searchPluginCatalog(
+  it("preserves the catalog data and an absent category", async () => {
+    const data = await searchPluginCatalog(
       fetchReturning({
         results: [
           {
@@ -140,33 +140,50 @@ describe("plugin catalog queries", () => {
             incompatibleReason: "requires bb >= 0.15",
           },
         ],
+        collections: [
+          {
+            id: "new-and-notable",
+            displayName: "New & notable",
+            pluginIds: ["todoist"],
+          },
+        ],
       }),
       "todo",
     );
-    expect(entries).toEqual([
-      {
-        entryId: "todoist",
-        pluginId: "todoist",
-        displayName: "Todoist",
-        description: "Personal task capture",
-        icon: "CheckList",
-        iconUrl: null,
-        iconTinted: false,
-        category: "Uncategorized",
-        source: "npm:@bb-plugins/todoist",
-        repositoryUrl: null,
-        marketplace: "acme-plugins",
-        marketplaceDisplayName: "Acme Plugins",
-        publisherKey: "acme-plugins",
-        publisherLabel: "Acme Plugins",
-        official: false,
-        author: { name: "Acme", url: "https://acme.dev" },
-        installed: false,
-        installs: null,
-        compatible: false,
-        incompatibleReason: "requires bb >= 0.15",
-      },
-    ]);
+    expect(data).toEqual({
+      entries: [
+        {
+          entryId: "todoist",
+          pluginId: "todoist",
+          displayName: "Todoist",
+          description: "Personal task capture",
+          icon: "CheckList",
+          iconUrl: null,
+          iconTinted: false,
+          screenshots: [],
+          collections: [],
+          source: "npm:@bb-plugins/todoist",
+          repositoryUrl: null,
+          marketplace: "acme-plugins",
+          marketplaceDisplayName: "Acme Plugins",
+          publisherKey: "acme-plugins",
+          publisherLabel: "Acme Plugins",
+          official: false,
+          author: { name: "Acme", url: "https://acme.dev" },
+          installed: false,
+          installs: null,
+          compatible: false,
+          incompatibleReason: "requires bb >= 0.15",
+        },
+      ],
+      collections: [
+        {
+          id: "new-and-notable",
+          displayName: "New & notable",
+          pluginIds: ["todoist"],
+        },
+      ],
+    });
   });
 
   it("throws instead of replacing cached search data with an empty result", async () => {

--- a/apps/app/src/hooks/queries/plugin-catalog-queries.ts
+++ b/apps/app/src/hooks/queries/plugin-catalog-queries.ts
@@ -2,6 +2,8 @@ import type {
   InstalledPlugin,
   PluginApplyUpdateResult as SdkPluginApplyUpdateResult,
   PluginCatalogAuthor,
+  PluginCatalogCollection,
+  PluginCatalogCollectionMembership,
   PluginCatalogInstallPlan,
   PluginCatalogResolvedSource,
   PluginCatalogSearchResult as SdkPluginCatalogSearchResult,
@@ -223,7 +225,11 @@ export interface PluginCatalogSearchEntry {
   icon: string | null;
   iconUrl: string | null;
   iconTinted: boolean;
-  category: string;
+  categoryId?: string;
+  category?: string;
+  screenshots: string[];
+  collections: PluginCatalogCollectionMembership[];
+  publishedAt?: string;
   source: string;
   repositoryUrl: string | null;
   marketplace: string;
@@ -249,7 +255,13 @@ function toPluginCatalogSearchEntry(
     icon: data.icon,
     iconUrl: data.iconUrl,
     iconTinted: data.iconTinted,
-    category: data.category ?? "Uncategorized",
+    ...(data.categoryId === undefined ? {} : { categoryId: data.categoryId }),
+    ...(data.category === undefined ? {} : { category: data.category }),
+    screenshots: data.screenshots,
+    collections: data.collections,
+    ...(data.publishedAt === undefined
+      ? {}
+      : { publishedAt: data.publishedAt }),
     source: data.source,
     repositoryUrl: data.repositoryUrl,
     marketplace: data.marketplace,
@@ -265,14 +277,24 @@ function toPluginCatalogSearchEntry(
   };
 }
 
+export interface PluginCatalogSearchData {
+  entries: PluginCatalogSearchEntry[];
+  collections: PluginCatalogCollection[];
+}
+
 export async function searchPluginCatalog(
   fetchImpl: FetchLike,
   query: string,
-): Promise<PluginCatalogSearchEntry[]> {
-  const { results } = await createPluginsClient(fetchImpl).catalog.search({
+): Promise<PluginCatalogSearchData> {
+  const { results, collections } = await createPluginsClient(
+    fetchImpl,
+  ).catalog.search({
     query,
   });
-  return results.map(toPluginCatalogSearchEntry);
+  return {
+    entries: results.map(toPluginCatalogSearchEntry),
+    collections,
+  };
 }
 
 const PLUGIN_CATALOG_STALE_TIME_MS = 30 * 60_000;

--- a/apps/app/src/views/ToolsView.plugin-detail.test.tsx
+++ b/apps/app/src/views/ToolsView.plugin-detail.test.tsx
@@ -8,13 +8,14 @@ import {
   waitFor,
   within,
 } from "@testing-library/react";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   EMPTY_PLUGIN_UPDATE_STATE,
   type PluginListItem,
 } from "@/hooks/queries/plugin-settings-queries";
 import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
+import { TooltipProvider } from "@bb/shared-ui/tooltip";
 import {
   resetPluginSlotStoreForTest,
   setPluginSlotRegistrations,
@@ -71,6 +72,8 @@ const GITHUB_CATALOG_ENTRY = {
   iconUrl: null,
   iconTinted: false,
   category: "Developer tools",
+  screenshots: [],
+  collections: [],
   source: "builtin:github",
   repositoryUrl: null,
   marketplaceDisplayName: "BB Official",
@@ -83,6 +86,22 @@ const GITHUB_CATALOG_ENTRY = {
   compatible: true,
   incompatibleReason: null,
 } satisfies PluginCatalogSearchEntry;
+
+function RoutedToolsView() {
+  const location = useLocation();
+  const prefix = "/extensions/plugins/";
+  const pluginId = location.pathname.startsWith(prefix)
+    ? decodeURIComponent(location.pathname.slice(prefix.length))
+    : undefined;
+  return (
+    <>
+      <TooltipProvider>
+        <ToolsView pluginId={pluginId} />
+      </TooltipProvider>
+      <output data-testid="route-path">{location.pathname}</output>
+    </>
+  );
+}
 
 afterEach(() => {
   cleanup();
@@ -126,10 +145,34 @@ describe("PluginDetail official catalog lifecycle", () => {
     );
 
     const link = screen.getByRole("link", {
-      name: "github.com/acme/bb-github",
+      name: /github\.com\/acme\/bb-github/u,
     });
     expect(link.getAttribute("href")).toBe("https://github.com/acme/bb-github");
     expect(link.getAttribute("target")).toBe("_blank");
+  });
+
+  it("loads remote screenshots only in detail and shows the listed date", () => {
+    const { container } = render(
+      <CatalogPluginDetail
+        entry={{
+          ...GITHUB_CATALOG_ENTRY,
+          screenshots: ["https://images.example/plugin.png"],
+          publishedAt: "2026-08-20T00:00:00Z",
+        }}
+        onInstall={() => undefined}
+      />,
+    );
+
+    const screenshot = screen.getByRole("img", {
+      name: "GitHub screenshot 1",
+    });
+    expect(screenshot.getAttribute("src")).toBe(
+      "https://images.example/plugin.png",
+    );
+    expect(screenshot.getAttribute("referrerpolicy")).toBe("no-referrer");
+    expect(screenshot.getAttribute("loading")).toBe("lazy");
+    expect(screen.getByText("Listed")).toBeTruthy();
+    expect(container.textContent).not.toContain("Last updated");
   });
 
   it("explains why an incompatible official plugin cannot be installed", () => {
@@ -205,12 +248,14 @@ describe("PluginDetail official catalog lifecycle", () => {
             onEdit={() => {}}
             onOpenSource={() => {}}
             onDelete={onDelete}
+            catalogEntry={GITHUB_CATALOG_ENTRY}
           />
         </QueryClientWrapper>
       </MemoryRouter>,
     );
 
-    expect(screen.getByText("BB Official")).toBeTruthy();
+    expect(screen.getAllByText("BB Official").length).toBeGreaterThan(0);
+    expect(screen.getByText("Developer tools")).toBeTruthy();
     expect(
       screen.queryByRole("button", { name: "Uninstall GitHub" }),
     ).toBeNull();
@@ -513,9 +558,12 @@ describe("BB Official plugin detail routing", () => {
             headers: { "content-type": "application/json" },
           });
         }
-        if (url === "/api/v1/plugin-catalog/search?q=github") {
+        if (url === "/api/v1/plugin-catalog/search?q=") {
           return new Response(
-            JSON.stringify({ results: [GITHUB_CATALOG_ENTRY] }),
+            JSON.stringify({
+              results: [GITHUB_CATALOG_ENTRY],
+              collections: [],
+            }),
             { headers: { "content-type": "application/json" } },
           );
         }
@@ -532,7 +580,11 @@ describe("BB Official plugin detail routing", () => {
         <Routes>
           <Route
             path="/extensions/plugins/:pluginId"
-            element={<ToolsView pluginId="github" />}
+            element={
+              <TooltipProvider>
+                <ToolsView pluginId="github" />
+              </TooltipProvider>
+            }
           />
         </Routes>
       </MemoryRouter>,
@@ -540,11 +592,74 @@ describe("BB Official plugin detail routing", () => {
     );
 
     expect(await screen.findByRole("heading", { name: "GitHub" })).toBeTruthy();
-    fireEvent.click(screen.getByRole("button", { name: "Install GitHub" }));
+    fireEvent.click(
+      screen.getAllByRole("button", { name: "Install GitHub" }).at(-1)!,
+    );
     expect(
       await screen.findByRole("heading", { name: "Install GitHub?" }),
     ).toBeTruthy();
     expect(screen.getByTestId("full-trust-warning")).toBeTruthy();
+  });
+
+  it("opens one detail tab beside Browse and restores card focus", async () => {
+    const catalogEntry = {
+      ...GITHUB_CATALOG_ENTRY,
+      categoryId: "code-and-reviews",
+      category: "Code & Reviews",
+      author: { name: "BB", url: "https://github.com/get-bb" },
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url === "/api/v1/plugins") {
+          return new Response(JSON.stringify({ enabled: true, plugins: [] }), {
+            headers: { "content-type": "application/json" },
+          });
+        }
+        if (url.startsWith("/api/v1/plugin-catalog/search")) {
+          return new Response(
+            JSON.stringify({ results: [catalogEntry], collections: [] }),
+            { headers: { "content-type": "application/json" } },
+          );
+        }
+        return new Response(JSON.stringify({ error: "not found" }), {
+          status: 404,
+          headers: { "content-type": "application/json" },
+        });
+      }),
+    );
+
+    const { wrapper: QueryClientWrapper } = createQueryClientTestHarness();
+    render(
+      <MemoryRouter initialEntries={["/extensions/plugins"]}>
+        <Routes>
+          <Route path="/extensions/plugins/*" element={<RoutedToolsView />} />
+        </Routes>
+      </MemoryRouter>,
+      { wrapper: QueryClientWrapper },
+    );
+
+    const card = await screen.findByRole("button", {
+      name: "Open GitHub details",
+    });
+    card.focus();
+    fireEvent.click(card);
+    expect(
+      await screen.findByRole("button", { name: "Close GitHub" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("textbox", { name: "Search plugins" }),
+    ).toBeTruthy();
+    expect(screen.getAllByRole("button", { name: /^Close /u })).toHaveLength(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Close GitHub" }));
+    await waitFor(() => {
+      expect(screen.getByTestId("route-path").textContent).toBe(
+        "/extensions/plugins",
+      );
+      expect(document.activeElement).toBe(card);
+    });
   });
 });
 
@@ -599,7 +714,11 @@ describe("plugin removal confirmation", () => {
         <Routes>
           <Route
             path="/extensions/plugins/:pluginId"
-            element={<ToolsView pluginId="github" />}
+            element={
+              <TooltipProvider>
+                <ToolsView pluginId="github" />
+              </TooltipProvider>
+            }
           />
         </Routes>
       </MemoryRouter>,

--- a/apps/app/src/views/ToolsView.tsx
+++ b/apps/app/src/views/ToolsView.tsx
@@ -2,6 +2,7 @@ import {
   Suspense,
   useCallback,
   useMemo,
+  useRef,
   useState,
   type ReactNode,
 } from "react";
@@ -46,6 +47,8 @@ import { useLocalOpenTargets } from "@/hooks/useLocalOpenTargets";
 import {
   TOOLS_REGISTRY_SKILLS_ROUTE_PATH,
   TOOLS_SKILLS_ROUTE_PATH,
+  getPluginDetailRoutePath,
+  getPluginsRoutePath,
   getRootComposeRoutePath,
 } from "@/lib/route-paths";
 import {
@@ -55,6 +58,10 @@ import {
 } from "@/components/tools/tools-navigation";
 import { cn } from "@bb/shared-ui/lib/utils";
 import { SkillsLibrary } from "@/components/tools/SkillsLibrary";
+import { PluginIcon } from "@/components/plugin/PluginIcon";
+import { SecondaryPanelLayout } from "@/components/secondary-panel/SecondaryPanelLayout";
+import { ThreadSecondaryPanel } from "@/components/secondary-panel/ThreadSecondaryPanel";
+import type { SecondaryPanelRenderableTab } from "@/components/secondary-panel/secondaryPanelTab";
 
 function ToolsBodyFallback() {
   return (
@@ -121,12 +128,12 @@ function ToolsScrollPage({
 
 function ToolsSectionBody({
   activeSection,
-  pluginId,
   pathname,
+  onOpenPlugin,
 }: {
   activeSection: ToolsSectionId;
-  pluginId: string | undefined;
   pathname: string;
+  onOpenPlugin: (pluginId: string, trigger: HTMLButtonElement) => void;
 }) {
   if (activeSection === "skills") {
     const isCollection =
@@ -138,16 +145,18 @@ function ToolsSectionBody({
       </ToolsScrollPage>
     );
   }
-  return <PluginsToolView pluginId={pluginId} />;
+  return <PluginsToolView onOpenPlugin={onOpenPlugin} />;
 }
 
-function PluginsToolView({ pluginId }: { pluginId: string | undefined }) {
-  return pluginId === undefined ? (
+function PluginsToolView({
+  onOpenPlugin,
+}: {
+  onOpenPlugin: (pluginId: string, trigger: HTMLButtonElement) => void;
+}) {
+  return (
     <ToolsScrollPage fillViewport>
-      <PluginsOverview />
+      <PluginsOverview onOpenPlugin={onOpenPlugin} />
     </ToolsScrollPage>
-  ) : (
-    <PluginDetailToolView pluginId={pluginId} />
   );
 }
 
@@ -157,7 +166,7 @@ function PluginDetailToolView({ pluginId }: { pluginId: string }) {
   const [installTarget, setInstallTarget] =
     useState<PluginCatalogSearchEntry | null>(null);
   const listQuery = usePluginList({ enabled: true });
-  const catalogQuery = usePluginCatalogSearch(pluginId, { enabled: true });
+  const catalogQuery = usePluginCatalogSearch("", { enabled: true });
   const plugins = useMemo(
     () => listQuery.data?.plugins ?? [],
     [listQuery.data],
@@ -210,7 +219,8 @@ function PluginDetailToolView({ pluginId }: { pluginId: string }) {
   const selectedPlugin =
     plugins.find((plugin) => plugin.id === pluginId) ?? null;
   const selectedCatalogEntry =
-    catalogQuery.data?.find((entry) => entry.pluginId === pluginId) ?? null;
+    catalogQuery.data?.entries.find((entry) => entry.pluginId === pluginId) ??
+    null;
   useResourceRouteLabel(
     selectedPlugin?.name ??
       selectedPlugin?.id ??
@@ -280,6 +290,14 @@ function PluginDetailToolView({ pluginId }: { pluginId: string }) {
         onEdit={handleEditPlugin}
         onOpenSource={handleOpenPluginSource}
         onDelete={setDeleteTarget}
+        catalogEntry={selectedCatalogEntry ?? undefined}
+      />
+    );
+  } else if (selectedCatalogEntry !== null && !selectedCatalogEntry.installed) {
+    detailContent = (
+      <CatalogPluginDetail
+        entry={selectedCatalogEntry}
+        onInstall={setInstallTarget}
       />
     );
   } else if (catalogQuery.isError) {
@@ -299,13 +317,6 @@ function PluginDetailToolView({ pluginId }: { pluginId: string }) {
         message="Loading plugin"
         layout="detail"
         maxWidthClassName="max-w-5xl"
-      />
-    );
-  } else if (selectedCatalogEntry !== null && !selectedCatalogEntry.installed) {
-    detailContent = (
-      <CatalogPluginDetail
-        entry={selectedCatalogEntry}
-        onInstall={setInstallTarget}
       />
     );
   } else if (selectedCatalogEntry?.installed) {
@@ -392,7 +403,7 @@ export function PluginDetailPaneView({ pluginId }: { pluginId: string }) {
     <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
       <div className="min-h-0 flex-1 overflow-hidden">
         <Suspense fallback={<ToolsBodyFallback />}>
-          <PluginsToolView pluginId={pluginId} />
+          <PluginDetailToolView pluginId={pluginId} />
         </Suspense>
       </div>
     </div>
@@ -401,19 +412,160 @@ export function PluginDetailPaneView({ pluginId }: { pluginId: string }) {
 
 export function ToolsView({ pluginId }: { pluginId?: string } = {}) {
   const location = useLocation();
+  const navigate = useNavigate();
   const activeSection = resolveToolsSection(location.pathname);
+  const focusReturnRef = useRef<HTMLButtonElement | null>(null);
+  const [isPluginDetailFullPage, setIsPluginDetailFullPage] = useState(false);
+  const catalogQuery = usePluginCatalogSearch("", {
+    enabled: activeSection === "plugins",
+  });
+  const listQuery = usePluginList({ enabled: activeSection === "plugins" });
+  const isInstalledDetail =
+    activeSection === "plugins" &&
+    pluginId !== undefined &&
+    new URLSearchParams(location.search).get("view") === "installed";
+  const isPanelOpen =
+    activeSection === "plugins" && pluginId !== undefined && !isInstalledDetail;
+
+  const openPlugin = useCallback(
+    (nextPluginId: string, trigger: HTMLButtonElement) => {
+      focusReturnRef.current = trigger;
+      navigate({
+        pathname: getPluginDetailRoutePath({ pluginId: nextPluginId }),
+        search: location.search,
+      });
+    },
+    [location.search, navigate],
+  );
+  const closePanel = useCallback(() => {
+    setIsPluginDetailFullPage(false);
+    navigate({
+      pathname: getPluginsRoutePath(),
+      search: location.search,
+    });
+    const focusTarget = focusReturnRef.current;
+    window.requestAnimationFrame(() => {
+      if (focusTarget?.isConnected) focusTarget.focus({ preventScroll: true });
+    });
+  }, [location.search, navigate]);
+  const catalogEntry = catalogQuery.data?.entries.find(
+    (entry) => entry.pluginId === pluginId,
+  );
+  const installedPlugin = listQuery.data?.plugins.find(
+    (entry) => entry.id === pluginId,
+  );
+  const panelLabel =
+    catalogEntry?.displayName ??
+    installedPlugin?.name ??
+    installedPlugin?.id ??
+    pluginId ??
+    "Plugin";
+  const panelTab = useMemo<SecondaryPanelRenderableTab | null>(() => {
+    if (pluginId === undefined) return null;
+    return {
+      contentFillsRegion: true,
+      label: panelLabel,
+      leadingVisual: (
+        <PluginIcon
+          pluginId={pluginId}
+          icon={catalogEntry?.icon ?? installedPlugin?.icon ?? null}
+          compactIconUrl={installedPlugin?.compactIconUrl}
+          className="size-3.5"
+        />
+      ),
+      onClose: closePanel,
+      onSelect: () => undefined,
+      renderContent: () => <PluginDetailToolView pluginId={pluginId} />,
+      statusLabel: null,
+      tab: {
+        id: `marketplace-plugin:${pluginId}`,
+        kind: "marketplace-plugin-detail",
+      },
+    };
+  }, [
+    catalogEntry?.icon,
+    closePanel,
+    installedPlugin?.compactIconUrl,
+    installedPlugin?.icon,
+    panelLabel,
+    pluginId,
+  ]);
+  const panelTabs = useMemo<readonly SecondaryPanelRenderableTab[]>(
+    () => (panelTab === null ? [] : [panelTab]),
+    [panelTab],
+  );
+  const mainContent = (
+    <div className="min-h-0 flex-1 overflow-hidden">
+      <Suspense fallback={<ToolsBodyFallback />}>
+        {isInstalledDetail && pluginId !== undefined ? (
+          <PluginDetailToolView pluginId={pluginId} />
+        ) : (
+          <ToolsSectionBody
+            activeSection={activeSection}
+            pathname={location.pathname}
+            onOpenPlugin={openPlugin}
+          />
+        )}
+      </Suspense>
+    </div>
+  );
+  const renderPanel = useCallback(
+    ({
+      presentation,
+      isMainCollapsed,
+      onToggleMainCollapse,
+      resizablePanelId,
+    }: {
+      presentation: "inline" | "drawer";
+      isMainCollapsed: boolean;
+      onToggleMainCollapse: () => void;
+      resizablePanelId?: string;
+    }) =>
+      isPanelOpen ? (
+        <ThreadSecondaryPanel
+          activeTab={panelTab?.tab ?? null}
+          canUseGitUi={false}
+          metadataContent={null}
+          tabs={panelTabs}
+          fixedTabs={[]}
+          onTabReorder={() => undefined}
+          isOpen={isPanelOpen}
+          showConversationCollapseControl
+          showNewTabButton={false}
+          onPanelFocus={() => undefined}
+          onCollapse={closePanel}
+          onClose={closePanel}
+          onOpenNewTab={() => undefined}
+          isConversationCollapsed={isMainCollapsed}
+          onToggleConversationCollapse={onToggleMainCollapse}
+          renderAsDrawer={presentation === "drawer"}
+          resizablePanelId={resizablePanelId}
+        />
+      ) : null,
+    [closePanel, isPanelOpen, panelTab?.tab, panelTabs],
+  );
 
   return (
     <div className="-mx-4 -mb-4 -mt-4 flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden md:-mx-5 md:-mb-5 md:-mt-5">
-      <div className="min-h-0 flex-1 overflow-hidden">
-        <Suspense fallback={<ToolsBodyFallback />}>
-          <ToolsSectionBody
-            activeSection={activeSection}
-            pluginId={pluginId}
-            pathname={location.pathname}
-          />
-        </Suspense>
-      </div>
+      <SecondaryPanelLayout
+        open={isPanelOpen}
+        onToggle={isPanelOpen ? closePanel : () => undefined}
+        onClose={closePanel}
+        panelGroupKey="extensions-plugin-details"
+        resetKey="extensions-plugin-details"
+        contentKey={pluginId ?? "extensions-plugins"}
+        drawerLabel="Plugin details"
+        drawerFallback={<ToolsBodyFallback />}
+        mainPanelId="extensions-main-panel"
+        main={mainContent}
+        collapse={{
+          active: isPluginDetailFullPage,
+          onToggle: () => setIsPluginDetailFullPage((current) => !current),
+        }}
+        renderPanel={renderPanel}
+        composerHost={null}
+        compactPresentation="full"
+      />
     </div>
   );
 }

--- a/packages/shared-ui/src/components/ui/resource-list.tsx
+++ b/packages/shared-ui/src/components/ui/resource-list.tsx
@@ -1,6 +1,9 @@
 export {
+  RESOURCE_ICON_FRAME_SIZES,
   RESOURCE_ROUTE_LABEL_EVENT,
   ResourceCardStat,
+  ResourceIconFrame,
+  type ResourceIconFrameSize,
   ResourceLocationMeta,
   ResourceMeta,
   ResourceState,

--- a/packages/shared-ui/src/components/ui/resource/atoms.tsx
+++ b/packages/shared-ui/src/components/ui/resource/atoms.tsx
@@ -1,4 +1,4 @@
-import { useEffect, type ReactNode } from "react";
+import { useEffect, type CSSProperties, type ReactNode } from "react";
 import { Icon, type IconName } from "../icon";
 import {
   Tooltip,
@@ -83,6 +83,40 @@ export function ResourceState({
 
 export const ResourceStatus = ResourceState;
 
+export const RESOURCE_ICON_FRAME_SIZES = {
+  sm: { frame: "size-5", glyph: "size-3" },
+  md: { frame: "size-6", glyph: "size-3.5" },
+  lg: { frame: "size-8", glyph: "size-[1.125rem]" },
+} as const;
+
+export type ResourceIconFrameSize = keyof typeof RESOURCE_ICON_FRAME_SIZES;
+
+export function ResourceIconFrame({
+  size = "md",
+  className,
+  style,
+  children,
+}: {
+  size?: ResourceIconFrameSize;
+  className?: string;
+  style?: CSSProperties;
+  children: (glyphClassName: string) => ReactNode;
+}) {
+  const { frame, glyph } = RESOURCE_ICON_FRAME_SIZES[size];
+  return (
+    <span
+      className={cn(
+        "flex shrink-0 items-center justify-center overflow-hidden",
+        frame,
+        className,
+      )}
+      style={style}
+    >
+      {children(glyph)}
+    </span>
+  );
+}
+
 export function ResourceMeta({
   items,
 }: {
@@ -123,18 +157,23 @@ export function ResourceLocationMeta({
 export function ResourceCardStat({
   icon,
   iconClassName,
+  className,
   accessibleLabel,
   children,
 }: {
   icon: IconName;
   iconClassName?: string;
+  className?: string;
   accessibleLabel?: string;
   children: ReactNode;
 }) {
   return (
     <span
       aria-label={accessibleLabel}
-      className="inline-flex h-7 shrink-0 items-center gap-1 whitespace-nowrap px-1 text-muted-foreground"
+      className={cn(
+        "inline-flex h-7 shrink-0 items-center gap-1 whitespace-nowrap px-1 text-muted-foreground",
+        className,
+      )}
     >
       <Icon
         name={icon}

--- a/packages/shared-ui/src/components/ui/resource/collection.tsx
+++ b/packages/shared-ui/src/components/ui/resource/collection.tsx
@@ -344,18 +344,22 @@ export function ResourceOverviewPage({
 export function ResourceSourceShelf({
   label,
   attribution,
+  description,
   leading,
   browseAction,
   scrollOverlay,
   contentMode = "rail",
+  contentSurface = "recessed",
   children,
 }: {
   label: ReactNode;
   attribution?: ReactNode;
+  description?: ReactNode;
   leading?: ReactNode;
   browseAction?: ReactNode;
   scrollOverlay?: ReactNode;
   contentMode?: "rail" | "panel";
+  contentSurface?: "recessed" | "plain";
   children: ReactNode;
 }) {
   return (
@@ -374,13 +378,31 @@ export function ResourceSourceShelf({
             </span>
           ) : null}
         </div>
-        {browseAction ? (
+        {browseAction && description === undefined ? (
           <div className="ml-auto shrink-0 text-xs text-muted-foreground">
             {browseAction}
           </div>
         ) : null}
       </div>
-      <div className="rounded-lg bg-surface-recessed/70 p-[var(--resource-source-shelf-inset)]">
+      {description === undefined ? null : (
+        <div className="flex min-w-0 items-center gap-3 px-[var(--resource-source-shelf-inset)]">
+          <p className="min-w-0 max-w-2xl text-xs leading-relaxed text-muted-foreground">
+            {description}
+          </p>
+          {browseAction ? (
+            <div className="ml-auto shrink-0 text-xs text-muted-foreground">
+              {browseAction}
+            </div>
+          ) : null}
+        </div>
+      )}
+      <div
+        className={cn(
+          contentSurface === "recessed"
+            ? "rounded-lg bg-surface-recessed/70 p-[var(--resource-source-shelf-inset)]"
+            : "px-[var(--resource-source-shelf-inset)]",
+        )}
+      >
         {contentMode === "panel" ? (
           children
         ) : (
@@ -452,6 +474,7 @@ export function ResourceSourceItem({
 type ResourceBrowseCardProps = {
   className?: string;
   leading?: ReactNode;
+  leadingClassName?: string;
   title: ReactNode;
   description?: ReactNode;
   descriptionLines?: 2 | 3;
@@ -460,13 +483,14 @@ type ResourceBrowseCardProps = {
   footerMeta?: ReactNode;
   pointerOnlyOpen?: boolean;
 } & (
-  | { openLabel: string; onOpen: () => void }
+  | { openLabel: string; onOpen: (trigger: HTMLButtonElement) => void }
   | { openLabel?: undefined; onOpen?: undefined }
 );
 
 export function ResourceBrowseCard({
   className,
   leading,
+  leadingClassName,
   title,
   description,
   descriptionLines = 2,
@@ -484,7 +508,7 @@ export function ResourceBrowseCard({
       className={cn(
         "group relative grid min-h-28 w-full grid-cols-[minmax(0,1fr)_auto] grid-rows-[auto_1fr_auto] gap-2 rounded-lg border border-border bg-card p-3 text-left",
         onOpen &&
-          "transition-[border-color,box-shadow] duration-150 hover:border-foreground/20 hover:shadow-xs",
+          "transition-[border-color,box-shadow,background-color] duration-150 hover:border-foreground/30 hover:bg-[color-mix(in_oklab,var(--ink)_2.5%,transparent)] hover:shadow-sm",
         className,
       )}
     >
@@ -495,13 +519,18 @@ export function ResourceBrowseCard({
           aria-hidden={pointerOnlyOpen || undefined}
           tabIndex={pointerOnlyOpen ? -1 : undefined}
           data-resource-card-pointer-action={pointerOnlyOpen ? "" : undefined}
-          onClick={onOpen}
+          onClick={(event) => onOpen(event.currentTarget)}
           className="absolute inset-0 cursor-pointer rounded-md focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
         />
       ) : null}
       {hasLeading ? (
         <span className="pointer-events-none relative col-start-1 row-start-1 flex min-w-0 items-center">
-          <span className="flex size-6 shrink-0 items-center justify-center">
+          <span
+            className={cn(
+              "flex size-6 shrink-0 items-center justify-center",
+              leadingClassName,
+            )}
+          >
             {leading}
           </span>
           <span className="ml-3 min-w-0 flex-1">{renderTitle()}</span>
@@ -530,12 +559,12 @@ export function ResourceBrowseCard({
         </span>
       ) : null}
       {byline ? (
-        <span className="pointer-events-none relative col-start-1 row-start-3 flex min-h-4 min-w-0 items-center text-left text-xs text-subtle-foreground">
+        <span className="pointer-events-none relative col-start-1 row-start-3 mt-1.5 flex min-h-4 min-w-0 items-center text-left text-xs text-subtle-foreground">
           <span className="block min-w-0 truncate">{byline}</span>
         </span>
       ) : null}
       {footerMeta ? (
-        <span className="pointer-events-none relative col-start-2 row-start-3 flex min-h-4 items-center justify-end text-right">
+        <span className="pointer-events-none relative col-start-2 row-start-3 mt-1.5 flex min-h-4 min-w-0 items-center justify-end text-right">
           {footerMeta}
         </span>
       ) : null}

--- a/packages/shared-ui/src/components/ui/resource/detail-controls.tsx
+++ b/packages/shared-ui/src/components/ui/resource/detail-controls.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { useId, type ReactNode } from "react";
 import { Button } from "../button";
 import { Icon, type IconName } from "../icon";
 import {
@@ -100,6 +100,7 @@ export function ResourceInstallControl({
   disabled = false,
   presentation = "label",
   tooltip,
+  count,
   className,
   onAction,
 }: {
@@ -109,11 +110,13 @@ export function ResourceInstallControl({
   pendingLabel?: string;
   pending?: boolean;
   disabled?: boolean;
-  presentation?: "label" | "icon";
+  presentation?: "label" | "icon" | "compact";
   tooltip?: ReactNode;
+  count?: { display: string; accessibleLabel: string };
   className?: string;
   onAction: () => void;
 }) {
+  const countId = useId();
   const control = (
     <Button
       type="button"
@@ -121,12 +124,17 @@ export function ResourceInstallControl({
       size="sm"
       className={cn(
         "h-7 shrink-0 justify-center text-xs",
-        presentation === "icon" ? "w-7 px-0" : "min-w-20 px-2.5",
+        presentation === "label"
+          ? "min-w-20 px-2.5"
+          : presentation === "icon"
+            ? "w-7 px-0"
+            : "min-w-7 gap-1.5 px-2",
         className,
       )}
       disabled={disabled || pending}
       aria-busy={pending}
       aria-label={accessibleLabel}
+      aria-describedby={count === undefined ? undefined : countId}
       onClick={onAction}
     >
       {pending ? (
@@ -140,9 +148,18 @@ export function ResourceInstallControl({
           {presentation === "label" ? label : null}
         </span>
       )}
+      {count === undefined ? null : (
+        <span
+          id={countId}
+          aria-label={count.accessibleLabel}
+          className="shrink-0 whitespace-nowrap text-2xs text-subtle-foreground"
+        >
+          {count.display}
+        </span>
+      )}
     </Button>
   );
-  return withTooltip(control, presentation === "icon" ? tooltip : undefined);
+  return withTooltip(control, presentation === "label" ? undefined : tooltip);
 }
 
 export function ResourceInstalledControl({
@@ -155,6 +172,7 @@ export function ResourceInstalledControl({
   pending = false,
   presentation = "label",
   tooltip,
+  count,
   className,
   onAction,
 }: {
@@ -165,15 +183,24 @@ export function ResourceInstalledControl({
   actionLabel?: string;
   pendingLabel?: string;
   pending?: boolean;
-  presentation?: "label" | "icon";
+  presentation?: "label" | "icon" | "compact";
   tooltip?: ReactNode;
+  count?: { display: string; accessibleLabel: string };
   className?: string;
   onAction?: () => void;
 }) {
   const installedContent = (
     <span className="inline-flex items-center gap-1">
       <Icon name={icon} className="size-3.5" aria-hidden />
-      {presentation === "label" ? label : null}
+      {presentation === "icon" ? null : label}
+      {count === undefined ? null : (
+        <span
+          aria-label={count.accessibleLabel}
+          className="shrink-0 whitespace-nowrap text-2xs text-subtle-foreground"
+        >
+          {count.display}
+        </span>
+      )}
     </span>
   );
 
@@ -182,18 +209,25 @@ export function ResourceInstalledControl({
       <span
         aria-label={accessibleLabel}
         tabIndex={
-          presentation === "icon" && tooltip !== undefined ? 0 : undefined
+          presentation !== "label" && tooltip !== undefined ? 0 : undefined
         }
         className={cn(
-          "inline-flex h-7 shrink-0 items-center justify-center rounded-md border border-success/30 bg-success/10 text-xs font-medium text-[color:color-mix(in_oklab,var(--success)_72%,var(--ink))]",
-          presentation === "icon" ? "w-7 px-0" : "min-w-20 px-2",
+          "inline-flex h-7 shrink-0 items-center justify-center rounded-md border text-xs font-medium",
+          appearance === "installed"
+            ? "border-success/30 bg-success/10 text-[color:color-mix(in_oklab,var(--success)_72%,var(--ink))]"
+            : "border-border/70 bg-transparent text-muted-foreground",
+          presentation === "label"
+            ? "min-w-20 px-2"
+            : presentation === "icon"
+              ? "w-7 px-0"
+              : "min-w-7 px-2",
           className,
         )}
       >
         {installedContent}
       </span>
     );
-    return withTooltip(status, presentation === "icon" ? tooltip : undefined);
+    return withTooltip(status, presentation === "label" ? undefined : tooltip);
   }
 
   const control = (
@@ -206,7 +240,11 @@ export function ResourceInstalledControl({
         appearance === "installed"
           ? "border-success/30 bg-success/10 text-[color:color-mix(in_oklab,var(--success)_72%,var(--ink))]"
           : "border-border/70 bg-transparent text-muted-foreground",
-        presentation === "icon" ? "w-7 px-0" : "min-w-20 px-2",
+        presentation === "label"
+          ? "min-w-20 px-2"
+          : presentation === "icon"
+            ? "w-7 px-0"
+            : "min-w-7 px-2",
         className,
       )}
       disabled={pending}
@@ -231,5 +269,5 @@ export function ResourceInstalledControl({
       )}
     </Button>
   );
-  return withTooltip(control, presentation === "icon" ? tooltip : undefined);
+  return withTooltip(control, presentation === "label" ? undefined : tooltip);
 }

--- a/packages/shared-ui/src/components/ui/resource/detail-sections.tsx
+++ b/packages/shared-ui/src/components/ui/resource/detail-sections.tsx
@@ -66,6 +66,7 @@ export function ResourceDetailPage({
   title,
   titleMeta,
   leading,
+  leadingClassName,
   lifecycleControl,
   overflowMenu,
   actions,
@@ -77,6 +78,7 @@ export function ResourceDetailPage({
   title: ReactNode;
   titleMeta?: ReactNode;
   leading?: ReactNode;
+  leadingClassName?: string;
   lifecycleControl?: ReactNode;
   overflowMenu?: ReactNode;
   actions?: ReactNode;
@@ -91,7 +93,12 @@ export function ResourceDetailPage({
         <div className="min-w-0 flex-1 space-y-2">
           <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
             {leading ? (
-              <span className="flex size-4 shrink-0 items-center justify-center">
+              <span
+                className={cn(
+                  "flex size-4 shrink-0 items-center justify-center",
+                  leadingClassName,
+                )}
+              >
                 {leading}
               </span>
             ) : null}

--- a/packages/shared-ui/src/components/ui/resource/toolbar.tsx
+++ b/packages/shared-ui/src/components/ui/resource/toolbar.tsx
@@ -82,6 +82,7 @@ export interface ResourceOption {
   leading?: ReactNode;
   description?: string;
   disabled?: boolean;
+  omitDirection?: boolean;
 }
 
 function ResourceOptionContent({
@@ -411,18 +412,27 @@ export function ResourceSortMenu({
   direction,
   options,
   onChange,
+  onClear,
+  placeholderLabel = "Sort",
   compact = false,
 }: {
-  value: string;
+  value: string | null;
   direction: "asc" | "desc";
   options: readonly ResourceOption[];
   onChange: (value: string) => void;
+  onClear?: () => void;
+  placeholderLabel?: string;
   compact?: boolean;
 }) {
   const [open, setOpen] = useState(false);
   const selectedOption = options.find((option) => option.id === value);
   const directionLabel = direction === "asc" ? "ascending" : "descending";
-  const sortStateLabel = `Sort: ${selectedOption?.label ?? value}, ${directionLabel}`;
+  const sortStateLabel =
+    selectedOption === undefined
+      ? `Sort: ${placeholderLabel}`
+      : selectedOption.omitDirection === true
+        ? `Sort: ${selectedOption.label}`
+        : `Sort: ${selectedOption.label}, ${directionLabel}`;
 
   return (
     <DropdownMenu onOpenChange={setOpen}>
@@ -430,6 +440,7 @@ export function ResourceSortMenu({
       <ResourceMenuTrigger
         label={sortStateLabel}
         icon="ArrowUpDown"
+        active={onClear !== undefined && value !== null}
         open={open}
       />
       <DropdownMenuContent
@@ -445,6 +456,30 @@ export function ResourceSortMenu({
         >
           Sort by
         </DropdownMenuLabel>
+        {onClear === undefined ? null : (
+          <DropdownMenuItem
+            role="menuitemradio"
+            aria-checked={value === null}
+            onSelect={(event) => {
+              event.preventDefault();
+              onClear();
+            }}
+            className={cn(
+              "flex items-center justify-between gap-3",
+              compact && "md:gap-2 md:px-1.5 md:py-1",
+            )}
+          >
+            {placeholderLabel}
+            <Icon
+              name="Check"
+              aria-hidden
+              className={cn(
+                "size-4 text-subtle-foreground",
+                value === null ? "opacity-100" : "opacity-0",
+              )}
+            />
+          </DropdownMenuItem>
+        )}
         {options.map((option) => {
           const selected = option.id === value;
           return (
@@ -467,7 +502,14 @@ export function ResourceSortMenu({
               <Icon
                 name={direction === "asc" ? "ArrowUp" : "ArrowDown"}
                 aria-hidden
-                className={cn("size-4", selected ? "opacity-100" : "opacity-0")}
+                className={cn(
+                  "size-4 text-subtle-foreground",
+                  option.omitDirection === true
+                    ? "hidden"
+                    : selected
+                      ? "opacity-100"
+                      : "opacity-0",
+                )}
               />
             </DropdownMenuItem>
           );


### PR DESCRIPTION
## Human comments

## What was wrong

Browse grouped plugins by publisher. It did not use category and collection data from marketplace v2.

## What changed

- Browse now shows collection shelves, category shelves, and a final More plugins shelf.
- Collection shelves keep the exact server order without a special collection ID.
- Search, repeated category filters, and three sort choices use URL parameters.
- Recently added and Most installed show one flat list with category labels.
- Cards now show neutral icons, author art, install counts, and compact install actions.
- Each catalog icon path now uses one tile and one glyph box.
- Installed cards now show a non-interactive check state and keep the install count.
- One plugin detail tab now opens beside Browse and keeps Browse mounted.
- The detail shows screenshots, author data, About, source, listing date, configuration, capabilities, and install state.
- This change has no wire, CLI, guide, or public API changes.

### Visual QA

| State | Main | This branch |
| --- | --- | --- |
| Default Browse | ![Main Browse groups plugins by publisher](https://github.com/user-attachments/assets/f4bc1672-edf5-40c7-b4ad-b3282ed728e5) | ![Browse shows collection and category shelves](https://github.com/user-attachments/assets/86cc0748-2878-4b36-9065-46775c37556a) |
| Category control | ![Main category control](https://github.com/user-attachments/assets/8b8794a9-4b4e-468a-82b7-b8d0603344bc) | ![Searchable category control with counts and checkboxes](https://github.com/user-attachments/assets/69f74078-198e-49e0-a88d-bdd3b87f17ce) |
| Most installed | ![Main Browse before the flat sort](https://github.com/user-attachments/assets/0c471a92-447e-404a-a7a0-0bec9c9fb6f5) | ![Flat Most installed list with category labels](https://github.com/user-attachments/assets/dde98d99-ee03-4c80-9f12-ff2f89a2e0c5) |
| Plugin detail | ![Main full-page plugin detail](https://github.com/user-attachments/assets/52296843-3ad4-42d9-877a-0480339e993a) | ![Plugin detail beside mounted Browse](https://github.com/user-attachments/assets/992ef120-c322-4bdb-bc9a-a189a32c27b6) |

#### Catalog icon alignment

![Notifications shelf with aligned bundled and community icons, plus an installed card](https://github.com/user-attachments/assets/c6d73738-3a48-4137-b389-c08f1cc34230)

## How you verified

- The new tests cover shelf order, URL filters, missing sort values, detail content, and focus return.
- Review tests cover install-count gating, narrow shelves, category order, isolated menu focus, and installed detail labels.
- `pnpm exec turbo run typecheck --filter=@bb/app --filter=@bb/shared-ui --filter=@bb/client-core` passed.
- `pnpm exec turbo run test --filter=@bb/app --filter=@bb/shared-ui --filter=@bb/client-core` passed.
- The synced app suite passed 3,768 tests. Three tests remained skipped.
- The focused catalog icon and card tests passed 19 tests.
- The focused shelf-order test passed 5 tests.
- The client-core suite passed 253 tests.
- Shared UI has no test script. Turbo included it in the requested scope.
- `pnpm exec turbo run lint --filter=@bb/app --filter=@bb/shared-ui --filter=@bb/client-core` passed with no errors.
- Live QA compared main and this branch at 1440 by 900.
- Live QA also verified that the hero chips hide beside an open detail panel.
- Live QA verified 40-pixel tiles and 24-pixel glyph boxes across all icon sources.
- Live QA verified the same icon sizes in flat cards and the detail header.
- The branch browser console showed no errors.

> AGENT GENERATED
