### PR TITLE
Add numeric plugin setting descriptors

### DIFF
--- a/apps/app/src/components/plugin/PluginSettings.test.tsx
+++ b/apps/app/src/components/plugin/PluginSettings.test.tsx
@@ -129,6 +129,72 @@ describe("PluginSettingsForm", () => {
     );
   });
 
+  it("autosaves a number input on blur and unsets it when cleared", async () => {
+    const view = {
+      ok: true,
+      schema: {
+        retries: { type: "number", label: "Retries" },
+      },
+      values: { retries: 3 },
+    };
+    const requests: RecordedRequest[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init?: RequestInit) => {
+        requests.push({ url, init });
+        if (init?.method === "PUT") {
+          const body = JSON.parse(String(init.body)) as {
+            values: Record<string, unknown>;
+          };
+          return jsonOk({
+            ...view,
+            values: { ...view.values, ...body.values },
+          });
+        }
+        return jsonOk(view);
+      }),
+    );
+
+    const { wrapper } = createQueryClientTestHarness();
+    render(<PluginSettingsForm pluginId="demo" />, { wrapper });
+
+    const retries = (await screen.findByLabelText(
+      "Retries",
+    )) as HTMLInputElement;
+    expect(retries.type).toBe("number");
+    expect(retries.step).toBe("any");
+    expect(retries.value).toBe("3");
+
+    fireEvent.change(retries, { target: { value: "4.5" } });
+    expect(requests.some((request) => request.init?.method === "PUT")).toBe(
+      false,
+    );
+    fireEvent.blur(retries);
+
+    const put = await vi.waitFor(() => {
+      const request = requests.find(
+        (candidate) => candidate.init?.method === "PUT",
+      );
+      expect(request).toBeDefined();
+      return request;
+    });
+    expect(JSON.parse(String(put?.init?.body))).toEqual({
+      values: { retries: 4.5 },
+    });
+
+    await vi.waitFor(() => expect(retries.value).toBe("4.5"));
+    fireEvent.change(retries, { target: { value: "" } });
+    fireEvent.blur(retries);
+    await vi.waitFor(() =>
+      expect(
+        requests.filter((request) => request.init?.method === "PUT"),
+      ).toHaveLength(2),
+    );
+    expect(JSON.parse(String(requests.at(-1)?.init?.body))).toEqual({
+      values: { retries: null },
+    });
+  });
+
   it("preserves text typed while an older save is pending", async () => {
     const first = deferred<Response>();
     const second = deferred<Response>();

--- a/apps/app/src/components/plugin/PluginSettings.tsx
+++ b/apps/app/src/components/plugin/PluginSettings.tsx
@@ -205,6 +205,29 @@ function PluginSettingField({
     );
   }
 
+  if (descriptor.type === "number") {
+    const value =
+      typeof draft === "string"
+        ? draft
+        : typeof storedValue === "number"
+          ? String(storedValue)
+          : "";
+    return (
+      <Input
+        type="number"
+        inputMode="decimal"
+        step="any"
+        value={value}
+        aria-label={descriptor.label}
+        aria-describedby={ariaDescribedBy}
+        aria-invalid={ariaInvalid}
+        onChange={(event) => onChange(event.target.value)}
+        onBlur={onBlur}
+        className="h-7 w-full text-xs sm:w-64"
+      />
+    );
+  }
+
   const isSecret = descriptor.secret === true;
   const secretIsSet =
     isSecret &&
@@ -257,6 +280,9 @@ function initialSettingDraft(
   if (descriptor.type === "boolean") {
     return typeof storedValue === "boolean" ? storedValue : false;
   }
+  if (descriptor.type === "number") {
+    return typeof storedValue === "number" ? String(storedValue) : "";
+  }
   if (descriptor.type === "string" && descriptor.secret === true) return "";
   return typeof storedValue === "string" ? storedValue : "";
 }
@@ -284,10 +310,20 @@ function AutosavingPluginSetting({
   const draft = draftState.value;
   const save = useMutation({
     scope: { id: `plugin-setting:${pluginId}:${settingKey}` },
-    mutationFn: (value: string | boolean) =>
-      updatePluginSettings(fetch, pluginId, {
-        [settingKey]: value,
-      }),
+    mutationFn: (value: string | boolean) => {
+      let settingValue: string | number | boolean | null = value;
+      if (descriptor.type === "number") {
+        const trimmed = typeof value === "string" ? value.trim() : "";
+        const parsed = Number(trimmed);
+        if (trimmed.length > 0 && !Number.isFinite(parsed)) {
+          throw new Error("Enter a finite number");
+        }
+        settingValue = trimmed.length === 0 ? null : parsed;
+      }
+      return updatePluginSettings(fetch, pluginId, {
+        [settingKey]: settingValue,
+      });
+    },
     onSuccess: (view) => {
       applyPluginSettingsView({ queryClient, pluginId, view });
     },
@@ -302,19 +338,33 @@ function AutosavingPluginSetting({
   function changeDraft(value: string | boolean): void {
     setDraftState({
       value,
-      hasNewerDraft: descriptor.type === "string",
+      hasNewerDraft:
+        descriptor.type === "string" || descriptor.type === "number",
     });
     if (!save.isPending) save.reset();
-    if (descriptor.type !== "string") {
+    if (descriptor.type !== "string" && descriptor.type !== "number") {
       save.mutate(value);
     }
   }
 
   function saveDraft(): void {
-    if (descriptor.type !== "string") return;
+    if (descriptor.type !== "string" && descriptor.type !== "number") return;
+    if (descriptor.type === "number") {
+      const trimmed = typeof draft === "string" ? draft.trim() : "";
+      const parsed = Number(trimmed);
+      if (
+        (trimmed.length === 0 && storedValue === undefined) ||
+        (trimmed.length > 0 && parsed === storedValue && !save.isPending)
+      ) {
+        setDraftState({ value: draft, hasNewerDraft: false });
+        return;
+      }
+    }
     if (
       (draft === storedValue && !save.isPending) ||
-      (descriptor.secret === true && draft === "")
+      (descriptor.type === "string" &&
+        descriptor.secret === true &&
+        draft === "")
     ) {
       setDraftState({ value: draft, hasNewerDraft: false });
       return;

--- a/apps/app/src/lib/plugin-sdk-hooks.test.ts
+++ b/apps/app/src/lib/plugin-sdk-hooks.test.ts
@@ -121,7 +121,7 @@ describe("callPluginRpc", () => {
 });
 
 describe("fetchPluginSdkSettings", () => {
-  it("keeps string/boolean values and excludes secret markers by shape", async () => {
+  it("keeps primitive setting values and excludes secret markers by shape", async () => {
     const fetchImpl = vi.fn<FetchLike>(async () =>
       jsonResponse({
         ok: true,
@@ -130,13 +130,14 @@ describe("fetchPluginSdkSettings", () => {
           greeting: "hello",
           enabled: true,
           apiKey: { set: true },
-          weird: 42,
+          retries: 4,
         },
       }),
     );
     await expect(fetchPluginSdkSettings(fetchImpl, "demo")).resolves.toEqual({
       greeting: "hello",
       enabled: true,
+      retries: 4,
     });
     expect(fetchImpl).toHaveBeenCalledWith("/api/v1/plugins/demo/settings");
   });

--- a/apps/app/src/lib/plugin-sdk-hooks.ts
+++ b/apps/app/src/lib/plugin-sdk-hooks.ts
@@ -177,7 +177,7 @@ export async function callPluginRpc(
 export async function fetchPluginSdkSettings(
   fetchImpl: FetchLike,
   pluginId: string,
-): Promise<Record<string, string | boolean> | null> {
+): Promise<Record<string, string | number | boolean> | null> {
   const response = await fetchImpl(
     `/api/v1/plugins/${encodeURIComponent(pluginId)}/settings`,
   );
@@ -193,9 +193,13 @@ export async function fetchPluginSdkSettings(
   ) {
     return null;
   }
-  const values: Record<string, string | boolean> = {};
+  const values: Record<string, string | number | boolean> = {};
   for (const [key, value] of Object.entries(body.values)) {
-    if (typeof value === "string" || typeof value === "boolean") {
+    if (
+      typeof value === "string" ||
+      (typeof value === "number" && Number.isFinite(value)) ||
+      typeof value === "boolean"
+    ) {
       values[key] = value;
     }
   }

--- a/apps/cli/src/__tests__/command-output/plugin-config.test.ts
+++ b/apps/cli/src/__tests__/command-output/plugin-config.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  runCommand,
+  setupCommandOutputTestEnvironment,
+  type CommandRegistrar,
+} from "../helpers/command-output-harness.js";
+import { registerPluginCommands } from "../../commands/plugin.js";
+
+function settingsResponse(value: number): Response {
+  return new Response(
+    JSON.stringify({
+      ok: true,
+      schema: {
+        retries: { type: "number", label: "Retries", default: 3 },
+      },
+      values: { retries: value },
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+describe("bb plugin config", () => {
+  setupCommandOutputTestEnvironment();
+
+  const register: CommandRegistrar = (program) =>
+    registerPluginCommands(program, () => "http://server");
+
+  it("converts a declared number before sending the settings update", async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(settingsResponse(3))
+      .mockResolvedValueOnce(settingsResponse(4.5));
+
+    await runCommand(
+      ["plugin", "config", "demo", "set", "retries", "4.5"],
+      register,
+    );
+
+    expect(fetch).toHaveBeenNthCalledWith(
+      2,
+      "http://server/api/v1/plugins/demo/settings",
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({ values: { retries: 4.5 } }),
+      }),
+    );
+  });
+
+  it("rejects a non-finite number before sending an update", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(settingsResponse(3));
+
+    await expect(
+      runCommand(
+        ["plugin", "config", "demo", "set", "retries", "Infinity"],
+        register,
+      ),
+    ).rejects.toThrow("process.exit:1");
+    expect(console.error).toHaveBeenCalledWith(
+      'Setting "retries" is a number — pass a finite number.',
+    );
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/cli/src/commands/plugin.ts
+++ b/apps/cli/src/commands/plugin.ts
@@ -103,11 +103,11 @@ async function searchCatalog(
 }
 
 const pluginSettingDescriptorSchema = z.object({
-  type: z.enum(["string", "boolean", "select", "project"]),
+  type: z.enum(["string", "number", "boolean", "select", "project"]),
   label: z.string(),
   description: z.string().optional(),
   secret: z.literal(true).optional(),
-  default: z.union([z.string(), z.boolean()]).optional(),
+  default: z.union([z.string(), z.number().finite(), z.boolean()]).optional(),
   options: z.array(z.string()).optional(),
 });
 const pluginSettingsResultSchema = z.object({
@@ -740,7 +740,7 @@ function parseSettingValue(
   descriptor: PluginSettingDescriptor,
   key: string,
   raw: string,
-): string | boolean {
+): string | number | boolean {
   if (descriptor.type === "boolean") {
     if (raw === "true") return true;
     if (raw === "false") return false;
@@ -751,6 +751,17 @@ function parseSettingValue(
     console.error(
       `Setting "${key}" must be one of: ${descriptor.options?.join(", ") ?? ""}`,
     );
+    process.exit(1);
+  }
+  if (descriptor.type === "number") {
+    let value: unknown;
+    try {
+      value = JSON.parse(raw);
+    } catch {
+      value = undefined;
+    }
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+    console.error(`Setting "${key}" is a number — pass a finite number.`);
     process.exit(1);
   }
   return raw;
@@ -1589,7 +1600,7 @@ export function registerPluginCommands(
             );
             process.exit(1);
           }
-          let parsedValue: string | boolean | null = null;
+          let parsedValue: string | number | boolean | null = null;
           if (actionName === "set") {
             if (value === undefined) {
               console.error("Usage: bb plugin config <id> set <key> <value>");

--- a/apps/server/src/services/plugins/plugin-settings.ts
+++ b/apps/server/src/services/plugins/plugin-settings.ts
@@ -73,7 +73,26 @@ function parseStoredSettingValue(
       parsed = undefined;
     }
   }
-  const expected = descriptor.type === "boolean" ? "boolean" : "string";
+  if (descriptor.type === "number" && typeof parsed === "string") {
+    const legacyNumber = Number(parsed.trim());
+    parsed =
+      parsed.trim().length > 0 && Number.isFinite(legacyNumber)
+        ? legacyNumber
+        : undefined;
+  }
+  if (
+    descriptor.type === "number" &&
+    typeof parsed === "number" &&
+    !Number.isFinite(parsed)
+  ) {
+    parsed = undefined;
+  }
+  const expected =
+    descriptor.type === "boolean"
+      ? "boolean"
+      : descriptor.type === "number"
+        ? "number"
+        : "string";
   if (typeof parsed !== expected) parsed = undefined;
   if (
     descriptor.type === "select" &&

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/references/plugins.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/references/plugins.md
@@ -133,7 +133,8 @@
     schedules; managed git/npm files are deleted, and local path sources stay
     on disk).
   - `bb plugin config <id> [set <key> <value> | unset <key>]` — declared
-    settings. Reload the plugin after configuring (`bb plugin reload <id>`).
+    settings; boolean and number arguments are converted to their declared
+    types. Reload the plugin after configuring (`bb plugin reload <id>`).
   - `bb plugin token <id>` — print a short-lived bearer token for that plugin.
   - List, reload, enable, disable, config, and remove support `--json`.
   - `bb plugin logs <id> [-n N] [-f]` — the plugin's `bb.log` output.

--- a/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/references/backend-foundation.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/references/backend-foundation.md
@@ -39,7 +39,7 @@ are additive, so registering multiple listeners is supported.
 
 `bb.settings.define(descriptors)` declares settings descriptors (rendered
 in Extensions → Plugins and editable via `bb plugin config <id> set <key>
-<value>`). Four descriptor types:
+<value>`). Five descriptor types:
 
 ```ts
 import { z } from "zod";
@@ -63,12 +63,10 @@ const settings = bb.settings.define({
     default: "[]",
   },
   retries: {
-    type: "string",
+    type: "number",
     label: "Retries",
-    experimental_schema: z
-      .string()
-      .regex(/^[1-5]$/, "Retries must be from 1 through 5"),
-    default: "3",
+    experimental_schema: z.number().int().min(1).max(5),
+    default: 3,
   },
   notes: {
     type: "string",
@@ -95,8 +93,10 @@ settings.onChange((next, prev) => {
 ```
 
 Typing rule: a descriptor **with** `default` yields a non-optional value
-from `get()`; without one the value is `string | boolean | undefined` — so
-give non-secrets defaults and handle missing secrets explicitly.
+from `get()`; without one the value is `string | number | boolean | undefined`
+— so give non-secrets defaults and handle missing secrets explicitly. Number
+descriptors accept finite numbers and render a numeric input; use
+`experimental_schema` for integer and range constraints.
 
 `experimental_schema` accepts a synchronous, non-transforming Standard Schema
 validator; Zod schemas qualify. It runs on the server for settings-page

--- a/apps/server/test/services/plugins/plugin-authoring-docs.test.ts
+++ b/apps/server/test/services/plugins/plugin-authoring-docs.test.ts
@@ -177,6 +177,7 @@ void _assertAllApiKeysListed;
 
 const SETTING_DESCRIPTOR_TYPES = [
   "string",
+  "number",
   "boolean",
   "select",
   "project",

--- a/apps/server/test/services/plugins/plugin-settings-storage.test.ts
+++ b/apps/server/test/services/plugins/plugin-settings-storage.test.ts
@@ -17,6 +17,7 @@ import {
   createConnection,
   getPluginSettingsValues,
   migrate,
+  setPluginSettingsValues,
   type DbConnection,
 } from "@bb/db";
 import type { Logger } from "@bb/logger";
@@ -117,6 +118,7 @@ describe("plugin settings + storage", () => {
               teamKey: { type: "string", label: "Team key", default: "ENG" },
               mode: { type: "select", label: "Mode", options: ["fast", "slow"], default: "fast" },
               autoSync: { type: "boolean", label: "Sync automatically", default: true },
+              retries: { type: "number", label: "Retries", default: 3 },
               note: { type: "string", label: "Note" },
             });
             const g = globalThis as any;
@@ -148,8 +150,20 @@ describe("plugin settings + storage", () => {
         teamKey: "ENG",
         mode: "fast",
         autoSync: true,
+        retries: 3,
         apiKey: undefined,
         note: undefined,
+      });
+    });
+
+    it("reads a legacy stored numeric string as a number", async () => {
+      await installConfigurable();
+      setPluginSettingsValues(db, "configurable", {
+        retries: JSON.stringify(" 5 "),
+      });
+
+      await expect(state().settings.get()).resolves.toMatchObject({
+        retries: 5,
       });
     });
 
@@ -158,6 +172,7 @@ describe("plugin settings + storage", () => {
       const view = await service.updateSettings("configurable", {
         apiKey: "sk-secret-123",
         autoSync: false,
+        retries: 4.5,
         note: "hello",
       });
 
@@ -174,6 +189,7 @@ describe("plugin settings + storage", () => {
       expect(view?.values.apiKey).toEqual({ set: true });
       expect(JSON.stringify(view)).not.toContain("sk-secret-123");
       expect(view?.values.autoSync).toBe(false);
+      expect(view?.values.retries).toBe(4.5);
       expect(view?.values.note).toBe("hello");
 
       expect(await state().settings.get()).toEqual({
@@ -181,6 +197,7 @@ describe("plugin settings + storage", () => {
         teamKey: "ENG",
         mode: "fast",
         autoSync: false,
+        retries: 4.5,
         note: "hello",
       });
 
@@ -298,6 +315,9 @@ describe("plugin settings + storage", () => {
       await expect(
         service.updateSettings("configurable", { autoSync: "yes" }),
       ).rejects.toThrow(/expects a boolean/);
+      await expect(
+        service.updateSettings("configurable", { retries: "4" }),
+      ).rejects.toThrow(/expects a finite number/);
       await expect(
         service.updateSettings("configurable", { mode: "warp" }),
       ).rejects.toThrow(/must be one of/);

--- a/docs/api_to_audit.md
+++ b/docs/api_to_audit.md
@@ -162,6 +162,23 @@ write.
   values and unsets, before stabilizing `experimental_set`.
 - Decide whether schemas and server-side writes stabilize independently.
 
+## `PluginSettingDescriptor` type `"number"`
+
+**What it does.** A numeric setting descriptor gives server code, provider
+configuration, and plugin UI a finite `number` instead of making each consumer
+parse a string. The host renders a number input and converts CLI values before
+validation. `experimental_schema` can enforce integer and range constraints.
+Stored numeric strings from settings created before this descriptor existed
+are read as numbers so migrated plugins preserve their configuration.
+
+**Audit before stabilizing.**
+
+- Decide whether common minimum, maximum, and step metadata belongs directly
+  on the descriptor instead of only in `experimental_schema`.
+- Confirm clearing a number input should continue to unset the stored value.
+- Decide how long legacy stored numeric strings should be coerced on read.
+- Exercise decimal and exponent input across browser engines and the CLI.
+
 ## `bb.experimental_hooks` (`on`, `recheck`)
 
 **What it does.** The one plugin surface that _decides_ rather than observes.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -854,8 +854,8 @@ nothing, because waiting does not fix them.
 
 The builtin Workflows plugin is disabled on fresh installations. Enable it
 under Extensions → Plugins or with `bb plugin enable workflows`. Its six
-settings accept base-10 integer strings through Extensions → Plugins or
-`bb plugin config workflows set <key> <value>`:
+settings are bounded integers, edited with numeric inputs under Extensions →
+Plugins or with `bb plugin config workflows set <key> <value>`:
 
 | Key                    |    Default |       Allowed range | Behavior                                               |
 | ---------------------- | ---------: | ------------------: | ------------------------------------------------------ |

--- a/packages/domain/src/plugin-sdk-version.ts
+++ b/packages/domain/src/plugin-sdk-version.ts
@@ -1,3 +1,3 @@
-export const PLUGIN_SDK_VERSION = "0.4.39";
+export const PLUGIN_SDK_VERSION = "0.4.40";
 
 export const PLUGIN_SDK_MAJOR = Number(PLUGIN_SDK_VERSION.split(".", 1)[0]);

--- a/packages/plugin-api-map/sdk-public-api.json
+++ b/packages/plugin-api-map/sdk-public-api.json
@@ -3,7 +3,7 @@
   "entries": {
     ".": {
       "types": "bundled-types/bb-plugin-sdk.d.ts",
-      "sha256": "8d20b180b058a09a637f000325ac99f00b9258dac9d4c44aa3330be3f06f4f57"
+      "sha256": "12ee61da01f416049d2b947a0856756b0eb11d33141a2596e13beb4d29eabaa9"
     },
     "./ai-services": {
       "types": "bundled-types/bb-plugin-sdk-ai-services.d.ts",
@@ -11,7 +11,7 @@
     },
     "./app": {
       "types": "bundled-types/bb-plugin-sdk-app.d.ts",
-      "sha256": "d8b17e4c887af101bfc0d50d37f48b6bb0cad11f86a6b2431d172fbe91d700e2"
+      "sha256": "181488175ba8447c2aacaadaca0b74d532d02f5b9f4dad16d34e83b9b881013c"
     },
     "./host": {
       "types": "bundled-types/bb-plugin-sdk-host.d.ts",
@@ -31,11 +31,11 @@
     },
     "./testing": {
       "types": "bundled-types/bb-plugin-sdk-testing.d.ts",
-      "sha256": "6c1eb48a1dcea18e35b8c40a92c57c5f9d8986f60cb1051ee314a5e199f65925"
+      "sha256": "94f3ab09f233362a6cf435a355be0be2272cba8a630d541aa81a545c50d0f86f"
     },
     "./testing/app": {
       "types": "bundled-types/bb-plugin-sdk-testing-app.d.ts",
-      "sha256": "4ebaad4c3ca379e0c233d5e6a9951ab966db94d9db27ca8008690b8dce002f52"
+      "sha256": "56fac5880ef60e36bab415525a254dffb5b670472c55a5e498aa27bd45414ba6"
     },
     "./testing/host": {
       "types": "bundled-types/bb-plugin-sdk-testing-host.d.ts",

--- a/packages/plugin-api-map/src/surfaces.ts
+++ b/packages/plugin-api-map/src/surfaces.ts
@@ -462,7 +462,7 @@ export const SURFACE_GROUPS: SurfaceGroup[] = [
         summary:
           "Declares the settings your plugin needs as plain data; bb renders the form for them on the plugin's settings page and stores the values. With this, a plugin can:",
         bullets: [
-          "Declare each field's type (text, toggle, choice, or project) with a label and an optional default",
+          "Declare each field's type (text, number, toggle, choice, or project) with a label and an optional default",
           "Get the form, its validation, and autosaving without writing any UI",
           "Validate each proposed value with a synchronous, non-transforming Standard Schema through `experimental_schema`; Zod schemas qualify",
           "Render multi-line text with `experimental_multiline`",

--- a/packages/plugin-api-map/src/wireframes.tsx
+++ b/packages/plugin-api-map/src/wireframes.tsx
@@ -1755,6 +1755,20 @@ export function SettingsWireframe() {
                 <span className="ml-auto size-3.5 rounded-full bg-background" />
               </span>
             </span>
+            <span className="flex items-start justify-between gap-3 py-1.5">
+              <span className="min-w-0">
+                <span className="block text-foreground">Retry attempts</span>
+                <span className="block pt-1 leading-relaxed">
+                  Maximum retries before stopping.
+                </span>
+              </span>
+              <span
+                aria-hidden
+                className="flex h-6 w-32 shrink-0 items-center rounded-md border border-border bg-card px-2 text-xs text-foreground"
+              >
+                3
+              </span>
+            </span>
             <span className="block py-1.5">
               <span className="block text-foreground">Custom instructions</span>
               <span className="block pt-1 leading-relaxed">

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@get-bb/plugin-sdk",
-  "version": "0.4.39",
+  "version": "0.4.40",
   "homepage": "https://github.com/get-bb/bb#readme",
   "bugs": {
     "url": "https://github.com/get-bb/bb/issues"

--- a/packages/plugin-sdk/src/app-contract.ts
+++ b/packages/plugin-sdk/src/app-contract.ts
@@ -1538,7 +1538,7 @@ export interface PluginSettingsState {
    * Effective non-secret setting values (secret settings are excluded —
    * read them server-side). Undefined while loading or unavailable.
    */
-  values: Record<string, string | boolean> | undefined;
+  values: Record<string, string | number | boolean> | undefined;
   isLoading: boolean;
 }
 

--- a/packages/plugin-sdk/src/backend-contract.ts
+++ b/packages/plugin-sdk/src/backend-contract.ts
@@ -86,6 +86,13 @@ export type PluginSettingDescriptor =
       default?: boolean;
     }
   | {
+      type: "number";
+      label: string;
+      description?: string;
+      experimental_schema?: StandardSchemaV1<number, number>;
+      default?: number;
+    }
+  | {
       type: "select";
       label: string;
       description?: string;
@@ -105,13 +112,13 @@ export type PluginSettingDescriptor =
 
 export type PluginSettingDescriptors = Record<string, PluginSettingDescriptor>;
 
-export type PluginSettingValue = string | boolean;
+export type PluginSettingValue = string | number | boolean;
 
 /** `default` present → non-optional value; absent → `T | undefined`. */
 export type PluginSettingsValues<
   Ds extends Record<string, PluginSettingDescriptor>,
 > = {
-  [K in keyof Ds]: Ds[K] extends { default: string | boolean }
+  [K in keyof Ds]: Ds[K] extends { default: string | number | boolean }
     ? PluginSettingValueOf<Ds[K]>
     : PluginSettingValueOf<Ds[K]> | undefined;
 };
@@ -120,7 +127,9 @@ type PluginSettingValueOf<D extends PluginSettingDescriptor> = D extends {
   type: "boolean";
 }
   ? boolean
-  : string;
+  : D extends { type: "number" }
+    ? number
+    : string;
 
 export interface PluginSettingsHandle<
   Ds extends Record<string, PluginSettingDescriptor>,

--- a/packages/plugin-sdk/src/internal/host-policy.ts
+++ b/packages/plugin-sdk/src/internal/host-policy.ts
@@ -125,6 +125,9 @@ const stringSettingSchemaSchema = z.custom<StandardSchemaV1<string, string>>(
 const booleanSettingSchemaSchema = z.custom<StandardSchemaV1<boolean, boolean>>(
   (value) => isStandardSchema(value),
 );
+const numberSettingSchemaSchema = z.custom<StandardSchemaV1<number, number>>(
+  (value) => isStandardSchema(value),
+);
 
 const settingDescriptorSchema = z.discriminatedUnion("type", [
   z
@@ -156,6 +159,14 @@ const settingDescriptorSchema = z.discriminatedUnion("type", [
       ...settingsBaseFields,
       experimental_schema: booleanSettingSchemaSchema.optional(),
       default: z.boolean().optional(),
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal("number"),
+      ...settingsBaseFields,
+      experimental_schema: numberSettingSchemaSchema.optional(),
+      default: z.number().finite().optional(),
     })
     .strict(),
   z
@@ -229,7 +240,7 @@ export function registerSettingDescriptors(
   return validated;
 }
 
-function settingSchemaError<T extends string | boolean>(
+function settingSchemaError<T extends string | number | boolean>(
   key: string,
   schema: StandardSchemaV1<T, T> | undefined,
   value: T,
@@ -272,6 +283,21 @@ export function validateSettingsUpdate(
     if (descriptor.type === "boolean") {
       if (typeof value !== "boolean") {
         errors.push(`setting "${key}" expects a boolean`);
+        continue;
+      }
+      const validationError = settingSchemaError(
+        key,
+        descriptor.experimental_schema,
+        value,
+      );
+      if (validationError !== null) {
+        errors.push(validationError);
+      }
+      continue;
+    }
+    if (descriptor.type === "number") {
+      if (typeof value !== "number" || !Number.isFinite(value)) {
+        errors.push(`setting "${key}" expects a finite number`);
         continue;
       }
       const validationError = settingSchemaError(

--- a/packages/plugin-sdk/src/testing/__tests__/fake-plugin-host.test.ts
+++ b/packages/plugin-sdk/src/testing/__tests__/fake-plugin-host.test.ts
@@ -273,6 +273,12 @@ describe("settings", () => {
         default: "fast",
       },
       enabled: { type: "boolean", label: "Enabled", default: true },
+      retries: {
+        type: "number",
+        label: "Retries",
+        experimental_schema: z.number().int().min(0).max(5),
+        default: 3,
+      },
     });
   }
 
@@ -285,6 +291,7 @@ describe("settings", () => {
       token: "xoxb-1",
       mode: "fast",
       enabled: false,
+      retries: 3,
     });
   });
 
@@ -301,11 +308,11 @@ describe("settings", () => {
       "must be one of: fast, slow",
     );
 
-    await harness.setSettings({ token: "xoxb-2", mode: "slow" });
+    await harness.setSettings({ token: "xoxb-2", mode: "slow", retries: 5 });
     expect(changes).toHaveLength(1);
     expect(changes[0]).toEqual({
-      next: { token: "xoxb-2", mode: "slow", enabled: true },
-      prev: { token: undefined, mode: "fast", enabled: true },
+      next: { token: "xoxb-2", mode: "slow", enabled: true, retries: 5 },
+      prev: { token: undefined, mode: "fast", enabled: true, retries: 3 },
     });
 
     await harness.setSettings({ mode: "slow" });
@@ -314,6 +321,16 @@ describe("settings", () => {
     await harness.setSettings({ mode: null });
     expect(changes).toHaveLength(2);
     expect(await handle.get()).toMatchObject({ mode: "fast" });
+
+    await expect(harness.setSettings({ retries: "4" })).rejects.toThrow(
+      "expects a finite number",
+    );
+    await expect(harness.setSettings({ retries: 6 })).rejects.toThrow(
+      "Too big",
+    );
+    await expect(harness.setSettings({ retries: Number.NaN })).rejects.toThrow(
+      "expects a finite number",
+    );
   });
 
   it("validates strings and lets plugin server code persist its own settings", async () => {
@@ -393,6 +410,15 @@ describe("settings", () => {
         notes: { type: "string", label: "Notes", experimental_multiline: true },
       }),
     ).not.toThrow();
+    expect(() =>
+      bb.settings.define({
+        invalidRetries: {
+          type: "number",
+          label: "Retries",
+          default: Number.POSITIVE_INFINITY,
+        },
+      }),
+    ).toThrow('invalid descriptor for setting "invalidRetries"');
     expect(() =>
       bb.settings.define({
         payload: {

--- a/packages/plugin-sdk/src/testing/app.tsx
+++ b/packages/plugin-sdk/src/testing/app.tsx
@@ -1105,7 +1105,7 @@ export interface RenderSlotOptions<
    */
   rpc?: PluginRpcTestHandlers<Contract>;
   /** `useSettings()` values; omitted → `{ values: undefined, isLoading: false }`. */
-  settings?: Record<string, string | boolean>;
+  settings?: Record<string, string | number | boolean>;
   /** `useBbContext()` selection; both default to null. */
   context?: { projectId?: string | null; threadId?: string | null };
   /** Initial `useRealtimeConnectionState()` value; defaults to `connected`. */

--- a/packages/plugin-sdk/src/testing/fake-plugin-host.ts
+++ b/packages/plugin-sdk/src/testing/fake-plugin-host.ts
@@ -480,7 +480,26 @@ function readSettingsValues(
   const values: Record<string, PluginSettingValue | undefined> = {};
   for (const [key, descriptor] of Object.entries(descriptors)) {
     let value = stored.get(key);
-    const expected = descriptor.type === "boolean" ? "boolean" : "string";
+    if (descriptor.type === "number" && typeof value === "string") {
+      const legacyNumber = Number(value.trim());
+      value =
+        value.trim().length > 0 && Number.isFinite(legacyNumber)
+          ? legacyNumber
+          : undefined;
+    }
+    if (
+      descriptor.type === "number" &&
+      typeof value === "number" &&
+      !Number.isFinite(value)
+    ) {
+      value = undefined;
+    }
+    const expected =
+      descriptor.type === "boolean"
+        ? "boolean"
+        : descriptor.type === "number"
+          ? "number"
+          : "string";
     if (typeof value !== expected) value = undefined;
     if (
       descriptor.type === "select" &&
@@ -991,9 +1010,10 @@ function createFakePluginHostInternal(
         );
       }
       const rows = database
-        .prepare<[], { id: number; statement_hash: string | null }>(
-          "SELECT id, statement_hash FROM _bb_migrations ORDER BY id",
-        )
+        .prepare<
+          [],
+          { id: number; statement_hash: string | null }
+        >("SELECT id, statement_hash FROM _bb_migrations ORDER BY id")
         .all();
       const applied = new Map<number, string | null>();
       for (const row of rows) applied.set(row.id, row.statement_hash);
@@ -1053,7 +1073,11 @@ function createFakePluginHostInternal(
     const prev = readSettingsValues(settingsDescriptors, storedSettings);
     for (const [key, value] of Object.entries(values)) {
       if (value === null) storedSettings.delete(key);
-      else if (typeof value === "string" || typeof value === "boolean") {
+      else if (
+        typeof value === "string" ||
+        typeof value === "number" ||
+        typeof value === "boolean"
+      ) {
         storedSettings.set(key, value);
       } else {
         throw new Error(`setting "${key}" has an unsupported value`);

--- a/packages/server-contract/src/api/plugins.ts
+++ b/packages/server-contract/src/api/plugins.ts
@@ -305,6 +305,13 @@ export const pluginSettingDescriptorSchema = z.discriminatedUnion("type", [
   z
     .object({
       ...pluginSettingBaseSchema,
+      type: z.literal("number"),
+      default: z.number().finite().optional(),
+    })
+    .strict(),
+  z
+    .object({
+      ...pluginSettingBaseSchema,
       type: z.literal("select"),
       options: z.array(z.string().min(1)).min(1),
       default: z.string().optional(),

--- a/packages/server-contract/test/plugins.test.ts
+++ b/packages/server-contract/test/plugins.test.ts
@@ -5,9 +5,27 @@ import {
   pluginCatalogSearchResponseSchema,
   pluginCatalogSearchResultSchema,
   pluginCatalogStatusSchema,
+  pluginSettingDescriptorSchema,
 } from "../src/index.js";
 
-describe("plugin catalog contracts", () => {
+describe("plugin contracts", () => {
+  it("accepts finite number setting descriptors", () => {
+    expect(
+      pluginSettingDescriptorSchema.parse({
+        type: "number",
+        label: "Retries",
+        default: 3,
+      }),
+    ).toEqual({ type: "number", label: "Retries", default: 3 });
+    expect(
+      pluginSettingDescriptorSchema.safeParse({
+        type: "number",
+        label: "Retries",
+        default: Number.POSITIVE_INFINITY,
+      }).success,
+    ).toBe(false);
+  });
+
   it("accepts catalog install coordinates without marketplace nesting", () => {
     expect(
       pluginCatalogInstallRequestSchema.parse({

--- a/plugins/provider-claude-code/src/server.test.ts
+++ b/plugins/provider-claude-code/src/server.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { PluginProviderOptionsContext } from "@get-bb/plugin-sdk";
 import { createFakePluginHost } from "@get-bb/plugin-sdk/testing";
 import claudeCodePlugin from "../server.js";
 
@@ -16,7 +17,7 @@ function loadClaudeCodePlugin() {
 
 function providerOptions(
   declaration: ReturnType<typeof loadClaudeCodePlugin>["declaration"],
-  settings: Readonly<Record<string, string | boolean | undefined>>,
+  settings: PluginProviderOptionsContext["settings"],
 ) {
   const deriveProviderOptions = declaration.deriveProviderOptions;
   if (deriveProviderOptions === undefined) {

--- a/plugins/provider-retry/server.ts
+++ b/plugins/provider-retry/server.ts
@@ -4,7 +4,7 @@ import { DEFAULT_MAXIMUM_WAIT_MS, decideRetry } from "./src/retry-policy.js";
 
 const MAXIMUM_WAIT_OPTIONS = ["6 hours", "24 hours", "No limit"] as const;
 
-function maximumWaitMs(value: string | boolean | undefined): number | null {
+function maximumWaitMs(value: string): number | null {
   switch (value) {
     case "6 hours":
       return DEFAULT_MAXIMUM_WAIT_MS;

--- a/plugins/workflows/src/server-harness.test.ts
+++ b/plugins/workflows/src/server-harness.test.ts
@@ -47,7 +47,7 @@ describe("workflows plugin", () => {
     const { bb, harness } = createFakePluginHost({
       pluginId: "workflows",
       agentSkillIds: ["workflows"],
-      settings: { maxActiveRuns: "not-a-number" },
+      settings: { maxActiveRuns: 0 },
     });
     hosts.push(harness);
     await expect(plugin(bb)).resolves.toBeUndefined();
@@ -58,7 +58,7 @@ describe("workflows plugin", () => {
     expect(
       harness.registrations.services.map((service) => service.name),
     ).toEqual(["workflow-worker"]);
-    await harness.setSettings({ maxActiveRuns: "5" });
+    await harness.setSettings({ maxActiveRuns: 5 });
   });
 
   it("registers tool schemas without recursive $refs", async () => {

--- a/plugins/workflows/src/service-policy.test.ts
+++ b/plugins/workflows/src/service-policy.test.ts
@@ -264,12 +264,12 @@ describe("workflow service policy integration", () => {
 
   it("applies live settings to future run snapshots without mutating existing runs", async () => {
     const initial = {
-      maxActiveRuns: "1",
-      maxConcurrentAgents: "2",
-      maxAgentCalls: "3",
-      totalRunTimeoutMs: "120000",
-      retentionDays: "7",
-      maxNotificationBytes: "2048",
+      maxActiveRuns: 1,
+      maxConcurrentAgents: 2,
+      maxAgentCalls: 3,
+      totalRunTimeoutMs: 120_000,
+      retentionDays: 7,
+      maxNotificationBytes: 2048,
     };
     const { bb, harness } = createFakePluginHost({
       pluginId: "workflows",
@@ -303,12 +303,12 @@ describe("workflow service policy integration", () => {
       })) as string,
     ) as { runId: string };
     const next = {
-      maxActiveRuns: "2",
-      maxConcurrentAgents: "4",
-      maxAgentCalls: "8",
-      totalRunTimeoutMs: "180000",
-      retentionDays: "14",
-      maxNotificationBytes: "4096",
+      maxActiveRuns: 2,
+      maxConcurrentAgents: 4,
+      maxAgentCalls: 8,
+      totalRunTimeoutMs: 180_000,
+      retentionDays: 14,
+      maxNotificationBytes: 4096,
     };
     await harness.setSettings(next);
     const second = JSON.parse(
@@ -337,16 +337,8 @@ describe("workflow service policy integration", () => {
     const secondStatus = JSON.parse(secondStatusResult.stdout!) as {
       settings: Record<string, number>;
     };
-    expect(firstStatus.settings).toEqual(
-      Object.fromEntries(
-        Object.entries(initial).map(([key, value]) => [key, Number(value)]),
-      ),
-    );
-    expect(secondStatus.settings).toEqual(
-      Object.fromEntries(
-        Object.entries(next).map(([key, value]) => [key, Number(value)]),
-      ),
-    );
+    expect(firstStatus.settings).toEqual(initial);
+    expect(secondStatus.settings).toEqual(next);
   });
 
   it("resolves named and path children on the origin host", async () => {

--- a/plugins/workflows/src/settings.test.ts
+++ b/plugins/workflows/src/settings.test.ts
@@ -3,22 +3,20 @@ import { describe, expect, it } from "vitest";
 import {
   DEFAULT_WORKFLOW_SETTINGS,
   WORKFLOW_SETTING_DESCRIPTORS,
-  parseWorkflowSettings,
   parseStoredWorkflowSettings,
   registerWorkflowSettings,
+  validateWorkflowSettings,
   type WorkflowSettings,
 } from "./settings.js";
 
-function rawSettings(
-  overrides: Partial<Record<keyof WorkflowSettings, string>> = {},
-) {
+function rawSettings(overrides: Partial<WorkflowSettings> = {}) {
   return {
-    maxActiveRuns: "4",
-    maxConcurrentAgents: "8",
-    maxAgentCalls: "100",
-    totalRunTimeoutMs: "86400000",
-    retentionDays: "30",
-    maxNotificationBytes: "16384",
+    maxActiveRuns: 4,
+    maxConcurrentAgents: 8,
+    maxAgentCalls: 100,
+    totalRunTimeoutMs: 86_400_000,
+    retentionDays: 30,
+    maxNotificationBytes: 16_384,
     ...overrides,
   };
 }
@@ -36,20 +34,20 @@ describe("workflow settings policy", () => {
         WORKFLOW_SETTING_DESCRIPTORS.maxNotificationBytes.default,
     };
 
-    expect(parseWorkflowSettings(descriptorDefaults)).toEqual(
+    expect(validateWorkflowSettings(descriptorDefaults)).toEqual(
       DEFAULT_WORKFLOW_SETTINGS,
     );
     expect(Object.isFrozen(DEFAULT_WORKFLOW_SETTINGS)).toBe(true);
   });
 
-  it("parses every custom value and deliberately trims surrounding whitespace", () => {
-    const parsed = parseWorkflowSettings({
-      maxActiveRuns: "  12\t",
-      maxConcurrentAgents: "16",
-      maxAgentCalls: "750",
-      totalRunTimeoutMs: "172800000",
-      retentionDays: "90",
-      maxNotificationBytes: "65536",
+  it("accepts typed custom values without parsing strings", () => {
+    const parsed = validateWorkflowSettings({
+      maxActiveRuns: 12,
+      maxConcurrentAgents: 16,
+      maxAgentCalls: 750,
+      totalRunTimeoutMs: 172_800_000,
+      retentionDays: 90,
+      maxNotificationBytes: 65_536,
     });
 
     expect(parsed).toEqual({
@@ -64,43 +62,30 @@ describe("workflow settings policy", () => {
   });
 
   it.each([
-    ["empty", ""],
-    ["whitespace-only", " \t\n"],
-    ["exponent", "1e2"],
-    ["hexadecimal", "0x10"],
-    ["fractional", "4.5"],
-    ["NaN", "NaN"],
-    ["Infinity", "Infinity"],
-    ["signed", "+4"],
-    ["negative", "-4"],
-    ["unknown text", "many"],
-  ])("rejects %s numeric syntax", (_category, value) => {
+    ["fractional", 4.5],
+    ["NaN", Number.NaN],
+    ["Infinity", Number.POSITIVE_INFINITY],
+  ])("rejects a %s numeric value", (_category, value) => {
     expect(() =>
-      parseWorkflowSettings(rawSettings({ maxActiveRuns: value })),
-    ).toThrow(/Maximum active runs.*base-10 integer.*1 through 32/);
-  });
-
-  it("rejects a digit-only integer too large to be finite", () => {
-    expect(() =>
-      parseWorkflowSettings(rawSettings({ maxActiveRuns: "9".repeat(400) })),
-    ).toThrow(/Maximum active runs.*finite base-10 integer/);
+      validateWorkflowSettings(rawSettings({ maxActiveRuns: value })),
+    ).toThrow();
   });
 
   it.each([
-    ["maxActiveRuns", "0", "33", "Maximum active runs"],
-    ["maxConcurrentAgents", "0", "65", "Per-run agent concurrency"],
-    ["maxAgentCalls", "0", "1001", "Maximum agent calls"],
-    ["totalRunTimeoutMs", "59999", "604800001", "Total run timeout"],
-    ["retentionDays", "0", "3651", "Retention days"],
-    ["maxNotificationBytes", "1023", "262145", "Maximum notification bytes"],
+    ["maxActiveRuns", 0, 33, "Maximum active runs"],
+    ["maxConcurrentAgents", 0, 65, "Per-run agent concurrency"],
+    ["maxAgentCalls", 0, 1001, "Maximum agent calls"],
+    ["totalRunTimeoutMs", 59_999, 604_800_001, "Total run timeout"],
+    ["retentionDays", 0, 3651, "Retention days"],
+    ["maxNotificationBytes", 1023, 262_145, "Maximum notification bytes"],
   ] as const)(
     "enforces lower and upper bounds for %s",
     (key, below, above, label) => {
       expect(() =>
-        parseWorkflowSettings(rawSettings({ [key]: below })),
+        validateWorkflowSettings(rawSettings({ [key]: below })),
       ).toThrow(new RegExp(label));
       expect(() =>
-        parseWorkflowSettings(rawSettings({ [key]: above })),
+        validateWorkflowSettings(rawSettings({ [key]: above })),
       ).toThrow(new RegExp(label));
     },
   );
@@ -129,31 +114,27 @@ describe("workflow settings policy", () => {
       previous: WorkflowSettings;
     }> = [];
     settings.onChange((next, previous) => changes.push({ next, previous }));
-    await harness.setSettings({ maxConcurrentAgents: "12" });
+    await harness.setSettings({ maxConcurrentAgents: 12 });
 
     expect(changes).toHaveLength(1);
     expect(changes[0]?.previous.maxConcurrentAgents).toBe(8);
     expect(changes[0]?.next.maxConcurrentAgents).toBe(12);
   });
 
-  it("surfaces a field-specific error for an invalid fake-host value", async () => {
+  it("falls back from a nonnumeric legacy stored string", async () => {
     const { bb } = createFakePluginHost({
       pluginId: "workflows",
       settings: { retentionDays: "forever" },
     });
 
-    await expect(registerWorkflowSettings(bb).get()).rejects.toThrow(
-      /Retention days.*base-10 integer.*1 through 3650/,
-    );
+    await expect(registerWorkflowSettings(bb).get()).resolves.toMatchObject({
+      retentionDays: 7,
+    });
   });
 
-  it("rejects invalid updates before replacing invalid persisted settings", async () => {
-    const { bb, harness } = createFakePluginHost({
-      pluginId: "workflows",
-      settings: { retentionDays: "forever" },
-    });
+  it("rejects string and out-of-range updates", async () => {
+    const { bb, harness } = createFakePluginHost({ pluginId: "workflows" });
     const settings = registerWorkflowSettings(bb);
-    await expect(settings.get()).rejects.toThrow("Retention days");
     const changes: WorkflowSettings[] = [];
     const errors: string[] = [];
     settings.onChange(
@@ -161,12 +142,15 @@ describe("workflow settings policy", () => {
       (error) => errors.push(error.message),
     );
 
-    await expect(harness.setSettings({ maxActiveRuns: "0" })).rejects.toThrow(
+    await expect(harness.setSettings({ maxActiveRuns: "6" })).rejects.toThrow(
+      "expects a finite number",
+    );
+    await expect(harness.setSettings({ maxActiveRuns: 0 })).rejects.toThrow(
       "Maximum active runs must be from 1 through 32",
     );
     expect(errors).toEqual([]);
     expect(changes).toEqual([]);
-    await harness.setSettings({ retentionDays: "14", maxActiveRuns: "6" });
+    await harness.setSettings({ retentionDays: 14, maxActiveRuns: 6 });
     expect(changes.at(-1)).toMatchObject({
       retentionDays: 14,
       maxActiveRuns: 6,

--- a/plugins/workflows/src/settings.ts
+++ b/plugins/workflows/src/settings.ts
@@ -5,65 +5,117 @@ import type {
 } from "@get-bb/plugin-sdk";
 import { z } from "zod";
 
-export const WORKFLOW_SETTING_DESCRIPTORS = {
+interface IntegerField {
+  label: string;
+  minimum: number;
+  maximum: number;
+}
+
+const INTEGER_FIELDS = Object.freeze({
   maxActiveRuns: {
-    type: "string",
     label: "Maximum active runs",
-    description: "Concurrent workflow runs across the plugin (1-32).",
-    experimental_schema: workflowIntegerSchema("maxActiveRuns"),
-    default: "4",
+    minimum: 1,
+    maximum: 32,
   },
   maxConcurrentAgents: {
-    type: "string",
     label: "Per-run agent concurrency",
-    description: "Agent calls that one workflow may run concurrently (1-64).",
-    experimental_schema: workflowIntegerSchema("maxConcurrentAgents"),
-    default: "8",
+    minimum: 1,
+    maximum: 64,
   },
   maxAgentCalls: {
-    type: "string",
     label: "Maximum agent calls",
-    description: "Agent calls allowed during one workflow run (1-1000).",
-    experimental_schema: workflowIntegerSchema("maxAgentCalls"),
-    default: "100",
+    minimum: 1,
+    maximum: 1_000,
   },
   totalRunTimeoutMs: {
-    type: "string",
+    label: "Total run timeout",
+    minimum: 60_000,
+    maximum: 604_800_000,
+  },
+  retentionDays: {
+    label: "Retention days",
+    minimum: 1,
+    maximum: 3_650,
+  },
+  maxNotificationBytes: {
+    label: "Maximum notification bytes",
+    minimum: 1_024,
+    maximum: 262_144,
+  },
+});
+
+function boundedIntegerSchema(field: IntegerField) {
+  const rangeMessage = `${field.label} must be from ${field.minimum} through ${field.maximum}`;
+  return z
+    .number()
+    .int(`${field.label} must be a whole number`)
+    .min(field.minimum, rangeMessage)
+    .max(field.maximum, rangeMessage);
+}
+
+const workflowSettingsSchema = z.object({
+  maxActiveRuns: boundedIntegerSchema(INTEGER_FIELDS.maxActiveRuns),
+  maxConcurrentAgents: boundedIntegerSchema(INTEGER_FIELDS.maxConcurrentAgents),
+  maxAgentCalls: boundedIntegerSchema(INTEGER_FIELDS.maxAgentCalls),
+  totalRunTimeoutMs: boundedIntegerSchema(INTEGER_FIELDS.totalRunTimeoutMs),
+  retentionDays: boundedIntegerSchema(INTEGER_FIELDS.retentionDays),
+  maxNotificationBytes: boundedIntegerSchema(
+    INTEGER_FIELDS.maxNotificationBytes,
+  ),
+});
+
+export type WorkflowSettings = z.infer<typeof workflowSettingsSchema>;
+
+export const WORKFLOW_SETTING_DESCRIPTORS = {
+  maxActiveRuns: {
+    type: "number",
+    label: "Maximum active runs",
+    description: "Concurrent workflow runs across the plugin (1-32).",
+    experimental_schema: workflowSettingsSchema.shape.maxActiveRuns,
+    default: 4,
+  },
+  maxConcurrentAgents: {
+    type: "number",
+    label: "Per-run agent concurrency",
+    description: "Agent calls that one workflow may run concurrently (1-64).",
+    experimental_schema: workflowSettingsSchema.shape.maxConcurrentAgents,
+    default: 8,
+  },
+  maxAgentCalls: {
+    type: "number",
+    label: "Maximum agent calls",
+    description: "Agent calls allowed during one workflow run (1-1000).",
+    experimental_schema: workflowSettingsSchema.shape.maxAgentCalls,
+    default: 100,
+  },
+  totalRunTimeoutMs: {
+    type: "number",
     label: "Total run timeout (milliseconds)",
     description:
       "Fail a workflow after this total duration in milliseconds (60000-604800000).",
-    experimental_schema: workflowIntegerSchema("totalRunTimeoutMs"),
-    default: "86400000",
+    experimental_schema: workflowSettingsSchema.shape.totalRunTimeoutMs,
+    default: 86_400_000,
   },
   retentionDays: {
-    type: "string",
+    type: "number",
     label: "Retention (days)",
     description: "Days to retain completed workflow data (1-3650).",
-    experimental_schema: workflowIntegerSchema("retentionDays"),
-    default: "7",
+    experimental_schema: workflowSettingsSchema.shape.retentionDays,
+    default: 7,
   },
   maxNotificationBytes: {
-    type: "string",
+    type: "number",
     label: "Maximum notification bytes",
     description:
       "Maximum UTF-8 size of a completion notification (1024-262144).",
-    experimental_schema: workflowIntegerSchema("maxNotificationBytes"),
-    default: "16384",
+    experimental_schema: workflowSettingsSchema.shape.maxNotificationBytes,
+    default: 16_384,
   },
 } as const satisfies PluginSettingDescriptors;
 
-type RawWorkflowSettings = PluginSettingsValues<
+type DeclaredWorkflowSettings = PluginSettingsValues<
   typeof WORKFLOW_SETTING_DESCRIPTORS
 >;
-
-export interface WorkflowSettings {
-  maxActiveRuns: number;
-  maxConcurrentAgents: number;
-  maxAgentCalls: number;
-  totalRunTimeoutMs: number;
-  retentionDays: number;
-  maxNotificationBytes: number;
-}
 
 export const DEFAULT_WORKFLOW_SETTINGS: Readonly<WorkflowSettings> =
   Object.freeze({
@@ -75,115 +127,10 @@ export const DEFAULT_WORKFLOW_SETTINGS: Readonly<WorkflowSettings> =
     maxNotificationBytes: 16 * 1_024,
   });
 
-interface IntegerField {
-  label: string;
-  minimum: number;
-  maximum: number;
-}
-
-const INTEGER_FIELDS: Readonly<Record<keyof WorkflowSettings, IntegerField>> =
-  Object.freeze({
-    maxActiveRuns: {
-      label: "Maximum active runs",
-      minimum: 1,
-      maximum: 32,
-    },
-    maxConcurrentAgents: {
-      label: "Per-run agent concurrency",
-      minimum: 1,
-      maximum: 64,
-    },
-    maxAgentCalls: {
-      label: "Maximum agent calls",
-      minimum: 1,
-      maximum: 1_000,
-    },
-    totalRunTimeoutMs: {
-      label: "Total run timeout",
-      minimum: 60_000,
-      maximum: 604_800_000,
-    },
-    retentionDays: {
-      label: "Retention days",
-      minimum: 1,
-      maximum: 3_650,
-    },
-    maxNotificationBytes: {
-      label: "Maximum notification bytes",
-      minimum: 1_024,
-      maximum: 262_144,
-    },
-  });
-
-function parseBoundedInteger(raw: string, field: IntegerField): number {
-  const value = raw.trim();
-  const expectation = `${field.minimum} through ${field.maximum}`;
-  if (value.length === 0) {
-    throw new Error(
-      `${field.label} cannot be empty; enter a base-10 integer from ${expectation}`,
-    );
-  }
-  if (!/^[0-9]+$/.test(value)) {
-    throw new Error(
-      `${field.label} must be a base-10 integer from ${expectation}; received ${JSON.stringify(raw)}`,
-    );
-  }
-  const parsed = Number(value);
-  if (!Number.isFinite(parsed) || !Number.isSafeInteger(parsed)) {
-    throw new Error(
-      `${field.label} must be a finite base-10 integer from ${expectation}; received ${JSON.stringify(raw)}`,
-    );
-  }
-  if (parsed < field.minimum || parsed > field.maximum) {
-    throw new Error(
-      `${field.label} must be from ${expectation}; received ${parsed}`,
-    );
-  }
-  return parsed;
-}
-
-function workflowIntegerSchema(key: keyof WorkflowSettings): z.ZodString {
-  return z.string().superRefine((value, context) => {
-    try {
-      parseBoundedInteger(value, INTEGER_FIELDS[key]);
-    } catch (error) {
-      context.addIssue({
-        code: "custom",
-        message: error instanceof Error ? error.message : String(error),
-      });
-    }
-  });
-}
-
-export function parseWorkflowSettings(
-  values: Readonly<RawWorkflowSettings>,
+export function validateWorkflowSettings(
+  values: Readonly<DeclaredWorkflowSettings>,
 ): WorkflowSettings {
-  return Object.freeze({
-    maxActiveRuns: parseBoundedInteger(
-      values.maxActiveRuns,
-      INTEGER_FIELDS.maxActiveRuns,
-    ),
-    maxConcurrentAgents: parseBoundedInteger(
-      values.maxConcurrentAgents,
-      INTEGER_FIELDS.maxConcurrentAgents,
-    ),
-    maxAgentCalls: parseBoundedInteger(
-      values.maxAgentCalls,
-      INTEGER_FIELDS.maxAgentCalls,
-    ),
-    totalRunTimeoutMs: parseBoundedInteger(
-      values.totalRunTimeoutMs,
-      INTEGER_FIELDS.totalRunTimeoutMs,
-    ),
-    retentionDays: parseBoundedInteger(
-      values.retentionDays,
-      INTEGER_FIELDS.retentionDays,
-    ),
-    maxNotificationBytes: parseBoundedInteger(
-      values.maxNotificationBytes,
-      INTEGER_FIELDS.maxNotificationBytes,
-    ),
-  });
+  return Object.freeze(workflowSettingsSchema.parse(values));
 }
 
 const LEGACY_STORED_SETTING_KEYS = new Set(["workerStallTimeoutMs"]);
@@ -205,16 +152,16 @@ export function parseStoredWorkflowSettings(value: unknown): WorkflowSettings {
   ) {
     throw new Error("Workflow settings snapshot has unexpected fields");
   }
-  const raw = Object.fromEntries(
+  const stored = Object.fromEntries(
     expected.map((key) => {
-      const stored = object[key];
-      if (typeof stored !== "number" || !Number.isSafeInteger(stored)) {
+      const value = object[key];
+      if (typeof value !== "number" || !Number.isSafeInteger(value)) {
         throw new Error(`Workflow settings snapshot.${key} must be an integer`);
       }
-      return [key, String(stored)];
+      return [key, value];
     }),
-  ) as Record<keyof WorkflowSettings, string>;
-  return parseWorkflowSettings(raw);
+  ) as WorkflowSettings;
+  return validateWorkflowSettings(stored);
 }
 
 interface WorkflowSettingsHandle {
@@ -232,20 +179,20 @@ export function registerWorkflowSettings(
   let lastValid = DEFAULT_WORKFLOW_SETTINGS;
   return {
     async get() {
-      const parsed = parseWorkflowSettings(await handle.get());
-      lastValid = parsed;
-      return parsed;
+      const validated = validateWorkflowSettings(await handle.get());
+      lastValid = validated;
+      return validated;
     },
     onChange(listener, onInvalid) {
       handle.onChange((next, previous) => {
         try {
-          const parsedNext = parseWorkflowSettings(next);
+          const validatedNext = validateWorkflowSettings(next);
           let parsedPrevious = lastValid;
           try {
-            parsedPrevious = parseWorkflowSettings(previous);
+            parsedPrevious = validateWorkflowSettings(previous);
           } catch {}
-          lastValid = parsedNext;
-          listener(parsedNext, parsedPrevious);
+          lastValid = validatedNext;
+          listener(validatedNext, parsedPrevious);
         } catch (error) {
           onInvalid?.(
             error instanceof Error ? error : new Error(String(error)),


### PR DESCRIPTION
## Human comments

## What was wrong

Plugin settings could describe only strings and booleans, so plugins with numeric configuration had to expose string fields and parse them internally. That deferred type errors beyond the settings boundary and prevented the host UI, CLI, and settings API from consistently validating and preserving numeric values.

## What changed

- Add a finite `number` setting descriptor, typed defaults, Standard Schema validation, and numeric effective values across the Plugin SDK, host policy, server contract, app contract, and fake host.
- Render number descriptors as numeric inputs, preserve editable drafts, autosave numbers on blur, and unset cleared values.
- Parse number settings in `bb plugin config` as JSON numbers and reject invalid or non-finite input.
- Preserve compatibility by converting legacy persisted numeric strings when number descriptors are loaded.
- Migrate Workflows limits to bounded integer descriptors and remove provider-side string parsing.
- Bump the Plugin SDK version to `0.4.40` and update the Plugin Guide inventory, wireframe, API audit, CLI skill, authoring guidance, and configuration docs.
- No host-daemon wire contract changed, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

## How you verified

- Added SDK, server, server-contract, app, CLI, and Workflows tests covering numeric defaults, persistence, legacy strings, bounds, non-finite rejection, UI autosave/unset behavior, and CLI parsing. These cases fail against the previous string/boolean-only contract.
- Ran `pnpm exec turbo run test typecheck --filter=@get-bb/plugin-sdk --filter=@bb/plugin-api-map --filter=@bb/app --filter=bb-plugin-plugin-api-docs --force` after rebasing onto `main`: 11 tasks passed, including 3,786 app tests with 4 skipped.
- Ran focused server, CLI, Workflows, server-contract, provider-retry, and provider-claude-code suites and all affected Turbo typechecks.
- Ran `bb plugin build plugins/plugin-api-docs` successfully.
- Started an isolated dev app and verified that Workflows publishes number descriptors, numeric values round-trip, `null` resets to defaults, and string updates are rejected.

> AGENT GENERATED
