### PR TITLE
Disable swipe navigation in mobile WebViews

### DIFF
--- a/apps/mobile/src/screens/dev/WebViewSpikeScreen.tsx
+++ b/apps/mobile/src/screens/dev/WebViewSpikeScreen.tsx
@@ -335,7 +335,7 @@ export function WebViewSpikeScreen() {
           allowsInlineMediaPlayback
           mediaPlaybackRequiresUserAction={false}
           mediaCapturePermissionGrantType={grantType}
-          allowsBackForwardNavigationGestures
+          allowsBackForwardNavigationGestures={false}
           allowFileAccessFromFileURLs
           incognito={incognito}
           cacheEnabled={cacheEnabled}

--- a/apps/mobile/src/screens/webview/ProfileWebViewScreen.tsx
+++ b/apps/mobile/src/screens/webview/ProfileWebViewScreen.tsx
@@ -253,7 +253,7 @@ export function ProfileWebViewScreen() {
         mediaPlaybackRequiresUserAction={false}
         mediaCapturePermissionGrantType="grant"
         hideKeyboardAccessoryView
-        allowsBackForwardNavigationGestures
+        allowsBackForwardNavigationGestures={false}
         pullToRefreshEnabled
         webviewDebuggingEnabled={__DEV__}
         injectedJavaScriptBeforeContentLoaded={buildBridgeInjectionScript(


### PR DESCRIPTION
## Human comments

## What was wrong

The native WebView enabled iOS back and forward swipe navigation. That gesture competed with the embedded app's sidebar swipe gesture.

## What changed

Disabled back and forward swipe navigation in the main mobile WebView and the development WebView.

## How you verified

- `pnpm exec turbo run typecheck --filter=@bb/mobile`
- `pnpm exec turbo run lint --filter=@bb/mobile`
- Built a signed release app and installed it on a connected iPhone 15 Pro.
- Confirmed that iOS reports bb version 0.39.0 with bundle identifier `app.getbb.mobile`.

> AGENT GENERATED
