### PR TITLE
Ship a host-only artifact for enrolled machines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ out
 /build
 /apps/app/build/
 /packages/bb-app/host-daemon/
+/packages/bb-app/host-package/
 /apps/desktop/release/
 /apps/desktop/.electron-builder.generated.json
 

--- a/apps/host-daemon/src/protocol-self-update.test.ts
+++ b/apps/host-daemon/src/protocol-self-update.test.ts
@@ -1,4 +1,5 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { delimiter, dirname, join } from "node:path";
 import { HOST_DAEMON_PROTOCOL_VERSION } from "@bb/host-daemon-contract";
@@ -61,7 +62,14 @@ async function createFixture(
     now: args.now,
     serverUrl: args.serverUrl ?? "https://server.example.test",
   });
-  return { fetchFn, installTarball, logger: testLogger, runProcess, updater };
+  return {
+    dataDir,
+    fetchFn,
+    installTarball,
+    logger: testLogger,
+    runProcess,
+    updater,
+  };
 }
 
 afterEach(async () => {
@@ -79,6 +87,85 @@ describe("protocol self-update", () => {
     );
     expect(test.fetchFn).toHaveBeenCalledTimes(2);
     expect(test.installTarball).toHaveBeenCalledOnce();
+  });
+
+  it("verifies and persists the server artifact digest", async () => {
+    const test = await createFixture();
+    const bytes = new TextEncoder().encode("verified-tarball");
+    const digest = createHash("sha256").update(bytes).digest("hex");
+    test.fetchFn.mockImplementation(async (input: RequestInfo | URL) => {
+      if (String(input).endsWith("/install/version")) {
+        return Response.json({
+          version: "9.0.0-test",
+          protocolVersion: HOST_DAEMON_PROTOCOL_VERSION + 1,
+        });
+      }
+      return new Response(bytes, {
+        headers: { "x-bb-artifact-sha256": digest },
+      });
+    });
+
+    await expect(test.updater.handleProtocolMismatch()).resolves.toBe(
+      "updated",
+    );
+    await expect(
+      readFile(join(test.dataDir, "host-artifact.sha256"), "utf8"),
+    ).resolves.toBe(`${digest}\n`);
+    expect(test.installTarball).toHaveBeenCalledOnce();
+  });
+
+  it("rejects a downloaded artifact whose digest does not match", async () => {
+    const test = await createFixture();
+    test.fetchFn.mockImplementation(async (input: RequestInfo | URL) => {
+      if (String(input).endsWith("/install/version")) {
+        return Response.json({
+          version: "9.0.0-test",
+          protocolVersion: HOST_DAEMON_PROTOCOL_VERSION + 1,
+        });
+      }
+      return new Response("tampered", {
+        headers: { "x-bb-artifact-sha256": "a".repeat(64) },
+      });
+    });
+
+    await expect(test.updater.handleProtocolMismatch()).resolves.toBe("failed");
+    expect(test.installTarball).not.toHaveBeenCalled();
+    expect(test.logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ err: expect.any(Error) }),
+      expect.stringContaining("self-update failed"),
+    );
+  });
+
+  it("skips downloading and reinstalling an identical installed artifact", async () => {
+    const test = await createFixture();
+    const digest = "b".repeat(64);
+    await writeFile(join(test.dataDir, "host-artifact.sha256"), `${digest}\n`);
+    test.fetchFn.mockImplementation(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        if (String(input).endsWith("/install/version")) {
+          return Response.json({
+            version: "9.0.0-test",
+            protocolVersion: HOST_DAEMON_PROTOCOL_VERSION + 1,
+          });
+        }
+        expect(init?.headers).toEqual({
+          "if-none-match": `"sha256-${digest}"`,
+        });
+        return new Response(null, {
+          headers: { "x-bb-artifact-sha256": digest },
+          status: 304,
+        });
+      },
+    );
+
+    await expect(test.updater.handleProtocolMismatch()).resolves.toBe(
+      "updated",
+    );
+    expect(test.installTarball).not.toHaveBeenCalled();
+    expect(test.logger.info).toHaveBeenCalledWith(
+      { artifactDigest: digest },
+      expect.stringContaining("already installed"),
+    );
   });
 
   it("finds npm beside the running Node executable when the service PATH omits it", async () => {

--- a/apps/host-daemon/src/protocol-self-update.ts
+++ b/apps/host-daemon/src/protocol-self-update.ts
@@ -6,11 +6,15 @@ import { HOST_DAEMON_PROTOCOL_VERSION } from "@bb/host-daemon-contract";
 import type { HostDaemonLogger } from "./logger.js";
 import type { FetchFn } from "./server-client.js";
 import { usesSecureInternalFetchTransport } from "./server-client.js";
+import { sha256Hex } from "./sha256-hex.js";
 
 const execFileAsync = promisify(execFile);
 export const SELF_UPDATE_INITIAL_RETRY_DELAY_MS = 5_000;
 export const SELF_UPDATE_MAX_RETRY_DELAY_MS = 5 * 60 * 1000;
 const ATTEMPT_FILE_NAME = "host-daemon-update-attempt.json";
+const INSTALLED_ARTIFACT_DIGEST_FILE_NAME = "host-artifact.sha256";
+const ARTIFACT_DIGEST_HEADER = "x-bb-artifact-sha256";
+const ARTIFACT_DIGEST_PATTERN = /^[a-f0-9]{64}$/u;
 
 interface UpdateVersion {
   protocolVersion: number;
@@ -117,6 +121,33 @@ async function writeAttempt(
   await rename(temporary, path);
 }
 
+async function readInstalledArtifactDigest(
+  path: string,
+): Promise<string | null> {
+  try {
+    const digest = (await readFile(path, "utf8")).trim();
+    return ARTIFACT_DIGEST_PATTERN.test(digest) ? digest : null;
+  } catch {
+    return null;
+  }
+}
+
+async function writeInstalledArtifactDigest(
+  path: string,
+  digest: string,
+): Promise<void> {
+  const temporary = `${path}.${process.pid}.tmp`;
+  await writeFile(temporary, `${digest}\n`, { mode: 0o600 });
+  await rename(temporary, path);
+}
+
+function responseArtifactDigest(response: Response): string | null {
+  const digest = response.headers.get(ARTIFACT_DIGEST_HEADER);
+  return digest !== null && ARTIFACT_DIGEST_PATTERN.test(digest)
+    ? digest
+    : null;
+}
+
 const defaultRunProcess: SelfUpdateProcessRunner = async (
   command,
   args,
@@ -167,6 +198,10 @@ export function createProtocolSelfUpdater(
       ));
   const now = options.now ?? Date.now;
   const attemptPath = join(options.dataDir, ATTEMPT_FILE_NAME);
+  const installedArtifactDigestPath = join(
+    options.dataDir,
+    INSTALLED_ARTIFACT_DIGEST_FILE_NAME,
+  );
 
   return {
     async handleProtocolMismatch(
@@ -252,18 +287,51 @@ export function createProtocolSelfUpdater(
         );
         try {
           const tarballUrl = new URL("/install/bb-app.tgz", options.serverUrl);
-          const response = await fetchFn(tarballUrl, { method: "GET" });
+          const installedDigest = await readInstalledArtifactDigest(
+            installedArtifactDigestPath,
+          );
+          const response = await fetchFn(tarballUrl, {
+            method: "GET",
+            ...(installedDigest === null
+              ? {}
+              : {
+                  headers: {
+                    "if-none-match": `"sha256-${installedDigest}"`,
+                  },
+                }),
+          });
+          if (response.status === 304 && installedDigest !== null) {
+            options.logger.info(
+              { artifactDigest: installedDigest },
+              "The server-matched bb host artifact is already installed; restarting the daemon.",
+            );
+            return "updated";
+          }
           if (!response.ok) {
             throw new Error(
               `Package download failed: ${response.status} ${response.statusText}`,
             );
           }
-          await writeFile(
-            tarballPath,
-            new Uint8Array(await response.arrayBuffer()),
-            { mode: 0o600 },
-          );
+          const bytes = new Uint8Array(await response.arrayBuffer());
+          const expectedDigest = responseArtifactDigest(response);
+          if (expectedDigest !== null) {
+            const actualDigest = sha256Hex(bytes);
+            if (actualDigest !== expectedDigest) {
+              throw new Error(
+                `Package digest mismatch: expected ${expectedDigest}, received ${actualDigest}`,
+              );
+            }
+          }
+          await writeFile(tarballPath, bytes, { mode: 0o600 });
           await installTarball(tarballPath);
+          if (expectedDigest === null) {
+            await rm(installedArtifactDigestPath, { force: true });
+          } else {
+            await writeInstalledArtifactDigest(
+              installedArtifactDigestPath,
+              expectedDigest,
+            );
+          }
         } finally {
           await rm(tarballPath, { force: true });
         }
@@ -274,7 +342,7 @@ export function createProtocolSelfUpdater(
             serverProtocolVersion: server.protocolVersion,
             serverVersion: server.version,
           },
-          "Installed the server-matched bb-app package; restarting the daemon.",
+          "Installed the server-matched bb host package; restarting the daemon.",
         );
         return "updated";
       } catch (error) {

--- a/apps/server/src/assets/install-machine.sh
+++ b/apps/server/src/assets/install-machine.sh
@@ -375,6 +375,20 @@ complete_step "Using local host-daemon port $host_daemon_port"
 package_url="${server_url%/}/install/bb-app.tgz"
 package_dir=$(mktemp -d "${TMPDIR:-/tmp}/bb-app.XXXXXX")
 package_file="$package_dir/bb-app.tgz"
+package_headers="$package_dir/headers"
+host_artifact_digest_file="$data_dir/host-artifact.sha256"
+installed_artifact_digest=
+if [ -x "$machine_npm_prefix/bin/bb-app" ] && \
+   [ -x "$machine_npm_prefix/bin/bb" ] && \
+   [ -f "$machine_npm_prefix/lib/node_modules/bb-app/host-daemon/dist/daemon-bundle.mjs" ]; then
+  installed_artifact_digest=$(node -e '
+    const fs = require("node:fs");
+    try {
+      const digest = fs.readFileSync(process.argv[1], "utf8").trim();
+      if (/^[a-f0-9]{64}$/u.test(digest)) process.stdout.write(digest);
+    } catch {}
+  ' "$host_artifact_digest_file")
+fi
 # curl's numeric meter shows bytes, rate, percentage, and ETA without the
 # animated ASCII bar. Keep redirected installs quiet while preserving errors.
 curl_output_mode=--progress-meter
@@ -382,19 +396,58 @@ if [ ! -t 2 ]; then
   curl_output_mode=--silent
 fi
 active_step "Downloading the server's bb-app package (timeout: 5 minutes)"
-package_status=$(curl "$curl_output_mode" --show-error --location \
-  --connect-timeout "$CURL_CONNECT_TIMEOUT_SECONDS" \
-  --max-time "$PACKAGE_DOWNLOAD_TIMEOUT_SECONDS" \
-  --output "$package_file" \
-  --write-out '%{http_code}' \
-  "$package_url") || package_status=000
+if [ -n "$installed_artifact_digest" ]; then
+  package_status=$(curl "$curl_output_mode" --show-error --location \
+    --connect-timeout "$CURL_CONNECT_TIMEOUT_SECONDS" \
+    --max-time "$PACKAGE_DOWNLOAD_TIMEOUT_SECONDS" \
+    --header "If-None-Match: \"sha256-$installed_artifact_digest\"" \
+    --dump-header "$package_headers" \
+    --output "$package_file" \
+    --write-out '%{http_code}' \
+    "$package_url") || package_status=000
+else
+  package_status=$(curl "$curl_output_mode" --show-error --location \
+    --connect-timeout "$CURL_CONNECT_TIMEOUT_SECONDS" \
+    --max-time "$PACKAGE_DOWNLOAD_TIMEOUT_SECONDS" \
+    --dump-header "$package_headers" \
+    --output "$package_file" \
+    --write-out '%{http_code}' \
+    "$package_url") || package_status=000
+fi
+
+package_digest=$(node -e '
+  const fs = require("node:fs");
+  try {
+    const headers = fs.readFileSync(process.argv[1], "utf8");
+    const matches = [...headers.matchAll(/^x-bb-artifact-sha256:\s*([a-f0-9]{64})\s*$/gimu)];
+    const digest = matches.at(-1)?.[1];
+    if (digest) process.stdout.write(digest);
+  } catch {}
+' "$package_headers")
 
 bb_app=
 bb_app_npm_prefix=
-if [ "$package_status" -ge 200 ] && [ "$package_status" -lt 300 ]; then
+if [ "$package_status" = 304 ] && [ -n "$installed_artifact_digest" ]; then
+  bb_app_npm_prefix=$machine_npm_prefix
+  complete_step "The identical server host artifact is already installed"
+elif [ "$package_status" -ge 200 ] && [ "$package_status" -lt 300 ]; then
+  if [ -n "$package_digest" ]; then
+    downloaded_digest=$(node -e '
+      const crypto = require("node:crypto");
+      const fs = require("node:fs");
+      process.stdout.write(crypto.createHash("sha256").update(fs.readFileSync(process.argv[1])).digest("hex"));
+    ' "$package_file")
+    if [ "$downloaded_digest" != "$package_digest" ]; then
+      rm -rf "$package_dir"
+      fail_step "The downloaded bb host artifact failed SHA-256 verification."
+      detail "Expected $package_digest but received $downloaded_digest." >&2
+      exit 1
+    fi
+  fi
   require_npm
   complete_step "Downloaded the server's bb-app package"
   active_step "Installing the server's bb-app build"
+  rm -f "$host_artifact_digest_file"
   if ! npm install -g "$bb_app_allow_scripts" --prefix "$machine_npm_prefix" "$package_file"; then
     rm -rf "$package_dir"
     fail_step "Could not install bb-app for this machine. Check the npm error above, then rerun this command."
@@ -403,6 +456,7 @@ if [ "$package_status" -ge 200 ] && [ "$package_status" -lt 300 ]; then
   bb_app_npm_prefix=$machine_npm_prefix
   complete_step "Installed the server's bb-app build"
 elif command -v bb-app >/dev/null 2>&1; then
+  rm -f "$host_artifact_digest_file"
   bb_app=$(command -v bb-app)
   if [ "$package_status" = 404 ]; then
     warning_step "The server does not provide its bb-app package; using bb-app at $bb_app"
@@ -411,6 +465,7 @@ elif command -v bb-app >/dev/null 2>&1; then
   fi
 elif [ "$package_status" = 404 ]; then
   require_npm
+  rm -f "$host_artifact_digest_file"
   warning_step "The server does not provide its bb-app package"
   active_step "Installing bb-app from the npm registry"
   if ! npm install -g "$bb_app_allow_scripts" --prefix "$machine_npm_prefix" bb-app; then
@@ -439,12 +494,17 @@ if [ -n "$bb_app_npm_prefix" ]; then
   bb_app_root="$bb_app_npm_prefix/lib/node_modules/bb-app"
   if ! node -e '
     const root = process.argv[1];
-    require(root + "/node_modules/better-sqlite3");
     require(root + "/node_modules/node-pty");
+    require(root + "/node_modules/@parcel/watcher");
   ' "$bb_app_root" >/dev/null 2>&1; then
-    fail_step "npm installed bb-app, but its native add-ons (better-sqlite3, node-pty) did not load."
+    fail_step "npm installed bb-app, but its host native add-ons (node-pty, @parcel/watcher) did not load."
     detail "npm did not run their install scripts. Check the npm warnings above. If they mention allowScripts or ignore-scripts, rerun this command with: npm_config_allow_scripts=$bb_app_native_modules npm_config_ignore_scripts=false" >&2
     exit 1
+  fi
+  if [ "$package_status" -ge 200 ] && [ "$package_status" -lt 300 ] && [ -n "$package_digest" ]; then
+    host_artifact_digest_temp="$host_artifact_digest_file.$$.tmp"
+    (umask 077 && printf '%s\n' "$package_digest" >"$host_artifact_digest_temp")
+    mv "$host_artifact_digest_temp" "$host_artifact_digest_file"
   fi
 fi
 

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -480,12 +480,20 @@ export function createApp(
     });
   });
   app.get("/install/bb-app.tgz", async (context) => {
-    const tarball = await readFile(await bbAppArtifactService.getTarballPath());
+    const artifact = await bbAppArtifactService.getArtifact();
+    const etag = `"sha256-${artifact.digest}"`;
+    const headers = {
+      "cache-control": "public, max-age=300",
+      "content-type": "application/gzip",
+      etag,
+      "x-bb-artifact-sha256": artifact.digest,
+    };
+    if (context.req.header("if-none-match") === etag) {
+      return new Response(null, { headers, status: 304 });
+    }
+    const tarball = await readFile(artifact.path);
     return new Response(tarball, {
-      headers: {
-        "cache-control": "public, max-age=300",
-        "content-type": "application/gzip",
-      },
+      headers: { ...headers, "content-length": String(artifact.size) },
     });
   });
   app.use("/api/v1/*", async (context, next) => {

--- a/apps/server/src/services/install/bb-app-artifact.ts
+++ b/apps/server/src/services/install/bb-app-artifact.ts
@@ -1,14 +1,46 @@
 import { execFile } from "node:child_process";
-import { mkdir, readFile, rename, rm } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import {
+  chmod,
+  copyFile,
+  cp,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import { HOST_DAEMON_PROTOCOL_VERSION } from "@bb/host-daemon-contract";
 
 const execFileAsync = promisify(execFile);
+const HOST_DEPENDENCIES = [
+  "@parcel/watcher",
+  "node-pty",
+  "pino",
+  "pino-pretty",
+  "pino-roll",
+] as const;
+const HOST_DAEMON_FILES = [
+  "bb",
+  "bb-parcel-watcher-child.mjs",
+  "bb-plugin-host-worker.mjs",
+  "bb-provider-bridge-worker.mjs",
+  "daemon-bundle.mjs",
+] as const;
+
+export interface BbAppArtifact {
+  digest: string;
+  path: string;
+  size: number;
+}
 
 export interface BbAppArtifactService {
-  getTarballPath(): Promise<string>;
+  getArtifact(): Promise<BbAppArtifact>;
   getVersion(): Promise<string>;
 }
 
@@ -24,7 +56,10 @@ interface CreateBbAppArtifactServiceOptions {
 }
 
 interface BbAppPackageJson {
-  name: string;
+  dependencies: Record<string, string>;
+  engines: { node: string };
+  name: "bb-app";
+  os: string[];
   version: string;
 }
 
@@ -40,6 +75,14 @@ async function defaultCommandRunner(
   return result.stdout;
 }
 
+function isStringRecord(value: unknown): value is Record<string, string> {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    Object.values(value).every((entry) => typeof entry === "string")
+  );
+}
+
 async function readBbAppPackageJson(
   packageRoot: string,
 ): Promise<BbAppPackageJson> {
@@ -52,11 +95,27 @@ async function readBbAppPackageJson(
     !("name" in parsed) ||
     parsed.name !== "bb-app" ||
     !("version" in parsed) ||
-    typeof parsed.version !== "string"
+    typeof parsed.version !== "string" ||
+    !("dependencies" in parsed) ||
+    !isStringRecord(parsed.dependencies) ||
+    !("engines" in parsed) ||
+    parsed.engines === null ||
+    typeof parsed.engines !== "object" ||
+    !("node" in parsed.engines) ||
+    typeof parsed.engines.node !== "string" ||
+    !("os" in parsed) ||
+    !Array.isArray(parsed.os) ||
+    !parsed.os.every((entry) => typeof entry === "string")
   ) {
     throw new Error(`Expected a bb-app package at ${packageRoot}`);
   }
-  return { name: parsed.name, version: parsed.version };
+  return {
+    dependencies: parsed.dependencies,
+    engines: { node: parsed.engines.node },
+    name: parsed.name,
+    os: parsed.os,
+    version: parsed.version,
+  };
 }
 
 interface ResolvedBbAppPackage {
@@ -89,8 +148,76 @@ export async function resolveBbAppPackage(
   );
 }
 
-function safeVersionFilePart(version: string): string {
-  return version.replace(/[^a-zA-Z0-9._-]/gu, "_");
+function hostPackageJson(packageJson: BbAppPackageJson): object {
+  const dependencies = Object.fromEntries(
+    HOST_DEPENDENCIES.map((name) => {
+      const version = packageJson.dependencies[name];
+      if (version === undefined) {
+        throw new Error(`bb-app is missing host dependency ${name}`);
+      }
+      return [name, version];
+    }),
+  );
+  return {
+    name: packageJson.name,
+    version: packageJson.version,
+    description: "bb enrolled host runtime",
+    type: "module",
+    os: packageJson.os,
+    bin: {
+      bb: "dist/bb.js",
+      "bb-app": "dist/bb-app.js",
+      "bb-host-daemon": "dist/bb-host-daemon.js",
+    },
+    files: ["dist", "host-daemon", "README.md"],
+    engines: packageJson.engines,
+    dependencies,
+  };
+}
+
+async function materializePackagedHostPackage(
+  packageRoot: string,
+  packageJson: BbAppPackageJson,
+  cacheDir: string,
+): Promise<string> {
+  const hostPackageRoot = await mkdtemp(join(cacheDir, "host-package-"));
+  const distDir = join(hostPackageRoot, "dist");
+  const hostDaemonSource = join(packageRoot, "host-daemon", "dist");
+  const hostDaemonTarget = join(hostPackageRoot, "host-daemon", "dist");
+  await mkdir(hostDaemonTarget, { recursive: true });
+  await mkdir(distDir, { recursive: true });
+  for (const fileName of ["bb-app.js", "bb-host-daemon.js", "bb.js"]) {
+    await copyFile(
+      join(packageRoot, "dist", fileName),
+      join(distDir, fileName),
+    );
+    await chmod(join(distDir, fileName), 0o755);
+  }
+  for (const fileName of HOST_DAEMON_FILES) {
+    await copyFile(
+      join(hostDaemonSource, fileName),
+      join(hostDaemonTarget, fileName),
+    );
+  }
+  await chmod(join(hostDaemonTarget, "bb"), 0o755);
+  await cp(
+    join(hostDaemonSource, "bb-chunks"),
+    join(hostDaemonTarget, "bb-chunks"),
+    { recursive: true },
+  );
+  await copyFile(
+    join(packageRoot, "README.md"),
+    join(hostPackageRoot, "README.md"),
+  );
+  await writeFile(
+    join(hostPackageRoot, "package.json"),
+    `${JSON.stringify(hostPackageJson(packageJson), null, 2)}\n`,
+  );
+  return hostPackageRoot;
+}
+
+function sha256(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
 }
 
 export function createBbAppArtifactService(
@@ -102,49 +229,66 @@ export function createBbAppArtifactService(
   const protocolVersion =
     options.protocolVersion ?? HOST_DAEMON_PROTOCOL_VERSION;
   let resolvedPackagePromise: Promise<ResolvedBbAppPackage> | undefined;
-  let artifactPromise: Promise<string> | undefined;
+  let artifactPromise: Promise<BbAppArtifact> | undefined;
 
   function getResolvedPackage(): Promise<ResolvedBbAppPackage> {
     resolvedPackagePromise ??= resolveBbAppPackage(serverEntryUrl);
     return resolvedPackagePromise;
   }
 
-  async function buildTarball(): Promise<string> {
+  async function buildArtifact(): Promise<BbAppArtifact> {
     const resolved = await getResolvedPackage();
     const { packageJson, root: packageRoot } = resolved;
-    const tarballPath = join(
-      cacheDir,
-      `bb-app-${safeVersionFilePart(packageJson.version)}-protocol-${protocolVersion}.tgz`,
-    );
     await mkdir(cacheDir, { recursive: true });
-    await rm(`${tarballPath}.json`, { force: true });
-
+    let temporaryHostPackageRoot: string | undefined;
+    let hostPackageRoot: string;
     if (resolved.layout === "repo") {
       const repoRoot = resolve(packageRoot, "../..");
       await commandRunner(
         "pnpm",
-        ["exec", "turbo", "run", "build", "--filter=bb-app"],
+        ["exec", "turbo", "run", "build:host", "--filter=bb-app"],
         repoRoot,
       );
+      hostPackageRoot = join(packageRoot, "host-package");
+    } else {
+      temporaryHostPackageRoot = await materializePackagedHostPackage(
+        packageRoot,
+        packageJson,
+        cacheDir,
+      );
+      hostPackageRoot = temporaryHostPackageRoot;
     }
 
-    const stdout = await commandRunner(
-      "npm",
-      ["pack", "--pack-destination", cacheDir],
-      packageRoot,
-    );
-    const packedName = stdout.trim().split(/\r?\n/u).at(-1);
-    if (!packedName) {
-      throw new Error("npm pack did not report a tarball name");
+    try {
+      const stdout = await commandRunner(
+        "npm",
+        ["pack", "--pack-destination", cacheDir],
+        hostPackageRoot,
+      );
+      const packedName = stdout.trim().split(/\r?\n/u).at(-1);
+      if (!packedName) {
+        throw new Error("npm pack did not report a tarball name");
+      }
+      const packedPath = join(cacheDir, packedName);
+      const bytes = await readFile(packedPath);
+      const digest = sha256(bytes);
+      const artifactPath = join(
+        cacheDir,
+        `bb-app-host-${packageJson.version}-protocol-${protocolVersion}-${digest}.tgz`,
+      );
+      await rename(packedPath, artifactPath);
+      const artifactStats = await stat(artifactPath);
+      return { digest, path: artifactPath, size: artifactStats.size };
+    } finally {
+      if (temporaryHostPackageRoot !== undefined) {
+        await rm(temporaryHostPackageRoot, { force: true, recursive: true });
+      }
     }
-    const packedPath = join(cacheDir, packedName);
-    await rename(packedPath, tarballPath);
-    return tarballPath;
   }
 
   return {
-    getTarballPath(): Promise<string> {
-      artifactPromise ??= buildTarball().catch((error: unknown) => {
+    getArtifact(): Promise<BbAppArtifact> {
+      artifactPromise ??= buildArtifact().catch((error: unknown) => {
         artifactPromise = undefined;
         throw error;
       });

--- a/apps/server/test/app/bb-app-artifact.test.ts
+++ b/apps/server/test/app/bb-app-artifact.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -14,12 +14,58 @@ import {
 const execFileAsync = promisify(execFile);
 const roots: string[] = [];
 const ARTIFACT_LIFECYCLE_TIMEOUT_MS = 15_000;
-
 const MODES = ["repo-src", "repo-dist", "packaged"] as const;
+const packageJson = {
+  name: "bb-app",
+  version: "1.2.3-test",
+  type: "module",
+  os: ["darwin", "linux"],
+  engines: { node: ">=22.19.0" },
+  dependencies: {
+    "@parcel/watcher": "2.5.6",
+    "node-pty": "1.2.0-beta.15",
+    pino: "9.6.0",
+    "pino-pretty": "13.0.0",
+    "pino-roll": "4.0.0",
+  },
+  bin: {
+    bb: "dist/bb.js",
+    "bb-app": "dist/bb-app.js",
+    "bb-host-daemon": "dist/bb-host-daemon.js",
+  },
+  files: ["dist", "host-daemon", "README.md"],
+};
+
 type Mode = (typeof MODES)[number];
 
 function isRepoMode(mode: Mode): boolean {
   return mode !== "packaged";
+}
+
+async function writeHostPackage(root: string, readme: string): Promise<void> {
+  await mkdir(join(root, "dist"), { recursive: true });
+  await mkdir(join(root, "host-daemon/dist/bb-chunks"), { recursive: true });
+  await writeFile(join(root, "package.json"), JSON.stringify(packageJson));
+  await writeFile(join(root, "dist/bb-app.js"), "#!/usr/bin/env node\n");
+  await writeFile(
+    join(root, "dist/bb-host-daemon.js"),
+    "#!/usr/bin/env node\n",
+  );
+  await writeFile(join(root, "dist/bb.js"), "#!/usr/bin/env node\n");
+  await writeFile(join(root, "README.md"), readme);
+  for (const fileName of [
+    "bb",
+    "bb-parcel-watcher-child.mjs",
+    "bb-plugin-host-worker.mjs",
+    "bb-provider-bridge-worker.mjs",
+    "daemon-bundle.mjs",
+  ]) {
+    await writeFile(join(root, "host-daemon/dist", fileName), fileName);
+  }
+  await writeFile(
+    join(root, "host-daemon/dist/bb-chunks/chunk-TEST.js"),
+    "export {};\n",
+  );
 }
 
 async function fixture(mode: Mode) {
@@ -33,31 +79,30 @@ async function fixture(mode: Mode) {
         ? join(root, "apps/server/dist/server.js")
         : join(root, "server/dist/server.js");
   await mkdir(dirname(serverEntry), { recursive: true });
-  await mkdir(join(packageRoot, "dist"), { recursive: true });
-  await writeFile(serverEntry, "// fixture\n");
-  await writeFile(
-    join(packageRoot, "package.json"),
-    JSON.stringify({
-      name: "bb-app",
-      version: "1.2.3-test",
-      files: ["dist", "README.md"],
-    }),
-  );
-  await writeFile(join(packageRoot, "dist/bb-app.js"), "#!/usr/bin/env node\n");
-  await writeFile(join(packageRoot, "README.md"), "fixture\n");
+  await writeFile(serverEntry, "");
+  await writeHostPackage(packageRoot, "fixture\n");
   await writeFile(join(packageRoot, "private.txt"), "must not ship\n");
-  return { packageRoot, root, serverEntry };
+
+  const refreshHostPackage = async (): Promise<void> => {
+    if (!isRepoMode(mode)) return;
+    await writeHostPackage(
+      join(packageRoot, "host-package"),
+      await readFile(join(packageRoot, "README.md"), "utf8"),
+    );
+  };
+  await refreshHostPackage();
+  return { packageRoot, refreshHostPackage, root, serverEntry };
 }
 
 afterEach(async () => {
   await Promise.all(
-    roots.splice(0).map((root) => rm(root, { recursive: true })),
+    roots.splice(0).map((root) => rm(root, { force: true, recursive: true })),
   );
 });
 
 describe.each(MODES)("bb-app artifact service (%s)", (mode) => {
   it(
-    "resolves and packs a structurally valid npm package",
+    "packs only the enrolled host runtime as an exact-version npm package",
     async () => {
       const test = await fixture(mode);
       const calls: Array<{
@@ -68,10 +113,10 @@ describe.each(MODES)("bb-app artifact service (%s)", (mode) => {
       const runner: BbAppArtifactCommandRunner = async (command, args, cwd) => {
         calls.push({ command, args, cwd });
         if (command === "pnpm") {
+          await test.refreshHostPackage();
           return "built";
         }
-        const result = await execFileAsync(command, [...args], { cwd });
-        return result.stdout;
+        return (await execFileAsync(command, [...args], { cwd })).stdout;
       };
       const resolved = await resolveBbAppPackage(
         pathToFileURL(test.serverEntry).href,
@@ -84,41 +129,71 @@ describe.each(MODES)("bb-app artifact service (%s)", (mode) => {
         serverEntryUrl: pathToFileURL(test.serverEntry).href,
       });
 
-      const tarball = await service.getTarballPath();
+      const artifact = await service.getArtifact();
       await expect(service.getVersion()).resolves.toBe("1.2.3-test");
       const listing = (
-        await execFileAsync("tar", ["-tzf", tarball])
+        await execFileAsync("tar", ["-tzf", artifact.path])
       ).stdout.split("\n");
       expect(listing).toContain("package/package.json");
       expect(listing).toContain("package/dist/bb-app.js");
-      expect(listing).toContain("package/README.md");
+      expect(listing).toContain("package/dist/bb.js");
+      expect(listing).toContain("package/host-daemon/dist/daemon-bundle.mjs");
+      expect(listing).toContain("package/host-daemon/dist/bb");
       expect(listing).not.toContain("package/private.txt");
-      const packageJson = JSON.parse(
-        (await execFileAsync("tar", ["-xOzf", tarball, "package/package.json"]))
-          .stdout,
+      expect(listing.some((entry) => entry.startsWith("package/app/"))).toBe(
+        false,
       );
-      expect(packageJson.version).toBe("1.2.3-test");
+      expect(listing.some((entry) => entry.startsWith("package/server/"))).toBe(
+        false,
+      );
+      const packedPackageJson = JSON.parse(
+        (
+          await execFileAsync("tar", [
+            "-xOzf",
+            artifact.path,
+            "package/package.json",
+          ])
+        ).stdout,
+      );
+      expect(packedPackageJson).toMatchObject({
+        name: "bb-app",
+        version: "1.2.3-test",
+        bin: {
+          bb: "dist/bb.js",
+          "bb-app": "dist/bb-app.js",
+          "bb-host-daemon": "dist/bb-host-daemon.js",
+        },
+      });
+      expect(Object.keys(packedPackageJson.dependencies).sort()).toEqual([
+        "@parcel/watcher",
+        "node-pty",
+        "pino",
+        "pino-pretty",
+        "pino-roll",
+      ]);
+      expect(artifact.digest).toMatch(/^[a-f0-9]{64}$/u);
+      expect(artifact.path).toContain(artifact.digest);
+      expect(artifact.size).toBeGreaterThan(0);
       expect(calls.filter((call) => call.command === "pnpm")).toHaveLength(
         isRepoMode(mode) ? 1 : 0,
       );
-      await expect(service.getTarballPath()).resolves.toBe(tarball);
+      await expect(service.getArtifact()).resolves.toEqual(artifact);
       expect(calls.filter((call) => call.command === "npm")).toHaveLength(1);
     },
     ARTIFACT_LIFECYCLE_TIMEOUT_MS,
   );
 
   it(
-    "rebuilds the artifact after package contents change without a version or protocol change",
+    "content-addresses rebuilds when package contents change",
     async () => {
       const test = await fixture(mode);
-      const calls: Array<{
-        command: string;
-        args: readonly string[];
-        cwd: string;
-      }> = [];
+      const calls: Array<{ command: string }> = [];
       const runner: BbAppArtifactCommandRunner = async (command, args, cwd) => {
-        calls.push({ command, args, cwd });
-        if (command === "pnpm") return "built";
+        calls.push({ command });
+        if (command === "pnpm") {
+          await test.refreshHostPackage();
+          return "built";
+        }
         return (await execFileAsync(command, [...args], { cwd })).stdout;
       };
       const options = {
@@ -128,40 +203,35 @@ describe.each(MODES)("bb-app artifact service (%s)", (mode) => {
         protocolVersion: 51,
       };
 
-      const first = await createBbAppArtifactService(options).getTarballPath();
-      expect(
-        (await execFileAsync("tar", ["-xOzf", first, "package/README.md"]))
-          .stdout,
-      ).toBe("fixture\n");
-
+      const first = await createBbAppArtifactService(options).getArtifact();
       await writeFile(join(test.packageRoot, "README.md"), "updated\n");
-      const second = await createBbAppArtifactService(options).getTarballPath();
+      const second = await createBbAppArtifactService(options).getArtifact();
 
-      expect(second).toBe(first);
+      expect(second.path).not.toBe(first.path);
+      expect(second.digest).not.toBe(first.digest);
       expect(
-        (await execFileAsync("tar", ["-xOzf", second, "package/README.md"]))
-          .stdout,
+        (
+          await execFileAsync("tar", [
+            "-xOzf",
+            second.path,
+            "package/README.md",
+          ])
+        ).stdout,
       ).toBe("updated\n");
       expect(calls.filter((call) => call.command === "npm")).toHaveLength(2);
-      expect(calls.filter((call) => call.command === "pnpm")).toHaveLength(
-        isRepoMode(mode) ? 2 : 0,
-      );
     },
     ARTIFACT_LIFECYCLE_TIMEOUT_MS,
   );
 
   it(
-    "builds a fresh artifact when the protocol changes at the same package version",
+    "separates protocol cache keys without changing identical content digests",
     async () => {
       const test = await fixture(mode);
-      const calls: Array<{
-        command: string;
-        args: readonly string[];
-        cwd: string;
-      }> = [];
       const runner: BbAppArtifactCommandRunner = async (command, args, cwd) => {
-        calls.push({ command, args, cwd });
-        if (command === "pnpm") return "built";
+        if (command === "pnpm") {
+          await test.refreshHostPackage();
+          return "built";
+        }
         return (await execFileAsync(command, [...args], { cwd })).stdout;
       };
       const baseOptions = {
@@ -173,28 +243,28 @@ describe.each(MODES)("bb-app artifact service (%s)", (mode) => {
       const first = await createBbAppArtifactService({
         ...baseOptions,
         protocolVersion: 51,
-      }).getTarballPath();
+      }).getArtifact();
       const second = await createBbAppArtifactService({
         ...baseOptions,
         protocolVersion: 52,
-      }).getTarballPath();
+      }).getArtifact();
 
-      expect(second).not.toBe(first);
-      expect(calls.filter((call) => call.command === "npm")).toHaveLength(2);
-      expect(calls.filter((call) => call.command === "pnpm")).toHaveLength(
-        isRepoMode(mode) ? 2 : 0,
-      );
+      expect(second.path).not.toBe(first.path);
+      expect(second.digest).toBe(first.digest);
     },
     ARTIFACT_LIFECYCLE_TIMEOUT_MS,
   );
 
   it(
-    "keeps serving the previous artifact when a rebuild fails, and retries after",
+    "keeps the previous content-addressed artifact when a rebuild fails",
     async () => {
       const test = await fixture(mode);
       let failNextPack = false;
       const runner: BbAppArtifactCommandRunner = async (command, args, cwd) => {
-        if (command === "pnpm") return "built";
+        if (command === "pnpm") {
+          await test.refreshHostPackage();
+          return "built";
+        }
         if (failNextPack) throw new Error("npm pack exploded");
         return (await execFileAsync(command, [...args], { cwd })).stdout;
       };
@@ -205,25 +275,27 @@ describe.each(MODES)("bb-app artifact service (%s)", (mode) => {
         protocolVersion: 51,
       };
 
-      const tarball =
-        await createBbAppArtifactService(options).getTarballPath();
-
+      const first = await createBbAppArtifactService(options).getArtifact();
       failNextPack = true;
       await writeFile(join(test.packageRoot, "README.md"), "updated\n");
       const service = createBbAppArtifactService(options);
-      await expect(service.getTarballPath()).rejects.toThrow(
-        "npm pack exploded",
-      );
+      await expect(service.getArtifact()).rejects.toThrow("npm pack exploded");
       expect(
-        (await execFileAsync("tar", ["-xOzf", tarball, "package/README.md"]))
+        (await execFileAsync("tar", ["-xOzf", first.path, "package/README.md"]))
           .stdout,
       ).toBe("fixture\n");
 
       failNextPack = false;
-      await expect(service.getTarballPath()).resolves.toBe(tarball);
+      const second = await service.getArtifact();
+      expect(second.path).not.toBe(first.path);
       expect(
-        (await execFileAsync("tar", ["-xOzf", tarball, "package/README.md"]))
-          .stdout,
+        (
+          await execFileAsync("tar", [
+            "-xOzf",
+            second.path,
+            "package/README.md",
+          ])
+        ).stdout,
       ).toBe("updated\n");
     },
     ARTIFACT_LIFECYCLE_TIMEOUT_MS,

--- a/apps/server/test/app/install-machine-script.test.ts
+++ b/apps/server/test/app/install-machine-script.test.ts
@@ -1,4 +1,5 @@
 import { spawn, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import {
   chmodSync,
   existsSync,
@@ -20,6 +21,9 @@ const SCRIPT_PATH = new URL(
   import.meta.url,
 );
 const createdDirectories: string[] = [];
+const FIXTURE_ARTIFACT_DIGEST = createHash("sha256")
+  .update("fixture-tarball")
+  .digest("hex");
 
 function createFixture(): { binDir: string; dataDir: string; homeDir: string } {
   const root = mkdtempSync(join(tmpdir(), "bb-install-script-test-"));
@@ -30,6 +34,7 @@ function createFixture(): { binDir: string; dataDir: string; homeDir: string } {
   mkdirSync(binDir, { recursive: true });
   mkdirSync(dataDir, { recursive: true });
   mkdirSync(homeDir, { recursive: true });
+  writeFileSync(join(root, "package.json"), '{"type":"commonjs"}\n');
   symlinkSync(process.execPath, join(binDir, "node"));
   return { binDir, dataDir, homeDir };
 }
@@ -162,6 +167,7 @@ process.on("SIGTERM", () => server.close(() => process.exit(0)));
 function writeServerInstallTools(
   fixture: ReturnType<typeof createFixture>,
   artifactStatus: 200 | 404,
+  artifactDigest = FIXTURE_ARTIFACT_DIGEST,
 ): void {
   const curlLog = join(fixture.dataDir, "curl.log");
   const npmLog = join(fixture.dataDir, "npm.log");
@@ -173,11 +179,22 @@ case "$*" in
   *redeem-machine*) printf '%s' '{"credential":"bbcm_durable","machineId":"machine-1"}' ;;
   *)
     output=
+    headers=
+    unchanged=no
+    case "$*" in *'If-None-Match: "sha256-${artifactDigest}"'*) unchanged=yes ;; esac
     while [ "$#" -gt 0 ]; do
-      if [ "$1" = --output ]; then output=$2; shift 2; else shift; fi
+      if [ "$1" = --output ]; then output=$2; shift 2
+      elif [ "$1" = --dump-header ]; then headers=$2; shift 2
+      else shift
+      fi
     done
-    [ -z "$output" ] || printf '%s' 'fixture-tarball' >"$output"
-    printf '%s' '${artifactStatus}'
+    [ -z "$headers" ] || printf '%s\n' 'HTTP/1.1 ${artifactStatus}' 'x-bb-artifact-sha256: ${artifactDigest}' >"$headers"
+    if [ "$unchanged" = yes ] && [ '${artifactStatus}' = 200 ]; then
+      printf '%s' 304
+    else
+      [ -z "$output" ] || printf '%s' 'fixture-tarball' >"$output"
+      printf '%s' '${artifactStatus}'
+    fi
     ;;
 esac
 `,
@@ -199,7 +216,11 @@ done
 mkdir -p "$prefix/bin"
 cp "${bbAppTemplatePath}" "$prefix/bin/bb-app"
 chmod +x "$prefix/bin/bb-app"
-for module in better-sqlite3 node-pty; do
+cp "${bbAppTemplatePath}" "$prefix/bin/bb"
+chmod +x "$prefix/bin/bb"
+mkdir -p "$prefix/lib/node_modules/bb-app/host-daemon/dist"
+printf '%s\n' 'fixture' >"$prefix/lib/node_modules/bb-app/host-daemon/dist/daemon-bundle.mjs"
+for module in node-pty @parcel/watcher; do
   mkdir -p "$prefix/lib/node_modules/bb-app/node_modules/$module"
   if [ -z "$FAKE_NPM_SKIP_NATIVE_MODULES" ]; then
     printf '%s\n' 'module.exports = {};' >"$prefix/lib/node_modules/bb-app/node_modules/$module/index.js"
@@ -304,7 +325,10 @@ describe("machine install script", () => {
       BB_INSTALL_SKIP_SERVICE: "1",
     });
 
-    expect(result.status, result.stderr).toBe(0);
+    expect(
+      result.status,
+      `${result.stderr}\n${readFileSync(join(fixture.dataDir, "install-join.log"), "utf8")}`,
+    ).toBe(0);
     const selectedPort = readFileSync(
       join(fixture.dataDir, "host-daemon-port"),
       "utf8",
@@ -426,6 +450,53 @@ describe("machine install script", () => {
     process.kill(daemonPid, "SIGTERM");
   });
 
+  it("skips downloading and installing an identical host artifact", () => {
+    const fixture = createFixture();
+    writeServerInstallTools(fixture, 200);
+    const first = runScript(JOIN_ARGS, fixture, {
+      BB_INSTALL_SKIP_SERVICE: "1",
+    });
+    expect(first.status, first.stderr).toBe(0);
+
+    const second = runScript(JOIN_ARGS, fixture, {
+      BB_INSTALL_SKIP_SERVICE: "1",
+    });
+
+    expect(second.status, second.stderr).toBe(0);
+    expect(second.stdout).toContain(
+      "The identical server host artifact is already installed",
+    );
+    expect(
+      readFileSync(join(fixture.dataDir, "host-artifact.sha256"), "utf8"),
+    ).toBe(`${FIXTURE_ARTIFACT_DIGEST}\n`);
+    expect(
+      readFileSync(join(fixture.dataDir, "npm.log"), "utf8").trim().split("\n"),
+    ).toHaveLength(1);
+    expect(readFileSync(join(fixture.dataDir, "curl.log"), "utf8")).toContain(
+      `If-None-Match: "sha256-${FIXTURE_ARTIFACT_DIGEST}"`,
+    );
+    const daemonPid = Number(
+      readFileSync(join(fixture.dataDir, "install-daemon.pid"), "utf8"),
+    );
+    process.kill(daemonPid, "SIGTERM");
+  });
+
+  it("rejects a server host artifact whose digest does not match", () => {
+    const fixture = createFixture();
+    writeServerInstallTools(fixture, 200, "a".repeat(64));
+
+    const result = runScript(JOIN_ARGS, fixture, {
+      BB_INSTALL_SKIP_SERVICE: "1",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("failed SHA-256 verification");
+    expect(existsSync(join(fixture.dataDir, "npm.log"))).toBe(false);
+    expect(existsSync(join(fixture.dataDir, "host-artifact.sha256"))).toBe(
+      false,
+    );
+  });
+
   it("falls back to npm only when the server artifact returns 404", () => {
     const fixture = createFixture();
     writeServerInstallTools(fixture, 404);
@@ -453,7 +524,7 @@ describe("machine install script", () => {
 
     expect(result.status, result.stderr).toBe(1);
     expect(result.stderr).toContain(
-      "npm installed bb-app, but its native add-ons (better-sqlite3, node-pty) did not load.",
+      "npm installed bb-app, but its host native add-ons (node-pty, @parcel/watcher) did not load.",
     );
     expect(result.stderr).toContain(
       "npm_config_allow_scripts=better-sqlite3,node-pty,@parcel/watcher",

--- a/apps/server/test/app/skeleton.test.ts
+++ b/apps/server/test/app/skeleton.test.ts
@@ -62,7 +62,11 @@ describe("server skeleton", () => {
     const harness = await createTestAppHarness();
     const { app } = createApp(harness.deps, {
       bbAppArtifactService: {
-        getTarballPath: async () => "/unused",
+        getArtifact: async () => ({
+          digest: "a".repeat(64),
+          path: "/unused",
+          size: 0,
+        }),
         getVersion: async () => "3.2.1-test",
       },
     });
@@ -82,16 +86,28 @@ describe("server skeleton", () => {
     const harness = await createTestAppHarness();
     const tarballPath = join(harness.config.dataDir, "fixture.tgz");
     writeFileSync(tarballPath, "tarball-bytes");
-    const getTarballPath = vi.fn(async () => tarballPath);
+    const digest = "b".repeat(64);
+    const getArtifact = vi.fn(async () => ({
+      digest,
+      path: tarballPath,
+      size: 13,
+    }));
     const { app } = createApp(harness.deps, {
-      bbAppArtifactService: { getTarballPath, getVersion: async () => "test" },
+      bbAppArtifactService: { getArtifact, getVersion: async () => "test" },
     });
     try {
       const response = await app.request("/install/bb-app.tgz");
       expect(response.status).toBe(200);
       expect(response.headers.get("content-type")).toBe("application/gzip");
+      expect(response.headers.get("etag")).toBe(`"sha256-${digest}"`);
+      expect(response.headers.get("x-bb-artifact-sha256")).toBe(digest);
       expect(await response.text()).toBe("tarball-bytes");
-      expect(getTarballPath).toHaveBeenCalledOnce();
+      const unchanged = await app.request("/install/bb-app.tgz", {
+        headers: { "if-none-match": `"sha256-${digest}"` },
+      });
+      expect(unchanged.status).toBe(304);
+      expect(await unchanged.text()).toBe("");
+      expect(getArtifact).toHaveBeenCalledTimes(2);
     } finally {
       await harness.cleanup();
     }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -566,10 +566,14 @@ machine. The current value is readable through the host API and
 
 Machine installation and daemon protocol repair use the owning server as the
 distribution source: `/install/version` reports the server package/protocol and
-`/install/bb-app.tgz` serves its exact installable package. The installer falls
-back to the npm registry only when the package route returns 404. It installs
-the package under the machine's bb data directory rather than npm's system-wide
-prefix, so enrollment needs neither `sudo` nor a global npm configuration.
+`/install/bb-app.tgz` serves its exact host-only package with a SHA-256 digest
+and strong ETag. That package contains the daemon, its workers and native
+dependencies, and the bundled `bb` CLI; it omits the server and web app. The
+installer verifies the digest and skips the download and npm install when its
+recorded installed digest receives `304 Not Modified`. It falls back to the npm
+registry only when the package route returns 404. It installs the package under
+the machine's bb data directory rather than npm's system-wide prefix, so
+enrollment needs neither `sudo` nor a global npm configuration.
 Installed services enable `--auto-update`; remove that flag from the launchd
 plist or systemd user unit and reload the service to opt out. Updates only move
 to a newer server protocol, retry failures with a persisted exponential backoff

--- a/docs/multiple-devices.md
+++ b/docs/multiple-devices.md
@@ -173,16 +173,18 @@ not directly reachable from another machine. When bb connect is not paired and
 the server URL is a loopback or unspecified address, the dialog does not show an
 installer. It links to Settings → Remote access instead.
 
-The installer always installs the exact `bb-app` package exposed by that
-server at `/install/bb-app.tgz`; a `bb-app` already on PATH is reused, and the
-npm registry consulted, only when the server provides no package. Version
-strings cannot distinguish unpublished builds, so this keeps remote machines
-aligned with development and pre-release servers whose build may not exist on
-npm. The package route is public like `/install.sh`: `bb-app` is public
-software, and exposing an unpublished build slightly early through a paired
-tunnel is an accepted tradeoff. npm installs the package into the machine's bb
-data directory, not its system-wide global prefix, so enrollment needs neither
-`sudo` nor a PATH change.
+The installer always installs the exact host-only `bb-app` package exposed by
+that server at `/install/bb-app.tgz`. The package contains the host daemon,
+provider/plugin workers, native host dependencies, and bundled `bb` CLI, but no
+web app or server. A `bb-app` already on PATH is reused, and the npm registry
+consulted, only when the server provides no package. Version strings cannot
+distinguish unpublished builds, so the route also publishes a SHA-256 digest.
+The installer verifies that digest and uses a conditional request on later runs
+to skip an identical installed artifact. The package route is public like
+`/install.sh`: `bb-app` is public software, and exposing an unpublished build
+slightly early through a paired tunnel is an accepted tradeoff. npm installs
+the package into the machine's bb data directory, not its system-wide global
+prefix, so enrollment needs neither `sudo` nor a PATH change.
 
 Each joined server gets its own daemon instance, data directory
 (`~/.bb-machines/<server-host>`, override with `BB_DATA_DIR` when running the
@@ -198,7 +200,10 @@ bb versions on one machine remain isolated.
 
 The installed launchd/systemd service enables `--auto-update`. If session open
 reports a newer server protocol, the daemon downloads the server artifact,
-updates its private install, then exits so the service manager restarts it.
+verifies its SHA-256 digest, updates its private install, then exits so the
+service manager restarts it. If the identical artifact is already installed,
+the server returns `304` and the daemon restarts without downloading or running
+npm again.
 Failed attempts fall back to normal reconnect behavior with a persisted
 exponential retry backoff from 5 seconds to 5 minutes. Settings → Machines and
 `bb machine retry-update <id-or-name>` can bypass the current backoff. A daemon

--- a/packages/bb-app/package.json
+++ b/packages/bb-app/package.json
@@ -61,6 +61,7 @@
   },
   "scripts": {
     "build": "node scripts/build.mjs",
+    "build:host": "node scripts/build-host.mjs",
     "clean": "rimraf dist app host-daemon server tsconfig.tsbuildinfo",
     "prepack": "node dist/prune-bb-chunks.mjs",
     "smoke:tarball": "node scripts/smoke-tarball.mjs",

--- a/packages/bb-app/scripts/build-host.mjs
+++ b/packages/bb-app/scripts/build-host.mjs
@@ -1,0 +1,124 @@
+import {
+  chmod,
+  copyFile,
+  mkdir,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  buildNodeEsmEntry,
+  copyDirectory,
+  pruneUnreferencedChunks,
+} from "../../../scripts/build-utils.mjs";
+
+const scriptsDir = dirname(fileURLToPath(import.meta.url));
+const packageRoot = resolve(scriptsDir, "..");
+const workspaceRoot = resolve(packageRoot, "..", "..");
+const hostPackageRoot = resolve(packageRoot, "host-package");
+const hostDaemonSource = resolve(workspaceRoot, "apps", "host-daemon", "dist");
+const hostDaemonTarget = resolve(hostPackageRoot, "host-daemon", "dist");
+const dependencyNames = [
+  "@parcel/watcher",
+  "node-pty",
+  "pino",
+  "pino-pretty",
+  "pino-roll",
+];
+const hostDaemonFiles = [
+  "bb-parcel-watcher-child.mjs",
+  "bb-plugin-host-worker.mjs",
+  "bb-provider-bridge-worker.mjs",
+  "daemon-bundle.mjs",
+];
+
+const sourcePackageJson = JSON.parse(
+  await readFile(resolve(packageRoot, "package.json"), "utf8"),
+);
+const dependencies = Object.fromEntries(
+  dependencyNames.map((name) => {
+    const version = sourcePackageJson.dependencies?.[name];
+    if (typeof version !== "string") {
+      throw new Error(`Missing bb host dependency ${name}`);
+    }
+    return [name, version];
+  }),
+);
+
+await rm(hostPackageRoot, { force: true, recursive: true });
+await buildNodeEsmEntry({
+  cleanDist: true,
+  entryPoint: resolve(packageRoot, "src", "bin", "bb-app.ts"),
+  executable: true,
+  outfile: resolve(hostPackageRoot, "dist", "bb-app.js"),
+  packageRoot: hostPackageRoot,
+  sourcemap: false,
+});
+await buildNodeEsmEntry({
+  cleanDist: false,
+  entryPoint: resolve(packageRoot, "src", "bin", "bb.ts"),
+  executable: true,
+  outfile: resolve(hostPackageRoot, "dist", "bb.js"),
+  packageRoot: hostPackageRoot,
+  sourcemap: false,
+});
+await buildNodeEsmEntry({
+  cleanDist: false,
+  entryPoint: resolve(packageRoot, "src", "bin", "bb-host-daemon.ts"),
+  executable: true,
+  outfile: resolve(hostPackageRoot, "dist", "bb-host-daemon.js"),
+  packageRoot: hostPackageRoot,
+  sourcemap: false,
+});
+
+await mkdir(hostDaemonTarget, { recursive: true });
+await copyFile(
+  resolve(hostDaemonSource, "bb"),
+  resolve(hostDaemonTarget, "bb"),
+);
+await chmod(resolve(hostDaemonTarget, "bb"), 0o755);
+await copyDirectory({
+  from: resolve(hostDaemonSource, "bb-chunks"),
+  to: resolve(hostDaemonTarget, "bb-chunks"),
+});
+await pruneUnreferencedChunks({
+  chunkDir: resolve(hostDaemonTarget, "bb-chunks"),
+  entry: resolve(hostDaemonTarget, "bb"),
+});
+for (const fileName of hostDaemonFiles) {
+  await copyFile(
+    resolve(hostDaemonSource, fileName),
+    resolve(hostDaemonTarget, fileName),
+  );
+}
+
+await copyFile(
+  resolve(packageRoot, "README.md"),
+  resolve(hostPackageRoot, "README.md"),
+);
+await writeFile(
+  resolve(hostPackageRoot, "package.json"),
+  `${JSON.stringify(
+    {
+      name: sourcePackageJson.name,
+      version: sourcePackageJson.version,
+      description: "bb enrolled host runtime",
+      type: "module",
+      os: sourcePackageJson.os,
+      bin: {
+        bb: "dist/bb.js",
+        "bb-app": "dist/bb-app.js",
+        "bb-host-daemon": "dist/bb-host-daemon.js",
+      },
+      files: ["dist", "host-daemon", "README.md"],
+      engines: sourcePackageJson.engines,
+      dependencies,
+    },
+    null,
+    2,
+  )}\n`,
+);
+
+process.stdout.write("bb-app: built enrolled host package\n");

--- a/packages/bb-app/src/launcher.ts
+++ b/packages/bb-app/src/launcher.ts
@@ -2103,9 +2103,8 @@ async function runClientCommand(args: RunClientCommandArgs): Promise<void> {
   );
 }
 
-function requiredArtifactPaths(context: BbAppStartContext): ArtifactPath[] {
+function requiredHostArtifactPaths(context: BbAppStartContext): ArtifactPath[] {
   return [
-    { kind: "file", label: "server entry", path: context.serverEntry },
     { kind: "file", label: "host daemon entry", path: context.daemonEntry },
     {
       kind: "file",
@@ -2132,6 +2131,15 @@ function requiredArtifactPaths(context: BbAppStartContext): ArtifactPath[] {
       label: "plugin host worker",
       path: join(context.daemonBundleDir, "bb-plugin-host-worker.mjs"),
     },
+  ];
+}
+
+function requiredFullStackArtifactPaths(
+  context: BbAppStartContext,
+): ArtifactPath[] {
+  return [
+    ...requiredHostArtifactPaths(context),
+    { kind: "file", label: "server entry", path: context.serverEntry },
     {
       kind: "file",
       label: "web app",
@@ -2161,12 +2169,23 @@ function artifactPresent(artifact: ArtifactPath): boolean {
 }
 
 export function assertBbAppArtifacts(context: BbAppStartContext): void {
-  const missingArtifact = requiredArtifactPaths(context).find(
+  const missingArtifact = requiredFullStackArtifactPaths(context).find(
     (artifact) => !artifactPresent(artifact),
   );
   if (missingArtifact) {
     throw new Error(
       `Missing ${missingArtifact.label} at ${missingArtifact.path}. Rebuild bb-app before running this package.`,
+    );
+  }
+}
+
+export function assertBbHostArtifacts(context: BbAppStartContext): void {
+  const missingArtifact = requiredHostArtifactPaths(context).find(
+    (artifact) => !artifactPresent(artifact),
+  );
+  if (missingArtifact) {
+    throw new Error(
+      `Missing ${missingArtifact.label} at ${missingArtifact.path}. Rebuild the bb host artifact before running this package.`,
     );
   }
 }
@@ -2751,7 +2770,7 @@ export async function runBbCli(
     options: createDefaultLauncherOptions(),
     serverUrlMode: "managed",
   });
-  assertBbAppArtifacts(runtime.context);
+  assertBbHostArtifacts(runtime.context);
   process.exitCode = await runBundledCliCommand({
     args: cliArgs,
     context: runtime.context,
@@ -2965,7 +2984,7 @@ Usage:
     options: parsedArgs.options,
     serverUrlMode: "managed",
   });
-  assertBbAppArtifacts(runtime.context);
+  assertBbHostArtifacts(runtime.context);
   await runHostDaemonOnly({
     args: parsedArgs.positionals,
     context: runtime.context,
@@ -3374,9 +3393,8 @@ export async function runBbApp(
     return;
   }
 
-  assertBbAppArtifacts(runtime.context);
-
   if (command.kind === "host-daemon") {
+    assertBbHostArtifacts(runtime.context);
     await runHostDaemonOnly({
       args: command.args,
       context: runtime.context,
@@ -3384,6 +3402,8 @@ export async function runBbApp(
     });
     return;
   }
+
+  assertBbAppArtifacts(runtime.context);
 
   const context = runtime.context;
   const serverListenerUrl = resolveServerListenerUrl({

--- a/packages/bb-app/test/index.test.ts
+++ b/packages/bb-app/test/index.test.ts
@@ -22,6 +22,7 @@ import { z } from "zod";
 import { resolvePortFromEnv } from "@bb/config/runtime";
 import {
   assertBbAppArtifacts,
+  assertBbHostArtifacts,
   completeFullStackSupervision,
   createDaemonEnv,
   createHostEnrollKeyRequestBody,
@@ -2179,6 +2180,13 @@ describe("bb-app launcher", () => {
 
       writeFileSync(join(chunkDir, "chunk-AAAAAAAA.js"), "");
       expect(() => assertBbAppArtifacts(context)).not.toThrow();
+
+      rmSync(context.serverEntry);
+      rmSync(join(context.appDistDir, "index.html"));
+      expect(() => assertBbHostArtifacts(context)).not.toThrow();
+      expect(() => assertBbAppArtifacts(context)).toThrow(
+        /^Missing server entry/u,
+      );
     } finally {
       rmSync(packageRoot, { recursive: true, force: true });
     }

--- a/turbo.json
+++ b/turbo.json
@@ -152,6 +152,23 @@
       ],
       "outputs": ["app/**", "dist/**", "host-daemon/**", "server/**"]
     },
+    "bb-app#build:host": {
+      "dependsOn": ["@bb/host-daemon#build"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/apps/host-daemon/dist/**",
+        "$TURBO_ROOT$/packages/bb-app/package.json",
+        "$TURBO_ROOT$/packages/bb-app/scripts/build-host.mjs",
+        "$TURBO_ROOT$/packages/bb-app/src/**",
+        "$TURBO_ROOT$/packages/bb-app/tsconfig.json",
+        "$TURBO_ROOT$/packages/config/package.json",
+        "$TURBO_ROOT$/packages/config/src/**",
+        "$TURBO_ROOT$/packages/config/tsconfig.json",
+        "$TURBO_ROOT$/packages/tsconfig/*.json",
+        "$TURBO_ROOT$/scripts/build-utils.mjs"
+      ],
+      "outputs": ["host-package/**"]
+    },
     "bb-plugin-tasks#build": {
       // The tasks plugin's app bundle imports the @get-bb/plugin-sdk root at
       // runtime (shared RPC contract), so the SDK dist must exist first.


### PR DESCRIPTION
## Human comments

## What was wrong

The enrolled-machine installer and protocol updater consumed the same complete `bb-app` tarball as local and desktop installations. That artifact included the server, web application, SDK output, and dependencies a remote execution machine never launches, while the route exposed no content identity that could distinguish an identical unpublished build and safely avoid another download and npm install.

## What changed

- Add a dedicated Turbo `bb-app#build:host` package containing the host daemon, provider/plugin workers, reachable bundled CLI chunks, the `bb`, `bb-app`, and `bb-host-daemon` bins, and only host runtime dependencies. The source-tree route builds it directly; a packaged server materializes the equivalent host package from its full distribution for release compatibility.
- Content-address generated tarballs by SHA-256 and publish the digest through a strong ETag and `x-bb-artifact-sha256` while retaining `/install/version` and `/install/bb-app.tgz`. Conditional requests return `304` with no artifact bytes.
- Make `install.sh` and protocol self-update verify the advertised digest, persist it only after a valid install, and skip downloading/running npm when the identical artifact is already installed. Legacy responses without the digest and the existing PATH/npm-registry fallbacks remain supported.
- Split launcher artifact validation so daemon and CLI entrypoints do not require server/web assets. Keep the existing exact package version, bin names, enrollment flags, launchd/systemd paths, and update prefix.
- Document the host-only distribution and update behavior. No public command or configuration changed, so no CLI guide surface changed.
- `HOST_DAEMON_PROTOCOL_VERSION` remains 177 because the session, WebSocket, and host-RPC contracts are unchanged. The HTTP metadata is additive; new clients accept legacy servers without it and older clients ignore it.

Measured on macOS with Node 22.23.1 and warm npm dependencies:

| Metric | Full artifact | Host artifact | Reduction |
| --- | ---: | ---: | ---: |
| Compressed tarball | 39,602,419 B | 1,236,936 B | 96.9% |
| Unpacked tarball | 177,646,835 B | 5,877,691 B | 96.7% |
| Files | 2,063 | 43 | 97.9% |
| Forced Turbo build | 53.83 s | 13.09 s | 75.7% |
| `npm pack` | 16.20 s | 0.28 s | 98.3% |
| Fresh installed footprint | 267,087,872 B | 65,912,832 B | 75.3% |
| Fresh install | 5.20 s | 0.77 s | 85.2% |

The old route transferred 39,602,419 bytes on every request. The new route transferred 1,236,936 bytes once and returned `304`/zero bytes for the identical repeat. Two independent packs produced SHA-256 `26e365744761a80d434052151181f311caa1d67ca2d24ef6724df814db6fb033`.

## How you verified

The new artifact, installer, route, and updater assertions fail against the previous full-package/no-digest behavior and pass with this change.

- `pnpm exec turbo run test --filter=@bb/server --force -- test/app/bb-app-artifact.test.ts test/app/install-machine-script.test.ts test/app/skeleton.test.ts` — 43 tests passed.
- `pnpm exec turbo run test --filter=@bb/host-daemon --force -- src/protocol-self-update.test.ts` — 15 tests passed.
- `pnpm exec turbo run test --filter=bb-app --force` — 73 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/server --filter=@bb/host-daemon --filter=bb-app --force` — 7 Turbo tasks passed.
- `pnpm exec turbo run build --filter=bb-app` — 12 Turbo tasks passed.
- `pnpm exec turbo run build:host --filter=bb-app --force` — 6 Turbo tasks passed.
- Installed the exact `0.41.0` host tarball into a clean prefix and exercised all three bins.
- Enrolled the packaged daemon against a fresh local server, observed connected status, and used its bundled `bb machine list --json` successfully.
- Ran the real updater with npm: first install completed in 771 ms and persisted the verified digest; the identical second request returned `304` and completed in 5 ms without npm.
- Upgraded an existing full private-prefix install in place: 267,087,872 B to 65,851,392 B in 1.15 s, with server/web payloads removed and all host bins working.
- Verified shell syntax, Prettier, deterministic packing, artifact contents, response digest, and `git diff --check`.

Fixes #2968

> AGENT GENERATED