### PR TITLE
Hide thread search by default behind a sidebar More row

### DIFF
--- a/apps/app/src/components/plugin/PluginNavSidebarItems.test.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.test.tsx
@@ -8,12 +8,7 @@ import {
   waitFor,
   within,
 } from "@testing-library/react";
-import {
-  useEffect,
-  useState,
-  type ComponentType,
-  type MouseEvent as ReactMouseEvent,
-} from "react";
+import { useEffect, useState, type ComponentType } from "react";
 import { createStore, Provider } from "jotai";
 import { MemoryRouter, useLocation } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -36,6 +31,7 @@ import {
   type BuiltInSidebarNavEntry,
   ExtensionsNavSidebarItem,
   PluginNavSidebarItems,
+  type SidebarNavActivationModifiers,
 } from "./PluginNavSidebarItems";
 import {
   pluginNavPanelOrderAtom,
@@ -168,7 +164,7 @@ function panelRowNames(
 function builtInEntry(
   id: string,
   title: string,
-  onActivate: (event: ReactMouseEvent<HTMLButtonElement>) => void = vi.fn(),
+  onActivate: (event: SidebarNavActivationModifiers) => void = vi.fn(),
 ): BuiltInSidebarNavEntry {
   return {
     kind: "built-in",
@@ -187,6 +183,39 @@ function customizeRows(): HTMLElement[] {
       .getByRole("list", { name: "Sidebar navigation" })
       .querySelectorAll<HTMLElement>("[data-plugin-nav-customize-item]"),
   );
+}
+
+function visibleRowKeys(): string[] {
+  return Array.from(
+    screen
+      .getByTestId("plugin-nav-sidebar-items")
+      .querySelectorAll("[data-sidebar-navigation-item]"),
+  ).map((row) => row.getAttribute("data-sidebar-navigation-item") ?? "");
+}
+
+function moreTrigger(): HTMLElement {
+  return screen.getByRole("button", { name: "More sidebar navigation" });
+}
+
+async function openMoreMenu(): Promise<HTMLElement[]> {
+  fireEvent.pointerDown(moreTrigger(), { button: 0 });
+  await screen.findByRole("menuitem", { name: "Customize sidebar" });
+  return screen.getAllByRole("menuitem");
+}
+
+async function openCustomizeFromMore(): Promise<HTMLElement> {
+  fireEvent.click(screen.getByRole("menuitem", { name: "Customize sidebar" }));
+  return await screen.findByRole("list", { name: "Sidebar navigation" });
+}
+
+async function openCustomizeFromContextMenu(
+  target: HTMLElement,
+): Promise<HTMLElement> {
+  fireEvent.contextMenu(target);
+  fireEvent.click(
+    await screen.findByRole("menuitem", { name: "Customize sidebar" }),
+  );
+  return await screen.findByRole("list", { name: "Sidebar navigation" });
 }
 
 beforeEach(() => {
@@ -212,18 +241,24 @@ describe("PluginNavSidebarItems", () => {
     expect(screen.queryByText("Plugins")).toBeNull();
   });
 
-  it("shows one plugin with a unified customization entry point and no section label", () => {
+  it("shows one plugin without a More row and reaches Customize from the row menu", async () => {
     registerPanel("docs", "Docs");
     renderSidebarItems();
 
     expect(screen.queryByText("Plugins")).toBeNull();
     expect(panelRowNames(["Docs"])).toEqual(["Docs"]);
+    expect(screen.queryByTestId("sidebar-navigation-more-row")).toBeNull();
     expect(
-      screen.queryByTestId("plugin-nav-sidebar-overflow-toggle"),
+      screen.queryByRole("button", { name: "Customize sidebar navigation" }),
     ).toBeNull();
-    expect(
-      screen.getByRole("button", { name: "Customize sidebar navigation" }),
-    ).not.toBeNull();
+
+    await openCustomizeFromContextMenu(
+      screen.getByRole("button", { name: "Docs" }),
+    );
+
+    expect(customizeRows().map((row) => row.textContent?.trim())).toEqual([
+      "Docs",
+    ]);
   });
 
   it("keeps an accessory-less plugin row unchanged", () => {
@@ -350,7 +385,7 @@ describe("PluginNavSidebarItems", () => {
     ).toBeNull();
   });
 
-  it("uses an in-place customization mode instead of a drawer on compact viewports", () => {
+  it("uses an in-place customization mode from the More drawer on compact viewports", async () => {
     const onCompactCustomizeModeChange = vi.fn();
     renderSidebarItems({
       compactViewport: true,
@@ -361,20 +396,28 @@ describe("PluginNavSidebarItems", () => {
       onCompactCustomizeModeChange,
     });
 
+    expect(visibleRowKeys()).toEqual(["__bb__/new-thread"]);
+    fireEvent.click(moreTrigger());
     fireEvent.click(
-      screen.getByRole("button", { name: "Customize sidebar navigation" }),
+      await screen.findByRole("menuitem", { name: "Customize sidebar" }),
     );
 
     expect(onCompactCustomizeModeChange).toHaveBeenCalledWith(true);
     expect(
       screen.getByTestId("sidebar-navigation-customize-inline"),
     ).not.toBeNull();
-    expect(screen.queryByRole("dialog")).toBeNull();
-    expect(screen.getByRole("button", { name: "Back to sidebar" })).toBe(
-      document.activeElement,
+    expect(
+      screen
+        .queryByRole("list", { name: "Sidebar navigation" })
+        ?.closest("[role=dialog]"),
+    ).toBeFalsy();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Back to sidebar" })).toBe(
+        document.activeElement,
+      ),
     );
     expect(
-      screen.queryByRole("button", { name: "Customize sidebar navigation" }),
+      screen.queryByRole("button", { name: "More sidebar navigation" }),
     ).toBeNull();
     const firstCustomizeRow = customizeRows()[0];
     const firstDragHandle = firstCustomizeRow?.querySelector<HTMLElement>(
@@ -405,20 +448,19 @@ describe("PluginNavSidebarItems", () => {
       screen.queryByTestId("sidebar-navigation-customize-inline"),
     ).toBeNull();
     expect(screen.getByRole("button", { name: "New thread" })).not.toBeNull();
-    expect(
-      screen.getByRole("button", { name: "Customize sidebar navigation" }),
-    ).toBe(document.activeElement);
+    expect(moreTrigger()).toBe(document.activeElement);
   });
 
-  it("keeps compact visibility changes in place and closes the mode when launching", () => {
+  it("keeps compact visibility changes in place and closes the mode when launching", async () => {
     const onActivate = vi.fn();
     const { store } = renderSidebarItems({
       compactViewport: true,
       builtInEntries: [builtInEntry("new-thread", "New thread", onActivate)],
     });
 
-    fireEvent.click(
-      screen.getByRole("button", { name: "Customize sidebar navigation" }),
+    expect(screen.queryByTestId("sidebar-navigation-more-row")).toBeNull();
+    await openCustomizeFromContextMenu(
+      screen.getByRole("button", { name: "New thread" }),
     );
     fireEvent.click(
       screen.getByRole("checkbox", { name: "Show New thread in sidebar" }),
@@ -438,21 +480,86 @@ describe("PluginNavSidebarItems", () => {
     expect(screen.queryByRole("checkbox")).toBeNull();
   });
 
-  it("keeps the desktop customization popover", () => {
+  it("replaces the desktop rows with an inline card until Done", async () => {
+    renderSidebarItems({
+      builtInEntries: [
+        builtInEntry("new-thread", "New thread"),
+        builtInEntry("search-threads", "Search threads"),
+      ],
+    });
+
+    await openCustomizeFromContextMenu(
+      screen.getByRole("button", { name: "New thread" }),
+    );
+
+    await waitFor(() => expect(screen.queryByRole("menu")).toBeNull());
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(
+      screen
+        .getByTestId("plugin-nav-sidebar-items")
+        .getAttribute("data-sidebar-navigation-customize-mode"),
+    ).toBe("true");
+    expect(
+      screen.getByTestId("sidebar-navigation-customize-inline"),
+    ).not.toBeNull();
+    expect(screen.queryByTestId("sidebar-navigation-more-row")).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Back to sidebar" }),
+    ).toBeNull();
+    await waitFor(() =>
+      expect(
+        document.activeElement?.getAttribute(
+          "data-sidebar-navigation-customize-launch",
+        ),
+      ).toBe("__bb__/new-thread"),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Done" }));
+
+    expect(
+      screen.queryByRole("list", { name: "Sidebar navigation" }),
+    ).toBeNull();
+    expect(visibleRowKeys()).toEqual(["__bb__/new-thread"]);
+    expect(moreTrigger()).toBe(document.activeElement);
+  });
+
+  it("closes the inline card on Escape", async () => {
     renderSidebarItems({
       builtInEntries: [builtInEntry("new-thread", "New thread")],
     });
 
-    fireEvent.click(
-      screen.getByRole("button", { name: "Customize sidebar navigation" }),
+    await openCustomizeFromContextMenu(
+      screen.getByRole("button", { name: "New thread" }),
+    );
+    fireEvent.keyDown(
+      screen.getByTestId("sidebar-navigation-customize-inline"),
+      { key: "Escape" },
     );
 
     expect(
-      screen.getByRole("list", { name: "Sidebar navigation" }),
-    ).not.toBeNull();
-    expect(
-      screen.queryByTestId("sidebar-navigation-customize-inline"),
+      screen.queryByRole("list", { name: "Sidebar navigation" }),
     ).toBeNull();
+    expect(screen.getByRole("button", { name: "New thread" })).not.toBeNull();
+  });
+
+  it("hides a built-in row from its context menu", async () => {
+    const { store } = renderSidebarItems({
+      builtInEntries: [
+        builtInEntry("new-thread", "New thread"),
+        builtInEntry("extensions", "Extensions"),
+      ],
+    });
+
+    fireEvent.contextMenu(screen.getByRole("button", { name: "Extensions" }));
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: "Hide from sidebar" }),
+    );
+
+    expect(store.get(pluginNavVisiblePanelKeysAtom)).toEqual([
+      "__bb__/new-thread",
+    ]);
+    expect(visibleRowKeys()).toEqual(["__bb__/new-thread"]);
+    expect(screen.getByTestId("sidebar-navigation-more-row")).not.toBeNull();
   });
 
   it("hides a crashed accessory and retries it after a plugin reload", () => {
@@ -475,35 +582,24 @@ describe("PluginNavSidebarItems", () => {
     expect(screen.queryByText("plugin tasks crashed")).toBeNull();
   });
 
-  it("shows only the first three plugins directly and lists every plugin in the menu", () => {
+  it("shows every plugin directly by default", () => {
     const labels = ["One", "Two", "Three", "Four", "Five", "Six"];
     labels.forEach((label, index) => registerPanel(`plugin-${index}`, label));
 
     renderSidebarItems();
 
-    expect(panelRowNames(labels)).toEqual(labels.slice(0, 3));
-    expect(
-      screen.queryByTestId("plugin-nav-sidebar-overflow-toggle"),
-    ).toBeNull();
-
-    fireEvent.click(
-      screen.getByRole("button", { name: "Customize sidebar navigation" }),
-    );
-    expect(customizeRows().map((row) => row.textContent?.trim())).toEqual(
-      labels,
-    );
-    expect(
-      screen.queryByRole("button", { name: "Four panel options" }),
-    ).toBeNull();
+    expect(panelRowNames(labels)).toEqual(labels);
+    expect(screen.queryByTestId("sidebar-navigation-more-row")).toBeNull();
   });
 
-  it("keeps built-ins visible without letting their order consume plugin slots", () => {
+  it("hides only Search by default and offers it under More", async () => {
     const labels = ["One", "Two", "Three", "Four"];
     labels.forEach((label, index) => registerPanel(`plugin-${index}`, label));
+    const onSearch = vi.fn();
     renderSidebarItems({
       builtInEntries: [
         builtInEntry("new-thread", "New thread"),
-        builtInEntry("search-threads", "Search threads"),
+        builtInEntry("search-threads", "Search threads", onSearch),
       ],
       storedOrder: [
         "plugin-0/main",
@@ -515,19 +611,57 @@ describe("PluginNavSidebarItems", () => {
       ],
     });
 
-    expect(
-      Array.from(
-        screen
-          .getByTestId("plugin-nav-sidebar-items")
-          .querySelectorAll("[data-sidebar-navigation-item]"),
-      ).map((row) => row.getAttribute("data-sidebar-navigation-item")),
-    ).toEqual([
+    expect(visibleRowKeys()).toEqual([
       "plugin-0/main",
       "__bb__/new-thread",
       "plugin-1/main",
-      "__bb__/search-threads",
       "plugin-2/main",
+      "plugin-3/main",
     ]);
+    expect(
+      screen.getByTestId("plugin-nav-sidebar-items").lastElementChild,
+    ).toBe(screen.getByTestId("sidebar-navigation-more-row"));
+
+    const items = await openMoreMenu();
+    expect(items.map((item) => item.textContent?.trim())).toEqual([
+      "Search threads",
+      "Customize sidebar",
+    ]);
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "Search threads" }));
+
+    expect(onSearch).toHaveBeenCalledOnce();
+    expect(onSearch.mock.calls[0]?.[0]).toEqual({
+      metaKey: false,
+      ctrlKey: false,
+    });
+    await waitFor(() => expect(screen.queryByRole("menu")).toBeNull());
+  });
+
+  it("opens a hidden plugin in a split on modifier-click from More", async () => {
+    registerPanel("docs", "Docs");
+    const { store } = renderSidebarItems({
+      splitEnabled: true,
+      storedOrder: ["docs/main"],
+      storedVisibleKeys: [],
+    });
+
+    await openMoreMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Docs" }), {
+      metaKey: true,
+    });
+
+    const layout = store.get(splitLayoutAtom);
+    expect(layout).not.toBeNull();
+    expect(countPanes(layout!.root)).toBe(2);
+    expect(
+      findPaneByContent(layout!.root, {
+        kind: "plugin-panel",
+        pluginId: "docs",
+        panelPath: "main",
+        subPath: "",
+      }),
+    ).not.toBeNull();
   });
 
   it("keeps launch and visibility as distinct targets with a clear row hover state", async () => {
@@ -535,12 +669,9 @@ describe("PluginNavSidebarItems", () => {
     labels.forEach((label, index) => registerPanel(`plugin-${index}`, label));
     const { store, unmount } = renderSidebarItems();
 
-    const trigger = screen.getByRole("button", {
-      name: "Customize sidebar navigation",
-    });
-    expect(trigger.querySelector("svg")).not.toBeNull();
-
-    fireEvent.click(trigger);
+    await openCustomizeFromContextMenu(
+      screen.getByRole("button", { name: "One" }),
+    );
     const choices = screen.getAllByRole("checkbox");
     await waitFor(() =>
       expect(
@@ -553,14 +684,14 @@ describe("PluginNavSidebarItems", () => {
       "checked",
       "checked",
       "checked",
-      "unchecked",
+      "checked",
     ]);
     expect(
       document.querySelectorAll("[data-plugin-nav-customize-drag-handle]"),
     ).toHaveLength(4);
-    expect(customizeRows()[0]?.classList.contains("hover:bg-state-hover")).toBe(
-      true,
-    );
+    expect(
+      customizeRows()[0]?.classList.contains("hover:bg-sidebar-accent"),
+    ).toBe(true);
 
     fireEvent.click(choices[0]!);
     expect(
@@ -569,38 +700,35 @@ describe("PluginNavSidebarItems", () => {
     expect(store.get(pluginNavVisiblePanelKeysAtom)).toEqual([
       "plugin-1/main",
       "plugin-2/main",
+      "plugin-3/main",
     ]);
-    expect(panelRowNames(labels)).toEqual(["Two", "Three"]);
+    fireEvent.click(screen.getByRole("button", { name: "Done" }));
+    expect(panelRowNames(labels)).toEqual(["Two", "Three", "Four"]);
+    expect(screen.getByTestId("sidebar-navigation-more-row")).not.toBeNull();
 
     unmount();
     renderSidebarItems();
-    expect(panelRowNames(labels)).toEqual(["Two", "Three"]);
-    fireEvent.click(
-      screen.getByRole("button", { name: "Customize sidebar navigation" }),
-    );
+    expect(panelRowNames(labels)).toEqual(["Two", "Three", "Four"]);
+    expect(screen.queryByRole("button", { name: "One" })).toBeNull();
 
-    const hiddenRow = document.querySelector<HTMLElement>(
-      '[data-plugin-nav-customize-item="plugin-0/main"]',
-    );
-    expect(hiddenRow).not.toBeNull();
-    fireEvent.click(
-      within(hiddenRow as HTMLElement).getByRole("button", { name: "One" }),
-    );
+    const items = await openMoreMenu();
+    expect(items.map((item) => item.textContent?.trim())).toEqual([
+      "One",
+      "Customize sidebar",
+    ]);
+    fireEvent.click(screen.getByRole("menuitem", { name: "One" }));
 
     expect(screen.getByTestId("location-path").textContent).toBe(
       getPluginPanelRoutePath({ pluginId: "plugin-0", path: "main" }),
     );
-    await waitFor(() =>
-      expect(
-        screen.queryByRole("list", { name: "Sidebar navigation" }),
-      ).toBeNull(),
-    );
+    await waitFor(() => expect(screen.queryByRole("menu")).toBeNull());
+    expect(panelRowNames(labels)).toEqual(["Two", "Three", "Four"]);
   });
 
   it("seeds newly introduced built-ins without overriding existing plugin visibility", () => {
     registerPanel("docs", "Docs");
     registerPanel("tasks", "Tasks");
-    renderSidebarItems({
+    const { store } = renderSidebarItems({
       builtInEntries: [
         builtInEntry("new-thread", "New thread"),
         builtInEntry("search-threads", "Search threads"),
@@ -609,48 +737,80 @@ describe("PluginNavSidebarItems", () => {
       storedVisibleKeys: ["docs/main"],
     });
 
-    expect(
-      Array.from(
-        screen
-          .getByTestId("plugin-nav-sidebar-items")
-          .querySelectorAll("[data-sidebar-navigation-item]"),
-      ).map((row) => row.getAttribute("data-sidebar-navigation-item")),
-    ).toEqual(["__bb__/new-thread", "__bb__/search-threads", "docs/main"]);
+    expect(visibleRowKeys()).toEqual(["__bb__/new-thread", "docs/main"]);
+    expect(store.get(pluginNavVisiblePanelKeysAtom)).toEqual([
+      "__bb__/new-thread",
+      "docs/main",
+    ]);
   });
 
-  it("keeps Customize on the New thread row without stranding it when the row is hidden", () => {
+  it("shows a newly installed plugin without touching existing choices", () => {
+    registerPanel("docs", "Docs");
+    registerPanel("tasks", "Tasks");
+    const { store } = renderSidebarItems({
+      builtInEntries: [builtInEntry("new-thread", "New thread")],
+      storedOrder: ["__bb__/new-thread", "docs/main"],
+      storedVisibleKeys: ["__bb__/new-thread"],
+    });
+
+    expect(visibleRowKeys()).toEqual(["__bb__/new-thread", "tasks/main"]);
+    expect(store.get(pluginNavVisiblePanelKeysAtom)).toEqual([
+      "tasks/main",
+      "__bb__/new-thread",
+    ]);
+    expect(store.get(pluginNavPanelOrderAtom)).toEqual([
+      "__bb__/new-thread",
+      "docs/main",
+      "tasks/main",
+    ]);
+  });
+
+  it("respects a stored choice to keep Search visible", () => {
     renderSidebarItems({
       builtInEntries: [
         builtInEntry("new-thread", "New thread"),
         builtInEntry("search-threads", "Search threads"),
       ],
+      storedOrder: ["__bb__/new-thread", "__bb__/search-threads"],
+      storedVisibleKeys: ["__bb__/new-thread", "__bb__/search-threads"],
     });
 
-    const trigger = screen.getByRole("button", {
-      name: "Customize sidebar navigation",
-    });
-    expect(
-      trigger
-        .closest("[data-sidebar-navigation-item]")
-        ?.getAttribute("data-sidebar-navigation-item"),
-    ).toBe("__bb__/new-thread");
+    expect(visibleRowKeys()).toEqual([
+      "__bb__/new-thread",
+      "__bb__/search-threads",
+    ]);
+    expect(screen.queryByTestId("sidebar-navigation-more-row")).toBeNull();
+  });
 
-    fireEvent.click(trigger);
+  it("shows More only while something is hidden", async () => {
+    renderSidebarItems({
+      builtInEntries: [builtInEntry("new-thread", "New thread")],
+    });
+
+    expect(screen.queryByTestId("sidebar-navigation-more-row")).toBeNull();
+    await openCustomizeFromContextMenu(
+      screen.getByRole("button", { name: "New thread" }),
+    );
     fireEvent.click(
       screen.getByRole("checkbox", { name: "Show New thread in sidebar" }),
     );
+    fireEvent.click(screen.getByRole("button", { name: "Done" }));
 
-    expect(
-      screen.getByRole("list", { name: "Sidebar navigation" }),
-    ).not.toBeNull();
-    expect(
-      screen
-        .getByRole("button", { name: "Customize sidebar navigation" })
-        .closest("[data-sidebar-navigation-item]"),
-    ).toBeNull();
+    expect(visibleRowKeys()).toEqual([]);
+    expect(screen.getByTestId("sidebar-navigation-more-row")).not.toBeNull();
+
+    await openMoreMenu();
+    await openCustomizeFromMore();
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: "Show New thread in sidebar" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Done" }));
+
+    expect(visibleRowKeys()).toEqual(["__bb__/new-thread"]);
+    expect(screen.queryByTestId("sidebar-navigation-more-row")).toBeNull();
   });
 
-  it("applies one persisted mixed order to direct rows and the menu", () => {
+  it("applies one persisted mixed order to direct rows and the menu", async () => {
     const labels = ["One", "Two", "Three", "Four"];
     labels.forEach((label, index) => registerPanel(`plugin-${index}`, label));
     const newThread = builtInEntry("new-thread", "New thread");
@@ -673,22 +833,20 @@ describe("PluginNavSidebarItems", () => {
       ],
     });
 
-    expect(
-      Array.from(
-        screen
-          .getByTestId("plugin-nav-sidebar-items")
-          .querySelectorAll("[data-sidebar-navigation-item]"),
-      ).map((row) => row.getAttribute("data-sidebar-navigation-item")),
-    ).toEqual([
+    expect(visibleRowKeys()).toEqual([
       "plugin-3/main",
       "__bb__/search-threads",
       "__bb__/new-thread",
       "plugin-0/main",
     ]);
 
-    fireEvent.click(
-      screen.getByRole("button", { name: "Customize sidebar navigation" }),
-    );
+    const items = await openMoreMenu();
+    expect(items.map((item) => item.textContent?.trim())).toEqual([
+      "Two",
+      "Three",
+      "Customize sidebar",
+    ]);
+    await openCustomizeFromMore();
     expect(customizeRows().map((row) => row.textContent?.trim())).toEqual([
       "Four",
       "Search threads",
@@ -717,8 +875,8 @@ describe("PluginNavSidebarItems", () => {
       builtInEntries: [builtInEntry("new-thread", "New thread", onActivate)],
     });
 
-    fireEvent.click(
-      screen.getByRole("button", { name: "Customize sidebar navigation" }),
+    await openCustomizeFromContextMenu(
+      screen.getByRole("button", { name: "New thread" }),
     );
     const row = customizeRows()[0];
     expect(row).toBeDefined();
@@ -740,8 +898,8 @@ describe("PluginNavSidebarItems", () => {
       builtInEntries: [builtInEntry("new-thread", "New thread", onActivate)],
     });
 
-    fireEvent.click(
-      screen.getByRole("button", { name: "Customize sidebar navigation" }),
+    await openCustomizeFromContextMenu(
+      screen.getByRole("button", { name: "New thread" }),
     );
     const row = customizeRows()[0];
     expect(row).toBeDefined();
@@ -763,8 +921,8 @@ describe("PluginNavSidebarItems", () => {
     registerPanel("docs", "Docs");
     const { store } = renderSidebarItems({ splitEnabled: true });
 
-    fireEvent.click(
-      screen.getByRole("button", { name: "Customize sidebar navigation" }),
+    await openCustomizeFromContextMenu(
+      screen.getByRole("button", { name: "Docs" }),
     );
     const row = customizeRows()[0];
     expect(row).toBeDefined();

--- a/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
@@ -26,12 +26,14 @@ import {
   ContextMenu,
   ContextMenuContent,
   ContextMenuItem,
+  ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@bb/shared-ui/context-menu";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@bb/shared-ui/dropdown-menu";
 import {
@@ -41,11 +43,6 @@ import {
 } from "@bb/shared-ui/coarse-pointer-sizing";
 import { CHROME_SECTION_LABEL_CLASS } from "@bb/shared-ui/chrome-style-tokens";
 import { useIsCompactViewport } from "@bb/shared-ui/hooks/use-compact-viewport";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@bb/shared-ui/popover";
 import { PluginIcon } from "@/components/plugin/PluginIcon";
 import { PluginSlotMount } from "@/components/plugin/PluginSlotMount";
 import { PROJECT_LIST_ACTION_BUTTON_CLASS } from "@/components/sidebar/ProjectList";
@@ -83,13 +80,27 @@ import {
 } from "./pluginNavSidebarAtoms";
 import {
   arrangePluginNavPanelPreferences,
-  BUILT_IN_SIDEBAR_NAVIGATION_KEYS,
+  DEFAULT_HIDDEN_SIDEBAR_NAVIGATION_KEYS,
   getPluginNavPanelKey,
   togglePluginNavPanelVisibility,
 } from "./pluginNavSidebarOrder";
 import { haveSameOrder, reorderStoredOrder } from "@/lib/stored-order";
 
-const PLUGIN_NAV_VISIBLE_LIMIT = 3;
+const MORE_TRIGGER_TEST_ID = "sidebar-navigation-more-trigger";
+
+export interface SidebarNavActivationModifiers {
+  metaKey: boolean;
+  ctrlKey: boolean;
+}
+
+function CustomizeMenuItemContent() {
+  return (
+    <>
+      <HugeiconsIcon icon={FilterHorizontalIcon} aria-hidden="true" />
+      Customize sidebar
+    </>
+  );
+}
 
 type PluginSidebarNavRow = {
   kind: "plugin";
@@ -108,14 +119,12 @@ export interface BuiltInSidebarNavEntry {
   icon: ReactNode;
   content: ReactNode;
   disabled?: boolean;
-  onActivate: (event: ReactMouseEvent<HTMLButtonElement>) => void;
+  onActivate: (event: SidebarNavActivationModifiers) => void;
 }
 
 type SidebarNavRow = PluginSidebarNavRow | BuiltInSidebarNavEntry;
 
-function isPluginSidebarNavRow(
-  row: SidebarNavRow,
-): row is PluginSidebarNavRow {
+function isPluginSidebarNavRow(row: SidebarNavRow): row is PluginSidebarNavRow {
   return row.kind === "plugin";
 }
 
@@ -140,9 +149,7 @@ export function PluginNavSidebarItems(props: {
             ? "__bb__"
             : chrome.pluginId,
         id:
-          chrome.pluginId === AUTOMATIONS_PLUGIN_ID
-            ? "automations"
-            : chrome.id,
+          chrome.pluginId === AUTOMATIONS_PLUGIN_ID ? "automations" : chrome.id,
         title: chrome.title,
         chrome,
         panel,
@@ -167,8 +174,7 @@ export function PluginNavSidebarItems(props: {
         : { compactCustomizeMode: props.compactCustomizeMode })}
       {...(props.onCompactCustomizeModeChange
         ? {
-            onCompactCustomizeModeChange:
-              props.onCompactCustomizeModeChange,
+            onCompactCustomizeModeChange: props.onCompactCustomizeModeChange,
           }
         : {})}
       {...(props.onNavigate ? { onNavigate: props.onNavigate } : {})}
@@ -216,22 +222,24 @@ function PluginNavSidebarItemList({
         onCompactCustomizeModeChange?.(isOpen);
       }
     },
-    [
-      compactCustomizeMode,
-      isCompactViewport,
-      onCompactCustomizeModeChange,
-    ],
-  );
-  const defaultVisibleKeys = useMemo(
-    () =>
-      leadingOrderKeys.filter((key) =>
-        rows.some((row) => getPluginNavPanelKey(row) === key),
-      ),
-    [leadingOrderKeys, rows],
+    [compactCustomizeMode, isCompactViewport, onCompactCustomizeModeChange],
   );
   const newLeadingKeys = useMemo(
     () => leadingOrderKeys.filter((key) => !storedOrder.includes(key)),
     [leadingOrderKeys, storedOrder],
+  );
+  const newVisibleKeys = useMemo(
+    () =>
+      rows
+        .map(getPluginNavPanelKey)
+        .filter(
+          (key) =>
+            !storedOrder.includes(key) &&
+            !DEFAULT_HIDDEN_SIDEBAR_NAVIGATION_KEYS.some(
+              (hiddenKey) => hiddenKey === key,
+            ),
+        ),
+    [rows, storedOrder],
   );
   const {
     ordered,
@@ -248,19 +256,17 @@ function PluginNavSidebarItemList({
             ? storedOrder
             : [...newLeadingKeys, ...storedOrder],
         storedVisibleKeys:
-          storedVisibleKeys === null || newLeadingKeys.length === 0
+          storedVisibleKeys === null || newVisibleKeys.length === 0
             ? storedVisibleKeys
-            : [...newLeadingKeys, ...storedVisibleKeys],
-        defaultVisibleKeys,
-        defaultVisibleCount: PLUGIN_NAV_VISIBLE_LIMIT,
+            : [...newVisibleKeys, ...storedVisibleKeys],
+        defaultHiddenKeys: DEFAULT_HIDDEN_SIDEBAR_NAVIGATION_KEYS,
       }),
-    [
-      defaultVisibleKeys,
-      newLeadingKeys,
-      rows,
-      storedOrder,
-      storedVisibleKeys,
-    ],
+    [newLeadingKeys, newVisibleKeys, rows, storedOrder, storedVisibleKeys],
+  );
+  const hidden = useMemo(
+    () =>
+      ordered.filter((row) => !visibleKeys.includes(getPluginNavPanelKey(row))),
+    [ordered, visibleKeys],
   );
 
   useEffect(() => {
@@ -343,15 +349,20 @@ function PluginNavSidebarItemList({
   );
 
   const reorderDisabled = ordered.length < 2;
+  const openCustomize = useCallback(
+    () => setIsCustomizeOpen(true),
+    [setIsCustomizeOpen],
+  );
   const rowProps = {
     onNavigate,
     pathname: location.pathname,
     splitEnabled,
     onHide: (key: string) => setPanelVisible(key, false),
+    onCustomize: openCustomize,
   };
 
   const handleActivate = useCallback(
-    (row: SidebarNavRow, event: ReactMouseEvent<HTMLButtonElement>) => {
+    (row: SidebarNavRow, event: SidebarNavActivationModifiers) => {
       if (!isPluginSidebarNavRow(row)) {
         row.onActivate(event);
         return;
@@ -385,25 +396,27 @@ function PluginNavSidebarItemList({
     if (isCustomizeOpen || !restoreCustomizeTriggerFocusRef.current) return;
     restoreCustomizeTriggerFocusRef.current = false;
     containerRef.current
-      ?.querySelector<HTMLElement>(
-        '[data-testid="sidebar-navigation-customize-trigger"]',
-      )
+      ?.querySelector<HTMLElement>(`[data-testid="${MORE_TRIGGER_TEST_ID}"]`)
       ?.focus();
   }, [isCustomizeOpen]);
 
-  if (isCompactViewport && isCustomizeOpen) {
+  if (isCustomizeOpen) {
     return (
       <div
         ref={containerRef}
-        className="flex min-h-0 flex-1 flex-col px-2 py-2 group-data-[collapsible=icon]:hidden"
+        className={cn(
+          "px-2 py-2 group-data-[collapsible=icon]:hidden",
+          isCompactViewport ? "flex min-h-0 flex-1 flex-col" : "shrink-0",
+        )}
         data-testid="plugin-nav-sidebar-items"
         data-sidebar-navigation-customize-mode="true"
       >
         <SidebarNavigationInlineCustomizeMode
+          variant={isCompactViewport ? "compact" : "card"}
           rows={ordered}
           visibleKeys={visibleKeys}
           onActivate={handleActivate}
-          onBack={() => {
+          onDone={() => {
             restoreCustomizeTriggerFocusRef.current = true;
             setIsCustomizeOpen(false);
           }}
@@ -422,19 +435,6 @@ function PluginNavSidebarItemList({
       data-testid="plugin-nav-sidebar-items"
       onClickCapture={onClickCapture}
     >
-      {!visibleKeys.includes(BUILT_IN_SIDEBAR_NAVIGATION_KEYS.newThread) ? (
-        <div className="flex min-w-0 items-center justify-end">
-          <SidebarNavigationCustomizeMenu
-            isOpen={isCustomizeOpen}
-            rows={ordered}
-            visibleKeys={visibleKeys}
-            onActivate={handleActivate}
-            onDragEnd={handleCustomizeDragEnd}
-            onOpenChange={setIsCustomizeOpen}
-            onVisibleChange={setPanelVisible}
-          />
-        </div>
-      ) : null}
       <DndContext {...dndContextProps}>
         <SortableContext
           items={visibleKeys}
@@ -449,187 +449,264 @@ function PluginNavSidebarItemList({
                 {...rowProps}
               />
             ) : (
-              <div
+              <BuiltInSidebarNavRow
                 key={getPluginNavPanelKey(row)}
-                data-sidebar-navigation-item={getPluginNavPanelKey(row)}
-              >
-                {getPluginNavPanelKey(row) ===
-                BUILT_IN_SIDEBAR_NAVIGATION_KEYS.newThread ? (
-                  <div
-                    className="flex min-w-0 items-center gap-0.5"
-                    data-sidebar-navigation-primary-row
-                  >
-                    <div className="min-w-0 flex-1">{row.content}</div>
-                    <SidebarNavigationCustomizeMenu
-                      isOpen={isCustomizeOpen}
-                      rows={ordered}
-                      visibleKeys={visibleKeys}
-                      onActivate={handleActivate}
-                      onDragEnd={handleCustomizeDragEnd}
-                      onOpenChange={setIsCustomizeOpen}
-                      onVisibleChange={setPanelVisible}
-                    />
-                  </div>
-                ) : (
-                  row.content
-                )}
-              </div>
+                row={row}
+                onHide={rowProps.onHide}
+                onCustomize={openCustomize}
+              />
             ),
           )}
         </SortableContext>
       </DndContext>
+      {hidden.length > 0 ? (
+        <SidebarNavigationMoreRow
+          hiddenRows={hidden}
+          onActivate={handleActivate}
+          onCustomize={openCustomize}
+        />
+      ) : null}
     </div>
+  );
+}
+
+function SidebarNavigationMoreRow({
+  hiddenRows,
+  onActivate,
+  onCustomize,
+}: {
+  hiddenRows: readonly SidebarNavRow[];
+  onActivate: (
+    row: SidebarNavRow,
+    event: SidebarNavActivationModifiers,
+  ) => void;
+  onCustomize: () => void;
+}) {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const modifiersRef = useRef<SidebarNavActivationModifiers>({
+    metaKey: false,
+    ctrlKey: false,
+  });
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <div data-testid="sidebar-navigation-more-row">
+          <DropdownMenu open={isMenuOpen} onOpenChange={setIsMenuOpen}>
+            <DropdownMenuTrigger asChild>
+              <Button
+                type="button"
+                size="sm"
+                variant="ghost"
+                aria-label="More sidebar navigation"
+                className={cn(
+                  PROJECT_LIST_ACTION_BUTTON_CLASS,
+                  "w-full",
+                  isMenuOpen && "bg-sidebar-accent text-sidebar-foreground",
+                )}
+                data-testid={MORE_TRIGGER_TEST_ID}
+              >
+                <Icon name="MoreHorizontal" aria-hidden="true" />
+                <span className="min-w-0 truncate text-left">More</span>
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              side="right"
+              align="start"
+              sideOffset={8}
+              mobileTitle="More"
+            >
+              {hiddenRows.map((row) => (
+                <DropdownMenuItem
+                  key={getPluginNavPanelKey(row)}
+                  disabled={!isPluginSidebarNavRow(row) && row.disabled}
+                  data-sidebar-navigation-more-item={getPluginNavPanelKey(row)}
+                  onClick={(event) => {
+                    modifiersRef.current = {
+                      metaKey: event.metaKey,
+                      ctrlKey: event.ctrlKey,
+                    };
+                  }}
+                  onSelect={() => {
+                    const modifiers = modifiersRef.current;
+                    modifiersRef.current = { metaKey: false, ctrlKey: false };
+                    onActivate(row, modifiers);
+                  }}
+                >
+                  <span className="flex size-4 shrink-0 items-center justify-center">
+                    {isPluginSidebarNavRow(row) ? (
+                      <PluginIcon
+                        pluginId={row.chrome.pluginId}
+                        icon={row.chrome.icon}
+                      />
+                    ) : (
+                      row.icon
+                    )}
+                  </span>
+                  <span className="min-w-0 flex-1 truncate">{row.title}</span>
+                </DropdownMenuItem>
+              ))}
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                data-testid="sidebar-navigation-customize-trigger"
+                onSelect={onCustomize}
+              >
+                <CustomizeMenuItemContent />
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </ContextMenuTrigger>
+      <ContextMenuContent aria-label="More sidebar navigation options">
+        <ContextMenuItem onSelect={onCustomize}>
+          <CustomizeMenuItemContent />
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+}
+
+function BuiltInSidebarNavRow({
+  row,
+  onHide,
+  onCustomize,
+}: {
+  row: BuiltInSidebarNavEntry;
+  onHide: (key: string) => void;
+  onCustomize: () => void;
+}) {
+  const rowKey = getPluginNavPanelKey(row);
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <div data-sidebar-navigation-item={rowKey}>{row.content}</div>
+      </ContextMenuTrigger>
+      <ContextMenuContent aria-label={`${row.title} options`}>
+        <ContextMenuItem onSelect={() => onHide(rowKey)}>
+          <Icon name="EyeOff" aria-hidden="true" />
+          Hide from sidebar
+        </ContextMenuItem>
+        <ContextMenuSeparator />
+        <ContextMenuItem onSelect={onCustomize}>
+          <CustomizeMenuItemContent />
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
   );
 }
 
 function SidebarNavigationInlineCustomizeMode({
   onActivate,
-  onBack,
+  onDone,
   onDragEnd,
   onExit,
   onVisibleChange,
   rows,
+  variant,
   visibleKeys,
 }: {
   onActivate: (
     row: SidebarNavRow,
-    event: ReactMouseEvent<HTMLButtonElement>,
+    event: SidebarNavActivationModifiers,
   ) => void;
-  onBack: () => void;
+  onDone: () => void;
   onDragEnd: (activeKey: string, overKey: string) => void;
   onExit: () => void;
   onVisibleChange: (key: string, visible: boolean) => void;
   rows: readonly SidebarNavRow[];
+  variant: "compact" | "card";
   visibleKeys: readonly string[];
 }) {
-  const backButtonRef = useRef<HTMLButtonElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const doneButtonRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
-    backButtonRef.current?.focus();
-  }, []);
+    if (variant === "compact") {
+      doneButtonRef.current?.focus();
+      return;
+    }
+    containerRef.current
+      ?.querySelector<HTMLElement>("[data-sidebar-navigation-customize-launch]")
+      ?.focus();
+  }, [variant]);
 
-  return (
-    <div
-      className="flex min-h-0 flex-1 flex-col"
-      data-testid="sidebar-navigation-customize-inline"
-    >
-      <div className="flex shrink-0 items-center gap-1">
-        <Button
-          ref={backButtonRef}
-          type="button"
-          variant="ghost"
-          size="icon"
-          aria-label="Back to sidebar"
-          className={cn(
-            COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
-            "shrink-0 text-muted-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-foreground focus-visible:ring-2",
-          )}
-          onClick={onBack}
-        >
-          <Icon name="ChevronLeft" aria-hidden="true" />
-        </Button>
-        <div className={cn("min-w-0 flex-1 px-1", CHROME_SECTION_LABEL_CLASS)}>
-          Customize sidebar
+  const list = (
+    <SidebarNavigationCustomizeList
+      rows={rows}
+      visibleKeys={visibleKeys}
+      surface="sidebar"
+      onActivate={(row, event) => {
+        onActivate(row, event);
+        onExit();
+      }}
+      onDragEnd={onDragEnd}
+      onVisibleChange={onVisibleChange}
+    />
+  );
+
+  if (variant === "compact") {
+    return (
+      <div
+        ref={containerRef}
+        className="flex min-h-0 flex-1 flex-col"
+        data-testid="sidebar-navigation-customize-inline"
+      >
+        <div className="flex shrink-0 items-center gap-1">
+          <Button
+            ref={doneButtonRef}
+            type="button"
+            variant="ghost"
+            size="icon"
+            aria-label="Back to sidebar"
+            className={cn(
+              COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
+              "shrink-0 text-muted-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-foreground focus-visible:ring-2",
+            )}
+            onClick={onDone}
+          >
+            <Icon name="ChevronLeft" aria-hidden="true" />
+          </Button>
+          <div
+            className={cn("min-w-0 flex-1 px-1", CHROME_SECTION_LABEL_CLASS)}
+          >
+            Customize sidebar
+          </div>
         </div>
+        <div className="min-h-0 flex-1 overflow-y-auto pt-1">{list}</div>
       </div>
-      <div className="min-h-0 flex-1 overflow-y-auto pt-1">
-        <SidebarNavigationCustomizeList
-          rows={rows}
-          visibleKeys={visibleKeys}
-          surface="sidebar"
-          onActivate={(row, event) => {
-            onActivate(row, event);
-            onExit();
-          }}
-          onDragEnd={onDragEnd}
-          onVisibleChange={onVisibleChange}
-        />
-      </div>
-    </div>
-  );
-}
-
-function SidebarNavigationCustomizeMenu({
-  isOpen,
-  onActivate,
-  onDragEnd,
-  onOpenChange,
-  onVisibleChange,
-  rows,
-  visibleKeys,
-}: {
-  isOpen: boolean;
-  onActivate: (
-    row: SidebarNavRow,
-    event: ReactMouseEvent<HTMLButtonElement>,
-  ) => void;
-  onDragEnd: (activeKey: string, overKey: string) => void;
-  onOpenChange: (isOpen: boolean) => void;
-  onVisibleChange: (key: string, visible: boolean) => void;
-  rows: readonly SidebarNavRow[];
-  visibleKeys: readonly string[];
-}) {
-  const isCompactViewport = useIsCompactViewport();
-  const contentRef = useRef<HTMLDivElement>(null);
-  const trigger = (
-    <Button
-      type="button"
-      variant="ghost"
-      size="icon"
-      aria-label="Customize sidebar navigation"
-      aria-expanded={isCompactViewport ? isOpen : undefined}
-      className={cn(
-        COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
-        "shrink-0 text-subtle-foreground opacity-60 ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-foreground hover:opacity-100 focus-visible:ring-2 focus-visible:opacity-100 max-md:pointer-coarse:[&_svg]:size-5 data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-foreground data-[state=open]:opacity-100",
-      )}
-      data-testid="sidebar-navigation-customize-trigger"
-      {...(isCompactViewport
-        ? { onClick: () => onOpenChange(true) }
-        : {})}
-    >
-      <HugeiconsIcon icon={FilterHorizontalIcon} aria-hidden="true" />
-    </Button>
-  );
-
-  if (isCompactViewport) {
-    return <span className="inline-flex shrink-0">{trigger}</span>;
+    );
   }
 
   return (
-    <Popover open={isOpen} onOpenChange={onOpenChange}>
-      <span className="inline-flex shrink-0">
-        <PopoverTrigger asChild>{trigger}</PopoverTrigger>
-      </span>
-      <PopoverContent
-        ref={contentRef}
-        side="right"
-        align="start"
-        sideOffset={8}
-        className="w-52 p-2"
-        onOpenAutoFocus={(event) => {
-          event.preventDefault();
-          contentRef.current
-            ?.querySelector<HTMLElement>(
-              "[data-sidebar-navigation-customize-launch]",
-            )
-            ?.focus();
-        }}
-      >
-        <div className={cn("px-2 py-1", CHROME_SECTION_LABEL_CLASS)}>
+    <div
+      ref={containerRef}
+      className="rounded-lg border border-sidebar-border/40 bg-sidebar-accent/40 p-1"
+      data-testid="sidebar-navigation-customize-inline"
+      onKeyDown={(event) => {
+        if (event.key !== "Escape") return;
+        event.preventDefault();
+        onDone();
+      }}
+    >
+      <div className="flex items-center gap-1 pb-1">
+        <div
+          className={cn("min-w-0 flex-1 px-2 py-1", CHROME_SECTION_LABEL_CLASS)}
+        >
           Customize sidebar
         </div>
-        <SidebarNavigationCustomizeList
-          rows={rows}
-          visibleKeys={visibleKeys}
-          onActivate={(row, event) => {
-            onActivate(row, event);
-            onOpenChange(false);
-          }}
-          onDragEnd={onDragEnd}
-          onVisibleChange={onVisibleChange}
-        />
-      </PopoverContent>
-    </Popover>
+        <Button
+          ref={doneButtonRef}
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-6 shrink-0 px-2 text-xs text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent focus-visible:ring-2"
+          onClick={onDone}
+        >
+          Done
+        </Button>
+      </div>
+      {list}
+    </div>
   );
 }
 
@@ -643,7 +720,7 @@ function SidebarNavigationCustomizeList({
 }: {
   onActivate: (
     row: SidebarNavRow,
-    event: ReactMouseEvent<HTMLButtonElement>,
+    event: SidebarNavActivationModifiers,
   ) => void;
   onDragEnd: (activeKey: string, overKey: string) => void;
   onVisibleChange: (key: string, visible: boolean) => void;
@@ -651,10 +728,7 @@ function SidebarNavigationCustomizeList({
   surface?: "popover" | "sidebar";
   visibleKeys: readonly string[];
 }) {
-  const orderedKeys = useMemo(
-    () => rows.map(getPluginNavPanelKey),
-    [rows],
-  );
+  const orderedKeys = useMemo(() => rows.map(getPluginNavPanelKey), [rows]);
   const visibleKeySet = useMemo(() => new Set(visibleKeys), [visibleKeys]);
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
@@ -694,9 +768,7 @@ function SidebarNavigationCustomizeList({
                 reorderDisabled={rows.length < 2}
                 surface={surface}
                 onActivate={(event) => onActivate(row, event)}
-                onCheckedChange={(checked) =>
-                  onVisibleChange(key, checked)
-                }
+                onCheckedChange={(checked) => onVisibleChange(key, checked)}
               />
             );
           })}
@@ -850,6 +922,7 @@ interface SidebarNavRowItemProps {
   onNavigate?: () => void;
   splitEnabled: boolean;
   onHide?: (key: string) => void;
+  onCustomize?: () => void;
   dragBindings?: SidebarSortableDragBindings;
   rowRef?: (element: HTMLElement | null) => void;
   rowStyle?: CSSProperties;
@@ -992,6 +1065,7 @@ interface SidebarNavRowChromeProps {
   onSelect: (event: ReactMouseEvent<HTMLButtonElement>) => void;
   onPointerDown?: PointerEventHandler<HTMLElement>;
   onHide?: (key: string) => void;
+  onCustomize?: () => void;
   splitMiniMap?: MiniMapSlot[] | null;
   accessory?: ReactNode;
   dragBindings?: SidebarSortableDragBindings;
@@ -1007,6 +1081,7 @@ function SidebarNavRowChrome({
   onSelect,
   onPointerDown,
   onHide,
+  onCustomize,
   splitMiniMap = null,
   accessory,
   dragBindings,
@@ -1016,11 +1091,28 @@ function SidebarNavRowChrome({
   const [isActionsOpen, setIsActionsOpen] = useState(false);
   const { onKeyDown: _keyboardDragActivator, ...pointerDragListeners } =
     dragBindings?.listeners ?? {};
-  const visibilityItem = (surface: PluginNavRowMenuSurface): ReactNode => (
-    <PluginNavRowVisibilityMenuItem
-      surface={surface}
-      onSelect={() => onHide?.(rowKey)}
-    />
+  const menuItems = (surface: PluginNavRowMenuSurface): ReactNode => (
+    <>
+      <PluginNavRowVisibilityMenuItem
+        surface={surface}
+        onSelect={() => onHide?.(rowKey)}
+      />
+      {onCustomize === undefined ? null : surface === "context" ? (
+        <>
+          <ContextMenuSeparator />
+          <ContextMenuItem onSelect={onCustomize}>
+            <CustomizeMenuItemContent />
+          </ContextMenuItem>
+        </>
+      ) : (
+        <>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onSelect={onCustomize}>
+            <CustomizeMenuItemContent />
+          </DropdownMenuItem>
+        </>
+      )}
+    </>
   );
 
   return (
@@ -1104,14 +1196,14 @@ function SidebarNavRowChrome({
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
-                {visibilityItem("dropdown")}
+                {menuItems("dropdown")}
               </DropdownMenuContent>
             </DropdownMenu>
           </div>
         </div>
       </ContextMenuTrigger>
       <ContextMenuContent aria-label={`${title} panel options`}>
-        {visibilityItem("context")}
+        {menuItems("context")}
       </ContextMenuContent>
     </ContextMenu>
   );

--- a/apps/app/src/components/plugin/pluginNavSidebarOrder.test.ts
+++ b/apps/app/src/components/plugin/pluginNavSidebarOrder.test.ts
@@ -66,20 +66,20 @@ describe("arrangePluginNavPanels", () => {
 });
 
 describe("arrangePluginNavPanelPreferences", () => {
-  it("shows the first three ordered panels by default", () => {
+  it("shows every ordered panel by default", () => {
     const extra = panel("calendar", "agenda");
     const result = arrangePluginNavPanelPreferences({
       panels: [github, docs, tasks, extra],
       storedOrder: ["tasks/board", "github/pulls"],
       storedVisibleKeys: null,
-      defaultVisibleKeys: [],
-      defaultVisibleCount: 3,
+      defaultHiddenKeys: [],
     });
 
     expect(result.visible.map(getPluginNavPanelKey)).toEqual([
       "tasks/board",
       "github/pulls",
       "docs/vault",
+      "calendar/agenda",
     ]);
     expect(result.ordered.map(getPluginNavPanelKey)).toEqual([
       "tasks/board",
@@ -91,6 +91,7 @@ describe("arrangePluginNavPanelPreferences", () => {
       "tasks/board",
       "github/pulls",
       "docs/vault",
+      "calendar/agenda",
     ]);
     expect(result.normalizedVisibleKeys).toBeNull();
   });
@@ -100,8 +101,7 @@ describe("arrangePluginNavPanelPreferences", () => {
       panels: [github, docs, tasks],
       storedOrder: [],
       storedVisibleKeys: [],
-      defaultVisibleKeys: [],
-      defaultVisibleCount: 3,
+      defaultHiddenKeys: [],
     });
 
     expect(result.visible).toEqual([]);
@@ -118,8 +118,7 @@ describe("arrangePluginNavPanelPreferences", () => {
       panels: [github, docs, tasks],
       storedOrder: ["future/main", "docs/vault", "github/pulls"],
       storedVisibleKeys: ["future/main", "github/pulls", "future/main"],
-      defaultVisibleKeys: [],
-      defaultVisibleCount: 3,
+      defaultHiddenKeys: [],
     });
 
     expect(result.visible.map(getPluginNavPanelKey)).toEqual(["github/pulls"]);
@@ -134,13 +133,12 @@ describe("arrangePluginNavPanelPreferences", () => {
     ]);
   });
 
-  it("keeps a newly installed panel unchecked", () => {
+  it("leaves a panel missing from a stored visible list unchecked", () => {
     const result = arrangePluginNavPanelPreferences({
       panels: [github, docs, tasks],
       storedOrder: ["github/pulls", "docs/vault"],
       storedVisibleKeys: ["github/pulls", "docs/vault"],
-      defaultVisibleKeys: [],
-      defaultVisibleCount: 3,
+      defaultHiddenKeys: [],
     });
 
     expect(result.visible.map(getPluginNavPanelKey)).toEqual([
@@ -159,8 +157,7 @@ describe("arrangePluginNavPanelPreferences", () => {
       panels: [github, docs, tasks],
       storedOrder: ["tasks/board", "github/pulls", "docs/vault"],
       storedVisibleKeys: ["docs/vault", "tasks/board"],
-      defaultVisibleKeys: [],
-      defaultVisibleCount: 3,
+      defaultHiddenKeys: [],
     });
 
     expect(result.visible.map(getPluginNavPanelKey)).toEqual([
@@ -174,7 +171,7 @@ describe("arrangePluginNavPanelPreferences", () => {
     ]);
   });
 
-  it("keeps every default destination visible while limiting optional plugins", () => {
+  it("hides only the default-hidden keys before the user customizes", () => {
     const newThread = panel("__bb__", "new-thread");
     const searchThreads = panel("__bb__", "search-threads");
     const extra = panel("calendar", "agenda");
@@ -189,20 +186,28 @@ describe("arrangePluginNavPanelPreferences", () => {
         "calendar/agenda",
       ],
       storedVisibleKeys: null,
-      defaultVisibleKeys: [
-        "__bb__/new-thread",
-        "__bb__/search-threads",
-      ],
-      defaultVisibleCount: 3,
+      defaultHiddenKeys: ["__bb__/search-threads"],
     });
 
     expect(result.visibleKeys).toEqual([
       "github/pulls",
       "__bb__/new-thread",
       "docs/vault",
-      "__bb__/search-threads",
       "tasks/board",
+      "calendar/agenda",
     ]);
+  });
+
+  it("keeps a stored visible list authoritative over the default-hidden keys", () => {
+    const searchThreads = panel("__bb__", "search-threads");
+    const result = arrangePluginNavPanelPreferences({
+      panels: [searchThreads, github],
+      storedOrder: ["__bb__/search-threads", "github/pulls"],
+      storedVisibleKeys: ["__bb__/search-threads"],
+      defaultHiddenKeys: ["__bb__/search-threads"],
+    });
+
+    expect(result.visibleKeys).toEqual(["__bb__/search-threads"]);
   });
 });
 
@@ -218,10 +223,7 @@ describe("legacy hidden-panel migration", () => {
 
   it("retains a hidden key missing from the stored order", () => {
     expect(
-      migrateLegacyHiddenPluginNavPanelOrder(
-        ["github/pulls"],
-        ["docs/vault"],
-      ),
+      migrateLegacyHiddenPluginNavPanelOrder(["github/pulls"], ["docs/vault"]),
     ).toEqual(["github/pulls", "docs/vault"]);
   });
 });
@@ -234,11 +236,7 @@ describe("togglePluginNavPanelVisibility", () => {
       true,
     );
 
-    expect(checked).toEqual([
-      "github/pulls",
-      "future/main",
-      "docs/vault",
-    ]);
+    expect(checked).toEqual(["github/pulls", "future/main", "docs/vault"]);
     expect(
       togglePluginNavPanelVisibility(checked, "github/pulls", false),
     ).toEqual(["future/main", "docs/vault"]);

--- a/apps/app/src/components/plugin/pluginNavSidebarOrder.ts
+++ b/apps/app/src/components/plugin/pluginNavSidebarOrder.ts
@@ -12,6 +12,10 @@ export const BUILT_IN_SIDEBAR_NAVIGATION_KEYS = {
   automations: "__bb__/automations",
 } as const;
 
+export const DEFAULT_HIDDEN_SIDEBAR_NAVIGATION_KEYS = [
+  BUILT_IN_SIDEBAR_NAVIGATION_KEYS.searchThreads,
+] as const;
+
 export const DEFAULT_BUILT_IN_SIDEBAR_NAVIGATION_ORDER = [
   BUILT_IN_SIDEBAR_NAVIGATION_KEYS.newThread,
   BUILT_IN_SIDEBAR_NAVIGATION_KEYS.searchThreads,
@@ -37,8 +41,7 @@ interface ArrangePluginNavPanelPreferencesArgs<
   TPanel extends PluginNavPanelIdentity,
 > extends ArrangePluginNavPanelsArgs<TPanel> {
   storedVisibleKeys: readonly string[] | null;
-  defaultVisibleKeys: readonly string[];
-  defaultVisibleCount: number;
+  defaultHiddenKeys: readonly string[];
 }
 
 interface ArrangedPluginNavPanelPreferences<
@@ -66,8 +69,7 @@ export function arrangePluginNavPanelPreferences<
   panels,
   storedOrder,
   storedVisibleKeys,
-  defaultVisibleKeys,
-  defaultVisibleCount,
+  defaultHiddenKeys,
 }: ArrangePluginNavPanelPreferencesArgs<TPanel>): ArrangedPluginNavPanelPreferences<TPanel> {
   const { ordered, normalizedOrder } = arrangePluginNavPanels({
     panels,
@@ -77,16 +79,12 @@ export function arrangePluginNavPanelPreferences<
     storedVisibleKeys === null
       ? null
       : [...new Set(storedVisibleKeys.filter((key) => key.length > 0))];
-  const defaultVisibleKeySet = new Set(defaultVisibleKeys);
-  const visibleKeys = normalizedVisibleKeys ?? [
-    ...ordered
-      .filter((panel) => defaultVisibleKeySet.has(getPluginNavPanelKey(panel)))
-      .map(getPluginNavPanelKey),
-    ...ordered
-      .filter((panel) => !defaultVisibleKeySet.has(getPluginNavPanelKey(panel)))
-      .slice(0, Math.max(0, defaultVisibleCount))
-      .map(getPluginNavPanelKey),
-  ];
+  const defaultHiddenKeySet = new Set(defaultHiddenKeys);
+  const visibleKeys =
+    normalizedVisibleKeys ??
+    ordered
+      .map(getPluginNavPanelKey)
+      .filter((key) => !defaultHiddenKeySet.has(key));
   const visibleSet = new Set(visibleKeys);
 
   return {
@@ -107,7 +105,9 @@ export function togglePluginNavPanelVisibility(
   key: string,
   visible: boolean,
 ): string[] {
-  const normalized = [...new Set(visibleKeys.filter((item) => item.length > 0))];
+  const normalized = [
+    ...new Set(visibleKeys.filter((item) => item.length > 0)),
+  ];
   if (visible) {
     return normalized.includes(key) ? normalized : [...normalized, key];
   }

--- a/apps/app/src/components/sidebar/BuiltInSidebarNavigation.tsx
+++ b/apps/app/src/components/sidebar/BuiltInSidebarNavigation.tsx
@@ -1,9 +1,10 @@
-import type { ComponentProps, MouseEvent as ReactMouseEvent } from "react";
+import type { ComponentProps } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   type BuiltInSidebarNavEntry,
   ExtensionsNavSidebarItem,
   PluginNavSidebarItems,
+  type SidebarNavActivationModifiers,
 } from "@/components/plugin/PluginNavSidebarItems";
 import { useAppCommandRunner } from "@/components/commands/AppCommandProvider";
 import { Icon } from "@bb/shared-ui/icon";
@@ -50,7 +51,7 @@ export function BuiltInSidebarNavigation({
         />
       ),
       disabled: onNewChat === undefined,
-      onActivate: (event: ReactMouseEvent<HTMLButtonElement>) => {
+      onActivate: (event: SidebarNavActivationModifiers) => {
         if (event.metaKey || event.ctrlKey) {
           newThreadSplit?.openInSplit();
           return;


### PR DESCRIPTION
## Human comments

## What was wrong

The sidebar navigation showed Search threads and a dedicated customize (config) button by default, and only the first three plugin panels were visible. The customize UI opened in a popover on desktop. Owner feedback (thread thr_iyp57yqy6x): hide Search by default, drop the config button in favor of a Codex-style More row, and make customization inline and reachable by right-click.

## What changed

- `pluginNavSidebarOrder.ts`: the visibility model takes `defaultHiddenKeys` (Search threads) instead of a default-visible count. Everything else, including newly installed plugin panels, is visible by default. A stored visible list stays authoritative, so existing customizations are untouched.
- `PluginNavSidebarItems.tsx`: removed the customize trigger from the New thread row and the desktop popover. Added a More row as the last nav item that only renders while something is hidden; it lists the hidden destinations (modifier-click opens in a split) and Customize sidebar. On compact viewports it uses the shared responsive drawer. Customize now renders inline: a card with a Done button that replaces the nav rows on desktop (Escape also closes it, focus returns to More), and the existing full-height mode with Back on compact. Customize is also in the right-click menu of the More row, every built-in row, and every plugin row, plus plugin rows' options menu. Built-in rows gained a context menu with Hide from sidebar.
- `BuiltInSidebarNavigation.tsx`: built-in activation handlers take `{ metaKey, ctrlKey }` so menu items can launch them.

No wire, CLI, or doc changes.

## How you verified

- `pnpm exec turbo run typecheck --filter=@bb/app` green.
- `apps/app` vitest for `src/components/plugin` and `src/components/sidebar`: 68 files, 533 tests pass. New tests cover Search hidden by default with More offering it, More absent when nothing is hidden, modifier-click from More opening a split, seeding of newly installed panels without touching stored choices, a stored choice keeping Search visible, the inline card replacing rows until Done, Escape closing it, hide-from-context-menu on built-in rows, and the compact drawer to inline mode flow.
- Live QA with doobie against the dev app on desktop (1280x800) and mobile (390x844, touch): default state, More menu, Search launch from More, inline card open/close from More and from right-click, toggling Search on/off, all three context menus, mobile drawer, inline mode, and plugin row options.

Fixes #

> AGENT GENERATED
