### PR TITLE
Add @vznh to contributor allow list

### DIFF
--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -65,3 +65,4 @@ swairshah
 danielbachhuber
 aivanov93
 MayankBansal12
+vznh


### PR DESCRIPTION
## Human comments

## What was wrong

GitHub user `vznh` was not in the persistent contributor allow list, so the PR approval gate would not treat contributions from their fork as approved.

## What changed

Added `vznh` to `.github/APPROVED_CONTRIBUTORS`. This is a policy-only change with no host daemon wire, CLI, guide, or documentation impact.

## How you verified

- Confirmed the GitHub account exists (`gh api users/vznh` returns login vznh).
- Ran `git diff --check`.
- Checked the contributor list for case-insensitive duplicates.

> AGENT GENERATED