### PR TITLE
Restore personal environment forks in CLI

### DIFF
--- a/apps/cli/src/__tests__/command-output/thread-fork.test.ts
+++ b/apps/cli/src/__tests__/command-output/thread-fork.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { PERSONAL_PROJECT_ID } from "@bb/domain";
 import {
   collectLogLines,
   getHelpOutput,
@@ -155,9 +156,55 @@ describe("bb thread fork command output", () => {
     });
   });
 
+  it("creates a personal environment on the source host", async () => {
+    const source = fixtures.makeThread({
+      id: "thread-source",
+      environmentId: "env-source",
+      projectId: PERSONAL_PROJECT_ID,
+      providerId: "codex",
+    });
+    const sourceEnvironment = fixtures.makeEnvironment({
+      id: "env-source",
+      hostId: "host-source",
+      projectId: PERSONAL_PROJECT_ID,
+    });
+    const thread = fixtures.makeThread({
+      id: "thread-fork-personal",
+      originKind: "fork",
+      projectId: PERSONAL_PROJECT_ID,
+      providerId: "codex",
+      sourceThreadId: source.id,
+    });
+    const post = vi.fn(async () => thread);
+    stubServerApi({
+      "v1.threads.:id.$get": vi.fn(async () => source),
+      "v1.environments.:id.$get": vi.fn(async () => sourceEnvironment),
+      "v1.threads.fork.$post": post,
+    });
+
+    await runCommand(
+      ["thread", "fork", source.id, "--new-environment", "personal"],
+      register,
+    );
+
+    expect(post).toHaveBeenCalledWith({
+      json: {
+        sourceThreadId: source.id,
+        origin: "cli",
+        visibility: "visible",
+        environment: {
+          type: "host",
+          hostId: "host-source",
+          workspace: { type: "personal" },
+        },
+      },
+    });
+  });
+
   it("does not offer a host selector", async () => {
     const help = await getHelpOutput(["thread", "fork"], register);
 
+    expect(help).toContain("personal or worktree");
     expect(help).not.toContain("--host");
     expect(help).not.toContain("--machine");
   });

--- a/apps/cli/src/__tests__/spawn-helpers.test.ts
+++ b/apps/cli/src/__tests__/spawn-helpers.test.ts
@@ -146,6 +146,19 @@ describe("buildSpawnEnvironment", () => {
     });
   });
 
+  it("returns personal for --new-environment personal with host", () => {
+    const result = buildSpawnEnvironment({
+      defaultPersonalWorkspace: false,
+      newEnvironmentKind: "personal",
+      hostId: HOST_ID,
+    });
+    expect(result).toEqual({
+      type: "host",
+      hostId: HOST_ID,
+      workspace: { type: "personal" },
+    });
+  });
+
   it("returns named base branch for --base-branch with managed worktrees", () => {
     const result = buildSpawnEnvironment({
       defaultPersonalWorkspace: false,

--- a/apps/cli/src/commands/thread/fork.ts
+++ b/apps/cli/src/commands/thread/fork.ts
@@ -107,7 +107,7 @@ export function registerForkCommand(
     )
     .option(
       "--new-environment <kind>",
-      "Create a new managed environment of the given kind (worktree)",
+      "Create a fresh environment of the given kind (personal or worktree)",
     )
     .option(
       "--base-branch <branch>",

--- a/apps/cli/src/commands/thread/spawn.ts
+++ b/apps/cli/src/commands/thread/spawn.ts
@@ -127,6 +127,13 @@ export function buildSpawnEnvironment(args: {
     throw new Error("--base-branch requires --new-environment worktree.");
   }
   if (newEnvironmentKind) {
+    if (newEnvironmentKind === "personal") {
+      return {
+        type: "host",
+        hostId: requireHostId(args.hostId),
+        workspace: { type: "personal" },
+      };
+    }
     if (newEnvironmentKind === "worktree") {
       return {
         type: "host",
@@ -135,7 +142,7 @@ export function buildSpawnEnvironment(args: {
       };
     }
     throw new Error(
-      `Unknown environment kind '${newEnvironmentKind}'. Supported: worktree.`,
+      `Unknown environment kind '${newEnvironmentKind}'. Supported: personal, worktree.`,
     );
   }
   if (!environmentValue) {
@@ -183,7 +190,7 @@ export function registerSpawnCommand(
     )
     .option(
       "--new-environment <kind>",
-      "Create a new managed environment of the given kind (worktree)",
+      "Create a fresh environment of the given kind (personal or worktree)",
     )
     .option(
       "--base-branch <branch>",
@@ -301,9 +308,7 @@ export function registerSpawnCommand(
           throw new Error("--source-seq-end must be a non-negative integer.");
         }
         const sendAt =
-          opts.sendAt === undefined
-            ? undefined
-            : parseSendAt(opts.sendAt);
+          opts.sendAt === undefined ? undefined : parseSendAt(opts.sendAt);
         const providerId = opts.provider?.trim();
 
         let thread: Thread;

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/references/thread-creation.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/references/thread-creation.md
@@ -22,9 +22,10 @@
 - Use `bb thread fork <source-thread-id>` to clone a provider session. The
   fork inherits the source conversation in its timeline. It creates an idle
   fork in the source environment by default; add `--prompt`, select an existing
-  environment with `--environment`, or create a worktree with
-  `--new-environment worktree`. `--base-branch` matches spawn, while the target
-  machine is always derived from the source environment. Anchor with
+  environment with `--environment`, or create a fresh personal workspace or
+  worktree with `--new-environment personal|worktree`. `--base-branch` matches
+  spawn for worktrees, while the target machine is always derived from the
+  source environment. Anchor with
   `--source-seq-end` on a completed source turn (the clone and inherited
   timeline both end with the turn containing that sequence). Permission mode
   inherits the source thread unless explicitly overridden.

--- a/packages/templates/src/templates/bb-guide-threads.md
+++ b/packages/templates/src/templates/bb-guide-threads.md
@@ -22,7 +22,7 @@ Spawning:
     --model <model>                Model override
     --reasoning-level <level>      Reasoning level: low, medium, high, xhigh, max (provider-dependent)
     --environment <id-or-path>     Attach to an existing environment (ID or workspace path)
-    --new-environment <kind>       Create a new environment (worktree)
+    --new-environment <kind>       Create a fresh personal workspace or managed worktree
     --base-branch <branch>         Exact Git ref for a new managed worktree
     --machine <id-or-name>         Run on a machine (--host is an alias)
     --service-tier <tier>          Service tier: fast, default
@@ -70,7 +70,7 @@ Forking:
     --prompt <prompt>              Optional first prompt; omit for an idle fork
     --source-seq-end <seq>         Fork after the source turn containing this event sequence (tip by default)
     --environment <id-or-path>     Existing environment ID or unmanaged workspace path
-    --new-environment worktree     Create a new managed worktree
+    --new-environment <kind>       Create a fresh personal workspace or managed worktree
     --base-branch <branch>         Exact Git ref for a new worktree; omit for the project default
     --title <title>                Thread title
     --permission-mode <mode>       Inherit source by default; accepts accept-edits, auto, full
@@ -86,11 +86,12 @@ Forking:
   branches before it, like editing it). Without it a fork clones the session
   tip and inherits every completed turn. Providers that can only clone a whole
   session accept an anchor only on the source's latest turn. A fork reuses the
-  source environment by default. Use --new-environment worktree for a fresh
-  worktree on the source machine; --environment can select another environment
-  or unmanaged path on that machine. A different machine is rejected because
-  the source provider session lives on its original machine. Omit --prompt to
-  create an idle fork.
+  source environment by default. Use --new-environment personal for a fresh
+  personal workspace or --new-environment worktree for a fresh worktree on the
+  source machine; --environment can select another environment or unmanaged
+  path on that machine. A different machine is rejected because the source
+  provider session lives on its original machine. Omit --prompt to create an
+  idle fork.
 
 Editing a sent message (requires the default-on `editMessages` experiment):
 


### PR DESCRIPTION
## Human comments

## What was wrong

[PR #3018](https://github.com/get-bb/bb/pull/3018) replaced the fork-specific workspace switch with normal environment selection, but the shared CLI environment builder recognized only `worktree`. The server and SDK still accepted fresh personal workspaces, so personal-project users lost the CLI path that the former isolated fork option provided.

## What changed

- Accept `--new-environment personal` through the existing host-placement path, which makes forks use their derived source host.
- Advertise and document both supported fresh environment choices in CLI help, the generated guide source, and the bundled bb-cli skill.
- Add focused builder, fork-request, source-host, and help coverage while preserving default reuse, worktree/base-branch behavior, and the absence of a cross-host fork selector.
- No server/daemon wire contract changed, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

## How you verified

- The new focused assertions failed before the implementation and pass afterward: 40/40 tests across `spawn-helpers.test.ts` and `command-output/thread-fork.test.ts`.
- `pnpm exec turbo run test --filter=@bb/templates -- --run test/templates.test.ts` — 7/7 passed.
- `pnpm exec turbo run build typecheck --filter=@bb/cli --filter=@bb/templates` — 6/6 tasks passed.
- `pnpm exec oxfmt --check ...` and `git diff --check` passed.

Fixes #3018

> AGENT GENERATED
