### PR TITLE
Collapse pending approvals into a one-row strip above the composer

### DIFF
--- a/apps/app/src/components/thread/pending-interactions/ThreadPendingInteractionBanner.shortcuts.test.tsx
+++ b/apps/app/src/components/thread/pending-interactions/ThreadPendingInteractionBanner.shortcuts.test.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { defaultAppSettings, type PendingInteraction } from "@bb/domain";
+import { AppCommandProvider } from "@/components/commands/AppCommandProvider";
+import { ThreadPendingInteractionBanner } from "./ThreadPendingInteractionBanner";
+
+vi.mock("@/hooks/queries/system-queries", () => ({
+  useSystemConfig: () => ({
+    data: {
+      generalSettings: { ...defaultAppSettings },
+      keybindings: [1, 2].map((digit) => ({
+        command: `question.select.${digit}` as const,
+        desktopOnly: false,
+        shortcut: {
+          key: String(digit),
+          mod: false,
+          meta: false,
+          control: false,
+          alt: false,
+          shift: false,
+        },
+        when: { all: ["questionOpen" as const], none: [] },
+      })),
+    },
+  }),
+}));
+
+vi.mock("@/lib/bb-desktop", () => ({
+  getBbDesktopInfo: () => null,
+}));
+
+vi.mock("@/hooks/mutations/thread-runtime-mutations", () => ({
+  useStopThread: () => ({
+    mutateAsync: vi.fn(),
+    mutate: vi.fn(),
+    isPending: false,
+  }),
+}));
+
+vi.mock("@/hooks/mutations/thread-interaction-mutations", () => ({
+  useResolveThreadPendingInteraction: () => ({
+    mutateAsync: vi.fn(async () => ({})),
+    isPending: false,
+    error: null,
+  }),
+}));
+
+const question: PendingInteraction = {
+  id: "pint_question",
+  threadId: "thr_1",
+  turnId: "turn_1",
+  providerId: "claude-code",
+  providerThreadId: "pt_1",
+  providerRequestId: "req_1",
+  status: "pending",
+  statusReason: null,
+  createdAt: 1,
+  resolvedAt: null,
+  resolution: null,
+  payload: {
+    kind: "user_question",
+    questions: [
+      {
+        id: "path",
+        prompt: "Which path should I take?",
+        shortLabel: "Path",
+        multiSelect: false,
+        allowFreeText: false,
+        options: [
+          { value: "a", label: "A", description: "Option A" },
+          { value: "b", label: "B", description: "Option B" },
+        ],
+      },
+    ],
+  },
+};
+
+function pressDigit(digit: string) {
+  act(() => {
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", { key: digit, bubbles: true }),
+    );
+  });
+}
+
+function pressedState(name: string): string | null {
+  return screen
+    .getByRole("button", { name, hidden: true })
+    .getAttribute("aria-pressed");
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ThreadPendingInteractionBanner question shortcuts", () => {
+  it("ignores numeric answer shortcuts while collapsed and honours them again once expanded", () => {
+    render(
+      <QueryClientProvider client={new QueryClient()}>
+        <MemoryRouter>
+          <AppCommandProvider>
+            <ThreadPendingInteractionBanner
+              interaction={question}
+              threadId="thr_1"
+            />
+          </AppCommandProvider>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+    pressDigit("1");
+    expect(pressedState("AOption A")).toBe("true");
+    expect(pressedState("BOption B")).toBe("false");
+
+    fireEvent.click(screen.getByRole("button", { name: "Hide details" }));
+    pressDigit("2");
+    expect(pressedState("AOption A")).toBe("true");
+    expect(pressedState("BOption B")).toBe("false");
+
+    fireEvent.click(screen.getByRole("button", { name: "Show details" }));
+    pressDigit("2");
+    expect(pressedState("AOption A")).toBe("false");
+    expect(pressedState("BOption B")).toBe("true");
+  });
+});

--- a/apps/app/src/components/thread/pending-interactions/ThreadPendingInteractionBanner.stories.tsx
+++ b/apps/app/src/components/thread/pending-interactions/ThreadPendingInteractionBanner.stories.tsx
@@ -70,6 +70,33 @@ const longCommandApproval: PendingInteraction = {
   },
 };
 
+const multiLineCommandApproval: PendingInteraction = {
+  ...basePendingInteraction(),
+  resolution: null,
+  id: "pi_demo_multiline",
+  providerId: "acp-cursor",
+  payload: {
+    kind: "approval",
+    subject: {
+      kind: "command",
+      itemId: "item_cmd_multiline",
+      command:
+        "`python3 -m unittest discover -s tests 2>&1 | tail -20\necho '=== bash -n ==='\nbash -n install.sh && echo OK\necho '=== watcher untouched ==='\ngit diff --stat -- watcher.py\necho '=== live telemetry flag untouched? ==='\nif [ -f \"$HOME/.immortal-agents/telemetry\" ]; then echo LIVE_FLAG_EXISTS; else echo LIVE_FLAG_ABSENT; fi`",
+      cwd: "/Users/michael/Projects/immortal-agents",
+      actions: [
+        {
+          type: "unknown",
+          command:
+            "`python3 -m unittest discover -s tests 2>&1 | tail -20\necho '=== bash -n ==='\nbash -n install.sh && echo OK\necho '=== watcher untouched ==='\ngit diff --stat -- watcher.py\necho '=== live telemetry flag untouched? ==='\nif [ -f \"$HOME/.immortal-agents/telemetry\" ]; then echo LIVE_FLAG_EXISTS; else echo LIVE_FLAG_ABSENT; fi`",
+        },
+      ],
+      sessionGrant: null,
+    },
+    reason: "Not in allowlist: bash -n install.sh",
+    availableDecisions: ["allow_once", "allow_for_session", "deny"],
+  },
+};
+
 const resolvingCommandApproval: PendingInteraction = {
   ...commandApproval,
   id: "pi_demo_resolving",
@@ -204,7 +231,7 @@ export function Overview() {
       </StoryRow>
       <StoryRow
         label="command approval"
-        hint="agent wants to run a shell command; default selection is the first decision"
+        hint="arrives as a one-line strip: reason, first command line, decisions; the chevron opens the card and Esc collapses it"
       >
         <PromptStage>
           <ThreadPendingInteractionBanner
@@ -221,6 +248,21 @@ export function Overview() {
           <ThreadPendingInteractionBanner
             interaction={longCommandApproval}
             threadId={longCommandApproval.threadId}
+          />
+        </PromptStage>
+      </StoryRow>
+      <StoryRow
+        label="command approval (multi-line script from a child)"
+        hint="open the card: the preview caps at four lines with a Show more control, and the script is not repeated as an action line"
+      >
+        <PromptStage>
+          <ThreadPendingInteractionBanner
+            interaction={multiLineCommandApproval}
+            sourceThread={{
+              href: "/projects/proj-1/threads/thr_blocked",
+              title: "Telemetry option in installer",
+            }}
+            threadId={multiLineCommandApproval.threadId}
           />
         </PromptStage>
       </StoryRow>

--- a/apps/app/src/components/thread/pending-interactions/ThreadPendingInteractionBanner.test.tsx
+++ b/apps/app/src/components/thread/pending-interactions/ThreadPendingInteractionBanner.test.tsx
@@ -170,6 +170,10 @@ function expandBanner() {
   fireEvent.click(screen.getByRole("button", { name: "Show details" }));
 }
 
+function isHidden(element: HTMLElement): boolean {
+  return element.closest("[hidden]") !== null;
+}
+
 afterEach(() => {
   cleanup();
   resetPluginSlotStoreForTest();
@@ -182,7 +186,7 @@ afterEach(() => {
 describe("ThreadPendingInteractionBanner tool-use approval", () => {
   it("renders the ask from the subject's presentation with the permission decisions", () => {
     renderBanner(toolUseApproval);
-    expect(screen.getByText("Creating issue")).toBeTruthy();
+    expect(screen.getAllByText("Creating issue").length).toBeGreaterThan(0);
     expandBanner();
     const ask = screen.getByTestId("tool-use-ask");
     expect(ask.textContent).toContain("get-bb/bb#42");
@@ -259,9 +263,10 @@ describe("ThreadPendingInteractionBanner tool-use approval", () => {
 describe("ThreadPendingInteractionBanner request family", () => {
   it("renders a plan review as a request with plan-verdict actions, resolved through today's approval", () => {
     renderBanner(planReview);
-    expect(screen.getByText("Ready to code?")).toBeTruthy();
-    expect(screen.queryByTestId("plan-review-request")).toBeNull();
+    expect(screen.getAllByText("Ready to code?").length).toBeGreaterThan(0);
+    expect(isHidden(screen.getByTestId("plan-review-request"))).toBe(true);
     expandBanner();
+    expect(isHidden(screen.getByTestId("plan-review-request"))).toBe(false);
     expect(screen.getByTestId("plan-review-request").textContent).toContain(
       "Read labels from the declaration",
     );
@@ -369,8 +374,7 @@ describe("ThreadPendingInteractionBanner collapsed strip", () => {
     expect(banner.textContent).toContain(
       "python3 -m unittest discover -s tests 2>&1 | tail -20",
     );
-    expect(banner.textContent).not.toContain("bash -n install.sh");
-    expect(screen.queryByTestId("command-preview")).toBeNull();
+    expect(isHidden(screen.getByTestId("command-preview"))).toBe(true);
     fireEvent.click(screen.getByRole("button", { name: "Allow once" }));
     expect(mocks.resolveMutateAsync).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -400,6 +404,22 @@ describe("ThreadPendingInteractionBanner collapsed strip", () => {
     expect(screen.getByRole("button", { name: "Show less" })).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "Hide details" }));
     expect(banner.hasAttribute("data-expanded")).toBe(false);
+  });
+
+  it("keeps focus on the disclosure button across toggles so Escape works right after opening", () => {
+    renderBanner(commandApproval);
+    const show = screen.getByRole("button", { name: "Show details" });
+    show.focus();
+    fireEvent.click(show);
+    const hide = screen.getByRole("button", { name: "Hide details" });
+    expect(document.activeElement).toBe(hide);
+    fireEvent.keyDown(hide, { key: "Escape" });
+    expect(
+      screen.getByTestId("approval-banner").hasAttribute("data-expanded"),
+    ).toBe(false);
+    expect(document.activeElement).toBe(
+      screen.getByRole("button", { name: "Show details" }),
+    );
   });
 
   it("collapses on Escape while open and forgets the open state when a different request arrives", () => {
@@ -458,7 +478,7 @@ describe("ThreadPendingInteractionBanner collapsed strip", () => {
     ).toBeTruthy();
   });
 
-  it("renders a user question open by default because answering needs the form", () => {
+  it("renders a user question open by default and keeps draft answers across collapse", () => {
     const question: PendingInteraction = {
       ...planReview,
       id: "pint_question",
@@ -480,10 +500,23 @@ describe("ThreadPendingInteractionBanner collapsed strip", () => {
     renderBanner(question);
     const banner = screen.getByTestId("user-question-banner");
     expect(banner.hasAttribute("data-expanded")).toBe(true);
-    expect(screen.getByRole("button", { name: "AOption A" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "AOption A" }));
+    expect(
+      screen
+        .getByRole("button", { name: "AOption A" })
+        .getAttribute("aria-pressed"),
+    ).toBe("true");
     fireEvent.click(screen.getByRole("button", { name: "Hide details" }));
     expect(banner.hasAttribute("data-expanded")).toBe(false);
-    expect(screen.queryByRole("button", { name: "AOption A" })).toBeNull();
+    expect(
+      isHidden(screen.getByRole("button", { name: "AOption A", hidden: true })),
+    ).toBe(true);
     expect(banner.textContent).toContain("Which path should I take?");
+    fireEvent.click(screen.getByRole("button", { name: "Show details" }));
+    expect(
+      screen
+        .getByRole("button", { name: "AOption A" })
+        .getAttribute("aria-pressed"),
+    ).toBe("true");
   });
 });

--- a/apps/app/src/components/thread/pending-interactions/ThreadPendingInteractionBanner.test.tsx
+++ b/apps/app/src/components/thread/pending-interactions/ThreadPendingInteractionBanner.test.tsx
@@ -123,17 +123,51 @@ const pluginRequest: PluginPendingInteraction = {
   payload: { kind: "plugin", title: "Add secrets", data: { fields: ["KEY"] } },
 };
 
+const commandApproval: PendingInteraction = {
+  ...planReview,
+  id: "pint_cmd",
+  providerId: "acp-cursor",
+  payload: {
+    kind: "approval",
+    reason: "Not in allowlist: bash",
+    availableDecisions: ["allow_once", "allow_for_session", "deny"],
+    subject: {
+      kind: "command",
+      itemId: "call_cmd",
+      command:
+        "`python3 -m unittest discover -s tests 2>&1 | tail -20\necho '=== bash -n ==='\nbash -n install.sh && echo OK\necho '=== watcher untouched ==='\ngit diff --stat -- watcher.py\necho '=== live flag ==='`",
+      cwd: "/home/user/immortal-agents",
+      actions: [
+        {
+          type: "unknown",
+          command:
+            "`python3 -m unittest discover -s tests 2>&1 | tail -20\necho '=== bash -n ==='\nbash -n install.sh && echo OK\necho '=== watcher untouched ==='\ngit diff --stat -- watcher.py\necho '=== live flag ==='`",
+        },
+      ],
+      sessionGrant: null,
+    },
+  },
+};
+
+function bannerElement(interaction: PendingInteraction) {
+  return (
+    <ThreadPendingInteractionBanner
+      interaction={interaction}
+      threadId="thr_1"
+    />
+  );
+}
+
 function renderBanner(interaction: PendingInteraction) {
   return render(
     <QueryClientProvider client={new QueryClient()}>
-      <MemoryRouter>
-        <ThreadPendingInteractionBanner
-          interaction={interaction}
-          threadId="thr_1"
-        />
-      </MemoryRouter>
+      <MemoryRouter>{bannerElement(interaction)}</MemoryRouter>
     </QueryClientProvider>,
   );
+}
+
+function expandBanner() {
+  fireEvent.click(screen.getByRole("button", { name: "Show details" }));
 }
 
 afterEach(() => {
@@ -149,6 +183,7 @@ describe("ThreadPendingInteractionBanner tool-use approval", () => {
   it("renders the ask from the subject's presentation with the permission decisions", () => {
     renderBanner(toolUseApproval);
     expect(screen.getByText("Creating issue")).toBeTruthy();
+    expandBanner();
     const ask = screen.getByTestId("tool-use-ask");
     expect(ask.textContent).toContain("get-bb/bb#42");
     expect(ask.textContent).toContain("Tool: mcp__github__create_issue");
@@ -200,6 +235,7 @@ describe("ThreadPendingInteractionBanner tool-use approval", () => {
       ]),
     );
     const withIcon = renderBanner(namespacedAsk);
+    expandBanner();
     const ask = screen.getByTestId("tool-use-ask");
     const mask = ask.querySelector(`[data-plugin-icon-asset="${iconUrl}"]`);
     expect(mask).not.toBeNull();
@@ -211,6 +247,7 @@ describe("ThreadPendingInteractionBanner tool-use approval", () => {
 
     resetPluginLogoStoreForTest();
     renderBanner(namespacedAsk);
+    expandBanner();
     const fallback = screen.getByTestId("tool-use-ask");
     expect(fallback.querySelector("[data-plugin-icon-asset]")).toBeNull();
     expect(fallback.querySelector("svg")?.getAttribute("data-icon")).toBe(
@@ -223,6 +260,8 @@ describe("ThreadPendingInteractionBanner request family", () => {
   it("renders a plan review as a request with plan-verdict actions, resolved through today's approval", () => {
     renderBanner(planReview);
     expect(screen.getByText("Ready to code?")).toBeTruthy();
+    expect(screen.queryByTestId("plan-review-request")).toBeNull();
+    expandBanner();
     expect(screen.getByTestId("plan-review-request").textContent).toContain(
       "Read labels from the declaration",
     );
@@ -314,8 +353,137 @@ describe("ThreadPendingInteractionBanner presentation detail images", () => {
         },
       },
     });
+    expandBanner();
     const ask = screen.getByTestId("tool-use-ask");
     expect(container.querySelector("img")).toBeNull();
     expect(ask.textContent).toContain("[Image: pixel]");
+  });
+});
+
+describe("ThreadPendingInteractionBanner collapsed strip", () => {
+  it("arrives collapsed with the reason, the first command line, and every decision", () => {
+    renderBanner(commandApproval);
+    const banner = screen.getByTestId("approval-banner");
+    expect(banner.hasAttribute("data-expanded")).toBe(false);
+    expect(banner.textContent).toContain("Not in allowlist: bash");
+    expect(banner.textContent).toContain(
+      "python3 -m unittest discover -s tests 2>&1 | tail -20",
+    );
+    expect(banner.textContent).not.toContain("bash -n install.sh");
+    expect(screen.queryByTestId("command-preview")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Allow once" }));
+    expect(mocks.resolveMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        interactionId: "pint_cmd",
+        resolution: { decision: "allow_once", grantedPermissions: null },
+      }),
+    );
+  });
+
+  it("opens the full card on demand, shows a four-line preview, and never repeats the command as an action line", () => {
+    renderBanner(commandApproval);
+    expandBanner();
+    const banner = screen.getByTestId("approval-banner");
+    expect(banner.hasAttribute("data-expanded")).toBe(true);
+    expect(screen.getByText("Approval needed")).toBeTruthy();
+    const preview = screen.getByTestId("command-preview");
+    const pre = preview.querySelector("pre");
+    expect(pre?.textContent).toContain("bash -n install.sh && echo OK");
+    expect(pre?.textContent).toContain("echo '=== watcher untouched ==='");
+    expect(pre?.textContent).not.toContain("git diff --stat -- watcher.py");
+    expect(preview.textContent).not.toContain("Action:");
+    expect(preview.textContent).toContain("/home/user/immortal-agents");
+    fireEvent.click(screen.getByRole("button", { name: "Show 2 more lines" }));
+    expect(preview.querySelector("pre")?.textContent).toContain(
+      "git diff --stat -- watcher.py",
+    );
+    expect(screen.getByRole("button", { name: "Show less" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Hide details" }));
+    expect(banner.hasAttribute("data-expanded")).toBe(false);
+  });
+
+  it("collapses on Escape while open and forgets the open state when a different request arrives", () => {
+    const client = new QueryClient();
+    const view = render(
+      <QueryClientProvider client={client}>
+        <MemoryRouter>{bannerElement(commandApproval)}</MemoryRouter>
+      </QueryClientProvider>,
+    );
+    expandBanner();
+    fireEvent.keyDown(screen.getByRole("button", { name: "Deny" }), {
+      key: "Escape",
+    });
+    expect(
+      screen.getByTestId("approval-banner").hasAttribute("data-expanded"),
+    ).toBe(false);
+    expandBanner();
+    expect(
+      screen.getByTestId("approval-banner").hasAttribute("data-expanded"),
+    ).toBe(true);
+    view.rerender(
+      <QueryClientProvider client={client}>
+        <MemoryRouter>
+          {bannerElement({ ...commandApproval, id: "pint_cmd_next" })}
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+    expect(
+      screen.getByTestId("approval-banner").hasAttribute("data-expanded"),
+    ).toBe(false);
+  });
+
+  it("keeps the source thread reachable from the strip and the card", () => {
+    render(
+      <QueryClientProvider client={new QueryClient()}>
+        <MemoryRouter>
+          <ThreadPendingInteractionBanner
+            interaction={commandApproval}
+            sourceThread={{
+              href: "/threads/thr_child",
+              title: "Install tools",
+            }}
+            threadId="thr_child"
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+    expect(
+      screen
+        .getByRole("link", { name: "From Install tools" })
+        .getAttribute("href"),
+    ).toBe("/threads/thr_child");
+    expandBanner();
+    expect(
+      screen.getByRole("link", { name: "From Install tools" }),
+    ).toBeTruthy();
+  });
+
+  it("renders a user question open by default because answering needs the form", () => {
+    const question: PendingInteraction = {
+      ...planReview,
+      id: "pint_question",
+      resolution: null,
+      payload: {
+        kind: "user_question",
+        questions: [
+          {
+            id: "path",
+            prompt: "Which path should I take?",
+            shortLabel: "Path",
+            multiSelect: false,
+            allowFreeText: false,
+            options: [{ value: "a", label: "A", description: "Option A" }],
+          },
+        ],
+      },
+    };
+    renderBanner(question);
+    const banner = screen.getByTestId("user-question-banner");
+    expect(banner.hasAttribute("data-expanded")).toBe(true);
+    expect(screen.getByRole("button", { name: "AOption A" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Hide details" }));
+    expect(banner.hasAttribute("data-expanded")).toBe(false);
+    expect(screen.queryByRole("button", { name: "AOption A" })).toBeNull();
+    expect(banner.textContent).toContain("Which path should I take?");
   });
 });

--- a/apps/app/src/components/thread/pending-interactions/ThreadPendingInteractionBanner.tsx
+++ b/apps/app/src/components/thread/pending-interactions/ThreadPendingInteractionBanner.tsx
@@ -84,7 +84,7 @@ interface BannerShellProps {
   initiallyExpanded: boolean;
   errorMessage?: string | null;
   footer?: (layout: BannerLayout) => ReactNode;
-  children?: ReactNode;
+  children?: (isExpanded: boolean) => ReactNode;
   sourceThread?: ThreadPendingInteractionSourceThread;
   testId: string;
 }
@@ -239,24 +239,26 @@ function PlanReviewRequestBanner({
         />
       )}
     >
-      <div
-        className="overflow-hidden rounded-lg border border-border bg-card"
-        data-testid="plan-review-request"
-      >
+      {() => (
         <div
-          className={cn(
-            getDetailScrollMaxHeightClass("base"),
-            "overflow-auto px-3 py-2",
-          )}
+          className="overflow-hidden rounded-lg border border-border bg-card"
+          data-testid="plan-review-request"
         >
-          <MarkdownPreview content={plan} className="text-xs" />
+          <div
+            className={cn(
+              getDetailScrollMaxHeightClass("base"),
+              "overflow-auto px-3 py-2",
+            )}
+          >
+            <MarkdownPreview content={plan} className="text-xs" />
+          </div>
+          {planFilePath ? (
+            <p className="truncate border-t border-border px-3 py-2 font-mono text-xs text-muted-foreground">
+              {planFilePath}
+            </p>
+          ) : null}
         </div>
-        {planFilePath ? (
-          <p className="truncate border-t border-border px-3 py-2 font-mono text-xs text-muted-foreground">
-            {planFilePath}
-          </p>
-        ) : null}
-      </div>
+      )}
     </BannerShell>
   );
 }
@@ -385,7 +387,9 @@ function BannerShell({
           </h3>
         ) : null}
         {children ? (
-          <div className={title ? "mt-2" : undefined}>{children}</div>
+          <div className={title ? "mt-2" : undefined}>
+            {children(isExpanded)}
+          </div>
         ) : null}
         {footer ? (
           <div className="mt-3 flex flex-wrap items-center gap-2">
@@ -484,7 +488,7 @@ function ApprovalPendingInteractionBanner({
         />
       )}
     >
-      {view.body}
+      {() => view.body}
     </BannerShell>
   );
 }
@@ -507,12 +511,15 @@ function ThreadUserQuestionPendingInteractionBanner({
       sourceThread={sourceThread}
       testId="user-question-banner"
     >
-      <UserQuestionAnswerForm
-        interactionId={interaction.id}
-        isResolving={isResolving}
-        questions={questions}
-        threadId={threadId}
-      />
+      {(isExpanded) => (
+        <UserQuestionAnswerForm
+          interactionId={interaction.id}
+          isResolving={isResolving}
+          questions={questions}
+          shortcutsEnabled={isExpanded}
+          threadId={threadId}
+        />
+      )}
     </BannerShell>
   );
 }

--- a/apps/app/src/components/thread/pending-interactions/ThreadPendingInteractionBanner.tsx
+++ b/apps/app/src/components/thread/pending-interactions/ThreadPendingInteractionBanner.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type ReactNode } from "react";
+import { useMemo, useState, type KeyboardEvent, type ReactNode } from "react";
 import { NavLink } from "react-router-dom";
 import {
   assertNever,
@@ -20,11 +20,13 @@ import {
 import { Button } from "@bb/shared-ui/button";
 import { ExpandableLine } from "@/components/ui/expandable-line.js";
 import { Icon } from "@bb/shared-ui/icon";
+import { useIsCompactViewport } from "@bb/shared-ui/hooks/use-compact-viewport";
 import { MarkdownPreview } from "@/components/ui/markdown-preview.js";
 import { getDetailScrollMaxHeightClass } from "@/components/ui/detail-scroll-size.js";
 import { UserQuestionAnswerForm } from "@/components/thread/user-questions/UserQuestionInteractionContent.js";
 import { useResolveThreadPendingInteraction } from "@/hooks/mutations/thread-interaction-mutations";
 import { PluginPendingInteractionComposer } from "@/components/plugin/PluginPendingInteractionComposer";
+import { PromptBannerActionButton } from "@/components/promptbox/banner/prompt-banner-actions";
 import {
   classifyInteractionRequest,
   type InteractionRequestView,
@@ -70,17 +72,30 @@ interface UserQuestionPendingInteractionBannerProps {
 }
 
 interface BannerShellProps {
+  label: string;
   title?: string;
+  summary?: string | null;
+  initiallyExpanded: boolean;
   errorMessage?: string | null;
-  footer?: ReactNode;
+  footer?: (layout: BannerLayout) => ReactNode;
   children?: ReactNode;
   sourceThread?: ThreadPendingInteractionSourceThread;
+  testId: string;
 }
+
+type BannerLayout = "strip" | "card";
 
 interface ApprovalSubject {
   title: string;
+  summary: string | null;
   body: ReactNode;
 }
+
+const COMMAND_PREVIEW_LINE_COUNT = 4;
+const APPROVAL_DECISION_ORDER: Record<
+  PendingInteractionApprovalDecision,
+  number
+> = { deny: 0, allow_for_session: 1, allow_once: 2 };
 
 interface BuildApprovalSubjectInput {
   interaction: PendingInteraction;
@@ -88,7 +103,13 @@ interface BuildApprovalSubjectInput {
   subject: ApprovalBannerSubject;
 }
 
-export function ThreadPendingInteractionBanner({
+export function ThreadPendingInteractionBanner(
+  props: ThreadPendingInteractionBannerProps,
+) {
+  return <PendingInteractionBanner key={props.interaction.id} {...props} />;
+}
+
+function PendingInteractionBanner({
   interaction,
   sourceThread,
   threadId,
@@ -194,19 +215,23 @@ function PlanReviewRequestBanner({
   const { plan, planFilePath } = request.review;
   return (
     <BannerShell
+      label="Plan review"
       title={approval.reason ?? "Ready to code?"}
+      summary={planFilePath ?? firstLine(plan)}
+      initiallyExpanded={false}
       errorMessage={mutationErrorMessage}
       sourceThread={sourceThread}
-      footer={approval.availableDecisions.map((decision) => (
-        <ApprovalDecisionButton
-          key={decision}
-          decision={decision}
+      testId="plan-review-banner"
+      footer={(layout) => (
+        <ApprovalDecisionButtons
+          decisions={approval.availableDecisions}
           disabled={submitDisabled}
-          isLoading={isResolving && submittedDecision === decision}
-          onClick={() => submitDecision(decision)}
+          layout={layout}
+          loadingDecision={isResolving ? submittedDecision : null}
+          onDecide={submitDecision}
           subjectKind="plan"
         />
-      ))}
+      )}
     >
       <div
         className="overflow-hidden rounded-lg border border-border bg-card"
@@ -231,44 +256,171 @@ function PlanReviewRequestBanner({
 }
 
 function BannerShell({
+  label,
   title,
+  summary,
+  initiallyExpanded,
   errorMessage,
   footer,
   children,
   sourceThread,
+  testId,
 }: BannerShellProps) {
-  return (
-    <div className="mb-2 min-w-0 max-w-full overflow-hidden rounded-lg border border-border bg-surface-recessed px-4 py-3 text-xs text-muted-foreground">
-      {sourceThread ? (
-        <NavLink
-          to={sourceThread.href}
-          className="mb-1 block text-xs text-muted-foreground no-underline hover:underline"
-        >
-          From child thread: {sourceThread.title}
-        </NavLink>
-      ) : null}
-      {title ? (
-        <h3 className="min-w-0 text-sm font-semibold text-foreground">
-          <ExpandableLine fullText={title} collapsedClassName="line-clamp-2">
-            {title}
-          </ExpandableLine>
-        </h3>
-      ) : null}
-      {children ? (
-        <div className={title ? "mt-3" : undefined}>{children}</div>
-      ) : null}
-      {footer ? (
-        <div className="mt-3 flex flex-wrap items-center justify-end gap-2">
-          {footer}
-        </div>
-      ) : null}
-      {errorMessage ? (
-        <div className="mt-2 rounded-md border border-surface-destructive-border bg-surface-destructive px-2 py-1 text-xs text-destructive-text">
-          {errorMessage}
-        </div>
-      ) : null}
-    </div>
+  const [isExpanded, setIsExpanded] = useState(initiallyExpanded);
+  const isCompactViewport = useIsCompactViewport();
+  const collapsesOnEscape = !initiallyExpanded;
+  const handleKeyDown = (event: KeyboardEvent<HTMLElement>) => {
+    if (
+      event.key === "Escape" &&
+      isExpanded &&
+      collapsesOnEscape &&
+      !event.defaultPrevented
+    ) {
+      event.preventDefault();
+      event.stopPropagation();
+      setIsExpanded(false);
+    }
+  };
+  const toggle = (
+    <button
+      type="button"
+      aria-expanded={isExpanded}
+      aria-label={isExpanded ? "Hide details" : "Show details"}
+      onClick={() => setIsExpanded((value) => !value)}
+      className="flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-state-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+    >
+      <Icon
+        name="ChevronDown"
+        className={cn(
+          "size-3.5 transition-transform duration-200",
+          isExpanded ? "rotate-180" : undefined,
+        )}
+      />
+    </button>
   );
+  const errorNode = errorMessage ? (
+    <div className="mx-3 mb-3 rounded-md border border-surface-destructive-border bg-surface-destructive px-2 py-1 text-xs text-destructive-text">
+      {errorMessage}
+    </div>
+  ) : null;
+  const sourceThreadLink = sourceThread ? (
+    <NavLink
+      to={sourceThread.href}
+      title={sourceThread.title}
+      className={cn(
+        "min-w-0 shrink-[3] truncate text-xs text-subtle-foreground no-underline hover:underline",
+        isExpanded ? undefined : "hidden @3xl:block",
+      )}
+    >
+      From {sourceThread.title}
+    </NavLink>
+  ) : null;
+
+  return (
+    <section
+      aria-label={label}
+      data-testid={testId}
+      data-expanded={isExpanded ? "" : undefined}
+      onKeyDown={handleKeyDown}
+      className="@container mb-2 min-w-0 max-w-full rounded-lg border border-attention/40 bg-surface-raised-solid text-xs text-muted-foreground ring-[3px] ring-surface-attention"
+    >
+      {isExpanded ? (
+        <>
+          <div className="flex items-center gap-2 border-b border-border-hairline py-1.5 pl-3 pr-1.5">
+            <AttentionDot />
+            <span className="shrink-0 text-sm font-semibold text-foreground">
+              {label}
+            </span>
+            {sourceThreadLink}
+            <span className="flex-1" />
+            {toggle}
+          </div>
+          <div className="px-3 pb-3 pt-2.5">
+            {title ? (
+              <h3 className="min-w-0 text-sm font-medium text-foreground">
+                <ExpandableLine
+                  fullText={title}
+                  collapsedClassName="line-clamp-2"
+                >
+                  {title}
+                </ExpandableLine>
+              </h3>
+            ) : null}
+            {children ? (
+              <div className={title ? "mt-2" : undefined}>{children}</div>
+            ) : null}
+            {footer ? (
+              <div className="mt-3 flex flex-wrap items-center gap-2">
+                {footer("card")}
+              </div>
+            ) : null}
+          </div>
+          {errorNode}
+        </>
+      ) : (
+        <>
+          <div
+            className={cn(
+              "flex min-h-9 items-center gap-2 py-1 pl-3 pr-1.5",
+              isCompactViewport ? "flex-wrap" : undefined,
+            )}
+          >
+            <AttentionDot />
+            <span
+              className="min-w-24 shrink truncate text-sm font-medium text-foreground"
+              title={title ?? label}
+            >
+              {title ?? label}
+            </span>
+            {summary ? (
+              <span
+                className="min-w-20 shrink-[2] truncate font-mono text-xs text-muted-foreground"
+                title={summary}
+              >
+                {summary}
+              </span>
+            ) : null}
+            {sourceThreadLink}
+            <span className="flex-1" />
+            {footer ? (
+              <div className="flex shrink-0 items-center gap-1.5">
+                {footer("strip")}
+              </div>
+            ) : null}
+            {toggle}
+          </div>
+          {errorNode}
+        </>
+      )}
+    </section>
+  );
+}
+
+function AttentionDot() {
+  return (
+    <span
+      aria-hidden="true"
+      className="size-2 shrink-0 rounded-full bg-attention ring-[3px] ring-surface-attention"
+    />
+  );
+}
+
+function unwrapBacktickedCommand(command: string): string {
+  const trimmed = command.trim();
+  return trimmed.length > 2 &&
+    trimmed.startsWith("`") &&
+    trimmed.endsWith("`") &&
+    !trimmed.slice(1, -1).includes("`")
+    ? trimmed.slice(1, -1)
+    : command;
+}
+
+function firstLine(text: string): string | null {
+  const line = text
+    .split("\n")
+    .map((candidate) => candidate.trim())
+    .find((candidate) => candidate.length > 0);
+  return line ?? null;
 }
 
 function ApprovalPendingInteractionBanner({
@@ -312,19 +464,23 @@ function ApprovalPendingInteractionBanner({
 
   return (
     <BannerShell
+      label="Approval needed"
       title={view.title}
+      summary={view.summary}
+      initiallyExpanded={false}
       errorMessage={mutationErrorMessage}
       sourceThread={sourceThread}
-      footer={payload.availableDecisions.map((decision) => (
-        <ApprovalDecisionButton
-          key={decision}
-          decision={decision}
+      testId="approval-banner"
+      footer={(layout) => (
+        <ApprovalDecisionButtons
+          decisions={payload.availableDecisions}
           disabled={submitDisabled}
-          isLoading={isResolving && submittedDecision === decision}
-          onClick={() => submitDecision(decision)}
+          layout={layout}
+          loadingDecision={isResolving ? submittedDecision : null}
+          onDecide={submitDecision}
           subjectKind={subject.kind}
         />
-      ))}
+      )}
     >
       {view.body}
     </BannerShell>
@@ -340,7 +496,15 @@ function ThreadUserQuestionPendingInteractionBanner({
   const isResolving = interaction.status === "resolving";
 
   return (
-    <BannerShell sourceThread={sourceThread}>
+    <BannerShell
+      label={
+        questions.length === 1 ? "Question" : `${questions.length} questions`
+      }
+      summary={questions[0]?.prompt ?? null}
+      initiallyExpanded
+      sourceThread={sourceThread}
+      testId="user-question-banner"
+    >
       <UserQuestionAnswerForm
         interactionId={interaction.id}
         isResolving={isResolving}
@@ -351,7 +515,48 @@ function ThreadUserQuestionPendingInteractionBanner({
   );
 }
 
+interface ApprovalDecisionButtonsProps {
+  decisions: readonly PendingInteractionApprovalDecision[];
+  disabled: boolean;
+  layout: BannerLayout;
+  loadingDecision: PendingInteractionApprovalDecision | null;
+  onDecide: (decision: PendingInteractionApprovalDecision) => void;
+  subjectKind: PendingInteractionApprovalSubject["kind"];
+}
+
+function ApprovalDecisionButtons({
+  decisions,
+  disabled,
+  layout,
+  loadingDecision,
+  onDecide,
+  subjectKind,
+}: ApprovalDecisionButtonsProps) {
+  const denyFirst = [...decisions].sort(
+    (left, right) =>
+      APPROVAL_DECISION_ORDER[left] - APPROVAL_DECISION_ORDER[right],
+  );
+  return denyFirst.map((decision, index) => (
+    <ApprovalDecisionButton
+      key={decision}
+      decision={decision}
+      disabled={disabled}
+      isLoading={loadingDecision === decision}
+      layout={layout}
+      onClick={() => onDecide(decision)}
+      subjectKind={subjectKind}
+      className={
+        layout === "card" && index === 0 && decision === "deny"
+          ? "mr-auto"
+          : undefined
+      }
+    />
+  ));
+}
+
 interface ApprovalDecisionButtonProps {
+  className?: string;
+  layout: BannerLayout;
   decision: PendingInteractionApprovalDecision;
   disabled: boolean;
   isLoading: boolean;
@@ -360,12 +565,34 @@ interface ApprovalDecisionButtonProps {
 }
 
 function ApprovalDecisionButton({
+  className,
   decision,
   disabled,
   isLoading,
+  layout,
   onClick,
   subjectKind,
 }: ApprovalDecisionButtonProps) {
+  const label = labelForApprovalDecision(decision, subjectKind);
+  const spinner = isLoading ? (
+    <Icon name="Spinner" className="size-3 animate-spin" />
+  ) : null;
+  if (layout === "strip") {
+    return (
+      <PromptBannerActionButton
+        disabled={disabled}
+        onClick={onClick}
+        className={cn(
+          "gap-1",
+          compactApprovalDecisionButtonClass(decision),
+          className,
+        )}
+      >
+        {spinner}
+        {label}
+      </PromptBannerActionButton>
+    );
+  }
   return (
     <Button
       type="button"
@@ -373,13 +600,25 @@ function ApprovalDecisionButton({
       variant={approvalDecisionButtonVariant(decision)}
       disabled={disabled}
       onClick={onClick}
+      className={className}
     >
-      {isLoading ? (
-        <Icon name="Spinner" className="size-3 animate-spin" />
-      ) : null}
-      {labelForApprovalDecision(decision, subjectKind)}
+      {spinner}
+      {label}
     </Button>
   );
+}
+
+function compactApprovalDecisionButtonClass(
+  decision: PendingInteractionApprovalDecision,
+): string | undefined {
+  switch (decision) {
+    case "allow_once":
+      return "border-foreground bg-foreground text-background hover:bg-foreground/90 hover:text-background";
+    case "allow_for_session":
+      return undefined;
+    case "deny":
+      return "border-transparent bg-transparent shadow-none";
+  }
 }
 
 function approvalDecisionButtonVariant(
@@ -464,6 +703,59 @@ function ToolUseAskCard({ ask }: { ask: PendingInteractionToolUseAsk }) {
   );
 }
 
+function CommandPreview({
+  command,
+  detailLines,
+}: {
+  command: string;
+  detailLines: readonly string[];
+}) {
+  const [showsAllLines, setShowsAllLines] = useState(false);
+  const lines = command.split("\n");
+  const hiddenLineCount = Math.max(
+    0,
+    lines.length - COMMAND_PREVIEW_LINE_COUNT,
+  );
+  const visibleCommand =
+    showsAllLines || hiddenLineCount === 0
+      ? command
+      : lines.slice(0, COMMAND_PREVIEW_LINE_COUNT).join("\n");
+  return (
+    <div
+      className="min-w-0 max-w-full overflow-hidden rounded-lg border border-border bg-card"
+      data-testid="command-preview"
+    >
+      <pre
+        className={cn(
+          getDetailScrollMaxHeightClass("base"),
+          "max-w-full overflow-auto whitespace-pre px-3 py-2 font-mono text-xs leading-relaxed text-foreground",
+        )}
+      >
+        $ {visibleCommand}
+      </pre>
+      {hiddenLineCount > 0 ? (
+        <button
+          type="button"
+          onClick={() => setShowsAllLines((value) => !value)}
+          className="block w-full border-t border-border px-3 py-1.5 text-left text-xs text-muted-foreground hover:bg-state-hover hover:text-foreground"
+        >
+          {showsAllLines
+            ? "Show less"
+            : hiddenLineCount === 1
+              ? "Show 1 more line"
+              : `Show ${hiddenLineCount} more lines`}
+        </button>
+      ) : null}
+      {detailLines.length > 0 ? (
+        <ApprovalDetailList
+          className="border-t border-border px-3 py-2"
+          lines={detailLines}
+        />
+      ) : null}
+    </div>
+  );
+}
+
 function buildApprovalSubject({
   interaction,
   payload,
@@ -473,34 +765,27 @@ function buildApprovalSubject({
     case "command": {
       const rawCommand = subject.command;
       const command = rawCommand
-        ? (extractShellCommandFromString(rawCommand) ?? rawCommand)
+        ? unwrapBacktickedCommand(
+            extractShellCommandFromString(rawCommand) ?? rawCommand,
+          )
         : null;
       const detailLines = formatPendingInteractionSubjectDetailLines(
         interaction,
       )
-        .filter((line) => !line.startsWith("Command: "))
+        .filter(
+          (line) =>
+            !line.startsWith("Command: ") &&
+            line !== `Action: ${rawCommand}` &&
+            line !== `Action: ${command}`,
+        )
         .map((line) =>
           line.startsWith("Cwd: ") ? line.slice("Cwd: ".length) : line,
         );
       return {
         title: payload.reason ?? "Do you want to run this command?",
+        summary: command ? firstLine(command) : null,
         body: command ? (
-          <div className="min-w-0 max-w-full overflow-hidden rounded-lg border border-border bg-card">
-            <pre
-              className={cn(
-                getDetailScrollMaxHeightClass("base"),
-                "max-w-full overflow-auto whitespace-pre px-3 py-2 font-mono text-xs leading-relaxed text-foreground",
-              )}
-            >
-              $ {command}
-            </pre>
-            {detailLines.length > 0 ? (
-              <ApprovalDetailList
-                className="border-t border-border px-3 py-2"
-                lines={detailLines}
-              />
-            ) : null}
-          </div>
+          <CommandPreview command={command} detailLines={detailLines} />
         ) : null,
       };
     }
@@ -509,6 +794,7 @@ function buildApprovalSubject({
         formatPendingInteractionSubjectDetailLines(interaction);
       return {
         title: payload.reason ?? "Do you want to make these changes?",
+        summary: subject.writeScope,
         body:
           detailLines.length > 0 ? (
             <ApprovalDetailList
@@ -523,6 +809,7 @@ function buildApprovalSubject({
         formatPendingInteractionSubjectDetailLines(interaction);
       return {
         title: payload.reason ?? "Do you want to grant this permission?",
+        summary: subject.toolName ?? detailLines[0] ?? null,
         body:
           detailLines.length > 0 ? (
             <ApprovalDetailList
@@ -536,6 +823,7 @@ function buildApprovalSubject({
       const ask = describePendingInteractionToolUse({ ...payload, subject });
       return {
         title: ask.title,
+        summary: ask.headline ?? ask.tool,
         body: <ToolUseAskCard ask={ask} />,
       };
     }

--- a/apps/app/src/components/thread/pending-interactions/ThreadPendingInteractionBanner.tsx
+++ b/apps/app/src/components/thread/pending-interactions/ThreadPendingInteractionBanner.tsx
@@ -1,4 +1,11 @@
-import { useMemo, useState, type KeyboardEvent, type ReactNode } from "react";
+import {
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type ReactNode,
+} from "react";
 import { NavLink } from "react-router-dom";
 import {
   assertNever,
@@ -20,7 +27,6 @@ import {
 import { Button } from "@bb/shared-ui/button";
 import { ExpandableLine } from "@/components/ui/expandable-line.js";
 import { Icon } from "@bb/shared-ui/icon";
-import { useIsCompactViewport } from "@bb/shared-ui/hooks/use-compact-viewport";
 import { MarkdownPreview } from "@/components/ui/markdown-preview.js";
 import { getDetailScrollMaxHeightClass } from "@/components/ui/detail-scroll-size.js";
 import { UserQuestionAnswerForm } from "@/components/thread/user-questions/UserQuestionInteractionContent.js";
@@ -267,8 +273,14 @@ function BannerShell({
   testId,
 }: BannerShellProps) {
   const [isExpanded, setIsExpanded] = useState(initiallyExpanded);
-  const isCompactViewport = useIsCompactViewport();
+  const toggleRef = useRef<HTMLButtonElement>(null);
+  const shouldRestoreToggleFocusRef = useRef(false);
   const collapsesOnEscape = !initiallyExpanded;
+  useLayoutEffect(() => {
+    if (!shouldRestoreToggleFocusRef.current) return;
+    shouldRestoreToggleFocusRef.current = false;
+    toggleRef.current?.focus();
+  }, [isExpanded]);
   const handleKeyDown = (event: KeyboardEvent<HTMLElement>) => {
     if (
       event.key === "Escape" &&
@@ -278,15 +290,21 @@ function BannerShell({
     ) {
       event.preventDefault();
       event.stopPropagation();
+      shouldRestoreToggleFocusRef.current = true;
       setIsExpanded(false);
     }
   };
   const toggle = (
     <button
+      ref={toggleRef}
       type="button"
       aria-expanded={isExpanded}
       aria-label={isExpanded ? "Hide details" : "Show details"}
-      onClick={() => setIsExpanded((value) => !value)}
+      onClick={(event) => {
+        shouldRestoreToggleFocusRef.current =
+          document.activeElement === event.currentTarget;
+        setIsExpanded((value) => !value);
+      }}
       className="flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-state-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
     >
       <Icon
@@ -307,10 +325,7 @@ function BannerShell({
     <NavLink
       to={sourceThread.href}
       title={sourceThread.title}
-      className={cn(
-        "min-w-0 shrink-[3] truncate text-xs text-subtle-foreground no-underline hover:underline",
-        isExpanded ? undefined : "hidden @3xl:block",
-      )}
+      className="min-w-24 shrink-[3] truncate text-xs text-subtle-foreground no-underline hover:underline"
     >
       From {sourceThread.title}
     </NavLink>
@@ -325,73 +340,60 @@ function BannerShell({
       className="@container mb-2 min-w-0 max-w-full rounded-lg border border-attention/40 bg-surface-raised-solid text-xs text-muted-foreground ring-[3px] ring-surface-attention"
     >
       {isExpanded ? (
-        <>
-          <div className="flex items-center gap-2 border-b border-border-hairline py-1.5 pl-3 pr-1.5">
-            <AttentionDot />
-            <span className="shrink-0 text-sm font-semibold text-foreground">
-              {label}
-            </span>
-            {sourceThreadLink}
-            <span className="flex-1" />
-            {toggle}
-          </div>
-          <div className="px-3 pb-3 pt-2.5">
-            {title ? (
-              <h3 className="min-w-0 text-sm font-medium text-foreground">
-                <ExpandableLine
-                  fullText={title}
-                  collapsedClassName="line-clamp-2"
-                >
-                  {title}
-                </ExpandableLine>
-              </h3>
-            ) : null}
-            {children ? (
-              <div className={title ? "mt-2" : undefined}>{children}</div>
-            ) : null}
-            {footer ? (
-              <div className="mt-3 flex flex-wrap items-center gap-2">
-                {footer("card")}
-              </div>
-            ) : null}
-          </div>
-          {errorNode}
-        </>
+        <div className="flex items-center gap-2 border-b border-border-hairline py-1.5 pl-3 pr-1.5">
+          <AttentionDot />
+          <span className="shrink-0 text-sm font-semibold text-foreground">
+            {label}
+          </span>
+          {sourceThreadLink}
+          <span className="flex-1" />
+          {toggle}
+        </div>
       ) : (
-        <>
-          <div
-            className={cn(
-              "flex min-h-9 items-center gap-2 py-1 pl-3 pr-1.5",
-              isCompactViewport ? "flex-wrap" : undefined,
-            )}
+        <div className="flex min-h-9 flex-wrap items-center gap-2 py-1 pl-3 pr-1.5 @2xl:flex-nowrap">
+          <AttentionDot />
+          <span
+            className="min-w-24 shrink truncate text-sm font-medium text-foreground"
+            title={title ?? label}
           >
-            <AttentionDot />
+            {title ?? label}
+          </span>
+          {summary ? (
             <span
-              className="min-w-24 shrink truncate text-sm font-medium text-foreground"
-              title={title ?? label}
+              className="min-w-20 shrink-[2] truncate font-mono text-xs text-muted-foreground"
+              title={summary}
             >
-              {title ?? label}
+              {summary}
             </span>
-            {summary ? (
-              <span
-                className="min-w-20 shrink-[2] truncate font-mono text-xs text-muted-foreground"
-                title={summary}
-              >
-                {summary}
-              </span>
-            ) : null}
-            {sourceThreadLink}
-            <span className="flex-1" />
-            {footer ? (
-              <div className="flex shrink-0 items-center gap-1.5">
-                {footer("strip")}
-              </div>
-            ) : null}
-            {toggle}
-          </div>
-          {errorNode}
-        </>
+          ) : null}
+          {sourceThreadLink}
+          <span className="flex-1" />
+          {footer ? (
+            <div className="flex shrink-0 items-center gap-1.5">
+              {footer("strip")}
+            </div>
+          ) : null}
+          {toggle}
+        </div>
       )}
+      <div hidden={!isExpanded} className="px-3 pb-3 pt-2.5">
+        {title ? (
+          <h3 className="min-w-0 text-sm font-medium text-foreground">
+            <ExpandableLine fullText={title} collapsedClassName="line-clamp-2">
+              {title}
+            </ExpandableLine>
+          </h3>
+        ) : null}
+        {children ? (
+          <div className={title ? "mt-2" : undefined}>{children}</div>
+        ) : null}
+        {footer ? (
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            {footer("card")}
+          </div>
+        ) : null}
+      </div>
+      {errorNode}
     </section>
   );
 }

--- a/apps/app/src/components/thread/user-questions/UserQuestionInteractionContent.tsx
+++ b/apps/app/src/components/thread/user-questions/UserQuestionInteractionContent.tsx
@@ -41,6 +41,7 @@ interface UserQuestionAnswerFormProps {
   interactionId: string;
   isResolving?: boolean;
   questions: readonly PendingInteractionUserQuestionQuestion[];
+  shortcutsEnabled: boolean;
   threadId: string;
 }
 
@@ -279,6 +280,7 @@ export function UserQuestionAnswerForm({
   interactionId,
   isResolving = false,
   questions,
+  shortcutsEnabled,
   threadId,
 }: UserQuestionAnswerFormProps) {
   const [formState, setFormState] = useState<QuestionFormState>(() =>
@@ -399,7 +401,9 @@ export function UserQuestionAnswerForm({
 
   const isFocusedPane = useOptionalPaneContext()?.isFocused ?? true;
   const selectChoiceAt = (index: number): boolean => {
-    if (!isFocusedPane || disabled || !currentQuestion) return false;
+    if (!isFocusedPane || disabled || !shortcutsEnabled || !currentQuestion) {
+      return false;
+    }
     const choice = resolveQuestionShortcutChoice(currentQuestion, index);
     if (choice?.kind === "option") {
       handleToggleOption(currentQuestion, choice.value);
@@ -412,11 +416,15 @@ export function UserQuestionAnswerForm({
     return false;
   };
 
-  useAppCommandContext("questionOpen", currentQuestion !== null && !disabled);
+  useAppCommandContext(
+    "questionOpen",
+    currentQuestion !== null && !disabled && shortcutsEnabled,
+  );
   useIndexedAppCommandHandlers(
     QUESTION_SELECT_APP_COMMAND_IDS,
     selectChoiceAt,
     100,
+    shortcutsEnabled,
   );
 
   if (!currentQuestion) {


### PR DESCRIPTION
## Human comments

## What was wrong

The pending-approval banner above the composer claimed most of the viewport: a full-height command block, the same command repeated as a flattened "Action:" paragraph, and no way to get it out of the way without deciding. When a child thread asked for an approval, the parent's transcript was pushed up until the message that caused the request was no longer readable. The bridge's backtick-wrapped commands also leaked a literal backtick into the block.

## What changed

`apps/app/src/components/thread/pending-interactions/ThreadPendingInteractionBanner.tsx`

- Approvals and plan reviews now arrive collapsed as a one-row strip: attention dot, reason, first command line in mono, child-thread link, every decision button, and a chevron. The strip is fully actionable.
- The full card opens on demand with a header row, the reason, the subject body, and Deny on the left. Esc collapses an open approval or plan-review card.
- Open state is keyed by interaction id, so it never carries over to the next request.
- Command previews cap at four lines with a "Show N more lines" control. The working directory sits under the preview. The "Action:" line that repeated the whole script is dropped, and backtick-wrapped commands are unwrapped.
- Decisions are ordered Deny, Allow for session, Allow once. The strip uses the compact `PromptBannerActionButton` the context banner already uses; the card keeps the full-size buttons.
- User questions still open by default because answering needs the form, but they get the same header and collapse control. Plugin-defined requests are unchanged.

Stories gained a multi-line child-thread script row. No wire, CLI, or SDK changes.

## How you verified

- `ThreadPendingInteractionBanner.test.tsx`: 12 tests pass, five new. They cover the collapsed default and deciding from the strip, the four-line preview and dropped "Action:" duplicate, Esc and the per-request reset, the child-thread link in both states, and the user-question default. The collapsed-default and no-duplicate assertions fail on main.
- `pnpm exec turbo run typecheck lint test --filter=@bb/app`: clean (479 files, 3905 tests).
- Ladle: every approval story rendered collapsed and expanded in dark mode.
- Dev app: spawned an `acp-cursor` thread in accept-edits mode that requested a real out-of-allowlist command. The strip rendered at 38px, the chevron opened the card, Esc collapsed it, and Allow once from the strip resolved the interaction server-side; Cursor ran the command and the thread went idle.

> AGENT GENERATED
