### PR TITLE
Keep compact Usage refresh with its heading

### DIFF
--- a/apps/app/src/components/settings/UsageLimitsSettingsSection.test.tsx
+++ b/apps/app/src/components/settings/UsageLimitsSettingsSection.test.tsx
@@ -278,6 +278,11 @@ describe("UsageLimitsSettingsSectionContent", () => {
       onSelectHost,
     });
 
+    const sectionHeader = screen
+      .getByRole("heading", { name: "Usage limits" })
+      .closest("section")?.firstElementChild;
+    expect(sectionHeader?.classList.contains("flex-col")).toBe(true);
+
     fireEvent.pointerDown(
       screen.getByRole("button", { name: "Usage limits machine" }),
       { button: 0 },
@@ -299,6 +304,11 @@ describe("UsageLimitsSettingsSectionContent", () => {
       onSelectHost: vi.fn(),
     });
 
+    const sectionHeader = screen
+      .getByRole("heading", { name: "Usage limits" })
+      .closest("section")?.firstElementChild;
+    expect(sectionHeader?.classList.contains("flex-row")).toBe(true);
+    expect(sectionHeader?.classList.contains("flex-col")).toBe(false);
     expect(
       screen.queryByRole("button", { name: "Usage limits machine" }),
     ).toBeNull();

--- a/apps/app/src/components/settings/UsageLimitsSettingsSection.tsx
+++ b/apps/app/src/components/settings/UsageLimitsSettingsSection.tsx
@@ -391,6 +391,7 @@ export function UsageLimitsSettingsSectionContent({
         : "No providers available.";
   return (
     <SettingsSection
+      actionPlacement={showMachinePicker ? "responsive" : "inline"}
       title="Usage limits"
       description="Your provider subscription usage."
       action={


### PR DESCRIPTION
## Human comments

## What was wrong

[PR #3076](https://github.com/get-bb/bb/pull/3076) added compact action placement for settings sections, but Usage limits still used the responsive action layout even when its only action was a small refresh icon. At compact widths with a single available machine, that moved the refresh control onto a detached row instead of keeping it beside the section heading.

## What changed

`UsageLimitsSettingsSectionContent` now uses inline action placement when there is no machine picker, while retaining responsive placement for the multi-machine picker. Focus, accessibility, refresh behavior, desktop layout, and the multi-machine compact layout are unchanged.

## How you verified

- Added assertions covering inline one-machine placement and responsive multi-machine placement; the new one-machine assertion fails before the fix and passes afterward.
- `pnpm exec turbo run test --filter=@bb/app --force -- src/components/settings/UsageLimitsSettingsSection.test.tsx src/components/settings/VoiceInputSettingsSection.test.tsx src/components/settings/UpdatesSettingsSection.test.tsx` — 41 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/app --force` — passed.
- Targeted `oxfmt --check` and `git diff --check origin/main...HEAD` — passed.
- Verified the 390px and 1280px layouts in the browser, including keyboard focus, the accessible refresh name, and refresh requests.

Follow-up to #3076.

> AGENT GENERATED
