### PR TITLE
feat: drag to reorder the new tab Actions list

### DIFF
--- a/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
@@ -62,12 +62,11 @@ import {
 import {
   arrangePluginNavPanels,
   getPluginNavPanelKey,
-  havePluginNavPanelOrdersDiverged,
   hidePluginNavPanel,
-  reorderPluginNavPanels,
   seedLeadingNavPanelKeys,
   showPluginNavPanel,
 } from "./pluginNavSidebarOrder";
+import { haveSameOrder, reorderStoredOrder } from "@/lib/stored-order";
 
 const BUILTIN_NAV_ROW_PLUGIN_ID = "__builtin__";
 
@@ -153,7 +152,7 @@ function PluginNavSidebarItemList({
   }, [hiddenKeys, rows, storedOrder]);
 
   useEffect(() => {
-    if (!havePluginNavPanelOrdersDiverged(storedOrder, normalizedOrder)) return;
+    if (haveSameOrder(storedOrder, normalizedOrder)) return;
     setStoredOrder(normalizedOrder);
   }, [normalizedOrder, setStoredOrder, storedOrder]);
 
@@ -171,11 +170,11 @@ function PluginNavSidebarItemList({
       ) {
         return;
       }
-      const nextOrder = reorderPluginNavPanels({
-        activeKey: event.active.id,
-        overKey: event.over.id,
+      const nextOrder = reorderStoredOrder({
+        activeId: event.active.id,
+        overId: event.over.id,
         order: normalizedOrder,
-        visibleKeys,
+        visibleIds: visibleKeys,
       });
       if (nextOrder) setStoredOrder(nextOrder);
     },

--- a/apps/app/src/components/plugin/plugin-slot-mounts.test.tsx
+++ b/apps/app/src/components/plugin/plugin-slot-mounts.test.tsx
@@ -68,7 +68,7 @@ import {
   usePluginPanelActions,
   type OpenPluginPanelArgs,
 } from "./PluginPanelActions";
-import { NewTabActions } from "@/components/secondary-panel/NewTabFileSearch";
+import { NewTabActions } from "@/components/secondary-panel/NewTabActions";
 import { buildFileOpenerPanelTab } from "./file-opener-tabs";
 import { splitLayoutAtom } from "@/lib/split-layout/atoms";
 import type { PromptDraftState } from "@bb/client-core";

--- a/apps/app/src/components/plugin/pluginNavSidebarOrder.test.ts
+++ b/apps/app/src/components/plugin/pluginNavSidebarOrder.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 import {
   arrangePluginNavPanels,
   getPluginNavPanelKey,
-  reorderPluginNavPanels,
   seedLeadingNavPanelKeys,
 } from "./pluginNavSidebarOrder";
 
@@ -34,52 +33,6 @@ describe("arrangePluginNavPanels", () => {
     ]);
   });
 
-  it("appends newly installed panels last instead of at the top of a customized list", () => {
-    const { visible } = arrangePluginNavPanels({
-      panels: [github, docs, tasks],
-      storedOrder: ["tasks/board", "github/pulls"],
-      hiddenKeys: [],
-    });
-
-    expect(visible.map(getPluginNavPanelKey)).toEqual([
-      "tasks/board",
-      "github/pulls",
-      "docs/vault",
-    ]);
-  });
-
-  it("renders no row for an unregistered key but keeps its slot in the order", () => {
-    const { visible, normalizedOrder } = arrangePluginNavPanels({
-      panels: [github, docs],
-      storedOrder: ["strudel/repl", "docs/vault", "github/pulls"],
-      hiddenKeys: [],
-    });
-
-    expect(visible.map(getPluginNavPanelKey)).toEqual([
-      "docs/vault",
-      "github/pulls",
-    ]);
-    expect(normalizedOrder).toEqual([
-      "strudel/repl",
-      "docs/vault",
-      "github/pulls",
-    ]);
-  });
-
-  it("returns a late-registering panel to its stored slot", () => {
-    const { visible } = arrangePluginNavPanels({
-      panels: [github, docs, tasks],
-      storedOrder: ["tasks/board", "docs/vault", "github/pulls"],
-      hiddenKeys: [],
-    });
-
-    expect(visible.map(getPluginNavPanelKey)).toEqual([
-      "tasks/board",
-      "docs/vault",
-      "github/pulls",
-    ]);
-  });
-
   it("splits hidden panels out while both lists keep the user's order", () => {
     const { visible, hidden } = arrangePluginNavPanels({
       panels: [github, docs, tasks],
@@ -92,65 +45,6 @@ describe("arrangePluginNavPanels", () => {
       "tasks/board",
       "docs/vault",
     ]);
-  });
-
-  it("ignores duplicate stored keys so a corrupted list can't render a panel twice", () => {
-    const { visible } = arrangePluginNavPanels({
-      panels: [github, docs],
-      storedOrder: ["github/pulls", "github/pulls", "docs/vault"],
-      hiddenKeys: [],
-    });
-
-    expect(visible.map(getPluginNavPanelKey)).toEqual([
-      "github/pulls",
-      "docs/vault",
-    ]);
-  });
-});
-
-describe("reorderPluginNavPanels", () => {
-  it("moves a visible row to the target slot", () => {
-    expect(
-      reorderPluginNavPanels({
-        activeKey: "tasks/board",
-        overKey: "github/pulls",
-        order: ["github/pulls", "docs/vault", "tasks/board"],
-        visibleKeys: ["github/pulls", "docs/vault", "tasks/board"],
-      }),
-    ).toEqual(["tasks/board", "github/pulls", "docs/vault"]);
-  });
-
-  it("keeps hidden panels pinned to their index in the stored order", () => {
-    expect(
-      reorderPluginNavPanels({
-        activeKey: "tasks/board",
-        overKey: "github/pulls",
-        order: ["github/pulls", "docs/vault", "tasks/board"],
-        visibleKeys: ["github/pulls", "tasks/board"],
-      }),
-    ).toEqual(["tasks/board", "docs/vault", "github/pulls"]);
-  });
-
-  it("returns null when the drag lands where it started", () => {
-    expect(
-      reorderPluginNavPanels({
-        activeKey: "github/pulls",
-        overKey: "github/pulls",
-        order: ["github/pulls", "docs/vault"],
-        visibleKeys: ["github/pulls", "docs/vault"],
-      }),
-    ).toBeNull();
-  });
-
-  it("returns null when the drop target is not a visible row", () => {
-    expect(
-      reorderPluginNavPanels({
-        activeKey: "github/pulls",
-        overKey: "docs/vault",
-        order: ["github/pulls", "docs/vault"],
-        visibleKeys: ["github/pulls"],
-      }),
-    ).toBeNull();
   });
 });
 

--- a/apps/app/src/components/plugin/pluginNavSidebarOrder.ts
+++ b/apps/app/src/components/plugin/pluginNavSidebarOrder.ts
@@ -1,8 +1,4 @@
-import {
-  arrangeByStoredOrder,
-  haveStoredOrdersDiverged,
-  reorderStoredOrder,
-} from "@/lib/stored-order";
+import { arrangeByStoredOrder } from "@/lib/stored-order";
 
 interface PluginNavPanelIdentity {
   pluginId: string;
@@ -47,27 +43,6 @@ export function arrangePluginNavPanels<TPanel extends PluginNavPanelIdentity>({
   return { visible, hidden, normalizedOrder };
 }
 
-interface ReorderPluginNavPanelsArgs {
-  activeKey: string;
-  overKey: string;
-  order: readonly string[];
-  visibleKeys: readonly string[];
-}
-
-export function reorderPluginNavPanels({
-  activeKey,
-  overKey,
-  order,
-  visibleKeys,
-}: ReorderPluginNavPanelsArgs): string[] | null {
-  return reorderStoredOrder({
-    activeId: activeKey,
-    overId: overKey,
-    order,
-    visibleIds: visibleKeys,
-  });
-}
-
 export function seedLeadingNavPanelKeys(
   order: readonly string[],
   leadingKeys: readonly string[],
@@ -90,11 +65,4 @@ export function showPluginNavPanel(
   key: string,
 ): string[] {
   return hiddenKeys.filter((hiddenKey) => hiddenKey !== key);
-}
-
-export function havePluginNavPanelOrdersDiverged(
-  left: readonly string[],
-  right: readonly string[],
-): boolean {
-  return haveStoredOrdersDiverged(left, right);
 }

--- a/apps/app/src/components/plugin/pluginNavSidebarOrder.ts
+++ b/apps/app/src/components/plugin/pluginNavSidebarOrder.ts
@@ -1,3 +1,9 @@
+import {
+  arrangeByStoredOrder,
+  haveStoredOrdersDiverged,
+  reorderStoredOrder,
+} from "@/lib/stored-order";
+
 interface PluginNavPanelIdentity {
   pluginId: string;
   id: string;
@@ -24,26 +30,11 @@ export function arrangePluginNavPanels<TPanel extends PluginNavPanelIdentity>({
   storedOrder,
   hiddenKeys,
 }: ArrangePluginNavPanelsArgs<TPanel>): ArrangedPluginNavPanels<TPanel> {
-  const byKey = new Map(
-    panels.map((panel) => [getPluginNavPanelKey(panel), panel]),
-  );
-  const ordered: TPanel[] = [];
-  const normalizedOrder: string[] = [];
-  const seen = new Set<string>();
-  for (const key of storedOrder) {
-    if (seen.has(key)) continue;
-    seen.add(key);
-    normalizedOrder.push(key);
-    const panel = byKey.get(key);
-    if (panel) ordered.push(panel);
-  }
-  for (const panel of panels) {
-    const key = getPluginNavPanelKey(panel);
-    if (seen.has(key)) continue;
-    seen.add(key);
-    normalizedOrder.push(key);
-    ordered.push(panel);
-  }
+  const { ordered, normalizedOrder } = arrangeByStoredOrder({
+    items: panels,
+    getId: getPluginNavPanelKey,
+    storedOrder,
+  });
 
   const hiddenSet = new Set(hiddenKeys);
   const visible: TPanel[] = [];
@@ -69,19 +60,12 @@ export function reorderPluginNavPanels({
   order,
   visibleKeys,
 }: ReorderPluginNavPanelsArgs): string[] | null {
-  const from = visibleKeys.indexOf(activeKey);
-  const to = visibleKeys.indexOf(overKey);
-  if (from === -1 || to === -1 || from === to) return null;
-
-  const nextVisible = [...visibleKeys];
-  const [moved] = nextVisible.splice(from, 1);
-  nextVisible.splice(to, 0, moved);
-
-  const visibleSet = new Set(visibleKeys);
-  let cursor = 0;
-  return order.map((key) =>
-    visibleSet.has(key) ? nextVisible[cursor++] : key,
-  );
+  return reorderStoredOrder({
+    activeId: activeKey,
+    overId: overKey,
+    order,
+    visibleIds: visibleKeys,
+  });
 }
 
 export function seedLeadingNavPanelKeys(
@@ -112,8 +96,5 @@ export function havePluginNavPanelOrdersDiverged(
   left: readonly string[],
   right: readonly string[],
 ): boolean {
-  return (
-    left.length !== right.length ||
-    left.some((key, index) => key !== right[index])
-  );
+  return haveStoredOrdersDiverged(left, right);
 }

--- a/apps/app/src/components/secondary-panel/NewTabActions.test.tsx
+++ b/apps/app/src/components/secondary-panel/NewTabActions.test.tsx
@@ -4,7 +4,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { createStore, Provider } from "jotai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { PluginPanelActionEntry } from "@/components/plugin/PluginPanelActions";
-import { NewTabActions } from "./NewTabFileSearch";
+import { NewTabActions } from "./NewTabActions";
 import { newTabActionOrderAtom } from "./newTabActionsAtoms";
 
 vi.mock("@/components/commands/AppCommandProvider", () => ({
@@ -84,6 +84,25 @@ describe("NewTabActions", () => {
     renderActions([sideChat.id, START_TERMINAL_ID], [sideChat]);
 
     expect(actionLabels()).toEqual(["Start side chat", "Start terminal"]);
+  });
+
+  it("offers a reorder handle per action once there are two to order", () => {
+    renderActions([], [sideChat]);
+
+    expect(
+      screen
+        .getAllByRole("button", { name: /^Reorder / })
+        .map((button) => button.getAttribute("aria-label")),
+    ).toEqual(["Reorder Start terminal", "Reorder Start side chat"]);
+  });
+
+  it("offers no reorder handle when a single action cannot move", () => {
+    renderActions([], []);
+
+    expect(
+      screen.getByRole("button", { name: "Start terminal" }),
+    ).toBeDefined();
+    expect(screen.queryByRole("button", { name: /^Reorder / })).toBeNull();
   });
 
   it("appends an action the saved order has never seen", () => {

--- a/apps/app/src/components/secondary-panel/NewTabActions.test.tsx
+++ b/apps/app/src/components/secondary-panel/NewTabActions.test.tsx
@@ -3,7 +3,9 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { createStore, Provider } from "jotai";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { COMPACT_VIEWPORT_QUERY } from "@bb/shared-ui/hooks/use-compact-viewport";
 import type { PluginPanelActionEntry } from "@/components/plugin/PluginPanelActions";
+import { setCompactSidebarDrawerShowing } from "@/components/ui/sidebar-mobile-drawer-visibility";
 import { NewTabActions } from "./NewTabActions";
 import { newTabActionOrderAtom } from "./newTabActionsAtoms";
 
@@ -52,7 +54,10 @@ function actionLabels(): string[] {
 
 afterEach(() => {
   cleanup();
+  setCompactSidebarDrawerShowing(false);
   window.localStorage.clear();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 });
 
 describe("NewTabActions", () => {
@@ -113,5 +118,47 @@ describe("NewTabActions", () => {
       "Start terminal",
       "Quickstart",
     ]);
+  });
+
+  it("installs touch reorder on a compact viewport while the sidebar drawer is closed", () => {
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn(() => ({
+        matches: true,
+        media: COMPACT_VIEWPORT_QUERY,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })),
+    );
+    setCompactSidebarDrawerShowing(false);
+    const addSpy = vi.spyOn(window, "addEventListener");
+
+    renderActions([], [sideChat]);
+
+    const touchMoveInstalls = addSpy.mock.calls.filter(
+      ([type]) => type === "touchmove",
+    );
+    expect(touchMoveInstalls).toHaveLength(1);
+    expect(touchMoveInstalls[0]?.[2]).toEqual({
+      capture: false,
+      passive: false,
+    });
+  });
+
+  it("uses the default order after stored data has an invalid shape", () => {
+    window.localStorage.setItem("bb.newTab.actionOrder", JSON.stringify({}));
+    const store = createStore();
+
+    render(
+      <Provider store={store}>
+        <NewTabActions
+          onStartTerminal={() => undefined}
+          pluginActions={[sideChat]}
+        />
+      </Provider>,
+    );
+
+    expect(store.get(newTabActionOrderAtom)).toEqual([]);
+    expect(actionLabels()).toEqual(["Start terminal", "Start side chat"]);
   });
 });

--- a/apps/app/src/components/secondary-panel/NewTabActions.test.tsx
+++ b/apps/app/src/components/secondary-panel/NewTabActions.test.tsx
@@ -1,14 +1,59 @@
 // @vitest-environment jsdom
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { createStore, Provider } from "jotai";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { PluginPanelActionEntry } from "@/components/plugin/PluginPanelActions";
 import { NewTabActions } from "./NewTabFileSearch";
+import { newTabActionOrderAtom } from "./newTabActionsAtoms";
 
 vi.mock("@/components/commands/AppCommandProvider", () => ({
   useAppCommandShortcut: () => null,
+  useIsAppCommandModifierHeld: () => false,
 }));
 
-afterEach(cleanup);
+const START_TERMINAL_ID = "file-search-result-start-terminal";
+
+function pluginAction(id: string, title: string): PluginPanelActionEntry {
+  return {
+    id: `plugin-action:${id}`,
+    pluginId: id,
+    icon: null,
+    title,
+    onSelect: () => undefined,
+  };
+}
+
+const sideChat = pluginAction("side-chat", "Start side chat");
+const quickstart = pluginAction("quickstart", "Quickstart");
+
+function renderActions(
+  storedOrder: string[],
+  pluginActions: PluginPanelActionEntry[],
+) {
+  const store = createStore();
+  store.set(newTabActionOrderAtom, storedOrder);
+  return render(
+    <Provider store={store}>
+      <NewTabActions
+        onStartTerminal={() => undefined}
+        pluginActions={pluginActions}
+      />
+    </Provider>,
+  );
+}
+
+function actionLabels(): string[] {
+  return screen
+    .getAllByRole("button")
+    .map((button) => button.textContent?.trim() ?? "")
+    .filter((label) => label.length > 0);
+}
+
+afterEach(() => {
+  cleanup();
+  window.localStorage.clear();
+});
 
 describe("NewTabActions", () => {
   it("keeps a trailing terminal control separate from the terminal action", () => {
@@ -33,5 +78,21 @@ describe("NewTabActions", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Start terminal" }));
     expect(onStartTerminal).toHaveBeenCalledOnce();
+  });
+
+  it("renders built-in and plugin actions in the order the user saved", () => {
+    renderActions([sideChat.id, START_TERMINAL_ID], [sideChat]);
+
+    expect(actionLabels()).toEqual(["Start side chat", "Start terminal"]);
+  });
+
+  it("appends an action the saved order has never seen", () => {
+    renderActions([sideChat.id, START_TERMINAL_ID], [sideChat, quickstart]);
+
+    expect(actionLabels()).toEqual([
+      "Start side chat",
+      "Start terminal",
+      "Quickstart",
+    ]);
   });
 });

--- a/apps/app/src/components/secondary-panel/NewTabActions.tsx
+++ b/apps/app/src/components/secondary-panel/NewTabActions.tsx
@@ -13,7 +13,7 @@ import { useAppCommandShortcut } from "@/components/commands/AppCommandProvider"
 import { PluginIcon } from "@/components/plugin/PluginIcon";
 import type { PluginPanelActionEntry } from "@/components/plugin/PluginPanelActions";
 import { useSidebarSortable } from "@/components/sidebar/sortableMotion";
-import { useSidebarReorderDnd } from "@/components/sidebar/useSidebarReorderDnd";
+import { useReorderDnd } from "@/components/ui/useReorderDnd";
 import { isDesktopBrowserAvailable } from "@/lib/bb-desktop";
 import { arrangeByStoredOrder, reorderStoredOrder } from "@/lib/stored-order";
 import type { AppShortcutPresentation } from "@/lib/app-keybindings";
@@ -212,7 +212,7 @@ function ReorderableNewTabActionList({
     },
     [normalizedOrder, onOrderChange, orderedIds],
   );
-  const { dndContextProps, onClickCapture } = useSidebarReorderDnd({
+  const { dndContextProps, onClickCapture } = useReorderDnd({
     onDragEnd: handleDragEnd,
   });
 

--- a/apps/app/src/components/secondary-panel/NewTabActions.tsx
+++ b/apps/app/src/components/secondary-panel/NewTabActions.tsx
@@ -1,0 +1,301 @@
+import { useCallback, useMemo, type ReactNode } from "react";
+import { useAtom } from "jotai";
+import { DndContext, type DragEndEvent } from "@dnd-kit/core";
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { COARSE_POINTER_COMPACT_ICON_SIZE_CLASS } from "@bb/shared-ui/coarse-pointer-sizing";
+import { Icon, type IconName } from "@bb/shared-ui/icon";
+import { cn } from "@bb/shared-ui/lib/utils";
+import { AppCommandShortcutHint } from "@/components/commands/AppCommandShortcutHint";
+import { useAppCommandShortcut } from "@/components/commands/AppCommandProvider";
+import { PluginIcon } from "@/components/plugin/PluginIcon";
+import type { PluginPanelActionEntry } from "@/components/plugin/PluginPanelActions";
+import { useSidebarSortable } from "@/components/sidebar/sortableMotion";
+import { useSidebarReorderDnd } from "@/components/sidebar/useSidebarReorderDnd";
+import { isDesktopBrowserAvailable } from "@/lib/bb-desktop";
+import { arrangeByStoredOrder, reorderStoredOrder } from "@/lib/stored-order";
+import type { AppShortcutPresentation } from "@/lib/app-keybindings";
+import {
+  LAUNCHER_ACTION_ROW_BASE_CLASS,
+  LAUNCHER_ROW_ICON_CLASS,
+  LauncherSectionHeader,
+} from "./launcherRow";
+import { newTabActionOrderAtom } from "./newTabActionsAtoms";
+
+export type OpenBrowserHandler = () => void;
+export type StartTerminalHandler = () => void;
+
+export interface NewTabActionsProps {
+  onOpenBrowser?: OpenBrowserHandler;
+  onStartTerminal?: StartTerminalHandler;
+  startTerminalDisabled?: boolean;
+  startTerminalTrailing?: ReactNode;
+  pluginActions?: readonly PluginPanelActionEntry[];
+}
+
+interface NewTabAction {
+  id: string;
+  icon: ReactNode;
+  label: string;
+  disabled: boolean;
+  shortcut: AppShortcutPresentation | null;
+  trailing: ReactNode;
+  onSelect: () => void;
+}
+
+interface NewTabActionListProps {
+  actions: readonly NewTabAction[];
+}
+
+interface SortableNewTabActionRowProps {
+  action: NewTabAction;
+}
+
+interface ReorderableNewTabActionListProps {
+  actions: readonly NewTabAction[];
+  normalizedOrder: readonly string[];
+  onOrderChange: (order: string[]) => void;
+}
+
+interface NewTabActionRowProps {
+  action: NewTabAction;
+  dragHandle?: ReactNode;
+}
+
+const ACTIONS_SECTION_LABEL = "Actions";
+const NEW_TAB_ACTION_DRAG_HANDLE_CLASS =
+  "cursor-grab touch-none opacity-0 transition-opacity focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring active:cursor-grabbing group-hover:opacity-100 [@media(hover:none)]:opacity-100";
+const OPEN_BROWSER_ACTION_ID = "file-search-result-open-browser";
+const START_TERMINAL_ACTION_ID = "file-search-result-start-terminal";
+
+function actionIcon(iconName: IconName): ReactNode {
+  return (
+    <Icon
+      name={iconName}
+      className={COARSE_POINTER_COMPACT_ICON_SIZE_CLASS}
+      aria-hidden
+    />
+  );
+}
+
+export function NewTabActions({
+  onOpenBrowser,
+  onStartTerminal,
+  pluginActions,
+  startTerminalDisabled = false,
+  startTerminalTrailing,
+}: NewTabActionsProps) {
+  const terminalShortcut = useAppCommandShortcut("terminal.open");
+  const showOpenBrowser =
+    onOpenBrowser !== undefined && isDesktopBrowserAvailable();
+
+  const actions: NewTabAction[] = [];
+  if (showOpenBrowser) {
+    actions.push({
+      id: OPEN_BROWSER_ACTION_ID,
+      icon: actionIcon("Globe"),
+      label: "Open browser",
+      disabled: false,
+      shortcut: null,
+      trailing: null,
+      onSelect: () => onOpenBrowser?.(),
+    });
+  }
+  if (onStartTerminal !== undefined) {
+    actions.push({
+      id: START_TERMINAL_ACTION_ID,
+      icon: actionIcon("Terminal"),
+      label: "Start terminal",
+      disabled: startTerminalDisabled,
+      shortcut: terminalShortcut,
+      trailing: startTerminalTrailing ?? null,
+      onSelect: () => onStartTerminal(),
+    });
+  }
+  for (const action of pluginActions ?? []) {
+    actions.push({
+      id: action.id,
+      icon: (
+        <PluginIcon
+          pluginId={action.pluginId}
+          icon={action.icon}
+          className={COARSE_POINTER_COMPACT_ICON_SIZE_CLASS}
+        />
+      ),
+      label: action.title,
+      disabled: false,
+      shortcut: null,
+      trailing: null,
+      onSelect: action.onSelect,
+    });
+  }
+
+  if (actions.length === 0) {
+    return null;
+  }
+
+  return (
+    <div data-testid="new-tab-actions" className="flex min-w-0 flex-col">
+      <section>
+        <LauncherSectionHeader label={ACTIONS_SECTION_LABEL} className="pb-1" />
+        <NewTabActionList actions={actions} />
+      </section>
+    </div>
+  );
+}
+
+function NewTabActionList({ actions }: NewTabActionListProps) {
+  const [storedOrder, setStoredOrder] = useAtom(newTabActionOrderAtom);
+  const { ordered, normalizedOrder } = useMemo(
+    () =>
+      arrangeByStoredOrder({
+        items: actions.map((action) => action.id),
+        getId: (id) => id,
+        storedOrder,
+      }),
+    [actions, storedOrder],
+  );
+  const orderedActions = useMemo(() => {
+    const byId = new Map(actions.map((action) => [action.id, action]));
+    return ordered.flatMap((id) => {
+      const action = byId.get(id);
+      return action ? [action] : [];
+    });
+  }, [actions, ordered]);
+
+  if (orderedActions.length < 2) {
+    return (
+      <div className="flex flex-col gap-px">
+        {orderedActions.map((action) => (
+          <NewTabActionRow key={action.id} action={action} />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <ReorderableNewTabActionList
+      actions={orderedActions}
+      normalizedOrder={normalizedOrder}
+      onOrderChange={setStoredOrder}
+    />
+  );
+}
+
+function ReorderableNewTabActionList({
+  actions,
+  normalizedOrder,
+  onOrderChange,
+}: ReorderableNewTabActionListProps) {
+  const orderedIds = useMemo(
+    () => actions.map((action) => action.id),
+    [actions],
+  );
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      if (
+        !event.over ||
+        typeof event.active.id !== "string" ||
+        typeof event.over.id !== "string"
+      ) {
+        return;
+      }
+      const nextOrder = reorderStoredOrder({
+        activeId: event.active.id,
+        overId: event.over.id,
+        order: normalizedOrder,
+        visibleIds: orderedIds,
+      });
+      if (nextOrder) onOrderChange(nextOrder);
+    },
+    [normalizedOrder, onOrderChange, orderedIds],
+  );
+  const { dndContextProps, onClickCapture } = useSidebarReorderDnd({
+    onDragEnd: handleDragEnd,
+  });
+
+  return (
+    <DndContext {...dndContextProps}>
+      <SortableContext
+        items={orderedIds}
+        strategy={verticalListSortingStrategy}
+      >
+        <div className="flex flex-col gap-px" onClickCapture={onClickCapture}>
+          {actions.map((action) => (
+            <SortableNewTabActionRow key={action.id} action={action} />
+          ))}
+        </div>
+      </SortableContext>
+    </DndContext>
+  );
+}
+
+function SortableNewTabActionRow({ action }: SortableNewTabActionRowProps) {
+  const { dragBindings, setNodeRef, style } = useSidebarSortable({
+    id: action.id,
+    disabled: false,
+  });
+  const { attributes, listeners, setActivatorNodeRef } = dragBindings;
+
+  return (
+    <div ref={setNodeRef} style={style}>
+      <NewTabActionRow
+        action={action}
+        dragHandle={
+          <button
+            type="button"
+            ref={setActivatorNodeRef}
+            aria-label={`Reorder ${action.label}`}
+            className={cn(
+              LAUNCHER_ROW_ICON_CLASS,
+              NEW_TAB_ACTION_DRAG_HANDLE_CLASS,
+            )}
+            {...attributes}
+            {...listeners}
+          >
+            <Icon
+              name="DragDropVertical"
+              className={COARSE_POINTER_COMPACT_ICON_SIZE_CLASS}
+              aria-hidden
+            />
+          </button>
+        }
+      />
+    </div>
+  );
+}
+
+function NewTabActionRow({ action, dragHandle }: NewTabActionRowProps) {
+  return (
+    <div
+      className={cn(
+        LAUNCHER_ACTION_ROW_BASE_CLASS,
+        "relative scroll-mt-7 focus-within:bg-state-hover focus-within:text-foreground",
+        !action.disabled && "hover:bg-state-hover",
+      )}
+    >
+      <button
+        type="button"
+        id={action.id}
+        aria-keyshortcuts={action.shortcut?.ariaKeyshortcuts}
+        disabled={action.disabled}
+        onClick={action.onSelect}
+        className="flex min-w-0 flex-1 items-center gap-1.5 text-left focus-visible:outline-none disabled:cursor-default"
+      >
+        <span className={LAUNCHER_ROW_ICON_CLASS}>{action.icon}</span>
+        <span className="min-w-0 flex-1 truncate text-foreground">
+          {action.label}
+        </span>
+      </button>
+      <AppCommandShortcutHint shortcut={action.shortcut} />
+      {dragHandle}
+      {action.trailing !== null ? (
+        <div className="flex min-w-0 shrink-0 items-center">
+          {action.trailing}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/app/src/components/secondary-panel/NewTabFileSearch.tsx
+++ b/apps/app/src/components/secondary-panel/NewTabFileSearch.tsx
@@ -8,12 +8,6 @@ import {
   type KeyboardEvent,
   type ReactNode,
 } from "react";
-import { useAtom } from "jotai";
-import { DndContext, type DragEndEvent } from "@dnd-kit/core";
-import {
-  SortableContext,
-  verticalListSortingStrategy,
-} from "@dnd-kit/sortable";
 import { directoryFromPath } from "@bb/thread-view";
 import {
   COARSE_POINTER_COMPACT_ICON_SIZE_CLASS,
@@ -21,7 +15,7 @@ import {
   COARSE_POINTER_ICON_SIZE_CLASS,
   COARSE_POINTER_TEXT_SM_CLASS,
 } from "@bb/shared-ui/coarse-pointer-sizing";
-import { Icon, type IconName } from "@bb/shared-ui/icon";
+import { Icon } from "@bb/shared-ui/icon";
 import { EmptyStatePanel } from "@bb/shared-ui/empty-state";
 import { LIST_HOVER_TRANSITION } from "@bb/shared-ui/motion";
 import { usePointerCoarse } from "@bb/shared-ui/hooks/use-pointer-coarse";
@@ -33,8 +27,6 @@ import {
   type FileSearchSuggestion,
 } from "@/hooks/useFileSearchSuggestions";
 import type { FileSearchSelection } from "./useThreadFileTabs";
-import type { PluginPanelActionEntry } from "@/components/plugin/PluginPanelActions";
-import { PluginIcon } from "@/components/plugin/PluginIcon";
 import {
   useThreadRecentItems,
   THREAD_RECENT_ITEMS_VISIBLE_LIMIT,
@@ -45,25 +37,14 @@ import {
   resolveRightPanelFileVisual,
 } from "./rightPanelFileVisuals";
 import { cn } from "@bb/shared-ui/lib/utils";
-import { isDesktopBrowserAvailable } from "@/lib/bb-desktop";
+import { useAppCommandShortcut } from "@/components/commands/AppCommandProvider";
 import { formatRelativeTime } from "@/lib/relative-time";
 import {
-  LAUNCHER_ACTION_ROW_BASE_CLASS,
   LAUNCHER_ROW_BASE_CLASS,
   LAUNCHER_ROW_ICON_CLASS,
   LauncherRowTrailing,
   LauncherSectionHeader,
 } from "./launcherRow";
-import {
-  useSidebarSortable,
-  type SidebarSortableDragBindings,
-} from "@/components/sidebar/sortableMotion";
-import { useSidebarReorderDnd } from "@/components/sidebar/useSidebarReorderDnd";
-import { arrangeByStoredOrder, reorderStoredOrder } from "@/lib/stored-order";
-import { newTabActionOrderAtom } from "./newTabActionsAtoms";
-import { useAppCommandShortcut } from "@/components/commands/AppCommandProvider";
-import { AppCommandShortcutHint } from "@/components/commands/AppCommandShortcutHint";
-import type { AppShortcutPresentation } from "@/lib/app-keybindings";
 
 export interface NewTabFileSearchProps {
   projectId: string | undefined;
@@ -77,35 +58,6 @@ export interface NewTabFileSearchProps {
   onSelect: (selection: FileSearchSelection) => void;
   recentItemsThreadId?: string | null;
   showFileSearch?: boolean;
-}
-
-export type OpenBrowserHandler = () => void;
-export type StartTerminalHandler = () => void;
-
-interface NewTabActionsProps {
-  onOpenBrowser?: OpenBrowserHandler;
-  onStartTerminal?: StartTerminalHandler;
-  startTerminalDisabled?: boolean;
-  startTerminalTrailing?: ReactNode;
-  pluginActions?: readonly PluginPanelActionEntry[];
-}
-
-type NewTabActionDescriptor =
-  | {
-      kind: "builtin";
-      id: string;
-      iconName: IconName;
-      label: string;
-      disabled: boolean;
-      shortcut: AppShortcutPresentation | null;
-      trailing: ReactNode;
-      onSelect: () => void;
-    }
-  | { kind: "plugin"; id: string; action: PluginPanelActionEntry };
-
-interface SortableNewTabActionProps {
-  descriptor: NewTabActionDescriptor;
-  reorderDisabled: boolean;
 }
 
 interface FileResultRowProps {
@@ -147,8 +99,7 @@ interface FileSearchSection {
 
 type LauncherKeyDownHandler = (event: KeyboardEvent<HTMLElement>) => void;
 type FileSearchSource = FileSearchSuggestion["source"];
-type FileSearchSectionKind = "actions" | "files" | "recent";
-type LauncherTileVariant = "result" | "action";
+type FileSearchSectionKind = "files" | "recent";
 
 interface GroupFileSearchSectionsArgs {
   suggestions: readonly FileSearchSuggestion[];
@@ -156,28 +107,12 @@ interface GroupFileSearchSectionsArgs {
 }
 
 interface LauncherTileProps {
-  ariaKeyshortcuts?: string;
-  dragBindings?: SidebarSortableDragBindings;
   id: string;
   isActive: boolean;
-  variant?: LauncherTileVariant;
   onActivate: () => void;
   onSelect: () => void;
   title?: string;
   children: ReactNode;
-}
-
-interface NewTabActionTileProps {
-  disabled: boolean;
-  dragBindings?: SidebarSortableDragBindings;
-  id: string;
-  iconName: IconName;
-  label: string;
-  isActive: boolean;
-  onActivate: () => void;
-  onSelect: () => void;
-  shortcut: AppShortcutPresentation | null;
-  trailing: ReactNode;
 }
 
 interface ShowMoreToggleProps {
@@ -193,7 +128,6 @@ const FILE_SEARCH_SECTION_ORDER: readonly FileSearchSectionKind[] = [
 ];
 
 const FILE_SEARCH_SECTION_LABELS = {
-  actions: "Actions",
   files: "Files",
   recent: "Recent",
 } satisfies Record<FileSearchSectionKind, string>;
@@ -202,9 +136,6 @@ const FILE_SEARCH_SOURCE_LABELS = {
   workspace: "Workspace",
   "thread-storage": "Thread storage",
 } satisfies Record<FileSearchSource, string>;
-
-const OPEN_BROWSER_ENTRY_ID = "file-search-result-open-browser";
-const START_TERMINAL_ENTRY_ID = "file-search-result-start-terminal";
 
 const RECENT_ENTRY_ID_PREFIX = "file-search-result-recent";
 
@@ -301,124 +232,30 @@ function FileSearchMessage({
 }
 
 function LauncherTile({
-  ariaKeyshortcuts,
-  dragBindings,
   id,
   isActive,
-  variant = "result",
   onActivate,
   onSelect,
   title,
   children,
 }: LauncherTileProps) {
-  const baseClass =
-    variant === "action"
-      ? LAUNCHER_ACTION_ROW_BASE_CLASS
-      : LAUNCHER_ROW_BASE_CLASS;
-  const { onKeyDown: _keyboardDragActivator, ...pointerDragListeners } =
-    dragBindings?.listeners ?? {};
-
   return (
     <button
       type="button"
       id={id}
-      role={variant === "result" ? "option" : undefined}
-      aria-selected={variant === "result" ? isActive : undefined}
-      aria-keyshortcuts={ariaKeyshortcuts}
-      ref={dragBindings?.setActivatorNodeRef}
-      {...dragBindings?.attributes}
-      {...pointerDragListeners}
+      role="option"
+      aria-selected={isActive}
       onClick={onSelect}
       onMouseEnter={onActivate}
       title={title}
       className={cn(
-        baseClass,
+        LAUNCHER_ROW_BASE_CLASS,
         "relative scroll-mt-7",
         isActive ? "bg-state-active" : "hover:bg-state-hover",
       )}
     >
       {children}
     </button>
-  );
-}
-
-function NewTabActionTile({
-  disabled,
-  dragBindings,
-  id,
-  iconName,
-  label,
-  isActive,
-  onActivate,
-  onSelect,
-  shortcut,
-  trailing,
-}: NewTabActionTileProps) {
-  const { onKeyDown: _keyboardDragActivator, ...pointerDragListeners } =
-    dragBindings?.listeners ?? {};
-
-  if (trailing !== null) {
-    return (
-      <div
-        id={id}
-        className={cn(
-          LAUNCHER_ACTION_ROW_BASE_CLASS,
-          "relative scroll-mt-7",
-          isActive ? "bg-state-active" : disabled ? "" : "hover:bg-state-hover",
-        )}
-      >
-        <button
-          type="button"
-          aria-label={label}
-          aria-keyshortcuts={shortcut?.ariaKeyshortcuts}
-          disabled={disabled}
-          ref={dragBindings?.setActivatorNodeRef}
-          {...dragBindings?.attributes}
-          {...pointerDragListeners}
-          onClick={onSelect}
-          onMouseEnter={onActivate}
-          className="absolute inset-0 rounded focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-default"
-        />
-        <span className={cn(LAUNCHER_ROW_ICON_CLASS, "pointer-events-none")}>
-          <Icon
-            name={iconName}
-            className={COARSE_POINTER_COMPACT_ICON_SIZE_CLASS}
-            aria-hidden
-          />
-        </span>
-        <span className="pointer-events-none min-w-0 flex-1 truncate text-foreground">
-          {label}
-        </span>
-        <div className="relative z-10 ml-auto flex min-w-0 shrink-0 items-center">
-          {trailing}
-        </div>
-      </div>
-    );
-  }
-
-  return (
-    <LauncherTile
-      id={id}
-      isActive={isActive}
-      ariaKeyshortcuts={shortcut?.ariaKeyshortcuts}
-      dragBindings={dragBindings}
-      variant="action"
-      onActivate={onActivate}
-      onSelect={onSelect}
-    >
-      <span className={LAUNCHER_ROW_ICON_CLASS}>
-        <Icon
-          name={iconName}
-          className={COARSE_POINTER_COMPACT_ICON_SIZE_CLASS}
-          aria-hidden
-        />
-      </span>
-      <span className="min-w-0 flex-1 truncate text-foreground">{label}</span>
-      <AppCommandShortcutHint
-        shortcut={shortcut ?? null}
-        className="absolute right-2 top-1/2 -translate-y-1/2"
-      />
-    </LauncherTile>
   );
 }
 
@@ -821,197 +658,6 @@ export function NewTabFileSearch({
           }}
           sections={sections}
         />
-      )}
-    </div>
-  );
-}
-
-export function NewTabActions({
-  onOpenBrowser,
-  onStartTerminal,
-  pluginActions,
-  startTerminalDisabled = false,
-  startTerminalTrailing,
-}: NewTabActionsProps) {
-  const terminalShortcut = useAppCommandShortcut("terminal.open");
-  const [storedOrder, setStoredOrder] = useAtom(newTabActionOrderAtom);
-  const showOpenBrowserEntry =
-    onOpenBrowser !== undefined && isDesktopBrowserAvailable();
-  const showStartTerminalEntry = onStartTerminal !== undefined;
-
-  const handleOpenBrowser = useCallback(() => {
-    onOpenBrowser?.();
-  }, [onOpenBrowser]);
-
-  const handleStartTerminal = useCallback(() => {
-    onStartTerminal?.();
-  }, [onStartTerminal]);
-
-  const descriptors = useMemo<NewTabActionDescriptor[]>(
-    () => [
-      ...(showOpenBrowserEntry
-        ? [
-            {
-              kind: "builtin" as const,
-              id: OPEN_BROWSER_ENTRY_ID,
-              iconName: "Globe" as const,
-              label: "Open browser",
-              disabled: false,
-              shortcut: null,
-              trailing: null,
-              onSelect: handleOpenBrowser,
-            },
-          ]
-        : []),
-      ...(showStartTerminalEntry
-        ? [
-            {
-              kind: "builtin" as const,
-              id: START_TERMINAL_ENTRY_ID,
-              iconName: "Terminal" as const,
-              label: "Start terminal",
-              disabled: startTerminalDisabled,
-              shortcut: terminalShortcut,
-              trailing: startTerminalTrailing ?? null,
-              onSelect: handleStartTerminal,
-            },
-          ]
-        : []),
-      ...(pluginActions ?? []).map((action) => ({
-        kind: "plugin" as const,
-        id: action.id,
-        action,
-      })),
-    ],
-    [
-      handleOpenBrowser,
-      handleStartTerminal,
-      pluginActions,
-      showOpenBrowserEntry,
-      showStartTerminalEntry,
-      startTerminalDisabled,
-      startTerminalTrailing,
-      terminalShortcut,
-    ],
-  );
-
-  const { ordered, normalizedOrder } = useMemo(
-    () =>
-      arrangeByStoredOrder({
-        items: descriptors,
-        getId: (descriptor) => descriptor.id,
-        storedOrder,
-      }),
-    [descriptors, storedOrder],
-  );
-  const orderedIds = useMemo(
-    () => ordered.map((descriptor) => descriptor.id),
-    [ordered],
-  );
-
-  const handleDragEnd = useCallback(
-    (event: DragEndEvent) => {
-      if (
-        !event.over ||
-        typeof event.active.id !== "string" ||
-        typeof event.over.id !== "string"
-      ) {
-        return;
-      }
-      const nextOrder = reorderStoredOrder({
-        activeId: event.active.id,
-        overId: event.over.id,
-        order: normalizedOrder,
-        visibleIds: orderedIds,
-      });
-      if (nextOrder) setStoredOrder(nextOrder);
-    },
-    [normalizedOrder, orderedIds, setStoredOrder],
-  );
-  const { dndContextProps, onClickCapture } = useSidebarReorderDnd({
-    onDragEnd: handleDragEnd,
-  });
-
-  if (ordered.length === 0) {
-    return null;
-  }
-
-  return (
-    <div
-      data-testid="new-tab-actions"
-      className="flex min-w-0 flex-col"
-      onClickCapture={onClickCapture}
-    >
-      <section>
-        <LauncherSectionHeader
-          label={FILE_SEARCH_SECTION_LABELS.actions}
-          className="pb-1"
-        />
-        <DndContext {...dndContextProps}>
-          <SortableContext
-            items={orderedIds}
-            strategy={verticalListSortingStrategy}
-          >
-            <div className="flex flex-col gap-px">
-              {ordered.map((descriptor) => (
-                <SortableNewTabAction
-                  key={descriptor.id}
-                  descriptor={descriptor}
-                  reorderDisabled={ordered.length < 2}
-                />
-              ))}
-            </div>
-          </SortableContext>
-        </DndContext>
-      </section>
-    </div>
-  );
-}
-
-function SortableNewTabAction({
-  descriptor,
-  reorderDisabled,
-}: SortableNewTabActionProps) {
-  const { dragBindings, setNodeRef, style } = useSidebarSortable({
-    id: descriptor.id,
-    disabled: reorderDisabled,
-  });
-
-  return (
-    <div ref={setNodeRef} style={style}>
-      {descriptor.kind === "builtin" ? (
-        <NewTabActionTile
-          disabled={descriptor.disabled}
-          dragBindings={dragBindings}
-          id={descriptor.id}
-          iconName={descriptor.iconName}
-          label={descriptor.label}
-          isActive={false}
-          onActivate={() => undefined}
-          onSelect={descriptor.onSelect}
-          shortcut={descriptor.shortcut}
-          trailing={descriptor.trailing}
-        />
-      ) : (
-        <LauncherTile
-          dragBindings={dragBindings}
-          id={descriptor.id}
-          isActive={false}
-          variant="action"
-          onActivate={() => undefined}
-          onSelect={descriptor.action.onSelect}
-        >
-          <span className={LAUNCHER_ROW_ICON_CLASS}>
-            <PluginIcon
-              pluginId={descriptor.action.pluginId}
-              icon={descriptor.action.icon}
-              className={COARSE_POINTER_COMPACT_ICON_SIZE_CLASS}
-            />
-          </span>
-          <span className="min-w-0 flex-1 truncate text-foreground">
-            {descriptor.action.title}
-          </span>
-        </LauncherTile>
       )}
     </div>
   );

--- a/apps/app/src/components/secondary-panel/NewTabFileSearch.tsx
+++ b/apps/app/src/components/secondary-panel/NewTabFileSearch.tsx
@@ -8,6 +8,12 @@ import {
   type KeyboardEvent,
   type ReactNode,
 } from "react";
+import { useAtom } from "jotai";
+import { DndContext, type DragEndEvent } from "@dnd-kit/core";
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
 import { directoryFromPath } from "@bb/thread-view";
 import {
   COARSE_POINTER_COMPACT_ICON_SIZE_CLASS,
@@ -48,6 +54,13 @@ import {
   LauncherRowTrailing,
   LauncherSectionHeader,
 } from "./launcherRow";
+import {
+  useSidebarSortable,
+  type SidebarSortableDragBindings,
+} from "@/components/sidebar/sortableMotion";
+import { useSidebarReorderDnd } from "@/components/sidebar/useSidebarReorderDnd";
+import { arrangeByStoredOrder, reorderStoredOrder } from "@/lib/stored-order";
+import { newTabActionOrderAtom } from "./newTabActionsAtoms";
 import { useAppCommandShortcut } from "@/components/commands/AppCommandProvider";
 import { AppCommandShortcutHint } from "@/components/commands/AppCommandShortcutHint";
 import type { AppShortcutPresentation } from "@/lib/app-keybindings";
@@ -75,6 +88,24 @@ interface NewTabActionsProps {
   startTerminalDisabled?: boolean;
   startTerminalTrailing?: ReactNode;
   pluginActions?: readonly PluginPanelActionEntry[];
+}
+
+type NewTabActionDescriptor =
+  | {
+      kind: "builtin";
+      id: string;
+      iconName: IconName;
+      label: string;
+      disabled: boolean;
+      shortcut: AppShortcutPresentation | null;
+      trailing: ReactNode;
+      onSelect: () => void;
+    }
+  | { kind: "plugin"; id: string; action: PluginPanelActionEntry };
+
+interface SortableNewTabActionProps {
+  descriptor: NewTabActionDescriptor;
+  reorderDisabled: boolean;
 }
 
 interface FileResultRowProps {
@@ -126,6 +157,7 @@ interface GroupFileSearchSectionsArgs {
 
 interface LauncherTileProps {
   ariaKeyshortcuts?: string;
+  dragBindings?: SidebarSortableDragBindings;
   id: string;
   isActive: boolean;
   variant?: LauncherTileVariant;
@@ -136,15 +168,16 @@ interface LauncherTileProps {
 }
 
 interface NewTabActionTileProps {
-  disabled?: boolean;
+  disabled: boolean;
+  dragBindings?: SidebarSortableDragBindings;
   id: string;
   iconName: IconName;
   label: string;
   isActive: boolean;
   onActivate: () => void;
   onSelect: () => void;
-  shortcut?: AppShortcutPresentation;
-  trailing?: ReactNode;
+  shortcut: AppShortcutPresentation | null;
+  trailing: ReactNode;
 }
 
 interface ShowMoreToggleProps {
@@ -269,6 +302,7 @@ function FileSearchMessage({
 
 function LauncherTile({
   ariaKeyshortcuts,
+  dragBindings,
   id,
   isActive,
   variant = "result",
@@ -281,6 +315,8 @@ function LauncherTile({
     variant === "action"
       ? LAUNCHER_ACTION_ROW_BASE_CLASS
       : LAUNCHER_ROW_BASE_CLASS;
+  const { onKeyDown: _keyboardDragActivator, ...pointerDragListeners } =
+    dragBindings?.listeners ?? {};
 
   return (
     <button
@@ -289,6 +325,9 @@ function LauncherTile({
       role={variant === "result" ? "option" : undefined}
       aria-selected={variant === "result" ? isActive : undefined}
       aria-keyshortcuts={ariaKeyshortcuts}
+      ref={dragBindings?.setActivatorNodeRef}
+      {...dragBindings?.attributes}
+      {...pointerDragListeners}
       onClick={onSelect}
       onMouseEnter={onActivate}
       title={title}
@@ -304,7 +343,8 @@ function LauncherTile({
 }
 
 function NewTabActionTile({
-  disabled = false,
+  disabled,
+  dragBindings,
   id,
   iconName,
   label,
@@ -314,7 +354,10 @@ function NewTabActionTile({
   shortcut,
   trailing,
 }: NewTabActionTileProps) {
-  if (trailing !== undefined) {
+  const { onKeyDown: _keyboardDragActivator, ...pointerDragListeners } =
+    dragBindings?.listeners ?? {};
+
+  if (trailing !== null) {
     return (
       <div
         id={id}
@@ -329,6 +372,9 @@ function NewTabActionTile({
           aria-label={label}
           aria-keyshortcuts={shortcut?.ariaKeyshortcuts}
           disabled={disabled}
+          ref={dragBindings?.setActivatorNodeRef}
+          {...dragBindings?.attributes}
+          {...pointerDragListeners}
           onClick={onSelect}
           onMouseEnter={onActivate}
           className="absolute inset-0 rounded focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-default"
@@ -355,6 +401,7 @@ function NewTabActionTile({
       id={id}
       isActive={isActive}
       ariaKeyshortcuts={shortcut?.ariaKeyshortcuts}
+      dragBindings={dragBindings}
       variant="action"
       onActivate={onActivate}
       onSelect={onSelect}
@@ -783,10 +830,11 @@ export function NewTabActions({
   onOpenBrowser,
   onStartTerminal,
   pluginActions,
-  startTerminalDisabled,
+  startTerminalDisabled = false,
   startTerminalTrailing,
 }: NewTabActionsProps) {
   const terminalShortcut = useAppCommandShortcut("terminal.open");
+  const [storedOrder, setStoredOrder] = useAtom(newTabActionOrderAtom);
   const showOpenBrowserEntry =
     onOpenBrowser !== undefined && isDesktopBrowserAvailable();
   const showStartTerminalEntry = onStartTerminal !== undefined;
@@ -799,69 +847,172 @@ export function NewTabActions({
     onStartTerminal?.();
   }, [onStartTerminal]);
 
-  const hasOpenActions =
-    showOpenBrowserEntry ||
-    showStartTerminalEntry ||
-    (pluginActions !== undefined && pluginActions.length > 0);
+  const descriptors = useMemo<NewTabActionDescriptor[]>(
+    () => [
+      ...(showOpenBrowserEntry
+        ? [
+            {
+              kind: "builtin" as const,
+              id: OPEN_BROWSER_ENTRY_ID,
+              iconName: "Globe" as const,
+              label: "Open browser",
+              disabled: false,
+              shortcut: null,
+              trailing: null,
+              onSelect: handleOpenBrowser,
+            },
+          ]
+        : []),
+      ...(showStartTerminalEntry
+        ? [
+            {
+              kind: "builtin" as const,
+              id: START_TERMINAL_ENTRY_ID,
+              iconName: "Terminal" as const,
+              label: "Start terminal",
+              disabled: startTerminalDisabled,
+              shortcut: terminalShortcut,
+              trailing: startTerminalTrailing ?? null,
+              onSelect: handleStartTerminal,
+            },
+          ]
+        : []),
+      ...(pluginActions ?? []).map((action) => ({
+        kind: "plugin" as const,
+        id: action.id,
+        action,
+      })),
+    ],
+    [
+      handleOpenBrowser,
+      handleStartTerminal,
+      pluginActions,
+      showOpenBrowserEntry,
+      showStartTerminalEntry,
+      startTerminalDisabled,
+      startTerminalTrailing,
+      terminalShortcut,
+    ],
+  );
 
-  if (!hasOpenActions) {
+  const { ordered, normalizedOrder } = useMemo(
+    () =>
+      arrangeByStoredOrder({
+        items: descriptors,
+        getId: (descriptor) => descriptor.id,
+        storedOrder,
+      }),
+    [descriptors, storedOrder],
+  );
+  const orderedIds = useMemo(
+    () => ordered.map((descriptor) => descriptor.id),
+    [ordered],
+  );
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      if (
+        !event.over ||
+        typeof event.active.id !== "string" ||
+        typeof event.over.id !== "string"
+      ) {
+        return;
+      }
+      const nextOrder = reorderStoredOrder({
+        activeId: event.active.id,
+        overId: event.over.id,
+        order: normalizedOrder,
+        visibleIds: orderedIds,
+      });
+      if (nextOrder) setStoredOrder(nextOrder);
+    },
+    [normalizedOrder, orderedIds, setStoredOrder],
+  );
+  const { dndContextProps, onClickCapture } = useSidebarReorderDnd({
+    onDragEnd: handleDragEnd,
+  });
+
+  if (ordered.length === 0) {
     return null;
   }
 
   return (
-    <div data-testid="new-tab-actions" className="flex min-w-0 flex-col">
+    <div
+      data-testid="new-tab-actions"
+      className="flex min-w-0 flex-col"
+      onClickCapture={onClickCapture}
+    >
       <section>
         <LauncherSectionHeader
           label={FILE_SEARCH_SECTION_LABELS.actions}
           className="pb-1"
         />
-        <div className="flex flex-col gap-px">
-          {showOpenBrowserEntry ? (
-            <NewTabActionTile
-              id={OPEN_BROWSER_ENTRY_ID}
-              iconName="Globe"
-              label="Open browser"
-              isActive={false}
-              onActivate={() => undefined}
-              onSelect={handleOpenBrowser}
-            />
-          ) : null}
-          {showStartTerminalEntry ? (
-            <NewTabActionTile
-              disabled={startTerminalDisabled}
-              id={START_TERMINAL_ENTRY_ID}
-              iconName="Terminal"
-              label="Start terminal"
-              isActive={false}
-              onActivate={() => undefined}
-              onSelect={handleStartTerminal}
-              shortcut={terminalShortcut ?? undefined}
-              trailing={startTerminalTrailing}
-            />
-          ) : null}
-          {pluginActions?.map((action) => (
-            <LauncherTile
-              key={action.id}
-              id={action.id}
-              isActive={false}
-              variant="action"
-              onActivate={() => undefined}
-              onSelect={action.onSelect}
-            >
-              <span className={LAUNCHER_ROW_ICON_CLASS}>
-                <PluginIcon
-                  pluginId={action.pluginId}
-                  icon={action.icon}
-                  className={COARSE_POINTER_COMPACT_ICON_SIZE_CLASS}
+        <DndContext {...dndContextProps}>
+          <SortableContext
+            items={orderedIds}
+            strategy={verticalListSortingStrategy}
+          >
+            <div className="flex flex-col gap-px">
+              {ordered.map((descriptor) => (
+                <SortableNewTabAction
+                  key={descriptor.id}
+                  descriptor={descriptor}
+                  reorderDisabled={ordered.length < 2}
                 />
-              </span>
-              <span className="min-w-0 flex-1 truncate text-foreground">
-                {action.title}
-              </span>
-            </LauncherTile>
-          ))}
-        </div>
+              ))}
+            </div>
+          </SortableContext>
+        </DndContext>
       </section>
+    </div>
+  );
+}
+
+function SortableNewTabAction({
+  descriptor,
+  reorderDisabled,
+}: SortableNewTabActionProps) {
+  const { dragBindings, setNodeRef, style } = useSidebarSortable({
+    id: descriptor.id,
+    disabled: reorderDisabled,
+  });
+
+  return (
+    <div ref={setNodeRef} style={style}>
+      {descriptor.kind === "builtin" ? (
+        <NewTabActionTile
+          disabled={descriptor.disabled}
+          dragBindings={dragBindings}
+          id={descriptor.id}
+          iconName={descriptor.iconName}
+          label={descriptor.label}
+          isActive={false}
+          onActivate={() => undefined}
+          onSelect={descriptor.onSelect}
+          shortcut={descriptor.shortcut}
+          trailing={descriptor.trailing}
+        />
+      ) : (
+        <LauncherTile
+          dragBindings={dragBindings}
+          id={descriptor.id}
+          isActive={false}
+          variant="action"
+          onActivate={() => undefined}
+          onSelect={descriptor.action.onSelect}
+        >
+          <span className={LAUNCHER_ROW_ICON_CLASS}>
+            <PluginIcon
+              pluginId={descriptor.action.pluginId}
+              icon={descriptor.action.icon}
+              className={COARSE_POINTER_COMPACT_ICON_SIZE_CLASS}
+            />
+          </span>
+          <span className="min-w-0 flex-1 truncate text-foreground">
+            {descriptor.action.title}
+          </span>
+        </LauncherTile>
+      )}
     </div>
   );
 }

--- a/apps/app/src/components/secondary-panel/NewTabPage.tsx
+++ b/apps/app/src/components/secondary-panel/NewTabPage.tsx
@@ -2,10 +2,12 @@ import type { ReactNode } from "react";
 import type { PluginPanelActionEntry } from "@/components/plugin/PluginPanelActions";
 import {
   NewTabActions,
-  NewTabFileSearch,
-  type NewTabFileSearchProps,
   type OpenBrowserHandler,
   type StartTerminalHandler,
+} from "./NewTabActions";
+import {
+  NewTabFileSearch,
+  type NewTabFileSearchProps,
 } from "./NewTabFileSearch";
 
 type NewTabPageFileSearchProps = Omit<NewTabFileSearchProps, "idleActions">;

--- a/apps/app/src/components/secondary-panel/newTabActionsAtoms.ts
+++ b/apps/app/src/components/secondary-panel/newTabActionsAtoms.ts
@@ -1,0 +1,11 @@
+import { atomWithStorage } from "jotai/utils";
+import { createJsonLocalStorage } from "@/lib/browser-storage";
+
+const NEW_TAB_ACTION_ORDER_STORAGE_KEY = "bb.newTab.actionOrder";
+
+export const newTabActionOrderAtom = atomWithStorage<string[]>(
+  NEW_TAB_ACTION_ORDER_STORAGE_KEY,
+  [],
+  createJsonLocalStorage<string[]>(),
+  { getOnInit: true },
+);

--- a/apps/app/src/components/secondary-panel/newTabActionsAtoms.ts
+++ b/apps/app/src/components/secondary-panel/newTabActionsAtoms.ts
@@ -3,9 +3,15 @@ import { createJsonLocalStorage } from "@/lib/browser-storage";
 
 const NEW_TAB_ACTION_ORDER_STORAGE_KEY = "bb.newTab.actionOrder";
 
+function isStringArray(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) && value.every((item) => typeof item === "string")
+  );
+}
+
 export const newTabActionOrderAtom = atomWithStorage<string[]>(
   NEW_TAB_ACTION_ORDER_STORAGE_KEY,
   [],
-  createJsonLocalStorage<string[]>(),
+  createJsonLocalStorage(isStringArray),
   { getOnInit: true },
 );

--- a/apps/app/src/components/sidebar/ProjectList.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.tsx
@@ -145,7 +145,7 @@ import {
 } from "./BuiltInSidebarSection";
 import { ReorderableSidebarSectionOrderList } from "./ReorderableSidebarSectionOrderList";
 import { useSidebarModeSectionOrder } from "./useSidebarModeSectionOrder";
-import { haveSameOrder } from "./usePersistedSidebarSectionOrder";
+import { haveSameOrder } from "@/lib/stored-order";
 import {
   resolveThreadTitleDisplayText,
   type ThreadTitleMentionResources,

--- a/apps/app/src/components/sidebar/usePersistedSidebarSectionOrder.ts
+++ b/apps/app/src/components/sidebar/usePersistedSidebarSectionOrder.ts
@@ -4,6 +4,7 @@ import {
   normalizeSidebarSectionOrder,
   type LegacySidebarEntityAnchor,
 } from "@bb/client-core";
+import { haveSameOrder } from "@/lib/stored-order";
 
 interface UsePersistedSidebarSectionOrderArgs {
   entitySectionIds: readonly SidebarSectionId[];
@@ -13,16 +14,6 @@ interface UsePersistedSidebarSectionOrderArgs {
   legacyEntityAnchor: LegacySidebarEntityAnchor;
   setStoredOrder: (order: string[]) => void;
   storedOrder: readonly string[];
-}
-
-export function haveSameOrder(
-  left: readonly string[],
-  right: readonly string[],
-) {
-  return (
-    left.length === right.length &&
-    left.every((sectionId, index) => sectionId === right[index])
-  );
 }
 
 export function usePersistedSidebarSectionOrder({

--- a/apps/app/src/components/sidebar/useSidebarReorderDnd.ts
+++ b/apps/app/src/components/sidebar/useSidebarReorderDnd.ts
@@ -1,26 +1,9 @@
+import { useCallback, useEffect } from "react";
 import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  type MouseEventHandler,
-} from "react";
-import {
-  closestCenter,
-  KeyboardSensor,
-  MouseSensor,
-  pointerWithin,
   TouchSensor,
-  useSensor,
-  useSensors,
-  type CollisionDetection,
-  type DndContextProps,
   type DragEndEvent,
-  type DragOverEvent,
   type DragStartEvent,
-  type Modifier,
 } from "@dnd-kit/core";
-import { sortableKeyboardCoordinates } from "@dnd-kit/sortable";
 import { COMPACT_VIEWPORT_QUERY } from "@bb/shared-ui/hooks/use-compact-viewport";
 import {
   getMediaQuerySnapshot,
@@ -31,23 +14,14 @@ import {
   subscribeCompactSidebarDrawerShowing,
 } from "@/components/ui/sidebar-mobile-drawer-visibility.js";
 import {
-  useDragClickSuppression,
-  type ConsumeDragClickSuppression,
-} from "@/components/ui/use-drag-click-suppression";
+  reorderCollisionDetection,
+  useReorderDnd,
+  type ReorderDndContextProps,
+  type UseReorderDndArgs,
+  type UseReorderDndResult,
+} from "@/components/ui/useReorderDnd";
 
-export const sidebarReorderCollisionDetection: CollisionDetection = (args) => {
-  const pointerCollisions = pointerWithin(args);
-  return pointerCollisions.length > 0 ? pointerCollisions : closestCenter(args);
-};
-
-const restrictSidebarDragToVerticalAxis: Modifier = ({ transform }) => ({
-  ...transform,
-  x: 0,
-});
-
-const SIDEBAR_REORDER_MODIFIERS: Modifier[] = [
-  restrictSidebarDragToVerticalAxis,
-];
+export const sidebarReorderCollisionDetection = reorderCollisionDetection;
 
 function setSidebarDraggingCursor(active: boolean): void {
   if (active) {
@@ -57,30 +31,8 @@ function setSidebarDraggingCursor(active: boolean): void {
   delete document.body.dataset.sidebarDragging;
 }
 
-interface UseSidebarReorderDndArgs {
-  onDragEnd: (event: DragEndEvent) => void;
-  onDragStart?: (event: DragStartEvent) => void;
-  onDragOver?: (event: DragOverEvent) => void;
-  onDragCancel?: () => void;
-  collisionDetection?: CollisionDetection;
-}
-
-export type SidebarReorderDndContextProps = Pick<
-  DndContextProps,
-  | "sensors"
-  | "collisionDetection"
-  | "onDragStart"
-  | "onDragOver"
-  | "onDragCancel"
-  | "onDragEnd"
-  | "modifiers"
->;
-
-interface UseSidebarReorderDndResult {
-  dndContextProps: SidebarReorderDndContextProps;
-  consumeClickSuppression: ConsumeDragClickSuppression;
-  onClickCapture: MouseEventHandler<HTMLElement>;
-}
+type UseSidebarReorderDndArgs = Omit<UseReorderDndArgs, "touchSensor">;
+export type SidebarReorderDndContextProps = ReorderDndContextProps;
 
 function shouldInstallSidebarTouchMoveListener(): boolean {
   return (
@@ -132,96 +84,38 @@ export function useSidebarReorderDnd({
   onDragOver,
   onDragCancel,
   collisionDetection = sidebarReorderCollisionDetection,
-}: UseSidebarReorderDndArgs): UseSidebarReorderDndResult {
-  const {
-    beginDragClickSuppression,
-    clearDragClickSuppressionSoon,
-    consumeDragClickSuppression,
-  } = useDragClickSuppression();
-  const isDraggingRef = useRef(false);
-  const sensors = useSensors(
-    useSensor(MouseSensor, { activationConstraint: { distance: 4 } }),
-    useSensor(SidebarTouchSensor, {
-      activationConstraint: { delay: 200, tolerance: 6 },
-    }),
-    useSensor(KeyboardSensor, {
-      coordinateGetter: sortableKeyboardCoordinates,
-    }),
-  );
+}: UseSidebarReorderDndArgs): UseReorderDndResult {
   const handleDragStart = useCallback(
     (event: DragStartEvent) => {
-      isDraggingRef.current = true;
       setSidebarDraggingCursor(true);
-      beginDragClickSuppression();
       onDragStart?.(event);
     },
-    [beginDragClickSuppression, onDragStart],
+    [onDragStart],
   );
   const handleDragCancel = useCallback(() => {
-    if (!isDraggingRef.current) {
-      return;
-    }
-    isDraggingRef.current = false;
     setSidebarDraggingCursor(false);
-    clearDragClickSuppressionSoon();
     onDragCancel?.();
-  }, [clearDragClickSuppressionSoon, onDragCancel]);
+  }, [onDragCancel]);
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
-      isDraggingRef.current = false;
       setSidebarDraggingCursor(false);
-      clearDragClickSuppressionSoon();
       onDragEnd(event);
     },
-    [clearDragClickSuppressionSoon, onDragEnd],
+    [onDragEnd],
   );
 
   useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent): void => {
-      if (event.code === "Escape") {
-        handleDragCancel();
-      }
-    };
-    document.addEventListener("keydown", handleKeyDown);
     return () => {
-      document.removeEventListener("keydown", handleKeyDown);
-      isDraggingRef.current = false;
       setSidebarDraggingCursor(false);
     };
-  }, [handleDragCancel]);
-  const onClickCapture = useCallback<MouseEventHandler<HTMLElement>>(
-    (event) => {
-      if (!consumeDragClickSuppression()) {
-        return;
-      }
-      event.preventDefault();
-      event.stopPropagation();
-    },
-    [consumeDragClickSuppression],
-  );
-  const dndContextProps = useMemo<SidebarReorderDndContextProps>(
-    () => ({
-      sensors,
-      collisionDetection,
-      modifiers: SIDEBAR_REORDER_MODIFIERS,
-      onDragStart: handleDragStart,
-      onDragOver,
-      onDragCancel: handleDragCancel,
-      onDragEnd: handleDragEnd,
-    }),
-    [
-      collisionDetection,
-      handleDragCancel,
-      handleDragEnd,
-      handleDragStart,
-      onDragOver,
-      sensors,
-    ],
-  );
+  }, []);
 
-  return {
-    dndContextProps,
-    consumeClickSuppression: consumeDragClickSuppression,
-    onClickCapture,
-  };
+  return useReorderDnd({
+    onDragEnd: handleDragEnd,
+    onDragStart: handleDragStart,
+    onDragOver,
+    onDragCancel: handleDragCancel,
+    collisionDetection,
+    touchSensor: SidebarTouchSensor,
+  });
 }

--- a/apps/app/src/components/ui/useReorderDnd.ts
+++ b/apps/app/src/components/ui/useReorderDnd.ts
@@ -1,0 +1,164 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  type MouseEventHandler,
+} from "react";
+import {
+  closestCenter,
+  KeyboardSensor,
+  MouseSensor,
+  pointerWithin,
+  TouchSensor,
+  useSensor,
+  useSensors,
+  type CollisionDetection,
+  type DndContextProps,
+  type DragEndEvent,
+  type DragOverEvent,
+  type DragStartEvent,
+  type Modifier,
+  type Sensor,
+  type TouchSensorOptions,
+} from "@dnd-kit/core";
+import { sortableKeyboardCoordinates } from "@dnd-kit/sortable";
+import {
+  useDragClickSuppression,
+  type ConsumeDragClickSuppression,
+} from "@/components/ui/use-drag-click-suppression";
+
+export const reorderCollisionDetection: CollisionDetection = (args) => {
+  const pointerCollisions = pointerWithin(args);
+  return pointerCollisions.length > 0 ? pointerCollisions : closestCenter(args);
+};
+
+const restrictDragToVerticalAxis: Modifier = ({ transform }) => ({
+  ...transform,
+  x: 0,
+});
+
+const REORDER_MODIFIERS: Modifier[] = [restrictDragToVerticalAxis];
+
+export interface UseReorderDndArgs {
+  onDragEnd: (event: DragEndEvent) => void;
+  onDragStart?: (event: DragStartEvent) => void;
+  onDragOver?: (event: DragOverEvent) => void;
+  onDragCancel?: () => void;
+  collisionDetection?: CollisionDetection;
+  touchSensor?: Sensor<TouchSensorOptions>;
+}
+
+export type ReorderDndContextProps = Pick<
+  DndContextProps,
+  | "sensors"
+  | "collisionDetection"
+  | "onDragStart"
+  | "onDragOver"
+  | "onDragCancel"
+  | "onDragEnd"
+  | "modifiers"
+>;
+
+export interface UseReorderDndResult {
+  dndContextProps: ReorderDndContextProps;
+  consumeClickSuppression: ConsumeDragClickSuppression;
+  onClickCapture: MouseEventHandler<HTMLElement>;
+}
+
+export function useReorderDnd({
+  onDragEnd,
+  onDragStart,
+  onDragOver,
+  onDragCancel,
+  collisionDetection = reorderCollisionDetection,
+  touchSensor = TouchSensor,
+}: UseReorderDndArgs): UseReorderDndResult {
+  const {
+    beginDragClickSuppression,
+    clearDragClickSuppressionSoon,
+    consumeDragClickSuppression,
+  } = useDragClickSuppression();
+  const isDraggingRef = useRef(false);
+  const sensors = useSensors(
+    useSensor(MouseSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(touchSensor, {
+      activationConstraint: { delay: 200, tolerance: 6 },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+  const handleDragStart = useCallback(
+    (event: DragStartEvent) => {
+      isDraggingRef.current = true;
+      beginDragClickSuppression();
+      onDragStart?.(event);
+    },
+    [beginDragClickSuppression, onDragStart],
+  );
+  const handleDragCancel = useCallback(() => {
+    if (!isDraggingRef.current) {
+      return;
+    }
+    isDraggingRef.current = false;
+    clearDragClickSuppressionSoon();
+    onDragCancel?.();
+  }, [clearDragClickSuppressionSoon, onDragCancel]);
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      isDraggingRef.current = false;
+      clearDragClickSuppressionSoon();
+      onDragEnd(event);
+    },
+    [clearDragClickSuppressionSoon, onDragEnd],
+  );
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (event.code === "Escape") {
+        handleDragCancel();
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      isDraggingRef.current = false;
+    };
+  }, [handleDragCancel]);
+  const onClickCapture = useCallback<MouseEventHandler<HTMLElement>>(
+    (event) => {
+      if (!consumeDragClickSuppression()) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+    },
+    [consumeDragClickSuppression],
+  );
+  const dndContextProps = useMemo<ReorderDndContextProps>(
+    () => ({
+      sensors,
+      collisionDetection,
+      modifiers: REORDER_MODIFIERS,
+      onDragStart: handleDragStart,
+      onDragOver,
+      onDragCancel: handleDragCancel,
+      onDragEnd: handleDragEnd,
+    }),
+    [
+      collisionDetection,
+      handleDragCancel,
+      handleDragEnd,
+      handleDragStart,
+      onDragOver,
+      sensors,
+    ],
+  );
+
+  return {
+    dndContextProps,
+    consumeClickSuppression: consumeDragClickSuppression,
+    onClickCapture,
+  };
+}

--- a/apps/app/src/lib/browser-storage.ts
+++ b/apps/app/src/lib/browser-storage.ts
@@ -1,6 +1,7 @@
 import { atomWithStorage } from "jotai/utils";
 
 type StringValueGuard<T extends string> = (value: string) => value is T;
+type StoredValueGuard<T> = (value: unknown) => value is T;
 type StoredValueListener = (storedValue: string | null) => void;
 
 export interface SyncStorage<T> {
@@ -85,7 +86,9 @@ export const rawStringLocalStorage = createLocalStorageSyncStorage<string>({
   serialize: (value) => value,
 });
 
-export function createJsonLocalStorage<T>(): SyncStorage<T> {
+export function createJsonLocalStorage<T>(
+  isValue?: StoredValueGuard<T>,
+): SyncStorage<T> {
   return createLocalStorageSyncStorage<T>({
     parse: (storedValue, initialValue) => {
       if (storedValue === null) {
@@ -93,7 +96,10 @@ export function createJsonLocalStorage<T>(): SyncStorage<T> {
       }
 
       try {
-        return JSON.parse(storedValue) as T;
+        const parsedValue: unknown = JSON.parse(storedValue);
+        return isValue === undefined || isValue(parsedValue)
+          ? (parsedValue as T)
+          : initialValue;
       } catch {
         return initialValue;
       }

--- a/apps/app/src/lib/stored-order.test.ts
+++ b/apps/app/src/lib/stored-order.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import {
+  arrangeByStoredOrder,
+  haveStoredOrdersDiverged,
+  reorderStoredOrder,
+} from "./stored-order";
+
+const getId = (item: { id: string }) => item.id;
+
+describe("arrangeByStoredOrder", () => {
+  it("keeps registration order before anything has been reordered", () => {
+    const { ordered, normalizedOrder } = arrangeByStoredOrder({
+      items: [{ id: "browser" }, { id: "terminal" }],
+      getId,
+      storedOrder: [],
+    });
+
+    expect(ordered.map(getId)).toEqual(["browser", "terminal"]);
+    expect(normalizedOrder).toEqual(["browser", "terminal"]);
+  });
+
+  it("appends items that appeared after the user customized the order", () => {
+    const { ordered } = arrangeByStoredOrder({
+      items: [{ id: "browser" }, { id: "terminal" }, { id: "side-chat" }],
+      getId,
+      storedOrder: ["terminal", "browser"],
+    });
+
+    expect(ordered.map(getId)).toEqual(["terminal", "browser", "side-chat"]);
+  });
+
+  it("keeps the slot of an absent item so its position survives a reload", () => {
+    const { ordered, normalizedOrder } = arrangeByStoredOrder({
+      items: [{ id: "browser" }, { id: "terminal" }],
+      getId,
+      storedOrder: ["side-chat", "terminal", "browser"],
+    });
+
+    expect(ordered.map(getId)).toEqual(["terminal", "browser"]);
+    expect(normalizedOrder).toEqual(["side-chat", "terminal", "browser"]);
+  });
+
+  it("drops duplicate stored ids", () => {
+    const { ordered, normalizedOrder } = arrangeByStoredOrder({
+      items: [{ id: "browser" }],
+      getId,
+      storedOrder: ["browser", "browser"],
+    });
+
+    expect(ordered.map(getId)).toEqual(["browser"]);
+    expect(normalizedOrder).toEqual(["browser"]);
+  });
+});
+
+describe("reorderStoredOrder", () => {
+  it("moves an item onto its drop target", () => {
+    expect(
+      reorderStoredOrder({
+        activeId: "terminal",
+        overId: "browser",
+        order: ["browser", "terminal", "side-chat"],
+        visibleIds: ["browser", "terminal", "side-chat"],
+      }),
+    ).toEqual(["terminal", "browser", "side-chat"]);
+  });
+
+  it("leaves absent items pinned to their slot while visible items move", () => {
+    expect(
+      reorderStoredOrder({
+        activeId: "side-chat",
+        overId: "browser",
+        order: ["browser", "quickstart", "side-chat"],
+        visibleIds: ["browser", "side-chat"],
+      }),
+    ).toEqual(["side-chat", "quickstart", "browser"]);
+  });
+
+  it("declines a drag that ends where it started or outside the list", () => {
+    expect(
+      reorderStoredOrder({
+        activeId: "browser",
+        overId: "browser",
+        order: ["browser", "terminal"],
+        visibleIds: ["browser", "terminal"],
+      }),
+    ).toBeNull();
+    expect(
+      reorderStoredOrder({
+        activeId: "browser",
+        overId: "elsewhere",
+        order: ["browser", "terminal"],
+        visibleIds: ["browser", "terminal"],
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("haveStoredOrdersDiverged", () => {
+  it("compares by position, not membership", () => {
+    expect(haveStoredOrdersDiverged(["a", "b"], ["a", "b"])).toBe(false);
+    expect(haveStoredOrdersDiverged(["a", "b"], ["b", "a"])).toBe(true);
+    expect(haveStoredOrdersDiverged(["a"], ["a", "b"])).toBe(true);
+  });
+});

--- a/apps/app/src/lib/stored-order.test.ts
+++ b/apps/app/src/lib/stored-order.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   arrangeByStoredOrder,
-  haveStoredOrdersDiverged,
+  haveSameOrder,
   reorderStoredOrder,
 } from "./stored-order";
 
@@ -95,10 +95,10 @@ describe("reorderStoredOrder", () => {
   });
 });
 
-describe("haveStoredOrdersDiverged", () => {
+describe("haveSameOrder", () => {
   it("compares by position, not membership", () => {
-    expect(haveStoredOrdersDiverged(["a", "b"], ["a", "b"])).toBe(false);
-    expect(haveStoredOrdersDiverged(["a", "b"], ["b", "a"])).toBe(true);
-    expect(haveStoredOrdersDiverged(["a"], ["a", "b"])).toBe(true);
+    expect(haveSameOrder(["a", "b"], ["a", "b"])).toBe(true);
+    expect(haveSameOrder(["a", "b"], ["b", "a"])).toBe(false);
+    expect(haveSameOrder(["a"], ["a", "b"])).toBe(false);
   });
 });

--- a/apps/app/src/lib/stored-order.ts
+++ b/apps/app/src/lib/stored-order.ts
@@ -1,3 +1,5 @@
+import { arrayMove } from "@bb/client-core";
+
 interface ArrangeByStoredOrderArgs<TItem> {
   items: readonly TItem[];
   getId: (item: TItem) => string;
@@ -53,21 +55,18 @@ export function reorderStoredOrder({
   const to = visibleIds.indexOf(overId);
   if (from === -1 || to === -1 || from === to) return null;
 
-  const nextVisible = [...visibleIds];
-  const [moved] = nextVisible.splice(from, 1);
-  nextVisible.splice(to, 0, moved);
-
+  const nextVisible = arrayMove(visibleIds, from, to);
   const visibleSet = new Set(visibleIds);
   let cursor = 0;
   return order.map((id) => (visibleSet.has(id) ? nextVisible[cursor++] : id));
 }
 
-export function haveStoredOrdersDiverged(
+export function haveSameOrder(
   left: readonly string[],
   right: readonly string[],
-): boolean {
+) {
   return (
-    left.length !== right.length ||
-    left.some((id, index) => id !== right[index])
+    left.length === right.length &&
+    left.every((id, index) => id === right[index])
   );
 }

--- a/apps/app/src/lib/stored-order.ts
+++ b/apps/app/src/lib/stored-order.ts
@@ -1,0 +1,73 @@
+interface ArrangeByStoredOrderArgs<TItem> {
+  items: readonly TItem[];
+  getId: (item: TItem) => string;
+  storedOrder: readonly string[];
+}
+
+interface ArrangedByStoredOrder<TItem> {
+  ordered: TItem[];
+  normalizedOrder: string[];
+}
+
+export function arrangeByStoredOrder<TItem>({
+  items,
+  getId,
+  storedOrder,
+}: ArrangeByStoredOrderArgs<TItem>): ArrangedByStoredOrder<TItem> {
+  const byId = new Map(items.map((item) => [getId(item), item]));
+  const ordered: TItem[] = [];
+  const normalizedOrder: string[] = [];
+  const seen = new Set<string>();
+  for (const id of storedOrder) {
+    if (seen.has(id)) continue;
+    seen.add(id);
+    normalizedOrder.push(id);
+    const item = byId.get(id);
+    if (item) ordered.push(item);
+  }
+  for (const item of items) {
+    const id = getId(item);
+    if (seen.has(id)) continue;
+    seen.add(id);
+    normalizedOrder.push(id);
+    ordered.push(item);
+  }
+
+  return { ordered, normalizedOrder };
+}
+
+interface ReorderStoredOrderArgs {
+  activeId: string;
+  overId: string;
+  order: readonly string[];
+  visibleIds: readonly string[];
+}
+
+export function reorderStoredOrder({
+  activeId,
+  overId,
+  order,
+  visibleIds,
+}: ReorderStoredOrderArgs): string[] | null {
+  const from = visibleIds.indexOf(activeId);
+  const to = visibleIds.indexOf(overId);
+  if (from === -1 || to === -1 || from === to) return null;
+
+  const nextVisible = [...visibleIds];
+  const [moved] = nextVisible.splice(from, 1);
+  nextVisible.splice(to, 0, moved);
+
+  const visibleSet = new Set(visibleIds);
+  let cursor = 0;
+  return order.map((id) => (visibleSet.has(id) ? nextVisible[cursor++] : id));
+}
+
+export function haveStoredOrdersDiverged(
+  left: readonly string[],
+  right: readonly string[],
+): boolean {
+  return (
+    left.length !== right.length ||
+    left.some((id, index) => id !== right[index])
+  );
+}


### PR DESCRIPTION
## Human comments

## Context

The new tab shows an Actions list in the side panel. The list holds up to two built-in actions: Open browser and Start terminal. The list also holds one row for each action that a plugin registers. The user starts work from these rows many times each day. The sidebar already lets the user drag its sections and its plugin rows into a new order.

## Problem

The Actions list used a fixed order. It showed Open browser first, then Start terminal, then the plugin actions in registration order. This order caused three problems:

1. The user cannot move a frequent action to the top of the list.
2. A plugin action stays below both built-in actions.
3. The order changes when a plugin registers a new action.

## Solution

Each row now has a reorder handle. The user drags the handle to move the action. The app keeps the new order for that client.

| The list at rest | The handle after hover |
| --- | --- |
| ![The Actions list at rest](https://raw.githubusercontent.com/nlorio-notion/bb/pr-media-drag-reorder-actions/media/new-tab-actions/01-actions-resting.png) | ![The reorder handle after the pointer moves onto the row](https://raw.githubusercontent.com/nlorio-notion/bb/pr-media-drag-reorder-actions/media/new-tab-actions/02-grip-on-hover.png) |

| The row during the drag | The list after the drop |
| --- | --- |
| ![The row moves and the list shows the new order](https://raw.githubusercontent.com/nlorio-notion/bb/pr-media-drag-reorder-actions/media/new-tab-actions/03-mid-drag.png) | ![The action is now the first row](https://raw.githubusercontent.com/nlorio-notion/bb/pr-media-drag-reorder-actions/media/new-tab-actions/04-after-drop.png) |

![The user drags the last action to the top of the list with its handle](https://raw.githubusercontent.com/nlorio-notion/bb/pr-media-drag-reorder-actions/media/new-tab-actions/drag-reorder.gif)

I recorded this media from a dev app on this branch. A temporary local plugin supplies the Quickstart row and the Subagents row. That plugin registers two `experimental_newThreadPanelAction` slots. The list therefore holds both built-in actions and plugin actions.

The change has six parts:

1. **A new module.** `apps/app/src/components/secondary-panel/NewTabActions.tsx` holds the Actions list. The list was in `NewTabFileSearch.tsx`, which has more than 1,200 lines. Both callers and both test files already imported the list as one unit.
2. **One row shape.** Each action is one flat `NewTabAction` value with a ready `icon` node. Built-in rows and plugin rows use the same `NewTabActionRow`. The row holds the action button, the shortcut hint, the reorder handle, and the optional trailing control as siblings. `LauncherTile` loses the `variant` prop and the `ariaKeyshortcuts` prop, because only the action rows used them.
3. **A handle, not a whole row.** The handle starts the drag. `ProvidersSettingsSection` and `QueuedMessagesList` already use a handle in the same way. A handle also gives keyboard reorder, and it keeps a click on the row unambiguous. The app hides the handle until the pointer moves onto the row, and it always shows the handle on a touch device.
4. **Shared drag behavior.** The list uses the general `useReorderDnd` hook and the shared sortable motion. The general hook owns the sensors, drag threshold, Escape key behavior, vertical movement, and click suppression. The sidebar wrapper keeps its compact-drawer touch policy. The Actions list uses the standard touch sensor, so touch reorder works while the sidebar drawer is closed.
5. **Storage.** The app writes the order to `bb.newTab.actionOrder` in `newTabActionsAtoms.ts`. This is the `atomWithStorage` pattern that the sidebar section order and the plugin nav order already use. The app puts a new action after the saved rows. The app also keeps the slot of an action whose plugin is absent, so the position survives a reload.
6. **Shared order helpers.** `apps/app/src/lib/stored-order.ts` holds `arrangeByStoredOrder`, `reorderStoredOrder`, and `haveSameOrder`. The plugin nav sidebar already had this logic, so this change moves the logic instead of a copy. `reorderStoredOrder` uses `arrayMove` from `@bb/client-core`. `haveSameOrder` moves here from `usePersistedSidebarSectionOrder`. After the delegation, `reorderPluginNavPanels` and `havePluginNavPanelOrdersDiverged` only renamed arguments, so this change deletes them and the tests that only tested them.

The list keeps its cost low when the user cannot reorder it. The app orders the rows by id. The app mounts `DndContext`, its sensors, and the document key listener only for two or more actions. For an empty list, the component returns before this work.

## Result

The user can now put the Actions rows in any order, and the app keeps that order after a reload.

Automatic checks:

1. `pnpm exec turbo run typecheck --filter=@bb/app` passes after the review fixes.
2. The 11 focused action and sidebar drag tests pass after the review fixes.
3. `pnpm exec turbo run build --filter=@bb/app` passes.
4. Lint reports 175 warnings and 0 errors. This count equals the count on `main`.
5. 898 tests pass in the plugin, secondary-panel, sidebar, and settings suites.

New tests:

1. `apps/app/src/lib/stored-order.test.ts` tests the fallback to registration order, a new id at the end, the kept slot of an absent id, a duplicate stored id, and the reorder and decline cases.
2. `NewTabActions.test.tsx` tests saved and new actions, handle availability, compact touch setup with the sidebar closed, and invalid saved data.

Manual checks in a dev app on this branch:

1. Move the pointer onto a row. The app shows the handle.
2. Drag the last action to the top with its handle. The list shows the new order.
3. Read `bb.newTab.actionOrder`. The value matches the new order.
4. Reload the page. The list keeps the order.
5. Drag the action back to the bottom. The app does not run the action.
6. Click the row. The app runs the action.

This change does not send new data between the server and the host daemon, so it does not change `HOST_DAEMON_PROTOCOL_VERSION`. It also adds no CLI command and no SDK method. The sidebar section order and the plugin nav order are client-local in the same way. Tell me if you want an agent-facing surface, and I will add one.

One follow-up stays out of this change. Three call sites repeat the same check of `event.over` and the same string check of `event.active.id`: this list, `PluginNavSidebarItems`, and `ReorderableSidebarSectionOrderList`. An `onReorder(activeId, overId)` option on the general hook and the sidebar wrapper would remove the repeat. That option changes every reorder caller, so it needs its own change.

> AGENT GENERATED

