### PR TITLE
Badge terminal rows that opt out of the sandbox

### DIFF
--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.presentation.test.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.presentation.test.tsx
@@ -8,6 +8,7 @@ import { MemoryRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { PluginTimelineRendererProps } from "@get-bb/plugin-sdk";
 import {
+  commandRow,
   ECHO_RECEIPT_PRESENTATION,
   extensionRow,
   planStepsRow,
@@ -102,6 +103,52 @@ describe("presentation-driven timeline rows", () => {
     expect(markup).toContain("Compute primes");
     expect(markup).toContain('data-icon="Code"');
     expect(markup).not.toContain("Ran tool");
+  });
+
+  it("renders a presentation badge as a labelled icon on command and exploration rows", () => {
+    const presentation = {
+      label: { pending: "Running command", completed: "Ran command" },
+      icon: { glyph: "Terminal" },
+      title: "ls -la ~/.claude/ide",
+      badge: {
+        glyph: "SquareUnlock02",
+        label: "sandbox off",
+        hint: "Ran outside of sandbox",
+        tone: "destructive" as const,
+      },
+    };
+    const markup = toMarkup(
+      <ThreadTimelineRows
+        threadId="thr_main"
+        threadRuntimeDisplayStatus="idle"
+        workspaceRootPath={undefined}
+        timelineRows={[
+          commandRow({
+            id: "cmd_escaped",
+            command: "ls -la ~/.claude/ide",
+            presentation,
+          }),
+          commandRow({
+            id: "cmd_search",
+            command: "grep -rn pid ~/.claude/ide",
+            activityIntents: [
+              {
+                type: "search",
+                command: "grep -rn pid ~/.claude/ide",
+                query: "pid",
+                path: "~/.claude/ide",
+              },
+            ],
+            presentation,
+          }),
+          commandRow({ id: "cmd_plain", command: "ls -la src" }),
+        ]}
+      />,
+    );
+    expect(markup.match(/data-icon="SquareUnlock02"/g) ?? []).toHaveLength(2);
+    expect(markup).toContain('aria-label="Ran outside of sandbox"');
+    expect(markup).toContain('title="Ran outside of sandbox"');
+    expect(markup).toContain("text-destructive-text");
   });
 
   it("draws a plugin-declared icon as a tinted mask when the inventory has it, else the per-kind glyph", () => {

--- a/apps/app/src/components/thread/timeline/TimelineTitleView.tsx
+++ b/apps/app/src/components/thread/timeline/TimelineTitleView.tsx
@@ -13,6 +13,8 @@ import {
   type TimelineTitleTone,
 } from "@bb/thread-view";
 import { cn } from "@bb/shared-ui/lib/utils";
+import { Icon } from "@bb/shared-ui/icon";
+import { isIconName } from "./presentation-display.js";
 import { DiffStatsTally } from "@/components/ui/diff-stats-tally.js";
 import { RouteAnchor } from "@/components/ui/app-route-anchor.js";
 import { useSecondTick } from "@/hooks/useSecondTick";
@@ -67,6 +69,12 @@ function plainToneClass(tone: TimelineTitleTone): string {
     default:
       return assertNever(tone);
   }
+}
+
+function badgeToneClass(tone: "neutral" | "destructive"): string {
+  return tone === "destructive"
+    ? "text-destructive-text"
+    : "text-muted-foreground";
 }
 
 function decorationToneClass(tone: TimelineTitleTone): string {
@@ -287,6 +295,29 @@ function renderDecoration(
           hideZero
           className="shrink-0"
         />
+      );
+    }
+    case "badge": {
+      const badgeClass = badgeToneClass(decoration.tone);
+      if (!isIconName(decoration.glyph)) {
+        return (
+          <span key={index} className={cn(baseClass, badgeClass)}>
+            {decoration.label}
+          </span>
+        );
+      }
+      return (
+        <span
+          key={index}
+          className="inline-flex shrink-0 items-center"
+          title={decoration.hint}
+        >
+          <Icon
+            name={decoration.glyph}
+            className={cn("size-3.5", badgeClass)}
+            aria-label={decoration.hint}
+          />
+        </span>
       );
     }
     default:

--- a/apps/app/src/test/fixtures/thread-timeline-rows.ts
+++ b/apps/app/src/test/fixtures/thread-timeline-rows.ts
@@ -78,6 +78,7 @@ interface CommandRowArgs extends RowBaseOverrideArgs {
   exitCode?: number | null;
   id?: string;
   output?: string;
+  presentation?: TimelineRowPresentation;
   seq?: number;
   source?: string | null;
   sourceSeqEnd?: number;
@@ -530,6 +531,7 @@ export function commandRow({
   exitCode,
   id = DEFAULT_COMMAND_ID,
   output = "",
+  presentation,
   seq,
   source = "exec_command",
   sourceSeqEnd,
@@ -563,6 +565,7 @@ export function commandRow({
     completedAt: completedAtFromDuration(base.startedAt, durationMs),
     approvalStatus,
     activityIntents,
+    ...(presentation === undefined ? {} : { presentation }),
   };
 }
 

--- a/packages/domain/src/item-presentation.ts
+++ b/packages/domain/src/item-presentation.ts
@@ -32,6 +32,24 @@ export function isPresentationTintColor(value: string): boolean {
   return PRESENTATION_TINT_COLOR_PATTERN.test(value.trim());
 }
 
+export const THREAD_EVENT_ITEM_PRESENTATION_BADGE_LABEL_MAX_LENGTH = 80;
+
+export const threadEventItemPresentationBadgeSchema = z.object({
+  glyph: z.string().min(1),
+  label: z
+    .string()
+    .min(1)
+    .max(THREAD_EVENT_ITEM_PRESENTATION_BADGE_LABEL_MAX_LENGTH),
+  hint: z
+    .string()
+    .min(1)
+    .max(THREAD_EVENT_ITEM_PRESENTATION_BADGE_LABEL_MAX_LENGTH),
+  tone: z.enum(["neutral", "destructive"]),
+});
+export type ThreadEventItemPresentationBadge = z.infer<
+  typeof threadEventItemPresentationBadgeSchema
+>;
+
 export const threadEventItemPresentationSchema = z.object({
   label: threadEventItemPresentationLabelSchema,
   icon: threadEventItemPresentationIconSchema,
@@ -42,6 +60,7 @@ export const threadEventItemPresentationSchema = z.object({
     .optional(),
   suppress: z.boolean().optional(),
   tint: threadEventItemPresentationTintSchema.optional(),
+  badge: threadEventItemPresentationBadgeSchema.optional(),
 });
 export type ThreadEventItemPresentation = z.infer<
   typeof threadEventItemPresentationSchema

--- a/packages/host-daemon-contract/src/protocol.ts
+++ b/packages/host-daemon-contract/src/protocol.ts
@@ -1,3 +1,3 @@
-export const HOST_DAEMON_PROTOCOL_VERSION = 179 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 180 as const;
 
 export const HOST_ARTIFACT_MAX_BYTES = 256 * 1024 * 1024;

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -636,6 +636,8 @@ const INTENTIONAL_OPTIONAL_HOST_DAEMON_FIELDS: Record<string, string> = {
     "host.write_file may omit mode to preserve existing permissions; when present it only controls newly created files.",
   "hostDaemonOnlineRpcCommandSchema.mergeBaseBranch":
     "workspace.status may omit mergeBaseBranch when the caller only needs working-tree state.",
+  "hostDaemonInteractiveRequestSchema.interaction.payload.subject.presentation.badge":
+    "a tool_use approval's presentation carries a badge only when the bridge has something to flag about how the call will run, such as a command opting out of the session sandbox; absence means the ordinary case, not a blank badge.",
   "hostDaemonInteractiveRequestSchema.interaction.payload.subject.presentation.detail":
     "a tool_use approval's presentation has a detail only when the bridge summarized the call; a missing detail means the label and title are the whole summary, not an empty string.",
   "hostDaemonInteractiveRequestSchema.interaction.payload.subject.presentation.suppress":
@@ -930,7 +932,7 @@ const ACP_BRIDGE_LAUNCH = {
 
 describe("host-daemon command schemas", () => {
   it("uses the current host-daemon protocol version", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(179);
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(180);
     expect(HOST_ARTIFACT_MAX_BYTES).toBe(256 * 1024 * 1024);
   });
 

--- a/packages/provider-bridge-protocol/src/contract-tests/provider-bridge-grammar.v2.snapshot.json
+++ b/packages/provider-bridge-protocol/src/contract-tests/provider-bridge-grammar.v2.snapshot.json
@@ -277,7 +277,8 @@
     "title": "optional",
     "detail": "optional",
     "suppress": "optional",
-    "tint": "optional"
+    "tint": "optional",
+    "badge": "optional"
   },
   "capabilities": {
     "sessionRestore": "default",

--- a/packages/thread-view/src/exec-lifecycle.ts
+++ b/packages/thread-view/src/exec-lifecycle.ts
@@ -160,6 +160,7 @@ export function parseExecLifecycleEvent(
     const completedAt = kind === "end" ? meta.createdAt : null;
 
     const command = extractShellCommandFromString(decoded.item.command);
+    const presentation = decoded.item.presentation;
     return {
       kind,
       call: {
@@ -173,6 +174,7 @@ export function parseExecLifecycleEvent(
         completedAt,
         approvalStatus: itemStatusToApprovalStatus(decoded.item.approvalStatus),
         status,
+        ...(presentation ? { presentation } : {}),
         ...(parentToolCallId ? { parentToolCallId } : {}),
       },
     };

--- a/packages/thread-view/src/timeline-row-title.ts
+++ b/packages/thread-view/src/timeline-row-title.ts
@@ -92,7 +92,14 @@ export type TimelineTitleDecoration =
       errorCount: number;
       interruptedCount: number;
     }
-  | { kind: "diff-stats"; added: number; removed: number };
+  | { kind: "diff-stats"; added: number; removed: number }
+  | {
+      kind: "badge";
+      glyph: string;
+      label: string;
+      hint: string;
+      tone: "neutral" | "destructive";
+    };
 
 export type TimelineTitleAction =
   | {
@@ -129,6 +136,7 @@ interface BuildTimelineActivityIntentTitleArgs {
   intent: TimelineActivityIntent;
   pending: boolean;
   failureStatus?: "error" | "interrupted";
+  badges: readonly TimelineTitleDecoration[];
 }
 
 interface DisplayStatusArgs {
@@ -223,6 +231,24 @@ function completedTurnDurationDecoration(
   };
 }
 
+function badgeDecorations(row: {
+  presentation?: TimelineRowPresentation;
+}): TimelineTitleDecoration[] {
+  const badge = row.presentation?.badge;
+  if (badge === undefined) {
+    return [];
+  }
+  return [
+    {
+      kind: "badge",
+      glyph: badge.glyph,
+      label: badge.label,
+      hint: badge.hint,
+      tone: badge.tone,
+    },
+  ];
+}
+
 function statusDecoration(
   status: TimelineStatusDecorationStatus,
   durationMs: number | null,
@@ -289,6 +315,8 @@ export function formatTimelineDecorationText(
         removed: d.removed,
         hideZero: true,
       });
+    case "badge":
+      return `(${d.label})`;
     default:
       return assertNever(d);
   }
@@ -391,12 +419,14 @@ function presentedTitle({
     );
   }
   const durationMs = completedAt !== null ? completedAt - startedAt : null;
-  const decorations: TimelineTitleDecoration[] =
-    status === "error"
+  const decorations: TimelineTitleDecoration[] = [
+    ...badgeDecorations({ presentation }),
+    ...(status === "error"
       ? [statusDecoration("error", durationMs)]
       : status === "interrupted"
         ? [statusDecoration("interrupted", durationMs)]
-        : filterNull([durationDecoration(startedAt, completedAt)]);
+        : filterNull([durationDecoration(startedAt, completedAt)])),
+  ];
   return makeTitle({ segments, decorations });
 }
 
@@ -427,6 +457,7 @@ function mapExecutionTitle(row: TimelineExecutionWorkRow): TimelineTitle {
   if (explorationTitle !== null) {
     return explorationTitle;
   }
+  const badges = badgeDecorations(row);
   switch (status) {
     case "waiting":
       return makeTitle({
@@ -435,6 +466,7 @@ function mapExecutionTitle(row: TimelineExecutionWorkRow): TimelineTitle {
           segment(isCommand ? "to run" : "to use"),
           segment(content, { em: true, truncate: true }),
         ],
+        decorations: badges,
       });
     case "denied":
       return makeTitle({
@@ -442,9 +474,10 @@ function mapExecutionTitle(row: TimelineExecutionWorkRow): TimelineTitle {
           segment("Permission denied:"),
           segment(content, { em: true, truncate: true }),
         ],
-        decorations: filterNull([
-          durationDecoration(row.startedAt, row.completedAt),
-        ]),
+        decorations: [
+          ...badges,
+          ...filterNull([durationDecoration(row.startedAt, row.completedAt)]),
+        ],
       });
     case "pending":
       return makeTitle({
@@ -452,9 +485,10 @@ function mapExecutionTitle(row: TimelineExecutionWorkRow): TimelineTitle {
           segment(isCommand ? "Running" : "Running tool:", { shimmer: true }),
           segment(content, { em: true, truncate: true }),
         ],
-        decorations: filterNull([
-          durationDecoration(row.startedAt, row.completedAt),
-        ]),
+        decorations: [
+          ...badges,
+          ...filterNull([durationDecoration(row.startedAt, row.completedAt)]),
+        ],
       });
     case "completed":
       return makeTitle({
@@ -462,9 +496,10 @@ function mapExecutionTitle(row: TimelineExecutionWorkRow): TimelineTitle {
           segment(isCommand ? "Ran" : "Ran tool"),
           segment(content, { em: true, truncate: true }),
         ],
-        decorations: filterNull([
-          durationDecoration(row.startedAt, row.completedAt),
-        ]),
+        decorations: [
+          ...badges,
+          ...filterNull([durationDecoration(row.startedAt, row.completedAt)]),
+        ],
       });
     case "error":
       return makeTitle({
@@ -473,6 +508,7 @@ function mapExecutionTitle(row: TimelineExecutionWorkRow): TimelineTitle {
           segment(content, { em: true, truncate: true }),
         ],
         decorations: [
+          ...badges,
           statusDecoration(
             "error",
             row.completedAt !== null ? row.completedAt - row.startedAt : null,
@@ -486,6 +522,7 @@ function mapExecutionTitle(row: TimelineExecutionWorkRow): TimelineTitle {
           segment(content, { em: true, truncate: true }),
         ],
         decorations: [
+          ...badges,
           statusDecoration(
             "interrupted",
             row.completedAt !== null ? row.completedAt - row.startedAt : null,
@@ -529,6 +566,7 @@ function mapSingleExplorationIntentTitle(
     pending,
   });
 
+  const badges = badgeDecorations(row);
   if (status === "denied") {
     const verbContent = detail.prefix
       ? `${detail.prefix} ${detail.content}`
@@ -545,6 +583,7 @@ function mapSingleExplorationIntentTitle(
           plainText: plainVerbContent,
         }),
       ],
+      decorations: badges,
     });
   }
   if (status === "waiting") {
@@ -564,6 +603,7 @@ function mapSingleExplorationIntentTitle(
           plainText: plainVerbContent,
         }),
       ],
+      decorations: badges,
     });
   }
 
@@ -579,12 +619,14 @@ function mapSingleExplorationIntentTitle(
     }),
   );
 
-  const decorations: TimelineTitleDecoration[] =
-    status === "error"
+  const decorations: TimelineTitleDecoration[] = [
+    ...badges,
+    ...(status === "error"
       ? [statusDecoration("error", null)]
       : status === "interrupted"
         ? [statusDecoration("interrupted", null)]
-        : [];
+        : []),
+  ];
 
   return makeTitle({ segments, decorations });
 }
@@ -1541,6 +1583,7 @@ function mapTimelineActivityIntentTitle({
   intent,
   pending,
   failureStatus,
+  badges,
 }: BuildTimelineActivityIntentTitleArgs): TimelineTitle {
   const detail = formatTimelineActivityIntentDetailParts({
     intent,
@@ -1563,9 +1606,10 @@ function mapTimelineActivityIntentTitle({
       plainText: plainDetail.content,
     }),
   );
-  const decorations = failureStatus
-    ? [statusDecoration(failureStatus, null)]
-    : [];
+  const decorations = [
+    ...badges,
+    ...(failureStatus ? [statusDecoration(failureStatus, null)] : []),
+  ];
   return makeTitle({ segments, decorations });
 }
 
@@ -1578,6 +1622,7 @@ export function buildTimelineActivityIntentTitles(
 
   let lastEmittedKey: string | null = null;
   const titles: TimelineActivityIntentTitle[] = [];
+  const badges = badgeDecorations(row);
   const failureStatus =
     row.status === "error"
       ? "error"
@@ -1600,6 +1645,7 @@ export function buildTimelineActivityIntentTitles(
       title: mapTimelineActivityIntentTitle({
         intent,
         pending: row.status === "pending",
+        badges: titles.length === 0 ? badges : [],
         ...(failureStatus ? { failureStatus } : {}),
       }),
     });

--- a/packages/thread-view/test/timeline-row-title.test.ts
+++ b/packages/thread-view/test/timeline-row-title.test.ts
@@ -157,6 +157,14 @@ function searchIntent(query: string, path: string): TimelineActivityIntent {
   };
 }
 
+function listFilesIntent(path: string): TimelineActivityIntent {
+  return {
+    type: "list_files",
+    command: `ls ${path}`,
+    path,
+  };
+}
+
 function deletedFileRow(): TimelineFileChangeWorkRow {
   return {
     ...baseRow("file-1"),
@@ -1633,6 +1641,42 @@ describe("buildTimelineRowTitle", () => {
     expect(titles[0]?.title.decorations).toEqual([
       { kind: "status", status: "error", durationMs: null, emphasis: false },
     ]);
+  });
+
+  it("carries a presentation badge onto command and exploration titles", () => {
+    const badge = {
+      glyph: "SquareUnlock02",
+      label: "sandbox off",
+      hint: "Ran outside of sandbox",
+      tone: "destructive",
+    } as const;
+    const presentation = {
+      label: { pending: "Running command", completed: "Ran command" },
+      icon: { glyph: "Terminal" },
+      badge,
+    };
+    const badgeDecoration = {
+      kind: "badge",
+      glyph: "SquareUnlock02",
+      label: "sandbox off",
+      hint: "Ran outside of sandbox",
+      tone: "destructive",
+    };
+
+    const plainCommand = buildTimelineRowTitle(
+      { ...commandRow(), presentation } satisfies TimelineCommandWorkRow,
+      DEFAULT_OPTIONS,
+    );
+    expect(plainCommand.decorations[0]).toEqual(badgeDecoration);
+    expect(plainCommand.plain).toContain("(sandbox off)");
+
+    const explorationTitles = buildTimelineActivityIntentTitles({
+      ...commandRow(),
+      presentation,
+      activityIntents: [searchIntent("TODO", "src"), listFilesIntent("test")],
+    } satisfies TimelineCommandWorkRow);
+    expect(explorationTitles[0]?.title.decorations).toEqual([badgeDecoration]);
+    expect(explorationTitles[1]?.title.decorations).toEqual([]);
   });
 
   it("appends an (interrupted) decoration to compact exploration intents on interrupted rows", () => {

--- a/packages/thread-view/test/timeline-test-harness.ts
+++ b/packages/thread-view/test/timeline-test-harness.ts
@@ -196,6 +196,7 @@ interface CommandCompletedArgs extends ProviderTurnEventOptions {
   cwd?: string;
   exitCode?: number;
   itemId?: string;
+  presentation?: ThreadEventItemPresentation;
   status?: "pending" | "completed" | "failed" | "interrupted";
 }
 
@@ -676,6 +677,7 @@ export function createTimelineEventFactory(
             exitCode: args.exitCode,
             status: args.status ?? "completed",
             approvalStatus: args.approvalStatus ?? null,
+            ...(args.presentation ? { presentation: args.presentation } : {}),
           },
         },
       };
@@ -709,6 +711,7 @@ export function createTimelineEventFactory(
             exitCode: args.exitCode,
             status: args.status ?? "pending",
             approvalStatus: args.approvalStatus ?? null,
+            ...(args.presentation ? { presentation: args.presentation } : {}),
           },
         },
       };

--- a/packages/thread-view/test/v3-item-projection.test.ts
+++ b/packages/thread-view/test/v3-item-projection.test.ts
@@ -86,6 +86,18 @@ const ECHO_PRESENTATION: ThreadEventItemPresentation = {
   tint: { light: "#1d4ed8", dark: "#93c5fd" },
 };
 
+const SANDBOX_ESCAPED_COMMAND_PRESENTATION: ThreadEventItemPresentation = {
+  label: { pending: "Running command", completed: "Ran command" },
+  icon: { glyph: "Terminal" },
+  title: "ls -la ~/.claude/ide",
+  badge: {
+    glyph: "SquareUnlock02",
+    label: "sandbox off",
+    hint: "Ran outside of sandbox",
+    tone: "destructive",
+  },
+};
+
 const PLAN_PRESENTATION: ThreadEventItemPresentation = {
   label: { pending: "Updating plan", completed: "Updated plan" },
   icon: { glyph: "ListTodo" },
@@ -256,6 +268,35 @@ describe("v3 item projection", () => {
     expect(
       buildTimelineActivityIntentTitles(read).map((title) => title.title.plain),
     ).toEqual(["Read src/index.ts"]);
+  });
+
+  it("carries a command item's presentation through projection into its title", () => {
+    const event = createTimelineEventFactory({ threadId: "thread-1" });
+    const rendered = renderTimelineFixture({
+      events: [
+        event.turnStarted({ turnId: "turn-1", createdAt: 0 }),
+        event.commandStarted({
+          turnId: "turn-1",
+          itemId: "cmd-1",
+          command: "ls -la ~/.claude/ide",
+          presentation: SANDBOX_ESCAPED_COMMAND_PRESENTATION,
+          createdAt: 1_000,
+        }),
+        event.commandCompleted({
+          turnId: "turn-1",
+          itemId: "cmd-1",
+          command: "ls -la ~/.claude/ide",
+          presentation: SANDBOX_ESCAPED_COMMAND_PRESENTATION,
+          exitCode: 0,
+          createdAt: 2_000,
+        }),
+      ],
+      projectionOptions: { threadStatus: "idle", turnMessageDetail: "full" },
+    });
+
+    const row = workRow(rendered.rows, "command", "cmd-1");
+    expect(row.presentation).toEqual(SANDBOX_ESCAPED_COMMAND_PRESENTATION);
+    expect(plainTitle(row)).toContain("(sandbox off)");
   });
 
   it("groups v3 exploration rows into one exploration bundle like legacy reads", () => {

--- a/plugins/provider-claude-code/src/bridge/bridge.ts
+++ b/plugins/provider-claude-code/src/bridge/bridge.ts
@@ -1073,6 +1073,7 @@ function createThreadSession(attachment: ThreadAttachment): ThreadSession {
 
   const translator = createClaudeDeltaTranslator({
     cwd: attachment.sessionConstructionConfig.sessionOptions.cwd,
+    sandboxEnabled: attachment.sessionOptions.sandbox?.enabled === true,
   });
   translator.configureInjectedTools(
     (attachment.sessionConstructionConfig.dynamicTools ?? []).map((tool) => ({

--- a/plugins/provider-claude-code/src/delta-test-harness.ts
+++ b/plugins/provider-claude-code/src/delta-test-harness.ts
@@ -117,8 +117,13 @@ interface ClaudeDeltaHarness {
   itemId(providerItemId: string, threadId?: string): string;
 }
 
-export function createClaudeDeltaHarness(): ClaudeDeltaHarness {
-  const translator = createClaudeDeltaTranslator({ cwd: "/workspace" });
+export function createClaudeDeltaHarness(
+  options: { sandboxEnabled?: boolean } = {},
+): ClaudeDeltaHarness {
+  const translator = createClaudeDeltaTranslator({
+    cwd: "/workspace",
+    sandboxEnabled: options.sandboxEnabled ?? false,
+  });
   const assembler = createDeltaAssembler({
     providerId: "claude-code",
     entropyPrefix: CLAUDE_TEST_ENTROPY,

--- a/plugins/provider-claude-code/src/delta-translation.ts
+++ b/plugins/provider-claude-code/src/delta-translation.ts
@@ -417,12 +417,14 @@ function createThreadState(): ClaudeThreadDialectState {
 
 export interface ClaudeDeltaTranslatorOptions {
   cwd?: string | undefined;
+  sandboxEnabled: boolean;
 }
 
 export function createClaudeDeltaTranslator(
-  options: ClaudeDeltaTranslatorOptions = {},
+  options: ClaudeDeltaTranslatorOptions,
 ) {
   const sessionCwd = options.cwd;
+  const sandboxEnabled = options.sandboxEnabled;
   const statesByThreadId = new Map<string, ClaudeThreadDialectState>();
   let injectedToolsByName = new Map<string, ClaudeInjectedTool>();
 
@@ -873,6 +875,7 @@ export function createClaudeDeltaTranslator(
         toolUseId: toolUse.id,
         input: toolUse.input,
         injectedTools: injectedToolsByName,
+        sandboxEnabled,
       });
       state.startedTools.set(toolUse.id, classified);
       deltas.push({

--- a/plugins/provider-claude-code/src/presentation.test.ts
+++ b/plugins/provider-claude-code/src/presentation.test.ts
@@ -281,7 +281,7 @@ describe("claude item presentation", () => {
   });
 
   it("emits a bb-injected tool call as server:bb with the definition's presentation", () => {
-    const translator = createClaudeDeltaTranslator();
+    const translator = createClaudeDeltaTranslator({ sandboxEnabled: false });
     translator.configureInjectedTools([
       {
         name: "bb_workflow_result",
@@ -492,6 +492,67 @@ describe("claude item presentation", () => {
     });
   });
 
+  it("badges a Bash call that opts out of the session sandbox", () => {
+    const harness = createClaudeDeltaHarness({ sandboxEnabled: true });
+    const events = harness.translate({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "b-1",
+            name: "Bash",
+            input: {
+              command: "ls -la ~/.claude/ide",
+              dangerouslyDisableSandbox: true,
+            },
+          },
+          {
+            type: "tool_use",
+            id: "b-2",
+            name: "Bash",
+            input: { command: "ls -la ~/.claude/ide" },
+          },
+        ],
+      },
+      session_id: "sess-1",
+    });
+    const started = startedItems(events);
+    expect(presentationOf(started[0])).toEqual({
+      label: { pending: "Running command", completed: "Ran command" },
+      icon: { glyph: "Terminal" },
+      title: "ls -la ~/.claude/ide",
+      badge: {
+        glyph: "SquareUnlock02",
+        label: "sandbox off",
+        hint: "Ran outside of sandbox",
+        tone: "destructive",
+      },
+    });
+    expect(presentationOf(started[1])).not.toHaveProperty("badge");
+  });
+
+  it("omits the sandbox badge when the session never enabled the sandbox", () => {
+    const harness = createClaudeDeltaHarness({ sandboxEnabled: false });
+    const events = harness.translate({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "b-1",
+            name: "Bash",
+            input: { command: "ls", dangerouslyDisableSandbox: true },
+          },
+        ],
+      },
+      session_id: "sess-1",
+    });
+    expect(presentationOf(startedItems(events)[0])).not.toHaveProperty("badge");
+  });
+
   it("presents a close without an open from the tool name alone", () => {
     const harness = createClaudeDeltaHarness();
     harness.translate({
@@ -527,7 +588,7 @@ describe("claude item presentation", () => {
   });
 
   it("attaches a presentation to every item.open and item.close delta", () => {
-    const translator = createClaudeDeltaTranslator();
+    const translator = createClaudeDeltaTranslator({ sandboxEnabled: false });
     const context = { threadId: "t" };
     const deltas = [
       ...translator.translate(

--- a/plugins/provider-claude-code/src/presentation.ts
+++ b/plugins/provider-claude-code/src/presentation.ts
@@ -7,11 +7,19 @@ import {
   experimental_withTitle as withTitle,
 } from "@get-bb/plugin-sdk/provider-bridge";
 
+const SANDBOX_ESCAPED_BADGE = {
+  glyph: "SquareUnlock02",
+  label: "sandbox off",
+  hint: "Ran outside of sandbox",
+  tone: "destructive",
+} as const;
+
 export function commandPresentation(args: {
   command: string;
   background: boolean;
+  sandboxEscaped: boolean;
 }): DeltaPresentation {
-  return withTitle(
+  const presentation = withTitle(
     {
       label: args.background
         ? {
@@ -23,6 +31,9 @@ export function commandPresentation(args: {
     },
     presentationTitle(args.command),
   );
+  return args.sandboxEscaped
+    ? { ...presentation, badge: SANDBOX_ESCAPED_BADGE }
+    : presentation;
 }
 
 export type ClaudeFileChangeVerb = "edit" | "write" | "notebook";

--- a/plugins/provider-claude-code/src/tool-classification.ts
+++ b/plugins/provider-claude-code/src/tool-classification.ts
@@ -46,6 +46,10 @@ const claudeBackgroundFlagSchema = z
   .object({ run_in_background: z.boolean().optional() })
   .passthrough();
 
+const claudeSandboxOverrideFlagSchema = z
+  .object({ dangerouslyDisableSandbox: z.boolean().optional() })
+  .passthrough();
+
 const claudeReadArgsSchema = z
   .object({ file_path: z.string().optional(), path: z.string().optional() })
   .passthrough();
@@ -100,6 +104,7 @@ interface ClaudeBashCommand {
   command: string;
   cwd: string | null;
   background: boolean;
+  sandboxOverridden: boolean;
 }
 
 export function parseClaudeBashCommand(
@@ -114,11 +119,15 @@ export function parseClaudeBashCommand(
     return null;
   }
   const background = claudeBackgroundFlagSchema.safeParse(input);
+  const sandboxOverride = claudeSandboxOverrideFlagSchema.safeParse(input);
   return {
     command,
     cwd: toOptionalString(parsed.data.cwd) ?? null,
     background:
       background.success && background.data.run_in_background === true,
+    sandboxOverridden:
+      sandboxOverride.success &&
+      sandboxOverride.data.dangerouslyDisableSandbox === true,
   };
 }
 
@@ -338,8 +347,9 @@ export function classifyClaudeToolUse(args: {
   toolUseId: string;
   input: unknown;
   injectedTools: ReadonlyMap<string, ClaudeInjectedTool>;
+  sandboxEnabled: boolean;
 }): ClaudeClassifiedTool {
-  const { toolName, toolUseId, input } = args;
+  const { toolName, toolUseId, input, sandboxEnabled } = args;
   switch (toolName) {
     case "Bash": {
       const command = parseClaudeBashCommand(input);
@@ -350,7 +360,10 @@ export function classifyClaudeToolUse(args: {
               command: command.command,
               cwd: command.cwd ?? "",
             },
-            presentation: commandPresentation(command),
+            presentation: commandPresentation({
+              ...command,
+              sandboxEscaped: sandboxEnabled && command.sandboxOverridden,
+            }),
           }
         : genericTool(toolName, input);
     }
@@ -460,7 +473,11 @@ export function classifyClaudeToolResultFallback(
     }
     return {
       shape: { type: "command", command: "", cwd: sessionCwd },
-      presentation: commandPresentation({ command: "", background: false }),
+      presentation: commandPresentation({
+        command: "",
+        background: false,
+        sandboxEscaped: false,
+      }),
     };
   }
   if (


### PR DESCRIPTION
## Human comments

Adds a red "unlocked" badge next to claude code terminal commands that run outside of sandbox:
<img width="716" height="504" alt="Screenshot 2026-09-03 at 5 14 35 PM" src="https://github.com/user-attachments/assets/6b3b229b-59a1-4e7b-97f7-5ee21e808d86" />


## What was wrong

Claude Code's Bash tool accepts a `dangerouslyDisableSandbox` flag, and bb turns the SDK sandbox on itself for workspace-scoped `acceptEdits`/`auto` sessions (`buildWorkspaceWriteSandbox`). The timeline rendered a command that ran sandboxed and one that deliberately escaped identically, so the security-relevant call was indistinguishable from its neighbours. `parseClaudeBashCommand` read `run_in_background` off the tool input and dropped the sandbox flag next to it, so the signal never left the provider bridge.

While verifying the fix in the dev app I found a second, pre-existing bug: the `commandExecution` branch of `parseExecLifecycleEvent` never copied `item.presentation` onto the projected call, unlike the delegation (`exec-lifecycle.ts:222`) and tool-call (`:294`) branches. Every command row reached the UI with `presentation: undefined`. Nothing had consumed it before — `mapExecutionTitle` skips the presentation path for commands — so the badge was persisted correctly on the event and then silently dropped in projection.

## What changed

**Sandbox signal (`plugins/provider-claude-code`)** — `parseClaudeBashCommand` parses `dangerouslyDisableSandbox` alongside `run_in_background`; `createClaudeDeltaTranslator` takes a required `sandboxEnabled`, fed from `sessionOptions.sandbox?.enabled` in the bridge, so `classifyClaudeToolUse` can distinguish "opted out of an active sandbox" from "session never had one". Only the former gets a badge.

**Contract (`packages/domain/src/item-presentation.ts`)** — presentation grows an optional `badge`: `glyph`, a compact `label`, a `hint` for hover/screen-reader text, and `tone`. Available to any provider bridge, not just this one.

**Rendering (`packages/thread-view`, `apps/app`)** — a new `badge` title decoration derived from the row presentation, added in the command-title path, the single-exploration-intent path, and the compact multi-intent path (first line only, so a compound command doesn't repeat it). The app renders it as a destructive-toned icon with `title`/`aria-label` set to the hint; the CLI gets `(sandbox off)` for free through `title.plain`. Bash-driven `grep`/`ls` rows are command rows with parsed intents, so terminal, search, and list rows are all covered by one change.

**Projection fix (`packages/thread-view/src/exec-lifecycle.ts`)** — one line copying `item.presentation` onto command calls, mirroring the sibling branches.

**Wire change: `HOST_DAEMON_PROTOCOL_VERSION` 173 → 174.** The bridge artifact is served by the server, so a new bridge can run under an old daemon. That daemon parses each `thread/delta` with its own compiled copy of the schema (`bridge-protocol-adapter.ts:513`), and since presentation is a non-strict `z.object` it strips unknown keys rather than rejecting — verified: an old shape accepts the new payload and `badge` comes back `null`. Without the bump the badge would be silently swallowed before the event is persisted, with no error anywhere.

No CLI command, flag, or config knob changed. Mobile renders none of the title decorations, so the badge is web/CLI only — the same gap `docs/api_to_audit.md:1435` already tracks for the presentation base.

## How you verified

Tests added:

- `plugins/provider-claude-code/src/presentation.test.ts` — badge present/absent across the three input × session-sandbox combinations.
- `packages/thread-view/test/timeline-row-title.test.ts` — the decoration reaches both title paths, and only the first compact intent line.
- `packages/thread-view/test/v3-item-projection.test.ts` — a `commandExecution` item with a badge presentation driven through the real projection, asserting both `row.presentation` and `(sandbox off)` in the rendered title. Confirmed this fails with the `exec-lifecycle.ts` fix reverted and passes with it.
- `apps/app/.../ThreadTimelineRows.presentation.test.tsx` — the icon renders on both a command row and a search row, with the hint on `title` and `aria-label`, and not on an unbadged row.

Commands run:

- `pnpm exec turbo run typecheck` — 80/80 packages pass.
- `pnpm exec turbo run test --filter=@bb/thread-view --filter=bb-plugin-provider-claude-code --force` — 370 and 337 tests pass.
- `pnpm exec turbo run test --filter=@bb/app --force` — 3507 pass, 3 skipped.
- `oxfmt --check` clean on all 16 changed files.

Manual check in the dev desktop app: ran the same command with and without the sandbox, confirmed via the dev SQLite DB that the badge is persisted on the escaped call only.

> AGENT GENERATED
