### PR TITLE
Support editing turns that contain steers

### DIFF
--- a/apps/server/src/services/threads/thread-edit-message.ts
+++ b/apps/server/src/services/threads/thread-edit-message.ts
@@ -242,22 +242,6 @@ function resolveEditableTurnCandidate(
   ) {
     conflict("The selected message does not belong to a root turn");
   }
-  const turnAcceptedCount = db
-    .select({ count: sql<number>`COUNT(*)` })
-    .from(events)
-    .where(
-      and(
-        eq(events.threadId, thread.id),
-        eq(events.type, "turn/input/accepted"),
-        eq(events.turnId, accepted.turnId),
-      ),
-    )
-    .get()?.count;
-  if (turnAcceptedCount !== 1) {
-    conflict(
-      "A turn containing steers or multiple accepted messages cannot be edited",
-    );
-  }
   const precedingTurn = db
     .select({ turnId: events.turnId })
     .from(events)

--- a/apps/server/test/threads/thread-edit-message.test.ts
+++ b/apps/server/test/threads/thread-edit-message.test.ts
@@ -450,6 +450,117 @@ describe("editThreadMessage", () => {
     });
   });
 
+  it("replaces a turn containing an accepted steer", async () => {
+    await withTestHarness(async (harness) => {
+      const { environment, thread } = seedEditableThread(harness, {
+        includeSecondTurn: false,
+      });
+      seedTurn(harness, {
+        completionStatus: null,
+        providerThreadId: "provider-original",
+        requestSequence: 7,
+        text: "Original steered message",
+        threadId: thread.id,
+        turnId: "turn-steered",
+      });
+      const steerRequestId = encodeClientTurnRequestIdNumber({ value: 11 });
+      seedStoredEvent(harness.deps, {
+        threadId: thread.id,
+        providerThreadId: "provider-original",
+        sequence: 11,
+        type: "client/turn/requested",
+        scope: threadScope(),
+        data: {
+          direction: "outbound",
+          requestId: steerRequestId,
+          input: [{ type: "text", text: "Accepted steer", mentions: [] }],
+          target: { kind: "steer", expectedTurnId: "turn-steered" },
+          execution: {
+            model: "gpt-5",
+            serviceTier: "default",
+            reasoningLevel: "medium",
+            permissionMode: "full",
+            source: "client/turn/requested",
+          },
+          initiator: "user",
+          senderThreadId: null,
+          request: { method: "turn/start", params: {} },
+          source: "tell",
+        },
+      });
+      seedStoredEvent(harness.deps, {
+        threadId: thread.id,
+        providerThreadId: "provider-original",
+        sequence: 12,
+        type: "turn/input/accepted",
+        scope: turnScope("turn-steered"),
+        data: {
+          providerThreadId: "provider-original",
+          clientRequestId: steerRequestId,
+        },
+      });
+      seedStoredEvent(harness.deps, {
+        threadId: thread.id,
+        providerThreadId: "provider-original",
+        sequence: 13,
+        type: "turn/completed",
+        scope: turnScope("turn-steered"),
+        data: {
+          providerThreadId: "provider-original",
+          providerCheckpointId: "checkpoint-steered",
+          status: "completed",
+        },
+      });
+
+      const editPromise = editThreadMessage(harness.deps, {
+        environment,
+        thread,
+        payload: {
+          operationId: "edit-op-steered-turn",
+          expectedRequestSequence: 7,
+          input: [{ type: "text", text: "Replacement", mentions: [] }],
+        },
+      });
+      const rewind = await waitForQueuedCommand(
+        harness,
+        (queued) => queued.command.type === "thread.rewind.prepare",
+      );
+      expect(rewind.command).toMatchObject({
+        retainThroughProviderCheckpoint: "checkpoint-first",
+        sourceProviderThreadId: "provider-original",
+      });
+      if (rewind.command.type !== "thread.rewind.prepare") {
+        throw new Error("Expected a thread.rewind.prepare command");
+      }
+      await reportQueuedCommandSuccess(harness, rewind, {
+        providerThreadId: "provider-staged-steered-edit",
+      });
+
+      await expect(editPromise).resolves.toEqual({
+        ok: true,
+        operationId: "edit-op-steered-turn",
+        requestSequence: 15,
+      });
+      const stored = listEvents(harness.db, { threadId: thread.id });
+      expect(stored.map((event) => event.sequence)).toEqual([
+        1, 2, 3, 4, 5, 6, 14, 15,
+      ]);
+      expect(
+        stored.some((event) => event.data.includes("Accepted steer")),
+      ).toBe(false);
+      const replacement = await waitForQueuedCommand(
+        harness,
+        (queued) =>
+          queued.command.type === "thread.start" &&
+          queued.command.threadId === thread.id,
+      );
+      expect(replacement.command).toMatchObject({
+        fork: { sourceProviderThreadId: "provider-staged-steered-edit" },
+        input: [{ type: "text", text: "Replacement", mentions: [] }],
+      });
+    });
+  });
+
   it.each(["codex", "claude-code", "pi"] as const)(
     "starts a fresh %s session when editing the first turn",
     async (providerId) => {


### PR DESCRIPTION
## Human comments

## What was wrong

Sent-message editing required the selected root turn to contain exactly one `turn/input/accepted` event. A steer accepted while that turn was running added a second accepted input, so editing the original message returned `409 invalid_request` even though the history-rewrite operation already replaces the entire suffix beginning at that root request.

## What changed

Removed the one-accepted-input eligibility restriction. A root message can now be edited after one or more steers were accepted into its turn; the existing rewind behavior retains the preceding provider checkpoint, removes the original turn including its steers and later history, and starts the replacement message from that checkpoint.

Added a regression test that constructs a completed turn with an accepted steer and verifies the provider rewind checkpoint, deleted suffix, replacement request sequence, and replacement start command. Steer messages themselves remain ineligible edit targets.

There are no host-daemon wire changes, protocol-version changes, CLI changes, guide changes, or public contract changes.

## How you verified

- `pnpm exec turbo run test --filter=@bb/server --force -- --run test/threads/thread-edit-message.test.ts` — 43 tests passed
- `pnpm exec turbo run typecheck --filter=@bb/server`
- `git diff --check`
- Live CLI QA against the branch dev server: spawned Codex thread `thr_axcz3earhf`, delivered a steer, confirmed both inputs were accepted into `da34ff8a26-t1`, edited the root message with `bb thread edit-message`, and verified the rewritten log contains only the replacement request while `bb thread output` returns `EDITED_DONE`

No linked issue.

> AGENT GENERATED
