### PR TITLE
Fix mobile sidebar close animation

### DIFF
--- a/apps/app/src/components/ui/sidebar.test.tsx
+++ b/apps/app/src/components/ui/sidebar.test.tsx
@@ -476,7 +476,7 @@ describe("mobile sidebar shelf stacking", () => {
 });
 
 describe("mobile sidebar persistence", () => {
-  it("closes from a left swipe that starts on the exposed main content", () => {
+  it("closes from an exposed-content swipe after committing the closed state", () => {
     vi.useFakeTimers();
     renderCompactSidebarHarness();
 
@@ -485,14 +485,30 @@ describe("mobile sidebar persistence", () => {
 
     const panel = getMobilePanel();
     const backdrop = screen.getByTestId("sidebar-mobile-backdrop");
+    const inset = document.querySelector('[data-sidebar="inset"]');
+    if (!(inset instanceof HTMLElement)) {
+      throw new Error("Expected a page inset");
+    }
+    const shelfStatesAtDragStyleClear: string[] = [];
+    const removeInsetAttribute = inset.removeAttribute.bind(inset);
+    vi.spyOn(inset, "removeAttribute").mockImplementation((name) => {
+      if (name === "data-vaul-animate") {
+        shelfStatesAtDragStyleClear.push(
+          inset.dataset.sidebarShelf ?? "missing",
+        );
+      }
+      removeInsetAttribute(name);
+    });
     expect(panel?.dataset.state).toBe("open");
 
     fireTouch(backdrop, "touchstart", createTouch(360, 160));
     fireTouch(window, "touchmove", createTouch(180, 164));
     fireTouchEnd(window, createTouch(180, 164));
+    expect(inset.getAttribute("data-vaul-animate")).toBe("false");
     settleMobileToggle();
 
     expect(panel?.dataset.state).toBe("closed");
+    expect(shelfStatesAtDragStyleClear).toEqual(["closed"]);
     act(() => {
       vi.advanceTimersByTime(400);
     });

--- a/apps/app/src/components/ui/use-horizontal-dismiss-drag.ts
+++ b/apps/app/src/components/ui/use-horizontal-dismiss-drag.ts
@@ -143,8 +143,9 @@ export function useHorizontalDismissDrag(options: Options) {
         settleTimeoutRef.current = null;
         if (dismiss && current.dismissTiming === "settled") {
           optionsRef.current.onDismiss();
+        } else {
+          optionsRef.current.onClear();
         }
-        optionsRef.current.onClear();
       }, DRAG_SETTLE_MS);
     },
     [clearSettle, optionsRef],


### PR DESCRIPTION
## Human comments

## What was wrong

A settled swipe requested the sidebar close and immediately cleared its inline drag transform before React committed the closed state. The still-open CSS could briefly restore the sidebar's open position, followed by the real closed-state transition, which produced the intermittent double close animation.

## What changed

The horizontal dismiss hook now retains the settled swipe transform when dismissal is deferred until the end of the animation. The sidebar's existing closed-state lifecycle clears the drag styles after React commits, while cancelled and non-settled drag paths still clear immediately. A focused regression records the shelf state when the drag animation attribute is removed and verifies it is already closed. This is app-local behavior with no server/daemon wire change, so HOST_DAEMON_PROTOCOL_VERSION is unchanged.

## How you verified

- Added a regression that fails with the previous cleanup ordering and passes with the fix.
- `pnpm exec turbo run test --filter=@bb/app -- --run src/components/ui/sidebar.test.tsx src/components/secondary-panel/CompactSecondaryPanelShelf.test.tsx` — 41 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/app` — passed.
- `pnpm exec turbo run lint --filter=@bb/app` — passed with 0 errors.
- `git diff --check origin/main...HEAD` — passed.

> AGENT GENERATED
