### PR TITLE
Preserve reasoning summary and body after completion

### DIFF
--- a/packages/thread-view/src/assistant-buffering.ts
+++ b/packages/thread-view/src/assistant-buffering.ts
@@ -36,7 +36,7 @@ export function parseReasoningFinalText(decoded: ThreadEvent): string | null {
   if (decoded.item.type !== "reasoning") return null;
   const summaryText = decoded.item.summary.join("");
   const contentText = decoded.item.content.join("");
-  const text = summaryText || contentText;
+  const text = `${summaryText}${contentText}`;
   return text.length > 0 ? text : null;
 }
 

--- a/packages/thread-view/src/assistant-event-projection.ts
+++ b/packages/thread-view/src/assistant-event-projection.ts
@@ -9,7 +9,10 @@ import {
   projectBufferedTextEvent,
   projectReasoningTextEvent,
 } from "./buffered-text-projection.js";
-import { resolveBufferedTextIdentity } from "./buffered-text-identity.js";
+import {
+  createBufferedTextInstanceKey,
+  resolveBufferedTextIdentity,
+} from "./buffered-text-identity.js";
 import type { EventMeta } from "./event-decode.js";
 import type { EventProjectionAssistantTextMessage } from "./event-projection-types.js";
 import { messageId } from "./format-helpers.js";
@@ -133,7 +136,10 @@ export function projectAssistantAndReasoningEvent(
   if (
     projectReasoningTextEvent({
       identity: reasoningIdentity,
-      mode: "delta",
+      mode:
+        args.decoded.type === "item/reasoning/summaryTextDelta"
+          ? "summary-delta"
+          : "content-delta",
       state: args.state,
       text: parseReasoningDeltaText(args.decoded),
     })
@@ -141,11 +147,28 @@ export function projectAssistantAndReasoningEvent(
     return true;
   }
 
+  const reasoningFinalText = parseReasoningFinalText(args.decoded);
+  let reasoningCompletionText = reasoningFinalText;
+  if (
+    reasoningIdentity &&
+    args.decoded.type === "item/completed" &&
+    args.decoded.item.type === "reasoning"
+  ) {
+    const deltas = args.state.reasoningDeltaTextByKey.get(
+      createBufferedTextInstanceKey(reasoningIdentity),
+    );
+    if (
+      deltas?.summary === args.decoded.item.summary.join("") &&
+      deltas.content === args.decoded.item.content.join("")
+    ) {
+      reasoningCompletionText = null;
+    }
+  }
   const projectedReasoningFinal = projectReasoningTextEvent({
     identity: reasoningIdentity,
     mode: "final",
     state: args.state,
-    text: parseReasoningFinalText(args.decoded),
+    text: reasoningCompletionText,
   });
 
   if (
@@ -157,9 +180,9 @@ export function projectAssistantAndReasoningEvent(
       meta: args.meta,
       state: args.state,
       status: "completed",
-      text: parseReasoningFinalText(args.decoded),
+      text: reasoningCompletionText,
     });
   }
 
-  return projectedReasoningFinal;
+  return projectedReasoningFinal || reasoningFinalText !== null;
 }

--- a/packages/thread-view/src/buffered-text-projection.ts
+++ b/packages/thread-view/src/buffered-text-projection.ts
@@ -59,7 +59,7 @@ type UpsertBufferedTextMessageArgs<
 
 interface ProjectReasoningTextEventArgs {
   identity: BufferedTextInstanceIdentity | null;
-  mode: "delta" | "final";
+  mode: "content-delta" | "final" | "summary-delta";
   state: ProjectionState;
   text: string | null;
 }
@@ -171,7 +171,13 @@ export function projectReasoningTextEvent(
 
   const buffer = getReasoningTextBuffer(args.state, messageKey);
 
-  if (args.mode === "delta") {
+  if (args.mode !== "final") {
+    const deltas = args.state.reasoningDeltaTextByKey.get(messageKey) ?? {
+      content: "",
+      summary: "",
+    };
+    deltas[args.mode === "summary-delta" ? "summary" : "content"] += args.text;
+    args.state.reasoningDeltaTextByKey.set(messageKey, deltas);
     appendVisibleTextBuffer(buffer, args.text);
     return true;
   }

--- a/packages/thread-view/src/reasoning-lifecycle-projection.ts
+++ b/packages/thread-view/src/reasoning-lifecycle-projection.ts
@@ -37,6 +37,7 @@ interface ReasoningTurnLifecycleState {
 
 export interface ReasoningProjectionState {
   finalizedReasoningKeys: Set<string>;
+  reasoningDeltaTextByKey: Map<string, { content: string; summary: string }>;
   reasoningMessagesAwaitingCompletion: Map<
     string,
     EventProjectionOperationMessage
@@ -95,6 +96,7 @@ interface FinalizeOpenReasoningLifecyclesForTurnArgs extends FinalizeOpenReasoni
 export function createReasoningProjectionState(): ReasoningProjectionState {
   return {
     openReasoningLifecyclesByKey: new Map(),
+    reasoningDeltaTextByKey: new Map(),
     reasoningTextBuffersByKey: new Map(),
     finalizedReasoningKeys: new Set(),
     reasoningMessagesAwaitingCompletion: new Map(),
@@ -250,6 +252,7 @@ export function finalizeReasoningLifecycle(
   }
 
   const messageKey = createBufferedTextInstanceKey(args.identity);
+  args.state.reasoningDeltaTextByKey.delete(messageKey);
   const message =
     args.state.reasoningMessagesAwaitingCompletion.get(messageKey);
   if (message) {

--- a/packages/thread-view/test/timeline-cli-rendering.snapshots.test.ts
+++ b/packages/thread-view/test/timeline-cli-rendering.snapshots.test.ts
@@ -2353,6 +2353,43 @@ describe("timeline CLI rendering snapshots", () => {
     `);
   });
 
+  it("preserves interleaved reasoning order across live and restored timelines", () => {
+    const event = createTimelineEventFactory({ threadId: "thread-1" });
+    const itemId = "reasoning-1";
+    const streamingEvents = [
+      event.turnStarted(),
+      event.reasoningStarted({ itemId }),
+      event.reasoningSummaryDelta({ delta: "Summary 1.\n", itemId }),
+      event.reasoningDelta({ delta: "Body.\n", itemId }),
+      event.reasoningSummaryDelta({ delta: "Summary 2.\n", itemId }),
+    ];
+    const completedEvents = [
+      ...streamingEvents,
+      event.reasoningCompleted({
+        itemId,
+        summary: "Summary 1.\nSummary 2.\n",
+        text: "Body.\n",
+      }),
+      event.turnCompleted(),
+    ];
+    const expectedText = "Summary 1.\nBody.\nSummary 2.\n";
+
+    expect(
+      renderActiveTimeline(streamingEvents).projection.state.activeThinking?.text,
+    ).toBe(expectedText);
+    const completedMessages = renderActiveTimeline(
+      completedEvents.slice(0, -1),
+    ).messages;
+    expect(
+      completedMessages.filter((message) => message.kind === "operation"),
+    ).toEqual([
+      expect.objectContaining({ detail: expectedText, status: "completed" }),
+    ]);
+    expect(renderIdleTimeline(completedEvents).messages).toEqual(
+      completedMessages,
+    );
+  });
+
   it("keeps completed reasoning at root when provider parent scope is suppressed", () => {
     const event = createTimelineEventFactory({ threadId: "thread-1" });
     const startRequest = event.clientTurnRequested({

--- a/packages/thread-view/test/timeline-test-harness.ts
+++ b/packages/thread-view/test/timeline-test-harness.ts
@@ -122,6 +122,7 @@ interface ClientTurnRejectedArgs extends EventFactoryRowOptions {
 
 interface ReasoningCompletedArgs extends ProviderTurnEventOptions {
   itemId?: string;
+  summary?: string;
   text: string;
 }
 
@@ -382,6 +383,9 @@ export interface TimelineEventFactory {
   reasoningDelta(
     args: ReasoningDeltaArgs,
   ): ThreadEventRowOfType<"item/reasoning/textDelta">;
+  reasoningSummaryDelta(
+    args: ReasoningDeltaArgs,
+  ): ThreadEventRowOfType<"item/reasoning/summaryTextDelta">;
   reasoningStarted(
     args?: ReasoningStartedArgs,
   ): ThreadEventRowOfType<"item/started">;
@@ -1275,7 +1279,7 @@ export function createTimelineEventFactory(
           item: {
             type: "reasoning",
             id: args.itemId ?? `reasoning-${base.seq}`,
-            summary: [],
+            summary: args.summary ? [args.summary] : [],
             content: [args.text],
             ...(args.parentToolCallId
               ? { parentToolCallId: args.parentToolCallId }
@@ -1297,6 +1301,12 @@ export function createTimelineEventFactory(
             ? { parentToolCallId: args.parentToolCallId }
             : {}),
         },
+      };
+    },
+    reasoningSummaryDelta(args) {
+      return {
+        ...this.reasoningDelta(args),
+        type: "item/reasoning/summaryTextDelta",
       };
     },
     reasoningStarted(args = {}) {


### PR DESCRIPTION
## Human comments

## What was wrong

Completed reasoning has two valid persisted channels, summary and body, whose deltas can arrive interleaved. The final parser originally selected only one channel; the first version of this fix retained both but rebuilt them as all summary followed by all body, so a live `S1 → B1 → S2` stream reopened as `S1 → S2 → B1`. This became user-visible after [the completed-thinking history change](https://github.com/get-bb/bb/commit/6e83eb205a9debf8a92e03b6eda8cbd4ee041b7a).

## What changed

The shared reasoning projection now keeps the arrival-order buffer and separately totals each channel. When both totals exactly match the completed item, completion preserves the live buffer; when deltas are missing or the provider corrects the final payload, the combined completed summary and body remain the fallback replacement. The same decision feeds normal and late post-interruption completion, preserving the generic Thought row, timing, status, single-channel behavior, and deterministic live/restored parity. There are no wire, database, CLI, Plugin SDK, configuration, documentation, or mobile changes.

## How you verified

- Added an assembler-valid `summary S1 → body B1 → summary S2` regression that failed before the projection change and passed after it across active, just-completed, restored, and replayed projections.
- `pnpm exec turbo run test --filter=@bb/thread-view --force`: 23 files and 379 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/thread-view --force` passed.
- Repeated both Turbo checks after rebasing onto current local `origin/main`.
- DevBrowser at the same real route and 1440×1000 viewport showed the completed row change from `S1 → S2 → B1` to the live `S1 → B1 → S2` order.

Fixes #1248

> AGENT GENERATED