### PR TITLE
Hide the empty projectless Threads section in project sidebar mode

### DIFF
--- a/apps/app/src/components/sidebar/ProjectList.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.tsx
@@ -1046,9 +1046,6 @@ function ProjectModeSections({
   const { onOrderChange, order, persistedOrder } = useSidebarModeSectionOrder({
     mode: "project",
     entitySectionIds: projectSectionIds,
-    // Project rows carry their own actions, so an empty projectless Threads
-    // section is only noise. Keep it while there are no projects so the
-    // sidebar still has an entry point.
     hasThreadsSection: personalThreads.length > 0 || projectRows.length === 0,
     showPinnedSection,
     isReady,

--- a/apps/app/src/components/sidebar/ProjectList.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.tsx
@@ -1040,16 +1040,20 @@ function ProjectModeSections({
     }
     return rows;
   }, [projectRows]);
+  const personalThreads =
+    threadsByProject.get(PERSONAL_PROJECT_ID)?.filter(isSidebarProjectThread) ??
+    [];
   const { onOrderChange, order, persistedOrder } = useSidebarModeSectionOrder({
     mode: "project",
     entitySectionIds: projectSectionIds,
+    // Project rows carry their own actions, so an empty projectless Threads
+    // section is only noise. Keep it while there are no projects so the
+    // sidebar still has an entry point.
+    hasThreadsSection: personalThreads.length > 0 || projectRows.length === 0,
     showPinnedSection,
     isReady,
   });
   const reorderDisabled = order.length < 2;
-  const personalThreads =
-    threadsByProject.get(PERSONAL_PROJECT_ID)?.filter(isSidebarProjectThread) ??
-    [];
   const builtInSections: BuiltInSidebarSectionOptionsById = {
     pinned: pinnedSection,
     threads: {

--- a/packages/client-core/test/sidebarSectionOrder.test.ts
+++ b/packages/client-core/test/sidebarSectionOrder.test.ts
@@ -43,6 +43,18 @@ describe("normalizeSidebarSectionOrder", () => {
     ).toEqual(["pinned", "threads", projectB, projectA, projectC]);
   });
 
+  it("drops a stored Threads section when it is not available", () => {
+    expect(
+      normalizeSidebarSectionOrder({
+        storedOrder: [projectA, "threads", projectB],
+        entitySectionIds: [projectA, projectB],
+        legacyEntityAnchor: "projects",
+        hasPinnedSection: true,
+        hasThreadsSection: false,
+      }),
+    ).toEqual(["pinned", projectA, projectB]);
+  });
+
   it("uses the same reconciliation for sections", () => {
     const section = buildSidebarEntitySectionId("section", "work");
     expect(


### PR DESCRIPTION
## Human comments

## What was wrong

In the project organization mode, the sidebar always rendered the built-in "Threads" section (the hidden Personal project) even when it held no threads. Users who only run agents inside project repos see a permanent "Threads / No threads" block wedged between their project rows. Machine mode already gates this section with `hasThreadsSection`; project mode did not.

## What changed

- `apps/app/src/components/sidebar/ProjectList.tsx`: `ProjectModeSections` now passes `hasThreadsSection: personalThreads.length > 0 || projectRows.length === 0` to `useSidebarModeSectionOrder`. The section hides when there are no projectless threads, returns when one exists, and stays when there are no projects so the sidebar keeps an entry point. "New project" remains available in the composer project picker and display options live on each project header.
- `packages/client-core/test/sidebarSectionOrder.test.ts`: test that `normalizeSidebarSectionOrder` drops a stored `threads` entry when `hasThreadsSection` is false.

No wire changes, no CLI or guide changes.

## How you verified

- Removed three forbidden comments that caused the app lint job to fail.
- `pnpm exec turbo run lint typecheck --filter=@bb/app` passes.
- `pnpm exec turbo run test --filter=@bb/app --filter=@bb/client-core -- ProjectList.modes BuiltInSidebarSection sidebarSectionOrder` passes (13 tests).
- `pnpm exec turbo run test --filter=@bb/client-core --force` (254 pass, new test included)
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `vitest run src/components/sidebar/ProjectList.modes.test.tsx src/components/sidebar/BuiltInSidebarSection.test.tsx` (6 pass)

Fixes #

> AGENT GENERATED
