### PR TITLE
Fix the plugin submission entry contract and require screenshots

### DIFF
--- a/apps/server/src/services/skills/builtin-skills/submit-a-plugin/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/submit-a-plugin/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: submit-a-plugin
-description: Submit a bb plugin to the BB Community marketplace. Use whenever a user asks to submit, list, publish, or add a plugin to the BB marketplace, or asks for a marketplace pull request. This skill validates the plugin and release, creates the marketplace entry and icon, and opens the pull request.
+description: Submit a bb plugin to the BB Community marketplace. Use whenever a user asks to submit, list, publish, or add a plugin to the BB marketplace, or asks for a marketplace pull request. This skill validates the plugin and release, creates the marketplace entry, icon, and screenshots, and opens the pull request.
 ---
 
 # Submit a plugin
@@ -29,9 +29,15 @@ The marketplace contract can change independently from BB releases. Read these
 files from the default branch of https://github.com/get-bb/marketplace:
 
 - README.md
-- schema/marketplace.schema.json
+- schema/marketplace-v2.schema.json
+- marketplace.base.json, for the current category IDs
 - icons/README.md
 - At least two current files in entries/
+
+An entry file uses the version 2 entry fields. Read
+schema/marketplace-v2.schema.json for those fields. The older
+schema/marketplace.schema.json file describes the frozen version 1 output
+document. Do not use it as the entry contract.
 
 Treat those files as the contract. Use this skill for workflow and quality
 rules.
@@ -42,15 +48,20 @@ rules.
 2. Validate the plugin with its package manager and bb plugin build.
 3. Select and verify one public release source.
 4. Get separate approval before any release mutation.
-5. Create one marketplace entry and a vendored icon.
-6. Validate the marketplace repository.
-7. Commit only the entry and icon.
-8. Open a pull request from the submitter account.
+5. Create one marketplace entry with a vendored icon.
+6. Install the plugin and capture its screenshots.
+7. Validate the marketplace repository.
+8. Commit only the entry, icon, and screenshots.
+9. Open a pull request from the submitter account.
 
 Read these references as the task reaches each stage:
 
 - Read references/plugin-release.md before validating or releasing a plugin.
-- Read references/marketplace-entry.md before creating the entry or icon.
+- Read references/marketplace-entry.md before you create the entry, icon, or
+  screenshots. It states what a good entry and description hold, how to capture
+  screenshots with a harness browser or computer automation tool, and what to
+  ask the user for when the harness has no such tool. It ends with a quality
+  check to run before the pull request.
 - Read references/pull-request.md before cloning, validating, or submitting
   the marketplace repository.
 
@@ -67,4 +78,4 @@ for a merge unless the user asks.
 
 A compatible release within an existing tracking range usually needs no new
 marketplace pull request. Open another pull request when source, branding,
-description, ownership, tag, or range changes.
+description, category, screenshots, ownership, tag, or range changes.

--- a/apps/server/src/services/skills/builtin-skills/submit-a-plugin/references/marketplace-entry.md
+++ b/apps/server/src/services/skills/builtin-skills/submit-a-plugin/references/marketplace-entry.md
@@ -1,22 +1,80 @@
-# Marketplace entry and icon
+# Marketplace entry, icon, and screenshots
 
-Read this file before you create a marketplace entry or icon. Confirm every
-field against the current marketplace schema.
+Read this file before you create a marketplace entry, icon, or screenshots.
+Confirm every field against schema/marketplace-v2.schema.json in the
+marketplace repository.
 
 ## Create the entry
 
 Create entries/<plugin-id>.json. The filename, entry ID, and plugin manifest ID
-must match. Do not add fields that the schema does not define.
+must match.
 
-The current required fields are id, displayName, description, icon, author, and
-source. Use tags and engines when they add useful search or compatibility data.
+The schema rejects an unknown field. The permitted fields are id, displayName,
+description, icon, tags, author, source, category, and screenshots. The schema
+requires id, displayName, description, icon, author, and source. The build
+writes publishedAt itself, so do not author it. The entry has no engines field
+and no version field. Read the plugin manifest for compatibility data instead.
 
-Use the product name for displayName. Write one concrete description sentence
-that states the feature and user value. Do not make subjective marketing claims.
+### Write the display name
 
-Use no more than ten specific lowercase tags. Use hyphens inside multiword tags.
-Copy honest engine ranges from the plugin manifest. An entry can narrow those
-ranges but cannot widen them.
+Use the product name. Keep it short enough to read in a card title. Do not add
+the word plugin. Do not add the word BB unless the product name holds it.
+
+### Write the description
+
+Write an App Store listing, not a README line. A user who never heard of the
+plugin decides here. Do not copy the style of the current entries. Many of them
+read as release notes.
+
+An App Store listing has two parts. BB holds both in one field.
+
+**The hook is the first sentence.** BB clamps the description to two lines in a
+browse card, and to one line in a compact row. The hook must stand alone there.
+State the outcome the user gets. Do not state the mechanism. Keep it under
+about 140 characters. Start with a verb. Do not start with the display name.
+Do not start with "A plugin that".
+
+**The body is every sentence after the hook.** The detail page shows the body
+in full. Give one distinct capability in each sentence. Put the most valuable
+capability first. Stop at four sentences unless the plugin adds several
+surfaces.
+
+Write for a person who decides. Do not write for a reviewer who reads a
+changelog. Use concrete nouns and verbs. Use a real number when you have one.
+Never let an adjective carry the value.
+
+Do not use these words: powerful, seamless, easy, simple, fast, best, modern,
+beautiful, robust, and intuitive. Delete the word. State the fact that made you
+reach for it. Do not compare the plugin with another plugin or product.
+
+Name every cost in the body. State an external service, a paid account, a
+separate install, or a limited operating system.
+
+This description is weak:
+
+```text
+A powerful plugin that makes code review seamless and easy.
+```
+
+This description is better:
+
+```text
+Puts a second model on every code review, so a bug has to survive two
+reviewers instead of one. Findings stay attached to the thread until you
+resolve them, and a thread with open findings cannot report a clean review.
+Runs on any provider you already installed.
+```
+
+The better text leads with the outcome. It then gives two concrete behaviors
+and one requirement. It holds no adjective that carries value.
+
+### Choose the tags
+
+Use no more than ten specific lowercase tags. Each tag holds a maximum of 32
+characters. Use hyphens inside a multiword tag. Repeat the words a user would
+search for. Do not repeat the display name. Do not repeat the category ID.
+
+### Name the author
 
 Set author.github to the account that opens the pull request. Get it with:
 
@@ -34,16 +92,14 @@ Use this shape only as a guide:
   "displayName": "Notes",
   "description": "Keeps project notes beside each BB thread.",
   "icon": { "url": "./icons/notes-1234abcd.svg" },
+  "screenshots": ["./screenshots/notes/overview.png"],
   "tags": ["notes", "interface"],
   "author": {
     "name": "Acme",
     "github": "acme",
     "url": "https://acme.example"
   },
-  "engines": {
-    "bb": ">=0.40.0",
-    "bbPluginSdk": ">=0.5.0"
-  },
+  "category": "thread-content",
   "source": {
     "git": {
       "url": "https://github.com/acme/bb-plugin-notes.git",
@@ -52,6 +108,15 @@ Use this shape only as a guide:
   }
 }
 ```
+
+## Choose the category
+
+Marketplace CI refuses a new or changed entry with no category. Set one
+category ID from the categories array in marketplace.base.json. Read that file
+for the current list. Do not invent a category ID.
+
+Pick the category for the surface a user gets, not for the code inside. Ask the
+user when two categories fit the plugin equally well.
 
 ## Add the icon
 
@@ -84,3 +149,78 @@ Use the first available command. Name the file
 
 If no suitable artwork exists, select a host icon from the current supported
 list. Do not invent a host icon name.
+
+## Add screenshots
+
+Add screenshots to every submission. The store detail page shows them, and a
+user judges a plugin by them before an install. An entry with no screenshot
+looks unfinished beside the entries around it.
+
+An entry can reference a maximum of six. Two or three good images beat six weak
+ones. Submit with no screenshot only when the plugin adds no visible surface,
+or when the user refuses the images. State that reason in the pull request
+body.
+
+### Choose what to show
+
+Lead with the surface a user gets first. Add one image for each further surface
+that a description cannot carry, such as a panel, a settings page, or a command
+result. Do not repeat one surface. Do not show a splash screen or a logo.
+
+### Capture the images
+
+Install the plugin in BB first. Capture the real plugin surface. Do not draw a
+mockup. Do not reuse marketing artwork.
+
+Use a browser or computer automation tool that the current harness supplies.
+Look for a browser control skill, a computer use tool, or a screenshot tool in
+the session. Drive BB with that tool. Open the plugin surface. Capture the
+image.
+
+If the harness supplies no such tool, ask the user for the images. Name each
+surface to capture. State the file rules below. Wait for the files. Do not
+submit an entry with no screenshots because a tool was absent.
+
+Capture at a device pixel ratio of 2 when the tool permits it. A community
+screenshot must be at least 1200 pixels wide. A narrow panel needs a wider
+window, or a capture of the window around it.
+
+Show real content in each image. Look at every image before you commit it.
+Remove private data such as tokens, email addresses, home directory paths, and
+unrelated thread text.
+
+### Follow the file rules
+
+Put each file in screenshots/<plugin-id>/. Use PNG, JPEG, or WebP. Make the
+file extension match the real image format. Keep each file at or below 2 MiB.
+Keep each image at least 1200 pixels wide.
+
+Reference each file from the entry with a relative path:
+
+```json
+"screenshots": ["./screenshots/notes/overview.png"]
+```
+
+The marketplace build rejects a file in screenshots/ that no entry references.
+Delete a file you do not reference. The build changes each local path to a CDN
+URL. Do not write a CDN URL yourself. An absolute URL must use HTTPS on
+getbb.app, so use a local path for a submission.
+
+## Check the entry quality
+
+Read the finished entry as a user who has never seen the plugin. Confirm each
+statement below before you open the pull request.
+
+- The hook states the outcome the user gets, not the mechanism.
+- The hook survives a two-line clamp without loss of its main point.
+- Each body sentence gives one distinct capability.
+- Every claim in the description matches behavior you observed.
+- The description names each external service, account, and separate install.
+- The category matches the surface the user gets.
+- The tags hold words a user would search for.
+- The icon reads clearly at 40 pixels.
+- The first screenshot shows the main surface with real content.
+- No field holds private data, a local path, or an internal URL.
+
+Fix the entry when one statement fails. Do not submit an entry you cannot
+defend.

--- a/apps/server/src/services/skills/builtin-skills/submit-a-plugin/references/pull-request.md
+++ b/apps/server/src/services/skills/builtin-skills/submit-a-plugin/references/pull-request.md
@@ -33,8 +33,10 @@ cd /SAFE/NEW/PATH/marketplace
 git switch -c submit-PLUGIN_ID
 ```
 
-Prepare and validate the entry and icon. Return their paths, the clone path,
-branch name, and results. Give the user these remaining steps:
+Prepare and validate the entry, icon, and screenshots.
+
+Return their paths, the clone path, branch name, and results. Give the user
+these remaining steps:
 
 1. Fork get-bb/marketplace.
 2. Add the fork as a remote.
@@ -52,26 +54,38 @@ npm run build
 npm run check
 git status --short
 git diff --check
-git diff -- entries/PLUGIN_ID.json icons/
+git diff -- entries/PLUGIN_ID.json icons/ screenshots/PLUGIN_ID/
 ```
+
+Omit each screenshots/PLUGIN_ID/ argument when the entry has no screenshots.
 
 Confirm:
 
 - The entry ID matches the filename and plugin manifest.
+- The entry holds no field that the schema rejects.
+- The category is one ID from marketplace.base.json.
+- The entry references at least one screenshot, or the pull request body states
+  why it has none.
 - The public source contains the selected release and reviewed code.
 - The source subdirectory is correct.
-- Entry engine ranges do not exceed manifest ranges.
 - The author account matches the pull request account.
-- The description states observed user value.
+- The description hook states observed user value, and survives a two-line
+  clamp.
+- The entry passes the quality check in references/marketplace-entry.md.
 - The icon meets size, format, location, and reference rules.
+- Each screenshot meets the width, size, format, location, and reference
+  rules, and shows no private data.
+- The screenshots directory holds no unreferenced file.
 - Both marketplace checks pass.
 
 ## Open the pull request
 
-Commit only the entry and icon. Do not commit dist/ or unrelated files.
+Commit only the entry, icon, and screenshots. Do not commit dist/ or
+unrelated files.
 
 ```sh
 git add entries/PLUGIN_ID.json icons/PLUGIN_ICON
+git add screenshots/PLUGIN_ID/
 git commit -m "Add plugin entry: PLUGIN_ID"
 git push -u origin submit-PLUGIN_ID
 ```
@@ -96,3 +110,4 @@ Follow the marketplace repository instructions. The pull request body must state
 - The plugin checks that passed.
 - The marketplace checks that passed.
 - Required permissions, external services, and relevant security facts.
+- What each screenshot shows, or why the entry has none.

--- a/apps/server/test/skills/submit-a-plugin.test.ts
+++ b/apps/server/test/skills/submit-a-plugin.test.ts
@@ -99,6 +99,34 @@ describe("submit-a-plugin skill", () => {
     expect(skill).not.toContain("PLUGIN_DISPLAY_NAME");
   });
 
+  it("captures screenshots with a harness tool and falls back to the user", async () => {
+    const skill = await readSkillTree();
+
+    expect(skill).toContain(
+      "Use a browser or computer automation tool that the current harness supplies.",
+    );
+    expect(skill).toContain(
+      "If the harness supplies no such tool, ask the user for the images.",
+    );
+    expect(skill).toContain("at least 1200 pixels wide");
+    expect(skill).toContain("at or below 2 MiB");
+    expect(skill).toContain("a maximum of six");
+  });
+
+  it("states the entry quality rules the store UI depends on", async () => {
+    const skill = await readSkillTree();
+
+    expect(skill).toContain("Write an App Store listing, not a README line.");
+    expect(skill).toContain(
+      "Do not use these words: powerful, seamless, easy, simple, fast, best, modern,",
+    );
+    expect(skill).toContain("clamps the description to two lines in a");
+    expect(skill).toContain(
+      "Marketplace CI refuses a new or changed entry with no category.",
+    );
+    expect(skill).toContain("The entry has no engines field");
+  });
+
   it("provides a local submission path without gh", async () => {
     const skill = await readSkillTree();
 


### PR DESCRIPTION
## Human comments

## What was wrong

The built-in `submit-a-plugin` skill described an entry contract that the marketplace rejects. Two defects blocked every submission it produced.

1. The sample entry carried an `engines` object, and two paragraphs told the agent to copy engine ranges from the plugin manifest and narrow them. Neither marketplace schema defines `engines`, and both set `additionalProperties: false`, so `npm run check` fails on any entry built from that sample.
2. The skill never mentioned `category`. `checkRequiredCategories` in the marketplace's `scripts/marketplace-lib.mjs` pushes an **error**, not a warning, for a *changed* entry file with no category. Every new submission is a changed file, so marketplace CI failed every time. All 122 live entries carry one.

The root cause of both is the same wrong pointer: the skill told the agent to read `schema/marketplace.schema.json` and "treat those files as the contract". That file is the frozen v1 output document, which CI compares against the live registry. Entry files use the v2 fields. v1 defines neither `category` nor `screenshots`, so an agent following the skill would conclude both fields were invalid.

Separately, the skill said nothing about screenshots, although the store detail page renders them. 5 of the 122 live entries have one.

## What changed

Guidance-only change to the skill, plus one test file. No product code.

**Contract fixes**
- `SKILL.md` points at `schema/marketplace-v2.schema.json` and states why v1 is not the entry contract. `marketplace.base.json` joins the contract list, since it holds the category IDs and nothing else the skill read did.
- `references/marketplace-entry.md` drops `engines`, lists the permitted and required fields explicitly, notes that the build writes `publishedAt`, and adds a "Choose the category" section.
- `references/pull-request.md` drops the now-stale "Entry engine ranges do not exceed manifest ranges" check and gains checks for the category, the schema-rejected-field case, and screenshots.

**Screenshots**
Capture is workflow step 6. The agent uses a browser or computer automation tool the harness supplies, and asks the user for the images when the harness has none — explicitly, it may not skip screenshots because a tool was absent. The reference carries the marketplace CI rules: max six, at least 1200 px wide, at or below 2 MiB, PNG/JPEG/WebP with a matching extension, no orphan files in `screenshots/`, local path only. It also tells the agent to look at each image and strip tokens, email addresses, and home directory paths before commit.

**Description quality**
New App Store-style guidance: a hook that must stand alone, then a body of one capability per sentence. This is anchored to real rendering rather than taste — a browse card clamps to `line-clamp-2` (`packages/shared-ui/src/components/ui/resource/collection.tsx:496`), a compact row truncates to one line (`resource/row.tsx:271`), and the detail page renders it unclamped (`apps/app/src/components/tools/PluginDetail.tsx:370`). The reference ends with a nine-item quality check to run before the pull request.

No wire change. `HOST_DAEMON_PROTOCOL_VERSION` is untouched; nothing here crosses the server/daemon boundary.

## How you verified

- `pnpm exec turbo run typecheck --filter=@bb/server` — 5 tasks successful.
- `pnpm exec turbo run test --filter=@bb/server --force -- test/skills/submit-a-plugin.test.ts test/skills/injected-skills.test.ts` — 20 passed.
- Fail-before proof: with `git checkout origin/main -- .../submit-a-plugin/`, the two new tests fail and the four pre-existing tests still pass (2 failed | 4 passed). Restored after.
- Every contract claim was checked against `get-bb/marketplace` at `43f25ef`, not from memory: the v2 entry properties, `checkRequiredCategories`, `validateScreenshotReference` (1200 px, 2 MiB, format match, orphan rejection), the category IDs in `marketplace.base.json`, and that `icons/README.md`, `npm run build`, and `npm run check` all exist.

## Not in this change

`marketplace-review` has the mirror-image gap — no screenshot check and no script beside `icon-check.mjs` — so nobody on the review side looks for private data in a submitted image.

> AGENT GENERATED
