### PR TITLE
Fix Codex archive undo synchronization

### DIFF
--- a/apps/server/src/routes/threads/actions.ts
+++ b/apps/server/src/routes/threads/actions.ts
@@ -574,7 +574,7 @@ export function registerThreadActionRoutes(app: Hono, deps: AppDeps): void {
     const thread = requirePublicThread(deps.db, context.req.param("id"));
     const providerThreadId = getLastProviderThreadId(deps, thread.id);
     unarchiveThread(deps.db, deps.hub, thread.id);
-    const environment = thread.environmentId
+    let environment = thread.environmentId
       ? getEnvironment(deps.db, thread.environmentId)
       : null;
     if (environment?.status === "retiring") {
@@ -582,6 +582,7 @@ export function registerThreadActionRoutes(app: Hono, deps: AppDeps): void {
         environmentId: environment.id,
         event: { type: "retire.cancelled" },
       });
+      environment = getEnvironment(deps.db, environment.id);
     }
     if (providerThreadId && environment) {
       dispatchThreadUnarchiveCommand(deps, {

--- a/apps/server/test/public/public-thread-environment-decoupling.test.ts
+++ b/apps/server/test/public/public-thread-environment-decoupling.test.ts
@@ -5,6 +5,7 @@ import {
 } from "@bb/db/internal-environment-lifecycle";
 import type { EnvironmentStatus } from "@bb/domain";
 import { describe, expect, it } from "vitest";
+import { listQueuedThreadCommands } from "../helpers/commands.js";
 import { readJson } from "../helpers/json.js";
 import {
   seedEnvironment,
@@ -37,6 +38,12 @@ describe("thread environment decoupling (B*)", () => {
         environmentId: environment.id,
         status: "idle",
       });
+      const providerThreadId = "provider-unarchive-revive";
+      seedThreadRuntimeState(harness.deps, {
+        environmentId: environment.id,
+        providerThreadId,
+        threadId: thread.id,
+      });
       archiveThread(harness.db, harness.hub, thread.id);
 
       const response = await harness.app.request(
@@ -49,6 +56,17 @@ describe("thread environment decoupling (B*)", () => {
       expect(getEnvironment(harness.db, environment.id)).toMatchObject({
         status: "ready",
       });
+      expect(
+        listQueuedThreadCommands(harness, "thread.unarchive", thread.id),
+      ).toEqual([
+        expect.objectContaining({
+          environmentId: environment.id,
+          providerThreadId,
+          providerId: thread.providerId,
+          threadId: thread.id,
+          type: "thread.unarchive",
+        }),
+      ]);
     });
   });
 

--- a/packages/host-daemon-contract/src/protocol.ts
+++ b/packages/host-daemon-contract/src/protocol.ts
@@ -1,3 +1,3 @@
-export const HOST_DAEMON_PROTOCOL_VERSION = 178 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 179 as const;
 
 export const HOST_ARTIFACT_MAX_BYTES = 256 * 1024 * 1024;

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -930,7 +930,7 @@ const ACP_BRIDGE_LAUNCH = {
 
 describe("host-daemon command schemas", () => {
   it("uses the current host-daemon protocol version", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(178);
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(179);
     expect(HOST_ARTIFACT_MAX_BYTES).toBe(256 * 1024 * 1024);
   });
 

--- a/plugins/provider-codex/src/bridge/app-server-connection.ts
+++ b/plugins/provider-codex/src/bridge/app-server-connection.ts
@@ -44,7 +44,7 @@ interface CodexAppServerRequestArgs<TResult> {
 export interface CodexAppServerConnection {
   request<TResult>(args: CodexAppServerRequestArgs<TResult>): Promise<TResult>;
   notify(method: string, params?: unknown): void;
-  kill(): void;
+  kill(): Promise<void>;
   readonly exited: boolean;
 }
 
@@ -112,6 +112,10 @@ export function createCodexAppServerConnection(
   } | null = null;
   let closeGraceTimer: NodeJS.Timeout | null = null;
   let stdoutLines: Interface | null = null;
+  let resolveExit!: () => void;
+  const exitPromise = new Promise<void>((resolve) => {
+    resolveExit = resolve;
+  });
 
   function writeLine(message: object): void {
     const stdin = child.stdin;
@@ -155,7 +159,11 @@ export function createCodexAppServerConnection(
         { spawnFailed },
       ),
     );
-    options.onExit({ ...status, stderrTail, spawnFailed });
+    try {
+      options.onExit({ ...status, stderrTail, spawnFailed });
+    } finally {
+      resolveExit();
+    }
   }
 
   if (child.stdout) {
@@ -313,7 +321,7 @@ export function createCodexAppServerConnection(
 
     kill() {
       if (finalized) {
-        return;
+        return exitPromise;
       }
       const escalation = setTimeout(() => {
         if (!finalized) {
@@ -322,6 +330,7 @@ export function createCodexAppServerConnection(
       }, KILL_ESCALATION_MS);
       escalation.unref?.();
       child.kill("SIGTERM");
+      return exitPromise;
     },
   };
 }

--- a/plugins/provider-codex/src/bridge/bridge.archive-idempotency.test.ts
+++ b/plugins/provider-codex/src/bridge/bridge.archive-idempotency.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -15,14 +15,25 @@ const fakeAppServerPath = fileURLToPath(
 
 let harness: ReturnType<typeof createBridgeJsonRpcTestHarness>;
 let workspaceDir: string;
+let processLogPath: string;
+
+const sessionOptions = {
+  permissionMode: "full",
+  permissionScope: "full",
+  approvalReviewer: null,
+  permissionEscalation: null,
+} as const;
 
 beforeEach(() => {
   workspaceDir = mkdtempSync(join(tmpdir(), "bb-codex-archive-ws-"));
+  processLogPath = join(workspaceDir, "app-server-processes.log");
   const fakeScriptPath = join(workspaceDir, "fake-codex-script.json");
   writeFileSync(
     fakeScriptPath,
     JSON.stringify({
       archiveStatePath: join(workspaceDir, "fake-codex-archived.json"),
+      processLogPath,
+      sigtermDelayMs: 250,
     }),
   );
   vi.stubEnv("BB_CODEX_BRIDGE_APP_SERVER_COMMAND", process.execPath);
@@ -46,6 +57,31 @@ function request(id: number, method: string) {
   });
   return harness.waitForResponse(id);
 }
+
+function processStepCount(step: string): number {
+  return readFileSync(processLogPath, "utf8")
+    .split("\n")
+    .filter((line) => line.startsWith(`${step}:`)).length;
+}
+
+it("finishes each app-server handoff before acknowledging archive and unarchive", async () => {
+  harness.sendRequest(1, "thread/resume", {
+    threadId: THREAD_ID,
+    providerThreadId: PROVIDER_THREAD_ID,
+    cwd: workspaceDir,
+    instructionMode: "append",
+    options: sessionOptions,
+  });
+  expect((await harness.waitForResponse(1)).error).toBeUndefined();
+
+  expect((await request(2, "thread/archive")).result).toEqual({ ok: true });
+  expect(processStepCount("spawn")).toBe(1);
+  expect(processStepCount("exit")).toBe(1);
+
+  expect((await request(3, "thread/unarchive")).result).toEqual({ ok: true });
+  expect(processStepCount("spawn")).toBe(2);
+  expect(processStepCount("exit")).toBe(2);
+}, 30_000);
 
 it("answers a repeated archive and a repeated unarchive as already done", async () => {
   expect((await request(1, "thread/archive")).result).toEqual({ ok: true });

--- a/plugins/provider-codex/src/bridge/bridge.archived-resume.test.ts
+++ b/plugins/provider-codex/src/bridge/bridge.archived-resume.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -24,13 +24,20 @@ const sessionOptions = {
 
 let harness: ReturnType<typeof createBridgeJsonRpcTestHarness>;
 let workspaceDir: string;
+let processLogPath: string;
 
 beforeEach(() => {
   workspaceDir = mkdtempSync(join(tmpdir(), "bb-codex-archived-ws-"));
+  processLogPath = join(workspaceDir, "app-server-processes.log");
+  const scriptPath = join(workspaceDir, "fake-codex-script.json");
+  writeFileSync(
+    scriptPath,
+    JSON.stringify({ processLogPath, sigtermDelayMs: 250 }),
+  );
   vi.stubEnv("BB_CODEX_BRIDGE_APP_SERVER_COMMAND", process.execPath);
   vi.stubEnv(
     "BB_CODEX_BRIDGE_APP_SERVER_ARGS",
-    JSON.stringify([fakeAppServerPath]),
+    JSON.stringify([fakeAppServerPath, scriptPath]),
   );
   harness = createBridgeJsonRpcTestHarness(handleLine);
 });
@@ -71,6 +78,7 @@ it("preserves the archived-session error text verbatim on a rejected resume", as
       retryable: true,
     },
   });
+  expect(readFileSync(processLogPath, "utf8")).toContain("exit:");
 }, 30_000);
 
 it("attaches the sessionArchived hint to a fork whose source is archived", async () => {

--- a/plugins/provider-codex/src/bridge/bridge.ts
+++ b/plugins/provider-codex/src/bridge/bridge.ts
@@ -374,6 +374,8 @@ interface CodexBridgeSession {
   pendingPreIdentityDeltas: ThreadDelta[];
   rebuildBeforeNextTurnReason: string | null;
   closing: boolean;
+  previousChildExit: Promise<void> | null;
+  releasePromise: Promise<void> | null;
 }
 
 const sessionsByBbThreadId = new Map<string, CodexBridgeSession>();
@@ -401,13 +403,26 @@ function currentSession(
   return session;
 }
 
-function releaseSession(session: CodexBridgeSession): void {
+function releaseSession(session: CodexBridgeSession): Promise<void> {
+  if (session.releasePromise !== null) {
+    return session.releasePromise;
+  }
   session.closing = true;
   if (sessionsByBbThreadId.get(session.bbThreadId) === session) {
     sessionsByBbThreadId.delete(session.bbThreadId);
   }
-  session.connection?.kill();
+  const previousChildExit = session.previousChildExit;
+  session.previousChildExit = null;
+  const currentChildExit = session.connection?.kill() ?? Promise.resolve();
   session.connection = null;
+  const releasePromise =
+    previousChildExit === null
+      ? currentChildExit
+      : Promise.all([previousChildExit, currentChildExit]).then(
+          () => undefined,
+        );
+  session.releasePromise = releasePromise;
+  return releasePromise;
 }
 
 const codexProviderOptionsSchema = z
@@ -845,10 +860,6 @@ async function constructThreadSession(
   args: ConstructThreadSessionArgs,
 ): Promise<ConstructedCodexSession> {
   const existing = sessionsByBbThreadId.get(args.threadId);
-  if (existing) {
-    releaseSession(existing);
-  }
-
   const decoded = decodeCodexOptions(args.options);
   sessionSerialCounter += 1;
   const serial = sessionSerialCounter;
@@ -886,8 +897,25 @@ async function constructThreadSession(
     pendingPreIdentityDeltas: [],
     rebuildBeforeNextTurnReason: null,
     closing: false,
+    previousChildExit: null,
+    releasePromise: null,
   };
   sessionsByBbThreadId.set(args.threadId, session);
+  if (existing) {
+    const previousChildExit = releaseSession(existing);
+    session.previousChildExit = previousChildExit;
+    await previousChildExit;
+    if (session.previousChildExit === previousChildExit) {
+      session.previousChildExit = null;
+    }
+    if (session.closing) {
+      throw new CodexSessionReleasedError(
+        new Error(
+          "codex session was released while waiting for the previous app-server to exit",
+        ),
+      );
+    }
+  }
   if (args.request.kind === "resume") {
     announceSessionIdentity(session, args.request.providerThreadId);
   }
@@ -931,10 +959,7 @@ async function constructThreadSession(
     };
 
     let method: string;
-    let params:
-      | BbThreadStartParams
-      | BbThreadResumeParams
-      | BbThreadForkParams;
+    let params: BbThreadStartParams | BbThreadResumeParams | BbThreadForkParams;
     switch (args.request.kind) {
       case "start": {
         method = "thread/start";
@@ -994,7 +1019,7 @@ async function constructThreadSession(
       sessionsByBbThreadId.delete(args.threadId);
     }
     session.closing = true;
-    connection.kill();
+    await connection.kill();
     throw released ? new CodexSessionReleasedError(error) : error;
   }
 }
@@ -1029,6 +1054,8 @@ function registerResumableSession(session: CodexBridgeSession): void {
     pendingPreIdentityDeltas: [],
     rebuildBeforeNextTurnReason: null,
     closing: false,
+    previousChildExit: null,
+    releasePromise: null,
   });
 }
 
@@ -1090,7 +1117,7 @@ async function withMaintenanceChild<T>(
     return await fn(connection);
   } finally {
     maintenanceConnections.delete(connection);
-    connection.kill();
+    await connection.kill();
   }
 }
 
@@ -1126,7 +1153,7 @@ async function getModelListConnection(): Promise<CodexAppServerConnection> {
       return connection;
     } catch (error) {
       maintenanceConnections.delete(connection);
-      connection.kill();
+      await connection.kill();
       throw error;
     }
   })();
@@ -1459,7 +1486,7 @@ async function handleThreadStop(
 
   if (params.intent === "release") {
     if (session) {
-      releaseSession(session);
+      await releaseSession(session);
     }
     sendResult(id, { ok: true });
     return;
@@ -1515,7 +1542,7 @@ async function handleThreadStop(
       providerThreadId: session.codexThreadId,
     }),
   );
-  releaseSession(session);
+  await releaseSession(session);
   sendResult(id, { ok: true });
 }
 
@@ -1563,11 +1590,11 @@ async function handleThreadMaintenance(
     alreadyInRequestedState?: RegExp;
   },
 ): Promise<void> {
-  const settle = (): void => {
+  const settle = async (): Promise<void> => {
     if (options?.releaseAfter) {
       const session = sessionsByBbThreadId.get(params.threadId);
       if (session) {
-        releaseSession(session);
+        await releaseSession(session);
       }
     }
     sendResult(id, { ok: true });
@@ -1576,13 +1603,13 @@ async function handleThreadMaintenance(
     await withChildForThread(params.threadId, (connection) =>
       sendMaintenanceRequestWithRetries(connection, request),
     );
-    settle();
+    await settle();
   } catch (error) {
     if (
       error instanceof Error &&
       options?.alreadyInRequestedState?.test(error.message) === true
     ) {
-      settle();
+      await settle();
       return;
     }
     rejectWithCodexError(id, error);

--- a/plugins/provider-codex/src/bridge/fake-codex-app-server.mjs
+++ b/plugins/provider-codex/src/bridge/fake-codex-app-server.mjs
@@ -167,6 +167,7 @@ const archivedThreadIds = new Set();
 const processLogPath = script?.processLogPath ?? null;
 /** `startDelayMs`: answer `thread/start` only after this many milliseconds. */
 const startDelayMs = script?.startDelayMs ?? 0;
+const sigtermDelayMs = script?.sigtermDelayMs ?? 0;
 
 function logProcessStep(step) {
   if (processLogPath === null) {
@@ -176,9 +177,17 @@ function logProcessStep(step) {
 }
 
 logProcessStep("spawn");
-process.on("SIGTERM", () => {
+function exitCleanly() {
   logProcessStep("exit");
   process.exit(0);
+}
+
+process.on("SIGTERM", () => {
+  if (sigtermDelayMs > 0) {
+    setTimeout(exitCleanly, sigtermDelayMs);
+    return;
+  }
+  exitCleanly();
 });
 let scriptedTurnIndex = 0;
 
@@ -556,6 +565,5 @@ stdinLines.on("line", (line) => {
   }
 });
 stdinLines.on("close", () => {
-  logProcessStep("exit");
-  process.exit(0);
+  exitCleanly();
 });


### PR DESCRIPTION
## Human comments

## What was wrong

Undoing an archive revived the BB environment but passed its stale `retiring` snapshot to provider command dispatch, so Codex never received `thread.unarchive`. A later resume detected the archived Codex session and attempted recovery while the rejected app-server child was still exiting, allowing the maintenance unarchive request to contend with the old process and time out. Investigation: https://ymichael.getbb.app/projects/proj_qrv2s45kmq/threads/thr_s29iedumci

## What changed

The unarchive route now reloads the environment after cancelling retirement before dispatching the provider command. Codex app-server shutdown is now awaitable and session releases, maintenance children, rejected resumes, and replacement handoffs wait for process exit before acknowledging or starting the next child. Regression tests cover provider forwarding and delayed-process resume → archive → unarchive handoffs. `HOST_DAEMON_PROTOCOL_VERSION` is bumped to 179 because the server now sends an unarchive command that this route previously skipped.

## How you verified

- `pnpm exec turbo run test --filter=@bb/server -- test/public/public-thread-environment-decoupling.test.ts`
- `pnpm exec turbo run test --filter=bb-plugin-provider-codex`
- `pnpm exec turbo run test --filter=@bb/host-daemon-contract`
- `pnpm exec turbo run typecheck --filter=@bb/server --filter=bb-plugin-provider-codex --filter=@bb/host-daemon-contract`
- `bb plugin build plugins/provider-codex`
- `git diff --check`
- Source CLI against the isolated dev server: created a managed Codex thread, observed its environment enter `retiring` after archive, unarchived it back to `ready`, sent a follow-up, and received `managed-archive-followup-ok`

Fixes #

> AGENT GENERATED
