### PR TITLE
Add in-app plugin author pages

### DIFF
--- a/apps/app/src/components/plugin/PluginsOverview.tsx
+++ b/apps/app/src/components/plugin/PluginsOverview.tsx
@@ -24,6 +24,7 @@ import {
 import { BrowsePluginsTab } from "@/components/plugin/management/BrowsePluginsTab";
 import { CheckPluginUpdatesButton } from "@/components/plugin/management/CheckPluginUpdatesButton";
 import { InstalledPluginsTab } from "@/components/plugin/management/InstalledPluginsTab";
+import { PluginAuthorPage } from "@/components/plugin/management/PluginAuthorPage";
 import {
   pluginPublisherFilterId,
   pluginPublisherFilterOptions,
@@ -55,6 +56,7 @@ export function PluginsOverview({
     [listQuery.data?.plugins],
   );
   const activeMode = modeFromSearchParams(searchParams.get("view"));
+  const authorKey = searchParams.get("author");
   const [installedQuery, setInstalledQuery] = useState("");
   const [installedViewport, setInstalledViewport] =
     useState<HTMLDivElement | null>(null);
@@ -166,16 +168,25 @@ export function PluginsOverview({
 
   let content: ReactNode;
   if (activeMode === "browse") {
-    content = (
-      <BrowsePluginsTab
-        onInstall={(initial) => setAddDialog({ open: true, initial })}
-        onOpenPlugin={
-          onOpenPlugin ??
-          ((pluginId) => navigate(getPluginDetailRoutePath({ pluginId })))
-        }
-        onInstallFromSource={() => setAddDialog({ open: true, initial: null })}
-      />
-    );
+    const openPlugin =
+      onOpenPlugin ??
+      ((pluginId: string) => navigate(getPluginDetailRoutePath({ pluginId })));
+    content =
+      authorKey === null ? (
+        <BrowsePluginsTab
+          onInstall={(initial) => setAddDialog({ open: true, initial })}
+          onOpenPlugin={openPlugin}
+          onInstallFromSource={() =>
+            setAddDialog({ open: true, initial: null })
+          }
+        />
+      ) : (
+        <PluginAuthorPage
+          authorKey={authorKey}
+          onInstall={(initial) => setAddDialog({ open: true, initial })}
+          onOpenPlugin={openPlugin}
+        />
+      );
   } else {
     content = (
       <ResourceCollectionViewport

--- a/apps/app/src/components/plugin/management/BrowsePluginsTab.test.tsx
+++ b/apps/app/src/components/plugin/management/BrowsePluginsTab.test.tsx
@@ -186,6 +186,25 @@ describe("BrowsePluginsTab", () => {
     expect(params.get("query")).toBe("Memory");
   });
 
+  it("routes the card author name and preserves the Browse filters", async () => {
+    const onOpenPlugin = vi.fn();
+    renderBrowse(
+      { entries: [MEMORY_ENTRY], collections: [] },
+      "/extensions/plugins?category=memory-and-context&sort=recently-added",
+      vi.fn(),
+      onOpenPlugin,
+    );
+
+    fireEvent.click(await screen.findByRole("link", { name: "BB" }));
+    const params = new URLSearchParams(
+      screen.getByTestId("location-search").textContent ?? "",
+    );
+    expect(params.get("author")).toBe("11:bb-official:github:get-bb");
+    expect(params.getAll("category")).toEqual(["memory-and-context"]);
+    expect(params.get("sort")).toBe("recently-added");
+    expect(onOpenPlugin).not.toHaveBeenCalled();
+  });
+
   it("round trips repeatable category parameters", async () => {
     renderBrowse(
       { entries: [MEMORY_ENTRY, SECURITY_ENTRY, TASKS_ENTRY], collections: [] },

--- a/apps/app/src/components/plugin/management/BrowsePluginsTab.test.tsx
+++ b/apps/app/src/components/plugin/management/BrowsePluginsTab.test.tsx
@@ -36,7 +36,11 @@ const MEMORY_ENTRY: PluginCatalogSearchEntry = {
   publisherKey: "bb-official",
   publisherLabel: "BB Official",
   official: true,
-  author: { name: "BB", url: "https://github.com/get-bb" },
+  author: {
+    name: "BB",
+    github: "get-bb",
+    url: "https://github.com/get-bb",
+  },
   installed: false,
   installs: 4_210,
   compatible: true,

--- a/apps/app/src/components/plugin/management/BrowsePluginsTab.tsx
+++ b/apps/app/src/components/plugin/management/BrowsePluginsTab.tsx
@@ -32,7 +32,9 @@ import {
   type PluginCatalogSearchEntry,
 } from "@/hooks/queries/plugin-catalog-queries";
 import type { AddPluginInitial } from "./AddPluginDialog";
-import { PluginAuthorAvatar, pluginAuthorGithub } from "./PluginAuthorAvatar";
+import { PluginAuthorAvatar } from "./PluginAuthorAvatar";
+import { PluginAuthorLink } from "./PluginAuthorLink";
+import { pluginAuthorGithub } from "./plugin-marketplace-author";
 import {
   PluginBrowseCategoryFilter,
   pluginBrowseSort,
@@ -418,7 +420,7 @@ function BrowseShelf({
   );
 }
 
-function PluginCatalogGrid({
+export function PluginCatalogGrid({
   entries,
   showCategory,
   onInstall,
@@ -477,7 +479,19 @@ function PluginCatalogCard({
             github={pluginAuthorGithub(entry.author)}
             size="detail"
           />
-          <span className="truncate">By {authorName}</span>
+          <span className="truncate">
+            By{" "}
+            {entry.author === null ? (
+              authorName
+            ) : (
+              <PluginAuthorLink
+                entry={entry}
+                className="pointer-events-auto relative z-10 rounded-sm underline underline-offset-2 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              >
+                {authorName}
+              </PluginAuthorLink>
+            )}
+          </span>
         </span>
       }
       footerMeta={

--- a/apps/app/src/components/plugin/management/BrowsePluginsTab.tsx
+++ b/apps/app/src/components/plugin/management/BrowsePluginsTab.tsx
@@ -98,7 +98,7 @@ export function BrowsePluginsTab({
   const sort =
     requestedSort === "most-installed" && !installsKnown ? null : requestedSort;
   const categoryOptions = useMemo(
-    () => categoryFilterOptions(entries, selectedCategories),
+    () => pluginCategoryFilterOptions(entries, selectedCategories),
     [entries, selectedCategories],
   );
   const filteredEntries = useMemo(() => {
@@ -314,7 +314,7 @@ export function BrowsePluginsTab({
   );
 }
 
-function categoryFilterOptions(
+export function pluginCategoryFilterOptions(
   entries: readonly PluginCatalogSearchEntry[],
   selected: readonly string[],
 ): PluginBrowseCategoryOption[] {

--- a/apps/app/src/components/plugin/management/PluginAuthorAvatar.tsx
+++ b/apps/app/src/components/plugin/management/PluginAuthorAvatar.tsx
@@ -1,22 +1,5 @@
 import { Avatar, AvatarFallback, AvatarImage } from "@bb/shared-ui/avatar";
 import { cn } from "@bb/shared-ui/lib/utils";
-import type { PluginCatalogAuthor } from "@bb/server-contract";
-
-export function pluginAuthorGithub(
-  author: PluginCatalogAuthor | null,
-): string | null {
-  if (author?.url === null || author?.url === undefined) return null;
-  try {
-    const url = new URL(author.url);
-    if (url.hostname !== "github.com" && url.hostname !== "www.github.com") {
-      return null;
-    }
-    const [github] = url.pathname.split("/").filter(Boolean);
-    return github ?? null;
-  } catch {
-    return null;
-  }
-}
 
 function authorInitials(name: string): string {
   const initials = name

--- a/apps/app/src/components/plugin/management/PluginAuthorAvatar.tsx
+++ b/apps/app/src/components/plugin/management/PluginAuthorAvatar.tsx
@@ -36,6 +36,7 @@ export function PluginAuthorAvatar({
           src={`https://github.com/${github}.png?size=${size === "detail" ? 40 : 80}`}
           alt=""
           loading="lazy"
+          referrerPolicy="no-referrer"
         />
       )}
       <AvatarFallback

--- a/apps/app/src/components/plugin/management/PluginAuthorLink.tsx
+++ b/apps/app/src/components/plugin/management/PluginAuthorLink.tsx
@@ -1,0 +1,42 @@
+import { Link, useLocation } from "react-router-dom";
+import type { ReactNode } from "react";
+import type { PluginCatalogSearchEntry } from "@/hooks/queries/plugin-catalog-queries";
+import { getPluginsRoutePath } from "@/lib/route-paths";
+import { pluginMarketplaceAuthorKey } from "./plugin-marketplace-author";
+
+export function pluginAuthorPageSearch(
+  search: string,
+  authorKey: string,
+): string {
+  const params = new URLSearchParams(search);
+  params.delete("view");
+  params.set("author", authorKey);
+  const next = params.toString();
+  return next === "" ? "" : `?${next}`;
+}
+
+export function PluginAuthorLink({
+  entry,
+  className,
+  children,
+}: {
+  entry: Pick<PluginCatalogSearchEntry, "author" | "marketplace">;
+  className?: string;
+  children: ReactNode;
+}) {
+  const location = useLocation();
+  const authorKey = pluginMarketplaceAuthorKey(entry);
+  if (authorKey === null) return <>{children}</>;
+  return (
+    <Link
+      to={{
+        pathname: getPluginsRoutePath(),
+        search: pluginAuthorPageSearch(location.search, authorKey),
+      }}
+      className={className}
+      onClick={(event) => event.stopPropagation()}
+    >
+      {children}
+    </Link>
+  );
+}

--- a/apps/app/src/components/plugin/management/PluginAuthorPage.test.tsx
+++ b/apps/app/src/components/plugin/management/PluginAuthorPage.test.tsx
@@ -1,0 +1,184 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter, useLocation } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { PluginCatalogSearchEntry } from "@/hooks/queries/plugin-catalog-queries";
+import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
+import { PluginAuthorPage } from "./PluginAuthorPage";
+
+function catalogEntry(
+  pluginId: string,
+  overrides: Partial<PluginCatalogSearchEntry> = {},
+): PluginCatalogSearchEntry {
+  return {
+    entryId: pluginId,
+    pluginId,
+    displayName: pluginId,
+    description: `${pluginId} description`,
+    icon: "Zap",
+    iconUrl: null,
+    iconTinted: false,
+    categoryId: "thread-content",
+    category: "Thread Content",
+    screenshots: [],
+    collections: [],
+    publishedAt: "2026-08-01T00:00:00Z",
+    source: `npm:${pluginId}`,
+    repositoryUrl: null,
+    marketplace: "bb-community",
+    marketplaceDisplayName: "BB Community",
+    publisherKey: "bb-community",
+    publisherLabel: "BB Community",
+    official: true,
+    author: { name: "Pat Lee", url: "https://github.com/patlee" },
+    installed: false,
+    installs: 10,
+    compatible: true,
+    incompatibleReason: null,
+    ...overrides,
+  };
+}
+
+const ALPHA = catalogEntry("Alpha", { installs: null });
+const BETA = catalogEntry("Beta", {
+  author: { name: "Patricia Lee", url: "https://github.com/PatLee" },
+  categoryId: "security",
+  category: "Security",
+  publishedAt: "2026-08-20T00:00:00Z",
+  installs: 50,
+});
+const GAMMA = catalogEntry("Gamma", {
+  publishedAt: undefined,
+  installs: 100,
+});
+const OTHER = catalogEntry("Other", {
+  author: { name: "Pat Lee", url: null },
+});
+
+function LocationProbe() {
+  const location = useLocation();
+  return (
+    <output data-testid="location">{`${location.pathname}${location.search}`}</output>
+  );
+}
+
+function cardOrder(): string[] {
+  return [
+    ...document.querySelectorAll<HTMLButtonElement>(
+      'button[aria-label^="Open "][aria-label$=" details"]',
+    ),
+  ].map((button) => button.getAttribute("aria-label") ?? "");
+}
+
+function renderPage(initialEntry: string, onOpenPlugin = vi.fn()) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            results: [GAMMA, OTHER, BETA, ALPHA],
+            collections: [],
+          }),
+          { headers: { "content-type": "application/json" } },
+        ),
+    ),
+  );
+  const { wrapper } = createQueryClientTestHarness();
+  render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <PluginAuthorPage
+        authorKey="12:bb-community:github:patlee"
+        onInstall={() => undefined}
+        onOpenPlugin={onOpenPlugin}
+      />
+      <LocationProbe />
+    </MemoryRouter>,
+    { wrapper },
+  );
+  return onOpenPlugin;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("PluginAuthorPage", () => {
+  it("restores the URL and shows only the selected author's plugins", async () => {
+    renderPage(
+      "/extensions/plugins?author=12%3Abb-community%3Agithub%3Apatlee&sort=recently-added&direction=asc",
+    );
+
+    expect(
+      await screen.findByRole("heading", { name: /^Pat Lee/u }),
+    ).toBeTruthy();
+    expect(screen.getByText("3 plugins")).toBeTruthy();
+    expect(
+      screen
+        .getByRole("link", { name: /github\.com\/patlee/u })
+        .getAttribute("href"),
+    ).toBe("https://github.com/patlee");
+    expect(cardOrder()).toEqual([
+      "Open Alpha details",
+      "Open Beta details",
+      "Open Gamma details",
+    ]);
+    expect(screen.queryByText("Other")).toBeNull();
+    expect(screen.getByTestId("location").textContent).toContain(
+      "author=12%3Abb-community%3Agithub%3Apatlee",
+    );
+  });
+
+  it("applies search, multiple categories, and both optional-value sorts", async () => {
+    const onOpenPlugin = renderPage(
+      "/extensions/plugins?author=12%3Abb-community%3Agithub%3Apatlee&sort=most-installed",
+    );
+
+    await screen.findByRole("heading", { name: /^Pat Lee/u });
+    expect(cardOrder()).toEqual([
+      "Open Gamma details",
+      "Open Beta details",
+      "Open Alpha details",
+    ]);
+    const sort = screen.getByRole("button", {
+      name: "Sort: Most installed, descending",
+    });
+    fireEvent.pointerDown(sort);
+    fireEvent.click(
+      screen.getByRole("menuitemradio", { name: "Most installed" }),
+    );
+    expect(cardOrder()).toEqual([
+      "Open Beta details",
+      "Open Gamma details",
+      "Open Alpha details",
+    ]);
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Filter plugins by category: All categories",
+      }),
+    );
+    fireEvent.click(screen.getByRole("option", { name: /Thread Content/u }));
+    expect(cardOrder()).toEqual(["Open Gamma details", "Open Alpha details"]);
+    fireEvent.click(screen.getByRole("option", { name: /Security/u }));
+    expect(cardOrder()).toEqual([
+      "Open Beta details",
+      "Open Gamma details",
+      "Open Alpha details",
+    ]);
+    fireEvent.click(screen.getByRole("button", { name: "Clear filter" }));
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Search plugins" }), {
+      target: { value: "Beta" },
+    });
+    expect(cardOrder()).toEqual(["Open Beta details"]);
+    const beta = screen.getByRole("button", { name: "Open Beta details" });
+    fireEvent.click(beta);
+    expect(onOpenPlugin).toHaveBeenCalledWith("Beta", beta);
+    expect(screen.getByTestId("location").textContent).toContain("query=Beta");
+  });
+});

--- a/apps/app/src/components/plugin/management/PluginAuthorPage.test.tsx
+++ b/apps/app/src/components/plugin/management/PluginAuthorPage.test.tsx
@@ -50,6 +50,16 @@ function catalogEntry(
   };
 }
 
+function catalogEntryForAuthor(pluginId: string, name: string) {
+  return catalogEntry(pluginId, {
+    author: {
+      name,
+      github: "patlee",
+      url: "https://github.com/patlee",
+    },
+  });
+}
+
 const ALPHA = catalogEntry("Alpha", { installs: null });
 const BETA = catalogEntry("Beta", {
   author: {
@@ -85,7 +95,16 @@ function cardOrder(): string[] {
   ].map((button) => button.getAttribute("aria-label") ?? "");
 }
 
-function renderPage(initialEntry: string, onOpenPlugin = vi.fn()) {
+function renderPage(
+  initialEntry: string,
+  onOpenPlugin = vi.fn(),
+  catalogEntries: readonly PluginCatalogSearchEntry[] = [
+    GAMMA,
+    OTHER,
+    BETA,
+    ALPHA,
+  ],
+) {
   vi.stubGlobal(
     "fetch",
     vi.fn(async (input: RequestInfo | URL) => {
@@ -101,7 +120,7 @@ function renderPage(initialEntry: string, onOpenPlugin = vi.fn()) {
       const results =
         query === "Beta" || query === "agent-interaction"
           ? [BETA]
-          : [GAMMA, OTHER, BETA, ALPHA];
+          : catalogEntries;
       return new Response(
         JSON.stringify({
           results,
@@ -133,6 +152,60 @@ afterEach(() => {
 });
 
 describe("PluginAuthorPage", () => {
+  it("aligns the author header with the toolbar and card grid", async () => {
+    renderPage(
+      "/extensions/plugins?author=12%3Abb-community%3Agithub%3Apatlee",
+    );
+
+    await screen.findByRole("heading", { name: /^Pat Lee/u });
+    const headerContainer = screen
+      .getByRole("link", { name: "Browse plugins" })
+      .closest(".max-w-3xl");
+    const toolbarContainer = screen
+      .getByRole("textbox", { name: "Search plugins" })
+      .closest(".max-w-3xl");
+    const gridContainer = screen
+      .getByRole("button", { name: "Open Alpha details" })
+      .closest(".max-w-3xl");
+    for (const container of [
+      headerContainer,
+      toolbarContainer,
+      gridContainer,
+    ]) {
+      expect(container?.classList.contains("mx-auto")).toBe(true);
+      expect(container?.classList.contains("w-full")).toBe(true);
+    }
+  });
+
+  it.each([
+    {
+      rule: "frequency before length",
+      entries: [
+        catalogEntryForAuthor("Long", "Divyesh Puri"),
+        catalogEntryForAuthor("Short One", "Divyesh"),
+        catalogEntryForAuthor("Short Two", "Divyesh"),
+      ],
+      expected: "Divyesh",
+    },
+    {
+      rule: "length for equal counts",
+      entries: [
+        catalogEntryForAuthor("Short", "Divyesh"),
+        catalogEntryForAuthor("Long", "Divyesh Puri"),
+      ],
+      expected: "Divyesh Puri",
+    },
+  ])("selects an author name by $rule", async ({ entries, expected }) => {
+    renderPage(
+      "/extensions/plugins?author=12%3Abb-community%3Agithub%3Apatlee",
+      vi.fn(),
+      entries,
+    );
+
+    const heading = await screen.findByRole("heading");
+    expect(heading.firstElementChild?.textContent).toBe(expected);
+  });
+
   it("restores the URL and shows only the selected author's plugins", async () => {
     renderPage(
       "/extensions/plugins?author=12%3Abb-community%3Agithub%3Apatlee&sort=recently-added&direction=asc",

--- a/apps/app/src/components/plugin/management/PluginAuthorPage.test.tsx
+++ b/apps/app/src/components/plugin/management/PluginAuthorPage.test.tsx
@@ -1,6 +1,12 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { MemoryRouter, useLocation } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { PluginCatalogSearchEntry } from "@/hooks/queries/plugin-catalog-queries";
@@ -31,7 +37,11 @@ function catalogEntry(
     publisherKey: "bb-community",
     publisherLabel: "BB Community",
     official: true,
-    author: { name: "Pat Lee", url: "https://github.com/patlee" },
+    author: {
+      name: "Pat Lee",
+      github: "patlee",
+      url: "https://github.com/patlee",
+    },
     installed: false,
     installs: 10,
     compatible: true,
@@ -42,7 +52,11 @@ function catalogEntry(
 
 const ALPHA = catalogEntry("Alpha", { installs: null });
 const BETA = catalogEntry("Beta", {
-  author: { name: "Patricia Lee", url: "https://github.com/PatLee" },
+  author: {
+    name: "Patricia Lee",
+    github: "PatLee",
+    url: "https://github.com/PatLee",
+  },
   categoryId: "security",
   category: "Security",
   publishedAt: "2026-08-20T00:00:00Z",
@@ -53,7 +67,7 @@ const GAMMA = catalogEntry("Gamma", {
   installs: 100,
 });
 const OTHER = catalogEntry("Other", {
-  author: { name: "Pat Lee", url: null },
+  author: { name: "Pat Lee", github: null, url: null },
 });
 
 function LocationProbe() {
@@ -74,16 +88,28 @@ function cardOrder(): string[] {
 function renderPage(initialEntry: string, onOpenPlugin = vi.fn()) {
   vi.stubGlobal(
     "fetch",
-    vi.fn(
-      async () =>
-        new Response(
-          JSON.stringify({
-            results: [GAMMA, OTHER, BETA, ALPHA],
-            collections: [],
-          }),
-          { headers: { "content-type": "application/json" } },
-        ),
-    ),
+    vi.fn(async (input: RequestInfo | URL) => {
+      const requestUrl =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input.url;
+      const query = new URL(requestUrl, "http://localhost").searchParams.get(
+        "q",
+      );
+      const results =
+        query === "Beta" || query === "agent-interaction"
+          ? [BETA]
+          : [GAMMA, OTHER, BETA, ALPHA];
+      return new Response(
+        JSON.stringify({
+          results,
+          collections: [],
+        }),
+        { headers: { "content-type": "application/json" } },
+      );
+    }),
   );
   const { wrapper } = createQueryClientTestHarness();
   render(
@@ -175,10 +201,22 @@ describe("PluginAuthorPage", () => {
     fireEvent.change(screen.getByRole("textbox", { name: "Search plugins" }), {
       target: { value: "Beta" },
     });
-    expect(cardOrder()).toEqual(["Open Beta details"]);
+    await waitFor(() => expect(cardOrder()).toEqual(["Open Beta details"]));
     const beta = screen.getByRole("button", { name: "Open Beta details" });
     fireEvent.click(beta);
     expect(onOpenPlugin).toHaveBeenCalledWith("Beta", beta);
     expect(screen.getByTestId("location").textContent).toContain("query=Beta");
+  });
+
+  it("uses the catalog search result for a tag-only query", async () => {
+    renderPage(
+      "/extensions/plugins?author=12%3Abb-community%3Agithub%3Apatlee&query=agent-interaction",
+    );
+
+    expect(
+      await screen.findByRole("heading", { name: /^Pat Lee/u }),
+    ).toBeTruthy();
+    expect(screen.getByText("3 plugins")).toBeTruthy();
+    await waitFor(() => expect(cardOrder()).toEqual(["Open Beta details"]));
   });
 });

--- a/apps/app/src/components/plugin/management/PluginAuthorPage.tsx
+++ b/apps/app/src/components/plugin/management/PluginAuthorPage.tsx
@@ -1,0 +1,255 @@
+import { useMemo } from "react";
+import { Link, useSearchParams } from "react-router-dom";
+import { Icon } from "@bb/shared-ui/icon";
+import {
+  ResourceCollectionViewport,
+  ResourceListState,
+  ResourceSortMenu,
+  ResourceToolbar,
+} from "@bb/shared-ui/resource-list";
+import { cn } from "@bb/shared-ui/lib/utils";
+import { TOOLS_PAGE_BAND_CLASSES } from "@/components/tools/tools-navigation";
+import {
+  usePluginCatalogSearch,
+  type PluginCatalogSearchEntry,
+} from "@/hooks/queries/plugin-catalog-queries";
+import { getPluginsRoutePath } from "@/lib/route-paths";
+import type { AddPluginInitial } from "./AddPluginDialog";
+import { PluginCatalogGrid } from "./BrowsePluginsTab";
+import { PluginAuthorAvatar } from "./PluginAuthorAvatar";
+import {
+  PluginBrowseCategoryFilter,
+  pluginBrowseSort,
+  pluginBrowseSortDirection,
+  pluginBrowseSortOptions,
+} from "./PluginBrowseControls";
+import {
+  pluginCategoryFilterId,
+  sortPluginEntries,
+} from "./plugin-browse-discovery";
+import { pluginCategoryFilterOptions } from "./plugin-category-options";
+import {
+  entriesByMarketplaceAuthor,
+  pluginAuthorGithub,
+} from "./plugin-marketplace-author";
+
+function matchesAuthorSearch(
+  entry: PluginCatalogSearchEntry,
+  query: string,
+): boolean {
+  const normalizedQuery = query.trim().toLocaleLowerCase();
+  if (normalizedQuery === "") return true;
+  return [
+    entry.entryId,
+    entry.pluginId,
+    entry.displayName,
+    entry.description,
+    entry.category ?? "",
+    entry.marketplaceDisplayName,
+  ]
+    .join("\n")
+    .toLocaleLowerCase()
+    .includes(normalizedQuery);
+}
+
+function authorUrlLabel(url: string): string {
+  return url.replace(/^https?:\/\//u, "").replace(/\/+$/u, "");
+}
+
+export function PluginAuthorPage({
+  authorKey,
+  onInstall,
+  onOpenPlugin,
+}: {
+  authorKey: string;
+  onInstall: (initial: AddPluginInitial) => void;
+  onOpenPlugin: (pluginId: string, trigger: HTMLButtonElement) => void;
+}) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const query = searchParams.get("query") ?? "";
+  const selectedCategories = searchParams.getAll("category");
+  const requestedSort = pluginBrowseSort(searchParams.get("sort"));
+  const sortDirection =
+    pluginBrowseSortDirection(searchParams.get("direction")) ?? "desc";
+  const catalogQuery = usePluginCatalogSearch("", { enabled: true });
+  const entries = useMemo(
+    () =>
+      entriesByMarketplaceAuthor(
+        (catalogQuery.data?.entries ?? []).filter((entry) => entry.compatible),
+        authorKey,
+      ),
+    [authorKey, catalogQuery.data?.entries],
+  );
+  const author = entries[0]?.author ?? null;
+  const installsKnown = entries.some((entry) => entry.installs !== null);
+  const sort =
+    requestedSort === "most-installed" && !installsKnown ? null : requestedSort;
+  const categoryOptions = useMemo(
+    () =>
+      pluginCategoryFilterOptions(
+        entries.map((entry) => ({
+          id: pluginCategoryFilterId(entry),
+          label: entry.category ?? null,
+        })),
+        selectedCategories,
+      ),
+    [entries, selectedCategories],
+  );
+  const visibleEntries = useMemo(() => {
+    const selected = new Set(selectedCategories);
+    const filtered = entries.filter(
+      (entry) =>
+        matchesAuthorSearch(entry, query) &&
+        (selected.size === 0 || selected.has(pluginCategoryFilterId(entry))),
+    );
+    return sort === null
+      ? filtered
+      : sortPluginEntries(filtered, sort, sortDirection);
+  }, [entries, query, selectedCategories, sort, sortDirection]);
+  const browseParams = new URLSearchParams(searchParams);
+  browseParams.delete("author");
+  const browseSearch = browseParams.toString();
+
+  const changeSearchParams = (change: (next: URLSearchParams) => void) => {
+    const next = new URLSearchParams(searchParams);
+    change(next);
+    setSearchParams(next, { replace: true });
+  };
+
+  return (
+    <ResourceCollectionViewport scrollId="plugin-author-results">
+      <div className={cn("space-y-6 pb-8", TOOLS_PAGE_BAND_CLASSES)}>
+        <div className="space-y-2">
+          <Link
+            to={{
+              pathname: getPluginsRoutePath(),
+              search: browseSearch === "" ? "" : `?${browseSearch}`,
+            }}
+            className="-ml-1 inline-flex items-center gap-1 rounded-sm px-1 text-xs text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          >
+            <Icon name="ChevronLeft" className="size-3" aria-hidden />
+            Browse plugins
+          </Link>
+          {author === null ? null : (
+            <div className="flex items-center gap-3">
+              <PluginAuthorAvatar
+                name={author.name}
+                github={pluginAuthorGithub(author)}
+                size="page"
+              />
+              <div className="min-w-0 space-y-1">
+                <h1 className="flex flex-wrap items-center gap-2 text-xl font-semibold text-foreground">
+                  <span>{author.name}</span>
+                  <span className="rounded-md bg-muted px-2 py-1 text-2xs font-medium tabular-nums text-subtle-foreground">
+                    {entries.length.toLocaleString()}{" "}
+                    {entries.length === 1 ? "plugin" : "plugins"}
+                  </span>
+                </h1>
+                {author.url === null ? null : (
+                  <a
+                    href={author.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-flex items-center gap-1 rounded-sm text-xs text-subtle-foreground underline underline-offset-2 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                  >
+                    {authorUrlLabel(author.url)}
+                    <Icon name="ExternalLink" className="size-3" aria-hidden />
+                    <span className="sr-only">Opens in a new tab</span>
+                  </a>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {catalogQuery.isPending ? (
+          <ResourceListState state="loading" message="Loading author" />
+        ) : catalogQuery.isError && entries.length === 0 ? (
+          <ResourceListState
+            state="error"
+            message="The author catalog is not available."
+            onRetry={() => void catalogQuery.refetch()}
+          />
+        ) : author === null ? (
+          <ResourceListState state="empty" message="Author not found." />
+        ) : (
+          <section className="space-y-6">
+            <div className="mx-auto w-full max-w-3xl">
+              <ResourceToolbar
+                searchValue={query}
+                searchPlaceholder="Search plugins"
+                onSearchChange={(value) =>
+                  changeSearchParams((next) => {
+                    if (value === "") next.delete("query");
+                    else next.set("query", value);
+                  })
+                }
+                controls={
+                  <>
+                    <PluginBrowseCategoryFilter
+                      selectionMode="multiple"
+                      value={selectedCategories}
+                      options={categoryOptions}
+                      onChange={(values) =>
+                        changeSearchParams((next) => {
+                          next.delete("category");
+                          for (const value of values) {
+                            next.append("category", value);
+                          }
+                        })
+                      }
+                    />
+                    <ResourceSortMenu
+                      value={sort}
+                      direction={sortDirection}
+                      compact
+                      placeholderLabel="Featured"
+                      options={pluginBrowseSortOptions(installsKnown)}
+                      onChange={(value) =>
+                        changeSearchParams((next) => {
+                          if (value === sort) {
+                            next.set(
+                              "direction",
+                              sortDirection === "asc" ? "desc" : "asc",
+                            );
+                          } else {
+                            next.set("sort", value);
+                            next.set("direction", "desc");
+                          }
+                        })
+                      }
+                      onClear={() =>
+                        changeSearchParams((next) => {
+                          next.delete("sort");
+                          next.delete("direction");
+                        })
+                      }
+                    />
+                  </>
+                }
+              />
+            </div>
+            {catalogQuery.isError ? (
+              <p className="text-xs text-warning-text" role="status">
+                The latest search failed. The page shows saved catalog results.
+              </p>
+            ) : null}
+            {visibleEntries.length === 0 ? (
+              <ResourceListState
+                state="empty"
+                message="No plugins match these filters."
+              />
+            ) : (
+              <PluginCatalogGrid
+                entries={visibleEntries}
+                showCategory
+                onInstall={onInstall}
+                onOpenPlugin={onOpenPlugin}
+              />
+            )}
+          </section>
+        )}
+      </div>
+    </ResourceCollectionViewport>
+  );
+}

--- a/apps/app/src/components/plugin/management/PluginAuthorPage.tsx
+++ b/apps/app/src/components/plugin/management/PluginAuthorPage.tsx
@@ -13,7 +13,10 @@ import { TOOLS_PAGE_BAND_CLASSES } from "@/components/tools/tools-navigation";
 import { usePluginCatalogSearch } from "@/hooks/queries/plugin-catalog-queries";
 import { getPluginsRoutePath } from "@/lib/route-paths";
 import type { AddPluginInitial } from "./AddPluginDialog";
-import { PluginCatalogGrid } from "./BrowsePluginsTab";
+import {
+  PluginCatalogGrid,
+  pluginCategoryFilterOptions,
+} from "./BrowsePluginsTab";
 import { PluginAuthorAvatar } from "./PluginAuthorAvatar";
 import {
   PluginBrowseCategoryFilter,
@@ -25,7 +28,6 @@ import {
   pluginCategoryFilterId,
   sortPluginEntries,
 } from "./plugin-browse-discovery";
-import { pluginCategoryFilterOptions } from "./plugin-category-options";
 import {
   entriesByMarketplaceAuthor,
   pluginAuthorGithub,
@@ -68,14 +70,7 @@ export function PluginAuthorPage({
   const sort =
     requestedSort === "most-installed" && !installsKnown ? null : requestedSort;
   const categoryOptions = useMemo(
-    () =>
-      pluginCategoryFilterOptions(
-        entries.map((entry) => ({
-          id: pluginCategoryFilterId(entry),
-          label: entry.category ?? null,
-        })),
-        selectedCategories,
-      ),
+    () => pluginCategoryFilterOptions(entries, selectedCategories),
     [entries, selectedCategories],
   );
   const visibleEntries = useMemo(() => {

--- a/apps/app/src/components/plugin/management/PluginAuthorPage.tsx
+++ b/apps/app/src/components/plugin/management/PluginAuthorPage.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { Link, useSearchParams } from "react-router-dom";
+import { useDebounceValue } from "usehooks-ts";
 import { Icon } from "@bb/shared-ui/icon";
 import {
   ResourceCollectionViewport,
@@ -9,10 +10,7 @@ import {
 } from "@bb/shared-ui/resource-list";
 import { cn } from "@bb/shared-ui/lib/utils";
 import { TOOLS_PAGE_BAND_CLASSES } from "@/components/tools/tools-navigation";
-import {
-  usePluginCatalogSearch,
-  type PluginCatalogSearchEntry,
-} from "@/hooks/queries/plugin-catalog-queries";
+import { usePluginCatalogSearch } from "@/hooks/queries/plugin-catalog-queries";
 import { getPluginsRoutePath } from "@/lib/route-paths";
 import type { AddPluginInitial } from "./AddPluginDialog";
 import { PluginCatalogGrid } from "./BrowsePluginsTab";
@@ -33,25 +31,6 @@ import {
   pluginAuthorGithub,
 } from "./plugin-marketplace-author";
 
-function matchesAuthorSearch(
-  entry: PluginCatalogSearchEntry,
-  query: string,
-): boolean {
-  const normalizedQuery = query.trim().toLocaleLowerCase();
-  if (normalizedQuery === "") return true;
-  return [
-    entry.entryId,
-    entry.pluginId,
-    entry.displayName,
-    entry.description,
-    entry.category ?? "",
-    entry.marketplaceDisplayName,
-  ]
-    .join("\n")
-    .toLocaleLowerCase()
-    .includes(normalizedQuery);
-}
-
 function authorUrlLabel(url: string): string {
   return url.replace(/^https?:\/\//u, "").replace(/\/+$/u, "");
 }
@@ -67,11 +46,15 @@ export function PluginAuthorPage({
 }) {
   const [searchParams, setSearchParams] = useSearchParams();
   const query = searchParams.get("query") ?? "";
+  const [debouncedQuery] = useDebounceValue(query.trim(), 300);
   const selectedCategories = searchParams.getAll("category");
   const requestedSort = pluginBrowseSort(searchParams.get("sort"));
   const sortDirection =
     pluginBrowseSortDirection(searchParams.get("direction")) ?? "desc";
   const catalogQuery = usePluginCatalogSearch("", { enabled: true });
+  const searchQuery = usePluginCatalogSearch(debouncedQuery, {
+    enabled: debouncedQuery !== "",
+  });
   const entries = useMemo(
     () =>
       entriesByMarketplaceAuthor(
@@ -97,15 +80,30 @@ export function PluginAuthorPage({
   );
   const visibleEntries = useMemo(() => {
     const selected = new Set(selectedCategories);
-    const filtered = entries.filter(
+    const searchEntries =
+      debouncedQuery === ""
+        ? (catalogQuery.data?.entries ?? [])
+        : (searchQuery.data?.entries ?? []);
+    const filtered = entriesByMarketplaceAuthor(
+      searchEntries.filter((entry) => entry.compatible),
+      authorKey,
+    ).filter(
       (entry) =>
-        matchesAuthorSearch(entry, query) &&
-        (selected.size === 0 || selected.has(pluginCategoryFilterId(entry))),
+        selected.size === 0 || selected.has(pluginCategoryFilterId(entry)),
     );
     return sort === null
       ? filtered
       : sortPluginEntries(filtered, sort, sortDirection);
-  }, [entries, query, selectedCategories, sort, sortDirection]);
+  }, [
+    authorKey,
+    catalogQuery.data?.entries,
+    debouncedQuery,
+    searchQuery.data?.entries,
+    selectedCategories,
+    sort,
+    sortDirection,
+  ]);
+  const searchPending = debouncedQuery !== "" && searchQuery.isPending;
   const browseParams = new URLSearchParams(searchParams);
   browseParams.delete("author");
   const browseSearch = browseParams.toString();
@@ -229,12 +227,14 @@ export function PluginAuthorPage({
                 }
               />
             </div>
-            {catalogQuery.isError ? (
+            {catalogQuery.isError || searchQuery.isError ? (
               <p className="text-xs text-warning-text" role="status">
                 The latest search failed. The page shows saved catalog results.
               </p>
             ) : null}
-            {visibleEntries.length === 0 ? (
+            {searchPending ? (
+              <ResourceListState state="loading" message="Loading plugins" />
+            ) : visibleEntries.length === 0 ? (
               <ResourceListState
                 state="empty"
                 message="No plugins match these filters."

--- a/apps/app/src/components/plugin/management/PluginAuthorPage.tsx
+++ b/apps/app/src/components/plugin/management/PluginAuthorPage.tsx
@@ -10,7 +10,10 @@ import {
 } from "@bb/shared-ui/resource-list";
 import { cn } from "@bb/shared-ui/lib/utils";
 import { TOOLS_PAGE_BAND_CLASSES } from "@/components/tools/tools-navigation";
-import { usePluginCatalogSearch } from "@/hooks/queries/plugin-catalog-queries";
+import {
+  type PluginCatalogSearchEntry,
+  usePluginCatalogSearch,
+} from "@/hooks/queries/plugin-catalog-queries";
 import { getPluginsRoutePath } from "@/lib/route-paths";
 import type { AddPluginInitial } from "./AddPluginDialog";
 import {
@@ -35,6 +38,35 @@ import {
 
 function authorUrlLabel(url: string): string {
   return url.replace(/^https?:\/\//u, "").replace(/\/+$/u, "");
+}
+
+function authorForEntries(
+  entries: readonly PluginCatalogSearchEntry[],
+): PluginCatalogSearchEntry["author"] {
+  const nameCounts = new Map<string, number>();
+  for (const entry of entries) {
+    if (entry.author === null) continue;
+    nameCounts.set(
+      entry.author.name,
+      (nameCounts.get(entry.author.name) ?? 0) + 1,
+    );
+  }
+  let selected: PluginCatalogSearchEntry["author"] = null;
+  for (const entry of entries) {
+    if (entry.author === null) continue;
+    const candidateCount = nameCounts.get(entry.author.name) ?? 0;
+    const selectedCount =
+      selected === null ? 0 : (nameCounts.get(selected.name) ?? 0);
+    if (
+      selected === null ||
+      candidateCount > selectedCount ||
+      (candidateCount === selectedCount &&
+        entry.author.name.length > selected.name.length)
+    ) {
+      selected = entry.author;
+    }
+  }
+  return selected;
 }
 
 export function PluginAuthorPage({
@@ -65,7 +97,7 @@ export function PluginAuthorPage({
       ),
     [authorKey, catalogQuery.data?.entries],
   );
-  const author = entries[0]?.author ?? null;
+  const author = useMemo(() => authorForEntries(entries), [entries]);
   const installsKnown = entries.some((entry) => entry.installs !== null);
   const sort =
     requestedSort === "most-installed" && !installsKnown ? null : requestedSort;
@@ -112,7 +144,7 @@ export function PluginAuthorPage({
   return (
     <ResourceCollectionViewport scrollId="plugin-author-results">
       <div className={cn("space-y-6 pb-8", TOOLS_PAGE_BAND_CLASSES)}>
-        <div className="space-y-2">
+        <div className="mx-auto w-full max-w-3xl space-y-2">
           <Link
             to={{
               pathname: getPluginsRoutePath(),

--- a/apps/app/src/components/plugin/management/PluginMarketplaceListing.test.tsx
+++ b/apps/app/src/components/plugin/management/PluginMarketplaceListing.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { PluginCatalogSearchEntry } from "@/hooks/queries/plugin-catalog-queries";
+import {
+  PluginMarketplaceHeaderMetadata,
+  PluginMoreFromAuthorSection,
+} from "./PluginMarketplaceListing";
+
+function catalogEntry(pluginId: string): PluginCatalogSearchEntry {
+  return {
+    entryId: pluginId,
+    pluginId,
+    displayName: pluginId,
+    description: `${pluginId} description`,
+    icon: "Zap",
+    iconUrl: null,
+    iconTinted: false,
+    screenshots: [],
+    collections: [],
+    source: `npm:${pluginId}`,
+    repositoryUrl: null,
+    marketplace: "bb-community",
+    marketplaceDisplayName: "BB Community",
+    publisherKey: "bb-community",
+    publisherLabel: "BB Community",
+    official: true,
+    author: { name: "Pat Lee", url: "https://github.com/patlee" },
+    installed: false,
+    installs: null,
+    compatible: true,
+    incompatibleReason: null,
+  };
+}
+
+afterEach(cleanup);
+
+describe("plugin marketplace author links", () => {
+  it("routes the detail author name to the author page", () => {
+    render(
+      <MemoryRouter
+        initialEntries={["/extensions/plugins/Current?category=security"]}
+      >
+        <PluginMarketplaceHeaderMetadata entry={catalogEntry("Current")} />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByRole("link", { name: "Pat Lee" }).getAttribute("href"),
+    ).toBe(
+      "/extensions/plugins?category=security&author=12%3Abb-community%3Agithub%3Apatlee",
+    );
+  });
+
+  it("excludes the current plugin and caps plain teaser rows at four", () => {
+    const current = catalogEntry("Current");
+    const entries = [
+      current,
+      catalogEntry("Echo"),
+      catalogEntry("Delta"),
+      catalogEntry("Charlie"),
+      catalogEntry("Bravo"),
+      catalogEntry("Alpha"),
+      { ...catalogEntry("Other"), author: { name: "Other", url: null } },
+    ];
+    const onOpenPlugin = vi.fn();
+    render(
+      <MemoryRouter>
+        <PluginMoreFromAuthorSection
+          entry={current}
+          catalogEntries={entries}
+          onOpenPlugin={onOpenPlugin}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "More from this author" }),
+    ).toBeTruthy();
+    expect(
+      screen
+        .getAllByRole("button", { name: /^Open .+ details$/u })
+        .map((button) => button.getAttribute("aria-label")),
+    ).toEqual([
+      "Open Alpha details",
+      "Open Bravo details",
+      "Open Charlie details",
+      "Open Delta details",
+    ]);
+    expect(screen.queryByText("Current")).toBeNull();
+    expect(screen.queryByText("Echo")).toBeNull();
+    expect(screen.queryByText("Other")).toBeNull();
+    expect(screen.queryByRole("button", { name: /install/i })).toBeNull();
+    expect(screen.queryByText(/trusted|official|installed/iu)).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open Alpha details" }));
+    expect(onOpenPlugin).toHaveBeenCalledWith("Alpha");
+  });
+});

--- a/apps/app/src/components/plugin/management/PluginMarketplaceListing.test.tsx
+++ b/apps/app/src/components/plugin/management/PluginMarketplaceListing.test.tsx
@@ -27,7 +27,11 @@ function catalogEntry(pluginId: string): PluginCatalogSearchEntry {
     publisherKey: "bb-community",
     publisherLabel: "BB Community",
     official: true,
-    author: { name: "Pat Lee", url: "https://github.com/patlee" },
+    author: {
+      name: "Pat Lee",
+      github: "patlee",
+      url: "https://github.com/patlee",
+    },
     installed: false,
     installs: null,
     compatible: true,
@@ -63,7 +67,10 @@ describe("plugin marketplace author links", () => {
       catalogEntry("Charlie"),
       catalogEntry("Bravo"),
       catalogEntry("Alpha"),
-      { ...catalogEntry("Other"), author: { name: "Other", url: null } },
+      {
+        ...catalogEntry("Other"),
+        author: { name: "Other", github: null, url: null },
+      },
     ];
     const onOpenPlugin = vi.fn();
     render(

--- a/apps/app/src/components/plugin/management/PluginMarketplaceListing.tsx
+++ b/apps/app/src/components/plugin/management/PluginMarketplaceListing.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import {
   Carousel,
   CarouselContent,
@@ -9,10 +9,21 @@ import {
 } from "@bb/shared-ui/carousel";
 import { Icon } from "@bb/shared-ui/icon";
 import { cn } from "@bb/shared-ui/lib/utils";
-import { ResourceDefinitionSection } from "@bb/shared-ui/resource-list";
+import {
+  ResourceDefinitionSection,
+  ResourceListPanel,
+  ResourceRow,
+  ResourceRowDetailChevron,
+} from "@bb/shared-ui/resource-list";
 import type { PluginCatalogSearchEntry } from "@/hooks/queries/plugin-catalog-queries";
-import { PluginCategoryLabel } from "./plugin-ui";
-import { PluginAuthorAvatar, pluginAuthorGithub } from "./PluginAuthorAvatar";
+import { CatalogEntryIconChip, PluginCategoryLabel } from "./plugin-ui";
+import { PluginAuthorAvatar } from "./PluginAuthorAvatar";
+import { PluginAuthorLink } from "./PluginAuthorLink";
+import {
+  entriesByMarketplaceAuthor,
+  pluginAuthorGithub,
+  pluginMarketplaceAuthorKey,
+} from "./plugin-marketplace-author";
 
 function repositoryLinkLabel(url: string): string {
   return url.replace(/^https?:\/\//u, "").replace(/\/+$/u, "");
@@ -34,18 +45,12 @@ export function PluginMarketplaceHeaderMetadata({
       />
       <span className="min-w-0">
         By{" "}
-        {author.url === null ? (
-          author.name
-        ) : (
-          <a
-            href={author.url}
-            target="_blank"
-            rel="noreferrer"
-            className="rounded-sm underline underline-offset-2 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-          >
-            {author.name}
-          </a>
-        )}
+        <PluginAuthorLink
+          entry={entry}
+          className="rounded-sm underline underline-offset-2 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        >
+          {author.name}
+        </PluginAuthorLink>
       </span>
     </span>
   );
@@ -241,5 +246,54 @@ export function PluginMarketplaceListingSections({
       <PluginMarketplaceSource entry={entry} />
       <PluginMarketplaceDetails entry={entry} />
     </>
+  );
+}
+
+export function PluginMoreFromAuthorSection({
+  entry,
+  catalogEntries,
+  onOpenPlugin,
+}: {
+  entry: PluginCatalogSearchEntry;
+  catalogEntries: readonly PluginCatalogSearchEntry[];
+  onOpenPlugin: (pluginId: string) => void;
+}) {
+  const authorKey = pluginMarketplaceAuthorKey(entry);
+  const moreEntries = useMemo(
+    () =>
+      authorKey === null
+        ? []
+        : entriesByMarketplaceAuthor(catalogEntries, authorKey)
+            .filter(
+              (candidate) =>
+                candidate.compatible &&
+                (candidate.marketplace !== entry.marketplace ||
+                  candidate.entryId !== entry.entryId),
+            )
+            .sort(
+              (left, right) =>
+                left.displayName.localeCompare(right.displayName) ||
+                left.entryId.localeCompare(right.entryId),
+            )
+            .slice(0, 4),
+    [authorKey, catalogEntries, entry.entryId, entry.marketplace],
+  );
+  if (moreEntries.length === 0) return null;
+  return (
+    <ResourceDefinitionSection label="More from this author">
+      <ResourceListPanel className="py-0">
+        {moreEntries.map((candidate) => (
+          <ResourceRow
+            key={`${candidate.marketplace}/${candidate.entryId}`}
+            leading={<CatalogEntryIconChip entry={candidate} />}
+            title={candidate.displayName}
+            description={candidate.description || undefined}
+            trailingVisual={<ResourceRowDetailChevron />}
+            openLabel={`Open ${candidate.displayName} details`}
+            onOpen={() => onOpenPlugin(candidate.pluginId)}
+          />
+        ))}
+      </ResourceListPanel>
+    </ResourceDefinitionSection>
   );
 }

--- a/apps/app/src/components/plugin/management/plugin-marketplace-author.test.ts
+++ b/apps/app/src/components/plugin/management/plugin-marketplace-author.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import type { PluginCatalogSearchEntry } from "@/hooks/queries/plugin-catalog-queries";
+import {
+  entriesByMarketplaceAuthor,
+  pluginMarketplaceAuthorKey,
+} from "./plugin-marketplace-author";
+
+function entry(
+  marketplace: string,
+  author: PluginCatalogSearchEntry["author"],
+  pluginId: string,
+) {
+  return { marketplace, author, pluginId };
+}
+
+describe("plugin marketplace author identity", () => {
+  it("matches GitHub logins without using the display name", () => {
+    const selected = entry(
+      "first",
+      { name: "Pat Lee", url: "https://github.com/PatLee" },
+      "selected",
+    );
+    const sameLogin = entry(
+      "first",
+      { name: "Patricia Lee", url: "https://www.github.com/patlee/" },
+      "same-login",
+    );
+    const otherMarketplace = entry(
+      "second",
+      { name: "Patricia Lee", url: "https://github.com/patlee" },
+      "other-marketplace",
+    );
+    const sameName = entry(
+      "first",
+      { name: "Pat Lee", url: null },
+      "same-name",
+    );
+    const key = pluginMarketplaceAuthorKey(selected);
+
+    expect(key).toBe("5:first:github:patlee");
+    if (key === null) throw new Error("Expected an author key");
+    expect(
+      entriesByMarketplaceAuthor(
+        [selected, sameLogin, otherMarketplace, sameName],
+        key,
+      ),
+    ).toEqual([selected, sameLogin]);
+  });
+
+  it("uses an exact name when a GitHub login is not present", () => {
+    const selected = entry("first", { name: "BB", url: null }, "selected");
+    const sameName = entry(
+      "first",
+      { name: "BB", url: "https://bb.dev" },
+      "same-name",
+    );
+    const differentCase = entry(
+      "first",
+      { name: "bb", url: null },
+      "different-case",
+    );
+    const githubName = entry(
+      "first",
+      { name: "BB", url: "https://github.com/get-bb" },
+      "github-name",
+    );
+    const key = pluginMarketplaceAuthorKey(selected);
+
+    expect(key).toBe("5:first:name:BB");
+    if (key === null) throw new Error("Expected an author key");
+    expect(
+      entriesByMarketplaceAuthor(
+        [selected, sameName, differentCase, githubName],
+        key,
+      ),
+    ).toEqual([selected, sameName]);
+  });
+});

--- a/apps/app/src/components/plugin/management/plugin-marketplace-author.test.ts
+++ b/apps/app/src/components/plugin/management/plugin-marketplace-author.test.ts
@@ -17,22 +17,30 @@ describe("plugin marketplace author identity", () => {
   it("matches GitHub logins without using the display name", () => {
     const selected = entry(
       "first",
-      { name: "Pat Lee", url: "https://github.com/PatLee" },
+      { name: "Pat Lee", github: "PatLee", url: "https://patlee.dev" },
       "selected",
     );
     const sameLogin = entry(
       "first",
-      { name: "Patricia Lee", url: "https://www.github.com/patlee/" },
+      {
+        name: "Patricia Lee",
+        github: "patlee",
+        url: "https://patricia.dev",
+      },
       "same-login",
     );
     const otherMarketplace = entry(
       "second",
-      { name: "Patricia Lee", url: "https://github.com/patlee" },
+      {
+        name: "Patricia Lee",
+        github: "patlee",
+        url: "https://patricia.dev",
+      },
       "other-marketplace",
     );
     const sameName = entry(
       "first",
-      { name: "Pat Lee", url: null },
+      { name: "Pat Lee", github: null, url: null },
       "same-name",
     );
     const key = pluginMarketplaceAuthorKey(selected);
@@ -48,20 +56,24 @@ describe("plugin marketplace author identity", () => {
   });
 
   it("uses an exact name when a GitHub login is not present", () => {
-    const selected = entry("first", { name: "BB", url: null }, "selected");
+    const selected = entry(
+      "first",
+      { name: "BB", github: null, url: null },
+      "selected",
+    );
     const sameName = entry(
       "first",
-      { name: "BB", url: "https://bb.dev" },
+      { name: "BB", github: null, url: null },
       "same-name",
     );
     const differentCase = entry(
       "first",
-      { name: "bb", url: null },
+      { name: "bb", github: null, url: null },
       "different-case",
     );
     const githubName = entry(
       "first",
-      { name: "BB", url: "https://github.com/get-bb" },
+      { name: "BB", github: "get-bb", url: "https://bb.dev" },
       "github-name",
     );
     const key = pluginMarketplaceAuthorKey(selected);
@@ -74,5 +86,30 @@ describe("plugin marketplace author identity", () => {
         key,
       ),
     ).toEqual([selected, sameName]);
+  });
+
+  it("uses the author URL before the display name", () => {
+    const selected = entry(
+      "first",
+      { name: "Pat Lee", github: null, url: "https://PATLEE.dev/" },
+      "selected",
+    );
+    const sameUrl = entry(
+      "first",
+      { name: "Patricia Lee", github: null, url: "https://patlee.dev" },
+      "same-url",
+    );
+    const sameName = entry(
+      "first",
+      { name: "Pat Lee", github: null, url: "https://other.dev" },
+      "same-name",
+    );
+    const key = pluginMarketplaceAuthorKey(selected);
+
+    expect(key).toBe("5:first:url:https://patlee.dev");
+    if (key === null) throw new Error("Expected an author key");
+    expect(
+      entriesByMarketplaceAuthor([selected, sameUrl, sameName], key),
+    ).toEqual([selected, sameUrl]);
   });
 });

--- a/apps/app/src/components/plugin/management/plugin-marketplace-author.test.ts
+++ b/apps/app/src/components/plugin/management/plugin-marketplace-author.test.ts
@@ -58,12 +58,12 @@ describe("plugin marketplace author identity", () => {
   it("uses an exact name when a GitHub login is not present", () => {
     const selected = entry(
       "first",
-      { name: "BB", github: null, url: null },
+      { name: "BB", github: null, url: "https://bb.dev" },
       "selected",
     );
     const sameName = entry(
       "first",
-      { name: "BB", github: null, url: null },
+      { name: "BB", github: null, url: "https://other.dev" },
       "same-name",
     );
     const differentCase = entry(
@@ -86,30 +86,5 @@ describe("plugin marketplace author identity", () => {
         key,
       ),
     ).toEqual([selected, sameName]);
-  });
-
-  it("uses the author URL before the display name", () => {
-    const selected = entry(
-      "first",
-      { name: "Pat Lee", github: null, url: "https://PATLEE.dev/" },
-      "selected",
-    );
-    const sameUrl = entry(
-      "first",
-      { name: "Patricia Lee", github: null, url: "https://patlee.dev" },
-      "same-url",
-    );
-    const sameName = entry(
-      "first",
-      { name: "Pat Lee", github: null, url: "https://other.dev" },
-      "same-name",
-    );
-    const key = pluginMarketplaceAuthorKey(selected);
-
-    expect(key).toBe("5:first:url:https://patlee.dev");
-    if (key === null) throw new Error("Expected an author key");
-    expect(
-      entriesByMarketplaceAuthor([selected, sameUrl, sameName], key),
-    ).toEqual([selected, sameUrl]);
   });
 });

--- a/apps/app/src/components/plugin/management/plugin-marketplace-author.ts
+++ b/apps/app/src/components/plugin/management/plugin-marketplace-author.ts
@@ -1,0 +1,41 @@
+import type { PluginCatalogAuthor } from "@bb/server-contract";
+import type { PluginCatalogSearchEntry } from "@/hooks/queries/plugin-catalog-queries";
+
+const GITHUB_AUTHOR_PREFIX = "github:";
+const NAME_AUTHOR_PREFIX = "name:";
+
+export function pluginAuthorGithub(
+  author: PluginCatalogAuthor | null,
+): string | null {
+  if (author?.url === null || author?.url === undefined) return null;
+  try {
+    const url = new URL(author.url);
+    if (url.hostname !== "github.com" && url.hostname !== "www.github.com") {
+      return null;
+    }
+    const [github] = url.pathname.split("/").filter(Boolean);
+    return github ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function pluginMarketplaceAuthorKey(
+  entry: Pick<PluginCatalogSearchEntry, "author" | "marketplace">,
+): string | null {
+  if (entry.author === null) return null;
+  const github = pluginAuthorGithub(entry.author);
+  const identity =
+    github === null
+      ? `${NAME_AUTHOR_PREFIX}${entry.author.name}`
+      : `${GITHUB_AUTHOR_PREFIX}${github.toLocaleLowerCase()}`;
+  return `${entry.marketplace.length}:${entry.marketplace}:${identity}`;
+}
+
+export function entriesByMarketplaceAuthor<
+  Entry extends Pick<PluginCatalogSearchEntry, "author" | "marketplace">,
+>(entries: readonly Entry[], authorKey: string): Entry[] {
+  return entries.filter(
+    (entry) => pluginMarketplaceAuthorKey(entry) === authorKey,
+  );
+}

--- a/apps/app/src/components/plugin/management/plugin-marketplace-author.ts
+++ b/apps/app/src/components/plugin/management/plugin-marketplace-author.ts
@@ -3,21 +3,23 @@ import type { PluginCatalogSearchEntry } from "@/hooks/queries/plugin-catalog-qu
 
 const GITHUB_AUTHOR_PREFIX = "github:";
 const NAME_AUTHOR_PREFIX = "name:";
+const URL_AUTHOR_PREFIX = "url:";
+
+function authorUrlIdentity(url: string): string {
+  try {
+    const parsed = new URL(url);
+    parsed.hash = "";
+    const pathname = parsed.pathname.replace(/\/+$/u, "");
+    return `${parsed.origin}${pathname}${parsed.search}`;
+  } catch {
+    return url;
+  }
+}
 
 export function pluginAuthorGithub(
   author: PluginCatalogAuthor | null,
 ): string | null {
-  if (author?.url === null || author?.url === undefined) return null;
-  try {
-    const url = new URL(author.url);
-    if (url.hostname !== "github.com" && url.hostname !== "www.github.com") {
-      return null;
-    }
-    const [github] = url.pathname.split("/").filter(Boolean);
-    return github ?? null;
-  } catch {
-    return null;
-  }
+  return author?.github ?? null;
 }
 
 export function pluginMarketplaceAuthorKey(
@@ -26,9 +28,11 @@ export function pluginMarketplaceAuthorKey(
   if (entry.author === null) return null;
   const github = pluginAuthorGithub(entry.author);
   const identity =
-    github === null
-      ? `${NAME_AUTHOR_PREFIX}${entry.author.name}`
-      : `${GITHUB_AUTHOR_PREFIX}${github.toLocaleLowerCase()}`;
+    github !== null
+      ? `${GITHUB_AUTHOR_PREFIX}${github.toLowerCase()}`
+      : entry.author.url !== null
+        ? `${URL_AUTHOR_PREFIX}${authorUrlIdentity(entry.author.url)}`
+        : `${NAME_AUTHOR_PREFIX}${entry.author.name}`;
   return `${entry.marketplace.length}:${entry.marketplace}:${identity}`;
 }
 

--- a/apps/app/src/components/plugin/management/plugin-marketplace-author.ts
+++ b/apps/app/src/components/plugin/management/plugin-marketplace-author.ts
@@ -3,18 +3,6 @@ import type { PluginCatalogSearchEntry } from "@/hooks/queries/plugin-catalog-qu
 
 const GITHUB_AUTHOR_PREFIX = "github:";
 const NAME_AUTHOR_PREFIX = "name:";
-const URL_AUTHOR_PREFIX = "url:";
-
-function authorUrlIdentity(url: string): string {
-  try {
-    const parsed = new URL(url);
-    parsed.hash = "";
-    const pathname = parsed.pathname.replace(/\/+$/u, "");
-    return `${parsed.origin}${pathname}${parsed.search}`;
-  } catch {
-    return url;
-  }
-}
 
 export function pluginAuthorGithub(
   author: PluginCatalogAuthor | null,
@@ -30,9 +18,7 @@ export function pluginMarketplaceAuthorKey(
   const identity =
     github !== null
       ? `${GITHUB_AUTHOR_PREFIX}${github.toLowerCase()}`
-      : entry.author.url !== null
-        ? `${URL_AUTHOR_PREFIX}${authorUrlIdentity(entry.author.url)}`
-        : `${NAME_AUTHOR_PREFIX}${entry.author.name}`;
+      : `${NAME_AUTHOR_PREFIX}${entry.author.name}`;
   return `${entry.marketplace.length}:${entry.marketplace}:${identity}`;
 }
 

--- a/apps/app/src/components/tools/ExtensionsDetailStates.stories.tsx
+++ b/apps/app/src/components/tools/ExtensionsDetailStates.stories.tsx
@@ -616,6 +616,8 @@ function Plugin({
           onEdit={noop}
           onOpenSource={noop}
           onDelete={noop}
+          catalogEntries={[]}
+          onOpenPlugin={noop}
         />
       </div>
     </div>
@@ -637,6 +639,8 @@ function CatalogPlugin({
         <CatalogPluginDetail
           entry={entry}
           onInstall={() => setInstallOpen(true)}
+          catalogEntries={[entry]}
+          onOpenPlugin={noop}
         />
       </div>
       <AddPluginDialog

--- a/apps/app/src/components/tools/PluginDetail.tsx
+++ b/apps/app/src/components/tools/PluginDetail.tsx
@@ -38,6 +38,7 @@ import {
   PluginMarketplaceCategoryPill,
   PluginMarketplaceHeaderMetadata,
   PluginMarketplaceListingSections,
+  PluginMoreFromAuthorSection,
 } from "@/components/plugin/management/PluginMarketplaceListing";
 import { pluginRuntimeStatusPresentation } from "@/components/plugin/management/plugin-status";
 import {
@@ -119,9 +120,13 @@ function PluginPath({ path }: { path: string }) {
 export function CatalogPluginDetail({
   entry,
   onInstall,
+  catalogEntries = [entry],
+  onOpenPlugin = () => undefined,
 }: {
   entry: PluginCatalogSearchEntry;
   onInstall: (entry: PluginCatalogSearchEntry) => void;
+  catalogEntries?: readonly PluginCatalogSearchEntry[];
+  onOpenPlugin?: (pluginId: string) => void;
 }) {
   const count =
     entry.installs === null
@@ -149,6 +154,11 @@ export function CatalogPluginDetail({
     >
       <ResourceDetailStack>
         <PluginMarketplaceListingSections entry={entry} />
+        <PluginMoreFromAuthorSection
+          entry={entry}
+          catalogEntries={catalogEntries}
+          onOpenPlugin={onOpenPlugin}
+        />
       </ResourceDetailStack>
     </ResourceDetailPage>
   );
@@ -222,6 +232,8 @@ export function PluginDetail({
   onOpenSource,
   onDelete,
   catalogEntry,
+  catalogEntries = [],
+  onOpenPlugin = () => undefined,
 }: {
   isLoading: boolean;
   plugin: PluginListItem | null;
@@ -232,6 +244,8 @@ export function PluginDetail({
   onOpenSource: (plugin: PluginListItem) => void;
   onDelete: (plugin: PluginListItem) => void;
   catalogEntry?: PluginCatalogSearchEntry;
+  catalogEntries?: readonly PluginCatalogSearchEntry[];
+  onOpenPlugin?: (pluginId: string) => void;
 }) {
   const { settingsSections } = usePluginSlots();
   const sourceQuery = usePluginSource(plugin?.id ?? "", {
@@ -358,7 +372,14 @@ export function PluginDetail({
             </p>
           </ResourceDetailOverviewSection>
         ) : (
-          <PluginMarketplaceListingSections entry={catalogEntry} />
+          <>
+            <PluginMarketplaceListingSections entry={catalogEntry} />
+            <PluginMoreFromAuthorSection
+              entry={catalogEntry}
+              catalogEntries={catalogEntries}
+              onOpenPlugin={onOpenPlugin}
+            />
+          </>
         )}
         {hasConfiguration ? (
           <ResourceDetailConfigurationSection

--- a/apps/app/src/components/tools/PluginDetail.tsx
+++ b/apps/app/src/components/tools/PluginDetail.tsx
@@ -120,13 +120,13 @@ function PluginPath({ path }: { path: string }) {
 export function CatalogPluginDetail({
   entry,
   onInstall,
-  catalogEntries = [entry],
-  onOpenPlugin = () => undefined,
+  catalogEntries,
+  onOpenPlugin,
 }: {
   entry: PluginCatalogSearchEntry;
   onInstall: (entry: PluginCatalogSearchEntry) => void;
-  catalogEntries?: readonly PluginCatalogSearchEntry[];
-  onOpenPlugin?: (pluginId: string) => void;
+  catalogEntries: readonly PluginCatalogSearchEntry[];
+  onOpenPlugin: (pluginId: string) => void;
 }) {
   const count =
     entry.installs === null
@@ -232,8 +232,8 @@ export function PluginDetail({
   onOpenSource,
   onDelete,
   catalogEntry,
-  catalogEntries = [],
-  onOpenPlugin = () => undefined,
+  catalogEntries,
+  onOpenPlugin,
 }: {
   isLoading: boolean;
   plugin: PluginListItem | null;
@@ -244,8 +244,8 @@ export function PluginDetail({
   onOpenSource: (plugin: PluginListItem) => void;
   onDelete: (plugin: PluginListItem) => void;
   catalogEntry?: PluginCatalogSearchEntry;
-  catalogEntries?: readonly PluginCatalogSearchEntry[];
-  onOpenPlugin?: (pluginId: string) => void;
+  catalogEntries: readonly PluginCatalogSearchEntry[];
+  onOpenPlugin: (pluginId: string) => void;
 }) {
   const { settingsSections } = usePluginSlots();
   const sourceQuery = usePluginSource(plugin?.id ?? "", {

--- a/apps/app/src/components/tools/detail-page-recipes.test.tsx
+++ b/apps/app/src/components/tools/detail-page-recipes.test.tsx
@@ -162,6 +162,8 @@ function renderPlugin(
           onEdit={() => {}}
           onOpenSource={() => {}}
           onDelete={() => {}}
+          catalogEntries={[]}
+          onOpenPlugin={() => undefined}
         />
       </QueryClientWrapper>
     </MemoryRouter>,

--- a/apps/app/src/hooks/queries/plugin-catalog-queries.test.ts
+++ b/apps/app/src/hooks/queries/plugin-catalog-queries.test.ts
@@ -169,7 +169,11 @@ describe("plugin catalog queries", () => {
           publisherKey: "acme-plugins",
           publisherLabel: "Acme Plugins",
           official: false,
-          author: { name: "Acme", url: "https://acme.dev" },
+          author: {
+            name: "Acme",
+            github: null,
+            url: "https://acme.dev",
+          },
           installed: false,
           installs: null,
           compatible: false,

--- a/apps/app/src/views/ToolsView.plugin-detail.test.tsx
+++ b/apps/app/src/views/ToolsView.plugin-detail.test.tsx
@@ -618,7 +618,11 @@ describe("BB Official plugin detail routing", () => {
       ...GITHUB_CATALOG_ENTRY,
       categoryId: "code-and-reviews",
       category: "Code & Reviews",
-      author: { name: "BB", url: "https://github.com/get-bb" },
+      author: {
+        name: "BB",
+        github: "get-bb",
+        url: "https://github.com/get-bb",
+      },
     };
     vi.stubGlobal(
       "fetch",
@@ -675,7 +679,11 @@ describe("BB Official plugin detail routing", () => {
   });
 
   it("opens an author from a card and returns to the prior Browse filters", async () => {
-    const author = { name: "BB", url: "https://github.com/get-bb" };
+    const author = {
+      name: "BB",
+      github: "get-bb",
+      url: "https://github.com/get-bb",
+    };
     const catalogEntries = [
       {
         ...GITHUB_CATALOG_ENTRY,
@@ -764,7 +772,11 @@ describe("BB Official plugin detail routing", () => {
   });
 
   it("routes the detail author link to the restored author page", async () => {
-    const author = { name: "BB", url: "https://github.com/get-bb" };
+    const author = {
+      name: "BB",
+      github: "get-bb",
+      url: "https://github.com/get-bb",
+    };
     const catalogEntries = [
       { ...GITHUB_CATALOG_ENTRY, author },
       {

--- a/apps/app/src/views/ToolsView.plugin-detail.test.tsx
+++ b/apps/app/src/views/ToolsView.plugin-detail.test.tsx
@@ -129,6 +129,8 @@ describe("PluginDetail official catalog lifecycle", () => {
       <CatalogPluginDetail
         entry={GITHUB_CATALOG_ENTRY}
         onInstall={onInstall}
+        catalogEntries={[GITHUB_CATALOG_ENTRY]}
+        onOpenPlugin={() => undefined}
       />,
     );
 
@@ -153,6 +155,8 @@ describe("PluginDetail official catalog lifecycle", () => {
           repositoryUrl: "https://github.com/acme/bb-github",
         }}
         onInstall={() => {}}
+        catalogEntries={[]}
+        onOpenPlugin={() => undefined}
       />,
     );
 
@@ -172,6 +176,8 @@ describe("PluginDetail official catalog lifecycle", () => {
           publishedAt: "2026-08-20T00:00:00Z",
         }}
         onInstall={() => undefined}
+        catalogEntries={[]}
+        onOpenPlugin={() => undefined}
       />,
     );
 
@@ -196,7 +202,12 @@ describe("PluginDetail official catalog lifecycle", () => {
     render(
       <>
         <CatalogPluginDetailBanner entry={incompatibleEntry} />
-        <CatalogPluginDetail entry={incompatibleEntry} onInstall={() => {}} />
+        <CatalogPluginDetail
+          entry={incompatibleEntry}
+          onInstall={() => {}}
+          catalogEntries={[incompatibleEntry]}
+          onOpenPlugin={() => undefined}
+        />
       </>,
     );
 
@@ -261,6 +272,8 @@ describe("PluginDetail official catalog lifecycle", () => {
             onOpenSource={() => {}}
             onDelete={onDelete}
             catalogEntry={GITHUB_CATALOG_ENTRY}
+            catalogEntries={[GITHUB_CATALOG_ENTRY]}
+            onOpenPlugin={() => undefined}
           />
         </QueryClientWrapper>
       </MemoryRouter>,
@@ -329,6 +342,8 @@ describe("PluginDetail official catalog lifecycle", () => {
             onEdit={() => {}}
             onOpenSource={() => {}}
             onDelete={() => {}}
+            catalogEntries={[]}
+            onOpenPlugin={() => undefined}
           />
         </QueryClientWrapper>
       </MemoryRouter>,
@@ -391,6 +406,8 @@ describe("PluginDetail official catalog lifecycle", () => {
             onEdit={() => {}}
             onOpenSource={() => {}}
             onDelete={() => {}}
+            catalogEntries={[]}
+            onOpenPlugin={() => undefined}
           />
         </QueryClientWrapper>
       </MemoryRouter>,
@@ -449,6 +466,8 @@ describe("PluginDetail official catalog lifecycle", () => {
               onEdit={() => {}}
               onOpenSource={() => {}}
               onDelete={() => {}}
+              catalogEntries={[]}
+              onOpenPlugin={() => undefined}
             />
           </QueryClientWrapper>
         </MemoryRouter>,
@@ -496,6 +515,8 @@ describe("PluginDetail official catalog lifecycle", () => {
             onEdit={() => {}}
             onOpenSource={() => {}}
             onDelete={() => {}}
+            catalogEntries={[]}
+            onOpenPlugin={() => undefined}
           />
         </QueryClientWrapper>
       </MemoryRouter>,
@@ -532,6 +553,8 @@ describe("PluginDetail official catalog lifecycle", () => {
             onEdit={() => {}}
             onOpenSource={() => {}}
             onDelete={onDelete}
+            catalogEntries={[]}
+            onOpenPlugin={() => undefined}
           />
         </QueryClientWrapper>
       </MemoryRouter>,
@@ -676,6 +699,88 @@ describe("BB Official plugin detail routing", () => {
       );
       expect(document.activeElement).toBe(card);
     });
+  });
+
+  it("keeps related plugin navigation in the full-page detail", async () => {
+    const author = {
+      name: "BB",
+      github: "get-bb",
+      url: "https://github.com/get-bb",
+    };
+    const catalogEntries = [
+      { ...GITHUB_CATALOG_ENTRY, author, installed: true },
+      {
+        ...GITHUB_CATALOG_ENTRY,
+        entryId: "automations",
+        pluginId: "automations",
+        displayName: "Automations",
+        author,
+      },
+    ];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url === "/api/v1/plugins") {
+          return new Response(
+            JSON.stringify({
+              enabled: true,
+              plugins: [
+                {
+                  ...GITHUB_PLUGIN,
+                  iconUrl: null,
+                  screenshots: [],
+                  collections: [],
+                  providerIds: [],
+                  icons: {},
+                  updateState: {},
+                },
+              ],
+            }),
+            { headers: { "content-type": "application/json" } },
+          );
+        }
+        if (url.startsWith("/api/v1/plugin-catalog/search")) {
+          return new Response(
+            JSON.stringify({ results: catalogEntries, collections: [] }),
+            { headers: { "content-type": "application/json" } },
+          );
+        }
+        return new Response(JSON.stringify({ error: "not found" }), {
+          status: 404,
+          headers: { "content-type": "application/json" },
+        });
+      }),
+    );
+
+    const { wrapper: QueryClientWrapper } = createQueryClientTestHarness();
+    render(
+      <MemoryRouter
+        initialEntries={["/extensions/plugins/github?view=installed"]}
+      >
+        <Routes>
+          <Route path="/extensions/plugins/*" element={<RoutedToolsView />} />
+        </Routes>
+      </MemoryRouter>,
+      { wrapper: QueryClientWrapper },
+    );
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "Open Automations details",
+      }),
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("route-path").textContent).toBe(
+        "/extensions/plugins/automations",
+      );
+    });
+    expect(screen.getByTestId("route-search").textContent).toBe(
+      "?view=installed",
+    );
+    expect(
+      screen.queryByRole("button", { name: "Close Automations" }),
+    ).toBeNull();
   });
 
   it("opens an author from a card and returns to the prior Browse filters", async () => {
@@ -1049,6 +1154,8 @@ describe("PluginDetail runtime health", () => {
             onEdit={() => {}}
             onOpenSource={() => {}}
             onDelete={() => {}}
+            catalogEntries={[]}
+            onOpenPlugin={() => undefined}
           />
         </QueryClientWrapper>
       </MemoryRouter>,
@@ -1331,6 +1438,8 @@ describe("PluginDetail capability inventory", () => {
             onEdit={() => {}}
             onOpenSource={() => {}}
             onDelete={() => {}}
+            catalogEntries={[]}
+            onOpenPlugin={() => undefined}
           />
         </QueryClientWrapper>
       </MemoryRouter>,
@@ -1492,6 +1601,8 @@ describe("PluginDetail capability inventory", () => {
             onEdit={() => {}}
             onOpenSource={() => {}}
             onDelete={() => {}}
+            catalogEntries={[]}
+            onOpenPlugin={() => undefined}
           />
         </QueryClientWrapper>
       </MemoryRouter>,

--- a/apps/app/src/views/ToolsView.plugin-detail.test.tsx
+++ b/apps/app/src/views/ToolsView.plugin-detail.test.tsx
@@ -8,7 +8,13 @@ import {
   waitFor,
   within,
 } from "@testing-library/react";
-import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import {
+  MemoryRouter,
+  Route,
+  Routes,
+  useLocation,
+  useNavigate,
+} from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   EMPTY_PLUGIN_UPDATE_STATE,
@@ -99,8 +105,14 @@ function RoutedToolsView() {
         <ToolsView pluginId={pluginId} />
       </TooltipProvider>
       <output data-testid="route-path">{location.pathname}</output>
+      <output data-testid="route-search">{location.search}</output>
     </>
   );
+}
+
+function HistoryBackButton() {
+  const navigate = useNavigate();
+  return <button onClick={() => navigate(-1)}>Browser back</button>;
 }
 
 afterEach(() => {
@@ -660,6 +672,157 @@ describe("BB Official plugin detail routing", () => {
       );
       expect(document.activeElement).toBe(card);
     });
+  });
+
+  it("opens an author from a card and returns to the prior Browse filters", async () => {
+    const author = { name: "BB", url: "https://github.com/get-bb" };
+    const catalogEntries = [
+      {
+        ...GITHUB_CATALOG_ENTRY,
+        categoryId: "code-and-reviews",
+        category: "Code & Reviews",
+        author,
+      },
+      {
+        ...GITHUB_CATALOG_ENTRY,
+        entryId: "automations",
+        pluginId: "automations",
+        displayName: "Automations",
+        categoryId: "tasks-and-workflows",
+        category: "Tasks & Workflows",
+        author,
+      },
+    ];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url === "/api/v1/plugins") {
+          return new Response(JSON.stringify({ enabled: true, plugins: [] }), {
+            headers: { "content-type": "application/json" },
+          });
+        }
+        if (url.startsWith("/api/v1/plugin-catalog/search")) {
+          return new Response(
+            JSON.stringify({ results: catalogEntries, collections: [] }),
+            { headers: { "content-type": "application/json" } },
+          );
+        }
+        return new Response(JSON.stringify({ error: "not found" }), {
+          status: 404,
+          headers: { "content-type": "application/json" },
+        });
+      }),
+    );
+
+    const { wrapper: QueryClientWrapper } = createQueryClientTestHarness();
+    render(
+      <MemoryRouter
+        initialEntries={[
+          "/extensions/plugins?category=code-and-reviews&sort=recently-added",
+        ]}
+      >
+        <Routes>
+          <Route path="/extensions/plugins/*" element={<RoutedToolsView />} />
+        </Routes>
+        <HistoryBackButton />
+      </MemoryRouter>,
+      { wrapper: QueryClientWrapper },
+    );
+
+    fireEvent.click((await screen.findAllByRole("link", { name: "BB" }))[0]!);
+    expect(await screen.findByRole("heading", { name: /^BB/u })).toBeTruthy();
+    let params = new URLSearchParams(
+      screen.getByTestId("route-search").textContent ?? "",
+    );
+    expect(params.get("author")).toBe("11:bb-official:github:get-bb");
+    expect(params.getAll("category")).toEqual(["code-and-reviews"]);
+    expect(params.get("sort")).toBe("recently-added");
+
+    fireEvent.click(screen.getByRole("button", { name: "Browser back" }));
+    await waitFor(() => {
+      expect(screen.queryByRole("heading", { name: /^BB/u })).toBeNull();
+    });
+    params = new URLSearchParams(
+      screen.getByTestId("route-search").textContent ?? "",
+    );
+    expect(params.has("author")).toBe(false);
+    expect(params.getAll("category")).toEqual(["code-and-reviews"]);
+    expect(params.get("sort")).toBe("recently-added");
+
+    fireEvent.click((await screen.findAllByRole("link", { name: "BB" }))[0]!);
+    const card = await screen.findByRole("button", {
+      name: "Open GitHub details",
+    });
+    card.focus();
+    fireEvent.click(card);
+    expect(
+      await screen.findByRole("heading", { name: "More from this author" }),
+    ).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Close GitHub" }));
+    await waitFor(() => expect(document.activeElement).toBe(card));
+  });
+
+  it("routes the detail author link to the restored author page", async () => {
+    const author = { name: "BB", url: "https://github.com/get-bb" };
+    const catalogEntries = [
+      { ...GITHUB_CATALOG_ENTRY, author },
+      {
+        ...GITHUB_CATALOG_ENTRY,
+        entryId: "automations",
+        pluginId: "automations",
+        displayName: "Automations",
+        author,
+      },
+    ];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url === "/api/v1/plugins") {
+          return new Response(JSON.stringify({ enabled: true, plugins: [] }), {
+            headers: { "content-type": "application/json" },
+          });
+        }
+        if (url.startsWith("/api/v1/plugin-catalog/search")) {
+          return new Response(
+            JSON.stringify({ results: catalogEntries, collections: [] }),
+            { headers: { "content-type": "application/json" } },
+          );
+        }
+        return new Response(JSON.stringify({ error: "not found" }), {
+          status: 404,
+          headers: { "content-type": "application/json" },
+        });
+      }),
+    );
+
+    const { wrapper: QueryClientWrapper } = createQueryClientTestHarness();
+    render(
+      <MemoryRouter initialEntries={["/extensions/plugins/github"]}>
+        <Routes>
+          <Route path="/extensions/plugins/*" element={<RoutedToolsView />} />
+        </Routes>
+      </MemoryRouter>,
+      { wrapper: QueryClientWrapper },
+    );
+
+    expect(
+      await screen.findByRole("heading", { name: "More from this author" }),
+    ).toBeTruthy();
+    const authorLinks = screen.getAllByRole("link", { name: "BB" });
+    fireEvent.click(authorLinks.at(-1)!);
+    await waitFor(() => {
+      expect(screen.getByTestId("route-path").textContent).toBe(
+        "/extensions/plugins",
+      );
+    });
+    expect(await screen.findByRole("heading", { name: /^BB/u })).toBeTruthy();
+    expect(
+      new URLSearchParams(
+        screen.getByTestId("route-search").textContent ?? "",
+      ).get("author"),
+    ).toBe("11:bb-official:github:get-bb");
   });
 });
 

--- a/apps/app/src/views/ToolsView.tsx
+++ b/apps/app/src/views/ToolsView.tsx
@@ -162,6 +162,7 @@ function PluginsToolView({
 
 function PluginDetailToolView({ pluginId }: { pluginId: string }) {
   const navigate = useNavigate();
+  const location = useLocation();
   const [deleteTarget, setDeleteTarget] = useState<PluginListItem | null>(null);
   const [installTarget, setInstallTarget] =
     useState<PluginCatalogSearchEntry | null>(null);
@@ -258,6 +259,18 @@ function PluginDetailToolView({ pluginId }: { pluginId: string }) {
     },
     [canOpenPreferredDirectoryTarget, openPathInPreferredDirectoryTarget],
   );
+  const handleOpenCatalogPlugin = useCallback(
+    (nextPluginId: string) => {
+      const nextSearchParams = new URLSearchParams(location.search);
+      nextSearchParams.delete("view");
+      const search = nextSearchParams.toString();
+      navigate({
+        pathname: getPluginDetailRoutePath({ pluginId: nextPluginId }),
+        search: search === "" ? "" : `?${search}`,
+      });
+    },
+    [location.search, navigate],
+  );
 
   let detailContent: ReactNode;
   if (listQuery.isError) {
@@ -291,6 +304,8 @@ function PluginDetailToolView({ pluginId }: { pluginId: string }) {
         onOpenSource={handleOpenPluginSource}
         onDelete={setDeleteTarget}
         catalogEntry={selectedCatalogEntry ?? undefined}
+        catalogEntries={catalogQuery.data?.entries ?? []}
+        onOpenPlugin={handleOpenCatalogPlugin}
       />
     );
   } else if (selectedCatalogEntry !== null && !selectedCatalogEntry.installed) {
@@ -298,6 +313,8 @@ function PluginDetailToolView({ pluginId }: { pluginId: string }) {
       <CatalogPluginDetail
         entry={selectedCatalogEntry}
         onInstall={setInstallTarget}
+        catalogEntries={catalogQuery.data?.entries ?? []}
+        onOpenPlugin={handleOpenCatalogPlugin}
       />
     );
   } else if (catalogQuery.isError) {

--- a/apps/app/src/views/ToolsView.tsx
+++ b/apps/app/src/views/ToolsView.tsx
@@ -261,12 +261,9 @@ function PluginDetailToolView({ pluginId }: { pluginId: string }) {
   );
   const handleOpenCatalogPlugin = useCallback(
     (nextPluginId: string) => {
-      const nextSearchParams = new URLSearchParams(location.search);
-      nextSearchParams.delete("view");
-      const search = nextSearchParams.toString();
       navigate({
         pathname: getPluginDetailRoutePath({ pluginId: nextPluginId }),
-        search: search === "" ? "" : `?${search}`,
+        search: location.search,
       });
     },
     [location.search, navigate],

--- a/apps/server/src/services/plugin-catalog/plugin-catalog-service.ts
+++ b/apps/server/src/services/plugin-catalog/plugin-catalog-service.ts
@@ -1349,5 +1349,9 @@ function entryAuthor(entry: MarketplaceEntry): PluginCatalogAuthor {
     (entry.author.github === undefined
       ? null
       : `https://github.com/${entry.author.github}`);
-  return { name: entry.author.name, url };
+  return {
+    name: entry.author.name,
+    github: entry.author.github ?? null,
+    url,
+  };
 }

--- a/apps/server/test/services/plugin-catalog/plugin-catalog-service.test.ts
+++ b/apps/server/test/services/plugin-catalog/plugin-catalog-service.test.ts
@@ -488,6 +488,11 @@ describe("plugin catalog service", () => {
                   [
                     remoteEntry({
                       icon: "Zap",
+                      author: {
+                        name: "Acme",
+                        github: "acme",
+                        url: "https://acme.dev",
+                      },
                       category: "acme-tools",
                       screenshots: ["./screenshots/widgets/widgets.webp"],
                       publishedAt: "2026-08-20T11:47:04-07:00",
@@ -525,6 +530,11 @@ describe("plugin catalog service", () => {
         (entry) => entry.entryId === "widgets",
       );
       expect(widgets).toMatchObject({
+        author: {
+          name: "Acme",
+          github: "acme",
+          url: "https://acme.dev",
+        },
         categoryId: "acme-tools",
         category: "Acme tools",
         screenshots: [

--- a/packages/plugin-api-map/sdk-public-api.json
+++ b/packages/plugin-api-map/sdk-public-api.json
@@ -3,7 +3,7 @@
   "entries": {
     ".": {
       "types": "bundled-types/bb-plugin-sdk.d.ts",
-      "sha256": "12ee61da01f416049d2b947a0856756b0eb11d33141a2596e13beb4d29eabaa9"
+      "sha256": "41733b0e90c75c3bdbc5a11810d2a3e34b0985bc5ffe39c0087f727eca4bd410"
     },
     "./ai-services": {
       "types": "bundled-types/bb-plugin-sdk-ai-services.d.ts",

--- a/packages/server-contract/src/api/plugins.ts
+++ b/packages/server-contract/src/api/plugins.ts
@@ -365,6 +365,7 @@ export const pluginCatalogStatusResponseSchema = z.object({
 
 export const pluginCatalogAuthorSchema = z.object({
   name: z.string(),
+  github: z.string().nullable().default(null),
   url: z.string().nullable(),
 });
 export type PluginCatalogAuthor = z.infer<typeof pluginCatalogAuthorSchema>;


### PR DESCRIPTION
## Human comments

## What was wrong

Browse cards and plugin details showed author data without an in-app author route. The detail panel also omitted related plugins from the same author.

## What changed

This layer adds in-app author links to Browse cards and plugin details. Each link opens one author page with compatible plugins from one marketplace.

The author page keeps search, category, and sort state in the URL. It supports Featured, Recently added, and Most installed sorts.

The author header uses the same centered width as the toolbar and card grid. It stays aligned when a detail panel is open.

The header uses the most frequent author name. It uses the longest name when counts are equal.

Plugin details now show up to four other plugins from the same author. A related item keeps the current detail presentation.

Author identity uses a normalized GitHub login when available. It uses the exact author name otherwise. Marketplace identity prevents entries from different marketplaces from merging.

This PR targets `main`. It contains no code from the closed PR #2945.

This PR is intended for a squash merge. Intermediate commits import a file that existed only in the closed PR #2945.

This layer changes no host daemon wire data. It needs no CLI, guide, or protocol update.

The catalog response now includes the author's GitHub login. The Plugin SDK inventory records this contract change.

### Visual QA

| State | Before | After |
| --- | --- | --- |
| Author page | ![Browse had author text without an author page](https://github.com/user-attachments/assets/b484f819-406d-44d9-8258-3a9efca19207) | ![The BB author page shows 26 plugins](https://github.com/user-attachments/assets/7684220c-1af5-4b8a-a4d5-ea808d27ff0d) |
| Plugin detail | ![The plugin detail ended after Details](https://github.com/user-attachments/assets/b59e7940-e603-4351-97b6-4f7a1c0b644d) | ![The plugin detail shows four plugins from this author](https://github.com/user-attachments/assets/5cea2209-3eac-4b04-b2de-dd8fd3266c45) |

## How you verified

- `pnpm exec turbo run typecheck --filter=@bb/app --filter=@bb/shared-ui` passed.
- `pnpm exec turbo run test --filter=@bb/app --filter=@bb/shared-ui --force` passed.
- The app suite passed 3,800 tests. Four tests remained skipped.
- Shared UI has no test script. Turbo included it in the requested scope.
- The server catalog test passed 44 tests.
- The Plugin API map suite passed 76 tests.
- New tests cover header alignment, author name selection, filters, sorts, URL history, focus return, related limits, and full-page navigation.
- Doobie verified the author page and related-plugin detail at 1440 by 900 pixels.
- Doobie verified that a tag-only search returns plugins from the selected author.
- The browser console showed no errors during the final checks.

Fixes #N/A

> AGENT GENERATED
