### PR TITLE
Toggle focused composer with its keyboard shortcut

### DIFF
--- a/apps/app/src/components/plugin/ComposerExtensionHost.test.tsx
+++ b/apps/app/src/components/plugin/ComposerExtensionHost.test.tsx
@@ -16,6 +16,7 @@ import {
 } from "./ComposerExtensionHost";
 
 const mocks = vi.hoisted(() => ({
+  collapseIfFocused: vi.fn(() => false),
   focusDefault: vi.fn(() => true),
   focusHost: vi.fn(),
 }));
@@ -98,6 +99,7 @@ function Harness({
     view,
     isFocused,
     isPrimary,
+    collapseIfFocused: mocks.collapseIfFocused,
     focusDefault: mocks.focusDefault,
   });
   return (
@@ -132,6 +134,17 @@ describe("ComposerExtensionHost", () => {
     fireEvent.keyDown(window, { key: "c", ctrlKey: true });
 
     expect(mocks.focusHost).toHaveBeenCalledOnce();
+    expect(mocks.focusDefault).not.toHaveBeenCalled();
+  });
+
+  it("collapses an already-focused composer instead of focusing it again", () => {
+    mocks.collapseIfFocused.mockReturnValueOnce(true);
+    renderHarness();
+
+    fireEvent.keyDown(window, { key: "c", ctrlKey: true });
+
+    expect(mocks.collapseIfFocused).toHaveBeenCalledOnce();
+    expect(mocks.focusHost).not.toHaveBeenCalled();
     expect(mocks.focusDefault).not.toHaveBeenCalled();
   });
 

--- a/apps/app/src/components/plugin/ComposerExtensionHost.tsx
+++ b/apps/app/src/components/plugin/ComposerExtensionHost.tsx
@@ -21,6 +21,7 @@ interface UseComposerExtensionControllerOptions {
   view: ComposerView;
   isFocused: boolean;
   isPrimary: boolean;
+  collapseIfFocused?(): boolean;
   focusDefault(): boolean;
 }
 
@@ -29,16 +30,18 @@ export function useComposerExtensionController({
   view,
   isFocused,
   isPrimary,
+  collapseIfFocused,
   focusDefault,
 }: UseComposerExtensionControllerOptions): ComposerExtensionController {
   const focus = useCallback(() => {
     if (!isFocused || !isPrimary) return false;
+    if (collapseIfFocused?.()) return true;
     if (host !== null) {
       host.focus();
       return true;
     }
     return focusDefault();
-  }, [focusDefault, host, isFocused, isPrimary]);
+  }, [collapseIfFocused, focusDefault, host, isFocused, isPrimary]);
   useAppCommandContext("promptAvailable", true);
   useAppCommandHandler("composer.focus", focus);
 

--- a/apps/app/src/components/promptbox/FollowUpPromptBox.test.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.test.tsx
@@ -12,6 +12,7 @@ import { Profiler, startTransition, type ReactNode } from "react";
 import { flushSync } from "react-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { EMPTY_ORDERED_MENTION_SUGGESTIONS } from "@bb/client-core";
+import { AppCommandProvider } from "@/components/commands/AppCommandProvider";
 import {
   resetPluginSlotStoreForTest,
   setPluginSlotRegistrations,
@@ -51,6 +52,31 @@ vi.mock("@bb/shared-ui/hooks/use-compact-viewport", () => ({
 
 vi.mock("@bb/shared-ui/hooks/use-pointer-coarse", () => ({
   usePointerCoarse: () => mocks.isPointerCoarse,
+}));
+
+vi.mock("@/hooks/queries/system-queries", () => ({
+  useSystemConfig: () => ({
+    data: {
+      keybindings: [
+        {
+          command: "composer.focus",
+          desktopOnly: false,
+          shortcut: {
+            key: "c",
+            mod: false,
+            meta: true,
+            control: false,
+            alt: false,
+            shift: true,
+          },
+          when: {
+            all: ["mainSurface", "promptAvailable"],
+            none: [],
+          },
+        },
+      ],
+    },
+  }),
 }));
 
 vi.mock("@/components/promptbox/PromptBoxInternal", () => ({
@@ -792,6 +818,34 @@ describe("FollowUpPromptBox", () => {
       screen.getByRole("textbox", { name: "Follow-up prompt" }).focus(),
     );
 
+    expect(screen.getByTestId("prompt-box").getAttribute("data-compact")).toBe(
+      null,
+    );
+    expect(screen.getByText("Local environment")).toBeTruthy();
+  });
+
+  it("toggles between focused and collapsed with the composer shortcut", () => {
+    const props = createFollowUpPromptBoxProps({ kind: "ready" });
+    props.environmentSummary = <span>Local environment</span>;
+    render(
+      <AppCommandProvider>
+        <FollowUpPromptBox {...props} />
+      </AppCommandProvider>,
+    );
+    const input = screen.getByRole("textbox", { name: "Follow-up prompt" });
+
+    act(() => input.focus());
+    fireEvent.keyDown(input, { key: "c", metaKey: true, shiftKey: true });
+
+    expect(document.activeElement).not.toBe(input);
+    expect(screen.getByTestId("prompt-box").getAttribute("data-compact")).toBe(
+      "true",
+    );
+    expect(screen.queryByText("Local environment")).toBeNull();
+
+    fireEvent.keyDown(window, { key: "c", metaKey: true, shiftKey: true });
+
+    expect(document.activeElement).toBe(input);
     expect(screen.getByTestId("prompt-box").getAttribute("data-compact")).toBe(
       null,
     );

--- a/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
@@ -290,13 +290,6 @@ function FollowUpPromptBoxWithComposer({
     promptBoxRef.current?.focusEnd();
     return promptBoxRef.current !== null;
   }, []);
-  const extensionController = useComposerExtensionController({
-    host: pluginComposerHost ?? null,
-    view: composerView,
-    isFocused: isFocusedPane,
-    isPrimary: isPrimaryComposer,
-    focusDefault,
-  });
   const voice = usePromptVoice(promptBoxRef);
   const isCompactViewport = useIsCompactViewport();
   const isPointerCoarse = usePointerCoarse();
@@ -554,6 +547,27 @@ function FollowUpPromptBoxWithComposer({
     setIsInteractionExpanded(false);
     setWidePromptBoxCollapsedFor(collapseResetKey);
   }, [cancelPendingFocusExpansion, cancelPendingFocusLoss, collapseResetKey]);
+  const collapseIfFocused = useCallback(() => {
+    const activeElement = document.activeElement;
+    if (
+      !(activeElement instanceof HTMLElement) ||
+      !composerInteractionRef.current?.contains(activeElement)
+    ) {
+      return false;
+    }
+    promptBoxRef.current?.captureHeightForLayoutChange();
+    activeElement.blur();
+    collapseWidePromptBox();
+    return true;
+  }, [collapseWidePromptBox]);
+  const extensionController = useComposerExtensionController({
+    host: pluginComposerHost ?? null,
+    view: composerView,
+    isFocused: isFocusedPane,
+    isPrimary: isPrimaryComposer,
+    collapseIfFocused,
+    focusDefault,
+  });
   useEffect(
     () => () => {
       cancelPendingFocusExpansion();


### PR DESCRIPTION
## Human comments

## What was wrong

The `composer.focus` command always sent focus to the active composer. The follow-up composer already had a collapse path, but the shortcut command could not use it when the editor was focused.

## What changed

The composer command now tries to collapse the active follow-up composer before it falls back to focusing it. A focused composer captures its height, releases editor focus, and uses the existing compact state. The next shortcut press focuses the editor and expands the composer again. There are no wire, CLI, or plugin API changes.

## How you verified

Added controller and follow-up composer tests that fail before the change and cover both shortcut directions. Ran `pnpm exec turbo run test --filter=@bb/app -- src/components/plugin/ComposerExtensionHost.test.tsx src/components/promptbox/FollowUpPromptBox.test.tsx` and `pnpm exec turbo run typecheck --filter=@bb/app` after rebasing onto `get-bb/bb:main`. All 37 focused tests and the typecheck passed. The shortcut was also confirmed in the browser dev build.

> AGENT GENERATED
