### PR TITLE
Show Codex accounts' real limit windows in the Account Pooler

### DIFF
--- a/plugins/account-pool/app.test.tsx
+++ b/plugins/account-pool/app.test.tsx
@@ -41,6 +41,7 @@ function account(overrides: Partial<AccountSummary> = {}): AccountSummary {
       haiku: null,
       other: null,
     },
+    limitWindows: [],
     observedAt: 1,
     heldUntil: null,
     error: null,
@@ -103,6 +104,40 @@ describe("Account Pool settings", () => {
     expect(
       slot.getByText("Hub accepting · 2 in flight · used by bee"),
     ).toBeTruthy();
+  });
+
+  it("renders only the windows a Codex account reports and no Fable slot", async () => {
+    const slot = render([
+      account({
+        id: "22222222-2222-4222-8222-222222222222",
+        provider: "codex",
+        label: "pro@example.com",
+        codexAccountId: "chatgpt-account",
+        fiveHourUtilization: null,
+        limitWindows: [
+          {
+            slot: "primary",
+            windowMinutes: 10_080,
+            utilization: 0.48,
+            resetAt: Date.now() + 3_600_000,
+            status: "allowed",
+            observedAt: 1,
+            source: "usage",
+          },
+        ],
+      }),
+    ]);
+    expect(await slot.findByText("pro@example.com")).toBeTruthy();
+    expect(slot.getByText("7D")).toBeTruthy();
+    expect(slot.getByText("48%")).toBeTruthy();
+    expect(slot.queryByText("5H")).toBeNull();
+    expect(slot.queryByText("FABLE")).toBeNull();
+    fireEvent.click(
+      await slot.findByRole("button", { name: "Open pro@example.com details" }),
+    );
+    expect(await slot.findByText("Weekly")).toBeTruthy();
+    expect(slot.queryByText("5 hour")).toBeNull();
+    expect(slot.queryByText("7 day")).toBeNull();
   });
 
   it("dispatches kebab actions to their RPC contracts", async () => {

--- a/plugins/account-pool/app.tsx
+++ b/plugins/account-pool/app.tsx
@@ -35,6 +35,7 @@ import type {
   AccountPoolConfig,
   AccountPoolConfigSetInput,
   FamilyQuota,
+  LimitWindow,
   ModelFamily,
   PoolProvider,
   PoolStatus,
@@ -139,6 +140,32 @@ function relative(timestamp: number, now = Date.now()): string {
   const hours = Math.round(minutes / 60);
   return hours < 24 ? `${hours}h ago` : `${Math.round(hours / 24)}d ago`;
 }
+function windowShortLabel(window: LimitWindow): string {
+  if (window.windowMinutes === null)
+    return window.slot === "primary" ? "LIMIT" : "LIMIT 2";
+  if (window.windowMinutes % 1_440 === 0)
+    return `${window.windowMinutes / 1_440}D`;
+  if (window.windowMinutes % 60 === 0) return `${window.windowMinutes / 60}H`;
+  return `${window.windowMinutes}M`;
+}
+function windowLongLabel(window: LimitWindow): string {
+  if (window.windowMinutes === null)
+    return window.slot === "primary" ? "Usage limit" : "Secondary limit";
+  if (window.windowMinutes === 7 * 24 * 60) return "Weekly";
+  if (window.windowMinutes % 1_440 === 0)
+    return `${window.windowMinutes / 1_440} day`;
+  if (window.windowMinutes % 60 === 0)
+    return `${window.windowMinutes / 60} hour`;
+  return `${window.windowMinutes} minute`;
+}
+function exhaustedResetAt(account: AccountSummary): number | null {
+  return (
+    account.fiveHourResetAt ??
+    account.sevenDayResetAt ??
+    account.limitWindows.find((window) => window.resetAt !== null)?.resetAt ??
+    null
+  );
+}
 function resetLabel(timestamp: number | null): string {
   if (timestamp === null) return "";
   const minutes = Math.max(1, Math.round((timestamp - Date.now()) / 60_000));
@@ -157,7 +184,7 @@ function statusPresentation(account: AccountSummary): {
     };
   if (account.status === "exhausted")
     return {
-      label: `Exhausted${account.fiveHourResetAt === null && account.sevenDayResetAt === null ? "" : ` · ${resetLabel(account.fiveHourResetAt ?? account.sevenDayResetAt)}`}`,
+      label: `Exhausted${exhaustedResetAt(account) === null ? "" : ` · ${resetLabel(exhaustedResetAt(account))}`}`,
       dot: "bg-destructive",
     };
   if (account.status === "error")
@@ -291,24 +318,47 @@ function AccountRow({
             </div>
           </div>
           <div className="hidden shrink-0 items-center gap-1 sm:flex">
-            <QuotaValue
-              label="5H"
-              utilization={account.fiveHourUtilization}
-              status={account.fiveHourStatus}
-              threshold={threshold}
-            />
-            <QuotaValue
-              label="7D"
-              utilization={account.sevenDayUtilization}
-              status={account.sevenDayStatus}
-              threshold={threshold}
-            />
-            <QuotaValue
-              label="FABLE"
-              utilization={account.familyWeekly.fable?.utilization ?? null}
-              status={account.familyWeekly.fable?.status ?? null}
-              threshold={threshold}
-            />
+            {account.provider === "codex" ? (
+              account.limitWindows.length === 0 ? (
+                <QuotaValue
+                  label="LIMIT"
+                  utilization={null}
+                  status={null}
+                  threshold={threshold}
+                />
+              ) : (
+                account.limitWindows.map((window) => (
+                  <QuotaValue
+                    key={window.slot}
+                    label={windowShortLabel(window)}
+                    utilization={window.utilization}
+                    status={window.status}
+                    threshold={threshold}
+                  />
+                ))
+              )
+            ) : (
+              <>
+                <QuotaValue
+                  label="5H"
+                  utilization={account.fiveHourUtilization}
+                  status={account.fiveHourStatus}
+                  threshold={threshold}
+                />
+                <QuotaValue
+                  label="7D"
+                  utilization={account.sevenDayUtilization}
+                  status={account.sevenDayStatus}
+                  threshold={threshold}
+                />
+                <QuotaValue
+                  label="FABLE"
+                  utilization={account.familyWeekly.fable?.utilization ?? null}
+                  status={account.familyWeekly.fable?.status ?? null}
+                  threshold={threshold}
+                />
+              </>
+            )}
           </div>
         </button>
         <DropdownMenu>
@@ -1245,35 +1295,54 @@ function AccountDrawer({
         <SettingsBadge>{statusPresentation(account).label}</SettingsBadge>
       </div>
       <div className="space-y-4">
-        <QuotaDetail
-          label="5 hour"
-          quota={shared(
-            account.fiveHourUtilization,
-            account.fiveHourResetAt,
-            account.fiveHourStatus,
-          )}
-          threshold={threshold}
-        />
-        <QuotaDetail
-          label="7 day"
-          quota={shared(
-            account.sevenDayUtilization,
-            account.sevenDayResetAt,
-            account.sevenDayStatus,
-          )}
-          threshold={threshold}
-        />
-        {MODEL_FAMILIES.flatMap((family) =>
-          account.familyWeekly[family] === null
-            ? []
-            : [
-                <QuotaDetail
-                  key={family}
-                  label={FAMILY_LABELS[family]}
-                  quota={account.familyWeekly[family]}
-                  threshold={threshold}
-                />,
-              ],
+        {account.provider === "codex" ? (
+          account.limitWindows.length === 0 ? (
+            <div className="text-sm text-muted-foreground">
+              No usage limits observed yet.
+            </div>
+          ) : (
+            account.limitWindows.map((window) => (
+              <QuotaDetail
+                key={window.slot}
+                label={windowLongLabel(window)}
+                quota={window}
+                threshold={threshold}
+              />
+            ))
+          )
+        ) : (
+          <>
+            <QuotaDetail
+              label="5 hour"
+              quota={shared(
+                account.fiveHourUtilization,
+                account.fiveHourResetAt,
+                account.fiveHourStatus,
+              )}
+              threshold={threshold}
+            />
+            <QuotaDetail
+              label="7 day"
+              quota={shared(
+                account.sevenDayUtilization,
+                account.sevenDayResetAt,
+                account.sevenDayStatus,
+              )}
+              threshold={threshold}
+            />
+            {MODEL_FAMILIES.flatMap((family) =>
+              account.familyWeekly[family] === null
+                ? []
+                : [
+                    <QuotaDetail
+                      key={family}
+                      label={FAMILY_LABELS[family]}
+                      quota={account.familyWeekly[family]}
+                      threshold={threshold}
+                    />,
+                  ],
+            )}
+          </>
         )}
       </div>
       <dl className="grid grid-cols-[7rem_1fr] gap-x-3 gap-y-2 border-t border-border pt-4 text-sm">

--- a/plugins/account-pool/src/cli.ts
+++ b/plugins/account-pool/src/cli.ts
@@ -14,6 +14,7 @@ import {
   type AccountPoolConfigSetInput,
   type AccountSummary,
   type FamilyQuota,
+  type LimitWindow,
   type ModelFamily,
   type PoolStatus,
 } from "./contracts.js";
@@ -100,6 +101,24 @@ function familyLabel(family: ModelFamily): string {
   return family[0]?.toUpperCase() + family.slice(1);
 }
 
+function formatWindowLabel(window: LimitWindow): string {
+  if (window.windowMinutes === null) return window.slot;
+  if (window.windowMinutes % 1_440 === 0)
+    return `${window.windowMinutes / 1_440}d`;
+  if (window.windowMinutes % 60 === 0) return `${window.windowMinutes / 60}h`;
+  return `${window.windowMinutes}m`;
+}
+
+function formatLimitWindows(windows: readonly LimitWindow[]): string {
+  if (windows.length === 0) return "-";
+  return windows
+    .map(
+      (window) =>
+        `${formatWindowLabel(window)}=${formatUtilization(window.utilization)} ${formatReset(window.resetAt)}`,
+    )
+    .join("; ");
+}
+
 function formatFamilyQuota(quota: FamilyQuota | null): string {
   if (quota === null) return "-";
   return [
@@ -127,6 +146,7 @@ function formatAccounts(accounts: readonly AccountSummary[]): string {
       "5h reset",
       "7d",
       "7d reset",
+      "Windows",
       ...families.map(familyLabel),
       "Status",
     ].join("\t"),
@@ -142,6 +162,7 @@ function formatAccounts(accounts: readonly AccountSummary[]): string {
         formatReset(account.fiveHourResetAt),
         formatUtilization(account.sevenDayUtilization),
         formatReset(account.sevenDayResetAt),
+        formatLimitWindows(account.limitWindows),
         ...families.map((family) =>
           formatFamilyQuota(account.familyWeekly[family]),
         ),

--- a/plugins/account-pool/src/codex-adapter.test.ts
+++ b/plugins/account-pool/src/codex-adapter.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+import { codexQuotaFromUsage, createCodexAdapter } from "./codex-adapter.js";
+import type { AccountQuota } from "./contracts.js";
+import { isQuotaExhausted } from "./quota.js";
+
+const ACCOUNT_ID = "11111111-1111-4111-8111-111111111111";
+
+function emptyQuota(): AccountQuota {
+  return {
+    accountId: ACCOUNT_ID,
+    fiveHourUtilization: null,
+    fiveHourResetAt: null,
+    fiveHourStatus: null,
+    sevenDayUtilization: null,
+    sevenDayResetAt: null,
+    sevenDayStatus: null,
+    representativeClaim: null,
+    familyWeekly: {
+      fable: null,
+      sonnet: null,
+      opus: null,
+      haiku: null,
+      other: null,
+    },
+    limitWindows: [],
+    observedAt: null,
+    heldUntil: null,
+    error: null,
+  };
+}
+
+const adapter = createCodexAdapter({
+  refreshUrl: "https://auth.example/oauth/token",
+  usageUrl: "https://usage.example/usage",
+});
+
+describe("codexQuotaFromUsage", () => {
+  it("keeps a Pro account's single weekly window out of the Claude slots", () => {
+    const quota = codexQuotaFromUsage(
+      ACCOUNT_ID,
+      {
+        plan_type: "pro",
+        rate_limit: {
+          allowed: true,
+          limit_reached: false,
+          primary_window: {
+            used_percent: 48,
+            limit_window_seconds: 604_800,
+            reset_after_seconds: 180_092,
+            reset_at: 1_788_748_205,
+          },
+          secondary_window: null,
+        },
+      },
+      emptyQuota(),
+      1_000,
+    );
+    expect(quota).toMatchObject({
+      fiveHourUtilization: null,
+      sevenDayUtilization: null,
+      familyWeekly: { fable: null, other: null },
+      limitWindows: [
+        {
+          slot: "primary",
+          windowMinutes: 10_080,
+          utilization: 0.48,
+          resetAt: 1_788_748_205_000,
+          status: "allowed",
+          source: "usage",
+        },
+      ],
+    });
+  });
+
+  it("clears slots a pre-window adapter wrote for a Codex account", () => {
+    const stale: AccountQuota = {
+      ...emptyQuota(),
+      fiveHourUtilization: 1,
+      fiveHourStatus: "rejected",
+      familyWeekly: {
+        ...emptyQuota().familyWeekly,
+        other: {
+          utilization: 1,
+          resetAt: null,
+          status: "rejected",
+          observedAt: 1,
+          source: "header",
+        },
+      },
+    };
+    expect(isQuotaExhausted(stale, "other", 0.9, 2_000)).toBe(true);
+    const refreshed = codexQuotaFromUsage(
+      ACCOUNT_ID,
+      {
+        rate_limit: {
+          primary_window: { used_percent: 10, limit_window_seconds: 604_800 },
+        },
+      },
+      stale,
+      2_000,
+    );
+    expect(refreshed).toMatchObject({
+      fiveHourUtilization: null,
+      fiveHourStatus: null,
+      familyWeekly: { other: null },
+    });
+    if (refreshed === null) throw new Error("Expected a quota.");
+    expect(isQuotaExhausted(refreshed, "other", 0.9, 2_000)).toBe(false);
+  });
+
+  it("returns null for a payload without rate limits", () => {
+    expect(codexQuotaFromUsage(ACCOUNT_ID, {}, emptyQuota(), 1)).toBeNull();
+  });
+});
+
+describe("codex header quotas", () => {
+  it("retains the reported window length when a later response omits it", () => {
+    const fromUsage = codexQuotaFromUsage(
+      ACCOUNT_ID,
+      {
+        rate_limit: {
+          primary_window: { used_percent: 10, limit_window_seconds: 604_800 },
+        },
+      },
+      emptyQuota(),
+      1_000,
+    );
+    if (fromUsage === null) throw new Error("Expected a quota.");
+    const rejected = adapter.quotaFromHeaders(
+      ACCOUNT_ID,
+      new Headers({ "x-codex-primary-used-percent": "100" }),
+      fromUsage,
+      "other",
+      2_000,
+    );
+    expect(rejected.limitWindows).toEqual([
+      {
+        slot: "primary",
+        windowMinutes: 10_080,
+        utilization: 1,
+        resetAt: null,
+        status: "rejected",
+        observedAt: 2_000,
+        source: "header",
+      },
+    ]);
+    expect(isQuotaExhausted(rejected, "other", 0.9, 2_000)).toBe(true);
+    expect(isQuotaExhausted(fromUsage, "other", 0.9, 2_000)).toBe(false);
+  });
+
+  it("reads both windows and their lengths from response headers", () => {
+    const quota = adapter.quotaFromHeaders(
+      ACCOUNT_ID,
+      new Headers({
+        "x-codex-primary-used-percent": "25",
+        "x-codex-primary-window-minutes": "300",
+        "x-codex-primary-reset-after-seconds": "60",
+        "x-codex-secondary-used-percent": "40",
+        "x-codex-secondary-window-minutes": "10080",
+        "x-codex-secondary-reset-at": "4102452000",
+      }),
+      emptyQuota(),
+      "other",
+      5_000,
+    );
+    expect(quota.limitWindows).toEqual([
+      {
+        slot: "primary",
+        windowMinutes: 300,
+        utilization: 0.25,
+        resetAt: 65_000,
+        status: null,
+        observedAt: 5_000,
+        source: "header",
+      },
+      {
+        slot: "secondary",
+        windowMinutes: 10_080,
+        utilization: 0.4,
+        resetAt: 4_102_452_000_000,
+        status: null,
+        observedAt: 5_000,
+        source: "header",
+      },
+    ]);
+    expect(
+      adapter.quotaFromHeaders(
+        ACCOUNT_ID,
+        new Headers(),
+        quota,
+        "other",
+        6_000,
+      ),
+    ).toBe(quota);
+  });
+});

--- a/plugins/account-pool/src/codex-adapter.ts
+++ b/plugins/account-pool/src/codex-adapter.ts
@@ -1,5 +1,10 @@
 import { z } from "zod";
-import type { AccountQuota, AccountSecret, FamilyQuota } from "./contracts.js";
+import type {
+  AccountQuota,
+  AccountSecret,
+  LimitWindow,
+  LimitWindowSlot,
+} from "./contracts.js";
 import {
   codexAccessTokenExpiresAt,
   importCodexCredentials,
@@ -14,7 +19,10 @@ import {
 export const CODEX_AUTH_BASE_URL = "https://auth.openai.com";
 export const CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
 export const DEFAULT_CODEX_REFRESH_URL = `${CODEX_AUTH_BASE_URL}/oauth/token`;
+export const DEFAULT_CODEX_USAGE_URL =
+  "https://chatgpt.com/backend-api/wham/usage";
 const REFRESH_WINDOW_MS = 5 * 60 * 1_000;
+const USAGE_REQUEST_TIMEOUT_MS = 15_000;
 const ALLOWED_REQUEST_HEADERS = new Set([
   "accept",
   "content-encoding",
@@ -49,25 +57,74 @@ function resetAt(headers: Headers, prefix: string, now: number): number | null {
   return after === null ? null : now + Math.round(after * 1_000);
 }
 
-function windowQuota(
+function windowMinutesFromSeconds(
+  seconds: number | null | undefined,
+): number | null {
+  if (seconds === null || seconds === undefined || !Number.isFinite(seconds))
+    return null;
+  const minutes = Math.round(seconds / 60);
+  return minutes > 0 ? minutes : null;
+}
+
+function previousWindow(
+  previous: AccountQuota,
+  slot: LimitWindowSlot,
+): LimitWindow | null {
+  return previous.limitWindows.find((window) => window.slot === slot) ?? null;
+}
+
+function windowFromHeaders(
   headers: Headers,
-  prefix: string,
-  previous: FamilyQuota | null,
+  slot: LimitWindowSlot,
+  previous: LimitWindow | null,
   now: number,
-): FamilyQuota | null {
+): LimitWindow | null {
+  const prefix = `x-codex-${slot}`;
   const usedPercent = numberHeader(headers, `${prefix}-used-percent`);
   const reset = resetAt(headers, prefix, now);
+  const minutes = numberHeader(headers, `${prefix}-window-minutes`);
   if (usedPercent === null && reset === null) return previous;
   const utilization =
     usedPercent === null
       ? (previous?.utilization ?? null)
       : Math.max(0, Math.min(1, usedPercent / 100));
   return {
+    slot,
+    windowMinutes:
+      minutes !== null && minutes > 0
+        ? Math.round(minutes)
+        : (previous?.windowMinutes ?? null),
     utilization,
     resetAt: reset ?? previous?.resetAt ?? null,
     status: utilization !== null && utilization >= 1 ? "rejected" : null,
     observedAt: now,
     source: "header",
+  };
+}
+
+function orderedWindows(
+  windows: ReadonlyArray<LimitWindow | null>,
+): LimitWindow[] {
+  return windows.filter((window): window is LimitWindow => window !== null);
+}
+
+function withoutClaudeSlots(previous: AccountQuota): AccountQuota {
+  return {
+    ...previous,
+    fiveHourUtilization: null,
+    fiveHourResetAt: null,
+    fiveHourStatus: null,
+    sevenDayUtilization: null,
+    sevenDayResetAt: null,
+    sevenDayStatus: null,
+    representativeClaim: null,
+    familyWeekly: {
+      fable: null,
+      sonnet: null,
+      opus: null,
+      haiku: null,
+      other: null,
+    },
   };
 }
 
@@ -77,33 +134,104 @@ function codexQuotaFromHeaders(
   previous: AccountQuota,
   now: number,
 ): AccountQuota {
-  const primary = windowQuota(
+  const priorPrimary = previousWindow(previous, "primary");
+  const priorSecondary = previousWindow(previous, "secondary");
+  const primary = windowFromHeaders(headers, "primary", priorPrimary, now);
+  const secondary = windowFromHeaders(
     headers,
-    "x-codex-primary",
-    previous.familyWeekly.other,
+    "secondary",
+    priorSecondary,
     now,
   );
-  const secondary = windowQuota(headers, "x-codex-secondary", null, now);
-  if (primary === previous.familyWeekly.other && secondary === null)
-    return previous;
+  if (primary === priorPrimary && secondary === priorSecondary) return previous;
   return {
-    ...previous,
+    ...withoutClaudeSlots(previous),
     accountId,
-    fiveHourUtilization: primary?.utilization ?? previous.fiveHourUtilization,
-    fiveHourResetAt: primary?.resetAt ?? previous.fiveHourResetAt,
-    fiveHourStatus: primary === null ? previous.fiveHourStatus : primary.status,
-    sevenDayUtilization: secondary?.utilization ?? previous.sevenDayUtilization,
-    sevenDayResetAt: secondary?.resetAt ?? previous.sevenDayResetAt,
-    sevenDayStatus:
-      secondary === null ? previous.sevenDayStatus : secondary.status,
-    familyWeekly: { ...previous.familyWeekly, other: primary },
+    limitWindows: orderedWindows([primary, secondary]),
     observedAt: now,
     heldUntil: null,
   };
 }
 
+const usageWindowSchema = z
+  .object({
+    used_percent: z.number(),
+    reset_at: z.number().nullish(),
+    reset_after_seconds: z.number().nullish(),
+    limit_window_seconds: z.number().nullish(),
+  })
+  .passthrough();
+
+const usageResponseSchema = z
+  .object({
+    rate_limit: z
+      .object({
+        primary_window: usageWindowSchema.nullish(),
+        secondary_window: usageWindowSchema.nullish(),
+      })
+      .passthrough()
+      .nullish(),
+  })
+  .passthrough();
+
+function windowFromUsage(
+  slot: LimitWindowSlot,
+  value: z.infer<typeof usageWindowSchema> | null | undefined,
+  now: number,
+): LimitWindow | null {
+  if (value === null || value === undefined) return null;
+  const utilization = Math.max(0, Math.min(1, value.used_percent / 100));
+  const reset =
+    value.reset_at !== null &&
+    value.reset_at !== undefined &&
+    Number.isFinite(value.reset_at)
+      ? Math.round(
+          value.reset_at < 1_000_000_000_000
+            ? value.reset_at * 1_000
+            : value.reset_at,
+        )
+      : value.reset_after_seconds !== null &&
+          value.reset_after_seconds !== undefined &&
+          Number.isFinite(value.reset_after_seconds)
+        ? now + Math.round(value.reset_after_seconds * 1_000)
+        : null;
+  return {
+    slot,
+    windowMinutes: windowMinutesFromSeconds(value.limit_window_seconds),
+    utilization,
+    resetAt: reset,
+    status: utilization >= 1 ? "rejected" : "allowed",
+    observedAt: now,
+    source: "usage",
+  };
+}
+
+export function codexQuotaFromUsage(
+  accountId: string,
+  payload: unknown,
+  previous: AccountQuota,
+  now: number,
+): AccountQuota | null {
+  const parsed = usageResponseSchema.safeParse(payload);
+  if (!parsed.success || parsed.data.rate_limit == null) return null;
+  return {
+    ...withoutClaudeSlots(previous),
+    accountId,
+    limitWindows: orderedWindows([
+      windowFromUsage("primary", parsed.data.rate_limit.primary_window, now),
+      windowFromUsage(
+        "secondary",
+        parsed.data.rate_limit.secondary_window,
+        now,
+      ),
+    ]),
+    observedAt: now,
+  };
+}
+
 export function createCodexAdapter(options: {
   refreshUrl: string;
+  usageUrl: string;
   importCredentials?: () => Promise<ImportedCodexCredentials>;
 }): ProviderAdapter {
   return {
@@ -194,6 +322,34 @@ export function createCodexAdapter(options: {
       };
       await context.accounts.writeSecret(context.account.id, refreshed);
       return { secret: refreshed, refreshed: true };
+    },
+    async refreshUsage(context) {
+      const secret = await context.freshSecret();
+      if (
+        secret.kind !== "oauth" ||
+        context.account.codexAccountId === undefined
+      )
+        return;
+      const response = await context.fetch(options.usageUrl, {
+        headers: {
+          authorization: `Bearer ${secret.accessToken}`,
+          "chatgpt-account-id": context.account.codexAccountId,
+          originator: "bb",
+          accept: "application/json",
+        },
+        signal: AbortSignal.timeout(USAGE_REQUEST_TIMEOUT_MS),
+      });
+      if (!response.ok) {
+        await response.body?.cancel();
+        return;
+      }
+      const quota = codexQuotaFromUsage(
+        context.account.id,
+        await response.json().catch(() => null),
+        context.quotas.get(context.account.id),
+        context.now(),
+      );
+      if (quota !== null) context.quotas.put(quota);
     },
     errorResponse(status, message, headers) {
       return Response.json(

--- a/plugins/account-pool/src/codex-device-login.test.ts
+++ b/plugins/account-pool/src/codex-device-login.test.ts
@@ -88,6 +88,7 @@ function summary(account: CodexDeviceAccount): AccountSummary {
       haiku: null,
       other: null,
     },
+    limitWindows: [],
     observedAt: null,
     heldUntil: null,
     error: null,

--- a/plugins/account-pool/src/contracts.ts
+++ b/plugins/account-pool/src/contracts.ts
@@ -89,6 +89,24 @@ export const familyWeeklySchema = z
 
 export type FamilyWeekly = z.infer<typeof familyWeeklySchema>;
 
+export const limitWindowSlotSchema = z.enum(["primary", "secondary"]);
+
+export type LimitWindowSlot = z.infer<typeof limitWindowSlotSchema>;
+
+export const limitWindowSchema = z
+  .object({
+    slot: limitWindowSlotSchema,
+    windowMinutes: z.number().int().positive().nullable(),
+    utilization: z.number().nullable(),
+    resetAt: z.number().int().nullable(),
+    status: z.string().nullable(),
+    observedAt: z.number().int(),
+    source: z.enum(["header", "usage"]),
+  })
+  .strict();
+
+export type LimitWindow = z.infer<typeof limitWindowSchema>;
+
 export const accountSchema = z
   .object({
     id: z.string().uuid(),
@@ -145,6 +163,7 @@ export const quotaSchema = z
     sevenDayStatus: z.string().nullable(),
     representativeClaim: z.string().nullable(),
     familyWeekly: familyWeeklySchema,
+    limitWindows: z.array(limitWindowSchema),
     observedAt: z.number().int().nullable(),
     heldUntil: z.number().int().nullable(),
     error: z.string().nullable(),
@@ -163,6 +182,7 @@ export const accountSummarySchema = accountSchema.extend({
   sevenDayStatus: z.string().nullable(),
   representativeClaim: z.string().nullable(),
   familyWeekly: familyWeeklySchema,
+  limitWindows: z.array(limitWindowSchema),
   observedAt: z.number().int().nullable(),
   heldUntil: z.number().int().nullable(),
   error: z.string().nullable(),

--- a/plugins/account-pool/src/hub.ts
+++ b/plugins/account-pool/src/hub.ts
@@ -10,6 +10,7 @@ import { createClaudeAdapter } from "./claude-adapter.js";
 import {
   createCodexAdapter,
   DEFAULT_CODEX_REFRESH_URL,
+  DEFAULT_CODEX_USAGE_URL,
 } from "./codex-adapter.js";
 import type { ProviderAdapter } from "./provider-adapter.js";
 import type { ImportedProviderAccount } from "./provider-adapter.js";
@@ -228,6 +229,7 @@ export class AccountPoolHub {
           sevenDayStatus: quota.sevenDayStatus,
           representativeClaim: quota.representativeClaim,
           familyWeekly: quota.familyWeekly,
+          limitWindows: quota.limitWindows,
           observedAt: quota.observedAt,
           heldUntil: quota.heldUntil,
           error: quota.error,
@@ -566,6 +568,7 @@ export class AccountPoolHub {
           quota.heldUntil,
           quota.fiveHourResetAt,
           quota.sevenDayResetAt,
+          ...quota.limitWindows.map((window) => window.resetAt),
           governingWeeklyResetAt(quota, family),
         ].filter((value): value is number => value !== null && value > now);
       })
@@ -625,6 +628,7 @@ export function createHub(options: {
   now?: () => number;
   refreshUrl?: string;
   codexRefreshUrl?: string;
+  codexUsageUrl?: string;
   importClaudeCredentials?: () => Promise<ImportedClaudeCredentials>;
   importCodexCredentials?: () => Promise<ImportedCodexCredentials>;
   usageUrl?: string;
@@ -647,6 +651,7 @@ export function createHub(options: {
       "codex",
       createCodexAdapter({
         refreshUrl: options.codexRefreshUrl ?? DEFAULT_CODEX_REFRESH_URL,
+        usageUrl: options.codexUsageUrl ?? DEFAULT_CODEX_USAGE_URL,
         importCredentials: options.importCodexCredentials,
       }),
     ],

--- a/plugins/account-pool/src/quota.ts
+++ b/plugins/account-pool/src/quota.ts
@@ -3,6 +3,7 @@ import type {
   AccountQuota,
   AccountSummary,
   FamilyQuota,
+  LimitWindow,
   ModelFamily,
 } from "./contracts.js";
 
@@ -123,6 +124,7 @@ export function quotaFromHeaders(
     sevenDayStatus: sevenDayStatus ?? previous.sevenDayStatus,
     representativeClaim: representativeClaim ?? previous.representativeClaim,
     familyWeekly,
+    limitWindows: previous.limitWindows,
     observedAt: observed ? now : previous.observedAt,
     heldUntil: previous.heldUntil,
     error: previous.error,
@@ -173,8 +175,33 @@ export function isSharedQuotaExhausted(
       quota.sevenDayResetAt,
       threshold,
       now,
+    ) ||
+    quota.limitWindows.some((window) =>
+      activeWindow(
+        window.utilization,
+        window.status,
+        window.resetAt,
+        threshold,
+        now,
+      ),
     )
   );
+}
+
+export const WEEKLY_WINDOW_MINUTES = 7 * 24 * 60;
+
+export function longestLimitWindow(
+  windows: readonly LimitWindow[],
+): LimitWindow | null {
+  let longest: LimitWindow | null = null;
+  for (const window of windows) {
+    if (
+      longest === null ||
+      (window.windowMinutes ?? 0) > (longest.windowMinutes ?? 0)
+    )
+      longest = window;
+  }
+  return longest;
 }
 
 export function isQuotaExhausted(
@@ -207,7 +234,12 @@ export function governingWeeklyResetAt(
   quota: AccountQuota,
   family: ModelFamily,
 ): number | null {
-  return quota.familyWeekly[family]?.resetAt ?? quota.sevenDayResetAt;
+  return (
+    quota.familyWeekly[family]?.resetAt ??
+    quota.sevenDayResetAt ??
+    longestLimitWindow(quota.limitWindows)?.resetAt ??
+    null
+  );
 }
 
 export function accountStatus(

--- a/plugins/account-pool/src/server.test.ts
+++ b/plugins/account-pool/src/server.test.ts
@@ -273,6 +273,9 @@ async function addApiAccount(
   return found;
 }
 
+const EMPTY_USAGE_URL = "data:application/json,{}";
+const CODEX_USAGE_STUB_URL = "https://usage.example/wham/usage";
+
 describe("Account Pool config schema", () => {
   it("fills defaults and rejects invalid URLs and thresholds", () => {
     expect(accountPoolConfigSchema.parse({})).toEqual({
@@ -383,6 +386,26 @@ describe("Account Pool plugin", () => {
         );
         return;
       }
+      if (request.url === "/usage") {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(
+          JSON.stringify({
+            plan_type: "pro",
+            rate_limit: {
+              allowed: true,
+              limit_reached: false,
+              primary_window: {
+                used_percent: 48,
+                limit_window_seconds: 604_800,
+                reset_after_seconds: 180_092,
+                reset_at: 4_102_452_000,
+              },
+              secondary_window: null,
+            },
+          }),
+        );
+        return;
+      }
       if (request.url === "/models") {
         modelRequests.push(
           request.headers["chatgpt-account-id"]?.toString() ?? "",
@@ -405,8 +428,10 @@ describe("Account Pool plugin", () => {
         response.writeHead(200, {
           "content-type": "application/json",
           "x-codex-primary-used-percent": "25",
+          "x-codex-primary-window-minutes": "300",
           "x-codex-primary-reset-after-seconds": "3600",
           "x-codex-secondary-used-percent": "40",
+          "x-codex-secondary-window-minutes": "10080",
           "x-codex-secondary-reset-after-seconds": "86400",
         });
         response.end('{"id":"http-response"}');
@@ -465,6 +490,7 @@ describe("Account Pool plugin", () => {
     });
     await createAccountPoolPlugin({
       codexRefreshUrl: `${upstream.url}/oauth`,
+      codexUsageUrl: `${upstream.url}/usage`,
       importCodexCredentials,
       usageUrl: "data:application/json,{}",
     })(host.bb);
@@ -508,6 +534,8 @@ describe("Account Pool plugin", () => {
     ]);
     expect(accountTable.stdout).toContain("Provider");
     expect(accountTable.stdout).toContain("codex");
+    expect(accountTable.stdout).toContain("7d=48% 2100-01-01T02:00:00.000Z");
+    expect(accountTable.stdout).not.toContain("5h=");
     const routed = await resolveCodexToken(host);
     expect(routed.baseUrl).toBe("/api/v1/plugins/account-pool/http/v1");
     await expect(
@@ -610,17 +638,46 @@ describe("Account Pool plugin", () => {
     const firstCodex = status.accounts.find(
       (account) => account.codexAccountId === "chatgpt-account-1",
     );
+    expect(seen[1]?.accountId).toBe("chatgpt-account-1");
     expect(firstCodex).toMatchObject({
       provider: "codex",
-      sevenDayUtilization: 0.4,
+      status: "exhausted",
+      fiveHourUtilization: null,
+      sevenDayUtilization: null,
+      familyWeekly: { other: null },
+      limitWindows: [
+        {
+          slot: "primary",
+          windowMinutes: 300,
+          utilization: 1,
+          status: "rejected",
+          source: "header",
+        },
+        {
+          slot: "secondary",
+          windowMinutes: 10_080,
+          utilization: 0.4,
+          status: null,
+          source: "header",
+        },
+      ],
     });
     expect(
       status.accounts.find(
-        (account) => account.codexAccountId === seen[1]?.accountId,
+        (account) => account.codexAccountId === seen[2]?.accountId,
       ),
     ).toMatchObject({
       provider: "codex",
-      fiveHourUtilization: 1,
+      status: "ready",
+      limitWindows: [
+        {
+          slot: "primary",
+          windowMinutes: 10_080,
+          utilization: 0.48,
+          status: "allowed",
+          source: "usage",
+        },
+      ],
     });
     const secret = accountSecretSchema.parse(
       JSON.parse(
@@ -654,6 +711,7 @@ describe("Account Pool plugin", () => {
       sdk: sdkStubs(),
     });
     await createAccountPoolPlugin({
+      codexUsageUrl: EMPTY_USAGE_URL,
       importCodexCredentials: async () => ({
         accessToken: "access",
         refreshToken: "refresh",
@@ -716,9 +774,10 @@ describe("Account Pool plugin", () => {
     );
     let upstreamReadCanceled = false;
     const upstreamFetch = async (
-      _input: string | URL | Request,
+      input: string | URL | Request,
       init?: RequestInit,
     ): Promise<Response> => {
+      if (String(input) === CODEX_USAGE_STUB_URL) return Response.json({});
       const signal = init?.signal;
       if (signal === undefined || signal === null) {
         throw new Error("Expected the upstream request to carry a signal.");
@@ -754,6 +813,7 @@ describe("Account Pool plugin", () => {
     });
     await createAccountPoolPlugin({
       fetch: upstreamFetch,
+      codexUsageUrl: CODEX_USAGE_STUB_URL,
       importCodexCredentials: async () => ({
         accessToken: "access",
         refreshToken: "refresh",
@@ -813,7 +873,10 @@ describe("Account Pool plugin", () => {
       path.join(tmpdir(), "bb-account-pool-codex-malformed-"),
     );
     let upstreamReadCanceled = false;
-    const upstreamFetch = async (): Promise<Response> => {
+    const upstreamFetch = async (
+      input: string | URL | Request,
+    ): Promise<Response> => {
+      if (String(input) === CODEX_USAGE_STUB_URL) return Response.json({});
       const body = new ReadableStream<Uint8Array>({
         start(controller) {
           controller.enqueue(new TextEncoder().encode("data: {\n\n"));
@@ -836,6 +899,7 @@ describe("Account Pool plugin", () => {
     });
     await createAccountPoolPlugin({
       fetch: upstreamFetch,
+      codexUsageUrl: CODEX_USAGE_STUB_URL,
       importCodexCredentials: async () => ({
         accessToken: "access",
         refreshToken: "refresh",
@@ -1346,6 +1410,7 @@ describe("Account Pool plugin", () => {
     });
     await createAccountPoolPlugin({
       codexAuthBaseUrl: auth.url,
+      codexUsageUrl: EMPTY_USAGE_URL,
       usageUrl: "data:application/json,{}",
     })(host.bb);
     cleanups.push(async () => {
@@ -2464,6 +2529,7 @@ describe("Account Pool plugin", () => {
     const fixture = await createFixture({
       upstreamUrl: upstream.url,
       options: {
+        codexUsageUrl: EMPTY_USAGE_URL,
         importCodexCredentials: async () => ({
           accessToken: "codex-access",
           refreshToken: "codex-refresh",

--- a/plugins/account-pool/src/server.ts
+++ b/plugins/account-pool/src/server.ts
@@ -33,6 +33,7 @@ export interface AccountPoolPluginOptions {
   now?: () => number;
   refreshUrl?: string;
   codexRefreshUrl?: string;
+  codexUsageUrl?: string;
   usageUrl?: string;
   usageRefreshIntervalMs?: number;
   drainTimeoutMs?: number;
@@ -100,6 +101,7 @@ export function createAccountPoolPlugin(
       now,
       refreshUrl: options.refreshUrl,
       codexRefreshUrl: options.codexRefreshUrl,
+      codexUsageUrl: options.codexUsageUrl,
       usageUrl: options.usageUrl,
       profileUrl: options.oauthProfileUrl,
       importClaudeCredentials: options.importCredentials,

--- a/plugins/account-pool/src/store.test.ts
+++ b/plugins/account-pool/src/store.test.ts
@@ -105,7 +105,12 @@ describe("QuotaStore", () => {
     const database = new Database(":memory:");
     const initial = QUOTA_MIGRATIONS[0];
     const familyMigration = QUOTA_MIGRATIONS[1];
-    if (initial === undefined || familyMigration === undefined) {
+    const windowMigration = QUOTA_MIGRATIONS[2];
+    if (
+      initial === undefined ||
+      familyMigration === undefined ||
+      windowMigration === undefined
+    ) {
       throw new Error("Expected quota migrations.");
     }
     database.exec(initial);
@@ -121,10 +126,12 @@ describe("QuotaStore", () => {
         '{"7d_oi":4102452000000}',
       );
     database.exec(familyMigration);
+    database.exec(windowMigration);
     const quotas = new QuotaStore(database);
 
     const migrated = quotas.get("11111111-1111-4111-8111-111111111111");
     expect(migrated.sevenDayUtilization).toBe(0.5);
+    expect(migrated.limitWindows).toEqual([]);
     expect(migrated.familyWeekly).toEqual({
       fable: null,
       sonnet: null,
@@ -148,6 +155,33 @@ describe("QuotaStore", () => {
     expect(
       quotas.get("11111111-1111-4111-8111-111111111111").familyWeekly.fable,
     ).toMatchObject({ utilization: 1, source: "usage" });
+    quotas.put({
+      ...migrated,
+      limitWindows: [
+        {
+          slot: "primary",
+          windowMinutes: 10_080,
+          utilization: 0.48,
+          resetAt: 4_102_452_000_000,
+          status: "allowed",
+          observedAt: 10,
+          source: "usage",
+        },
+      ],
+    });
+    expect(
+      quotas.get("11111111-1111-4111-8111-111111111111").limitWindows,
+    ).toEqual([
+      {
+        slot: "primary",
+        windowMinutes: 10_080,
+        utilization: 0.48,
+        resetAt: 4_102_452_000_000,
+        status: "allowed",
+        observedAt: 10,
+        source: "usage",
+      },
+    ]);
     database.close();
   });
 });

--- a/plugins/account-pool/src/store.ts
+++ b/plugins/account-pool/src/store.ts
@@ -526,6 +526,7 @@ const quotaRowSchema = z
     representative_claim: z.string().nullable(),
     bucket_exhaustion_json: z.string(),
     family_weekly_json: z.string(),
+    limit_windows_json: z.string(),
     observed_at: z.number().int().nullable(),
     held_until: z.number().int().nullable(),
     error: z.string().nullable(),
@@ -547,6 +548,7 @@ const EMPTY_QUOTA = {
     haiku: null,
     other: null,
   },
+  limitWindows: [],
   observedAt: null,
   heldUntil: null,
   error: null,
@@ -576,6 +578,7 @@ export class QuotaStore {
       sevenDayStatus: row.seven_day_status,
       representativeClaim: row.representative_claim,
       familyWeekly: JSON.parse(row.family_weekly_json),
+      limitWindows: JSON.parse(row.limit_windows_json),
       observedAt: row.observed_at,
       heldUntil: row.held_until,
       error: row.error,
@@ -590,8 +593,8 @@ export class QuotaStore {
           account_id, five_hour_utilization, five_hour_reset_at,
           five_hour_status, seven_day_utilization, seven_day_reset_at,
           seven_day_status, representative_claim, bucket_exhaustion_json,
-          family_weekly_json, observed_at, held_until, error
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, '{}', ?, ?, ?, ?)
+          family_weekly_json, limit_windows_json, observed_at, held_until, error
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, '{}', ?, ?, ?, ?, ?)
         ON CONFLICT(account_id) DO UPDATE SET
           five_hour_utilization = excluded.five_hour_utilization,
           five_hour_reset_at = excluded.five_hour_reset_at,
@@ -601,6 +604,7 @@ export class QuotaStore {
           seven_day_status = excluded.seven_day_status,
           representative_claim = excluded.representative_claim,
           family_weekly_json = excluded.family_weekly_json,
+          limit_windows_json = excluded.limit_windows_json,
           observed_at = excluded.observed_at,
           held_until = excluded.held_until,
           error = excluded.error`,
@@ -615,6 +619,7 @@ export class QuotaStore {
         value.sevenDayStatus,
         value.representativeClaim,
         JSON.stringify(value.familyWeekly),
+        JSON.stringify(value.limitWindows),
         value.observedAt,
         value.heldUntil,
         value.error,
@@ -644,4 +649,5 @@ export const QUOTA_MIGRATIONS = [
     error TEXT
   )`,
   `ALTER TABLE account_quota ADD COLUMN family_weekly_json TEXT NOT NULL DEFAULT '{"fable":null,"sonnet":null,"opus":null,"haiku":null,"other":null}'`,
+  `ALTER TABLE account_quota ADD COLUMN limit_windows_json TEXT NOT NULL DEFAULT '[]'`,
 ];


### PR DESCRIPTION
## Human comments

## What was wrong

The Account Pooler's Codex adapter forced ChatGPT's primary rate-limit window into the Claude 5H slot and its secondary window into the 7D slot, and every account row rendered the Claude-only Fable column. ChatGPT Pro accounts report a single weekly window (`limit_window_seconds` 604800) and no secondary window, so a Pro account showed its weekly usage under **5H**, an empty **7D**, and an empty **FABLE**.

## What changed

`plugins/account-pool` only. No server/daemon wire change.

- `contracts.ts` / `store.ts`: quotas and account summaries carry a `limitWindows` list (slot, reported length in minutes, utilization, reset, status, source). New quota-store migration adds `limit_windows_json`.
- `codex-adapter.ts`: response headers populate `limitWindows`, reading the window length from `x-codex-{primary,secondary}-window-minutes`; a new `refreshUsage` fetches the ChatGPT usage endpoint (the same one the Codex provider's usage limits page uses) so windows are known right after an account is added. Codex writes clear anything a previous version left in the Claude 5H/7D/family slots so an existing install stops showing stale data after the first refresh.
- `quota.ts` / `hub.ts`: exhaustion, routing order (governing weekly reset), and the 429 retry-after computation include the new windows.
- `app.tsx`: Codex rows render one column per reported window labeled by length (`5H`, `7D`) and no Fable column; the detail drawer lists windows as "Weekly" / "5 hour".
- `cli.ts`: `bb pool account list` gains a `Windows` column.
- `server.ts`: `codexUsageUrl` plugin option for tests.



## How you verified

- New `src/codex-adapter.test.ts`: Pro payload maps to one weekly window and leaves the Claude slots null; header window lengths are read and retained when a later 429 omits them; stale Claude-slot data from the previous adapter is cleared; empty payload is ignored.
- `server.test.ts` Codex integration test now serves a Pro usage payload, sends window-minutes headers, and asserts the CLI table and both accounts' `limitWindows`.
- `app.test.tsx`: a Codex account renders only `7D`, no `5H`/`FABLE`, and "Weekly" in the drawer.
- `store.test.ts`: migration round-trips `limitWindows`.
- `pnpm exec turbo run test typecheck --filter=bb-plugin-account-pool` — 69 tests pass.
- Manually launched the dev app with a copy of the production pool data and confirmed the settings page and drawer render the weekly window only.

> AGENT GENERATED
