### PR TITLE
Streamline agent instructions and move plugin guidance into plugins

### DIFF
--- a/.bb/skills/plugin-guide-maintenance/SKILL.md
+++ b/.bb/skills/plugin-guide-maintenance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plugin-guide-maintenance
-description: Keep the Plugin Guide accurate when a public Plugin SDK change affects its documented contract or an existing Guide annotation changes order, placement, target, or overlay ownership. Use for additions, changes, renames, stabilizations, or removals in @get-bb/plugin-sdk, app.slots.*, or BbPluginApi that affect a Guide card, fixture, or symbol list, and for annotation-only maintenance. Do not use for internal implementation or API work that leaves the Guide accurate.
+description: "Update Plugin Guide cards, fixtures, and annotations when public SDK contracts or Guide presentation change."
 ---
 
 # Maintain the Plugin Guide

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,81 +1,57 @@
 # Codebase Guidelines
 
-## Simplicity First
+## Task Completion
 
-- When renaming a domain concept, search project-wide for stale names in variables, files, query keys, constants, tests, and docs. TypeScript only catches type references.
+- Carry the requested change through implementation, relevant verification, and fixes for failures it causes. Continue authorized, reversible local work without asking for approval at each step; ask when a missing user decision blocks progress.
+- Match verification to the change. Once relevant checks pass, broaden or repeat them only for new changes, failures, or unresolved concerns.
+- Read the linked guidance when its topic applies to the task.
 
-## Code Comments
+## Code And Contracts
 
 - Code comments are forbidden, except for semantic tool directives and Plugin SDK declaration comments.
-
-## Types And Contracts
-
-- Validate and parse data at system boundaries, then pass typed values internally.
-- Avoid `unknown` and `as X` casts inside the system. Use them only at genuinely unknowable boundaries such as freeform tool input, then narrow immediately.
-- Keep one-off types near the code that uses them. Move types to a shared package only for a real cross-package contract.
-- Optional contract fields are allowed only when omission has real semantic meaning. Do not use optional or nullable fields to hide defaults.
-- If a field has a default, fill it in once at the server boundary and pass the explicit value through internal routes, commands, and persisted events.
-- Accepted-but-ignored route or command fields are forbidden. Delete them or implement them end to end.
-- Add or update route and command documentation only when behavior is non-obvious.
+- When renaming a domain concept, search project-wide for stale names in variables, files, query keys, constants, tests, and docs; TypeScript only catches type references.
+- Parse and validate data at system boundaries, then pass typed values internally. Restrict `unknown` and `as X` casts to genuinely unknowable boundaries and narrow immediately.
+- Keep one-off types local; share types only for real cross-package contracts.
+- Optional or nullable fields must represent meaningful absence. Fill defaults once at the server boundary and pass explicit values through internal routes, commands, and persisted events.
+- Delete accepted-but-ignored route or command fields, or implement them end to end. Document route and command behavior when it is non-obvious.
 
 ## Server And Daemon
 
-- The server owns product policy: defaults, instructions, manager behavior, tool lists, and thread behavior.
-- The host daemon owns host-local primitives, provider translation, runtime/session management, and workspace execution.
-- If the server needs host-local data, the daemon should return raw data and the server should assemble product behavior.
-- Do not move responsibility across the server/daemon boundary unless the current change requires it.
-- **Always increment `HOST_DAEMON_PROTOCOL_VERSION` when a change can alter anything sent between the server and host daemon.** This includes adding, removing, renaming, or changing the type, requiredness, default, or meaning of fields in session payloads, WebSocket messages, host RPC commands, or host RPC results. A shared TypeScript build passing is not evidence of wire compatibility: enrolled machines can still be running an older daemon. The version mismatch is what triggers their automatic update; without a bump, an old daemon may connect successfully and then enter an `invalid-message` reconnect loop. If compatibility with the previously shipped daemon has not been deliberately preserved and tested, bump the version.
+- The server owns product policy: defaults, instructions, manager behavior, tool lists, and thread behavior. The host daemon owns host-local primitives, provider translation, runtime/session management, and workspace execution.
+- Return raw host-local data from the daemon; assemble product behavior on the server. Move responsibility across this boundary only when the change requires it.
+- Increment `HOST_DAEMON_PROTOCOL_VERSION` for changes to server/daemon wire fields, including their types, requiredness, defaults, or meaning, unless compatibility with the previously shipped daemon is deliberately preserved and tested. This covers session payloads, WebSocket messages, and host RPC commands/results. Shared TypeScript builds do not verify compatibility with enrolled machines; the version bump triggers their update.
 
-## CLI, Guide, And Skill
+## CLI And Plugin API
 
-- When you add or change a `bb` CLI command, flag, or a user-facing configuration knob (env var, `.bb/` workspace file, settings field), update its discoverable surfaces in the same change. See [docs/cli-guide-and-skill.md](docs/cli-guide-and-skill.md) for which surfaces to update.
-- Every end-user feature must also be usable by agents through both the SDK and the `bb` CLI; ship and document those surfaces in the same change as the UI.
-
-## Plugin API
-
-- Any new public plugin API member (a `@get-bb/plugin-sdk/app` export, an `app.slots.*` method, or a `BbPluginApi` property) ships with an `experimental_` name prefix and an entry in [docs/api_to_audit.md](docs/api_to_audit.md) describing what it does and what to audit before stabilizing. Dropping the prefix is the deliberate stabilization step: audit the entry, rename project-wide, and remove it from the doc in the same change.
-- The Plugin Guide (the `plugin-api-docs` plugin, rendering `packages/plugin-api-map`) is bb's only plugin API documentation. A new surface needs a card in `packages/plugin-api-map/src/surfaces.ts` naming its SDK symbols in the same change.
+- Every end-user feature must also be usable through the SDK and `bb` CLI; ship and document these surfaces with the UI.
+- For changes to CLI commands/flags or user-facing configuration (env vars, `.bb/` workspace files, settings), update the discoverable surfaces listed in [docs/cli-guide-and-skill.md](docs/cli-guide-and-skill.md).
+- New public plugin API members (`@get-bb/plugin-sdk/app` exports, `app.slots.*` methods, or `BbPluginApi` properties) require an `experimental_` prefix and an entry in [docs/api_to_audit.md](docs/api_to_audit.md) describing behavior and stabilization criteria. Stabilization includes the audit, a project-wide rename, and removal of the entry.
+- The Plugin Guide is the only plugin API documentation. Add new surfaces to `packages/plugin-api-map/src/surfaces.ts` with their SDK symbols.
 
 ## Data Access
 
-- Do not load all rows and filter in JavaScript when a targeted query with `WHERE` or `JOIN` is possible.
-- Add indexes only when they are required by the new or changed query.
-- Do not manually edit Drizzle snapshot JSON. Change the schema, then regenerate migrations/snapshots with Drizzle so the snapshot chain stays consistent.
-- Never mock the database in tests. Use in-memory SQLite via `createConnection(":memory:")` plus `migrate(db)`.
+- Use targeted `WHERE`/`JOIN` queries instead of loading all rows and filtering in JavaScript. Add indexes only when required by the query.
+- Change Drizzle schemas and regenerate migrations/snapshots; never edit snapshot JSON manually.
+- Never mock the database in tests. Use `createConnection(":memory:")` and `migrate(db)`.
 
 ## UI
 
-- Prefer sanctioned typography tokens over arbitrary `text-[Npx]` classes.
-- Derive theme color tokens from the `--canvas`/`--ink` anchors (`color-mix(in oklch, var(--ink) N%, var(--canvas))`) or from another derived token — never hand-set an `oklch(L 0 0)` literal. Achromatic literals don't follow custom palettes (Nord, Dracula, …), which re-anchor only `--canvas`/`--ink`, so a hardcoded token strands a neutral-gray element in an otherwise tinted UI. Mix opaque steps `in oklch`; mix translucent steps (a `transparent` pole) `in oklab` so the hue survives. `apps/app/src/components/ui/theme.css` is the source of truth and `theme.test.ts` guards it.
-- Never scope styles with the CSS `@scope` at-rule. WebKit resolves scope containment per element per scoped rule with no selector bucketing, so a rule set inside `@scope` costs `elements × rules` on every style recalculation. Measured on a 2,635-element page: one plugin's Tailwind utilities layer inside `@scope` took 306ms per recalculation, 7ms after rewriting to a `:where()` prefix, against a 6ms floor for the whole document. Blink shows none of it, so this is invisible in Chrome and dominant in Safari. To confine rules to a subtree, prefix each selector with a zero-specificity `:where(<roots>) ` arm plus a `:where(<roots>)` compound arm — `packages/plugin-build/src/scope-plugin-utilities.ts` does this for every plugin's compiled stylesheet and explains why both arms are required. When style recalculation is slow, bisect it: disable stylesheets one at a time and time `getComputedStyle` after invalidating a custom property on `:root`.
-- Use the shared persistent responsive drawer for every compact slide-out menu, picker, popover, and dialog. Do not use modal drawer primitives that add `inert` or `aria-hidden` to the app root: iOS Safari can recalculate styles for the full app tree and stall the interaction. Start the drawer transform before heavy content, realize that content after two animation frames with a timeout fallback, and retain it after the first open. Verify representative drawers in iOS Simulator Safari and protect the app-root and deferred-realization behavior with tests.
+- Use sanctioned typography tokens instead of arbitrary `text-[Npx]` classes.
+- Derive theme colors from `--canvas`/`--ink` or other derived tokens; never use achromatic `oklch(L 0 0)` literals. Mix opaque steps in `oklch` and translucent steps in `oklab`. See `apps/app/src/components/ui/theme.css` and `theme.test.ts`.
+- Never use CSS `@scope`; it causes severe WebKit style-recalculation costs. Confine styles with zero-specificity `:where(<roots>)` descendant and compound selector arms, as implemented in `packages/plugin-build/src/scope-plugin-utilities.ts`.
+- Use the shared persistent responsive drawer for compact slide-out menus, pickers, popovers, and dialogs. Avoid modal primitives that add `inert` or `aria-hidden` to the app root. Start the transform before heavy content; realize content after two animation frames with a timeout fallback, then retain it. Verify representative drawers in iOS Simulator Safari and test app-root and deferred-realization behavior.
 
-## Build And Typecheck
+## Build And Test
 
-- Always use Turbo when building and typechecking: `pnpm exec turbo run <task> --filter=@bb/<pkg>`. Turbo ensures upstream `^build` dependencies run first.
-- Typecheck with `pnpm exec turbo run typecheck --filter=@bb/<pkg>`.
-- Do not run package scripts directly, such as `pnpm --filter @bb/foo test`, or raw `npx tsc --noEmit` unless you are deliberately bypassing repo orchestration for investigation.
-- Generated modules are not committed: `packages/templates/src/generated/`, `packages/plugin-build/src/generated/`, and `packages/plugin-sdk/bundled-types/` are gitignored. Turbo tasks (`@bb/templates#generate:*`, `@bb/plugin-build#generate`, `@get-bb/plugin-sdk#build:types`) produce them before every dependent build, typecheck, and test task, and `pnpm install` runs the cheap ones. If your editor cannot resolve `@get-bb/plugin-sdk` inside a plugin, run `pnpm exec turbo run build:types --filter=@get-bb/plugin-sdk` once. Never commit a generated module and never add a `--check` mode for one; when you add a generated module, add a turbo task with explicit `inputs`/`outputs` and edges from its consumers.
+- Use Turbo for builds, typechecks, and tests so upstream dependencies run first: `pnpm exec turbo run <task> --filter=@bb/<pkg>`. Use the package's actual name for other scopes. Bypass orchestration only for deliberate investigation; do not invoke package scripts or raw `tsc` routinely.
+- Generated modules are gitignored: `packages/templates/src/generated/`, `packages/plugin-build/src/generated/`, and `packages/plugin-sdk/bundled-types/`. Never commit them or add a `--check` mode. New generated modules need Turbo tasks with explicit inputs, outputs, and consumer dependencies.
+- If a plugin cannot resolve `@get-bb/plugin-sdk`, run `pnpm exec turbo run build:types --filter=@get-bb/plugin-sdk`.
+- Test plausible failure modes; avoid trivial getters/setters and framework wiring. Pipe slow test output to a file and inspect it.
+- Build Vitest projects with `sharedWorkerProjects` from `vitest.shared.ts`. Node tests share workers (`isolate: false`); DOM tests and files/helpers that mutate worker-global state receive isolated workers. Restore any global state a test changes.
 
-## Testing
+## Issues, Pull Requests, And Debugging
 
-- Only write high quality tests that verify where there could be potential bugs. Avoid testing trivial getters/setters, framework wiring, or other code that is unlikely to break.
-- Pipe slow test output to a file, then read the file. Example: `pnpm exec turbo run test --filter=@bb/integration-tests --force > /tmp/test-out.txt 2>&1`.
-- Package `vitest.config.ts` files build their `projects` with `sharedWorkerProjects` from `vitest.shared.ts`. It runs node-environment test files in shared workers (`isolate: false`) and gives a file its own worker when it runs in a DOM environment (`jsdom`) or when the file, or a test helper it imports, mutates worker-global state (`vi.mock`, `vi.stubGlobal`, `process.env`, `globalThis.*` assignments, `Object.defineProperty` on a global). Re-importing the module graph per file was 80–90% of the big suites' CPU. Restore what a test changes anyway; the scan is a safety net, not a license.
-
-## GitHub Issues And Pull Requests
-
-- Follow [docs/filing-issues.md](docs/filing-issues.md) when you file an issue. Reproduce first; give versions, minimal copy-pasteable steps, expected vs actual output pasted verbatim, evidence with commit permalinks, and what you ruled out. Use the issue form's sections. Do not file from a single symptom or log line, and do not open a duplicate — add evidence to the existing issue instead.
-- Follow `.github/PULL_REQUEST_TEMPLATE.md` when you open a pull request: what was wrong (root cause), what changed, how you verified (tests that fail before and pass after), `Fixes #N`.
-- When an agent creates a GitHub issue or pull request, add this line at the end of the body:
-
-  ```
-  > AGENT GENERATED
-  ```
-
-- Add this line to each new issue and pull request. It shows the readers that an agent made the content.
-
-## Debugging And QA
-
-- Do not assume. Inspect logs, query the database, call server APIs, or use the CLI to observe real state.
-- See [docs/debugging-and-qa.md](docs/debugging-and-qa.md) for dev ports/data dirs, entity-ID lookups, and the `scripts/bb-dev-app` local dev QA launcher.
+- When filing issues, follow [docs/filing-issues.md](docs/filing-issues.md): reproduce first, check for duplicates, and include versions, copy-pasteable steps, verbatim expected/actual output, commit-permalink evidence, and what you ruled out. Add evidence to an existing issue when applicable.
+- Use [.github/PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md): root cause, change, verification that demonstrates the fix, and `Fixes #N` when applicable.
+- End every agent-created issue and PR body with `> AGENT GENERATED`.
+- Ground debugging in observed state: logs, database queries, server APIs, or CLI output. For dev ports, data directories, entity IDs, and the local QA launcher, see [docs/debugging-and-qa.md](docs/debugging-and-qa.md).

--- a/apps/server/src/services/plugins/plugin-commands-skill.ts
+++ b/apps/server/src/services/plugins/plugin-commands-skill.ts
@@ -48,7 +48,7 @@ function renderPluginCommandsSkill(
   return [
     "---",
     `name: ${SKILL_NAME}`,
-    "description: CLI commands contributed by installed BB plugins. Use when a task involves one of the plugin commands listed here; run them with bash like any other bb command.",
+    "description: Discover CLI commands contributed by installed BB plugins and their invocation paths.",
     "---",
     "",
     "# Plugin Commands",

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: bb-cli
-description: Use this when controlling bb. The bb CLI inspects and manages threads, environments, projects, machines, providers, notifications, skills, plugins, settings, terminals, and other BB services.
+description: "Inspect or manage BB state with the bb CLI; use for BB commands and configuration."
 ---
 
 # BB CLI
 
-Use bb for BB state and actions. Inspect the current context before you choose
-IDs, machines, workspaces, providers, or models.
+Use bb for BB state and actions. Inspect context when the target project, host,
+workspace, or execution selection is not already established.
 
 ## Start with context
 
@@ -52,82 +52,6 @@ BB_HOST_DAEMON_PORT only for an intentional non-default target.
 - Pass `--yes` for a confirmed destructive command in a non-interactive shell.
 - Treat plugin commands as normal top-level commands after installation.
 
-The builtin Account Pooler plugin is disabled by default. Enable it, add Claude
-or Codex credentials, and inspect its proxy routes and account quota with:
-
-```sh
-bb plugin enable account-pool
-bb pool account add --provider claude --login
-printf '%s\n' "$CLAUDE_AUTH_CODE" | bb pool account login-complete --session <id> --code-stdin
-bb pool account add --provider codex --login
-bb pool account login-poll --session <id>
-bb pool account add --provider claude --import
-bb pool account add --provider codex --import
-printf '%s\n' "$ANTHROPIC_API_KEY" | bb pool account add --provider claude --api-key-stdin [--label <text>] [--priority <n>]
-bb pool account add --provider claude --api-key <key> [--label <text>] [--priority <n>]
-bb pool account list [--json]
-bb pool account remove <id>
-bb pool account enable <id>
-bb pool account disable <id>
-bb pool account priority <id> <n>
-bb pool account reorder <claude|codex> <id>...
-bb pool status [--json]
-bb pool routing <claude|codex> [--off]
-bb pool config
-bb pool config set <anthropicUpstreamBaseUrl|codexUpstreamBaseUrl|switchThreshold> <value>
-bb pool token rotate --machine <id-or-name>
-bb pool bypass <thread-id> [--off]
-```
-
-Claude `--login` starts a PKCE session, prints a browser URL and session ID,
-then exits. Pipe the manual callback code to `account login-complete` with that
-session ID within ten minutes. Codex `--login` prints a device verification
-URL, one-time code, session ID, and an `account login-poll` command that waits
-for authorization. The Claude code stays out of process arguments, and either
-browser may be on a different machine from the bb server. Newly added or
-enabled accounts are available without a plugin reload. With an
-enabled account whose secret file remains readable and valid, matching Claude
-Code or Codex sessions receive the pool route and a distinct secret token for
-their machine.
-Codex receives `CODEX_OPENAI_BASE_URL` and the secret
-`CODEX_POOL_AUTH_TOKEN`; bb applies them as in-memory app-server config.
-Tokens are never printed. `status` prunes tokens for unenrolled machines and
-shows token timestamps plus recently routed threads whose machines need a
-local Claude login before the pool can be disabled safely. Rotation keeps the
-prior token valid for ten minutes. Agents should pipe API keys to
-`--api-key-stdin`;
-`--api-key <key>` is an unsafe compatibility form that exposes the key in
-process arguments, shell history, and agent transcripts. Prefer `--import` for
-an existing Claude Code login. The CLI Codex import path reads
-`~/.codex/auth.json` on the bb server host. OAuth quota refreshes on add or
-enable and every five minutes while an account is idle. Account tables add columns for observed
-model-family buckets; JSON status exposes their utilization, reset, status,
-observation time, and source under `familyWeekly`. Selection skips an account
-whose requested family is spent while retaining it for other families. A
-present `metadata.user_id` account UUID is aligned with the selected OAuth
-account. Use `bb pool config` to inspect the full routing configuration and
-`bb pool config set <key> <value>` to update one value. The upstream URL keys
-are QA-only overrides; `switchThreshold` must be greater than 0 and at most 1.
-
-Accounts run sequentially per provider: lower priority numbers first, with ties
-following the order accounts were added. New conversations use the current
-account until it reaches the switch threshold or fails; the pool then advances
-to the next eligible account and wraps at the end. It keeps using that fallback
-even when an earlier account recovers. Existing conversations stay pinned while
-their account remains eligible. Short temporary rate limits wait on the same
-account once; longer holds return Retry-After for pinned conversations while new
-conversations can advance. A model-family limit detours only requests for that
-family without moving the session's main pin or the provider cursor. The cursor
-and session pins survive hub restarts. Session pins expire after 30 idle minutes,
-and the pool retains the 4,096 most recently used pins.
-
-Use the up/down arrows in Account Pooler settings, or
-`bb pool account reorder <claude|codex> <id>...`, to set the complete order for
-one provider. Include disabled accounts too. Reordering changes the next failover
-sequence without moving the current account. `bb pool account priority <id> <n>`
-sets an individual priority; the same operations are available through the
-`account.reorder` and `account.setPriority` plugin RPCs.
-
 - Inspect real status, logs, API results, or diffs instead of assumptions.
 - Keep file paths on the machine that owns the selected workspace.
 
@@ -153,6 +77,10 @@ remote service. Report the stable ID or URL that the user needs next.
 
 Use `bb plugin config <id>` to inspect the plugin’s configuration and
 `bb plugin config <id> set <key> <value>` to change it. Read the plugin’s own
-guidance for its delivery commands and supported clients. A server-side
-notification switch does not grant browser or operating system permission;
-that permission is granted from the target client’s settings.
+skill for its commands, configuration meanings, and operating constraints.
+Discover contributed command paths through `bb plugin list`, the generated
+`plugin-commands` skill, or `bb plugin run <id> --help`.
+
+Keep this skill and its references focused on core BB commands. Plugin-specific
+behavior belongs in the owning plugin’s `skills/` directory, including built-in
+plugins; do not add plugin command manuals here.

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/references/configuration.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/references/configuration.md
@@ -24,18 +24,6 @@
 - Use `bb settings reload` to reload BB-managed configuration.
 - These commands support `--json`.
 
-## Provider plugin settings
-
-- Read provider settings with `bb plugin config <plugin-id>` and change them
-  with `bb plugin config <plugin-id> set <key> <value>`.
-- Claude Code's `idleQueryReleaseEnabled` setting opts into closing its native
-  process after 30 seconds of quiescence while keeping the bb thread resumable.
-  It defaults to `false`; changes apply on the next start, resume, or turn.
-- Claude Code's `chromeEnabled` setting starts its process with `--chrome` so
-  bb threads get the Claude in Chrome browser tools. It defaults to `false`;
-  the host needs the Chrome extension and a claude.ai login. A change restarts
-  the thread's Claude process before its next turn without losing context.
-
 ## Agent Instructions
 
 - Add `AGENTS.md` to the bb data dir (usually `~/.bb/AGENTS.md`) to inject

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/references/failure-recovery.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/references/failure-recovery.md
@@ -18,21 +18,15 @@
   a busy thread or a plugin's dispatch hook. `--reason <text>` labels the queued
   row. The SDK equivalent is `sdk.threads.retry({ threadId, turnRequestId?,
 sendAt?, reason? })`.
-- The Provider retry plugin is enabled on fresh installations. When a turn fails
-  on a structured Codex or Claude Code subscription-window limit that reports a
-  reset, it queues that turn to be re-sent after the window opens, re-sending
-  the original message verbatim and marked agent-only. A pending retry is an
-  ordinary queued row on the thread, so it survives a restart and appears in
-  `bb thread queue list <thread-id>`.
 - For interrupted or stopped threads, inspect first. If the user stopped the
   thread, treat that as intentional unless they ask you to continue.
 - Use `bb thread stop <id>` when a thread is stuck or no longer needed.
 - `bb thread stop <id>` also releases an idle or stuck agent runtime. The
   command is idempotent and preserves thread history.
-- Use `bb thread compact <id>` to send the built-in `/compact` command to an idle or errored thread. Completion or failure appears in the timeline. Codex, Claude Code, Pi, and OpenCode ACP support it; Cursor ACP does not expose compatible compaction through ACP.
+- Use `bb thread compact <id>` to send the built-in `/compact` command to an idle or errored thread. Completion or failure appears in the timeline. Provider support varies; consult its skill and reported capabilities.
 - Use `bb thread clear <id>` on an idle or failed thread to reset its active
   timeline and model context in place while keeping the same BB thread,
   workspace, durable event history, and sticky execution settings.
 - Use `bb thread cancel-plan <id>` to exit an active Plan turn without
   optimistically clearing its banner. Use `bb thread clear-goal <id>` to clear
-  a Codex thread's durable active Goal. Both wait for provider confirmation.
+  a thread's durable active Goal when supported by its provider. Both wait for provider confirmation.

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/references/plugins.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/references/plugins.md
@@ -6,11 +6,6 @@
   it with services, schedules, HTTP/RPC endpoints, settings — and `bb` CLI
   subcommands that agents run through bash like any other command.
 - Use `bb plugin list` to inspect installed plugins and their current state.
-- The builtin Concurrency limit plugin exposes
-  `bb concurrency-limit status [--json]`,
-  `bb concurrency-limit global [unlimited|<limit>] [--json]`, and
-  `bb concurrency-limit host <host-id> [auto|<limit>] [--json]`. Automatic
-  host limits allow one thread per available processor.
 - **BB plugin catalog** (store under `/api/v1/plugin-catalog`):
   - The reserved **BB Official marketplace** has the name `bb-official`. It
     describes all plugins in the app bundle with a generated v2 document.

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/references/thread-creation.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/references/thread-creation.md
@@ -5,8 +5,8 @@
 - Use `bb thread spawn --project <project-id> --prompt "..."` to create another
   thread. Pass the intended project explicitly; the CLI does not infer it from
   context variables. Omitted execution flags use remembered project defaults;
-  without a remembered model, bb uses the explicitly requested provider or
-  Codex and resolves its provider-reported default model on the target machine.
+  without a remembered model, bb resolves the selected provider and its reported
+  default model on the target machine.
 - Select a target with `--environment`, `--new-environment`, `--base-branch`,
   or `--machine`. Select execution with `--provider`, `--model`,
   `--reasoning-level`, `--service-tier`, and `--permission-mode`.
@@ -136,21 +136,10 @@ environment pull-request show <id>`. Diff commands require an explicit target
   (alias `--host`) or `--environment <id>` to inspect the machine where work
   will run; the selectors cannot be combined. With neither selector they
   intentionally inspect the primary machine.
-- Known ACP agents can appear automatically when their CLI is installed on the
-  host; for example `opencode`, `omp`, Grok Build's `grok` CLI, or Hermes'
-  `hermes` CLI on PATH appears as provider `acp-opencode`, `acp-omp`,
-  `acp-grok`, or `acp-hermes-agent`.
-- Cursor ACP threads discover project skills from `.cursor/skills`. This root
-  can link to `.agents/skills`. `bb skill list` shows linked Cursor skills under
-  `cursor-project` and keeps them read-only.
 - Top-level `customModels` in the same `config.json` registers extra picker
-  models. `providerId` accepts a built-in provider id or any `acp-*` provider
-  id. The provider must still accept the id: `claude-code` and `codex` accept
-  unlisted ids, while an ACP agent can reject an unknown id at session start.
-  OpenCode rejects unlisted ids; add the model to the OpenCode config instead
-  and bb discovers it automatically. An OpenCode agent is a session mode, not
-  a model, and cannot be selected through bb. This list also has no set/unset
-  CLI surface. Edit the JSON and restart BB.
+  models. Use a provider ID returned by the target host's catalog. Acceptance
+  of unlisted models is provider-specific; consult that provider's skill.
+  This list has no set/unset CLI surface. Edit the JSON and restart BB.
   The `streamerMode` General preference hides every entry from model lists.
 - Top-level `sharedSkillRoots` uses the same relative `user` and `project`
   paths. bb lists these skills as read-only. bb injects them into each provider,

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/references/thread-operation.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/references/thread-operation.md
@@ -14,13 +14,13 @@
   needs clarification, or follow-up work is needed.
 - Add `--plan` to `bb thread spawn` or `bb thread tell` to send the prompt as
   the provider's structured `/plan` action: the agent proposes a plan for
-  approval before executing (Claude Code and Codex). Plain `/plan ...` text is
+  approval before executing when supported by the provider. Plain `/plan ...` text is
   not recognized and reaches the provider as literal text. Review the proposed
   plan with `bb thread interactions`; `bb thread cancel-plan` leaves Plan mode
   early. The SDK equivalent is `input: [createBuiltinPlanCommandTextInput(text)]`
   (exported by `@bb/sdk`) on `threads.spawn` / `threads.send`.
 - Use `bb thread edit-message <thread-id> --message "..."` to replace and rerun
-  the latest eligible user message in a Codex, Claude Code, or Pi thread. Pass
+  the latest eligible user message in a supporting provider thread. Pass
   `--expected-request-sequence <sequence>` to select an earlier message. Failed
   and incomplete turns are eligible; submitting against a running thread stops
   and settles its current turn first. Opening edit mode in the app is

--- a/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bb-plugin-authoring
-description: Write, build, test, and install BB plugins. Use whenever a task creates or changes a BB plugin, BB CLI command, agent tool, background service, provider, setting, panel, mention provider, file renderer, message action, or other Plugin SDK surface.
+description: "Create or change BB plugins and Plugin SDK extensions, including CLI commands, agent tools, providers, and UI surfaces."
 ---
 
 # Author BB plugins
@@ -12,14 +12,11 @@ Use the current SDK types and repository source as the contract. This skill
 routes to detailed references, but the installed BB version decides the exact
 API.
 
-## Start
+## Implement and verify
 
-1. Read repository instructions and the existing package.
-2. Decide whether the feature needs a backend, frontend, or both.
-3. Inspect the exact current SDK declaration before you implement a surface.
-4. Build with bb plugin build.
-5. Test the contract and the user workflow.
-6. Install or reload only when the task requires a live check.
+Inspect the affected package and current SDK declarations to select backend,
+frontend, or both. Build the plugin and verify the affected contracts and user
+workflow. Install or reload when a live check is needed for the requested work.
 
 Use bb plugin new <name> for a new plugin. The scaffold includes frontend files.
 Remove `bb.app` and those files when the plugin is headless.
@@ -84,6 +81,9 @@ the same change.
 - Keep secret settings on the server.
 - Treat frontend parameters and persisted values as untrusted input.
 - Return bounded CLI and agent-tool output.
+- Document plugin commands, settings, and operating constraints in the plugin's
+  own `skills/` directory. The core CLI skill owns generic plugin management,
+  not individual plugin behavior.
 - Dispose every service, schedule, listener, content script, and resource.
 - Use SDK host components and navigation for host-owned behavior.
 - Use vendored UI source for plugin-owned controls.

--- a/apps/server/src/services/skills/builtin-skills/skill-creator/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/skill-creator/SKILL.md
@@ -1,121 +1,62 @@
 ---
 name: skill-creator
-description: Create new bb skills and improve existing ones. Use whenever a user asks to create, write, edit, refine, test, or optimize a skill; turn a workflow into a reusable skill; fix skill triggering; or improve a SKILL.md file.
+description: "Create or improve BB skills, including their triggers, instructions, and supporting resources."
 ---
 
 # Skill creator
 
-Create skills that trigger for the correct requests and improve agent results.
+Create skills that add useful domain knowledge and trigger only for relevant tasks.
+User skills live at `~/.bb/skills/<name>/SKILL.md`. Edit built-in and plugin
+skills at their source, not in generated runtime copies.
 
-## Workflow
+## Contract
 
-1. Read the conversation and the existing skill before asking questions.
-2. Confirm the trigger, expected result, inputs, edge cases, and dependencies.
-3. Write or revise the skill and any required resources.
-4. Test realistic prompts in fresh BB threads.
-5. Compare the results with the previous skill or no-skill baseline.
-6. Revise until further changes do not give a useful improvement.
-
-Ask only for decisions that the available context cannot answer. Match the
-amount of evaluation to the risk and the result quality that the user needs.
-
-## Skill contract
-
-A skill uses this structure:
-
-```text
-skill-name/
-├── SKILL.md
-├── references/
-├── scripts/
-└── assets/
-```
-
-Only `SKILL.md` is required. User skills live at
-`~/.bb/skills/<name>/SKILL.md`.
-
-The file starts with YAML frontmatter:
+Start `SKILL.md` with YAML frontmatter:
 
 ```yaml
 ---
 name: skill-name
-description: State what the skill does and when an agent must use it.
+description: Briefly state the capability and when it applies.
 ---
 ```
 
-The directory and `name` value must match. A name uses lowercase letters,
-numbers, and single hyphens. It cannot exceed 64 characters. The description
-cannot exceed 1024 characters.
+The directory and name must match. Names use lowercase letters, numbers, and
+single hyphens, with at most 64 characters. Descriptions have a 1024-character
+limit; use a short, discriminating sentence rather than filling that limit.
+Preserve supported metadata and invocation settings when editing.
 
-Put all trigger conditions in the description. Include concrete tasks and
-nearby user phrases. Keep procedural instructions in the body.
+BB loads names and descriptions for discovery, the body when a skill is used,
+and supporting files when needed. New threads discover revisions; existing
+threads may retain the version they started with.
 
-BB discovers edits for newly spawned threads. An existing thread does not
-receive a skill revision after it starts.
+## Write for the task
 
-## Progressive disclosure
+- Keep the purpose, essential constraints, completion criteria, and reference
+  routing in the entrypoint. A short skill needs no extra files.
+- Move substantial mode-specific procedures and examples into `references/`.
+  State when to read each file; do not require loading every reference.
+- Use `scripts/` for repeated deterministic work and `assets/` for output
+  templates or resources. Reuse existing resources before adding new ones.
+- Describe outcomes and decision boundaries. Reserve rigid steps for fragile
+  operations where order matters; avoid generic advice, repeated repository
+  rules, keyword catchalls, and model-specific scaffolding.
+- Preserve the user's scope and existing authorization. Continue through
+  authorized implementation and verification; ask only for missing decisions.
+  A skill being loaded does not itself authorize external writes or new work.
+- Keep real safety and product constraints explicit. Explain a constraint when
+  its reason helps the agent apply it correctly.
 
-BB loads skill information in three levels:
+## Verify and finish
 
-1. BB always loads the name and description.
-2. An agent reads `SKILL.md` after the skill triggers.
-3. The agent reads or runs bundled resources only when the task needs them.
+Check frontmatter, resource paths, scripts affected by the edit, and whether
+realistic requests select the right skill. Include near misses when changing
+triggers. Preserve working behavior rather than optimizing word count alone.
 
-Keep `SKILL.md` focused on routing, the main workflow, safety, and success
-criteria. Aim for fewer than 500 lines.
+For substantial workflow or boundary changes, use
+[references/evaluation.md](references/evaluation.md) for fresh-thread tests
+against the previous skill or no-skill baseline. A wording edit does not require
+full workflow execution. Keep evaluations isolated from live external actions.
 
-Move detailed variants, contracts, and examples into `references/`. Tell the
-agent exactly when to read each reference. Add a table of contents to reference
-files longer than 300 lines.
-
-Put deterministic or repeated work in `scripts/`. Put output templates, icons,
-fonts, and similar material in `assets/`.
-
-## Writing guidance
-
-- Use direct instructions and concrete examples.
-- Explain the reason for a constraint when the reason helps generalization.
-- Remove rules that repeat the system prompt or repository instructions.
-- Avoid absolute language when a clear reason and condition work better.
-- Keep shared workflow in `SKILL.md` and organize references by task variant.
-- Do not add unsafe, misleading, or unauthorized behavior.
-
-## Evaluation
-
-Create two or three realistic prompts. State the expected result for each
-prompt. Include near-miss prompts when you tune the description.
-
-Spawn a fresh thread for every test:
-
-```sh
-bb thread spawn --project "$BB_PROJECT_ID" --prompt "<test prompt>" --json
-bb thread wait <thread-id>
-bb thread output <thread-id>
-bb thread log <thread-id>
-bb thread show <thread-id> --git-diff
-```
-
-Read the transcript, not only the final answer. Check whether the skill
-triggered, whether the agent read only relevant resources, and whether the
-instructions improved the result.
-
-For an existing skill, compare the revision with the previous version. For a
-new skill, compare it with a run that does not expose the skill. Use an
-objective check when the result has a machine-verifiable contract.
-
-## Improve the revision
-
-- Generalize from evaluation failures instead of adding prompt-specific rules.
-- Remove instructions that cause delay or do not change results.
-- Add a reusable script when each run repeats the same setup.
-- Update an existing resource instead of creating overlapping guidance.
-- Keep the description broad enough for true matches and quiet for near misses.
-
-## Completion check
-
-- The directory matches the valid frontmatter name.
-- The description says what the skill does and when to use it.
-- The body stays focused and routes optional detail to bundled resources.
-- Every referenced resource exists and has a clear read condition.
-- Fresh-thread evaluations cover realistic matches and useful near misses.
-- The final revision improves results without unnecessary instructions.
+Finish after relevant checks pass and demonstrated failures are corrected.
+Report the changes and any limits of the validation; do not keep testing without
+new evidence that another run would help.

--- a/apps/server/src/services/skills/builtin-skills/skill-creator/references/evaluation.md
+++ b/apps/server/src/services/skills/builtin-skills/skill-creator/references/evaluation.md
@@ -1,0 +1,22 @@
+## Evaluation
+
+Create two or three realistic prompts. State the expected result for each
+prompt. Include near-miss prompts when you tune the description.
+
+Spawn a fresh thread for every test:
+
+```sh
+bb thread spawn --project "$BB_PROJECT_ID" --prompt "<test prompt>" --json
+bb thread wait <thread-id>
+bb thread output <thread-id>
+bb thread log <thread-id>
+bb thread show <thread-id> --git-diff
+```
+
+Read the transcript, not only the final answer. Check whether the skill
+triggered, whether the agent read only relevant resources, and whether the
+instructions improved the result.
+
+For an existing skill, compare the revision with the previous version. For a
+new skill, compare it with a run that does not expose the skill. Use an
+objective check when the result has a machine-verifiable contract.

--- a/apps/server/src/services/skills/builtin-skills/submit-a-plugin/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/submit-a-plugin/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: submit-a-plugin
-description: Submit a bb plugin to the BB Community marketplace. Use whenever a user asks to submit, list, publish, or add a plugin to the BB marketplace, or asks for a marketplace pull request. This skill validates the plugin and release, creates the marketplace entry, icon, screenshots, and long-form overview, and opens the pull request.
+description: "Prepare and submit a BB plugin to the Community marketplace when publication or a marketplace PR is requested."
 ---
 
 # Submit a plugin

--- a/apps/server/test/services/plugins/heroes.test.ts
+++ b/apps/server/test/services/plugins/heroes.test.ts
@@ -9,7 +9,10 @@ import {
   generatedSkillsRootPath,
   pluginCommandsSkillDir,
 } from "../../../src/services/plugins/plugin-commands-skill.js";
-import { resolveInjectedSkillSources } from "../../../src/services/skills/injected-skills.js";
+import {
+  resolveInjectedSkillSources,
+  resolveProjectSkillSourceFromContent,
+} from "../../../src/services/skills/injected-skills.js";
 import { applyLoggedThreadLifecycleEvent } from "../../../src/services/threads/lifecycle-outcome.js";
 import {
   seedEvent,
@@ -132,7 +135,7 @@ describe("hero plugin: agent-enrichment", () => {
     ).toMatchObject({ kind: "tree", entryPath: "SKILL.md" });
   });
 
-  it("auto-imports its skills/ directory through the plugin skills tier", () => {
+  it("auto-imports its skills/ directory through the plugin skills tier", async () => {
     const pluginSkillRoots = harness.pluginService.listSkillRootContributions();
     expect(pluginSkillRoots).toContainEqual(
       expect.objectContaining({
@@ -147,7 +150,19 @@ describe("hero plugin: agent-enrichment", () => {
     });
     const skill = sources.find((source) => source.name === "repo-conventions");
     expect(skill).toBeDefined();
-    expect(skill?.description).toContain("Conventions");
+    const skillRoot = join(
+      EXAMPLES_DIR,
+      "agent-enrichment",
+      "skills",
+      "repo-conventions",
+    );
+    const expected = resolveProjectSkillSourceFromContent(testLogger, {
+      candidatePath: skillRoot,
+      content: await readFile(join(skillRoot, "SKILL.md"), "utf8"),
+      directoryName: "repo-conventions",
+    });
+    expect(expected).not.toBeNull();
+    expect(skill?.description).toBe(expected?.description);
     expect(skill).toMatchObject({ kind: "tree", entryPath: "SKILL.md" });
   });
 });

--- a/apps/server/test/skills/shipped-skills-quality.test.ts
+++ b/apps/server/test/skills/shipped-skills-quality.test.ts
@@ -3,6 +3,8 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { listBundledPluginRegistrations } from "../../src/services/plugins/builtin-registry.js";
 import { readPluginManifest } from "../../src/services/plugins/manifest.js";
+import { testLogger } from "../helpers/test-app.js";
+import { resolveProjectSkillSourceFromContent } from "../../src/services/skills/injected-skills.js";
 import { resolveBuiltinSkillsRootPath } from "../../src/services/skills/builtin-skills-copy.js";
 
 function skillDirectories(
@@ -32,15 +34,17 @@ function lineCount(text: string): number {
 
 describe("shipped skills", () => {
   it.each(SHIPPED_SKILLS)(
-    "%s uses concise frontmatter and one-level progressive disclosure",
+    "%s has loadable metadata and routed reference files",
     (expectedName, skillRoot) => {
       const skill = readFileSync(path.join(skillRoot, "SKILL.md"), "utf8");
-      const frontmatter = skill.match(
-        /^---\nname: ([^\n]+)\ndescription: ([^\n]+)\n---\n/,
-      );
+      const source = resolveProjectSkillSourceFromContent(testLogger, {
+        candidatePath: skillRoot,
+        content: skill,
+        directoryName: expectedName,
+      });
 
-      expect(frontmatter?.[1]).toBe(expectedName);
-      expect(frontmatter?.[2]).toMatch(/\bUse\b/);
+      expect(source).not.toBeNull();
+      expect(source?.name).toBe(expectedName);
       expect(lineCount(skill)).toBeLessThanOrEqual(500);
 
       const referencesRoot = path.join(skillRoot, "references");

--- a/docs/cli-guide-and-skill.md
+++ b/docs/cli-guide-and-skill.md
@@ -3,5 +3,5 @@
 Keep the discoverable surfaces in sync whenever you add or change a `bb` CLI command, flag, or a user-facing configuration knob (env var, `.bb/` workspace file, settings field):
 
 - Update the in-CLI guide templates under `packages/templates/src/templates/bb-guide-*.md`, turbo regenerates `packages/templates/src/generated/templates.generated.ts` (not committed) before every build, typecheck, and test task.
-- Update the bb-cli skill at `apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md`. Configuration knobs also belong in `docs/configuration.md`.
+- For core commands, update the bb-cli skill at `apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md` or its relevant reference. For plugin commands and settings, update the owning plugin's `skills/<name>/SKILL.md` or supporting reference, including built-in plugins. Keep plugin-specific behavior out of the core CLI skill. Configuration knobs also belong in `docs/configuration.md`.
 - Match the existing chapter/section style; keep entries concise and accurate against the implementation.

--- a/examples/plugins/agent-enrichment/skills/repo-conventions/SKILL.md
+++ b/examples/plugins/agent-enrichment/skills/repo-conventions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: repo-conventions
-description: Conventions for working in this repository — commit style, branch naming, and testing expectations. Use when writing commits, opening PRs, or adding tests here.
+description: "Repository conventions for commits, pull requests, and tests in this example project."
 ---
 
 # Repo conventions

--- a/plugins/account-pool/skills/account-pool/SKILL.md
+++ b/plugins/account-pool/skills/account-pool/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: account-pool
+description: "Configure or diagnose Account Pooler accounts, authentication, quota routing, and failover through bb pool."
+---
+
+# Account Pooler
+
+Use `bb pool` for this plugin's accounts and routes. Inspect current state with
+`bb pool status --json` and `bb pool account list --json` before changing routing.
+Use `bb pool --help` for available commands.
+
+For account login/import, secret handling, routing settings, ordering, or failover,
+read [references/accounts-and-routing.md](references/accounts-and-routing.md).
+
+Use stdin or supported login/import flows for credentials; never put secret values
+in command arguments or chat. Confirm the resulting account and routing state.
+Do not enable the plugin or change accounts unless the requested task calls for it.

--- a/plugins/account-pool/skills/account-pool/references/accounts-and-routing.md
+++ b/plugins/account-pool/skills/account-pool/references/accounts-and-routing.md
@@ -1,0 +1,75 @@
+The builtin Account Pooler plugin is disabled by default. Enable it, add Claude
+or Codex credentials, and inspect its proxy routes and account quota with:
+
+```sh
+bb plugin enable account-pool
+bb pool account add --provider claude --login
+printf '%s\n' "$CLAUDE_AUTH_CODE" | bb pool account login-complete --session <id> --code-stdin
+bb pool account add --provider codex --login
+bb pool account login-poll --session <id>
+bb pool account add --provider claude --import
+bb pool account add --provider codex --import
+printf '%s\n' "$ANTHROPIC_API_KEY" | bb pool account add --provider claude --api-key-stdin [--label <text>] [--priority <n>]
+bb pool account add --provider claude --api-key <key> [--label <text>] [--priority <n>]
+bb pool account list [--json]
+bb pool account remove <id>
+bb pool account enable <id>
+bb pool account disable <id>
+bb pool account priority <id> <n>
+bb pool account reorder <claude|codex> <id>...
+bb pool status [--json]
+bb pool routing <claude|codex> [--off]
+bb pool config
+bb pool config set <anthropicUpstreamBaseUrl|codexUpstreamBaseUrl|switchThreshold> <value>
+bb pool token rotate --machine <id-or-name>
+bb pool bypass <thread-id> [--off]
+```
+
+Claude `--login` starts a PKCE session, prints a browser URL and session ID,
+then exits. Pipe the manual callback code to `account login-complete` with that
+session ID within ten minutes. Codex `--login` prints a device verification
+URL, one-time code, session ID, and an `account login-poll` command that waits
+for authorization. The Claude code stays out of process arguments, and either
+browser may be on a different machine from the bb server. Newly added or
+enabled accounts are available without a plugin reload. With an
+enabled account whose secret file remains readable and valid, matching Claude
+Code or Codex sessions receive the pool route and a distinct secret token for
+their machine.
+Codex receives `CODEX_OPENAI_BASE_URL` and the secret
+`CODEX_POOL_AUTH_TOKEN`; bb applies them as in-memory app-server config.
+Tokens are never printed. `status` prunes tokens for unenrolled machines and
+shows token timestamps plus recently routed threads whose machines need a
+local Claude login before the pool can be disabled safely. Rotation keeps the
+prior token valid for ten minutes. Agents should pipe API keys to
+`--api-key-stdin`;
+`--api-key <key>` is an unsafe compatibility form that exposes the key in
+process arguments, shell history, and agent transcripts. Prefer `--import` for
+an existing Claude Code login. The CLI Codex import path reads
+`~/.codex/auth.json` on the bb server host. OAuth quota refreshes on add or
+enable and every five minutes while an account is idle. Account tables add columns for observed
+model-family buckets; JSON status exposes their utilization, reset, status,
+observation time, and source under `familyWeekly`. Selection skips an account
+whose requested family is spent while retaining it for other families. A
+present `metadata.user_id` account UUID is aligned with the selected OAuth
+account. Use `bb pool config` to inspect the full routing configuration and
+`bb pool config set <key> <value>` to update one value. The upstream URL keys
+are QA-only overrides; `switchThreshold` must be greater than 0 and at most 1.
+
+Accounts run sequentially per provider: lower priority numbers first, with ties
+following the order accounts were added. New conversations use the current
+account until it reaches the switch threshold or fails; the pool then advances
+to the next eligible account and wraps at the end. It keeps using that fallback
+even when an earlier account recovers. Existing conversations stay pinned while
+their account remains eligible. Short temporary rate limits wait on the same
+account once; longer holds return Retry-After for pinned conversations while new
+conversations can advance. A model-family limit detours only requests for that
+family without moving the session's main pin or the provider cursor. The cursor
+and session pins survive hub restarts. Session pins expire after 30 idle minutes,
+and the pool retains the 4,096 most recently used pins.
+
+Use the up/down arrows in Account Pooler settings, or
+`bb pool account reorder <claude|codex> <id>...`, to set the complete order for
+one provider. Include disabled accounts too. Reordering changes the next failover
+sequence without moving the current account. `bb pool account priority <id> <n>`
+sets an individual priority; the same operations are available through the
+`account.reorder` and `account.setPriority` plugin RPCs.

--- a/plugins/automations/skills/automations/SKILL.md
+++ b/plugins/automations/skills/automations/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: automations
-description: Create and manage bb automations from the first-party automations plugin. Use when scheduling recurring or one-shot agent/script work with bb automation commands.
+description: "Schedule or manage recurring and one-shot BB agent or script automations."
 ---
 
 # Automations
@@ -28,44 +28,8 @@ Creating:
 bb automation create --project <id> --name "..." [schedule flags] [mode flags]
 ```
 
-Schedule flags:
-
-```text
---cron <expr>                  Recurring 5-field cron expression
---timezone <tz>                IANA timezone for --cron
---at <datetime>                One-shot run time, preferably ISO 8601
---in <duration>                One-shot delay, e.g. 30s, 5m, 2h, 1d
-```
-
-Agent mode flags:
-
-```text
---prompt <prompt>              Prompt to run when due
---provider <id>                Provider ID
---model <model>                Model ID
---reasoning <level>            none, low, medium, high, xhigh, ultracode, max, or ultra
---service-tier <tier>          default or fast (update also accepts none to clear)
---permission-mode <mode>       accept-edits, auto, or full
---target-thread <id>           Reuse/re-prompt an existing thread
---environment <id-or-path>     Existing environment ID or unmanaged workspace path
---new-environment <kind>       Create a new environment (worktree)
---base-branch <branch>         Base branch for new managed worktrees
-```
-
-When `--permission-mode` is omitted, the plugin chooses Approve for me
-(`auto`) when the provider supports it and otherwise uses Full Access
-(`full`).
-
-Script mode flags:
-
-```text
---script <inline>              Inline script content
---script-file <path>           Copy script content from a file on a host
---host <name-or-id>            Host that owns --script-file (default: thread host or server)
---interpreter <name>           bash, sh, node, or python3
---timeout <ms>                 Timeout in milliseconds, default 120000, max 900000
---env-json <json>              Script variables as a string-to-string JSON object
-```
+For creation flags and mode-specific defaults, read
+[references/creation.md](references/creation.md).
 
 Read `references/script-runtime.md` before you use a script file, depend on
 injected variables, or diagnose retries, timeouts, restarts, and silent runs.
@@ -83,49 +47,5 @@ bb automation runs <automationId> --project <id> [--limit <count>] [--output <ru
 bb automation delete <automationId> --project <id> --yes
 ```
 
-`list` and `show` are diagnostic reads: a damaged record remains visible as
-`Prompt required` or `Invalid data` instead of failing the whole read. A
-`Prompt required` record opens in the Automations panel's standard editor,
-where the user can add its prompt while reviewing the other settings. It can
-also be repaired directly:
-
-```bash
-bb automation update <automationId> --project <id> --prompt "<prompt>"
-```
-
-Writes remain strict. Run, pause, and resume reject damaged records; update
-succeeds only when the resulting complete record is canonical. Every successful
-create/update persists the canonical format.
-
-Choose one of two execution update forms:
-
-- A complete replacement uses `--prompt`, `--provider`, and `--model` together
-  to replace the execution with an agent, or `--script`/`--script-file` to
-  replace it with a script. Add `--reasoning` and `--service-tier` when needed.
-  Include every desired mode-specific setting;
-  settings from the previous execution do not carry over.
-- A partial agent update preserves every omitted execution field and edits the
-  existing agent automation in place. Use any combination of `--prompt`,
-  `--provider`, `--model`, `--reasoning`, `--service-tier`, and
-  `--permission-mode accept-edits|auto|full`, then choose at most one execution
-  target. When changing providers, pass the provider's coherent model,
-  reasoning, tier, and permission selection together:
-
-```bash
-bb automation update <automationId> --project <id> \
-  --environment <environment-id-or-path>
-bb automation update <automationId> --project <id> \
-  --target-thread <thread-id>
-bb automation update <automationId> --project <id> \
-  --new-environment worktree [--base-branch <branch>]
-```
-
-`--target-thread`, `--environment`, and `--new-environment` are mutually
-exclusive. These flags apply only to agent automations; script automations have
-no execution environment.
-
-Every command supports `--json`. For `list` and `show`, the JSON result is a
-union discriminated by `problem`: canonical records omit it, while degraded
-records use `"missing-agent-prompt"` or `"invalid-stored-data"`. The
-missing-prompt variant retains the full readable automation; the invalid-data
-variant contains only `id`, `projectId`, `name`, and `problem`.
+For partial updates, mode replacement, execution targets, or damaged records,
+read [references/updates.md](references/updates.md). Every command supports `--json`.

--- a/plugins/automations/skills/automations/references/creation.md
+++ b/plugins/automations/skills/automations/references/creation.md
@@ -1,0 +1,38 @@
+Schedule flags:
+
+```text
+--cron <expr>                  Recurring 5-field cron expression
+--timezone <tz>                IANA timezone for --cron
+--at <datetime>                One-shot run time, preferably ISO 8601
+--in <duration>                One-shot delay, e.g. 30s, 5m, 2h, 1d
+```
+
+Agent mode flags:
+
+```text
+--prompt <prompt>              Prompt to run when due
+--provider <id>                Provider ID
+--model <model>                Model ID
+--reasoning <level>            none, low, medium, high, xhigh, ultracode, max, or ultra
+--service-tier <tier>          default or fast (update also accepts none to clear)
+--permission-mode <mode>       accept-edits, auto, or full
+--target-thread <id>           Reuse/re-prompt an existing thread
+--environment <id-or-path>     Existing environment ID or unmanaged workspace path
+--new-environment <kind>       Create a new environment (worktree)
+--base-branch <branch>         Base branch for new managed worktrees
+```
+
+When `--permission-mode` is omitted, the plugin chooses Approve for me
+(`auto`) when the provider supports it and otherwise uses Full Access
+(`full`).
+
+Script mode flags:
+
+```text
+--script <inline>              Inline script content
+--script-file <path>           Copy script content from a file on a host
+--host <name-or-id>            Host that owns --script-file (default: thread host or server)
+--interpreter <name>           bash, sh, node, or python3
+--timeout <ms>                 Timeout in milliseconds, default 120000, max 900000
+--env-json <json>              Script variables as a string-to-string JSON object
+```

--- a/plugins/automations/skills/automations/references/updates.md
+++ b/plugins/automations/skills/automations/references/updates.md
@@ -1,0 +1,46 @@
+`list` and `show` are diagnostic reads: a damaged record remains visible as
+`Prompt required` or `Invalid data` instead of failing the whole read. A
+`Prompt required` record opens in the Automations panel's standard editor,
+where the user can add its prompt while reviewing the other settings. It can
+also be repaired directly:
+
+```bash
+bb automation update <automationId> --project <id> --prompt "<prompt>"
+```
+
+Writes remain strict. Run, pause, and resume reject damaged records; update
+succeeds only when the resulting complete record is canonical. Every successful
+create/update persists the canonical format.
+
+Choose one of two execution update forms:
+
+- A complete replacement uses `--prompt`, `--provider`, and `--model` together
+  to replace the execution with an agent, or `--script`/`--script-file` to
+  replace it with a script. Add `--reasoning` and `--service-tier` when needed.
+  Include every desired mode-specific setting;
+  settings from the previous execution do not carry over.
+- A partial agent update preserves every omitted execution field and edits the
+  existing agent automation in place. Use any combination of `--prompt`,
+  `--provider`, `--model`, `--reasoning`, `--service-tier`, and
+  `--permission-mode accept-edits|auto|full`, then choose at most one execution
+  target. When changing providers, pass the provider's coherent model,
+  reasoning, tier, and permission selection together:
+
+```bash
+bb automation update <automationId> --project <id> \
+  --environment <environment-id-or-path>
+bb automation update <automationId> --project <id> \
+  --target-thread <thread-id>
+bb automation update <automationId> --project <id> \
+  --new-environment worktree [--base-branch <branch>]
+```
+
+`--target-thread`, `--environment`, and `--new-environment` are mutually
+exclusive. These flags apply only to agent automations; script automations have
+no execution environment.
+
+Every command supports `--json`. For `list` and `show`, the JSON result is a
+union discriminated by `problem`: canonical records omit it, while degraded
+records use `"missing-agent-prompt"` or `"invalid-stored-data"`. The
+missing-prompt variant retains the full readable automation; the invalid-data
+variant contains only `id`, `projectId`, `name`, and `problem`.

--- a/plugins/concurrency-limit/skills/concurrency-limit/SKILL.md
+++ b/plugins/concurrency-limit/skills/concurrency-limit/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: concurrency-limit
+description: "Inspect or change global and per-host limits on concurrently running BB threads."
+---
+
+# Concurrency limits
+
+Use `bb concurrency-limit status --json` to inspect current limits.
+
+```sh
+bb concurrency-limit global [unlimited|<limit>] [--json]
+bb concurrency-limit host <host-id> [auto|<limit>] [--json]
+```
+
+Automatic host limits allow one thread per available processor. Resolve the host
+with `bb machine list` before changing a host limit. Omit the value to inspect it;
+change limits only for the requested scope and verify the resulting status.

--- a/plugins/connect/skills/share-server-links/SKILL.md
+++ b/plugins/connect/skills/share-server-links/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: share-server-links
-description: Share a local HTTP server with the user over bb connect. Use when an agent has started a local HTTP server (dev server, preview, static server) and wants to hand the user a link they can open — especially remotely ("start the dev server", "let me see it", "preview", "open it on my phone", "share a link"). Prefer this over pasting localhost URLs when bb connect may be paired.
+description: "Expose a local HTTP server through BB Connect and give the user its remotely accessible URL."
 ---
 
 # Share local server links via bb connect

--- a/plugins/docs/skills/docs/SKILL.md
+++ b/plugins/docs/skills/docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: docs
-description: Access and update the user's Docs vaults. Use whenever the user asks to read, find, create, update, or store a note, document, plan, or HTML artifact; when a Docs @-mention appears in context; or when an answer should link to a document the user can open in Docs.
+description: "Read, edit, or save documents in BB Docs vaults, including documents supplied through Docs mentions."
 ---
 
 # Docs

--- a/plugins/inline-vis/skills/inline-vis/SKILL.md
+++ b/plugins/inline-vis/skills/inline-vis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: inline-vis
-description: Emit a sandboxed inline HTML visualization in an assistant message when a workspace .html file should render in-thread. Use after writing or updating a demo/chart/report HTML file the user should see without opening a panel.
+description: "Render a workspace HTML artifact inline in BB chat using the inline-vis directive."
 ---
 
 # Inline HTML visualizations
@@ -32,23 +32,6 @@ block):
   stays literal text.
 - Incomplete streaming syntax stays literal until the closing `}` arrives — emit
   a complete directive in one piece when possible.
-
-## Example turn
-
-1. Write `demo.html` with a simple visualization (inline styles, no remote JS).
-2. Reply with a short caption and the directive:
-
-```text
-Here is the chart:
-
-::inline-vis{file="demo.html"}
-```
-
-For a taller visualization, emit for example:
-
-```text
-::inline-vis{file="demo.html" height="640"}
-```
 
 The bb app replaces the directive with a sandboxed preview. If the plugin is
 disabled or the path is invalid, users see the original directive source or an

--- a/plugins/memory/skills/memory/SKILL.md
+++ b/plugins/memory/skills/memory/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: memory
-description: Use durable BB memory when prior project knowledge or cross-project user preferences can improve the current task, and save durable new learning through the bb memory CLI.
+description: "Retrieve relevant durable BB memories or save verified knowledge useful to future threads."
 ---
 
 # BB memory
 
-This plugin is provider-independent. Recommend disabling provider-native
-memory under Settings → Providers to avoid duplicated or conflicting stores.
+This plugin is provider-independent. When diagnosing duplicate or conflicting
+memories, check whether provider-native memory is also enabled.
 
 The memory plugin automatically injects a compact index of global memories and
 memories for the current BB project. The index contains summaries only.

--- a/plugins/provider-acp/skills/acp-provider/SKILL.md
+++ b/plugins/provider-acp/skills/acp-provider/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: acp-provider
+description: "Configure or troubleshoot ACP agent discovery, custom models, skills, and compaction in BB."
+---
+
+# ACP providers
+
+Known agents can be discovered automatically when their CLI is installed on the
+host: `opencode`, `omp`, `grok`, and `hermes` appear as `acp-opencode`, `acp-omp`,
+`acp-grok`, and `acp-hermes-agent`. Inspect the target host's catalog with
+`bb provider list` and `bb provider models <provider-id>` using its environment
+or machine selector.
+
+Cursor project skills come from `.cursor/skills`, which can link to
+`.agents/skills`. BB lists these linked skills as read-only under `cursor-project`.
+
+ACP agents may reject unlisted model IDs. OpenCode requires models in its own
+configuration; BB discovers them there. OpenCode agents are session modes, not
+models selectable through BB's model field.
+
+OpenCode ACP supports the core `bb thread compact` command; Cursor ACP does not
+expose compatible compaction. Check the actual agent's capabilities before
+attempting provider-specific recovery.

--- a/plugins/provider-claude-code/skills/claude-code-provider/SKILL.md
+++ b/plugins/provider-claude-code/skills/claude-code-provider/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: claude-code-provider
+description: "Configure or troubleshoot BB-specific Claude Code provider settings and session behavior."
+---
+
+# Claude Code provider
+
+Read settings with `bb plugin config provider-claude-code`; change a declared key
+with `bb plugin config provider-claude-code set <key> <value>`.
+
+- `idleQueryReleaseEnabled` defaults to `false`. When enabled, the native process
+  closes after 30 seconds of quiescence while the BB thread remains resumable.
+  Changes apply on the next start, resume, or turn.
+- `chromeEnabled` defaults to `false`. It starts Claude Code with `--chrome` for
+  Claude in Chrome tools. The host needs the extension and a claude.ai login.
+  A change restarts the thread's Claude process before its next turn, preserving
+  context.
+- Structured plan, message editing, and compaction are supported through the
+  corresponding `bb thread` commands. Unlisted model IDs are accepted by the
+  provider; verify actual availability on the target host.
+
+Inspect the thread and provider state after a change; do not restart unrelated
+threads or change settings merely to answer a question.

--- a/plugins/provider-codex/skills/codex-provider/SKILL.md
+++ b/plugins/provider-codex/skills/codex-provider/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: codex-provider
+description: "Diagnose BB-specific Codex session controls, model acceptance, and durable goals."
+---
+
+# Codex provider
+
+Codex supports structured plan requests, editing and rerunning eligible messages,
+and compaction through the corresponding core `bb thread` commands.
+`bb thread clear-goal <id>` clears its durable active Goal and waits for provider
+confirmation. Inspect the thread before recovery actions.
+
+Unlisted model IDs are accepted by this provider; acceptance does not establish
+account access. Inspect models on the actual execution host with
+`bb provider models codex` using the machine or environment selector.
+
+Use the core CLI skill for command syntax and official Codex guidance for
+upstream product behavior.

--- a/plugins/provider-pi/skills/pi-provider/SKILL.md
+++ b/plugins/provider-pi/skills/pi-provider/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: pi-provider
+description: "Inspect BB Pi provider support for message editing and context compaction."
+---
+
+# Pi provider
+
+Pi supports editing and rerunning eligible user messages and compacting idle or
+errored threads through the core `bb thread edit-message` and `bb thread compact`
+commands. Inspect the thread first and use live command help for arguments.
+Provider confirmation determines whether the operation completed.
+
+Use the target host's provider catalog for available models and execution options.

--- a/plugins/provider-retry/skills/provider-retry/SKILL.md
+++ b/plugins/provider-retry/skills/provider-retry/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: provider-retry
+description: "Diagnose automatic retries of BB turns after provider subscription-window limits."
+---
+
+# Provider retry
+
+The plugin is enabled on fresh installations. When a turn fails on a structured
+Codex or Claude Code subscription-window limit with a reset time, it queues the
+original input verbatim for after the window opens, marked agent-only.
+
+A pending retry is an ordinary durable queued row and survives restart. Inspect
+it with `bb thread queue list <thread-id>` and inspect the failed turn before
+manually retrying it; avoid duplicating an existing queued retry.
+
+Use the core `bb thread retry` command for an intentional manual retry. Follow
+its live help for selection and scheduling flags.

--- a/plugins/secrets/skills/secrets/SKILL.md
+++ b/plugins/secrets/skills/secrets/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: secrets
-description: Securely request API keys, access tokens, passwords, webhook secrets, or other credentials and write them to a dotenv file without exposing their values to the agent. Use whenever a task needs a credential that the user must supply.
+description: "Request user-supplied credentials securely into a dotenv file without exposing their values to the agent."
 ---
 
 # Request secrets securely
 
-Use `bb secret request` whenever work needs a credential. Do not ask the user to paste a secret into chat.
+Use `bb secret request` when the user needs to supply a credential. Do not ask the user to paste a secret into chat.
 
 Batch every currently known variable into one request. Inspect documentation or `.env.example` to identify variable names, but do not read or print an existing secret-bearing env file.
 

--- a/plugins/tasks/skills/tasks/SKILL.md
+++ b/plugins/tasks/skills/tasks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tasks
-description: Use when asked to work on or track a task in the Tasks plugin, when the prompt mentions a task key such as ABC-12, or when work needs task comments, attachments, delegation tracking, or status updates.
+description: "Work on or manage records in BB Tasks, including task keys such as ABC-12."
 ---
 
 # Tasks
@@ -8,21 +8,8 @@ description: Use when asked to work on or track a task in the Tasks plugin, when
 Use the `bb tasks` CLI to understand the assigned task, keep its record useful,
 and report the outcome where the work is tracked.
 
-Delegation presets are user-defined; Tasks ships with none. Before dispatching
-work, use `bb tasks preset list` and create a preset if the required one does
-not already exist. Dispatch requires an existing preset.
-
-Create or update the same execution selection exposed in the Tasks UI with
-`--provider`, `--model`, `--reasoning`, and optional
-`--service-tier default|fast|none`:
-
-```sh
-bb tasks preset create --name "Codex high" --provider codex \
-  --model gpt-5.6-sol --reasoning high --service-tier fast \
-  --permission auto
-```
-
-`preset update` accepts the same flags; `--service-tier none` clears a tier.
+For task dispatch and execution presets, read
+[references/delegation.md](references/delegation.md).
 
 ## Work a task
 
@@ -75,7 +62,8 @@ bb tasks preset create --name "Codex high" --provider codex \
    Read `references/attachments.md` for comment attachments, initial files,
    removal rules, and machine selection.
 
-5. When the work is ready for review, update the task:
+5. Set the status to match the completion criteria. Use `done` when they are
+   met, or `in_review` when required review remains:
 
    ```sh
    bb tasks update ABC-12 --status in_review

--- a/plugins/tasks/skills/tasks/references/delegation.md
+++ b/plugins/tasks/skills/tasks/references/delegation.md
@@ -1,0 +1,15 @@
+Delegation presets are user-defined; Tasks ships with none. Before dispatching
+work, use `bb tasks preset list` and create a preset if the required one does
+not already exist. Dispatch requires an existing preset.
+
+Create or update the same execution selection exposed in the Tasks UI with
+`--provider`, `--model`, `--reasoning`, and optional
+`--service-tier default|fast|none`:
+
+```sh
+bb tasks preset create --name "Codex high" --provider codex \
+  --model gpt-5.6-sol --reasoning high --service-tier fast \
+  --permission auto
+```
+
+`preset update` accepts the same flags; `--service-tier none` clears a tier.

--- a/plugins/theme-preview/skills/bb-theme-authoring/SKILL.md
+++ b/plugins/theme-preview/skills/bb-theme-authoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bb-theme-authoring
-description: Create or edit a bb theme (the app's colour palette) as a custom CSS theme and verify it live in the Theme Preview panel. Use whenever the user asks for a new bb theme, a palette change, a light/dark variant, or wants to iterate on how bb looks.
+description: "Create or edit BB color themes and inspect them in the Theme Preview panel."
 ---
 
 # Authoring a bb theme
@@ -41,11 +41,10 @@ Every declaration is a `--token: value;` custom property.
 
 ```css
 :root, .light {
-  --canvas: #f4f4f4;          /* the app background */
-  --ink: #0a0a0a;             /* body text */
-  --primary: #2e6f95;         /* links, focus ring, accents */
+  --canvas: #f4f4f4;
+  --ink: #0a0a0a;
+  --primary: #2e6f95;
   --primary-foreground: #ffffff;
-  /* …more tokens… */
 }
 
 .dark {
@@ -113,15 +112,5 @@ thread; Theme Preview does not block or automatically adjust the theme.
 
 Keep dark-mode text below ~12:1 on near-black surfaces; higher blooms on OLED.
 
-## Shipping a theme in a plugin
-
-A plugin can contribute themes via its manifest instead of the theme dir:
-
-```json
-"bb": { "themes": [{ "id": "mine", "name": "Mine", "css": "./themes/mine.css" }] }
-```
-
-bb lists it as `plugin:<pluginId>:mine`. Theme Preview resolves the CSS through
-the manifest, so chips and live reload work the same way. Install with
-`bb plugin install path:<dir> --yes`, reload with `bb plugin reload <pluginId>`
-after CSS edits.
+For manifest-contributed themes, read
+[references/plugin-themes.md](references/plugin-themes.md).

--- a/plugins/theme-preview/skills/bb-theme-authoring/references/plugin-themes.md
+++ b/plugins/theme-preview/skills/bb-theme-authoring/references/plugin-themes.md
@@ -1,0 +1,12 @@
+## Shipping a theme in a plugin
+
+A plugin can contribute themes via its manifest instead of the theme dir:
+
+```json
+"bb": { "themes": [{ "id": "mine", "name": "Mine", "css": "./themes/mine.css" }] }
+```
+
+bb lists it as `plugin:<pluginId>:mine`. Theme Preview resolves the CSS through
+the manifest, so chips and live reload work the same way. Install with
+`bb plugin install path:<dir> --yes`, reload with `bb plugin reload <pluginId>`
+after CSS edits.

--- a/plugins/workflows/skills/workflows/SKILL.md
+++ b/plugins/workflows/skills/workflows/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflows
-description: Execute a workflow script that orchestrates multiple subagents deterministically. Use when the user explicitly requests a workflow, multi-agent orchestration, parallel or sequential agent pipelines, structured agent outputs, or a durable background workflow run.
+description: "Author or run durable BB workflows when the user requests workflow execution or multi-agent orchestration."
 ---
 
 # BB workflows


### PR DESCRIPTION
## Human comments

## What was wrong

Always-loaded agent instructions repeated workflow details and mixed individual plugins' behavior into the core BB CLI skill. Broad skill descriptions and unconditional reading or evaluation steps added context and work unrelated to the request.

## What changed

- Condense AGENTS.md while preserving repository constraints and clarifying completion and proportionate verification.
- Shorten built-in and repository skill descriptions, move conditional procedures into references, and make skill evaluation proportional to the change.
- Move Account Pooler, concurrency limits, provider retries, and provider-specific guidance into seven skills owned by their plugins. Keep the core CLI skill focused on core commands and generic plugin management.
- Update the CLI documentation policy and plugin-authoring guidance to preserve that ownership boundary.
- Replace prose-specific test assertions with runtime metadata parsing and verification that plugin import preserves the description.

This PR contains repository changes only; separately updated provider-installed and personal skills remain local.

## How you verified

- Validated skill frontmatter, names, description limits, and concrete resource links; checked that new plugin skills use the default discovered `skills/` root.
- Confirmed no plugin-specific command manuals remain in the core CLI skill and ran `git diff --check`.
- Ran simulated workflow-selection checks and before/after comparisons for representative instructions. These were instruction reviews, not live end-to-end executions.
- CI exposed 21 wording-only failures: descriptions had to contain capitalized `Use`, and the example description had to contain capitalized `Conventions`. Updated both affected test files to validate metadata rather than wording.
- With Node 22.23.2, `pnpm exec turbo run test --filter=@bb/server -- test/skills/shipped-skills-quality.test.ts test/services/plugins/heroes.test.ts` passes: 25 tests in two files. The earlier Node 24 run was blocked by native-module setup; Node 22 matches CI and completed setup successfully.
- The working-tree, HEAD, and push-range EAP codename scans were clean.

> AGENT GENERATED
