### PR TITLE
Keep Claude and Codex account pools on ordered fallbacks

### DIFF
--- a/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
@@ -69,6 +69,8 @@ bb pool account list [--json]
 bb pool account remove <id>
 bb pool account enable <id>
 bb pool account disable <id>
+bb pool account priority <id> <n>
+bb pool account reorder <claude|codex> <id>...
 bb pool status [--json]
 bb pool routing <claude|codex> [--off]
 bb pool config
@@ -106,6 +108,25 @@ present `metadata.user_id` account UUID is aligned with the selected OAuth
 account. Use `bb pool config` to inspect the full routing configuration and
 `bb pool config set <key> <value>` to update one value. The upstream URL keys
 are QA-only overrides; `switchThreshold` must be greater than 0 and at most 1.
+
+Accounts run sequentially per provider: lower priority numbers first, with ties
+following the order accounts were added. New conversations use the current
+account until it reaches the switch threshold or fails; the pool then advances
+to the next eligible account and wraps at the end. It keeps using that fallback
+even when an earlier account recovers. Existing conversations stay pinned while
+their account remains eligible. Short temporary rate limits wait on the same
+account once; longer holds return Retry-After for pinned conversations while new
+conversations can advance. A model-family limit detours only requests for that
+family without moving the session's main pin or the provider cursor. The cursor
+and session pins survive hub restarts. Session pins expire after 30 idle minutes,
+and the pool retains the 4,096 most recently used pins.
+
+Use the up/down arrows in Account Pooler settings, or
+`bb pool account reorder <claude|codex> <id>...`, to set the complete order for
+one provider. Include disabled accounts too. Reordering changes the next failover
+sequence without moving the current account. `bb pool account priority <id> <n>`
+sets an individual priority; the same operations are available through the
+`account.reorder` and `account.setPriority` plugin RPCs.
 
 - Inspect real status, logs, API results, or diffs instead of assumptions.
 - Keep file paths on the machine that owns the selected workspace.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -687,6 +687,25 @@ without disabling that account for other families. Imported and newly signed-in
 accounts retain their Anthropic account UUID, and the hub aligns a present
 `metadata.user_id` account component with the selected account.
 
+Accounts run sequentially per provider: lower priority numbers first, with ties
+following the order accounts were added. New conversations use the current
+account until it reaches the switch threshold or fails; the pool then advances
+to the next eligible account and wraps at the end. It keeps using that fallback
+even when an earlier account recovers. Existing conversations stay pinned while
+their account remains eligible. Short temporary rate limits wait on the same
+account once; longer holds return Retry-After for pinned conversations while new
+conversations can advance. A model-family limit detours only requests for that
+family without moving the session's main pin or the provider cursor. The cursor
+and session pins survive hub restarts. Session pins expire after 30 idle minutes,
+and the pool retains the 4,096 most recently used pins.
+
+Use the up/down arrows in Account Pooler settings, or
+`bb pool account reorder <claude|codex> <id>...`, to set the complete order for
+one provider. Include disabled accounts too. Reordering changes the next failover
+sequence without moving the current account. `bb pool account priority <id> <n>`
+sets an individual priority; the same operations are available through the
+`account.reorder` and `account.setPriority` plugin RPCs.
+
 Three plugin-owned configuration values control routing. `switchThreshold` is
 the shared or requested model-family quota fraction at which an account stops
 receiving matching traffic and defaults to `0.98`.

--- a/packages/templates/src/templates/bb-guide-plugins.md
+++ b/packages/templates/src/templates/bb-guide-plugins.md
@@ -39,6 +39,8 @@ bb pool account list [--json]
 bb pool account remove <id>
 bb pool account enable <id>
 bb pool account disable <id>
+bb pool account priority <id> <n>
+bb pool account reorder <claude|codex> <id>...
 bb pool status [--json]
 bb pool routing <claude|codex> [--off]
 bb pool config
@@ -82,6 +84,25 @@ account. `bb pool config` prints the quota switch threshold and both upstream
 URLs. Use `bb pool config set <key> <value>` to change one; the two URL values
 are QA-only overrides. Upgrading from a build that stored these values through
 plugin settings resets the threshold and QA overrides to their defaults.
+
+Accounts run sequentially per provider: lower priority numbers first, with ties
+following the order accounts were added. New conversations use the current
+account until it reaches the switch threshold or fails; the pool then advances
+to the next eligible account and wraps at the end. It keeps using that fallback
+even when an earlier account recovers. Existing conversations stay pinned while
+their account remains eligible. Short temporary rate limits wait on the same
+account once; longer holds return Retry-After for pinned conversations while new
+conversations can advance. A model-family limit detours only requests for that
+family without moving the session's main pin or the provider cursor. The cursor
+and session pins survive hub restarts. Session pins expire after 30 idle minutes,
+and the pool retains the 4,096 most recently used pins.
+
+Use the up/down arrows in Account Pooler settings, or
+`bb pool account reorder <claude|codex> <id>...`, to set the complete order for
+one provider. Include disabled accounts too. Reordering changes the next failover
+sequence without moving the current account. `bb pool account priority <id> <n>`
+sets an individual priority; the same operations are available through the
+`account.reorder` and `account.setPriority` plugin RPCs.
 
 The builtin Keep Awake plugin prevents macOS idle sleep while bb is running.
 Its settings page lets you target all hosts or selected hosts. The CLI

--- a/plugins/account-pool/PLUGIN_OVERVIEW.md
+++ b/plugins/account-pool/PLUGIN_OVERVIEW.md
@@ -3,13 +3,16 @@ Keep a Claude Code or Codex thread running when one account hits its limit. The 
 ## What you get
 
 - A pool of Claude and Codex accounts, added by importing the login already on the machine, signing in through the browser, or pasting an Anthropic API key.
-- New conversations follow your priority order, then the account with the fewest requests in flight, then the account whose weekly window resets first. A conversation stays on its account while that account remains eligible.
+- Accounts run one after another in priority order, with ties following the order added. New conversations stay on the current fallback even when an earlier account recovers. Existing conversations keep their own account until it becomes unavailable.
+- Up/down arrows set the account order in settings, with the same operation available through `bb pool account reorder <claude|codex> <id>...`.
 - Live limit windows per account and model family in the plugin's settings page, and the same numbers from `bb pool status`.
 - A routing switch per provider and a bypass per thread, so one thread can go straight to its own credentials.
 
 ## How it works
 
-The hub runs inside BB and serves an Anthropic Messages endpoint and an OpenAI Responses endpoint. With routing on, BB hands the Claude Code or Codex process a base URL that points at the hub and a token scoped to that machine, and the provider reports **Proxied** in its health row. An account is skipped for a request when it is at or above the switch threshold, on hold, or in error. The threshold defaults to 98 percent of a window. Account secrets stay in the BB data directory on the server machine, and the hub refreshes them in the background.
+The hub runs inside BB and serves an Anthropic Messages endpoint and an OpenAI Responses endpoint. With routing on, BB hands the Claude Code or Codex process a base URL that points at the hub and a token scoped to that machine, and the provider reports **Proxied** in its health row. An account is skipped for a request when it is at or above the switch threshold or in error. The threshold defaults to 98 percent of a window. Account secrets stay in the BB data directory on the server machine, and the hub refreshes them in the background.
+
+The pool waits once on the same account for short temporary rate limits. Longer holds return Retry-After for pinned conversations while new conversations can advance. A model-family limit detours requests for that family without moving the session’s main pin or the provider cursor. The pool commits a new account after a successful response; a failed attempt across every account retains the previous binding. The current account and session pins survive hub restarts. Session pins expire after 30 idle minutes, with the 4,096 most recently used pins retained.
 
 ## Requirements
 
@@ -19,4 +22,4 @@ This plugin is experimental. Routing behavior, stored data, and the CLI can chan
 
 ## For agents
 
-`bb pool account add|list|remove|enable|disable`, `bb pool status`, `bb pool routing <claude|codex> [--off]`, `bb pool config`, `bb pool config set`, `bb pool token rotate`, and `bb pool bypass <thread-id>`. `list` and `status` take `--json`.
+`bb pool account add|list|remove|enable|disable|priority|reorder`, `bb pool status`, `bb pool routing <claude|codex> [--off]`, `bb pool config`, `bb pool config set`, `bb pool token rotate`, and `bb pool bypass <thread-id>`. `list` and `status` take `--json`.

--- a/plugins/account-pool/app.test.tsx
+++ b/plugins/account-pool/app.test.tsx
@@ -77,7 +77,7 @@ function config(overrides: Partial<AccountPoolConfig> = {}): AccountPoolConfig {
 
 function render(
   accounts = [account()],
-  extraRpc: Record<string, () => object> = {},
+  extraRpc: Record<string, () => object | null> = {},
 ) {
   return renderSlot(
     app.settingsSections[0]!,
@@ -316,5 +316,91 @@ describe("Account Pool settings", () => {
     );
     fireEvent.click(await slot.findByRole("button", { name: "Try again" }));
     await waitFor(() => expect(starts).toBe(2));
+  });
+  it("reorders accounts within their provider and refreshes the displayed order", async () => {
+    const first = account({ label: "First" });
+    const second = account({
+      id: "22222222-2222-4222-8222-222222222222",
+      label: "Second",
+    });
+    const codex = account({
+      id: "33333333-3333-4333-8333-333333333333",
+      provider: "codex",
+      label: "Codex",
+    });
+    const accounts = [first, second, codex];
+    const slot = render(accounts, {
+      "account.reorder": () => {
+        accounts.splice(0, 2, second, first);
+        return null;
+      },
+    });
+    expect(
+      (await slot.findByRole("button", { name: "Move First up" })).hasAttribute(
+        "disabled",
+      ),
+    ).toBe(true);
+    fireEvent.click(slot.getByRole("button", { name: "Move First down" }));
+    await waitFor(() =>
+      expect(slot.rpcCalls).toContainEqual({
+        method: "account.reorder",
+        input: { provider: "claude", accountIds: [second.id, first.id] },
+      }),
+    );
+    await waitFor(() =>
+      expect(
+        slot
+          .getByRole("button", { name: "Move Second up" })
+          .hasAttribute("disabled"),
+      ).toBe(true),
+    );
+    expect(
+      slot
+        .getByRole("button", { name: "Move First down" })
+        .hasAttribute("disabled"),
+    ).toBe(true);
+    expect(
+      slot
+        .getByRole("button", { name: "Move Codex up" })
+        .hasAttribute("disabled"),
+    ).toBe(true);
+    expect(
+      slot
+        .getByRole("button", { name: "Move Codex down" })
+        .hasAttribute("disabled"),
+    ).toBe(true);
+  });
+
+  it("keeps the displayed order and reports a rejected reorder", async () => {
+    const slot = render(
+      [
+        account({ label: "First" }),
+        account({
+          id: "22222222-2222-4222-8222-222222222222",
+          label: "Second",
+        }),
+      ],
+      {
+        "account.reorder": () => {
+          throw new Error("Refresh the account list and try again.");
+        },
+      },
+    );
+    fireEvent.click(
+      await slot.findByRole("button", { name: "Move First down" }),
+    );
+    expect(
+      await slot.findByText("Refresh the account list and try again."),
+    ).toBeTruthy();
+    expect(
+      slot
+        .getByRole("button", { name: "Move First up" })
+        .hasAttribute("disabled"),
+    ).toBe(true);
+    expect(
+      slot
+        .getByRole("button", { name: "Move First down" })
+        .hasAttribute("disabled"),
+    ).toBe(false);
   });
 });

--- a/plugins/account-pool/app.tsx
+++ b/plugins/account-pool/app.tsx
@@ -278,16 +278,42 @@ function AccountRow({
   pending,
   onAction,
   onOpen,
+  onMoveUp,
+  onMoveDown,
 }: {
   account: AccountSummary;
   threshold: number;
   pending: boolean;
   onAction: (action: "toggle" | "priority" | "refresh" | "remove") => void;
   onOpen: () => void;
+  onMoveUp: (() => void) | null;
+  onMoveDown: (() => void) | null;
 }) {
   const status = statusPresentation(account);
   return (
     <div className="flex items-center gap-3 text-sm">
+      <div className="flex shrink-0 items-center gap-1">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-8"
+          aria-label={`Move ${account.label} up`}
+          disabled={pending || onMoveUp === null}
+          onClick={() => onMoveUp?.()}
+        >
+          <Icon name="ArrowUp" className="size-4" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-8"
+          aria-label={`Move ${account.label} down`}
+          disabled={pending || onMoveDown === null}
+          onClick={() => onMoveDown?.()}
+        >
+          <Icon name="ArrowDown" className="size-4" />
+        </Button>
+      </div>
       <div
         className={cn(
           "group -mx-2 flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-2.5 transition-colors hover:bg-state-hover focus-within:bg-state-hover",
@@ -838,6 +864,25 @@ function AccountPoolSettings() {
         await rpc.call("account.refreshUsage", { accountId: account.id });
     });
   }
+  async function moveAccount(
+    account: AccountSummary,
+    offset: number,
+  ): Promise<void> {
+    const ordered = accounts
+      .filter((candidate) => candidate.provider === account.provider)
+      .map((candidate) => candidate.id);
+    const index = ordered.indexOf(account.id);
+    const target = index + offset;
+    if (index < 0 || target < 0 || target >= ordered.length) return;
+    ordered.splice(index, 1);
+    ordered.splice(target, 0, account.id);
+    await run(`order-${account.provider}`, async () => {
+      await rpc.call("account.reorder", {
+        provider: account.provider,
+        accountIds: ordered,
+      });
+    });
+  }
   function closeDrawer(): void {
     if (drawer?.kind === "codex-login" && codexStep !== null)
       void rpc.call("codexLogin.cancel", { sessionId: codexStep.sessionId });
@@ -927,13 +972,21 @@ function AccountPoolSettings() {
               </p>
             ) : (
               <div className="divide-y divide-border">
-                {providerAccounts.map((account) => (
+                {providerAccounts.map((account, index) => (
                   <AccountRow
                     key={account.id}
                     account={account}
                     threshold={threshold}
                     pending={pending !== null}
                     onAction={(action) => void accountAction(account, action)}
+                    onMoveUp={
+                      index === 0 ? null : () => void moveAccount(account, -1)
+                    }
+                    onMoveDown={
+                      index === providerAccounts.length - 1
+                        ? null
+                        : () => void moveAccount(account, 1)
+                    }
                     onOpen={() =>
                       setDrawer({ kind: "account", accountId: account.id })
                     }
@@ -1101,8 +1154,8 @@ function AccountPoolSettings() {
             }
           >
             <p className="text-sm text-muted-foreground">
-              Lower numbers route first. Accounts with the same priority share
-              work by availability.
+              Lower numbers come first in the failover order. Ties follow the
+              order accounts were added. Existing conversations stay pinned.
             </p>
             <Input
               type="number"

--- a/plugins/account-pool/src/cli.ts
+++ b/plugins/account-pool/src/cli.ts
@@ -3,6 +3,8 @@ import { setTimeout as wait } from "node:timers/promises";
 import {
   accountAddInputSchema,
   accountIdInputSchema,
+  accountPriorityInputSchema,
+  accountReorderInputSchema,
   accountPoolConfigSetInputSchema,
   bypassInputSchema,
   codexLoginPollInputSchema,
@@ -41,12 +43,17 @@ const HELP = [
   "  bb pool account remove <id>",
   "  bb pool account enable <id>",
   "  bb pool account disable <id>",
+  "  bb pool account priority <id> <n>",
+  "  bb pool account reorder <claude|codex> <id>...",
   "  bb pool status [--json]",
   "  bb pool routing <claude|codex> [--off]",
   "  bb pool config",
   "  bb pool config set <anthropicUpstreamBaseUrl|codexUpstreamBaseUrl|switchThreshold> <value>",
   "  bb pool token rotate --machine <id-or-name>",
   "  bb pool bypass <thread-id> [--off]",
+  "",
+  "Accounts run sequentially by priority, then order added. The current fallback stays active until unavailable.",
+  "Reorder includes every account for the provider and changes the next failover sequence; existing conversations stay pinned.",
 ].join("\n");
 
 function parseFlags(
@@ -287,6 +294,16 @@ export function registerPoolCli(
         usage: "bb pool account disable <id>",
       },
       {
+        name: "account-priority",
+        summary: "Set an account's position in the failover priority order",
+        usage: "bb pool account priority <id> <n>",
+      },
+      {
+        name: "account-reorder",
+        summary: "Set the complete failover order for one provider",
+        usage: "bb pool account reorder <claude|codex> <id>...",
+      },
+      {
         name: "status",
         summary: "Show hub, machine token, routing, and account status",
         usage: "bb pool status [--json]",
@@ -322,6 +339,34 @@ export function registerPoolCli(
       try {
         if (argv.includes("--help") || argv.includes("-h")) {
           return { exitCode: 0, stdout: `${HELP}\n` };
+        }
+        if (argv[0] === "account" && argv[1] === "priority") {
+          if (argv.length !== 4 || argv[3]?.trim() === "")
+            throw new Error(HELP);
+          const input = accountPriorityInputSchema.parse({
+            accountId: argv[2],
+            priority: Number(argv[3]),
+          });
+          const account = await operations.setPriority(
+            input.accountId,
+            input.priority,
+          );
+          if (account === null) throw new Error("Account not found.");
+          return {
+            exitCode: 0,
+            stdout: `Set ${account.label} priority to ${account.priority}.\n`,
+          };
+        }
+        if (argv[0] === "account" && argv[1] === "reorder") {
+          const input = accountReorderInputSchema.parse({
+            provider: argv[2],
+            accountIds: argv.slice(3),
+          });
+          await operations.reorder(input.provider, input.accountIds);
+          return {
+            exitCode: 0,
+            stdout: `Updated ${input.provider} account order.\n`,
+          };
         }
         if (argv[0] === "account" && argv[1] === "add") {
           const flags = parseFlags(

--- a/plugins/account-pool/src/codex-adapter.test.ts
+++ b/plugins/account-pool/src/codex-adapter.test.ts
@@ -114,6 +114,45 @@ describe("codexQuotaFromUsage", () => {
 });
 
 describe("codex header quotas", () => {
+  it.each(["primary", "secondary"] as const)(
+    "honors a fresh over-limit %s header after the previous reset expires",
+    (slot) => {
+      const previous = adapter.quotaFromHeaders(
+        ACCOUNT_ID,
+        new Headers({
+          [`x-codex-${slot}-used-percent`]: "25",
+          [`x-codex-${slot}-reset-after-seconds`]: "1",
+        }),
+        emptyQuota(),
+        "other",
+        1_000,
+      );
+      const rejected = adapter.quotaFromHeaders(
+        ACCOUNT_ID,
+        new Headers({ [`x-codex-${slot}-over-limit`]: "true" }),
+        previous,
+        "other",
+        3_000,
+      );
+      expect(isQuotaExhausted(rejected, "other", 0.98, 3_000)).toBe(true);
+      expect(
+        rejected.limitWindows.find((window) => window.slot === slot)?.resetAt,
+      ).toBeNull();
+      const recovered = codexQuotaFromUsage(
+        ACCOUNT_ID,
+        {
+          rate_limit: {
+            [`${slot}_window`]: { used_percent: 10, reset_after_seconds: 60 },
+          },
+        },
+        rejected,
+        4_000,
+      );
+      if (recovered === null) throw new Error("Expected refreshed usage.");
+      expect(isQuotaExhausted(recovered, "other", 0.98, 4_000)).toBe(false);
+    },
+  );
+
   it("retains the reported window length when a later response omits it", () => {
     const fromUsage = codexQuotaFromUsage(
       ACCOUNT_ID,

--- a/plugins/account-pool/src/codex-adapter.ts
+++ b/plugins/account-pool/src/codex-adapter.ts
@@ -87,7 +87,9 @@ function windowFromHeaders(
   const usedPercent = numberHeader(headers, `${prefix}-used-percent`);
   const reset = resetAt(headers, prefix, now);
   const minutes = numberHeader(headers, `${prefix}-window-minutes`);
-  if (usedPercent === null && reset === null) return previous;
+  const overLimit =
+    headers.get(`${prefix}-over-limit`)?.toLowerCase() === "true";
+  if (usedPercent === null && reset === null && !overLimit) return previous;
   const utilization =
     usedPercent === null
       ? (previous?.utilization ?? null)
@@ -99,8 +101,17 @@ function windowFromHeaders(
         ? Math.round(minutes)
         : (previous?.windowMinutes ?? null),
     utilization,
-    resetAt: reset ?? previous?.resetAt ?? null,
-    status: utilization !== null && utilization >= 1 ? "rejected" : null,
+    resetAt:
+      reset ??
+      (previous?.resetAt !== null &&
+      previous?.resetAt !== undefined &&
+      previous.resetAt > now
+        ? previous.resetAt
+        : null),
+    status:
+      overLimit || (utilization !== null && utilization >= 1)
+        ? "rejected"
+        : null,
     observedAt: now,
     source: "header",
   };

--- a/plugins/account-pool/src/contracts.ts
+++ b/plugins/account-pool/src/contracts.ts
@@ -294,6 +294,13 @@ export const accountPriorityInputSchema = z
   .object({ accountId: z.string().uuid(), priority: z.number().int() })
   .strict();
 
+export const accountReorderInputSchema = z
+  .object({
+    provider: providerSchema,
+    accountIds: z.array(z.string().uuid()).min(1),
+  })
+  .strict();
+
 export const routingSetInputSchema = z
   .object({ provider: providerSchema, enabled: z.boolean() })
   .strict();

--- a/plugins/account-pool/src/hub.ts
+++ b/plugins/account-pool/src/hub.ts
@@ -23,9 +23,16 @@ import {
   accountStatus,
   governingWeeklyResetAt,
   isQuotaExhausted,
+  isSharedQuotaExhausted,
   retryAfterMilliseconds,
 } from "./quota.js";
-import type { AccountStore, HubTokenStore, QuotaStore } from "./store.js";
+import type {
+  AccountBinding,
+  AccountStore,
+  HubTokenStore,
+  PoolAffinityStore,
+  QuotaStore,
+} from "./store.js";
 
 const ROUTE = "/api/v1/plugins/account-pool/http";
 const DEFAULT_REFRESH_URL = "https://platform.claude.com/v1/oauth/token";
@@ -61,6 +68,7 @@ export interface HubSettings {
 interface HubOptions {
   accounts: AccountStore;
   quotas: QuotaStore;
+  affinity: PoolAffinityStore;
   hubTokens: HubTokenStore;
   getSettings: () => HubSettings;
   adapters: ReadonlyMap<PoolProvider, ProviderAdapter>;
@@ -74,6 +82,18 @@ interface HubOptions {
 interface SelectedAccount {
   account: Account;
   quota: AccountQuota;
+  keepAffinity: boolean;
+  accept: () => void;
+}
+
+interface ActiveAccount {
+  accountId: string;
+}
+
+interface RoutingAttempt {
+  binding: AccountBinding | null;
+  active: ActiveAccount | null;
+  pinnedAccountId: string | null;
 }
 interface UpstreamResult {
   response: Response;
@@ -110,10 +130,8 @@ export class AccountPoolHub {
   private readonly activeControllers = new Set<AbortController>();
   private readonly refreshes = new Map<string, SecretFlight>();
   private readonly refreshBackoffs = new Map<string, RefreshBackoff>();
-  private readonly affinityBindings = new Map<
-    string,
-    { accountId: string; lastUsedAt: number }
-  >();
+  private affinityBindings = new Map<string, AccountBinding>();
+  private activeAccounts = new Map<PoolProvider, ActiveAccount>();
   private readonly usageRefreshes = new Map<string, Promise<void>>();
   private readonly lastUsageRefreshAt = new Map<string, number>();
   private readonly drainWaiters = new Set<() => void>();
@@ -121,7 +139,11 @@ export class AccountPoolHub {
   constructor(private readonly options: HubOptions) {}
 
   async start(signal: AbortSignal): Promise<void> {
-    this.affinityBindings.clear();
+    this.affinityBindings = this.options.affinity.loadBindings(
+      this.options.now() - AFFINITY_IDLE_TTL_MS,
+      MAX_AFFINITY_BINDINGS,
+    );
+    this.activeAccounts = this.options.affinity.loadActiveAccounts();
     this.stopped = new AbortController();
     this.accepting = true;
     while (!signal.aborted) {
@@ -248,7 +270,9 @@ export class AccountPoolHub {
   > {
     const settings = this.options.getSettings();
     const now = this.options.now();
-    const accounts = await this.options.accounts.list();
+    const accounts = (await this.options.accounts.list()).sort(
+      (left, right) => left.priority - right.priority,
+    );
     return {
       route: ROUTE,
       enabledAccountCount: accounts.filter((account) => account.enabled).length,
@@ -287,6 +311,12 @@ export class AccountPoolHub {
   ): Promise<Response> {
     const signal = AbortSignal.any([request.signal, this.stopped.signal]);
     const attempted = new Set<string>();
+    const waited = new Set<string>();
+    const routing: RoutingAttempt = {
+      binding: null,
+      active: null,
+      pinnedAccountId: null,
+    };
     let previousAccountId: string | null = null;
     let failure: FailureSummary | null = null;
     const accounts = (await this.options.accounts.list()).filter(
@@ -314,9 +344,33 @@ export class AccountPoolHub {
           affinityKey,
           parentAffinityKey,
           previousAccountId,
+          routing,
           signal,
         );
         if (selected === null) break;
+        const heldMs = (selected.quota.heldUntil ?? 0) - this.options.now();
+        if (heldMs > 0) {
+          if (heldMs > MAX_INLINE_HOLD_MS || waited.has(selected.account.id)) {
+            failure = {
+              status: 429,
+              message:
+                "The current Account Pooler account is temporarily rate limited.",
+              headers: { "retry-after": String(Math.ceil(heldMs / 1_000)) },
+            };
+            if (selected.keepAffinity)
+              return adapter.errorResponse(
+                failure.status,
+                failure.message,
+                failure.headers,
+              );
+            attempted.add(selected.account.id);
+            previousAccountId = selected.account.id;
+            continue;
+          }
+          waited.add(selected.account.id);
+          await waitForDelay(heldMs, signal);
+          continue;
+        }
         previousAccountId = selected.account.id;
         attempted.add(selected.account.id);
         if (hostId !== null) {
@@ -344,7 +398,7 @@ export class AccountPoolHub {
           continue;
         }
         let authRetried = false;
-        let paced = false;
+        let paced = waited.has(selected.account.id);
         while (true) {
           signal.throwIfAborted();
           let upstream: UpstreamResult;
@@ -398,6 +452,14 @@ export class AccountPoolHub {
               await this.discardUpstream(upstream, false);
               await waitForDelay(waitMs, signal);
               continue;
+            }
+            if (!selected.keepAffinity) {
+              failure = {
+                status: 429,
+                message: await this.discardUpstream(upstream, true),
+                headers: { "retry-after": String(Math.ceil(waitMs / 1_000)) },
+              };
+              break;
             }
           }
           if (
@@ -467,6 +529,7 @@ export class AccountPoolHub {
             }
             break;
           }
+          if (response.ok) selected.accept();
           return this.clientResponse(upstream);
         }
       }
@@ -592,78 +655,143 @@ export class AccountPoolHub {
     affinityKey: string | null,
     parentAffinityKey: string | null,
     previousAccountId: string | null,
+    routing: RoutingAttempt,
     signal: AbortSignal,
   ): Promise<SelectedAccount | null> {
-    const accounts = await this.options.accounts.list();
+    const accounts = (await this.options.accounts.list()).sort(
+      (left, right) => left.priority - right.priority,
+    );
     signal.throwIfAborted();
     const now = this.options.now();
     const threshold = this.options.getSettings().switchThreshold;
-    const eligible = accounts
+    const available = accounts
       .filter((account) => account.provider === provider && account.enabled)
       .map((account) => ({
         account,
         quota: this.options.quotas.get(account.id),
       }))
       .filter(({ quota }) => quota.error === null)
-      .filter(({ quota }) => quota.heldUntil === null || quota.heldUntil <= now)
-      .filter(({ quota }) => !isQuotaExhausted(quota, family, threshold, now));
-    const candidates = eligible.filter(
+      .filter(({ quota }) => !isSharedQuotaExhausted(quota, threshold, now));
+    const eligible = available.filter(
+      ({ quota }) => !isQuotaExhausted(quota, family, threshold, now),
+    );
+    const unattempted = eligible.filter(
       ({ account }) =>
         candidateIds.has(account.id) && !attempted.has(account.id),
     );
-    candidates.sort((left, right) => {
-      const priority = left.account.priority - right.account.priority;
-      if (priority !== 0) return priority;
-      const inFlight =
-        (this.inFlightByAccount.get(left.account.id) ?? 0) -
-        (this.inFlightByAccount.get(right.account.id) ?? 0);
-      if (inFlight !== 0) return inFlight;
-      return (
-        (governingWeeklyResetAt(left.quota, family) ??
-          Number.MAX_SAFE_INTEGER) -
-        (governingWeeklyResetAt(right.quota, family) ?? Number.MAX_SAFE_INTEGER)
-      );
-    });
-    const binding =
+    const candidates = unattempted.filter(
+      ({ quota }) => quota.heldUntil === null || quota.heldUntil <= now,
+    );
+    let binding =
       affinityKey === null ? undefined : this.affinityBindings.get(affinityKey);
-    const bound =
+    const boundAccountId =
       binding !== undefined && now - binding.lastUsedAt < AFFINITY_IDLE_TTL_MS
-        ? eligible.find(({ account }) => account.id === binding.accountId)
+        ? binding.accountId
+        : null;
+    const bound =
+      boundAccountId !== null
+        ? eligible.find(({ account }) => account.id === boundAccountId)
         : undefined;
-    let inherited: SelectedAccount | undefined;
+    let inherited: (typeof candidates)[number] | undefined;
     if (bound === undefined && parentAffinityKey !== null) {
       const parent = this.affinityBindings.get(parentAffinityKey);
       if (
         parent !== undefined &&
         now - parent.lastUsedAt < AFFINITY_IDLE_TTL_MS
       ) {
-        inherited = candidates.find(
+        inherited = unattempted.find(
           ({ account }) => account.id === parent.accountId,
         );
       }
     }
+    let active = this.activeAccounts.get(provider);
+    const activeAccount = eligible.find(
+      ({ account }) => account.id === active?.accountId,
+    );
+    const anchorId = previousAccountId ?? boundAccountId ?? active?.accountId;
+    const anchorIndex = accounts.findIndex(
+      (account) => account.id === anchorId,
+    );
+    const ordered = [
+      ...accounts.slice(anchorIndex + 1),
+      ...accounts.slice(0, anchorIndex + 1),
+    ];
+    const next = ordered
+      .map((account) =>
+        candidates.find((candidate) => candidate.account.id === account.id),
+      )
+      .find((candidate) => candidate !== undefined);
     const selected =
-      bound !== undefined && candidates.includes(bound)
+      bound !== undefined && unattempted.includes(bound)
         ? bound
-        : (inherited ?? candidates[0] ?? null);
-    if (
-      affinityKey !== null &&
-      selected !== null &&
-      (bound === undefined ||
-        bound.account.id === selected.account.id ||
-        bound.account.id === previousAccountId)
-    ) {
-      this.affinityBindings.delete(affinityKey);
-      this.affinityBindings.set(affinityKey, {
-        accountId: selected.account.id,
-        lastUsedAt: now,
-      });
-      while (this.affinityBindings.size > MAX_AFFINITY_BINDINGS) {
-        const oldest = this.affinityBindings.keys().next();
-        if (!oldest.done) this.affinityBindings.delete(oldest.value);
+        : (inherited ??
+          (boundAccountId === null &&
+          previousAccountId === null &&
+          activeAccount !== undefined &&
+          unattempted.includes(activeAccount)
+            ? activeAccount
+            : next) ??
+          null);
+    if (selected === null) return null;
+    if (routing.active === null)
+      routing.pinnedAccountId = boundAccountId ?? inherited?.account.id ?? null;
+    if (affinityKey !== null && binding === undefined) {
+      binding = { accountId: selected.account.id, lastUsedAt: now };
+      this.affinityBindings.set(affinityKey, binding);
+    }
+    if (binding !== undefined && binding.accountId === selected.account.id) {
+      binding.lastUsedAt = now;
+      if (affinityKey !== null) {
+        this.affinityBindings.delete(affinityKey);
+        this.affinityBindings.set(affinityKey, binding);
       }
     }
-    return selected;
+    while (this.affinityBindings.size > MAX_AFFINITY_BINDINGS) {
+      const oldest = this.affinityBindings.keys().next();
+      if (!oldest.done) {
+        this.affinityBindings.delete(oldest.value);
+        this.options.affinity.removeBinding(oldest.value);
+      }
+    }
+    if (active === undefined) {
+      active = { accountId: selected.account.id };
+      this.activeAccounts.set(provider, active);
+    }
+    routing.binding ??= binding ?? null;
+    routing.active ??= active;
+    const familyDetour = (accountId: string | null) =>
+      available.some(({ account }) => account.id === accountId) &&
+      !eligible.some(({ account }) => account.id === accountId);
+    const rebind =
+      affinityKey !== null &&
+      !familyDetour(boundAccountId) &&
+      (bound === undefined ||
+        bound.account.id === selected.account.id ||
+        (binding === routing.binding && attempted.has(bound.account.id)));
+    const advance =
+      !familyDetour(active.accountId) &&
+      (activeAccount === undefined ||
+        active.accountId === selected.account.id ||
+        (active === routing.active && attempted.has(active.accountId)));
+    return {
+      ...selected,
+      keepAffinity: selected.account.id === routing.pinnedAccountId,
+      accept: () => {
+        if (rebind && this.affinityBindings.get(affinityKey) === binding) {
+          const accepted = {
+            accountId: selected.account.id,
+            lastUsedAt: this.options.now(),
+          };
+          this.options.affinity.putBinding(affinityKey, accepted);
+          this.affinityBindings.delete(affinityKey);
+          this.affinityBindings.set(affinityKey, accepted);
+        }
+        if (advance && this.activeAccounts.get(provider) === active) {
+          this.options.affinity.putActiveAccount(provider, selected.account.id);
+          this.activeAccounts.set(provider, { accountId: selected.account.id });
+        }
+      },
+    };
   }
 
   private async freshSecret(
@@ -992,6 +1120,7 @@ export class AccountPoolHub {
 export function createHub(options: {
   accounts: AccountStore;
   quotas: QuotaStore;
+  affinity: PoolAffinityStore;
   hubTokens: HubTokenStore;
   getSettings: () => HubSettings;
   fetch?: typeof fetch;
@@ -1029,6 +1158,7 @@ export function createHub(options: {
   return new AccountPoolHub({
     accounts: options.accounts,
     quotas: options.quotas,
+    affinity: options.affinity,
     hubTokens: options.hubTokens,
     getSettings: options.getSettings,
     adapters,

--- a/plugins/account-pool/src/operations.ts
+++ b/plugins/account-pool/src/operations.ts
@@ -187,6 +187,11 @@ export class PoolOperations {
     return account;
   }
 
+  async reorder(provider: PoolProvider, accountIds: string[]): Promise<void> {
+    await this.accounts.reorder(provider, accountIds);
+    this.onAccountsChanged();
+  }
+
   async refreshUsage(id: string): Promise<AccountSummary | null> {
     if ((await this.accounts.get(id)) === null) return null;
     await this.hub.refreshUsage(id, true);

--- a/plugins/account-pool/src/rpc.ts
+++ b/plugins/account-pool/src/rpc.ts
@@ -6,6 +6,7 @@ import {
   accountPoolConfigSetInputSchema,
   accountIdInputSchema,
   accountPriorityInputSchema,
+  accountReorderInputSchema,
   accountSchema,
   accountSummarySchema,
   bypassInputSchema,
@@ -50,6 +51,10 @@ export const accountPoolRpcContract = defineRpcContract({
   "account.setPriority": {
     input: accountPriorityInputSchema,
     output: z.object({ account: accountSchema.nullable() }).strict(),
+  },
+  "account.reorder": {
+    input: accountReorderInputSchema,
+    output: z.null(),
   },
   "account.refreshUsage": {
     input: z.object({ accountId: z.string().uuid() }).strict(),
@@ -134,6 +139,13 @@ export function createRpcHandlers(
     "account.refreshUsage": async ({ accountId }: { accountId: string }) => ({
       account: await operations.refreshUsage(accountId),
     }),
+    "account.reorder": async ({
+      provider,
+      accountIds,
+    }: z.infer<typeof accountReorderInputSchema>) => {
+      await operations.reorder(provider, accountIds);
+      return null;
+    },
     "routing.set": async ({
       provider,
       enabled,

--- a/plugins/account-pool/src/server.test.ts
+++ b/plugins/account-pool/src/server.test.ts
@@ -323,6 +323,29 @@ async function addApiAccount(
   return found;
 }
 
+async function movePoolToOtherAccount(
+  fixture: Fixture,
+  provider: "claude" | "codex",
+  disabledId = fixture.account.id,
+): Promise<void> {
+  await fixture.host.harness.behavior.callRpc("account.disable", {
+    id: disabledId,
+  });
+  try {
+    const response = await fixture.host.harness.behavior.fetchHttp(
+      "POST",
+      provider === "claude" ? "/v1/messages" : "/v1/responses",
+      { headers: authHeaders(fixture.key), body: "{}" },
+    );
+    expect(response.status).toBe(200);
+    await response.text();
+  } finally {
+    await fixture.host.harness.behavior.callRpc("account.enable", {
+      id: disabledId,
+    });
+  }
+}
+
 const EMPTY_USAGE_URL = "data:application/json,{}";
 const CODEX_USAGE_STUB_URL = "https://usage.example/wham/usage";
 
@@ -2331,7 +2354,7 @@ describe("Account Pool plugin", () => {
       await response.text();
     }
 
-    expect(authorizations).toEqual(["Bearer oauth-b", "Bearer oauth-a"]);
+    expect(authorizations).toEqual(["Bearer oauth-b", "Bearer oauth-b"]);
   });
 
   it("rewrites both known metadata account UUID formats", async () => {
@@ -3338,7 +3361,8 @@ describe("Account Pool plugin", () => {
               ? Promise.resolve(Response.json({}))
               : upstreamFetch(input, init),
           importCodexCredentials: async () => ({
-            accessToken: imported++ === 0 ? "sk-first" : "sk-second",
+            accessToken:
+              ["sk-first", "sk-second", "sk-third"][imported++] ?? "sk-extra",
             refreshToken: "refresh",
             idToken: null,
             accountId: `codex-account-${imported}`,
@@ -3357,6 +3381,307 @@ describe("Account Pool plugin", () => {
         });
       return fixture;
     }
+
+    it.each(["claude", "codex"] as const)(
+      "keeps %s sessions and the pool cursor on the third account after two failures",
+      async (provider) => {
+        let outage = false;
+        const attempts: string[] = [];
+        const fixture = await affinityFixture(
+          provider,
+          async (_input, init) => {
+            const headers = new Headers(init?.headers);
+            const key =
+              headers.get("x-api-key") ??
+              headers.get("authorization")?.slice(7) ??
+              "";
+            attempts.push(key);
+            return Response.json(
+              {},
+              { status: outage && key !== "sk-third" ? 503 : 200 },
+            );
+          },
+        );
+        if (provider === "claude") await addApiAccount(fixture, "sk-third");
+        else
+          await fixture.host.harness.behavior.callRpc("account.add", {
+            provider,
+            source: { kind: "import" },
+            label: null,
+            priority: 100,
+          });
+        const send = async (id: string) => {
+          const response = await fixture.host.harness.behavior.fetchHttp(
+            "POST",
+            provider === "claude" ? "/v1/messages" : "/v1/responses",
+            {
+              headers: { ...authHeaders(fixture.key), "session-id": id },
+              body: provider === "claude" ? claudeBody(id) : "{}",
+            },
+          );
+          expect(response.status).toBe(200);
+          await response.text();
+        };
+        await send("warm");
+        outage = true;
+        await send("warm");
+        await send("warm");
+        await send("fresh");
+        outage = false;
+        await send("warm");
+        await send("fresh-after-recovery");
+        expect(attempts).toEqual([
+          "sk-first",
+          "sk-first",
+          "sk-second",
+          "sk-third",
+          "sk-third",
+          "sk-third",
+          "sk-third",
+          "sk-third",
+        ]);
+      },
+    );
+
+    it.each(["claude", "codex"] as const)(
+      "lets new %s conversations bypass long holds while preserving established pins",
+      async (provider) => {
+        let now = 1_800_000_000_000;
+        let limited = false;
+        const attempts: string[] = [];
+        const fixture = await affinityFixture(
+          provider,
+          async (_input, init) => {
+            const headers = new Headers(init?.headers);
+            const key =
+              headers.get("x-api-key") ??
+              headers.get("authorization")?.slice(7) ??
+              "";
+            attempts.push(key);
+            return limited && key === "sk-first"
+              ? Response.json(
+                  {},
+                  { status: 429, headers: { "retry-after": "60" } },
+                )
+              : Response.json({});
+          },
+          () => now,
+        );
+        const send = async (id: string, status = 200) => {
+          const response = await fixture.host.harness.behavior.fetchHttp(
+            "POST",
+            provider === "claude" ? "/v1/messages" : "/v1/responses",
+            {
+              headers: { ...authHeaders(fixture.key), "session-id": id },
+              body: provider === "claude" ? claudeBody(id) : "{}",
+            },
+          );
+          expect(response.status).toBe(status);
+          await response.text();
+        };
+        await send("warm");
+        limited = true;
+        await send("warm", 429);
+        await send("fresh");
+        await send("warm", 429);
+        now += 60_000;
+        limited = false;
+        await send("warm");
+        await send("fresh-after-recovery");
+        expect(attempts).toEqual([
+          "sk-first",
+          "sk-first",
+          "sk-second",
+          "sk-first",
+          "sk-second",
+        ]);
+      },
+    );
+
+    it.each(["claude", "codex"] as const)(
+      "fails over immediately when a new %s conversation receives a long rate limit",
+      async (provider) => {
+        const attempts: string[] = [];
+        const fixture = await affinityFixture(
+          provider,
+          async (_input, init) => {
+            const headers = new Headers(init?.headers);
+            const key =
+              headers.get("x-api-key") ??
+              headers.get("authorization")?.slice(7) ??
+              "";
+            attempts.push(key);
+            return key === "sk-first"
+              ? Response.json(
+                  {},
+                  { status: 429, headers: { "retry-after": "60" } },
+                )
+              : Response.json({});
+          },
+        );
+        for (const id of ["fresh", "another"]) {
+          const response = await fixture.host.harness.behavior.fetchHttp(
+            "POST",
+            provider === "claude" ? "/v1/messages" : "/v1/responses",
+            {
+              headers: { ...authHeaders(fixture.key), "session-id": id },
+              body: provider === "claude" ? claudeBody(id) : "{}",
+            },
+          );
+          expect(response.status).toBe(200);
+          await response.text();
+        }
+        expect(attempts).toEqual(["sk-first", "sk-second", "sk-second"]);
+      },
+    );
+
+    it.each(["claude", "codex"] as const)(
+      "restores the %s cursor and distinct session pins after a full plugin reload",
+      async (provider) => {
+        let outage = false;
+        const attempts: string[] = [];
+        const upstreamFetch: typeof fetch = async (input, init) => {
+          if (String(input) === EMPTY_USAGE_URL) return Response.json({});
+          const headers = new Headers(init?.headers);
+          const key =
+            headers.get("x-api-key") ??
+            headers.get("authorization")?.slice(7) ??
+            "";
+          attempts.push(key);
+          return Response.json(
+            {},
+            { status: outage && key === "sk-first" ? 503 : 200 },
+          );
+        };
+        const fixture = await affinityFixture(provider, upstreamFetch);
+        let host = fixture.host;
+        const send = async (id: string) => {
+          const response = await host.harness.behavior.fetchHttp(
+            "POST",
+            provider === "claude" ? "/v1/messages" : "/v1/responses",
+            {
+              headers: { ...authHeaders(fixture.key), "session-id": id },
+              body: provider === "claude" ? claudeBody(id) : "{}",
+            },
+          );
+          expect(response.status).toBe(200);
+          await response.text();
+        };
+        await send("original");
+        outage = true;
+        await send("fallback");
+        outage = false;
+        host = await host.harness.lifecycle.reload(
+          createAccountPoolPlugin({
+            fetch: upstreamFetch,
+            now: () => 1_800_000_000_000,
+            usageUrl: EMPTY_USAGE_URL,
+            codexUsageUrl: EMPTY_USAGE_URL,
+          }),
+        );
+        const service = host.harness.behavior.runService("hub");
+        cleanups.push(async () => {
+          service.controller.abort();
+          await service.done;
+          await host.harness.lifecycle.dispose();
+        });
+        await vi.waitFor(async () => {
+          const status = statusSchema.parse(
+            await host.harness.behavior.callRpc("status.get", null),
+          );
+          expect(status.accepting).toBe(true);
+        });
+        await send("fresh-after-restart");
+        await send("original");
+        await send("fallback");
+        await send("another-fresh");
+        expect(attempts).toEqual([
+          "sk-first",
+          "sk-first",
+          "sk-second",
+          "sk-second",
+          "sk-first",
+          "sk-second",
+          "sk-second",
+        ]);
+      },
+    );
+
+    it.each(["claude", "codex"] as const)(
+      "runs %s sequentially across conversations and keeps a recovered earlier account as backup",
+      async (provider) => {
+        let now = 1_800_000_000_000;
+        let rejected: string | null = null;
+        const attempts: string[] = [];
+        const fixture = await affinityFixture(
+          provider,
+          async (_input, init) => {
+            const headers = new Headers(init?.headers);
+            const key =
+              headers.get("x-api-key") ??
+              headers.get("authorization")?.slice(7) ??
+              "";
+            attempts.push(key);
+            if (key === rejected)
+              return Response.json(
+                {},
+                {
+                  status: 429,
+                  headers:
+                    provider === "claude"
+                      ? {
+                          "anthropic-ratelimit-unified-5h-status": "rejected",
+                          "anthropic-ratelimit-unified-5h-reset": String(
+                            now / 1000 + 60,
+                          ),
+                        }
+                      : {
+                          "x-codex-primary-over-limit": "true",
+                          "x-codex-primary-reset-after-seconds": "60",
+                        },
+                },
+              );
+            return attempts.length === 1 ? openStream() : Response.json({});
+          },
+          () => now,
+        );
+        const send = (id: string) =>
+          fixture.host.harness.behavior.fetchHttp(
+            "POST",
+            provider === "claude" ? "/v1/messages" : "/v1/responses",
+            {
+              headers: { ...authHeaders(fixture.key), "thread-id": id },
+              body: provider === "claude" ? claudeBody(id) : "{}",
+            },
+          );
+        const first = await send("original");
+        try {
+          await (await send("new-while-busy")).text();
+          expect(attempts).toEqual(["sk-first", "sk-first"]);
+          rejected = "sk-first";
+          await (await send("failover")).text();
+          now += 60_000;
+          rejected = null;
+          await (await send("new-after-recovery")).text();
+          await (await send("original")).text();
+          await (await send("another-new")).text();
+          expect(attempts).toEqual([
+            "sk-first",
+            "sk-first",
+            "sk-first",
+            "sk-second",
+            "sk-second",
+            "sk-first",
+            "sk-second",
+          ]);
+          rejected = "sk-second";
+          await (await send("wrap")).text();
+          expect(attempts.slice(-2)).toEqual(["sk-second", "sk-first"]);
+        } finally {
+          await first.body?.cancel();
+        }
+      },
+    );
 
     it.each(["claude", "codex"] as const)(
       "handles %s quota exhaustion and reset with session affinity",
@@ -3545,6 +3870,80 @@ describe("Account Pool plugin", () => {
         };
       }
 
+      it.each<Wire>(["claude", "codex-fork"])(
+        "keeps a fork on its short-held parent account over %s",
+        async (wire) => {
+          const provider = wire === "claude" ? "claude" : "codex";
+          const attempts: Array<string | null> = [];
+          const fixture = await affinityFixture(
+            provider,
+            async (_input, init) => {
+              const headers = new Headers(init?.headers);
+              attempts.push(
+                headers.get("x-api-key") ??
+                  headers.get("authorization")?.slice(7) ??
+                  null,
+              );
+              return attempts.length === 3
+                ? Response.json(
+                    {},
+                    { status: 429, headers: { "retry-after": "0.25" } },
+                  )
+                : Response.json({});
+            },
+            Date.now,
+          );
+          const send = (own: string, parent: string | null) => {
+            const request = forkRequest(wire, own, parent);
+            return fixture.host.harness.behavior.fetchHttp(
+              "POST",
+              provider === "claude" ? "/v1/messages" : "/v1/responses",
+              {
+                headers: { ...authHeaders(fixture.key), ...request.headers },
+                body: request.body,
+              },
+            );
+          };
+          await (await send("parent", null)).text();
+          await movePoolToOtherAccount(fixture, provider);
+          const paced = send("parent", null);
+          try {
+            await vi.waitFor(
+              async () => {
+                const status = statusSchema.parse(
+                  await fixture.host.harness.behavior.callRpc(
+                    "status.get",
+                    null,
+                  ),
+                );
+                expect(
+                  status.accounts.find(
+                    (account) => account.id === fixture.account.id,
+                  )?.status,
+                ).toBe("held");
+              },
+              { interval: 5 },
+            );
+            const child = await send("child", "parent");
+            expect(child.status).toBe(200);
+            await child.text();
+            await (await paced).text();
+            await (await send("child", "parent")).text();
+            expect(attempts).toEqual([
+              "sk-first",
+              "sk-second",
+              "sk-first",
+              "sk-first",
+              "sk-first",
+              "sk-first",
+            ]);
+          } finally {
+            const response = await paced;
+            if (!response.bodyUsed) await response.text();
+          }
+        },
+      );
+
       it.each<Wire>([
         "claude",
         "codex-fork",
@@ -3658,6 +4057,8 @@ describe("Account Pool plugin", () => {
                 },
               );
               try {
+                await movePoolToOtherAccount(fixture, provider);
+                attempts.splice(1);
                 if (reason === "disabled")
                   await fixture.host.harness.behavior.callRpc(
                     "account.disable",
@@ -3718,6 +4119,8 @@ describe("Account Pool plugin", () => {
             };
             const held = await send("parent-session", null);
             try {
+              await movePoolToOtherAccount(fixture, provider);
+              attempts.splice(1);
               now += 29 * 60 * 1_000;
               await (await send("child-session", "parent-session")).text();
               now += 2 * 60 * 1_000;
@@ -3766,6 +4169,8 @@ describe("Account Pool plugin", () => {
           ),
         ];
         try {
+          await movePoolToOtherAccount(fixture, "codex");
+          attempts.splice(2);
           const request = forkRequest(
             "codex-fork",
             "child-session",
@@ -3884,7 +4289,13 @@ describe("Account Pool plugin", () => {
               ? (await resolveCodexToken(fixture.host, "host-two")).token
               : await resolveToken(fixture.host, "host-two");
           expect(await send(fixture.key, body)).toBe(keyFor("sk-first"));
+          await fixture.host.harness.behavior.callRpc("account.disable", {
+            id: fixture.account.id,
+          });
           expect(await send(otherHost, body)).toBe(keyFor("sk-second"));
+          await fixture.host.harness.behavior.callRpc("account.enable", {
+            id: fixture.account.id,
+          });
           expect(await send(fixture.key, "{}", {})).toBe(keyFor("sk-second"));
           now += 29 * 60 * 1_000;
           expect(await send(fixture.key, body)).toBe(keyFor("sk-first"));
@@ -3913,6 +4324,8 @@ describe("Account Pool plugin", () => {
         },
       );
       try {
+        await movePoolToOtherAccount(fixture, "codex");
+        attempts.splice(1);
         const variants: Array<Record<string, string>> = [
           {},
           { session_id: sessionId },
@@ -3946,7 +4359,7 @@ describe("Account Pool plugin", () => {
       "disabled account",
       "network error",
     ])(
-      "rebinds after %s without letting an older response completion restore the binding",
+      "preserves the correct binding after %s despite an older response completion",
       async (reason) => {
         const attempts: Array<string | null> = [];
         let finishOld = () => {};
@@ -4030,7 +4443,11 @@ describe("Account Pool plugin", () => {
           expect(attempts).toEqual(
             reason === "auth error" || reason === "network error"
               ? ["sk-first", "sk-first", "sk-second", "sk-second"]
-              : ["sk-first", "sk-second", "sk-second"],
+              : [
+                  "sk-first",
+                  "sk-second",
+                  reason === "family quota" ? "sk-first" : "sk-second",
+                ],
           );
         } finally {
           finishOld();
@@ -4307,7 +4724,7 @@ describe("Account Pool plugin", () => {
       }
     });
 
-    it("isolates provider bindings and clears them on hub restart", async () => {
+    it("isolates provider bindings and retains them on hub restart", async () => {
       const attempts: Array<string | null> = [];
       const started = new Set<string>();
       const fixture = await affinityFixture("codex", async (_input, init) => {
@@ -4372,8 +4789,8 @@ describe("Account Pool plugin", () => {
           "Bearer sk-first",
           "sk-claude-first",
           "Bearer sk-first",
-          "sk-claude-second",
-          "Bearer sk-second",
+          "sk-claude-first",
+          "Bearer sk-first",
         ]);
       } finally {
         for (const response of held)
@@ -4396,7 +4813,7 @@ describe("Account Pool plugin", () => {
           },
         },
       });
-      await addApiAccount(fixture, "sk-second");
+      const second = await addApiAccount(fixture, "sk-second");
       const send = async (id: string) => {
         const response = await fixture.host.harness.behavior.fetchHttp(
           "POST",
@@ -4418,12 +4835,14 @@ describe("Account Pool plugin", () => {
         },
       );
       try {
+        await movePoolToOtherAccount(fixture, "claude");
         for (let index = 1; index < 4096; index += 1)
           await send(`session-${index}`);
         const touched = await send("oldest");
         await send("newest");
         const retained = await send("oldest");
         await held.body?.cancel();
+        await movePoolToOtherAccount(fixture, "claude", second.id);
         const nextOldest = await send("session-2");
         const evicted = await send("session-1");
         expect([touched, retained, nextOldest, evicted]).toEqual([
@@ -4603,9 +5022,8 @@ describe("Account Pool plugin", () => {
       await vi.waitFor(() => {
         expect(refreshes).toEqual(["refresh-1"]);
       });
-      await fixture.host.harness.behavior.callRpc("account.setPriority", {
-        accountId: second.id,
-        priority: 0,
+      await fixture.host.harness.behavior.callRpc("account.disable", {
+        id: fixture.account.id,
       });
       requests.push(
         fixture.host.harness.behavior.fetchHttp("POST", "/v1/messages", {
@@ -5041,5 +5459,304 @@ describe("Account Pool plugin", () => {
       { headers: authHeaders(fixture.key), body: "{}" },
     );
     expect(rejected.status).toBe(503);
+  });
+});
+
+describe("sequential pool recovery", () => {
+  const body = JSON.stringify({
+    model: "claude-opus-4-1",
+    metadata: { user_id: JSON.stringify({ session_id: "review-session" }) },
+  });
+
+  it("bounds repeated waits when a session's rate-limit hold keeps extending", async () => {
+    let attempts = 0;
+    const fixture = await createFixture({
+      upstreamUrl: "https://upstream.example",
+      options: {
+        now: () => 1_800_000_000_000,
+        fetch: async () =>
+          ++attempts === 1
+            ? Response.json({})
+            : Response.json(
+                {},
+                { status: 429, headers: { "retry-after": "0.01" } },
+              ),
+      },
+    });
+    const send = () =>
+      fixture.host.harness.behavior.fetchHttp("POST", "/v1/messages", {
+        headers: authHeaders(fixture.key),
+        body,
+        signal: AbortSignal.timeout(1_000),
+      });
+    await (await send()).text();
+    const paced = await send();
+    expect(paced.status).toBe(429);
+    await paced.text();
+    const held = await send();
+    expect(held.status).toBe(429);
+    await held.text();
+    expect(attempts).toBe(3);
+  });
+
+  it("keeps a paced session on its account when another request arrives during a short hold", async () => {
+    const attempts: Array<string | null> = [];
+    const fixture = await createFixture({
+      upstreamUrl: "https://upstream.example",
+      apiKey: "sk-first",
+      options: {
+        fetch: async (_input, init) => {
+          attempts.push(new Headers(init?.headers).get("x-api-key"));
+          return attempts.length === 2
+            ? Response.json(
+                {},
+                { status: 429, headers: { "retry-after": "0.25" } },
+              )
+            : Response.json({});
+        },
+      },
+    });
+    await addApiAccount(fixture, "sk-second");
+    const send = () =>
+      fixture.host.harness.behavior.fetchHttp("POST", "/v1/messages", {
+        headers: authHeaders(fixture.key),
+        body,
+      });
+    await (await send()).text();
+    const paced = send();
+    try {
+      await vi.waitFor(async () => {
+        const status = statusSchema.parse(
+          await fixture.host.harness.behavior.callRpc("status.get", null),
+        );
+        expect(
+          status.accounts.find((account) => account.id === fixture.account.id)
+            ?.status,
+        ).toBe("held");
+      });
+      await (await send()).text();
+      await (await paced).text();
+      await (await send()).text();
+      expect(attempts).toEqual([
+        "sk-first",
+        "sk-first",
+        "sk-first",
+        "sk-first",
+        "sk-first",
+      ]);
+    } finally {
+      const response = await paced;
+      if (!response.bodyUsed) await response.text();
+    }
+  });
+
+  it("keeps the last working binding after every account fails during a provider outage", async () => {
+    const attempts: Array<string | null> = [];
+    let outage = false;
+    const fixture = await createFixture({
+      upstreamUrl: "https://upstream.example",
+      apiKey: "sk-first",
+      options: {
+        fetch: async (_input, init) => {
+          attempts.push(new Headers(init?.headers).get("x-api-key"));
+          return Response.json({}, { status: outage ? 503 : 200 });
+        },
+      },
+    });
+    await addApiAccount(fixture, "sk-second");
+    const send = () =>
+      fixture.host.harness.behavior.fetchHttp("POST", "/v1/messages", {
+        headers: authHeaders(fixture.key),
+        body,
+      });
+    await (await send()).text();
+    outage = true;
+    const failed = await send();
+    expect(failed.status).toBe(503);
+    await failed.text();
+    outage = false;
+    await (await send()).text();
+    expect(attempts).toEqual(["sk-first", "sk-first", "sk-second", "sk-first"]);
+  });
+
+  it("keeps Codex over-limit accounts ineligible until reset when utilization is omitted", async () => {
+    let imported = 0;
+    const attempts: Array<string | null> = [];
+    const fixture = await createFixture({
+      upstreamUrl: "https://upstream.example",
+      provider: "codex",
+      source: "import",
+      options: {
+        codexUsageUrl: EMPTY_USAGE_URL,
+        importCodexCredentials: async () => ({
+          accessToken: imported++ === 0 ? "sk-first" : "sk-second",
+          refreshToken: "refresh",
+          idToken: null,
+          accountId: `review-codex-account-${imported}`,
+          email: null,
+          expiresAt: Date.now() + 24 * 60 * 60 * 1_000,
+        }),
+        fetch: async (input, init) => {
+          if (String(input) === EMPTY_USAGE_URL) return Response.json({});
+          const key = new Headers(init?.headers).get("authorization");
+          attempts.push(key);
+          return key === "Bearer sk-first"
+            ? Response.json(
+                {},
+                {
+                  status: 429,
+                  headers: {
+                    "x-codex-primary-over-limit": "true",
+                    "x-codex-primary-reset-after-seconds": "60",
+                    "x-codex-primary-window-minutes": "300",
+                  },
+                },
+              )
+            : Response.json({});
+        },
+      },
+    });
+    await fixture.host.harness.behavior.callRpc("account.add", {
+      provider: "codex",
+      source: { kind: "import" },
+      label: null,
+      priority: 100,
+    });
+    for (const session of ["first-session", "second-session"]) {
+      const response = await fixture.host.harness.behavior.fetchHttp(
+        "POST",
+        "/v1/responses",
+        {
+          headers: { ...authHeaders(fixture.key), "thread-id": session },
+          body: "{}",
+        },
+      );
+      expect(response.status).toBe(200);
+      await response.text();
+    }
+    expect(attempts).toEqual([
+      "Bearer sk-first",
+      "Bearer sk-second",
+      "Bearer sk-second",
+    ]);
+    const status = statusSchema.parse(
+      await fixture.host.harness.behavior.callRpc("status.get", null),
+    );
+    expect(
+      status.accounts.find((account) => account.id === fixture.account.id)
+        ?.status,
+    ).toBe("exhausted");
+  });
+  it("applies reordered failover atomically without moving current conversations", async () => {
+    const attempts: Array<string | null> = [];
+    let rejectFirst = false;
+    let rejectThird = false;
+    const fixture = await createFixture({
+      upstreamUrl: "https://upstream.example",
+      apiKey: "sk-first",
+      options: {
+        fetch: async (_input, init) => {
+          const key = new Headers(init?.headers).get("x-api-key");
+          attempts.push(key);
+          return Response.json(
+            {},
+            {
+              status:
+                (key === "sk-first" && rejectFirst) ||
+                (key === "sk-third" && rejectThird)
+                  ? 503
+                  : 200,
+            },
+          );
+        },
+      },
+    });
+    const second = await addApiAccount(fixture, "sk-second");
+    const third = await addApiAccount(fixture, "sk-third");
+    const send = async (session: string) => {
+      const response = await fixture.host.harness.behavior.fetchHttp(
+        "POST",
+        "/v1/messages",
+        {
+          headers: authHeaders(fixture.key),
+          body: JSON.stringify({
+            metadata: { user_id: JSON.stringify({ session_id: session }) },
+          }),
+        },
+      );
+      expect(response.status).toBe(200);
+      await response.text();
+    };
+    await send("original");
+    const reorder = await fixture.host.harness.behavior.runCli([
+      "account",
+      "reorder",
+      "claude",
+      fixture.account.id,
+      third.id,
+      second.id,
+    ]);
+    expect(reorder.exitCode).toBe(0);
+    const ordered = z
+      .array(accountSummarySchema)
+      .parse(await fixture.host.harness.behavior.callRpc("account.list", null));
+    expect(ordered.map((account) => account.id)).toEqual([
+      fixture.account.id,
+      third.id,
+      second.id,
+    ]);
+    const persisted = z
+      .array(accountSchema)
+      .parse(await fixture.host.bb.storage.kv.get("accounts:v1"));
+    expect(
+      persisted.find((account) => account.id === third.id)?.priority,
+    ).toBeLessThan(
+      persisted.find((account) => account.id === second.id)?.priority ?? 0,
+    );
+    for (const accountIds of [
+      [fixture.account.id],
+      [fixture.account.id, third.id, third.id],
+      [fixture.account.id, third.id, "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"],
+    ]) {
+      await expect(
+        fixture.host.harness.behavior.callRpc("account.reorder", {
+          provider: "claude",
+          accountIds,
+        }),
+      ).rejects.toThrow("exactly once");
+    }
+    expect(await fixture.host.bb.storage.kv.get("accounts:v1")).toEqual(
+      persisted,
+    );
+    await send("new-before-failover");
+    rejectFirst = true;
+    await send("advance");
+    rejectFirst = false;
+    await send("new-after-recovery");
+    rejectThird = true;
+    await send("advance-again");
+    expect(attempts).toEqual([
+      "sk-first",
+      "sk-first",
+      "sk-first",
+      "sk-third",
+      "sk-third",
+      "sk-third",
+      "sk-second",
+    ]);
+    const priority = await fixture.host.harness.behavior.runCli([
+      "account",
+      "priority",
+      second.id,
+      "0",
+    ]);
+    expect(priority.exitCode).toBe(0);
+    expect(
+      z
+        .array(accountSummarySchema)
+        .parse(
+          await fixture.host.harness.behavior.callRpc("account.list", null),
+        )[0]?.id,
+    ).toBe(second.id);
   });
 });

--- a/plugins/account-pool/src/server.ts
+++ b/plugins/account-pool/src/server.ts
@@ -23,6 +23,7 @@ import {
 import {
   AccountStore,
   HubTokenStore,
+  PoolAffinityStore,
   QUOTA_MIGRATIONS,
   QuotaStore,
   RoutingStore,
@@ -95,6 +96,7 @@ export function createAccountPoolPlugin(
     const hub = createHub({
       accounts,
       quotas,
+      affinity: new PoolAffinityStore(db),
       hubTokens,
       getSettings: () => currentSettings,
       fetch: options.fetch,

--- a/plugins/account-pool/src/store.ts
+++ b/plugins/account-pool/src/store.ts
@@ -8,11 +8,13 @@ import {
   accountSchema,
   accountSecretSchema,
   hubTokenSummarySchema,
+  providerSchema,
   quotaSchema,
   type Account,
   type AccountQuota,
   type AccountSecret,
   type HubTokenSummary,
+  type PoolProvider,
 } from "./contracts.js";
 
 const ACCOUNTS_KEY = "accounts:v1";
@@ -125,6 +127,34 @@ export class AccountStore {
 
   async setPriority(id: string, priority: number): Promise<Account | null> {
     return this.update(id, (account) => ({ ...account, priority }));
+  }
+
+  async reorder(provider: PoolProvider, accountIds: string[]): Promise<void> {
+    return this.serialized(async () => {
+      const accounts = await this.list();
+      const current = accounts.filter(
+        (account) => account.provider === provider,
+      );
+      const positions = new Map(accountIds.map((id, index) => [id, index]));
+      if (
+        positions.size !== accountIds.length ||
+        current.length !== positions.size ||
+        current.some((account) => !positions.has(account.id))
+      ) {
+        throw new Error(
+          "Include every account for this provider exactly once. Refresh the account list and try again.",
+        );
+      }
+      await this.kv.set(
+        ACCOUNTS_KEY,
+        accounts.map((account) => {
+          const position = positions.get(account.id);
+          return position === undefined
+            ? account
+            : { ...account, priority: position + 1 };
+        }),
+      );
+    });
   }
 
   async recordUsed(
@@ -633,6 +663,85 @@ export class QuotaStore {
   }
 }
 
+const affinityRowSchema = z.object({
+  affinity_key: z.string(),
+  account_id: z.string().uuid(),
+  last_used_at: z.number().int(),
+});
+
+const activeAccountRowSchema = z.object({
+  provider: providerSchema,
+  account_id: z.string().uuid(),
+});
+
+export interface AccountBinding {
+  accountId: string;
+  lastUsedAt: number;
+}
+
+export class PoolAffinityStore {
+  constructor(private readonly db: Database.Database) {}
+
+  loadBindings(since: number, limit: number): Map<string, AccountBinding> {
+    this.db
+      .prepare("DELETE FROM pool_affinity WHERE last_used_at <= ?")
+      .run(since);
+    this.db
+      .prepare(
+        `DELETE FROM pool_affinity WHERE affinity_key NOT IN (
+        SELECT affinity_key FROM pool_affinity ORDER BY last_used_at DESC, rowid DESC LIMIT ?
+      )`,
+      )
+      .run(limit);
+    return new Map(
+      z
+        .array(affinityRowSchema)
+        .parse(
+          this.db
+            .prepare("SELECT * FROM pool_affinity ORDER BY last_used_at, rowid")
+            .all(),
+        )
+        .map((row) => [
+          row.affinity_key,
+          { accountId: row.account_id, lastUsedAt: row.last_used_at },
+        ]),
+    );
+  }
+
+  loadActiveAccounts(): Map<PoolProvider, { accountId: string }> {
+    return new Map(
+      z
+        .array(activeAccountRowSchema)
+        .parse(this.db.prepare("SELECT * FROM pool_active_account").all())
+        .map((row) => [row.provider, { accountId: row.account_id }]),
+    );
+  }
+
+  putBinding(key: string, binding: AccountBinding): void {
+    this.db
+      .prepare(
+        `INSERT INTO pool_affinity (affinity_key, account_id, last_used_at) VALUES (?, ?, ?)
+       ON CONFLICT(affinity_key) DO UPDATE SET account_id = excluded.account_id, last_used_at = excluded.last_used_at`,
+      )
+      .run(key, binding.accountId, binding.lastUsedAt);
+  }
+
+  removeBinding(key: string): void {
+    this.db
+      .prepare("DELETE FROM pool_affinity WHERE affinity_key = ?")
+      .run(key);
+  }
+
+  putActiveAccount(provider: PoolProvider, accountId: string): void {
+    this.db
+      .prepare(
+        `INSERT INTO pool_active_account (provider, account_id) VALUES (?, ?)
+       ON CONFLICT(provider) DO UPDATE SET account_id = excluded.account_id`,
+      )
+      .run(provider, accountId);
+  }
+}
+
 export const QUOTA_MIGRATIONS = [
   `CREATE TABLE account_quota (
     account_id TEXT PRIMARY KEY,
@@ -650,4 +759,13 @@ export const QUOTA_MIGRATIONS = [
   )`,
   `ALTER TABLE account_quota ADD COLUMN family_weekly_json TEXT NOT NULL DEFAULT '{"fable":null,"sonnet":null,"opus":null,"haiku":null,"other":null}'`,
   `ALTER TABLE account_quota ADD COLUMN limit_windows_json TEXT NOT NULL DEFAULT '[]'`,
+  `CREATE TABLE pool_affinity (
+    affinity_key TEXT PRIMARY KEY,
+    account_id TEXT NOT NULL,
+    last_used_at INTEGER NOT NULL
+  );
+  CREATE TABLE pool_active_account (
+    provider TEXT PRIMARY KEY,
+    account_id TEXT NOT NULL
+  )`,
 ];


### PR DESCRIPTION
## Human comments

## What was wrong

New conversations could spread across equally ranked accounts, and account selection could return to an earlier account after recovery. Session pins were lost on hub restart, while failed attempts and temporary rate limits could move conversations unnecessarily. These account changes risk losing prompt-cache reuse. Codex could also ignore a fresh over-limit signal when utilization was omitted or a previous reset timestamp had already expired.

## What changed

- Run Claude and Codex accounts sequentially by priority, then order added. Keep the current fallback for new conversations until it becomes unavailable; existing conversations retain their own pins. Commit failover only after a successful response, with concurrency guards against stale completions.
- Persist the current account and session pins in the plugin database. Keep the existing 30-minute idle expiry and 4,096-pin limit. Wait once for short rate limits, preserve parent affinity for forks, and let new conversations bypass long holds. Model-family limits detour only that family's requests without moving the main pin.
- Add account-order arrows in settings, `bb pool account reorder` and `priority`, and the matching plugin RPC surface. Update the CLI help, guide, skill, and configuration documentation.
- Honor Codex over-limit headers without utilization and stop inheriting expired reset timestamps. The shared routing behavior covers Claude and Codex, including Codex HTTP and WebSocket requests. No server/daemon wire changes.

## How you verified

- `pnpm exec turbo run test typecheck --filter=bb-plugin-account-pool`: 250 tests pass; typecheck passes.
- Regression coverage includes three-account failover and recovery, stale concurrent completions, all-account outages, short and long holds, fork inheritance, full plugin reloads, and provider-specific UI/CLI ordering. The Codex expired-reset and held-parent fork tests were observed failing before their fixes and passing afterward.
- Plugin server and app bundles built through Turbo using the plugin build CLI.
- Independent review approved the final routing, persistence, concurrency, and prompt-cache handling. Actual upstream cache hit rates were not measured.
- Secret-model scan clean: zero EAP codename mentions in the working tree, tracked HEAD, added lines, or commit messages in `origin/main..HEAD`.

> AGENT GENERATED
