### PR TITLE
Add @MayankBansal12 to contributor allow list

### DIFF
--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -64,3 +64,4 @@ IlyaM
 swairshah
 danielbachhuber
 aivanov93
+MayankBansal12


### PR DESCRIPTION
## Human comments

## What was wrong

GitHub user `MayankBansal12` was not in the persistent contributor allow list, so the PR approval gate would not treat contributions from their fork as approved.

## What changed

Added `MayankBansal12` to `.github/APPROVED_CONTRIBUTORS`. This is a policy-only change with no host daemon wire, CLI, guide, or documentation impact.

## How you verified

- Confirmed the GitHub account exists (`gh api users/MayankBansal12` returns login MayankBansal12).
- Ran `git diff --check`.
- Checked the contributor list for case-insensitive duplicates.

> AGENT GENERATED