### PR TITLE
fix(mobile): unblock Android release build for WKS-1535

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
     "patchedDependencies": {
       "expo-modules-jsi@57.0.4": "patches/expo-modules-jsi@57.0.4.patch",
       "oniguruma-to-es@4.3.4": "patches/oniguruma-to-es@4.3.4.patch",
-      "@pierre/diffs@1.2.9": "patches/@pierre__diffs@1.2.9.patch"
+      "@pierre/diffs@1.2.9": "patches/@pierre__diffs@1.2.9.patch",
+      "@react-native-cookies/cookies@6.2.1": "patches/@react-native-cookies__cookies@6.2.1.patch"
     }
   }
 }

--- a/patches/@react-native-cookies__cookies@6.2.1.patch
+++ b/patches/@react-native-cookies__cookies@6.2.1.patch
@@ -1,0 +1,20 @@
+diff --git a/android/build.gradle b/android/build.gradle
+index 13c7e43faf79865f9c9aef8d4d4971edf5057449..14ab1bef34ea1b93f377aa72cf086da4b32db905 100644
+--- a/android/build.gradle
++++ b/android/build.gradle
+@@ -31,7 +31,7 @@ buildscript {
+     if (project == rootProject) {
+         repositories {
+             google()
+-            jcenter()
++            mavenCentral()
+         }
+         dependencies {
+             classpath 'com.android.tools.build:gradle:3.5.3'
+@@ -67,5 +67,5 @@ repositories {
+         url "$rootDir/../node_modules/jsc-android/dist"
+     }
+     google()
+-    jcenter()
++    mavenCentral()
+ }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ patchedDependencies:
   '@pierre/diffs@1.2.9':
     hash: wdjikkl65wfpocm6wrflymrtdq
     path: patches/@pierre__diffs@1.2.9.patch
+  '@react-native-cookies/cookies@6.2.1':
+    hash: s72aowoinnkfundvu4ubltsjfi
+    path: patches/@react-native-cookies__cookies@6.2.1.patch
   expo-modules-jsi@57.0.4:
     hash: raucdrgf3mznkb7qkl7fkzjw5u
     path: patches/expo-modules-jsi@57.0.4.patch
@@ -838,7 +841,7 @@ importers:
         version: 1.0.15(react-native-svg@15.15.4(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.86.2(@babel/core@7.29.0))(@types/react@19.2.13)(react@19.2.4))(react@19.2.4))(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.86.2(@babel/core@7.29.0))(@types/react@19.2.13)(react@19.2.4))(react@19.2.4)
       '@react-native-cookies/cookies':
         specifier: ^6.2.1
-        version: 6.2.1(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.86.2(@babel/core@7.29.0))(@types/react@19.2.13)(react@19.2.4))
+        version: 6.2.1(patch_hash=s72aowoinnkfundvu4ubltsjfi)(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.86.2(@babel/core@7.29.0))(@types/react@19.2.13)(react@19.2.4))
       '@react-native/normalize-colors':
         specifier: 0.86.2
         version: 0.86.2
@@ -19564,7 +19567,7 @@ snapshots:
 
   '@radix-ui/rect@1.1.2': {}
 
-  '@react-native-cookies/cookies@6.2.1(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.86.2(@babel/core@7.29.0))(@types/react@19.2.13)(react@19.2.4))':
+  '@react-native-cookies/cookies@6.2.1(patch_hash=s72aowoinnkfundvu4ubltsjfi)(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.86.2(@babel/core@7.29.0))(@types/react@19.2.13)(react@19.2.4))':
     dependencies:
       invariant: 2.2.4
       react-native: 0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.86.2(@babel/core@7.29.0))(@types/react@19.2.13)(react@19.2.4)

--- a/qa/receipts/wks-1535-2026-09-02.md
+++ b/qa/receipts/wks-1535-2026-09-02.md
@@ -11,7 +11,7 @@ This receipt records the Android candidate build and the live-device gate. No pa
 
 - Samsung was reachable earlier at `100.74.61.90:5555`; the installed package was `app.getbb.mobile`, version `0.39.0`, version code `1`.
 - The original deep-link reproduction accepted `am start` with `Status: ok`, but focus then landed on `expo.modules.devlauncher.launcher.DevLauncherActivity` instead of rendering the requested thread. Launch success was therefore not treated as acceptance.
-- On 2026-09-02, ADB first reported the tablet offline and then absent. `adb connect 100.74.61.90:5555` timed out. The final `adb devices -l` observation at `2026-09-02T16:49:08-0500` had no attached devices.
+- On 2026-09-02, ADB first reported the tablet offline and then absent. `adb connect 100.74.61.90:5555` timed out. A recorded `adb devices -l` observation at `2026-09-02T16:49:08-0500` had no attached devices; the same empty state was confirmed again at final verification.
 - ADB/watchdog polling and restart attempts are stopped. No candidate install, data clear, deep-link render check, pairing survival check, or rollback was attempted while the tablet was unreachable.
 
 ## Android candidate

--- a/qa/receipts/wks-1535-2026-09-02.md
+++ b/qa/receipts/wks-1535-2026-09-02.md
@@ -1,0 +1,63 @@
+# WKS-1535 native-client certification receipt
+
+Date: 2026-09-02
+Branch: `dallascrilley/wks-1535-certify-bb-native-clients-pairing-reconnect-pending`
+
+## Scope
+
+This receipt records the Android candidate build and the live-device gate. No pairing credentials, cookies, tokens, or server secrets are recorded.
+
+## Samsung live-device gate
+
+- Samsung was reachable earlier at `100.74.61.90:5555`; the installed package was `app.getbb.mobile`, version `0.39.0`, version code `1`.
+- The original deep-link reproduction accepted `am start` with `Status: ok`, but focus then landed on `expo.modules.devlauncher.launcher.DevLauncherActivity` instead of rendering the requested thread. Launch success was therefore not treated as acceptance.
+- On 2026-09-02, ADB first reported the tablet offline and then absent. `adb connect 100.74.61.90:5555` timed out. The final `adb devices -l` observation at `2026-09-02T16:49:08-0500` had no attached devices.
+- ADB/watchdog polling and restart attempts are stopped. No candidate install, data clear, deep-link render check, pairing survival check, or rollback was attempted while the tablet was unreachable.
+
+## Android candidate
+
+The repository-owned dependency repair is `patches/@react-native-cookies__cookies@6.2.1.patch`; it replaces both obsolete `jcenter()` repository entries with `mavenCentral()`. `pnpm install --frozen-lockfile` applied the patch successfully; a fresh run on 2026-09-02 exited 0 with the repository's pre-existing missing generated desktop/daemon bin warnings.
+
+The all-ABI release attempt timed out without producing a usable APK and was not repeated. The arm64-only command completed successfully on 2026-09-02:
+
+```text
+cd apps/mobile/android && ANDROID_HOME=/opt/homebrew/share/android-commandlinetools ANDROID_SDK_ROOT=/opt/homebrew/share/android-commandlinetools ./gradlew app:assembleRelease --no-daemon -PreactNativeArchitectures=arm64-v8a
+```
+
+Artifact:
+
+- Path: `apps/mobile/android/app/build/outputs/apk/release/app-release.apk`
+- Size: `65426699` bytes
+- SHA-256: `d4055cc0480715e09765a0ee8b68cdf52045a8f41e673dbf1662e65d1e3341b2`
+- APK package: `app.getbb.mobile`
+- Version: `0.39.0` (`versionCode=1`)
+- Native ABI: `arm64-v8a`
+- Signature: APK v2, Android debug certificate SHA-256 `fac61745dc0903786fb9ede62a962b399f7348f0bb6f899b8332667591033b9c`
+
+Offline manifest inspection shows `app.getbb.mobile.MainActivity` exported with the `bb` URI scheme and no DevLauncher activity in the release manifest. The installed tablet certificate could not be compared because the tablet disappeared before the required pre-install APK pull. The candidate was not installed.
+
+## Shared-server and repository checks
+
+- The mobile E2E backend started successfully on localhost and returned `{"ok":true}` from `/health`; it was stopped after the check.
+- `pnpm exec turbo run test:smoke --filter=@bb/integration-tests`: passed, 10 files / 28 tests.
+- `pnpm exec turbo run test --filter=@bb/integration-tests`: not clean, 20 files / 71 tests passed and 6 files / 6 tests failed by the existing 60-second test timeout in fake environment/multi-thread coverage. No mobile device claim is based on this suite.
+- `pnpm exec turbo run typecheck lint test --filter=@bb/mobile --force`: passed on 2026-09-02, with typecheck and tests clean; 43 files / 326 tests passed. Lint completed with four pre-existing warnings in `WebViewSpikeScreen.tsx` and `useShellBridge.ts`.
+
+## Recovery and rollback gate
+
+- Recovery action taken: stopped ADB/watchdog polling and restart attempts after the TCP timeout and empty device list. No repeated connection attempts were made.
+- Rollback artifact status: no original APK was pulled before the tablet disappeared, so no rollback APK is held by this worktree. Because the candidate was never installed, installed app data was not changed and no rollback was needed.
+- Required next live-install sequence: restore the tablet connection, pull the installed APK, verify both installed and candidate certificates with `apksigner`, then use data-preserving `adb install -r` only after the signatures match. Capture install output and pairing state; if recovery is required, reinstall the saved original APK with `adb install -r` and verify the saved pairing state without clearing data.
+- Install/update proof: none. The only verified artifact is the offline arm64 APK described above; no `adb install`, update, launch-render, or rollback command ran.
+
+## Acceptance status
+
+| Behavior | Samsung | iPhone |
+| --- | --- | --- |
+| Pairing | Blocked: tablet unreachable | Blocked: physical device/Xcode unavailable |
+| Reconnect | Blocked: tablet unreachable | Blocked: physical device/Xcode unavailable |
+| Pending interaction | Blocked: tablet unreachable | Blocked: physical device/Xcode unavailable |
+| Revocation | Blocked: tablet unreachable | Blocked: physical device/Xcode unavailable |
+| Update and pairing-data survival | Blocked: no install performed | Blocked: physical device/Xcode unavailable |
+
+This is an evidence-backed partial receipt, not a certification pass.

--- a/qa/receipts/wks-1535-2026-09-02.md
+++ b/qa/receipts/wks-1535-2026-09-02.md
@@ -41,7 +41,7 @@ Offline manifest inspection shows `app.getbb.mobile.MainActivity` exported with 
 - The mobile E2E backend started successfully on localhost and returned `{"ok":true}` from `/health`; it was stopped after the check.
 - `pnpm exec turbo run test:smoke --filter=@bb/integration-tests`: passed, 10 files / 28 tests.
 - `pnpm exec turbo run test --filter=@bb/integration-tests`: not clean, 20 files / 71 tests passed and 6 files / 6 tests failed by the existing 60-second test timeout in fake environment/multi-thread coverage. No mobile device claim is based on this suite.
-- `pnpm exec turbo run typecheck lint test --filter=@bb/mobile --force`: passed on 2026-09-02, with typecheck and tests clean; 43 files / 326 tests passed. Lint completed with four pre-existing warnings in `WebViewSpikeScreen.tsx` and `useShellBridge.ts`.
+- `pnpm exec turbo run typecheck lint test --filter=@bb/mobile --force`: passed at `2026-09-02T16:51:26-0500`, with typecheck and tests clean; 43 files / 326 tests passed. Lint completed with four pre-existing warnings in `WebViewSpikeScreen.tsx` and `useShellBridge.ts`.
 
 ## Recovery and rollback gate
 


### PR DESCRIPTION
## Human comments

## What was wrong

The Android candidate could not be packaged for native-client certification because `@react-native-cookies/cookies@6.2.1` still referenced the retired `jcenter()` repository in both Android repository blocks. WKS-1535 live-device certification also remains gated by device availability.

## What changed

- Added the repository-owned pnpm patch `patches/@react-native-cookies__cookies@6.2.1.patch` to use `mavenCentral()`.
- Updated `package.json` and `pnpm-lock.yaml` so frozen installs apply the patch.
- Added the dated, evidence-backed partial certification receipt at `qa/receipts/wks-1535-2026-09-02.md`.

## How you verified

- `pnpm install --frozen-lockfile`: passed.
- Arm64-only Android release build: passed; APK package/version/signature/manifest evidence is recorded in the receipt.
- `pnpm exec turbo run typecheck lint test --filter=@bb/mobile --force`: passed, 326 tests; lint has four existing warnings.
- `pnpm exec turbo run test:smoke --filter=@bb/integration-tests`: passed, 28 tests.
- Full integration suite was not clean: six tests hit the existing 60-second timeout; details are recorded in the receipt.
- Samsung ADB is unreachable and iPhone/Xcode is unavailable, so no install, update, pairing-data, render, or rollback claim is made.

Fixes WKS-1535

> AGENT GENERATED
