### PR TITLE
Simplify thread fork environment selection

### DIFF
--- a/apps/cli/src/__tests__/command-output/thread-fork.test.ts
+++ b/apps/cli/src/__tests__/command-output/thread-fork.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   collectLogLines,
+  getHelpOutput,
   runCommand,
   setupCommandOutputTestEnvironment,
   stubServerApi,
@@ -154,54 +155,10 @@ describe("bb thread fork command output", () => {
     });
   });
 
-  it("resolves an explicit host for a new worktree", async () => {
-    const thread = fixtures.makeThread({
-      id: "thread-fork-host",
-      originKind: "fork",
-      projectId: "proj-1",
-      providerId: "codex",
-      sourceThreadId: "thread-source",
-    });
-    const post = vi.fn(async () => thread);
-    stubServerApi({
-      "v1.hosts.$get": vi.fn(async () => [
-        {
-          id: "host-source",
-          name: "builder",
-          type: "persistent",
-          status: "connected",
-          lastSeenAt: 1,
-          createdAt: 1,
-          updatedAt: 1,
-        },
-      ]),
-      "v1.threads.fork.$post": post,
-    });
+  it("does not offer a host selector", async () => {
+    const help = await getHelpOutput(["thread", "fork"], register);
 
-    await runCommand(
-      [
-        "thread",
-        "fork",
-        "thread-source",
-        "--new-environment",
-        "worktree",
-        "--host",
-        "builder",
-      ],
-      register,
-    );
-
-    expect(post).toHaveBeenCalledWith({
-      json: expect.objectContaining({
-        environment: {
-          type: "host",
-          hostId: "host-source",
-          workspace: {
-            type: "managed-worktree",
-            baseBranch: { kind: "default" },
-          },
-        },
-      }),
-    });
+    expect(help).not.toContain("--host");
+    expect(help).not.toContain("--machine");
   });
 });

--- a/apps/cli/src/__tests__/command-output/thread-fork.test.ts
+++ b/apps/cli/src/__tests__/command-output/thread-fork.test.ts
@@ -15,7 +15,7 @@ describe("bb thread fork command output", () => {
   const register: CommandRegistrar = (program) =>
     registerThreadCommands(program, () => "http://server");
 
-  it("creates an idle isolated fork by default", async () => {
+  it("creates an idle source-environment fork by default", async () => {
     const thread = fixtures.makeThread({
       id: "thread-fork-idle",
       originKind: "fork",
@@ -33,7 +33,6 @@ describe("bb thread fork command output", () => {
       json: {
         sourceThreadId: "thread-source",
         origin: "cli",
-        workspace: "isolated",
         visibility: "visible",
       },
     });
@@ -42,7 +41,7 @@ describe("bb thread fork command output", () => {
     );
   });
 
-  it("forwards input, seed, fork point, permissions, visibility, and workspace", async () => {
+  it("forwards input, seed, fork point, permissions, visibility, and environment", async () => {
     const thread = fixtures.makeThread({
       id: "thread-fork-input",
       originKind: "fork",
@@ -69,8 +68,8 @@ describe("bb thread fork command output", () => {
         "accept-edits",
         "--visibility",
         "hidden",
-        "--workspace",
-        "reuse",
+        "--environment",
+        "env-fork",
       ],
       register,
     );
@@ -91,11 +90,118 @@ describe("bb thread fork command output", () => {
         origin: "cli",
         permissionMode: "accept-edits",
         visibility: "hidden",
-        workspace: "reuse",
+        environment: { type: "reuse", environmentId: "env-fork" },
       }),
     });
     expect(collectLogLines(vi.mocked(console.log))).toContain(
       "Visibility: hidden",
     );
+  });
+
+  it("creates a worktree on the source host when no host is explicit", async () => {
+    const source = fixtures.makeThread({
+      id: "thread-source",
+      environmentId: "env-source",
+      projectId: "proj-1",
+      providerId: "codex",
+    });
+    const sourceEnvironment = fixtures.makeEnvironment({
+      id: "env-source",
+      hostId: "host-source",
+      projectId: "proj-1",
+    });
+    const thread = fixtures.makeThread({
+      id: "thread-fork-worktree",
+      originKind: "fork",
+      projectId: "proj-1",
+      providerId: "codex",
+      sourceThreadId: source.id,
+    });
+    const post = vi.fn(async () => thread);
+    stubServerApi({
+      "v1.threads.:id.$get": vi.fn(async () => source),
+      "v1.environments.:id.$get": vi.fn(async () => sourceEnvironment),
+      "v1.threads.fork.$post": post,
+    });
+
+    await runCommand(
+      [
+        "thread",
+        "fork",
+        source.id,
+        "--new-environment",
+        "worktree",
+        "--base-branch",
+        "origin/release",
+      ],
+      register,
+    );
+
+    expect(post).toHaveBeenCalledWith({
+      json: {
+        sourceThreadId: source.id,
+        origin: "cli",
+        visibility: "visible",
+        environment: {
+          type: "host",
+          hostId: "host-source",
+          workspace: {
+            type: "managed-worktree",
+            baseBranch: { kind: "named", name: "origin/release" },
+          },
+        },
+      },
+    });
+  });
+
+  it("resolves an explicit host for a new worktree", async () => {
+    const thread = fixtures.makeThread({
+      id: "thread-fork-host",
+      originKind: "fork",
+      projectId: "proj-1",
+      providerId: "codex",
+      sourceThreadId: "thread-source",
+    });
+    const post = vi.fn(async () => thread);
+    stubServerApi({
+      "v1.hosts.$get": vi.fn(async () => [
+        {
+          id: "host-source",
+          name: "builder",
+          type: "persistent",
+          status: "connected",
+          lastSeenAt: 1,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ]),
+      "v1.threads.fork.$post": post,
+    });
+
+    await runCommand(
+      [
+        "thread",
+        "fork",
+        "thread-source",
+        "--new-environment",
+        "worktree",
+        "--host",
+        "builder",
+      ],
+      register,
+    );
+
+    expect(post).toHaveBeenCalledWith({
+      json: expect.objectContaining({
+        environment: {
+          type: "host",
+          hostId: "host-source",
+          workspace: {
+            type: "managed-worktree",
+            baseBranch: { kind: "default" },
+          },
+        },
+      }),
+    });
   });
 });

--- a/apps/cli/src/commands/thread/fork.ts
+++ b/apps/cli/src/commands/thread/fork.ts
@@ -8,10 +8,6 @@ import type { EnvironmentArgs } from "@bb/server-contract";
 import { action } from "../../action.js";
 import { createCliBbSdk } from "../../client.js";
 import { resolveExplicitIdFlag } from "../../context-env.js";
-import {
-  resolveMachineHostId,
-  resolveMachineTargetOption,
-} from "../machine.js";
 import { outputJson, prependErrorContext } from "../helpers.js";
 import {
   buildPromptInputs,
@@ -30,10 +26,8 @@ interface ThreadForkCommandOptions {
   baseBranch?: string;
   environment?: string;
   file?: string[];
-  host?: string;
   image?: string[];
   json?: boolean;
-  machine?: string;
   newEnvironment?: string;
   permissionMode?: string;
   prompt?: string;
@@ -119,11 +113,6 @@ export function registerForkCommand(
       "--base-branch <branch>",
       "Exact Git ref; omit for bb's project default (use origin/<branch> for a remote ref)",
     )
-    .option(
-      "--machine <id-or-name>",
-      "Execution machine ID or unambiguous name",
-    )
-    .option("--host <id-or-name>", "Alias for --machine")
     .option("--permission-mode <mode>", PERMISSION_MODE_HELP)
     .option("--visibility <visibility>", "Thread visibility: visible or hidden")
     .option(
@@ -163,25 +152,6 @@ export function registerForkCommand(
           const environmentValue = resolveSpawnEnvironmentValue(
             opts.environment,
           );
-          const machineTarget = resolveMachineTargetOption(opts);
-          if (
-            machineTarget &&
-            environmentValue &&
-            !looksLikePath(environmentValue)
-          ) {
-            throw new Error(
-              "Cannot combine --machine or --host with an existing environment ID; that environment already selects its machine.",
-            );
-          }
-          if (
-            machineTarget &&
-            environmentValue === undefined &&
-            opts.newEnvironment === undefined
-          ) {
-            throw new Error(
-              "--machine or --host requires --new-environment or an unmanaged --environment path.",
-            );
-          }
 
           let thread: Thread;
           let environment: EnvironmentArgs | undefined;
@@ -192,12 +162,7 @@ export function registerForkCommand(
               (environmentValue !== undefined &&
                 looksLikePath(environmentValue));
             const hostId = needsHostId
-              ? machineTarget
-                ? await resolveMachineHostId({
-                    serverUrl: getUrl(),
-                    target: machineTarget,
-                  })
-                : await resolveForkSourceHostId(sdk, sourceThreadId)
+              ? await resolveForkSourceHostId(sdk, sourceThreadId)
               : null;
             environment =
               environmentValue === undefined &&

--- a/apps/cli/src/commands/thread/fork.ts
+++ b/apps/cli/src/commands/thread/fork.ts
@@ -4,9 +4,14 @@ import {
   type PromptInput,
   type Thread,
 } from "@bb/domain";
+import type { EnvironmentArgs } from "@bb/server-contract";
 import { action } from "../../action.js";
 import { createCliBbSdk } from "../../client.js";
 import { resolveExplicitIdFlag } from "../../context-env.js";
+import {
+  resolveMachineHostId,
+  resolveMachineTargetOption,
+} from "../machine.js";
 import { outputJson, prependErrorContext } from "../helpers.js";
 import {
   buildPromptInputs,
@@ -14,18 +19,27 @@ import {
   parsePermissionMode,
   PERMISSION_MODE_HELP,
 } from "./helpers.js";
+import {
+  buildSpawnEnvironment,
+  looksLikePath,
+  resolveSpawnEnvironmentValue,
+} from "./spawn.js";
 
 interface ThreadForkCommandOptions {
   agentContextSeed?: string;
+  baseBranch?: string;
+  environment?: string;
   file?: string[];
+  host?: string;
   image?: string[];
   json?: boolean;
+  machine?: string;
+  newEnvironment?: string;
   permissionMode?: string;
   prompt?: string;
   sourceSeqEnd?: string;
   title?: string;
   visibility?: string;
-  workspace?: string;
 }
 
 function parseSourceSeqEnd(value: string | undefined): number | undefined {
@@ -35,14 +49,6 @@ function parseSourceSeqEnd(value: string | undefined): number | undefined {
     throw new Error("--source-seq-end must be a non-negative integer.");
   }
   return parsed;
-}
-
-function parseWorkspace(value: string | undefined): "isolated" | "reuse" {
-  const workspace = value ?? "isolated";
-  if (workspace !== "isolated" && workspace !== "reuse") {
-    throw new Error("--workspace must be isolated or reuse.");
-  }
-  return workspace;
 }
 
 function buildForkInput(
@@ -62,6 +68,32 @@ function buildForkInput(
   ];
 }
 
+async function resolveForkSourceHostId(
+  sdk: ReturnType<typeof createCliBbSdk>,
+  sourceThreadId: string,
+): Promise<string> {
+  const sourceThread = await sdk.threads.get({ threadId: sourceThreadId });
+  if (sourceThread.environmentId === null) {
+    throw new Error("Source thread has no environment.");
+  }
+  const sourceEnvironment = await sdk.environments.get({
+    environmentId: sourceThread.environmentId,
+  });
+  return sourceEnvironment.hostId;
+}
+
+function describeForkEnvironment(
+  environment: EnvironmentArgs | undefined,
+): string {
+  if (environment === undefined) return "source environment";
+  if (environment.type === "reuse") return environment.environmentId;
+  if (environment.workspace.type === "managed-worktree") {
+    return "new worktree";
+  }
+  if (environment.workspace.type === "personal") return "new personal";
+  return environment.workspace.path ?? "host project source";
+}
+
 export function registerForkCommand(
   parent: Command,
   getUrl: () => string,
@@ -75,7 +107,23 @@ export function registerForkCommand(
       "--source-seq-end <seq>",
       "Fork after the source turn containing this event sequence",
     )
-    .option("--workspace <mode>", "Workspace: isolated (default) or reuse")
+    .option(
+      "--environment <id-or-path>",
+      "Existing environment ID or unmanaged workspace path",
+    )
+    .option(
+      "--new-environment <kind>",
+      "Create a new managed environment of the given kind (worktree)",
+    )
+    .option(
+      "--base-branch <branch>",
+      "Exact Git ref; omit for bb's project default (use origin/<branch> for a remote ref)",
+    )
+    .option(
+      "--machine <id-or-name>",
+      "Execution machine ID or unambiguous name",
+    )
+    .option("--host <id-or-name>", "Alias for --machine")
     .option("--permission-mode <mode>", PERMISSION_MODE_HELP)
     .option("--visibility <visibility>", "Thread visibility: visible or hidden")
     .option(
@@ -112,14 +160,61 @@ export function registerForkCommand(
             opts.visibility === undefined
               ? undefined
               : threadVisibilitySchema.parse(opts.visibility);
-          const workspace = parseWorkspace(opts.workspace);
+          const environmentValue = resolveSpawnEnvironmentValue(
+            opts.environment,
+          );
+          const machineTarget = resolveMachineTargetOption(opts);
+          if (
+            machineTarget &&
+            environmentValue &&
+            !looksLikePath(environmentValue)
+          ) {
+            throw new Error(
+              "Cannot combine --machine or --host with an existing environment ID; that environment already selects its machine.",
+            );
+          }
+          if (
+            machineTarget &&
+            environmentValue === undefined &&
+            opts.newEnvironment === undefined
+          ) {
+            throw new Error(
+              "--machine or --host requires --new-environment or an unmanaged --environment path.",
+            );
+          }
 
           let thread: Thread;
+          let environment: EnvironmentArgs | undefined;
           try {
-            thread = await createCliBbSdk(getUrl()).threads.fork({
+            const sdk = createCliBbSdk(getUrl());
+            const needsHostId =
+              Boolean(opts.newEnvironment) ||
+              (environmentValue !== undefined &&
+                looksLikePath(environmentValue));
+            const hostId = needsHostId
+              ? machineTarget
+                ? await resolveMachineHostId({
+                    serverUrl: getUrl(),
+                    target: machineTarget,
+                  })
+                : await resolveForkSourceHostId(sdk, sourceThreadId)
+              : null;
+            environment =
+              environmentValue === undefined &&
+              opts.newEnvironment === undefined &&
+              opts.baseBranch === undefined
+                ? undefined
+                : buildSpawnEnvironment({
+                    defaultPersonalWorkspace: false,
+                    environmentValue,
+                    newEnvironmentKind: opts.newEnvironment,
+                    hostId,
+                    baseBranch: opts.baseBranch,
+                  });
+            thread = await sdk.threads.fork({
               sourceThreadId,
               origin: "cli",
-              workspace,
+              ...(environment === undefined ? {} : { environment }),
               ...(input === undefined ? {} : { input }),
               ...(sourceSeqEnd === undefined ? {} : { sourceSeqEnd }),
               ...(opts.title === undefined ? {} : { title: opts.title }),
@@ -149,7 +244,7 @@ export function registerForkCommand(
           console.log(`Thread forked: ${thread.id}`);
           console.log(`Source: ${sourceThreadId}`);
           console.log(`Status: ${thread.status}`);
-          console.log(`Workspace: ${workspace}`);
+          console.log(`Environment: ${describeForkEnvironment(environment)}`);
           if (thread.visibility === "hidden") {
             console.log("Visibility: hidden");
           }

--- a/apps/cli/src/commands/thread/spawn.ts
+++ b/apps/cli/src/commands/thread/spawn.ts
@@ -73,7 +73,9 @@ export function requireHostId(hostId: string | null): string {
   return hostId;
 }
 
-function resolveSpawnEnvironmentValue(flagValue?: string): string | undefined {
+export function resolveSpawnEnvironmentValue(
+  flagValue?: string,
+): string | undefined {
   const trimmedValue = flagValue?.trim();
   if (!trimmedValue) return undefined;
   if (looksLikePath(trimmedValue)) return trimmedValue;

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/references/thread-creation.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/references/thread-creation.md
@@ -21,9 +21,12 @@
 - Spawn creates a root thread unless you pass `--parent-thread`.
 - Use `bb thread fork <source-thread-id>` to clone a provider session. The
   fork inherits the source conversation in its timeline. It creates an idle
-  fork by default; add `--prompt`, select `--workspace isolated|reuse`, or
-  anchor with `--source-seq-end` on a completed source turn (the clone and the
-  inherited timeline both end with the turn containing that sequence).
+  fork in the source environment by default; add `--prompt`, select an existing
+  environment with `--environment`, or create a worktree with
+  `--new-environment worktree`. `--base-branch` and `--host` (`--machine`
+  alias) match spawn, but every target must be on the source environment's
+  machine. Anchor with `--source-seq-end` on a completed source turn (the clone
+  and inherited timeline both end with the turn containing that sequence).
   Permission mode inherits the source thread unless explicitly overridden.
 - Pass `--visibility hidden` for background/plugin workers that should remain
   out of sidebar organization without contributing unread/pending favicon

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/references/thread-creation.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/references/thread-creation.md
@@ -23,11 +23,11 @@
   fork inherits the source conversation in its timeline. It creates an idle
   fork in the source environment by default; add `--prompt`, select an existing
   environment with `--environment`, or create a worktree with
-  `--new-environment worktree`. `--base-branch` and `--host` (`--machine`
-  alias) match spawn, but every target must be on the source environment's
-  machine. Anchor with `--source-seq-end` on a completed source turn (the clone
-  and inherited timeline both end with the turn containing that sequence).
-  Permission mode inherits the source thread unless explicitly overridden.
+  `--new-environment worktree`. `--base-branch` matches spawn, while the target
+  machine is always derived from the source environment. Anchor with
+  `--source-seq-end` on a completed source turn (the clone and inherited
+  timeline both end with the turn containing that sequence). Permission mode
+  inherits the source thread unless explicitly overridden.
 - Pass `--visibility hidden` for background/plugin workers that should remain
   out of sidebar organization without contributing unread/pending favicon
   attention. `bb thread list` excludes them by

--- a/apps/server/src/services/threads/thread-create.ts
+++ b/apps/server/src/services/threads/thread-create.ts
@@ -95,7 +95,6 @@ interface CreateProvisioningThreadArgs {
 }
 
 interface ResolveForkPointArgs {
-  childHostId: string;
   originKind: ThreadOriginKind | null;
   providerId: string;
   sourceSeqEnd: number | undefined;
@@ -168,16 +167,40 @@ function resolveForkPoint(
     return null;
   }
   const sourceEnvironment = getEnvironment(deps.db, sourceEnvironmentId);
-  if (
-    sourceEnvironment === null ||
-    sourceEnvironment.hostId !== args.childHostId
-  ) {
+  if (sourceEnvironment === null) {
     return null;
   }
   return resolveThreadForkPoint(deps, {
     sourceSeqEnd: args.sourceSeqEnd,
     sourceThread: args.sourceThread,
   });
+}
+
+function assertForkSourceHost(
+  deps: Pick<ThreadCreateDeps, "db">,
+  args: {
+    childHostId: string;
+    originKind: ThreadOriginKind | null;
+    sourceThread: Thread | null;
+  },
+): void {
+  if (args.originKind !== "fork" || args.sourceThread === null) {
+    return;
+  }
+  const sourceEnvironment =
+    args.sourceThread.environmentId === null
+      ? null
+      : getEnvironment(deps.db, args.sourceThread.environmentId);
+  if (
+    sourceEnvironment !== null &&
+    sourceEnvironment.hostId !== args.childHostId
+  ) {
+    throw new ApiError(
+      400,
+      "invalid_request",
+      `Fork environment must use the source thread's host (${sourceEnvironment.hostId}), not ${args.childHostId}`,
+    );
+  }
 }
 
 function childHostIdForResolvedEnvironment(
@@ -702,6 +725,11 @@ export async function createThreadFromRequest(
     projectId: request.projectId,
   });
   const childHostId = childHostIdForResolvedEnvironment(resolvedEnvironment);
+  assertForkSourceHost(deps, {
+    childHostId,
+    originKind: request.originKind ?? null,
+    sourceThread,
+  });
   const hostDataDir = (
     await ensureHostSessionReadyForWork(deps, { hostId: childHostId })
   ).dataDir;
@@ -842,7 +870,6 @@ export async function createThreadFromRequest(
     await resolveEnvironmentPlacement(request.environment);
 
   const fork = resolveForkPoint(deps, {
-    childHostId,
     originKind: request.originKind ?? null,
     providerId: request.providerId,
     sourceSeqEnd: request.sourceSeqEnd,

--- a/apps/server/src/services/threads/thread-fork.ts
+++ b/apps/server/src/services/threads/thread-fork.ts
@@ -1,11 +1,6 @@
 import { getEnvironment, getThread } from "@bb/db";
-import {
-  PERSONAL_PROJECT_ID,
-  type Environment,
-  type PromptInput,
-  type Thread,
-} from "@bb/domain";
-import type { EnvironmentArgs, ForkThreadRequest } from "@bb/server-contract";
+import type { Environment, PromptInput, Thread } from "@bb/domain";
+import type { ForkThreadRequest } from "@bb/server-contract";
 import type { LoggedPendingInteractionWorkSessionDeps } from "../../types.js";
 import { ApiError } from "../../errors.js";
 import { resolveExistingThreadPermissionMode } from "./thread-execution-plan.js";
@@ -63,39 +58,6 @@ function requireSourceEnvironment(
   return environment;
 }
 
-function resolveForkEnvironment(
-  sourceEnvironment: Environment,
-  args: {
-    projectId: string;
-    workspace: ForkThreadRequest["workspace"];
-  },
-): EnvironmentArgs {
-  if (args.workspace === "reuse") {
-    return { type: "reuse", environmentId: sourceEnvironment.id };
-  }
-  if (
-    args.projectId === PERSONAL_PROJECT_ID ||
-    sourceEnvironment.workspaceProvisionType === "personal"
-  ) {
-    return {
-      type: "host",
-      hostId: sourceEnvironment.hostId,
-      workspace: { type: "personal" },
-    };
-  }
-  const sourceBranchName = sourceEnvironment.branchName?.trim();
-  return {
-    type: "host",
-    hostId: sourceEnvironment.hostId,
-    workspace: {
-      type: "managed-worktree",
-      baseBranch: sourceBranchName
-        ? { kind: "named", name: sourceBranchName }
-        : { kind: "default" },
-    },
-  };
-}
-
 export async function createThreadForkFromRequest(
   deps: ThreadForkDeps,
   request: ForkThreadRequest,
@@ -113,10 +75,10 @@ export async function createThreadForkFromRequest(
   return createThreadFromRequest(
     deps,
     {
-      environment: resolveForkEnvironment(sourceEnvironment, {
-        projectId: sourceThread.projectId,
-        workspace: request.workspace,
-      }),
+      environment: request.environment ?? {
+        type: "reuse",
+        environmentId: sourceEnvironment.id,
+      },
       input,
       origin: request.origin,
       ...(request.originPluginId === undefined

--- a/apps/server/test/public/public-thread-fork.test.ts
+++ b/apps/server/test/public/public-thread-fork.test.ts
@@ -1,4 +1,5 @@
 import {
+  createProjectSource,
   ensurePersonalProject,
   getEnvironment,
   getThread,
@@ -23,6 +24,7 @@ import { appendClientTurnEventInTransaction } from "../../src/services/threads/t
 import { sendQueuedMessage } from "../../src/services/threads/queued-messages.js";
 import { sendThreadMessage } from "../../src/services/threads/thread-send.js";
 import {
+  listQueuedCommands,
   listQueuedThreadCommands,
   reportQueuedCommandError,
   reportQueuedCommandSuccess,
@@ -140,7 +142,6 @@ async function createIdleSeededFork(
   const response = await postFork(harness, {
     sourceThreadId: sourceThread.id,
     agentContextSeed: [args.seed],
-    workspace: "reuse",
   });
   expect(response.status).toBe(201);
   const fork = threadResponseSchema.parse(await readJson(response));
@@ -167,6 +168,19 @@ async function createIdleSeededFork(
 }
 
 describe("public thread fork route", () => {
+  it("rejects the removed workspace selector", async () => {
+    await withTestHarness(async (harness) => {
+      const { sourceThread } = seedForkSource(harness);
+
+      const response = await postFork(harness, {
+        sourceThreadId: sourceThread.id,
+        workspace: "isolated",
+      });
+
+      expect(response.status).toBe(400);
+    });
+  });
+
   it("reuses a switched directory from a personal-project source", async () => {
     await withTestHarness(async (harness) => {
       const { environment, sourceThread } =
@@ -174,7 +188,6 @@ describe("public thread fork route", () => {
 
       const response = await postFork(harness, {
         sourceThreadId: sourceThread.id,
-        workspace: "reuse",
       });
 
       expect(response.status).toBe(201);
@@ -196,14 +209,78 @@ describe("public thread fork route", () => {
     });
   });
 
-  it("uses a personal workspace for an isolated fork after a directory switch", async () => {
+  it("rejects a new environment on another host before provisioning", async () => {
+    await withTestHarness(async (harness) => {
+      const { environment, project, sourceThread } = seedForkSource(harness);
+      const { host: otherHost } = seedHostSession(harness.deps, {
+        id: "host-other",
+        name: "Other Host",
+      });
+      createProjectSource(harness.db, harness.hub, {
+        hostId: otherHost.id,
+        path: "/tmp/public-thread-fork-other",
+        projectId: project.id,
+        type: "local_path",
+      });
+
+      const response = await postFork(harness, {
+        sourceThreadId: sourceThread.id,
+        environment: {
+          type: "host",
+          hostId: otherHost.id,
+          workspace: {
+            type: "managed-worktree",
+            baseBranch: { kind: "default" },
+          },
+        },
+      });
+
+      expect(response.status).toBe(400);
+      expect(await readJson(response)).toMatchObject({
+        code: "invalid_request",
+        message: `Fork environment must use the source thread's host (${environment.hostId}), not ${otherHost.id}`,
+      });
+      expect(listQueuedCommands(harness, "environment.provision")).toEqual([]);
+    });
+  });
+
+  it("reuses a requested environment on the source host", async () => {
+    await withTestHarness(async (harness) => {
+      const { host, project, sourceThread } = seedForkSource(harness);
+      const targetEnvironment = seedEnvironment(harness.deps, {
+        hostId: host.id,
+        path: "/tmp/public-thread-fork-target",
+        projectId: project.id,
+      });
+
+      const response = await postFork(harness, {
+        sourceThreadId: sourceThread.id,
+        environment: {
+          type: "reuse",
+          environmentId: targetEnvironment.id,
+        },
+      });
+
+      expect(response.status).toBe(201);
+      const fork = threadResponseSchema.parse(await readJson(response));
+      expect(getThread(harness.db, fork.id)?.environmentId).toBe(
+        targetEnvironment.id,
+      );
+    });
+  });
+
+  it("creates a requested personal environment after a directory switch", async () => {
     await withTestHarness(async (harness) => {
       const { environment, sourceThread } =
         seedPersonalDirectoryForkSource(harness);
 
       const response = await postFork(harness, {
         sourceThreadId: sourceThread.id,
-        workspace: "isolated",
+        environment: {
+          type: "host",
+          hostId: environment.hostId,
+          workspace: { type: "personal" },
+        },
       });
 
       expect(response.status).toBe(201);
@@ -255,7 +332,6 @@ describe("public thread fork route", () => {
 
       const response = await postFork(harness, {
         sourceThreadId: sourceThread.id,
-        workspace: "reuse",
       });
 
       expect(response.status).toBe(201);
@@ -311,7 +387,6 @@ describe("public thread fork route", () => {
         sourceThreadId: sourceThread.id,
         sourceSeqEnd: 3,
         input,
-        workspace: "reuse",
       });
 
       expect(response.status).toBe(201);
@@ -705,7 +780,6 @@ describe("public thread fork route", () => {
 
       const response = await postFork(harness, {
         sourceThreadId: sourceThread.id,
-        workspace: "reuse",
       });
 
       expect(response.status).toBe(201);
@@ -732,7 +806,6 @@ describe("public thread fork route", () => {
 
       const response = await postFork(harness, {
         sourceThreadId: sourceThread.id,
-        workspace: "reuse",
       });
 
       expect(response.status).toBe(201);
@@ -784,7 +857,6 @@ describe("public thread fork route", () => {
 
       const response = await postFork(harness, {
         sourceThreadId: sourceThread.id,
-        workspace: "reuse",
       });
 
       expect(response.status).toBe(201);
@@ -1043,7 +1115,6 @@ describe("fork branch point and inherited history", () => {
       const response = await postFork(harness, {
         sourceThreadId: sourceThread.id,
         sourceSeqEnd: 5,
-        workspace: "reuse",
       });
 
       expect(response.status).toBe(201);
@@ -1085,7 +1156,6 @@ describe("fork branch point and inherited history", () => {
       const response = await postFork(harness, {
         sourceThreadId: sourceThread.id,
         sourceSeqEnd: 6,
-        workspace: "reuse",
       });
 
       expect(response.status).toBe(201);
@@ -1109,7 +1179,6 @@ describe("fork branch point and inherited history", () => {
 
       const response = await postFork(harness, {
         sourceThreadId: sourceThread.id,
-        workspace: "reuse",
       });
 
       expect(response.status).toBe(201);
@@ -1133,7 +1202,6 @@ describe("fork branch point and inherited history", () => {
 
       const response = await postFork(harness, {
         sourceThreadId: sourceThread.id,
-        workspace: "reuse",
       });
 
       expect(response.status).toBe(201);
@@ -1165,7 +1233,6 @@ describe("fork branch point and inherited history", () => {
         sourceThreadId: sourceThread.id,
         sourceSeqEnd: 5,
         visibility: "hidden",
-        workspace: "reuse",
       });
 
       expect(response.status).toBe(201);
@@ -1191,7 +1258,6 @@ describe("fork branch point and inherited history", () => {
       const running = await postFork(harness, {
         sourceThreadId: sourceThread.id,
         sourceSeqEnd: 14,
-        workspace: "reuse",
       });
       expect(running.status).toBe(400);
       expect(await readJson(running)).toMatchObject({
@@ -1203,7 +1269,6 @@ describe("fork branch point and inherited history", () => {
       const beforeFirstTurn = await postFork(harness, {
         sourceThreadId: sourceThread.id,
         sourceSeqEnd: 2,
-        workspace: "reuse",
       });
       expect(beforeFirstTurn.status).toBe(400);
       expect(await readJson(beforeFirstTurn)).toMatchObject({
@@ -1224,7 +1289,6 @@ describe("fork branch point and inherited history", () => {
 
       const response = await postFork(harness, {
         sourceThreadId: sourceThread.id,
-        workspace: "reuse",
       });
 
       expect(response.status).toBe(201);
@@ -1252,7 +1316,6 @@ describe("fork branch point and inherited history", () => {
       const earlier = await postFork(harness, {
         sourceThreadId: sourceThread.id,
         sourceSeqEnd: 5,
-        workspace: "reuse",
       });
       expect(earlier.status).toBe(400);
       expect(await readJson(earlier)).toMatchObject({
@@ -1263,7 +1326,6 @@ describe("fork branch point and inherited history", () => {
       const tip = await postFork(harness, {
         sourceThreadId: sourceThread.id,
         sourceSeqEnd: 10,
-        workspace: "reuse",
       });
       expect(tip.status).toBe(201);
       const fork = threadResponseSchema.parse(await readJson(tip));

--- a/apps/server/test/public/public-threads.named-base-branch.test.ts
+++ b/apps/server/test/public/public-threads.named-base-branch.test.ts
@@ -142,7 +142,7 @@ describe("named managed-worktree base branch", () => {
     });
   });
 
-  it("keeps a fork on its source branch even when local main is behind origin", async () => {
+  it("passes a fork's explicitly named base branch through unchanged", async () => {
     await withTestHarness(async (harness) => {
       const { host, session } = seedHostSession(harness.deps);
       registerTestHostRpcCapture(harness, {
@@ -155,7 +155,7 @@ describe("named managed-worktree base branch", () => {
         path: SOURCE_PATH,
       });
       const environment = seedEnvironment(harness.deps, {
-        branchName: "main",
+        branchName: "feature/source",
         hostId: host.id,
         path: SOURCE_PATH,
         projectId: project.id,
@@ -183,7 +183,14 @@ describe("named managed-worktree base branch", () => {
         headers: { "content-type": "application/json" },
         body: JSON.stringify({
           sourceThreadId: sourceThread.id,
-          workspace: "isolated",
+          environment: {
+            type: "host",
+            hostId: host.id,
+            workspace: {
+              type: "managed-worktree",
+              baseBranch: { kind: "named", name: "main" },
+            },
+          },
         }),
       });
       expect(response.status).toBe(201);

--- a/apps/server/test/services/plugins/plugin-sdk.test.ts
+++ b/apps/server/test/services/plugins/plugin-sdk.test.ts
@@ -537,7 +537,6 @@ describe("plugin bb.sdk against a running server", () => {
       });
       const fork = await api.sdk.threads.fork({
         sourceThreadId: operable.id,
-        workspace: "reuse",
       });
       expect(fork).toMatchObject({
         originKind: "fork",

--- a/packages/domain/src/plugin-sdk-version.ts
+++ b/packages/domain/src/plugin-sdk-version.ts
@@ -1,3 +1,3 @@
-export const PLUGIN_SDK_VERSION = "0.4.41";
+export const PLUGIN_SDK_VERSION = "0.4.42";
 
 export const PLUGIN_SDK_MAJOR = Number(PLUGIN_SDK_VERSION.split(".", 1)[0]);

--- a/packages/plugin-api-map/sdk-public-api.json
+++ b/packages/plugin-api-map/sdk-public-api.json
@@ -3,7 +3,7 @@
   "entries": {
     ".": {
       "types": "bundled-types/bb-plugin-sdk.d.ts",
-      "sha256": "77f4428abd1f071e89c5da296af3faa7c5c41dc0af5a4ef6188b4136d1795057"
+      "sha256": "5c95a2ff45f0165e3cbe5c760d9b7904afb195f06f6a1e6d2006b2e10ae8801f"
     },
     "./ai-services": {
       "types": "bundled-types/bb-plugin-sdk-ai-services.d.ts",

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@get-bb/plugin-sdk",
-  "version": "0.4.41",
+  "version": "0.4.42",
   "homepage": "https://github.com/get-bb/bb#readme",
   "bugs": {
     "url": "https://github.com/get-bb/bb/issues"

--- a/packages/sdk/src/areas/threads.ts
+++ b/packages/sdk/src/areas/threads.ts
@@ -229,11 +229,10 @@ export type ThreadSpawnArgs = ThreadSpawnBaseArgs &
 
 export interface ThreadForkArgs extends Omit<
   ForkThreadRequest,
-  "origin" | "visibility" | "workspace"
+  "origin" | "visibility"
 > {
   origin?: ForkThreadRequest["origin"];
   visibility?: ForkThreadRequest["visibility"];
-  workspace?: ForkThreadRequest["workspace"];
 }
 
 export interface ThreadUpdateArgs extends UpdateThreadRequest {
@@ -700,7 +699,6 @@ function forkJson(args: ThreadForkArgs): ForkThreadRequest {
     ...args,
     origin: args.origin ?? "sdk",
     visibility: args.visibility ?? "visible",
-    workspace: args.workspace ?? "isolated",
   };
 }
 

--- a/packages/sdk/test/sdk.test.ts
+++ b/packages/sdk/test/sdk.test.ts
@@ -1017,7 +1017,7 @@ describe("@bb/sdk", () => {
     );
   });
 
-  it("fills thread fork defaults and preserves an agent-only context seed", async () => {
+  it("defaults thread forks to source-environment reuse and preserves an agent-only context seed", async () => {
     const queue = createFetchQueue([{ body: { id: "thr_fork" }, status: 201 }]);
     const sdk = createBbSdk({
       transport: createHttpTransport({
@@ -1055,7 +1055,6 @@ describe("@bb/sdk", () => {
       ],
       origin: "sdk",
       visibility: "visible",
-      workspace: "isolated",
     });
   });
 
@@ -1983,5 +1982,4 @@ describe("@bb/sdk", () => {
       },
     ]);
   });
-
 });

--- a/packages/server-contract/src/api/threads.ts
+++ b/packages/server-contract/src/api/threads.ts
@@ -167,10 +167,11 @@ export const forkThreadRequestSchema = z
     title: z.string().min(1).optional(),
     permissionMode: permissionModeInputSchema.optional(),
     visibility: threadVisibilitySchema.default("visible"),
-    workspace: z.enum(["isolated", "reuse"]).default("isolated"),
+    environment: createThreadEnvironmentArgsSchema.optional(),
     origin: threadCreateOriginSchema.default("sdk"),
     originPluginId: z.string().min(1).optional(),
   })
+  .strict()
   .superRefine((value, ctx) => {
     if (value.origin === "plugin" && value.originPluginId === undefined) {
       ctx.addIssue({

--- a/packages/server-contract/test/contract.test.ts
+++ b/packages/server-contract/test/contract.test.ts
@@ -60,12 +60,18 @@ const OPTIONAL_SERVER_FIELD_GROUPS: readonly OptionalServerFieldGroup[] = [
   {
     reason:
       "Unmanaged workspaces may omit branch checkout intent when the daemon should leave HEAD untouched.",
-    fields: ["createThreadRequestSchema.environment.workspace.branch"],
+    fields: [
+      "createThreadRequestSchema.environment.workspace.branch",
+      "forkThreadRequestSchema.environment.workspace.branch",
+    ],
   },
   {
     reason:
       "Personal workspace requests may omit hostId so the server can use the default connected local host.",
-    fields: ["createThreadRequestSchema.environment.hostId"],
+    fields: [
+      "createThreadRequestSchema.environment.hostId",
+      "forkThreadRequestSchema.environment.hostId",
+    ],
   },
   {
     reason:
@@ -82,6 +88,7 @@ const OPTIONAL_SERVER_FIELD_GROUPS: readonly OptionalServerFieldGroup[] = [
       "Fork creation requires only a source thread; all other fields either select an optional behavior or receive an explicit server-boundary default.",
     fields: [
       "forkThreadRequestSchema.agentContextSeed",
+      "forkThreadRequestSchema.environment",
       "forkThreadRequestSchema.input",
       "forkThreadRequestSchema.originPluginId",
       "forkThreadRequestSchema.permissionMode",

--- a/packages/templates/src/templates/bb-guide-threads.md
+++ b/packages/templates/src/templates/bb-guide-threads.md
@@ -72,7 +72,6 @@ Forking:
     --environment <id-or-path>     Existing environment ID or unmanaged workspace path
     --new-environment worktree     Create a new managed worktree
     --base-branch <branch>         Exact Git ref for a new worktree; omit for the project default
-    --host <id-or-name>            Machine for a new environment or unmanaged path (--machine alias)
     --title <title>                Thread title
     --permission-mode <mode>       Inherit source by default; accepts accept-edits, auto, full
     --visibility <visibility>      visible (default) or hidden

--- a/packages/templates/src/templates/bb-guide-threads.md
+++ b/packages/templates/src/templates/bb-guide-threads.md
@@ -69,7 +69,10 @@ Forking:
 
     --prompt <prompt>              Optional first prompt; omit for an idle fork
     --source-seq-end <seq>         Fork after the source turn containing this event sequence (tip by default)
-    --workspace <mode>             isolated (default) or reuse
+    --environment <id-or-path>     Existing environment ID or unmanaged workspace path
+    --new-environment worktree     Create a new managed worktree
+    --base-branch <branch>         Exact Git ref for a new worktree; omit for the project default
+    --host <id-or-name>            Machine for a new environment or unmanaged path (--machine alias)
     --title <title>                Thread title
     --permission-mode <mode>       Inherit source by default; accepts accept-edits, auto, full
     --visibility <visibility>      visible (default) or hidden
@@ -83,9 +86,12 @@ Forking:
   inherited timeline both end with that turn (an anchor on a user message
   branches before it, like editing it). Without it a fork clones the session
   tip and inherits every completed turn. Providers that can only clone a whole
-  session accept an anchor only on the source's latest turn. Isolated forks
-  create a fresh managed worktree (or personal workspace for personal threads);
-  reuse attaches the source environment. Omit --prompt to create an idle fork.
+  session accept an anchor only on the source's latest turn. A fork reuses the
+  source environment by default. Use --new-environment worktree for a fresh
+  worktree on the source machine; --environment can select another environment
+  or unmanaged path on that machine. A different machine is rejected because
+  the source provider session lives on its original machine. Omit --prompt to
+  create an idle fork.
 
 Editing a sent message (requires the default-on `editMessages` experiment):
 

--- a/plugins/provider-claude-code/src/bridge/__tests__/bridge.test.ts
+++ b/plugins/provider-claude-code/src/bridge/__tests__/bridge.test.ts
@@ -816,7 +816,6 @@ describe("bridge", () => {
         },
       });
       expect(forkSessionMock).toHaveBeenCalledWith("source-session-1", {
-        dir: "/tmp/worktree",
         upToMessageId: "assistant-message-42",
       });
     } finally {

--- a/plugins/provider-claude-code/src/bridge/bridge.ts
+++ b/plugins/provider-claude-code/src/bridge/bridge.ts
@@ -2431,7 +2431,6 @@ async function handleThreadFork(
   let forkedProviderThreadId: string;
   try {
     const forkResult = await forkSession(params.sourceProviderThreadId, {
-      dir: params.cwd,
       ...(params.sourceProviderCheckpointId !== undefined
         ? { upToMessageId: params.sourceProviderCheckpointId }
         : {}),

--- a/plugins/side-chat/server.test.ts
+++ b/plugins/side-chat/server.test.ts
@@ -92,7 +92,6 @@ describe("createSideChat rpc", () => {
       sourceThreadId: "thr_src",
       sourceSeqEnd: 42,
       visibility: "hidden",
-      workspace: "reuse",
       agentContextSeed: [
         {
           type: "text",
@@ -188,7 +187,6 @@ describe("createSideChat rpc", () => {
     expect(fork).toHaveBeenCalledWith({
       sourceThreadId: "thr_src",
       visibility: "hidden",
-      workspace: "reuse",
     });
   });
 });

--- a/plugins/side-chat/server.ts
+++ b/plugins/side-chat/server.ts
@@ -95,7 +95,6 @@ export default async function plugin(bb: BbPluginApi) {
       const forkArgs = {
         sourceThreadId,
         visibility: "hidden" as const,
-        workspace: "reuse" as const,
         ...(seedText !== null
           ? {
               agentContextSeed: [


### PR DESCRIPTION
## Human comments

## What was wrong

Thread forking exposed a fork-specific `workspace` policy even though continuing a provider session already requires the child environment to live on the source thread's host. That split environment selection between fork-specific core logic and normal thread placement, allowed invalid cross-host requests to fail late, and caused Claude forks into a new directory to look for the source session under the new working directory.

## What changed

- Replaced the fork request's `workspace` field with the create-style `environment` argument. Omitting it now reuses the source environment.
- Routed explicit fork environments through normal thread placement and reject a different host before provisioning.
- Updated the SDK, side-chat plugin, CLI guide, and built-in CLI skill. `bb thread fork` now supports `--environment`, `--new-environment worktree`, and `--base-branch`; `--workspace` was removed.
- Bumped `@get-bb/plugin-sdk` to `0.4.42` and refreshed the Plugin Guide API inventory for the changed `threads.fork` declaration.
- The CLI derives the required host from the source thread. It does not expose `--host` or `--machine`, because another host is never valid for a fork.
- Kept the Claude bridge fix that finds the source session independently of the fork's new working directory.
- There are no database model, lifecycle, or host-daemon wire changes, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

The user-visible default changes from creating an isolated environment to reusing the source environment. Explicit new worktrees use normal create placement and the project's default base branch unless `--base-branch` is supplied.

## How you verified

Added regression coverage that failed before the implementation and passes after for default reuse, early cross-host rejection, SDK serialization, CLI environment flags, side-chat requests, and Claude forks across directories.

- Server fork/create suites: 61 tests passed.
- Contract, SDK, CLI, side-chat, Claude bridge, and template suites: 299 tests passed.
- Turbo typechecks passed for the affected server-contract, SDK, CLI, server, side-chat, Claude bridge, and templates packages.
- Plugin SDK npm version guard and Plugin Guide build passed.

No linked issue.

> AGENT GENERATED
