### PR TITLE
Offer Show more when a toast title is truncated

### DIFF
--- a/apps/app/src/components/ui/app-toast.tsx
+++ b/apps/app/src/components/ui/app-toast.tsx
@@ -4,6 +4,7 @@ import {
   useState,
   type MouseEvent,
   type ReactNode,
+  type RefObject,
 } from "react";
 import { toast as sonnerToast, type Action, type ExternalToast } from "sonner";
 import { Button } from "@bb/shared-ui/button";
@@ -54,12 +55,6 @@ interface AppToastContentProps {
   onDismiss?: () => void;
   title: ReactNode;
   tone: AppToastTone;
-}
-
-interface AppToastDescriptionProps {
-  description: ReactNode;
-  notificationId: string | null;
-  onShowMore: () => void;
 }
 
 interface ShowAppToastParams {
@@ -129,44 +124,22 @@ function AppToastActionButton({
   );
 }
 
-export function AppToastDescription({
-  description,
-  notificationId,
-  onShowMore,
-}: AppToastDescriptionProps) {
-  const bodyRef = useRef<HTMLDivElement | null>(null);
+function useOverflowTruncation(
+  content: ReactNode,
+): [RefObject<HTMLDivElement | null>, boolean] {
+  const ref = useRef<HTMLDivElement | null>(null);
   const [truncated, setTruncated] = useState(false);
 
   useLayoutEffect(() => {
-    const body = bodyRef.current;
-    if (body === null) {
+    const node = ref.current;
+    if (node === null) {
+      setTruncated(false);
       return;
     }
-    setTruncated(body.scrollWidth - body.clientWidth > 1);
-  }, [description]);
+    setTruncated(node.scrollWidth - node.clientWidth > 1);
+  }, [content]);
 
-  return (
-    <>
-      <div
-        ref={bodyRef}
-        data-testid="app-toast-description"
-        className="min-w-0 flex-1 truncate"
-      >
-        {description}
-      </div>
-      {truncated && notificationId !== null ? (
-        <Button
-          type="button"
-          variant="link"
-          size="sm"
-          className="h-auto shrink-0 px-0 py-0 text-xs text-muted-foreground underline underline-offset-4"
-          onClick={onShowMore}
-        >
-          Show more
-        </Button>
-      ) : null}
-    </>
-  );
+  return [ref, truncated];
 }
 
 export function AppToastContent({
@@ -180,6 +153,11 @@ export function AppToastContent({
   title,
   tone,
 }: AppToastContentProps) {
+  const [titleRef, titleTruncated] = useOverflowTruncation(title);
+  const [descriptionRef, descriptionTruncated] =
+    useOverflowTruncation(description);
+  const canShowMore =
+    notificationId !== null && (titleTruncated || descriptionTruncated);
   const hasActions = action !== undefined || cancel !== undefined;
   const actions = hasActions ? (
     <>
@@ -205,21 +183,33 @@ export function AppToastContent({
         </div>
         <div className="min-w-0 flex-1">
           <div className="flex min-w-0 items-center gap-2">
-            <div className="min-w-0 flex-1 truncate text-sm font-medium leading-5">
+            <div
+              ref={titleRef}
+              className="min-w-0 flex-1 truncate text-sm font-medium leading-5"
+            >
               {title}
             </div>
           </div>
-          {description || hasActions ? (
+          {description || hasActions || canShowMore ? (
             <div className="mt-0.5 flex min-w-0 flex-nowrap items-center gap-2 text-xs leading-5 text-muted-foreground">
               {description ? (
-                <AppToastDescription
-                  description={description}
-                  notificationId={notificationId}
-                  onShowMore={() => {
+                <div ref={descriptionRef} className="min-w-0 flex-1 truncate">
+                  {description}
+                </div>
+              ) : null}
+              {canShowMore ? (
+                <Button
+                  type="button"
+                  variant="link"
+                  size="sm"
+                  className="h-auto shrink-0 px-0 py-0 text-xs text-muted-foreground underline underline-offset-4"
+                  onClick={() => {
                     dismissToast(id);
                     openNotificationCenter(notificationId);
                   }}
-                />
+                >
+                  Show more
+                </Button>
               ) : null}
               {actions}
             </div>

--- a/apps/app/src/lib/notifications/notifications.test.tsx
+++ b/apps/app/src/lib/notifications/notifications.test.tsx
@@ -51,47 +51,88 @@ describe("toast history", () => {
   });
 });
 
-describe("truncated toast descriptions", () => {
-  function renderToast() {
+describe("truncated toast text", () => {
+  const FITTING_WIDTH = 300;
+  const OVERFLOWING_WIDTH = 600;
+  const LONG_TITLE =
+    "Cannot checkout branch while another thread is using this workspace";
+  const SHORT_TITLE = "Installing the plugin failed";
+  const DESCRIPTION = "a very long esbuild error";
+
+  function mockOverflowingText(overflowingText: string | null) {
+    vi.spyOn(HTMLElement.prototype, "scrollWidth", "get").mockImplementation(
+      function (this: HTMLElement) {
+        return this.textContent === overflowingText
+          ? OVERFLOWING_WIDTH
+          : FITTING_WIDTH;
+      },
+    );
+    vi.spyOn(HTMLElement.prototype, "clientWidth", "get").mockReturnValue(
+      FITTING_WIDTH,
+    );
+  }
+
+  function showMoreButton() {
+    return screen.queryByRole("button", { name: "Show more" });
+  }
+
+  it("offers Show more when only the title does not fit", () => {
+    mockOverflowingText(LONG_TITLE);
     render(
       <AppToastContent
-        title="Installing the plugin failed"
-        description="a very long esbuild error"
+        title={LONG_TITLE}
+        description={DESCRIPTION}
         tone="error"
         notificationId="notification-7"
       />,
     );
-  }
 
-  function mockWidths(scrollWidth: number, clientWidth: number) {
-    vi.spyOn(HTMLElement.prototype, "scrollWidth", "get").mockReturnValue(
-      scrollWidth,
-    );
-    vi.spyOn(HTMLElement.prototype, "clientWidth", "get").mockReturnValue(
-      clientWidth,
-    );
-  }
-
-  it("offers Show more only when the description does not fit", () => {
-    mockWidths(300, 300);
-    renderToast();
-    expect(screen.queryByRole("button", { name: "Show more" })).toBeNull();
-
-    cleanup();
-    mockWidths(600, 300);
-    renderToast();
-    expect(screen.queryByRole("button", { name: "Show more" })).not.toBeNull();
+    expect(showMoreButton()).not.toBeNull();
   });
 
-  it("opens the center on the matching entry from Show more", () => {
-    mockWidths(600, 300);
-    renderToast();
+  it("offers Show more when only the description does not fit", () => {
+    mockOverflowingText(DESCRIPTION);
+    render(
+      <AppToastContent
+        title={SHORT_TITLE}
+        description={DESCRIPTION}
+        tone="error"
+        notificationId="notification-7"
+      />,
+    );
+
+    expect(showMoreButton()).not.toBeNull();
+  });
+
+  it("hides Show more when the title and the description both fit", () => {
+    mockOverflowingText(null);
+    render(
+      <AppToastContent
+        title={SHORT_TITLE}
+        description={DESCRIPTION}
+        tone="error"
+        notificationId="notification-7"
+      />,
+    );
+
+    expect(showMoreButton()).toBeNull();
+  });
+
+  it("recovers a title-only toast whose title does not fit", () => {
+    mockOverflowingText(LONG_TITLE);
+    render(
+      <AppToastContent
+        title={LONG_TITLE}
+        tone="error"
+        notificationId="notification-9"
+      />,
+    );
 
     fireEvent.click(screen.getByRole("button", { name: "Show more" }));
 
     expect(getNotificationCenterState()).toEqual({
       open: true,
-      focusedId: "notification-7",
+      focusedId: "notification-9",
     });
   });
 });


### PR DESCRIPTION
## Human comments

Minimal fix — it just restores a way to read the message. Two things I think
still need doing:

1. The toast is too narrow. 356px is only Sonner's default, not a decision
anyone here made, and there's plenty of screen going spare.

2. These should really be a short title plus a longer body. Part of that
already exists and gets thrown away — lifecycle errors do emit
`{title, body}`, then `formatLifecycleErrorDescription` glues them back into
one string. That part's a one-function fix. The flat `ApiError(…, message)`
throws never had a split at all, and sorting those out is a much bigger job.

## What was wrong

The toast card clamps its title to a single line with `truncate`, but the
"Show more" affordance — the only route to the Notification Center, where
toast text wraps and can be copied — lived inside `AppToastDescription` and
was measured against the description alone. A toast with no description
therefore had no recovery path at all.

`showMutationErrorToast` produces exactly that shape: it calls
`appToast.error(message)` with a single argument
(`apps/app/src/lib/mutation-errors.ts:197`), so the whole server message
lands in the title slot. Flat errors take this path because they carry no
structure to split on — `thread-create.ts:363` raises
`ApiError(409, "invalid_request", …)` for a busy workspace, and
`invalid_request` is not one of the eight `lifecycleApiErrorSchema` codes,
so `describeLifecycleError` returns null and `getMutationErrorMessage`
falls through to the raw server sentence (`mutation-errors.ts:152`).

At Sonner's default 356px width the title holds roughly 40 characters, so
"Cannot checkout branch while another thread is using this workspace"
rendered as "Cannot checkout branch while another thr…" with no way to read
the rest. Line references are against `ea6ce5b0c`.

## What changed

**`apps/app/src/components/ui/app-toast.tsx`** — extracted the overflow
measurement out of `AppToastDescription` into a `useOverflowTruncation`
hook and applied it to the title as well as the description.
`AppToastContent` now owns a single "Show more" button, rendered when
either region overflows, and emits the secondary row for a title-only toast
that overflowed. `AppToastDescription` collapsed into `AppToastContent` (it
had no consumers outside this file), and an unused `data-testid` was
dropped. Net -10 lines.

Descriptions behave exactly as before, and `mutation-errors.ts` is
untouched, so the inline consumers of `getMutationErrorMessage` render
identical text. App-only change: no host daemon wire impact (no
`HOST_DAEMON_PROTOCOL_VERSION` bump needed), and no CLI, guide, or
documentation surface is affected.

Deliberately out of scope: the deeper fix of giving flat server errors a
real title/body split, and promoting `invalid_request` refusals to
structured lifecycle codes. Both would narrow the class of errors that can
overflow, but neither removes the need for a recovery path on the title.

## How you verified

- Four tests in `apps/app/src/lib/notifications/notifications.test.tsx`
  covering title-only overflow, title-overflows-while-description-fits,
  description-only overflow, and the both-fit negative case. The first two
  fail before this change and pass after.
- Replaced the prototype-wide width stub with a per-element one, so a title
  and a description can disagree about fitting; the previous stub forced
  them to agree and could not exercise the new branch.
- Mutation-tested the assertions: reverting `canShowMore` to
  description-only fails exactly the two title tests and leaves the
  description test green; hardcoding `titleTruncated = true` fails exactly
  the both-fit test.
- `pnpm exec turbo run test --filter=@bb/app` — 18/18 across
  `app-toast.test`, `notifications.test`, `AppToaster.test`.
- `pnpm exec turbo run typecheck --filter=@bb/app` clean;
  `lint --filter=@bb/app` reports no warnings in either touched file.

Fixes #3068

> AGENT GENERATED
