### PR TITLE
Add the BB Official plugin collection

### DIFF
--- a/apps/server/scripts/generate-bb-official-marketplace.ts
+++ b/apps/server/scripts/generate-bb-official-marketplace.ts
@@ -229,7 +229,13 @@ export async function generateBbOfficialMarketplace(args: {
     displayName: "BB Official",
     description: "Plugins that ship with bb.",
     categories: PLUGIN_CATALOG_CATEGORIES,
-    collections: [],
+    collections: [
+      {
+        id: "bb-official",
+        displayName: "BB Official",
+        pluginIds: entries.map((entry) => entry.id),
+      },
+    ],
     plugins: entries,
   };
   await mkdir(path.dirname(args.outputPath), { recursive: true });

--- a/apps/server/src/services/plugin-catalog/plugin-catalog-service.ts
+++ b/apps/server/src/services/plugin-catalog/plugin-catalog-service.ts
@@ -22,6 +22,7 @@ import type {
   InstalledPlugin,
   PluginCatalogAuthor,
   PluginCatalogCollection,
+  PluginCatalogCollectionMembership,
   PluginCatalogInstallPlan,
   PluginCatalogResolvedSource,
   PluginCatalogSearchResult,
@@ -66,7 +67,6 @@ import {
   CURATED_MARKETPLACE_NAME,
   isBundledMarketplaceEntry,
   marketplaceEntryCategory,
-  marketplaceEntryCollections,
   marketplaceCollections,
   parseMarketplaceManifestJson,
   parseBundledMarketplaceManifestJson,
@@ -186,6 +186,7 @@ export function createPluginCatalogService(deps: {
 
   seedBundledMarketplace(now());
   seedCuratedMarketplace();
+  reservedCollectionIndex();
 
   const locks = new Map<string, Promise<unknown>>();
   const ADD_LOCK_KEY = "\0add";
@@ -321,6 +322,49 @@ export function createPluginCatalogService(deps: {
     };
   }
 
+  function reservedCollectionIndex(
+    overrides: ReadonlyMap<string, MarketplaceManifest> = new Map(),
+  ): {
+    collections: PluginCatalogCollection[];
+    membershipsByEntry: ReadonlyMap<
+      string,
+      readonly PluginCatalogCollectionMembership[]
+    >;
+  } {
+    const collectionsByKey = new Map<string, PluginCatalogCollection>();
+    const membershipsByEntry = new Map<
+      string,
+      PluginCatalogCollectionMembership[]
+    >();
+    const marketplacesByExposedId = new Map<string, string>();
+    for (const row of orderedMarketplaces()) {
+      if (!isReservedMarketplace(row.name)) continue;
+      const catalog = overrides.get(row.name) ?? catalogOf(row);
+      if (catalog === null) continue;
+      for (const collection of marketplaceCollections(catalog)) {
+        const existingMarketplace = marketplacesByExposedId.get(collection.id);
+        if (existingMarketplace !== undefined) {
+          throw new Error(
+            `duplicate reserved marketplace collection id "${collection.id}" in "${existingMarketplace}" and "${row.name}"`,
+          );
+        }
+        marketplacesByExposedId.set(collection.id, row.name);
+        const collectionKey = catalogEntryKey(row.name, collection.id);
+        collectionsByKey.set(collectionKey, collection);
+        collection.pluginIds.forEach((pluginId, rank) => {
+          const entryKey = catalogEntryKey(row.name, pluginId);
+          const memberships = membershipsByEntry.get(entryKey) ?? [];
+          memberships.push({ id: collection.id, rank });
+          membershipsByEntry.set(entryKey, memberships);
+        });
+      }
+    }
+    return {
+      collections: [...collectionsByKey.values()],
+      membershipsByEntry,
+    };
+  }
+
   function compatibilityProblem(ranges: {
     bbRange: string | undefined;
     sdkRange: string | undefined;
@@ -396,6 +440,7 @@ export function createPluginCatalogService(deps: {
     catalog: MarketplaceManifest;
     installedEntryIds: ReadonlySet<string>;
     installs: number | null;
+    collections: readonly PluginCatalogCollectionMembership[];
   }): Promise<PluginCatalogSearchResult | null> {
     const { entry, row, catalog } = args;
     const official = isReservedMarketplace(row.name);
@@ -449,7 +494,7 @@ export function createPluginCatalogService(deps: {
           ? {}
           : { categoryId: category.id, category: category.displayName }),
       screenshots,
-      collections: marketplaceEntryCollections(catalog, entry.id),
+      collections: [...args.collections],
       ...("publishedAt" in entry && typeof entry.publishedAt === "string"
         ? { publishedAt: entry.publishedAt }
         : {}),
@@ -534,6 +579,7 @@ export function createPluginCatalogService(deps: {
   ): Promise<void> {
     if (row.name === BUNDLED_MARKETPLACE_NAME) {
       seedBundledMarketplace(attemptedAt);
+      reservedCollectionIndex();
       deps.notifyCatalogChanged?.();
       return;
     }
@@ -564,6 +610,9 @@ export function createPluginCatalogService(deps: {
       }
       const rejection = rejectBundledIdCollisions(materialized.catalog);
       const catalog = rejection.catalog;
+      if (isReservedMarketplace(row.name)) {
+        reservedCollectionIndex(new Map([[row.name, catalog]]));
+      }
       collisionError = rejection.error;
       if (collisionError !== null) {
         deps.warn?.(`marketplace ${row.name} refresh ${collisionError}`);
@@ -993,10 +1042,7 @@ export function createPluginCatalogService(deps: {
     },
 
     collections() {
-      return orderedMarketplaces().flatMap((row) => {
-        const catalog = catalogOf(row);
-        return catalog === null ? [] : marketplaceCollections(catalog);
-      });
+      return reservedCollectionIndex().collections;
     },
 
     async addMarketplace(rawSource) {
@@ -1079,6 +1125,7 @@ export function createPluginCatalogService(deps: {
 
     async search(rawQuery) {
       const query = rawQuery.trim().toLowerCase();
+      const collectionIndex = reservedCollectionIndex();
       const curatedRow = getPluginMarketplace(
         deps.db,
         CURATED_MARKETPLACE_NAME,
@@ -1118,6 +1165,10 @@ export function createPluginCatalogService(deps: {
               installs: isReservedMarketplace(row.name)
                 ? (curatedInstalls.get(pluginId) ?? null)
                 : null,
+              collections:
+                collectionIndex.membershipsByEntry.get(
+                  catalogEntryKey(row.name, entry.id),
+                ) ?? [],
             });
             return result === null
               ? null

--- a/apps/server/src/services/plugin-catalog/plugin-catalog-service.ts
+++ b/apps/server/src/services/plugin-catalog/plugin-catalog-service.ts
@@ -134,6 +134,15 @@ type ResolvedCatalogEntry = {
   entry: MarketplaceEntry;
 };
 
+interface ReservedCollectionIndex {
+  catalogsByMarketplace: ReadonlyMap<string, MarketplaceManifest>;
+  collections: readonly PluginCatalogCollection[];
+  membershipsByEntry: ReadonlyMap<
+    string,
+    readonly PluginCatalogCollectionMembership[]
+  >;
+}
+
 export function createPluginCatalogService(deps: {
   db: DbConnection;
   appVersion: string;
@@ -186,7 +195,7 @@ export function createPluginCatalogService(deps: {
 
   seedBundledMarketplace(now());
   seedCuratedMarketplace();
-  reservedCollectionIndex();
+  let reservedCollections = buildReservedCollectionIndex();
 
   const locks = new Map<string, Promise<unknown>>();
   const ADD_LOCK_KEY = "\0add";
@@ -322,15 +331,10 @@ export function createPluginCatalogService(deps: {
     };
   }
 
-  function reservedCollectionIndex(
+  function buildReservedCollectionIndex(
     overrides: ReadonlyMap<string, MarketplaceManifest> = new Map(),
-  ): {
-    collections: PluginCatalogCollection[];
-    membershipsByEntry: ReadonlyMap<
-      string,
-      readonly PluginCatalogCollectionMembership[]
-    >;
-  } {
+  ): ReservedCollectionIndex {
+    const catalogsByMarketplace = new Map<string, MarketplaceManifest>();
     const collectionsByKey = new Map<string, PluginCatalogCollection>();
     const membershipsByEntry = new Map<
       string,
@@ -341,6 +345,7 @@ export function createPluginCatalogService(deps: {
       if (!isReservedMarketplace(row.name)) continue;
       const catalog = overrides.get(row.name) ?? catalogOf(row);
       if (catalog === null) continue;
+      catalogsByMarketplace.set(row.name, catalog);
       for (const collection of marketplaceCollections(catalog)) {
         const existingMarketplace = marketplacesByExposedId.get(collection.id);
         if (existingMarketplace !== undefined) {
@@ -360,6 +365,7 @@ export function createPluginCatalogService(deps: {
       }
     }
     return {
+      catalogsByMarketplace,
       collections: [...collectionsByKey.values()],
       membershipsByEntry,
     };
@@ -579,7 +585,7 @@ export function createPluginCatalogService(deps: {
   ): Promise<void> {
     if (row.name === BUNDLED_MARKETPLACE_NAME) {
       seedBundledMarketplace(attemptedAt);
-      reservedCollectionIndex();
+      reservedCollections = buildReservedCollectionIndex();
       deps.notifyCatalogChanged?.();
       return;
     }
@@ -610,9 +616,9 @@ export function createPluginCatalogService(deps: {
       }
       const rejection = rejectBundledIdCollisions(materialized.catalog);
       const catalog = rejection.catalog;
-      if (isReservedMarketplace(row.name)) {
-        reservedCollectionIndex(new Map([[row.name, catalog]]));
-      }
+      const nextReservedCollections = isReservedMarketplace(row.name)
+        ? buildReservedCollectionIndex(new Map([[row.name, catalog]]))
+        : null;
       collisionError = rejection.error;
       if (collisionError !== null) {
         deps.warn?.(`marketplace ${row.name} refresh ${collisionError}`);
@@ -646,6 +652,9 @@ export function createPluginCatalogService(deps: {
         });
         replacePluginMarketplaceIcons(tx, row.name, icons);
       });
+      if (nextReservedCollections !== null) {
+        reservedCollections = nextReservedCollections;
+      }
       deps.notifyCatalogChanged?.();
     } finally {
       await materialized.dispose();
@@ -1042,7 +1051,7 @@ export function createPluginCatalogService(deps: {
     },
 
     collections() {
-      return reservedCollectionIndex().collections;
+      return [...reservedCollections.collections];
     },
 
     async addMarketplace(rawSource) {
@@ -1125,7 +1134,7 @@ export function createPluginCatalogService(deps: {
 
     async search(rawQuery) {
       const query = rawQuery.trim().toLowerCase();
-      const collectionIndex = reservedCollectionIndex();
+      const collectionIndex = reservedCollections;
       const curatedRow = getPluginMarketplace(
         deps.db,
         CURATED_MARKETPLACE_NAME,
@@ -1152,7 +1161,9 @@ export function createPluginCatalogService(deps: {
       );
       const catalogEntryPromises = orderedMarketplaces().flatMap(
         (row, index) => {
-          const catalog = catalogOf(row);
+          const catalog = isReservedMarketplace(row.name)
+            ? (collectionIndex.catalogsByMarketplace.get(row.name) ?? null)
+            : catalogOf(row);
           if (catalog === null) return [];
           return catalog.plugins.map(async (entry) => {
             const bundled = bundledRegistration(entry);

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/references/plugins.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/references/plugins.md
@@ -15,7 +15,9 @@
   - The reserved **BB Official marketplace** has the name `bb-official`. It
     describes all plugins in the app bundle with a generated v2 document.
     Its source is a local path. It never uses the network. It appears first in
-    `bb marketplace list`. It can be neither added nor removed.
+    `bb marketplace list`. Its plugins appear in the first Browse shelf, BB
+    Official, and in their category shelves. It can be neither added nor
+    removed.
   - The store lists the **BB Community marketplace** catalog: a manifest
     the server re-reads at startup and every two hours from
     `https://getbb.app/marketplace/v2/marketplace.json`. A 404 response causes

--- a/apps/server/test/services/plugin-catalog/bb-official-generator.test.ts
+++ b/apps/server/test/services/plugin-catalog/bb-official-generator.test.ts
@@ -50,8 +50,14 @@ describe("bb-official marketplace generator", () => {
     expect(catalog.name).toBe(BUNDLED_MARKETPLACE_NAME);
     expect(catalog.displayName).toBe("BB Official");
     expect(catalog.categories).toEqual(PLUGIN_CATALOG_CATEGORIES);
-    expect(catalog.collections).toEqual([]);
     expect(catalog.plugins).toHaveLength(BUNDLED_PLUGINS.length);
+    expect(catalog.collections).toEqual([
+      {
+        id: "bb-official",
+        displayName: "BB Official",
+        pluginIds: BUNDLED_PLUGINS.map((plugin) => plugin.pluginId),
+      },
+    ]);
     for (const plugin of BUNDLED_PLUGINS) {
       const entry = catalog.plugins.find(
         (candidate) =>

--- a/apps/server/test/services/plugin-catalog/plugin-catalog-routes.test.ts
+++ b/apps/server/test/services/plugin-catalog/plugin-catalog-routes.test.ts
@@ -78,7 +78,7 @@ describe("plugin catalog routes", () => {
     );
     await expect(search.json()).resolves.toMatchObject({
       results: [{ entryId: "memory", installed: false }],
-      collections: [],
+      collections: [{ id: "bb-official", displayName: "BB Official" }],
     });
 
     const refresh = await app.request("/plugin-catalog/refresh", {

--- a/apps/server/test/services/plugin-catalog/plugin-catalog-service.test.ts
+++ b/apps/server/test/services/plugin-catalog/plugin-catalog-service.test.ts
@@ -196,6 +196,14 @@ describe("plugin catalog service", () => {
       iconUrl: null,
       category: "File Viewers & Editors",
       screenshots: [],
+      collections: [
+        {
+          id: "bb-official",
+          rank: BUNDLED_PLUGINS.findIndex(
+            (plugin) => plugin.pluginId === "simple-notes",
+          ),
+        },
+      ],
       source: "builtin:docs",
       marketplace: "bb-official",
       marketplaceDisplayName: "BB Official",
@@ -205,6 +213,13 @@ describe("plugin catalog service", () => {
       installed: false,
       compatible: true,
     });
+    expect(catalog.collections()).toEqual([
+      {
+        id: "bb-official",
+        displayName: "BB Official",
+        pluginIds: BUNDLED_PLUGINS.map((plugin) => plugin.pluginId),
+      },
+    ]);
     for (const category of PLUGIN_CATALOG_CATEGORIES) {
       const categoryNames = results
         .filter((entry) => entry.category === category.displayName)
@@ -494,8 +509,8 @@ describe("plugin catalog service", () => {
                     ],
                     collections: [
                       {
-                        id: "featured",
-                        displayName: "Featured",
+                        id: "new-and-notable",
+                        displayName: "New & notable",
                         pluginIds: ["missing-plugin", "widgets"],
                       },
                     ],
@@ -515,7 +530,7 @@ describe("plugin catalog service", () => {
         screenshots: [
           "https://marketplace.test/screenshots/widgets/widgets.webp",
         ],
-        collections: [{ id: "featured", rank: 0 }],
+        collections: [{ id: "new-and-notable", rank: 0 }],
         publishedAt: "2026-08-20T11:47:04-07:00",
         updatedAt: "2026-08-27T16:12:00Z",
       });
@@ -525,11 +540,86 @@ describe("plugin catalog service", () => {
       expect(uncategorized?.collections).toEqual([]);
       expect(catalog.collections()).toEqual([
         {
-          id: "featured",
-          displayName: "Featured",
+          id: "bb-official",
+          displayName: "BB Official",
+          pluginIds: BUNDLED_PLUGINS.map((plugin) => plugin.pluginId),
+        },
+        {
+          id: "new-and-notable",
+          displayName: "New & notable",
           pluginIds: ["widgets"],
         },
       ]);
+    });
+
+    it("ignores collections from a third-party marketplace", async () => {
+      const catalog = service();
+      upsertPluginMarketplace(db, {
+        name: "acme",
+        sourceKind: "path",
+        manifestUrl: dataDir,
+        sourceGitRef: null,
+        sourceGitCommit: null,
+        manifestJson: JSON.stringify(
+          manifestV2([remoteEntry({ icon: "Zap" })], {
+            name: "acme",
+            displayName: "Acme",
+            collections: [
+              {
+                id: "featured",
+                displayName: "Featured",
+                pluginIds: ["widgets"],
+              },
+            ],
+          }),
+        ),
+        statsJson: null,
+        etag: null,
+        lastModified: null,
+        lastSuccessfulRefreshAt: 1_000,
+        lastAttemptedRefreshAt: 1_000,
+        lastError: null,
+      });
+
+      expect((await catalog.search("widgets"))[0]?.collections).toEqual([]);
+      expect(catalog.collections()).toEqual([
+        {
+          id: "bb-official",
+          displayName: "BB Official",
+          pluginIds: BUNDLED_PLUGINS.map((plugin) => plugin.pluginId),
+        },
+      ]);
+    });
+
+    it("fails at load when reserved marketplace collection ids collide", () => {
+      upsertPluginMarketplace(db, {
+        name: "bb-community",
+        sourceKind: "https",
+        manifestUrl: MANIFEST_URL,
+        sourceGitRef: null,
+        sourceGitCommit: null,
+        manifestJson: JSON.stringify(
+          manifestV2([], {
+            collections: [
+              {
+                id: "bb-official",
+                displayName: "Duplicate",
+                pluginIds: [],
+              },
+            ],
+          }),
+        ),
+        statsJson: null,
+        etag: null,
+        lastModified: null,
+        lastSuccessfulRefreshAt: 1_000,
+        lastAttemptedRefreshAt: 1_000,
+        lastError: null,
+      });
+
+      expect(() => service()).toThrow(
+        'duplicate reserved marketplace collection id "bb-official" in "bb-official" and "bb-community"',
+      );
     });
 
     it("tints a catalog SVG but keeps a raster icon's own colors", async () => {

--- a/packages/templates/src/templates/bb-guide-plugins.md
+++ b/packages/templates/src/templates/bb-guide-plugins.md
@@ -350,8 +350,9 @@ marketplace describes these plugins with the standard v2 format. Its catalog
 uses a local path. It never uses the network. `bb marketplace list` shows it
 first. You cannot add or remove it.
 
-The plugins appear in Extensions → Plugins → Browse under BB Official. Install
-a plugin by its bare name or its qualified name. For example, use
+The plugins appear in the first Browse shelf, BB Official. They also appear in
+their category shelves. Install a plugin by its bare name or its qualified name.
+For example, use
 `bb plugin install docs` or `bb plugin install docs@bb-official`. bb copies the
 plugin from the app bundle. An app update also updates the bundled copy.
 


### PR DESCRIPTION
## Human comments

## What was wrong

The bundled marketplace document had no collection. The server also returned collections from third-party marketplaces and did not protect collection IDs across reserved marketplaces.

## What changed

- Added the BB Official collection to the generated v2 marketplace document.
- Added every bundled plugin ID in document order.
- Added a reserved collection index with marketplace-qualified internal keys.
- Ordered reserved collections by marketplace rank and document order.
- Added BB Official and BB Community membership data to search results.
- Excluded third-party marketplace collections.
- Rejected duplicate collection IDs across the two reserved marketplaces.
- Updated the plugin guide and the bb-cli skill reference.
- Kept the server contract unchanged because it already has all required fields.

No host daemon wire contract changed. `HOST_DAEMON_PROTOCOL_VERSION` stays unchanged.

## How you verified

- Ran the BB Official marketplace generator through Turbo.
- Ran Turbo type checks for `@bb/server`, `@bb/cli`, `@bb/templates`, and `@bb/app`.
- Ran Turbo tests for the same four packages.
- The server passed 2,184 tests.
- Added tests for collection output, order, membership rank, third-party exclusion, and duplicate IDs.
- Ran `git diff --check`.

Fixes #

> AGENT GENERATED
