### PR TITLE
Bound and clear the ACP compaction prose buffer

### DIFF
--- a/packages/domain/src/plugin-sdk-version.ts
+++ b/packages/domain/src/plugin-sdk-version.ts
@@ -1,3 +1,3 @@
-export const PLUGIN_SDK_VERSION = "0.4.40";
+export const PLUGIN_SDK_VERSION = "0.4.41";
 
 export const PLUGIN_SDK_MAJOR = Number(PLUGIN_SDK_VERSION.split(".", 1)[0]);

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@get-bb/plugin-sdk",
-  "version": "0.4.40",
+  "version": "0.4.41",
   "homepage": "https://github.com/get-bb/bb#readme",
   "bugs": {
     "url": "https://github.com/get-bb/bb/issues"

--- a/packages/provider-bridge-acp/src/bridge/bridge.test.ts
+++ b/packages/provider-bridge-acp/src/bridge/bridge.test.ts
@@ -2531,6 +2531,78 @@ describe("acp bridge", () => {
     expect(threadEventsOfType("thread/compacted")).toEqual([]);
   });
 
+  it("classifies failure prose that arrives within the compaction buffer cap", async () => {
+    const { providerThreadId } = await startThread({
+      dialectId: "omp",
+      envVars: {
+        FAKE_ACP_COMPACT_AGENT_MESSAGE: `Compaction failed: summary model rejected the request ${"x".repeat(70_000)}`,
+      },
+    });
+
+    const turnId = sendTurnRequest("turn/start", providerThreadId, {
+      input: compactCommandInput(),
+    });
+    expect((await waitForResponse(turnId)).error).toBeUndefined();
+
+    const completed = await waitForTurnCompleted();
+    expect(completed).toMatchObject({
+      status: "failed",
+      error: { message: expect.stringContaining("summary model rejected") },
+    });
+    expect(threadEventsOfType("thread/compacted")).toEqual([]);
+  });
+
+  it("ignores failure prose that arrives past the compaction buffer cap", async () => {
+    const { providerThreadId } = await startThread({
+      dialectId: "omp",
+      envVars: {
+        FAKE_ACP_COMPACT_AGENT_MESSAGE: `${"x".repeat(70_000)} Compaction failed: summary model rejected the request`,
+      },
+    });
+
+    const turnId = sendTurnRequest("turn/start", providerThreadId, {
+      input: compactCommandInput(),
+    });
+    expect((await waitForResponse(turnId)).error).toBeUndefined();
+
+    const completed = await waitForTurnCompleted();
+    expect(completed).toMatchObject({ status: "completed" });
+    expect(threadEventsOfType("thread/compacted")).toHaveLength(1);
+  });
+
+  it("clears the compaction message buffer between compactions", async () => {
+    const { providerThreadId } = await startThread({
+      dialectId: "omp",
+      envVars: {
+        FAKE_ACP_COMPACT_AGENT_MESSAGES: JSON.stringify([
+          "Compaction failed: summary model rejected the request",
+          "Context compacted; the session is smaller now.",
+        ]),
+      },
+    });
+
+    const firstTurnId = sendTurnRequest("turn/start", providerThreadId, {
+      input: compactCommandInput(),
+    });
+    expect((await waitForResponse(firstTurnId)).error).toBeUndefined();
+    expect(await waitForTurnCompleted()).toMatchObject({ status: "failed" });
+
+    const completedCount = threadEventsOfType("turn/completed").length;
+    const secondTurnId = sendTurnRequest("turn/start", providerThreadId, {
+      input: compactCommandInput(),
+    });
+    expect((await waitForResponse(secondTurnId)).error).toBeUndefined();
+    const secondCompleted = await waitFor(
+      () =>
+        threadEventsOfType("turn/completed").length > completedCount
+          ? threadEventsOfType("turn/completed").at(-1)
+          : undefined,
+      "second turn/completed thread event",
+    );
+    expect(secondCompleted).toMatchObject({ status: "completed" });
+    expect(threadEventsOfType("thread/compacted")).toHaveLength(1);
+  });
+
   it("accepts turn input only after the prompt carrying it goes out", async () => {
     const { providerThreadId } = await startThread();
     const turnId = sendTurnRequest("turn/start", providerThreadId, {

--- a/packages/provider-bridge-acp/src/bridge/bridge.ts
+++ b/packages/provider-bridge-acp/src/bridge/bridge.ts
@@ -63,6 +63,7 @@ import {
   type AcpDeltaTranslator,
 } from "../delta-translation.js";
 import {
+  collectsCompactionAgentMessage,
   compactionOutcomeForEndTurn,
   resolveAcpDialect,
   type AcpDialect,
@@ -2097,12 +2098,12 @@ function runTurn(
   })();
 }
 
+const COMPACTION_AGENT_MESSAGE_CAP = 64 * 1024;
 function startCompaction(
   session: AcpThreadSession,
   pending: AcpPendingTurnInput,
 ): void {
   session.activePromptKind = "compaction";
-  session.compactionAgentMessage = "";
   emitForSession(session, ACP_COMPACTION_STARTED_METHOD, {
     threadId: session.bbThreadId,
   });
@@ -2158,6 +2159,7 @@ function finishCompaction(
   });
   session.activePromptKind = null;
   session.turnSettled = undefined;
+  session.compactionAgentMessage = "";
 }
 
 function handleAgentRequest(
@@ -2242,13 +2244,21 @@ function handleAgentNotification(
   if (parsed.data.sessionId !== session.providerThreadId) {
     return;
   }
-  if (session.activePromptKind === "compaction") {
+  if (
+    session.activePromptKind === "compaction" &&
+    collectsCompactionAgentMessage(session.dialect)
+  ) {
     const chunk = acpAgentMessageChunkUpdateSchema.safeParse(
       parsed.data.update,
     );
-    if (chunk.success) {
-      session.compactionAgentMessage +=
-        extractAcpContentText(chunk.data.content) ?? "";
+    if (
+      chunk.success &&
+      session.compactionAgentMessage.length < COMPACTION_AGENT_MESSAGE_CAP
+    ) {
+      session.compactionAgentMessage = (
+        session.compactionAgentMessage +
+        (extractAcpContentText(chunk.data.content) ?? "")
+      ).slice(0, COMPACTION_AGENT_MESSAGE_CAP);
     }
   }
   emitForSession(session, ACP_UPDATE_METHOD, update);

--- a/packages/provider-bridge-acp/src/bridge/fake-acp-agent.mjs
+++ b/packages/provider-bridge-acp/src/bridge/fake-acp-agent.mjs
@@ -63,6 +63,11 @@
  *                              count model-discovery spawns in cache/TTL tests)
  * - FAKE_ACP_PROMPT_LOG      → append one JSON-encoded prompt text per request
  * - FAKE_ACP_PROMPT_ERROR=1  → reject every session/prompt request
+ * - FAKE_ACP_COMPACT_AGENT_MESSAGE
+ *                            → agent message chunk to emit for /compact
+ * - FAKE_ACP_COMPACT_AGENT_MESSAGES
+ *                            → JSON string array; one message per /compact
+ *                              request, repeating the last once exhausted
  * - FAKE_ACP_COMPACT_STOP_REASON
  *                            → stop reason returned for /compact
  */
@@ -128,6 +133,11 @@ let selectedFast = process.env.FAKE_ACP_INITIAL_FAST ?? "false";
 let clientSupportsParameterizedModels = false;
 let authenticatedMethod = null;
 let activeSessionId = sessionId;
+let compactRequestCount = 0;
+const compactMessages =
+  process.env.FAKE_ACP_COMPACT_AGENT_MESSAGES === undefined
+    ? undefined
+    : JSON.parse(process.env.FAKE_ACP_COMPACT_AGENT_MESSAGES);
 const pendingClientRequests = new Map();
 let currentMcpServers = [];
 
@@ -434,10 +444,16 @@ async function handlePrompt(message) {
 
   if (text === "/compact") {
     // OpenCode treats this exact prompt as a provider-local control.
-    const compactMessage = process.env.FAKE_ACP_COMPACT_AGENT_MESSAGE;
+    const compactMessage =
+      compactMessages === undefined
+        ? process.env.FAKE_ACP_COMPACT_AGENT_MESSAGE
+        : compactMessages[
+            Math.min(compactRequestCount, compactMessages.length - 1)
+          ];
     if (compactMessage !== undefined) {
       notifyUpdate(messageChunk(compactMessage));
     }
+    compactRequestCount += 1;
   } else if (text.includes("request-external-directory-permission")) {
     // opencode's external_directory permission: the running edit tool asks
     // with the generic kind "other", a bare directory title, and

--- a/packages/provider-bridge-acp/src/dialect.ts
+++ b/packages/provider-bridge-acp/src/dialect.ts
@@ -323,6 +323,10 @@ export const OMP_ACP_DIALECT: AcpDialect = {
   commandResult: ompCommandResult,
 };
 
+export function collectsCompactionAgentMessage(dialect: AcpDialect): boolean {
+  return dialect.id === OMP_ACP_DIALECT.id;
+}
+
 const openCodeCommandRawOutputSchema = z
   .object({
     output: z.unknown().optional(),


### PR DESCRIPTION
> AGENT GENERATED

## Human comments

Follow-up to #2293, addressing the two review findings SlopCop left on the merged commit (`eece92f8`):

1. **Major — "OMP text rule applies to all ACP agents":** already fixed on main by #2957, which moved end-turn compaction classification behind the dialect (`compactionOutcomeForEndTurn(dialect, …)` with `dialect.id !== "omp"` short-circuiting to `completed`). No further change needed; this PR builds on that shape.
2. **Medium — "unbounded compaction message text, no cleanup in finishCompaction":** still open on main; this PR fixes it.

## What was wrong

- `handleAgentNotification` accumulated every `agent_message_chunk` streamed during a compaction prompt into `session.compactionAgentMessage` for **every** dialect, even though only the omp dialect ever reads the text — unbounded growth on a long-lived session.
- The accumulation had no size limit.
- The buffer was only reset at `startCompaction`, so after a compaction completed, the text stayed resident until the next compaction began.

## What changed

- Accumulation is now gated on `collectsCompactionAgentMessage(session.dialect)` — the dialect module owns the "does this dialect parse compaction prose" decision, so non-omp dialects carry no classifier state at all.
- Accumulation clamps at 64 KiB (`COMPACTION_AGENT_MESSAGE_CAP`), keeping the head of the message: omp's failure/no-op prose ("Compaction failed: …", "Nothing to compact") leads its compaction report.
- The buffer is cleared in `finishCompaction` — the single settlement funnel that success, failure, and interrupt all route through. The now-redundant reset at `startCompaction` is removed; session-creation initialization covers the first compaction.
- `fake-acp-agent.mjs` gains `FAKE_ACP_COMPACT_AGENT_MESSAGES` (JSON string array; one message per `/compact` request, last entry repeats) so one session can exercise sequential compactions with different prose.
- SDK bump 0.4.40 → 0.4.41 (bridge dist output changes).

## How you verified

- Three new regression tests, each mutation-checked (revert the guard, confirm the test fails, restore):
  - failure prose within the cap still classifies the turn failed — kills a tail-keeping clamp;
  - failure prose past the cap is ignored and the turn completes with `thread/compacted` — kills cap removal;
  - a second compaction in the same session classifies independently after a failed first one — kills removal of the `finishCompaction` clear.
- The accumulation dialect gate is behaviorally invisible by construction (no non-omp code reads the buffer), so it is covered by #2957's existing generic/OpenCode `completed`-outcome regressions rather than a test that could not fail.
- Package gates: `turbo run test typecheck --filter=@bb/provider-bridge-acp --force` — 18/18 test files, typecheck clean; `oxfmt --check` clean; `oxlint` zero new findings (the pre-existing `bb(no-comments)` hits in the `.mjs` harness are identical to main: 15 before, 15 after); `check-npm-version-guard` PASS at 0.4.41.
