### PR TITLE
Add @aivanov93 to contributor allow list

### DIFF
--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -63,3 +63,4 @@ alanagoyal
 IlyaM
 swairshah
 danielbachhuber
+aivanov93


### PR DESCRIPTION
## Human comments

## What was wrong

GitHub user `aivanov93` was not in the persistent contributor allow list, so the PR approval gate would not treat contributions from their fork as approved.

## What changed

Added `aivanov93` to `.github/APPROVED_CONTRIBUTORS`. This is a policy-only change with no host daemon wire, CLI, guide, or documentation impact.

## How you verified

- Confirmed the GitHub account exists (`gh api users/aivanov93` returns login aivanov93).
- Ran `git diff --check`.
- Checked the contributor list for case-insensitive duplicates.

> AGENT GENERATED