### PR TITLE
Preserve leading timeline history past event budget

### DIFF
--- a/apps/server/src/services/threads/timeline.ts
+++ b/apps/server/src/services/threads/timeline.ts
@@ -1011,8 +1011,11 @@ function resolveTimelineWindowBounds(
   args: ResolveTimelineWindowBoundsArgs,
 ): Pick<
   ResolvedTimelineSegmentWindow,
-  "effectiveSegmentLimit" | "sequenceStart" | "sequenceWindowStart"
-> & { affordableAnchorCount: number } {
+  | "effectiveSegmentLimit"
+  | "knownHasOlderSegments"
+  | "sequenceStart"
+  | "sequenceWindowStart"
+> {
   const { anchors, budgetFloorSequence, segmentLimit, threadId } = args;
   const affordable = countAffordableAnchors(
     anchors,
@@ -1036,8 +1039,8 @@ function resolveTimelineWindowBounds(
     })
   ) {
     return {
-      affordableAnchorCount: 0,
       effectiveSegmentLimit: segmentLimit,
+      knownHasOlderSegments: true,
       sequenceWindowStart: {
         kind: "event",
         sequenceStart: budgetFloorSequence,
@@ -1049,19 +1052,33 @@ function resolveTimelineWindowBounds(
 
   if (budgetFloorSequence === undefined && anchors.length <= segmentLimit) {
     return {
-      affordableAnchorCount: anchors.length,
       effectiveSegmentLimit: segmentLimit,
+      knownHasOlderSegments: null,
       sequenceWindowStart: null,
       sequenceStart: 0,
     };
   }
 
   const segmentCount = Math.max(1, affordable);
+  const sequenceStart = anchors[segmentCount - 1]?.sequence ?? 0;
+  const budgetHasOlderRows =
+    budgetFloorSequence !== undefined &&
+    (budgetFloorSequence < sequenceStart ||
+      (budgetFloorSequence === sequenceStart &&
+        findTimelineWindowBudgetFloorSequence(db, {
+          beforeSequence: sequenceStart,
+          eventBudget: 0,
+          excludedTypes: THREAD_TIMELINE_EXCLUDED_EVENT_TYPES,
+          threadId,
+        }) !== undefined));
   return {
-    affordableAnchorCount: segmentCount,
     effectiveSegmentLimit: segmentCount,
+    knownHasOlderSegments:
+      sequenceStart === 0
+        ? null
+        : anchors.length > segmentCount || budgetHasOlderRows,
     sequenceWindowStart: null,
-    sequenceStart: anchors[segmentCount - 1]?.sequence ?? 0,
+    sequenceStart,
   };
 }
 
@@ -1148,10 +1165,7 @@ function resolveTimelineSegmentWindow(
       effectiveSegmentLimit: bounds.effectiveSegmentLimit,
       hasAnchors: true,
       sequenceWindowStart: bounds.sequenceWindowStart,
-      knownHasOlderSegments:
-        bounds.sequenceStart === 0
-          ? null
-          : precedingAnchors.length > bounds.affordableAnchorCount,
+      knownHasOlderSegments: bounds.knownHasOlderSegments,
       oversizedEventPlaceholder: null,
       sequenceStart: bounds.sequenceStart,
     };
@@ -1181,10 +1195,7 @@ function resolveTimelineSegmentWindow(
     effectiveSegmentLimit: bounds.effectiveSegmentLimit,
     hasAnchors: true,
     sequenceWindowStart: bounds.sequenceWindowStart,
-    knownHasOlderSegments:
-      bounds.sequenceStart === 0
-        ? null
-        : newestAnchors.length > bounds.affordableAnchorCount,
+    knownHasOlderSegments: bounds.knownHasOlderSegments,
     oversizedEventPlaceholder: null,
     sequenceStart: bounds.sequenceStart,
   };

--- a/apps/server/test/services/threads/timeline-in-turn-window.test.ts
+++ b/apps/server/test/services/threads/timeline-in-turn-window.test.ts
@@ -1138,6 +1138,21 @@ describe("in-turn timeline windows", () => {
 describe("timeline segment anchors", () => {
   it("includes provisioning before the first visible user message", () => {
     const { db, thread } = setup();
+    const fillerEvent = (sequence: number): EventInput => ({
+      threadId: thread.id,
+      sequence,
+      type: "system/operation",
+      scope: threadScope(),
+      itemId: null,
+      itemKind: null,
+      parentToolCallId: null,
+      data: JSON.stringify({
+        operation: "event_budget_filler",
+        status: "completed",
+        message: `Visible operation ${sequence}`,
+        operationId: `event-budget-${sequence}`,
+      }),
+    });
     insertEvents(db, noopNotifier, [
       {
         threadId: thread.id,
@@ -1196,7 +1211,13 @@ describe("timeline segment anchors", () => {
       },
     ]);
 
-    const timeline = buildPage(db, thread, LARGE_BUDGET, null).response;
+    insertEvents(
+      db,
+      noopNotifier,
+      Array.from({ length: 1_498 }, (_, index) => fillerEvent(index + 4)),
+    );
+
+    const timeline = buildPage(db, thread, 1_501, null).response;
 
     expect(timeline.timelinePage.hasOlderRows).toBe(false);
     expect(timeline.timelinePage.olderCursor).toBeNull();
@@ -1215,15 +1236,38 @@ describe("timeline segment anchors", () => {
       ]),
     );
 
+    const budgeted = buildPage(db, thread, 1_500, null).response;
+    expect(budgeted.timelinePage.olderCursor).toEqual({
+      anchorSeq: 3,
+      anchorId: `${thread.id}:user-seed:3`,
+    });
+    expect(
+      budgeted.rows.some(
+        (row) =>
+          row.kind === "system" &&
+          row.systemKind === "operation" &&
+          row.title === "Provisioned thread",
+      ),
+    ).toBe(false);
+
+    insertEvents(db, noopNotifier, [fillerEvent(1_502), fillerEvent(1_503)]);
+    const exactFloor = buildPage(db, thread, 1_500, null).response.timelinePage;
+    expect(exactFloor.olderCursor).toEqual({
+      anchorSeq: 3,
+      anchorId: `${thread.id}:user-seed:3`,
+    });
+
     const latest = buildPage(db, thread, LARGE_BUDGET, null, 1).response;
     expect(latest.timelinePage.hasOlderRows).toBe(true);
-    expect(latest.rows).toEqual([
-      expect.objectContaining({
-        kind: "conversation",
-        role: "user",
-        text: "Start now",
-      }),
-    ]);
+    expect(latest.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "conversation",
+          role: "user",
+          text: "Start now",
+        }),
+      ]),
+    );
     if (latest.timelinePage.olderCursor === null) {
       throw new Error("expected an older timeline cursor");
     }


### PR DESCRIPTION
## Human comments

## What was wrong

After #3021 made setup and system activity before the first non-empty message visible, that leading history could still disappear once a thread exceeded the normal 1,500-event read budget. The timeline resolver treated affordable message-anchor count as complete evidence about older history, so it omitted the budget-truncated prefix without returning an older cursor.

## What changed

The resolver now carries event-budget evidence into the shared older-history decision for both latest and backward pages. When the budget floor exactly equals the selected anchor, it performs one indexed existence lookup to distinguish a complete boundary from hidden earlier events. Ordinary paging, short-thread behavior, and existing event and byte limits are unchanged; no response contract or host-daemon protocol fields changed.

## How you verified

- `pnpm exec turbo run test --filter=@bb/server --force -- --run test/services/threads/timeline-in-turn-window.test.ts test/services/threads/timeline-event-budget.test.ts test/services/threads/timeline-workflow-progress-window.test.ts test/services/threads/timeline-pagination.test.ts` — 4 files and 36 tests passed
- `pnpm exec turbo run typecheck build --filter=@bb/server --force`
- Targeted Prettier and `git diff --check` passed
- The regression failed before the production edit and passes after it for both a budget floor before the first visible anchor and an exact-anchor floor
- Query-plan verification confirmed the exact-floor lookup uses `events_thread_sequence_idx`

Follow-up to #3021.

> AGENT GENERATED