### PR TITLE
Avoid redundant launchd restart during host enrollment

### DIFF
--- a/apps/server/src/assets/install-machine.sh
+++ b/apps/server/src/assets/install-machine.sh
@@ -715,12 +715,6 @@ EOF
     [ -z "$launchctl_error" ] || detail "launchctl: $launchctl_error" >&2
     exit 1
   fi
-  if ! launchctl_error=$(launchctl kickstart -k "gui/$(id -u)/$service_label" 2>&1); then
-    fail_step "The bb host-daemon launch agent was registered, but the daemon did not start."
-    [ -z "$launchctl_error" ] || detail "launchctl: $launchctl_error" >&2
-    detail "See $data_dir/logs/launchd.log for the daemon error." >&2
-    exit 1
-  fi
   if ! wait_for_daemon_connection "the launch agent"; then
     fail_step "The bb host-daemon launch agent started but did not connect to $server_url."
     detail "See $data_dir/logs/launchd.log for the daemon error." >&2

--- a/apps/server/test/app/install-machine-script.test.ts
+++ b/apps/server/test/app/install-machine-script.test.ts
@@ -728,7 +728,7 @@ setInterval(() => {}, 1000);
     expect(result.stderr).toContain("Timed out waiting for host daemon");
   });
 
-  it("installs an idempotent macOS launch agent for joined state", () => {
+  it("starts a fresh macOS launch agent once and replaces it with one new process", () => {
     const fixture = createFixture();
     writeJoinedState(fixture);
     writeServerInstallTools(fixture, 200);
@@ -737,18 +737,34 @@ setInterval(() => {}, 1000);
       join(fixture.binDir, "launchctl"),
       `#!/bin/sh
 printf '%s\n' "$*" >>"${join(fixture.dataDir, "launchctl.log")}"
-if [ "$1" = kickstart ]; then
+if [ "$1" = bootout ] && [ -f "${join(fixture.dataDir, "service-daemon.pid")}" ]; then
+  service_pid=$(sed -n '1p' "${join(fixture.dataDir, "service-daemon.pid")}")
+  kill "$service_pid" 2>/dev/null || true
+  attempts=0
+  while kill -0 "$service_pid" 2>/dev/null && [ "$attempts" -lt 100 ]; do
+    attempts=$((attempts + 1))
+    sleep 0.01
+  done
+  rm -f "${join(fixture.dataDir, "service-daemon.pid")}"
+fi
+if [ "$1" = bootstrap ]; then
   port=$(sed -n '1p' "${join(fixture.dataDir, "host-daemon-port")}")
   BB_DATA_DIR="${fixture.dataDir}" "${join(fixture.dataDir, "npm/bin/bb-app")}" host-daemon --host-daemon-port "$port" --server-url https://machine.getbb.app >/dev/null 2>&1 &
   echo $! >"${join(fixture.dataDir, "service-daemon.pid")}"
+  printf 'start\n' >>"${join(fixture.dataDir, "launchctl-starts.log")}"
+fi
+if [ "$1" = kickstart ]; then
+  printf '%s\n' 'unexpected kickstart' >&2
+  exit 70
 fi
 `,
     );
 
-    const result = runScript(
+    const firstResult = runScript([...JOIN_ARGS], fixture);
+    const secondResult = runScript(
       [
         "--join-code",
-        "unused-fresh-code",
+        "unused-reinstall-code",
         "--host-id",
         "host-test",
         "--server",
@@ -757,15 +773,20 @@ fi
       fixture,
     );
 
-    expect(result.status, result.stderr).toBe(0);
-    expect(result.stdout).toContain("already joined");
-    expect(result.stdout).toContain(
+    expect(firstResult.status, firstResult.stderr).toBe(0);
+    expect(firstResult.stdout).toContain("already joined");
+    expect(firstResult.stdout).toContain(
       "Installing the persistent bb host daemon service",
     );
-    expect(result.stdout).toContain("Waiting for the launch agent to connect");
-    expect(result.stdout).toContain("  ●  bb machine is ready");
-    expect(result.stdout).toContain("server  https://machine.getbb.app");
-    expect(result.stdout).toContain(
+    expect(firstResult.stdout).toContain(
+      "Waiting for the launch agent to connect",
+    );
+    expect(firstResult.stdout).toContain("  ●  bb machine is ready");
+    expect(secondResult.status, secondResult.stderr).toBe(0);
+    expect(secondResult.stdout).toContain("already joined");
+    expect(secondResult.stdout).toContain("  ●  bb machine is ready");
+    expect(secondResult.stdout).toContain("server  https://machine.getbb.app");
+    expect(secondResult.stdout).toContain(
       "service " +
         join(
           fixture.homeDir,
@@ -782,6 +803,8 @@ fi
     expect(plist).toContain(
       "<string>app.getbb.host-daemon.machine-getbb-app</string>",
     );
+    expect(plist).toContain("<key>RunAtLoad</key><true/>");
+    expect(plist).toContain("<key>KeepAlive</key><true/>");
     expect(plist).toContain("<string>host-daemon</string>");
     expect(plist).toContain("<string>--auto-update</string>");
     const selectedPort = readFileSync(
@@ -795,10 +818,70 @@ fi
     expect(plist).toContain(
       `<key>BB_APP_NPM_PREFIX</key><string>${realpathSync(fixture.dataDir)}/npm</string>`,
     );
+    const serviceFile = join(
+      fixture.homeDir,
+      "Library/LaunchAgents/app.getbb.host-daemon.machine-getbb-app.plist",
+    );
+    const domain = `gui/${process.getuid?.()}`;
+    expect(readFileSync(join(fixture.dataDir, "launchctl.log"), "utf8")).toBe(
+      `bootout ${domain} ${serviceFile}\nbootstrap ${domain} ${serviceFile}\nbootout ${domain} ${serviceFile}\nbootstrap ${domain} ${serviceFile}\n`,
+    );
     expect(
-      readFileSync(join(fixture.dataDir, "launchctl.log"), "utf8"),
-    ).toContain("bootstrap");
+      readFileSync(join(fixture.dataDir, "launchctl-starts.log"), "utf8"),
+    ).toBe("start\nstart\n");
   });
+
+  it("reports launchctl bootstrap failures", () => {
+    const fixture = createFixture();
+    writeJoinedState(fixture);
+    writeServerInstallTools(fixture, 200);
+    writeExecutable(join(fixture.binDir, "uname"), "#!/bin/sh\necho Darwin\n");
+    writeExecutable(
+      join(fixture.binDir, "launchctl"),
+      `#!/bin/sh
+printf '%s\n' "$*" >>"${join(fixture.dataDir, "launchctl.log")}"
+if [ "$1" = bootstrap ]; then
+  printf '%s\n' 'fixture bootstrap failure' >&2
+  exit 36
+fi
+`,
+    );
+
+    const result = runScript(JOIN_ARGS, fixture);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "Could not register the bb host-daemon launch agent app.getbb.host-daemon.machine-getbb-app.",
+    );
+    expect(result.stderr).toContain("launchctl: fixture bootstrap failure");
+  });
+
+  it("treats launch-agent readiness as authoritative after bootstrap", () => {
+    const fixture = createFixture();
+    writeJoinedState(fixture);
+    writeServerInstallTools(fixture, 200);
+    writeExecutable(join(fixture.binDir, "uname"), "#!/bin/sh\necho Darwin\n");
+    writeExecutable(
+      join(fixture.binDir, "launchctl"),
+      `#!/bin/sh
+printf '%s\n' "$*" >>"${join(fixture.dataDir, "launchctl.log")}"
+`,
+    );
+    writeExecutable(join(fixture.binDir, "sleep"), "#!/bin/sh\nexit 0\n");
+
+    const result = runScript(JOIN_ARGS, fixture);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "The bb host-daemon launch agent started but did not connect to https://machine.getbb.app.",
+    );
+    expect(result.stderr).toContain(
+      `See ${fixture.dataDir}/logs/launchd.log for the daemon error.`,
+    );
+    expect(result.stdout).toContain(
+      "Still waiting for the launch agent (60/60 checks)",
+    );
+  }, 15_000);
 
   it("restarts an active Linux systemd user unit after replacing it", () => {
     const fixture = createFixture();


### PR DESCRIPTION
## Human comments

## What was wrong

The macOS installer bootstrapped a launch agent configured with both RunAtLoad and unconditional KeepAlive, then immediately ran kickstart -k. launchd already starts that job during bootstrap; -k can kill that just-started process and subject the replacement to launchd's default 10-second spawn throttle. The existing readiness check was therefore delayed by an unnecessary forced restart.

## What changed

- Remove only the macOS kickstart -k step, leaving replacement as bootout followed by bootstrap.
- Keep the existing connected-daemon readiness check authoritative after bootstrap.
- Cover first-time service registration, reinstall/replacement, bootstrap diagnostics, readiness diagnostics, and the exact absence of kickstart in the installer fixture.
- Make temporary executable fixtures independent of any ambient /tmp package type.
- Leave Linux/systemd behavior unchanged.
- No host-daemon wire contract changed, so HOST_DAEMON_PROTOCOL_VERSION is unchanged.

## How you verified

- Confirmed from the local macOS launchd.plist and launchctl manuals that KeepAlive implies RunAtLoad, RunAtLoad launches the job when loaded, kickstart -k kills a running service, and the default spawn throttle is 10 seconds.
- Measured a disposable real launchd agent on Apple Silicon macOS 26.5.1 from bootstrap invocation to successful WebSocket handshake. Three bootstrap-plus-kickstart trials took 10,129 ms, 10,162 ms, and 10,128 ms; three bootstrap-only trials took 139 ms, 71 ms, and 73 ms. This controlled service reproduced the launchd behavior but was not the production bb host daemon.
- Verified the new regression test fails against the old script because it observes the unexpected kickstart.
- pnpm exec turbo run test --filter=@bb/server --force -- test/app/install-machine-script.test.ts (19 passed)
- pnpm exec turbo run build typecheck --filter=@bb/server
- pnpm exec turbo run smoke:tarball --filter=bb-app
- sh -n apps/server/src/assets/install-machine.sh
- Compared the built installer asset byte-for-byte with the source and confirmed it contains no launchctl kickstart.
- Prettier check and git diff --check.

Fixes: N/A (standalone performance improvement)

> AGENT GENERATED
