### PR TITLE
Prevent localStorage quota crashes

### DIFF
--- a/apps/app/src/components/secondary-panel/SidebarSplitContainer.test.tsx
+++ b/apps/app/src/components/secondary-panel/SidebarSplitContainer.test.tsx
@@ -1240,4 +1240,34 @@ describe("SidebarSplitContainer", () => {
       setItem.mock.calls.filter(([key]) => key === storageKey),
     ).toHaveLength(0);
   });
+
+  it("keeps a changed layout in memory when localStorage quota is exhausted", () => {
+    const storageKey = sidebarSplitStorageKey(PANEL_STATE_ID);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    renderContainer({
+      renderPane: ({ group, onMoveActiveTabToSide }) => (
+        <button type="button" onClick={() => onMoveActiveTabToSide?.("right")}>
+          Split {group.activeTabId}
+        </button>
+      ),
+    });
+
+    const setItem = vi
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation((key) => {
+        if (key === storageKey) {
+          throw new DOMException("quota", "QuotaExceededError");
+        }
+      });
+
+    expect(() =>
+      fireEvent.click(screen.getByRole("button", { name: "Split tab-a" })),
+    ).not.toThrow();
+
+    expect(document.querySelectorAll("[data-split-pane-id]")).toHaveLength(2);
+    expect(window.localStorage.getItem(storageKey)).toBeNull();
+    expect(warn).toHaveBeenCalledOnce();
+    expect(setItem).toHaveBeenCalledWith(storageKey, expect.any(String));
+  });
 });

--- a/apps/app/src/components/secondary-panel/SidebarSplitContainer.tsx
+++ b/apps/app/src/components/secondary-panel/SidebarSplitContainer.tsx
@@ -226,13 +226,20 @@ export function SidebarSplitContainer({
     ) {
       return;
     }
-    if (persistedValue === null) {
-      window.localStorage.removeItem(storageKey);
-    } else {
-      window.localStorage.setItem(storageKey, persistedValue);
+    try {
+      if (persistedValue === null) {
+        window.localStorage.removeItem(storageKey);
+      } else {
+        window.localStorage.setItem(storageKey, persistedValue);
+      }
+      lastPersistedValueRef.current = { storageKey, value: persistedValue };
+    } catch (error) {
+      console.warn(
+        `[secondary-panel] could not persist split layout for ${panelStateId}; keeping it in memory only`,
+        error,
+      );
     }
-    lastPersistedValueRef.current = { storageKey, value: persistedValue };
-  }, [activeTabId, availableTabIds, state, storageKey]);
+  }, [activeTabId, availableTabIds, panelStateId, state, storageKey]);
 
   const commitState = useCallback(
     (

--- a/apps/app/src/lib/last-known-cache.test.ts
+++ b/apps/app/src/lib/last-known-cache.test.ts
@@ -90,4 +90,48 @@ describe("createLastKnownCache", () => {
     expect(window.localStorage.getItem("bb.other.0.keep")).toBe("1");
     expect(cache.read(cache.key("new"))).toEqual({ models: ["b"] });
   });
+
+  it("prunes obsolete cache families on first access", () => {
+    window.localStorage.setItem(
+      "bb.test-legacy.2.scope-a",
+      JSON.stringify({ models: ["old"] }),
+    );
+    window.localStorage.setItem(
+      "bb.test-legacy.2.scope-b",
+      JSON.stringify({ models: ["old"] }),
+    );
+    const cache = createLastKnownCache({
+      prefix: "bb.test",
+      version: "1",
+      schema,
+      obsoletePrefixes: ["bb.test-legacy"],
+    });
+
+    cache.read(cache.key("current"));
+
+    expect(window.localStorage.getItem("bb.test-legacy.2.scope-a")).toBeNull();
+    expect(window.localStorage.getItem("bb.test-legacy.2.scope-b")).toBeNull();
+  });
+
+  it("bounds scoped entries while retaining the key being accessed", () => {
+    const cache = createLastKnownCache({
+      prefix: "bb.test",
+      version: "1",
+      schema,
+      maxEntries: 3,
+    });
+    const firstKey = cache.key("a");
+    const lastKey = cache.key("d");
+    const keys = [firstKey, cache.key("b"), cache.key("c"), lastKey];
+    for (const key of keys) cache.write(key, { models: [key] });
+
+    expect(
+      keys.filter((key) => window.localStorage.getItem(key) !== null),
+    ).toHaveLength(3);
+    expect(cache.read(firstKey)).toBeNull();
+    expect(cache.read(lastKey)).toEqual({ models: [lastKey] });
+    expect(
+      keys.filter((key) => window.localStorage.getItem(key) !== null),
+    ).toHaveLength(3);
+  });
 });

--- a/apps/app/src/lib/last-known-cache.ts
+++ b/apps/app/src/lib/last-known-cache.ts
@@ -12,10 +12,14 @@ export function createLastKnownCache<T>({
   prefix,
   version,
   schema,
+  maxEntries,
+  obsoletePrefixes = [],
 }: {
   prefix: string;
   version: string;
   schema: z.ZodType<T>;
+  maxEntries?: number;
+  obsoletePrefixes?: readonly string[];
 }): LastKnownCache<T> {
   const storage = createJsonLocalStorage<unknown>();
   const zeroScopeKey = `${prefix}.${version}`;
@@ -30,14 +34,55 @@ export function createLastKnownCache<T>({
         const stored = window.localStorage.key(index);
         if (
           stored !== null &&
-          stored.startsWith(`${prefix}.`) &&
-          stored !== zeroScopeKey &&
-          !stored.startsWith(versionPrefix)
+          ((stored.startsWith(`${prefix}.`) &&
+            stored !== zeroScopeKey &&
+            !stored.startsWith(versionPrefix)) ||
+            obsoletePrefixes.some(
+              (obsoletePrefix) =>
+                stored === obsoletePrefix ||
+                stored.startsWith(`${obsoletePrefix}.`),
+            ))
         ) {
           stale.push(stored);
         }
       }
       for (const key of stale) window.localStorage.removeItem(key);
+    } catch {}
+  };
+  const pruneExcessEntries = (
+    currentKey: string,
+    reservesCurrentKey: boolean,
+  ) => {
+    if (maxEntries === undefined) return;
+    try {
+      const otherKeys: string[] = [];
+      let hasCurrentKey = false;
+      for (let index = 0; index < window.localStorage.length; index += 1) {
+        const stored = window.localStorage.key(index);
+        if (stored === currentKey) {
+          hasCurrentKey = true;
+          continue;
+        }
+        if (
+          stored !== null &&
+          (stored === zeroScopeKey || stored.startsWith(versionPrefix))
+        ) {
+          otherKeys.push(stored);
+        }
+      }
+      const entryLimit = Math.max(1, Math.floor(maxEntries));
+      const retainedOtherEntries = Math.max(
+        0,
+        entryLimit - (reservesCurrentKey || hasCurrentKey ? 1 : 0),
+      );
+      for (
+        let index = 0;
+        index < otherKeys.length - retainedOtherEntries;
+        index += 1
+      ) {
+        const key = otherKeys[index];
+        if (key !== undefined) window.localStorage.removeItem(key);
+      }
     } catch {}
   };
   return {
@@ -46,6 +91,7 @@ export function createLastKnownCache<T>({
     read: (key) => {
       try {
         pruneOtherVersions();
+        pruneExcessEntries(key, false);
         const stored = storage.getItem(key, null);
         if (stored === null) return null;
         const parsed = schema.safeParse(stored);
@@ -56,6 +102,7 @@ export function createLastKnownCache<T>({
     },
     write: (key, value) => {
       pruneOtherVersions();
+      pruneExcessEntries(key, true);
       try {
         storage.setItem(key, value);
       } catch {}

--- a/apps/app/src/lib/model-catalog-cache.ts
+++ b/apps/app/src/lib/model-catalog-cache.ts
@@ -11,6 +11,8 @@ const modelCatalogCache = createLastKnownCache({
   prefix: "bb.model-catalog",
   version: "1",
   schema: cachedModelCatalogSchema,
+  maxEntries: 8,
+  obsoletePrefixes: ["bb.claude-model-catalog"],
 });
 
 export function modelCatalogCacheKey({

--- a/apps/app/src/lib/provider-list-cache.ts
+++ b/apps/app/src/lib/provider-list-cache.ts
@@ -6,6 +6,7 @@ const providerListCache = createLastKnownCache({
   prefix: "bb.provider-list",
   version: "2",
   schema: z.array(providerInfoSchema),
+  maxEntries: 16,
 });
 
 export function providerListCacheKey({


### PR DESCRIPTION
## Human comments

## What was wrong

Last-known model and provider caches created one localStorage entry for every environment, host, and provider scope without bounding the number retained. The earlier Claude-only cache namespace was also abandoned without being removed when the generalized model cache replaced it. A real affected profile had accumulated 5.6 MB across 2,011 entries, with model/provider caches accounting for about 4.86 MB. Once the origin quota was exhausted, the secondary-panel split-layout effect allowed `QuotaExceededError` to escape and disrupt rendering even though the layout is only a best-effort cache.

## What changed

The last-known cache primitive can now prune obsolete cache namespaces and bound scoped entries while retaining the key currently being read or written. Model catalogs retain at most eight scopes, provider lists retain at most sixteen, and the obsolete `bb.claude-model-catalog` namespace is removed on first model-cache access. Secondary-panel split layouts now remain usable in memory when browser storage rejects a write, and failed writes are not marked as persisted so a later state change can retry. This is client-only; there are no wire, CLI, or Plugin SDK changes.

## How you verified

- Added regression coverage for obsolete-family pruning and bounded scoped caches; the new tests fail against the previous unbounded behavior.
- Added a `QuotaExceededError` regression proving a changed panel layout remains usable in memory without throwing.
- `pnpm exec turbo run test --filter=@bb/app --force` — 478 files passed, 3,863 tests passed, 4 skipped.
- `pnpm exec turbo run typecheck --filter=@bb/app`.
- `pnpm exec turbo run lint --filter=@bb/app` — no errors; 182 existing warnings.
- `git diff --check`.

> AGENT GENERATED
