### PR TITLE
Fix safe project skill alias discovery

### DIFF
--- a/apps/host-daemon/src/command-discovery.test.ts
+++ b/apps/host-daemon/src/command-discovery.test.ts
@@ -498,7 +498,7 @@ describe("discoverProviderCommands over declared roots", () => {
     ]);
   });
 
-  it("does not follow project-origin symlinked skill directories or skill files", async () => {
+  it("rejects project-origin skill directory and file links outside the workspace", async () => {
     const fixture = await makeWorkspaceFixture();
     const skillsRoot = path.join(fixture.cwd, ".agent", "skills");
     await mkdir(skillsRoot, { recursive: true });
@@ -1087,6 +1087,7 @@ describe("resolveDeclaredScanRoots", () => {
         skillIdentitySeed: `${PROVIDER_ID}:provider-user:${skillDirectory}`,
       },
       {
+        boundaryPath: fixture.cwd,
         filePath: skillFilePath,
         fallbackName: "notes",
         shape: "skill-file",

--- a/apps/host-daemon/src/command-discovery.ts
+++ b/apps/host-daemon/src/command-discovery.ts
@@ -19,6 +19,8 @@ const MAX_SCAN_DEPTH = 24;
 const MAX_SCAN_ENTRY_COUNT = 1_000;
 
 interface CommandScanRootBase {
+  allowExternalProjectRoot?: boolean;
+  boundaryPath?: string;
   namePrefix: string;
   skipIfManifest?: string;
   source: HostCommandSource;
@@ -27,7 +29,6 @@ interface CommandScanRootBase {
 }
 
 interface CommandScanDirectoryRoot extends CommandScanRootBase {
-  boundaryPath?: string;
   rootPath: string;
   shape: "skill" | "skill-recursive" | "skill-directory" | "command";
 }
@@ -63,9 +64,15 @@ interface ScanBudget {
 }
 
 interface SkillDirectoryCheckArgs {
+  boundary: SkillPathBoundary;
   entry: Dirent;
   entryPath: string;
-  root: CommandScanDirectoryRoot;
+}
+
+interface SkillPathBoundary {
+  canonicalPath: string | null;
+  followLinks: boolean;
+  requirePlainRoot: boolean;
 }
 
 interface WalkMarkdownTreeArgs {
@@ -161,41 +168,103 @@ async function parseFrontmatter(filePath: string): Promise<ParsedFrontmatter> {
   };
 }
 
-function canFollowSkillSymlink(root: CommandScanRoot): boolean {
-  return root.origin === "user" && root.source === "skill";
+async function resolveSkillPathBoundary(
+  root: CommandScanRoot,
+): Promise<SkillPathBoundary | null> {
+  if ("rootKind" in root && root.rootKind === "bb-project") {
+    return {
+      canonicalPath: null,
+      followLinks: false,
+      requirePlainRoot: false,
+    };
+  }
+  if (root.origin === "user") {
+    return {
+      canonicalPath: null,
+      followLinks: true,
+      requirePlainRoot: false,
+    };
+  }
+  if (root.boundaryPath === undefined) {
+    return null;
+  }
+  const canonicalPath = await fs.realpath(root.boundaryPath).catch(() => null);
+  if (canonicalPath === null) {
+    return null;
+  }
+  const rootPath = "rootPath" in root ? root.rootPath : root.filePath;
+  if (!isPathWithinDirectory(root.boundaryPath, rootPath)) {
+    return root.allowExternalProjectRoot === true
+      ? { canonicalPath: null, followLinks: false, requirePlainRoot: true }
+      : null;
+  }
+  return { canonicalPath, followLinks: true, requirePlainRoot: false };
+}
+
+async function resolveSkillPath(
+  boundary: SkillPathBoundary,
+  candidatePath: string,
+): Promise<string | null> {
+  const resolvedPath = await fs.realpath(candidatePath).catch(() => null);
+  if (resolvedPath === null) {
+    return null;
+  }
+  return boundary.canonicalPath === null ||
+    isPathWithinDirectory(boundary.canonicalPath, resolvedPath)
+    ? resolvedPath
+    : null;
+}
+
+async function resolveSkillRootPath(
+  boundary: SkillPathBoundary,
+  candidatePath: string,
+): Promise<string | null> {
+  if (boundary.requirePlainRoot) {
+    const stat = await fs.lstat(candidatePath).catch(() => null);
+    if (stat === null || stat.isSymbolicLink()) {
+      return null;
+    }
+  }
+  return resolveSkillPath(boundary, candidatePath);
 }
 
 async function isSkillDirectory(
   args: SkillDirectoryCheckArgs,
-): Promise<boolean> {
-  if (args.entry.isDirectory()) {
-    return true;
+): Promise<string | null> {
+  if (!args.entry.isDirectory() && !args.entry.isSymbolicLink()) {
+    return null;
   }
-  if (!args.entry.isSymbolicLink() || !canFollowSkillSymlink(args.root)) {
-    return false;
+  if (args.entry.isSymbolicLink() && !args.boundary.followLinks) {
+    return null;
   }
-  try {
-    const stat = await fs.stat(args.entryPath);
-    return stat.isDirectory();
-  } catch {
-    return false;
-  }
+  const resolvedPath = await resolveSkillPath(args.boundary, args.entryPath);
+  const stat =
+    resolvedPath === null
+      ? null
+      : await fs.stat(resolvedPath).catch(() => null);
+  return stat?.isDirectory() === true ? resolvedPath : null;
 }
 
 async function statSkillFile(
   filePath: string,
-  root: CommandScanRoot,
-): Promise<{ linked: boolean } | null> {
+  boundary: SkillPathBoundary,
+): Promise<{ linked: boolean; resolvedPath: string } | null> {
   try {
     const stat = await fs.lstat(filePath);
-    if (stat.isFile()) {
-      return { linked: false };
-    }
-    if (!stat.isSymbolicLink() || !canFollowSkillSymlink(root)) {
+    if (!stat.isFile() && !stat.isSymbolicLink()) {
       return null;
     }
-    const targetStat = await fs.stat(filePath);
-    return targetStat.isFile() ? { linked: true } : null;
+    if (stat.isSymbolicLink() && !boundary.followLinks) {
+      return null;
+    }
+    const resolvedPath = await resolveSkillPath(boundary, filePath);
+    if (resolvedPath === null) {
+      return null;
+    }
+    const targetStat = await fs.stat(resolvedPath);
+    return targetStat.isFile()
+      ? { linked: stat.isSymbolicLink(), resolvedPath }
+      : null;
   } catch {
     return null;
   }
@@ -249,29 +318,39 @@ async function hasManifestMarker(
 
 async function scanSkillRootFiles(
   root: CommandScanDirectoryRoot,
+  boundary: SkillPathBoundary,
 ): Promise<SkillFileMatch[]> {
-  const entries = await readDirEntries(root.rootPath);
+  const resolvedRootPath = await resolveSkillRootPath(boundary, root.rootPath);
+  if (resolvedRootPath === null) {
+    return [];
+  }
+  const entries = await readDirEntries(resolvedRootPath);
   if (entries === null) {
     return [];
   }
   const rootLinked = await isSymbolicLinkPath(root.rootPath);
   const matches: SkillFileMatch[] = [];
   for (const entry of entries) {
-    const skillDirPath = path.join(root.rootPath, entry.name);
-    if (!(await isSkillDirectory({ entry, entryPath: skillDirPath, root }))) {
+    const skillDirPath = path.join(resolvedRootPath, entry.name);
+    const resolvedSkillDirPath = await isSkillDirectory({
+      boundary,
+      entry,
+      entryPath: skillDirPath,
+    });
+    if (resolvedSkillDirPath === null) {
       continue;
     }
-    if (await hasManifestMarker(root, skillDirPath)) {
+    if (await hasManifestMarker(root, resolvedSkillDirPath)) {
       continue;
     }
-    const skillFilePath = path.join(skillDirPath, SKILL_FILE_NAME);
-    const skillFile = await statSkillFile(skillFilePath, root);
+    const skillFilePath = path.join(resolvedSkillDirPath, SKILL_FILE_NAME);
+    const skillFile = await statSkillFile(skillFilePath, boundary);
     if (skillFile === null) {
       continue;
     }
     matches.push({
-      filePath: skillFilePath,
-      frontmatter: await parseFrontmatter(skillFilePath),
+      filePath: path.join(root.rootPath, entry.name, SKILL_FILE_NAME),
+      frontmatter: await parseFrontmatter(skillFile.resolvedPath),
       linked: rootLinked || entry.isSymbolicLink() || skillFile.linked,
       name: entry.name,
     });
@@ -320,30 +399,12 @@ export function isPathWithinDirectory(
   );
 }
 
-async function resolveRecursiveRootPath(
-  root: CommandScanDirectoryRoot,
-): Promise<string | null> {
-  const resolvedRoot = await fs.realpath(root.rootPath).catch(() => null);
-  if (resolvedRoot === null) {
-    return null;
-  }
-  if (root.origin !== "project" || root.boundaryPath === undefined) {
-    return resolvedRoot;
-  }
-  const resolvedBoundary = await fs
-    .realpath(root.boundaryPath)
-    .catch(() => null);
-  return resolvedBoundary !== null &&
-    isPathWithinDirectory(resolvedBoundary, resolvedRoot)
-    ? resolvedRoot
-    : null;
-}
-
 async function scanRecursiveSkillRootFiles(
   root: CommandScanDirectoryRoot,
   budget: ScanBudget,
+  boundary: SkillPathBoundary,
 ): Promise<SkillFileMatch[]> {
-  const rootPath = await resolveRecursiveRootPath(root);
+  const rootPath = await resolveSkillRootPath(boundary, root.rootPath);
   if (rootPath === null) {
     return [];
   }
@@ -371,16 +432,23 @@ async function scanRecursiveSkillRootFiles(
 
 async function scanSingleSkillDirectoryFiles(
   root: CommandScanDirectoryRoot,
+  boundary: SkillPathBoundary,
 ): Promise<SkillFileMatch[]> {
-  const skillFilePath = path.join(root.rootPath, SKILL_FILE_NAME);
-  const skillFile = await statSkillFile(skillFilePath, root);
+  const resolvedRootPath = await resolveSkillRootPath(boundary, root.rootPath);
+  if (resolvedRootPath === null) {
+    return [];
+  }
+  const skillFile = await statSkillFile(
+    path.join(resolvedRootPath, SKILL_FILE_NAME),
+    boundary,
+  );
   if (skillFile === null) {
     return [];
   }
   return [
     {
-      filePath: skillFilePath,
-      frontmatter: await parseFrontmatter(skillFilePath),
+      filePath: path.join(root.rootPath, SKILL_FILE_NAME),
+      frontmatter: await parseFrontmatter(skillFile.resolvedPath),
       linked: (await isSymbolicLinkPath(root.rootPath)) || skillFile.linked,
       name: path.basename(root.rootPath),
     },
@@ -389,12 +457,13 @@ async function scanSingleSkillDirectoryFiles(
 
 async function scanSkillFileRootFiles(
   root: CommandScanSkillFileRoot,
+  boundary: SkillPathBoundary,
 ): Promise<SkillFileMatch[]> {
-  const skillFile = await statSkillFile(root.filePath, root);
+  const skillFile = await statSkillFile(root.filePath, boundary);
   if (skillFile === null) {
     return [];
   }
-  const frontmatter = await parseFrontmatter(root.filePath);
+  const frontmatter = await parseFrontmatter(skillFile.resolvedPath);
   return [
     {
       filePath: root.filePath,
@@ -407,15 +476,19 @@ async function scanSkillFileRootFiles(
 
 async function scanSkillFiles(args: ScanRootArgs): Promise<SkillFileMatch[]> {
   const { root } = args;
+  const boundary = await resolveSkillPathBoundary(root);
+  if (boundary === null) {
+    return [];
+  }
   switch (root.shape) {
     case "skill":
-      return scanSkillRootFiles(root);
+      return scanSkillRootFiles(root, boundary);
     case "skill-recursive":
-      return scanRecursiveSkillRootFiles(root, args.budget);
+      return scanRecursiveSkillRootFiles(root, args.budget, boundary);
     case "skill-directory":
-      return scanSingleSkillDirectoryFiles(root);
+      return scanSingleSkillDirectoryFiles(root, boundary);
     case "skill-file":
-      return scanSkillFileRootFiles(root);
+      return scanSkillFileRootFiles(root, boundary);
     case "command":
     case "command-file":
       return [];

--- a/apps/host-daemon/src/command-handlers/list-commands.ts
+++ b/apps/host-daemon/src/command-handlers/list-commands.ts
@@ -115,6 +115,7 @@ function toPosixRelativePath(fromPath: string, toPath: string): string {
 }
 
 function directoryScanRoot(args: {
+  allowExternalProjectRoot?: boolean;
   boundaryPath: string | null;
   identity: string;
   namePrefix: string;
@@ -127,6 +128,10 @@ function directoryScanRoot(args: {
 }): CommandScanRoot {
   const boundary =
     args.boundaryPath === null ? {} : { boundaryPath: args.boundaryPath };
+  const externalProjectRoot =
+    args.allowExternalProjectRoot === true
+      ? { allowExternalProjectRoot: true }
+      : {};
   const marker =
     args.skipIfManifest === undefined
       ? {}
@@ -143,6 +148,7 @@ function directoryScanRoot(args: {
   }
   return {
     ...boundary,
+    ...externalProjectRoot,
     ...marker,
     rootPath: args.rootPath,
     shape: args.recursive ? "skill-recursive" : "skill",
@@ -193,6 +199,7 @@ async function declaredProjectScanRoots(args: {
   workspace: Workspace;
 }): Promise<CommandScanRoot[]> {
   const roots: CommandScanRoot[] = [];
+  const boundaryPath = (await args.workspace.ancestors()).projectRootPath;
   for (const entry of args.entries) {
     if (entry.ancestors) {
       roots.push(
@@ -210,7 +217,7 @@ async function declaredProjectScanRoots(args: {
     }
     roots.push(
       directoryScanRoot({
-        boundaryPath: args.workspace.cwd,
+        boundaryPath,
         identity: entry.path,
         namePrefix: entry.namePrefix,
         origin: "project",
@@ -260,7 +267,16 @@ async function declaredScanRoots(args: {
 function resolvedSingleScanRoot(
   root: ProviderResolvedNativeRoot,
   providerId: string,
+  boundaryPath: string | null,
 ): CommandScanRoot | null {
+  const boundary =
+    root.origin === "project" && boundaryPath !== null ? { boundaryPath } : {};
+  const externalProjectRoot =
+    root.origin === "project" &&
+    boundaryPath !== null &&
+    !isPathWithinDirectory(boundaryPath, root.path)
+      ? { allowExternalProjectRoot: true }
+      : {};
   const seed =
     root.namePrefix === ""
       ? {
@@ -274,6 +290,8 @@ function resolvedSingleScanRoot(
   switch (root.shape) {
     case "skill":
       return {
+        ...boundary,
+        ...externalProjectRoot,
         rootPath: root.path,
         shape: "skill-directory",
         namePrefix: root.namePrefix,
@@ -283,6 +301,8 @@ function resolvedSingleScanRoot(
       };
     case "skill-file":
       return {
+        ...boundary,
+        ...externalProjectRoot,
         filePath: root.path,
         fallbackName:
           root.fallbackName ?? path.basename(path.dirname(root.path)),
@@ -314,12 +334,18 @@ async function resolvedScanRoots(args: {
 }): Promise<CommandScanRoot[]> {
   const roots: CommandScanRoot[] = [];
   for (const root of args.roots) {
-    const single = resolvedSingleScanRoot(root, args.providerId);
+    const workspace = root.origin === "project" ? args.workspace : null;
+    const boundaryPath =
+      workspace === null ? null : (await workspace.ancestors()).projectRootPath;
+    const allowExternalProjectRoot =
+      root.origin === "project" &&
+      boundaryPath !== null &&
+      !isPathWithinDirectory(boundaryPath, root.path);
+    const single = resolvedSingleScanRoot(root, args.providerId, boundaryPath);
     if (single !== null) {
       roots.push(single);
       continue;
     }
-    const workspace = root.origin === "project" ? args.workspace : null;
     if (
       root.ancestors &&
       workspace !== null &&
@@ -340,10 +366,8 @@ async function resolvedScanRoots(args: {
     }
     roots.push(
       directoryScanRoot({
-        boundaryPath:
-          workspace === null || root.origin !== "project"
-            ? null
-            : (await workspace.ancestors()).projectRootPath,
+        ...(allowExternalProjectRoot ? { allowExternalProjectRoot: true } : {}),
+        boundaryPath,
         identity: root.path,
         namePrefix: root.namePrefix,
         origin: root.origin,

--- a/apps/host-daemon/src/command-handlers/list-skills.test.ts
+++ b/apps/host-daemon/src/command-handlers/list-skills.test.ts
@@ -16,6 +16,7 @@ import type {
   ProviderNativeRoot,
   ProviderNativeRootSet,
   ProviderNativeRoots,
+  ProviderResolvedNativeRoot,
 } from "@bb/domain";
 import type { DiscoveredSkill } from "@bb/host-daemon-contract";
 import { discoverSkills, type SkillScanRoot } from "../command-discovery.js";
@@ -74,6 +75,22 @@ function skillRoots(
     commands: { user: [], project: [] },
     resolved: { skills: [], commands: [] },
   };
+}
+
+function resolvedSkillRoots(
+  skills: ProviderResolvedNativeRoot[],
+): ProviderNativeRootSet {
+  return {
+    skills: { user: [], project: [] },
+    commands: { user: [], project: [] },
+    resolved: { skills, commands: [] },
+  };
+}
+
+function expectedSkillId(identitySeed: string, logicalPath: string): string {
+  return `skill_${createHash("sha256")
+    .update(`${identitySeed}\0${logicalPath}`)
+    .digest("hex")}`;
 }
 
 const AGENT_SKILL_ROOTS = skillRoots({
@@ -274,7 +291,7 @@ describe("resolveSkillScanRoots + discoverSkills", () => {
     expect(new Set(reviews.map((skill) => skill.id)).size).toBe(2);
   });
 
-  it("marks followed user skill directory and SKILL.md symlinks as linked", async () => {
+  it("preserves user object-store skill directory and SKILL.md links", async () => {
     const fixture = await makeWorkspaceFixture();
     const skillsRoot = path.join(fixture.homeDir, ".agent", "skills");
     const linkedDirectoryTarget = path.join(tempRoot, "linked-skill-target");
@@ -296,8 +313,574 @@ describe("resolveSkillScanRoots + discoverSkills", () => {
 
     const skills = await listSkills(fixture, fixture.cwd, AGENT_SKILL_ROOTS);
 
-    expect(byName(skills, "linked-directory")?.linked).toBe(true);
-    expect(byName(skills, "linked-file")?.linked).toBe(true);
+    expect(byName(skills, "linked-directory")).toMatchObject({
+      filePath: path.join(skillsRoot, "linked-directory", "SKILL.md"),
+      linked: true,
+      rootKind: "provider-user",
+    });
+    expect(byName(skills, "linked-file")).toMatchObject({
+      filePath: path.join(skillsRoot, "linked-file", "SKILL.md"),
+      linked: true,
+      rootKind: "provider-user",
+    });
+  });
+
+  it("follows project skill directory and SKILL.md links inside the repository", async () => {
+    const fixture = await makeWorkspaceFixture();
+    const canonicalRoot = path.join(fixture.cwd, ".agents", "skills");
+    const providerRoot = path.join(fixture.cwd, ".claude", "skills");
+    await writeSkill(
+      path.join(canonicalRoot, "voice", "SKILL.md"),
+      "canonical-voice",
+    );
+    await writeSkill(
+      path.join(canonicalRoot, "domain-modeling", "SKILL.md"),
+      "canonical-domain-modeling",
+    );
+    await mkdir(path.join(providerRoot, "domain-modeling"), {
+      recursive: true,
+    });
+    await symlink(
+      path.join("..", "..", ".agents", "skills", "voice"),
+      path.join(providerRoot, "voice"),
+      "dir",
+    );
+    await symlink(
+      path.join(
+        "..",
+        "..",
+        "..",
+        ".agents",
+        "skills",
+        "domain-modeling",
+        "SKILL.md",
+      ),
+      path.join(providerRoot, "domain-modeling", "SKILL.md"),
+    );
+
+    const skills = await listSkills(
+      fixture,
+      fixture.cwd,
+      skillRoots({ project: [declared(".claude/skills")] }),
+      "test-provider",
+    );
+
+    expect(byName(skills, "voice")).toEqual({
+      id: expectedSkillId(
+        "test-provider:provider-project:.claude/skills",
+        "voice/SKILL.md",
+      ),
+      name: "voice",
+      description: "canonical-voice skill",
+      filePath: path.join(providerRoot, "voice", "SKILL.md"),
+      rootKind: "provider-project",
+      linked: true,
+    });
+    expect(byName(skills, "domain-modeling")).toEqual({
+      id: expectedSkillId(
+        "test-provider:provider-project:.claude/skills",
+        "domain-modeling/SKILL.md",
+      ),
+      name: "domain-modeling",
+      description: "canonical-domain-modeling skill",
+      filePath: path.join(providerRoot, "domain-modeling", "SKILL.md"),
+      rootKind: "provider-project",
+      linked: true,
+    });
+  });
+
+  it("follows project resolved skill roots only inside the repository", async () => {
+    const fixture = await makeWorkspaceFixture();
+    const canonicalDirectory = path.join(
+      fixture.cwd,
+      ".agents",
+      "skills",
+      "directory-alias",
+    );
+    const canonicalFile = path.join(
+      fixture.cwd,
+      ".agents",
+      "skills",
+      "file-alias",
+      "SKILL.md",
+    );
+    const resolvedDirectory = path.join(
+      fixture.cwd,
+      ".provider",
+      "directory-alias",
+    );
+    const resolvedFile = path.join(
+      fixture.cwd,
+      ".provider",
+      "file-alias",
+      "SKILL.md",
+    );
+    const outsideDirectory = path.join(tempRoot, "resolved-outside-directory");
+    const outsideFile = path.join(
+      tempRoot,
+      "resolved-outside-file",
+      "SKILL.md",
+    );
+    const resolvedOutsideDirectory = path.join(
+      fixture.cwd,
+      ".provider",
+      "outside-directory",
+    );
+    const resolvedOutsideFile = path.join(
+      fixture.cwd,
+      ".provider",
+      "outside-file",
+      "SKILL.md",
+    );
+    await writeSkill(
+      path.join(canonicalDirectory, "SKILL.md"),
+      "directory-alias",
+    );
+    await writeSkill(canonicalFile, "file-alias");
+    await writeSkill(
+      path.join(outsideDirectory, "SKILL.md"),
+      "outside-directory",
+    );
+    await writeSkill(outsideFile, "outside-file");
+    await mkdir(path.dirname(resolvedDirectory), { recursive: true });
+    await mkdir(path.dirname(resolvedFile), { recursive: true });
+    await mkdir(path.dirname(resolvedOutsideFile), { recursive: true });
+    await symlink(canonicalDirectory, resolvedDirectory, "dir");
+    await symlink(canonicalFile, resolvedFile);
+    await symlink(outsideDirectory, resolvedOutsideDirectory, "dir");
+    await symlink(outsideFile, resolvedOutsideFile);
+
+    const skills = await listSkills(
+      fixture,
+      fixture.cwd,
+      resolvedSkillRoots([
+        {
+          path: resolvedDirectory,
+          origin: "project",
+          shape: "skill",
+          recursive: false,
+          ancestors: false,
+          namePrefix: "",
+        },
+        {
+          path: resolvedFile,
+          origin: "project",
+          shape: "skill-file",
+          recursive: false,
+          ancestors: false,
+          namePrefix: "",
+        },
+        {
+          path: resolvedOutsideDirectory,
+          origin: "project",
+          shape: "skill",
+          recursive: false,
+          ancestors: false,
+          namePrefix: "",
+        },
+        {
+          path: resolvedOutsideFile,
+          origin: "project",
+          shape: "skill-file",
+          recursive: false,
+          ancestors: false,
+          namePrefix: "",
+        },
+      ]),
+    );
+
+    expect(byName(skills, "directory-alias")).toMatchObject({
+      filePath: path.join(resolvedDirectory, "SKILL.md"),
+      linked: true,
+      rootKind: "provider-project",
+    });
+    expect(byName(skills, "file-alias")).toMatchObject({
+      filePath: resolvedFile,
+      linked: true,
+      rootKind: "provider-project",
+    });
+    expect(byName(skills, "outside-directory")).toBeUndefined();
+    expect(byName(skills, "outside-file")).toBeUndefined();
+  });
+
+  it("keeps an OMP-style external plain project root scannable without following child links", async () => {
+    const fixture = await makeWorkspaceFixture();
+    const externalRoot = path.join(tempRoot, "omp-custom-skills");
+    const externalFile = path.join(tempRoot, "omp-custom-file", "SKILL.md");
+    const linkedExternalFile = path.join(
+      tempRoot,
+      "omp-linked-file",
+      "SKILL.md",
+    );
+    const internalDirectory = path.join(
+      fixture.cwd,
+      ".agents",
+      "skills",
+      "internal-directory",
+    );
+    const internalFile = path.join(
+      fixture.cwd,
+      ".agents",
+      "skills",
+      "internal-file",
+      "SKILL.md",
+    );
+    await writeSkill(
+      path.join(externalRoot, "external-plain", "SKILL.md"),
+      "external-plain",
+    );
+    await writeSkill(externalFile, "external-file");
+    await writeSkill(
+      path.join(internalDirectory, "SKILL.md"),
+      "linked-directory",
+    );
+    await writeSkill(internalFile, "linked-file");
+    await symlink(
+      internalDirectory,
+      path.join(externalRoot, "linked-directory"),
+      "dir",
+    );
+    await mkdir(path.join(externalRoot, "linked-file"), { recursive: true });
+    await symlink(
+      internalFile,
+      path.join(externalRoot, "linked-file", "SKILL.md"),
+    );
+    await mkdir(path.dirname(linkedExternalFile), { recursive: true });
+    await symlink(internalFile, linkedExternalFile);
+
+    const skills = await listSkills(
+      fixture,
+      fixture.cwd,
+      resolvedSkillRoots([
+        {
+          path: externalRoot,
+          origin: "project",
+          shape: "skills",
+          recursive: false,
+          ancestors: false,
+          namePrefix: "",
+        },
+        {
+          path: externalFile,
+          origin: "project",
+          shape: "skill-file",
+          recursive: false,
+          ancestors: false,
+          namePrefix: "",
+        },
+        {
+          path: linkedExternalFile,
+          origin: "project",
+          shape: "skill-file",
+          recursive: false,
+          ancestors: false,
+          namePrefix: "",
+        },
+      ]),
+    );
+
+    expect(skills.map((skill) => skill.name)).toEqual([
+      "external-plain",
+      "external-file",
+    ]);
+    expect(byName(skills, "external-plain")).toMatchObject({
+      filePath: path.join(externalRoot, "external-plain", "SKILL.md"),
+      linked: false,
+      rootKind: "provider-project",
+    });
+  });
+
+  it("keeps a Claude cached project plugin's external plain skill root scannable", async () => {
+    const fixture = await makeWorkspaceFixture();
+    const cachedSkill = path.join(tempRoot, "claude-cache", "cached-skill");
+    const linkedSkillTarget = path.join(
+      tempRoot,
+      "claude-cache-target",
+      "linked-skill",
+    );
+    const linkedSkill = path.join(tempRoot, "claude-cache", "linked-skill");
+    await writeSkill(path.join(cachedSkill, "SKILL.md"), "cached-skill");
+    await writeSkill(path.join(linkedSkillTarget, "SKILL.md"), "linked-skill");
+    await mkdir(path.dirname(linkedSkill), { recursive: true });
+    await symlink(linkedSkillTarget, linkedSkill, "dir");
+
+    const skills = await listSkills(
+      fixture,
+      fixture.cwd,
+      resolvedSkillRoots([
+        {
+          path: cachedSkill,
+          origin: "project",
+          shape: "skill",
+          recursive: false,
+          ancestors: false,
+          namePrefix: "cache:",
+        },
+        {
+          path: linkedSkill,
+          origin: "project",
+          shape: "skill",
+          recursive: false,
+          ancestors: false,
+          namePrefix: "cache:",
+        },
+      ]),
+    );
+
+    expect(skills.map((skill) => skill.name)).toEqual(["cache:cached-skill"]);
+    expect(byName(skills, "cache:cached-skill")).toMatchObject({
+      filePath: path.join(cachedSkill, "SKILL.md"),
+      linked: false,
+      rootKind: "plugin",
+    });
+  });
+
+  it("rejects project resolved roots without a repository boundary", async () => {
+    const fixture = await makeWorkspaceFixture();
+    const directoryRoot = path.join(tempRoot, "unbounded-project-directory");
+    const fileRoot = path.join(tempRoot, "unbounded-project-file", "SKILL.md");
+    await writeSkill(path.join(directoryRoot, "SKILL.md"), "directory-root");
+    await writeSkill(fileRoot, "file-root");
+
+    const skills = await listSkills(
+      fixture,
+      null,
+      resolvedSkillRoots([
+        {
+          path: directoryRoot,
+          origin: "project",
+          shape: "skill",
+          recursive: false,
+          ancestors: false,
+          namePrefix: "",
+        },
+        {
+          path: fileRoot,
+          origin: "project",
+          shape: "skill-file",
+          recursive: false,
+          ancestors: false,
+          namePrefix: "",
+        },
+      ]),
+    );
+
+    expect(skills).toEqual([]);
+  });
+
+  it("preserves plain bb-project skills without following child links", async () => {
+    const fixture = await makeWorkspaceFixture();
+    const plainFile = path.join(
+      fixture.cwd,
+      ".bb",
+      "skills",
+      "plain",
+      "SKILL.md",
+    );
+    const inside = path.join(fixture.cwd, ".agents", "skills", "inside");
+    const fileTarget = path.join(
+      fixture.cwd,
+      ".agents",
+      "skills",
+      "file-target",
+      "SKILL.md",
+    );
+    const outside = path.join(tempRoot, "outside-bb-project");
+    await writeSkill(plainFile, "plain");
+    await writeSkill(path.join(inside, "SKILL.md"), "inside");
+    await writeSkill(fileTarget, "file-target");
+    await writeSkill(path.join(outside, "SKILL.md"), "outside");
+    const bbRoot = path.join(fixture.cwd, ".bb", "skills");
+    await mkdir(bbRoot, { recursive: true });
+    await symlink(inside, path.join(bbRoot, "inside"), "dir");
+    await symlink(outside, path.join(bbRoot, "outside"), "dir");
+    await mkdir(path.join(bbRoot, "file-linked"), { recursive: true });
+    await symlink(fileTarget, path.join(bbRoot, "file-linked", "SKILL.md"));
+
+    const skills = await listSkills(fixture, fixture.cwd, skillRoots({}));
+
+    expect(skills).toHaveLength(1);
+    expect(byName(skills, "plain")).toMatchObject({
+      filePath: plainFile,
+      linked: false,
+      rootKind: "bb-project",
+    });
+    expect(byName(skills, "inside")).toBeUndefined();
+    expect(byName(skills, "file-target")).toBeUndefined();
+    expect(byName(skills, "outside")).toBeUndefined();
+  });
+
+  it("allows project aliases from a nested cwd to target the repository root", async () => {
+    const fixture = await makeWorkspaceFixture();
+    const cwd = path.join(fixture.cwd, "packages", "app");
+    const providerTarget = path.join(
+      fixture.cwd,
+      ".agents",
+      "skills",
+      "provider-root-skill",
+    );
+    const bbTarget = path.join(
+      fixture.cwd,
+      ".agents",
+      "skills",
+      "bb-root-skill",
+    );
+    const providerRoot = path.join(cwd, ".provider", "skills");
+    const bbRoot = path.join(cwd, ".bb", "skills");
+    await mkdir(path.join(fixture.cwd, ".git"), { recursive: true });
+    await writeSkill(
+      path.join(providerTarget, "SKILL.md"),
+      "provider-root-skill",
+    );
+    await writeSkill(path.join(bbTarget, "SKILL.md"), "bb-root-skill");
+    await mkdir(providerRoot, { recursive: true });
+    await mkdir(bbRoot, { recursive: true });
+    await symlink(
+      providerTarget,
+      path.join(providerRoot, "provider-root-skill"),
+      "dir",
+    );
+    await symlink(bbTarget, path.join(bbRoot, "bb-root-skill"), "dir");
+
+    const skills = await listSkills(
+      fixture,
+      cwd,
+      skillRoots({ project: [declared(".provider/skills")] }),
+    );
+
+    expect(byName(skills, "provider-root-skill")).toMatchObject({
+      filePath: path.join(providerRoot, "provider-root-skill", "SKILL.md"),
+      linked: true,
+      rootKind: "provider-project",
+    });
+    expect(byName(skills, "bb-root-skill")).toBeUndefined();
+  });
+
+  it("rejects sibling-prefix, external, broken, and looping project skill links", async () => {
+    const fixture = await makeWorkspaceFixture();
+    const providerRoot = path.join(fixture.cwd, ".provider", "skills");
+    const outsideRoot = `${fixture.cwd}-sibling`;
+    const outsideDirectory = path.join(tempRoot, "outside-directory");
+    const outsideFile = path.join(tempRoot, "outside-file", "SKILL.md");
+    await writeSkill(
+      path.join(outsideRoot, "outside-root", "SKILL.md"),
+      "outside-root",
+    );
+    await writeSkill(
+      path.join(outsideDirectory, "SKILL.md"),
+      "outside-directory",
+    );
+    await writeSkill(outsideFile, "outside-file");
+    await writeSkill(path.join(providerRoot, "safe", "SKILL.md"), "safe");
+    await mkdir(path.join(providerRoot, "outside-file"), { recursive: true });
+    await mkdir(path.join(providerRoot, "broken-file"), { recursive: true });
+    await mkdir(path.join(providerRoot, "looping-file"), { recursive: true });
+    await symlink(
+      outsideDirectory,
+      path.join(providerRoot, "outside-directory"),
+      "dir",
+    );
+    await symlink(
+      outsideFile,
+      path.join(providerRoot, "outside-file", "SKILL.md"),
+    );
+    await symlink(
+      path.join(tempRoot, "missing-directory"),
+      path.join(providerRoot, "broken-directory"),
+      "dir",
+    );
+    await symlink(
+      path.join(tempRoot, "missing-file.md"),
+      path.join(providerRoot, "broken-file", "SKILL.md"),
+    );
+    await symlink(
+      "looping-directory",
+      path.join(providerRoot, "looping-directory"),
+      "dir",
+    );
+    await symlink(
+      "SKILL.md",
+      path.join(providerRoot, "looping-file", "SKILL.md"),
+    );
+
+    const outsideRootLink = path.join(fixture.cwd, ".outside-root");
+    const brokenRootLink = path.join(fixture.cwd, ".broken-root");
+    const loopingRootLink = path.join(fixture.cwd, ".looping-root");
+    await symlink(outsideRoot, outsideRootLink, "dir");
+    await symlink(path.join(tempRoot, "missing-root"), brokenRootLink, "dir");
+    await symlink(".looping-root", loopingRootLink, "dir");
+
+    const skills = await listSkills(
+      fixture,
+      fixture.cwd,
+      skillRoots({
+        project: [
+          declared(".provider/skills"),
+          declared(".outside-root"),
+          declared(".broken-root"),
+          declared(".looping-root"),
+        ],
+      }),
+    );
+
+    expect(skills.map((skill) => skill.name)).toEqual(["safe"]);
+  });
+
+  it("rejects internal project roots whose root or parent component escapes the repository", async () => {
+    const fixture = await makeWorkspaceFixture();
+    const outsideParent = path.join(tempRoot, "outside-parent");
+    const outsideRoot = path.join(tempRoot, "outside-root");
+    await writeSkill(
+      path.join(outsideParent, "skills", "parent-escape", "SKILL.md"),
+      "parent-escape",
+    );
+    await writeSkill(
+      path.join(outsideRoot, "root-escape", "SKILL.md"),
+      "root-escape",
+    );
+    await symlink(outsideParent, path.join(fixture.cwd, ".parent-link"), "dir");
+    await mkdir(path.join(fixture.cwd, ".root-link"), { recursive: true });
+    await symlink(
+      outsideRoot,
+      path.join(fixture.cwd, ".root-link", "skills"),
+      "dir",
+    );
+
+    const skills = await listSkills(
+      fixture,
+      fixture.cwd,
+      skillRoots({
+        project: [
+          declared(".parent-link/skills"),
+          declared(".root-link/skills"),
+        ],
+      }),
+    );
+
+    expect(skills).toEqual([]);
+  });
+
+  it("deduplicates project root aliases by real skill file", async () => {
+    const fixture = await makeWorkspaceFixture();
+    const canonicalRoot = path.join(fixture.cwd, ".agents", "skills");
+    const aliasRoot = path.join(fixture.cwd, ".claude", "skills");
+    await writeSkill(path.join(canonicalRoot, "review", "SKILL.md"), "review");
+    await mkdir(path.dirname(aliasRoot), { recursive: true });
+    await symlink(path.join("..", ".agents", "skills"), aliasRoot, "dir");
+
+    const skills = await listSkills(
+      fixture,
+      fixture.cwd,
+      skillRoots({
+        project: [declared(".claude/skills"), declared(".agents/skills")],
+      }),
+    );
+
+    expect(skills.filter((skill) => skill.name === "review")).toHaveLength(1);
+    expect(byName(skills, "review")).toMatchObject({
+      filePath: path.join(aliasRoot, "review", "SKILL.md"),
+      linked: true,
+    });
   });
 
   it("classifies a prefixed declared root as a plugin root", async () => {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -510,6 +510,14 @@ itself knows no agent's layout. The Skills page and `bb skill list` show
 native skills for every provider whose plugin declares or resolves roots. The
 table lists what the shipped plugins declare and resolve.
 
+A provider-native project root inside the repository is followed only when its
+real root remains inside the canonical repository boundary. Non-recursive
+roots may also follow child skill directory and `SKILL.md` symbolic links only
+to repository-contained targets. A plain provider-resolved root outside the
+repository remains scannable, but links beneath it are not followed. Recursive
+roots skip nested links. External, broken, and looping links are ignored.
+Linked skills retain their logical workspace path and are read-only.
+
 | Provider     | User roots                                                                                               | Project roots                                                                                                |
 | ------------ | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
 | Codex        | `~/.agents/skills`, `$CODEX_HOME/skills`                                                                 | `.agents/skills` from the repository root to the current directory, plus `.codex/skills`                     |

--- a/docs/provider-plugin-api.md
+++ b/docs/provider-plugin-api.md
@@ -97,9 +97,12 @@ directories, `ancestors` (project roots only) also scans the same relative
 directory in every ancestor of the workspace up to the repository root,
 `namePrefix` is prepended to every name under the root, and `skipIfManifest`
 names the marker file whose presence makes bb skip a directory as a vendor
-plugin rather than a skill; a symlink out of a project root is followed
-within the workspace for a plain root and within the repository root for a
-root that walks ancestors or that the plugin resolved) and
+plugin rather than a skill; a project skill root inside the repository is
+followed only when its real root remains inside it, while non-recursive roots
+may also follow child-directory and SKILL.md symlinks only to
+repository-contained targets; a plain resolved root outside the repository
+remains scannable but follows no links beneath it; recursive roots skip nested
+links; external, broken, and looping links are ignored) and
 `experimental_resolvesNativeRoots` (the plugin's `bb.host`
 entry answers `resolveNativeRoots({ providerId, cwd })` with the roots only
 that host and workspace know: a moved config directory, installed vendor

--- a/packages/host-daemon-contract/src/protocol.ts
+++ b/packages/host-daemon-contract/src/protocol.ts
@@ -1,3 +1,3 @@
-export const HOST_DAEMON_PROTOCOL_VERSION = 178 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 179 as const;
 
 export const HOST_ARTIFACT_MAX_BYTES = 256 * 1024 * 1024;

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -930,7 +930,7 @@ const ACP_BRIDGE_LAUNCH = {
 
 describe("host-daemon command schemas", () => {
   it("uses the current host-daemon protocol version", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(178);
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(179);
     expect(HOST_ARTIFACT_MAX_BYTES).toBe(256 * 1024 * 1024);
   });
 

--- a/packages/templates/src/templates/bb-guide-agent-configuration.md
+++ b/packages/templates/src/templates/bb-guide-agent-configuration.md
@@ -47,6 +47,13 @@ Skills (.bb/skills/):
 
   A project skill overrides a user or builtin skill with the same name. Two
   skills with the same name within one source collide and are both dropped.
+  A provider-native project root inside the repository is followed only when
+  its real root remains inside it. Non-recursive roots may also follow child
+  skill directory and SKILL.md links only to repository-contained targets. A
+  plain provider-resolved root outside the repository is scanned, but links
+  beneath it are not followed. Recursive roots skip nested links. External,
+  broken, and looping links are ignored. Linked skills keep their workspace
+  path and are read-only.
 
   Use `bb skill list` to inspect installed and discovered skills and copy the
   opaque skill ID. `bb skill show|files <skill-id>` reads that exact skill;


### PR DESCRIPTION
## Human comments

## What was wrong

Project-native non-recursive skill discovery rejected every child symlink while still allowing a symlinked plain project root to escape its workspace. That made repository-contained compatibility aliases such as The Ascent's `.claude/skills/*` links invisible, while the root-level path handling did not enforce the intended repository boundary. See [#2769](https://github.com/get-bb/bb/issues/2769).

## What changed

- Canonicalize the repository boundary and every candidate project skill path, then follow in-repository root, child-directory, and `SKILL.md` links only when the real target remains inside that boundary.
- Use the canonical repository root for nested-cwd project scans, including plain declared and provider-resolved roots.
- Reject external, sibling-prefix, broken, and looping links while preserving logical paths, linked/read-only metadata, stable IDs, realpath deduplication, and user object-store links.
- Preserve OMP-style and Claude cached-plugin project metadata: a plain explicitly resolved root outside the repository remains scannable, but its root and descendants gain no new symlink following.
- Preserve `.bb/skills` injection-compatible behavior and recursive roots' existing refusal to traverse nested links. Provider discovery declarations are unchanged; Claude does not gain `.agents` as a root.
- Document the non-recursive boundary and external resolved-root compatibility contract.
- Increment `HOST_DAEMON_PROTOCOL_VERSION` from 178 to 179 because host skill-list result semantics change even though the wire schema does not.

The scan consumes the canonical resolved path after validation. A concurrent local filesystem mutation can still race any path-based scan; that remains within the host-local trust model rather than expanding the server/daemon contract.

## How you verified

Strict TDD evidence:

- The initial focused additions failed four positive/negative cases before implementation; the nested-cwd regression then failed on the cwd-scoped boundary.
- The `.bb/skills` scope correction failed two focused cases before restoring its existing behavior.
- On the fresh rescope branch, the OMP-style external plain root and Claude cached-plugin fixtures both failed before the explicit-external-root policy and passed afterward.

Green gates:

- `pnpm exec turbo run test --filter=@bb/host-daemon -- --run src/command-handlers/list-skills.test.ts src/command-discovery.test.ts` — 59/59.
- `pnpm exec turbo run test --filter=@bb/host-daemon --filter=@bb/host-daemon-contract --filter=@bb/templates --filter=@bb/cli --force` — host daemon 582/582, contract 51/51, templates 43/43, CLI 525/525.
- `pnpm exec turbo run generate:templates --filter=@bb/templates`.
- Turbo typecheck and build passed for host daemon, host-daemon contract, templates, and CLI.
- `oxfmt --check`, `git diff --check`, and the provider-root diff ratchet passed.
- Source-built live proof against the clean The Ascent checkout at `e4743aa6eb7cb24292f50ab42c7bb667b5f53f20` returned all 17 logical `.claude/skills/*` aliases as Claude project skills, all linked/read-only, with 17 unique repeat-stable IDs and zero Claude `.agents` project records.

Independent review:

- Council session `3fdc1df4-b5b0-4d02-a995-b47a8ce114d7`: 2 support / 1 oppose; its sibling-prefix, canonical-read, TOCTOU, and protocol-version conditions were addressed.
- Fresh cross-model receipt: Claude PASS, round 1, diff SHA-256 `e1e0e14a3767f0c15627d96472f61296cc26b669720ccc32b929d0f50b0ea6a1`. Two minors were rejected by design: external resolved project roots must be plain to avoid adding root-link following, and `.bb/skills` remains loader-compatible and outside SD-14's provider-native scope.

Fixes #2769

Author-Model-Family: codex
Author-Model: gpt-5
Reviewed-By-Model-Family: claude

> AGENT GENERATED
