### PR TITLE
Share changelog metadata with the app

### DIFF
--- a/apps/app/src/components/settings/UpdatesSettingsSection.tsx
+++ b/apps/app/src/components/settings/UpdatesSettingsSection.tsx
@@ -52,9 +52,9 @@ import {
   subscribeAppUpdateCheck,
 } from "@/components/settings/app-update-check-store";
 import {
-  CHANGELOG_RELEASE_META,
   fetchLatestChangelogEntry,
   LATEST_CHANGELOG_ENTRY,
+  RELEASE_META,
   type ChangelogBlock,
 } from "@/components/settings/changelog-preview";
 import { appToast } from "@/components/ui/app-toast";
@@ -547,7 +547,7 @@ export function ChangelogPreviewCard() {
   ) {
     return null;
   }
-  const releaseMeta = CHANGELOG_RELEASE_META[entry.version];
+  const releaseMeta = RELEASE_META[entry.version];
   const dismissalPhase =
     dismissal?.version === entry.version ? dismissal.phase : "visible";
   const releaseVisible = dismissalPhase === "visible";

--- a/apps/app/src/components/settings/changelog-preview.test.ts
+++ b/apps/app/src/components/settings/changelog-preview.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   CHANGELOG_ENTRIES,
   LATEST_CHANGELOG_ENTRY,
+  RELEASE_META,
   parseChangelogEntries,
 } from "./changelog-preview";
 
@@ -91,5 +92,13 @@ describe("LATEST_CHANGELOG_ENTRY", () => {
     expect(CHANGELOG_ENTRIES.length).toBeGreaterThan(0);
     expect(LATEST_CHANGELOG_ENTRY?.version).toMatch(/^\d+\.\d+\.\d+/);
     expect(LATEST_CHANGELOG_ENTRY?.sections.length).toBeGreaterThan(0);
+  });
+
+  it("has presentation metadata for the newest release", () => {
+    expect(
+      LATEST_CHANGELOG_ENTRY === null
+        ? undefined
+        : RELEASE_META[LATEST_CHANGELOG_ENTRY.version],
+    ).toBeDefined();
   });
 });

--- a/apps/app/src/components/settings/changelog-preview.ts
+++ b/apps/app/src/components/settings/changelog-preview.ts
@@ -1,4 +1,5 @@
 import changelogSource from "../../../../../CHANGELOG.md?raw";
+export { RELEASE_META } from "../../../../../changelog-metadata";
 
 const LATEST_CHANGELOG_SOURCE_URL =
   "https://raw.githubusercontent.com/get-bb/bb/main/CHANGELOG.md";
@@ -17,48 +18,6 @@ interface ChangelogEntry {
   lede: ChangelogBlock[];
   sections: ChangelogSection[];
 }
-
-interface ChangelogReleaseMeta {
-  date: string;
-  headline: string;
-}
-
-export const CHANGELOG_RELEASE_META: Record<string, ChangelogReleaseMeta> = {
-  "0.39.0": {
-    date: "August 19, 2026",
-    headline: "Faster large threads and a long list of fixes",
-  },
-  "0.38.0": {
-    date: "August 15, 2026",
-    headline: "Extensions Page and Plugin Marketplaces",
-  },
-  "0.37.0": {
-    date: "August 11, 2026",
-    headline: "A much faster mobile app",
-  },
-  "0.36.0": {
-    date: "August 8, 2026",
-    headline: "Fixes and improvements",
-  },
-  "0.35.0": { date: "August 4, 2026", headline: "Plugins" },
-  "0.34.0": {
-    date: "July 28, 2026",
-    headline: "Fresher models, cross-provider questions",
-  },
-  "0.33.0": {
-    date: "July 21, 2026",
-    headline: "Quieter updates and safer approvals",
-  },
-  "0.0.31": { date: "July 17, 2026", headline: "Splits for everyone" },
-  "0.0.30": {
-    date: "July 14, 2026",
-    headline: "Multi-machine workflows and bb Connect",
-  },
-  "0.0.29": {
-    date: "July 9, 2026",
-    headline: "More agents, more models, redesigned Settings",
-  },
-};
 
 export function parseChangelogEntries(source: string): ChangelogEntry[] {
   const entries: ChangelogEntry[] = [];

--- a/apps/app/tsconfig.json
+++ b/apps/app/tsconfig.json
@@ -10,7 +10,7 @@
     "paths": {
       "@/*": ["./src/*"]
     },
-    "rootDir": ".",
+    "rootDir": "../..",
     // Pin auto-included global type packages (like the sibling apps do):
     // without this, tsc walks up past the repo and pulls in whatever
     // @types happen to sit in ancestor node_modules (e.g. @types/bun in

--- a/apps/web/src/landing/changelog.ts
+++ b/apps/web/src/landing/changelog.ts
@@ -13,66 +13,6 @@ export type Release = {
   sections: ReleaseSection[];
 };
 
-type ReleaseMeta = {
-  date: string;
-  headline: string;
-};
-
-export const RELEASE_META: Record<string, ReleaseMeta> = {
-  "0.42.0": {
-    date: "September 5, 2026",
-    headline: "Account Pooler, push notifications, and a new plugin catalog",
-  },
-  "0.41.0": {
-    date: "September 1, 2026",
-    headline: "Scheduled sends, concurrency limits, and a rebuilt mobile app",
-  },
-  "0.40.0": {
-    date: "August 26, 2026",
-    headline: "File Editor, quick palette, and agent providers",
-  },
-  "0.39.0": {
-    date: "August 19, 2026",
-    headline: "Faster large threads and a long list of fixes",
-  },
-  "0.38.0": {
-    date: "August 15, 2026",
-    headline: "Extensions Page and Plugin Marketplaces",
-  },
-  "0.37.0": {
-    date: "August 11, 2026",
-    headline: "A much faster mobile app",
-  },
-  "0.36.0": {
-    date: "August 8, 2026",
-    headline: "Fixes and improvements",
-  },
-  "0.35.0": {
-    date: "August 4, 2026",
-    headline: "Plugins",
-  },
-  "0.34.0": {
-    date: "July 28, 2026",
-    headline: "Fresher models, cross-provider questions",
-  },
-  "0.33.0": {
-    date: "July 21, 2026",
-    headline: "Quieter updates and safer approvals",
-  },
-  "0.0.31": {
-    date: "July 17, 2026",
-    headline: "Splits for everyone",
-  },
-  "0.0.30": {
-    date: "July 14, 2026",
-    headline: "Multi-machine workflows and bb Connect",
-  },
-  "0.0.29": {
-    date: "July 9, 2026",
-    headline: "More agents, more models, redesigned Settings",
-  },
-};
-
 export function parseChangelog(markdown: string): Release[] {
   const releases: Release[] = [];
   let release: Release | null = null;

--- a/apps/web/src/routes/changelog.tsx
+++ b/apps/web/src/routes/changelog.tsx
@@ -5,9 +5,10 @@ import { Fragment, useEffect } from "react";
 import type { ReactNode } from "react";
 
 import changelogMd from "../../../../CHANGELOG.md?raw";
+import { RELEASE_META } from "../../../../changelog-metadata";
 import { initAnalytics } from "../landing/analytics";
 import type { Release, ReleaseBlock } from "../landing/changelog";
-import { RELEASE_META, parseChangelog } from "../landing/changelog";
+import { parseChangelog } from "../landing/changelog";
 import { ChangelogInline } from "../landing/changelog-inline";
 import {
   EmailSignup,

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -32,6 +32,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, ReactNode } from "react";
 
 import changelogMd from "../../../../CHANGELOG.md?raw";
+import { RELEASE_META } from "../../../../changelog-metadata";
 import { initAnalytics, trackLandingEvent } from "../landing/analytics";
 import blackstoneLogo from "../assets/company-logos/blackstone.png";
 import datadogLogo from "../assets/company-logos/datadog.svg";
@@ -46,7 +47,7 @@ import shortcutLogo from "../assets/company-logos/shortcut.svg";
 import simileLogo from "../assets/company-logos/simile.svg";
 import hermesAvatar from "../assets/hermes-avatar.jpg";
 import vscodeIcon from "../assets/vscode.png";
-import { RELEASE_META, parseChangelog } from "../landing/changelog";
+import { parseChangelog } from "../landing/changelog";
 import { CommandButton } from "../landing/command-button";
 import {
   DiscordLink,

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": ["@bb/tsconfig/base.json"],
   "compilerOptions": {
-    "rootDir": ".",
+    "rootDir": "../..",
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "jsx": "react-jsx",

--- a/changelog-metadata.ts
+++ b/changelog-metadata.ts
@@ -1,0 +1,59 @@
+type ReleaseMeta = {
+  date: string;
+  headline: string;
+};
+
+export const RELEASE_META: Record<string, ReleaseMeta> = {
+  "0.42.0": {
+    date: "September 5, 2026",
+    headline: "Account Pooler, push notifications, and a new plugin catalog",
+  },
+  "0.41.0": {
+    date: "September 1, 2026",
+    headline: "Scheduled sends, concurrency limits, and a rebuilt mobile app",
+  },
+  "0.40.0": {
+    date: "August 26, 2026",
+    headline: "File Editor, quick palette, and agent providers",
+  },
+  "0.39.0": {
+    date: "August 19, 2026",
+    headline: "Faster large threads and a long list of fixes",
+  },
+  "0.38.0": {
+    date: "August 15, 2026",
+    headline: "Extensions Page and Plugin Marketplaces",
+  },
+  "0.37.0": {
+    date: "August 11, 2026",
+    headline: "A much faster mobile app",
+  },
+  "0.36.0": {
+    date: "August 8, 2026",
+    headline: "Fixes and improvements",
+  },
+  "0.35.0": {
+    date: "August 4, 2026",
+    headline: "Plugins",
+  },
+  "0.34.0": {
+    date: "July 28, 2026",
+    headline: "Fresher models, cross-provider questions",
+  },
+  "0.33.0": {
+    date: "July 21, 2026",
+    headline: "Quieter updates and safer approvals",
+  },
+  "0.0.31": {
+    date: "July 17, 2026",
+    headline: "Splits for everyone",
+  },
+  "0.0.30": {
+    date: "July 14, 2026",
+    headline: "Multi-machine workflows and bb Connect",
+  },
+  "0.0.29": {
+    date: "July 9, 2026",
+    headline: "More agents, more models, redesigned Settings",
+  },
+};

--- a/docs/bb-release-process.md
+++ b/docs/bb-release-process.md
@@ -113,10 +113,11 @@ If any input is unclear, ask before bumping the version.
 
 4. Update the release notes. Add the new version's section to the repo-root
    `CHANGELOG.md`, and add its entry (ship date and headline) to
-   `RELEASE_META` in `apps/web/src/landing/changelog.ts`. The marketing site's
-   `/changelog` page renders `CHANGELOG.md` at build time, so both must land
-   before the release is published — redeploy `@bb/web` after the release
-   commit lands so the site shows the new version.
+   `RELEASE_META` in the repo-root `changelog-metadata.ts`. The marketing site's
+   `/changelog` page and the optional in-app Updates preview consume these
+   shared files, so both changes must land before the release is published —
+   redeploy `@bb/web` after the release commit lands so the site shows the new
+   version.
 
 5. Make any release documentation updates requested by the user.
 
@@ -124,7 +125,7 @@ If any input is unclear, ask before bumping the version.
 
    ```bash
    node .github/workflows/check-version-lockstep.mjs
-   pnpm exec turbo run typecheck test --filter=@bb/config --filter=@bb/server --filter=bb-app
+   pnpm exec turbo run typecheck test --filter=@bb/app --filter=@bb/config --filter=@bb/server --filter=bb-app
    pnpm exec turbo run smoke:tarball --filter=bb-app --force
    git diff --check
    ```

--- a/turbo.json
+++ b/turbo.json
@@ -4,6 +4,8 @@
     "@bb/web#build": {
       "inputs": [
         "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/CHANGELOG.md",
+        "$TURBO_ROOT$/changelog-metadata.ts",
         "$TURBO_ROOT$/apps/web/package.json",
         "$TURBO_ROOT$/apps/web/src/**",
         "$TURBO_ROOT$/apps/web/tsconfig.json",
@@ -26,6 +28,8 @@
       "dependsOn": ["//#ensure-native-modules", "topo"],
       "inputs": [
         "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/CHANGELOG.md",
+        "$TURBO_ROOT$/changelog-metadata.ts",
         "$TURBO_ROOT$/packages/plugin-api-map/src/anatomy-manifest.json",
         "$TURBO_ROOT$/vitest.shared.ts"
       ]
@@ -33,10 +37,7 @@
     // The Plugin Guide's API inventory is checked against the SDK's committed
     // declarations, so those files are inputs to this test.
     "@bb/plugin-api-map#test": {
-      "dependsOn": [
-        "//#ensure-native-modules",
-        "topo"
-      ],
+      "dependsOn": ["//#ensure-native-modules", "topo"],
       "inputs": [
         "$TURBO_DEFAULT$",
         // wireframes.test.ts asserts fixture fidelity against the real app
@@ -56,6 +57,8 @@
       "dependsOn": ["topo"],
       "inputs": [
         "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/CHANGELOG.md",
+        "$TURBO_ROOT$/changelog-metadata.ts",
         "$TURBO_ROOT$/package.json",
         "$TURBO_ROOT$/packages/tsconfig/*.json",
         "$TURBO_ROOT$/pnpm-lock.yaml",
@@ -397,6 +400,14 @@
     },
     "typecheck": {
       "dependsOn": ["topo"]
+    },
+    "@bb/app#typecheck": {
+      "dependsOn": ["topo"],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/changelog-metadata.ts"]
+    },
+    "@bb/web#typecheck": {
+      "dependsOn": ["topo"],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/changelog-metadata.ts"]
     },
     // The packaged CLI (host-daemon/dist/bb) inlines the SDK declaration
     // bundles for `bb plugin types` on vendored-layout plugins; see


### PR DESCRIPTION
## Human comments

## What was wrong

The website and app kept independent release-presentation tables. The website metadata covered 0.40.0 through 0.42.0, while the app copy stopped at 0.39.0, so the optional in-app Updates preview rendered the current release with a bare version title. Follow-up to #3106.

## What changed

- Move changelog presentation metadata beside `CHANGELOG.md` in a repository-level module consumed by both the website and app.
- Add the 0.42.0 date and headline to the in-app release preview while preserving existing release notes and update behavior.
- Track the shared changelog inputs in Turbo and document the metadata/update checks in the release runbook.
- Add a regression requiring the newest checked-in changelog release to have presentation metadata.

## How you verified

- `pnpm exec turbo run test --filter=@bb/app --force -- 'src/components/settings/changelog-preview.test.ts'` (6/6 passed)
- `pnpm exec turbo run test typecheck build --filter=@bb/web --force` (117 tests passed; typecheck and build passed)
- `pnpm exec turbo run typecheck build --filter=@bb/app --force`
- Targeted `oxfmt --check`
- `git diff --check origin/main...HEAD`
- The fixer also ran the full app suite (3,913 passed, 3 skipped) before handoff.

> AGENT GENERATED
