### PR TITLE
fix(pi): resume at requested cwd when the session's directory was removed

### DIFF
--- a/plugins/provider-pi/src/bridge/bridge.round2.test.ts
+++ b/plugins/provider-pi/src/bridge/bridge.round2.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
@@ -399,4 +399,41 @@ it("a resumed thread reports the session header's cwd, not the cwd bb asked for"
   } finally {
     rmSync(headerDir, { recursive: true, force: true });
   }
+}, 90_000);
+
+it("resumes at bb's requested cwd when the session header's cwd was removed", async () => {
+  // bb moved the thread's environment directory; the old environment's
+  // directory (recorded in the pi session header) no longer exists. The
+  // bridge must still resume at the requested, existing cwd instead of
+  // rejecting the turn.
+  const sessionDir = join(harness.workspaceDir, "sessions");
+  mkdirSync(sessionDir, { recursive: true });
+  const ghostCwd = join(harness.workspaceDir, "worktree-removed");
+  expect(existsSync(ghostCwd)).toBe(false);
+  writeFileSync(
+    join(sessionDir, "thr-resume-missing-cwd.jsonl"),
+    `${JSON.stringify({ type: "session", version: 3, id: "sess-missing-cwd", timestamp: "2026-01-01T00:00:00.000Z", cwd: ghostCwd })}\n`,
+  );
+
+  const threadId = "thr-resume-missing-cwd";
+  const resumed = await harness.request((nextId += 1), "thread/resume", {
+    threadId,
+    providerThreadId: threadId,
+    cwd: harness.workspaceDir,
+    instructionMode: "append",
+    options: FULL_PERMISSION_OPTIONS,
+  });
+  expect(resumed.error, JSON.stringify(resumed)).toBeUndefined();
+  expect(resumed.result).toMatchObject({ providerThreadId: threadId });
+
+  turnStart(threadId, '/tool bash {"command":"pwd"}', "creq_rsm2345678");
+  await harness.waitForDelta(threadId, (d) => d.kind === "item.close");
+  const opened = harness
+    .deltasOf(threadId)
+    .find((d) => d.kind === "item.open");
+  expect(opened?.item).toMatchObject({
+    type: "command",
+    command: "pwd",
+    cwd: harness.workspaceDir,
+  });
 }, 90_000);

--- a/plugins/provider-pi/src/bridge/bridge.ts
+++ b/plugins/provider-pi/src/bridge/bridge.ts
@@ -532,7 +532,11 @@ async function handleRequest(
       const missingCwd = resumedSessionMissingCwd(
         request.params.providerThreadId,
       );
-      if (missingCwd !== null) {
+      const requestedCwd = request.params.cwd;
+      // The persisted cwd is stale when bb already moved the thread to a
+      // new environment directory and the old one was removed; resume at
+      // the requested, existing cwd instead of failing the whole turn.
+      if (missingCwd !== null && !existsSync(requestedCwd ?? "")) {
         sendError(
           request.id,
           -32000,
@@ -750,7 +754,7 @@ async function constructPiThreadSession(
     sessionSerial,
     closing: false,
     providerThreadId,
-    cwd: persistedSessionCwd(providerThreadId) ?? params.cwd,
+    cwd: usablePersistedSessionCwd(providerThreadId) ?? params.cwd,
     construction: params,
     constructionModel: sessionOptions.model,
   };
@@ -857,6 +861,11 @@ async function handleThreadConstruction(
 function resumedSessionMissingCwd(providerThreadId: string): string | null {
   const cwd = persistedSessionCwd(providerThreadId);
   return cwd !== null && !existsSync(cwd) ? cwd : null;
+}
+
+function usablePersistedSessionCwd(providerThreadId: string): string | null {
+  const cwd = persistedSessionCwd(providerThreadId);
+  return cwd !== null && existsSync(cwd) ? cwd : null;
 }
 
 function persistedSessionCwd(providerThreadId: string): string | null {


### PR DESCRIPTION
## Human comments

Similar to the other PR I just opened, this almost drove me nuts :sweat_smile: I'm now rebuilding my container with both patches and will report back if anything goes wrong.

## What was wrong

When `update_environment_directory` moved a thread to a new environment (e.g. the agent deleted the old worktree first), the next turn died at the bridge: `thread/resume` rejected with `Cannot resume: the pi session's working directory "...no longer exists."` because the pi session file still recorded the old cwd — even though the runtime supplied a valid, existing requested cwd. In the observed case the thread was effectively bricked until an external stop/recovery.

Root cause: `resumedSessionMissingCwd` (`plugins/provider-pi/src/bridge/bridge.ts:532`) rejects the whole resume whenever the persisted cwd is gone, without considering the requested cwd.

## What changed

- `thread/resume` now only rejects when the **requested** cwd is also missing — i.e. there is genuinely nowhere to run. With the persisted cwd gone but a valid requested cwd present, resume proceeds.
- `constructPiThreadSession` prefers the persisted session cwd only when the directory still exists (new `usablePersistedSessionCwd()`), falling back to the requested cwd for the child spawn and delta-translation `sessionCwd`. When the persisted cwd still exists, behavior is unchanged (session reports the header cwd).
- No wire/protocol changes; provider-bridge-only. No CLI/guide/doc updates needed.

## How you verified

- New regression test `resumes at bb's requested cwd when the session header's cwd was removed` (`bridge.round2.test.ts`): **red** before the fix (reproduced the exact user error text), **green** after.
- Existing `a resumed thread reports the session header's cwd, not the cwd bb asked for` still passes — persisted-cwd precedence preserved when the dir exists.
- `bridge.round2` + `bridge.settings` + `bridge.checkpoint-fork`: 15/15 pass. `turbo run typecheck --filter=bb-plugin-provider-pi`: clean.

> AGENT GENERATED
> <sub><em>Generated with "Omen Alpha" (Opencode Go) via BB / Pi</em></sub>