### PR TITLE
Preserve leading timeline segments before first message

### DIFF
--- a/apps/server/src/services/threads/timeline.ts
+++ b/apps/server/src/services/threads/timeline.ts
@@ -1047,6 +1047,15 @@ function resolveTimelineWindowBounds(
     };
   }
 
+  if (budgetFloorSequence === undefined && anchors.length <= segmentLimit) {
+    return {
+      affordableAnchorCount: anchors.length,
+      effectiveSegmentLimit: segmentLimit,
+      sequenceWindowStart: null,
+      sequenceStart: 0,
+    };
+  }
+
   const segmentCount = Math.max(1, affordable);
   return {
     affordableAnchorCount: segmentCount,
@@ -1140,7 +1149,9 @@ function resolveTimelineSegmentWindow(
       hasAnchors: true,
       sequenceWindowStart: bounds.sequenceWindowStart,
       knownHasOlderSegments:
-        precedingAnchors.length > bounds.affordableAnchorCount,
+        bounds.sequenceStart === 0
+          ? null
+          : precedingAnchors.length > bounds.affordableAnchorCount,
       oversizedEventPlaceholder: null,
       sequenceStart: bounds.sequenceStart,
     };
@@ -1170,7 +1181,10 @@ function resolveTimelineSegmentWindow(
     effectiveSegmentLimit: bounds.effectiveSegmentLimit,
     hasAnchors: true,
     sequenceWindowStart: bounds.sequenceWindowStart,
-    knownHasOlderSegments: newestAnchors.length > bounds.affordableAnchorCount,
+    knownHasOlderSegments:
+      bounds.sequenceStart === 0
+        ? null
+        : newestAnchors.length > bounds.affordableAnchorCount,
     oversizedEventPlaceholder: null,
     sequenceStart: bounds.sequenceStart,
   };

--- a/apps/server/test/services/threads/timeline-in-turn-window.test.ts
+++ b/apps/server/test/services/threads/timeline-in-turn-window.test.ts
@@ -399,6 +399,7 @@ function buildPage(
   thread: Thread,
   eventBudget: number,
   cursor: TimelinePaginationCursor | null,
+  segmentLimit = 20,
 ) {
   return buildThreadTimelineWithProfile(db, thread, {
     eventBudget,
@@ -407,8 +408,8 @@ function buildPage(
     maxInlineOutputChars: 32_000,
     maxSeq: 0,
     page: cursor
-      ? { kind: "older", beforeCursor: cursor, segmentLimit: 20 }
-      : { kind: "latest", segmentLimit: 20 },
+      ? { kind: "older", beforeCursor: cursor, segmentLimit }
+      : { kind: "latest", segmentLimit },
   });
 }
 
@@ -1135,6 +1136,116 @@ describe("in-turn timeline windows", () => {
 });
 
 describe("timeline segment anchors", () => {
+  it("includes provisioning before the first visible user message", () => {
+    const { db, thread } = setup();
+    insertEvents(db, noopNotifier, [
+      {
+        threadId: thread.id,
+        sequence: 1,
+        type: "client/turn/requested",
+        scope: threadScope(),
+        itemId: null,
+        itemKind: null,
+        parentToolCallId: null,
+        data: JSON.stringify({
+          direction: "outbound",
+          source: "spawn",
+          initiator: "user",
+          request: { method: "turn/start", params: {} },
+          requestId: requestId(1),
+          senderThreadId: null,
+          input: [{ type: "text", text: "", mentions: [] }],
+          target: { kind: "thread-start" },
+          execution,
+        }),
+      },
+      {
+        threadId: thread.id,
+        sequence: 2,
+        type: "system/thread-provisioning",
+        scope: threadScope(),
+        itemId: null,
+        itemKind: null,
+        parentToolCallId: null,
+        data: JSON.stringify({
+          provisioningId: "tpv-first-message",
+          status: "completed",
+          environmentId: "env-first-message",
+          entries: [],
+        }),
+      },
+      {
+        threadId: thread.id,
+        sequence: 3,
+        type: "client/turn/requested",
+        scope: threadScope(),
+        itemId: null,
+        itemKind: null,
+        parentToolCallId: null,
+        data: JSON.stringify({
+          direction: "outbound",
+          source: "tell",
+          initiator: "user",
+          request: { method: "turn/start", params: {} },
+          requestId: requestId(2),
+          senderThreadId: null,
+          input: [{ type: "text", text: "Start now", mentions: [] }],
+          target: { kind: "new-turn" },
+          execution,
+        }),
+      },
+    ]);
+
+    const timeline = buildPage(db, thread, LARGE_BUDGET, null).response;
+
+    expect(timeline.timelinePage.hasOlderRows).toBe(false);
+    expect(timeline.timelinePage.olderCursor).toBeNull();
+    expect(timeline.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "system",
+          systemKind: "operation",
+          title: "Provisioned thread",
+        }),
+        expect.objectContaining({
+          kind: "conversation",
+          role: "user",
+          text: "Start now",
+        }),
+      ]),
+    );
+
+    const latest = buildPage(db, thread, LARGE_BUDGET, null, 1).response;
+    expect(latest.timelinePage.hasOlderRows).toBe(true);
+    expect(latest.rows).toEqual([
+      expect.objectContaining({
+        kind: "conversation",
+        role: "user",
+        text: "Start now",
+      }),
+    ]);
+    if (latest.timelinePage.olderCursor === null) {
+      throw new Error("expected an older timeline cursor");
+    }
+
+    const older = buildPage(
+      db,
+      thread,
+      LARGE_BUDGET,
+      latest.timelinePage.olderCursor,
+      1,
+    ).response;
+    expect(older.timelinePage.hasOlderRows).toBe(false);
+    expect(older.timelinePage.olderCursor).toBeNull();
+    expect(older.rows).toEqual([
+      expect.objectContaining({
+        kind: "system",
+        systemKind: "operation",
+        title: "Provisioned thread",
+      }),
+    ]);
+  });
+
   it("treats a steer sent with nothing running as a pageable anchor", () => {
     const { db, thread } = setup();
     seedTurns(db, thread, { completeLastTurn: true, itemsPerTurn: [40] });


### PR DESCRIPTION
## Human comments

## What was wrong

The legacy timeline window selector counted visible user-request anchors as though they represented every semantic timeline segment. When a thread started with an empty request, provisioning events appeared before the first visible user-message anchor; the selector began at that later anchor and also reported that no older segments existed, making the provisioning row disappear from the timeline. This was reproduced from [thread `thr_vdikwi8kb9`](https://ymichael.getbb.app/projects/proj_qrv2s45kmq/threads/thr_vdikwi8kb9).

## What changed

When the anchor query and event budget reach the beginning of a timeline, the server now reads from sequence zero and preserves the requested segment limit. It leaves the final `hasOlderRows` decision to the projected semantic segments, which keeps leading provisioning/system rows visible and pageable without treating empty requests as user messages. The regression covers both a normal initial page and a one-segment walk to the older provisioning row. There are no host-daemon wire, CLI, guide, or documentation changes.

## How you verified

- Added a regression that failed before the fix with the provisioning row absent and passed afterward.
- `pnpm exec turbo run test --filter=@bb/server -- --run test/services/threads/timeline-in-turn-window.test.ts test/services/threads/timeline-event-budget.test.ts test/services/threads/timeline-workflow-progress-window.test.ts test/services/threads/timeline-pagination.test.ts` (36 tests passed)
- `pnpm exec turbo run typecheck --filter=@bb/server`
- `pnpm exec prettier --check apps/server/src/services/threads/timeline.ts apps/server/test/services/threads/timeline-in-turn-window.test.ts`
- `git diff --check`

> AGENT GENERATED
