### PR TITLE
Handle secondary panel storage failures

### DIFF
--- a/apps/app/src/components/secondary-panel/SidebarSplitContainer.test.tsx
+++ b/apps/app/src/components/secondary-panel/SidebarSplitContainer.test.tsx
@@ -1241,6 +1241,26 @@ describe("SidebarSplitContainer", () => {
     ).toHaveLength(0);
   });
 
+  it("uses the canonical layout when localStorage rejects the read", () => {
+    const storageKey = sidebarSplitStorageKey(PANEL_STATE_ID);
+    const getItem = vi
+      .spyOn(Storage.prototype, "getItem")
+      .mockImplementation((key) => {
+        if (key === storageKey) {
+          throw new DOMException("blocked", "SecurityError");
+        }
+        return null;
+      });
+
+    renderContainer({
+      renderPane: ({ paneId }) => <div data-testid="only-pane">{paneId}</div>,
+      tabs: [TABS[0] as SidebarSplitTabDescriptor],
+    });
+
+    expect(screen.getByTestId("only-pane")).not.toBeNull();
+    expect(getItem).toHaveBeenCalledWith(storageKey);
+  });
+
   it("keeps a changed layout in memory when localStorage quota is exhausted", () => {
     const storageKey = sidebarSplitStorageKey(PANEL_STATE_ID);
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/apps/app/src/components/secondary-panel/SidebarSplitContainer.tsx
+++ b/apps/app/src/components/secondary-panel/SidebarSplitContainer.tsx
@@ -25,6 +25,7 @@ import { dimInactiveSplitsAtom } from "@/lib/split-layout/atoms";
 import { createSplitResizeSnapSession } from "@/lib/split-resize-snap";
 import { IframeDragGuardOverlay } from "@/lib/iframe-drag-guard";
 import { MACOS_APP_REGION_NO_DRAG_CLASS } from "@/lib/bb-desktop";
+import { withLocalStorage } from "@/lib/browser-storage";
 import {
   PaneContext,
   type PaneContextValue,
@@ -110,9 +111,7 @@ export function SidebarSplitContainer({
   const availableTabIds = useMemo(() => tabs.map((tab) => tab.id), [tabs]);
   const storageKey = sidebarSplitStorageKey(panelStateId);
   const [initialStorageValue] = useState<string | null>(() =>
-    typeof window === "undefined"
-      ? null
-      : window.localStorage.getItem(storageKey),
+    withLocalStorage((storage) => storage.getItem(storageKey), null),
   );
   const [state, setState] = useState<SidebarSplitState>(() => {
     const restored =
@@ -201,13 +200,17 @@ export function SidebarSplitContainer({
   }, [activeTabId, availableTabIds]);
 
   useEffect(() => {
-    pruneSidebarSplitStorage({
-      storage: window.localStorage,
-      now: Date.now(),
-    });
+    withLocalStorage(
+      (storage) =>
+        pruneSidebarSplitStorage({
+          storage,
+          now: Date.now(),
+        }),
+      undefined,
+    );
     lastPersistedValueRef.current = {
       storageKey,
-      value: window.localStorage.getItem(storageKey),
+      value: withLocalStorage((storage) => storage.getItem(storageKey), null),
     };
   }, [storageKey]);
 

--- a/apps/app/src/lib/browser-storage.ts
+++ b/apps/app/src/lib/browser-storage.ts
@@ -31,10 +31,21 @@ interface StoredValueCodec<T> {
 }
 
 export function getLocalStorage(): Storage | null {
+  return withLocalStorage((storage) => storage, null);
+}
+
+export function withLocalStorage<T>(
+  operation: (storage: Storage) => T,
+  fallback: T,
+): T {
   if (typeof window === "undefined") {
-    return null;
+    return fallback;
   }
-  return window.localStorage;
+  try {
+    return operation(window.localStorage);
+  } catch {
+    return fallback;
+  }
 }
 
 function getSessionStorage(): Storage | null {
@@ -70,12 +81,13 @@ function subscribeToLocalStorageKey(
 }
 
 const localStorageStringStorage: SyncStringStorage = {
-  getItem: (key: string) => getLocalStorage()?.getItem(key) ?? null,
+  getItem: (key: string) =>
+    withLocalStorage((storage) => storage.getItem(key), null),
   setItem: (key: string, value: string) => {
-    getLocalStorage()?.setItem(key, value);
+    withLocalStorage((storage) => storage.setItem(key, value), undefined);
   },
   removeItem: (key: string) => {
-    getLocalStorage()?.removeItem(key);
+    withLocalStorage((storage) => storage.removeItem(key), undefined);
   },
   subscribe: (key: string, callback: StoredValueListener) =>
     subscribeToLocalStorageKey(key, callback),

--- a/apps/app/src/lib/fixed-panel-tabs-sync.test.ts
+++ b/apps/app/src/lib/fixed-panel-tabs-sync.test.ts
@@ -18,6 +18,7 @@ import {
   resetFixedPanelTabsStorageMaintenanceForTest,
   useFixedPanelTabsState,
   useFixedPanelTabsStorageMaintenance,
+  useSetFixedSecondaryPanelTab,
   useUpdateFixedPanelTabsState,
 } from "./fixed-panel-tabs";
 import { BbHttpError } from "./sdk";
@@ -62,6 +63,7 @@ afterEach(() => {
   cleanup();
   apiMocks.getThreadTabs.mockReset();
   apiMocks.updateThreadTabs.mockReset();
+  vi.restoreAllMocks();
   window.localStorage.clear();
 });
 
@@ -371,6 +373,35 @@ describe("fixed panel tab server sync", () => {
 });
 
 describe("fixed panel tab storage churn", () => {
+  it("keeps panel selection in memory when localStorage rejects the write", () => {
+    const threadId = "storage-write-failure";
+    const storageKey = getFixedPanelTabsStateStorageKey({ threadId });
+    const queryClient = createTestQueryClient();
+    const { result } = renderHook(
+      () => ({
+        selectPanel: useSetFixedSecondaryPanelTab(threadId, null),
+        state: useFixedPanelTabsState(threadId, null),
+      }),
+      { wrapper: createQueryWrapper(queryClient) },
+    );
+    const setItem = vi
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation((key) => {
+        if (key === storageKey) {
+          throw new DOMException("quota", "QuotaExceededError");
+        }
+      });
+
+    act(() => result.current.selectPanel("thread-info"));
+
+    expect(result.current.state.secondary).toMatchObject({
+      activeTabId: createThreadInfoFixedPanelTab().id,
+      isOpen: true,
+    });
+    expect(window.localStorage.getItem(storageKey)).toBeNull();
+    expect(setItem).toHaveBeenCalledWith(storageKey, expect.any(String));
+  });
+
   it("does not rewrite localStorage when hydration and reconciliation leave the state unchanged", async () => {
     resetFixedPanelTabsStateForTest();
     const threadId = "sync-no-rewrite";

--- a/apps/app/src/lib/fixed-panel-tabs.ts
+++ b/apps/app/src/lib/fixed-panel-tabs.ts
@@ -236,7 +236,9 @@ const FIXED_PANEL_TABS_STORAGE_PRUNE_FALLBACK_DELAY_MS = 1_500;
 
 function scheduleIdleFixedPanelTabsStoragePrune(): void {
   const run = () => {
-    pruneFixedPanelTabsStorage({ now: Date.now() });
+    try {
+      pruneFixedPanelTabsStorage({ now: Date.now() });
+    } catch {}
   };
   if (typeof window === "undefined") {
     return;


### PR DESCRIPTION
## Human comments

## What was wrong

The localStorage quota handling added in #3047 protected the desktop split-layout save, but the same panel still performed unprotected layout reads and cleanup work, while compact panel state wrote through a shared synchronous storage helper that allowed storage exceptions to escape. When browser storage was blocked or full, opening a desktop thread could reach the crash screen and selecting a compact panel tab could raise an uncaught error.

## What changed

- Added one no-throw localStorage helper and used it for shared synchronous reads, writes, and removals.
- Protected split-layout initialization and cleanup scans while preserving the existing in-memory fallback, warning, and retry behavior.
- Contained scheduled fixed-panel cleanup failures.
- Added desktop-read and compact-write regression coverage.
- No host-daemon protocol, CLI, guide, or documentation surface changed.

## How you verified

- Confirmed both new regressions fail against the pre-fix production paths and pass with the fix.
- `pnpm exec turbo run test --filter=@bb/app --force -- 'src/components/secondary-panel/SidebarSplitContainer.test.tsx' 'src/lib/fixed-panel-tabs-sync.test.ts'` — 46 tests passed after rebasing onto current `origin/main`.
- Full `@bb/app` suite — 478 files and 3,865 tests passed, with 4 skipped.
- Turbo typecheck, build, and lint passed; lint reported 0 errors.
- Matched desktop and compact-web DevBrowser checks reproduced the failures before the fix and confirmed no uncaught errors afterward.

Follow-up to #3047.

@slopcop please review.

> AGENT GENERATED
