### PR TITLE
Show OMP advisor output and model sources

### DIFF
--- a/apps/app/src/components/pickers/ModelReasoningPicker.test.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.test.tsx
@@ -613,6 +613,32 @@ describe("ModelReasoningPicker", () => {
     expect(onModelChange).toHaveBeenCalledWith(apiModel);
   });
 
+  it("shows a model source in the trigger and menu row", () => {
+    const modelLabel = "Grok 4.6 Fast";
+    renderPicker({
+      modelOptions: [
+        {
+          value: "cursor/cursor-grok-4.6-fast",
+          label: modelLabel,
+          qualifier: "Cursor",
+        },
+      ],
+      pickerProviderOptions: [{ value: "acp-omp", label: "omp" }],
+      selectedProviderId: "acp-omp",
+    });
+
+    const trigger = screen.getByRole("button", {
+      name: "Provider, model and reasoning",
+    });
+    expect(trigger.textContent).toContain("Grok 4.6 Fast · Cursor");
+
+    fireEvent.click(trigger);
+
+    expect(screen.getByTitle("Grok 4.6 Fast · Cursor").textContent).toBe(
+      "Grok 4.6 Fast · Cursor",
+    );
+  });
+
   it("uses picker search policy and selects the match by keyboard", () => {
     const { onModelChange } = renderPicker({ modelOptions: manyCodexModels });
 

--- a/apps/app/src/components/pickers/ModelReasoningPicker.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.tsx
@@ -275,6 +275,7 @@ export function ModelReasoningPicker({
   const ProviderIcon = selectedProvider?.icon;
   const selectedModelOption = modelOptions.find((m) => m.value === modelValue);
   const selectedModelLabel = selectedModelOption?.label ?? modelValue;
+  const selectedModelQualifier = selectedModelOption?.qualifier;
   const hasSelectedModel = selectedModelLabel.trim().length > 0;
   const selectedProviderLabel = selectedProvider?.label ?? selectedProviderId;
   const selectedModelLoadErrorMatches =
@@ -452,10 +453,11 @@ export function ModelReasoningPicker({
       query: searchQuery,
       getLabel: (option) =>
         stripModelBrandPrefix(option.label, activeBrandPrefix),
-      getAliases: (option) =>
-        option.routeProviderId
-          ? [option.routeProviderId, option.value]
-          : [option.value],
+      getAliases: (option) => [
+        ...(option.qualifier ? [option.qualifier] : []),
+        ...(option.routeProviderId ? [option.routeProviderId] : []),
+        option.value,
+      ],
     });
   }, [
     activeBrandPrefix,
@@ -746,8 +748,11 @@ export function ModelReasoningPicker({
     : selectedModelLoadFailed
       ? selectedModelLoadErrorText
       : triggerModelLabel;
+  const qualifiedTriggerTitleModelLabel = selectedModelQualifier
+    ? `${triggerTitleModelLabel} · ${selectedModelQualifier}`
+    : triggerTitleModelLabel;
   const triggerTitle = [
-    `${selectedProviderLabel}: ${triggerTitleModelLabel}`,
+    `${selectedProviderLabel}: ${qualifiedTriggerTitleModelLabel}`,
     triggerReasoningLabel ? ` · ${triggerReasoningLabel} reasoning` : "",
     showSelectedFastMode ? " (Fast mode)" : "",
   ].join("");
@@ -819,6 +824,11 @@ export function ModelReasoningPicker({
             {triggerModelTag ? (
               <span className="shrink-0 text-subtle-foreground">
                 {triggerModelTag}
+              </span>
+            ) : null}
+            {selectedModelQualifier ? (
+              <span className="shrink-0 text-subtle-foreground">
+                {` · ${selectedModelQualifier}`}
               </span>
             ) : null}
             {triggerReasoningLabel ? (
@@ -993,7 +1003,9 @@ export function ModelReasoningPicker({
                           option.label,
                           activeBrandPrefix,
                         )}
-                        qualifier={option.routeProviderId}
+                        qualifier={
+                          option.qualifier ?? option.routeProviderId
+                        }
                         selected={!isPreviewing && option.value === modelValue}
                         disabled={previewSelectionBlocked}
                         onClick={() => handleModelSelect(option.value)}
@@ -1300,7 +1312,7 @@ function MoreModelsSubmenu({
             <MenuRowButton
               key={option.value}
               label={stripModelBrandPrefix(option.label, activeBrandPrefix)}
-              qualifier={option.routeProviderId}
+              qualifier={option.qualifier ?? option.routeProviderId}
               selected={!isPreviewing && option.value === modelValue}
               onClick={() => onSelect(option.value)}
             />
@@ -1376,7 +1388,12 @@ function MenuRowButton({
           <span className="ml-1.5 text-subtle-foreground">{tag}</span>
         ) : null}
         {qualifier ? (
-          <span className="ml-1.5 text-subtle-foreground">{qualifier}</span>
+          <>
+            <span className="text-subtle-foreground" aria-hidden>
+              {" · "}
+            </span>
+            <span className="text-subtle-foreground">{qualifier}</span>
+          </>
         ) : null}
       </span>
       <span className="flex shrink-0 items-center gap-1.5">

--- a/apps/app/src/components/pickers/model-picker-option.ts
+++ b/apps/app/src/components/pickers/model-picker-option.ts
@@ -1,5 +1,6 @@
 import type { PickerOption } from "./OptionPicker";
 
 export interface ModelPickerOption extends PickerOption<string> {
+  qualifier?: string;
   routeProviderId?: string;
 }

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
@@ -2019,8 +2019,16 @@ function ThreadTimelineRowsForTimelineView(props: ThreadTimelineRowsProps) {
   const terminalAutoExpandedRowIds = useStableReadonlySet(
     accumulatedTerminalRowIds,
   );
+  const initialAndDefaultExpandedRowIds = useMemo(
+    () =>
+      new Set([
+        ...(props.initialExpanded ?? EMPTY_ROW_ID_SET),
+        ...computedAutoExpansionRowIds.defaultExpandedRowIds,
+      ]),
+    [computedAutoExpansionRowIds.defaultExpandedRowIds, props.initialExpanded],
+  );
   const initialAutoExpandedRowIds = useStableReadonlySet(
-    props.initialExpanded ?? EMPTY_ROW_ID_SET,
+    initialAndDefaultExpandedRowIds,
   );
   const projectId = props.projectId;
   const senderThreadMetadataById = useSenderThreadMetadataById();

--- a/apps/app/src/components/thread/timeline/timeline-auto-expand.test.ts
+++ b/apps/app/src/components/thread/timeline/timeline-auto-expand.test.ts
@@ -24,12 +24,16 @@ function collectAutoExpandedIds({
   rows,
   scopeActive,
 }: CollectAutoExpandedIdsArgs): Set<string> {
-  const { liveExpandedRowIds, terminalFrontierRowIds } =
+  const { defaultExpandedRowIds, liveExpandedRowIds, terminalFrontierRowIds } =
     collectTimelineAutoExpansionRowIds({
       rows,
       scopeActive,
     });
-  return new Set([...liveExpandedRowIds, ...terminalFrontierRowIds]);
+  return new Set([
+    ...defaultExpandedRowIds,
+    ...liveExpandedRowIds,
+    ...terminalFrontierRowIds,
+  ]);
 }
 
 describe("isWorkRowExpandable", () => {
@@ -85,6 +89,29 @@ describe("collectTimelineAutoExpansionRowIds", () => {
     });
 
     expect(Array.from(ids)).toEqual([]);
+  });
+
+  it("defaults every OMP advisor row to expanded after it leaves the frontier", () => {
+    const rows = buildTimelineViewRows([
+      extensionRow({
+        extensionKind: "provider-acp/advisor",
+        id: "omp-advisor",
+        sourceSeqStart: 1,
+      }),
+      conversationRow({
+        id: "assistant-final",
+        role: "assistant",
+        text: "All done.",
+        sourceSeqStart: 2,
+      }),
+    ]);
+
+    const ids = collectAutoExpandedIds({
+      rows,
+      scopeActive: false,
+    });
+
+    expect(Array.from(ids)).toEqual(["omp-advisor"]);
   });
 
   it("auto-expands a trailing bundle in an active scope without expanding its children", () => {

--- a/apps/app/src/hooks/thread-creation-options/model-catalog-selection.test.ts
+++ b/apps/app/src/hooks/thread-creation-options/model-catalog-selection.test.ts
@@ -1,0 +1,65 @@
+import type { AvailableModel } from "@bb/domain";
+import { describe, expect, it } from "vitest";
+import { resolveModelCatalogSelection } from "./model-catalog-selection";
+
+function model(value: string, displayName: string): AvailableModel {
+  return {
+    id: value,
+    model: value,
+    displayName,
+    description: "",
+    supportedReasoningEfforts: [],
+    defaultReasoningEffort: "medium",
+    isDefault: false,
+  };
+}
+
+describe("resolveModelCatalogSelection", () => {
+  it("labels OMP models with their backing source", () => {
+    const selection = resolveModelCatalogSelection({
+      models: [
+        model("cursor/cursor-grok-4.6-fast", "Grok 4.6 Fast"),
+        model("openrouter/x-ai/grok-4.6", "Grok 4.6"),
+        model("xai-oauth/grok-4.6", "Grok 4.6"),
+      ],
+      selectedOnlyModels: [],
+      selectedModel: "cursor/cursor-grok-4.6-fast",
+      provider: { id: "acp-omp" },
+      catalogIsVerified: true,
+      formatModelLabel: (value) => value,
+    });
+
+    expect(selection.modelOptions).toEqual([
+      {
+        value: "cursor/cursor-grok-4.6-fast",
+        label: "Grok 4.6 Fast",
+        qualifier: "Cursor",
+      },
+      {
+        value: "openrouter/x-ai/grok-4.6",
+        label: "Grok 4.6",
+        qualifier: "OpenRouter",
+      },
+      {
+        value: "xai-oauth/grok-4.6",
+        label: "Grok 4.6",
+        qualifier: "xAI OAuth",
+      },
+    ]);
+  });
+
+  it("does not label namespaced models from other agent providers", () => {
+    const selection = resolveModelCatalogSelection({
+      models: [model("vendor/model", "Model")],
+      selectedOnlyModels: [],
+      selectedModel: "vendor/model",
+      provider: { id: "another-provider" },
+      catalogIsVerified: true,
+      formatModelLabel: (value) => value,
+    });
+
+    expect(selection.modelOptions).toEqual([
+      { value: "vendor/model", label: "Model" },
+    ]);
+  });
+});

--- a/apps/app/src/hooks/thread-creation-options/model-catalog-selection.ts
+++ b/apps/app/src/hooks/thread-creation-options/model-catalog-selection.ts
@@ -1,21 +1,21 @@
 import {
   reconcileReasoningLevel,
   type AvailableModel,
+  type ProviderInfo,
   type ReasoningLevel,
 } from "@bb/domain";
 import type { ModelPickerOption } from "@/components/pickers/model-picker-option";
 import type { PickerOption } from "@/components/pickers/OptionPicker";
-import {
-  reasoningLevelLabel,
-  type ReasoningLabelSource,
-} from "@/lib/reasoning-labels";
+import { reasoningLevelLabel } from "@/lib/reasoning-labels";
+
+type ModelCatalogProvider = Pick<ProviderInfo, "id" | "reasoningLevels">;
 
 interface ResolveModelCatalogSelectionArgs {
   models: readonly AvailableModel[];
   selectedOnlyModels: readonly AvailableModel[];
   selectedModel: string;
   preferredReasoningLevel?: ReasoningLevel;
-  provider: ReasoningLabelSource | undefined;
+  provider: ModelCatalogProvider | undefined;
   catalogIsVerified: boolean;
   formatModelLabel: (displayName: string) => string;
 }
@@ -30,13 +30,41 @@ interface ResolvedModelCatalogSelection {
   isUnavailableModelRecovery: boolean;
 }
 
+const OMP_MODEL_SOURCE_LABELS: Readonly<Record<string, string>> = {
+  anthropic: "Anthropic",
+  cursor: "Cursor",
+  "kimi-code": "Kimi Code",
+  ollama: "Ollama",
+  "openai-codex": "OpenAI Codex",
+  openrouter: "OpenRouter",
+  "xai-oauth": "xAI OAuth",
+};
+
+function modelSourceQualifier(
+  provider: ModelCatalogProvider | undefined,
+  model: AvailableModel,
+): string | undefined {
+  if (provider?.id !== "acp-omp") {
+    return undefined;
+  }
+  const separator = model.model.indexOf("/");
+  if (separator <= 0) {
+    return undefined;
+  }
+  const source = model.model.slice(0, separator);
+  return OMP_MODEL_SOURCE_LABELS[source] ?? source;
+}
+
 function toModelPickerOption(
   model: AvailableModel,
   formatModelLabel: (displayName: string) => string,
+  provider: ModelCatalogProvider | undefined,
 ): ModelPickerOption {
+  const qualifier = modelSourceQualifier(provider, model);
   return {
     value: model.model,
     label: formatModelLabel(model.displayName || model.model),
+    ...(qualifier ? { qualifier } : {}),
     ...(model.routeProviderId
       ? { routeProviderId: model.routeProviderId }
       : {}),
@@ -124,14 +152,14 @@ export function resolveModelCatalogSelection({
     selectedModel,
     activeModel,
     modelOptions: availableModels.map((model) =>
-      toModelPickerOption(model, formatModelLabel),
+      toModelPickerOption(model, formatModelLabel, provider),
     ),
     moreModelOptions: selectedOnlyModels
       .filter(
         (model) =>
           !availableModels.some((active) => active.model === model.model),
       )
-      .map((model) => toModelPickerOption(model, formatModelLabel)),
+      .map((model) => toModelPickerOption(model, formatModelLabel, provider)),
     reasoningLevel,
     reasoningOptions,
     isUnavailableModelRecovery:

--- a/packages/client-core/src/timeline/timeline-auto-expand.ts
+++ b/packages/client-core/src/timeline/timeline-auto-expand.ts
@@ -12,12 +12,54 @@ interface CollectTimelineAutoExpansionRowIdsArgs {
 }
 
 export interface TimelineAutoExpansionRowIds {
+  defaultExpandedRowIds: ReadonlySet<string>;
   /**
    * Rows the timeline opens for as long as the condition holds and closes
    * again when it stops: the active scope's live frontier.
    */
   liveExpandedRowIds: ReadonlySet<string>;
   terminalFrontierRowIds: ReadonlySet<string>;
+}
+
+function isDefaultExpandedRow(row: ThreadTimelineViewRow): boolean {
+  return (
+    isRowExpandable(row) &&
+    row.kind === "work" &&
+    row.workKind === "extension" &&
+    row.extensionKind === "provider-acp/advisor"
+  );
+}
+
+function visitForDefaultAutoExpand(
+  rows: readonly ThreadTimelineViewRow[],
+  ids: Set<string>,
+): void {
+  for (const row of rows) {
+    if (isDefaultExpandedRow(row)) {
+      ids.add(row.id);
+    }
+    switch (row.kind) {
+      case "conversation":
+      case "system":
+        break;
+      case "bundle-summary":
+      case "step-summary":
+        visitForDefaultAutoExpand(row.children, ids);
+        break;
+      case "turn":
+        if (row.children) {
+          visitForDefaultAutoExpand(row.children, ids);
+        }
+        break;
+      case "work":
+        if (row.workKind === "delegation") {
+          visitForDefaultAutoExpand(row.childRows, ids);
+        }
+        break;
+      default:
+        assertNever(row);
+    }
+  }
 }
 
 export function isWorkRowExpandable(row: TimelineViewWorkRow): boolean {
@@ -183,11 +225,14 @@ export function collectTimelineAutoExpansionRowIds({
   rows,
   scopeActive,
 }: CollectTimelineAutoExpansionRowIdsArgs): TimelineAutoExpansionRowIds {
+  const defaultExpandedRowIds = new Set<string>();
   const terminalFrontierRowIds = new Set<string>();
   const liveExpandedRowIds = new Set<string>();
+  visitForDefaultAutoExpand(rows, defaultExpandedRowIds);
   visitForTerminalFrontierAutoExpand(rows, terminalFrontierRowIds);
   visitForLiveFrontierAutoExpand(rows, scopeActive, liveExpandedRowIds);
   return {
+    defaultExpandedRowIds,
     liveExpandedRowIds,
     terminalFrontierRowIds,
   };

--- a/packages/host-daemon-contract/src/protocol.ts
+++ b/packages/host-daemon-contract/src/protocol.ts
@@ -1,3 +1,3 @@
-export const HOST_DAEMON_PROTOCOL_VERSION = 177 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 178 as const;
 
 export const HOST_ARTIFACT_MAX_BYTES = 256 * 1024 * 1024;

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -935,7 +935,7 @@ const ACP_BRIDGE_LAUNCH = {
 
 describe("host-daemon command schemas", () => {
   it("uses the current host-daemon protocol version", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(177);
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(178);
     expect(HOST_ARTIFACT_MAX_BYTES).toBe(256 * 1024 * 1024);
   });
 

--- a/packages/provider-bridge-acp/src/bridge/bridge.test.ts
+++ b/packages/provider-bridge-acp/src/bridge/bridge.test.ts
@@ -1,14 +1,16 @@
 import {
   chmodSync,
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   rmSync,
   symlinkSync,
+  writeFileSync,
 } from "node:fs";
 import { createConnection } from "node:net";
 import { tmpdir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createStandaloneBuiltinCompactCommandInput } from "@bb/domain";
@@ -2402,6 +2404,96 @@ describe("acp bridge", () => {
       expect(threadEventsOfType("thread/compacted")).toHaveLength(1);
     },
   );
+
+  it("adds OMP advisor transcript output to the thread timeline", async () => {
+    const ompAgentDir = join(workspaceDir, "omp-agent");
+    const { providerThreadId } = await startThread({
+      dialectId: "omp",
+      envVars: { PI_CODING_AGENT_DIR: ompAgentDir },
+    });
+    const turnId = sendTurnRequest("turn/start", providerThreadId, {
+      input: [{ type: "text", text: "slow review this", mentions: [] }],
+    });
+    await waitFor(
+      () =>
+        agentMessageTexts().includes("echo:slow review this")
+          ? true
+          : undefined,
+      "slow OMP turn to start",
+    );
+
+    const artifactDir = join(
+      ompAgentDir,
+      "sessions",
+      `-tmp-${basename(workspaceDir)}`,
+      `2026-09-02T00-00-00-000Z_${providerThreadId}`,
+    );
+    mkdirSync(artifactDir, { recursive: true });
+    writeFileSync(
+      join(artifactDir, "__advisor.jsonl"),
+      [
+        {
+          type: "message",
+          id: "review-1",
+          message: {
+            role: "user",
+            content: [{ type: "text", text: "### Session update" }],
+          },
+        },
+        {
+          type: "message",
+          id: "response-1",
+          message: {
+            role: "assistant",
+            provider: "anthropic",
+            model: "claude-fable-5-1",
+            stopReason: "stop",
+            content: [{ type: "text", text: "Silent — no concerns." }],
+          },
+        },
+      ]
+        .map((entry) => JSON.stringify(entry))
+        .join("\n") + "\n",
+    );
+
+    const completed = await waitFor(
+      () =>
+        threadEventsOfType("item/completed").find((event) => {
+          const item = event.item;
+          const record = item as Record<string, unknown>;
+          return (
+            typeof item === "object" &&
+            item !== null &&
+            !Array.isArray(item) &&
+            record.type === "extension" &&
+            record.kind === "provider-acp/advisor"
+          );
+        }),
+      "OMP advisor extension item",
+    );
+    expect(completed).toMatchObject({
+      item: {
+        type: "extension",
+        kind: "provider-acp/advisor",
+        status: "completed",
+        payload: {
+          advisor: "default",
+          provider: "anthropic",
+          model: "claude-fable-5-1",
+          output: "Silent — no concerns.",
+          notes: [],
+        },
+        presentation: {
+          title: "anthropic/claude-fable-5-1",
+          detail: "Silent — no concerns.",
+        },
+      },
+    });
+    await waitForResponse(turnId);
+    await waitForTurnCompleted();
+    expect(threadEventsOfType("turn/started")).toHaveLength(1);
+    expect(threadEventsOfType("turn/completed")).toHaveLength(1);
+  });
 
   it("fails the compaction turn when the agent reports the failure in an end-turn message", async () => {
     const { providerThreadId } = await startThread({

--- a/packages/provider-bridge-acp/src/bridge/bridge.ts
+++ b/packages/provider-bridge-acp/src/bridge/bridge.ts
@@ -139,6 +139,10 @@ import {
   runAcpDynamicToolMcpServer,
   type AcpMcpServerConfig,
 } from "./tool-proxy-mcp.js";
+import {
+  createOmpAdvisorTranscriptObserver,
+  type OmpAdvisorTranscriptObserver,
+} from "./omp-advisor-observer.js";
 
 interface AcpSessionPolicy {
   permissionMode: "accept-edits" | "full";
@@ -180,6 +184,7 @@ interface AcpThreadSession {
   pendingPermissions: Set<PendingAcpPermission>;
   cursorMcpApproval: CursorMcpApproval | undefined;
   deferStartEmit: AcpDeferredStartEmitter | undefined;
+  advisorObserver: OmpAdvisorTranscriptObserver | undefined;
 }
 
 type AcpDeferredStartEmitter = (
@@ -1567,6 +1572,8 @@ function liveSessionForThread(
 }
 
 function removeSession(session: AcpThreadSession): void {
+  session.advisorObserver?.stop();
+  session.advisorObserver = undefined;
   if (sessionsByBbThreadId.get(session.bbThreadId) === session) {
     sessionsByBbThreadId.delete(session.bbThreadId);
   }
@@ -1723,6 +1730,7 @@ async function startAgentSession(
     pendingPermissions: new Set(),
     cursorMcpApproval: undefined,
     deferStartEmit: emitStartNotification,
+    advisorObserver: undefined,
   };
   sessionsByBbThreadId.set(bbThreadId, session);
 
@@ -1879,6 +1887,26 @@ async function startAgentSession(
       sessionRestorable: session.supportsLoadSession,
     });
     sendThreadDeltas(bbThreadId, [{ kind: "session.reset" }]);
+    if (session.dialect.id === "omp") {
+      const observer = createOmpAdvisorTranscriptObserver({
+        providerThreadId: sessionId,
+        cwd: params.cwd,
+        env: childEnv,
+        ignoreExisting: request.kind === "resume",
+        isTurnActive: () => session.activePromptKind === "turn",
+        emit: (deltas) => {
+          if (
+            sessionsByBbThreadId.get(bbThreadId) === session &&
+            !session.stopping &&
+            session.activePromptKind === "turn"
+          ) {
+            sendThreadDeltas(bbThreadId, deltas);
+          }
+        },
+      });
+      session.advisorObserver = observer;
+      await observer.start().catch(() => undefined);
+    }
     session.deferStartEmit = undefined;
     for (const deferred of deferredEmits) {
       if (
@@ -2017,6 +2045,7 @@ function finishTurn(
   if (session.activePromptKind !== "turn") {
     return;
   }
+  session.advisorObserver?.finishTurn();
   session.activePromptKind = null;
   dropQueuedTurnInputs(session, "ACP turn ended before the steer was sent");
   session.promptRequestPending = false;
@@ -2037,6 +2066,7 @@ function runTurn(
   });
 
   session.turnSettled = (async () => {
+    await session.advisorObserver?.prepareTurn().catch(() => undefined);
     let pending = firstInput;
     for (;;) {
       if (session.stopping) {
@@ -2063,6 +2093,7 @@ function runTurn(
         }
         const result = await promptResult;
         stopReason = result.stopReason;
+        await session.advisorObserver?.poll();
       } catch (error) {
         session.promptRequestPending = false;
         dropTurnInput(pending, "ACP turn failed before the prompt was sent");
@@ -2077,6 +2108,7 @@ function runTurn(
             error instanceof Error ? error.message : String(error),
           );
         }
+        session.advisorObserver?.finishTurn();
         session.activePromptKind = null;
         return;
       }

--- a/packages/provider-bridge-acp/src/bridge/omp-advisor-observer.test.ts
+++ b/packages/provider-bridge-acp/src/bridge/omp-advisor-observer.test.ts
@@ -1,0 +1,521 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ThreadDelta } from "@bb/provider-bridge-protocol";
+import {
+  createOmpAdvisorTranscriptObserver,
+  type OmpAdvisorTranscriptObserver,
+} from "./omp-advisor-observer.js";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function temporaryRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "bb-omp-advisor-"));
+  roots.push(root);
+  return root;
+}
+
+function appendEntries(path: string, entries: readonly unknown[]): void {
+  const text = entries.map((entry) => JSON.stringify(entry)).join("\n");
+  writeFileSync(path, `${text}\n`, { flag: "a" });
+}
+
+function sessionUpdate(id: string): unknown {
+  return {
+    type: "message",
+    id,
+    message: {
+      role: "user",
+      content: [{ type: "text", text: "### Session update" }],
+    },
+  };
+}
+
+function advisorContext(id: string): unknown {
+  return {
+    type: "message",
+    id,
+    message: {
+      role: "user",
+      content: [{ type: "text", text: "**agent**:" }],
+    },
+  };
+}
+
+function advisorResponse(args: {
+  id: string;
+  model: string;
+  provider: string;
+  content: readonly unknown[];
+  stopReason: string;
+  errorMessage?: string;
+}): unknown {
+  return {
+    type: "message",
+    id: args.id,
+    message: {
+      role: "assistant",
+      content: args.content,
+      provider: args.provider,
+      model: args.model,
+      stopReason: args.stopReason,
+      ...(args.errorMessage === undefined
+        ? {}
+        : { errorMessage: args.errorMessage }),
+    },
+  };
+}
+
+function observerFixture(
+  advisorFileName = "__advisor.jsonl",
+  ignoreExisting = false,
+): {
+  artifactDir: string;
+  deltas: ThreadDelta[];
+  observer: OmpAdvisorTranscriptObserver;
+  transcriptPath: string;
+} {
+  const root = temporaryRoot();
+  const sessionDir = join(root, "sessions");
+  const artifactDir = join(
+    sessionDir,
+    "2026-09-02T00-00-00-000Z_provider-session",
+  );
+  mkdirSync(artifactDir, { recursive: true });
+  const transcriptPath = join(artifactDir, advisorFileName);
+  const deltas: ThreadDelta[] = [];
+  const observer = createOmpAdvisorTranscriptObserver({
+    providerThreadId: "provider-session",
+    cwd: root,
+    env: {},
+    ignoreExisting,
+    sessionDir,
+    pollIntervalMs: null,
+    emit: (next) => deltas.push(...next),
+  });
+  return { artifactDir, deltas, observer, transcriptPath };
+}
+
+function lastClose(deltas: readonly ThreadDelta[]): ThreadDelta | undefined {
+  for (let index = deltas.length - 1; index >= 0; index -= 1) {
+    const delta = deltas[index];
+    if (delta?.kind === "item.close") {
+      return delta;
+    }
+  }
+  return undefined;
+}
+
+describe("OMP advisor transcript observer", () => {
+  it("shows a pending review, then its note and exact model", async () => {
+    const { deltas, observer, transcriptPath } = observerFixture();
+    await observer.start();
+
+    appendEntries(transcriptPath, [sessionUpdate("review-1")]);
+    await observer.poll();
+
+    expect(deltas).toEqual([
+      expect.objectContaining({
+        kind: "item.open",
+        key: { providerItemId: "omp-advisor:default:review-1" },
+        item: expect.objectContaining({
+          type: "extension",
+          kind: "provider-acp/advisor",
+          payload: expect.objectContaining({
+            advisor: "default",
+            model: null,
+            output: null,
+          }),
+        }),
+        presentation: expect.objectContaining({
+          label: {
+            pending: "Advisor reviewing",
+            completed: "Advisor reviewed",
+          },
+        }),
+      }),
+    ]);
+
+    appendEntries(transcriptPath, [
+      advisorResponse({
+        id: "response-1",
+        provider: "anthropic",
+        model: "claude-fable-5-1",
+        stopReason: "toolUse",
+        content: [
+          {
+            type: "toolCall",
+            id: "call-1",
+            name: "advise",
+            arguments: { note: "Keep the existing API.", severity: "concern" },
+          },
+        ],
+      }),
+    ]);
+    await observer.poll();
+
+    expect(lastClose(deltas)).toEqual(
+      expect.objectContaining({
+        kind: "item.close",
+        key: { providerItemId: "omp-advisor:default:review-1" },
+        status: "completed",
+        item: expect.objectContaining({
+          type: "extension",
+          kind: "provider-acp/advisor",
+          payload: {
+            advisor: "default",
+            provider: "anthropic",
+            model: "claude-fable-5-1",
+            output: "**Concern:** Keep the existing API.",
+            notes: [{ note: "Keep the existing API.", severity: "concern" }],
+          },
+        }),
+        presentation: expect.objectContaining({
+          title: "anthropic/claude-fable-5-1",
+          detail: "**Concern:** Keep the existing API.",
+        }),
+      }),
+    );
+    expect(deltas.map((delta) => delta.kind)).toEqual([
+      "item.open",
+      "item.close",
+    ]);
+  });
+
+  it("does not treat OMP context messages as separate reviews", async () => {
+    const { deltas, observer, transcriptPath } = observerFixture();
+    await observer.start();
+    appendEntries(transcriptPath, [
+      sessionUpdate("review-context"),
+      advisorContext("context-message"),
+      advisorResponse({
+        id: "response-context",
+        provider: "openrouter",
+        model: "anthropic/claude-opus-4.8",
+        stopReason: "stop",
+        content: [{ type: "text", text: "Silent — no concerns." }],
+      }),
+    ]);
+    await observer.poll();
+
+    expect(deltas.filter((delta) => delta.kind === "item.open")).toHaveLength(
+      1,
+    );
+    expect(lastClose(deltas)).toMatchObject({
+      status: "completed",
+      item: { payload: { output: "Silent — no concerns." } },
+    });
+  });
+
+  it("marks a superseded advisor review as interrupted", async () => {
+    const { deltas, observer, transcriptPath } = observerFixture();
+    await observer.start();
+    appendEntries(transcriptPath, [
+      sessionUpdate("review-superseded"),
+      advisorResponse({
+        id: "response-reading",
+        provider: "anthropic",
+        model: "claude-fable-5-1",
+        stopReason: "toolUse",
+        content: [{ type: "toolCall", name: "grep", arguments: {} }],
+      }),
+      sessionUpdate("review-next"),
+    ]);
+    await observer.poll();
+
+    const interrupted = deltas.find(
+      (delta) => delta.kind === "item.close" && delta.status === "interrupted",
+    );
+    expect(interrupted).toMatchObject({
+      presentation: {
+        label: { completed: "Advisor stopped" },
+        detail: "Advisor review stopped before responding.",
+      },
+    });
+  });
+
+  it("closes a pending review when the main turn ends", async () => {
+    const { deltas, observer, transcriptPath } = observerFixture();
+    await observer.start();
+    appendEntries(transcriptPath, [sessionUpdate("review-ending")]);
+    await observer.poll();
+
+    observer.finishTurn();
+
+    expect(lastClose(deltas)).toMatchObject({
+      status: "interrupted",
+      presentation: {
+        label: { completed: "Advisor stopped" },
+        detail: "Advisor review stopped before responding.",
+      },
+    });
+  });
+
+  it("shows a silent named advisor review", async () => {
+    const { deltas, observer, transcriptPath } = observerFixture(
+      "__advisor.security.jsonl",
+    );
+    await observer.start();
+    appendEntries(transcriptPath, [
+      sessionUpdate("review-2"),
+      advisorResponse({
+        id: "response-3",
+        provider: "openrouter",
+        model: "anthropic/claude-opus-4.8",
+        stopReason: "stop",
+        content: [{ type: "text", text: "Silent — no concerns." }],
+      }),
+    ]);
+    await observer.poll();
+
+    expect(lastClose(deltas)).toEqual(
+      expect.objectContaining({
+        kind: "item.close",
+        status: "completed",
+        item: expect.objectContaining({
+          payload: expect.objectContaining({
+            advisor: "security",
+            provider: "openrouter",
+            model: "anthropic/claude-opus-4.8",
+            output: "Silent — no concerns.",
+            notes: [],
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("marks an advisor model error as failed", async () => {
+    const { deltas, observer, transcriptPath } = observerFixture();
+    await observer.start();
+    appendEntries(transcriptPath, [
+      sessionUpdate("review-3"),
+      advisorResponse({
+        id: "response-4",
+        provider: "anthropic",
+        model: "claude-fable-5-1",
+        stopReason: "error",
+        errorMessage: "Quota exhausted",
+        content: [],
+      }),
+    ]);
+    await observer.poll();
+
+    expect(lastClose(deltas)).toEqual(
+      expect.objectContaining({
+        kind: "item.close",
+        status: "failed",
+        presentation: expect.objectContaining({
+          label: {
+            pending: "Advisor reviewing",
+            completed: "Advisor failed",
+          },
+          detail: "Quota exhausted",
+        }),
+      }),
+    );
+  });
+
+  it("keeps full output in the payload and bounds the fallback detail", async () => {
+    const { deltas, observer, transcriptPath } = observerFixture();
+    const output = "Long advisor output ".repeat(40);
+    await observer.start();
+    appendEntries(transcriptPath, [
+      sessionUpdate("review-long"),
+      advisorResponse({
+        id: "response-long",
+        provider: "anthropic",
+        model: "claude-fable-5-1",
+        stopReason: "stop",
+        content: [{ type: "text", text: output }],
+      }),
+    ]);
+    await observer.poll();
+
+    expect(lastClose(deltas)).toMatchObject({
+      item: { payload: { output: output.trim() } },
+      presentation: { detail: expect.any(String) },
+    });
+    const close = lastClose(deltas);
+    expect(
+      close?.kind === "item.close" ? close.presentation?.detail?.length : 0,
+    ).toBe(280);
+  });
+
+  it("does not replay reviews already present when a session resumes", async () => {
+    const { deltas, observer, transcriptPath } = observerFixture(
+      "__advisor.jsonl",
+      true,
+    );
+    appendEntries(transcriptPath, [
+      sessionUpdate("old-review"),
+      advisorResponse({
+        id: "old-response",
+        provider: "anthropic",
+        model: "claude-fable-5-1",
+        stopReason: "stop",
+        content: [{ type: "text", text: "Old output" }],
+      }),
+    ]);
+
+    await observer.start();
+    expect(deltas).toEqual([]);
+
+    appendEntries(transcriptPath, [
+      sessionUpdate("new-review"),
+      advisorResponse({
+        id: "new-response",
+        provider: "anthropic",
+        model: "claude-fable-5-1",
+        stopReason: "stop",
+        content: [{ type: "text", text: "New output" }],
+      }),
+    ]);
+    await observer.poll();
+
+    expect(deltas).toHaveLength(2);
+    expect(lastClose(deltas)).toEqual(
+      expect.objectContaining({
+        kind: "item.close",
+        item: expect.objectContaining({
+          payload: expect.objectContaining({ output: "New output" }),
+        }),
+      }),
+    );
+  });
+
+  it("does not replay a resumed transcript discovered after startup", async () => {
+    const root = temporaryRoot();
+    const sessionDir = join(root, "sessions");
+    const artifactDir = join(
+      sessionDir,
+      "2026-09-02T00-00-00-000Z_provider-session",
+    );
+    const transcriptPath = join(artifactDir, "__advisor.jsonl");
+    const deltas: ThreadDelta[] = [];
+    const observer = createOmpAdvisorTranscriptObserver({
+      providerThreadId: "provider-session",
+      cwd: root,
+      env: {},
+      sessionDir,
+      ignoreExisting: true,
+      pollIntervalMs: null,
+      emit: (next) => deltas.push(...next),
+    });
+    await observer.start();
+    mkdirSync(artifactDir, { recursive: true });
+    appendEntries(transcriptPath, [
+      sessionUpdate("old-review"),
+      advisorResponse({
+        id: "old-response",
+        provider: "anthropic",
+        model: "claude-fable-5-1",
+        stopReason: "stop",
+        content: [{ type: "text", text: "Old output" }],
+      }),
+    ]);
+
+    await observer.poll();
+    expect(deltas).toEqual([]);
+    appendEntries(transcriptPath, [
+      sessionUpdate("new-review"),
+      advisorResponse({
+        id: "new-response",
+        provider: "anthropic",
+        model: "claude-fable-5-1",
+        stopReason: "stop",
+        content: [{ type: "text", text: "New output" }],
+      }),
+    ]);
+    await observer.poll();
+
+    expect(lastClose(deltas)).toMatchObject({
+      item: { payload: { output: "New output" } },
+    });
+  });
+
+  it("ignores partial and malformed lines without failing the OMP session", async () => {
+    const { deltas, observer, transcriptPath } = observerFixture();
+    await observer.start();
+    const update = JSON.stringify(sessionUpdate("review-4"));
+    const split = Math.floor(update.length / 2);
+    writeFileSync(transcriptPath, update.slice(0, split), { flag: "a" });
+    await expect(observer.poll()).resolves.toBeUndefined();
+    expect(deltas).toEqual([]);
+
+    writeFileSync(
+      transcriptPath,
+      `${update.slice(split)}\n{"type":"broken"\n`,
+      { flag: "a" },
+    );
+    await expect(observer.poll()).resolves.toBeUndefined();
+    expect(deltas).toEqual([
+      expect.objectContaining({
+        kind: "item.open",
+        key: { providerItemId: "omp-advisor:default:review-4" },
+      }),
+    ]);
+  });
+
+  it("preserves multi-byte text split across polls", async () => {
+    const { deltas, observer, transcriptPath } = observerFixture();
+    await observer.start();
+    const transcript = Buffer.from(
+      `${JSON.stringify(sessionUpdate("review-unicode"))}\n${JSON.stringify(
+        advisorResponse({
+          id: "response-unicode",
+          provider: "anthropic",
+          model: "claude-fable-5-1",
+          stopReason: "toolUse",
+          content: [
+            {
+              type: "toolCall",
+              name: "advise",
+              arguments: { note: "Keep — exact", severity: "concern" },
+            },
+          ],
+        }),
+      )}\n`,
+    );
+    const emDashIndex = transcript.indexOf(Buffer.from("—"));
+    expect(emDashIndex).toBeGreaterThan(0);
+
+    writeFileSync(transcriptPath, transcript.subarray(0, emDashIndex + 1), {
+      flag: "a",
+    });
+    await observer.poll();
+    writeFileSync(transcriptPath, transcript.subarray(emDashIndex + 1), {
+      flag: "a",
+    });
+    await observer.poll();
+
+    expect(lastClose(deltas)).toMatchObject({
+      item: { payload: { output: "**Concern:** Keep — exact" } },
+    });
+  });
+
+  it("stops scheduled polling", async () => {
+    vi.useFakeTimers();
+    const { observer } = observerFixture();
+    const scheduled = createOmpAdvisorTranscriptObserver({
+      providerThreadId: "provider-session",
+      cwd: temporaryRoot(),
+      env: {},
+      sessionDir: temporaryRoot(),
+      pollIntervalMs: 50,
+      emit: () => undefined,
+    });
+    await scheduled.start();
+    scheduled.stop();
+    await vi.advanceTimersByTimeAsync(100);
+    observer.stop();
+    vi.useRealTimers();
+  });
+});

--- a/packages/provider-bridge-acp/src/bridge/omp-advisor-observer.ts
+++ b/packages/provider-bridge-acp/src/bridge/omp-advisor-observer.ts
@@ -1,0 +1,622 @@
+import { promises as fs } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { basename, isAbsolute, join, relative, resolve } from "node:path";
+import type { JsonObject } from "@bb/domain";
+import { presentationDetail } from "@bb/provider-bridge-protocol/bridge-kit";
+import type {
+  DeltaPresentation,
+  ThreadDelta,
+} from "@bb/provider-bridge-protocol";
+
+const OMP_ADVISOR_EXTENSION_KIND = "provider-acp/advisor";
+const OMP_ADVISOR_FILE_PATTERN = /^__advisor(?:\.([a-z0-9-]+))?\.jsonl$/;
+const OMP_TRANSCRIPT_ID_PATTERN = /^[a-zA-Z0-9._:-]{1,128}$/;
+const OMP_PROFILE_PATTERN = /^[a-z0-9][a-z0-9._-]{0,63}$/;
+const TOOL_USE_STOP_REASONS = new Set(["toolUse", "tool_use"]);
+const FAILED_STOP_REASONS = new Set(["aborted", "cancelled", "error"]);
+
+interface OmpAdvisorNote {
+  note: string;
+  severity?: string;
+}
+
+interface OmpAdvisorReview {
+  key: string;
+  notes: OmpAdvisorNote[];
+  provider: string | null;
+  model: string | null;
+  finalText: string | null;
+}
+
+interface TranscriptCursor {
+  offset: number;
+  remainder: Buffer;
+  parser: OmpAdvisorTranscriptParser;
+}
+
+interface OmpAdvisorTranscriptObserverOptions {
+  providerThreadId: string;
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  emit(deltas: readonly ThreadDelta[]): void;
+  ignoreExisting?: boolean;
+  sessionDir?: string;
+  pollIntervalMs?: number | null;
+  isTurnActive?(): boolean;
+}
+
+export interface OmpAdvisorTranscriptObserver {
+  start(): Promise<void>;
+  prepareTurn(): Promise<void>;
+  poll(): Promise<void>;
+  finishTurn(): void;
+  stop(): void;
+}
+
+function textContent(content: unknown): string | null {
+  if (typeof content === "string") {
+    return content.trim() || null;
+  }
+  if (!Array.isArray(content)) {
+    return null;
+  }
+  const text = content
+    .flatMap((block) => {
+      if (
+        typeof block === "object" &&
+        block !== null &&
+        "type" in block &&
+        block.type === "text" &&
+        "text" in block &&
+        typeof block.text === "string"
+      ) {
+        return [block.text];
+      }
+      return [];
+    })
+    .join("\n")
+    .trim();
+  return text || null;
+}
+
+function advisorNotes(content: unknown): OmpAdvisorNote[] {
+  if (!Array.isArray(content)) {
+    return [];
+  }
+  const notes: OmpAdvisorNote[] = [];
+  for (const block of content) {
+    if (
+      typeof block !== "object" ||
+      block === null ||
+      !("type" in block) ||
+      block.type !== "toolCall" ||
+      !("name" in block) ||
+      block.name !== "advise" ||
+      !("arguments" in block) ||
+      typeof block.arguments !== "object" ||
+      block.arguments === null ||
+      !("note" in block.arguments) ||
+      typeof block.arguments.note !== "string" ||
+      block.arguments.note.trim().length === 0
+    ) {
+      continue;
+    }
+    const severity =
+      "severity" in block.arguments &&
+      typeof block.arguments.severity === "string" &&
+      block.arguments.severity.trim().length > 0
+        ? block.arguments.severity.trim()
+        : undefined;
+    notes.push({
+      note: block.arguments.note.trim(),
+      ...(severity === undefined ? {} : { severity }),
+    });
+  }
+  return notes;
+}
+
+function formatNotes(notes: readonly OmpAdvisorNote[]): string {
+  return notes
+    .map((note) => {
+      if (note.severity === undefined) {
+        return note.note;
+      }
+      const severity =
+        note.severity.charAt(0).toUpperCase() + note.severity.slice(1);
+      return `**${severity}:** ${note.note}`;
+    })
+    .join("\n\n");
+}
+
+function modelIdentity(review: OmpAdvisorReview): string | null {
+  if (review.model === null) {
+    return review.provider;
+  }
+  if (
+    review.provider === null ||
+    review.model.startsWith(`${review.provider}/`)
+  ) {
+    return review.model;
+  }
+  return `${review.provider}/${review.model}`;
+}
+
+function advisorTitle(advisor: string, identity: string | null): string {
+  const advisorName = advisor === "default" ? null : advisor;
+  if (advisorName !== null && identity !== null) {
+    return `${advisorName} · ${identity}`;
+  }
+  return advisorName ?? identity ?? "Advisor";
+}
+
+function presentation(args: {
+  advisor: string;
+  completedLabel: string;
+  detail?: string;
+  identity: string | null;
+}): DeltaPresentation {
+  return {
+    label: {
+      pending: "Advisor reviewing",
+      completed: args.completedLabel,
+    },
+    icon: { glyph: "Eye" },
+    title: advisorTitle(args.advisor, args.identity),
+    ...(args.detail === undefined ? {} : { detail: args.detail }),
+  };
+}
+
+function payload(
+  advisor: string,
+  review?: OmpAdvisorReview,
+  output: string | null = null,
+): JsonObject {
+  return {
+    advisor,
+    provider: review?.provider ?? null,
+    model: review?.model ?? null,
+    output,
+    notes:
+      review === undefined
+        ? []
+        : review.notes.map((note) => ({
+            note: note.note,
+            ...(note.severity === undefined ? {} : { severity: note.severity }),
+          })),
+  };
+}
+
+class OmpAdvisorTranscriptParser {
+  private current: OmpAdvisorReview | null = null;
+  private reviewSerial = 0;
+
+  constructor(private readonly advisor: string) {}
+
+  accept(entry: unknown): ThreadDelta[] {
+    if (
+      typeof entry !== "object" ||
+      entry === null ||
+      !("type" in entry) ||
+      entry.type !== "message" ||
+      !("message" in entry) ||
+      typeof entry.message !== "object" ||
+      entry.message === null ||
+      !("role" in entry.message) ||
+      typeof entry.message.role !== "string"
+    ) {
+      return [];
+    }
+    const message = entry.message;
+    if (message.role === "user") {
+      const update = "content" in message ? textContent(message.content) : null;
+      if (update?.startsWith("### Session update") !== true) {
+        return [];
+      }
+      const unfinished = this.interrupt();
+      this.reviewSerial += 1;
+      const entryId =
+        "id" in entry &&
+        typeof entry.id === "string" &&
+        OMP_TRANSCRIPT_ID_PATTERN.test(entry.id)
+          ? entry.id
+          : String(this.reviewSerial);
+      this.current = {
+        key: `omp-advisor:${this.advisor}:${entryId}`,
+        notes: [],
+        provider: null,
+        model: null,
+        finalText: null,
+      };
+      return [
+        ...unfinished,
+        {
+          kind: "item.open",
+          key: { providerItemId: this.current.key },
+          item: {
+            type: "extension",
+            kind: OMP_ADVISOR_EXTENSION_KIND,
+            payload: payload(this.advisor),
+          },
+          presentation: presentation({
+            advisor: this.advisor,
+            completedLabel: "Advisor reviewed",
+            identity: null,
+          }),
+        },
+      ];
+    }
+    if (message.role !== "assistant" || this.current === null) {
+      return [];
+    }
+    if (
+      "provider" in message &&
+      typeof message.provider === "string" &&
+      message.provider.trim().length > 0
+    ) {
+      this.current.provider = message.provider.trim();
+    }
+    if (
+      "model" in message &&
+      typeof message.model === "string" &&
+      message.model.trim().length > 0
+    ) {
+      this.current.model = message.model.trim();
+    }
+    const notes = "content" in message ? advisorNotes(message.content) : [];
+    if ("content" in message) {
+      this.current.notes.push(...notes);
+      const finalText = textContent(message.content);
+      if (finalText !== null) {
+        this.current.finalText = finalText;
+      }
+    }
+    const stopReason =
+      "stopReason" in message && typeof message.stopReason === "string"
+        ? message.stopReason
+        : null;
+    const errorMessage =
+      "errorMessage" in message && typeof message.errorMessage === "string"
+        ? message.errorMessage.trim()
+        : "";
+    const failed =
+      errorMessage.length > 0 ||
+      (stopReason !== null && FAILED_STOP_REASONS.has(stopReason));
+    const noteOutput = formatNotes(this.current.notes);
+    if (
+      !failed &&
+      notes.length === 0 &&
+      stopReason !== null &&
+      TOOL_USE_STOP_REASONS.has(stopReason)
+    ) {
+      return [];
+    }
+    const output =
+      errorMessage ||
+      noteOutput ||
+      this.current.finalText ||
+      "No advisor note.";
+    return this.close(failed ? "failed" : "completed", output);
+  }
+
+  interrupt(): ThreadDelta[] {
+    return this.close(
+      "interrupted",
+      "Advisor review stopped before responding.",
+    );
+  }
+
+  private close(
+    status: "completed" | "failed" | "interrupted",
+    output: string,
+  ): ThreadDelta[] {
+    const review = this.current;
+    if (review === null) {
+      return [];
+    }
+    this.current = null;
+    const identity = modelIdentity(review);
+    return [
+      {
+        kind: "item.close",
+        key: { providerItemId: review.key },
+        status,
+        item: {
+          type: "extension",
+          kind: OMP_ADVISOR_EXTENSION_KIND,
+          payload: payload(this.advisor, review, output),
+        },
+        presentation: presentation({
+          advisor: this.advisor,
+          completedLabel:
+            status === "failed"
+              ? "Advisor failed"
+              : status === "interrupted"
+                ? "Advisor stopped"
+                : "Advisor reviewed",
+          detail: presentationDetail(output),
+          identity,
+        }),
+      },
+    ];
+  }
+}
+
+function profileName(env: NodeJS.ProcessEnv): string | null {
+  const raw = env.OMP_PROFILE !== undefined ? env.OMP_PROFILE : env.PI_PROFILE;
+  const value = raw?.trim();
+  if (
+    value === undefined ||
+    value === "" ||
+    value === "default" ||
+    !OMP_PROFILE_PATTERN.test(value)
+  ) {
+    return null;
+  }
+  return value;
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await fs.access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveOmpSessionsRoot(
+  cwd: string,
+  env: NodeJS.ProcessEnv,
+): Promise<string> {
+  const home = homedir();
+  const configRoot = join(home, env.PI_CONFIG_DIR || ".omp");
+  const profile = profileName(env);
+  const profileRoot =
+    profile === null ? configRoot : join(configRoot, "profiles", profile);
+  const defaultAgentDir = join(profileRoot, "agent");
+  const configuredAgentDir = env.PI_CODING_AGENT_DIR?.trim();
+  const agentDir =
+    profile === null && configuredAgentDir
+      ? resolve(cwd, configuredAgentDir)
+      : defaultAgentDir;
+  const xdgRoot = env.XDG_DATA_HOME?.trim();
+  if (agentDir === defaultAgentDir && xdgRoot) {
+    const appRoot = join(xdgRoot, "omp");
+    const profileDataRoot =
+      profile === null ? appRoot : join(appRoot, "profiles", profile);
+    if (await pathExists(profileDataRoot)) {
+      return join(profileDataRoot, "sessions");
+    }
+  }
+  return join(agentDir, "sessions");
+}
+
+async function canonicalPath(path: string): Promise<string> {
+  try {
+    return await fs.realpath(path);
+  } catch {
+    return resolve(path);
+  }
+}
+
+function relativeWithin(root: string, target: string): string | null {
+  const value = relative(root, target);
+  return value === "" || (!value.startsWith("..") && !isAbsolute(value))
+    ? value
+    : null;
+}
+
+function encodeRelative(prefix: string, value: string): string {
+  const encoded = value.replace(/[/\\:]/g, "-");
+  if (!encoded) {
+    return prefix;
+  }
+  return prefix.endsWith("-") ? `${prefix}${encoded}` : `${prefix}-${encoded}`;
+}
+
+async function resolveOmpSessionDir(
+  cwd: string,
+  env: NodeJS.ProcessEnv,
+): Promise<string> {
+  const sessionsRoot = await resolveOmpSessionsRoot(cwd, env);
+  const target = await canonicalPath(cwd);
+  const home = await canonicalPath(homedir());
+  const temporary = await canonicalPath(tmpdir());
+  const homeRelative = relativeWithin(home, target);
+  const temporaryRelative = relativeWithin(temporary, target);
+  const encoded =
+    homeRelative !== null
+      ? encodeRelative("-", homeRelative)
+      : temporaryRelative !== null
+        ? encodeRelative("-tmp", temporaryRelative)
+        : `--${target.replace(/^[/\\]/, "").replace(/[/\\:]/g, "-")}--`;
+  return join(sessionsRoot, encoded);
+}
+
+function advisorName(path: string): string | null {
+  const name = basename(path);
+  const match = OMP_ADVISOR_FILE_PATTERN.exec(name);
+  return match === null ? null : (match[1] ?? "default");
+}
+
+class FileBackedOmpAdvisorTranscriptObserver implements OmpAdvisorTranscriptObserver {
+  private active = false;
+  private artifactDir: string | null = null;
+  private readonly cursors = new Map<string, TranscriptCursor>();
+  private shouldPrimeFirstArtifact: boolean;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private polling: Promise<void> = Promise.resolve();
+
+  constructor(private readonly options: OmpAdvisorTranscriptObserverOptions) {
+    this.shouldPrimeFirstArtifact = options.ignoreExisting === true;
+  }
+
+  async start(): Promise<void> {
+    if (this.active) {
+      return;
+    }
+    this.active = true;
+    await this.scan();
+    const interval =
+      this.options.pollIntervalMs === undefined
+        ? 200
+        : this.options.pollIntervalMs;
+    if (interval !== null) {
+      this.timer = setInterval(() => void this.poll(), interval);
+      this.timer.unref?.();
+    }
+  }
+
+  async prepareTurn(): Promise<void> {
+    if (!this.active) {
+      return;
+    }
+    this.polling = this.polling
+      .then(async () => {
+        this.cursors.clear();
+        await this.scan(true);
+      })
+      .catch(() => undefined);
+    await this.polling;
+  }
+
+  poll(): Promise<void> {
+    if (!this.active || this.options.isTurnActive?.() === false) {
+      return Promise.resolve();
+    }
+    this.polling = this.polling.then(() => this.scan()).catch(() => undefined);
+    return this.polling;
+  }
+
+  finishTurn(): void {
+    for (const cursor of this.cursors.values()) {
+      const deltas = cursor.parser.interrupt();
+      if (deltas.length > 0) {
+        this.options.emit(deltas);
+      }
+    }
+  }
+
+  stop(): void {
+    this.active = false;
+    if (this.timer !== null) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  private async scan(primeExisting = false): Promise<void> {
+    if (!this.active) {
+      return;
+    }
+    if (this.artifactDir === null) {
+      this.artifactDir = await this.findArtifactDir();
+    }
+    if (this.artifactDir === null) {
+      return;
+    }
+    let entries;
+    try {
+      entries = await fs.readdir(this.artifactDir, { withFileTypes: true });
+    } catch {
+      this.artifactDir = null;
+      return;
+    }
+    const prime = primeExisting || this.shouldPrimeFirstArtifact;
+    for (const entry of entries) {
+      if (!entry.isFile() || advisorName(entry.name) === null) {
+        continue;
+      }
+      await this.readTranscript(join(this.artifactDir, entry.name), prime);
+    }
+    this.shouldPrimeFirstArtifact = false;
+  }
+
+  private async findArtifactDir(): Promise<string | null> {
+    const sessionDir =
+      this.options.sessionDir ??
+      (await resolveOmpSessionDir(this.options.cwd, this.options.env));
+    let entries;
+    try {
+      entries = await fs.readdir(sessionDir, { withFileTypes: true });
+    } catch {
+      return null;
+    }
+    const suffix = `_${this.options.providerThreadId}`;
+    const matches = entries
+      .filter((entry) => entry.isDirectory() && entry.name.endsWith(suffix))
+      .map((entry) => entry.name)
+      .sort();
+    const match = matches.at(-1);
+    return match === undefined ? null : join(sessionDir, match);
+  }
+
+  private async readTranscript(path: string, prime: boolean): Promise<void> {
+    const name = advisorName(path);
+    if (name === null) {
+      return;
+    }
+    let handle;
+    try {
+      handle = await fs.open(path, "r");
+      const stat = await handle.stat();
+      let cursor = this.cursors.get(path);
+      if (cursor === undefined) {
+        cursor = {
+          offset: prime ? stat.size : 0,
+          remainder: Buffer.alloc(0),
+          parser: new OmpAdvisorTranscriptParser(name),
+        };
+        this.cursors.set(path, cursor);
+      }
+      if (stat.size < cursor.offset) {
+        cursor.offset = 0;
+        cursor.remainder = Buffer.alloc(0);
+        cursor.parser = new OmpAdvisorTranscriptParser(name);
+      }
+      const length = stat.size - cursor.offset;
+      if (length <= 0) {
+        return;
+      }
+      const buffer = Buffer.alloc(length);
+      const result = await handle.read(buffer, 0, length, cursor.offset);
+      cursor.offset += result.bytesRead;
+      const combined = Buffer.concat([
+        cursor.remainder,
+        buffer.subarray(0, result.bytesRead),
+      ]);
+      let lineStart = 0;
+      for (let index = 0; index < combined.length; index += 1) {
+        if (combined[index] !== 0x0a) {
+          continue;
+        }
+        const line = combined.subarray(lineStart, index).toString("utf8");
+        lineStart = index + 1;
+        if (line.trim().length === 0) {
+          continue;
+        }
+        let entry: unknown;
+        try {
+          entry = JSON.parse(line);
+        } catch {
+          continue;
+        }
+        const deltas = cursor.parser.accept(entry);
+        if (deltas.length > 0) {
+          this.options.emit(deltas);
+        }
+      }
+      cursor.remainder = Buffer.from(combined.subarray(lineStart));
+    } catch {
+      return;
+    } finally {
+      await handle?.close().catch(() => undefined);
+    }
+  }
+}
+
+export function createOmpAdvisorTranscriptObserver(
+  options: OmpAdvisorTranscriptObserverOptions,
+): OmpAdvisorTranscriptObserver {
+  return new FileBackedOmpAdvisorTranscriptObserver(options);
+}

--- a/plugins/provider-acp/app.test.tsx
+++ b/plugins/provider-acp/app.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import { cleanup } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import type { PluginTimelineRendererProps } from "@get-bb/plugin-sdk/app";
+import { loadPluginApp, renderSlot } from "@get-bb/plugin-sdk/testing/app";
+
+const app = await loadPluginApp(() => import("./app"));
+
+afterEach(cleanup);
+
+function props(output: string | null): PluginTimelineRendererProps {
+  return {
+    row: {
+      id: "item_advisor",
+      threadId: "thr_test",
+      turnId: "turn_test",
+      kind: "provider-acp/advisor",
+      toolName: null,
+      status: output === null ? "pending" : "completed",
+      startedAt: 1,
+      completedAt: output === null ? null : 2,
+    },
+    payload: {
+      advisor: "default",
+      provider: "anthropic",
+      model: "claude-fable-5-1",
+      output,
+      notes: [],
+    },
+    presentation: {
+      label: {
+        pending: "Advisor reviewing",
+        completed: "Advisor reviewed",
+      },
+      icon: { glyph: "Eye" },
+    },
+    thread: { id: "thr_test", providerId: "acp-omp" },
+    Original: () => <div>Fallback detail</div>,
+  };
+}
+
+describe("OMP advisor timeline renderer", () => {
+  it("registers for the OMP advisor extension kind", () => {
+    expect(app.timelineRenderers).toHaveLength(1);
+    expect(app.timelineRenderers[0]?.kind).toBe("provider-acp/advisor");
+  });
+
+  it("shows the complete advisor output", () => {
+    const output = `**Concern:** ${"Keep this detail. ".repeat(40)}`;
+    const rendered = renderSlot(app.timelineRenderers[0]!, props(output));
+
+    expect(rendered.container.textContent).toContain("**Concern:**");
+    expect(rendered.container.textContent).toContain(
+      "Keep this detail. Keep this detail.",
+    );
+    expect(rendered.container.textContent?.length).toBeGreaterThan(280);
+  });
+
+  it("does not repeat the pending row label in its body", () => {
+    const rendered = renderSlot(app.timelineRenderers[0]!, props(null));
+    expect(rendered.container.textContent).toBe("");
+  });
+});

--- a/plugins/provider-acp/app.test.tsx
+++ b/plugins/provider-acp/app.test.tsx
@@ -56,6 +56,19 @@ describe("OMP advisor timeline renderer", () => {
     expect(rendered.container.textContent?.length).toBeGreaterThan(280);
   });
 
+  it("surrounds the advisor output with a bordered card", () => {
+    const rendered = renderSlot(
+      app.timelineRenderers[0]!,
+      props("The implementation is sound."),
+    );
+
+    expect(
+      Array.from(rendered.container.firstElementChild?.classList ?? []),
+    ).toEqual(
+      expect.arrayContaining(["rounded-md", "border", "border-border"]),
+    );
+  });
+
   it("does not repeat the pending row label in its body", () => {
     const rendered = renderSlot(app.timelineRenderers[0]!, props(null));
     expect(rendered.container.textContent).toBe("");

--- a/plugins/provider-acp/app.test.tsx
+++ b/plugins/provider-acp/app.test.tsx
@@ -56,7 +56,7 @@ describe("OMP advisor timeline renderer", () => {
     expect(rendered.container.textContent?.length).toBeGreaterThan(280);
   });
 
-  it("surrounds the advisor output with a bordered card", () => {
+  it("surrounds the advisor output with a violet-bordered card", () => {
     const rendered = renderSlot(
       app.timelineRenderers[0]!,
       props("The implementation is sound."),
@@ -65,7 +65,7 @@ describe("OMP advisor timeline renderer", () => {
     expect(
       Array.from(rendered.container.firstElementChild?.classList ?? []),
     ).toEqual(
-      expect.arrayContaining(["rounded-md", "border", "border-border"]),
+      expect.arrayContaining(["rounded-md", "border", "border-violet-500"]),
     );
   });
 

--- a/plugins/provider-acp/app.tsx
+++ b/plugins/provider-acp/app.tsx
@@ -17,7 +17,7 @@ export function OmpAdvisorTimelineRenderer({
     return null;
   }
   return (
-    <div className="rounded-md border border-border bg-surface-raised px-3 py-2">
+    <div className="rounded-md border border-violet-500 bg-surface-raised px-3 py-2">
       <Markdown content={advisor.data.output} className="text-sm" />
     </div>
   );

--- a/plugins/provider-acp/app.tsx
+++ b/plugins/provider-acp/app.tsx
@@ -1,0 +1,31 @@
+import {
+  definePluginApp,
+  Markdown,
+  type PluginTimelineRendererProps,
+} from "@get-bb/plugin-sdk/app";
+import { ompAdvisorPayloadSchema } from "./src/advisor.js";
+
+export function OmpAdvisorTimelineRenderer({
+  payload,
+  Original,
+}: PluginTimelineRendererProps) {
+  const advisor = ompAdvisorPayloadSchema.safeParse(payload);
+  if (!advisor.success) {
+    return <Original />;
+  }
+  if (advisor.data.output === null) {
+    return null;
+  }
+  return (
+    <div className="px-2 py-1">
+      <Markdown content={advisor.data.output} className="text-sm" />
+    </div>
+  );
+}
+
+export default definePluginApp((app) => {
+  app.slots.experimental_timelineRenderer({
+    kind: "provider-acp/advisor",
+    component: OmpAdvisorTimelineRenderer,
+  });
+});

--- a/plugins/provider-acp/app.tsx
+++ b/plugins/provider-acp/app.tsx
@@ -17,7 +17,7 @@ export function OmpAdvisorTimelineRenderer({
     return null;
   }
   return (
-    <div className="px-2 py-1">
+    <div className="rounded-md border border-border bg-surface-raised px-3 py-2">
       <Markdown content={advisor.data.output} className="text-sm" />
     </div>
   );

--- a/plugins/provider-acp/package.json
+++ b/plugins/provider-acp/package.json
@@ -21,6 +21,7 @@
       }
     },
     "server": "./server.ts",
+    "app": "./app.tsx",
     "host": "./src/host.ts"
   },
   "keywords": [
@@ -32,7 +33,12 @@
   },
   "devDependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^22.0.0",
+    "@types/react": "^19.0.0",
+    "jsdom": "^29.0.1",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "typescript-7": "npm:typescript@^7.0.2",
     "vitest": "^4.1.1"

--- a/plugins/provider-acp/public-sdk-only.test.ts
+++ b/plugins/provider-acp/public-sdk-only.test.ts
@@ -4,7 +4,12 @@ import { describe, expect, it } from "vitest";
 import { experimental_scanPublicSdkOnly as scanPublicSdkOnly } from "@get-bb/plugin-sdk/testing";
 
 const scan = scanPublicSdkOnly(dirname(fileURLToPath(import.meta.url)), {
-  allow: [/^yaml$/u, /^smol-toml$/u, /^(?:\.\.\/)+vitest\.shared\.js$/u],
+  allow: [
+    /^yaml$/u,
+    /^smol-toml$/u,
+    /^@testing-library\/react$/u,
+    /^(?:\.\.\/)+vitest\.shared\.js$/u,
+  ],
 });
 
 describe("provider-acp imports only the public SDK", () => {

--- a/plugins/provider-acp/src/advisor.ts
+++ b/plugins/provider-acp/src/advisor.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+export const ompAdvisorPayloadSchema = z.object({
+  advisor: z.string().min(1),
+  provider: z.string().nullable(),
+  model: z.string().nullable(),
+  output: z.string().nullable(),
+  notes: z.array(
+    z.object({
+      note: z.string().min(1),
+      severity: z.string().min(1).optional(),
+    }),
+  ),
+});
+
+export const ompAdvisorExtensionKinds = {
+  advisor: { item: ompAdvisorPayloadSchema },
+} as const;

--- a/plugins/provider-acp/src/agents.test.ts
+++ b/plugins/provider-acp/src/agents.test.ts
@@ -240,6 +240,12 @@ describe("acpProviderDeclaration", () => {
     expect(byId.get("acp-opencode")?.experimental_bridgeOptions).toMatchObject({
       acpDialect: "opencode",
     });
+    expect(byId.get("acp-omp")?.experimental_bridgeOptions).toMatchObject({
+      acpDialect: "omp",
+    });
+    expect(byId.get("acp-omp")?.extensionKinds).toEqual({
+      advisor: expect.objectContaining({ item: expect.anything() }),
+    });
     expect(
       byId.get("acp-opencode")?.capabilities.supportsManualCompaction,
     ).toBe(true);

--- a/plugins/provider-acp/src/declaration.ts
+++ b/plugins/provider-acp/src/declaration.ts
@@ -4,6 +4,7 @@ import type {
   PluginProviderStrings,
 } from "@get-bb/plugin-sdk";
 import { ACP_FAMILY, type AcpAgentDefinition } from "./agents.js";
+import { ompAdvisorExtensionKinds } from "./advisor.js";
 
 const ACP_BASE_CAPABILITIES: PluginProviderCapabilities = {
   supportsServiceTier: true,
@@ -98,6 +99,9 @@ export function acpProviderDeclaration(
           ? [...ACP_BASE_CAPABILITIES.reasoningLevels]
           : [...agent.reasoningLevels],
     },
+    ...(agent.dialect === "omp"
+      ? { extensionKinds: ompAdvisorExtensionKinds }
+      : {}),
     composerActions: [],
   };
 }

--- a/plugins/provider-acp/src/known-agents.ts
+++ b/plugins/provider-acp/src/known-agents.ts
@@ -114,6 +114,7 @@ export const KNOWN_ACP_AGENTS: readonly AcpAgentDefinition[] = [
     signInCommand: "omp login",
     installUrl: "https://github.com/can1357/omp",
     visibility: "installed",
+    dialect: "omp",
     supportsManualCompaction: true,
     fork: "tip",
     launch: {

--- a/plugins/provider-acp/tsconfig.json
+++ b/plugins/provider-acp/tsconfig.json
@@ -4,10 +4,8 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "lib": [
-      "ES2022",
-      "DOM"
-    ],
+    "jsx": "react-jsx",
+    "lib": ["ES2022", "DOM"],
     "noEmit": true,
     "skipLibCheck": true,
     "paths": {
@@ -21,12 +19,12 @@
         "../../packages/plugin-sdk/bundled-types/bb-plugin-sdk-provider-bridge-acp.d.ts"
       ]
     },
-    "types": [
-      "node"
-    ]
+    "types": ["node"]
   },
   "include": [
     "server.ts",
+    "app.tsx",
+    "app.test.tsx",
     "src",
     "public-sdk-only.test.ts",
     "vitest.config.ts"

--- a/plugins/provider-acp/vitest.config.ts
+++ b/plugins/provider-acp/vitest.config.ts
@@ -9,7 +9,7 @@ export default defineWorkspaceTestConfig({
     projects: sharedWorkerProjects({
       pkgDir: __dirname,
       name: "bb-plugin-provider-acp",
-      include: ["*.test.ts", "src/**/*.test.ts"],
+      include: ["*.test.ts", "*.test.tsx", "src/**/*.test.ts"],
     }),
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3424,9 +3424,24 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.3.6)
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.10
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.13
+      jsdom:
+        specifier: ^29.0.1
+        version: 29.0.1(@noble/hashes@2.4.0)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.4(react@19.2.4)
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'


### PR DESCRIPTION
## Human comments

## What was wrong

The OMP provider left advisor activity in sidecar transcripts, so BB did not show when the advisor ran, which model it used, or what it returned. OMP's combined model catalog also presented duplicate display names without identifying whether they came from Cursor, OpenRouter, or xAI OAuth.

## What changed

- Observe active OMP advisor transcripts and emit typed advisor timeline items.
- Render advisor output expanded by default in a violet-bordered card with its provider/model identity.
- Label OMP model choices and the selected model with their backing source.
- Bump `HOST_DAEMON_PROTOCOL_VERSION` to 178 for the changed provider-delta behavior.

## How you verified

- Added regressions that fail without OMP advisor observation, timeline rendering, auto-expansion, and model-source labels.
- `pnpm exec turbo run test --filter=@bb/app` — 475 files and 3,805 tests passed.
- Provider bridge, ACP plugin, client-core, and host-daemon-contract suites — 709 tests passed.
- App lint, typecheck, and production build passed.
- Verified the OMP picker and advisor cards in the live browser preview.

Fixes #

> AGENT GENERATED
