### PR TITLE
Add @IlyaM and @swairshah to contributor allow list

### DIFF
--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -60,3 +60,5 @@ yazydzhi
 ymichael
 kravtsovd
 alanagoyal
+IlyaM
+swairshah


### PR DESCRIPTION
## Human comments

## What was wrong

GitHub users `IlyaM` and `swairshah` were not in the persistent contributor allow list, so the PR approval gate would not treat contributions from their forks as approved.

## What changed

Added `IlyaM` and `swairshah` to `.github/APPROVED_CONTRIBUTORS`. This is a policy-only change with no host daemon wire, CLI, guide, or documentation impact.

## How you verified

- Confirmed both GitHub accounts exist (`gh api users/IlyaM`, `gh api users/swairshah`).
- Ran `git diff --check`.
- Checked the contributor list for case-insensitive duplicates.

> AGENT GENERATED
