### PR TITLE
Add remote worktree start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,19 @@ updates. The server API is unauthenticated and permits command execution and
 file reads, so use this only behind a trusted network boundary and restrict the
 ports to Tailscale traffic with the host firewall when the LAN is not trusted.
 
+To access the production-style worktree server directly from another machine,
+run:
+
+```bash
+pnpm start:worktree-remote
+```
+
+This uses the same checkout-specific data directory and ports as
+`pnpm start:worktree`, but binds its single server listener to all IPv4
+interfaces. The server API is unauthenticated and permits command execution and
+file reads, so use it only behind a trusted network boundary and restrict the
+port to Tailscale traffic with the host firewall when the LAN is not trusted.
+
 To use the component storybook from another machine, run:
 
 ```bash

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1079,9 +1079,10 @@ enrolled to other servers. Atomic reservations under
 
 ## Source Development
 
-For source development only, `pnpm dev`, `pnpm start:worktree`, and `pnpm start`
-load the repo-root dotenv cascade. Add a repo-root `.env` only when you need to
-override the defaults described above.
+For source development only, `pnpm dev`, `pnpm start:worktree`,
+`pnpm start:worktree-remote`, and `pnpm start` load the repo-root dotenv
+cascade. Add a repo-root `.env` only when you need to override the defaults
+described above.
 
 The standard [dotenv-cli](https://github.com/entropitor/dotenv-cli) cascade
 applies to source development. `pnpm dev` loads `.env`, `.env.local`,
@@ -1101,6 +1102,10 @@ disabled for this source-development command. Its worktree data directory,
 ports, inherited skills, listener host, absent Vite port, and telemetry policy
 take precedence over conflicting values saved in that instance's `config.json`
 or `env.json`.
+`pnpm start:worktree-remote` applies the same policy while binding the main
+server to `0.0.0.0` for direct access on a trusted network. The API is
+unauthenticated and permits command execution and file reads, so protect the
+port with a trusted network boundary such as Tailscale and a host firewall.
 `pnpm start` loads `.env`, `.env.local`, `.env.production`, and
 `.env.production.local`.
 

--- a/docs/debugging-and-qa.md
+++ b/docs/debugging-and-qa.md
@@ -2,6 +2,7 @@
 
 - `pnpm dev` prints the active frontend URL, server API URL, host daemon port, data dir, and logs dir. Do not assume fixed dev ports.
 - `pnpm start:worktree` builds production artifacts and serves the optimized app bundle from the checkout-specific dev server URL, while keeping the same dev data directory and deterministic server/host-daemon ports. It has no Vite dev server or hot reload.
+- `pnpm start:worktree-remote` is the trusted-network variant of `pnpm start:worktree`; it binds that server to all IPv4 interfaces.
 - The packaged app defaults to server/frontend `:38886`, host daemon `:38887`, data dir `~/.bb/`, and logs under `~/.bb/logs/`.
 - Entity IDs in URLs (`proj_*`, `thr_*`) are primary keys. Query them directly against the active data dir: `sqlite3 <data>/bb.db "SELECT * FROM threads WHERE id = 'thr_xxx';"`.
 - API routes are under `/api/v1/`, for example `GET /api/v1/threads/:id`.

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -83,7 +83,8 @@ Not available on the phone (use the web app or desktop for these):
 
 - `npx bb-app`
 - `npx --package bb-app bb ...`
-- source checkout package startup with `pnpm start` or `pnpm start:worktree`
+- source checkout package startup with `pnpm start`, `pnpm start:worktree`, or
+  `pnpm start:worktree-remote`
 - source checkout validation with `pnpm install`, `pnpm build`,
   `pnpm exec turbo run typecheck`, and `pnpm exec turbo run test`
 - app + server + host-daemon startup on supported persistent-host OSes

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "ensure-native-modules": "node scripts/ensure-native-modules.mjs",
     "dev": "node scripts/ensure-native-modules.mjs && cross-env NODE_ENV=development dotenv -c development -- node --conditions=source --import tsx packages/scripts/src/commands/run-dev.ts",
     "start:worktree": "cross-env NODE_ENV=development dotenv -c development -- node --conditions=source --import tsx packages/scripts/src/commands/run-dev.ts --worktree",
+    "start:worktree-remote": "cross-env BB_SERVER_BIND_HOST=0.0.0.0 pnpm run start:worktree",
     "dev:remote": "cross-env BB_DEV_APP_HOST=0.0.0.0 BB_SERVER_BIND_HOST=0.0.0.0 pnpm run dev",
     "cloud:dev": "node --conditions=source --import tsx scripts/bb-cloud-dev.mjs",
     "dev:desktop": "scripts/bb-dev-app current --desktop",


### PR DESCRIPTION
## Human comments

## What was wrong

The production-style source worktree launcher had no script equivalent to `pnpm dev:remote`, so it could not be started with its server intentionally bound for direct trusted-network access.

## What changed

Added `pnpm start:worktree-remote`, which wraps `pnpm start:worktree` with `BB_SERVER_BIND_HOST=0.0.0.0`. Documented its behavior, supported status, and trusted-network security requirements. No host-daemon protocol change.

## How you verified

- `pnpm exec turbo run test --filter=@bb/scripts --force`
- Started `pnpm start:worktree-remote`; confirmed the server listened on `0.0.0.0:19327` and the colocated host daemon connected.

Fixes #

No issue.

> AGENT GENERATED