### PR TITLE
Add @danielbachhuber to contributor allow list

### DIFF
--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -62,3 +62,4 @@ kravtsovd
 alanagoyal
 IlyaM
 swairshah
+danielbachhuber


### PR DESCRIPTION
## Human comments

## What was wrong

GitHub user `danielbachhuber` was not in the persistent contributor allow list, so the PR approval gate would not treat contributions from their fork as approved.

## What changed

Added `danielbachhuber` to `.github/APPROVED_CONTRIBUTORS`. This is a policy-only change with no host daemon wire, CLI, guide, or documentation impact.

## How you verified

- Confirmed the GitHub account exists (`gh api users/danielbachhuber` returns login danielbachhuber).
- Ran `git diff --check`.
- Checked the contributor list for case-insensitive duplicates.

> AGENT GENERATED