### PR TITLE
Improve plugin lifecycle notifications

### DIFF
--- a/apps/app/src/components/plugin/PluginNotificationDescription.tsx
+++ b/apps/app/src/components/plugin/PluginNotificationDescription.tsx
@@ -1,0 +1,50 @@
+import { type ReactNode } from "react";
+import { Link } from "react-router-dom";
+import { appToast } from "@/components/ui/app-toast";
+import { getPluginDetailRoutePath } from "@/lib/route-paths";
+
+interface PluginNotificationTarget {
+  id: string;
+  name: string | null;
+}
+
+type PluginView = "catalog" | "installed";
+
+export function pluginNotificationDescription(
+  plugin: PluginNotificationTarget,
+  view: PluginView,
+  detail?: ReactNode,
+): ReactNode {
+  return (
+    <>
+      <Link
+        to={getPluginDetailRoutePath({
+          pluginId: plugin.id,
+          ...(view === "installed" ? { view } : {}),
+        })}
+        className="rounded-sm underline underline-offset-2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+      >
+        {plugin.name ?? plugin.id}
+      </Link>
+      {detail === undefined ? null : <> — {detail}</>}
+    </>
+  );
+}
+
+function createPluginToast(tone: "error" | "message" | "success") {
+  return (
+    title: ReactNode,
+    plugin: PluginNotificationTarget,
+    view: PluginView,
+    detail?: ReactNode,
+  ) =>
+    appToast[tone](title, {
+      description: pluginNotificationDescription(plugin, view, detail),
+    });
+}
+
+export const pluginToast = {
+  error: createPluginToast("error"),
+  message: createPluginToast("message"),
+  success: createPluginToast("success"),
+};

--- a/apps/app/src/components/plugin/management/AddPluginDialog.test.tsx
+++ b/apps/app/src/components/plugin/management/AddPluginDialog.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
 import type { InstalledPlugin } from "@bb/server-contract";
@@ -225,6 +226,7 @@ describe("AddPluginDialog", () => {
     stubFetch();
     const { unmount } = renderDialog({
       entryId: "linear",
+      pluginId: "linear",
       marketplace: "bb-official",
       publisherLabel: "BB Official",
       displayName: "Linear",
@@ -240,6 +242,7 @@ describe("AddPluginDialog", () => {
 
     const git = renderDialog({
       entryId: "thread-hover-cards",
+      pluginId: "thread-hover-cards",
       marketplace: "bb-community",
       publisherLabel: "BB Community",
       displayName: "Thread Hover Cards",
@@ -258,6 +261,7 @@ describe("AddPluginDialog", () => {
 
     renderDialog({
       entryId: "widgets",
+      pluginId: "widgets",
       marketplace: "bb-community",
       publisherLabel: "BB Community",
       displayName: "Widgets",
@@ -277,6 +281,7 @@ describe("AddPluginDialog", () => {
     stubFetch();
     renderDialog({
       entryId: "widgets",
+      pluginId: "widgets",
       displayName: "Widgets",
       icon: "Zap",
       iconUrl: null,
@@ -297,6 +302,7 @@ describe("AddPluginDialog", () => {
     const requests = stubFetch();
     renderDialog({
       entryId: "linear",
+      pluginId: "linear",
       marketplace: "bb-official",
       publisherLabel: "BB Official",
       displayName: "Linear",
@@ -329,6 +335,7 @@ describe("AddPluginDialog", () => {
       "/api/v1/plugin-catalog/icons/bb-community/widgets?h=icon-hash";
     renderDialog({
       entryId: "widgets",
+      pluginId: "widgets",
       marketplace: "bb-community",
       publisherLabel: "BB Community",
       displayName: "Widgets",
@@ -352,6 +359,7 @@ describe("AddPluginDialog", () => {
         onOpenChange={() => {}}
         initial={{
           entryId: "linear",
+          pluginId: "linear",
           marketplace: "bb-official",
           publisherLabel: "BB Official",
           displayName: "Linear",
@@ -381,33 +389,44 @@ describe("AddPluginDialog", () => {
     });
   });
 
-  it("surfaces the server's install error (e.g. incompatible source) as a toast", async () => {
+  it("names and links a catalog plugin when installation fails", async () => {
     const errorToast = vi.spyOn(appToast, "error").mockReturnValue("toast");
     stubFetch(
       { ok: false, error: "requires bb >= 0.15 — you have 0.14.1" },
       422,
     );
-    renderDialog();
-
-    fireEvent.change(screen.getByLabelText("Plugin source"), {
-      target: { value: "npm:@bb-plugins/linear@2.0.0" },
+    renderDialog({
+      entryId: "linear",
+      pluginId: "linear",
+      marketplace: "bb-official",
+      publisherLabel: "BB Official",
+      displayName: "Linear",
+      icon: null,
+      iconUrl: null,
+      iconTinted: false,
+      source: "builtin:linear",
     });
-    fireEvent.click(screen.getByRole("button", { name: /install plugin/i }));
+    fireEvent.click(screen.getByRole("button", { name: /install linear/i }));
 
     await vi.waitFor(() => {
-      expect(errorToast).toHaveBeenCalledWith(
-        "Installing the plugin failed",
-        expect.objectContaining({
-          description: "requires bb >= 0.15 — you have 0.14.1",
-        }),
-      );
+      expect(errorToast).toHaveBeenCalledTimes(1);
     });
+    expect(errorToast.mock.calls[0]?.[0]).toBe("Plugin installation failed");
+    render(
+      <MemoryRouter>{errorToast.mock.calls[0]?.[1]?.description}</MemoryRouter>,
+    );
+    const pluginLink = screen.getByRole("link", { name: "Linear" });
+    expect(pluginLink.getAttribute("href")).toBe("/extensions/plugins/linear");
+    expect(pluginLink.parentElement?.textContent).toBe(
+      "Linear — requires bb >= 0.15 — you have 0.14.1",
+    );
   });
 
   it("shows a third-party listing's resolved source before confirming", async () => {
     const requests = stubFetch();
     renderDialog({
       entryId: "notes",
+      pluginId: "notes",
       marketplace: "acme-plugins",
       publisherLabel: "Acme Plugins",
       displayName: "Acme Notes",
@@ -460,6 +479,7 @@ describe("AddPluginDialog", () => {
     const requests = stubFetch();
     renderDialog({
       entryId: "linear",
+      pluginId: "linear",
       marketplace: "bb-official",
       publisherLabel: "BB Official",
       displayName: "Linear",

--- a/apps/app/src/components/plugin/management/AddPluginDialog.tsx
+++ b/apps/app/src/components/plugin/management/AddPluginDialog.tsx
@@ -18,6 +18,7 @@ import {
 import { Icon } from "@bb/shared-ui/icon";
 import { Input } from "@bb/shared-ui/input";
 import { appToast } from "@/components/ui/app-toast.js";
+import { pluginToast } from "@/components/plugin/PluginNotificationDescription";
 import { pluginAdminErrorMessage } from "@/lib/plugin-admin-error";
 import {
   applyInstalledPlugin,
@@ -34,6 +35,7 @@ import { CatalogEntryIcon, FullTrustWarning } from "./plugin-ui";
 export type AddPluginInitial = {
   entryId: string;
   marketplace: string;
+  pluginId: string;
   publisherLabel: string;
   displayName: string;
   icon: string | null;
@@ -263,14 +265,22 @@ function AddPluginDialogContent({
       applyInstalledPlugin({ queryClient, plugin });
       invalidatePluginList({ queryClient });
       invalidatePluginCatalogSearch({ queryClient });
-      appToast.success(`${initial?.displayName ?? "Plugin"} installed`);
+      pluginToast.success("Plugin installed", plugin, "installed");
       onOpenChange(false);
       onInstalled?.(plugin);
     },
     onError: (error) => {
-      appToast.error("Installing the plugin failed", {
-        description: pluginAdminErrorMessage(error),
-      });
+      const detail = pluginAdminErrorMessage(error);
+      if (initial === null) {
+        appToast.error("Plugin installation failed", { description: detail });
+        return;
+      }
+      pluginToast.error(
+        "Plugin installation failed",
+        { id: initial.pluginId, name: initial.displayName },
+        "catalog",
+        detail,
+      );
     },
   });
 

--- a/apps/app/src/components/plugin/management/BrowsePluginsTab.test.tsx
+++ b/apps/app/src/components/plugin/management/BrowsePluginsTab.test.tsx
@@ -524,6 +524,7 @@ describe("BrowsePluginsTab", () => {
     fireEvent.click(install);
     expect(onInstall).toHaveBeenCalledWith({
       entryId: "memory",
+      pluginId: "memory",
       marketplace: "bb-official",
       publisherLabel: "BB Official",
       displayName: "Memory",

--- a/apps/app/src/components/plugin/management/BrowsePluginsTab.tsx
+++ b/apps/app/src/components/plugin/management/BrowsePluginsTab.tsx
@@ -523,6 +523,7 @@ function PluginCatalogCard({
               onInstall({
                 entryId: entry.entryId,
                 marketplace: entry.marketplace,
+                pluginId: entry.pluginId,
                 publisherLabel: entry.publisherLabel,
                 displayName: entry.displayName,
                 icon: entry.icon,

--- a/apps/app/src/components/plugin/management/PluginUpdatesCard.tsx
+++ b/apps/app/src/components/plugin/management/PluginUpdatesCard.tsx
@@ -3,7 +3,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { UPDATE_ACTION_ICON } from "@bb/domain/update-state";
 import { Button } from "@bb/shared-ui/button";
 import { Icon } from "@bb/shared-ui/icon";
-import { appToast } from "@/components/ui/app-toast";
+import { pluginToast } from "@/components/plugin/PluginNotificationDescription";
 import { invalidatePluginList } from "@/hooks/cache-owners/plugin-cache-owner";
 import { applyPluginUpdate } from "@/hooks/queries/plugin-catalog-queries";
 import type { PluginListItem } from "@/hooks/queries/plugin-settings-queries";
@@ -38,7 +38,6 @@ export function PluginDetailReleaseControl({
 }) {
   const [detailsOpen, setDetailsOpen] = useState(false);
   const queryClient = useQueryClient();
-  const name = plugin.name ?? plugin.id;
   const availableVersion = plugin.updateState.availableVersion;
   const failure = plugin.updateState.lastFailure;
   const retry = useMutation({
@@ -47,26 +46,33 @@ export function PluginDetailReleaseControl({
     onSuccess: (result) => {
       invalidatePluginList({ queryClient });
       if (result.outcome === "rolled-back") {
-        appToast.error(`Updating ${name} failed`, {
-          description:
-            result.detail ??
+        pluginToast.error(
+          "Plugin update failed",
+          plugin,
+          "installed",
+          result.detail ??
             `${displayPluginVersion(plugin.version)} was restored.`,
-        });
+        );
       } else if (result.applied) {
-        appToast.success(`${name} updated`, {
-          description:
-            result.to === null
-              ? undefined
-              : `Now running ${displayPluginVersion(result.to.display)}.`,
-        });
+        pluginToast.success(
+          "Plugin updated",
+          plugin,
+          "installed",
+          result.to === null
+            ? undefined
+            : `Now running ${displayPluginVersion(result.to.display)}.`,
+        );
       } else {
-        appToast.message(`${name} is already up to date`);
+        pluginToast.message("Plugin is up to date", plugin, "installed");
       }
     },
     onError: (error) => {
-      appToast.error(`Updating ${name} failed`, {
-        description: pluginAdminErrorMessage(error),
-      });
+      pluginToast.error(
+        "Plugin update failed",
+        plugin,
+        "installed",
+        pluginAdminErrorMessage(error),
+      );
     },
   });
 

--- a/apps/app/src/components/plugin/management/UpdatePluginDialog.test.tsx
+++ b/apps/app/src/components/plugin/management/UpdatePluginDialog.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
 import {
@@ -220,13 +221,18 @@ describe("UpdatePluginDialog", () => {
     fireEvent.click(screen.getByRole("button", { name: "Update" }));
 
     await vi.waitFor(() => {
-      expect(getNotifications()).toEqual([
-        expect.objectContaining({
-          title: "Updating Linear failed",
-          description: "plugin source is unavailable",
-        }),
-      ]);
+      expect(getNotifications()).toHaveLength(1);
     });
+    const notification = getNotifications()[0];
+    expect(notification?.title).toBe("Plugin update failed");
+
+    render(<MemoryRouter>{notification?.description}</MemoryRouter>);
+    expect(
+      screen.getByRole("link", { name: "Linear" }).getAttribute("href"),
+    ).toBe("/extensions/plugins/linear?view=installed");
+    expect(
+      screen.getByRole("link", { name: "Linear" }).parentElement?.textContent,
+    ).toBe("Linear — plugin source is unavailable");
   });
 
   it("treats a malformed 2xx update response as an error, never success", async () => {

--- a/apps/app/src/components/plugin/management/UpdatePluginDialog.tsx
+++ b/apps/app/src/components/plugin/management/UpdatePluginDialog.tsx
@@ -11,7 +11,7 @@ import {
   DialogTitle,
 } from "@bb/shared-ui/dialog";
 import { Icon } from "@bb/shared-ui/icon";
-import { appToast } from "@/components/ui/app-toast.js";
+import { pluginToast } from "@/components/plugin/PluginNotificationDescription";
 import { pluginAdminErrorMessage } from "@/lib/plugin-admin-error";
 import { invalidatePluginList } from "@/hooks/cache-owners/plugin-cache-owner";
 import {
@@ -75,21 +75,26 @@ function UpdatePluginDialogContent({
         return;
       }
       if (result.applied) {
-        appToast.success(`${name} updated`, {
-          description:
-            result.to !== null
-              ? `Now running ${displayPluginVersion(result.to.display)}.`
-              : undefined,
-        });
+        pluginToast.success(
+          "Plugin updated",
+          plugin,
+          "installed",
+          result.to !== null
+            ? `Now running ${displayPluginVersion(result.to.display)}.`
+            : undefined,
+        );
       } else {
-        appToast.message(`${name} is already up to date`);
+        pluginToast.message("Plugin is up to date", plugin, "installed");
       }
       onOpenChange(false);
     },
     onError: (error) => {
-      appToast.error(`Updating ${name} failed`, {
-        description: pluginAdminErrorMessage(error),
-      });
+      pluginToast.error(
+        "Plugin update failed",
+        plugin,
+        "installed",
+        pluginAdminErrorMessage(error),
+      );
     },
   });
 

--- a/apps/app/src/components/tools/ExtensionsDetailStates.stories.tsx
+++ b/apps/app/src/components/tools/ExtensionsDetailStates.stories.tsx
@@ -633,6 +633,7 @@ function CatalogPlugin({
         open={installOpen}
         initial={{
           entryId: entry.entryId,
+          pluginId: entry.pluginId,
           marketplace: "bb-official",
           publisherLabel: "BB Official",
           displayName: entry.displayName,

--- a/apps/app/src/components/ui/sonner.stories.tsx
+++ b/apps/app/src/components/ui/sonner.stories.tsx
@@ -1,6 +1,7 @@
 import { appToast, AppToastContent, type AppToastTone } from "./app-toast";
 import { AppToastCommitDescription } from "./app-toast-descriptions";
 import { ArchivedThreadToastDescription } from "../thread/ArchivedThreadToastDescription";
+import { pluginNotificationDescription } from "../plugin/PluginNotificationDescription";
 import { Button } from "@bb/shared-ui/button";
 import { StoryCard, StoryRow } from "../../../.ladle/story-card";
 import { useState, type ReactNode } from "react";
@@ -104,6 +105,62 @@ const TOAST_EXAMPLES: readonly ToastExample[] = [
       title: "Codex update failed",
       description: "Command exited with code 1",
       primaryActionLabel: "View log",
+    },
+  },
+  {
+    id: "plugin-update-failed",
+    group: "Plugin management",
+    label: "update failed",
+    source: "UpdatePluginDialog / PluginUpdatesCard",
+    usage: [
+      "Plugin update fails",
+      "Plugin name opens its installed detail page",
+    ],
+    current: {
+      tone: "error",
+      title: "Plugin update failed",
+      description: pluginNotificationDescription(
+        { id: "usage", name: "Usage" },
+        "installed",
+        "bb connect: timed out waiting for the tunnel client.",
+      ),
+    },
+  },
+  {
+    id: "plugin-updated",
+    group: "Plugin management",
+    label: "update success",
+    source: "UpdatePluginDialog / PluginUpdatesCard",
+    usage: [
+      "Plugin update succeeds",
+      "Plugin name opens its installed detail page",
+    ],
+    current: {
+      tone: "success",
+      title: "Plugin updated",
+      description: pluginNotificationDescription(
+        { id: "usage", name: "Usage" },
+        "installed",
+        "Now running 1.4.0.",
+      ),
+    },
+  },
+  {
+    id: "plugin-installed",
+    group: "Plugin management",
+    label: "install success",
+    source: "AddPluginDialog",
+    usage: [
+      "Plugin install succeeds",
+      "Plugin name opens its installed detail page",
+    ],
+    current: {
+      tone: "success",
+      title: "Plugin installed",
+      description: pluginNotificationDescription(
+        { id: "linear", name: "Linear" },
+        "installed",
+      ),
     },
   },
   {

--- a/apps/app/src/views/ToolsView.tsx
+++ b/apps/app/src/views/ToolsView.tsx
@@ -44,6 +44,7 @@ import {
   type PluginListItem,
 } from "@/hooks/queries/plugin-settings-queries";
 import { useLocalOpenTargets } from "@/hooks/useLocalOpenTargets";
+import { pluginAdminErrorMessage } from "@/lib/plugin-admin-error";
 import {
   TOOLS_REGISTRY_SKILLS_ROUTE_PATH,
   TOOLS_SKILLS_ROUTE_PATH,
@@ -59,6 +60,7 @@ import {
 import { cn } from "@bb/shared-ui/lib/utils";
 import { SkillsLibrary } from "@/components/tools/SkillsLibrary";
 import { PluginIcon } from "@/components/plugin/PluginIcon";
+import { pluginToast } from "@/components/plugin/PluginNotificationDescription";
 import { SecondaryPanelLayout } from "@/components/secondary-panel/SecondaryPanelLayout";
 import { ThreadSecondaryPanel } from "@/components/secondary-panel/ThreadSecondaryPanel";
 import type { SecondaryPanelRenderableTab } from "@/components/secondary-panel/secondaryPanelTab";
@@ -197,25 +199,26 @@ function PluginDetailToolView({ pluginId }: { pluginId: string }) {
   });
   const pluginDelete = useMutation({
     meta: { showErrorToast: false },
-    mutationFn: async (plugin: PluginListItem) => {
-      try {
-        await removePlugin(fetch, plugin.id);
-      } catch {
-        throw new Error("Failed to delete plugin");
-      }
-    },
+    mutationFn: (plugin: PluginListItem) => removePlugin(fetch, plugin.id),
     onSuccess: (_data, deletedPlugin) => {
-      appToast.success(
-        pluginIsLocalSource(deletedPlugin)
-          ? "Plugin removed from bb"
-          : "Plugin uninstalled",
+      const isLocal = pluginIsLocalSource(deletedPlugin);
+      pluginToast.success(
+        isLocal ? "Plugin removed from bb" : "Plugin uninstalled",
+        deletedPlugin,
+        "catalog",
       );
       setDeleteTarget(null);
       navigate(getToolsOwnedCollectionRoutePath("plugins"));
       return listQuery.refetch();
     },
-    onError: (error) => {
-      appToast.error(error instanceof Error ? error.message : String(error));
+    onError: (error, plugin) => {
+      const isLocal = pluginIsLocalSource(plugin);
+      pluginToast.error(
+        isLocal ? "Plugin removal failed" : "Plugin uninstall failed",
+        plugin,
+        "installed",
+        pluginAdminErrorMessage(error),
+      );
     },
   });
   const isLoading = listQuery.isFetching && listQuery.data === undefined;
@@ -395,6 +398,7 @@ function PluginDetailToolView({ pluginId }: { pluginId: string }) {
                 : {
                     entryId: installTarget.entryId,
                     marketplace: installTarget.marketplace,
+                    pluginId: installTarget.pluginId,
                     publisherLabel: installTarget.publisherLabel,
                     displayName: installTarget.displayName,
                     icon: installTarget.icon,


### PR DESCRIPTION
## Human comments

## What was wrong

Plugin lifecycle mutations assembled their notifications independently, which put plugin names into inconsistent titles and left the resource name as plain text. As a result, install, update, uninstall, and removal notifications did not follow the resource-first title/description pattern used elsewhere in the app.

## What changed

Added a small shared plugin notification description that links the plugin display name to its installed or catalog detail page and appends any diagnostic detail. Standardized the scoped lifecycle titles to Plugin installed, Plugin installation failed, Plugin updated, Plugin update failed, Plugin uninstalled, and Plugin removed from bb. Updated the toast catalog with three representative plugin lifecycle states. Adjacent plugin enable/disable, reload, update-check, runtime, and unrelated notifications remain unchanged. There are no host-daemon wire, CLI, guide, or public Plugin SDK changes.

## How you verified

- Focused install and update assertions cover both catalog and installed plugin links; these assertions fail against the previous titles and text-only descriptions.
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run test --filter=@bb/app --force -- src/components/plugin/management/AddPluginDialog.test.tsx src/components/plugin/management/BrowsePluginsTab.test.tsx src/components/plugin/management/UpdatePluginDialog.test.tsx (35 passed)
- pnpm exec turbo run test --filter=@bb/app --force (3,876 passed, 4 skipped before the final rebase)
- Manually inspected the Toasts / Catalog story with Doobie.

Fixes: N/A (no linked issue)

> AGENT GENERATED
