### PR TITLE
Fix empty project picker menu spacing

### DIFF
--- a/apps/app/src/components/pickers/ProjectSelector.test.tsx
+++ b/apps/app/src/components/pickers/ProjectSelector.test.tsx
@@ -169,6 +169,27 @@ describe("ProjectSelector", () => {
     expect(screen.getByRole("option", { name: "Alpha Web" })).toBeTruthy();
   });
 
+  it("keeps empty-list actions in the project group", () => {
+    render(
+      <ProjectSelector
+        projects={[]}
+        value={null}
+        onChange={() => {}}
+        allowNoProject
+        createProject={{ onCreate: () => {} }}
+        defaultOpen
+        modal={false}
+      />,
+    );
+
+    const groups = document.querySelectorAll("[cmdk-group]");
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.querySelector("[cmdk-group-heading]")?.textContent).toBe(
+      "Project",
+    );
+    expect(groups[0]?.querySelectorAll("[cmdk-item]")).toHaveLength(2);
+  });
+
   it("keeps the search fixed while the project results scroll", () => {
     render(
       <ProjectSelector

--- a/apps/app/src/components/pickers/ProjectSelector.tsx
+++ b/apps/app/src/components/pickers/ProjectSelector.tsx
@@ -181,43 +181,47 @@ export function ProjectSelector({
             ref={listRef}
             className="min-h-0 max-h-none flex-1 overscroll-contain"
           >
-            <CommandGroup heading="Project">
-              {filteredProjects.map((project) => (
-                <CommandItem
-                  key={project.id}
-                  value={project.id}
-                  keywords={[project.name]}
-                  aria-current={project.id === value ? "true" : undefined}
-                  onSelect={() => selectProject(project.id)}
-                  className={PROJECT_PICKER_ITEM_CLASS_NAME}
-                >
-                  <Icon
-                    name="Folder"
-                    className="size-4 text-muted-foreground"
-                    aria-hidden
-                  />
-                  <span className="min-w-0 flex-1 truncate">
-                    {project.name}
-                  </span>
-                  <Icon
-                    name="Check"
-                    className={cn(
-                      "ml-auto size-4",
-                      project.id === value ? "opacity-100" : "opacity-0",
-                    )}
-                    aria-hidden
-                  />
-                </CommandItem>
-              ))}
-              {showSearch && filteredProjects.length === 0 ? (
-                <div className="px-2 py-1.5 text-xs text-muted-foreground max-md:py-2">
-                  No projects found
-                </div>
-              ) : null}
-            </CommandGroup>
+            {projects.length > 0 ? (
+              <CommandGroup heading="Project">
+                {filteredProjects.map((project) => (
+                  <CommandItem
+                    key={project.id}
+                    value={project.id}
+                    keywords={[project.name]}
+                    aria-current={project.id === value ? "true" : undefined}
+                    onSelect={() => selectProject(project.id)}
+                    className={PROJECT_PICKER_ITEM_CLASS_NAME}
+                  >
+                    <Icon
+                      name="Folder"
+                      className="size-4 text-muted-foreground"
+                      aria-hidden
+                    />
+                    <span className="min-w-0 flex-1 truncate">
+                      {project.name}
+                    </span>
+                    <Icon
+                      name="Check"
+                      className={cn(
+                        "ml-auto size-4",
+                        project.id === value ? "opacity-100" : "opacity-0",
+                      )}
+                      aria-hidden
+                    />
+                  </CommandItem>
+                ))}
+                {showSearch && filteredProjects.length === 0 ? (
+                  <div className="px-2 py-1.5 text-xs text-muted-foreground max-md:py-2">
+                    No projects found
+                  </div>
+                ) : null}
+              </CommandGroup>
+            ) : null}
             {showActionSeparator ? <CommandSeparator /> : null}
             {createProjectAction || allowNoProject ? (
-              <CommandGroup>
+              <CommandGroup
+                heading={projects.length === 0 ? "Project" : undefined}
+              >
                 {createProjectAction ? (
                   <CommandItem
                     disabled={createProjectAction.disabled}


### PR DESCRIPTION
## Human comments

## What was wrong

When the project picker had no projects, it rendered an empty headed project group above the create and no-project actions. The empty group left an unnecessary gap between the `Project` heading and the first available action.

## What changed

The picker now renders the results group only when projects exist. For an empty project list, the action group owns the `Project` heading, keeping the available actions directly beneath it without changing populated or filtered-result behavior.

## How you verified

- `pnpm exec turbo run test --filter=@bb/app --force -- src/components/pickers/ProjectSelector.test.tsx` — 7 tests passed
- `pnpm exec turbo run typecheck --filter=@bb/app --force`
- `pnpm exec turbo run build --filter=@bb/app --force`
- Targeted Oxfmt and `git diff --check` passed
- Browser measurement confirmed the heading-to-action gap changed from approximately 8px to 0px

> AGENT GENERATED