### PR TITLE
Enable GPT-6 Astra with Codex 0.153.4

### DIFF
--- a/plugins/provider-codex/PLUGIN_OVERVIEW.md
+++ b/plugins/provider-codex/PLUGIN_OVERVIEW.md
@@ -4,6 +4,7 @@ Start a thread, pick Codex, and let it write and review code in your repository 
 
 - Permission modes `accept-edits`, `auto`, and `full`, plus plan and goal actions in the composer.
 - Reasoning levels from Low to Ultra. Ultra adds automatic task delegation.
+- GPT-6 Astra and other models reported by the host's Codex CLI.
 - A service tier picker with two tiers.
 - Checkpoint forks, manual compaction, thread rename, and thread archive.
 - Codex skills from your home directory and project, listed next to bb skills.
@@ -17,6 +18,6 @@ Start a thread, pick Codex, and let it write and review code in your repository 
 
 ## Requirements
 
-- Install the Codex CLI (`codex`) on the host machine, version 0.136.0 or newer. The plugin can run the npm install for you.
+- Install the Codex CLI (`codex`) on the host machine, version 0.153.4 or newer. This version exposes GPT-6 Astra in the model catalog. The plugin can run the npm install for you; run `codex update` if the installed version is older.
 - Sign in with `codex login` on that machine. A ChatGPT account or an OpenAI API key both work.
 - Usage limits show only for ChatGPT accounts.

--- a/plugins/provider-codex/src/bridge/provider-maintenance.test.ts
+++ b/plugins/provider-codex/src/bridge/provider-maintenance.test.ts
@@ -17,7 +17,7 @@ function installationStatus() {
     installSource: "npmGlobal" as const,
     currentVersion: "1.0.0",
     latestVersion: "1.1.0",
-    minimumSupportedVersion: "0.136.0",
+    minimumSupportedVersion: "0.153.4",
     npmPackageName: "@openai/codex",
     npmGlobalPackageVersion: "1.0.0",
     installAction: {
@@ -66,11 +66,14 @@ describe("Codex provider maintenance", () => {
     });
   });
 
-  it("owns the stricter CLI requirement for thread rewind", () => {
-    expect(__testing.minimumSupportedVersionForRequirement()).toBe("0.136.0");
+  it("requires the CLI release that exposes GPT-6 Astra", () => {
+    expect(__testing.minimumSupportedVersionForRequirement()).toBe("0.153.4");
+  });
+
+  it("does not lower the Astra CLI requirement for thread rewind", () => {
     expect(
       __testing.minimumSupportedVersionForRequirement("thread_rewind"),
-    ).toBe("0.143.0");
+    ).toBe("0.153.4");
   });
 
   it("resolves a fresh typed update plan and rejects a stale action", () => {
@@ -137,7 +140,7 @@ describe("Codex credential health and usage", () => {
     await fs.mkdir(binDir);
     await fs.writeFile(
       path.join(binDir, "codex"),
-      '#!/bin/sh\necho "codex-cli 0.150.0"\n',
+      '#!/bin/sh\necho "codex-cli 0.153.4"\n',
       { mode: 0o755 },
     );
     vi.stubEnv("HOME", homeDir);
@@ -156,6 +159,26 @@ describe("Codex credential health and usage", () => {
     );
   });
 
+  it.each(["0.152.1", "0.153.3"])(
+    "requires an update for Codex %s before offering Astra",
+    async (version) => {
+      await fs.writeFile(
+        path.join(homeDir, "bin", "codex"),
+        `#!/bin/sh\necho "codex-cli ${version}"\n`,
+        { mode: 0o755 },
+      );
+
+      await expect(getCodexProviderHealth()).resolves.toMatchObject({
+        health: {
+          status: "unsupported_version",
+          installedVersion: version,
+          minimumSupportedVersion: "0.153.4",
+          canUpdate: true,
+        },
+      });
+    },
+  );
+
   it("reports unauthenticated when auth.json is missing", async () => {
     await expect(getCodexProviderHealth()).resolves.toEqual({
       supported: true,
@@ -164,8 +187,8 @@ describe("Codex credential health and usage", () => {
         statusMessage: null,
         accountEmail: null,
         planLabel: null,
-        installedVersion: "0.150.0",
-        minimumSupportedVersion: "0.136.0",
+        installedVersion: "0.153.4",
+        minimumSupportedVersion: "0.153.4",
         canInstall: true,
         canUpdate: true,
         loginCommand: "codex login",
@@ -190,7 +213,7 @@ describe("Codex credential health and usage", () => {
       health: {
         status: "expired",
         accountEmail: "codex@example.com",
-        installedVersion: "0.150.0",
+        installedVersion: "0.153.4",
       },
     });
     await expect(getCodexProviderUsage()).resolves.toEqual({

--- a/plugins/provider-codex/src/bridge/provider-maintenance.ts
+++ b/plugins/provider-codex/src/bridge/provider-maintenance.ts
@@ -25,7 +25,7 @@ import {
   type CodexAuthCredentials,
 } from "../ai/codex-auth.js";
 
-const CODEX_MINIMUM_SUPPORTED_VERSION = "0.136.0";
+const CODEX_MINIMUM_SUPPORTED_VERSION = "0.153.4";
 const CODEX_REWIND_MINIMUM_SUPPORTED_VERSION = "0.143.0";
 const CODEX_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
 const USAGE_FETCH_TIMEOUT_MS = 15_000;
@@ -64,8 +64,13 @@ async function readCredentials(): Promise<CodexAuthCredentials | null> {
 function minimumSupportedVersionForRequirement(
   requirement?: "thread_rewind",
 ): string {
-  return requirement === "thread_rewind"
-    ? CODEX_REWIND_MINIMUM_SUPPORTED_VERSION
+  const requirementVersion =
+    requirement === "thread_rewind"
+      ? CODEX_REWIND_MINIMUM_SUPPORTED_VERSION
+      : CODEX_MINIMUM_SUPPORTED_VERSION;
+  return compareVersions(requirementVersion, CODEX_MINIMUM_SUPPORTED_VERSION) >
+    0
+    ? requirementVersion
     : CODEX_MINIMUM_SUPPORTED_VERSION;
 }
 

--- a/plugins/provider-codex/src/models.test.ts
+++ b/plugins/provider-codex/src/models.test.ts
@@ -21,7 +21,7 @@ describe("mapBbReasoningLevelToCodex", () => {
 });
 
 describe("parseModelsResponse", () => {
-  it("parses a live-shaped Codex payload with max and ultra", () => {
+  it("preserves GPT-6 Astra metadata and its full reasoning ladder", () => {
     const models = parseModelsResponse({
       data: [
         {
@@ -36,13 +36,13 @@ describe("parseModelsResponse", () => {
             { reasoningEffort: "xhigh", description: "XHigh" },
           ],
           defaultReasoningEffort: "medium",
-          isDefault: true,
+          isDefault: false,
         },
         {
-          id: "gpt-5.6-sol",
-          model: "gpt-5.6-sol",
-          displayName: "GPT-5.6-Sol",
-          description: "Latest frontier",
+          id: "gpt-6-astra",
+          model: "gpt-6-astra",
+          displayName: "GPT-6-Astra",
+          description: "Our most capable model for complex, demanding work.",
           supportedReasoningEfforts: [
             { reasoningEffort: "low", description: "Low" },
             { reasoningEffort: "medium", description: "Medium" },
@@ -55,13 +55,21 @@ describe("parseModelsResponse", () => {
             },
           ],
           defaultReasoningEffort: "low",
-          isDefault: false,
+          isDefault: true,
         },
       ],
     });
 
     expect(models).toHaveLength(2);
     expect(models[0]?.id).toBe("gpt-5.5");
+    expect(models[0]?.isDefault).toBe(false);
+    expect(models[1]).toMatchObject({
+      id: "gpt-6-astra",
+      model: "gpt-6-astra",
+      displayName: "GPT-6-Astra",
+      description: "Our most capable model for complex, demanding work.",
+      isDefault: true,
+    });
     expect(
       models[1]?.supportedReasoningEfforts.map((e) => e.reasoningEffort),
     ).toEqual(["low", "medium", "high", "xhigh", "max", "ultra"]);


### PR DESCRIPTION
## Human comments

## What was wrong

bb accepted Codex CLI versions as old as 0.136.0, but Astra needs a newer CLI. A live `model/list` call on 0.152.1 returned five models without `gpt-6-astra`, and an explicit Astra request failed with "The 'gpt-6-astra' model requires a newer version of Codex." [Codex 0.153.4](https://github.com/openai/codex/releases/tag/rust-v0.153.4) fixes Astra's visibility in the model picker. Its catalog returns Astra with Low through Ultra reasoning and Low as the default effort.

## What changed

- Require Codex 0.153.4 so older hosts use bb's existing Update Codex flow. This raises the minimum for all Codex sessions.
- Keep the thread-rewind requirement from lowering the new provider minimum.
- Update the Codex plugin overview and test Astra's identity, default flag, and reasoning metadata.

This follows the native Codex discovery approach in #580 and #945 and reuses the update gate from #1335. The existing bridge already forwards Astra correctly on 0.153.4, so there is no hardcoded model entry or override of the CLI's default. Server/daemon message shapes and field meanings are unchanged.

## How you verified

- The version-floor and health regression tests failed before the implementation change: four failures, including 0.152.1 and 0.153.3 being accepted below the new minimum.
- `pnpm exec turbo run test typecheck --filter=bb-plugin-provider-codex`: all 264 tests passed across 26 files; typecheck passed.
- `pnpm exec oxfmt --check` on the four changed files and `git diff --check` passed.
- Queried bb's actual Codex bridge using an isolated official 0.153.4 binary. It returned `gpt-6-astra`, its native metadata, and `low`, `medium`, `high`, `xhigh`, `max`, and `ultra`.
- A minimal read-only Astra request failed on 0.152.1 and completed with `OK` on 0.153.4. The downloaded standalone binary lacked the optional code-mode host, so this verifies model invocation, not code-mode tools. No browser validation was performed.

> AGENT GENERATED