### PR TITLE
Account Pooler: sign in to Codex from the settings page

### DIFF
--- a/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
@@ -52,7 +52,7 @@ BB_HOST_DAEMON_PORT only for an intentional non-default target.
 - Pass `--yes` for a confirmed destructive command in a non-interactive shell.
 - Treat plugin commands as normal top-level commands after installation.
 
-The builtin Account Pool plugin is disabled by default. Enable it, add Claude
+The builtin Account Pooler [Experimental] plugin is disabled by default. Enable it, add Claude
 or Codex credentials, and inspect its proxy routes and account quota with:
 
 ```sh

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
@@ -52,7 +52,7 @@ BB_HOST_DAEMON_PORT only for an intentional non-default target.
 - Pass `--yes` for a confirmed destructive command in a non-interactive shell.
 - Treat plugin commands as normal top-level commands after installation.
 
-The builtin Account Pooler [Experimental] plugin is disabled by default. Enable it, add Claude
+The builtin Account Pooler plugin is disabled by default. Enable it, add Claude
 or Codex credentials, and inspect its proxy routes and account quota with:
 
 ```sh

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
@@ -59,6 +59,8 @@ or Codex credentials, and inspect its proxy routes and account quota with:
 bb plugin enable account-pool
 bb pool account add --provider claude --login
 printf '%s\n' "$CLAUDE_AUTH_CODE" | bb pool account login-complete --session <id> --code-stdin
+bb pool account add --provider codex --login
+bb pool account login-poll --session <id>
 bb pool account add --provider claude --import
 bb pool account add --provider codex --import
 printf '%s\n' "$ANTHROPIC_API_KEY" | bb pool account add --provider claude --api-key-stdin [--label <text>] [--priority <n>]
@@ -72,10 +74,12 @@ bb pool token rotate --machine <id-or-name>
 bb pool bypass <thread-id> [--off]
 ```
 
-`--login` starts a PKCE session, prints a browser URL and session ID, then
-exits. Pipe the manual Claude callback code to `account login-complete` with
-that session ID within ten minutes. The code stays out of process arguments,
-and the browser and bb server may be on different machines. Newly added or
+Claude `--login` starts a PKCE session, prints a browser URL and session ID,
+then exits. Pipe the manual callback code to `account login-complete` with that
+session ID within ten minutes. Codex `--login` prints a device verification
+URL, one-time code, session ID, and an `account login-poll` command that waits
+for authorization. The Claude code stays out of process arguments, and either
+browser may be on a different machine from the bb server. Newly added or
 enabled accounts are available without a plugin reload. With an
 enabled account whose secret file remains readable and valid, matching Claude
 Code or Codex sessions receive the pool route and a distinct secret token for
@@ -89,9 +93,9 @@ prior token valid for ten minutes. Agents should pipe API keys to
 `--api-key-stdin`;
 `--api-key <key>` is an unsafe compatibility form that exposes the key in
 process arguments, shell history, and agent transcripts. Prefer `--import` for
-an existing Claude Code login. Codex import reads `~/.codex/auth.json` on the
-bb server host. OAuth quota refreshes on add or enable and every
-five minutes while an account is idle. Account tables add columns for observed
+an existing Claude Code login. The CLI Codex import path reads
+`~/.codex/auth.json` on the bb server host. OAuth quota refreshes on add or
+enable and every five minutes while an account is idle. Account tables add columns for observed
 model-family buckets; JSON status exposes their utilization, reset, status,
 observation time, and source under `familyWeekly`. Selection skips an account
 whose requested family is spent while retaining it for other families. A

--- a/apps/server/test/system/provider-states.test.ts
+++ b/apps/server/test/system/provider-states.test.ts
@@ -60,7 +60,7 @@ describe("getProviderStates", () => {
             ? {
                 label: "Proxied",
                 statusMessage:
-                  "Credentials are provided by the Account Pooler [Experimental] hub.",
+                  "Credentials are provided by the Account Pooler hub.",
               }
             : null,
       });
@@ -101,7 +101,7 @@ describe("getProviderStates", () => {
         ).toMatchObject({
           status: "ready",
           statusMessage:
-            "Credentials are provided by the Account Pooler [Experimental] hub.",
+            "Credentials are provided by the Account Pooler hub.",
           planLabel: "Proxied",
           accountEmail: null,
           loginCommand: null,

--- a/apps/server/test/system/provider-states.test.ts
+++ b/apps/server/test/system/provider-states.test.ts
@@ -60,7 +60,7 @@ describe("getProviderStates", () => {
             ? {
                 label: "Proxied",
                 statusMessage:
-                  "Credentials are provided by the Account Pool hub.",
+                  "Credentials are provided by the Account Pooler [Experimental] hub.",
               }
             : null,
       });
@@ -100,7 +100,8 @@ describe("getProviderStates", () => {
           ),
         ).toMatchObject({
           status: "ready",
-          statusMessage: "Credentials are provided by the Account Pool hub.",
+          statusMessage:
+            "Credentials are provided by the Account Pooler [Experimental] hub.",
           planLabel: "Proxied",
           accountEmail: null,
           loginCommand: null,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -613,7 +613,7 @@ persistently restores undimmed splits.
 
 ## Account Pooler [Experimental]
 
-The builtin Account Pooler [Experimental] plugin is disabled on fresh installations. It stores
+The builtin Account Pooler plugin is disabled on fresh installations. It stores
 non-secret Claude and Codex account metadata in plugin KV, quota observations
 in the plugin SQLite database, and each account token plus per-machine hub
 tokens in 0600 files under
@@ -638,7 +638,7 @@ pipe the code shown on Anthropic's manual callback page to
 machine from the bb server, and the code stays out of process arguments. The
 Codex login command prints a ChatGPT device verification URL, one-time code,
 session ID, and an `account login-poll` command that waits until authorization
-completes or expires. The Account Pooler [Experimental] plugin settings page exposes both flows
+completes or expires. The Account Pooler plugin settings page exposes both flows
 with **Sign in to Claude** and **Sign in to Codex**, plus Claude import,
 API-key, enable/disable, and removal controls.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -611,9 +611,9 @@ how many connected clients received the broadcast. `spotlight` focuses the
 target pane and persistently dims the others; `clear-spotlight` focuses it and
 persistently restores undimmed splits.
 
-## Account Pool
+## Account Pooler [Experimental]
 
-The builtin Account Pool plugin is disabled on fresh installations. It stores
+The builtin Account Pooler [Experimental] plugin is disabled on fresh installations. It stores
 non-secret Claude and Codex account metadata in plugin KV, quota observations
 in the plugin SQLite database, and each account token plus per-machine hub
 tokens in 0600 files under
@@ -638,7 +638,7 @@ pipe the code shown on Anthropic's manual callback page to
 machine from the bb server, and the code stays out of process arguments. The
 Codex login command prints a ChatGPT device verification URL, one-time code,
 session ID, and an `account login-poll` command that waits until authorization
-completes or expires. The Account Pool plugin settings page exposes both flows
+completes or expires. The Account Pooler [Experimental] plugin settings page exposes both flows
 with **Sign in to Claude** and **Sign in to Codex**, plus Claude import,
 API-key, enable/disable, and removal controls.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -624,22 +624,25 @@ Enable it and add at least one account:
 bb plugin enable account-pool
 bb pool account add --provider claude --login
 printf '%s\n' "$CLAUDE_AUTH_CODE" | bb pool account login-complete --session <id> --code-stdin
+bb pool account add --provider codex --login
+bb pool account login-poll --session <id>
 bb pool account add --provider claude --import
 bb pool account add --provider codex --import
 printf '%s\n' "$ANTHROPIC_API_KEY" | bb pool account add --provider claude --api-key-stdin [--label <text>] [--priority <n>]
 ```
 
-The login start command creates a ten-minute in-memory PKCE session, prints a
-Claude browser authorization URL and session ID, then exits. After sign-in,
+The Claude login start command creates a ten-minute in-memory PKCE session,
+prints a browser authorization URL and session ID, then exits. After sign-in,
 pipe the code shown on Anthropic's manual callback page to
 `account login-complete` with that session ID. The browser can be on a different
 machine from the bb server, and the code stays out of process arguments. The
-Account Pool plugin settings page exposes the same flow with **Sign in to
-Claude**, plus provider-specific import, API-key, enable/disable, and removal
-controls. Codex has no browser sign-in flow; **Import Codex from this machine**
-reads the bb server host's `~/.codex/auth.json`.
+Codex login command prints a ChatGPT device verification URL, one-time code,
+session ID, and an `account login-poll` command that waits until authorization
+completes or expires. The Account Pool plugin settings page exposes both flows
+with **Sign in to Claude** and **Sign in to Codex**, plus Claude import,
+API-key, enable/disable, and removal controls.
 
-The import paths read the Claude Code or Codex login on the bb server host.
+The CLI import paths read the Claude Code or Codex login on the bb server host.
 `--api-key-stdin` reads exactly one non-empty key from piped standard input and
 is the default API-key path for agents. The compatibility form `--api-key
 <key>` remains available, but exposes the secret in process arguments, shell

--- a/packages/plugin-api-map/src/plugin-icons.ts
+++ b/packages/plugin-api-map/src/plugin-icons.ts
@@ -33,7 +33,7 @@ interface FirstPartyPlugin {
 }
 
 const FIRST_PARTY_PLUGINS: Record<string, FirstPartyPlugin> = {
-  "Account Pool": { id: "account-pool", icon: Layers01Icon },
+  "Account Pooler [Experimental]": { id: "account-pool", icon: Layers01Icon },
   "Ask User Question": { id: "ask-user-question", icon: MessageQuestionIcon },
   Automations: { id: "automations", icon: Clock01Icon },
   "Custom instructions": { id: "custom-instructions", icon: Edit04Icon },

--- a/packages/templates/src/templates/bb-guide-plugins.md
+++ b/packages/templates/src/templates/bb-guide-plugins.md
@@ -23,7 +23,7 @@ The builtin Custom instructions plugin adds a multiline editor under Settings
 → Custom instructions. Saved text is persisted on this bb host and included in
 agent task instructions; blank text contributes nothing.
 
-The builtin Account Pool plugin is disabled on fresh installations. It stores
+The builtin Account Pooler [Experimental] plugin is disabled on fresh installations. It stores
 Claude and Codex account tokens in per-account 0600 secret files and proxies
 provider API requests through the bb server. Enable it and add an account:
 

--- a/packages/templates/src/templates/bb-guide-plugins.md
+++ b/packages/templates/src/templates/bb-guide-plugins.md
@@ -44,13 +44,15 @@ bb pool token rotate --machine <id-or-name>
 bb pool bypass <thread-id> [--off]
 ```
 
-`--login` starts a ten-minute in-memory PKCE session, prints the Claude browser
+Claude `--login` starts a ten-minute in-memory PKCE session, prints the browser
 sign-in URL and session ID, then exits. After sign-in, pipe the manual callback
 code to `account login-complete` with that session ID. The browser does not need
 to run on the bb server machine, and neither the code nor account tokens enter
-process arguments. The same flow is available in the plugin settings page
-through the **Sign in to Claude** button. Codex import reads the bb server
-host's `~/.codex/auth.json` and has no browser sign-in flow.
+process arguments. Codex `--login` prints a device verification URL, one-time
+code, session ID, and an `account login-poll` command that waits for
+authorization. Both flows are available in the plugin settings page through
+the **Sign in to Claude** and **Sign in to Codex** buttons. The CLI Codex import
+path continues to read the bb server host's `~/.codex/auth.json`.
 
 The hub starts immediately, even before an account is configured, so newly
 added or enabled accounts are available without a plugin reload. With an

--- a/packages/templates/src/templates/bb-guide-plugins.md
+++ b/packages/templates/src/templates/bb-guide-plugins.md
@@ -23,7 +23,7 @@ The builtin Custom instructions plugin adds a multiline editor under Settings
 → Custom instructions. Saved text is persisted on this bb host and included in
 agent task instructions; blank text contributes nothing.
 
-The builtin Account Pooler [Experimental] plugin is disabled on fresh installations. It stores
+The builtin Account Pooler plugin is disabled on fresh installations. It stores
 Claude and Codex account tokens in per-account 0600 secret files and proxies
 provider API requests through the bb server. Enable it and add an account:
 

--- a/plugins/account-pool/app.test.tsx
+++ b/plugins/account-pool/app.test.tsx
@@ -94,44 +94,104 @@ describe("Account Pool settings", () => {
     });
   });
 
-  it("imports Codex credentials from the server machine", async () => {
-    const added = {
+  it("signs in to Codex through the device-code state machine", async () => {
+    const added: AccountSummary = {
       ...account(),
-      provider: "codex" as const,
+      provider: "codex",
       label: "Codex Pro",
+      email: "codex@example.com",
+      codexAccountId: "chatgpt-account-1",
     };
     const accounts: AccountSummary[] = [];
+    const opened: string[] = [];
+    let polls = 0;
     const slot = renderSlot(
       app.settingsSections[0]!,
       {},
       {
+        openUrl: (url) => {
+          opened.push(url);
+          return true;
+        },
         rpc: {
           "account.list": () => [...accounts],
-          "account.add": () => {
+          "codexLogin.start": () => ({
+            sessionId: "33333333-3333-4333-8333-333333333333",
+            verificationUri: "https://auth.openai.com/codex/device",
+            userCode: "ABCD-1234",
+            expiresAt: Date.now() + 600_000,
+            intervalMs: 1,
+          }),
+          "codexLogin.poll": () => {
+            polls += 1;
+            if (polls === 1) return { status: "pending" };
             accounts.push(added);
-            return added;
+            return { status: "complete", account: added };
           },
         },
       },
     );
     fireEvent.click(
       await slot.findByRole("button", {
-        name: "Import Codex from this machine",
+        name: "Sign in to Codex",
       }),
     );
-    await waitFor(() =>
-      expect(slot.rpcCalls).toContainEqual({
-        method: "account.add",
-        input: {
-          provider: "codex",
-          source: { kind: "import" },
-          label: null,
-          priority: 100,
-        },
-      }),
+    expect(await slot.findByText("Finish signing in to Codex")).toBeTruthy();
+    expect(slot.getByLabelText("Codex user code").textContent).toContain(
+      "ABCD-1234",
     );
+    expect(slot.getByText("Waiting for you to authorize…")).toBeTruthy();
+    expect(opened).toEqual(["https://auth.openai.com/codex/device"]);
     expect(await slot.findByText("Codex Pro")).toBeTruthy();
     expect(slot.getByText("Codex")).toBeTruthy();
+    expect(
+      slot.rpcCalls.filter((call) => call.method === "codexLogin.poll"),
+    ).toHaveLength(2);
+  });
+
+  it("shows a Codex device-login error and allows retry", async () => {
+    const slot = renderSlot(
+      app.settingsSections[0]!,
+      {},
+      {
+        openUrl: () => true,
+        rpc: {
+          "account.list": () => [],
+          "codexLogin.start": () => ({
+            sessionId: "33333333-3333-4333-8333-333333333333",
+            verificationUri: "https://auth.openai.com/codex/device",
+            userCode: "ABCD-1234",
+            expiresAt: Date.now() + 600_000,
+            intervalMs: 1,
+          }),
+          "codexLogin.poll": () => ({
+            status: "error",
+            message: "Code expired, start again.",
+          }),
+        },
+      },
+    );
+    fireEvent.click(
+      await slot.findByRole("button", { name: "Sign in to Codex" }),
+    );
+    expect((await slot.findByRole("alert")).textContent).toContain(
+      "Code expired, start again.",
+    );
+    expect(slot.getByRole("button", { name: "Try again" })).toBeTruthy();
+  });
+
+  it("does not render a Codex import button", async () => {
+    const slot = renderSlot(
+      app.settingsSections[0]!,
+      {},
+      {
+        rpc: { "account.list": () => [] },
+      },
+    );
+    expect(await slot.findByText("No provider accounts yet")).toBeTruthy();
+    expect(
+      slot.queryByRole("button", { name: "Import Codex from this machine" }),
+    ).toBeNull();
   });
 
   it("keeps the login step open and shows a completion error inline", async () => {

--- a/plugins/account-pool/app.test.tsx
+++ b/plugins/account-pool/app.test.tsx
@@ -180,6 +180,37 @@ describe("Account Pool settings", () => {
     expect(slot.getByRole("button", { name: "Try again" })).toBeTruthy();
   });
 
+  it("cancels the server-side Codex login session", async () => {
+    const slot = renderSlot(
+      app.settingsSections[0]!,
+      {},
+      {
+        openUrl: () => true,
+        rpc: {
+          "account.list": () => [],
+          "codexLogin.start": () => ({
+            sessionId: "33333333-3333-4333-8333-333333333333",
+            verificationUri: "https://auth.openai.com/codex/device",
+            userCode: "ABCD-1234",
+            expiresAt: Date.now() + 600_000,
+            intervalMs: 60_000,
+          }),
+          "codexLogin.cancel": () => ({ cancelled: true }),
+        },
+      },
+    );
+    fireEvent.click(
+      await slot.findByRole("button", { name: "Sign in to Codex" }),
+    );
+    fireEvent.click(await slot.findByRole("button", { name: "Cancel" }));
+
+    expect(slot.queryByText("Finish signing in to Codex")).toBeNull();
+    expect(slot.rpcCalls).toContainEqual({
+      method: "codexLogin.cancel",
+      input: { sessionId: "33333333-3333-4333-8333-333333333333" },
+    });
+  });
+
   it("does not render a Codex import button", async () => {
     const slot = renderSlot(
       app.settingsSections[0]!,

--- a/plugins/account-pool/app.tsx
+++ b/plugins/account-pool/app.tsx
@@ -275,7 +275,7 @@ function AccountPoolSettings() {
           Provider accounts
         </h3>
         <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-          Account Pool routes Claude and Codex threads through available
+          Account Pooler [Experimental] routes Claude and Codex threads through available
           accounts and moves away from accounts that reach their limits.
         </p>
       </div>
@@ -577,7 +577,7 @@ function AccountPoolSettings() {
                 <DialogTitle>Add an Anthropic API key</DialogTitle>
                 <DialogDescription>
                   The key is sent directly to this bb server and stored in its
-                  protected Account Pool secret directory.
+                  protected Account Pooler [Experimental] secret directory.
                 </DialogDescription>
               </DialogHeader>
               <Input

--- a/plugins/account-pool/app.tsx
+++ b/plugins/account-pool/app.tsx
@@ -25,6 +25,14 @@ interface LoginStep {
   authorizeUrl: string;
 }
 
+interface CodexLoginStep {
+  sessionId: string;
+  verificationUri: string;
+  userCode: string;
+  expiresAt: number;
+  intervalMs: number;
+}
+
 function errorText(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
@@ -42,9 +50,13 @@ function AccountPoolSettings() {
   const navigate = useBbNavigate();
   const [accounts, setAccounts] = useState<AccountSummary[] | null>(null);
   const [loading, setLoading] = useState(false);
-  const [codexLoading, setCodexLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [loginStep, setLoginStep] = useState<LoginStep | null>(null);
+  const [codexLoginStep, setCodexLoginStep] = useState<CodexLoginStep | null>(
+    null,
+  );
+  const [codexLoginError, setCodexLoginError] = useState<string | null>(null);
+  const [codexLoginPending, setCodexLoginPending] = useState(false);
   const [pastedCode, setPastedCode] = useState("");
   const [loginPending, setLoginPending] = useState(false);
   const [removeAccount, setRemoveAccount] = useState<AccountSummary | null>(
@@ -79,6 +91,37 @@ function AccountPoolSettings() {
   useRealtime(ACCOUNT_POOL_ACCOUNTS_CHANGED, () => {
     void refresh();
   });
+
+  useEffect(() => {
+    if (codexLoginStep === null || codexLoginError !== null) return;
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const poll = async () => {
+      try {
+        const result = await rpc.call("codexLogin.poll", {
+          sessionId: codexLoginStep.sessionId,
+        });
+        if (cancelled) return;
+        if (result.status === "complete") {
+          setCodexLoginStep(null);
+          await refresh();
+          return;
+        }
+        if (result.status === "error") {
+          setCodexLoginError(result.message);
+          return;
+        }
+        timer = setTimeout(poll, codexLoginStep.intervalMs);
+      } catch (pollError) {
+        if (!cancelled) setCodexLoginError(errorText(pollError));
+      }
+    };
+    timer = setTimeout(poll, codexLoginStep.intervalMs);
+    return () => {
+      cancelled = true;
+      if (timer !== null) clearTimeout(timer);
+    };
+  }, [codexLoginError, codexLoginStep, refresh, rpc]);
 
   const mutate = useCallback(
     async (action: () => Promise<void>) => {
@@ -129,6 +172,22 @@ function AccountPoolSettings() {
     }
   }
 
+  async function startCodexLogin(): Promise<void> {
+    if (codexLoginPending) return;
+    setCodexLoginPending(true);
+    setCodexLoginError(null);
+    setError(null);
+    try {
+      const started = await rpc.call("codexLogin.start", null);
+      setCodexLoginStep(started);
+      navigate.openUrl(started.verificationUri);
+    } catch (startError) {
+      setError(errorText(startError));
+    } finally {
+      setCodexLoginPending(false);
+    }
+  }
+
   async function importAccount(): Promise<void> {
     if (loading) return;
     setLoading(true);
@@ -141,20 +200,6 @@ function AccountPoolSettings() {
       });
     });
     setLoading(false);
-  }
-
-  async function importCodexAccount(): Promise<void> {
-    if (codexLoading) return;
-    setCodexLoading(true);
-    await mutate(async () => {
-      await rpc.call("account.add", {
-        provider: "codex",
-        source: { kind: "import" },
-        label: null,
-        priority: 100,
-      });
-    });
-    setCodexLoading(false);
   }
 
   async function addApiKey(): Promise<void> {
@@ -200,6 +245,14 @@ function AccountPoolSettings() {
       await navigator.clipboard.writeText(loginStep.authorizeUrl);
     } catch {
       setError("Copy failed. Select the URL and copy it manually.");
+    }
+  }
+
+  async function copyCodexValue(value: string): Promise<void> {
+    try {
+      await navigator.clipboard.writeText(value);
+    } catch {
+      setError("Copy failed. Select the value and copy it manually.");
     }
   }
 
@@ -285,36 +338,7 @@ function AccountPoolSettings() {
         </div>
       )}
 
-      {loginStep === null ? (
-        <div className="flex flex-wrap gap-2">
-          <Button type="button" disabled={loginPending} onClick={startLogin}>
-            {loginPending ? "Starting…" : "Sign in to Claude"}
-          </Button>
-          <Button
-            type="button"
-            variant="outline"
-            disabled={loading}
-            onClick={() => void importAccount()}
-          >
-            {loading ? "Importing…" : "Import Claude from this machine"}
-          </Button>
-          <Button
-            type="button"
-            variant="outline"
-            disabled={codexLoading}
-            onClick={() => void importCodexAccount()}
-          >
-            {codexLoading ? "Importing…" : "Import Codex from this machine"}
-          </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            onClick={() => setApiKeyOpen(true)}
-          >
-            Add API key
-          </Button>
-        </div>
-      ) : (
+      {loginStep !== null ? (
         <div className="space-y-3 rounded-md border border-border/60 px-4 py-4">
           <div>
             <p className="text-sm font-medium text-foreground">
@@ -371,6 +395,118 @@ function AccountPoolSettings() {
               Cancel
             </Button>
           </div>
+        </div>
+      ) : codexLoginStep !== null ? (
+        <div className="space-y-3 rounded-md border border-border/60 px-4 py-4">
+          <div>
+            <p className="text-sm font-medium text-foreground">
+              Finish signing in to Codex
+            </p>
+            <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+              Open the verification page, sign in to ChatGPT, and enter this
+              one-time code.
+            </p>
+          </div>
+          <div className="flex gap-2">
+            <Input
+              readOnly
+              value={codexLoginStep.verificationUri}
+              aria-label="Codex verification URL"
+              className="font-mono text-xs"
+              onFocus={(event) => event.currentTarget.select()}
+            />
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() =>
+                void copyCodexValue(codexLoginStep.verificationUri)
+              }
+            >
+              Copy URL
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => navigate.openUrl(codexLoginStep.verificationUri)}
+            >
+              Open
+            </Button>
+          </div>
+          <div className="flex items-center gap-3 rounded-md bg-surface-recessed px-3 py-3">
+            <code
+              aria-label="Codex user code"
+              className="select-all font-mono text-lg font-semibold tracking-wider text-foreground"
+            >
+              {codexLoginStep.userCode}
+            </code>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="ml-auto"
+              onClick={() => void copyCodexValue(codexLoginStep.userCode)}
+            >
+              Copy code
+            </Button>
+          </div>
+          {codexLoginError === null ? (
+            <p className="text-sm text-muted-foreground" role="status">
+              Waiting for you to authorize…
+            </p>
+          ) : (
+            <div className="space-y-2">
+              <p className="text-xs text-destructive-text" role="alert">
+                {codexLoginError}
+              </p>
+              <Button
+                type="button"
+                onClick={() => {
+                  setCodexLoginStep(null);
+                  void startCodexLogin();
+                }}
+              >
+                Try again
+              </Button>
+            </div>
+          )}
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => {
+              setCodexLoginStep(null);
+              setCodexLoginError(null);
+            }}
+          >
+            Cancel
+          </Button>
+        </div>
+      ) : (
+        <div className="flex flex-wrap gap-2">
+          <Button type="button" disabled={loginPending} onClick={startLogin}>
+            {loginPending ? "Starting…" : "Sign in to Claude"}
+          </Button>
+          <Button
+            type="button"
+            disabled={codexLoginPending}
+            onClick={() => void startCodexLogin()}
+          >
+            {codexLoginPending ? "Starting…" : "Sign in to Codex"}
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            disabled={loading}
+            onClick={() => void importAccount()}
+          >
+            {loading ? "Importing…" : "Import Claude from this machine"}
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => setApiKeyOpen(true)}
+          >
+            Add API key
+          </Button>
         </div>
       )}
 

--- a/plugins/account-pool/app.tsx
+++ b/plugins/account-pool/app.tsx
@@ -275,7 +275,7 @@ function AccountPoolSettings() {
           Provider accounts
         </h3>
         <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-          Account Pooler [Experimental] routes Claude and Codex threads through available
+          Account Pooler routes Claude and Codex threads through available
           accounts and moves away from accounts that reach their limits.
         </p>
       </div>
@@ -577,7 +577,7 @@ function AccountPoolSettings() {
                 <DialogTitle>Add an Anthropic API key</DialogTitle>
                 <DialogDescription>
                   The key is sent directly to this bb server and stored in its
-                  protected Account Pooler [Experimental] secret directory.
+                  protected Account Pooler secret directory.
                 </DialogDescription>
               </DialogHeader>
               <Input

--- a/plugins/account-pool/app.tsx
+++ b/plugins/account-pool/app.tsx
@@ -188,6 +188,18 @@ function AccountPoolSettings() {
     }
   }
 
+  async function cancelCodexLogin(): Promise<void> {
+    if (codexLoginStep === null) return;
+    const sessionId = codexLoginStep.sessionId;
+    setCodexLoginStep(null);
+    setCodexLoginError(null);
+    try {
+      await rpc.call("codexLogin.cancel", { sessionId });
+    } catch (cancelError) {
+      setError(errorText(cancelError));
+    }
+  }
+
   async function importAccount(): Promise<void> {
     if (loading) return;
     setLoading(true);
@@ -472,10 +484,7 @@ function AccountPoolSettings() {
           <Button
             type="button"
             variant="ghost"
-            onClick={() => {
-              setCodexLoginStep(null);
-              setCodexLoginError(null);
-            }}
+            onClick={() => void cancelCodexLogin()}
           >
             Cancel
           </Button>

--- a/plugins/account-pool/package.json
+++ b/plugins/account-pool/package.json
@@ -8,7 +8,7 @@
     "bb": ">=0.0"
   },
   "bb": {
-    "name": "Account Pool",
+    "name": "Account Pooler [Experimental]",
     "description": "Routes Claude and Codex API traffic across provider account pools.",
     "branding": {
       "icon": "Layers"

--- a/plugins/account-pool/src/cli.ts
+++ b/plugins/account-pool/src/cli.ts
@@ -329,20 +329,31 @@ export function registerPoolCli(
           const input = codexLoginPollInputSchema.parse({
             sessionId: flags.values.get("session"),
           });
-          while (true) {
-            const result = await codexLogin.poll(input);
-            if (result.status === "complete") {
-              return {
-                exitCode: 0,
-                stdout: `Added ${result.account.label} (${result.account.id}).\n`,
-              };
+          const signal = ctx.signal;
+          try {
+            while (true) {
+              await wait(
+                codexLogin.nextPollDelayMs(input.sessionId),
+                undefined,
+                { signal },
+              );
+              const result = await codexLogin.poll(input);
+              if (signal?.aborted) {
+                throw signal.reason ?? new Error("Codex login was cancelled.");
+              }
+              if (result.status === "complete") {
+                return {
+                  exitCode: 0,
+                  stdout: `Added ${result.account.label} (${result.account.id}).\n`,
+                };
+              }
+              if (result.status === "error") {
+                throw new Error(result.message);
+              }
             }
-            if (result.status === "error") {
-              throw new Error(result.message);
-            }
-            await wait(codexLogin.nextPollDelayMs(input.sessionId), undefined, {
-              signal: ctx.signal,
-            });
+          } catch (error) {
+            if (signal?.aborted) codexLogin.cancel(input);
+            throw error;
           }
         }
         if (argv[0] === "account" && argv[1] === "login-complete") {

--- a/plugins/account-pool/src/cli.ts
+++ b/plugins/account-pool/src/cli.ts
@@ -331,7 +331,13 @@ export function registerPoolCli(
             sessionId: flags.values.get("session"),
           });
           const signal = ctx.signal;
+          const cancel = () => codexLogin.cancel(input);
+          signal?.addEventListener("abort", cancel, { once: true });
           try {
+            if (signal?.aborted) {
+              cancel();
+              throw signal.reason ?? new Error("Codex login was cancelled.");
+            }
             while (true) {
               await wait(
                 codexLogin.nextPollDelayMs(input.sessionId),
@@ -355,6 +361,8 @@ export function registerPoolCli(
           } catch (error) {
             if (signal?.aborted) codexLogin.cancel(input);
             throw error;
+          } finally {
+            signal?.removeEventListener("abort", cancel);
           }
         }
         if (argv[0] === "account" && argv[1] === "login-complete") {

--- a/plugins/account-pool/src/cli.ts
+++ b/plugins/account-pool/src/cli.ts
@@ -1,8 +1,10 @@
 import type { BbPluginApi, PluginCliResult } from "@get-bb/plugin-sdk";
+import { setTimeout as wait } from "node:timers/promises";
 import {
   accountAddInputSchema,
   accountIdInputSchema,
   bypassInputSchema,
+  codexLoginPollInputSchema,
   loginCompleteInputSchema,
   tokenRotateInputSchema,
   type AccountSummary,
@@ -12,6 +14,7 @@ import {
 } from "./contracts.js";
 import type { PoolOperations } from "./operations.js";
 import type { ClaudeOAuthLogin } from "./oauth-login.js";
+import type { CodexDeviceLogin } from "./codex-device-login.js";
 
 interface ParsedFlags {
   booleans: Set<string>;
@@ -23,6 +26,8 @@ const HELP = [
   "  bb pool account add --provider claude --import [--label <text>] [--priority <n>]",
   "  bb pool account add --provider codex --import [--label <text>] [--priority <n>]",
   "  bb pool account add --provider claude --login",
+  "  bb pool account add --provider codex --login",
+  "  bb pool account login-poll --session <id>",
   "  printf '%s\\n' \"$CLAUDE_AUTH_CODE\" | bb pool account login-complete --session <id> --code-stdin",
   "  bb pool account add --provider claude --api-key-stdin [--label <text>] [--priority <n>]",
   "  bb pool account add --provider claude --api-key <key> [--label <text>] [--priority <n>]  Unsafe: exposes the key in process arguments.",
@@ -173,6 +178,7 @@ export function registerPoolCli(
   bb: Pick<BbPluginApi, "cli">,
   operations: PoolOperations,
   login: ClaudeOAuthLogin,
+  codexLogin: CodexDeviceLogin,
 ): void {
   bb.cli.register({
     name: "pool",
@@ -182,9 +188,14 @@ export function registerPoolCli(
       {
         name: "account-add",
         summary:
-          "Sign in to Claude, import Claude or Codex credentials, or add an Anthropic API key",
+          "Sign in to Claude or Codex, import credentials, or add an Anthropic API key",
         usage:
-          "bb pool account add --provider claude --login\nbb pool account add --provider <claude|codex> --import [--label <text>] [--priority <n>]\nbb pool account add --provider claude --api-key-stdin [--label <text>] [--priority <n>]\nUnsafe compatibility form: bb pool account add --provider claude --api-key <key> [--label <text>] [--priority <n>]",
+          "bb pool account add --provider <claude|codex> --login\nbb pool account add --provider <claude|codex> --import [--label <text>] [--priority <n>]\nbb pool account add --provider claude --api-key-stdin [--label <text>] [--priority <n>]\nUnsafe compatibility form: bb pool account add --provider claude --api-key <key> [--label <text>] [--priority <n>]",
+      },
+      {
+        name: "account-login-poll",
+        summary: "Wait for a Codex device-code login to complete",
+        usage: "bb pool account login-poll --session <id>",
       },
       {
         name: "account-login-complete",
@@ -228,7 +239,7 @@ export function registerPoolCli(
         usage: "bb pool bypass <thread-id> [--off]",
       },
     ],
-    async run(argv): Promise<PluginCliResult> {
+    async run(argv, ctx): Promise<PluginCliResult> {
       try {
         if (argv.includes("--help") || argv.includes("-h")) {
           return { exitCode: 0, stdout: `${HELP}\n` };
@@ -253,11 +264,30 @@ export function registerPoolCli(
               "Choose exactly one of --login, --import, --api-key-stdin, or --api-key <key>.",
             );
           if (loginRequested) {
-            if (flags.values.get("provider") !== "claude") {
-              throw new Error("--login requires --provider claude.");
+            const provider = flags.values.get("provider");
+            if (provider !== "claude" && provider !== "codex") {
+              throw new Error(
+                "--login requires --provider claude or --provider codex.",
+              );
             }
             if (flags.values.has("label") || flags.values.has("priority")) {
               throw new Error("--login does not accept --label or --priority.");
+            }
+            if (provider === "codex") {
+              const started = await codexLogin.start();
+              return {
+                exitCode: 0,
+                stdout: `${[
+                  "Open this URL to sign in to Codex:",
+                  started.verificationUri,
+                  "",
+                  `Enter this code: ${started.userCode}`,
+                  `Session ID: ${started.sessionId}`,
+                  "",
+                  "After authorizing, wait for the account to be added with:",
+                  `bb pool account login-poll --session ${started.sessionId}`,
+                ].join("\n")}\n`,
+              };
             }
             const started = login.start();
             return {
@@ -293,6 +323,27 @@ export function registerPoolCli(
             exitCode: 0,
             stdout: `Added ${account.label} (${account.id}).\n`,
           };
+        }
+        if (argv[0] === "account" && argv[1] === "login-poll") {
+          const flags = parseFlags(argv.slice(2), [], ["session"]);
+          const input = codexLoginPollInputSchema.parse({
+            sessionId: flags.values.get("session"),
+          });
+          while (true) {
+            const result = await codexLogin.poll(input);
+            if (result.status === "complete") {
+              return {
+                exitCode: 0,
+                stdout: `Added ${result.account.label} (${result.account.id}).\n`,
+              };
+            }
+            if (result.status === "error") {
+              throw new Error(result.message);
+            }
+            await wait(codexLogin.nextPollDelayMs(input.sessionId), undefined, {
+              signal: ctx.signal,
+            });
+          }
         }
         if (argv[0] === "account" && argv[1] === "login-complete") {
           const flags = parseFlags(

--- a/plugins/account-pool/src/cli.ts
+++ b/plugins/account-pool/src/cli.ts
@@ -183,7 +183,7 @@ export function registerPoolCli(
   bb.cli.register({
     name: "pool",
     summary:
-      "Manage Claude and Codex accounts and inspect the Account Pooler [Experimental] hub",
+      "Manage Claude and Codex accounts and inspect the Account Pooler hub",
     commands: [
       {
         name: "account-add",
@@ -231,12 +231,12 @@ export function registerPoolCli(
       {
         name: "token-rotate",
         summary:
-          "Rotate one machine's Account Pooler [Experimental] bearer token",
+          "Rotate one machine's Account Pooler bearer token",
         usage: "bb pool token rotate --machine <id-or-name>",
       },
       {
         name: "bypass",
-        summary: "Bypass Account Pooler [Experimental] routing for one thread",
+        summary: "Bypass Account Pooler routing for one thread",
         usage: "bb pool bypass <thread-id> [--off]",
       },
     ],
@@ -436,7 +436,7 @@ export function registerPoolCli(
           const token = await operations.rotateToken(machine);
           return {
             exitCode: 0,
-            stdout: `Rotated the Account Pooler [Experimental] token for ${token.hostName ?? token.hostId}.\n`,
+            stdout: `Rotated the Account Pooler token for ${token.hostName ?? token.hostId}.\n`,
           };
         }
         if (argv[0] === "bypass") {
@@ -453,7 +453,7 @@ export function registerPoolCli(
           );
           return {
             exitCode: 0,
-            stdout: `${result.bypassed ? "Enabled" : "Disabled"} Account Pooler [Experimental] bypass for ${result.threadId}.\n`,
+            stdout: `${result.bypassed ? "Enabled" : "Disabled"} Account Pooler bypass for ${result.threadId}.\n`,
           };
         }
         throw new Error(HELP);

--- a/plugins/account-pool/src/cli.ts
+++ b/plugins/account-pool/src/cli.ts
@@ -183,7 +183,7 @@ export function registerPoolCli(
   bb.cli.register({
     name: "pool",
     summary:
-      "Manage Claude and Codex accounts and inspect the Account Pool hub",
+      "Manage Claude and Codex accounts and inspect the Account Pooler [Experimental] hub",
     commands: [
       {
         name: "account-add",
@@ -230,12 +230,13 @@ export function registerPoolCli(
       },
       {
         name: "token-rotate",
-        summary: "Rotate one machine's Account Pool bearer token",
+        summary:
+          "Rotate one machine's Account Pooler [Experimental] bearer token",
         usage: "bb pool token rotate --machine <id-or-name>",
       },
       {
         name: "bypass",
-        summary: "Bypass Account Pool routing for one thread",
+        summary: "Bypass Account Pooler [Experimental] routing for one thread",
         usage: "bb pool bypass <thread-id> [--off]",
       },
     ],
@@ -427,7 +428,7 @@ export function registerPoolCli(
           const token = await operations.rotateToken(machine);
           return {
             exitCode: 0,
-            stdout: `Rotated the Account Pool token for ${token.hostName ?? token.hostId}.\n`,
+            stdout: `Rotated the Account Pooler [Experimental] token for ${token.hostName ?? token.hostId}.\n`,
           };
         }
         if (argv[0] === "bypass") {
@@ -444,7 +445,7 @@ export function registerPoolCli(
           );
           return {
             exitCode: 0,
-            stdout: `${result.bypassed ? "Enabled" : "Disabled"} Account Pool bypass for ${result.threadId}.\n`,
+            stdout: `${result.bypassed ? "Enabled" : "Disabled"} Account Pooler [Experimental] bypass for ${result.threadId}.\n`,
           };
         }
         throw new Error(HELP);

--- a/plugins/account-pool/src/codex-adapter.ts
+++ b/plugins/account-pool/src/codex-adapter.ts
@@ -11,7 +11,9 @@ import {
   mountedUpstreamUrl,
 } from "./provider-adapter.js";
 
-const OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
+export const CODEX_AUTH_BASE_URL = "https://auth.openai.com";
+export const CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
+export const DEFAULT_CODEX_REFRESH_URL = `${CODEX_AUTH_BASE_URL}/oauth/token`;
 const REFRESH_WINDOW_MS = 5 * 60 * 1_000;
 const ALLOWED_REQUEST_HEADERS = new Set([
   "accept",
@@ -173,7 +175,7 @@ export function createCodexAdapter(options: {
           accept: "application/json",
         },
         body: JSON.stringify({
-          client_id: OAUTH_CLIENT_ID,
+          client_id: CODEX_OAUTH_CLIENT_ID,
           grant_type: "refresh_token",
           refresh_token: secret.refreshToken,
         }),

--- a/plugins/account-pool/src/codex-device-login.test.ts
+++ b/plugins/account-pool/src/codex-device-login.test.ts
@@ -1,0 +1,299 @@
+import http, { type IncomingMessage, type ServerResponse } from "node:http";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AccountSummary } from "./contracts.js";
+import {
+  CodexDeviceLogin,
+  type CodexDeviceAccount,
+} from "./codex-device-login.js";
+
+type Handler = (
+  request: IncomingMessage,
+  response: ServerResponse,
+) => void | Promise<void>;
+
+const servers: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  while (servers.length > 0) await servers.pop()?.();
+});
+
+async function startAuth(handler: Handler): Promise<string> {
+  const server = http.createServer((request, response) => {
+    Promise.resolve(handler(request, response)).catch(() => {
+      response.statusCode = 500;
+      response.end();
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("Fake auth server did not bind.");
+  }
+  servers.push(
+    () =>
+      new Promise<void>((resolve, reject) => {
+        server.closeAllConnections();
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  );
+  return `http://127.0.0.1:${address.port}`;
+}
+
+async function body(request: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+function jwt(payload: object): string {
+  return [
+    Buffer.from(JSON.stringify({ alg: "none" })).toString("base64url"),
+    Buffer.from(JSON.stringify(payload)).toString("base64url"),
+    "signature",
+  ].join(".");
+}
+
+function summary(account: CodexDeviceAccount): AccountSummary {
+  return {
+    id: "11111111-1111-4111-8111-111111111111",
+    provider: "codex",
+    kind: "oauth",
+    label: account.label,
+    email: account.email,
+    accountUuid: null,
+    codexAccountId: account.accountId,
+    subscriptionType: null,
+    rateLimitTier: null,
+    enabled: true,
+    priority: 100,
+    createdAt: 1,
+    fiveHourUtilization: null,
+    fiveHourResetAt: null,
+    fiveHourStatus: null,
+    sevenDayUtilization: null,
+    sevenDayResetAt: null,
+    sevenDayStatus: null,
+    representativeClaim: null,
+    familyWeekly: {
+      fable: null,
+      sonnet: null,
+      opus: null,
+      haiku: null,
+      other: null,
+    },
+    observedAt: null,
+    heldUntil: null,
+    error: null,
+    inFlight: 0,
+    status: "ready",
+  };
+}
+
+describe("Codex device login", () => {
+  it("polls pending then exchanges and stores the ID-token account claims", async () => {
+    let now = Date.parse("2026-09-04T12:00:00Z");
+    let polls = 0;
+    const requests: Array<{ url: string; body: string }> = [];
+    const accessToken = jwt({ exp: 2_000_000_000 });
+    const idToken = jwt({
+      email: "codex@example.com",
+      "https://api.openai.com/auth": {
+        chatgpt_account_id: "chatgpt-account-1",
+      },
+    });
+    const authBaseUrl = await startAuth(async (request, response) => {
+      const requestBody = await body(request);
+      requests.push({ url: request.url ?? "", body: requestBody });
+      response.setHeader("content-type", "application/json");
+      if (request.url === "/api/accounts/deviceauth/usercode") {
+        response.end(
+          JSON.stringify({
+            device_auth_id: "device-secret",
+            user_code: "USER-SECRET",
+            interval: "5",
+            expires_at: "2026-09-04T12:10:00Z",
+          }),
+        );
+        return;
+      }
+      if (request.url === "/api/accounts/deviceauth/token") {
+        polls += 1;
+        if (polls === 1) {
+          response.statusCode = 403;
+          response.end(
+            JSON.stringify({
+              error: { code: "deviceauth_authorization_pending" },
+            }),
+          );
+          return;
+        }
+        response.end(
+          JSON.stringify({
+            authorization_code: "authorization-secret",
+            code_challenge: "challenge-secret",
+            code_verifier: "verifier-secret",
+          }),
+        );
+        return;
+      }
+      if (request.url === "/oauth/token") {
+        response.end(
+          JSON.stringify({
+            access_token: accessToken,
+            refresh_token: "refresh-secret",
+            id_token: idToken,
+          }),
+        );
+        return;
+      }
+      response.statusCode = 404;
+      response.end("{}");
+    });
+    const added: CodexDeviceAccount[] = [];
+    const login = new CodexDeviceLogin({
+      authBaseUrl,
+      now: () => now,
+      addAccount: async (account) => {
+        added.push(account);
+        return summary(account);
+      },
+    });
+
+    const started = await login.start();
+    expect(started).toMatchObject({
+      verificationUri: `${authBaseUrl}/codex/device`,
+      userCode: "USER-SECRET",
+      intervalMs: 5_000,
+      expiresAt: Date.parse("2026-09-04T12:10:00Z"),
+    });
+    expect(await login.poll({ sessionId: started.sessionId })).toEqual({
+      status: "pending",
+    });
+    expect(await login.poll({ sessionId: started.sessionId })).toEqual({
+      status: "pending",
+    });
+    expect(polls).toBe(1);
+    now += 5_000;
+    const completed = await login.poll({ sessionId: started.sessionId });
+
+    expect(completed).toMatchObject({
+      status: "complete",
+      account: {
+        codexAccountId: "chatgpt-account-1",
+        email: "codex@example.com",
+      },
+    });
+    expect(added).toEqual([
+      expect.objectContaining({
+        accountId: "chatgpt-account-1",
+        email: "codex@example.com",
+        accessToken,
+        refreshToken: "refresh-secret",
+        idToken,
+        expiresAt: 2_000_000_000_000,
+      }),
+    ]);
+    expect(JSON.parse(requests[0]?.body ?? "")).toEqual({
+      client_id: "app_EMoamEEZ73f0CkXaXp7hrann",
+    });
+    expect(JSON.parse(requests[1]?.body ?? "")).toEqual({
+      device_auth_id: "device-secret",
+      user_code: "USER-SECRET",
+    });
+    expect(new URLSearchParams(requests[3]?.body)).toEqual(
+      new URLSearchParams({
+        grant_type: "authorization_code",
+        code: "authorization-secret",
+        redirect_uri: `${authBaseUrl}/deviceauth/callback`,
+        client_id: "app_EMoamEEZ73f0CkXaXp7hrann",
+        code_verifier: "verifier-secret",
+      }),
+    );
+  });
+
+  it("expires the session after ten minutes without polling auth", async () => {
+    let now = Date.parse("2026-09-04T12:00:00Z");
+    let tokenPolls = 0;
+    const authBaseUrl = await startAuth((request, response) => {
+      response.setHeader("content-type", "application/json");
+      if (request.url === "/api/accounts/deviceauth/usercode") {
+        response.end(
+          JSON.stringify({
+            device_auth_id: "device-secret",
+            user_code: "USER-SECRET",
+            interval: "5",
+            expires_at: "2026-09-04T12:15:00Z",
+          }),
+        );
+        return;
+      }
+      tokenPolls += 1;
+      response.end("{}");
+    });
+    const login = new CodexDeviceLogin({
+      authBaseUrl,
+      now: () => now,
+      addAccount: async (account) => summary(account),
+    });
+    const started = await login.start();
+    now += 10 * 60 * 1_000;
+    expect(await login.poll({ sessionId: started.sessionId })).toEqual({
+      status: "error",
+      message: "Code expired, start again.",
+    });
+    expect(tokenPolls).toBe(0);
+  });
+
+  it("redacts exchange failures and never writes codes or tokens to logs", async () => {
+    const logged: string[] = [];
+    const methods: Array<"log" | "warn" | "error"> = ["log", "warn", "error"];
+    for (const method of methods) {
+      vi.spyOn(console, method).mockImplementation((...values) => {
+        logged.push(values.map(String).join(" "));
+      });
+    }
+    const authBaseUrl = await startAuth((request, response) => {
+      response.setHeader("content-type", "application/json");
+      if (request.url === "/api/accounts/deviceauth/usercode") {
+        response.end(
+          JSON.stringify({
+            device_auth_id: "device-secret",
+            user_code: "USER-SECRET",
+            interval: "5",
+            expires_in: 600,
+          }),
+        );
+        return;
+      }
+      if (request.url === "/api/accounts/deviceauth/token") {
+        response.end(
+          JSON.stringify({
+            authorization_code: "authorization-secret",
+            code_challenge: "challenge-secret",
+            code_verifier: "verifier-secret",
+          }),
+        );
+        return;
+      }
+      response.statusCode = 400;
+      response.end("refresh-secret rejected");
+    });
+    const login = new CodexDeviceLogin({
+      authBaseUrl,
+      addAccount: async (account) => summary(account),
+    });
+    const started = await login.start();
+    const result = await login.poll({ sessionId: started.sessionId });
+    expect(result).toEqual({
+      status: "error",
+      message: "Codex token exchange failed (HTTP 400). Start again.",
+    });
+    expect(JSON.stringify(result)).not.toMatch(
+      /USER-SECRET|device-secret|authorization-secret|verifier-secret|refresh-secret/u,
+    );
+    expect(logged).toEqual([]);
+  });
+});

--- a/plugins/account-pool/src/codex-device-login.test.ts
+++ b/plugins/account-pool/src/codex-device-login.test.ts
@@ -302,6 +302,22 @@ describe("Codex device login", () => {
     expect(tokenPolls()).toBe(2);
   });
 
+  it("extends the session interval for slow_down on HTTP 200", async () => {
+    const { clock, login, tokenPolls } = createPollingHarness({
+      tokenResponses: [
+        Response.json({ error: { code: "deviceauth_slow_down" } }),
+      ],
+    });
+    const started = await login.start();
+    clock.now += 5_000;
+
+    expect(await login.poll({ sessionId: started.sessionId })).toEqual({
+      status: "pending",
+    });
+    expect(login.nextPollDelayMs(started.sessionId)).toBe(10_000);
+    expect(tokenPolls()).toBe(1);
+  });
+
   it("keeps a session pending after a pre-expiry HTTP 500", async () => {
     const { clock, login, tokenPolls } = createPollingHarness({
       tokenResponses: [new Response(null, { status: 500 })],

--- a/plugins/account-pool/src/codex-device-login.test.ts
+++ b/plugins/account-pool/src/codex-device-login.test.ts
@@ -14,6 +14,7 @@ type Handler = (
 const servers: Array<() => Promise<void>> = [];
 
 afterEach(async () => {
+  vi.useRealTimers();
   vi.restoreAllMocks();
   while (servers.length > 0) await servers.pop()?.();
 });
@@ -90,6 +91,37 @@ function summary(account: CodexDeviceAccount): AccountSummary {
     inFlight: 0,
     status: "ready",
   };
+}
+
+function createPollingHarness(args?: {
+  tokenResponses?: Response[];
+  expiresIn?: number;
+}) {
+  const clock = { now: Date.parse("2026-09-04T12:00:00Z") };
+  let tokenPolls = 0;
+  const tokenResponses = args?.tokenResponses ?? [];
+  const login = new CodexDeviceLogin({
+    now: () => clock.now,
+    fetch: async (input) => {
+      const url = String(input);
+      if (url.endsWith("/api/accounts/deviceauth/usercode")) {
+        return Response.json({
+          device_auth_id: "device-secret",
+          user_code: "USER-SECRET",
+          interval: 5,
+          expires_in: args?.expiresIn ?? 600,
+        });
+      }
+      if (url.endsWith("/api/accounts/deviceauth/token")) {
+        const response = tokenResponses[tokenPolls];
+        tokenPolls += 1;
+        return response ?? new Response(null, { status: 404 });
+      }
+      throw new Error(`Unexpected request to ${url}`);
+    },
+    addAccount: async (account) => summary(account),
+  });
+  return { clock, login, tokenPolls: () => tokenPolls };
 }
 
 describe("Codex device login", () => {
@@ -172,6 +204,8 @@ describe("Codex device login", () => {
     expect(await login.poll({ sessionId: started.sessionId })).toEqual({
       status: "pending",
     });
+    expect(polls).toBe(0);
+    now += 5_000;
     expect(await login.poll({ sessionId: started.sessionId })).toEqual({
       status: "pending",
     });
@@ -214,6 +248,115 @@ describe("Codex device login", () => {
     );
   });
 
+  it("returns pending for an immediate poll without fetching", async () => {
+    const { login, tokenPolls } = createPollingHarness();
+    const started = await login.start();
+
+    expect(await login.poll({ sessionId: started.sessionId })).toEqual({
+      status: "pending",
+    });
+    expect(tokenPolls()).toBe(0);
+    expect(login.nextPollDelayMs(started.sessionId)).toBe(5_000);
+  });
+
+  it("keeps a session pending after HTTP 404", async () => {
+    const { clock, login, tokenPolls } = createPollingHarness();
+    const started = await login.start();
+    clock.now += 5_000;
+
+    expect(await login.poll({ sessionId: started.sessionId })).toEqual({
+      status: "pending",
+    });
+    clock.now += 5_000;
+    expect(await login.poll({ sessionId: started.sessionId })).toEqual({
+      status: "pending",
+    });
+    expect(tokenPolls()).toBe(2);
+  });
+
+  it("extends the session interval after slow_down", async () => {
+    const { clock, login, tokenPolls } = createPollingHarness({
+      tokenResponses: [
+        Response.json(
+          { error: { code: "deviceauth_slow_down" } },
+          { status: 429 },
+        ),
+      ],
+    });
+    const started = await login.start();
+    clock.now += 5_000;
+
+    expect(await login.poll({ sessionId: started.sessionId })).toEqual({
+      status: "pending",
+    });
+    expect(login.nextPollDelayMs(started.sessionId)).toBe(10_000);
+    clock.now += 5_000;
+    expect(await login.poll({ sessionId: started.sessionId })).toEqual({
+      status: "pending",
+    });
+    expect(tokenPolls()).toBe(1);
+    clock.now += 5_000;
+    expect(await login.poll({ sessionId: started.sessionId })).toEqual({
+      status: "pending",
+    });
+    expect(tokenPolls()).toBe(2);
+  });
+
+  it("keeps a session pending after a pre-expiry HTTP 500", async () => {
+    const { clock, login, tokenPolls } = createPollingHarness({
+      tokenResponses: [new Response(null, { status: 500 })],
+    });
+    const started = await login.start();
+    clock.now += 5_000;
+
+    expect(await login.poll({ sessionId: started.sessionId })).toEqual({
+      status: "pending",
+    });
+    clock.now += 5_000;
+    expect(await login.poll({ sessionId: started.sessionId })).toEqual({
+      status: "pending",
+    });
+    expect(tokenPolls()).toBe(2);
+  });
+
+  it("removes a cancelled session", async () => {
+    const { login } = createPollingHarness();
+    const started = await login.start();
+
+    expect(login.cancel({ sessionId: started.sessionId })).toBe(true);
+    expect(await login.poll({ sessionId: started.sessionId })).toEqual({
+      status: "error",
+      message: "Login session was not found. Start again.",
+    });
+  });
+
+  it("removes an expired session with its timer", async () => {
+    vi.useFakeTimers();
+    const { login } = createPollingHarness({ expiresIn: 1 });
+    const started = await login.start();
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(await login.poll({ sessionId: started.sessionId })).toEqual({
+      status: "error",
+      message: "Login session was not found. Start again.",
+    });
+  });
+
+  it("clears session timers and state on dispose", async () => {
+    vi.useFakeTimers();
+    const { login } = createPollingHarness();
+    const started = await login.start();
+    expect(vi.getTimerCount()).toBe(1);
+
+    login.dispose();
+
+    expect(vi.getTimerCount()).toBe(0);
+    expect(await login.poll({ sessionId: started.sessionId })).toEqual({
+      status: "error",
+      message: "Login session was not found. Start again.",
+    });
+  });
+
   it("expires the session after ten minutes without polling auth", async () => {
     let now = Date.parse("2026-09-04T12:00:00Z");
     let tokenPolls = 0;
@@ -248,6 +391,7 @@ describe("Codex device login", () => {
   });
 
   it("redacts exchange failures and never writes codes or tokens to logs", async () => {
+    let now = Date.parse("2026-09-04T12:00:00Z");
     const logged: string[] = [];
     const methods: Array<"log" | "warn" | "error"> = ["log", "warn", "error"];
     for (const method of methods) {
@@ -283,9 +427,11 @@ describe("Codex device login", () => {
     });
     const login = new CodexDeviceLogin({
       authBaseUrl,
+      now: () => now,
       addAccount: async (account) => summary(account),
     });
     const started = await login.start();
+    now += 5_000;
     const result = await login.poll({ sessionId: started.sessionId });
     expect(result).toEqual({
       status: "error",

--- a/plugins/account-pool/src/codex-device-login.ts
+++ b/plugins/account-pool/src/codex-device-login.ts
@@ -1,0 +1,364 @@
+import { randomUUID } from "node:crypto";
+import { z } from "zod";
+import { CODEX_AUTH_BASE_URL, CODEX_OAUTH_CLIENT_ID } from "./codex-adapter.js";
+import { codexAccessTokenExpiresAt } from "./credentials.js";
+import type { AccountSummary } from "./contracts.js";
+
+const LOGIN_SESSION_TTL_MS = 10 * 60 * 1_000;
+const DEVICE_CALLBACK_PATH = "/deviceauth/callback";
+const CHATGPT_AUTH_CLAIM = "https://api.openai.com/auth";
+const CHATGPT_PROFILE_CLAIM = "https://api.openai.com/profile";
+
+const intervalSchema = z.union([
+  z.number().int().positive(),
+  z
+    .string()
+    .trim()
+    .regex(/^\d+$/u)
+    .transform(Number)
+    .pipe(z.number().positive()),
+]);
+
+const userCodeResponseSchema = z
+  .object({
+    device_auth_id: z.string().min(1),
+    user_code: z.string().min(1),
+    interval: intervalSchema,
+    expires_at: z.string().datetime({ offset: true }).optional(),
+    expires_in: z.number().positive().optional(),
+  })
+  .passthrough();
+
+const deviceTokenResponseSchema = z
+  .object({
+    authorization_code: z.string().min(1),
+    code_challenge: z.string().min(1),
+    code_verifier: z.string().min(1),
+  })
+  .passthrough();
+
+const tokenResponseSchema = z
+  .object({
+    access_token: z.string().min(1),
+    refresh_token: z.string().min(1),
+    id_token: z.string().min(1),
+  })
+  .passthrough();
+
+const deviceErrorResponseSchema = z
+  .object({
+    error: z
+      .object({ code: z.string().nullable().optional() })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough();
+
+const idTokenPayloadSchema = z
+  .object({
+    email: z.string().email().optional(),
+    chatgpt_account_id: z.string().min(1).optional(),
+    [CHATGPT_AUTH_CLAIM]: z
+      .object({ chatgpt_account_id: z.string().min(1).optional() })
+      .passthrough()
+      .optional(),
+    [CHATGPT_PROFILE_CLAIM]: z
+      .object({ email: z.string().email().optional() })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough();
+
+interface DeviceLoginSession {
+  sessionId: string;
+  deviceAuthId: string;
+  userCode: string;
+  intervalMs: number;
+  expiresAt: number;
+  lastPolledAt: number | null;
+  polling: boolean;
+}
+
+export interface CodexDeviceAccount {
+  label: string;
+  email: string | null;
+  accountId: string;
+  accessToken: string;
+  refreshToken: string;
+  idToken: string;
+  expiresAt: number | null;
+}
+
+export interface CodexDeviceLoginOptions {
+  fetch?: typeof fetch;
+  now?: () => number;
+  authBaseUrl?: string;
+  addAccount: (authenticated: CodexDeviceAccount) => Promise<AccountSummary>;
+}
+
+export interface CodexDeviceLoginStart {
+  sessionId: string;
+  verificationUri: string;
+  userCode: string;
+  expiresAt: number;
+  intervalMs: number;
+}
+
+export type CodexDeviceLoginPoll =
+  | { status: "pending" }
+  | { status: "complete"; account: AccountSummary }
+  | { status: "error"; message: string };
+
+function expiresAt(
+  payload: z.infer<typeof userCodeResponseSchema>,
+  now: number,
+): number {
+  const serviceExpiry =
+    payload.expires_at === undefined
+      ? payload.expires_in === undefined
+        ? now + LOGIN_SESSION_TTL_MS
+        : now + payload.expires_in * 1_000
+      : Date.parse(payload.expires_at);
+  if (!Number.isFinite(serviceExpiry)) {
+    throw new Error("Codex device login returned an invalid expiry.");
+  }
+  return Math.min(now + LOGIN_SESSION_TTL_MS, serviceExpiry);
+}
+
+function idTokenClaims(idToken: string): {
+  accountId: string;
+  email: string | null;
+} {
+  const payloadSegment = idToken.split(".")[1];
+  if (payloadSegment === undefined) {
+    throw new Error("Codex token exchange returned an invalid ID token.");
+  }
+  let payload: z.infer<typeof idTokenPayloadSchema>;
+  try {
+    payload = idTokenPayloadSchema.parse(
+      JSON.parse(Buffer.from(payloadSegment, "base64url").toString("utf8")),
+    );
+  } catch {
+    throw new Error("Codex token exchange returned an invalid ID token.");
+  }
+  const accountId =
+    payload[CHATGPT_AUTH_CLAIM]?.chatgpt_account_id ??
+    payload.chatgpt_account_id;
+  if (accountId === undefined) {
+    throw new Error("Codex ID token does not include a ChatGPT account id.");
+  }
+  return {
+    accountId,
+    email: payload.email ?? payload[CHATGPT_PROFILE_CLAIM]?.email ?? null,
+  };
+}
+
+export class CodexDeviceLogin {
+  private readonly sessions = new Map<string, DeviceLoginSession>();
+  private readonly fetch: typeof fetch;
+  private readonly now: () => number;
+  private readonly authBaseUrl: string;
+
+  constructor(private readonly options: CodexDeviceLoginOptions) {
+    this.fetch = options.fetch ?? fetch;
+    this.now = options.now ?? Date.now;
+    this.authBaseUrl = (options.authBaseUrl ?? CODEX_AUTH_BASE_URL).replace(
+      /\/$/u,
+      "",
+    );
+  }
+
+  async start(): Promise<CodexDeviceLoginStart> {
+    const pruneBefore = this.now();
+    for (const [sessionId, session] of this.sessions) {
+      if (pruneBefore >= session.expiresAt) this.sessions.delete(sessionId);
+    }
+    const response = await this.fetch(
+      `${this.authBaseUrl}/api/accounts/deviceauth/usercode`,
+      {
+        method: "POST",
+        headers: {
+          accept: "application/json",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ client_id: CODEX_OAUTH_CLIENT_ID }),
+      },
+    );
+    if (!response.ok) {
+      await response.body?.cancel();
+      throw new Error(
+        `Codex device login could not start (HTTP ${response.status}). Try again.`,
+      );
+    }
+    const payload = await response.json().catch(() => null);
+    const parsed = userCodeResponseSchema.safeParse(payload);
+    if (!parsed.success) {
+      throw new Error("Codex device login returned an invalid response.");
+    }
+    const now = this.now();
+    const session: DeviceLoginSession = {
+      sessionId: randomUUID(),
+      deviceAuthId: parsed.data.device_auth_id,
+      userCode: parsed.data.user_code,
+      intervalMs: parsed.data.interval * 1_000,
+      expiresAt: expiresAt(parsed.data, now),
+      lastPolledAt: null,
+      polling: false,
+    };
+    this.sessions.set(session.sessionId, session);
+    return {
+      sessionId: session.sessionId,
+      verificationUri: `${this.authBaseUrl}/codex/device`,
+      userCode: session.userCode,
+      expiresAt: session.expiresAt,
+      intervalMs: session.intervalMs,
+    };
+  }
+
+  async poll(input: { sessionId: string }): Promise<CodexDeviceLoginPoll> {
+    const session = this.sessions.get(input.sessionId);
+    if (session === undefined) {
+      return {
+        status: "error",
+        message: "Login session was not found. Start again.",
+      };
+    }
+    const now = this.now();
+    if (now >= session.expiresAt) {
+      this.sessions.delete(session.sessionId);
+      return { status: "error", message: "Code expired, start again." };
+    }
+    if (
+      session.polling ||
+      (session.lastPolledAt !== null &&
+        now - session.lastPolledAt < session.intervalMs)
+    ) {
+      return { status: "pending" };
+    }
+    session.polling = true;
+    session.lastPolledAt = now;
+    try {
+      const response = await this.fetch(
+        `${this.authBaseUrl}/api/accounts/deviceauth/token`,
+        {
+          method: "POST",
+          headers: {
+            accept: "application/json",
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            device_auth_id: session.deviceAuthId,
+            user_code: session.userCode,
+          }),
+        },
+      );
+      if (!response.ok) {
+        const payload = await response.json().catch(() => null);
+        const parsedError = deviceErrorResponseSchema.safeParse(payload);
+        const errorCode = parsedError.success
+          ? parsedError.data.error?.code
+          : null;
+        if (
+          response.status === 403 &&
+          errorCode === "deviceauth_authorization_pending"
+        ) {
+          return { status: "pending" };
+        }
+        if (errorCode?.includes("expired") === true) {
+          this.sessions.delete(session.sessionId);
+          return { status: "error", message: "Code expired, start again." };
+        }
+        this.sessions.delete(session.sessionId);
+        return {
+          status: "error",
+          message: `Codex authorization failed (HTTP ${response.status}). Start again.`,
+        };
+      }
+      const payload = await response.json().catch(() => null);
+      const parsed = deviceTokenResponseSchema.safeParse(payload);
+      if (!parsed.success) {
+        this.sessions.delete(session.sessionId);
+        return {
+          status: "error",
+          message:
+            "Codex authorization returned an invalid response. Start again.",
+        };
+      }
+      this.sessions.delete(session.sessionId);
+      return await this.exchange(parsed.data);
+    } catch {
+      this.sessions.delete(session.sessionId);
+      return {
+        status: "error",
+        message: "Codex authorization could not be completed. Start again.",
+      };
+    } finally {
+      session.polling = false;
+    }
+  }
+
+  nextPollDelayMs(sessionId: string): number {
+    const session = this.sessions.get(sessionId);
+    if (session === undefined || session.lastPolledAt === null) return 0;
+    return Math.max(
+      0,
+      session.intervalMs - (this.now() - session.lastPolledAt),
+    );
+  }
+
+  private async exchange(
+    authorized: z.infer<typeof deviceTokenResponseSchema>,
+  ): Promise<CodexDeviceLoginPoll> {
+    const response = await this.fetch(`${this.authBaseUrl}/oauth/token`, {
+      method: "POST",
+      headers: {
+        accept: "application/json",
+        "content-type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        code: authorized.authorization_code,
+        redirect_uri: `${this.authBaseUrl}${DEVICE_CALLBACK_PATH}`,
+        client_id: CODEX_OAUTH_CLIENT_ID,
+        code_verifier: authorized.code_verifier,
+      }).toString(),
+    });
+    if (!response.ok) {
+      await response.body?.cancel();
+      return {
+        status: "error",
+        message: `Codex token exchange failed (HTTP ${response.status}). Start again.`,
+      };
+    }
+    const payload = await response.json().catch(() => null);
+    const parsed = tokenResponseSchema.safeParse(payload);
+    if (!parsed.success) {
+      return {
+        status: "error",
+        message:
+          "Codex token exchange returned an invalid response. Start again.",
+      };
+    }
+    try {
+      const claims = idTokenClaims(parsed.data.id_token);
+      const account = await this.options.addAccount({
+        label: claims.email ?? "Codex account",
+        email: claims.email,
+        accountId: claims.accountId,
+        accessToken: parsed.data.access_token,
+        refreshToken: parsed.data.refresh_token,
+        idToken: parsed.data.id_token,
+        expiresAt: codexAccessTokenExpiresAt(parsed.data.access_token),
+      });
+      return { status: "complete", account };
+    } catch (error) {
+      return {
+        status: "error",
+        message:
+          error instanceof Error && error.message.startsWith("Codex ")
+            ? `${error.message} Start again.`
+            : "Codex account could not be saved. Start again.",
+      };
+    }
+  }
+}

--- a/plugins/account-pool/src/codex-device-login.ts
+++ b/plugins/account-pool/src/codex-device-login.ts
@@ -264,32 +264,32 @@ export class CodexDeviceLogin {
         this.deleteSession(session.sessionId);
         return { status: "error", message: "Code expired, start again." };
       }
+      const payload = await response.json().catch(() => null);
+      const parsedError = deviceErrorResponseSchema.safeParse(payload);
+      const errorCode = parsedError.success
+        ? parsedError.data.error?.code
+        : null;
+      const normalizedCode = errorCode?.toLowerCase() ?? "";
+      if (normalizedCode.includes("slow_down")) {
+        session.intervalMs += 5_000;
+        session.nextPollAt = this.now() + session.intervalMs;
+        return { status: "pending" };
+      }
+      if (normalizedCode.includes("expired")) {
+        this.deleteSession(session.sessionId);
+        return { status: "error", message: "Code expired, start again." };
+      }
+      if (
+        normalizedCode.includes("denied") ||
+        normalizedCode.includes("declined")
+      ) {
+        this.deleteSession(session.sessionId);
+        return {
+          status: "error",
+          message: "Codex authorization was declined. Start again.",
+        };
+      }
       if (!response.ok) {
-        const payload = await response.json().catch(() => null);
-        const parsedError = deviceErrorResponseSchema.safeParse(payload);
-        const errorCode = parsedError.success
-          ? parsedError.data.error?.code
-          : null;
-        const normalizedCode = errorCode?.toLowerCase() ?? "";
-        if (normalizedCode.includes("slow_down")) {
-          session.intervalMs += 5_000;
-          session.nextPollAt = this.now() + session.intervalMs;
-          return { status: "pending" };
-        }
-        if (normalizedCode.includes("expired")) {
-          this.deleteSession(session.sessionId);
-          return { status: "error", message: "Code expired, start again." };
-        }
-        if (
-          normalizedCode.includes("denied") ||
-          normalizedCode.includes("declined")
-        ) {
-          this.deleteSession(session.sessionId);
-          return {
-            status: "error",
-            message: "Codex authorization was declined. Start again.",
-          };
-        }
         if (
           response.status === 403 ||
           response.status === 404 ||
@@ -302,7 +302,6 @@ export class CodexDeviceLogin {
           message: `Codex authorization failed (HTTP ${response.status}). Start again.`,
         };
       }
-      const payload = await response.json().catch(() => null);
       const parsed = deviceTokenResponseSchema.safeParse(payload);
       if (!parsed.success) {
         return {

--- a/plugins/account-pool/src/codex-device-login.ts
+++ b/plugins/account-pool/src/codex-device-login.ts
@@ -75,7 +75,7 @@ interface DeviceLoginSession {
   userCode: string;
   intervalMs: number;
   expiresAt: number;
-  lastPolledAt: number | null;
+  nextPollAt: number;
   polling: boolean;
 }
 
@@ -155,6 +155,10 @@ function idTokenClaims(idToken: string): {
 
 export class CodexDeviceLogin {
   private readonly sessions = new Map<string, DeviceLoginSession>();
+  private readonly expiryTimers = new Map<
+    string,
+    ReturnType<typeof setTimeout>
+  >();
   private readonly fetch: typeof fetch;
   private readonly now: () => number;
   private readonly authBaseUrl: string;
@@ -171,7 +175,7 @@ export class CodexDeviceLogin {
   async start(): Promise<CodexDeviceLoginStart> {
     const pruneBefore = this.now();
     for (const [sessionId, session] of this.sessions) {
-      if (pruneBefore >= session.expiresAt) this.sessions.delete(sessionId);
+      if (pruneBefore >= session.expiresAt) this.deleteSession(sessionId);
     }
     const response = await this.fetch(
       `${this.authBaseUrl}/api/accounts/deviceauth/usercode`,
@@ -196,16 +200,18 @@ export class CodexDeviceLogin {
       throw new Error("Codex device login returned an invalid response.");
     }
     const now = this.now();
+    const intervalMs = parsed.data.interval * 1_000;
     const session: DeviceLoginSession = {
       sessionId: randomUUID(),
       deviceAuthId: parsed.data.device_auth_id,
       userCode: parsed.data.user_code,
-      intervalMs: parsed.data.interval * 1_000,
+      intervalMs,
       expiresAt: expiresAt(parsed.data, now),
-      lastPolledAt: null,
+      nextPollAt: now + intervalMs,
       polling: false,
     };
     this.sessions.set(session.sessionId, session);
+    this.scheduleExpiry(session);
     return {
       sessionId: session.sessionId,
       verificationUri: `${this.authBaseUrl}/codex/device`,
@@ -225,18 +231,14 @@ export class CodexDeviceLogin {
     }
     const now = this.now();
     if (now >= session.expiresAt) {
-      this.sessions.delete(session.sessionId);
+      this.deleteSession(session.sessionId);
       return { status: "error", message: "Code expired, start again." };
     }
-    if (
-      session.polling ||
-      (session.lastPolledAt !== null &&
-        now - session.lastPolledAt < session.intervalMs)
-    ) {
+    if (session.polling || now < session.nextPollAt) {
       return { status: "pending" };
     }
     session.polling = true;
-    session.lastPolledAt = now;
+    session.nextPollAt = now + session.intervalMs;
     try {
       const response = await this.fetch(
         `${this.authBaseUrl}/api/accounts/deviceauth/token`,
@@ -252,23 +254,49 @@ export class CodexDeviceLogin {
           }),
         },
       );
+      if (this.sessions.get(session.sessionId) !== session) {
+        return {
+          status: "error",
+          message: "Login session was not found. Start again.",
+        };
+      }
+      if (this.now() >= session.expiresAt) {
+        this.deleteSession(session.sessionId);
+        return { status: "error", message: "Code expired, start again." };
+      }
       if (!response.ok) {
         const payload = await response.json().catch(() => null);
         const parsedError = deviceErrorResponseSchema.safeParse(payload);
         const errorCode = parsedError.success
           ? parsedError.data.error?.code
           : null;
+        const normalizedCode = errorCode?.toLowerCase() ?? "";
+        if (normalizedCode.includes("slow_down")) {
+          session.intervalMs += 5_000;
+          session.nextPollAt = this.now() + session.intervalMs;
+          return { status: "pending" };
+        }
+        if (normalizedCode.includes("expired")) {
+          this.deleteSession(session.sessionId);
+          return { status: "error", message: "Code expired, start again." };
+        }
         if (
-          response.status === 403 &&
-          errorCode === "deviceauth_authorization_pending"
+          normalizedCode.includes("denied") ||
+          normalizedCode.includes("declined")
+        ) {
+          this.deleteSession(session.sessionId);
+          return {
+            status: "error",
+            message: "Codex authorization was declined. Start again.",
+          };
+        }
+        if (
+          response.status === 403 ||
+          response.status === 404 ||
+          response.status >= 500
         ) {
           return { status: "pending" };
         }
-        if (errorCode?.includes("expired") === true) {
-          this.sessions.delete(session.sessionId);
-          return { status: "error", message: "Code expired, start again." };
-        }
-        this.sessions.delete(session.sessionId);
         return {
           status: "error",
           message: `Codex authorization failed (HTTP ${response.status}). Start again.`,
@@ -277,21 +305,18 @@ export class CodexDeviceLogin {
       const payload = await response.json().catch(() => null);
       const parsed = deviceTokenResponseSchema.safeParse(payload);
       if (!parsed.success) {
-        this.sessions.delete(session.sessionId);
         return {
           status: "error",
           message:
             "Codex authorization returned an invalid response. Start again.",
         };
       }
-      this.sessions.delete(session.sessionId);
+      this.deleteSession(session.sessionId);
       return await this.exchange(parsed.data);
     } catch {
-      this.sessions.delete(session.sessionId);
-      return {
-        status: "error",
-        message: "Codex authorization could not be completed. Start again.",
-      };
+      if (this.now() < session.expiresAt) return { status: "pending" };
+      this.deleteSession(session.sessionId);
+      return { status: "error", message: "Code expired, start again." };
     } finally {
       session.polling = false;
     }
@@ -299,11 +324,34 @@ export class CodexDeviceLogin {
 
   nextPollDelayMs(sessionId: string): number {
     const session = this.sessions.get(sessionId);
-    if (session === undefined || session.lastPolledAt === null) return 0;
-    return Math.max(
-      0,
-      session.intervalMs - (this.now() - session.lastPolledAt),
+    if (session === undefined) return 0;
+    return Math.max(0, session.nextPollAt - this.now());
+  }
+
+  cancel(input: { sessionId: string }): boolean {
+    return this.deleteSession(input.sessionId);
+  }
+
+  dispose(): void {
+    for (const timer of this.expiryTimers.values()) clearTimeout(timer);
+    this.expiryTimers.clear();
+    this.sessions.clear();
+  }
+
+  private scheduleExpiry(session: DeviceLoginSession): void {
+    const timer = setTimeout(
+      () => this.deleteSession(session.sessionId),
+      Math.max(0, session.expiresAt - this.now()),
     );
+    timer.unref();
+    this.expiryTimers.set(session.sessionId, timer);
+  }
+
+  private deleteSession(sessionId: string): boolean {
+    const timer = this.expiryTimers.get(sessionId);
+    if (timer !== undefined) clearTimeout(timer);
+    this.expiryTimers.delete(sessionId);
+    return this.sessions.delete(sessionId);
   }
 
   private async exchange(

--- a/plugins/account-pool/src/codex-websocket.ts
+++ b/plugins/account-pool/src/codex-websocket.ts
@@ -191,11 +191,11 @@ export function createCodexWebSocketHandlers(
     async onOpen(socket) {
       authenticated = await hub.authenticate(context.request);
       if (!authenticated) {
-        socket.close(1008, "invalid Account Pool token");
+        socket.close(1008, "invalid Account Pooler [Experimental] token");
         return;
       }
       log.debug(
-        "Account Pool Codex transport: WebSocket downstream, HTTPS SSE upstream.",
+        "Account Pooler [Experimental] Codex transport: WebSocket downstream, HTTPS SSE upstream.",
       );
     },
     async onMessage(socket, data) {

--- a/plugins/account-pool/src/codex-websocket.ts
+++ b/plugins/account-pool/src/codex-websocket.ts
@@ -191,11 +191,11 @@ export function createCodexWebSocketHandlers(
     async onOpen(socket) {
       authenticated = await hub.authenticate(context.request);
       if (!authenticated) {
-        socket.close(1008, "invalid Account Pooler [Experimental] token");
+        socket.close(1008, "invalid Account Pooler token");
         return;
       }
       log.debug(
-        "Account Pooler [Experimental] Codex transport: WebSocket downstream, HTTPS SSE upstream.",
+        "Account Pooler Codex transport: WebSocket downstream, HTTPS SSE upstream.",
       );
     },
     async onMessage(socket, data) {

--- a/plugins/account-pool/src/contracts.ts
+++ b/plugins/account-pool/src/contracts.ts
@@ -184,6 +184,28 @@ export const loginCompleteInputSchema = z
   })
   .strict();
 
+export const codexLoginStartSchema = z
+  .object({
+    sessionId: z.string().uuid(),
+    verificationUri: z.string().url(),
+    userCode: z.string().min(1),
+    expiresAt: z.number().int().positive(),
+    intervalMs: z.number().int().positive(),
+  })
+  .strict();
+
+export const codexLoginPollInputSchema = z
+  .object({ sessionId: z.string().uuid() })
+  .strict();
+
+export const codexLoginPollSchema = z.discriminatedUnion("status", [
+  z.object({ status: z.literal("pending") }).strict(),
+  z
+    .object({ status: z.literal("complete"), account: accountSummarySchema })
+    .strict(),
+  z.object({ status: z.literal("error"), message: z.string().min(1) }).strict(),
+]);
+
 export const accountIdInputSchema = z
   .object({ id: z.string().uuid() })
   .strict();

--- a/plugins/account-pool/src/contracts.ts
+++ b/plugins/account-pool/src/contracts.ts
@@ -198,6 +198,10 @@ export const codexLoginPollInputSchema = z
   .object({ sessionId: z.string().uuid() })
   .strict();
 
+export const codexLoginCancelSchema = z
+  .object({ cancelled: z.boolean() })
+  .strict();
+
 export const codexLoginPollSchema = z.discriminatedUnion("status", [
   z.object({ status: z.literal("pending") }).strict(),
   z

--- a/plugins/account-pool/src/hub.ts
+++ b/plugins/account-pool/src/hub.ts
@@ -108,7 +108,10 @@ export class AccountPoolHub {
   async handle(request: Request, provider: PoolProvider): Promise<Response> {
     const adapter = this.adapter(provider);
     if (!(await this.authenticate(request))) {
-      return adapter.errorResponse(401, "Invalid Account Pool bearer token.");
+      return adapter.errorResponse(
+        401,
+        "Invalid Account Pooler [Experimental] bearer token.",
+      );
     }
     return this.handleAuthenticated(request, provider);
   }
@@ -121,7 +124,7 @@ export class AccountPoolHub {
     if (!this.accepting)
       return adapter.errorResponse(
         503,
-        "Account Pool is not accepting requests.",
+        "Account Pooler [Experimental] is not accepting requests.",
       );
     return this.forward(
       request,
@@ -193,7 +196,7 @@ export class AccountPoolHub {
     for (const controller of this.activeControllers) {
       controller.abort(
         new Error(
-          "Account Pool stopped before the upstream response completed.",
+          "Account Pooler [Experimental] stopped before the upstream response completed.",
         ),
       );
     }
@@ -265,7 +268,7 @@ export class AccountPoolHub {
       } catch {
         return adapter.errorResponse(
           502,
-          `Account Pool could not reach ${adapter.upstreamName}.`,
+          `Account Pooler [Experimental] could not reach ${adapter.upstreamName}.`,
         );
       }
       const observed = adapter.quotaFromHeaders(
@@ -334,7 +337,7 @@ export class AccountPoolHub {
           } catch {
             return adapter.errorResponse(
               502,
-              `Account Pool could not reach ${adapter.upstreamName}.`,
+              `Account Pooler [Experimental] could not reach ${adapter.upstreamName}.`,
             );
           }
         }
@@ -536,7 +539,10 @@ export class AccountPoolHub {
     adapter: ProviderAdapter,
   ): Response {
     if (!accounts.some((account) => account.enabled)) {
-      return adapter.errorResponse(503, "Account Pool has no enabled account");
+      return adapter.errorResponse(
+        503,
+        "Account Pooler [Experimental] has no enabled account",
+      );
     }
     const now = this.options.now();
     const next = accounts
@@ -557,7 +563,7 @@ export class AccountPoolHub {
     );
     return adapter.errorResponse(
       429,
-      "No Account Pool account is currently eligible.",
+      "No Account Pooler [Experimental] account is currently eligible.",
       { "retry-after": String(retryAfter) },
     );
   }
@@ -570,7 +576,9 @@ export class AccountPoolHub {
   private adapter(provider: PoolProvider): ProviderAdapter {
     const adapter = this.options.adapters.get(provider);
     if (adapter === undefined)
-      throw new Error(`Missing ${provider} Account Pool adapter.`);
+      throw new Error(
+        `Missing ${provider} Account Pooler [Experimental] adapter.`,
+      );
     return adapter;
   }
 

--- a/plugins/account-pool/src/hub.ts
+++ b/plugins/account-pool/src/hub.ts
@@ -110,7 +110,7 @@ export class AccountPoolHub {
     if (!(await this.authenticate(request))) {
       return adapter.errorResponse(
         401,
-        "Invalid Account Pooler [Experimental] bearer token.",
+        "Invalid Account Pooler bearer token.",
       );
     }
     return this.handleAuthenticated(request, provider);
@@ -124,7 +124,7 @@ export class AccountPoolHub {
     if (!this.accepting)
       return adapter.errorResponse(
         503,
-        "Account Pooler [Experimental] is not accepting requests.",
+        "Account Pooler is not accepting requests.",
       );
     return this.forward(
       request,
@@ -196,7 +196,7 @@ export class AccountPoolHub {
     for (const controller of this.activeControllers) {
       controller.abort(
         new Error(
-          "Account Pooler [Experimental] stopped before the upstream response completed.",
+          "Account Pooler stopped before the upstream response completed.",
         ),
       );
     }
@@ -268,7 +268,7 @@ export class AccountPoolHub {
       } catch {
         return adapter.errorResponse(
           502,
-          `Account Pooler [Experimental] could not reach ${adapter.upstreamName}.`,
+          `Account Pooler could not reach ${adapter.upstreamName}.`,
         );
       }
       const observed = adapter.quotaFromHeaders(
@@ -337,7 +337,7 @@ export class AccountPoolHub {
           } catch {
             return adapter.errorResponse(
               502,
-              `Account Pooler [Experimental] could not reach ${adapter.upstreamName}.`,
+              `Account Pooler could not reach ${adapter.upstreamName}.`,
             );
           }
         }
@@ -541,7 +541,7 @@ export class AccountPoolHub {
     if (!accounts.some((account) => account.enabled)) {
       return adapter.errorResponse(
         503,
-        "Account Pooler [Experimental] has no enabled account",
+        "Account Pooler has no enabled account",
       );
     }
     const now = this.options.now();
@@ -563,7 +563,7 @@ export class AccountPoolHub {
     );
     return adapter.errorResponse(
       429,
-      "No Account Pooler [Experimental] account is currently eligible.",
+      "No Account Pooler account is currently eligible.",
       { "retry-after": String(retryAfter) },
     );
   }
@@ -577,7 +577,7 @@ export class AccountPoolHub {
     const adapter = this.options.adapters.get(provider);
     if (adapter === undefined)
       throw new Error(
-        `Missing ${provider} Account Pooler [Experimental] adapter.`,
+        `Missing ${provider} Account Pooler adapter.`,
       );
     return adapter;
   }

--- a/plugins/account-pool/src/hub.ts
+++ b/plugins/account-pool/src/hub.ts
@@ -7,7 +7,10 @@ import type {
   PoolStatus,
 } from "./contracts.js";
 import { createClaudeAdapter } from "./claude-adapter.js";
-import { createCodexAdapter } from "./codex-adapter.js";
+import {
+  createCodexAdapter,
+  DEFAULT_CODEX_REFRESH_URL,
+} from "./codex-adapter.js";
 import type { ProviderAdapter } from "./provider-adapter.js";
 import type { ImportedProviderAccount } from "./provider-adapter.js";
 import type {
@@ -24,7 +27,6 @@ import type { AccountStore, HubTokenStore, QuotaStore } from "./store.js";
 
 const ROUTE = "/api/v1/plugins/account-pool/http";
 const DEFAULT_REFRESH_URL = "https://platform.claude.com/v1/oauth/token";
-const DEFAULT_CODEX_REFRESH_URL = "https://auth.openai.com/oauth/token";
 const DEFAULT_USAGE_URL = "https://api.anthropic.com/api/oauth/usage";
 const DEFAULT_PROFILE_URL = "https://api.anthropic.com/api/oauth/profile";
 const DEFAULT_USAGE_REFRESH_INTERVAL_MS = 5 * 60 * 1_000;

--- a/plugins/account-pool/src/operations.ts
+++ b/plugins/account-pool/src/operations.ts
@@ -15,6 +15,7 @@ import type {
   RoutingStore,
 } from "./store.js";
 import type { ClaudeOAuthAccount } from "./oauth-login.js";
+import type { CodexDeviceAccount } from "./codex-device-login.js";
 
 interface PoolHost {
   id: string;
@@ -116,6 +117,39 @@ export class PoolOperations {
     this.onAccountsChanged();
     await this.onAccountEnabled(account.id);
     return account;
+  }
+
+  async addCodexOAuth(
+    authenticated: CodexDeviceAccount,
+  ): Promise<AccountSummary> {
+    const account = await this.accounts.add(
+      {
+        provider: "codex",
+        kind: "oauth",
+        label: authenticated.label,
+        email: authenticated.email,
+        accountUuid: null,
+        codexAccountId: authenticated.accountId,
+        subscriptionType: null,
+        rateLimitTier: null,
+        enabled: true,
+        priority: 100,
+      },
+      {
+        kind: "oauth",
+        accessToken: authenticated.accessToken,
+        refreshToken: authenticated.refreshToken,
+        idToken: authenticated.idToken,
+        expiresAt: authenticated.expiresAt,
+      },
+    );
+    this.onAccountsChanged();
+    await this.onAccountEnabled(account.id);
+    const summary = (await this.list()).find((item) => item.id === account.id);
+    if (summary === undefined) {
+      throw new Error("Added Codex account could not be read back.");
+    }
+    return summary;
   }
 
   async list(): Promise<AccountSummary[]> {

--- a/plugins/account-pool/src/rpc.ts
+++ b/plugins/account-pool/src/rpc.ts
@@ -7,6 +7,7 @@ import {
   accountSummarySchema,
   bypassInputSchema,
   bypassResultSchema,
+  codexLoginCancelSchema,
   codexLoginPollInputSchema,
   codexLoginPollSchema,
   codexLoginStartSchema,
@@ -57,6 +58,10 @@ export const accountPoolRpcContract = defineRpcContract({
     input: codexLoginPollInputSchema,
     output: codexLoginPollSchema,
   },
+  "codexLogin.cancel": {
+    input: codexLoginPollInputSchema,
+    output: codexLoginCancelSchema,
+  },
   status: {
     input: z.null(),
     output: statusSchema,
@@ -94,6 +99,9 @@ export function createRpcHandlers(
       login.complete(input),
     "codexLogin.start": () => codexLogin.start(),
     "codexLogin.poll": (input: { sessionId: string }) => codexLogin.poll(input),
+    "codexLogin.cancel": (input: { sessionId: string }) => ({
+      cancelled: codexLogin.cancel(input),
+    }),
     status: () => operations.status(),
     "token.rotate": ({ machine }: { machine: string }) =>
       operations.rotateToken(machine),

--- a/plugins/account-pool/src/rpc.ts
+++ b/plugins/account-pool/src/rpc.ts
@@ -7,6 +7,9 @@ import {
   accountSummarySchema,
   bypassInputSchema,
   bypassResultSchema,
+  codexLoginPollInputSchema,
+  codexLoginPollSchema,
+  codexLoginStartSchema,
   hubTokenSummarySchema,
   loginCompleteInputSchema,
   loginStartSchema,
@@ -15,6 +18,7 @@ import {
 } from "./contracts.js";
 import type { PoolOperations } from "./operations.js";
 import type { ClaudeOAuthLogin } from "./oauth-login.js";
+import type { CodexDeviceLogin } from "./codex-device-login.js";
 
 export const accountPoolRpcContract = defineRpcContract({
   "account.add": {
@@ -45,6 +49,14 @@ export const accountPoolRpcContract = defineRpcContract({
     input: loginCompleteInputSchema,
     output: accountSchema,
   },
+  "codexLogin.start": {
+    input: z.null(),
+    output: codexLoginStartSchema,
+  },
+  "codexLogin.poll": {
+    input: codexLoginPollInputSchema,
+    output: codexLoginPollSchema,
+  },
   status: {
     input: z.null(),
     output: statusSchema,
@@ -62,6 +74,7 @@ export const accountPoolRpcContract = defineRpcContract({
 export function createRpcHandlers(
   operations: PoolOperations,
   login: ClaudeOAuthLogin,
+  codexLogin: CodexDeviceLogin,
 ) {
   return {
     "account.add": (input: Parameters<PoolOperations["add"]>[0]) =>
@@ -79,6 +92,8 @@ export function createRpcHandlers(
     "login.start": () => login.start(),
     "login.complete": (input: { sessionId: string; pasted: string }) =>
       login.complete(input),
+    "codexLogin.start": () => codexLogin.start(),
+    "codexLogin.poll": (input: { sessionId: string }) => codexLogin.poll(input),
     status: () => operations.status(),
     "token.rotate": ({ machine }: { machine: string }) =>
       operations.rotateToken(machine),

--- a/plugins/account-pool/src/server.test.ts
+++ b/plugins/account-pool/src/server.test.ts
@@ -1260,6 +1260,14 @@ describe("Account Pool plugin", () => {
       userCode: "ABCD-1234",
       intervalMs: 1_000,
     });
+    expect(
+      codexLoginPollSchema.parse(
+        await host.harness.behavior.callRpc("codexLogin.poll", {
+          sessionId: started.sessionId,
+        }),
+      ),
+    ).toEqual({ status: "pending" });
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
     const completed = codexLoginPollSchema.parse(
       await host.harness.behavior.callRpc("codexLogin.poll", {
         sessionId: started.sessionId,
@@ -1300,6 +1308,36 @@ describe("Account Pool plugin", () => {
     expect(cliCompleted).toMatchObject({
       exitCode: 0,
       stdout: expect.stringContaining("Added codex@example.com"),
+    });
+    const cancelledStart = await host.harness.behavior.runCli([
+      "account",
+      "add",
+      "--provider",
+      "codex",
+      "--login",
+    ]);
+    const cancelledSessionId = cancelledStart.stdout.match(
+      /Session ID: ([0-9a-f-]+)/u,
+    )?.[1];
+    if (cancelledSessionId === undefined) {
+      throw new Error("Codex CLI login start omitted its session ID.");
+    }
+    const controller = new AbortController();
+    const cancelledPoll = host.harness.behavior.runCli(
+      ["account", "login-poll", "--session", cancelledSessionId],
+      { signal: controller.signal },
+    );
+    controller.abort(new Error("cancelled by test"));
+    expect(await cancelledPoll).toMatchObject({ exitCode: 1 });
+    expect(
+      codexLoginPollSchema.parse(
+        await host.harness.behavior.callRpc("codexLogin.poll", {
+          sessionId: cancelledSessionId,
+        }),
+      ),
+    ).toEqual({
+      status: "error",
+      message: "Login session was not found. Start again.",
     });
     expect(host.harness.inspection.logEntries.join("\n")).not.toMatch(
       /device-secret|ABCD-1234|authorization-secret|verifier-secret|refresh-secret/u,

--- a/plugins/account-pool/src/server.test.ts
+++ b/plugins/account-pool/src/server.test.ts
@@ -9,6 +9,8 @@ import {
   accountSchema,
   accountSecretSchema,
   accountSummarySchema,
+  codexLoginPollSchema,
+  codexLoginStartSchema,
   statusSchema,
   type AccountSummary,
 } from "./contracts.js";
@@ -162,6 +164,14 @@ function importedCredentials(
     accountUuid: "11111111-1111-4111-8111-111111111111",
     ...overrides,
   };
+}
+
+function testJwt(payload: object): string {
+  return [
+    Buffer.from(JSON.stringify({ alg: "none" })).toString("base64url"),
+    Buffer.from(JSON.stringify(payload)).toString("base64url"),
+    "signature",
+  ].join(".");
 }
 
 async function createFixture(args: {
@@ -1181,6 +1191,119 @@ describe("Account Pool plugin", () => {
     });
     expect(tokenBodies).toHaveLength(2);
     expect(tokenBodies[1]).toMatchObject({ code: "cli-code", state: cliState });
+  });
+
+  it("exposes Codex device login over RPC and the two-step CLI", async () => {
+    const auth = await startUpstream(async (request, response) => {
+      await readRequestBody(request);
+      response.setHeader("content-type", "application/json");
+      if (request.url === "/api/accounts/deviceauth/usercode") {
+        response.end(
+          JSON.stringify({
+            device_auth_id: "device-secret",
+            user_code: "ABCD-1234",
+            interval: "1",
+            expires_in: 600,
+          }),
+        );
+        return;
+      }
+      if (request.url === "/api/accounts/deviceauth/token") {
+        response.end(
+          JSON.stringify({
+            authorization_code: "authorization-secret",
+            code_challenge: "challenge-secret",
+            code_verifier: "verifier-secret",
+          }),
+        );
+        return;
+      }
+      if (request.url === "/oauth/token") {
+        response.end(
+          JSON.stringify({
+            access_token: testJwt({ exp: 2_000_000_000 }),
+            refresh_token: "refresh-secret",
+            id_token: testJwt({
+              email: "codex@example.com",
+              "https://api.openai.com/auth": {
+                chatgpt_account_id: "chatgpt-account-1",
+              },
+            }),
+          }),
+        );
+        return;
+      }
+      response.statusCode = 404;
+      response.end("{}");
+    });
+    cleanups.push(auth.close);
+    const dataDir = await mkdtemp(path.join(tmpdir(), "bb-pool-codex-login-"));
+    const host = createFakePluginHost({
+      pluginId: "account-pool",
+      dataDir,
+      sdk: sdkStubs(),
+    });
+    await createAccountPoolPlugin({
+      codexAuthBaseUrl: auth.url,
+      usageUrl: "data:application/json,{}",
+    })(host.bb);
+    cleanups.push(async () => {
+      await host.harness.lifecycle.dispose();
+      await fs.rm(dataDir, { recursive: true, force: true });
+    });
+
+    const started = codexLoginStartSchema.parse(
+      await host.harness.behavior.callRpc("codexLogin.start", null),
+    );
+    expect(started).toMatchObject({
+      verificationUri: `${auth.url}/codex/device`,
+      userCode: "ABCD-1234",
+      intervalMs: 1_000,
+    });
+    const completed = codexLoginPollSchema.parse(
+      await host.harness.behavior.callRpc("codexLogin.poll", {
+        sessionId: started.sessionId,
+      }),
+    );
+    expect(completed).toMatchObject({
+      status: "complete",
+      account: {
+        provider: "codex",
+        codexAccountId: "chatgpt-account-1",
+        email: "codex@example.com",
+      },
+    });
+
+    const cliStarted = await host.harness.behavior.runCli([
+      "account",
+      "add",
+      "--provider",
+      "codex",
+      "--login",
+    ]);
+    expect(cliStarted).toMatchObject({
+      exitCode: 0,
+      stdout: expect.stringContaining("Open this URL to sign in to Codex:"),
+    });
+    expect(cliStarted.stdout).toContain("Enter this code: ABCD-1234");
+    expect(cliStarted.stdout).toContain("account login-poll --session");
+    const sessionId = cliStarted.stdout.match(/Session ID: ([0-9a-f-]+)/u)?.[1];
+    if (sessionId === undefined) {
+      throw new Error("Codex CLI login start omitted its session ID.");
+    }
+    const cliCompleted = await host.harness.behavior.runCli([
+      "account",
+      "login-poll",
+      "--session",
+      sessionId,
+    ]);
+    expect(cliCompleted).toMatchObject({
+      exitCode: 0,
+      stdout: expect.stringContaining("Added codex@example.com"),
+    });
+    expect(host.harness.inspection.logEntries.join("\n")).not.toMatch(
+      /device-secret|ABCD-1234|authorization-secret|verifier-secret|refresh-secret/u,
+    );
   });
 
   it("resolves distinct secret machine tokens and honors per-thread bypass", async () => {

--- a/plugins/account-pool/src/server.test.ts
+++ b/plugins/account-pool/src/server.test.ts
@@ -436,7 +436,8 @@ describe("Account Pool plugin", () => {
       }),
     ).resolves.toEqual({
       label: "Proxied",
-      statusMessage: "Credentials are provided by the Account Pool hub.",
+      statusMessage:
+        "Credentials are provided by the Account Pooler [Experimental] hub.",
     });
     const httpResponse = await host.harness.behavior.fetchHttp(
       "POST",
@@ -602,7 +603,10 @@ describe("Account Pool plugin", () => {
       { headers: { "x-bb-account-pool-token": "invalid" } },
     );
     expect(rejected.closeCalls).toEqual([
-      { code: 1008, reason: "invalid Account Pool token" },
+      {
+        code: 1008,
+        reason: "invalid Account Pooler [Experimental] token",
+      },
     ]);
     const socket = await host.harness.experimental_openWebSocket(
       "/v1/responses",
@@ -1364,13 +1368,13 @@ describe("Account Pool plugin", () => {
       {
         name: "ANTHROPIC_BASE_URL",
         value: { serverPath: "/api/v1/plugins/account-pool/http" },
-        reason: "Routed through the Account Pool hub",
+        reason: "Routed through the Account Pooler [Experimental] hub",
         secret: false,
       },
       {
         name: "ANTHROPIC_AUTH_TOKEN",
         value: fixture.key,
-        reason: "Account Pool hub token for this machine",
+        reason: "Account Pooler [Experimental] hub token for this machine",
         secret: true,
       },
       {
@@ -1387,7 +1391,8 @@ describe("Account Pool plugin", () => {
       }),
     ).resolves.toEqual({
       label: "Proxied",
-      statusMessage: "Credentials are provided by the Account Pool hub.",
+      statusMessage:
+        "Credentials are provided by the Account Pooler [Experimental] hub.",
     });
     const secondToken = await resolveToken(
       fixture.host,
@@ -1564,7 +1569,7 @@ describe("Account Pool plugin", () => {
     expect(fixture.host.harness.inspection.logEntries).toContainEqual({
       level: "warn",
       message:
-        "Account Pool disabled with 1 recently routed thread on machines without a local Claude login. Run bb pool status before disabling to inspect them.",
+        "Account Pooler [Experimental] disabled with 1 recently routed thread on machines without a local Claude login. Run bb pool status before disabling to inspect them.",
     });
   });
 
@@ -1585,7 +1590,7 @@ describe("Account Pool plugin", () => {
     expect(fixture.host.harness.inspection.logEntries).toContainEqual({
       level: "debug",
       message:
-        "Account Pool disable inspection skipped: plugin list unavailable",
+        "Account Pooler [Experimental] disable inspection skipped: plugin list unavailable",
     });
   });
 
@@ -1612,7 +1617,7 @@ describe("Account Pool plugin", () => {
     );
     expect(fixture.host.harness.inspection.logEntries).toContainEqual({
       level: "debug",
-      message: "Account Pool disable inspection timed out.",
+      message: "Account Pooler [Experimental] disable inspection timed out.",
     });
   });
 
@@ -2372,7 +2377,7 @@ describe("Account Pool plugin", () => {
     expect(Date.now() - startedAt).toBeGreaterThanOrEqual(30);
     const stopped = await reader.read();
     expect(new TextDecoder().decode(stopped.value)).toContain(
-      "Account Pool stopped",
+      "Account Pooler [Experimental] stopped",
     );
     const rejected = await fixture.host.harness.behavior.fetchHttp(
       "POST",

--- a/plugins/account-pool/src/server.test.ts
+++ b/plugins/account-pool/src/server.test.ts
@@ -1198,6 +1198,15 @@ describe("Account Pool plugin", () => {
   });
 
   it("exposes Codex device login over RPC and the two-step CLI", async () => {
+    let holdTokenPoll = false;
+    let markTokenPollStarted: () => void = () => {};
+    const tokenPollStarted = new Promise<void>((resolve) => {
+      markTokenPollStarted = resolve;
+    });
+    let releaseTokenPoll: () => void = () => {};
+    const tokenPollRelease = new Promise<void>((resolve) => {
+      releaseTokenPoll = resolve;
+    });
     const auth = await startUpstream(async (request, response) => {
       await readRequestBody(request);
       response.setHeader("content-type", "application/json");
@@ -1213,6 +1222,10 @@ describe("Account Pool plugin", () => {
         return;
       }
       if (request.url === "/api/accounts/deviceauth/token") {
+        if (holdTokenPoll) {
+          markTokenPollStarted();
+          await tokenPollRelease;
+        }
         response.end(
           JSON.stringify({
             authorization_code: "authorization-secret",
@@ -1326,13 +1339,14 @@ describe("Account Pool plugin", () => {
     if (cancelledSessionId === undefined) {
       throw new Error("Codex CLI login start omitted its session ID.");
     }
+    holdTokenPoll = true;
     const controller = new AbortController();
     const cancelledPoll = host.harness.behavior.runCli(
       ["account", "login-poll", "--session", cancelledSessionId],
       { signal: controller.signal },
     );
+    await tokenPollStarted;
     controller.abort(new Error("cancelled by test"));
-    expect(await cancelledPoll).toMatchObject({ exitCode: 1 });
     expect(
       codexLoginPollSchema.parse(
         await host.harness.behavior.callRpc("codexLogin.poll", {
@@ -1343,6 +1357,8 @@ describe("Account Pool plugin", () => {
       status: "error",
       message: "Login session was not found. Start again.",
     });
+    releaseTokenPoll();
+    expect(await cancelledPoll).toMatchObject({ exitCode: 1 });
     expect(host.harness.inspection.logEntries.join("\n")).not.toMatch(
       /device-secret|ABCD-1234|authorization-secret|verifier-secret|refresh-secret/u,
     );

--- a/plugins/account-pool/src/server.test.ts
+++ b/plugins/account-pool/src/server.test.ts
@@ -437,7 +437,7 @@ describe("Account Pool plugin", () => {
     ).resolves.toEqual({
       label: "Proxied",
       statusMessage:
-        "Credentials are provided by the Account Pooler [Experimental] hub.",
+        "Credentials are provided by the Account Pooler hub.",
     });
     const httpResponse = await host.harness.behavior.fetchHttp(
       "POST",
@@ -605,7 +605,7 @@ describe("Account Pool plugin", () => {
     expect(rejected.closeCalls).toEqual([
       {
         code: 1008,
-        reason: "invalid Account Pooler [Experimental] token",
+        reason: "invalid Account Pooler token",
       },
     ]);
     const socket = await host.harness.experimental_openWebSocket(
@@ -1384,13 +1384,13 @@ describe("Account Pool plugin", () => {
       {
         name: "ANTHROPIC_BASE_URL",
         value: { serverPath: "/api/v1/plugins/account-pool/http" },
-        reason: "Routed through the Account Pooler [Experimental] hub",
+        reason: "Routed through the Account Pooler hub",
         secret: false,
       },
       {
         name: "ANTHROPIC_AUTH_TOKEN",
         value: fixture.key,
-        reason: "Account Pooler [Experimental] hub token for this machine",
+        reason: "Account Pooler hub token for this machine",
         secret: true,
       },
       {
@@ -1408,7 +1408,7 @@ describe("Account Pool plugin", () => {
     ).resolves.toEqual({
       label: "Proxied",
       statusMessage:
-        "Credentials are provided by the Account Pooler [Experimental] hub.",
+        "Credentials are provided by the Account Pooler hub.",
     });
     const secondToken = await resolveToken(
       fixture.host,
@@ -1585,7 +1585,7 @@ describe("Account Pool plugin", () => {
     expect(fixture.host.harness.inspection.logEntries).toContainEqual({
       level: "warn",
       message:
-        "Account Pooler [Experimental] disabled with 1 recently routed thread on machines without a local Claude login. Run bb pool status before disabling to inspect them.",
+        "Account Pooler disabled with 1 recently routed thread on machines without a local Claude login. Run bb pool status before disabling to inspect them.",
     });
   });
 
@@ -1606,7 +1606,7 @@ describe("Account Pool plugin", () => {
     expect(fixture.host.harness.inspection.logEntries).toContainEqual({
       level: "debug",
       message:
-        "Account Pooler [Experimental] disable inspection skipped: plugin list unavailable",
+        "Account Pooler disable inspection skipped: plugin list unavailable",
     });
   });
 
@@ -1633,7 +1633,7 @@ describe("Account Pool plugin", () => {
     );
     expect(fixture.host.harness.inspection.logEntries).toContainEqual({
       level: "debug",
-      message: "Account Pooler [Experimental] disable inspection timed out.",
+      message: "Account Pooler disable inspection timed out.",
     });
   });
 
@@ -2393,7 +2393,7 @@ describe("Account Pool plugin", () => {
     expect(Date.now() - startedAt).toBeGreaterThanOrEqual(30);
     const stopped = await reader.read();
     expect(new TextDecoder().decode(stopped.value)).toContain(
-      "Account Pooler [Experimental] stopped",
+      "Account Pooler stopped",
     );
     const rejected = await fixture.host.harness.behavior.fetchHttp(
       "POST",

--- a/plugins/account-pool/src/server.ts
+++ b/plugins/account-pool/src/server.ts
@@ -11,6 +11,7 @@ import { createHub } from "./hub.js";
 import { PoolOperations } from "./operations.js";
 import { accountPoolRpcContract, createRpcHandlers } from "./rpc.js";
 import { ClaudeOAuthLogin } from "./oauth-login.js";
+import { CodexDeviceLogin } from "./codex-device-login.js";
 import { ACCOUNT_POOL_ACCOUNTS_CHANGED } from "./realtime.js";
 import {
   AccountStore,
@@ -34,6 +35,7 @@ export interface AccountPoolPluginOptions {
   oauthAuthorizeUrl?: string;
   oauthTokenUrl?: string;
   oauthProfileUrl?: string;
+  codexAuthBaseUrl?: string;
 }
 
 const DISPOSE_INSPECTION_TIMEOUT_MS = 2_000;
@@ -140,6 +142,12 @@ export function createAccountPoolPlugin(
       profileUrl: options.oauthProfileUrl,
       addAccount: (authenticated) => operations.addOAuth(authenticated),
     });
+    const codexLogin = new CodexDeviceLogin({
+      fetch: options.fetch,
+      now,
+      authBaseUrl: options.codexAuthBaseUrl,
+      addAccount: (authenticated) => operations.addCodexOAuth(authenticated),
+    });
     if ((await accounts.list()).every((account) => !account.enabled)) {
       bb.status.needsConfiguration(
         "Add and enable a Claude or Codex account with `bb pool account add`.",
@@ -147,9 +155,9 @@ export function createAccountPoolPlugin(
     }
     bb.rpc.register(
       accountPoolRpcContract,
-      createRpcHandlers(operations, login),
+      createRpcHandlers(operations, login, codexLogin),
     );
-    registerPoolCli(bb, operations, login);
+    registerPoolCli(bb, operations, login, codexLogin);
     bb.providers.experimental_contributeEnv("claude-code", async (context) => {
       if (
         (await routing.isBypassed(context.threadId)) ||

--- a/plugins/account-pool/src/server.ts
+++ b/plugins/account-pool/src/server.ts
@@ -173,13 +173,13 @@ export function createAccountPoolPlugin(
           value: {
             serverPath: "/api/v1/plugins/account-pool/http",
           },
-          reason: "Routed through the Account Pooler [Experimental] hub",
+          reason: "Routed through the Account Pooler hub",
           secret: false,
         },
         {
           name: "ANTHROPIC_AUTH_TOKEN",
           value: token,
-          reason: "Account Pooler [Experimental] hub token for this machine",
+          reason: "Account Pooler hub token for this machine",
           secret: true,
         },
         {
@@ -196,7 +196,7 @@ export function createAccountPoolPlugin(
         ? {
             label: "Proxied",
             statusMessage:
-              "Credentials are provided by the Account Pooler [Experimental] hub.",
+              "Credentials are provided by the Account Pooler hub.",
           }
         : null,
     );
@@ -214,13 +214,13 @@ export function createAccountPoolPlugin(
           value: {
             serverPath: "/api/v1/plugins/account-pool/http/v1",
           },
-          reason: "Routed through the Account Pooler [Experimental] hub",
+          reason: "Routed through the Account Pooler hub",
           secret: false,
         },
         {
           name: "CODEX_POOL_AUTH_TOKEN",
           value: token,
-          reason: "Account Pooler [Experimental] hub token for this machine",
+          reason: "Account Pooler hub token for this machine",
           secret: true,
         },
       ];
@@ -230,7 +230,7 @@ export function createAccountPoolPlugin(
         ? {
             label: "Proxied",
             statusMessage:
-              "Credentials are provided by the Account Pooler [Experimental] hub.",
+              "Credentials are provided by the Account Pooler hub.",
           }
         : null,
     );
@@ -251,14 +251,14 @@ export function createAccountPoolPlugin(
         const result = await Promise.race([inspection, timeout]);
         if (result === DISPOSE_INSPECTION_TIMEOUT) {
           bb.log.debug(
-            "Account Pooler [Experimental] disable inspection timed out.",
+            "Account Pooler disable inspection timed out.",
           );
           return;
         }
         if (result !== null) bb.log.warn(result);
       } catch (error) {
         bb.log.debug(
-          `Account Pooler [Experimental] disable inspection skipped: ${error instanceof Error ? error.message : String(error)}`,
+          `Account Pooler disable inspection skipped: ${error instanceof Error ? error.message : String(error)}`,
         );
       } finally {
         if (timer !== null) clearTimeout(timer);
@@ -313,7 +313,7 @@ async function inspectDisableState(
   if (!disabled) return null;
   const warnings = await operations.routedThreadsWithoutLocalLogin();
   if (warnings.length === 0) return null;
-  return `Account Pooler [Experimental] disabled with ${warnings.length} recently routed thread${warnings.length === 1 ? "" : "s"} on machines without a local Claude login. Run bb pool status before disabling to inspect them.`;
+  return `Account Pooler disabled with ${warnings.length} recently routed thread${warnings.length === 1 ? "" : "s"} on machines without a local Claude login. Run bb pool status before disabling to inspect them.`;
 }
 
 export default createAccountPoolPlugin();

--- a/plugins/account-pool/src/server.ts
+++ b/plugins/account-pool/src/server.ts
@@ -233,6 +233,7 @@ export function createAccountPoolPlugin(
         : null,
     );
     bb.onDispose(async () => {
+      codexLogin.dispose();
       let timer: ReturnType<typeof setTimeout> | null = null;
       try {
         const inspection = inspectDisableState(bb, operations);

--- a/plugins/account-pool/src/server.ts
+++ b/plugins/account-pool/src/server.ts
@@ -173,13 +173,13 @@ export function createAccountPoolPlugin(
           value: {
             serverPath: "/api/v1/plugins/account-pool/http",
           },
-          reason: "Routed through the Account Pool hub",
+          reason: "Routed through the Account Pooler [Experimental] hub",
           secret: false,
         },
         {
           name: "ANTHROPIC_AUTH_TOKEN",
           value: token,
-          reason: "Account Pool hub token for this machine",
+          reason: "Account Pooler [Experimental] hub token for this machine",
           secret: true,
         },
         {
@@ -195,7 +195,8 @@ export function createAccountPoolPlugin(
       (await operations.hasUsableEnabledAccount("claude"))
         ? {
             label: "Proxied",
-            statusMessage: "Credentials are provided by the Account Pool hub.",
+            statusMessage:
+              "Credentials are provided by the Account Pooler [Experimental] hub.",
           }
         : null,
     );
@@ -213,13 +214,13 @@ export function createAccountPoolPlugin(
           value: {
             serverPath: "/api/v1/plugins/account-pool/http/v1",
           },
-          reason: "Routed through the Account Pool hub",
+          reason: "Routed through the Account Pooler [Experimental] hub",
           secret: false,
         },
         {
           name: "CODEX_POOL_AUTH_TOKEN",
           value: token,
-          reason: "Account Pool hub token for this machine",
+          reason: "Account Pooler [Experimental] hub token for this machine",
           secret: true,
         },
       ];
@@ -228,7 +229,8 @@ export function createAccountPoolPlugin(
       (await operations.hasUsableEnabledAccount("codex"))
         ? {
             label: "Proxied",
-            statusMessage: "Credentials are provided by the Account Pool hub.",
+            statusMessage:
+              "Credentials are provided by the Account Pooler [Experimental] hub.",
           }
         : null,
     );
@@ -248,13 +250,15 @@ export function createAccountPoolPlugin(
         );
         const result = await Promise.race([inspection, timeout]);
         if (result === DISPOSE_INSPECTION_TIMEOUT) {
-          bb.log.debug("Account Pool disable inspection timed out.");
+          bb.log.debug(
+            "Account Pooler [Experimental] disable inspection timed out.",
+          );
           return;
         }
         if (result !== null) bb.log.warn(result);
       } catch (error) {
         bb.log.debug(
-          `Account Pool disable inspection skipped: ${error instanceof Error ? error.message : String(error)}`,
+          `Account Pooler [Experimental] disable inspection skipped: ${error instanceof Error ? error.message : String(error)}`,
         );
       } finally {
         if (timer !== null) clearTimeout(timer);
@@ -309,7 +313,7 @@ async function inspectDisableState(
   if (!disabled) return null;
   const warnings = await operations.routedThreadsWithoutLocalLogin();
   if (warnings.length === 0) return null;
-  return `Account Pool disabled with ${warnings.length} recently routed thread${warnings.length === 1 ? "" : "s"} on machines without a local Claude login. Run bb pool status before disabling to inspect them.`;
+  return `Account Pooler [Experimental] disabled with ${warnings.length} recently routed thread${warnings.length === 1 ? "" : "s"} on machines without a local Claude login. Run bb pool status before disabling to inspect them.`;
 }
 
 export default createAccountPoolPlugin();


### PR DESCRIPTION
## Human comments

## What was wrong

Account Pool could only add a Codex account by importing the bb server machine's existing `~/.codex/auth.json`. That duplicated the account already available directly on that machine instead of letting the pool add another ChatGPT account, and the browser-oriented settings UI exposed an import action that could not provide the pool's main value.

## What changed

- Added an in-memory Codex ChatGPT device-code login with ten-minute expiry, server-enforced poll intervals, authorization-code exchange, ID-token account/email claim parsing, and redacted user-facing failures.
- Added `codexLogin.start` and `codexLogin.poll` RPC methods and the settings state machine that opens the verification page, displays/copies the one-time code, polls until completion, and supports retry after errors.
- Replaced the settings-page Codex import action with **Sign in to Codex**. The headless `bb pool account add --provider codex --import` path remains available.
- Added the two-command CLI flow: `bb pool account add --provider codex --login` prints the verification details, then `bb pool account login-poll --session <id>` blocks until completion or expiry.
- Updated the built-in CLI guide template, bb-cli skill, and configuration documentation. No host-daemon wire contract or public Plugin SDK surface changed.
- The live usercode endpoint currently omits a verification URI and returns `interval` as a string plus `expires_at` as an ISO timestamp. Per coordinator decision and the official Codex client, the verification URI is derived from the single auth base as `<base>/codex/device`; no second OpenAI auth-base literal was added.

## How you verified

- `pnpm exec turbo run typecheck test --filter=bb-plugin-account-pool --continue` — passed; 6 test files and 47 tests. New coverage fakes all three OpenAI auth endpoints and verifies pending-then-success polling, interval enforcement, expiry, exchange failure redaction, ID-token claims, RPC contracts, CLI flow, UI success/error states, and removal of the Codex import button.
- `bb plugin build plugins/account-pool` — passed and produced backend/frontend bundles.
- Live dev app on this branch with Account Pool enabled — verified **Sign in to Codex** is present and the Codex import button is absent; attached `bb95-account-pool-settings.png` to BB-95.
- Clicked **Sign in to Codex** — verified the derived verification URL, prominent one-time code, and live waiting state; attached `bb95-codex-device-step.png` to BB-95. OpenAI reached its protected authorization page and required human sign-in, so the flow was stopped and the exact verification state was posted to BB-95 as required. Account-row, CLI list, and routed-thread proof remain pending owner authorization.

## Review fixes

- Matched Codex CLI 0.153 device polling: the first poll waits for `nextPollAt`, HTTP 403/404 and transient 5xx responses remain pending, `slow_down` on any status adds five seconds, and expiry/decline terminate the session.
- Added `codexLogin.cancel`, immediate CLI abort cleanup, UI cancellation, unref'd expiry timers, and complete session/timer disposal coverage.
- Renamed the user-facing plugin display name to **Account Pooler [Experimental]** without changing its id, package, CLI namespace, settings keys, or stored secret paths.
- `pnpm exec turbo run typecheck test --filter=bb-plugin-account-pool --continue` passes with 57/57 tests and all selected typechecks.

Tracks BB-95 (layer C of BB-93).

> AGENT GENERATED
