### PR TITLE
fix(app): verify inline Markdown paths before linking

### DIFF
--- a/apps/app/src/components/thread/timeline/ConversationMessageContent.tsx
+++ b/apps/app/src/components/thread/timeline/ConversationMessageContent.tsx
@@ -125,6 +125,7 @@ const STREAMING_TAIL_MARKDOWN_CLASS_NAME =
 interface ConversationMessageContentAssistantProps
   extends ConversationMessageContentBaseProps, AssistantMessageRowIdentity {
   role: "assistant";
+  localFileHostId?: string;
   onOpenLink?: ThreadTimelineLinkHandler;
   onAddToChat?: ThreadTimelineAddToChatHandler;
   onFork?: () => void;
@@ -170,6 +171,7 @@ interface UserConversationMessageProps {
 interface AssistantConversationMessageProps extends AssistantMessageRowIdentity {
   addToChatAttachments: readonly PromptDraftAttachment[];
   attachmentItems: ConversationAttachmentItems;
+  localFileHostId?: string;
   pluginActions?: readonly ThreadTimelinePluginMessageAction[];
   onAddToChat?: ThreadTimelineAddToChatHandler;
   onFork?: () => void;
@@ -471,6 +473,7 @@ function AssistantConversationMessage({
   addToChatAttachments,
   attachmentItems,
   id,
+  localFileHostId,
   onAddToChat,
   onFork,
   onSendToMain,
@@ -519,6 +522,11 @@ function AssistantConversationMessage({
         },
         onOpenLink: onOpenLocalFileLink,
       };
+      if (localFileHostId !== undefined) {
+        routing.localFile.inlineCodeFileLinks = {
+          hostId: localFileHostId,
+        };
+      }
       if (workspaceRootPath !== undefined) {
         routing.localFile.relativeLinks = {
           baseDir: workspaceRootPath,
@@ -527,7 +535,13 @@ function AssistantConversationMessage({
       }
     }
     return routing;
-  }, [onOpenLink, onOpenLocalFileLink, threadId, workspaceRootPath]);
+  }, [
+    localFileHostId,
+    onOpenLink,
+    onOpenLocalFileLink,
+    threadId,
+    workspaceRootPath,
+  ]);
 
   const messageDirectiveRegistry = useMessageDirectiveRegistry();
   const openDirectiveWorkspaceFile = useMemo<
@@ -697,6 +711,7 @@ export function ConversationMessageContent(
       addToChatAttachments={addToChatAttachments}
       attachmentItems={attachmentItems}
       id={props.id}
+      localFileHostId={props.localFileHostId}
       pluginActions={props.pluginActions}
       onAddToChat={props.onAddToChat}
       onFork={props.onFork}

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
@@ -155,6 +155,7 @@ export interface ThreadTimelineRowsProps {
   onSelectionAddToChat?: ThreadTimelineAddToChatHandler;
   consumerMessageActions?: readonly ThreadTimelineConsumerMessageAction[];
   includePluginMessageActions?: boolean;
+  localFileHostId?: string;
   onOpenLink?: ThreadTimelineLinkHandler;
   onOpenLocalFileLink?: ThreadTimelineLocalFileLinkHandler;
   onOpenPluginPanel?: ThreadTimelineOpenPluginPanelHandler;
@@ -181,6 +182,7 @@ interface TimelineRendererStaticContextValue {
   onForkMessage: ThreadTimelineForkMessageHandler | undefined;
   onEditMessage: ThreadTimelineEditMessageHandler | undefined;
   inlineMessageEditor: ThreadTimelineInlineMessageEditor | undefined;
+  localFileHostId: string | undefined;
   onMessageAddToChat: ThreadTimelineAddToChatHandler | undefined;
   onSendToMainMessage: ThreadTimelineSendToMainMessageHandler | undefined;
   onSelectionAddToChat: ThreadTimelineAddToChatHandler | undefined;
@@ -908,6 +910,7 @@ const ConversationRowContent = memo(function ConversationRowContent({
   const {
     canSpawnChild,
     inlineMessageEditor,
+    localFileHostId,
     onEditMessage,
     onForkMessage,
     onMessageAddToChat,
@@ -1050,6 +1053,7 @@ const ConversationRowContent = memo(function ConversationRowContent({
     <ConversationMessageContent
       attachments={row.attachments}
       id={row.id}
+      localFileHostId={localFileHostId}
       onAddToChat={onMessageAddToChat}
       onFork={onFork}
       onSendToMain={onSendToMain}
@@ -1139,6 +1143,7 @@ function TimelineExpandableBody({
   showAssistantMessageActions,
 }: TimelineExpandableBodyProps) {
   const {
+    localFileHostId,
     onOpenLink,
     onOpenLocalFileLink,
     projectId,
@@ -1212,6 +1217,7 @@ function TimelineExpandableBody({
                 <ConversationMessageContent
                   attachments={null}
                   id={row.id}
+                  localFileHostId={localFileHostId}
                   onOpenLink={onOpenLink}
                   onOpenLocalFileLink={onOpenLocalFileLink}
                   projectId={projectId}
@@ -2134,6 +2140,7 @@ function ThreadTimelineRowsForTimelineView(props: ThreadTimelineRowsProps) {
       onForkMessage: props.onForkMessage,
       onEditMessage: props.onEditMessage,
       inlineMessageEditor: props.inlineMessageEditor,
+      localFileHostId: props.localFileHostId,
       onMessageAddToChat: props.onMessageAddToChat,
       onSendToMainMessage: props.onSendToMainMessage,
       onSelectionAddToChat: selectionAddToChatHandler,
@@ -2164,6 +2171,7 @@ function ThreadTimelineRowsForTimelineView(props: ThreadTimelineRowsProps) {
       props.onForkMessage,
       props.onEditMessage,
       props.inlineMessageEditor,
+      props.localFileHostId,
       props.onMessageAddToChat,
       props.onSendToMainMessage,
       selectionAddToChatHandler,

--- a/apps/app/src/components/thread/timeline/ThreadTimelineSurface.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineSurface.tsx
@@ -55,6 +55,7 @@ export interface ThreadTimelineSurfaceProps {
   onSelectionAddToChat?: ThreadTimelineAddToChatHandler;
   consumerMessageActions?: readonly ThreadTimelineConsumerMessageAction[];
   includePluginMessageActions?: boolean;
+  localFileHostId?: string;
   onLoadOlderRows?: () => Promise<void> | void;
   onOpenLink?: ThreadTimelineLinkHandler;
   onOpenLocalFileLink?: ThreadTimelineLocalFileLinkHandler;
@@ -156,6 +157,7 @@ export function ThreadTimelineSurface({
   onSelectionAddToChat,
   consumerMessageActions,
   includePluginMessageActions,
+  localFileHostId,
   onLoadOlderRows,
   onOpenLink,
   onOpenLocalFileLink,
@@ -231,6 +233,7 @@ export function ThreadTimelineSurface({
           onSelectionAddToChat={onSelectionAddToChat}
           consumerMessageActions={consumerMessageActions}
           includePluginMessageActions={includePluginMessageActions}
+          localFileHostId={localFileHostId}
           onOpenLink={onOpenLink}
           onOpenLocalFileLink={onOpenLocalFileLink}
           onOpenPluginPanel={onOpenPluginPanel}

--- a/apps/app/src/components/ui/markdown-link-routing.ts
+++ b/apps/app/src/components/ui/markdown-link-routing.ts
@@ -43,6 +43,9 @@ export const MarkdownLocalFileContextMenuContext =
 
 export interface MarkdownLocalFileLinkRouting {
   absoluteLinks: MarkdownAbsoluteLocalFileLinkRouting;
+  inlineCodeFileLinks?: {
+    hostId: string;
+  };
   onOpenLink: MarkdownPreviewLocalFileLinkHandler;
   relativeLinks?: MarkdownRelativeLocalFileLinkRouting;
 }

--- a/apps/app/src/components/ui/markdown-preview.test.tsx
+++ b/apps/app/src/components/ui/markdown-preview.test.tsx
@@ -8,12 +8,24 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { sdk } from "@/lib/sdk";
 import { MarkdownPreview } from "./markdown-preview";
 import {
   MarkdownLocalFileContextMenuContext,
   type MarkdownLinkRouting,
 } from "./markdown-link-routing";
+
+vi.mock("@/lib/sdk", () => ({
+  sdk: {
+    hosts: {
+      pathsExist: vi.fn(),
+    },
+  },
+}));
+
+const pathsExist = vi.mocked(sdk.hosts.pathsExist);
 
 const workspaceLinkRouting = {
   localFile: {
@@ -270,23 +282,54 @@ describe("MarkdownPreview", () => {
     expect(container.textContent).toContain("<script>alert(1)</script>");
   });
 
-  it("renders inline-code Markdown file paths as local file links", () => {
+  it("links only inline-code Markdown file paths that exist", async () => {
+    pathsExist.mockImplementation(async ({ paths }) => ({
+      existence: Object.fromEntries(
+        paths.map((path) => [path, path === "/workspace/README.md"]),
+      ),
+    }));
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
     render(
-      <MarkdownPreview
-        content="Read `README.md`, `docs/guide.markdown:4`, and `src/app.ts`."
-        linkRouting={workspaceLinkRouting}
-      />,
+      <QueryClientProvider client={queryClient}>
+        <MarkdownPreview
+          content="Read `README.md`, `docs/guide.markdown:4`, and `src/app.ts`."
+          linkRouting={{
+            localFile: {
+              ...workspaceLinkRouting.localFile,
+              inlineCodeFileLinks: { hostId: "host_1" },
+            },
+          }}
+        />
+      </QueryClientProvider>,
     );
 
+    expect(screen.getByText("README.md").tagName).toBe("CODE");
+    await waitFor(() => {
+      expect(
+        screen.getByRole("link", { name: "README.md" }).getAttribute("href"),
+      ).toBe("file:///workspace/README.md");
+    });
     expect(
-      screen.getByRole("link", { name: "README.md" }).getAttribute("href"),
-    ).toBe("file:///workspace/README.md");
-    expect(
-      screen
-        .getByRole("link", { name: "docs/guide.markdown:4" })
-        .getAttribute("href"),
-    ).toBe("file:///workspace/docs/guide.markdown#L4");
+      screen.queryByRole("link", { name: "docs/guide.markdown:4" }),
+    ).toBeNull();
+    expect(screen.getByText("docs/guide.markdown:4").tagName).toBe("CODE");
     expect(screen.getByText("src/app.ts").tagName).toBe("CODE");
+    expect(
+      pathsExist.mock.calls.map(([request]) => ({
+        hostId: request.hostId,
+        paths: request.paths,
+      })),
+    ).toEqual(
+      expect.arrayContaining([
+        { hostId: "host_1", paths: ["/workspace/README.md"] },
+        {
+          hostId: "host_1",
+          paths: ["/workspace/docs/guide.markdown"],
+        },
+      ]),
+    );
   });
 
   it("shows a context menu on local file links when the context provides items", () => {

--- a/apps/app/src/components/ui/markdown-preview.tsx
+++ b/apps/app/src/components/ui/markdown-preview.tsx
@@ -88,6 +88,7 @@ import {
   type MountedMessageDirective,
 } from "./markdown-message-directives.js";
 import { normalizePromptBlockquoteBoundaries } from "./markdown-prompt-blockquote-boundaries.js";
+import { useHostPathExistence } from "@/hooks/queries/host-path-queries";
 import { MarkdownMermaidDiagram } from "./markdown-mermaid-diagram.js";
 import type { PromptTextMention } from "@bb/domain";
 import type { PromptMentionLinkResolver } from "@/components/promptbox/editor/prompt-mention-link";
@@ -239,6 +240,18 @@ interface MarkdownCodeRendererProps extends MarkdownCodeProps {
   preferredTheme: Theme;
   rewriteLocalhostLinks: boolean;
 }
+interface MarkdownInlineCodeFileLinkCandidate {
+  href: string;
+  path: string;
+}
+interface MarkdownInlineCodeFileLinkProps {
+  candidate: MarkdownInlineCodeFileLinkCandidate;
+  code: ReactElement;
+  codeText: string;
+  hostId: string;
+  linkRouting: MarkdownLinkRouting;
+  rewriteLocalhostLinks: boolean;
+}
 type MarkdownHeadingProps = ComponentPropsWithoutRef<"h1"> & ExtraProps;
 type MarkdownHrProps = ComponentPropsWithoutRef<"hr"> & ExtraProps;
 type MarkdownImageProps = ComponentPropsWithoutRef<"img"> & ExtraProps;
@@ -316,6 +329,8 @@ function areMarkdownLocalFileLinkRoutingsEqual({
   if (previous === undefined || next === undefined) return false;
   return (
     previous.onOpenLink === next.onOpenLink &&
+    previous.inlineCodeFileLinks?.hostId ===
+      next.inlineCodeFileLinks?.hostId &&
     areMarkdownAbsoluteLocalFileLinkRoutingsEqual({
       next: next.absoluteLinks,
       previous: previous.absoluteLinks,
@@ -524,13 +539,13 @@ function hasMarkdownFileExtension(path: string): boolean {
   return /\.(?:md|markdown)$/iu.test(path);
 }
 
-function resolveInlineCodeMarkdownFileHref({
+function resolveInlineCodeMarkdownFileLink({
   codeText,
   localFileRouting,
 }: {
   codeText: string;
   localFileRouting: MarkdownLocalFileLinkRouting | undefined;
-}): string | null {
+}): MarkdownInlineCodeFileLinkCandidate | null {
   if (
     localFileRouting === undefined ||
     codeText.length === 0 ||
@@ -546,7 +561,9 @@ function resolveInlineCodeMarkdownFileHref({
     href: codeText,
   });
   if (absoluteLink !== null) {
-    return hasMarkdownFileExtension(absoluteLink.path) ? codeText : null;
+    return hasMarkdownFileExtension(absoluteLink.path)
+      ? { href: codeText, path: absoluteLink.path }
+      : null;
   }
 
   if (localFileRouting.relativeLinks === undefined) {
@@ -566,7 +583,7 @@ function resolveInlineCodeMarkdownFileHref({
     href: resolvedHref,
   });
   return resolvedLink !== null && hasMarkdownFileExtension(resolvedLink.path)
-    ? resolvedHref
+    ? { href: resolvedHref, path: resolvedLink.path }
     : null;
 }
 
@@ -757,29 +774,60 @@ function MarkdownCode({
     );
   }
 
-  const markdownFileHref = resolveInlineCodeMarkdownFileHref({
-    codeText,
-    localFileRouting: linkRouting?.localFile,
-  });
-  if (markdownFileHref !== null) {
-    return (
-      <MarkdownAnchor
-        href={markdownFileHref}
-        linkRouting={linkRouting}
-        rewriteLocalhostLinks={rewriteLocalhostLinks}
-      >
-        {codeText}
-      </MarkdownAnchor>
-    );
-  }
-
-  return (
+  const code = (
     <code
       className="rounded bg-muted/70 px-1.5 py-0.5 font-mono text-xs"
       {...props}
     >
       {children}
     </code>
+  );
+  const inlineCodeFileLink = resolveInlineCodeMarkdownFileLink({
+    codeText,
+    localFileRouting: linkRouting?.localFile,
+  });
+  const hostId = linkRouting?.localFile?.inlineCodeFileLinks?.hostId;
+  if (
+    inlineCodeFileLink === null ||
+    hostId === undefined ||
+    linkRouting === undefined
+  ) {
+    return code;
+  }
+
+  return (
+    <MarkdownInlineCodeFileLink
+      candidate={inlineCodeFileLink}
+      code={code}
+      codeText={codeText}
+      hostId={hostId}
+      linkRouting={linkRouting}
+      rewriteLocalhostLinks={rewriteLocalhostLinks}
+    />
+  );
+}
+
+function MarkdownInlineCodeFileLink({
+  candidate,
+  code,
+  codeText,
+  hostId,
+  linkRouting,
+  rewriteLocalhostLinks,
+}: MarkdownInlineCodeFileLinkProps) {
+  const pathExistence = useHostPathExistence(hostId, [candidate.path]);
+  if (pathExistence[candidate.path] !== true) {
+    return code;
+  }
+
+  return (
+    <MarkdownAnchor
+      href={candidate.href}
+      linkRouting={linkRouting}
+      rewriteLocalhostLinks={rewriteLocalhostLinks}
+    >
+      {codeText}
+    </MarkdownAnchor>
   );
 }
 

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -374,6 +374,7 @@ type ThreadDetailViewProps =
 
 interface BuildMarkdownPreviewLinkRoutingArgs {
   baseDir: string | undefined;
+  localFileHostId: string | undefined;
   onOpenLink: ThreadTimelineLinkHandler;
   onOpenLocalFileLink: ThreadTimelineLocalFileLinkHandler;
   rootPath: string | null | undefined;
@@ -409,6 +410,7 @@ function buildHostConnectionNotice(
 
 function buildMarkdownPreviewLinkRouting({
   baseDir,
+  localFileHostId,
   onOpenLink,
   onOpenLocalFileLink,
   rootPath,
@@ -426,6 +428,11 @@ function buildMarkdownPreviewLinkRouting({
     },
     onOpenLink: onOpenLocalFileLink,
   };
+  if (localFileHostId !== undefined) {
+    localFileRouting.inlineCodeFileLinks = {
+      hostId: localFileHostId,
+    };
+  }
   if (baseDir !== undefined) {
     localFileRouting.relativeLinks = {
       baseDir,
@@ -2608,6 +2615,7 @@ function ThreadDetailViewInternal(props: ThreadRoutePathArgs) {
               baseDir: copyPath
                 ? getAbsoluteDirname({ path: copyPath })
                 : undefined,
+              localFileHostId: environment?.hostId,
               onOpenLink: handleOpenTimelineLink,
               onOpenLocalFileLink: handleOpenTimelineLocalFileLink,
               rootPath: workspacePreviewRootPath,
@@ -2631,6 +2639,7 @@ function ThreadDetailViewInternal(props: ThreadRoutePathArgs) {
             lineRange={tab.lineRange}
             markdownLinkRouting={buildMarkdownPreviewLinkRouting({
               baseDir,
+              localFileHostId: environment?.hostId,
               onOpenLink: handleOpenTimelineLink,
               onOpenLocalFileLink: handleOpenTimelineLocalFileLink,
               rootPath: resolveHostFilePreviewLinkRootPath({
@@ -2660,6 +2669,7 @@ function ThreadDetailViewInternal(props: ThreadRoutePathArgs) {
               baseDir: copyPath
                 ? getAbsoluteDirname({ path: copyPath })
                 : undefined,
+              localFileHostId: environment?.hostId,
               onOpenLink: handleOpenTimelineLink,
               onOpenLocalFileLink: handleOpenTimelineLocalFileLink,
               rootPath: threadStorageRootPath,
@@ -2923,6 +2933,7 @@ function ThreadDetailViewInternal(props: ThreadRoutePathArgs) {
               onMessageAddToChat: handleSelectionAddToChat,
               onSendToMainMessage: handleSendToMainMessage,
               onSelectionAddToChat: handleSelectionAddToChat,
+              localFileHostId: environment?.hostId,
               onLoadOlderRows: loadOlderTimelineRows,
               onOpenLink: handleOpenTimelineLink,
               onOpenLocalFileLink: handleOpenTimelineLocalFileLink,


### PR DESCRIPTION
## Human comments

## What was wrong

Inline code spans that looked like Markdown file paths (for example `docs/notes.md`) were turned into local-file links purely from their shape. Clicking one for a file that does not exist on the host opened an empty file tab. The renderer had no way to check the path because it did not know which host the thread ran on.

## What changed

- `markdown-link-routing.ts`: `MarkdownLocalFileLinkRouting` gains an optional `inlineCodeFileLinks.hostId` that says which host to check paths against.
- `markdown-preview.tsx`: `resolveInlineCodeMarkdownFileHref` becomes `resolveInlineCodeMarkdownFileLink` and returns the resolved absolute path alongside the href. A new `MarkdownInlineCodeFileLink` component calls `useHostPathExistence` for that path and only renders the anchor when the host reports the file exists. Without a host id the span stays plain code.
- Thread timeline (`ThreadTimelineSurface` → `ThreadTimelineRows` → `ConversationMessageContent`) and `ThreadDetailView` thread the environment's `hostId` into the routing so assistant messages and file previews get the existence check.

No wire changes.

## How you verified

- Added `links only inline-code Markdown file paths that exist` in `apps/app/src/components/ui/markdown-preview.test.tsx`. It renders two inline-code paths, one present and one missing on the host, and asserts only the present one becomes a link. Fails before, passes after.
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run test --filter=@bb/app`

> AGENT GENERATED