### PR TITLE
Revert startup pane reconciliation so handoff does not open a new split

### DIFF
--- a/apps/app/src/views/thread-detail/SplitThreadArea.test.tsx
+++ b/apps/app/src/views/thread-detail/SplitThreadArea.test.tsx
@@ -1797,29 +1797,6 @@ describe("SplitThreadArea", () => {
     expect(screen.getByTestId("pane-thr-b")).toBeTruthy();
   });
 
-  it("keeps restored thread panes when the root compose route mounts", async () => {
-    const store = renderSplitArea({
-      path: "/",
-      layout: twoPaneLayout("pane-1"),
-      routeContent: newThreadContent,
-    });
-
-    expect(await screen.findByTestId("root-compose-view")).toBeTruthy();
-    await waitFor(() => {
-      const restored = store.get(splitLayoutAtom);
-      if (restored === null) {
-        throw new Error("Expected a restored split layout");
-      }
-      expect(
-        listPanes(restored.root).map((pane) => pane.content),
-      ).toEqual([
-        threadContent("thr-a"),
-        threadContent("thr-b"),
-        newThreadContent,
-      ]);
-    });
-  });
-
   it("restores eight successive default-right opens, then focuses and closes with valid URL state", async () => {
     const layout = eightPaneThreadLayout();
     expect(layout.root).toMatchObject({

--- a/apps/app/src/views/thread-detail/SplitThreadArea.tsx
+++ b/apps/app/src/views/thread-detail/SplitThreadArea.tsx
@@ -96,7 +96,6 @@ import {
   focusedPaneRoute,
   paneContentRoute,
   reconcileLayoutForContent,
-  reconcileRestoredLayoutForContent,
   threadPaneContent,
 } from "./splitThreadNavigation";
 import { ThreadDetailWorkerPoolProvider } from "./ThreadDetailWorkerPoolProvider";
@@ -277,7 +276,6 @@ function SplitThreadAreaContent({ routeContent }: SplitThreadAreaProps) {
   const dimsInactiveSplits = useAtomValue(dimInactiveSplitsAtom);
   const [maximizedPaneId, setMaximizedPaneIdAtom] =
     useAtom(maximizedPaneIdAtom);
-  const shouldReconcileRestoredLayout = useRef(true);
   const secondaryPanelRegistry = useMemo(
     () => createPaneSecondaryPanelRegistry(),
     [],
@@ -296,12 +294,8 @@ function SplitThreadAreaContent({ routeContent }: SplitThreadAreaProps) {
     if (currentContent === null) {
       return;
     }
-    const reconcile = shouldReconcileRestoredLayout.current
-      ? reconcileRestoredLayoutForContent
-      : reconcileLayoutForContent;
-    shouldReconcileRestoredLayout.current = false;
     setLayout((previous) =>
-      reconcile(previous, currentContent),
+      reconcileLayoutForContent(previous, currentContent),
     );
   }, [currentContent, setLayout]);
 

--- a/apps/app/src/views/thread-detail/splitThreadNavigation.ts
+++ b/apps/app/src/views/thread-detail/splitThreadNavigation.ts
@@ -5,7 +5,6 @@ import {
   findPane,
   findPaneByContent,
   findPaneByThread,
-  listPanes,
   MAX_PANES,
   replacePaneContent,
   setFocus,
@@ -123,25 +122,6 @@ export function reconcileLayoutForContent(
       : setFocus(withRouteState, existing.paneId);
   }
   return replacePaneContent(layout, layout.focusedPaneId, content);
-}
-
-export function reconcileRestoredLayoutForContent(
-  layout: SplitLayout | null,
-  content: PaneContent,
-): SplitLayout {
-  if (
-    layout === null ||
-    content.kind !== "new-thread" ||
-    findPaneByContent(layout.root, content) !== null ||
-    countPanes(layout.root) >= MAX_PANES
-  ) {
-    return reconcileLayoutForContent(layout, content);
-  }
-  const panes = listPanes(layout.root);
-  const rightmostPane = panes[panes.length - 1];
-  return rightmostPane === undefined
-    ? reconcileLayoutForContent(layout, content)
-    : splitPane(layout, rightmostPane.paneId, "right", content);
 }
 
 export function focusedPaneRoute(layout: SplitLayout): string | null {


### PR DESCRIPTION
## Human comments

## What was wrong

The "Handoff to new thread" action opened the composer in a new split pane instead of the focused pane. `handleHandoffToNewThread` navigates to the legacy project compose path `/projects/:projectId` (`apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx:1004`). `SplitWorkspaceRoute` answers that path with `LegacyProjectComposeRedirect`, so React unmounts `SplitThreadArea`. The redirect then replaces the URL with `/`, and `SplitThreadArea` mounts again. PR #2921 gated its startup reconciliation behind a per-mount `useRef`, so the remount looked like a fresh startup. The mount effect therefore called `reconcileRestoredLayoutForContent`, which splits the rightmost pane to the right for `new-thread` content. A handoff from the personal project did not show the bug, because `getProjectComposeRoutePath` returns `/` for that project and no unmount happens.

## What changed

This pull request reverts commit `970480f6c6` (PR #2921). It removes `reconcileRestoredLayoutForContent` from `apps/app/src/views/thread-detail/splitThreadNavigation.ts`, removes the `shouldReconcileRestoredLayout` ref from `apps/app/src/views/thread-detail/SplitThreadArea.tsx`, and removes that PR's regression test. Route reconciliation again always replaces the focused pane. The change does not touch a wire protocol, `HOST_DAEMON_PROTOCOL_VERSION`, a CLI surface, a schema, or a stored-data format.

Note the cost of this revert: issue #2919 comes back. After a restart with a restored multi-pane layout on `/`, the composer replaces a restored thread pane instead of joining the layout at the right edge. A later change can fix both bugs together. It must make the startup guard true only for the first route reconciliation of the session, and not for each mount of `SplitThreadArea`.

## How you verified

- `pnpm exec turbo run typecheck --filter=@bb/app` passed.
- `pnpm exec turbo run test --filter=@bb/app -- SplitThreadArea splitThreadNavigation` passed with 4 test files and 58 tests.
- The first test run failed in the `ensure-native-modules` prerequisite with a `better-sqlite3` segmentation fault. That step is unrelated to this change, and the retry passed.
- This pull request adds no test. The reverted commit held the only test of this reconciliation path, and the revert removes it.

Fixes #

This revert reopens #2919.

> AGENT GENERATED
