### PR TITLE
Expose safe Markdown media and explicit native file routing

### DIFF
--- a/apps/app/src/components/plugin/ExperimentalFileLink.test.tsx
+++ b/apps/app/src/components/plugin/ExperimentalFileLink.test.tsx
@@ -39,7 +39,7 @@ describe("ExperimentalFileLink", () => {
     });
   });
 
-  it("leaves modifier clicks native", () => {
+  it("gates modifier clicks without a browser fallback", () => {
     const openFilePreview = vi.fn(() => true);
     render(
       <MemoryRouter>
@@ -56,7 +56,7 @@ describe("ExperimentalFileLink", () => {
     expect(openFilePreview).not.toHaveBeenCalled();
   });
 
-  it("uses a scheme-safe href for a valid scheme-like file name", () => {
+  it("keeps a scheme-like file name out of browser navigation", () => {
     const openFilePreview = vi.fn(() => true);
     render(
       <MemoryRouter>
@@ -68,7 +68,7 @@ describe("ExperimentalFileLink", () => {
       </MemoryRouter>,
     );
     const link = screen.getByRole("link", { name: "vscode:foo" });
-    expect(link.getAttribute("href")).toBe("./vscode%3Afoo");
+    expect(link.getAttribute("href")).toBeNull();
 
     fireEvent.click(link);
     expect(openFilePreview).toHaveBeenCalledWith({

--- a/apps/app/src/components/plugin/ExperimentalFileLink.tsx
+++ b/apps/app/src/components/plugin/ExperimentalFileLink.tsx
@@ -41,6 +41,8 @@ export function ExperimentalFileLink({
   target,
   location = null,
   onClick,
+  onAuxClick,
+  onKeyDown,
   ...anchorProps
 }: ExperimentalFileLinkProps) {
   const navigation = useAppNavigationHost();
@@ -52,18 +54,38 @@ export function ExperimentalFileLink({
   const handleClick = useCallback(
     (event: ReactMouseEvent<HTMLAnchorElement>) => {
       onClick?.(event);
-      if (intent === null || !shouldHandleFileClick(event)) {
-        return;
-      }
+      const shouldOpen = intent !== null && shouldHandleFileClick(event);
       event.preventDefault();
+      if (!shouldOpen) return;
       navigation.openFilePreview(intent);
     },
     [intent, navigation, onClick],
   );
-  const href =
-    intent === null ? undefined : `./${encodeURIComponent(intent.target.path)}`;
   const anchor = (
-    <RouteAnchor {...anchorProps} href={href} onClick={handleClick} />
+    <RouteAnchor
+      {...anchorProps}
+      href={undefined}
+      role={intent === null ? undefined : "link"}
+      tabIndex={intent === null ? undefined : (anchorProps.tabIndex ?? 0)}
+      onClick={handleClick}
+      onAuxClick={(event) => {
+        onAuxClick?.(event);
+        event.preventDefault();
+      }}
+      onKeyDown={(event) => {
+        onKeyDown?.(event);
+        if (event.key === "Enter" && !event.defaultPrevented) {
+          event.preventDefault();
+          if (
+            !event.altKey &&
+            !event.ctrlKey &&
+            !event.metaKey &&
+            !event.shiftKey
+          )
+            event.currentTarget.click();
+        }
+      }}
+    />
   );
 
   if (intent === null) return anchor;

--- a/apps/app/src/components/ui/markdown-link-routing.ts
+++ b/apps/app/src/components/ui/markdown-link-routing.ts
@@ -1,3 +1,4 @@
+import type { MarkdownProps } from "@get-bb/plugin-sdk";
 import { createContext, type ReactNode } from "react";
 import type { MarkdownPreviewLinkHandler } from "./markdown-link.js";
 import type {
@@ -53,7 +54,19 @@ export interface MarkdownLocalImageRouting {
   resolveSrc: (image: MarkdownPreviewLocalFileLink) => string;
 }
 
+export function isMarkdownLocalFileHref(href: string): boolean {
+  return (
+    href.length > 0 &&
+    !href.startsWith("#") &&
+    !href.startsWith("//") &&
+    (/^file:/iu.test(href) ||
+      /^[a-z]:[\\/]/iu.test(href) ||
+      !/^[a-z][a-z0-9+.-]*:/iu.test(href))
+  );
+}
+
 export interface MarkdownLinkRouting {
+  resolveFileLink?: MarkdownProps["experimental_resolveFileLink"];
   localFile?: MarkdownLocalFileLinkRouting;
   localImage?: MarkdownLocalImageRouting;
   onOpenLink?: MarkdownPreviewLinkHandler;

--- a/apps/app/src/components/ui/markdown-preview.tsx
+++ b/apps/app/src/components/ui/markdown-preview.tsx
@@ -1,3 +1,6 @@
+import { ExperimentalFileLink } from "@/components/plugin/ExperimentalFileLink";
+import { normalizeExperimentalFileOpenOptions } from "@/lib/live-file-navigation";
+import { isMarkdownLocalFileHref } from "./markdown-link-routing";
 import {
   Children,
   cloneElement,
@@ -353,6 +356,7 @@ function areMarkdownLinkRoutingsEqual({
   if (previous === next) return true;
   if (previous === undefined || next === undefined) return false;
   return (
+    previous.resolveFileLink === next.resolveFileLink &&
     previous.onOpenLink === next.onOpenLink &&
     areMarkdownLocalFileLinkRoutingsEqual({
       next: next.localFile,
@@ -599,6 +603,30 @@ function MarkdownAnchor({
     localFileLink !== null && getContextMenuItems !== null
       ? getContextMenuItems(localFileLink)
       : null;
+  if (
+    linkRouting?.resolveFileLink &&
+    href &&
+    !isAppRouteHref &&
+    isMarkdownLocalFileHref(href)
+  ) {
+    let intent;
+    try {
+      intent = normalizeExperimentalFileOpenOptions(
+        linkRouting.resolveFileLink(href),
+      );
+    } catch {
+      return <span>{children}</span>;
+    }
+    if (intent === null) return <span>{children}</span>;
+    return (
+      <ExperimentalFileLink
+        {...intent}
+        className="break-words [overflow-wrap:anywhere] underline underline-offset-2"
+      >
+        {children}
+      </ExperimentalFileLink>
+    );
+  }
   const handleAnchorClick = (event: MarkdownAnchorEvent) => {
     if (localFileLink && onOpenLocalFileLink) {
       if (onOpenLocalFileLink(localFileLink)) {
@@ -1681,16 +1709,26 @@ function MarkdownPreviewComponent({
     }
     return plugins;
   }, [threadMentions, promptMentions, messageDirectiveMounts]);
+  const resolveFileLink = linkRouting?.resolveFileLink;
   const resolvedUrlTransform = useMemo(
     () =>
-      localFileRouting || localImageRouting
-        ? buildLocalAwareUrlTransform({
-            fallbackUrlTransform: urlTransform,
-            localFileRouting,
-            localImageRouting,
-          })
-        : urlTransform,
-    [localFileRouting, localImageRouting, urlTransform],
+      resolveFileLink
+        ? (((value, key, node) =>
+            key === "href" && isMarkdownLocalFileHref(value)
+              ? value
+              : (urlTransform ?? defaultUrlTransform)(
+                  value,
+                  key,
+                  node,
+                )) satisfies UrlTransform)
+        : localFileRouting || localImageRouting
+          ? buildLocalAwareUrlTransform({
+              fallbackUrlTransform: urlTransform,
+              localFileRouting,
+              localImageRouting,
+            })
+          : urlTransform,
+    [localFileRouting, localImageRouting, urlTransform, resolveFileLink],
   );
 
   const rehypeKatex = useRehypeKatex(markdownMayContainMath(body));

--- a/apps/app/src/lib/plugin-sdk-app-impl.test.tsx
+++ b/apps/app/src/lib/plugin-sdk-app-impl.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ExperimentalFileOpenOptions } from "@get-bb/plugin-sdk";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PluginSlotMount } from "@/components/plugin/PluginSlotMount";
@@ -8,6 +9,25 @@ import { ThreadTimelineNavigationProvider } from "@/components/thread/timeline/T
 import { pluginSdkAppImplementation } from "./plugin-sdk-app-impl";
 import { resetDeprecatedAliasWarningsForTests } from "./plugin-sdk-deprecated-aliases";
 import { AppNavigationHostProvider } from "./app-navigation-host";
+
+const copyFilePath = vi.hoisted(() => vi.fn());
+vi.mock("@/hooks/useResolvedLiveFileTarget", () => ({
+  useResolvedLiveFileTarget: () => ({ status: "unavailable" }),
+}));
+vi.mock("@/hooks/useLocalOpenTargets", () => ({
+  useLocalOpenTargets: () => ({
+    isLoading: false,
+    canOpenPreferredFileTarget: false,
+    fileOpenTargets: [],
+  }),
+}));
+vi.mock("@/lib/plugin-slots", () => ({
+  usePluginSlots: () => ({ fileOpeners: [] }),
+}));
+vi.mock("@/lib/clipboard", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/clipboard")>()),
+  copyToClipboardWithToast: copyFilePath,
+}));
 
 afterEach(cleanup);
 
@@ -187,5 +207,277 @@ describe("plugin SDK navigation components", () => {
       },
       location: null,
     });
+  });
+});
+
+describe("plugin SDK Markdown policies at the real renderer", () => {
+  const Markdown = pluginSdkAppImplementation.Markdown;
+  const media = `![inline alt](https://beacon.invalid/inline.png)
+
+![reference alt][beacon]
+
+[beacon]: https://beacon.invalid/reference.png
+
+<img src="https://beacon.invalid/html.png"><video src="https://beacon.invalid/video" poster="https://beacon.invalid/poster"><source src="https://beacon.invalid/source"></video><audio src="https://beacon.invalid/audio"></audio><iframe src="https://beacon.invalid/frame"></iframe><object data="https://beacon.invalid/object"></object>`;
+
+  it("emits alt text without any fetchable media, and preserves default image rendering", () => {
+    const view = render(
+      <Markdown content={media} experimental_imagePolicy="alt-text" />,
+    );
+    expect(view.container.textContent).toContain("inline alt");
+    expect(view.container.textContent).toContain("reference alt");
+    expect(
+      view.container.querySelector(
+        "img,video,audio,source,iframe,object,embed,link,[src],[srcset],[poster]",
+      ),
+    ).toBeNull();
+    view.rerender(<Markdown content={media} />);
+    expect(
+      screen.getByRole("img", { name: "inline alt" }).getAttribute("src"),
+    ).toBe("https://beacon.invalid/inline.png");
+    expect(
+      screen.getByRole("img", { name: "reference alt" }).getAttribute("src"),
+    ).toBe("https://beacon.invalid/reference.png");
+    expect(
+      view.container.querySelector("video,audio,source,iframe,object,embed"),
+    ).toBeNull();
+  });
+
+  it("preserves host typography and URL routing without ambient timeline context", () => {
+    const openUrl = vi.fn(() => true);
+    const resolver = vi.fn(() => null);
+    const urls = [
+      "https://example.com/docs",
+      "http://example.com/docs",
+      "http://localhost:5173/report",
+      "https://github.com/get-bb/bb/issues/135",
+    ];
+    const view = render(
+      <AppNavigationHostProvider capabilities={{ openUrl }}>
+        <Markdown
+          experimental_imagePolicy="alt-text"
+          experimental_resolveFileLink={resolver}
+          content={`# Heading
+
+| Name | Value |
+| --- | --- |
+| result | yes |
+
+- First
+- Second
+
+\`inline code\`
+
+\`\`\`text
+block code
+\`\`\`
+
+${urls.map((url, i) => `[URL ${i}](${url})`).join(" ")}`}
+        />
+      </AppNavigationHostProvider>,
+    );
+    expect(screen.getByRole("heading", { name: "Heading" })).toBeTruthy();
+    expect(screen.getByRole("table")).toBeTruthy();
+    expect(screen.getAllByRole("listitem")).toHaveLength(2);
+    expect(
+      view.container.querySelectorAll("code").length,
+    ).toBeGreaterThanOrEqual(2);
+    for (const [i, url] of urls.entries()) {
+      fireEvent.click(screen.getByRole("link", { name: `URL ${i}` }));
+      expect(openUrl).toHaveBeenLastCalledWith({ url });
+    }
+    expect(resolver).not.toHaveBeenCalled();
+  });
+
+  it("exposes raw local anchors without a resolver: capture cannot secure context-menu or drag", () => {
+    render(
+      <Markdown content="[report](/Users/sender/report.md) [relative](reports/result.md)" />,
+    );
+    expect(
+      screen.getByRole("link", { name: "report" }).getAttribute("href"),
+    ).toBe("/Users/sender/report.md");
+    expect(
+      screen.getByRole("link", { name: "relative" }).getAttribute("href"),
+    ).toBe("reports/result.md");
+  });
+
+  it("resolves raw destinations before normalization and never borrows ambient identity", () => {
+    const openFilePreview = vi.fn(() => true);
+    const ambient = vi.fn(() => true);
+    const resolver = vi.fn((href: string) =>
+      href === "/Users/sender/.bb/thread-storage/thr_foreign/report.md"
+        ? {
+            target: {
+              kind: "host" as const,
+              hostId: "host_sender",
+              path: href,
+            },
+            location: { kind: "line" as const, line: 7, column: null },
+          }
+        : null,
+    );
+    const view = render(
+      <AppNavigationHostProvider capabilities={{ openFilePreview }}>
+        <ThreadTimelineNavigationProvider
+          environmentId="env_wrong"
+          onOpenLink={() => false}
+          onOpenLocalFileLink={ambient}
+          resolveMentionLink={() => null}
+          workspaceRootPath="/wrong"
+        >
+          <Markdown
+            experimental_resolveFileLink={resolver}
+            content="[foreign report](/Users/sender/.bb/thread-storage/thr_foreign/report.md) [traversal](../secret.md) [encoded](%2e%2e/secret.md) [double](%252e%252e/secret.md) [file](file:///tmp/report.md) [missing](missing.md)"
+          />
+        </ThreadTimelineNavigationProvider>
+      </AppNavigationHostProvider>,
+    );
+    expect(resolver.mock.calls.map(([href]) => href)).toEqual([
+      "/Users/sender/.bb/thread-storage/thr_foreign/report.md",
+      "../secret.md",
+      "%2e%2e/secret.md",
+      "%252e%252e/secret.md",
+      "file:///tmp/report.md",
+      "missing.md",
+    ]);
+    expect(view.container.querySelector("a[href]")).toBeNull();
+    expect(screen.queryByRole("link", { name: "missing" })).toBeNull();
+    fireEvent.click(screen.getByRole("link", { name: "foreign report" }));
+    expect(openFilePreview).toHaveBeenCalledWith({
+      target: {
+        kind: "host",
+        hostId: "host_sender",
+        path: "/Users/sender/.bb/thread-storage/thr_foreign/report.md",
+      },
+      location: { kind: "line", line: 7, column: null },
+    });
+    expect(ambient).not.toHaveBeenCalled();
+    view.rerender(
+      <Markdown
+        experimental_resolveFileLink={() => ({
+          target: { kind: "host", hostId: "", path: "/tmp/report.md" },
+          location: null,
+        })}
+        content="[invalid](report.md)"
+      />,
+    );
+    expect(screen.queryByRole("link")).toBeNull();
+    expect(screen.getByText("invalid").tagName).toBe("SPAN");
+  });
+});
+
+describe("resolved Markdown native file activation", () => {
+  const Markdown = pluginSdkAppImplementation.Markdown;
+  const intents: ExperimentalFileOpenOptions[] = [
+    {
+      target: {
+        kind: "host",
+        hostId: "host_sender",
+        path: "/Users/sender/.bb/thread-storage/thr_foreign/report.md",
+      },
+      location: { kind: "line", line: 9, column: 2 },
+    },
+    {
+      target: {
+        kind: "workspace",
+        environmentId: "env_sender",
+        path: "images/result.png",
+      },
+      location: null,
+    },
+    {
+      target: {
+        kind: "thread-storage",
+        threadId: "thr_sender",
+        path: "result.md",
+      },
+      location: null,
+    },
+  ];
+
+  it.each(intents)(
+    "preserves $target.kind identity and gates browser activation",
+    async (intent) => {
+      const openFilePreview = vi.fn(() => true);
+      const view = render(
+        <AppNavigationHostProvider capabilities={{ openFilePreview }}>
+          <Markdown
+            content="[result](result.md)"
+            experimental_resolveFileLink={() => intent}
+          />
+        </AppNavigationHostProvider>,
+      );
+      const link = screen.getByRole("link", { name: "result" });
+      expect(link.getAttribute("href")).toBeNull();
+      expect(link.tabIndex).toBe(0);
+      for (const modifier of ["metaKey", "ctrlKey", "altKey", "shiftKey"]) {
+        expect(fireEvent.click(link, { [modifier]: true })).toBe(false);
+      }
+      expect(
+        fireEvent(
+          link,
+          new MouseEvent("auxclick", {
+            button: 1,
+            bubbles: true,
+            cancelable: true,
+          }),
+        ),
+      ).toBe(false);
+      expect(openFilePreview).not.toHaveBeenCalled();
+      fireEvent.dragStart(link);
+      expect(view.container.querySelector("a[href]")).toBeNull();
+      expect(fireEvent.click(link)).toBe(false);
+      expect(openFilePreview).toHaveBeenLastCalledWith(intent);
+      fireEvent.keyDown(link, { key: "Enter" });
+      expect(openFilePreview).toHaveBeenCalledTimes(2);
+      expect(openFilePreview).toHaveBeenLastCalledWith(intent);
+      expect(fireEvent.contextMenu(link)).toBe(false);
+      fireEvent.click(
+        await screen.findByRole("menuitem", { name: "Copy file path" }),
+      );
+      expect(copyFilePath).toHaveBeenLastCalledWith(
+        intent.target.path,
+        expect.any(Object),
+      );
+      fireEvent.contextMenu(link);
+      fireEvent.click(
+        await screen.findByRole("menuitem", { name: "Open preview" }),
+      );
+      expect(openFilePreview).toHaveBeenLastCalledWith(intent);
+    },
+  );
+
+  it("keeps throwing, malformed, traversal, and rejected resolutions inert without ambient fallback", () => {
+    const openFilePreview = vi.fn(() => true);
+    const content = "[result](result.md)";
+    const view = render(
+      <AppNavigationHostProvider capabilities={{ openFilePreview }}>
+        <Markdown
+          content={content}
+          experimental_resolveFileLink={() => {
+            throw new Error("unavailable context");
+          }}
+        />
+      </AppNavigationHostProvider>,
+    );
+    expect(screen.queryByRole("link")).toBeNull();
+    for (const path of [
+      "../secret",
+      "/tmp/../secret",
+      String.fromCharCode(0xd800),
+    ]) {
+      view.rerender(
+        <Markdown
+          content={content}
+          experimental_resolveFileLink={() => ({
+            target: { kind: "host", hostId: "host_sender", path },
+            location: null,
+          })}
+        />,
+      );
+      expect(screen.queryByRole("link")).toBeNull();
+      expect(view.container.querySelector("[href]")).toBeNull();
+    }
+    expect(openFilePreview).not.toHaveBeenCalled();
   });
 });

--- a/apps/app/src/lib/plugin-sdk-app-impl.tsx
+++ b/apps/app/src/lib/plugin-sdk-app-impl.tsx
@@ -71,7 +71,12 @@ export const pluginSdkAppImplementation = installDeprecatedAliases(
   { experimental_UrlLink: "UrlLink" },
 );
 
-function PluginMarkdown({ content, className }: MarkdownProps) {
+function PluginMarkdown({
+  content,
+  className,
+  experimental_imagePolicy,
+  experimental_resolveFileLink,
+}: MarkdownProps) {
   const timelineNavigation = useThreadTimelineNavigation();
   const onOpenLocalFileLink = timelineNavigation?.onOpenLocalFileLink;
   const workspaceRootPath = timelineNavigation?.workspaceRootPath;
@@ -81,6 +86,9 @@ function PluginMarkdown({ content, className }: MarkdownProps) {
     [navigation],
   );
   const linkRouting = useMemo<MarkdownLinkRouting>(() => {
+    if (experimental_resolveFileLink !== undefined) {
+      return { onOpenLink, resolveFileLink: experimental_resolveFileLink };
+    }
     if (onOpenLocalFileLink === undefined) {
       return { onOpenLink };
     }
@@ -95,11 +103,17 @@ function PluginMarkdown({ content, className }: MarkdownProps) {
       };
     }
     return { localFile, onOpenLink };
-  }, [onOpenLink, onOpenLocalFileLink, workspaceRootPath]);
+  }, [
+    onOpenLink,
+    onOpenLocalFileLink,
+    workspaceRootPath,
+    experimental_resolveFileLink,
+  ]);
 
   return (
     <MarkdownPreview
       content={content}
+      imagePolicy={experimental_imagePolicy}
       className={className}
       linkRouting={linkRouting}
     />

--- a/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/references/frontend-components.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/references/frontend-components.md
@@ -131,10 +131,20 @@ className? }` —
 
 - `Markdown` — bb's chat-message markdown renderer (same typography,
   spacing, and code styling as timeline messages). Props:
-  `{ content, className? }`. Use it wherever plugin UI quotes or previews
-  message content (e.g. a reply header) so it reads like the rest of the
-  chat instead of a differently-styled bundled renderer. Renderer options
-  beyond content/className stay host-internal.
+  `{ content, className?, experimental_imagePolicy?, experimental_resolveFileLink? }`.
+  Use it wherever plugin UI quotes or previews message content.
+  `experimental_imagePolicy` is `"render"` (the default) or `"alt-text"`
+  (descriptions without image loading); HTML remains disabled.
+  `experimental_resolveFileLink(href)` receives local destinations before path
+  normalization and returns `ExperimentalFileOpenOptions` (`{ target, location }`,
+  including null location) or null. The host validates the complete explicit
+  target and renders native FileLink; null, malformed results, and throws render
+  inert selectable labels without href. A supplied resolver replaces ambient
+  timeline file routing; the caller verifies sender identity and rejects
+  traversal. HTTP(S), other URL schemes, fragments, and BB routes bypass it and
+  retain host handling. These props require the matching host runtime, not just
+  updated SDK declarations. The frontend harness exposes supplied policies on
+  its source-text wrapper; renderer safety requires real host-renderer tests.
 - `UrlLink` — a real anchor whose ordinary HTTP(S) activation
   follows the current client's in-app/external-browser preference. It keeps
   internal BB routes in SPA history, preserves modifier clicks, copying,
@@ -144,15 +154,18 @@ className? }` —
   contains `opener`. Use `useBbNavigate().openUrl(url)` for
   buttons, menus, and effects; its boolean reports whether the current app
   accepted the intent, not whether a later OS launch completed.
-- `experimental_FileLink` — a real anchor for an explicit live file target:
+- `experimental_FileLink` — a native preview link for an explicit live file target:
   `{ kind: "workspace", environmentId, path }`,
   `{ kind: "host", hostId, path }` (absolute), or
   `{ kind: "thread-storage", threadId, path }`. Ordinary activation opens the
   current surface's shared BB preview. Its lazy context menu offers the
   built-in preview, matching plugin `fileOpener`s, the preferred external
-  target, available client apps, and copy actions. Valid targets expose an
-  encoded, scheme-safe href; traversal paths, ill-formed Unicode, and other
-  malformed runtime targets are inert in both the app and SDK test harness.
+  target, available client apps, and copy actions. File links have no browser
+  href until an identity-preserving file URL exists: ordinary click and Enter
+  preview remain, while modified/auxiliary navigation, downloads, and URL
+  dragging are gated. Use the native context menu for copy/open actions.
+  Traversal paths, ill-formed Unicode, and other malformed runtime targets are
+  inert in both the app and SDK test harness.
   Optional `location` is a one-based line/column or line range. For buttons and
   effects use
   `useBbNavigate().experimental_openFilePreview({ target, location })` or

--- a/docs/api_to_audit.md
+++ b/docs/api_to_audit.md
@@ -658,9 +658,12 @@ external method resolves the current client's preferred file target, absolute
 path, local/remote-SSH context, and line/column support. The boolean methods
 report host acceptance; later OS failures remain host-owned. The host id added
 to file-opener sources preserves explicit host identity when a plugin page
-opens a host file without ambient thread context. Valid link targets expose a
-scheme-safe href, while traversal paths, ill-formed Unicode, and other
-malformed runtime targets remain inert in both the app and SDK test runtime.
+opens a host file without ambient thread context. File links intentionally have
+no browser href: ordinary click and Enter use the native preview; modifier and
+auxiliary activation and downloads are gated. Native context-menu copy/open
+uses the full intent. No raw path becomes browser navigation or a dragged URL.
+Malformed targets remain inert in both the app and SDK test runtime. A durable,
+identity-preserving browser URL is required before restoring browser fallback.
 
 **Audit before stabilizing.**
 
@@ -1887,3 +1890,36 @@ other pane's copy (or release its owned state). The thread-list slot omits it
 deliberately: it mounts once, and a crash there should disable it everywhere.
 Confirm that split before stabilizing, and decide whether other multi-mount
 slots need the same treatment.
+
+
+## Markdown policies (`MarkdownProps.experimental_imagePolicy`, `MarkdownProps.experimental_resolveFileLink`)
+
+**What they do.** The public host Markdown component forwards the existing
+image policy: omission or `render` retains normal images, while `alt-text`
+emits descriptions without image elements. HTML remains disabled in both modes.
+The optional synchronous file resolver receives local Markdown destinations
+before filesystem path normalization and returns `ExperimentalFileOpenOptions`
+(with explicit target and location, including null location) or null. The host
+validates the result and reuses native FileLink; null, malformed results, and
+throws render inert selectable labels without href. HTTP(S), other URL schemes,
+fragments, and BB routes retain host handling and never enter the resolver.
+Supplying the resolver replaces ambient timeline file routing. The plugin owns
+sender authorization and traversal checks; target syntax validation cannot
+prove a host/environment/thread belongs to the sender. Never infer identity
+from a file's path (a sender can reference another thread's report on its host).
+
+**Nav-panel integration.** Without the resolver, Markdown retains raw local
+anchors outside timeline context. Containing-body click/auxclick capture cannot
+secure browser context-menu opening, copying link addresses, or dragging URLs.
+Use the render-time resolver with verified sender context, returning null while
+context is absent or rejected. Do not rewrite Markdown or mutate rendered DOM.
+The SDK test harness only exposes supplied policies on its source-text wrapper;
+renderer safety evidence belongs at the real host PluginMarkdown boundary.
+
+**Audit before stabilizing.** Verify the image/reference-image/HTML-media
+negative controls, typography and web URL parity, raw encoded traversal inputs,
+resolver changes, rejection and throwing behavior, explicit target identity on
+nav panels without timeline context, native preview/menu/copy actions and
+modifier/auxiliary/drag gating. Verify installed client support separately from
+SDK declaration availability; these props require the matching host runtime.
+An identity-preserving browser file URL remains deferred, not emulated.

--- a/packages/domain/src/plugin-sdk-version.ts
+++ b/packages/domain/src/plugin-sdk-version.ts
@@ -1,3 +1,3 @@
-export const PLUGIN_SDK_VERSION = "0.4.28";
+export const PLUGIN_SDK_VERSION = "0.4.35-inbox-parity.0";
 
 export const PLUGIN_SDK_MAJOR = Number(PLUGIN_SDK_VERSION.split(".", 1)[0]);

--- a/packages/plugin-api-map/sdk-public-api.json
+++ b/packages/plugin-api-map/sdk-public-api.json
@@ -3,7 +3,7 @@
   "entries": {
     ".": {
       "types": "bundled-types/bb-plugin-sdk.d.ts",
-      "sha256": "70077a510684588d29816ecb221ca99476640c7972c31730025064904265535e"
+      "sha256": "9134ae9cbc756f6716e704188811636711e2ccc5a01b0bcec18732bf158830ce"
     },
     "./ai-services": {
       "types": "bundled-types/bb-plugin-sdk-ai-services.d.ts",
@@ -11,7 +11,7 @@
     },
     "./app": {
       "types": "bundled-types/bb-plugin-sdk-app.d.ts",
-      "sha256": "d5a5ca8bb14f04dbe5d53dc47470412337ce1fcf8a8019c692479620b05ef7c2"
+      "sha256": "352abd1b1832aee2a7062ba42c5074fe2dd1f9b105ae342e1ceed12d67d3e261"
     },
     "./host": {
       "types": "bundled-types/bb-plugin-sdk-host.d.ts",

--- a/packages/plugin-api-map/src/surfaces.ts
+++ b/packages/plugin-api-map/src/surfaces.ts
@@ -681,12 +681,17 @@ export const SURFACE_GROUPS: SurfaceGroup[] = [
           "Renders bb's own conversation and prompt-box components inside the plugin's pages. With this, a plugin can:",
         bullets: [
           "Embed the thread view and the new-thread prompt box as components",
-          "Render message text with the same Markdown renderer bb uses",
+          "Render message text with the same Markdown renderer bb uses; experimental_imagePolicy=alt-text suppresses image loading while omission preserves rendered images and HTML stays disabled",
+          "Resolve local Markdown destinations with experimental_resolveFileLink(href): return a complete native file intent or null for inert selectable text; HTTP(S) and BB routes stay host-owned",
+          "Native file links preserve explicit host, workspace, or thread-storage identity in preview and context-menu actions; browser href, modified/auxiliary navigation, downloads, and URL dragging are gated until identity-preserving URLs exist",
           "Inherit bb's styling, so embedded UI matches the rest of the app",
         ],
         apiSymbols: [
           "ThreadChat",
           "Markdown",
+          "MarkdownProps",
+          "experimental_FileLink",
+          "ExperimentalFileOpenOptions",
           "experimental_NewThreadComposer",
         ],
         firstParty: ["Side chat"],

--- a/packages/plugin-sdk/README.md
+++ b/packages/plugin-sdk/README.md
@@ -33,16 +33,32 @@ both forms in `navigateCalls` and accepts an `openUrl` behavior option.
 Use `experimental_FileLink` for an explicit live workspace, host, or
 thread-storage file. Ordinary activation opens the shared BB preview and its
 context menu exposes built-in/plugin viewers, preferred external opening, and
-copy actions. Valid targets expose an encoded, scheme-safe anchor href so
-modifier clicks, downloads, and copied links cannot reinterpret a file name as
-an external URL scheme. Malformed runtime targets—including traversal paths
-and ill-formed Unicode—have no active href and cannot record a preview in the
-frontend harness. Buttons and menus can call
+copy actions. File links have no browser href until an identity-preserving
+file URL exists: ordinary click and Enter open the native preview, while
+modified/auxiliary navigation, downloads, and URL dragging are gated. Use the
+native context menu for copy/open actions. Malformed runtime targets—including
+traversal paths and ill-formed Unicode—remain inert and cannot record a preview
+in the frontend harness. Buttons and menus can call
 `experimental_openFilePreview({ target, location })` or
 `experimental_openFileExternally({ target, location })`; both return whether
 the current host accepted the intent. Targets never infer an ambient workspace.
 The frontend harness records both methods and accepts `openFilePreview` and
 `openFileExternally` behavior options.
+
+Use host `Markdown` for message typography, tables, lists, and code. Its
+`experimental_imagePolicy?: "render" | "alt-text"` preserves rendered images
+when omitted; `alt-text` emits descriptions without loading images. HTML stays
+disabled. `experimental_resolveFileLink?: (href: string) =>
+ExperimentalFileOpenOptions | null` receives local destinations before path
+normalization. Return a complete verified sender target and `location` (null
+is allowed); the host validates the intent and renders native FileLink. Null,
+malformed results, and throws produce inert selectable labels without href.
+Supplying the resolver replaces ambient timeline file routing; the caller owns
+sender authorization and traversal rejection. HTTP(S), other URL schemes,
+fragments, and BB routes retain host handling and bypass the resolver. These
+props require a matching host runtime, not merely updated SDK declarations.
+The frontend harness exposes the supplied policies on its source-text wrapper;
+it does not reproduce the Markdown parser or prove renderer safety.
 
 A nav panel's `fixedTabs` entries must include the containing nav
 panel's `id` as `panelId`; each entry is also a stable reference to that

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@get-bb/plugin-sdk",
-  "version": "0.4.28",
+  "version": "0.4.35-inbox-parity.0",
   "homepage": "https://github.com/get-bb/bb#readme",
   "bugs": {
     "url": "https://github.com/get-bb/bb/issues"

--- a/packages/plugin-sdk/src/app-contract.ts
+++ b/packages/plugin-sdk/src/app-contract.ts
@@ -1900,6 +1900,18 @@ export interface NewThreadComposerProps {
 export interface MarkdownProps {
   /** Markdown source, rendered exactly like a chat message body. */
   content: string;
+  /** Omit to render images; alt-text emits image descriptions without loading media. HTML stays disabled. */
+  experimental_imagePolicy?: "render" | "alt-text";
+  /**
+   * Resolve a local Markdown destination before path normalization. HTTP(S),
+   * other URL schemes, fragments, and BB routes retain host handling. Return a
+   * complete explicit native file intent, or null for inert, selectable text.
+   * The host validates the returned intent; the caller verifies sender identity
+   * and rejects untrusted/traversal destinations. Omit for existing behavior.
+   */
+  experimental_resolveFileLink?: (
+    href: string,
+  ) => ExperimentalFileOpenOptions | null;
   className?: string;
 }
 
@@ -1935,9 +1947,11 @@ export interface ExperimentalFileOpenOptions {
 }
 
 /**
- * Props for BB's host-rendered semantic file link. Valid targets receive a
- * scheme-safe anchor href; traversal paths, ill-formed Unicode, and other
- * malformed runtime targets remain inert.
+ * Props for BB's host-rendered semantic file link. Ordinary click and Enter
+ * open the native preview. Browser navigation, modifier/auxiliary activation,
+ * download, and URL dragging are disabled until an identity-preserving URL
+ * exists. Use the native context menu for copy/open actions. Malformed targets
+ * remain inert.
  */
 export interface ExperimentalFileLinkProps extends Omit<
   ComponentPropsWithoutRef<"a">,

--- a/packages/plugin-sdk/src/testing/__tests__/app-harness.test.tsx
+++ b/packages/plugin-sdk/src/testing/__tests__/app-harness.test.tsx
@@ -28,6 +28,7 @@ const {
   experimental_useAppPanel,
   experimental_useFixedTabTarget,
   ThreadChat,
+  Markdown,
   useBbNavigate,
   useComposer,
   useComposerView,
@@ -1303,15 +1304,29 @@ describe("renderSlot", () => {
     ]);
   });
 
-  it("exposes a scheme-safe href for file links", () => {
+  it("gates browser hrefs for file links", () => {
     const slot = renderSlot(
       { component: SchemeLikeFileLinkProbe },
       {},
       { openFilePreview: () => true },
     );
     const link = slot.getByRole("link", { name: "Open scheme-like file" });
-    expect(link.getAttribute("href")).toBe("./vscode%3Afoo");
-    fireEvent.click(link);
+    expect(link.getAttribute("href")).toBeNull();
+    for (const modifier of ["metaKey", "ctrlKey", "altKey", "shiftKey"]) {
+      expect(fireEvent.click(link, { [modifier]: true })).toBe(false);
+    }
+    expect(
+      fireEvent(
+        link,
+        new MouseEvent("auxclick", {
+          button: 1,
+          bubbles: true,
+          cancelable: true,
+        }),
+      ),
+    ).toBe(false);
+    expect(slot.inspection.navigateCalls).toEqual([]);
+    fireEvent.keyDown(link, { key: "Enter" });
     expect(slot.inspection.navigateCalls).toEqual([
       {
         method: "experimental_openFilePreview",
@@ -1675,5 +1690,32 @@ describe("renderSlot", () => {
     expect(slot.composer.textEffectCalls).toEqual([
       { className: "cleanup-effect" },
     ]);
+  });
+});
+
+describe("Markdown harness policy inspection", () => {
+  it("records renderer options without claiming parser fidelity", () => {
+    const resolver = vi.fn(() => null);
+    const view = render(
+      <Markdown
+        content="![alt](https://beacon.invalid/image)"
+        experimental_imagePolicy="alt-text"
+        experimental_resolveFileLink={resolver}
+      />,
+    );
+    expect(
+      view.getByTestId("bb-markdown").getAttribute("data-image-policy"),
+    ).toBe("alt-text");
+    expect(
+      view.getByTestId("bb-markdown").getAttribute("data-file-link-resolver"),
+    ).toBe("true");
+    expect(resolver).not.toHaveBeenCalled();
+    view.rerender(<Markdown content="default" />);
+    expect(
+      view.getByTestId("bb-markdown").getAttribute("data-image-policy"),
+    ).toBe("render");
+    expect(
+      view.getByTestId("bb-markdown").getAttribute("data-file-link-resolver"),
+    ).toBe("false");
   });
 });

--- a/packages/plugin-sdk/src/testing/app.tsx
+++ b/packages/plugin-sdk/src/testing/app.tsx
@@ -327,9 +327,19 @@ function TestThreadChat({
  * recognizable wrapper so plugin tests can assert what content they passed
  * without the real renderer.
  */
-function TestMarkdown({ content, className }: MarkdownProps) {
+function TestMarkdown({
+  content,
+  className,
+  experimental_imagePolicy = "render",
+  experimental_resolveFileLink,
+}: MarkdownProps) {
   return (
-    <div data-testid="bb-markdown" className={className}>
+    <div
+      data-testid="bb-markdown"
+      data-image-policy={experimental_imagePolicy}
+      data-file-link-resolver={experimental_resolveFileLink !== undefined}
+      className={className}
+    >
       {content}
     </div>
   );
@@ -393,23 +403,41 @@ function TestFileLink({
   target,
   location = null,
   onClick,
+  onAuxClick,
+  onKeyDown,
   ...anchorProps
 }: ExperimentalFileLinkProps) {
   const navigate = useSlotEnv("experimental_FileLink").navigate;
   const options = normalizeExperimentalFileOpenOptions({ target, location });
-  const href =
-    options === null
-      ? undefined
-      : `./${encodeURIComponent(options.target.path)}`;
   return (
     <a
       {...anchorProps}
-      href={href}
+      role={options === null ? undefined : "link"}
+      tabIndex={options === null ? undefined : (anchorProps.tabIndex ?? 0)}
+      onAuxClick={(event) => {
+        onAuxClick?.(event);
+        event.preventDefault();
+      }}
+      onKeyDown={(event) => {
+        onKeyDown?.(event);
+        if (event.key === "Enter" && !event.defaultPrevented) {
+          event.preventDefault();
+          if (
+            !event.altKey &&
+            !event.ctrlKey &&
+            !event.metaKey &&
+            !event.shiftKey
+          )
+            event.currentTarget.click();
+        }
+      }}
       onClick={(event: ReactMouseEvent<HTMLAnchorElement>) => {
         onClick?.(event);
+        const prevented = event.defaultPrevented;
+        event.preventDefault();
         if (
           options === null ||
-          event.defaultPrevented ||
+          prevented ||
           event.button !== 0 ||
           event.altKey ||
           event.ctrlKey ||
@@ -419,7 +447,6 @@ function TestFileLink({
         ) {
           return;
         }
-        event.preventDefault();
         navigate.experimental_openFilePreview(options);
       }}
     />

--- a/packages/templates/src/templates/bb-guide-plugins.md
+++ b/packages/templates/src/templates/bb-guide-plugins.md
@@ -581,10 +581,24 @@ HTTP(S) activation uses the same client preference as first-party links while
 leaving app routes, modifiers, copying, unsupported schemes, and explicit
 targets browser-owned. A `_blank` or named target preserves your `rel` tokens
 but adds `noopener noreferrer` unless `rel` explicitly contains `opener`.
-experimental_FileLink renders a real explicit live-file anchor whose ordinary activation uses the same
-preview/file-opener controller as first-party links. Valid targets expose an
-encoded, scheme-safe href; traversal paths, ill-formed Unicode, and other
-malformed runtime targets are inert in both the app and SDK test harness. Its
+Markdown renders message text with bb's typography, tables, lists, and code.
+Its optional experimental_imagePolicy is "render" (the default) or "alt-text"
+(image descriptions without loading images); HTML stays disabled. Optional
+experimental_resolveFileLink(href) receives local destinations before path
+normalization and returns ExperimentalFileOpenOptions ({ target, location },
+including null location) or null. The host validates complete explicit targets
+and renders native FileLink; null, malformed results, and throws produce inert
+selectable labels without href. A supplied resolver replaces ambient timeline
+file routing; the caller verifies sender identity and rejects traversal.
+HTTP(S), other URL schemes, fragments, and BB routes bypass the resolver and
+retain host handling. Both policies require the matching host runtime, not
+merely updated SDK declarations.
+experimental_FileLink uses the same preview/file-opener controller as
+first-party links for ordinary click and Enter. It has no browser href until
+an identity-preserving file URL exists: modified/auxiliary navigation,
+downloads, and URL dragging are gated. Use its native context menu for copy/open
+actions. Traversal paths, ill-formed Unicode, and other malformed runtime
+targets are inert in both the app and SDK test harness. Its
 lazy context menu adds Open with, preferred-external, installed-app, and copy
 actions without reading the file or discovering editors on mount.
 experimental_ProviderModelPicker is the controlled


### PR DESCRIPTION
## Human comments

## What was wrong

Plugin nav-panel message bodies could not use host-owned Markdown while suppressing remote image requests and resolving files from an explicit sender context. `Markdown` exposed neither the existing alt-text image policy nor a native file resolver. The Operator Inbox therefore maintained a separate renderer whose raw links could replace the app or turn filesystem paths into broken browser routes. Native `FileLink` also exposed a path-only href that lost target identity on modified or auxiliary activation.

## What changed

Expose `Markdown.experimental_imagePolicy` (`render` or `alt-text`) by forwarding the existing renderer policy, and `experimental_resolveFileLink(href)` returning complete native file-open options or null. The host validates results and renders existing native FileLink; null, malformed, or throwing resolutions stay inert. The caller verifies sender authority; supplied resolution never borrows ambient timeline identity. Host Markdown continues to own parsing, typography, sanitization and ordinary URL handling.

Gate FileLink browser hrefs until an identity-preserving URL contract exists. Ordinary click/Enter and native copy/open menus remain available; modified/auxiliary browser navigation and URL dragging cannot lose the host/workspace/thread target. Update SDK declarations, test harness, API inventory/registry, Plugin Guide, SDK README and existing authoring/CLI guidance. No new dependency or daemon wire/protocol change.

This is the prerequisite for [the companion Operator Inbox PR](https://github.com/pixexid/bb-plugin-operator-inbox/pull/4) (reviewed commit `41832d8b6b3e6ddc561d3d62be4dc40ee4822ed3`). The candidate SDK is `0.4.35-inbox-parity.0`; publication must follow the BB release train from main. This PR does not publish the SDK or update an installed runtime.

## How you verified

Delivery evidence and independent source/package review are bound to base `8d926c312569b63924825db761e9cc73663bc3bc` and head `77549a615200698fc8c4d053c6eec320d9ef6562`:

- `pnpm exec turbo run test typecheck --filter=@get-bb/plugin-sdk --filter=@bb/plugin-api-map --filter=@bb/app --filter=bb-plugin-plugin-api-docs`: app 3,516 passed / 4 skipped; SDK 221 passed; API map 73 passed.
- `pnpm exec turbo run test --filter=@bb/app -- plugin-sdk-app-impl.test.tsx ExperimentalFileLink.test.tsx`: 18 passed. Restoring the old image/resolver forwarding and path-only href caused 7 expected failures; mutations were restored.
- Real renderer checks cover inline/reference images and HTML media, default-image positive control, tables/code/lists/headings, HTTP(S)/localhost/GitHub, raw and encoded traversal, inert rejection, explicit target identity and ordinary/Enter/modified/auxiliary/menu/copy/drag behavior.
- After the documentation repair: `pnpm exec turbo run test typecheck build --filter=@bb/templates --filter=@get-bb/plugin-sdk --filter=@bb/plugin-api-map` passed (43 templates, 221 SDK, 73 API-map tests); shipped-skill checks passed (14).
- SDK build, API inventory, Guide build, formatting and npm version guard passed. The repacked artifact differs from the first reviewed artifact only in README; SHA256 `939e1dd06d965ed999bbf39965a524397f6c053c65e414161c66aee9625c3c80`.
- A separate composed actual-Inbox/actual-host-renderer fixture passed 22 tests, including the five-link session oracle: localhost, workspace PNG, cross-thread report on the verified sender host, GitHub PR, and workspace AGENTS.md. This is React/jsdom intent evidence with RPC/IO fixtures, not installed-client or OS-opener QA.

The reviewed head is preserved without rebasing onto newer upstream main. Installed-runtime verification remains required after the normal release path; no installed app/plugin was changed. Native protocol-relative URLs and sanitized empty href behavior are unchanged.

> AGENT GENERATED
