### PR TITLE
Unify picker search matching

### DIFF
--- a/apps/app/src/components/pickers/BranchPicker.scroll.test.tsx
+++ b/apps/app/src/components/pickers/BranchPicker.scroll.test.tsx
@@ -6,8 +6,8 @@ import { BranchPicker } from "./BranchPicker";
 
 afterEach(cleanup);
 
-describe("BranchPicker search scrolling", () => {
-  it("returns the results viewport to the top when searching", () => {
+describe("BranchPicker search", () => {
+  it("uses fuzzy matching and returns the results viewport to the top", () => {
     render(
       <BranchPicker
         value="main"
@@ -30,8 +30,37 @@ describe("BranchPicker search scrolling", () => {
     if (!(scrollArea instanceof HTMLElement)) return;
     scrollArea.scrollTop = 120;
 
-    fireEvent.change(search, { target: { value: "feature/three" } });
+    fireEvent.change(search, { target: { value: "fth" } });
 
     expect(scrollArea.scrollTop).toBe(0);
+    expect(screen.getByText("feature/three")).toBeTruthy();
+    expect(screen.queryByText("feature/two")).toBeNull();
+  });
+
+  it("uses relevance order instead of pinning the selected match", () => {
+    const selectedBranch = "super-feature/three-compatibility";
+    const directBranch = "feature/three";
+    render(
+      <BranchPicker
+        value={selectedBranch}
+        options={[selectedBranch, directBranch]}
+        onChange={vi.fn()}
+        modal={false}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("combobox", { name: "Branch" }));
+    fireEvent.change(screen.getByPlaceholderText("Search branches"), {
+      target: { value: "fth" },
+    });
+
+    const directResult = screen.getByText(directBranch);
+    const selectedResult = screen.getAllByText(selectedBranch).at(-1);
+    expect(selectedResult).toBeTruthy();
+    if (!selectedResult) return;
+    expect(
+      directResult.compareDocumentPosition(selectedResult) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).not.toBe(0);
   });
 });

--- a/apps/app/src/components/pickers/BranchPicker.tsx
+++ b/apps/app/src/components/pickers/BranchPicker.tsx
@@ -35,6 +35,7 @@ import {
 } from "@bb/shared-ui/option-display";
 import { cn } from "@bb/shared-ui/lib/utils";
 import type { GitBranchRefClassification } from "@bb/domain";
+import { searchPickerOptions } from "./picker-search";
 import { useResetPickerScroll } from "./useResetPickerScroll";
 
 interface GetMergeBaseBranchCandidatesArgs {
@@ -217,11 +218,6 @@ interface BranchPickerBranchOptionsProps {
 interface BuildBranchPickerOptionGroupsArgs {
   options: readonly string[];
   remoteOptions: readonly string[];
-}
-
-interface FilterBranchOptionsArgs {
-  normalizedQuery: string;
-  options: readonly string[];
 }
 
 interface OrderBranchPickerOptionsArgs {
@@ -588,19 +584,6 @@ export function buildBranchPickerOptionGroups({
   return { local, remote };
 }
 
-function filterBranchOptions({
-  normalizedQuery,
-  options,
-}: FilterBranchOptionsArgs): string[] {
-  if (normalizedQuery.length === 0) {
-    return [...options];
-  }
-
-  return options.filter((branch) =>
-    branch.toLowerCase().includes(normalizedQuery),
-  );
-}
-
 export function orderBranchPickerOptions({
   options,
   selectedValue,
@@ -715,6 +698,7 @@ export function BranchPicker({
   const deferredQuery = useDeferredValue(query);
   const inputRef = useRef<HTMLInputElement>(null);
   const normalizedQuery = deferredQuery.trim().toLowerCase();
+  const isSearching = normalizedQuery.length > 0;
   const [debouncedNormalizedQuery] = useDebounceValue(
     normalizedQuery,
     BRANCH_SEARCH_DEBOUNCE_MS,
@@ -744,39 +728,41 @@ export function BranchPicker({
   );
   const filteredLocalBranchOptions = useMemo(
     () =>
-      filterBranchOptions({
-        normalizedQuery,
+      searchPickerOptions({
         options: branchOptionGroups.local,
+        query: deferredQuery,
+        getLabel: (branch) => branch,
       }),
-    [branchOptionGroups.local, normalizedQuery],
+    [branchOptionGroups.local, deferredQuery],
   );
-  const filteredRemoteBranchOptions = useMemo(
-    () =>
-      filterBranchOptions({
-        normalizedQuery,
-        options: branchOptionGroups.remote,
-      }),
-    [branchOptionGroups.remote, normalizedQuery],
+  const combinedBranchOptions = useMemo(
+    () => [...branchOptionGroups.local, ...branchOptionGroups.remote],
+    [branchOptionGroups.local, branchOptionGroups.remote],
   );
   const filteredCombinedBranchOptions = useMemo(
-    () => [...filteredLocalBranchOptions, ...filteredRemoteBranchOptions],
-    [filteredLocalBranchOptions, filteredRemoteBranchOptions],
+    () =>
+      searchPickerOptions({
+        options: combinedBranchOptions,
+        query: deferredQuery,
+        getLabel: (branch) => branch,
+      }),
+    [combinedBranchOptions, deferredQuery],
   );
   const filteredCheckoutTargetOptions = useMemo(
     () =>
       orderBranchPickerOptions({
         options: filteredLocalBranchOptions,
-        selectedValue: value,
+        selectedValue: isSearching ? null : value,
       }),
-    [filteredLocalBranchOptions, value],
+    [filteredLocalBranchOptions, isSearching, value],
   );
   const filteredBranchOptions = useMemo(
     () =>
       orderBranchPickerOptions({
         options: filteredCombinedBranchOptions,
-        selectedValue: value,
+        selectedValue: isSearching ? null : value,
       }),
-    [filteredCombinedBranchOptions, value],
+    [filteredCombinedBranchOptions, isSearching, value],
   );
   const activeEnterOptions =
     isCheckoutMenu && activeCheckoutIntent === "checkout"

--- a/apps/app/src/components/pickers/ModelReasoningPicker.test.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.test.tsx
@@ -22,7 +22,6 @@ import {
   type PaneContextValue,
 } from "@/views/thread-detail/PaneContext";
 import {
-  buildFuzzyRegex,
   buildModelNavRows,
   ModelReasoningPicker,
 } from "./ModelReasoningPicker";
@@ -614,7 +613,7 @@ describe("ModelReasoningPicker", () => {
     expect(onModelChange).toHaveBeenCalledWith(apiModel);
   });
 
-  it("fuzzy-filters a long model list and selects the match by keyboard", () => {
+  it("uses picker search policy and selects the match by keyboard", () => {
     const { onModelChange } = renderPicker({ modelOptions: manyCodexModels });
 
     fireEvent.click(
@@ -622,7 +621,7 @@ describe("ModelReasoningPicker", () => {
     );
 
     const search = screen.getByPlaceholderText("Search models");
-    fireEvent.change(search, { target: { value: "o4" } });
+    fireEvent.change(search, { target: { value: "o4m" } });
 
     expect(screen.getByText("o4-mini")).not.toBeNull();
     expect(screen.queryByText("Sonnet")).toBeNull();
@@ -631,6 +630,38 @@ describe("ModelReasoningPicker", () => {
     fireEvent.keyDown(search, { key: "Enter" });
 
     expect(onModelChange).toHaveBeenCalledWith("o4-mini");
+  });
+
+  it("ranks primary and selected-only model matches together", () => {
+    const looseMatch = "Super GPT-4 Compatibility";
+    const directMatch = "GPT-4 Turbo";
+    renderPicker({
+      modelOptions: [
+        { value: "super-gpt-4", label: looseMatch },
+        { value: "alpha", label: "Alpha" },
+        { value: "beta", label: "Beta" },
+        { value: "gamma", label: "Gamma" },
+        { value: "delta", label: "Delta" },
+      ],
+      moreModelOptions: [{ value: "gpt-4-turbo", label: directMatch }],
+      pickerProviderOptions: [{ value: "codex", label: "Codex" }],
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Provider, model and reasoning" }),
+    );
+    fireEvent.change(screen.getByPlaceholderText("Search models"), {
+      target: { value: "gpt4" },
+    });
+
+    const directResult = screen.getByText(directMatch);
+    const looseResult = screen.getAllByText(looseMatch).at(-1);
+    expect(looseResult).toBeTruthy();
+    if (!looseResult) return;
+    expect(
+      directResult.compareDocumentPosition(looseResult) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).not.toBe(0);
   });
 
   it("returns the results viewport to the top when searching", () => {
@@ -798,18 +829,5 @@ describe("buildModelNavRows", () => {
       { kind: "model", option: primary[0] },
       { kind: "model", option: primary[1] },
     ]);
-  });
-});
-
-describe("buildFuzzyRegex", () => {
-  it("matches subsequences case-insensitively", () => {
-    expect(buildFuzzyRegex("gpt4").test("GPT-4 Turbo")).toBe(true);
-    expect(buildFuzzyRegex("o4m").test("o4-mini")).toBe(true);
-    expect(buildFuzzyRegex("xyz").test("o4-mini")).toBe(false);
-  });
-
-  it("escapes regex metacharacters so they match literally", () => {
-    expect(buildFuzzyRegex("5.2").test("5.2")).toBe(true);
-    expect(buildFuzzyRegex("5.2").test("512")).toBe(false);
   });
 });

--- a/apps/app/src/components/pickers/ModelReasoningPicker.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.tsx
@@ -55,6 +55,7 @@ import {
 } from "@bb/shared-ui/option-display";
 import { type PickerOption } from "./OptionPicker";
 import type { ModelPickerOption } from "./model-picker-option";
+import { searchPickerOptions } from "./picker-search";
 import { useResetPickerScroll } from "./useResetPickerScroll";
 import {
   formatModelLoadErrorText,
@@ -117,31 +118,6 @@ function splitModelLabelTag(label: string): ModelLabelParts {
     return { base: label, tag: null };
   }
   return { base: match[1], tag: match[2] };
-}
-
-export function buildFuzzyRegex(query: string): RegExp {
-  const pattern = query
-    .split("")
-    .map((c) => c.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
-    .join(".*");
-  return new RegExp(pattern, "i");
-}
-
-function fuzzyFilter<T>(
-  options: readonly T[],
-  normalizedQuery: string,
-  getText: (option: T) => string,
-): readonly T[] {
-  if (!normalizedQuery) return options;
-  const regex = buildFuzzyRegex(normalizedQuery);
-  return options.filter((option) => regex.test(getText(option)));
-}
-
-function modelSearchText(
-  option: ModelPickerOption,
-  brandPrefix: string | undefined,
-): string {
-  return `${stripModelBrandPrefix(option.label, brandPrefix)} ${option.routeProviderId ?? ""} ${option.value}`;
 }
 
 type ModelNavRow =
@@ -271,8 +247,7 @@ export function ModelReasoningPicker({
   const listRef = useResetPickerScroll<HTMLDivElement>(searchQuery);
   const [activeIndex, setActiveIndex] = useState(-1);
   const searchInputRef = useRef<HTMLInputElement>(null);
-  const normalizedQuery = searchQuery.trim().toLowerCase();
-  const isSearching = normalizedQuery.length > 0;
+  const isSearching = searchQuery.trim().length > 0;
   const navId = useId();
   const listboxId = `${navId}-listbox`;
   const optionDomId = (index: number) => `${navId}-opt-${index}`;
@@ -471,16 +446,29 @@ export function ModelReasoningPicker({
 
   const activeBrandPrefix = activeProvider?.brandPrefix;
   const filteredModelOptions = useMemo(() => {
-    return fuzzyFilter(activeModelOptions, normalizedQuery, (option) =>
-      modelSearchText(option, activeBrandPrefix),
-    );
-  }, [activeModelOptions, normalizedQuery, activeBrandPrefix]);
-
-  const filteredMoreModelOptions = useMemo(() => {
-    return fuzzyFilter(activeMoreModelOptions, normalizedQuery, (option) =>
-      modelSearchText(option, activeBrandPrefix),
-    );
-  }, [activeMoreModelOptions, normalizedQuery, activeBrandPrefix]);
+    if (!isSearching) {
+      return activeModelOptions;
+    }
+    return searchPickerOptions({
+      options: [...activeModelOptions, ...activeMoreModelOptions],
+      query: searchQuery,
+      getLabel: (option) =>
+        stripModelBrandPrefix(option.label, activeBrandPrefix),
+      getAliases: (option) =>
+        option.routeProviderId
+          ? [option.routeProviderId, option.value]
+          : [option.value],
+    });
+  }, [
+    activeBrandPrefix,
+    activeModelOptions,
+    activeMoreModelOptions,
+    isSearching,
+    searchQuery,
+  ]);
+  const filteredMoreModelOptions = isSearching
+    ? EMPTY_MODEL_OPTIONS
+    : activeMoreModelOptions;
 
   const navRows = useMemo(
     () =>

--- a/apps/app/src/components/pickers/ParentThreadPicker.test.tsx
+++ b/apps/app/src/components/pickers/ParentThreadPicker.test.tsx
@@ -79,7 +79,7 @@ describe("ParentThreadPicker", () => {
     expect(await screen.findByText("Codex Parent")).toBeTruthy();
   });
 
-  it("searches candidates by title and selects the match", async () => {
+  it("fuzzy-searches candidates by title and selects the match", async () => {
     const onChange = vi.fn();
     render(picker({ onChange }));
 
@@ -87,7 +87,7 @@ describe("ParentThreadPicker", () => {
     const search = await screen.findByRole("combobox", {
       name: "Search parent threads",
     });
-    fireEvent.change(search, { target: { value: "frontend" } });
+    fireEvent.change(search, { target: { value: "frpar" } });
 
     expect(screen.queryByRole("option", { name: /Codex Parent/u })).toBeNull();
     fireEvent.click(screen.getByRole("option", { name: /Frontend Parent/u }));
@@ -96,6 +96,23 @@ describe("ParentThreadPicker", () => {
     expect(
       screen.queryByRole("combobox", { name: "Search parent threads" }),
     ).toBeNull();
+  });
+
+  it("augments thread titles with thread IDs", async () => {
+    render(picker());
+
+    fireEvent.click(screen.getByRole("button"));
+    fireEvent.change(
+      await screen.findByRole("combobox", {
+        name: "Search parent threads",
+      }),
+      { target: { value: "frontend_parent" } },
+    );
+
+    expect(screen.queryByRole("option", { name: /Codex Parent/u })).toBeNull();
+    expect(
+      screen.getByRole("option", { name: /Frontend Parent/u }),
+    ).toBeTruthy();
   });
 
   it("returns the results viewport to the top when searching", async () => {

--- a/apps/app/src/components/pickers/ParentThreadPicker.tsx
+++ b/apps/app/src/components/pickers/ParentThreadPicker.tsx
@@ -1,7 +1,6 @@
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import {
   Command,
-  CommandEmpty,
   CommandGroup,
   CommandInput,
   CommandItem,
@@ -15,6 +14,7 @@ import {
 import { Icon } from "@bb/shared-ui/icon";
 import { cn } from "@bb/shared-ui/lib/utils";
 import { Popover, PopoverContent, PopoverTrigger } from "@bb/shared-ui/popover";
+import { searchPickerOptions } from "./picker-search";
 import { useResetPickerScroll } from "./useResetPickerScroll";
 
 export interface ParentThreadPickerOption {
@@ -48,6 +48,16 @@ export function ParentThreadPicker({
   const [open, setOpen] = useState(defaultOpen ?? false);
   const [searchQuery, setSearchQuery] = useState("");
   const listRef = useResetPickerScroll<HTMLDivElement>(searchQuery);
+  const filteredOptions = useMemo(
+    () =>
+      searchPickerOptions({
+        options,
+        query: searchQuery,
+        getLabel: (option) => option.label,
+        getAliases: (option) => [option.value],
+      }),
+    [options, searchQuery],
+  );
   const selectedLabel =
     options.find((option) => option.value === value)?.label ?? "None";
   const handleOpenChange = useCallback(
@@ -94,7 +104,7 @@ export function ParentThreadPicker({
         className="w-72 p-0 max-md:w-full"
         mobileTitle="Assign parent thread"
       >
-        <Command label="Search parent threads">
+        <Command label="Search parent threads" shouldFilter={false}>
           <CommandInput
             aria-label="Search parent threads"
             placeholder="Search threads…"
@@ -121,34 +131,42 @@ export function ParentThreadPicker({
               </CommandGroup>
             ) : (
               <>
-                <CommandEmpty>No matching threads.</CommandEmpty>
-                <CommandGroup heading="Assign parent thread">
-                  {options.map((option) => (
-                    <CommandItem
-                      key={option.value}
-                      value={option.value}
-                      keywords={[option.label]}
-                      aria-current={value === option.value ? "true" : undefined}
-                      onSelect={() => {
-                        onChange(option.value);
-                        handleOpenChange(false);
-                      }}
-                      className="flex items-center justify-between gap-3"
-                    >
-                      <span className="truncate" title={option.label}>
-                        {option.label}
-                      </span>
-                      <Icon
-                        name="Check"
-                        aria-hidden
-                        className={cn(
-                          COARSE_POINTER_ICON_SIZE_CLASS,
-                          value === option.value ? "opacity-100" : "opacity-0",
-                        )}
-                      />
-                    </CommandItem>
-                  ))}
-                </CommandGroup>
+                {filteredOptions.length === 0 ? (
+                  <div className="py-6 text-center text-sm">
+                    No matching threads.
+                  </div>
+                ) : (
+                  <CommandGroup heading="Assign parent thread">
+                    {filteredOptions.map((option) => (
+                      <CommandItem
+                        key={option.value}
+                        value={option.value}
+                        aria-current={
+                          value === option.value ? "true" : undefined
+                        }
+                        onSelect={() => {
+                          onChange(option.value);
+                          handleOpenChange(false);
+                        }}
+                        className="flex items-center justify-between gap-3"
+                      >
+                        <span className="truncate" title={option.label}>
+                          {option.label}
+                        </span>
+                        <Icon
+                          name="Check"
+                          aria-hidden
+                          className={cn(
+                            COARSE_POINTER_ICON_SIZE_CLASS,
+                            value === option.value
+                              ? "opacity-100"
+                              : "opacity-0",
+                          )}
+                        />
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                )}
               </>
             )}
           </CommandList>

--- a/apps/app/src/components/pickers/ProjectSelector.test.tsx
+++ b/apps/app/src/components/pickers/ProjectSelector.test.tsx
@@ -74,7 +74,7 @@ describe("ProjectSelector", () => {
     ).toBeTruthy();
   });
 
-  it("filters projects case-insensitively and selects the match", () => {
+  it("fuzzy-matches project names case-insensitively and selects the match", () => {
     const onChange = vi.fn();
     render(
       <ProjectSelector
@@ -88,7 +88,7 @@ describe("ProjectSelector", () => {
 
     fireEvent.change(
       screen.getByRole("combobox", { name: "Search projects" }),
-      { target: { value: "CHARLIE" } },
+      { target: { value: "CD" } },
     );
 
     expect(screen.queryByRole("option", { name: "Alpha Web" })).toBeNull();

--- a/apps/app/src/components/pickers/ProjectSelector.tsx
+++ b/apps/app/src/components/pickers/ProjectSelector.tsx
@@ -17,6 +17,7 @@ import {
   OPTION_TRIGGER_CONTENT_CLASS_NAME,
 } from "@bb/shared-ui/option-display";
 import { Popover, PopoverContent, PopoverTrigger } from "@bb/shared-ui/popover";
+import { searchPickerOptions } from "./picker-search";
 import { useResetPickerScroll } from "./useResetPickerScroll";
 
 const PROJECT_SEARCH_MIN_OPTIONS = 5;
@@ -67,15 +68,16 @@ export function ProjectSelector({
   const listRef = useResetPickerScroll<HTMLDivElement>(searchQuery);
   const disabled = disabledProp || isLoading;
   const showSearch = projects.length > PROJECT_SEARCH_MIN_OPTIONS;
-  const normalizedSearchQuery = searchQuery.trim().toLocaleLowerCase();
   const filteredProjects = useMemo(
     () =>
-      showSearch && normalizedSearchQuery.length > 0
-        ? projects.filter((project) =>
-            project.name.toLocaleLowerCase().includes(normalizedSearchQuery),
-          )
+      showSearch
+        ? searchPickerOptions({
+            options: projects,
+            query: searchQuery,
+            getLabel: (project) => project.name,
+          })
         : projects,
-    [normalizedSearchQuery, projects, showSearch],
+    [projects, searchQuery, showSearch],
   );
   const selected = value !== null ? projects.find((p) => p.id === value) : null;
   const fallback = !allowNoProject && !selected ? projects[0] : null;

--- a/apps/app/src/components/pickers/picker-search.test.ts
+++ b/apps/app/src/components/pickers/picker-search.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { searchPickerOptions } from "./picker-search";
+
+interface TestOption {
+  label: string;
+  aliases: readonly string[];
+}
+
+const getLabel = (option: TestOption) => option.label;
+const getAliases = (option: TestOption) => option.aliases;
+
+describe("searchPickerOptions", () => {
+  it("matches case-insensitive character sequences in visible labels", () => {
+    const options = [
+      { label: "Alpha Web", aliases: [] },
+      { label: "Charlie Docs", aliases: [] },
+      { label: "feature/three", aliases: [] },
+    ];
+
+    expect(
+      searchPickerOptions({ options, query: "AW", getLabel, getAliases }),
+    ).toEqual([options[0]]);
+    expect(
+      searchPickerOptions({ options, query: "cd", getLabel, getAliases }),
+    ).toEqual([options[1]]);
+    expect(
+      searchPickerOptions({ options, query: "fth", getLabel, getAliases }),
+    ).toEqual([options[2]]);
+  });
+
+  it("lets option types augment visible labels with aliases", () => {
+    const options = [
+      {
+        label: "Codex Parent",
+        aliases: ["thr_codex_parent"],
+      },
+      {
+        label: "Frontend Parent",
+        aliases: ["thr_frontend_parent"],
+      },
+    ];
+
+    expect(
+      searchPickerOptions({
+        options,
+        query: "frontend_parent",
+        getLabel,
+        getAliases,
+      }),
+    ).toEqual([options[1]]);
+    expect(
+      searchPickerOptions({ options, query: "cdxp", getLabel, getAliases }),
+    ).toEqual([options[0]]);
+  });
+
+  it("ranks stronger matches first and preserves source order for ties", () => {
+    const exact = { label: "gpt4", aliases: [] };
+    const direct = { label: "GPT-4 Turbo", aliases: [] };
+    const loose = { label: "Super GPT-4 Compatibility", aliases: [] };
+    const duplicateA = { label: "Alpha Web", aliases: ["first"] };
+    const duplicateB = { label: "Alpha Web", aliases: ["second"] };
+
+    expect(
+      searchPickerOptions({
+        options: [loose, direct, exact],
+        query: "gpt4",
+        getLabel,
+        getAliases,
+      }),
+    ).toEqual([exact, direct, loose]);
+    expect(
+      searchPickerOptions({
+        options: [duplicateA, duplicateB],
+        query: "aw",
+        getLabel,
+        getAliases,
+      }),
+    ).toEqual([duplicateA, duplicateB]);
+  });
+
+  it("treats punctuation literally and returns source order for blank queries", () => {
+    const options = [
+      { label: "5.2", aliases: [] },
+      { label: "512", aliases: [] },
+    ];
+
+    expect(
+      searchPickerOptions({ options, query: "5.2", getLabel, getAliases }),
+    ).toEqual([options[0]]);
+    expect(
+      searchPickerOptions({ options, query: "  ", getLabel, getAliases }),
+    ).toBe(options);
+  });
+});

--- a/apps/app/src/components/pickers/picker-search.test.ts
+++ b/apps/app/src/components/pickers/picker-search.test.ts
@@ -53,6 +53,26 @@ describe("searchPickerOptions", () => {
     ).toEqual([options[0]]);
   });
 
+  it("ranks visible-label matches ahead of alias-only matches", () => {
+    const nemotron = {
+      label: "NVIDIA: Nemotron 3 Ultra",
+      aliases: ["openrouter/nvidia/nemotron-3-ultra-550b-a55b"],
+    };
+    const gpt = {
+      label: "GPT-5.5",
+      aliases: ["openai/gpt-5.5"],
+    };
+
+    expect(
+      searchPickerOptions({
+        options: [nemotron, gpt],
+        query: "55",
+        getLabel,
+        getAliases,
+      }),
+    ).toEqual([gpt, nemotron]);
+  });
+
   it("ranks stronger matches first and preserves source order for ties", () => {
     const exact = { label: "gpt4", aliases: [] };
     const direct = { label: "GPT-4 Turbo", aliases: [] };

--- a/apps/app/src/components/pickers/picker-search.ts
+++ b/apps/app/src/components/pickers/picker-search.ts
@@ -21,7 +21,8 @@ export function searchPickerOptions<T>({
   return fuzzyMatchText({
     items: options,
     query: normalizedQuery,
-    getText: (option) => [getLabel(option), ...(getAliases?.(option) ?? [])],
+    getText: getLabel,
+    getAliases: (option) => getAliases?.(option) ?? [],
     limit: options.length,
   }).map((match) => match.item);
 }

--- a/apps/app/src/components/pickers/picker-search.ts
+++ b/apps/app/src/components/pickers/picker-search.ts
@@ -1,28 +1,10 @@
-import { defaultFilter } from "cmdk";
+import { fuzzyMatchText } from "@bb/fuzzy-match";
 
 interface SearchPickerOptionsArgs<T> {
   options: readonly T[];
   query: string;
   getLabel: (option: T) => string;
   getAliases?: (option: T) => readonly string[];
-}
-
-interface RankedPickerOption<T> {
-  option: T;
-  sourceIndex: number;
-  score: number;
-}
-
-function scorePickerOption(
-  label: string,
-  aliases: readonly string[],
-  query: string,
-): number {
-  let score = defaultFilter(label, query, []);
-  for (const alias of aliases) {
-    score = Math.max(score, defaultFilter(alias, query, []));
-  }
-  return score;
 }
 
 export function searchPickerOptions<T>({
@@ -36,22 +18,10 @@ export function searchPickerOptions<T>({
     return options;
   }
 
-  return options
-    .map((option, sourceIndex): RankedPickerOption<T> => {
-      return {
-        option,
-        sourceIndex,
-        score: scorePickerOption(
-          getLabel(option),
-          getAliases?.(option) ?? [],
-          normalizedQuery,
-        ),
-      };
-    })
-    .filter(({ score }) => score > 0)
-    .sort(
-      (left, right) =>
-        right.score - left.score || left.sourceIndex - right.sourceIndex,
-    )
-    .map(({ option }) => option);
+  return fuzzyMatchText({
+    items: options,
+    query: normalizedQuery,
+    getText: (option) => [getLabel(option), ...(getAliases?.(option) ?? [])],
+    limit: options.length,
+  }).map((match) => match.item);
 }

--- a/apps/app/src/components/pickers/picker-search.ts
+++ b/apps/app/src/components/pickers/picker-search.ts
@@ -1,0 +1,57 @@
+import { defaultFilter } from "cmdk";
+
+interface SearchPickerOptionsArgs<T> {
+  options: readonly T[];
+  query: string;
+  getLabel: (option: T) => string;
+  getAliases?: (option: T) => readonly string[];
+}
+
+interface RankedPickerOption<T> {
+  option: T;
+  sourceIndex: number;
+  score: number;
+}
+
+function scorePickerOption(
+  label: string,
+  aliases: readonly string[],
+  query: string,
+): number {
+  let score = defaultFilter(label, query, []);
+  for (const alias of aliases) {
+    score = Math.max(score, defaultFilter(alias, query, []));
+  }
+  return score;
+}
+
+export function searchPickerOptions<T>({
+  options,
+  query,
+  getLabel,
+  getAliases,
+}: SearchPickerOptionsArgs<T>): readonly T[] {
+  const normalizedQuery = query.trim();
+  if (normalizedQuery.length === 0) {
+    return options;
+  }
+
+  return options
+    .map((option, sourceIndex): RankedPickerOption<T> => {
+      return {
+        option,
+        sourceIndex,
+        score: scorePickerOption(
+          getLabel(option),
+          getAliases?.(option) ?? [],
+          normalizedQuery,
+        ),
+      };
+    })
+    .filter(({ score }) => score > 0)
+    .sort(
+      (left, right) =>
+        right.score - left.score || left.sourceIndex - right.sourceIndex,
+    )
+    .map(({ option }) => option);
+}

--- a/apps/app/src/hooks/projectMentionSuggestions.ts
+++ b/apps/app/src/hooks/projectMentionSuggestions.ts
@@ -18,11 +18,9 @@ interface BuildProjectMentionSuggestionsArgs {
   limit: number;
 }
 
-function getProjectSearchTexts(
-  project: ProjectMentionCandidate,
-): readonly string[] {
+function getProjectSearchText(project: ProjectMentionCandidate): string {
   const name = project.name.trim();
-  return name ? [name, project.id] : [project.id];
+  return name || project.id;
 }
 
 function toProjectMentionSuggestion(
@@ -48,7 +46,8 @@ export function buildProjectMentionSuggestions(
   const matches = fuzzyMatchText({
     items: args.projects,
     query: trimmedQuery,
-    getText: getProjectSearchTexts,
+    getText: getProjectSearchText,
+    getAliases: (project) => [project.id],
     limit: args.projects.length,
   });
 

--- a/apps/app/src/hooks/sectionMentionSuggestions.ts
+++ b/apps/app/src/hooks/sectionMentionSuggestions.ts
@@ -18,11 +18,9 @@ interface BuildSectionMentionSuggestionsArgs {
   limit: number;
 }
 
-function getSectionSearchTexts(
-  section: SectionMentionCandidate,
-): readonly string[] {
+function getSectionSearchText(section: SectionMentionCandidate): string {
   const name = section.name.trim();
-  return name ? [name, section.id] : [section.id];
+  return name || section.id;
 }
 
 function toSectionMentionSuggestion(
@@ -48,7 +46,8 @@ export function buildSectionMentionSuggestions(
   const matches = fuzzyMatchText({
     items: args.sections,
     query: trimmedQuery,
-    getText: getSectionSearchTexts,
+    getText: getSectionSearchText,
+    getAliases: (section) => [section.id],
     limit: args.sections.length,
   });
 

--- a/apps/app/src/hooks/threadMentionSuggestions.ts
+++ b/apps/app/src/hooks/threadMentionSuggestions.ts
@@ -46,9 +46,9 @@ function getThreadDisplayTitle(thread: Thread): string | undefined {
   return titleFallback || undefined;
 }
 
-function getThreadSearchTexts(thread: Thread): readonly string[] {
+function getThreadSearchText(thread: Thread): string {
   const title = getThreadDisplayTitle(thread);
-  return title ? [title, thread.id] : [thread.id];
+  return title ?? thread.id;
 }
 
 function canSuggestThread(
@@ -169,7 +169,8 @@ export function buildThreadMentionSuggestions(
   const matches = fuzzyMatchText({
     items: candidateThreads,
     query: trimmedQuery,
-    getText: getThreadSearchTexts,
+    getText: getThreadSearchText,
+    getAliases: (thread) => [thread.id],
     limit: candidateThreads.length,
   });
 

--- a/apps/app/src/lib/command-palette/palette-ranking.ts
+++ b/apps/app/src/lib/command-palette/palette-ranking.ts
@@ -55,7 +55,8 @@ export function rankPaletteActions(
   const matches = fuzzyMatchText({
     items: args.actions,
     query: args.query,
-    getText: (action) => [action.title, action.group],
+    getText: (action) => action.title,
+    getAliases: (action) => [action.group],
     limit: PALETTE_RESULT_LIMIT,
   });
 

--- a/packages/fuzzy-match/src/index.ts
+++ b/packages/fuzzy-match/src/index.ts
@@ -162,6 +162,16 @@ function getComparableValues(query: string, value: string): ComparableValues {
   return { query, value: value.toLowerCase() };
 }
 
+function getCaseInsensitiveComparableValues(
+  query: string,
+  value: string,
+): ComparableValues {
+  return {
+    query: query.toLowerCase(),
+    value: value.toLowerCase(),
+  };
+}
+
 function startsWithQueryCase(value: string, query: string): boolean {
   const comparable = getComparableValues(query, value);
   return comparable.value.startsWith(comparable.query);
@@ -622,7 +632,7 @@ function rankedMatchesToFuzzyMatches<T>(
 }
 
 function getTextRelevanceBonus(text: string, query: string): number {
-  const comparable = getComparableValues(query, text);
+  const comparable = getCaseInsensitiveComparableValues(query, text);
 
   if (comparable.value === comparable.query) {
     return TEXT_RELEVANCE_SCORE.exact;
@@ -707,7 +717,7 @@ function rankTextQueryMatches<T>(
   ];
   const matcher = new Fzf<readonly NormalizedTextCandidate<T>[]>(candidates, {
     selector: (candidate: NormalizedTextCandidate<T>) => candidate.text,
-    casing: "smart-case",
+    casing: "case-insensitive",
     forward: true,
     tiebreakers,
   });

--- a/packages/fuzzy-match/src/index.ts
+++ b/packages/fuzzy-match/src/index.ts
@@ -2,7 +2,8 @@ import { Fzf } from "fzf";
 import type { FzfResultItem, Selector, Tiebreaker } from "fzf";
 
 type FuzzyPathGetter<T> = (item: T) => string;
-type FuzzyTextGetter<T> = (item: T) => string | readonly string[];
+type FuzzyTextGetter<T> = (item: T) => string;
+type FuzzyTextAliasesGetter<T> = (item: T) => readonly string[];
 
 interface FuzzyMatch<T> {
   item: T;
@@ -21,6 +22,7 @@ interface FuzzyMatchTextArgs<T> {
   items: readonly T[];
   query: string;
   getText: FuzzyTextGetter<T>;
+  getAliases?: FuzzyTextAliasesGetter<T>;
   limit: number;
 }
 
@@ -42,6 +44,7 @@ interface NormalizedTextCandidate<T> {
   itemIndex: number;
   text: string;
   textIndex: number;
+  isAlias: boolean;
 }
 
 interface RankedTextMatch<T> {
@@ -115,6 +118,8 @@ const TEXT_RELEVANCE_SCORE = {
   contains: 10_000,
   subsequence: 5_000,
 };
+
+const PRIMARY_TEXT_SCORE = 1_000_000;
 
 function byPathStartAsc<T>(
   left: FzfResultItem<T>,
@@ -650,32 +655,37 @@ function getTextRelevanceBonus(text: string, query: string): number {
   return 0;
 }
 
-function getTextValues<T>(item: T, getText: FuzzyTextGetter<T>): string[] {
-  const text = getText(item);
-  if (typeof text === "string") {
-    return text.length > 0 ? [text] : [];
-  }
-
-  return text.filter((value) => value.length > 0);
-}
-
 function getTextCandidates<T>(
   items: readonly T[],
   getText: FuzzyTextGetter<T>,
+  getAliases: FuzzyTextAliasesGetter<T> | undefined,
 ): NormalizedTextCandidate<T>[] {
   const candidates: NormalizedTextCandidate<T>[] = [];
   let itemIndex = 0;
   for (const item of items) {
-    const values = getTextValues(item, getText);
-    let textIndex = 0;
-    for (const text of values) {
+    const text = getText(item);
+    if (text.length > 0) {
       candidates.push({
         item,
         itemIndex,
         text,
-        textIndex,
+        textIndex: 0,
+        isAlias: false,
       });
-      textIndex += 1;
+    }
+    const aliases = getAliases?.(item) ?? [];
+    let aliasIndex = 0;
+    for (const alias of aliases) {
+      if (alias.length > 0) {
+        candidates.push({
+          item,
+          itemIndex,
+          text: alias,
+          textIndex: aliasIndex + 1,
+          isAlias: true,
+        });
+      }
+      aliasIndex += 1;
     }
     itemIndex += 1;
   }
@@ -732,7 +742,10 @@ function rankTextQueryMatches<T>(
       text: match.item.text,
       textIndex: match.item.textIndex,
       positions: [...match.positions].sort((left, right) => left - right),
-      score: match.score + getTextRelevanceBonus(match.item.text, query),
+      score:
+        match.score +
+        getTextRelevanceBonus(match.item.text, query) +
+        (match.item.isAlias ? 0 : PRIMARY_TEXT_SCORE),
       start: match.start,
     }))
     .sort(compareRankedTextMatches);
@@ -819,7 +832,7 @@ export function fuzzyMatchText<T>(
   return rankedTextMatchesToFuzzyMatches(
     mergeRankedTextMatches(
       rankTextQueryMatches(
-        getTextCandidates(args.items, args.getText),
+        getTextCandidates(args.items, args.getText, args.getAliases),
         args.query,
       ),
     ),

--- a/packages/fuzzy-match/test/index.test.ts
+++ b/packages/fuzzy-match/test/index.test.ts
@@ -303,8 +303,14 @@ interface ThreadSearchFixture {
   title: string;
 }
 
-function getThreadSearchTexts(thread: ThreadSearchFixture): readonly string[] {
-  return [thread.title, thread.id];
+function getThreadSearchText(thread: ThreadSearchFixture): string {
+  return thread.title;
+}
+
+function getThreadSearchAliases(
+  thread: ThreadSearchFixture,
+): readonly string[] {
+  return [thread.id];
 }
 
 describe("fuzzyMatchText", () => {
@@ -331,7 +337,8 @@ describe("fuzzyMatchText", () => {
     const matches = fuzzyMatchText({
       items: threads,
       query: "pmi",
-      getText: getThreadSearchTexts,
+      getText: getThreadSearchText,
+      getAliases: getThreadSearchAliases,
       limit: 3,
     });
 
@@ -370,10 +377,34 @@ describe("fuzzyMatchText", () => {
       fuzzyMatchText({
         items: threads,
         query: "beta",
-        getText: getThreadSearchTexts,
+        getText: getThreadSearchText,
+        getAliases: getThreadSearchAliases,
         limit: 3,
       }).map((match) => match.item.id),
     ).toEqual(["thr_beta"]);
+  });
+
+  it("ranks primary text matches ahead of stronger alias matches", () => {
+    const models = [
+      {
+        id: "openrouter/nvidia/nemotron-3-ultra-550b-a55b",
+        label: "NVIDIA: Nemotron 3 Ultra",
+      },
+      {
+        id: "openai/gpt-5.5",
+        label: "GPT-5.5",
+      },
+    ];
+
+    expect(
+      fuzzyMatchText({
+        items: models,
+        query: "55",
+        getText: (model) => model.label,
+        getAliases: (model) => [model.id],
+        limit: models.length,
+      }).map((match) => match.item.label),
+    ).toEqual(["GPT-5.5", "NVIDIA: Nemotron 3 Ultra"]);
   });
 
   it("keeps deterministic ordering for equal text matches", () => {
@@ -386,7 +417,8 @@ describe("fuzzyMatchText", () => {
       fuzzyMatchText({
         items: threads,
         query: "shared",
-        getText: getThreadSearchTexts,
+        getText: getThreadSearchText,
+        getAliases: getThreadSearchAliases,
         limit: 3,
       }).map((match) => match.item.id),
     ).toEqual(["thr_b", "thr_a"]);

--- a/packages/fuzzy-match/test/index.test.ts
+++ b/packages/fuzzy-match/test/index.test.ts
@@ -339,6 +339,27 @@ describe("fuzzyMatchText", () => {
     expect(matches[0].positions.length).toBeGreaterThan(0);
   });
 
+  it("matches case-insensitively regardless of query casing", () => {
+    const items = ["atlas-web", "Beacon API"];
+
+    expect(
+      fuzzyMatchText({
+        items,
+        query: "AW",
+        getText: (item) => item,
+        limit: items.length,
+      }).map((match) => match.item),
+    ).toEqual(["atlas-web"]);
+    expect(
+      fuzzyMatchText({
+        items,
+        query: "beacon api",
+        getText: (item) => item,
+        limit: items.length,
+      }).map((match) => match.item),
+    ).toEqual(["Beacon API"]);
+  });
+
   it("matches secondary text values such as ids", () => {
     const threads: ThreadSearchFixture[] = [
       { id: "thr_alpha", title: "Design review" },


### PR DESCRIPTION
## Human comments

left: before, right after

<img width="1854" height="680" alt="image" src="https://github.com/user-attachments/assets/fde1ba20-c932-4285-983d-35c16bcc4ea6" />


<img width="1854" height="680" alt="image" src="https://github.com/user-attachments/assets/d38a4f90-6e32-42e1-b795-3696fbad8a14" />

## What was wrong

Searchable pickers did not share a matching policy. Project and Branch used case-insensitive substring filtering in source order, Model used an unranked subsequence regex, and Parent Thread implicitly inherited cmdk scoring. Matching behavior and result ordering therefore changed depending on which picker a user opened.

The first revision centralized picker behavior but introduced another fuzzy-matching implementation even though `@bb/fuzzy-match` already owns shared text-search policy. It also treated visible labels and hidden aliases as equivalent fields. A strong hidden-ID match could therefore outrank a useful visible-label match: the query `55` placed Nemotron above GPT-5.5 because Nemotron's raw ID contains `550b-a55b`.

## What changed

All searchable pickers now use one `searchPickerOptions` adapter backed by `@bb/fuzzy-match`. The adapter trims input and explicitly supplies each option's visible label as its primary text plus any type-specific aliases.

`fuzzyMatchText` now owns one field-aware policy:

- Matching is case-insensitive for every query.
- Any primary-text match ranks ahead of any alias-only match.
- Within each field class, exact matches rank above prefixes, prefixes above contains matches, and contains matches above non-contiguous subsequences.
- Deterministic tiebreakers prefer earlier matches, shorter text, lexical order, then source order.

Aliases still add results. Parent Thread adds the thread ID, Model adds the route provider and raw model ID, mention suggestions add entity IDs, and command-palette groups remain searchable. Project and Branch search their visible names. Branch search no longer pins a weaker selected result above stronger matches, and Model search ranks primary and selected-only models together after flattening them.

Path matching remains structurally specialized through `fuzzyMatchPaths`; generic text matching has one policy.

No wire, CLI, guide, documentation, or protocol changes.

### Query behavior

| Query | Before | After |
| --- | --- | --- |
| Model `55` | Nemotron alias-only matches from `550b-a55b` could outrank visible `GPT-5.5` labels | All visible `GPT-5.5` label matches rank first; Nemotron remains included later through its raw-ID alias |
| Project `aw` → `atlas-web` | No match because `aw` is not contiguous | Matches as an ordered subsequence |
| Branch `fth` → `feature/three` | No match because `fth` is not contiguous | Matches as an ordered subsequence |
| Model `gpt4` | Fuzzy matches stayed in source/bucket order | Exact, prefix, and tighter matches rank first across all model buckets |
| Parent `cdxp` → `Codex Parent` | Fuzzy matched through cmdk | Same query uses the shared text matcher |
| Parent `frontend_parent` | Matched the thread-ID keyword | Same; thread ID is an explicit alias augmenting the visible label |
| Uppercase text query such as `ATLAS` | `fuzzyMatchText` used smart-case and rejected lowercase-only text | Matches `atlas-web` case-insensitively |
| Equal-score results | Ordering depended on the picker | Use the same deterministic tiebreakers everywhere |

## How you verified

- `pnpm exec turbo run test --filter=@bb/fuzzy-match --force` (26 passed)
- `pnpm exec turbo run test --filter=@bb/app --force` (468 files; 3,751 passed, 4 skipped)
- Focused picker, mention-suggestion, and command-palette suites (10 files; 74 passed)
- `pnpm exec turbo run typecheck --filter=@bb/fuzzy-match --filter=@bb/app --force`
- `pnpm exec turbo run lint --filter=@bb/app --force` (0 errors; 177 existing warnings)
- `pnpm exec oxfmt --check` on changed files
- Desktop manual QA with Doobie: project query `aw`, uppercase project query `AW`, and model query `55`; the model results show visible GPT-5.5 matches ahead of alias-only Nemotron matches

Fixes: no linked issue.

> AGENT GENERATED
