### PR TITLE
Preview thread storage artifacts inline

### DIFF
--- a/plugins/inline-vis/PLUGIN_OVERVIEW.md
+++ b/plugins/inline-vis/PLUGIN_OVERVIEW.md
@@ -1,21 +1,27 @@
-See an agent's chart, demo, or report in the conversation without opening a side panel. The agent writes an HTML file to the workspace. The plugin shows that file inside the assistant message.
+See an agent's chart, demo, or report in the conversation without opening a side panel. The agent writes an HTML file to the workspace or the thread's storage directory. The plugin shows that file inside the assistant message.
 
 ## What you get
 
 - A live preview card in the message. Scripts and styles in the file run.
 - A default viewport height of 224 pixels. The agent can set a height from 120 to 1200 pixels.
-- A header action that opens the source HTML file in the workspace viewer.
+- A header action that opens workspace source HTML in the workspace viewer. Thread-storage previews omit this action.
 - A clear inline error when the file is missing, too large, or not HTML.
 
 ## How it works
 
-The agent emits a message directive that names a workspace-relative `.html` or `.htm` file:
+The agent emits a message directive that names a source-relative `.html` or `.htm` file. Omitting `source` defaults to the workspace, and explicit `source="workspace"` is equivalent:
 
 ```text
 ::inline-vis{file="charts/out.html" height="480"}
 ```
 
-The plugin confirms the file exists in the thread workspace before it renders. Files must be UTF-8 text with a maximum size of 5 MiB. Relative assets next to the file load as usual.
+Read-only artifacts in the thread's storage directory can be rendered without resolving the workspace:
+
+```text
+::inline-vis{source="thread-storage" file="reports/result.html"}
+```
+
+The plugin confirms the file exists in the selected source before it renders. Files must be UTF-8 text with a maximum size of 5 MiB. Relative assets next to the file load as usual.
 
 The preview runs in a sandboxed iframe with an opaque origin. Scripts in the file cannot read the bb page, its cookies, or its storage.
 

--- a/plugins/inline-vis/README.md
+++ b/plugins/inline-vis/README.md
@@ -7,6 +7,13 @@ Builtin plugin for the assistant **message directive** slot
 ::inline-vis{file="demo.html"}
 ```
 
+The omitted `source` defaults to `workspace`; `source="workspace"` is equivalent.
+For a read-only artifact in the current thread's storage directory, use:
+
+```text
+::inline-vis{source="thread-storage" file="reports/result.html"}
+```
+
 Set an optional iframe viewport height in pixels with `height`:
 
 ```text
@@ -17,13 +24,14 @@ The default is 224px; accepted values are whole numbers from 120 through 1200.
 
 bb replaces that leaf with this plugin's React component, which:
 
-1. Validates the untrusted `file` attribute.
-2. Calls the plugin RPC `prepareHtmlPreview` with the message `threadId` and
-   file path to validate the target and surface clean inline errors.
-3. Shows loading / error states and a header action that opens the source HTML
-   file in bb's sidebar workspace viewer.
-4. Points a sandboxed iframe at bb's path-shaped worktree preview route. This
-   matches the sidebar HTML preview: relative sibling assets work, scripts are
+1. Validates the untrusted `source` and `file` attributes.
+2. Calls the plugin RPC `prepareHtmlPreview` with the message `threadId`, source,
+   and file path to validate the target and surface clean inline errors.
+3. Shows loading / error states. Workspace previews include a header action
+   that opens the source HTML file in bb's sidebar workspace viewer;
+   thread-storage previews do not.
+4. Points a sandboxed iframe at bb's existing path-shaped worktree or thread
+   storage route. Relative sibling assets work, scripts are
    enabled, and normal web loading is allowed. The iframe keeps an opaque
    origin (no `allow-same-origin`) so scripts cannot access the bb page, its
    cookies, or storage. Remote scripts, styles, images, fonts, media, fetches,
@@ -33,16 +41,18 @@ bb replaces that leaf with this plugin's React component, which:
 ## Backend security
 
 `prepareHtmlPreview` narrows `unknown` input immediately (rejects unknown
-keys), loads the thread with `include: "environment"`, requires a live
-workspace `path` and `hostId`, confines the workspace-relative `.html`/`.htm`
-path under that root, and preflights it through `bb.sdk.files` (host-routed).
-Absolute paths, traversal, non-html extensions, missing files, non-UTF-8
-content, and files over 5 MiB are rejected. The iframe then uses bb's existing
-confined worktree preview route to serve the document and relative assets.
+keys and source values). Workspace previews load the thread with
+`include: "environment"` and require its live `path` and `hostId`. Thread
+storage previews use `bb.sdk.threads.storageLocation` instead and do not resolve
+the workspace. Both sources confine the relative `.html`/`.htm` path under the
+returned root and preflight it through `bb.sdk.files` (host-routed). Absolute
+paths, traversal, non-html extensions, missing files, non-UTF-8 content, and
+files over 5 MiB are rejected. The iframe then uses bb's existing confined
+worktree or thread-storage route to serve the document and relative assets.
 
 It ships with bb and is reconciled through the builtin plugin lifecycle. Ship
-a workspace HTML file, then ask the agent to visualize it with the directive
-(see the bundled `inline-vis` skill).
+an HTML file in either supported source, then ask the agent to visualize it
+with the directive (see the bundled `inline-vis` skill).
 
 ## Tests
 

--- a/plugins/inline-vis/app.test.tsx
+++ b/plugins/inline-vis/app.test.tsx
@@ -39,6 +39,48 @@ describe("InlineVisDirective", () => {
     expect(slot.rpcCalls).toEqual([]);
   });
 
+  it("shows the rpc validation error for an unknown source", async () => {
+    const slot = renderSlot(
+      app.messageDirectives[0]!,
+      {
+        attributes: { file: "demo.html", source: "project" },
+        source: '::inline-vis{source="project" file="demo.html"}',
+        message,
+        openWorkspaceFile: vi.fn(() => true),
+      },
+      {
+        rpc: {
+          prepareHtmlPreview: (input) => {
+            expect(input).toEqual({
+              threadId: "thr_1",
+              file: "demo.html",
+              source: "project",
+            });
+            throw new Error(
+              'Invalid option: expected "workspace"|"thread-storage"',
+            );
+          },
+        },
+      },
+    );
+
+    const alert = await slot.findByRole("alert");
+    expect(alert.textContent).toMatch(
+      /expected "workspace"\|"thread-storage"/i,
+    );
+    expect(slot.container.querySelector("iframe")).toBeNull();
+    expect(slot.rpcCalls).toEqual([
+      {
+        method: "prepareHtmlPreview",
+        input: {
+          threadId: "thr_1",
+          file: "demo.html",
+          source: "project",
+        },
+      },
+    ]);
+  });
+
   it("uses the sidebar worktree route with an opaque-origin script sandbox", async () => {
     const openWorkspaceFile = vi.fn(() => true);
     const slot = renderSlot(
@@ -56,7 +98,7 @@ describe("InlineVisDirective", () => {
               threadId: "thr_1",
               file: "charts/demo file.html",
             });
-            return { file: "charts/demo file.html" };
+            return { file: "charts/demo file.html", source: "workspace" };
           },
         },
       },
@@ -88,9 +130,59 @@ describe("InlineVisDirective", () => {
     expect(slot.rpcCalls).toEqual([
       {
         method: "prepareHtmlPreview",
-        input: { threadId: "thr_1", file: "charts/demo file.html" },
+        input: {
+          threadId: "thr_1",
+          file: "charts/demo file.html",
+        },
       },
     ]);
+  });
+
+  it("uses the thread-storage route without a workspace action", async () => {
+    const openWorkspaceFile = vi.fn(() => true);
+    const slot = renderSlot(
+      app.messageDirectives[0]!,
+      {
+        attributes: {
+          source: "thread-storage",
+          file: "reports/result file.html",
+        },
+        source:
+          '::inline-vis{source="thread-storage" file="reports/result file.html"}',
+        message,
+        openWorkspaceFile,
+      },
+      {
+        rpc: {
+          prepareHtmlPreview: (input) => {
+            expect(input).toEqual({
+              threadId: "thr_1",
+              file: "reports/result file.html",
+              source: "thread-storage",
+            });
+            return {
+              file: "reports/result file.html",
+              source: "thread-storage",
+            };
+          },
+        },
+      },
+    );
+
+    const iframe = await waitFor(() => {
+      const el = slot.container.querySelector("iframe");
+      expect(el).toBeTruthy();
+      return el as HTMLIFrameElement;
+    });
+
+    expect(iframe.getAttribute("src")).toBe(
+      "/api/v1/threads/thr_1/thread-storage/files/reports/result%20file.html",
+    );
+    expect(iframe.getAttribute("sandbox")).toBe("allow-scripts");
+    expect(
+      slot.queryByRole("button", { name: /open .* in sidebar/i }),
+    ).toBeNull();
+    expect(openWorkspaceFile).not.toHaveBeenCalled();
   });
 
   it("uses an optional bounded height attribute", async () => {
@@ -104,7 +196,10 @@ describe("InlineVisDirective", () => {
       },
       {
         rpc: {
-          prepareHtmlPreview: () => ({ file: "demo.html" }),
+          prepareHtmlPreview: () => ({
+            file: "demo.html",
+            source: "workspace",
+          }),
         },
       },
     );
@@ -118,8 +213,14 @@ describe("InlineVisDirective", () => {
   });
 
   it("reserves the preview height while loading so the timeline does not jump", async () => {
-    let resolvePreview = (_result: { file: string }) => {};
-    const pendingPreview = new Promise<{ file: string }>((resolve) => {
+    let resolvePreview = (_result: {
+      file: string;
+      source: "workspace" | "thread-storage";
+    }) => {};
+    const pendingPreview = new Promise<{
+      file: string;
+      source: "workspace" | "thread-storage";
+    }>((resolve) => {
       resolvePreview = resolve;
     });
     const slot = renderSlot(
@@ -152,7 +253,7 @@ describe("InlineVisDirective", () => {
     const loadingHeader = loadingCard.firstElementChild!;
     const loadingHeaderHtml = loadingHeader.outerHTML;
 
-    resolvePreview({ file: "demo.html" });
+    resolvePreview({ file: "demo.html", source: "workspace" });
 
     const iframe = await waitFor(() => {
       const el = slot.container.querySelector("iframe");

--- a/plugins/inline-vis/app.tsx
+++ b/plugins/inline-vis/app.tsx
@@ -8,11 +8,24 @@ import {
 } from "@get-bb/plugin-sdk/app";
 import type { inlineVisRpcContract } from "./server.js";
 
+type PreviewSource = "workspace" | "thread-storage";
+
+const PREVIEW_SOURCE_CONFIG = {
+  workspace: { route: "worktree/files", opensWorkspace: true },
+  "thread-storage": {
+    route: "thread-storage/files",
+    opensWorkspace: false,
+  },
+} as const satisfies Record<
+  PreviewSource,
+  { route: string; opensWorkspace: boolean }
+>;
+
 type LoadState =
   | { status: "missing-file" }
   | { status: "invalid-height"; message: string }
   | { status: "loading"; file: string }
-  | { status: "ready"; file: string }
+  | { status: "ready"; file: string; source: PreviewSource }
   | { status: "error"; file: string; message: string };
 
 const DEFAULT_HEIGHT_PX = 224;
@@ -23,8 +36,13 @@ function encodePathSegments(file: string): string {
   return file.split("/").map(encodeURIComponent).join("/");
 }
 
-function buildWorktreePreviewUrl(threadId: string, file: string): string {
-  return `/api/v1/threads/${encodeURIComponent(threadId)}/worktree/files/${encodePathSegments(file)}`;
+function buildPreviewUrl(
+  threadId: string,
+  file: string,
+  source: PreviewSource,
+): string {
+  const route = PREVIEW_SOURCE_CONFIG[source].route;
+  return `/api/v1/threads/${encodeURIComponent(threadId)}/${route}/${encodePathSegments(file)}`;
 }
 
 function parsePreviewHeight(value: string | undefined): number | null {
@@ -70,6 +88,7 @@ function InlineVisDirective({
 }: PluginMessageDirectiveProps) {
   const rpc = useRpc<typeof inlineVisRpcContract>();
   const fileAttr = attributes.file?.trim() ?? "";
+  const sourceAttr = attributes.source;
   const heightAttr = attributes.height;
   const previewHeight = parsePreviewHeight(heightAttr);
   const heightError =
@@ -93,7 +112,6 @@ function InlineVisDirective({
       setState({ status: "missing-file" });
       return;
     }
-
     let cancelled = false;
     setState({ status: "loading", file: fileAttr });
 
@@ -102,11 +120,13 @@ function InlineVisDirective({
         const result = await rpc.call("prepareHtmlPreview", {
           threadId: message.threadId,
           file: fileAttr,
+          ...(sourceAttr === undefined ? {} : { source: sourceAttr }),
         });
         if (cancelled) return;
         setState({
           status: "ready",
           file: result.file,
+          source: result.source,
         });
       } catch (error) {
         if (cancelled) return;
@@ -121,7 +141,7 @@ function InlineVisDirective({
     return () => {
       cancelled = true;
     };
-  }, [fileAttr, heightError, message.threadId, rpc]);
+  }, [fileAttr, heightError, message.threadId, rpc, sourceAttr]);
 
   if (state.status === "missing-file") {
     return (
@@ -183,13 +203,18 @@ function InlineVisDirective({
     );
   }
 
-  const previewUrl = buildWorktreePreviewUrl(message.threadId, state.file);
+  const sourceConfig = PREVIEW_SOURCE_CONFIG[state.source];
+  const previewUrl = buildPreviewUrl(
+    message.threadId,
+    state.file,
+    state.source,
+  );
 
   return (
     <PreviewCard
       file={state.file}
       action={
-        openWorkspaceFile === null ? null : (
+        !sourceConfig.opensWorkspace || openWorkspaceFile === null ? null : (
           <button
             type="button"
             aria-label={`Open ${state.file} in sidebar`}

--- a/plugins/inline-vis/package.json
+++ b/plugins/inline-vis/package.json
@@ -3,13 +3,13 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "description": "Render workspace HTML visualizations inline in assistant messages.",
+  "description": "Render workspace or thread-storage HTML visualizations inline in assistant messages.",
   "engines": {
     "bb": ">=0.0"
   },
   "bb": {
     "name": "Inline visualizations",
-    "description": "Render workspace HTML visualizations inline in assistant messages.",
+    "description": "Render workspace or thread-storage HTML visualizations inline in assistant messages.",
     "branding": {
       "icon": "AppWindow"
     },

--- a/plugins/inline-vis/server.test.ts
+++ b/plugins/inline-vis/server.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { createFakePluginHost } from "@get-bb/plugin-sdk/testing";
 import plugin, {
   MAX_HTML_BYTES,
-  requireWorkspaceHtmlFile,
+  requireRelativeHtmlFile,
   resolveContainedHtmlPath,
 } from "./server";
 
@@ -22,7 +22,10 @@ function threadWithEnv(overrides?: { path?: string | null; hostId?: string }) {
 }
 
 async function load(sdk: {
-  threads?: { get: (args: unknown) => unknown };
+  threads?: {
+    get?: (args: unknown) => unknown;
+    storageLocation?: (args: unknown) => unknown;
+  };
   files?: { read: (args: unknown) => unknown };
 }) {
   const host = createFakePluginHost({
@@ -33,25 +36,25 @@ async function load(sdk: {
   return host;
 }
 
-describe("requireWorkspaceHtmlFile", () => {
+describe("requireRelativeHtmlFile", () => {
   it("accepts nested html paths", () => {
-    expect(requireWorkspaceHtmlFile("demo.html")).toBe("demo.html");
-    expect(requireWorkspaceHtmlFile("charts/out.HTML")).toBe("charts/out.HTML");
+    expect(requireRelativeHtmlFile("demo.html")).toBe("demo.html");
+    expect(requireRelativeHtmlFile("charts/out.HTML")).toBe("charts/out.HTML");
   });
 
   it("rejects absolute, traversal, and non-html paths", () => {
-    expect(() => requireWorkspaceHtmlFile("/etc/passwd.html")).toThrow(
-      /workspace-relative/,
+    expect(() => requireRelativeHtmlFile("/etc/passwd.html")).toThrow(
+      /source-relative/,
     );
-    expect(() => requireWorkspaceHtmlFile("../secret.html")).toThrow(
+    expect(() => requireRelativeHtmlFile("../secret.html")).toThrow(
       /traversal|escape/,
     );
-    expect(() => requireWorkspaceHtmlFile("..\\secret.html")).toThrow();
-    expect(() => requireWorkspaceHtmlFile("charts/../secret.html")).toThrow(
+    expect(() => requireRelativeHtmlFile("..\\secret.html")).toThrow();
+    expect(() => requireRelativeHtmlFile("charts/../secret.html")).toThrow(
       /traversal/,
     );
-    expect(() => requireWorkspaceHtmlFile("demo.md")).toThrow(/\.html/);
-    expect(() => requireWorkspaceHtmlFile("")).toThrow(/non-empty/);
+    expect(() => requireRelativeHtmlFile("demo.md")).toThrow(/\.html/);
+    expect(() => requireRelativeHtmlFile("")).toThrow(/non-empty/);
   });
 });
 
@@ -85,6 +88,24 @@ describe("prepareHtmlPreview rpc", () => {
       code: "invalid_input",
       issues: expect.any(Array),
     });
+  });
+
+  it("rejects an unknown source during input validation", async () => {
+    const { harness } = await load({
+      threads: { get: () => threadWithEnv() },
+      files: { read: () => ({ content: "", contentEncoding: "utf8" }) },
+    });
+    await expect(
+      harness.callRpc("prepareHtmlPreview", {
+        threadId: "thr_1",
+        file: "demo.html",
+        source: "project",
+      }),
+    ).rejects.toMatchObject({
+      code: "invalid_input",
+      issues: expect.any(Array),
+    });
+    expect(harness.sdk.calls).toHaveLength(0);
   });
 
   it("rejects missing fields and non-object input", async () => {
@@ -158,8 +179,52 @@ describe("prepareHtmlPreview rpc", () => {
     const result = await harness.callRpc("prepareHtmlPreview", {
       threadId: "thr_1",
       file: "charts/demo.html",
+      source: "workspace",
     });
-    expect(result).toEqual({ file: "charts/demo.html" });
+    expect(result).toEqual({
+      file: "charts/demo.html",
+      source: "workspace",
+    });
+    expect(harness.sdk.callsTo("files.read")).toHaveLength(1);
+  });
+
+  it("reads thread storage without resolving the workspace", async () => {
+    const storageRootPath = "/thread-storage/thr_1";
+    const { harness } = await load({
+      threads: {
+        storageLocation: (args) => {
+          expect(args).toEqual({ threadId: "thr_1" });
+          return { hostId: HOST_ID, storageRootPath };
+        },
+      },
+      files: {
+        read: (args) => {
+          expect(args).toEqual({
+            path: path.resolve(storageRootPath, "reports/result.html"),
+            rootPath: storageRootPath,
+            hostId: HOST_ID,
+          });
+          return {
+            content: "<html><body>ok</body></html>",
+            contentEncoding: "utf8",
+            sizeBytes: 32,
+            sha256: "abc",
+          };
+        },
+      },
+    });
+
+    const result = await harness.callRpc("prepareHtmlPreview", {
+      threadId: "thr_1",
+      file: "reports/result.html",
+      source: "thread-storage",
+    });
+    expect(result).toEqual({
+      file: "reports/result.html",
+      source: "thread-storage",
+    });
+    expect(harness.sdk.callsTo("threads.storageLocation")).toHaveLength(1);
+    expect(harness.sdk.callsTo("threads.get")).toHaveLength(0);
     expect(harness.sdk.callsTo("files.read")).toHaveLength(1);
   });
 
@@ -177,7 +242,7 @@ describe("prepareHtmlPreview rpc", () => {
         threadId: "thr_1",
         file: "/tmp/x.html",
       }),
-    ).rejects.toThrow(/workspace-relative/);
+    ).rejects.toThrow(/source-relative/);
     await expect(
       harness.callRpc("prepareHtmlPreview", {
         threadId: "thr_1",

--- a/plugins/inline-vis/server.ts
+++ b/plugins/inline-vis/server.ts
@@ -8,6 +8,7 @@ const HTML_EXTENSIONS = new Set([".html", ".htm"]);
 
 interface PrepareHtmlPreviewResult {
   file: string;
+  source: "workspace" | "thread-storage";
 }
 
 function requireNonEmptyString(value: unknown, field: string): string {
@@ -21,13 +22,13 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-export function requireWorkspaceHtmlFile(value: unknown): string {
+export function requireRelativeHtmlFile(value: unknown): string {
   const file = requireNonEmptyString(value, "file");
   if (path.isAbsolute(file)) {
-    throw new Error(`"file" must be workspace-relative, not absolute: ${file}`);
+    throw new Error(`"file" must be source-relative, not absolute: ${file}`);
   }
   if (/^[a-zA-Z]:[\\/]/.test(file) || file.startsWith("\\\\")) {
-    throw new Error(`"file" must be workspace-relative, not absolute: ${file}`);
+    throw new Error(`"file" must be source-relative, not absolute: ${file}`);
   }
   const slashNormalized = file.replace(/\\/g, "/");
   if (slashNormalized.split("/").includes("..")) {
@@ -41,7 +42,7 @@ export function requireWorkspaceHtmlFile(value: unknown): string {
     normalized === "." ||
     normalized.startsWith("/")
   ) {
-    throw new Error(`"file" must not escape the workspace: ${file}`);
+    throw new Error(`"file" must not escape its source: ${file}`);
   }
   const ext = path.posix.extname(normalized).toLowerCase();
   if (!HTML_EXTENSIONS.has(ext)) {
@@ -64,7 +65,7 @@ export function resolveContainedHtmlPath(
     relative.startsWith(`..${path.sep}`) ||
     path.isAbsolute(relative)
   ) {
-    throw new Error(`"file" must not escape the workspace: ${relativeFile}`);
+    throw new Error(`"file" must not escape its source: ${relativeFile}`);
   }
   return absolute;
 }
@@ -82,10 +83,20 @@ export const inlineVisRpcContract = defineRpcContract({
     input: z
       .object({
         threadId: z.string().trim().min(1),
-        file: z.string().transform((value) => requireWorkspaceHtmlFile(value)),
+        file: z.string().transform((value) => requireRelativeHtmlFile(value)),
+        source: z
+          .string()
+          .trim()
+          .pipe(z.enum(["workspace", "thread-storage"]))
+          .default("workspace"),
       })
       .strict(),
-    output: z.object({ file: z.string() }).strict(),
+    output: z
+      .object({
+        file: z.string(),
+        source: z.enum(["workspace", "thread-storage"]),
+      })
+      .strict(),
   },
 });
 
@@ -94,32 +105,44 @@ export default async function plugin(bb: BbPluginApi) {
     async prepareHtmlPreview({
       threadId,
       file,
+      source,
     }): Promise<PrepareHtmlPreviewResult> {
-      const thread = await bb.sdk.threads.get({
-        threadId,
-        include: "environment",
-      });
+      let rootPath: string;
+      let hostId: string;
 
-      if (!("environment" in thread)) {
-        throw new Error(
-          "Thread environment was not returned — inline-vis needs a live environment.",
-        );
-      }
+      if (source === "thread-storage") {
+        const storage = await bb.sdk.threads.storageLocation({ threadId });
+        rootPath = storage.storageRootPath;
+        hostId = storage.hostId;
+      } else {
+        const thread = await bb.sdk.threads.get({
+          threadId,
+          include: "environment",
+        });
 
-      const environment = thread.environment;
-      const rootPath =
-        typeof environment?.path === "string" ? environment.path : null;
-      if (!rootPath) {
-        throw new Error(
-          "This thread has no workspace path — inline-vis needs a live environment.",
-        );
-      }
-      const hostId =
-        typeof environment?.hostId === "string" ? environment.hostId : null;
-      if (!hostId) {
-        throw new Error(
-          "This thread's environment has no hostId — cannot read workspace files.",
-        );
+        if (!("environment" in thread)) {
+          throw new Error(
+            "Thread environment was not returned — inline-vis needs a live environment.",
+          );
+        }
+
+        const environment = thread.environment;
+        const workspacePath =
+          typeof environment?.path === "string" ? environment.path : null;
+        if (!workspacePath) {
+          throw new Error(
+            "This thread has no workspace path — inline-vis needs a live environment.",
+          );
+        }
+        const workspaceHostId =
+          typeof environment?.hostId === "string" ? environment.hostId : null;
+        if (!workspaceHostId) {
+          throw new Error(
+            "This thread's environment has no hostId — cannot read workspace files.",
+          );
+        }
+        rootPath = workspacePath;
+        hostId = workspaceHostId;
       }
 
       const absolutePath = resolveContainedHtmlPath(rootPath, file);
@@ -150,7 +173,7 @@ export default async function plugin(bb: BbPluginApi) {
         );
       }
 
-      return { file };
+      return { file, source };
     },
   });
 }

--- a/plugins/inline-vis/skills/inline-vis/SKILL.md
+++ b/plugins/inline-vis/skills/inline-vis/SKILL.md
@@ -1,23 +1,33 @@
 ---
 name: inline-vis
-description: "Render a workspace HTML artifact inline in BB chat using the inline-vis directive."
+description: "Render a workspace or thread-storage HTML artifact inline in BB chat using the inline-vis directive."
 ---
 
 # Inline HTML visualizations
 
 When the user should see a small HTML demo, chart, or report **inline in the
-assistant message**, write (or update) a workspace-relative `.html` file, then
-emit this **message directive** as its own block (not inside a fenced code
-block):
+assistant message**, write (or update) a source-relative `.html` file, then emit
+this **message directive** as its own block (not inside a fenced code block):
 
 ```text
 ::inline-vis{file="demo.html"}
 ```
 
+Omitting `source` defaults to the workspace. Explicit `source="workspace"` is
+equivalent. For a read-only thread-storage artifact, write the document to
+`$BB_THREAD_STORAGE/reports/result.html`, then emit its storage-relative path:
+
+```text
+::inline-vis{source="thread-storage" file="reports/result.html"}
+```
+
 ## Rules
 
-- `file` is **workspace-relative** (e.g. `demo.html`, `charts/out.html`). Never
-  use absolute paths.
+- `source` is optional and must be `workspace` or `thread-storage`.
+- `file` is relative to the selected source (e.g. `demo.html`,
+  `charts/out.html`). Workspace paths are relative to the current workspace;
+  thread-storage paths are relative to `$BB_THREAD_STORAGE`. Never put an
+  absolute path in the directive.
 - `height` is optional and sets the iframe viewport height in pixels. It must be
   a whole number from 120 through 1200; omit it for the 224px default.
 - Only `.html` / `.htm` files are accepted.
@@ -26,8 +36,9 @@ block):
   CORS, mixed-content, and remote-server policies. Scripts execute in an
   opaque-origin iframe and cannot access the bb page, cookies, or storage.
 - Keep files small (under the sidebar preview's 5 MiB document limit).
-- Emit the directive only after the file exists on disk in the current thread
-  workspace.
+- Emit the directive only after the file exists on disk in the selected source.
+- Prefer `thread-storage` for read-only generated reports and other artifacts
+  that should not modify the workspace.
 - Do **not** put the directive inside backticks or a markdown code fence, or it
   stays literal text.
 - Incomplete streaming syntax stays literal until the closing `}` arrives — emit


### PR DESCRIPTION
## Human comments

## What was wrong

The inline-vis plugin assumed every HTML artifact belonged to the thread workspace: its RPC always resolved the thread environment, and its frontend always used the worktree file route and workspace-open action. This prevented read-only artifacts stored in thread storage from being rendered inline. Fixes [#3158](https://github.com/get-bb/bb/issues/3158).

## What changed

Added `source="workspace" | "thread-storage"` to the inline-vis directive, with omitted source defaulting to `workspace`.

The backend now resolves thread-storage roots through `bb.sdk.threads.storageLocation()` and preflights files with the returned host and root confinement. The plugin-local RPC returns the validated file and authoritative normalized source.

The frontend uses the existing worktree or thread-storage route based on that returned source. Thread-storage previews retain the sandboxed iframe but omit the workspace-open action.

Updated the inline-vis README, plugin overview, package metadata, and bundled skill. The skill explains that thread-storage artifacts are written beneath `$BB_THREAD_STORAGE` while directive file paths remain storage-relative.

This changes only the plugin-local RPC contract. It does not change the server/daemon protocol and requires no `HOST_DAEMON_PROTOCOL_VERSION` increment.

## How you verified

Added focused backend coverage for thread-storage resolution, host/root confinement, workspace bypass, source defaulting, and invalid-source validation.

Added focused frontend coverage for source-specific routes, segment encoding, iframe sandboxing, RPC validation errors, and suppression of the workspace-open action.

Ran:

`pnpm exec turbo run test typecheck --filter=bb-plugin-inline-vis`

Results:

- 21 tests passed across 2 test files
- Typecheck passed
- 6 Turbo tasks succeeded
- `git diff --check` passed

Fixes #3158

> AGENT GENERATED
