### PR TITLE
fix(app): register custom themes before starting diff workers

### DIFF
--- a/apps/app/src/lib/pierre-worker-pool.test.tsx
+++ b/apps/app/src/lib/pierre-worker-pool.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import { defaultResolvedCodeTheme } from "@bb/domain";
+import { resolveTheme } from "@pierre/diffs";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { applyResolvedCodeTheme } from "./code-theme";
+
+const worker = vi.hoisted(() => ({
+  getOrCreate: vi.fn(),
+  terminate: vi.fn(),
+}));
+
+vi.mock("@pierre/diffs/worker", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@pierre/diffs/worker")>();
+  return {
+    ...actual,
+    getOrCreateWorkerPoolSingleton: worker.getOrCreate,
+    terminateWorkerPoolSingleton: worker.terminate,
+  };
+});
+
+const { acquirePierreWorkerPool } = await import("./pierre-worker-pool");
+
+afterEach(() => {
+  applyResolvedCodeTheme(defaultResolvedCodeTheme);
+  worker.getOrCreate.mockReset();
+  worker.terminate.mockReset();
+});
+
+describe("acquirePierreWorkerPool", () => {
+  it("registers the selected plugin theme before constructing the pool", async () => {
+    const sourceName = "bb:plugin:worker-pool-test:dark";
+    applyResolvedCodeTheme({
+      dark: sourceName,
+      light: defaultResolvedCodeTheme.light,
+      files: {
+        [sourceName]: {
+          type: "dark",
+          colors: {
+            "editor.background": "#101010",
+            "editor.foreground": "#f0f0f0",
+          },
+          tokenColors: [],
+        },
+      },
+    });
+    const theme = {
+      dark: document.documentElement.dataset.bbCodeThemeDark!,
+      light: defaultResolvedCodeTheme.light,
+    };
+    let resolution: Promise<unknown> | undefined;
+    const pool = {};
+    worker.getOrCreate.mockImplementation(({ highlighterOptions }) => {
+      resolution = resolveTheme(highlighterOptions.theme.dark);
+      return pool;
+    });
+
+    expect(acquirePierreWorkerPool(theme)).toBe(pool);
+    await expect(resolution).resolves.toMatchObject({ name: theme.dark });
+  });
+});

--- a/apps/app/src/lib/pierre-worker-pool.tsx
+++ b/apps/app/src/lib/pierre-worker-pool.tsx
@@ -1,8 +1,10 @@
+import { registerCustomTheme } from "@pierre/diffs";
 import {
   getOrCreateWorkerPoolSingleton,
   terminateWorkerPoolSingleton,
   type WorkerPoolManager,
 } from "@pierre/diffs/worker";
+import { registerResolvedCodeThemeFiles } from "./code-theme-registration";
 import { createDiffWorker, getDiffWorkerPoolSize } from "./diff-worker-pool";
 import {
   useSyncPierreWorkerPoolTheme,
@@ -17,6 +19,7 @@ const WORKER_POOL_OPTIONS = {
 export function acquirePierreWorkerPool(
   theme: CodeThemePair,
 ): WorkerPoolManager {
+  registerResolvedCodeThemeFiles(registerCustomTheme);
   return getOrCreateWorkerPoolSingleton({
     poolOptions: WORKER_POOL_OPTIONS,
     highlighterOptions: { theme },


### PR DESCRIPTION
## Human comments

## What was wrong

Opening a thread with a plugin palette such as Monokai could leave diff bodies blank. The diff worker pool resolved its initial theme before the theme-sync component registered that palette's loader, producing `No valid theme loader registered`.

## What changed

Register resolved custom theme files at the worker-pool acquisition boundary before creating the singleton. Existing theme synchronization still handles later palette changes.

## How you verified

- Added a regression test using Pierre's real theme resolver. It fails with the original missing-loader error before the fix and passes afterward.
- Eight focused worker-pool and theme synchronization tests pass.
- All CI test packages pass in a clean checkout with a minimal environment. The integration suite passes all 77 tests across 26 files with `--maxWorkers=4`.
- Clean-branch CI build, typecheck, lint, bundle budgets, version guards, provider-literal ratchet, SDK npm guard, and macOS tarball smoke pass. The SDK guard used npm 10 for its supported JSON output.
- Linux AppImage checks require a Linux/FUSE runner. Actions cache usage requires the GitHub Actions token and was skipped locally.
- In the source-built dev app, cold-loaded a recovered Smart Diff using the Monokai palette. The diff body rendered with syntax highlighting and no browser errors.

> AGENT GENERATED