### PR TITLE
Contain linked project skill roots inside the repository

### DIFF
--- a/apps/host-daemon/src/command-discovery.test.ts
+++ b/apps/host-daemon/src/command-discovery.test.ts
@@ -498,6 +498,56 @@ describe("discoverProviderCommands over declared roots", () => {
     ]);
   });
 
+  it("rejects a project skill root linked outside the workspace", async () => {
+    const fixture = await makeWorkspaceFixture();
+    const outsideRoot = path.join(tempRoot, "outside-skill-root");
+    const linkedRoot = path.join(fixture.cwd, ".claude", "skills");
+    await writeFileEnsuringDir(
+      path.join(outsideRoot, "leaked", "SKILL.md"),
+      skillFile("leaked"),
+    );
+    await mkdir(path.dirname(linkedRoot), { recursive: true });
+    await symlink(outsideRoot, linkedRoot, "dir");
+
+    const commands = await discover(
+      fixture,
+      fixture.cwd,
+      nativeRoots({ skills: { project: [declared(".claude/skills")] } }),
+    );
+
+    expect(commands).toEqual([]);
+  });
+
+  it("discovers skills through a project skill root symlink inside the workspace", async () => {
+    const fixture = await makeWorkspaceFixture();
+    await writeFileEnsuringDir(
+      path.join(fixture.cwd, ".agents", "skills", "in-repo", "SKILL.md"),
+      skillFile("in-repo", "Inside the repository"),
+    );
+    await mkdir(path.join(fixture.cwd, ".claude"), { recursive: true });
+    await symlink(
+      path.join("..", ".agents", "skills"),
+      path.join(fixture.cwd, ".claude", "skills"),
+      "dir",
+    );
+
+    const commands = await discover(
+      fixture,
+      fixture.cwd,
+      nativeRoots({ skills: { project: [declared(".claude/skills")] } }),
+    );
+
+    expect(commands).toEqual([
+      {
+        name: "in-repo",
+        source: "skill",
+        origin: "project",
+        description: "Inside the repository",
+        argumentHint: null,
+      },
+    ]);
+  });
+
   it("does not follow project-origin symlinked skill directories or skill files", async () => {
     const fixture = await makeWorkspaceFixture();
     const skillsRoot = path.join(fixture.cwd, ".agent", "skills");

--- a/apps/host-daemon/src/command-discovery.ts
+++ b/apps/host-daemon/src/command-discovery.ts
@@ -250,6 +250,9 @@ async function hasManifestMarker(
 async function scanSkillRootFiles(
   root: CommandScanDirectoryRoot,
 ): Promise<SkillFileMatch[]> {
+  if ((await resolveBoundedRootPath(root)) === null) {
+    return [];
+  }
   const entries = await readDirEntries(root.rootPath);
   if (entries === null) {
     return [];
@@ -320,7 +323,7 @@ export function isPathWithinDirectory(
   );
 }
 
-async function resolveRecursiveRootPath(
+async function resolveBoundedRootPath(
   root: CommandScanDirectoryRoot,
 ): Promise<string | null> {
   const resolvedRoot = await fs.realpath(root.rootPath).catch(() => null);
@@ -343,7 +346,7 @@ async function scanRecursiveSkillRootFiles(
   root: CommandScanDirectoryRoot,
   budget: ScanBudget,
 ): Promise<SkillFileMatch[]> {
-  const rootPath = await resolveRecursiveRootPath(root);
+  const rootPath = await resolveBoundedRootPath(root);
   if (rootPath === null) {
     return [];
   }


### PR DESCRIPTION
## Human comments

## What was wrong

`scanSkillRootFiles` opened a non-recursive project skill root before
resolving it against the workspace boundary, so a root that is itself a
symlink was scanned wherever it pointed. A checked-in `.claude/skills`
link to a directory outside the repository put every skill under it into
the project's skill and command lists, with `origin: "project"`. The
recursive shape already resolved the same plumbed `boundaryPath` before
walking, and `docs/provider-plugin-api.md` already states the rule for
both shapes: a symlink out of a project root is followed within the
workspace for a plain root and within the repository root for a root
that walks ancestors or that the plugin resolved.

Issue: #2769. Investigation report: https://get-bb.github.io/reports/issues/2769.html

## What changed

`resolveRecursiveRootPath` becomes `resolveBoundedRootPath` and the flat
skill root scan consults it, so both shapes enforce one containment rule
against the same `boundaryPath`. A root link that stays inside the
repository still resolves and is still scanned, and user-origin roots,
which carry no boundary, are unaffected.

No field or message on the server/host-daemon wire changed, so
`HOST_DAEMON_PROTOCOL_VERSION` stays at 178.

## How you verified

- Added two `command-discovery` regressions: a project `.claude/skills`
  root symlinked outside the workspace discovers nothing, and one
  symlinked to `.agents/skills` inside the workspace still discovers its
  skill. The first fails on the parent commit
  (`expected [ { name: 'leaked', …(4) } ] to deeply equal []`) and
  passes here; the second passes on both.
- `pnpm exec turbo run test --filter=@bb/host-daemon --force`: 46 files,
  574 tests passed (1 failed before the fix).
- `pnpm exec turbo run typecheck --filter=@bb/host-daemon`: passed.
- `BB_TEST_TIMEOUT_SCALE=3 pnpm exec turbo run test
  --filter=@bb/integration-tests --force --env-mode=loose --
  native-roots-golden`: 22 provider golden fixtures passed unchanged,
  including the cursor symlink-boundary and grok symlink variants.
- Drove `listHostCommands` with the shipping claude-code declaration
  (`.claude/skills`, `ancestors: true`) over the issue's fixture: the
  escaping root reported `["leaked"]` before and `[]` after, while the
  in-repository link reported `["in-repo"]` in both.

Fixes #2769

> AGENT GENERATED
