### PR TITLE
Remove unused mobile cache invalidations and clipboard dependency

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -579,7 +579,7 @@ argument drives a dev client through Metro instead.
 - **Input**: tapping the terminal focuses xterm's hidden textarea and raises
   the keyboard (`keyboardDisplayRequiresUserAction={false}`); the accessory
   bar above it adds esc, tab, a sticky ctrl (applied to the next keystroke),
-  arrows, home / end, `-`, `/`, `|`, paste (`expo-clipboard`), a keyboard
+  arrows, home / end, `-`, `/`, `|`, paste, a keyboard
   key and, full screen, a "…" that opens the same menu as the header
   (rename / restart / new / close). Cursor keys follow DECCKM (SS3 in
   application mode), Ctrl+arrow sends `CSI 1;5<final>`.

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -39,7 +39,6 @@
     "expo-asset": "~57.0.12",
     "expo-build-properties": "~57.0.12",
     "expo-camera": "~57.0.3",
-    "expo-clipboard": "~57.0.1",
     "expo-constants": "~57.0.12",
     "expo-crypto": "~57.0.1",
     "expo-dev-client": "~57.0.13",

--- a/apps/mobile/src/lib/query/query-keys.ts
+++ b/apps/mobile/src/lib/query/query-keys.ts
@@ -527,7 +527,6 @@ export function allHostCloneDefaultPathQueryKeyPrefix(): readonly [
 }
 
 const PLUGIN_CONTRIBUTIONS_QUERY_KEY = "pluginContributions";
-const PLUGIN_MENTION_SEARCH_QUERY_KEY = "pluginMentionSearch";
 const ENVIRONMENT_PATHS_QUERY_KEY = "environmentPaths";
 const THREAD_STORAGE_PATHS_QUERY_KEY = "threadStoragePaths";
 const PROJECT_COMMANDS_QUERY_KEY = "projectCommands";
@@ -565,12 +564,6 @@ type ProjectCommandsQueryKey = readonly [
 
 export function pluginContributionsQueryKey(): PluginContributionsQueryKey {
   return [PLUGIN_CONTRIBUTIONS_QUERY_KEY];
-}
-
-export function allPluginMentionSearchQueryKeyPrefix(): readonly [
-  typeof PLUGIN_MENTION_SEARCH_QUERY_KEY,
-] {
-  return [PLUGIN_MENTION_SEARCH_QUERY_KEY];
 }
 
 export function environmentPathsQueryKey(
@@ -839,7 +832,6 @@ export function allProjectFilePreviewQueryKeyPrefix(): readonly [
 }
 
 const TERMINALS_QUERY_KEY = "terminals";
-const TERMINAL_SESSION_QUERY_KEY = "terminalSession";
 
 export type TerminalQueryScope =
   | { kind: "thread"; threadId: string }
@@ -863,14 +855,7 @@ export function allTerminalsQueryKeyPrefix(): readonly [
   return [TERMINALS_QUERY_KEY];
 }
 
-export function allTerminalSessionQueryKeyPrefix(): readonly [
-  typeof TERMINAL_SESSION_QUERY_KEY,
-] {
-  return [TERMINAL_SESSION_QUERY_KEY];
-}
-
 const PLUGINS_QUERY_KEY = "plugins";
-const PLUGIN_SETTINGS_QUERY_KEY = "pluginSettings";
 const PLUGIN_UPDATES_QUERY_KEY = "pluginUpdates";
 const PLUGIN_CATALOG_SEARCH_QUERY_KEY = "pluginCatalogSearch";
 const PLUGIN_CATALOG_INSTALL_PLAN_QUERY_KEY = "pluginCatalogInstallPlan";
@@ -908,12 +893,6 @@ type SkillContentQueryKey = readonly [
 
 export function pluginsQueryKey(): PluginsQueryKey {
   return [PLUGINS_QUERY_KEY];
-}
-
-export function allPluginSettingsQueryKeyPrefix(): readonly [
-  typeof PLUGIN_SETTINGS_QUERY_KEY,
-] {
-  return [PLUGIN_SETTINGS_QUERY_KEY];
 }
 
 export function pluginUpdatesQueryKey(): PluginUpdatesQueryKey {

--- a/apps/mobile/src/lib/query/realtime-invalidation.test.ts
+++ b/apps/mobile/src/lib/query/realtime-invalidation.test.ts
@@ -37,7 +37,6 @@ import {
   threadTimelineTurnSummaryDetailsQueryKeyPrefix,
   threadsQueryKey,
   allPluginCatalogSearchQueryKeyPrefix,
-  allPluginSettingsQueryKeyPrefix,
   allProjectSkillsQueryKeyPrefix,
   pluginMarketplacesQueryKey,
   pluginsQueryKey,
@@ -328,7 +327,6 @@ describe("queryKeysForChangedMessage", () => {
     expect(keys).toEqual(
       expect.arrayContaining([
         pluginsQueryKey(),
-        allPluginSettingsQueryKeyPrefix(),
         pluginUpdatesQueryKey(),
         allPluginCatalogSearchQueryKeyPrefix(),
         allProjectSkillsQueryKeyPrefix(),

--- a/apps/mobile/src/lib/query/realtime-invalidation.ts
+++ b/apps/mobile/src/lib/query/realtime-invalidation.ts
@@ -35,7 +35,6 @@ import {
   hostProviderCliStatusQueryKey,
   systemCliSkillsQueryKey,
   themeCatalogQueryKey,
-  allPluginMentionSearchQueryKeyPrefix,
   allProjectCommandsQueryKeyPrefix,
   allProjectDefaultExecutionOptionsQueryKeyPrefix,
   allProjectPathsQueryKeyPrefix,
@@ -44,7 +43,6 @@ import {
   allSystemProvidersQueryKeyPrefix,
   pluginContributionsQueryKey,
   pluginsQueryKey,
-  allPluginSettingsQueryKeyPrefix,
   pluginUpdatesQueryKey,
   allPluginCatalogSearchQueryKeyPrefix,
   allProjectSkillsQueryKeyPrefix,
@@ -67,7 +65,6 @@ import {
   threadQueuedMessagesQueryKey,
   threadSearchQueryKeyPrefix,
   allTerminalsQueryKeyPrefix,
-  allTerminalSessionQueryKeyPrefix,
   threadTabsQueryKey,
   allThreadStoragePathsQueryKeyPrefix,
   allThreadStorageFilesQueryKeyPrefix,
@@ -140,10 +137,7 @@ export function queryKeysForChangedMessage(
         keys.push(threadQueuedMessagesQueryKey(id));
       }
       if (kinds.has("terminals-changed")) {
-        keys.push(
-          allTerminalsQueryKeyPrefix(),
-          allTerminalSessionQueryKeyPrefix(),
-        );
+        keys.push(allTerminalsQueryKeyPrefix());
       }
       if (kinds.has("tabs-changed")) {
         keys.push(threadTabsQueryKey(id));
@@ -258,10 +252,8 @@ export function queryKeysForChangedMessage(
       if (kinds.has("plugins-changed")) {
         keys.push(
           pluginContributionsQueryKey(),
-          allPluginMentionSearchQueryKeyPrefix(),
           allProjectCommandsQueryKeyPrefix(),
           pluginsQueryKey(),
-          allPluginSettingsQueryKeyPrefix(),
           pluginUpdatesQueryKey(),
           allPluginCatalogSearchQueryKeyPrefix(),
           allProjectSkillsQueryKeyPrefix(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -863,9 +863,6 @@ importers:
       expo-camera:
         specifier: ~57.0.3
         version: 57.0.3(@types/emscripten@1.41.5)(expo@57.0.14)(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.86.2(@babel/core@7.29.0))(@types/react@19.2.13)(react@19.2.4))(react@19.2.4)
-      expo-clipboard:
-        specifier: ~57.0.1
-        version: 57.0.1(expo@57.0.14)(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.86.2(@babel/core@7.29.0))(@types/react@19.2.13)(react@19.2.4))(react@19.2.4)
       expo-constants:
         specifier: ~57.0.12
         version: 57.0.12(expo@57.0.14)(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.86.2(@babel/core@7.29.0))(@types/react@19.2.13)(react@19.2.4))
@@ -11177,13 +11174,6 @@ packages:
     peerDependenciesMeta:
       react-native-web:
         optional: true
-
-  expo-clipboard@57.0.1:
-    resolution: {integrity: sha512-HWICri4+1ao7S6QEfcorxVumXDiDnx1guGGewjZgGJWLGxFYs0RgH8ujBs+lkTzBkMmlwADaWSlaesR+nDJt5Q==}
-    peerDependencies:
-      expo: '*'
-      react: '*'
-      react-native: '*'
 
   expo-constants@57.0.12:
     resolution: {integrity: sha512-js9qxZw4G9ulSc72GGpYGwtmk/IzFcf6/tTcEG6wB8HTlkunMS4W86R+4e6oHIrIkHA7W6s/79Se+E+DC3RAqA==}
@@ -23642,12 +23632,6 @@ snapshots:
       react-native: 0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.86.2(@babel/core@7.29.0))(@types/react@19.2.13)(react@19.2.4)
     transitivePeerDependencies:
       - '@types/emscripten'
-
-  expo-clipboard@57.0.1(expo@57.0.14)(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.86.2(@babel/core@7.29.0))(@types/react@19.2.13)(react@19.2.4))(react@19.2.4):
-    dependencies:
-      expo: 57.0.14(@babel/core@7.29.0)(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.11)(@typescript/typescript6@6.0.2)(expo-router@57.0.14)(react-dom@19.2.4(react@19.2.4))(react-native-webview@13.16.1(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.86.2(@babel/core@7.29.0))(@types/react@19.2.13)(react@19.2.4))(react@19.2.4))(react-native-worklets@0.10.1(@babel/core@7.29.0)(@react-native/metro-config@0.86.2(@babel/core@7.29.0))(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.86.2(@babel/core@7.29.0))(@types/react@19.2.13)(react@19.2.4))(react@19.2.4))(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.86.2(@babel/core@7.29.0))(@types/react@19.2.13)(react@19.2.4))(react@19.2.4)
-      react: 19.2.4
-      react-native: 0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.86.2(@babel/core@7.29.0))(@types/react@19.2.13)(react@19.2.4)
 
   expo-constants@57.0.12(expo@57.0.14)(react-native@0.86.2(@babel/core@7.29.0)(@react-native/metro-config@0.86.2(@babel/core@7.29.0))(@types/react@19.2.13)(react@19.2.4)):
     dependencies:


### PR DESCRIPTION
## Human comments

## What was wrong

The mobile app still invalidated three query families that no code creates, and retained the native clipboard dependency after its only caller was deleted.

## What changed

Remove the unused plugin mention, plugin settings, and terminal session invalidation prefixes and their calls. Remove `expo-clipboard` from the mobile manifest and lockfile, and remove its stale README reference. This completes the remaining cleanup after #3103.

## How you verified

- Searched for consumers of the removed query families and clipboard dependency.
- `pnpm exec turbo run test typecheck --filter=@bb/mobile` passes on the rebased branch: 326 tests across 43 files.
- Updated the existing invalidation test to reflect the remaining query families; no new tests for dead-code deletion.
- `git diff --check` passes.

> AGENT GENERATED
