### PR TITLE
Show completed thinking in thread history

### DIFF
--- a/apps/server/test/services/threads/timeline-in-turn-window.test.ts
+++ b/apps/server/test/services/threads/timeline-in-turn-window.test.ts
@@ -1710,6 +1710,95 @@ function collectTurnDetailsAndChildren(
 }
 
 describe("turn details for an item that finishes in a later turn", () => {
+  it("retains interrupted thinking when the provider completes the item after Stop", () => {
+    const { db, thread } = setup();
+    seedTurns(db, thread, { completeLastTurn: false, itemsPerTurn: [0] });
+    const firstSequence = getLatestThreadSequence(db, { threadId: thread.id });
+    const turnId = "turn-1";
+    const itemId = "stopped-reasoning";
+    const text = "Checking each constraint before choosing a solution.";
+    const events: EventInput[] = [];
+    const push = (event: Omit<EventInput, "sequence" | "threadId">) => {
+      events.push({
+        ...event,
+        sequence: firstSequence + events.length + 1,
+        threadId: thread.id,
+      });
+    };
+    const base = {
+      scope: turnScope(turnId),
+      providerThreadId,
+      parentToolCallId: null,
+      itemId: null,
+      itemKind: null,
+    };
+    push({
+      ...base,
+      type: "item/started",
+      itemId,
+      itemKind: "reasoning",
+      data: JSON.stringify({
+        item: { type: "reasoning", id: itemId, summary: [], content: [] },
+      }),
+    });
+    push({
+      ...base,
+      type: "item/reasoning/textDelta",
+      itemId,
+      data: JSON.stringify({ itemId, delta: "Checking" }),
+    });
+    push({
+      ...base,
+      type: "system/thread/interrupted",
+      scope: threadScope(),
+      data: JSON.stringify({ reason: "manual-stop" }),
+    });
+    insertEvents(db, noopNotifier, events);
+    const before = buildNestedPage(db, thread, LARGE_BUDGET, null).response;
+    const beforeThought = before.rows.find(
+      (row) => row.kind === "system" && row.title.startsWith("Thought for"),
+    );
+    expect(beforeThought).toMatchObject({
+      detail: "Checking",
+      status: "interrupted",
+    });
+
+    const storedCount = events.length;
+    push({
+      ...base,
+      type: "item/completed",
+      itemId,
+      itemKind: "reasoning",
+      data: JSON.stringify({
+        item: { type: "reasoning", id: itemId, summary: [], content: [text] },
+      }),
+    });
+    push({
+      ...base,
+      type: "turn/completed",
+      data: JSON.stringify({ status: "interrupted", providerThreadId }),
+    });
+    insertEvents(db, noopNotifier, events.slice(storedCount));
+
+    const after = collectTurnDetailsAndChildren(db, thread).get(turnId);
+    const thoughts = after?.details.filter(
+      (row) => row.kind === "system" && row.title.startsWith("Thought for"),
+    );
+    expect(thoughts).toEqual([
+      expect.objectContaining({
+        id: beforeThought?.id,
+        detail: text,
+        status: "interrupted",
+        sourceSeqStart: firstSequence + 1,
+        sourceSeqEnd: firstSequence + 4,
+      }),
+    ]);
+    expect(after?.details).toEqual(after?.children);
+    expect(collectTurnDetailsAndChildren(db, thread).get(turnId)).toEqual(
+      after,
+    );
+  });
+
   it("shows the spawning turn's item completed with its late output", () => {
     const { db, thread } = setup();
     seedCrossTurnCompletion(db, thread, { reuseCallIdInLaterTurn: false });

--- a/packages/provider-bridge-protocol/recordings/row-counts.json
+++ b/packages/provider-bridge-protocol/recordings/row-counts.json
@@ -25,7 +25,7 @@
   },
   "acp-cursor/resume": {
     "events": 21,
-    "rows": 2,
+    "rows": 4,
     "unhandled": 0,
     "grammarDrops": 0
   },
@@ -37,7 +37,7 @@
   },
   "acp-cursor/stop-interrupt": {
     "events": 39,
-    "rows": 3,
+    "rows": 5,
     "unhandled": 0,
     "grammarDrops": 0
   },

--- a/packages/thread-view/src/assistant-event-projection.ts
+++ b/packages/thread-view/src/assistant-event-projection.ts
@@ -15,7 +15,6 @@ import type { EventProjectionAssistantTextMessage } from "./event-projection-typ
 import { messageId } from "./format-helpers.js";
 import {
   finalizeReasoningLifecycle,
-  trackReasoningTurn,
   upsertReasoningLifecycle,
 } from "./reasoning-lifecycle-projection.js";
 import type { ProjectionState } from "./event-projection-state.js";
@@ -25,7 +24,6 @@ interface ProjectAssistantAndReasoningEventArgs {
   eventParentToolCallId: string | undefined;
   eventTurnId: string | undefined;
   meta: EventMeta;
-  shouldTrackActiveThinking: boolean;
   state: ProjectionState;
 }
 
@@ -72,18 +70,14 @@ export function projectAssistantAndReasoningEvent(
     turnId: args.eventTurnId,
   });
 
-  if (
-    args.decoded.type === "item/started" &&
-    args.decoded.item.type === "reasoning"
-  ) {
-    trackReasoningTurn(args.state, reasoningIdentity);
-    if (args.shouldTrackActiveThinking) {
-      upsertReasoningLifecycle({
-        identity: reasoningIdentity,
-        meta: args.meta,
-        state: args.state,
-      });
-    }
+  if (reasoningIdentity) {
+    upsertReasoningLifecycle({
+      identity: reasoningIdentity,
+      meta: args.meta,
+      parentToolCallId: args.eventParentToolCallId,
+      state: args.state,
+      threadId: args.decoded.threadId,
+    });
   }
 
   if (
@@ -137,21 +131,6 @@ export function projectAssistantAndReasoningEvent(
   }
 
   if (
-    (args.decoded.type === "item/reasoning/summaryTextDelta" ||
-      args.decoded.type === "item/reasoning/textDelta") &&
-    reasoningIdentity
-  ) {
-    trackReasoningTurn(args.state, reasoningIdentity);
-    if (args.shouldTrackActiveThinking) {
-      upsertReasoningLifecycle({
-        identity: reasoningIdentity,
-        meta: args.meta,
-        state: args.state,
-      });
-    }
-  }
-
-  if (
     projectReasoningTextEvent({
       identity: reasoningIdentity,
       mode: "delta",
@@ -162,29 +141,24 @@ export function projectAssistantAndReasoningEvent(
     return true;
   }
 
-  if (
-    projectReasoningTextEvent({
-      identity: reasoningIdentity,
-      mode: "final",
-      state: args.state,
-      text: parseReasoningFinalText(args.decoded),
-    })
-  ) {
-    if (
-      args.decoded.type === "item/completed" &&
-      args.decoded.item.type === "reasoning"
-    ) {
-      finalizeReasoningLifecycle(args.state, reasoningIdentity);
-    }
-    return true;
-  }
+  const projectedReasoningFinal = projectReasoningTextEvent({
+    identity: reasoningIdentity,
+    mode: "final",
+    state: args.state,
+    text: parseReasoningFinalText(args.decoded),
+  });
 
   if (
     args.decoded.type === "item/completed" &&
     args.decoded.item.type === "reasoning"
   ) {
-    finalizeReasoningLifecycle(args.state, reasoningIdentity);
+    finalizeReasoningLifecycle({
+      identity: reasoningIdentity,
+      meta: args.meta,
+      state: args.state,
+      status: "completed",
+    });
   }
 
-  return false;
+  return projectedReasoningFinal;
 }

--- a/packages/thread-view/src/assistant-event-projection.ts
+++ b/packages/thread-view/src/assistant-event-projection.ts
@@ -157,6 +157,7 @@ export function projectAssistantAndReasoningEvent(
       meta: args.meta,
       state: args.state,
       status: "completed",
+      text: parseReasoningFinalText(args.decoded),
     });
   }
 

--- a/packages/thread-view/src/buffered-text-projection.ts
+++ b/packages/thread-view/src/buffered-text-projection.ts
@@ -6,7 +6,6 @@ import {
 } from "./assistant-stream-projection.js";
 import type { ProjectionState } from "./event-projection-state.js";
 import {
-  finalizeReasoningTextBuffer,
   getReasoningTextBuffer,
   isReasoningProjectionKeyFinalized,
 } from "./reasoning-lifecycle-projection.js";
@@ -178,6 +177,5 @@ export function projectReasoningTextEvent(
   }
 
   setVisibleTextBuffer(buffer, args.text, true);
-  finalizeReasoningTextBuffer(args.state, messageKey);
   return true;
 }

--- a/packages/thread-view/src/build-event-projection.ts
+++ b/packages/thread-view/src/build-event-projection.ts
@@ -565,7 +565,6 @@ function buildFlatProjectionData(
   args: BuildFlatProjectionDataArgs,
 ): BuildFlatProjectionDataResult {
   const state = createProjectionState();
-  const shouldTrackActiveThinking = args.includeActiveThinking;
 
   const orderedEvents = args.events;
   const acceptedClientRequestById = buildAcceptedClientRequestById({
@@ -669,7 +668,7 @@ function buildFlatProjectionData(
           scope: decoded.scope,
         });
         onTurnCompleted({
-          completedAt: meta.createdAt,
+          meta,
           state,
           turnId: completedTurnId,
           status: decoded.status,
@@ -775,7 +774,6 @@ function buildFlatProjectionData(
         eventParentToolCallId,
         eventTurnId,
         meta,
-        shouldTrackActiveThinking,
         state,
       })
     ) {

--- a/packages/thread-view/src/event-projection-state.ts
+++ b/packages/thread-view/src/event-projection-state.ts
@@ -146,7 +146,7 @@ export function onTurnCompleted(args: CompleteTurnArgs): void {
   finalizeOpenReasoningLifecyclesForTurn({
     meta: args.meta,
     state: args.state,
-    status: args.status === "interrupted" ? "interrupted" : "completed",
+    status: args.status === "completed" ? "completed" : "interrupted",
     turnId: args.turnId,
   });
 }

--- a/packages/thread-view/src/event-projection-state.ts
+++ b/packages/thread-view/src/event-projection-state.ts
@@ -59,7 +59,7 @@ type TurnCompletedStatus = Extract<
 >["status"];
 
 interface CompleteTurnArgs {
-  completedAt: number;
+  meta: EventMeta;
   state: ProjectionState;
   status: TurnCompletedStatus;
   turnId: string;
@@ -139,11 +139,16 @@ export function onTurnCompleted(args: CompleteTurnArgs): void {
   args.state.openTurnIds.delete(args.turnId);
   if (args.status === "interrupted") {
     args.state.pendingFinalizationByTurnId.set(args.turnId, {
-      completedAt: args.completedAt,
+      completedAt: args.meta.createdAt,
       status: "interrupted",
     });
   }
-  finalizeOpenReasoningLifecyclesForTurn(args.state, args.turnId);
+  finalizeOpenReasoningLifecyclesForTurn({
+    meta: args.meta,
+    state: args.state,
+    status: args.status === "interrupted" ? "interrupted" : "completed",
+    turnId: args.turnId,
+  });
 }
 
 export function onThreadInterrupted(args: ThreadInterruptedArgs): void {
@@ -160,7 +165,11 @@ export function onThreadInterrupted(args: ThreadInterruptedArgs): void {
     });
   }
   closeOpenTurns(args.state);
-  finalizeOpenReasoningLifecycles(args.state);
+  finalizeOpenReasoningLifecycles({
+    meta: args.meta,
+    state: args.state,
+    status: "interrupted",
+  });
 }
 
 export function flushProjectionBufferedOutputs(state: ProjectionState): void {

--- a/packages/thread-view/src/reasoning-lifecycle-projection.ts
+++ b/packages/thread-view/src/reasoning-lifecycle-projection.ts
@@ -1,9 +1,15 @@
 import type { ActiveThinking } from "@bb/domain";
 import type { EventMeta } from "./event-decode.js";
-import type { BuildEventProjectionMessagesOptions } from "./event-projection-types.js";
-import { finalizeProjectionKey } from "./assistant-stream-projection.js";
+import type {
+  BuildEventProjectionMessagesOptions,
+  EventProjectionMessage,
+  EventProjectionOperationMessage,
+} from "./event-projection-types.js";
+import { durationToCompactString, messageId } from "./format-helpers.js";
+import { eventProjectionMessageTurnScopeFields } from "./message-scope.js";
 import {
   createVisibleTextBuffer,
+  getVisibleTextBufferFullText,
   getVisibleTextBufferText,
   type VisibleTextBuffer,
 } from "./visible-text-buffer.js";
@@ -15,7 +21,10 @@ import {
 interface ActiveThinkingLifecycle {
   itemId: string;
   messageKey: string;
+  parentToolCallId: string | null;
+  sourceSeqStart: number;
   startedAt: number;
+  threadId: string;
   turnId: string;
   updatedAt: number;
   updatedSeq: number;
@@ -33,12 +42,38 @@ export interface ReasoningProjectionState {
 }
 
 interface ReasoningLifecycleHostState
-  extends ReasoningProjectionState, ReasoningTurnLifecycleState {}
+  extends ReasoningProjectionState, ReasoningTurnLifecycleState {
+  messages: EventProjectionMessage[];
+}
 
 interface UpsertReasoningLifecycleArgs {
   identity: BufferedTextInstanceIdentity | null;
   meta: EventMeta;
+  parentToolCallId: string | undefined;
   state: ReasoningLifecycleHostState;
+  threadId: string;
+}
+
+type ReasoningCompletionStatus = Extract<
+  EventProjectionOperationMessage["status"],
+  "completed" | "interrupted"
+>;
+
+interface FinalizeReasoningLifecycleArgs {
+  identity: BufferedTextInstanceIdentity | null;
+  meta: EventMeta;
+  state: ReasoningLifecycleHostState;
+  status: ReasoningCompletionStatus;
+}
+
+interface FinalizeOpenReasoningLifecyclesArgs {
+  meta: EventMeta;
+  state: ReasoningLifecycleHostState;
+  status: ReasoningCompletionStatus;
+}
+
+interface FinalizeOpenReasoningLifecyclesForTurnArgs extends FinalizeOpenReasoningLifecyclesArgs {
+  turnId: string;
 }
 
 export function createReasoningProjectionState(): ReasoningProjectionState {
@@ -133,55 +168,93 @@ export function upsertReasoningLifecycle(
   args.state.openReasoningLifecyclesByKey.set(messageKey, {
     itemId: args.identity.itemId,
     messageKey,
+    parentToolCallId: args.parentToolCallId ?? null,
+    sourceSeqStart: args.meta.seq,
     startedAt: args.meta.createdAt,
+    threadId: args.threadId,
     turnId: args.identity.turnId,
     updatedAt: args.meta.createdAt,
     updatedSeq: args.meta.seq,
   });
 }
 
-export function trackReasoningTurn(
-  state: ReasoningTurnLifecycleState,
-  identity: BufferedTextInstanceIdentity | null,
+function finalizeReasoningLifecycleByKey(
+  args: FinalizeOpenReasoningLifecyclesArgs & { messageKey: string },
 ): void {
-  if (!identity || state.closedTurnIds.has(identity.turnId)) {
+  const lifecycle = args.state.openReasoningLifecyclesByKey.get(
+    args.messageKey,
+  );
+  const buffer = args.state.reasoningTextBuffersByKey.get(args.messageKey);
+  args.state.openReasoningLifecyclesByKey.delete(args.messageKey);
+  args.state.reasoningTextBuffersByKey.delete(args.messageKey);
+  args.state.finalizedReasoningKeys.add(args.messageKey);
+  if (!lifecycle || !buffer) {
     return;
   }
-  state.openTurnIds.add(identity.turnId);
+
+  const detail = getVisibleTextBufferFullText(buffer);
+  if (detail.trim().length === 0) {
+    return;
+  }
+
+  args.state.messages.push({
+    kind: "operation",
+    id: messageId(
+      lifecycle.threadId,
+      "op",
+      `reasoning:${lifecycle.messageKey}`,
+    ),
+    threadId: lifecycle.threadId,
+    sourceSeqStart: lifecycle.sourceSeqStart,
+    sourceSeqEnd: args.meta.seq,
+    createdAt: args.meta.createdAt,
+    startedAt: lifecycle.startedAt,
+    completedAt: args.meta.createdAt,
+    ...eventProjectionMessageTurnScopeFields(lifecycle.turnId),
+    ...(lifecycle.parentToolCallId
+      ? { parentToolCallId: lifecycle.parentToolCallId }
+      : {}),
+    opType: "operation",
+    title: `Thought for ${durationToCompactString(
+      args.meta.createdAt - lifecycle.startedAt,
+    )}`,
+    detail,
+    status: args.status,
+  });
 }
 
 export function finalizeReasoningLifecycle(
-  state: ReasoningProjectionState,
-  identity: BufferedTextInstanceIdentity | null,
+  args: FinalizeReasoningLifecycleArgs,
 ): void {
-  if (!identity) {
+  if (!args.identity) {
     return;
   }
 
-  const messageKey = createBufferedTextInstanceKey(identity);
-  state.openReasoningLifecyclesByKey.delete(messageKey);
-  state.finalizedReasoningKeys.add(messageKey);
+  finalizeReasoningLifecycleByKey({
+    meta: args.meta,
+    state: args.state,
+    status: args.status,
+    messageKey: createBufferedTextInstanceKey(args.identity),
+  });
 }
 
 export function finalizeOpenReasoningLifecycles(
-  state: ReasoningProjectionState,
+  args: FinalizeOpenReasoningLifecyclesArgs,
 ): void {
-  for (const messageKey of state.openReasoningLifecyclesByKey.keys()) {
-    state.finalizedReasoningKeys.add(messageKey);
+  for (const messageKey of args.state.openReasoningLifecyclesByKey.keys()) {
+    finalizeReasoningLifecycleByKey({ ...args, messageKey });
   }
-  state.openReasoningLifecyclesByKey.clear();
 }
 
 export function finalizeOpenReasoningLifecyclesForTurn(
-  state: ReasoningProjectionState,
-  turnId: string,
+  args: FinalizeOpenReasoningLifecyclesForTurnArgs,
 ): void {
-  for (const [messageKey, lifecycle] of state.openReasoningLifecyclesByKey) {
-    if (lifecycle.turnId !== turnId) {
+  for (const [messageKey, lifecycle] of args.state
+    .openReasoningLifecyclesByKey) {
+    if (lifecycle.turnId !== args.turnId) {
       continue;
     }
-    state.finalizedReasoningKeys.add(messageKey);
-    state.openReasoningLifecyclesByKey.delete(messageKey);
+    finalizeReasoningLifecycleByKey({ ...args, messageKey });
   }
 }
 
@@ -201,12 +274,4 @@ export function isReasoningProjectionKeyFinalized(
   messageKey: string,
 ): boolean {
   return state.finalizedReasoningKeys.has(messageKey);
-}
-
-export function finalizeReasoningTextBuffer(
-  state: ReasoningProjectionState,
-  messageKey: string,
-): void {
-  state.reasoningTextBuffersByKey.delete(messageKey);
-  finalizeProjectionKey(state.finalizedReasoningKeys, messageKey);
 }

--- a/packages/thread-view/src/reasoning-lifecycle-projection.ts
+++ b/packages/thread-view/src/reasoning-lifecycle-projection.ts
@@ -59,6 +59,17 @@ type ReasoningCompletionStatus = Extract<
   "completed" | "interrupted"
 >;
 
+const MAX_REASONING_DETAIL_CHARS = 32_000;
+const REASONING_DETAIL_TRUNCATION_SUFFIX_TAIL = " more characters truncated]";
+
+function truncateReasoningDetail(detail: string): string {
+  if (detail.length <= MAX_REASONING_DETAIL_CHARS) {
+    return detail;
+  }
+  const dropped = detail.length - MAX_REASONING_DETAIL_CHARS;
+  return `${detail.slice(0, MAX_REASONING_DETAIL_CHARS)}\n…[${dropped.toLocaleString("en-US")}${REASONING_DETAIL_TRUNCATION_SUFFIX_TAIL}`;
+}
+
 interface FinalizeReasoningLifecycleArgs {
   identity: BufferedTextInstanceIdentity | null;
   meta: EventMeta;
@@ -218,7 +229,7 @@ function finalizeReasoningLifecycleByKey(
     title: `Thought for ${durationToCompactString(
       args.meta.createdAt - lifecycle.startedAt,
     )}`,
-    detail,
+    detail: truncateReasoningDetail(detail),
     status: args.status,
   });
 }

--- a/packages/thread-view/src/reasoning-lifecycle-projection.ts
+++ b/packages/thread-view/src/reasoning-lifecycle-projection.ts
@@ -37,6 +37,10 @@ interface ReasoningTurnLifecycleState {
 
 export interface ReasoningProjectionState {
   finalizedReasoningKeys: Set<string>;
+  reasoningMessagesAwaitingCompletion: Map<
+    string,
+    EventProjectionOperationMessage
+  >;
   openReasoningLifecyclesByKey: Map<string, ActiveThinkingLifecycle>;
   reasoningTextBuffersByKey: Map<string, VisibleTextBuffer>;
 }
@@ -75,6 +79,7 @@ interface FinalizeReasoningLifecycleArgs {
   meta: EventMeta;
   state: ReasoningLifecycleHostState;
   status: ReasoningCompletionStatus;
+  text: string | null;
 }
 
 interface FinalizeOpenReasoningLifecyclesArgs {
@@ -92,6 +97,7 @@ export function createReasoningProjectionState(): ReasoningProjectionState {
     openReasoningLifecyclesByKey: new Map(),
     reasoningTextBuffersByKey: new Map(),
     finalizedReasoningKeys: new Set(),
+    reasoningMessagesAwaitingCompletion: new Map(),
   };
 }
 
@@ -191,7 +197,7 @@ export function upsertReasoningLifecycle(
 
 function finalizeReasoningLifecycleByKey(
   args: FinalizeOpenReasoningLifecyclesArgs & { messageKey: string },
-): void {
+): EventProjectionOperationMessage | null {
   const lifecycle = args.state.openReasoningLifecyclesByKey.get(
     args.messageKey,
   );
@@ -200,15 +206,15 @@ function finalizeReasoningLifecycleByKey(
   args.state.reasoningTextBuffersByKey.delete(args.messageKey);
   args.state.finalizedReasoningKeys.add(args.messageKey);
   if (!lifecycle || !buffer) {
-    return;
+    return null;
   }
 
   const detail = getVisibleTextBufferFullText(buffer);
   if (detail.trim().length === 0) {
-    return;
+    return null;
   }
 
-  args.state.messages.push({
+  const message: EventProjectionOperationMessage = {
     kind: "operation",
     id: messageId(
       lifecycle.threadId,
@@ -231,7 +237,9 @@ function finalizeReasoningLifecycleByKey(
     )}`,
     detail: truncateReasoningDetail(detail),
     status: args.status,
-  });
+  };
+  args.state.messages.push(message);
+  return message;
 }
 
 export function finalizeReasoningLifecycle(
@@ -241,19 +249,43 @@ export function finalizeReasoningLifecycle(
     return;
   }
 
+  const messageKey = createBufferedTextInstanceKey(args.identity);
+  const message =
+    args.state.reasoningMessagesAwaitingCompletion.get(messageKey);
+  if (message) {
+    args.state.reasoningMessagesAwaitingCompletion.delete(messageKey);
+    message.sourceSeqEnd = args.meta.seq;
+    if (args.text?.trim()) {
+      message.detail = truncateReasoningDetail(args.text);
+    }
+    return;
+  }
+
   finalizeReasoningLifecycleByKey({
     meta: args.meta,
     state: args.state,
     status: args.status,
-    messageKey: createBufferedTextInstanceKey(args.identity),
+    messageKey,
   });
+}
+
+function finalizeReasoningWithoutCompletion(
+  args: FinalizeOpenReasoningLifecyclesArgs & { messageKey: string },
+): void {
+  const message = finalizeReasoningLifecycleByKey(args);
+  if (message) {
+    args.state.reasoningMessagesAwaitingCompletion.set(
+      args.messageKey,
+      message,
+    );
+  }
 }
 
 export function finalizeOpenReasoningLifecycles(
   args: FinalizeOpenReasoningLifecyclesArgs,
 ): void {
   for (const messageKey of args.state.openReasoningLifecyclesByKey.keys()) {
-    finalizeReasoningLifecycleByKey({ ...args, messageKey });
+    finalizeReasoningWithoutCompletion({ ...args, messageKey });
   }
 }
 
@@ -265,7 +297,7 @@ export function finalizeOpenReasoningLifecyclesForTurn(
     if (lifecycle.turnId !== args.turnId) {
       continue;
     }
-    finalizeReasoningLifecycleByKey({ ...args, messageKey });
+    finalizeReasoningWithoutCompletion({ ...args, messageKey });
   }
 }
 

--- a/packages/thread-view/test/timeline-cli-rendering.snapshots.test.ts
+++ b/packages/thread-view/test/timeline-cli-rendering.snapshots.test.ts
@@ -2402,6 +2402,59 @@ describe("timeline CLI rendering snapshots", () => {
     expect(reasoningMessages[0]).not.toHaveProperty("parentToolCallId");
   });
 
+  it("finalizes streamed reasoning as interrupted when its turn fails", () => {
+    const event = createTimelineEventFactory({ threadId: "thread-1" });
+    const timeline = renderIdleTimeline([
+      event.turnStarted({ createdAt: 0 }),
+      event.reasoningDelta({
+        createdAt: 2_000,
+        itemId: "reasoning-1",
+        delta: "Checking the failure path.",
+      }),
+      event.turnCompleted({ createdAt: 7_000, status: "failed" }),
+    ]);
+
+    expect(
+      timeline.messages.filter((message) => message.kind === "operation"),
+    ).toEqual([
+      expect.objectContaining({
+        completedAt: 7_000,
+        detail: "Checking the failure path.",
+        sourceSeqEnd: 3,
+        sourceSeqStart: 2,
+        startedAt: 2_000,
+        status: "interrupted",
+        title: "Thought for 5s",
+      }),
+    ]);
+  });
+
+  it("truncates very long completed reasoning detail", () => {
+    const event = createTimelineEventFactory({ threadId: "thread-1" });
+    const timeline = renderIdleTimeline([
+      event.turnStarted({ createdAt: 0 }),
+      event.reasoningStarted({
+        createdAt: 1_000,
+        itemId: "reasoning-1",
+      }),
+      event.reasoningCompleted({
+        createdAt: 4_000,
+        itemId: "reasoning-1",
+        text: "x".repeat(40_000),
+      }),
+      event.turnCompleted({ createdAt: 7_000 }),
+    ]);
+
+    const rows = timeline.messages.filter(
+      (message) => message.kind === "operation",
+    );
+    expect(rows).toHaveLength(1);
+    const detail = (rows[0] as { detail: string }).detail;
+    expect(detail).toContain("more characters truncated");
+    expect(detail.startsWith("x".repeat(32_000))).toBe(true);
+    expect(detail.length).toBeLessThan(40_000);
+  });
+
   it("finalizes streamed reasoning as interrupted when its turn is interrupted", () => {
     const event = createTimelineEventFactory({ threadId: "thread-1" });
     const timeline = renderIdleTimeline([

--- a/packages/thread-view/test/timeline-cli-rendering.snapshots.test.ts
+++ b/packages/thread-view/test/timeline-cli-rendering.snapshots.test.ts
@@ -1385,7 +1385,7 @@ describe("timeline CLI rendering snapshots", () => {
     ]);
   });
 
-  it("keeps root reasoning active when a nested turn completes first", () => {
+  it("keeps root reasoning active when a nested reasoning lifecycle completes first", () => {
     const event = createTimelineEventFactory({
       providerThreadId: "root-provider",
       threadId: "thread-1",
@@ -1409,13 +1409,30 @@ describe("timeline CLI rendering snapshots", () => {
         delta: "Root is still thinking.\n",
         itemId: "root-reasoning",
       }),
-      event.turnCompleted({ turnId: "child-turn" }),
+      event.reasoningDelta({
+        delta: "Child thought.",
+        itemId: "child-reasoning",
+        parentToolCallId: "delegation-1",
+        turnId: "child-turn",
+      }),
+      event.turnCompleted({ createdAt: 5_000, turnId: "child-turn" }),
     ]);
 
     expect(timeline.projection.state.activeThinking).toMatchObject({
       id: "root-reasoning",
       text: "Root is still thinking.\n",
     });
+    expect(
+      timeline.messages.filter((message) => message.kind === "operation"),
+    ).toEqual([
+      expect.objectContaining({
+        detail: "Child thought.",
+        parentToolCallId: "delegation-1",
+        scope: { kind: "turn", turnId: "child-turn" },
+        status: "completed",
+        title: "Thought for 5s",
+      }),
+    ]);
   });
 
   it("does not attach later root turns to Claude receiver-thread delegations", () => {
@@ -2269,39 +2286,181 @@ describe("timeline CLI rendering snapshots", () => {
     `);
   });
 
-  it("omits completed reasoning from timeline rows", () => {
+  it("retains completed reasoning through the generic system operation row", () => {
     const event = createTimelineEventFactory({ threadId: "thread-1" });
-    const timeline = renderIdleTimeline([
-      event.turnStarted(),
+    const events = [
+      event.turnStarted({ createdAt: 0 }),
+      event.reasoningStarted({
+        createdAt: 1_000,
+        itemId: "reasoning-1",
+      }),
       event.reasoningDelta({
+        createdAt: 2_000,
         itemId: "reasoning-1",
         delta: "I should inspect the nearby files first.",
       }),
       event.reasoningCompleted({
+        createdAt: 4_000,
         itemId: "reasoning-1",
-        text: "I should inspect the nearby files first.",
+        text: "I should inspect the projection seam first.",
       }),
       event.toolCallCompleted({
+        createdAt: 5_000,
         itemId: "tool-1",
         arguments: { cmd: "sed -n '1,80p' packages/core-ui/src/index.ts" },
       }),
       event.assistantCompleted({
+        createdAt: 6_000,
         itemId: "assistant-1",
         text: "The extension point is the timeline row builder.",
       }),
-      event.turnCompleted(),
-    ]);
+      event.turnCompleted({ createdAt: 7_000 }),
+    ];
+    const timeline = renderIdleTimeline(events);
+    const reloadedTimeline = renderIdleTimeline(events);
 
     expect(timeline.turnRows).toHaveLength(1);
-    expect(timeline.turnRows[0]?.summaryCount).toBe(1);
-    expect(timeline.text).not.toContain("Reasoning");
+    expect(timeline.turnRows[0]?.summaryCount).toBe(2);
+    expect(
+      timeline.messages.filter((message) => message.kind === "operation"),
+    ).toEqual([
+      {
+        kind: "operation",
+        id: "thread-1:op:reasoning:kind:reasoning|turn:turn-1|parent:root|item:reasoning-1",
+        threadId: "thread-1",
+        sourceSeqStart: 2,
+        sourceSeqEnd: 4,
+        createdAt: 4_000,
+        startedAt: 1_000,
+        completedAt: 4_000,
+        scope: { kind: "turn", turnId: "turn-1" },
+        opType: "operation",
+        title: "Thought for 3s",
+        detail: "I should inspect the projection seam first.",
+        status: "completed",
+      },
+    ]);
+    expect(reloadedTimeline.text).toBe(timeline.text);
     expect(timeline.text).toMatchInlineSnapshot(`
-      "── Worked for (5ms) ────────────────────────────────────────
+      "── Worked for (7s) ─────────────────────────────────────────
+        ── Thought for 3s
+          I should inspect the projection seam first.
+
         ── Ran tool exec_command { cmd: sed -n '1,80p' packages/core-ui/src/i... }
 
       ── Assistant ───────────────────────────────────────────────
       The extension point is the timeline row builder."
     `);
+  });
+
+  it("keeps completed reasoning at root when provider parent scope is suppressed", () => {
+    const event = createTimelineEventFactory({ threadId: "thread-1" });
+    const startRequest = event.clientTurnRequested({
+      target: { kind: "thread-start" },
+      text: "Inspect the projection.",
+    });
+    const timeline = renderIdleTimeline([
+      startRequest,
+      event.turnStarted({
+        createdAt: 1_000,
+        parentToolCallId: "stale-parent",
+      }),
+      event.inputAccepted({
+        clientRequestId: startRequest.data.requestId,
+        createdAt: 1_500,
+      }),
+      event.reasoningStarted({
+        createdAt: 2_000,
+        itemId: "reasoning-1",
+        parentToolCallId: "stale-parent",
+      }),
+      event.reasoningDelta({
+        createdAt: 3_000,
+        delta: "Checking effective scope.",
+        itemId: "reasoning-1",
+        parentToolCallId: "stale-parent",
+      }),
+      event.reasoningCompleted({
+        createdAt: 4_000,
+        itemId: "reasoning-1",
+        parentToolCallId: "stale-parent",
+        text: "Checked effective scope.",
+      }),
+      event.turnCompleted({ createdAt: 5_000 }),
+    ]);
+
+    const reasoningMessages = timeline.messages.filter(
+      (message) =>
+        message.kind === "operation" && message.title === "Thought for 2s",
+    );
+    expect(reasoningMessages).toEqual([
+      expect.objectContaining({
+        detail: "Checked effective scope.",
+        scope: { kind: "turn", turnId: "turn-1" },
+      }),
+    ]);
+    expect(reasoningMessages[0]).not.toHaveProperty("parentToolCallId");
+  });
+
+  it("finalizes streamed reasoning as interrupted when its turn is interrupted", () => {
+    const event = createTimelineEventFactory({ threadId: "thread-1" });
+    const timeline = renderIdleTimeline([
+      event.turnStarted({ createdAt: 0 }),
+      event.reasoningDelta({
+        createdAt: 2_000,
+        itemId: "reasoning-1",
+        delta: "Checking the failure path.",
+      }),
+      event.turnCompleted({ createdAt: 7_000, status: "interrupted" }),
+    ]);
+
+    expect(
+      timeline.messages.filter((message) => message.kind === "operation"),
+    ).toEqual([
+      expect.objectContaining({
+        completedAt: 7_000,
+        detail: "Checking the failure path.",
+        sourceSeqEnd: 3,
+        sourceSeqStart: 2,
+        startedAt: 2_000,
+        status: "interrupted",
+        title: "Thought for 5s",
+      }),
+    ]);
+  });
+
+  it("ignores reasoning deltas after explicit completion", () => {
+    const event = createTimelineEventFactory({ threadId: "thread-1" });
+    const timeline = renderActiveTimeline([
+      event.turnStarted({ createdAt: 0 }),
+      event.reasoningDelta({
+        createdAt: 1_000,
+        itemId: "reasoning-1",
+        delta: "Initial thought.",
+      }),
+      event.reasoningCompleted({
+        createdAt: 3_000,
+        itemId: "reasoning-1",
+        text: "Final thought.",
+      }),
+      event.reasoningDelta({
+        createdAt: 5_000,
+        itemId: "reasoning-1",
+        delta: "Late duplicate.",
+      }),
+    ]);
+
+    expect(timeline.projection.state.activeThinking).toBeNull();
+    expect(
+      timeline.messages.filter((message) => message.kind === "operation"),
+    ).toEqual([
+      expect.objectContaining({
+        detail: "Final thought.",
+        sourceSeqEnd: 3,
+        status: "completed",
+        title: "Thought for 2s",
+      }),
+    ]);
   });
 
   it("omits active reasoning from timeline rows", () => {

--- a/packages/thread-view/test/timeline-cli-rendering.snapshots.test.ts
+++ b/packages/thread-view/test/timeline-cli-rendering.snapshots.test.ts
@@ -2516,6 +2516,49 @@ describe("timeline CLI rendering snapshots", () => {
     ]);
   });
 
+  it("accepts the final text after fallback completion without reopening thinking", () => {
+    const event = createTimelineEventFactory({ threadId: "thread-1" });
+    const timeline = renderActiveTimeline([
+      event.turnStarted({ createdAt: 0 }),
+      event.reasoningDelta({
+        createdAt: 1_000,
+        itemId: "reasoning-1",
+        delta: "Initial thought.",
+      }),
+      event.turnCompleted({ createdAt: 3_000, status: "interrupted" }),
+      event.reasoningDelta({
+        createdAt: 4_000,
+        itemId: "reasoning-1",
+        delta: "Late delta.",
+      }),
+      event.reasoningCompleted({
+        createdAt: 5_000,
+        itemId: "reasoning-1",
+        text: "Final thought.",
+      }),
+      event.reasoningCompleted({
+        createdAt: 6_000,
+        itemId: "reasoning-1",
+        text: "Duplicate completion.",
+      }),
+    ]);
+
+    expect(timeline.projection.state.activeThinking).toBeNull();
+    expect(
+      timeline.messages.filter((message) => message.kind === "operation"),
+    ).toEqual([
+      expect.objectContaining({
+        detail: "Final thought.",
+        startedAt: 1_000,
+        completedAt: 3_000,
+        sourceSeqStart: 2,
+        sourceSeqEnd: 5,
+        status: "interrupted",
+        title: "Thought for 2s",
+      }),
+    ]);
+  });
+
   it("omits active reasoning from timeline rows", () => {
     const event = createTimelineEventFactory({ threadId: "thread-1" });
     const timeline = renderActiveTimeline([

--- a/packages/thread-view/test/timeline-test-harness.ts
+++ b/packages/thread-view/test/timeline-test-harness.ts
@@ -130,6 +130,10 @@ interface ReasoningDeltaArgs extends ProviderTurnEventOptions {
   itemId?: string;
 }
 
+interface ReasoningStartedArgs extends ProviderTurnEventOptions {
+  itemId?: string;
+}
+
 interface ToolCallCompletedArgs extends ProviderTurnEventOptions {
   arguments?: Record<string, JsonValue>;
   error?: string;
@@ -378,6 +382,9 @@ export interface TimelineEventFactory {
   reasoningDelta(
     args: ReasoningDeltaArgs,
   ): ThreadEventRowOfType<"item/reasoning/textDelta">;
+  reasoningStarted(
+    args?: ReasoningStartedArgs,
+  ): ThreadEventRowOfType<"item/started">;
   systemError(args: SystemErrorArgs): ThreadEventRowOfType<"system/error">;
   systemOperation(
     args: SystemOperationArgs,
@@ -1270,6 +1277,9 @@ export function createTimelineEventFactory(
             id: args.itemId ?? `reasoning-${base.seq}`,
             summary: [],
             content: [args.text],
+            ...(args.parentToolCallId
+              ? { parentToolCallId: args.parentToolCallId }
+              : {}),
           },
         },
       };
@@ -1283,6 +1293,28 @@ export function createTimelineEventFactory(
           ...providerFields(args),
           itemId: args.itemId ?? `reasoning-${base.seq}`,
           delta: args.delta,
+          ...(args.parentToolCallId
+            ? { parentToolCallId: args.parentToolCallId }
+            : {}),
+        },
+      };
+    },
+    reasoningStarted(args = {}) {
+      const base = nextProviderTurnScopedRowBase("reasoning-started", args);
+      return {
+        ...base,
+        type: "item/started",
+        data: {
+          ...providerFields(args),
+          item: {
+            type: "reasoning",
+            id: args.itemId ?? `reasoning-${base.seq}`,
+            summary: [],
+            content: [],
+            ...(args.parentToolCallId
+              ? { parentToolCallId: args.parentToolCallId }
+              : {}),
+          },
         },
       };
     },


### PR DESCRIPTION
## Human comments

## What was wrong

[#1248](https://github.com/get-bb/bb/issues/1248) requests expandable
`Thought for <duration>` sections while retaining the existing streaming
thinking presentation.

bb already displayed provider-visible reasoning through the active
`Thinking…` disclosure, but discarded that text from the timeline projection
when the reasoning lifecycle completed. Completed threads therefore retained
the surrounding work and assistant response, but not the reasoning shown while
the turn was running.

## What changed

Completed, non-empty reasoning lifecycles now produce expandable
`Thought for <duration>` entries in thread history through the existing generic
system-operation timeline machinery.

- Titles use persisted lifecycle timestamps and the existing compact duration
  formatter.
- Expandable details contain only reasoning text exposed by the provider.
- Entries retain their event range, turn scope, effective parent scope, and
  completed or interrupted status.
- Turn completion and thread interruption finalize reasoning that did not
  receive an explicit completion event.
- Finalized lifecycle keys reject late streaming deltas and duplicate completions.
- When a provider completes reasoning after Stop, its final text and event range
  update the saved thought while preserving its interrupted status and stop time.
- Completed reasoning details are capped at 32,000 characters.
- Active reasoning remains in the existing `Thinking…` disclosure.

Completed thoughts can appear inside the existing `Worked for…` disclosure.
No new public timeline-row kind or reasoning-specific UI component was added.

There are no database, persisted-event, server/host-daemon wire, CLI,
Plugin SDK, configuration, or documentation contract changes.
`HOST_DAEMON_PROTOCOL_VERSION` remains unchanged.

## How you verified

- Added focused coverage for explicit completion, final-text replacement,
  persisted lifecycle start times, interrupted reasoning, turn-finalization
  fallback, nested/root lifecycle isolation, late-delta rejection, completed
  CLI rendering, and deterministic replay.
- Replayed provider reasoning events through the timeline projection and
  confirmed that active reasoning appears only through `Thinking…`, completed
  reasoning appears once as `Thought for <duration>`, and completed entries
  survive rebuilding the idle timeline.
- Verified the behavior in the isolated development app with Claude Code and
  Pi sessions.
- `@bb/thread-view`: 377 tests passed; server timeline integration tests: 54
  passed; provider parity: 56 passed. Server and thread-view typechecks passed.
- The Stop → late provider completion regression fails on the original code and
  passes with the fix. Doobie verified the saved interrupted thought expands
  after reload in the development app.
- Formatting and `git diff --check` passed.

Fixes #1248

> AGENT GENERATED
