### PR TITLE
Copy message images with text

### DIFF
--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -278,6 +278,7 @@ function renderPromptBox(
     mentionTriggers?: TypeaheadConfig["mention"]["triggers"];
     mentionSuggestions?: readonly PromptMentionSuggestion[];
     commandSuggestions?: TypeaheadConfig["command"]["suggestions"];
+    onAttachFiles?: (files: File[]) => Promise<void> | void;
   } = {},
 ) {
   const changes: PromptChange[] = [];
@@ -309,7 +310,7 @@ function renderPromptBox(
           onCommandQueryChange,
         })}
         mentionMenuPlacement="bottom"
-        attachments={{}}
+        attachments={{ onAttachFiles: options.onAttachFiles }}
         promptActions={promptActions}
         promptBoxRef={promptBoxRef}
       />
@@ -416,15 +417,20 @@ function pastePlainText(text: string) {
 }
 
 function pasteClipboard({
+  files = [],
   html = "",
   plainText = "",
 }: {
+  files?: File[];
   html?: string;
   plainText?: string;
 }) {
   fireEvent.paste(getPromptEditorElement(), {
     clipboardData: {
-      items: [],
+      items: files.map((file) => ({
+        kind: "file",
+        getAsFile: () => file,
+      })),
       getData: (type: string) => {
         if (type === "text/html") return html;
         if (type === "text/plain") return plainText;
@@ -3381,6 +3387,20 @@ describe("PromptBoxInternal prompt actions", () => {
       coordsAtPosSpy.mockRestore();
       scrollRectSpy.mockRestore();
     }
+  });
+
+  it("pastes clipboard text and attaches the clipboard image", async () => {
+    const onAttachFiles = vi.fn().mockResolvedValue(undefined);
+    const { changes, promptBoxRef } = renderPromptBox("Before ", {
+      onAttachFiles,
+    });
+    const image = new File(["image"], "photo.png", { type: "image/png" });
+
+    await focusPromptEnd(promptBoxRef);
+    pasteClipboard({ files: [image], plainText: "A photo" });
+
+    await waitFor(() => expect(latestValue(changes)).toBe("Before A photo"));
+    expect(onAttachFiles).toHaveBeenCalledWith([image]);
   });
 
   it("preserves blockquote structure when pasting copied blockquote html", async () => {

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -1698,7 +1698,6 @@ export function PromptBoxInternal({
           if (attachFiles && pastedFiles.length > 0) {
             event.preventDefault();
             void attachFiles(pastedFiles);
-            return true;
           }
 
           const plainText = event.clipboardData?.getData("text/plain") ?? "";
@@ -1737,7 +1736,9 @@ export function PromptBoxInternal({
             event.clipboardData ?? null,
             promptActions,
           );
-          if (pastedValue === null) return false;
+          if (pastedValue === null) {
+            return attachFiles !== undefined && pastedFiles.length > 0;
+          }
 
           event.preventDefault();
           if (pastedValue.text.length === 0) return true;

--- a/apps/app/src/components/thread/timeline/ConversationMessageContent.tsx
+++ b/apps/app/src/components/thread/timeline/ConversationMessageContent.tsx
@@ -457,6 +457,7 @@ function UserConversationMessage({
             alignment="end"
             mobileActionDisplay={mobileActionDisplay}
             addToChatAttachments={addToChatAttachments}
+            copyImageUrl={attachmentItems.imageItems[0]?.src}
             onAddToChat={onAddToChat}
             onEdit={onEdit}
             pluginActions={pluginActions}
@@ -626,6 +627,7 @@ function AssistantConversationMessage({
           alignment="start"
           mobileActionDisplay={mobileActionDisplay}
           addToChatAttachments={addToChatAttachments}
+          copyImageUrl={attachmentItems.imageItems[0]?.src}
           onAddToChat={onAddToChat}
           onFork={onFork}
           onSendToMain={onSendToMain}

--- a/apps/app/src/components/thread/timeline/MessageActionBar.test.tsx
+++ b/apps/app/src/components/thread/timeline/MessageActionBar.test.tsx
@@ -301,6 +301,19 @@ describe("MessageActionBar", () => {
     expect(onAddToChat).toHaveBeenCalledWith("", [attachment]);
   });
 
+  it("renders copy for an image-only message", () => {
+    render(
+      <MessageActionBar
+        messageText=""
+        copyImageUrl="/attachments/screenshot.png"
+        alignment="end"
+        mobileActionDisplay="overflow"
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Copy message" })).toBeTruthy();
+  });
+
   it("omits the send-to-main action when no handler is supplied", () => {
     render(
       <MessageActionBar

--- a/apps/app/src/components/thread/timeline/MessageActionBar.tsx
+++ b/apps/app/src/components/thread/timeline/MessageActionBar.tsx
@@ -58,6 +58,7 @@ interface MessageActionBarProps {
   alignment: "start" | "end";
   mobileActionDisplay: "inline" | "overflow";
   addToChatAttachments?: readonly PromptDraftAttachment[];
+  copyImageUrl?: string;
   onAddToChat?: (
     text: string,
     attachments?: readonly PromptDraftAttachment[],
@@ -77,6 +78,7 @@ interface MessageOverflowAction {
   onSelect: () => void;
   disabled?: boolean;
   copyText?: string;
+  copyImageUrl?: string;
   kind?: "copy";
 }
 
@@ -319,6 +321,7 @@ function DesktopMessageAction({
         {action.kind === "copy" ? (
           <CopyButton
             text={action.copyText ?? ""}
+            imageUrl={action.copyImageUrl}
             label={action.label}
             className={className}
           />
@@ -382,6 +385,7 @@ export function MessageActionBar({
   alignment,
   mobileActionDisplay,
   addToChatAttachments = [],
+  copyImageUrl,
   onAddToChat,
   onEdit,
   onFork,
@@ -391,7 +395,7 @@ export function MessageActionBar({
 }: MessageActionBarProps) {
   const isCompactViewport = useIsCompactViewport();
   const isPointerCoarse = usePointerCoarse();
-  const hasCopy = messageText.length > 0;
+  const hasCopy = messageText.length > 0 || copyImageUrl !== undefined;
   const hasAddToChat =
     (hasCopy || addToChatAttachments.length > 0) && onAddToChat !== undefined;
   const [collisionBoundary, setCollisionBoundary] = useState<
@@ -475,9 +479,11 @@ export function MessageActionBar({
             onSelect: () => {
               void copyToClipboardWithToast(messageText, {
                 errorMessage: "Failed to copy",
+                imageUrl: copyImageUrl,
               });
             },
             copyText: messageText,
+            copyImageUrl,
             kind: "copy" as const,
           },
         ]
@@ -723,6 +729,7 @@ function MobileInlineActions({
             void copyToClipboardWithToast(action.copyText ?? "", {
               successMessage: null,
               errorMessage: "Failed to copy",
+              imageUrl: action.copyImageUrl,
             }).then((didCopy) => {
               if (didCopy) onCopied();
             });
@@ -735,6 +742,7 @@ function MobileInlineActions({
         <CopyButton
           key={action.key ?? action.label}
           text={action.copyText ?? ""}
+          imageUrl={action.copyImageUrl}
           label={action.label}
           className={cn(HOVER_REVEAL_CLASS, MOBILE_INLINE_ACTION_CLASS)}
         />

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.actions.test.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.actions.test.tsx
@@ -432,7 +432,7 @@ describe("ThreadTimelineRows actions", () => {
     });
   });
 
-  it("keeps the last real user action footer inline when a remote-image-only row follows", () => {
+  it("adds a copy action to a remote-image-only row", () => {
     const { container } = renderWithRouter(
       <ThreadTimelineRows
         timelineRows={[
@@ -475,7 +475,7 @@ describe("ThreadTimelineRows actions", () => {
     ).not.toBeNull();
     expect(
       remoteImageOnlyMessage?.querySelector('[aria-label="Copy message"]'),
-    ).toBeNull();
+    ).not.toBeNull();
   });
 
   it("keeps the last text footer inline when an attachment-only row has no add action", () => {

--- a/apps/app/src/components/ui/copy-button.tsx
+++ b/apps/app/src/components/ui/copy-button.tsx
@@ -25,6 +25,7 @@ export const CopyButton = forwardRef<HTMLButtonElement, CopyButtonProps>(
       label = "Copy to clipboard",
       successMessage,
       errorMessage,
+      imageUrl,
       ...rest
     },
     ref,
@@ -33,6 +34,7 @@ export const CopyButton = forwardRef<HTMLButtonElement, CopyButtonProps>(
       text,
       successMessage,
       errorMessage,
+      imageUrl,
     });
 
     return (

--- a/apps/app/src/lib/clipboard.test.ts
+++ b/apps/app/src/lib/clipboard.test.ts
@@ -41,6 +41,7 @@ afterEach(() => {
   toastMocks.error.mockReset();
   toastMocks.success.mockReset();
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
   removeClipboard();
 });
 
@@ -97,6 +98,102 @@ describe("copyTextToClipboard", () => {
 });
 
 describe("copyToClipboardWithToast", () => {
+  it("writes message text and an attached PNG as one clipboard item", async () => {
+    const clipboardData: Record<string, Blob | Promise<Blob>>[] = [];
+    class TestClipboardItem {
+      constructor(data: Record<string, Blob | Promise<Blob>>) {
+        clipboardData.push(data);
+      }
+    }
+    const write = vi.fn(async () => {
+      await Promise.all(Object.values(clipboardData[0] ?? {}));
+    });
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("ClipboardItem", TestClipboardItem);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response("image", {
+          headers: { "Content-Type": "image/png" },
+          status: 200,
+        }),
+      ),
+    );
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { write, writeText },
+    });
+
+    await expect(
+      copyToClipboardWithToast("A photo", {
+        imageUrl: "/attachments/photo.png",
+      }),
+    ).resolves.toBe(true);
+
+    expect(write).toHaveBeenCalledOnce();
+    expect(writeText).not.toHaveBeenCalled();
+    const copiedImageBlob = await Promise.resolve(
+      clipboardData[0]?.["image/png"],
+    );
+    expect(copiedImageBlob?.type).toBe("image/png");
+    expect(await copiedImageBlob?.text()).toBe("image");
+    const textBlob = await Promise.resolve(clipboardData[0]?.["text/plain"]);
+    expect(await textBlob?.text()).toBe("A photo");
+  });
+
+  it("writes an attached image when the message has no text", async () => {
+    const clipboardData: Record<string, Blob | Promise<Blob>>[] = [];
+    const write = vi.fn(async () => {
+      await Promise.all(Object.values(clipboardData[0] ?? {}));
+    });
+    vi.stubGlobal(
+      "ClipboardItem",
+      class TestClipboardItem {
+        constructor(data: Record<string, Blob | Promise<Blob>>) {
+          clipboardData.push(data);
+        }
+      },
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response("image", {
+          headers: { "Content-Type": "image/png" },
+        }),
+      ),
+    );
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { write },
+    });
+
+    await expect(
+      copyToClipboardWithToast("", {
+        imageUrl: "/attachments/photo.png",
+      }),
+    ).resolves.toBe(true);
+
+    expect(write).toHaveBeenCalledOnce();
+  });
+
+  it("reports a failure when the browser cannot write the attached image", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+
+    await expect(
+      copyToClipboardWithToast("A photo", {
+        errorMessage: "Failed to copy",
+        imageUrl: "/attachments/photo.png",
+      }),
+    ).resolves.toBe(false);
+
+    expect(writeText).not.toHaveBeenCalled();
+    expect(toastMocks.error).toHaveBeenCalledWith("Failed to copy");
+  });
+
   it("shows the configured error only after both copy methods fail", async () => {
     installClipboard(vi.fn().mockRejectedValue(new Error("denied")));
     installEditingCommand(() => false);

--- a/apps/app/src/lib/clipboard.ts
+++ b/apps/app/src/lib/clipboard.ts
@@ -4,6 +4,51 @@ import { appToast } from "@/components/ui/app-toast";
 interface CopyToClipboardOptions {
   successMessage?: string | null;
   errorMessage?: string | null;
+  imageUrl?: string;
+}
+
+async function convertImageBlobToPng(blob: Blob): Promise<Blob> {
+  if (blob.type.toLowerCase() === "image/png") {
+    return blob;
+  }
+
+  const objectUrl = URL.createObjectURL(blob);
+  try {
+    const image = document.createElement("img");
+    image.src = objectUrl;
+    await image.decode();
+
+    const canvas = document.createElement("canvas");
+    canvas.width = image.naturalWidth;
+    canvas.height = image.naturalHeight;
+    const context = canvas.getContext("2d");
+    if (!context) {
+      throw new Error("The browser cannot convert the clipboard image");
+    }
+    context.drawImage(image, 0, 0);
+
+    return await new Promise<Blob>((resolve, reject) => {
+      canvas.toBlob((pngBlob) => {
+        if (pngBlob) {
+          resolve(pngBlob);
+          return;
+        }
+        reject(new Error("The browser cannot encode the clipboard image"));
+      }, "image/png");
+    });
+  } finally {
+    URL.revokeObjectURL(objectUrl);
+  }
+}
+
+async function fetchClipboardImage(imageUrl: string): Promise<Blob> {
+  const response = await fetch(imageUrl);
+  if (!response.ok) {
+    throw new Error(
+      `The clipboard image request failed with ${response.status}`,
+    );
+  }
+  return convertImageBlobToPng(await response.blob());
 }
 
 function copyWithEditingCommand(text: string): boolean {
@@ -78,14 +123,45 @@ export async function copyTextToClipboard(text: string): Promise<boolean> {
   return copyWithEditingCommand(text);
 }
 
+async function copyTextAndImageToClipboard(
+  text: string,
+  imageUrl: string,
+): Promise<boolean> {
+  if (
+    typeof navigator === "undefined" ||
+    typeof navigator.clipboard?.write !== "function" ||
+    typeof ClipboardItem === "undefined"
+  ) {
+    return false;
+  }
+
+  try {
+    const imageBlob = fetchClipboardImage(imageUrl);
+    void imageBlob.catch(() => undefined);
+    const clipboardData: Record<string, Blob | Promise<Blob>> = {
+      "image/png": imageBlob,
+    };
+    if (text.length > 0) {
+      clipboardData["text/plain"] = new Blob([text], { type: "text/plain" });
+    }
+    await navigator.clipboard.write([new ClipboardItem(clipboardData)]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export async function copyToClipboardWithToast(
   text: string,
   {
     successMessage = "Copied",
     errorMessage = "Failed to copy",
+    imageUrl,
   }: CopyToClipboardOptions = {},
 ): Promise<boolean> {
-  const copied = await copyTextToClipboard(text);
+  const copied = imageUrl
+    ? await copyTextAndImageToClipboard(text, imageUrl)
+    : await copyTextToClipboard(text);
   if (copied) {
     if (successMessage) appToast.success(successMessage);
     return true;
@@ -102,6 +178,7 @@ export function useClipboardCopy({
   text,
   successMessage = null,
   errorMessage = "Failed to copy",
+  imageUrl,
 }: ClipboardCopyOptions) {
   const [copied, setCopied] = useState(false);
 
@@ -112,13 +189,14 @@ export function useClipboardCopy({
   }, [copied]);
 
   const copy = useCallback(async () => {
-    if (!text || copied) return;
+    if ((!text && !imageUrl) || copied) return;
     const success = await copyToClipboardWithToast(text, {
       successMessage,
       errorMessage,
+      imageUrl,
     });
     if (success) setCopied(true);
-  }, [text, copied, successMessage, errorMessage]);
+  }, [text, imageUrl, copied, successMessage, errorMessage]);
 
   return { copied, copy };
 }


### PR DESCRIPTION
## Human comments

## What was wrong

The message copy action wrote only plain text. The prompt paste handler also returned after it attached clipboard files, so it discarded the clipboard text.

## What changed

The copy action now writes the message text and the first attached image in one clipboard item. It converts non-PNG images to PNG and supports image-only messages. The prompt paste handler now attaches clipboard files and continues through the existing text parser.

## How you verified

- `pnpm exec turbo run test --filter=@bb/app -- --run src/lib/clipboard.test.ts src/components/thread/timeline/MessageActionBar.test.tsx src/components/thread/timeline/ThreadTimelineRows.actions.test.tsx`
- `pnpm exec turbo run test --filter=@bb/app -- --run src/components/promptbox/PromptBoxInternal.test.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run lint --filter=@bb/app` completed with no errors.

> AGENT GENERATED
