### PR TITLE
feat(app): add a download action to file previews

### DIFF
--- a/apps/app/src/components/secondary-panel/FilePreview.test.tsx
+++ b/apps/app/src/components/secondary-panel/FilePreview.test.tsx
@@ -200,6 +200,7 @@ describe("FilePreview", () => {
     cleanup();
     vi.useRealTimers();
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it("offers a manual file refresh action", () => {
@@ -221,6 +222,119 @@ describe("FilePreview", () => {
     fireEvent.click(screen.getByRole("button", { name: "Refresh file" }));
 
     expect(onRefresh).toHaveBeenCalledOnce();
+  });
+
+  it("downloads a text file from the header using the file name", async () => {
+    const createObjectURL = vi
+      .spyOn(URL, "createObjectURL")
+      .mockReturnValue("blob:notes");
+    vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => undefined);
+    let downloadedName: string | null = null;
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(
+      function (this: HTMLAnchorElement) {
+        downloadedName = this.download;
+      },
+    );
+
+    render(
+      <FilePreview
+        path="docs/research/gmail-setup-handoff.md"
+        state={{
+          kind: "ready",
+          file: {
+            name: "gmail-setup-handoff.md",
+            contents: "# Handoff",
+          },
+          lineRange: null,
+          textPreviewKind: "markdown",
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Download file" }));
+
+    await waitFor(() => {
+      expect(downloadedName).toBe("gmail-setup-handoff.md");
+    });
+    const blob = createObjectURL.mock.calls[0]?.[0];
+    if (!(blob instanceof Blob)) {
+      throw new Error("expected a Blob");
+    }
+    expect(await blob.text()).toBe("# Handoff");
+  });
+
+  it("downloads an image from its preview url", async () => {
+    vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:image");
+    vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => undefined);
+    let downloadedName: string | null = null;
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(
+      function (this: HTMLAnchorElement) {
+        downloadedName = this.download;
+      },
+    );
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      blob: async () => new Blob(["png"], { type: "image/png" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <FilePreview
+        path="docs/screenshots/right-panel.png"
+        state={{ kind: "image", url: "/preview/right-panel.png" }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Download file" }));
+
+    await waitFor(() => {
+      expect(downloadedName).toBe("right-panel.png");
+    });
+    expect(fetchMock).toHaveBeenCalledWith("/preview/right-panel.png");
+  });
+
+  it("hides download when the file has no bytes to save", () => {
+    render(<FilePreview path="README.md" state={{ kind: "loading" }} />);
+
+    expect(screen.queryByRole("button", { name: "Download file" })).toBeNull();
+  });
+
+  it("still offers download when preview is empty or unsupported", () => {
+    const view = render(
+      <SecondaryPanelFilePreview
+        activePath="notes.txt"
+        filePreview={{
+          kind: "text",
+          content: "",
+          mimeType: "text/plain",
+          name: "notes.txt",
+          path: "notes.txt",
+          url: "/api/v1/preview/notes.txt",
+        }}
+        isLoading={false}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Download file" })).toBeTruthy();
+
+    view.rerender(
+      <SecondaryPanelFilePreview
+        activePath="assets/model.glb"
+        filePreview={{
+          kind: "unsupported",
+          mimeType: "model/gltf-binary",
+          name: "model.glb",
+          path: "assets/model.glb",
+          url: "/api/v1/preview/model.glb",
+        }}
+        isLoading={false}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Download file" })).toBeTruthy();
+    expect(
+      screen.getByText("Preview not available for model/gltf-binary."),
+    ).toBeTruthy();
   });
 
   it("disables the manual refresh action while a refresh is running", () => {
@@ -562,6 +676,7 @@ describe("FilePreview", () => {
 
     const actionButtons = [
       screen.getByRole("button", { name: "Copy HTML source" }),
+      screen.getByRole("button", { name: "Download file" }),
       screen.getByRole("button", { name: /Open in editor/ }),
     ];
 

--- a/apps/app/src/components/secondary-panel/FilePreview.tsx
+++ b/apps/app/src/components/secondary-panel/FilePreview.tsx
@@ -11,9 +11,14 @@ import { Button } from "@bb/shared-ui/button";
 import { SourceCodeHost } from "@/components/code/SourceCodeHost";
 import { COARSE_POINTER_TEXT_SM_CLASS } from "@bb/shared-ui/coarse-pointer-sizing";
 import { EmptyStatePanel } from "@bb/shared-ui/empty-state";
+import { appToast } from "@/components/ui/app-toast";
 import { CopyButton } from "@/components/ui/copy-button.js";
 import { Icon } from "@bb/shared-ui/icon";
 import { OpenInEditorButton } from "@/components/ui/open-in-editor-button.js";
+import {
+  downloadNamedFile,
+  type FileDownloadSource,
+} from "@/lib/file-download";
 import { useAppCommandShortcut } from "@/components/commands/AppCommandProvider";
 import { AppCommandShortcutHint } from "@/components/commands/AppCommandShortcutHint";
 import type { MarkdownLinkRouting } from "@/components/ui/markdown-link-routing.js";
@@ -32,6 +37,7 @@ import type {
   FilePreviewLineRange,
   WorkspaceFilePreviewStatusLabel,
 } from "@bb/client-core";
+import { fileNameFromPath } from "@bb/thread-view";
 import {
   DEFAULT_CODE_OVERFLOW_MODE,
   type CodeOverflowMode,
@@ -80,6 +86,7 @@ interface FilePreviewProps {
   state: FilePreviewState;
   path: string;
   copyPath?: string | null;
+  downloadUrl?: string | null;
   headerMode?: FilePreviewHeaderMode;
   onSelectionAddToChat?: (text: string) => void;
   onOpenInEditor?: (path: string) => void;
@@ -109,6 +116,7 @@ interface FilePreviewHeaderProps {
   path: string;
   copyPath: string | null;
   rawContents: string | null;
+  downloadSource: FileDownloadSource | null;
   externalUrl: string | null;
   onOpenInEditor?: (path: string) => void;
   onRefresh?: () => void;
@@ -120,6 +128,11 @@ interface FilePreviewHeaderProps {
   onLineOverflowModeChange: CodeOverflowModeChangeHandler;
   viewMode: FilePreviewViewMode;
   onViewModeChange: (mode: FilePreviewViewMode) => void;
+}
+
+interface FilePreviewDownloadButtonProps {
+  path: string;
+  source: FileDownloadSource;
 }
 
 interface FilePreviewLineWrapButtonProps {
@@ -212,6 +225,30 @@ function getFilePreviewExternalUrl(state: FilePreviewState): string | null {
   }
   if (state.kind === "html") {
     return state.iframe.url;
+  }
+  return null;
+}
+
+function getFilePreviewDownloadSource(
+  state: FilePreviewState,
+  downloadUrl: string | null,
+  rawContents: string | null,
+): FileDownloadSource | null {
+  if (downloadUrl !== null) {
+    return { kind: "url", url: downloadUrl };
+  }
+  if (
+    state.kind === "image" ||
+    state.kind === "video" ||
+    state.kind === "iframe"
+  ) {
+    return { kind: "url", url: state.url };
+  }
+  if (state.kind === "html") {
+    return { kind: "url", url: state.iframe.url };
+  }
+  if (rawContents !== null) {
+    return { kind: "contents", contents: rawContents };
   }
   return null;
 }
@@ -423,6 +460,7 @@ export function FilePreview({
   state,
   path,
   copyPath = null,
+  downloadUrl = null,
   headerMode = "file",
   onSelectionAddToChat,
   onOpenInEditor,
@@ -434,6 +472,11 @@ export function FilePreview({
   const toggleKind = getFilePreviewToggleKind(state);
   const filePreviewLineRange = getFilePreviewLineRange(state);
   const rawContents = getRawFilePreviewContents(state);
+  const downloadSource = getFilePreviewDownloadSource(
+    state,
+    downloadUrl,
+    rawContents,
+  );
   const externalUrl = getFilePreviewExternalUrl(state);
   const [viewMode, setViewMode] = useState<FilePreviewViewMode>(
     getInitialFilePreviewViewMode({
@@ -488,6 +531,7 @@ export function FilePreview({
           path={path}
           copyPath={copyPath}
           rawContents={rawContents}
+          downloadSource={downloadSource}
           externalUrl={externalUrl}
           onOpenInEditor={onOpenInEditor}
           onRefresh={onRefresh}
@@ -596,6 +640,7 @@ function FilePreviewHeader({
   path,
   copyPath,
   rawContents,
+  downloadSource,
   externalUrl,
   onOpenInEditor,
   onRefresh,
@@ -677,6 +722,9 @@ function FilePreviewHeader({
                   {copyFileContentsLabel}
                 </TooltipContent>
               </Tooltip>
+            )}
+            {downloadSource === null ? null : (
+              <FilePreviewDownloadButton path={path} source={downloadSource} />
             )}
             {externalUrl === null ? null : (
               <Tooltip>
@@ -811,6 +859,55 @@ function FilePreviewPath({ path, copyPath }: FilePreviewPathProps) {
         <TooltipContent side="bottom">{label}</TooltipContent>
       </Tooltip>
     </TooltipProvider>
+  );
+}
+
+function FilePreviewDownloadButton({
+  path,
+  source,
+}: FilePreviewDownloadButtonProps) {
+  const [isDownloading, setIsDownloading] = useState(false);
+  const label = isDownloading ? "Downloading file" : "Download file";
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className={cn(
+            FILE_PREVIEW_HEADER_ICON_BUTTON_CLASS,
+            "shrink-0 text-muted-foreground hover:bg-state-hover hover:text-foreground",
+          )}
+          onClick={() => {
+            if (isDownloading) {
+              return;
+            }
+            setIsDownloading(true);
+            void downloadNamedFile({
+              fileName: fileNameFromPath(path),
+              source,
+            })
+              .catch(() => {
+                appToast.error("Failed to download file");
+              })
+              .finally(() => {
+                setIsDownloading(false);
+              });
+          }}
+          disabled={isDownloading}
+          aria-label={label}
+        >
+          <Icon
+            name={isDownloading ? "Spinner" : "Download"}
+            className={cn(isDownloading && "animate-spin")}
+            aria-hidden
+          />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">{label}</TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/apps/app/src/components/secondary-panel/ThreadStorageFilePreview.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadStorageFilePreview.tsx
@@ -101,12 +101,18 @@ export function SecondaryPanelFilePreview({
   onRefresh,
   statusLabel = null,
 }: SecondaryPanelFilePreviewProps) {
+  const downloadUrl =
+    error || !filePreview || filePreview.path !== activePath
+      ? null
+      : filePreview.url;
+
   if (error) {
     const isNotFound = error instanceof HttpError && error.status === 404;
     return (
       <FilePreviewSurface
         path={activePath}
         copyPath={copyPath}
+        downloadUrl={downloadUrl}
         onSelectionAddToChat={onSelectionAddToChat}
         onOpenInEditor={onOpenInEditor}
         onRefresh={onRefresh}
@@ -122,6 +128,7 @@ export function SecondaryPanelFilePreview({
       <FilePreviewSurface
         path={activePath}
         copyPath={copyPath}
+        downloadUrl={downloadUrl}
         onSelectionAddToChat={onSelectionAddToChat}
         onOpenInEditor={onOpenInEditor}
         onRefresh={onRefresh}
@@ -138,6 +145,7 @@ export function SecondaryPanelFilePreview({
         <FilePreviewSurface
           path={activePath}
           copyPath={copyPath}
+          downloadUrl={downloadUrl}
           onSelectionAddToChat={onSelectionAddToChat}
           onOpenInEditor={onOpenInEditor}
           onRefresh={onRefresh}
@@ -157,6 +165,7 @@ export function SecondaryPanelFilePreview({
       <FilePreviewSurface
         path={activePath}
         copyPath={copyPath}
+        downloadUrl={downloadUrl}
         onSelectionAddToChat={onSelectionAddToChat}
         onOpenInEditor={onOpenInEditor}
         onRefresh={onRefresh}
@@ -182,6 +191,7 @@ export function SecondaryPanelFilePreview({
         <FilePreviewSurface
           path={activePath}
           copyPath={copyPath}
+          downloadUrl={downloadUrl}
           onSelectionAddToChat={onSelectionAddToChat}
           onOpenInEditor={onOpenInEditor}
           onRefresh={onRefresh}
@@ -195,6 +205,7 @@ export function SecondaryPanelFilePreview({
       <FilePreviewSurface
         path={activePath}
         copyPath={copyPath}
+        downloadUrl={downloadUrl}
         onSelectionAddToChat={onSelectionAddToChat}
         onOpenInEditor={onOpenInEditor}
         onRefresh={onRefresh}
@@ -216,6 +227,7 @@ export function SecondaryPanelFilePreview({
       <FilePreviewSurface
         path={activePath}
         copyPath={copyPath}
+        downloadUrl={downloadUrl}
         onSelectionAddToChat={onSelectionAddToChat}
         onOpenInEditor={onOpenInEditor}
         onRefresh={onRefresh}
@@ -231,6 +243,7 @@ export function SecondaryPanelFilePreview({
       <FilePreviewSurface
         path={activePath}
         copyPath={copyPath}
+        downloadUrl={downloadUrl}
         onSelectionAddToChat={onSelectionAddToChat}
         onOpenInEditor={onOpenInEditor}
         onRefresh={onRefresh}
@@ -245,6 +258,7 @@ export function SecondaryPanelFilePreview({
     <FilePreviewSurface
       path={activePath}
       copyPath={copyPath}
+      downloadUrl={downloadUrl}
       onSelectionAddToChat={onSelectionAddToChat}
       onOpenInEditor={onOpenInEditor}
       onRefresh={onRefresh}

--- a/apps/app/src/lib/file-download.test.ts
+++ b/apps/app/src/lib/file-download.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { downloadNamedFile } from "./file-download";
+
+function installObjectUrl(objectUrl = "blob:download"): {
+  createObjectURL: ReturnType<typeof vi.spyOn>;
+  revokeObjectURL: ReturnType<typeof vi.spyOn>;
+} {
+  const createObjectURL = vi
+    .spyOn(URL, "createObjectURL")
+    .mockReturnValue(objectUrl);
+  const revokeObjectURL = vi
+    .spyOn(URL, "revokeObjectURL")
+    .mockImplementation(() => undefined);
+  return { createObjectURL, revokeObjectURL };
+}
+
+afterEach(() => {
+  document.body.replaceChildren();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("downloadNamedFile", () => {
+  it("saves in-memory contents under the given file name without fetching", async () => {
+    const { createObjectURL, revokeObjectURL } = installObjectUrl();
+    let downloadedName: string | null = null;
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(
+      function (this: HTMLAnchorElement) {
+        downloadedName = this.download;
+      },
+    );
+
+    await downloadNamedFile({
+      fileName: "notes.md",
+      source: { kind: "contents", contents: "# Hello" },
+    });
+
+    expect(createObjectURL).toHaveBeenCalledOnce();
+    const blob = createObjectURL.mock.calls[0]?.[0];
+    if (!(blob instanceof Blob)) {
+      throw new Error("expected a Blob");
+    }
+    expect(blob.type).toBe("application/octet-stream");
+    expect(await blob.text()).toBe("# Hello");
+    expect(downloadedName).toBe("notes.md");
+    expect(document.querySelector("a")).toBeNull();
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:download");
+  });
+
+  it("fetches a content url and saves the bytes under the given file name", async () => {
+    const { createObjectURL } = installObjectUrl();
+    let downloadedName: string | null = null;
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(
+      function (this: HTMLAnchorElement) {
+        downloadedName = this.download;
+      },
+    );
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      blob: async () => new Blob(["pdf-bytes"], { type: "application/pdf" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await downloadNamedFile({
+      fileName: "report.pdf",
+      source: { kind: "url", url: "/api/v1/files/report.pdf" },
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/v1/files/report.pdf");
+    expect(createObjectURL).toHaveBeenCalledOnce();
+    expect(downloadedName).toBe("report.pdf");
+  });
+
+  it("does not save a file when the content request fails", async () => {
+    const { createObjectURL } = installObjectUrl();
+    const click = vi.fn();
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(click);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+      }),
+    );
+
+    await expect(
+      downloadNamedFile({
+        fileName: "missing.bin",
+        source: { kind: "url", url: "/api/v1/files/missing.bin" },
+      }),
+    ).rejects.toThrow("File download failed with 404");
+
+    expect(createObjectURL).not.toHaveBeenCalled();
+    expect(click).not.toHaveBeenCalled();
+  });
+});

--- a/apps/app/src/lib/file-download.ts
+++ b/apps/app/src/lib/file-download.ts
@@ -1,0 +1,42 @@
+export type FileDownloadSource =
+  | { kind: "contents"; contents: string }
+  | { kind: "url"; url: string };
+
+interface DownloadNamedFileArgs {
+  fileName: string;
+  source: FileDownloadSource;
+}
+
+export async function downloadNamedFile({
+  fileName,
+  source,
+}: DownloadNamedFileArgs): Promise<void> {
+  const blob =
+    source.kind === "contents"
+      ? new Blob([source.contents], { type: "application/octet-stream" })
+      : await fetchFileDownloadBlob(source.url);
+  const objectUrl = URL.createObjectURL(blob);
+  try {
+    triggerBrowserDownload(objectUrl, fileName);
+  } finally {
+    URL.revokeObjectURL(objectUrl);
+  }
+}
+
+async function fetchFileDownloadBlob(url: string): Promise<Blob> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`File download failed with ${response.status}`);
+  }
+  return response.blob();
+}
+
+function triggerBrowserDownload(objectUrl: string, fileName: string): void {
+  const anchor = document.createElement("a");
+  anchor.href = objectUrl;
+  anchor.download = fileName;
+  anchor.rel = "noopener";
+  document.body.append(anchor);
+  anchor.click();
+  anchor.remove();
+}


### PR DESCRIPTION
<!-- Keep the below sections. Delete this comment. See docs/filing-issues.md for the issue side. -->

## Human comments

<!-- Agents: Do not fill in this section. This is for human users to fill in. -->

## What was wrong

File preview offered copy, refresh, and open-in-editor, but no way to save the file. Images, binaries, and types BB cannot preview had no download path at all. Related: #2697.

## What changed

The file preview header now has a Download button next to copy, so any open file can be saved locally.

```diff
 <FilePreviewHeader>
   Refresh
   Copy
+  Download
   Open in browser
   Open in editor
   Preview | Raw
```

- Text, HTML, images, video, empty files, and unpreviewable types all get the control when BB has a content URL or loaded bytes.
- The button prefers the file's content URL so it saves original bytes, not a truncated preview. Loaded text is the fallback when no URL exists.
- A failed content request shows an error toast instead of writing the error page as a file.
- No host-daemon protocol bump. No new Plugin SDK or CLI surface; agents already have the file on disk.

## How you verified

Added focused coverage that failed before the header control existed:

- Header download uses the file name from the path.
- Image previews download from their content URL.
- Loading previews hide the control.
- Empty and unpreviewable files still offer download when a content URL exists.
- Content request failures do not save a file.
- Download uses the same coarse-pointer tap target as the other header actions.

```
pnpm exec turbo run test --filter=@bb/app -- src/lib/file-download.test.ts src/components/secondary-panel/FilePreview.test.tsx
pnpm exec turbo run typecheck lint --filter=@bb/app
```

31 app tests passed. Typecheck passed. Lint reported 0 errors.

Refs #2697

> AGENT GENERATED
