### PR TITLE
Scope compaction outcome parsing to OMP

### DIFF
--- a/packages/provider-bridge-acp/src/bridge/bridge.test.ts
+++ b/packages/provider-bridge-acp/src/bridge/bridge.test.ts
@@ -2378,8 +2378,34 @@ describe("acp bridge", () => {
     expect(threadEventsOfType("thread/compacted")).toEqual([]);
   });
 
+  it.each([
+    { dialect: "generic", startArgs: {} },
+    { dialect: "OpenCode", startArgs: { dialectId: "opencode" } },
+  ])(
+    "does not apply OMP compaction prose to $dialect ACP",
+    async ({ startArgs }) => {
+      const { providerThreadId } = await startThread({
+        ...startArgs,
+        envVars: {
+          FAKE_ACP_COMPACT_AGENT_MESSAGE:
+            "The first compaction failed, but retry succeeded and the context is now smaller.",
+        },
+      });
+
+      const turnId = sendTurnRequest("turn/start", providerThreadId, {
+        input: compactCommandInput(),
+      });
+      expect((await waitForResponse(turnId)).error).toBeUndefined();
+
+      const completed = await waitForTurnCompleted();
+      expect(completed).toMatchObject({ status: "completed" });
+      expect(threadEventsOfType("thread/compacted")).toHaveLength(1);
+    },
+  );
+
   it("fails the compaction turn when the agent reports the failure in an end-turn message", async () => {
     const { providerThreadId } = await startThread({
+      dialectId: "omp",
       envVars: {
         FAKE_ACP_COMPACT_AGENT_MESSAGE:
           "Compaction failed: summary model rejected the request",
@@ -2403,6 +2429,7 @@ describe("acp bridge", () => {
 
   it("completes a no-op compaction turn without reporting a compacted context", async () => {
     const { providerThreadId } = await startThread({
+      dialectId: "omp",
       envVars: {
         FAKE_ACP_COMPACT_AGENT_MESSAGE:
           "Compaction failed: Nothing to compact (session too small)",
@@ -2426,6 +2453,7 @@ describe("acp bridge", () => {
 
   it("keeps classifying a no-op compaction when the agent rewords its prose", async () => {
     const { providerThreadId } = await startThread({
+      dialectId: "omp",
       envVars: {
         FAKE_ACP_COMPACT_AGENT_MESSAGE:
           "compaction failed: nothing to compact — the session is still small",
@@ -2450,6 +2478,7 @@ describe("acp bridge", () => {
 
   it("fails the compaction turn when the failure report is reworded or preceded by other text", async () => {
     const { providerThreadId } = await startThread({
+      dialectId: "omp",
       envVars: {
         FAKE_ACP_COMPACT_AGENT_MESSAGE:
           "Tried shrinking the context.\nCompaction failed: session is locked by another compaction",

--- a/packages/provider-bridge-acp/src/bridge/bridge.ts
+++ b/packages/provider-bridge-acp/src/bridge/bridge.ts
@@ -62,7 +62,11 @@ import {
   createAcpDeltaTranslator,
   type AcpDeltaTranslator,
 } from "../delta-translation.js";
-import { resolveAcpDialect, type AcpDialect } from "../dialect.js";
+import {
+  compactionOutcomeForEndTurn,
+  resolveAcpDialect,
+  type AcpDialect,
+} from "../dialect.js";
 import type { AcpMaintenanceDialect } from "./provider-maintenance.js";
 import {
   buildAcpPermissionInteractionPayload,
@@ -2092,20 +2096,6 @@ function runTurn(
   })();
 }
 
-const COMPACTION_FAILURE_PATTERN = /\bcompaction failed\b/i;
-const COMPACTION_NOOP_PATTERN = /\b(?:nothing to compact|already compacted)\b/i;
-
-function compactionOutcomeForEndTurn(
-  agentMessage: string,
-): Record<string, unknown> {
-  const text = agentMessage.trim();
-  if (!COMPACTION_FAILURE_PATTERN.test(text)) {
-    return { status: "completed" };
-  }
-  return COMPACTION_NOOP_PATTERN.test(text)
-    ? { status: "skipped", detail: text }
-    : { status: "failed", error: text };
-}
 function startCompaction(
   session: AcpThreadSession,
   pending: AcpPendingTurnInput,
@@ -2134,7 +2124,10 @@ function startCompaction(
     .then((result) => {
       finish(
         result.stopReason === "end_turn"
-          ? compactionOutcomeForEndTurn(session.compactionAgentMessage)
+          ? compactionOutcomeForEndTurn(
+              session.dialect,
+              session.compactionAgentMessage,
+            )
           : result.stopReason === "cancelled"
             ? { status: "interrupted" }
             : {

--- a/packages/provider-bridge-acp/src/dialect.ts
+++ b/packages/provider-bridge-acp/src/dialect.ts
@@ -28,6 +28,11 @@ export interface AcpDelegationReport {
   detail?: string;
 }
 
+type AcpCompactionOutcome =
+  | { status: "completed" }
+  | { status: "skipped"; detail: string }
+  | { status: "failed"; error: string };
+
 export interface AcpDialect {
   readonly id: string;
   toolIdentity?(event: AcpToolCallUpdateEvent): AcpToolIdentity | undefined;
@@ -291,6 +296,26 @@ function ompCommandResult(
     ...(exitCode === undefined ? {} : { exitCode }),
     ...(output.length === 0 ? {} : { output }),
   };
+}
+
+const OMP_COMPACTION_FAILURE_PATTERN = /\bcompaction failed\b/i;
+const OMP_COMPACTION_NOOP_PATTERN =
+  /\b(?:nothing to compact|already compacted)\b/i;
+
+export function compactionOutcomeForEndTurn(
+  dialect: AcpDialect,
+  agentMessage: string,
+): AcpCompactionOutcome {
+  if (dialect.id !== "omp") {
+    return { status: "completed" };
+  }
+  const text = agentMessage.trim();
+  if (!OMP_COMPACTION_FAILURE_PATTERN.test(text)) {
+    return { status: "completed" };
+  }
+  return OMP_COMPACTION_NOOP_PATTERN.test(text)
+    ? { status: "skipped", detail: text }
+    : { status: "failed", error: text };
 }
 
 export const OMP_ACP_DIALECT: AcpDialect = {


### PR DESCRIPTION
## Human comments

## What was wrong

The ACP bridge classified every successful manual-compaction response by looking for OMP-specific phrases such as `compaction failed`. That policy leaked across dialects, so a generic ACP or OpenCode response describing an earlier failed attempt could be reported as a failed compaction even when the agent's final result was successful.

## What changed

- Move end-turn compaction classification into the ACP dialect contract.
- Apply the existing failure/no-op prose handling only to OMP.
- Let generic ACP and OpenCode keep the completed result reported by their successful end turn.
- Add regressions for generic ACP and OpenCode while preserving OMP failed and skipped outcomes.
- No wire contract or host-daemon protocol change is required.

## How you verified

- `pnpm exec turbo run test typecheck --filter=@bb/provider-bridge-acp --force` (307 tests passed)
- `pnpm exec turbo run test --filter=@bb/server --force -- "test/public/public-thread-compaction.test.ts"` (4 tests passed)
- `pnpm exec turbo run build:types --filter=@get-bb/plugin-sdk --force`
- `pnpm exec turbo run test --filter=@bb/plugin-api-map --force` (75 tests passed; public SDK inventory unchanged)
- `pnpm exec oxfmt --check packages/provider-bridge-acp/src/bridge/bridge.ts packages/provider-bridge-acp/src/bridge/bridge.test.ts packages/provider-bridge-acp/src/dialect.ts`
- `git diff --check origin/main...HEAD`

Follow-up to #2293.

> AGENT GENERATED
