### PR TITLE
Fix mobile cold-start swipe dismissal and keyboard white flicker

### DIFF
--- a/apps/mobile/src/screens/shell/RootNavigator.tsx
+++ b/apps/mobile/src/screens/shell/RootNavigator.tsx
@@ -73,7 +73,10 @@ export function RootNavigator() {
         }}
       >
         <Stack.Screen name="index" options={hiddenHeader} />
-        <Stack.Screen name="webview" options={hiddenHeader} />
+        <Stack.Screen
+          name="webview"
+          options={{ ...hiddenHeader, gestureEnabled: false }}
+        />
         <Stack.Screen
           name="settings/device"
           options={{ title: "This device", ...listScreen }}

--- a/apps/mobile/src/screens/webview/ProfileWebViewScreen.tsx
+++ b/apps/mobile/src/screens/webview/ProfileWebViewScreen.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/lib/shell";
 import { getShellPreferenceStore } from "@/lib/shell/shell-preference-store";
 import { settingsSectionHref } from "@/screens/shell/hrefs";
+import { useTheme } from "@/theme";
 import { Button, EmptyStatePanel, Spinner, Text } from "@/ui";
 import { Linking } from "react-native";
 import { useShellBridge } from "./useShellBridge";
@@ -36,6 +37,7 @@ function firstParam(value: string | string[] | undefined): string | undefined {
 }
 
 export function ProfileWebViewScreen() {
+  const { tokens } = useTheme();
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const params = useLocalSearchParams<{ profileId?: string; path?: string }>();
@@ -241,11 +243,12 @@ export function ProfileWebViewScreen() {
   if (profile === null || sourceUrl === null || handshake === null) return null;
 
   return (
-    <View className="flex-1" testID="shell-webview">
+    <View className="flex-1 bg-background" testID="shell-webview">
       <WebView
         key={`${profile.id}#${sourceUrl}#${reloadKey}`}
         ref={webViewRef}
         source={{ uri: sourceUrl }}
+        style={{ backgroundColor: tokens.background }}
         sharedCookiesEnabled
         javaScriptEnabled
         domStorageEnabled
@@ -254,7 +257,10 @@ export function ProfileWebViewScreen() {
         mediaCapturePermissionGrantType="grant"
         hideKeyboardAccessoryView
         allowsBackForwardNavigationGestures={false}
-        pullToRefreshEnabled
+        bounces={false}
+        pullToRefreshEnabled={false}
+        automaticallyAdjustContentInsets={false}
+        contentInsetAdjustmentBehavior="never"
         webviewDebuggingEnabled={__DEV__}
         injectedJavaScriptBeforeContentLoaded={buildBridgeInjectionScript(
           handshake,


### PR DESCRIPTION
## Human comments

## What was wrong

The mobile shell still allowed native stack swipe dismissal even though WebView back/forward gestures were disabled. On cold launch, a swipe could move the whole screen alongside the web sidebar and recreate the page. The WebView also enabled pull-to-refresh, which forces native bouncing, and retained a white background exposed during keyboard transitions.

## What changed

Disable native dismissal for the webview route. Disable WebView bouncing, pull-to-refresh, and automatic content insets, and use the native theme background for the WebView and its container. The page handles its safe area through the existing bridge. Explicit reload remains available in This device settings.

## How you verified

- `pnpm exec turbo run typecheck lint test --filter=@bb/mobile`: passed; 326 tests, four existing lint warnings, no errors.
- Formatting and `git diff --check`: passed.
- iOS 26.3 simulator using the current JavaScript bundle and an isolated integration backend: restored the saved thread after cold launch, opened/closed the sidebar without another page-ready event, and exercised keyboard input/dismissal. Recorded frames showed no white flash.
- Physical iPhone release verification remains outstanding. No automated regression test was added for these native gesture/rendering changes.

> AGENT GENERATED
