### PR TITLE
Show attachment upload progress on prompt submit

### DIFF
--- a/apps/app/src/components/promptbox/PromptBoxActionsMenu.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxActionsMenu.test.tsx
@@ -53,7 +53,7 @@ describe("PromptBoxActionsMenu", () => {
     expect(onAttach).toHaveBeenCalledOnce();
   });
 
-  it("keeps attachment upload progress visible on the menu trigger", () => {
+  it("keeps the plus menu trigger stable during attachment uploads", () => {
     render(
       <PromptBoxActionsMenu
         isAttaching
@@ -63,7 +63,8 @@ describe("PromptBoxActionsMenu", () => {
     );
 
     const trigger = screen.getByRole("button", { name: "Prompt actions" });
-    expect(trigger.querySelector('[data-icon="Spinner"]')).not.toBeNull();
+    expect(trigger.querySelector('[data-icon="Plus"]')).not.toBeNull();
+    expect(trigger.querySelector('[data-icon="Spinner"]')).toBeNull();
   });
 
   it("seeds the composer with the plugin prompt after the provider actions", async () => {

--- a/apps/app/src/components/promptbox/PromptBoxActionsMenu.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxActionsMenu.tsx
@@ -186,10 +186,7 @@ export function PromptBoxActionsMenu({
             "-ml-1.5",
           )}
         >
-          <Icon
-            name={isAttaching ? "Spinner" : "Plus"}
-            className={cn("size-4", isAttaching && "animate-spin")}
-          />
+          <Icon name="Plus" className="size-4" />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent

--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -1992,6 +1992,42 @@ describe("PromptBoxInternal plugin composer actions", () => {
 });
 
 describe("PromptBoxInternal compact layout", () => {
+  it("shows attachment upload progress on the submit button", () => {
+    const restoreMatchMedia = mockPointerCoarse(true);
+    try {
+      render(
+        <PromptBoxInternal
+          {...createPromptBoxProps({
+            attachments: { isAttaching: true },
+            compact: {
+              isCompact: true,
+              placeholder: "Ask a follow-up",
+            },
+            voice: {
+              state: "idle",
+              isSupported: true,
+              stream: null,
+              start: vi.fn(),
+              stop: vi.fn(),
+              cancel: vi.fn(),
+            },
+          })}
+        />,
+      );
+
+      const submit = screen.getByRole("button", {
+        name: "Uploading attachments...",
+      });
+      expect(submit.hasAttribute("disabled")).toBe(true);
+      expect(submit.querySelector('[data-icon="Spinner"]')).not.toBeNull();
+      expect(
+        screen.queryByRole("button", { name: "Start voice input" }),
+      ).toBeNull();
+    } finally {
+      restoreMatchMedia();
+    }
+  });
+
   it("publishes the container-compact placeholder for CSS", () => {
     const baseProps = createPromptBoxProps();
     const view = render(

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -227,8 +227,8 @@ interface PromptSubmitButtonProps {
   canSubmit: boolean;
   className: string;
   disabledReason: string | undefined;
+  isBusy: boolean;
   isCompact: boolean;
-  isSubmitting: boolean;
   onClick: (event: ReactMouseEvent<HTMLButtonElement>) => void;
   onPointerDown: (event: ReactPointerEvent<HTMLButtonElement>) => void;
   title: string;
@@ -238,8 +238,8 @@ function PromptSubmitButton({
   canSubmit,
   className,
   disabledReason,
+  isBusy,
   isCompact,
-  isSubmitting,
   onClick,
   onPointerDown,
   title,
@@ -251,12 +251,13 @@ function PromptSubmitButton({
       size={isCompact ? "icon" : "sm"}
       variant="default"
       aria-label={title}
+      aria-busy={isBusy}
       disabled={!canSubmit}
       onPointerDown={onPointerDown}
       onClick={onClick}
       className={className}
     >
-      {isSubmitting ? (
+      {isBusy ? (
         <Icon name="Spinner" className="size-4 animate-spin" />
       ) : (
         <Icon name="CornerDownLeft" className="size-4" />
@@ -2520,17 +2521,27 @@ export function PromptBoxInternal({
   );
 
   const canSubmit =
-    hasSubmittableInput && !isSubmitting && !submitDisabled && !isVoiceBusy;
-  const canModifierSubmit =
-    onModifierSubmit !== undefined &&
+    hasSubmittableInput &&
+    !isAttaching &&
     !isSubmitting &&
     !submitDisabled &&
     !isVoiceBusy;
-  const showStop = Boolean(isRunning && onStop && !canSubmit && !isVoiceBusy);
+  const canModifierSubmit =
+    onModifierSubmit !== undefined &&
+    !isAttaching &&
+    !isSubmitting &&
+    !submitDisabled &&
+    !isVoiceBusy;
+  const showStop = Boolean(
+    isRunning && onStop && !canSubmit && !isAttaching && !isVoiceBusy,
+  );
   const canStartVoiceInput =
     voice !== undefined && voice.isSupported && !isSubmitting;
   const showVoiceAsPrimaryAction =
-    isPointerCoarse && !hasSubmittableInput && canStartVoiceInput;
+    isPointerCoarse &&
+    !isAttaching &&
+    !hasSubmittableInput &&
+    canStartVoiceInput;
   const handleVoicePointerDown = useCallback(
     (event: ReactPointerEvent<HTMLButtonElement>) => {
       if (!isPointerCoarse || event.button !== 0) return;
@@ -2556,8 +2567,12 @@ export function PromptBoxInternal({
     setVoiceActionTransition("exiting");
     voice?.cancel();
   }, [voice]);
-  const effectiveSubmitTitle =
-    !canSubmit && submitDisabledReason ? submitDisabledReason : submitTitle;
+  const attachmentUploadTitle = "Uploading attachments...";
+  const effectiveSubmitTitle = isAttaching
+    ? attachmentUploadTitle
+    : !canSubmit && submitDisabledReason
+      ? submitDisabledReason
+      : submitTitle;
 
   const emitAttachmentFiles = useCallback(
     (files: File[]) => {
@@ -3259,10 +3274,14 @@ export function PromptBoxInternal({
                           "transition-colors",
                         )}
                         disabledReason={
-                          !canSubmit ? submitDisabledReason : undefined
+                          !canSubmit
+                            ? isAttaching
+                              ? attachmentUploadTitle
+                              : submitDisabledReason
+                            : undefined
                         }
+                        isBusy={isSubmitting || isAttaching}
                         isCompact={showCompactLayout}
-                        isSubmitting={isSubmitting}
                         onPointerDown={handleSubmitPointerDown}
                         onClick={handleSubmitClick}
                         title={effectiveSubmitTitle}


### PR DESCRIPTION
## Human comments

## What was wrong

The prompt box received attachment upload state, but only the expanded plus menu rendered it. Compact mode hides that menu, so pasting an image could leave the primary action looking idle, and drafts with existing text could still be submitted before the attachment finished uploading.

## What changed

The shared submit action now treats attachment uploads as a busy state: it shows a spinner, exposes an upload-specific accessible label and `aria-busy`, and blocks primary and modifier submission until the attachment is ready. Upload feedback takes priority over compact voice and stop actions. The plus-menu trigger stays visually stable, while Attach files remains disabled during an active upload. There are no wire, CLI, guide, or protocol changes.

## How you verified

- Added a compact coarse-pointer regression test that fails on the baseline send/mic state and passes with the upload spinner.
- Updated plus-menu coverage to assert that its trigger stays on the Plus icon during uploads.
- `pnpm exec turbo run test --filter=@bb/app -- --run src/components/promptbox/PromptBoxActionsMenu.test.tsx src/components/promptbox/PromptBoxInternal.test.tsx` (119 passed)
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run lint --filter=@bb/app` (0 errors; 177 existing warnings)
- `pnpm exec oxfmt --check apps/app/src/components/promptbox/PromptBoxActionsMenu.test.tsx apps/app/src/components/promptbox/PromptBoxActionsMenu.tsx apps/app/src/components/promptbox/PromptBoxInternal.test.tsx apps/app/src/components/promptbox/PromptBoxInternal.tsx`
- `git diff --check`

Fixes # (no linked issue)

> AGENT GENERATED
