### PR TITLE
Add BB Official plugin screenshots

### DIFF
--- a/apps/server/test/services/plugin-catalog/bb-official-generator.test.ts
+++ b/apps/server/test/services/plugin-catalog/bb-official-generator.test.ts
@@ -46,6 +46,15 @@ describe("bb-official marketplace generator", () => {
       raw,
       "generated marketplace",
     );
+    const fields = parseBbOfficialCatalogFields(
+      JSON.parse(
+        await readFile(
+          new URL("../../../../../plugins/bb-official.json", import.meta.url),
+          "utf8",
+        ),
+      ),
+      BUNDLED_PLUGINS,
+    );
 
     expect(catalog.name).toBe(BUNDLED_MARKETPLACE_NAME);
     expect(catalog.displayName).toBe("BB Official");
@@ -65,7 +74,7 @@ describe("bb-official marketplace generator", () => {
           candidate.source.bundled.plugin === plugin.name,
       );
       expect(entry?.id).toBe(plugin.pluginId);
-      expect(entry?.screenshots).toEqual([]);
+      expect(entry?.screenshots).toEqual(fields[plugin.name]?.screenshots);
       expect(entry?.author).toEqual({ name: "BB" });
     }
   });

--- a/plugins/bb-official.json
+++ b/plugins/bb-official.json
@@ -5,7 +5,10 @@
   },
   "automations": {
     "category": "tasks-and-workflows",
-    "screenshots": []
+    "screenshots": [
+      "https://getbb.app/marketplace/v2/screenshots/automations/automations-catalog.png",
+      "https://getbb.app/marketplace/v2/screenshots/automations/automations-sidebar.png"
+    ]
   },
   "connect": {
     "category": "cloud-and-remote",
@@ -53,7 +56,11 @@
   },
   "plugin-api-docs": {
     "category": "plugin-development",
-    "screenshots": []
+    "screenshots": [
+      "https://getbb.app/marketplace/v2/screenshots/plugin-api-docs/plugin-guide-map.png",
+      "https://getbb.app/marketplace/v2/screenshots/plugin-api-docs/plugin-guide-surfaces.png",
+      "https://getbb.app/marketplace/v2/screenshots/plugin-api-docs/plugin-guide-reference.png"
+    ]
   },
   "provider-retry": {
     "category": "agents-and-providers",


### PR DESCRIPTION
## Human comments

## What was wrong

The prototype supplied five screenshots for two bundled plugins. The production port left every BB Official screenshot list empty.

## What changed

The BB Official registry now links the CDN images for Automations and Plugin Guide. The generator test now checks each generated list against its registry block.

The CDN source is [get-bb/marketplace#181](https://github.com/get-bb/marketplace/pull/181). This change does not change the host daemon protocol, CLI, or guide.

## How you verified

- `pnpm exec turbo run typecheck --filter=@bb/server`
- `pnpm exec turbo run test --filter=@bb/server --force -- test/services/plugin-catalog/bb-official-generator.test.ts`
- The generated BB Official document contains all five URLs.
- The CDN publisher passed its build, tests, v1 gate, liveness check, and CI.

> AGENT GENERATED
