### PR TITLE
Fix daemon updates when desktop packaging omits README

### DIFF
--- a/apps/server/src/services/install/bb-app-artifact.ts
+++ b/apps/server/src/services/install/bb-app-artifact.ts
@@ -205,10 +205,18 @@ async function materializePackagedHostPackage(
     join(hostDaemonTarget, "bb-chunks"),
     { recursive: true },
   );
-  await copyFile(
-    join(packageRoot, "README.md"),
-    join(hostPackageRoot, "README.md"),
-  );
+  try {
+    await copyFile(
+      join(packageRoot, "README.md"),
+      join(hostPackageRoot, "README.md"),
+    );
+  } catch (error) {
+    if (
+      !(error instanceof Error && "code" in error && error.code === "ENOENT")
+    ) {
+      throw error;
+    }
+  }
   await writeFile(
     join(hostPackageRoot, "package.json"),
     `${JSON.stringify(hostPackageJson(packageJson), null, 2)}\n`,

--- a/apps/server/test/app/bb-app-artifact.test.ts
+++ b/apps/server/test/app/bb-app-artifact.test.ts
@@ -100,6 +100,80 @@ afterEach(async () => {
   );
 });
 
+describe("bb-app artifact service (desktop packaging)", () => {
+  it(
+    "packs the runtime when Electron Builder omits the README",
+    async () => {
+      const test = await fixture("packaged");
+      await rm(join(test.packageRoot, "README.md"));
+      const service = createBbAppArtifactService({
+        dataDir: join(test.root, "data"),
+        serverEntryUrl: pathToFileURL(test.serverEntry).href,
+      });
+
+      await expect(service.getVersion()).resolves.toBe("1.2.3-test");
+      const artifact = await service.getArtifact();
+      const listing = (
+        await execFileAsync("tar", ["-tzf", artifact.path])
+      ).stdout.split("\n");
+      expect(listing).toEqual(
+        expect.arrayContaining([
+          "package/package.json",
+          "package/dist/bb-app.js",
+          "package/dist/bb-host-daemon.js",
+          "package/dist/bb.js",
+          "package/host-daemon/dist/bb",
+          "package/host-daemon/dist/bb-chunks/chunk-TEST.js",
+          "package/host-daemon/dist/bb-parcel-watcher-child.mjs",
+          "package/host-daemon/dist/bb-plugin-host-worker.mjs",
+          "package/host-daemon/dist/bb-provider-bridge-worker.mjs",
+          "package/host-daemon/dist/daemon-bundle.mjs",
+        ]),
+      );
+      expect(listing).not.toContain("package/README.md");
+      expect(listing).not.toContain("package/private.txt");
+      expect(artifact.size).toBeGreaterThan(0);
+      await expect(service.getArtifact()).resolves.toEqual(artifact);
+    },
+    ARTIFACT_LIFECYCLE_TIMEOUT_MS,
+  );
+
+  it("rejects missing runtime files even when the README is absent", async () => {
+    const test = await fixture("packaged");
+    const runtimePath = join(
+      test.packageRoot,
+      "host-daemon/dist/daemon-bundle.mjs",
+    );
+    await rm(join(test.packageRoot, "README.md"));
+    await rm(runtimePath);
+    const service = createBbAppArtifactService({
+      dataDir: join(test.root, "data"),
+      serverEntryUrl: pathToFileURL(test.serverEntry).href,
+    });
+
+    await expect(service.getArtifact()).rejects.toMatchObject({
+      code: "ENOENT",
+      path: runtimePath,
+    });
+  });
+
+  it("propagates README copy failures other than a missing file", async () => {
+    const test = await fixture("packaged");
+    const readmePath = join(test.packageRoot, "README.md");
+    await rm(readmePath);
+    await mkdir(readmePath);
+    const service = createBbAppArtifactService({
+      dataDir: join(test.root, "data"),
+      serverEntryUrl: pathToFileURL(test.serverEntry).href,
+    });
+
+    await expect(service.getArtifact()).rejects.toMatchObject({
+      code: "EISDIR",
+      path: readmePath,
+    });
+  });
+});
+
 describe.each(MODES)("bb-app artifact service (%s)", (mode) => {
   it(
     "packs only the enrolled host runtime as an exact-version npm package",


### PR DESCRIPTION
## Human comments

## What was wrong

Electron Builder excludes top-level dependency README files, but the server unconditionally copied `bb-app/README.md` when generating an enrolled daemon's update package. In Desktop 0.42.0 this throws `ENOENT` before `npm pack`, making `/install/bb-app.tgz` return HTTP 500 and preventing outdated daemons from updating. The [reproduction report](https://get-bb.github.io/reports/issues/3118.html) verified the omission in two macOS builds; a new regression test reproduces the same failure on unchanged main.

## What changed

The artifact service now tolerates `ENOENT` only for the README copy and preserves the file when present. Required runtime files and other copy errors still fail. This differs from the report's proposed packaging override: documentation is optional when assembling the runtime package, so Electron Builder's default exclusion no longer breaks updates. No daemon wire contract changes or protocol bump are needed.

## How you verified

- Added a missing-README regression test that fails before the fix and passes afterward, running real `npm pack` and inspecting the tarball for every required runtime file.
- Added checks that missing runtime files and non-ENOENT README errors still fail. Existing coverage verifies README preservation and artifact caching.
- `pnpm exec turbo run test --filter=@bb/server -- test/app/bb-app-artifact.test.ts test/app/install-machine-script.test.ts` — 37 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/server` — passed.
- `git diff --check` — passed. EAP codename scan: clean working tree, HEAD, added lines, and commit messages in the push range.
- Validation ran on Linux; the complete two-machine macOS upgrade was not repeated.

Fixes #3118

> AGENT GENERATED
