### PR TITLE
fix(provider-pi): deliver dynamic tool results to Bun-based pi

### DIFF
--- a/plugins/provider-pi/src/bridge/bb-pi-extension.ts
+++ b/plugins/provider-pi/src/bridge/bb-pi-extension.ts
@@ -172,12 +172,7 @@ export default function bbExtension(pi) {
   let nextId = 0;
   let sessionContext = null;
 
-  // Non-blocking: libuv polls the pipe, so pi's process.exit is never held
-  // up by an outstanding read; EOF (the bridge ended its writer) closes it.
-  const bridgeIn = new Socket({ fd: BRIDGE_TO_CHILD_FD, readable: true, writable: false });
-  bridgeIn.on("error", () => undefined);
-  bridgeIn.unref();
-  readLines(bridgeIn, (line) => {
+  const onBridgeLine = (line) => {
     const trimmed = line.trim();
     if (!trimmed) return;
     let message;
@@ -200,7 +195,42 @@ export default function bbExtension(pi) {
     if (message.kind === "request") {
       void handleBridgeRequest(message);
     }
-  });
+  };
+  if (typeof Bun !== "undefined") {
+    // pi ships as a Bun-compiled binary, and Bun's net.Socket cannot attach
+    // to a borrowed stdio fd (the handle stays null and nothing is ever
+    // read), so the bridge channel is read through Bun's file stream instead.
+    void (async () => {
+      const decoder = new StringDecoder("utf8");
+      let pending = "";
+      try {
+        for await (const chunk of Bun.file(BRIDGE_TO_CHILD_FD).stream()) {
+          const text = typeof chunk === "string" ? chunk : decoder.write(chunk);
+          let start = 0;
+          for (;;) {
+            const index = text.indexOf("\n", start);
+            if (index === -1) {
+              pending += text.slice(start);
+              break;
+            }
+            const line = pending + text.slice(start, index);
+            pending = "";
+            start = index + 1;
+            onBridgeLine(line.endsWith("\r") ? line.slice(0, -1) : line);
+          }
+        }
+      } catch {
+        // The bridge is gone; nothing to report to.
+      }
+    })();
+  } else {
+    // Non-blocking: libuv polls the pipe, so pi's process.exit is never held
+    // up by an outstanding read; EOF (the bridge ended its writer) closes it.
+    const bridgeIn = new Socket({ fd: BRIDGE_TO_CHILD_FD, readable: true, writable: false });
+    bridgeIn.on("error", () => undefined);
+    bridgeIn.unref();
+    readLines(bridgeIn, onBridgeLine);
+  }
 
   async function handleBridgeRequest(message) {
     try {

--- a/plugins/provider-pi/src/bridge/bridge.bun-runtime.test.ts
+++ b/plugins/provider-pi/src/bridge/bridge.bun-runtime.test.ts
@@ -1,0 +1,102 @@
+import { spawnSync } from "node:child_process";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { handleLine } from "./bridge.js";
+import { PI_BRIDGE_ARGS_ENV, PI_BRIDGE_COMMAND_ENV } from "./rpc-child.js";
+import {
+  FULL_PERMISSION_OPTIONS,
+  fakePiPath,
+  type FakePiBridgeHarness,
+  startFakePiBridge,
+} from "./test-support.js";
+
+let harness: FakePiBridgeHarness;
+let nextId = 2000;
+
+beforeEach(async () => {
+  harness = await startFakePiBridge({
+    prefix: "bb-pi-bun-",
+    initialize: true,
+  });
+});
+
+afterEach(async () => {
+  await harness.teardown();
+});
+
+function bunBinary(): string | null {
+  // spawnSync failure (bun absent) and a broken-but-present bun both skip.
+  const probe = spawnSync("bun", ["--version"], { encoding: "utf8" });
+  if (probe.status !== 0 || !probe.stdout?.trim()) return null;
+  return "bun";
+}
+
+// pi ships as a Bun standalone binary whose node:net cannot attach a read
+// handle to a borrowed stdio fd, so the extension's bridge channel was dead
+// and every dynamic tool result was dropped. This test runs the same fake pi
+// through the Bun runtime so the fd channel is exercised the way production
+// does. It covers a single fd-4 delivery; sequential messages are untested.
+it.skipIf(bunBinary() === null)(
+  "delivers dynamic tool results when pi runs under the Bun runtime",
+  async () => {
+  const bun = "bun";
+  vi.stubEnv(PI_BRIDGE_COMMAND_ENV, bun);
+  vi.stubEnv(PI_BRIDGE_ARGS_ENV, JSON.stringify([fakePiPath]));
+
+  const threadId = "thr_bun_dyn_tool";
+  const started = await harness.request((nextId += 1), "thread/start", {
+    threadId,
+    cwd: harness.workspaceDir,
+    instructionMode: "append",
+    options: FULL_PERMISSION_OPTIONS,
+    dynamicTools: [
+      {
+        name: "bb_probe",
+        description: "A bb tool.",
+        inputSchema: { type: "object", properties: { value: { type: "string" } } },
+      },
+    ],
+  });
+  expect(started.error, JSON.stringify(started)).toBeUndefined();
+
+  handleLine(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      id: (nextId += 1),
+      method: "turn/start",
+      params: {
+        threadId,
+        providerThreadId: threadId,
+        clientRequestId: "creq_bu23456789",
+        input: [{ type: "text", text: `/tool bb_probe ${JSON.stringify({ value: "hi" })}`, mentions: [] }],
+        options: FULL_PERMISSION_OPTIONS,
+      },
+    }),
+  );
+  const toolCall = await harness.waitForMessage(
+    (m) => m.method === "item/tool/call",
+    "the dynamic tool call",
+  );
+  handleLine(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      id: toolCall.id,
+      result: {
+        contentItems: [{ type: "inputText", text: "bun-result-text" }],
+        success: true,
+      },
+    }),
+  );
+  await harness.waitForMessage(
+    () =>
+      harness
+        .deltasOf(threadId)
+        .some(
+          (d) =>
+            d.kind === "item.textDelta" && String(d.text).includes("Tool said: bun-result-text"),
+        ),
+    "the tool result to reach pi under Bun",
+  );
+  await harness.waitForDelta(threadId, (d) => d.kind === "turn.boundary");
+  },
+  90_000,
+);

--- a/plugins/provider-pi/src/bridge/fake-pi-rpc.mjs
+++ b/plugins/provider-pi/src/bridge/fake-pi-rpc.mjs
@@ -18,7 +18,9 @@
  *   parameters as JSON Schema) for the schema-conversion test.
  * - `--extension <path>` loads the module through a resolve hook that maps
  *   `@earendil-works/pi-coding-agent` and `typebox` onto this package's
- *   copies (pi's loader aliases them the same way), hands it a minimal
+ *   copies (pi's loader aliases them the same way); under runtimes without
+ *   `module.registerHooks` (Bun) a staged copy beside this package's
+ *   node_modules resolves the same bare imports natively. It hands a minimal
  *   extension API (registerTool, on, get/setActiveTools), and emits
  *   `session_start`, `agent_start`, `agent_end` to it in pi's order — the
  *   extension's `ready`, tool calls, `agent-end-leaf`, and fork replies all
@@ -63,9 +65,9 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { registerHooks } from "node:module";
-import { dirname } from "node:path";
+import { appendFileSync, copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { StringDecoder } from "node:string_decoder";
 import { pathToFileURL } from "node:url";
 
@@ -250,13 +252,37 @@ async function loadExtension(path) {
     ["@earendil-works/pi-coding-agent", import.meta.resolve("@earendil-works/pi-coding-agent")],
     ["typebox", import.meta.resolve("typebox")],
   ]);
-  registerHooks({
-    resolve(specifier, context, nextResolve) {
-      const url = aliases.get(specifier);
-      return url ? { url, shortCircuit: true } : nextResolve(specifier, context);
-    },
-  });
-  const module = await import(pathToFileURL(path).href);
+  let hooksRegistered = false;
+  if (typeof Bun === "undefined") {
+    try {
+      const { registerHooks } = await import("node:module");
+      if (typeof registerHooks === "function") {
+        registerHooks({
+          resolve(specifier, context, nextResolve) {
+            const url = aliases.get(specifier);
+            return url ? { url, shortCircuit: true } : nextResolve(specifier, context);
+          },
+        });
+        hooksRegistered = true;
+      }
+    } catch {
+      hooksRegistered = false;
+    }
+  }
+  let loadPath = path;
+  if (!hooksRegistered) {
+    // Bun has no registerHooks: stage the extension copy inside this
+    // package's (gitignored) node_modules so its bare imports
+    // (@earendil-works/pi-coding-agent, typebox) resolve natively.
+    const pkgRoot = join(dirname(fileURLToPath(import.meta.url)), "../..");
+    const staging = mkdtempSync(join(pkgRoot, "node_modules", ".fake-pi-ext-"));
+    copyFileSync(path, staging + "/extension.mjs");
+    loadPath = staging + "/extension.mjs";
+    process.on("exit", () => {
+      try { rmSync(staging, { recursive: true, force: true }); } catch {}
+    });
+  }
+  const module = await import(pathToFileURL(loadPath).href);
   module.default({
     registerTool(tool) {
       extensionTools.set(tool.name, tool);


### PR DESCRIPTION
## Human comments

This is something that almost made me give up on bb but my clanker got through and was able to diagnose the problem. TBH, not sure how this hasn't been reported before, I got it to do some searching on the repo issues / PRs / discussions but it did not find anything related.

Anyways, I hope this is the right way to fix the problem but if not, happy to provide more info about my environment as a separate ticket for discussion and investigation.

I'm about to rebuild my container with this patch + another one I got in the works and will report back if it goes sideways before marking the PR as ready for review.

## What was wrong

The pi provider's dynamic tools (`AskUserQuestion`, `update_environment_directory`, plugin agent tools) hang forever under the shipped pi. pi has been distributed as a Bun-compiled binary since v0.55.0 ([release assets](https://github.com/earendil-works/pi/releases/tag/v0.55.0), built via `bun build --compile` in [earendil-works/pi scripts/build-binaries.sh#L205](https://github.com/earendil-works/pi/blob/main/scripts/build-binaries.sh#L205)), and pi 0.85.0's binary embeds Bun 1.3.14.

Bun's `net.Socket({ fd })` validates the fd and attaches no handle (`_handle === null`, no poll registered — see [bun-v1.3.14 net.ts#L684](https://github.com/oven-sh/bun/blob/bun-v1.3.14/src/js/node/net.ts#L684) and the open upstream fix PRs [oven-sh/bun#35341](https://github.com/oven-sh/bun/pull/35341), [#29141](https://github.com/oven-sh/bun/pull/29141)). The bridge→extension channel read ([bb-pi-extension.ts#L177](https://github.com/get-bb/bb/blob/c49ba3f54/plugins/provider-pi/src/bridge/bb-pi-extension.ts#L177)) relied on a Node-only behavior, so under the compiled pi every dynamic tool result was written but never read: the extension's tool promise never settled, pi never emitted `tool_execution_end`, and turns hung until manually stopped.

This is not a Bun regression (read adoption has never shipped) and cannot be worked around by pinning Bun because pi embeds its runtime. The existing suite missed it because the fake pi loads extensions under Node, where the fd semantics work.

## What changed

- `plugins/provider-pi/src/bridge/bb-pi-extension.ts` — the bridge→extension channel reader branches on the runtime: under Bun it reads fd 4 through `Bun.file(fd).stream()` (same newline framing and `StringDecoder` handling); under Node the existing `net.Socket` path is unchanged, with its non-blocking comment moved onto that branch. No message formats, wire content, or fd assignments changed — server↔daemon payloads are untouched, so `HOST_DAEMON_PROTOCOL_VERSION` is not bumped.
- `plugins/provider-pi/src/bridge/fake-pi-rpc.mjs` — test fake: under runtimes without `module.registerHooks` (Bun) it stages the extension copy beside the package's gitignored `node_modules` so the extension's bare imports resolve natively; Node keeps the resolve-hook path. Header docs updated.
- `plugins/provider-pi/src/bridge/bridge.bun-runtime.test.ts` (new) — regression test running the fake pi under Bun and driving a dynamic tool round trip end to end. Known limitation, called out: it skips when Bun is absent from `PATH` (`it.skipIf(bunBinary() === null)`), and no CI leg installs Bun today, so this guard does not run in CI yet (follow-up issue; without it, CI cannot detect a revert of the Bun branch).
- An adversarial review pass shaped the change: staging lives in gitignored `node_modules` (not the source tree), the Bun branch is gated on the runtime rather than on `registerHooks` availability, and the single-message fd-4 coverage plus a bridge→extension liveness handshake are tracked as follow-ups rather than shipped here.
- Verified against Bun 1.4.0 in the test and against Bun 1.3.14 (pi's embedded runtime) via a direct fd probe.

## How you verified

- `plugins/provider-pi/src/bridge/bridge.bun-runtime.test.ts`: red on `main` at `timed out waiting for the tool result to reach pi under Bun` (the exact production symptom), green with this change.
- `pnpm exec vitest run --config vitest.config.ts src/bridge/bridge.bun-runtime.test.ts src/bridge/bridge.round2.test.ts src/bridge/bridge.framing.test.ts` — 13/13 pass (Bun on PATH).
- `pnpm exec turbo run typecheck --filter=bb-plugin-provider-pi` — clean.
- Live-incident capture (`BB_PROVIDER_BRIDGE_RECORD_DIR`): recorded lanes show the full request→response chain through the bridge's fd-4 write with no error anywhere, matching the failure mode; pi's own session file shows it only ever received the abort-path tool result.

> AGENT GENERATED

---

<sub><em>Generated with "Omen Alpha" (Opencode Go) via BB / Pi</em></sub>