### PR TITLE
Fix Cursor reasoning ladders for every model

### DIFF
--- a/apps/app/src/hooks/thread-creation-options/model-catalog-selection.ts
+++ b/apps/app/src/hooks/thread-creation-options/model-catalog-selection.ts
@@ -30,6 +30,21 @@ interface ResolvedModelCatalogSelection {
   isUnavailableModelRecovery: boolean;
 }
 
+export function resolveModelReasoningLevel(
+  model: AvailableModel | undefined,
+  preferredReasoningLevel: ReasoningLevel,
+): ReasoningLevel {
+  const supportedReasoningLevels =
+    model?.supportedReasoningEfforts.map((effort) => effort.reasoningEffort) ??
+    [];
+  return supportedReasoningLevels.length === 0
+    ? preferredReasoningLevel
+    : reconcileReasoningLevel(
+        preferredReasoningLevel,
+        supportedReasoningLevels,
+      );
+}
+
 function toModelPickerOption(
   model: AvailableModel,
   formatModelLabel: (displayName: string) => string,
@@ -112,13 +127,10 @@ export function resolveModelCatalogSelection({
   }
 
   const preferredLevel = preferredReasoningLevel ?? "medium";
-  const reasoningLevel =
-    reasoningOptions.length === 0
-      ? preferredLevel
-      : reconcileReasoningLevel(
-          preferredLevel,
-          reasoningOptions.map((option) => option.value),
-        );
+  const reasoningLevel = resolveModelReasoningLevel(
+    activeModel,
+    preferredLevel,
+  );
 
   return {
     selectedModel,

--- a/apps/app/src/hooks/useThreadCreationOptions.test.tsx
+++ b/apps/app/src/hooks/useThreadCreationOptions.test.tsx
@@ -406,6 +406,78 @@ describe("useThreadCreationOptions", () => {
     });
   });
 
+  it("persists the reconciled reasoning level when switching to a shorter model ladder", async () => {
+    const response = executionOptionsResponse();
+    vi.mocked(sdk.system.executionOptions).mockResolvedValue({
+      ...response,
+      models: [
+        {
+          id: "wide-model",
+          model: "wide-model",
+          displayName: "Wide Model",
+          description: "",
+          supportedReasoningEfforts: [
+            { reasoningEffort: "low", description: "" },
+            { reasoningEffort: "medium", description: "" },
+            { reasoningEffort: "high", description: "" },
+            { reasoningEffort: "xhigh", description: "" },
+            { reasoningEffort: "max", description: "" },
+          ],
+          defaultReasoningEffort: "medium",
+          isDefault: true,
+        },
+        {
+          id: "short-model",
+          model: "short-model",
+          displayName: "Short Model",
+          description: "",
+          supportedReasoningEfforts: [
+            { reasoningEffort: "low", description: "" },
+            { reasoningEffort: "medium", description: "" },
+            { reasoningEffort: "high", description: "" },
+          ],
+          defaultReasoningEffort: "medium",
+          isDefault: false,
+        },
+      ],
+    });
+    const { result } = renderHook(
+      () =>
+        useThreadCreationOptions({
+          scope: "new-thread",
+          initialProviderId: GLOBAL_PROVIDER_ID,
+          initialModel: "wide-model",
+          initialReasoningLevel: "max",
+        }),
+      { wrapper: createQueryClientTestHarness().wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.selectedModel).toBe("wide-model");
+      expect(result.current.reasoningLevel).toBe("max");
+    });
+
+    act(() => {
+      result.current.setSelectedModel("short-model");
+    });
+
+    await waitFor(() => {
+      expect(result.current.selectedModel).toBe("short-model");
+      expect(result.current.reasoningLevel).toBe("high");
+      expect(result.current.executionInputSources.reasoningLevel).toBe(
+        "client-preference",
+      );
+    });
+
+    act(() => {
+      result.current.setSelectedModel("wide-model");
+    });
+
+    await waitFor(() => {
+      expect(result.current.reasoningLevel).toBe("high");
+    });
+  });
+
   it("applies a fork provider, model, and reasoning seed atomically", async () => {
     window.localStorage.setItem("bb.promptbox.provider", GLOBAL_PROVIDER_ID);
     vi.mocked(sdk.system.executionOptions).mockImplementation(async (args) =>

--- a/apps/app/src/hooks/useThreadCreationOptions.ts
+++ b/apps/app/src/hooks/useThreadCreationOptions.ts
@@ -64,7 +64,10 @@ import {
   type UsePromptModelReasoningOptions,
   updateThreadPromptSelections,
 } from "./thread-creation-options/selection-state";
-import { resolveModelCatalogSelection } from "./thread-creation-options/model-catalog-selection";
+import {
+  resolveModelCatalogSelection,
+  resolveModelReasoningLevel,
+} from "./thread-creation-options/model-catalog-selection";
 
 export { formatModelLabel, resolvePermissionModeSelection };
 
@@ -735,8 +738,23 @@ export function useThreadCreationOptions(
   const setSelectedModel = useCallback(
     (value: string) => {
       touchedThreadFieldsRef.current.add("selectedModel");
+      const nextModel =
+        executionOptionsQuery.data?.models.find(
+          (model) => model.model === value,
+        ) ??
+        executionOptionsQuery.data?.selectedOnlyModels.find(
+          (model) => model.model === value,
+        );
+      const nextReasoningLevel = resolveModelReasoningLevel(
+        nextModel,
+        reasoningLevel,
+      );
       if (usesStoredCreateSelections) {
-        setStoredSelectedModel(value);
+        setStoredProviderModelReasoning({
+          providerId: effectiveProviderId,
+          model: value,
+          reasoningLevel: nextReasoningLevel,
+        });
         return;
       }
       setLocalProvidersUsingDefaults((current) => {
@@ -747,18 +765,20 @@ export function useThreadCreationOptions(
       });
       localProviderSelectionsRef.current.set(effectiveProviderId, {
         model: value,
-        reasoningLevel,
+        reasoningLevel: nextReasoningLevel,
       });
       setThreadSelections((currentSelections) => ({
         ...currentSelections,
         selectedModel: value,
-        reasoningLevel,
+        reasoningLevel: nextReasoningLevel,
       }));
     },
     [
       effectiveProviderId,
+      executionOptionsQuery.data?.models,
+      executionOptionsQuery.data?.selectedOnlyModels,
       reasoningLevel,
-      setStoredSelectedModel,
+      setStoredProviderModelReasoning,
       usesStoredCreateSelections,
     ],
   );

--- a/packages/host-daemon-contract/src/protocol.ts
+++ b/packages/host-daemon-contract/src/protocol.ts
@@ -1,3 +1,3 @@
-export const HOST_DAEMON_PROTOCOL_VERSION = 177 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 178 as const;
 
 export const HOST_ARTIFACT_MAX_BYTES = 256 * 1024 * 1024;

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -935,7 +935,7 @@ const ACP_BRIDGE_LAUNCH = {
 
 describe("host-daemon command schemas", () => {
   it("uses the current host-daemon protocol version", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(177);
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(178);
     expect(HOST_ARTIFACT_MAX_BYTES).toBe(256 * 1024 * 1024);
   });
 

--- a/packages/provider-bridge-acp/src/bridge/bridge.test.ts
+++ b/packages/provider-bridge-acp/src/bridge/bridge.test.ts
@@ -630,6 +630,36 @@ describe("acp bridge", () => {
     });
   });
 
+  it("uses Cursor CLI variants as reasoning metadata for bare ACP models", async () => {
+    const modelListId = sendModelList({
+      dialectId: "cursor",
+      parameterizedModelPicker: true,
+      modelPickerPrimaryModels: ["default", "gemini-3.8-flash"],
+      modelLines: [
+        "auto - Auto (default)",
+        "gemini-3.8-flash-low - Gemini 3.8 Flash Low",
+        "gemini-3.8-flash-medium - Gemini 3.8 Flash Medium",
+        "gemini-3.8-flash-high - Gemini 3.8 Flash High",
+      ].join("\n"),
+    });
+
+    const result = (await waitForResponse(modelListId)).result as {
+      models: {
+        id: string;
+        supportedReasoningEfforts: { reasoningEffort: string }[];
+      }[];
+    };
+    expect(result.models.map((model) => model.id)).toEqual([
+      "default",
+      "gemini-3.8-flash",
+    ]);
+    expect(
+      result.models[1]?.supportedReasoningEfforts.map(
+        (effort) => effort.reasoningEffort,
+      ),
+    ).toEqual(["low", "medium", "high"]);
+  });
+
   it("discovers ACP-native models and per-model reasoning from session configOptions", async () => {
     const modelListId = sendModelList({
       envVars: {

--- a/packages/provider-bridge-acp/src/bridge/bridge.ts
+++ b/packages/provider-bridge-acp/src/bridge/bridge.ts
@@ -80,6 +80,7 @@ import {
   type AcpSessionParams,
   type AcpSkillRoot,
 } from "../session-params.js";
+import { buildCursorParameterizedModelCatalog } from "../cursor-model-selection.js";
 import {
   getAcpProviderHealth,
   getAcpProviderInstallationRun,
@@ -2303,15 +2304,20 @@ function decodeAcpBridgeJsonRpcRequest(raw: unknown): DecodedAcpBridgeRequest {
 async function handleModelList(
   id: string | number,
   params: AcpModelListParams,
+  dialectId: string | undefined,
 ): Promise<void> {
   const catalog = params.listCommand
     ? await loadAgentModelCatalog(params.listCommand)
     : null;
   if (catalog) {
+    const catalogModels =
+      params.parameterizedModelPicker && dialectId === "cursor"
+        ? buildCursorParameterizedModelCatalog(catalog.models)
+        : catalog.models;
     sendResult(
       id,
       splitPrimaryModels(
-        applyConfiguredReasoningToModels(catalog.models, {
+        applyConfiguredReasoningToModels(catalogModels, {
           reasoningCli: params.reasoningCli,
           nativeReasoning: params.nativeReasoning,
         }),
@@ -2451,6 +2457,7 @@ async function handleRequest(
           decodeLaunchSpec(request.params.providerOptions),
           modelPicker,
         ),
+        decodeDialectId(request.params.providerOptions),
       );
       return;
     }

--- a/packages/provider-bridge-acp/src/cursor-model-selection.test.ts
+++ b/packages/provider-bridge-acp/src/cursor-model-selection.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildAgentModelCatalog,
+  parseAgentModelLines,
+} from "./bridge/model-catalog.js";
+import {
+  buildCursorParameterizedModelCatalog,
+  cursorParameterizedSelection,
+} from "./cursor-model-selection.js";
+
+describe("Cursor parameterized model selection", () => {
+  it("keeps bare ACP ids while preserving CLI reasoning variants", () => {
+    const catalog = buildAgentModelCatalog(
+      parseAgentModelLines(
+        [
+          "auto - Auto (default)",
+          "cursor-grok-4.6-low - Cursor Grok 4.6 Low",
+          "cursor-grok-4.6-medium - Cursor Grok 4.6 Medium",
+          "cursor-grok-4.6-high - Cursor Grok 4.6 High",
+          "gemini-3.8-flash-low - Gemini 3.8 Flash Low",
+          "gemini-3.8-flash-medium - Gemini 3.8 Flash Medium",
+          "gemini-3.8-flash-high - Gemini 3.8 Flash High",
+        ].join("\n"),
+      ),
+    );
+    if (catalog === null) {
+      throw new Error("expected Cursor model catalog");
+    }
+
+    const models = buildCursorParameterizedModelCatalog(catalog.models);
+    expect(models.map((model) => model.id)).toEqual([
+      "default",
+      "grok-4.6",
+      "gemini-3.8-flash",
+    ]);
+    expect(
+      models
+        .find((model) => model.id === "gemini-3.8-flash")
+        ?.supportedReasoningEfforts.map((effort) => effort.reasoningEffort),
+    ).toEqual(["low", "medium", "high"]);
+    expect(models[0]?.isDefault).toBe(true);
+  });
+
+  it("merges legacy fixed-effort families into their bare model", () => {
+    const catalog = buildAgentModelCatalog(
+      parseAgentModelLines(
+        [
+          "gemini-3.6-flash-minimal - Gemini 3.6 Flash Minimal",
+          "gemini-3.6-flash-medium - Gemini 3.6 Flash Medium",
+          "gemini-3.6-flash-high - Gemini 3.6 Flash High",
+        ].join("\n"),
+      ),
+    );
+    if (catalog === null) {
+      throw new Error("expected Cursor model catalog");
+    }
+
+    const models = buildCursorParameterizedModelCatalog(catalog.models);
+    expect(models).toHaveLength(1);
+    expect(models[0]).toMatchObject({
+      id: "gemini-3.6-flash",
+      displayName: "Gemini 3.6 Flash",
+      defaultReasoningEffort: "medium",
+    });
+    expect(
+      models[0]?.supportedReasoningEfforts.map(
+        (effort) => effort.reasoningEffort,
+      ),
+    ).toEqual(["low", "medium", "high"]);
+  });
+
+  it("normalizes a legacy variant before session selection", () => {
+    expect(
+      cursorParameterizedSelection("cursor-grok-4.6-medium", "high"),
+    ).toEqual({ modelId: "grok-4.6", reasoningLevel: "high" });
+  });
+});

--- a/packages/provider-bridge-acp/src/cursor-model-selection.ts
+++ b/packages/provider-bridge-acp/src/cursor-model-selection.ts
@@ -1,0 +1,126 @@
+import { reasoningLevelValues } from "@bb/domain";
+import type { AvailableModel, ReasoningLevel } from "@bb/domain";
+import { agentModelFamilyId } from "./bridge/model-catalog.js";
+
+interface CursorParameterizedSelection {
+  modelId: string;
+  reasoningLevel?: ReasoningLevel;
+}
+
+const CURSOR_LEGACY_FAMILY_SELECTIONS: Readonly<
+  Record<string, CursorParameterizedSelection>
+> = {
+  "claude-4-sonnet": { modelId: "claude-sonnet-4" },
+  "claude-4.5-opus": { modelId: "claude-opus-4-5" },
+  "claude-4.5-sonnet": { modelId: "claude-sonnet-4-5" },
+  "claude-4.6-opus": { modelId: "claude-opus-4-6" },
+  "claude-4.6-sonnet": { modelId: "claude-sonnet-4-6" },
+  "gemini-3.6-flash-minimal": {
+    modelId: "gemini-3.6-flash",
+    reasoningLevel: "low",
+  },
+  "gpt-5.1-codex-max": { modelId: "gpt-5.1" },
+};
+
+function bareCursorFamilyId(model: string): string {
+  const familyId = model === "auto" ? "default" : agentModelFamilyId(model);
+  return familyId.startsWith("cursor-")
+    ? familyId.slice("cursor-".length)
+    : familyId;
+}
+
+export function cursorParameterizedSelection(
+  model: string,
+  reasoningLevel: ReasoningLevel | undefined,
+): CursorParameterizedSelection {
+  const familyId = bareCursorFamilyId(model);
+  const selection = CURSOR_LEGACY_FAMILY_SELECTIONS[familyId] ?? {
+    modelId: familyId,
+  };
+  return selection.reasoningLevel !== undefined || reasoningLevel === undefined
+    ? selection
+    : { ...selection, reasoningLevel };
+}
+
+function cursorCatalogModel(model: AvailableModel): {
+  model: AvailableModel;
+  directFamily: boolean;
+} {
+  const selection = cursorParameterizedSelection(
+    model.id,
+    model.defaultReasoningEffort,
+  );
+  const efforts = new Map<
+    ReasoningLevel,
+    AvailableModel["supportedReasoningEfforts"][number]
+  >();
+  for (const effort of model.supportedReasoningEfforts) {
+    const level =
+      cursorParameterizedSelection(model.id, effort.reasoningEffort)
+        .reasoningLevel ?? effort.reasoningEffort;
+    if (!efforts.has(level)) {
+      efforts.set(level, { ...effort, reasoningEffort: level });
+    }
+  }
+  return {
+    model: {
+      ...model,
+      id: selection.modelId,
+      model: selection.modelId,
+      supportedReasoningEfforts: [...efforts.values()].sort(
+        (a, b) =>
+          reasoningLevelValues.indexOf(a.reasoningEffort) -
+          reasoningLevelValues.indexOf(b.reasoningEffort),
+      ),
+      defaultReasoningEffort:
+        selection.reasoningLevel ?? model.defaultReasoningEffort,
+    },
+    directFamily: bareCursorFamilyId(model.id) === selection.modelId,
+  };
+}
+
+export function buildCursorParameterizedModelCatalog(
+  models: readonly AvailableModel[],
+): AvailableModel[] {
+  const normalized = new Map<
+    string,
+    { model: AvailableModel; directFamily: boolean }
+  >();
+  for (const model of models) {
+    const candidate = cursorCatalogModel(model);
+    const current = normalized.get(candidate.model.id);
+    if (current === undefined) {
+      normalized.set(candidate.model.id, candidate);
+      continue;
+    }
+    const preferred =
+      candidate.directFamily && !current.directFamily ? candidate : current;
+    const efforts = new Map(
+      preferred.model.supportedReasoningEfforts.map((effort) => [
+        effort.reasoningEffort,
+        effort,
+      ]),
+    );
+    for (const effort of [
+      ...current.model.supportedReasoningEfforts,
+      ...candidate.model.supportedReasoningEfforts,
+    ]) {
+      if (!efforts.has(effort.reasoningEffort)) {
+        efforts.set(effort.reasoningEffort, effort);
+      }
+    }
+    normalized.set(candidate.model.id, {
+      model: {
+        ...preferred.model,
+        supportedReasoningEfforts: [...efforts.values()].sort(
+          (a, b) =>
+            reasoningLevelValues.indexOf(a.reasoningEffort) -
+            reasoningLevelValues.indexOf(b.reasoningEffort),
+        ),
+        isDefault: current.model.isDefault || candidate.model.isDefault,
+      },
+      directFamily: preferred.directFamily,
+    });
+  }
+  return [...normalized.values()].map((entry) => entry.model);
+}

--- a/packages/provider-bridge-acp/src/session-params.ts
+++ b/packages/provider-bridge-acp/src/session-params.ts
@@ -12,7 +12,7 @@ import {
   type AcpBridgePermissionCli,
   type AcpBridgeReasoningCli,
 } from "./bridge-protocol.js";
-import { agentModelFamilyId } from "./bridge/model-catalog.js";
+import { cursorParameterizedSelection } from "./cursor-model-selection.js";
 import type { AcpLaunchSpec } from "./launch-spec.js";
 
 export interface AcpSessionExecutionOptions {
@@ -203,42 +203,6 @@ export function buildAcpModelListParams(
       ? { nativeReasoning: launchSpec.nativeReasoning }
       : {}),
   };
-}
-
-interface CursorParameterizedSelection {
-  modelId: string;
-  reasoningLevel?: ReasoningLevel;
-}
-
-const CURSOR_LEGACY_FAMILY_SELECTIONS: Readonly<
-  Record<string, CursorParameterizedSelection>
-> = {
-  "claude-4-sonnet": { modelId: "claude-sonnet-4" },
-  "claude-4.5-opus": { modelId: "claude-opus-4-5" },
-  "claude-4.5-sonnet": { modelId: "claude-sonnet-4-5" },
-  "claude-4.6-opus": { modelId: "claude-opus-4-6" },
-  "claude-4.6-sonnet": { modelId: "claude-sonnet-4-6" },
-  "gemini-3.6-flash-minimal": {
-    modelId: "gemini-3.6-flash",
-    reasoningLevel: "low",
-  },
-  "gpt-5.1-codex-max": { modelId: "gpt-5.1" },
-};
-
-function cursorParameterizedSelection(
-  model: string,
-  reasoningLevel: ReasoningLevel | undefined,
-): CursorParameterizedSelection {
-  const familyId = model === "auto" ? "default" : agentModelFamilyId(model);
-  const bareFamilyId = familyId.startsWith("cursor-")
-    ? familyId.slice("cursor-".length)
-    : familyId;
-  const selection = CURSOR_LEGACY_FAMILY_SELECTIONS[bareFamilyId] ?? {
-    modelId: bareFamilyId,
-  };
-  return selection.reasoningLevel !== undefined || reasoningLevel === undefined
-    ? selection
-    : { ...selection, reasoningLevel };
 }
 
 function buildAcpModelSelectionParam(

--- a/plugins/provider-acp/src/agents.test.ts
+++ b/plugins/provider-acp/src/agents.test.ts
@@ -232,6 +232,10 @@ describe("acpProviderDeclaration", () => {
       acpLaunchSpec: {
         command: "cursor-agent",
         args: ["acp"],
+        modelCli: {
+          listArgs: ["--list-models"],
+          primaryModels: [],
+        },
       },
     });
     expect(byId.get("acp-grok")?.experimental_bridgeOptions).toMatchObject({

--- a/plugins/provider-acp/src/known-agents.ts
+++ b/plugins/provider-acp/src/known-agents.ts
@@ -60,6 +60,10 @@ export const KNOWN_ACP_AGENTS: readonly AcpAgentDefinition[] = [
       command: "cursor-agent",
       args: ["acp"],
       env: {},
+      modelCli: {
+        listArgs: ["--list-models"],
+        primaryModels: [],
+      },
       nativeSkillRoots: {
         user: recursiveRoots([
           ".cursor/skills",


### PR DESCRIPTION
## Human comments

## What was wrong

Cursor probed ACP models sequentially within five seconds and prioritized Grok. Later models, including Gemini 3.8 Flash, therefore kept a synthetic Medium-only reasoning choice even though Cursor listed their real variants.

## What changed

- Read Cursor model and reasoning metadata from `cursor-agent --list-models`.
- Normalize CLI variant families to the bare model IDs required by Cursor ACP sessions.
- Merge legacy fixed-effort families into their current parameterized models.
- Bump `HOST_DAEMON_PROTOCOL_VERSION` from 177 to 178 because the Cursor launch specification now sends the model-list command to the host daemon.

## How you verified

- `pnpm exec turbo run test --filter=@bb/provider-bridge-acp --filter=bb-plugin-provider-acp --filter=@bb/host-daemon-contract --force` — 443 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/provider-bridge-acp --filter=bb-plugin-provider-acp --filter=@bb/host-daemon-contract --force` — six tasks passed.
- Cursor CLI 2026.08.31 live catalog mapped Gemini 3.8 Flash to Low, Medium, and High while preserving model id `gemini-3.8-flash`.

Fixes #2503

> AGENT GENERATED