### PR TITLE
fix(push-notifications): avoid duplicate macOS notification icons

### DIFF
--- a/plugins/push-notifications/client.test.ts
+++ b/plugins/push-notifications/client.test.ts
@@ -37,6 +37,25 @@ afterEach(() => {
 });
 
 describe("client system notifications", () => {
+  it.each([
+    { platform: "macos", icon: undefined },
+    { platform: "linux", icon: "http://localhost:3000/icon-192.png" },
+    { platform: "web", icon: "http://localhost:3000/icon-192.png" },
+  ])(
+    "uses the appropriate notification icon on $platform",
+    async ({ platform, icon }) => {
+      if (platform !== "web") vi.stubGlobal("bbDesktop", { platform });
+      const delivery = createClientDelivery(vi.fn());
+      await delivery.deliver(
+        { ...message, channels: [platform === "web" ? "web" : "desktop"] },
+        true,
+      );
+      expect(TestNotification.instances).toHaveLength(1);
+      expect(TestNotification.instances[0]?.options.icon).toBe(icon);
+      delivery.dispose();
+    },
+  );
+
   it("deduplicates windows, navigates on click, and cleans up on disposal", async () => {
     const navigate = vi.fn();
     const first = createClientDelivery(navigate);

--- a/plugins/push-notifications/client.ts
+++ b/plugins/push-notifications/client.ts
@@ -31,9 +31,17 @@ export function createClientDelivery(navigate: (threadId: string) => void) {
 
   function display(message: ClientNotification): void {
     if (disposed || notificationPermission() !== "granted") return;
+    const isMacDesktop =
+      "bbDesktop" in window &&
+      typeof window.bbDesktop === "object" &&
+      window.bbDesktop !== null &&
+      "platform" in window.bbDesktop &&
+      window.bbDesktop.platform === "macos";
     const notification = new Notification(message.title, {
       body: message.body,
-      icon: new URL("/icon-192.png", window.location.origin).href,
+      ...(isMacDesktop
+        ? {}
+        : { icon: new URL("/icon-192.png", window.location.origin).href }),
       tag: `bb-${message.threadId ?? message.id}`,
     });
     active.add(notification);


### PR DESCRIPTION
## Human comments

## What was wrong

Desktop notifications always supplied `/icon-192.png` through the Web Notification API. On macOS, Electron displays this as a content image alongside the app icon macOS already adds, producing two BB logos.

## What changed

Omit the explicit notification icon when the desktop bridge identifies macOS. Keep the existing icon for web and Linux desktop notifications. Notification content, navigation, and deduplication remain unchanged.

## How you verified

- Added macOS, Linux, and web regression cases. Before the fix, only the macOS case failed because the extra icon was present. After the fix, all 20 plugin tests pass.
- `NODE_OPTIONS=--no-experimental-webstorage pnpm exec turbo run test typecheck --filter=bb-plugin-push-notifications` passes on Node 22.23.2. Disabling Node's experimental web storage lets jsdom own localStorage.
- Formatting and oxlint pass for both changed files.
- Built and reloaded the plugin in the source-built Electron app, then triggered the real `notifications.test` RPC. Observed Electron's Notification constructor receiving the title, body, and tag with no icon. Native delivery remained enabled during observation. Desktop logs showed no notification errors.

## Before and after

The after capture uses the source-built dev app, so the single application icon is Electron's development icon.

| Before: duplicate icons | After: single application icon |
| --- | --- |
| ![Before: two BB icons](https://github.com/user-attachments/assets/09e12ecc-e3d5-48f1-9e5e-bcd7dd97ce23) | ![After: one application icon and no extra image](https://github.com/user-attachments/assets/545bde07-a8f6-4be5-b922-97b061a9f237) |

> AGENT GENERATED
