### PR TITLE
Exit host daemon promptly after clean shutdown

### DIFF
--- a/apps/host-daemon/src/app.test.ts
+++ b/apps/host-daemon/src/app.test.ts
@@ -407,7 +407,7 @@ describe("createHostDaemonApp", () => {
     const closeMachineAuthProxy = vi.fn(async () => undefined);
     const { app } = await createAppFixture({}, { closeMachineAuthProxy });
 
-    await app.daemon.shutdown("test");
+    await app.daemon.shutdown("test", 0);
 
     expect(closeMachineAuthProxy).toHaveBeenCalledTimes(1);
   });
@@ -510,7 +510,7 @@ describe("createHostDaemonApp", () => {
       expect(resolveRuntimeShellEnv).toHaveBeenCalledTimes(1);
       expect(listModels).toHaveBeenCalledTimes(2);
     } finally {
-      await app.daemon.shutdown("test");
+      await app.daemon.shutdown("test", 0);
     }
   });
 
@@ -586,7 +586,7 @@ describe("createHostDaemonApp", () => {
         }),
       );
     } finally {
-      await app.daemon.shutdown("test");
+      await app.daemon.shutdown("test", 0);
     }
   });
 
@@ -744,7 +744,7 @@ describe("createHostDaemonApp", () => {
         "Server reported inactive daemon session; reconnecting",
       );
     } finally {
-      await app.daemon.shutdown("test");
+      await app.daemon.shutdown("test", 0);
     }
   });
 
@@ -803,7 +803,7 @@ describe("createHostDaemonApp", () => {
         loadedEnvironments: [{ environmentId: "env-app-retired" }],
       });
     } finally {
-      await app.daemon.shutdown("test");
+      await app.daemon.shutdown("test", 0);
     }
   });
 
@@ -849,7 +849,7 @@ describe("createHostDaemonApp", () => {
         "Unexpected provider process exited with stderr",
       );
     } finally {
-      await app.daemon.shutdown("test");
+      await app.daemon.shutdown("test", 0);
     }
   });
 
@@ -917,7 +917,7 @@ describe("createHostDaemonApp", () => {
         ],
       });
     } finally {
-      await app.daemon.shutdown("test");
+      await app.daemon.shutdown("test", 0);
     }
   });
 
@@ -992,7 +992,7 @@ describe("createHostDaemonApp", () => {
         reason: 'Provider "codex" exited while awaiting user interaction',
       });
     } finally {
-      await app.daemon.shutdown("test");
+      await app.daemon.shutdown("test", 0);
     }
   });
 
@@ -1027,7 +1027,7 @@ describe("createHostDaemonApp", () => {
         "Failed to forward dynamic tool call to server",
       );
     } finally {
-      await app.daemon.shutdown("test");
+      await app.daemon.shutdown("test", 0);
     }
   });
 
@@ -1067,7 +1067,7 @@ describe("createHostDaemonApp", () => {
         "Failed to forward interactive provider request to server",
       );
     } finally {
-      await app.daemon.shutdown("test");
+      await app.daemon.shutdown("test", 0);
     }
   });
 
@@ -1115,7 +1115,7 @@ describe("createHostDaemonApp", () => {
         "Failed to forward interactive provider request to server",
       );
     } finally {
-      await app.daemon.shutdown("test");
+      await app.daemon.shutdown("test", 0);
     }
   });
 });

--- a/apps/host-daemon/src/app.ts
+++ b/apps/host-daemon/src/app.ts
@@ -129,7 +129,7 @@ interface CreateHostDaemonAppOptions {
   fetchFn?: FetchFn;
   createWebSocket?: CreateReconnectingWebSocket;
   closeMachineAuthProxy?: () => Promise<void>;
-  forceExit?: (code: number) => void;
+  exitProcess?: (code: number) => void;
 }
 
 export interface HostDaemonApp {
@@ -921,7 +921,7 @@ export async function createHostDaemonApp(
     },
     logger: options.logger,
     releaseLock: options.releaseLock,
-    ...(options.forceExit ? { forceExit: options.forceExit } : {}),
+    ...(options.exitProcess ? { exitProcess: options.exitProcess } : {}),
     flushEvents: async () => {
       await eventSink.flush();
     },

--- a/apps/host-daemon/src/app.ts
+++ b/apps/host-daemon/src/app.ts
@@ -950,12 +950,12 @@ export async function createHostDaemonApp(
     },
   });
   requestDaemonRestart = () => {
-    void daemon.shutdown("self-update").catch((error) => {
+    void daemon.shutdown("self-update", 0).catch((error) => {
       options.logger.error({ err: error }, "Self-update shutdown failed");
     });
   };
   connection.setSessionCloseHandler((reason) =>
-    daemon.shutdown(`session-close:${reason}`),
+    daemon.shutdown(`session-close:${reason}`, 0),
   );
 
   return {

--- a/apps/host-daemon/src/daemon.test.ts
+++ b/apps/host-daemon/src/daemon.test.ts
@@ -93,7 +93,7 @@ describe("daemon lifecycle", () => {
     });
 
     await daemon.start();
-    await daemon.shutdown("test");
+    await daemon.shutdown("test", 0);
 
     const reacquired = await acquireDaemonLock(dataDir);
     await reacquired();
@@ -175,7 +175,7 @@ describe("daemon lifecycle", () => {
 
     await daemon.start();
 
-    await expect(daemon.shutdown("test")).rejects.toThrow("release failed");
+    await expect(daemon.shutdown("test", 0)).rejects.toThrow("release failed");
     await expect(daemon.waitUntilStopped()).rejects.toThrow("release failed");
     expect(logger.error).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -217,7 +217,7 @@ describe("daemon lifecycle", () => {
     });
   });
 
-  it("forces the process to exit when a shutdown step never finishes", async () => {
+  it("forces the requested exit status when a shutdown step never finishes", async () => {
     const logger = createLogger();
     const exitProcess = vi.fn();
     const daemon = createDaemon({
@@ -233,13 +233,13 @@ describe("daemon lifecycle", () => {
     });
 
     await daemon.start();
-    void daemon.shutdown("self-update");
+    void daemon.shutdown("daemon-lock-lost", 1);
 
     await vi.waitFor(() => {
-      expect(exitProcess).toHaveBeenCalledWith(0);
+      expect(exitProcess).toHaveBeenCalledWith(1);
     });
     expect(logger.error).toHaveBeenCalledWith(
-      expect.objectContaining({ reason: "self-update" }),
+      expect.objectContaining({ reason: "daemon-lock-lost" }),
       "Host daemon shutdown did not end the process; forcing exit so the service manager can restart it.",
     );
   });
@@ -269,7 +269,7 @@ describe("daemon lifecycle", () => {
     });
 
     await daemon.start();
-    await daemon.shutdown("self-update");
+    await daemon.shutdown("self-update", 0);
 
     expect(lifecycle).toEqual([
       "flushEvents",
@@ -278,5 +278,61 @@ describe("daemon lifecycle", () => {
       "exitProcess",
     ]);
     expect(exitProcess).toHaveBeenCalledWith(0);
+  });
+
+  it("preserves the requested failure status after daemon lock loss", async () => {
+    const logger = createLogger();
+    const exitProcess = vi.fn();
+    const daemon = createDaemon({
+      identity: {
+        hostId: "host-1",
+        hostName: "test-host",
+        instanceId: "instance-1",
+      },
+      logger,
+      releaseLock: async () => undefined,
+      exitProcess,
+    });
+
+    await daemon.start();
+    await daemon.shutdown("daemon-lock-lost", 1);
+
+    expect(exitProcess).toHaveBeenCalledWith(1);
+  });
+
+  it("exits promptly when a signal requests shutdown during startup", async () => {
+    const logger = createLogger();
+    const signalSource = new FakeSignalSource();
+    const exitProcess = vi.fn();
+    let resolveStartup: () => void = () => undefined;
+    const startup = new Promise<void>((resolve) => {
+      resolveStartup = resolve;
+    });
+    const daemon = createDaemon({
+      identity: {
+        hostId: "host-1",
+        hostName: "test-host",
+        instanceId: "instance-1",
+      },
+      logger,
+      releaseLock: async () => undefined,
+      onStart: async () => startup,
+      signalSource,
+      exitProcess,
+      shutdownExitGraceMs: 60_000,
+    });
+
+    const startPromise = daemon.start();
+    signalSource.emit("SIGTERM");
+    await daemon.waitUntilStopped();
+
+    expect(exitProcess).toHaveBeenCalledWith(0);
+    expect(logger.info).not.toHaveBeenCalledWith(
+      expect.anything(),
+      "Host daemon started",
+    );
+
+    resolveStartup();
+    await startPromise;
   });
 });

--- a/apps/host-daemon/src/daemon.test.ts
+++ b/apps/host-daemon/src/daemon.test.ts
@@ -107,6 +107,7 @@ describe("daemon lifecycle", () => {
     const startupFailure = new Error("server unavailable");
     const shutdownRuntimes = vi.fn(async () => undefined);
     const releaseLock = vi.fn(async () => undefined);
+    const exitProcess = vi.fn();
     const daemon = createDaemon({
       identity: {
         hostId: "host-1",
@@ -119,6 +120,7 @@ describe("daemon lifecycle", () => {
       },
       releaseLock,
       shutdownRuntimes,
+      exitProcess,
     });
 
     await expect(daemon.start()).rejects.toBe(startupFailure);
@@ -126,6 +128,7 @@ describe("daemon lifecycle", () => {
 
     expect(shutdownRuntimes).toHaveBeenCalledOnce();
     expect(releaseLock).toHaveBeenCalledOnce();
+    expect(exitProcess).not.toHaveBeenCalled();
     expect(logger.info).toHaveBeenCalledWith(
       { mode: "shutdown", reason: "startup-failed" },
       "Shutting down host daemon",
@@ -216,7 +219,7 @@ describe("daemon lifecycle", () => {
 
   it("forces the process to exit when a shutdown step never finishes", async () => {
     const logger = createLogger();
-    const forceExit = vi.fn();
+    const exitProcess = vi.fn();
     const daemon = createDaemon({
       identity: {
         hostId: "host-1",
@@ -225,7 +228,7 @@ describe("daemon lifecycle", () => {
       },
       logger,
       releaseLock: () => new Promise<void>(() => undefined),
-      forceExit,
+      exitProcess,
       shutdownExitGraceMs: 10,
     });
 
@@ -233,7 +236,7 @@ describe("daemon lifecycle", () => {
     void daemon.shutdown("self-update");
 
     await vi.waitFor(() => {
-      expect(forceExit).toHaveBeenCalledWith(0);
+      expect(exitProcess).toHaveBeenCalledWith(0);
     });
     expect(logger.error).toHaveBeenCalledWith(
       expect.objectContaining({ reason: "self-update" }),
@@ -241,9 +244,10 @@ describe("daemon lifecycle", () => {
     );
   });
 
-  it("forces the process to exit when cleanup succeeds but the event loop stays alive", async () => {
+  it("exits the process immediately after clean shutdown", async () => {
     const logger = createLogger();
-    const forceExit = vi.fn();
+    const lifecycle: string[] = [];
+    const exitProcess = vi.fn(() => lifecycle.push("exitProcess"));
     const daemon = createDaemon({
       identity: {
         hostId: "host-1",
@@ -251,16 +255,28 @@ describe("daemon lifecycle", () => {
         instanceId: "instance-1",
       },
       logger,
-      releaseLock: async () => undefined,
-      forceExit,
-      shutdownExitGraceMs: 10,
+      flushEvents: async () => {
+        lifecycle.push("flushEvents");
+      },
+      shutdownRuntimes: async () => {
+        lifecycle.push("shutdownRuntimes");
+      },
+      releaseLock: async () => {
+        lifecycle.push("releaseLock");
+      },
+      exitProcess,
+      shutdownExitGraceMs: 60_000,
     });
 
     await daemon.start();
     await daemon.shutdown("self-update");
 
-    await vi.waitFor(() => {
-      expect(forceExit).toHaveBeenCalledWith(0);
-    });
+    expect(lifecycle).toEqual([
+      "flushEvents",
+      "shutdownRuntimes",
+      "releaseLock",
+      "exitProcess",
+    ]);
+    expect(exitProcess).toHaveBeenCalledWith(0);
   });
 });

--- a/apps/host-daemon/src/daemon.test.ts
+++ b/apps/host-daemon/src/daemon.test.ts
@@ -280,6 +280,39 @@ describe("daemon lifecycle", () => {
     expect(exitProcess).toHaveBeenCalledWith(0);
   });
 
+  it("escalates an active clean shutdown after daemon lock loss", async () => {
+    const logger = createLogger();
+    const exitProcess = vi.fn();
+    let finishRelease: () => void = () => undefined;
+    const releaseBlocked = new Promise<void>((resolve) => {
+      finishRelease = resolve;
+    });
+    const releaseLock = vi.fn(async () => releaseBlocked);
+    const daemon = createDaemon({
+      identity: {
+        hostId: "host-1",
+        hostName: "test-host",
+        instanceId: "instance-1",
+      },
+      logger,
+      releaseLock,
+      exitProcess,
+      shutdownExitGraceMs: 60_000,
+    });
+
+    await daemon.start();
+    const signalShutdown = daemon.shutdown("SIGTERM", 0);
+    await vi.waitFor(() => {
+      expect(releaseLock).toHaveBeenCalledOnce();
+    });
+    const lockLossShutdown = daemon.shutdown("daemon-lock-lost", 1);
+    finishRelease();
+    await Promise.all([signalShutdown, lockLossShutdown]);
+
+    expect(exitProcess).toHaveBeenCalledOnce();
+    expect(exitProcess).toHaveBeenCalledWith(1);
+  });
+
   it("preserves the requested failure status after daemon lock loss", async () => {
     const logger = createLogger();
     const exitProcess = vi.fn();

--- a/apps/host-daemon/src/daemon.ts
+++ b/apps/host-daemon/src/daemon.ts
@@ -41,6 +41,8 @@ export function createDaemon(options: CreateDaemonOptions): HostDaemon {
   let stopPromise: Promise<void> | null = null;
   let stopFailure: Error | null = null;
   let shutdownExitWatchdog: ReturnType<typeof setTimeout> | null = null;
+  let shutdownExitReason: string | null = null;
+  let shutdownExitCode: 0 | 1 = 0;
 
   let resolveStopped: (() => void) | undefined;
   const stopped = new Promise<void>((resolve) => {
@@ -57,7 +59,14 @@ export function createDaemon(options: CreateDaemonOptions): HostDaemon {
     listeners.clear();
   }
 
-  function armShutdownExitWatchdog(reason: string, exitCode: 0 | 1): void {
+  function requestProcessExit(reason: string, exitCode: 0 | 1): void {
+    if (shutdownExitReason === null || exitCode > shutdownExitCode) {
+      shutdownExitReason = reason;
+      shutdownExitCode = exitCode;
+    }
+  }
+
+  function armShutdownExitWatchdog(): void {
     const exitProcess = options.exitProcess;
     if (!exitProcess) {
       return;
@@ -68,15 +77,19 @@ export function createDaemon(options: CreateDaemonOptions): HostDaemon {
     shutdownExitWatchdog = setTimeout(() => {
       shutdownExitWatchdog = null;
       options.logger.error(
-        { reason, graceMs, activeResources: process.getActiveResourcesInfo() },
+        {
+          reason: shutdownExitReason,
+          graceMs,
+          activeResources: process.getActiveResourcesInfo(),
+        },
         "Host daemon shutdown did not end the process; forcing exit so the service manager can restart it.",
       );
-      exitProcess(exitCode);
+      exitProcess(shutdownExitCode);
     }, graceMs);
     shutdownExitWatchdog.unref?.();
   }
 
-  function exitAfterCleanShutdown(exitCode: 0 | 1): void {
+  function exitAfterCleanShutdown(): void {
     const exitProcess = options.exitProcess;
     if (startupFailed || !exitProcess) {
       return;
@@ -85,15 +98,16 @@ export function createDaemon(options: CreateDaemonOptions): HostDaemon {
       clearTimeout(shutdownExitWatchdog);
       shutdownExitWatchdog = null;
     }
-    exitProcess(exitCode);
+    exitProcess(shutdownExitCode);
   }
 
   async function stop(reason: string, exitCode: 0 | 1): Promise<void> {
+    requestProcessExit(reason, exitCode);
     if (stopPromise) {
       return stopPromise;
     }
 
-    armShutdownExitWatchdog(reason, exitCode);
+    armShutdownExitWatchdog();
 
     stopPromise = (async () => {
       unregisterSignalHandlers();
@@ -142,7 +156,7 @@ export function createDaemon(options: CreateDaemonOptions): HostDaemon {
       }
 
       resolveStopped?.();
-      exitAfterCleanShutdown(exitCode);
+      exitAfterCleanShutdown();
     })();
 
     return stopPromise;

--- a/apps/host-daemon/src/daemon.ts
+++ b/apps/host-daemon/src/daemon.ts
@@ -20,7 +20,7 @@ interface CreateDaemonOptions {
   shutdownRuntimes?: () => Promise<void>;
   onStart?: () => Promise<void>;
   signalSource?: SignalSource;
-  forceExit?: (code: number) => void;
+  exitProcess?: (code: number) => void;
   shutdownExitGraceMs?: number;
 }
 
@@ -39,6 +39,7 @@ export function createDaemon(options: CreateDaemonOptions): HostDaemon {
   let started = false;
   let stopPromise: Promise<void> | null = null;
   let stopFailure: Error | null = null;
+  let shutdownExitWatchdog: ReturnType<typeof setTimeout> | null = null;
 
   let resolveStopped: (() => void) | undefined;
   const stopped = new Promise<void>((resolve) => {
@@ -56,21 +57,34 @@ export function createDaemon(options: CreateDaemonOptions): HostDaemon {
   }
 
   function armShutdownExitWatchdog(reason: string): void {
-    const forceExit = options.forceExit;
-    if (!forceExit) {
+    const exitProcess = options.exitProcess;
+    if (!exitProcess) {
       return;
     }
 
     const graceMs =
       options.shutdownExitGraceMs ?? DEFAULT_SHUTDOWN_EXIT_GRACE_MS;
-    const timer = setTimeout(() => {
+    shutdownExitWatchdog = setTimeout(() => {
+      shutdownExitWatchdog = null;
       options.logger.error(
         { reason, graceMs, activeResources: process.getActiveResourcesInfo() },
         "Host daemon shutdown did not end the process; forcing exit so the service manager can restart it.",
       );
-      forceExit(0);
+      exitProcess(0);
     }, graceMs);
-    timer.unref?.();
+    shutdownExitWatchdog.unref?.();
+  }
+
+  function exitAfterCleanShutdown(): void {
+    const exitProcess = options.exitProcess;
+    if (!started || !exitProcess) {
+      return;
+    }
+    if (shutdownExitWatchdog !== null) {
+      clearTimeout(shutdownExitWatchdog);
+      shutdownExitWatchdog = null;
+    }
+    exitProcess(0);
   }
 
   async function stop(reason: string): Promise<void> {
@@ -127,6 +141,7 @@ export function createDaemon(options: CreateDaemonOptions): HostDaemon {
       }
 
       resolveStopped?.();
+      exitAfterCleanShutdown();
     })();
 
     return stopPromise;

--- a/apps/host-daemon/src/daemon.ts
+++ b/apps/host-daemon/src/daemon.ts
@@ -27,7 +27,7 @@ interface CreateDaemonOptions {
 export interface HostDaemon {
   readonly identity: HostDaemonIdentity;
   start(): Promise<void>;
-  shutdown(reason?: string): Promise<void>;
+  shutdown(reason: string, exitCode: 0 | 1): Promise<void>;
   waitUntilStopped(): Promise<void>;
 }
 
@@ -37,6 +37,7 @@ const DEFAULT_SHUTDOWN_EXIT_GRACE_MS = 15_000;
 
 export function createDaemon(options: CreateDaemonOptions): HostDaemon {
   let started = false;
+  let startupFailed = false;
   let stopPromise: Promise<void> | null = null;
   let stopFailure: Error | null = null;
   let shutdownExitWatchdog: ReturnType<typeof setTimeout> | null = null;
@@ -56,7 +57,7 @@ export function createDaemon(options: CreateDaemonOptions): HostDaemon {
     listeners.clear();
   }
 
-  function armShutdownExitWatchdog(reason: string): void {
+  function armShutdownExitWatchdog(reason: string, exitCode: 0 | 1): void {
     const exitProcess = options.exitProcess;
     if (!exitProcess) {
       return;
@@ -70,29 +71,29 @@ export function createDaemon(options: CreateDaemonOptions): HostDaemon {
         { reason, graceMs, activeResources: process.getActiveResourcesInfo() },
         "Host daemon shutdown did not end the process; forcing exit so the service manager can restart it.",
       );
-      exitProcess(0);
+      exitProcess(exitCode);
     }, graceMs);
     shutdownExitWatchdog.unref?.();
   }
 
-  function exitAfterCleanShutdown(): void {
+  function exitAfterCleanShutdown(exitCode: 0 | 1): void {
     const exitProcess = options.exitProcess;
-    if (!started || !exitProcess) {
+    if (startupFailed || !exitProcess) {
       return;
     }
     if (shutdownExitWatchdog !== null) {
       clearTimeout(shutdownExitWatchdog);
       shutdownExitWatchdog = null;
     }
-    exitProcess(0);
+    exitProcess(exitCode);
   }
 
-  async function stop(reason: string): Promise<void> {
+  async function stop(reason: string, exitCode: 0 | 1): Promise<void> {
     if (stopPromise) {
       return stopPromise;
     }
 
-    armShutdownExitWatchdog(reason);
+    armShutdownExitWatchdog(reason, exitCode);
 
     stopPromise = (async () => {
       unregisterSignalHandlers();
@@ -141,26 +142,26 @@ export function createDaemon(options: CreateDaemonOptions): HostDaemon {
       }
 
       resolveStopped?.();
-      exitAfterCleanShutdown();
+      exitAfterCleanShutdown(exitCode);
     })();
 
     return stopPromise;
   }
 
-  async function shutdown(reason = "shutdown"): Promise<void> {
-    return stop(reason);
+  async function shutdown(reason: string, exitCode: 0 | 1): Promise<void> {
+    return stop(reason, exitCode);
   }
 
   return {
     identity: options.identity,
     async start(): Promise<void> {
-      if (started) {
+      if (started || stopPromise) {
         return;
       }
 
       for (const signal of TERMINATION_SIGNALS) {
         const listener = () => {
-          void stop(signal).catch((error) => {
+          void stop(signal, 0).catch((error) => {
             options.logger.error(
               { err: error, signal },
               "Signal-triggered host daemon shutdown failed",
@@ -173,13 +174,21 @@ export function createDaemon(options: CreateDaemonOptions): HostDaemon {
 
       try {
         await options.onStart?.();
+        if (stopPromise) {
+          return;
+        }
         started = true;
         options.logger.info(
           { identity: options.identity },
           "Host daemon started",
         );
       } catch (error) {
-        await stop("startup-failed").catch(() => undefined);
+        if (stopPromise) {
+          await stop("startup-interrupted", 0).catch(() => undefined);
+          return;
+        }
+        startupFailed = true;
+        await stop("startup-failed", 1).catch(() => undefined);
         throw error;
       }
     },

--- a/apps/host-daemon/src/start-host-daemon.ts
+++ b/apps/host-daemon/src/start-host-daemon.ts
@@ -206,7 +206,7 @@ export async function startHostDaemon(
       resolveRuntimeShellEnv,
       hostWatcher,
       closeMachineAuthProxy: machineAuthProxy?.close,
-      forceExit: (code) => process.exit(code),
+      exitProcess: (code) => process.exit(code),
     });
     const startedApp = app;
     handleDaemonLockLost = () => {

--- a/apps/host-daemon/src/start-host-daemon.ts
+++ b/apps/host-daemon/src/start-host-daemon.ts
@@ -211,9 +211,8 @@ export async function startHostDaemon(
     const startedApp = app;
     handleDaemonLockLost = () => {
       void startedApp.daemon
-        .shutdown("daemon-lock-lost")
-        .catch(() => undefined)
-        .finally(() => process.exit(1));
+        .shutdown("daemon-lock-lost", 1)
+        .catch(() => process.exit(1));
     };
     await app.daemon.start();
     return app.daemon;

--- a/tests/integration/helpers/harness.ts
+++ b/tests/integration/helpers/harness.ts
@@ -452,7 +452,7 @@ export async function createIntegrationHarness(
       const mismatchedResources = daemonResources;
       daemonResources = null;
       await mismatchedResources.daemon
-        .shutdown("integration-host-id-mismatch")
+        .shutdown("integration-host-id-mismatch", 0)
         .catch(() => undefined);
       throw new Error(
         `Restarted daemon host ID ${mismatchedResources.hostId} did not match existing harness host ID ${harness.hostId}`,
@@ -476,7 +476,7 @@ export async function createIntegrationHarness(
     }
     const currentResources = daemonResources;
     daemonResources = null;
-    await currentResources.daemon.shutdown(reason);
+    await currentResources.daemon.shutdown(reason, 0);
   }
 
   async function restartDaemon(reason = "integration-restart"): Promise<void> {


### PR DESCRIPTION
## Human comments

## What was wrong

The production host daemon had no deterministic process exit after its semantic shutdown completed. It relied on every Node resource allowing the event loop to drain or on a 15-second watchdog, while the machine installer allows the temporary daemon only five seconds before sending SIGKILL. Lingering resources could therefore turn an otherwise clean shutdown into a forced kill and delay the service-manager handoff.

## What changed

After event flushing, runtime shutdown, and lock release all succeed, the production daemon now clears its watchdog and exits immediately with the caller-selected status. Normal shutdowns exit with status 0, while daemon-lock loss exits with status 1 through both clean and watchdog paths.

Startup failure is tracked separately from a shutdown requested while startup is pending. A real startup failure still reaches the entrypoint's diagnostic and failure path, while SIGINT or SIGTERM during pending startup exits promptly and cannot subsequently report the daemon as started. A cleanup step that genuinely hangs retains the existing 15-second watchdog.

This does not change the host-daemon wire contract, so HOST_DAEMON_PROTOCOL_VERSION is unchanged. There are no CLI or documentation changes.

## How you verified

- `pnpm exec turbo run test --filter=@bb/host-daemon --force`: 46 files and 568 tests passed.
- `pnpm exec turbo run test --filter=@bb/host-daemon --force -- --run src/daemon.test.ts`: 11 tests passed, including clean exit, caller-selected lock-loss status, pending-startup signal handling, hung-cleanup watchdog, and startup-failure behavior.
- `pnpm exec turbo run typecheck --filter=@bb/host-daemon --force`: passed.
- `pnpm exec turbo run build --filter=bb-app --force`: 12 tasks passed.
- Started the rebuilt `bb-app host-daemon join` against a fresh local server, waited until connected, sent SIGTERM, and measured 274 ms to exit with status 0 and no forced-kill warning.
- Direct child-process checks confirmed daemon-lock loss exits with status 1 and SIGTERM during deliberately blocked startup exits with status 0 in 140 ms despite a 60-second watchdog and an active interval.

> AGENT GENERATED
