### PR TITLE
Require a plugin store overview file, scaffold one, and give the Account Pooler one

### DIFF
--- a/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/references/distribution.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/references/distribution.md
@@ -182,10 +182,19 @@ package.json is the one-sentence hook. It appears on every browse card and as
 the lead paragraph on the detail page. Keep it under about 140 characters.
 State the outcome the user gets.
 
-An optional `PLUGIN_OVERVIEW.md` beside package.json holds the long-form
-description. The detail page shows it in an Overview section under the lead
-paragraph, in the app and on the public getbb.app marketplace. The
-`submit-a-plugin` skill copies the file into the marketplace repository as
+`PLUGIN_OVERVIEW.md` beside package.json holds the long-form description. The
+detail page shows it in an Overview section under the lead paragraph, in the
+app and on the public getbb.app marketplace. `bb plugin new` scaffolds one, the
+BB Community marketplace requires one, and a plugin that is only installed from
+a local path or a private source still reads better with one.
+
+The file is the same claim as `bb.description` at length: the same outcome, the
+same surfaces, no capability the short text does not imply. Treat the two as
+one text in two lengths. Whenever you change `bb.description`, or add or remove
+a surface, update this file in the same change so the lead paragraph and the
+Overview section never disagree.
+
+The `submit-a-plugin` skill copies the file into the marketplace repository as
 `overview/<plugin-id>.md` and references it from the entry with
 `"overview": "./overview/<plugin-id>.md"`. A bundled BB plugin uses the same
 file, and the bb-official generator folds it into the built catalog.

--- a/apps/server/src/services/skills/builtin-skills/submit-a-plugin/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/submit-a-plugin/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: submit-a-plugin
-description: Submit a bb plugin to the BB Community marketplace. Use whenever a user asks to submit, list, publish, or add a plugin to the BB marketplace, or asks for a marketplace pull request. This skill validates the plugin and release, creates the marketplace entry, icon, screenshots, and optional long-form description, and opens the pull request.
+description: Submit a bb plugin to the BB Community marketplace. Use whenever a user asks to submit, list, publish, or add a plugin to the BB marketplace, or asks for a marketplace pull request. This skill validates the plugin and release, creates the marketplace entry, icon, screenshots, and long-form overview, and opens the pull request.
 ---
 
 # Submit a plugin
@@ -50,7 +50,8 @@ rules.
 4. Get separate approval before any release mutation.
 5. Create one marketplace entry with a vendored icon.
 6. Install the plugin and capture its screenshots.
-7. Copy the plugin PLUGIN_OVERVIEW.md file into the marketplace when the plugin has one.
+7. Copy the plugin PLUGIN_OVERVIEW.md file into the marketplace. The public
+   marketplace requires an overview file on every entry.
 8. Validate the marketplace repository.
 9. Commit only the entry, icon, screenshots, and overview file.
 10. Open a pull request from the submitter account.
@@ -62,8 +63,9 @@ Read these references as the task reaches each stage:
   screenshots, or overview file. It states what a good entry and description
   hold, how to capture screenshots with a harness browser or computer
   automation tool, what to ask the user for when the harness has no such
-  tool, and which markdown the long-form description can use. It ends with a
-  quality check to run before the pull request.
+  tool, which markdown the long-form description can use, and what to do when
+  the plugin has no PLUGIN_OVERVIEW.md yet. It ends with a quality check to run
+  before the pull request.
 - Read references/pull-request.md before cloning, validating, or submitting
   the marketplace repository.
 

--- a/apps/server/src/services/skills/builtin-skills/submit-a-plugin/references/marketplace-entry.md
+++ b/apps/server/src/services/skills/builtin-skills/submit-a-plugin/references/marketplace-entry.md
@@ -211,11 +211,18 @@ getbb.app, so use a local path for a submission.
 
 ## Add the overview file
 
-The plugin author can keep a long-form description in a PLUGIN_OVERVIEW.md
-file beside the plugin package.json. The store detail page shows the short
-description as a lead paragraph under the plugin name, then an Overview
-section with this file. It is optional. Do not write one for the author. Copy
-the file only when the plugin repository holds it.
+Every entry in the public marketplace needs an overview file. The plugin author
+keeps the long-form description in a PLUGIN_OVERVIEW.md file beside the plugin
+package.json. The store detail page shows the short description as a lead
+paragraph under the plugin name, then an Overview section with this file. The
+overview is the same claim as the short description at length: the same
+outcome, the same surfaces, no capability the short text does not imply.
+
+Copy the author's file when the plugin repository holds it. When it does not,
+draft one from the behavior you observed while validating and screenshotting
+the plugin, show the full text to the user, and get approval before you commit
+it. Offer to add the same file to the plugin repository as PLUGIN_OVERVIEW.md
+so the two stay together. Never invent a capability to fill the file.
 
 Copy the file to overview/<plugin-id>.md in the marketplace repository. Reference
 it from the entry with the exact relative path:
@@ -265,8 +272,9 @@ statement below before you open the pull request.
 - The tags hold words a user would search for.
 - The icon reads clearly at 40 pixels.
 - The first screenshot shows the main surface with real content.
-- The overview file, when present, uses only the permitted markdown and https
-  links.
+- The entry references an overview file, and the overview says the same thing
+  as the short description at greater length.
+- The overview file uses only the permitted markdown and https links.
 - No field holds private data, a local path, or an internal URL.
 
 Fix the entry when one statement fails. Do not submit an entry you cannot

--- a/apps/server/src/services/skills/builtin-skills/submit-a-plugin/references/pull-request.md
+++ b/apps/server/src/services/skills/builtin-skills/submit-a-plugin/references/pull-request.md
@@ -58,7 +58,6 @@ git diff -- entries/PLUGIN_ID.json icons/ screenshots/PLUGIN_ID/ overview/PLUGIN
 ```
 
 Omit each screenshots/PLUGIN_ID/ argument when the entry has no screenshots.
-Omit each overview/PLUGIN_ID.md argument when the entry has no overview file.
 
 Confirm:
 
@@ -77,8 +76,8 @@ Confirm:
 - Each screenshot meets the width, size, format, location, and reference
   rules, and shows no private data.
 - The screenshots directory holds no unreferenced file.
-- The overview file, when present, is at overview/PLUGIN_ID.md, is referenced from
-  the entry, and passes the build.
+- The overview file is at overview/PLUGIN_ID.md, is referenced from the entry,
+  and passes the build.
 - Both marketplace checks pass.
 
 ## Open the pull request
@@ -115,4 +114,4 @@ Follow the marketplace repository instructions. The pull request body must state
 - The marketplace checks that passed.
 - Required permissions, external services, and relevant security facts.
 - What each screenshot shows, or why the entry has none.
-- Whether the entry has an overview file, and where the text came from.
+- Where the overview text came from: the plugin repository, or a draft the user approved.

--- a/apps/server/test/skills/submit-a-plugin.test.ts
+++ b/apps/server/test/skills/submit-a-plugin.test.ts
@@ -113,12 +113,19 @@ describe("submit-a-plugin skill", () => {
     expect(skill).toContain("a maximum of six");
   });
 
-  it("copies an author PLUGIN_OVERVIEW.md into the marketplace overview directory", async () => {
+  it("requires an overview file on every public marketplace entry", async () => {
     const skill = await readSkillTree();
 
     expect(skill).toContain(
-      "Copy the plugin PLUGIN_OVERVIEW.md file into the marketplace when the plugin has one.",
+      "Every entry in the public marketplace needs an overview file.",
     );
+    expect(skill).toContain(
+      "marketplace requires an overview file on every entry.",
+    );
+    expect(skill).toContain(
+      "draft one from the behavior you observed while validating and screenshotting",
+    );
+    expect(skill).not.toContain("when the entry has no overview file");
     expect(skill).toContain("Copy the file to overview/<plugin-id>.md");
     expect(skill).toContain('"overview": "./overview/notes.md"');
     expect(skill).toContain("a maximum of 4000 characters");

--- a/packages/templates/src/plugin-scaffold.ts
+++ b/packages/templates/src/plugin-scaffold.ts
@@ -1317,6 +1317,32 @@ Add \`--json\` to any command when the output drives code.
 `;
 }
 
+function pluginOverviewSource(packageName: string): string {
+  const id = derivePluginId(packageName);
+  return `Keep a todo list beside the work it belongs to, in the sidebar and in
+your agent threads.
+
+## What you get
+
+- An **Example todos** page in the left sidebar that adds, completes, and
+  removes todos.
+- A \`bb ${id}\` command that does the same from a terminal.
+- Live updates, so a change made in one place reaches every open page at once.
+
+## How it works
+
+The todos live in this plugin's own storage on the BB server, one list per
+installation. Nothing leaves the machine, and the plugin needs no account, API
+key, or external service.
+
+## For agents
+
+The bundled skill tells an agent to read the list with \`bb ${id} list\`, add
+one todo at a time with \`bb ${id} add\`, and close finished work with
+\`bb ${id} done\`.
+`;
+}
+
 function readmeSource(packageName: string): string {
   const id = derivePluginId(packageName);
   return `# ${packageName}
@@ -1330,6 +1356,9 @@ A BB plugin that keeps a todo list. It shows every surface a plugin can own:
   (\`app.slots.navPanel\`) built from the vendored components.
 - \`skills/example-todos/SKILL.md\` — a skill that tells agents how to keep the list
   with \`bb ${id}\`. BB imports it into agent threads automatically.
+- \`PLUGIN_OVERVIEW.md\` — the store listing text: a longer version of
+  \`bb.description\` that the plugin detail page shows under it. See
+  [Store listing](#store-listing).
 
 Try it: install the plugin, open **Example todos** in the sidebar, then run
 \`bb ${id} add "Ship it"\` in a terminal. The page updates at once.
@@ -1385,6 +1414,22 @@ Run \`bb plugin build\` before publishing git/npm installs. It writes
 \`app.meta.json\`. Each \`*.meta.json\` stamps SDK major/version,
 \`artifactFormatVersion\`, \`pluginId\`, \`pluginVersion\`, and
 \`builtWith\` so managed installs can verify the artifacts.
+
+## Store listing
+
+Two texts describe the plugin in the store. \`bb.description\` in package.json
+is the one-sentence hook on every browse card and the lead paragraph on the
+detail page; keep it under about 140 characters. \`PLUGIN_OVERVIEW.md\` is the
+same claim at length, shown in an Overview section under that paragraph.
+Rewrite the scaffold's copy for your plugin, and update it whenever
+\`bb.description\` changes, so the two never disagree.
+
+The submission to the public BB Community marketplace requires the file. Keep
+it under 4000 characters (aim for 700 to 1800) and use headings, paragraphs,
+emphasis, code, blockquotes, lists, thematic breaks, and absolute https links
+only — raw HTML, images, tables, footnotes, and task lists are rejected. Do
+not open with a \`#\` title or repeat \`bb.description\` verbatim; the page
+shows both directly above.
 
 ## Install
 
@@ -1510,4 +1555,8 @@ export async function scaffoldPlugin(args: ScaffoldPluginArgs): Promise<void> {
   await writeFile(join(skillDir, "SKILL.md"), skillSource(packageName));
   await writeFile(join(targetDir, ".gitignore"), "dist/\nnode_modules/\n");
   await writeFile(join(targetDir, "README.md"), readmeSource(packageName));
+  await writeFile(
+    join(targetDir, "PLUGIN_OVERVIEW.md"),
+    pluginOverviewSource(packageName),
+  );
 }

--- a/packages/templates/src/templates/bb-guide-plugins.md
+++ b/packages/templates/src/templates/bb-guide-plugins.md
@@ -747,6 +747,14 @@ default. Scoped names such as `@acme/bb-plugin-hello` are also supported. The
 plugin id is the final package-name component minus `bb-plugin-`, so both forms
 use `hello`.
 
+The scaffold also writes `PLUGIN_OVERVIEW.md` beside package.json: the
+long-form store listing, shown in an Overview section under `bb.description` on
+the plugin detail page in the app and on getbb.app. It says the same thing as
+`bb.description` at length, so update both together. Keep it under 4000
+characters, use headings, paragraphs, emphasis, code, blockquotes, lists,
+thematic breaks, and absolute https links only, and do not open with a `#`
+title. A submission to the BB Community marketplace requires the file.
+
 Plugins can contribute palettes with `bb.themes`: an array of
 `{ id, name, description?, css, codeTheme? }`, where `css` is a
 plugin-relative `.css` file and optional `codeTheme` is

--- a/packages/templates/test/plugin-scaffold.test.ts
+++ b/packages/templates/test/plugin-scaffold.test.ts
@@ -82,6 +82,32 @@ describe("scaffoldPlugin SDK dependency", () => {
     await access(join(targetDir, "components", "ui", "checkbox.tsx"));
   });
 
+  it("writes a store overview that follows the marketplace content rules", async () => {
+    const targetDir = join(workDir, "bb-plugin-todo");
+    await scaffoldPlugin({
+      targetDir,
+      packageName: "bb-plugin-todo",
+      bbVersion: "0.9.0",
+    });
+
+    const overview = await readFile(
+      join(targetDir, "PLUGIN_OVERVIEW.md"),
+      "utf8",
+    );
+    expect(overview).toContain("bb todo list");
+    expect(overview).toMatch(/^[^#]/u);
+    expect([...overview].length).toBeGreaterThan(700);
+    expect([...overview].length).toBeLessThanOrEqual(4000);
+    const prose = overview
+      .replace(/```[\s\S]*?```/gu, "")
+      .replace(/`[^`]*`/gu, "");
+    expect(prose).not.toMatch(/<[A-Za-z!/?]|!\[/u);
+
+    const readme = await readFile(join(targetDir, "README.md"), "utf8");
+    expect(readme).toContain("## Store listing");
+    expect(readme).toContain("marketplace requires the file");
+  });
+
   it("uses the canonical id in a scoped package scaffold", async () => {
     const targetDir = join(workDir, "bb-plugin-scoped");
     await scaffoldPlugin({

--- a/plugins/account-pool/PLUGIN_OVERVIEW.md
+++ b/plugins/account-pool/PLUGIN_OVERVIEW.md
@@ -1,0 +1,22 @@
+Keep a Claude Code or Codex thread running when one account hits its limit. The Account Pooler puts every account you own behind a local hub and picks the account for each request.
+
+## What you get
+
+- A pool of Claude and Codex accounts, added by importing the login already on the machine, signing in through the browser, or pasting an Anthropic API key.
+- Per-request selection that follows your priority order, then the account with the fewest requests in flight, then the account whose weekly window resets first.
+- Live limit windows per account and model family in the plugin's settings page, and the same numbers from `bb pool status`.
+- A routing switch per provider and a bypass per thread, so one thread can go straight to its own credentials.
+
+## How it works
+
+The hub runs inside BB and serves an Anthropic Messages endpoint and an OpenAI Responses endpoint. With routing on, BB hands the Claude Code or Codex process a base URL that points at the hub and a token scoped to that machine, and the provider reports **Proxied** in its health row. An account is skipped for a request when it is at or above the switch threshold, on hold, or in error. The threshold defaults to 98 percent of a window. Account secrets stay in the BB data directory on the server machine, and the hub refreshes them in the background.
+
+## Requirements
+
+Accounts you own and are permitted to use this way.
+
+This plugin is experimental. Routing behavior, stored data, and the CLI can change between releases.
+
+## For agents
+
+`bb pool account add|list|remove|enable|disable`, `bb pool status`, `bb pool routing <claude|codex> [--off]`, `bb pool config`, `bb pool config set`, `bb pool token rotate`, and `bb pool bypass <thread-id>`. `list` and `status` take `--json`.


### PR DESCRIPTION
## Human comments

## What was wrong

`PLUGIN_OVERVIEW.md` landed as an optional file that only a plugin author
already familiar with it would ever write. `bb plugin new` did not scaffold
one, so nothing put the file in front of an author; the `submit-a-plugin`
skill told the agent to copy the file only when the repository happened to
hold one, so a submission with no long-form text was the normal outcome; and
no document said the overview and `bb.description` are the same claim at two
lengths, so the two could drift. The Account Pooler was one of two bundled
plugins with no overview at all.

## What changed

- `packages/templates/src/plugin-scaffold.ts` writes `PLUGIN_OVERVIEW.md` in
  every new scaffold: a real overview of the example todo plugin, not a
  placeholder, so the generator and marketplace CI accept it as is. The
  scaffold README lists the file and gains a Store listing section that pairs
  it with `bb.description` and states the content rules.
- `bb-plugin-authoring/references/distribution.md` drops "optional", says the
  BB Community marketplace requires the file, and states that the overview is
  `bb.description` at length and must be updated in the same change as the
  short description or a surface.
- `submit-a-plugin` requires an overview on every entry. When the plugin
  repository has none, the skill drafts one from observed behavior, gets the
  user's approval, and offers to add it back to the plugin repository. The
  pull-request reference no longer has a no-overview branch, and the entry
  quality check asserts the overview agrees with the short description.
- `plugins/account-pool/PLUGIN_OVERVIEW.md` describes the hub, account
  sources, per-request selection, routing switch and per-thread bypass,
  the experimental status, and the `bb pool` commands.
- `packages/templates/src/templates/bb-guide-plugins.md` documents the
  scaffolded file in the authoring chapter.

No wire change between the server and the host daemon, so
`HOST_DAEMON_PROTOCOL_VERSION` stays as is. No new public plugin API member.

## How you verified

- New `packages/templates/test/plugin-scaffold.test.ts` case: the scaffolded
  overview is 700 to 4000 characters, does not open with a heading, holds no
  raw HTML or image outside code, and the README documents the file. It fails
  on main.
- `apps/server/test/skills/submit-a-plugin.test.ts` now asserts the required
  wording and that the no-overview branch is gone.
- `pnpm exec turbo run generate:bb-official-marketplace --filter=@bb/server
  --force` folds the Account Pooler overview into the catalog (1,755
  characters) with the generator's own empty, length, HTML, and image checks.
  `provider-usage` is now the only bundled plugin with no overview.
- `pnpm exec turbo run test --filter=@bb/templates`,
  `--filter=@bb/server -- test/skills test/services/plugin-catalog`,
  `--filter=@bb/cli -- plugin-guide-docs.test.ts`, and
  `pnpm exec turbo run typecheck lint --filter=@bb/templates
  --filter=@bb/server` all pass.

> AGENT GENERATED
