### PR TITLE
Fix incomplete numeric plugin setting entry

### DIFF
--- a/apps/app/src/components/plugin/PluginSettings.test.tsx
+++ b/apps/app/src/components/plugin/PluginSettings.test.tsx
@@ -167,6 +167,17 @@ describe("PluginSettingsForm", () => {
     expect(retries.step).toBe("any");
     expect(retries.value).toBe("3");
 
+    const badInput = vi
+      .spyOn(retries.validity, "badInput", "get")
+      .mockReturnValue(true);
+    fireEvent.change(retries, { target: { value: "" } });
+    fireEvent.blur(retries);
+    expect((await screen.findByRole("alert")).textContent).toContain(
+      "Enter a finite number",
+    );
+    expect(retries.value).toBe("3");
+    badInput.mockRestore();
+
     fireEvent.change(retries, { target: { value: "4.5" } });
     expect(requests.some((request) => request.init?.method === "PUT")).toBe(
       false,

--- a/apps/app/src/components/plugin/PluginSettings.tsx
+++ b/apps/app/src/components/plugin/PluginSettings.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useState } from "react";
+import { useEffect, useId, useState, type FocusEvent } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { appToast } from "@/components/ui/app-toast.js";
 import { PluginSettingsSections } from "@/components/plugin/PluginSettingsSections";
@@ -46,6 +46,7 @@ const DROPDOWN_CONTENT_CLASS =
 
 const MULTILINE_MIN_ROWS = 6;
 const MULTILINE_MAX_ROWS = 24;
+const INVALID_NUMBER_DRAFT = Symbol();
 const MULTILINE_TEXTAREA_CLASS =
   "max-h-96 min-h-32 w-full resize-y overflow-y-auto font-mono text-xs field-sizing-content";
 function multilineRows(value: string): number {
@@ -112,7 +113,7 @@ interface PluginSettingFieldProps {
   ariaInvalid: boolean;
   descriptor: PluginSettingFieldDescriptor;
   draft: string | boolean;
-  onBlur: () => void;
+  onBlur: (event: FocusEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
   onChange: (value: string | boolean) => void;
   storedValue: unknown;
 }
@@ -310,7 +311,9 @@ function AutosavingPluginSetting({
   const draft = draftState.value;
   const save = useMutation({
     scope: { id: `plugin-setting:${pluginId}:${settingKey}` },
-    mutationFn: (value: string | boolean) => {
+    mutationFn: (value: string | boolean | typeof INVALID_NUMBER_DRAFT) => {
+      if (value === INVALID_NUMBER_DRAFT)
+        throw new Error("Enter a finite number");
       let settingValue: string | number | boolean | null = value;
       if (descriptor.type === "number") {
         const trimmed = typeof value === "string" ? value.trim() : "";
@@ -347,8 +350,15 @@ function AutosavingPluginSetting({
     }
   }
 
-  function saveDraft(): void {
+  function saveDraft(
+    event: FocusEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ): void {
     if (descriptor.type !== "string" && descriptor.type !== "number") return;
+    if (descriptor.type === "number" && event.currentTarget.validity.badInput) {
+      setDraftState({ value: initialDraft, hasNewerDraft: false });
+      save.mutate(INVALID_NUMBER_DRAFT);
+      return;
+    }
     if (descriptor.type === "number") {
       const trimmed = typeof draft === "string" ? draft.trim() : "";
       const parsed = Number(trimmed);

--- a/apps/cli/src/__tests__/command-output/plugin-config.test.ts
+++ b/apps/cli/src/__tests__/command-output/plugin-config.test.ts
@@ -25,13 +25,13 @@ describe("bb plugin config", () => {
   const register: CommandRegistrar = (program) =>
     registerPluginCommands(program, () => "http://server");
 
-  it("converts a declared number before sending the settings update", async () => {
+  it("accepts a negative number while preserving unknown-option errors", async () => {
     vi.mocked(fetch)
       .mockResolvedValueOnce(settingsResponse(3))
-      .mockResolvedValueOnce(settingsResponse(4.5));
+      .mockResolvedValueOnce(settingsResponse(-4.5));
 
     await runCommand(
-      ["plugin", "config", "demo", "set", "retries", "4.5"],
+      ["plugin", "config", "demo", "set", "retries", "-4.5"],
       register,
     );
 
@@ -40,9 +40,22 @@ describe("bb plugin config", () => {
       "http://server/api/v1/plugins/demo/settings",
       expect.objectContaining({
         method: "PUT",
-        body: JSON.stringify({ values: { retries: 4.5 } }),
+        body: JSON.stringify({ values: { retries: -4.5 } }),
       }),
     );
+
+    vi.mocked(fetch).mockClear();
+    const stderr = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+    await expect(
+      runCommand(
+        ["plugin", "config", "demo", "set", "retries", "3", "--bogus"],
+        register,
+      ),
+    ).rejects.toThrow("process.exit:1");
+    expect(stderr).toHaveBeenCalledWith("error: unknown option '--bogus'\n");
+    expect(fetch).not.toHaveBeenCalled();
   });
 
   it("rejects a non-finite number before sending an update", async () => {

--- a/apps/cli/src/commands/plugin.ts
+++ b/apps/cli/src/commands/plugin.ts
@@ -110,6 +110,8 @@ const pluginSettingDescriptorSchema = z.object({
   default: z.union([z.string(), z.number().finite(), z.boolean()]).optional(),
   options: z.array(z.string()).optional(),
 });
+const negativeNumberValuePattern =
+  /^-(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?$/;
 const pluginSettingsResultSchema = z.object({
   ok: z.boolean(),
   error: z.string().optional(),
@@ -1560,6 +1562,8 @@ export function registerPluginCommands(
       "Show a plugin's settings, or change them: config <id> set <key> <value> | config <id> unset <key>",
     )
     .option("--json", "Output JSON")
+    .allowUnknownOption()
+    .allowExcessArguments()
     .action(
       action(
         async (
@@ -1568,7 +1572,27 @@ export function registerPluginCommands(
           key: string | undefined,
           value: string | undefined,
           opts: JsonOutputOptions,
+          command: Command,
         ) => {
+          const rawArgs = (program as Command & { rawArgs: string[] }).rawArgs;
+          const terminatorIndex = rawArgs.indexOf("--");
+          const valueIsOption =
+            value?.startsWith("-") === true &&
+            (terminatorIndex < 0 ||
+              terminatorIndex > rawArgs.lastIndexOf(value));
+          const unknownOption =
+            [id, actionName, key, ...command.args.slice(4)].find((argument) =>
+              argument?.startsWith("-"),
+            ) ??
+            (valueIsOption && !negativeNumberValuePattern.test(value)
+              ? value
+              : undefined);
+          if (unknownOption !== undefined)
+            command.error(`error: unknown option '${unknownOption}'`);
+          if (command.args.length > 4)
+            command.error(
+              `error: too many arguments for 'config'. Expected 4 arguments but got ${command.args.length}.`,
+            );
           const settingsPath = `/${encodeURIComponent(id)}/settings`;
           if (actionName === undefined) {
             const result = pluginSettingsResultSchema.parse(
@@ -1617,6 +1641,9 @@ export function registerPluginCommands(
                 `Unknown setting "${key}"${known ? ` — known settings: ${known}` : ""}`,
               );
               process.exit(1);
+            }
+            if (valueIsOption && descriptor.type !== "number") {
+              command.error(`error: unknown option '${value}'`);
             }
             parsedValue = parseSettingValue(descriptor, key, value);
           }


### PR DESCRIPTION
## Human comments

## What was wrong

Numeric plugin settings had two incomplete entry paths after #2976: Chromium reports a lone minus as `badInput` with an empty value, so blurring silently cleared the saved setting, while the CLI option parser rejected valid negative numbers before plugin validation could run.

## What changed

The app now distinguishes incomplete numeric input from a deliberate clear, restores the saved value, and shows the existing accessible finite-number error without sending a settings update. The CLI accepts negative JSON-number syntax as positional input only for numeric settings while preserving `--json`, explicit `--` string escaping, unknown-option errors, and excess-argument handling. No wire or public API changes are included.

## How you verified

- `pnpm exec turbo run test --filter=@bb/app --force -- src/components/plugin/PluginSettings.test.tsx` — 14 tests passed
- `pnpm exec turbo run test --filter=@bb/cli --force -- src/__tests__/command-output/plugin-config.test.ts` — 2 tests passed
- Turbo builds and typechecks passed for `@bb/app` and `@bb/cli`
- Targeted Oxfmt and `git diff --check` passed
- Browser QA confirmed a lone minus restores the saved value and reports `Enter a finite number`
- CLI QA confirmed `-1` reaches plugin range validation while unknown options remain rejected

Follow-up to #2976.

> AGENT GENERATED