### PR TITLE
Fix text selection in mobile panel previews

### DIFF
--- a/apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.test.tsx
+++ b/apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.test.tsx
@@ -39,6 +39,7 @@ function fireTouch(
 
 afterEach(() => {
   cleanup();
+  window.getSelection()?.removeAllRanges();
   vi.restoreAllMocks();
 });
 
@@ -161,6 +162,43 @@ describe("CompactSecondaryPanelShelf", () => {
 
     expect(onClose).toHaveBeenCalledTimes(1);
   });
+
+  it.each(["before touch", "after long press"])(
+    "preserves text selection established %s instead of dismissing",
+    (timing) => {
+      const { onClose } = renderShelf(true);
+      const shelf = screen.getByTestId("secondary-panel-shelf");
+      const body = screen.getByTestId("panel-body");
+      body.textContent = "Select this preview text";
+      Object.defineProperty(shelf, "clientWidth", { value: 300 });
+      const selectText = () => {
+        const range = document.createRange();
+        range.selectNodeContents(body);
+        window.getSelection()?.removeAllRanges();
+        window.getSelection()?.addRange(range);
+        expect(document.getSelection()?.toString()).toBe(
+          "Select this preview text",
+        );
+      };
+
+      if (timing === "before touch") selectText();
+      fireTouch(body, "touchstart", createTouch(60, 160));
+      if (timing === "after long press") selectText();
+      fireTouch(window, "touchmove", createTouch(240, 164));
+      fireTouch(window, "touchend", createTouch(240, 164));
+
+      expect(onClose).not.toHaveBeenCalled();
+      expect(window.getSelection()?.toString()).toBe(
+        "Select this preview text",
+      );
+
+      window.getSelection()?.removeAllRanges();
+      fireTouch(body, "touchstart", createTouch(60, 160));
+      fireTouch(window, "touchmove", createTouch(240, 164));
+      fireTouch(window, "touchend", createTouch(240, 164));
+      expect(onClose).toHaveBeenCalledTimes(1);
+    },
+  );
 
   it("ignores a closing swipe from the left browser edge", () => {
     const { onClose } = renderShelf(true);

--- a/apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.tsx
+++ b/apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.tsx
@@ -172,7 +172,7 @@ export function CompactSecondaryPanelShelf({
               : APP_OVERLAY_LAYER.secondaryPanel,
         }}
         className={cn(
-          "fixed inset-y-0 right-0 flex h-(--bb-shell-height) touch-pan-y select-none flex-col overflow-hidden border-l border-border-seam bg-background pt-[env(safe-area-inset-top)] pr-[env(safe-area-inset-right)] pb-[var(--bb-safe-area-bottom,env(safe-area-inset-bottom))] pl-[env(safe-area-inset-left)] outline-none",
+          "fixed inset-y-0 right-0 flex h-(--bb-shell-height) touch-pan-y flex-col overflow-hidden border-l border-border-seam bg-background pt-[env(safe-area-inset-top)] pr-[env(safe-area-inset-right)] pb-[var(--bb-safe-area-bottom,env(safe-area-inset-bottom))] pl-[env(safe-area-inset-left)] outline-none",
           "w-(--secondary-panel-width-mobile) data-[state=full]:w-full data-[state=full]:border-l-0",
           SHELF_TRANSITION_CLASS,
           "data-[state=closed]:invisible data-[state=closed]:[transition:visibility_0s_linear_220ms]",

--- a/apps/app/src/components/ui/use-horizontal-dismiss-drag.ts
+++ b/apps/app/src/components/ui/use-horizontal-dismiss-drag.ts
@@ -99,6 +99,16 @@ function startsInHorizontalScroller(session: DragSession): boolean {
   return false;
 }
 
+function hasTextSelectionWithin(boundary: Element): boolean {
+  const selection = boundary.ownerDocument.getSelection();
+  if (selection === null || selection.isCollapsed) return false;
+  return (
+    (selection.anchorNode !== null &&
+      boundary.contains(selection.anchorNode)) ||
+    (selection.focusNode !== null && boundary.contains(selection.focusNode))
+  );
+}
+
 function suppressNextClick() {
   const cleanup = () => {
     window.removeEventListener("click", suppress, { capture: true });
@@ -157,6 +167,10 @@ export function useHorizontalDismissDrag(options: Options) {
       if (session === null) return;
       const point = trackedPoint(event, session);
       if (point === null) return;
+      if (!session.dragging && hasTextSelectionWithin(session.boundary)) {
+        clearSession();
+        return;
+      }
       const direction = optionsRef.current.direction === "left" ? -1 : 1;
       const deltaX = point.x - session.startX;
       const deltaY = point.y - session.startY;
@@ -256,6 +270,7 @@ export function useHorizontalDismissDrag(options: Options) {
       target: EventTarget | null,
       boundary: Element,
     ) => {
+      if (hasTextSelectionWithin(boundary)) return;
       const view = boundary.ownerDocument.defaultView;
       if (
         (optionsRef.current.direction === "left" &&


### PR DESCRIPTION
## Human comments

## What was wrong

The mobile right panel applied `select-none` to its entire container, preventing native selection in markdown previews and other content without an explicit selection override. Its dismiss gesture also had no guard for active text selections.

## What changed

Remove the container-wide selection block. Keep horizontal dismiss gestures from starting, or claiming a pending touch, while a noncollapsed selection touches their panel. This intentionally disables swipe-to-dismiss throughout that panel while text is selected; clearing the selection restores swiping. Gestures already being dragged continue normally.

Add regression coverage for selections present before touch and established after a long press, including successful dismissal after clearing the selection.

## How you verified

- `pnpm exec turbo run test --filter=@bb/app -- CompactSecondaryPanelShelf` — 16 tests passed.
- `pnpm exec turbo run test --filter=@bb/app -- sidebar.test.tsx` — 43 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/app` — passed.
- Opened a markdown fixture through the source app in Chrome mobile emulation (412 × 915, coarse pointer). With the old class restored, a mouse drag selected nothing; removing it allowed the same drag to select the paragraph.
- Started `pnpm start:worktree` and confirmed the dedicated test thread opens its markdown preview.
- Native Android long-press and selection-handle interactions have not been verified on a device.

> AGENT GENERATED
