### PR TITLE
feat(sidebar): add progressive disclosure to threads lists instead of showing all threads

### DIFF
--- a/apps/app/src/components/layout/AppLayout.plugin-panel-header.test.tsx
+++ b/apps/app/src/components/layout/AppLayout.plugin-panel-header.test.tsx
@@ -28,6 +28,7 @@ vi.mock("@/hooks/queries/system-queries", () => ({
         changelogPreview: false,
         editMessages: false,
         mobileApp: false,
+        sidebarProgressiveDisclosure: false,
         timelineWindowing: false,
       },
     },

--- a/apps/app/src/components/layout/AppLayout.root-compose-project.test.tsx
+++ b/apps/app/src/components/layout/AppLayout.root-compose-project.test.tsx
@@ -36,6 +36,7 @@ vi.mock("@/hooks/queries/system-queries", () => ({
         changelogPreview: false,
         editMessages: false,
         mobileApp: false,
+        sidebarProgressiveDisclosure: false,
         timelineWindowing: false,
       },
     },

--- a/apps/app/src/components/sidebar/ProjectList.modes.test.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.modes.test.tsx
@@ -40,6 +40,10 @@ vi.mock("@/hooks/queries/host-queries", () => ({
   usePrimaryHost: vi.fn(() => undefined),
 }));
 
+vi.mock("@/hooks/queries/system-queries", () => ({
+  useSystemConfig: () => ({ data: undefined }),
+}));
+
 vi.mock("@bb/client-core", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@bb/client-core")>();
   return {

--- a/apps/app/src/components/sidebar/ProjectList.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.tsx
@@ -27,6 +27,7 @@ import {
 import { isTransientReadError } from "@/hooks/queries/query-helpers";
 import { stripProjectThreads } from "@/hooks/queries/project-queries";
 import { useSidebarNavigation } from "@/hooks/queries/sidebar-navigation-query";
+import { useSystemConfig } from "@/hooks/queries/system-queries";
 import { useReorderPinnedThread } from "@/hooks/mutations/thread-state-mutations";
 import {
   useCreateThreadSection,
@@ -899,6 +900,12 @@ export function ActiveSidebarModeSections({
   return renderProject();
 }
 
+function useSidebarProgressiveDisclosureEnabled(): boolean {
+  return (
+    useSystemConfig().data?.experiments.sidebarProgressiveDisclosure ?? false
+  );
+}
+
 interface ProjectModeSectionsProps extends BuiltInSectionRenderState {
   collapsedEnvironmentIds: Set<string>;
   collapsedThreadIds: Set<string>;
@@ -943,6 +950,8 @@ function ProjectModeSections({
   threads,
   threadsSection,
 }: ProjectModeSectionsProps) {
+  const progressiveDisclosureEnabled =
+    useSidebarProgressiveDisclosureEnabled();
   const [collapsedProjectIdList, setCollapsedProjectIdList] = useAtom(
     collapsedProjectIdsAtom,
   );
@@ -1063,6 +1072,7 @@ function ProjectModeSections({
             status,
             threads: personalThreads,
           })}
+          progressiveDisclosureEnabled={progressiveDisclosureEnabled}
           selectedThreadId={selectedThreadId}
           collapsedThreadIds={collapsedThreadIds}
           collapsedEnvironmentIds={collapsedEnvironmentIds}
@@ -1101,6 +1111,7 @@ function ProjectModeSections({
             sortableId={sectionId}
             project={row.project}
             threadListState={row.threadListState}
+            progressiveDisclosureEnabled={progressiveDisclosureEnabled}
             selectedThreadId={selectedThreadId}
             isActive={row.isActive}
             isCollapsed={collapsedProjectIds.has(row.project.id)}
@@ -1271,6 +1282,8 @@ export function MachineModeSections({
   threads,
   threadsSection,
 }: MachineModeSectionsProps) {
+  const progressiveDisclosureEnabled =
+    useSidebarProgressiveDisclosureEnabled();
   const { data: hosts } = useHosts();
   const [collapsedMachineKeyList, setCollapsedMachineKeyList] = useAtom(
     sidebarCollapsedMachinesAtom,
@@ -1347,6 +1360,7 @@ export function MachineModeSections({
       content: (
         <ProjectThreadTree
           threadListState={allThreadsListState}
+          progressiveDisclosureEnabled={progressiveDisclosureEnabled}
           compareThreads={compareThreads}
           variant="section"
           selectedThreadId={selectedThreadId}
@@ -1398,6 +1412,7 @@ export function MachineModeSections({
           >
             <ProjectThreadTree
               threadListState={section.threadListState}
+              progressiveDisclosureEnabled={progressiveDisclosureEnabled}
               compareThreads={compareThreads}
               variant="section"
               selectedThreadId={selectedThreadId}

--- a/apps/app/src/components/sidebar/ProjectListProjects.tsx
+++ b/apps/app/src/components/sidebar/ProjectListProjects.tsx
@@ -36,6 +36,7 @@ interface ProjectListReorderBindings {
 interface ProjectListProjectsProps {
   status: ConnectionAwareQueryStatus;
   rows: ProjectListRowModel[];
+  progressiveDisclosureEnabled: boolean;
   selectedThreadId?: string;
   collapsedProjectIds: Set<string>;
   collapsedThreadIds: Set<string>;
@@ -79,6 +80,7 @@ export const SortableProjectRow = memo(function SortableProjectRow({
 export function ProjectListProjects({
   status,
   rows,
+  progressiveDisclosureEnabled,
   selectedThreadId,
   collapsedProjectIds,
   collapsedThreadIds,
@@ -94,6 +96,7 @@ export function ProjectListProjects({
   const sharedRowProps = (row: ProjectListRowModel) => ({
     project: row.project,
     threadListState: row.threadListState,
+    progressiveDisclosureEnabled,
     selectedThreadId,
     isActive: row.isActive,
     isCollapsed: collapsedProjectIds.has(row.project.id),

--- a/apps/app/src/components/sidebar/ProjectRow.interactions.test.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.interactions.test.tsx
@@ -533,13 +533,10 @@ describe("ProjectRow interactions", () => {
     fireEvent.click(screen.getByRole("button", { name: "Show more" }));
     expect(screen.getByText("Cap thread 5")).not.toBeNull();
     expect(screen.getByText("Cap thread 6")).not.toBeNull();
-    expect(
-      screen
-        .getByRole("button", { name: "Show less" })
-        .getAttribute("aria-expanded"),
-    ).toBe("true");
+    expect(screen.queryByRole("button", { name: "Show more" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Collapse" })).not.toBeNull();
 
-    fireEvent.click(screen.getByRole("button", { name: "Show less" }));
+    fireEvent.click(screen.getByRole("button", { name: "Collapse" }));
     expect(screen.queryByText("Cap thread 5")).toBeNull();
     expect(screen.getByText("Cap thread 6")).not.toBeNull();
     expect(screen.getByText("Cap thread 7")).not.toBeNull();

--- a/apps/app/src/components/sidebar/ProjectRow.interactions.test.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.interactions.test.tsx
@@ -93,6 +93,7 @@ function renderProjectRow(
   isActive = false,
   collapsedEnvironmentIds: Set<string> = new Set(),
   isCollapsed = false,
+  selectedThreadId?: string,
 ) {
   const onToggleEnvironmentCollapsed = vi.fn();
   const result = render(
@@ -101,6 +102,7 @@ function renderProjectRow(
         <ProjectRow
           project={makeProjectResponse()}
           threadListState={threadListState}
+          selectedThreadId={selectedThreadId}
           isActive={isActive}
           isCollapsed={isCollapsed}
           compareThreads={() => 0}
@@ -495,5 +497,56 @@ describe("ProjectRow interactions", () => {
         screen.queryByRole("menuitem", { name: "Rename worktree" }),
       ).toBeNull();
     });
+  });
+
+  it("keeps ongoing and selected project items visible when collapsed", () => {
+    const threads = Array.from({ length: 8 }, (_, index) => {
+      const thread = makeThread({
+        id: `thr_cap_${index}`,
+        title: `Cap thread ${index}`,
+        titleFallback: `Cap thread ${index}`,
+        createdAt: index,
+        updatedAt: index,
+      });
+      return index === 6
+        ? {
+            ...thread,
+            activity: { ...thread.activity, activeBackgroundAgentCount: 1 },
+          }
+        : thread;
+    });
+    renderProjectRow(
+      vi.fn(),
+      { status: "ready", threads },
+      false,
+      new Set(),
+      false,
+      "thr_cap_7",
+    );
+
+    expect(screen.getByText("Cap thread 0")).not.toBeNull();
+    expect(screen.getByText("Cap thread 4")).not.toBeNull();
+    expect(screen.queryByText("Cap thread 5")).toBeNull();
+    expect(screen.getByText("Cap thread 6")).not.toBeNull();
+    expect(screen.getByText("Cap thread 7")).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Show more" }));
+    expect(screen.getByText("Cap thread 5")).not.toBeNull();
+    expect(screen.getByText("Cap thread 6")).not.toBeNull();
+    expect(
+      screen
+        .getByRole("button", { name: "Show less" })
+        .getAttribute("aria-expanded"),
+    ).toBe("true");
+
+    fireEvent.click(screen.getByRole("button", { name: "Show less" }));
+    expect(screen.queryByText("Cap thread 5")).toBeNull();
+    expect(screen.getByText("Cap thread 6")).not.toBeNull();
+    expect(screen.getByText("Cap thread 7")).not.toBeNull();
+    expect(
+      screen
+        .getByRole("button", { name: "Show more" })
+        .getAttribute("aria-expanded"),
+    ).toBe("false");
   });
 });

--- a/apps/app/src/components/sidebar/ProjectRow.interactions.test.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.interactions.test.tsx
@@ -30,6 +30,12 @@ const mockDraftThreadIds = vi.hoisted(() => ({
   current: new Set<string>(),
 }));
 
+vi.mock("@/hooks/queries/system-queries", () => ({
+  useSystemConfig: () => ({
+    data: { experiments: { sidebarProgressiveDisclosure: true } },
+  }),
+}));
+
 vi.mock("@/hooks/useLocalPathPicker", () => ({
   usePathPickerHost: () => ({ hostId: null, hostName: null }),
 }));
@@ -102,10 +108,10 @@ function renderProjectRow(
         <ProjectRow
           project={makeProjectResponse()}
           threadListState={threadListState}
-          selectedThreadId={selectedThreadId}
           isActive={isActive}
           isCollapsed={isCollapsed}
           compareThreads={() => 0}
+          selectedThreadId={selectedThreadId}
           collapsedThreadIds={new Set()}
           collapsedEnvironmentIds={collapsedEnvironmentIds}
           isLocalPathInvalid={false}
@@ -534,16 +540,6 @@ describe("ProjectRow interactions", () => {
     expect(screen.getByText("Cap thread 5")).not.toBeNull();
     expect(screen.getByText("Cap thread 6")).not.toBeNull();
     expect(screen.queryByRole("button", { name: "Show more" })).toBeNull();
-    expect(screen.getByRole("button", { name: "Collapse" })).not.toBeNull();
-
-    fireEvent.click(screen.getByRole("button", { name: "Collapse" }));
-    expect(screen.queryByText("Cap thread 5")).toBeNull();
-    expect(screen.getByText("Cap thread 6")).not.toBeNull();
-    expect(screen.getByText("Cap thread 7")).not.toBeNull();
-    expect(
-      screen
-        .getByRole("button", { name: "Show more" })
-        .getAttribute("aria-expanded"),
-    ).toBe("false");
+    expect(screen.queryByRole("button", { name: "Collapse" })).toBeNull();
   });
 });

--- a/apps/app/src/components/sidebar/ProjectRow.interactions.test.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.interactions.test.tsx
@@ -30,12 +30,6 @@ const mockDraftThreadIds = vi.hoisted(() => ({
   current: new Set<string>(),
 }));
 
-vi.mock("@/hooks/queries/system-queries", () => ({
-  useSystemConfig: () => ({
-    data: { experiments: { sidebarProgressiveDisclosure: true } },
-  }),
-}));
-
 vi.mock("@/hooks/useLocalPathPicker", () => ({
   usePathPickerHost: () => ({ hostId: null, hostName: null }),
 }));
@@ -99,7 +93,6 @@ function renderProjectRow(
   isActive = false,
   collapsedEnvironmentIds: Set<string> = new Set(),
   isCollapsed = false,
-  selectedThreadId?: string,
 ) {
   const onToggleEnvironmentCollapsed = vi.fn();
   const result = render(
@@ -111,7 +104,7 @@ function renderProjectRow(
           isActive={isActive}
           isCollapsed={isCollapsed}
           compareThreads={() => 0}
-          selectedThreadId={selectedThreadId}
+          progressiveDisclosureEnabled
           collapsedThreadIds={new Set()}
           collapsedEnvironmentIds={collapsedEnvironmentIds}
           isLocalPathInvalid={false}
@@ -503,43 +496,5 @@ describe("ProjectRow interactions", () => {
         screen.queryByRole("menuitem", { name: "Rename worktree" }),
       ).toBeNull();
     });
-  });
-
-  it("keeps ongoing and selected project items visible when collapsed", () => {
-    const threads = Array.from({ length: 8 }, (_, index) => {
-      const thread = makeThread({
-        id: `thr_cap_${index}`,
-        title: `Cap thread ${index}`,
-        titleFallback: `Cap thread ${index}`,
-        createdAt: index,
-        updatedAt: index,
-      });
-      return index === 6
-        ? {
-            ...thread,
-            activity: { ...thread.activity, activeBackgroundAgentCount: 1 },
-          }
-        : thread;
-    });
-    renderProjectRow(
-      vi.fn(),
-      { status: "ready", threads },
-      false,
-      new Set(),
-      false,
-      "thr_cap_7",
-    );
-
-    expect(screen.getByText("Cap thread 0")).not.toBeNull();
-    expect(screen.getByText("Cap thread 4")).not.toBeNull();
-    expect(screen.queryByText("Cap thread 5")).toBeNull();
-    expect(screen.getByText("Cap thread 6")).not.toBeNull();
-    expect(screen.getByText("Cap thread 7")).not.toBeNull();
-
-    fireEvent.click(screen.getByRole("button", { name: "Show more" }));
-    expect(screen.getByText("Cap thread 5")).not.toBeNull();
-    expect(screen.getByText("Cap thread 6")).not.toBeNull();
-    expect(screen.queryByRole("button", { name: "Show more" })).toBeNull();
-    expect(screen.queryByRole("button", { name: "Collapse" })).toBeNull();
   });
 });

--- a/apps/app/src/components/sidebar/ProjectRow.stories.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.stories.tsx
@@ -114,6 +114,7 @@ function InteractiveProjectList({
     <ProjectListProjects
       status="ready"
       rows={resolvedRows}
+      progressiveDisclosureEnabled
       collapsedProjectIds={collapsedProjectIds}
       collapsedThreadIds={collapsedThreadIds}
       collapsedEnvironmentIds={collapsedEnvironmentIds}

--- a/apps/app/src/components/sidebar/ProjectRow.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.tsx
@@ -54,6 +54,7 @@ import {
   COARSE_POINTER_GLYPH_BOX_CLASS,
   COARSE_POINTER_ICON_SIZE_CLASS,
   COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
+  COARSE_POINTER_TEXT_SM_CLASS,
 } from "@bb/shared-ui/coarse-pointer-sizing";
 import {
   SIDEBAR_HOVER_ACTIONS_CLASS,
@@ -64,6 +65,8 @@ import {
 } from "@/components/ui/sidebar-hover-actions.js";
 import {
   getCollapsedChildActivity,
+  isBusyThread,
+  isUnreadDoneThread,
   NO_COLLAPSED_CHILD_ACTIVITY,
   type CollapsedChildActivity,
 } from "@bb/client-core";
@@ -1850,11 +1853,30 @@ export const ProjectThreadTree = memo(function ProjectThreadTree({
       ? threadListState.threads
       : EMPTY_PROJECT_THREADS;
   const draftThreadIds = usePromptDraftInputThreadIds(projectThreads);
-  const rootItems = useMemo(
+  const [isExpanded, setIsExpanded] = useState(false);
+  const allRootItems = useMemo(
     () =>
       buildProjectThreadGroups(projectThreads, compareThreads, draftThreadIds),
     [compareThreads, draftThreadIds, projectThreads],
   );
+  const limitedRootItems = useMemo(() => {
+    if (allRootItems.length <= 5) {
+      return allRootItems;
+    }
+
+    const extraItems = allRootItems.slice(5).filter((item) => {
+      const descendants = getProjectThreadItemDescendants([item]);
+      return (
+        descendants.some(isBusyThread) ||
+        descendants.some(isUnreadDoneThread) ||
+        (selectedThreadId !== undefined &&
+          projectThreadItemContainsThread(item, selectedThreadId))
+      );
+    });
+    return [...allRootItems.slice(0, 5), ...extraItems];
+  }, [allRootItems, selectedThreadId]);
+  const rootItems = isExpanded ? allRootItems : limitedRootItems;
+  const hasAdditionalItems = limitedRootItems.length < allRootItems.length;
 
   if (threadListState.status === "loading") {
     return <ThreadTreeLoadingSkeleton />;
@@ -1887,19 +1909,36 @@ export const ProjectThreadTree = memo(function ProjectThreadTree({
   }
 
   return (
-    <SectionThreadTreeItems
-      items={rootItems}
-      sectionDnd={null}
-      variant={variant}
-      projectId={projectId}
-      sortableParentKey={projectId}
-      selectedThreadId={selectedThreadId}
-      collapsedThreadIds={collapsedThreadIds}
-      collapsedEnvironmentIds={collapsedEnvironmentIds}
-      onProjectSelect={onProjectSelect}
-      onToggleThreadCollapsed={onToggleThreadCollapsed}
-      onToggleEnvironmentCollapsed={onToggleEnvironmentCollapsed}
-    />
+    <>
+      <SectionThreadTreeItems
+        items={rootItems}
+        sectionDnd={null}
+        variant={variant}
+        projectId={projectId}
+        sortableParentKey={projectId}
+        selectedThreadId={selectedThreadId}
+        collapsedThreadIds={collapsedThreadIds}
+        collapsedEnvironmentIds={collapsedEnvironmentIds}
+        onProjectSelect={onProjectSelect}
+        onToggleThreadCollapsed={onToggleThreadCollapsed}
+        onToggleEnvironmentCollapsed={onToggleEnvironmentCollapsed}
+      />
+      {hasAdditionalItems ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          aria-expanded={isExpanded}
+          onClick={() => setIsExpanded((expanded) => !expanded)}
+          className={cn(
+            "mt-0.5 w-full justify-start px-2 text-subtle-foreground",
+            COARSE_POINTER_TEXT_SM_CLASS,
+          )}
+        >
+          {isExpanded ? "Show less" : "Show more"}
+        </Button>
+      ) : null}
+    </>
   );
 });
 

--- a/apps/app/src/components/sidebar/ProjectRow.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.tsx
@@ -18,7 +18,6 @@ import { PERSONAL_PROJECT_ID, type ThreadListEntry } from "@bb/domain";
 import type { ProjectResponse } from "@bb/server-contract";
 import { NavLink } from "react-router-dom";
 import { useCreateThreadInWorktree } from "@/hooks/useCreateThreadInWorktree";
-import { useSystemConfig } from "@/hooks/queries/system-queries";
 import {
   usePromptDraftHasInput,
   usePromptDraftInputThreadIds,
@@ -157,6 +156,7 @@ export type ProjectThreadListState =
 export interface ProjectRowProps {
   project: ProjectResponse;
   threadListState: ProjectThreadListState;
+  progressiveDisclosureEnabled: boolean;
   selectedThreadId?: string;
   isActive: boolean;
   isCollapsed: boolean;
@@ -180,6 +180,7 @@ export interface ProjectRowProps {
 interface ProjectThreadTreeProps {
   projectId?: string;
   threadListState: ProjectThreadListState;
+  progressiveDisclosureEnabled: boolean;
   compareThreads: ThreadComparator;
   selectedThreadId?: string;
   collapsedThreadIds: Set<string>;
@@ -1856,6 +1857,7 @@ function isAttentionProjectThreadItem(
 export const ProjectThreadTree = memo(function ProjectThreadTree({
   projectId,
   threadListState,
+  progressiveDisclosureEnabled,
   compareThreads,
   selectedThreadId,
   collapsedThreadIds,
@@ -1865,9 +1867,6 @@ export const ProjectThreadTree = memo(function ProjectThreadTree({
   onToggleThreadCollapsed,
   onToggleEnvironmentCollapsed,
 }: ProjectThreadTreeProps) {
-  const systemConfigQuery = useSystemConfig();
-  const progressiveDisclosureEnabled =
-    systemConfigQuery.data?.experiments.sidebarProgressiveDisclosure ?? false;
   const projectThreads =
     threadListState.status === "ready"
       ? threadListState.threads
@@ -2261,6 +2260,7 @@ export const ChronologicalSectionThreadSections = memo(
 function ProjectRowComponent({
   project,
   threadListState,
+  progressiveDisclosureEnabled,
   selectedThreadId,
   isCollapsed,
   compareThreads,
@@ -2408,6 +2408,7 @@ function ProjectRowComponent({
           <ProjectThreadTree
             projectId={project.id}
             threadListState={threadListState}
+            progressiveDisclosureEnabled={progressiveDisclosureEnabled}
             selectedThreadId={selectedThreadId}
             collapsedThreadIds={collapsedThreadIds}
             collapsedEnvironmentIds={collapsedEnvironmentIds}
@@ -2501,6 +2502,7 @@ function areProjectRowPropsEqual(
   if (
     prev.project !== next.project ||
     prev.threadListState !== next.threadListState ||
+    prev.progressiveDisclosureEnabled !== next.progressiveDisclosureEnabled ||
     prev.isActive !== next.isActive ||
     prev.isCollapsed !== next.isCollapsed ||
     prev.compareThreads !== next.compareThreads ||

--- a/apps/app/src/components/sidebar/ProjectRow.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.tsx
@@ -1836,6 +1836,22 @@ function SectionThreadTreeItems({
   );
 }
 
+const THREAD_ITEMS_ATTENTION_LIMIT = 5;
+const THREAD_ITEMS_EXPAND_SIZE = 10;
+
+function isAttentionProjectThreadItem(
+  item: ProjectThreadItem,
+  selectedThreadId: string | undefined,
+): boolean {
+  const descendants = getProjectThreadItemDescendants([item]);
+  return (
+    descendants.some(isBusyThread) ||
+    descendants.some(isUnreadDoneThread) ||
+    (selectedThreadId !== undefined &&
+      projectThreadItemContainsThread(item, selectedThreadId))
+  );
+}
+
 export const ProjectThreadTree = memo(function ProjectThreadTree({
   projectId,
   threadListState,
@@ -1853,30 +1869,34 @@ export const ProjectThreadTree = memo(function ProjectThreadTree({
       ? threadListState.threads
       : EMPTY_PROJECT_THREADS;
   const draftThreadIds = usePromptDraftInputThreadIds(projectThreads);
-  const [isExpanded, setIsExpanded] = useState(false);
+  const [extraVisibleCount, setExtraVisibleCount] = useState(0);
   const allRootItems = useMemo(
     () =>
       buildProjectThreadGroups(projectThreads, compareThreads, draftThreadIds),
     [compareThreads, draftThreadIds, projectThreads],
   );
-  const limitedRootItems = useMemo(() => {
-    if (allRootItems.length <= 5) {
-      return allRootItems;
-    }
-
-    const extraItems = allRootItems.slice(5).filter((item) => {
-      const descendants = getProjectThreadItemDescendants([item]);
-      return (
-        descendants.some(isBusyThread) ||
-        descendants.some(isUnreadDoneThread) ||
-        (selectedThreadId !== undefined &&
-          projectThreadItemContainsThread(item, selectedThreadId))
-      );
+  const { items: rootItems, hasHiddenItems: hasMoreItems } = useMemo(() => {
+    const items: ProjectThreadItem[] = [];
+    let extraSlots = extraVisibleCount;
+    let hasHiddenItems = false;
+    allRootItems.forEach((item, index) => {
+      if (index < THREAD_ITEMS_ATTENTION_LIMIT) {
+        items.push(item);
+        return;
+      }
+      const isAttention = isAttentionProjectThreadItem(item, selectedThreadId);
+      if (isAttention || extraSlots > 0) {
+        items.push(item);
+        if (!isAttention) {
+          extraSlots -= 1;
+        }
+        return;
+      }
+      hasHiddenItems = true;
     });
-    return [...allRootItems.slice(0, 5), ...extraItems];
-  }, [allRootItems, selectedThreadId]);
-  const rootItems = isExpanded ? allRootItems : limitedRootItems;
-  const hasAdditionalItems = limitedRootItems.length < allRootItems.length;
+    return { items, hasHiddenItems };
+  }, [allRootItems, selectedThreadId, extraVisibleCount]);
+  const isExpanded = extraVisibleCount > 0;
 
   if (threadListState.status === "loading") {
     return <ThreadTreeLoadingSkeleton />;
@@ -1923,20 +1943,44 @@ export const ProjectThreadTree = memo(function ProjectThreadTree({
         onToggleThreadCollapsed={onToggleThreadCollapsed}
         onToggleEnvironmentCollapsed={onToggleEnvironmentCollapsed}
       />
-      {hasAdditionalItems ? (
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          aria-expanded={isExpanded}
-          onClick={() => setIsExpanded((expanded) => !expanded)}
-          className={cn(
-            "mt-0.5 w-full justify-start px-2 text-subtle-foreground",
-            COARSE_POINTER_TEXT_SM_CLASS,
-          )}
-        >
-          {isExpanded ? "Show less" : "Show more"}
-        </Button>
+      {(hasMoreItems || isExpanded) ? (
+        <div className="mt-0.5 flex items-center justify-between">
+          {hasMoreItems ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              aria-expanded={isExpanded}
+              onClick={() =>
+                setExtraVisibleCount(
+                  (count) => count + THREAD_ITEMS_EXPAND_SIZE,
+                )
+              }
+              className={cn(
+                "justify-start px-2 text-subtle-foreground",
+                COARSE_POINTER_TEXT_SM_CLASS,
+              )}
+            >
+              <Icon name="ChevronDown" />
+              Show more
+            </Button>
+          ) : null}
+          {isExpanded ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => setExtraVisibleCount(0)}
+              className={cn(
+                "ml-auto justify-start px-2 text-subtle-foreground",
+                COARSE_POINTER_TEXT_SM_CLASS,
+              )}
+            >
+              <Icon name="ChevronUp" />
+              Collapse
+            </Button>
+          ) : null}
+        </div>
       ) : null}
     </>
   );

--- a/apps/app/src/components/sidebar/ProjectRow.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.tsx
@@ -18,6 +18,7 @@ import { PERSONAL_PROJECT_ID, type ThreadListEntry } from "@bb/domain";
 import type { ProjectResponse } from "@bb/server-contract";
 import { NavLink } from "react-router-dom";
 import { useCreateThreadInWorktree } from "@/hooks/useCreateThreadInWorktree";
+import { useSystemConfig } from "@/hooks/queries/system-queries";
 import {
   usePromptDraftHasInput,
   usePromptDraftInputThreadIds,
@@ -54,7 +55,7 @@ import {
   COARSE_POINTER_GLYPH_BOX_CLASS,
   COARSE_POINTER_ICON_SIZE_CLASS,
   COARSE_POINTER_ROW_ACTION_SIZE_CLASS,
-  COARSE_POINTER_TEXT_SM_CLASS,
+  COARSE_POINTER_ROW_HEIGHT_CLASS,
 } from "@bb/shared-ui/coarse-pointer-sizing";
 import {
   SIDEBAR_HOVER_ACTIONS_CLASS,
@@ -1843,12 +1844,12 @@ function isAttentionProjectThreadItem(
   item: ProjectThreadItem,
   selectedThreadId: string | undefined,
 ): boolean {
-  const descendants = getProjectThreadItemDescendants([item]);
-  return (
-    descendants.some(isBusyThread) ||
-    descendants.some(isUnreadDoneThread) ||
-    (selectedThreadId !== undefined &&
-      projectThreadItemContainsThread(item, selectedThreadId))
+  return getProjectThreadItemDescendants([item]).some(
+    (thread) =>
+      thread.hasPendingInteraction ||
+      isBusyThread(thread) ||
+      isUnreadDoneThread(thread) ||
+      thread.id === selectedThreadId,
   );
 }
 
@@ -1864,6 +1865,9 @@ export const ProjectThreadTree = memo(function ProjectThreadTree({
   onToggleThreadCollapsed,
   onToggleEnvironmentCollapsed,
 }: ProjectThreadTreeProps) {
+  const systemConfigQuery = useSystemConfig();
+  const progressiveDisclosureEnabled =
+    systemConfigQuery.data?.experiments.sidebarProgressiveDisclosure ?? false;
   const projectThreads =
     threadListState.status === "ready"
       ? threadListState.threads
@@ -1875,28 +1879,25 @@ export const ProjectThreadTree = memo(function ProjectThreadTree({
       buildProjectThreadGroups(projectThreads, compareThreads, draftThreadIds),
     [compareThreads, draftThreadIds, projectThreads],
   );
-  const { items: rootItems, hasHiddenItems: hasMoreItems } = useMemo(() => {
-    const items: ProjectThreadItem[] = [];
+  const rootItems = useMemo(() => {
+    if (!progressiveDisclosureEnabled) {
+      return allRootItems;
+    }
     let extraSlots = extraVisibleCount;
-    let hasHiddenItems = false;
-    allRootItems.forEach((item, index) => {
-      if (index < THREAD_ITEMS_ATTENTION_LIMIT) {
-        items.push(item);
-        return;
-      }
-      const isAttention = isAttentionProjectThreadItem(item, selectedThreadId);
-      if (isAttention || extraSlots > 0) {
-        items.push(item);
-        if (!isAttention) {
-          extraSlots -= 1;
-        }
-        return;
-      }
-      hasHiddenItems = true;
+    return allRootItems.filter((item, index) => {
+      if (index < THREAD_ITEMS_ATTENTION_LIMIT) return true;
+      if (isAttentionProjectThreadItem(item, selectedThreadId)) return true;
+      if (extraSlots === 0) return false;
+      extraSlots -= 1;
+      return true;
     });
-    return { items, hasHiddenItems };
-  }, [allRootItems, selectedThreadId, extraVisibleCount]);
-  const isExpanded = extraVisibleCount > 0;
+  }, [
+    allRootItems,
+    selectedThreadId,
+    extraVisibleCount,
+    progressiveDisclosureEnabled,
+  ]);
+  const hasMoreItems = rootItems.length < allRootItems.length;
 
   if (threadListState.status === "loading") {
     return <ThreadTreeLoadingSkeleton />;
@@ -1943,44 +1944,22 @@ export const ProjectThreadTree = memo(function ProjectThreadTree({
         onToggleThreadCollapsed={onToggleThreadCollapsed}
         onToggleEnvironmentCollapsed={onToggleEnvironmentCollapsed}
       />
-      {(hasMoreItems || isExpanded) ? (
-        <div className="mt-0.5 flex items-center justify-between">
-          {hasMoreItems ? (
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              aria-expanded={isExpanded}
-              onClick={() =>
-                setExtraVisibleCount(
-                  (count) => count + THREAD_ITEMS_EXPAND_SIZE,
-                )
-              }
-              className={cn(
-                "justify-start px-2 text-subtle-foreground",
-                COARSE_POINTER_TEXT_SM_CLASS,
-              )}
-            >
-              <Icon name="ChevronDown" />
-              Show more
-            </Button>
-          ) : null}
-          {isExpanded ? (
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              onClick={() => setExtraVisibleCount(0)}
-              className={cn(
-                "ml-auto justify-start px-2 text-subtle-foreground",
-                COARSE_POINTER_TEXT_SM_CLASS,
-              )}
-            >
-              <Icon name="ChevronUp" />
-              Collapse
-            </Button>
-          ) : null}
-        </div>
+      {hasMoreItems ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() =>
+            setExtraVisibleCount((count) => count + THREAD_ITEMS_EXPAND_SIZE)
+          }
+          className={cn(
+            "mt-0.5 w-full justify-start px-2 font-normal text-subtle-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+            COARSE_POINTER_ROW_HEIGHT_CLASS,
+          )}
+        >
+          <Icon name="ChevronDown" />
+          Show more
+        </Button>
       ) : null}
     </>
   );

--- a/apps/app/src/components/sidebar/ProjectThreadTree.disclosure.test.tsx
+++ b/apps/app/src/components/sidebar/ProjectThreadTree.disclosure.test.tsx
@@ -1,0 +1,151 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ThreadListEntry } from "@bb/domain";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { ProjectThreadTree } from "./ProjectRow";
+import { makeThreadListEntry } from "@/test/fixtures/thread-list-entries";
+
+vi.mock("@/hooks/useThreadSplitsEnabled", () => ({
+  useThreadSplitsEnabled: () => false,
+}));
+
+vi.mock("@/hooks/usePromptDraftStorage", () => ({
+  usePromptDraftHasInput: () => false,
+  usePromptDraftInputThreadIds: () => new Set(),
+}));
+
+function makePlainThreads(count: number): ThreadListEntry[] {
+  return Array.from({ length: count }, (_, index) =>
+    makeThreadListEntry({
+      id: `thr_item_${index}`,
+      title: `Thread ${index}`,
+      titleFallback: `Thread ${index}`,
+      createdAt: index,
+      updatedAt: index,
+    }),
+  );
+}
+
+function renderThreadTree(
+  threads: ThreadListEntry[],
+  selectedThreadId?: string,
+) {
+  return render(
+    <MemoryRouter>
+      <ProjectThreadTree
+        threadListState={{ status: "ready", threads }}
+        compareThreads={() => 0}
+        selectedThreadId={selectedThreadId}
+        collapsedThreadIds={new Set()}
+        collapsedEnvironmentIds={new Set()}
+        variant="section"
+        onToggleThreadCollapsed={vi.fn()}
+        onToggleEnvironmentCollapsed={vi.fn()}
+      />
+    </MemoryRouter>,
+  );
+}
+
+describe("ProjectThreadTree progressive disclosure", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("renders every item without controls when the list fits the attention limit", () => {
+    renderThreadTree(makePlainThreads(5));
+
+    expect(screen.getByText("Thread 0")).not.toBeNull();
+    expect(screen.getByText("Thread 4")).not.toBeNull();
+    expect(screen.queryByRole("button", { name: "Show more" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Collapse" })).toBeNull();
+  });
+
+  it("keeps busy threads visible beyond the attention limit", () => {
+    const threads = makePlainThreads(7);
+    threads[6] = {
+      ...threads[6],
+      activity: { ...threads[6].activity, activeBackgroundAgentCount: 1 },
+    };
+    renderThreadTree(threads);
+
+    expect(screen.getByText("Thread 4")).not.toBeNull();
+    expect(screen.queryByText("Thread 5")).toBeNull();
+    expect(screen.getByText("Thread 6")).not.toBeNull();
+  });
+
+  it("keeps unread finished threads visible beyond the attention limit", () => {
+    const threads = makePlainThreads(7);
+    threads[6] = {
+      ...threads[6],
+      lastReadAt: 100,
+      latestAttentionAt: 200,
+    };
+    renderThreadTree(threads);
+
+    expect(screen.getByText("Thread 4")).not.toBeNull();
+    expect(screen.queryByText("Thread 5")).toBeNull();
+    expect(screen.getByText("Thread 6")).not.toBeNull();
+  });
+
+  it("keeps the selected thread visible beyond the attention limit", () => {
+    renderThreadTree(makePlainThreads(7), "thr_item_6");
+
+    expect(screen.getByText("Thread 4")).not.toBeNull();
+    expect(screen.queryByText("Thread 5")).toBeNull();
+    expect(screen.getByText("Thread 6")).not.toBeNull();
+  });
+
+  it("reveals ten more items per Show more click and hides the button when exhausted", () => {
+    renderThreadTree(makePlainThreads(17));
+
+    expect(screen.getByText("Thread 4")).not.toBeNull();
+    expect(screen.queryByText("Thread 5")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Collapse" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Show more" }));
+    expect(screen.getByText("Thread 14")).not.toBeNull();
+    expect(screen.queryByText("Thread 15")).toBeNull();
+    expect(screen.getByRole("button", { name: "Show more" })).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Collapse" })).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Show more" }));
+    expect(screen.getByText("Thread 16")).not.toBeNull();
+    expect(screen.queryByRole("button", { name: "Show more" })).toBeNull();
+  });
+
+  it("does not spend Show more slots on attention items", () => {
+    const threads = makePlainThreads(18);
+    for (let index = 5; index <= 14; index += 1) {
+      threads[index] = {
+        ...threads[index],
+        lastReadAt: 100,
+        latestAttentionAt: 200,
+      };
+    }
+    renderThreadTree(threads);
+
+    expect(screen.getByText("Thread 14")).not.toBeNull();
+    expect(screen.queryByText("Thread 15")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Show more" }));
+    expect(screen.getByText("Thread 15")).not.toBeNull();
+    expect(screen.getByText("Thread 17")).not.toBeNull();
+    expect(screen.queryByRole("button", { name: "Show more" })).toBeNull();
+  });
+
+  it("collapses back to the attention set", () => {
+    renderThreadTree(makePlainThreads(17));
+
+    fireEvent.click(screen.getByRole("button", { name: "Show more" }));
+    expect(screen.getByText("Thread 14")).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Collapse" }));
+    expect(screen.getByText("Thread 4")).not.toBeNull();
+    expect(screen.queryByText("Thread 5")).toBeNull();
+    expect(screen.getByRole("button", { name: "Show more" })).not.toBeNull();
+    expect(screen.queryByRole("button", { name: "Collapse" })).toBeNull();
+  });
+});

--- a/apps/app/src/components/sidebar/ProjectThreadTree.disclosure.test.tsx
+++ b/apps/app/src/components/sidebar/ProjectThreadTree.disclosure.test.tsx
@@ -8,10 +8,6 @@ import { TooltipProvider } from "@bb/shared-ui/tooltip";
 import { ProjectThreadTree } from "./ProjectRow";
 import { makeThreadListEntry } from "@bb/test-helpers/domain-fixtures";
 
-const mockExperiments = vi.hoisted(() => ({
-  sidebarProgressiveDisclosure: true,
-}));
-
 vi.mock("@/hooks/useThreadSplitsEnabled", () => ({
   useThreadSplitsEnabled: () => false,
 }));
@@ -19,12 +15,6 @@ vi.mock("@/hooks/useThreadSplitsEnabled", () => ({
 vi.mock("@/hooks/usePromptDraftStorage", () => ({
   usePromptDraftHasInput: () => false,
   usePromptDraftInputThreadIds: () => new Set(),
-}));
-
-vi.mock("@/hooks/queries/system-queries", () => ({
-  useSystemConfig: () => ({
-    data: { experiments: mockExperiments },
-  }),
 }));
 
 vi.mock("@/components/thread/ThreadActionsProvider", () => ({
@@ -53,13 +43,20 @@ function makePlainThreads(count: number): ThreadListEntry[] {
 
 function renderThreadTree(
   threads: ThreadListEntry[],
-  selectedThreadId?: string,
+  {
+    progressiveDisclosureEnabled = true,
+    selectedThreadId,
+  }: {
+    progressiveDisclosureEnabled?: boolean;
+    selectedThreadId?: string;
+  } = {},
 ) {
   return render(
     <TooltipProvider>
       <MemoryRouter>
         <ProjectThreadTree
           threadListState={{ status: "ready", threads }}
+          progressiveDisclosureEnabled={progressiveDisclosureEnabled}
           compareThreads={() => 0}
           selectedThreadId={selectedThreadId}
           collapsedThreadIds={new Set()}
@@ -77,12 +74,12 @@ describe("ProjectThreadTree progressive disclosure", () => {
   afterEach(() => {
     cleanup();
     vi.clearAllMocks();
-    mockExperiments.sidebarProgressiveDisclosure = true;
   });
 
   it("renders the full list when the experiment is disabled", () => {
-    mockExperiments.sidebarProgressiveDisclosure = false;
-    renderThreadTree(makePlainThreads(7));
+    renderThreadTree(makePlainThreads(7), {
+      progressiveDisclosureEnabled: false,
+    });
 
     expect(screen.getByText("Thread 6")).not.toBeNull();
     expect(screen.queryByRole("button", { name: "Show more" })).toBeNull();
@@ -138,7 +135,7 @@ describe("ProjectThreadTree progressive disclosure", () => {
   });
 
   it("keeps the selected thread visible beyond the attention limit", () => {
-    renderThreadTree(makePlainThreads(7), "thr_item_6");
+    renderThreadTree(makePlainThreads(7), { selectedThreadId: "thr_item_6" });
 
     expect(screen.getByText("Thread 4")).not.toBeNull();
     expect(screen.queryByText("Thread 5")).toBeNull();
@@ -151,13 +148,6 @@ describe("ProjectThreadTree progressive disclosure", () => {
     expect(screen.getByText("Thread 4")).not.toBeNull();
     expect(screen.queryByText("Thread 5")).toBeNull();
     const showMoreButton = screen.getByRole("button", { name: "Show more" });
-    expect(showMoreButton.className).toContain("w-full");
-    expect(showMoreButton.className).toContain("text-subtle-foreground");
-    expect(showMoreButton.className).toContain("hover:bg-sidebar-accent");
-    expect(showMoreButton.className).toContain(
-      "hover:text-sidebar-accent-foreground",
-    );
-    expect(showMoreButton.className).toContain("h-[var(--bb-sidebar-row-height)]");
 
     fireEvent.click(showMoreButton);
     expect(screen.getByText("Thread 14")).not.toBeNull();

--- a/apps/app/src/components/sidebar/ProjectThreadTree.disclosure.test.tsx
+++ b/apps/app/src/components/sidebar/ProjectThreadTree.disclosure.test.tsx
@@ -4,8 +4,13 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { ThreadListEntry } from "@bb/domain";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
+import { TooltipProvider } from "@bb/shared-ui/tooltip";
 import { ProjectThreadTree } from "./ProjectRow";
-import { makeThreadListEntry } from "@/test/fixtures/thread-list-entries";
+import { makeThreadListEntry } from "@bb/test-helpers/domain-fixtures";
+
+const mockExperiments = vi.hoisted(() => ({
+  sidebarProgressiveDisclosure: true,
+}));
 
 vi.mock("@/hooks/useThreadSplitsEnabled", () => ({
   useThreadSplitsEnabled: () => false,
@@ -14,6 +19,24 @@ vi.mock("@/hooks/useThreadSplitsEnabled", () => ({
 vi.mock("@/hooks/usePromptDraftStorage", () => ({
   usePromptDraftHasInput: () => false,
   usePromptDraftInputThreadIds: () => new Set(),
+}));
+
+vi.mock("@/hooks/queries/system-queries", () => ({
+  useSystemConfig: () => ({
+    data: { experiments: mockExperiments },
+  }),
+}));
+
+vi.mock("@/components/thread/ThreadActionsProvider", () => ({
+  useThreadActions: () => ({
+    renameThread: vi.fn(),
+    requestRename: vi.fn(),
+    requestDelete: vi.fn(),
+    archiveThreadAndChildren: vi.fn(),
+    unarchiveThread: vi.fn(),
+    togglePin: vi.fn(),
+    toggleRead: vi.fn(),
+  }),
 }));
 
 function makePlainThreads(count: number): ThreadListEntry[] {
@@ -33,18 +56,20 @@ function renderThreadTree(
   selectedThreadId?: string,
 ) {
   return render(
-    <MemoryRouter>
-      <ProjectThreadTree
-        threadListState={{ status: "ready", threads }}
-        compareThreads={() => 0}
-        selectedThreadId={selectedThreadId}
-        collapsedThreadIds={new Set()}
-        collapsedEnvironmentIds={new Set()}
-        variant="section"
-        onToggleThreadCollapsed={vi.fn()}
-        onToggleEnvironmentCollapsed={vi.fn()}
-      />
-    </MemoryRouter>,
+    <TooltipProvider>
+      <MemoryRouter>
+        <ProjectThreadTree
+          threadListState={{ status: "ready", threads }}
+          compareThreads={() => 0}
+          selectedThreadId={selectedThreadId}
+          collapsedThreadIds={new Set()}
+          collapsedEnvironmentIds={new Set()}
+          variant="section"
+          onToggleThreadCollapsed={vi.fn()}
+          onToggleEnvironmentCollapsed={vi.fn()}
+        />
+      </MemoryRouter>
+    </TooltipProvider>,
   );
 }
 
@@ -52,6 +77,15 @@ describe("ProjectThreadTree progressive disclosure", () => {
   afterEach(() => {
     cleanup();
     vi.clearAllMocks();
+    mockExperiments.sidebarProgressiveDisclosure = true;
+  });
+
+  it("renders the full list when the experiment is disabled", () => {
+    mockExperiments.sidebarProgressiveDisclosure = false;
+    renderThreadTree(makePlainThreads(7));
+
+    expect(screen.getByText("Thread 6")).not.toBeNull();
+    expect(screen.queryByRole("button", { name: "Show more" })).toBeNull();
   });
 
   it("renders every item without controls when the list fits the attention limit", () => {
@@ -60,7 +94,6 @@ describe("ProjectThreadTree progressive disclosure", () => {
     expect(screen.getByText("Thread 0")).not.toBeNull();
     expect(screen.getByText("Thread 4")).not.toBeNull();
     expect(screen.queryByRole("button", { name: "Show more" })).toBeNull();
-    expect(screen.queryByRole("button", { name: "Collapse" })).toBeNull();
   });
 
   it("keeps busy threads visible beyond the attention limit", () => {
@@ -68,6 +101,20 @@ describe("ProjectThreadTree progressive disclosure", () => {
     threads[6] = {
       ...threads[6],
       activity: { ...threads[6].activity, activeBackgroundAgentCount: 1 },
+    };
+    renderThreadTree(threads);
+
+    expect(screen.getByText("Thread 4")).not.toBeNull();
+    expect(screen.queryByText("Thread 5")).toBeNull();
+    expect(screen.getByText("Thread 6")).not.toBeNull();
+  });
+
+  it("keeps threads waiting for input visible beyond the attention limit", () => {
+    const threads = makePlainThreads(7);
+    threads[6] = {
+      ...threads[6],
+      hasPendingInteraction: true,
+      runtime: { displayStatus: "idle", hostReconnectGraceExpiresAt: null },
     };
     renderThreadTree(threads);
 
@@ -103,13 +150,20 @@ describe("ProjectThreadTree progressive disclosure", () => {
 
     expect(screen.getByText("Thread 4")).not.toBeNull();
     expect(screen.queryByText("Thread 5")).toBeNull();
-    expect(screen.queryByRole("button", { name: "Collapse" })).toBeNull();
+    const showMoreButton = screen.getByRole("button", { name: "Show more" });
+    expect(showMoreButton.className).toContain("w-full");
+    expect(showMoreButton.className).toContain("text-subtle-foreground");
+    expect(showMoreButton.className).toContain("hover:bg-sidebar-accent");
+    expect(showMoreButton.className).toContain(
+      "hover:text-sidebar-accent-foreground",
+    );
+    expect(showMoreButton.className).toContain("h-[var(--bb-sidebar-row-height)]");
 
-    fireEvent.click(screen.getByRole("button", { name: "Show more" }));
+    fireEvent.click(showMoreButton);
     expect(screen.getByText("Thread 14")).not.toBeNull();
     expect(screen.queryByText("Thread 15")).toBeNull();
     expect(screen.getByRole("button", { name: "Show more" })).not.toBeNull();
-    expect(screen.getByRole("button", { name: "Collapse" })).not.toBeNull();
+    expect(screen.queryByRole("button", { name: "Collapse" })).toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: "Show more" }));
     expect(screen.getByText("Thread 16")).not.toBeNull();
@@ -134,18 +188,5 @@ describe("ProjectThreadTree progressive disclosure", () => {
     expect(screen.getByText("Thread 15")).not.toBeNull();
     expect(screen.getByText("Thread 17")).not.toBeNull();
     expect(screen.queryByRole("button", { name: "Show more" })).toBeNull();
-  });
-
-  it("collapses back to the attention set", () => {
-    renderThreadTree(makePlainThreads(17));
-
-    fireEvent.click(screen.getByRole("button", { name: "Show more" }));
-    expect(screen.getByText("Thread 14")).not.toBeNull();
-
-    fireEvent.click(screen.getByRole("button", { name: "Collapse" }));
-    expect(screen.getByText("Thread 4")).not.toBeNull();
-    expect(screen.queryByText("Thread 5")).toBeNull();
-    expect(screen.getByRole("button", { name: "Show more" })).not.toBeNull();
-    expect(screen.queryByRole("button", { name: "Collapse" })).toBeNull();
   });
 });

--- a/apps/app/src/components/sidebar/SidebarStatusNotifications.stories.tsx
+++ b/apps/app/src/components/sidebar/SidebarStatusNotifications.stories.tsx
@@ -242,6 +242,7 @@ function ProjectListStage({
         <ProjectListProjects
           status="ready"
           rows={rowModels}
+          progressiveDisclosureEnabled
           collapsedProjectIds={collapsedProjectIds}
           collapsedThreadIds={collapsedThreadIds}
           collapsedEnvironmentIds={collapsedEnvironmentIds}

--- a/apps/app/src/lib/system-config-atoms.ts
+++ b/apps/app/src/lib/system-config-atoms.ts
@@ -26,6 +26,7 @@ const unavailableSystemConfig: SystemConfigResponse = {
     changelogPreview: false,
     editMessages: false,
     mobileApp: false,
+    sidebarProgressiveDisclosure: false,
     timelineWindowing: false,
   },
   appearance: defaultAppTheme,

--- a/apps/app/src/views/SettingsView.experiments.test.tsx
+++ b/apps/app/src/views/SettingsView.experiments.test.tsx
@@ -8,6 +8,7 @@ afterEach(cleanup);
 function renderSection(overrides?: {
   onChangelogPreviewEnabledChange?: (enabled: boolean) => void;
   onMobileAppEnabledChange?: (enabled: boolean) => void;
+  onSidebarProgressiveDisclosureEnabledChange?: (enabled: boolean) => void;
   onTimelineWindowingEnabledChange?: (enabled: boolean) => void;
 }) {
   return render(
@@ -16,12 +17,16 @@ function renderSection(overrides?: {
       disabled={false}
       editMessagesEnabled={false}
       mobileAppEnabled={false}
+      sidebarProgressiveDisclosureEnabled={false}
       timelineWindowingEnabled={false}
       onChangelogPreviewEnabledChange={
         overrides?.onChangelogPreviewEnabledChange ?? vi.fn()
       }
       onEditMessagesEnabledChange={vi.fn()}
       onMobileAppEnabledChange={overrides?.onMobileAppEnabledChange ?? vi.fn()}
+      onSidebarProgressiveDisclosureEnabledChange={
+        overrides?.onSidebarProgressiveDisclosureEnabledChange ?? vi.fn()
+      }
       onTimelineWindowingEnabledChange={
         overrides?.onTimelineWindowingEnabledChange ?? vi.fn()
       }
@@ -41,6 +46,13 @@ describe("ExperimentsSettingsSection", () => {
     const onChange = vi.fn();
     renderSection({ onMobileAppEnabledChange: onChange });
     fireEvent.click(screen.getByLabelText("Mobile app"));
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  it("reports sidebar progressive disclosure changes", () => {
+    const onChange = vi.fn();
+    renderSection({ onSidebarProgressiveDisclosureEnabledChange: onChange });
+    fireEvent.click(screen.getByLabelText("Sidebar progressive disclosure"));
     expect(onChange).toHaveBeenCalledWith(true);
   });
 

--- a/apps/app/src/views/SettingsView.stories.tsx
+++ b/apps/app/src/views/SettingsView.stories.tsx
@@ -358,6 +358,9 @@ function ExperimentsStory() {
       disabled={false}
       editMessagesEnabled={state.experiments.editMessages}
       mobileAppEnabled={state.experiments.mobileApp}
+      sidebarProgressiveDisclosureEnabled={
+        state.experiments.sidebarProgressiveDisclosure
+      }
       timelineWindowingEnabled={state.experiments.timelineWindowing}
       onChangelogPreviewEnabledChange={(enabled) =>
         state.setExperiments((current) => ({
@@ -375,6 +378,12 @@ function ExperimentsStory() {
         state.setExperiments((current) => ({
           ...current,
           mobileApp: enabled,
+        }))
+      }
+      onSidebarProgressiveDisclosureEnabledChange={(enabled) =>
+        state.setExperiments((current) => ({
+          ...current,
+          sidebarProgressiveDisclosure: enabled,
         }))
       }
       onTimelineWindowingEnabledChange={(enabled) =>

--- a/apps/app/src/views/SettingsView.tsx
+++ b/apps/app/src/views/SettingsView.tsx
@@ -189,10 +189,12 @@ interface ExperimentsSettingsSectionProps {
   changelogPreviewEnabled: boolean;
   editMessagesEnabled: boolean;
   mobileAppEnabled: boolean;
+  sidebarProgressiveDisclosureEnabled: boolean;
   timelineWindowingEnabled: boolean;
   onChangelogPreviewEnabledChange: (enabled: boolean) => void;
   onEditMessagesEnabledChange: (enabled: boolean) => void;
   onMobileAppEnabledChange: (enabled: boolean) => void;
+  onSidebarProgressiveDisclosureEnabledChange: (enabled: boolean) => void;
   onTimelineWindowingEnabledChange: (enabled: boolean) => void;
 }
 
@@ -944,16 +946,20 @@ export function DebugSettingsSection({
 const CHANGELOG_PREVIEW_EXPERIMENT_LABEL = "Changelog preview";
 const EDIT_MESSAGES_EXPERIMENT_LABEL = "Edit messages";
 const MOBILE_APP_EXPERIMENT_LABEL = "Mobile app";
+const SIDEBAR_PROGRESSIVE_DISCLOSURE_EXPERIMENT_LABEL =
+  "Sidebar progressive disclosure";
 const TIMELINE_WINDOWING_EXPERIMENT_LABEL = "Timeline windowing";
 export function ExperimentsSettingsSection({
   changelogPreviewEnabled,
   disabled,
   editMessagesEnabled,
   mobileAppEnabled,
+  sidebarProgressiveDisclosureEnabled,
   timelineWindowingEnabled,
   onChangelogPreviewEnabledChange,
   onEditMessagesEnabledChange,
   onMobileAppEnabledChange,
+  onSidebarProgressiveDisclosureEnabledChange,
   onTimelineWindowingEnabledChange,
 }: ExperimentsSettingsSectionProps) {
   return (
@@ -995,6 +1001,18 @@ export function ExperimentsSettingsSection({
             disabled={disabled}
             onCheckedChange={onMobileAppEnabledChange}
             aria-label={MOBILE_APP_EXPERIMENT_LABEL}
+          />
+        </SettingsWithControl>
+
+        <SettingsWithControl
+          label={SIDEBAR_PROGRESSIVE_DISCLOSURE_EXPERIMENT_LABEL}
+          description="Show five recent thread groups per project or machine, keep attention items visible, and reveal older groups in batches."
+        >
+          <Switch
+            checked={sidebarProgressiveDisclosureEnabled}
+            disabled={disabled}
+            onCheckedChange={onSidebarProgressiveDisclosureEnabledChange}
+            aria-label={SIDEBAR_PROGRESSIVE_DISCLOSURE_EXPERIMENT_LABEL}
           />
         </SettingsWithControl>
 
@@ -1153,6 +1171,15 @@ export function SettingsView() {
           updateExperimentsMutation.mutate({
             ...experiments,
             mobileApp: enabled,
+          })
+        }
+        sidebarProgressiveDisclosureEnabled={
+          experiments.sidebarProgressiveDisclosure
+        }
+        onSidebarProgressiveDisclosureEnabledChange={(enabled) =>
+          updateExperimentsMutation.mutate({
+            ...experiments,
+            sidebarProgressiveDisclosure: enabled,
           })
         }
         timelineWindowingEnabled={experiments.timelineWindowing}

--- a/apps/app/src/views/SettingsView.tsx
+++ b/apps/app/src/views/SettingsView.tsx
@@ -1006,7 +1006,7 @@ export function ExperimentsSettingsSection({
 
         <SettingsWithControl
           label={SIDEBAR_PROGRESSIVE_DISCLOSURE_EXPERIMENT_LABEL}
-          description="Show five recent thread groups per project or machine, keep attention items visible, and reveal older groups in batches."
+          description="In By project and By machine, show the first five groups in the current sort order, keep attention groups visible, and reveal ten more per click. Manually is unchanged."
         >
           <Switch
             checked={sidebarProgressiveDisclosureEnabled}

--- a/apps/desktop/test/preload-build.test.ts
+++ b/apps/desktop/test/preload-build.test.ts
@@ -130,6 +130,7 @@ async function startDesktopSmokeServer(
             changelogPreview: false,
             editMessages: false,
             mobileApp: false,
+            sidebarProgressiveDisclosure: false,
             timelineWindowing: false,
           },
           featureFlags: {

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/references/app-settings.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/references/app-settings.md
@@ -113,9 +113,9 @@ every window and client sees the same value.
 
 - The `sidebarProgressiveDisclosure` experiment defaults to false.
 - Enable it with `bb settings experiment sidebarProgressiveDisclosure true`.
-- It limits project and machine groups to five recent items, keeps attention
-  items visible, and reveals ten more per **Show more** click. Manual sections
-  and Unorganized are unchanged.
+- In **By project** and **By machine**, it shows the first five groups in the
+  current sort order, keeps attention groups visible, and reveals ten more per
+  **Show more** click. **Manually** is unchanged.
 
 ## Timeline windowing
 

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/references/app-settings.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/references/app-settings.md
@@ -109,6 +109,14 @@ every window and client sees the same value.
 - Enable it with `bb settings experiment changelogPreview true` to show the
   latest release notes on Settings → Updates.
 
+## Sidebar progressive disclosure
+
+- The `sidebarProgressiveDisclosure` experiment defaults to false.
+- Enable it with `bb settings experiment sidebarProgressiveDisclosure true`.
+- It limits project and machine groups to five recent items, keeps attention
+  items visible, and reveals ten more per **Show more** click. Manual sections
+  and Unorganized are unchanged.
+
 ## Timeline windowing
 
 - The `timelineWindowing` experiment defaults to false.

--- a/apps/server/test/system/experiments.test.ts
+++ b/apps/server/test/system/experiments.test.ts
@@ -15,6 +15,7 @@ describe("experiments settings", () => {
         changelogPreview: false,
         editMessages: true,
         mobileApp: false,
+        sidebarProgressiveDisclosure: false,
         timelineWindowing: false,
       });
     });
@@ -29,6 +30,7 @@ describe("experiments settings", () => {
           changelogPreview: true,
           editMessages: true,
           mobileApp: true,
+          sidebarProgressiveDisclosure: true,
           timelineWindowing: true,
         }),
       });
@@ -37,12 +39,14 @@ describe("experiments settings", () => {
         changelogPreview: true,
         editMessages: true,
         mobileApp: true,
+        sidebarProgressiveDisclosure: true,
         timelineWindowing: true,
       });
       expect(getExperiments(harness.db)).toEqual({
         changelogPreview: true,
         editMessages: true,
         mobileApp: true,
+        sidebarProgressiveDisclosure: true,
         timelineWindowing: true,
       });
 
@@ -53,6 +57,7 @@ describe("experiments settings", () => {
         changelogPreview: true,
         editMessages: true,
         mobileApp: true,
+        sidebarProgressiveDisclosure: true,
         timelineWindowing: true,
       });
     });
@@ -70,6 +75,7 @@ describe("experiments settings", () => {
           changelogPreview: false,
           editMessages: false,
           mobileApp: false,
+          sidebarProgressiveDisclosure: false,
           timelineWindowing: false,
         }),
       });

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -763,11 +763,11 @@ BB releases restorable provider sessions after 30 idle minutes. The daemon
 checks for these sessions every five minutes. Active turns, commands, agents,
 workflows, and monitors keep their sessions loaded.
 
-The `sidebarProgressiveDisclosure` experiment is off by default. When enabled,
-project and machine grouping show five recent thread groups, always retain
-threads waiting for input, busy, unread-finished, and selected threads, and
-reveal ten more groups per **Show more** click. Manual sections and Unorganized are unchanged. Toggle it with
-`bb settings experiment sidebarProgressiveDisclosure <true|false>`.
+The `sidebarProgressiveDisclosure` experiment is off by default. In **By
+project** and **By machine**, it shows the first five groups in the current sort
+order, keeps attention groups visible, and reveals ten more per **Show more**
+click. **Manually** is unchanged. Toggle it with `bb settings experiment
+sidebarProgressiveDisclosure <true|false>`.
 
 The `timelineWindowing` experiment is off by default. When enabled, long
 timelines and large expanded timeline details retain stable height-preserving

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -763,6 +763,12 @@ BB releases restorable provider sessions after 30 idle minutes. The daemon
 checks for these sessions every five minutes. Active turns, commands, agents,
 workflows, and monitors keep their sessions loaded.
 
+The `sidebarProgressiveDisclosure` experiment is off by default. When enabled,
+project and machine grouping show five recent thread groups, always retain
+threads waiting for input, busy, unread-finished, and selected threads, and
+reveal ten more groups per **Show more** click. Manual sections and Unorganized are unchanged. Toggle it with
+`bb settings experiment sidebarProgressiveDisclosure <true|false>`.
+
 The `timelineWindowing` experiment is off by default. When enabled, long
 timelines and large expanded timeline details retain stable height-preserving
 wrappers while mounting only rows near their active scrollport. Toggle it with

--- a/packages/client-core/src/thread/thread-activity.ts
+++ b/packages/client-core/src/thread/thread-activity.ts
@@ -54,6 +54,19 @@ export function hasActiveGoalActivity(
   return thread.activity.activeGoalCount > 0;
 }
 
+export function isBusyThread(
+  thread: ThreadRuntimeShape & ThreadActivityStateShape,
+): boolean {
+  return (
+    isRuntimeBusyThread(thread) ||
+    hasActiveWorkflowActivity(thread) ||
+    hasActiveBackgroundAgentActivity(thread) ||
+    hasActiveBackgroundCommandActivity(thread) ||
+    hasActivePlanModeActivity(thread) ||
+    hasActiveGoalActivity(thread)
+  );
+}
+
 export interface ThreadListIndicatorState {
   hasPendingInteraction: boolean;
   hasUnsubmittedDraft: boolean;
@@ -219,37 +232,13 @@ export function getCollapsedChildActivity(
     if (thread.hasPendingInteraction) {
       pending = true;
     }
-    const childRuntimeWorking = isRuntimeBusyThread(thread);
-    const childWorkflowActive = hasActiveWorkflowActivity(thread);
-    const childBackgroundAgentActive = hasActiveBackgroundAgentActivity(thread);
-    const childBackgroundCommandActive =
-      hasActiveBackgroundCommandActivity(thread);
-    const childPlanModeActive = hasActivePlanModeActivity(thread);
-    const childGoalActive = hasActiveGoalActivity(thread);
-    if (childRuntimeWorking) {
-      runtimeWorking = true;
-      working = true;
-    }
-    if (childWorkflowActive) {
-      workflow = true;
-      working = true;
-    }
-    if (childBackgroundAgentActive) {
-      backgroundAgent = true;
-      working = true;
-    }
-    if (childBackgroundCommandActive) {
-      backgroundCommand = true;
-      working = true;
-    }
-    if (childPlanModeActive) {
-      planMode = true;
-      working = true;
-    }
-    if (childGoalActive) {
-      goal = true;
-      working = true;
-    }
+    if (isBusyThread(thread)) working = true;
+    if (isRuntimeBusyThread(thread)) runtimeWorking = true;
+    if (hasActiveWorkflowActivity(thread)) workflow = true;
+    if (hasActiveBackgroundAgentActivity(thread)) backgroundAgent = true;
+    if (hasActiveBackgroundCommandActivity(thread)) backgroundCommand = true;
+    if (hasActivePlanModeActivity(thread)) planMode = true;
+    if (hasActiveGoalActivity(thread)) goal = true;
   }
   return {
     pending,

--- a/packages/db/test/experiments.test.ts
+++ b/packages/db/test/experiments.test.ts
@@ -39,6 +39,7 @@ describe("experiments", () => {
         "editMessages",
         "futureExperiment",
         "mobileApp",
+        "sidebarProgressiveDisclosure",
         "timelineWindowing",
       ]);
     } finally {

--- a/packages/domain/src/experiments.ts
+++ b/packages/domain/src/experiments.ts
@@ -4,6 +4,7 @@ export const experimentKeys = [
   "changelogPreview",
   "editMessages",
   "mobileApp",
+  "sidebarProgressiveDisclosure",
   "timelineWindowing",
 ] as const;
 export const experimentKeySchema = z.enum(experimentKeys);
@@ -16,5 +17,6 @@ export const defaultExperiments: Experiments = {
   changelogPreview: false,
   editMessages: true,
   mobileApp: false,
+  sidebarProgressiveDisclosure: false,
   timelineWindowing: false,
 };

--- a/packages/templates/src/templates/bb-guide-customization.md
+++ b/packages/templates/src/templates/bb-guide-customization.md
@@ -137,12 +137,11 @@ BB releases restorable provider sessions after 30 idle minutes. The daemon
 checks for these sessions every five minutes. Active turns, commands, agents,
 workflows, and monitors keep their sessions loaded.
 
-The default-off `sidebarProgressiveDisclosure` experiment limits project and
-machine groups to five recent items, keeps threads waiting for input, busy,
-unread-finished, and selected threads visible, and reveals ten more per **Show
-more** click. Manual sections
-and Unorganized are unchanged. Enable it with
-`bb settings experiment sidebarProgressiveDisclosure true`.
+The default-off `sidebarProgressiveDisclosure` experiment shows the first five
+groups in the current sort order in **By project** and **By machine**, keeps
+attention groups visible, and reveals ten more per **Show more** click.
+**Manually** is unchanged. Enable it with `bb settings experiment
+sidebarProgressiveDisclosure true`.
 
 The default-off `timelineWindowing` experiment mounts only nearby rows in long
 timelines and large expanded timeline details. Enable it with

--- a/packages/templates/src/templates/bb-guide-customization.md
+++ b/packages/templates/src/templates/bb-guide-customization.md
@@ -137,6 +137,13 @@ BB releases restorable provider sessions after 30 idle minutes. The daemon
 checks for these sessions every five minutes. Active turns, commands, agents,
 workflows, and monitors keep their sessions loaded.
 
+The default-off `sidebarProgressiveDisclosure` experiment limits project and
+machine groups to five recent items, keeps threads waiting for input, busy,
+unread-finished, and selected threads visible, and reveals ten more per **Show
+more** click. Manual sections
+and Unorganized are unchanged. Enable it with
+`bb settings experiment sidebarProgressiveDisclosure true`.
+
 The default-off `timelineWindowing` experiment mounts only nearby rows in long
 timelines and large expanded timeline details. Enable it with
 `bb settings experiment timelineWindowing true`.


### PR DESCRIPTION
## Human comments

<!-- Agents: Do not fill in this section. This is for human users to fill in. -->

- This PR limits thread/project sessions in the **By project** and **By machine** sidebar modes to attention based items (unread + busy + pending interaction + recent 5)
- **Manually** mode uses a separate section-aware, drag-and-drop thread tree and this PR doesn't covers it.
- **Collapse** to get back to initial state is not part of the current PR and will be considered in future
- The feature is behind the experiments under **Sidebar Progressive Disclosure**

## What was wrong

The sidebar modes rendered every root thread group at once. This made large thread lists harder to scan, with no way to reveal older groups while keeping sessions that need attention easily visible.

## What changed

Added the default-off `sidebarProgressiveDisclosure` experiment for **By project** and **By machine**. When enabled, each thread tree:

- Shows the first five groups in the current sort order.
- Keeps busy, waiting-for-input, unread-finished, and selected thread groups visible beyond that limit.
- Reveals ten additional non-attention groups per **Show more** click.
- Hides the control once every group is visible.
- Preserves the existing full-list behavior when the experiment is disabled.

The experiment is available in Settings and through `bb settings experiment sidebarProgressiveDisclosure <true|false>`. Configuration docs, the generated guide template, and the built-in CLI skill reference were updated.

**Manually** remains unchanged because it uses a separate section-aware, drag-and-drop thread tree and requires its own disclosure behavior.

The shared thread activity helpers now expose `isBusyThread` so attention-state detection uses the same definition as collapsed sidebar activity.

There are no host-daemon wire changes, so `HOST_DAEMON_PROTOCOL_VERSION` was not incremented.

### Working Demo

https://github.com/user-attachments/assets/4c9fc5da-f119-4937-9bea-5177c788fd4a



## How you verified

Added focused tests covering:

- Full-list behavior when the experiment is disabled.
- Lists at or below the five-group limit.
- Busy, waiting-for-input, unread-finished, and selected groups beyond the limit.
- Ten-item incremental expansion.
- Attention groups not consuming expansion slots.
- Settings toggle updates.

Commands run:

- `pnpm exec turbo run test --filter=@bb/app -- src/components/sidebar/ProjectThreadTree.disclosure.test.tsx src/views/SettingsView.experiments.test.tsx` — 12 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/app` — passed.

Fixes #1509 