### PR TITLE
Fix provisioning steers and optimistic follow-up delivery

### DIFF
--- a/apps/app/src/components/promptbox/FollowUpPromptBox.stories.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.stories.tsx
@@ -775,11 +775,12 @@ function Row({
         attachedToComposer={true}
         queuedMessages={storyQueuedMessages}
         inlineEditor={inlineEditor}
+        sendAction="send-now"
         sendDisabled={false}
         actionDisabled={false}
         processingMessageId={null}
         processingAction={null}
-        onSendImmediately={(id) =>
+        onSend={(id) =>
           setStoryQueuedMessages((current) =>
             current.filter((message) => message.id !== id),
           )

--- a/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
@@ -568,6 +568,10 @@ function FollowUpPromptBoxWithComposer({
   );
   const steerOnPrimarySubmit =
     submitMode.kind === "queue" && composer.steerActiveThreadOnEnter;
+  const isSteeringWhenReady =
+    steerOnPrimarySubmit &&
+    (composer.threadRuntimeDisplayStatus === "provisioning" ||
+      composer.threadRuntimeDisplayStatus === "starting");
   const onPrimarySubmit = steerOnPrimarySubmit
     ? composer.onModifierSubmit
     : composer.onSubmit;
@@ -719,7 +723,9 @@ function FollowUpPromptBoxWithComposer({
               ? composer.submitTitle
               : canQueueFollowUp
                 ? steerOnPrimarySubmit
-                  ? "Steer current run (Enter)"
+                  ? isSteeringWhenReady
+                    ? "Steer when ready (Enter)"
+                    : "Steer current run (Enter)"
                   : "Queue follow-up (Enter)"
                 : isStopping
                   ? "Stopping run..."

--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.drag.test.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.drag.test.tsx
@@ -48,11 +48,12 @@ describe("QueuedMessagesList group-handle drag", () => {
       <QueuedMessagesList
         attachedToComposer={true}
         queuedMessages={queuedMessages}
+        sendAction="send-now"
         sendDisabled={false}
         actionDisabled={false}
         processingMessageId={null}
         processingAction={null}
-        onSendImmediately={noop}
+        onSend={noop}
         onReorder={noop}
         onSetGroupBoundary={onSetGroupBoundary}
         onEdit={noop}

--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.stories.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.stories.tsx
@@ -352,11 +352,12 @@ function StaticQueuedMessagesList({
     <QueuedMessagesList
       attachedToComposer={true}
       queuedMessages={queuedMessages}
+      sendAction="send-now"
       sendDisabled={sendDisabled}
       actionDisabled={actionDisabled}
       processingMessageId={processingMessageId ?? null}
       processingAction={processingAction ?? null}
-      onSendImmediately={noop}
+      onSend={noop}
       onReorder={noop}
       onSetGroupBoundary={noop}
       onEdit={noop}
@@ -389,11 +390,12 @@ function ReorderableQueuedMessagesList() {
     <QueuedMessagesList
       attachedToComposer={true}
       queuedMessages={queuedMessages}
+      sendAction="send-now"
       sendDisabled={false}
       actionDisabled={false}
       processingMessageId={null}
       processingAction={null}
-      onSendImmediately={noop}
+      onSend={noop}
       onReorder={handleReorder}
       onSetGroupBoundary={handleSetGroupBoundary}
       onEdit={noop}

--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.test.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.test.tsx
@@ -32,14 +32,17 @@ const bottomAnchorMocks = vi.hoisted(() => ({
 
 function QueuedMessagesList({
   attachedToComposer = true,
+  sendAction = "send-now",
   ...props
-}: Omit<QueuedMessagesListProps, "attachedToComposer"> & {
+}: Omit<QueuedMessagesListProps, "attachedToComposer" | "sendAction"> & {
   attachedToComposer?: boolean;
+  sendAction?: QueuedMessagesListProps["sendAction"];
 }) {
   return (
     <QueuedMessagesListComponent
       {...props}
       attachedToComposer={attachedToComposer}
+      sendAction={sendAction}
     />
   );
 }
@@ -127,7 +130,7 @@ function renderQueuedMessages(
       actionDisabled={false}
       processingMessageId={null}
       processingAction={null}
-      onSendImmediately={noop}
+      onSend={noop}
       onReorder={noop}
       onSetGroupBoundary={noop}
       onEdit={noop}
@@ -149,7 +152,7 @@ function renderQueuedMessagesWithOptions(
       actionDisabled={false}
       processingMessageId={null}
       processingAction={null}
-      onSendImmediately={noop}
+      onSend={noop}
       onReorder={noop}
       onSetGroupBoundary={noop}
       onEdit={noop}
@@ -269,7 +272,7 @@ describe("QueuedMessagesList", () => {
       actionDisabled: false,
       processingMessageId: null,
       processingAction: null,
-      onSendImmediately: noop,
+      onSend: noop,
       onReorder: noop,
       onSetGroupBoundary: noop,
       onEdit: noop,
@@ -378,7 +381,9 @@ describe("QueuedMessagesList", () => {
       name: "Delete queued message 1",
     });
 
-    expect(getByRole("button", { name: "Queued message 1 actions" })).toBeTruthy();
+    expect(
+      getByRole("button", { name: "Queued message 1 actions" }),
+    ).toBeTruthy();
     expect(editButton).toBeTruthy();
     expect(deleteButton).toBeTruthy();
     expect(container.querySelector('[data-icon="Sent"]')).not.toBeNull();
@@ -425,7 +430,7 @@ describe("QueuedMessagesList", () => {
         actionDisabled={false}
         processingMessageId={null}
         processingAction={null}
-        onSendImmediately={noop}
+        onSend={noop}
         onReorder={noop}
         onSetGroupBoundary={noop}
         onEdit={noop}
@@ -464,7 +469,9 @@ describe("QueuedMessagesList", () => {
     ).not.toBeNull();
     expect(getByTestId("inline-queue-editor")).toBeTruthy();
 
-    fireEvent.click(getByRole("button", { name: "Stop editing queued message" }));
+    fireEvent.click(
+      getByRole("button", { name: "Stop editing queued message" }),
+    );
     expect(onDismiss).toHaveBeenCalledOnce();
   });
 
@@ -482,7 +489,7 @@ describe("QueuedMessagesList", () => {
         actionDisabled={false}
         processingMessageId={null}
         processingAction={null}
-        onSendImmediately={noop}
+        onSend={noop}
         onReorder={noop}
         onSetGroupBoundary={noop}
         onEdit={noop}
@@ -515,7 +522,7 @@ describe("QueuedMessagesList", () => {
       actionDisabled: false,
       processingMessageId: null,
       processingAction: null,
-      onSendImmediately: noop,
+      onSend: noop,
       onReorder: noop,
       onSetGroupBoundary: noop,
       onEdit: noop,
@@ -562,7 +569,7 @@ describe("QueuedMessagesList", () => {
       actionDisabled: false,
       processingMessageId: null,
       processingAction: null,
-      onSendImmediately: noop,
+      onSend: noop,
       onReorder: noop,
       onSetGroupBoundary: noop,
       onEdit: noop,
@@ -623,7 +630,7 @@ describe("QueuedMessagesList", () => {
       actionDisabled: false,
       processingMessageId: null,
       processingAction: null,
-      onSendImmediately: noop,
+      onSend: noop,
       onReorder: noop,
       onSetGroupBoundary: noop,
       onEdit: noop,
@@ -725,7 +732,7 @@ describe("QueuedMessagesList", () => {
             actionDisabled={false}
             processingMessageId={null}
             processingAction={null}
-            onSendImmediately={noop}
+            onSend={noop}
             onReorder={noop}
             onSetGroupBoundary={noop}
             onEdit={noop}
@@ -811,7 +818,7 @@ describe("QueuedMessagesList", () => {
             actionDisabled={false}
             processingMessageId={null}
             processingAction={null}
-            onSendImmediately={noop}
+            onSend={noop}
             onReorder={noop}
             onSetGroupBoundary={noop}
             onEdit={noop}
@@ -915,7 +922,7 @@ describe("QueuedMessagesList", () => {
               actionDisabled={false}
               processingMessageId={null}
               processingAction={null}
-              onSendImmediately={noop}
+              onSend={noop}
               onReorder={noop}
               onSetGroupBoundary={noop}
               onEdit={noop}
@@ -1072,7 +1079,7 @@ describe("QueuedMessagesList", () => {
         actionDisabled={false}
         processingMessageId={queuedMessage.id}
         processingAction="send"
-        onSendImmediately={noop}
+        onSend={noop}
         onReorder={noop}
         onSetGroupBoundary={noop}
         onEdit={noop}
@@ -1461,7 +1468,7 @@ describe("QueuedMessagesList", () => {
         actionDisabled={false}
         processingMessageId={null}
         processingAction={null}
-        onSendImmediately={noop}
+        onSend={noop}
         onReorder={noop}
         onSetGroupBoundary={noop}
         onEdit={noop}
@@ -1485,7 +1492,7 @@ describe("QueuedMessagesList", () => {
         actionDisabled={false}
         processingMessageId={null}
         processingAction={null}
-        onSendImmediately={noop}
+        onSend={noop}
         onReorder={noop}
         onSetGroupBoundary={noop}
         onEdit={noop}
@@ -1635,6 +1642,33 @@ describe("queued row affordances", () => {
       },
     ]);
     expect(queued.queryByLabelText("Send queued message 1 now")).toBeNull();
+  });
+
+  it("offers to steer a provisioning row when the thread is ready", () => {
+    const onSend = vi.fn();
+    const { getByLabelText } = render(
+      <QueuedMessagesList
+        queuedMessages={[
+          {
+            ...makeQueuedMessage("q_provisioning", "Steer after startup"),
+            waitingOn: { kind: "provisioning" },
+          },
+        ]}
+        sendAction="steer-when-ready"
+        sendDisabled={false}
+        actionDisabled={false}
+        processingMessageId={null}
+        processingAction={null}
+        onSend={onSend}
+        onReorder={noop}
+        onSetGroupBoundary={noop}
+        onEdit={noop}
+        onDelete={noop}
+      />,
+    );
+
+    fireEvent.click(getByLabelText("Steer queued message 1 when ready"));
+    expect(onSend).toHaveBeenCalledWith("q_provisioning");
   });
 
   it("names the absent machine on a host-offline row and hides Send now", () => {

--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
@@ -101,6 +101,7 @@ import {
 } from "@/components/promptbox/queued-editor-typeahead-layout";
 
 export type QueuedMessageProcessingAction = "send" | "edit" | "delete";
+export type QueuedMessageSendAction = "send-now" | "steer-when-ready";
 
 export interface QueuedMessageGroupBoundaryRequest {
   expectedGroupedPrefixQueuedMessageIds: string[];
@@ -123,12 +124,13 @@ export interface QueuedMessagesListProps {
   attachedToComposer: boolean;
   queuedMessages: readonly ThreadQueuedMessage[];
   resolveMentionLink?: PromptMentionLinkResolver;
+  sendAction: QueuedMessageSendAction;
   sendDisabled: boolean;
   actionDisabled: boolean;
   processingMessageId: string | null;
   processingAction: QueuedMessageProcessingAction | null;
   inlineEditor?: QueuedMessageInlineEditor;
-  onSendImmediately: (id: string) => void;
+  onSend: (id: string) => void;
   onReorder: (request: QueuedMessageReorderRequest) => void;
   onSetGroupBoundary: (request: QueuedMessageGroupBoundaryRequest) => void;
   onEdit: (request: QueuedMessageEditRequest) => void;
@@ -151,9 +153,10 @@ interface QueuedMessageRowProps {
   isProcessing: boolean;
   processingLabel: string;
   dragDisabled: boolean;
+  sendAction: QueuedMessageSendAction;
   sendDisabled: boolean;
   actionDisabled: boolean;
-  onSendImmediately: (id: string) => void;
+  onSend: (id: string) => void;
   onEdit: (request: QueuedMessageEditRequest) => void;
   onDelete: (id: string) => void;
   compact: boolean;
@@ -739,9 +742,10 @@ const QueuedMessageRow = memo(function QueuedMessageRow({
   isProcessing,
   processingLabel,
   dragDisabled,
+  sendAction,
   sendDisabled,
   actionDisabled,
-  onSendImmediately,
+  onSend,
   onEdit,
   onDelete,
   compact,
@@ -757,7 +761,15 @@ const QueuedMessageRow = memo(function QueuedMessageRow({
       : "",
   );
   const hasWaitLine = queuedMessageHasWaitLine(queuedMessage);
-  const sendNowAllowed = isQueuedMessageSendNowAllowed(queuedMessage.waitingOn);
+  const sendAllowed =
+    sendAction === "steer-when-ready" ||
+    isQueuedMessageSendNowAllowed(queuedMessage.waitingOn);
+  const sendAriaLabel =
+    sendAction === "steer-when-ready"
+      ? `Steer queued message ${index + 1} when ready`
+      : `Send queued message ${index + 1} now`;
+  const sendLabel =
+    sendAction === "steer-when-ready" ? "Steer when ready" : "Send now";
   const {
     attributes,
     isDragging,
@@ -868,7 +880,7 @@ const QueuedMessageRow = memo(function QueuedMessageRow({
                   "group-focus-within/dispatch-row:pointer-events-auto group-focus-within/dispatch-row:opacity-100",
                 )}
               >
-                {sendNowAllowed ? (
+                {sendAllowed ? (
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <Button
@@ -880,13 +892,13 @@ const QueuedMessageRow = memo(function QueuedMessageRow({
                           compact ? "size-7" : "size-8",
                         )}
                         disabled={actionDisabled || sendDisabled}
-                        onClick={() => onSendImmediately(queuedMessage.id)}
-                        aria-label={`Send queued message ${index + 1} now`}
+                        onClick={() => onSend(queuedMessage.id)}
+                        aria-label={sendAriaLabel}
                       >
                         <Icon name="Sent" className="size-4" aria-hidden />
                       </Button>
                     </TooltipTrigger>
-                    <TooltipContent>Send now</TooltipContent>
+                    <TooltipContent>{sendLabel}</TooltipContent>
                   </Tooltip>
                 ) : null}
                 {queuedMessage.editable ? (
@@ -958,13 +970,13 @@ const QueuedMessageRow = memo(function QueuedMessageRow({
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="min-w-[7rem]">
-                {sendNowAllowed ? (
+                {sendAllowed ? (
                   <DropdownMenuItem
                     disabled={sendDisabled}
-                    onSelect={() => onSendImmediately(queuedMessage.id)}
+                    onSelect={() => onSend(queuedMessage.id)}
                   >
                     <Icon name="Sent" aria-hidden />
-                    Send now
+                    {sendLabel}
                   </DropdownMenuItem>
                 ) : null}
                 {queuedMessage.editable ? (
@@ -1130,12 +1142,13 @@ export function QueuedMessagesList({
   attachedToComposer,
   queuedMessages,
   resolveMentionLink,
+  sendAction,
   sendDisabled,
   actionDisabled,
   processingMessageId,
   processingAction,
   inlineEditor,
-  onSendImmediately,
+  onSend,
   onReorder,
   onSetGroupBoundary,
   onEdit,
@@ -1631,11 +1644,12 @@ export function QueuedMessagesList({
           isProcessing={processingMessageId === queuedMessage.id}
           processingLabel={processingLabel}
           dragDisabled={sortingDisabled || inlineEditor !== undefined}
+          sendAction={sendAction}
           sendDisabled={sendDisabled}
           actionDisabled={actionDisabled}
           compact={mode !== "workspace"}
           isGroupBoundary={messageIndex === groupBoundaryIndex}
-          onSendImmediately={onSendImmediately}
+          onSend={onSend}
           onEdit={handleEdit}
           onDelete={onDelete}
         />,

--- a/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.test.tsx
+++ b/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.test.tsx
@@ -26,6 +26,7 @@ const mocks = vi.hoisted(() => ({
   pendingInteractionsRefetch: vi.fn(),
   queuedMessages: [] as Array<{ id: string }>,
   readTrackingThreads: [] as Array<unknown>,
+  sendQueuedMessageMutateAsync: vi.fn(),
   sendThreadMessageMutateAsync: vi.fn(),
   threadRuntimeDisplayStatus: "idle" as string,
   timelineRows: [] as Array<{ text: string }>,
@@ -107,19 +108,27 @@ vi.mock("@/components/promptbox/FollowUpPromptBox", async () => {
 vi.mock("@/components/promptbox/banner/QueuedMessagesList", () => ({
   QueuedMessagesList: ({
     attachedToComposer,
+    onSend,
     queuedMessages,
+    sendAction,
     sendDisabled,
   }: {
     attachedToComposer: boolean;
+    onSend: (queuedMessageId: string) => void;
     queuedMessages: readonly unknown[];
+    sendAction: "send-now" | "steer-when-ready";
     sendDisabled: boolean;
   }) => (
     <div
       data-testid="embedded-chat-queued-messages"
       data-attached-to-composer={String(attachedToComposer)}
+      data-send-action={sendAction}
       data-send-disabled={sendDisabled ? "" : undefined}
     >
       <span data-testid="queued-count">{queuedMessages.length}</span>
+      <button type="button" onClick={() => onSend("q1")}>
+        Send queued message
+      </button>
     </div>
   ),
 }));
@@ -310,7 +319,7 @@ vi.mock("@/hooks/mutations/thread-runtime-mutations", () => ({
     isPending: false,
   }),
   useSendThreadQueuedMessage: () => ({
-    mutateAsync: vi.fn(),
+    mutateAsync: mocks.sendQueuedMessageMutateAsync,
     isPending: false,
   }),
   useSetThreadQueuedMessageGroupBoundary: () => ({
@@ -398,6 +407,7 @@ describe("EmbeddedThreadChat", () => {
     mocks.pendingInteractionsRefetch.mockReset().mockResolvedValue({});
     mocks.queuedMessages = [];
     mocks.readTrackingThreads = [];
+    mocks.sendQueuedMessageMutateAsync.mockReset().mockResolvedValue({});
     mocks.threadRuntimeDisplayStatus = "idle";
     mocks.timelineRows = [];
     mocks.injectedTimelineProps = [];
@@ -534,6 +544,27 @@ describe("EmbeddedThreadChat", () => {
     const composer = screen.getByTestId("embedded-chat-composer");
     expect(queue.nextElementSibling).toBe(composer);
     expect(screen.getByTestId("queued-count").textContent).toBe("2");
+  });
+
+  it("steers a queued row once provisioning is ready", async () => {
+    mocks.threadRuntimeDisplayStatus = "provisioning";
+    mocks.queuedMessages = [{ id: "q1" }];
+    renderEmbeddedChat();
+
+    const queue = screen.getByTestId("embedded-chat-queued-messages");
+    expect(queue.dataset.sendAction).toBe("steer-when-ready");
+    expect(queue.dataset.sendDisabled).toBeUndefined();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Send queued message" }),
+    );
+
+    await vi.waitFor(() => {
+      expect(mocks.sendQueuedMessageMutateAsync).toHaveBeenCalledWith({
+        id: "thr_child",
+        mode: "steer",
+        queuedMessageId: "q1",
+      });
+    });
   });
 
   it("shows a pending approval in place of the composer", () => {

--- a/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.tsx
+++ b/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.tsx
@@ -262,11 +262,10 @@ function EmbeddedThreadChatWithComposer({
   const hasComposerBlockingPendingInteraction =
     activePendingInteraction !== null &&
     activePendingInteraction.payload.kind !== "plugin";
-  const pendingInteractionsInitialLoading =
-    isPendingInteractionStateUnknown(
-      pendingInteractionsQuery.data,
-      pendingInteractionsQuery.isFetching,
-    );
+  const pendingInteractionsInitialLoading = isPendingInteractionStateUnknown(
+    pendingInteractionsQuery.data,
+    pendingInteractionsQuery.isFetching,
+  );
   const pendingInteractionsUnavailable =
     activePendingInteraction === null && pendingInteractionsQuery.isError;
   const pendingInteractionOccupiesComposer =
@@ -439,7 +438,7 @@ function EmbeddedThreadChatWithComposer({
     processingQueuedMessage,
     queuedMessageActionPending,
     isUpdateQueuedMessagePending,
-    handleSendQueuedImmediately,
+    sendQueuedMessageById,
     handleSaveInlineQueuedMessage,
     handleDeleteQueuedMessage,
     handleReorderQueuedMessage,
@@ -448,7 +447,6 @@ function EmbeddedThreadChatWithComposer({
     threadId,
     queuedMessages,
     sendProcessingPersistence: "clear-on-settle",
-    canSendNow: () => !isProvisioning,
     onSaveSuccess: () => setInlineAttachmentError(null),
     inlineEditingQueuedMessage,
     dismissInlineQueuedMessageEditor,
@@ -548,6 +546,16 @@ function EmbeddedThreadChatWithComposer({
 
   const isQueueMutationPending =
     queuedMessageActionPending || createQueuedMessage.isPending;
+  const handleSendQueuedMessage = useCallback(
+    (queuedMessageId: string) => {
+      void sendQueuedMessageById({
+        guard: "exists",
+        messageId: queuedMessageId,
+        mode: isProvisioning ? "steer" : "auto",
+      });
+    },
+    [isProvisioning, sendQueuedMessageById],
+  );
   const hasPromptDraftInput = currentPromptDraftInput.length > 0;
   const canSubmitModifierShortcut = canSubmitFollowUpShortcut({
     hasPromptDraftInput,
@@ -567,7 +575,11 @@ function EmbeddedThreadChatWithComposer({
     if (submittedInput.length === 0) {
       const nextQueuedMessage = queuedMessages[0];
       if (nextQueuedMessage) {
-        handleSendQueuedImmediately(nextQueuedMessage.id);
+        void sendQueuedMessageById({
+          guard: "current-head",
+          messageId: nextQueuedMessage.id,
+          mode: "steer",
+        });
       }
       return;
     }
@@ -608,10 +620,10 @@ function EmbeddedThreadChatWithComposer({
     currentPromptDraft,
     currentPromptDraftInput,
     executionRequestFields,
-    handleSendQueuedImmediately,
     labels.sendError,
     promptDraft,
     queuedMessages,
+    sendQueuedMessageById,
     sendThreadMessage,
     setBottomAttachmentError,
     threadId,
@@ -1092,11 +1104,12 @@ function EmbeddedThreadChatWithComposer({
           queuedMessages={queuedMessages}
           resolveMentionLink={resolveMentionLink}
           inlineEditor={inlineEditor}
-          sendDisabled={isProvisioning || queuedMessageActionPending}
+          sendAction={isProvisioning ? "steer-when-ready" : "send-now"}
+          sendDisabled={queuedMessageActionPending}
           actionDisabled={queuedMessageActionPending}
           processingMessageId={processingQueuedMessage?.id ?? null}
           processingAction={processingQueuedMessage?.action ?? null}
-          onSendImmediately={handleSendQueuedImmediately}
+          onSend={handleSendQueuedMessage}
           onReorder={handleReorderQueuedMessage}
           onSetGroupBoundary={handleSetQueuedMessageGroupBoundary}
           onEdit={beginEditQueuedMessage}
@@ -1107,7 +1120,7 @@ function EmbeddedThreadChatWithComposer({
       beginEditQueuedMessage,
       handleDeleteQueuedMessage,
       handleReorderQueuedMessage,
-      handleSendQueuedImmediately,
+      handleSendQueuedMessage,
       handleSetQueuedMessageGroupBoundary,
       inlineEditor,
       isProvisioning,

--- a/apps/app/src/components/thread/embedded-chat/useQueuedMessageActions.ts
+++ b/apps/app/src/components/thread/embedded-chat/useQueuedMessageActions.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useRef, useState } from "react";
 import type { PromptInput, ThreadQueuedMessage } from "@bb/domain";
+import type { SendQueuedMessageMode } from "@bb/server-contract";
 import type {
   QueuedMessageGroupBoundaryRequest,
   QueuedMessageProcessingAction,
@@ -22,13 +23,13 @@ type QueuedMessageSendGuard = "current-head" | "exists" | "none";
 interface SendQueuedMessageByIdArgs {
   guard: QueuedMessageSendGuard;
   messageId: string;
+  mode: SendQueuedMessageMode;
 }
 
 interface UseQueuedMessageActionsArgs {
   threadId: string;
   queuedMessages: readonly ThreadQueuedMessage[];
   sendProcessingPersistence: "clear-on-settle" | "until-left-queue";
-  canSendNow?: () => boolean;
   onSendSuccess?: () => void;
   onSaveSuccess?: () => void;
   inlineEditingQueuedMessage: InlineQueuedMessageEditState | null;
@@ -44,7 +45,6 @@ interface UseQueuedMessageActionsResult {
   queuedMessageActionPending: boolean;
   isUpdateQueuedMessagePending: boolean;
   sendQueuedMessageById: (args: SendQueuedMessageByIdArgs) => Promise<void>;
-  handleSendQueuedImmediately: (queuedMessageId: string) => void;
   handleSaveInlineQueuedMessage: () => Promise<void>;
   handleDeleteQueuedMessage: (queuedMessageId: string) => void;
   handleReorderQueuedMessage: (request: QueuedMessageReorderRequest) => void;
@@ -57,7 +57,6 @@ export function useQueuedMessageActions({
   threadId,
   queuedMessages,
   sendProcessingPersistence,
-  canSendNow,
   onSendSuccess,
   onSaveSuccess,
   inlineEditingQueuedMessage,
@@ -91,10 +90,7 @@ export function useQueuedMessageActions({
   );
 
   const sendQueuedMessageById = useCallback(
-    async ({ guard, messageId }: SendQueuedMessageByIdArgs) => {
-      if (canSendNow !== undefined && !canSendNow()) {
-        return;
-      }
+    async ({ guard, messageId, mode }: SendQueuedMessageByIdArgs) => {
       if (
         guard !== "none" &&
         !queuedMessagesRef.current.some((message) => message.id === messageId)
@@ -112,11 +108,14 @@ export function useQueuedMessageActions({
       try {
         await sendQueuedMessage.mutateAsync({
           id: threadId,
-          mode: "auto",
+          mode,
           queuedMessageId: messageId,
         });
         onSendSuccess?.();
-        if (sendProcessingPersistence === "clear-on-settle") {
+        if (
+          mode === "steer" ||
+          sendProcessingPersistence === "clear-on-settle"
+        ) {
           setProcessingQueuedMessage((current) =>
             current?.id === messageId ? null : current,
           );
@@ -134,20 +133,7 @@ export function useQueuedMessageActions({
         );
       }
     },
-    [
-      canSendNow,
-      onSendSuccess,
-      sendProcessingPersistence,
-      sendQueuedMessage,
-      threadId,
-    ],
-  );
-
-  const handleSendQueuedImmediately = useCallback(
-    (queuedMessageId: string) => {
-      void sendQueuedMessageById({ guard: "none", messageId: queuedMessageId });
-    },
-    [sendQueuedMessageById],
+    [onSendSuccess, sendProcessingPersistence, sendQueuedMessage, threadId],
   );
 
   const handleSaveInlineQueuedMessage = useCallback(async () => {
@@ -282,7 +268,6 @@ export function useQueuedMessageActions({
     queuedMessageActionPending,
     isUpdateQueuedMessagePending: updateQueuedMessage.isPending,
     sendQueuedMessageById,
-    handleSendQueuedImmediately,
     handleSaveInlineQueuedMessage,
     handleDeleteQueuedMessage,
     handleReorderQueuedMessage,

--- a/apps/app/src/hooks/cache-owners/thread-runtime-cache-owner.test.ts
+++ b/apps/app/src/hooks/cache-owners/thread-runtime-cache-owner.test.ts
@@ -19,6 +19,7 @@ import {
 import { threadDefaultExecutionOptionsQueryKey } from "../queries/thread-default-execution-options-query";
 import {
   applyQueuedMessageCreateResult,
+  applyQueuedMessageSendResult,
   applyQueuedMessageUpdateResult,
   applySendThreadMessageSuccess,
   applyThreadGoalClearResult,
@@ -638,6 +639,59 @@ describe("thread runtime cache owner", () => {
     ).toEqual([]);
   });
 
+  it("optimistically queues a scheduled send even when the cached thread is idle", async () => {
+    const queryClient = createAppQueryClient({
+      defaultOptions: { queries: { gcTime: Infinity, retry: false } },
+      showMutationErrorToasts: false,
+    });
+    const sendAt = Date.now() + 3_600_000;
+    queryClient.setQueryData(threadQueryKey("thread-1"), { status: "idle" });
+    queryClient.setQueryData(threadQueuedMessagesQueryKey("thread-1"), []);
+    const request = {
+      id: "thread-1",
+      mode: "auto" as const,
+      input: [{ type: "text" as const, text: "Send later", mentions: [] }],
+      sendAt,
+    };
+
+    const transaction = await beginSendThreadMessageTransaction({
+      queryClient,
+      request,
+    });
+
+    expect(transaction.kind).toBe("queued-message");
+    expect(
+      queryClient.getQueryData<ThreadQueuedMessage[]>(
+        threadQueuedMessagesQueryKey("thread-1"),
+      ),
+    ).toMatchObject([{ sendAt, waitingOn: { kind: "time" } }]);
+
+    applySendThreadMessageSuccess({
+      queryClient,
+      realtimeConnected: true,
+      request,
+      result: {
+        ok: true,
+        delivery: "queued",
+        queuedMessage: makeQueuedMessage({
+          id: "qmsg-scheduled",
+          content: request.input,
+          sendAt,
+          waitingOn: { kind: "time" },
+        }),
+      },
+      transaction,
+    });
+
+    expect(
+      queryClient.getQueryData<ThreadQueuedMessage[]>(
+        threadQueuedMessagesQueryKey("thread-1"),
+      ),
+    ).toMatchObject([
+      { id: "qmsg-scheduled", sendAt, waitingOn: { kind: "time" } },
+    ]);
+  });
+
   it("optimistically removes queued messages and rolls back on failure", async () => {
     const queryClient = createAppQueryClient({
       defaultOptions: { queries: { gcTime: Infinity, retry: false } },
@@ -820,6 +874,151 @@ describe("thread runtime cache owner", () => {
     ).toEqual([]);
   });
 
+  it("restores a queued row and removes its optimistic turn when delivery remains queued", async () => {
+    const queryClient = createAppQueryClient({
+      defaultOptions: { queries: { gcTime: Infinity, retry: false } },
+      showMutationErrorToasts: false,
+    });
+    const previousQueue = [
+      makeQueuedMessage({
+        id: "qmsg-1",
+        waitingOn: { kind: "thread-busy" },
+      }),
+    ];
+    const previousThread = {
+      id: "thread-1",
+      status: "starting",
+      updatedAt: 1,
+      runtime: {
+        displayStatus: "provisioning",
+        hostReconnectGraceExpiresAt: null,
+      },
+    };
+    queryClient.setQueryData(
+      threadQueuedMessagesQueryKey("thread-1"),
+      previousQueue,
+    );
+    queryClient.setQueryData(threadQueryKey("thread-1"), previousThread);
+    queryClient.setQueryData(
+      threadTimelineQueryKey("thread-1"),
+      makeTimelineResponse(),
+    );
+    const request = {
+      id: "thread-1",
+      mode: "steer" as const,
+      queuedMessageId: "qmsg-1",
+    };
+    const transaction = await beginSendQueuedMessageTransaction({
+      queryClient,
+      request,
+    });
+
+    applyQueuedMessageSendResult({
+      queryClient,
+      request,
+      result: {
+        ok: true,
+        delivery: "queued",
+        queuedMessage: makeQueuedMessage({
+          id: "qmsg-1",
+          waitingOn: { kind: "provisioning" },
+          updatedAt: 2,
+        }),
+      },
+      transaction,
+    });
+
+    expect(
+      queryClient.getQueryData(threadQueuedMessagesQueryKey("thread-1")),
+    ).toEqual([
+      makeQueuedMessage({
+        id: "qmsg-1",
+        waitingOn: { kind: "provisioning" },
+        updatedAt: 2,
+      }),
+    ]);
+    expect(
+      queryClient.getQueryData<ThreadTimelineResponse>(
+        threadTimelineQueryKey("thread-1"),
+      )?.rows,
+    ).toEqual([]);
+    expect(queryClient.getQueryData(threadQueryKey("thread-1"))).toEqual(
+      previousThread,
+    );
+  });
+
+  it("does not duplicate a queued-row steer or overwrite newer thread state after realtime wins", async () => {
+    const queryClient = createAppQueryClient({
+      defaultOptions: { queries: { gcTime: Infinity, retry: false } },
+      showMutationErrorToasts: false,
+    });
+    const queuedMessage = makeQueuedMessage({
+      waitingOn: { kind: "thread-busy" },
+    });
+    const previousThread = {
+      id: "thread-1",
+      status: "starting",
+      updatedAt: 1,
+      runtime: {
+        displayStatus: "provisioning",
+        hostReconnectGraceExpiresAt: null,
+      },
+    };
+    queryClient.setQueryData(threadQueuedMessagesQueryKey("thread-1"), [
+      queuedMessage,
+    ]);
+    queryClient.setQueryData(threadQueryKey("thread-1"), previousThread);
+    queryClient.setQueryData(
+      threadTimelineQueryKey("thread-1"),
+      makeTimelineResponse(),
+    );
+    const request = {
+      id: "thread-1",
+      mode: "steer" as const,
+      queuedMessageId: queuedMessage.id,
+    };
+    const transaction = await beginSendQueuedMessageTransaction({
+      queryClient,
+      request,
+    });
+    const authoritativeQueuedMessage = makeQueuedMessage({
+      waitingOn: { kind: "provisioning" },
+      updatedAt: 2,
+    });
+    const realtimeThread = {
+      ...previousThread,
+      title: "Realtime title",
+      updatedAt: 2,
+    };
+    queryClient.setQueryData(threadQueuedMessagesQueryKey("thread-1"), [
+      authoritativeQueuedMessage,
+    ]);
+    queryClient.setQueryData(threadQueryKey("thread-1"), realtimeThread);
+
+    applyQueuedMessageSendResult({
+      queryClient,
+      request,
+      result: {
+        ok: true,
+        delivery: "queued",
+        queuedMessage: authoritativeQueuedMessage,
+      },
+      transaction,
+    });
+
+    expect(
+      queryClient.getQueryData(threadQueuedMessagesQueryKey("thread-1")),
+    ).toEqual([authoritativeQueuedMessage]);
+    expect(queryClient.getQueryData(threadQueryKey("thread-1"))).toEqual(
+      realtimeThread,
+    );
+    expect(
+      queryClient.getQueryData<ThreadTimelineResponse>(
+        threadTimelineQueryKey("thread-1"),
+      )?.rows,
+    ).toEqual([]);
+  });
+
   it("clears optimistic group edges when sending a grouped successor", async () => {
     const queryClient = createAppQueryClient({
       defaultOptions: { queries: { gcTime: Infinity, retry: false } },
@@ -935,7 +1134,7 @@ describe("thread runtime cache owner", () => {
       )?.rows,
     ).toEqual([]);
   });
-  it("drops the optimistic turn when a send joins the queue", async () => {
+  it("moves an optimistic turn into the queue when the server holds an idle send", async () => {
     const queryClient = createAppQueryClient({
       defaultOptions: { queries: { gcTime: Infinity, retry: false } },
       showMutationErrorToasts: false,
@@ -955,7 +1154,6 @@ describe("thread runtime cache owner", () => {
       id: "thread-1",
       mode: "queue-if-active" as const,
       input: [{ type: "text" as const, text: "ship the notes", mentions: [] }],
-      sendAt: Date.now() + 3_600_000,
     };
     const transaction = await beginSendThreadMessageTransaction({
       queryClient,
@@ -964,10 +1162,17 @@ describe("thread runtime cache owner", () => {
     expect(transaction.kind).toBe("accepted-turn");
 
     applySendThreadMessageSuccess({
-      delivery: "queued",
       queryClient,
       realtimeConnected: true,
       request,
+      result: {
+        ok: true,
+        delivery: "queued",
+        queuedMessage: makeQueuedMessage({
+          content: request.input,
+          waitingOn: { kind: "plugin", pluginId: "limiter", reason: "busy" },
+        }),
+      },
       transaction,
     });
     await Promise.resolve();
@@ -988,6 +1193,91 @@ describe("thread runtime cache owner", () => {
       queryClient.getQueryState(threadQueuedMessagesQueryKey("thread-1"))
         ?.isInvalidated,
     ).toBe(true);
+    expect(
+      queryClient.getQueryData<ThreadQueuedMessage[]>(
+        threadQueuedMessagesQueryKey("thread-1"),
+      ),
+    ).toMatchObject([
+      {
+        content: request.input,
+        waitingOn: { kind: "plugin", pluginId: "limiter" },
+      },
+    ]);
+  });
+
+  it("keeps newer realtime queue and thread state when it arrives before send success", async () => {
+    const queryClient = createAppQueryClient({
+      defaultOptions: { queries: { gcTime: Infinity, retry: false } },
+      showMutationErrorToasts: false,
+    });
+    const previousThread = {
+      id: "thread-1",
+      status: "idle",
+      updatedAt: 1,
+      runtime: { displayStatus: "idle", hostReconnectGraceExpiresAt: null },
+    };
+    queryClient.setQueryData(threadQueryKey("thread-1"), previousThread);
+    queryClient.setQueryData(
+      threadTimelineQueryKey("thread-1"),
+      makeTimelineResponse(),
+    );
+    queryClient.setQueryData(threadQueuedMessagesQueryKey("thread-1"), []);
+    const request = {
+      id: "thread-1",
+      mode: "auto" as const,
+      input: [{ type: "text" as const, text: "Wait for input", mentions: [] }],
+    };
+    const transaction = await beginSendThreadMessageTransaction({
+      queryClient,
+      request,
+    });
+    const authoritativeQueuedMessage = makeQueuedMessage({
+      id: "qmsg-realtime",
+      content: request.input,
+      waitingOn: { kind: "interaction" },
+      updatedAt: 5,
+    });
+    const realtimeThread = {
+      ...previousThread,
+      status: "starting",
+      updatedAt: 5,
+      runtime: {
+        displayStatus: "provisioning",
+        hostReconnectGraceExpiresAt: null,
+      },
+    };
+    queryClient.setQueryData(threadQueuedMessagesQueryKey("thread-1"), [
+      authoritativeQueuedMessage,
+    ]);
+    queryClient.setQueryData(
+      threadTimelineQueryKey("thread-1"),
+      makeTimelineResponse(),
+    );
+    queryClient.setQueryData(threadQueryKey("thread-1"), realtimeThread);
+
+    applySendThreadMessageSuccess({
+      queryClient,
+      realtimeConnected: true,
+      request,
+      result: {
+        ok: true,
+        delivery: "queued",
+        queuedMessage: authoritativeQueuedMessage,
+      },
+      transaction,
+    });
+
+    expect(
+      queryClient.getQueryData(threadQueuedMessagesQueryKey("thread-1")),
+    ).toEqual([authoritativeQueuedMessage]);
+    expect(queryClient.getQueryData(threadQueryKey("thread-1"))).toEqual(
+      realtimeThread,
+    );
+    expect(
+      queryClient.getQueryData<ThreadTimelineResponse>(
+        threadTimelineQueryKey("thread-1"),
+      )?.rows,
+    ).toEqual([]);
   });
 
   it("keeps an accepted send local while realtime is connected: prompt history is prepended, not refetched, and default execution options only go stale", async () => {
@@ -1032,10 +1322,10 @@ describe("thread runtime cache owner", () => {
     expect(transaction.kind).toBe("accepted-turn");
 
     applySendThreadMessageSuccess({
-      delivery: "sent",
       queryClient,
       realtimeConnected: true,
       request,
+      result: { ok: true, delivery: "sent" },
       transaction,
     });
     await Promise.resolve();
@@ -1060,15 +1350,27 @@ describe("thread runtime cache owner", () => {
     }
   });
 
-  it("refetches only the queue list for a queued send while realtime is connected", async () => {
+  it("moves a predicted queued send into the timeline when the server sends it", async () => {
     const queryClient = createAppQueryClient({
       defaultOptions: { queries: { gcTime: Infinity, retry: false } },
       showMutationErrorToasts: false,
     });
-    queryClient.setQueryData(threadQueryKey("thread-1"), { status: "active" });
+    const activeThread = {
+      status: "active",
+      updatedAt: 1,
+      runtime: {
+        displayStatus: "active",
+        hostReconnectGraceExpiresAt: null,
+      },
+    };
+    queryClient.setQueryData(threadQueryKey("thread-1"), activeThread);
+    queryClient.setQueryData(
+      threadTimelineQueryKey("thread-1"),
+      makeTimelineResponse(),
+    );
     const queuedMessagesQueryFn = vi.fn(async () => []);
     const promptHistoryQueryFn = vi.fn(async () => []);
-    const threadQueryFn = vi.fn(async () => ({ status: "active" }));
+    const threadQueryFn = vi.fn(async () => activeThread);
     const observers = [
       new QueryObserver(queryClient, {
         queryKey: threadQueuedMessagesQueryKey("thread-1"),
@@ -1105,10 +1407,10 @@ describe("thread runtime cache owner", () => {
     expect(transaction.kind).toBe("queued-message");
 
     applySendThreadMessageSuccess({
-      delivery: "sent",
       queryClient,
       realtimeConnected: true,
       request,
+      result: { ok: true, delivery: "sent" },
       transaction,
     });
     await vi.waitFor(() => {
@@ -1123,6 +1425,16 @@ describe("thread runtime cache owner", () => {
     expect(
       queryClient.getQueryState(threadQueryKey("thread-1"))?.isInvalidated,
     ).toBe(false);
+    expect(
+      queryClient.getQueryData<ThreadQueuedMessage[]>(
+        threadQueuedMessagesQueryKey("thread-1"),
+      ),
+    ).toEqual([]);
+    expect(
+      queryClient.getQueryData<ThreadTimelineResponse>(
+        threadTimelineQueryKey("thread-1"),
+      )?.rows,
+    ).toMatchObject([{ kind: "conversation", text: "Queued prompt" }]);
 
     for (const unsubscribe of unsubscribers) {
       unsubscribe();

--- a/apps/app/src/hooks/cache-owners/thread-runtime-cache-owner.ts
+++ b/apps/app/src/hooks/cache-owners/thread-runtime-cache-owner.ts
@@ -10,7 +10,8 @@ import type {
 import type {
   CreateQueuedMessageRequest,
   PromptHistoryResponse,
-  SendMessageDelivery,
+  SendMessageResponse,
+  SendQueuedMessageResponse,
   SendQueuedMessageMode,
   ThreadQueuedMessageListResponse,
   ThreadResponse,
@@ -154,11 +155,18 @@ interface RollbackRemoveQueuedMessageTransactionArgs {
   transaction: RemoveQueuedMessageTransaction | undefined;
 }
 
+interface ApplyQueuedMessageSendResultArgs {
+  queryClient: QueryClient;
+  request: SendQueuedMessageRequest;
+  result: SendQueuedMessageResponse;
+  transaction: RemoveQueuedMessageTransaction | undefined;
+}
+
 interface ApplySendThreadMessageSuccessArgs {
-  delivery: SendMessageDelivery;
   queryClient: QueryClient;
   realtimeConnected: boolean;
   request: SendThreadMessageMutationRequest;
+  result: SendMessageResponse;
   transaction: SendThreadMessageTransaction | undefined;
 }
 
@@ -239,7 +247,7 @@ interface BuildOptimisticUserMessageRowParams {
 interface BuildOptimisticQueuedMessageParams {
   createdAt: number;
   queryClient: QueryClient;
-  request: CreateQueuedMessageRequestWithThreadId;
+  request: CreateQueuedMessageRequestWithThreadId & { sendAt?: number };
 }
 
 type OptimisticTurnRequestKind = "message" | "steer";
@@ -253,13 +261,15 @@ interface SendThreadMessageAcceptedTurnTransaction {
   kind: "accepted-turn";
   optimisticCreatedAt: number;
   optimisticRowId: string;
+  optimisticThreadDataUpdateCount: number | null;
   previousThread: ThreadResponse | undefined;
 }
 
 interface SendThreadMessageQueuedTransaction {
   kind: "queued-message";
+  optimisticCreatedAt: number;
   optimisticQueuedMessageId: string;
-  previousQueuedMessages: ThreadQueuedMessageListResponse | undefined;
+  previousThreadStatus: ThreadWithRuntime["status"] | null;
 }
 
 export type SendThreadMessageTransaction =
@@ -271,8 +281,8 @@ export interface ReorderQueuedMessageTransaction {
 }
 
 export interface CreateQueuedMessageTransaction {
+  optimisticCreatedAt: number;
   optimisticQueuedMessageId: string;
-  previousQueuedMessages: ThreadQueuedMessageListResponse | undefined;
 }
 
 export interface UpdateQueuedMessageTransaction {
@@ -281,7 +291,10 @@ export interface UpdateQueuedMessageTransaction {
 }
 
 export interface RemoveQueuedMessageTransaction {
+  optimisticCreatedAt: number | null;
+  optimisticQueueDataUpdateCount: number;
   optimisticRowId: string | null;
+  optimisticThreadDataUpdateCount: number | null;
   previousQueuedMessages: ThreadQueuedMessageListResponse | undefined;
   previousThread: ThreadResponse | undefined;
 }
@@ -394,6 +407,10 @@ function buildOptimisticQueuedMessage({
     queryClient,
     request.id,
   );
+  const scheduledSendAt =
+    request.sendAt !== undefined && request.sendAt > createdAt
+      ? request.sendAt
+      : null;
 
   return {
     id: `optimistic-queued-${nanoid()}`,
@@ -411,8 +428,8 @@ function buildOptimisticQueuedMessage({
     serviceTier:
       request.serviceTier ?? defaultExecutionOptions?.serviceTier ?? "default",
     groupWithNext: false,
-    sendAt: null,
-    waitingOn: null,
+    sendAt: scheduledSendAt,
+    waitingOn: scheduledSendAt === null ? null : { kind: "time" },
     failureReason: null,
     payload: { kind: "inline" },
     editable: true,
@@ -424,12 +441,14 @@ function buildOptimisticQueuedMessage({
 function insertOptimisticQueuedMessage({
   queryClient,
   request,
-}: CreateQueuedMessageTransactionArgs): CreateQueuedMessageTransaction {
+}: {
+  queryClient: QueryClient;
+  request: CreateQueuedMessageRequestWithThreadId & { sendAt?: number };
+}): CreateQueuedMessageTransaction {
   const queryKey = threadQueuedMessagesQueryKey(request.id);
-  const previousQueuedMessages =
-    queryClient.getQueryData<ThreadQueuedMessageListResponse>(queryKey);
+  const optimisticCreatedAt = Date.now();
   const optimisticQueuedMessage = buildOptimisticQueuedMessage({
-    createdAt: Date.now(),
+    createdAt: optimisticCreatedAt,
     queryClient,
     request,
   });
@@ -443,23 +462,99 @@ function insertOptimisticQueuedMessage({
   );
 
   return {
+    optimisticCreatedAt,
     optimisticQueuedMessageId: optimisticQueuedMessage.id,
-    previousQueuedMessages,
   };
 }
 
-function restoreQueuedMessageSnapshot({
+function restoreQueuedMessageSnapshotIfUnchanged({
+  optimisticQueueDataUpdateCount,
   previousQueuedMessages,
   queryClient,
   threadId,
 }: {
+  optimisticQueueDataUpdateCount: number;
   previousQueuedMessages: ThreadQueuedMessageListResponse | undefined;
   queryClient: QueryClient;
+  threadId: string;
+}): boolean {
+  const queryKey = threadQueuedMessagesQueryKey(threadId);
+  if (
+    queryClient.getQueryState(queryKey)?.dataUpdateCount !==
+    optimisticQueueDataUpdateCount
+  ) {
+    return false;
+  }
+  queryClient.setQueryData<ThreadQueuedMessageListResponse>(
+    queryKey,
+    previousQueuedMessages ?? [],
+  );
+  return true;
+}
+
+function removeOptimisticQueuedMessage(
+  queryClient: QueryClient,
+  threadId: string,
+  optimisticQueuedMessageId: string,
+): boolean {
+  let removed = false;
+  queryClient.setQueryData<ThreadQueuedMessageListResponse>(
+    threadQueuedMessagesQueryKey(threadId),
+    (currentQueuedMessages) => {
+      if (!currentQueuedMessages) return currentQueuedMessages;
+      const nextQueuedMessages = currentQueuedMessages.filter(
+        (queuedMessage) => queuedMessage.id !== optimisticQueuedMessageId,
+      );
+      removed = nextQueuedMessages.length !== currentQueuedMessages.length;
+      return removed ? nextQueuedMessages : currentQueuedMessages;
+    },
+  );
+  return removed;
+}
+
+function reconcileAuthoritativeQueuedMessage({
+  insertWhenMissing,
+  optimisticQueuedMessageId,
+  queryClient,
+  queuedMessage,
+  threadId,
+}: {
+  insertWhenMissing: boolean;
+  optimisticQueuedMessageId: string | null;
+  queryClient: QueryClient;
+  queuedMessage: ThreadQueuedMessage;
   threadId: string;
 }): void {
   queryClient.setQueryData<ThreadQueuedMessageListResponse>(
     threadQueuedMessagesQueryKey(threadId),
-    previousQueuedMessages ?? [],
+    (currentQueuedMessages) => {
+      if (!currentQueuedMessages) {
+        return insertWhenMissing ? [queuedMessage] : currentQueuedMessages;
+      }
+      const authoritativeIndex = currentQueuedMessages.findIndex(
+        (currentQueuedMessage) => currentQueuedMessage.id === queuedMessage.id,
+      );
+      if (authoritativeIndex !== -1) {
+        const nextQueuedMessages = [...currentQueuedMessages];
+        nextQueuedMessages[authoritativeIndex] = queuedMessage;
+        return nextQueuedMessages;
+      }
+      const optimisticIndex =
+        optimisticQueuedMessageId === null
+          ? -1
+          : currentQueuedMessages.findIndex(
+              (currentQueuedMessage) =>
+                currentQueuedMessage.id === optimisticQueuedMessageId,
+            );
+      if (optimisticIndex !== -1) {
+        const nextQueuedMessages = [...currentQueuedMessages];
+        nextQueuedMessages[optimisticIndex] = queuedMessage;
+        return nextQueuedMessages;
+      }
+      return insertWhenMissing
+        ? [...currentQueuedMessages, queuedMessage]
+        : currentQueuedMessages;
+    },
   );
 }
 
@@ -481,7 +576,11 @@ function removeCachedQueuedMessage({
   );
 
   return {
+    optimisticCreatedAt: null,
+    optimisticQueueDataUpdateCount:
+      queryClient.getQueryState(queryKey)?.dataUpdateCount ?? 0,
     optimisticRowId: null,
+    optimisticThreadDataUpdateCount: null,
     previousQueuedMessages,
     previousThread: undefined,
   };
@@ -543,11 +642,14 @@ function optimisticTurnRequestKind({
   return "message";
 }
 
-function requestWillQueueForActiveThread(
+function requestWillOptimisticallyQueue(
   request: SendThreadMessageMutationRequest,
   thread: ThreadWithRuntime | undefined,
 ): boolean {
-  return request.mode === "queue-if-active" && thread?.status === "active";
+  return (
+    (request.sendAt !== undefined && request.sendAt > Date.now()) ||
+    (request.mode === "queue-if-active" && thread?.status === "active")
+  );
 }
 
 function buildOptimisticUserMessageRow({
@@ -624,6 +726,47 @@ function applyOptimisticAcceptedTurnThreadState({
           : "active",
     },
   }));
+}
+
+function removeOptimisticTimelineRowIfPresent(
+  queryClient: QueryClient,
+  threadId: string,
+  optimisticRowId: string,
+): boolean {
+  const wasPresent = queryClient
+    .getQueriesData<ThreadTimelineResponse>({
+      queryKey: threadTimelineQueryKeyPrefix(threadId),
+    })
+    .some(([, timeline]) =>
+      timeline?.rows.some((row) => row.id === optimisticRowId),
+    );
+  removeOptimisticTimelineRow(queryClient, threadId, optimisticRowId);
+  return wasPresent;
+}
+
+function restoreOptimisticThreadSnapshotIfUnchanged({
+  optimisticThreadDataUpdateCount,
+  previousThread,
+  queryClient,
+  threadId,
+}: {
+  optimisticThreadDataUpdateCount: number | null;
+  previousThread: ThreadResponse | undefined;
+  queryClient: QueryClient;
+  threadId: string;
+}): void {
+  if (
+    optimisticThreadDataUpdateCount === null ||
+    previousThread === undefined ||
+    queryClient.getQueryState(threadQueryKey(threadId))?.dataUpdateCount !==
+      optimisticThreadDataUpdateCount
+  ) {
+    return;
+  }
+  queryClient.setQueryData<ThreadResponse>(
+    threadQueryKey(threadId),
+    previousThread,
+  );
 }
 
 function applyOptimisticStopRequest({
@@ -776,27 +919,11 @@ export async function beginSendThreadMessageTransaction({
   queryClient,
   request,
 }: SendThreadMessageTransactionArgs): Promise<SendThreadMessageTransaction> {
-  await queryClient.cancelQueries({ queryKey: threadQueryKey(request.id) });
-
-  const previousThread = queryClient.getQueryData<ThreadResponse>(
-    threadQueryKey(request.id),
-  );
-  if (requestWillQueueForActiveThread(request, previousThread)) {
-    const queryKey = threadQueuedMessagesQueryKey(request.id);
-    await queryClient.cancelQueries({
-      queryKey,
-    });
-    const transaction = insertOptimisticQueuedMessage({
-      queryClient,
-      request,
-    });
-    return {
-      kind: "queued-message",
-      ...transaction,
-    };
-  }
-
   await Promise.all([
+    queryClient.cancelQueries({ queryKey: threadQueryKey(request.id) }),
+    queryClient.cancelQueries({
+      queryKey: threadQueuedMessagesQueryKey(request.id),
+    }),
     queryClient.cancelQueries({
       queryKey: threadTimelineQueryKeyPrefix(request.id),
     }),
@@ -804,6 +931,22 @@ export async function beginSendThreadMessageTransaction({
       queryKey: threadTimelineTurnSummaryDetailsQueryKeyPrefix(request.id),
     }),
   ]);
+
+  const previousThread = queryClient.getQueryData<ThreadResponse>(
+    threadQueryKey(request.id),
+  );
+  if (requestWillOptimisticallyQueue(request, previousThread)) {
+    const transaction = insertOptimisticQueuedMessage({
+      queryClient,
+      request,
+    });
+    return {
+      kind: "queued-message",
+      previousThreadStatus: previousThread?.status ?? null,
+      ...transaction,
+    };
+  }
+
   const optimisticCreatedAt = Date.now();
 
   applyOptimisticAcceptedTurnThreadState({
@@ -826,6 +969,9 @@ export async function beginSendThreadMessageTransaction({
     previousThread,
     optimisticCreatedAt,
     optimisticRowId: optimisticRow.id,
+    optimisticThreadDataUpdateCount:
+      queryClient.getQueryState(threadQueryKey(request.id))?.dataUpdateCount ??
+      null,
   };
 }
 
@@ -835,89 +981,114 @@ export function rollbackSendThreadMessageTransaction({
   transaction,
 }: RollbackSendThreadMessageTransactionArgs): void {
   if (transaction?.kind === "queued-message") {
-    restoreQueuedMessageSnapshot({
-      previousQueuedMessages: transaction.previousQueuedMessages,
+    removeOptimisticQueuedMessage(
       queryClient,
-      threadId: request.id,
-    });
+      request.id,
+      transaction.optimisticQueuedMessageId,
+    );
     return;
   }
   if (transaction?.kind !== "accepted-turn") {
     return;
   }
-  if (transaction.optimisticRowId) {
-    removeOptimisticTimelineRow(
-      queryClient,
-      request.id,
-      transaction.optimisticRowId,
-    );
-  }
-  if (!transaction?.previousThread) {
-    return;
-  }
-
-  queryClient.setQueryData<ThreadResponse>(
-    threadQueryKey(request.id),
-    transaction.previousThread,
+  removeOptimisticTimelineRow(
+    queryClient,
+    request.id,
+    transaction.optimisticRowId,
   );
+  restoreOptimisticThreadSnapshotIfUnchanged({
+    optimisticThreadDataUpdateCount:
+      transaction.optimisticThreadDataUpdateCount,
+    previousThread: transaction.previousThread,
+    queryClient,
+    threadId: request.id,
+  });
 }
 
 export function applySendThreadMessageSuccess({
-  delivery,
   queryClient,
   realtimeConnected,
   request,
+  result,
   transaction,
 }: ApplySendThreadMessageSuccessArgs): void {
-  if (delivery === "queued" && transaction?.kind === "accepted-turn") {
-    if (transaction.optimisticRowId) {
-      removeOptimisticTimelineRow(
+  const optimisticCreatedAt = transaction?.optimisticCreatedAt ?? Date.now();
+  if (result.delivery === "queued") {
+    const optimisticTimelineRowRemoved =
+      transaction?.kind === "accepted-turn"
+        ? removeOptimisticTimelineRowIfPresent(
+            queryClient,
+            request.id,
+            transaction.optimisticRowId,
+          )
+        : false;
+    reconcileAuthoritativeQueuedMessage({
+      insertWhenMissing:
+        transaction === undefined || optimisticTimelineRowRemoved,
+      optimisticQueuedMessageId:
+        transaction?.kind === "queued-message"
+          ? transaction.optimisticQueuedMessageId
+          : null,
+      queryClient,
+      queuedMessage: result.queuedMessage,
+      threadId: request.id,
+    });
+    if (transaction?.kind === "accepted-turn" && optimisticTimelineRowRemoved) {
+      restoreOptimisticThreadSnapshotIfUnchanged({
+        optimisticThreadDataUpdateCount:
+          transaction.optimisticThreadDataUpdateCount,
+        previousThread: transaction.previousThread,
         queryClient,
-        request.id,
-        transaction.optimisticRowId,
-      );
-    }
-    if (transaction.previousThread) {
-      queryClient.setQueryData<ThreadResponse>(
-        threadQueryKey(request.id),
-        transaction.previousThread,
-      );
+        threadId: request.id,
+      });
     }
     prependThreadPromptHistory(
       queryClient,
       request.id,
       buildAcceptedPromptHistoryEntry({
-        createdAt: transaction.optimisticCreatedAt,
+        createdAt: optimisticCreatedAt,
         input: request.input,
       }),
     );
     invalidateThreadQueueQueries({ queryClient, threadId: request.id });
     return;
   }
+
   if (transaction?.kind === "queued-message") {
-    prependThreadPromptHistory(
+    const optimisticQueuedMessageRemoved = removeOptimisticQueuedMessage(
       queryClient,
       request.id,
-      buildAcceptedPromptHistoryEntry({
-        createdAt: Date.now(),
-        input: request.input,
-      }),
+      transaction.optimisticQueuedMessageId,
     );
-    if (realtimeConnected) {
-      invalidateThreadQueuedMessageListQuery({
+    if (optimisticQueuedMessageRemoved) {
+      applyOptimisticAcceptedTurnThreadState({
+        createdAt: optimisticCreatedAt,
         queryClient,
         threadId: request.id,
       });
-    } else {
-      invalidateThreadQueueQueries({ queryClient, threadId: request.id });
+      insertOptimisticTimelineRow(
+        queryClient,
+        request.id,
+        buildOptimisticUserMessageRow({
+          createdAt: optimisticCreatedAt,
+          input: request.input,
+          mode: request.mode,
+          threadId: request.id,
+          threadStatus: transaction.previousThreadStatus,
+        }),
+      );
     }
-    return;
+    invalidateThreadQueuedMessageListQuery({
+      queryClient,
+      threadId: request.id,
+    });
   }
+
   prependThreadPromptHistory(
     queryClient,
     request.id,
     buildAcceptedPromptHistoryEntry({
-      createdAt: transaction?.optimisticCreatedAt ?? Date.now(),
+      createdAt: optimisticCreatedAt,
       input: request.input,
     }),
   );
@@ -949,11 +1120,11 @@ export function rollbackCreateQueuedMessageTransaction({
   if (!transaction) {
     return;
   }
-  restoreQueuedMessageSnapshot({
-    previousQueuedMessages: transaction.previousQueuedMessages,
+  removeOptimisticQueuedMessage(
     queryClient,
-    threadId: request.id,
-  });
+    request.id,
+    transaction.optimisticQueuedMessageId,
+  );
 }
 
 export function applyQueuedMessageCreateResult({
@@ -1126,10 +1297,16 @@ export async function beginSendQueuedMessageTransaction({
     (currentQueuedMessages) =>
       removeQueuedMessagesAndRepairGroupEdges(currentQueuedMessages, sendIds),
   );
+  const optimisticQueueDataUpdateCount =
+    queryClient.getQueryState(threadQueuedMessagesQueryKey(request.id))
+      ?.dataUpdateCount ?? 0;
 
   if (!queuedMessage) {
     return {
+      optimisticCreatedAt: null,
+      optimisticQueueDataUpdateCount,
       optimisticRowId: null,
+      optimisticThreadDataUpdateCount: null,
       previousQueuedMessages,
       previousThread,
     };
@@ -1141,9 +1318,15 @@ export async function beginSendQueuedMessageTransaction({
     queryClient,
     threadId: request.id,
   });
+  const optimisticThreadDataUpdateCount =
+    queryClient.getQueryState(threadQueryKey(request.id))?.dataUpdateCount ??
+    null;
   if (queuedMessageGroup.length > 1) {
     return {
+      optimisticCreatedAt,
+      optimisticQueueDataUpdateCount,
       optimisticRowId: null,
+      optimisticThreadDataUpdateCount,
       previousQueuedMessages,
       previousThread,
     };
@@ -1158,7 +1341,10 @@ export async function beginSendQueuedMessageTransaction({
   insertOptimisticTimelineRow(queryClient, request.id, optimisticRow);
 
   return {
+    optimisticCreatedAt,
+    optimisticQueueDataUpdateCount,
     optimisticRowId: optimisticRow.id,
+    optimisticThreadDataUpdateCount,
     previousQueuedMessages,
     previousThread,
   };
@@ -1179,24 +1365,72 @@ export function rollbackRemoveQueuedMessageTransaction({
       transaction.optimisticRowId,
     );
   }
-  if (transaction.previousThread) {
-    queryClient.setQueryData<ThreadResponse>(
-      threadQueryKey(request.id),
-      transaction.previousThread,
-    );
-  }
-  restoreQueuedMessageSnapshot({
+  restoreOptimisticThreadSnapshotIfUnchanged({
+    optimisticThreadDataUpdateCount:
+      transaction.optimisticThreadDataUpdateCount,
+    previousThread: transaction.previousThread,
+    queryClient,
+    threadId: request.id,
+  });
+  const queueRestored = restoreQueuedMessageSnapshotIfUnchanged({
+    optimisticQueueDataUpdateCount: transaction.optimisticQueueDataUpdateCount,
     previousQueuedMessages: transaction.previousQueuedMessages,
     queryClient,
     threadId: request.id,
   });
+  if (!queueRestored) {
+    invalidateThreadQueueQueries({ queryClient, threadId: request.id });
+  }
 }
 
 export function applyQueuedMessageSendResult({
   queryClient,
-  threadId,
-}: ThreadIdCacheArgs): void {
-  invalidateThreadQueuedMessageSendQueries({ queryClient, threadId });
+  request,
+  result,
+  transaction,
+}: ApplyQueuedMessageSendResultArgs): void {
+  if (result.delivery === "queued") {
+    const optimisticQueueUnchanged =
+      transaction !== undefined &&
+      queryClient.getQueryState(threadQueuedMessagesQueryKey(request.id))
+        ?.dataUpdateCount === transaction.optimisticQueueDataUpdateCount;
+    if (optimisticQueueUnchanged && transaction !== undefined) {
+      restoreQueuedMessageSnapshotIfUnchanged({
+        optimisticQueueDataUpdateCount:
+          transaction.optimisticQueueDataUpdateCount,
+        previousQueuedMessages: transaction.previousQueuedMessages,
+        queryClient,
+        threadId: request.id,
+      });
+    }
+    reconcileAuthoritativeQueuedMessage({
+      insertWhenMissing: transaction === undefined || optimisticQueueUnchanged,
+      optimisticQueuedMessageId: null,
+      queryClient,
+      queuedMessage: result.queuedMessage,
+      threadId: request.id,
+    });
+    if (transaction !== undefined && transaction.optimisticRowId !== null) {
+      removeOptimisticTimelineRow(
+        queryClient,
+        request.id,
+        transaction.optimisticRowId,
+      );
+    }
+    if (transaction !== undefined) {
+      restoreOptimisticThreadSnapshotIfUnchanged({
+        optimisticThreadDataUpdateCount:
+          transaction.optimisticThreadDataUpdateCount,
+        previousThread: transaction.previousThread,
+        queryClient,
+        threadId: request.id,
+      });
+    }
+  }
+  invalidateThreadQueuedMessageSendQueries({
+    queryClient,
+    threadId: request.id,
+  });
 }
 
 export async function beginReorderQueuedMessageTransaction({

--- a/apps/app/src/hooks/mutations/thread-runtime-mutations.test.tsx
+++ b/apps/app/src/hooks/mutations/thread-runtime-mutations.test.tsx
@@ -13,6 +13,7 @@ import { BbHttpError, sdk } from "@/lib/sdk";
 import { wsManager } from "@/lib/ws";
 import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
 import {
+  threadQueryKey,
   threadQueuedMessagesQueryKey,
   threadTimelineQueryKey,
 } from "../queries/query-keys";
@@ -24,6 +25,7 @@ import {
   useDeleteThreadQueuedMessage,
   useEditThreadMessage,
   useSetThreadQueuedMessageGroupBoundary,
+  useSendThreadQueuedMessage,
   useSendThreadMessage,
 } from "./thread-runtime-mutations";
 
@@ -40,6 +42,7 @@ vi.mock("@/lib/sdk", async (importOriginal) => {
           create: vi.fn(),
           delete: vi.fn(),
           list: vi.fn(),
+          send: vi.fn(),
           setGroupBoundary: vi.fn(),
         },
         send: vi.fn(),
@@ -174,6 +177,10 @@ beforeEach(() => {
   vi.mocked(sdk.threads.queuedMessages.list).mockResolvedValue([
     makeQueuedMessage(),
   ]);
+  vi.mocked(sdk.threads.queuedMessages.send).mockResolvedValue({
+    ok: true,
+    delivery: "sent",
+  });
   vi.mocked(sdk.threads.queuedMessages.setGroupBoundary).mockResolvedValue([]);
 });
 
@@ -366,9 +373,9 @@ describe("thread runtime mutations", () => {
     vi.mocked(sdk.threads.send).mockResolvedValue({
       ok: true,
       delivery: "queued",
-      queuedMessageId: "qmsg-1",
-      waitingOn: { kind: "interaction" },
-      sendAt: null,
+      queuedMessage: makeQueuedMessage({
+        waitingOn: { kind: "interaction" },
+      }),
     });
     const { wrapper } = createQueryClientTestHarness();
     const { result } = renderHook(() => useSendThreadMessage(), { wrapper });
@@ -388,10 +395,63 @@ describe("thread runtime mutations", () => {
     expect(sendResult).toEqual({
       ok: true,
       delivery: "queued",
-      queuedMessageId: "qmsg-1",
-      waitingOn: { kind: "interaction" },
-      sendAt: null,
+      queuedMessage: makeQueuedMessage({
+        waitingOn: { kind: "interaction" },
+      }),
     });
+  });
+
+  it("restores a queued-row steer when provisioning keeps it queued", async () => {
+    const queuedMessage = makeQueuedMessage({
+      waitingOn: { kind: "thread-busy" },
+    });
+    const provisioningQueuedMessage = makeQueuedMessage({
+      waitingOn: { kind: "provisioning" },
+      updatedAt: 2,
+    });
+    vi.mocked(sdk.threads.queuedMessages.send).mockResolvedValue({
+      ok: true,
+      delivery: "queued",
+      queuedMessage: provisioningQueuedMessage,
+    });
+    const { queryClient, wrapper } = createQueryClientTestHarness();
+    queryClient.setQueryData(threadQueuedMessagesQueryKey("thread-1"), [
+      queuedMessage,
+    ]);
+    queryClient.setQueryData(
+      threadQueryKey("thread-1"),
+      makeThreadResponse({
+        status: "starting",
+        runtime: {
+          displayStatus: "provisioning",
+          hostReconnectGraceExpiresAt: null,
+        },
+      }),
+    );
+    queryClient.setQueryData(
+      threadTimelineQueryKey("thread-1"),
+      makeBannerTimeline(),
+    );
+    const { result } = renderHook(() => useSendThreadQueuedMessage(), {
+      wrapper,
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        id: "thread-1",
+        mode: "steer",
+        queuedMessageId: queuedMessage.id,
+      });
+    });
+
+    expect(
+      queryClient.getQueryData(threadQueuedMessagesQueryKey("thread-1")),
+    ).toEqual([provisioningQueuedMessage]);
+    expect(
+      queryClient.getQueryData<ThreadTimelineResponse>(
+        threadTimelineQueryKey("thread-1"),
+      )?.rows,
+    ).toEqual([]);
   });
 
   it("forwards execution input sources and sender thread when queueing a message", async () => {

--- a/apps/app/src/hooks/mutations/thread-runtime-mutations.ts
+++ b/apps/app/src/hooks/mutations/thread-runtime-mutations.ts
@@ -206,10 +206,10 @@ export function useSendThreadMessage() {
     },
     onSuccess: (data, variables, context) => {
       applySendThreadMessageSuccess({
-        delivery: data.delivery,
         queryClient,
         realtimeConnected: wsManager.getConnectionState() === "connected",
         request: variables,
+        result: data,
         transaction: context,
       });
     },
@@ -360,10 +360,12 @@ export function useSendThreadQueuedMessage() {
         transaction: context,
       });
     },
-    onSuccess: (_data, variables) => {
+    onSuccess: (data, variables, transaction) => {
       applyQueuedMessageSendResult({
         queryClient,
-        threadId: variables.id,
+        request: variables,
+        result: data,
+        transaction,
       });
     },
   });

--- a/apps/app/src/views/thread-detail/ThreadDetailPromptArea.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailPromptArea.test.tsx
@@ -292,6 +292,9 @@ vi.mock(
       inlineEditor,
       queuedMessages,
       onEdit,
+      onSend,
+      sendAction,
+      sendDisabled,
     }: {
       inlineEditor?: { content: ReactNode; onDismiss: () => void };
       queuedMessages: readonly ThreadQueuedMessage[];
@@ -299,22 +302,35 @@ vi.mock(
         queuedMessageId: string;
         queuedMessageIndex: number;
       }) => void;
+      onSend: (queuedMessageId: string) => void;
+      sendAction: "send-now" | "steer-when-ready";
+      sendDisabled: boolean;
     }) => (
-      <div data-testid="queued-message-list">
+      <div
+        data-testid="queued-message-list"
+        data-send-action={sendAction}
+        data-send-disabled={sendDisabled ? "" : undefined}
+      >
         <div data-testid="queued-message-count">{queuedMessages.length}</div>
         {queuedMessages.map((message, index) => (
-          <button
-            key={message.id}
-            type="button"
-            onClick={() =>
-              onEdit({
-                queuedMessageId: message.id,
-                queuedMessageIndex: index,
-              })
-            }
-          >
-            Edit queued message {index + 1}
-          </button>
+          <div key={message.id}>
+            <button type="button" onClick={() => onSend(message.id)}>
+              {sendAction === "steer-when-ready"
+                ? `Steer queued message ${index + 1} when ready`
+                : `Send queued message ${index + 1} now`}
+            </button>
+            <button
+              type="button"
+              onClick={() =>
+                onEdit({
+                  queuedMessageId: message.id,
+                  queuedMessageIndex: index,
+                })
+              }
+            >
+              Edit queued message {index + 1}
+            </button>
+          </div>
         ))}
         {inlineEditor ? (
           <div data-testid="inline-queued-message-editor">
@@ -934,6 +950,39 @@ describe("ThreadDetailPromptArea", () => {
     const composer = screen.getByTestId("composer-boundary");
     expect(stack.lastElementChild).toBe(queue);
     expect(stack.nextElementSibling).toBe(composer);
+  });
+
+  it("steers a queued row once a provisioning thread is ready", async () => {
+    mocks.queuedMessages = [
+      makeQueuedMessage({ waitingOn: { kind: "provisioning" } }),
+    ];
+
+    renderPromptArea({
+      thread: makeThread({
+        runtime: {
+          displayStatus: "provisioning",
+          hostReconnectGraceExpiresAt: null,
+        },
+        status: "starting",
+      }),
+    });
+
+    const queue = screen.getByTestId("queued-message-list");
+    expect(queue.dataset.sendAction).toBe("steer-when-ready");
+    expect(queue.dataset.sendDisabled).toBeUndefined();
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Steer queued message 1 when ready",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mocks.sendQueuedMessageMutateAsync).toHaveBeenCalledWith({
+        id: "thr_1",
+        mode: "steer",
+        queuedMessageId: "qmsg_1",
+      });
+    });
   });
 
   it("uses the real thread cache keys immediately", () => {

--- a/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
@@ -668,6 +668,9 @@ export function ThreadDetailPromptArea({
     resolveMentionLink,
   });
   const runtimeDisplayStatus = thread.runtime.displayStatus;
+  const shouldSteerWhenReady =
+    runtimeDisplayStatus === "provisioning" ||
+    runtimeDisplayStatus === "starting";
   const isStopRequested =
     thread.status === "stopping" ||
     (stopThread.isPending && stopThread.variables === thread.id);
@@ -949,6 +952,7 @@ export function ThreadDetailPromptArea({
         await sendQueuedMessageById({
           guard: "current-head",
           messageId: queuedMessageId,
+          mode: shortcutRequest.request.mode,
         });
       },
     );
@@ -965,14 +969,15 @@ export function ThreadDetailPromptArea({
     thread.id,
   ]);
 
-  const handleSendQueuedImmediately = useCallback(
+  const handleSendQueuedMessage = useCallback(
     (messageId: string) => {
       void sendQueuedMessageById({
         guard: "exists",
         messageId,
+        mode: shouldSteerWhenReady ? "steer" : "auto",
       });
     },
-    [sendQueuedMessageById],
+    [sendQueuedMessageById, shouldSteerWhenReady],
   );
 
   const bottomFocusEndKey = `${composerFocusRequestNonce}:${bottomPluginFocusNonce}`;
@@ -1604,10 +1609,9 @@ export function ThreadDetailPromptArea({
             queuedMessages={queuedMessages}
             resolveMentionLink={resolveMentionLink}
             inlineEditor={queuedMessageEditor ?? undefined}
+            sendAction={shouldSteerWhenReady ? "steer-when-ready" : "send-now"}
             sendDisabled={
               !(submitMode.kind === "ready" || submitMode.kind === "queue") ||
-              runtimeDisplayStatus === "provisioning" ||
-              runtimeDisplayStatus === "starting" ||
               runtimeDisplayStatus === "waiting-for-host" ||
               isFollowUpSubmitting ||
               isQueueMutationPending
@@ -1615,7 +1619,7 @@ export function ThreadDetailPromptArea({
             actionDisabled={isQueueMutationPending}
             processingMessageId={displayedProcessingQueuedMessage?.id ?? null}
             processingAction={displayedProcessingQueuedMessage?.action ?? null}
-            onSendImmediately={handleSendQueuedImmediately}
+            onSend={handleSendQueuedMessage}
             onReorder={handleReorderQueuedMessage}
             onSetGroupBoundary={handleSetQueuedMessageGroupBoundary}
             onEdit={beginEditQueuedMessage}
@@ -1633,7 +1637,7 @@ export function ThreadDetailPromptArea({
       beginEditQueuedMessage,
       onChangedFileClick,
       handleReorderQueuedMessage,
-      handleSendQueuedImmediately,
+      handleSendQueuedMessage,
       handleSetQueuedMessageGroupBoundary,
       handleToggleBannerSection,
       handleUnarchiveCurrentThread,
@@ -1661,6 +1665,7 @@ export function ThreadDetailPromptArea({
       queuedMessagesPending,
       resolveMentionLink,
       runtimeDisplayStatus,
+      shouldSteerWhenReady,
       shouldHideComposer,
       submitMode.kind,
       thread.archivedAt,

--- a/apps/cli/src/__tests__/command-output/thread-organization.test.ts
+++ b/apps/cli/src/__tests__/command-output/thread-organization.test.ts
@@ -125,6 +125,33 @@ describe("bb thread organization commands", () => {
     expect(update).not.toHaveBeenCalled();
   });
 
+  it("reports when sending a queued message leaves it waiting", async () => {
+    const send = vi.fn(async () => ({
+      ok: true,
+      delivery: "queued",
+      queuedMessage: {
+        waitingOn: { kind: "provisioning" },
+        sendAt: null,
+      },
+    }));
+    stubServerApi({
+      "v1.threads.:id.queued-messages.:queuedMessageId.send.$post": send,
+    });
+
+    await runCommand(
+      ["thread", "queue", "send", "thread-1", "queued-1", "--mode", "steer"],
+      register,
+    );
+
+    expect(send).toHaveBeenCalledWith({
+      param: { id: "thread-1", queuedMessageId: "queued-1" },
+      json: { mode: "steer" },
+    });
+    expect(console.log).toHaveBeenCalledWith(
+      "Queued message queued-1 is still queued (waiting for the workspace)",
+    );
+  });
+
   it("reorders pinned threads with explicit neighbors", async () => {
     const reorder = vi.fn(async () => []);
     stubServerApi({ "v1.threads.:id.pin-order.$patch": reorder });

--- a/apps/cli/src/__tests__/command-output/thread-tell.test.ts
+++ b/apps/cli/src/__tests__/command-output/thread-tell.test.ts
@@ -38,9 +38,11 @@ describe("bb thread tell command output", () => {
     const post = vi.fn(async () => ({
       ok: true,
       delivery: "queued",
-      queuedMessageId: "qm_1",
-      waitingOn: { kind: "interaction" },
-      sendAt: null,
+      queuedMessage: {
+        id: "qm_1",
+        waitingOn: { kind: "interaction" },
+        sendAt: null,
+      },
     }));
     stubServerApi({ "v1.threads.:id.send.$post": post });
 
@@ -55,13 +57,15 @@ describe("bb thread tell command output", () => {
     const post = vi.fn(async () => ({
       ok: true,
       delivery: "queued",
-      queuedMessageId: "qm_2",
-      waitingOn: {
-        kind: "plugin",
-        pluginId: "concurrency-limit",
-        reason: "4 of 4 running",
+      queuedMessage: {
+        id: "qm_2",
+        waitingOn: {
+          kind: "plugin",
+          pluginId: "concurrency-limit",
+          reason: "4 of 4 running",
+        },
+        sendAt: null,
       },
-      sendAt: null,
     }));
     stubServerApi({ "v1.threads.:id.send.$post": post });
 

--- a/apps/cli/src/commands/thread/actions.ts
+++ b/apps/cli/src/commands/thread/actions.ts
@@ -610,7 +610,7 @@ function describeThreadTellOutcome(
     // The server says WHY it is waiting, so the CLI does not have to guess
     // from the flags it happened to send. `bb thread queue list` shows the
     // same reason for the row afterwards.
-    return `Thread ${threadId} message queued (${describeQueueWait(response)}); it dispatches when that clears`;
+    return `Thread ${threadId} message queued (${describeQueueWait(response.queuedMessage)}); it dispatches when that clears`;
   }
   return response.mode === "steer"
     ? `Thread ${threadId} steered`

--- a/apps/cli/src/commands/thread/organization.ts
+++ b/apps/cli/src/commands/thread/organization.ts
@@ -443,6 +443,12 @@ export function registerOrganizationCommands(
             mode: opts.mode,
           });
           if (outputJson(opts, result)) return;
+          if (result.delivery === "queued") {
+            console.log(
+              `Queued message ${messageId} is still queued (${describeQueueWait(result.queuedMessage)})`,
+            );
+            return;
+          }
           console.log(`Queued message ${messageId} sent`);
         },
       ),

--- a/apps/demo-server/src/demo-world.test.ts
+++ b/apps/demo-server/src/demo-world.test.ts
@@ -263,7 +263,7 @@ describe("sending a message", () => {
         threadQueuedMessageListResponseSchema,
       ),
     ).toEqual([queued]);
-    await parsed(
+    const sent = await parsed(
       send(
         "POST",
         `/api/v1/threads/${THREAD_ID}/queued-messages/${queued.id}/send`,
@@ -273,6 +273,7 @@ describe("sending a message", () => {
       ),
       sendQueuedMessageResponseSchema,
     );
+    expect(sent.delivery).toBe("sent");
     expect(
       await parsed(
         get(`/api/v1/threads/${THREAD_ID}/queued-messages`),

--- a/apps/demo-server/src/demo-world.ts
+++ b/apps/demo-server/src/demo-world.ts
@@ -321,7 +321,7 @@ export class DemoWorld {
       this.appendTurn(state, promptText(message.content), now);
       return json({
         ok: true,
-        queuedMessage: message,
+        delivery: "sent",
       } satisfies SendQueuedMessageResponse);
     }
     return null;

--- a/apps/server/src/routes/threads/actions.ts
+++ b/apps/server/src/routes/threads/actions.ts
@@ -266,12 +266,12 @@ export function registerThreadActionRoutes(app: Hono, deps: AppDeps): void {
     const thread = requirePublicThread(deps.db, context.req.param("id"));
     ensureThreadIsWritable(thread);
     ensureThreadIsNotAwaitingUserInteraction(deps, thread.id);
-    const queuedMessage = await sendQueuedMessageNow(deps, {
+    const result = await sendQueuedMessageNow(deps, {
       queuedMessageId: context.req.param("queuedMessageId"),
       mode: payload.mode,
       threadId: context.req.param("id"),
     });
-    return context.json({ ok: true, queuedMessage });
+    return context.json({ ok: true, ...result });
   });
 
   patch(routes.reorderQueuedMessage, (context, payload) => {

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/references/thread-operation.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/references/thread-operation.md
@@ -39,10 +39,10 @@
   (epoch ms) on `threads.spawn` / `threads.send`.
 - A send that cannot run right now does not fail: it joins the thread's queue
   with a typed reason. `--json` reports `delivery: "queued"` plus
-  `queuedMessageId`, `waitingOn` and `sendAt`, so a script can tell "waiting for
-  the current turn" from "waiting on a plugin" without guessing. `waitingOn.kind`
-  is one of `time`, `thread-busy`, `provisioning`, `interaction` or `plugin`
-  (which also carries `pluginId` and a human reason).
+  the complete `queuedMessage` row, so a script can inspect its `id`,
+  `waitingOn`, and `sendAt` without guessing. `queuedMessage.waitingOn.kind` is
+  one of `time`, `thread-busy`, `turn-starting`, `provisioning`, `host-offline`,
+  `interaction`, or `plugin` (which also carries `pluginId` and a human reason).
 - Inspect and act on queued dispatches with `bb thread queue list [<thread-id>]
   [--wait-holder plugin:<plugin-id>]`, `bb thread queue send <thread-id>
   <message-id>` (send it now, bypassing every plugin wait and its schedule), and
@@ -51,6 +51,10 @@
   and `Send at` columns. Several queued rows on one thread are normal. The SDK
   equivalents are `threads.queue.list` (cross-thread) and
   `threads.queuedMessages.list/send/update/delete` (one thread).
+- `bb thread queue send <thread-id> <message-id> --mode steer` re-attempts the
+  row as a steer with the same send-now behavior: it bypasses the row's schedule
+  and plugin waits, while core waits still apply. During provisioning it reports
+  that the row is still queued and leaves it waiting for the workspace.
 - Queueing writes nothing to the timeline: a queued message reaches the thread
   log only once it dispatches. Ask the queue instead. In the app the same fact
   reaches the sidebar as a clock on any thread that holds queued work and is not

--- a/apps/server/src/services/threads/queued-message-dispatch.ts
+++ b/apps/server/src/services/threads/queued-message-dispatch.ts
@@ -57,9 +57,7 @@ interface QueuedMessageDispatchRef {
 
 type PreparedQueuedMessageDispatchWake = Exclude<
   QueuedMessageDispatchWake,
-  | { kind: "workspace-ready" }
-  | { kind: "provisioning-ended" }
-  | { kind: "host-connected" }
+  { kind: "provisioning-ended" } | { kind: "host-connected" }
 >;
 
 const pendingPluginRechecks = new WeakSet<
@@ -86,12 +84,7 @@ function prepareQueuedMessageDispatchWake(
 ): PreparedQueuedMessageDispatchWake[] {
   switch (wake.kind) {
     case "workspace-ready":
-      return clearThreadQueueWaitsOfKind(deps, {
-        threadId: wake.threadId,
-        kind: "provisioning",
-      }) === 0
-        ? []
-        : [{ kind: "thread-ready", threadId: wake.threadId }];
+      return [wake];
     case "provisioning-ended":
       clearThreadQueueWaitsOfKind(deps, {
         threadId: wake.threadId,
@@ -123,6 +116,7 @@ function dispatchWakeContext(
   wake: PreparedQueuedMessageDispatchWake,
 ): Record<string, number | string | undefined> {
   switch (wake.kind) {
+    case "workspace-ready":
     case "thread-ready":
     case "turn-started":
     case "interaction-settled":
@@ -185,6 +179,9 @@ async function executePreparedQueuedMessageDispatch(
   wake: PreparedQueuedMessageDispatchWake,
 ): Promise<void> {
   switch (wake.kind) {
+    case "workspace-ready":
+      await runWorkspaceReadyDispatch(deps, wake.threadId);
+      return;
     case "thread-ready":
       await runThreadReadyDispatch(deps, wake.threadId);
       return;
@@ -239,10 +236,53 @@ async function runTurnStartedDispatch(
   deps: QueueDispatchDeps,
   threadId: string,
 ): Promise<void> {
-  const rows = listQueuedThreadMessagesWaitingOnKind(deps.db, {
+  const turnStartingRows = listQueuedThreadMessagesWaitingOnKind(deps.db, {
     kind: "turn-starting",
     threadId,
   });
+  const provisioningRows = listQueuedThreadMessagesWaitingOnKind(deps.db, {
+    kind: "provisioning",
+    threadId,
+  });
+  for (const row of provisioningRows) {
+    clearQueuedMessageWait(deps, {
+      queuedMessageId: row.id,
+      threadId,
+    });
+  }
+  const rows = [...turnStartingRows, ...provisioningRows].sort(
+    (left, right) => {
+      if (left.sortKey !== right.sortKey) {
+        return left.sortKey < right.sortKey ? -1 : 1;
+      }
+      if (left.id === right.id) return 0;
+      return left.id < right.id ? -1 : 1;
+    },
+  );
+  for (const row of rows) {
+    await attemptAutomaticQueuedMessage(deps, row, {
+      now: Date.now(),
+      respectRequeuePacing: false,
+    });
+  }
+}
+
+async function runWorkspaceReadyDispatch(
+  deps: QueueDispatchDeps,
+  threadId: string,
+): Promise<void> {
+  const thread = getThread(deps.db, threadId);
+  if (thread?.status === "starting") return;
+  const rows = listQueuedThreadMessagesWaitingOnKind(deps.db, {
+    kind: "provisioning",
+    threadId,
+  });
+  for (const row of rows) {
+    clearQueuedMessageWait(deps, {
+      queuedMessageId: row.id,
+      threadId,
+    });
+  }
   for (const row of rows) {
     await attemptAutomaticQueuedMessage(deps, row, {
       now: Date.now(),

--- a/apps/server/src/services/threads/queued-messages.ts
+++ b/apps/server/src/services/threads/queued-messages.ts
@@ -734,7 +734,7 @@ async function sendClaimedQueuedMessageForThread(
     startedOnBehalfOf: null,
     trigger: "auto-dispatch",
   });
-  if (args.sendNow && outcome.kind === "queued") {
+  if (args.sendNow && args.mode !== "steer" && outcome.kind === "queued") {
     // "Send now" overrides every plugin wait and the row's own schedule, but
     // not a core wait — those guard invariants rather than express a policy.
     // The row is back on the queue with its new reason; say so rather than
@@ -817,13 +817,26 @@ export async function sendQueuedMessageNow(
     queuedMessageId: string;
     threadId: string;
   },
-): Promise<ThreadQueuedMessage> {
-  return sendQueuedMessage(deps, {
+): Promise<
+  | { delivery: "sent" }
+  | { delivery: "queued"; queuedMessage: ThreadQueuedMessage }
+> {
+  await sendQueuedMessage(deps, {
     claimPolicy: { kind: "explicit-send" },
     mode: args.mode,
     queuedMessageId: args.queuedMessageId,
     threadId: args.threadId,
   });
+  const remainingQueuedMessage = getQueuedThreadMessage(
+    deps.db,
+    args.queuedMessageId,
+  );
+  return remainingQueuedMessage
+    ? {
+        delivery: "queued",
+        queuedMessage: toThreadQueuedMessage(remainingQueuedMessage),
+      }
+    : { delivery: "sent" };
 }
 
 export async function sendNextQueuedMessageIfPresent(

--- a/apps/server/src/services/threads/thread-send-request.ts
+++ b/apps/server/src/services/threads/thread-send-request.ts
@@ -41,11 +41,6 @@ export async function acceptThreadSendRequest(
   return {
     ok: true,
     delivery: "queued",
-    queuedMessageId: outcome.entry.id,
-    // A queued row's `waitingOn` is null only when a drain cleared its wait
-    // and is about to re-attempt it — a state this row, just written by the
-    // attempt above, cannot be in. The fallback narrows the type honestly.
-    waitingOn: outcome.entry.waitingOn ?? { kind: "thread-busy" },
-    sendAt: outcome.entry.sendAt,
+    queuedMessage: outcome.entry,
   };
 }

--- a/apps/server/test/internal/internal-events-tool-calls.test.ts
+++ b/apps/server/test/internal/internal-events-tool-calls.test.ts
@@ -598,12 +598,14 @@ describe("internal event and tool-call routes", () => {
       );
 
       expect(sendResponse.status).toBe(200);
-      await expect(readJson(sendResponse)).resolves.toEqual({
+      await expect(readJson(sendResponse)).resolves.toMatchObject({
         ok: true,
         delivery: "queued",
-        queuedMessageId: expect.any(String),
-        waitingOn: { kind: "thread-busy" },
-        sendAt: null,
+        queuedMessage: {
+          id: expect.any(String),
+          waitingOn: { kind: "thread-busy" },
+          sendAt: null,
+        },
       });
       const queuedRows = listQueuedThreadMessages(harness.db, thread.id);
       expect(queuedRows).toHaveLength(1);

--- a/apps/server/test/public/public-thread-data.test.ts
+++ b/apps/server/test/public/public-thread-data.test.ts
@@ -2607,12 +2607,14 @@ describe("public thread data routes", () => {
       );
 
       expect(response.status).toBe(200);
-      await expect(readJson(response)).resolves.toEqual({
+      await expect(readJson(response)).resolves.toMatchObject({
         ok: true,
         delivery: "queued",
-        queuedMessageId: expect.any(String),
-        waitingOn: { kind: "thread-busy" },
-        sendAt: null,
+        queuedMessage: {
+          id: expect.any(String),
+          waitingOn: { kind: "thread-busy" },
+          sendAt: null,
+        },
       });
       const queuedRows = listQueuedThreadMessages(harness.db, thread.id);
       expect(queuedRows).toMatchObject([
@@ -2674,12 +2676,14 @@ describe("public thread data routes", () => {
       );
 
       expect(response.status).toBe(200);
-      await expect(readJson(response)).resolves.toEqual({
+      await expect(readJson(response)).resolves.toMatchObject({
         ok: true,
         delivery: "queued",
-        queuedMessageId: expect.any(String),
-        waitingOn: { kind: "thread-busy" },
-        sendAt: null,
+        queuedMessage: {
+          id: expect.any(String),
+          waitingOn: { kind: "thread-busy" },
+          sendAt: null,
+        },
       });
       expect(listQueuedThreadMessages(harness.db, thread.id)).toMatchObject([
         {

--- a/apps/server/test/public/public-thread-interactions.test.ts
+++ b/apps/server/test/public/public-thread-interactions.test.ts
@@ -891,12 +891,14 @@ describe("public thread interaction routes", () => {
       // A prompt cannot interrupt the interaction, but the message is not lost:
       // it joins the queue and delivers once the interaction settles (#1650).
       expect(sendResponse.status).toBe(200);
-      await expect(readJson(sendResponse)).resolves.toEqual({
+      await expect(readJson(sendResponse)).resolves.toMatchObject({
         ok: true,
         delivery: "queued",
-        queuedMessageId: expect.any(String),
-        waitingOn: { kind: "interaction" },
-        sendAt: null,
+        queuedMessage: {
+          id: expect.any(String),
+          waitingOn: { kind: "interaction" },
+          sendAt: null,
+        },
       });
       // The queued row sits alongside the message that was already queued, and
       // it is the only one carrying the interaction wait.
@@ -993,12 +995,14 @@ describe("public thread interaction routes", () => {
       // interaction does not change, so an explicit queue request queues behind
       // the running turn rather than behind the interaction.
       expect(activeSendResponse.status).toBe(200);
-      await expect(readJson(activeSendResponse)).resolves.toEqual({
+      await expect(readJson(activeSendResponse)).resolves.toMatchObject({
         ok: true,
         delivery: "queued",
-        queuedMessageId: expect.any(String),
-        waitingOn: { kind: "thread-busy" },
-        sendAt: null,
+        queuedMessage: {
+          id: expect.any(String),
+          waitingOn: { kind: "thread-busy" },
+          sendAt: null,
+        },
       });
       expect(
         listQueuedThreadMessages(harness.db, activeThread.id),

--- a/apps/server/test/public/public-thread-offline-followup.test.ts
+++ b/apps/server/test/public/public-thread-offline-followup.test.ts
@@ -98,7 +98,7 @@ describe("offline host follow-ups", () => {
       const body = sendMessageResponseSchema.parse(await readJson(response));
       expect(body).toMatchObject({
         delivery: "queued",
-        sendAt: null,
+        queuedMessage: { sendAt: null },
       });
       if (body.delivery !== "queued") {
         throw new Error("expected the offline follow-up to queue");
@@ -107,7 +107,7 @@ describe("offline host follow-ups", () => {
       const queued = listQueuedThreadMessages(harness.db, thread.id);
       expect(queued).toHaveLength(1);
       expect(queued[0]).toMatchObject({
-        id: body.queuedMessageId,
+        id: body.queuedMessage.id,
         sendAt: null,
         failureReason: null,
       });
@@ -132,7 +132,9 @@ describe("offline host follow-ups", () => {
           listQueuedThreadCommands(harness, "turn.submit", thread.id),
         ).toEqual([]);
       }
-      expect(body).toMatchObject({ waitingOn: testCase.waitingOn });
+      expect(body).toMatchObject({
+        queuedMessage: { waitingOn: testCase.waitingOn },
+      });
       expect(
         queuedMessageWaitingOnSchema.parse(JSON.parse(queued[0]!.waitingOn!)),
       ).toEqual(testCase.waitingOn);

--- a/apps/server/test/public/public-thread-stop-runtime.test.ts
+++ b/apps/server/test/public/public-thread-stop-runtime.test.ts
@@ -172,7 +172,7 @@ describe("thread runtime stop", () => {
       expect(queueResponse.status).toBe(200);
       await expect(readJson(queueResponse)).resolves.toMatchObject({
         delivery: "queued",
-        waitingOn: { kind: "turn-starting" },
+        queuedMessage: { waitingOn: { kind: "turn-starting" } },
       });
       expect(listQueuedThreadMessages(harness.db, thread.id)).toHaveLength(1);
 

--- a/apps/server/test/threads/thread-send-dispatch.test.ts
+++ b/apps/server/test/threads/thread-send-dispatch.test.ts
@@ -23,6 +23,7 @@ import { runQueuedMessageDispatch } from "../../src/services/threads/queued-mess
 import {
   createAutomaticQueuedMessageGroupEligibility,
   sendQueuedMessage,
+  sendQueuedMessageNow,
 } from "../../src/services/threads/queued-messages.js";
 import { queueParentSystemMessage } from "../../src/services/threads/parent-system-messages.js";
 import { acceptThreadSendRequest } from "../../src/services/threads/thread-send-request.js";
@@ -61,7 +62,7 @@ interface SeedIdleThreadFixtureArgs {
 }
 
 interface SeedProviderThreadFixtureArgs extends SeedIdleThreadFixtureArgs {
-  status?: "active" | "idle";
+  status?: "active" | "idle" | "starting";
 }
 
 afterEach(() => vi.restoreAllMocks());
@@ -328,7 +329,113 @@ describe("user message telemetry", () => {
   });
 });
 
-describe("turn-starting queue wait", () => {
+describe("startup queue waits", () => {
+  it("steers provisioning input into the first turn in queue order", async () => {
+    await withTestHarness(async (harness) => {
+      const { environment, thread } = seedProviderThreadFixture({
+        harness,
+        status: "starting",
+        value: 69,
+      });
+      for (const text of [
+        "first provisioning steer",
+        "second provisioning steer",
+      ]) {
+        await expect(
+          acceptThreadSendRequest(harness.deps, {
+            payload: {
+              input: textInput(text),
+              mode: "steer-if-active",
+            },
+            thread,
+          }),
+        ).resolves.toMatchObject({
+          delivery: "queued",
+          queuedMessage: { waitingOn: { kind: "provisioning" } },
+        });
+      }
+
+      await runQueuedMessageDispatch(harness.deps, {
+        kind: "workspace-ready",
+        threadId: thread.id,
+      });
+      expect(listQueuedThreadMessages(harness.db, thread.id)).toMatchObject([
+        { waitingOn: JSON.stringify({ kind: "provisioning" }) },
+        { waitingOn: JSON.stringify({ kind: "provisioning" }) },
+      ]);
+
+      applyLoggedThreadLifecycleEvent(harness.deps, {
+        event: { type: "run.started" },
+        threadId: thread.id,
+      });
+      seedTurnStarted(harness.deps, {
+        environmentId: environment.id,
+        providerThreadId: "provider-send-dispatch-69",
+        threadId: thread.id,
+        turnId: "turn-send-dispatch-69",
+      });
+      await runQueuedMessageDispatch(harness.deps, {
+        kind: "turn-started",
+        threadId: thread.id,
+      });
+
+      expect(listQueuedThreadMessages(harness.db, thread.id)).toEqual([]);
+      expect(
+        listQueuedThreadCommands(harness, "turn.submit", thread.id),
+      ).toMatchObject([
+        {
+          input: textInput("first provisioning steer"),
+          target: {
+            mode: "auto",
+            expectedTurnId: "turn-send-dispatch-69",
+          },
+        },
+        {
+          input: textInput("second provisioning steer"),
+          target: {
+            mode: "auto",
+            expectedTurnId: "turn-send-dispatch-69",
+          },
+        },
+      ]);
+    });
+  });
+
+  it("keeps an explicitly steered queued row parked during provisioning", async () => {
+    await withTestHarness(async (harness) => {
+      const { thread } = seedProviderThreadFixture({
+        harness,
+        status: "starting",
+        value: 70,
+      });
+      const queued = seedQueuedMessage(harness.deps, {
+        content: textInput("steer this queued row when ready"),
+        threadId: thread.id,
+        waitingOn: { kind: "thread-busy" },
+      });
+
+      await expect(
+        sendQueuedMessageNow(harness.deps, {
+          mode: "steer",
+          queuedMessageId: queued.id,
+          threadId: thread.id,
+        }),
+      ).resolves.toMatchObject({
+        delivery: "queued",
+        queuedMessage: {
+          id: queued.id,
+          waitingOn: { kind: "provisioning" },
+        },
+      });
+      expect(listQueuedThreadMessages(harness.db, thread.id)).toMatchObject([
+        {
+          id: queued.id,
+          waitingOn: JSON.stringify({ kind: "provisioning" }),
+        },
+      ]);
+    });
+  });
+
   it("starts a new turn when startup settles before its queued wake", async () => {
     await withTestHarness(async (harness) => {
       const { thread } = seedProviderThreadFixture({
@@ -584,7 +691,7 @@ describe("turn-starting queue wait", () => {
         }),
       ).resolves.toMatchObject({
         delivery: "queued",
-        waitingOn: { kind: "turn-starting" },
+        queuedMessage: { waitingOn: { kind: "turn-starting" } },
       });
       await expect(
         acceptThreadSendRequest(harness.deps, {
@@ -600,7 +707,7 @@ describe("turn-starting queue wait", () => {
         }),
       ).resolves.toMatchObject({
         delivery: "queued",
-        waitingOn: { kind: "turn-starting" },
+        queuedMessage: { waitingOn: { kind: "turn-starting" } },
       });
       expect(queueChangedInTransactions).toEqual([false, false]);
       const queued = listQueuedThreadMessages(harness.db, thread.id);

--- a/packages/client-core/src/prompt/threadDetailPromptSubmission.ts
+++ b/packages/client-core/src/prompt/threadDetailPromptSubmission.ts
@@ -22,7 +22,7 @@ export interface CreateQueuedFollowUpRequest extends CreateQueuedMessageRequest 
 
 export interface SendQueuedMessageByIdRequest {
   id: string;
-  mode: "auto";
+  mode: "steer";
   queuedMessageId: string;
 }
 
@@ -190,7 +190,9 @@ export function canSubmitFollowUpShortcut({
   submitModeKind,
 }: CanSubmitFollowUpShortcutArgs): boolean {
   return (
-    runtimeDisplayStatus === "active" &&
+    (runtimeDisplayStatus === "active" ||
+      runtimeDisplayStatus === "provisioning" ||
+      runtimeDisplayStatus === "starting") &&
     submitModeKind === "queue" &&
     !isFollowUpSubmitting &&
     !isQueueMutationPending &&
@@ -268,7 +270,7 @@ function buildSendQueuedMessageByIdRequest({
 }: BuildSendQueuedMessageByIdRequestArgs): SendQueuedMessageByIdRequest {
   return {
     id: threadId,
-    mode: "auto",
+    mode: "steer",
     queuedMessageId,
   };
 }

--- a/packages/client-core/test/threadDetailPromptSubmission.test.ts
+++ b/packages/client-core/test/threadDetailPromptSubmission.test.ts
@@ -83,7 +83,7 @@ describe("threadDetailPromptSubmission", () => {
       kind: "queued",
       request: {
         id: "thread-1",
-        mode: "auto",
+        mode: "steer",
         queuedMessageId: "queued-1",
       },
     });
@@ -227,6 +227,18 @@ describe("threadDetailPromptSubmission", () => {
         submitModeKind: "queue",
       }),
     ).toBe(true);
+    for (const runtimeDisplayStatus of ["provisioning", "starting"] as const) {
+      expect(
+        canSubmitFollowUpShortcut({
+          hasPromptDraftInput: true,
+          isFollowUpSubmitting: false,
+          isQueueMutationPending: false,
+          queuedMessageCount: 0,
+          runtimeDisplayStatus,
+          submitModeKind: "queue",
+        }),
+      ).toBe(true);
+    }
     expect(
       canSubmitFollowUpShortcut({
         hasPromptDraftInput: true,

--- a/packages/plugin-api-map/sdk-public-api.json
+++ b/packages/plugin-api-map/sdk-public-api.json
@@ -3,7 +3,7 @@
   "entries": {
     ".": {
       "types": "bundled-types/bb-plugin-sdk.d.ts",
-      "sha256": "86776afcbde4eff1b7837b1a2a16894fc9c7e44145db6682e1327617055f2e60"
+      "sha256": "715892acd2b006c182696bb4902082d47c5a20ae790de96df1b954d7484951e5"
     },
     "./ai-services": {
       "types": "bundled-types/bb-plugin-sdk-ai-services.d.ts",

--- a/packages/sdk/test/sdk.test.ts
+++ b/packages/sdk/test/sdk.test.ts
@@ -1301,9 +1301,11 @@ describe("@bb/sdk", () => {
         body: {
           ok: true,
           delivery: "queued",
-          queuedMessageId: "qm_1",
-          waitingOn: { kind: "time" },
-          sendAt: 1750,
+          queuedMessage: {
+            id: "qm_1",
+            waitingOn: { kind: "time" },
+            sendAt: 1750,
+          },
         },
       },
     ]);
@@ -1329,9 +1331,11 @@ describe("@bb/sdk", () => {
     ).resolves.toEqual({
       ok: true,
       delivery: "queued",
-      queuedMessageId: "qm_1",
-      waitingOn: { kind: "time" },
-      sendAt: 1750,
+      queuedMessage: {
+        id: "qm_1",
+        waitingOn: { kind: "time" },
+        sendAt: 1750,
+      },
     });
 
     expect(queue.requests[0].url).toBe(

--- a/packages/server-contract/src/api/threads.ts
+++ b/packages/server-contract/src/api/threads.ts
@@ -231,12 +231,7 @@ export const sendMessageResponseSchema = z.discriminatedUnion("delivery", [
   z.object({
     ok: z.literal(true),
     delivery: z.literal("queued"),
-    /** The row now carrying this message; addressable for send-now or cancel. */
-    queuedMessageId: z.string().min(1),
-    /** Why it is waiting, as the card and `bb thread queue` render it. */
-    waitingOn: queuedMessageWaitingOnSchema,
-    /** The row's scheduled instant, when it has one. */
-    sendAt: z.number().int().nonnegative().nullable(),
+    queuedMessage: threadQueuedMessageSchema,
   }),
 ]);
 export type SendMessageResponse = z.infer<typeof sendMessageResponseSchema>;
@@ -366,10 +361,7 @@ export type SetQueuedMessageGroupBoundaryRequest = z.infer<
   typeof setQueuedMessageGroupBoundaryRequestSchema
 >;
 
-export const sendQueuedMessageResponseSchema = z.object({
-  ok: z.literal(true),
-  queuedMessage: threadQueuedMessageSchema,
-});
+export const sendQueuedMessageResponseSchema = sendMessageResponseSchema;
 export type SendQueuedMessageResponse = z.infer<
   typeof sendQueuedMessageResponseSchema
 >;

--- a/packages/templates/src/templates/bb-guide-threads.md
+++ b/packages/templates/src/templates/bb-guide-threads.md
@@ -216,8 +216,9 @@ Messaging:
   approval) cannot take a prompt; tell then adds the message to the thread's
   queue and dispatches it once the interaction settles. That outcome is not a
   failure, so do not resend. `--json` reports `delivery` as `sent` or `queued`,
-  and a queued answer carries `queuedMessageId`, `waitingOn` and `sendAt`. A deferred message waits for a thread that failed while
-  it was deferred, and delivers when the thread is retried.
+  and a queued answer carries the complete row as `queuedMessage`, including
+  its `id`, `waitingOn`, and `sendAt`. A deferred message waits for a thread
+  that failed while it was deferred, and delivers when the thread is retried.
 
   --plan sends the same structured /plan command the composer's plan action
   sends, so the agent proposes a plan for approval before executing (Claude
@@ -300,7 +301,10 @@ Queued messages:
   `queue send` dispatches a row now, bypassing every plugin wait and its own
   schedule — the invariants (a running turn, an unfinished workspace, an
   unanswered interaction) still apply, and a message that hits one simply queues
-  again. `queue delete` discards it instead. Both are always permitted.
+  again. `--mode steer` uses those same send-now bypasses and re-attempts the row
+  as a steer; it does not bypass the invariants, so a provisioning row remains
+  queued until the workspace is ready.
+  `queue delete` discards it instead. Both are always permitted.
 
   --send-at takes an ISO 8601 timestamp (2026-08-25T09:00, local without an
   offset) or a duration from now (30s, 10m, 2h, 7d). A time that has already


### PR DESCRIPTION
## Human comments

## What was wrong

A provisioning-held steer was woken when the workspace became ready, before the provider's first turn had started, so startup dispatch raced the turn it needed to steer and did not reliably preserve the queued order into that first turn. Separately, both direct composer sends and queued-row sends inferred whether a follow-up belonged in the timeline or queue from cached client state instead of reconciling the server's authoritative `sent | queued` outcome. The server can queue for provisioning, interaction, host, time, or plugin waits, so a prediction mismatch caused optimistic rows to disappear, jump between surfaces after a refetch, remain pending in the timeline, or overwrite newer realtime state.

## What changed

- Enabled steer actions throughout the provisioning and starting UI, including the direct composer, queued-message rows, and embedded chat.
- Kept provisioning-held messages queued through workspace readiness and drained startup messages in order when the first turn started so steers enter that turn reliably.
- Unified direct sends and queued-row sends around a discriminated `sent | queued` response whose queued arm contains the complete `queuedMessage`.
- Reconciled the exact optimistic timeline or queue item synchronously and idempotently, including realtime-before-HTTP races, without restoring stale whole-thread or whole-queue snapshots.
- Predicted future scheduled sends as queued immediately with the time wait represented in the optimistic row.
- Updated CLI, SDK, demo-server, contract, tests, built-in skill, guide consumers, and the Plugin Guide SDK inventory for the shared response and documented queued-row send-now/steer semantics.
- This changes the HTTP API contract but does not change the server-to-host-daemon wire protocol, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

## How you verified

- Focused post-rebase tests: app 125/125, server 173/173, client-core 253/253, server-contract 63/63, CLI 18/18, templates 7/7, SDK 100/100, and demo-server 9/9.
- Affected-package Turbo typechecks passed: 11/11 tasks across server-contract, client-core, server, app, CLI, SDK, and demo-server.
- Plugin Guide/API sync verification passed: plugin-api-map 75/75, Plugin SDK 223/223, app 3,779 passed with 4 skipped, all 11 Turbo tasks green, and the Plugin Guide built successfully.
- Broad suites passed for server-contract (63 tests), client-core (253 tests), and app (3,779 passed, 4 skipped).
- The broad server lane passed 2,177 tests; its 10 failures were confined to the unrelated machine-installer fake-daemon connection-timeout suite.
- A full CLI lane passed 516 tests; its 7 failures were confined to the unrelated `plugin-new` ESM mock-npm fixture. Both changed CLI files passed 18/18 when run independently.
- `git diff --check` passed, and the running development server returned HTTP 200 after the rebase.

> AGENT GENERATED
