### PR TITLE
Render Markdown files in inline previews

### DIFF
--- a/plugins/inline-vis/PLUGIN_OVERVIEW.md
+++ b/plugins/inline-vis/PLUGIN_OVERVIEW.md
@@ -1,23 +1,24 @@
-See an agent's chart, demo, or report in the conversation without opening a side panel. The agent writes an HTML file to the workspace. The plugin shows that file inside the assistant message.
+See an agent's chart, demo, report, or Markdown document in the conversation without opening a side panel. The plugin shows the workspace file inside the assistant message.
 
 ## What you get
 
-- A live preview card in the message. Scripts and styles in the file run.
+- A live HTML preview or formatted Markdown document in the message.
 - A default viewport height of 224 pixels. The agent can set a height from 120 to 1200 pixels.
-- A header action that opens the source HTML file in the workspace viewer.
-- A clear inline error when the file is missing, too large, or not HTML.
+- A header action that opens the source file in the workspace viewer.
+- A clear inline error when the file is missing, too large, or unsupported.
 
 ## How it works
 
-The agent emits a message directive that names a workspace-relative `.html` or `.htm` file:
+The agent emits a message directive that names a workspace-relative `.html`, `.htm`, `.md`, or `.markdown` file:
 
 ```text
 ::inline-vis{file="charts/out.html" height="480"}
+::inline-vis{file="reports/summary.md"}
 ```
 
-The plugin confirms the file exists in the thread workspace before it renders. Files must be UTF-8 text with a maximum size of 5 MiB. Relative assets next to the file load as usual.
+The plugin confirms the file exists in the thread workspace before it renders. Files must be UTF-8 text with a maximum size of 5 MiB. Relative assets next to HTML files load as usual.
 
-The preview runs in a sandboxed iframe with an opaque origin. Scripts in the file cannot read the bb page, its cookies, or its storage.
+HTML runs in a sandboxed iframe with an opaque origin. Markdown uses bb's renderer with raw HTML disabled.
 
 ## For agents
 

--- a/plugins/inline-vis/README.md
+++ b/plugins/inline-vis/README.md
@@ -5,9 +5,10 @@ Builtin plugin for the assistant **message directive** slot
 
 ```text
 ::inline-vis{file="demo.html"}
+::inline-vis{file="notes.md"}
 ```
 
-Set an optional iframe viewport height in pixels with `height`:
+Set an optional preview height in pixels with `height`:
 
 ```text
 ::inline-vis{file="demo.html" height="480"}
@@ -18,30 +19,31 @@ The default is 224px; accepted values are whole numbers from 120 through 1200.
 bb replaces that leaf with this plugin's React component, which:
 
 1. Validates the untrusted `file` attribute.
-2. Calls the plugin RPC `prepareHtmlPreview` with the message `threadId` and
+2. Calls the plugin RPC `preparePreview` with the message `threadId` and
    file path to validate the target and surface clean inline errors.
-3. Shows loading / error states and a header action that opens the source HTML
-   file in bb's sidebar workspace viewer.
-4. Points a sandboxed iframe at bb's path-shaped worktree preview route. This
-   matches the sidebar HTML preview: relative sibling assets work, scripts are
-   enabled, and normal web loading is allowed. The iframe keeps an opaque
-   origin (no `allow-same-origin`) so scripts cannot access the bb page, its
-   cookies, or storage. Remote scripts, styles, images, fonts, media, fetches,
-   and WebSockets work subject to ordinary browser CORS, mixed-content, and
-   remote-server policies.
+3. Shows loading / error states and a header action that opens the source file
+   in bb's sidebar workspace viewer.
+4. Points HTML files at bb's path-shaped worktree preview route. This matches
+   the sidebar HTML preview: relative sibling assets work, scripts are enabled,
+   and normal web loading is allowed. The iframe keeps an opaque origin (no
+   `allow-same-origin`) so scripts cannot access the bb page, its cookies, or
+   storage. Remote scripts, styles, images, fonts, media, fetches, and WebSockets
+   work subject to ordinary browser CORS, mixed-content, and remote-server
+   policies.
+5. Renders Markdown files with bb's Markdown renderer. Raw HTML is disabled.
 
 ## Backend security
 
-`prepareHtmlPreview` narrows `unknown` input immediately (rejects unknown
+`preparePreview` narrows `unknown` input immediately (rejects unknown
 keys), loads the thread with `include: "environment"`, requires a live
-workspace `path` and `hostId`, confines the workspace-relative `.html`/`.htm`
-path under that root, and preflights it through `bb.sdk.files` (host-routed).
-Absolute paths, traversal, non-html extensions, missing files, non-UTF-8
-content, and files over 5 MiB are rejected. The iframe then uses bb's existing
+workspace `path` and `hostId`, confines the workspace-relative `.html`, `.htm`,
+`.md`, or `.markdown` path under that root, and reads it through `bb.sdk.files`
+(host-routed). Absolute paths, traversal, unsupported extensions, missing files,
+non-UTF-8 content, and files over 5 MiB are rejected. The iframe then uses bb's existing
 confined worktree preview route to serve the document and relative assets.
 
 It ships with bb and is reconciled through the builtin plugin lifecycle. Ship
-a workspace HTML file, then ask the agent to visualize it with the directive
+a supported workspace file, then ask the agent to show it with the directive
 (see the bundled `inline-vis` skill).
 
 ## Tests

--- a/plugins/inline-vis/app.test.tsx
+++ b/plugins/inline-vis/app.test.tsx
@@ -39,6 +39,47 @@ describe("InlineVisDirective", () => {
     expect(slot.rpcCalls).toEqual([]);
   });
 
+  it("renders a Markdown document with the host renderer and no iframe", async () => {
+    const openWorkspaceFile = vi.fn(() => true);
+    const slot = renderSlot(
+      app.messageDirectives[0]!,
+      {
+        attributes: { file: "reports/notes.md" },
+        source: '::inline-vis{file="reports/notes.md"}',
+        message,
+        openWorkspaceFile,
+      },
+      {
+        rpc: {
+          preparePreview: (input) => {
+            expect(input).toEqual({
+              threadId: "thr_1",
+              file: "reports/notes.md",
+            });
+            return {
+              kind: "markdown",
+              file: "reports/notes.md",
+              content: "# Notes\n\nReady for review.",
+            };
+          },
+        },
+      },
+    );
+
+    const markdown = await slot.findByTestId("bb-markdown");
+    expect(markdown.textContent).toBe("# Notes\n\nReady for review.");
+    expect(slot.container.querySelector("iframe")).toBeNull();
+    expect(markdown.parentElement?.style.height).toBe("224px");
+    expect(markdown.parentElement?.className).toContain("overflow-auto");
+
+    fireEvent.click(
+      slot.getByRole("button", {
+        name: "Open reports/notes.md in sidebar",
+      }),
+    );
+    expect(openWorkspaceFile).toHaveBeenCalledWith("reports/notes.md");
+  });
+
   it("uses the sidebar worktree route with an opaque-origin script sandbox", async () => {
     const openWorkspaceFile = vi.fn(() => true);
     const slot = renderSlot(
@@ -51,12 +92,12 @@ describe("InlineVisDirective", () => {
       },
       {
         rpc: {
-          prepareHtmlPreview: (input) => {
+          preparePreview: (input) => {
             expect(input).toEqual({
               threadId: "thr_1",
               file: "charts/demo file.html",
             });
-            return { file: "charts/demo file.html" };
+            return { kind: "html", file: "charts/demo file.html" };
           },
         },
       },
@@ -87,52 +128,57 @@ describe("InlineVisDirective", () => {
     expect(openWorkspaceFile).toHaveBeenCalledWith("charts/demo file.html");
     expect(slot.rpcCalls).toEqual([
       {
-        method: "prepareHtmlPreview",
+        method: "preparePreview",
         input: { threadId: "thr_1", file: "charts/demo file.html" },
       },
     ]);
   });
 
-  it("uses an optional bounded height attribute", async () => {
+  it("uses an optional bounded height for Markdown", async () => {
     const slot = renderSlot(
       app.messageDirectives[0]!,
       {
-        attributes: { file: "demo.html", height: "480" },
-        source: '::inline-vis{file="demo.html" height="480"}',
+        attributes: { file: "notes.md", height: "480" },
+        source: '::inline-vis{file="notes.md" height="480"}',
         message,
         openWorkspaceFile: null,
       },
       {
         rpc: {
-          prepareHtmlPreview: () => ({ file: "demo.html" }),
+          preparePreview: () => ({
+            kind: "markdown",
+            file: "notes.md",
+            content: "# Notes",
+          }),
         },
       },
     );
 
-    const iframe = await waitFor(() => {
-      const el = slot.container.querySelector("iframe");
-      expect(el).toBeTruthy();
-      return el as HTMLIFrameElement;
-    });
-    expect(iframe.style.height).toBe("480px");
+    const markdown = await slot.findByTestId("bb-markdown");
+    expect(markdown.parentElement?.style.height).toBe("480px");
   });
 
-  it("reserves the preview height while loading so the timeline does not jump", async () => {
-    let resolvePreview = (_result: { file: string }) => {};
-    const pendingPreview = new Promise<{ file: string }>((resolve) => {
+  it("reserves the Markdown preview height while loading", async () => {
+    type MarkdownPreview = {
+      kind: "markdown";
+      file: string;
+      content: string;
+    };
+    let resolvePreview = (_result: MarkdownPreview) => {};
+    const pendingPreview = new Promise<MarkdownPreview>((resolve) => {
       resolvePreview = resolve;
     });
     const slot = renderSlot(
       app.messageDirectives[0]!,
       {
-        attributes: { file: "demo.html", height: "480" },
-        source: '::inline-vis{file="demo.html" height="480"}',
+        attributes: { file: "notes.md", height: "480" },
+        source: '::inline-vis{file="notes.md" height="480"}',
         message,
         openWorkspaceFile: vi.fn(() => true),
       },
       {
         rpc: {
-          prepareHtmlPreview: () => pendingPreview,
+          preparePreview: () => pendingPreview,
         },
       },
     );
@@ -146,25 +192,24 @@ describe("InlineVisDirective", () => {
     });
     expect(loading.style.height).toBe("480px");
     expect(
-      slot.getByRole("status", { name: "Loading visualization demo.html" }),
+      slot.getByRole("status", { name: "Loading visualization notes.md" }),
     ).toBe(loading);
     const loadingCard = loading.parentElement!;
     const loadingHeader = loadingCard.firstElementChild!;
     const loadingHeaderHtml = loadingHeader.outerHTML;
 
-    resolvePreview({ file: "demo.html" });
-
-    const iframe = await waitFor(() => {
-      const el = slot.container.querySelector("iframe");
-      if (!(el instanceof HTMLIFrameElement)) {
-        throw new Error("Expected the inline visualization iframe to render");
-      }
-      return el;
+    resolvePreview({
+      kind: "markdown",
+      file: "notes.md",
+      content: "# Notes",
     });
-    expect(iframe.style.height).toBe("480px");
+
+    const markdown = await slot.findByTestId("bb-markdown");
+    const markdownBody = markdown.parentElement!;
+    expect(markdownBody.style.height).toBe("480px");
     expect(slot.queryByRole("status")).toBeNull();
 
-    const readyCard = iframe.parentElement!;
+    const readyCard = markdownBody.parentElement!;
     expect(readyCard.className).toBe(loadingCard.className);
     const readyHeader = readyCard.firstElementChild!;
     expect(readyHeader.className).toBe(loadingHeader.className);
@@ -204,15 +249,15 @@ describe("InlineVisDirective", () => {
       },
       {
         rpc: {
-          prepareHtmlPreview: () => {
-            throw new Error("HTML file not found: missing.html");
+          preparePreview: () => {
+            throw new Error("Preview file not found: missing.html");
           },
         },
       },
     );
 
     const alert = await slot.findByRole("alert");
-    expect(alert.textContent).toMatch(/HTML file not found: missing\.html/);
+    expect(alert.textContent).toMatch(/Preview file not found: missing\.html/);
     expect(slot.container.querySelector("iframe")).toBeNull();
   });
 });

--- a/plugins/inline-vis/app.tsx
+++ b/plugins/inline-vis/app.tsx
@@ -3,6 +3,7 @@ import { Icon } from "@bb/shared-ui/icon";
 import { Skeleton } from "@bb/shared-ui/skeleton";
 import {
   definePluginApp,
+  Markdown,
   useRpc,
   type PluginMessageDirectiveProps,
 } from "@get-bb/plugin-sdk/app";
@@ -12,7 +13,8 @@ type LoadState =
   | { status: "missing-file" }
   | { status: "invalid-height"; message: string }
   | { status: "loading"; file: string }
-  | { status: "ready"; file: string }
+  | { status: "ready"; kind: "html"; file: string }
+  | { status: "ready"; kind: "markdown"; file: string; content: string }
   | { status: "error"; file: string; message: string };
 
 const DEFAULT_HEIGHT_PX = 224;
@@ -99,15 +101,12 @@ function InlineVisDirective({
 
     void (async () => {
       try {
-        const result = await rpc.call("prepareHtmlPreview", {
+        const result = await rpc.call("preparePreview", {
           threadId: message.threadId,
           file: fileAttr,
         });
         if (cancelled) return;
-        setState({
-          status: "ready",
-          file: result.file,
-        });
+        setState({ status: "ready", ...result });
       } catch (error) {
         if (cancelled) return;
         setState({
@@ -183,8 +182,6 @@ function InlineVisDirective({
     );
   }
 
-  const previewUrl = buildWorktreePreviewUrl(message.threadId, state.file);
-
   return (
     <PreviewCard
       file={state.file}
@@ -204,13 +201,22 @@ function InlineVisDirective({
         )
       }
     >
-      <iframe
-        title={`inline-vis: ${state.file}`}
-        src={previewUrl}
-        sandbox="allow-scripts"
-        style={{ height: previewHeight ?? DEFAULT_HEIGHT_PX }}
-        className="block w-full border-0 bg-background"
-      />
+      {state.kind === "markdown" ? (
+        <div
+          style={{ height: previewHeight ?? DEFAULT_HEIGHT_PX }}
+          className="overflow-auto p-3"
+        >
+          <Markdown content={state.content} />
+        </div>
+      ) : (
+        <iframe
+          title={`inline-vis: ${state.file}`}
+          src={buildWorktreePreviewUrl(message.threadId, state.file)}
+          sandbox="allow-scripts"
+          style={{ height: previewHeight ?? DEFAULT_HEIGHT_PX }}
+          className="block w-full border-0 bg-background"
+        />
+      )}
     </PreviewCard>
   );
 }

--- a/plugins/inline-vis/package.json
+++ b/plugins/inline-vis/package.json
@@ -3,13 +3,13 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "description": "Render workspace HTML visualizations inline in assistant messages.",
+  "description": "Render workspace HTML visualizations and Markdown documents inline in assistant messages.",
   "engines": {
     "bb": ">=0.0"
   },
   "bb": {
     "name": "Inline visualizations",
-    "description": "Render workspace HTML visualizations inline in assistant messages.",
+    "description": "Render workspace HTML visualizations and Markdown documents inline in assistant messages.",
     "branding": {
       "icon": "AppWindow"
     },

--- a/plugins/inline-vis/server.test.ts
+++ b/plugins/inline-vis/server.test.ts
@@ -2,9 +2,9 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { createFakePluginHost } from "@get-bb/plugin-sdk/testing";
 import plugin, {
-  MAX_HTML_BYTES,
-  requireWorkspaceHtmlFile,
-  resolveContainedHtmlPath,
+  MAX_PREVIEW_BYTES,
+  requireWorkspacePreviewFile,
+  resolveContainedPreviewPath,
 } from "./server";
 
 const ROOT = "/workspace/project";
@@ -33,50 +33,111 @@ async function load(sdk: {
   return host;
 }
 
-describe("requireWorkspaceHtmlFile", () => {
-  it("accepts nested html paths", () => {
-    expect(requireWorkspaceHtmlFile("demo.html")).toBe("demo.html");
-    expect(requireWorkspaceHtmlFile("charts/out.HTML")).toBe("charts/out.HTML");
+describe("requireWorkspacePreviewFile", () => {
+  it("accepts nested preview paths", () => {
+    expect(requireWorkspacePreviewFile("demo.html")).toBe("demo.html");
+    expect(requireWorkspacePreviewFile("charts/out.HTML")).toBe(
+      "charts/out.HTML",
+    );
   });
 
-  it("rejects absolute, traversal, and non-html paths", () => {
-    expect(() => requireWorkspaceHtmlFile("/etc/passwd.html")).toThrow(
+  it("rejects absolute, traversal, and unsupported paths", () => {
+    expect(() => requireWorkspacePreviewFile("/etc/passwd.html")).toThrow(
       /workspace-relative/,
     );
-    expect(() => requireWorkspaceHtmlFile("../secret.html")).toThrow(
+    expect(() => requireWorkspacePreviewFile("../secret.html")).toThrow(
       /traversal|escape/,
     );
-    expect(() => requireWorkspaceHtmlFile("..\\secret.html")).toThrow();
-    expect(() => requireWorkspaceHtmlFile("charts/../secret.html")).toThrow(
+    expect(() => requireWorkspacePreviewFile("..\\secret.html")).toThrow();
+    expect(() => requireWorkspacePreviewFile("charts/../secret.html")).toThrow(
       /traversal/,
     );
-    expect(() => requireWorkspaceHtmlFile("demo.md")).toThrow(/\.html/);
-    expect(() => requireWorkspaceHtmlFile("")).toThrow(/non-empty/);
+    expect(() => requireWorkspacePreviewFile("demo.txt")).toThrow(/\.html/);
+    expect(() => requireWorkspacePreviewFile("")).toThrow(/non-empty/);
   });
 });
 
-describe("resolveContainedHtmlPath", () => {
+describe("resolveContainedPreviewPath", () => {
   it("resolves under the root", () => {
-    expect(resolveContainedHtmlPath(ROOT, "demo.html")).toBe(
+    expect(resolveContainedPreviewPath(ROOT, "demo.html")).toBe(
       path.resolve(ROOT, "demo.html"),
     );
   });
 
   it("rejects resolved paths outside the root", () => {
     expect(() =>
-      resolveContainedHtmlPath(ROOT, path.join("..", "outside.html")),
+      resolveContainedPreviewPath(ROOT, path.join("..", "outside.html")),
     ).toThrow(/escape/);
   });
 });
 
-describe("prepareHtmlPreview rpc", () => {
+describe("preview preparation rpc", () => {
+  it("returns Markdown content for a workspace document", async () => {
+    const { harness } = await load({
+      threads: { get: () => threadWithEnv() },
+      files: {
+        read: (args) => {
+          expect(args).toEqual({
+            path: path.resolve(ROOT, "notes.md"),
+            rootPath: ROOT,
+            hostId: HOST_ID,
+          });
+          return {
+            content: "# Notes\n\nReady for review.",
+            contentEncoding: "utf8",
+            sizeBytes: 26,
+            sha256: "abc",
+          };
+        },
+      },
+    });
+
+    await expect(
+      harness.callRpc("preparePreview", {
+        threadId: "thr_1",
+        file: "notes.md",
+      }),
+    ).resolves.toEqual({
+      kind: "markdown",
+      file: "notes.md",
+      content: "# Notes\n\nReady for review.",
+    });
+  });
+
+  it("accepts Markdown extensions case-insensitively", async () => {
+    const { harness } = await load({
+      threads: { get: () => threadWithEnv() },
+      files: {
+        read: () => ({
+          content: "# Report",
+          contentEncoding: "utf8",
+          sizeBytes: 8,
+          sha256: "abc",
+        }),
+      },
+    });
+
+    for (const file of ["reports/summary.markdown", "reports/summary.MD"]) {
+      await expect(
+        harness.callRpc("preparePreview", {
+          threadId: "thr_1",
+          file,
+        }),
+      ).resolves.toEqual({
+        kind: "markdown",
+        file,
+        content: "# Report",
+      });
+    }
+  });
+
   it("rejects unknown input fields immediately", async () => {
     const { harness } = await load({
       threads: { get: () => threadWithEnv() },
       files: { read: () => ({ content: "", contentEncoding: "utf8" }) },
     });
     await expect(
-      harness.callRpc("prepareHtmlPreview", {
+      harness.callRpc("preparePreview", {
         threadId: "thr_1",
         file: "demo.html",
         extra: true,
@@ -92,20 +153,20 @@ describe("prepareHtmlPreview rpc", () => {
       threads: { get: () => threadWithEnv() },
       files: { read: () => ({ content: "", contentEncoding: "utf8" }) },
     });
+    await expect(harness.callRpc("preparePreview", null)).rejects.toMatchObject(
+      {
+        code: "invalid_input",
+        issues: expect.any(Array),
+      },
+    );
     await expect(
-      harness.callRpc("prepareHtmlPreview", null),
+      harness.callRpc("preparePreview", { threadId: "thr_1" }),
     ).rejects.toMatchObject({
       code: "invalid_input",
       issues: expect.any(Array),
     });
     await expect(
-      harness.callRpc("prepareHtmlPreview", { threadId: "thr_1" }),
-    ).rejects.toMatchObject({
-      code: "invalid_input",
-      issues: expect.any(Array),
-    });
-    await expect(
-      harness.callRpc("prepareHtmlPreview", { file: "demo.html" }),
+      harness.callRpc("preparePreview", { file: "demo.html" }),
     ).rejects.toMatchObject({
       code: "invalid_input",
       issues: expect.any(Array),
@@ -120,7 +181,7 @@ describe("prepareHtmlPreview rpc", () => {
       files: { read: () => ({ content: "<p>x</p>", contentEncoding: "utf8" }) },
     });
     await expect(
-      harness.callRpc("prepareHtmlPreview", {
+      harness.callRpc("preparePreview", {
         threadId: "thr_1",
         file: "demo.html",
       }),
@@ -155,15 +216,15 @@ describe("prepareHtmlPreview rpc", () => {
       },
     });
 
-    const result = await harness.callRpc("prepareHtmlPreview", {
+    const result = await harness.callRpc("preparePreview", {
       threadId: "thr_1",
       file: "charts/demo.html",
     });
-    expect(result).toEqual({ file: "charts/demo.html" });
+    expect(result).toEqual({ kind: "html", file: "charts/demo.html" });
     expect(harness.sdk.callsTo("files.read")).toHaveLength(1);
   });
 
-  it("rejects absolute and traversing file attributes before reading", async () => {
+  it("rejects invalid Markdown paths and extensions before reading", async () => {
     const { harness } = await load({
       threads: { get: () => threadWithEnv() },
       files: {
@@ -173,17 +234,29 @@ describe("prepareHtmlPreview rpc", () => {
       },
     });
     await expect(
-      harness.callRpc("prepareHtmlPreview", {
+      harness.callRpc("preparePreview", {
         threadId: "thr_1",
-        file: "/tmp/x.html",
+        file: "/tmp/x.md",
       }),
     ).rejects.toThrow(/workspace-relative/);
     await expect(
-      harness.callRpc("prepareHtmlPreview", {
+      harness.callRpc("preparePreview", {
         threadId: "thr_1",
-        file: "../etc/passwd.html",
+        file: "../etc/passwd.md",
       }),
     ).rejects.toThrow(/traversal|escape/);
+    await expect(
+      harness.callRpc("preparePreview", {
+        threadId: "thr_1",
+        file: "notes.mdx",
+      }),
+    ).rejects.toThrow(/\.md/);
+    await expect(
+      harness.callRpc("preparePreview", {
+        threadId: "thr_1",
+        file: "notes.txt",
+      }),
+    ).rejects.toThrow(/\.html/);
     expect(harness.sdk.callsTo("files.read")).toHaveLength(0);
   });
 
@@ -197,9 +270,9 @@ describe("prepareHtmlPreview rpc", () => {
       },
     });
     await expect(
-      missingHost.harness.callRpc("prepareHtmlPreview", {
+      missingHost.harness.callRpc("preparePreview", {
         threadId: "thr_1",
-        file: "gone.html",
+        file: "gone.md",
       }),
     ).rejects.toThrow(/not found/);
 
@@ -214,9 +287,9 @@ describe("prepareHtmlPreview rpc", () => {
       },
     });
     await expect(
-      binaryHost.harness.callRpc("prepareHtmlPreview", {
+      binaryHost.harness.callRpc("preparePreview", {
         threadId: "thr_1",
-        file: "bin.html",
+        file: "bin.md",
       }),
     ).rejects.toThrow(/UTF-8/);
 
@@ -226,14 +299,14 @@ describe("prepareHtmlPreview rpc", () => {
         read: () => ({
           content: "",
           contentEncoding: "utf8",
-          sizeBytes: MAX_HTML_BYTES + 1,
+          sizeBytes: MAX_PREVIEW_BYTES + 1,
         }),
       },
     });
     await expect(
-      hugeHost.harness.callRpc("prepareHtmlPreview", {
+      hugeHost.harness.callRpc("preparePreview", {
         threadId: "thr_1",
-        file: "big.html",
+        file: "big.md",
       }),
     ).rejects.toThrow(/too large/);
   });

--- a/plugins/inline-vis/server.ts
+++ b/plugins/inline-vis/server.ts
@@ -2,13 +2,20 @@ import path from "node:path";
 import { defineRpcContract, type BbPluginApi } from "@get-bb/plugin-sdk";
 import { z } from "zod";
 
-export const MAX_HTML_BYTES = 5 * 1024 * 1024;
+export const MAX_PREVIEW_BYTES = 5 * 1024 * 1024;
 
-const HTML_EXTENSIONS = new Set([".html", ".htm"]);
+type PreviewKind = "html" | "markdown";
 
-interface PrepareHtmlPreviewResult {
-  file: string;
-}
+const PREVIEW_KIND_BY_EXTENSION: ReadonlyMap<string, PreviewKind> = new Map([
+  [".html", "html"],
+  [".htm", "html"],
+  [".md", "markdown"],
+  [".markdown", "markdown"],
+]);
+
+type PreparePreviewResult =
+  | { kind: "html"; file: string }
+  | { kind: "markdown"; file: string; content: string };
 
 function requireNonEmptyString(value: unknown, field: string): string {
   if (typeof value !== "string" || value.trim().length === 0) {
@@ -21,7 +28,18 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-export function requireWorkspaceHtmlFile(value: unknown): string {
+function previewKind(file: string): PreviewKind {
+  const extension = path.posix.extname(file).toLowerCase();
+  const kind = PREVIEW_KIND_BY_EXTENSION.get(extension);
+  if (kind === undefined) {
+    throw new Error(
+      `"file" must end with .html, .htm, .md, or .markdown, got ${JSON.stringify(file)}`,
+    );
+  }
+  return kind;
+}
+
+export function requireWorkspacePreviewFile(value: unknown): string {
   const file = requireNonEmptyString(value, "file");
   if (path.isAbsolute(file)) {
     throw new Error(`"file" must be workspace-relative, not absolute: ${file}`);
@@ -43,16 +61,11 @@ export function requireWorkspaceHtmlFile(value: unknown): string {
   ) {
     throw new Error(`"file" must not escape the workspace: ${file}`);
   }
-  const ext = path.posix.extname(normalized).toLowerCase();
-  if (!HTML_EXTENSIONS.has(ext)) {
-    throw new Error(
-      `"file" must end with .html or .htm, got ${JSON.stringify(file)}`,
-    );
-  }
+  previewKind(normalized);
   return normalized;
 }
 
-export function resolveContainedHtmlPath(
+export function resolveContainedPreviewPath(
   rootPath: string,
   relativeFile: string,
 ): string {
@@ -78,23 +91,31 @@ function httpStatus(error: unknown): number | null {
 }
 
 export const inlineVisRpcContract = defineRpcContract({
-  prepareHtmlPreview: {
+  preparePreview: {
     input: z
       .object({
         threadId: z.string().trim().min(1),
-        file: z.string().transform((value) => requireWorkspaceHtmlFile(value)),
+        file: z
+          .string()
+          .transform((value) => requireWorkspacePreviewFile(value)),
       })
       .strict(),
-    output: z.object({ file: z.string() }).strict(),
+    output: z.discriminatedUnion("kind", [
+      z.object({ kind: z.literal("html"), file: z.string() }).strict(),
+      z
+        .object({
+          kind: z.literal("markdown"),
+          file: z.string(),
+          content: z.string(),
+        })
+        .strict(),
+    ]),
   },
 });
 
 export default async function plugin(bb: BbPluginApi) {
   bb.rpc.register(inlineVisRpcContract, {
-    async prepareHtmlPreview({
-      threadId,
-      file,
-    }): Promise<PrepareHtmlPreviewResult> {
+    async preparePreview({ threadId, file }): Promise<PreparePreviewResult> {
       const thread = await bb.sdk.threads.get({
         threadId,
         include: "environment",
@@ -122,7 +143,7 @@ export default async function plugin(bb: BbPluginApi) {
         );
       }
 
-      const absolutePath = resolveContainedHtmlPath(rootPath, file);
+      const absolutePath = resolveContainedPreviewPath(rootPath, file);
 
       let result;
       try {
@@ -133,24 +154,27 @@ export default async function plugin(bb: BbPluginApi) {
         });
       } catch (error) {
         if (httpStatus(error) === 404) {
-          throw new Error(`HTML file not found: ${file}`);
+          throw new Error(`Preview file not found: ${file}`);
         }
         throw error;
       }
 
       if (result.contentEncoding !== "utf8") {
         throw new Error(
-          `HTML file is not valid UTF-8 text (encoding=${result.contentEncoding}).`,
+          `Preview file is not valid UTF-8 text (encoding=${result.contentEncoding}).`,
         );
       }
       const sizeBytes = result.sizeBytes;
-      if (sizeBytes > MAX_HTML_BYTES) {
+      if (sizeBytes > MAX_PREVIEW_BYTES) {
         throw new Error(
-          `HTML file is too large (${sizeBytes} bytes; max ${MAX_HTML_BYTES}).`,
+          `Preview file is too large (${sizeBytes} bytes; max ${MAX_PREVIEW_BYTES}).`,
         );
       }
 
-      return { file };
+      const kind = previewKind(file);
+      return kind === "markdown"
+        ? { kind, file, content: result.content }
+        : { kind, file };
     },
   });
 }

--- a/plugins/inline-vis/skills/inline-vis/SKILL.md
+++ b/plugins/inline-vis/skills/inline-vis/SKILL.md
@@ -1,30 +1,32 @@
 ---
 name: inline-vis
-description: "Render a workspace HTML artifact inline in BB chat using the inline-vis directive."
+description: "Show a newly created or updated workspace HTML demo, chart, or report, or Markdown plan, summary, or notes inline in BB chat with the inline-vis directive."
 ---
 
-# Inline HTML visualizations
+# Inline workspace previews
 
-When the user should see a small HTML demo, chart, or report **inline in the
-assistant message**, write (or update) a workspace-relative `.html` file, then
+When the user should see an HTML demo or a Markdown document **inline in the
+assistant message**, write or update the workspace-relative file, then
 emit this **message directive** as its own block (not inside a fenced code
 block):
 
 ```text
 ::inline-vis{file="demo.html"}
+::inline-vis{file="notes.md"}
 ```
 
 ## Rules
 
 - `file` is **workspace-relative** (e.g. `demo.html`, `charts/out.html`). Never
   use absolute paths.
-- `height` is optional and sets the iframe viewport height in pixels. It must be
-  a whole number from 120 through 1200; omit it for the 224px default.
-- Only `.html` / `.htm` files are accepted.
-- Inline and external CSS/JavaScript are supported. Remote images, fonts,
+- `height` is optional and sets the preview height in pixels. It must be a whole
+  number from 120 through 1200; omit it for the 224px default.
+- `.html`, `.htm`, `.md`, and `.markdown` files are accepted.
+- Inline and external CSS/JavaScript are supported in HTML. Remote images, fonts,
   media, fetches, and WebSockets are also allowed subject to normal browser
   CORS, mixed-content, and remote-server policies. Scripts execute in an
   opaque-origin iframe and cannot access the bb page, cookies, or storage.
+  Markdown uses BB's renderer with raw HTML disabled.
 - Keep files small (under the sidebar preview's 5 MiB document limit).
 - Emit the directive only after the file exists on disk in the current thread
   workspace.
@@ -33,6 +35,6 @@ block):
 - Incomplete streaming syntax stays literal until the closing `}` arrives — emit
   a complete directive in one piece when possible.
 
-The bb app replaces the directive with a sandboxed preview. If the plugin is
+The bb app replaces the directive with an inline preview. If the plugin is
 disabled or the path is invalid, users see the original directive source or an
 inline error from the plugin.


### PR DESCRIPTION
## Human comments

## What was wrong

The inline-vis plugin hard-coded HTML extensions in its server validation and always rendered accepted files through an iframe, leaving no path for workspace Markdown documents to use the existing inline preview chrome. This meant agents had to convert Markdown artifacts to HTML or paste their contents directly into messages. Fixes [#3159](https://github.com/get-bb/bb/issues/3159).

## What changed

Generalized inline-vis file validation and its plugin-private RPC to support `.md` and `.markdown` files alongside HTML. The RPC now returns a discriminated HTML or Markdown result, including validated UTF-8 content for Markdown.

Markdown previews use BB's host Markdown renderer inside the existing bounded, scrollable preview card. HTML iframe behavior and sandboxing remain unchanged. Updated the plugin metadata, README, overview, and bundled agent skill with the new supported formats.

The plugin-private RPC was renamed from `prepareHtmlPreview` to `preparePreview`. No server/daemon wire contract changed, so `HOST_DAEMON_PROTOCOL_VERSION` was not incremented. No CLI changes were required.

## How you verified

Added red-first server coverage for Markdown content and extension handling, followed by frontend coverage for host-rendered Markdown, sidebar opening, bounded height, scrolling, and loading-to-ready layout stability.

Ran:

- `pnpm exec turbo run test typecheck --filter=bb-plugin-inline-vis` — 20 tests passed; typecheck passed.
- `bb plugin build plugins/inline-vis` — server and app bundles built successfully.
- `git diff --check` — passed.

Fixes #3159

> AGENT GENERATED
