### PR TITLE
Avoid rerendering existing plugin overlays

### DIFF
--- a/apps/app/src/components/plugin/PluginAppOverlays.test.tsx
+++ b/apps/app/src/components/plugin/PluginAppOverlays.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { createPortal } from "react-dom";
 import { MemoryRouter, useLocation } from "react-router-dom";
 import { useState } from "react";
@@ -131,6 +131,41 @@ afterEach(() => {
 });
 
 describe("PluginAppOverlays", () => {
+  it("does not render an existing overlay when another one registers", () => {
+    const firstRender = vi.fn();
+    function First() {
+      firstRender();
+      return <div>first overlay</div>;
+    }
+    function Second() {
+      return <div>second overlay</div>;
+    }
+    setPluginSlotRegistrations(
+      "first",
+      registrationSet({
+        appOverlays: [{ id: "first", component: First }],
+      }),
+    );
+    render(
+      <MemoryRouter>
+        <PluginAppOverlays />
+      </MemoryRouter>,
+    );
+
+    expect(firstRender).toHaveBeenCalledTimes(1);
+    act(() => {
+      setPluginSlotRegistrations(
+        "second",
+        registrationSet({
+          appOverlays: [{ id: "second", component: Second }],
+        }),
+      );
+    });
+
+    expect(screen.getByText("second overlay")).toBeDefined();
+    expect(firstRender).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps sidebar thread actions available through a portal and route change", async () => {
     const fetchMock = vi.fn(async (input: string | URL | Request) => {
       const url = String(input);

--- a/apps/app/src/components/plugin/PluginAppOverlays.tsx
+++ b/apps/app/src/components/plugin/PluginAppOverlays.tsx
@@ -1,5 +1,27 @@
-import { usePluginSlots } from "@/lib/plugin-slots";
+import { memo } from "react";
+import {
+  usePluginSlots,
+  type ExperimentalAppOverlaySlot,
+} from "@/lib/plugin-slots";
 import { PluginSlotMount } from "./PluginSlotMount";
+
+const PluginAppOverlay = memo(function PluginAppOverlay({
+  slot,
+}: {
+  slot: ExperimentalAppOverlaySlot;
+}) {
+  const Component = slot.component;
+  return (
+    <PluginSlotMount
+      pluginId={slot.pluginId}
+      slotKind="appOverlay"
+      slotId={slot.id}
+      crashFallback={null}
+    >
+      <Component />
+    </PluginSlotMount>
+  );
+});
 
 export function PluginAppOverlays() {
   const { appOverlays } = usePluginSlots();
@@ -7,20 +29,12 @@ export function PluginAppOverlays() {
 
   return (
     <div data-bb-plugin-app-overlays="" className="contents">
-      {appOverlays.map((slot) => {
-        const Component = slot.component;
-        return (
-          <PluginSlotMount
-            key={`${slot.pluginId}/${slot.id}/${slot.generation}`}
-            pluginId={slot.pluginId}
-            slotKind="appOverlay"
-            slotId={slot.id}
-            crashFallback={null}
-          >
-            <Component />
-          </PluginSlotMount>
-        );
-      })}
+      {appOverlays.map((slot) => (
+        <PluginAppOverlay
+          key={`${slot.pluginId}/${slot.id}/${slot.generation}`}
+          slot={slot}
+        />
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
## Human comments

## What was wrong

`PluginAppOverlays` subscribed to the full slot snapshot and rendered every overlay directly from its list. Each slot-store notification therefore rendered every existing overlay again even when its stable slot object had not changed, causing sequential registrations to do triangular render work. This addresses the low-priority finding from the [app-overlay review](https://github.com/get-bb/bb/pull/2966#discussion_r3919608591).

## What changed

Extracted each overlay mount into a memoized component that receives the stable overlay slot object. Adding or removing another plugin overlay still updates the host list, while unchanged overlay subtrees skip the parent-driven render. A plugin re-registration still supplies a new slot object and generation key, preserving the existing replacement behavior. Added a focused render-count regression test. This is app-local React behavior with no server/daemon wire change, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

## How you verified

- Added a regression test that registers a second overlay and verifies the first overlay renders only once.
- `pnpm exec turbo run test --filter=@bb/app -- --run src/components/plugin/PluginAppOverlays.test.tsx` — 3 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/app` — passed.
- `pnpm exec turbo run lint --filter=@bb/app` — passed with zero errors.
- `git diff --check` — passed.

> AGENT GENERATED