### PR TITLE
Preserve trusted bots in PR approval gate

### DIFF
--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -2,6 +2,7 @@ amadad
 andrewkchan
 AndrewSB
 barelyhuman
+bb-slop-cop[bot]
 ben-vargas
 bradhallett
 brsbl
@@ -9,6 +10,7 @@ builtui
 charpeni
 Danielalnajjar
 davidondrej
+dependabot[bot]
 DevVig
 Diffuzmetall
 dillonzq

--- a/.github/workflows/approve-contributor.yml
+++ b/.github/workflows/approve-contributor.yml
@@ -32,7 +32,10 @@ jobs:
           COMMENT_BODY: ${{ github.event.comment.body }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
-          target="$(printf '%s' "$COMMENT_BODY" | sed -n 's|^/approve @\([A-Za-z0-9-]*\).*|\1|p' | head -n 1)"
+          target=""
+          if [[ "$COMMENT_BODY" =~ ^/approve\ @([A-Za-z0-9]+(-[A-Za-z0-9]+)*)(\[bot\])?$ ]] && [ "${#BASH_REMATCH[1]}" -le 39 ]; then
+            target="${BASH_REMATCH[1]}${BASH_REMATCH[3]}"
+          fi
           if [ -z "$target" ]; then
             exit 1
           fi

--- a/packages/scripts/test/pr-approval-workflows.test.ts
+++ b/packages/scripts/test/pr-approval-workflows.test.ts
@@ -1,0 +1,73 @@
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, it } from "vitest";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+
+function stepScript(workflow: string, step: string): string {
+  const lines = readFileSync(
+    resolve(repoRoot, ".github/workflows", workflow),
+    "utf8",
+  ).split("\n");
+  const stepIndex = lines.indexOf(`      - name: ${step}`);
+  const runIndex = lines.indexOf("        run: |", stepIndex);
+  let end = runIndex + 1;
+  while (
+    end < lines.length &&
+    (lines[end] === "" || lines[end]?.startsWith("          "))
+  )
+    end += 1;
+  return lines
+    .slice(runIndex + 1, end)
+    .map((line) => line.slice(10))
+    .join("\n");
+}
+
+function run(script: string, env: Record<string, string>) {
+  return spawnSync("bash", ["-c", script], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: { ...process.env, ...env },
+  });
+}
+
+it("keeps trusted automation pull requests open", () => {
+  const script = `gh() { printf '%s\\n' "$*"; }\n${stepScript("pr-gate.yml", "Check approval and close unapproved PRs")}`;
+  const gate = (author: string) =>
+    run(script, {
+      PR_AUTHOR: author,
+      PR_ASSOCIATION: "NONE",
+      PR_NUMBER: "123",
+      GITHUB_REPOSITORY: "get-bb/bb",
+    });
+  for (const author of ["bb-slop-cop[bot]", "dependabot[bot]"]) {
+    const result = gate(author);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("--remove-label needs-approval");
+    expect(result.stdout).not.toContain("pr close");
+  }
+  expect(gate("untrusted-automation[bot]").stdout).toContain("pr close");
+});
+
+it("parses only complete GitHub user and bot approval commands", () => {
+  const workflow = stepScript("approve-contributor.yml", "Add name and push");
+  const parser = `${workflow.slice(0, workflow.indexOf("list_path="))}printf '%s' "$target"`;
+  for (const [comment, target] of [
+    ["/approve @trusted-user", "trusted-user"],
+    ["/approve @dependabot[bot]", "dependabot[bot]"],
+  ]) {
+    const result = run(parser, { COMMENT_BODY: comment });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe(target);
+  }
+  for (const comment of [
+    "/approve @bad-",
+    "/approve @bad--name",
+    "/approve @dependabot[bot] trailing",
+    "/approve @user; echo unsafe",
+  ]) {
+    expect(run(parser, { COMMENT_BODY: comment }).status).not.toBe(0);
+  }
+});

--- a/turbo.json
+++ b/turbo.json
@@ -461,6 +461,9 @@
       "dependsOn": ["//#ensure-native-modules", "@bb/cli#build", "topo"],
       "inputs": [
         "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/.github/APPROVED_CONTRIBUTORS",
+        "$TURBO_ROOT$/.github/workflows/approve-contributor.yml",
+        "$TURBO_ROOT$/.github/workflows/pr-gate.yml",
         "$TURBO_ROOT$/package.json",
         "$TURBO_ROOT$/vitest.shared.ts"
       ]


### PR DESCRIPTION
## Human comments

## What was wrong

The approval gate added in #3022 seeded only human contributors, so trusted pull requests from `bb-slop-cop[bot]` and `dependabot[bot]` were rejected. The maintainer escape hatch could not repair this because `/approve @name[bot]` was parsed only through the opening bracket and accepted otherwise-invalid trailing content.

## What changed

- Add the two active, repository-evidenced automation authors to the exact allow list without exempting arbitrary bots.
- Require `/approve` to contain one complete GitHub-style human or `[bot]` login, rejecting malformed identities and trailing content.
- Exercise the workflow shell directly for trusted and untrusted bot gating plus valid and invalid approval commands, and include the workflow inputs in the Turbo test cache key.

No permissions, approval-file writes, human allow-list behavior, fork safety, wire contracts, CLI surfaces, or mobile behavior changed.

## How you verified

- Reproduced both trusted bots being rejected and `[bot]` approval names being truncated before the fix.
- `pnpm exec turbo run test --filter=@bb/scripts --force` — 22 files and 129 tests passed.
- `pnpm exec turbo run typecheck build --filter=@bb/scripts` — both tasks passed.
- Parsed both workflows as YAML, checked their shell blocks with `bash -n`, and ran `git diff --check`.

Fixes #3022

> AGENT GENERATED
