### PR TITLE
Prevent duplicate Extensions history on close

### DIFF
--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
@@ -174,10 +174,7 @@ export interface SecondaryPanelFixedTab {
 }
 
 export interface ThreadSecondaryPanelProps {
-  activeTab:
-    | SecondaryFixedPanelTab
-    | MarketplacePluginDetailPanelTab
-    | null;
+  activeTab: SecondaryFixedPanelTab | MarketplacePluginDetailPanelTab | null;
   canUseGitUi: boolean;
   gitDiffTabStatus?: GitDiffTabStatus;
   onRetryGitDiffEligibility?: () => void;
@@ -257,9 +254,7 @@ export function ThreadSecondaryPanel({
   );
   const activeRenderableTab =
     tabs.find((tab) => tab.tab.id === activeTab?.id) ??
-    (activeTab === null && fixedTabs.length === 0
-      ? visibleTabs[0]
-      : undefined);
+    (activeTab === null && fixedTabs.length === 0 ? visibleTabs[0] : undefined);
   const hasActiveRenderableTab = activeRenderableTab !== undefined;
   const hidePanelIconName = RIGHT_PANEL_TOGGLE_ICON_NAME;
   const conversationCollapseControl =
@@ -311,7 +306,7 @@ export function ThreadSecondaryPanel({
   );
   const hostLayout = useContext(SecondaryPanelHostLayoutContext);
   const handlePanelCollapse = useCallback(() => {
-    if (hostLayout?.isSuppressed) {
+    if (!isOpen || hostLayout?.isSuppressed) {
       return;
     }
     if (!hasPanelExpandedRef.current) {
@@ -319,7 +314,7 @@ export function ThreadSecondaryPanel({
     }
     hasPanelExpandedRef.current = false;
     onCollapse();
-  }, [hostLayout?.isSuppressed, onCollapse]);
+  }, [hostLayout?.isSuppressed, isOpen, onCollapse]);
   const handlePanelTransitionEnd = useCallback(
     (event: TransitionEvent<HTMLElement>) => {
       if (

--- a/apps/app/src/views/ToolsView.plugin-detail.test.tsx
+++ b/apps/app/src/views/ToolsView.plugin-detail.test.tsx
@@ -680,6 +680,7 @@ describe("BB Official plugin detail routing", () => {
         <Routes>
           <Route path="/extensions/plugins/*" element={<RoutedToolsView />} />
         </Routes>
+        <HistoryBackButton />
       </MemoryRouter>,
       { wrapper: QueryClientWrapper },
     );
@@ -723,6 +724,13 @@ describe("BB Official plugin detail routing", () => {
     expect(screen.getByRole("textbox", { name: "Search plugins" })).toBe(
       search,
     );
+
+    fireEvent.click(screen.getByRole("button", { name: "Browser back" }));
+    await waitFor(() => {
+      expect(screen.getByTestId("route-path").textContent).toBe(
+        "/extensions/plugins/github",
+      );
+    });
   });
 
   it.each([


### PR DESCRIPTION
## Human comments

## What was wrong

The retained Extensions plugin-detail panel could notify collapse again after its route was already closed. That duplicate close navigation recorded the Extensions list twice in browser history, so the first Back press appeared to do nothing instead of reopening the plugin detail. Follow-up to #3101.

## What changed

- Ignore secondary-panel collapse notifications when the panel is already closed.
- Preserve resize-to-zero collapse while the panel is open, along with retained panel identity, focus restoration, and responsive behavior.
- Add a route regression proving one Back action immediately reopens the detail after closing it.
- Resolve the rebase conflict by retaining current-main test coverage plus the new Back assertion; apply formatter-required wrapping in the touched component.

## How you verified

- `pnpm exec turbo run test --filter=@bb/app --force -- 'src/views/ToolsView.plugin-detail.test.tsx' 'src/components/secondary-panel/ThreadSecondaryPanel.test.ts' 'src/components/secondary-panel/ThreadSecondaryPanel.collapseControl.test.tsx' 'src/components/secondary-panel/ThreadSecondaryPanelTabContent.panelGate.test.tsx'` (67/67 passed)
- `pnpm exec turbo run typecheck build --filter=@bb/app --force`
- Targeted `oxfmt --check`
- `git diff --check origin/main...HEAD`
- The fixer also verified desktop Back/Forward, panel resize, DOM identity, focus restoration, and compact Escape behavior before handoff.

> AGENT GENERATED
