### PR TITLE
Add RAPP Brainstem as a first-class provider

### DIFF
--- a/apps/cli/src/commands/thread/actions.ts
+++ b/apps/cli/src/commands/thread/actions.ts
@@ -154,7 +154,7 @@ export function registerActionsCommands(
     )
     .option(
       "--reasoning-level <level>",
-      "Set the sticky reasoning level applied on the thread's next turn: low, medium, high, xhigh, max (provider-dependent)",
+      "Set the sticky reasoning level applied on the thread's next turn: none, low, medium, high, xhigh, ultracode, max (provider-dependent)",
     )
     .option("--visibility <visibility>", "Thread visibility: visible or hidden")
     .action(
@@ -438,7 +438,7 @@ export function registerActionsCommands(
     .option("--service-tier <tier>", "Service tier: fast or default")
     .option(
       "--reasoning-level <level>",
-      "Reasoning level: low, medium, high, xhigh, max (provider-dependent)",
+      "Reasoning level: none, low, medium, high, xhigh, ultracode, max (provider-dependent)",
     )
     .option("--permission-mode <mode>", PERMISSION_MODE_HELP)
     .option(

--- a/apps/cli/src/commands/thread/spawn.ts
+++ b/apps/cli/src/commands/thread/spawn.ts
@@ -201,7 +201,7 @@ export function registerSpawnCommand(
     )
     .option(
       "--reasoning-level <level>",
-      "Reasoning level: low, medium, high, xhigh, max (provider-dependent)",
+      "Reasoning level: none, low, medium, high, xhigh, ultracode, max (provider-dependent)",
     )
     .option("--title <title>", "Thread title")
     .option("--service-tier <tier>", "Service tier: fast or default")

--- a/apps/server/src/services/plugins/builtin-registry.ts
+++ b/apps/server/src/services/plugins/builtin-registry.ts
@@ -79,6 +79,11 @@ export const BUILTIN_PLUGINS = [
     defaultEnabled: true,
   },
   {
+    name: "provider-rapp",
+    pluginId: "provider-rapp",
+    defaultEnabled: true,
+  },
+  {
     name: "provider-acp",
     pluginId: "provider-acp",
     defaultEnabled: true,

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/references/configuration.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/references/configuration.md
@@ -40,9 +40,11 @@
   `RAPP_BRAINSTEM_URL` and `RAPP_BRAINSTEM_SECRET` from the host daemon.
   Business mode reads `RAPP_BUSINESS_URL`, `RAPP_FUNCTION_KEY`, and optional
   `RAPP_USER_GUID`. Store credentials with `npx bb-app env set`, not in plugin
-  settings or endpoint URLs. Automatic startup applies only to plain HTTP
-  loopback `/chat` endpoints, and the launched Brainstem does not inherit
-  those five RAPP routing and credential variables.
+  settings or endpoint URLs. Endpoint URLs may not contain query parameters or
+  fragments, and header credentials require HTTPS outside loopback. Automatic
+  startup applies only to plain HTTP `localhost` or `127.0.0.1` `/chat`
+  endpoints, and the launched Brainstem does not inherit those five RAPP
+  routing and credential variables.
 
 ## Agent Instructions
 

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/references/configuration.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/references/configuration.md
@@ -31,6 +31,18 @@
 - Claude Code's `idleQueryReleaseEnabled` setting opts into closing its native
   process after 30 seconds of quiescence while keeping the bb thread resumable.
   It defaults to `false`; changes apply on the next start, resume, or turn.
+- The bundled `rapp` provider speaks only the `rapp/1` protocol. Consumer mode
+  discovers the Brainstem's verified GitHub Copilot models; select one of
+  those ids or use `brainstem` to follow its current default. Business mode
+  exposes the fixed `business-grail` model. Configure the non-secret `grail`
+  setting as `consumer` or `business`, and optionally set `endpoint`.
+- Consumer mode defaults to the shared local Brainstem and also reads
+  `RAPP_BRAINSTEM_URL` and `RAPP_BRAINSTEM_SECRET` from the host daemon.
+  Business mode reads `RAPP_BUSINESS_URL`, `RAPP_FUNCTION_KEY`, and optional
+  `RAPP_USER_GUID`. Store credentials with `npx bb-app env set`, not in plugin
+  settings or endpoint URLs. Automatic startup applies only to plain HTTP
+  loopback `/chat` endpoints, and the launched Brainstem does not inherit
+  those five RAPP routing and credential variables.
 
 ## Agent Instructions
 

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/references/configuration.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/references/configuration.md
@@ -45,6 +45,12 @@
   startup applies only to plain HTTP `localhost` or `127.0.0.1` `/chat`
   endpoints, and the launched Brainstem does not inherit those five RAPP
   routing and credential variables.
+- RAPP persists complete transcripts in canonical `rapp/1` session eggs,
+  journals completed responses before delivery, caps responses at 64 KiB, and
+  fails before `/chat` when the egg cannot reserve that response capacity.
+  Continue in a new thread after the 1 MiB egg limit or an uncertain legacy
+  Brainstem completion; bb retains uncertain requests for audit and does not
+  replay them automatically.
 
 ## Agent Instructions
 

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/references/thread-creation.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/references/thread-creation.md
@@ -140,13 +140,15 @@ environment pull-request show <id>`. Diff commands require an explicit target
   can link to `.agents/skills`. `bb skill list` shows linked Cursor skills under
   `cursor-project` and keeps them read-only.
 - Top-level `customModels` in the same `config.json` registers extra picker
-  models. `providerId` accepts a built-in provider id or any `acp-*` provider
-  id. The provider must still accept the id: `claude-code` and `codex` accept
-  unlisted ids, while an ACP agent can reject an unknown id at session start.
-  OpenCode rejects unlisted ids; add the model to the OpenCode config instead
-  and bb discovers it automatically. An OpenCode agent is a session mode, not
-  a model, and cannot be selected through bb. This list also has no set/unset
-  CLI surface. Edit the JSON and restart BB.
+  models. `providerId` accepts `codex`, `claude-code`, `pi`, `acp-cursor`, or
+  any `acp-*` provider id. It intentionally excludes `rapp`, whose Brainstem
+  supplies an authoritative dynamic GitHub Copilot catalog. The provider must
+  still accept the id: `claude-code` and `codex` accept unlisted ids, while an
+  ACP agent can reject an unknown id at session start. OpenCode rejects
+  unlisted ids; add the model to the OpenCode config instead and bb discovers
+  it automatically. An OpenCode agent is a session mode, not a model, and
+  cannot be selected through bb. This list also has no set/unset CLI surface.
+  Edit the JSON and restart BB.
   The `streamerMode` General preference hides every entry from model lists.
 - Top-level `sharedSkillRoots` uses the same relative `user` and `project`
   paths. bb lists these skills as read-only. bb injects them into each provider,

--- a/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/references/backend-sdk.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/references/backend-sdk.md
@@ -39,6 +39,23 @@ Prefer your own `bb.settings` and `bb.storage` over `sdk.system` and
 areas write app-wide state that the user owns.
 
 ```ts
+const catalog = await bb.sdk.providers.models({
+  providerId: "echo-agent",
+});
+const installedSettings = await bb.sdk.plugins.getSettings({
+  pluginId: "another-plugin",
+});
+await bb.sdk.plugins.updateSettings({
+  pluginId: "another-plugin",
+  values: { mode: "fast" },
+});
+```
+
+Use `providers.models` before persisting a provider/model choice. The plugin
+settings calls are for explicit administration of another installed plugin;
+use the typed `bb.settings` handle for your own plugin.
+
+```ts
 const thread = await bb.sdk.threads.spawn({
   projectId,
   environment: { type: "project-default" }, // server resolves the project's default environment

--- a/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/references/providers.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/references/providers.md
@@ -61,8 +61,9 @@ bb.providers.register({
   // Called by the server on EVERY session and turn command. The returned
   // JSON reaches the bridge as `options.providerOptions`; core never reads
   // it. This is where the provider's own knobs travel — read them from the
-  // plugin's own `bb.settings.define` values in `ctx.settings` (secrets are
-  // omitted). `ctx.promptMode` is "plan" when the prompt entered plan mode.
+  // plugin's own non-secret `bb.settings.define` values in `ctx.settings`.
+  // Secret settings are omitted. `ctx.promptMode` is "plan" when the prompt
+  // entered plan mode.
   deriveProviderOptions(ctx) {
     return {
       verbose: ctx.settings.verbose === true,
@@ -110,7 +111,7 @@ export default definePluginApp((app) => {
 });
 ```
 
-(The four first-party provider plugins ship no `app.tsx`: bb vendors their
+(The five first-party provider plugins ship no `app.tsx`: bb vendors their
 marks itself, so an icon-only bundle would only add fetches at boot.)
 
 A provider plugin's `app.tsx` loads in the same deferred boot pass as every
@@ -132,17 +133,24 @@ user reorders them and picks a default in Settings → Providers
 
 `experimental_bridgeOptions` must be a plain JSON object no larger than 64
 KiB. It is validated and frozen at registration, then carried on every bridge
-request as provider-scoped static options. Use it for immutable launch facts
-shared by all hosts, not user settings or machine-local state. It participates
-in bridge process identity, so changing it causes the next runtime to use a
-new bridge process. `experimental_visibility: "installed"` makes the provider
+request as provider-scoped static options. Use it for immutable
+per-registration launch facts shared by all hosts, including validated
+non-secret provider settings that cause a re-registration when they change.
+Do not put credentials or machine-local state in it. It participates in bridge
+process identity, so changing it causes the next runtime to use a new bridge
+process. `experimental_visibility: "installed"` makes the provider
 host-dependent: BB asks that provider's bridge for `provider/health` and lists
-it only when the status is not `not_installed`. Such a declaration must support
-health; bridge failures hide only that provider.
+it only when the status is not `not_installed`. Such a declaration must
+support health; bridge failures hide only that provider.
 
 `deriveProviderOptions` runs synchronously for each session and turn command.
 Its plain JSON result has the same 64 KiB limit. The runtime merges the result
 over `experimental_bridgeOptions`; a derived key replaces its static key.
+
+Provider credentials stay in the provider's native authentication store or in
+host-local environment variables named by `env.passthrough`. Secret plugin
+settings are deliberately absent from `ctx.settings`, so they cannot leak into
+`providerOptions`. Never encode a credential in an endpoint URL.
 
 Use `extensionKinds` to declare provider-specific item or state payloads. Each
 kind needs an item schema, a state schema, or both. The server validates each

--- a/apps/server/src/services/threads/thread-create.ts
+++ b/apps/server/src/services/threads/thread-create.ts
@@ -114,8 +114,14 @@ async function resolveCatalogExecutionDefaults(
   deps: ThreadCreateDeps,
   args: ResolveCatalogExecutionDefaultsArgs,
 ): Promise<ProjectExecutionDefaults | null> {
-  if (args.executionDefaults !== null || args.requestedModel !== null) {
+  if (args.executionDefaults !== null) {
     return args.executionDefaults;
+  }
+  if (args.requestedModel !== null) {
+    return buildProviderThreadExecutionDefaults(deps.providerRegistry, {
+      providerId: args.providerId,
+      model: args.requestedModel,
+    });
   }
 
   const catalog = await resolveSystemProviderModels(deps, {

--- a/apps/server/src/services/threads/thread-default-policy.ts
+++ b/apps/server/src/services/threads/thread-default-policy.ts
@@ -6,7 +6,11 @@ import type {
   ServiceTier,
   Thread,
 } from "@bb/domain";
-import { PERSONAL_PROJECT_ID, clampPermissionModeToCeiling } from "@bb/domain";
+import {
+  PERSONAL_PROJECT_ID,
+  clampPermissionModeToCeiling,
+  reconcileReasoningLevel,
+} from "@bb/domain";
 import type { EnvironmentArgs } from "@bb/server-contract";
 import { COMMAND_TIMEOUT_MS } from "../../constants.js";
 import type { WorkSessionDeps } from "../../types.js";
@@ -186,10 +190,15 @@ export function buildProviderThreadExecutionDefaults(
     providerId: string;
   },
 ): ProjectExecutionDefaults {
+  const supportedReasoning =
+    registry.getServerCapabilities(args.providerId)?.reasoningLevels ?? [];
   return {
     providerId: args.providerId,
     model: args.model,
-    reasoningLevel: DEFAULT_REASONING_LEVEL,
+    reasoningLevel:
+      supportedReasoning.length === 0
+        ? DEFAULT_REASONING_LEVEL
+        : reconcileReasoningLevel(DEFAULT_REASONING_LEVEL, supportedReasoning),
     permissionMode: resolveSupportedPermissionMode(registry, {
       providerId: args.providerId,
       preferredPermissionMode: DEFAULT_PERMISSION_MODE,

--- a/apps/server/test/helpers/provider-registry.ts
+++ b/apps/server/test/helpers/provider-registry.ts
@@ -40,6 +40,7 @@ const FIRST_PARTY_PROVIDER_PLUGIN_IDS = [
   "provider-codex",
   "provider-claude-code",
   "provider-pi",
+  "provider-rapp",
   "provider-acp",
 ] as const;
 

--- a/apps/server/test/providers/plugin-provider-registration.test.ts
+++ b/apps/server/test/providers/plugin-provider-registration.test.ts
@@ -351,6 +351,11 @@ describe("buildPluginProviderRegistration", () => {
         icon: undefined,
       },
       {
+        id: "rapp",
+        logoUrl: "/api/v1/system/providers/rapp/logo",
+        icon: undefined,
+      },
+      {
         id: "acp-cursor",
         logoUrl: "/api/v1/system/providers/acp-cursor/logo",
         icon: undefined,

--- a/apps/server/test/public/public-threads.defaults.test.ts
+++ b/apps/server/test/public/public-threads.defaults.test.ts
@@ -104,6 +104,60 @@ describe("public thread default routes", () => {
     });
   });
 
+  it("uses provider-compatible defaults for an explicit RAPP model", async () => {
+    await withTestHarness(async (harness) => {
+      const { host } = seedHostSession(harness.deps);
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.id,
+        path: "/tmp/rapp-explicit-model",
+      });
+      seedEnvironment(harness.deps, {
+        hostId: host.id,
+        projectId: project.id,
+        path: "/tmp/rapp-explicit-model",
+      });
+
+      const response = await harness.app.request("/api/v1/threads", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          origin: "cli",
+          projectId: project.id,
+          providerId: "rapp",
+          model: "claude-opus-5",
+          input: [{ type: "text", text: "Use RAPP Brainstem" }],
+          environment: {
+            type: "host",
+            hostId: host.id,
+            workspace: {
+              type: "unmanaged",
+              path: null,
+            },
+          },
+        }),
+      });
+
+      expect(response.status).toBe(201);
+      const createdThread = threadSchema.parse(await readJson(response));
+      const queuedStart = await waitForQueuedCommand(
+        harness,
+        ({ command }) =>
+          command.type === "thread.start" &&
+          command.threadId === createdThread.id,
+      );
+      expect(queuedStart.command).toMatchObject({
+        providerId: "rapp",
+        options: {
+          model: "claude-opus-5",
+          reasoningLevel: "none",
+          permissionMode: "full",
+        },
+      });
+    });
+  });
+
   it("allows managed-worktree threads on a secondary host", async () => {
     await withTestHarness(async (harness) => {
       const { host: localHost } = seedHostSession(harness.deps, {

--- a/apps/server/test/services/plugins/builtin-plugins.test.ts
+++ b/apps/server/test/services/plugins/builtin-plugins.test.ts
@@ -238,6 +238,7 @@ describe("builtin plugin reconciliation", () => {
       ["provider-claude-code", "./icons/claude-code.svg"],
       ["provider-codex", "./icons/codex.svg"],
       ["provider-pi", "./icons/pi.svg"],
+      ["provider-rapp", "./icons/rapp.svg"],
       ["provider-retry", "ArrowReloadHorizontal"],
       ["push-notifications", "BellDot"],
       ["scheduled-send", "Calendar"],

--- a/apps/server/test/services/plugins/first-party-provider-plugins.test.ts
+++ b/apps/server/test/services/plugins/first-party-provider-plugins.test.ts
@@ -46,6 +46,19 @@ const FIRST_PARTY_PROVIDER_DECLARATIONS = [
     hasLogo: true,
   },
   {
+    builtinName: "provider-rapp",
+    pluginId: "provider-rapp",
+    providerId: "rapp",
+    displayName: "RAPP Brainstem",
+    supportsThreadArchive: false,
+    supportsThreadRename: false,
+    fork: "none",
+    supportsManualCompaction: false,
+    supportsUsage: false,
+    visibility: "always",
+    hasLogo: true,
+  },
+  {
     builtinName: "provider-acp",
     pluginId: "provider-acp",
     providerId: "acp-cursor",
@@ -215,7 +228,7 @@ describe("first-party provider plugins", () => {
     );
   }, 60_000);
 
-  it("pins the client-read ProviderInfo fields of the four core providers", async () => {
+  it("pins the client-read ProviderInfo fields of the bundled providers", async () => {
     await withTestHarness(
       { seedFirstPartyProviders: false },
       async (harness) => {
@@ -309,6 +322,24 @@ describe("first-party provider plugins", () => {
           },
           composerActions: [skills],
         });
+        expect(clientFields("rapp")).toStrictEqual({
+          id: "rapp",
+          displayName: "RAPP Brainstem",
+          logoUrl: expectedLogoUrl(harness.deps.providerRegistry, "rapp"),
+          available: true,
+          maintenance: { health: false, usage: false, installation: false },
+          capabilities: {
+            supportsThreadArchive: false,
+            supportsThreadRename: false,
+            supportsServiceTier: false,
+            supportsNativeUserQuestion: false,
+            permissionModes: ["full"],
+            supportsFork: false,
+            supportsSessionRewind: false,
+            modelCatalogScope: "host",
+          },
+          composerActions: [skills],
+        });
         expect(clientFields("acp-cursor")).toStrictEqual({
           id: "acp-cursor",
           displayName: "Cursor",
@@ -369,6 +400,7 @@ describe("first-party provider plugins", () => {
         expect(registry.list().map((entry) => entry.info.id)).toEqual([
           "codex",
           "claude-code",
+          "rapp",
           "acp-cursor",
           "acp-opencode",
           "acp-omp",

--- a/apps/server/test/services/plugins/first-party-provider-plugins.test.ts
+++ b/apps/server/test/services/plugins/first-party-provider-plugins.test.ts
@@ -340,6 +340,13 @@ describe("first-party provider plugins", () => {
           },
           composerActions: [skills],
         });
+        const rappRegistration = harness.deps.providerRegistry.get("rapp");
+        expect(
+          [
+            ...(rappRegistration?.envPassthrough ?? []),
+            ...Object.keys(rappRegistration?.bridgeOptions ?? {}),
+          ].filter((key) => /COPILOT|GITHUB_TOKEN|GH_TOKEN/iu.test(key)),
+        ).toEqual([]);
         expect(clientFields("acp-cursor")).toStrictEqual({
           id: "acp-cursor",
           displayName: "Cursor",

--- a/apps/server/test/system/execution-options.test.ts
+++ b/apps/server/test/system/execution-options.test.ts
@@ -1238,7 +1238,7 @@ describe("resolveSystemExecutionOptions", () => {
         registry.markRegistrationsSettled();
 
         expect((await providersPromise).map((provider) => provider.id)).toEqual(
-          ["codex", "claude-code", "pi", "acp-cursor"],
+          ["codex", "claude-code", "pi", "rapp", "acp-cursor"],
         );
       },
     );

--- a/apps/server/test/system/provider-states.test.ts
+++ b/apps/server/test/system/provider-states.test.ts
@@ -45,7 +45,7 @@ describe("getProviderStates", () => {
   it("asks each provider bridge and preserves model-picker order", async () => {
     await withTestHarness(async (harness) => {
       const { host, session } = seedHostSession(harness.deps);
-      registerHostRpcResponder(harness, {
+      const responder = registerHostRpcResponder(harness, {
         hostId: host.id,
         sessionId: session.id,
         handle: (request) => {
@@ -73,6 +73,7 @@ describe("getProviderStates", () => {
         "codex",
         "claude-code",
         "pi",
+        "rapp",
         "acp-cursor",
         "acp-opencode",
       ]);
@@ -80,6 +81,19 @@ describe("getProviderStates", () => {
         providerId: "codex",
         status: "ready",
       });
+      expect(
+        result.providers.find((provider) => provider.providerId === "rapp"),
+      ).toMatchObject({
+        status: "unknown",
+        statusMessage: "This provider does not report readiness.",
+      });
+      expect(
+        responder.requests.some(
+          (request) =>
+            request.command.type === "provider.health" &&
+            request.command.providerId === "rapp",
+        ),
+      ).toBe(false);
     });
   });
 

--- a/apps/server/test/threads/thread-default-policy.test.ts
+++ b/apps/server/test/threads/thread-default-policy.test.ts
@@ -5,6 +5,7 @@ import {
 } from "@bb/domain";
 import { describe, expect, it } from "vitest";
 import {
+  buildProviderThreadExecutionDefaults,
   resolveCreateThreadEnvironment,
   resolveCreateThreadExecutionDefaults,
   resolveThreadDefaultPermissionMode,
@@ -85,6 +86,20 @@ describe("resolveCreateThreadExecutionDefaults", () => {
     });
   });
 
+  it("uses a reasoning level supported by the selected provider", () => {
+    expect(
+      buildProviderThreadExecutionDefaults(registry, {
+        providerId: "rapp",
+        model: "claude-opus-5",
+      }),
+    ).toMatchObject({
+      providerId: "rapp",
+      model: "claude-opus-5",
+      reasoningLevel: "none",
+      permissionMode: "full",
+    });
+  });
+
   it("honors the user's default provider and picker order", async () => {
     const preferences = {
       providerOrder: ["pi", "claude-code"],
@@ -99,6 +114,7 @@ describe("resolveCreateThreadExecutionDefaults", () => {
       "pi",
       "claude-code",
       "codex",
+      "rapp",
       "acp-cursor",
       "acp-opencode",
       "acp-omp",

--- a/apps/server/test/threads/thread-runtime-config.test.ts
+++ b/apps/server/test/threads/thread-runtime-config.test.ts
@@ -843,7 +843,9 @@ describe("thread runtime config", () => {
         projectId: project.id,
       });
 
-      async function build(providerId: "codex" | "claude-code" | "pi") {
+      async function build(
+        providerId: "codex" | "claude-code" | "pi" | "rapp",
+      ) {
         const thread = seedThread(harness.deps, {
           projectId: project.id,
           environmentId: environment.id,
@@ -857,7 +859,12 @@ describe("thread runtime config", () => {
                 ? "gpt-5"
                 : providerId === "pi"
                   ? "pi-model"
-                  : "claude-sonnet-4-6",
+                  : providerId === "rapp"
+                    ? "brainstem"
+                    : "claude-sonnet-4-6",
+            ...(providerId === "rapp"
+              ? { reasoningLevel: "none" as const }
+              : {}),
             source: "client/turn/requested",
           },
         });
@@ -894,6 +901,15 @@ describe("thread runtime config", () => {
 
       const pi = await build("pi");
       expect(pi.options.providerOptions).toEqual({});
+
+      const rapp = await build("rapp");
+      expect(rapp.bridgeLaunch.providerOptions).toEqual({
+        endpoint: "",
+        grail: "consumer",
+      });
+      expect(rapp.options.providerOptions).toEqual({
+        model: "brainstem",
+      });
     });
   });
 

--- a/apps/server/test/threads/thread-runtime-config.test.ts
+++ b/apps/server/test/threads/thread-runtime-config.test.ts
@@ -860,7 +860,7 @@ describe("thread runtime config", () => {
                 : providerId === "pi"
                   ? "pi-model"
                   : providerId === "rapp"
-                    ? "brainstem"
+                    ? "claude-sonnet-5"
                     : "claude-sonnet-4-6",
             ...(providerId === "rapp"
               ? { reasoningLevel: "none" as const }
@@ -908,8 +908,14 @@ describe("thread runtime config", () => {
         grail: "consumer",
       });
       expect(rapp.options.providerOptions).toEqual({
-        model: "brainstem",
+        model: "claude-sonnet-5",
       });
+      expect(
+        [
+          ...Object.keys(rapp.bridgeLaunch.providerOptions),
+          ...Object.keys(rapp.options.providerOptions),
+        ].filter((key) => /COPILOT|GITHUB_TOKEN|GH_TOKEN/iu.test(key)),
+      ).toEqual([]);
     });
   });
 

--- a/docs/api_to_audit.md
+++ b/docs/api_to_audit.md
@@ -442,7 +442,7 @@ plugin is owed when the spec grows a field.
 
 ## `PluginProviderDeclaration.experimental_nativeSkillRoots`
 
-**Kept experimental (2026-08-22).** every first-party provider declares it now (stabilization S5 moved the daemon's per-provider scan table here), but no third-party agent has validated the relative-path / 32-root rule or the per-root options, and the split between a global declaration and the per-workspace resolver (`experimental_resolvesNativeRoots`) is one release old.
+**Kept experimental (2026-08-22).** every first-party provider that exposes native skills declares it now (stabilization S5 moved the daemon's per-provider scan table here); RAPP intentionally has no native roots because its agents live behind Brainstem. No third-party agent has validated the relative-path / 32-root rule or the per-root options, and the split between a global declaration and the per-workspace resolver (`experimental_resolvesNativeRoots`) is one release old.
 
 **What it does.** Names the directories a provider's own agent reads skills
 from, relative to the target host's home directory (`user`) or to the
@@ -1070,7 +1070,7 @@ Before stabilization, audit:
 
 ## `bb.providers.register` (`experimental_bridgeOptions`, `experimental_visibility`, and the `experimental_providerBridge` artifact export)
 
-**Kept experimental (2026-08-22).** `bb.providers.register` and the declaration's target-state fields are stable. `experimental_bridgeOptions` and `experimental_visibility` have one consumer (the ACP plugin); docs/provider-plugin-api.md §1 lists both under "Still experimental on the declaration" — decide whether static options survive beside `deriveProviderOptions` before naming them. The `experimental_providerBridge` export name is an artifact contract read by the daemon bootstrap from every installed plugin; renaming it needs a dual-name acceptance window plus a protocol bump, so it stabilizes with the bridge kit once that deprecation policy exists.
+**Kept experimental (2026-08-22).** `bb.providers.register` and the declaration's target-state fields are stable. `experimental_visibility` has one consumer (the ACP plugin), while `experimental_bridgeOptions` has two (ACP and RAPP); docs/provider-plugin-api.md §1 lists both under "Still experimental on the declaration" — decide whether static options survive beside `deriveProviderOptions` before naming them. The `experimental_providerBridge` export name is an artifact contract read by the daemon bootstrap from every installed plugin; renaming it needs a dual-name acceptance window plus a protocol bump, so it stabilizes with the bridge kit once that deprecation policy exists.
 
 **What it does.** Lets a plugin declare an agent provider into the server's
 `ProviderRegistryService`. The declaration owns static metadata and opaque
@@ -1305,9 +1305,12 @@ protocol`'s `assembler`, `conformance`, and `testing` subpaths.
    first-party bridges needed (`env`, `rewriteRuntimeLine`, `prepareState`)
    and `ReplayDialect` is the three protocols the replay child speaks
    (`json-rpc`, `claude-cli`, `pi-rpc`). A third-party bridge whose CLI
-   speaks none of them cannot replay its provider lanes. Decide whether the
-   dialect set grows, or whether the child becomes pluggable, before the
-   profile is a promise.
+   speaks none of them cannot replay its provider lanes. RAPP is the concrete
+   first-party exception: its provider transport is HTTP, so its deterministic
+   local-endpoint conformance suite is inventoried as conformance-only instead
+   of pretending it has a replay-child dialect. Decide whether the dialect set
+   grows, or whether the child becomes pluggable, before the profile is a
+   promise.
 4. **Two shipped programs.** The kit's bundle spawns `provider-bridge-worker-entry.mjs`
    and `replay-provider-child.mjs` from beside itself (`import.meta.url`),
    so the published package carries both under `dist/`. Confirm the bundled
@@ -1440,7 +1443,7 @@ wholesale with the rest of the plugin's slot set, so disable/uninstall/failed
 reload falls back to `logoUrl`, then the declared glyph, then the generic
 glyph. No provider bb ships uses it: each declares an SVG asset and the mask
 rendering keeps it theme-aware with no frontend bundle (an icon-only bundle
-cost four JS+CSS fetches and four icon remounts at every boot).
+cost five JS+CSS fetches and five icon remounts at every boot).
 
 **Audit before stabilizing.**
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -299,6 +299,14 @@ environment but does not inherit the five RAPP routing and credential
 variables above.
 RAPP threads are saved as canonical `rapp/1` session eggs so they remain
 resumable after a host-daemon restart.
+Each egg keeps the complete transcript and is subject to RAPP/1's 1 MiB
+canonical limit. bb caps endpoint responses at 64 KiB and checks before
+`/chat` that a maximum-size response can still be committed; once capacity is
+exhausted, continue in a new thread. Successful responses are journaled before
+thread delivery. If an older Brainstem may have completed a request without
+honoring its `idempotency_key`, bb retains the uncertain request for audit and
+does not replay it automatically; continue in a new thread to avoid duplicate
+agent actions.
 
 Outside an open typeahead menu, Shift+Enter inserts a newline. On
 coarse-pointer touch devices, the software-keyboard Return path inserts a

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -263,13 +263,14 @@ Copilot model catalog, and defaults to `http://127.0.0.1:7071/chat`. Select a
 discovered model id or use `brainstem` to follow the Brainstem's current
 GitHub Copilot default. bb reuses a healthy shared Brainstem or starts the
 installed `~/.brainstem` runtime, and stops only a process it owns. Automatic
-startup applies only to a plain HTTP loopback endpoint with the exact `/chat`
-path and no URL credentials, query, or fragment; any other endpoint must
-already be running. Override the endpoint with
+startup applies only to a plain HTTP `localhost` or `127.0.0.1` endpoint with
+the exact `/chat` path; any other endpoint must already be running. Override
+the endpoint with
 `bb plugin config provider-rapp set endpoint <url>` or
 `RAPP_BRAINSTEM_URL`. Set `RAPP_BRAINSTEM_SECRET` when a LAN Brainstem
-requires `X-Brainstem-Secret`; credential-bearing non-loopback endpoints must
-use HTTPS. Business mode adapts
+requires `X-Brainstem-Secret`. Endpoint URLs may not contain credentials,
+query parameters, or fragments; header credentials require HTTPS outside
+loopback. Business mode adapts
 `microsoft/aibast-agents-library` and exposes the fixed `business-grail`
 model:
 
@@ -282,6 +283,7 @@ bb plugin config provider-rapp set endpoint \
 `RAPP_BUSINESS_URL` can supply that endpoint instead. The host daemon reads the
 Azure Function key from `RAPP_FUNCTION_KEY` and sends it as
 `x-functions-key`; do not put it in the endpoint URL or a plugin setting.
+Business endpoint URLs also may not contain query parameters or fragments.
 `RAPP_USER_GUID` optionally selects the Business Grail's persistent user
 memory. Store host credentials and identifiers through the launcher:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -257,6 +257,47 @@ its bake period and applies on the next start, resume, or turn command. Read and
 set provider options like any plugin setting, for example
 `bb plugin config provider-claude-code set idleQueryReleaseEnabled true`.
 
+The bundled `rapp` provider speaks only the `rapp/1` protocol. Consumer mode
+uses `kody-w/rapp-installer`, discovers the Brainstem's verified GitHub
+Copilot model catalog, and defaults to `http://127.0.0.1:7071/chat`. Select a
+discovered model id or use `brainstem` to follow the Brainstem's current
+GitHub Copilot default. bb reuses a healthy shared Brainstem or starts the
+installed `~/.brainstem` runtime, and stops only a process it owns. Automatic
+startup applies only to a plain HTTP loopback endpoint with the exact `/chat`
+path and no URL credentials, query, or fragment; any other endpoint must
+already be running. Override the endpoint with
+`bb plugin config provider-rapp set endpoint <url>` or
+`RAPP_BRAINSTEM_URL`. Set `RAPP_BRAINSTEM_SECRET` when a LAN Brainstem
+requires `X-Brainstem-Secret`; credential-bearing non-loopback endpoints must
+use HTTPS. Business mode adapts
+`microsoft/aibast-agents-library` and exposes the fixed `business-grail`
+model:
+
+```bash
+bb plugin config provider-rapp set grail business
+bb plugin config provider-rapp set endpoint \
+  https://YOUR_APP.azurewebsites.net/api/businessinsightbot_function
+```
+
+`RAPP_BUSINESS_URL` can supply that endpoint instead. The host daemon reads the
+Azure Function key from `RAPP_FUNCTION_KEY` and sends it as
+`x-functions-key`; do not put it in the endpoint URL or a plugin setting.
+`RAPP_USER_GUID` optionally selects the Business Grail's persistent user
+memory. Store host credentials and identifiers through the launcher:
+
+```bash
+npx bb-app env set RAPP_BRAINSTEM_SECRET <secret>
+npx bb-app env set RAPP_FUNCTION_KEY <function-key>
+npx bb-app env set RAPP_USER_GUID <user-guid>
+```
+
+The `grail` and `endpoint` plugin settings are non-secret routing choices.
+An auto-launched local Brainstem keeps the ordinary host and GitHub Copilot
+environment but does not inherit the five RAPP routing and credential
+variables above.
+RAPP threads are saved as canonical `rapp/1` session eggs so they remain
+resumable after a host-daemon restart.
+
 Outside an open typeahead menu, Shift+Enter inserts a newline. On
 coarse-pointer touch devices, the software-keyboard Return path inserts a
 newline and the submit button sends.
@@ -446,6 +487,10 @@ edit the JSON, then run `npx bb-app config refresh` or restart bb. `bb-app confi
 such as `acp-opencode`, or a custom ACP agent's derived `acp-<id>`. `displayName` is
 optional; bb derives the label from the model id when it is omitted. bb skips
 an invalid entry with a warning and keeps the rest of the config.
+
+The `rapp` provider is intentionally not accepted here. Its Consumer
+Brainstem publishes an authoritative dynamic GitHub Copilot catalog, and its
+Business Grail publishes its fixed model through the provider plugin.
 
 Each entry appears in `bb provider models <providerId>` and in the model
 picker after the provider's own catalog. The provider catalog wins on a model

--- a/docs/provider-bridge-protocol.md
+++ b/docs/provider-bridge-protocol.md
@@ -602,6 +602,9 @@ The conformance kit runs the same recordings as its recorded-traffic
 scenario set: `checkRecordedCellReplay` replays a bridge's cells and
 `checkRecordedCellReplay` reports `recorded/<cell>/{replays,
 events-schema-valid, grammar, turn-lifecycle, not-empty}` per cell. Each
-first-party bridge has a `bridge.recorded-conformance.test.ts` beside its
-scripted suite, so conformance reflects the real dialect as well as the
-protocol.
+first-party child-process bridge has a
+`bridge.recorded-conformance.test.ts` beside its scripted suite, so
+conformance reflects the real dialect as well as the protocol. RAPP is the
+explicit conformance-only exception: its provider transport is HTTP rather
+than one of the replay child's stdio dialects, and its bridge suite runs the
+public conformance kit against a deterministic local endpoint.

--- a/docs/provider-plugin-api.md
+++ b/docs/provider-plugin-api.md
@@ -8,10 +8,11 @@ Members that still carry the `experimental_` prefix are named with it here;
 each has an entry in [api_to_audit.md](api_to_audit.md) saying why.
 
 A "provider" is a coding agent BB can run a thread on (Claude Code, Codex, Pi,
-ACP agents such as Cursor or Amp). The design goal is that **everything a
-provider touches is owned by its plugin** — translating the agent's native
-output into BB's data model, projecting that data onto the timeline, and how
-its tools are represented — with the smallest possible provider-agnostic core.
+RAPP Brainstem backed by GitHub Copilot, or ACP agents such as Cursor or Amp).
+The design goal is that **everything a provider touches is owned by its
+plugin** — translating the agent's native output into BB's data model,
+projecting that data onto the timeline, and how its tools are represented —
+with the smallest possible provider-agnostic core.
 
 ## Principles
 
@@ -125,6 +126,11 @@ Rules:
   is plugin install order. First-party plugins install first at bootstrap.
 - Third-party ACP agents (for example Amp) register the same way, with a
   bridge built from the published ACP kit.
+- Provider credentials stay in the provider's native authentication store or
+  host-local environment variables declared through `env.passthrough`.
+  `ctx.settings` omits secret plugin settings, and neither
+  `experimental_bridgeOptions` nor derived `providerOptions` should carry
+  credentials or secret-bearing endpoint URLs.
 
 ## 2. Bridge (plugin `bb.host` artifact, runs on the host)
 

--- a/docs/repository-overview.md
+++ b/docs/repository-overview.md
@@ -2,26 +2,48 @@
 
 This monorepo contains the packaged app plus the runtime services it bundles:
 
-| Package or app                                                      | Role                                                                                                |
-| ------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| [`packages/bb-app`](../packages/bb-app)                             | Published npm package, `npx bb-app@latest` launcher, bundled `bb` CLI entry, and public SDK export. |
-| [`apps/desktop`](../apps/desktop)                                   | macOS/Linux Electron shell that supervises the packaged runtime and loads the bb web UI.            |
-| [`apps/app`](../apps/app)                                           | Web UI for inspecting projects, threads, environments, and running work.                            |
-| [`apps/mobile`](../apps/mobile)                                     | Native phone client (Expo; iOS first, Android next) for a bb server over Direct URLs or bb connect. |
-| [`apps/server`](../apps/server)                                     | HTTP API, WebSocket notifications, state management, and server-owned product policy.               |
-| [`apps/host-daemon`](../apps/host-daemon)                           | Host-local runtime that provisions workspaces and runs provider processes.                          |
-| [`apps/cli`](../apps/cli)                                           | Scriptable `bb` CLI for users and agents.                                                           |
-| [`apps/web`](../apps/web)                                           | getbb.app site: marketing page + bb connect auth/dashboard (TanStack Start on Cloudflare Workers).  |
-| [`packages/sdk`](../packages/sdk)                                   | TypeScript SDK used by the CLI, package SDK export, and programmatic clients.                       |
-| [`packages/agent-runtime`](../packages/agent-runtime)               | Provider runtime adapters and bridges for Codex, Claude Code, Pi, and ACP agents.                   |
-| [`packages/config`](../packages/config)                             | Config parsing, defaults, managed package config schema, and environment variable definitions.      |
-| [`packages/db`](../packages/db)                                     | SQLite schema, migrations, and data access helpers.                                                 |
-| [`packages/server-contract`](../packages/server-contract)           | HTTP and WebSocket contract between clients and the server.                                         |
-| [`packages/host-daemon-contract`](../packages/host-daemon-contract) | Command/event contract between the server and host daemons.                                         |
+| Package or app                                                      | Role                                                                                                                            |
+| ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| [`packages/bb-app`](../packages/bb-app)                             | Published npm package, `npx bb-app@latest` launcher, bundled `bb` CLI entry, and public SDK export.                             |
+| [`apps/desktop`](../apps/desktop)                                   | macOS/Linux Electron shell that supervises the packaged runtime and loads the bb web UI.                                        |
+| [`apps/app`](../apps/app)                                           | Web UI for inspecting projects, threads, environments, and running work.                                                        |
+| [`apps/mobile`](../apps/mobile)                                     | Native phone client (Expo; iOS first, Android next) for a bb server over Direct URLs or bb connect.                             |
+| [`apps/server`](../apps/server)                                     | HTTP API, WebSocket notifications, state management, and server-owned product policy.                                           |
+| [`apps/host-daemon`](../apps/host-daemon)                           | Host-local runtime that provisions workspaces and runs provider processes.                                                      |
+| [`apps/cli`](../apps/cli)                                           | Scriptable `bb` CLI for users and agents.                                                                                       |
+| [`apps/web`](../apps/web)                                           | getbb.app site: marketing page + bb connect auth/dashboard (TanStack Start on Cloudflare Workers).                              |
+| [`packages/sdk`](../packages/sdk)                                   | TypeScript SDK used by the CLI, package SDK export, and programmatic clients.                                                   |
+| [`packages/agent-runtime`](../packages/agent-runtime)               | Provider-agnostic runtime that launches plugin-supplied bridges and normalizes their events.                                    |
+| [`packages/config`](../packages/config)                             | Config parsing, defaults, managed package config schema, and environment variable definitions.                                  |
+| [`packages/db`](../packages/db)                                     | SQLite schema, migrations, and data access helpers.                                                                             |
+| [`packages/server-contract`](../packages/server-contract)           | HTTP and WebSocket contract between clients and the server.                                                                     |
+| [`packages/host-daemon-contract`](../packages/host-daemon-contract) | Command/event contract between the server and host daemons.                                                                     |
+| [`plugins`](../plugins)                                             | First-party plugins, including provider bridges for Codex, Claude Code, Pi, RAPP Brainstem with GitHub Copilot, and ACP agents. |
 
 `bb-app` also exposes a Node scripting SDK:
 `import { BBSdk } from "bb-app"`. See
 [`packages/bb-app`](../packages/bb-app/README.md#scripting-with-the-sdk).
+
+```ts
+import { BBSdk } from "bb-app";
+
+const bb = new BBSdk();
+const catalog = await bb.providers.models({ providerId: "my-provider" });
+const thread = await bb.threads.spawn({
+  projectId: "proj_example",
+  environment: { type: "project-default" },
+  providerId: "my-provider",
+  model: "my-model",
+  prompt: "Review the current changes.",
+});
+const settings = await bb.plugins.getSettings({ pluginId: "my-plugin" });
+await bb.plugins.updateSettings({
+  pluginId: "my-plugin",
+  values: { mode: "fast" },
+});
+
+console.log(catalog.models, thread.id, settings);
+```
 
 ## Pinned Dependencies
 

--- a/packages/agent-runtime/src/integration.rapp-artifact.test.ts
+++ b/packages/agent-runtime/src/integration.rapp-artifact.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import {
+  cleanup,
+  createTestRuntime,
+} from "./test/runtime-integration-harness.js";
+
+describe("RAPP provider artifact", () => {
+  it("lists the deterministic Business Grail model without a live Brainstem", async () => {
+    const ctx = createTestRuntime("rapp");
+    try {
+      await expect(
+        ctx.runtime.listModels({ providerId: "rapp" }),
+      ).resolves.toMatchObject({
+        models: [
+          {
+            id: "business-grail",
+            isDefault: true,
+            model: "business-grail",
+          },
+        ],
+      });
+    } finally {
+      await ctx.runtime.shutdown();
+      cleanup(ctx);
+    }
+  });
+});

--- a/packages/agent-runtime/src/integration.rapp-artifact.test.ts
+++ b/packages/agent-runtime/src/integration.rapp-artifact.test.ts
@@ -1,24 +1,40 @@
+import { readFile } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 import {
   cleanup,
   createTestRuntime,
 } from "./test/runtime-integration-harness.js";
+import {
+  INTEGRATION_RAPP_MODEL_IDS,
+  INTEGRATION_RAPP_MODEL_REQUEST_PATH,
+} from "./test/integration-provider-bridges.js";
 
 describe("RAPP provider artifact", () => {
-  it("lists the deterministic Business Grail model without a live Brainstem", async () => {
+  it("loads the deterministic Consumer catalog from the fake Brainstem", async () => {
     const ctx = createTestRuntime("rapp");
     try {
-      await expect(
-        ctx.runtime.listModels({ providerId: "rapp" }),
-      ).resolves.toMatchObject({
-        models: [
-          {
-            id: "business-grail",
-            isDefault: true,
-            model: "business-grail",
-          },
-        ],
-      });
+      const result = await ctx.runtime.listModels({ providerId: "rapp" });
+      expect(
+        result.models.map((model) => ({
+          id: model.id,
+          isDefault: model.isDefault,
+        })),
+      ).toEqual([
+        { id: INTEGRATION_RAPP_MODEL_IDS[0], isDefault: true },
+        { id: INTEGRATION_RAPP_MODEL_IDS[1], isDefault: false },
+      ]);
+      expect(
+        result.selectedOnlyModels.map((model) => ({
+          id: model.id,
+          isDefault: model.isDefault,
+        })),
+      ).toEqual([{ id: "brainstem", isDefault: false }]);
+      expect(
+        Number.parseInt(
+          await readFile(INTEGRATION_RAPP_MODEL_REQUEST_PATH, "utf8"),
+          10,
+        ),
+      ).toBeGreaterThan(0);
     } finally {
       await ctx.runtime.shutdown();
       cleanup(ctx);

--- a/packages/agent-runtime/src/test/integration-global-setup.ts
+++ b/packages/agent-runtime/src/test/integration-global-setup.ts
@@ -7,6 +7,7 @@ import type { NormalizedPluginProviderDeclaration } from "@get-bb/plugin-sdk/int
 import {
   captureFirstPartyProviderDeclarations,
   firstPartyPluginRootDir,
+  type CaptureFirstPartyProviderDeclarationsOptions,
 } from "./first-party-provider-declarations.js";
 import {
   INTEGRATION_PROVIDER_BRIDGE_MANIFEST_PATH,
@@ -18,7 +19,35 @@ const PROVIDER_BRIDGE_PLUGIN_IDS = [
   "provider-claude-code",
   "provider-acp",
   "provider-pi",
+  "provider-rapp",
 ] as const;
+
+function declarationSettings(
+  pluginId: string,
+): CaptureFirstPartyProviderDeclarationsOptions {
+  return pluginId === "provider-rapp"
+    ? { settings: { endpoint: "", grail: "business" } }
+    : {};
+}
+
+function integrationProviderOptions(
+  pluginId: string,
+  declaration: NormalizedPluginProviderDeclaration,
+): IntegrationProviderBridgeManifest[string]["providerOptions"] {
+  const bridgeOptions = declaration.experimental_bridgeOptions ?? {};
+  if (pluginId !== "provider-rapp") {
+    return bridgeOptions;
+  }
+  const defaultModel = (declaration.models.fallback ?? []).find(
+    (model) => model.isDefault,
+  );
+  if (defaultModel === undefined) {
+    throw new Error(
+      "provider-rapp integration declaration has no default model",
+    );
+  }
+  return { ...bridgeOptions, model: defaultModel.id };
+}
 
 function wireCapabilities(
   declaration: NormalizedPluginProviderDeclaration,
@@ -43,7 +72,10 @@ export async function setup(): Promise<void> {
   for (const pluginId of PROVIDER_BRIDGE_PLUGIN_IDS) {
     const rootDir = firstPartyPluginRootDir(pluginId);
     const [declarations, build] = await Promise.all([
-      captureFirstPartyProviderDeclarations(pluginId),
+      captureFirstPartyProviderDeclarations(
+        pluginId,
+        declarationSettings(pluginId),
+      ),
       buildPluginHost(rootDir, "0.0.0-integration", toolchain),
     ]);
     const dataDir = await ensurePluginProcessDataDir({
@@ -60,7 +92,7 @@ export async function setup(): Promise<void> {
           digest: build.artifactDigest,
           artifactPath: build.jsPath,
         },
-        providerOptions: declaration.experimental_bridgeOptions ?? {},
+        providerOptions: integrationProviderOptions(pluginId, declaration),
         envPassthrough: [...(declaration.env?.passthrough ?? [])],
         capabilities: wireCapabilities(declaration),
       };

--- a/packages/agent-runtime/src/test/integration-global-setup.ts
+++ b/packages/agent-runtime/src/test/integration-global-setup.ts
@@ -1,4 +1,10 @@
-import { writeFile } from "node:fs/promises";
+import {
+  createServer,
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from "node:http";
+import { rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { buildPluginHost, resolvePluginBuildToolchain } from "@bb/plugin-build";
@@ -11,6 +17,8 @@ import {
 } from "./first-party-provider-declarations.js";
 import {
   INTEGRATION_PROVIDER_BRIDGE_MANIFEST_PATH,
+  INTEGRATION_RAPP_MODEL_IDS,
+  INTEGRATION_RAPP_MODEL_REQUEST_PATH,
   type IntegrationProviderBridgeManifest,
 } from "./integration-provider-bridges.js";
 
@@ -22,11 +30,101 @@ const PROVIDER_BRIDGE_PLUGIN_IDS = [
   "provider-rapp",
 ] as const;
 
+let rappBrainstemServer: Server | null = null;
+let rappModelRequestCount = 0;
+
+function sendJson(response: ServerResponse, value: unknown): void {
+  response.statusCode = 200;
+  response.setHeader("content-type", "application/json");
+  response.end(JSON.stringify(value));
+}
+
+async function handleRappBrainstemRequest(
+  request: IncomingMessage,
+  response: ServerResponse,
+): Promise<void> {
+  if (request.method === "GET" && request.url === "/health") {
+    sendJson(response, { status: "ok", version: "integration", agents: [] });
+    return;
+  }
+  if (request.method === "GET" && request.url === "/models") {
+    rappModelRequestCount += 1;
+    await writeFile(
+      INTEGRATION_RAPP_MODEL_REQUEST_PATH,
+      String(rappModelRequestCount),
+    );
+    sendJson(response, {
+      current: INTEGRATION_RAPP_MODEL_IDS[0],
+      models: [
+        {
+          id: INTEGRATION_RAPP_MODEL_IDS[0],
+          name: "Claude Sonnet 5",
+          available: true,
+        },
+        {
+          id: INTEGRATION_RAPP_MODEL_IDS[1],
+          name: "GPT-5.4",
+          available: true,
+        },
+        {
+          id: "unavailable-integration-model",
+          name: "Unavailable",
+          available: false,
+        },
+      ],
+    });
+    return;
+  }
+  response.statusCode = 404;
+  response.end();
+}
+
+async function stopRappBrainstem(): Promise<void> {
+  const server = rappBrainstemServer;
+  rappBrainstemServer = null;
+  if (server === null) {
+    return;
+  }
+  await new Promise<void>((resolvePromise, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolvePromise();
+    });
+  });
+}
+
+async function startRappBrainstem(): Promise<string> {
+  await stopRappBrainstem();
+  rappModelRequestCount = 0;
+  await rm(INTEGRATION_RAPP_MODEL_REQUEST_PATH, { force: true });
+  const server = createServer((request, response) => {
+    void handleRappBrainstemRequest(request, response).catch((error) => {
+      response.statusCode = 500;
+      response.end(error instanceof Error ? error.message : String(error));
+    });
+  });
+  rappBrainstemServer = server;
+  await new Promise<void>((resolvePromise, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolvePromise);
+  });
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    await stopRappBrainstem();
+    throw new Error("RAPP integration Brainstem has no TCP address");
+  }
+  return `http://127.0.0.1:${address.port}/chat`;
+}
+
 function declarationSettings(
   pluginId: string,
+  rappEndpoint: string,
 ): CaptureFirstPartyProviderDeclarationsOptions {
   return pluginId === "provider-rapp"
-    ? { settings: { endpoint: "", grail: "business" } }
+    ? { settings: { endpoint: rappEndpoint, grail: "consumer" } }
     : {};
 }
 
@@ -64,42 +162,53 @@ function wireCapabilities(
 }
 
 export async function setup(): Promise<void> {
+  const rappEndpoint = await startRappBrainstem();
   const bridgeDataRoot = join(tmpdir(), "bb-agent-runtime-integration-daemon");
   const toolchain = await resolvePluginBuildToolchain(
     join(tmpdir(), "bb-plugin-build-toolchain"),
   );
   const manifest: IntegrationProviderBridgeManifest = {};
-  for (const pluginId of PROVIDER_BRIDGE_PLUGIN_IDS) {
-    const rootDir = firstPartyPluginRootDir(pluginId);
-    const [declarations, build] = await Promise.all([
-      captureFirstPartyProviderDeclarations(
+  try {
+    for (const pluginId of PROVIDER_BRIDGE_PLUGIN_IDS) {
+      const rootDir = firstPartyPluginRootDir(pluginId);
+      const [declarations, build] = await Promise.all([
+        captureFirstPartyProviderDeclarations(
+          pluginId,
+          declarationSettings(pluginId, rappEndpoint),
+        ),
+        buildPluginHost(rootDir, "0.0.0-integration", toolchain),
+      ]);
+      const dataDir = await ensurePluginProcessDataDir({
+        daemonDataDir: bridgeDataRoot,
         pluginId,
-        declarationSettings(pluginId),
-      ),
-      buildPluginHost(rootDir, "0.0.0-integration", toolchain),
-    ]);
-    const dataDir = await ensurePluginProcessDataDir({
-      daemonDataDir: bridgeDataRoot,
-      pluginId,
-      kind: "bridge-data",
-    });
-    for (const declaration of declarations) {
-      manifest[declaration.id] = {
-        pluginId,
-        dataDir,
-        source: {
-          kind: "artifact",
-          digest: build.artifactDigest,
-          artifactPath: build.jsPath,
-        },
-        providerOptions: integrationProviderOptions(pluginId, declaration),
-        envPassthrough: [...(declaration.env?.passthrough ?? [])],
-        capabilities: wireCapabilities(declaration),
-      };
+        kind: "bridge-data",
+      });
+      for (const declaration of declarations) {
+        manifest[declaration.id] = {
+          pluginId,
+          dataDir,
+          source: {
+            kind: "artifact",
+            digest: build.artifactDigest,
+            artifactPath: build.jsPath,
+          },
+          providerOptions: integrationProviderOptions(pluginId, declaration),
+          envPassthrough: [...(declaration.env?.passthrough ?? [])],
+          capabilities: wireCapabilities(declaration),
+        };
+      }
     }
+    await writeFile(
+      INTEGRATION_PROVIDER_BRIDGE_MANIFEST_PATH,
+      JSON.stringify(manifest, null, 2),
+    );
+  } catch (error) {
+    await stopRappBrainstem();
+    throw error;
   }
-  await writeFile(
-    INTEGRATION_PROVIDER_BRIDGE_MANIFEST_PATH,
-    JSON.stringify(manifest, null, 2),
-  );
+}
+
+export async function teardown(): Promise<void> {
+  await stopRappBrainstem();
+  await rm(INTEGRATION_RAPP_MODEL_REQUEST_PATH, { force: true });
 }

--- a/packages/agent-runtime/src/test/integration-provider-bridges.ts
+++ b/packages/agent-runtime/src/test/integration-provider-bridges.ts
@@ -14,6 +14,16 @@ export const INTEGRATION_PROVIDER_BRIDGE_MANIFEST_PATH = join(
   "bb-agent-runtime-integration-provider-bridges.json",
 );
 
+export const INTEGRATION_RAPP_MODEL_REQUEST_PATH = join(
+  tmpdir(),
+  "bb-agent-runtime-integration-rapp-model-request.txt",
+);
+
+export const INTEGRATION_RAPP_MODEL_IDS = [
+  "claude-sonnet-5",
+  "gpt-5.4",
+] as const;
+
 const bridgeLaunchSchema = z.object({
   pluginId: z.string(),
   dataDir: z.string(),

--- a/packages/bb-app/scripts/smoke-tarball.mjs
+++ b/packages/bb-app/scripts/smoke-tarball.mjs
@@ -30,6 +30,7 @@ const EXPECTED_RUNNING_BUILTIN_PLUGINS = [
   "provider-acp",
   "provider-claude-code",
   "provider-codex",
+  "provider-rapp",
   "push-notifications",
   "connect",
   "custom-instructions",
@@ -435,6 +436,7 @@ async function smokeBridgeModelList({
   packageDir,
   pluginId,
   label,
+  providerOptions,
 }) {
   const childProcess = spawnPackedBridge({ bridgePath, packageDir, pluginId });
   const output = collectProcessOutput(childProcess);
@@ -460,7 +462,12 @@ async function smokeBridgeModelList({
       jsonrpc: "2.0",
       id: 2,
       method: "model/list",
-      params: {},
+      params:
+        providerOptions === undefined
+          ? {}
+          : {
+              providerOptions,
+            },
     })}\n`,
   );
   const modelListResponse = await modelListResponsePromise;
@@ -533,6 +540,24 @@ async function smokeProviderBridgeBundles(packageDir) {
     packageDir,
     pluginId: "provider-pi",
     label: "Pi host-artifact bridge model/list",
+  });
+  await smokeBridgeModelList({
+    bridgePath: join(
+      packageDir,
+      "server",
+      "dist",
+      "builtin-plugins",
+      "provider-rapp",
+      "dist",
+      "host.js",
+    ),
+    packageDir,
+    pluginId: "provider-rapp",
+    providerOptions: {
+      endpoint: "",
+      grail: "business",
+    },
+    label: "RAPP host-artifact bridge model/list",
   });
   await smokeBridgeModelList({
     // ACP ships its bridge as a plugin artifact (graduation wave 5). With no

--- a/packages/bb-app/scripts/smoke-tarball.mjs
+++ b/packages/bb-app/scripts/smoke-tarball.mjs
@@ -8,7 +8,8 @@ import {
   rm,
   writeFile,
 } from "node:fs/promises";
-import { createServer } from "node:net";
+import { createServer as createHttpServer } from "node:http";
+import { createServer as createNetServer } from "node:net";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -147,7 +148,7 @@ function spawnManagedProcess({ args, command, env = {}, label }) {
 
 function reserveFreePort() {
   return new Promise((resolvePromise, reject) => {
-    const server = createServer();
+    const server = createNetServer();
     server.once("error", reject);
     server.listen(0, "127.0.0.1", () => {
       const address = server.address();
@@ -433,6 +434,8 @@ function spawnPackedBridge({ bridgePath, packageDir, pluginId }) {
 async function smokeBridgeModelList({
   allowUnavailableProvider = false,
   bridgePath,
+  expectedModelIds,
+  expectedSelectedOnlyModelIds,
   packageDir,
   pluginId,
   label,
@@ -484,7 +487,50 @@ async function smokeBridgeModelList({
     isRecord(modelListResponse.result) &&
     Array.isArray(modelListResponse.result.models)
   ) {
-    return;
+    const models = modelListResponse.result.models;
+    if (models.length === 0) {
+      throw new Error(`${label} returned an empty model catalog`);
+    }
+    for (const model of models) {
+      if (
+        !isRecord(model) ||
+        typeof model.id !== "string" ||
+        typeof model.model !== "string" ||
+        typeof model.displayName !== "string"
+      ) {
+        throw new Error(`${label} returned an invalid model`);
+      }
+    }
+    if (!models.some((model) => model.isDefault === true)) {
+      throw new Error(`${label} returned no default model`);
+    }
+    const modelIds = models.map((model) => model.id);
+    if (
+      expectedModelIds !== undefined &&
+      JSON.stringify(modelIds) !== JSON.stringify(expectedModelIds)
+    ) {
+      throw new Error(
+        `${label} returned models ${JSON.stringify(modelIds)}, expected ${JSON.stringify(expectedModelIds)}`,
+      );
+    }
+    if (expectedSelectedOnlyModelIds !== undefined) {
+      const selectedOnlyModels = modelListResponse.result.selectedOnlyModels;
+      if (!Array.isArray(selectedOnlyModels)) {
+        throw new Error(`${label} returned no selected-only model catalog`);
+      }
+      const selectedOnlyModelIds = selectedOnlyModels.map((model) =>
+        isRecord(model) ? model.id : undefined,
+      );
+      if (
+        JSON.stringify(selectedOnlyModelIds) !==
+        JSON.stringify(expectedSelectedOnlyModelIds)
+      ) {
+        throw new Error(
+          `${label} returned selected-only models ${JSON.stringify(selectedOnlyModelIds)}, expected ${JSON.stringify(expectedSelectedOnlyModelIds)}`,
+        );
+      }
+    }
+    return models;
   }
 
   const unavailableProviderMessage =
@@ -499,6 +545,66 @@ async function smokeBridgeModelList({
       `${label} did not return a model/list response\n${formatProcessOutput(output)}`,
     );
   }
+}
+
+async function startFakeRappBrainstem() {
+  let modelRequestCount = 0;
+  const server = createHttpServer((request, response) => {
+    response.setHeader("content-type", "application/json");
+    if (request.method === "GET" && request.url === "/health") {
+      response.end(
+        JSON.stringify({ status: "ok", version: "smoke", agents: [] }),
+      );
+      return;
+    }
+    if (request.method === "GET" && request.url === "/models") {
+      modelRequestCount += 1;
+      response.end(
+        JSON.stringify({
+          current: "claude-sonnet-5",
+          models: [
+            {
+              id: "claude-sonnet-5",
+              name: "Claude Sonnet 5",
+              available: true,
+            },
+            { id: "gpt-5.4", name: "GPT-5.4", available: true },
+            {
+              id: "unavailable-smoke-model",
+              name: "Unavailable",
+              available: false,
+            },
+          ],
+        }),
+      );
+      return;
+    }
+    response.statusCode = 404;
+    response.end(JSON.stringify({ error: "not found" }));
+  });
+  await new Promise((resolvePromise, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolvePromise);
+  });
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    server.close();
+    throw new Error("Fake RAPP Brainstem has no TCP address");
+  }
+  return {
+    endpoint: `http://127.0.0.1:${address.port}/chat`,
+    modelRequestCount: () => modelRequestCount,
+    close: () =>
+      new Promise((resolvePromise, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolvePromise();
+        });
+      }),
+  };
 }
 
 async function smokeProviderBridgeBundles(packageDir) {
@@ -541,24 +647,36 @@ async function smokeProviderBridgeBundles(packageDir) {
     pluginId: "provider-pi",
     label: "Pi host-artifact bridge model/list",
   });
-  await smokeBridgeModelList({
-    bridgePath: join(
+  const fakeRappBrainstem = await startFakeRappBrainstem();
+  try {
+    await smokeBridgeModelList({
+      bridgePath: join(
+        packageDir,
+        "server",
+        "dist",
+        "builtin-plugins",
+        "provider-rapp",
+        "dist",
+        "host.js",
+      ),
+      expectedModelIds: ["claude-sonnet-5", "gpt-5.4"],
+      expectedSelectedOnlyModelIds: ["brainstem"],
       packageDir,
-      "server",
-      "dist",
-      "builtin-plugins",
-      "provider-rapp",
-      "dist",
-      "host.js",
-    ),
-    packageDir,
-    pluginId: "provider-rapp",
-    providerOptions: {
-      endpoint: "",
-      grail: "business",
-    },
-    label: "RAPP host-artifact bridge model/list",
-  });
+      pluginId: "provider-rapp",
+      providerOptions: {
+        endpoint: fakeRappBrainstem.endpoint,
+        grail: "consumer",
+      },
+      label: "RAPP host-artifact bridge model/list",
+    });
+    if (fakeRappBrainstem.modelRequestCount() === 0) {
+      throw new Error(
+        "RAPP bridge did not request the Brainstem model catalog",
+      );
+    }
+  } finally {
+    await fakeRappBrainstem.close();
+  }
   await smokeBridgeModelList({
     // ACP ships its bridge as a plugin artifact (graduation wave 5). With no
     // launch spec in the provider options it serves its synthetic "Agent

--- a/packages/config/test/bb-app-managed-config.test.ts
+++ b/packages/config/test/bb-app-managed-config.test.ts
@@ -37,6 +37,14 @@ describe("bbAppManagedConfigSchema", () => {
     expect(parsed.customModels?.[1]?.displayName).toBeUndefined();
   });
 
+  it("rejects custom models for RAPP's plugin-owned catalogs", () => {
+    expect(
+      bbAppManagedConfigSchema.safeParse({
+        customModels: [{ providerId: "rapp", model: "brainstem" }],
+      }).success,
+    ).toBe(false);
+  });
+
   it("parses custom models with dynamic ACP provider ids", () => {
     const parsed = bbAppManagedConfigSchema.parse({
       customModels: [

--- a/packages/config/test/bb-app-managed-config.test.ts
+++ b/packages/config/test/bb-app-managed-config.test.ts
@@ -37,12 +37,30 @@ describe("bbAppManagedConfigSchema", () => {
     expect(parsed.customModels?.[1]?.displayName).toBeUndefined();
   });
 
-  it("rejects custom models for RAPP's plugin-owned catalogs", () => {
-    expect(
-      bbAppManagedConfigSchema.safeParse({
-        customModels: [{ providerId: "rapp", model: "brainstem" }],
-      }).success,
-    ).toBe(false);
+  it("drops RAPP custom models at the parsed config boundary", () => {
+    const warnings: Record<string, unknown>[] = [];
+    const parsed = parseBbAppManagedConfig(
+      {
+        customModels: [
+          { providerId: "claude-code", model: "claude-example-preview" },
+          { providerId: "rapp", model: "brainstem" },
+          { providerId: "acp-my-agent", model: "provider/model" },
+        ],
+      },
+      {
+        logger: {
+          warn(fields): void {
+            warnings.push(fields);
+          },
+        },
+      },
+    );
+
+    expect(parsed.customModels).toEqual([
+      { providerId: "claude-code", model: "claude-example-preview" },
+      { providerId: "acp-my-agent", model: "provider/model" },
+    ]);
+    expect(warnings.map((warning) => warning.index)).toEqual([1]);
   });
 
   it("parses custom models with dynamic ACP provider ids", () => {

--- a/packages/plugin-api-map/src/plugin-icons.ts
+++ b/packages/plugin-api-map/src/plugin-icons.ts
@@ -53,6 +53,7 @@ const FIRST_PARTY_PLUGINS: Record<string, FirstPartyPlugin> = {
   "Claude Code provider": { id: "provider-claude-code", icon: SparklesIcon },
   "Codex provider": { id: "provider-codex", icon: SparklesIcon },
   "Pi provider": { id: "provider-pi", icon: SparklesIcon },
+  "RAPP provider": { id: "provider-rapp", icon: BrainIcon },
 };
 
 export function pluginIcon(displayName: string): IconSvgElement | null {

--- a/packages/plugin-api-map/src/surfaces.ts
+++ b/packages/plugin-api-map/src/surfaces.ts
@@ -380,6 +380,7 @@ export const SURFACE_GROUPS: SurfaceGroup[] = [
           "Claude Code provider",
           "Codex provider",
           "Pi provider",
+          "RAPP provider",
         ],
         experimental: true,
       },

--- a/packages/plugin-build/src/builtin-host-artifacts.test.ts
+++ b/packages/plugin-build/src/builtin-host-artifacts.test.ts
@@ -100,6 +100,7 @@ describe("builtin host artifacts", () => {
     { pluginDir: "provider-claude-code", methods: ["resolveNativeRoots"] },
     { pluginDir: "provider-codex", methods: ["resolveNativeRoots"] },
     { pluginDir: "provider-pi", methods: ["resolveNativeRoots"] },
+    { pluginDir: "provider-rapp", methods: [] },
   ])(
     "builds the $pluginDir host entry that serves a host contract beside its bridge",
     async ({ pluginDir, methods }) => {

--- a/packages/plugin-build/src/builtin-host-artifacts.test.ts
+++ b/packages/plugin-build/src/builtin-host-artifacts.test.ts
@@ -22,6 +22,7 @@ function isBuiltProviderBridge(value: unknown): value is BuiltProviderBridge {
 
 interface BuiltHostEntry {
   readonly experimental_apiVersion: 1;
+  readonly contract: Readonly<Record<string, unknown>>;
   readonly handlers: Readonly<
     Record<string, (input: unknown, context: unknown) => unknown>
   >;
@@ -31,7 +32,10 @@ function isBuiltHostEntry(value: unknown): value is BuiltHostEntry {
   if (typeof value !== "object" || value === null) return false;
   return (
     Reflect.get(value, "experimental_apiVersion") === 1 &&
-    typeof Reflect.get(value, "handlers") === "object"
+    typeof Reflect.get(value, "contract") === "object" &&
+    Reflect.get(value, "contract") !== null &&
+    typeof Reflect.get(value, "handlers") === "object" &&
+    Reflect.get(value, "handlers") !== null
   );
 }
 
@@ -98,7 +102,14 @@ describe("builtin host artifacts", () => {
       methods: ["probeAgent", "resolveNativeRoots"],
     },
     { pluginDir: "provider-claude-code", methods: ["resolveNativeRoots"] },
-    { pluginDir: "provider-codex", methods: ["resolveNativeRoots"] },
+    {
+      pluginDir: "provider-codex",
+      methods: [
+        "ai.inference.complete",
+        "ai.voice.transcribe",
+        "resolveNativeRoots",
+      ],
+    },
     { pluginDir: "provider-pi", methods: ["resolveNativeRoots"] },
     { pluginDir: "provider-rapp", methods: [] },
   ])(
@@ -130,10 +141,10 @@ describe("builtin host artifacts", () => {
       );
       expect(isBuiltProviderBridge(bridge)).toBe(true);
       const entry = Reflect.get(Object(imported), "default");
-      const contract = Reflect.get(Object(entry), "contract");
-      expect(Object.keys(Object(contract))).toEqual(
-        expect.arrayContaining(methods),
-      );
+      if (!isBuiltHostEntry(entry)) {
+        throw new Error(`${pluginDir} did not build a valid host entry`);
+      }
+      expect(Object.keys(entry.contract).sort()).toEqual([...methods].sort());
     },
     90_000,
   );

--- a/packages/plugin-build/src/builtin-server-artifacts.test.ts
+++ b/packages/plugin-build/src/builtin-server-artifacts.test.ts
@@ -33,6 +33,7 @@ describe("builtin server artifacts", () => {
     { pluginDir: "provider-claude-code" },
     { pluginDir: "provider-codex" },
     { pluginDir: "provider-pi" },
+    { pluginDir: "provider-rapp" },
   ])(
     "builds the $pluginDir server entry with only the bare SDK specifier left external",
     async ({ pluginDir }) => {

--- a/packages/plugin-build/src/svg-asset.test.ts
+++ b/packages/plugin-build/src/svg-asset.test.ts
@@ -26,6 +26,7 @@ const FIRST_PARTY_BRANDING_SVGS = [
   "plugins/provider-claude-code/icons/claude-code.svg",
   "plugins/provider-codex/icons/codex.svg",
   "plugins/provider-pi/icons/pi.svg",
+  "plugins/provider-rapp/icons/rapp.svg",
 ];
 
 function discoverFirstPartyBrandingSvgs(): string[] {

--- a/packages/provider-bridge-protocol/src/contract-tests/provider-contract-purity.test.ts
+++ b/packages/provider-bridge-protocol/src/contract-tests/provider-contract-purity.test.ts
@@ -23,6 +23,7 @@ const PROVIDER_NAME_SEGMENTS = new Set([
   "pi",
   "acp",
   "cursor",
+  "rapp",
 ]);
 
 const allowlistSchema = z.object({
@@ -87,6 +88,7 @@ describe("guardrail G2: the provider contract names no provider", () => {
     expect(keyNamesProvider("acpLaunchSpec")).toBe(true);
     expect(keyNamesProvider("codex_goal")).toBe(true);
     expect(keyNamesProvider("piMode")).toBe(true);
+    expect(keyNamesProvider("rappGrail")).toBe(true);
   });
 
   it("flags every provider-named key and keeps the allowlist honest", () => {

--- a/packages/provider-bridge-protocol/src/testing/first-party-replay.ts
+++ b/packages/provider-bridge-protocol/src/testing/first-party-replay.ts
@@ -45,6 +45,23 @@ export const FIRST_PARTY_BRIDGE_MODULES: Readonly<
     legacyModulePaths: ["plugins/provider-pi/src/bridge/bridge.ts"],
     pluginId: "provider-pi",
   },
+  rapp: {
+    modulePath: "plugins/provider-rapp/src/host.ts",
+    pluginId: "provider-rapp",
+  },
+};
+
+export const FIRST_PARTY_REPLAY_MATRIX_PROVIDER_IDS = [
+  "acp-cursor",
+  "claude-code",
+  "codex",
+  "pi",
+] as const;
+
+export const FIRST_PARTY_CONFORMANCE_ONLY_PROVIDER_REASONS: Readonly<
+  Record<string, string>
+> = {
+  rapp: "its provider transport is HTTP rather than a replay-child stdio dialect; plugins/provider-rapp/provider-bridge.test.ts runs the public conformance kit against a deterministic local endpoint",
 };
 
 const BRIDGE_WORKER_ENTRY =
@@ -113,7 +130,11 @@ export function resolveReplayProfile(
       prepareState: seedPiSessionFiles,
     };
   }
-  throw new UnreplayableProviderError(providerId, "no replay profile");
+  throw new UnreplayableProviderError(
+    providerId,
+    FIRST_PARTY_CONFORMANCE_ONLY_PROVIDER_REASONS[providerId] ??
+      "no replay profile",
+  );
 }
 
 function claudeConfigDir(stateDir: string): string {

--- a/packages/provider-parity/src/parity.self.test.ts
+++ b/packages/provider-parity/src/parity.self.test.ts
@@ -11,7 +11,11 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   compareParity,
+  FIRST_PARTY_BRIDGE_MODULES,
+  FIRST_PARTY_CONFORMANCE_ONLY_PROVIDER_REASONS,
+  FIRST_PARTY_REPLAY_MATRIX_PROVIDER_IDS,
   type ParityAllowlistEntry,
+  resolveReplayProfile,
 } from "@bb/provider-bridge-protocol/testing/parity";
 import {
   RECORDINGS_ROOT,
@@ -43,12 +47,29 @@ function readPinned(): Record<string, RowCountsEntry> {
 describe("recorded fixtures", () => {
   it("has every matrix provider", () => {
     const providers = new Set(cells.map((cell) => cell.provider));
-    expect([...providers].sort()).toEqual([
-      "acp-cursor",
-      "claude-code",
-      "codex",
-      "pi",
-    ]);
+    expect([...providers].sort()).toEqual(
+      [...FIRST_PARTY_REPLAY_MATRIX_PROVIDER_IDS].sort(),
+    );
+  });
+
+  it("accounts for every first-party bridge family in replay policy", () => {
+    const replayFamilies = FIRST_PARTY_REPLAY_MATRIX_PROVIDER_IDS.map(
+      (providerId) => resolveReplayProfile(providerId).bridgeFamily,
+    );
+    const conformanceOnlyProviders = Object.keys(
+      FIRST_PARTY_CONFORMANCE_ONLY_PROVIDER_REASONS,
+    );
+
+    expect(
+      [...new Set([...replayFamilies, ...conformanceOnlyProviders])].sort(),
+    ).toEqual(Object.keys(FIRST_PARTY_BRIDGE_MODULES).sort());
+    expect(conformanceOnlyProviders).toEqual(["rapp"]);
+    expect(FIRST_PARTY_CONFORMANCE_ONLY_PROVIDER_REASONS.rapp).toMatch(
+      /HTTP.*deterministic local endpoint/u,
+    );
+    expect(() => resolveReplayProfile("rapp")).toThrow(
+      /cannot be replayed.*HTTP/u,
+    );
   });
 
   it("assembles every cell to its pinned counts", () => {

--- a/packages/scripts/test/provider-literal-ratchet.test.mjs
+++ b/packages/scripts/test/provider-literal-ratchet.test.mjs
@@ -45,14 +45,14 @@ function write(rel, content) {
 }
 
 describe("scanTree (pure)", () => {
-  it("counts every occurrence, including two ids on one line", () => {
+  it("counts every occurrence, including multiple ids on one line", () => {
     write(
       "packages/core/a.ts",
-      'const m = { codexHint: "codex", claudeHint: "claude-code" };\n',
+      'const m = { codexHint: "codex", claudeHint: "claude-code", rappHint: "rapp" };\n',
     );
     const { total, files } = scanTree(dir);
-    expect(files["packages/core/a.ts"]).toBe(2); // both ids on one line
-    expect(total).toBe(2);
+    expect(files["packages/core/a.ts"]).toBe(3);
+    expect(total).toBe(3);
   });
 
   it("counts named id constants and helpers", () => {

--- a/packages/templates/src/templates/bb-guide-providers.md
+++ b/packages/templates/src/templates/bb-guide-providers.md
@@ -60,7 +60,13 @@ settings. Business endpoint URLs also may not contain query parameters or
 fragments. An auto-launched local Brainstem keeps ordinary host and GitHub
 Copilot environment but does not inherit those five RAPP routing and
 credential variables. bb persists each RAPP thread as a canonical `rapp/1`
-session egg for restart-safe resume.
+session egg for restart-safe resume and journals completed responses before
+delivery. RAPP/1 limits a complete-transcript session egg to 1 MiB, so bb caps
+responses at 64 KiB and fails locally before `/chat` when a maximum response no
+longer fits; continue in a new thread. If an older Brainstem may have completed
+an uncertain request without enforcing `idempotency_key`, bb keeps it for
+audit and never replays it automatically; continue in a new thread to avoid a
+duplicate agent action.
 
 Provider-native memory can be controlled on the separate Settings → Providers
 → Codex and Settings → Providers → Claude Code pages. Codex memory controls

--- a/packages/templates/src/templates/bb-guide-providers.md
+++ b/packages/templates/src/templates/bb-guide-providers.md
@@ -32,9 +32,8 @@ verified GitHub Copilot models, and defaults to the local Brainstem at
 `http://127.0.0.1:7071/chat`. Select a discovered model id or use `brainstem`
 to follow the Brainstem's current GitHub Copilot default. bb reuses a healthy
 shared Brainstem or starts the installed `~/.brainstem` runtime, and stops only
-a process it owns. Automatic startup applies only to a plain HTTP loopback
-`/chat` endpoint with no URL credentials, query, or fragment; other endpoints
-must already be running:
+a process it owns. Automatic startup applies only to a plain HTTP `localhost`
+or `127.0.0.1` `/chat` endpoint; other endpoints must already be running:
 
   bb provider models rapp
   bb thread spawn --project <project-id> --provider rapp --model brainstem --prompt "Use my RAPP agents."
@@ -43,8 +42,8 @@ Override the Consumer endpoint with
 `bb plugin config provider-rapp set endpoint <url>` or the host-daemon
 environment variable `RAPP_BRAINSTEM_URL`. Set
 `RAPP_BRAINSTEM_SECRET` for a LAN Brainstem that requires the
-`X-Brainstem-Secret` header; credential-bearing non-loopback endpoints must
-use HTTPS.
+`X-Brainstem-Secret` header. Endpoint URLs may not contain credentials, query
+parameters, or fragments; header credentials require HTTPS outside loopback.
 
 Business mode adapts `microsoft/aibast-agents-library` and exposes the fixed
 `business-grail` model:
@@ -57,7 +56,8 @@ Business mode adapts `microsoft/aibast-agents-library` and exposes the fixed
 variable `RAPP_FUNCTION_KEY` supplies `x-functions-key`, and
 `RAPP_USER_GUID` optionally selects persistent Business Grail memory. Store
 credentials with `npx bb-app env set`, never in endpoint URLs or plugin
-settings. An auto-launched local Brainstem keeps ordinary host and GitHub
+settings. Business endpoint URLs also may not contain query parameters or
+fragments. An auto-launched local Brainstem keeps ordinary host and GitHub
 Copilot environment but does not inherit those five RAPP routing and
 credential variables. bb persists each RAPP thread as a canonical `rapp/1`
 session egg for restart-safe resume.

--- a/packages/templates/src/templates/bb-guide-providers.md
+++ b/packages/templates/src/templates/bb-guide-providers.md
@@ -24,6 +24,44 @@ the explicitly requested provider or Codex, then resolves the model marked
 default by that provider on the target machine (falling back to the first
 catalog model when none is marked).
 
+RAPP
+
+The bundled `rapp` provider speaks only the frozen `rapp/1` protocol.
+Consumer mode targets `kody-w/rapp-installer`, discovers the Brainstem's
+verified GitHub Copilot models, and defaults to the local Brainstem at
+`http://127.0.0.1:7071/chat`. Select a discovered model id or use `brainstem`
+to follow the Brainstem's current GitHub Copilot default. bb reuses a healthy
+shared Brainstem or starts the installed `~/.brainstem` runtime, and stops only
+a process it owns. Automatic startup applies only to a plain HTTP loopback
+`/chat` endpoint with no URL credentials, query, or fragment; other endpoints
+must already be running:
+
+  bb provider models rapp
+  bb thread spawn --project <project-id> --provider rapp --model brainstem --prompt "Use my RAPP agents."
+
+Override the Consumer endpoint with
+`bb plugin config provider-rapp set endpoint <url>` or the host-daemon
+environment variable `RAPP_BRAINSTEM_URL`. Set
+`RAPP_BRAINSTEM_SECRET` for a LAN Brainstem that requires the
+`X-Brainstem-Secret` header; credential-bearing non-loopback endpoints must
+use HTTPS.
+
+Business mode adapts `microsoft/aibast-agents-library` and exposes the fixed
+`business-grail` model:
+
+  bb plugin config provider-rapp set grail business
+  bb plugin config provider-rapp set endpoint \
+    https://YOUR_APP.azurewebsites.net/api/businessinsightbot_function
+
+`RAPP_BUSINESS_URL` may supply the endpoint. The host-daemon environment
+variable `RAPP_FUNCTION_KEY` supplies `x-functions-key`, and
+`RAPP_USER_GUID` optionally selects persistent Business Grail memory. Store
+credentials with `npx bb-app env set`, never in endpoint URLs or plugin
+settings. An auto-launched local Brainstem keeps ordinary host and GitHub
+Copilot environment but does not inherit those five RAPP routing and
+credential variables. bb persists each RAPP thread as a canonical `rapp/1`
+session egg for restart-safe resume.
+
 Provider-native memory can be controlled on the separate Settings → Providers
 → Codex and Settings → Providers → Claude Code pages. Codex memory controls
 both recall (`memories.use_memories`) and future generation
@@ -104,7 +142,7 @@ list mirrors the OpenCode catalog, so a custom model from the OpenCode config
 appears automatically. Discover and select one with:
 
   bb provider models acp-opencode --environment "$BB_ENVIRONMENT_ID"
-  bb thread spawn --provider acp-opencode --model <provider/model>
+  bb thread spawn --project <project-id> --provider acp-opencode --model <provider/model>
 
 bb applies the selected model to the ACP session before the first prompt.
 
@@ -114,14 +152,16 @@ session mode, not a model. bb does not select OpenCode agents; configure the
 default agent in the OpenCode config and the ACP session uses it.
 
 Top-level customModels in the app data-dir config.json adds extra picker
-entries. Each entry has a providerId (a built-in provider id or any acp-*
-provider id), a model id, and an optional displayName. bb skips an invalid
-entry with a warning. The entry then appears in bb provider models output and
-in the model picker, but the provider must still accept the id: claude-code
-and codex accept unlisted ids, while an ACP agent can reject an id it does
-not know at session start. OpenCode rejects unlisted ids, so add an OpenCode
-model to the OpenCode config instead. Edit the JSON and run bb-app config
-refresh; there is no set/unset CLI surface. The streamerMode
+entries. Each entry has a providerId (`codex`, `claude-code`, `pi`,
+`acp-cursor`, or any `acp-*` provider id), a model id, and an optional
+displayName. The `rapp` provider is intentionally excluded because its
+Brainstem supplies an authoritative dynamic GitHub Copilot catalog. bb skips
+an invalid entry with a warning. The entry then appears in bb provider models
+output and in the model picker, but the provider must still accept the id:
+claude-code and codex accept unlisted ids, while an ACP agent can reject an id
+it does not know at session start. OpenCode rejects unlisted ids, so add an
+OpenCode model to the OpenCode config instead. Edit the JSON and run bb-app
+config refresh; there is no set/unset CLI surface. The streamerMode
 General setting hides every entry from these lists; see the customization
 chapter.
 

--- a/packages/templates/src/templates/bb-guide-threads.md
+++ b/packages/templates/src/templates/bb-guide-threads.md
@@ -20,7 +20,7 @@ Spawning:
     --parent-self                  Parent to the current thread (BB_THREAD_ID)
     --provider <id>                Provider override
     --model <model>                Model override
-    --reasoning-level <level>      Reasoning level: low, medium, high, xhigh, max (provider-dependent)
+    --reasoning-level <level>      Reasoning level: none, low, medium, high, xhigh, ultracode, max (provider-dependent)
     --environment <id-or-path>     Attach to an existing environment (ID or workspace path)
     --new-environment <kind>       Create a new environment (worktree)
     --base-branch <branch>         Exact Git ref for a new managed worktree

--- a/plugins/bb-official.json
+++ b/plugins/bb-official.json
@@ -43,6 +43,10 @@
     "category": "agents-and-providers",
     "screenshots": []
   },
+  "provider-rapp": {
+    "category": "agents-and-providers",
+    "screenshots": []
+  },
   "provider-acp": {
     "category": "agents-and-providers",
     "screenshots": []

--- a/plugins/provider-rapp/README.md
+++ b/plugins/provider-rapp/README.md
@@ -1,0 +1,77 @@
+# RAPP provider
+
+The bundled RAPP provider runs bb threads over the frozen `rapp/1` protocol. It
+supports both production Grails:
+
+- **Consumer:** [`kody-w/rapp-installer`](https://github.com/kody-w/rapp-installer),
+  using `POST /chat`.
+- **Business:** [`microsoft/aibast-agents-library`](https://github.com/microsoft/aibast-agents-library),
+  using `POST /api/businessinsightbot_function`.
+
+The bridge sends `user_input`, optional `session_id`, `idempotency_key`, and
+`conversation_history`, adapts both Grails' response envelopes, and stores the
+bb transcript as a canonical RAPP/1 `session` egg so a host-daemon restart can
+resume the same conversation.
+
+## Consumer Grail
+
+The default points to `http://127.0.0.1:7071/chat`. bb reuses a healthy shared
+Brainstem or starts the installed `~/.brainstem` runtime with the same bounded
+launcher pattern as RAPP Brainstem Frontier. It stops only a process it started
+itself. `bb provider models rapp` reads Brainstem's verified GitHub Copilot
+catalog. Select one of those model ids, or use the selected-only `brainstem`
+alias to follow Brainstem's current default.
+
+Set a different base URL or full `/chat` URL with either:
+
+```bash
+bb plugin config provider-rapp set endpoint https://brainstem.example.com/chat
+```
+
+or the host-daemon environment variable `RAPP_BRAINSTEM_URL`. Deployments that
+require `X-Brainstem-Secret` read it from `RAPP_BRAINSTEM_SECRET`; a
+credential-bearing non-loopback endpoint must use HTTPS.
+
+Brainstem's current `/models/set` endpoint changes a process-global selection,
+so bb serializes each concrete model selection with its complete `/chat`
+request per endpoint. Brainstem remains the owner of Copilot authentication,
+catalog filtering, fallback, soul, agents, and execution.
+
+## Business Grail
+
+Select the Business Grail and configure the Azure Function App URL:
+
+```bash
+bb plugin config provider-rapp set grail business
+bb plugin config provider-rapp set endpoint \
+  https://YOUR_APP.azurewebsites.net/api/businessinsightbot_function
+```
+
+The endpoint can instead come from `RAPP_BUSINESS_URL`. Put the Function key in
+the host-daemon environment as `RAPP_FUNCTION_KEY`; the bridge sends it through
+`x-functions-key` and never stores it in bb settings, provider options, thread
+events, or the endpoint URL. `RAPP_USER_GUID` optionally selects the Business
+Grail's persistent user memory.
+
+## CLI
+
+```bash
+bb provider models rapp
+bb thread spawn --project <project-id> --provider rapp \
+  --model <brainstem-copilot-model-id> --prompt "Use my RAPP agents."
+```
+
+The same generic SDK surfaces work without a RAPP-specific client:
+
+```ts
+const models = await sdk.providers.models({ providerId: "rapp" });
+const model = models.models.find((candidate) => candidate.isDefault)?.model;
+if (!model) throw new Error("RAPP Brainstem returned no default model");
+const thread = await sdk.threads.spawn({
+  projectId,
+  environment: { type: "project-default" },
+  providerId: "rapp",
+  model,
+  prompt: "Use my RAPP agents.",
+});
+```

--- a/plugins/provider-rapp/README.md
+++ b/plugins/provider-rapp/README.md
@@ -29,8 +29,10 @@ bb plugin config provider-rapp set endpoint https://brainstem.example.com/chat
 ```
 
 or the host-daemon environment variable `RAPP_BRAINSTEM_URL`. Deployments that
-require `X-Brainstem-Secret` read it from `RAPP_BRAINSTEM_SECRET`; a
-credential-bearing non-loopback endpoint must use HTTPS.
+require `X-Brainstem-Secret` read it from `RAPP_BRAINSTEM_SECRET`. Endpoint
+URLs may not contain credentials, query parameters, or fragments; header
+credentials require HTTPS outside loopback. Automatic startup is limited to
+plain HTTP `localhost` or `127.0.0.1` `/chat` endpoints.
 
 Brainstem's current `/models/set` endpoint changes a process-global selection,
 so bb serializes each concrete model selection with its complete `/chat`
@@ -50,7 +52,8 @@ bb plugin config provider-rapp set endpoint \
 The endpoint can instead come from `RAPP_BUSINESS_URL`. Put the Function key in
 the host-daemon environment as `RAPP_FUNCTION_KEY`; the bridge sends it through
 `x-functions-key` and never stores it in bb settings, provider options, thread
-events, or the endpoint URL. `RAPP_USER_GUID` optionally selects the Business
+events, or the endpoint URL. Business endpoint URLs also may not contain query
+parameters or fragments. `RAPP_USER_GUID` optionally selects the Business
 Grail's persistent user memory.
 
 ## CLI

--- a/plugins/provider-rapp/README.md
+++ b/plugins/provider-rapp/README.md
@@ -39,6 +39,23 @@ so bb serializes each concrete model selection with its complete `/chat`
 request per endpoint. Brainstem remains the owner of Copilot authentication,
 catalog filtering, fallback, soul, agents, and execution.
 
+## Durable turn safety
+
+bb persists the complete transcript in canonical RAPP/1 session eggs and
+journals a successful response before delivering it to the thread. A bridge
+restart can recover a response committed before delivery.
+
+RAPP/1 caps each canonical session egg at 1 MiB. Responses are capped at
+64 KiB, and bb reserves enough space for a maximum-size response before calling
+`/chat`. When a thread no longer has that capacity, the turn fails locally and
+must continue in a new thread.
+
+Some installed Brainstem versions accept but do not enforce
+`idempotency_key`. If a `/chat` attempt may have completed but bb did not
+receive a valid response, bb retains the pending request for audit and refuses
+to replay it automatically. Start a new thread to continue without risking a
+duplicate agent action.
+
 ## Business Grail
 
 Select the Business Grail and configure the Azure Function App URL:

--- a/plugins/provider-rapp/icons/rapp.svg
+++ b/plugins/provider-rapp/icons/rapp.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <path d="M12 3.25a3.25 3.25 0 0 0-3.18 2.58A3.5 3.5 0 0 0 5.5 9.32v.24A3.75 3.75 0 0 0 7 16.75v.5A3.75 3.75 0 0 0 10.75 21H12V3.25Z" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M12 3.25a3.25 3.25 0 0 1 3.18 2.58 3.5 3.5 0 0 1 3.32 3.49v.24A3.75 3.75 0 0 1 17 16.75v.5A3.75 3.75 0 0 1 13.25 21H12V3.25Z" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M8.75 8.25A2.25 2.25 0 0 0 11 10.5M15.25 8.25A2.25 2.25 0 0 1 13 10.5M8.5 14.25A2.5 2.5 0 0 1 11 16.75M15.5 14.25a2.5 2.5 0 0 0-2.5 2.5" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
+</svg>

--- a/plugins/provider-rapp/package.json
+++ b/plugins/provider-rapp/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "bb-plugin-provider-rapp",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Run bb threads through RAPP/1 brainstems.",
+  "engines": {
+    "bb": ">=0.0"
+  },
+  "bb": {
+    "name": "RAPP provider",
+    "description": "Run bb threads through the RAPP Consumer or Business Grail over the frozen RAPP/1 wire.",
+    "branding": {
+      "icon": "./icons/rapp.svg"
+    },
+    "server": "./server.ts",
+    "host": "./src/host.ts"
+  },
+  "keywords": [
+    "bb-plugin"
+  ],
+  "scripts": {
+    "test": "vitest run --config vitest.config.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@get-bb/plugin-sdk": "workspace:*",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "npm:@typescript/typescript6@^6.0.2",
+    "typescript-7": "npm:typescript@^7.0.2",
+    "vitest": "^4.1.1"
+  }
+}

--- a/plugins/provider-rapp/provider-bridge.test.ts
+++ b/plugins/provider-rapp/provider-bridge.test.ts
@@ -3,10 +3,17 @@ import {
   type IncomingMessage,
   type ServerResponse,
 } from "node:http";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  experimental_createBridgeDeltaEventCollector as createBridgeDeltaEventCollector,
   experimental_createBridgeJsonRpcTestHarness as createBridgeJsonRpcTestHarness,
   experimental_formatConformanceReport as formatConformanceReport,
   experimental_runBridgeConformance as runBridgeConformance,
@@ -19,13 +26,18 @@ import type {
 import {
   experimental_providerBridge,
   experimental_resetRappBridgeForTests,
+  experimental_setRappBridgeDurabilityFaultForTests,
   handleLine,
 } from "./src/bridge.js";
+import { canonicalString } from "./src/rapp1.js";
+import { RappSessionStore } from "./src/session-store.js";
 import {
   RAPP_BUSINESS_MODEL_ID,
+  RAPP_FUNCTION_KEY_ENV,
   RAPP_MODEL_ID,
   RAPP_PROVIDER_ID,
   RAPP_SPEC,
+  RAPP_USER_GUID_ENV,
 } from "./src/vocabulary.js";
 
 const servers: ReturnType<typeof createServer>[] = [];
@@ -154,6 +166,42 @@ function threadDeltas(threadId: string): Array<Record<string, unknown>> {
     };
     return params.threadId === threadId ? (params.deltas ?? []) : [];
   });
+}
+
+function agentMessageText(delta: Record<string, unknown>): string | null {
+  if (delta.kind !== "item.close") {
+    return null;
+  }
+  const item = delta.item;
+  if (typeof item !== "object" || item === null) {
+    return null;
+  }
+  const text: unknown = Reflect.get(item, "text");
+  return Reflect.get(item, "type") === "agentMessage" &&
+    typeof text === "string"
+    ? text
+    : null;
+}
+
+function persistedStateText(directory: string): string {
+  const paths = [
+    join(directory, "identity.json"),
+    ...readdirSync(join(directory, "sessions")).map((name) =>
+      join(directory, "sessions", name),
+    ),
+    ...readdirSync(join(directory, "objects")).map((name) =>
+      join(directory, "objects", name),
+    ),
+  ];
+  return paths.map((path) => readFileSync(path, "utf8")).join("\n");
+}
+
+function persistedSessionHeadPath(directory: string): string {
+  const names = readdirSync(join(directory, "sessions"));
+  if (names.length !== 1) {
+    throw new Error("Expected exactly one persisted RAPP session head");
+  }
+  return join(directory, "sessions", names[0] ?? "");
 }
 
 async function waitFor(
@@ -439,13 +487,97 @@ describe("RAPP provider bridge", () => {
       ),
     ).toMatchObject({
       error: {
-        message:
+        message: expect.stringContaining(
           "RAPP Brainstem requested model model-b after bb selected model-a",
+        ),
       },
     });
     expect(
       threadDeltas(threadId).some((delta) => delta.kind === "extension.state"),
     ).toBe(false);
+  });
+
+  it("does not retain a pending turn when model selection fails before chat", async () => {
+    let modelSetCalls = 0;
+    let chatCalls = 0;
+    const endpoint = await listen(async (incoming, response) => {
+      response.setHeader("content-type", "application/json");
+      if (incoming.method === "GET") {
+        response.end(
+          JSON.stringify({ status: "ok", version: "test", agents: [] }),
+        );
+        return;
+      }
+      const body = await readJson(incoming);
+      if (incoming.url === "/models/set") {
+        modelSetCalls += 1;
+        if (modelSetCalls === 1) {
+          response.statusCode = 503;
+          response.end(JSON.stringify({ error: "model unavailable" }));
+          return;
+        }
+        response.end(JSON.stringify({ model: "model-a" }));
+        return;
+      }
+      chatCalls += 1;
+      response.end(
+        JSON.stringify({
+          response: "after local precondition retry",
+          session_id: "precondition-session",
+          agent_logs: [],
+          requested_model: "model-a",
+          model: "model-a",
+          received: body,
+        }),
+      );
+    });
+    const threadId = "thr_model_precondition";
+    const start = await request("thread/start", {
+      threadId,
+      cwd: "/workspace/rapp",
+      instructionMode: "append",
+      options: options(endpoint, "model-a"),
+    });
+    const identity = start.result as { providerThreadId: string };
+
+    await request("turn/start", {
+      threadId,
+      providerThreadId: identity.providerThreadId,
+      input: [{ type: "text", text: "first attempt", mentions: [] }],
+      clientRequestId: "creq_abcdefghjq",
+      options: options(endpoint, "model-a"),
+    });
+    await waitFor(
+      () =>
+        threadDeltas(threadId).some(
+          (delta) =>
+            delta.kind === "turn.boundary" && delta.status === "failed",
+        ),
+      "model selection failure did not settle",
+    );
+    expect(chatCalls).toBe(0);
+    expect(
+      new RappSessionStore(dataDir).load(identity.providerThreadId)?.snapshot
+        .pendingTurn,
+    ).toBeNull();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    await request("turn/start", {
+      threadId,
+      providerThreadId: identity.providerThreadId,
+      input: [{ type: "text", text: "second attempt", mentions: [] }],
+      clientRequestId: "creq_abcdefghjr",
+      options: options(endpoint, "model-a"),
+    });
+    await waitForCompletedTurn(threadId);
+    expect(modelSetCalls).toBe(2);
+    expect(chatCalls).toBe(1);
+    expect(
+      threadDeltas(threadId).some(
+        (delta) =>
+          agentMessageText(delta) === "after local precondition retry",
+      ),
+    ).toBe(true);
   });
 
   it("routes Business turns without model selection", async () => {
@@ -497,6 +629,73 @@ describe("RAPP provider bridge", () => {
     });
   });
 
+  it("never persists Business credentials or user identifiers in pending or delivery state", async () => {
+    const userGuid = "user-guid-must-not-persist";
+    const functionKey = "function-key-must-not-persist";
+    const previousUserGuid = process.env[RAPP_USER_GUID_ENV];
+    const previousFunctionKey = process.env[RAPP_FUNCTION_KEY_ENV];
+    process.env[RAPP_USER_GUID_ENV] = userGuid;
+    process.env[RAPP_FUNCTION_KEY_ENV] = functionKey;
+    try {
+      let receivedUserGuid: unknown;
+      let receivedFunctionKey: string | undefined;
+      const endpoint = await listen(async (incoming, response) => {
+        const body = await readJson(incoming);
+        if (typeof body === "object" && body !== null) {
+          receivedUserGuid = Reflect.get(body, "user_guid");
+        }
+        const header = incoming.headers["x-functions-key"];
+        receivedFunctionKey = typeof header === "string" ? header : undefined;
+        response.setHeader("content-type", "application/json");
+        response.end(
+          JSON.stringify({
+            assistant_response: "business answer",
+            agent_logs: [],
+            user_guid: userGuid,
+          }),
+        );
+      });
+      const threadId = "thr_business_sensitive_state";
+      const start = await request("thread/start", {
+        threadId,
+        cwd: "/workspace/rapp",
+        instructionMode: "append",
+        options: options(endpoint, RAPP_BUSINESS_MODEL_ID, "business"),
+      });
+      const identity = start.result as { providerThreadId: string };
+
+      await request("turn/start", {
+        threadId,
+        providerThreadId: identity.providerThreadId,
+        input: [{ type: "text", text: "business prompt", mentions: [] }],
+        clientRequestId: "creq_abcdefghjs",
+        options: options(endpoint, RAPP_BUSINESS_MODEL_ID, "business"),
+      });
+      await waitForCompletedTurn(threadId);
+
+      expect(receivedUserGuid).toBe(userGuid);
+      expect(receivedFunctionKey).toBe(functionKey);
+      const persisted = persistedStateText(dataDir);
+      expect(persisted).not.toContain(userGuid);
+      expect(persisted).not.toContain(functionKey);
+      expect(persisted).not.toContain("user_guid");
+      expect(persisted).not.toContain("x-functions-key");
+      expect(persisted).toContain("business");
+      expect(persisted).toContain(RAPP_BUSINESS_MODEL_ID);
+    } finally {
+      if (previousUserGuid === undefined) {
+        delete process.env[RAPP_USER_GUID_ENV];
+      } else {
+        process.env[RAPP_USER_GUID_ENV] = previousUserGuid;
+      }
+      if (previousFunctionKey === undefined) {
+        delete process.env[RAPP_FUNCTION_KEY_ENV];
+      } else {
+        process.env[RAPP_FUNCTION_KEY_ENV] = previousFunctionKey;
+      }
+    }
+  });
+
   it("rejects model and Grail mismatches before opening a session", async () => {
     for (const [grail, model] of [
       ["business", "claude-sonnet-5"],
@@ -517,7 +716,7 @@ describe("RAPP provider bridge", () => {
     }
   });
 
-  it("persists and reuses an exact pending chat after failure and resume", async () => {
+  it("never replays an ambiguous pending chat and requires an explicit interrupt to discard it", async () => {
     const requests: Array<Record<string, unknown>> = [];
     let chatCount = 0;
     const endpoint = await listen(async (incoming, response) => {
@@ -533,7 +732,7 @@ describe("RAPP provider bridge", () => {
       chatCount += 1;
       if (chatCount === 1) {
         response.statusCode = 503;
-        response.end(JSON.stringify({ error: "retry this turn" }));
+        response.end(JSON.stringify({ error: "completion unknown" }));
         return;
       }
       response.end(
@@ -573,6 +772,34 @@ describe("RAPP provider bridge", () => {
         ),
       "initial pending turn did not fail",
     );
+    expect(requests).toHaveLength(1);
+    expect(
+      threadDeltas(threadId).find(
+        (delta) => delta.kind === "turn.boundary" && delta.status === "failed",
+      ),
+    ).toMatchObject({
+      error: {
+        message: expect.stringContaining(
+          "legacy Brainstem does not honor idempotency keys",
+        ),
+      },
+    });
+    const legacyPending = new RappSessionStore(dataDir).load(
+      identity.providerThreadId,
+    );
+    if (legacyPending === null) {
+      throw new Error("Ambiguous pending RAPP turn was not persisted");
+    }
+    writeFileSync(
+      persistedSessionHeadPath(dataDir),
+      canonicalString({
+        schema: "bb/provider-rapp-session-head/1",
+        provider_thread_id: identity.providerThreadId,
+        egg_address: legacyPending.eggAddress,
+        turn_counter: legacyPending.snapshot.turnCounter,
+      }),
+      "utf8",
+    );
 
     experimental_resetRappBridgeForTests(dataDir);
     await request("thread/resume", {
@@ -589,24 +816,47 @@ describe("RAPP provider bridge", () => {
       clientRequestId: "creq_23456789ad",
       options: options(endpoint),
     });
-    await waitForCompletedTurn(threadId);
-
-    await request("turn/start", {
-      threadId,
-      providerThreadId: identity.providerThreadId,
-      input: [{ type: "text", text: "next prompt", mentions: [] }],
-      clientRequestId: "creq_23456789ae",
-      options: options(endpoint),
-    });
     await waitFor(
       () =>
         threadDeltas(threadId).filter(
           (delta) =>
-            delta.kind === "turn.boundary" && delta.status === "completed",
+            delta.kind === "turn.boundary" && delta.status === "failed",
         ).length === 2,
-      "new turn did not complete after pending success",
+      "retained pending turn did not fail closed",
     );
+    expect(requests).toHaveLength(1);
+    expect(
+      threadDeltas(threadId)
+        .filter(
+          (delta) =>
+            delta.kind === "turn.boundary" && delta.status === "failed",
+        )
+        .at(-1),
+    ).toMatchObject({
+      error: {
+        message: expect.stringContaining(
+          "Explicitly interrupt/stop this thread",
+        ),
+      },
+    });
 
+    await request("thread/stop", {
+      threadId,
+      providerThreadId: identity.providerThreadId,
+      intent: "interrupt",
+      activeTurnId: null,
+    });
+
+    await request("turn/start", {
+      threadId,
+      providerThreadId: identity.providerThreadId,
+      input: [{ type: "text", text: "later prompt", mentions: [] }],
+      clientRequestId: "creq_23456789ae",
+      options: options(endpoint),
+    });
+    await waitForCompletedTurn(threadId);
+
+    expect(requests).toHaveLength(2);
     expect(requests[0]).toEqual({
       user_input: "original prompt",
       idempotency_key: "creq_23456789ac",
@@ -617,20 +867,364 @@ describe("RAPP provider bridge", () => {
         },
       ],
     });
-    expect(requests[1]).toEqual(requests[0]);
-    expect(requests[2]).toMatchObject({
-      user_input: "next prompt",
-      session_id: "remote-session",
+    expect(requests[1]).toEqual({
+      user_input: "later prompt",
       idempotency_key: "creq_23456789ae",
       conversation_history: [
         {
           role: "user",
           content: "BB thread instructions:\nBe concise.",
         },
-        { role: "user", content: "original prompt" },
-        { role: "assistant", content: "answer-2" },
       ],
     });
+  }, 15_000);
+
+  it("recovers a committed completion from the delivery journal after a bridge crash", async () => {
+    let chatCalls = 0;
+    const endpoint = await listen(async (incoming, response) => {
+      response.setHeader("content-type", "application/json");
+      if (incoming.method === "GET") {
+        response.end(
+          JSON.stringify({ status: "ok", version: "test", agents: [] }),
+        );
+        return;
+      }
+      await readJson(incoming);
+      chatCalls += 1;
+      response.end(
+        JSON.stringify({
+          response: "recovered answer",
+          session_id: "recovered-session",
+          agent_logs: ["RecoveryAgent"],
+          requested_model: "claude-opus-5",
+          model: "claude-opus-5",
+        }),
+      );
+    });
+    const threadId = "thr_delivery_recovery";
+    const start = await request("thread/start", {
+      threadId,
+      cwd: "/workspace/rapp",
+      instructionMode: "append",
+      options: options(endpoint),
+    });
+    const identity = start.result as { providerThreadId: string };
+
+    experimental_setRappBridgeDurabilityFaultForTests(
+      "after-completion-commit",
+      () => experimental_resetRappBridgeForTests(dataDir),
+    );
+    await request("turn/start", {
+      threadId,
+      providerThreadId: identity.providerThreadId,
+      input: [{ type: "text", text: "recover me", mentions: [] }],
+      clientRequestId: "creq_abcdefghjm",
+      options: options(endpoint),
+    });
+    await waitFor(
+      () =>
+        (new RappSessionStore(dataDir).load(identity.providerThreadId)
+          ?.pendingDelivery ??
+          null) !== null,
+      "completed response was not committed to the delivery journal",
+    );
+
+    expect(chatCalls).toBe(1);
+    expect(
+      threadDeltas(threadId).some(
+        (delta) => agentMessageText(delta) === "recovered answer",
+      ),
+    ).toBe(false);
+    const providerTurnId = threadDeltas(threadId).find(
+      (delta) => delta.kind === "turn.open",
+    )?.providerTurnId;
+    expect(typeof providerTurnId).toBe("string");
+
+    await request("thread/resume", {
+      threadId,
+      providerThreadId: identity.providerThreadId,
+      cwd: "/workspace/rapp",
+      instructionMode: "append",
+      options: options(endpoint),
+    });
+    await waitForCompletedTurn(threadId);
+
+    expect(chatCalls).toBe(1);
+    expect(
+      threadDeltas(threadId).find(
+        (delta) => agentMessageText(delta) === "recovered answer",
+      ),
+    ).toMatchObject({
+      key: {
+        providerItemId: `${identity.providerThreadId}-t1-message`,
+      },
+      providerTurnId,
+    });
+    expect(
+      threadDeltas(threadId).find(
+        (delta) =>
+          delta.kind === "item.close" &&
+          typeof delta.item === "object" &&
+          delta.item !== null &&
+          Reflect.get(delta.item, "tool") === "rapp_agents",
+      ),
+    ).toMatchObject({
+      item: { result: "RecoveryAgent" },
+      providerTurnId,
+    });
+    expect(
+      threadDeltas(threadId).find(
+        (delta) => delta.kind === "extension.state",
+      ),
+    ).toMatchObject({
+      payload: {
+        grail: "consumer",
+        sessionId: "recovered-session",
+        endpoint: expect.stringContaining("/chat"),
+        selectedModel: RAPP_MODEL_ID,
+        requestedModel: "claude-opus-5",
+        actualModel: "claude-opus-5",
+      },
+    });
+    const recovered = new RappSessionStore(dataDir).load(
+      identity.providerThreadId,
+    );
+    expect(recovered?.pendingDelivery?.phase).toBe("emitted");
+    expect(recovered?.snapshot.transcript).toEqual([
+      { role: "user", content: "recover me" },
+      { role: "assistant", content: "recovered answer" },
+    ]);
+    await request("turn/start", {
+      threadId,
+      providerThreadId: identity.providerThreadId,
+      input: [{ type: "text", text: "   ", mentions: [] }],
+      clientRequestId: "creq_abcdefghjt",
+      options: options(endpoint),
+    });
+    await waitFor(
+      () =>
+        threadDeltas(threadId).some(
+          (delta) =>
+            delta.kind === "turn.boundary" && delta.status === "failed",
+        ),
+      "acknowledging follow-up turn did not settle locally",
+    );
+    expect(chatCalls).toBe(1);
+    expect(
+      new RappSessionStore(dataDir).load(identity.providerThreadId)
+        ?.pendingDelivery,
+    ).toBeNull();
+  });
+
+  it("deduplicates replay in a surviving assembler but exposes the unavoidable fresh-assembler duplicate", async () => {
+    let chatCalls = 0;
+    const endpoint = await listen(async (incoming, response) => {
+      response.setHeader("content-type", "application/json");
+      if (incoming.method === "GET") {
+        response.end(
+          JSON.stringify({ status: "ok", version: "test", agents: [] }),
+        );
+        return;
+      }
+      await readJson(incoming);
+      chatCalls += 1;
+      response.end(
+        JSON.stringify({
+          response: "deliver once",
+          session_id: "delivery-session",
+          agent_logs: ["DeliveryAgent"],
+          requested_model: "claude-opus-5",
+          model: "claude-opus-5",
+        }),
+      );
+    });
+    const threadId = "thr_delivery_duplicate_safe";
+    const start = await request("thread/start", {
+      threadId,
+      cwd: "/workspace/rapp",
+      instructionMode: "append",
+      options: options(endpoint),
+    });
+    const identity = start.result as { providerThreadId: string };
+
+    experimental_setRappBridgeDurabilityFaultForTests(
+      "after-delivery-emission",
+      () => experimental_resetRappBridgeForTests(dataDir),
+    );
+    await request("turn/start", {
+      threadId,
+      providerThreadId: identity.providerThreadId,
+      input: [{ type: "text", text: "deliver safely", mentions: [] }],
+      clientRequestId: "creq_abcdefghjn",
+      options: options(endpoint),
+    });
+    await waitFor(
+      () =>
+        (new RappSessionStore(dataDir).load(identity.providerThreadId)
+          ?.pendingDelivery ??
+          null) !== null,
+      "delivery journal was acknowledged despite the injected crash",
+    );
+    expect(
+      new RappSessionStore(dataDir).load(identity.providerThreadId)
+        ?.pendingDelivery?.phase,
+    ).toBe("ready");
+
+    const replayStartIndex = harness.messages.length;
+    await request("thread/resume", {
+      threadId,
+      providerThreadId: identity.providerThreadId,
+      cwd: "/workspace/rapp",
+      instructionMode: "append",
+      options: options(endpoint),
+    });
+    await waitForCompletedTurn(threadId);
+
+    expect(chatCalls).toBe(1);
+    expect(
+      threadDeltas(threadId).filter(
+        (delta) => agentMessageText(delta) === "deliver once",
+      ),
+    ).toHaveLength(2);
+    const collector = createBridgeDeltaEventCollector(RAPP_PROVIDER_ID);
+    const assembled = harness.messages.flatMap((message) =>
+      collector.assembleMessage(message),
+    );
+    expect(
+      assembled.filter(
+        (event) =>
+          event.type === "item/completed" &&
+          event.item.type === "agentMessage" &&
+          event.item.text === "deliver once",
+      ),
+    ).toHaveLength(1);
+    expect(
+      assembled.filter(
+        (event) =>
+          event.type === "item/completed" &&
+          event.item.type === "toolCall" &&
+          event.item.tool === "rapp_agents",
+      ),
+    ).toHaveLength(1);
+    const resetAssembler = createBridgeDeltaEventCollector(RAPP_PROVIDER_ID);
+    const initialEvents = harness.messages
+      .slice(0, replayStartIndex)
+      .flatMap((message) => resetAssembler.assembleMessage(message));
+    resetAssembler.assembler.assemble({
+      threadId,
+      deltas: [{ kind: "session.reset" }],
+    });
+    const replayEvents = harness.messages
+      .slice(replayStartIndex)
+      .flatMap((message) => resetAssembler.assembleMessage(message));
+    const initialMessageIds = initialEvents.flatMap((event) =>
+      event.type === "item/completed" &&
+      event.item.type === "agentMessage" &&
+      event.item.text === "deliver once"
+        ? [event.item.id]
+        : [],
+    );
+    const replayMessageIds = replayEvents.flatMap((event) =>
+      event.type === "item/completed" &&
+      event.item.type === "agentMessage" &&
+      event.item.text === "deliver once"
+        ? [event.item.id]
+        : [],
+    );
+    expect(initialMessageIds).toHaveLength(1);
+    expect(replayMessageIds).toHaveLength(1);
+    expect(replayMessageIds[0]).not.toBe(initialMessageIds[0]);
+    expect(
+      new RappSessionStore(dataDir).load(identity.providerThreadId)
+        ?.pendingDelivery?.phase,
+    ).toBe("emitted");
+    await request("turn/start", {
+      threadId,
+      providerThreadId: identity.providerThreadId,
+      input: [{ type: "text", text: "   ", mentions: [] }],
+      clientRequestId: "creq_abcdefghju",
+      options: options(endpoint),
+    });
+    await waitFor(
+      () =>
+        threadDeltas(threadId).some(
+          (delta) =>
+            delta.kind === "turn.boundary" && delta.status === "failed",
+        ),
+      "duplicate-window acknowledgement turn did not settle locally",
+    );
+    expect(chatCalls).toBe(1);
+    expect(
+      new RappSessionStore(dataDir).load(identity.providerThreadId)
+        ?.pendingDelivery,
+    ).toBeNull();
+  });
+
+  it("rejects a near-limit turn before making any endpoint request", async () => {
+    let networkCalls = 0;
+    const endpoint = await listen((_incoming, response) => {
+      networkCalls += 1;
+      response.setHeader("content-type", "application/json");
+      response.end(
+        JSON.stringify({
+          response: "must not execute",
+          session_id: "unused",
+          agent_logs: [],
+        }),
+      );
+    });
+    const threadId = "thr_capacity_preflight";
+    const start = await request("thread/start", {
+      threadId,
+      cwd: "/workspace/rapp",
+      instructionMode: "append",
+      options: options(endpoint),
+    });
+    const identity = start.result as { providerThreadId: string };
+    const store = new RappSessionStore(dataDir);
+    const saved = store.load(identity.providerThreadId);
+    if (saved === null) {
+      throw new Error("RAPP session was not persisted");
+    }
+    store.save(
+      {
+        ...saved.snapshot,
+        turnCounter: 1,
+        transcript: [{ role: "assistant", content: "x".repeat(985_000) }],
+      },
+      null,
+    );
+    experimental_resetRappBridgeForTests(dataDir);
+    await request("thread/resume", {
+      threadId,
+      providerThreadId: identity.providerThreadId,
+      cwd: "/workspace/rapp",
+      instructionMode: "append",
+      options: options(endpoint),
+    });
+
+    await request("turn/start", {
+      threadId,
+      providerThreadId: identity.providerThreadId,
+      input: [{ type: "text", text: "too late", mentions: [] }],
+      clientRequestId: "creq_abcdefghjp",
+      options: options(endpoint),
+    });
+    await waitFor(
+      () =>
+        threadDeltas(threadId).some(
+          (delta) =>
+            delta.kind === "turn.boundary" &&
+            delta.status === "failed" &&
+            typeof delta.error === "object" &&
+            delta.error !== null &&
+            String(Reflect.get(delta.error, "message")).includes(
+              "Start a new thread",
+            ),
+        ),
+      "near-limit turn did not fail its local capacity preflight",
+    );
+    expect(networkCalls).toBe(0);
   });
 
   it("serializes model selection and full chats across Consumer threads", async () => {
@@ -843,8 +1437,7 @@ describe("RAPP provider bridge", () => {
     await waitFor(
       () =>
         threadDeltas(threadId).some(
-          (delta) =>
-            delta.kind === "item.textClose" && delta.text === "after interrupt",
+          (delta) => agentMessageText(delta) === "after interrupt",
         ),
       "session was not usable after interrupt",
     );
@@ -922,7 +1515,7 @@ describe("RAPP provider bridge", () => {
     );
     expect(
       threadDeltas(brokenThreadId).some(
-        (delta) => delta.kind === "item.textClose",
+        (delta) => agentMessageText(delta) !== null,
       ),
     ).toBe(false);
   });
@@ -983,6 +1576,10 @@ describe("RAPP provider bridge", () => {
       intent: "release",
       activeTurnId: null,
     });
+    expect(
+      new RappSessionStore(dataDir).load(identity.providerThreadId)
+        ?.pendingDelivery?.phase,
+    ).toBe("emitted");
     await request("thread/resume", {
       threadId,
       providerThreadId: identity.providerThreadId,
@@ -1000,10 +1597,10 @@ describe("RAPP provider bridge", () => {
     });
     await waitFor(
       () =>
-        threadDeltas(threadId).filter(
-          (delta) =>
-            delta.kind === "turn.boundary" && delta.status === "completed",
-        ).length === 2,
+        requests.length === 2 &&
+        threadDeltas(threadId).some(
+          (delta) => agentMessageText(delta) === "answer-2",
+        ),
       "second turn did not settle after resume",
     );
 
@@ -1035,8 +1632,20 @@ describe("RAPP provider bridge", () => {
     const deltas = threadDeltas(threadId);
     expect(
       deltas
-        .filter((delta) => delta.kind === "item.textClose")
-        .map((delta) => delta.text),
+        .map(agentMessageText)
+        .filter((text): text is string => text !== null),
+    ).toEqual(["answer-1", "answer-1", "answer-2"]);
+    const collector = createBridgeDeltaEventCollector(RAPP_PROVIDER_ID);
+    const assembled = harness.messages.flatMap((message) =>
+      collector.assembleMessage(message),
+    );
+    expect(
+      assembled.flatMap((event) =>
+        event.type === "item/completed" &&
+        event.item.type === "agentMessage"
+          ? [event.item.text]
+          : [],
+      ),
     ).toEqual(["answer-1", "answer-2"]);
     const states = deltas.filter((delta) => delta.kind === "extension.state");
     expect(states.at(-1)).toMatchObject({
@@ -1052,14 +1661,13 @@ describe("RAPP provider bridge", () => {
       },
     });
     expect(
-      deltas
-        .filter(
-          (delta) =>
-            delta.kind === "item.close" &&
-            (delta.item as { tool?: string } | undefined)?.tool ===
-              "rapp_agents",
-        )
-        .map((delta) => (delta.item as { result?: string }).result),
+      assembled.flatMap((event) =>
+        event.type === "item/completed" &&
+        event.item.type === "toolCall" &&
+        event.item.tool === "rapp_agents"
+          ? [event.item.result]
+          : [],
+      ),
     ).toEqual(["Agent-1", "Agent-2"]);
   });
 });

--- a/plugins/provider-rapp/provider-bridge.test.ts
+++ b/plugins/provider-rapp/provider-bridge.test.ts
@@ -1,0 +1,1065 @@
+import {
+  createServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from "node:http";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  experimental_createBridgeJsonRpcTestHarness as createBridgeJsonRpcTestHarness,
+  experimental_formatConformanceReport as formatConformanceReport,
+  experimental_runBridgeConformance as runBridgeConformance,
+} from "@get-bb/plugin-sdk/provider-bridge/testing";
+import { BRIDGE_JSON_RPC_ERRORS } from "@get-bb/plugin-sdk/provider-bridge";
+import type {
+  BridgeJsonRpcObject,
+  BridgeJsonRpcTestHarness,
+} from "@get-bb/plugin-sdk/provider-bridge/testing";
+import {
+  experimental_providerBridge,
+  experimental_resetRappBridgeForTests,
+  handleLine,
+} from "./src/bridge.js";
+import {
+  RAPP_BUSINESS_MODEL_ID,
+  RAPP_MODEL_ID,
+  RAPP_PROVIDER_ID,
+  RAPP_SPEC,
+} from "./src/vocabulary.js";
+
+const servers: ReturnType<typeof createServer>[] = [];
+const directories: string[] = [];
+let harness: BridgeJsonRpcTestHarness;
+let requestCounter = 0;
+let dataDir: string;
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(process.cwd(), ".bb-rapp-bridge-"));
+  const tempDir = mkdtempSync(join(process.cwd(), ".bb-rapp-temp-"));
+  directories.push(dataDir, tempDir);
+  experimental_resetRappBridgeForTests(dataDir);
+  experimental_providerBridge.start?.({
+    pluginId: "provider-rapp",
+    dataDir,
+    tempDir,
+  });
+  harness = createBridgeJsonRpcTestHarness(handleLine);
+});
+
+afterEach(async () => {
+  harness.restore();
+  experimental_providerBridge.onClose?.();
+  await Promise.all(
+    servers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        }),
+    ),
+  );
+  for (const directory of directories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+async function listen(
+  handler: (request: IncomingMessage, response: ServerResponse) => void,
+): Promise<string> {
+  const server = createServer(handler);
+  servers.push(server);
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("expected TCP server address");
+  }
+  return `http://127.0.0.1:${address.port}`;
+}
+
+async function readJson(request: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+}
+
+async function request(method: string, params: BridgeJsonRpcObject) {
+  requestCounter += 1;
+  const id = `rapp-test-${requestCounter}`;
+  harness.sendRequest(id, method, params);
+  const response = await harness.waitForResponse(id);
+  expect(response.error, `${method} returned an error`).toBeUndefined();
+  return response;
+}
+
+function options(
+  endpoint: string,
+  model = RAPP_MODEL_ID,
+  grail: "consumer" | "business" = "consumer",
+): BridgeJsonRpcObject {
+  return {
+    model,
+    reasoningLevel: "none",
+    permissionMode: "full",
+    permissionScope: "full",
+    approvalReviewer: null,
+    permissionEscalation: null,
+    instructions: "Be concise.",
+    providerOptions: {
+      grail,
+      endpoint,
+      model,
+    },
+  };
+}
+
+async function waitForCompletedTurn(threadId: string): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const settled = harness.messages.some((message) => {
+      if (message.method !== "thread/delta") {
+        return false;
+      }
+      const params = message.params as {
+        threadId?: string;
+        deltas?: Array<{ kind?: string; status?: string }>;
+      };
+      return (
+        params.threadId === threadId &&
+        params.deltas?.some(
+          (delta) =>
+            delta.kind === "turn.boundary" && delta.status === "completed",
+        ) === true
+      );
+    });
+    if (settled) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`RAPP turn did not settle for ${threadId}`);
+}
+
+function threadDeltas(threadId: string): Array<Record<string, unknown>> {
+  return harness.messages.flatMap((message) => {
+    if (message.method !== "thread/delta") {
+      return [];
+    }
+    const params = message.params as {
+      threadId?: string;
+      deltas?: Array<Record<string, unknown>>;
+    };
+    return params.threadId === threadId ? (params.deltas ?? []) : [];
+  });
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  message: string,
+): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(message);
+}
+
+describe("RAPP provider bridge", () => {
+  it("passes the provider bridge conformance suite", async () => {
+    const endpoint = await listen(async (incoming, response) => {
+      if (incoming.method === "GET") {
+        response.setHeader("content-type", "application/json");
+        if (incoming.url === "/models") {
+          response.end(
+            JSON.stringify({
+              current: "claude-opus-5",
+              models: [
+                {
+                  id: "claude-opus-5",
+                  name: "Claude Opus 5",
+                  available: true,
+                },
+              ],
+            }),
+          );
+          return;
+        }
+        response.end(
+          JSON.stringify({
+            status: "ok",
+            version: "test",
+            agents: [],
+          }),
+        );
+        return;
+      }
+      const body = await readJson(incoming);
+      const parsed = body as { user_input?: string; session_id?: string };
+      response.setHeader("content-type", "application/json");
+      response.end(
+        JSON.stringify({
+          response: `RAPP: ${parsed.user_input ?? ""}`,
+          agent_logs: [],
+          session_id: parsed.session_id ?? "session",
+        }),
+      );
+    });
+    const report = await runBridgeConformance({
+      transport: { send: handleLine, takeMessages: harness.takeMessages },
+      providerId: RAPP_PROVIDER_ID,
+      session: {
+        cwd: "/workspace/rapp",
+        promptInput: [{ type: "text", text: "hello", mentions: [] }],
+        options: options(endpoint),
+      },
+      timeoutMs: 5_000,
+    });
+    harness.restore();
+    console.info(
+      `RAPP bridge conformance:\n${formatConformanceReport(report)}`,
+    );
+    expect(report.results.filter((result) => result.status === "fail")).toEqual(
+      [],
+    );
+    expect(report.passed).toBe(true);
+  });
+
+  it("maps Brainstem's verified Copilot catalog in source order", async () => {
+    const requests: string[] = [];
+    const endpoint = await listen((incoming, response) => {
+      requests.push(`${incoming.method} ${incoming.url}`);
+      response.setHeader("content-type", "application/json");
+      if (incoming.url === "/models") {
+        response.end(
+          JSON.stringify({
+            current: "claude-sonnet-5",
+            models: [
+              {
+                id: "gpt-5.4",
+                name: "GPT-5.4",
+                available: true,
+              },
+              {
+                id: "gpt-4o",
+                name: "GPT-4o",
+                available: false,
+              },
+              {
+                id: "bootstrap-only",
+                name: "Bootstrap only",
+              },
+              {
+                id: "claude-sonnet-5",
+                name: "Claude Sonnet 5",
+                available: true,
+              },
+              {
+                id: "gpt-5.4",
+                name: "GPT-5.4 duplicate",
+                available: true,
+              },
+            ],
+          }),
+        );
+        return;
+      }
+      response.end(
+        JSON.stringify({ status: "ok", version: "test", agents: [] }),
+      );
+    });
+
+    const response = await request("model/list", {
+      providerOptions: {
+        grail: "consumer",
+        endpoint,
+      },
+    });
+    const result = response.result as {
+      models: Array<Record<string, unknown>>;
+      selectedOnlyModels: Array<Record<string, unknown>>;
+    };
+
+    expect(requests).toEqual(["GET /health", "GET /models"]);
+    expect(result.models.map((model) => model.model)).toEqual([
+      "gpt-5.4",
+      "claude-sonnet-5",
+    ]);
+    expect(
+      result.models.filter((model) => model.isDefault).map((model) => model.id),
+    ).toEqual(["claude-sonnet-5"]);
+    expect(result.models[0]).toMatchObject({
+      displayName: "GPT-5.4",
+      description: "GitHub Copilot model supplied by RAPP Brainstem",
+    });
+    expect(result.selectedOnlyModels).toEqual([
+      expect.objectContaining({
+        id: RAPP_MODEL_ID,
+        model: RAPP_MODEL_ID,
+        isDefault: false,
+      }),
+    ]);
+  });
+
+  it("returns the fixed Business Grail model without contacting model endpoints", async () => {
+    const response = await request("model/list", {
+      providerOptions: {
+        grail: "business",
+        endpoint: "",
+      },
+    });
+
+    expect(response.result).toEqual({
+      models: [
+        expect.objectContaining({
+          id: RAPP_BUSINESS_MODEL_ID,
+          model: RAPP_BUSINESS_MODEL_ID,
+          isDefault: true,
+        }),
+      ],
+      selectedOnlyModels: [],
+    });
+  });
+
+  it("sets a concrete Consumer model before chat and attributes fallback", async () => {
+    const calls: Array<{ path: string; body: unknown }> = [];
+    const endpoint = await listen(async (incoming, response) => {
+      response.setHeader("content-type", "application/json");
+      if (incoming.method === "GET") {
+        response.end(
+          JSON.stringify({ status: "ok", version: "test", agents: [] }),
+        );
+        return;
+      }
+      const body = await readJson(incoming);
+      calls.push({ path: incoming.url ?? "", body });
+      if (incoming.url === "/models/set") {
+        response.end(JSON.stringify({ model: "claude-sonnet-5" }));
+        return;
+      }
+      response.end(
+        JSON.stringify({
+          response: "fallback answer",
+          session_id: "consumer-session",
+          agent_logs: [],
+          requested_model: "claude-sonnet-5",
+          model: "claude-haiku-4.5",
+        }),
+      );
+    });
+    const threadId = "thr_concrete_model";
+    const start = await request("thread/start", {
+      threadId,
+      cwd: "/workspace/rapp",
+      instructionMode: "append",
+      options: options(endpoint, "claude-sonnet-5"),
+    });
+    const identity = start.result as { providerThreadId: string };
+
+    await request("turn/start", {
+      threadId,
+      providerThreadId: identity.providerThreadId,
+      input: [{ type: "text", text: "route me", mentions: [] }],
+      clientRequestId: "creq_abcdefghjk",
+      options: options(endpoint, "claude-sonnet-5"),
+    });
+    await waitForCompletedTurn(threadId);
+
+    expect(calls.map((call) => call.path)).toEqual(["/models/set", "/chat"]);
+    expect(calls[0]?.body).toEqual({ model: "claude-sonnet-5" });
+    expect(
+      threadDeltas(threadId).find((delta) => delta.kind === "extension.state"),
+    ).toMatchObject({
+      payload: {
+        selectedModel: "claude-sonnet-5",
+        requestedModel: "claude-sonnet-5",
+        actualModel: "claude-haiku-4.5",
+      },
+    });
+  });
+
+  it("rejects a concrete Consumer turn when Brainstem reports another requested model", async () => {
+    const endpoint = await listen(async (incoming, response) => {
+      response.setHeader("content-type", "application/json");
+      if (incoming.method === "GET") {
+        response.end(
+          JSON.stringify({ status: "ok", version: "test", agents: [] }),
+        );
+        return;
+      }
+      await readJson(incoming);
+      if (incoming.url === "/models/set") {
+        response.end(JSON.stringify({ model: "model-a" }));
+        return;
+      }
+      response.end(
+        JSON.stringify({
+          response: "wrong route",
+          session_id: "mismatch-session",
+          agent_logs: [],
+          requested_model: "model-b",
+          model: "model-b",
+        }),
+      );
+    });
+    const threadId = "thr_requested_mismatch";
+    const selectedOptions = options(endpoint, "model-a");
+    const start = await request("thread/start", {
+      threadId,
+      cwd: "/workspace/rapp",
+      instructionMode: "append",
+      options: selectedOptions,
+    });
+    const identity = start.result as { providerThreadId: string };
+
+    await request("turn/start", {
+      threadId,
+      providerThreadId: identity.providerThreadId,
+      input: [{ type: "text", text: "mismatch", mentions: [] }],
+      clientRequestId: "creq_mnpqrstuvw",
+      options: selectedOptions,
+    });
+    await waitFor(
+      () =>
+        threadDeltas(threadId).some(
+          (delta) =>
+            delta.kind === "turn.boundary" && delta.status === "failed",
+        ),
+      "mismatched Consumer turn did not fail",
+    );
+
+    expect(
+      threadDeltas(threadId).find(
+        (delta) => delta.kind === "turn.boundary" && delta.status === "failed",
+      ),
+    ).toMatchObject({
+      error: {
+        message:
+          "RAPP Brainstem requested model model-b after bb selected model-a",
+      },
+    });
+    expect(
+      threadDeltas(threadId).some((delta) => delta.kind === "extension.state"),
+    ).toBe(false);
+  });
+
+  it("routes Business turns without model selection", async () => {
+    const calls: string[] = [];
+    const endpoint = await listen(async (incoming, response) => {
+      calls.push(`${incoming.method} ${incoming.url}`);
+      response.setHeader("content-type", "application/json");
+      const body = await readJson(incoming);
+      response.end(
+        JSON.stringify({
+          assistant_response: `Business: ${(body as { user_input?: string }).user_input ?? ""}`,
+          agent_logs: [],
+        }),
+      );
+    });
+    const threadId = "thr_business_model";
+    const businessOptions = options(
+      endpoint,
+      RAPP_BUSINESS_MODEL_ID,
+      "business",
+    );
+    const start = await request("thread/start", {
+      threadId,
+      cwd: "/workspace/rapp",
+      instructionMode: "append",
+      options: businessOptions,
+    });
+    const identity = start.result as { providerThreadId: string };
+
+    await request("turn/start", {
+      threadId,
+      providerThreadId: identity.providerThreadId,
+      input: [{ type: "text", text: "business", mentions: [] }],
+      clientRequestId: "creq_23456789ab",
+      options: businessOptions,
+    });
+    await waitForCompletedTurn(threadId);
+
+    expect(calls).toEqual(["POST /api/businessinsightbot_function"]);
+    expect(
+      threadDeltas(threadId).find((delta) => delta.kind === "extension.state"),
+    ).toMatchObject({
+      payload: {
+        grail: "business",
+        selectedModel: RAPP_BUSINESS_MODEL_ID,
+        requestedModel: RAPP_BUSINESS_MODEL_ID,
+        actualModel: RAPP_BUSINESS_MODEL_ID,
+      },
+    });
+  });
+
+  it("rejects model and Grail mismatches before opening a session", async () => {
+    for (const [grail, model] of [
+      ["business", "claude-sonnet-5"],
+      ["consumer", RAPP_BUSINESS_MODEL_ID],
+    ] as const) {
+      requestCounter += 1;
+      const id = `rapp-mismatch-${requestCounter}`;
+      harness.sendRequest(id, "thread/start", {
+        threadId: `thr_${grail}_mismatch`,
+        cwd: "/workspace/rapp",
+        instructionMode: "append",
+        options: options("http://127.0.0.1:7071", model, grail),
+      });
+      const response = await harness.waitForResponse(id);
+      expect(response.error).toMatchObject({
+        code: BRIDGE_JSON_RPC_ERRORS.INVALID_PARAMS,
+      });
+    }
+  });
+
+  it("persists and reuses an exact pending chat after failure and resume", async () => {
+    const requests: Array<Record<string, unknown>> = [];
+    let chatCount = 0;
+    const endpoint = await listen(async (incoming, response) => {
+      response.setHeader("content-type", "application/json");
+      if (incoming.method === "GET") {
+        response.end(
+          JSON.stringify({ status: "ok", version: "test", agents: [] }),
+        );
+        return;
+      }
+      const body = (await readJson(incoming)) as Record<string, unknown>;
+      requests.push(body);
+      chatCount += 1;
+      if (chatCount === 1) {
+        response.statusCode = 503;
+        response.end(JSON.stringify({ error: "retry this turn" }));
+        return;
+      }
+      response.end(
+        JSON.stringify({
+          response: `answer-${chatCount}`,
+          session_id:
+            typeof body.session_id === "string"
+              ? body.session_id
+              : "remote-session",
+          agent_logs: [],
+          requested_model: "claude-opus-5",
+          model: "claude-opus-5",
+        }),
+      );
+    });
+    const threadId = "thr_pending_retry";
+    const firstStart = await request("thread/start", {
+      threadId,
+      cwd: "/workspace/rapp",
+      instructionMode: "append",
+      options: options(endpoint),
+    });
+    const identity = firstStart.result as { providerThreadId: string };
+
+    await request("turn/start", {
+      threadId,
+      providerThreadId: identity.providerThreadId,
+      input: [{ type: "text", text: "original prompt", mentions: [] }],
+      clientRequestId: "creq_23456789ac",
+      options: options(endpoint),
+    });
+    await waitFor(
+      () =>
+        threadDeltas(threadId).some(
+          (delta) =>
+            delta.kind === "turn.boundary" && delta.status === "failed",
+        ),
+      "initial pending turn did not fail",
+    );
+
+    experimental_resetRappBridgeForTests(dataDir);
+    await request("thread/resume", {
+      threadId,
+      providerThreadId: identity.providerThreadId,
+      cwd: "/workspace/rapp",
+      instructionMode: "append",
+      options: options(endpoint),
+    });
+    await request("turn/start", {
+      threadId,
+      providerThreadId: identity.providerThreadId,
+      input: [{ type: "text", text: "replacement prompt", mentions: [] }],
+      clientRequestId: "creq_23456789ad",
+      options: options(endpoint),
+    });
+    await waitForCompletedTurn(threadId);
+
+    await request("turn/start", {
+      threadId,
+      providerThreadId: identity.providerThreadId,
+      input: [{ type: "text", text: "next prompt", mentions: [] }],
+      clientRequestId: "creq_23456789ae",
+      options: options(endpoint),
+    });
+    await waitFor(
+      () =>
+        threadDeltas(threadId).filter(
+          (delta) =>
+            delta.kind === "turn.boundary" && delta.status === "completed",
+        ).length === 2,
+      "new turn did not complete after pending success",
+    );
+
+    expect(requests[0]).toEqual({
+      user_input: "original prompt",
+      idempotency_key: "creq_23456789ac",
+      conversation_history: [
+        {
+          role: "user",
+          content: "BB thread instructions:\nBe concise.",
+        },
+      ],
+    });
+    expect(requests[1]).toEqual(requests[0]);
+    expect(requests[2]).toMatchObject({
+      user_input: "next prompt",
+      session_id: "remote-session",
+      idempotency_key: "creq_23456789ae",
+      conversation_history: [
+        {
+          role: "user",
+          content: "BB thread instructions:\nBe concise.",
+        },
+        { role: "user", content: "original prompt" },
+        { role: "assistant", content: "answer-2" },
+      ],
+    });
+  });
+
+  it("serializes model selection and full chats across Consumer threads", async () => {
+    let activeModel = "";
+    let chatCount = 0;
+    let releaseFirstChat: () => void = () => {};
+    const firstChatGate = new Promise<void>((resolve) => {
+      releaseFirstChat = resolve;
+    });
+    const events: string[] = [];
+    const endpoint = await listen(async (incoming, response) => {
+      response.setHeader("content-type", "application/json");
+      if (incoming.method === "GET") {
+        response.end(
+          JSON.stringify({ status: "ok", version: "test", agents: [] }),
+        );
+        return;
+      }
+      const body = (await readJson(incoming)) as { model?: string };
+      if (incoming.url === "/models/set") {
+        activeModel = body.model ?? "";
+        events.push(`set:${activeModel}`);
+        response.end(JSON.stringify({ model: activeModel }));
+        return;
+      }
+      chatCount += 1;
+      const thisChat = chatCount;
+      events.push(`chat-start:${activeModel}`);
+      if (thisChat === 1) {
+        await firstChatGate;
+      }
+      events.push(`chat-end:${activeModel}`);
+      response.end(
+        JSON.stringify({
+          response: `answer:${activeModel}`,
+          session_id: `session-${thisChat}`,
+          agent_logs: [],
+          requested_model: activeModel,
+          model: activeModel,
+        }),
+      );
+    });
+
+    const firstThread = "thr_model_a";
+    const secondThread = "thr_model_b";
+    const firstStart = await request("thread/start", {
+      threadId: firstThread,
+      cwd: "/workspace/rapp",
+      instructionMode: "append",
+      options: options(endpoint, "model-a"),
+    });
+    const secondStart = await request("thread/start", {
+      threadId: secondThread,
+      cwd: "/workspace/rapp",
+      instructionMode: "append",
+      options: options(endpoint, "model-b"),
+    });
+    const firstIdentity = firstStart.result as { providerThreadId: string };
+    const secondIdentity = secondStart.result as { providerThreadId: string };
+
+    await request("turn/start", {
+      threadId: firstThread,
+      providerThreadId: firstIdentity.providerThreadId,
+      input: [{ type: "text", text: "first", mentions: [] }],
+      clientRequestId: "creq_aaaaabbbbb",
+      options: options(endpoint, "model-a"),
+    });
+    await waitFor(
+      () => events.includes("chat-start:model-a"),
+      "first Consumer chat did not start",
+    );
+    await request("turn/start", {
+      threadId: secondThread,
+      providerThreadId: secondIdentity.providerThreadId,
+      input: [{ type: "text", text: "second", mentions: [] }],
+      clientRequestId: "creq_cccccddddd",
+      options: options(endpoint, "model-b"),
+    });
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(events).toEqual(["set:model-a", "chat-start:model-a"]);
+
+    releaseFirstChat();
+    await Promise.all([
+      waitForCompletedTurn(firstThread),
+      waitForCompletedTurn(secondThread),
+    ]);
+    expect(events).toEqual([
+      "set:model-a",
+      "chat-start:model-a",
+      "chat-end:model-a",
+      "set:model-b",
+      "chat-start:model-b",
+      "chat-end:model-b",
+    ]);
+    expect(
+      threadDeltas(firstThread).find(
+        (delta) => delta.kind === "extension.state",
+      ),
+    ).toMatchObject({
+      payload: {
+        selectedModel: "model-a",
+        requestedModel: "model-a",
+        actualModel: "model-a",
+      },
+    });
+    expect(
+      threadDeltas(secondThread).find(
+        (delta) => delta.kind === "extension.state",
+      ),
+    ).toMatchObject({
+      payload: {
+        selectedModel: "model-b",
+        requestedModel: "model-b",
+        actualModel: "model-b",
+      },
+    });
+  });
+
+  it("interrupts only the active turn and keeps the RAPP session usable", async () => {
+    let chatCount = 0;
+    const prompts: unknown[] = [];
+    const endpoint = await listen(async (incoming, response) => {
+      response.setHeader("content-type", "application/json");
+      if (incoming.method === "GET") {
+        response.end(
+          JSON.stringify({ status: "ok", version: "test", agents: [] }),
+        );
+        return;
+      }
+      const body = (await readJson(incoming)) as Record<string, unknown>;
+      prompts.push(body.user_input);
+      chatCount += 1;
+      if (chatCount === 1) {
+        response.write('{"response":"waiting');
+        setTimeout(() => response.end('"}'), 500);
+        return;
+      }
+      response.end(
+        JSON.stringify({
+          response: "after interrupt",
+          session_id:
+            typeof body.session_id === "string"
+              ? body.session_id
+              : "interrupt-session",
+          agent_logs: [],
+          requested_model: "claude-opus-5",
+          model: "claude-opus-5",
+        }),
+      );
+    });
+    const threadId = "thr_interrupt_keeps_session";
+    const start = await request("thread/start", {
+      threadId,
+      cwd: "/workspace/rapp",
+      instructionMode: "append",
+      options: options(endpoint),
+    });
+    const identity = start.result as { providerThreadId: string };
+
+    await request("turn/start", {
+      threadId,
+      providerThreadId: identity.providerThreadId,
+      input: [{ type: "text", text: "wait", mentions: [] }],
+      clientRequestId: "creq_23456789af",
+      options: options(endpoint),
+    });
+    await waitFor(
+      () => threadDeltas(threadId).some((delta) => delta.kind === "turn.open"),
+      "interruptible turn did not open",
+    );
+    await waitFor(
+      () => prompts.length === 1 && prompts[0] === "wait",
+      "interruptible prompt did not reach Brainstem",
+    );
+    const opened = threadDeltas(threadId).find(
+      (delta) => delta.kind === "turn.open",
+    );
+    const providerTurnId = opened?.providerTurnId;
+    expect(typeof providerTurnId).toBe("string");
+    if (typeof providerTurnId !== "string") {
+      throw new Error("turn.open did not carry a provider turn id");
+    }
+
+    await request("thread/stop", {
+      threadId,
+      providerThreadId: identity.providerThreadId,
+      intent: "interrupt",
+      activeTurnId: providerTurnId,
+    });
+    await waitFor(
+      () =>
+        threadDeltas(threadId).some(
+          (delta) =>
+            delta.kind === "turn.boundary" && delta.status === "interrupted",
+        ),
+      "active turn did not settle as interrupted",
+    );
+
+    await request("turn/start", {
+      threadId,
+      providerThreadId: identity.providerThreadId,
+      input: [{ type: "text", text: "continue", mentions: [] }],
+      clientRequestId: "creq_23456789ag",
+      options: options(endpoint),
+    });
+    await waitFor(
+      () => prompts.length === 2,
+      "second prompt did not reach Brainstem after interrupt",
+    );
+    await waitFor(
+      () =>
+        threadDeltas(threadId).some(
+          (delta) =>
+            delta.kind === "item.textClose" && delta.text === "after interrupt",
+        ),
+      "session was not usable after interrupt",
+    );
+    expect(prompts).toEqual(["wait", "continue"]);
+  }, 15_000);
+
+  it("ignores a stale release and settles persistence failures as failed turns", async () => {
+    const endpoint = await listen(async (incoming, response) => {
+      response.setHeader("content-type", "application/json");
+      if (incoming.method === "GET") {
+        response.end(
+          JSON.stringify({ status: "ok", version: "test", agents: [] }),
+        );
+        return;
+      }
+      response.end(
+        JSON.stringify({
+          response: "still attached",
+          session_id: "stale-stop-session",
+          agent_logs: [],
+          requested_model: "claude-opus-5",
+          model: "claude-opus-5",
+        }),
+      );
+    });
+    const threadId = "thr_stale_stop";
+    const start = await request("thread/start", {
+      threadId,
+      cwd: "/workspace/rapp",
+      instructionMode: "append",
+      options: options(endpoint),
+    });
+    const identity = start.result as { providerThreadId: string };
+    await request("thread/stop", {
+      threadId,
+      providerThreadId: "rapp_stale_identity",
+      intent: "release",
+      activeTurnId: null,
+    });
+    await request("turn/start", {
+      threadId,
+      providerThreadId: identity.providerThreadId,
+      input: [{ type: "text", text: "still here", mentions: [] }],
+      clientRequestId: "creq_23456789ah",
+      options: options(endpoint),
+    });
+    await waitForCompletedTurn(threadId);
+
+    const brokenThreadId = "thr_persistence_failure";
+    const brokenStart = await request("thread/start", {
+      threadId: brokenThreadId,
+      cwd: "/workspace/rapp",
+      instructionMode: "append",
+      options: options(endpoint),
+    });
+    const brokenIdentity = brokenStart.result as {
+      providerThreadId: string;
+    };
+    rmSync(join(dataDir, "sessions"), { recursive: true, force: true });
+    writeFileSync(join(dataDir, "sessions"), "not a directory");
+    await request("turn/start", {
+      threadId: brokenThreadId,
+      providerThreadId: brokenIdentity.providerThreadId,
+      input: [{ type: "text", text: "cannot persist", mentions: [] }],
+      clientRequestId: "creq_23456789aj",
+      options: options(endpoint),
+    });
+    await waitFor(
+      () =>
+        threadDeltas(brokenThreadId).some(
+          (delta) =>
+            delta.kind === "turn.boundary" && delta.status === "failed",
+        ),
+      "persistence failure did not settle the turn",
+    );
+    expect(
+      threadDeltas(brokenThreadId).some(
+        (delta) => delta.kind === "item.textClose",
+      ),
+    ).toBe(false);
+  });
+
+  it("carries instructions, history, idempotency, logs, and RAPP/1 state across resume", async () => {
+    const requests: Array<Record<string, unknown>> = [];
+    const paths: string[] = [];
+    const endpoint = await listen(async (incoming, response) => {
+      if (incoming.method === "GET") {
+        response.setHeader("content-type", "application/json");
+        response.end(
+          JSON.stringify({
+            status: "ok",
+            version: "test",
+            agents: [],
+          }),
+        );
+        return;
+      }
+      const body = await readJson(incoming);
+      const parsed = body as Record<string, unknown>;
+      requests.push(parsed);
+      paths.push(incoming.url ?? "");
+      response.setHeader("content-type", "application/json");
+      response.end(
+        JSON.stringify({
+          response: `answer-${requests.length}`,
+          session_id:
+            typeof parsed.session_id === "string"
+              ? parsed.session_id
+              : "session-1",
+          agent_logs: `Agent-${requests.length}`,
+          model: "grail-model",
+          requested_model: "claude-opus-5",
+        }),
+      );
+    });
+    const threadId = "thr_rapp";
+    const start = await request("thread/start", {
+      threadId,
+      cwd: "/workspace/rapp",
+      instructionMode: "append",
+      options: options(endpoint),
+    });
+    const identity = start.result as { providerThreadId: string };
+
+    await request("turn/start", {
+      threadId,
+      providerThreadId: identity.providerThreadId,
+      input: [{ type: "text", text: "first", mentions: [] }],
+      clientRequestId: "creq_abcdefghjk",
+      options: options(endpoint),
+    });
+    await waitForCompletedTurn(threadId);
+    await request("thread/stop", {
+      threadId,
+      providerThreadId: identity.providerThreadId,
+      intent: "release",
+      activeTurnId: null,
+    });
+    await request("thread/resume", {
+      threadId,
+      providerThreadId: identity.providerThreadId,
+      cwd: "/workspace/rapp",
+      instructionMode: "append",
+      options: options(endpoint),
+    });
+
+    await request("turn/start", {
+      threadId,
+      providerThreadId: identity.providerThreadId,
+      input: [{ type: "text", text: "second", mentions: [] }],
+      clientRequestId: "creq_mnpqrstuvw",
+      options: options(endpoint),
+    });
+    await waitFor(
+      () =>
+        threadDeltas(threadId).filter(
+          (delta) =>
+            delta.kind === "turn.boundary" && delta.status === "completed",
+        ).length === 2,
+      "second turn did not settle after resume",
+    );
+
+    expect(requests).toHaveLength(2);
+    expect(paths).toEqual(["/chat", "/chat"]);
+    expect(requests[0]).toMatchObject({
+      user_input: "first",
+      idempotency_key: "creq_abcdefghjk",
+      conversation_history: [
+        {
+          role: "user",
+          content: "BB thread instructions:\nBe concise.",
+        },
+      ],
+    });
+    expect(requests[1]).toMatchObject({
+      user_input: "second",
+      idempotency_key: "creq_mnpqrstuvw",
+      conversation_history: [
+        {
+          role: "user",
+          content: "BB thread instructions:\nBe concise.",
+        },
+        { role: "user", content: "first" },
+        { role: "assistant", content: "answer-1" },
+      ],
+    });
+
+    const deltas = threadDeltas(threadId);
+    expect(
+      deltas
+        .filter((delta) => delta.kind === "item.textClose")
+        .map((delta) => delta.text),
+    ).toEqual(["answer-1", "answer-2"]);
+    const states = deltas.filter((delta) => delta.kind === "extension.state");
+    expect(states.at(-1)).toMatchObject({
+      payload: {
+        spec: RAPP_SPEC,
+        grail: "consumer",
+        sessionId: "session-1",
+        turnCount: 2,
+        eggAddress: expect.stringMatching(/^[0-9a-f]{64}$/u),
+        selectedModel: RAPP_MODEL_ID,
+        requestedModel: "claude-opus-5",
+        actualModel: "grail-model",
+      },
+    });
+    expect(
+      deltas
+        .filter(
+          (delta) =>
+            delta.kind === "item.close" &&
+            (delta.item as { tool?: string } | undefined)?.tool ===
+              "rapp_agents",
+        )
+        .map((delta) => (delta.item as { result?: string }).result),
+    ).toEqual(["Agent-1", "Agent-2"]);
+  });
+});

--- a/plugins/provider-rapp/provider-bridge.test.ts
+++ b/plugins/provider-rapp/provider-bridge.test.ts
@@ -491,8 +491,8 @@ describe("RAPP provider bridge", () => {
       payload: {
         grail: "business",
         selectedModel: RAPP_BUSINESS_MODEL_ID,
-        requestedModel: RAPP_BUSINESS_MODEL_ID,
-        actualModel: RAPP_BUSINESS_MODEL_ID,
+        requestedModel: null,
+        actualModel: null,
       },
     });
   });

--- a/plugins/provider-rapp/provider-bridge.test.ts
+++ b/plugins/provider-rapp/provider-bridge.test.ts
@@ -574,8 +574,7 @@ describe("RAPP provider bridge", () => {
     expect(chatCalls).toBe(1);
     expect(
       threadDeltas(threadId).some(
-        (delta) =>
-          agentMessageText(delta) === "after local precondition retry",
+        (delta) => agentMessageText(delta) === "after local precondition retry",
       ),
     ).toBe(true);
   });
@@ -835,7 +834,7 @@ describe("RAPP provider bridge", () => {
     ).toMatchObject({
       error: {
         message: expect.stringContaining(
-          "Explicitly interrupt/stop this thread",
+          "Start a new thread to continue safely",
         ),
       },
     });
@@ -924,8 +923,7 @@ describe("RAPP provider bridge", () => {
     await waitFor(
       () =>
         (new RappSessionStore(dataDir).load(identity.providerThreadId)
-          ?.pendingDelivery ??
-          null) !== null,
+          ?.pendingDelivery ?? null) !== null,
       "completed response was not committed to the delivery journal",
     );
 
@@ -973,9 +971,7 @@ describe("RAPP provider bridge", () => {
       providerTurnId,
     });
     expect(
-      threadDeltas(threadId).find(
-        (delta) => delta.kind === "extension.state",
-      ),
+      threadDeltas(threadId).find((delta) => delta.kind === "extension.state"),
     ).toMatchObject({
       payload: {
         grail: "consumer",
@@ -1010,6 +1006,98 @@ describe("RAPP provider bridge", () => {
       "acknowledging follow-up turn did not settle locally",
     );
     expect(chatCalls).toBe(1);
+    expect(
+      new RappSessionStore(dataDir).load(identity.providerThreadId)
+        ?.pendingDelivery,
+    ).toBeNull();
+  });
+
+  it("does not replay a delivery already marked emitted on a normal bridge restart", async () => {
+    let chatCalls = 0;
+    const endpoint = await listen(async (incoming, response) => {
+      response.setHeader("content-type", "application/json");
+      if (incoming.method === "GET") {
+        response.end(
+          JSON.stringify({ status: "ok", version: "test", agents: [] }),
+        );
+        return;
+      }
+      await readJson(incoming);
+      chatCalls += 1;
+      response.end(
+        JSON.stringify({
+          response: "persisted answer",
+          session_id: "persisted-session",
+          agent_logs: [],
+          requested_model: "claude-opus-5",
+          model: "claude-opus-5",
+        }),
+      );
+    });
+    const threadId = "thr_emitted_delivery_restart";
+    const start = await request("thread/start", {
+      threadId,
+      cwd: "/workspace/rapp",
+      instructionMode: "append",
+      options: options(endpoint),
+    });
+    const identity = start.result as { providerThreadId: string };
+
+    await request("turn/start", {
+      threadId,
+      providerThreadId: identity.providerThreadId,
+      input: [{ type: "text", text: "persist once", mentions: [] }],
+      clientRequestId: "creq_abcdefghjv",
+      options: options(endpoint),
+    });
+    await waitForCompletedTurn(threadId);
+    expect(
+      new RappSessionStore(dataDir).load(identity.providerThreadId)
+        ?.pendingDelivery?.phase,
+    ).toBe("emitted");
+
+    experimental_resetRappBridgeForTests(dataDir);
+    const resumeStartIndex = harness.messages.length;
+    await request("thread/resume", {
+      threadId,
+      providerThreadId: identity.providerThreadId,
+      cwd: "/workspace/rapp",
+      instructionMode: "append",
+      options: options(endpoint),
+    });
+
+    expect(chatCalls).toBe(1);
+    expect(
+      harness.messages
+        .slice(resumeStartIndex)
+        .flatMap((message) => {
+          if (message.method !== "thread/delta") {
+            return [];
+          }
+          const params = message.params as {
+            threadId?: string;
+            deltas?: Array<Record<string, unknown>>;
+          };
+          return params.threadId === threadId ? (params.deltas ?? []) : [];
+        })
+        .filter((delta) => agentMessageText(delta) === "persisted answer"),
+    ).toEqual([]);
+
+    await request("turn/start", {
+      threadId,
+      providerThreadId: identity.providerThreadId,
+      input: [{ type: "text", text: "   ", mentions: [] }],
+      clientRequestId: "creq_abcdefghjw",
+      options: options(endpoint),
+    });
+    await waitFor(
+      () =>
+        threadDeltas(threadId).some(
+          (delta) =>
+            delta.kind === "turn.boundary" && delta.status === "failed",
+        ),
+      "post-restart acknowledgement turn did not settle locally",
+    );
     expect(
       new RappSessionStore(dataDir).load(identity.providerThreadId)
         ?.pendingDelivery,
@@ -1061,8 +1149,7 @@ describe("RAPP provider bridge", () => {
     await waitFor(
       () =>
         (new RappSessionStore(dataDir).load(identity.providerThreadId)
-          ?.pendingDelivery ??
-          null) !== null,
+          ?.pendingDelivery ?? null) !== null,
       "delivery journal was acknowledged despite the injected crash",
     );
     expect(
@@ -1634,15 +1721,14 @@ describe("RAPP provider bridge", () => {
       deltas
         .map(agentMessageText)
         .filter((text): text is string => text !== null),
-    ).toEqual(["answer-1", "answer-1", "answer-2"]);
+    ).toEqual(["answer-1", "answer-2"]);
     const collector = createBridgeDeltaEventCollector(RAPP_PROVIDER_ID);
     const assembled = harness.messages.flatMap((message) =>
       collector.assembleMessage(message),
     );
     expect(
       assembled.flatMap((event) =>
-        event.type === "item/completed" &&
-        event.item.type === "agentMessage"
+        event.type === "item/completed" && event.item.type === "agentMessage"
           ? [event.item.text]
           : [],
       ),

--- a/plugins/provider-rapp/server.test.ts
+++ b/plugins/provider-rapp/server.test.ts
@@ -4,8 +4,10 @@ import rappPlugin from "./server.js";
 import {
   RAPP_BRAINSTEM_SECRET_ENV,
   RAPP_BRAINSTEM_URL_ENV,
+  RAPP_BUSINESS_REASONING_DESCRIPTION,
   RAPP_BUSINESS_MODEL_ID,
   RAPP_BUSINESS_URL_ENV,
+  RAPP_CONSUMER_REASONING_DESCRIPTION,
   RAPP_ENDPOINT_URL_REQUIREMENTS,
   RAPP_FUNCTION_KEY_ENV,
   RAPP_MODEL_ID,
@@ -21,8 +23,7 @@ const invalidEndpointSettings = [
   },
   {
     label: "a sig query parameter",
-    endpoint:
-      "https://example.com/api/businessinsightbot_function?sig=secret",
+    endpoint: "https://example.com/api/businessinsightbot_function?sig=secret",
   },
   {
     label: "a signature query parameter",
@@ -30,8 +31,7 @@ const invalidEndpointSettings = [
   },
   {
     label: "an auth query parameter",
-    endpoint:
-      "https://example.com/api/businessinsightbot_function?auth=secret",
+    endpoint: "https://example.com/api/businessinsightbot_function?auth=secret",
   },
   {
     label: "a credential query parameter",
@@ -106,6 +106,12 @@ describe("RAPP provider registration", () => {
       }),
     ]);
     expect(declaration.extensionKinds).toHaveProperty("session.state");
+    expect(declaration.reasoningLevels).toEqual([
+      expect.objectContaining({
+        id: "none",
+        description: RAPP_CONSUMER_REASONING_DESCRIPTION,
+      }),
+    ]);
     expect(
       Object.keys(host.harness.registrations.settingsDescriptors).sort(),
     ).toEqual(["endpoint", "grail"]);
@@ -157,6 +163,17 @@ describe("RAPP provider registration", () => {
       expect.objectContaining({
         id: RAPP_BUSINESS_MODEL_ID,
         isDefault: true,
+        supportedReasoningEfforts: [
+          expect.objectContaining({
+            description: RAPP_BUSINESS_REASONING_DESCRIPTION,
+          }),
+        ],
+      }),
+    ]);
+    expect(registrations[0]?.reasoningLevels).toEqual([
+      expect.objectContaining({
+        id: "none",
+        description: RAPP_BUSINESS_REASONING_DESCRIPTION,
       }),
     ]);
   });

--- a/plugins/provider-rapp/server.test.ts
+++ b/plugins/provider-rapp/server.test.ts
@@ -1,0 +1,105 @@
+import { createFakePluginHost } from "@get-bb/plugin-sdk/testing";
+import { describe, expect, it } from "vitest";
+import rappPlugin from "./server.js";
+import {
+  RAPP_BRAINSTEM_SECRET_ENV,
+  RAPP_BRAINSTEM_URL_ENV,
+  RAPP_BUSINESS_MODEL_ID,
+  RAPP_BUSINESS_URL_ENV,
+  RAPP_FUNCTION_KEY_ENV,
+  RAPP_MODEL_ID,
+  RAPP_PROVIDER_ID,
+  RAPP_USER_GUID_ENV,
+} from "./src/vocabulary.js";
+
+async function registration(
+  settings: { grail: "consumer" | "business"; endpoint: string } = {
+    grail: "consumer",
+    endpoint: "",
+  },
+) {
+  const host = createFakePluginHost({
+    pluginId: "provider-rapp",
+    settings,
+  });
+  await rappPlugin(host.bb);
+  const declaration = host.harness.registrations.providerRegistrations.find(
+    (entry) => entry.id === RAPP_PROVIDER_ID,
+  );
+  if (declaration === undefined) {
+    throw new Error("expected RAPP provider registration");
+  }
+  return { declaration, host };
+}
+
+describe("RAPP provider registration", () => {
+  it("registers one Brainstem provider with Consumer catalog routing", async () => {
+    const { declaration, host } = await registration();
+    expect(declaration.displayName).toBe("RAPP Brainstem");
+    expect(declaration.experimental_bridgeOptions).toEqual({
+      grail: "consumer",
+      endpoint: "",
+    });
+    expect(declaration.models?.fallback).toEqual([
+      expect.objectContaining({
+        id: RAPP_MODEL_ID,
+        displayName: "GitHub Copilot (Brainstem default)",
+        isDefault: true,
+      }),
+    ]);
+    expect(declaration.extensionKinds).toHaveProperty("session.state");
+    expect(
+      Object.keys(host.harness.registrations.settingsDescriptors).sort(),
+    ).toEqual(["endpoint", "grail"]);
+    expect(
+      host.harness.registrations.providerRegistrations.map((entry) => entry.id),
+    ).toEqual([RAPP_PROVIDER_ID]);
+  });
+
+  it("keeps secrets in host environment and derives only the selected model", async () => {
+    const { declaration } = await registration();
+    expect(declaration.env?.passthrough).toEqual([
+      RAPP_BRAINSTEM_URL_ENV,
+      RAPP_BRAINSTEM_SECRET_ENV,
+      RAPP_BUSINESS_URL_ENV,
+      RAPP_FUNCTION_KEY_ENV,
+      RAPP_USER_GUID_ENV,
+    ]);
+    expect(
+      declaration.deriveProviderOptions?.({
+        threadId: "thr_rapp",
+        projectId: "proj_rapp",
+        model: "claude-opus-5",
+        permissionMode: "full",
+        settings: {
+          grail: "consumer",
+          endpoint: "http://127.0.0.1:7071",
+        },
+      }),
+    ).toEqual({ model: "claude-opus-5" });
+  });
+
+  it("safely re-registers the same provider with Business catalog routing", async () => {
+    const { host } = await registration();
+    await host.harness.setSettings({
+      grail: "business",
+      endpoint: "https://example.azurewebsites.net",
+    });
+
+    const registrations =
+      host.harness.registrations.providerRegistrations.filter(
+        (entry) => entry.id === RAPP_PROVIDER_ID,
+      );
+    expect(registrations).toHaveLength(1);
+    expect(registrations[0]?.experimental_bridgeOptions).toEqual({
+      grail: "business",
+      endpoint: "https://example.azurewebsites.net",
+    });
+    expect(registrations[0]?.models?.fallback).toEqual([
+      expect.objectContaining({
+        id: RAPP_BUSINESS_MODEL_ID,
+        isDefault: true,
+      }),
+    ]);
+  });
+});

--- a/plugins/provider-rapp/server.test.ts
+++ b/plugins/provider-rapp/server.test.ts
@@ -6,11 +6,50 @@ import {
   RAPP_BRAINSTEM_URL_ENV,
   RAPP_BUSINESS_MODEL_ID,
   RAPP_BUSINESS_URL_ENV,
+  RAPP_ENDPOINT_URL_REQUIREMENTS,
   RAPP_FUNCTION_KEY_ENV,
   RAPP_MODEL_ID,
   RAPP_PROVIDER_ID,
   RAPP_USER_GUID_ENV,
+  rappPluginSettingsSchema,
 } from "./src/vocabulary.js";
+
+const invalidEndpointSettings = [
+  {
+    label: "a generic query parameter",
+    endpoint: "https://example.com/chat?tenant=test",
+  },
+  {
+    label: "a sig query parameter",
+    endpoint:
+      "https://example.com/api/businessinsightbot_function?sig=secret",
+  },
+  {
+    label: "a signature query parameter",
+    endpoint: "https://example.com/chat?signature=secret",
+  },
+  {
+    label: "an auth query parameter",
+    endpoint:
+      "https://example.com/api/businessinsightbot_function?auth=secret",
+  },
+  {
+    label: "a credential query parameter",
+    endpoint: "https://example.com/chat?credential=secret",
+  },
+  {
+    label: "a username",
+    endpoint: "https://user@example.com/chat",
+  },
+  {
+    label: "a password",
+    endpoint: "https://:password@example.com/chat",
+  },
+  {
+    label: "a fragment",
+    endpoint: "https://example.com/chat#tenant",
+  },
+];
 
 async function registration(
   settings: { grail: "consumer" | "business"; endpoint: string } = {
@@ -31,6 +70,25 @@ async function registration(
   }
   return { declaration, host };
 }
+
+describe("RAPP endpoint setting validation", () => {
+  it.each(invalidEndpointSettings)("rejects $label", ({ endpoint }) => {
+    const result = rappPluginSettingsSchema.safeParse({
+      grail: "consumer",
+      endpoint,
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues).toContainEqual(
+        expect.objectContaining({
+          path: ["endpoint"],
+          message: RAPP_ENDPOINT_URL_REQUIREMENTS,
+        }),
+      );
+    }
+  });
+});
 
 describe("RAPP provider registration", () => {
   it("registers one Brainstem provider with Consumer catalog routing", async () => {

--- a/plugins/provider-rapp/server.ts
+++ b/plugins/provider-rapp/server.ts
@@ -6,8 +6,10 @@ import {
   RAPP_BRAINSTEM_SECRET_ENV,
   RAPP_BRAINSTEM_URL_ENV,
   RAPP_BRAINSTEM_MODEL,
+  RAPP_BUSINESS_REASONING_DESCRIPTION,
   RAPP_BUSINESS_MODEL,
   RAPP_BUSINESS_URL_ENV,
+  RAPP_CONSUMER_REASONING_DESCRIPTION,
   RAPP_FUNCTION_KEY_ENV,
   RAPP_PROVIDER_ID,
   RAPP_USER_GUID_ENV,
@@ -50,7 +52,9 @@ function providerDeclaration(
         id: "none",
         label: "Brainstem",
         description:
-          "RAPP Brainstem owns GitHub Copilot reasoning and execution.",
+          settings.grail === "consumer"
+            ? RAPP_CONSUMER_REASONING_DESCRIPTION
+            : RAPP_BUSINESS_REASONING_DESCRIPTION,
       },
     ],
     composerActions: [],

--- a/plugins/provider-rapp/server.ts
+++ b/plugins/provider-rapp/server.ts
@@ -1,0 +1,140 @@
+import type {
+  BbPluginApi,
+  PluginProviderDeclaration,
+} from "@get-bb/plugin-sdk";
+import {
+  RAPP_BRAINSTEM_SECRET_ENV,
+  RAPP_BRAINSTEM_URL_ENV,
+  RAPP_BRAINSTEM_MODEL,
+  RAPP_BUSINESS_MODEL,
+  RAPP_BUSINESS_URL_ENV,
+  RAPP_FUNCTION_KEY_ENV,
+  RAPP_PROVIDER_ID,
+  RAPP_USER_GUID_ENV,
+  rappEndpointSettingSchema,
+  rappExtensionKinds,
+  rappPluginSettingsSchema,
+  type RappPluginSettings,
+} from "./src/vocabulary.js";
+
+function providerDeclaration(
+  settings: RappPluginSettings,
+): PluginProviderDeclaration {
+  return {
+    id: RAPP_PROVIDER_ID,
+    displayName: "RAPP Brainstem",
+    icon: "./icons/rapp.svg",
+    strings: {
+      signInHint:
+        "Start RAPP Brainstem and complete GitHub Copilot sign-in through Brainstem, or configure the Business Grail deployment and host credentials.",
+      expiredHint:
+        "Refresh the selected RAPP Brainstem deployment credentials, then retry the turn.",
+      installUrl: "https://github.com/kody-w/rapp-installer",
+      brandPrefix: "RAPP ",
+      iconTint: { light: "#5b21b6", dark: "#c4b5fd" },
+    },
+    experimental_bridgeOptions: settings,
+    maintenance: { health: false, usage: false, installation: false },
+    capabilities: {
+      supportsServiceTier: false,
+      supportsNativeUserQuestion: false,
+      fork: "none",
+      supportsManualCompaction: false,
+      supportsThreadArchive: false,
+      supportsThreadRename: false,
+      permissionModes: ["full"],
+      reasoningLevels: ["none"],
+    },
+    reasoningLevels: [
+      {
+        id: "none",
+        label: "Brainstem",
+        description:
+          "RAPP Brainstem owns GitHub Copilot reasoning and execution.",
+      },
+    ],
+    composerActions: [],
+    models: {
+      fallback: [
+        settings.grail === "consumer"
+          ? RAPP_BRAINSTEM_MODEL
+          : RAPP_BUSINESS_MODEL,
+      ],
+      scope: "host",
+    },
+    env: {
+      passthrough: [
+        RAPP_BRAINSTEM_URL_ENV,
+        RAPP_BRAINSTEM_SECRET_ENV,
+        RAPP_BUSINESS_URL_ENV,
+        RAPP_FUNCTION_KEY_ENV,
+        RAPP_USER_GUID_ENV,
+      ],
+    },
+    deriveProviderOptions(context) {
+      return { model: context.model };
+    },
+    extensionKinds: rappExtensionKinds,
+  };
+}
+
+export default async function plugin(bb: BbPluginApi): Promise<void> {
+  const settings = bb.settings.define({
+    grail: {
+      type: "select",
+      label: "RAPP Grail",
+      description:
+        "Consumer uses kody-w/rapp-installer. Business uses microsoft/aibast-agents-library.",
+      options: ["consumer", "business"],
+      default: "consumer",
+    },
+    endpoint: {
+      type: "string",
+      label: "RAPP endpoint",
+      description:
+        "Optional HTTP(S) endpoint override. Leave blank to use the matching RAPP environment variable or the local Consumer Grail.",
+      experimental_schema: rappEndpointSettingSchema,
+      default: "",
+    },
+  });
+
+  let currentSettings = rappPluginSettingsSchema.parse(await settings.get());
+  let registered = bb.providers.register(providerDeclaration(currentSettings));
+  let disposed = false;
+
+  function replaceRegistration(nextValues: RappPluginSettings): void {
+    if (
+      nextValues.grail === currentSettings.grail &&
+      nextValues.endpoint === currentSettings.endpoint
+    ) {
+      return;
+    }
+    const previousSettings = currentSettings;
+    registered.dispose();
+    try {
+      registered = bb.providers.register(providerDeclaration(nextValues));
+      currentSettings = nextValues;
+    } catch (error) {
+      registered = bb.providers.register(providerDeclaration(previousSettings));
+      throw error;
+    }
+  }
+
+  settings.onChange((next) => {
+    if (disposed) {
+      return;
+    }
+    try {
+      replaceRegistration(rappPluginSettingsSchema.parse(next));
+    } catch (error) {
+      bb.log.error(
+        `Could not update RAPP Brainstem routing: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  });
+
+  bb.onDispose(() => {
+    disposed = true;
+    registered.dispose();
+  });
+}

--- a/plugins/provider-rapp/server.ts
+++ b/plugins/provider-rapp/server.ts
@@ -92,7 +92,7 @@ export default async function plugin(bb: BbPluginApi): Promise<void> {
       type: "string",
       label: "RAPP endpoint",
       description:
-        "Optional HTTP(S) endpoint override. Leave blank to use the matching RAPP environment variable or the local Consumer Grail.",
+        "Optional HTTP(S) endpoint override without URL credentials, query parameters, or fragments. Leave blank to use the matching RAPP environment variable or the local Consumer Grail.",
       experimental_schema: rappEndpointSettingSchema,
       default: "",
     },

--- a/plugins/provider-rapp/src/brainstem-process.test.ts
+++ b/plugins/provider-rapp/src/brainstem-process.test.ts
@@ -1,0 +1,680 @@
+import { describe, expect, it } from "vitest";
+import type { RappClientConfig } from "./rapp-client.js";
+import {
+  canonicalLocalBrainstemKey,
+  createBrainstemProcessManager,
+  shouldManageLocalBrainstem,
+  type BrainstemChildProcess,
+  type BrainstemLaunchLock,
+  type BrainstemLaunchLockRequest,
+  type BrainstemProcessDependencies,
+  type BrainstemProcessTimings,
+  type BrainstemSpawnRequest,
+  type BrainstemTimer,
+} from "./brainstem-process.js";
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve(value: T): void;
+}
+
+interface FakeLockWaiter {
+  active: boolean;
+  signal: AbortSignal;
+  onAbort(): void;
+  resolve(lock: BrainstemLaunchLock): void;
+  reject(error: Error): void;
+}
+
+const fastTimings: BrainstemProcessTimings = {
+  startTimeoutMs: 50,
+  healthRetryMs: 5,
+  existingHealthGraceMs: 0,
+  stopTimeoutMs: 10,
+  forceStopTimeoutMs: 5,
+};
+
+const recoveryTimings: BrainstemProcessTimings = {
+  ...fastTimings,
+  existingHealthGraceMs: 10,
+};
+
+function createDeferred<T>(): Deferred<T> {
+  let resolvePromise: ((value: T) => void) | null = null;
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return {
+    promise,
+    resolve(value: T): void {
+      if (resolvePromise === null) {
+        throw new Error("Deferred promise was not initialized");
+      }
+      resolvePromise(value);
+    },
+  };
+}
+
+function config(
+  endpoint: string,
+  grail: RappClientConfig["grail"] = "consumer",
+): RappClientConfig {
+  const url = new URL(endpoint);
+  return {
+    grail,
+    endpoint: url,
+    modelListEndpoint: null,
+    modelSetEndpoint: null,
+    displayEndpoint: url.toString(),
+    headers: {},
+    userGuid: null,
+    timeoutMs: 1_000,
+  };
+}
+
+async function waitUntil(
+  predicate: () => boolean,
+  message: string,
+): Promise<void> {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    if (predicate()) {
+      return;
+    }
+    await Promise.resolve();
+  }
+  throw new Error(message);
+}
+
+function captureRejection(promise: Promise<void>): Promise<Error> {
+  return promise.then(
+    () => new Error("Expected promise to reject"),
+    (error) => (error instanceof Error ? error : new Error(String(error))),
+  );
+}
+
+class FakeTimer implements BrainstemTimer {
+  private active = true;
+
+  constructor(
+    private readonly dependencies: FakeDependencies,
+    private readonly callback: () => void,
+    private readonly delayMs: number,
+    autoRun: boolean,
+  ) {
+    dependencies.addTimer(this);
+    if (autoRun) {
+      queueMicrotask(() => this.run());
+    }
+  }
+
+  get isActive(): boolean {
+    return this.active;
+  }
+
+  cancel(): void {
+    if (!this.active) {
+      return;
+    }
+    this.active = false;
+    this.dependencies.removeTimer(this);
+  }
+
+  unref(): void {}
+
+  run(): void {
+    if (!this.active) {
+      return;
+    }
+    this.active = false;
+    this.dependencies.removeTimer(this);
+    this.dependencies.advanceTime(this.delayMs);
+    this.callback();
+  }
+}
+
+class FakeChild implements BrainstemChildProcess {
+  exitCode: number | null = null;
+  signalCode: NodeJS.Signals | null = null;
+  readonly killSignals: NodeJS.Signals[] = [];
+  autoExitOnKill = true;
+
+  private readonly errorListeners = new Set<(error: Error) => void>();
+  private readonly exitListeners = new Set<
+    (code: number | null, signal: NodeJS.Signals | null) => void
+  >();
+
+  kill(signal: NodeJS.Signals): boolean {
+    this.killSignals.push(signal);
+    if (this.autoExitOnKill) {
+      this.emitExit(null, signal);
+    }
+    return true;
+  }
+
+  onError(listener: (error: Error) => void): () => void {
+    this.errorListeners.add(listener);
+    return () => this.errorListeners.delete(listener);
+  }
+
+  onExit(
+    listener: (code: number | null, signal: NodeJS.Signals | null) => void,
+  ): () => void {
+    this.exitListeners.add(listener);
+    return () => this.exitListeners.delete(listener);
+  }
+
+  emitError(error: Error): void {
+    for (const listener of this.errorListeners) {
+      listener(error);
+    }
+  }
+
+  emitExit(code: number | null, signal: NodeJS.Signals | null): void {
+    this.exitCode = code;
+    this.signalCode = signal;
+    for (const listener of this.exitListeners) {
+      listener(code, signal);
+    }
+  }
+}
+
+class FakeDependencies implements BrainstemProcessDependencies {
+  readonly platform: NodeJS.Platform = "darwin";
+  readonly spawnRequests: BrainstemSpawnRequest[] = [];
+  readonly children: FakeChild[] = [];
+  readonly closedLogs: number[] = [];
+  readonly openedLogs: string[] = [];
+  readonly madeDirectories: string[] = [];
+  readonly lockRequests: BrainstemLaunchLockRequest[] = [];
+  readonly probeUrls: string[] = [];
+  readonly probeSignals: AbortSignal[] = [];
+  readonly env: NodeJS.ProcessEnv = {
+    BRAINSTEM_HOME: "/brainstem-test",
+    HOME: "/home/test",
+    PATH: "/usr/bin",
+  };
+  autoRunTimers = true;
+  spawnFailure: Error | null = null;
+
+  private currentTimeMs = 0;
+  private nextFd = 20;
+  private readonly healthResults: Array<boolean | Promise<boolean>> = [];
+  private readonly timers = new Set<FakeTimer>();
+  private readonly heldLocks = new Set<string>();
+  private readonly lockWaiters = new Map<string, FakeLockWaiter[]>();
+
+  environment(): NodeJS.ProcessEnv {
+    return this.env;
+  }
+
+  homeDirectory(): string {
+    return "/home/test";
+  }
+
+  now(): number {
+    return this.currentTimeMs;
+  }
+
+  advanceTime(delayMs: number): void {
+    this.currentTimeMs += delayMs;
+  }
+
+  fileExists(): boolean {
+    return true;
+  }
+
+  makeDirectory(directoryPath: string): void {
+    this.madeDirectories.push(directoryPath);
+  }
+
+  openLog(filePath: string): number {
+    this.openedLogs.push(filePath);
+    const fd = this.nextFd;
+    this.nextFd += 1;
+    return fd;
+  }
+
+  closeLog(fd: number): void {
+    this.closedLogs.push(fd);
+  }
+
+  spawn(request: BrainstemSpawnRequest): BrainstemChildProcess {
+    this.spawnRequests.push(request);
+    if (this.spawnFailure !== null) {
+      throw this.spawnFailure;
+    }
+    const child = new FakeChild();
+    this.children.push(child);
+    return child;
+  }
+
+  async probeHealth(url: string, signal: AbortSignal): Promise<boolean> {
+    this.probeUrls.push(url);
+    this.probeSignals.push(signal);
+    if (signal.aborted) {
+      throw new Error("probe aborted");
+    }
+    const result = this.healthResults.shift();
+    if (result === undefined) {
+      throw new Error("No fake health result was queued");
+    }
+    return result;
+  }
+
+  acquireLaunchLock(
+    request: BrainstemLaunchLockRequest,
+  ): Promise<BrainstemLaunchLock> {
+    this.lockRequests.push(request);
+    if (request.signal.aborted) {
+      return Promise.reject(new Error("lock aborted"));
+    }
+    if (!this.heldLocks.has(request.lockPath)) {
+      this.heldLocks.add(request.lockPath);
+      return Promise.resolve(this.createLock(request.lockPath));
+    }
+    return new Promise<BrainstemLaunchLock>((resolve, reject) => {
+      const waiter: FakeLockWaiter = {
+        active: true,
+        signal: request.signal,
+        onAbort: () => {
+          if (!waiter.active) {
+            return;
+          }
+          waiter.active = false;
+          reject(new Error("lock aborted"));
+        },
+        resolve,
+        reject,
+      };
+      request.signal.addEventListener("abort", waiter.onAbort, {
+        once: true,
+      });
+      const waiters = this.lockWaiters.get(request.lockPath) ?? [];
+      waiters.push(waiter);
+      this.lockWaiters.set(request.lockPath, waiters);
+    });
+  }
+
+  setTimer(callback: () => void, delayMs: number): BrainstemTimer {
+    return new FakeTimer(this, callback, delayMs, this.autoRunTimers);
+  }
+
+  queueHealth(...results: Array<boolean | Promise<boolean>>): void {
+    this.healthResults.push(...results);
+  }
+
+  addTimer(timer: FakeTimer): void {
+    this.timers.add(timer);
+  }
+
+  removeTimer(timer: FakeTimer): void {
+    this.timers.delete(timer);
+  }
+
+  get activeTimerCount(): number {
+    return [...this.timers].filter((timer) => timer.isActive).length;
+  }
+
+  private createLock(lockPath: string): BrainstemLaunchLock {
+    let released = false;
+    return {
+      release: async (): Promise<void> => {
+        if (released) {
+          return;
+        }
+        released = true;
+        this.heldLocks.delete(lockPath);
+        const waiters = this.lockWaiters.get(lockPath) ?? [];
+        while (waiters.length > 0) {
+          const waiter = waiters.shift();
+          if (waiter === undefined || !waiter.active) {
+            continue;
+          }
+          waiter.active = false;
+          waiter.signal.removeEventListener("abort", waiter.onAbort);
+          this.heldLocks.add(lockPath);
+          waiter.resolve(this.createLock(lockPath));
+          break;
+        }
+        if (waiters.length === 0) {
+          this.lockWaiters.delete(lockPath);
+        } else {
+          this.lockWaiters.set(lockPath, waiters);
+        }
+      },
+    };
+  }
+}
+
+describe("local Brainstem process lifecycle", () => {
+  it("manages only launchable plain-http loopback chat endpoints", async () => {
+    const dependencies = new FakeDependencies();
+    const manager = createBrainstemProcessManager(dependencies, fastTimings);
+    const accepted = config("http://localhost:7071/chat");
+    expect(shouldManageLocalBrainstem(accepted)).toBe(true);
+
+    const rejected = [
+      config("https://localhost:7071/chat"),
+      config("http://10.0.0.1:7071/chat"),
+      config("http://localhost:7071/custom/chat"),
+      config("http://localhost:7071/chat?tenant=test"),
+      config("http://user:secret@localhost:7071/chat"),
+      config("http://localhost:0/chat"),
+      config("http://localhost:7071/chat", "business"),
+    ];
+    for (const item of rejected) {
+      expect(shouldManageLocalBrainstem(item)).toBe(false);
+      await manager.ensureLocalBrainstem(item, new AbortController().signal);
+    }
+
+    expect(dependencies.lockRequests).toEqual([]);
+    expect(dependencies.spawnRequests).toEqual([]);
+    expect(dependencies.probeUrls).toEqual([]);
+  });
+
+  it("canonicalizes loopback aliases and shares their concurrent startup", async () => {
+    const dependencies = new FakeDependencies();
+    const manager = createBrainstemProcessManager(dependencies, fastTimings);
+    const localhost = config("http://localhost:7071/chat");
+    const ipv4 = config("http://127.0.0.1:7071/chat");
+    const ipv6 = config("http://[::1]:7071/chat");
+    expect(canonicalLocalBrainstemKey(localhost)).toBe(
+      canonicalLocalBrainstemKey(ipv4),
+    );
+    expect(canonicalLocalBrainstemKey(ipv4)).toBe(
+      canonicalLocalBrainstemKey(ipv6),
+    );
+
+    const healthy = createDeferred<boolean>();
+    dependencies.queueHealth(false, healthy.promise);
+    const first = manager.ensureLocalBrainstem(
+      localhost,
+      new AbortController().signal,
+    );
+    const second = manager.ensureLocalBrainstem(
+      ipv4,
+      new AbortController().signal,
+    );
+    await waitUntil(
+      () => dependencies.children.length === 1,
+      "Brainstem child was not spawned",
+    );
+
+    expect(dependencies.lockRequests).toHaveLength(1);
+    expect(dependencies.spawnRequests).toHaveLength(1);
+    healthy.resolve(true);
+    await Promise.all([first, second]);
+    expect(dependencies.probeUrls).toEqual([
+      "http://127.0.0.1:7071/health",
+      "http://127.0.0.1:7071/health",
+    ]);
+    await manager.stopManagedBrainstems();
+  });
+
+  it("reuses an already healthy process without taking ownership", async () => {
+    const dependencies = new FakeDependencies();
+    const manager = createBrainstemProcessManager(dependencies, fastTimings);
+    dependencies.queueHealth(true);
+
+    await manager.ensureLocalBrainstem(
+      config("http://127.0.0.1:7071/chat"),
+      new AbortController().signal,
+    );
+    await manager.stopManagedBrainstems();
+
+    expect(dependencies.spawnRequests).toEqual([]);
+    expect(dependencies.children).toEqual([]);
+    expect(dependencies.closedLogs).toEqual([]);
+  });
+
+  it("lets each startup waiter abort without cancelling shared startup", async () => {
+    const dependencies = new FakeDependencies();
+    const manager = createBrainstemProcessManager(dependencies, fastTimings);
+    const healthy = createDeferred<boolean>();
+    dependencies.queueHealth(false, healthy.promise);
+    const firstController = new AbortController();
+    const secondController = new AbortController();
+    const first = manager.ensureLocalBrainstem(
+      config("http://127.0.0.1:7071/chat"),
+      firstController.signal,
+    );
+    const firstError = captureRejection(first);
+    const second = manager.ensureLocalBrainstem(
+      config("http://127.0.0.1:7071/chat"),
+      secondController.signal,
+    );
+    await waitUntil(
+      () => dependencies.children.length === 1,
+      "Brainstem child was not spawned",
+    );
+
+    firstController.abort();
+    expect((await firstError).message).toBe(
+      "RAPP Brainstem startup was interrupted",
+    );
+    expect(dependencies.children[0]?.killSignals).toEqual([]);
+    expect(
+      dependencies.probeSignals.every(
+        (signal) => signal !== firstController.signal,
+      ),
+    ).toBe(true);
+
+    healthy.resolve(true);
+    await second;
+    expect(dependencies.spawnRequests).toHaveLength(1);
+    await manager.stopManagedBrainstems();
+  });
+
+  it("preserves living owned and reused processes across transient health misses", async () => {
+    const ownedDependencies = new FakeDependencies();
+    const ownedManager = createBrainstemProcessManager(
+      ownedDependencies,
+      recoveryTimings,
+    );
+    ownedDependencies.queueHealth(false, false, false, true, false, true);
+    const ownedConfig = config("http://127.0.0.1:7071/chat");
+    await ownedManager.ensureLocalBrainstem(
+      ownedConfig,
+      new AbortController().signal,
+    );
+    await ownedManager.ensureLocalBrainstem(
+      ownedConfig,
+      new AbortController().signal,
+    );
+
+    expect(ownedDependencies.spawnRequests).toHaveLength(1);
+    expect(ownedDependencies.children[0]?.killSignals).toEqual([]);
+
+    const reusedDependencies = new FakeDependencies();
+    const reusedManager = createBrainstemProcessManager(
+      reusedDependencies,
+      recoveryTimings,
+    );
+    reusedDependencies.queueHealth(true, false, true);
+    const reusedConfig = config("http://127.0.0.1:7072/chat");
+    await reusedManager.ensureLocalBrainstem(
+      reusedConfig,
+      new AbortController().signal,
+    );
+    await reusedManager.ensureLocalBrainstem(
+      reusedConfig,
+      new AbortController().signal,
+    );
+
+    expect(reusedDependencies.spawnRequests).toEqual([]);
+    await Promise.all([
+      ownedManager.stopManagedBrainstems(),
+      reusedManager.stopManagedBrainstems(),
+    ]);
+  });
+
+  it("re-probes under the launch lock and reuses a winning process", async () => {
+    const dependencies = new FakeDependencies();
+    const firstManager = createBrainstemProcessManager(
+      dependencies,
+      fastTimings,
+    );
+    const secondManager = createBrainstemProcessManager(
+      dependencies,
+      fastTimings,
+    );
+    const winnerHealthy = createDeferred<boolean>();
+    dependencies.queueHealth(false, winnerHealthy.promise, true);
+    const localConfig = config("http://127.0.0.1:7071/chat");
+    const first = firstManager.ensureLocalBrainstem(
+      localConfig,
+      new AbortController().signal,
+    );
+    await waitUntil(
+      () => dependencies.children.length === 1,
+      "Winning Brainstem child was not spawned",
+    );
+    const second = secondManager.ensureLocalBrainstem(
+      localConfig,
+      new AbortController().signal,
+    );
+    await waitUntil(
+      () => dependencies.lockRequests.length === 2,
+      "Losing manager did not wait for the launch lock",
+    );
+
+    winnerHealthy.resolve(true);
+    await Promise.all([first, second]);
+
+    expect(dependencies.lockRequests).toHaveLength(2);
+    expect(dependencies.spawnRequests).toHaveLength(1);
+    await Promise.all([
+      firstManager.stopManagedBrainstems(),
+      secondManager.stopManagedBrainstems(),
+    ]);
+  });
+
+  it("scrubs remote RAPP settings while preserving Copilot environment", async () => {
+    const dependencies = new FakeDependencies();
+    Object.assign(dependencies.env, {
+      GH_TOKEN: "gh-token",
+      GITHUB_TOKEN: "github-token",
+      COPILOT_TOKEN: "copilot-token",
+      RAPP_BRAINSTEM_URL: "https://remote.example/chat",
+      RAPP_BRAINSTEM_SECRET: "brainstem-secret",
+      RAPP_BUSINESS_URL: "https://business.example/api",
+      RAPP_FUNCTION_KEY: "function-key",
+      RAPP_USER_GUID: "user-guid",
+    });
+    dependencies.queueHealth(false, true);
+    const manager = createBrainstemProcessManager(dependencies, fastTimings);
+
+    await manager.ensureLocalBrainstem(
+      config("http://127.0.0.1:7071/chat"),
+      new AbortController().signal,
+    );
+
+    const request = dependencies.spawnRequests[0];
+    expect(request?.env).toMatchObject({
+      BRAINSTEM_HOME: "/brainstem-test",
+      HOME: "/home/test",
+      PATH: "/usr/bin",
+      GH_TOKEN: "gh-token",
+      GITHUB_TOKEN: "github-token",
+      COPILOT_TOKEN: "copilot-token",
+      PORT: "7071",
+      BRAINSTEM_BB_LAUNCHER: "1",
+      PYTHONUTF8: "1",
+    });
+    expect(request?.env.RAPP_BRAINSTEM_URL).toBeUndefined();
+    expect(request?.env.RAPP_BRAINSTEM_SECRET).toBeUndefined();
+    expect(request?.env.RAPP_BUSINESS_URL).toBeUndefined();
+    expect(request?.env.RAPP_FUNCTION_KEY).toBeUndefined();
+    expect(request?.env.RAPP_USER_GUID).toBeUndefined();
+    expect(dependencies.env.RAPP_FUNCTION_KEY).toBe("function-key");
+    await manager.stopManagedBrainstems();
+  });
+
+  it("handles asynchronous spawn errors and closes owned resources", async () => {
+    const dependencies = new FakeDependencies();
+    const pendingHealth = createDeferred<boolean>();
+    dependencies.queueHealth(false, pendingHealth.promise);
+    const manager = createBrainstemProcessManager(dependencies, fastTimings);
+    const startup = manager.ensureLocalBrainstem(
+      config("http://127.0.0.1:7071/chat"),
+      new AbortController().signal,
+    );
+    const startupError = captureRejection(startup);
+    await waitUntil(
+      () => dependencies.children.length === 1,
+      "Brainstem child was not spawned",
+    );
+
+    dependencies.children[0]?.emitError(new Error("spawn EACCES"));
+    pendingHealth.resolve(false);
+    expect((await startupError).message).toContain("spawn EACCES");
+    expect(dependencies.children[0]?.killSignals).toEqual([]);
+    expect(dependencies.closedLogs).toEqual([20]);
+    expect(dependencies.activeTimerCount).toBe(0);
+    await manager.stopManagedBrainstems();
+  });
+
+  it("closes the log when spawning throws synchronously", async () => {
+    const dependencies = new FakeDependencies();
+    dependencies.spawnFailure = new Error("spawn failed");
+    dependencies.queueHealth(false);
+    const manager = createBrainstemProcessManager(dependencies, fastTimings);
+
+    await expect(
+      manager.ensureLocalBrainstem(
+        config("http://127.0.0.1:7071/chat"),
+        new AbortController().signal,
+      ),
+    ).rejects.toThrow("spawn failed");
+    expect(dependencies.children).toEqual([]);
+    expect(dependencies.closedLogs).toEqual([20]);
+    await manager.stopManagedBrainstems();
+  });
+
+  it("recognizes signal exits and cancels pending wait timers", async () => {
+    const dependencies = new FakeDependencies();
+    dependencies.autoRunTimers = false;
+    dependencies.queueHealth(false, false, false);
+    const manager = createBrainstemProcessManager(dependencies, fastTimings);
+    const startup = manager.ensureLocalBrainstem(
+      config("http://127.0.0.1:7071/chat"),
+      new AbortController().signal,
+    );
+    const startupError = captureRejection(startup);
+    await waitUntil(
+      () => dependencies.activeTimerCount === 1,
+      "Health retry timer was not scheduled",
+    );
+
+    dependencies.children[0]?.emitExit(null, "SIGTERM");
+    const error = await startupError;
+    expect(error.message).toContain("signal SIGTERM");
+    expect(dependencies.activeTimerCount).toBe(0);
+    expect(dependencies.closedLogs).toEqual([20]);
+  });
+
+  it("stops only owned children and remains idempotent", async () => {
+    const dependencies = new FakeDependencies();
+    dependencies.queueHealth(true, false, true);
+    const manager = createBrainstemProcessManager(dependencies, fastTimings);
+    await manager.ensureLocalBrainstem(
+      config("http://127.0.0.1:7071/chat"),
+      new AbortController().signal,
+    );
+    await manager.ensureLocalBrainstem(
+      config("http://127.0.0.1:7072/chat"),
+      new AbortController().signal,
+    );
+
+    await Promise.all([
+      manager.stopManagedBrainstems(),
+      manager.stopManagedBrainstems(),
+    ]);
+    await manager.stopManagedBrainstems();
+
+    expect(dependencies.spawnRequests).toHaveLength(1);
+    expect(dependencies.children[0]?.killSignals).toEqual(["SIGTERM"]);
+    expect(dependencies.closedLogs).toEqual([20]);
+    expect(dependencies.activeTimerCount).toBe(0);
+  });
+});

--- a/plugins/provider-rapp/src/brainstem-process.test.ts
+++ b/plugins/provider-rapp/src/brainstem-process.test.ts
@@ -350,8 +350,12 @@ describe("local Brainstem process lifecycle", () => {
   it("manages only launchable plain-http loopback chat endpoints", async () => {
     const dependencies = new FakeDependencies();
     const manager = createBrainstemProcessManager(dependencies, fastTimings);
-    const accepted = config("http://localhost:7071/chat");
-    expect(shouldManageLocalBrainstem(accepted)).toBe(true);
+    expect(
+      shouldManageLocalBrainstem(config("http://localhost:7071/chat")),
+    ).toBe(true);
+    expect(
+      shouldManageLocalBrainstem(config("http://127.0.0.1:7071/chat")),
+    ).toBe(true);
 
     const rejected = [
       config("https://localhost:7071/chat"),
@@ -372,17 +376,30 @@ describe("local Brainstem process lifecycle", () => {
     expect(dependencies.probeUrls).toEqual([]);
   });
 
-  it("canonicalizes loopback aliases and shares their concurrent startup", async () => {
+  it("does not auto-manage IPv6 loopback endpoints", async () => {
+    const dependencies = new FakeDependencies();
+    const manager = createBrainstemProcessManager(dependencies, fastTimings);
+    const ipv6 = config("http://[::1]:7071/chat");
+
+    expect(canonicalLocalBrainstemKey(ipv6)).toBeNull();
+    expect(shouldManageLocalBrainstem(ipv6)).toBe(false);
+    await manager.ensureLocalBrainstem(
+      ipv6,
+      new AbortController().signal,
+    );
+
+    expect(dependencies.lockRequests).toEqual([]);
+    expect(dependencies.spawnRequests).toEqual([]);
+    expect(dependencies.probeUrls).toEqual([]);
+  });
+
+  it("canonicalizes launcher-served aliases and shares their concurrent startup", async () => {
     const dependencies = new FakeDependencies();
     const manager = createBrainstemProcessManager(dependencies, fastTimings);
     const localhost = config("http://localhost:7071/chat");
     const ipv4 = config("http://127.0.0.1:7071/chat");
-    const ipv6 = config("http://[::1]:7071/chat");
     expect(canonicalLocalBrainstemKey(localhost)).toBe(
       canonicalLocalBrainstemKey(ipv4),
-    );
-    expect(canonicalLocalBrainstemKey(ipv4)).toBe(
-      canonicalLocalBrainstemKey(ipv6),
     );
 
     const healthy = createDeferred<boolean>();

--- a/plugins/provider-rapp/src/brainstem-process.ts
+++ b/plugins/provider-rapp/src/brainstem-process.ts
@@ -1,0 +1,1048 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { closeSync, existsSync, mkdirSync, openSync } from "node:fs";
+import {
+  mkdir as mkdirAsync,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { homedir } from "node:os";
+import path from "node:path";
+import { z } from "zod";
+import type { RappClientConfig } from "./rapp-client.js";
+import {
+  RAPP_BRAINSTEM_SECRET_ENV,
+  RAPP_BRAINSTEM_URL_ENV,
+  RAPP_BUSINESS_URL_ENV,
+  RAPP_FUNCTION_KEY_ENV,
+  RAPP_USER_GUID_ENV,
+} from "./vocabulary.js";
+
+const START_TIMEOUT_MS = 90_000;
+const HEALTH_TIMEOUT_MS = 1_500;
+const HEALTH_RETRY_MS = 500;
+const EXISTING_HEALTH_GRACE_MS = 3_000;
+const STOP_TIMEOUT_MS = 5_000;
+const FORCE_STOP_TIMEOUT_MS = 1_000;
+const LOCK_RETRY_MS = 100;
+const LOCK_OWNER_GRACE_MS = 5_000;
+const LOCK_EXPIRY_GRACE_MS = 15_000;
+const LOCK_OWNER_FILE = "owner";
+
+const healthSchema = z.object({
+  status: z.enum(["ok", "unauthenticated"]),
+  version: z.string(),
+  agents: z.array(z.string()),
+});
+
+const scrubbedEnvironmentVariables = new Set(
+  [
+    RAPP_BRAINSTEM_URL_ENV,
+    RAPP_BRAINSTEM_SECRET_ENV,
+    RAPP_BUSINESS_URL_ENV,
+    RAPP_FUNCTION_KEY_ENV,
+    RAPP_USER_GUID_ENV,
+  ].map((name) => name.toUpperCase()),
+);
+
+interface LocalBrainstemAddress {
+  key: string;
+  port: number;
+  baseUrl: string;
+  healthUrl: string;
+}
+
+interface BrainstemConfig extends LocalBrainstemAddress {
+  sourceDir: string;
+  python: string;
+  logFile: string;
+  lockPath: string;
+}
+
+export interface BrainstemTimer {
+  cancel(): void;
+  unref(): void;
+}
+
+export interface BrainstemChildProcess {
+  readonly exitCode: number | null;
+  readonly signalCode: NodeJS.Signals | null;
+  kill(signal: NodeJS.Signals): boolean;
+  onError(listener: (error: Error) => void): () => void;
+  onExit(
+    listener: (code: number | null, signal: NodeJS.Signals | null) => void,
+  ): () => void;
+}
+
+export interface BrainstemSpawnRequest {
+  command: string;
+  args: string[];
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  logFd: number;
+}
+
+export interface BrainstemLaunchLockRequest {
+  lockPath: string;
+  deadlineMs: number;
+  signal: AbortSignal;
+}
+
+export interface BrainstemLaunchLock {
+  release(): Promise<void>;
+}
+
+export interface BrainstemProcessDependencies {
+  readonly platform: NodeJS.Platform;
+  environment(): NodeJS.ProcessEnv;
+  homeDirectory(): string;
+  now(): number;
+  fileExists(filePath: string): boolean;
+  makeDirectory(directoryPath: string): void;
+  openLog(filePath: string): number;
+  closeLog(fd: number): void;
+  spawn(request: BrainstemSpawnRequest): BrainstemChildProcess;
+  probeHealth(url: string, signal: AbortSignal): Promise<boolean>;
+  acquireLaunchLock(
+    request: BrainstemLaunchLockRequest,
+  ): Promise<BrainstemLaunchLock>;
+  setTimer(callback: () => void, delayMs: number): BrainstemTimer;
+}
+
+export interface BrainstemProcessTimings {
+  startTimeoutMs: number;
+  healthRetryMs: number;
+  existingHealthGraceMs: number;
+  stopTimeoutMs: number;
+  forceStopTimeoutMs: number;
+}
+
+export interface BrainstemProcessManager {
+  ensureLocalBrainstem(
+    config: RappClientConfig,
+    signal: AbortSignal,
+  ): Promise<void>;
+  stopManagedBrainstems(): Promise<void>;
+}
+
+interface ChildObservation {
+  readonly error: Error | null;
+  subscribe(listener: () => void): () => void;
+  dispose(): void;
+}
+
+interface ReusedReadyState {
+  phase: "ready";
+  ownership: "reused";
+}
+
+interface OwnedReadyState {
+  phase: "ready";
+  ownership: "owned";
+  child: BrainstemChildProcess;
+  observation: ChildObservation;
+  logFd: number;
+  disposed: boolean;
+}
+
+type ReadyState = ReusedReadyState | OwnedReadyState;
+
+interface StartContext {
+  fallback: ReadyState | null;
+}
+
+interface IdleState {
+  phase: "idle";
+}
+
+interface StartingState {
+  phase: "starting";
+  token: object;
+  controller: AbortController;
+  operation: Promise<void>;
+}
+
+interface StoppingState {
+  phase: "stopping";
+  token: object;
+  operation: Promise<void>;
+}
+
+type ManagedState = IdleState | ReadyState | StartingState | StoppingState;
+
+type HealthWaitResult =
+  | { kind: "healthy" }
+  | { kind: "spawn-error"; error: Error }
+  | {
+      kind: "terminal";
+      exitCode: number | null;
+      signalCode: NodeJS.Signals | null;
+    }
+  | { kind: "timeout" };
+
+const defaultTimings: BrainstemProcessTimings = {
+  startTimeoutMs: START_TIMEOUT_MS,
+  healthRetryMs: HEALTH_RETRY_MS,
+  existingHealthGraceMs: EXISTING_HEALTH_GRACE_MS,
+  stopTimeoutMs: STOP_TIMEOUT_MS,
+  forceStopTimeoutMs: FORCE_STOP_TIMEOUT_MS,
+};
+
+class BrainstemStartupInterruptedError extends Error {
+  constructor() {
+    super("RAPP Brainstem startup was interrupted");
+    this.name = "BrainstemStartupInterruptedError";
+  }
+}
+
+function errorCode(error: unknown): string | null {
+  if (
+    typeof error !== "object" ||
+    error === null ||
+    !("code" in error) ||
+    typeof error.code !== "string"
+  ) {
+    return null;
+  }
+  return error.code;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function throwIfAborted(signal: AbortSignal): void {
+  if (signal.aborted) {
+    throw new BrainstemStartupInterruptedError();
+  }
+}
+
+function setNodeTimer(callback: () => void, delayMs: number): BrainstemTimer {
+  const timeout = setTimeout(callback, delayMs);
+  return {
+    cancel(): void {
+      clearTimeout(timeout);
+    },
+    unref(): void {
+      timeout.unref();
+    },
+  };
+}
+
+function waitForNodeDelay(delayMs: number, signal: AbortSignal): Promise<void> {
+  throwIfAborted(signal);
+  return new Promise<void>((resolve, reject) => {
+    let settled = false;
+    let timer: BrainstemTimer | null = null;
+    const finish = (error?: Error): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      timer?.cancel();
+      signal.removeEventListener("abort", onAbort);
+      if (error === undefined) {
+        resolve();
+      } else {
+        reject(error);
+      }
+    };
+    const onAbort = (): void => {
+      finish(new BrainstemStartupInterruptedError());
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    timer = setNodeTimer(() => finish(), delayMs);
+    timer.unref();
+    if (settled) {
+      timer.cancel();
+    }
+  });
+}
+
+async function probeNodeHealth(
+  url: string,
+  signal: AbortSignal,
+): Promise<boolean> {
+  const controller = new AbortController();
+  const onAbort = (): void => controller.abort();
+  if (signal.aborted) {
+    controller.abort();
+  } else {
+    signal.addEventListener("abort", onAbort, { once: true });
+  }
+  const timer = setNodeTimer(() => controller.abort(), HEALTH_TIMEOUT_MS);
+  timer.unref();
+  try {
+    const response = await fetch(url, {
+      headers: { accept: "application/json" },
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      return false;
+    }
+    return healthSchema.safeParse(await response.json()).success;
+  } catch {
+    return false;
+  } finally {
+    timer.cancel();
+    signal.removeEventListener("abort", onAbort);
+  }
+}
+
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return errorCode(error) === "EPERM";
+  }
+}
+
+async function lockCanBeRemoved(lockPath: string): Promise<boolean> {
+  const ownerPath = path.join(lockPath, LOCK_OWNER_FILE);
+  try {
+    const owner = await readFile(ownerPath, "utf8");
+    const [pidText, expiryText] = owner.split(":");
+    const pid = Number.parseInt(pidText ?? "", 10);
+    const expiryMs = Number.parseInt(expiryText ?? "", 10);
+    if (Number.isFinite(expiryMs) && Date.now() >= expiryMs) {
+      return true;
+    }
+    if (Number.isInteger(pid) && pid > 0) {
+      return !isPidAlive(pid);
+    }
+  } catch (error) {
+    if (errorCode(error) !== "ENOENT") {
+      throw error;
+    }
+  }
+  try {
+    const lockStat = await stat(lockPath);
+    return Date.now() - lockStat.mtimeMs >= LOCK_OWNER_GRACE_MS;
+  } catch (error) {
+    if (errorCode(error) === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function acquireNodeLaunchLock(
+  request: BrainstemLaunchLockRequest,
+): Promise<BrainstemLaunchLock> {
+  await mkdirAsync(path.dirname(request.lockPath), { recursive: true });
+  const token = `${process.pid}:${
+    request.deadlineMs + LOCK_EXPIRY_GRACE_MS
+  }:${randomUUID()}`;
+  const ownerPath = path.join(request.lockPath, LOCK_OWNER_FILE);
+  while (true) {
+    throwIfAborted(request.signal);
+    try {
+      await mkdirAsync(request.lockPath);
+      try {
+        await writeFile(ownerPath, token, "utf8");
+      } catch (error) {
+        await rm(request.lockPath, { recursive: true, force: true });
+        throw error;
+      }
+      let released = false;
+      return {
+        async release(): Promise<void> {
+          if (released) {
+            return;
+          }
+          released = true;
+          try {
+            const currentOwner = await readFile(ownerPath, "utf8");
+            if (currentOwner === token) {
+              await rm(request.lockPath, { recursive: true, force: true });
+            }
+          } catch (error) {
+            if (errorCode(error) !== "ENOENT") {
+              throw error;
+            }
+          }
+        },
+      };
+    } catch (error) {
+      if (errorCode(error) !== "EEXIST") {
+        throw error;
+      }
+    }
+    if (await lockCanBeRemoved(request.lockPath)) {
+      await rm(request.lockPath, { recursive: true, force: true });
+      continue;
+    }
+    const remainingMs = request.deadlineMs - Date.now();
+    if (remainingMs <= 0) {
+      throw new Error(
+        `Timed out waiting for the RAPP Brainstem startup lock at ${request.lockPath}`,
+      );
+    }
+    await waitForNodeDelay(
+      Math.min(LOCK_RETRY_MS, remainingMs),
+      request.signal,
+    );
+  }
+}
+
+function adaptChildProcess(child: ChildProcess): BrainstemChildProcess {
+  return {
+    get exitCode(): number | null {
+      return child.exitCode;
+    },
+    get signalCode(): NodeJS.Signals | null {
+      return child.signalCode;
+    },
+    kill(signal: NodeJS.Signals): boolean {
+      return child.kill(signal);
+    },
+    onError(listener: (error: Error) => void): () => void {
+      child.on("error", listener);
+      return () => child.off("error", listener);
+    },
+    onExit(
+      listener: (code: number | null, signal: NodeJS.Signals | null) => void,
+    ): () => void {
+      child.on("exit", listener);
+      return () => child.off("exit", listener);
+    },
+  };
+}
+
+const nodeDependencies: BrainstemProcessDependencies = {
+  platform: process.platform,
+  environment: () => process.env,
+  homeDirectory: homedir,
+  now: () => Date.now(),
+  fileExists: existsSync,
+  makeDirectory: (directoryPath) => {
+    mkdirSync(directoryPath, { recursive: true });
+  },
+  openLog: (filePath) => openSync(filePath, "a"),
+  closeLog: closeSync,
+  spawn(request) {
+    return adaptChildProcess(
+      spawn(request.command, request.args, {
+        cwd: request.cwd,
+        env: request.env,
+        windowsHide: true,
+        shell: false,
+        stdio: ["ignore", request.logFd, request.logFd],
+      }),
+    );
+  },
+  probeHealth: probeNodeHealth,
+  acquireLaunchLock: acquireNodeLaunchLock,
+  setTimer: setNodeTimer,
+};
+
+function normalizeLoopbackHostname(hostname: string): string {
+  const normalized = hostname.toLowerCase();
+  return normalized.startsWith("[") && normalized.endsWith("]")
+    ? normalized.slice(1, -1)
+    : normalized;
+}
+
+function isLoopback(hostname: string): boolean {
+  const normalized = normalizeLoopbackHostname(hostname);
+  return (
+    normalized === "localhost" ||
+    normalized === "127.0.0.1" ||
+    normalized === "::1"
+  );
+}
+
+function resolveLocalBrainstemAddress(
+  endpoint: URL,
+): LocalBrainstemAddress | null {
+  if (
+    endpoint.protocol !== "http:" ||
+    !isLoopback(endpoint.hostname) ||
+    endpoint.username !== "" ||
+    endpoint.password !== "" ||
+    endpoint.pathname !== "/chat" ||
+    endpoint.search !== "" ||
+    endpoint.hash !== ""
+  ) {
+    return null;
+  }
+  const port = endpoint.port === "" ? 80 : Number.parseInt(endpoint.port, 10);
+  if (!Number.isInteger(port) || port <= 0 || port > 65_535) {
+    return null;
+  }
+  const canonicalEndpoint = new URL(`http://127.0.0.1:${port}`);
+  return {
+    key: `http-loopback:${port}`,
+    port,
+    baseUrl: canonicalEndpoint.origin,
+    healthUrl: new URL("/health", canonicalEndpoint).toString(),
+  };
+}
+
+export function canonicalLocalBrainstemKey(
+  config: RappClientConfig,
+): string | null {
+  if (config.grail !== "consumer") {
+    return null;
+  }
+  return resolveLocalBrainstemAddress(config.endpoint)?.key ?? null;
+}
+
+export function shouldManageLocalBrainstem(config: RappClientConfig): boolean {
+  return canonicalLocalBrainstemKey(config) !== null;
+}
+
+function resolveBrainstemConfig(
+  address: LocalBrainstemAddress,
+  dependencies: BrainstemProcessDependencies,
+): BrainstemConfig {
+  const env = dependencies.environment();
+  const home =
+    env.BRAINSTEM_HOME?.trim() ||
+    path.join(dependencies.homeDirectory(), ".brainstem");
+  const sourceDir = path.join(home, "src", "rapp_brainstem");
+  const python =
+    dependencies.platform === "win32"
+      ? path.join(home, "venv", "Scripts", "python.exe")
+      : path.join(home, "venv", "bin", "python");
+  return {
+    ...address,
+    sourceDir,
+    python,
+    logFile: path.join(home, "logs", "bb-brainstem.log"),
+    lockPath: path.join(home, "run", `bb-brainstem-${address.port}.lock`),
+  };
+}
+
+function createChildEnvironment(
+  env: NodeJS.ProcessEnv,
+  port: number,
+): NodeJS.ProcessEnv {
+  const childEnv = { ...env };
+  for (const name of Object.keys(childEnv)) {
+    if (scrubbedEnvironmentVariables.has(name.toUpperCase())) {
+      delete childEnv[name];
+    }
+  }
+  childEnv.PORT = String(port);
+  childEnv.BRAINSTEM_BB_LAUNCHER = "1";
+  childEnv.PYTHONUTF8 = "1";
+  return childEnv;
+}
+
+function observeChild(child: BrainstemChildProcess): ChildObservation {
+  let childError: Error | null = null;
+  let disposed = false;
+  const listeners = new Set<() => void>();
+  const notify = (): void => {
+    for (const listener of listeners) {
+      listener();
+    }
+  };
+  const removeErrorListener = child.onError((error) => {
+    childError = error;
+    notify();
+  });
+  const removeExitListener = child.onExit(() => notify());
+  return {
+    get error(): Error | null {
+      return childError;
+    },
+    subscribe(listener: () => void): () => void {
+      if (disposed) {
+        return () => undefined;
+      }
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    dispose(): void {
+      if (disposed) {
+        return;
+      }
+      disposed = true;
+      listeners.clear();
+      removeErrorListener();
+      removeExitListener();
+    },
+  };
+}
+
+function isChildTerminal(child: BrainstemChildProcess): boolean {
+  return child.exitCode !== null || child.signalCode !== null;
+}
+
+function terminalDescription(
+  exitCode: number | null,
+  signalCode: NodeJS.Signals | null,
+): string {
+  if (signalCode !== null) {
+    return `signal ${signalCode}`;
+  }
+  return `code ${exitCode ?? "unknown"}`;
+}
+
+class ManagedBrainstem {
+  private state: ManagedState = { phase: "idle" };
+
+  constructor(
+    private readonly config: BrainstemConfig,
+    private readonly dependencies: BrainstemProcessDependencies,
+    private readonly timings: BrainstemProcessTimings,
+  ) {}
+
+  async ensureStarted(signal: AbortSignal): Promise<void> {
+    throwIfAborted(signal);
+    while (true) {
+      const state = this.state;
+      if (state.phase === "starting") {
+        await this.waitForSharedOperation(state.operation, signal);
+        return;
+      }
+      if (state.phase === "stopping") {
+        await this.waitForSharedOperation(state.operation, signal);
+        continue;
+      }
+      const operation = this.beginStart(state.phase === "ready" ? state : null);
+      await this.waitForSharedOperation(operation, signal);
+      return;
+    }
+  }
+
+  async stop(): Promise<void> {
+    while (true) {
+      const state = this.state;
+      if (state.phase === "idle") {
+        return;
+      }
+      if (state.phase === "starting") {
+        state.controller.abort();
+        try {
+          await state.operation;
+        } catch {}
+        continue;
+      }
+      if (state.phase === "stopping") {
+        await state.operation;
+        return;
+      }
+      if (state.ownership === "reused") {
+        this.state = { phase: "idle" };
+        return;
+      }
+      const token = {};
+      const operation = this.terminateOwned(state, true).finally(() => {
+        if (this.state.phase === "stopping" && this.state.token === token) {
+          this.state = { phase: "idle" };
+        }
+      });
+      this.state = { phase: "stopping", token, operation };
+      await operation;
+      return;
+    }
+  }
+
+  private beginStart(fallback: ReadyState | null): Promise<void> {
+    const controller = new AbortController();
+    const context: StartContext = { fallback };
+    const token = {};
+    const operation = this.runStart(context, controller.signal).then(
+      (ready) => {
+        if (this.state.phase === "starting" && this.state.token === token) {
+          this.state = ready;
+        }
+      },
+      (error) => {
+        if (this.state.phase === "starting" && this.state.token === token) {
+          this.state = context.fallback ?? { phase: "idle" };
+        }
+        throw error;
+      },
+    );
+    this.state = {
+      phase: "starting",
+      token,
+      controller,
+      operation,
+    };
+    void operation.catch(() => undefined);
+    return operation;
+  }
+
+  private async runStart(
+    context: StartContext,
+    signal: AbortSignal,
+  ): Promise<ReadyState> {
+    const deadlineMs = this.dependencies.now() + this.timings.startTimeoutMs;
+    const lock = await this.dependencies.acquireLaunchLock({
+      lockPath: this.config.lockPath,
+      deadlineMs,
+      signal,
+    });
+    try {
+      throwIfAborted(signal);
+      const existing = context.fallback;
+      const existingDeadlineMs = Math.min(
+        deadlineMs,
+        this.dependencies.now() + this.timings.existingHealthGraceMs,
+      );
+      const existingHealth = await this.waitForHealth(
+        existingDeadlineMs,
+        signal,
+        existing?.ownership === "owned" ? existing : null,
+      );
+      if (existingHealth.kind === "healthy") {
+        if (
+          existing?.ownership === "owned" &&
+          !isChildTerminal(existing.child) &&
+          existing.observation.error === null
+        ) {
+          return existing;
+        }
+        if (existing?.ownership === "owned") {
+          this.disposeOwned(existing);
+        }
+        context.fallback = {
+          phase: "ready",
+          ownership: "reused",
+        };
+        return context.fallback;
+      }
+      if (existing?.ownership === "owned") {
+        if (existingHealth.kind === "spawn-error") {
+          this.disposeOwned(existing);
+          context.fallback = null;
+          throw new Error(
+            `RAPP Brainstem process error: ${existingHealth.error.message}. See ${this.config.logFile}`,
+          );
+        }
+        if (existingHealth.kind === "terminal") {
+          this.disposeOwned(existing);
+          context.fallback = null;
+        } else if (!isChildTerminal(existing.child)) {
+          throw new Error(
+            `RAPP Brainstem did not respond at ${this.config.baseUrl}, but the managed process is still running`,
+          );
+        } else {
+          this.disposeOwned(existing);
+          context.fallback = null;
+        }
+      } else {
+        context.fallback = null;
+      }
+      if (this.dependencies.now() >= deadlineMs) {
+        throw new Error(
+          `RAPP Brainstem did not become healthy at ${this.config.baseUrl}`,
+        );
+      }
+      this.assertLaunchFiles();
+      const owned = this.spawnOwned();
+      context.fallback = owned;
+      const started = await this.waitForHealth(deadlineMs, signal, owned);
+      if (started.kind === "healthy") {
+        if (!isChildTerminal(owned.child) && owned.observation.error === null) {
+          return owned;
+        }
+        this.disposeOwned(owned);
+        context.fallback = {
+          phase: "ready",
+          ownership: "reused",
+        };
+        return context.fallback;
+      }
+      if (started.kind === "spawn-error") {
+        this.disposeOwned(owned);
+        context.fallback = null;
+        throw new Error(
+          `Failed to start RAPP Brainstem: ${started.error.message}. See ${this.config.logFile}`,
+        );
+      }
+      if (started.kind === "terminal") {
+        this.disposeOwned(owned);
+        context.fallback = null;
+        throw new Error(
+          `RAPP Brainstem exited with ${terminalDescription(
+            started.exitCode,
+            started.signalCode,
+          )}. See ${this.config.logFile}`,
+        );
+      }
+      await this.terminateOwned(owned, false);
+      context.fallback = isChildTerminal(owned.child) ? null : owned;
+      throw new Error(
+        `RAPP Brainstem did not become healthy at ${this.config.baseUrl}. See ${this.config.logFile}`,
+      );
+    } finally {
+      await lock.release();
+    }
+  }
+
+  private assertLaunchFiles(): void {
+    const serverFile = path.join(this.config.sourceDir, "brainstem.py");
+    if (!this.dependencies.fileExists(serverFile)) {
+      throw new Error(
+        `RAPP Brainstem is not installed at ${this.config.sourceDir}. Install it from https://github.com/kody-w/rapp-installer`,
+      );
+    }
+    if (!this.dependencies.fileExists(this.config.python)) {
+      throw new Error(
+        `RAPP Brainstem Python is missing at ${this.config.python}. Re-run the RAPP installer`,
+      );
+    }
+  }
+
+  private spawnOwned(): OwnedReadyState {
+    this.dependencies.makeDirectory(path.dirname(this.config.logFile));
+    const logFd = this.dependencies.openLog(this.config.logFile);
+    let child: BrainstemChildProcess;
+    try {
+      child = this.dependencies.spawn({
+        command: this.config.python,
+        args: ["brainstem.py"],
+        cwd: this.config.sourceDir,
+        env: createChildEnvironment(
+          this.dependencies.environment(),
+          this.config.port,
+        ),
+        logFd,
+      });
+    } catch (error) {
+      this.dependencies.closeLog(logFd);
+      throw new Error(
+        `Failed to start RAPP Brainstem: ${errorMessage(error)}. See ${this.config.logFile}`,
+      );
+    }
+    return {
+      phase: "ready",
+      ownership: "owned",
+      child,
+      observation: observeChild(child),
+      logFd,
+      disposed: false,
+    };
+  }
+
+  private async waitForHealth(
+    deadlineMs: number,
+    signal: AbortSignal,
+    owned: OwnedReadyState | null,
+  ): Promise<HealthWaitResult> {
+    while (true) {
+      throwIfAborted(signal);
+      const healthy = await this.dependencies.probeHealth(
+        this.config.healthUrl,
+        signal,
+      );
+      throwIfAborted(signal);
+      if (healthy) {
+        return { kind: "healthy" };
+      }
+      if (owned !== null && owned.observation.error !== null) {
+        return {
+          kind: "spawn-error",
+          error: owned.observation.error,
+        };
+      }
+      if (owned !== null && isChildTerminal(owned.child)) {
+        return {
+          kind: "terminal",
+          exitCode: owned.child.exitCode,
+          signalCode: owned.child.signalCode,
+        };
+      }
+      const remainingMs = deadlineMs - this.dependencies.now();
+      if (remainingMs <= 0) {
+        return { kind: "timeout" };
+      }
+      await this.waitForWake(
+        Math.min(this.timings.healthRetryMs, remainingMs),
+        signal,
+        owned?.observation ?? null,
+      );
+    }
+  }
+
+  private waitForWake(
+    delayMs: number,
+    signal: AbortSignal | null,
+    observation: ChildObservation | null,
+  ): Promise<void> {
+    if (signal?.aborted) {
+      return Promise.reject(new BrainstemStartupInterruptedError());
+    }
+    return new Promise<void>((resolve, reject) => {
+      let settled = false;
+      let timer: BrainstemTimer | null = null;
+      let unsubscribe = (): void => undefined;
+      const finish = (error?: Error): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        timer?.cancel();
+        unsubscribe();
+        signal?.removeEventListener("abort", onAbort);
+        if (error === undefined) {
+          resolve();
+        } else {
+          reject(error);
+        }
+      };
+      const onAbort = (): void => {
+        finish(new BrainstemStartupInterruptedError());
+      };
+      signal?.addEventListener("abort", onAbort, { once: true });
+      unsubscribe = observation?.subscribe(() => finish()) ?? unsubscribe;
+      timer = this.dependencies.setTimer(() => finish(), delayMs);
+      timer.unref();
+      if (settled) {
+        timer.cancel();
+      }
+    });
+  }
+
+  private async terminateOwned(
+    owned: OwnedReadyState,
+    disposeRegardless: boolean,
+  ): Promise<void> {
+    if (!isChildTerminal(owned.child)) {
+      try {
+        owned.child.kill("SIGTERM");
+      } catch {}
+      if (!isChildTerminal(owned.child)) {
+        await this.waitForWake(
+          this.timings.stopTimeoutMs,
+          null,
+          owned.observation,
+        );
+      }
+    }
+    if (!isChildTerminal(owned.child)) {
+      try {
+        owned.child.kill("SIGKILL");
+      } catch {}
+      if (!isChildTerminal(owned.child)) {
+        await this.waitForWake(
+          this.timings.forceStopTimeoutMs,
+          null,
+          owned.observation,
+        );
+      }
+    }
+    if (disposeRegardless || isChildTerminal(owned.child)) {
+      this.disposeOwned(owned);
+    }
+  }
+
+  private disposeOwned(owned: OwnedReadyState): void {
+    if (owned.disposed) {
+      return;
+    }
+    owned.disposed = true;
+    owned.observation.dispose();
+    this.dependencies.closeLog(owned.logFd);
+  }
+
+  private waitForSharedOperation(
+    operation: Promise<void>,
+    signal: AbortSignal,
+  ): Promise<void> {
+    throwIfAborted(signal);
+    return new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const finish = (error?: unknown): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        signal.removeEventListener("abort", onAbort);
+        if (error === undefined) {
+          resolve();
+        } else {
+          reject(error);
+        }
+      };
+      const onAbort = (): void => {
+        finish(new BrainstemStartupInterruptedError());
+      };
+      signal.addEventListener("abort", onAbort, { once: true });
+      void operation.then(
+        () => finish(),
+        (error) => finish(error),
+      );
+    });
+  }
+}
+
+class BrainstemProcessManagerImpl implements BrainstemProcessManager {
+  private readonly managed = new Map<string, ManagedBrainstem>();
+  private stopAllOperation: Promise<void> | null = null;
+
+  constructor(
+    private readonly dependencies: BrainstemProcessDependencies,
+    private readonly timings: BrainstemProcessTimings,
+  ) {}
+
+  async ensureLocalBrainstem(
+    config: RappClientConfig,
+    signal: AbortSignal,
+  ): Promise<void> {
+    if (config.grail !== "consumer") {
+      return;
+    }
+    const address = resolveLocalBrainstemAddress(config.endpoint);
+    if (address === null) {
+      return;
+    }
+    let managed = this.managed.get(address.key);
+    if (managed === undefined) {
+      managed = new ManagedBrainstem(
+        resolveBrainstemConfig(address, this.dependencies),
+        this.dependencies,
+        this.timings,
+      );
+      this.managed.set(address.key, managed);
+    }
+    await managed.ensureStarted(signal);
+  }
+
+  stopManagedBrainstems(): Promise<void> {
+    if (this.stopAllOperation !== null) {
+      return this.stopAllOperation;
+    }
+    const managed = [...this.managed.values()];
+    this.managed.clear();
+    const operation = Promise.all(
+      managed.map((brainstem) => brainstem.stop()),
+    ).then(() => undefined);
+    const tracked = operation.finally(() => {
+      if (this.stopAllOperation === tracked) {
+        this.stopAllOperation = null;
+      }
+    });
+    this.stopAllOperation = tracked;
+    return tracked;
+  }
+}
+
+export function createBrainstemProcessManager(
+  dependencies: BrainstemProcessDependencies,
+  timings: BrainstemProcessTimings = defaultTimings,
+): BrainstemProcessManager {
+  return new BrainstemProcessManagerImpl(dependencies, timings);
+}
+
+const defaultManager = createBrainstemProcessManager(nodeDependencies);
+
+export function ensureLocalBrainstem(
+  config: RappClientConfig,
+  signal: AbortSignal,
+): Promise<void> {
+  return defaultManager.ensureLocalBrainstem(config, signal);
+}
+
+export function stopManagedBrainstems(): Promise<void> {
+  return defaultManager.stopManagedBrainstems();
+}

--- a/plugins/provider-rapp/src/brainstem-process.ts
+++ b/plugins/provider-rapp/src/brainstem-process.ts
@@ -439,20 +439,9 @@ const nodeDependencies: BrainstemProcessDependencies = {
   setTimer: setNodeTimer,
 };
 
-function normalizeLoopbackHostname(hostname: string): string {
+function isLaunchableBrainstemHostname(hostname: string): boolean {
   const normalized = hostname.toLowerCase();
-  return normalized.startsWith("[") && normalized.endsWith("]")
-    ? normalized.slice(1, -1)
-    : normalized;
-}
-
-function isLoopback(hostname: string): boolean {
-  const normalized = normalizeLoopbackHostname(hostname);
-  return (
-    normalized === "localhost" ||
-    normalized === "127.0.0.1" ||
-    normalized === "::1"
-  );
+  return normalized === "localhost" || normalized === "127.0.0.1";
 }
 
 function resolveLocalBrainstemAddress(
@@ -460,7 +449,7 @@ function resolveLocalBrainstemAddress(
 ): LocalBrainstemAddress | null {
   if (
     endpoint.protocol !== "http:" ||
-    !isLoopback(endpoint.hostname) ||
+    !isLaunchableBrainstemHostname(endpoint.hostname) ||
     endpoint.username !== "" ||
     endpoint.password !== "" ||
     endpoint.pathname !== "/chat" ||

--- a/plugins/provider-rapp/src/bridge.ts
+++ b/plugins/provider-rapp/src/bridge.ts
@@ -85,12 +85,13 @@ const TURN_STOP_TIMEOUT_MS = 5_000;
 const UNKNOWN_COMPLETION_MESSAGE = [
   "A prior RAPP completion is unknown.",
   "The endpoint may have completed the request, but legacy Brainstem does not honor idempotency keys, so bb will not replay it.",
-  "Explicitly interrupt/stop this thread to discard the retained pending turn, then send a new message.",
+  "Start a new thread to continue safely; bb will retain this thread for audit.",
 ].join(" ");
 let sessionStore = new RappSessionStore();
-let durabilityFault:
-  | { stage: RappBridgeDurabilityFault; trigger: () => void }
-  | null = null;
+let durabilityFault: {
+  stage: RappBridgeDurabilityFault;
+  trigger: () => void;
+} | null = null;
 
 function notify(method: string, params: Record<string, unknown>): void {
   io.send({ jsonrpc: "2.0", method, params });
@@ -296,7 +297,7 @@ function openSession(args: {
     threadId: args.threadId,
     providerThreadId: args.providerThreadId,
   });
-  if (session.saved.pendingDelivery !== null) {
+  if (session.saved.pendingDelivery?.phase === "ready") {
     if (!deliverPending(session)) {
       throw new Error(
         "RAPP delivery replay was interrupted before acknowledgement",
@@ -414,7 +415,11 @@ function acknowledgeDeliveryBeforeNextTurn(session: Session): void {
   if (session.saved.pendingDelivery === null) {
     return;
   }
-  if (!session.deliveryEmittedInProcess && !deliverPending(session)) {
+  if (
+    session.saved.pendingDelivery.phase === "ready" &&
+    !session.deliveryEmittedInProcess &&
+    !deliverPending(session)
+  ) {
     throw new Error(
       "RAPP delivery replay was interrupted before acknowledgement",
     );
@@ -519,10 +524,7 @@ async function executeTurn(args: {
       if (!isCurrentTurn(session, args.providerTurnId)) {
         throw new Error("RAPP turn is no longer active");
       }
-      session.saved = sessionStore.save(
-        { ...nextSnapshot, pendingTurn },
-        null,
-      );
+      session.saved = sessionStore.save({ ...nextSnapshot, pendingTurn }, null);
       chatMayHaveStarted = true;
     };
     let response: RappChatResponse;
@@ -630,9 +632,7 @@ async function executeTurn(args: {
         }
       } catch (clearError) {
         const message =
-          clearError instanceof Error
-            ? clearError.message
-            : String(clearError);
+          clearError instanceof Error ? clearError.message : String(clearError);
         emitTurnFailure(
           session,
           args.providerTurnId,
@@ -649,9 +649,7 @@ async function executeTurn(args: {
       session,
       args.providerTurnId,
       "failed",
-      chatMayHaveStarted
-        ? `${message} ${UNKNOWN_COMPLETION_MESSAGE}`
-        : message,
+      chatMayHaveStarted ? `${message} ${UNKNOWN_COMPLETION_MESSAGE}` : message,
     );
   }
 }

--- a/plugins/provider-rapp/src/bridge.ts
+++ b/plugins/provider-rapp/src/bridge.ts
@@ -28,6 +28,7 @@ import {
   callRapp,
   fixedBusinessModelList,
   listRappModels,
+  RAPP_MAX_RESPONSE_BYTES,
   resolveRappClientConfig,
   setRappModel,
   type RappClientConfig,
@@ -47,8 +48,10 @@ import {
 } from "./vocabulary.js";
 import {
   RappSessionStore,
+  type RappDeliveryDraft,
   type RappPendingTurn,
   type RappSessionSnapshot,
+  type SavedRappSession,
 } from "./session-store.js";
 
 type JsonRpcId = string | number;
@@ -64,17 +67,30 @@ interface ActiveTurn {
 interface Session {
   threadId: string;
   providerThreadId: string;
-  snapshot: RappSessionSnapshot;
+  saved: SavedRappSession;
+  deliveryEmittedInProcess: boolean;
   activeTurn: ActiveTurn | null;
   closed: boolean;
 }
+
+type RappBridgeDurabilityFault =
+  | "after-completion-commit"
+  | "after-delivery-emission";
 
 const io = createBridgeIo<OutboundMessage>();
 const sessions = new Map<string, Session>();
 const consumerEndpointTails = new Map<string, Promise<void>>();
 const maintenanceControllers = new Set<AbortController>();
 const TURN_STOP_TIMEOUT_MS = 5_000;
+const UNKNOWN_COMPLETION_MESSAGE = [
+  "A prior RAPP completion is unknown.",
+  "The endpoint may have completed the request, but legacy Brainstem does not honor idempotency keys, so bb will not replay it.",
+  "Explicitly interrupt/stop this thread to discard the retained pending turn, then send a new message.",
+].join(" ");
 let sessionStore = new RappSessionStore();
+let durabilityFault:
+  | { stage: RappBridgeDurabilityFault; trigger: () => void }
+  | null = null;
 
 function notify(method: string, params: Record<string, unknown>): void {
   io.send({ jsonrpc: "2.0", method, params });
@@ -260,7 +276,7 @@ function conversationHistory(
 function openSession(args: {
   threadId: string;
   providerThreadId: string;
-  snapshot: RappSessionSnapshot;
+  saved: SavedRappSession;
 }): Session {
   const existing = sessions.get(args.threadId);
   if (existing !== undefined) {
@@ -270,7 +286,8 @@ function openSession(args: {
   const session: Session = {
     threadId: args.threadId,
     providerThreadId: args.providerThreadId,
-    snapshot: args.snapshot,
+    saved: args.saved,
+    deliveryEmittedInProcess: false,
     activeTurn: null,
     closed: false,
   };
@@ -279,22 +296,138 @@ function openSession(args: {
     threadId: args.threadId,
     providerThreadId: args.providerThreadId,
   });
+  if (session.saved.pendingDelivery !== null) {
+    if (!deliverPending(session)) {
+      throw new Error(
+        "RAPP delivery replay was interrupted before acknowledgement",
+      );
+    }
+  }
   emitDeltas(args.threadId, [{ kind: "session.reset" }]);
   return session;
 }
 
+function isOpenSession(session: Session): boolean {
+  return !session.closed && sessions.get(session.threadId) === session;
+}
+
 function isCurrentTurn(session: Session, providerTurnId: string): boolean {
   return (
-    !session.closed &&
-    sessions.get(session.threadId) === session &&
+    isOpenSession(session) &&
     session.activeTurn?.providerTurnId === providerTurnId
   );
 }
 
-function turnItemId(session: Session, turnCounter: number, name: string) {
-  return {
-    providerItemId: `${session.providerThreadId}-t${turnCounter}-${name}`,
-  };
+function turnItemProviderId(
+  session: Session,
+  turnCounter: number,
+  name: string,
+): string {
+  return `${session.providerThreadId}-t${turnCounter}-${name}`;
+}
+
+function runDurabilityFault(stage: RappBridgeDurabilityFault): void {
+  if (durabilityFault?.stage !== stage) {
+    return;
+  }
+  const trigger = durabilityFault.trigger;
+  durabilityFault = null;
+  trigger();
+}
+
+function deliveryDeltas(saved: SavedRappSession): ThreadDelta[] {
+  const delivery = saved.pendingDelivery;
+  if (delivery === null) {
+    return [];
+  }
+  const deltas: ThreadDelta[] = [];
+  if (delivery.agentItemId !== null) {
+    const logs = delivery.agentLogs.join("\n");
+    deltas.push({
+      kind: "item.close",
+      key: { providerItemId: delivery.agentItemId },
+      providerTurnId: delivery.providerTurnId,
+      status: "completed",
+      item: {
+        type: "tool",
+        tool: "rapp_agents",
+        server: "rapp",
+        args: { spec: RAPP_SPEC },
+        result: logs,
+      },
+      presentation: RAPP_AGENT_ACTIVITY_PRESENTATION,
+    });
+  }
+  deltas.push(
+    {
+      kind: "item.close",
+      key: { providerItemId: delivery.messageItemId },
+      providerTurnId: delivery.providerTurnId,
+      status: "completed",
+      item: { type: "agentMessage", text: delivery.response },
+      presentation: RAPP_MESSAGE_PRESENTATION,
+    },
+    {
+      kind: "extension.state",
+      extensionKind: RAPP_SESSION_STATE_KIND,
+      payload: {
+        spec: RAPP_SPEC,
+        grail: delivery.grail,
+        rappid: saved.rappid,
+        sessionId: saved.snapshot.remoteSessionId,
+        turnCount: saved.snapshot.turnCounter,
+        eggAddress: delivery.eggAddress,
+        endpoint: delivery.endpoint,
+        selectedModel: delivery.selectedModel,
+        requestedModel: delivery.requestedModel,
+        actualModel: delivery.actualModel,
+      },
+    },
+    {
+      kind: "turn.boundary",
+      status: "completed",
+      providerTurnId: delivery.providerTurnId,
+    },
+  );
+  return deltas;
+}
+
+function deliverPending(session: Session): boolean {
+  const deliveryAddress = session.saved.deliveryAddress;
+  if (session.saved.pendingDelivery === null || deliveryAddress === null) {
+    throw new Error("RAPP delivery journal state is incomplete");
+  }
+  emitDeltas(session.threadId, deliveryDeltas(session.saved));
+  runDurabilityFault("after-delivery-emission");
+  if (!isOpenSession(session)) {
+    return false;
+  }
+  session.saved = sessionStore.markDeliveryEmitted(
+    session.providerThreadId,
+    deliveryAddress,
+  );
+  session.deliveryEmittedInProcess = true;
+  return true;
+}
+
+function acknowledgeDeliveryBeforeNextTurn(session: Session): void {
+  if (session.saved.pendingDelivery === null) {
+    return;
+  }
+  if (!session.deliveryEmittedInProcess && !deliverPending(session)) {
+    throw new Error(
+      "RAPP delivery replay was interrupted before acknowledgement",
+    );
+  }
+  const deliveryAddress = session.saved.deliveryAddress;
+  if (deliveryAddress === null) {
+    throw new Error("RAPP delivery journal state is incomplete");
+  }
+  session.saved = sessionStore.acknowledgeDelivery(
+    session.providerThreadId,
+    deliveryAddress,
+  );
+  session.deliveryEmittedInProcess = false;
 }
 
 function emitTurnFailure(
@@ -324,7 +457,8 @@ async function executeTurn(args: {
 }): Promise<void> {
   const { session } = args;
   const submittedPrompt = renderPrompt(args.input);
-  let pendingTurn: RappPendingTurn | null = null;
+  let chatMayHaveStarted = false;
+  let completionCommitted = false;
   emitDeltas(session.threadId, [
     {
       kind: "turn.open",
@@ -341,37 +475,55 @@ async function executeTurn(args: {
         ]),
   ]);
   try {
-    if (session.snapshot.pendingTurn === null) {
-      if (submittedPrompt === "") {
-        throw new Error("RAPP requires a non-empty prompt");
-      }
-      const turnCounter = session.snapshot.turnCounter + 1;
-      pendingTurn = {
-        idempotencyKey:
-          args.clientRequestId ?? `${session.providerThreadId}:${turnCounter}`,
-        userInput: submittedPrompt,
-        conversationHistory: conversationHistory(
-          session.snapshot,
-          args.instructions,
-        ),
-      };
-      const nextSnapshot: RappSessionSnapshot = {
-        ...session.snapshot,
-        turnCounter,
-        transcript: session.snapshot.transcript.map((entry) => ({ ...entry })),
-        pendingTurn,
-      };
-      session.snapshot = sessionStore.save(nextSnapshot).snapshot;
-    } else {
-      pendingTurn = session.snapshot.pendingTurn;
+    if (session.saved.snapshot.pendingTurn !== null) {
+      throw new Error(UNKNOWN_COMPLETION_MESSAGE);
     }
+    if (submittedPrompt === "") {
+      throw new Error("RAPP requires a non-empty prompt");
+    }
+    const turnCounter = session.saved.snapshot.turnCounter + 1;
     const config = resolveRappClientConfig(args.options);
+    const pendingTurn: RappPendingTurn = {
+      idempotencyKey:
+        args.clientRequestId ?? `${session.providerThreadId}:${turnCounter}`,
+      userInput: submittedPrompt,
+      conversationHistory: conversationHistory(
+        session.saved.snapshot,
+        args.instructions,
+      ),
+    };
+    const nextSnapshot: RappSessionSnapshot = {
+      ...session.saved.snapshot,
+      turnCounter,
+      transcript: session.saved.snapshot.transcript.map((entry) => ({
+        ...entry,
+      })),
+      pendingTurn: null,
+    };
+    sessionStore.assertCanCommitCompletion(
+      nextSnapshot,
+      pendingTurn.userInput,
+      RAPP_MAX_RESPONSE_BYTES,
+    );
     await ensureLocalBrainstem(config, args.controller.signal);
     const request = {
       userInput: pendingTurn.userInput,
-      sessionId: session.snapshot.remoteSessionId,
+      sessionId: session.saved.snapshot.remoteSessionId,
       idempotencyKey: pendingTurn.idempotencyKey,
       conversationHistory: pendingTurn.conversationHistory,
+    };
+    const persistPendingTurn = (): void => {
+      if (args.controller.signal.aborted) {
+        throw abortReason(args.controller.signal);
+      }
+      if (!isCurrentTurn(session, args.providerTurnId)) {
+        throw new Error("RAPP turn is no longer active");
+      }
+      session.saved = sessionStore.save(
+        { ...nextSnapshot, pendingTurn },
+        null,
+      );
+      chatMayHaveStarted = true;
     };
     let response: RappChatResponse;
     let requestedModel: string | null;
@@ -389,6 +541,7 @@ async function executeTurn(args: {
                   args.options.model,
                   args.controller.signal,
                 );
+          persistPendingTurn();
           const consumerResponse = await callRapp(
             config,
             request,
@@ -417,6 +570,7 @@ async function executeTurn(args: {
       requestedModel = result.requestedModel;
       actualModel = result.actualModel;
     } else {
+      persistPendingTurn();
       response = await callRapp(config, request, args.controller.signal);
       requestedModel = null;
       actualModel = null;
@@ -425,126 +579,79 @@ async function executeTurn(args: {
       return;
     }
     const completedSnapshot: RappSessionSnapshot = {
-      ...session.snapshot,
+      ...session.saved.snapshot,
       remoteSessionId: response.sessionId,
       transcript: [
-        ...session.snapshot.transcript,
+        ...session.saved.snapshot.transcript,
         { role: "user", content: pendingTurn.userInput },
         { role: "assistant", content: response.response },
       ],
       pendingTurn: null,
     };
-    const saved = sessionStore.save(completedSnapshot);
-    session.snapshot = saved.snapshot;
-
-    const deltas: ThreadDelta[] = [];
-    if (response.agentLogs.length > 0) {
-      const logsKey = turnItemId(
-        session,
-        session.snapshot.turnCounter,
-        "agents",
-      );
-      const logs = response.agentLogs.join("\n");
-      deltas.push(
-        {
-          kind: "item.open",
-          key: logsKey,
-          providerTurnId: args.providerTurnId,
-          item: {
-            type: "tool",
-            tool: "rapp_agents",
-            server: "rapp",
-            args: { spec: RAPP_SPEC },
-          },
-          presentation: RAPP_AGENT_ACTIVITY_PRESENTATION,
-        },
-        {
-          kind: "item.close",
-          key: logsKey,
-          providerTurnId: args.providerTurnId,
-          status: "completed",
-          item: {
-            type: "tool",
-            tool: "rapp_agents",
-            server: "rapp",
-            args: { spec: RAPP_SPEC },
-            result: logs,
-          },
-          presentation: RAPP_AGENT_ACTIVITY_PRESENTATION,
-        },
-      );
+    const delivery: RappDeliveryDraft = {
+      providerTurnId: args.providerTurnId,
+      agentItemId:
+        response.agentLogs.length === 0
+          ? null
+          : turnItemProviderId(session, turnCounter, "agents"),
+      messageItemId: turnItemProviderId(session, turnCounter, "message"),
+      response: response.response,
+      agentLogs: [...response.agentLogs],
+      grail: config.grail,
+      endpoint: config.displayEndpoint,
+      selectedModel: args.options.model,
+      requestedModel,
+      actualModel,
+    };
+    session.saved = sessionStore.save(completedSnapshot, delivery);
+    completionCommitted = true;
+    runDurabilityFault("after-completion-commit");
+    if (!isCurrentTurn(session, args.providerTurnId)) {
+      return;
     }
-
-    const messageKey = turnItemId(
-      session,
-      session.snapshot.turnCounter,
-      "message",
-    );
-    deltas.push(
-      {
-        kind: "item.open",
-        key: messageKey,
-        providerTurnId: args.providerTurnId,
-        item: { type: "agentMessage", text: "" },
-        presentation: RAPP_MESSAGE_PRESENTATION,
-      },
-      {
-        kind: "item.textClose",
-        key: messageKey,
-        providerTurnId: args.providerTurnId,
-        channel: "agentMessage",
-        text: response.response,
-      },
-      {
-        kind: "extension.state",
-        extensionKind: RAPP_SESSION_STATE_KIND,
-        payload: {
-          spec: RAPP_SPEC,
-          grail: config.grail,
-          rappid: saved.rappid,
-          sessionId: session.snapshot.remoteSessionId,
-          turnCount: session.snapshot.turnCounter,
-          eggAddress: saved.eggAddress,
-          endpoint: config.displayEndpoint,
-          selectedModel: args.options.model,
-          requestedModel,
-          actualModel,
-        },
-      },
-      {
-        kind: "turn.boundary",
-        status: "completed",
-        providerTurnId: args.providerTurnId,
-      },
-    );
-    emitDeltas(session.threadId, deltas);
+    deliverPending(session);
   } catch (error) {
     if (!isCurrentTurn(session, args.providerTurnId)) {
       return;
     }
+    if (completionCommitted) {
+      return;
+    }
     if (args.controller.signal.aborted) {
       try {
-        session.snapshot = sessionStore.save({
-          ...session.snapshot,
-          pendingTurn: null,
-        }).snapshot;
+        if (session.saved.snapshot.pendingTurn !== null) {
+          session.saved = sessionStore.save(
+            {
+              ...session.saved.snapshot,
+              pendingTurn: null,
+            },
+            null,
+          );
+        }
       } catch (clearError) {
+        const message =
+          clearError instanceof Error
+            ? clearError.message
+            : String(clearError);
         emitTurnFailure(
           session,
           args.providerTurnId,
           "failed",
-          `Could not clear interrupted RAPP turn: ${clearError instanceof Error ? clearError.message : String(clearError)}`,
+          `Could not clear interrupted RAPP turn: ${message}`,
         );
         return;
       }
       emitTurnFailure(session, args.providerTurnId, "interrupted");
       return;
     }
+    const message = error instanceof Error ? error.message : String(error);
     emitTurnFailure(
       session,
       args.providerTurnId,
       "failed",
-      error instanceof Error ? error.message : String(error),
+      chatMayHaveStarted
+        ? `${message} ${UNKNOWN_COMPLETION_MESSAGE}`
+        : message,
     );
   }
 }
@@ -557,10 +664,23 @@ function startTurn(args: {
   clientRequestId?: ClientTurnRequestId;
 }): void {
   const turnCounter =
-    args.session.snapshot.pendingTurn === null
-      ? args.session.snapshot.turnCounter + 1
-      : args.session.snapshot.turnCounter;
-  const providerTurnId = `${args.session.providerThreadId}-turn-${turnCounter}-${randomUUID().replaceAll("-", "")}`;
+    args.session.saved.snapshot.pendingTurn === null
+      ? args.session.saved.snapshot.turnCounter + 1
+      : args.session.saved.snapshot.turnCounter;
+  const providerTurnId =
+    args.session.saved.snapshot.pendingTurn === null
+      ? [
+          args.session.providerThreadId,
+          "turn",
+          String(turnCounter),
+          randomUUID().replaceAll("-", ""),
+        ].join("-")
+      : [
+          args.session.providerThreadId,
+          "blocked",
+          String(turnCounter),
+          randomUUID().replaceAll("-", ""),
+        ].join("-");
   const controller = new AbortController();
   const promise = Promise.resolve()
     .then(() =>
@@ -667,7 +787,7 @@ const handlers: Record<string, RequestHandler> = {
     const session = openSession({
       threadId: parsed.data.threadId,
       providerThreadId,
-      snapshot: saved.snapshot,
+      saved,
     });
     io.sendResult(id, { providerThreadId, sessionRestorable: true });
     if (parsed.data.input !== undefined && parsed.data.input.length > 0) {
@@ -710,7 +830,7 @@ const handlers: Record<string, RequestHandler> = {
     openSession({
       threadId: parsed.data.threadId,
       providerThreadId: parsed.data.providerThreadId,
-      snapshot: saved.snapshot,
+      saved,
     });
     io.sendResult(id, {
       providerThreadId: parsed.data.providerThreadId,
@@ -757,6 +877,19 @@ const handlers: Record<string, RequestHandler> = {
     if (options === null) {
       return;
     }
+    if (session.saved.pendingDelivery !== null) {
+      try {
+        acknowledgeDeliveryBeforeNextTurn(session);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        io.sendError(
+          id,
+          BRIDGE_JSON_RPC_ERRORS.BRIDGE_ERROR,
+          `Could not replay the prior completed RAPP turn: ${message}`,
+        );
+        return;
+      }
+    }
     io.sendResult(id, {});
     startTurn({
       session,
@@ -796,6 +929,7 @@ const handlers: Record<string, RequestHandler> = {
     }
     if (parsed.data.intent === "interrupt") {
       const activeTurn = session.activeTurn;
+      let canClearPending = activeTurn === null;
       if (
         activeTurn !== null &&
         parsed.data.activeTurnId === activeTurn.providerTurnId
@@ -805,6 +939,29 @@ const handlers: Record<string, RequestHandler> = {
         if (!settled && isCurrentTurn(session, activeTurn.providerTurnId)) {
           session.activeTurn = null;
           emitTurnFailure(session, activeTurn.providerTurnId, "interrupted");
+        }
+        canClearPending = true;
+      } else if (activeTurn !== null && parsed.data.activeTurnId === null) {
+        canClearPending = await waitForTurnSettlement(activeTurn.promise);
+      }
+      if (canClearPending && session.saved.snapshot.pendingTurn !== null) {
+        try {
+          session.saved = sessionStore.save(
+            {
+              ...session.saved.snapshot,
+              pendingTurn: null,
+            },
+            null,
+          );
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          io.sendError(
+            id,
+            BRIDGE_JSON_RPC_ERRORS.BRIDGE_ERROR,
+            `Could not discard the retained RAPP turn: ${message}`,
+          );
+          return;
         }
       }
       io.sendResult(id, {});
@@ -870,7 +1027,15 @@ export function handleLine(line: string): void {
 
 export function experimental_resetRappBridgeForTests(dataDir?: string): void {
   shutdownBridge();
+  durabilityFault = null;
   sessionStore = new RappSessionStore(dataDir);
+}
+
+export function experimental_setRappBridgeDurabilityFaultForTests(
+  stage: RappBridgeDurabilityFault,
+  trigger: () => void,
+): void {
+  durabilityFault = { stage, trigger };
 }
 
 function shutdownBridge(): void {

--- a/plugins/provider-rapp/src/bridge.ts
+++ b/plugins/provider-rapp/src/bridge.ts
@@ -418,8 +418,8 @@ async function executeTurn(args: {
       actualModel = result.actualModel;
     } else {
       response = await callRapp(config, request, args.controller.signal);
-      requestedModel = RAPP_BUSINESS_MODEL_ID;
-      actualModel = RAPP_BUSINESS_MODEL_ID;
+      requestedModel = null;
+      actualModel = null;
     }
     if (!isCurrentTurn(session, args.providerTurnId)) {
       return;

--- a/plugins/provider-rapp/src/bridge.ts
+++ b/plugins/provider-rapp/src/bridge.ts
@@ -1,0 +1,904 @@
+import {
+  type ClientTurnRequestId,
+  type PromptInput,
+  type ThreadDelta,
+  BRIDGE_JSON_RPC_ERRORS,
+  BRIDGE_NOTIFICATION_METHODS,
+  BRIDGE_REQUEST_METHODS,
+  PROVIDER_BRIDGE_PROTOCOL_VERSION,
+  THREAD_DELTA_GRAMMAR_V3,
+  THREAD_DELTA_NOTIFICATION_METHOD,
+  createBridgeIo,
+  experimental_defineProviderBridge,
+  initializeParamsSchema,
+  modelListParamsSchema,
+  runBridgeRequest,
+  threadResumeParamsSchema,
+  threadStartParamsSchema,
+  threadStopParamsSchema,
+  turnStartParamsSchema,
+  turnSteerParamsSchema,
+} from "@get-bb/plugin-sdk/provider-bridge";
+import { randomUUID } from "node:crypto";
+import {
+  ensureLocalBrainstem,
+  stopManagedBrainstems,
+} from "./brainstem-process.js";
+import {
+  callRapp,
+  fixedBusinessModelList,
+  listRappModels,
+  resolveRappClientConfig,
+  setRappModel,
+  type RappClientConfig,
+  type RappChatResponse,
+} from "./rapp-client.js";
+import {
+  RAPP_AGENT_ACTIVITY_PRESENTATION,
+  RAPP_BUSINESS_MODEL_ID,
+  RAPP_MESSAGE_PRESENTATION,
+  RAPP_MODEL_ID,
+  RAPP_SESSION_STATE_KIND,
+  RAPP_SPEC,
+  rappCatalogOptionsSchema,
+  rappProviderOptionsSchema,
+  type RappCatalogOptions,
+  type RappProviderOptions,
+} from "./vocabulary.js";
+import {
+  RappSessionStore,
+  type RappPendingTurn,
+  type RappSessionSnapshot,
+} from "./session-store.js";
+
+type JsonRpcId = string | number;
+type OutboundMessage = { jsonrpc: "2.0" } & Record<string, unknown>;
+type RequestHandler = (id: JsonRpcId, params: unknown) => void | Promise<void>;
+
+interface ActiveTurn {
+  providerTurnId: string;
+  controller: AbortController;
+  promise: Promise<void>;
+}
+
+interface Session {
+  threadId: string;
+  providerThreadId: string;
+  snapshot: RappSessionSnapshot;
+  activeTurn: ActiveTurn | null;
+  closed: boolean;
+}
+
+const io = createBridgeIo<OutboundMessage>();
+const sessions = new Map<string, Session>();
+const consumerEndpointTails = new Map<string, Promise<void>>();
+const maintenanceControllers = new Set<AbortController>();
+const TURN_STOP_TIMEOUT_MS = 5_000;
+let sessionStore = new RappSessionStore();
+
+function notify(method: string, params: Record<string, unknown>): void {
+  io.send({ jsonrpc: "2.0", method, params });
+}
+
+function emitDeltas(threadId: string, deltas: ThreadDelta[]): void {
+  notify(THREAD_DELTA_NOTIFICATION_METHOD, { threadId, deltas });
+}
+
+function invalidParams(id: JsonRpcId, method: string, issues: unknown): void {
+  io.send({
+    jsonrpc: "2.0",
+    id,
+    error: {
+      code: BRIDGE_JSON_RPC_ERRORS.INVALID_PARAMS,
+      message: `Invalid params for ${method}`,
+      data: issues,
+    },
+  });
+}
+
+function parseProviderOptions(
+  id: JsonRpcId,
+  method: string,
+  value: unknown,
+): RappProviderOptions | null {
+  const parsed = rappProviderOptionsSchema.safeParse(value);
+  if (!parsed.success) {
+    invalidParams(id, method, parsed.error.issues);
+    return null;
+  }
+  try {
+    resolveRappClientConfig(parsed.data);
+  } catch (error) {
+    invalidParams(
+      id,
+      method,
+      error instanceof Error ? error.message : String(error),
+    );
+    return null;
+  }
+  return parsed.data;
+}
+
+function parseCatalogOptions(
+  id: JsonRpcId,
+  method: string,
+  value: unknown,
+): RappCatalogOptions | null {
+  const parsed = rappCatalogOptionsSchema.safeParse(value);
+  if (!parsed.success) {
+    invalidParams(id, method, parsed.error.issues);
+    return null;
+  }
+  return parsed.data;
+}
+
+async function runConsumerEndpointExclusive<T>(
+  config: RappClientConfig,
+  signal: AbortSignal,
+  run: () => Promise<T>,
+): Promise<T> {
+  const key = config.endpoint.toString();
+  const previous = consumerEndpointTails.get(key) ?? Promise.resolve();
+  let release: () => void = () => {};
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const tail = previous.catch(() => undefined).then(() => current);
+  consumerEndpointTails.set(key, tail);
+  try {
+    await waitForPromiseOrAbort(
+      previous.catch(() => undefined),
+      signal,
+    );
+    if (signal.aborted) {
+      throw signal.reason;
+    }
+    return await run();
+  } finally {
+    release();
+    if (consumerEndpointTails.get(key) === tail) {
+      consumerEndpointTails.delete(key);
+    }
+  }
+}
+
+function abortReason(signal: AbortSignal): unknown {
+  return signal.reason ?? new Error("RAPP request was interrupted");
+}
+
+function waitForPromiseOrAbort<T>(
+  promise: Promise<T>,
+  signal: AbortSignal,
+): Promise<T> {
+  if (signal.aborted) {
+    return Promise.reject(abortReason(signal));
+  }
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const finish = (result: { value: T } | { error: unknown }): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      signal.removeEventListener("abort", onAbort);
+      if ("error" in result) {
+        reject(result.error);
+      } else {
+        resolve(result.value);
+      }
+    };
+    const onAbort = (): void => finish({ error: abortReason(signal) });
+    signal.addEventListener("abort", onAbort, { once: true });
+    if (signal.aborted) {
+      onAbort();
+      return;
+    }
+    promise.then(
+      (value) => finish({ value }),
+      (error: unknown) => finish({ error }),
+    );
+  });
+}
+
+async function waitForTurnSettlement(promise: Promise<void>): Promise<boolean> {
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+  try {
+    return await Promise.race([
+      promise.then(
+        () => true,
+        () => true,
+      ),
+      new Promise<boolean>((resolve) => {
+        timeout = setTimeout(() => resolve(false), TURN_STOP_TIMEOUT_MS);
+        timeout.unref();
+      }),
+    ]);
+  } finally {
+    if (timeout !== null) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+function renderPrompt(input: readonly PromptInput[]): string {
+  return input
+    .map((item) => {
+      if (item.type === "text") {
+        return item.text;
+      }
+      if (item.type === "image") {
+        return `[Remote image: ${item.url}]`;
+      }
+      if (item.type === "localImage") {
+        return `[Local image: ${item.path}]`;
+      }
+      const name = item.name === undefined ? item.path : item.name;
+      return `[Local file: ${name} at ${item.path}]`;
+    })
+    .join("\n\n")
+    .trim();
+}
+
+function conversationHistory(
+  snapshot: RappSessionSnapshot,
+  instructions: string | undefined,
+) {
+  const trimmed = instructions?.trim() ?? "";
+  return [
+    ...(trimmed === ""
+      ? []
+      : [
+          {
+            role: "user" as const,
+            content: `BB thread instructions:\n${trimmed}`,
+          },
+        ]),
+    ...snapshot.transcript.slice(-40),
+  ];
+}
+
+function openSession(args: {
+  threadId: string;
+  providerThreadId: string;
+  snapshot: RappSessionSnapshot;
+}): Session {
+  const existing = sessions.get(args.threadId);
+  if (existing !== undefined) {
+    existing.closed = true;
+    existing.activeTurn?.controller.abort();
+  }
+  const session: Session = {
+    threadId: args.threadId,
+    providerThreadId: args.providerThreadId,
+    snapshot: args.snapshot,
+    activeTurn: null,
+    closed: false,
+  };
+  sessions.set(args.threadId, session);
+  notify(BRIDGE_NOTIFICATION_METHODS.threadIdentity, {
+    threadId: args.threadId,
+    providerThreadId: args.providerThreadId,
+  });
+  emitDeltas(args.threadId, [{ kind: "session.reset" }]);
+  return session;
+}
+
+function isCurrentTurn(session: Session, providerTurnId: string): boolean {
+  return (
+    !session.closed &&
+    sessions.get(session.threadId) === session &&
+    session.activeTurn?.providerTurnId === providerTurnId
+  );
+}
+
+function turnItemId(session: Session, turnCounter: number, name: string) {
+  return {
+    providerItemId: `${session.providerThreadId}-t${turnCounter}-${name}`,
+  };
+}
+
+function emitTurnFailure(
+  session: Session,
+  providerTurnId: string,
+  status: "failed" | "interrupted",
+  error?: string,
+): void {
+  emitDeltas(session.threadId, [
+    {
+      kind: "turn.boundary",
+      status,
+      providerTurnId,
+      ...(error === undefined ? {} : { error: { message: error } }),
+    },
+  ]);
+}
+
+async function executeTurn(args: {
+  session: Session;
+  input: readonly PromptInput[];
+  options: RappProviderOptions;
+  instructions: string | undefined;
+  clientRequestId?: ClientTurnRequestId;
+  providerTurnId: string;
+  controller: AbortController;
+}): Promise<void> {
+  const { session } = args;
+  const submittedPrompt = renderPrompt(args.input);
+  let pendingTurn: RappPendingTurn | null = null;
+  emitDeltas(session.threadId, [
+    {
+      kind: "turn.open",
+      providerTurnId: args.providerTurnId,
+    },
+    ...(args.clientRequestId === undefined
+      ? []
+      : [
+          {
+            kind: "input.accepted" as const,
+            clientRequestId: args.clientRequestId,
+            providerTurnId: args.providerTurnId,
+          },
+        ]),
+  ]);
+  try {
+    if (session.snapshot.pendingTurn === null) {
+      if (submittedPrompt === "") {
+        throw new Error("RAPP requires a non-empty prompt");
+      }
+      const turnCounter = session.snapshot.turnCounter + 1;
+      pendingTurn = {
+        idempotencyKey:
+          args.clientRequestId ?? `${session.providerThreadId}:${turnCounter}`,
+        userInput: submittedPrompt,
+        conversationHistory: conversationHistory(
+          session.snapshot,
+          args.instructions,
+        ),
+      };
+      const nextSnapshot: RappSessionSnapshot = {
+        ...session.snapshot,
+        turnCounter,
+        transcript: session.snapshot.transcript.map((entry) => ({ ...entry })),
+        pendingTurn,
+      };
+      session.snapshot = sessionStore.save(nextSnapshot).snapshot;
+    } else {
+      pendingTurn = session.snapshot.pendingTurn;
+    }
+    const config = resolveRappClientConfig(args.options);
+    await ensureLocalBrainstem(config, args.controller.signal);
+    const request = {
+      userInput: pendingTurn.userInput,
+      sessionId: session.snapshot.remoteSessionId,
+      idempotencyKey: pendingTurn.idempotencyKey,
+      conversationHistory: pendingTurn.conversationHistory,
+    };
+    let response: RappChatResponse;
+    let requestedModel: string | null;
+    let actualModel: string | null;
+    if (config.grail === "consumer") {
+      const result = await runConsumerEndpointExclusive(
+        config,
+        args.controller.signal,
+        async () => {
+          const selectedModel =
+            args.options.model === RAPP_MODEL_ID
+              ? null
+              : await setRappModel(
+                  config,
+                  args.options.model,
+                  args.controller.signal,
+                );
+          const consumerResponse = await callRapp(
+            config,
+            request,
+            args.controller.signal,
+          );
+          if (selectedModel !== null) {
+            if (consumerResponse.requestedModel === null) {
+              throw new Error(
+                `RAPP Brainstem did not report requested_model for selected model ${selectedModel}`,
+              );
+            }
+            if (consumerResponse.requestedModel !== selectedModel) {
+              throw new Error(
+                `RAPP Brainstem requested model ${consumerResponse.requestedModel} after bb selected ${selectedModel}`,
+              );
+            }
+          }
+          return {
+            response: consumerResponse,
+            requestedModel: consumerResponse.requestedModel,
+            actualModel: consumerResponse.actualModel,
+          };
+        },
+      );
+      response = result.response;
+      requestedModel = result.requestedModel;
+      actualModel = result.actualModel;
+    } else {
+      response = await callRapp(config, request, args.controller.signal);
+      requestedModel = RAPP_BUSINESS_MODEL_ID;
+      actualModel = RAPP_BUSINESS_MODEL_ID;
+    }
+    if (!isCurrentTurn(session, args.providerTurnId)) {
+      return;
+    }
+    const completedSnapshot: RappSessionSnapshot = {
+      ...session.snapshot,
+      remoteSessionId: response.sessionId,
+      transcript: [
+        ...session.snapshot.transcript,
+        { role: "user", content: pendingTurn.userInput },
+        { role: "assistant", content: response.response },
+      ],
+      pendingTurn: null,
+    };
+    const saved = sessionStore.save(completedSnapshot);
+    session.snapshot = saved.snapshot;
+
+    const deltas: ThreadDelta[] = [];
+    if (response.agentLogs.length > 0) {
+      const logsKey = turnItemId(
+        session,
+        session.snapshot.turnCounter,
+        "agents",
+      );
+      const logs = response.agentLogs.join("\n");
+      deltas.push(
+        {
+          kind: "item.open",
+          key: logsKey,
+          providerTurnId: args.providerTurnId,
+          item: {
+            type: "tool",
+            tool: "rapp_agents",
+            server: "rapp",
+            args: { spec: RAPP_SPEC },
+          },
+          presentation: RAPP_AGENT_ACTIVITY_PRESENTATION,
+        },
+        {
+          kind: "item.close",
+          key: logsKey,
+          providerTurnId: args.providerTurnId,
+          status: "completed",
+          item: {
+            type: "tool",
+            tool: "rapp_agents",
+            server: "rapp",
+            args: { spec: RAPP_SPEC },
+            result: logs,
+          },
+          presentation: RAPP_AGENT_ACTIVITY_PRESENTATION,
+        },
+      );
+    }
+
+    const messageKey = turnItemId(
+      session,
+      session.snapshot.turnCounter,
+      "message",
+    );
+    deltas.push(
+      {
+        kind: "item.open",
+        key: messageKey,
+        providerTurnId: args.providerTurnId,
+        item: { type: "agentMessage", text: "" },
+        presentation: RAPP_MESSAGE_PRESENTATION,
+      },
+      {
+        kind: "item.textClose",
+        key: messageKey,
+        providerTurnId: args.providerTurnId,
+        channel: "agentMessage",
+        text: response.response,
+      },
+      {
+        kind: "extension.state",
+        extensionKind: RAPP_SESSION_STATE_KIND,
+        payload: {
+          spec: RAPP_SPEC,
+          grail: config.grail,
+          rappid: saved.rappid,
+          sessionId: session.snapshot.remoteSessionId,
+          turnCount: session.snapshot.turnCounter,
+          eggAddress: saved.eggAddress,
+          endpoint: config.displayEndpoint,
+          selectedModel: args.options.model,
+          requestedModel,
+          actualModel,
+        },
+      },
+      {
+        kind: "turn.boundary",
+        status: "completed",
+        providerTurnId: args.providerTurnId,
+      },
+    );
+    emitDeltas(session.threadId, deltas);
+  } catch (error) {
+    if (!isCurrentTurn(session, args.providerTurnId)) {
+      return;
+    }
+    if (args.controller.signal.aborted) {
+      try {
+        session.snapshot = sessionStore.save({
+          ...session.snapshot,
+          pendingTurn: null,
+        }).snapshot;
+      } catch (clearError) {
+        emitTurnFailure(
+          session,
+          args.providerTurnId,
+          "failed",
+          `Could not clear interrupted RAPP turn: ${clearError instanceof Error ? clearError.message : String(clearError)}`,
+        );
+        return;
+      }
+      emitTurnFailure(session, args.providerTurnId, "interrupted");
+      return;
+    }
+    emitTurnFailure(
+      session,
+      args.providerTurnId,
+      "failed",
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+}
+
+function startTurn(args: {
+  session: Session;
+  input: readonly PromptInput[];
+  options: RappProviderOptions;
+  instructions: string | undefined;
+  clientRequestId?: ClientTurnRequestId;
+}): void {
+  const turnCounter =
+    args.session.snapshot.pendingTurn === null
+      ? args.session.snapshot.turnCounter + 1
+      : args.session.snapshot.turnCounter;
+  const providerTurnId = `${args.session.providerThreadId}-turn-${turnCounter}-${randomUUID().replaceAll("-", "")}`;
+  const controller = new AbortController();
+  const promise = Promise.resolve()
+    .then(() =>
+      executeTurn({
+        ...args,
+        providerTurnId,
+        controller,
+      }),
+    )
+    .catch((error: unknown) => {
+      if (isCurrentTurn(args.session, providerTurnId)) {
+        emitTurnFailure(
+          args.session,
+          providerTurnId,
+          "failed",
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+    })
+    .finally(() => {
+      if (args.session.activeTurn?.providerTurnId === providerTurnId) {
+        args.session.activeTurn = null;
+      }
+    });
+  args.session.activeTurn = { providerTurnId, controller, promise };
+}
+
+const handlers: Record<string, RequestHandler> = {
+  [BRIDGE_REQUEST_METHODS.initialize]: (id, params) => {
+    const parsed = initializeParamsSchema.safeParse(params);
+    if (!parsed.success) {
+      invalidParams(id, BRIDGE_REQUEST_METHODS.initialize, parsed.error.issues);
+      return;
+    }
+    io.sendResult(id, {
+      protocolVersion: PROVIDER_BRIDGE_PROTOCOL_VERSION,
+      capabilities: {
+        grammarVersions: [THREAD_DELTA_GRAMMAR_V3, THREAD_DELTA_GRAMMAR_V3],
+        sessionRestore: true,
+        threadArchive: false,
+        threadRename: false,
+        threadGoalClear: false,
+        fork: "none",
+        approvalEnforcedBy: "provider",
+        steerMode: "queue",
+      },
+    });
+  },
+
+  [BRIDGE_REQUEST_METHODS.modelList]: async (id, params) => {
+    const parsed = modelListParamsSchema.safeParse(params);
+    if (!parsed.success) {
+      invalidParams(id, BRIDGE_REQUEST_METHODS.modelList, parsed.error.issues);
+      return;
+    }
+    const options = parseCatalogOptions(
+      id,
+      BRIDGE_REQUEST_METHODS.modelList,
+      Reflect.get(parsed.data, "providerOptions"),
+    );
+    if (options === null) {
+      return;
+    }
+    if (options.grail === "business") {
+      io.sendResult(id, fixedBusinessModelList());
+      return;
+    }
+    const config = resolveRappClientConfig(options);
+    const controller = new AbortController();
+    maintenanceControllers.add(controller);
+    try {
+      await ensureLocalBrainstem(config, controller.signal);
+      const result = await runConsumerEndpointExclusive(
+        config,
+        controller.signal,
+        () => listRappModels(config, controller.signal),
+      );
+      io.sendResult(id, result);
+    } finally {
+      maintenanceControllers.delete(controller);
+    }
+  },
+
+  [BRIDGE_REQUEST_METHODS.threadStart]: (id, params) => {
+    const parsed = threadStartParamsSchema.safeParse(params);
+    if (!parsed.success) {
+      invalidParams(
+        id,
+        BRIDGE_REQUEST_METHODS.threadStart,
+        parsed.error.issues,
+      );
+      return;
+    }
+    const options = parseProviderOptions(
+      id,
+      BRIDGE_REQUEST_METHODS.threadStart,
+      parsed.data.options.providerOptions,
+    );
+    if (options === null) {
+      return;
+    }
+    const providerThreadId = `rapp_${randomUUID().replaceAll("-", "")}`;
+    const saved = sessionStore.create(providerThreadId);
+    const session = openSession({
+      threadId: parsed.data.threadId,
+      providerThreadId,
+      snapshot: saved.snapshot,
+    });
+    io.sendResult(id, { providerThreadId, sessionRestorable: true });
+    if (parsed.data.input !== undefined && parsed.data.input.length > 0) {
+      startTurn({
+        session,
+        input: parsed.data.input,
+        options,
+        instructions: parsed.data.options.instructions,
+      });
+    }
+  },
+
+  [BRIDGE_REQUEST_METHODS.threadResume]: (id, params) => {
+    const parsed = threadResumeParamsSchema.safeParse(params);
+    if (!parsed.success) {
+      invalidParams(
+        id,
+        BRIDGE_REQUEST_METHODS.threadResume,
+        parsed.error.issues,
+      );
+      return;
+    }
+    const options = parseProviderOptions(
+      id,
+      BRIDGE_REQUEST_METHODS.threadResume,
+      parsed.data.options.providerOptions,
+    );
+    if (options === null) {
+      return;
+    }
+    const saved = sessionStore.load(parsed.data.providerThreadId);
+    if (saved === null) {
+      io.sendError(
+        id,
+        BRIDGE_JSON_RPC_ERRORS.INVALID_PARAMS,
+        `Unknown RAPP session: ${parsed.data.providerThreadId}`,
+      );
+      return;
+    }
+    openSession({
+      threadId: parsed.data.threadId,
+      providerThreadId: parsed.data.providerThreadId,
+      snapshot: saved.snapshot,
+    });
+    io.sendResult(id, {
+      providerThreadId: parsed.data.providerThreadId,
+      sessionRestorable: true,
+    });
+  },
+
+  [BRIDGE_REQUEST_METHODS.turnStart]: (id, params) => {
+    const parsed = turnStartParamsSchema.safeParse(params);
+    if (!parsed.success) {
+      invalidParams(id, BRIDGE_REQUEST_METHODS.turnStart, parsed.error.issues);
+      return;
+    }
+    const session = sessions.get(parsed.data.threadId);
+    if (session === undefined) {
+      io.sendError(
+        id,
+        BRIDGE_JSON_RPC_ERRORS.INVALID_PARAMS,
+        `No RAPP session for thread ${parsed.data.threadId}`,
+      );
+      return;
+    }
+    if (session.providerThreadId !== parsed.data.providerThreadId) {
+      io.sendError(
+        id,
+        BRIDGE_JSON_RPC_ERRORS.INVALID_PARAMS,
+        "RAPP provider thread identity mismatch",
+      );
+      return;
+    }
+    if (session.activeTurn !== null) {
+      io.sendError(
+        id,
+        BRIDGE_JSON_RPC_ERRORS.INVALID_PARAMS,
+        "RAPP already has an active turn for this thread",
+      );
+      return;
+    }
+    const options = parseProviderOptions(
+      id,
+      BRIDGE_REQUEST_METHODS.turnStart,
+      parsed.data.options.providerOptions,
+    );
+    if (options === null) {
+      return;
+    }
+    io.sendResult(id, {});
+    startTurn({
+      session,
+      input: parsed.data.input,
+      options,
+      instructions: parsed.data.options.instructions,
+      clientRequestId: parsed.data.clientRequestId,
+    });
+  },
+
+  [BRIDGE_REQUEST_METHODS.turnSteer]: (id, params) => {
+    const parsed = turnSteerParamsSchema.safeParse(params);
+    if (!parsed.success) {
+      invalidParams(id, BRIDGE_REQUEST_METHODS.turnSteer, parsed.error.issues);
+      return;
+    }
+    io.sendError(
+      id,
+      BRIDGE_JSON_RPC_ERRORS.NO_ACTIVE_TURN,
+      `RAPP's synchronous wire cannot steer turn ${parsed.data.expectedTurnId}`,
+    );
+  },
+
+  [BRIDGE_REQUEST_METHODS.threadStop]: async (id, params) => {
+    const parsed = threadStopParamsSchema.safeParse(params);
+    if (!parsed.success) {
+      invalidParams(id, BRIDGE_REQUEST_METHODS.threadStop, parsed.error.issues);
+      return;
+    }
+    const session = sessions.get(parsed.data.threadId);
+    if (
+      session === undefined ||
+      session.providerThreadId !== parsed.data.providerThreadId
+    ) {
+      io.sendResult(id, {});
+      return;
+    }
+    if (parsed.data.intent === "interrupt") {
+      const activeTurn = session.activeTurn;
+      if (
+        activeTurn !== null &&
+        parsed.data.activeTurnId === activeTurn.providerTurnId
+      ) {
+        activeTurn.controller.abort();
+        const settled = await waitForTurnSettlement(activeTurn.promise);
+        if (!settled && isCurrentTurn(session, activeTurn.providerTurnId)) {
+          session.activeTurn = null;
+          emitTurnFailure(session, activeTurn.providerTurnId, "interrupted");
+        }
+      }
+      io.sendResult(id, {});
+      return;
+    }
+    if (session.activeTurn !== null) {
+      const settled = await waitForTurnSettlement(session.activeTurn.promise);
+      if (!settled) {
+        io.sendError(
+          id,
+          BRIDGE_JSON_RPC_ERRORS.BRIDGE_ERROR,
+          "RAPP turn did not settle before session release",
+        );
+        return;
+      }
+    }
+    session.closed = true;
+    if (sessions.get(parsed.data.threadId) === session) {
+      sessions.delete(parsed.data.threadId);
+    }
+    io.sendResult(id, {});
+  },
+};
+
+export function handleLine(line: string): void {
+  let message: unknown;
+  try {
+    message = JSON.parse(line);
+  } catch {
+    return;
+  }
+  if (
+    typeof message !== "object" ||
+    message === null ||
+    Array.isArray(message)
+  ) {
+    return;
+  }
+  const id: unknown = Reflect.get(message, "id");
+  const method: unknown = Reflect.get(message, "method");
+  const params: unknown = Reflect.get(message, "params");
+  if (typeof method !== "string") {
+    return;
+  }
+  if (typeof id !== "string" && typeof id !== "number") {
+    return;
+  }
+  const handler = handlers[method];
+  if (handler === undefined) {
+    io.sendError(
+      id,
+      BRIDGE_JSON_RPC_ERRORS.METHOD_NOT_FOUND,
+      `Method not found: ${method}`,
+    );
+    return;
+  }
+  runBridgeRequest({
+    request: { id, method, params },
+    sendError: io.sendError,
+    handleRequest: async (request) => handler(request.id, request.params),
+  });
+}
+
+export function experimental_resetRappBridgeForTests(dataDir?: string): void {
+  shutdownBridge();
+  sessionStore = new RappSessionStore(dataDir);
+}
+
+function shutdownBridge(): void {
+  for (const controller of maintenanceControllers) {
+    controller.abort();
+  }
+  maintenanceControllers.clear();
+  for (const session of sessions.values()) {
+    session.closed = true;
+    session.activeTurn?.controller.abort();
+  }
+  sessions.clear();
+  consumerEndpointTails.clear();
+  void stopManagedBrainstems();
+}
+
+export const experimental_providerBridge = experimental_defineProviderBridge({
+  handleLine,
+  start(context) {
+    experimental_resetRappBridgeForTests(context.dataDir);
+  },
+  onClose() {
+    shutdownBridge();
+  },
+  onSigterm() {
+    shutdownBridge();
+  },
+  onSigint() {
+    shutdownBridge();
+  },
+});

--- a/plugins/provider-rapp/src/host.ts
+++ b/plugins/provider-rapp/src/host.ts
@@ -1,0 +1,9 @@
+import { defineRpcContract } from "@get-bb/plugin-sdk";
+import { experimental_defineHostEntry } from "@get-bb/plugin-sdk/host";
+
+export { experimental_providerBridge } from "./bridge.js";
+
+export default experimental_defineHostEntry({
+  contract: defineRpcContract({}),
+  handlers: {},
+});

--- a/plugins/provider-rapp/src/rapp-client.test.ts
+++ b/plugins/provider-rapp/src/rapp-client.test.ts
@@ -10,6 +10,13 @@ import {
   resolveRappClientConfig,
   type RappChatRequest,
 } from "./rapp-client.js";
+import {
+  RAPP_BRAINSTEM_SECRET_ENV,
+  RAPP_BRAINSTEM_URL_ENV,
+  RAPP_BUSINESS_URL_ENV,
+  RAPP_ENDPOINT_URL_REQUIREMENTS,
+  RAPP_FUNCTION_KEY_ENV,
+} from "./vocabulary.js";
 
 const servers: ReturnType<typeof createServer>[] = [];
 
@@ -27,16 +34,29 @@ afterEach(async () => {
 async function listen(
   handler: (request: IncomingMessage, response: ServerResponse) => void,
 ): Promise<string> {
+  return listenOn("127.0.0.1", handler);
+}
+
+async function listenOn(
+  host: "127.0.0.1" | "::1",
+  handler: (request: IncomingMessage, response: ServerResponse) => void,
+): Promise<string> {
   const server = createServer(handler);
-  servers.push(server);
-  await new Promise<void>((resolve) => {
-    server.listen(0, "127.0.0.1", resolve);
+  await new Promise<void>((resolve, reject) => {
+    const onError = (error: Error): void => reject(error);
+    server.once("error", onError);
+    server.listen(0, host, () => {
+      server.off("error", onError);
+      resolve();
+    });
   });
+  servers.push(server);
   const address = server.address();
   if (address === null || typeof address === "string") {
     throw new Error("expected TCP server address");
   }
-  return `http://127.0.0.1:${address.port}`;
+  const displayHost = host === "::1" ? "[::1]" : host;
+  return `http://${displayHost}:${address.port}`;
 }
 
 async function readJson(request: IncomingMessage): Promise<unknown> {
@@ -54,11 +74,63 @@ const chatRequest: RappChatRequest = {
   conversationHistory: [{ role: "user", content: "earlier" }],
 };
 
+const invalidRuntimeEndpoints = [
+  {
+    label: "a generic query parameter",
+    endpoint: "https://example.com/chat?tenant=test",
+  },
+  {
+    label: "a sig query parameter",
+    endpoint:
+      "https://example.com/api/businessinsightbot_function?sig=secret",
+  },
+  {
+    label: "a signature query parameter",
+    endpoint: "https://example.com/chat?signature=secret",
+  },
+  {
+    label: "an auth query parameter",
+    endpoint:
+      "https://example.com/api/businessinsightbot_function?auth=secret",
+  },
+  {
+    label: "a credential query parameter",
+    endpoint: "https://example.com/chat?credential=secret",
+  },
+  {
+    label: "a username",
+    endpoint: "https://user@example.com/chat",
+  },
+  {
+    label: "a password",
+    endpoint: "https://:password@example.com/chat",
+  },
+  {
+    label: "a fragment",
+    endpoint: "https://example.com/chat#tenant",
+  },
+];
+
+const runtimeEndpointSources = [
+  {
+    label: "Consumer",
+    grail: "consumer",
+    envName: RAPP_BRAINSTEM_URL_ENV,
+  },
+  {
+    label: "Business",
+    grail: "business",
+    envName: RAPP_BUSINESS_URL_ENV,
+  },
+] as const;
+
 describe("RAPP Grail client", () => {
   it("normalizes the Consumer Grail response while preserving RAPP/1 request fields", async () => {
     let received: unknown;
+    let brainstemSecret: string | string[] | undefined;
     const base = await listen(async (request, response) => {
       received = await readJson(request);
+      brainstemSecret = request.headers["x-brainstem-secret"];
       response.setHeader("content-type", "application/json");
       response.end(
         JSON.stringify({
@@ -73,7 +145,7 @@ describe("RAPP Grail client", () => {
     });
     const config = resolveRappClientConfig(
       { grail: "consumer", endpoint: base },
-      {},
+      { [RAPP_BRAINSTEM_SECRET_ENV]: "brainstem-secret" },
     );
     const result = await callRapp(
       config,
@@ -96,6 +168,7 @@ describe("RAPP Grail client", () => {
     expect(config.endpoint.pathname).toBe("/chat");
     expect(config.modelListEndpoint?.pathname).toBe("/models");
     expect(config.modelSetEndpoint?.pathname).toBe("/models/set");
+    expect(brainstemSecret).toBe("brainstem-secret");
   });
 
   it("omits session_id until Brainstem assigns one", async () => {
@@ -129,10 +202,10 @@ describe("RAPP Grail client", () => {
 
   it("normalizes the Business Grail and keeps credentials out of the URL and body", async () => {
     let received: unknown;
-    let functionKey: string | undefined;
+    let functionKey: string | string[] | undefined;
     const base = await listen(async (request, response) => {
       received = await readJson(request);
-      functionKey = request.headers["x-functions-key"] as string | undefined;
+      functionKey = request.headers["x-functions-key"];
       response.setHeader("content-type", "application/json");
       response.end(
         JSON.stringify({
@@ -146,7 +219,7 @@ describe("RAPP Grail client", () => {
     const config = resolveRappClientConfig(
       { grail: "business", endpoint: base },
       {
-        RAPP_FUNCTION_KEY: "function-secret",
+        [RAPP_FUNCTION_KEY_ENV]: "function-secret",
         RAPP_USER_GUID: "user-1",
       },
     );
@@ -173,36 +246,62 @@ describe("RAPP Grail client", () => {
     expect(config.modelSetEndpoint).toBeNull();
   });
 
-  it("refuses secret-bearing endpoint query parameters", () => {
-    expect(() =>
-      resolveRappClientConfig(
-        {
-          grail: "business",
-          endpoint:
-            "https://example.com/api/businessinsightbot_function?code=x",
-        },
-        {},
-      ),
-    ).toThrow("secret-bearing query parameters");
+  describe.each(runtimeEndpointSources)(
+    "$label runtime endpoint validation",
+    ({ grail, envName }) => {
+      it.each(invalidRuntimeEndpoints)("rejects $label", ({ endpoint }) => {
+        const resolve = () =>
+          resolveRappClientConfig(
+            { grail, endpoint: "" },
+            { [envName]: endpoint },
+          );
+
+        expect(resolve).toThrowError(RappClientError);
+        expect(resolve).toThrow(RAPP_ENDPOINT_URL_REQUIREMENTS);
+      });
+    },
+  );
+
+  it("contacts an explicitly running IPv6 loopback endpoint without rewriting it", async () => {
+    let requestUrl: string | undefined;
+    let brainstemSecret: string | string[] | undefined;
+    const base = await listenOn("::1", (request, response) => {
+      requestUrl = request.url;
+      brainstemSecret = request.headers["x-brainstem-secret"];
+      response.setHeader("content-type", "application/json");
+      response.end(
+        JSON.stringify({
+          response: "ipv6 answer",
+          session_id: "session-1",
+          agent_logs: [],
+        }),
+      );
+    });
+    const config = resolveRappClientConfig(
+      { grail: "consumer", endpoint: base },
+      { [RAPP_BRAINSTEM_SECRET_ENV]: "ipv6-secret" },
+    );
+
+    const result = await callRapp(
+      config,
+      chatRequest,
+      new AbortController().signal,
+    );
+
+    expect(config.endpoint.toString()).toBe(`${base}/chat`);
+    expect(requestUrl).toBe("/chat");
+    expect(brainstemSecret).toBe("ipv6-secret");
+    expect(result.response).toBe("ipv6 answer");
   });
 
-  it("refuses URL credentials and credential-bearing remote HTTP", () => {
-    expect(() =>
-      resolveRappClientConfig(
-        {
-          grail: "consumer",
-          endpoint: "https://user:password@example.com/chat",
-        },
-        {},
-      ),
-    ).toThrow("without credentials");
+  it("refuses credential-bearing remote HTTP", () => {
     expect(() =>
       resolveRappClientConfig(
         {
           grail: "business",
           endpoint: "http://example.com/api/businessinsightbot_function",
         },
-        { RAPP_FUNCTION_KEY: "secret" },
+        { [RAPP_FUNCTION_KEY_ENV]: "secret" },
       ),
     ).toThrow("require HTTPS");
   });

--- a/plugins/provider-rapp/src/rapp-client.test.ts
+++ b/plugins/provider-rapp/src/rapp-client.test.ts
@@ -1,0 +1,254 @@
+import {
+  createServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  callRapp,
+  RappClientError,
+  resolveRappClientConfig,
+  type RappChatRequest,
+} from "./rapp-client.js";
+
+const servers: ReturnType<typeof createServer>[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    servers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        }),
+    ),
+  );
+});
+
+async function listen(
+  handler: (request: IncomingMessage, response: ServerResponse) => void,
+): Promise<string> {
+  const server = createServer(handler);
+  servers.push(server);
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("expected TCP server address");
+  }
+  return `http://127.0.0.1:${address.port}`;
+}
+
+async function readJson(request: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+}
+
+const chatRequest: RappChatRequest = {
+  userInput: "hello",
+  sessionId: "session-1",
+  idempotencyKey: "request-1",
+  conversationHistory: [{ role: "user", content: "earlier" }],
+};
+
+describe("RAPP Grail client", () => {
+  it("normalizes the Consumer Grail response while preserving RAPP/1 request fields", async () => {
+    let received: unknown;
+    const base = await listen(async (request, response) => {
+      received = await readJson(request);
+      response.setHeader("content-type", "application/json");
+      response.end(
+        JSON.stringify({
+          response: "consumer answer",
+          session_id: "session-1",
+          agent_logs: "AgentOne\nAgentTwo",
+          model: "claude-opus-5",
+          requested_model: "claude-sonnet-5",
+          voice_mode: false,
+        }),
+      );
+    });
+    const config = resolveRappClientConfig(
+      { grail: "consumer", endpoint: base },
+      {},
+    );
+    const result = await callRapp(
+      config,
+      chatRequest,
+      new AbortController().signal,
+    );
+    expect(received).toEqual({
+      user_input: "hello",
+      session_id: "session-1",
+      idempotency_key: "request-1",
+      conversation_history: [{ role: "user", content: "earlier" }],
+    });
+    expect(result).toEqual({
+      response: "consumer answer",
+      agentLogs: ["AgentOne", "AgentTwo"],
+      sessionId: "session-1",
+      requestedModel: "claude-sonnet-5",
+      actualModel: "claude-opus-5",
+    });
+    expect(config.endpoint.pathname).toBe("/chat");
+    expect(config.modelListEndpoint?.pathname).toBe("/models");
+    expect(config.modelSetEndpoint?.pathname).toBe("/models/set");
+  });
+
+  it("omits session_id until Brainstem assigns one", async () => {
+    let received: unknown;
+    const base = await listen(async (request, response) => {
+      received = await readJson(request);
+      response.setHeader("content-type", "application/json");
+      response.end(
+        JSON.stringify({
+          response: "assigned",
+          session_id: "brainstem-session",
+          agent_logs: [],
+          model: "claude-opus-5",
+          requested_model: "claude-opus-5",
+        }),
+      );
+    });
+    const result = await callRapp(
+      resolveRappClientConfig({ grail: "consumer", endpoint: base }, {}),
+      { ...chatRequest, sessionId: null },
+      new AbortController().signal,
+    );
+
+    expect(received).toEqual({
+      user_input: "hello",
+      idempotency_key: "request-1",
+      conversation_history: [{ role: "user", content: "earlier" }],
+    });
+    expect(result.sessionId).toBe("brainstem-session");
+  });
+
+  it("normalizes the Business Grail and keeps credentials out of the URL and body", async () => {
+    let received: unknown;
+    let functionKey: string | undefined;
+    const base = await listen(async (request, response) => {
+      received = await readJson(request);
+      functionKey = request.headers["x-functions-key"] as string | undefined;
+      response.setHeader("content-type", "application/json");
+      response.end(
+        JSON.stringify({
+          assistant_response: "business answer",
+          voice_response: "short answer",
+          agent_logs: ["BusinessAgent"],
+          user_guid: "user-1",
+        }),
+      );
+    });
+    const config = resolveRappClientConfig(
+      { grail: "business", endpoint: base },
+      {
+        RAPP_FUNCTION_KEY: "function-secret",
+        RAPP_USER_GUID: "user-1",
+      },
+    );
+    const result = await callRapp(
+      config,
+      chatRequest,
+      new AbortController().signal,
+    );
+    expect(config.endpoint.pathname).toBe("/api/businessinsightbot_function");
+    expect(config.endpoint.search).toBe("");
+    expect(functionKey).toBe("function-secret");
+    expect(received).toEqual({
+      user_input: "hello",
+      session_id: "session-1",
+      idempotency_key: "request-1",
+      conversation_history: [{ role: "user", content: "earlier" }],
+      user_guid: "user-1",
+    });
+    expect(result.response).toBe("business answer");
+    expect(result.sessionId).toBe("session-1");
+    expect(result.requestedModel).toBeNull();
+    expect(result.actualModel).toBeNull();
+    expect(config.modelListEndpoint).toBeNull();
+    expect(config.modelSetEndpoint).toBeNull();
+  });
+
+  it("refuses secret-bearing endpoint query parameters", () => {
+    expect(() =>
+      resolveRappClientConfig(
+        {
+          grail: "business",
+          endpoint:
+            "https://example.com/api/businessinsightbot_function?code=x",
+        },
+        {},
+      ),
+    ).toThrow("secret-bearing query parameters");
+  });
+
+  it("refuses URL credentials and credential-bearing remote HTTP", () => {
+    expect(() =>
+      resolveRappClientConfig(
+        {
+          grail: "consumer",
+          endpoint: "https://user:password@example.com/chat",
+        },
+        {},
+      ),
+    ).toThrow("without credentials");
+    expect(() =>
+      resolveRappClientConfig(
+        {
+          grail: "business",
+          endpoint: "http://example.com/api/businessinsightbot_function",
+        },
+        { RAPP_FUNCTION_KEY: "secret" },
+      ),
+    ).toThrow("require HTTPS");
+  });
+
+  it("does not forward credentials or prompts through redirects", async () => {
+    let redirected = false;
+    const target = await listen((_request, response) => {
+      redirected = true;
+      response.end();
+    });
+    const source = await listen((_request, response) => {
+      response.statusCode = 307;
+      response.setHeader("location", `${target}/capture`);
+      response.end();
+    });
+    const config = resolveRappClientConfig(
+      { grail: "business", endpoint: source },
+      { RAPP_FUNCTION_KEY: "function-secret" },
+    );
+
+    await expect(
+      callRapp(config, chatRequest, new AbortController().signal),
+    ).rejects.toMatchObject({
+      name: "RappClientError",
+      kind: "connection",
+    });
+    expect(redirected).toBe(false);
+  });
+
+  it("keeps timeout and abort coverage active while reading the body", async () => {
+    const base = await listen((_request, response) => {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.write('{"response":"partial');
+      setTimeout(() => response.end('"}'), 200);
+    });
+    const config = {
+      ...resolveRappClientConfig({ grail: "consumer", endpoint: base }, {}),
+      timeoutMs: 25,
+    };
+
+    const error = await callRapp(
+      config,
+      chatRequest,
+      new AbortController().signal,
+    ).catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(RappClientError);
+    expect(error).toMatchObject({ kind: "timeout" });
+  });
+});

--- a/plugins/provider-rapp/src/rapp-client.test.ts
+++ b/plugins/provider-rapp/src/rapp-client.test.ts
@@ -6,6 +6,7 @@ import {
 import { afterEach, describe, expect, it } from "vitest";
 import {
   callRapp,
+  RAPP_MAX_RESPONSE_BYTES,
   RappClientError,
   resolveRappClientConfig,
   type RappChatRequest,
@@ -349,5 +350,50 @@ describe("RAPP Grail client", () => {
     ).catch((caught: unknown) => caught);
     expect(error).toBeInstanceOf(RappClientError);
     expect(error).toMatchObject({ kind: "timeout" });
+  });
+
+  it("rejects a response whose declared body exceeds the persistence-safe cap", async () => {
+    const base = await listen((_request, response) => {
+      response.writeHead(200, {
+        "content-type": "application/json",
+        "content-length": String(RAPP_MAX_RESPONSE_BYTES + 1),
+      });
+      response.end("{}");
+    });
+
+    await expect(
+      callRapp(
+        resolveRappClientConfig({ grail: "consumer", endpoint: base }, {}),
+        chatRequest,
+        new AbortController().signal,
+      ),
+    ).rejects.toMatchObject({
+      kind: "response",
+      message: `RAPP response exceeds ${RAPP_MAX_RESPONSE_BYTES} bytes`,
+      statusCode: 200,
+    });
+  });
+
+  it("rejects a chunked response that crosses the persistence-safe cap", async () => {
+    const base = await listen((_request, response) => {
+      response.writeHead(200, { "content-type": "application/json" });
+      const chunk = Buffer.alloc(16 * 1024, "x");
+      for (let index = 0; index < 5; index += 1) {
+        response.write(chunk);
+      }
+      response.end();
+    });
+
+    await expect(
+      callRapp(
+        resolveRappClientConfig({ grail: "consumer", endpoint: base }, {}),
+        chatRequest,
+        new AbortController().signal,
+      ),
+    ).rejects.toMatchObject({
+      kind: "response",
+      message: `RAPP response exceeds ${RAPP_MAX_RESPONSE_BYTES} bytes`,
+      statusCode: 200,
+    });
   });
 });

--- a/plugins/provider-rapp/src/rapp-client.ts
+++ b/plugins/provider-rapp/src/rapp-client.ts
@@ -6,6 +6,7 @@ import {
   RAPP_BRAINSTEM_MODEL,
   RAPP_BUSINESS_MODEL,
   RAPP_BUSINESS_URL_ENV,
+  RAPP_ENDPOINT_URL_REQUIREMENTS,
   RAPP_FUNCTION_KEY_ENV,
   RAPP_USER_GUID_ENV,
   rappCatalogOptionsSchema,
@@ -152,21 +153,17 @@ function normalizeEndpoint(raw: string, grail: RappGrail): URL {
       "configuration",
     );
   }
-  if (endpoint.username !== "" || endpoint.password !== "") {
+  if (
+    endpoint.username !== "" ||
+    endpoint.password !== "" ||
+    endpoint.search !== "" ||
+    endpoint.hash !== ""
+  ) {
     throw new RappClientError(
-      "RAPP endpoint URLs must not contain credentials",
+      RAPP_ENDPOINT_URL_REQUIREMENTS,
       "configuration",
     );
   }
-  for (const key of endpoint.searchParams.keys()) {
-    if (/(code|token|secret|key|password)/iu.test(key)) {
-      throw new RappClientError(
-        "Put RAPP credentials in the documented host environment variables, not the endpoint URL",
-        "configuration",
-      );
-    }
-  }
-  endpoint.hash = "";
   const path = endpoint.pathname.replace(/\/+$/u, "");
   if (grail === "consumer") {
     endpoint.pathname =

--- a/plugins/provider-rapp/src/rapp-client.ts
+++ b/plugins/provider-rapp/src/rapp-client.ts
@@ -1,0 +1,621 @@
+import { z } from "zod";
+import type { AvailableModel } from "@get-bb/plugin-sdk/provider-bridge";
+import {
+  RAPP_BRAINSTEM_SECRET_ENV,
+  RAPP_BRAINSTEM_URL_ENV,
+  RAPP_BRAINSTEM_MODEL,
+  RAPP_BUSINESS_MODEL,
+  RAPP_BUSINESS_URL_ENV,
+  RAPP_FUNCTION_KEY_ENV,
+  RAPP_USER_GUID_ENV,
+  rappCatalogOptionsSchema,
+  type RappCatalogOptions,
+  type RappGrail,
+} from "./vocabulary.js";
+import type { RappTranscriptEntry } from "./rapp1.js";
+
+const canonicalResponseSchema = z
+  .object({
+    response: z.string().refine((value) => value.trim() !== ""),
+    agent_logs: z.array(z.string()),
+    session_id: z.string().min(1),
+  })
+  .strict();
+
+const consumerResponseSchema = z
+  .object({
+    response: z.string().refine((value) => value.trim() !== ""),
+    agent_logs: z.union([z.string(), z.array(z.string())]),
+    session_id: z.string().min(1),
+    model: z.string().optional(),
+    requested_model: z.string().optional(),
+  })
+  .passthrough();
+
+const businessResponseSchema = z
+  .object({
+    assistant_response: z.string().refine((value) => value.trim() !== ""),
+    voice_response: z.string().optional(),
+    agent_logs: z.union([z.string(), z.array(z.string())]),
+    user_guid: z.string().optional(),
+  })
+  .passthrough();
+
+const nestedErrorSchema = z.object({
+  error: z.union([
+    z.string(),
+    z.object({
+      code: z.string(),
+      step: z.string().nullable().optional(),
+    }),
+  ]),
+  details: z.string().optional(),
+});
+
+const consumerModelSchema = z
+  .object({
+    id: z.string().min(1),
+    name: z.string().min(1),
+    available: z.boolean().optional(),
+  })
+  .passthrough();
+
+const consumerModelListSchema = z
+  .object({
+    models: z.array(consumerModelSchema),
+    current: z.string().min(1),
+  })
+  .passthrough();
+
+const modelSetResponseSchema = z
+  .object({
+    model: z.string().min(1),
+  })
+  .passthrough();
+
+const MAX_RESPONSE_BYTES = 16 * 1024 * 1024;
+
+export interface RappClientConfig {
+  grail: RappGrail;
+  endpoint: URL;
+  modelListEndpoint: URL | null;
+  modelSetEndpoint: URL | null;
+  displayEndpoint: string;
+  headers: Readonly<Record<string, string>>;
+  userGuid: string | null;
+  timeoutMs: number;
+}
+
+export interface RappChatRequest {
+  userInput: string;
+  sessionId: string | null;
+  idempotencyKey: string;
+  conversationHistory: readonly RappTranscriptEntry[];
+}
+
+export interface RappChatResponse {
+  response: string;
+  agentLogs: string[];
+  sessionId: string | null;
+  requestedModel: string | null;
+  actualModel: string | null;
+}
+
+export interface RappModelList {
+  models: AvailableModel[];
+  selectedOnlyModels: AvailableModel[];
+}
+
+export class RappClientError extends Error {
+  constructor(
+    message: string,
+    readonly kind:
+      | "configuration"
+      | "connection"
+      | "timeout"
+      | "unauthorized"
+      | "rate-limit"
+      | "response",
+    readonly statusCode: number | null = null,
+  ) {
+    super(message);
+    this.name = "RappClientError";
+  }
+}
+
+function normalizedHostname(hostname: string): string {
+  const normalized = hostname.toLowerCase();
+  return normalized.startsWith("[") && normalized.endsWith("]")
+    ? normalized.slice(1, -1)
+    : normalized;
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  const normalized = normalizedHostname(hostname);
+  return (
+    normalized === "localhost" ||
+    normalized === "127.0.0.1" ||
+    normalized === "::1"
+  );
+}
+
+function normalizeEndpoint(raw: string, grail: RappGrail): URL {
+  let endpoint: URL;
+  try {
+    endpoint = new URL(raw);
+  } catch {
+    throw new RappClientError(`Invalid RAPP endpoint: ${raw}`, "configuration");
+  }
+  if (endpoint.protocol !== "http:" && endpoint.protocol !== "https:") {
+    throw new RappClientError(
+      "RAPP endpoint must use HTTP or HTTPS",
+      "configuration",
+    );
+  }
+  if (endpoint.username !== "" || endpoint.password !== "") {
+    throw new RappClientError(
+      "RAPP endpoint URLs must not contain credentials",
+      "configuration",
+    );
+  }
+  for (const key of endpoint.searchParams.keys()) {
+    if (/(code|token|secret|key|password)/iu.test(key)) {
+      throw new RappClientError(
+        "Put RAPP credentials in the documented host environment variables, not the endpoint URL",
+        "configuration",
+      );
+    }
+  }
+  endpoint.hash = "";
+  const path = endpoint.pathname.replace(/\/+$/u, "");
+  if (grail === "consumer") {
+    endpoint.pathname =
+      path === "" ? "/chat" : path.endsWith("/chat") ? path : `${path}/chat`;
+  } else {
+    endpoint.pathname =
+      path === ""
+        ? "/api/businessinsightbot_function"
+        : path.endsWith("/api")
+          ? `${path}/businessinsightbot_function`
+          : path;
+  }
+  return endpoint;
+}
+
+function displayEndpoint(endpoint: URL): string {
+  const display = new URL(endpoint);
+  display.username = "";
+  display.password = "";
+  display.search = "";
+  display.hash = "";
+  return display.toString();
+}
+
+function consumerSiblingEndpoint(endpoint: URL, path: string): URL {
+  const sibling = new URL(endpoint);
+  sibling.pathname = `${sibling.pathname.slice(0, -"/chat".length)}${path}`;
+  return sibling;
+}
+
+export function resolveRappClientConfig(
+  rawOptions: RappCatalogOptions,
+  env: NodeJS.ProcessEnv = process.env,
+): RappClientConfig {
+  const options = rappCatalogOptionsSchema.parse(rawOptions);
+  const override = options.endpoint.trim();
+  const rawEndpoint =
+    options.grail === "consumer"
+      ? override ||
+        env[RAPP_BRAINSTEM_URL_ENV]?.trim() ||
+        "http://127.0.0.1:7071"
+      : override || env[RAPP_BUSINESS_URL_ENV]?.trim();
+  if (!rawEndpoint) {
+    throw new RappClientError(
+      `Configure the Business Grail endpoint with bb plugin config provider-rapp set endpoint <url> or ${RAPP_BUSINESS_URL_ENV}`,
+      "configuration",
+    );
+  }
+  const endpoint = normalizeEndpoint(rawEndpoint, options.grail);
+  const modelListEndpoint =
+    options.grail === "consumer"
+      ? consumerSiblingEndpoint(endpoint, "/models")
+      : null;
+  const modelSetEndpoint =
+    options.grail === "consumer"
+      ? consumerSiblingEndpoint(endpoint, "/models/set")
+      : null;
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+  };
+  const brainstemSecret = env[RAPP_BRAINSTEM_SECRET_ENV]?.trim();
+  if (options.grail === "consumer" && brainstemSecret) {
+    headers["x-brainstem-secret"] = brainstemSecret;
+  }
+  const functionKey = env[RAPP_FUNCTION_KEY_ENV]?.trim();
+  if (options.grail === "business" && functionKey) {
+    headers["x-functions-key"] = functionKey;
+  }
+  if (
+    endpoint.protocol === "http:" &&
+    !isLoopbackHostname(endpoint.hostname) &&
+    (brainstemSecret || functionKey)
+  ) {
+    throw new RappClientError(
+      "RAPP credentials require HTTPS outside the local machine",
+      "configuration",
+    );
+  }
+  return {
+    grail: options.grail,
+    endpoint,
+    modelListEndpoint,
+    modelSetEndpoint,
+    displayEndpoint: displayEndpoint(endpoint),
+    headers,
+    userGuid:
+      options.grail === "business"
+        ? (env[RAPP_USER_GUID_ENV]?.trim() ?? null)
+        : null,
+    timeoutMs: options.grail === "business" ? 230_000 : 120_000,
+  };
+}
+
+function normalizeAgentLogs(value: string | string[]): string[] {
+  if (Array.isArray(value)) {
+    return value.map((entry) => entry.trim()).filter(Boolean);
+  }
+  const trimmed = value.trim();
+  if (trimmed === "") {
+    return [];
+  }
+  let possibleArray: unknown = null;
+  if (trimmed.startsWith("[")) {
+    try {
+      possibleArray = JSON.parse(trimmed);
+    } catch {
+      possibleArray = null;
+    }
+  }
+  const parsed = z.array(z.string()).safeParse(possibleArray);
+  if (parsed.success) {
+    return parsed.data.map((entry) => entry.trim()).filter(Boolean);
+  }
+  return trimmed
+    .split(/\r?\n/u)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function responseErrorMessage(value: unknown, status: number): string {
+  const parsed = nestedErrorSchema.safeParse(value);
+  if (!parsed.success) {
+    return `RAPP endpoint returned HTTP ${status}`;
+  }
+  if (typeof parsed.data.error === "string") {
+    return parsed.data.details
+      ? `${parsed.data.error}: ${parsed.data.details}`
+      : parsed.data.error;
+  }
+  const step =
+    parsed.data.error.step === undefined || parsed.data.error.step === null
+      ? ""
+      : ` at verification step ${parsed.data.error.step}`;
+  return `RAPP refusal ${parsed.data.error.code}${step}`;
+}
+
+function errorKind(status: number): RappClientError["kind"] {
+  if (status === 401 || status === 403) {
+    return "unauthorized";
+  }
+  if (status === 429) {
+    return "rate-limit";
+  }
+  return "response";
+}
+
+async function readBoundedResponseText(response: Response): Promise<string> {
+  const declaredLength = response.headers.get("content-length");
+  if (declaredLength !== null) {
+    const parsedLength = Number.parseInt(declaredLength, 10);
+    if (Number.isFinite(parsedLength) && parsedLength > MAX_RESPONSE_BYTES) {
+      throw new RappClientError(
+        `RAPP response exceeds ${MAX_RESPONSE_BYTES} bytes`,
+        "response",
+        response.status,
+      );
+    }
+  }
+  if (response.body === null) {
+    return "";
+  }
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  try {
+    while (true) {
+      const chunk = await reader.read();
+      if (chunk.done) {
+        break;
+      }
+      totalBytes += chunk.value.byteLength;
+      if (totalBytes > MAX_RESPONSE_BYTES) {
+        await reader.cancel();
+        throw new RappClientError(
+          `RAPP response exceeds ${MAX_RESPONSE_BYTES} bytes`,
+          "response",
+          response.status,
+        );
+      }
+      chunks.push(chunk.value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const bytes = Buffer.concat(
+    chunks.map((chunk) =>
+      Buffer.from(chunk.buffer, chunk.byteOffset, chunk.byteLength),
+    ),
+    totalBytes,
+  );
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    throw new RappClientError(
+      "RAPP endpoint returned non-UTF-8 response bytes",
+      "response",
+      response.status,
+    );
+  }
+}
+
+async function requestRappJson(args: {
+  config: RappClientConfig;
+  endpoint: URL;
+  method: "GET" | "POST";
+  body?: unknown;
+  signal: AbortSignal;
+  timeoutMs: number;
+}): Promise<{ payload: unknown; status: number }> {
+  const controller = new AbortController();
+  let timedOut = false;
+  const abort = () => controller.abort();
+  if (args.signal.aborted) {
+    controller.abort();
+  } else {
+    args.signal.addEventListener("abort", abort, { once: true });
+  }
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, args.timeoutMs);
+
+  let response: Response;
+  let text: string;
+  try {
+    response = await fetch(args.endpoint, {
+      method: args.method,
+      headers: args.config.headers,
+      ...(args.body === undefined ? {} : { body: JSON.stringify(args.body) }),
+      signal: controller.signal,
+      redirect: "error",
+    });
+    text = await readBoundedResponseText(response);
+  } catch (error) {
+    if (error instanceof RappClientError) {
+      throw error;
+    }
+    if (timedOut) {
+      throw new RappClientError(
+        `RAPP request timed out after ${Math.round(args.timeoutMs / 1000)} seconds`,
+        "timeout",
+      );
+    }
+    if (args.signal.aborted) {
+      throw error;
+    }
+    throw new RappClientError(
+      `Could not reach RAPP at ${displayEndpoint(args.endpoint)}: ${error instanceof Error ? error.message : String(error)}`,
+      "connection",
+    );
+  } finally {
+    clearTimeout(timeout);
+    args.signal.removeEventListener("abort", abort);
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(text);
+  } catch {
+    if (!response.ok) {
+      throw new RappClientError(
+        text.trim() || `RAPP endpoint returned HTTP ${response.status}`,
+        errorKind(response.status),
+        response.status,
+      );
+    }
+    throw new RappClientError(
+      "RAPP endpoint returned a non-JSON success response",
+      "response",
+      response.status,
+    );
+  }
+  if (!response.ok) {
+    throw new RappClientError(
+      responseErrorMessage(payload, response.status),
+      errorKind(response.status),
+      response.status,
+    );
+  }
+  return { payload, status: response.status };
+}
+
+function availableModel(
+  model: typeof RAPP_BRAINSTEM_MODEL | typeof RAPP_BUSINESS_MODEL,
+  isDefault: boolean,
+): AvailableModel {
+  return {
+    ...model,
+    model: model.id,
+    isDefault,
+    supportedReasoningEfforts: model.supportedReasoningEfforts.map(
+      (effort) => ({ ...effort }),
+    ),
+  };
+}
+
+export function fixedBusinessModelList(): RappModelList {
+  return {
+    models: [availableModel(RAPP_BUSINESS_MODEL, true)],
+    selectedOnlyModels: [],
+  };
+}
+
+export async function listRappModels(
+  config: RappClientConfig,
+  signal: AbortSignal,
+): Promise<RappModelList> {
+  if (config.grail !== "consumer" || config.modelListEndpoint === null) {
+    return fixedBusinessModelList();
+  }
+  const { payload, status } = await requestRappJson({
+    config,
+    endpoint: config.modelListEndpoint,
+    method: "GET",
+    signal,
+    timeoutMs: 15_000,
+  });
+  const parsed = consumerModelListSchema.safeParse(payload);
+  if (!parsed.success) {
+    throw new RappClientError(
+      "RAPP Brainstem returned an unsupported model catalog",
+      "response",
+      status,
+    );
+  }
+  const seen = new Set<string>();
+  const sourceModels = parsed.data.models.filter((model) => {
+    if (model.available !== true || seen.has(model.id)) {
+      return false;
+    }
+    seen.add(model.id);
+    return true;
+  });
+  if (sourceModels.length === 0) {
+    throw new RappClientError(
+      "RAPP Brainstem returned no verified GitHub Copilot models",
+      "response",
+      status,
+    );
+  }
+  const defaultId = sourceModels.some(
+    (model) => model.id === parsed.data.current,
+  )
+    ? parsed.data.current
+    : sourceModels[0].id;
+  return {
+    models: sourceModels.map((model) => ({
+      id: model.id,
+      model: model.id,
+      displayName: model.name,
+      description: "GitHub Copilot model supplied by RAPP Brainstem",
+      supportedReasoningEfforts: [
+        {
+          reasoningEffort: "none",
+          description:
+            "RAPP Brainstem owns GitHub Copilot reasoning and execution.",
+        },
+      ],
+      defaultReasoningEffort: "none",
+      isDefault: model.id === defaultId,
+    })),
+    selectedOnlyModels: [availableModel(RAPP_BRAINSTEM_MODEL, false)],
+  };
+}
+
+export async function setRappModel(
+  config: RappClientConfig,
+  model: string,
+  signal: AbortSignal,
+): Promise<string> {
+  if (config.grail !== "consumer" || config.modelSetEndpoint === null) {
+    throw new RappClientError(
+      "Only the Consumer Grail supports selectable Brainstem models",
+      "configuration",
+    );
+  }
+  const { payload, status } = await requestRappJson({
+    config,
+    endpoint: config.modelSetEndpoint,
+    method: "POST",
+    body: { model },
+    signal,
+    timeoutMs: 15_000,
+  });
+  const parsed = modelSetResponseSchema.safeParse(payload);
+  if (!parsed.success || parsed.data.model !== model) {
+    throw new RappClientError(
+      `RAPP Brainstem did not select requested model ${model}`,
+      "response",
+      status,
+    );
+  }
+  return parsed.data.model;
+}
+
+export async function callRapp(
+  config: RappClientConfig,
+  request: RappChatRequest,
+  signal: AbortSignal,
+): Promise<RappChatResponse> {
+  const body = {
+    user_input: request.userInput,
+    idempotency_key: request.idempotencyKey,
+    conversation_history: request.conversationHistory,
+    ...(request.sessionId === null ? {} : { session_id: request.sessionId }),
+    ...(config.userGuid === null ? {} : { user_guid: config.userGuid }),
+  };
+  const { payload, status } = await requestRappJson({
+    config,
+    endpoint: config.endpoint,
+    method: "POST",
+    body,
+    signal,
+    timeoutMs: config.timeoutMs,
+  });
+
+  const canonical = canonicalResponseSchema.safeParse(payload);
+  if (canonical.success) {
+    return {
+      response: canonical.data.response,
+      agentLogs: canonical.data.agent_logs,
+      sessionId: canonical.data.session_id,
+      requestedModel: null,
+      actualModel: null,
+    };
+  }
+  const consumer = consumerResponseSchema.safeParse(payload);
+  if (consumer.success) {
+    return {
+      response: consumer.data.response,
+      agentLogs: normalizeAgentLogs(consumer.data.agent_logs),
+      sessionId: consumer.data.session_id,
+      requestedModel: consumer.data.requested_model ?? null,
+      actualModel: consumer.data.model ?? null,
+    };
+  }
+  const business = businessResponseSchema.safeParse(payload);
+  if (business.success) {
+    return {
+      response: business.data.assistant_response,
+      agentLogs: normalizeAgentLogs(business.data.agent_logs),
+      sessionId: request.sessionId,
+      requestedModel: null,
+      actualModel: null,
+    };
+  }
+  throw new RappClientError(
+    "RAPP endpoint returned an unsupported success envelope",
+    "response",
+    status,
+  );
+}

--- a/plugins/provider-rapp/src/rapp-client.ts
+++ b/plugins/provider-rapp/src/rapp-client.ts
@@ -74,7 +74,7 @@ const modelSetResponseSchema = z
   })
   .passthrough();
 
-const MAX_RESPONSE_BYTES = 16 * 1024 * 1024;
+export const RAPP_MAX_RESPONSE_BYTES = 64 * 1024;
 
 export interface RappClientConfig {
   grail: RappGrail;
@@ -314,9 +314,12 @@ async function readBoundedResponseText(response: Response): Promise<string> {
   const declaredLength = response.headers.get("content-length");
   if (declaredLength !== null) {
     const parsedLength = Number.parseInt(declaredLength, 10);
-    if (Number.isFinite(parsedLength) && parsedLength > MAX_RESPONSE_BYTES) {
+    if (
+      Number.isFinite(parsedLength) &&
+      parsedLength > RAPP_MAX_RESPONSE_BYTES
+    ) {
       throw new RappClientError(
-        `RAPP response exceeds ${MAX_RESPONSE_BYTES} bytes`,
+        `RAPP response exceeds ${RAPP_MAX_RESPONSE_BYTES} bytes`,
         "response",
         response.status,
       );
@@ -335,10 +338,10 @@ async function readBoundedResponseText(response: Response): Promise<string> {
         break;
       }
       totalBytes += chunk.value.byteLength;
-      if (totalBytes > MAX_RESPONSE_BYTES) {
+      if (totalBytes > RAPP_MAX_RESPONSE_BYTES) {
         await reader.cancel();
         throw new RappClientError(
-          `RAPP response exceeds ${MAX_RESPONSE_BYTES} bytes`,
+          `RAPP response exceeds ${RAPP_MAX_RESPONSE_BYTES} bytes`,
           "response",
           response.status,
         );

--- a/plugins/provider-rapp/src/rapp1.test.ts
+++ b/plugins/provider-rapp/src/rapp1.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "vitest";
+import {
+  canonicalString,
+  createSessionEgg,
+  hashValue,
+  mintKeylessRappid,
+  parseSessionEgg,
+  serializeSessionEgg,
+  sessionEggAddress,
+} from "./rapp1.js";
+
+describe("RAPP/1 primitives", () => {
+  it("matches the public canonicalization and domain-hash vectors", () => {
+    expect(
+      canonicalString({
+        b: 1,
+        a: [3, 2],
+        c: { y: 1, x: 2 },
+      }),
+    ).toBe('{"a":[3,2],"b":1,"c":{"x":2,"y":1}}');
+    expect(
+      canonicalString({
+        é: 1,
+        é: 2,
+        b: 5,
+        aa: 6,
+        "a-b": 7,
+        a: 3,
+        B: 4,
+      }),
+    ).toBe('{"B":4,"a":3,"a-b":7,"aa":6,"b":5,"é":2,"é":1}');
+    expect(hashValue("rapp/1:particle", { x: 1 })).toBe(
+      "2ba28c1fad4d0fbea812dddc74f13e3d097099fb07ce621fd208282ade5e5fc3",
+    );
+  });
+
+  it("accepts finite JCS numbers and refuses non-I-JSON values", () => {
+    expect(canonicalString(2 ** 53)).toBe("9007199254740992");
+    expect(canonicalString(1e21)).toBe("1e+21");
+    expect(() => canonicalString({ value: Number.POSITIVE_INFINITY })).toThrow(
+      "finite",
+    );
+    expect(() => canonicalString("\ud800")).toThrow("unpaired");
+    expect(() => canonicalString(new Array(1))).toThrow("sparse");
+  });
+
+  it("round-trips a canonical session egg and rejects non-canonical bytes", () => {
+    const identity = mintKeylessRappid(
+      "get-bb",
+      "provider-rapp",
+      "123e4567-e89b-42d3-a456-426614174000",
+    );
+    const egg = createSessionEgg({
+      rappid: identity.rappid,
+      createdUtc: "2026-09-02T14:00:00.000Z",
+      runtime: {
+        provider: "bb/provider-rapp",
+        provider_thread_id: "rapp_thread",
+        remote_session_id: null,
+        turn_counter: 1,
+        pending_turn: {
+          idempotency_key: "rapp_thread:1",
+          user_input: "hello",
+          conversation_history: [{ role: "user", content: "context" }],
+        },
+      },
+      transcript: [
+        { role: "user", content: "hello" },
+        { role: "assistant", content: "hi" },
+      ],
+    });
+    const serialized = serializeSessionEgg(egg);
+    const parsed = parseSessionEgg(Buffer.from(serialized), identity.rappid);
+    expect(parsed.runtime.remote_session_id).toBeNull();
+    expect(parsed.runtime.pending_turn).toEqual({
+      idempotency_key: "rapp_thread:1",
+      user_input: "hello",
+      conversation_history: [{ role: "user", content: "context" }],
+    });
+    expect(parsed.egg.payload.transcript).toHaveLength(2);
+    expect(parsed.eggAddress).toMatch(/^[0-9a-f]{64}$/u);
+    expect(() =>
+      parseSessionEgg(Buffer.from(`${JSON.stringify(egg)}\n`), identity.rappid),
+    ).toThrow("not canonical");
+    expect(() =>
+      parseSessionEgg(
+        Buffer.concat([
+          Buffer.from([0xef, 0xbb, 0xbf]),
+          Buffer.from(serialized),
+        ]),
+        identity.rappid,
+      ),
+    ).toThrow();
+  });
+
+  it("matches the frozen current session egg vector exactly", () => {
+    const egg = {
+      schema: "rapp/1-egg" as const,
+      variant: "session" as const,
+      rappid: `rappid:@kody/twin:${"a".repeat(64)}`,
+      created_utc: "2026-07-15T00:00:00.000Z",
+      contents: [] as [],
+      payload: {
+        runtime: "test",
+        transcript: [],
+      },
+      sig: null,
+    };
+    expect(serializeSessionEgg(egg)).toBe(
+      '{"contents":[],"created_utc":"2026-07-15T00:00:00.000Z","payload":{"runtime":"test","transcript":[]},"rappid":"rappid:@kody/twin:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","schema":"rapp/1-egg","sig":null,"variant":"session"}',
+    );
+    expect(sessionEggAddress(egg)).toBe(
+      "8ca5f7815a3a77f60bd442e1b7dc9df9caf3173c23066f8546659bddb756e5a3",
+    );
+  });
+
+  it("refuses invalid frozen RAPPID and UTC forms", () => {
+    const identity = mintKeylessRappid(
+      "get-bb",
+      "provider-rapp",
+      "123e4567-e89b-42d3-a456-426614174000",
+    );
+    const runtime = {
+      provider: "bb/provider-rapp" as const,
+      provider_thread_id: "rapp_thread",
+      remote_session_id: null,
+      turn_counter: 0,
+      pending_turn: null,
+    };
+    expect(() =>
+      createSessionEgg({
+        rappid: `rappid:@${"a".repeat(40)}/x:${"b".repeat(64)}`,
+        createdUtc: "2026-09-02T14:00:00.000Z",
+        runtime,
+        transcript: [],
+      }),
+    ).toThrow("rappid");
+    expect(() =>
+      createSessionEgg({
+        rappid: `rappid:@owner/${"a".repeat(101)}:${"b".repeat(64)}`,
+        createdUtc: "2026-09-02T14:00:00.000Z",
+        runtime,
+        transcript: [],
+      }),
+    ).toThrow("rappid");
+    for (const createdUtc of [
+      "0000-01-01T00:00:00.000Z",
+      "2026-02-29T00:00:00.000Z",
+      "2026-04-31T00:00:00.000Z",
+      "2026-12-01T24:00:00.000Z",
+      "2026-12-01T23:60:00.000Z",
+    ]) {
+      expect(() =>
+        createSessionEgg({
+          rappid: identity.rappid,
+          createdUtc,
+          runtime,
+          transcript: [],
+        }),
+      ).toThrow("UTC");
+    }
+    expect(
+      createSessionEgg({
+        rappid: identity.rappid,
+        createdUtc: "2028-02-29T23:59:59.999Z",
+        runtime,
+        transcript: [],
+      }).created_utc,
+    ).toBe("2028-02-29T23:59:59.999Z");
+  });
+
+  it("requires the bridge-private runtime string to be canonical JSON", () => {
+    const identity = mintKeylessRappid(
+      "get-bb",
+      "provider-rapp",
+      "123e4567-e89b-42d3-a456-426614174000",
+    );
+    const egg = {
+      schema: "rapp/1-egg" as const,
+      variant: "session" as const,
+      rappid: identity.rappid,
+      created_utc: "2026-09-02T14:00:00.000Z",
+      contents: [] as [],
+      payload: {
+        runtime:
+          '{ "provider": "bb/provider-rapp", "provider_thread_id": "rapp_thread", "remote_session_id": null, "turn_counter": 0, "pending_turn": null }',
+        transcript: [],
+      },
+      sig: null,
+    };
+    expect(() =>
+      parseSessionEgg(Buffer.from(serializeSessionEgg(egg)), identity.rappid),
+    ).toThrow("runtime is not canonical");
+  });
+});

--- a/plugins/provider-rapp/src/rapp1.ts
+++ b/plugins/provider-rapp/src/rapp1.ts
@@ -1,0 +1,305 @@
+import { createHash, randomUUID } from "node:crypto";
+import { z } from "zod";
+
+const MAX_CANONICAL_BYTES = 1024 * 1024;
+const MAX_DEPTH = 64;
+const MAX_SAFE_INTEGER = 2 ** 53 - 1;
+const LABEL_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/u;
+const RAPPID_PATTERN =
+  /^rappid:@([a-z0-9]+(?:-[a-z0-9]+)*)\/([a-z0-9]+(?:-[a-z0-9]+)*):([0-9a-f]{64})$/u;
+const UTC_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:(?:[0-5]\d)\.\d{3}Z$/u;
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+
+export const rappTranscriptEntrySchema = z
+  .object({
+    role: z.enum(["user", "assistant"]),
+    content: z.string(),
+  })
+  .strict();
+export type RappTranscriptEntry = z.infer<typeof rappTranscriptEntrySchema>;
+
+const pendingTurnRuntimeSchema = z
+  .object({
+    idempotency_key: z.string().min(1),
+    user_input: z.string().min(1),
+    conversation_history: z.array(rappTranscriptEntrySchema),
+  })
+  .strict();
+export type RappPendingTurnRuntime = z.infer<typeof pendingTurnRuntimeSchema>;
+
+const sessionRuntimeSchema = z
+  .object({
+    provider: z.literal("bb/provider-rapp"),
+    provider_thread_id: z.string().min(1),
+    remote_session_id: z.string().min(1).nullable(),
+    turn_counter: z.number().int().nonnegative().max(MAX_SAFE_INTEGER),
+    pending_turn: pendingTurnRuntimeSchema.nullable(),
+  })
+  .strict();
+export type RappSessionRuntime = z.infer<typeof sessionRuntimeSchema>;
+
+function isValidRappid(value: string): boolean {
+  const match = RAPPID_PATTERN.exec(value);
+  return (
+    match !== null &&
+    (match[1]?.length ?? 0) <= 39 &&
+    (match[2]?.length ?? 0) <= 100
+  );
+}
+
+function isLeapYear(year: number): boolean {
+  return year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+}
+
+function isValidFixedUtc(value: string): boolean {
+  const match = UTC_PATTERN.exec(value);
+  if (match === null) {
+    return false;
+  }
+  const year = Number(value.slice(0, 4));
+  const month = Number(value.slice(5, 7));
+  const day = Number(value.slice(8, 10));
+  const hour = Number(value.slice(11, 13));
+  const minute = Number(value.slice(14, 16));
+  if (year < 1 || month < 1 || month > 12 || hour > 23 || minute > 59) {
+    return false;
+  }
+  const daysInMonth = [
+    31,
+    isLeapYear(year) ? 29 : 28,
+    31,
+    30,
+    31,
+    30,
+    31,
+    31,
+    30,
+    31,
+    30,
+    31,
+  ];
+  return day >= 1 && day <= (daysInMonth[month - 1] ?? 0);
+}
+
+const sessionEggSchema = z
+  .object({
+    schema: z.literal("rapp/1-egg"),
+    variant: z.literal("session"),
+    rappid: z.string().refine(isValidRappid, "Invalid RAPP/1 rappid"),
+    created_utc: z
+      .string()
+      .refine(isValidFixedUtc, "Invalid RAPP/1 fixed UTC timestamp"),
+    contents: z.tuple([]),
+    payload: z
+      .object({
+        runtime: z.string(),
+        transcript: z.array(rappTranscriptEntrySchema),
+      })
+      .strict(),
+    sig: z.null(),
+  })
+  .strict();
+export type RappSessionEgg = z.infer<typeof sessionEggSchema>;
+
+function validateString(value: string): void {
+  for (let index = 0; index < value.length; index += 1) {
+    const unit = value.charCodeAt(index);
+    if (unit >= 0xd800 && unit <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        throw new Error("RAPP/1 strings must not contain unpaired surrogates");
+      }
+      index += 1;
+      continue;
+    }
+    if (unit >= 0xdc00 && unit <= 0xdfff) {
+      throw new Error("RAPP/1 strings must not contain unpaired surrogates");
+    }
+  }
+}
+
+function encodeCanonical(value: unknown, depth: number): string {
+  if (depth > MAX_DEPTH) {
+    throw new Error(`RAPP/1 JSON nesting exceeds ${MAX_DEPTH}`);
+  }
+  if (value === null) {
+    return "null";
+  }
+  if (typeof value === "boolean") {
+    return value ? "true" : "false";
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new Error("RAPP/1 numbers must be finite");
+    }
+    return JSON.stringify(value);
+  }
+  if (typeof value === "string") {
+    validateString(value);
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    const items: string[] = [];
+    for (let index = 0; index < value.length; index += 1) {
+      if (!Object.hasOwn(value, index)) {
+        throw new Error("RAPP/1 arrays must not be sparse");
+      }
+      items.push(encodeCanonical(value[index], depth + 1));
+    }
+    return `[${items.join(",")}]`;
+  }
+  if (typeof value === "object") {
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      throw new Error("RAPP/1 values must be plain JSON objects");
+    }
+    const members = Object.keys(value)
+      .sort()
+      .map((key) => {
+        validateString(key);
+        const member: unknown = Reflect.get(value, key);
+        return `${JSON.stringify(key)}:${encodeCanonical(member, depth + 1)}`;
+      });
+    return `{${members.join(",")}}`;
+  }
+  throw new Error(`RAPP/1 value is not I-JSON: ${typeof value}`);
+}
+
+export function canonicalString(value: unknown): string {
+  const encoded = encodeCanonical(value, 1);
+  if (Buffer.byteLength(encoded, "utf8") > MAX_CANONICAL_BYTES) {
+    throw new Error("RAPP/1 canonical form exceeds 1 MiB");
+  }
+  return encoded;
+}
+
+export function hashValue(space: string, value: unknown): string {
+  return createHash("sha256")
+    .update(space, "ascii")
+    .update("\n", "ascii")
+    .update(canonicalString(value), "utf8")
+    .digest("hex");
+}
+
+export function hashBytes(space: string, value: Uint8Array): string {
+  return createHash("sha256")
+    .update(space, "ascii")
+    .update("\n", "ascii")
+    .update(value)
+    .digest("hex");
+}
+
+function validateIdentityLabel(value: string, maximum: number): void {
+  if (
+    value.length < 1 ||
+    value.length > maximum ||
+    !LABEL_PATTERN.test(value)
+  ) {
+    throw new Error(`Invalid RAPP/1 identity label: ${value}`);
+  }
+}
+
+export function mintKeylessRappid(
+  owner: string,
+  slug: string,
+  uuidAnchor: string = randomUUID(),
+): { rappid: string; uuidAnchor: string } {
+  validateIdentityLabel(owner, 39);
+  validateIdentityLabel(slug, 100);
+  if (!UUID_PATTERN.test(uuidAnchor)) {
+    throw new Error("RAPP/1 keyless identity requires an RFC 9562 UUIDv4");
+  }
+  const bytes = Buffer.from(uuidAnchor.replaceAll("-", ""), "hex");
+  const tail = hashBytes("rapp/1:rappid", bytes);
+  return {
+    rappid: `rappid:@${owner}/${slug}:${tail}`,
+    uuidAnchor,
+  };
+}
+
+export function createSessionEgg(args: {
+  rappid: string;
+  createdUtc: string;
+  runtime: RappSessionRuntime;
+  transcript: readonly RappTranscriptEntry[];
+}): RappSessionEgg {
+  const egg = {
+    schema: "rapp/1-egg",
+    variant: "session",
+    rappid: args.rappid,
+    created_utc: args.createdUtc,
+    contents: [],
+    payload: {
+      runtime: canonicalString(args.runtime),
+      transcript: args.transcript.map((entry) => ({ ...entry })),
+    },
+    sig: null,
+  };
+  return sessionEggSchema.parse(egg);
+}
+
+export function sessionEggAddress(egg: RappSessionEgg): string {
+  return hashValue("rapp/1:egg-manifest", {
+    schema: egg.schema,
+    variant: egg.variant,
+    rappid: egg.rappid,
+    created_utc: egg.created_utc,
+    contents: egg.contents,
+    payload: egg.payload,
+  });
+}
+
+export function serializeSessionEgg(egg: RappSessionEgg): string {
+  return canonicalString(sessionEggSchema.parse(egg));
+}
+
+export function parseSessionEgg(
+  bytes: Uint8Array,
+  expectedRappid?: string,
+): {
+  egg: RappSessionEgg;
+  runtime: RappSessionRuntime;
+  eggAddress: string;
+} {
+  if (bytes.byteLength > MAX_CANONICAL_BYTES) {
+    throw new Error("RAPP/1 session egg exceeds 1 MiB");
+  }
+  const text = new TextDecoder("utf-8", {
+    fatal: true,
+    ignoreBOM: true,
+  }).decode(bytes);
+  let parsedJson: unknown;
+  try {
+    parsedJson = JSON.parse(text);
+  } catch (error) {
+    throw new Error(
+      `Invalid RAPP/1 session egg JSON: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  const egg = sessionEggSchema.parse(parsedJson);
+  const serialized = serializeSessionEgg(egg);
+  if (!Buffer.from(bytes).equals(Buffer.from(serialized, "utf8"))) {
+    throw new Error("RAPP/1 session egg is not canonical JSON");
+  }
+  if (expectedRappid !== undefined && egg.rappid !== expectedRappid) {
+    throw new Error("RAPP/1 session egg identity does not match this bridge");
+  }
+  let runtimeJson: unknown;
+  try {
+    runtimeJson = JSON.parse(egg.payload.runtime);
+  } catch (error) {
+    throw new Error(
+      `Invalid RAPP/1 session runtime: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  const runtime = sessionRuntimeSchema.parse(runtimeJson);
+  if (canonicalString(runtime) !== egg.payload.runtime) {
+    throw new Error("RAPP/1 session runtime is not canonical JSON");
+  }
+  return {
+    egg,
+    runtime,
+    eggAddress: sessionEggAddress(egg),
+  };
+}

--- a/plugins/provider-rapp/src/session-store.test.ts
+++ b/plugins/provider-rapp/src/session-store.test.ts
@@ -13,7 +13,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
-import { canonicalString, parseSessionEgg } from "./rapp1.js";
+import { canonicalString, hashValue, parseSessionEgg } from "./rapp1.js";
 import { RappSessionStore } from "./session-store.js";
 
 const directories: string[] = [];
@@ -35,6 +35,7 @@ function readHead(directory: string): {
   schema: string;
   provider_thread_id: string;
   egg_address: string;
+  delivery_address?: string | null;
   turn_counter: number;
 } {
   return JSON.parse(readFileSync(sessionHeadPath(directory), "utf8"));
@@ -58,21 +59,25 @@ describe("RAPP session store", () => {
       transcript: [],
       pendingTurn: null,
     });
-    const saved = first.save({
-      ...created.snapshot,
-      remoteSessionId: "remote_thread",
-      turnCounter: 2,
-      transcript: [
-        { role: "user", content: "hello" },
-        { role: "assistant", content: "hi" },
-      ],
-    });
+    const saved = first.save(
+      {
+        ...created.snapshot,
+        remoteSessionId: "remote_thread",
+        turnCounter: 2,
+        transcript: [
+          { role: "user", content: "hello" },
+          { role: "assistant", content: "hi" },
+        ],
+      },
+      null,
+    );
 
     const head = readHead(directory);
     expect(head).toEqual({
-      schema: "bb/provider-rapp-session-head/1",
+      schema: "bb/provider-rapp-session-head/2",
       provider_thread_id: "rapp_thread",
       egg_address: saved.eggAddress,
+      delivery_address: null,
       turn_counter: 2,
     });
     const objectPath = join(directory, "objects", `${saved.eggAddress}.json`);
@@ -92,18 +97,21 @@ describe("RAPP session store", () => {
     const directory = makeDirectory();
     const first = new RappSessionStore(directory);
     const created = first.create("rapp_thread");
-    const saved = first.save({
-      ...created.snapshot,
-      turnCounter: 1,
-      pendingTurn: {
-        idempotencyKey: "rapp_thread:1",
-        userInput: "hello",
-        conversationHistory: [
-          { role: "user", content: "prior" },
-          { role: "assistant", content: "context" },
-        ],
+    const saved = first.save(
+      {
+        ...created.snapshot,
+        turnCounter: 1,
+        pendingTurn: {
+          idempotencyKey: "rapp_thread:1",
+          userInput: "hello",
+          conversationHistory: [
+            { role: "user", content: "prior" },
+            { role: "assistant", content: "context" },
+          ],
+        },
       },
-    });
+      null,
+    );
 
     const second = new RappSessionStore(directory);
     expect(second.load("rapp_thread")).toEqual(saved);
@@ -115,16 +123,287 @@ describe("RAPP session store", () => {
     expect(second.load("rapp_thread")).toEqual(saved);
   });
 
+  it("commits and acknowledges a content-addressed delivery journal with its completed transcript", () => {
+    const directory = makeDirectory();
+    const first = new RappSessionStore(directory);
+    const created = first.create("rapp_thread");
+    const completed = first.save(
+      {
+        ...created.snapshot,
+        remoteSessionId: "remote-session",
+        turnCounter: 1,
+        transcript: [
+          { role: "user", content: "hello" },
+          { role: "assistant", content: "durable answer" },
+        ],
+      },
+      {
+        providerTurnId: "rapp_thread-turn-1",
+        agentItemId: "rapp_thread-t1-agents",
+        messageItemId: "rapp_thread-t1-message",
+        response: "durable answer",
+        agentLogs: ["AgentOne"],
+        grail: "consumer",
+        endpoint: "http://127.0.0.1:7071/chat",
+        selectedModel: "rapp-brainstem",
+        requestedModel: "claude-opus-5",
+        actualModel: "claude-opus-5",
+      },
+    );
+
+    expect(completed.deliveryAddress).toMatch(/^[0-9a-f]{64}$/u);
+    expect(completed.pendingDelivery).toMatchObject({
+      providerTurnId: "rapp_thread-turn-1",
+      response: "durable answer",
+      agentLogs: ["AgentOne"],
+      eggAddress: completed.eggAddress,
+      phase: "ready",
+    });
+    expect(readHead(directory)).toEqual({
+      schema: "bb/provider-rapp-session-head/2",
+      provider_thread_id: "rapp_thread",
+      egg_address: completed.eggAddress,
+      delivery_address: completed.deliveryAddress,
+      turn_counter: 1,
+    });
+
+    const recovered = new RappSessionStore(directory).load("rapp_thread");
+    expect(recovered).toEqual(completed);
+    if (completed.deliveryAddress === null) {
+      throw new Error("delivery address was not persisted");
+    }
+    const emitted = first.markDeliveryEmitted(
+      "rapp_thread",
+      completed.deliveryAddress,
+    );
+    expect(emitted.eggAddress).toBe(completed.eggAddress);
+    expect(emitted.deliveryAddress).not.toBe(completed.deliveryAddress);
+    expect(emitted.pendingDelivery?.phase).toBe("emitted");
+    if (emitted.deliveryAddress === null) {
+      throw new Error("emitted delivery address was not persisted");
+    }
+    const acknowledged = first.acknowledgeDelivery(
+      "rapp_thread",
+      emitted.deliveryAddress,
+    );
+    expect(acknowledged.snapshot).toEqual(completed.snapshot);
+    expect(acknowledged.eggAddress).toBe(completed.eggAddress);
+    expect(acknowledged.pendingDelivery).toBeNull();
+    expect(acknowledged.deliveryAddress).toBeNull();
+    expect(new RappSessionStore(directory).load("rapp_thread")).toEqual(
+      acknowledged,
+    );
+  });
+
+  it("loads version-one delivery journals as unacknowledged ready deliveries", () => {
+    const directory = makeDirectory();
+    const store = new RappSessionStore(directory);
+    const created = store.create("rapp_thread");
+    const completed = store.save(
+      {
+        ...created.snapshot,
+        remoteSessionId: "remote-session",
+        turnCounter: 1,
+        transcript: [
+          { role: "user", content: "hello" },
+          { role: "assistant", content: "legacy durable answer" },
+        ],
+      },
+      {
+        providerTurnId: "rapp_thread-turn-1",
+        agentItemId: "rapp_thread-t1-agents",
+        messageItemId: "rapp_thread-t1-message",
+        response: "legacy durable answer",
+        agentLogs: ["LegacyAgent"],
+        grail: "consumer",
+        endpoint: "http://127.0.0.1:7071/chat",
+        selectedModel: "brainstem",
+        requestedModel: "claude-opus-5",
+        actualModel: "claude-opus-5",
+      },
+    );
+    const legacyDelivery = {
+      schema: "bb/provider-rapp-delivery/1",
+      provider_thread_id: "rapp_thread",
+      egg_address: completed.eggAddress,
+      turn_counter: 1,
+      provider_turn_id: "rapp_thread-turn-1",
+      agent_item_id: "rapp_thread-t1-agents",
+      message_item_id: "rapp_thread-t1-message",
+      response: "legacy durable answer",
+      agent_logs: ["LegacyAgent"],
+      grail: "consumer",
+      endpoint: "http://127.0.0.1:7071/chat",
+      selected_model: "brainstem",
+      requested_model: "claude-opus-5",
+      actual_model: "claude-opus-5",
+    };
+    const legacyDeliveryAddress = hashValue(
+      "bb/provider-rapp-delivery",
+      legacyDelivery,
+    );
+    writeFileSync(
+      join(directory, "objects", `${legacyDeliveryAddress}.json`),
+      canonicalString(legacyDelivery),
+      "utf8",
+    );
+    writeFileSync(
+      sessionHeadPath(directory),
+      canonicalString({
+        schema: "bb/provider-rapp-session-head/2",
+        provider_thread_id: "rapp_thread",
+        egg_address: completed.eggAddress,
+        delivery_address: legacyDeliveryAddress,
+        turn_counter: 1,
+      }),
+      "utf8",
+    );
+
+    const migratedStore = new RappSessionStore(directory);
+    const loaded = migratedStore.load("rapp_thread");
+    expect(loaded?.deliveryAddress).toBe(legacyDeliveryAddress);
+    expect(loaded?.pendingDelivery).toMatchObject({
+      response: "legacy durable answer",
+      agentLogs: ["LegacyAgent"],
+      phase: "ready",
+    });
+    const emitted = migratedStore.markDeliveryEmitted(
+      "rapp_thread",
+      legacyDeliveryAddress,
+    );
+    expect(emitted.pendingDelivery?.phase).toBe("emitted");
+    if (emitted.deliveryAddress === null) {
+      throw new Error("Migrated delivery address was not persisted");
+    }
+    expect(
+      JSON.parse(
+        readFileSync(
+          join(directory, "objects", `${emitted.deliveryAddress}.json`),
+          "utf8",
+        ),
+      ),
+    ).toMatchObject({
+      schema: "bb/provider-rapp-delivery/2",
+      phase: "emitted",
+    });
+  });
+
+  it("rejects delivery journal bytes that no longer match their address", () => {
+    const directory = makeDirectory();
+    const store = new RappSessionStore(directory);
+    const created = store.create("rapp_thread");
+    const completed = store.save(
+      {
+        ...created.snapshot,
+        turnCounter: 1,
+        transcript: [
+          { role: "user", content: "hello" },
+          { role: "assistant", content: "answer" },
+        ],
+      },
+      {
+        providerTurnId: "turn-1",
+        agentItemId: null,
+        messageItemId: "message-1",
+        response: "answer",
+        agentLogs: [],
+        grail: "consumer",
+        endpoint: "http://127.0.0.1:7071/chat",
+        selectedModel: "rapp-brainstem",
+        requestedModel: null,
+        actualModel: null,
+      },
+    );
+    if (completed.deliveryAddress === null) {
+      throw new Error("delivery address was not persisted");
+    }
+    const deliveryPath = join(
+      directory,
+      "objects",
+      `${completed.deliveryAddress}.json`,
+    );
+    const delivery = JSON.parse(readFileSync(deliveryPath, "utf8"));
+    delivery.endpoint = "https://tampered.example/chat";
+    writeFileSync(deliveryPath, canonicalString(delivery), "utf8");
+
+    expect(() => new RappSessionStore(directory).load("rapp_thread")).toThrow(
+      "delivery journal address does not match",
+    );
+  });
+
+  it("loads legacy version-one heads with ambiguous pending turns intact", () => {
+    const directory = makeDirectory();
+    const store = new RappSessionStore(directory);
+    const saved = store.save(
+      {
+        ...store.create("rapp_thread").snapshot,
+        turnCounter: 1,
+        pendingTurn: {
+          idempotencyKey: "legacy-request",
+          userInput: "legacy pending prompt",
+          conversationHistory: [{ role: "assistant", content: "prior answer" }],
+        },
+      },
+      null,
+    );
+    writeFileSync(
+      sessionHeadPath(directory),
+      canonicalString({
+        schema: "bb/provider-rapp-session-head/1",
+        provider_thread_id: "rapp_thread",
+        egg_address: saved.eggAddress,
+        turn_counter: 1,
+      }),
+      "utf8",
+    );
+
+    const loaded = new RappSessionStore(directory).load("rapp_thread");
+    expect(loaded).toEqual(saved);
+    expect(loaded?.snapshot.pendingTurn).toEqual({
+      idempotencyKey: "legacy-request",
+      userInput: "legacy pending prompt",
+      conversationHistory: [{ role: "assistant", content: "prior answer" }],
+    });
+    expect(loaded?.pendingDelivery).toBeNull();
+  });
+
+  it("rejects a new turn when the worst-case bounded completion cannot fit the session egg", () => {
+    const store = new RappSessionStore();
+    const created = store.create("rapp_thread");
+    const nearLimit = store.save(
+      {
+        ...created.snapshot,
+        turnCounter: 1,
+        transcript: [{ role: "assistant", content: "x".repeat(985_000) }],
+      },
+      null,
+    );
+
+    expect(() =>
+      store.assertCanCommitCompletion(
+        {
+          ...nearLimit.snapshot,
+          turnCounter: 2,
+        },
+        "one more question",
+        64 * 1024,
+      ),
+    ).toThrow("Start a new thread");
+  });
+
   it("refuses an egg object whose bytes no longer match its address", () => {
     const directory = makeDirectory();
     const first = new RappSessionStore(directory);
     const created = first.create("rapp_thread");
-    const saved = first.save({
-      ...created.snapshot,
-      remoteSessionId: "remote_thread",
-      turnCounter: 1,
-      transcript: [{ role: "user", content: "hello" }],
-    });
+    const saved = first.save(
+      {
+        ...created.snapshot,
+        remoteSessionId: "remote_thread",
+        turnCounter: 1,
+        transcript: [{ role: "user", content: "hello" }],
+      },
+      null,
+    );
     const objectPath = join(directory, "objects", `${saved.eggAddress}.json`);
     const egg = JSON.parse(readFileSync(objectPath, "utf8"));
     egg.payload.transcript[0].content = "tampered";
@@ -140,12 +419,15 @@ describe("RAPP session store", () => {
     const directory = makeDirectory();
     const first = new RappSessionStore(directory);
     const created = first.create("rapp_thread");
-    const saved = first.save({
-      ...created.snapshot,
-      remoteSessionId: "remote_thread",
-      turnCounter: 2,
-      transcript: [{ role: "user", content: "hello" }],
-    });
+    const saved = first.save(
+      {
+        ...created.snapshot,
+        remoteSessionId: "remote_thread",
+        turnCounter: 2,
+        transcript: [{ role: "user", content: "hello" }],
+      },
+      null,
+    );
     const headPath = sessionHeadPath(directory);
     const head = readHead(directory);
     writeFileSync(
@@ -161,7 +443,7 @@ describe("RAPP session store", () => {
     expect(() => second.load("rapp_thread")).toThrow(
       "turn counter does not match",
     );
-    expect(() => first.save(created.snapshot)).toThrow("roll back");
+    expect(() => first.save(created.snapshot, null)).toThrow("roll back");
     expect(first.load("rapp_thread")).toEqual(saved);
   });
 
@@ -199,11 +481,14 @@ describe("RAPP session store", () => {
     writeFileSync(join(directory, "sessions"), "not a directory", "utf8");
 
     expect(() =>
-      store.save({
-        ...created.snapshot,
-        remoteSessionId: "remote_thread",
-        turnCounter: 1,
-      }),
+      store.save(
+        {
+          ...created.snapshot,
+          remoteSessionId: "remote_thread",
+          turnCounter: 1,
+        },
+        null,
+      ),
     ).toThrow();
     expect(store.load("rapp_thread")).toEqual(created);
   });

--- a/plugins/provider-rapp/src/session-store.test.ts
+++ b/plugins/provider-rapp/src/session-store.test.ts
@@ -1,0 +1,280 @@
+import { execFile } from "node:child_process";
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it } from "vitest";
+import { canonicalString, parseSessionEgg } from "./rapp1.js";
+import { RappSessionStore } from "./session-store.js";
+
+const directories: string[] = [];
+const execFileAsync = promisify(execFile);
+
+function makeDirectory(): string {
+  const directory = mkdtempSync(join(tmpdir(), "bb-rapp-session-"));
+  directories.push(directory);
+  return directory;
+}
+
+function sessionHeadPath(directory: string): string {
+  const files = readdirSync(join(directory, "sessions"));
+  expect(files).toHaveLength(1);
+  return join(directory, "sessions", files[0] ?? "");
+}
+
+function readHead(directory: string): {
+  schema: string;
+  provider_thread_id: string;
+  egg_address: string;
+  turn_counter: number;
+} {
+  return JSON.parse(readFileSync(sessionHeadPath(directory), "utf8"));
+}
+
+afterEach(() => {
+  for (const directory of directories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("RAPP session store", () => {
+  it("stores immutable addressed eggs behind a validated thread head", () => {
+    const directory = makeDirectory();
+    const first = new RappSessionStore(directory);
+    const created = first.create("rapp_thread");
+    expect(created.snapshot).toEqual({
+      providerThreadId: "rapp_thread",
+      remoteSessionId: null,
+      turnCounter: 0,
+      transcript: [],
+      pendingTurn: null,
+    });
+    const saved = first.save({
+      ...created.snapshot,
+      remoteSessionId: "remote_thread",
+      turnCounter: 2,
+      transcript: [
+        { role: "user", content: "hello" },
+        { role: "assistant", content: "hi" },
+      ],
+    });
+
+    const head = readHead(directory);
+    expect(head).toEqual({
+      schema: "bb/provider-rapp-session-head/1",
+      provider_thread_id: "rapp_thread",
+      egg_address: saved.eggAddress,
+      turn_counter: 2,
+    });
+    const objectPath = join(directory, "objects", `${saved.eggAddress}.json`);
+    const parsed = parseSessionEgg(readFileSync(objectPath), saved.rappid);
+    expect(parsed.eggAddress).toBe(saved.eggAddress);
+    expect(parsed.runtime.provider_thread_id).toBe("rapp_thread");
+    expect(parsed.runtime.remote_session_id).toBe("remote_thread");
+    expect(parsed.runtime.turn_counter).toBe(2);
+    expect(parsed.egg.payload.transcript).toEqual(saved.snapshot.transcript);
+
+    const second = new RappSessionStore(directory);
+    expect(second.load("rapp_thread")).toEqual(saved);
+    expect(readdirSync(join(directory, "objects")).length).toBeGreaterThan(1);
+  });
+
+  it("round-trips a persisted pending turn transaction", () => {
+    const directory = makeDirectory();
+    const first = new RappSessionStore(directory);
+    const created = first.create("rapp_thread");
+    const saved = first.save({
+      ...created.snapshot,
+      turnCounter: 1,
+      pendingTurn: {
+        idempotencyKey: "rapp_thread:1",
+        userInput: "hello",
+        conversationHistory: [
+          { role: "user", content: "prior" },
+          { role: "assistant", content: "context" },
+        ],
+      },
+    });
+
+    const second = new RappSessionStore(directory);
+    expect(second.load("rapp_thread")).toEqual(saved);
+    const loaded = second.load("rapp_thread");
+    loaded?.snapshot.pendingTurn?.conversationHistory.push({
+      role: "user",
+      content: "mutated",
+    });
+    expect(second.load("rapp_thread")).toEqual(saved);
+  });
+
+  it("refuses an egg object whose bytes no longer match its address", () => {
+    const directory = makeDirectory();
+    const first = new RappSessionStore(directory);
+    const created = first.create("rapp_thread");
+    const saved = first.save({
+      ...created.snapshot,
+      remoteSessionId: "remote_thread",
+      turnCounter: 1,
+      transcript: [{ role: "user", content: "hello" }],
+    });
+    const objectPath = join(directory, "objects", `${saved.eggAddress}.json`);
+    const egg = JSON.parse(readFileSync(objectPath, "utf8"));
+    egg.payload.transcript[0].content = "tampered";
+    writeFileSync(objectPath, canonicalString(egg), "utf8");
+
+    const second = new RappSessionStore(directory);
+    expect(() => second.load("rapp_thread")).toThrow(
+      "address does not match its head",
+    );
+  });
+
+  it("refuses a head that rolls back to an older egg address", () => {
+    const directory = makeDirectory();
+    const first = new RappSessionStore(directory);
+    const created = first.create("rapp_thread");
+    const saved = first.save({
+      ...created.snapshot,
+      remoteSessionId: "remote_thread",
+      turnCounter: 2,
+      transcript: [{ role: "user", content: "hello" }],
+    });
+    const headPath = sessionHeadPath(directory);
+    const head = readHead(directory);
+    writeFileSync(
+      headPath,
+      canonicalString({
+        ...head,
+        egg_address: created.eggAddress,
+      }),
+      "utf8",
+    );
+
+    const second = new RappSessionStore(directory);
+    expect(() => second.load("rapp_thread")).toThrow(
+      "turn counter does not match",
+    );
+    expect(() => first.save(created.snapshot)).toThrow("roll back");
+    expect(first.load("rapp_thread")).toEqual(saved);
+  });
+
+  it("refuses a head address that names different object bytes", () => {
+    const directory = makeDirectory();
+    const first = new RappSessionStore(directory);
+    const saved = first.create("rapp_thread");
+    const wrongAddress = "f".repeat(64);
+    copyFileSync(
+      join(directory, "objects", `${saved.eggAddress}.json`),
+      join(directory, "objects", `${wrongAddress}.json`),
+    );
+    const headPath = sessionHeadPath(directory);
+    const head = readHead(directory);
+    writeFileSync(
+      headPath,
+      canonicalString({
+        ...head,
+        egg_address: wrongAddress,
+      }),
+      "utf8",
+    );
+
+    const second = new RappSessionStore(directory);
+    expect(() => second.load("rapp_thread")).toThrow(
+      "address does not match its head",
+    );
+  });
+
+  it("does not publish a failed session write into memory", () => {
+    const directory = makeDirectory();
+    const store = new RappSessionStore(directory);
+    const created = store.create("rapp_thread");
+    rmSync(join(directory, "sessions"), { recursive: true });
+    writeFileSync(join(directory, "sessions"), "not a directory", "utf8");
+
+    expect(() =>
+      store.save({
+        ...created.snapshot,
+        remoteSessionId: "remote_thread",
+        turnCounter: 1,
+      }),
+    ).toThrow();
+    expect(store.load("rapp_thread")).toEqual(created);
+  });
+
+  it("keeps cached state when deleting the durable head fails", () => {
+    const directory = makeDirectory();
+    const store = new RappSessionStore(directory);
+    const created = store.create("rapp_thread");
+    const headPath = sessionHeadPath(directory);
+    rmSync(headPath);
+    mkdirSync(headPath);
+
+    expect(() => store.delete("rapp_thread")).toThrow();
+    expect(store.load("rapp_thread")).toEqual(created);
+  });
+
+  it("reuses one persisted mint across store instances", () => {
+    const directory = makeDirectory();
+    const first = new RappSessionStore(directory);
+    const firstSession = first.create("first_thread");
+    const second = new RappSessionStore(directory);
+    const secondSession = second.create("second_thread");
+
+    expect(secondSession.rappid).toBe(firstSession.rappid);
+  });
+
+  it("mints one identity under concurrent process startup", async () => {
+    const directory = makeDirectory();
+    const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+    const repositoryRoot = join(packageRoot, "..", "..");
+    const storeModuleUrl = pathToFileURL(
+      join(packageRoot, "src", "session-store.ts"),
+    ).href;
+    const script = `
+      import { RappSessionStore } from ${JSON.stringify(storeModuleUrl)};
+      const store = new RappSessionStore(process.argv[1]);
+      const saved = store.create(process.argv[2]);
+      process.stdout.write(saved.rappid);
+    `;
+    const [first, second] = await Promise.all([
+      execFileAsync(
+        process.execPath,
+        ["--import", "tsx", "--eval", script, directory, "first_thread"],
+        { cwd: repositoryRoot },
+      ),
+      execFileAsync(
+        process.execPath,
+        ["--import", "tsx", "--eval", script, directory, "second_thread"],
+        { cwd: repositoryRoot },
+      ),
+    ]);
+
+    expect(String(first.stdout).trim()).toBe(String(second.stdout).trim());
+    const third = new RappSessionStore(directory);
+    expect(third.create("third_thread").rappid).toBe(
+      String(first.stdout).trim(),
+    );
+  });
+
+  it("fails closed when identity is missing beside persisted state", () => {
+    const directory = makeDirectory();
+    mkdirSync(join(directory, "sessions"), { recursive: true });
+    mkdirSync(join(directory, "objects"), { recursive: true });
+    writeFileSync(
+      join(directory, "objects", `${"a".repeat(64)}.json`),
+      "{}",
+      "utf8",
+    );
+
+    expect(() => new RappSessionStore(directory)).toThrow(
+      "identity is missing",
+    );
+  });
+});

--- a/plugins/provider-rapp/src/session-store.ts
+++ b/plugins/provider-rapp/src/session-store.ts
@@ -1,0 +1,443 @@
+import { createHash, randomUUID } from "node:crypto";
+import {
+  closeSync,
+  existsSync,
+  fsyncSync,
+  linkSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { z } from "zod";
+import {
+  canonicalString,
+  createSessionEgg,
+  mintKeylessRappid,
+  parseSessionEgg,
+  serializeSessionEgg,
+  type RappTranscriptEntry,
+} from "./rapp1.js";
+
+const MAX_SAFE_INTEGER = 2 ** 53 - 1;
+const HEX64_PATTERN = /^[0-9a-f]{64}$/u;
+
+const identityRecordSchema = z
+  .object({
+    rappid: z.string().min(1),
+    uuidAnchor: z.string().uuid(),
+  })
+  .strict();
+
+const sessionHeadSchema = z
+  .object({
+    schema: z.literal("bb/provider-rapp-session-head/1"),
+    provider_thread_id: z.string().min(1),
+    egg_address: z.string().regex(HEX64_PATTERN),
+    turn_counter: z.number().int().nonnegative().max(MAX_SAFE_INTEGER),
+  })
+  .strict();
+
+export interface RappPendingTurn {
+  idempotencyKey: string;
+  userInput: string;
+  conversationHistory: RappTranscriptEntry[];
+}
+
+export interface RappSessionSnapshot {
+  providerThreadId: string;
+  remoteSessionId: string | null;
+  turnCounter: number;
+  transcript: RappTranscriptEntry[];
+  pendingTurn: RappPendingTurn | null;
+}
+
+export interface SavedRappSession {
+  snapshot: RappSessionSnapshot;
+  rappid: string;
+  eggAddress: string;
+}
+
+function cloneTranscript(
+  transcript: readonly RappTranscriptEntry[],
+): RappTranscriptEntry[] {
+  return transcript.map((entry) => ({ ...entry }));
+}
+
+function clonePendingTurn(
+  pendingTurn: RappPendingTurn | null,
+): RappPendingTurn | null {
+  if (pendingTurn === null) {
+    return null;
+  }
+  return {
+    ...pendingTurn,
+    conversationHistory: cloneTranscript(pendingTurn.conversationHistory),
+  };
+}
+
+function cloneSnapshot(snapshot: RappSessionSnapshot): RappSessionSnapshot {
+  return {
+    ...snapshot,
+    transcript: cloneTranscript(snapshot.transcript),
+    pendingTurn: clonePendingTurn(snapshot.pendingTurn),
+  };
+}
+
+function errorCode(error: unknown): string | null {
+  if (typeof error !== "object" || error === null) {
+    return null;
+  }
+  const code: unknown = Reflect.get(error, "code");
+  return typeof code === "string" ? code : null;
+}
+
+function removeFileIfPresent(path: string): void {
+  try {
+    unlinkSync(path);
+  } catch (error) {
+    if (errorCode(error) !== "ENOENT") {
+      throw error;
+    }
+  }
+}
+
+function syncDirectory(path: string): void {
+  let descriptor: number | null = null;
+  try {
+    descriptor = openSync(path, "r");
+    fsyncSync(descriptor);
+  } catch (error) {
+    if (
+      !["EBADF", "EINVAL", "EISDIR", "ENOSYS", "ENOTSUP", "EPERM"].includes(
+        errorCode(error) ?? "",
+      )
+    ) {
+      throw error;
+    }
+  } finally {
+    if (descriptor !== null) {
+      closeSync(descriptor);
+    }
+  }
+}
+
+function writeDurableFile(path: string, content: string): void {
+  const descriptor = openSync(path, "wx", 0o600);
+  try {
+    writeFileSync(descriptor, content, { encoding: "utf8" });
+    fsyncSync(descriptor);
+  } finally {
+    closeSync(descriptor);
+  }
+}
+
+function atomicWrite(path: string, content: string): void {
+  const temporaryPath = `${path}.${process.pid}.${randomUUID()}.tmp`;
+  try {
+    writeDurableFile(temporaryPath, content);
+    renameSync(temporaryPath, path);
+    syncDirectory(dirname(path));
+  } finally {
+    removeFileIfPresent(temporaryPath);
+  }
+}
+
+function atomicCreate(path: string, content: string): boolean {
+  const temporaryPath = `${path}.${process.pid}.${randomUUID()}.tmp`;
+  try {
+    writeDurableFile(temporaryPath, content);
+    try {
+      linkSync(temporaryPath, path);
+    } catch (error) {
+      if (errorCode(error) === "EEXIST") {
+        return false;
+      }
+      throw error;
+    }
+    unlinkSync(temporaryPath);
+    syncDirectory(dirname(path));
+    return true;
+  } finally {
+    removeFileIfPresent(temporaryPath);
+  }
+}
+
+function parseCanonicalState<T>(
+  bytes: Uint8Array,
+  schema: z.ZodType<T>,
+  label: string,
+): T {
+  const text = new TextDecoder("utf-8", {
+    fatal: true,
+    ignoreBOM: true,
+  }).decode(bytes);
+  let json: unknown;
+  try {
+    json = JSON.parse(text);
+  } catch (error) {
+    throw new Error(
+      `Invalid ${label} JSON: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  const parsed = schema.parse(json);
+  if (
+    !Buffer.from(bytes).equals(Buffer.from(canonicalString(parsed), "utf8"))
+  ) {
+    throw new Error(`${label} is not canonical JSON`);
+  }
+  return parsed;
+}
+
+function directoryHasEntries(path: string): boolean {
+  return readdirSync(path).length > 0;
+}
+
+export class RappSessionStore {
+  private readonly snapshots = new Map<string, SavedRappSession>();
+  private readonly dataDir: string | null;
+  private readonly sessionsDir: string | null;
+  private readonly objectsDir: string | null;
+  private readonly rappid: string;
+
+  constructor(dataDir?: string) {
+    this.dataDir = dataDir ?? null;
+    this.sessionsDir =
+      this.dataDir === null ? null : join(this.dataDir, "sessions");
+    this.objectsDir =
+      this.dataDir === null ? null : join(this.dataDir, "objects");
+    if (this.sessionsDir !== null && this.objectsDir !== null) {
+      mkdirSync(this.sessionsDir, { recursive: true });
+      mkdirSync(this.objectsDir, { recursive: true });
+    }
+    this.rappid = this.loadOrCreateIdentity();
+  }
+
+  create(providerThreadId: string): SavedRappSession {
+    const existing = this.load(providerThreadId);
+    if (existing !== null) {
+      throw new Error(`RAPP session already exists: ${providerThreadId}`);
+    }
+    return this.save({
+      providerThreadId,
+      remoteSessionId: null,
+      turnCounter: 0,
+      transcript: [],
+      pendingTurn: null,
+    });
+  }
+
+  load(providerThreadId: string): SavedRappSession | null {
+    const cached = this.snapshots.get(providerThreadId);
+    if (cached !== undefined) {
+      return {
+        ...cached,
+        snapshot: cloneSnapshot(cached.snapshot),
+      };
+    }
+    const path = this.sessionPath(providerThreadId);
+    if (path === null || !existsSync(path)) {
+      return null;
+    }
+    const head = parseCanonicalState(
+      readFileSync(path),
+      sessionHeadSchema,
+      "RAPP session head",
+    );
+    if (head.provider_thread_id !== providerThreadId) {
+      throw new Error("RAPP session head provider thread identity mismatch");
+    }
+    const objectPath = this.objectPath(head.egg_address);
+    if (objectPath === null || !existsSync(objectPath)) {
+      throw new Error("RAPP session head points to a missing egg object");
+    }
+    const parsed = parseSessionEgg(readFileSync(objectPath), this.rappid);
+    if (parsed.eggAddress !== head.egg_address) {
+      throw new Error("RAPP session egg address does not match its head");
+    }
+    if (parsed.runtime.provider_thread_id !== providerThreadId) {
+      throw new Error("RAPP session egg provider thread identity mismatch");
+    }
+    if (parsed.runtime.turn_counter !== head.turn_counter) {
+      throw new Error("RAPP session head turn counter does not match its egg");
+    }
+    const saved: SavedRappSession = {
+      snapshot: {
+        providerThreadId,
+        remoteSessionId: parsed.runtime.remote_session_id,
+        turnCounter: parsed.runtime.turn_counter,
+        transcript: cloneTranscript(parsed.egg.payload.transcript),
+        pendingTurn:
+          parsed.runtime.pending_turn === null
+            ? null
+            : {
+                idempotencyKey: parsed.runtime.pending_turn.idempotency_key,
+                userInput: parsed.runtime.pending_turn.user_input,
+                conversationHistory: cloneTranscript(
+                  parsed.runtime.pending_turn.conversation_history,
+                ),
+              },
+      },
+      rappid: this.rappid,
+      eggAddress: parsed.eggAddress,
+    };
+    this.snapshots.set(providerThreadId, saved);
+    return {
+      ...saved,
+      snapshot: cloneSnapshot(saved.snapshot),
+    };
+  }
+
+  save(snapshot: RappSessionSnapshot): SavedRappSession {
+    const egg = createSessionEgg({
+      rappid: this.rappid,
+      createdUtc: new Date().toISOString(),
+      runtime: {
+        provider: "bb/provider-rapp",
+        provider_thread_id: snapshot.providerThreadId,
+        remote_session_id: snapshot.remoteSessionId,
+        turn_counter: snapshot.turnCounter,
+        pending_turn:
+          snapshot.pendingTurn === null
+            ? null
+            : {
+                idempotency_key: snapshot.pendingTurn.idempotencyKey,
+                user_input: snapshot.pendingTurn.userInput,
+                conversation_history: cloneTranscript(
+                  snapshot.pendingTurn.conversationHistory,
+                ),
+              },
+      },
+      transcript: snapshot.transcript,
+    });
+    const serialized = serializeSessionEgg(egg);
+    const parsed = parseSessionEgg(Buffer.from(serialized), this.rappid);
+    const saved: SavedRappSession = {
+      snapshot: cloneSnapshot(snapshot),
+      rappid: this.rappid,
+      eggAddress: parsed.eggAddress,
+    };
+    const path = this.sessionPath(snapshot.providerThreadId);
+    if (path !== null) {
+      if (existsSync(path)) {
+        const currentHead = parseCanonicalState(
+          readFileSync(path),
+          sessionHeadSchema,
+          "RAPP session head",
+        );
+        if (currentHead.provider_thread_id !== snapshot.providerThreadId) {
+          throw new Error(
+            "RAPP session head provider thread identity mismatch",
+          );
+        }
+        if (snapshot.turnCounter < currentHead.turn_counter) {
+          throw new Error("RAPP session save would roll back the turn counter");
+        }
+      }
+      const objectPath = this.objectPath(parsed.eggAddress);
+      if (objectPath === null) {
+        throw new Error("RAPP session object directory is unavailable");
+      }
+      if (existsSync(objectPath)) {
+        if (!readFileSync(objectPath).equals(Buffer.from(serialized, "utf8"))) {
+          throw new Error(
+            "RAPP session object address contains different bytes",
+          );
+        }
+      } else if (!atomicCreate(objectPath, serialized)) {
+        if (!readFileSync(objectPath).equals(Buffer.from(serialized, "utf8"))) {
+          throw new Error(
+            "RAPP session object address contains different bytes",
+          );
+        }
+      }
+      atomicWrite(
+        path,
+        canonicalString({
+          schema: "bb/provider-rapp-session-head/1",
+          provider_thread_id: snapshot.providerThreadId,
+          egg_address: parsed.eggAddress,
+          turn_counter: snapshot.turnCounter,
+        }),
+      );
+    }
+    this.snapshots.set(snapshot.providerThreadId, saved);
+    return {
+      ...saved,
+      snapshot: cloneSnapshot(saved.snapshot),
+    };
+  }
+
+  delete(providerThreadId: string): void {
+    const path = this.sessionPath(providerThreadId);
+    if (path !== null && existsSync(path)) {
+      unlinkSync(path);
+      syncDirectory(dirname(path));
+    }
+    this.snapshots.delete(providerThreadId);
+  }
+
+  private loadOrCreateIdentity(): string {
+    if (
+      this.dataDir === null ||
+      this.sessionsDir === null ||
+      this.objectsDir === null
+    ) {
+      return mintKeylessRappid("get-bb", "provider-rapp").rappid;
+    }
+    mkdirSync(this.dataDir, { recursive: true });
+    const path = join(this.dataDir, "identity.json");
+    if (existsSync(path)) {
+      return this.loadIdentity(path);
+    }
+    if (
+      directoryHasEntries(this.sessionsDir) ||
+      directoryHasEntries(this.objectsDir)
+    ) {
+      throw new Error(
+        "RAPP bridge identity is missing while persisted session state exists",
+      );
+    }
+    const identity = mintKeylessRappid("get-bb", "provider-rapp");
+    if (!atomicCreate(path, canonicalString(identity))) {
+      return this.loadIdentity(path);
+    }
+    return identity.rappid;
+  }
+
+  private loadIdentity(path: string): string {
+    const parsed = identityRecordSchema.parse(
+      JSON.parse(readFileSync(path, "utf8")),
+    );
+    const expected = mintKeylessRappid(
+      "get-bb",
+      "provider-rapp",
+      parsed.uuidAnchor,
+    );
+    if (expected.rappid !== parsed.rappid) {
+      throw new Error("RAPP bridge identity record failed verification");
+    }
+    return parsed.rappid;
+  }
+
+  private sessionPath(providerThreadId: string): string | null {
+    if (this.sessionsDir === null) {
+      return null;
+    }
+    const name = createHash("sha256")
+      .update(providerThreadId, "utf8")
+      .digest("hex");
+    return join(this.sessionsDir, `${name}.json`);
+  }
+
+  private objectPath(eggAddress: string): string | null {
+    if (this.objectsDir === null) {
+      return null;
+    }
+    return join(this.objectsDir, `${eggAddress}.json`);
+  }
+}

--- a/plugins/provider-rapp/src/session-store.ts
+++ b/plugins/provider-rapp/src/session-store.ts
@@ -17,14 +17,20 @@ import { z } from "zod";
 import {
   canonicalString,
   createSessionEgg,
+  hashValue,
   mintKeylessRappid,
   parseSessionEgg,
   serializeSessionEgg,
   type RappTranscriptEntry,
 } from "./rapp1.js";
+import type { RappGrail } from "./vocabulary.js";
 
 const MAX_SAFE_INTEGER = 2 ** 53 - 1;
 const HEX64_PATTERN = /^[0-9a-f]{64}$/u;
+const INSUFFICIENT_CAPACITY_MESSAGE = [
+  "This RAPP thread does not have enough durable session capacity for another response.",
+  "Start a new thread before sending more messages.",
+].join(" ");
 
 const identityRecordSchema = z
   .object({
@@ -33,7 +39,7 @@ const identityRecordSchema = z
   })
   .strict();
 
-const sessionHeadSchema = z
+const sessionHeadV1Schema = z
   .object({
     schema: z.literal("bb/provider-rapp-session-head/1"),
     provider_thread_id: z.string().min(1),
@@ -42,10 +48,87 @@ const sessionHeadSchema = z
   })
   .strict();
 
+const sessionHeadV2Schema = z
+  .object({
+    schema: z.literal("bb/provider-rapp-session-head/2"),
+    provider_thread_id: z.string().min(1),
+    egg_address: z.string().regex(HEX64_PATTERN),
+    delivery_address: z.string().regex(HEX64_PATTERN).nullable(),
+    turn_counter: z.number().int().nonnegative().max(MAX_SAFE_INTEGER),
+  })
+  .strict();
+
+const sessionHeadSchema = z.discriminatedUnion("schema", [
+  sessionHeadV1Schema,
+  sessionHeadV2Schema,
+]);
+
+const deliveryJournalV1Schema = z
+  .object({
+    schema: z.literal("bb/provider-rapp-delivery/1"),
+    provider_thread_id: z.string().min(1),
+    egg_address: z.string().regex(HEX64_PATTERN),
+    turn_counter: z.number().int().nonnegative().max(MAX_SAFE_INTEGER),
+    provider_turn_id: z.string().min(1),
+    agent_item_id: z.string().min(1).nullable(),
+    message_item_id: z.string().min(1),
+    response: z.string().min(1),
+    agent_logs: z.array(z.string()),
+    grail: z.enum(["consumer", "business"]),
+    endpoint: z.string().min(1),
+    selected_model: z.string().min(1),
+    requested_model: z.string().min(1).nullable(),
+    actual_model: z.string().min(1).nullable(),
+  })
+  .strict();
+
+const deliveryJournalV2Schema = z
+  .object({
+    schema: z.literal("bb/provider-rapp-delivery/2"),
+    provider_thread_id: z.string().min(1),
+    egg_address: z.string().regex(HEX64_PATTERN),
+    turn_counter: z.number().int().nonnegative().max(MAX_SAFE_INTEGER),
+    provider_turn_id: z.string().min(1),
+    agent_item_id: z.string().min(1).nullable(),
+    message_item_id: z.string().min(1),
+    response: z.string().min(1),
+    agent_logs: z.array(z.string()),
+    grail: z.enum(["consumer", "business"]),
+    endpoint: z.string().min(1),
+    selected_model: z.string().min(1),
+    requested_model: z.string().min(1).nullable(),
+    actual_model: z.string().min(1).nullable(),
+    phase: z.enum(["ready", "emitted"]),
+  })
+  .strict();
+
+const deliveryJournalSchema = z.discriminatedUnion("schema", [
+  deliveryJournalV1Schema,
+  deliveryJournalV2Schema,
+]);
+
 export interface RappPendingTurn {
   idempotencyKey: string;
   userInput: string;
   conversationHistory: RappTranscriptEntry[];
+}
+
+export interface RappDeliveryDraft {
+  providerTurnId: string;
+  agentItemId: string | null;
+  messageItemId: string;
+  response: string;
+  agentLogs: string[];
+  grail: RappGrail;
+  endpoint: string;
+  selectedModel: string;
+  requestedModel: string | null;
+  actualModel: string | null;
+}
+
+export interface RappPendingDelivery extends RappDeliveryDraft {
+  eggAddress: string;
+  phase: "ready" | "emitted";
 }
 
 export interface RappSessionSnapshot {
@@ -60,6 +143,8 @@ export interface SavedRappSession {
   snapshot: RappSessionSnapshot;
   rappid: string;
   eggAddress: string;
+  pendingDelivery: RappPendingDelivery | null;
+  deliveryAddress: string | null;
 }
 
 function cloneTranscript(
@@ -86,6 +171,59 @@ function cloneSnapshot(snapshot: RappSessionSnapshot): RappSessionSnapshot {
     transcript: cloneTranscript(snapshot.transcript),
     pendingTurn: clonePendingTurn(snapshot.pendingTurn),
   };
+}
+
+function clonePendingDelivery(
+  pendingDelivery: RappPendingDelivery | null,
+): RappPendingDelivery | null {
+  return pendingDelivery === null
+    ? null
+    : {
+        ...pendingDelivery,
+        agentLogs: [...pendingDelivery.agentLogs],
+      };
+}
+
+function cloneSavedSession(saved: SavedRappSession): SavedRappSession {
+  return {
+    ...saved,
+    snapshot: cloneSnapshot(saved.snapshot),
+    pendingDelivery: clonePendingDelivery(saved.pendingDelivery),
+  };
+}
+
+function sessionRuntime(snapshot: RappSessionSnapshot) {
+  return {
+    provider: "bb/provider-rapp" as const,
+    provider_thread_id: snapshot.providerThreadId,
+    remote_session_id: snapshot.remoteSessionId,
+    turn_counter: snapshot.turnCounter,
+    pending_turn:
+      snapshot.pendingTurn === null
+        ? null
+        : {
+            idempotency_key: snapshot.pendingTurn.idempotencyKey,
+            user_input: snapshot.pendingTurn.userInput,
+            conversation_history: cloneTranscript(
+              snapshot.pendingTurn.conversationHistory,
+            ),
+          },
+  };
+}
+
+function serializeSnapshotEgg(
+  rappid: string,
+  snapshot: RappSessionSnapshot,
+  createdUtc: string,
+): string {
+  return serializeSessionEgg(
+    createSessionEgg({
+      rappid,
+      createdUtc,
+      runtime: sessionRuntime(snapshot),
+      transcript: snapshot.transcript,
+    }),
+  );
 }
 
 function errorCode(error: unknown): string | null {
@@ -222,22 +360,22 @@ export class RappSessionStore {
     if (existing !== null) {
       throw new Error(`RAPP session already exists: ${providerThreadId}`);
     }
-    return this.save({
-      providerThreadId,
-      remoteSessionId: null,
-      turnCounter: 0,
-      transcript: [],
-      pendingTurn: null,
-    });
+    return this.save(
+      {
+        providerThreadId,
+        remoteSessionId: null,
+        turnCounter: 0,
+        transcript: [],
+        pendingTurn: null,
+      },
+      null,
+    );
   }
 
   load(providerThreadId: string): SavedRappSession | null {
     const cached = this.snapshots.get(providerThreadId);
     if (cached !== undefined) {
-      return {
-        ...cached,
-        snapshot: cloneSnapshot(cached.snapshot),
-      };
+      return cloneSavedSession(cached);
     }
     const path = this.sessionPath(providerThreadId);
     if (path === null || !existsSync(path)) {
@@ -265,6 +403,72 @@ export class RappSessionStore {
     if (parsed.runtime.turn_counter !== head.turn_counter) {
       throw new Error("RAPP session head turn counter does not match its egg");
     }
+    let pendingDelivery: RappPendingDelivery | null = null;
+    let deliveryAddress: string | null = null;
+    if (
+      head.schema === "bb/provider-rapp-session-head/2" &&
+      head.delivery_address !== null
+    ) {
+      const deliveryPath = this.objectPath(head.delivery_address);
+      if (deliveryPath === null || !existsSync(deliveryPath)) {
+        throw new Error(
+          "RAPP session head points to a missing delivery object",
+        );
+      }
+      const delivery = parseCanonicalState(
+        readFileSync(deliveryPath),
+        deliveryJournalSchema,
+        "RAPP delivery journal",
+      );
+      if (
+        hashValue("bb/provider-rapp-delivery", delivery) !==
+        head.delivery_address
+      ) {
+        throw new Error(
+          "RAPP delivery journal address does not match its head",
+        );
+      }
+      if (delivery.provider_thread_id !== providerThreadId) {
+        throw new Error(
+          "RAPP delivery journal provider thread identity mismatch",
+        );
+      }
+      if (
+        delivery.egg_address !== head.egg_address ||
+        delivery.turn_counter !== head.turn_counter
+      ) {
+        throw new Error(
+          "RAPP delivery journal does not match its completed session egg",
+        );
+      }
+      const finalEntry = parsed.egg.payload.transcript.at(-1);
+      if (
+        finalEntry?.role !== "assistant" ||
+        finalEntry.content !== delivery.response
+      ) {
+        throw new Error(
+          "RAPP delivery journal response does not match its completed transcript",
+        );
+      }
+      pendingDelivery = {
+        providerTurnId: delivery.provider_turn_id,
+        agentItemId: delivery.agent_item_id,
+        messageItemId: delivery.message_item_id,
+        response: delivery.response,
+        agentLogs: [...delivery.agent_logs],
+        grail: delivery.grail,
+        endpoint: delivery.endpoint,
+        selectedModel: delivery.selected_model,
+        requestedModel: delivery.requested_model,
+        actualModel: delivery.actual_model,
+        eggAddress: delivery.egg_address,
+        phase:
+          delivery.schema === "bb/provider-rapp-delivery/1"
+            ? "ready"
+            : delivery.phase,
+      };
+      deliveryAddress = head.delivery_address;
+    }
     const saved: SavedRappSession = {
       snapshot: {
         providerThreadId,
@@ -284,42 +488,110 @@ export class RappSessionStore {
       },
       rappid: this.rappid,
       eggAddress: parsed.eggAddress,
+      pendingDelivery,
+      deliveryAddress,
     };
     this.snapshots.set(providerThreadId, saved);
-    return {
-      ...saved,
-      snapshot: cloneSnapshot(saved.snapshot),
-    };
+    return cloneSavedSession(saved);
   }
 
-  save(snapshot: RappSessionSnapshot): SavedRappSession {
-    const egg = createSessionEgg({
-      rappid: this.rappid,
-      createdUtc: new Date().toISOString(),
-      runtime: {
-        provider: "bb/provider-rapp",
-        provider_thread_id: snapshot.providerThreadId,
-        remote_session_id: snapshot.remoteSessionId,
-        turn_counter: snapshot.turnCounter,
-        pending_turn:
-          snapshot.pendingTurn === null
-            ? null
-            : {
-                idempotency_key: snapshot.pendingTurn.idempotencyKey,
-                user_input: snapshot.pendingTurn.userInput,
-                conversation_history: cloneTranscript(
-                  snapshot.pendingTurn.conversationHistory,
-                ),
-              },
-      },
-      transcript: snapshot.transcript,
-    });
-    const serialized = serializeSessionEgg(egg);
+  assertCanCommitCompletion(
+    snapshot: RappSessionSnapshot,
+    userInput: string,
+    maximumResponseBytes: number,
+  ): void {
+    if (
+      !Number.isSafeInteger(maximumResponseBytes) ||
+      maximumResponseBytes < 1
+    ) {
+      throw new Error("RAPP response capacity must be a positive integer");
+    }
+    const responseReserve = "x".repeat(maximumResponseBytes);
+    const sessionIdReserve = "\\".repeat(
+      Math.floor(maximumResponseBytes / 2),
+    );
+    const completion = {
+      ...snapshot,
+      pendingTurn: null,
+      transcript: [
+        ...cloneTranscript(snapshot.transcript),
+        { role: "user" as const, content: userInput },
+        { role: "assistant" as const, content: responseReserve },
+      ],
+    };
+    for (const remoteSessionId of [
+      snapshot.remoteSessionId,
+      sessionIdReserve,
+    ]) {
+      try {
+        serializeSnapshotEgg(
+          this.rappid,
+          { ...completion, remoteSessionId },
+          "9999-12-31T23:59:59.999Z",
+        );
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          error.message.includes("exceeds 1 MiB")
+        ) {
+          throw new Error(INSUFFICIENT_CAPACITY_MESSAGE);
+        }
+        throw error;
+      }
+    }
+  }
+
+  save(
+    snapshot: RappSessionSnapshot,
+    delivery: RappDeliveryDraft | null,
+  ): SavedRappSession {
+    const serialized = serializeSnapshotEgg(
+      this.rappid,
+      snapshot,
+      new Date().toISOString(),
+    );
     const parsed = parseSessionEgg(Buffer.from(serialized), this.rappid);
+    const deliveryRecord =
+      delivery === null
+        ? null
+        : {
+            schema: "bb/provider-rapp-delivery/2" as const,
+            provider_thread_id: snapshot.providerThreadId,
+            egg_address: parsed.eggAddress,
+            turn_counter: snapshot.turnCounter,
+            provider_turn_id: delivery.providerTurnId,
+            agent_item_id: delivery.agentItemId,
+            message_item_id: delivery.messageItemId,
+            response: delivery.response,
+            agent_logs: [...delivery.agentLogs],
+            grail: delivery.grail,
+            endpoint: delivery.endpoint,
+            selected_model: delivery.selectedModel,
+            requested_model: delivery.requestedModel,
+            actual_model: delivery.actualModel,
+            phase: "ready" as const,
+          };
+    const deliverySerialized =
+      deliveryRecord === null ? null : canonicalString(deliveryRecord);
+    const deliveryAddress =
+      deliveryRecord === null
+        ? null
+        : hashValue("bb/provider-rapp-delivery", deliveryRecord);
+    const pendingDelivery: RappPendingDelivery | null =
+      delivery === null
+        ? null
+        : {
+            ...delivery,
+            agentLogs: [...delivery.agentLogs],
+            eggAddress: parsed.eggAddress,
+            phase: "ready",
+          };
     const saved: SavedRappSession = {
       snapshot: cloneSnapshot(snapshot),
       rappid: this.rappid,
       eggAddress: parsed.eggAddress,
+      pendingDelivery,
+      deliveryAddress,
     };
     const path = this.sessionPath(snapshot.providerThreadId);
     if (path !== null) {
@@ -338,38 +610,160 @@ export class RappSessionStore {
           throw new Error("RAPP session save would roll back the turn counter");
         }
       }
-      const objectPath = this.objectPath(parsed.eggAddress);
-      if (objectPath === null) {
-        throw new Error("RAPP session object directory is unavailable");
-      }
-      if (existsSync(objectPath)) {
-        if (!readFileSync(objectPath).equals(Buffer.from(serialized, "utf8"))) {
-          throw new Error(
-            "RAPP session object address contains different bytes",
-          );
-        }
-      } else if (!atomicCreate(objectPath, serialized)) {
-        if (!readFileSync(objectPath).equals(Buffer.from(serialized, "utf8"))) {
-          throw new Error(
-            "RAPP session object address contains different bytes",
-          );
-        }
+      this.writeObject(parsed.eggAddress, serialized, "RAPP session object");
+      if (deliveryAddress !== null && deliverySerialized !== null) {
+        this.writeObject(
+          deliveryAddress,
+          deliverySerialized,
+          "RAPP delivery journal object",
+        );
       }
       atomicWrite(
         path,
         canonicalString({
-          schema: "bb/provider-rapp-session-head/1",
+          schema: "bb/provider-rapp-session-head/2",
           provider_thread_id: snapshot.providerThreadId,
           egg_address: parsed.eggAddress,
+          delivery_address: deliveryAddress,
           turn_counter: snapshot.turnCounter,
         }),
       );
     }
     this.snapshots.set(snapshot.providerThreadId, saved);
-    return {
-      ...saved,
-      snapshot: cloneSnapshot(saved.snapshot),
+    return cloneSavedSession(saved);
+  }
+
+  markDeliveryEmitted(
+    providerThreadId: string,
+    expectedDeliveryAddress: string,
+  ): SavedRappSession {
+    const current = this.load(providerThreadId);
+    if (
+      current === null ||
+      current.deliveryAddress !== expectedDeliveryAddress ||
+      current.pendingDelivery === null
+    ) {
+      throw new Error("RAPP delivery journal emission mismatch");
+    }
+    if (current.pendingDelivery.phase === "emitted") {
+      return current;
+    }
+    const delivery = current.pendingDelivery;
+    const deliveryRecord = {
+      schema: "bb/provider-rapp-delivery/2" as const,
+      provider_thread_id: providerThreadId,
+      egg_address: current.eggAddress,
+      turn_counter: current.snapshot.turnCounter,
+      provider_turn_id: delivery.providerTurnId,
+      agent_item_id: delivery.agentItemId,
+      message_item_id: delivery.messageItemId,
+      response: delivery.response,
+      agent_logs: [...delivery.agentLogs],
+      grail: delivery.grail,
+      endpoint: delivery.endpoint,
+      selected_model: delivery.selectedModel,
+      requested_model: delivery.requestedModel,
+      actual_model: delivery.actualModel,
+      phase: "emitted" as const,
     };
+    const serialized = canonicalString(deliveryRecord);
+    const deliveryAddress = hashValue(
+      "bb/provider-rapp-delivery",
+      deliveryRecord,
+    );
+    const path = this.sessionPath(providerThreadId);
+    if (path !== null) {
+      const head = parseCanonicalState(
+        readFileSync(path),
+        sessionHeadSchema,
+        "RAPP session head",
+      );
+      if (
+        head.schema !== "bb/provider-rapp-session-head/2" ||
+        head.provider_thread_id !== providerThreadId ||
+        head.egg_address !== current.eggAddress ||
+        head.turn_counter !== current.snapshot.turnCounter ||
+        head.delivery_address !== expectedDeliveryAddress
+      ) {
+        throw new Error("RAPP delivery journal emission mismatch");
+      }
+      this.writeObject(
+        deliveryAddress,
+        serialized,
+        "RAPP delivery journal object",
+      );
+      atomicWrite(
+        path,
+        canonicalString({
+          schema: "bb/provider-rapp-session-head/2",
+          provider_thread_id: providerThreadId,
+          egg_address: current.eggAddress,
+          delivery_address: deliveryAddress,
+          turn_counter: current.snapshot.turnCounter,
+        }),
+      );
+    }
+    const emitted: SavedRappSession = {
+      ...current,
+      pendingDelivery: {
+        ...delivery,
+        agentLogs: [...delivery.agentLogs],
+        phase: "emitted",
+      },
+      deliveryAddress,
+    };
+    this.snapshots.set(providerThreadId, emitted);
+    return cloneSavedSession(emitted);
+  }
+
+  acknowledgeDelivery(
+    providerThreadId: string,
+    expectedDeliveryAddress: string,
+  ): SavedRappSession {
+    const current = this.load(providerThreadId);
+    if (current === null) {
+      throw new Error(`Unknown RAPP session: ${providerThreadId}`);
+    }
+    if (
+      current.deliveryAddress !== expectedDeliveryAddress ||
+      current.pendingDelivery === null
+    ) {
+      throw new Error("RAPP delivery journal acknowledgement mismatch");
+    }
+    const path = this.sessionPath(providerThreadId);
+    if (path !== null) {
+      const head = parseCanonicalState(
+        readFileSync(path),
+        sessionHeadSchema,
+        "RAPP session head",
+      );
+      if (
+        head.schema !== "bb/provider-rapp-session-head/2" ||
+        head.provider_thread_id !== providerThreadId ||
+        head.egg_address !== current.eggAddress ||
+        head.turn_counter !== current.snapshot.turnCounter ||
+        head.delivery_address !== expectedDeliveryAddress
+      ) {
+        throw new Error("RAPP delivery journal acknowledgement mismatch");
+      }
+      atomicWrite(
+        path,
+        canonicalString({
+          schema: "bb/provider-rapp-session-head/2",
+          provider_thread_id: providerThreadId,
+          egg_address: current.eggAddress,
+          delivery_address: null,
+          turn_counter: current.snapshot.turnCounter,
+        }),
+      );
+    }
+    const acknowledged: SavedRappSession = {
+      ...current,
+      pendingDelivery: null,
+      deliveryAddress: null,
+    };
+    this.snapshots.set(providerThreadId, acknowledged);
+    return cloneSavedSession(acknowledged);
   }
 
   delete(providerThreadId: string): void {
@@ -379,6 +773,29 @@ export class RappSessionStore {
       syncDirectory(dirname(path));
     }
     this.snapshots.delete(providerThreadId);
+  }
+
+  private writeObject(
+    address: string,
+    serialized: string,
+    label: string,
+  ): void {
+    const objectPath = this.objectPath(address);
+    if (objectPath === null) {
+      throw new Error("RAPP session object directory is unavailable");
+    }
+    const expected = Buffer.from(serialized, "utf8");
+    if (existsSync(objectPath)) {
+      if (!readFileSync(objectPath).equals(expected)) {
+        throw new Error(`${label} address contains different bytes`);
+      }
+      return;
+    }
+    if (!atomicCreate(objectPath, serialized)) {
+      if (!readFileSync(objectPath).equals(expected)) {
+        throw new Error(`${label} address contains different bytes`);
+      }
+    }
   }
 
   private loadOrCreateIdentity(): string {

--- a/plugins/provider-rapp/src/vocabulary.ts
+++ b/plugins/provider-rapp/src/vocabulary.ts
@@ -1,0 +1,146 @@
+import type { DeltaPresentation } from "@get-bb/plugin-sdk/provider-bridge";
+import { z } from "zod";
+
+export const RAPP_PLUGIN_ID = "provider-rapp";
+export const RAPP_PROVIDER_ID = "rapp";
+export const RAPP_SPEC = "rapp/1";
+export const RAPP_MODEL_ID = "brainstem";
+export const RAPP_BUSINESS_MODEL_ID = "business-grail";
+export const RAPP_SESSION_STATE_KIND = `${RAPP_PLUGIN_ID}/session` as const;
+
+export const RAPP_BRAINSTEM_URL_ENV = "RAPP_BRAINSTEM_URL";
+export const RAPP_BRAINSTEM_SECRET_ENV = "RAPP_BRAINSTEM_SECRET";
+export const RAPP_BUSINESS_URL_ENV = "RAPP_BUSINESS_URL";
+export const RAPP_FUNCTION_KEY_ENV = "RAPP_FUNCTION_KEY";
+export const RAPP_USER_GUID_ENV = "RAPP_USER_GUID";
+
+export const rappGrailSchema = z.enum(["consumer", "business"]);
+export type RappGrail = z.infer<typeof rappGrailSchema>;
+
+const secretQueryKey = /(code|token|secret|key|password)/iu;
+
+export const rappEndpointSettingSchema = z.string().refine((value) => {
+  const trimmed = value.trim();
+  if (trimmed === "") {
+    return true;
+  }
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      return false;
+    }
+    if (url.username !== "" || url.password !== "") {
+      return false;
+    }
+    return [...url.searchParams.keys()].every(
+      (key) => !secretQueryKey.test(key),
+    );
+  } catch {
+    return false;
+  }
+}, "Use an HTTP(S) URL without credentials or secret-bearing query parameters");
+
+export const rappPluginSettingsSchema = z.object({
+  grail: rappGrailSchema,
+  endpoint: rappEndpointSettingSchema,
+});
+export type RappPluginSettings = z.infer<typeof rappPluginSettingsSchema>;
+
+export const rappCatalogOptionsSchema = rappPluginSettingsSchema;
+export type RappCatalogOptions = z.infer<typeof rappCatalogOptionsSchema>;
+
+export const rappProviderOptionsSchema = z
+  .object({
+    grail: rappGrailSchema,
+    endpoint: rappEndpointSettingSchema,
+    model: z.string().min(1),
+  })
+  .superRefine((options, context) => {
+    if (
+      options.grail === "business" &&
+      options.model !== RAPP_BUSINESS_MODEL_ID
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["model"],
+        message: `Business Grail requires model ${RAPP_BUSINESS_MODEL_ID}`,
+      });
+    }
+    if (
+      options.grail === "consumer" &&
+      options.model === RAPP_BUSINESS_MODEL_ID
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["model"],
+        message: `${RAPP_BUSINESS_MODEL_ID} is only available through the Business Grail`,
+      });
+    }
+  });
+export type RappProviderOptions = z.infer<typeof rappProviderOptionsSchema>;
+
+export const RAPP_BRAINSTEM_MODEL = {
+  id: RAPP_MODEL_ID,
+  displayName: "GitHub Copilot (Brainstem default)",
+  description:
+    "Use the GitHub Copilot model currently selected by RAPP Brainstem.",
+  supportedReasoningEfforts: [
+    {
+      reasoningEffort: "none",
+      description:
+        "RAPP Brainstem owns GitHub Copilot reasoning and execution.",
+    },
+  ],
+  defaultReasoningEffort: "none",
+  isDefault: true,
+} as const;
+
+export const RAPP_BUSINESS_MODEL = {
+  id: RAPP_BUSINESS_MODEL_ID,
+  displayName: "Business Grail",
+  description:
+    "Use the fixed managed GitHub Copilot model selected by the Business RAPP Brainstem deployment.",
+  supportedReasoningEfforts: [
+    {
+      reasoningEffort: "none",
+      description:
+        "RAPP Brainstem owns GitHub Copilot reasoning and execution.",
+    },
+  ],
+  defaultReasoningEffort: "none",
+  isDefault: true,
+} as const;
+
+export const rappSessionStateSchema = z.object({
+  spec: z.literal(RAPP_SPEC),
+  grail: rappGrailSchema,
+  rappid: z.string().min(1),
+  sessionId: z.string().min(1).nullable(),
+  turnCount: z.number().int().nonnegative(),
+  eggAddress: z.string().regex(/^[0-9a-f]{64}$/u),
+  endpoint: z.string().url(),
+  selectedModel: z.string().min(1),
+  requestedModel: z.string().min(1).nullable(),
+  actualModel: z.string().min(1).nullable(),
+});
+
+export const rappExtensionKinds = {
+  session: { state: rappSessionStateSchema },
+} as const;
+
+export const RAPP_AGENT_ACTIVITY_PRESENTATION: DeltaPresentation = {
+  label: {
+    pending: "Running RAPP agents",
+    completed: "Ran RAPP agents",
+  },
+  icon: { glyph: "Bot" },
+  suppress: true,
+};
+
+export const RAPP_MESSAGE_PRESENTATION: DeltaPresentation = {
+  label: {
+    pending: "Thinking through RAPP",
+    completed: "Answered through RAPP",
+  },
+  icon: { glyph: "Brain" },
+};

--- a/plugins/provider-rapp/src/vocabulary.ts
+++ b/plugins/provider-rapp/src/vocabulary.ts
@@ -13,6 +13,10 @@ export const RAPP_BRAINSTEM_SECRET_ENV = "RAPP_BRAINSTEM_SECRET";
 export const RAPP_BUSINESS_URL_ENV = "RAPP_BUSINESS_URL";
 export const RAPP_FUNCTION_KEY_ENV = "RAPP_FUNCTION_KEY";
 export const RAPP_USER_GUID_ENV = "RAPP_USER_GUID";
+export const RAPP_CONSUMER_REASONING_DESCRIPTION =
+  "RAPP Brainstem owns GitHub Copilot reasoning and execution.";
+export const RAPP_BUSINESS_REASONING_DESCRIPTION =
+  "The configured Business RAPP deployment owns reasoning and execution.";
 
 export const rappGrailSchema = z.enum(["consumer", "business"]);
 export type RappGrail = z.infer<typeof rappGrailSchema>;
@@ -86,8 +90,7 @@ export const RAPP_BRAINSTEM_MODEL = {
   supportedReasoningEfforts: [
     {
       reasoningEffort: "none",
-      description:
-        "RAPP Brainstem owns GitHub Copilot reasoning and execution.",
+      description: RAPP_CONSUMER_REASONING_DESCRIPTION,
     },
   ],
   defaultReasoningEffort: "none",
@@ -102,8 +105,7 @@ export const RAPP_BUSINESS_MODEL = {
   supportedReasoningEfforts: [
     {
       reasoningEffort: "none",
-      description:
-        "RAPP Brainstem owns GitHub Copilot reasoning and execution.",
+      description: RAPP_BUSINESS_REASONING_DESCRIPTION,
     },
   ],
   defaultReasoningEffort: "none",

--- a/plugins/provider-rapp/src/vocabulary.ts
+++ b/plugins/provider-rapp/src/vocabulary.ts
@@ -17,7 +17,8 @@ export const RAPP_USER_GUID_ENV = "RAPP_USER_GUID";
 export const rappGrailSchema = z.enum(["consumer", "business"]);
 export type RappGrail = z.infer<typeof rappGrailSchema>;
 
-const secretQueryKey = /(code|token|secret|key|password)/iu;
+export const RAPP_ENDPOINT_URL_REQUIREMENTS =
+  "Use an HTTP(S) RAPP endpoint without URL credentials, query parameters, or fragments; put credentials in the documented host environment variables and routing in the documented endpoint path";
 
 export const rappEndpointSettingSchema = z.string().refine((value) => {
   const trimmed = value.trim();
@@ -32,13 +33,11 @@ export const rappEndpointSettingSchema = z.string().refine((value) => {
     if (url.username !== "" || url.password !== "") {
       return false;
     }
-    return [...url.searchParams.keys()].every(
-      (key) => !secretQueryKey.test(key),
-    );
+    return url.search === "" && url.hash === "";
   } catch {
     return false;
   }
-}, "Use an HTTP(S) URL without credentials or secret-bearing query parameters");
+}, RAPP_ENDPOINT_URL_REQUIREMENTS);
 
 export const rappPluginSettingsSchema = z.object({
   grail: rappGrailSchema,

--- a/plugins/provider-rapp/src/vocabulary.ts
+++ b/plugins/provider-rapp/src/vocabulary.ts
@@ -99,7 +99,7 @@ export const RAPP_BUSINESS_MODEL = {
   id: RAPP_BUSINESS_MODEL_ID,
   displayName: "Business Grail",
   description:
-    "Use the fixed managed GitHub Copilot model selected by the Business RAPP Brainstem deployment.",
+    "Use the fixed managed model owned by the configured Business RAPP deployment.",
   supportedReasoningEfforts: [
     {
       reasoningEffort: "none",

--- a/plugins/provider-rapp/tsconfig.json
+++ b/plugins/provider-rapp/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM"],
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["*.ts", "src"]
+}

--- a/plugins/provider-rapp/vitest.config.ts
+++ b/plugins/provider-rapp/vitest.config.ts
@@ -1,0 +1,15 @@
+import {
+  defineWorkspaceTestConfig,
+  sharedWorkerProjects,
+} from "../../vitest.shared.js";
+
+export default defineWorkspaceTestConfig({
+  test: {
+    silent: "passed-only",
+    projects: sharedWorkerProjects({
+      pkgDir: __dirname,
+      name: "bb-plugin-provider-rapp",
+      include: ["*.test.ts", "src/**/*.test.ts"],
+    }),
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3539,6 +3539,28 @@ importers:
         specifier: ^4.1.1
         version: 4.1.1(@opentelemetry/api@1.9.1)(@types/node@22.19.10)(jsdom@29.0.1(@noble/hashes@2.4.0))(msw@2.12.14(@types/node@22.19.10)(@typescript/typescript6@6.0.2))(vite@8.0.12(@types/node@22.19.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.1)(yaml@2.9.0))
 
+  plugins/provider-rapp:
+    dependencies:
+      '@get-bb/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+      zod:
+        specifier: 4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.10
+      typescript:
+        specifier: npm:@typescript/typescript6@^6.0.2
+        version: '@typescript/typescript6@6.0.2'
+      typescript-7:
+        specifier: npm:typescript@^7.0.2
+        version: typescript@7.0.2
+      vitest:
+        specifier: ^4.1.1
+        version: 4.1.1(@opentelemetry/api@1.9.1)(@types/node@22.19.10)(jsdom@29.0.1(@noble/hashes@2.4.0))(msw@2.12.14(@types/node@22.19.10)(@typescript/typescript6@6.0.2))(vite@8.0.12(@types/node@22.19.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.1)(yaml@2.9.0))
+
   plugins/provider-retry:
     dependencies:
       zod:

--- a/scripts/check-provider-literal-ratchet.mjs
+++ b/scripts/check-provider-literal-ratchet.mjs
@@ -12,7 +12,7 @@
  * guard are deleted.
  *
  * Scope: provider-*id* references only — quoted id literals (`"codex"`,
- * `"claude-code"`, `"pi"`, `"acp-…"`, `"cursor"`) and the named id
+ * `"claude-code"`, `"pi"`, `"rapp"`, `"acp-…"`) and the named id
  * constants/helpers (`isAcpProviderId`, `CODEX_PROVIDER_ID`,
  * `RESERVED_PROVIDER_ID_OWNERS`, …). Tool-name keying (thread-view's
  * Read/Task/TodoWrite tables) is retired by its own workstream and would add
@@ -96,7 +96,7 @@ export function providerLiteralRegex() {
       // quoted provider-id literals (acp-* allows the bare `"acp-"` of
       // startsWith). The Cursor agent's id is `acp-cursor`; a bare `"cursor"`
       // is an editor id or a pagination cursor, never a provider.
-      String.raw`["'](?:codex|claude-code|pi|acp-[a-z0-9-]*)["']`,
+      String.raw`["'](?:codex|claude-code|pi|rapp|acp-[a-z0-9-]*)["']`,
       // named id constants / helpers
       String.raw`\bisAcpProviderId\b`,
       String.raw`\bACP_ID_PREFIX\b`,

--- a/turbo.json
+++ b/turbo.json
@@ -489,6 +489,10 @@
       ],
       "inputs": [
         "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/plugins/provider-*/**",
+        "!$TURBO_ROOT$/plugins/provider-*/dist/**",
+        "!$TURBO_ROOT$/plugins/provider-*/node_modules/**",
+        "!$TURBO_ROOT$/plugins/provider-*/.turbo/**",
         "$TURBO_ROOT$/plugins/*/skills/**",
         "$TURBO_ROOT$/tests/scripted-echo-provider/host.ts",
         "$TURBO_ROOT$/tests/scripted-echo-provider/src/**",
@@ -542,6 +546,10 @@
       "inputs": [
         "$TURBO_DEFAULT$",
         "$TURBO_ROOT$/vitest.shared.ts",
+        "$TURBO_ROOT$/plugins/provider-*/**",
+        "!$TURBO_ROOT$/plugins/provider-*/dist/**",
+        "!$TURBO_ROOT$/plugins/provider-*/node_modules/**",
+        "!$TURBO_ROOT$/plugins/provider-*/.turbo/**",
         "$TURBO_ROOT$/plugins/*/icons/**",
         "$TURBO_ROOT$/examples/plugins/*/icons/**"
       ]
@@ -593,7 +601,27 @@
         "@get-bb/plugin-sdk#build",
         "topo"
       ],
-      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/vitest.shared.ts"]
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/plugins/provider-*/**",
+        "!$TURBO_ROOT$/plugins/provider-*/dist/**",
+        "!$TURBO_ROOT$/plugins/provider-*/node_modules/**",
+        "!$TURBO_ROOT$/plugins/provider-*/.turbo/**",
+        "$TURBO_ROOT$/vitest.shared.ts"
+      ]
+    },
+    "@bb/provider-parity#test": {
+      "dependsOn": ["//#ensure-native-modules", "topo"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/packages/provider-bridge-protocol/recordings/**",
+        "$TURBO_ROOT$/plugins/provider-*/**",
+        "!$TURBO_ROOT$/plugins/provider-*/dist/**",
+        "!$TURBO_ROOT$/plugins/provider-*/node_modules/**",
+        "!$TURBO_ROOT$/plugins/provider-*/.turbo/**",
+        "$TURBO_ROOT$/vitest.shared.ts"
+      ],
+      "passThroughEnv": ["UPDATE_PARITY_ROW_COUNTS"]
     },
     "smoke:tarball": {
       "dependsOn": ["build"],
@@ -617,6 +645,10 @@
         "$TURBO_ROOT$/packages/templates/package.json",
         "$TURBO_ROOT$/packages/templates/scripts/**",
         "$TURBO_ROOT$/packages/templates/src/**",
+        "$TURBO_ROOT$/plugins/provider-*/**",
+        "!$TURBO_ROOT$/plugins/provider-*/dist/**",
+        "!$TURBO_ROOT$/plugins/provider-*/node_modules/**",
+        "!$TURBO_ROOT$/plugins/provider-*/.turbo/**",
         "$TURBO_ROOT$/tests/scripted-echo-provider/host.ts",
         "$TURBO_ROOT$/tests/scripted-echo-provider/src/**",
         "$TURBO_ROOT$/vitest.shared.ts"
@@ -655,6 +687,10 @@
         "$TURBO_ROOT$/packages/templates/package.json",
         "$TURBO_ROOT$/packages/templates/scripts/**",
         "$TURBO_ROOT$/packages/templates/src/**",
+        "$TURBO_ROOT$/plugins/provider-*/**",
+        "!$TURBO_ROOT$/plugins/provider-*/dist/**",
+        "!$TURBO_ROOT$/plugins/provider-*/node_modules/**",
+        "!$TURBO_ROOT$/plugins/provider-*/.turbo/**",
         "$TURBO_ROOT$/tests/scripted-echo-provider/host.ts",
         "$TURBO_ROOT$/tests/scripted-echo-provider/src/**",
         "$TURBO_ROOT$/vitest.shared.ts"
@@ -679,6 +715,10 @@
         "$TURBO_ROOT$/packages/templates/package.json",
         "$TURBO_ROOT$/packages/templates/scripts/**",
         "$TURBO_ROOT$/packages/templates/src/**",
+        "$TURBO_ROOT$/plugins/provider-*/**",
+        "!$TURBO_ROOT$/plugins/provider-*/dist/**",
+        "!$TURBO_ROOT$/plugins/provider-*/node_modules/**",
+        "!$TURBO_ROOT$/plugins/provider-*/.turbo/**",
         "$TURBO_ROOT$/vitest.shared.ts"
       ]
     },
@@ -815,6 +855,9 @@
       "dependsOn": ["@get-bb/plugin-sdk#build:types", "topo"]
     },
     "bb-plugin-provider-pi#typecheck": {
+      "dependsOn": ["@get-bb/plugin-sdk#build:types", "topo"]
+    },
+    "bb-plugin-provider-rapp#typecheck": {
       "dependsOn": ["@get-bb/plugin-sdk#build:types", "topo"]
     },
     "bb-plugin-provider-retry#typecheck": {


### PR DESCRIPTION
## Human comments

## What was wrong

bb had no first-class adapter for RAPP Brainstem, so a bb thread could not use Brainstem's GitHub Copilot authentication, dynamic model catalog, soul, agents, fallback, and restart-safe RAPP/1 session state through the normal provider, CLI, and SDK surfaces.

## What changed

Added the bundled `rapp` provider for the Consumer and Business Grails. Consumer mode reuses or safely starts the shared local Brainstem, discovers its verified GitHub Copilot models, serializes process-global model selection with `/chat`, and persists canonical content-addressed RAPP/1 session eggs. Business mode adapts the Azure Function endpoint as the fixed logical `business-grail` model while leaving unavailable raw model attribution null.

The bridge rejects credential-bearing/query/fragment endpoint URLs, refuses redirects, bounds response reads, validates UTF-8, manages only IPv4 localhost Brainstems it owns, and journals completed responses before thread delivery. It caps responses at 64 KiB and preflights RAPP/1's 1 MiB complete-transcript egg limit before remote execution. Because older Brainstems accept but do not enforce `idempotency_key`, an ambiguous request is retained for audit and never replayed automatically.

Registered RAPP across built-in provider inventories, packed host/server artifact gates, provider parity policy, plugin API maps, configuration, CLI/guide documentation, and the generic SDK surfaces. Explicit models now receive provider-compatible execution defaults, fixing providers whose supported reasoning ladder does not include bb's global `medium` default. No host-daemon wire contract changed: this reuses the existing plugin artifact, opaque provider options, environment passthrough, and generic runtime commands, so `HOST_DAEMON_PROTOCOL_VERSION` remains unchanged.

## How you verified

- `pnpm exec turbo run test typecheck --filter=bb-plugin-provider-rapp --force` — 87 tests passed and typecheck passed.
- Targeted `@bb/server` marketplace, provider registration, defaults, built-in plugin, execution option, provider state, and runtime configuration suites — 173 tests passed; server typecheck passed.
- Targeted `@bb/config` managed configuration suite — 20 tests passed.
- Built-in host/server artifact and SVG suites passed 88 tests; provider parity passed 57; plugin API map passed 4; provider literal ratchet passed 21; targeted CLI suites passed 63; the real agent-runtime RAPP artifact test passed.
- Turbo typechecks passed for `@bb/agent-runtime`, `@bb/cli`, `@bb/config`, `@bb/plugin-api-map`, `@bb/plugin-build`, `@bb/provider-bridge-protocol`, `@bb/provider-parity`, `@bb/scripts`, `@bb/server`, `@bb/templates`, `bb-app`, and the RAPP provider.
- `pnpm exec turbo run smoke:tarball --filter=bb-app --force` built the packaged app and passed its tarball smoke, including the packed RAPP host artifact and live fake-Brainstem catalog proof.
- Live local bb → RAPP Brainstem → GitHub Copilot thread `thr_ckhwbym9uu` returned exactly `RAPP final smoke works.` with effective reasoning `none`; persisted RAPP/1 state recorded selected/requested/actual model `gpt-5-mini` and a content-addressed session egg.

Fixes: N/A — direct integration request.

> AGENT GENERATED
