### PR TITLE
Document safe BB CLI automation workflows

### DIFF
--- a/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
@@ -49,6 +49,8 @@ BB_HOST_DAEMON_PORT only for an intentional non-default target.
 - Pass an environment or machine selector when the default host is uncertain.
 - Query provider models on the machine that will run the thread.
 - Prefer non-interactive commands and machine-readable output for automation.
+- Treat each `--json` command as its own schema. Inspect its top-level type
+  before filtering, and do not infer an envelope from another command.
 - Pass `--yes` for a confirmed destructive command in a non-interactive shell.
 - Treat plugin commands as normal top-level commands after installation.
 

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/references/thread-creation.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/references/thread-creation.md
@@ -7,9 +7,18 @@
   context variables. Omitted execution flags use remembered project defaults;
   without a remembered model, bb resolves the selected provider and its reported
   default model on the target machine.
+- Do not put generated prompt text in shell source. Stage generated Markdown in
+  a file and pass it as one quoted argument:
+  `bb thread spawn --project <project-id> --prompt "$(cat "$file")"`.
+  This remains subject to the shell's argument-size limit.
 - Select a target with `--environment`, `--new-environment`, `--base-branch`,
   or `--machine`. Select execution with `--provider`, `--model`,
   `--reasoning-level`, `--service-tier`, and `--permission-mode`.
+- Before setting `--permission-mode`, inspect the selected provider on the
+  target environment or machine. Run
+  `bb provider list --environment <id> --json`, or use the matching `--machine`
+  selector, then read the provider's `capabilities.permissionModes`. Do not
+  assume every provider supports every public mode.
 - Omit `--base-branch` for bb's default. Explicit values are exact; use
   `origin/<branch>` for a remote ref.
 - Spawn also accepts `--title`, `--origin-kind`, `--source-thread`,

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/references/thread-operation.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/references/thread-operation.md
@@ -12,6 +12,10 @@
 <seconds>` when you need a shorter or longer budget.
 - Use `bb thread tell <thread-id> "..."` when requirements change, a blocker
   needs clarification, or follow-up work is needed.
+- Do not put generated message text in shell source. Stage generated Markdown
+  in a file and pass it as one quoted argument:
+  `bb thread tell <thread-id> -- "$(cat "$file")"`. This remains subject to
+  the shell's argument-size limit.
 - Add `--plan` to `bb thread spawn` or `bb thread tell` to send the prompt as
   the provider's structured `/plan` action: the agent proposes a plan for
   approval before executing when supported by the provider. Plain `/plan ...` text is
@@ -60,6 +64,10 @@
   reaches the sidebar as a clock on any thread that holds queued work and is not
   running (the failure glyph instead if a drain attempt failed); a thread list
   entry carries it as `queuedWork: "none" | "waiting" | "failed"`.
+- Use `bb thread tell <thread-id> "..." --mode queue` for agent-to-agent
+  delivery that can wait. It preserves the caller's thread ID as sender
+  attribution. `bb thread queue create` creates an unattributed queued draft;
+  do not use it for agent reports.
 - Use `bb thread count` when you need how many threads there are, never a list
   plus a row count: the count is a database aggregate, while `bb thread list`
   pages a bounded window and would miscount. Narrow with `--status
@@ -145,9 +153,13 @@ For review or fix pipelines, get the environment ID from
 
 ## Long-Running Commands
 
-- Use `bb terminal ...` for long-running commands the user may need to inspect
-  or stop later: dev servers, watch tasks, REPLs, database consoles, and similar
-  processes. The terminal is a real persistent PTY shown in the bb UI.
+- Use `bb terminal ...` for interactive commands and processes the user needs
+  to inspect or stop later: dev servers, watch tasks, REPLs, database consoles,
+  and similar processes. The terminal is a real persistent PTY shown in the bb
+  UI.
+- Native terminal output is available only while the session is running. When
+  output must survive process exit, make the command write it to a durable
+  file. `bb terminal output` cannot recover completed scrollback.
 - `list` and `create` require exactly one explicit scope: `--thread <id>`,
   `--environment <id>`, or `--machine <id-or-name>` (`--host` is an alias).
   Add `--cwd <path>` only to a machine scope. Machine targets resolve to an


### PR DESCRIPTION
## Human comments

## What was wrong

The built-in `bb-cli` skill did not explain five current operating contracts that live help alone does not make safe for automation: argv-only generated message text, per-command JSON shapes, provider-specific permission modes, sender attribution for queued agent messages, and terminal output loss after process exit. A Papercut triage found 65 original occurrences across these five patterns.

## What changed

- Adds quoted staged-file forms for generated `thread spawn` and `thread tell` text, including the shell argument-size limit.
- Tells callers to inspect each command's JSON shape and the selected provider's live permission capabilities.
- Directs queued agent-to-agent reports through `thread tell --mode queue`, which preserves sender attribution, instead of an unattributed queue draft.
- Separates interactive, user-inspectable native terminals from output that must survive process exit.

This intentionally omits the earlier errored-thread workaround because #2715 fixed default `thread tell` recovery before this change.

## How you verified

Reviewed installed BB 0.41.0 help and behavior, then checked current `main` at `cffc82ad4db651f6dad600db33528df4e87348eb` against the command registrations, thread-send logic, queued-message sender handling, provider capabilities, and terminal output lifecycle.

- Focused skill tests — 17 passed
- Turbo CLI/server tests — 280 files and 2,705 tests passed; 1 file skipped
- Turbo CLI/server typecheck — 6 tasks passed
- `git diff --check`

Related to #2620, #2622, and #2520.

> AGENT GENERATED
