### PR TITLE
Account Pool: route Codex accounts through the hub over WebSocket

### DIFF
--- a/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
@@ -53,13 +53,14 @@ BB_HOST_DAEMON_PORT only for an intentional non-default target.
 - Treat plugin commands as normal top-level commands after installation.
 
 The builtin Account Pool plugin is disabled by default. Enable it, add Claude
-credentials, and inspect its proxy route and account quota with:
+or Codex credentials, and inspect its proxy routes and account quota with:
 
 ```sh
 bb plugin enable account-pool
 bb pool account add --provider claude --login
 printf '%s\n' "$CLAUDE_AUTH_CODE" | bb pool account login-complete --session <id> --code-stdin
 bb pool account add --provider claude --import
+bb pool account add --provider codex --import
 printf '%s\n' "$ANTHROPIC_API_KEY" | bb pool account add --provider claude --api-key-stdin [--label <text>] [--priority <n>]
 bb pool account add --provider claude --api-key <key> [--label <text>] [--priority <n>]
 bb pool account list [--json]
@@ -76,8 +77,11 @@ exits. Pipe the manual Claude callback code to `account login-complete` with
 that session ID within ten minutes. The code stays out of process arguments,
 and the browser and bb server may be on different machines. Newly added or
 enabled accounts are available without a plugin reload. With an
-enabled account whose secret file remains readable and valid, Claude Code
-sessions receive the pool route and a distinct secret token for their machine.
+enabled account whose secret file remains readable and valid, matching Claude
+Code or Codex sessions receive the pool route and a distinct secret token for
+their machine.
+Codex receives `CODEX_OPENAI_BASE_URL` and the secret
+`CODEX_POOL_AUTH_TOKEN`; bb applies them as in-memory app-server config.
 Tokens are never printed. `status` prunes tokens for unenrolled machines and
 shows token timestamps plus recently routed threads whose machines need a
 local Claude login before the pool can be disabled safely. Rotation keeps the
@@ -85,7 +89,8 @@ prior token valid for ten minutes. Agents should pipe API keys to
 `--api-key-stdin`;
 `--api-key <key>` is an unsafe compatibility form that exposes the key in
 process arguments, shell history, and agent transcripts. Prefer `--import` for
-an existing Claude Code login. OAuth quota refreshes on add or enable and every
+an existing Claude Code login. Codex import reads `~/.codex/auth.json` on the
+bb server host. OAuth quota refreshes on add or enable and every
 five minutes while an account is idle. Account tables add columns for observed
 model-family buckets; JSON status exposes their utilization, reset, status,
 observation time, and source under `familyWeekly`. Selection skips an account

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -614,9 +614,10 @@ persistently restores undimmed splits.
 ## Account Pool
 
 The builtin Account Pool plugin is disabled on fresh installations. It stores
-non-secret Claude account metadata in plugin KV, quota observations in the
-plugin SQLite database, and each account token plus per-machine hub tokens in
-0600 files under `<data-dir>/plugins/account-pool/secrets/accounts/`.
+non-secret Claude and Codex account metadata in plugin KV, quota observations
+in the plugin SQLite database, and each account token plus per-machine hub
+tokens in 0600 files under
+`<data-dir>/plugins/account-pool/secrets/accounts/`.
 Enable it and add at least one account:
 
 ```sh
@@ -624,6 +625,7 @@ bb plugin enable account-pool
 bb pool account add --provider claude --login
 printf '%s\n' "$CLAUDE_AUTH_CODE" | bb pool account login-complete --session <id> --code-stdin
 bb pool account add --provider claude --import
+bb pool account add --provider codex --import
 printf '%s\n' "$ANTHROPIC_API_KEY" | bb pool account add --provider claude --api-key-stdin [--label <text>] [--priority <n>]
 ```
 
@@ -633,10 +635,11 @@ pipe the code shown on Anthropic's manual callback page to
 `account login-complete` with that session ID. The browser can be on a different
 machine from the bb server, and the code stays out of process arguments. The
 Account Pool plugin settings page exposes the same flow with **Sign in to
-Claude**, plus the account list, import, API-key, enable/disable, and removal
-controls.
+Claude**, plus provider-specific import, API-key, enable/disable, and removal
+controls. Codex has no browser sign-in flow; **Import Codex from this machine**
+reads the bb server host's `~/.codex/auth.json`.
 
-The import path reads the Claude Code login on the bb server host.
+The import paths read the Claude Code or Codex login on the bb server host.
 `--api-key-stdin` reads exactly one non-empty key from piped standard input and
 is the default API-key path for agents. The compatibility form `--api-key
 <key>` remains available, but exposes the secret in process arguments, shell
@@ -644,8 +647,12 @@ history, and agent transcripts. The hub starts immediately, so a newly added
 or enabled account is available without a plugin reload.
 
 When the plugin has an enabled account whose secret file is readable and
-valid, it automatically contributes the hub route, a machine-specific secret
-token, and `ENABLE_TOOL_SEARCH=true` to Claude Code sessions on every host.
+valid, it automatically contributes the provider's hub route and a
+machine-specific secret token to Claude Code or Codex sessions on every host.
+Claude Code also receives `ENABLE_TOOL_SEARCH=true`.
+Codex receives `CODEX_OPENAI_BASE_URL` and the secret
+`CODEX_POOL_AUTH_TOKEN`; bb applies both when launching `codex app-server`
+without writing to `~/.codex/config.toml`.
 Claude Code disables tool search behind a custom base URL by default; the hub
 forwards `tool_reference` blocks unchanged, so the override keeps it on.
 Tokens are never printed
@@ -667,15 +674,21 @@ without disabling that account for other families. Imported and newly signed-in
 accounts retain their Anthropic account UUID, and the hub aligns a present
 `metadata.user_id` account component with the selected account.
 
-Two settings control routing. `switchThreshold` is the shared or requested
+Three settings control routing. `switchThreshold` is the shared or requested
 model-family quota fraction at which an account stops receiving matching
 traffic and defaults to `0.98`.
-`upstreamBaseUrl` defaults to `https://api.anthropic.com` and exists only for
-tests and QA with a controlled fake upstream:
+`upstreamBaseUrl` defaults to `https://api.anthropic.com` and
+`codexUpstreamBaseUrl` defaults to
+`https://chatgpt.com/backend-api/codex`. Codex uses the hub's HTTP Responses
+and models routes and prefers its WebSocket Responses route; the hub keeps the
+downstream WebSocket session semantics while forwarding upstream over HTTPS
+SSE. Both URL settings exist only for tests and QA with a controlled fake
+upstream:
 
 ```sh
 bb plugin config account-pool set switchThreshold 0.98
 bb plugin config account-pool set upstreamBaseUrl http://127.0.0.1:9000
+bb plugin config account-pool set codexUpstreamBaseUrl http://127.0.0.1:9001
 ```
 
 ## bb connect

--- a/packages/templates/src/templates/bb-guide-plugins.md
+++ b/packages/templates/src/templates/bb-guide-plugins.md
@@ -24,14 +24,15 @@ The builtin Custom instructions plugin adds a multiline editor under Settings
 agent task instructions; blank text contributes nothing.
 
 The builtin Account Pool plugin is disabled on fresh installations. It stores
-Claude account tokens in per-account 0600 secret files and proxies Anthropic
-Messages API requests through the bb server. Enable it and add an account:
+Claude and Codex account tokens in per-account 0600 secret files and proxies
+provider API requests through the bb server. Enable it and add an account:
 
 ```
 bb plugin enable account-pool
 bb pool account add --provider claude --login
 printf '%s\n' "$CLAUDE_AUTH_CODE" | bb pool account login-complete --session <id> --code-stdin
 bb pool account add --provider claude --import
+bb pool account add --provider codex --import
 printf '%s\n' "$ANTHROPIC_API_KEY" | bb pool account add --provider claude --api-key-stdin [--label <text>] [--priority <n>]
 bb pool account add --provider claude --api-key <key> [--label <text>] [--priority <n>]
 bb pool account list [--json]
@@ -48,14 +49,18 @@ sign-in URL and session ID, then exits. After sign-in, pipe the manual callback
 code to `account login-complete` with that session ID. The browser does not need
 to run on the bb server machine, and neither the code nor account tokens enter
 process arguments. The same flow is available in the plugin settings page
-through the **Sign in to Claude** button.
+through the **Sign in to Claude** button. Codex import reads the bb server
+host's `~/.codex/auth.json` and has no browser sign-in flow.
 
 The hub starts immediately, even before an account is configured, so newly
 added or enabled accounts are available without a plugin reload. With an
 enabled account whose secret file remains readable and valid, the plugin
-contributes its server route, a distinct secret token, and
-`ENABLE_TOOL_SEARCH=true` (tool search stays on through the hub) to Claude
-Code sessions on every host. Tokens are never printed. `status` prunes tokens for
+contributes its provider-specific server route and a distinct secret token to
+Claude Code or Codex sessions on every host. Claude Code also receives
+`ENABLE_TOOL_SEARCH=true` so tool search stays on through the hub. Codex
+receives `CODEX_OPENAI_BASE_URL` and the secret `CODEX_POOL_AUTH_TOKEN`; its
+app server uses those values without editing `~/.codex/config.toml`. Tokens are
+never printed. `status` prunes tokens for
 unenrolled machines and shows token timestamps plus recently routed threads
 whose machines need a local Claude login before the pool can be disabled
 safely. Rotation keeps the prior token valid for ten minutes. Agents should use

--- a/plugins/account-pool/app.test.tsx
+++ b/plugins/account-pool/app.test.tsx
@@ -70,7 +70,7 @@ describe("Account Pool settings", () => {
       },
     );
 
-    expect(await slot.findByText("No Claude accounts yet")).toBeTruthy();
+    expect(await slot.findByText("No provider accounts yet")).toBeTruthy();
     fireEvent.click(slot.getByRole("button", { name: "Sign in to Claude" }));
     expect(await slot.findByText("Finish signing in to Claude")).toBeTruthy();
     expect(opened).toEqual(["https://claude.ai/oauth/authorize?state=state"]);
@@ -83,6 +83,7 @@ describe("Account Pool settings", () => {
     expect(slot.getByText("person@example.com")).toBeTruthy();
     expect(slot.getByText("5h 21%")).toBeTruthy();
     expect(slot.getByText("7d 43%")).toBeTruthy();
+    expect(slot.getByText("Claude")).toBeTruthy();
     expect(slot.queryByText("Finish signing in to Claude")).toBeNull();
     expect(slot.rpcCalls).toContainEqual({
       method: "login.complete",
@@ -91,6 +92,46 @@ describe("Account Pool settings", () => {
         pasted: "code#state",
       },
     });
+  });
+
+  it("imports Codex credentials from the server machine", async () => {
+    const added = {
+      ...account(),
+      provider: "codex" as const,
+      label: "Codex Pro",
+    };
+    const accounts: AccountSummary[] = [];
+    const slot = renderSlot(
+      app.settingsSections[0]!,
+      {},
+      {
+        rpc: {
+          "account.list": () => [...accounts],
+          "account.add": () => {
+            accounts.push(added);
+            return added;
+          },
+        },
+      },
+    );
+    fireEvent.click(
+      await slot.findByRole("button", {
+        name: "Import Codex from this machine",
+      }),
+    );
+    await waitFor(() =>
+      expect(slot.rpcCalls).toContainEqual({
+        method: "account.add",
+        input: {
+          provider: "codex",
+          source: { kind: "import" },
+          label: null,
+          priority: 100,
+        },
+      }),
+    );
+    expect(await slot.findByText("Codex Pro")).toBeTruthy();
+    expect(slot.getByText("Codex")).toBeTruthy();
   });
 
   it("keeps the login step open and shows a completion error inline", async () => {

--- a/plugins/account-pool/app.tsx
+++ b/plugins/account-pool/app.tsx
@@ -42,6 +42,7 @@ function AccountPoolSettings() {
   const navigate = useBbNavigate();
   const [accounts, setAccounts] = useState<AccountSummary[] | null>(null);
   const [loading, setLoading] = useState(false);
+  const [codexLoading, setCodexLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [loginStep, setLoginStep] = useState<LoginStep | null>(null);
   const [pastedCode, setPastedCode] = useState("");
@@ -142,6 +143,20 @@ function AccountPoolSettings() {
     setLoading(false);
   }
 
+  async function importCodexAccount(): Promise<void> {
+    if (codexLoading) return;
+    setCodexLoading(true);
+    await mutate(async () => {
+      await rpc.call("account.add", {
+        provider: "codex",
+        source: { kind: "import" },
+        label: null,
+        priority: 100,
+      });
+    });
+    setCodexLoading(false);
+  }
+
   async function addApiKey(): Promise<void> {
     if (apiKey.trim().length === 0 || apiKeyPending) return;
     setApiKeyPending(true);
@@ -191,10 +206,12 @@ function AccountPoolSettings() {
   return (
     <div className="w-full space-y-5">
       <div>
-        <h3 className="text-sm font-medium text-foreground">Claude accounts</h3>
+        <h3 className="text-sm font-medium text-foreground">
+          Provider accounts
+        </h3>
         <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-          Account Pool routes Claude Code threads through an available account
-          and moves away from accounts that reach their limits.
+          Account Pool routes Claude and Codex threads through available
+          accounts and moves away from accounts that reach their limits.
         </p>
       </div>
 
@@ -205,11 +222,11 @@ function AccountPoolSettings() {
       ) : accounts.length === 0 ? (
         <div className="rounded-md border border-border/60 bg-surface-recessed px-4 py-4">
           <p className="text-sm font-medium text-foreground">
-            No Claude accounts yet
+            No provider accounts yet
           </p>
           <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-            Add an account and the plugin will route Claude Code threads through
-            the pool automatically.
+            Add an account and the plugin will route supported provider threads
+            through the pool automatically.
           </p>
         </div>
       ) : (
@@ -224,6 +241,9 @@ function AccountPoolSettings() {
                     </span>
                     <span className="text-xs text-muted-foreground">
                       {account.kind === "oauth" ? "OAuth" : "API key"}
+                    </span>
+                    <span className="rounded-full border border-border/60 px-2 py-0.5 text-xs text-muted-foreground">
+                      {account.provider === "claude" ? "Claude" : "Codex"}
                     </span>
                     <span className="text-xs text-muted-foreground">
                       {statusLabel(account.status)}
@@ -276,7 +296,15 @@ function AccountPoolSettings() {
             disabled={loading}
             onClick={() => void importAccount()}
           >
-            {loading ? "Importing…" : "Import from this machine"}
+            {loading ? "Importing…" : "Import Claude from this machine"}
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            disabled={codexLoading}
+            onClick={() => void importCodexAccount()}
+          >
+            {codexLoading ? "Importing…" : "Import Codex from this machine"}
           </Button>
           <Button
             type="button"

--- a/plugins/account-pool/package.json
+++ b/plugins/account-pool/package.json
@@ -3,13 +3,13 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "description": "Routes Anthropic Messages API traffic across a pool of Claude accounts.",
+  "description": "Routes Claude and Codex API traffic across provider account pools.",
   "engines": {
     "bb": ">=0.0"
   },
   "bb": {
     "name": "Account Pool",
-    "description": "Routes Anthropic Messages API traffic across a pool of Claude accounts.",
+    "description": "Routes Claude and Codex API traffic across provider account pools.",
     "branding": {
       "icon": "Layers"
     },

--- a/plugins/account-pool/src/claude-adapter.ts
+++ b/plugins/account-pool/src/claude-adapter.ts
@@ -1,0 +1,200 @@
+import { z } from "zod";
+import type { AccountSecret } from "./contracts.js";
+import {
+  importClaudeCredentials,
+  type ImportedClaudeCredentials,
+} from "./credentials.js";
+import type { ProviderAdapter } from "./provider-adapter.js";
+import {
+  filterRequestHeaders,
+  mountedUpstreamUrl,
+} from "./provider-adapter.js";
+import { isQuotaRejection, quotaFromHeaders } from "./quota.js";
+import { parseRequestBody } from "./request-body.js";
+import { quotaFromUsage } from "./usage.js";
+
+const OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
+const OAUTH_BETA = "oauth-2025-04-20";
+const REFRESH_WINDOW_MS = 5 * 60 * 1_000;
+const USAGE_REQUEST_TIMEOUT_MS = 10_000;
+const ALLOWED_REQUEST_HEADERS = new Set([
+  "accept",
+  "content-type",
+  "user-agent",
+  "x-app",
+]);
+const ALLOWED_REQUEST_HEADER_PREFIXES = ["anthropic-", "x-stainless-"];
+
+const refreshResponseSchema = z
+  .object({
+    access_token: z.string().min(1),
+    refresh_token: z.string().min(1).optional(),
+    expires_in: z.number().positive().optional(),
+    expires_at: z.number().positive().optional(),
+  })
+  .passthrough();
+
+const profileResponseSchema = z
+  .object({
+    account: z
+      .object({ uuid: z.string().uuid().nullish() })
+      .passthrough()
+      .nullish(),
+  })
+  .passthrough();
+
+export function createClaudeAdapter(options: {
+  refreshUrl: string;
+  usageUrl: string;
+  profileUrl: string;
+  importCredentials?: () => Promise<ImportedClaudeCredentials>;
+}): ProviderAdapter {
+  return {
+    provider: "claude",
+    upstreamName: "Anthropic",
+    async importAccount() {
+      const imported = await (
+        options.importCredentials ?? importClaudeCredentials
+      )();
+      return {
+        label: imported.email ?? "Claude Code account",
+        email: imported.email,
+        ...(imported.accountUuid === null
+          ? {}
+          : { accountUuid: imported.accountUuid }),
+        subscriptionType: imported.subscriptionType,
+        rateLimitTier: imported.rateLimitTier,
+        secret: {
+          kind: "oauth",
+          accessToken: imported.accessToken,
+          refreshToken: imported.refreshToken,
+          expiresAt: imported.expiresAt,
+        },
+      };
+    },
+    modelFamily: (body) => parseRequestBody(body).family,
+    prepareBody: (body, account) =>
+      parseRequestBody(body).forAccount(account.accountUuid),
+    upstreamUrl: (request, settings) =>
+      mountedUpstreamUrl(request, settings.upstreamBaseUrl),
+    requestHeaders(inbound, _account, secret) {
+      const headers = filterRequestHeaders(
+        inbound,
+        ALLOWED_REQUEST_HEADERS,
+        ALLOWED_REQUEST_HEADER_PREFIXES,
+      );
+      if (secret.kind === "oauth") {
+        headers.set("authorization", `Bearer ${secret.accessToken}`);
+      } else {
+        headers.set("x-api-key", secret.apiKey);
+      }
+      return headers;
+    },
+    quotaFromHeaders,
+    isQuotaRejection,
+    async refreshSecret(context) {
+      const secret = context.secret;
+      if (
+        secret.kind !== "oauth" ||
+        secret.expiresAt === null ||
+        secret.expiresAt > context.now() + REFRESH_WINDOW_MS
+      ) {
+        return { secret, refreshed: false };
+      }
+      const response = await context.fetch(options.refreshUrl, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json",
+        },
+        body: JSON.stringify({
+          grant_type: "refresh_token",
+          refresh_token: secret.refreshToken,
+          client_id: OAUTH_CLIENT_ID,
+        }),
+      });
+      if (!response.ok) {
+        throw new Error(`OAuth refresh failed with HTTP ${response.status}.`);
+      }
+      const parsed = refreshResponseSchema.parse(await response.json());
+      const rawExpiresAt =
+        parsed.expires_at ??
+        (parsed.expires_in === undefined
+          ? context.now() + 60 * 60 * 1_000
+          : context.now() + parsed.expires_in * 1_000);
+      const refreshed: AccountSecret = {
+        kind: "oauth",
+        accessToken: parsed.access_token,
+        refreshToken: parsed.refresh_token ?? secret.refreshToken,
+        expiresAt:
+          rawExpiresAt < 1_000_000_000_000
+            ? Math.round(rawExpiresAt * 1_000)
+            : Math.round(rawExpiresAt),
+        ...(secret.idToken === undefined ? {} : { idToken: secret.idToken }),
+      };
+      await context.accounts.writeSecret(context.account.id, refreshed);
+      return { secret: refreshed, refreshed: true };
+    },
+    async refreshUsage(context) {
+      if (context.account.kind !== "oauth") return;
+      const secret = await context.freshSecret();
+      if (secret.kind !== "oauth") return;
+      const response = await context.fetch(options.usageUrl, {
+        headers: {
+          authorization: `Bearer ${secret.accessToken}`,
+          "anthropic-beta": OAUTH_BETA,
+          accept: "application/json",
+        },
+        signal: AbortSignal.timeout(USAGE_REQUEST_TIMEOUT_MS),
+      });
+      if (response.ok) {
+        const payload = await response.json().catch(() => null);
+        if (typeof payload === "object" && payload !== null) {
+          const quota = quotaFromUsage(
+            context.account.id,
+            payload,
+            context.quotas.get(context.account.id),
+            context.now(),
+          );
+          if (quota !== null) context.quotas.put(quota);
+        }
+      } else {
+        await response.body?.cancel();
+      }
+      if (context.account.accountUuid !== null) return;
+      const profile = await context.fetch(options.profileUrl, {
+        headers: {
+          authorization: `Bearer ${secret.accessToken}`,
+          "anthropic-beta": OAUTH_BETA,
+          accept: "application/json",
+        },
+        signal: AbortSignal.timeout(USAGE_REQUEST_TIMEOUT_MS),
+      });
+      if (!profile.ok) {
+        await profile.body?.cancel();
+        return;
+      }
+      const parsed = profileResponseSchema.safeParse(
+        await profile.json().catch(() => null),
+      );
+      const accountUuid = parsed.success
+        ? (parsed.data.account?.uuid ?? null)
+        : null;
+      if (accountUuid !== null) {
+        await context.accounts.setAccountUuid(context.account.id, accountUuid);
+      }
+    },
+    errorResponse(status, message, headers) {
+      const type =
+        status === 401
+          ? "authentication_error"
+          : status === 429
+            ? "rate_limit_error"
+            : "api_error";
+      return Response.json(
+        { type: "error", error: { type, message } },
+        { status, headers },
+      );
+    },
+  };
+}

--- a/plugins/account-pool/src/cli.ts
+++ b/plugins/account-pool/src/cli.ts
@@ -21,6 +21,7 @@ interface ParsedFlags {
 const HELP = [
   "Usage:",
   "  bb pool account add --provider claude --import [--label <text>] [--priority <n>]",
+  "  bb pool account add --provider codex --import [--label <text>] [--priority <n>]",
   "  bb pool account add --provider claude --login",
   "  printf '%s\\n' \"$CLAUDE_AUTH_CODE\" | bb pool account login-complete --session <id> --code-stdin",
   "  bb pool account add --provider claude --api-key-stdin [--label <text>] [--priority <n>]",
@@ -105,6 +106,7 @@ function formatAccounts(accounts: readonly AccountSummary[]): string {
     [
       "ID",
       "Label",
+      "Provider",
       "Kind",
       "Enabled",
       "Priority",
@@ -119,6 +121,7 @@ function formatAccounts(accounts: readonly AccountSummary[]): string {
       [
         account.id,
         account.label,
+        account.provider,
         account.kind,
         String(account.enabled),
         String(account.priority),
@@ -173,14 +176,15 @@ export function registerPoolCli(
 ): void {
   bb.cli.register({
     name: "pool",
-    summary: "Manage Claude accounts and inspect the Account Pool hub",
+    summary:
+      "Manage Claude and Codex accounts and inspect the Account Pool hub",
     commands: [
       {
         name: "account-add",
         summary:
-          "Sign in to Claude, import Claude Code credentials, or add an Anthropic API key",
+          "Sign in to Claude, import Claude or Codex credentials, or add an Anthropic API key",
         usage:
-          "bb pool account add --provider claude --login\nbb pool account add --provider claude (--import | --api-key-stdin) [--label <text>] [--priority <n>]\nUnsafe compatibility form: bb pool account add --provider claude --api-key <key> [--label <text>] [--priority <n>]",
+          "bb pool account add --provider claude --login\nbb pool account add --provider <claude|codex> --import [--label <text>] [--priority <n>]\nbb pool account add --provider claude --api-key-stdin [--label <text>] [--priority <n>]\nUnsafe compatibility form: bb pool account add --provider claude --api-key <key> [--label <text>] [--priority <n>]",
       },
       {
         name: "account-login-complete",
@@ -273,6 +277,9 @@ export function registerPoolCli(
             throw new Error(
               "--api-key-stdin must be invoked through the bb CLI so it can read stdin safely.",
             );
+          }
+          if (!imported && flags.values.get("provider") !== "claude") {
+            throw new Error("Anthropic API keys require --provider claude.");
           }
           const priorityText = flags.values.get("priority") ?? "100";
           const input = accountAddInputSchema.parse({

--- a/plugins/account-pool/src/codex-adapter.ts
+++ b/plugins/account-pool/src/codex-adapter.ts
@@ -1,0 +1,209 @@
+import { z } from "zod";
+import type { AccountQuota, AccountSecret, FamilyQuota } from "./contracts.js";
+import {
+  codexAccessTokenExpiresAt,
+  importCodexCredentials,
+  type ImportedCodexCredentials,
+} from "./credentials.js";
+import type { ProviderAdapter } from "./provider-adapter.js";
+import {
+  filterRequestHeaders,
+  mountedUpstreamUrl,
+} from "./provider-adapter.js";
+
+const OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
+const REFRESH_WINDOW_MS = 5 * 60 * 1_000;
+const ALLOWED_REQUEST_HEADERS = new Set([
+  "accept",
+  "content-encoding",
+  "content-type",
+  "openai-beta",
+  "originator",
+  "session_id",
+  "user-agent",
+]);
+const ALLOWED_REQUEST_HEADER_PREFIXES = ["x-codex-", "x-stainless-"];
+
+const refreshResponseSchema = z
+  .object({
+    access_token: z.string().min(1),
+    refresh_token: z.string().min(1).optional(),
+    id_token: z.string().min(1).optional(),
+  })
+  .passthrough();
+
+function numberHeader(headers: Headers, name: string): number | null {
+  const value = headers.get(name);
+  if (value === null) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function resetAt(headers: Headers, prefix: string, now: number): number | null {
+  const raw = numberHeader(headers, `${prefix}-reset-at`);
+  if (raw !== null)
+    return Math.round(raw < 1_000_000_000_000 ? raw * 1_000 : raw);
+  const after = numberHeader(headers, `${prefix}-reset-after-seconds`);
+  return after === null ? null : now + Math.round(after * 1_000);
+}
+
+function windowQuota(
+  headers: Headers,
+  prefix: string,
+  previous: FamilyQuota | null,
+  now: number,
+): FamilyQuota | null {
+  const usedPercent = numberHeader(headers, `${prefix}-used-percent`);
+  const reset = resetAt(headers, prefix, now);
+  if (usedPercent === null && reset === null) return previous;
+  const utilization =
+    usedPercent === null
+      ? (previous?.utilization ?? null)
+      : Math.max(0, Math.min(1, usedPercent / 100));
+  return {
+    utilization,
+    resetAt: reset ?? previous?.resetAt ?? null,
+    status: utilization !== null && utilization >= 1 ? "rejected" : null,
+    observedAt: now,
+    source: "header",
+  };
+}
+
+function codexQuotaFromHeaders(
+  accountId: string,
+  headers: Headers,
+  previous: AccountQuota,
+  now: number,
+): AccountQuota {
+  const primary = windowQuota(
+    headers,
+    "x-codex-primary",
+    previous.familyWeekly.other,
+    now,
+  );
+  const secondary = windowQuota(headers, "x-codex-secondary", null, now);
+  if (primary === previous.familyWeekly.other && secondary === null)
+    return previous;
+  return {
+    ...previous,
+    accountId,
+    fiveHourUtilization: primary?.utilization ?? previous.fiveHourUtilization,
+    fiveHourResetAt: primary?.resetAt ?? previous.fiveHourResetAt,
+    fiveHourStatus: primary === null ? previous.fiveHourStatus : primary.status,
+    sevenDayUtilization: secondary?.utilization ?? previous.sevenDayUtilization,
+    sevenDayResetAt: secondary?.resetAt ?? previous.sevenDayResetAt,
+    sevenDayStatus:
+      secondary === null ? previous.sevenDayStatus : secondary.status,
+    familyWeekly: { ...previous.familyWeekly, other: primary },
+    observedAt: now,
+    heldUntil: null,
+  };
+}
+
+export function createCodexAdapter(options: {
+  refreshUrl: string;
+  importCredentials?: () => Promise<ImportedCodexCredentials>;
+}): ProviderAdapter {
+  return {
+    provider: "codex",
+    upstreamName: "ChatGPT",
+    async importAccount() {
+      const imported = await (
+        options.importCredentials ?? importCodexCredentials
+      )();
+      return {
+        label: imported.email ?? "Codex account",
+        email: imported.email,
+        codexAccountId: imported.accountId,
+        subscriptionType: null,
+        rateLimitTier: null,
+        secret: {
+          kind: "oauth",
+          accessToken: imported.accessToken,
+          refreshToken: imported.refreshToken,
+          expiresAt: imported.expiresAt,
+          ...(imported.idToken === null ? {} : { idToken: imported.idToken }),
+        },
+      };
+    },
+    modelFamily: () => "other",
+    prepareBody: (body) => body,
+    upstreamUrl: (request, settings) =>
+      mountedUpstreamUrl(request, settings.codexUpstreamBaseUrl, "v1/"),
+    requestHeaders(inbound, account, secret) {
+      if (secret.kind !== "oauth" || account.codexAccountId === undefined) {
+        throw new Error(
+          "Codex accounts require OAuth credentials and a ChatGPT account id.",
+        );
+      }
+      const headers = filterRequestHeaders(
+        inbound,
+        ALLOWED_REQUEST_HEADERS,
+        ALLOWED_REQUEST_HEADER_PREFIXES,
+      );
+      headers.set("authorization", `Bearer ${secret.accessToken}`);
+      headers.set("chatgpt-account-id", account.codexAccountId);
+      return headers;
+    },
+    quotaFromHeaders(accountId, headers, previous, _family, now) {
+      return codexQuotaFromHeaders(accountId, headers, previous, now);
+    },
+    isQuotaRejection(headers) {
+      return ["primary", "secondary"].some((window) => {
+        const prefix = `x-codex-${window}`;
+        return (
+          (numberHeader(headers, `${prefix}-used-percent`) ?? 0) >= 100 ||
+          headers.get(`${prefix}-over-limit`)?.toLowerCase() === "true"
+        );
+      });
+    },
+    async refreshSecret(context) {
+      const secret = context.secret;
+      if (
+        secret.kind !== "oauth" ||
+        secret.expiresAt === null ||
+        secret.expiresAt > context.now() + REFRESH_WINDOW_MS
+      ) {
+        return { secret, refreshed: false };
+      }
+      const response = await context.fetch(options.refreshUrl, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json",
+        },
+        body: JSON.stringify({
+          client_id: OAUTH_CLIENT_ID,
+          grant_type: "refresh_token",
+          refresh_token: secret.refreshToken,
+        }),
+      });
+      if (!response.ok)
+        throw new Error(`OAuth refresh failed with HTTP ${response.status}.`);
+      const parsed = refreshResponseSchema.parse(await response.json());
+      const refreshed: AccountSecret = {
+        kind: "oauth",
+        accessToken: parsed.access_token,
+        refreshToken: parsed.refresh_token ?? secret.refreshToken,
+        ...(parsed.id_token === undefined && secret.idToken === undefined
+          ? {}
+          : { idToken: parsed.id_token ?? secret.idToken }),
+        expiresAt: codexAccessTokenExpiresAt(parsed.access_token),
+      };
+      await context.accounts.writeSecret(context.account.id, refreshed);
+      return { secret: refreshed, refreshed: true };
+    },
+    errorResponse(status, message, headers) {
+      return Response.json(
+        {
+          error: {
+            message,
+            type: status === 429 ? "rate_limit_error" : "api_error",
+            code: status === 429 ? "rate_limit_exceeded" : null,
+          },
+        },
+        { status, headers },
+      );
+    },
+  };
+}

--- a/plugins/account-pool/src/codex-websocket.ts
+++ b/plugins/account-pool/src/codex-websocket.ts
@@ -62,7 +62,7 @@ export function createCodexWebSocketHandlers(
   async function forward(
     socket: ExperimentalPluginWebSocket,
     raw: string,
-    signal: AbortSignal,
+    controller: AbortController,
   ): Promise<void> {
     const parsed = envelopeSchema.safeParse(JSON.parse(raw));
     if (!parsed.success) {
@@ -130,7 +130,7 @@ export function createCodexWebSocketHandlers(
         method: "POST",
         headers,
         body: JSON.stringify(body),
-        signal,
+        signal: controller.signal,
       }),
       "codex",
     );
@@ -148,6 +148,7 @@ export function createCodexWebSocketHandlers(
     const reader = response.body.getReader();
     const decoder = new TextDecoder();
     let buffered = "";
+    let reachedEof = false;
     const emit = (block: string) => {
       const data = block
         .split(/\r?\n/u)
@@ -163,15 +164,27 @@ export function createCodexWebSocketHandlers(
       }
       send(socket, JSON.stringify(event));
     };
-    while (true) {
-      const chunk = await reader.read();
-      buffered += decoder.decode(chunk.value, { stream: !chunk.done });
-      const blocks = buffered.split(/\r?\n\r?\n/u);
-      buffered = blocks.pop() ?? "";
-      for (const block of blocks) emit(block);
-      if (chunk.done) break;
+    try {
+      while (true) {
+        const chunk = await reader.read();
+        buffered += decoder.decode(chunk.value, { stream: !chunk.done });
+        const blocks = buffered.split(/\r?\n\r?\n/u);
+        buffered = blocks.pop() ?? "";
+        for (const block of blocks) emit(block);
+        if (chunk.done) {
+          reachedEof = true;
+          break;
+        }
+      }
+      if (buffered.trim().length > 0) emit(buffered);
+    } finally {
+      if (!reachedEof) {
+        controller.abort(
+          new Error("Codex upstream response ended before reaching EOF."),
+        );
+        await reader.cancel().catch(() => undefined);
+      }
     }
-    if (buffered.trim().length > 0) emit(buffered);
   }
 
   return {
@@ -196,9 +209,9 @@ export function createCodexWebSocketHandlers(
         const controller = new AbortController();
         activeForward = controller;
         try {
-          await forward(socket, data, controller.signal);
+          await forward(socket, data, controller);
         } catch (error) {
-          if (!controller.signal.aborted) {
+          if (!closed) {
             send(
               socket,
               failure(

--- a/plugins/account-pool/src/codex-websocket.ts
+++ b/plugins/account-pool/src/codex-websocket.ts
@@ -1,0 +1,185 @@
+import { z } from "zod";
+import type {
+  ExperimentalPluginWebSocket,
+  ExperimentalPluginWebSocketContext,
+  ExperimentalPluginWebSocketHandlers,
+} from "@get-bb/plugin-sdk";
+import type { AccountPoolHub } from "./hub.js";
+
+const envelopeSchema = z
+  .object({
+    type: z.literal("response.create"),
+    generate: z.boolean().optional(),
+    previous_response_id: z.string().min(1).optional(),
+    input: z.array(z.json()).default([]),
+  })
+  .passthrough();
+const completedSchema = z
+  .object({
+    type: z.literal("response.completed"),
+    response: z
+      .object({ id: z.string().min(1), output: z.array(z.json()).default([]) })
+      .passthrough(),
+  })
+  .passthrough();
+
+interface SocketLog {
+  debug(message: string): void;
+}
+
+export function createCodexWebSocketHandlers(
+  context: ExperimentalPluginWebSocketContext,
+  hub: AccountPoolHub,
+  log: SocketLog,
+): ExperimentalPluginWebSocketHandlers {
+  let authenticated = false;
+  let lastId: string | null = null;
+  let lastInput: z.infer<typeof envelopeSchema>["input"] = [];
+  let lastOutput: z.infer<typeof envelopeSchema>["input"] = [];
+  let prewarms = 0;
+
+  function failure(message: string, code: string): string {
+    return JSON.stringify({
+      type: "response.failed",
+      sequence_number: 0,
+      response: { status: "failed", error: { message, code } },
+    });
+  }
+
+  async function forward(
+    socket: ExperimentalPluginWebSocket,
+    raw: string,
+  ): Promise<void> {
+    const parsed = envelopeSchema.safeParse(JSON.parse(raw));
+    if (!parsed.success) {
+      socket.send(failure("Invalid response.create frame.", "invalid_request"));
+      return;
+    }
+    const {
+      type: _type,
+      generate,
+      previous_response_id: previousId,
+      ...body
+    } = parsed.data;
+    if (previousId !== undefined) {
+      if (lastId === null || previousId !== lastId) {
+        socket.send(
+          failure(
+            `Unknown previous_response_id ${JSON.stringify(previousId)}; reconnect and resend full input.`,
+            "unknown_previous_response_id",
+          ),
+        );
+        socket.close(1011, "unknown previous_response_id");
+        return;
+      }
+      body.input = [...lastInput, ...lastOutput, ...body.input];
+    }
+    if (generate === false) {
+      prewarms += 1;
+      lastId = `resp_account_pool_prewarm_${prewarms}`;
+      lastInput = [...body.input];
+      lastOutput = [];
+      socket.send(
+        JSON.stringify({
+          type: "response.completed",
+          sequence_number: 0,
+          response: {
+            id: lastId,
+            object: "response",
+            status: "completed",
+            output: [],
+            usage: {
+              input_tokens: 0,
+              input_tokens_details: { cached_tokens: 0 },
+              output_tokens: 0,
+              output_tokens_details: { reasoning_tokens: 0 },
+              total_tokens: 0,
+            },
+          },
+        }),
+      );
+      return;
+    }
+    lastId = null;
+    lastInput = [...body.input];
+    lastOutput = [];
+    const headers = new Headers(context.headers);
+    headers.set("content-type", "application/json");
+    headers.set("accept", "text/event-stream");
+    const response = await hub.handleAuthenticated(
+      new Request("http://account-pool/v1/responses", {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body),
+      }),
+      "codex",
+    );
+    if (!response.ok || response.body === null) {
+      const detail = await response.text().catch(() => "");
+      socket.send(
+        failure(
+          detail || `Upstream returned HTTP ${response.status}.`,
+          "upstream_error",
+        ),
+      );
+      return;
+    }
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffered = "";
+    const emit = (block: string) => {
+      const data = block
+        .split(/\r?\n/u)
+        .filter((line) => line.startsWith("data:"))
+        .map((line) => line.slice(5).trimStart())
+        .join("\n");
+      if (data.length === 0 || data === "[DONE]") return;
+      const event = JSON.parse(data);
+      const completed = completedSchema.safeParse(event);
+      if (completed.success) {
+        lastId = completed.data.response.id;
+        lastOutput = completed.data.response.output;
+      }
+      socket.send(JSON.stringify(event));
+    };
+    while (true) {
+      const chunk = await reader.read();
+      buffered += decoder.decode(chunk.value, { stream: !chunk.done });
+      const blocks = buffered.split(/\r?\n\r?\n/u);
+      buffered = blocks.pop() ?? "";
+      for (const block of blocks) emit(block);
+      if (chunk.done) break;
+    }
+    if (buffered.trim().length > 0) emit(buffered);
+  }
+
+  return {
+    async onOpen(socket) {
+      authenticated = await hub.authenticate(context.request);
+      if (!authenticated) {
+        socket.close(1008, "invalid Account Pool token");
+        return;
+      }
+      log.debug(
+        "Account Pool Codex transport: WebSocket downstream, HTTPS SSE upstream.",
+      );
+    },
+    async onMessage(socket, data) {
+      if (!authenticated) return;
+      if (typeof data !== "string") {
+        socket.close(1003, "text frames required");
+        return;
+      }
+      try {
+        await forward(socket, data);
+      } catch (error) {
+        socket.send(
+          failure(
+            error instanceof Error ? error.message : String(error),
+            "proxy_error",
+          ),
+        );
+      }
+    },
+  };
+}

--- a/plugins/account-pool/src/codex-websocket.ts
+++ b/plugins/account-pool/src/codex-websocket.ts
@@ -37,6 +37,9 @@ export function createCodexWebSocketHandlers(
   let lastInput: z.infer<typeof envelopeSchema>["input"] = [];
   let lastOutput: z.infer<typeof envelopeSchema>["input"] = [];
   let prewarms = 0;
+  let closed = false;
+  let activeForward: AbortController | null = null;
+  let forwardQueue = Promise.resolve();
 
   function failure(message: string, code: string): string {
     return JSON.stringify({
@@ -46,13 +49,27 @@ export function createCodexWebSocketHandlers(
     });
   }
 
+  function send(socket: ExperimentalPluginWebSocket, data: string): boolean {
+    if (socket.readyState !== 1) return false;
+    try {
+      socket.send(data);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   async function forward(
     socket: ExperimentalPluginWebSocket,
     raw: string,
+    signal: AbortSignal,
   ): Promise<void> {
     const parsed = envelopeSchema.safeParse(JSON.parse(raw));
     if (!parsed.success) {
-      socket.send(failure("Invalid response.create frame.", "invalid_request"));
+      send(
+        socket,
+        failure("Invalid response.create frame.", "invalid_request"),
+      );
       return;
     }
     const {
@@ -63,7 +80,8 @@ export function createCodexWebSocketHandlers(
     } = parsed.data;
     if (previousId !== undefined) {
       if (lastId === null || previousId !== lastId) {
-        socket.send(
+        send(
+          socket,
           failure(
             `Unknown previous_response_id ${JSON.stringify(previousId)}; reconnect and resend full input.`,
             "unknown_previous_response_id",
@@ -79,7 +97,8 @@ export function createCodexWebSocketHandlers(
       lastId = `resp_account_pool_prewarm_${prewarms}`;
       lastInput = [...body.input];
       lastOutput = [];
-      socket.send(
+      send(
+        socket,
         JSON.stringify({
           type: "response.completed",
           sequence_number: 0,
@@ -111,12 +130,14 @@ export function createCodexWebSocketHandlers(
         method: "POST",
         headers,
         body: JSON.stringify(body),
+        signal,
       }),
       "codex",
     );
     if (!response.ok || response.body === null) {
       const detail = await response.text().catch(() => "");
-      socket.send(
+      send(
+        socket,
         failure(
           detail || `Upstream returned HTTP ${response.status}.`,
           "upstream_error",
@@ -140,7 +161,7 @@ export function createCodexWebSocketHandlers(
         lastId = completed.data.response.id;
         lastOutput = completed.data.response.output;
       }
-      socket.send(JSON.stringify(event));
+      send(socket, JSON.stringify(event));
     };
     while (true) {
       const chunk = await reader.read();
@@ -170,16 +191,32 @@ export function createCodexWebSocketHandlers(
         socket.close(1003, "text frames required");
         return;
       }
-      try {
-        await forward(socket, data);
-      } catch (error) {
-        socket.send(
-          failure(
-            error instanceof Error ? error.message : String(error),
-            "proxy_error",
-          ),
-        );
-      }
+      forwardQueue = forwardQueue.then(async () => {
+        if (closed) return;
+        const controller = new AbortController();
+        activeForward = controller;
+        try {
+          await forward(socket, data, controller.signal);
+        } catch (error) {
+          if (!controller.signal.aborted) {
+            send(
+              socket,
+              failure(
+                error instanceof Error ? error.message : String(error),
+                "proxy_error",
+              ),
+            );
+          }
+        } finally {
+          if (activeForward === controller) activeForward = null;
+        }
+      });
+    },
+    onClose() {
+      closed = true;
+      activeForward?.abort(
+        new Error("Codex WebSocket closed before the response completed."),
+      );
     },
   };
 }

--- a/plugins/account-pool/src/contracts.ts
+++ b/plugins/account-pool/src/contracts.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
-export const providerSchema = z.literal("claude");
+export const providerSchema = z.enum(["claude", "codex"]);
+export type PoolProvider = z.infer<typeof providerSchema>;
 export const accountKindSchema = z.enum(["oauth", "api-key"]);
 export const modelFamilySchema = z.enum([
   "fable",
@@ -44,6 +45,7 @@ export const accountSchema = z
     label: z.string().min(1),
     email: z.string().email().nullable(),
     accountUuid: z.string().uuid().nullable().default(null),
+    codexAccountId: z.string().min(1).optional(),
     subscriptionType: z.string().nullable(),
     rateLimitTier: z.string().nullable(),
     enabled: z.boolean(),
@@ -60,6 +62,7 @@ export const oauthSecretSchema = z
     accessToken: z.string().min(1),
     refreshToken: z.string().min(1),
     expiresAt: z.number().int().positive().nullable(),
+    idToken: z.string().min(1).optional(),
   })
   .strict();
 

--- a/plugins/account-pool/src/credentials.test.ts
+++ b/plugins/account-pool/src/credentials.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { parseCodexCredentials } from "./credentials.js";
+
+function token(payload: object): string {
+  return `header.${Buffer.from(JSON.stringify(payload)).toString("base64url")}.signature`;
+}
+
+describe("Codex credential import", () => {
+  it("reads account identity, email, token material, and access expiry", () => {
+    const expiresAtSeconds = 2_000_000_000;
+    expect(
+      parseCodexCredentials(
+        JSON.stringify({
+          tokens: {
+            access_token: token({ exp: expiresAtSeconds }),
+            refresh_token: "refresh-token",
+            account_id: "account-123",
+            id_token: token({
+              "https://api.openai.com/profile": { email: "codex@example.com" },
+            }),
+          },
+          last_refresh: "2026-09-04T00:00:00Z",
+        }),
+      ),
+    ).toEqual({
+      accessToken: token({ exp: expiresAtSeconds }),
+      refreshToken: "refresh-token",
+      idToken: token({
+        "https://api.openai.com/profile": { email: "codex@example.com" },
+      }),
+      accountId: "account-123",
+      email: "codex@example.com",
+      expiresAt: expiresAtSeconds * 1_000,
+    });
+  });
+
+  it("rejects credentials that cannot identify the ChatGPT account", () => {
+    expect(() =>
+      parseCodexCredentials(
+        JSON.stringify({
+          tokens: {
+            access_token: token({ exp: 2_000_000_000 }),
+            refresh_token: "refresh-token",
+          },
+        }),
+      ),
+    ).toThrow("ChatGPT account id");
+  });
+});

--- a/plugins/account-pool/src/credentials.ts
+++ b/plugins/account-pool/src/credentials.ts
@@ -31,6 +31,25 @@ const accountFileSchema = z.object({
     .nullish(),
 });
 
+const codexAuthFileSchema = z
+  .object({
+    tokens: z
+      .object({
+        access_token: z.string().min(1),
+        refresh_token: z.string().min(1),
+        account_id: z.string().min(1).nullish(),
+        id_token: z.string().min(1).nullish(),
+      })
+      .passthrough(),
+    last_refresh: z.string().nullish(),
+  })
+  .passthrough();
+
+const jwtPayloadSchema = z.record(z.string(), z.json());
+type JwtPayload = z.infer<typeof jwtPayloadSchema>;
+const CHATGPT_AUTH_CLAIM = "https://api.openai.com/auth";
+const CHATGPT_PROFILE_CLAIM = "https://api.openai.com/profile";
+
 export interface ImportedClaudeCredentials {
   accessToken: string;
   refreshToken: string;
@@ -39,6 +58,92 @@ export interface ImportedClaudeCredentials {
   rateLimitTier: string | null;
   email: string | null;
   accountUuid: string | null;
+}
+
+export interface ImportedCodexCredentials {
+  accessToken: string;
+  refreshToken: string;
+  idToken: string | null;
+  accountId: string;
+  email: string | null;
+  expiresAt: number | null;
+}
+
+function jwtPayload(token: string | null): JwtPayload | null {
+  if (token === null) return null;
+  const payload = token.split(".")[1];
+  if (payload === undefined) return null;
+  try {
+    const parsed = jwtPayloadSchema.safeParse(
+      JSON.parse(Buffer.from(payload, "base64url").toString("utf8")),
+    );
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
+  }
+}
+
+function nestedString(
+  payload: JwtPayload | null,
+  claim: string,
+  field: string,
+): string | null {
+  const nested = payload?.[claim];
+  if (nested === null || typeof nested !== "object" || Array.isArray(nested))
+    return null;
+  const value = nested[field];
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+export function codexAccessTokenExpiresAt(token: string): number | null {
+  const payload = jwtPayload(token);
+  return typeof payload?.exp === "number"
+    ? Math.round(payload.exp * 1_000)
+    : null;
+}
+
+export function parseCodexCredentials(raw: string): ImportedCodexCredentials {
+  const parsed = codexAuthFileSchema.parse(JSON.parse(raw));
+  const idToken = parsed.tokens.id_token ?? null;
+  const accessPayload = jwtPayload(parsed.tokens.access_token);
+  const idPayload = jwtPayload(idToken);
+  const accountId =
+    parsed.tokens.account_id ??
+    nestedString(accessPayload, CHATGPT_AUTH_CLAIM, "chatgpt_account_id") ??
+    nestedString(idPayload, CHATGPT_AUTH_CLAIM, "chatgpt_account_id");
+  if (accountId === null) {
+    throw new Error("Codex auth tokens do not include a ChatGPT account id.");
+  }
+  const directEmail =
+    typeof idPayload?.email === "string" ? idPayload.email : null;
+  const email =
+    directEmail ??
+    nestedString(idPayload, CHATGPT_PROFILE_CLAIM, "email") ??
+    (typeof accessPayload?.email === "string" ? accessPayload.email : null) ??
+    nestedString(accessPayload, CHATGPT_PROFILE_CLAIM, "email");
+  const expiresAt = codexAccessTokenExpiresAt(parsed.tokens.access_token);
+  return {
+    accessToken: parsed.tokens.access_token,
+    refreshToken: parsed.tokens.refresh_token,
+    idToken,
+    accountId,
+    email,
+    expiresAt,
+  };
+}
+
+export async function importCodexCredentials(): Promise<ImportedCodexCredentials> {
+  try {
+    return parseCodexCredentials(
+      await fs.readFile(path.join(os.homedir(), ".codex", "auth.json"), "utf8"),
+    );
+  } catch (error) {
+    if (error instanceof Error && error.message.includes("ChatGPT account id"))
+      throw error;
+    throw new Error(
+      "Codex OAuth credentials were not found or usable. Run `codex login` on the bb server host, then retry.",
+    );
+  }
 }
 
 function parseCredentials(

--- a/plugins/account-pool/src/hub.ts
+++ b/plugins/account-pool/src/hub.ts
@@ -1,43 +1,34 @@
-import { z } from "zod";
 import type {
   Account,
   AccountQuota,
   AccountSecret,
   ModelFamily,
+  PoolProvider,
   PoolStatus,
 } from "./contracts.js";
+import { createClaudeAdapter } from "./claude-adapter.js";
+import { createCodexAdapter } from "./codex-adapter.js";
+import type { ProviderAdapter } from "./provider-adapter.js";
+import type { ImportedProviderAccount } from "./provider-adapter.js";
+import type {
+  ImportedClaudeCredentials,
+  ImportedCodexCredentials,
+} from "./credentials.js";
 import {
   accountStatus,
   governingWeeklyResetAt,
   isQuotaExhausted,
-  isQuotaRejection,
-  quotaFromHeaders,
   retryAfterMilliseconds,
 } from "./quota.js";
-import { parseRequestBody } from "./request-body.js";
 import type { AccountStore, HubTokenStore, QuotaStore } from "./store.js";
-import { quotaFromUsage } from "./usage.js";
 
 const ROUTE = "/api/v1/plugins/account-pool/http";
-const OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
 const DEFAULT_REFRESH_URL = "https://platform.claude.com/v1/oauth/token";
+const DEFAULT_CODEX_REFRESH_URL = "https://auth.openai.com/oauth/token";
 const DEFAULT_USAGE_URL = "https://api.anthropic.com/api/oauth/usage";
 const DEFAULT_PROFILE_URL = "https://api.anthropic.com/api/oauth/profile";
-const OAUTH_BETA = "oauth-2025-04-20";
-const REFRESH_WINDOW_MS = 5 * 60 * 1_000;
 const DEFAULT_USAGE_REFRESH_INTERVAL_MS = 5 * 60 * 1_000;
-const USAGE_REQUEST_TIMEOUT_MS = 10_000;
 const MAX_INLINE_HOLD_MS = 20_000;
-
-const ALLOWED_REQUEST_HEADERS = new Set([
-  "accept",
-  "content-type",
-  "user-agent",
-  "x-app",
-]);
-
-const ALLOWED_REQUEST_HEADER_PREFIXES = ["anthropic-", "x-stainless-"];
-
 const DROPPED_RESPONSE_HEADERS = new Set([
   "content-encoding",
   "content-length",
@@ -51,26 +42,9 @@ const DROPPED_RESPONSE_HEADERS = new Set([
   "upgrade",
 ]);
 
-const refreshResponseSchema = z
-  .object({
-    access_token: z.string().min(1),
-    refresh_token: z.string().min(1).optional(),
-    expires_in: z.number().positive().optional(),
-    expires_at: z.number().positive().optional(),
-  })
-  .passthrough();
-
-const profileResponseSchema = z
-  .object({
-    account: z
-      .object({ uuid: z.string().uuid().nullish() })
-      .passthrough()
-      .nullish(),
-  })
-  .passthrough();
-
 export interface HubSettings {
   upstreamBaseUrl: string;
+  codexUpstreamBaseUrl: string;
   switchThreshold: number;
 }
 
@@ -79,11 +53,9 @@ interface HubOptions {
   quotas: QuotaStore;
   hubTokens: HubTokenStore;
   getSettings: () => HubSettings;
+  adapters: ReadonlyMap<PoolProvider, ProviderAdapter>;
   fetch: typeof fetch;
   now: () => number;
-  refreshUrl: string;
-  usageUrl: string;
-  profileUrl: string;
   usageRefreshIntervalMs: number;
   drainTimeoutMs: number;
 }
@@ -92,7 +64,6 @@ interface SelectedAccount {
   account: Account;
   quota: AccountQuota;
 }
-
 interface UpstreamResult {
   response: Response;
   controller: AbortController;
@@ -119,6 +90,44 @@ export class AccountPoolHub {
     await this.stop();
   }
 
+  async authenticate(request: Request): Promise<boolean> {
+    const token =
+      request.headers.get("x-bb-account-pool-token") ??
+      readBearer(request.headers.get("authorization"));
+    return (await this.options.hubTokens.authenticate(token)) !== null;
+  }
+
+  async importAccount(
+    provider: PoolProvider,
+  ): Promise<ImportedProviderAccount> {
+    return this.adapter(provider).importAccount();
+  }
+
+  async handle(request: Request, provider: PoolProvider): Promise<Response> {
+    const adapter = this.adapter(provider);
+    if (!(await this.authenticate(request))) {
+      return adapter.errorResponse(401, "Invalid Account Pool bearer token.");
+    }
+    return this.handleAuthenticated(request, provider);
+  }
+
+  async handleAuthenticated(
+    request: Request,
+    provider: PoolProvider,
+  ): Promise<Response> {
+    const adapter = this.adapter(provider);
+    if (!this.accepting)
+      return adapter.errorResponse(
+        503,
+        "Account Pool is not accepting requests.",
+      );
+    return this.forward(
+      request,
+      new Uint8Array(await request.arrayBuffer()),
+      adapter,
+    );
+  }
+
   async refreshUsage(accountId?: string, force = false): Promise<void> {
     const accounts = (await this.options.accounts.list()).filter(
       (account) =>
@@ -135,81 +144,36 @@ export class AccountPoolHub {
     account: Account,
     force: boolean,
   ): Promise<void> {
-    if ((this.inFlightByAccount.get(account.id) ?? 0) > 0) return;
+    const adapter = this.adapter(account.provider);
+    if (
+      adapter.refreshUsage === undefined ||
+      (this.inFlightByAccount.get(account.id) ?? 0) > 0
+    )
+      return;
     const now = this.options.now();
-    const lastRefreshAt = this.lastUsageRefreshAt.get(account.id);
+    const last = this.lastUsageRefreshAt.get(account.id);
     if (
       !force &&
-      lastRefreshAt !== undefined &&
-      now - lastRefreshAt < this.options.usageRefreshIntervalMs
+      last !== undefined &&
+      now - last < this.options.usageRefreshIntervalMs
     )
       return;
     const running = this.usageRefreshes.get(account.id);
     if (running !== undefined) return running;
     this.lastUsageRefreshAt.set(account.id, now);
-    const refresh = this.fetchAccountUsage(account).finally(() => {
-      this.usageRefreshes.delete(account.id);
-    });
+    const refresh = adapter
+      .refreshUsage({
+        account,
+        freshSecret: () => this.freshSecret(account, adapter),
+        accounts: this.options.accounts,
+        quotas: this.options.quotas,
+        fetch: this.options.fetch,
+        now: this.options.now,
+      })
+      .catch(() => undefined)
+      .finally(() => this.usageRefreshes.delete(account.id));
     this.usageRefreshes.set(account.id, refresh);
     return refresh;
-  }
-
-  private async fetchAccountUsage(account: Account): Promise<void> {
-    try {
-      const secret = await this.freshSecret(account);
-      if (secret.kind !== "oauth") return;
-      const response = await this.options.fetch(this.options.usageUrl, {
-        headers: {
-          authorization: `Bearer ${secret.accessToken}`,
-          "anthropic-beta": OAUTH_BETA,
-          accept: "application/json",
-        },
-        signal: AbortSignal.timeout(USAGE_REQUEST_TIMEOUT_MS),
-      });
-      if (response.ok) {
-        const payload = await response.json().catch(() => null);
-        if (typeof payload === "object" && payload !== null) {
-          const quota = quotaFromUsage(
-            account.id,
-            payload,
-            this.options.quotas.get(account.id),
-            this.options.now(),
-          );
-          if (quota !== null) this.options.quotas.put(quota);
-        }
-      } else {
-        await response.body?.cancel();
-      }
-      if (account.accountUuid === null) {
-        await this.backfillAccountUuid(account.id, secret.accessToken);
-      }
-    } catch {}
-  }
-
-  private async backfillAccountUuid(
-    accountId: string,
-    accessToken: string,
-  ): Promise<void> {
-    const response = await this.options.fetch(this.options.profileUrl, {
-      headers: {
-        authorization: `Bearer ${accessToken}`,
-        "anthropic-beta": OAUTH_BETA,
-        accept: "application/json",
-      },
-      signal: AbortSignal.timeout(USAGE_REQUEST_TIMEOUT_MS),
-    });
-    if (!response.ok) {
-      await response.body?.cancel();
-      return;
-    }
-    const payload = await response.json().catch(() => null);
-    const parsed = profileResponseSchema.safeParse(payload);
-    const accountUuid = parsed.success
-      ? (parsed.data.account?.uuid ?? null)
-      : null;
-    if (accountUuid !== null) {
-      await this.options.accounts.setAccountUuid(accountId, accountUuid);
-    }
   }
 
   async stop(): Promise<void> {
@@ -217,9 +181,7 @@ export class AccountPoolHub {
     if (this.inFlightCount() === 0) return;
     let timeout: ReturnType<typeof setTimeout> | null = null;
     await Promise.race([
-      new Promise<void>((resolve) => {
-        this.drainWaiters.add(resolve);
-      }),
+      new Promise<void>((resolve) => this.drainWaiters.add(resolve)),
       new Promise<void>((resolve) => {
         timeout = setTimeout(resolve, this.options.drainTimeoutMs);
       }),
@@ -233,29 +195,6 @@ export class AccountPoolHub {
         ),
       );
     }
-  }
-
-  async handle(request: Request): Promise<Response> {
-    if (
-      (await this.options.hubTokens.authenticate(
-        readBearer(request.headers.get("authorization")),
-      )) === null
-    ) {
-      return anthropicError(
-        401,
-        "authentication_error",
-        "Invalid Account Pool bearer token.",
-      );
-    }
-    if (!this.accepting) {
-      return anthropicError(
-        503,
-        "api_error",
-        "Account Pool is not accepting requests.",
-      );
-    }
-    const body = new Uint8Array(await request.arrayBuffer());
-    return this.forward(request, body);
   }
 
   async status(): Promise<Omit<PoolStatus, "routedThreadsWithoutLocalLogin">> {
@@ -290,18 +229,24 @@ export class AccountPoolHub {
     };
   }
 
-  private async forward(request: Request, body: Uint8Array): Promise<Response> {
+  private async forward(
+    request: Request,
+    body: Uint8Array,
+    adapter: ProviderAdapter,
+  ): Promise<Response> {
     const attempted = new Set<string>();
-    const accounts = await this.options.accounts.list();
-    const parsedBody = parseRequestBody(body);
+    const accounts = (await this.options.accounts.list()).filter(
+      (account) => account.provider === adapter.provider,
+    );
+    const family = adapter.modelFamily(body);
     while (attempted.size < accounts.length) {
-      const selected = await this.select(attempted, parsedBody.family);
+      const selected = await this.select(adapter.provider, attempted, family);
       if (selected === null)
-        return this.noEligibleResponse(accounts, parsedBody.family);
+        return this.noEligibleResponse(accounts, family, adapter);
       attempted.add(selected.account.id);
       let secret: AccountSecret;
       try {
-        secret = await this.freshSecret(selected.account);
+        secret = await this.freshSecret(selected.account, adapter);
       } catch (error) {
         this.markError(selected.account.id, errorMessage(error));
         continue;
@@ -310,28 +255,28 @@ export class AccountPoolHub {
       try {
         upstream = await this.fetchUpstream(
           request,
-          parsedBody.forAccount(selected.account.accountUuid),
+          adapter.prepareBody(body, selected.account),
           selected.account,
           secret,
+          adapter,
         );
-      } catch (error) {
-        return anthropicError(
+      } catch {
+        return adapter.errorResponse(
           502,
-          "api_error",
-          "Account Pool could not reach Anthropic.",
+          `Account Pool could not reach ${adapter.upstreamName}.`,
         );
       }
-      const observed = quotaFromHeaders(
+      const observed = adapter.quotaFromHeaders(
         selected.account.id,
         upstream.response.headers,
         this.options.quotas.get(selected.account.id),
-        parsedBody.family,
+        family,
         this.options.now(),
       );
       this.options.quotas.put(observed);
       if (
         upstream.response.status === 429 &&
-        isQuotaRejection(upstream.response.headers)
+        adapter.isQuotaRejection(upstream.response.headers)
       ) {
         await upstream.response.body?.cancel();
         upstream.release();
@@ -353,80 +298,82 @@ export class AccountPoolHub {
           try {
             const retry = await this.fetchUpstream(
               request,
-              parsedBody.forAccount(selected.account.accountUuid),
+              adapter.prepareBody(body, selected.account),
               selected.account,
               secret,
+              adapter,
             );
-            const retryQuota = quotaFromHeaders(
+            const retryQuota = adapter.quotaFromHeaders(
               selected.account.id,
               retry.response.headers,
               this.options.quotas.get(selected.account.id),
-              parsedBody.family,
+              family,
               this.options.now(),
             );
-            if (retry.response.status === 429) {
-              const retryWaitMs = retryAfterMilliseconds(
-                retry.response.headers.get("retry-after"),
-                this.options.now(),
-              );
-              this.options.quotas.put({
-                ...retryQuota,
-                heldUntil: this.options.now() + retryWaitMs,
-              });
-            } else {
-              this.options.quotas.put(retryQuota);
-            }
-            if (
-              retry.response.status === 401 ||
-              retry.response.status === 403
-            ) {
-              const detail = await retry.response
-                .clone()
-                .text()
-                .catch(() => "");
-              this.markError(
-                selected.account.id,
-                detail.trim() ||
-                  `Anthropic returned HTTP ${retry.response.status}.`,
-              );
-            }
+            this.options.quotas.put(
+              retry.response.status === 429
+                ? {
+                    ...retryQuota,
+                    heldUntil:
+                      this.options.now() +
+                      retryAfterMilliseconds(
+                        retry.response.headers.get("retry-after"),
+                        this.options.now(),
+                      ),
+                  }
+                : retryQuota,
+            );
+            await this.captureAuthError(
+              retry.response,
+              selected.account,
+              adapter,
+            );
             return this.clientResponse(retry);
           } catch {
-            return anthropicError(
+            return adapter.errorResponse(
               502,
-              "api_error",
-              "Account Pool could not reach Anthropic.",
+              `Account Pool could not reach ${adapter.upstreamName}.`,
             );
           }
         }
       }
-      if (
-        upstream.response.status === 401 ||
-        upstream.response.status === 403
-      ) {
-        const detail = await upstream.response
-          .clone()
-          .text()
-          .catch(() => "");
-        this.markError(
-          selected.account.id,
-          detail.trim() ||
-            `Anthropic returned HTTP ${upstream.response.status}.`,
-        );
-      }
+      await this.captureAuthError(upstream.response, selected.account, adapter);
       return this.clientResponse(upstream);
     }
-    return this.noEligibleResponse(accounts, parsedBody.family);
+    return this.noEligibleResponse(accounts, family, adapter);
+  }
+
+  private async captureAuthError(
+    response: Response,
+    account: Account,
+    adapter: ProviderAdapter,
+  ): Promise<void> {
+    if (response.status !== 401 && response.status !== 403) return;
+    const detail = await response
+      .clone()
+      .text()
+      .catch(() => "");
+    this.markError(
+      account.id,
+      detail.trim() ||
+        `${adapter.upstreamName} returned HTTP ${response.status}.`,
+    );
   }
 
   private async select(
+    provider: PoolProvider,
     attempted: ReadonlySet<string>,
     family: ModelFamily,
   ): Promise<SelectedAccount | null> {
     const now = this.options.now();
     const threshold = this.options.getSettings().switchThreshold;
     const candidates = (await this.options.accounts.list())
-      .filter((account) => account.enabled && !attempted.has(account.id))
+      .filter(
+        (account) =>
+          account.provider === provider &&
+          account.enabled &&
+          !attempted.has(account.id),
+      )
       .map((account) => ({
         account,
         quota: this.options.quotas.get(account.id),
@@ -450,62 +397,32 @@ export class AccountPoolHub {
     return candidates[0] ?? null;
   }
 
-  private async freshSecret(account: Account): Promise<AccountSecret> {
-    const secret = await this.options.accounts.readSecret(account.id);
-    if (
-      secret.kind !== "oauth" ||
-      secret.expiresAt === null ||
-      secret.expiresAt > this.options.now() + REFRESH_WINDOW_MS
-    ) {
-      return secret;
-    }
+  private async freshSecret(
+    account: Account,
+    adapter: ProviderAdapter,
+  ): Promise<AccountSecret> {
     const existing = this.refreshes.get(account.id);
     if (existing !== undefined) return existing;
-    const refresh = this.refresh(account.id, secret).finally(() => {
-      this.refreshes.delete(account.id);
-    });
+    const secret = await this.options.accounts.readSecret(account.id);
+    const refresh = adapter
+      .refreshSecret({
+        account,
+        secret,
+        accounts: this.options.accounts,
+        quotas: this.options.quotas,
+        fetch: this.options.fetch,
+        now: this.options.now,
+      })
+      .then((result) => {
+        if (result.refreshed) {
+          const quota = this.options.quotas.get(account.id);
+          this.options.quotas.put({ ...quota, error: null });
+        }
+        return result.secret;
+      })
+      .finally(() => this.refreshes.delete(account.id));
     this.refreshes.set(account.id, refresh);
     return refresh;
-  }
-
-  private async refresh(
-    accountId: string,
-    secret: Extract<AccountSecret, { kind: "oauth" }>,
-  ): Promise<AccountSecret> {
-    const response = await this.options.fetch(this.options.refreshUrl, {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        accept: "application/json",
-      },
-      body: JSON.stringify({
-        grant_type: "refresh_token",
-        refresh_token: secret.refreshToken,
-        client_id: OAUTH_CLIENT_ID,
-      }),
-    });
-    if (!response.ok) {
-      throw new Error(`OAuth refresh failed with HTTP ${response.status}.`);
-    }
-    const parsed = refreshResponseSchema.parse(await response.json());
-    const rawExpiresAt =
-      parsed.expires_at ??
-      (parsed.expires_in === undefined
-        ? this.options.now() + 60 * 60 * 1_000
-        : this.options.now() + parsed.expires_in * 1_000);
-    const refreshed: AccountSecret = {
-      kind: "oauth",
-      accessToken: parsed.access_token,
-      refreshToken: parsed.refresh_token ?? secret.refreshToken,
-      expiresAt:
-        rawExpiresAt < 1_000_000_000_000
-          ? Math.round(rawExpiresAt * 1_000)
-          : Math.round(rawExpiresAt),
-    };
-    await this.options.accounts.writeSecret(accountId, refreshed);
-    const quota = this.options.quotas.get(accountId);
-    this.options.quotas.put({ ...quota, error: null });
-    return refreshed;
   }
 
   private async fetchUpstream(
@@ -513,26 +430,8 @@ export class AccountPoolHub {
     body: Uint8Array,
     account: Account,
     secret: AccountSecret,
+    adapter: ProviderAdapter,
   ): Promise<UpstreamResult> {
-    const requestUrl = new URL(request.url);
-    const mountedPath = requestUrl.pathname.indexOf("/http/");
-    const upstreamPath =
-      mountedPath < 0
-        ? requestUrl.pathname
-        : requestUrl.pathname.slice(mountedPath + 5);
-    const upstreamUrl = new URL(
-      upstreamPath.replace(/^\//u, "") + requestUrl.search,
-      ensureSlash(this.options.getSettings().upstreamBaseUrl),
-    );
-    const headers = new Headers();
-    for (const [name, value] of request.headers) {
-      if (isAllowedRequestHeader(name)) headers.append(name, value);
-    }
-    if (secret.kind === "oauth") {
-      headers.set("authorization", `Bearer ${secret.accessToken}`);
-    } else {
-      headers.set("x-api-key", secret.apiKey);
-    }
     const controller = new AbortController();
     this.activeControllers.add(controller);
     this.increment(account.id);
@@ -546,12 +445,17 @@ export class AccountPoolHub {
     try {
       const upstreamBody = new ArrayBuffer(body.byteLength);
       new Uint8Array(upstreamBody).set(body);
-      const response = await this.options.fetch(upstreamUrl, {
-        method: request.method,
-        headers,
-        body: upstreamBody,
-        signal: controller.signal,
-      });
+      const response = await this.options.fetch(
+        adapter.upstreamUrl(request, this.options.getSettings()),
+        {
+          method: request.method,
+          headers: adapter.requestHeaders(request.headers, account, secret),
+          ...(request.method === "GET" || request.method === "HEAD"
+            ? {}
+            : { body: upstreamBody }),
+          signal: controller.signal,
+        },
+      );
       return { response, controller, release };
     } catch (error) {
       release();
@@ -587,24 +491,21 @@ export class AccountPoolHub {
           if (chunk.done) {
             upstream.release();
             controller.close();
-            return;
-          }
-          controller.enqueue(chunk.value);
+          } else controller.enqueue(chunk.value);
         } catch (error) {
           upstream.release();
-          if (eventStream) {
-            const message = errorMessage(error);
-            controller.enqueue(
-              new TextEncoder().encode(
-                `event: error\ndata: ${JSON.stringify({ type: "error", error: { type: "api_error", message } })}\n\n`,
-              ),
-            );
-            controller.close();
-          } else {
+          if (!eventStream) {
             controller.error(
               error instanceof Error ? error : new Error(String(error)),
             );
+            return;
           }
+          controller.enqueue(
+            new TextEncoder().encode(
+              `event: error\ndata: ${JSON.stringify({ type: "error", error: { type: "api_error", message: errorMessage(error) } })}\n\n`,
+            ),
+          );
+          controller.close();
         }
       },
       async cancel() {
@@ -623,13 +524,10 @@ export class AccountPoolHub {
   private noEligibleResponse(
     accounts: readonly Account[],
     family: ModelFamily,
+    adapter: ProviderAdapter,
   ): Response {
     if (!accounts.some((account) => account.enabled)) {
-      return anthropicError(
-        503,
-        "api_error",
-        "Account Pool has no enabled account",
-      );
+      return adapter.errorResponse(503, "Account Pool has no enabled account");
     }
     const now = this.options.now();
     const next = accounts
@@ -648,9 +546,8 @@ export class AccountPoolHub {
       1,
       Math.ceil(((next ?? now + 1_000) - now) / 1_000),
     );
-    return anthropicError(
+    return adapter.errorResponse(
       429,
-      "rate_limit_error",
       "No Account Pool account is currently eligible.",
       { "retry-after": String(retryAfter) },
     );
@@ -659,6 +556,13 @@ export class AccountPoolHub {
   private markError(accountId: string, message: string): void {
     const quota = this.options.quotas.get(accountId);
     this.options.quotas.put({ ...quota, error: message.slice(0, 1_000) });
+  }
+
+  private adapter(provider: PoolProvider): ProviderAdapter {
+    const adapter = this.options.adapters.get(provider);
+    if (adapter === undefined)
+      throw new Error(`Missing ${provider} Account Pool adapter.`);
+    return adapter;
   }
 
   private increment(accountId: string): void {
@@ -692,57 +596,49 @@ export function createHub(options: {
   fetch?: typeof fetch;
   now?: () => number;
   refreshUrl?: string;
+  codexRefreshUrl?: string;
+  importClaudeCredentials?: () => Promise<ImportedClaudeCredentials>;
+  importCodexCredentials?: () => Promise<ImportedCodexCredentials>;
   usageUrl?: string;
   profileUrl?: string;
   usageRefreshIntervalMs?: number;
   drainTimeoutMs?: number;
 }): AccountPoolHub {
+  const adapters: ReadonlyMap<PoolProvider, ProviderAdapter> = new Map([
+    [
+      "claude",
+      createClaudeAdapter({
+        refreshUrl: options.refreshUrl ?? DEFAULT_REFRESH_URL,
+        usageUrl: options.usageUrl ?? DEFAULT_USAGE_URL,
+        profileUrl: options.profileUrl ?? DEFAULT_PROFILE_URL,
+        importCredentials: options.importClaudeCredentials,
+      }),
+    ],
+    [
+      "codex",
+      createCodexAdapter({
+        refreshUrl: options.codexRefreshUrl ?? DEFAULT_CODEX_REFRESH_URL,
+        importCredentials: options.importCodexCredentials,
+      }),
+    ],
+  ]);
   return new AccountPoolHub({
     accounts: options.accounts,
     quotas: options.quotas,
     hubTokens: options.hubTokens,
     getSettings: options.getSettings,
+    adapters,
     fetch: options.fetch ?? fetch,
     now: options.now ?? Date.now,
-    refreshUrl: options.refreshUrl ?? DEFAULT_REFRESH_URL,
-    usageUrl: options.usageUrl ?? DEFAULT_USAGE_URL,
-    profileUrl: options.profileUrl ?? DEFAULT_PROFILE_URL,
     usageRefreshIntervalMs:
       options.usageRefreshIntervalMs ?? DEFAULT_USAGE_REFRESH_INTERVAL_MS,
     drainTimeoutMs: options.drainTimeoutMs ?? 60_000,
   });
 }
 
-function isAllowedRequestHeader(name: string): boolean {
-  const normalized = name.toLowerCase();
-  return (
-    ALLOWED_REQUEST_HEADERS.has(normalized) ||
-    ALLOWED_REQUEST_HEADER_PREFIXES.some((prefix) =>
-      normalized.startsWith(prefix),
-    )
-  );
-}
-
-function ensureSlash(value: string): string {
-  return value.endsWith("/") ? value : `${value}/`;
-}
-
 function readBearer(value: string | null): string | null {
   if (value === null) return null;
-  const match = /^Bearer\s+(.+)$/iu.exec(value);
-  return match?.[1] ?? null;
-}
-
-function anthropicError(
-  status: number,
-  type: string,
-  message: string,
-  headers?: HeadersInit,
-): Response {
-  return Response.json(
-    { type: "error", error: { type, message } },
-    { status, headers },
-  );
+  return /^Bearer\s+(.+)$/iu.exec(value)?.[1] ?? null;
 }
 
 function errorMessage(error: unknown): string {

--- a/plugins/account-pool/src/hub.ts
+++ b/plugins/account-pool/src/hub.ts
@@ -433,12 +433,19 @@ export class AccountPoolHub {
     adapter: ProviderAdapter,
   ): Promise<UpstreamResult> {
     const controller = new AbortController();
+    const abortFromRequest = () => controller.abort(request.signal.reason);
     this.activeControllers.add(controller);
     this.increment(account.id);
+    if (request.signal.aborted) abortFromRequest();
+    else
+      request.signal.addEventListener("abort", abortFromRequest, {
+        once: true,
+      });
     let released = false;
     const release = () => {
       if (released) return;
       released = true;
+      request.signal.removeEventListener("abort", abortFromRequest);
       this.activeControllers.delete(controller);
       this.decrement(account.id);
     };

--- a/plugins/account-pool/src/operations.ts
+++ b/plugins/account-pool/src/operations.ts
@@ -2,14 +2,11 @@ import type {
   Account,
   AccountSummary,
   HubTokenSummary,
+  PoolProvider,
   PoolStatus,
   RoutedThreadStatus,
 } from "./contracts.js";
 import type { AccountAddInput } from "./contracts.js";
-import {
-  importClaudeCredentials,
-  type ImportedClaudeCredentials,
-} from "./credentials.js";
 import type { AccountPoolHub } from "./hub.js";
 import type {
   AccountStore,
@@ -44,7 +41,6 @@ export class PoolOperations {
       hostId: string,
     ) => Promise<PoolProviderState[]>,
     private readonly now: () => number = Date.now,
-    private readonly importCredentials: () => Promise<ImportedClaudeCredentials> = importClaudeCredentials,
     private readonly onAccountsChanged: () => void = () => {},
     private readonly onAccountEnabled: (
       accountId: string,
@@ -53,6 +49,9 @@ export class PoolOperations {
 
   async add(input: AccountAddInput): Promise<Account> {
     if (input.source.kind === "api-key") {
+      if (input.provider !== "claude") {
+        throw new Error("Codex accounts can only be added with --import.");
+      }
       const account = await this.accounts.add(
         {
           provider: input.provider,
@@ -71,25 +70,23 @@ export class PoolOperations {
       await this.onAccountEnabled(account.id);
       return account;
     }
-    const imported = await this.importCredentials();
+    const imported = await this.hub.importAccount(input.provider);
     const account = await this.accounts.add(
       {
         provider: input.provider,
         kind: "oauth",
-        label: input.label ?? imported.email ?? "Claude Code account",
+        label: input.label ?? imported.label,
         email: imported.email,
-        accountUuid: imported.accountUuid,
+        accountUuid: imported.accountUuid ?? null,
+        ...(imported.codexAccountId === undefined
+          ? {}
+          : { codexAccountId: imported.codexAccountId }),
         subscriptionType: imported.subscriptionType,
         rateLimitTier: imported.rateLimitTier,
         enabled: true,
         priority: input.priority,
       },
-      {
-        kind: "oauth",
-        accessToken: imported.accessToken,
-        refreshToken: imported.refreshToken,
-        expiresAt: imported.expiresAt,
-      },
+      imported.secret,
     );
     this.onAccountsChanged();
     await this.onAccountEnabled(account.id);
@@ -195,9 +192,13 @@ export class PoolOperations {
     return { threadId, bypassed };
   }
 
-  async hasUsableEnabledAccount(): Promise<boolean> {
+  async hasUsableEnabledAccount(provider?: PoolProvider): Promise<boolean> {
     for (const account of await this.accounts.list()) {
-      if (!account.enabled) continue;
+      if (
+        !account.enabled ||
+        (provider !== undefined && account.provider !== provider)
+      )
+        continue;
       try {
         await this.accounts.readSecret(account.id);
         return true;

--- a/plugins/account-pool/src/provider-adapter.ts
+++ b/plugins/account-pool/src/provider-adapter.ts
@@ -1,0 +1,107 @@
+import type {
+  Account,
+  AccountQuota,
+  AccountSecret,
+  ModelFamily,
+  PoolProvider,
+} from "./contracts.js";
+import type { HubSettings } from "./hub.js";
+import type { AccountStore, QuotaStore } from "./store.js";
+
+export interface AdapterSecretContext {
+  account: Account;
+  secret: AccountSecret;
+  accounts: AccountStore;
+  quotas: QuotaStore;
+  fetch: typeof fetch;
+  now: () => number;
+}
+
+export interface AdapterUsageContext {
+  account: Account;
+  freshSecret: () => Promise<AccountSecret>;
+  accounts: AccountStore;
+  quotas: QuotaStore;
+  fetch: typeof fetch;
+  now: () => number;
+}
+
+export interface ImportedProviderAccount {
+  label: string;
+  email: string | null;
+  accountUuid?: string;
+  codexAccountId?: string;
+  subscriptionType: string | null;
+  rateLimitTier: string | null;
+  secret: Extract<AccountSecret, { kind: "oauth" }>;
+}
+
+export interface ProviderAdapter {
+  provider: PoolProvider;
+  upstreamName: string;
+  importAccount(): Promise<ImportedProviderAccount>;
+  modelFamily(body: Uint8Array): ModelFamily;
+  prepareBody(body: Uint8Array, account: Account): Uint8Array;
+  upstreamUrl(request: Request, settings: HubSettings): URL;
+  requestHeaders(
+    inbound: Headers,
+    account: Account,
+    secret: AccountSecret,
+  ): Headers;
+  quotaFromHeaders(
+    accountId: string,
+    headers: Headers,
+    previous: AccountQuota,
+    family: ModelFamily,
+    now: number,
+  ): AccountQuota;
+  isQuotaRejection(headers: Headers): boolean;
+  refreshSecret(
+    context: AdapterSecretContext,
+  ): Promise<{ secret: AccountSecret; refreshed: boolean }>;
+  refreshUsage?(context: AdapterUsageContext): Promise<void>;
+  errorResponse(
+    status: number,
+    message: string,
+    headers?: HeadersInit,
+  ): Response;
+}
+
+export function filterRequestHeaders(
+  inbound: Headers,
+  allowed: ReadonlySet<string>,
+  prefixes: readonly string[],
+): Headers {
+  const headers = new Headers();
+  for (const [name, value] of inbound) {
+    const normalized = name.toLowerCase();
+    if (
+      allowed.has(normalized) ||
+      prefixes.some((prefix) => normalized.startsWith(prefix))
+    ) {
+      headers.append(name, value);
+    }
+  }
+  return headers;
+}
+
+export function mountedUpstreamUrl(
+  request: Request,
+  upstreamBaseUrl: string,
+  stripPrefix = "",
+): URL {
+  const requestUrl = new URL(request.url);
+  const mountedPath = requestUrl.pathname.indexOf("/http/");
+  const rawPath =
+    mountedPath < 0
+      ? requestUrl.pathname
+      : requestUrl.pathname.slice(mountedPath + 5);
+  const normalizedPath = rawPath.replace(/^\//u, "");
+  const upstreamPath = normalizedPath.startsWith(stripPrefix)
+    ? normalizedPath.slice(stripPrefix.length)
+    : normalizedPath;
+  return new URL(
+    upstreamPath + requestUrl.search,
+    upstreamBaseUrl.endsWith("/") ? upstreamBaseUrl : `${upstreamBaseUrl}/`,
+  );
+}

--- a/plugins/account-pool/src/server.test.ts
+++ b/plugins/account-pool/src/server.test.ts
@@ -713,6 +713,91 @@ describe("Account Pool plugin", () => {
     expect(socket.sent).toHaveLength(1);
   });
 
+  it("releases a Codex request when an upstream SSE event is malformed", async () => {
+    const dataDir = await mkdtemp(
+      path.join(tmpdir(), "bb-account-pool-codex-malformed-"),
+    );
+    let upstreamReadCanceled = false;
+    const upstreamFetch = async (): Promise<Response> => {
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("data: {\n\n"));
+        },
+        cancel() {
+          upstreamReadCanceled = true;
+        },
+      });
+      return new Response(body, {
+        headers: { "content-type": "text/event-stream" },
+      });
+    };
+    const host = createFakePluginHost({
+      pluginId: "account-pool",
+      dataDir,
+      settings: {
+        codexUpstreamBaseUrl: "https://example.com",
+      },
+      sdk: sdkStubs(),
+    });
+    await createAccountPoolPlugin({
+      fetch: upstreamFetch,
+      importCodexCredentials: async () => ({
+        accessToken: "access",
+        refreshToken: "refresh",
+        idToken: null,
+        accountId: "account",
+        email: null,
+        expiresAt: null,
+      }),
+    })(host.bb);
+    const service = host.harness.behavior.runService("hub");
+    cleanups.push(async () => {
+      service.controller.abort();
+      await service.done;
+      await host.harness.lifecycle.dispose();
+      await fs.rm(dataDir, { recursive: true, force: true });
+    });
+    await vi.waitFor(async () => {
+      expect(
+        statusSchema.parse(await host.harness.behavior.callRpc("status", null))
+          .accepting,
+      ).toBe(true);
+    });
+    await host.harness.behavior.callRpc("account.add", {
+      provider: "codex",
+      source: { kind: "import" },
+      label: null,
+      priority: 100,
+    });
+    const { token } = await resolveCodexToken(host);
+    const socket = await host.harness.experimental_openWebSocket(
+      "/v1/responses",
+      { headers: { "x-bb-account-pool-token": token } },
+    );
+    await socket.receive(
+      JSON.stringify({
+        type: "response.create",
+        model: "gpt-5",
+        input: [],
+      }),
+    );
+    await vi.waitFor(async () => {
+      expect(JSON.parse(String(socket.sent[0]))).toMatchObject({
+        type: "response.failed",
+        response: { error: { code: "proxy_error" } },
+      });
+      expect(upstreamReadCanceled).toBe(true);
+      const statusResult = await host.harness.behavior.runCli([
+        "status",
+        "--json",
+      ]);
+      expect(statusResult.exitCode).toBe(0);
+      expect(statusSchema.parse(JSON.parse(statusResult.stdout)).inFlight).toBe(
+        0,
+      );
+    });
+  });
+
   it("prunes token files for unenrolled hosts on startup and status", async () => {
     const dataDir = await mkdtemp(path.join(tmpdir(), "bb-pool-prune-"));
     const secretDir = path.join(

--- a/plugins/account-pool/src/server.test.ts
+++ b/plugins/account-pool/src/server.test.ts
@@ -13,7 +13,10 @@ import {
   type AccountSummary,
 } from "./contracts.js";
 import { z } from "zod";
-import type { ImportedClaudeCredentials } from "./credentials.js";
+import type {
+  ImportedClaudeCredentials,
+  ImportedCodexCredentials,
+} from "./credentials.js";
 import { HubTokenStore } from "./store.js";
 import {
   createAccountPoolPlugin,
@@ -82,6 +85,27 @@ async function resolveToken(
     throw new Error("Account Pool token was not resolved.");
   }
   return token.value;
+}
+
+async function resolveCodexToken(
+  host: ReturnType<typeof createFakePluginHost>,
+): Promise<{ token: string; baseUrl: string }> {
+  const entries = await host.harness.behavior.resolveProviderEnv("codex", {
+    threadId: "thread-codex",
+    projectId: "project-one",
+    hostId: "host-one",
+  });
+  const token = entries.find((entry) => entry.name === "CODEX_POOL_AUTH_TOKEN");
+  const baseUrl = entries.find(
+    (entry) => entry.name === "CODEX_OPENAI_BASE_URL",
+  );
+  if (token === undefined || typeof token.value !== "string") {
+    throw new Error("Codex Account Pool token was not resolved.");
+  }
+  if (baseUrl === undefined || typeof baseUrl.value !== "object") {
+    throw new Error("Codex Account Pool base URL was not resolved.");
+  }
+  return { token: token.value, baseUrl: baseUrl.value.serverPath };
 }
 
 afterEach(async () => {
@@ -202,6 +226,21 @@ function authHeaders(key: string): Record<string, string> {
   };
 }
 
+const completedResponseSchema = z
+  .object({
+    type: z.literal("response.completed"),
+    response: z
+      .object({ id: z.string(), output: z.array(z.json()).default([]) })
+      .passthrough(),
+  })
+  .passthrough();
+
+function completedResponse(value: string | Uint8Array | undefined) {
+  if (typeof value !== "string")
+    throw new Error("Expected a text WebSocket frame.");
+  return completedResponseSchema.parse(JSON.parse(value));
+}
+
 async function addApiAccount(
   fixture: Fixture,
   apiKey: string,
@@ -224,6 +263,355 @@ async function addApiAccount(
 }
 
 describe("Account Pool plugin", () => {
+  it("imports, refreshes, and routes Codex HTTP and WebSocket sessions by provider", async () => {
+    const seen: Array<{
+      path: string;
+      authorization: string | undefined;
+      accountId: string | undefined;
+      body: string;
+    }> = [];
+    const modelRequests: string[] = [];
+    let responseNumber = 0;
+    const futureToken = `header.${Buffer.from(JSON.stringify({ exp: Math.floor(Date.now() / 1_000) + 3_600 })).toString("base64url")}.signature`;
+    const upstream = await startUpstream(async (request, response) => {
+      const body = (await readRequestBody(request)).toString("utf8");
+      if (request.url === "/oauth") {
+        const parsed = z
+          .object({
+            client_id: z.literal("app_EMoamEEZ73f0CkXaXp7hrann"),
+            grant_type: z.literal("refresh_token"),
+            refresh_token: z.string(),
+          })
+          .parse(JSON.parse(body));
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(
+          JSON.stringify({
+            access_token: futureToken,
+            refresh_token: `next-${parsed.refresh_token}`,
+            id_token: "next-id-token",
+          }),
+        );
+        return;
+      }
+      if (request.url === "/models") {
+        modelRequests.push(
+          request.headers["chatgpt-account-id"]?.toString() ?? "",
+        );
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end('{"data":[]}');
+        return;
+      }
+      responseNumber += 1;
+      seen.push({
+        path: request.url ?? "",
+        authorization: request.headers.authorization,
+        accountId: z
+          .string()
+          .optional()
+          .parse(request.headers["chatgpt-account-id"]),
+        body,
+      });
+      if (responseNumber === 1) {
+        response.writeHead(200, {
+          "content-type": "application/json",
+          "x-codex-primary-used-percent": "25",
+          "x-codex-primary-reset-after-seconds": "3600",
+          "x-codex-secondary-used-percent": "40",
+          "x-codex-secondary-reset-after-seconds": "86400",
+        });
+        response.end('{"id":"http-response"}');
+        return;
+      }
+      if (responseNumber === 2) {
+        response.writeHead(429, {
+          "content-type": "application/json",
+          "x-codex-primary-used-percent": "100",
+        });
+        response.end('{"error":{"message":"quota exhausted"}}');
+        return;
+      }
+      const id = `response-${responseNumber}`;
+      response.writeHead(200, {
+        "content-type": "text/event-stream",
+      });
+      response.end(
+        `event: response.created\ndata: ${JSON.stringify({
+          type: "response.created",
+          response: { id },
+        })}\n\nevent: response.completed\ndata: ${JSON.stringify({
+          type: "response.completed",
+          response: {
+            id,
+            output: [{ type: "message", id: `message-${responseNumber}` }],
+          },
+        })}\n\ndata: [DONE]\n\n`,
+      );
+    });
+    cleanups.push(upstream.close);
+    const dataDir = await mkdtemp(
+      path.join(tmpdir(), "bb-account-pool-codex-"),
+    );
+    let imported = 0;
+    const importCodexCredentials =
+      async (): Promise<ImportedCodexCredentials> => {
+        imported += 1;
+        return {
+          accessToken: "expired-token",
+          refreshToken: `refresh-${imported}`,
+          idToken: "id-token",
+          accountId: `chatgpt-account-${imported}`,
+          email: `codex-${imported}@example.com`,
+          expiresAt: Date.now() - 1,
+        };
+      };
+    const host = createFakePluginHost({
+      pluginId: "account-pool",
+      dataDir,
+      settings: {
+        upstreamBaseUrl: upstream.url,
+        codexUpstreamBaseUrl: upstream.url,
+        switchThreshold: 0.98,
+      },
+      sdk: sdkStubs(),
+    });
+    await createAccountPoolPlugin({
+      codexRefreshUrl: `${upstream.url}/oauth`,
+      importCodexCredentials,
+      usageUrl: "data:application/json,{}",
+    })(host.bb);
+    const service = host.harness.behavior.runService("hub");
+    cleanups.push(async () => {
+      service.controller.abort();
+      await service.done;
+      await host.harness.lifecycle.dispose();
+      await fs.rm(dataDir, { recursive: true, force: true });
+    });
+    await vi.waitFor(async () => {
+      expect(
+        statusSchema.parse(await host.harness.behavior.callRpc("status", null))
+          .accepting,
+      ).toBe(true);
+    });
+    await host.harness.behavior.callRpc("account.add", {
+      provider: "claude",
+      source: { kind: "api-key", apiKey: "claude-key" },
+      label: "Claude first",
+      priority: 0,
+    });
+    const importedByCli = await host.harness.behavior.runCli([
+      "account",
+      "add",
+      "--provider",
+      "codex",
+      "--import",
+    ]);
+    expect(importedByCli.exitCode).toBe(0);
+    await host.harness.behavior.callRpc("account.add", {
+      provider: "codex",
+      source: { kind: "import" },
+      label: null,
+      priority: 100,
+    });
+    const accountTable = await host.harness.behavior.runCli([
+      "account",
+      "list",
+    ]);
+    expect(accountTable.stdout).toContain("Provider");
+    expect(accountTable.stdout).toContain("codex");
+    const routed = await resolveCodexToken(host);
+    expect(routed.baseUrl).toBe("/api/v1/plugins/account-pool/http/v1");
+    await expect(
+      host.harness.behavior.resolveProviderEnvHealth("codex", {
+        hostId: "host-one",
+      }),
+    ).resolves.toEqual({
+      label: "Proxied",
+      statusMessage: "Credentials are provided by the Account Pool hub.",
+    });
+    const httpResponse = await host.harness.behavior.fetchHttp(
+      "POST",
+      "/v1/responses",
+      {
+        headers: {
+          authorization: "Bearer local-codex-token",
+          "x-bb-account-pool-token": routed.token,
+          "content-type": "application/json",
+          "openai-beta": "responses=experimental",
+        },
+        body: JSON.stringify({ model: "gpt-5", input: [] }),
+      },
+    );
+    expect(httpResponse.status).toBe(200);
+    expect(await httpResponse.json()).toEqual({ id: "http-response" });
+    const modelsResponse = await host.harness.behavior.fetchHttp(
+      "GET",
+      "/v1/models",
+      {
+        headers: { "x-bb-account-pool-token": routed.token },
+      },
+    );
+    expect(await modelsResponse.json()).toEqual({ data: [] });
+    expect(modelRequests).toHaveLength(1);
+    expect(modelRequests[0]).toMatch(/^chatgpt-account-[12]$/u);
+    expect(seen[0]).toMatchObject({
+      path: "/responses",
+      authorization: `Bearer ${futureToken}`,
+      accountId: "chatgpt-account-1",
+    });
+    const socket = await host.harness.experimental_openWebSocket(
+      "/v1/responses",
+      {
+        headers: {
+          "x-bb-account-pool-token": routed.token,
+          "openai-beta": "responses_websockets",
+        },
+      },
+    );
+    await socket.receive(
+      JSON.stringify({
+        type: "response.create",
+        generate: false,
+        input: [{ type: "message", id: "prefix" }],
+      }),
+    );
+    const prewarm = completedResponse(socket.sent[0]);
+    await socket.receive(
+      JSON.stringify({
+        type: "response.create",
+        previous_response_id: prewarm.response.id,
+        model: "gpt-5",
+        input: [{ type: "message", id: "delta-one" }],
+      }),
+    );
+    expect(JSON.parse(String(socket.sent[1]))).toMatchObject({
+      type: "response.created",
+    });
+    const first = completedResponse(socket.sent[2]);
+    await socket.receive(
+      JSON.stringify({
+        type: "response.create",
+        previous_response_id: first.response.id,
+        model: "gpt-5",
+        input: [{ type: "message", id: "delta-two" }],
+      }),
+    );
+    expect(socket.sent.map((frame) => JSON.parse(String(frame)).type)).toEqual([
+      "response.completed",
+      "response.created",
+      "response.completed",
+      "response.created",
+      "response.completed",
+    ]);
+    expect(seen[1]?.accountId).not.toBe(seen[2]?.accountId);
+    expect(seen[2]?.accountId).toBe(seen[3]?.accountId);
+    expect(JSON.parse(seen[3]?.body ?? "{}").input).toEqual([
+      { type: "message", id: "prefix" },
+      { type: "message", id: "delta-one" },
+      { type: "message", id: "message-3" },
+      { type: "message", id: "delta-two" },
+    ]);
+    await socket.close(1000, "done");
+    const status = statusSchema.parse(
+      await host.harness.behavior.callRpc("status", null),
+    );
+    const firstCodex = status.accounts.find(
+      (account) => account.codexAccountId === "chatgpt-account-1",
+    );
+    expect(firstCodex).toMatchObject({
+      provider: "codex",
+      sevenDayUtilization: 0.4,
+    });
+    expect(
+      status.accounts.find(
+        (account) => account.codexAccountId === seen[1]?.accountId,
+      ),
+    ).toMatchObject({
+      provider: "codex",
+      fiveHourUtilization: 1,
+    });
+    const secret = accountSecretSchema.parse(
+      JSON.parse(
+        await fs.readFile(
+          path.join(
+            dataDir,
+            "plugins",
+            "account-pool",
+            "secrets",
+            "accounts",
+            `account-${firstCodex?.id}.json`,
+          ),
+          "utf8",
+        ),
+      ),
+    );
+    expect(secret).toMatchObject({
+      accessToken: futureToken,
+      refreshToken: "next-refresh-1",
+      idToken: "next-id-token",
+    });
+  });
+
+  it("fails an unknown Codex WebSocket response id and closes with 1011", async () => {
+    const dataDir = await mkdtemp(
+      path.join(tmpdir(), "bb-account-pool-codex-unknown-"),
+    );
+    const host = createFakePluginHost({
+      pluginId: "account-pool",
+      dataDir,
+      sdk: sdkStubs(),
+    });
+    await createAccountPoolPlugin({
+      importCodexCredentials: async () => ({
+        accessToken: "access",
+        refreshToken: "refresh",
+        idToken: null,
+        accountId: "account",
+        email: null,
+        expiresAt: null,
+      }),
+    })(host.bb);
+    const service = host.harness.behavior.runService("hub");
+    cleanups.push(async () => {
+      service.controller.abort();
+      await service.done;
+      await host.harness.lifecycle.dispose();
+      await fs.rm(dataDir, { recursive: true, force: true });
+    });
+    await host.harness.behavior.callRpc("account.add", {
+      provider: "codex",
+      source: { kind: "import" },
+      label: null,
+      priority: 100,
+    });
+    const { token } = await resolveCodexToken(host);
+    const rejected = await host.harness.experimental_openWebSocket(
+      "/v1/responses",
+      { headers: { "x-bb-account-pool-token": "invalid" } },
+    );
+    expect(rejected.closeCalls).toEqual([
+      { code: 1008, reason: "invalid Account Pool token" },
+    ]);
+    const socket = await host.harness.experimental_openWebSocket(
+      "/v1/responses",
+      {
+        headers: { "x-bb-account-pool-token": token },
+      },
+    );
+    await socket.receive(
+      JSON.stringify({
+        type: "response.create",
+        previous_response_id: "missing",
+        input: [],
+      }),
+    );
+    expect(JSON.parse(String(socket.sent[0]))).toMatchObject({
+      type: "response.failed",
+      response: { error: { code: "unknown_previous_response_id" } },
+    });
+    expect(socket.closeCalls).toEqual([
+      { code: 1011, reason: "unknown previous_response_id" },
+    ]);
+  });
   it("prunes token files for unenrolled hosts on startup and status", async () => {
     const dataDir = await mkdtemp(path.join(tmpdir(), "bb-pool-prune-"));
     const secretDir = path.join(
@@ -347,7 +735,7 @@ describe("Account Pool plugin", () => {
       }),
     ).resolves.toBeNull();
     expect(host.harness.inspection.needsConfigurationMessages).toEqual([
-      "Add and enable a Claude account with `bb pool account add`.",
+      "Add and enable a Claude or Codex account with `bb pool account add`.",
     ]);
     const hello = helloResponse();
     expect(hello.status).toBe(200);

--- a/plugins/account-pool/src/server.test.ts
+++ b/plugins/account-pool/src/server.test.ts
@@ -474,6 +474,7 @@ describe("Account Pool plugin", () => {
         input: [{ type: "message", id: "prefix" }],
       }),
     );
+    await vi.waitFor(() => expect(socket.sent).toHaveLength(1));
     const prewarm = completedResponse(socket.sent[0]);
     await socket.receive(
       JSON.stringify({
@@ -483,6 +484,7 @@ describe("Account Pool plugin", () => {
         input: [{ type: "message", id: "delta-one" }],
       }),
     );
+    await vi.waitFor(() => expect(socket.sent).toHaveLength(3));
     expect(JSON.parse(String(socket.sent[1]))).toMatchObject({
       type: "response.created",
     });
@@ -495,6 +497,7 @@ describe("Account Pool plugin", () => {
         input: [{ type: "message", id: "delta-two" }],
       }),
     );
+    await vi.waitFor(() => expect(socket.sent).toHaveLength(5));
     expect(socket.sent.map((frame) => JSON.parse(String(frame)).type)).toEqual([
       "response.completed",
       "response.created",
@@ -604,6 +607,7 @@ describe("Account Pool plugin", () => {
         input: [],
       }),
     );
+    await vi.waitFor(() => expect(socket.closeCalls).toHaveLength(1));
     expect(JSON.parse(String(socket.sent[0]))).toMatchObject({
       type: "response.failed",
       response: { error: { code: "unknown_previous_response_id" } },
@@ -612,6 +616,103 @@ describe("Account Pool plugin", () => {
       { code: 1011, reason: "unknown previous_response_id" },
     ]);
   });
+
+  it("cancels a Codex upstream read when its WebSocket closes", async () => {
+    const dataDir = await mkdtemp(
+      path.join(tmpdir(), "bb-account-pool-codex-cancel-"),
+    );
+    let upstreamReadCanceled = false;
+    const upstreamFetch = async (
+      _input: string | URL | Request,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      const signal = init?.signal;
+      if (signal === undefined || signal === null) {
+        throw new Error("Expected the upstream request to carry a signal.");
+      }
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(
+            new TextEncoder().encode(
+              'event: response.created\ndata: {"type":"response.created","response":{"id":"streaming"}}\n\n',
+            ),
+          );
+          signal.addEventListener(
+            "abort",
+            () => {
+              upstreamReadCanceled = true;
+              controller.error(signal.reason);
+            },
+            { once: true },
+          );
+        },
+      });
+      return new Response(body, {
+        headers: { "content-type": "text/event-stream" },
+      });
+    };
+    const host = createFakePluginHost({
+      pluginId: "account-pool",
+      dataDir,
+      settings: {
+        codexUpstreamBaseUrl: "https://example.com",
+      },
+      sdk: sdkStubs(),
+    });
+    await createAccountPoolPlugin({
+      fetch: upstreamFetch,
+      importCodexCredentials: async () => ({
+        accessToken: "access",
+        refreshToken: "refresh",
+        idToken: null,
+        accountId: "account",
+        email: null,
+        expiresAt: null,
+      }),
+    })(host.bb);
+    const service = host.harness.behavior.runService("hub");
+    cleanups.push(async () => {
+      service.controller.abort();
+      await service.done;
+      await host.harness.lifecycle.dispose();
+      await fs.rm(dataDir, { recursive: true, force: true });
+    });
+    await vi.waitFor(async () => {
+      expect(
+        statusSchema.parse(await host.harness.behavior.callRpc("status", null))
+          .accepting,
+      ).toBe(true);
+    });
+    await host.harness.behavior.callRpc("account.add", {
+      provider: "codex",
+      source: { kind: "import" },
+      label: null,
+      priority: 100,
+    });
+    const { token } = await resolveCodexToken(host);
+    const socket = await host.harness.experimental_openWebSocket(
+      "/v1/responses",
+      { headers: { "x-bb-account-pool-token": token } },
+    );
+    await socket.receive(
+      JSON.stringify({
+        type: "response.create",
+        model: "gpt-5",
+        input: [],
+      }),
+    );
+    await vi.waitFor(() => expect(socket.sent).toHaveLength(1));
+    await socket.close(1000, "interrupted");
+    await vi.waitFor(async () => {
+      expect(upstreamReadCanceled).toBe(true);
+      expect(
+        statusSchema.parse(await host.harness.behavior.callRpc("status", null))
+          .inFlight,
+      ).toBe(0);
+    });
+    expect(socket.sent).toHaveLength(1);
+  });
+
   it("prunes token files for unenrolled hosts on startup and status", async () => {
     const dataDir = await mkdtemp(path.join(tmpdir(), "bb-pool-prune-"));
     const secretDir = path.join(

--- a/plugins/account-pool/src/server.ts
+++ b/plugins/account-pool/src/server.ts
@@ -2,7 +2,11 @@ import path from "node:path";
 import type { BbPluginApi } from "@get-bb/plugin-sdk";
 import { z } from "zod";
 import { registerPoolCli } from "./cli.js";
-import type { ImportedClaudeCredentials } from "./credentials.js";
+import type {
+  ImportedClaudeCredentials,
+  ImportedCodexCredentials,
+} from "./credentials.js";
+import { createCodexWebSocketHandlers } from "./codex-websocket.js";
 import { createHub } from "./hub.js";
 import { PoolOperations } from "./operations.js";
 import { accountPoolRpcContract, createRpcHandlers } from "./rpc.js";
@@ -20,11 +24,13 @@ export interface AccountPoolPluginOptions {
   fetch?: typeof fetch;
   now?: () => number;
   refreshUrl?: string;
+  codexRefreshUrl?: string;
   usageUrl?: string;
   usageRefreshIntervalMs?: number;
   drainTimeoutMs?: number;
   disposeTimeoutMs?: number;
   importCredentials?: () => Promise<ImportedClaudeCredentials>;
+  importCodexCredentials?: () => Promise<ImportedCodexCredentials>;
   oauthAuthorizeUrl?: string;
   oauthTokenUrl?: string;
   oauthProfileUrl?: string;
@@ -56,6 +62,14 @@ export function createAccountPoolPlugin(
         description:
           "Override only for tests and QA. Production traffic uses https://api.anthropic.com.",
         default: "https://api.anthropic.com",
+        experimental_schema: upstreamSchema,
+      },
+      codexUpstreamBaseUrl: {
+        type: "string",
+        label: "Codex upstream base URL",
+        description:
+          "Override only for tests and QA. Production traffic uses the ChatGPT Codex backend.",
+        default: "https://chatgpt.com/backend-api/codex",
         experimental_schema: upstreamSchema,
       },
       switchThreshold: {
@@ -97,8 +111,11 @@ export function createAccountPoolPlugin(
       fetch: options.fetch,
       now,
       refreshUrl: options.refreshUrl,
+      codexRefreshUrl: options.codexRefreshUrl,
       usageUrl: options.usageUrl,
       profileUrl: options.oauthProfileUrl,
+      importClaudeCredentials: options.importCredentials,
+      importCodexCredentials: options.importCodexCredentials,
       usageRefreshIntervalMs: options.usageRefreshIntervalMs,
       drainTimeoutMs: options.drainTimeoutMs,
     });
@@ -112,7 +129,6 @@ export function createAccountPoolPlugin(
       async (hostId) =>
         (await bb.sdk.system.providerStates({ hostId })).providers,
       now,
-      options.importCredentials,
       () => bb.realtime.publish(ACCOUNT_POOL_ACCOUNTS_CHANGED, {}),
       (accountId) => hub.refreshUsage(accountId, true),
     );
@@ -126,7 +142,7 @@ export function createAccountPoolPlugin(
     });
     if ((await accounts.list()).every((account) => !account.enabled)) {
       bb.status.needsConfiguration(
-        "Add and enable a Claude account with `bb pool account add`.",
+        "Add and enable a Claude or Codex account with `bb pool account add`.",
       );
     }
     bb.rpc.register(
@@ -137,7 +153,7 @@ export function createAccountPoolPlugin(
     bb.providers.experimental_contributeEnv("claude-code", async (context) => {
       if (
         (await routing.isBypassed(context.threadId)) ||
-        !(await operations.hasUsableEnabledAccount())
+        !(await operations.hasUsableEnabledAccount("claude"))
       ) {
         return [];
       }
@@ -168,7 +184,40 @@ export function createAccountPoolPlugin(
       ];
     });
     bb.providers.experimental_contributeEnvHealth("claude-code", async () =>
-      (await operations.hasUsableEnabledAccount())
+      (await operations.hasUsableEnabledAccount("claude"))
+        ? {
+            label: "Proxied",
+            statusMessage: "Credentials are provided by the Account Pool hub.",
+          }
+        : null,
+    );
+    bb.providers.experimental_contributeEnv("codex", async (context) => {
+      if (
+        (await routing.isBypassed(context.threadId)) ||
+        !(await operations.hasUsableEnabledAccount("codex"))
+      ) {
+        return [];
+      }
+      const token = await hubTokens.forHost(context.hostId);
+      return [
+        {
+          name: "CODEX_OPENAI_BASE_URL",
+          value: {
+            serverPath: "/api/v1/plugins/account-pool/http/v1",
+          },
+          reason: "Routed through the Account Pool hub",
+          secret: false,
+        },
+        {
+          name: "CODEX_POOL_AUTH_TOKEN",
+          value: token,
+          reason: "Account Pool hub token for this machine",
+          secret: true,
+        },
+      ];
+    });
+    bb.providers.experimental_contributeEnvHealth("codex", async () =>
+      (await operations.hasUsableEnabledAccount("codex"))
         ? {
             label: "Proxied",
             statusMessage: "Credentials are provided by the Account Pool hub.",
@@ -205,13 +254,30 @@ export function createAccountPoolPlugin(
     bb.http.route(
       "POST",
       "/v1/messages",
-      (context) => hub.handle(context.req.raw),
+      (context) => hub.handle(context.req.raw, "claude"),
       { auth: "none" },
     );
     bb.http.route(
       "POST",
       "/v1/messages/count_tokens",
-      (context) => hub.handle(context.req.raw),
+      (context) => hub.handle(context.req.raw, "claude"),
+      { auth: "none" },
+    );
+    bb.http.route(
+      "POST",
+      "/v1/responses",
+      (context) => hub.handle(context.req.raw, "codex"),
+      { auth: "none" },
+    );
+    bb.http.route(
+      "GET",
+      "/v1/models",
+      (context) => hub.handle(context.req.raw, "codex"),
+      { auth: "none" },
+    );
+    bb.http.experimental_websocket(
+      "/v1/responses",
+      (context) => createCodexWebSocketHandlers(context, hub, bb.log),
       { auth: "none" },
     );
     bb.http.route("HEAD", "/api/hello", () => helloResponse(), {

--- a/plugins/provider-codex/src/bridge/app-server-launch.test.ts
+++ b/plugins/provider-codex/src/bridge/app-server-launch.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveAppServerLaunch } from "./bridge.js";
+
+afterEach(() => vi.unstubAllEnvs());
+
+describe("Codex Account Pool launch", () => {
+  it("adds an in-memory base URL and environment-backed hub header", () => {
+    vi.stubEnv("CODEX_OPENAI_BASE_URL", "https://bb.example/pool/v1");
+    vi.stubEnv("CODEX_POOL_AUTH_TOKEN", "secret-machine-token");
+    const launch = resolveAppServerLaunch();
+    expect(launch.command).toBe("codex");
+    expect(launch.args).toContain(
+      'openai_base_url="https://bb.example/pool/v1"',
+    );
+    expect(launch.args).toContain('model_provider="bb-account-pool"');
+    expect(launch.args).toContain(
+      'model_providers.bb-account-pool.env_http_headers.x-bb-account-pool-token="CODEX_POOL_AUTH_TOKEN"',
+    );
+    expect(JSON.stringify(launch.args)).not.toContain("secret-machine-token");
+  });
+
+  it("does not partially route when either required variable is missing", () => {
+    vi.stubEnv("CODEX_OPENAI_BASE_URL", "https://bb.example/pool/v1");
+    expect(resolveAppServerLaunch()).toEqual({
+      command: "codex",
+      args: ["app-server"],
+    });
+  });
+});

--- a/plugins/provider-codex/src/bridge/bridge.ts
+++ b/plugins/provider-codex/src/bridge/bridge.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { createHash } from "node:crypto";
 import {
   isStandaloneBuiltinCompactCommand,
   approvalInteractionOutcomeSchema,
@@ -268,6 +269,8 @@ function sendRuntimeRequest(
 
 const CODEX_APP_SERVER_COMMAND_ENV = "BB_CODEX_BRIDGE_APP_SERVER_COMMAND";
 const CODEX_APP_SERVER_ARGS_ENV = "BB_CODEX_BRIDGE_APP_SERVER_ARGS";
+const CODEX_POOL_BASE_URL_ENV = "CODEX_OPENAI_BASE_URL";
+const CODEX_POOL_AUTH_TOKEN_ENV = "CODEX_POOL_AUTH_TOKEN";
 
 const CODEX_INITIALIZE_PARAMS = {
   clientInfo: { name: "bb", version: "1.0.0", title: null },
@@ -328,21 +331,67 @@ async function delay(ms: number): Promise<void> {
 const MISSING_CODEX_CLI_GUIDANCE =
   "bb could not find the Codex CLI on this machine. Install Codex (https://developers.openai.com/codex/cli) or put `codex` on PATH, then retry.";
 
-function resolveAppServerLaunch(): { command: string; args: string[] } {
-  const command = process.env[CODEX_APP_SERVER_COMMAND_ENV];
-  if (!command) {
-    return { command: "codex", args: ["app-server"] };
-  }
-  const rawArgs = process.env[CODEX_APP_SERVER_ARGS_ENV];
-  if (!rawArgs) {
-    return { command, args: [] };
-  }
-  return { command, args: z.array(z.string()).parse(JSON.parse(rawArgs)) };
+export function resolveAppServerLaunch(env: NodeJS.ProcessEnv = process.env): {
+  command: string;
+  args: string[];
+} {
+  const command = env[CODEX_APP_SERVER_COMMAND_ENV];
+  const rawArgs = env[CODEX_APP_SERVER_ARGS_ENV];
+  const args = command
+    ? rawArgs
+      ? z.array(z.string()).parse(JSON.parse(rawArgs))
+      : []
+    : ["app-server"];
+  const poolBaseUrl = env[CODEX_POOL_BASE_URL_ENV];
+  const poolToken = env[CODEX_POOL_AUTH_TOKEN_ENV];
+  if (!poolBaseUrl || !poolToken) return { command: command ?? "codex", args };
+  return {
+    command: command ?? "codex",
+    args: [
+      ...args,
+      "-c",
+      `openai_base_url=${JSON.stringify(poolBaseUrl)}`,
+      "-c",
+      'model_provider="bb-account-pool"',
+      "-c",
+      'model_providers.bb-account-pool.name="OpenAI"',
+      "-c",
+      `model_providers.bb-account-pool.base_url=${JSON.stringify(poolBaseUrl)}`,
+      "-c",
+      'model_providers.bb-account-pool.wire_api="responses"',
+      "-c",
+      "model_providers.bb-account-pool.requires_openai_auth=true",
+      "-c",
+      "model_providers.bb-account-pool.supports_websockets=true",
+      "-c",
+      'model_providers.bb-account-pool.env_http_headers.x-bb-account-pool-token="CODEX_POOL_AUTH_TOKEN"',
+    ],
+  };
 }
 
-function buildAppServerEnv(): NodeJS.ProcessEnv {
+function appServerLaunchEnv(
+  envVars: Readonly<Record<string, string>> | undefined,
+): NodeJS.ProcessEnv {
+  const poolBaseUrl = envVars?.[CODEX_POOL_BASE_URL_ENV];
+  const poolAuthToken = envVars?.[CODEX_POOL_AUTH_TOKEN_ENV];
+  return {
+    ...process.env,
+    ...(poolBaseUrl === undefined
+      ? {}
+      : { [CODEX_POOL_BASE_URL_ENV]: poolBaseUrl }),
+    ...(poolAuthToken === undefined
+      ? {}
+      : { [CODEX_POOL_AUTH_TOKEN_ENV]: poolAuthToken }),
+  };
+}
+
+function buildAppServerEnv(
+  envVars: Readonly<Record<string, string>> | undefined,
+): NodeJS.ProcessEnv {
   return withoutBridgeRuntimeEnv(
-    sanitizeInheritedChildProcessEnv({ env: process.env }),
+    sanitizeInheritedChildProcessEnv({
+      env: appServerLaunchEnv(envVars),
+    }),
   );
 }
 
@@ -463,6 +512,8 @@ function constructionSignature(
   sessionOptions: CodexSessionOptions,
 ): string {
   const permissionSettings = toCodexThreadPermissionSettings(sessionOptions);
+  const poolBaseUrl = sessionOptions.envVars?.[CODEX_POOL_BASE_URL_ENV];
+  const poolToken = sessionOptions.envVars?.[CODEX_POOL_AUTH_TOKEN_ENV];
   return JSON.stringify({
     cwd,
     reasoningLevel: sessionOptions.reasoningLevel ?? null,
@@ -471,6 +522,13 @@ function constructionSignature(
     approvalPolicy: permissionSettings.approvalPolicy,
     approvalsReviewer: permissionSettings.approvalsReviewer,
     sandbox: permissionSettings.sandbox,
+    poolRoute:
+      poolBaseUrl === undefined || poolToken === undefined
+        ? null
+        : {
+            baseUrl: poolBaseUrl,
+            tokenHash: createHash("sha256").update(poolToken).digest("hex"),
+          },
   });
 }
 
@@ -771,6 +829,7 @@ function handleChildExit(
 }
 
 function spawnChildConnection(callbacks: {
+  envVars?: Readonly<Record<string, string>>;
   recordThreadId: string | null;
   onNotification: (method: string, params: unknown) => void;
   onRequest: (
@@ -780,13 +839,15 @@ function spawnChildConnection(callbacks: {
   ) => void;
   onExit: (info: CodexAppServerExitInfo) => void;
 }): CodexAppServerConnection {
-  const launch = resolveAppServerLaunch();
+  const env = buildAppServerEnv(callbacks.envVars);
+  const launch = resolveAppServerLaunch(appServerLaunchEnv(callbacks.envVars));
+  const { envVars: _envVars, ...connectionCallbacks } = callbacks;
   return createCodexAppServerConnection({
     command: launch.command,
     args: launch.args,
     cwd: process.cwd(),
-    env: buildAppServerEnv(),
-    ...callbacks,
+    env,
+    ...connectionCallbacks,
   });
 }
 
@@ -922,6 +983,7 @@ async function constructThreadSession(
   sendThreadDeltas(session, [{ kind: "session.reset" }]);
 
   const connection = spawnChildConnection({
+    envVars: decoded.sessionOptions.envVars,
     recordThreadId: args.threadId,
     onNotification: (method, params) =>
       handleChildNotification(args.threadId, serial, method, params),


### PR DESCRIPTION
Stack layer 3 (Codex pool track). Prerequisites: #3053 and #3054 below it. Single-plugin design: Codex joins the existing Account Pool plugin as a provider adapter.

## Human comments

## What was wrong

Account Pool was coupled to Claude credentials, request rewriting, quota headers, and refresh behavior, so it could not select or maintain Codex OAuth accounts. Codex also attempts the Responses WebSocket protocol before HTTP SSE, while the Codex bridge launched `codex app-server` without applying provider-contributed per-thread base URL and hub authentication values. Pointing Codex at the hub therefore required both a provider-neutral pool core inside the plugin and a session-aware app-server launch path.

## What changed

- Added an internal provider-adapter contract in `plugins/account-pool` and preserved the existing Claude behavior behind its adapter.
- Added Codex OAuth import from `~/.codex/auth.json`, serialized pre-expiry refresh with write-back, ChatGPT account identity storage, and provider-scoped account selection.
- Added Codex request/header rewriting for ChatGPT's Codex backend and parsed `x-codex-primary-*` / `x-codex-secondary-*` rate-limit observations and quota rejections.
- Added authenticated HTTP `POST /v1/responses`, `GET /v1/models`, and WebSocket `/v1/responses` routes in the existing Account Pool `/http/` namespace.
- Implemented Codex's downstream envelope session behavior: local prewarm completion, incremental input expansion after a completed response, unknown-id failure plus close 1011, upstream HTTPS SSE forwarding as one JSON event per WebSocket frame, and rotation after quota rejection.
- Made each WebSocket forward independently abortable. A downstream close now cancels the hub request signal and upstream fetch/body read, releases the account's in-flight slot, drops queued frames, and guards every send against a closing or closed socket.
- Extended the single `bb pool` CLI and Account Pool settings section with Codex import, provider badges, shared machine tokens, Codex environment and health contributions, and provider-aware status.
- Made the Codex bridge consume the resolved per-session pool environment, append in-memory `-c openai_base_url=...` configuration, add an environment-backed hub header without putting the token in process arguments, and rebuild a session when pool routing or token identity changes.
- Updated the configuration reference, generated Guide source, and builtin bb CLI skill. The original two-plugin extraction plan was intentionally dropped after the scope decision to keep both providers in `plugins/account-pool`.

There is no server/host-daemon wire contract change, so `HOST_DAEMON_PROTOCOL_VERSION` does not need a bump. There is no new public Plugin SDK surface in this layer.

## Not in this PR

- Keeping `model_provider="openai"` while adding the machine-token header is not possible with Codex CLI 0.153.2: a live app-server launch rejects `model_providers.openai` because built-in provider IDs are reserved and cannot be overridden. The bridge therefore retains the custom `bb-account-pool` provider ID. That changes the provider recorded in newly pooled rollouts and may affect Codex's provider-keyed session grouping, remote compaction, and remote-control behavior. Compatibility for existing sessions was verified live: a rollout created with `model_provider: "openai"` completed a direct turn, Account Pool was enabled, and the same rollout resumed and completed a pooled WebSocket turn.

## How you verified

The new focused regressions fail on the layer-A base because Codex is not an Account Pool provider there and the bridge ignores per-session pool configuration. They now cover import parsing, refresh persistence, HTTP credential/account-id rewrite, provider-scoped selection, Codex quota parsing and rotation, WebSocket authentication/prewarm/incremental/unknown-id/session streaming behavior, provider env/health, UI import and badges, and token-free app-server launch arguments.

- `pnpm exec turbo run typecheck test --filter=bb-plugin-account-pool --filter=bb-plugin-provider-codex --continue --force` — 8/8 tasks passed; Account Pool 41/41 tests and Codex provider 261/261 tests passed; both typechecks passed. The added regression closes a downstream WebSocket during a non-terminating SSE response and proves the upstream abort signal fires, the account's in-flight count returns to zero, and no post-close frame is sent.
- `pnpm exec turbo run test typecheck --filter=@bb/server --filter=@bb/app --filter=@bb/templates --filter=@bb/cli --continue` — 15/15 tasks passed; server 2,209, app 3,872, templates 43, and CLI 530 tests passed; 4 app tests skipped; all selected typechecks passed.
- `bb plugin build plugins/account-pool` — production server and app bundles built successfully.
- `node scripts/check-provider-literal-ratchet.mjs` — passed with all core provider literals allowlisted.
- `node .github/workflows/check-plugin-sdk-version.mjs` — passed against the layer-A SDK surface/version state.
- `git diff --check` — passed.
- Live dev app with Codex CLI 0.153.2 and this machine's imported account: a pooled WebSocket turn returned `BB93_POOL_WS_OK`, emitted the Account Pool WebSocket transport marker, and updated five-hour utilization to 0.4% without fallback/retry noise. The resolved-env card showed the Account Pool base URL and masked token. After `bb pool bypass`, a direct turn returned `BB93_DIRECT_OK` while the pool observation timestamp stayed unchanged. Settings and timeline screenshots were inspected and attached to BB-93.
- Review E2E with Codex CLI 0.153.2: the attempted built-in `openai` provider override failed with the reserved-provider validation error. With Account Pool disabled, rollout `01a06b6b-a3a4-7de2-9d07-d98af7bc5c90` recorded `model_provider: "openai"` and returned `BB93_PREPOOL_OPENAI_OK`; after enabling Account Pool, that same rollout returned `BB93_RESUMED_THROUGH_POOL_OK` over the plugin WebSocket route and advanced pool utilization from 0.40% to 0.41% with no account error.

## Review fixes

- Malformed or otherwise failing Codex SSE forwarding now aborts the hub request and cancels the response reader on every non-EOF exit, immediately releasing the selected account's in-flight slot.
- Added `releases a Codex request when an upstream SSE event is malformed`, which sends `data: {\n\n` on a stream that stays open and proves `response.failed` plus zero in flight through `bb pool status --json`.
- `pnpm exec turbo run typecheck test --filter=bb-plugin-account-pool --continue` passes with 42/42 tests and all selected typechecks.

Tracks BB-93 (layer B).

> AGENT GENERATED

