### PR TITLE
Make the unsandboxed-command badge truthful

### DIFF
--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.presentation.test.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.presentation.test.tsx
@@ -112,8 +112,8 @@ describe("presentation-driven timeline rows", () => {
       title: "ls -la ~/.claude/ide",
       badge: {
         glyph: "SquareUnlock02",
-        label: "sandbox off",
-        hint: "Ran outside of sandbox",
+        label: "Outside of sandbox",
+        hint: "Outside of sandbox",
         tone: "destructive" as const,
       },
     };
@@ -146,8 +146,8 @@ describe("presentation-driven timeline rows", () => {
       />,
     );
     expect(markup.match(/data-icon="SquareUnlock02"/g) ?? []).toHaveLength(2);
-    expect(markup).toContain('aria-label="Ran outside of sandbox"');
-    expect(markup).toContain('title="Ran outside of sandbox"');
+    expect(markup).toContain('aria-label="Outside of sandbox"');
+    expect(markup).toContain('title="Outside of sandbox"');
     expect(markup).toContain("text-destructive-text");
   });
 

--- a/packages/thread-view/test/timeline-row-title.test.ts
+++ b/packages/thread-view/test/timeline-row-title.test.ts
@@ -1646,8 +1646,8 @@ describe("buildTimelineRowTitle", () => {
   it("carries a presentation badge onto command and exploration titles", () => {
     const badge = {
       glyph: "SquareUnlock02",
-      label: "sandbox off",
-      hint: "Ran outside of sandbox",
+      label: "Outside of sandbox",
+      hint: "Outside of sandbox",
       tone: "destructive",
     } as const;
     const presentation = {
@@ -1658,8 +1658,8 @@ describe("buildTimelineRowTitle", () => {
     const badgeDecoration = {
       kind: "badge",
       glyph: "SquareUnlock02",
-      label: "sandbox off",
-      hint: "Ran outside of sandbox",
+      label: "Outside of sandbox",
+      hint: "Outside of sandbox",
       tone: "destructive",
     };
 
@@ -1668,7 +1668,7 @@ describe("buildTimelineRowTitle", () => {
       DEFAULT_OPTIONS,
     );
     expect(plainCommand.decorations[0]).toEqual(badgeDecoration);
-    expect(plainCommand.plain).toContain("(sandbox off)");
+    expect(plainCommand.plain).toContain("(Outside of sandbox)");
 
     const explorationTitles = buildTimelineActivityIntentTitles({
       ...commandRow(),
@@ -1677,6 +1677,33 @@ describe("buildTimelineRowTitle", () => {
     } satisfies TimelineCommandWorkRow);
     expect(explorationTitles[0]?.title.decorations).toEqual([badgeDecoration]);
     expect(explorationTitles[1]?.title.decorations).toEqual([]);
+
+    for (const [approvalStatus, status, expected] of [
+      ["waiting_for_approval", "pending", true],
+      ["denied", "interrupted", true],
+      [null, "pending", true],
+      [null, "error", true],
+      [null, "interrupted", true],
+      [null, "completed", true],
+    ] as const) {
+      const row = {
+        ...commandRow(),
+        approvalStatus,
+        status,
+        presentation,
+        activityIntents: [searchIntent("TODO", "src")],
+      } satisfies TimelineCommandWorkRow;
+      expect(
+        buildTimelineRowTitle(row, DEFAULT_OPTIONS).decorations.some(
+          (decoration) => decoration.kind === "badge",
+        ),
+      ).toBe(expected);
+      expect(
+        buildTimelineActivityIntentTitles(row)[0]?.title.decorations.some(
+          (decoration) => decoration.kind === "badge",
+        ),
+      ).toBe(expected);
+    }
   });
 
   it("appends an (interrupted) decoration to compact exploration intents on interrupted rows", () => {

--- a/packages/thread-view/test/v3-item-projection.test.ts
+++ b/packages/thread-view/test/v3-item-projection.test.ts
@@ -92,8 +92,8 @@ const SANDBOX_ESCAPED_COMMAND_PRESENTATION: ThreadEventItemPresentation = {
   title: "ls -la ~/.claude/ide",
   badge: {
     glyph: "SquareUnlock02",
-    label: "sandbox off",
-    hint: "Ran outside of sandbox",
+    label: "Outside of sandbox",
+    hint: "Outside of sandbox",
     tone: "destructive",
   },
 };
@@ -296,7 +296,7 @@ describe("v3 item projection", () => {
 
     const row = workRow(rendered.rows, "command", "cmd-1");
     expect(row.presentation).toEqual(SANDBOX_ESCAPED_COMMAND_PRESENTATION);
-    expect(plainTitle(row)).toContain("(sandbox off)");
+    expect(plainTitle(row)).toContain("(Outside of sandbox)");
   });
 
   it("groups v3 exploration rows into one exploration bundle like legacy reads", () => {

--- a/plugins/provider-claude-code/src/presentation.test.ts
+++ b/plugins/provider-claude-code/src/presentation.test.ts
@@ -525,8 +525,8 @@ describe("claude item presentation", () => {
       title: "ls -la ~/.claude/ide",
       badge: {
         glyph: "SquareUnlock02",
-        label: "sandbox off",
-        hint: "Ran outside of sandbox",
+        label: "Outside of sandbox",
+        hint: "Outside of sandbox",
         tone: "destructive",
       },
     });

--- a/plugins/provider-claude-code/src/presentation.ts
+++ b/plugins/provider-claude-code/src/presentation.ts
@@ -9,8 +9,8 @@ import {
 
 const SANDBOX_ESCAPED_BADGE = {
   glyph: "SquareUnlock02",
-  label: "sandbox off",
-  hint: "Ran outside of sandbox",
+  label: "Outside of sandbox",
+  hint: "Outside of sandbox",
   tone: "destructive",
 } as const;
 


### PR DESCRIPTION
## Human comments

## What was wrong

Claude Code’s unsandboxed-command badge is attached when a command requests `dangerouslyDisableSandbox`, before its approval or execution outcome is known. Its tooltip said “Ran outside of sandbox,” so waiting and denied rows made a false past-tense claim even though the command had not run. This follows up on #3038.

## What changed

Use the state-neutral wording “Outside of sandbox” for both the badge’s accessible hint and its plain-text label. The badge remains visible for waiting, denied, running, failed, interrupted, and completed commands; ordinary sandboxed commands remain unbadged.

## How you verified

- Added lifecycle coverage for the badge across all six command states.
- The updated provider assertion fails against the old production copy and passes with the fix.
- `pnpm exec turbo run test typecheck build --filter=@bb/app --filter=@bb/thread-view --filter=bb-plugin-provider-claude-code --force`
- Full app suite after refreshing the current frozen lockfile: 3,923 passed, 3 skipped.
- Thread-view and Claude provider suites: 378 and 360 passed.
- Targeted Oxfmt and `git diff --check origin/main...HEAD` passed.

> AGENT GENERATED
