### PR TITLE
Declare plan support for ACP agents and translate it via session modes

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -408,8 +408,13 @@ entry is a path or `{"path": ..., "recursive": true, "ancestors": true}` for
 an agent that nests skills or reads them from every ancestor directory),
 `permissionCli` (permission-mode launch flags), `supportsManualCompaction`
 (only if the agent accepts an explicit compaction request — bb hides
-`/compact` otherwise), and `dialect` (the vendor side channels bb reads for
-the agent: `cursor`, `opencode`, `omp`, or `grok`).
+`/compact` otherwise), `supportsPlan` (only if the agent exposes a `plan`
+session mode over ACP — bb offers the composer's `/plan` action and switches
+the session into that mode for plan turns), and `dialect` (the vendor side
+channels bb reads for the agent: `cursor`, `opencode`, `omp`, or `grok`).
+Editing a past message (session rewind) stays unavailable for ACP agents:
+ACP `session/fork` can only fork a session's current end, never an earlier
+point, so no `fork` declaration is offered for these entries.
 
 The change applies immediately: the plugin re-registers its providers when the
 setting changes, with no restart and no `config refresh`.

--- a/packages/provider-bridge-acp/src/bridge/bridge.test.ts
+++ b/packages/provider-bridge-acp/src/bridge/bridge.test.ts
@@ -11,7 +11,10 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createStandaloneBuiltinCompactCommandInput } from "@bb/domain";
+import {
+  createBuiltinPlanCommandTextInput,
+  createStandaloneBuiltinCompactCommandInput,
+} from "@bb/domain";
 import type { DynamicTool, ReasoningLevel } from "@bb/domain";
 import {
   PROVIDER_BRIDGE_PROTOCOL_VERSION,
@@ -145,6 +148,7 @@ function executionOptions(args: {
   envVars?: Record<string, string>;
   instructions?: string;
   model?: string;
+  promptMode?: "plan";
   reasoningLevel?: ReasoningLevel;
   serviceTier?: "default" | "fast";
   providerOptions?: Record<string, unknown>;
@@ -167,6 +171,7 @@ function executionOptions(args: {
     ...(args.envVars ? { envVars: args.envVars } : {}),
     ...(args.instructions ? { instructions: args.instructions } : {}),
     ...(args.model ? { model: args.model } : {}),
+    ...(args.promptMode ? { promptMode: args.promptMode } : {}),
     ...(args.reasoningLevel ? { reasoningLevel: args.reasoningLevel } : {}),
     ...(args.serviceTier ? { serviceTier: args.serviceTier } : {}),
     ...(args.providerOptions ? { providerOptions: args.providerOptions } : {}),
@@ -492,6 +497,24 @@ function agentMessageTexts(): string[] {
     textsByItemId.set(typedItem.id, typedItem.text ?? "");
   }
   return order.map((id) => textsByItemId.get(id) ?? "");
+}
+
+function promptTexts(request: LoggedAcpRequest | undefined): string[] {
+  const prompt = request?.params?.["prompt"];
+  if (!Array.isArray(prompt)) {
+    return [];
+  }
+  return prompt.flatMap((block) => {
+    if (
+      typeof block === "object" &&
+      block !== null &&
+      "text" in block &&
+      typeof block.text === "string"
+    ) {
+      return [block.text];
+    }
+    return [];
+  });
 }
 
 function callDynamicToolBridge(args: {
@@ -3317,5 +3340,95 @@ describe("acp bridge", () => {
       code: -32602,
       message: expect.stringContaining("acpLaunchSpec"),
     });
+  });
+
+  it("enters the agent's plan session mode and strips the plan command mention", async () => {
+    const requestLog = join(workspaceDir, "plan-mode-requests.jsonl");
+    const { providerThreadId } = await startThread({
+      envVars: {
+        FAKE_ACP_SESSION_MODES: "1",
+        FAKE_ACP_REQUEST_LOG: requestLog,
+      },
+    });
+
+    const id = sendTurnRequest("turn/start", providerThreadId, {
+      input: [createBuiltinPlanCommandTextInput("ship it")],
+      options: executionOptions({ promptMode: "plan" }),
+    });
+    await waitForResponse(id);
+    await waitForTurnCompleted();
+
+    const requests = loggedAcpRequests(requestLog);
+    const setModeIndex = requests.findIndex(
+      (request) => request.method === "session/set_mode",
+    );
+    const promptIndex = requests.findIndex(
+      (request) => request.method === "session/prompt",
+    );
+    expect(setModeIndex).toBeGreaterThanOrEqual(0);
+    expect(setModeIndex).toBeLessThan(promptIndex);
+    expect(requests[setModeIndex]?.params).toMatchObject({ modeId: "plan" });
+    expect(promptTexts(requests[promptIndex])).toEqual(["ship it"]);
+  });
+
+  it("leaves plan turns untouched for agents that report no session modes", async () => {
+    const requestLog = join(workspaceDir, "no-modes-requests.jsonl");
+    const { providerThreadId } = await startThread({
+      envVars: {
+        FAKE_ACP_REQUEST_LOG: requestLog,
+      },
+    });
+
+    const id = sendTurnRequest("turn/start", providerThreadId, {
+      input: [createBuiltinPlanCommandTextInput("ship it")],
+      options: executionOptions({ promptMode: "plan" }),
+    });
+    await waitForResponse(id);
+    await waitForTurnCompleted();
+
+    const requests = loggedAcpRequests(requestLog);
+    expect(
+      requests.filter((request) => request.method === "session/set_mode"),
+    ).toEqual([]);
+    expect(
+      promptTexts(
+        requests.find((request) => request.method === "session/prompt"),
+      ),
+    ).toEqual(["/plan ship it"]);
+  });
+
+  it("returns the agent to its initial session mode after a plan turn", async () => {
+    const requestLog = join(workspaceDir, "plan-mode-reset-requests.jsonl");
+    const { providerThreadId } = await startThread({
+      envVars: {
+        FAKE_ACP_SESSION_MODES: "1",
+        FAKE_ACP_REQUEST_LOG: requestLog,
+      },
+    });
+
+    const planTurnId = sendTurnRequest("turn/start", providerThreadId, {
+      input: [createBuiltinPlanCommandTextInput("look around")],
+      options: executionOptions({ promptMode: "plan" }),
+    });
+    await waitForResponse(planTurnId);
+    await waitForTurnCompleted();
+
+    const normalTurnId = sendTurnRequest("turn/start", providerThreadId, {
+      input: [{ type: "text", text: "go ahead" }],
+    });
+    await waitForResponse(normalTurnId);
+    await waitForTurnCompleted();
+
+    expect(
+      loggedAcpRequests(requestLog)
+        .filter((request) => request.method === "session/set_mode")
+        .map((request) => request.params?.["modeId"]),
+    ).toEqual(["plan", "default"]);
+    const promptRequests = loggedAcpRequests(requestLog).filter(
+      (request) => request.method === "session/prompt",
+    );
+    expect(promptTexts(promptRequests[promptRequests.length - 1])).toEqual([
+      "go ahead",
+    ]);
   });
 });

--- a/packages/provider-bridge-acp/src/bridge/bridge.ts
+++ b/packages/provider-bridge-acp/src/bridge/bridge.ts
@@ -2,6 +2,7 @@ import {
   isStandaloneBuiltinCompactCommand,
   pendingInteractionResolutionSchema,
   reasoningEffortsForLevels,
+  removeCommandMentionsFromPromptInput,
 } from "@bb/domain";
 import type { AvailableModel, PromptInput, ReasoningLevel } from "@bb/domain";
 import { acpLaunchSpecSchema, type AcpLaunchSpec } from "../launch-spec.js";
@@ -98,6 +99,9 @@ import {
   acpSessionForkResultSchema,
   acpSessionNewResultSchema,
   acpSessionNotificationParamsSchema,
+  acpCurrentModeUpdateSchema,
+  acpSetModeResultSchema,
+  type AcpSessionModes,
   acpAgentMessageChunkUpdateSchema,
   extractAcpContentText,
   acpUsageUpdateSchema,
@@ -154,7 +158,14 @@ interface PendingAcpPermission {
 interface AcpPendingTurnInput {
   clientRequestId: string;
   input: PromptInput[];
+  promptMode: "plan" | undefined;
   requestId: AcpBridgeRequestId | null;
+}
+
+interface AcpSessionModeState {
+  planModeId: string;
+  resetModeId: string;
+  currentModeId: string;
 }
 
 interface AcpThreadSession {
@@ -166,6 +177,7 @@ interface AcpThreadSession {
   connection: AcpAgentConnection;
   supportsImageInput: boolean;
   supportsLoadSession: boolean;
+  modeState: AcpSessionModeState | null;
   policy: AcpSessionPolicy;
   pendingInstructions: string | undefined;
   activePromptKind: "turn" | "compaction" | null;
@@ -1298,6 +1310,64 @@ function buildPromptContentBlocks(
   return blocks;
 }
 
+const ACP_PLAN_MODE_ID = "plan";
+
+function acpSessionModeState(
+  modes: AcpSessionModes | undefined,
+): AcpSessionModeState | null {
+  if (modes === undefined) {
+    return null;
+  }
+  const planMode = modes.availableModes.find(
+    (mode) => mode.id === ACP_PLAN_MODE_ID,
+  );
+  if (planMode === undefined) {
+    return null;
+  }
+  return {
+    planModeId: planMode.id,
+    resetModeId: modes.currentModeId,
+    currentModeId: modes.currentModeId,
+  };
+}
+
+function planModeTurnInput(
+  session: AcpThreadSession,
+  pending: AcpPendingTurnInput,
+): PromptInput[] {
+  if (pending.promptMode !== "plan" || session.modeState === null) {
+    return pending.input;
+  }
+  return removeCommandMentionsFromPromptInput(pending.input, {
+    trigger: "/",
+    name: ACP_PLAN_MODE_ID,
+  });
+}
+
+async function reconcilePlanMode(
+  session: AcpThreadSession,
+  pending: AcpPendingTurnInput,
+): Promise<void> {
+  const modeState = session.modeState;
+  if (modeState === null) {
+    return;
+  }
+  const targetModeId =
+    pending.promptMode === "plan" ? modeState.planModeId : modeState.resetModeId;
+  if (modeState.currentModeId === targetModeId) {
+    return;
+  }
+  await session.connection.request({
+    method: "session/set_mode",
+    params: {
+      sessionId: session.providerThreadId,
+      modeId: targetModeId,
+    },
+    resultSchema: acpSetModeResultSchema,
+  });
+  modeState.currentModeId = targetModeId;
+}
+
 function findOptionIdByKinds(
   options: AcpPermissionOption[],
   kinds: AcpPermissionOption["kind"][],
@@ -1706,6 +1776,7 @@ async function startAgentSession(
     connection,
     supportsImageInput: false,
     supportsLoadSession: false,
+    modeState: null,
     policy: {
       permissionMode: params.permissionMode,
       workspaceWriteRoots: params.workspaceWriteRoots,
@@ -1776,6 +1847,7 @@ async function startAgentSession(
     let sessionId: string | undefined;
     let loadedConfigOptions: readonly AcpConfigOption[] | undefined;
     let loadedModels: AcpSessionModels | undefined;
+    let loadedModes: AcpSessionModes | undefined;
     if (request.kind === "fork") {
       const forkedSession = await connection.request({
         method: "session/fork",
@@ -1797,6 +1869,7 @@ async function startAgentSession(
       sessionId = forkedSession.sessionId;
       loadedConfigOptions = forkedSession.configOptions;
       loadedModels = forkedSession.models;
+      loadedModes = forkedSession.modes;
     } else if (request.kind === "resume" && supportsLoadSession) {
       session.loading = true;
       session.loadingSessionId = request.resumeProviderThreadId;
@@ -1813,6 +1886,7 @@ async function startAgentSession(
         });
         loadedConfigOptions = configState?.configOptions;
         loadedModels = configState?.models;
+        loadedModes = configState?.modes;
         sessionId = request.resumeProviderThreadId;
       } catch {
         sessionId = undefined;
@@ -1832,6 +1906,7 @@ async function startAgentSession(
         resultSchema: acpSessionNewResultSchema,
       });
       sessionId = newSession.sessionId;
+      loadedModes = newSession.modes;
       await selectAcpNativeModel({
         connection,
         sessionId,
@@ -1866,6 +1941,8 @@ async function startAgentSession(
         });
       }
     }
+
+    session.modeState = acpSessionModeState(loadedModes);
 
     if (session.stopping) {
       throw new Error(
@@ -2050,11 +2127,15 @@ function runTurn(
       session.cancelRequested = false;
       try {
         session.promptRequestPending = true;
+        await reconcilePlanMode(session, pending);
         const promptResult = session.connection.request({
           method: "session/prompt",
           params: {
             sessionId: session.providerThreadId,
-            prompt: buildPromptContentBlocks(session, pending.input),
+            prompt: buildPromptContentBlocks(
+              session,
+              planModeTurnInput(session, pending),
+            ),
           },
           resultSchema: acpPromptResultSchema,
         });
@@ -2241,6 +2322,14 @@ function handleAgentNotification(
   }
   if (parsed.data.sessionId !== session.providerThreadId) {
     return;
+  }
+  if (session.modeState !== null) {
+    const modeUpdate = acpCurrentModeUpdateSchema.safeParse(
+      parsed.data.update,
+    );
+    if (modeUpdate.success) {
+      session.modeState.currentModeId = modeUpdate.data.currentModeId;
+    }
   }
   if (session.activePromptKind === "compaction") {
     const chunk = acpAgentMessageChunkUpdateSchema.safeParse(
@@ -2602,6 +2691,7 @@ async function handleRequest(
       const pending: AcpPendingTurnInput = {
         clientRequestId: params.clientRequestId,
         input: params.input,
+        promptMode: params.options.promptMode,
         requestId: request.id,
       };
       if (isStandaloneBuiltinCompactCommand(params.input)) {
@@ -2629,6 +2719,7 @@ async function handleRequest(
       session.queuedInputs.push({
         clientRequestId: params.clientRequestId,
         input: params.input,
+        promptMode: params.options.promptMode,
         requestId: null,
       });
       requestSteerCancel(session);

--- a/packages/provider-bridge-acp/src/bridge/fake-acp-agent.mjs
+++ b/packages/provider-bridge-acp/src/bridge/fake-acp-agent.mjs
@@ -102,6 +102,8 @@ const sessionNewDelayMs = Number(
 const updatesWithSessionResponse =
   process.env.FAKE_ACP_UPDATES_WITH_SESSION_RESPONSE === "1";
 const ignoreCancel = process.env.FAKE_ACP_IGNORE_CANCEL === "1";
+const sessionModes = process.env.FAKE_ACP_SESSION_MODES === "1";
+let currentModeId = "default";
 // `--list-models` is the agent's own model-list mode: the bridge derives its
 // list command from the launch spec's agent binary plus `modelCli.listArgs`,
 // so a list command can only ever be this binary.
@@ -311,6 +313,15 @@ function configState() {
   const options = configOptions();
   if (options !== undefined) {
     state.configOptions = options;
+  }
+  if (sessionModes) {
+    state.modes = {
+      currentModeId,
+      availableModes: [
+        { id: "default", name: "Default" },
+        { id: "plan", name: "Plan" },
+      ],
+    };
   }
   if (cursorParameterizedModels) {
     const availableModels = cursorModelOptions();
@@ -733,6 +744,27 @@ async function handleMessage(message) {
       }
       selectedModel = modelId;
       send({ jsonrpc: "2.0", id: message.id, result: configState() });
+      return;
+    }
+    case "session/set_mode": {
+      const modeId = message.params?.modeId;
+      if (
+        !sessionModes ||
+        (modeId !== "default" && modeId !== "plan")
+      ) {
+        send({
+          jsonrpc: "2.0",
+          id: message.id,
+          error: { code: -32602, message: `unsupported mode: ${modeId}` },
+        });
+        return;
+      }
+      currentModeId = modeId;
+      notifyUpdate({
+        sessionUpdate: "current_mode_update",
+        currentModeId,
+      });
+      send({ jsonrpc: "2.0", id: message.id, result: {} });
       return;
     }
     case "session/set_config_option": {

--- a/packages/provider-bridge-acp/src/wire.test.ts
+++ b/packages/provider-bridge-acp/src/wire.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
+  acpConfigStateResultSchema,
   acpInitializeResultSchema,
   acpRequestPermissionParamsSchema,
   acpSessionForkResultSchema,
   acpSessionNewResultSchema,
+  acpSessionUpdateSchema,
   acpToolCallUpdateEventSchema,
 } from "./wire.js";
 
@@ -150,6 +152,53 @@ describe("acpSessionNewResultSchema", () => {
     );
     expect(parsed.data.configOptions?.[1].category).toBeUndefined();
     expect(parsed.data.configOptions?.[1].options?.[0].name).toBeUndefined();
+  });
+
+  it("reads the session modes an agent reports", () => {
+    const parsed = acpSessionNewResultSchema.parse({
+      sessionId: "session-1",
+      modes: {
+        currentModeId: "default",
+        availableModes: [
+          { id: "default", name: "Default" },
+          {
+            id: "plan",
+            name: "Plan",
+            description: "Read-only planning",
+          },
+        ],
+      },
+    });
+
+    expect(parsed.modes?.currentModeId).toBe("default");
+    expect(parsed.modes?.availableModes.map((mode) => mode.id)).toEqual([
+      "default",
+      "plan",
+    ]);
+  });
+});
+
+describe("acpConfigStateResultSchema", () => {
+  it("carries session modes through a fork or config-state result", () => {
+    const parsed = acpConfigStateResultSchema.parse({
+      modes: {
+        currentModeId: "plan",
+        availableModes: [{ id: "default", name: "Default" }],
+      },
+    });
+
+    expect(parsed.modes?.currentModeId).toBe("plan");
+  });
+});
+
+describe("acpSessionUpdateSchema", () => {
+  it("accepts a current-mode update without swallowing it as other", () => {
+    const parsed = acpSessionUpdateSchema.parse({
+      sessionUpdate: "current_mode_update",
+      currentModeId: "plan",
+    });
+
+    expect(parsed.sessionUpdate).toBe("current_mode_update");
   });
 });
 

--- a/packages/provider-bridge-acp/src/wire.ts
+++ b/packages/provider-bridge-acp/src/wire.ts
@@ -185,6 +185,14 @@ export const acpPlanUpdateSchema = z
   })
   .passthrough();
 
+export const acpCurrentModeUpdateSchema = z
+  .object({
+    sessionUpdate: z.literal("current_mode_update"),
+    currentModeId: z.string().min(1),
+  })
+  .passthrough();
+export type AcpCurrentModeUpdate = z.infer<typeof acpCurrentModeUpdateSchema>;
+
 export const acpUsageUpdateSchema = z
   .object({
     sessionUpdate: z.literal("usage_update"),
@@ -205,6 +213,7 @@ export const acpSessionUpdateSchema = z.union([
   acpAgentThoughtChunkUpdateSchema,
   acpToolCallUpdateEventSchema,
   acpPlanUpdateSchema,
+  acpCurrentModeUpdateSchema,
   acpUsageUpdateSchema,
   acpOtherSessionUpdateSchema,
 ]);
@@ -351,6 +360,25 @@ function parseAcpConfigOptions(
   return parsedOptions;
 }
 
+export const acpSessionModeSchema = z
+  .object({
+    id: z.string().min(1),
+    name: z.string(),
+    description: z.string().optional(),
+  })
+  .passthrough();
+export type AcpSessionMode = z.infer<typeof acpSessionModeSchema>;
+
+export const acpSessionModesSchema = z
+  .object({
+    currentModeId: z.string().min(1),
+    availableModes: z.array(acpSessionModeSchema),
+  })
+  .passthrough();
+export type AcpSessionModes = z.infer<typeof acpSessionModesSchema>;
+
+export const acpSetModeResultSchema = z.object({}).passthrough();
+
 export const acpSessionNewResultSchema = z
   .object({
     sessionId: z.string(),
@@ -360,6 +388,7 @@ export const acpSessionNewResultSchema = z
       .nullable()
       .optional()
       .transform((options, ctx) => parseAcpConfigOptions(options, ctx)),
+    modes: acpSessionModesSchema.optional(),
   })
   .passthrough();
 
@@ -371,6 +400,7 @@ export const acpConfigStateResultSchema = z
       .nullable()
       .optional()
       .transform((options, ctx) => parseAcpConfigOptions(options, ctx)),
+    modes: acpSessionModesSchema.optional(),
   })
   .passthrough();
 export type AcpConfigStateResult = z.infer<typeof acpConfigStateResultSchema>;

--- a/packages/templates/src/templates/bb-guide-customization.md
+++ b/packages/templates/src/templates/bb-guide-customization.md
@@ -127,7 +127,9 @@ and `null` clears a preference that can be unset.
 The default-off `changelogPreview` experiment shows the latest release notes
 as a compact, dismissible card on Settings → Updates.
 The default-on `editMessages` experiment enables editing eligible, accepted
-root user messages in Codex, Claude Code, and Pi threads, including failed or
+root user messages in threads whose provider can restore an earlier checkpoint
+(Codex, Claude Code, and Pi today; ACP agents cannot offer it because ACP
+session/fork only clones a session's current end), including failed or
 incomplete turns; turn it off to hide the editor. Opening the editor is
 client-local; submitting stops and settles a running thread, then replaces the
 selected turn and all later conversation history while retaining workspace side

--- a/packages/templates/src/templates/bb-guide-threads.md
+++ b/packages/templates/src/templates/bb-guide-threads.md
@@ -94,7 +94,9 @@ Editing a sent message (requires the default-on `editMessages` experiment):
     --expected-request-sequence <seq>   Select the message and reject a stale target
 
   Without --expected-request-sequence, the latest eligible message is edited.
-  Codex, Claude Code, and Pi threads are supported. The original conversation
+  Threads whose provider can restore an earlier checkpoint are supported
+  (Codex, Claude Code, and Pi today); ACP agents cannot offer it because ACP
+  session/fork only clones a session's current end. The original conversation
   remains unchanged until the provider prepares the replacement history.
   Failed and incomplete turns are eligible. If the thread is running,
   submission stops the current turn and waits for it to settle. It then
@@ -221,9 +223,11 @@ Messaging:
   that failed while it was deferred, and delivers when the thread is retried.
 
   --plan sends the same structured /plan command the composer's plan action
-  sends, so the agent proposes a plan for approval before executing (Claude
-  Code and Codex threads). Plain "/plan ..." text is not recognized; it reaches
-  the provider as literal text. Approve or deny the proposed plan with
+  sends, so the agent proposes a plan for approval before executing. Providers
+  that declare the plan action offer it (Claude Code, Codex, and ACP agents
+  like omp whose ACP layer exposes a plan session mode). Plain "/plan ..." text
+  is not recognized; it reaches the provider as literal text. Approve or deny
+  the proposed plan with
   `bb thread interactions`; `bb thread cancel-plan` leaves Plan mode early.
   SDK callers build the same input with
   `createBuiltinPlanCommandTextInput(text)` from `@bb/sdk` and pass it as

--- a/plugins/provider-acp/src/agents.test.ts
+++ b/plugins/provider-acp/src/agents.test.ts
@@ -27,6 +27,7 @@ describe("parseCustomAcpAgents", () => {
         args: [],
         env: {},
         supportsManualCompaction: false,
+        supportsPlan: false,
       },
     ]);
   });
@@ -149,6 +150,7 @@ describe("customAcpAgentDefinition", () => {
           cwd: "/srv/amp",
           modelCli: { listArgs: [], primaryModels: [] },
           supportsManualCompaction: true,
+          supportsPlan: true,
         },
       ],
       reservedProviderIds: reserved,
@@ -165,6 +167,7 @@ describe("customAcpAgentDefinition", () => {
       cwd: "/srv/amp",
     });
     expect(definition.supportsManualCompaction).toBe(true);
+    expect(definition.supportsPlan).toBe(true);
     expect(definition.fork).toBe("none");
   });
 });
@@ -287,6 +290,7 @@ describe("acpProviderDeclaration", () => {
         args: [],
         env: {},
         supportsManualCompaction: false,
+        supportsPlan: false,
       }),
     );
 
@@ -294,5 +298,39 @@ describe("acpProviderDeclaration", () => {
       "Sign in to Amp on the machine, then reload.",
     );
     expect(declaration.maintenance?.usage).toBe(false);
+  });
+
+  it("offers the plan composer action only to agents that declare it", () => {
+    const byId = new Map(
+      KNOWN_ACP_AGENTS.map((agent) => [
+        agent.id,
+        acpProviderDeclaration(agent),
+      ]),
+    );
+    for (const agent of KNOWN_ACP_AGENTS) {
+      expect(byId.get(agent.id)?.composerActions).toEqual(
+        agent.id === "acp-omp" ? ["plan"] : [],
+      );
+    }
+    expect(byId.get("acp-omp")?.capabilities.fork).toBe("tip");
+
+    const [planningCustom] = parseCustomAcpAgents({
+      entries: [
+        {
+          id: "amp",
+          displayName: "Amp",
+          command: "amp",
+          supportsPlan: true,
+        },
+      ],
+      reservedProviderIds: reserved,
+    }).agents;
+    if (planningCustom === undefined) {
+      throw new Error("expected the agent to parse");
+    }
+    expect(
+      acpProviderDeclaration(customAcpAgentDefinition(planningCustom))
+        .composerActions,
+    ).toEqual(["plan"]);
   });
 });

--- a/plugins/provider-acp/src/agents.ts
+++ b/plugins/provider-acp/src/agents.ts
@@ -26,6 +26,7 @@ export interface AcpAgentDefinition {
   installUrl?: string;
   iconTint?: { light: string; dark: string };
   supportsManualCompaction?: boolean;
+  supportsPlan?: boolean;
   fork?: "none" | "tip";
   reasoningLevels?: readonly PluginProviderReasoningLevel[];
   providerUsage?: boolean;
@@ -53,6 +54,7 @@ export const customAcpAgentSchema = z
     nativeSkillRoots: launchSpecFields.nativeSkillRoots,
     permissionCli: launchSpecFields.permissionCli,
     supportsManualCompaction: z.boolean().default(false),
+    supportsPlan: z.boolean().default(false),
   })
   .strict();
 export type CustomAcpAgent = z.infer<typeof customAcpAgentSchema>;
@@ -94,6 +96,7 @@ export function customAcpAgentDefinition(
     visibility: "always",
     fork: "none",
     supportsManualCompaction: agent.supportsManualCompaction,
+    supportsPlan: agent.supportsPlan,
   };
 }
 

--- a/plugins/provider-acp/src/declaration.ts
+++ b/plugins/provider-acp/src/declaration.ts
@@ -98,6 +98,6 @@ export function acpProviderDeclaration(
           ? [...ACP_BASE_CAPABILITIES.reasoningLevels]
           : [...agent.reasoningLevels],
     },
-    composerActions: [],
+    composerActions: agent.supportsPlan === true ? ["plan"] : [],
   };
 }

--- a/plugins/provider-acp/src/known-agents.ts
+++ b/plugins/provider-acp/src/known-agents.ts
@@ -119,6 +119,7 @@ export const KNOWN_ACP_AGENTS: readonly AcpAgentDefinition[] = [
     installUrl: "https://github.com/can1357/omp",
     visibility: "installed",
     supportsManualCompaction: true,
+    supportsPlan: true,
     fork: "tip",
     launch: {
       displayName: "omp",


### PR DESCRIPTION
## Human comments

I hit this running omp as an ACP provider day-to-day: plan-then-approve works on first-party providers and silently doesn't exist for ACP threads, which made the orchestration workflows I use bb for (scouts → review → implement) awkward to gate. The slop-cop repro matches what I saw before filing.

Two things I'd flag for reviewers: the capability only un-gates what the agent actually advertises (no-modes agents get byte-identical passthrough — that was a hard requirement for me, not a nice-to-have), and rewind is deliberately left undeclarable rather than approximated. Built agent-assisted; I reviewed the wire-shape decisions myself.

## What was wrong

The plan action and edit-past-message gates were already capability-driven (`composerActions: ["plan"]`, `capabilities.fork`), but ACP agents could not declare either: the ACP provider hardcoded `composerActions` to `[]` and typed `AcpAgentDefinition.fork` as `none|tip`, so every ACP agent was excluded by declaration shape rather than by capability. The bridge also dropped `promptMode` and discarded current-mode updates as noise. Reproduced independently by the slop-cop triage at base `43e3fc519` ([report](https://get-bb.github.io/reports/issues/3019.html)); fixes #3019.

## What changed

- `AcpAgentDefinition` gains `supportsPlan` (mirroring `supportsManualCompaction`), threaded through the `customAgents` setting and mapped to `composerActions: ["plan"]` in the declaration; `acp-omp` declares it.
- The ACP bridge now reads the session modes agents advertise (`session/new`, `session/load`, `session/fork` results and `current_mode_update` notifications) and, when the agent advertises a plan mode, drives it with `session/set_mode` on plan turns, strips the `/plan` command mention from the prompt, and returns the session to its initial mode afterward; agents that report no modes keep byte-identical text passthrough.
- Session rewind stays undeclarable for ACP agents: ACP v1 `session/fork` is tip-only with no fork-point selector and reports no per-turn checkpoints, so no shipped or custom ACP agent can honestly declare checkpoint rewind today.

## How you verified

`pnpm exec turbo run typecheck test lint --continue` plus `pnpm format:check`. provider-bridge-acp typecheck clean, all 317 tests pass, including the new ones: declaration mapping (`composerActions: ["plan"]` only for agents declaring it), wire modes/`current_mode_update` parsing, and bridge plan-turn translation (`set_mode "plan"` precedes `session/prompt` with the mention stripped; a no-modes agent gets no `set_mode` and untouched text; the mode resets to the initial mode after the turn). Server suites that consume provider declarations pass solo (first-party-provider-plugins, plugin-install, plugin-update). Remaining failures are pre-existing on main `f6868ad0c`, each verified by stash-rerun on a clean tree: secret-storage concurrent-creators, server install-machine-script (macOS `Abort trap: 6` on the spawned host-daemon), host-workspace workspace-diff/provisioning, and 183 files flagged by `format:check` from the pinned oxfmt 0.64.0 at head (formatter default drift); the new code matches the dominant committed style of the files it touches.

Fixes #3019

> AGENT GENERATED
