### PR TITLE
Keep dispatch fixture identities internally consistent

### DIFF
--- a/packages/plugin-sdk/src/testing/__tests__/fake-plugin-host.test.ts
+++ b/packages/plugin-sdk/src/testing/__tests__/fake-plugin-host.test.ts
@@ -20,6 +20,38 @@ import {
 } from "../index.js";
 
 describe("fixtures", () => {
+  it("derives linked dispatch identities unless explicitly overridden", () => {
+    const inherited = makeMessageDispatchHookContext({
+      project: { id: "project-target" },
+      environment: { id: "environment-target" },
+      host: { id: "host-target" },
+    });
+    const explicit = makeMessageDispatchHookContext({
+      project: { id: "project-target" },
+      environment: {
+        id: "environment-target",
+        projectId: "environment-project-explicit",
+        hostId: "environment-host-explicit",
+      },
+      host: { id: "host-target" },
+      thread: {
+        projectId: "thread-project-explicit",
+        environmentId: "thread-environment-explicit",
+      },
+    });
+
+    expect(inherited.thread.projectId).toBe("project-target");
+    expect(inherited.thread.environmentId).toBe("environment-target");
+    expect(inherited.environment?.projectId).toBe("project-target");
+    expect(inherited.environment?.hostId).toBe("host-target");
+    expect(explicit.thread.projectId).toBe("thread-project-explicit");
+    expect(explicit.thread.environmentId).toBe("thread-environment-explicit");
+    expect(explicit.environment?.projectId).toBe(
+      "environment-project-explicit",
+    );
+    expect(explicit.environment?.hostId).toBe("environment-host-explicit");
+  });
+
   it("keeps queued messages on the dispatch context thread by default", () => {
     const inherited = makeMessageDispatchHookContext({
       thread: { id: "thread-target" },

--- a/packages/plugin-sdk/src/testing/fixtures.ts
+++ b/packages/plugin-sdk/src/testing/fixtures.ts
@@ -184,7 +184,9 @@ export function makeMessageDispatchHookContext(
     startedOnBehalfOf: null,
     parentThreadId: null,
   };
-  const environment: NonNullable<MessageDispatchHookContext["environment"]> = {
+  const environmentDefaults: NonNullable<
+    MessageDispatchHookContext["environment"]
+  > = {
     id: "environment-1",
     name: null,
     projectId: "project-1",
@@ -202,7 +204,7 @@ export function makeMessageDispatchHookContext(
     createdAt: 0,
     updatedAt: 0,
   };
-  const host: NonNullable<MessageDispatchHookContext["host"]> = {
+  const hostDefaults: NonNullable<MessageDispatchHookContext["host"]> = {
     id: "host-1",
     name: "Test host",
     type: "persistent",
@@ -213,24 +215,37 @@ export function makeMessageDispatchHookContext(
     createdAt: 0,
     updatedAt: 0,
   };
-  const thread = { ...context.thread, ...overrides.thread };
+  const project = { ...context.project, ...overrides.project };
+  const host =
+    overrides.host === undefined
+      ? context.host
+      : overrides.host === null
+        ? null
+        : { ...hostDefaults, ...overrides.host };
+  const environment =
+    overrides.environment === undefined
+      ? context.environment
+      : overrides.environment === null
+        ? null
+        : {
+            ...environmentDefaults,
+            projectId: project.id,
+            hostId: host?.id ?? environmentDefaults.hostId,
+            ...overrides.environment,
+          };
+  const thread = {
+    ...context.thread,
+    projectId: project.id,
+    environmentId: environment?.id ?? null,
+    ...overrides.thread,
+  };
   return {
     ...context,
     ...overrides,
     thread,
-    project: { ...context.project, ...overrides.project },
-    environment:
-      overrides.environment === undefined
-        ? context.environment
-        : overrides.environment === null
-          ? null
-          : { ...environment, ...overrides.environment },
-    host:
-      overrides.host === undefined
-        ? context.host
-        : overrides.host === null
-          ? null
-          : { ...host, ...overrides.host },
+    project,
+    environment,
+    host,
     input: { ...context.input, ...overrides.input },
     requestedExecution: {
       ...context.requestedExecution,


### PR DESCRIPTION
## Human comments

## What was wrong

The public `makeMessageDispatchHookContext` testing helper merged project, environment, host, and thread overrides independently, so linked default IDs could still point at the fixture's original objects after callers supplied replacements. That let plugin tests exercise combinations bb never emits. Fixes the reproduced issue in #3026; investigation details are in the [fixer thread](https://ymichael.getbb.app/projects/proj_qrv2s45kmq/threads/thr_f28ttatjms).

## What changed

The helper now builds related objects in dependency order and derives default project, environment, and host references from the already-merged objects. Explicit relationship overrides still win, null environment/host behavior is unchanged, and all defaults remain local to each call for fresh-object isolation. Added one regression test covering both derived identities and deliberate explicit overrides. There are no wire-contract, host-daemon protocol, CLI, configuration, documentation, or public API signature changes.

## How you verified

- The new relation test failed before the implementation with `expected 'project-1' to be 'project-target'` and passes after it.
- `pnpm exec turbo run test typecheck build --filter=@get-bb/plugin-sdk --filter=bb-plugin-concurrency-limit --force` — 226 SDK tests and 28 consumer tests passed; both typechecks and the 17-entry SDK runtime build passed after rebase.
- `pnpm exec turbo run test typecheck --filter=@bb/plugin-api-map --force` — all 76 Plugin Guide/API inventory tests and typecheck passed.
- A package-level `@get-bb/plugin-sdk/testing` import returned matching custom project, environment, host, and linked IDs after the fix.
- The branch was rebased onto `dbc16017c9c980391fb1bc604b45b94f9c3ae105`; stable patch ID `18522f86972fa384d2fe769926fd4dedc0945957` was unchanged and `git diff --check` passed.

Fixes #3026

> AGENT GENERATED
