### PR TITLE
Prepare bb-app 0.42.0

### DIFF
--- a/.github/actions/install-appimage-fuse/action.yml
+++ b/.github/actions/install-appimage-fuse/action.yml
@@ -1,0 +1,22 @@
+name: Install AppImage FUSE runtime
+description: Install FUSE from Ubuntu mirrors over HTTPS with bounded network waits.
+inputs:
+  package:
+    description: FUSE package for the runner's Ubuntu version.
+    default: libfuse2
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        FUSE_PACKAGE: ${{ inputs.package }}
+      run: |
+        set -euo pipefail
+        for source in /etc/apt/sources.list /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources /etc/apt/blacksmith-ubuntu-mirrors.txt; do
+          if [ -f "$source" ]; then
+            sudo sed -E -i 's#http://((([a-z0-9-]+\.)?archive|security)\.ubuntu\.com/ubuntu|mirrors\.sonic\.net/ubuntu)#https://\1#g' "$source"
+          fi
+        done
+        apt_options=(-o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 -o Acquire::Retries=1)
+        sudo apt-get "${apt_options[@]}" update
+        sudo apt-get "${apt_options[@]}" install --yes "$FUSE_PACKAGE"

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -170,9 +170,8 @@ jobs:
         run: pnpm install --frozen-lockfile --prefer-offline
 
       - name: Install AppImage FUSE runtime
-        run: |
-          sudo apt-get update
-          sudo apt-get install --yes libfuse2
+        uses: ./.github/actions/install-appimage-fuse
+        timeout-minutes: 5
 
       - name: Typecheck desktop and launcher
         run: pnpm exec turbo run typecheck --filter=@bb/desktop --filter=bb-app --output-logs=new-only

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,9 +181,10 @@ jobs:
 
       - name: Install AppImage FUSE runtime
         if: ${{ runner.os == 'Linux' }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install --yes libfuse2t64
+        uses: ./.github/actions/install-appimage-fuse
+        timeout-minutes: 5
+        with:
+          package: libfuse2t64
 
       - name: Package Linux AppImage
         if: ${{ runner.os == 'Linux' }}

--- a/.github/workflows/publish-bb-app.yml
+++ b/.github/workflows/publish-bb-app.yml
@@ -674,9 +674,8 @@ jobs:
         run: pnpm install --frozen-lockfile --prefer-offline
 
       - name: Install AppImage FUSE runtime
-        run: |
-          sudo apt-get update
-          sudo apt-get install --yes libfuse2
+        uses: ./.github/actions/install-appimage-fuse
+        timeout-minutes: 5
 
       - name: Apply the nightly version
         id: nightly_version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,106 @@
 # Changelog
 
+## 0.42.0
+
+This release adds Account Pooler for Claude and Codex, push notifications across devices, and a new plugin catalog.
+
+### New features
+
+- Use `/clear` in an idle thread to reset agent context while keeping the workspace and history.
+- Show, hide, and reorder sidebar destinations. Reorder new-tab Actions too.
+- Browse plugins by category, with screenshots, author pages, and a BB Official collection. The marketplace is also on getbb.app.
+- Manage installed plugins in Settings. Plugin settings now autosave with inline validation.
+- Read missed notifications in the notification center and expand long messages.
+- Expand completed **Thought for** entries to read provider-shared thinking.
+- Approvals and plan reviews open as a compact, actionable strip.
+- Search the project picker and customize worktree branch prefixes.
+- Copy images with message text and see attachment upload progress.
+
+### Built-in plugin updates
+
+- **Account Pooler.** Sign into multiple Claude and Codex accounts in one place. A proxy automatically rotates through your accounts as they hit usage limits. Experimental.
+- **Push notifications.** Choose mobile, web, and desktop delivery independently. Web needs permission and an open tab; desktop needs an open app window.
+- **Provider Usage.** Enable this new plugin to see limits and reset times across machines in the sidebar footer.
+- **Theme Preview.** Install this optional plugin to compare themes across bb screens and components.
+- **Side chat.** Fixes for pending questions, queued messages, and compact layouts.
+
+### Agent providers
+
+- Enable **Claude in Chrome** for browser tools.
+- Opt into releasing idle Claude queries after 30 seconds. The next turn resumes the conversation; background work stays active.
+- Cursor shows the correct reasoning choices. OMP supports manual compaction.
+- Fixes for Pi file attachments, Claude usage checks on macOS, and Codex rate-limit reporting.
+
+### CLI
+
+- `bb thread clear` resets context in an idle thread.
+- `bb thread fork` now reuses the source environment. Replace `--workspace` with `--environment` or `--new-environment worktree|personal`; forks stay on the same host.
+- Manage pooled accounts with `bb pool account`, check `bb pool status`, and control routing with `bb pool routing <claude|codex> [--off]`.
+- Test notifications with `bb push-notifications test <web|desktop>`.
+- Set branch prefixes with `bb settings general managedBranchPrefix <prefix>`.
+- `bb plugin new` scaffolds a store overview.
+- Use `bb environment branches`; `bb thread show --merge-base-branches` has been removed.
+
+### Performance
+
+- Enrolled machines download a smaller host-only package and skip identical reinstalls.
+- Codex resumes avoid loading full history. Plugin overlays rerender less often.
+- The optional `sidebarProgressiveDisclosure` experiment shortens long thread lists while keeping threads that need attention visible.
+
+### Notable fixes
+
+- Stopping a thread pauses its queue. Failed messages wait for an explicit retry.
+- Queued follow-ups survive offline hosts and reconnects; grouped messages dispatch together.
+- User questions survive daemon reconnects.
+- Turns containing steers can be edited, and follow-ups arrive reliably during startup.
+- Long conversations retain their leading history.
+- Codex archive undo stays in sync with bb.
+- Desktop browser OAuth popups work. Escape returns to the app.
+- Full browser storage no longer crashes the app.
+- Plugin settings preserve newer edits during saves, reloads report the correct version, and tool schemas support newer Zod 4 minors.
+- Fixes for intermittent Linux AppImage startup failures and host daemon startup and shutdown.
+
+### Plugin API changes
+
+- `threads.clearContext()` resets context within a thread.
+- `threads.fork()` takes `environment` and defaults to reusing the source environment.
+- `interaction.pending` reports questions and approvals; `bb.server.experimental_appUrl` exposes the app URL.
+- Plugin settings support numeric fields and validation through `experimental_schema`.
+- `app.slots.experimental_appOverlay` adds persistent app-wide UI.
+- `app.experimental_sidebarFooter.register()` adds footer actions and disclosures.
+- `bb.providers.experimental_contributeEnv()` supplies provider environment variables.
+- `bb.http.experimental_websocket()` registers plugin WebSocket routes.
+
+### Thanks
+
+Thank you to the fourteen contributors and co-authors outside the core team:
+
+- [@alanagoyal](https://github.com/alanagoyal)
+- [@andrewkchan](https://github.com/andrewkchan)
+- [@bradhallett](https://github.com/bradhallett)
+- [@davidondrej](https://github.com/davidondrej)
+- [@dillonzq](https://github.com/dillonzq)
+- [@IlyaM](https://github.com/IlyaM)
+- [@kravtsovd](https://github.com/kravtsovd)
+- [@MateoCerquetella](https://github.com/MateoCerquetella)
+- [@MayankBansal12](https://github.com/MayankBansal12)
+- [@nlorio-notion](https://github.com/nlorio-notion)
+- [@salemsayed](https://github.com/salemsayed)
+- [@smsunarto](https://github.com/smsunarto)
+- [@swairshah](https://github.com/swairshah)
+- [@vburojevic](https://github.com/vburojevic)
+
+Thank you also to everyone who reported an issue addressed in this release: **[@aaronphifer](https://github.com/aaronphifer)**, **[@amirghst](https://github.com/amirghst)**, **[@bradhallett](https://github.com/bradhallett)**, **[@dillonzq](https://github.com/dillonzq)**, **[@Guitaraholic](https://github.com/Guitaraholic)**, **[@GusevV1987](https://github.com/GusevV1987)**, **[@iamhenry](https://github.com/iamhenry)**, **[@IlyaM](https://github.com/IlyaM)**, **[@kravtsovd](https://github.com/kravtsovd)**, **[@lzfxxx](https://github.com/lzfxxx)**, **[@markasoftware-tc](https://github.com/markasoftware-tc)**, **[@MayankBansal12](https://github.com/MayankBansal12)**, **[@technicalpickles](https://github.com/technicalpickles)**, **[@Techno911](https://github.com/Techno911)**, **[@vixalien](https://github.com/vixalien)**, and **[@yusuf8834](https://github.com/yusuf8834)**.
+
+### Mobile app
+
+[Join the iOS TestFlight](https://testflight.apple.com/join/T9MayTMb).
+
+- Receive push notifications while the app is closed. Tap to open the thread on its server.
+- Use the new dark iOS app icon.
+- Toast swipes and sidebar dismissal are more reliable.
+- Panels respect device safe areas, pickers fit short screens, and the keyboard no longer flashes white.
+
 ## 0.41.0
 
 This release adds a dispatch queue. You can schedule a send for later and limit how much work runs at the same time. The mobile app is now the bb web app in a native shell, and the new Plugin Guide maps every public plugin API.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bb/desktop",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "private": true,
   "description": "macOS and Linux Electron shell for bb",
   "main": "dist/main.js",

--- a/apps/web/src/landing/changelog.ts
+++ b/apps/web/src/landing/changelog.ts
@@ -20,7 +20,7 @@ type ReleaseMeta = {
 
 export const RELEASE_META: Record<string, ReleaseMeta> = {
   "0.42.0": {
-    date: "Draft",
+    date: "September 5, 2026",
     headline: "Account Pooler, push notifications, and a new plugin catalog",
   },
   "0.41.0": {

--- a/apps/web/src/landing/changelog.ts
+++ b/apps/web/src/landing/changelog.ts
@@ -19,6 +19,10 @@ type ReleaseMeta = {
 };
 
 export const RELEASE_META: Record<string, ReleaseMeta> = {
+  "0.42.0": {
+    date: "Draft",
+    headline: "Account Pooler, push notifications, and a new plugin catalog",
+  },
   "0.41.0": {
     date: "September 1, 2026",
     headline: "Scheduled sends, concurrency limits, and a rebuilt mobile app",

--- a/packages/bb-app/package.json
+++ b/packages/bb-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bb-app",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "description": "bb app launcher for npx",
   "keywords": [
     "bb",


### PR DESCRIPTION
## Human comments

## What was wrong

The stable npm and desktop releases are still on 0.41.0. Changes since that release need a version bump and release notes.

## What changed

Prepare 0.42.0 with matching npm and desktop versions, the approved changelog, and the September 5 ship date and headline. Notes include commit co-authors and the iOS TestFlight link.

Two Linux CI attempts encountered repeated HTTP connection failures to Ubuntu mirrors during FUSE installation. A shared action now switches Ubuntu mirror URLs to HTTPS and bounds network waits across CI, stable desktop, and nightly desktop workflows.

## How you verified

- Version lockstep check passed.
- Turbo typecheck and tests passed for config, server, and bb-app: 2,407 tests.
- Changelog rendering tests passed: 9 tests; dev preview verified.
- Packaged tarball smoke test passed, including install, CLI, SDK, full-stack startup, and daemon enrollment.
- Workflow YAML parsing, shell syntax, and Ubuntu-only URL rewriting checks passed. Ubuntu archive and security HTTPS endpoints returned 200.
- Diff whitespace check and pre-push EAP codename scan passed.
- SlopCop review skipped at the owner’s request.

No linked issue.

> AGENT GENERATED
