### PR TITLE
Match the submit-a-plugin entry example to the marketplace schema

### DIFF
--- a/apps/server/src/services/skills/builtin-skills/submit-a-plugin/references/marketplace-entry.md
+++ b/apps/server/src/services/skills/builtin-skills/submit-a-plugin/references/marketplace-entry.md
@@ -9,14 +9,16 @@ Create entries/<plugin-id>.json. The filename, entry ID, and plugin manifest ID
 must match. Do not add fields that the schema does not define.
 
 The current required fields are id, displayName, description, icon, author, and
-source. Use tags and engines when they add useful search or compatibility data.
+source. Use tags when they add useful search data.
 
 Use the product name for displayName. Write one concrete description sentence
 that states the feature and user value. Do not make subjective marketing claims.
 
 Use no more than ten specific lowercase tags. Use hyphens inside multiword tags.
-Copy honest engine ranges from the plugin manifest. An entry can narrow those
-ranges but cannot widen them.
+
+An entry declares no compatibility range. BB reads engines.bb and
+engines.bbPluginSdk from the plugin's own package.json and refuses the install
+there. Keep those ranges honest in the plugin manifest instead.
 
 Set author.github to the account that opens the pull request. Get it with:
 
@@ -39,10 +41,6 @@ Use this shape only as a guide:
     "name": "Acme",
     "github": "acme",
     "url": "https://acme.example"
-  },
-  "engines": {
-    "bb": ">=0.40.0",
-    "bbPluginSdk": ">=0.5.0"
   },
   "source": {
     "git": {

--- a/apps/server/src/services/skills/builtin-skills/submit-a-plugin/references/pull-request.md
+++ b/apps/server/src/services/skills/builtin-skills/submit-a-plugin/references/pull-request.md
@@ -60,7 +60,6 @@ Confirm:
 - The entry ID matches the filename and plugin manifest.
 - The public source contains the selected release and reviewed code.
 - The source subdirectory is correct.
-- Entry engine ranges do not exceed manifest ranges.
 - The author account matches the pull request account.
 - The description states observed user value.
 - The icon meets size, format, location, and reference rules.

--- a/apps/server/test/skills/submit-a-plugin.test.ts
+++ b/apps/server/test/skills/submit-a-plugin.test.ts
@@ -4,7 +4,9 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { Ajv2020 } from "ajv/dist/2020.js";
 import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
 import { derivePluginId } from "@bb/domain";
 
 const skillRoot = fileURLToPath(
@@ -24,6 +26,18 @@ const skillReferencePaths = [
   "plugin-release.md",
   "pull-request.md",
 ].map((name) => path.join(skillRoot, "references", name));
+const marketplaceEntryReferencePath = path.join(
+  skillRoot,
+  "references",
+  "marketplace-entry.md",
+);
+const publishedMarketplaceSchemaPath = fileURLToPath(
+  new URL(
+    "../../../web/public/schemas/marketplace-v2.schema.json",
+    import.meta.url,
+  ),
+);
+const publishedSchemaSchema = z.record(z.string(), z.unknown());
 const tempDirs: string[] = [];
 
 async function readSkillTree(): Promise<string> {
@@ -97,6 +111,33 @@ describe("submit-a-plugin skill", () => {
     expect(skill).toContain("npm pack --dry-run --ignore-scripts");
     expect(skill).toContain("npm publish --ignore-scripts");
     expect(skill).not.toContain("PLUGIN_DISPLAY_NAME");
+  });
+
+  it("keeps the worked entry valid under the published marketplace schema", async () => {
+    const markdown = await readFile(marketplaceEntryReferencePath, "utf8");
+    const entries = [...markdown.matchAll(/```json\n([\s\S]*?)```/gu)]
+      .map((match) => match[1])
+      .filter((block) => block.includes('"id":'))
+      .map((block): unknown => JSON.parse(block));
+    expect(entries).toHaveLength(1);
+
+    const validate = new Ajv2020({
+      allErrors: true,
+      strict: false,
+      validateFormats: false,
+    }).compile(
+      publishedSchemaSchema.parse(
+        JSON.parse(await readFile(publishedMarketplaceSchemaPath, "utf8")),
+      ),
+    );
+    validate({
+      schemaVersion: 2,
+      name: "bb-community",
+      displayName: "BB Community",
+      plugins: entries,
+    });
+
+    expect(validate.errors ?? []).toEqual([]);
   });
 
   it("provides a local submission path without gh", async () => {


### PR DESCRIPTION
## Human comments

## What was wrong

The `submit-a-plugin` skill's worked marketplace entry still carried an
`engines` object. The published entry contract sets
`additionalProperties: false` and never defined `engines`: a listing
declares no compatibility, and bb reads `engines.bb` and
`engines.bbPluginSdk` from the plugin's own `package.json` instead, as
`docs/plugin-marketplace-plan.md` describes. Anyone who copied the
example produced an entry that `npm run build` and `npm run check`
reject in get-bb/marketplace. Nothing guarded the example against the
schema, so the field survived the schema change.

Issue: #2508. Investigation report: https://get-bb.github.io/reports/issues/2508.html

## What changed

- `references/marketplace-entry.md`: drops `engines` from the worked
  entry, and replaces the "copy honest engine ranges" prose with the
  actual rule, that compatibility lives in the plugin manifest.
- `references/pull-request.md`: drops the "Entry engine ranges do not
  exceed manifest ranges" review item, which checked a field an entry
  cannot have.
- `test/skills/submit-a-plugin.test.ts`: validates the worked entry
  against `apps/web/public/schemas/marketplace-v2.schema.json`, the
  document get-bb/marketplace compiles each entry file against.

The remaining example fields (`id`, `displayName`, `description`,
`icon`, `tags`, `author`, `source`) already match the schema.

## How you verified

- `pnpm exec turbo run test --filter=@bb/server -- test/skills/submit-a-plugin.test.ts`
  passes. Re-adding `engines` to the example fails the new test with
  `must NOT have additional properties`.
- `pnpm exec turbo run typecheck --filter=@bb/server` passes.
- Validated the corrected example against `schema/marketplace-v2.schema.json`
  fetched from get-bb/marketplace@main; that file is byte-identical to the
  copy this repo publishes.

Fixes #2508

> AGENT GENERATED
