### PR TITLE
Make mobile toast swipes reliable

### DIFF
--- a/apps/app/src/components/AppToaster.test.tsx
+++ b/apps/app/src/components/AppToaster.test.tsx
@@ -7,7 +7,7 @@ import {
   render,
   waitFor,
 } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { toast } from "sonner";
 import { CompactViewportOverrideProvider } from "@bb/shared-ui/hooks/use-compact-viewport";
 import { AppToaster } from "./AppToaster";
@@ -34,6 +34,31 @@ async function renderToaster(isCompactViewport: boolean) {
     );
     expect(toaster).not.toBeNull();
     return toaster;
+  });
+}
+
+function flickToast(toastElement: HTMLElement, pointerId: number): void {
+  Object.defineProperty(toastElement, "setPointerCapture", {
+    configurable: true,
+    value: () => undefined,
+  });
+  fireEvent.pointerDown(toastElement, {
+    clientX: 120,
+    clientY: 100,
+    pointerId,
+    pointerType: "touch",
+  });
+  fireEvent.pointerMove(toastElement, {
+    clientX: 200,
+    clientY: 100,
+    pointerId,
+    pointerType: "touch",
+  });
+  fireEvent.pointerUp(toastElement, {
+    clientX: 200,
+    clientY: 100,
+    pointerId,
+    pointerType: "touch",
   });
 }
 
@@ -109,4 +134,58 @@ describe("AppToaster", () => {
       }
     },
   );
+
+  it("dismisses rapid stacked flicks by stable toast identity", async () => {
+    const onDismissA = vi.fn();
+    const onDismissB = vi.fn();
+    const onDismissC = vi.fn();
+    render(
+      <CompactViewportOverrideProvider isCompactViewport>
+        <AppToaster position="bottom-right" />
+      </CompactViewportOverrideProvider>,
+    );
+    act(() => {
+      toast("Stack A", {
+        duration: Number.POSITIVE_INFINITY,
+        id: "stack-a",
+        onDismiss: onDismissA,
+      });
+      toast("Stack B", {
+        duration: Number.POSITIVE_INFINITY,
+        id: "stack-b",
+        onDismiss: onDismissB,
+      });
+      toast("Stack C", {
+        duration: Number.POSITIVE_INFINITY,
+        id: "stack-c",
+        onDismiss: onDismissC,
+      });
+    });
+    await waitFor(() => {
+      expect(document.querySelectorAll("[data-sonner-toast]")).toHaveLength(3);
+    });
+    const toastElements = Array.from(
+      document.querySelectorAll<HTMLElement>("[data-sonner-toast]"),
+    );
+    const toastB = toastElements.find(
+      (toastElement) => toastElement.textContent === "Stack B",
+    );
+    const toastC = toastElements.find(
+      (toastElement) => toastElement.textContent === "Stack C",
+    );
+    expect(toastB).toBeDefined();
+    expect(toastC).toBeDefined();
+    if (toastB === undefined || toastC === undefined) {
+      return;
+    }
+
+    flickToast(toastC, 1);
+    await act(async () => Promise.resolve());
+    flickToast(toastB, 2);
+    await act(async () => Promise.resolve());
+
+    expect(onDismissC).toHaveBeenCalledOnce();
+    expect(onDismissB).toHaveBeenCalledOnce();
+    expect(onDismissA).not.toHaveBeenCalled();
+  });
 });

--- a/apps/app/src/components/AppToaster.test.tsx
+++ b/apps/app/src/components/AppToaster.test.tsx
@@ -1,6 +1,12 @@
 // @vitest-environment jsdom
 
-import { act, cleanup, render, waitFor } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { toast } from "sonner";
 import { CompactViewportOverrideProvider } from "@bb/shared-ui/hooks/use-compact-viewport";
@@ -13,9 +19,7 @@ afterEach(() => {
 
 async function renderToaster(isCompactViewport: boolean) {
   render(
-    <CompactViewportOverrideProvider
-      isCompactViewport={isCompactViewport}
-    >
+    <CompactViewportOverrideProvider isCompactViewport={isCompactViewport}>
       <AppToaster position="bottom-right" />
     </CompactViewportOverrideProvider>,
   );
@@ -51,4 +55,58 @@ describe("AppToaster", () => {
     expect(toaster?.getAttribute("data-x-position")).toBe("right");
     expect(toaster?.getAttribute("data-y-position")).toBe("bottom");
   });
+
+  it.each([
+    ["left flick", 200, 100, 120, 100, true],
+    ["right flick", 120, 100, 200, 100, true],
+    ["up flick", 160, 120, 160, 80, true],
+    ["downward drag", 160, 100, 160, 180, false],
+    ["short horizontal drag", 160, 100, 172, 100, false],
+  ] as const)(
+    "handles a compact viewport single-move %s",
+    async (_gesture, startX, startY, endX, endY, shouldDismiss) => {
+      await renderToaster(true);
+      const toastElement = document.querySelector<HTMLElement>(
+        "[data-sonner-toast]",
+      );
+      expect(toastElement).not.toBeNull();
+      if (toastElement === null) {
+        return;
+      }
+      Object.defineProperty(toastElement, "setPointerCapture", {
+        configurable: true,
+        value: () => undefined,
+      });
+
+      fireEvent.pointerDown(toastElement, {
+        clientX: startX,
+        clientY: startY,
+        pointerId: 1,
+        pointerType: "touch",
+      });
+      fireEvent.pointerMove(toastElement, {
+        clientX: endX,
+        clientY: endY,
+        pointerId: 1,
+        pointerType: "touch",
+      });
+      fireEvent.pointerUp(toastElement, {
+        clientX: endX,
+        clientY: endY,
+        pointerId: 1,
+        pointerType: "touch",
+      });
+
+      if (shouldDismiss) {
+        await waitFor(() => {
+          expect(document.querySelector("[data-sonner-toast]")).toBeNull();
+        });
+      } else {
+        await act(async () => Promise.resolve());
+        expect(document.querySelector("[data-sonner-toast]")).toBe(
+          toastElement,
+        );
+      }
+    },
+  );
 });

--- a/apps/app/src/components/AppToaster.test.tsx
+++ b/apps/app/src/components/AppToaster.test.tsx
@@ -10,12 +10,27 @@ import {
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { toast } from "sonner";
 import { CompactViewportOverrideProvider } from "@bb/shared-ui/hooks/use-compact-viewport";
+import { POINTER_COARSE_QUERY } from "@bb/shared-ui/hooks/use-pointer-coarse";
 import { AppToaster } from "./AppToaster";
 
 afterEach(() => {
   toast.dismiss();
   cleanup();
+  vi.restoreAllMocks();
 });
+
+function mockPointerCoarse(): void {
+  vi.spyOn(window, "matchMedia").mockImplementation((query) => ({
+    matches: query === POINTER_COARSE_QUERY,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }));
+}
 
 async function renderToaster(isCompactViewport: boolean) {
   render(
@@ -85,7 +100,9 @@ describe("AppToaster", () => {
     ["left flick", 200, 100, 120, 100, true],
     ["right flick", 120, 100, 200, 100, true],
     ["up flick", 160, 120, 160, 80, true],
-    ["downward drag", 160, 100, 160, 180, false],
+    ["down flick", 160, 100, 160, 180, true],
+    ["down-right diagonal flick", 120, 100, 180, 170, true],
+    ["down-left diagonal flick", 200, 100, 140, 170, true],
     ["short horizontal drag", 160, 100, 172, 100, false],
   ] as const)(
     "handles a compact viewport single-move %s",
@@ -134,6 +151,24 @@ describe("AppToaster", () => {
       }
     },
   );
+
+  it("handles touch flicks outside the compact viewport", async () => {
+    mockPointerCoarse();
+    await renderToaster(false);
+    const toastElement = document.querySelector<HTMLElement>(
+      "[data-sonner-toast]",
+    );
+    expect(toastElement).not.toBeNull();
+    if (toastElement === null) {
+      return;
+    }
+
+    flickToast(toastElement, 1);
+
+    await waitFor(() => {
+      expect(document.querySelector("[data-sonner-toast]")).toBeNull();
+    });
+  });
 
   it("dismisses rapid stacked flicks by stable toast identity", async () => {
     const onDismissA = vi.fn();

--- a/apps/app/src/components/AppToaster.test.tsx
+++ b/apps/app/src/components/AppToaster.test.tsx
@@ -56,12 +56,6 @@ function swipeToast(
     pointerType: "touch",
   });
   fireEvent.pointerMove(toastElement, {
-    clientX: startX + Math.sign(endX - startX) * 2,
-    clientY: startY + Math.sign(endY - startY) * 2,
-    pointerId,
-    pointerType: "touch",
-  });
-  fireEvent.pointerMove(toastElement, {
     clientX: endX,
     clientY: endY,
     pointerId,

--- a/apps/app/src/components/AppToaster.test.tsx
+++ b/apps/app/src/components/AppToaster.test.tsx
@@ -3,6 +3,7 @@
 import {
   act,
   cleanup,
+  createEvent,
   fireEvent,
   render,
   waitFor,
@@ -52,29 +53,88 @@ async function renderToaster(isCompactViewport: boolean) {
   });
 }
 
-function flickToast(toastElement: HTMLElement, pointerId: number): void {
+interface ToastFlickOptions {
+  duration?: number;
+  endX?: number;
+  endY?: number;
+  startX?: number;
+  startY?: number;
+  terminal?: "cancel" | "up";
+  terminalTarget?: Document | HTMLElement;
+}
+
+function fireTimedPointerEvent(
+  target: Document | HTMLElement,
+  type: "cancel" | "down" | "move" | "up",
+  init: PointerEventInit,
+  timeStamp: number,
+): void {
+  const event =
+    type === "down"
+      ? createEvent.pointerDown(target, init)
+      : type === "move"
+        ? createEvent.pointerMove(target, init)
+        : type === "up"
+          ? createEvent.pointerUp(target, init)
+          : createEvent.pointerCancel(target, init);
+  Object.defineProperty(event, "timeStamp", {
+    configurable: true,
+    value: timeStamp,
+  });
+  fireEvent(target, event);
+}
+
+function flickToast(
+  toastElement: HTMLElement,
+  pointerId: number,
+  {
+    duration = 200,
+    endX = 200,
+    endY = 100,
+    startX = 120,
+    startY = 100,
+    terminal = "up",
+    terminalTarget = toastElement,
+  }: ToastFlickOptions = {},
+): void {
   Object.defineProperty(toastElement, "setPointerCapture", {
     configurable: true,
     value: () => undefined,
   });
-  fireEvent.pointerDown(toastElement, {
-    clientX: 120,
-    clientY: 100,
+  const pointerInit = {
     pointerId,
     pointerType: "touch",
-  });
-  fireEvent.pointerMove(toastElement, {
-    clientX: 200,
-    clientY: 100,
-    pointerId,
-    pointerType: "touch",
-  });
-  fireEvent.pointerUp(toastElement, {
-    clientX: 200,
-    clientY: 100,
-    pointerId,
-    pointerType: "touch",
-  });
+  };
+  fireTimedPointerEvent(
+    toastElement,
+    "down",
+    {
+      ...pointerInit,
+      clientX: startX,
+      clientY: startY,
+    },
+    100,
+  );
+  fireTimedPointerEvent(
+    toastElement,
+    "move",
+    {
+      ...pointerInit,
+      clientX: endX,
+      clientY: endY,
+    },
+    100 + duration / 2,
+  );
+  fireTimedPointerEvent(
+    terminalTarget,
+    terminal,
+    {
+      ...pointerInit,
+      clientX: endX,
+      clientY: endY,
+    },
+    100 + duration,
+  );
 }
 
 describe("AppToaster", () => {
@@ -115,28 +175,11 @@ describe("AppToaster", () => {
       if (toastElement === null) {
         return;
       }
-      Object.defineProperty(toastElement, "setPointerCapture", {
-        configurable: true,
-        value: () => undefined,
-      });
-
-      fireEvent.pointerDown(toastElement, {
-        clientX: startX,
-        clientY: startY,
-        pointerId: 1,
-        pointerType: "touch",
-      });
-      fireEvent.pointerMove(toastElement, {
-        clientX: endX,
-        clientY: endY,
-        pointerId: 1,
-        pointerType: "touch",
-      });
-      fireEvent.pointerUp(toastElement, {
-        clientX: endX,
-        clientY: endY,
-        pointerId: 1,
-        pointerType: "touch",
+      flickToast(toastElement, 1, {
+        endX,
+        endY,
+        startX,
+        startY,
       });
 
       if (shouldDismiss) {
@@ -151,6 +194,87 @@ describe("AppToaster", () => {
       }
     },
   );
+
+  it("handles a short high-velocity flick", async () => {
+    await renderToaster(true);
+    const toastElement = document.querySelector<HTMLElement>(
+      "[data-sonner-toast]",
+    );
+    expect(toastElement).not.toBeNull();
+    if (toastElement === null) {
+      return;
+    }
+
+    flickToast(toastElement, 1, { duration: 50, endX: 132 });
+
+    await waitFor(() => {
+      expect(document.querySelector("[data-sonner-toast]")).toBeNull();
+    });
+  });
+
+  it("handles a flick released outside the toast", async () => {
+    await renderToaster(true);
+    const toastElement = document.querySelector<HTMLElement>(
+      "[data-sonner-toast]",
+    );
+    expect(toastElement).not.toBeNull();
+    if (toastElement === null) {
+      return;
+    }
+
+    flickToast(toastElement, 1, { terminalTarget: document });
+
+    await waitFor(() => {
+      expect(document.querySelector("[data-sonner-toast]")).toBeNull();
+    });
+  });
+
+  it("handles a flick while unrelated page text is selected", async () => {
+    await renderToaster(true);
+    const toastElement = document.querySelector<HTMLElement>(
+      "[data-sonner-toast]",
+    );
+    expect(toastElement).not.toBeNull();
+    if (toastElement === null) {
+      return;
+    }
+    const unrelatedText = document.createElement("p");
+    unrelatedText.textContent = "Unrelated selection";
+    document.body.append(unrelatedText);
+    const selection = document.getSelection();
+    const range = document.createRange();
+    range.selectNodeContents(unrelatedText);
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+
+    try {
+      flickToast(toastElement, 1);
+
+      await waitFor(() => {
+        expect(document.querySelector("[data-sonner-toast]")).toBeNull();
+      });
+    } finally {
+      selection?.removeAllRanges();
+      unrelatedText.remove();
+    }
+  });
+
+  it("completes a qualified flick after pointer cancellation", async () => {
+    await renderToaster(true);
+    const toastElement = document.querySelector<HTMLElement>(
+      "[data-sonner-toast]",
+    );
+    expect(toastElement).not.toBeNull();
+    if (toastElement === null) {
+      return;
+    }
+
+    flickToast(toastElement, 1, { terminal: "cancel" });
+
+    await waitFor(() => {
+      expect(document.querySelector("[data-sonner-toast]")).toBeNull();
+    });
+  });
 
   it("handles touch flicks outside the compact viewport", async () => {
     mockPointerCoarse();

--- a/apps/app/src/components/AppToaster.test.tsx
+++ b/apps/app/src/components/AppToaster.test.tsx
@@ -3,7 +3,6 @@
 import {
   act,
   cleanup,
-  createEvent,
   fireEvent,
   render,
   waitFor,
@@ -11,27 +10,12 @@ import {
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { toast } from "sonner";
 import { CompactViewportOverrideProvider } from "@bb/shared-ui/hooks/use-compact-viewport";
-import { POINTER_COARSE_QUERY } from "@bb/shared-ui/hooks/use-pointer-coarse";
 import { AppToaster } from "./AppToaster";
 
 afterEach(() => {
   toast.dismiss();
   cleanup();
-  vi.restoreAllMocks();
 });
-
-function mockPointerCoarse(): void {
-  vi.spyOn(window, "matchMedia").mockImplementation((query) => ({
-    matches: query === POINTER_COARSE_QUERY,
-    media: query,
-    onchange: null,
-    addListener: () => {},
-    removeListener: () => {},
-    addEventListener: () => {},
-    removeEventListener: () => {},
-    dispatchEvent: () => false,
-  }));
-}
 
 async function renderToaster(isCompactViewport: boolean) {
   render(
@@ -53,88 +37,42 @@ async function renderToaster(isCompactViewport: boolean) {
   });
 }
 
-interface ToastFlickOptions {
-  duration?: number;
-  endX?: number;
-  endY?: number;
-  startX?: number;
-  startY?: number;
-  terminal?: "cancel" | "up";
-  terminalTarget?: Document | HTMLElement;
-}
-
-function fireTimedPointerEvent(
-  target: Document | HTMLElement,
-  type: "cancel" | "down" | "move" | "up",
-  init: PointerEventInit,
-  timeStamp: number,
-): void {
-  const event =
-    type === "down"
-      ? createEvent.pointerDown(target, init)
-      : type === "move"
-        ? createEvent.pointerMove(target, init)
-        : type === "up"
-          ? createEvent.pointerUp(target, init)
-          : createEvent.pointerCancel(target, init);
-  Object.defineProperty(event, "timeStamp", {
-    configurable: true,
-    value: timeStamp,
-  });
-  fireEvent(target, event);
-}
-
-function flickToast(
+function swipeToast(
   toastElement: HTMLElement,
   pointerId: number,
-  {
-    duration = 200,
-    endX = 200,
-    endY = 100,
-    startX = 120,
-    startY = 100,
-    terminal = "up",
-    terminalTarget = toastElement,
-  }: ToastFlickOptions = {},
+  startX: number,
+  startY: number,
+  endX: number,
+  endY: number,
 ): void {
   Object.defineProperty(toastElement, "setPointerCapture", {
     configurable: true,
     value: () => undefined,
   });
-  const pointerInit = {
+  fireEvent.pointerDown(toastElement, {
+    clientX: startX,
+    clientY: startY,
     pointerId,
     pointerType: "touch",
-  };
-  fireTimedPointerEvent(
-    toastElement,
-    "down",
-    {
-      ...pointerInit,
-      clientX: startX,
-      clientY: startY,
-    },
-    100,
-  );
-  fireTimedPointerEvent(
-    toastElement,
-    "move",
-    {
-      ...pointerInit,
-      clientX: endX,
-      clientY: endY,
-    },
-    100 + duration / 2,
-  );
-  fireTimedPointerEvent(
-    terminalTarget,
-    terminal,
-    {
-      ...pointerInit,
-      clientX: endX,
-      clientY: endY,
-    },
-    100 + duration,
-  );
+  });
+  fireEvent.pointerMove(toastElement, {
+    clientX: startX + Math.sign(endX - startX) * 2,
+    clientY: startY + Math.sign(endY - startY) * 2,
+    pointerId,
+    pointerType: "touch",
+  });
+  fireEvent.pointerMove(toastElement, {
+    clientX: endX,
+    clientY: endY,
+    pointerId,
+    pointerType: "touch",
+  });
+  fireEvent.pointerUp(toastElement, {
+    clientX: endX,
+    clientY: endY,
+    pointerId,
+    pointerType: "touch",
+  });
 }
 
 describe("AppToaster", () => {
@@ -157,16 +95,11 @@ describe("AppToaster", () => {
   });
 
   it.each([
-    ["left flick", 200, 100, 120, 100, true],
-    ["right flick", 120, 100, 200, 100, true],
-    ["up flick", 160, 120, 160, 80, true],
-    ["down flick", 160, 100, 160, 180, true],
-    ["down-right diagonal flick", 120, 100, 180, 170, true],
-    ["down-left diagonal flick", 200, 100, 140, 170, true],
-    ["short horizontal drag", 160, 100, 172, 100, false],
+    ["left", 200, 120],
+    ["right", 120, 200],
   ] as const)(
-    "handles a compact viewport single-move %s",
-    async (_gesture, startX, startY, endX, endY, shouldDismiss) => {
+    "dismisses a compact toast to the %s",
+    async (_name, startX, endX) => {
       await renderToaster(true);
       const toastElement = document.querySelector<HTMLElement>(
         "[data-sonner-toast]",
@@ -175,91 +108,16 @@ describe("AppToaster", () => {
       if (toastElement === null) {
         return;
       }
-      flickToast(toastElement, 1, {
-        endX,
-        endY,
-        startX,
-        startY,
-      });
 
-      if (shouldDismiss) {
-        await waitFor(() => {
-          expect(document.querySelector("[data-sonner-toast]")).toBeNull();
-        });
-      } else {
-        await act(async () => Promise.resolve());
-        expect(document.querySelector("[data-sonner-toast]")).toBe(
-          toastElement,
-        );
-      }
-    },
-  );
-
-  it("handles a short high-velocity flick", async () => {
-    await renderToaster(true);
-    const toastElement = document.querySelector<HTMLElement>(
-      "[data-sonner-toast]",
-    );
-    expect(toastElement).not.toBeNull();
-    if (toastElement === null) {
-      return;
-    }
-
-    flickToast(toastElement, 1, { duration: 50, endX: 132 });
-
-    await waitFor(() => {
-      expect(document.querySelector("[data-sonner-toast]")).toBeNull();
-    });
-  });
-
-  it("handles a flick released outside the toast", async () => {
-    await renderToaster(true);
-    const toastElement = document.querySelector<HTMLElement>(
-      "[data-sonner-toast]",
-    );
-    expect(toastElement).not.toBeNull();
-    if (toastElement === null) {
-      return;
-    }
-
-    flickToast(toastElement, 1, { terminalTarget: document });
-
-    await waitFor(() => {
-      expect(document.querySelector("[data-sonner-toast]")).toBeNull();
-    });
-  });
-
-  it("handles a flick while unrelated page text is selected", async () => {
-    await renderToaster(true);
-    const toastElement = document.querySelector<HTMLElement>(
-      "[data-sonner-toast]",
-    );
-    expect(toastElement).not.toBeNull();
-    if (toastElement === null) {
-      return;
-    }
-    const unrelatedText = document.createElement("p");
-    unrelatedText.textContent = "Unrelated selection";
-    document.body.append(unrelatedText);
-    const selection = document.getSelection();
-    const range = document.createRange();
-    range.selectNodeContents(unrelatedText);
-    selection?.removeAllRanges();
-    selection?.addRange(range);
-
-    try {
-      flickToast(toastElement, 1);
+      swipeToast(toastElement, 1, startX, 100, endX, 100);
 
       await waitFor(() => {
         expect(document.querySelector("[data-sonner-toast]")).toBeNull();
       });
-    } finally {
-      selection?.removeAllRanges();
-      unrelatedText.remove();
-    }
-  });
+    },
+  );
 
-  it("completes a qualified flick after pointer cancellation", async () => {
+  it("keeps a downward drag onscreen", async () => {
     await renderToaster(true);
     const toastElement = document.querySelector<HTMLElement>(
       "[data-sonner-toast]",
@@ -269,32 +127,12 @@ describe("AppToaster", () => {
       return;
     }
 
-    flickToast(toastElement, 1, { terminal: "cancel" });
+    swipeToast(toastElement, 1, 160, 100, 160, 180);
 
-    await waitFor(() => {
-      expect(document.querySelector("[data-sonner-toast]")).toBeNull();
-    });
+    expect(document.querySelector("[data-sonner-toast]")).toBe(toastElement);
   });
 
-  it("handles touch flicks outside the compact viewport", async () => {
-    mockPointerCoarse();
-    await renderToaster(false);
-    const toastElement = document.querySelector<HTMLElement>(
-      "[data-sonner-toast]",
-    );
-    expect(toastElement).not.toBeNull();
-    if (toastElement === null) {
-      return;
-    }
-
-    flickToast(toastElement, 1);
-
-    await waitFor(() => {
-      expect(document.querySelector("[data-sonner-toast]")).toBeNull();
-    });
-  });
-
-  it("dismisses rapid stacked flicks by stable toast identity", async () => {
+  it("keeps stacked toast identity during rapid swipes", async () => {
     const onDismissA = vi.fn();
     const onDismissB = vi.fn();
     const onDismissC = vi.fn();
@@ -338,10 +176,8 @@ describe("AppToaster", () => {
       return;
     }
 
-    flickToast(toastC, 1);
-    await act(async () => Promise.resolve());
-    flickToast(toastB, 2);
-    await act(async () => Promise.resolve());
+    swipeToast(toastC, 1, 120, 100, 200, 100);
+    swipeToast(toastB, 2, 200, 100, 120, 100);
 
     expect(onDismissC).toHaveBeenCalledOnce();
     expect(onDismissB).toHaveBeenCalledOnce();

--- a/apps/app/src/components/AppToaster.test.tsx
+++ b/apps/app/src/components/AppToaster.test.tsx
@@ -3,6 +3,7 @@
 import {
   act,
   cleanup,
+  createEvent,
   fireEvent,
   render,
   waitFor,
@@ -11,6 +12,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { toast } from "sonner";
 import { CompactViewportOverrideProvider } from "@bb/shared-ui/hooks/use-compact-viewport";
 import { AppToaster } from "./AppToaster";
+import { ArchivedThreadToastDescription } from "./thread/ArchivedThreadToastDescription";
+import { AppToastContent } from "./ui/app-toast";
 
 afterEach(() => {
   toast.dismiss();
@@ -44,24 +47,29 @@ function swipeToast(
   startY: number,
   endX: number,
   endY: number,
+  pointerTarget: HTMLElement = toastElement,
 ): void {
   Object.defineProperty(toastElement, "setPointerCapture", {
     configurable: true,
     value: () => undefined,
   });
-  fireEvent.pointerDown(toastElement, {
+  Object.defineProperty(pointerTarget, "setPointerCapture", {
+    configurable: true,
+    value: () => undefined,
+  });
+  fireEvent.pointerDown(pointerTarget, {
     clientX: startX,
     clientY: startY,
     pointerId,
     pointerType: "touch",
   });
-  fireEvent.pointerMove(toastElement, {
+  fireEvent.pointerMove(pointerTarget, {
     clientX: endX,
     clientY: endY,
     pointerId,
     pointerType: "touch",
   });
-  fireEvent.pointerUp(toastElement, {
+  fireEvent.pointerUp(pointerTarget, {
     clientX: endX,
     clientY: endY,
     pointerId,
@@ -124,6 +132,113 @@ describe("AppToaster", () => {
     swipeToast(toastElement, 1, 160, 100, 160, 180);
 
     expect(document.querySelector("[data-sonner-toast]")).toBe(toastElement);
+  });
+
+  it("keeps movement continuous while Sonner's axis update is batched", async () => {
+    await renderToaster(true);
+    const toastElement = document.querySelector<HTMLElement>(
+      "[data-sonner-toast]",
+    );
+    expect(toastElement).not.toBeNull();
+    if (toastElement === null) {
+      return;
+    }
+    Object.defineProperty(toastElement, "setPointerCapture", {
+      configurable: true,
+      value: () => undefined,
+    });
+    fireEvent.pointerDown(toastElement, {
+      clientX: 120,
+      clientY: 100,
+      pointerId: 1,
+      pointerType: "touch",
+    });
+    const firstMove = createEvent.pointerMove(toastElement, {
+      clientX: 129,
+      clientY: 100,
+      pointerId: 1,
+      pointerType: "touch",
+    });
+    const secondMove = createEvent.pointerMove(toastElement, {
+      clientX: 142,
+      clientY: 100,
+      pointerId: 1,
+      pointerType: "touch",
+    });
+
+    act(() => {
+      toastElement.dispatchEvent(firstMove);
+      expect(toastElement.style.getPropertyValue("--swipe-amount-x")).toBe(
+        "9px",
+      );
+      toastElement.dispatchEvent(secondMove);
+      expect(toastElement.style.getPropertyValue("--swipe-amount-x")).toBe(
+        "22px",
+      );
+    });
+  });
+
+  it("keeps an archive title tappable but does not open it during a swipe", async () => {
+    const onDismiss = vi.fn();
+    const onOpenThread = vi.fn();
+    render(
+      <CompactViewportOverrideProvider isCompactViewport>
+        <AppToaster position="bottom-right" />
+      </CompactViewportOverrideProvider>,
+    );
+    act(() => {
+      toast.custom(
+        (id) => (
+          <AppToastContent
+            cancel={{ label: "Undo", onClick: vi.fn() }}
+            description={
+              <ArchivedThreadToastDescription
+                archivedThreadCount={1}
+                onOpenThread={onOpenThread}
+                threadTitle="Archive swipe target"
+              />
+            }
+            id={id}
+            title="Thread Archived"
+            tone="success"
+          />
+        ),
+        {
+          className: "bb-app-toast",
+          duration: Number.POSITIVE_INFINITY,
+          id: "archive-swipe-test",
+          onDismiss,
+        },
+      );
+    });
+    await waitFor(() => {
+      expect(document.querySelectorAll("[data-sonner-toast]")).toHaveLength(1);
+    });
+    const toastElement = document.querySelector<HTMLElement>(
+      "[data-sonner-toast]",
+    );
+    const threadTitle = document.querySelector<HTMLButtonElement>(
+      'button[title="Archive swipe target"]',
+    );
+    expect(toastElement).not.toBeNull();
+    expect(threadTitle).not.toBeNull();
+    if (toastElement === null || threadTitle === null) {
+      return;
+    }
+
+    swipeToast(toastElement, 1, 120, 100, 120, 100, threadTitle);
+    fireEvent.click(threadTitle);
+    expect(onOpenThread).toHaveBeenCalledOnce();
+    onOpenThread.mockClear();
+
+    swipeToast(toastElement, 2, 120, 100, 200, 100, threadTitle);
+    fireEvent.click(threadTitle);
+
+    expect(onDismiss).toHaveBeenCalledOnce();
+    expect(onOpenThread).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(document.querySelector("[data-sonner-toast]")).toBeNull();
+    });
   });
 
   it("keeps stacked toast identity during rapid swipes", async () => {

--- a/apps/app/src/components/AppToaster.tsx
+++ b/apps/app/src/components/AppToaster.tsx
@@ -1,9 +1,187 @@
-import { Toaster, type ToasterProps } from "sonner";
+import { useEffect, useRef, type RefObject } from "react";
+import {
+  toast,
+  Toaster,
+  type ToasterProps,
+  type ToastT,
+  type ToastToDismiss,
+} from "sonner";
 import { useIsCompactViewport } from "@bb/shared-ui/hooks/use-compact-viewport";
 import { usePreferredTheme } from "@/hooks/useTheme";
 
 const COMPACT_TOAST_TOP_OFFSET =
   "calc(env(safe-area-inset-top) + var(--bb-app-chrome-row-height) + 16px)";
+const COMPACT_TOAST_SWIPE_DISTANCE_PX = 20;
+const COMPACT_TOAST_SWIPE_DIRECTIONS: NonNullable<
+  ToasterProps["swipeDirections"]
+> = ["top", "left", "right"];
+
+type ToastPosition = NonNullable<ToasterProps["position"]>;
+type ToastSwipeDirection = NonNullable<ToasterProps["swipeDirections"]>[number];
+
+interface ToastSwipeStart {
+  pointerId: number;
+  toast: ToastT;
+  toastElement: HTMLElement;
+  x: number;
+  y: number;
+}
+
+interface CompactToastSwipeFallbackOptions {
+  enabled: boolean;
+  position: ToastPosition;
+  swipeDirections: readonly ToastSwipeDirection[] | undefined;
+  toasterRef: RefObject<HTMLElement | null>;
+}
+
+function isActiveToast(entry: ToastT | ToastToDismiss): entry is ToastT {
+  return !("dismiss" in entry);
+}
+
+function activeToastForElement(
+  toastElement: HTMLElement,
+  defaultPosition: ToastPosition,
+): ToastT | null {
+  const index = Number(toastElement.dataset.index);
+  if (!Number.isInteger(index) || index < 0) {
+    return null;
+  }
+  const elementPosition = `${toastElement.dataset.yPosition}-${toastElement.dataset.xPosition}`;
+  const activeToasts = toast.getToasts();
+  let positionIndex = 0;
+  for (
+    let storeIndex = activeToasts.length - 1;
+    storeIndex >= 0;
+    storeIndex--
+  ) {
+    const candidate = activeToasts[storeIndex];
+    if (
+      candidate === undefined ||
+      !isActiveToast(candidate) ||
+      (candidate.position ?? defaultPosition) !== elementPosition
+    ) {
+      continue;
+    }
+    if (positionIndex === index) {
+      return candidate;
+    }
+    positionIndex += 1;
+  }
+  return null;
+}
+
+function swipeDirection(
+  deltaX: number,
+  deltaY: number,
+): ToastSwipeDirection | null {
+  if (deltaX === 0 && deltaY === 0) {
+    return null;
+  }
+  if (Math.abs(deltaX) > Math.abs(deltaY)) {
+    return deltaX > 0 ? "right" : "left";
+  }
+  return deltaY > 0 ? "bottom" : "top";
+}
+
+function useCompactToastSwipeFallback({
+  enabled,
+  position,
+  swipeDirections,
+  toasterRef,
+}: CompactToastSwipeFallbackOptions): void {
+  const swipeStartRef = useRef<ToastSwipeStart | null>(null);
+
+  useEffect(() => {
+    const toasterElement = toasterRef.current;
+    if (!enabled || toasterElement === null) {
+      return;
+    }
+    const allowedDirections = new Set(swipeDirections);
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target;
+      if (
+        event.button !== 0 ||
+        event.pointerType !== "touch" ||
+        !(target instanceof Element) ||
+        target.closest("button") !== null
+      ) {
+        return;
+      }
+      const toastElement = target.closest<HTMLElement>("[data-sonner-toast]");
+      if (
+        toastElement === null ||
+        toastElement.dataset.dismissible !== "true" ||
+        toastElement.dataset.type === "loading"
+      ) {
+        return;
+      }
+      const activeToast = activeToastForElement(toastElement, position);
+      if (activeToast === null) {
+        return;
+      }
+      swipeStartRef.current = {
+        pointerId: event.pointerId,
+        toast: activeToast,
+        toastElement,
+        x: event.clientX,
+        y: event.clientY,
+      };
+    };
+
+    const handlePointerUp = (event: PointerEvent) => {
+      const start = swipeStartRef.current;
+      if (start === null || start.pointerId !== event.pointerId) {
+        return;
+      }
+      swipeStartRef.current = null;
+      if (start.toastElement.ownerDocument.getSelection()?.toString()) {
+        return;
+      }
+      const deltaX = event.clientX - start.x;
+      const deltaY = event.clientY - start.y;
+      const direction = swipeDirection(deltaX, deltaY);
+      const distance =
+        direction === "left" || direction === "right"
+          ? Math.abs(deltaX)
+          : Math.abs(deltaY);
+      if (
+        direction === null ||
+        !allowedDirections.has(direction) ||
+        distance < COMPACT_TOAST_SWIPE_DISTANCE_PX
+      ) {
+        return;
+      }
+      queueMicrotask(() => {
+        if (
+          !start.toastElement.isConnected ||
+          start.toastElement.dataset.removed === "true" ||
+          start.toastElement.dataset.swipeOut === "true"
+        ) {
+          return;
+        }
+        start.toast.onDismiss?.(start.toast);
+        toast.dismiss(start.toast.id);
+      });
+    };
+
+    const handlePointerCancel = (event: PointerEvent) => {
+      if (swipeStartRef.current?.pointerId === event.pointerId) {
+        swipeStartRef.current = null;
+      }
+    };
+
+    toasterElement.addEventListener("pointerdown", handlePointerDown);
+    toasterElement.addEventListener("pointerup", handlePointerUp);
+    toasterElement.addEventListener("pointercancel", handlePointerCancel);
+    return () => {
+      swipeStartRef.current = null;
+      toasterElement.removeEventListener("pointerdown", handlePointerDown);
+      toasterElement.removeEventListener("pointerup", handlePointerUp);
+      toasterElement.removeEventListener("pointercancel", handlePointerCancel);
+    };
+  }, [enabled, position, swipeDirections, toasterRef]);
+}
 
 function withCompactTopOffset(
   offset: ToasterProps["offset"],
@@ -23,21 +201,33 @@ export function AppToaster({
   position = "bottom-right",
   offset,
   mobileOffset,
+  swipeDirections,
   ...props
 }: ToasterProps) {
   const theme = usePreferredTheme();
   const isCompactViewport = useIsCompactViewport();
+  const toasterRef = useRef<HTMLElement | null>(null);
+  const renderedPosition = isCompactViewport ? "top-center" : position;
+  const renderedSwipeDirections =
+    swipeDirections ??
+    (isCompactViewport ? COMPACT_TOAST_SWIPE_DIRECTIONS : undefined);
+  useCompactToastSwipeFallback({
+    enabled: isCompactViewport,
+    position: renderedPosition,
+    swipeDirections: renderedSwipeDirections,
+    toasterRef,
+  });
   return (
     <Toaster
+      ref={toasterRef}
       theme={theme}
-      position={isCompactViewport ? "top-center" : position}
+      position={renderedPosition}
       {...props}
       offset={isCompactViewport ? withCompactTopOffset(offset) : offset}
       mobileOffset={
-        isCompactViewport
-          ? withCompactTopOffset(mobileOffset)
-          : mobileOffset
+        isCompactViewport ? withCompactTopOffset(mobileOffset) : mobileOffset
       }
+      swipeDirections={renderedSwipeDirections}
     />
   );
 }

--- a/apps/app/src/components/AppToaster.tsx
+++ b/apps/app/src/components/AppToaster.tsx
@@ -21,7 +21,7 @@ type ToastSwipeDirection = NonNullable<ToasterProps["swipeDirections"]>[number];
 
 interface ToastSwipeStart {
   pointerId: number;
-  toast: ToastT;
+  toastId: ToastT["id"];
   toastElement: HTMLElement;
   x: number;
   y: number;
@@ -38,36 +38,77 @@ function isActiveToast(entry: ToastT | ToastToDismiss): entry is ToastT {
   return !("dismiss" in entry);
 }
 
-function activeToastForElement(
-  toastElement: HTMLElement,
+function toastPositionForElement(toastElement: HTMLElement): string {
+  return `${toastElement.dataset.yPosition}-${toastElement.dataset.xPosition}`;
+}
+
+function activeToastById(id: ToastT["id"]): ToastT | null {
+  return (
+    toast
+      .getToasts()
+      .find(
+        (entry): entry is ToastT => isActiveToast(entry) && entry.id === id,
+      ) ?? null
+  );
+}
+
+function associateToastElements(
+  toasterElement: HTMLElement,
   defaultPosition: ToastPosition,
-): ToastT | null {
-  const index = Number(toastElement.dataset.index);
-  if (!Number.isInteger(index) || index < 0) {
-    return null;
-  }
-  const elementPosition = `${toastElement.dataset.yPosition}-${toastElement.dataset.xPosition}`;
+  toastIdsByElement: WeakMap<HTMLElement, ToastT["id"]>,
+): void {
+  const activeToastsByPosition = new Map<string, ToastT[]>();
   const activeToasts = toast.getToasts();
-  let positionIndex = 0;
   for (
     let storeIndex = activeToasts.length - 1;
     storeIndex >= 0;
     storeIndex--
   ) {
     const candidate = activeToasts[storeIndex];
+    if (candidate === undefined || !isActiveToast(candidate)) {
+      continue;
+    }
+    const candidatePosition = candidate.position ?? defaultPosition;
+    const positionToasts = activeToastsByPosition.get(candidatePosition) ?? [];
+    positionToasts.push(candidate);
+    activeToastsByPosition.set(candidatePosition, positionToasts);
+  }
+
+  const activeElementsByPosition = new Map<string, HTMLElement[]>();
+  const toastElements = toasterElement.querySelectorAll<HTMLElement>(
+    "[data-sonner-toast]",
+  );
+  for (const toastElement of toastElements) {
+    if (toastElement.dataset.removed === "true") {
+      continue;
+    }
+    const elementPosition = toastPositionForElement(toastElement);
+    const positionElements =
+      activeElementsByPosition.get(elementPosition) ?? [];
+    positionElements.push(toastElement);
+    activeElementsByPosition.set(elementPosition, positionElements);
+  }
+
+  for (const [elementPosition, positionElements] of activeElementsByPosition) {
+    const positionToasts = activeToastsByPosition.get(elementPosition);
     if (
-      candidate === undefined ||
-      !isActiveToast(candidate) ||
-      (candidate.position ?? defaultPosition) !== elementPosition
+      positionToasts === undefined ||
+      positionElements.length > positionToasts.length
     ) {
       continue;
     }
-    if (positionIndex === index) {
-      return candidate;
+    for (let index = 0; index < positionElements.length; index++) {
+      const toastElement = positionElements[index];
+      const activeToast = positionToasts[index];
+      if (
+        toastElement !== undefined &&
+        activeToast !== undefined &&
+        !toastIdsByElement.has(toastElement)
+      ) {
+        toastIdsByElement.set(toastElement, activeToast.id);
+      }
     }
-    positionIndex += 1;
   }
-  return null;
 }
 
 function swipeDirection(
@@ -97,6 +138,7 @@ function useCompactToastSwipeFallback({
       return;
     }
     const allowedDirections = new Set(swipeDirections);
+    const toastIdsByElement = new WeakMap<HTMLElement, ToastT["id"]>();
 
     const handlePointerDown = (event: PointerEvent) => {
       const target = event.target;
@@ -116,13 +158,14 @@ function useCompactToastSwipeFallback({
       ) {
         return;
       }
-      const activeToast = activeToastForElement(toastElement, position);
-      if (activeToast === null) {
+      associateToastElements(toasterElement, position, toastIdsByElement);
+      const toastId = toastIdsByElement.get(toastElement);
+      if (toastId === undefined || activeToastById(toastId) === null) {
         return;
       }
       swipeStartRef.current = {
         pointerId: event.pointerId,
-        toast: activeToast,
+        toastId,
         toastElement,
         x: event.clientX,
         y: event.clientY,
@@ -160,8 +203,12 @@ function useCompactToastSwipeFallback({
         ) {
           return;
         }
-        start.toast.onDismiss?.(start.toast);
-        toast.dismiss(start.toast.id);
+        const activeToast = activeToastById(start.toastId);
+        if (activeToast === null) {
+          return;
+        }
+        activeToast.onDismiss?.(activeToast);
+        toast.dismiss(activeToast.id);
       });
     };
 

--- a/apps/app/src/components/AppToaster.tsx
+++ b/apps/app/src/components/AppToaster.tsx
@@ -7,14 +7,15 @@ import {
   type ToastToDismiss,
 } from "sonner";
 import { useIsCompactViewport } from "@bb/shared-ui/hooks/use-compact-viewport";
+import { usePointerCoarse } from "@bb/shared-ui/hooks/use-pointer-coarse";
 import { usePreferredTheme } from "@/hooks/useTheme";
 
 const COMPACT_TOAST_TOP_OFFSET =
   "calc(env(safe-area-inset-top) + var(--bb-app-chrome-row-height) + 16px)";
-const COMPACT_TOAST_SWIPE_DISTANCE_PX = 20;
-const COMPACT_TOAST_SWIPE_DIRECTIONS: NonNullable<
+const TOUCH_TOAST_SWIPE_DISTANCE_PX = 20;
+const TOUCH_TOAST_SWIPE_DIRECTIONS: NonNullable<
   ToasterProps["swipeDirections"]
-> = ["top", "left", "right"];
+> = ["top", "right", "bottom", "left"];
 
 type ToastPosition = NonNullable<ToasterProps["position"]>;
 type ToastSwipeDirection = NonNullable<ToasterProps["swipeDirections"]>[number];
@@ -27,7 +28,7 @@ interface ToastSwipeStart {
   y: number;
 }
 
-interface CompactToastSwipeFallbackOptions {
+interface TouchToastSwipeFallbackOptions {
   enabled: boolean;
   position: ToastPosition;
   swipeDirections: readonly ToastSwipeDirection[] | undefined;
@@ -124,12 +125,12 @@ function swipeDirection(
   return deltaY > 0 ? "bottom" : "top";
 }
 
-function useCompactToastSwipeFallback({
+function useTouchToastSwipeFallback({
   enabled,
   position,
   swipeDirections,
   toasterRef,
-}: CompactToastSwipeFallbackOptions): void {
+}: TouchToastSwipeFallbackOptions): void {
   const swipeStartRef = useRef<ToastSwipeStart | null>(null);
 
   useEffect(() => {
@@ -191,7 +192,7 @@ function useCompactToastSwipeFallback({
       if (
         direction === null ||
         !allowedDirections.has(direction) ||
-        distance < COMPACT_TOAST_SWIPE_DISTANCE_PX
+        distance < TOUCH_TOAST_SWIPE_DISTANCE_PX
       ) {
         return;
       }
@@ -253,13 +254,15 @@ export function AppToaster({
 }: ToasterProps) {
   const theme = usePreferredTheme();
   const isCompactViewport = useIsCompactViewport();
+  const isPointerCoarse = usePointerCoarse();
   const toasterRef = useRef<HTMLElement | null>(null);
   const renderedPosition = isCompactViewport ? "top-center" : position;
+  const touchSwipeEnabled = isCompactViewport || isPointerCoarse;
   const renderedSwipeDirections =
     swipeDirections ??
-    (isCompactViewport ? COMPACT_TOAST_SWIPE_DIRECTIONS : undefined);
-  useCompactToastSwipeFallback({
-    enabled: isCompactViewport,
+    (touchSwipeEnabled ? TOUCH_TOAST_SWIPE_DIRECTIONS : undefined);
+  useTouchToastSwipeFallback({
+    enabled: touchSwipeEnabled,
     position: renderedPosition,
     swipeDirections: renderedSwipeDirections,
     toasterRef,

--- a/apps/app/src/components/AppToaster.tsx
+++ b/apps/app/src/components/AppToaster.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, type RefObject } from "react";
 import { Toaster, type ToasterProps } from "sonner";
 import { useIsCompactViewport } from "@bb/shared-ui/hooks/use-compact-viewport";
 import { usePreferredTheme } from "@/hooks/useTheme";
@@ -7,6 +8,116 @@ const COMPACT_TOAST_TOP_OFFSET =
 const COMPACT_TOAST_SWIPE_DIRECTIONS: NonNullable<
   ToasterProps["swipeDirections"]
 > = ["top", "left", "right"];
+
+type ToastSwipeDirection = NonNullable<ToasterProps["swipeDirections"]>[number];
+
+interface ToastSwipeStart {
+  moved: boolean;
+  pointerId: number;
+  toastElement: HTMLElement;
+  x: number;
+  y: number;
+}
+
+interface SonnerFirstMoveFixOptions {
+  enabled: boolean;
+  swipeDirections: readonly ToastSwipeDirection[] | undefined;
+  toasterRef: RefObject<HTMLElement | null>;
+}
+
+function useSonnerFirstMoveFix({
+  enabled,
+  swipeDirections,
+  toasterRef,
+}: SonnerFirstMoveFixOptions): void {
+  const swipeStartRef = useRef<ToastSwipeStart | null>(null);
+
+  useEffect(() => {
+    const toasterElement = toasterRef.current;
+    if (!enabled || toasterElement === null) {
+      return;
+    }
+    const allowedDirections = new Set(swipeDirections);
+    const ownerDocument = toasterElement.ownerDocument;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target;
+      if (
+        event.button !== 0 ||
+        event.pointerType !== "touch" ||
+        !(target instanceof Element) ||
+        target.closest("button") !== null
+      ) {
+        return;
+      }
+      const toastElement = target.closest<HTMLElement>("[data-sonner-toast]");
+      if (
+        toastElement === null ||
+        toastElement.dataset.dismissible !== "true" ||
+        toastElement.dataset.type === "loading"
+      ) {
+        return;
+      }
+      swipeStartRef.current = {
+        moved: false,
+        pointerId: event.pointerId,
+        toastElement,
+        x: event.clientX,
+        y: event.clientY,
+      };
+    };
+
+    const handlePointerMove = (event: PointerEvent) => {
+      const start = swipeStartRef.current;
+      if (
+        start === null ||
+        start.moved ||
+        start.pointerId !== event.pointerId ||
+        ownerDocument.getSelection()?.toString()
+      ) {
+        return;
+      }
+      const deltaX = event.clientX - start.x;
+      const deltaY = event.clientY - start.y;
+      if (Math.abs(deltaX) <= 1 && Math.abs(deltaY) <= 1) {
+        return;
+      }
+      start.moved = true;
+      if (Math.abs(deltaX) > Math.abs(deltaY)) {
+        const direction = deltaX > 0 ? "right" : "left";
+        if (allowedDirections.has(direction)) {
+          start.toastElement.style.setProperty(
+            "--swipe-amount-x",
+            `${deltaX}px`,
+          );
+        }
+        return;
+      }
+      const direction = deltaY > 0 ? "bottom" : "top";
+      if (allowedDirections.has(direction)) {
+        start.toastElement.style.setProperty("--swipe-amount-y", `${deltaY}px`);
+      }
+    };
+
+    const handlePointerEnd = (event: PointerEvent) => {
+      if (swipeStartRef.current?.pointerId === event.pointerId) {
+        swipeStartRef.current = null;
+      }
+    };
+
+    toasterElement.addEventListener("pointerdown", handlePointerDown);
+    ownerDocument.addEventListener("pointermove", handlePointerMove);
+    ownerDocument.addEventListener("pointerup", handlePointerEnd);
+    ownerDocument.addEventListener("pointercancel", handlePointerEnd);
+    return () => {
+      swipeStartRef.current = null;
+      toasterElement.removeEventListener("pointerdown", handlePointerDown);
+      ownerDocument.removeEventListener("pointermove", handlePointerMove);
+      ownerDocument.removeEventListener("pointerup", handlePointerEnd);
+      ownerDocument.removeEventListener("pointercancel", handlePointerEnd);
+    };
+  }, [enabled, swipeDirections, toasterRef]);
+}
 
 function withCompactTopOffset(
   offset: ToasterProps["offset"],
@@ -31,8 +142,18 @@ export function AppToaster({
 }: ToasterProps) {
   const theme = usePreferredTheme();
   const isCompactViewport = useIsCompactViewport();
+  const toasterRef = useRef<HTMLElement | null>(null);
+  const renderedSwipeDirections =
+    swipeDirections ??
+    (isCompactViewport ? COMPACT_TOAST_SWIPE_DIRECTIONS : undefined);
+  useSonnerFirstMoveFix({
+    enabled: isCompactViewport,
+    swipeDirections: renderedSwipeDirections,
+    toasterRef,
+  });
   return (
     <Toaster
+      ref={toasterRef}
       theme={theme}
       position={isCompactViewport ? "top-center" : position}
       {...props}
@@ -40,10 +161,7 @@ export function AppToaster({
       mobileOffset={
         isCompactViewport ? withCompactTopOffset(mobileOffset) : mobileOffset
       }
-      swipeDirections={
-        swipeDirections ??
-        (isCompactViewport ? COMPACT_TOAST_SWIPE_DIRECTIONS : undefined)
-      }
+      swipeDirections={renderedSwipeDirections}
     />
   );
 }

--- a/apps/app/src/components/AppToaster.tsx
+++ b/apps/app/src/components/AppToaster.tsx
@@ -1,285 +1,12 @@
-import { useEffect, useRef, type RefObject } from "react";
-import {
-  toast,
-  Toaster,
-  type ToasterProps,
-  type ToastT,
-  type ToastToDismiss,
-} from "sonner";
+import { Toaster, type ToasterProps } from "sonner";
 import { useIsCompactViewport } from "@bb/shared-ui/hooks/use-compact-viewport";
-import { usePointerCoarse } from "@bb/shared-ui/hooks/use-pointer-coarse";
 import { usePreferredTheme } from "@/hooks/useTheme";
 
 const COMPACT_TOAST_TOP_OFFSET =
   "calc(env(safe-area-inset-top) + var(--bb-app-chrome-row-height) + 16px)";
-const TOUCH_TOAST_SWIPE_DIRECTION_LOCK_PX = 1;
-const TOUCH_TOAST_SWIPE_DISTANCE_PX = 20;
-const TOUCH_TOAST_SWIPE_VELOCITY_PX_PER_MS = 0.11;
-const TOUCH_TOAST_SWIPE_DIRECTIONS: NonNullable<
+const COMPACT_TOAST_SWIPE_DIRECTIONS: NonNullable<
   ToasterProps["swipeDirections"]
-> = ["top", "right", "bottom", "left"];
-
-type ToastPosition = NonNullable<ToasterProps["position"]>;
-type ToastSwipeDirection = NonNullable<ToasterProps["swipeDirections"]>[number];
-
-interface ToastSwipeStart {
-  lastX: number;
-  lastY: number;
-  pointerId: number;
-  startTime: number;
-  startX: number;
-  startY: number;
-  toastId: ToastT["id"];
-  toastElement: HTMLElement;
-}
-
-interface TouchToastSwipeFallbackOptions {
-  enabled: boolean;
-  position: ToastPosition;
-  swipeDirections: readonly ToastSwipeDirection[] | undefined;
-  toasterRef: RefObject<HTMLElement | null>;
-}
-
-function isActiveToast(entry: ToastT | ToastToDismiss): entry is ToastT {
-  return !("dismiss" in entry);
-}
-
-function toastPositionForElement(toastElement: HTMLElement): string {
-  return `${toastElement.dataset.yPosition}-${toastElement.dataset.xPosition}`;
-}
-
-function activeToastById(id: ToastT["id"]): ToastT | null {
-  return (
-    toast
-      .getToasts()
-      .find(
-        (entry): entry is ToastT => isActiveToast(entry) && entry.id === id,
-      ) ?? null
-  );
-}
-
-function associateToastElements(
-  toasterElement: HTMLElement,
-  defaultPosition: ToastPosition,
-  toastIdsByElement: WeakMap<HTMLElement, ToastT["id"]>,
-): void {
-  const activeToastsByPosition = new Map<string, ToastT[]>();
-  const activeToasts = toast.getToasts();
-  for (
-    let storeIndex = activeToasts.length - 1;
-    storeIndex >= 0;
-    storeIndex--
-  ) {
-    const candidate = activeToasts[storeIndex];
-    if (candidate === undefined || !isActiveToast(candidate)) {
-      continue;
-    }
-    const candidatePosition = candidate.position ?? defaultPosition;
-    const positionToasts = activeToastsByPosition.get(candidatePosition) ?? [];
-    positionToasts.push(candidate);
-    activeToastsByPosition.set(candidatePosition, positionToasts);
-  }
-
-  const activeElementsByPosition = new Map<string, HTMLElement[]>();
-  const toastElements = toasterElement.querySelectorAll<HTMLElement>(
-    "[data-sonner-toast]",
-  );
-  for (const toastElement of toastElements) {
-    if (toastElement.dataset.removed === "true") {
-      continue;
-    }
-    const elementPosition = toastPositionForElement(toastElement);
-    const positionElements =
-      activeElementsByPosition.get(elementPosition) ?? [];
-    positionElements.push(toastElement);
-    activeElementsByPosition.set(elementPosition, positionElements);
-  }
-
-  for (const [elementPosition, positionElements] of activeElementsByPosition) {
-    const positionToasts = activeToastsByPosition.get(elementPosition);
-    if (
-      positionToasts === undefined ||
-      positionElements.length > positionToasts.length
-    ) {
-      continue;
-    }
-    for (let index = 0; index < positionElements.length; index++) {
-      const toastElement = positionElements[index];
-      const activeToast = positionToasts[index];
-      if (
-        toastElement !== undefined &&
-        activeToast !== undefined &&
-        !toastIdsByElement.has(toastElement)
-      ) {
-        toastIdsByElement.set(toastElement, activeToast.id);
-      }
-    }
-  }
-}
-
-function allowedSwipeDistance(
-  deltaX: number,
-  deltaY: number,
-  allowedDirections: ReadonlySet<ToastSwipeDirection>,
-): number {
-  return Math.max(
-    deltaX < 0 && allowedDirections.has("left") ? -deltaX : 0,
-    deltaX > 0 && allowedDirections.has("right") ? deltaX : 0,
-    deltaY < 0 && allowedDirections.has("top") ? -deltaY : 0,
-    deltaY > 0 && allowedDirections.has("bottom") ? deltaY : 0,
-  );
-}
-
-function toastContainsSelection(toastElement: HTMLElement): boolean {
-  const selection = toastElement.ownerDocument.getSelection();
-  if (selection === null || selection.isCollapsed) {
-    return false;
-  }
-  return (
-    (selection.anchorNode !== null &&
-      toastElement.contains(selection.anchorNode)) ||
-    (selection.focusNode !== null && toastElement.contains(selection.focusNode))
-  );
-}
-
-function useTouchToastSwipeFallback({
-  enabled,
-  position,
-  swipeDirections,
-  toasterRef,
-}: TouchToastSwipeFallbackOptions): void {
-  const swipeStartRef = useRef<ToastSwipeStart | null>(null);
-
-  useEffect(() => {
-    const toasterElement = toasterRef.current;
-    if (!enabled || toasterElement === null) {
-      return;
-    }
-    const allowedDirections = new Set(swipeDirections);
-    const toastIdsByElement = new WeakMap<HTMLElement, ToastT["id"]>();
-
-    const handlePointerDown = (event: PointerEvent) => {
-      const target = event.target;
-      if (
-        event.button !== 0 ||
-        event.pointerType !== "touch" ||
-        !(target instanceof Element) ||
-        target.closest("button") !== null
-      ) {
-        return;
-      }
-      const toastElement = target.closest<HTMLElement>("[data-sonner-toast]");
-      if (
-        toastElement === null ||
-        toastElement.dataset.dismissible !== "true" ||
-        toastElement.dataset.type === "loading"
-      ) {
-        return;
-      }
-      associateToastElements(toasterElement, position, toastIdsByElement);
-      const toastId = toastIdsByElement.get(toastElement);
-      if (toastId === undefined || activeToastById(toastId) === null) {
-        return;
-      }
-      swipeStartRef.current = {
-        lastX: event.clientX,
-        lastY: event.clientY,
-        pointerId: event.pointerId,
-        startTime: event.timeStamp,
-        startX: event.clientX,
-        startY: event.clientY,
-        toastId,
-        toastElement,
-      };
-    };
-
-    const handlePointerMove = (event: PointerEvent) => {
-      const start = swipeStartRef.current;
-      if (start === null || start.pointerId !== event.pointerId) {
-        return;
-      }
-      start.lastX = event.clientX;
-      start.lastY = event.clientY;
-    };
-
-    const finishSwipe = (event: PointerEvent, useLastPosition: boolean) => {
-      const start = swipeStartRef.current;
-      if (start === null || start.pointerId !== event.pointerId) {
-        return;
-      }
-      swipeStartRef.current = null;
-      if (toastContainsSelection(start.toastElement)) {
-        return;
-      }
-      const endX = useLastPosition ? start.lastX : event.clientX;
-      const endY = useLastPosition ? start.lastY : event.clientY;
-      const distance = allowedSwipeDistance(
-        endX - start.startX,
-        endY - start.startY,
-        allowedDirections,
-      );
-      const elapsed = Math.max(event.timeStamp - start.startTime, 1);
-      const velocity = distance / elapsed;
-      if (
-        distance <= TOUCH_TOAST_SWIPE_DIRECTION_LOCK_PX ||
-        (distance < TOUCH_TOAST_SWIPE_DISTANCE_PX &&
-          velocity <= TOUCH_TOAST_SWIPE_VELOCITY_PX_PER_MS)
-      ) {
-        return;
-      }
-      queueMicrotask(() => {
-        if (
-          !start.toastElement.isConnected ||
-          start.toastElement.dataset.removed === "true" ||
-          start.toastElement.dataset.swipeOut === "true"
-        ) {
-          return;
-        }
-        const activeToast = activeToastById(start.toastId);
-        if (activeToast === null) {
-          return;
-        }
-        activeToast.onDismiss?.(activeToast);
-        toast.dismiss(activeToast.id);
-      });
-    };
-
-    const handlePointerUp = (event: PointerEvent) => finishSwipe(event, false);
-    const handlePointerTermination = (event: PointerEvent) =>
-      finishSwipe(event, true);
-    const ownerDocument = toasterElement.ownerDocument;
-
-    toasterElement.addEventListener("pointerdown", handlePointerDown);
-    ownerDocument.addEventListener("pointermove", handlePointerMove, true);
-    ownerDocument.addEventListener("pointerup", handlePointerUp, true);
-    ownerDocument.addEventListener(
-      "pointercancel",
-      handlePointerTermination,
-      true,
-    );
-    ownerDocument.addEventListener(
-      "lostpointercapture",
-      handlePointerTermination,
-      true,
-    );
-    return () => {
-      swipeStartRef.current = null;
-      toasterElement.removeEventListener("pointerdown", handlePointerDown);
-      ownerDocument.removeEventListener("pointermove", handlePointerMove, true);
-      ownerDocument.removeEventListener("pointerup", handlePointerUp, true);
-      ownerDocument.removeEventListener(
-        "pointercancel",
-        handlePointerTermination,
-        true,
-      );
-      ownerDocument.removeEventListener(
-        "lostpointercapture",
-        handlePointerTermination,
-        true,
-      );
-    };
-  }, [enabled, position, swipeDirections, toasterRef]);
-}
+> = ["top", "left", "right"];
 
 function withCompactTopOffset(
   offset: ToasterProps["offset"],
@@ -304,30 +31,19 @@ export function AppToaster({
 }: ToasterProps) {
   const theme = usePreferredTheme();
   const isCompactViewport = useIsCompactViewport();
-  const isPointerCoarse = usePointerCoarse();
-  const toasterRef = useRef<HTMLElement | null>(null);
-  const renderedPosition = isCompactViewport ? "top-center" : position;
-  const touchSwipeEnabled = isCompactViewport || isPointerCoarse;
-  const renderedSwipeDirections =
-    swipeDirections ??
-    (touchSwipeEnabled ? TOUCH_TOAST_SWIPE_DIRECTIONS : undefined);
-  useTouchToastSwipeFallback({
-    enabled: touchSwipeEnabled,
-    position: renderedPosition,
-    swipeDirections: renderedSwipeDirections,
-    toasterRef,
-  });
   return (
     <Toaster
-      ref={toasterRef}
       theme={theme}
-      position={renderedPosition}
+      position={isCompactViewport ? "top-center" : position}
       {...props}
       offset={isCompactViewport ? withCompactTopOffset(offset) : offset}
       mobileOffset={
         isCompactViewport ? withCompactTopOffset(mobileOffset) : mobileOffset
       }
-      swipeDirections={renderedSwipeDirections}
+      swipeDirections={
+        swipeDirections ??
+        (isCompactViewport ? COMPACT_TOAST_SWIPE_DIRECTIONS : undefined)
+      }
     />
   );
 }

--- a/apps/app/src/components/AppToaster.tsx
+++ b/apps/app/src/components/AppToaster.tsx
@@ -12,7 +12,9 @@ import { usePreferredTheme } from "@/hooks/useTheme";
 
 const COMPACT_TOAST_TOP_OFFSET =
   "calc(env(safe-area-inset-top) + var(--bb-app-chrome-row-height) + 16px)";
+const TOUCH_TOAST_SWIPE_DIRECTION_LOCK_PX = 1;
 const TOUCH_TOAST_SWIPE_DISTANCE_PX = 20;
+const TOUCH_TOAST_SWIPE_VELOCITY_PX_PER_MS = 0.11;
 const TOUCH_TOAST_SWIPE_DIRECTIONS: NonNullable<
   ToasterProps["swipeDirections"]
 > = ["top", "right", "bottom", "left"];
@@ -21,11 +23,14 @@ type ToastPosition = NonNullable<ToasterProps["position"]>;
 type ToastSwipeDirection = NonNullable<ToasterProps["swipeDirections"]>[number];
 
 interface ToastSwipeStart {
+  lastX: number;
+  lastY: number;
   pointerId: number;
+  startTime: number;
+  startX: number;
+  startY: number;
   toastId: ToastT["id"];
   toastElement: HTMLElement;
-  x: number;
-  y: number;
 }
 
 interface TouchToastSwipeFallbackOptions {
@@ -112,17 +117,29 @@ function associateToastElements(
   }
 }
 
-function swipeDirection(
+function allowedSwipeDistance(
   deltaX: number,
   deltaY: number,
-): ToastSwipeDirection | null {
-  if (deltaX === 0 && deltaY === 0) {
-    return null;
+  allowedDirections: ReadonlySet<ToastSwipeDirection>,
+): number {
+  return Math.max(
+    deltaX < 0 && allowedDirections.has("left") ? -deltaX : 0,
+    deltaX > 0 && allowedDirections.has("right") ? deltaX : 0,
+    deltaY < 0 && allowedDirections.has("top") ? -deltaY : 0,
+    deltaY > 0 && allowedDirections.has("bottom") ? deltaY : 0,
+  );
+}
+
+function toastContainsSelection(toastElement: HTMLElement): boolean {
+  const selection = toastElement.ownerDocument.getSelection();
+  if (selection === null || selection.isCollapsed) {
+    return false;
   }
-  if (Math.abs(deltaX) > Math.abs(deltaY)) {
-    return deltaX > 0 ? "right" : "left";
-  }
-  return deltaY > 0 ? "bottom" : "top";
+  return (
+    (selection.anchorNode !== null &&
+      toastElement.contains(selection.anchorNode)) ||
+    (selection.focusNode !== null && toastElement.contains(selection.focusNode))
+  );
 }
 
 function useTouchToastSwipeFallback({
@@ -165,34 +182,48 @@ function useTouchToastSwipeFallback({
         return;
       }
       swipeStartRef.current = {
+        lastX: event.clientX,
+        lastY: event.clientY,
         pointerId: event.pointerId,
+        startTime: event.timeStamp,
+        startX: event.clientX,
+        startY: event.clientY,
         toastId,
         toastElement,
-        x: event.clientX,
-        y: event.clientY,
       };
     };
 
-    const handlePointerUp = (event: PointerEvent) => {
+    const handlePointerMove = (event: PointerEvent) => {
+      const start = swipeStartRef.current;
+      if (start === null || start.pointerId !== event.pointerId) {
+        return;
+      }
+      start.lastX = event.clientX;
+      start.lastY = event.clientY;
+    };
+
+    const finishSwipe = (event: PointerEvent, useLastPosition: boolean) => {
       const start = swipeStartRef.current;
       if (start === null || start.pointerId !== event.pointerId) {
         return;
       }
       swipeStartRef.current = null;
-      if (start.toastElement.ownerDocument.getSelection()?.toString()) {
+      if (toastContainsSelection(start.toastElement)) {
         return;
       }
-      const deltaX = event.clientX - start.x;
-      const deltaY = event.clientY - start.y;
-      const direction = swipeDirection(deltaX, deltaY);
-      const distance =
-        direction === "left" || direction === "right"
-          ? Math.abs(deltaX)
-          : Math.abs(deltaY);
+      const endX = useLastPosition ? start.lastX : event.clientX;
+      const endY = useLastPosition ? start.lastY : event.clientY;
+      const distance = allowedSwipeDistance(
+        endX - start.startX,
+        endY - start.startY,
+        allowedDirections,
+      );
+      const elapsed = Math.max(event.timeStamp - start.startTime, 1);
+      const velocity = distance / elapsed;
       if (
-        direction === null ||
-        !allowedDirections.has(direction) ||
-        distance < TOUCH_TOAST_SWIPE_DISTANCE_PX
+        distance <= TOUCH_TOAST_SWIPE_DIRECTION_LOCK_PX ||
+        (distance < TOUCH_TOAST_SWIPE_DISTANCE_PX &&
+          velocity <= TOUCH_TOAST_SWIPE_VELOCITY_PX_PER_MS)
       ) {
         return;
       }
@@ -213,20 +244,39 @@ function useTouchToastSwipeFallback({
       });
     };
 
-    const handlePointerCancel = (event: PointerEvent) => {
-      if (swipeStartRef.current?.pointerId === event.pointerId) {
-        swipeStartRef.current = null;
-      }
-    };
+    const handlePointerUp = (event: PointerEvent) => finishSwipe(event, false);
+    const handlePointerTermination = (event: PointerEvent) =>
+      finishSwipe(event, true);
+    const ownerDocument = toasterElement.ownerDocument;
 
     toasterElement.addEventListener("pointerdown", handlePointerDown);
-    toasterElement.addEventListener("pointerup", handlePointerUp);
-    toasterElement.addEventListener("pointercancel", handlePointerCancel);
+    ownerDocument.addEventListener("pointermove", handlePointerMove, true);
+    ownerDocument.addEventListener("pointerup", handlePointerUp, true);
+    ownerDocument.addEventListener(
+      "pointercancel",
+      handlePointerTermination,
+      true,
+    );
+    ownerDocument.addEventListener(
+      "lostpointercapture",
+      handlePointerTermination,
+      true,
+    );
     return () => {
       swipeStartRef.current = null;
       toasterElement.removeEventListener("pointerdown", handlePointerDown);
-      toasterElement.removeEventListener("pointerup", handlePointerUp);
-      toasterElement.removeEventListener("pointercancel", handlePointerCancel);
+      ownerDocument.removeEventListener("pointermove", handlePointerMove, true);
+      ownerDocument.removeEventListener("pointerup", handlePointerUp, true);
+      ownerDocument.removeEventListener(
+        "pointercancel",
+        handlePointerTermination,
+        true,
+      );
+      ownerDocument.removeEventListener(
+        "lostpointercapture",
+        handlePointerTermination,
+        true,
+      );
     };
   }, [enabled, position, swipeDirections, toasterRef]);
 }

--- a/apps/app/src/components/AppToaster.tsx
+++ b/apps/app/src/components/AppToaster.tsx
@@ -8,28 +8,31 @@ const COMPACT_TOAST_TOP_OFFSET =
 const COMPACT_TOAST_SWIPE_DIRECTIONS: NonNullable<
   ToasterProps["swipeDirections"]
 > = ["top", "left", "right"];
+const TOAST_BUTTON_TAP_SLOP = 4;
 
 type ToastSwipeDirection = NonNullable<ToasterProps["swipeDirections"]>[number];
 
 interface ToastSwipeStart {
-  moved: boolean;
+  axis: "x" | "y" | null;
+  button: HTMLButtonElement | null;
+  dragged: boolean;
   pointerId: number;
   toastElement: HTMLElement;
   x: number;
   y: number;
 }
 
-interface SonnerFirstMoveFixOptions {
+interface ReliableToastSwipesOptions {
   enabled: boolean;
   swipeDirections: readonly ToastSwipeDirection[] | undefined;
   toasterRef: RefObject<HTMLElement | null>;
 }
 
-function useSonnerFirstMoveFix({
+function useReliableToastSwipes({
   enabled,
   swipeDirections,
   toasterRef,
-}: SonnerFirstMoveFixOptions): void {
+}: ReliableToastSwipesOptions): void {
   const swipeStartRef = useRef<ToastSwipeStart | null>(null);
 
   useEffect(() => {
@@ -39,14 +42,17 @@ function useSonnerFirstMoveFix({
     }
     const allowedDirections = new Set(swipeDirections);
     const ownerDocument = toasterElement.ownerDocument;
+    const bridgedPointerDowns = new WeakSet<Event>();
+    let suppressedClickButton: HTMLButtonElement | null = null;
+    let suppressedClickTimeout: number | null = null;
 
     const handlePointerDown = (event: PointerEvent) => {
       const target = event.target;
       if (
+        bridgedPointerDowns.has(event) ||
         event.button !== 0 ||
         event.pointerType !== "touch" ||
-        !(target instanceof Element) ||
-        target.closest("button") !== null
+        !(target instanceof Element)
       ) {
         return;
       }
@@ -58,20 +64,43 @@ function useSonnerFirstMoveFix({
       ) {
         return;
       }
+      const button = target.closest<HTMLButtonElement>("button");
       swipeStartRef.current = {
-        moved: false,
+        axis: null,
+        button,
+        dragged: false,
         pointerId: event.pointerId,
         toastElement,
         x: event.clientX,
         y: event.clientY,
       };
+      if (target === button) {
+        const PointerEventConstructor = ownerDocument.defaultView?.PointerEvent;
+        if (PointerEventConstructor === undefined) {
+          return;
+        }
+        const bridgedPointerDown = new PointerEventConstructor("pointerdown", {
+          bubbles: true,
+          button: event.button,
+          buttons: event.buttons,
+          cancelable: true,
+          clientX: event.clientX,
+          clientY: event.clientY,
+          composed: true,
+          isPrimary: event.isPrimary,
+          pointerId: event.pointerId,
+          pointerType: event.pointerType,
+          pressure: event.pressure,
+        });
+        bridgedPointerDowns.add(bridgedPointerDown);
+        toastElement.dispatchEvent(bridgedPointerDown);
+      }
     };
 
     const handlePointerMove = (event: PointerEvent) => {
       const start = swipeStartRef.current;
       if (
         start === null ||
-        start.moved ||
         start.pointerId !== event.pointerId ||
         ownerDocument.getSelection()?.toString()
       ) {
@@ -82,39 +111,76 @@ function useSonnerFirstMoveFix({
       if (Math.abs(deltaX) <= 1 && Math.abs(deltaY) <= 1) {
         return;
       }
-      start.moved = true;
-      if (Math.abs(deltaX) > Math.abs(deltaY)) {
+      if (
+        start.button !== null &&
+        Math.max(Math.abs(deltaX), Math.abs(deltaY)) > TOAST_BUTTON_TAP_SLOP
+      ) {
+        start.dragged = true;
+        event.preventDefault();
+      }
+      start.axis ??= Math.abs(deltaX) > Math.abs(deltaY) ? "x" : "y";
+      if (start.axis === "x") {
         const direction = deltaX > 0 ? "right" : "left";
-        if (allowedDirections.has(direction)) {
-          start.toastElement.style.setProperty(
-            "--swipe-amount-x",
-            `${deltaX}px`,
-          );
-        }
+        const amount = allowedDirections.has(direction) ? deltaX : 0;
+        start.toastElement.style.setProperty("--swipe-amount-x", `${amount}px`);
         return;
       }
       const direction = deltaY > 0 ? "bottom" : "top";
-      if (allowedDirections.has(direction)) {
-        start.toastElement.style.setProperty("--swipe-amount-y", `${deltaY}px`);
-      }
+      const amount = allowedDirections.has(direction) ? deltaY : 0;
+      start.toastElement.style.setProperty("--swipe-amount-y", `${amount}px`);
     };
 
     const handlePointerEnd = (event: PointerEvent) => {
-      if (swipeStartRef.current?.pointerId === event.pointerId) {
-        swipeStartRef.current = null;
+      const start = swipeStartRef.current;
+      if (start?.pointerId !== event.pointerId) {
+        return;
       }
+      swipeStartRef.current = null;
+      if (
+        event.type === "pointerup" &&
+        start.dragged &&
+        start.button !== null
+      ) {
+        suppressedClickButton = start.button;
+        if (suppressedClickTimeout !== null) {
+          window.clearTimeout(suppressedClickTimeout);
+        }
+        suppressedClickTimeout = window.setTimeout(() => {
+          suppressedClickButton = null;
+          suppressedClickTimeout = null;
+        }, 0);
+      }
+    };
+
+    const handleClick = (event: MouseEvent) => {
+      const target = event.target;
+      if (
+        suppressedClickButton === null ||
+        !(target instanceof Node) ||
+        !suppressedClickButton.contains(target)
+      ) {
+        return;
+      }
+      suppressedClickButton = null;
+      event.preventDefault();
+      event.stopPropagation();
     };
 
     toasterElement.addEventListener("pointerdown", handlePointerDown);
     ownerDocument.addEventListener("pointermove", handlePointerMove);
     ownerDocument.addEventListener("pointerup", handlePointerEnd);
     ownerDocument.addEventListener("pointercancel", handlePointerEnd);
+    ownerDocument.addEventListener("click", handleClick, true);
     return () => {
       swipeStartRef.current = null;
+      if (suppressedClickTimeout !== null) {
+        window.clearTimeout(suppressedClickTimeout);
+      }
       toasterElement.removeEventListener("pointerdown", handlePointerDown);
       ownerDocument.removeEventListener("pointermove", handlePointerMove);
       ownerDocument.removeEventListener("pointerup", handlePointerEnd);
       ownerDocument.removeEventListener("pointercancel", handlePointerEnd);
+      ownerDocument.removeEventListener("click", handleClick, true);
     };
   }, [enabled, swipeDirections, toasterRef]);
 }
@@ -146,7 +212,7 @@ export function AppToaster({
   const renderedSwipeDirections =
     swipeDirections ??
     (isCompactViewport ? COMPACT_TOAST_SWIPE_DIRECTIONS : undefined);
-  useSonnerFirstMoveFix({
+  useReliableToastSwipes({
     enabled: isCompactViewport,
     swipeDirections: renderedSwipeDirections,
     toasterRef,


### PR DESCRIPTION
## Human comments

## What was wrong

Compact toasts render at `top-center`, while Sonner derives an upward-only swipe direction from that position and processes the first pointer movement before its React-managed axis has updated. The archived-thread toast exposed a second, more important gap: its linked thread title, Undo action, and close control are buttons, and Sonner deliberately does not begin a swipe when the pointer target is a button. That made most of the real "Thread Archived" toast a swipe dead zone even though plain diagnostic toasts felt reliable.

## What changed

- Allow compact toasts to use Sonner's native top, left, and right swipe directions.
- Keep the CSS swipe distance continuous while Sonner's axis state catches up, preserving short Android touch movements without replacing Sonner's threshold, animation, callbacks, or toast identity.
- Bridge touch starts on toast buttons into Sonner's normal swipe handling, then suppress the button click only after movement exceeds tap slop. Normal taps still invoke the thread-title, Undo, and close actions.
- Add regression coverage using the actual archived-thread toast layout, including tap-versus-drag behavior, continuous batched movement, directional dismissal, rejected downward drags, and rapid stacked-toast identity.

There is no server/host-daemon wire change, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged. No CLI, SDK, guide, or user-facing configuration surface changed.

## How you verified

- Physical Android Chrome 152: archived a thread and swiped from the interactive title row; the user confirmed the interaction felt great. Captured movement stayed continuous through `130.8px`, and Sonner reported `direction: right`, `removed: true`, and `swipeOut: true` at pointer-up.
- Physical Android Chrome 152 diagnostic runs: both user-tested runs felt great and completed native swipe-out dismissal.
- Doobie with a 390×844 touch viewport: 10/10 single-move left, right, up, and upward-diagonal flicks dismissed.
- iPhone 16 Pro, iOS 18.4 Simulator, Mobile Safari: left, right, up, and both upward diagonals dismissed.
- `pnpm exec turbo run test --filter=@bb/app --force -- --run src/components/AppToaster.test.tsx` — 8 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/app` — passed.
- `pnpm exec turbo run lint --filter=@bb/app` — passed with 178 existing warnings in unrelated files and 0 errors.
- `pnpm exec oxfmt apps/app/src/components/AppToaster.tsx apps/app/src/components/AppToaster.test.tsx` and `git diff --check` — passed.

> AGENT GENERATED
