### PR TITLE
feat: allow plugins to filter the injected skill catalog

### DIFF
--- a/apps/server/src/services/plugins/plugin-api.ts
+++ b/apps/server/src/services/plugins/plugin-api.ts
@@ -1024,6 +1024,10 @@ export function createPluginApi(options: {
   let instructionProvider: PluginInstructionProvider | null = null;
 
   const agents: PluginAgents = {
+    experimental_skillCatalogCapabilities: () => ({
+      injectedCatalog: true,
+      nativeCatalog: false,
+    }),
     configure(provider) {
       assertLive();
       if (agentConfigurationProvider !== null) {

--- a/apps/server/src/services/plugins/plugin-service-internal.ts
+++ b/apps/server/src/services/plugins/plugin-service-internal.ts
@@ -166,6 +166,10 @@ export interface PluginInstructionContribution {
 }
 
 export interface PluginResolvedAgentConfiguration {
+  skillCatalogPolicy?: {
+    defaultMode: "always" | "discover" | "off";
+    overrides: Record<string, "always" | "discover" | "off">;
+  };
   tools: PluginAgentToolContribution[];
   selectedSkillIdsByPlugin: ReadonlyMap<string, ReadonlySet<string>>;
   dynamicInstructions: Array<{ pluginId: string; text: string }>;

--- a/apps/server/src/services/plugins/plugin-service.ts
+++ b/apps/server/src/services/plugins/plugin-service.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import { watch } from "node:fs";
 import { readFile, rm } from "node:fs/promises";
 import { join } from "node:path";
@@ -638,7 +639,20 @@ function normalizeMentionSearchItems(
   });
 }
 
+const skillCatalogPolicySchema = z
+  .object({
+    defaultMode: z.enum(["always", "discover", "off"]),
+    overrides: z
+      .record(z.string().min(1).max(200), z.enum(["always", "discover", "off"]))
+      .refine(
+        (value) => Object.keys(value).length <= 5000,
+        "At most 5000 skill overrides",
+      ),
+  })
+  .strict();
+
 interface NormalizedPluginAgentConfiguration {
+  skillCatalogPolicy?: z.infer<typeof skillCatalogPolicySchema>;
   toolIds: string[];
   toolParameterOverrides: Map<string, Record<string, unknown>>;
   skillIds: string[];
@@ -815,7 +829,15 @@ function normalizePluginAgentConfiguration(args: {
   }
   const output = args.value as Record<string, unknown>;
   const unknownKeys = Object.keys(output)
-    .filter((key) => !["tools", "skills", "instructions"].includes(key))
+    .filter(
+      (key) =>
+        ![
+          "tools",
+          "skills",
+          "instructions",
+          "experimental_skillCatalog",
+        ].includes(key),
+    )
     .sort();
   if (unknownKeys.length > 0) {
     throw new Error(
@@ -842,6 +864,13 @@ function normalizePluginAgentConfiguration(args: {
     value: output.tools,
   });
   return {
+    ...(output.experimental_skillCatalog === undefined
+      ? {}
+      : {
+          skillCatalogPolicy: skillCatalogPolicySchema.parse(
+            output.experimental_skillCatalog,
+          ),
+        }),
     toolIds: toolSelections.toolIds,
     toolParameterOverrides: toolSelections.parameterOverrides,
     skillIds: normalizePluginAgentSelectionIds({
@@ -2234,6 +2263,10 @@ export function createPluginService(deps: PluginServiceDeps): PluginService {
     },
 
     async resolveAgentConfiguration({ context, skillIdsByPlugin }) {
+      let skillCatalogPolicy:
+        | z.infer<typeof skillCatalogPolicySchema>
+        | undefined;
+      let policyPluginId: string | undefined;
       const allTools = collectAgentTools();
       const tools: PluginAgentToolContribution[] = [];
       const selectedSkillIdsByPlugin = new Map<string, ReadonlySet<string>>();
@@ -2261,19 +2294,39 @@ export function createPluginService(deps: PluginServiceDeps): PluginService {
         const knownToolIds = new Set(
           pluginTools.map(({ record }) => record.name),
         );
-        const outcome = await invokeWrapped(pluginId, "agent configure", () =>
-          normalizePluginAgentConfiguration({
+        let catalogPolicyRequested = false;
+        const outcome = await invokeWrapped(pluginId, "agent configure", () => {
+          const value = provider(context);
+          catalogPolicyRequested =
+            value !== null &&
+            typeof value === "object" &&
+            Object.hasOwn(value, "experimental_skillCatalog");
+          return normalizePluginAgentConfiguration({
             knownSkillIds,
             knownToolIds,
             pluginId,
-            value: provider(context),
-          }),
-        );
+            value,
+          });
+        });
         if (!outcome.ok) {
+          if (catalogPolicyRequested) {
+            throw new Error(
+              `Invalid skill catalog policy from ${pluginId}: ${outcome.error}`,
+            );
+          }
           selectedSkillIdsByPlugin.set(pluginId, new Set());
           continue;
         }
 
+        if (outcome.value.skillCatalogPolicy !== undefined) {
+          if (policyPluginId !== undefined) {
+            throw new Error(
+              `Skill catalog policies conflict: ${policyPluginId} and ${pluginId}`,
+            );
+          }
+          policyPluginId = pluginId;
+          skillCatalogPolicy = outcome.value.skillCatalogPolicy;
+        }
         const selectedTools = new Set(outcome.value.toolIds);
         const parameterOverrides = outcome.value.toolParameterOverrides;
         tools.push(
@@ -2298,7 +2351,12 @@ export function createPluginService(deps: PluginServiceDeps): PluginService {
         }
       }
 
-      return { tools, selectedSkillIdsByPlugin, dynamicInstructions };
+      return {
+        tools,
+        selectedSkillIdsByPlugin,
+        dynamicInstructions,
+        ...(skillCatalogPolicy === undefined ? {} : { skillCatalogPolicy }),
+      };
     },
 
     async resolveProviderEnv({ providerId, context }) {

--- a/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/references/backend-cli-agents.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/references/backend-cli-agents.md
@@ -172,6 +172,33 @@ skills, and dynamic instructions use the same boundaries. The legacy
 only `threadId` and `projectId`. Use `configure` when the contribution must
 inspect the side-chat origin.
 
+### Optional skill catalog policy
+
+A Skill Manager can filter BB's staged catalog before session construction:
+
+```ts
+if (bb.agents.experimental_skillCatalogCapabilities?.().injectedCatalog) {
+  bb.agents.configure(() => ({
+    tools: ["skill_search", "skill_read"],
+    skills: [],
+    experimental_skillCatalog: {
+      defaultMode: "discover",
+      overrides: { "bb-cli": "always", "unused-workflow": "off" },
+    },
+  }));
+}
+```
+
+The tools in this example must be registered by the same plugin. Use one
+`configure` callback; include the field conditionally when also targeting older
+BB releases. `always` keeps the BB catalog entry, while `discover` and `off` omit
+it. The plugin owns discovery policy and its UI/CLI. Management and explicit
+slash catalogs remain intact. Two contributing plugins or malformed policy
+output fail resolution, rather than silently choosing a winner. At most 5000
+name overrides are accepted. Native-provider skill discovery is separate:
+`nativeCatalog` is currently `false`, so this does not promise removal of native
+harness metadata. Existing safe runtime/session refresh rules still apply.
+
 ### bb.experimental_aiServices — helper inference and voice transcription
 
 bb's own AI services — the server-side helper completions behind thread

--- a/apps/server/src/services/skills/skill-catalog-policy.test.ts
+++ b/apps/server/src/services/skills/skill-catalog-policy.test.ts
@@ -1,0 +1,27 @@
+import { expect, it } from "vitest";
+import { filterInjectedSkillCatalog } from "./skill-catalog-policy.js";
+
+it("omits discoverable and off skills without mutating the management catalog", () => {
+  const catalog = Array.from({ length: 1000 }, (_, index) => ({
+    name: `skill-${index}`,
+  }));
+  const filtered = filterInjectedSkillCatalog(catalog, {
+    defaultMode: "discover",
+    overrides: { "skill-7": "always", "skill-9": "off" },
+  });
+  expect(filtered).toEqual([{ name: "skill-7" }]);
+  expect(catalog).toHaveLength(1000);
+  expect(filterInjectedSkillCatalog(catalog, undefined)).toEqual(catalog);
+});
+
+it("does not interpret inherited object properties as skill overrides", () => {
+  expect(
+    filterInjectedSkillCatalog(
+      [{ name: "toString" }, { name: "constructor" }],
+      {
+        defaultMode: "always",
+        overrides: {},
+      },
+    ),
+  ).toHaveLength(2);
+});

--- a/apps/server/src/services/skills/skill-catalog-policy.ts
+++ b/apps/server/src/services/skills/skill-catalog-policy.ts
@@ -1,0 +1,17 @@
+interface CatalogPolicy {
+  defaultMode: "always" | "discover" | "off";
+  overrides: Record<string, "always" | "discover" | "off">;
+}
+
+export function filterInjectedSkillCatalog<T extends { name: string }>(
+  sources: readonly T[],
+  policy: CatalogPolicy | undefined,
+): T[] {
+  if (policy === undefined) return [...sources];
+  return sources.filter(
+    (source) =>
+      (Object.hasOwn(policy.overrides, source.name)
+        ? policy.overrides[source.name]
+        : policy.defaultMode) === "always",
+  );
+}

--- a/apps/server/src/services/threads/thread-runtime-config.ts
+++ b/apps/server/src/services/threads/thread-runtime-config.ts
@@ -1,3 +1,4 @@
+import { filterInjectedSkillCatalog } from "../skills/skill-catalog-policy.js";
 import { getEnvironment, getHost, getProject } from "@bb/db";
 import type {
   DynamicTool,
@@ -237,11 +238,14 @@ export async function resolveThreadRuntimeCommandConfig(
       hostId: host.id,
     },
   });
-  const injectedSkillSources = resolveSkillCatalog(deps, {
-    projectSkillSources,
-    sharedSkillSources: sharedSkills.runtimeSources,
-    pluginSkillSelections: conditionalConfiguration.selectedSkillIdsByPlugin,
-  }).map((entry) => entry.runtimeSource);
+  const injectedSkillSources = filterInjectedSkillCatalog(
+    resolveSkillCatalog(deps, {
+      projectSkillSources,
+      sharedSkillSources: sharedSkills.runtimeSources,
+      pluginSkillSelections: conditionalConfiguration.selectedSkillIdsByPlugin,
+    }).map((entry) => entry.runtimeSource),
+    conditionalConfiguration.skillCatalogPolicy,
+  );
   const dataDirAgentInstructions = readDataDirAgentInstructions(
     deps.logger,
     deps.config.dataDir,

--- a/apps/server/test/services/plugins/plugin-agent-tools.test.ts
+++ b/apps/server/test/services/plugins/plugin-agent-tools.test.ts
@@ -586,6 +586,7 @@ describe("bb.agents.experimental_registerProvider (removed in SDK 0.4.16)", () =
     expect(Object.keys(api.agents).sort()).toEqual([
       "configure",
       "contributeInstructions",
+      "experimental_skillCatalogCapabilities",
       "registerTool",
     ]);
     expect(Object.keys({ ...api.agents })).not.toContain(
@@ -1076,6 +1077,70 @@ describe("plugin tools reach thread runtime config", () => {
     ).toContain("beta-skill");
     expect(turnSubmit.resumeContext.instructions).toContain(
       "factory=1;configure=5",
+    );
+
+    const policyRoot = await writePlugin(pluginsDir, {
+      name: "bb-plugin-catalog-policy",
+      serverSource: `
+        export default function plugin(bb) {
+          if (!bb.agents.experimental_skillCatalogCapabilities().injectedCatalog) throw new Error("missing capability");
+          bb.agents.configure(context => ({
+            tools: [], skills: [], experimental_skillCatalog: {
+              defaultMode: context.provider.id === "codex" ? "discover" : "off",
+              overrides: context.provider.id === "codex" ? { "alpha-skill": "always" } : {},
+            },
+          }));
+        }
+      `,
+    });
+    await harness.pluginService.installPath(policyRoot);
+    expect(
+      (await build(alpha, 14)).injectedSkillSources.map((s) => s.name),
+    ).toEqual(["alpha-skill"]);
+    expect((await build(beta, 15)).injectedSkillSources).toEqual([]);
+    expect(
+      harness.pluginService
+        .listSkillRootContributions()
+        .some((root) => root.pluginId === "conditional"),
+    ).toBe(true);
+    const filteredTurn = await prepareTurnSubmitCommandPayload(harness.deps, {
+      environment: beta.environment,
+      execution: betaExecution,
+      permissionEscalation: "ask",
+      input: textInput("next turn"),
+      providerThreadId: "provider-thread-conditional-beta",
+      target: { mode: "start" },
+      thread: beta.thread,
+    });
+    expect(filteredTurn.resumeContext.injectedSkillSources).toEqual([]);
+
+    await writeFile(
+      join(policyRoot, "server.ts"),
+      `export default function plugin(bb) {
+      bb.agents.configure(() => ({ tools: [], skills: [], experimental_skillCatalog: { defaultMode: "typo", overrides: {} } }));
+    }`,
+    );
+    await harness.pluginService.reload("catalog-policy");
+    await expect(build(alpha, 16)).rejects.toThrow(
+      "Invalid skill catalog policy",
+    );
+
+    await writeFile(
+      join(policyRoot, "server.ts"),
+      `export default function plugin(bb) {
+      bb.agents.configure(() => ({ tools: [], skills: [], experimental_skillCatalog: { defaultMode: "discover", overrides: {} } }));
+    }`,
+    );
+    await harness.pluginService.reload("catalog-policy");
+    const competitor = await writePlugin(pluginsDir, {
+      name: "bb-plugin-competing-policy",
+      serverSource: `export default function plugin(bb) {
+        bb.agents.configure(() => ({ tools: [], skills: [], experimental_skillCatalog: { defaultMode: "always", overrides: {} } }));
+      }`,
+    });
+    await harness.pluginService.installPath(competitor);
+    await expect(build(alpha, 17)).rejects.toThrow(
+      "Skill catalog policies conflict",
     );
   });
 });

--- a/docs/api_to_audit.md
+++ b/docs/api_to_audit.md
@@ -2325,3 +2325,17 @@ too, after the host has restored the draft. Sole consumer:
 `bb.sdk.experimental_desktopBrowsers` and the exported `ExperimentalDesktopBrowsersArea`, `ExperimentalDesktopBrowserScope`, `ExperimentalDesktopBrowserLease`, `ExperimentalDesktopBrowserCreateInput`, and `ExperimentalDesktopBrowserAcquireInput` expose explicit host/window/thread discovery, isolated tab creation, expiring control leases, scoped CDP connections, capture, reveal, close, release, and disposable tab-state subscriptions. The matching core CLI is `bb browser`.
 
 Before stabilization, audit personal-profile handoff policy, per-tab mutual exclusion and child-target scope, native popup handling, debugger detachment, daemon/desktop disconnect and reconnect generations, expiry and cancellation races, bounded screenshot bytes, and cross-platform desktop startup. Connection credentials must remain private to workers on the browser host. `subscribe` polls every two seconds with one outstanding request; it is state observation, not a lossless event log. Cloud browsers and external provider registration are outside this surface.
+
+## Skill catalog policy
+
+`PluginAgentConfiguration.experimental_skillCatalog` selects `always`, `discover`,
+or `off` with a default and up to 5000 name overrides. A single plugin owns the
+policy per resolution; competing owners and malformed policy output fail the command. Filtering happens
+before host staging and retains the full management/slash catalog. It applies
+at the existing safe session boundary. It does not filter a harness's native
+roots. `PluginAgents.experimental_skillCatalogCapabilities()` reports that
+boundary so plugins on older BB builds can keep discovery available without
+claiming prompt reduction.
+
+Audit multi-plugin conflicts, error handling, provider-native isolation, live
+thread catalog changes, and actual assembled prompts before stabilizing.

--- a/packages/plugin-api-map/src/surfaces.ts
+++ b/packages/plugin-api-map/src/surfaces.ts
@@ -605,9 +605,14 @@ export const SURFACE_GROUPS: SurfaceGroup[] = [
         bullets: [
           "Register tools an agent calls the same way it calls bb's built-in tools",
           "Decide per thread which of its tools and skills are available",
+          "Filter BB’s staged skill catalog while retaining on-demand discovery; native harness catalogs remain separate",
           "Append instructions to a session's system prompt as that session starts",
         ],
-        apiSymbols: ["PluginAgents"],
+        apiSymbols: [
+          "PluginAgents",
+          "PluginAgentConfiguration.experimental_skillCatalog",
+          "PluginAgents.experimental_skillCatalogCapabilities",
+        ],
         firstParty: [
           "Ask User Question",
           "Custom instructions",

--- a/packages/plugin-sdk/src/backend-contract.ts
+++ b/packages/plugin-sdk/src/backend-contract.ts
@@ -906,6 +906,15 @@ export interface PluginAgentConfiguration {
   /** Skill frontmatter names from this plugin's manifest skill roots.
    * Duplicate or unknown names reject this plugin's complete selection. */
   skills: string[];
+  /** Filter BB's injected skill catalog before staging. Discovery and explicit
+   * slash invocation retain the installed library. Exactly one plugin may
+   * contribute a catalog policy for a resolution; conflicts fail the command.
+   * Native-provider discovery is a separate boundary and is not filtered by
+   * this field. Entries use frontmatter names, with at most 5000 overrides. */
+  experimental_skillCatalog?: {
+    defaultMode: "always" | "discover" | "off";
+    overrides: Record<string, "always" | "discover" | "off">;
+  };
   /** Optional dynamic instructions. Output is truncated to 4096 characters. */
   instructions?: string;
 }
@@ -1284,6 +1293,12 @@ export interface PluginProviderDeclaration {
 }
 
 export interface PluginAgents {
+  /** Reports the catalog boundaries this host can filter. Native discovery
+   * requires a provider-specific integration beyond BB's staged catalog. */
+  experimental_skillCatalogCapabilities(): {
+    injectedCatalog: true;
+    nativeCatalog: false;
+  };
   /**
    * Select this plugin's statically registered tools and manifest skills for
    * each thread/session resolution, with optional dynamic instructions. The

--- a/packages/plugin-sdk/src/testing/__tests__/fake-plugin-host.test.ts
+++ b/packages/plugin-sdk/src/testing/__tests__/fake-plugin-host.test.ts
@@ -1025,6 +1025,30 @@ describe("agent tools", () => {
     },
   });
 
+  it("exposes catalog capability and validates global catalog policy independently of owned skills", async () => {
+    const { bb, harness } = createFakePluginHost();
+    expect(bb.agents.experimental_skillCatalogCapabilities()).toEqual({
+      injectedCatalog: true,
+      nativeCatalog: false,
+    });
+    bb.agents.configure(() => ({
+      tools: [],
+      skills: [],
+      experimental_skillCatalog: {
+        defaultMode: "discover",
+        overrides: { "another-plugin-skill": "always" },
+      },
+    }));
+    expect(
+      (await harness.resolveAgentConfiguration(configurationContext))
+        .skillCatalogPolicy,
+    ).toEqual({
+      defaultMode: "discover",
+      overrides: { "another-plugin-skill": "always" },
+    });
+    await harness.lifecycle.dispose();
+  });
+
   it("validates zod parameters per call and executes with a default context", async () => {
     const { bb, harness } = createFakePluginHost();
     bb.agents.registerTool({

--- a/packages/plugin-sdk/src/testing/fake-plugin-host.ts
+++ b/packages/plugin-sdk/src/testing/fake-plugin-host.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import { createHash } from "node:crypto";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -423,6 +424,9 @@ export interface FakePluginBehaviorDrivers {
    * semantics. With no callback, every registered tool/declared test skill is
    * selected. Callback failures are logged and return empty selections. */
   resolveAgentConfiguration(context: PluginAgentConfigurationContext): Promise<{
+    skillCatalogPolicy?: NonNullable<
+      PluginAgentConfiguration["experimental_skillCatalog"]
+    >;
     tools: FakeAgentToolRecord[];
     skills: string[];
     instructions: string | null;
@@ -882,6 +886,15 @@ function normalizeAgentConfigurationIds(args: {
   return selected;
 }
 
+const catalogPolicySchema = z
+  .object({
+    defaultMode: z.enum(["always", "discover", "off"]),
+    overrides: z
+      .record(z.string().min(1).max(200), z.enum(["always", "discover", "off"]))
+      .refine((value) => Object.keys(value).length <= 5000),
+  })
+  .strict();
+
 function normalizeAgentConfiguration(args: {
   knownSkillIds: ReadonlySet<string>;
   knownToolIds: ReadonlySet<string>;
@@ -889,6 +902,7 @@ function normalizeAgentConfiguration(args: {
   value: unknown;
 }): {
   toolIds: string[];
+  skillCatalogPolicy?: z.infer<typeof catalogPolicySchema>;
   toolParameterOverrides: Map<string, Record<string, unknown>>;
   skillIds: string[];
   instructions: string | null;
@@ -904,7 +918,15 @@ function normalizeAgentConfiguration(args: {
   }
   const output = args.value as Record<string, unknown>;
   const unknownKeys = Object.keys(output)
-    .filter((key) => !["tools", "skills", "instructions"].includes(key))
+    .filter(
+      (key) =>
+        ![
+          "tools",
+          "skills",
+          "instructions",
+          "experimental_skillCatalog",
+        ].includes(key),
+    )
     .sort();
   if (unknownKeys.length > 0) {
     throw new Error(
@@ -923,6 +945,13 @@ function normalizeAgentConfiguration(args: {
     value: output.tools,
   });
   return {
+    ...(output.experimental_skillCatalog === undefined
+      ? {}
+      : {
+          skillCatalogPolicy: catalogPolicySchema.parse(
+            output.experimental_skillCatalog,
+          ),
+        }),
     toolIds: toolSelections.toolIds,
     toolParameterOverrides: toolSelections.parameterOverrides,
     skillIds: normalizeAgentConfigurationIds({
@@ -1534,6 +1563,10 @@ function createFakePluginHostInternal(
   };
 
   const agents: PluginAgents = {
+    experimental_skillCatalogCapabilities: () => ({
+      injectedCatalog: true,
+      nativeCatalog: false,
+    }),
     configure(provider) {
       assertLive();
       if (agentConfigurationProvider !== null) {
@@ -2633,12 +2666,18 @@ function createFakePluginHostInternal(
           instructions: null,
         };
       }
+      let catalogPolicyRequested = false;
       try {
+        const value = agentConfigurationProvider(context);
+        catalogPolicyRequested =
+          value !== null &&
+          typeof value === "object" &&
+          Object.hasOwn(value, "experimental_skillCatalog");
         const normalized = normalizeAgentConfiguration({
           knownSkillIds: new Set(agentSkillIds),
           knownToolIds: new Set(agentTools.map((tool) => tool.name)),
           pluginId,
-          value: agentConfigurationProvider(context),
+          value,
         });
         const selectedTools = new Set(normalized.toolIds);
         return {
@@ -2652,11 +2691,18 @@ function createFakePluginHostInternal(
                 ? tool
                 : { ...tool, inputSchema: parameters };
             }),
+          ...(normalized.skillCatalogPolicy === undefined
+            ? {}
+            : { skillCatalogPolicy: normalized.skillCatalogPolicy }),
           skills: normalized.skillIds,
           instructions: normalized.instructions,
         };
       } catch (error) {
         emitLog("warn", `agent configure failed: ${errorMessage(error)}`);
+        if (catalogPolicyRequested)
+          throw new Error(
+            `Invalid skill catalog policy from ${pluginId}: ${errorMessage(error)}`,
+          );
         return { tools: [], skills: [], instructions: null };
       }
     },


### PR DESCRIPTION
## Human comments

## What was wrong

Plugins can select their own contributed skills, but cannot filter the complete skill catalog BB stages and injects into agent sessions. A skill manager therefore cannot provide an on-demand catalog without adding instructions that leave the original catalog in the prompt.

## What changed

Adds an experimental plugin capability query and an optional `experimental_skillCatalog` configuration containing a default mode and name overrides (`always`, `discover`, `off`). Only `always` entries enter BB's injected catalog; management and explicit slash selection retain the installed library. Filtering applies during thread creation and turn resumption, before skill staging and prompt assembly. Without a policy, existing behavior is preserved.

The service validates policies and rejects conflicting policy owners. SDK types, fake-host support, regression tests, API audit documentation, and plugin-authoring guidance are included. No host-daemon wire fields change, so the protocol version is unchanged. This does not suppress catalogs independently loaded by native harnesses or provide a filesystem security boundary; discovery/read tools remain the policy plugin's responsibility.

## How you verified

- Server catalog and plugin-agent-tool suites: 22 tests passed.
- SDK fake-plugin-host suite: 66 tests passed.
- Server and SDK typecheck task graph: all 8 tasks passed.
- `git diff --cached --check` passed before commit.
- A companion Skill Manager plugin was built and exercised on stock BB: its capability check safely reports the missing hook while bounded discovery and reading remain available. The new hook has not been exercised in a running desktop build.

> AGENT GENERATED
