### PR TITLE
Fix bb:dev CLI arg parsing when pnpm forwards a literal --

### DIFF
--- a/packages/scripts/src/commands/run-cli.ts
+++ b/packages/scripts/src/commands/run-cli.ts
@@ -15,8 +15,10 @@ const packageRoot = resolve(commandDir, "..", "..");
 const repoRoot = resolve(packageRoot, "..", "..");
 
 export function resolveCliExecution(
-  cliArgs: string[] = process.argv.slice(2),
+  rawCliArgs: string[] = process.argv.slice(2),
 ): CliExecution {
+  const cliArgs =
+    rawCliArgs[0] === "--" ? rawCliArgs.slice(1) : rawCliArgs;
   const env = { ...process.env };
   if (process.env.NODE_ENV !== "production") {
     const devEnv = resolveCurrentDevProcessEnv(repoRoot, process.env);

--- a/packages/scripts/test/run-cli.test.ts
+++ b/packages/scripts/test/run-cli.test.ts
@@ -52,4 +52,24 @@ describe("run-cli", () => {
     expect(execution.env.BB_SERVER_URL).toBe("http://localhost:4444");
     expect(execution.env.BB_HOST_DAEMON_PORT).toBe("5555");
   });
+
+  it("strips the leading -- that pnpm forwards to scripts", () => {
+    vi.stubEnv("NODE_ENV", "production");
+
+    const execution = resolveCliExecution([
+      "--",
+      "machine",
+      "show",
+      "some-id",
+      "--json",
+    ]);
+
+    expect(execution.args).toEqual([
+      "apps/cli/dist/index.js",
+      "machine",
+      "show",
+      "some-id",
+      "--json",
+    ]);
+  });
 });


### PR DESCRIPTION
<!-- Keep the below sections. Delete this comment. See docs/filing-issues.md for the issue side. -->

## Human comments

<!-- Agents: Do not fill in this section. This is for human users to fill in. -->

## What was wrong

`pnpm run bb:dev -- <command> <positional> --<flag>` failed with `error: too many arguments`, for any CLI command that takes a positional argument followed by a flag. pnpm 9.15.0 forwards the `--` separator itself as a literal argument to the underlying script (npm strips it), and `resolveCliExecution` in `packages/scripts/src/commands/run-cli.ts` passed `process.argv.slice(2)` straight through to the spawned CLI process. Commander then saw that leading `--` and treated everything after it as "end of options," so a trailing flag got parsed as an extra positional argument instead of an option.

## What changed

`resolveCliExecution` now strips a single leading `--` from the forwarded args before spawning the CLI, matching the fix proposed in the issue.

## How you verified

- Added a test in `packages/scripts/test/run-cli.test.ts` asserting a leading `--` is stripped; confirmed it fails on the old code and passes after the fix.
- `pnpm exec turbo run test --filter=@bb/scripts` and `pnpm exec turbo run typecheck --filter=@bb/scripts` both pass.
- Reproduced the exact repro from the issue end-to-end: `pnpm run --silent bb:dev -- machine show fake-id --json` no longer fails at the parser (`too many arguments for 'show'`); it now proceeds past argument parsing to the expected "Cannot connect to BB server" error.

Fixes #2998

<!-- Agents: end with the line below. -->
> AGENT GENERATED
