### PR TITLE
Fix Extensions detail panel opening animation

### DIFF
--- a/apps/app/src/components/plugin/management/UpdatePluginDialog.test.tsx
+++ b/apps/app/src/components/plugin/management/UpdatePluginDialog.test.tsx
@@ -229,7 +229,7 @@ describe("UpdatePluginDialog", () => {
     render(<MemoryRouter>{notification?.description}</MemoryRouter>);
     expect(
       screen.getByRole("link", { name: "Linear" }).getAttribute("href"),
-    ).toBe("/extensions/plugins/linear?view=installed");
+    ).toBe("/settings/plugins/linear?view=installed");
     expect(
       screen.getByRole("link", { name: "Linear" }).parentElement?.textContent,
     ).toBe("Linear — plugin source is unavailable");

--- a/apps/app/src/views/ToolsView.plugin-detail.test.tsx
+++ b/apps/app/src/views/ToolsView.plugin-detail.test.tsx
@@ -43,6 +43,18 @@ import {
   makePluginRegistrationSet,
 } from "@/test/fixtures/plugins";
 
+vi.mock("react-resizable-panels", async () => {
+  const { createRequire } = await import("node:module");
+  const { dirname, join } = await import("node:path");
+  const require = createRequire(import.meta.url);
+  return require(
+    join(
+      dirname(require.resolve("react-resizable-panels/package.json")),
+      "dist/react-resizable-panels.browser.cjs.js",
+    ),
+  );
+});
+
 const GITHUB_PLUGIN = makePluginListItem({
   id: "github",
   source: "builtin:github",
@@ -675,6 +687,11 @@ describe("BB Official plugin detail routing", () => {
     const card = await screen.findByRole("button", {
       name: "Open GitHub details",
     });
+    const panels = Array.from(document.querySelectorAll("[data-panel]"));
+    expect(panels).toHaveLength(2);
+    expect(panels[0]?.getAttribute("data-panel-size")).toBe("100.0");
+    expect(panels[1]?.getAttribute("data-panel-size")).toBe("0.0");
+    const search = screen.getByRole("textbox", { name: "Search plugins" });
     card.focus();
     fireEvent.click(card);
     expect(
@@ -684,6 +701,8 @@ describe("BB Official plugin detail routing", () => {
       screen.getByRole("textbox", { name: "Search plugins" }),
     ).toBeTruthy();
     expect(screen.getAllByRole("button", { name: /^Close /u })).toHaveLength(1);
+    expect(Array.from(document.querySelectorAll("[data-panel]"))).toEqual(panels);
+    expect(screen.getByRole("textbox", { name: "Search plugins" })).toBe(search);
 
     fireEvent.click(screen.getByRole("button", { name: "Close GitHub" }));
     await waitFor(() => {
@@ -692,6 +711,10 @@ describe("BB Official plugin detail routing", () => {
       );
       expect(document.activeElement).toBe(card);
     });
+    expect(Array.from(document.querySelectorAll("[data-panel]"))).toEqual(panels);
+    expect(panels[0]?.getAttribute("data-panel-size")).toBe("100.0");
+    expect(panels[1]?.getAttribute("data-panel-size")).toBe("0.0");
+    expect(screen.getByRole("textbox", { name: "Search plugins" })).toBe(search);
   });
 
   it("keeps related plugin navigation in the full-page detail", async () => {

--- a/apps/app/src/views/ToolsView.tsx
+++ b/apps/app/src/views/ToolsView.tsx
@@ -531,28 +531,27 @@ export function ToolsView({ pluginId }: { pluginId?: string } = {}) {
       isMainCollapsed: boolean;
       onToggleMainCollapse: () => void;
       resizablePanelId?: string;
-    }) =>
-      isPanelOpen ? (
-        <ThreadSecondaryPanel
-          activeTab={panelTab?.tab ?? null}
-          canUseGitUi={false}
-          metadataContent={null}
-          tabs={panelTabs}
-          fixedTabs={[]}
-          onTabReorder={() => undefined}
-          isOpen={isPanelOpen}
-          showConversationCollapseControl
-          showNewTabButton={false}
-          onPanelFocus={() => undefined}
-          onCollapse={closePanel}
-          onClose={closePanel}
-          onOpenNewTab={() => undefined}
-          isConversationCollapsed={isMainCollapsed}
-          onToggleConversationCollapse={onToggleMainCollapse}
-          renderAsDrawer={presentation === "drawer"}
-          resizablePanelId={resizablePanelId}
-        />
-      ) : null,
+    }) => (
+      <ThreadSecondaryPanel
+        activeTab={panelTab?.tab ?? null}
+        canUseGitUi={false}
+        metadataContent={null}
+        tabs={panelTabs}
+        fixedTabs={[]}
+        onTabReorder={() => undefined}
+        isOpen={isPanelOpen}
+        showConversationCollapseControl
+        showNewTabButton={false}
+        onPanelFocus={() => undefined}
+        onCollapse={closePanel}
+        onClose={closePanel}
+        onOpenNewTab={() => undefined}
+        isConversationCollapsed={isMainCollapsed}
+        onToggleConversationCollapse={onToggleMainCollapse}
+        renderAsDrawer={presentation === "drawer"}
+        resizablePanelId={resizablePanelId}
+      />
+    ),
     [closePanel, isPanelOpen, panelTab?.tab, panelTabs],
   );
 


### PR DESCRIPTION
## Human comments

## What was wrong

Opening plugin details on Extensions mounted a second resizable panel only after selection. The resize library changed the main panel's flex weight from its single-panel value of 1 to a percentage, making the details jump too far left and then slide back right. Closing removed the panel before its exit animation could finish.

## What changed

Keep the Extensions detail panel mounted when closed so both panels retain their layout and animate from and to the right edge. Extend the routing test to verify panel persistence, collapsed sizes, list identity, and focus restoration. Load the resize library's real browser build in this DOM test so panel registration effects run. Correct a stale installed-plugin notification URL expectation exposed by CI after the Settings routing change.

## How you verified

- `pnpm exec turbo run test --filter=@bb/app -- ToolsView.plugin-detail.test.tsx UpdatePluginDialog.test.tsx`: 40 passed. The new persistence assertion fails against the original implementation.
- `pnpm exec turbo run typecheck --filter=@bb/app`: passed.
- Browser frame measurements on `/extensions/plugins`: reproduced the initial overshoot before the fix; verified opening from the right, closing to the right, and persistent list DOM after the fix.

> AGENT GENERATED
