### PR TITLE
Add app-wide plugin overlay slot

### DIFF
--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -58,6 +58,7 @@ import { AppCommandProvider } from "./components/commands/AppCommandProvider";
 import { ProviderCliInstallLogDialogHost } from "./components/provider-cli/provider-cli-install";
 import { PluginSettingsCompatibilityRoute } from "./components/settings/PluginSettingsCompatibilityRoute";
 import { RouteLoadingSkeleton } from "./components/ui/route-loading-skeleton";
+import { PluginAppOverlays } from "./components/plugin/PluginAppOverlays";
 
 const SettingsView = lazy(() =>
   import("./views/SettingsView").then((m) => ({
@@ -353,6 +354,7 @@ export function App() {
             <AppFileExternalNavigationHost>
               <HashNavigationScroll />
               <NativeShellReporter />
+              <PluginAppOverlays />
               <Routes>
                 <Route
                   path={AUTH_CALLBACK_ROUTE_PATH}

--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -58,7 +58,6 @@ import { AppCommandProvider } from "./components/commands/AppCommandProvider";
 import { ProviderCliInstallLogDialogHost } from "./components/provider-cli/provider-cli-install";
 import { PluginSettingsCompatibilityRoute } from "./components/settings/PluginSettingsCompatibilityRoute";
 import { RouteLoadingSkeleton } from "./components/ui/route-loading-skeleton";
-import { PluginAppOverlays } from "./components/plugin/PluginAppOverlays";
 
 const SettingsView = lazy(() =>
   import("./views/SettingsView").then((m) => ({
@@ -354,7 +353,6 @@ export function App() {
             <AppFileExternalNavigationHost>
               <HashNavigationScroll />
               <NativeShellReporter />
-              <PluginAppOverlays />
               <Routes>
                 <Route
                   path={AUTH_CALLBACK_ROUTE_PATH}

--- a/apps/app/src/components/layout/AppLayout.plugin-panel-header.test.tsx
+++ b/apps/app/src/components/layout/AppLayout.plugin-panel-header.test.tsx
@@ -41,6 +41,7 @@ vi.mock("@/hooks/useHostDaemon", () => ({
 
 vi.mock("@/lib/plugin-slots", () => ({
   usePluginSlots: () => ({
+    appOverlays: [],
     commandPaletteActions: [],
     fileOpeners: [],
     navPanels: [
@@ -70,8 +71,12 @@ vi.mock("@/components/project/ProjectActionsProvider", () => ({
 
 vi.mock("@/components/thread/ThreadActionsProvider", () => ({
   ThreadActionsProvider: ({ children }: { children: ReactNode }) => (
-    <>{children}</>
+    <div data-testid="thread-actions-provider">{children}</div>
   ),
+}));
+
+vi.mock("@/components/plugin/PluginAppOverlays", () => ({
+  PluginAppOverlays: () => <div data-testid="plugin-app-overlays" />,
 }));
 
 vi.mock("@/components/dialogs/ProjectPathDialog", () => ({
@@ -193,6 +198,16 @@ describe("AppLayout plugin panel header", () => {
     renderPluginPanelRoute();
 
     expect(screen.queryByTestId("app-page-header")).toBeNull();
+  });
+
+  it("mounts app overlays inside the app-level thread actions provider", () => {
+    renderPluginPanelRoute();
+
+    expect(
+      screen
+        .getByTestId("thread-actions-provider")
+        .contains(screen.getByTestId("plugin-app-overlays")),
+    ).toBe(true);
   });
 
   it("shows the fixed left trigger only while the compact right panel is closed", () => {

--- a/apps/app/src/components/layout/AppLayout.tsx
+++ b/apps/app/src/components/layout/AppLayout.tsx
@@ -58,6 +58,7 @@ import {
   PluginPanelHeaderActions,
   PluginPanelHeaderCenter,
 } from "@/components/plugin/PluginPanelHeader";
+import { PluginAppOverlays } from "@/components/plugin/PluginAppOverlays";
 import { ThreadActionsProvider } from "@/components/thread/ThreadActionsProvider";
 import {
   usePluginNavPanelChrome,
@@ -791,6 +792,7 @@ export function AppLayout({ children }: AppLayoutProps) {
               usesDesktopChrome={usesDesktopChrome}
             />
           </SidebarStateBridge>
+          <PluginAppOverlays />
           <IframeDragGuardOverlay
             active={isSidebarResizing}
             cursor="col-resize"

--- a/apps/app/src/components/plugin/PluginAppOverlays.test.tsx
+++ b/apps/app/src/components/plugin/PluginAppOverlays.test.tsx
@@ -1,0 +1,169 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { createPortal } from "react-dom";
+import { MemoryRouter, useLocation } from "react-router-dom";
+import { useState } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  resetPluginSlotStoreForTest,
+  setPluginSlotRegistrations,
+  type PluginRegistrationSet,
+} from "@/lib/plugin-slots";
+import {
+  useBbContext,
+  useBbNavigate,
+  useRpc,
+  useSettings,
+} from "@/lib/plugin-sdk-hooks";
+import { resetAllCrashedPluginSlotsForTest } from "./PluginSlotMount";
+import { PluginAppOverlays } from "./PluginAppOverlays";
+
+function registrationSet(
+  overrides: Partial<PluginRegistrationSet>,
+): PluginRegistrationSet {
+  return {
+    homepageSections: [],
+    settingsSections: [],
+    navPanels: [],
+    threadPanelActions: [],
+    sidebarFooterActions: [],
+    fileOpeners: [],
+    messageDirectives: [],
+    ...overrides,
+  };
+}
+
+function LocationProbe() {
+  return <div data-testid="location">{useLocation().pathname}</div>;
+}
+
+function PortaledProbe() {
+  const context = useBbContext();
+  const navigate = useBbNavigate();
+  const rpc = useRpc();
+  const settings = useSettings();
+  const [rpcResult, setRpcResult] = useState("idle");
+
+  return (
+    <div>
+      <div data-testid="overlay-context">
+        {context.projectId}/{context.threadId}
+      </div>
+      <div data-testid="overlay-settings">
+        {settings.isLoading ? "loading" : settings.values?.mode}
+      </div>
+      <div data-testid="overlay-rpc">{rpcResult}</div>
+      <button
+        type="button"
+        onClick={() => {
+          void rpc.call("ping").then((result) => setRpcResult(String(result)));
+        }}
+      >
+        Call RPC
+      </button>
+      <button type="button" onClick={() => navigate.toCompose()}>
+        Go home
+      </button>
+    </div>
+  );
+}
+
+function PortaledOverlay() {
+  return createPortal(<PortaledProbe />, document.body);
+}
+
+afterEach(() => {
+  cleanup();
+  resetPluginSlotStoreForTest();
+  resetAllCrashedPluginSlotsForTest();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("PluginAppOverlays", () => {
+  it("keeps plugin, query, and router contexts through a React portal", async () => {
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith("/settings")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ ok: true, values: { mode: "floating" } }),
+        };
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true, result: "pong" }),
+      };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    setPluginSlotRegistrations(
+      "office",
+      registrationSet({
+        appOverlays: [{ id: "widget", component: PortaledOverlay }],
+      }),
+    );
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={["/projects/proj_1/threads/thr_1"]}>
+          <PluginAppOverlays />
+          <LocationProbe />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByTestId("overlay-context").textContent).toBe(
+      "proj_1/thr_1",
+    );
+    expect(await screen.findByText("floating")).toBeDefined();
+    fireEvent.click(screen.getByRole("button", { name: "Call RPC" }));
+    expect(await screen.findByText("pong")).toBeDefined();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/v1/plugins/office/rpc/ping",
+      expect.objectContaining({ method: "POST" }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Go home" }));
+    expect(screen.getByTestId("location").textContent).toBe("/");
+    expect(screen.getByTestId("overlay-rpc").textContent).toBe("pong");
+  });
+
+  it("hides a crashing overlay without unmounting additive siblings", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    function Crashes(): never {
+      throw new Error("overlay crashed");
+    }
+    function Fine() {
+      return <div>fine overlay</div>;
+    }
+    setPluginSlotRegistrations(
+      "broken",
+      registrationSet({
+        appOverlays: [{ id: "broken", component: Crashes }],
+      }),
+    );
+    setPluginSlotRegistrations(
+      "fine",
+      registrationSet({
+        appOverlays: [{ id: "fine", component: Fine }],
+      }),
+    );
+
+    render(
+      <MemoryRouter>
+        <PluginAppOverlays />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("fine overlay")).toBeDefined();
+    expect(screen.queryByText("plugin broken crashed")).toBeNull();
+  });
+});

--- a/apps/app/src/components/plugin/PluginAppOverlays.test.tsx
+++ b/apps/app/src/components/plugin/PluginAppOverlays.test.tsx
@@ -6,11 +6,14 @@ import { createPortal } from "react-dom";
 import { MemoryRouter, useLocation } from "react-router-dom";
 import { useState } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { ThreadActionsProvider } from "@/components/thread/ThreadActionsProvider";
+import { RouteNavigationProvider } from "@/components/ui/app-route-anchor";
 import {
   resetPluginSlotStoreForTest,
   setPluginSlotRegistrations,
   type PluginRegistrationSet,
 } from "@/lib/plugin-slots";
+import { pluginSdkAppImplementation } from "@/lib/plugin-sdk-app-impl";
 import {
   useBbContext,
   useBbNavigate,
@@ -19,6 +22,46 @@ import {
 } from "@/lib/plugin-sdk-hooks";
 import { resetAllCrashedPluginSlotsForTest } from "./PluginSlotMount";
 import { PluginAppOverlays } from "./PluginAppOverlays";
+
+vi.mock("@/components/dialogs/ThreadDeleteDialog", () => ({
+  ThreadDeleteDialog: () => null,
+}));
+
+vi.mock("@/components/dialogs/ThreadRenameDialog", () => ({
+  ThreadRenameDialog: () => null,
+}));
+
+vi.mock("@/hooks/mutations/thread-state-mutations", () => {
+  const mutation = () => ({
+    isPending: false,
+    mutate: vi.fn(),
+    mutateAsync: vi.fn(),
+  });
+  return {
+    useArchiveThreadAndChildren: mutation,
+    useDeleteThread: mutation,
+    useMarkThreadRead: mutation,
+    useMarkThreadUnread: mutation,
+    usePinThread: mutation,
+    useUnarchiveThread: mutation,
+    useUnpinThread: mutation,
+    useUpdateThread: mutation,
+  };
+});
+
+vi.mock("@/hooks/queries/host-queries", () => ({
+  useHosts: () => ({ data: [] }),
+}));
+
+vi.mock("@/hooks/queries/sidebar-navigation-query", () => ({
+  useSidebarNavigation: () => ({
+    data: {
+      personalProject: { id: "personal", name: "Personal", threads: [] },
+      projects: [],
+    },
+    isError: false,
+  }),
+}));
 
 function registrationSet(
   overrides: Partial<PluginRegistrationSet>,
@@ -44,6 +87,8 @@ function PortaledProbe() {
   const navigate = useBbNavigate();
   const rpc = useRpc();
   const settings = useSettings();
+  const sidebarThreadActions =
+    pluginSdkAppImplementation.experimental_useSidebarThreadActions();
   const [rpcResult, setRpcResult] = useState("idle");
 
   return (
@@ -55,6 +100,9 @@ function PortaledProbe() {
         {settings.isLoading ? "loading" : settings.values?.mode}
       </div>
       <div data-testid="overlay-rpc">{rpcResult}</div>
+      <div data-testid="overlay-sidebar-actions">
+        {typeof sidebarThreadActions.openNewThread}
+      </div>
       <button
         type="button"
         onClick={() => {
@@ -83,7 +131,7 @@ afterEach(() => {
 });
 
 describe("PluginAppOverlays", () => {
-  it("keeps plugin, query, and router contexts through a React portal", async () => {
+  it("keeps sidebar thread actions available through a portal and route change", async () => {
     const fetchMock = vi.fn(async (input: string | URL | Request) => {
       const url = String(input);
       if (url.endsWith("/settings")) {
@@ -113,8 +161,12 @@ describe("PluginAppOverlays", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter initialEntries={["/projects/proj_1/threads/thr_1"]}>
-          <PluginAppOverlays />
-          <LocationProbe />
+          <RouteNavigationProvider>
+            <ThreadActionsProvider>
+              <PluginAppOverlays />
+              <LocationProbe />
+            </ThreadActionsProvider>
+          </RouteNavigationProvider>
         </MemoryRouter>
       </QueryClientProvider>,
     );
@@ -123,6 +175,9 @@ describe("PluginAppOverlays", () => {
       "proj_1/thr_1",
     );
     expect(await screen.findByText("floating")).toBeDefined();
+    expect(screen.getByTestId("overlay-sidebar-actions").textContent).toBe(
+      "function",
+    );
     fireEvent.click(screen.getByRole("button", { name: "Call RPC" }));
     expect(await screen.findByText("pong")).toBeDefined();
     expect(fetchMock).toHaveBeenCalledWith(
@@ -133,6 +188,9 @@ describe("PluginAppOverlays", () => {
     fireEvent.click(screen.getByRole("button", { name: "Go home" }));
     expect(screen.getByTestId("location").textContent).toBe("/");
     expect(screen.getByTestId("overlay-rpc").textContent).toBe("pong");
+    expect(screen.getByTestId("overlay-sidebar-actions").textContent).toBe(
+      "function",
+    );
   });
 
   it("hides a crashing overlay without unmounting additive siblings", () => {

--- a/apps/app/src/components/plugin/PluginAppOverlays.tsx
+++ b/apps/app/src/components/plugin/PluginAppOverlays.tsx
@@ -1,0 +1,26 @@
+import { usePluginSlots } from "@/lib/plugin-slots";
+import { PluginSlotMount } from "./PluginSlotMount";
+
+export function PluginAppOverlays() {
+  const { appOverlays } = usePluginSlots();
+  if (appOverlays.length === 0) return null;
+
+  return (
+    <div data-bb-plugin-app-overlays="" className="contents">
+      {appOverlays.map((slot) => {
+        const Component = slot.component;
+        return (
+          <PluginSlotMount
+            key={`${slot.pluginId}/${slot.id}/${slot.generation}`}
+            pluginId={slot.pluginId}
+            slotKind="appOverlay"
+            slotId={slot.id}
+            crashFallback={null}
+          >
+            <Component />
+          </PluginSlotMount>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/app/src/components/plugin/PluginSlotMount.test.tsx
+++ b/apps/app/src/components/plugin/PluginSlotMount.test.tsx
@@ -53,6 +53,21 @@ describe("PluginSlotMount", () => {
     expect(screen.getByText("healthy slot")).toBeDefined();
   });
 
+  it("renders nothing after a crash when the fallback is explicitly null", () => {
+    render(
+      <PluginSlotMount
+        pluginId="broken"
+        slotKind="appOverlay"
+        slotId="widget"
+        crashFallback={null}
+      >
+        <Bomb />
+      </PluginSlotMount>,
+    );
+
+    expect(screen.queryByText("plugin broken crashed")).toBeNull();
+  });
+
   it("keeps one sheet through simultaneous mounts and a portal until the final route unmount", async () => {
     vi.useFakeTimers();
     applyPluginCss("demo", "/demo.css?h=v1");

--- a/apps/app/src/components/plugin/PluginSlotMount.tsx
+++ b/apps/app/src/components/plugin/PluginSlotMount.tsx
@@ -146,10 +146,10 @@ class PluginSlotBoundary extends Component<
       this.state.crashed ||
       crashedSlotInstances.has(this.props.instanceKey)
     ) {
-      return (
-        this.props.fallback ?? (
-          <CrashedPluginChip pluginId={this.props.pluginId} />
-        )
+      return this.props.fallback === undefined ? (
+        <CrashedPluginChip pluginId={this.props.pluginId} />
+      ) : (
+        this.props.fallback
       );
     }
     return (

--- a/apps/app/src/components/tools/PluginCapabilities.tsx
+++ b/apps/app/src/components/tools/PluginCapabilities.tsx
@@ -216,6 +216,12 @@ function pluginAppSurfaceItems(
     ),
     ...namedSlotItems(
       pluginId,
+      slots.appOverlays,
+      "app-overlay",
+      "Renders app-wide floating interface content.",
+    ),
+    ...namedSlotItems(
+      pluginId,
       slots.threadLists,
       "thread-list",
       "Can replace the sidebar thread list; configured in Appearance.",

--- a/apps/app/src/lib/plugin-app-definition.test.ts
+++ b/apps/app/src/lib/plugin-app-definition.test.ts
@@ -26,6 +26,47 @@ describe("definePluginApp", () => {
   });
 });
 
+describe("collectPluginAppRegistrations — experimental_appOverlay", () => {
+  it("collects additive app overlays", () => {
+    const definition = definePluginApp((app) => {
+      app.slots.experimental_appOverlay({
+        id: "office",
+        component: Component,
+      });
+    });
+
+    expect(collectPluginAppRegistrations(definition).appOverlays).toEqual([
+      { id: "office", component: Component },
+    ]);
+  });
+
+  it("rejects duplicate ids and malformed components", () => {
+    const duplicate = definePluginApp((app) => {
+      app.slots.experimental_appOverlay({
+        id: "office",
+        component: Component,
+      });
+      app.slots.experimental_appOverlay({
+        id: "office",
+        component: Component,
+      });
+    });
+    const malformed = definePluginApp((app) => {
+      app.slots.experimental_appOverlay({
+        id: "office",
+        component: null as never,
+      });
+    });
+
+    expect(() => collectPluginAppRegistrations(duplicate)).toThrow(
+      'duplicate id "office"',
+    );
+    expect(() => collectPluginAppRegistrations(malformed)).toThrow(
+      '"component" must be a React component function',
+    );
+  });
+});
+
 describe("collectPluginAppRegistrations — experimental_threadHeaderAction", () => {
   it("collects a header action", () => {
     const definition = definePluginApp((app) => {
@@ -170,6 +211,10 @@ describe("collectPluginAppRegistrations", () => {
         description: "Configure it.",
         component: Component,
       });
+      app.slots.experimental_appOverlay({
+        id: "overlay",
+        component: Component,
+      });
       app.slots.navPanel({
         id: "panel",
         title: "Panel",
@@ -270,6 +315,10 @@ describe("collectPluginAppRegistrations", () => {
         title: "Custom settings",
         component: Component,
       });
+      app.slots.experimental_appOverlay({
+        id: "floating-widget",
+        component: Component,
+      });
       app.slots.navPanel({
         id: "board",
         title: "Board",
@@ -335,6 +384,9 @@ describe("collectPluginAppRegistrations", () => {
         title: "Custom settings",
         component: Component,
       },
+    ]);
+    expect(registrations.appOverlays).toEqual([
+      { id: "floating-widget", component: Component },
     ]);
     expect(registrations.navPanels).toEqual([
       {

--- a/apps/app/src/lib/plugin-slots.ts
+++ b/apps/app/src/lib/plugin-slots.ts
@@ -1,6 +1,7 @@
 import { useSyncExternalStore } from "react";
 import type {
   ComposerCustomization,
+  ExperimentalAppOverlayRegistration,
   PluginDiffRendererRegistration,
   PluginPendingInteractionRegistration,
   PluginFileOpenerRegistration,
@@ -24,6 +25,7 @@ import type {
 export interface PluginRegistrationSet {
   homepageSections: readonly PluginHomepageSectionRegistration[];
   settingsSections: readonly PluginSettingsSectionRegistration[];
+  appOverlays?: readonly ExperimentalAppOverlayRegistration[];
   navPanels: readonly PluginNavPanelRegistration[];
   threadPanelActions: readonly PluginThreadPanelActionRegistration[];
   newThreadPanelActions?: readonly PluginNewThreadPanelActionRegistration[];
@@ -52,6 +54,8 @@ export interface PluginHomepageSectionSlot
   extends PluginHomepageSectionRegistration, PluginSlotBase {}
 export interface PluginSettingsSectionSlot
   extends PluginSettingsSectionRegistration, PluginSlotBase {}
+export interface ExperimentalAppOverlaySlot
+  extends ExperimentalAppOverlayRegistration, PluginSlotBase {}
 export interface PluginNavPanelSlot
   extends PluginNavPanelRegistration, PluginSlotBase {}
 export interface PluginThreadPanelActionSlot
@@ -90,6 +94,7 @@ export interface PluginTimelineRendererSlot
 export interface PluginSlotSnapshot {
   homepageSections: readonly PluginHomepageSectionSlot[];
   settingsSections: readonly PluginSettingsSectionSlot[];
+  appOverlays: readonly ExperimentalAppOverlaySlot[];
   navPanels: readonly PluginNavPanelSlot[];
   threadPanelActions: readonly PluginThreadPanelActionSlot[];
   newThreadPanelActions: readonly PluginNewThreadPanelActionSlot[];
@@ -112,6 +117,7 @@ export interface PluginSlotSnapshot {
 export const EMPTY_PLUGIN_SLOT_SNAPSHOT: PluginSlotSnapshot = {
   homepageSections: [],
   settingsSections: [],
+  appOverlays: [],
   navPanels: [],
   threadPanelActions: [],
   newThreadPanelActions: [],
@@ -141,6 +147,7 @@ type SlotKind = keyof PluginSlotSnapshot;
 const SLOT_KINDS: readonly SlotKind[] = [
   "homepageSections",
   "settingsSections",
+  "appOverlays",
   "navPanels",
   "threadPanelActions",
   "newThreadPanelActions",
@@ -182,6 +189,7 @@ function flattenRegistrations(
   return {
     homepageSections: stamp(set.homepageSections),
     settingsSections: stamp(set.settingsSections),
+    appOverlays: stamp(set.appOverlays),
     navPanels: stamp(set.navPanels),
     threadPanelActions: stamp(set.threadPanelActions),
     newThreadPanelActions: stamp(set.newThreadPanelActions),

--- a/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/references/frontend-api-index.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/references/frontend-api-index.md
@@ -37,6 +37,7 @@ Read the installed SDK declarations for the exact current signatures.
 
 - `PluginHomepageSectionProps`
 - `PluginSettingsSectionProps`
+- `ExperimentalAppOverlayProps`
 - `PluginNavPanelProps`
 - `PluginThreadPanelProps`
 - `PluginNewThreadPanelProps`
@@ -67,6 +68,7 @@ Read the installed SDK declarations for the exact current signatures.
 - `PluginMessageDirectiveProps`
 - `PluginHomepageSectionRegistration`
 - `PluginSettingsSectionRegistration`
+- `ExperimentalAppOverlayRegistration`
 - `ExperimentalFixedTabTargetContract`
 - `ExperimentalPluginFixedTabReference`
 - `PluginFixedTabRegistration`

--- a/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/references/frontend-core-slots.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/references/frontend-core-slots.md
@@ -72,6 +72,16 @@ Slot props contracts (versioned, additive-only):
   for data. Enabled plugins appear in the
   settings sidebar when they declare settings descriptors OR register
   settings sections.
+- `experimental_appOverlay` → `{}` (deliberately no props). An additive,
+  app-wide React owner for floating plugin UI. Registration:
+  `{ id, component }`. BB mounts every registration once per app window
+  through `PluginSlotMount`, outside route-owned layout regions. The component
+  can therefore call app-level SDK hooks and keep their React contexts through
+  a portal. BB supplies no chrome, positioning, visibility, focus, or
+  responsive behavior; render fixed UI directly or use the vendored responsive
+  overlay primitives. A crash hides only that overlay. Use a content script
+  instead for DOM enhancement that does not need React context. Experimental:
+  see `docs/api_to_audit.md`.
 - `navPanel` → `{ subPath: string }` — owns the whole route at
   `/plugins/<pluginId>/<path>/*` and gets its own sidebar entry. `subPath`
   is the route remainder after the panel root (`""` at the root), so deep

--- a/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/references/frontend-core-slots.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/references/frontend-core-slots.md
@@ -76,12 +76,14 @@ Slot props contracts (versioned, additive-only):
   app-wide React owner for floating plugin UI. Registration:
   `{ id, component }`. BB mounts every registration once per app window
   through `PluginSlotMount`, outside route-owned layout regions. The component
-  can therefore call app-level SDK hooks and keep their React contexts through
-  a portal. BB supplies no chrome, positioning, visibility, focus, or
-  responsive behavior; render fixed UI directly or use the vendored responsive
-  overlay primitives. A crash hides only that overlay. Use a content script
-  instead for DOM enhancement that does not need React context. Experimental:
-  see `docs/api_to_audit.md`.
+  can therefore call app-level SDK hooks, including the sidebar thread data and
+  action hooks, and keep their React contexts through a portal. Hooks whose
+  contract requires a particular surface, including `useComposer` and
+  `useComposerView`, remain limited to that surface. BB supplies no chrome,
+  positioning, visibility, focus, or responsive behavior; render fixed UI
+  directly or use the vendored responsive overlay primitives. A crash hides
+  only that overlay. Use a content script instead for DOM enhancement that does
+  not need React context. Experimental: see `docs/api_to_audit.md`.
 - `navPanel` → `{ subPath: string }` — owns the whole route at
   `/plugins/<pluginId>/<path>/*` and gets its own sidebar entry. `subPath`
   is the route remainder after the panel root (`""` at the root), so deep

--- a/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/references/frontend-registration.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/references/frontend-registration.md
@@ -46,6 +46,10 @@ export default definePluginApp((app) => {
     description: "Configure the remote service used by this plugin.",
     component: SettingsSection,
   });
+  app.slots.experimental_appOverlay({
+    id: "floating-status",
+    component: FloatingStatus,
+  });
   app.slots.navPanel({
     id: "board",
     title: "Board",

--- a/apps/server/test/services/plugins/plugin-authoring-docs.test.ts
+++ b/apps/server/test/services/plugins/plugin-authoring-docs.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import * as pluginSdkApp from "@get-bb/plugin-sdk/app";
 import {
   type BbPluginApi,
+  type ExperimentalAppOverlayProps,
   type PluginAppBuilder,
   type PluginAppSlots,
   type PluginContentScriptContext,
@@ -241,6 +242,7 @@ void _assertAllThreadEventFieldsListed;
 type SlotPropsByName = {
   homepageSection: PluginHomepageSectionProps;
   settingsSection: PluginSettingsSectionProps;
+  experimental_appOverlay: ExperimentalAppOverlayProps;
   navPanel: PluginNavPanelProps;
   threadPanelAction: PluginThreadPanelProps;
   experimental_newThreadPanelAction: PluginNewThreadPanelProps;
@@ -311,6 +313,7 @@ void _assertAllContentScriptRegistrationFieldsListed;
 const FRONTEND_SLOT_PROP_FIELDS = {
   homepageSection: ["projectId"],
   settingsSection: [],
+  experimental_appOverlay: [],
   navPanel: ["subPath"],
   threadPanelAction: ["threadId", "params"],
   experimental_newThreadPanelAction: ["projectId", "params"],

--- a/docs/api_to_audit.md
+++ b/docs/api_to_audit.md
@@ -1694,6 +1694,40 @@ Implementation: the shared workflow is
    stabilizing, confirm unconditional project switching is right for embedded
    plugin workflows, rather than adding an explicit project-locking policy.
 
+## `app.slots.experimental_appOverlay` (`@get-bb/plugin-sdk/app`)
+
+**What it does.** Mounts an additive plugin React component once per BB app
+window, outside route-owned layout regions and inside `PluginSlotMount`. The
+component receives no props and owns its chrome, positioning, visibility,
+focus, and responsive behavior. It can call app-level SDK hooks and either
+render fixed UI directly or create a React portal without losing plugin,
+router, query, realtime, or sidebar context. One overlay crash hides only that
+registration; sibling overlays remain mounted.
+
+**Audit before stabilizing.**
+
+1. **Name and boundary.** Confirm "app overlay" is broad enough for floating
+   widgets, launchers, and transient app-wide UI without inviting plugins to
+   replace host-owned navigation or layout.
+2. **App-level versus pane-level context.** Define the selected route in split
+   layouts and document which pane-local capabilities remain unavailable to a
+   once-per-window owner, including composer and side-panel hosts.
+3. **Host-owned layer.** Decide whether arbitrary fixed/portalled content is
+   sufficient or BB should provide a named overlay root, z-index band,
+   collision area, docking, or drag persistence.
+4. **Responsive and accessibility policy.** Audit keyboard access, focus
+   restoration, escape behavior, compact drawers, reduced motion, and whether
+   any of those must become host-owned rather than plugin-owned.
+5. **Multiplicity and budgets.** Registrations are additive with no cap.
+   Measure startup, query fan-out, visual collisions, and several plugins
+   mounting persistent widgets in one window.
+6. **Lifecycle.** Verify exact once-per-window mounting across route changes,
+   split changes, frontend reload, disable, uninstall, app teardown, and
+   multiple desktop windows or browser tabs.
+7. **Crash and stylesheet lifetime.** Confirm a hidden crash fallback and the
+   standard slot-owned CSS retention are the right failure semantics for UI
+   that may have no in-layout representation.
+
 ## `app.slots.experimental_newThreadPanelAction` (`@get-bb/plugin-sdk/app`)
 
 **Kept experimental (2026-08-22).** zero consumers; item 5 (merging with `threadPanelAction`) is explicitly deferred until an external plugin adopts it.

--- a/docs/api_to_audit.md
+++ b/docs/api_to_audit.md
@@ -1701,8 +1701,10 @@ window, outside route-owned layout regions and inside `PluginSlotMount`. The
 component receives no props and owns its chrome, positioning, visibility,
 focus, and responsive behavior. It can call app-level SDK hooks and either
 render fixed UI directly or create a React portal without losing plugin,
-router, query, realtime, or sidebar context. One overlay crash hides only that
-registration; sibling overlays remain mounted.
+router, query, realtime, or sidebar thread/action context. Hooks whose contract
+requires a particular surface, including `useComposer` and `useComposerView`,
+remain limited to that surface. One overlay crash hides only that registration;
+sibling overlays remain mounted.
 
 **Audit before stabilizing.**
 

--- a/packages/domain/src/plugin-sdk-version.ts
+++ b/packages/domain/src/plugin-sdk-version.ts
@@ -1,3 +1,3 @@
-export const PLUGIN_SDK_VERSION = "0.4.38";
+export const PLUGIN_SDK_VERSION = "0.4.39";
 
 export const PLUGIN_SDK_MAJOR = Number(PLUGIN_SDK_VERSION.split(".", 1)[0]);

--- a/packages/plugin-api-map/sdk-public-api.json
+++ b/packages/plugin-api-map/sdk-public-api.json
@@ -3,7 +3,7 @@
   "entries": {
     ".": {
       "types": "bundled-types/bb-plugin-sdk.d.ts",
-      "sha256": "86776afcbde4eff1b7837b1a2a16894fc9c7e44145db6682e1327617055f2e60"
+      "sha256": "36c9cb3cac54b5dce8fa8294a4a53d31c05f2e4078d470280cb284abb7036e85"
     },
     "./ai-services": {
       "types": "bundled-types/bb-plugin-sdk-ai-services.d.ts",
@@ -11,7 +11,7 @@
     },
     "./app": {
       "types": "bundled-types/bb-plugin-sdk-app.d.ts",
-      "sha256": "6df302f5ba182bb44bafe5498253652165550d85941baa28b2ecafdf779c104c"
+      "sha256": "d8b17e4c887af101bfc0d50d37f48b6bb0cad11f86a6b2431d172fbe91d700e2"
     },
     "./host": {
       "types": "bundled-types/bb-plugin-sdk-host.d.ts",
@@ -35,7 +35,7 @@
     },
     "./testing/app": {
       "types": "bundled-types/bb-plugin-sdk-testing-app.d.ts",
-      "sha256": "5e9d3cc86c2b186ae0e7b067c9a02af4e52650bbe2c0904ff16cbf0bc350d87b"
+      "sha256": "4ebaad4c3ca379e0c233d5e6a9951ab966db94d9db27ca8008690b8dce002f52"
     },
     "./testing/host": {
       "types": "bundled-types/bb-plugin-sdk-testing-host.d.ts",

--- a/packages/plugin-api-map/src/anatomy-manifest.json
+++ b/packages/plugin-api-map/src/anatomy-manifest.json
@@ -103,6 +103,41 @@
           ]
         }
       ]
+    },
+    "app-overlay": {
+      "groupId": "app-shell",
+      "fidelity": "anchor",
+      "responsiveStrategy": "scale-together",
+      "requiredStates": ["anchor"],
+      "labels": {
+        "anchor": ["Office widget", "2 agents active"]
+      },
+      "fixtureClassAnchors": [
+        "absolute bottom-24 right-12",
+        "bg-popover",
+        "shadow-md"
+      ],
+      "sources": [
+        {
+          "path": "apps/app/src/components/plugin/PluginAppOverlays.tsx",
+          "anchors": [
+            "data-bb-plugin-app-overlays=\"\"",
+            "slotKind=\"appOverlay\"",
+            "crashFallback={null}"
+          ]
+        },
+        {
+          "path": "apps/app/src/App.tsx",
+          "anchors": ["<PluginAppOverlays />"]
+        },
+        {
+          "path": "apps/app/src/components/plugin/PluginAppOverlays.test.tsx",
+          "anchors": [
+            "keeps plugin, query, and router contexts through a React portal",
+            "hides a crashing overlay without unmounting additive siblings"
+          ]
+        }
+      ]
     }
   }
 }

--- a/packages/plugin-api-map/src/anatomy-manifest.json
+++ b/packages/plugin-api-map/src/anatomy-manifest.json
@@ -110,7 +110,7 @@
       "responsiveStrategy": "scale-together",
       "requiredStates": ["anchor"],
       "labels": {
-        "anchor": ["Office widget", "2 agents active"]
+        "anchor": ["Floating widget", "2 agents active"]
       },
       "fixtureClassAnchors": [
         "absolute bottom-24 right-12",

--- a/packages/plugin-api-map/src/anatomy-manifest.json
+++ b/packages/plugin-api-map/src/anatomy-manifest.json
@@ -127,13 +127,13 @@
           ]
         },
         {
-          "path": "apps/app/src/App.tsx",
+          "path": "apps/app/src/components/layout/AppLayout.tsx",
           "anchors": ["<PluginAppOverlays />"]
         },
         {
           "path": "apps/app/src/components/plugin/PluginAppOverlays.test.tsx",
           "anchors": [
-            "keeps plugin, query, and router contexts through a React portal",
+            "keeps sidebar thread actions available through a portal and route change",
             "hides a crashing overlay without unmounting additive siblings"
           ]
         }

--- a/packages/plugin-api-map/src/surfaces.ts
+++ b/packages/plugin-api-map/src/surfaces.ts
@@ -195,6 +195,23 @@ export const SURFACE_GROUPS: SurfaceGroup[] = [
         firstParty: ["Ask User Question", "Secrets"],
       },
       {
+        id: "app-overlay",
+        title: "App-wide overlays",
+        summary:
+          "Mounts floating plugin UI across the bb app, outside route-owned layout regions. With this, a plugin can:",
+        bullets: [
+          "Render a persistent widget once per bb window while the plugin is enabled",
+          "Use app-level SDK hooks and preserve their React context through portals",
+          "Own the widget's chrome, position, visibility, and responsive behavior",
+          "Coexist with other overlays while crashes remain isolated to the overlay that failed",
+        ],
+        apiSymbols: [
+          "ExperimentalAppOverlayRegistration",
+          "ExperimentalAppOverlayProps",
+        ],
+        experimental: true,
+      },
+      {
         id: "code-renderers",
         title: "Code & diff renderers",
         summary:

--- a/packages/plugin-api-map/src/surfaces.ts
+++ b/packages/plugin-api-map/src/surfaces.ts
@@ -195,23 +195,6 @@ export const SURFACE_GROUPS: SurfaceGroup[] = [
         firstParty: ["Ask User Question", "Secrets"],
       },
       {
-        id: "app-overlay",
-        title: "App-wide overlays",
-        summary:
-          "Mounts floating plugin UI across the bb app, outside route-owned layout regions. With this, a plugin can:",
-        bullets: [
-          "Render a persistent widget once per bb window while the plugin is enabled",
-          "Use app-level SDK hooks and preserve their React context through portals",
-          "Own the widget's chrome, position, visibility, and responsive behavior",
-          "Coexist with other overlays while crashes remain isolated to the overlay that failed",
-        ],
-        apiSymbols: [
-          "ExperimentalAppOverlayRegistration",
-          "ExperimentalAppOverlayProps",
-        ],
-        experimental: true,
-      },
-      {
         id: "code-renderers",
         title: "Code & diff renderers",
         summary:
@@ -253,6 +236,23 @@ export const SURFACE_GROUPS: SurfaceGroup[] = [
         ],
         apiSymbols: ["PluginFileOpenerRegistration"],
         firstParty: ["Docs"],
+      },
+      {
+        id: "app-overlay",
+        title: "App-wide overlays",
+        summary:
+          "Mounts floating plugin UI across the bb app, outside route-owned layout regions. With this, a plugin can:",
+        bullets: [
+          "Render a persistent widget once per bb window while the plugin is enabled",
+          "Use app-level SDK hooks and preserve their React context through portals",
+          "Own the widget's chrome, position, visibility, and responsive behavior",
+          "Coexist with other overlays while crashes remain isolated to the overlay that failed",
+        ],
+        apiSymbols: [
+          "ExperimentalAppOverlayRegistration",
+          "ExperimentalAppOverlayProps",
+        ],
+        experimental: true,
       },
       {
         id: "content-scripts",

--- a/packages/plugin-api-map/src/wireframes.tsx
+++ b/packages/plugin-api-map/src/wireframes.tsx
@@ -1178,7 +1178,7 @@ function AppShellWireframeBody({
       >
         <PluginGlyph className="size-4 shrink-0" />
         <span className="min-w-0">
-          <span className="block truncate font-medium">Office widget</span>
+          <span className="block truncate font-medium">Floating widget</span>
           <span className="block truncate text-2xs text-subtle-foreground">
             2 agents active
           </span>

--- a/packages/plugin-api-map/src/wireframes.tsx
+++ b/packages/plugin-api-map/src/wireframes.tsx
@@ -80,10 +80,10 @@ export const APP_SHELL_MARKS = [
   "message-directives",
   "message-actions",
   "pending-interaction",
-  "app-overlay",
   "code-renderers",
   "thread-panel",
   "file-opener",
+  "app-overlay",
   "content-scripts",
 ] as const;
 

--- a/packages/plugin-api-map/src/wireframes.tsx
+++ b/packages/plugin-api-map/src/wireframes.tsx
@@ -80,6 +80,7 @@ export const APP_SHELL_MARKS = [
   "message-directives",
   "message-actions",
   "pending-interaction",
+  "app-overlay",
   "code-renderers",
   "thread-panel",
   "file-opener",
@@ -1169,6 +1170,20 @@ function AppShellWireframeBody({
           onTabSelect={onRightPanelTabSelect}
         />
       </div>
+
+      <Mark
+        id="app-overlay"
+        label="App-wide floating plugin interface"
+        className="absolute bottom-24 right-12 z-[6] flex w-44 items-center gap-2 border border-border bg-popover px-3 py-2 text-foreground shadow-md"
+      >
+        <PluginGlyph className="size-4 shrink-0" />
+        <span className="min-w-0">
+          <span className="block truncate font-medium">Office widget</span>
+          <span className="block truncate text-2xs text-subtle-foreground">
+            2 agents active
+          </span>
+        </span>
+      </Mark>
     </WindowFrame>
   );
 }

--- a/packages/plugin-api-map/test/surfaces.test.ts
+++ b/packages/plugin-api-map/test/surfaces.test.ts
@@ -38,6 +38,7 @@ describe("product-map surfaces", () => {
       "message-directives",
       "message-actions",
       "pending-interaction",
+      "app-overlay",
       "code-renderers",
       "thread-panel",
       "file-opener",

--- a/packages/plugin-api-map/test/surfaces.test.ts
+++ b/packages/plugin-api-map/test/surfaces.test.ts
@@ -38,10 +38,10 @@ describe("product-map surfaces", () => {
       "message-directives",
       "message-actions",
       "pending-interaction",
-      "app-overlay",
       "code-renderers",
       "thread-panel",
       "file-opener",
+      "app-overlay",
       "content-scripts",
     ];
     expect(surfaceIds("app-shell")).toEqual(ordered);

--- a/packages/plugin-api-map/test/wireframes.test.ts
+++ b/packages/plugin-api-map/test/wireframes.test.ts
@@ -244,6 +244,25 @@ describe("guide fixture boundaries", () => {
     );
   });
 
+  it("shows the app-wide plugin overlay above the host layout", () => {
+    const markup = renderWireframe(createElement(AppShellWireframe));
+    const contract = anatomy.surfaceFixtures["app-overlay"];
+
+    expect(contract.requiredStates).toEqual(["anchor"]);
+    for (const label of contract.labels.anchor) {
+      expect(markup).toContain(label);
+    }
+    for (const classAnchor of contract.fixtureClassAnchors) {
+      expect(markup, `missing fixture class ${classAnchor}`).toContain(
+        classAnchor,
+      );
+    }
+    expect(markup).toMatch(
+      /data-guide-region="app-overlay"[^>]*class="[^"]*absolute[^"]*z-\[6\][^"]*shadow-md/,
+    );
+    expect(markup.match(/data-guide-badge="app-overlay"/g)).toHaveLength(1);
+  });
+
   it("shows the complete sidebar navigation replacement boundary", () => {
     const markup = renderWireframe(createElement(AppShellWireframe));
     const contract = anatomy.surfaceFixtures["sidebar-navigation"];

--- a/packages/plugin-sdk/README.md
+++ b/packages/plugin-sdk/README.md
@@ -68,10 +68,12 @@ open routine and branch on the result.
 Use `app.slots.experimental_appOverlay({ id, component })` for additive,
 app-wide floating React UI. BB mounts the component once per app window through
 the normal plugin slot boundary, so SDK hooks and plugin CSS work and React
-context survives portals. The plugin owns the overlay's chrome, positioning,
-visibility, focus, and responsive behavior; a crashing overlay is hidden
-without affecting siblings. Use a content script for app-wide DOM behavior
-that does not need React context.
+context survives portals. This app-level boundary includes the sidebar thread
+data and action hooks. Hooks whose contract requires a particular surface,
+including `useComposer` and `useComposerView`, remain limited to that surface.
+The plugin owns the overlay's chrome, positioning, visibility, focus, and
+responsive behavior; a crashing overlay is hidden without affecting siblings.
+Use a content script for app-wide DOM behavior that does not need React context.
 
 See the
 [`composer-customization` reference plugin](../../examples/plugins/composer-customization/README.md)

--- a/packages/plugin-sdk/README.md
+++ b/packages/plugin-sdk/README.md
@@ -65,6 +65,14 @@ action id, or a surface with no side panel). A decline is a return value, never
 a thrown error, so a plugin registering several kinds of action can share one
 open routine and branch on the result.
 
+Use `app.slots.experimental_appOverlay({ id, component })` for additive,
+app-wide floating React UI. BB mounts the component once per app window through
+the normal plugin slot boundary, so SDK hooks and plugin CSS work and React
+context survives portals. The plugin owns the overlay's chrome, positioning,
+visibility, focus, and responsive behavior; a crashing overlay is hidden
+without affecting siblings. Use a content script for app-wide DOM behavior
+that does not need React context.
+
 See the
 [`composer-customization` reference plugin](../../examples/plugins/composer-customization/README.md)
 for every region in one small app. The deprecated pre-1.0

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@get-bb/plugin-sdk",
-  "version": "0.4.38",
+  "version": "0.4.39",
   "homepage": "https://github.com/get-bb/bb#readme",
   "bugs": {
     "url": "https://github.com/get-bb/bb/issues"

--- a/packages/plugin-sdk/src/app-contract.ts
+++ b/packages/plugin-sdk/src/app-contract.ts
@@ -43,6 +43,14 @@ export interface PluginHomepageSectionProps {
  */
 export interface PluginSettingsSectionProps {}
 
+/**
+ * Props passed to an `experimental_appOverlay` component.
+ *
+ * Deliberately empty while the component reads live app state through SDK
+ * hooks; versioned additive like the other slot props.
+ */
+export interface ExperimentalAppOverlayProps {}
+
 /** Props passed to a `navPanel` component (it owns its whole route). */
 export interface PluginNavPanelProps {
   /**
@@ -439,6 +447,22 @@ export interface PluginSettingsSectionRegistration {
    */
   description?: string;
   component: ComponentType<PluginSettingsSectionProps>;
+}
+
+/**
+ * Render app-wide plugin UI outside BB's layout regions.
+ *
+ * The host mounts each registration once per app window through the ordinary
+ * plugin React boundary. The component therefore keeps PluginContext, router,
+ * query, realtime, and other app-level SDK contexts when it renders fixed UI
+ * or creates a React portal. BB supplies no chrome, positioning, visibility,
+ * or interaction policy; the plugin owns those details and responsive
+ * behavior. Registrations are additive and a crash hides only that overlay.
+ */
+export interface ExperimentalAppOverlayRegistration {
+  /** Unique within the plugin; letters, digits, `-`, `_`. */
+  id: string;
+  component: ComponentType<ExperimentalAppOverlayProps>;
 }
 
 /**
@@ -1326,6 +1350,14 @@ export interface PluginTimelineRendererRegistration {
 export interface PluginAppSlots {
   homepageSection(registration: PluginHomepageSectionRegistration): void;
   settingsSection(registration: PluginSettingsSectionRegistration): void;
+  /**
+   * Render one app-wide overlay component (see
+   * {@link ExperimentalAppOverlayRegistration}). Experimental: see
+   * docs/api_to_audit.md.
+   */
+  experimental_appOverlay(
+    registration: ExperimentalAppOverlayRegistration,
+  ): void;
   navPanel(registration: PluginNavPanelRegistration): void;
   /**
    * Add an action to an existing thread's panel launcher. This slot is

--- a/packages/plugin-sdk/src/internal/plugin-app-collector.ts
+++ b/packages/plugin-sdk/src/internal/plugin-app-collector.ts
@@ -1,5 +1,6 @@
 import type {
   ComposerCustomization,
+  ExperimentalAppOverlayRegistration,
   PluginAppDefinition,
   PluginContentScriptRegistration,
   PluginDiffRendererRegistration,
@@ -86,6 +87,7 @@ function rejectStaleNavPanelKeys(kind: string, registration: object): void {
 export interface CollectedPluginAppRegistrations {
   homepageSections: PluginHomepageSectionRegistration[];
   settingsSections: PluginSettingsSectionRegistration[];
+  appOverlays: ExperimentalAppOverlayRegistration[];
   navPanels: PluginNavPanelRegistration[];
   threadPanelActions: PluginThreadPanelActionRegistration[];
   newThreadPanelActions: PluginNewThreadPanelActionRegistration[];
@@ -120,6 +122,7 @@ export function collectPluginAppRegistrations(
   const collected: CollectedPluginAppRegistrations = {
     homepageSections: [],
     settingsSections: [],
+    appOverlays: [],
     navPanels: [],
     threadPanelActions: [],
     newThreadPanelActions: [],
@@ -142,6 +145,7 @@ export function collectPluginAppRegistrations(
   const seenIds = {
     homepageSection: new Set<string>(),
     settingsSection: new Set<string>(),
+    appOverlay: new Set<string>(),
     navPanel: new Set<string>(),
     threadPanelAction: new Set<string>(),
     newThreadPanelAction: new Set<string>(),
@@ -188,6 +192,15 @@ export function collectPluginAppRegistrations(
           id,
           ...(title !== undefined ? { title } : {}),
           ...(description !== undefined ? { description } : {}),
+          component: requireComponent(kind, registration.component),
+        });
+      },
+      experimental_appOverlay(registration) {
+        const kind = "slots.experimental_appOverlay";
+        const id = requireSlotId(kind, registration?.id);
+        requireUniqueId(kind, seenIds.appOverlay, id);
+        collected.appOverlays.push({
+          id,
           component: requireComponent(kind, registration.component),
         });
       },

--- a/packages/plugin-sdk/src/testing/__tests__/app-harness.test.tsx
+++ b/packages/plugin-sdk/src/testing/__tests__/app-harness.test.tsx
@@ -462,6 +462,38 @@ const app = await loadPluginApp(
 );
 
 describe("loadPluginApp", () => {
+  it("captures and validates app overlay registrations", async () => {
+    function Overlay() {
+      return <div>overlay</div>;
+    }
+    const captured = await loadPluginApp(
+      definePluginApp((builder) => {
+        builder.slots.experimental_appOverlay({
+          id: "office",
+          component: Overlay,
+        });
+      }),
+    );
+
+    expect(captured.appOverlays).toEqual([
+      { id: "office", component: Overlay },
+    ]);
+    await expect(
+      loadPluginApp(
+        definePluginApp((builder) => {
+          builder.slots.experimental_appOverlay({
+            id: "office",
+            component: Overlay,
+          });
+          builder.slots.experimental_appOverlay({
+            id: "office",
+            component: Overlay,
+          });
+        }),
+      ),
+    ).rejects.toThrow('slots.experimental_appOverlay: duplicate id "office"');
+  });
+
   it("captures and validates sidebar navigation registrations", async () => {
     const captured = await loadPluginApp(
       definePluginApp((builder) => {

--- a/packages/plugin-sdk/src/testing/app.tsx
+++ b/packages/plugin-sdk/src/testing/app.tsx
@@ -17,6 +17,7 @@ import {
   type BbNavigate,
   type ComposerCustomization,
   type ComposerView,
+  type ExperimentalAppOverlayRegistration,
   type PluginAppDefinition,
   type PluginAppSetup,
   type PluginCodeThemeState,
@@ -895,6 +896,7 @@ export function installTestPluginRuntime(): void {
 export interface CapturedPluginApp {
   homepageSections: PluginHomepageSectionRegistration[];
   settingsSections: PluginSettingsSectionRegistration[];
+  appOverlays: ExperimentalAppOverlayRegistration[];
   navPanels: PluginNavPanelRegistration[];
   threadPanelActions: PluginThreadPanelActionRegistration[];
   newThreadPanelActions: PluginNewThreadPanelActionRegistration[];


### PR DESCRIPTION
## Human comments

## What was wrong

Plugins had no additive React surface for persistent app-wide floating UI. A content script can create a separate React root, but that root sits outside the BB plugin, router, query, and sidebar provider tree, forcing plugins to reproduce RPC, realtime, settings, and route access. Portaling from an unrelated host slot preserves React context, but using the exclusive thread-list replacement for an overlay prevents legitimate sidebar replacements from coexisting.

## What changed

Added the experimental app.slots.experimental_appOverlay registration and app-level host mount. Overlays are additive, mount through PluginSlotMount beneath the existing app providers, retain SDK hooks and route state through React portals, preserve plugin stylesheet lifetime, and isolate crashes to the failing overlay. Added collector and frontend test-harness support, SDK declarations and examples, the experimental API audit entry, Plugin Guide inventory/card/wireframe coverage, and authoring documentation. Bumped the plugin SDK contract from 0.4.38 to 0.4.39 so plugins can require a host that provides the new surface. This is app-local frontend and SDK behavior, so HOST_DAEMON_PROTOCOL_VERSION is unchanged.

## How you verified

- Added tests for registration validation and duplicate IDs, app definition transport, plugin/router/query context through a document-body portal, RPC/settings/navigation behavior, additive sibling crash isolation, and portal stylesheet lifetime.
- Ran node .github/workflows/check-plugin-sdk-version.mjs.
- Ran pnpm exec turbo run build:types --filter=@get-bb/plugin-sdk.
- Ran pnpm exec turbo run update:sdk-inventory --filter=@bb/plugin-api-map and confirmed the committed inventory is stable.
- Ran pnpm exec turbo run test typecheck --filter=@get-bb/plugin-sdk --filter=@bb/domain --filter=@bb/plugin-api-map --filter=@bb/app --filter=bb-plugin-plugin-api-docs: 13 tasks passed; the app suite reported 471 files and 3,776 passing tests.
- Ran bb plugin build plugins/plugin-api-docs.
- Exercised the overlay in an isolated headless Doobie browser profile; the system Chrome session was not used.

> AGENT GENERATED