### PR TITLE
Show Provider Usage account identity

### DIFF
--- a/plugins/provider-usage/app.test.tsx
+++ b/plugins/provider-usage/app.test.tsx
@@ -76,6 +76,7 @@ describe("provider usage footer disclosure", () => {
                       expiredHint: "Sign in to Claude Code again.",
                       usage: {
                         status: "ok",
+                        accountEmail: "claude@example.com",
                         planLabel: "Max",
                         windows: [
                           {
@@ -97,6 +98,7 @@ describe("provider usage footer disclosure", () => {
                       expiredHint: "Sign in to Codex again.",
                       usage: {
                         status: "ok",
+                        accountEmail: "codex@example.com",
                         planLabel: "Plus",
                         windows: [
                           {
@@ -126,6 +128,7 @@ describe("provider usage footer disclosure", () => {
                       expiredHint: "Sign in to Codex again.",
                       usage: {
                         status: "ok",
+                        accountEmail: "codex@example.com",
                         planLabel: "Plus",
                         windows: [
                           {
@@ -193,6 +196,8 @@ describe("provider usage footer disclosure", () => {
     const machinePicker = slot.getByRole("button", {
       name: "Usage machine: M5",
     });
+    expect(slot.getByRole("heading", { name: "Codex" })).toBeTruthy();
+    expect(slot.getByText("codex@example.com")).toBeTruthy();
     expect(slot.getByText("97% used")).toBeTruthy();
 
     fireEvent.pointerDown(machinePicker, { button: 0 });
@@ -210,9 +215,13 @@ describe("provider usage footer disclosure", () => {
     expect(
       codexTab.querySelector("[data-provider-logo*='/codex/']"),
     ).not.toBeNull();
+    expect(slot.getByRole("heading", { name: "Claude Code" })).toBeTruthy();
+    expect(slot.getByText("claude@example.com")).toBeTruthy();
     expect(slot.getByText("82% used")).toBeTruthy();
 
     fireEvent.click(codexTab);
+    expect(slot.getByRole("heading", { name: "Codex" })).toBeTruthy();
+    expect(slot.getByText("codex@example.com")).toBeTruthy();
     expect(slot.getByText("37% used")).toBeTruthy();
     fireEvent.keyDown(codexTab, { key: "ArrowLeft" });
     expect(claudeTab.getAttribute("aria-selected")).toBe("true");

--- a/plugins/provider-usage/app.tsx
+++ b/plugins/provider-usage/app.tsx
@@ -598,13 +598,24 @@ function ProviderUsageStatus({
           </p>
         ) : (
           <>
-            <div className="flex items-baseline justify-between gap-2">
-              <h2 className="truncate text-xs font-medium text-sidebar-foreground">
-                {activeProvider.displayName}
-              </h2>
+            <div className="flex min-w-0 items-start gap-2">
+              <div className="min-w-0 flex-1">
+                <h2 className="truncate text-xs font-medium text-sidebar-foreground">
+                  {activeProvider.displayName}
+                </h2>
+                {activeProvider.usage?.status === "ok" &&
+                activeProvider.usage.accountEmail !== null ? (
+                  <p
+                    title={activeProvider.usage.accountEmail}
+                    className="truncate text-2xs text-subtle-foreground"
+                  >
+                    {activeProvider.usage.accountEmail}
+                  </p>
+                ) : null}
+              </div>
               {activeProvider.usage?.status === "ok" &&
               activeProvider.usage.planLabel !== null ? (
-                <span className="shrink-0 rounded bg-sidebar-border px-1.5 py-0.5 text-xs text-muted-foreground">
+                <span className="ml-auto shrink-0 rounded-sm bg-sidebar-border/60 px-1 py-0.5 text-2xs leading-none text-subtle-foreground">
                   {activeProvider.usage.planLabel}
                 </span>
               ) : null}

--- a/plugins/provider-usage/server.test.ts
+++ b/plugins/provider-usage/server.test.ts
@@ -104,6 +104,7 @@ describe("provider usage backend", () => {
               expiredHint: "Sign in to Claude Code again.",
               usage: {
                 status: "ok",
+                accountEmail: "dev@example.com",
                 planLabel: "Max",
                 windows: [
                   {

--- a/plugins/provider-usage/server.ts
+++ b/plugins/provider-usage/server.ts
@@ -64,6 +64,7 @@ function normalizedUsage(
     case "ok":
       return {
         status: "ok",
+        accountEmail: usage.accountEmail,
         planLabel: usage.planLabel,
         windows: usage.windows.map((window) => ({
           label: window.label,

--- a/plugins/provider-usage/usage-schema.test.ts
+++ b/plugins/provider-usage/usage-schema.test.ts
@@ -16,6 +16,7 @@ function provider(
     expiredHint: "Sign in again.",
     usage: {
       status: "ok",
+      accountEmail: null,
       planLabel: null,
       windows: [
         {

--- a/plugins/provider-usage/usage-schema.ts
+++ b/plugins/provider-usage/usage-schema.ts
@@ -16,6 +16,7 @@ export const usageWindowSchema = z.strictObject({
 export const providerUsageSchema = z.discriminatedUnion("status", [
   z.strictObject({
     status: z.literal("ok"),
+    accountEmail: z.nullable(nonemptyStringSchema),
     planLabel: z.nullable(nonemptyStringSchema),
     windows: z.array(usageWindowSchema),
   }),


### PR DESCRIPTION
## Human comments

## What was wrong

Provider Usage displayed quota for a machine's direct provider login without identifying which account supplied those limits. Users with multiple provider accounts therefore could not tell which account the card described. This is the narrow account-identity prototype requested after #3100; Account Pool-aware effective-source reporting remains out of scope.

## What changed

- Preserve the existing `accountEmail` field through the Provider Usage plugin's normalization and RPC schema.
- Show the provider name with a subtle, truncated account email beneath it and the plan pill at the right.
- Keep the full email available through the element title and omit the row when no account email exists.
- Update backend, schema, and frontend fixtures for the explicit account contract.

## How you verified

- `pnpm exec turbo run test typecheck --filter=bb-plugin-provider-usage --force` (4/4 tests and typecheck passed)
- `bb plugin build plugins/provider-usage`
- Targeted `oxfmt --check`
- `git diff --check origin/main...HEAD`
- The fixer rebuilt/reloaded the plugin and captured matching before/after UI evidence before handoff.

> AGENT GENERATED
