### PR TITLE
Probe current model's reasoning ladder first in ACP-native discovery

### DIFF
--- a/packages/domain/src/plugin-sdk-version.ts
+++ b/packages/domain/src/plugin-sdk-version.ts
@@ -1,3 +1,3 @@
-export const PLUGIN_SDK_VERSION = "0.4.40";
+export const PLUGIN_SDK_VERSION = "0.4.41";
 
 export const PLUGIN_SDK_MAJOR = Number(PLUGIN_SDK_VERSION.split(".", 1)[0]);

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@get-bb/plugin-sdk",
-  "version": "0.4.40",
+  "version": "0.4.41",
   "homepage": "https://github.com/get-bb/bb#readme",
   "bugs": {
     "url": "https://github.com/get-bb/bb/issues"

--- a/packages/provider-bridge-acp/src/bridge/bridge.test.ts
+++ b/packages/provider-bridge-acp/src/bridge/bridge.test.ts
@@ -735,8 +735,8 @@ describe("acp bridge", () => {
       loggedAcpRequests(requestLog)
         .filter((request) => request.method === "session/set_config_option")
         .map((request) => request.params?.["value"])
-        .slice(0, 2),
-    ).toEqual(["grok-4.6", "grok-4.5"]);
+        .slice(0, 3),
+    ).toEqual(["default", "grok-4.6", "grok-4.5"]);
     expect(result.models.map((model) => model.id)).toEqual([
       "default",
       "composer-2.5",
@@ -1010,6 +1010,49 @@ describe("acp bridge", () => {
       { reasoningEffort: "medium", description: "medium" },
       { reasoningEffort: "high", description: "high" },
     ]);
+  });
+
+  it("probes the current model's reasoning ladder first under a tight discovery deadline", async () => {
+    vi.stubEnv("ACP_NATIVE_REASONING_DISCOVERY_TIMEOUT_MS", "500");
+    let modelListId: number;
+    try {
+      modelListId = sendModelList({
+        envVars: {
+          FAKE_ACP_MODEL_CONFIG: "1",
+          FAKE_ACP_THOUGHT_LEVEL_CONFIG: "1",
+          FAKE_ACP_MODEL_COUNT: "8",
+          FAKE_ACP_INITIAL_MODEL: "fake/gen-7",
+          FAKE_ACP_SET_CONFIG_MODEL_DELAY_MS: "150",
+        },
+      });
+
+      const result = (await waitForResponse(modelListId)).result as {
+        models: {
+          id: string;
+          supportedReasoningEfforts: { reasoningEffort: string }[];
+        }[];
+      };
+      const currentModel = result.models.find(
+        (model) => model.id === "fake/gen-7",
+      );
+      expect(currentModel?.supportedReasoningEfforts).toEqual([
+        { reasoningEffort: "low", description: "low" },
+        { reasoningEffort: "medium", description: "medium" },
+        { reasoningEffort: "high", description: "high" },
+      ]);
+      const unprobedNeighbor = result.models.find(
+        (model) => model.id === "fake/gen-2",
+      );
+      expect(unprobedNeighbor?.supportedReasoningEfforts).toEqual([
+        {
+          reasoningEffort: "medium",
+          description:
+            "Reasoning effort is managed by the connected ACP agent.",
+        },
+      ]);
+    } finally {
+      vi.unstubAllEnvs();
+    }
   });
 
   it("keeps ACP-native discovered models when per-model reasoning discovery errors", async () => {

--- a/packages/provider-bridge-acp/src/bridge/bridge.ts
+++ b/packages/provider-bridge-acp/src/bridge/bridge.ts
@@ -462,6 +462,14 @@ const ACP_DEFAULT_MODEL: AvailableModel = {
 
 const MODEL_LIST_TIMEOUT_MS = 30_000;
 const ACP_NATIVE_REASONING_DISCOVERY_TIMEOUT_MS = 5_000;
+function acpNativeReasoningDiscoveryTimeoutMs(): number {
+  const override = Number(
+    process.env.ACP_NATIVE_REASONING_DISCOVERY_TIMEOUT_MS,
+  );
+  return Number.isFinite(override) && override > 0
+    ? override
+    : ACP_NATIVE_REASONING_DISCOVERY_TIMEOUT_MS;
+}
 const AUTH_REQUIRED_MODEL_LIST_ERROR_MESSAGE =
   "ACP agent is not authenticated.";
 
@@ -911,6 +919,13 @@ async function discoverAcpNativeReasoningByModel(args: {
   );
   const modelsToProbe: typeof modelOptions = [];
   const addedModels = new Set<string>();
+  if (modelOption.currentValue !== undefined) {
+    const currentModel = modelByValue.get(modelOption.currentValue);
+    if (currentModel) {
+      modelsToProbe.push(currentModel);
+      addedModels.add(currentModel.value);
+    }
+  }
   for (const value of args.reasoningProbePriorityModelIds) {
     const model = modelByValue.get(value);
     if (model && !addedModels.has(model.value)) {
@@ -932,7 +947,7 @@ async function discoverAcpNativeReasoningByModel(args: {
     timeout = setTimeout(() => {
       args.connection.kill();
       resolve(supportByModel);
-    }, ACP_NATIVE_REASONING_DISCOVERY_TIMEOUT_MS);
+    }, acpNativeReasoningDiscoveryTimeoutMs());
   });
 
   try {

--- a/packages/provider-bridge-acp/src/bridge/fake-acp-agent.mjs
+++ b/packages/provider-bridge-acp/src/bridge/fake-acp-agent.mjs
@@ -24,14 +24,20 @@
  * - FAKE_ACP_MODELS_FIELD=1  → advertise legacy ACP models state
  * - FAKE_ACP_THOUGHT_LEVEL_CONFIG=1
  *                            → advertise per-model effort configOptions
- * - FAKE_ACP_INITIAL_FAST    → set the initial Fast mode value
+ * - FAKE_ACP_INITIAL_MODEL    → set the initial selected model (the model
+ *                              config option's currentValue)
  * - FAKE_ACP_UNMAPPED_REASONING_CONFIG=1
  *                            → advertise unmapped thought_level values
  * - FAKE_ACP_ACCEPT_NATIVE_REASONING=1
  *                            → accept reasoning_effort config updates without
  *                              advertising a thought_level config option
  * - FAKE_ACP_SET_CONFIG_MODEL_ERROR=1
- *                            → fail session/set_config_option for model values
+ *                            → fail session/set_config_option for model
+ *                              values
+ * - FAKE_ACP_SET_CONFIG_MODEL_DELAY_MS=<ms>
+ *                            → answer model config probes only after this
+ *                              delay
+ * - FAKE_ACP_INITIAL_FAST    → set the initial Fast mode value
  * - FAKE_ACP_SET_CONFIG_FAST_ERROR=1
  *                            → fail session/set_config_option for Fast values
  * - FAKE_ACP_CURSOR_PARAMETERIZED_MODELS=1
@@ -84,7 +90,11 @@ const unmappedReasoningConfig =
 const acceptNativeReasoning =
   process.env.FAKE_ACP_ACCEPT_NATIVE_REASONING === "1";
 const setConfigModelError = process.env.FAKE_ACP_SET_CONFIG_MODEL_ERROR === "1";
+const initialModel = process.env.FAKE_ACP_INITIAL_MODEL;
 const setConfigFastError = process.env.FAKE_ACP_SET_CONFIG_FAST_ERROR === "1";
+const setConfigModelDelayMs = Number(
+  process.env.FAKE_ACP_SET_CONFIG_MODEL_DELAY_MS ?? "0",
+);
 const cursorParameterizedModels =
   process.env.FAKE_ACP_CURSOR_PARAMETERIZED_MODELS === "1";
 const requestLog = process.env.FAKE_ACP_REQUEST_LOG;
@@ -140,6 +150,13 @@ for (let i = fakeModels.length; i < modelCount; i += 1) {
   const value = `fake/gen-${i}`;
   fakeModels.push({ value, name: `Fake Gen ${i}` });
   effortsByModel.set(value, ["low", "medium", "high"]);
+}
+
+if (
+  initialModel !== undefined &&
+  fakeModels.some((model) => model.value === initialModel)
+) {
+  selectedModel = initialModel;
 }
 
 process.on("SIGTERM", () => {
@@ -761,6 +778,9 @@ async function handleMessage(message) {
             error: { code: -32602, message: `model not found: ${value}` },
           });
           return;
+        }
+        if (setConfigModelDelayMs > 0) {
+          await sleep(setConfigModelDelayMs);
         }
         selectedModel = value;
         send({ jsonrpc: "2.0", id: message.id, result: configState() });


### PR DESCRIPTION
## Problem

When an ACP agent exposes a large model catalog, most models show only a **Medium** reasoning effort in the model picker, even though the agent advertises a full ladder (low/medium/high/…) per model.

Root cause: `discoverAcpNativeReasoningByModel` probes models **serially** for their `thought_level` options under a fixed 5s budget (`ACP_NATIVE_REASONING_DISCOVERY_TIMEOUT_MS = 5_000`). With a 374-model catalog (current omp), the probe reaches only the first ~10–50 models before the deadline; every unprobed model falls back to the medium-only `ACP_NATIVE_REASONING_EFFORTS` entry. The session's **currently selected model** is frequently deep in the list (e.g. `zai/*` sorts last), so the model the user is actually on is the least likely to have real reasoning levels.

## Change

1. **Probe the current model first.** `modelsToProbe` is now seeded with the model config option's `currentValue` (already captured at `session/new`) before the `reasoningProbePriorityModelIds` ordering. The active model always gets its real ladder within budget.
2. **Env-overridable discovery deadline** — `acpNativeReasoningDiscoveryTimeoutMs()` reads `ACP_NATIVE_REASONING_DISCOVERY_TIMEOUT_MS` (default `5_000` unchanged), mirroring the `sessionBusyRetryTimeoutMs()` pattern. Operators with small catalogs can raise it; tests can shrink it.

Non-current model ordering is unchanged. No behavior change for clients that don't hit the deadline.

## Tests

- New: "probes the current model's reasoning ladder first under a tight discovery deadline" — 500ms deadline, 8-model fixture with 150ms probe latency, current model at position 8. Asserts the current model reports its real `[low, medium, high]` ladder while an unprobed neighbor keeps the medium-only fallback.
  - Kill 1 (revert priority seeding): current model never probed → real-ladder assertion fails.
  - Kill 2 (revert env helper to fixed 5s): all probes complete → unprobed-neighbor fallback assertion fails.
- Updated: the Cursor probe-order test now expects `currentValue` (`"default"`) first — the seeding change legitimately reorders it.
- Fixture knobs: `FAKE_ACP_INITIAL_MODEL` (set the model option's `currentValue`) and `FAKE_ACP_SET_CONFIG_MODEL_DELAY_MS` (per-probe latency), documented in the fixture header.

A follow-up PR will make probing fully lazy (capture reasoning levels from `session/set_config_option` responses on model switch) so every model a user touches gets real levels without eager discovery.

- Suite: 312/312 · typecheck · oxfmt · version guard PASS (SDK 0.4.41)
