### PR TITLE
Fix OAuth popups in the desktop browser

### DIFF
--- a/apps/desktop/src/desktop-browser-policy.ts
+++ b/apps/desktop/src/desktop-browser-policy.ts
@@ -8,14 +8,6 @@ export function isAllowedBrowserUrl(url: string): boolean {
   return parsed.protocol === "http:" || parsed.protocol === "https:";
 }
 
-interface WindowOpenDecision {
-  openTabUrl: string | null;
-}
-
-export function resolveWindowOpenAction(url: string): WindowOpenDecision {
-  return { openTabUrl: isAllowedBrowserUrl(url) ? url : null };
-}
-
 interface PopupRateDecision {
   allowed: boolean;
   timestamps: number[];

--- a/apps/desktop/src/desktop-browser-view.ts
+++ b/apps/desktop/src/desktop-browser-view.ts
@@ -1,4 +1,13 @@
-import { Menu, WebContentsView, session, type Session } from "electron";
+import {
+  BrowserWindow,
+  Menu,
+  WebContentsView,
+  session,
+  type BrowserWindowConstructorOptions,
+  type Session,
+  type WebContents,
+  type WebPreferences,
+} from "electron";
 import {
   BB_DESKTOP_BROWSER_MAX_TITLE_LENGTH,
   BB_DESKTOP_BROWSER_MAX_URL_LENGTH,
@@ -35,6 +44,14 @@ import {
 
 const POPUP_RATE_WINDOW_MS = 10_000;
 const POPUP_RATE_MAX_IN_WINDOW = 3;
+const POPUP_MAX_OPEN_PER_TAB = 3;
+const POPUP_MAX_OPEN_GLOBAL = 8;
+const POPUP_DEFAULT_WIDTH = 520;
+const POPUP_DEFAULT_HEIGHT = 700;
+const POPUP_MIN_WIDTH = 320;
+const POPUP_MIN_HEIGHT = 240;
+const POPUP_MAX_WIDTH = 960;
+const POPUP_MAX_HEIGHT = 900;
 
 const RESIZE_SNAPSHOT_HIDE_CAP_MS = 80;
 const RESIZE_SNAPSHOT_JPEG_QUALITY = 70;
@@ -43,6 +60,84 @@ const RENDERER_RECOVERY_MAX_ATTEMPTS = 2;
 
 function truncate(value: string, max: number): string {
   return value.length > max ? value.slice(0, max) : value;
+}
+
+function clampPopupDimension(
+  value: number | undefined,
+  fallback: number,
+  min: number,
+  max: number,
+): number {
+  if (value === undefined || !Number.isFinite(value)) {
+    return fallback;
+  }
+  return Math.min(max, Math.max(min, Math.round(value)));
+}
+
+function hasPopupWindowFeatures(features: string): boolean {
+  const nonPopupFeatures = new Set([
+    "attributionsrc",
+    "noopener",
+    "noreferrer",
+  ]);
+  return features
+    .split(/[,\s]+/)
+    .map((feature) => feature.split("=", 1)[0]?.trim().toLowerCase())
+    .some(
+      (feature) =>
+        feature !== undefined &&
+        feature.length > 0 &&
+        !nonPopupFeatures.has(feature),
+    );
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  return (
+    hostname === "localhost" ||
+    hostname.endsWith(".localhost") ||
+    hostname === "[::1]" ||
+    /^127(?:\.\d{1,3}){3}$/.test(hostname)
+  );
+}
+
+function isAllowedPopupNavigationUrl(url: string): boolean {
+  if (url === "about:blank") {
+    return true;
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+  return (
+    parsed.protocol === "https:" ||
+    (parsed.protocol === "http:" && isLoopbackHostname(parsed.hostname))
+  );
+}
+
+function popupWindowTitle(url: string | null): string {
+  if (url === null || url === "about:blank" || url.length === 0) {
+    return "bb browser popup";
+  }
+  try {
+    return `bb browser — ${new URL(url).origin}`;
+  } catch {
+    return "bb browser popup";
+  }
+}
+
+function isPopupWebContents(value: unknown): value is WebContents {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "id" in value &&
+    typeof value.id === "number" &&
+    "isDestroyed" in value &&
+    typeof value.isDestroyed === "function" &&
+    "on" in value &&
+    typeof value.on === "function"
+  );
 }
 
 const BB_BROWSER_PARTITION = "persist:bb-browser";
@@ -54,6 +149,7 @@ interface BrowserViewEntry {
   lastErrorText: string | null;
   desiredBounds: BbDesktopBrowserViewBounds;
   popupTimestamps: number[];
+  popupWindows: Set<BrowserWindow>;
   rendererRecoveryAttempts: number;
   rendererRecoveryState: "healthy" | "pending" | "blocked";
   rendererRecoveryTimer: ReturnType<typeof setTimeout> | null;
@@ -242,6 +338,7 @@ export function createDesktopBrowserViewManager(
   const partition = args.partition ?? BB_BROWSER_PARTITION;
   const entries = new Map<string, BrowserViewEntry>();
   const entriesByWebContentsId = new Map<number, BrowserViewEntry>();
+  const popupWindows = new Set<BrowserWindow>();
   const resizingHostIds = new Set<number>();
   let hardenedSession: Session | null = null;
 
@@ -374,6 +471,104 @@ export function createDesktopBrowserViewManager(
     );
   }
 
+  function hardenedPopupWebPreferences(
+    webPreferences: WebPreferences | undefined,
+  ): WebPreferences {
+    const inheritedPreferences = { ...webPreferences };
+    delete inheritedPreferences.preload;
+    return {
+      ...inheritedPreferences,
+      allowRunningInsecureContent: false,
+      contextIsolation: true,
+      javascript: true,
+      nodeIntegration: false,
+      nodeIntegrationInSubFrames: false,
+      nodeIntegrationInWorker: false,
+      partition,
+      sandbox: true,
+      webSecurity: true,
+      webviewTag: false,
+      zoomFactor: 1,
+    };
+  }
+
+  function createHardenedPopupWindow(
+    options: BrowserWindowConstructorOptions,
+    entry: BrowserViewEntry,
+  ): WebContents {
+    const width = clampPopupDimension(
+      options.width,
+      POPUP_DEFAULT_WIDTH,
+      POPUP_MIN_WIDTH,
+      POPUP_MAX_WIDTH,
+    );
+    const height = clampPopupDimension(
+      options.height,
+      POPUP_DEFAULT_HEIGHT,
+      POPUP_MIN_HEIGHT,
+      POPUP_MAX_HEIGHT,
+    );
+    const safeOptions: BrowserWindowConstructorOptions = {
+      center: true,
+      frame: true,
+      height,
+      show: true,
+      transparent: false,
+      webPreferences: hardenedPopupWebPreferences(options.webPreferences),
+      width,
+    };
+    const childWebContents: unknown = Reflect.get(options, "webContents");
+    if (childWebContents !== undefined) {
+      if (!isPopupWebContents(childWebContents)) {
+        throw new Error("Invalid popup webContents");
+      }
+      Reflect.set(safeOptions, "webContents", childWebContents);
+    }
+    const popupWindow = new BrowserWindow(safeOptions);
+    popupWindows.add(popupWindow);
+    entry.popupWindows.add(popupWindow);
+    popupWindow.once("closed", () => {
+      popupWindows.delete(popupWindow);
+      entry.popupWindows.delete(popupWindow);
+    });
+    const popupContents = popupWindow.webContents;
+    const updatePopupTitle = (url: string | null): void => {
+      if (!popupWindow.isDestroyed()) {
+        popupWindow.setTitle(popupWindowTitle(url));
+      }
+    };
+    updatePopupTitle(popupContents.getURL());
+    popupContents.on("will-frame-navigate", (event) => {
+      if (event.isMainFrame && !isAllowedPopupNavigationUrl(event.url)) {
+        event.preventDefault();
+      }
+    });
+    popupContents.on("will-navigate", (event, url) => {
+      if (!isAllowedPopupNavigationUrl(url)) {
+        event.preventDefault();
+      }
+    });
+    popupContents.on("will-redirect", (event, url, _isInPlace, isMainFrame) => {
+      if (isMainFrame && !isAllowedPopupNavigationUrl(url)) {
+        event.preventDefault();
+      }
+    });
+    popupContents.on("did-navigate", (_event, url) => {
+      updatePopupTitle(url);
+    });
+    popupContents.on("did-navigate-in-page", (_event, url, isMainFrame) => {
+      if (isMainFrame) {
+        updatePopupTitle(url);
+      }
+    });
+    popupContents.on("page-title-updated", (event) => {
+      event.preventDefault();
+      updatePopupTitle(popupContents.getURL());
+    });
+    popupContents.setWindowOpenHandler(() => ({ action: "deny" }));
+    return popupContents;
+  }
+
   function wireWebContents(
     hostWindow: DesktopBrowserHostWindow,
     tabId: string,
@@ -435,25 +630,52 @@ export function createDesktopBrowserViewManager(
     });
 
     webContents.setWindowOpenHandler((details) => {
+      const opensNamedPopup =
+        hasPopupWindowFeatures(details.features) ||
+        (details.frameName.length > 0 && details.frameName !== "_blank");
       const { openTabUrl } = resolveWindowOpenAction(details.url);
-      if (openTabUrl !== null) {
-        const decision = evaluatePopupRate({
-          timestamps: entry.popupTimestamps,
-          now: Date.now(),
-          windowMs: POPUP_RATE_WINDOW_MS,
-          maxInWindow: POPUP_RATE_MAX_IN_WINDOW,
-        });
-        entry.popupTimestamps = decision.timestamps;
-        if (decision.allowed) {
-          send(hostWindow, BB_DESKTOP_BROWSER_OPEN_TAB_CHANNEL, {
-            url: openTabUrl,
-          });
-          send(hostWindow, BB_DESKTOP_BROWSER_SCOPED_OPEN_TAB_CHANNEL, {
-            tabId,
-            url: openTabUrl,
-          });
-        }
+      const opensAllowedNativePopup =
+        opensNamedPopup && isAllowedPopupNavigationUrl(details.url);
+      if (openTabUrl === null && !opensAllowedNativePopup) {
+        return { action: "deny" };
       }
+      if (
+        opensAllowedNativePopup &&
+        (entry.popupWindows.size >= POPUP_MAX_OPEN_PER_TAB ||
+          popupWindows.size >= POPUP_MAX_OPEN_GLOBAL)
+      ) {
+        return { action: "deny" };
+      }
+      const decision = evaluatePopupRate({
+        timestamps: entry.popupTimestamps,
+        now: Date.now(),
+        windowMs: POPUP_RATE_WINDOW_MS,
+        maxInWindow: POPUP_RATE_MAX_IN_WINDOW,
+      });
+      entry.popupTimestamps = decision.timestamps;
+      if (!decision.allowed) {
+        return { action: "deny" };
+      }
+      if (opensAllowedNativePopup) {
+        return {
+          action: "allow",
+          createWindow: (options) => createHardenedPopupWindow(options, entry),
+          overrideBrowserWindowOptions: {
+            show: true,
+            webPreferences: hardenedPopupWebPreferences(undefined),
+          },
+        };
+      }
+      if (openTabUrl === null) {
+        return { action: "deny" };
+      }
+      send(hostWindow, BB_DESKTOP_BROWSER_OPEN_TAB_CHANNEL, {
+        url: openTabUrl,
+      });
+      send(hostWindow, BB_DESKTOP_BROWSER_SCOPED_OPEN_TAB_CHANNEL, {
+        tabId,
+        url: openTabUrl,
+      });
       return { action: "deny" };
     });
 
@@ -570,6 +792,7 @@ export function createDesktopBrowserViewManager(
       lastErrorText: null,
       desiredBounds: args.desiredBounds,
       popupTimestamps: [],
+      popupWindows: new Set(),
       rendererRecoveryAttempts: 0,
       rendererRecoveryState: "healthy",
       rendererRecoveryTimer: null,
@@ -827,6 +1050,12 @@ export function createDesktopBrowserViewManager(
         entries.delete(key);
         entriesByWebContentsId.delete(entry.view.webContents.id);
         clearEntryRendererRecoveryTimer(entry);
+        for (const popupWindow of [...entry.popupWindows]) {
+          if (!popupWindow.isDestroyed()) {
+            popupWindow.destroy();
+          }
+        }
+        entry.popupWindows.clear();
         if (!entry.view.webContents.isDestroyed()) {
           entry.view.webContents.close();
         }
@@ -834,6 +1063,12 @@ export function createDesktopBrowserViewManager(
     },
     destroyAll() {
       resizingHostIds.clear();
+      for (const popupWindow of [...popupWindows]) {
+        if (!popupWindow.isDestroyed()) {
+          popupWindow.destroy();
+        }
+      }
+      popupWindows.clear();
       for (const [key, entry] of [...entries.entries()]) {
         entries.delete(key);
         entriesByWebContentsId.delete(entry.view.webContents.id);

--- a/apps/desktop/src/desktop-browser-view.ts
+++ b/apps/desktop/src/desktop-browser-view.ts
@@ -39,7 +39,6 @@ import {
 import {
   evaluatePopupRate,
   isAllowedBrowserUrl,
-  resolveWindowOpenAction,
 } from "./desktop-browser-policy.js";
 
 const POPUP_RATE_WINDOW_MS = 10_000;
@@ -72,23 +71,6 @@ function clampPopupDimension(
     return fallback;
   }
   return Math.min(max, Math.max(min, Math.round(value)));
-}
-
-function hasPopupWindowFeatures(features: string): boolean {
-  const nonPopupFeatures = new Set([
-    "attributionsrc",
-    "noopener",
-    "noreferrer",
-  ]);
-  return features
-    .split(/[,\s]+/)
-    .map((feature) => feature.split("=", 1)[0]?.trim().toLowerCase())
-    .some(
-      (feature) =>
-        feature !== undefined &&
-        feature.length > 0 &&
-        !nonPopupFeatures.has(feature),
-    );
 }
 
 function isLoopbackHostname(hostname: string): boolean {
@@ -127,17 +109,24 @@ function popupWindowTitle(url: string | null): string {
   }
 }
 
-function isPopupWebContents(value: unknown): value is WebContents {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "id" in value &&
-    typeof value.id === "number" &&
-    "isDestroyed" in value &&
-    typeof value.isDestroyed === "function" &&
-    "on" in value &&
-    typeof value.on === "function"
-  );
+type PopupCreateWindowOptions = BrowserWindowConstructorOptions & {
+  webContents?: WebContents;
+};
+
+function guardMainFrameNavigation(
+  webContents: WebContents,
+  isAllowedUrl: (url: string) => boolean,
+): void {
+  webContents.on("will-frame-navigate", (event) => {
+    if (event.isMainFrame && !isAllowedUrl(event.url)) {
+      event.preventDefault();
+    }
+  });
+  webContents.on("will-redirect", (event, url, _isInPlace, isMainFrame) => {
+    if (isMainFrame && !isAllowedUrl(url)) {
+      event.preventDefault();
+    }
+  });
 }
 
 const BB_BROWSER_PARTITION = "persist:bb-browser";
@@ -471,60 +460,41 @@ export function createDesktopBrowserViewManager(
     );
   }
 
-  function hardenedPopupWebPreferences(
-    webPreferences: WebPreferences | undefined,
-  ): WebPreferences {
-    const inheritedPreferences = { ...webPreferences };
-    delete inheritedPreferences.preload;
-    return {
-      ...inheritedPreferences,
-      allowRunningInsecureContent: false,
-      contextIsolation: true,
-      javascript: true,
-      nodeIntegration: false,
-      nodeIntegrationInSubFrames: false,
-      nodeIntegrationInWorker: false,
-      partition,
-      sandbox: true,
-      webSecurity: true,
-      webviewTag: false,
-      zoomFactor: 1,
-    };
-  }
+  const hardenedWebPreferences: WebPreferences = {
+    partition,
+    sandbox: true,
+    contextIsolation: true,
+    nodeIntegration: false,
+    webSecurity: true,
+    allowRunningInsecureContent: false,
+  };
 
-  function createHardenedPopupWindow(
-    options: BrowserWindowConstructorOptions,
+  function createPopupWindow(
+    options: PopupCreateWindowOptions,
+    url: string,
     entry: BrowserViewEntry,
   ): WebContents {
-    const width = clampPopupDimension(
-      options.width,
-      POPUP_DEFAULT_WIDTH,
-      POPUP_MIN_WIDTH,
-      POPUP_MAX_WIDTH,
-    );
-    const height = clampPopupDimension(
-      options.height,
-      POPUP_DEFAULT_HEIGHT,
-      POPUP_MIN_HEIGHT,
-      POPUP_MAX_HEIGHT,
-    );
-    const safeOptions: BrowserWindowConstructorOptions = {
+    const popupOptions: PopupCreateWindowOptions = {
       center: true,
       frame: true,
-      height,
+      height: clampPopupDimension(
+        options.height,
+        POPUP_DEFAULT_HEIGHT,
+        POPUP_MIN_HEIGHT,
+        POPUP_MAX_HEIGHT,
+      ),
       show: true,
       transparent: false,
-      webPreferences: hardenedPopupWebPreferences(options.webPreferences),
-      width,
+      webContents: options.webContents,
+      webPreferences: hardenedWebPreferences,
+      width: clampPopupDimension(
+        options.width,
+        POPUP_DEFAULT_WIDTH,
+        POPUP_MIN_WIDTH,
+        POPUP_MAX_WIDTH,
+      ),
     };
-    const childWebContents: unknown = Reflect.get(options, "webContents");
-    if (childWebContents !== undefined) {
-      if (!isPopupWebContents(childWebContents)) {
-        throw new Error("Invalid popup webContents");
-      }
-      Reflect.set(safeOptions, "webContents", childWebContents);
-    }
-    const popupWindow = new BrowserWindow(safeOptions);
+    const popupWindow = new BrowserWindow(popupOptions);
     popupWindows.add(popupWindow);
     entry.popupWindows.add(popupWindow);
     popupWindow.once("closed", () => {
@@ -532,40 +502,24 @@ export function createDesktopBrowserViewManager(
       entry.popupWindows.delete(popupWindow);
     });
     const popupContents = popupWindow.webContents;
-    const updatePopupTitle = (url: string | null): void => {
+    const updatePopupTitle = (currentUrl: string | null): void => {
       if (!popupWindow.isDestroyed()) {
-        popupWindow.setTitle(popupWindowTitle(url));
+        popupWindow.setTitle(popupWindowTitle(currentUrl));
       }
     };
     updatePopupTitle(popupContents.getURL());
-    popupContents.on("will-frame-navigate", (event) => {
-      if (event.isMainFrame && !isAllowedPopupNavigationUrl(event.url)) {
-        event.preventDefault();
-      }
-    });
-    popupContents.on("will-navigate", (event, url) => {
-      if (!isAllowedPopupNavigationUrl(url)) {
-        event.preventDefault();
-      }
-    });
-    popupContents.on("will-redirect", (event, url, _isInPlace, isMainFrame) => {
-      if (isMainFrame && !isAllowedPopupNavigationUrl(url)) {
-        event.preventDefault();
-      }
-    });
-    popupContents.on("did-navigate", (_event, url) => {
-      updatePopupTitle(url);
-    });
-    popupContents.on("did-navigate-in-page", (_event, url, isMainFrame) => {
-      if (isMainFrame) {
-        updatePopupTitle(url);
-      }
+    guardMainFrameNavigation(popupContents, isAllowedPopupNavigationUrl);
+    popupContents.on("did-navigate", (_event, currentUrl) => {
+      updatePopupTitle(currentUrl);
     });
     popupContents.on("page-title-updated", (event) => {
       event.preventDefault();
       updatePopupTitle(popupContents.getURL());
     });
     popupContents.setWindowOpenHandler(() => ({ action: "deny" }));
+    if (options.webContents === undefined) {
+      void popupWindow.loadURL(url);
+    }
     return popupContents;
   }
 
@@ -607,43 +561,18 @@ export function createDesktopBrowserViewManager(
       });
     });
 
-    webContents.on("will-frame-navigate", (event) => {
-      if (!event.isMainFrame) {
-        return;
-      }
-      if (!isAllowedBrowserUrl(event.url)) {
-        event.preventDefault();
-      }
-    });
-    webContents.on("will-navigate", (event, url) => {
-      if (!isAllowedBrowserUrl(url)) {
-        event.preventDefault();
-      }
-    });
-    webContents.on("will-redirect", (event, url, _isInPlace, isMainFrame) => {
-      if (!isMainFrame) {
-        return;
-      }
-      if (!isAllowedBrowserUrl(url)) {
-        event.preventDefault();
-      }
-    });
+    guardMainFrameNavigation(webContents, isAllowedBrowserUrl);
 
     webContents.setWindowOpenHandler((details) => {
-      const opensNamedPopup =
-        hasPopupWindowFeatures(details.features) ||
-        (details.frameName.length > 0 && details.frameName !== "_blank");
-      const { openTabUrl } = resolveWindowOpenAction(details.url);
-      const opensAllowedNativePopup =
-        opensNamedPopup && isAllowedPopupNavigationUrl(details.url);
-      if (openTabUrl === null && !opensAllowedNativePopup) {
-        return { action: "deny" };
-      }
-      if (
-        opensAllowedNativePopup &&
+      const opensPopup = details.disposition === "new-window";
+      const allowedUrl = opensPopup
+        ? isAllowedPopupNavigationUrl(details.url)
+        : isAllowedBrowserUrl(details.url);
+      const popupCapReached =
+        opensPopup &&
         (entry.popupWindows.size >= POPUP_MAX_OPEN_PER_TAB ||
-          popupWindows.size >= POPUP_MAX_OPEN_GLOBAL)
-      ) {
+          popupWindows.size >= POPUP_MAX_OPEN_GLOBAL);
+      if (!allowedUrl || popupCapReached) {
         return { action: "deny" };
       }
       const decision = evaluatePopupRate({
@@ -656,25 +585,19 @@ export function createDesktopBrowserViewManager(
       if (!decision.allowed) {
         return { action: "deny" };
       }
-      if (opensAllowedNativePopup) {
+      if (opensPopup) {
         return {
           action: "allow",
-          createWindow: (options) => createHardenedPopupWindow(options, entry),
-          overrideBrowserWindowOptions: {
-            show: true,
-            webPreferences: hardenedPopupWebPreferences(undefined),
-          },
+          createWindow: (options) =>
+            createPopupWindow(options, details.url, entry),
         };
       }
-      if (openTabUrl === null) {
-        return { action: "deny" };
-      }
       send(hostWindow, BB_DESKTOP_BROWSER_OPEN_TAB_CHANNEL, {
-        url: openTabUrl,
+        url: details.url,
       });
       send(hostWindow, BB_DESKTOP_BROWSER_SCOPED_OPEN_TAB_CHANNEL, {
         tabId,
-        url: openTabUrl,
+        url: details.url,
       });
       return { action: "deny" };
     });
@@ -778,14 +701,7 @@ export function createDesktopBrowserViewManager(
   function createEntry(args: CreateEntryArgs): BrowserViewEntry {
     ensureHardenedSession();
     const view = new WebContentsView({
-      webPreferences: {
-        partition,
-        sandbox: true,
-        contextIsolation: true,
-        nodeIntegration: false,
-        webSecurity: true,
-        allowRunningInsecureContent: false,
-      },
+      webPreferences: hardenedWebPreferences,
     });
     const entry: BrowserViewEntry = {
       view,

--- a/apps/desktop/test/desktop-browser-policy.test.ts
+++ b/apps/desktop/test/desktop-browser-policy.test.ts
@@ -8,7 +8,6 @@ import {
 import {
   evaluatePopupRate,
   isAllowedBrowserUrl,
-  resolveWindowOpenAction,
 } from "../src/desktop-browser-policy.js";
 
 describe("isAllowedBrowserUrl", () => {
@@ -24,36 +23,6 @@ describe("isAllowedBrowserUrl", () => {
     expect(isAllowedBrowserUrl("about:blank")).toBe(false);
     expect(isAllowedBrowserUrl("not a url")).toBe(false);
     expect(isAllowedBrowserUrl("")).toBe(false);
-  });
-});
-
-describe("resolveWindowOpenAction", () => {
-  it("surfaces an allowed http(s) popup URL as a new-tab request", () => {
-    expect(resolveWindowOpenAction("https://example.com")).toEqual({
-      openTabUrl: "https://example.com",
-    });
-  });
-
-  it("denies popups to disallowed schemes (no new tab)", () => {
-    expect(resolveWindowOpenAction("file:///etc/passwd")).toEqual({
-      openTabUrl: null,
-    });
-    expect(resolveWindowOpenAction("javascript:alert(1)")).toEqual({
-      openTabUrl: null,
-    });
-  });
-
-  it("surfaces loopback and LAN popups like any other http(s) URL", () => {
-    for (const url of [
-      "http://localhost:5173/",
-      "https://app.localhost/path",
-      "http://127.0.0.1:38886/",
-      "http://[::1]:5173/",
-      "http://192.168.1.1/",
-      "http://printer.local/",
-    ]) {
-      expect(resolveWindowOpenAction(url)).toEqual({ openTabUrl: url });
-    }
   });
 });
 

--- a/apps/desktop/test/desktop-browser-view-manager.test.ts
+++ b/apps/desktop/test/desktop-browser-view-manager.test.ts
@@ -41,11 +41,6 @@ type FakeVoidWebContentsListener = () => void;
 
 type FakeWillFrameNavigateListener = (event: FakeNavigationEvent) => void;
 
-type FakeWillNavigateListener = (
-  event: FakeNavigationEvent,
-  url: string,
-) => void;
-
 type FakeWillRedirectListener = (
   event: FakeNavigationEvent,
   url: string,
@@ -141,7 +136,6 @@ interface FakeWebContentsEventMap {
   focus: FakeVoidWebContentsListener;
   "before-input-event": FakeBeforeInputListener;
   "will-frame-navigate": FakeWillFrameNavigateListener;
-  "will-navigate": FakeWillNavigateListener;
   "will-redirect": FakeWillRedirectListener;
   "did-start-loading": FakeVoidWebContentsListener;
   "did-stop-loading": FakeVoidWebContentsListener;
@@ -178,6 +172,7 @@ type FakePermissionCheckHandler = (
 ) => boolean;
 
 interface FakeWindowOpenDetails {
+  disposition: "foreground-tab" | "new-window";
   features: string;
   frameName: string;
   url: string;
@@ -199,13 +194,9 @@ interface FakeBrowserWindowOptions {
     allowRunningInsecureContent?: boolean;
     contextIsolation?: boolean;
     nodeIntegration?: boolean;
-    nodeIntegrationInSubFrames?: boolean;
-    nodeIntegrationInWorker?: boolean;
     partition?: string;
-    preload?: string;
     sandbox?: boolean;
     webSecurity?: boolean;
-    webviewTag?: boolean;
   };
 }
 
@@ -219,7 +210,6 @@ interface FakePopupWebContents {
 interface FakeWindowOpenDecision {
   action: "allow" | "deny";
   createWindow?: (options: FakeBrowserWindowOptions) => FakePopupWebContents;
-  overrideBrowserWindowOptions?: FakeBrowserWindowOptions;
 }
 
 type FakeWindowOpenHandler = (
@@ -306,7 +296,6 @@ const electronMock = vi.hoisted(() => {
       focus: [],
       "before-input-event": [],
       "will-frame-navigate": [],
-      "will-navigate": [],
       "will-redirect": [],
       "did-start-loading": [],
       "did-stop-loading": [],
@@ -493,18 +482,6 @@ const electronMock = vi.hoisted(() => {
       return event.defaultPrevented;
     }
 
-    emitWillNavigate(url: string, initiatorOrigin?: string | null): boolean {
-      const event = new FakeNavigationEventImpl({
-        initiatorOrigin,
-        isMainFrame: true,
-        url,
-      });
-      for (const listener of this.listeners["will-navigate"]) {
-        listener(event, url);
-      }
-      return event.defaultPrevented;
-    }
-
     emitWillRedirect(
       url: string,
       isMainFrame: boolean,
@@ -529,6 +506,7 @@ const electronMock = vi.hoisted(() => {
         throw new Error("Expected a window open handler to be registered.");
       }
       return this.windowOpenHandler({
+        disposition: "foreground-tab",
         features: "",
         frameName: "",
         ...details,
@@ -563,6 +541,7 @@ const electronMock = vi.hoisted(() => {
     public readonly webContents: FakePopupWebContents;
     public closeCalls = 0;
     public destroyCalls = 0;
+    public readonly loadURLCalls: string[] = [];
     public readonly titleCalls: string[] = [];
     private closedListener: (() => void) | null = null;
     private destroyed = false;
@@ -589,6 +568,11 @@ const electronMock = vi.hoisted(() => {
 
     isDestroyed(): boolean {
       return this.destroyed;
+    }
+
+    loadURL(url: string): Promise<void> {
+      this.loadURLCalls.push(url);
+      return Promise.resolve();
     }
 
     once(_eventName: "closed", listener: () => void): void {
@@ -1114,8 +1098,8 @@ describe("DesktopBrowserViewManager", () => {
 
     expect(
       view.webContents.emitWindowOpen("https://example.com/docs", {
-        features:
-          "noopener,noreferrer,attributionsrc=https%3A%2F%2Fexample.com",
+        disposition: "foreground-tab",
+        features: "noopener,noreferrer",
         frameName: "_blank",
       }),
     ).toEqual({ action: "deny" });
@@ -1129,7 +1113,7 @@ describe("DesktopBrowserViewManager", () => {
     ]);
   });
 
-  it("opens named popup flows in a hardened native window", () => {
+  it("opens popup dispositions in a hardened native window", () => {
     const manager = createDesktopBrowserViewManager({
       partition: "persist:test",
     });
@@ -1148,6 +1132,7 @@ describe("DesktopBrowserViewManager", () => {
     const decision = view.webContents.emitWindowOpen(
       "https://accounts.google.com/o/oauth2/auth",
       {
+        disposition: "new-window",
         features: "width=520,height=700",
         frameName: "oauth",
       },
@@ -1156,28 +1141,12 @@ describe("DesktopBrowserViewManager", () => {
     expect(decision.action).toBe("allow");
     expect(openTabPushesOf(hostWindow)).toEqual([]);
     expect(scopedOpenTabPushesOf(hostWindow)).toEqual([]);
-    expect(decision.overrideBrowserWindowOptions).toEqual({
-      show: true,
-      webPreferences: {
-        allowRunningInsecureContent: false,
-        contextIsolation: true,
-        javascript: true,
-        nodeIntegration: false,
-        nodeIntegrationInSubFrames: false,
-        nodeIntegrationInWorker: false,
-        partition: "persist:test",
-        sandbox: true,
-        webSecurity: true,
-        webviewTag: false,
-        zoomFactor: 1,
-      },
-    });
     if (decision.createWindow === undefined) {
       throw new Error("Expected the popup decision to create a window.");
     }
 
     const childContents = electronMock.createFakeWebContents();
-    const options: FakeBrowserWindowOptions = {
+    const popupContents = decision.createWindow({
       alwaysOnTop: true,
       frame: false,
       height: 4_000,
@@ -1189,24 +1158,20 @@ describe("DesktopBrowserViewManager", () => {
       x: 0,
       y: 0,
       webPreferences: {
-        allowRunningInsecureContent: true,
         contextIsolation: false,
         nodeIntegration: true,
         partition: "persist:untrusted",
-        preload: "/tmp/untrusted-preload.cjs",
         sandbox: false,
         webSecurity: false,
       },
-    };
-    const popupContents = decision.createWindow(options);
+    });
     const popupWindow = electronMock.fakeWindows[0];
-    expect(popupWindow).toBeDefined();
     if (popupWindow === undefined) {
       throw new Error("Expected a popup window to be created.");
     }
 
-    expect(popupWindow.options).not.toBe(options);
     expect(popupContents).toBe(childContents);
+    expect(popupWindow.loadURLCalls).toEqual([]);
     expect(popupWindow.options).toEqual({
       center: true,
       frame: true,
@@ -1218,50 +1183,11 @@ describe("DesktopBrowserViewManager", () => {
       webPreferences: {
         allowRunningInsecureContent: false,
         contextIsolation: true,
-        javascript: true,
         nodeIntegration: false,
-        nodeIntegrationInSubFrames: false,
-        nodeIntegrationInWorker: false,
         partition: "persist:test",
         sandbox: true,
         webSecurity: true,
-        webviewTag: false,
-        zoomFactor: 1,
       },
-    });
-    expect(options).toEqual({
-      alwaysOnTop: true,
-      frame: false,
-      height: 4_000,
-      show: false,
-      title: "bb sign in",
-      transparent: true,
-      width: 10,
-      webContents: childContents,
-      x: 0,
-      y: 0,
-      webPreferences: {
-        allowRunningInsecureContent: true,
-        contextIsolation: false,
-        nodeIntegration: true,
-        partition: "persist:untrusted",
-        preload: "/tmp/untrusted-preload.cjs",
-        sandbox: false,
-        webSecurity: false,
-      },
-    });
-    expect(popupWindow.options.webPreferences).toEqual({
-      allowRunningInsecureContent: false,
-      contextIsolation: true,
-      javascript: true,
-      nodeIntegration: false,
-      nodeIntegrationInSubFrames: false,
-      nodeIntegrationInWorker: false,
-      partition: "persist:test",
-      sandbox: true,
-      webSecurity: true,
-      webviewTag: false,
-      zoomFactor: 1,
     });
     expect(popupWindow.titleCalls).toEqual(["bb browser popup"]);
     childContents.emitDidNavigate("https://accounts.google.com/oauth2/auth");
@@ -1278,6 +1204,37 @@ describe("DesktopBrowserViewManager", () => {
     manager.destroyAll();
     expect(popupWindow.closeCalls).toBe(0);
     expect(popupWindow.destroyCalls).toBe(1);
+  });
+
+  it("loads the URL itself when Electron supplies no child webContents", () => {
+    const manager = createDesktopBrowserViewManager({
+      partition: "persist:test",
+    });
+    const hostWindow = new FakeHostWindow({
+      contentBounds: { width: 700, height: 450 },
+      webContentsId: 66,
+    });
+
+    attachBrowserTab({
+      manager,
+      hostWindow,
+      tabId: "browser:a",
+      url: "https://example.com/",
+    });
+    const view = requireFakeView(0);
+    const decision = view.webContents.emitWindowOpen(
+      "https://example.com/docs",
+      { disposition: "new-window" },
+    );
+
+    expect(decision.action).toBe("allow");
+    if (decision.createWindow === undefined) {
+      throw new Error("Expected the popup decision to create a window.");
+    }
+    decision.createWindow({});
+    expect(electronMock.fakeWindows[0]?.loadURLCalls).toEqual([
+      "https://example.com/docs",
+    ]);
   });
 
   it("supports blank-first OAuth navigation with secure remote URLs", () => {
@@ -1297,6 +1254,7 @@ describe("DesktopBrowserViewManager", () => {
     });
     const view = requireFakeView(0);
     const decision = view.webContents.emitWindowOpen("about:blank", {
+      disposition: "new-window",
       features: "width=520,height=700",
       frameName: "oauth",
     });
@@ -1309,15 +1267,25 @@ describe("DesktopBrowserViewManager", () => {
     decision.createWindow({ webContents: childContents });
 
     expect(
-      childContents.emitWillNavigate(
+      childContents.emitWillFrameNavigate(
         "https://accounts.google.com/o/oauth2/auth",
+        true,
       ),
     ).toBe(false);
     expect(
-      childContents.emitWillNavigate("http://accounts.google.com/oauth2/auth"),
+      childContents.emitWillFrameNavigate(
+        "http://accounts.google.com/oauth2/auth",
+        true,
+      ),
     ).toBe(true);
     expect(
-      childContents.emitWillNavigate("http://127.0.0.1:38886/callback"),
+      childContents.emitWillRedirect("http://evil.example/steal", true),
+    ).toBe(true);
+    expect(
+      childContents.emitWillFrameNavigate(
+        "http://127.0.0.1:38886/callback",
+        true,
+      ),
     ).toBe(false);
   });
 
@@ -1343,6 +1311,7 @@ describe("DesktopBrowserViewManager", () => {
       const decision = view.webContents.emitWindowOpen(
         "https://accounts.google.com/o/oauth2/auth",
         {
+          disposition: "new-window",
           features: "width=520,height=700",
           frameName: "oauth",
         },

--- a/apps/desktop/test/desktop-browser-view-manager.test.ts
+++ b/apps/desktop/test/desktop-browser-view-manager.test.ts
@@ -64,6 +64,11 @@ type FakeDidNavigateInPageListener = (
   isMainFrame: boolean,
 ) => void;
 
+type FakePageTitleUpdatedListener = (
+  event: FakePreventableEvent,
+  title: string,
+) => void;
+
 type FakeDidFailLoadListener = (
   event: FakeWebContentsEvent,
   errorCode: number,
@@ -144,7 +149,7 @@ interface FakeWebContentsEventMap {
   "did-navigate": FakeDidNavigateListener;
   "did-navigate-in-page": FakeDidNavigateInPageListener;
   "did-start-navigation": FakeVoidWebContentsListener;
-  "page-title-updated": FakeVoidWebContentsListener;
+  "page-title-updated": FakePageTitleUpdatedListener;
   "did-fail-load": FakeDidFailLoadListener;
   "context-menu": FakeContextMenuListener;
   "render-process-gone": FakeRenderProcessGoneListener;
@@ -173,11 +178,48 @@ type FakePermissionCheckHandler = (
 ) => boolean;
 
 interface FakeWindowOpenDetails {
+  features: string;
+  frameName: string;
   url: string;
 }
 
+interface FakeBrowserWindowOptions {
+  alwaysOnTop?: boolean;
+  center?: boolean;
+  frame?: boolean;
+  height?: number;
+  show?: boolean;
+  title?: string;
+  transparent?: boolean;
+  width?: number;
+  webContents?: FakePopupWebContents;
+  x?: number;
+  y?: number;
+  webPreferences?: {
+    allowRunningInsecureContent?: boolean;
+    contextIsolation?: boolean;
+    nodeIntegration?: boolean;
+    nodeIntegrationInSubFrames?: boolean;
+    nodeIntegrationInWorker?: boolean;
+    partition?: string;
+    preload?: string;
+    sandbox?: boolean;
+    webSecurity?: boolean;
+    webviewTag?: boolean;
+  };
+}
+
+interface FakePopupWebContents {
+  emitWindowOpen(
+    url: string,
+    details?: Partial<Omit<FakeWindowOpenDetails, "url">>,
+  ): FakeWindowOpenDecision;
+}
+
 interface FakeWindowOpenDecision {
-  action: "deny";
+  action: "allow" | "deny";
+  createWindow?: (options: FakeBrowserWindowOptions) => FakePopupWebContents;
+  overrideBrowserWindowOptions?: FakeBrowserWindowOptions;
 }
 
 type FakeWindowOpenHandler = (
@@ -427,6 +469,14 @@ const electronMock = vi.hoisted(() => {
       }
     }
 
+    emitPageTitleUpdated(title: string): boolean {
+      const event = new FakePreventableEventImpl();
+      for (const listener of this.listeners["page-title-updated"]) {
+        listener(event, title);
+      }
+      return event.defaultPrevented;
+    }
+
     emitWillFrameNavigate(
       url: string,
       isMainFrame: boolean,
@@ -471,11 +521,19 @@ const electronMock = vi.hoisted(() => {
       return event.defaultPrevented;
     }
 
-    emitWindowOpen(url: string): FakeWindowOpenDecision {
+    emitWindowOpen(
+      url: string,
+      details: Partial<Omit<FakeWindowOpenDetails, "url">> = {},
+    ): FakeWindowOpenDecision {
       if (this.windowOpenHandler === null) {
         throw new Error("Expected a window open handler to be registered.");
       }
-      return this.windowOpenHandler({ url });
+      return this.windowOpenHandler({
+        features: "",
+        frameName: "",
+        ...details,
+        url,
+      });
     }
   }
 
@@ -500,6 +558,48 @@ const electronMock = vi.hoisted(() => {
     }
   }
 
+  class FakeBrowserWindow {
+    public readonly options: FakeBrowserWindowOptions;
+    public readonly webContents: FakePopupWebContents;
+    public closeCalls = 0;
+    public destroyCalls = 0;
+    public readonly titleCalls: string[] = [];
+    private closedListener: (() => void) | null = null;
+    private destroyed = false;
+
+    constructor(options: FakeBrowserWindowOptions) {
+      this.options = options;
+      if (options.webContents === undefined) {
+        this.webContents = new FakeWebContents(nextWebContentsId);
+        nextWebContentsId += 1;
+      } else {
+        this.webContents = options.webContents;
+      }
+    }
+
+    close(): void {
+      this.closeCalls += 1;
+    }
+
+    destroy(): void {
+      this.destroyCalls += 1;
+      this.destroyed = true;
+      this.closedListener?.();
+    }
+
+    isDestroyed(): boolean {
+      return this.destroyed;
+    }
+
+    once(_eventName: "closed", listener: () => void): void {
+      this.closedListener = listener;
+    }
+
+    setTitle(title: string): void {
+      this.titleCalls.push(title);
+    }
+  }
+
   class FakeSession {
     public readonly willDownloadListeners: FakeSessionListener[] = [];
     public permissionCheckHandler: FakePermissionCheckHandler | null = null;
@@ -519,11 +619,24 @@ const electronMock = vi.hoisted(() => {
 
   const fakeSessions: FakeSession[] = [];
   const fakeViews: FakeWebContentsView[] = [];
+  const fakeWindows: FakeBrowserWindow[] = [];
 
   return {
     fakeCapturedImage,
     fakeSessions,
     fakeViews,
+    fakeWindows,
+    createFakeWebContents() {
+      const contents = new FakeWebContents(nextWebContentsId);
+      nextWebContentsId += 1;
+      return contents;
+    },
+    FakeBrowserWindow: class extends FakeBrowserWindow {
+      constructor(options: FakeBrowserWindowOptions) {
+        super(options);
+        fakeWindows.push(this);
+      }
+    },
     FakeWebContentsView: class extends FakeWebContentsView {
       constructor() {
         super();
@@ -541,6 +654,7 @@ const electronMock = vi.hoisted(() => {
 });
 
 vi.mock("electron", () => ({
+  BrowserWindow: electronMock.FakeBrowserWindow,
   WebContentsView: electronMock.FakeWebContentsView,
   session: electronMock.session,
 }));
@@ -607,6 +721,7 @@ beforeEach(() => {
   vi.useRealTimers();
   electronMock.fakeSessions.length = 0;
   electronMock.fakeViews.length = 0;
+  electronMock.fakeWindows.length = 0;
 });
 
 async function settlePendingCaptures(
@@ -934,7 +1049,11 @@ describe("DesktopBrowserViewManager", () => {
     });
     const view = requireFakeView(0);
 
-    expect(view.webContents.emitWindowOpen("http://localhost:38886/")).toEqual({
+    expect(
+      view.webContents.emitWindowOpen("http://localhost:38886/", {
+        frameName: "_blank",
+      }),
+    ).toEqual({
       action: "deny",
     });
     expect(openTabPushesOf(hostWindow)).toEqual(["http://localhost:38886/"]);
@@ -960,11 +1079,13 @@ describe("DesktopBrowserViewManager", () => {
     });
     const view = requireFakeView(0);
 
-    expect(view.webContents.emitWindowOpen("https://example.com/docs")).toEqual(
-      {
-        action: "deny",
-      },
-    );
+    expect(
+      view.webContents.emitWindowOpen("https://example.com/docs", {
+        frameName: "_blank",
+      }),
+    ).toEqual({
+      action: "deny",
+    });
     expect(openTabPushesOf(hostWindow)).toEqual(["https://example.com/docs"]);
     expect(scopedOpenTabPushesOf(hostWindow)).toEqual([
       {
@@ -972,6 +1093,277 @@ describe("DesktopBrowserViewManager", () => {
         url: "https://example.com/docs",
       },
     ]);
+  });
+
+  it("keeps noopener blank links in the browser panel", () => {
+    const manager = createDesktopBrowserViewManager({
+      partition: "persist:test",
+    });
+    const hostWindow = new FakeHostWindow({
+      contentBounds: { width: 700, height: 450 },
+      webContentsId: 63,
+    });
+
+    attachBrowserTab({
+      manager,
+      hostWindow,
+      tabId: "browser:a",
+      url: "https://example.com/",
+    });
+    const view = requireFakeView(0);
+
+    expect(
+      view.webContents.emitWindowOpen("https://example.com/docs", {
+        features:
+          "noopener,noreferrer,attributionsrc=https%3A%2F%2Fexample.com",
+        frameName: "_blank",
+      }),
+    ).toEqual({ action: "deny" });
+    expect(electronMock.fakeWindows).toEqual([]);
+    expect(openTabPushesOf(hostWindow)).toEqual(["https://example.com/docs"]);
+    expect(scopedOpenTabPushesOf(hostWindow)).toEqual([
+      {
+        tabId: "browser:a",
+        url: "https://example.com/docs",
+      },
+    ]);
+  });
+
+  it("opens named popup flows in a hardened native window", () => {
+    const manager = createDesktopBrowserViewManager({
+      partition: "persist:test",
+    });
+    const hostWindow = new FakeHostWindow({
+      contentBounds: { width: 700, height: 450 },
+      webContentsId: 62,
+    });
+
+    attachBrowserTab({
+      manager,
+      hostWindow,
+      tabId: "browser:a",
+      url: "https://www.notion.so/",
+    });
+    const view = requireFakeView(0);
+    const decision = view.webContents.emitWindowOpen(
+      "https://accounts.google.com/o/oauth2/auth",
+      {
+        features: "width=520,height=700",
+        frameName: "oauth",
+      },
+    );
+
+    expect(decision.action).toBe("allow");
+    expect(openTabPushesOf(hostWindow)).toEqual([]);
+    expect(scopedOpenTabPushesOf(hostWindow)).toEqual([]);
+    expect(decision.overrideBrowserWindowOptions).toEqual({
+      show: true,
+      webPreferences: {
+        allowRunningInsecureContent: false,
+        contextIsolation: true,
+        javascript: true,
+        nodeIntegration: false,
+        nodeIntegrationInSubFrames: false,
+        nodeIntegrationInWorker: false,
+        partition: "persist:test",
+        sandbox: true,
+        webSecurity: true,
+        webviewTag: false,
+        zoomFactor: 1,
+      },
+    });
+    if (decision.createWindow === undefined) {
+      throw new Error("Expected the popup decision to create a window.");
+    }
+
+    const childContents = electronMock.createFakeWebContents();
+    const options: FakeBrowserWindowOptions = {
+      alwaysOnTop: true,
+      frame: false,
+      height: 4_000,
+      show: false,
+      title: "bb sign in",
+      transparent: true,
+      width: 10,
+      webContents: childContents,
+      x: 0,
+      y: 0,
+      webPreferences: {
+        allowRunningInsecureContent: true,
+        contextIsolation: false,
+        nodeIntegration: true,
+        partition: "persist:untrusted",
+        preload: "/tmp/untrusted-preload.cjs",
+        sandbox: false,
+        webSecurity: false,
+      },
+    };
+    const popupContents = decision.createWindow(options);
+    const popupWindow = electronMock.fakeWindows[0];
+    expect(popupWindow).toBeDefined();
+    if (popupWindow === undefined) {
+      throw new Error("Expected a popup window to be created.");
+    }
+
+    expect(popupWindow.options).not.toBe(options);
+    expect(popupContents).toBe(childContents);
+    expect(popupWindow.options).toEqual({
+      center: true,
+      frame: true,
+      height: 900,
+      show: true,
+      transparent: false,
+      width: 320,
+      webContents: childContents,
+      webPreferences: {
+        allowRunningInsecureContent: false,
+        contextIsolation: true,
+        javascript: true,
+        nodeIntegration: false,
+        nodeIntegrationInSubFrames: false,
+        nodeIntegrationInWorker: false,
+        partition: "persist:test",
+        sandbox: true,
+        webSecurity: true,
+        webviewTag: false,
+        zoomFactor: 1,
+      },
+    });
+    expect(options).toEqual({
+      alwaysOnTop: true,
+      frame: false,
+      height: 4_000,
+      show: false,
+      title: "bb sign in",
+      transparent: true,
+      width: 10,
+      webContents: childContents,
+      x: 0,
+      y: 0,
+      webPreferences: {
+        allowRunningInsecureContent: true,
+        contextIsolation: false,
+        nodeIntegration: true,
+        partition: "persist:untrusted",
+        preload: "/tmp/untrusted-preload.cjs",
+        sandbox: false,
+        webSecurity: false,
+      },
+    });
+    expect(popupWindow.options.webPreferences).toEqual({
+      allowRunningInsecureContent: false,
+      contextIsolation: true,
+      javascript: true,
+      nodeIntegration: false,
+      nodeIntegrationInSubFrames: false,
+      nodeIntegrationInWorker: false,
+      partition: "persist:test",
+      sandbox: true,
+      webSecurity: true,
+      webviewTag: false,
+      zoomFactor: 1,
+    });
+    expect(popupWindow.titleCalls).toEqual(["bb browser popup"]);
+    childContents.emitDidNavigate("https://accounts.google.com/oauth2/auth");
+    expect(popupWindow.titleCalls.at(-1)).toBe(
+      "bb browser — https://accounts.google.com",
+    );
+    expect(childContents.emitPageTitleUpdated("Google Sign In")).toBe(true);
+    expect(popupWindow.titleCalls.at(-1)).toBe(
+      "bb browser — https://accounts.google.com",
+    );
+    expect(popupContents.emitWindowOpen("https://example.com/nested")).toEqual({
+      action: "deny",
+    });
+    manager.destroyAll();
+    expect(popupWindow.closeCalls).toBe(0);
+    expect(popupWindow.destroyCalls).toBe(1);
+  });
+
+  it("supports blank-first OAuth navigation with secure remote URLs", () => {
+    const manager = createDesktopBrowserViewManager({
+      partition: "persist:test",
+    });
+    const hostWindow = new FakeHostWindow({
+      contentBounds: { width: 700, height: 450 },
+      webContentsId: 64,
+    });
+
+    attachBrowserTab({
+      manager,
+      hostWindow,
+      tabId: "browser:a",
+      url: "https://example.com/",
+    });
+    const view = requireFakeView(0);
+    const decision = view.webContents.emitWindowOpen("about:blank", {
+      features: "width=520,height=700",
+      frameName: "oauth",
+    });
+
+    expect(decision.action).toBe("allow");
+    if (decision.createWindow === undefined) {
+      throw new Error("Expected the blank OAuth popup to create a window.");
+    }
+    const childContents = electronMock.createFakeWebContents();
+    decision.createWindow({ webContents: childContents });
+
+    expect(
+      childContents.emitWillNavigate(
+        "https://accounts.google.com/o/oauth2/auth",
+      ),
+    ).toBe(false);
+    expect(
+      childContents.emitWillNavigate("http://accounts.google.com/oauth2/auth"),
+    ).toBe(true);
+    expect(
+      childContents.emitWillNavigate("http://127.0.0.1:38886/callback"),
+    ).toBe(false);
+  });
+
+  it("caps live native popups across successive rate windows", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-09-03T12:00:00Z"));
+    const manager = createDesktopBrowserViewManager({
+      partition: "persist:test",
+    });
+    const hostWindow = new FakeHostWindow({
+      contentBounds: { width: 700, height: 450 },
+      webContentsId: 65,
+    });
+
+    attachBrowserTab({
+      manager,
+      hostWindow,
+      tabId: "browser:a",
+      url: "https://example.com/",
+    });
+    const view = requireFakeView(0);
+    const openPopup = (): FakeWindowOpenDecision => {
+      const decision = view.webContents.emitWindowOpen(
+        "https://accounts.google.com/o/oauth2/auth",
+        {
+          features: "width=520,height=700",
+          frameName: "oauth",
+        },
+      );
+      if (decision.createWindow !== undefined) {
+        decision.createWindow({
+          webContents: electronMock.createFakeWebContents(),
+        });
+      }
+      return decision;
+    };
+
+    expect(openPopup().action).toBe("allow");
+    expect(openPopup().action).toBe("allow");
+    expect(openPopup().action).toBe("allow");
+    vi.advanceTimersByTime(10_001);
+    expect(openPopup()).toEqual({ action: "deny" });
+
+    electronMock.fakeWindows[0]?.destroy();
+    expect(openPopup().action).toBe("allow");
+    manager.destroyAll();
   });
 
   it("snapshots then hides visible views on resize, revealing them clamped to the shrunken window", async () => {


### PR DESCRIPTION
## Human comments

## What was wrong

The desktop in-app browser answered every `window.open()` by creating an in-panel tab and returning `{ action: "deny" }`. Named or sized popups therefore returned `null` to the opener, lost `window.opener`, and could never complete an OAuth `postMessage` handshake (#2754). This supersedes #2757 by @kravtsovd, whose commit is carried here unchanged with a simplification commit on top; the original PR could not be updated further because its CI failure came from a stale base and the follow-up review changes were force-pushed to the contributor's fork.

## What changed

- `apps/desktop/src/desktop-browser-view.ts`
  - Popup classification uses Electron's `details.disposition === "new-window"`, which is Chromium's own popup decision for `window.open`, instead of re-parsing the features string. `noopener` and plain `_blank` opens stay in the in-panel tab flow because Chromium already reports them as tabs.
  - Popups become a hardened native `BrowserWindow` created through `createWindow`, adopting the child `webContents` Electron pre-creates so `window.opener` survives. When Electron supplies no child (Shift-click on a link), the window loads the URL itself, matching Electron's default branch. The untyped `webContents` option is narrowed once with a local type at that boundary.
  - Tab views and popups share one hardened `webPreferences` object and one main-frame navigation guard (`will-frame-navigate` + `will-redirect`). The duplicate `will-navigate` listeners are gone.
  - Popup navigation is HTTPS-only except loopback HTTP for callbacks, nested popups are denied, the native title is pinned to `bb browser — <origin>` with page titles suppressed, live popups are capped at 3 per tab and 8 globally on top of the existing rate limit, and popups are destroyed on tab release and manager teardown.
  - Behavior change to note: Shift-click on a link now opens a native window, as in Chrome, instead of an in-panel tab.
- `apps/desktop/src/desktop-browser-policy.ts`: removed `resolveWindowOpenAction`, which had no callers left.
- Tests in `apps/desktop/test/desktop-browser-view-manager.test.ts` cover the popup path, the blank-first flow, the no-child `loadURL` path, `noopener` staying in-panel, the navigation and redirect guards, and the live cap across rate windows.

No wire changes, no CLI or doc surfaces.

## How you verified

- The regression test from #2757 fails on the base implementation with `expected "allow", received "deny"`.
- `pnpm exec turbo run typecheck test --filter=@bb/desktop --force`: 38 test files, 250 tests passed, desktop typecheck passed.
- `oxfmt`, `oxlint`, and `git diff --check` on the changed files.
- End-to-end in the real Electron 41.7.0 desktop app on macOS (bb thread `thr_ugzgtcudhi`), all passing: sized OAuth popup and blank-first popup return a `Window`, keep `window.opener`, and complete the cross-origin `postMessage` handshake; plain `_blank` and `noopener,noreferrer` open in-panel tabs; nested popups are denied; non-loopback HTTP navigation in a popup is blocked while HTTPS proceeds and retitles; the fourth open in 10 s is rate-limited and the per-tab live cap holds until a popup closes; Shift-click loads the real URL in a native window; closing the source tab destroys its popup; Google's real OAuth endpoint opens natively titled `bb browser — https://accounts.google.com`.

Fixes #2754

> AGENT GENERATED
