### PR TITLE
Normalize outer whitespace in command search

### DIFF
--- a/apps/app/src/components/commands/CommandPalette.test.tsx
+++ b/apps/app/src/components/commands/CommandPalette.test.tsx
@@ -274,6 +274,17 @@ describe("CommandPalette", () => {
     expect(selectedOption()?.textContent).toContain("Open terminal");
   });
 
+  it("finds commands when the query starts with a space", async () => {
+    renderPalette();
+    openPalette();
+    await waitFor(() => expect(searchField()).toBeTruthy());
+
+    fireEvent.change(searchField(), { target: { value: "> new thread" } });
+
+    await waitFor(() => expect(optionTitles()).toHaveLength(1));
+    expect(selectedOption()?.textContent).toContain("New thread");
+  });
+
   it("wraps at both ends of the list", async () => {
     renderPalette();
     openPalette();

--- a/packages/fuzzy-match/src/index.ts
+++ b/packages/fuzzy-match/src/index.ts
@@ -817,7 +817,8 @@ export function fuzzyMatchText<T>(
     return [];
   }
 
-  if (!args.query) {
+  const query = args.query.trim();
+  if (!query) {
     return args.items.slice(0, args.limit).map((item) => ({
       item,
       score: 0,
@@ -825,7 +826,7 @@ export function fuzzyMatchText<T>(
     }));
   }
 
-  if (args.query.length > FUZZY_MATCH_QUERY_MAX_LENGTH) {
+  if (query.length > FUZZY_MATCH_QUERY_MAX_LENGTH) {
     return [];
   }
 
@@ -833,7 +834,7 @@ export function fuzzyMatchText<T>(
     mergeRankedTextMatches(
       rankTextQueryMatches(
         getTextCandidates(args.items, args.getText, args.getAliases),
-        args.query,
+        query,
       ),
     ),
     args.limit,

--- a/packages/fuzzy-match/test/index.test.ts
+++ b/packages/fuzzy-match/test/index.test.ts
@@ -327,6 +327,27 @@ describe("fuzzyMatchText", () => {
     ).toEqual(["Alpha", "Beta"]);
   });
 
+  it("normalizes outer whitespace while preserving internal spacing", () => {
+    const items = ["New thread", "New  thread", "Next thread"];
+
+    expect(
+      fuzzyMatchText({
+        items,
+        query: "  new  thread  ",
+        getText: (item) => item,
+        limit: items.length,
+      }).map((match) => match.item),
+    ).toEqual(["New  thread"]);
+    expect(
+      fuzzyMatchText({
+        items,
+        query: "  ",
+        getText: (item) => item,
+        limit: 2,
+      }).map((match) => match.item),
+    ).toEqual(["New thread", "New  thread"]);
+  });
+
   it("matches non-contiguous title queries", () => {
     const threads: ThreadSearchFixture[] = [
       { id: "thr_research", title: "Research notes" },


### PR DESCRIPTION
## Human comments

## What was wrong

Command mode removes the `>` prefix before ranking actions but passed the remaining text through unchanged. A natural query such as `> new thread` therefore reached the shared text matcher with a required leading space and returned no result, while `>new thread` worked.

## What changed

`fuzzyMatchText` now trims only leading and trailing query whitespace before its empty-query, length-limit, and matching paths. This fixes command search and keeps the shared behavior consistent for picker and mention callers without changing internal spacing, aliases, scores, result limits, or path matching. A rendered command-palette regression covers the user-facing query, and package coverage protects outer-whitespace normalization and blank-query ordering.

There are no wire, daemon-protocol, CLI, guide, documentation, native-app, or generated-file changes.

## How you verified

- Reproduced before the fix: `new thread` returned `New thread`; ` new thread` returned no result.
- Added red/green shared-matcher coverage for outer whitespace, preserved internal spacing, and blank-query ordering.
- Added a rendered command-palette regression for `> new thread`.
- `pnpm exec turbo run test --filter=@bb/fuzzy-match --force` — 27 tests passed.
- `pnpm exec turbo run test --filter=@bb/app --force -- "src/components/commands/CommandPalette.test.tsx"` — 21 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/fuzzy-match --filter=@bb/app --force` — both packages passed.
- Targeted `oxfmt --check` and `git diff --check origin/main...HEAD` passed.
- The full `@bb/app` suite and production app build also passed before the final clean rebase.

Fixes # (no linked issue)

> AGENT GENERATED
