### PR TITLE
Add drag reordering to account pool settings

### DIFF
--- a/plugins/account-pool/PLUGIN_OVERVIEW.md
+++ b/plugins/account-pool/PLUGIN_OVERVIEW.md
@@ -4,7 +4,7 @@ Keep a Claude Code or Codex thread running when one account hits its limit. The 
 
 - A pool of Claude and Codex accounts, added by importing the login already on the machine, signing in through the browser, or pasting an Anthropic API key.
 - Accounts run one after another in priority order, with ties following the order added. New conversations stay on the current fallback even when an earlier account recovers. Existing conversations keep their own account until it becomes unavailable.
-- Up/down arrows set the account order in settings, with the same operation available through `bb pool account reorder <claude|codex> <id>...`.
+- Drag handles set the account order within each provider in settings (keyboard: Space to pick up, arrow keys to move, Space to drop, Escape to cancel), with the same operation available through `bb pool account reorder <claude|codex> <id>...`.
 - Live limit windows per account and model family in the plugin's settings page, and the same numbers from `bb pool status`.
 - A routing switch per provider and a bypass per thread, so one thread can go straight to its own credentials.
 

--- a/plugins/account-pool/app.test.tsx
+++ b/plugins/account-pool/app.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, waitFor } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { loadPluginApp, renderSlot } from "@get-bb/plugin-sdk/testing/app";
 import type {
   AccountPoolConfig,
@@ -9,7 +9,30 @@ import type {
 } from "./src/contracts.js";
 
 const app = await loadPluginApp(() => import("./app"));
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function measureAccountRows() {
+  vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+    function (this: HTMLElement) {
+      const handle = this.querySelector(
+        'button[aria-roledescription="sortable"]',
+      );
+      const rows = Array.from(this.parentElement?.children ?? []);
+      return new DOMRect(0, handle ? rows.indexOf(this) * 60 : 0, 600, 60);
+    },
+  );
+}
+
+async function keyboardMove(handle: HTMLElement, code = "ArrowDown") {
+  handle.focus();
+  fireEvent.keyDown(handle, { code: "Space" });
+  await waitFor(() => expect(handle.getAttribute("aria-pressed")).toBe("true"));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  fireEvent.keyDown(document, { code });
+}
 
 function account(overrides: Partial<AccountSummary> = {}): AccountSummary {
   return {
@@ -317,61 +340,60 @@ describe("Account Pool settings", () => {
     fireEvent.click(await slot.findByRole("button", { name: "Try again" }));
     await waitFor(() => expect(starts).toBe(2));
   });
-  it("reorders accounts within their provider and refreshes the displayed order", async () => {
-    const first = account({ label: "First" });
-    const second = account({
-      id: "22222222-2222-4222-8222-222222222222",
-      label: "Second",
-    });
-    const codex = account({
-      id: "33333333-3333-4333-8333-333333333333",
-      provider: "codex",
-      label: "Codex",
-    });
-    const accounts = [first, second, codex];
-    const slot = render(accounts, {
-      "account.reorder": () => {
-        accounts.splice(0, 2, second, first);
-        return null;
-      },
-    });
-    expect(
-      (await slot.findByRole("button", { name: "Move First up" })).hasAttribute(
-        "disabled",
-      ),
-    ).toBe(true);
-    fireEvent.click(slot.getByRole("button", { name: "Move First down" }));
-    await waitFor(() =>
-      expect(slot.rpcCalls).toContainEqual({
-        method: "account.reorder",
-        input: { provider: "claude", accountIds: [second.id, first.id] },
-      }),
-    );
-    await waitFor(() =>
+  it.each(["claude", "codex"] as const)(
+    "reorders %s accounts with the keyboard and persists the displayed order",
+    async (provider) => {
+      measureAccountRows();
+      const first = account({ label: "First", provider });
+      const second = account({
+        id: "22222222-2222-4222-8222-222222222222",
+        label: "Second",
+        provider,
+      });
+      const other = account({
+        id: "33333333-3333-4333-8333-333333333333",
+        provider: provider === "claude" ? "codex" : "claude",
+        label: "Other",
+      });
+      const accounts = [first, second, other];
+      let finishSave = () => {};
+      const slot = render(accounts, {
+        "account.reorder": () =>
+          new Promise<null>((resolve) => {
+            finishSave = () => {
+              accounts.splice(0, 2, second, first);
+              resolve(null);
+            };
+          }),
+      });
+      const handle = await slot.findByRole("button", { name: "Reorder First" });
+      await keyboardMove(handle);
+      fireEvent.keyDown(document, { code: "Space" });
+      await waitFor(() =>
+        expect(slot.rpcCalls).toContainEqual({
+          method: "account.reorder",
+          input: { provider, accountIds: [second.id, first.id] },
+        }),
+      );
+      const providerOrder = () =>
+        slot
+          .getAllByRole("button", { name: /Reorder (First|Second)/ })
+          .map((button) => button.getAttribute("aria-label"));
+      expect(providerOrder()).toEqual(["Reorder Second", "Reorder First"]);
+      expect(handle.hasAttribute("disabled")).toBe(true);
+      finishSave();
+      await waitFor(() => expect(handle.hasAttribute("disabled")).toBe(false));
+      expect(providerOrder()).toEqual(["Reorder Second", "Reorder First"]);
       expect(
         slot
-          .getByRole("button", { name: "Move Second up" })
+          .getByRole("button", { name: "Reorder Other" })
           .hasAttribute("disabled"),
-      ).toBe(true),
-    );
-    expect(
-      slot
-        .getByRole("button", { name: "Move First down" })
-        .hasAttribute("disabled"),
-    ).toBe(true);
-    expect(
-      slot
-        .getByRole("button", { name: "Move Codex up" })
-        .hasAttribute("disabled"),
-    ).toBe(true);
-    expect(
-      slot
-        .getByRole("button", { name: "Move Codex down" })
-        .hasAttribute("disabled"),
-    ).toBe(true);
-  });
+      ).toBe(true);
+    },
+  );
 
-  it("keeps the displayed order and reports a rejected reorder", async () => {
+  it("restores the displayed order and reports a rejected reorder", async () => {
+    measureAccountRows();
     const slot = render(
       [
         account({ label: "First" }),
@@ -386,21 +408,47 @@ describe("Account Pool settings", () => {
         },
       },
     );
-    fireEvent.click(
-      await slot.findByRole("button", { name: "Move First down" }),
-    );
+    const handle = await slot.findByRole("button", { name: "Reorder First" });
+    await keyboardMove(handle);
+    fireEvent.keyDown(document, { code: "Space" });
     expect(
       await slot.findByText("Refresh the account list and try again."),
     ).toBeTruthy();
     expect(
       slot
-        .getByRole("button", { name: "Move First up" })
-        .hasAttribute("disabled"),
-    ).toBe(true);
-    expect(
-      slot
-        .getByRole("button", { name: "Move First down" })
-        .hasAttribute("disabled"),
-    ).toBe(false);
+        .getAllByRole("button", { name: /Reorder/ })
+        .map((button) => button.getAttribute("aria-label")),
+    ).toEqual(["Reorder First", "Reorder Second"]);
+    expect(handle.hasAttribute("disabled")).toBe(false);
   });
+
+  it.each(["cancel", "unchanged"])(
+    "does not save a %s drag",
+    async (action) => {
+      measureAccountRows();
+      const slot = render([
+        account({ label: "First" }),
+        account({
+          id: "22222222-2222-4222-8222-222222222222",
+          label: "Second",
+        }),
+      ]);
+      const handle = await slot.findByRole("button", { name: "Reorder First" });
+      await keyboardMove(handle, action === "cancel" ? "ArrowDown" : "ArrowUp");
+      fireEvent.keyDown(document, {
+        code: action === "cancel" ? "Escape" : "Space",
+      });
+      await waitFor(() =>
+        expect(handle.getAttribute("aria-pressed")).toBeNull(),
+      );
+      expect(
+        slot.rpcCalls.filter((call) => call.method === "account.reorder"),
+      ).toEqual([]);
+      expect(
+        slot
+          .getAllByRole("button", { name: /Reorder/ })
+          .map((button) => button.getAttribute("aria-label")),
+      ).toEqual(["Reorder First", "Reorder Second"]);
+    },
+  );
 });

--- a/plugins/account-pool/app.tsx
+++ b/plugins/account-pool/app.tsx
@@ -6,6 +6,24 @@ import {
   type ReactNode,
 } from "react";
 import {
+  closestCenter,
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type Modifier,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import {
   definePluginApp,
   useBbNavigate,
   useRealtime,
@@ -272,48 +290,59 @@ function QuotaValue({
   );
 }
 
+const restrictAccountDragToVerticalAxis: Modifier = ({ transform }) => ({
+  ...transform,
+  x: 0,
+});
+const accountDragModifiers: Modifier[] = [restrictAccountDragToVerticalAxis];
+
 function AccountRow({
   account,
   threshold,
   pending,
   onAction,
   onOpen,
-  onMoveUp,
-  onMoveDown,
+  reorderDisabled,
 }: {
   account: AccountSummary;
   threshold: number;
   pending: boolean;
   onAction: (action: "toggle" | "priority" | "refresh" | "remove") => void;
   onOpen: () => void;
-  onMoveUp: (() => void) | null;
-  onMoveDown: (() => void) | null;
+  reorderDisabled: boolean;
 }) {
   const status = statusPresentation(account);
+  const {
+    attributes,
+    isDragging,
+    listeners,
+    setActivatorNodeRef,
+    setNodeRef,
+    transform,
+    transition,
+  } = useSortable({ id: account.id, disabled: pending || reorderDisabled });
   return (
-    <div className="flex items-center gap-3 text-sm">
-      <div className="flex shrink-0 items-center gap-1">
-        <Button
-          variant="ghost"
-          size="icon"
-          className="size-8"
-          aria-label={`Move ${account.label} up`}
-          disabled={pending || onMoveUp === null}
-          onClick={() => onMoveUp?.()}
-        >
-          <Icon name="ArrowUp" className="size-4" />
-        </Button>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="size-8"
-          aria-label={`Move ${account.label} down`}
-          disabled={pending || onMoveDown === null}
-          onClick={() => onMoveDown?.()}
-        >
-          <Icon name="ArrowDown" className="size-4" />
-        </Button>
-      </div>
+    <div
+      ref={setNodeRef}
+      style={{ transform: CSS.Translate.toString(transform), transition }}
+      className={cn(
+        "flex items-center gap-3 text-sm",
+        isDragging && "relative z-10 rounded-md bg-card opacity-90 shadow-lift",
+      )}
+    >
+      <Button
+        ref={setActivatorNodeRef}
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="size-8 shrink-0 touch-none text-muted-foreground enabled:cursor-grab enabled:active:cursor-grabbing"
+        disabled={pending || reorderDisabled}
+        aria-label={`Reorder ${account.label}`}
+        {...attributes}
+        {...listeners}
+      >
+        <Icon name="DragDropVertical" aria-hidden="true" />
+      </Button>
       <div
         className={cn(
           "group -mx-2 flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-2.5 transition-colors hover:bg-state-hover focus-within:bg-state-hover",
@@ -650,6 +679,16 @@ function AccountPoolSettings() {
   const [drawer, setDrawer] = useState<DrawerState>(null);
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState<string | null>(null);
+  const [optimisticOrder, setOptimisticOrder] = useState<{
+    provider: PoolProvider;
+    ids: string[];
+  } | null>(null);
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
   const [loginStep, setLoginStep] = useState<LoginStep | null>(null);
   const [codexStep, setCodexStep] = useState<CodexLoginStep | null>(null);
   const [loginDone, setLoginDone] = useState<string | null>(null);
@@ -864,24 +903,26 @@ function AccountPoolSettings() {
         await rpc.call("account.refreshUsage", { accountId: account.id });
     });
   }
-  async function moveAccount(
-    account: AccountSummary,
-    offset: number,
+  async function reorderAccounts(
+    provider: PoolProvider,
+    event: DragEndEvent,
   ): Promise<void> {
-    const ordered = accounts
-      .filter((candidate) => candidate.provider === account.provider)
-      .map((candidate) => candidate.id);
-    const index = ordered.indexOf(account.id);
-    const target = index + offset;
-    if (index < 0 || target < 0 || target >= ordered.length) return;
-    ordered.splice(index, 1);
-    ordered.splice(target, 0, account.id);
-    await run(`order-${account.provider}`, async () => {
-      await rpc.call("account.reorder", {
-        provider: account.provider,
-        accountIds: ordered,
+    if (pending !== null || event.over === null) return;
+    const ids = accounts
+      .filter((account) => account.provider === provider)
+      .map((account) => account.id);
+    const from = ids.findIndex((id) => id === event.active.id);
+    const to = ids.findIndex((id) => id === event.over?.id);
+    if (from < 0 || to < 0 || from === to) return;
+    const accountIds = arrayMove(ids, from, to);
+    setOptimisticOrder({ provider, ids: accountIds });
+    try {
+      await run(`order-${provider}`, async () => {
+        await rpc.call("account.reorder", { provider, accountIds });
       });
-    });
+    } finally {
+      setOptimisticOrder(null);
+    }
   }
   function closeDrawer(): void {
     if (drawer?.kind === "codex-login" && codexStep !== null)
@@ -934,9 +975,21 @@ function AccountPoolSettings() {
         </div>
       ) : null}
       {PROVIDERS.map((provider) => {
-        const providerAccounts = accounts.filter(
+        const serverAccounts = accounts.filter(
           (account) => account.provider === provider.id,
         );
+        const order =
+          optimisticOrder?.provider === provider.id
+            ? optimisticOrder.ids
+            : null;
+        const providerAccounts =
+          order !== null &&
+          order.length === serverAccounts.length &&
+          serverAccounts.every((account) => order.includes(account.id))
+            ? order.flatMap((id) =>
+                serverAccounts.filter((account) => account.id === id),
+              )
+            : serverAccounts;
         return (
           <SettingsSection
             key={provider.id}
@@ -971,28 +1024,35 @@ function AccountPoolSettings() {
                 No accounts yet.
               </p>
             ) : (
-              <div className="divide-y divide-border">
-                {providerAccounts.map((account, index) => (
-                  <AccountRow
-                    key={account.id}
-                    account={account}
-                    threshold={threshold}
-                    pending={pending !== null}
-                    onAction={(action) => void accountAction(account, action)}
-                    onMoveUp={
-                      index === 0 ? null : () => void moveAccount(account, -1)
-                    }
-                    onMoveDown={
-                      index === providerAccounts.length - 1
-                        ? null
-                        : () => void moveAccount(account, 1)
-                    }
-                    onOpen={() =>
-                      setDrawer({ kind: "account", accountId: account.id })
-                    }
-                  />
-                ))}
-              </div>
+              <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                modifiers={accountDragModifiers}
+                onDragEnd={(event) => void reorderAccounts(provider.id, event)}
+              >
+                <SortableContext
+                  items={providerAccounts.map((account) => account.id)}
+                  strategy={verticalListSortingStrategy}
+                >
+                  <div className="divide-y divide-border">
+                    {providerAccounts.map((account) => (
+                      <AccountRow
+                        key={account.id}
+                        account={account}
+                        threshold={threshold}
+                        pending={pending !== null}
+                        reorderDisabled={providerAccounts.length < 2}
+                        onAction={(action) =>
+                          void accountAction(account, action)
+                        }
+                        onOpen={() =>
+                          setDrawer({ kind: "account", accountId: account.id })
+                        }
+                      />
+                    ))}
+                  </div>
+                </SortableContext>
+              </DndContext>
             )}
           </SettingsSection>
         );

--- a/plugins/account-pool/package.json
+++ b/plugins/account-pool/package.json
@@ -22,6 +22,9 @@
   },
   "dependencies": {
     "@bb/shared-ui": "workspace:*",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/plugins/account-pool/skills/account-pool/references/accounts-and-routing.md
+++ b/plugins/account-pool/skills/account-pool/references/accounts-and-routing.md
@@ -67,7 +67,8 @@ family without moving the session's main pin or the provider cursor. The cursor
 and session pins survive hub restarts. Session pins expire after 30 idle minutes,
 and the pool retains the 4,096 most recently used pins.
 
-Use the up/down arrows in Account Pooler settings, or
+Drag an account’s handle in Account Pooler settings (or focus the handle and use
+Space, arrow keys, and Space again), or
 `bb pool account reorder <claude|codex> <id>...`, to set the complete order for
 one provider. Include disabled accounts too. Reordering changes the next failover
 sequence without moving the current account. `bb pool account priority <id> <n>`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2748,6 +2748,15 @@ importers:
       '@bb/shared-ui':
         specifier: workspace:*
         version: link:../../packages/shared-ui
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.4)
       zod:
         specifier: 4.3.6
         version: 4.3.6


### PR DESCRIPTION
## Human comments

## What was wrong

Account Pooler settings only offered up/down buttons, so moving an account several positions required repeated clicks despite other settings lists already supporting drag reordering.

## What changed

Replace the arrows with drag handles using the provider settings list’s dnd-kit pattern. Claude and Codex each have their own sortable list, with keyboard support, immediate visual updates, disabled handles while saving, and rollback when saving fails. Reuse the existing account reorder RPC and CLI, and update the plugin documentation.

## How you verified

- `pnpm exec turbo run test typecheck --filter=bb-plugin-account-pool` on Node 22: 253 tests passed, including both providers’ keyboard reorder, pending saves, rollback, cancellation, and unchanged drops.
- Built the frontend with this checkout’s plugin build tooling and workspace SDK.
- Dragged rows in Chrome for both providers against the built bundle with fixture RPC handlers; confirmed the displayed order and provider-specific reorder requests.
- Started the dev app and added three dummy Claude accounts for manual testing.
- Formatting, whitespace checks, and EAP codename scan passed for the working tree and push range.

> AGENT GENERATED
