### PR TITLE
Honor Reduce Motion in secondary panels

### DIFF
--- a/apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.test.tsx
+++ b/apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.test.tsx
@@ -184,6 +184,10 @@ describe("CompactSecondaryPanelShelf", () => {
     expect(shelf.className).toContain(
       "data-[state=closed]:[transition:visibility_0s_linear_220ms]",
     );
+    expect(shelf.className).toContain("motion-reduce:transition-none!");
+    expect(
+      screen.getByTestId("secondary-panel-shelf-dismiss").className,
+    ).toContain("motion-reduce:transition-none!");
   });
 
   it("marks the shelf inert while closed and interactive while open", () => {

--- a/apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.tsx
+++ b/apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.tsx
@@ -18,7 +18,7 @@ import {
 } from "@/components/ui/secondary-panel-shelf-visibility";
 
 const SHELF_TRANSITION_CLASS =
-  "[transition:translate_220ms_cubic-bezier(0.32,0.72,0,1),width_220ms_cubic-bezier(0.32,0.72,0,1)]";
+  "[transition:translate_220ms_cubic-bezier(0.32,0.72,0,1),width_220ms_cubic-bezier(0.32,0.72,0,1)] motion-reduce:transition-none!";
 const SHELF_SETTLE_MS = 220;
 const SHELF_DRAG_SETTLE_TRANSITION =
   "translate 220ms cubic-bezier(0.32, 0.72, 0, 1)";

--- a/apps/app/src/components/secondary-panel/SecondaryPanelLayout.test.tsx
+++ b/apps/app/src/components/secondary-panel/SecondaryPanelLayout.test.tsx
@@ -333,6 +333,9 @@ describe("SecondaryPanelLayout", () => {
     expect(panelGroup.style.getPropertyValue("--panel-collapse-duration")).toBe(
       "220ms",
     );
+    expect(mainContent.parentElement?.className).toContain(
+      "motion-reduce:transition-none",
+    );
 
     view.rerenderWith({ resetKey: "plugin-page-b" });
 

--- a/apps/app/src/components/secondary-panel/panelTransitionTokens.ts
+++ b/apps/app/src/components/secondary-panel/panelTransitionTokens.ts
@@ -5,7 +5,7 @@ type PanelCollapseTransitionStyle = CSSProperties & {
 };
 
 export const PANEL_COLLAPSE_TRANSITION_CLASS =
-  "duration-[var(--panel-collapse-duration,220ms)] ease-[cubic-bezier(0.32,0.72,0,1)]";
+  "duration-[var(--panel-collapse-duration,220ms)] ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:transition-none";
 
 export function getPanelCollapseTransitionStyle(
   transitionsReady: boolean,

--- a/apps/app/src/components/ui/sidebar.test.tsx
+++ b/apps/app/src/components/ui/sidebar.test.tsx
@@ -422,6 +422,7 @@ describe("mobile sidebar shelf stacking", () => {
     expect(panel.className).toContain("data-[side=left]:border-r");
     expect(panel.className).toContain("data-[side=right]:border-l");
     expect(inset.className).toContain("max-md:z-30");
+    expect(inset.className).toContain("motion-reduce:transition-none!");
     expect(inset.dataset.sidebarShelf).toBe("closed");
 
     fireEvent.click(screen.getByRole("button", { name: "Toggle Sidebar" }));
@@ -441,9 +442,7 @@ describe("mobile sidebar shelf stacking", () => {
       throw new Error("Expected a page inset");
     }
 
-    expect(inset.className).not.toContain(
-      "data-[sidebar-shelf=open]:rounded",
-    );
+    expect(inset.className).not.toContain("data-[sidebar-shelf=open]:rounded");
     expect(inset.className).not.toContain("data-[panel-shelf=shelf]:rounded");
     expect(inset.className).not.toContain(
       "data-[sidebar-shelf=open]:overflow-hidden",
@@ -451,9 +450,7 @@ describe("mobile sidebar shelf stacking", () => {
     expect(inset.className).not.toContain(
       "data-[panel-shelf=shelf]:overflow-hidden",
     );
-    expect(inset.className).not.toContain(
-      "data-[sidebar-shelf=open]:shadow",
-    );
+    expect(inset.className).not.toContain("data-[sidebar-shelf=open]:shadow");
     expect(inset.className).not.toContain("data-[panel-shelf=shelf]:shadow");
   });
 

--- a/apps/app/src/components/ui/sidebar.tsx
+++ b/apps/app/src/components/ui/sidebar.tsx
@@ -39,7 +39,7 @@ const SIDEBAR_MOBILE_SHELF_BACKDROP_SETTLE_TRANSITION = `opacity ${SIDEBAR_MOBIL
 const SIDEBAR_MOBILE_WHEEL_SWIPE_OPEN_DISTANCE_PX = 90;
 const SIDEBAR_MOBILE_WHEEL_SWIPE_RESET_MS = 250;
 const SIDEBAR_MOBILE_SHELF_INSET_TRANSITION_CLASS =
-  "max-md:[transition:translate_220ms_cubic-bezier(0.32,0.72,0,1)]";
+  "max-md:[transition:translate_220ms_cubic-bezier(0.32,0.72,0,1)] motion-reduce:transition-none!";
 const SIDEBAR_MOBILE_BACKDROP_TRANSITION_CLASS =
   "[transition:opacity_220ms_cubic-bezier(0.32,0.72,0,1),translate_220ms_cubic-bezier(0.32,0.72,0,1)]";
 const SIDEBAR_GROUP_LABEL_BASE_CLASS =
@@ -1584,9 +1584,7 @@ const SidebarInset = React.forwardRef<
       : "closed"
     : undefined;
   const panelShelfState =
-    isCompactViewport && !openMobile
-      ? secondaryPanelPresentation
-      : undefined;
+    isCompactViewport && !openMobile ? secondaryPanelPresentation : undefined;
 
   return (
     <main


### PR DESCRIPTION
## Human comments

## What was wrong

Secondary-panel movement retained its 220 ms transitions when the operating system's Reduce Motion preference was enabled. Opening and closing plugin details therefore moved large page regions on both desktop and compact layouts despite the accessibility preference. Follow-up to #3101.

## What changed

- Add reduced-motion transition overrides at the shared desktop panel-collapse token.
- Add important reduced-motion overrides for the compact shelf and page inset so they also beat closed-state shorthands and gesture-set inline transitions.
- Preserve ordinary-motion timing, panel layout, drawer behavior, resizing, persistence, focus, and hidden-state safety.
- Add focused class-contract regressions for all three transition owners.

## How you verified

- `pnpm exec turbo run test --filter=@bb/app --force -- 'src/components/secondary-panel/CompactSecondaryPanelShelf.test.tsx' 'src/components/secondary-panel/SecondaryPanelLayout.test.tsx' 'src/components/ui/sidebar.test.tsx'` (57/57 passed)
- `pnpm exec turbo run typecheck build --filter=@bb/app --force`
- Targeted `oxfmt --check`
- `git diff --check origin/main...HEAD`
- The fixer measured zero reduced-motion animations in desktop and compact browser QA while ordinary motion retained the original 220 ms transitions.

> AGENT GENERATED
