### PR TITLE
Correct picker current-value accessibility

### DIFF
--- a/apps/app/src/components/pickers/ParentThreadPicker.test.tsx
+++ b/apps/app/src/components/pickers/ParentThreadPicker.test.tsx
@@ -31,6 +31,30 @@ function picker(overrides: Partial<ParentThreadPickerProps> = {}) {
 afterEach(cleanup);
 
 describe("ParentThreadPicker", () => {
+  it("exposes the current parent separately from keyboard highlight", () => {
+    render(
+      picker({
+        value: "thr_frontend_parent",
+        defaultOpen: true,
+      }),
+    );
+
+    const search = screen.getByRole("combobox", {
+      name: "Search parent threads",
+    });
+    const none = screen.getByRole("option", { name: "None" });
+    const codex = screen.getByRole("option", { name: "Codex Parent" });
+    const frontend = screen.getByRole("option", { name: "Frontend Parent" });
+    expect(none.getAttribute("aria-selected")).toBe("true");
+    expect(frontend.getAttribute("aria-selected")).toBe("false");
+    expect(frontend.getAttribute("aria-current")).toBe("true");
+
+    fireEvent.keyDown(search, { key: "ArrowDown" });
+
+    expect(codex.getAttribute("aria-selected")).toBe("true");
+    expect(frontend.getAttribute("aria-current")).toBe("true");
+  });
+
   it("requests candidates only when opened", async () => {
     const onOpenChange = vi.fn();
     render(picker({ isLoading: true, onOpenChange }));

--- a/apps/app/src/components/pickers/ParentThreadPicker.tsx
+++ b/apps/app/src/components/pickers/ParentThreadPicker.tsx
@@ -128,6 +128,7 @@ export function ParentThreadPicker({
                       key={option.value}
                       value={option.value}
                       keywords={[option.label]}
+                      aria-current={value === option.value ? "true" : undefined}
                       onSelect={() => {
                         onChange(option.value);
                         handleOpenChange(false);
@@ -139,6 +140,7 @@ export function ParentThreadPicker({
                       </span>
                       <Icon
                         name="Check"
+                        aria-hidden
                         className={cn(
                           COARSE_POINTER_ICON_SIZE_CLASS,
                           value === option.value ? "opacity-100" : "opacity-0",

--- a/apps/app/src/components/pickers/ProjectSelector.test.tsx
+++ b/apps/app/src/components/pickers/ProjectSelector.test.tsx
@@ -16,6 +16,34 @@ const PROJECTS = [
 afterEach(cleanup);
 
 describe("ProjectSelector", () => {
+  it("exposes the current project separately from keyboard highlight", () => {
+    render(
+      <ProjectSelector
+        projects={PROJECTS}
+        value="proj_charlie"
+        onChange={() => {}}
+        defaultOpen
+        modal={false}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Project: Charlie Docs" }),
+    ).toBeTruthy();
+    const search = screen.getByRole("combobox", { name: "Search projects" });
+    const alpha = screen.getByRole("option", { name: "Alpha Web" });
+    const bravo = screen.getByRole("option", { name: "Bravo API" });
+    const charlie = screen.getByRole("option", { name: "Charlie Docs" });
+    expect(alpha.getAttribute("aria-selected")).toBe("true");
+    expect(charlie.getAttribute("aria-selected")).toBe("false");
+    expect(charlie.getAttribute("aria-current")).toBe("true");
+
+    fireEvent.keyDown(search, { key: "ArrowDown" });
+
+    expect(bravo.getAttribute("aria-selected")).toBe("true");
+    expect(charlie.getAttribute("aria-current")).toBe("true");
+  });
+
   it("shows search only when there are more than five projects", () => {
     const result = render(
       <ProjectSelector
@@ -102,7 +130,7 @@ describe("ProjectSelector", () => {
     render(
       <ProjectSelector
         projects={PROJECTS}
-        value="proj_alpha"
+        value={null}
         onChange={() => {}}
         allowNoProject
         createProject={{ onCreate }}
@@ -111,6 +139,11 @@ describe("ProjectSelector", () => {
       />,
     );
 
+    expect(
+      screen
+        .getByRole("option", { name: "Don't work in a project" })
+        .getAttribute("aria-current"),
+    ).toBe("true");
     fireEvent.change(
       screen.getByRole("combobox", { name: "Search projects" }),
       { target: { value: "missing" } },
@@ -125,7 +158,9 @@ describe("ProjectSelector", () => {
     fireEvent.click(screen.getByRole("option", { name: "New project" }));
     expect(onCreate).toHaveBeenCalledTimes(1);
 
-    fireEvent.click(screen.getByRole("button", { name: "Project" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Project: Work in a project" }),
+    );
     expect(
       screen.getByRole<HTMLInputElement>("combobox", {
         name: "Search projects",

--- a/apps/app/src/components/pickers/ProjectSelector.tsx
+++ b/apps/app/src/components/pickers/ProjectSelector.tsx
@@ -111,7 +111,7 @@ export function ProjectSelector({
           type="button"
           variant="ghost"
           size="sm"
-          aria-label="Project"
+          aria-label={`Project: ${triggerLabel}`}
           aria-busy={isLoading || undefined}
           disabled={disabled}
           data-promptbox-project-control=""
@@ -185,6 +185,7 @@ export function ProjectSelector({
                   key={project.id}
                   value={project.id}
                   keywords={[project.name]}
+                  aria-current={project.id === value ? "true" : undefined}
                   onSelect={() => selectProject(project.id)}
                   className={PROJECT_PICKER_ITEM_CLASS_NAME}
                 >
@@ -236,6 +237,7 @@ export function ProjectSelector({
                 {allowNoProject ? (
                   <CommandItem
                     value="no-project"
+                    aria-current={value === null ? "true" : undefined}
                     onSelect={() => selectProject(null)}
                     className={PROJECT_PICKER_ITEM_CLASS_NAME}
                   >


### PR DESCRIPTION
## Human comments

## What was wrong

The searchable Project picker used cmdk's moving `aria-selected` state as its only option-selection signal after #2939. That state identifies the keyboard-highlighted row, not the persisted project value, so assistive technology could report Alpha selected while Charlie was the actual checked project; the trigger also exposed only the generic name “Project.” Parent Thread had the same current-value ambiguity.

## What changed

- Name the Project trigger with its displayed current value.
- Mark the persisted Project, no-project choice, and Parent Thread value with `aria-current`.
- Keep cmdk's `aria-selected` behavior for the movable keyboard highlight.
- Hide decorative check icons from assistive technology.
- Add focused regressions proving current value remains stable while keyboard highlight moves.

This is semantically separate from #2943's open search-matching change and composes with it. No daemon wire contract, server API, public Plugin SDK API, CLI, documentation, or protocol version changed.

## How you verified

- The four focused accessibility assertions failed before the implementation and passed afterward.
- `pnpm exec turbo run test --filter=@bb/app --force -- --run src/components/pickers/ProjectSelector.test.tsx src/components/pickers/ParentThreadPicker.test.tsx` — 11 tests passed.
- Full app suite — 3,744 tests passed and 4 skipped.
- `pnpm exec turbo run typecheck --filter=@bb/app` — passed.
- `pnpm exec oxfmt --check apps/app/src/components/pickers/ProjectSelector.tsx apps/app/src/components/pickers/ProjectSelector.test.tsx apps/app/src/components/pickers/ParentThreadPicker.tsx apps/app/src/components/pickers/ParentThreadPicker.test.tsx` — passed.
- `git diff --check origin/main...HEAD` — passed.
- Matching desktop and compact QA confirmed the current project remains visually checked while ArrowDown moves the command highlight.

> AGENT GENERATED
