### PR TITLE
Clarify workspace mode in the new-thread environment picker

### DIFF
--- a/apps/app/src/components/pickers/EnvironmentPicker.stories.tsx
+++ b/apps/app/src/components/pickers/EnvironmentPicker.stories.tsx
@@ -41,7 +41,7 @@ const noop = () => {};
 export function Overview() {
   return (
     <StoryCard>
-      <StoryRow label="local direct" hint="selected: Work locally">
+      <StoryRow label="current checkout" hint="selected: Current checkout">
         <EnvironmentPickerUI
           value={`host:${HOST_IDS.local}:local`}
           onChange={noop}
@@ -70,8 +70,8 @@ export function Overview() {
         />
       </StoryRow>
       <StoryRow
-        label="reuse selected"
-        hint="env mode is reuse — button shows 'Reuse worktree'; the specific worktree lives in the adjacent WorktreePicker"
+        label="existing worktree selected"
+        hint="env mode is reuse — button shows 'Existing worktree'; the specific worktree lives in the adjacent WorktreePicker"
       >
         <EnvironmentPickerUI
           value="reuse"
@@ -109,7 +109,7 @@ export function Overview() {
       </StoryRow>
       <StoryRow
         label="remote host (online)"
-        hint="viewed from another device: open the menu to see the host name and 'Work remotely' enabled"
+        hint="viewed from another device: the trigger shows the selected host and 'Current checkout' workspace mode"
       >
         <EnvironmentPickerUI
           value={`host:${HOST_IDS.local}:local`}

--- a/apps/app/src/components/pickers/EnvironmentPicker.test.tsx
+++ b/apps/app/src/components/pickers/EnvironmentPicker.test.tsx
@@ -48,12 +48,15 @@ describe("EnvironmentPickerUI", () => {
       button: 0,
     });
 
-    const localItem = screen.getByRole("menuitem", { name: /Work locally/u });
+    const checkoutItem = screen.getByRole("menuitem", {
+      name: /Current checkout/u,
+    });
     const worktreeItem = screen.getByRole("menuitem", {
       name: /New worktree/u,
     });
 
-    expect(localItem.getAttribute("aria-disabled")).toBeNull();
+    expect(checkoutItem.getAttribute("aria-disabled")).toBeNull();
+    expect(screen.getByText("/tmp/project")).toBeTruthy();
     expect(worktreeItem.getAttribute("aria-disabled")).toBe("true");
     expect(
       screen.getByText("Project source is not a git repository"),
@@ -191,10 +194,10 @@ describe("EnvironmentPickerUI multi-machine menu", () => {
       button: 0,
     });
 
-    const checkoutItem = screen.getByRole("menuitem", {
-      name: /Work in checkout/u,
+    const checkoutItems = screen.getAllByRole("menuitem", {
+      name: /Current checkout/u,
     });
-    expect(checkoutItem.getAttribute("aria-disabled")).toBe("true");
+    expect(checkoutItems[1]!.getAttribute("aria-disabled")).toBe("true");
   });
 
   it("offers guided setup for a connected machine without a source", () => {
@@ -255,11 +258,11 @@ describe("EnvironmentPickerUI multi-machine menu", () => {
     expect(placeholder.getAttribute("aria-disabled")).toBe("true");
   });
 
-  it("names the primary machine in the trigger label when multiple machines exist", () => {
-    renderMachineMenu({ value: `host:${thisMachine.id}:worktree` });
+  it("names the primary machine and workspace mode in the trigger label", () => {
+    renderMachineMenu({ value: `host:${thisMachine.id}:local` });
 
-    expect(screen.getByText("MacBook Pro · New worktree")).toBeTruthy();
-    expect(screen.getByText("Worktree")).toBeTruthy();
+    expect(screen.getByText("MacBook Pro · Current checkout")).toBeTruthy();
+    expect(screen.getByText("Checkout")).toBeTruthy();
   });
 
   it("names another selected machine in the trigger label", () => {
@@ -269,10 +272,10 @@ describe("EnvironmentPickerUI multi-machine menu", () => {
     expect(screen.getByText("Worktree")).toBeTruthy();
   });
 
-  it("keeps the single-host menu when only one host exists", () => {
+  it("keeps the single-host menu for an existing worktree selection", () => {
     render(
       <EnvironmentPickerUI
-        value={`host:${thisMachine.id}:local`}
+        value="reuse"
         onChange={vi.fn()}
         sources={machineSources}
         host={thisMachine}
@@ -285,12 +288,16 @@ describe("EnvironmentPickerUI multi-machine menu", () => {
         modal={false}
       />,
     );
+
+    expect(screen.getByText("Existing worktree")).toBeTruthy();
+    expect(screen.getByText("Existing")).toBeTruthy();
+
     fireEvent.pointerDown(screen.getByRole("button", { name: "Environment" }), {
       button: 0,
     });
 
     expect(
-      screen.getByRole("menuitem", { name: /Work locally/u }),
+      screen.getByRole("menuitem", { name: /Current checkout/u }),
     ).toBeTruthy();
     expect(screen.queryByText("MacBook Pro")).toBeNull();
   });

--- a/apps/app/src/components/pickers/EnvironmentPicker.tsx
+++ b/apps/app/src/components/pickers/EnvironmentPicker.tsx
@@ -42,6 +42,9 @@ interface SelectedEnvironment {
   icon: IconName;
 }
 
+const CURRENT_CHECKOUT_LABEL = "Current checkout";
+const EXISTING_WORKTREE_LABEL = "Existing worktree";
+
 export interface EnvironmentPickerMachines {
   hosts: readonly Host[];
   localDaemonHostId: string | null;
@@ -84,14 +87,14 @@ export function EnvironmentPickerUI({
   const hostId = host?.id ?? null;
   const isMachineMenu = (machines?.hosts.length ?? 0) > 1;
   const hostConnected = host?.status === "connected";
-  const hasSource = useMemo(
+  const projectSource = useMemo(
     () =>
-      hostId !== null &&
-      findLocalPathProjectSourceForHost(sources, hostId) !== undefined,
+      hostId === null
+        ? null
+        : (findLocalPathProjectSourceForHost(sources, hostId) ?? null),
     [hostId, sources],
   );
-  const localLabel = isLocal ? "Work locally" : "Work remotely";
-
+  const hasSource = projectSource !== null;
   const hostUnavailableReason = !host
     ? "No host connected"
     : !hostConnected
@@ -135,14 +138,15 @@ export function EnvironmentPickerUI({
     }
     if (parsed.type === "reuse") {
       return {
-        modeLabel: "Reuse worktree",
-        compactModeLabel: "Reuse",
+        modeLabel: EXISTING_WORKTREE_LABEL,
+        compactModeLabel: "Existing",
         icon: getEnvironmentWorkspaceLabelIconName("managed-worktree"),
       };
     }
-    const modeLabel = parsed.mode === "worktree" ? "New worktree" : localLabel;
+    const modeLabel =
+      parsed.mode === "worktree" ? "New worktree" : CURRENT_CHECKOUT_LABEL;
     const compactModeLabel =
-      parsed.mode === "worktree" ? "Worktree" : isLocal ? "Local" : "Remote";
+      parsed.mode === "worktree" ? "Worktree" : "Checkout";
     const icon = getEnvironmentWorkspaceLabelIconName(
       parsed.mode === "worktree" ? "managed-worktree" : "other",
     );
@@ -153,14 +157,7 @@ export function EnvironmentPickerUI({
       compactModeLabel,
       icon,
     };
-  }, [
-    parsed,
-    localLabel,
-    isLocal,
-    hostUnavailableReason,
-    host,
-    selectedMachineName,
-  ]);
+  }, [parsed, hostUnavailableReason, host, selectedMachineName]);
 
   return (
     <DropdownMenu defaultOpen={defaultOpen} modal={modal}>
@@ -230,7 +227,7 @@ export function EnvironmentPickerUI({
             hostId={hostId}
             hostName={isLocal ? null : (host?.name ?? null)}
             hostUnavailableReason={hostUnavailableReason}
-            localLabel={localLabel}
+            workspacePath={projectSource?.path ?? null}
             workspaceDisabledReason={workspaceDisabledReason}
             worktreeDisabledReason={newWorktreeDisabledReason}
             reuseDisabledReason={reuseDisabledReason}
@@ -248,7 +245,7 @@ interface EnvironmentOptionsSectionProps {
   hostId: string | null;
   hostName: string | null;
   hostUnavailableReason: string | null;
-  localLabel: string;
+  workspacePath: string | null;
   workspaceDisabledReason: string | null;
   worktreeDisabledReason: string | null;
   reuseDisabledReason: string | null;
@@ -263,7 +260,7 @@ function EnvironmentOptionsSection({
   hostId,
   hostName,
   hostUnavailableReason,
-  localLabel,
+  workspacePath,
   workspaceDisabledReason,
   worktreeDisabledReason,
   reuseDisabledReason,
@@ -295,8 +292,9 @@ function EnvironmentOptionsSection({
       ) : (
         <>
           <EnvironmentMenuItem
-            label={localLabel}
+            label={CURRENT_CHECKOUT_LABEL}
             description={workspaceDisabledDescription}
+            hint={workspacePath ?? undefined}
             icon={getEnvironmentWorkspaceLabelIconName("other")}
             selected={localValue !== null && value === localValue}
             disabled={workspaceDisabled || localValue === null}
@@ -315,7 +313,7 @@ function EnvironmentOptionsSection({
             }}
           />
           <EnvironmentMenuItem
-            label="Existing worktree"
+            label={EXISTING_WORKTREE_LABEL}
             description={reuseDisabledReason ?? undefined}
             icon={getEnvironmentWorkspaceLabelIconName("managed-worktree")}
             selected={selectedType === "reuse"}
@@ -384,7 +382,7 @@ function MachineGroupedEnvironmentOptions({
       <DropdownMenuSeparator />
       <DropdownMenuGroup>
         <EnvironmentMenuItem
-          label="Existing worktree"
+          label={EXISTING_WORKTREE_LABEL}
           description={reuseDisabledReason ?? undefined}
           icon={getEnvironmentWorkspaceLabelIconName("managed-worktree")}
           selected={selectedType === "reuse"}
@@ -444,7 +442,7 @@ function MachineSection({
       {source ? (
         <>
           <EnvironmentMenuItem
-            label={isThisMachine ? "Work locally" : "Work in checkout"}
+            label={CURRENT_CHECKOUT_LABEL}
             hint={source.path}
             icon={getEnvironmentWorkspaceLabelIconName("other")}
             selected={value === localValue}

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -883,7 +883,7 @@ function Composer({ thread }: { thread?: MockThread }) {
           ) : (
             <FolderGitIcon className="ctx-ic" />
           )}
-          <span>{isNew ? "Work locally" : "Worktree"}</span>
+          <span>{isNew ? "Current checkout" : "Worktree"}</span>
           <ChevronDown className="ctx-chev" />
         </span>
         <span className="ctx">


### PR DESCRIPTION
## Human comments

This is technically a minor UI change, but I'd treat it as a usability bug. I found the default picker very confusing: instead of showing useful information about the current checkout and leading me to the correct picker, it misled me into thinking that I needed to use a different picker to choose a worktree.

Also, “working remotely/locally” seems like useless information, since the machine being used is already shown. As far as I know, it is also slightly broken for reasons I did not dig into: it showed that I was working remotely despite the machine actually being local.

## What was wrong

The environment picker derived its checkout-mode label from the machine relationship (`Work locally` or `Work remotely`) instead of describing the selected workspace. This hid that the current checkout was selected and made the adjacent branch picker appear to be responsible for worktree selection. Fixes [#3139](https://github.com/get-bb/bb/issues/3139).

## What changed

- Label the checkout workspace mode `Current checkout`, with the compact label `Checkout`.
- Label reused worktrees `Existing worktree`, with the compact label `Existing`.
- Show the project source path beneath `Current checkout` in single-machine menus, matching multi-machine menus.
- Use the same workspace terminology in the picker stories and website composer demo.
- Update picker tests to cover the selected labels and checkout path.

This is a UI-only change. It does not change environment behavior, defaults, CLI or SDK contracts, or the host-daemon protocol.

## How you verified

- `pnpm exec turbo run test --filter=@bb/app -- src/components/pickers/EnvironmentPicker.test.tsx`
  - 10 tests passed.
  - The changed assertions fail against the previous picker labels and missing single-machine path.
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run typecheck --filter=@bb/web`
- `pnpm exec oxfmt --check apps/app/src/components/pickers/EnvironmentPicker.tsx apps/app/src/components/pickers/EnvironmentPicker.test.tsx apps/app/src/components/pickers/EnvironmentPicker.stories.tsx apps/web/src/routes/index.tsx`
- `git diff --check`

Fixes #3139

> AGENT GENERATED
