### PR TITLE
Reject extra values on plugin config unset

### DIFF
--- a/apps/cli/src/__tests__/command-output/plugin-config.test.ts
+++ b/apps/cli/src/__tests__/command-output/plugin-config.test.ts
@@ -58,6 +58,22 @@ describe("bb plugin config", () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
+  it("rejects a negative value passed to unset", async () => {
+    const stderr = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+
+    await expect(
+      runCommand(
+        ["plugin", "config", "demo", "unset", "retries", "-1"],
+        register,
+      ),
+    ).rejects.toThrow("process.exit:1");
+
+    expect(stderr).toHaveBeenCalledWith("error: unknown option '-1'\n");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   it("rejects a non-finite number before sending an update", async () => {
     vi.mocked(fetch).mockResolvedValueOnce(settingsResponse(3));
 

--- a/apps/cli/src/commands/plugin.ts
+++ b/apps/cli/src/commands/plugin.ts
@@ -1580,13 +1580,13 @@ export function registerPluginCommands(
             value?.startsWith("-") === true &&
             (terminatorIndex < 0 ||
               terminatorIndex > rawArgs.lastIndexOf(value));
+          const valueIsUnknownOption =
+            valueIsOption &&
+            (actionName !== "set" || !negativeNumberValuePattern.test(value));
           const unknownOption =
             [id, actionName, key, ...command.args.slice(4)].find((argument) =>
               argument?.startsWith("-"),
-            ) ??
-            (valueIsOption && !negativeNumberValuePattern.test(value)
-              ? value
-              : undefined);
+            ) ?? (valueIsUnknownOption ? value : undefined);
           if (unknownOption !== undefined)
             command.error(`error: unknown option '${unknownOption}'`);
           if (command.args.length > 4)


### PR DESCRIPTION
## Human comments

## What was wrong

The plugin configuration command deliberately accepts option-like negative numbers as values for `set`, but that exception was applied before considering the action. As a result, `bb plugin config <id> unset <key> -1` treated the extra value as valid input and silently cleared the setting. This follows up on #3031.

## What changed

Limit the negative-number exception to the `set` action. `unset` now rejects a trailing negative value as an unknown option before making any request, while valid negative values for numeric `set` operations remain supported.

## How you verified

- Added a focused regression that fails before the production change and verifies that `unset ... -1` exits with an unknown-option error without calling the server.
- `TMPDIR="$(mktemp -d)" pnpm exec turbo run test --filter=@bb/cli --force --env-mode=loose` (534/534 tests passed; loose env mode keeps fixtures out of a user-owned `/tmp` ESM package boundary)
- `pnpm exec turbo run typecheck build --filter=@bb/cli --force`
- `pnpm exec oxfmt --check apps/cli/src/commands/plugin.ts apps/cli/src/__tests__/command-output/plugin-config.test.ts`
- `git diff --check origin/main...HEAD`

> AGENT GENERATED
