### PR TITLE
Add @alanagoyal to contributor allow list

### DIFF
--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -59,3 +59,4 @@ wy3z
 yazydzhi
 ymichael
 kravtsovd
+alanagoyal


### PR DESCRIPTION
## Human comments

## What was wrong

GitHub user `alanagoyal` was not in the persistent contributor allow list, so the PR approval gate would not treat contributions from their fork as approved.

## What changed

Added `alanagoyal` to `.github/APPROVED_CONTRIBUTORS`. This is a policy-only change with no host daemon wire, CLI, guide, or documentation impact.

## How you verified

- Confirmed the GitHub account and referenced fork branch exist.
- Ran `git diff --check`.
- Checked the contributor list for case-insensitive duplicates.

> AGENT GENERATED
