### PR TITLE
Add retry action for stopped unaccepted requests

### DIFF
--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.stories.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.stories.tsx
@@ -679,7 +679,7 @@ export function ScheduledAndWaitingDispatch() {
       </StoryRow>
       <StoryRow
         label="retry"
-        hint="a failed turn queued by reference; no message to quote, not editable"
+        hint="a retryable turn queued by reference; no message to quote, not editable"
       >
         <ResponsivePromptStage>
           <StaticQueuedMessagesList queuedMessages={retry} />

--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.test.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.test.tsx
@@ -1711,7 +1711,7 @@ describe("queued row affordances", () => {
         sendAt: 0,
       },
     ]);
-    expect(getByText(/^Retry failed turn from /u)).toBeDefined();
+    expect(getByText(/^Retry turn from /u)).toBeDefined();
     expect(
       getByText(/^Rate limited · retrying at .* · attempt 2$/u),
     ).toBeDefined();

--- a/apps/app/src/components/thread/timeline/ConversationMessageContent.tsx
+++ b/apps/app/src/components/thread/timeline/ConversationMessageContent.tsx
@@ -88,8 +88,10 @@ interface ConversationMessageContentUserProps extends ConversationMessageContent
   mentions: readonly PromptTextMention[];
   onAddToChat?: ThreadTimelineAddToChatHandler;
   onEdit?: () => void;
+  onRetry?: () => void;
   resolveMentionLink?: PromptMentionLinkResolver;
   resolveSegmentLinkHref?: TimelineTitleLinkResolver;
+  retryDisabled?: boolean;
   onOpenLink?: ThreadTimelineLinkHandler;
   onTitleAction?: TimelineTitleActionResolver;
   senderThreadId: TimelineUserConversationRow["senderThreadId"];
@@ -151,11 +153,13 @@ interface UserConversationMessageProps {
   mobileActionDisplay: "inline" | "overflow";
   onAddToChat?: ThreadTimelineAddToChatHandler;
   onEdit?: () => void;
+  onRetry?: () => void;
   onOpenLink?: ThreadTimelineLinkHandler;
   onOpenLocalFileLink?: ThreadTimelineLocalFileLinkHandler;
   projectId?: string;
   resolveMentionLink?: PromptMentionLinkResolver;
   resolveSegmentLinkHref?: TimelineTitleLinkResolver;
+  retryDisabled?: boolean;
   onTitleAction?: TimelineTitleActionResolver;
   senderThreadId: TimelineUserConversationRow["senderThreadId"];
   senderThreadProjectId: string | null;
@@ -333,12 +337,14 @@ function UserConversationMessage({
   mobileActionDisplay,
   onAddToChat,
   onEdit,
+  onRetry,
   onOpenLink,
   onOpenLocalFileLink,
   pluginActions = [],
   projectId,
   resolveMentionLink,
   resolveSegmentLinkHref,
+  retryDisabled,
   onTitleAction,
   senderThreadId,
   senderThreadProjectId,
@@ -460,7 +466,9 @@ function UserConversationMessage({
             copyImageUrl={attachmentItems.imageItems[0]?.src}
             onAddToChat={onAddToChat}
             onEdit={onEdit}
+            onRetry={onRetry}
             pluginActions={pluginActions}
+            retryDisabled={retryDisabled}
           />
         </div>
       </div>
@@ -676,11 +684,13 @@ export function ConversationMessageContent(
         mobileActionDisplay={props.mobileActionDisplay ?? "overflow"}
         onAddToChat={props.onAddToChat}
         onEdit={props.onEdit}
+        onRetry={props.onRetry}
         onOpenLink={props.onOpenLink}
         onOpenLocalFileLink={onOpenLocalFileLink}
         projectId={projectId}
         resolveMentionLink={props.resolveMentionLink}
         resolveSegmentLinkHref={props.resolveSegmentLinkHref}
+        retryDisabled={props.retryDisabled}
         onTitleAction={props.onTitleAction}
         senderThreadId={props.senderThreadId}
         senderThreadProjectId={props.senderThreadProjectId ?? null}

--- a/apps/app/src/components/thread/timeline/MessageActionBar.test.tsx
+++ b/apps/app/src/components/thread/timeline/MessageActionBar.test.tsx
@@ -80,6 +80,23 @@ function mockMobileCoarsePointer() {
 }
 
 describe("MessageActionBar", () => {
+  it("renders retry as a destructive message action", () => {
+    const onRetry = vi.fn();
+    render(
+      <MessageActionBar
+        messageText="Build the sidebar"
+        alignment="end"
+        mobileActionDisplay="inline"
+        onRetry={onRetry}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "Retry request" });
+    expect(button.className).toContain("text-destructive");
+    fireEvent.click(button);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
   it("uses the nearest thread window as the tooltip collision boundary", () => {
     const threadWindow = document.createElement("div");
     threadWindow.setAttribute("data-thread-window", "");

--- a/apps/app/src/components/thread/timeline/MessageActionBar.tsx
+++ b/apps/app/src/components/thread/timeline/MessageActionBar.tsx
@@ -65,13 +65,21 @@ interface MessageActionBarProps {
   ) => void;
   onEdit?: () => void;
   onFork?: () => void;
+  onRetry?: () => void;
   onSendToMain?: () => void;
+  retryDisabled?: boolean;
   disabled?: boolean;
   pluginActions?: readonly ThreadTimelinePluginMessageAction[];
 }
 
 interface MessageOverflowAction {
-  icon: "Copy" | "Edit" | "MessageSquarePlus" | "Fork" | "ArrowTurnBackward";
+  icon:
+    | "Copy"
+    | "Edit"
+    | "MessageSquarePlus"
+    | "Fork"
+    | "ArrowTurnBackward"
+    | "RotateCcw";
   plugin?: { pluginId: string | null; icon: string | null };
   key?: string;
   label: string;
@@ -80,6 +88,7 @@ interface MessageOverflowAction {
   copyText?: string;
   copyImageUrl?: string;
   kind?: "copy";
+  variant?: "default" | "destructive";
 }
 
 const DESKTOP_ACTION_WIDTH_PX = 20;
@@ -238,7 +247,10 @@ function MobileMessageOverflowPopover({
             <button
               key={action.key ?? action.label}
               type="button"
-              className={MOBILE_OVERFLOW_ITEM_CLASS}
+              className={cn(
+                MOBILE_OVERFLOW_ITEM_CLASS,
+                action.variant === "destructive" && "text-destructive",
+              )}
               disabled={action.disabled}
               onClick={() => {
                 if (action.kind === "copy") {
@@ -328,7 +340,12 @@ function DesktopMessageAction({
         ) : (
           <button
             type="button"
-            className={cn(ACTION_BUTTON_CLASS, className)}
+            className={cn(
+              ACTION_BUTTON_CLASS,
+              action.variant === "destructive" &&
+                "text-destructive hover:text-destructive",
+              className,
+            )}
             onClick={action.onSelect}
             disabled={action.disabled}
             aria-label={action.label}
@@ -366,6 +383,7 @@ function MessageActionMenuItems({
       disabled={action.disabled}
       onSelect={action.onSelect}
       textValue={action.label}
+      variant={action.variant}
     >
       {action.plugin ? (
         <PluginActionIcon
@@ -389,7 +407,9 @@ export function MessageActionBar({
   onAddToChat,
   onEdit,
   onFork,
+  onRetry,
   onSendToMain,
+  retryDisabled,
   disabled,
   pluginActions = [],
 }: MessageActionBarProps) {
@@ -494,6 +514,17 @@ export function MessageActionBar({
             icon: "Edit" as const,
             label: "Edit message",
             onSelect: onEdit,
+          },
+        ]
+      : []),
+    ...(onRetry
+      ? [
+          {
+            icon: "RotateCcw" as const,
+            label: "Retry request",
+            onSelect: onRetry,
+            disabled: retryDisabled,
+            variant: "destructive" as const,
           },
         ]
       : []),
@@ -755,6 +786,8 @@ function MobileInlineActions({
           ACTION_BUTTON_CLASS,
           HOVER_REVEAL_CLASS,
           MOBILE_INLINE_ACTION_CLASS,
+          action.variant === "destructive" &&
+            "text-destructive hover:text-destructive",
         )}
         onClick={action.onSelect}
         disabled={action.disabled}

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.actions.test.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.actions.test.tsx
@@ -258,6 +258,51 @@ afterEach(() => {
 });
 
 describe("ThreadTimelineRows actions", () => {
+  it("offers retry only on the latest pending user request while idle", () => {
+    const onRetryMessage = vi.fn();
+    renderWithRouter(
+      <ThreadTimelineRows
+        timelineRows={[
+          conversationRow({
+            id: "older_pending_request",
+            role: "user",
+            text: "First request",
+            sourceSeqStart: 3,
+            turnRequest: {
+              isGrouped: false,
+              kind: "message",
+              status: "pending",
+            },
+          }),
+          conversationRow({
+            id: "latest_pending_request",
+            role: "user",
+            text: "Build the sidebar",
+            sourceSeqStart: 7,
+            turnRequest: {
+              isGrouped: false,
+              kind: "message",
+              status: "pending",
+            },
+          }),
+        ]}
+        onRetryMessage={onRetryMessage}
+        retryMessagePending={false}
+        threadRuntimeDisplayStatus="idle"
+        workspaceRootPath={undefined}
+      />,
+    );
+
+    const retry = screen.getByRole("button", { name: "Retry request" });
+    expect(
+      retry
+        .closest("[data-timeline-row-id]")
+        ?.getAttribute("data-timeline-row-id"),
+    ).toBe("latest_pending_request");
+    fireEvent.click(retry);
+    expect(onRetryMessage).toHaveBeenCalledTimes(1);
+  });
+
   it("uses inline mobile actions only for the last assistant message", () => {
     const { container } = renderWithRouter(
       <ThreadTimelineRows

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.actions.test.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.actions.test.tsx
@@ -303,6 +303,61 @@ describe("ThreadTimelineRows actions", () => {
     expect(onRetryMessage).toHaveBeenCalledTimes(1);
   });
 
+  it("does not rerender unrelated messages when retry pending changes", () => {
+    const rolesRead = vi.fn();
+    const rows = [
+      conversationRow({
+        id: "retryable_request",
+        role: "user",
+        text: "Build the sidebar",
+        turnRequest: {
+          isGrouped: false,
+          kind: "message",
+          status: "pending",
+        },
+      }),
+      conversationRow({
+        id: "unrelated_answer",
+        role: "assistant",
+        text: "Earlier answer",
+      }),
+    ];
+    const consumerAction = {
+      id: "observe-renders",
+      pluginId: null,
+      icon: null,
+      label: "Observe renders",
+      get roles(): readonly ("user" | "assistant")[] | undefined {
+        rolesRead();
+        return undefined;
+      },
+      run: vi.fn(),
+    };
+    const onRetryMessage = vi.fn();
+    const consumerMessageActions = [consumerAction];
+    const timeline = (retryMessagePending: boolean) => (
+      <ThreadTimelineRows
+        timelineRows={rows}
+        consumerMessageActions={consumerMessageActions}
+        onRetryMessage={onRetryMessage}
+        retryMessagePending={retryMessagePending}
+        threadRuntimeDisplayStatus="idle"
+        workspaceRootPath={undefined}
+      />
+    );
+    const rendered = renderWithRouter(timeline(false));
+    const initialReads = rolesRead.mock.calls.length;
+
+    rendered.rerender(<MemoryRouter>{timeline(true)}</MemoryRouter>);
+
+    expect(rolesRead).toHaveBeenCalledTimes(initialReads);
+    expect(
+      screen
+        .getByRole("button", { name: "Retry request" })
+        .getAttribute("disabled"),
+    ).not.toBeNull();
+  });
+
   it("uses inline mobile actions only for the last assistant message", () => {
     const { container } = renderWithRouter(
       <ThreadTimelineRows

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
@@ -149,6 +149,8 @@ export interface ThreadTimelineRowsProps {
   threadOriginKind?: ThreadOriginKind | null;
   onForkMessage?: ThreadTimelineForkMessageHandler;
   onEditMessage?: ThreadTimelineEditMessageHandler;
+  onRetryMessage?: () => void;
+  retryMessagePending?: boolean;
   inlineMessageEditor?: ThreadTimelineInlineMessageEditor;
   onMessageAddToChat?: ThreadTimelineAddToChatHandler;
   onSendToMainMessage?: ThreadTimelineSendToMainMessageHandler;
@@ -180,6 +182,9 @@ interface TimelineRendererStaticContextValue {
   getViewRows: GetTimelineViewRows;
   onForkMessage: ThreadTimelineForkMessageHandler | undefined;
   onEditMessage: ThreadTimelineEditMessageHandler | undefined;
+  onRetryMessage: (() => void) | undefined;
+  retryMessagePending: boolean;
+  retryableUserMessageId: string | null;
   inlineMessageEditor: ThreadTimelineInlineMessageEditor | undefined;
   onMessageAddToChat: ThreadTimelineAddToChatHandler | undefined;
   onSendToMainMessage: ThreadTimelineSendToMainMessageHandler | undefined;
@@ -790,6 +795,28 @@ function findLastActionableUserMessageId(
   return lastMessageId;
 }
 
+function findLastPendingUserRequestId(
+  rows: readonly ThreadTimelineViewRow[],
+): string | null {
+  let lastMessageId: string | null = null;
+  const visitRows = (candidateRows: readonly ThreadTimelineViewRow[]): void => {
+    for (const row of candidateRows) {
+      if (
+        row.kind === "conversation" &&
+        row.role === "user" &&
+        row.initiator === "user" &&
+        row.turnRequest.status === "pending"
+      ) {
+        lastMessageId = row.id;
+      } else if (row.kind === "turn" && row.children !== null) {
+        visitRows(row.children);
+      }
+    }
+  };
+  visitRows(rows);
+  return lastMessageId;
+}
+
 const EMPTY_CONSUMER_MESSAGE_ACTIONS: readonly ThreadTimelineConsumerMessageAction[] =
   [];
 
@@ -910,6 +937,7 @@ const ConversationRowContent = memo(function ConversationRowContent({
     inlineMessageEditor,
     onEditMessage,
     onForkMessage,
+    onRetryMessage,
     onMessageAddToChat,
     onSendToMainMessage,
     onSelectionAddToChat,
@@ -925,6 +953,8 @@ const ConversationRowContent = memo(function ConversationRowContent({
     resolveMentionLink,
     resolveSegmentLinkHref,
     resolveUserAttachmentImageSrc,
+    retryMessagePending,
+    retryableUserMessageId,
     threadId,
     workspaceRootPath,
   } = useTimelineRendererStaticContext();
@@ -996,6 +1026,10 @@ const ConversationRowContent = memo(function ConversationRowContent({
           });
         }
       : undefined;
+    const onRetry =
+      onRetryMessage !== undefined && row.id === retryableUserMessageId
+        ? onRetryMessage
+        : undefined;
     return (
       <ConversationMessageContent
         attachments={row.attachments}
@@ -1005,11 +1039,13 @@ const ConversationRowContent = memo(function ConversationRowContent({
         mobileActionDisplay={mobileActionDisplay}
         onAddToChat={onSelectionAddToChat}
         onEdit={onEdit}
+        onRetry={onRetry}
         onOpenLink={onOpenLink}
         onOpenLocalFileLink={onOpenLocalFileLink}
         projectId={projectId}
         resolveMentionLink={resolveMentionLink}
         resolveUserAttachmentImageSrc={resolveUserAttachmentImageSrc}
+        retryDisabled={retryMessagePending}
         role="user"
         resolveSegmentLinkHref={resolveSegmentLinkHref}
         onTitleAction={onTitleAction}
@@ -1989,6 +2025,14 @@ function ThreadTimelineRowsForTimelineView(props: ThreadTimelineRowsProps) {
   const scopeActive = isRunningThreadRuntimeDisplayStatus(
     props.threadRuntimeDisplayStatus,
   );
+  const retryableUserMessageId = useMemo(
+    () =>
+      props.onRetryMessage !== undefined &&
+      props.threadRuntimeDisplayStatus === "idle"
+        ? findLastPendingUserRequestId(rows)
+        : null,
+    [props.onRetryMessage, props.threadRuntimeDisplayStatus, rows],
+  );
   const streamingAssistantMessageId = useMemo(
     () => (scopeActive ? findStreamingAssistantMessageId(rows) : null),
     [rows, scopeActive],
@@ -2133,6 +2177,9 @@ function ThreadTimelineRowsForTimelineView(props: ThreadTimelineRowsProps) {
       getViewRows,
       onForkMessage: props.onForkMessage,
       onEditMessage: props.onEditMessage,
+      onRetryMessage: props.onRetryMessage,
+      retryMessagePending: props.retryMessagePending ?? false,
+      retryableUserMessageId,
       inlineMessageEditor: props.inlineMessageEditor,
       onMessageAddToChat: props.onMessageAddToChat,
       onSendToMainMessage: props.onSendToMainMessage,
@@ -2163,6 +2210,9 @@ function ThreadTimelineRowsForTimelineView(props: ThreadTimelineRowsProps) {
       getViewRows,
       props.onForkMessage,
       props.onEditMessage,
+      props.onRetryMessage,
+      props.retryMessagePending,
+      retryableUserMessageId,
       props.inlineMessageEditor,
       props.onMessageAddToChat,
       props.onSendToMainMessage,

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
@@ -183,7 +183,6 @@ interface TimelineRendererStaticContextValue {
   onForkMessage: ThreadTimelineForkMessageHandler | undefined;
   onEditMessage: ThreadTimelineEditMessageHandler | undefined;
   onRetryMessage: (() => void) | undefined;
-  retryMessagePending: boolean;
   retryableUserMessageId: string | null;
   inlineMessageEditor: ThreadTimelineInlineMessageEditor | undefined;
   onMessageAddToChat: ThreadTimelineAddToChatHandler | undefined;
@@ -379,6 +378,7 @@ const LatestActionableAssistantMessageIdContext = createContext<string | null>(
 );
 const LatestActionableUserMessageIdContext = createContext<string | null>(null);
 const StreamingAssistantMessageIdContext = createContext<string | null>(null);
+const RetryMessagePendingContext = createContext(false);
 const EMPTY_ROW_ID_SET: ReadonlySet<string> = new Set<string>();
 const TimelineSearchExpansionContext =
   createContext<ReadonlySet<string>>(EMPTY_ROW_ID_SET);
@@ -926,6 +926,14 @@ function InlineMessageEditorHost({
   );
 }
 
+function RetryMessagePendingContent({
+  children,
+}: {
+  children: (pending: boolean) => ReactNode;
+}) {
+  return children(useContext(RetryMessagePendingContext));
+}
+
 const ConversationRowContent = memo(function ConversationRowContent({
   row,
   showAssistantMessageActions,
@@ -953,7 +961,6 @@ const ConversationRowContent = memo(function ConversationRowContent({
     resolveMentionLink,
     resolveSegmentLinkHref,
     resolveUserAttachmentImageSrc,
-    retryMessagePending,
     retryableUserMessageId,
     threadId,
     workspaceRootPath,
@@ -1030,7 +1037,7 @@ const ConversationRowContent = memo(function ConversationRowContent({
       onRetryMessage !== undefined && row.id === retryableUserMessageId
         ? onRetryMessage
         : undefined;
-    return (
+    const renderMessage = (retryDisabled: boolean) => (
       <ConversationMessageContent
         attachments={row.attachments}
         originKind={originKind}
@@ -1045,7 +1052,7 @@ const ConversationRowContent = memo(function ConversationRowContent({
         projectId={projectId}
         resolveMentionLink={resolveMentionLink}
         resolveUserAttachmentImageSrc={resolveUserAttachmentImageSrc}
-        retryDisabled={retryMessagePending}
+        retryDisabled={retryDisabled}
         role="user"
         resolveSegmentLinkHref={resolveSegmentLinkHref}
         onTitleAction={onTitleAction}
@@ -1061,6 +1068,11 @@ const ConversationRowContent = memo(function ConversationRowContent({
         text={row.text}
         turnRequest={row.turnRequest}
       />
+    );
+    return onRetry === undefined ? (
+      renderMessage(false)
+    ) : (
+      <RetryMessagePendingContent>{renderMessage}</RetryMessagePendingContent>
     );
   }
   const onFork =
@@ -2178,7 +2190,6 @@ function ThreadTimelineRowsForTimelineView(props: ThreadTimelineRowsProps) {
       onForkMessage: props.onForkMessage,
       onEditMessage: props.onEditMessage,
       onRetryMessage: props.onRetryMessage,
-      retryMessagePending: props.retryMessagePending ?? false,
       retryableUserMessageId,
       inlineMessageEditor: props.inlineMessageEditor,
       onMessageAddToChat: props.onMessageAddToChat,
@@ -2211,7 +2222,6 @@ function ThreadTimelineRowsForTimelineView(props: ThreadTimelineRowsProps) {
       props.onForkMessage,
       props.onEditMessage,
       props.onRetryMessage,
-      props.retryMessagePending,
       retryableUserMessageId,
       props.inlineMessageEditor,
       props.onMessageAddToChat,
@@ -2272,27 +2282,31 @@ function ThreadTimelineRowsForTimelineView(props: ThreadTimelineRowsProps) {
                       value={props.timelineWindowingEnabled ?? false}
                     >
                       <AutoHeightContainer snapRevision={heightSnapRevision}>
-                        <TimelineRowsList
-                          hasOlderTimelineRows={props.hasOlderTimelineRows}
-                          isLoadingOlderTimelineRows={
-                            props.isLoadingOlderTimelineRows
-                          }
-                          navigationTargetRowId={
-                            props.timelineNavigationTargetRowId
-                          }
-                          onLoadOlderRows={props.onLoadOlderRows}
-                          rows={rows}
-                          scopeActive={scopeActive}
-                          showAssistantMessageActions={true}
-                          compactActivityIntents={false}
-                          spacing="top-level"
-                          unreadDividerAutoScroll={
-                            props.unreadDividerAutoScroll ?? true
-                          }
-                          unreadDividerPlacement={
-                            props.unreadDividerPlacement ?? null
-                          }
-                        />
+                        <RetryMessagePendingContext.Provider
+                          value={props.retryMessagePending ?? false}
+                        >
+                          <TimelineRowsList
+                            hasOlderTimelineRows={props.hasOlderTimelineRows}
+                            isLoadingOlderTimelineRows={
+                              props.isLoadingOlderTimelineRows
+                            }
+                            navigationTargetRowId={
+                              props.timelineNavigationTargetRowId
+                            }
+                            onLoadOlderRows={props.onLoadOlderRows}
+                            rows={rows}
+                            scopeActive={scopeActive}
+                            showAssistantMessageActions={true}
+                            compactActivityIntents={false}
+                            spacing="top-level"
+                            unreadDividerAutoScroll={
+                              props.unreadDividerAutoScroll ?? true
+                            }
+                            unreadDividerPlacement={
+                              props.unreadDividerPlacement ?? null
+                            }
+                          />
+                        </RetryMessagePendingContext.Provider>
                       </AutoHeightContainer>
                     </TimelineWindowingEnabledContext.Provider>
                   </TimelineWindowingMeasurementsContext.Provider>

--- a/apps/app/src/components/thread/timeline/ThreadTimelineSurface.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineSurface.tsx
@@ -49,6 +49,8 @@ export interface ThreadTimelineSurfaceProps {
   leadingContent?: ReactNode;
   onForkMessage?: ThreadTimelineForkMessageHandler;
   onEditMessage?: ThreadTimelineEditMessageHandler;
+  onRetryMessage?: () => void;
+  retryMessagePending?: boolean;
   inlineMessageEditor?: ThreadTimelineInlineMessageEditor;
   onMessageAddToChat?: ThreadTimelineAddToChatHandler;
   onSendToMainMessage?: ThreadTimelineSendToMainMessageHandler;
@@ -150,6 +152,8 @@ export function ThreadTimelineSurface({
   leadingContent,
   onForkMessage,
   onEditMessage,
+  onRetryMessage,
+  retryMessagePending,
   inlineMessageEditor,
   onMessageAddToChat,
   onSendToMainMessage,
@@ -225,6 +229,8 @@ export function ThreadTimelineSurface({
           threadOriginKind={threadOriginKind}
           onForkMessage={onForkMessage}
           onEditMessage={onEditMessage}
+          onRetryMessage={onRetryMessage}
+          retryMessagePending={retryMessagePending}
           inlineMessageEditor={inlineMessageEditor}
           onMessageAddToChat={onMessageAddToChat}
           onSendToMainMessage={onSendToMainMessage}

--- a/apps/app/src/hooks/mutations/thread-runtime-mutations.test.tsx
+++ b/apps/app/src/hooks/mutations/thread-runtime-mutations.test.tsx
@@ -94,6 +94,7 @@ function makeThreadResponse(
     },
     canSpawnChild: false,
     queuedMessageCount: 1,
+    retryableStoppedTurnRequestId: null,
     ...thread,
   });
 }

--- a/apps/app/src/hooks/mutations/thread-runtime-mutations.ts
+++ b/apps/app/src/hooks/mutations/thread-runtime-mutations.ts
@@ -53,6 +53,7 @@ import {
 import {
   invalidateThreadBannerQueries,
   invalidateThreadHistoryRewriteQueries,
+  invalidateThreadQueuedMessageSendQueries,
 } from "../cache-owners/mutation-cache-effects";
 
 interface CreateThreadQueuedMessageMutationRequest extends CreateQueuedMessageRequest {
@@ -83,6 +84,11 @@ interface SetThreadQueuedMessageGroupBoundaryMutationRequest {
   expectedGroupedPrefixQueuedMessageIds: string[];
   groupBoundaryQueuedMessageId: string;
   id: string;
+}
+
+interface RetryStoppedThreadRequestMutationRequest {
+  id: string;
+  turnRequestId: string;
 }
 
 function getHttpErrorBodyMessage(error: BbHttpError): string | null {
@@ -518,6 +524,28 @@ export function useStopThread() {
     },
     onSettled: (_data, _error, threadId) => {
       settleStopThreadTransaction({ queryClient, threadId });
+    },
+  });
+}
+
+export function useRetryStoppedThreadRequest() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    meta: {
+      errorMessage: "Failed to retry request.",
+      lifecycleOperation: "retry_request",
+    },
+    mutationFn: ({
+      id,
+      turnRequestId,
+    }: RetryStoppedThreadRequestMutationRequest) =>
+      sdk.threads.retry({ threadId: id, turnRequestId }),
+    onSuccess: (_data, variables) => {
+      invalidateThreadQueuedMessageSendQueries({
+        queryClient,
+        threadId: variables.id,
+      });
     },
   });
 }

--- a/apps/app/src/hooks/queries/thread-queries.ts
+++ b/apps/app/src/hooks/queries/thread-queries.ts
@@ -648,6 +648,7 @@ function liftThreadListPlaceholder(
     activeBackgroundAgentCount: thread.activity.activeBackgroundAgentCount,
     canSpawnChild: false,
     queuedMessageCount: 0,
+    retryableStoppedTurnRequestId: null,
   };
 }
 

--- a/apps/app/src/lib/queued-message-wait.test.ts
+++ b/apps/app/src/lib/queued-message-wait.test.ts
@@ -183,7 +183,7 @@ describe("queuedMessageWaitIcon", () => {
 });
 
 describe("queuedMessageFallbackTitle", () => {
-  it("names the failed turn a retry row re-submits", () => {
+  it("names the turn a retry row re-submits", () => {
     expect(
       queuedMessageFallbackTitle({
         createdAt: NOW,
@@ -195,7 +195,7 @@ describe("queuedMessageFallbackTitle", () => {
           reason: "Rate limited",
         },
       }),
-    ).toBe(`Retry failed turn from ${clockAt(NOW)}`);
+    ).toBe(`Retry turn from ${clockAt(NOW)}`);
   });
 });
 

--- a/apps/app/src/lib/queued-message-wait.ts
+++ b/apps/app/src/lib/queued-message-wait.ts
@@ -91,7 +91,7 @@ export function queuedMessageFallbackTitle(args: {
   payload: QueuedMessagePayload;
 }): string {
   if (args.payload.kind !== "retry") return "Queued message";
-  return `Retry failed turn from ${formatScheduledTime({
+  return `Retry turn from ${formatScheduledTime({
     now: args.now,
     timestamp: args.createdAt,
   })}`;

--- a/apps/app/src/test/fixtures/thread-responses.ts
+++ b/apps/app/src/test/fixtures/thread-responses.ts
@@ -23,6 +23,7 @@ export function makeThreadResponse(
     activeBackgroundAgentCount: 0,
     canSpawnChild: true,
     queuedMessageCount: 0,
+    retryableStoppedTurnRequestId: null,
     ...overrides,
     runtime: thread.runtime,
   };

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -52,6 +52,7 @@ import {
 import {
   useCreateThreadQueuedMessage,
   useEditThreadMessage,
+  useRetryStoppedThreadRequest,
   useSendThreadMessage,
 } from "../../hooks/mutations/thread-runtime-mutations";
 import { useUpdateEnvironment } from "../../hooks/mutations/environment-mutations";
@@ -630,11 +631,10 @@ function ThreadDetailViewInternal(props: ThreadRoutePathArgs) {
     },
   );
   const pendingInteractions = pendingInteractionsQuery.data ?? [];
-  const pendingInteractionsInitialLoading =
-    isPendingInteractionStateUnknown(
-      pendingInteractionsQuery.data,
-      pendingInteractionsQuery.isFetching,
-    );
+  const pendingInteractionsInitialLoading = isPendingInteractionStateUnknown(
+    pendingInteractionsQuery.data,
+    pendingInteractionsQuery.isFetching,
+  );
   const hasPendingInteraction =
     getLatestPendingInteraction(pendingInteractions) !== null;
   const { data: queuedMessagesForEditEligibility = [] } =
@@ -863,6 +863,8 @@ function ThreadDetailViewInternal(props: ThreadRoutePathArgs) {
   });
   const sendMessage = useSendThreadMessage();
   const editMessage = useEditThreadMessage();
+  const { isPending: retryStoppedRequestPending, mutate: retryStoppedRequest } =
+    useRetryStoppedThreadRequest();
   const createQueuedMessage = useCreateThreadQueuedMessage();
   const requestEnvironmentAction = useRequestEnvironmentAction();
   const [pullRequestMergeMethod, setPullRequestMergeMethod] = useAtom(
@@ -948,6 +950,15 @@ function ThreadDetailViewInternal(props: ThreadRoutePathArgs) {
     },
     [forkThreadFromMessage],
   );
+  const retryableStoppedTurnRequestId =
+    thread?.retryableStoppedTurnRequestId ?? null;
+  const handleRetryStoppedRequest = useCallback(() => {
+    if (thread === undefined || retryableStoppedTurnRequestId === null) return;
+    retryStoppedRequest({
+      id: thread.id,
+      turnRequestId: retryableStoppedTurnRequestId,
+    });
+  }, [retryStoppedRequest, retryableStoppedTurnRequestId, thread]);
   const threadProviderInfo = useSystemProviderInfo(
     thread?.environmentId
       ? {
@@ -2919,6 +2930,11 @@ function ThreadDetailViewInternal(props: ThreadRoutePathArgs) {
               onEditMessage: canEditSentMessages
                 ? handleEditSentMessage
                 : undefined,
+              onRetryMessage:
+                retryableStoppedTurnRequestId === null
+                  ? undefined
+                  : handleRetryStoppedRequest,
+              retryMessagePending: retryStoppedRequestPending,
               inlineMessageEditor,
               onMessageAddToChat: handleSelectionAddToChat,
               onSendToMainMessage: handleSendToMainMessage,

--- a/apps/cli/src/commands/thread/actions.ts
+++ b/apps/cli/src/commands/thread/actions.ts
@@ -487,30 +487,35 @@ export function registerActionsCommands(
 
   parent
     .command("retry [id]")
-    .description("Retry the failed turn on a thread")
+    .description("Retry a failed or stopped unaccepted turn on a thread")
     .option("--self", "Target the current thread (from BB_THREAD_ID)")
     .option(
       "--turn <requestId>",
-      "Retry this turn request id specifically; fails when it is not the thread's failed turn",
+      "Retry this turn request id specifically; fails when it is not the thread's retryable turn",
     )
     .option("--send-at <when>", SEND_AT_HELP)
-    .option("--reason <text>", "Why it is being retried, shown on the queued row")
+    .option(
+      "--reason <text>",
+      "Why it is being retried, shown on the queued row",
+    )
     .option("--json", "Print machine-readable JSON output")
     .action(
-      action(async (id: string | undefined, opts: ThreadRetryCommandOptions) => {
-        const threadId = requireThreadIdOrSelf(id, opts);
-        const sdk = createCliBbSdk(getUrl());
-        const response = await sdk.threads.retry({
-          threadId,
-          ...(opts.turn === undefined ? {} : { turnRequestId: opts.turn }),
-          ...(opts.sendAt === undefined
-            ? {}
-            : { sendAt: parseSendAt(opts.sendAt) }),
-          ...(opts.reason === undefined ? {} : { reason: opts.reason }),
-        });
-        if (outputJson(opts, { threadId, ...response })) return;
-        console.log(describeThreadRetryOutcome(threadId, response));
-      }),
+      action(
+        async (id: string | undefined, opts: ThreadRetryCommandOptions) => {
+          const threadId = requireThreadIdOrSelf(id, opts);
+          const sdk = createCliBbSdk(getUrl());
+          const response = await sdk.threads.retry({
+            threadId,
+            ...(opts.turn === undefined ? {} : { turnRequestId: opts.turn }),
+            ...(opts.sendAt === undefined
+              ? {}
+              : { sendAt: parseSendAt(opts.sendAt) }),
+            ...(opts.reason === undefined ? {} : { reason: opts.reason }),
+          });
+          if (outputJson(opts, { threadId, ...response })) return;
+          console.log(describeThreadRetryOutcome(threadId, response));
+        },
+      ),
     );
 
   parent

--- a/apps/cli/src/commands/thread/actions.ts
+++ b/apps/cli/src/commands/thread/actions.ts
@@ -487,7 +487,9 @@ export function registerActionsCommands(
 
   parent
     .command("retry [id]")
-    .description("Retry a failed or stopped unaccepted turn on a thread")
+    .description(
+      "Retry a failed turn or stopped unaccepted user request on a thread",
+    )
     .option("--self", "Target the current thread (from BB_THREAD_ID)")
     .option(
       "--turn <requestId>",

--- a/apps/demo-server/src/fixtures/world.ts
+++ b/apps/demo-server/src/fixtures/world.ts
@@ -98,7 +98,13 @@ export function threadResponse(
     queuedWork: _queuedWork,
     ...thread
   } = threadListEntry(view, now);
-  return { ...thread, activeBackgroundAgentCount: 0, canSpawnChild: true, queuedMessageCount: 0 };
+  return {
+    ...thread,
+    activeBackgroundAgentCount: 0,
+    canSpawnChild: true,
+    queuedMessageCount: 0,
+    retryableStoppedTurnRequestId: null,
+  };
 }
 
 const PROJECT_DEFAULT_EXECUTION_OPTIONS = {

--- a/apps/mobile/src/data/test/fixtures.ts
+++ b/apps/mobile/src/data/test/fixtures.ts
@@ -81,6 +81,8 @@ export function threadResponse(
     canSpawnChild: true,
     queuedMessageCount: 0,
     ...overrides,
+    retryableStoppedTurnRequestId:
+      overrides.retryableStoppedTurnRequestId ?? null,
   };
 }
 

--- a/apps/server/src/routes/threads/actions.ts
+++ b/apps/server/src/routes/threads/actions.ts
@@ -36,7 +36,7 @@ import {
   wouldCleanupEnvironment,
 } from "../../services/environments/environment-cleanup-internal.js";
 import { applyLoggedEnvironmentLifecycleEvent } from "../../services/environments/lifecycle-outcome.js";
-import { retryFailedTurn } from "../../services/threads/turn-retry.js";
+import { retryTurn } from "../../services/threads/turn-retry.js";
 import { requirePublicThread } from "../../services/lib/entity-lookup.js";
 import { parseSafeRelativeRoutePath } from "../relative-route-path.js";
 import { validatePromptAttachmentReferences } from "../../services/projects/attachments.js";
@@ -249,7 +249,7 @@ export function registerThreadActionRoutes(app: Hono, deps: AppDeps): void {
   post(routes.retry, async (context, payload) => {
     const thread = requirePublicThread(deps.db, context.req.param("id"));
     ensureThreadIsWritable(thread);
-    const result = await retryFailedTurn(deps, { request: payload, thread });
+    const result = await retryTurn(deps, { request: payload, thread });
     return context.json(result);
   });
 

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/references/failure-recovery.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/references/failure-recovery.md
@@ -5,19 +5,24 @@
 - For failed threads, inspect `bb thread show <id> --json` and
   `bb thread log <id>` before deciding whether to retry, clarify, or update the
   user.
-- Use `bb thread retry <thread-id>` to re-send a failed turn's original message
-  verbatim. It re-submits the same input — it does not add a new user message to
-  the timeline — and increments the attempt number (2 is the first retry). With
-  no `--turn` it retries the most recent turn, the one whose failure put the
-  thread in `error`; `--turn <requestId>` asserts which turn you mean and fails
-  when the thread has moved on. It errors when the thread has not failed or
-  `--turn` names a different turn (409 `no_failed_turn`), and when that turn
-  already has a retry queued (`retry_already_queued`). Add `--send-at <when>` to
-  queue the retry on the clock (same `<when>` grammar as `bb thread tell
-  --send-at`); without it the retry is attempted now and may still queue behind
-  a busy thread or a plugin's dispatch hook. `--reason <text>` labels the queued
-  row. The SDK equivalent is `sdk.threads.retry({ threadId, turnRequestId?,
-  sendAt?, reason? })`.
+- Use `bb thread retry <thread-id>` to re-send a retryable turn's original
+  message verbatim. It re-submits the same input — it does not add a new user
+  message to the timeline — and increments the attempt number (2 is the first
+  retry). With no `--turn` it retries the most recent failed turn, or the latest
+  unaccepted request after a manual Stop; `--turn <requestId>` asserts which
+  turn you mean and fails when the thread has moved on. It returns 409
+  `no_failed_turn` when no turn is eligible, and
+  `retry_already_queued` when that turn already has a retry queued. Add
+  `--send-at <when>` to queue the retry on the clock (same `<when>` grammar as
+  `bb thread tell --send-at`); without it the retry is attempted now and may
+  still queue behind a busy thread or a plugin's dispatch hook. The
+  `--reason <text>` option labels the queued row. The SDK equivalent is
+  `sdk.threads.retry({ threadId, turnRequestId?, sendAt?, reason? })`.
+- A provider-start watchdog warning does not fail a healthy runtime. If an
+  opening request never starts, stop it first; the latest unaccepted request is
+  then retryable whether Stop happened before or after the warning. Inputs sent
+  while it was starting stay queued and drain after the retry starts. In the
+  app, use the red **Retry request** action beneath the original message.
 - The Provider retry plugin is enabled on fresh installations. When a turn fails
   on a structured Codex or Claude Code subscription-window limit that reports a
   reset, it queues that turn to be re-sent after the window opens, re-sending

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/references/failure-recovery.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/references/failure-recovery.md
@@ -9,7 +9,7 @@
   message verbatim. It re-submits the same input — it does not add a new user
   message to the timeline — and increments the attempt number (2 is the first
   retry). With no `--turn` it retries the most recent failed turn, or the latest
-  unaccepted request after a manual Stop; `--turn <requestId>` asserts which
+  unaccepted user request after a manual Stop; `--turn <requestId>` asserts which
   turn you mean and fails when the thread has moved on. It returns 409
   `no_failed_turn` when no turn is eligible, and
   `retry_already_queued` when that turn already has a retry queued. Add
@@ -19,10 +19,11 @@
   `--reason <text>` option labels the queued row. The SDK equivalent is
   `sdk.threads.retry({ threadId, turnRequestId?, sendAt?, reason? })`.
 - A provider-start watchdog warning does not fail a healthy runtime. If an
-  opening request never starts, stop it first; the latest unaccepted request is
-  then retryable whether Stop happened before or after the warning. Inputs sent
-  while it was starting stay queued and drain after the retry starts. In the
-  app, use the red **Retry request** action beneath the original message.
+  opening user request never starts, stop it first; the latest unaccepted user
+  request is then retryable whether Stop happened before or after the warning.
+  Inputs sent while it was starting stay queued and drain after the retry
+  starts. In the app, use the red **Retry request** action beneath the original
+  message.
 - The Provider retry plugin is enabled on fresh installations. When a turn fails
   on a structured Codex or Claude Code subscription-window limit that reports a
   reset, it queues that turn to be re-sent after the window opens, re-sending

--- a/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/references/backend-events.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/references/backend-events.md
@@ -58,10 +58,10 @@ bb.events.on("turn.failed", async (event) => {
 });
 ```
 
-`threads.retry` re-submits a failed turn, or the latest unaccepted request after
-a manual Stop: the user's message never re-enters the timeline, and what the
-provider is sent follows `inputAccepted` — an input the provider never took is
-re-sent verbatim, while an accepted turn (already in the provider's
+`threads.retry` re-submits a failed turn, or the latest unaccepted user request
+after a manual Stop: the user's message never re-enters the timeline, and what
+the provider is sent follows `inputAccepted` — an input the provider never took
+is re-sent verbatim, while an accepted turn (already in the provider's
 conversation) is continued with a nudge rather than asked twice.
 The new attempt carries a retry marker so the next failure's `attemptNumber` is
 right. A future `sendAt`

--- a/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/references/backend-events.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/references/backend-events.md
@@ -44,7 +44,7 @@ BY REFERENCE:
 ```ts
 bb.events.on("turn.failed", async (event) => {
   if (event.errorInfo?.category !== "rate-limit") return;
-  if (event.attemptNumber >= 5) return;                  // cap your own retries
+  if (event.attemptNumber >= 5) return; // cap your own retries
   const resetsAt =
     event.rateLimits?.windows.find((w) => w.resetsAtMs !== null)?.resetsAtMs ??
     null;
@@ -53,15 +53,16 @@ bb.events.on("turn.failed", async (event) => {
     turnRequestId: event.requestId,
     // omit sendAt to attempt now
     ...(resetsAt === null ? {} : { sendAt: resetsAt + 15_000 }),
-    reason: "Rate limited",        // shown verbatim on the queued row
+    reason: "Rate limited", // shown verbatim on the queued row
   });
 });
 ```
 
-`threads.retry` re-submits the failed turn: the user's message never re-enters
-the timeline, and what the provider is sent follows `inputAccepted` — an input
-the provider never took is re-sent verbatim, while an accepted turn (already in
-the provider's conversation) is continued with a nudge rather than asked twice.
+`threads.retry` re-submits a failed turn, or the latest unaccepted request after
+a manual Stop: the user's message never re-enters the timeline, and what the
+provider is sent follows `inputAccepted` — an input the provider never took is
+re-sent verbatim, while an accepted turn (already in the provider's
+conversation) is continued with a nudge rather than asked twice.
 The new attempt carries a retry marker so the next failure's `attemptNumber` is
 right. A future `sendAt`
 queues it on the clock; without one it is attempted now. Either way it is an
@@ -94,7 +95,7 @@ ACTS ON what you return — the opposite of `bb.events`, whose handlers are told
 what already happened. There is ONE hook today, `"message.dispatch"`
 (`PluginHookName`), the admission checkpoint every message passes through
 exactly once per attempt: a thread's first message, a follow-up, a steer, a
-drained queue row, a retry of a failed turn. Two members: `on` answers the
+drained queue row, a retry of a retryable turn. Two members: `on` answers the
 question, and `recheck("message.dispatch")` asks core to ask it again.
 
 ```ts

--- a/apps/server/src/services/threads/dispatch-attempt.ts
+++ b/apps/server/src/services/threads/dispatch-attempt.ts
@@ -184,9 +184,9 @@ export interface DispatchAttemptArgs {
    * thread. Absent on a drain re-attempt, which reads it back off the thread.
    */
   startContext?: PendingThreadStartContext;
-  /** What the queued row would carry; `retry` for a re-submitted failed turn. */
+  /** What the queued row would carry; `retry` for a re-submitted turn. */
   queuePayload: QueuedMessagePayload;
-  /** Retry provenance, when this attempt re-submits a failed turn. */
+  /** Retry provenance, when this attempt re-submits a prior turn. */
   retryOf?: TurnRequestRetryMarker;
   origin: ThreadCreateOrigin | null;
   originPluginId: string | null;

--- a/apps/server/src/services/threads/thread-runtime-display.ts
+++ b/apps/server/src/services/threads/thread-runtime-display.ts
@@ -38,7 +38,7 @@ import type { ProviderRegistryService } from "../providers/provider-registry.js"
 import { listQueuedThreadMessageCountsByThreadIds } from "@bb/db";
 import { canThreadSpawnChild } from "./thread-parent.js";
 import { toThreadEventWithMeta } from "./timeline.js";
-import { loadStoppedUnacceptedTurn } from "./turn-retry-eligibility.js";
+import { loadStoppedUnacceptedUserTurn } from "./turn-retry-eligibility.js";
 
 type ThreadRuntimeDisplayHub = Pick<
   NotificationHub,
@@ -349,7 +349,10 @@ export function toThreadResponseFromThread(
     ...args,
     environmentHostId: resolveThreadEnvironmentHostId(deps, args.thread),
   });
-  const stoppedUnacceptedTurn = loadStoppedUnacceptedTurn(deps.db, args.thread);
+  const stoppedUnacceptedTurn = loadStoppedUnacceptedUserTurn(
+    deps.db,
+    args.thread,
+  );
   const retryableStoppedTurn =
     stoppedUnacceptedTurn !== null &&
     !hasQueuedRetryOfTurnRequest(deps.db, {

--- a/apps/server/src/services/threads/thread-runtime-display.ts
+++ b/apps/server/src/services/threads/thread-runtime-display.ts
@@ -2,6 +2,7 @@ import {
   getEnvironment,
   getLatestSessionForHost,
   getSessionById,
+  hasQueuedRetryOfTurnRequest,
   listActiveBackgroundTaskCountsByThreadIds,
   listLatestThreadStateEventRowsByThreadIds,
   listLatestSessionsForHosts,
@@ -37,6 +38,7 @@ import type { ProviderRegistryService } from "../providers/provider-registry.js"
 import { listQueuedThreadMessageCountsByThreadIds } from "@bb/db";
 import { canThreadSpawnChild } from "./thread-parent.js";
 import { toThreadEventWithMeta } from "./timeline.js";
+import { loadStoppedUnacceptedTurn } from "./turn-retry-eligibility.js";
 
 type ThreadRuntimeDisplayHub = Pick<
   NotificationHub,
@@ -347,6 +349,15 @@ export function toThreadResponseFromThread(
     ...args,
     environmentHostId: resolveThreadEnvironmentHostId(deps, args.thread),
   });
+  const stoppedUnacceptedTurn = loadStoppedUnacceptedTurn(deps.db, args.thread);
+  const retryableStoppedTurn =
+    stoppedUnacceptedTurn !== null &&
+    !hasQueuedRetryOfTurnRequest(deps.db, {
+      threadId: args.thread.id,
+      retryOfTurnRequestId: stoppedUnacceptedTurn.request.requestId,
+    })
+      ? stoppedUnacceptedTurn
+      : null;
   return {
     ...threadWithRuntime,
     activeBackgroundAgentCount:
@@ -358,6 +369,8 @@ export function toThreadResponseFromThread(
       listQueuedThreadMessageCountsByThreadIds(deps.db, {
         threadIds: [args.thread.id],
       })[0]?.queuedMessageCount ?? 0,
+    retryableStoppedTurnRequestId:
+      retryableStoppedTurn?.request.requestId ?? null,
   };
 }
 

--- a/apps/server/src/services/threads/thread-send.ts
+++ b/apps/server/src/services/threads/thread-send.ts
@@ -80,7 +80,7 @@ type SendThreadMessagePayload = SendMessageRequest & {
 interface SendThreadMessageArgs {
   beforeAppendInTransaction?: SendThreadMessageTransactionPreflight;
   /**
-   * Present only when this send re-submits a failed turn. Marks the turn event
+   * Present only when this send re-submits a retryable turn. Marks the turn event
    * as attempt N of an earlier request, which is what makes the next failure's
    * attempt number correct without a separate tally.
    */

--- a/apps/server/src/services/threads/turn-retry-eligibility.ts
+++ b/apps/server/src/services/threads/turn-retry-eligibility.ts
@@ -1,0 +1,49 @@
+import {
+  events,
+  getLatestStoredThreadEventOfTypes,
+  type DbConnection,
+} from "@bb/db";
+import type { Thread } from "@bb/domain";
+import { and, desc, eq, gt, sql } from "drizzle-orm";
+import { loadFailedTurn, type FailedTurnRecord } from "./turn-failed.js";
+
+export function loadStoppedUnacceptedTurn(
+  db: DbConnection,
+  thread: Thread,
+): FailedTurnRecord | null {
+  if (
+    thread.status !== "idle" ||
+    thread.archivedAt !== null ||
+    thread.deletedAt !== null
+  ) {
+    return null;
+  }
+  const pending = loadFailedTurn(db, thread.id);
+  if (pending === null) return null;
+  const settled = getLatestStoredThreadEventOfTypes(db, {
+    threadId: thread.id,
+    types: [
+      "client/turn/rejected",
+      "turn/input/accepted",
+      "turn/started",
+      "turn/completed",
+    ],
+    afterSequence: pending.requestSequence,
+  });
+  if (settled !== null) return null;
+  const interruption = db
+    .select({ sequence: events.sequence })
+    .from(events)
+    .where(
+      and(
+        eq(events.threadId, thread.id),
+        eq(events.type, "system/thread/interrupted"),
+        gt(events.sequence, pending.requestSequence),
+        sql`json_extract(${events.data}, '$.reason') = 'manual-stop'`,
+      ),
+    )
+    .orderBy(desc(events.sequence))
+    .limit(1)
+    .get();
+  return interruption === undefined ? null : pending;
+}

--- a/apps/server/src/services/threads/turn-retry-eligibility.ts
+++ b/apps/server/src/services/threads/turn-retry-eligibility.ts
@@ -4,10 +4,10 @@ import {
   type DbConnection,
 } from "@bb/db";
 import type { Thread } from "@bb/domain";
-import { and, desc, eq, gt, sql } from "drizzle-orm";
+import { and, desc, eq, sql } from "drizzle-orm";
 import { loadFailedTurn, type FailedTurnRecord } from "./turn-failed.js";
 
-export function loadStoppedUnacceptedTurn(
+export function loadStoppedUnacceptedUserTurn(
   db: DbConnection,
   thread: Thread,
 ): FailedTurnRecord | null {
@@ -18,8 +18,28 @@ export function loadStoppedUnacceptedTurn(
   ) {
     return null;
   }
+  const interruption = db
+    .select({ sequence: events.sequence })
+    .from(events)
+    .where(
+      and(
+        eq(events.threadId, thread.id),
+        eq(events.type, "system/thread/interrupted"),
+        sql`json_extract(${events.data}, '$.reason') = 'manual-stop'`,
+      ),
+    )
+    .orderBy(desc(events.sequence))
+    .limit(1)
+    .get();
+  if (interruption === undefined) return null;
   const pending = loadFailedTurn(db, thread.id);
-  if (pending === null) return null;
+  if (
+    pending === null ||
+    pending.request.initiator !== "user" ||
+    pending.requestSequence >= interruption.sequence
+  ) {
+    return null;
+  }
   const settled = getLatestStoredThreadEventOfTypes(db, {
     threadId: thread.id,
     types: [
@@ -30,20 +50,5 @@ export function loadStoppedUnacceptedTurn(
     ],
     afterSequence: pending.requestSequence,
   });
-  if (settled !== null) return null;
-  const interruption = db
-    .select({ sequence: events.sequence })
-    .from(events)
-    .where(
-      and(
-        eq(events.threadId, thread.id),
-        eq(events.type, "system/thread/interrupted"),
-        gt(events.sequence, pending.requestSequence),
-        sql`json_extract(${events.data}, '$.reason') = 'manual-stop'`,
-      ),
-    )
-    .orderBy(desc(events.sequence))
-    .limit(1)
-    .get();
-  return interruption === undefined ? null : pending;
+  return settled === null ? pending : null;
 }

--- a/apps/server/src/services/threads/turn-retry.ts
+++ b/apps/server/src/services/threads/turn-retry.ts
@@ -20,6 +20,7 @@ import {
   wasFailedTurnInputAccepted,
   type FailedTurnRecord,
 } from "./turn-failed.js";
+import { loadStoppedUnacceptedTurn } from "./turn-retry-eligibility.js";
 
 type TurnRetryDeps = LoggedPendingInteractionWorkSessionDeps;
 
@@ -40,34 +41,20 @@ function hasQueuedRetryFor(
   });
 }
 
-/**
- * The failed turn a retry re-submits.
- *
- * A thread has exactly one retryable turn: its most recent one, whose failure
- * is what put it in `error`. Anything earlier has already been answered by the
- * turns after it, so re-submitting it would ask the provider to redo work the
- * conversation has moved past. `turnRequestId` therefore ASSERTS which turn the
- * caller means rather than selecting among several — it is how a retry policy
- * that decided on one failure refuses to act on a different one it never saw.
- */
-function requireFailedTurn(
+function requireRetryableTurn(
   deps: Pick<TurnRetryDeps, "db">,
   args: { thread: Thread; turnRequestId: ClientTurnRequestId | null },
 ) {
   const { thread } = args;
-  if (thread.status !== "error") {
-    throw new ApiError(
-      409,
-      "no_failed_turn",
-      `Thread ${thread.id} has no failed turn to retry: it is ${thread.status}.`,
-    );
-  }
-  const failed = loadFailedTurn(deps.db, thread.id);
+  const failed =
+    thread.status === "error"
+      ? loadFailedTurn(deps.db, thread.id)
+      : loadStoppedUnacceptedTurn(deps.db, thread);
   if (failed === null) {
     throw new ApiError(
       409,
       "no_failed_turn",
-      `Thread ${thread.id} failed before it dispatched a turn, so there is nothing to retry.`,
+      `Thread ${thread.id} has no failed or stopped unaccepted turn to retry: it is ${thread.status}.`,
     );
   }
   if (
@@ -77,13 +64,13 @@ function requireFailedTurn(
     throw new ApiError(
       409,
       "no_failed_turn",
-      `Turn ${args.turnRequestId} is not the failed turn on thread ${thread.id}; its most recent turn is ${failed.request.requestId}.`,
+      `Turn ${args.turnRequestId} is not the retryable turn on thread ${thread.id}; its most recent retryable turn is ${failed.request.requestId}.`,
     );
   }
   return failed;
 }
 
-export interface RetryFailedTurnArgs {
+export interface RetryTurnArgs {
   thread: Thread;
   request: RetryTurnRequest;
 }
@@ -167,13 +154,13 @@ function retryExecution(failed: FailedTurnRecord): {
  *
  * The queued-row check below cannot see a concurrent call that has passed it
  * but not yet written anything — two clients clicking Retry together would
- * both dispatch. One failure earns one retry, so the second caller gets the
- * same 409 a queued duplicate gets.
+ * both dispatch. One retryable request earns one retry, so the second caller
+ * gets the same 409 a queued duplicate gets.
  */
 const retriesInFlight = new Set<string>();
 
 /**
- * Re-submits a failed turn.
+ * Re-submits a failed or manually stopped unaccepted turn.
  *
  * The retry is an ordinary dispatch attempt carrying a `retry` payload, which
  * is what makes it behave like everything else: a `sendAt` in the future queues
@@ -182,12 +169,12 @@ const retriesInFlight = new Set<string>();
  * a rate-limit window respects a limiter that is at capacity instead of jumping
  * the queue. What the attempt carries is `retryInput` and `retryExecution` decide.
  */
-export async function retryFailedTurn(
+export async function retryTurn(
   deps: TurnRetryDeps,
-  args: RetryFailedTurnArgs,
+  args: RetryTurnArgs,
 ): Promise<RetryTurnResponse> {
   const { request, thread } = args;
-  const failed = requireFailedTurn(deps, {
+  const failed = requireRetryableTurn(deps, {
     thread,
     turnRequestId: request.turnRequestId,
   });

--- a/apps/server/src/services/threads/turn-retry.ts
+++ b/apps/server/src/services/threads/turn-retry.ts
@@ -20,7 +20,7 @@ import {
   wasFailedTurnInputAccepted,
   type FailedTurnRecord,
 } from "./turn-failed.js";
-import { loadStoppedUnacceptedTurn } from "./turn-retry-eligibility.js";
+import { loadStoppedUnacceptedUserTurn } from "./turn-retry-eligibility.js";
 
 type TurnRetryDeps = LoggedPendingInteractionWorkSessionDeps;
 
@@ -49,12 +49,12 @@ function requireRetryableTurn(
   const failed =
     thread.status === "error"
       ? loadFailedTurn(deps.db, thread.id)
-      : loadStoppedUnacceptedTurn(deps.db, thread);
+      : loadStoppedUnacceptedUserTurn(deps.db, thread);
   if (failed === null) {
     throw new ApiError(
       409,
       "no_failed_turn",
-      `Thread ${thread.id} has no failed or stopped unaccepted turn to retry: it is ${thread.status}.`,
+      `Thread ${thread.id} has no failed turn or stopped unaccepted user request to retry: it is ${thread.status}.`,
     );
   }
   if (
@@ -160,7 +160,7 @@ function retryExecution(failed: FailedTurnRecord): {
 const retriesInFlight = new Set<string>();
 
 /**
- * Re-submits a failed or manually stopped unaccepted turn.
+ * Re-submits a failed turn or manually stopped unaccepted user request.
  *
  * The retry is an ordinary dispatch attempt carrying a `retry` payload, which
  * is what makes it behave like everything else: a `sendAt` in the future queues

--- a/apps/server/test/helpers/provider-registry.ts
+++ b/apps/server/test/helpers/provider-registry.ts
@@ -312,6 +312,9 @@ export async function registerFakeProviders(
             reasoningLevels: ["low", "medium", "high"],
           },
           composerActions: ["plan", "goal"],
+          experimental_bridgeOptions: {
+            scripted: { swallowUserTurnStartText: "[stopped-unaccepted]" },
+          },
         }),
         readSettings: NO_PLUGIN_SETTINGS,
       }),

--- a/apps/server/test/threads/turn-failed-retry.test.ts
+++ b/apps/server/test/threads/turn-failed-retry.test.ts
@@ -18,7 +18,7 @@ import { applyLoggedThreadLifecycleEvent } from "../../src/services/threads/life
 import { runQueuedMessageDispatch } from "../../src/services/threads/queued-message-dispatch.js";
 import { toThreadQueuedMessage } from "../../src/services/threads/thread-queued-messages.js";
 import { buildTurnFailedEvent } from "../../src/services/threads/turn-failed.js";
-import { retryFailedTurn } from "../../src/services/threads/turn-retry.js";
+import { retryTurn } from "../../src/services/threads/turn-retry.js";
 import {
   seedEnvironment,
   seedEvent,
@@ -438,7 +438,7 @@ describe("retrying a failed turn", () => {
       const { requestId, thread } = seedFailableThread(harness, "host-retry");
       failThread(harness, thread.id);
 
-      const result = await retryFailedTurn(harness.deps, {
+      const result = await retryTurn(harness.deps, {
         thread: requireThread(harness, thread.id),
         request: { turnRequestId: requestId, sendAt, reason: "Rate limited" },
       });
@@ -502,7 +502,7 @@ describe("retrying a failed turn", () => {
       });
       failThread(harness, thread.id);
 
-      const result = await retryFailedTurn(harness.deps, {
+      const result = await retryTurn(harness.deps, {
         thread: requireThread(harness, thread.id),
         request: {
           turnRequestId: requestId,
@@ -534,7 +534,7 @@ describe("retrying a failed turn", () => {
       const { thread } = seedFailableThread(harness, "host-retry-now");
       failThread(harness, thread.id);
 
-      const result = await retryFailedTurn(harness.deps, {
+      const result = await retryTurn(harness.deps, {
         thread: requireThread(harness, thread.id),
         request: { turnRequestId: null, sendAt: null, reason: "Retry" },
       });
@@ -560,7 +560,7 @@ describe("retrying a failed turn", () => {
         modelOverride: "gpt-6-pro",
       });
 
-      await retryFailedTurn(harness.deps, {
+      await retryTurn(harness.deps, {
         thread: requireThread(harness, thread.id),
         request: { turnRequestId: requestId, sendAt: null, reason: "Retry" },
       });
@@ -578,7 +578,7 @@ describe("retrying a failed turn", () => {
       const { requestId, thread } = seedFailableThread(harness, "host-race");
       failThread(harness, thread.id);
       const retry = () =>
-        retryFailedTurn(harness.deps, {
+        retryTurn(harness.deps, {
           thread: requireThread(harness, thread.id),
           request: {
             turnRequestId: requestId,
@@ -612,7 +612,7 @@ describe("retrying a failed turn", () => {
         "host-attempts",
       );
       failThread(harness, thread.id);
-      await retryFailedTurn(harness.deps, {
+      await retryTurn(harness.deps, {
         thread: requireThread(harness, thread.id),
         request: {
           turnRequestId: requestId,
@@ -630,7 +630,7 @@ describe("retrying a failed turn", () => {
       expect(failedAgain?.attemptNumber).toBe(2);
       expect(failedAgain?.requestId).not.toBe(requestId);
 
-      await retryFailedTurn(harness.deps, {
+      await retryTurn(harness.deps, {
         thread: requireThread(harness, thread.id),
         request: {
           turnRequestId: failedAgain?.requestId ?? null,
@@ -667,7 +667,7 @@ describe("retrying a failed turn", () => {
       });
       const { thread } = seedFailableThread(harness, "host-limit");
       failThread(harness, thread.id);
-      await retryFailedTurn(harness.deps, {
+      await retryTurn(harness.deps, {
         thread: requireThread(harness, thread.id),
         request: {
           turnRequestId: null,
@@ -698,7 +698,7 @@ describe("retrying a failed turn", () => {
     await withTestHarness(async (harness) => {
       const { requestId, thread } = seedFailableThread(harness, "host-refuse");
       const retry = (turnRequestId: string | null) =>
-        retryFailedTurn(harness.deps, {
+        retryTurn(harness.deps, {
           thread: requireThread(harness, thread.id),
           request: {
             turnRequestId,

--- a/apps/server/test/threads/turn-stopped-unaccepted-retry.test.ts
+++ b/apps/server/test/threads/turn-stopped-unaccepted-retry.test.ts
@@ -1,0 +1,203 @@
+import {
+  getLatestThreadSequence,
+  getThread,
+  listEvents,
+  listQueuedThreadMessages,
+} from "@bb/db";
+import { encodeClientTurnRequestIdNumber } from "@bb/domain";
+import { describe, expect, it } from "vitest";
+import { applyLoggedThreadLifecycleEvent } from "../../src/services/threads/lifecycle-outcome.js";
+import { finalizeStoppedThread } from "../../src/services/threads/thread-lifecycle.js";
+import { toThreadResponseFromThread } from "../../src/services/threads/thread-runtime-display.js";
+import { retryTurn } from "../../src/services/threads/turn-retry.js";
+import {
+  seedEvent,
+  seedThreadFixture,
+  seedThreadRuntimeState,
+  seedTurnStarted,
+} from "../helpers/seed.js";
+import { withTestHarness, type TestAppHarness } from "../helpers/test-app.js";
+
+function seedPendingStart(harness: TestAppHarness) {
+  const { environment, thread } = seedThreadFixture(harness, {
+    session: { id: "host-retry" },
+    environment: { path: "/tmp/stopped-unaccepted" },
+    thread: { status: "active" },
+  });
+  seedThreadRuntimeState(harness.deps, {
+    environmentId: environment.id,
+    inputText: "Build the sidebar",
+    providerThreadId: "provider-retry",
+    threadId: thread.id,
+  });
+  const request = listEvents(harness.db, { threadId: thread.id }).find(
+    (event) => event.type === "client/turn/requested",
+  );
+  if (request === undefined) throw new Error("expected request");
+  return {
+    environment,
+    request,
+    requestId: (JSON.parse(request.data) as { requestId: string }).requestId,
+    thread,
+  };
+}
+
+function requireThread(harness: TestAppHarness, threadId: string) {
+  const thread = getThread(harness.db, threadId);
+  if (thread === null) throw new Error("expected thread");
+  return thread;
+}
+
+function stop(harness: TestAppHarness, threadId: string): void {
+  applyLoggedThreadLifecycleEvent(harness.deps, {
+    event: { type: "stop.requested" },
+    threadId,
+  });
+  finalizeStoppedThread(harness.deps, { threadId });
+}
+
+async function retry(
+  harness: TestAppHarness,
+  requestId: string,
+  threadId: string,
+) {
+  return retryTurn(harness.deps, {
+    thread: requireThread(harness, threadId),
+    request: {
+      turnRequestId: requestId,
+      sendAt: Date.now() + 60_000,
+      reason: "Retry request",
+    },
+  });
+}
+
+function nextSequence(harness: TestAppHarness, threadId: string): number {
+  return getLatestThreadSequence(harness.db, { threadId }) + 1;
+}
+
+describe("retrying a manually stopped unaccepted request", () => {
+  it.each([false, true])(
+    "allows retry with watchdog event: %s",
+    async (withWatchdog) => {
+      await withTestHarness(async (harness) => {
+        const { environment, requestId, thread } = seedPendingStart(harness);
+        if (withWatchdog) {
+          seedEvent(harness.deps, {
+            environmentId: environment.id,
+            threadId: thread.id,
+            sequence: nextSequence(harness, thread.id),
+            type: "system/error",
+            scope: { kind: "thread" },
+            data: {
+              code: "provider_turn_start_timeout",
+              message: "Provider has not started the turn yet",
+            },
+          });
+        }
+        stop(harness, thread.id);
+        expect(
+          toThreadResponseFromThread(harness.deps, {
+            thread: requireThread(harness, thread.id),
+          }).retryableStoppedTurnRequestId,
+        ).toBe(requestId);
+        await expect(
+          retry(harness, requestId, thread.id),
+        ).resolves.toMatchObject({
+          attempt: 2,
+          delivery: "queued",
+          turnRequestId: requestId,
+        });
+        expect(listQueuedThreadMessages(harness.db, thread.id)).toHaveLength(1);
+      });
+    },
+  );
+
+  it("requires a manual Stop", async () => {
+    await withTestHarness(async (harness) => {
+      const { requestId, thread } = seedPendingStart(harness);
+      await expect(retry(harness, requestId, thread.id)).rejects.toMatchObject({
+        body: { code: "no_failed_turn" },
+      });
+    });
+  });
+
+  it.each(["accepted", "started", "rejected", "completed"] as const)(
+    "refuses a request the provider %s",
+    async (settlement) => {
+      await withTestHarness(async (harness) => {
+        const { environment, requestId, thread } = seedPendingStart(harness);
+        if (settlement === "started") {
+          seedTurnStarted(harness.deps, {
+            environmentId: environment.id,
+            threadId: thread.id,
+            turnId: "turn-started",
+          });
+        } else {
+          seedEvent(harness.deps, {
+            environmentId: environment.id,
+            threadId: thread.id,
+            providerThreadId:
+              settlement === "accepted" || settlement === "completed"
+                ? "provider-session"
+                : undefined,
+            sequence: nextSequence(harness, thread.id),
+            type:
+              settlement === "accepted"
+                ? "turn/input/accepted"
+                : settlement === "rejected"
+                  ? "client/turn/rejected"
+                  : "turn/completed",
+            scope:
+              settlement === "rejected"
+                ? { kind: "thread" }
+                : { kind: "turn", turnId: `turn-${settlement}` },
+            data:
+              settlement === "accepted"
+                ? {
+                    clientRequestId: requestId,
+                    providerThreadId: "provider-session",
+                  }
+                : settlement === "rejected"
+                  ? {
+                      requestId,
+                      reason: "provider_busy",
+                      message: "refused",
+                    }
+                  : { status: "completed" },
+          });
+        }
+        stop(harness, thread.id);
+        await expect(
+          retry(harness, requestId, thread.id),
+        ).rejects.toMatchObject({ body: { code: "no_failed_turn" } });
+      });
+    },
+  );
+
+  it("only allows the latest request", async () => {
+    await withTestHarness(async (harness) => {
+      const { environment, request, requestId, thread } =
+        seedPendingStart(harness);
+      const latestRequestId = encodeClientTurnRequestIdNumber({ value: 99 });
+      seedEvent(harness.deps, {
+        environmentId: environment.id,
+        threadId: thread.id,
+        providerThreadId: request.providerThreadId,
+        sequence: nextSequence(harness, thread.id),
+        type: "client/turn/requested",
+        scope: { kind: "thread" },
+        data: { ...JSON.parse(request.data), requestId: latestRequestId },
+      });
+      stop(harness, thread.id);
+      await expect(retry(harness, requestId, thread.id)).rejects.toMatchObject({
+        body: { code: "no_failed_turn" },
+      });
+      await expect(
+        retry(harness, latestRequestId, thread.id),
+      ).resolves.toMatchObject({
+        attempt: 2,
+        turnRequestId: latestRequestId,
+      });
+    });
+  });
+});

--- a/apps/server/test/threads/turn-stopped-unaccepted-retry.test.ts
+++ b/apps/server/test/threads/turn-stopped-unaccepted-retry.test.ts
@@ -75,7 +75,7 @@ function nextSequence(harness: TestAppHarness, threadId: string): number {
   return getLatestThreadSequence(harness.db, { threadId }) + 1;
 }
 
-describe("retrying a manually stopped unaccepted request", () => {
+describe("retrying a manually stopped unaccepted user request", () => {
   it.each([false, true])(
     "allows retry with watchdog event: %s",
     async (withWatchdog) => {
@@ -120,6 +120,40 @@ describe("retrying a manually stopped unaccepted request", () => {
       });
     });
   });
+
+  it.each(["agent", "system"] as const)(
+    "does not offer the user-message retry action when initiator is %s",
+    async (initiator) => {
+      await withTestHarness(async (harness) => {
+        const { environment, request, thread } = seedPendingStart(harness);
+        const requestId = encodeClientTurnRequestIdNumber({ value: 99 });
+        seedEvent(harness.deps, {
+          environmentId: environment.id,
+          threadId: thread.id,
+          providerThreadId: request.providerThreadId,
+          sequence: nextSequence(harness, thread.id),
+          type: "client/turn/requested",
+          scope: { kind: "thread" },
+          data: {
+            ...JSON.parse(request.data),
+            requestId,
+            initiator,
+            senderThreadId: initiator === "agent" ? "thr_parent" : null,
+          },
+        });
+        stop(harness, thread.id);
+
+        expect(
+          toThreadResponseFromThread(harness.deps, {
+            thread: requireThread(harness, thread.id),
+          }).retryableStoppedTurnRequestId,
+        ).toBeNull();
+        await expect(
+          retry(harness, requestId, thread.id),
+        ).rejects.toMatchObject({ body: { code: "no_failed_turn" } });
+      });
+    },
+  );
 
   it.each(["accepted", "started", "rejected", "completed"] as const)(
     "refuses a request the provider %s",

--- a/packages/db/src/data/queued-thread-messages.ts
+++ b/packages/db/src/data/queued-thread-messages.ts
@@ -272,7 +272,11 @@ function hasOrdinaryTurnEndWait(row: QueuedThreadMessageRow): boolean {
 export function isOrdinaryTurnEndQueuedMessage(
   row: QueuedThreadMessageRow,
 ): boolean {
-  return row.systemNotice === null && hasOrdinaryTurnEndWait(row);
+  return (
+    row.payloadKind === "inline" &&
+    row.systemNotice === null &&
+    hasOrdinaryTurnEndWait(row)
+  );
 }
 
 /**

--- a/packages/db/test/data/queued-thread-messages.test.ts
+++ b/packages/db/test/data/queued-thread-messages.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { threadScope, type PromptInput } from "@bb/domain";
+import {
+  encodeClientTurnRequestIdNumber,
+  threadScope,
+  type PromptInput,
+} from "@bb/domain";
 import { noopNotifier } from "../../src/notifier.js";
 import { insertEvents } from "../../src/data/events.js";
 import {
@@ -811,7 +815,7 @@ describe("queued thread messages", () => {
     ).toEqual([thirdQueuedMessage.id]);
   });
 
-  it("pauses ordinary turn-end rows without pausing system notices", () => {
+  it("pauses ordinary turn-end rows without pausing notices or retries", () => {
     const { db, project } = setup();
     const thread = createThread(db, noopNotifier, {
       projectId: project.id,
@@ -849,6 +853,27 @@ describe("queued thread messages", () => {
         },
       },
     });
+    const retry = createQueuedThreadMessage(db, noopNotifier, {
+      threadId: thread.id,
+      content: textInput("Retry the stopped request"),
+      model: "gpt-5",
+      reasoningLevel: "medium",
+      permissionMode: "full",
+      serviceTier: "default",
+      waitingOn: { kind: "host-offline", hostName: "test-host" },
+      sendAt: null,
+      payload: {
+        kind: "retry",
+        retryOfTurnRequestId: encodeClientTurnRequestIdNumber({ value: 1 }),
+        attempt: 2,
+        reason: "Stopped before acceptance",
+      },
+      systemNotice: null,
+    });
+    clearQueuedThreadMessageWaitingOn(db, noopNotifier, {
+      id: retry.id,
+      threadId: thread.id,
+    });
     insertEvents(db, noopNotifier, [
       {
         threadId: thread.id,
@@ -876,6 +901,11 @@ describe("queued thread messages", () => {
         (row) => row.id,
       ),
     ).toEqual([notice.id]);
+    expect(
+      claimNextQueuedThreadMessageGroup(db, noopNotifier, thread.id)?.map(
+        (row) => row.id,
+      ),
+    ).toEqual([retry.id]);
     expect(
       listQueuedThreadMessages(db, thread.id).map((row) => row.id),
     ).toEqual([ordinary.id]);

--- a/packages/domain/src/plugin-sdk-version.ts
+++ b/packages/domain/src/plugin-sdk-version.ts
@@ -1,3 +1,3 @@
-export const PLUGIN_SDK_VERSION = "0.4.43";
+export const PLUGIN_SDK_VERSION = "0.4.44";
 
 export const PLUGIN_SDK_MAJOR = Number(PLUGIN_SDK_VERSION.split(".", 1)[0]);

--- a/packages/domain/src/queued-message.ts
+++ b/packages/domain/src/queued-message.ts
@@ -154,9 +154,9 @@ export type QueuedMessageWaitHolder = z.infer<
  * the sender wrote and the execution tuple frozen at queue time. It is a draft
  * that has not run, so it is editable while it waits.
  *
- * `retry` only references a failed turn's original request. Nothing about it
- * is editable: the point of a retry is to re-submit the original faithfully,
- * with no duplicated user message.
+ * `retry` only references a retryable turn's original request. Nothing about
+ * it is editable: the point of a retry is to re-submit the original
+ * faithfully, with no duplicated user message.
  */
 export const queuedMessagePayloadKindValues = ["inline", "retry"] as const;
 export const queuedMessagePayloadKindSchema = z.enum(
@@ -171,7 +171,7 @@ export const queuedMessagePayloadSchema = z.discriminatedUnion("kind", [
   z.object({
     kind: z.literal("retry"),
     /**
-     * The ORIGINAL request, not the attempt that just failed. Retrying a retry
+     * The ORIGINAL request, not the attempt being retried. Retrying a retry
      * re-submits the same original blocks, so this id is carried forward
      * unchanged across attempts and `attempt` is what distinguishes them.
      */

--- a/packages/plugin-api-map/sdk-public-api.json
+++ b/packages/plugin-api-map/sdk-public-api.json
@@ -3,7 +3,7 @@
   "entries": {
     ".": {
       "types": "bundled-types/bb-plugin-sdk.d.ts",
-      "sha256": "5c95a2ff45f0165e3cbe5c760d9b7904afb195f06f6a1e6d2006b2e10ae8801f"
+      "sha256": "bd8151cb4b2eaa236f6429c65e68ece919494dc7f16f45f82b65dcb20f61fb45"
     },
     "./ai-services": {
       "types": "bundled-types/bb-plugin-sdk-ai-services.d.ts",

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@get-bb/plugin-sdk",
-  "version": "0.4.43",
+  "version": "0.4.44",
   "homepage": "https://github.com/get-bb/bb#readme",
   "bugs": {
     "url": "https://github.com/get-bb/bb/issues"

--- a/packages/plugin-sdk/src/backend-contract.ts
+++ b/packages/plugin-sdk/src/backend-contract.ts
@@ -397,7 +397,7 @@ export type PluginDispatchAttemptKind = "start-turn" | "join-turn";
  *
  * It runs identically whether the attempt is inline (someone just sent) or
  * from a drain (a queued row became eligible again), and whether the message
- * is a thread's first, a follow-up, a steer, or a retry of a failed turn. A
+ * is a thread's first, a follow-up, a steer, or a retry of a prior turn. A
  * handler must therefore be idempotent for one logical dispatch: passes re-run
  * on every drain, on restart, and on retry.
  */

--- a/packages/plugin-sdk/src/testing/fixtures.ts
+++ b/packages/plugin-sdk/src/testing/fixtures.ts
@@ -83,6 +83,7 @@ export function makeThreadResponse(
     activeBackgroundAgentCount: 0,
     canSpawnChild: true,
     queuedMessageCount: 0,
+    retryableStoppedTurnRequestId: null,
     ...overrides,
   };
 }

--- a/packages/sdk/src/areas/threads.ts
+++ b/packages/sdk/src/areas/threads.ts
@@ -254,9 +254,9 @@ export interface ThreadEditMessageArgs extends EditMessageRequest {
 export interface ThreadRetryArgs {
   threadId: string;
   /**
-   * The failed turn or manually stopped unaccepted request to re-submit. Omitted
-   * means the thread's most recent retryable turn; naming one asserts which
-   * request you decided on and fails if the thread has moved on since.
+   * The failed turn or manually stopped unaccepted user request to re-submit.
+   * Omitted means the thread's most recent retryable turn; naming one asserts
+   * which request you decided on and fails if the thread has moved on since.
    */
   turnRequestId?: string;
   /**
@@ -561,7 +561,7 @@ export interface ThreadsArea {
     args: ThreadResolveMentionsArgs,
   ): Promise<ThreadResolveMentionsResult>;
   /**
-   * Re-submit a failed turn or manually stopped unaccepted request. The retry
+   * Re-submit a failed turn or manually stopped unaccepted user request. The retry
    * is an ordinary dispatch attempt, so a `sendAt` in the future queues it on
    * the clock and a `message.dispatch` hook can still hold it; the response
    * says which of the two happened.

--- a/packages/sdk/src/areas/threads.ts
+++ b/packages/sdk/src/areas/threads.ts
@@ -254,9 +254,9 @@ export interface ThreadEditMessageArgs extends EditMessageRequest {
 export interface ThreadRetryArgs {
   threadId: string;
   /**
-   * The failed turn to re-submit. Omitted means the thread's most recent turn,
-   * which is the one whose failure put it in `error`; naming one asserts which
-   * failure you decided on and fails if the thread has moved on since.
+   * The failed turn or manually stopped unaccepted request to re-submit. Omitted
+   * means the thread's most recent retryable turn; naming one asserts which
+   * request you decided on and fails if the thread has moved on since.
    */
   turnRequestId?: string;
   /**
@@ -561,9 +561,10 @@ export interface ThreadsArea {
     args: ThreadResolveMentionsArgs,
   ): Promise<ThreadResolveMentionsResult>;
   /**
-   * Re-submit a failed turn. The retry is an ordinary dispatch attempt, so a
-   * `sendAt` in the future queues it on the clock and a `message.dispatch` hook
-   * can still hold it; the response says which of the two happened.
+   * Re-submit a failed turn or manually stopped unaccepted request. The retry
+   * is an ordinary dispatch attempt, so a `sendAt` in the future queues it on
+   * the clock and a `message.dispatch` hook can still hold it; the response
+   * says which of the two happened.
    */
   retry(args: ThreadRetryArgs): Promise<ThreadRetryResult>;
   search(args: ThreadSearchArgs): Promise<ThreadSearchResult>;

--- a/packages/server-contract/src/api/threads.ts
+++ b/packages/server-contract/src/api/threads.ts
@@ -267,8 +267,8 @@ export const DEFAULT_TURN_RETRY_REASON = "Retry";
 export const retryTurnRequestSchema = z
   .object({
     /**
-     * The failed turn or manually stopped unaccepted request to re-submit. Null
-     * means the thread's own most recent retryable turn.
+     * The failed turn or manually stopped unaccepted user request to re-submit.
+     * Null means the thread's own most recent retryable turn.
      */
     turnRequestId: clientTurnRequestIdSchema.nullable().default(null),
     /**

--- a/packages/server-contract/src/api/threads.ts
+++ b/packages/server-contract/src/api/threads.ts
@@ -267,9 +267,8 @@ export const DEFAULT_TURN_RETRY_REASON = "Retry";
 export const retryTurnRequestSchema = z
   .object({
     /**
-     * The failed turn to re-submit. Null means the thread's own most recent
-     * turn, which is the one whose failure put it in `error` — the only turn a
-     * caller who did not watch the failure happen can mean.
+     * The failed turn or manually stopped unaccepted request to re-submit. Null
+     * means the thread's own most recent retryable turn.
      */
     turnRequestId: clientTurnRequestIdSchema.nullable().default(null),
     /**
@@ -454,6 +453,7 @@ export const threadResponseSchema = threadWithRuntimeSchema.extend({
   // `GET /threads/:id/queued-messages` supplies the reasons once a surface
   // actually renders them.
   queuedMessageCount: z.number().int().nonnegative(),
+  retryableStoppedTurnRequestId: clientTurnRequestIdSchema.nullable(),
 });
 export type ThreadResponse = z.infer<typeof threadResponseSchema>;
 

--- a/packages/server-contract/src/public-api.ts
+++ b/packages/server-contract/src/public-api.ts
@@ -1021,7 +1021,7 @@ export const publicApiRoutes = {
       response: jsonResponse<EditMessageResponse>(),
     }),
     /**
-     * Retry a failed turn or manually stopped unaccepted request by reference
+     * Retry a failed turn or manually stopped unaccepted user request by reference
      * as an ordinary dispatch attempt. `turnRequestId` null selects the most
      * recent retryable turn.
      */

--- a/packages/server-contract/src/public-api.ts
+++ b/packages/server-contract/src/public-api.ts
@@ -1021,9 +1021,9 @@ export const publicApiRoutes = {
       response: jsonResponse<EditMessageResponse>(),
     }),
     /**
-     * Retry a failed turn: re-submit it by reference, as an ordinary dispatch
-     * attempt. `turnRequestId` null means the thread's most recent turn, whose
-     * failure is what put the thread in `error`.
+     * Retry a failed turn or manually stopped unaccepted request by reference
+     * as an ordinary dispatch attempt. `turnRequestId` null selects the most
+     * recent retryable turn.
      */
     retry: defineRoute({
       path: "/threads/:id/retry",

--- a/packages/templates/src/templates/bb-guide-threads.md
+++ b/packages/templates/src/templates/bb-guide-threads.md
@@ -324,7 +324,7 @@ Persisted panel tabs:
 
 Lifecycle:
 
-  bb thread retry [id]                     Retry a failed or stopped unaccepted turn
+  bb thread retry [id]                     Retry a failed turn or stopped unaccepted user request
     --self                                 Target current thread
     --turn <requestId>                     Retry this turn request id specifically; fails when it is not the thread's retryable turn
     --send-at <when>                       Dispatch at an ISO 8601 timestamp or a duration from now (30s, 10m, 2h, 7d)
@@ -336,9 +336,9 @@ Lifecycle:
   never accepted is re-sent verbatim, while an accepted turn (already in the
   provider's conversation) is continued with a nudge rather than asked twice.
   With no --turn it retries the most recent failed turn, or the latest
-  unaccepted request after a manual Stop; --turn asserts which turn you mean and
-  fails when the thread has moved on, as does retrying a turn that is not
-  eligible or already has a retry queued. Without --send-at the retry is
+  unaccepted user request after a manual Stop; --turn asserts which turn you
+  mean and fails when the thread has moved on, as does retrying a turn that is
+  not eligible or already has a retry queued. Without --send-at the retry is
   attempted now, and may still queue behind a busy thread or a plugin.
 
   bb thread archive [id]                   Archive a thread (and children/hidden forks)

--- a/packages/templates/src/templates/bb-guide-threads.md
+++ b/packages/templates/src/templates/bb-guide-threads.md
@@ -324,22 +324,22 @@ Persisted panel tabs:
 
 Lifecycle:
 
-  bb thread retry [id]                     Retry the thread's failed turn
+  bb thread retry [id]                     Retry a failed or stopped unaccepted turn
     --self                                 Target current thread
-    --turn <requestId>                     Retry this turn request id specifically; fails when it is not the thread's failed turn
+    --turn <requestId>                     Retry this turn request id specifically; fails when it is not the thread's retryable turn
     --send-at <when>                       Dispatch at an ISO 8601 timestamp or a duration from now (30s, 10m, 2h, 7d)
     --reason <text>                        Why it is being retried, shown on the queued row
 
-  Retry re-submits the failed turn by reference: no duplicated user message in
+  Retry re-submits the retryable turn by reference: no duplicated user message in
   the timeline, and an attempt number that increments (2 is the first retry).
   What the provider is sent follows its own acceptance record — an input it
   never accepted is re-sent verbatim, while an accepted turn (already in the
   provider's conversation) is continued with a nudge rather than asked twice.
-  With no --turn it retries the most recent turn, the
-  one whose failure put the thread in error; --turn asserts which turn you mean
-  and fails when the thread has moved on, as does retrying a thread that has not
-  failed or a turn that already has a retry queued. Without --send-at the retry
-  is attempted now, and may still queue behind a busy thread or a plugin.
+  With no --turn it retries the most recent failed turn, or the latest
+  unaccepted request after a manual Stop; --turn asserts which turn you mean and
+  fails when the thread has moved on, as does retrying a turn that is not
+  eligible or already has a retry queued. Without --send-at the retry is
+  attempted now, and may still queue behind a busy thread or a plugin.
 
   bb thread archive [id]                   Archive a thread (and children/hidden forks)
     --self                                 Archive current thread

--- a/tests/integration/fake/recovery/stopped-unaccepted-request-recovery.test.ts
+++ b/tests/integration/fake/recovery/stopped-unaccepted-request-recovery.test.ts
@@ -1,0 +1,248 @@
+import { listQueuedThreadMessages } from "@bb/db";
+import {
+  retryTurnResponseSchema,
+  sendMessageResponseSchema,
+} from "@bb/server-contract";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { createAgentRuntime } from "../../../../packages/agent-runtime/src/index.js";
+import { getThread, getThreadEvents, stopThread } from "../../helpers/api.js";
+import {
+  waitForEventType,
+  waitForThreadStatus,
+} from "../../helpers/assertions.js";
+import { withHarness, type IntegrationHarness } from "../../helpers/harness.js";
+import {
+  recordScriptedEchoRequests,
+  type ScriptedEchoRecordedRequest,
+} from "../../helpers/scripted-echo.js";
+import {
+  createProjectFixture,
+  createReadyThread,
+  TURN_TIMEOUT_MS,
+} from "../smoke/shared.js";
+
+const ORIGINAL = "[stopped-unaccepted] original request";
+const PARKED = ["parked second", "parked third"] as const;
+const providerInputSchema = z.object({
+  input: z.array(
+    z.object({ type: z.string(), text: z.string().optional() }).passthrough(),
+  ),
+});
+
+function inputText(input: readonly { type: string; text?: string }[]): string {
+  return input
+    .map((item) => (item.type === "text" ? (item.text ?? "") : ""))
+    .join("");
+}
+
+function providerInputs(
+  requests: readonly ScriptedEchoRecordedRequest[],
+  threadId: string,
+): string[] {
+  return requests.flatMap((request) => {
+    if (request.params?.threadId !== threadId) return [];
+    const parsed = providerInputSchema.safeParse(request.params);
+    return parsed.success ? [inputText(parsed.data.input)] : [];
+  });
+}
+
+async function waitUntil(
+  check: () => boolean | Promise<boolean>,
+): Promise<void> {
+  const deadline = Date.now() + 3_000;
+  while (!(await check())) {
+    if (Date.now() >= deadline)
+      throw new Error("Timed out waiting for condition");
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+}
+
+async function send(
+  harness: IntegrationHarness,
+  threadId: string,
+  text: string,
+) {
+  const response = await harness.api.threads[":id"].send.$post({
+    param: { id: threadId },
+    json: { input: [{ type: "text", text, mentions: [] }], mode: "auto" },
+  });
+  expect(response.status).toBe(200);
+  return sendMessageResponseSchema.parse(await response.json());
+}
+
+describe.sequential("stopped unaccepted request recovery", () => {
+  it("retries once, then drains parked messages once in order", async () => {
+    const record = await recordScriptedEchoRequests();
+    try {
+      await withHarness(
+        {
+          createRuntime: (options) =>
+            createAgentRuntime({
+              ...options,
+              turnStartWatchdog: { thresholdMs: 150, intervalMs: 25 },
+            }),
+        },
+        async (harness) => {
+          const project = await createProjectFixture(
+            harness,
+            "Stopped Unaccepted Recovery",
+          );
+          const { environment, thread } = await createReadyThread(harness, {
+            projectId: project.id,
+            workspace: { type: "unmanaged", path: harness.repoDir },
+          });
+          const baselineRequestCount = (await record.read()).filter(
+            (request) => request.params?.threadId === thread.id,
+          ).length;
+
+          expect(await send(harness, thread.id, ORIGINAL)).toEqual({
+            ok: true,
+            delivery: "sent",
+          });
+          await waitForThreadStatus(
+            harness.api,
+            thread.id,
+            "active",
+            TURN_TIMEOUT_MS,
+          );
+          const runtime = harness.daemonApp.runtimeManager.get(
+            environment.id,
+          )?.runtime;
+          await waitUntil(() =>
+            Boolean(runtime?.getLiveThreadIds().includes(thread.id)),
+          );
+          expect(runtime?.getActiveTurnId(thread.id)).toBeNull();
+
+          const parkedIds: string[] = [];
+          for (const text of PARKED) {
+            const result = await send(harness, thread.id, text);
+            expect(result.delivery).toBe("queued");
+            if (result.delivery === "queued") {
+              expect(result.queuedMessage.waitingOn).toEqual({
+                kind: "turn-starting",
+              });
+              parkedIds.push(result.queuedMessage.id);
+            }
+          }
+          expect(
+            listQueuedThreadMessages(harness.db, thread.id).map(
+              (row) => row.id,
+            ),
+          ).toEqual(parkedIds);
+
+          const watchdog = await waitForEventType(
+            harness.api,
+            thread.id,
+            "system/error",
+            TURN_TIMEOUT_MS,
+          );
+          expect(watchdog.data).toMatchObject({
+            code: "provider_turn_start_timeout",
+          });
+          expect((await getThread(harness.api, thread.id)).status).toBe(
+            "active",
+          );
+          const beforeStop = await getThreadEvents(harness.api, thread.id);
+          const original = beforeStop.find(
+            (event) =>
+              event.type === "client/turn/requested" &&
+              inputText(event.data.input) === ORIGINAL,
+          );
+          if (original?.type !== "client/turn/requested") {
+            throw new Error("Missing original request");
+          }
+          expect(
+            beforeStop
+              .filter((event) => event.seq > original.seq)
+              .map((event) => event.type),
+          ).not.toEqual(
+            expect.arrayContaining([
+              "turn/input/accepted",
+              "turn/started",
+              "client/turn/rejected",
+              "turn/completed",
+            ]),
+          );
+
+          await stopThread(harness.api, thread.id);
+          await waitForThreadStatus(
+            harness.api,
+            thread.id,
+            "idle",
+            TURN_TIMEOUT_MS,
+          );
+          expect(runtime?.getLiveThreadIds()).not.toContain(thread.id);
+          expect(
+            listQueuedThreadMessages(harness.db, thread.id).map(
+              (row) => row.id,
+            ),
+          ).toEqual(parkedIds);
+          const beforeRetry = (await record.read())
+            .filter((request) => request.params?.threadId === thread.id)
+            .slice(baselineRequestCount);
+          expect(providerInputs(beforeRetry, thread.id)).toEqual([ORIGINAL]);
+          expect(
+            beforeRetry.find((request) => request.method === "thread/stop")
+              ?.params?.intent,
+          ).toBe("release");
+
+          const response = await harness.api.threads[":id"].retry.$post({
+            param: { id: thread.id },
+            json: {
+              turnRequestId: original.data.requestId,
+              sendAt: null,
+              reason: "Retry stopped request",
+            },
+          });
+          expect(response.status).toBe(200);
+          expect(
+            retryTurnResponseSchema.parse(await response.json()),
+          ).toMatchObject({
+            ok: true,
+            delivery: "sent",
+            turnRequestId: original.data.requestId,
+            attempt: 2,
+          });
+          await waitForThreadStatus(
+            harness.api,
+            thread.id,
+            "idle",
+            TURN_TIMEOUT_MS,
+          );
+          expect(listQueuedThreadMessages(harness.db, thread.id)).toEqual([]);
+
+          const recoveryRequests = (
+            await getThreadEvents(harness.api, thread.id)
+          )
+            .slice(beforeStop.length)
+            .filter((event) => event.type === "client/turn/requested");
+          expect(
+            recoveryRequests.map((event) => inputText(event.data.input)),
+          ).toEqual([ORIGINAL, ...PARKED]);
+          expect(recoveryRequests[0]?.data).toMatchObject({
+            retryOfRequestId: original.data.requestId,
+            retryAttempt: 2,
+          });
+          await waitUntil(async () => {
+            const requests = (await record.read())
+              .filter((request) => request.params?.threadId === thread.id)
+              .slice(baselineRequestCount + beforeRetry.length);
+            return providerInputs(requests, thread.id).length === 3;
+          });
+          const afterRetry = (await record.read())
+            .filter((request) => request.params?.threadId === thread.id)
+            .slice(baselineRequestCount);
+          expect(
+            providerInputs(afterRetry.slice(beforeRetry.length), thread.id),
+          ).toEqual([ORIGINAL, ...PARKED]);
+          expect(
+            afterRetry.filter((request) => request.method === "thread/stop"),
+          ).toHaveLength(1);
+        },
+      );
+    } finally {
+      await record.dispose();
+    }
+  });
+});

--- a/tests/integration/fake/recovery/stopped-unaccepted-request-recovery.test.ts
+++ b/tests/integration/fake/recovery/stopped-unaccepted-request-recovery.test.ts
@@ -24,6 +24,8 @@ import {
 
 const ORIGINAL = "[stopped-unaccepted] original request";
 const PARKED = ["parked second", "parked third"] as const;
+type ThreadEvent = Awaited<ReturnType<typeof getThreadEvents>>[number];
+type TurnRequestEvent = Extract<ThreadEvent, { type: "client/turn/requested" }>;
 const providerInputSchema = z.object({
   input: z.array(
     z.object({ type: z.string(), text: z.string().optional() }).passthrough(),
@@ -71,7 +73,7 @@ async function send(
   return sendMessageResponseSchema.parse(await response.json());
 }
 
-describe.sequential("stopped unaccepted request recovery", () => {
+describe.sequential("stopped unaccepted user request recovery", () => {
   it("retries once, then drains parked messages once in order", async () => {
     const record = await recordScriptedEchoRequests();
     try {
@@ -212,11 +214,13 @@ describe.sequential("stopped unaccepted request recovery", () => {
           );
           expect(listQueuedThreadMessages(harness.db, thread.id)).toEqual([]);
 
-          const recoveryRequests = (
-            await getThreadEvents(harness.api, thread.id)
-          )
-            .slice(beforeStop.length)
-            .filter((event) => event.type === "client/turn/requested");
+          let recoveryRequests: TurnRequestEvent[] = [];
+          await waitUntil(async () => {
+            recoveryRequests = (await getThreadEvents(harness.api, thread.id))
+              .slice(beforeStop.length)
+              .filter((event) => event.type === "client/turn/requested");
+            return recoveryRequests.length === 3;
+          });
           expect(
             recoveryRequests.map((event) => inputText(event.data.input)),
           ).toEqual([ORIGINAL, ...PARKED]);

--- a/tests/integration/helpers/harness.ts
+++ b/tests/integration/helpers/harness.ts
@@ -108,6 +108,9 @@ export interface IntegrationHarness {
 export interface CreateHarnessOptions {
   serverPort?: number;
   bindHost?: "127.0.0.1" | "0.0.0.0";
+  createRuntime?: NonNullable<
+    Parameters<typeof createHostDaemonApp>[0]["createRuntime"]
+  >;
   staticDir?: string;
 }
 
@@ -374,6 +377,9 @@ async function startHarnessDaemon(
       logger: testLogger,
       releaseLock,
       serverUrl: server.baseUrl,
+      ...(options.createRuntime === undefined
+        ? {}
+        : { createRuntime: options.createRuntime }),
     });
     for (
       let attempt = 1;

--- a/tests/scripted-echo-provider/src/provider-bridge.ts
+++ b/tests/scripted-echo-provider/src/provider-bridge.ts
@@ -82,6 +82,7 @@ export const scriptedEchoOptionsSchema = z
     goalClearNotifyDelayMs: z.number().int().nonnegative().optional(),
     goalClearReportsCleared: z.boolean().optional(),
     swallowTurnStart: z.boolean().optional(),
+    swallowUserTurnStartText: z.string().min(1).optional(),
     sessionRestorable: z.boolean().optional(),
     warnOnTurn: z.boolean().optional(),
     toolCallThreadIdHint: z.string().min(1).optional(),
@@ -1038,7 +1039,19 @@ const handlers: Record<string, RequestHandler> = {
     if (responseDelayMs === undefined) {
       io.sendResult(id, {});
     }
-    if (session.options.swallowTurnStart !== true) {
+    const swallowUserTurnStartText = session.options.swallowUserTurnStartText;
+    const swallowsVisibleMatchingInput =
+      swallowUserTurnStartText !== undefined &&
+      parsed.data.input.some(
+        (item) =>
+          item.type === "text" &&
+          item.visibility !== "agent-only" &&
+          item.text.includes(swallowUserTurnStartText),
+      );
+    if (
+      session.options.swallowTurnStart !== true &&
+      !swallowsVisibleMatchingInput
+    ) {
       beginTurn({
         session,
         input: parsed.data.input,


### PR DESCRIPTION
## Human comments

## What was wrong

The broad busy-turn and pending-start message-loss paths from [#2370](https://github.com/get-bb/bb/issues/2370) are already covered by #2379, #2816, #2884, and #2886. One recovery gap remained: if a provider never acknowledged or started the latest dispatched request, a manual Stop could release the orphaned runtime, but the visible original request had no supported way to run again. The existing retry endpoint only admitted failed threads, so recovery required retyping the request and could strand messages parked behind it. See the [investigation report](https://get-bb.github.io/reports/issues/2370.html).

## What changed

- Treat the latest unresolved dispatched request as explicitly retryable only after a later manual Stop, while the thread is idle and writable, and only if the provider never accepted, started, rejected, or completed it. The startup watchdog remains diagnostic and does not affect eligibility.
- Expose that request ID in `ThreadResponse` and add a destructive `Retry request` action below the original user message. The action reuses the existing retry path, including retry IDs/attempts and duplicate-delivery safeguards.
- Preserve queued messages, IDs, groups, taxonomy, and arrival order; they remain parked until retry recovery permits delivery.
- Document the recovery behavior in the CLI guide and SDK-facing contracts. Existing failed-turn retry behavior remains unchanged.
- Add focused server, UI, and integration regressions, including a deterministic scripted provider that delays the opening turn without invoking a paid provider.

There is no database migration or new lifecycle event. The public plugin backend contract change bumps `@get-bb/plugin-sdk` from 0.4.43 to 0.4.44. `HOST_DAEMON_PROTOCOL_VERSION` remains 179 because this changes the server HTTP response and UI/SDK behavior, not any server/daemon payload, result, default, or meaning.

## How you verified

- Red/green regression coverage: the stopped-unaccepted retry cases and message action fail without the implementation and pass with it.
- `pnpm exec turbo run test --filter=@bb/server -- --run test/threads/turn-stopped-unaccepted-retry.test.ts test/threads/turn-failed-retry.test.ts` — 20 tests passed.
- `pnpm exec turbo run test --filter=@bb/app -- --run src/components/thread/timeline/MessageActionBar.test.tsx src/components/thread/timeline/ThreadTimelineRows.actions.test.tsx` — 71 tests passed.
- `pnpm exec turbo run test --filter=@bb/integration-tests -- --run fake/recovery/stopped-unaccepted-request-recovery.test.ts` — 1 test passed with in-memory SQLite.
- `pnpm exec turbo run typecheck --filter=@bb/app --filter=@bb/server --filter=@bb/server-contract --filter=@bb/sdk --filter=@bb/integration-tests --filter=bb-plugin-scripted-echo-provider --filter=@bb/cli` — 12 tasks passed.
- `pnpm exec turbo run build --filter=@bb/app --filter=@bb/server --filter=@bb/cli` — 7 tasks passed.
- `node .github/workflows/check-plugin-sdk-version.mjs` and the npm version guard passed; 0.4.44 is unpublished and ready for the publish job.
- `pnpm exec turbo run test --filter=@get-bb/plugin-sdk -- --run src/__tests__/version.test.ts` — 1 test passed.
- `pnpm exec turbo run test typecheck --filter=@bb/demo-server --force` — demo contract fixture typecheck and 9 tests passed.
- `pnpm exec turbo run typecheck --force` — all 86 workspace packages passed after auditing the remaining contract consumers.
- Plugin Guide maintenance: regenerated `sdk-public-api.json`; combined SDK/Guide/app/docs tests and typechecks passed (including 3,852 app tests and the API sync test), and `bb plugin build plugins/plugin-api-docs` succeeded.
- `oxfmt --check` on every changed file and `git diff --check origin/main...HEAD` passed.
- Browser QA with the deterministic provider reproduced an opening request that never started, parked a follow-up, released the orphan runtime with Stop, and verified that `Retry request` delivered the original and parked follow-up once, in order, without falsely marking the thread failed.

Fixes #2370

@slopcop — tagged for visibility and review.

> AGENT GENERATED
