### PR TITLE
Show installed plugins in Extensions and Settings

### DIFF
--- a/apps/app/src/components/plugin/PluginsOverview.test.tsx
+++ b/apps/app/src/components/plugin/PluginsOverview.test.tsx
@@ -341,24 +341,27 @@ describe("PluginsOverview", () => {
     expect(screen.getByTestId("location-path").textContent).toBe("/");
   });
 
-  it("shows the Type filter on Installed instead of Category", async () => {
-    installFetch([AUTOMATIONS_PLUGIN]);
-    const { wrapper: QueryClientWrapper } = createQueryClientTestHarness();
-    render(
-      <MemoryRouter initialEntries={["/settings/plugins"]}>
-        <QueryClientWrapper>
-          <PluginsOverview />
-          <SwitchViewButton view="browse" />
-          <SwitchViewButton view="installed" />
-        </QueryClientWrapper>
-      </MemoryRouter>,
-    );
+  it.each(["/settings/plugins", "/extensions/plugins?view=installed"])(
+    "shows installed plugin management at %s",
+    async (path) => {
+      installFetch([AUTOMATIONS_PLUGIN]);
+      const { wrapper: QueryClientWrapper } = createQueryClientTestHarness();
+      render(
+        <MemoryRouter initialEntries={[path]}>
+          <QueryClientWrapper>
+            <PluginsOverview />
+            <SwitchViewButton view="browse" />
+            <SwitchViewButton view="installed" />
+          </QueryClientWrapper>
+        </MemoryRouter>,
+      );
 
-    expect(await screen.findByText("Automations")).toBeTruthy();
-    expect(screen.queryByRole("button", { name: "Category" })).toBeNull();
-    expect(screen.getByRole("button", { name: "Type" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "New plugin" })).toBeTruthy();
-  });
+      expect(await screen.findByText("Automations")).toBeTruthy();
+      expect(screen.queryByRole("button", { name: "Category" })).toBeNull();
+      expect(screen.getByRole("button", { name: "Type" })).toBeTruthy();
+      expect(screen.getByRole("button", { name: "New plugin" })).toBeTruthy();
+    },
+  );
 
   it("keeps Browse filters in the toolbar rather than a separate pill band", async () => {
     installFetch();

--- a/apps/app/src/components/plugin/PluginsOverview.tsx
+++ b/apps/app/src/components/plugin/PluginsOverview.tsx
@@ -51,7 +51,8 @@ export function PluginsOverview({
   );
   const location = useLocation();
   const activeMode =
-    location.pathname.replace(/\/+$/u, "") === SETTINGS_PLUGINS_ROUTE_PATH
+    location.pathname.replace(/\/+$/u, "") === SETTINGS_PLUGINS_ROUTE_PATH ||
+    searchParams.get("view") === "installed"
       ? "installed"
       : "browse";
   const authorKey = searchParams.get("author");

--- a/apps/app/src/components/tools/ToolsSidebar.test.tsx
+++ b/apps/app/src/components/tools/ToolsSidebar.test.tsx
@@ -8,7 +8,12 @@ import { SidebarProvider } from "@/components/ui/sidebar";
 
 afterEach(cleanup);
 
-const PAGE_ROWS = ["Browse plugins", "Browse skills", "My skills"];
+const PAGE_ROWS = [
+  "Browse plugins",
+  "Installed plugins",
+  "Browse skills",
+  "My skills",
+];
 
 function renderAt(path: string, appRoutePath = "/") {
   return render(
@@ -36,9 +41,9 @@ describe("ToolsSidebar", () => {
     expect(row("Browse plugins").getAttribute("href")).toBe(
       "/extensions/plugins",
     );
-    expect(
-      screen.queryByRole("link", { name: "Installed plugins" }),
-    ).toBeNull();
+    expect(row("Installed plugins").getAttribute("href")).toBe(
+      "/extensions/plugins?view=installed",
+    );
     expect(row("Browse skills").getAttribute("href")).toBe(
       "/extensions/skills",
     );
@@ -50,7 +55,7 @@ describe("ToolsSidebar", () => {
 
   it.each([
     ["/extensions/plugins", "Browse plugins"],
-    ["/extensions/plugins?view=installed", "Browse plugins"],
+    ["/extensions/plugins?view=installed", "Installed plugins"],
     ["/extensions/plugins/github", "Browse plugins"],
     ["/extensions/plugins/github?view=installed", "Browse plugins"],
     ["/extensions/skills", "Browse skills"],

--- a/apps/app/src/components/tools/tools-navigation.ts
+++ b/apps/app/src/components/tools/tools-navigation.ts
@@ -252,7 +252,11 @@ export function resolveToolsBreadcrumbs(
 }
 
 interface ToolsPageDefinition {
-  id: "plugins-browse" | "skills-browse" | "skills-library";
+  id:
+    | "plugins-browse"
+    | "plugins-installed"
+    | "skills-browse"
+    | "skills-library";
   section: ToolsSectionId;
   label: string;
   icon: IconName;
@@ -266,6 +270,13 @@ export const TOOLS_PAGES: readonly ToolsPageDefinition[] = [
     label: `Browse ${TOOLS_SECTIONS.plugins.label.toLowerCase()}`,
     icon: TOOLS_SECTIONS.plugins.icon,
     to: TOOLS_SECTIONS.plugins.to,
+  },
+  {
+    id: "plugins-installed",
+    section: "plugins",
+    label: "Installed plugins",
+    icon: "PackageReceive",
+    to: `${TOOLS_SECTIONS.plugins.to}?view=installed`,
   },
   {
     id: "skills-browse",
@@ -299,7 +310,9 @@ export function resolveToolsActivePage(
   }
   const section = resolveToolsSection(pathname);
   if (section === "plugins") {
-    return "plugins-browse";
+    return view === TOOLS_OWNED_COLLECTION_VIEW.plugins
+      ? "plugins-installed"
+      : "plugins-browse";
   }
   return view === TOOLS_OWNED_COLLECTION_VIEW.skills
     ? "skills-library"

--- a/apps/app/src/views/ToolsView.plugin-detail.test.tsx
+++ b/apps/app/src/views/ToolsView.plugin-detail.test.tsx
@@ -701,8 +701,12 @@ describe("BB Official plugin detail routing", () => {
       screen.getByRole("textbox", { name: "Search plugins" }),
     ).toBeTruthy();
     expect(screen.getAllByRole("button", { name: /^Close /u })).toHaveLength(1);
-    expect(Array.from(document.querySelectorAll("[data-panel]"))).toEqual(panels);
-    expect(screen.getByRole("textbox", { name: "Search plugins" })).toBe(search);
+    expect(Array.from(document.querySelectorAll("[data-panel]"))).toEqual(
+      panels,
+    );
+    expect(screen.getByRole("textbox", { name: "Search plugins" })).toBe(
+      search,
+    );
 
     fireEvent.click(screen.getByRole("button", { name: "Close GitHub" }));
     await waitFor(() => {
@@ -711,13 +715,20 @@ describe("BB Official plugin detail routing", () => {
       );
       expect(document.activeElement).toBe(card);
     });
-    expect(Array.from(document.querySelectorAll("[data-panel]"))).toEqual(panels);
+    expect(Array.from(document.querySelectorAll("[data-panel]"))).toEqual(
+      panels,
+    );
     expect(panels[0]?.getAttribute("data-panel-size")).toBe("100.0");
     expect(panels[1]?.getAttribute("data-panel-size")).toBe("0.0");
-    expect(screen.getByRole("textbox", { name: "Search plugins" })).toBe(search);
+    expect(screen.getByRole("textbox", { name: "Search plugins" })).toBe(
+      search,
+    );
   });
 
-  it("keeps related plugin navigation in the full-page detail", async () => {
+  it.each([
+    "/extensions/plugins/github?view=installed",
+    "/extensions/plugins?view=installed",
+  ])("opens installed plugin settings from %s", async (path) => {
     const author = {
       name: "BB",
       github: "get-bb",
@@ -771,9 +782,7 @@ describe("BB Official plugin detail routing", () => {
 
     const { wrapper: QueryClientWrapper } = createQueryClientTestHarness();
     render(
-      <MemoryRouter
-        initialEntries={["/extensions/plugins/github?view=installed"]}
-      >
+      <MemoryRouter initialEntries={[path]}>
         <Routes>
           <Route path="/extensions/plugins/*" element={<RoutedToolsView />} />
           <Route path="/settings/plugins/*" element={<RoutedToolsView />} />
@@ -781,6 +790,20 @@ describe("BB Official plugin detail routing", () => {
       </MemoryRouter>,
       { wrapper: QueryClientWrapper },
     );
+
+    if (path === "/extensions/plugins?view=installed") {
+      expect(
+        await screen.findByRole("textbox", {
+          name: "Search installed plugins",
+        }),
+      ).toBeTruthy();
+      expect(screen.getByTestId("route-path").textContent).toBe(
+        "/extensions/plugins",
+      );
+      fireEvent.click(
+        await screen.findByRole("button", { name: "GitHub plugin details" }),
+      );
+    }
 
     fireEvent.click(
       await screen.findByRole("button", {

--- a/apps/app/src/views/ToolsView.tsx
+++ b/apps/app/src/views/ToolsView.tsx
@@ -557,12 +557,13 @@ export function ToolsView({ pluginId }: { pluginId?: string } = {}) {
 
   if (
     activeSection === "plugins" &&
+    pluginId !== undefined &&
     new URLSearchParams(location.search).get("view") === "installed"
   ) {
     return (
       <Navigate
         replace
-        to={`${pluginId === undefined ? getToolsOwnedCollectionRoutePath("plugins") : getPluginDetailRoutePath({ pluginId, view: "installed" })}${location.hash}`}
+        to={`${getPluginDetailRoutePath({ pluginId, view: "installed" })}${location.hash}`}
       />
     );
   }


### PR DESCRIPTION
## Human comments

## What was wrong

Moving installed plugins into Settings removed their entry from Extensions and redirected the installed collection there. Users browsing Extensions could no longer find the installed-plugin inventory.

## What changed

Restored the Installed plugins entry in Extensions with its original PackageReceive icon. Extensions and Settings reuse PluginsOverview for the same installed-plugin management view. The Extensions collection stays in Extensions; individual plugin details continue opening in Settings.

## How you verified

- Added coverage for installed-plugin management at both routes, the Extensions sidebar link and active state, and opening plugin settings from the Extensions installed collection.
- `pnpm exec turbo run typecheck --filter=@bb/app` passed.
- `pnpm exec turbo run test --filter=@bb/app -- PluginsOverview.test.tsx ToolsSidebar.test.tsx ToolsView.plugin-detail.test.tsx` passed: 61 tests.
- Started the dev app and verified the installed collection and plugins API return HTTP 200.

Fixes #3122

> AGENT GENERATED
