### PR TITLE
Fix project and plugin startup races

### DIFF
--- a/apps/app/src/components/plugin/PluginNavSidebarItems.test.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.test.tsx
@@ -37,6 +37,13 @@ import {
   pluginNavPanelOrderAtom,
   pluginNavVisiblePanelKeysAtom,
 } from "./pluginNavSidebarAtoms";
+import {
+  markPluginFrontendsSettled,
+  resetPluginFrontendBootStateForTest,
+  setServerPluginsStarting,
+  setPluginFrontendReconcilePending,
+} from "@/lib/plugin-frontend-boot-state";
+import { writeLastKnownPluginNavPanelChrome } from "@/lib/plugin-nav-panel-chrome";
 import { splitLayoutAtom } from "@/lib/split-layout/atoms";
 import { countPanes, findPaneByContent } from "@/lib/split-layout";
 import { makePluginRegistrationSet as registrationSet } from "@/test/fixtures/plugins";
@@ -219,6 +226,8 @@ async function openCustomizeFromContextMenu(
 }
 
 beforeEach(() => {
+  resetPluginFrontendBootStateForTest();
+  markPluginFrontendsSettled();
   window.localStorage.clear();
   resetAllCrashedPluginSlotsForTest();
   vi.spyOn(console, "error").mockImplementation(() => {});
@@ -227,6 +236,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  resetPluginFrontendBootStateForTest();
   resetPluginSlotStoreForTest();
   resetAllCrashedPluginSlotsForTest();
   vi.restoreAllMocks();
@@ -234,6 +244,62 @@ afterEach(() => {
 });
 
 describe("PluginNavSidebarItems", () => {
+  it("shows placeholders on first launch and removes them when startup settles", () => {
+    resetPluginFrontendBootStateForTest();
+    renderSidebarItems({
+      builtInEntries: [builtInEntry("new-thread", "New thread")],
+    });
+    expect(
+      screen.getByRole("status", { name: "Loading plugins" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByTestId("plugin-nav-loading-placeholders").children,
+    ).toHaveLength(3);
+    expect(screen.getByRole("button", { name: "New thread" })).toBeTruthy();
+    act(() => markPluginFrontendsSettled());
+    expect(
+      screen.queryByRole("status", { name: "Loading plugins" }),
+    ).toBeNull();
+    expect(screen.queryByTestId("plugin-nav-loading-placeholders")).toBeNull();
+  });
+
+  it("keeps remembered labels while the server starts, then reveals ready panels in place", () => {
+    writeLastKnownPluginNavPanelChrome([
+      {
+        pluginId: "docs",
+        id: "main",
+        path: "main",
+        title: "Docs",
+        icon: "Puzzle",
+      },
+    ]);
+    setServerPluginsStarting(true);
+    renderSidebarItems();
+    const row = screen.getByRole("button", { name: "Docs" });
+    expect(row.getAttribute("aria-busy")).toBe("true");
+    expect(screen.getByText("Docs").classList.contains("animate-shine")).toBe(
+      true,
+    );
+    expect(screen.queryByTestId("plugin-nav-loading-placeholders")).toBeNull();
+    act(() => {
+      setPluginFrontendReconcilePending(true);
+      setServerPluginsStarting(false);
+      registerPanel("docs", "Docs");
+    });
+    expect(screen.getByRole("button", { name: "Docs" })).toBe(row);
+    expect(row.hasAttribute("aria-busy")).toBe(false);
+    expect(
+      screen.getByRole("status", { name: "Loading plugins" }),
+    ).toBeTruthy();
+    act(() => setPluginFrontendReconcilePending(false));
+    expect(
+      screen.queryByRole("status", { name: "Loading plugins" }),
+    ).toBeNull();
+    expect(screen.getByText("Docs").classList.contains("animate-shine")).toBe(
+      false,
+    );
+  });
+
   it("collapses the entire subsection with zero traditional plugins", () => {
     renderSidebarItems();
 

--- a/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
@@ -22,6 +22,8 @@ import {
 import { Button } from "@bb/shared-ui/button";
 import { Checkbox } from "@bb/shared-ui/checkbox";
 import { Icon } from "@bb/shared-ui/icon";
+import { Skeleton } from "@bb/shared-ui/skeleton";
+import { usePluginFrontendsSettled } from "@/lib/plugin-frontend-boot-state";
 import {
   ContextMenu,
   ContextMenuContent,
@@ -137,6 +139,7 @@ export function PluginNavSidebarItems(props: {
   onNavigate?: () => void;
   splitEnabled?: boolean;
 }) {
+  const pluginsLoading = !usePluginFrontendsSettled();
   const discoveredEntries = usePluginNavPanelChrome();
   const entries = props.entries ?? discoveredEntries;
   const rows = useMemo<SidebarNavRow[]>(
@@ -163,9 +166,10 @@ export function PluginNavSidebarItems(props: {
       (props.builtInEntries ?? []).map(getPluginNavPanelKey),
     [props.builtInEntries, props.leadingOrderKeys],
   );
-  if (rows.length === 0) return null;
+  if (rows.length === 0 && !pluginsLoading) return null;
   return (
     <PluginNavSidebarItemList
+      pluginsLoading={pluginsLoading}
       rows={rows}
       leadingOrderKeys={leadingOrderKeys}
       splitEnabled={props.splitEnabled ?? false}
@@ -183,6 +187,7 @@ export function PluginNavSidebarItems(props: {
 }
 
 function PluginNavSidebarItemList({
+  pluginsLoading,
   compactCustomizeMode,
   leadingOrderKeys,
   onCompactCustomizeModeChange,
@@ -190,6 +195,7 @@ function PluginNavSidebarItemList({
   rows,
   splitEnabled = false,
 }: {
+  pluginsLoading: boolean;
   compactCustomizeMode?: boolean;
   leadingOrderKeys: readonly string[];
   onCompactCustomizeModeChange?: (isCustomizing: boolean) => void;
@@ -459,6 +465,36 @@ function PluginNavSidebarItemList({
           )}
         </SortableContext>
       </DndContext>
+      {pluginsLoading ? (
+        <div role="status" aria-label="Loading plugins" className="space-y-0.5">
+          {rows.every((row) => !isPluginSidebarNavRow(row)) ? (
+            <div
+              aria-hidden="true"
+              data-testid="plugin-nav-loading-placeholders"
+            >
+              {["w-24", "w-32", "w-20"].map((width) => (
+                <div key={width} className="flex h-8 items-center gap-2 px-2">
+                  <Skeleton className="size-4 shrink-0 rounded-md bg-sidebar-border/60 motion-reduce:animate-none" />
+                  <Skeleton
+                    className={cn(
+                      "h-2.5 rounded-full bg-sidebar-border/60 motion-reduce:animate-none",
+                      width,
+                    )}
+                  />
+                </div>
+              ))}
+            </div>
+          ) : null}
+          <div className="flex items-center gap-2 px-2 py-1.5 text-xs text-muted-foreground">
+            <Icon
+              name="Loading"
+              className="size-3 motion-safe:animate-spin"
+              aria-hidden="true"
+            />
+            <span className="animate-shine">Loading plugins…</span>
+          </div>
+        </div>
+      ) : null}
       {hidden.length > 0 ? (
         <SidebarNavigationMoreRow
           hiddenRows={hidden}
@@ -1039,6 +1075,7 @@ function PluginNavSidebarItem({
     <SidebarNavRowChrome
       {...props}
       rowKey={rowKey}
+      loading={panel === null}
       title={chrome.title}
       icon={<PluginIcon pluginId={chrome.pluginId} icon={chrome.icon} />}
       isActive={pathname === path || pathname.startsWith(`${path}/`)}
@@ -1059,6 +1096,7 @@ function PluginNavSidebarItem({
 
 interface SidebarNavRowChromeProps {
   rowKey: string;
+  loading?: boolean;
   title: string;
   icon: ReactNode;
   isActive: boolean;
@@ -1075,6 +1113,7 @@ interface SidebarNavRowChromeProps {
 
 function SidebarNavRowChrome({
   rowKey,
+  loading = false,
   title,
   icon,
   isActive,
@@ -1121,7 +1160,12 @@ function SidebarNavRowChrome({
         <div
           ref={rowRef}
           style={rowStyle}
-          className={cn(SIDEBAR_HOVER_ACTIONS_ROW_CLASS, "relative")}
+          className={cn(
+            SIDEBAR_HOVER_ACTIONS_ROW_CLASS,
+            "relative",
+            !loading &&
+              "motion-safe:animate-in motion-safe:fade-in motion-safe:duration-200",
+          )}
           data-sidebar-navigation-item={rowKey}
         >
           <Button
@@ -1134,6 +1178,7 @@ function SidebarNavRowChrome({
               accessory && "pr-18",
               isActive && "bg-sidebar-accent text-sidebar-foreground",
             )}
+            aria-busy={loading || undefined}
             aria-current={isActive ? "page" : undefined}
             ref={dragBindings?.setActivatorNodeRef}
             {...dragBindings?.attributes}
@@ -1143,7 +1188,11 @@ function SidebarNavRowChrome({
           >
             {icon}
             <span className="flex min-w-0 flex-1 items-center gap-1.5 text-left">
-              <span className="min-w-0 truncate">{title}</span>
+              <span
+                className={cn("min-w-0 truncate", loading && "animate-shine")}
+              >
+                {title}
+              </span>
               {splitMiniMap ? (
                 <SplitPaneMiniMap
                   slots={splitMiniMap}

--- a/apps/app/src/components/plugin/management/InstalledPluginsTab.tsx
+++ b/apps/app/src/components/plugin/management/InstalledPluginsTab.tsx
@@ -104,7 +104,9 @@ export function InstalledPluginRow({
   const runtimeStatusToneClass =
     runtimeStatus?.tone === "error"
       ? "text-destructive-text"
-      : "text-warning-text";
+      : runtimeStatus?.tone === "warning"
+        ? "text-warning-text"
+        : "text-muted-foreground";
 
   const openDetail = () =>
     navigate(

--- a/apps/app/src/components/plugin/management/PluginRowSignal.tsx
+++ b/apps/app/src/components/plugin/management/PluginRowSignal.tsx
@@ -97,7 +97,9 @@ export function PluginRowSignalView({
                 : "size-7",
               signal.tone === "error"
                 ? "text-destructive hover:text-destructive"
-                : "text-warning-text hover:text-warning-text",
+                : signal.tone === "warning"
+                  ? "text-warning-text hover:text-warning-text"
+                  : "text-muted-foreground hover:text-muted-foreground",
             )}
             aria-label={statusDescription}
             onClick={onStatusClick}

--- a/apps/app/src/components/plugin/management/plugin-status.ts
+++ b/apps/app/src/components/plugin/management/plugin-status.ts
@@ -5,7 +5,7 @@ import type { PluginListItem } from "@/hooks/queries/plugin-settings-queries";
 export interface PluginRuntimeStatusPresentation {
   icon: IconName;
   label: string;
-  tone: "error" | "warning";
+  tone: "error" | "warning" | "muted";
   condition: string;
   recovery: string;
 }
@@ -19,6 +19,7 @@ const PLUGIN_RUNTIME_STATUS_DEFINITIONS: Record<
   PluginRuntimeStatus,
   PluginRuntimeStatusDefinition | null
 > = {
+  starting: { icon: "Clock", label: "Starting", tone: "muted" },
   running: null,
   error: { icon: "CircleX", label: "Failed", tone: "error" },
   incompatible: {
@@ -67,6 +68,8 @@ function pluginRuntimeRecovery(plugin: PluginListItem): string {
 
 function pluginRuntimeCondition(plugin: PluginListItem): string {
   switch (plugin.status) {
+    case "starting":
+      return "The plugin is starting. This can take a moment.";
     case "error":
       return "The plugin couldn't start.";
     case "incompatible":
@@ -100,7 +103,7 @@ export type PluginRowSignal =
       kind: "status";
       icon: IconName;
       label: string;
-      tone: "error" | "warning";
+      tone: PluginRuntimeStatusPresentation["tone"];
       detail: string | null;
     };
 

--- a/apps/app/src/components/tools/PluginCapabilities.tsx
+++ b/apps/app/src/components/tools/PluginCapabilities.tsx
@@ -523,8 +523,8 @@ function PluginRuntimeStatusAlert({
     .join(" ");
   return (
     <PluginBannerBar
-      role="alert"
-      tone={runtimeStatus.tone === "error" ? "destructive" : "warning"}
+      role={plugin.status === "starting" ? "status" : "alert"}
+      tone={runtimeStatus.tone === "error" ? "destructive" : runtimeStatus.tone}
       icon={runtimeStatus.icon}
       title={runtimeStatus.label}
       detail={detail}

--- a/apps/app/src/components/tools/plugin-detail-banner.tsx
+++ b/apps/app/src/components/tools/plugin-detail-banner.tsx
@@ -2,11 +2,12 @@ import type { AriaRole, ReactNode } from "react";
 import { Icon, type IconName } from "@bb/shared-ui/icon";
 import { cn } from "@bb/shared-ui/lib/utils";
 
-type PluginBannerTone = "destructive" | "warning";
+type PluginBannerTone = "destructive" | "warning" | "muted";
 
 const TONE_ICON: Record<PluginBannerTone, string> = {
   destructive: "text-destructive",
   warning: "text-warning",
+  muted: "text-muted-foreground",
 };
 
 export function PluginBannerBar({

--- a/apps/app/src/hooks/plugin-startup-recovery.test.ts
+++ b/apps/app/src/hooks/plugin-startup-recovery.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+
+import { afterEach, expect, it, vi } from "vitest";
+import { QueryClient } from "@tanstack/react-query";
+import { createRealtimeCacheEffects } from "./realtime-cache-effects";
+import { pluginListQueryKey } from "./queries/query-keys";
+import { markEnabledPluginListStale } from "./cache-owners/plugin-cache-owner";
+import {
+  createPluginFrontendReconcileState,
+  fetchFrontendCandidates,
+  reconcilePluginFrontends,
+  type PluginFrontendReconcileDeps,
+} from "@/lib/plugin-frontend";
+import { definePluginApp } from "@/lib/plugin-app-definition";
+import { makeInstalledPlugin } from "@/test/fixtures/plugins";
+
+const scheduled = vi.hoisted(() => ({ run: () => {} }));
+vi.mock("@/lib/plugin-frontend-lazy", () => ({
+  schedulePluginFrontendReconcile: () => scheduled.run(),
+}));
+
+afterEach(() => {
+  scheduled.run = () => {};
+  vi.unstubAllGlobals();
+});
+
+it.each(["initial connect", "reconnect", "reload notification"])(
+  "loads plugins after a missed startup notification on %s",
+  async (trigger) => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: Infinity } },
+    });
+    const plugins = ["first", "second"].map((id) =>
+      makeInstalledPlugin({
+        id,
+        app: {
+          hasApp: true,
+          bundle: {
+            jsUrl: `/plugins/${id}.js`,
+            cssUrl: null,
+            jsBytes: 100,
+            hash: id,
+            sdkMajor: 0,
+            sdkVersion: "0.1.0",
+            compatible: true,
+          },
+        },
+      }),
+    );
+    queryClient.setQueryData(
+      pluginListQueryKey(true),
+      plugins.map((plugin) => ({
+        ...plugin,
+        status: "error",
+        statusDetail: "not loaded",
+      })),
+    );
+    const fetch = vi.fn(async () => Response.json({ plugins }));
+    vi.stubGlobal("fetch", fetch);
+    const state = createPluginFrontendReconcileState();
+    const register = vi.fn();
+    const deps: PluginFrontendReconcileDeps = {
+      fetchCandidates: () => fetchFrontendCandidates(queryClient),
+      importModule: async () => ({ default: definePluginApp(() => {}) }),
+      applyCss: () => {},
+      retainCss: () => () => {},
+      resetCrashedSlots: () => {},
+      setRegistrations: register,
+      removeRegistrations: () => {},
+      beginSlotBatch: () => () => {},
+      warn: () => {},
+      routePluginId: () => null,
+    };
+    const effects = createRealtimeCacheEffects({ queryClient });
+    let reconcile = Promise.resolve();
+    scheduled.run = () => {
+      reconcile = markEnabledPluginListStale({ queryClient }).then(() =>
+        reconcilePluginFrontends(state, deps),
+      );
+    };
+    try {
+      await reconcilePluginFrontends(state, deps);
+      expect(register).not.toHaveBeenCalled();
+      expect(fetch).not.toHaveBeenCalled();
+      if (trigger === "reload notification") {
+        effects.handleChanged({
+          type: "changed",
+          entity: "system",
+          changes: ["plugins-changed"],
+        });
+      } else {
+        effects.handleConnected(
+          trigger === "reconnect"
+            ? { reconnected: true, disconnectedAt: Date.now() }
+            : { reconnected: false },
+        );
+      }
+      await reconcile;
+      expect([...state.activeGenerations.keys()].sort()).toEqual([
+        "first",
+        "second",
+      ]);
+      expect(register).toHaveBeenCalledTimes(2);
+    } finally {
+      effects.dispose();
+      queryClient.clear();
+    }
+  },
+);

--- a/apps/app/src/hooks/plugin-startup-recovery.test.ts
+++ b/apps/app/src/hooks/plugin-startup-recovery.test.ts
@@ -51,8 +51,8 @@ it.each(["initial connect", "reconnect", "reload notification"])(
       pluginListQueryKey(true),
       plugins.map((plugin) => ({
         ...plugin,
-        status: "error",
-        statusDetail: "not loaded",
+        status: "starting",
+        statusDetail: null,
       })),
     );
     const fetch = vi.fn(async () => Response.json({ plugins }));

--- a/apps/app/src/hooks/realtime-cache-effects.ts
+++ b/apps/app/src/hooks/realtime-cache-effects.ts
@@ -560,6 +560,7 @@ export function createRealtimeCacheEffects({
       }
     },
     handleConnected: (event) => {
+      applySystemChanges(["plugins-changed"]);
       if (event.reconnected) {
         invalidateRealtimeQueriesAfterServerReconnect({
           disconnectedAt: event.disconnectedAt,

--- a/apps/app/src/lib/plugin-frontend-boot-state.ts
+++ b/apps/app/src/lib/plugin-frontend-boot-state.ts
@@ -4,6 +4,8 @@ type PluginFrontendBootPhase = "idle" | "booting" | "complete";
 
 let phase: PluginFrontendBootPhase = "idle";
 let settleFloorReached = false;
+let serverPluginsStarting = false;
+let reconcilePending = false;
 const listeners = new Set<() => void>();
 
 function notify(): void {
@@ -28,6 +30,18 @@ export function markPluginFrontendSettleFloorReached(): void {
   notify();
 }
 
+export function setServerPluginsStarting(starting: boolean): void {
+  if (serverPluginsStarting === starting) return;
+  serverPluginsStarting = starting;
+  notify();
+}
+
+export function setPluginFrontendReconcilePending(pending: boolean): void {
+  if (reconcilePending === pending) return;
+  reconcilePending = pending;
+  notify();
+}
+
 function subscribe(listener: () => void): () => void {
   listeners.add(listener);
   return () => {
@@ -36,11 +50,15 @@ function subscribe(listener: () => void): () => void {
 }
 
 function getSettledSnapshot(): boolean {
-  return phase === "complete" || (phase === "idle" && settleFloorReached);
+  return (
+    !serverPluginsStarting &&
+    !reconcilePending &&
+    (phase === "complete" || (phase === "idle" && settleFloorReached))
+  );
 }
 
 function getBootCompleteSnapshot(): boolean {
-  return phase === "complete";
+  return phase === "complete" && !serverPluginsStarting && !reconcilePending;
 }
 
 export function usePluginFrontendsSettled(): boolean {
@@ -62,4 +80,6 @@ export function usePluginFrontendBootComplete(): boolean {
 export function resetPluginFrontendBootStateForTest(): void {
   phase = "idle";
   settleFloorReached = false;
+  serverPluginsStarting = false;
+  reconcilePending = false;
 }

--- a/apps/app/src/lib/plugin-frontend.ts
+++ b/apps/app/src/lib/plugin-frontend.ts
@@ -28,6 +28,10 @@ import { markEnabledPluginListStale } from "@/hooks/cache-owners/plugin-cache-ow
 import { pluginListQueryOptions } from "@/hooks/queries/plugin-settings-queries";
 import { createRecordingToast } from "@/lib/notifications/plugin-toast-recording";
 import { appQueryClient } from "./app-query-client";
+import {
+  setServerPluginsStarting,
+  setPluginFrontendReconcilePending,
+} from "./plugin-frontend-boot-state";
 import type {
   PluginContentScriptDisposer,
   PluginContentScriptRegistration,
@@ -245,6 +249,7 @@ export async function fetchFrontendCandidates(
       pluginListQueryOptions({ enabled: true }),
     );
   } catch (error) {
+    setServerPluginsStarting(false);
     if (
       error instanceof BbHttpError &&
       (error.status === 401 || error.status === 403)
@@ -254,6 +259,9 @@ export async function fetchFrontendCandidates(
     }
     throw error;
   }
+  setServerPluginsStarting(
+    plugins.some((plugin) => plugin.enabled && plugin.status === "starting"),
+  );
   const candidates: PluginFrontendCandidate[] = [];
   const logoUrls = new Map<string, PluginLogoUrls>();
   for (const plugin of plugins) {
@@ -936,6 +944,7 @@ function installPluginFrontendPageLifecycle(): void {
   const lifecycle = createPluginFrontendPageLifecycle({
     restore: () => schedulePluginFrontendReconcile(),
     teardown: () => {
+      setPluginFrontendReconcilePending(true);
       void disposePluginFrontends(state, browserReconcileDeps);
     },
   });
@@ -957,6 +966,7 @@ export function bootPluginFrontends(): Promise<void> {
 }
 
 async function runLiveReconcile(): Promise<void> {
+  setPluginFrontendReconcilePending(true);
   try {
     await bootPromise;
     await markEnabledPluginListStale({ queryClient: appQueryClient });
@@ -971,6 +981,8 @@ async function runLiveReconcile(): Promise<void> {
     console.warn(
       `plugin frontend reconcile failed: ${error instanceof Error ? error.message : String(error)}`,
     );
+  } finally {
+    setPluginFrontendReconcilePending(false);
   }
 }
 

--- a/apps/app/src/lib/plugin-nav-panel-chrome.test.tsx
+++ b/apps/app/src/lib/plugin-nav-panel-chrome.test.tsx
@@ -6,6 +6,8 @@ import {
   markPluginFrontendSettleFloorReached,
   markPluginFrontendsSettled,
   resetPluginFrontendBootStateForTest,
+  setServerPluginsStarting,
+  setPluginFrontendReconcilePending,
 } from "./plugin-frontend-boot-state";
 import {
   readLastKnownPluginNavPanelChrome,
@@ -135,6 +137,33 @@ describe("usePluginNavPanelChrome", () => {
 });
 
 describe("useRememberPluginNavPanelChrome", () => {
+  it("preserves the complete cache until server startup and the final frontend load finish", () => {
+    writeLastKnownPluginNavPanelChrome([TASKS, DOCS]);
+    setServerPluginsStarting(true);
+    markPluginFrontendsSettled();
+    renderHook(() => useRememberPluginNavPanelChrome());
+    expect(readLastKnownPluginNavPanelChrome()).toEqual([TASKS, DOCS]);
+    act(() => {
+      setPluginFrontendReconcilePending(true);
+      setServerPluginsStarting(false);
+      setPluginSlotRegistrations(
+        "tasks",
+        registrations([
+          {
+            id: "tasks",
+            path: "tasks",
+            title: "Tasks",
+            icon: "ListTodo",
+            component: Body,
+          },
+        ]),
+      );
+    });
+    expect(readLastKnownPluginNavPanelChrome()).toEqual([TASKS, DOCS]);
+    act(() => setPluginFrontendReconcilePending(false));
+    expect(readLastKnownPluginNavPanelChrome()).toEqual([TASKS]);
+  });
+
   it("writes the live panels only after frontends have settled, and follows later changes", () => {
     act(() =>
       setPluginSlotRegistrations(

--- a/apps/app/src/views/ToolsView.plugin-detail.test.tsx
+++ b/apps/app/src/views/ToolsView.plugin-detail.test.tsx
@@ -1172,7 +1172,12 @@ describe("PluginDetail runtime health", () => {
   function renderRuntimeStatus(
     status: Extract<
       PluginListItem["status"],
-      "error" | "incompatible" | "missing" | "needs-configuration" | "degraded"
+      | "starting"
+      | "error"
+      | "incompatible"
+      | "missing"
+      | "needs-configuration"
+      | "degraded"
     >,
     overrides: Partial<PluginListItem> = {},
   ) {
@@ -1210,6 +1215,16 @@ describe("PluginDetail runtime health", () => {
     );
     return { ...result, queryClient };
   }
+
+  it("shows startup as a neutral status without failure recovery", () => {
+    renderRuntimeStatus("starting", { statusDetail: null });
+    expect(screen.getByRole("status").textContent).toContain("Starting");
+    expect(screen.getByRole("status").textContent).toContain(
+      "The plugin is starting.",
+    );
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Reload" })).toBeNull();
+  });
 
   it("lifts a failed runtime status into a destructive alert above the content", () => {
     const { container } = renderRuntimeStatus("error");

--- a/apps/server/src/routes/projects.ts
+++ b/apps/server/src/routes/projects.ts
@@ -48,7 +48,6 @@ import {
   requirePublicStandardProject,
 } from "../services/lib/entity-lookup.js";
 import { PROMPT_HISTORY_ENTRY_LIMIT } from "@bb/domain";
-import { resolveCreateThreadExecutionDefaults } from "../services/threads/thread-default-policy.js";
 import { toThreadListEntryResponses } from "../services/threads/thread-runtime-display.js";
 import { callHostRetryableOnlineRpc } from "../services/hosts/online-rpc.js";
 import { runLiveHostCommand } from "../services/hosts/live-command.js";
@@ -244,12 +243,7 @@ function buildProjectsWithThreadsResponseFromRows(
   return projects.map((project) => ({
     ...project,
     threads: threadsByProjectId.get(project.id) ?? [],
-    defaultExecutionOptions: resolveCreateThreadExecutionDefaults(
-      deps.providerRegistry,
-      {
-        storedDefaults: defaultsByProjectId.get(project.id) ?? null,
-      },
-    ).executionDefaults,
+    defaultExecutionOptions: defaultsByProjectId.get(project.id) ?? null,
   }));
 }
 
@@ -395,15 +389,10 @@ export function registerProjectRoutes(app: Hono, deps: AppDeps): void {
     context.json(buildProjectResponses(deps, context.req.param("id"))[0]),
   );
 
-  get(routes.defaultExecutionOptions, (context, query) => {
+  get(routes.defaultExecutionOptions, (context) => {
     const projectId = context.req.param("id");
     requirePublicProject(deps.db, projectId);
-    const storedDefaults = getProjectExecutionDefaults(deps.db, { projectId });
-    return context.json(
-      resolveCreateThreadExecutionDefaults(deps.providerRegistry, {
-        storedDefaults,
-      }).executionDefaults,
-    );
+    return context.json(getProjectExecutionDefaults(deps.db, { projectId }));
   });
 
   get(routes.promptHistory, (context, query) => {

--- a/apps/server/src/services/plugins/plugin-runtime.ts
+++ b/apps/server/src/services/plugins/plugin-runtime.ts
@@ -384,6 +384,18 @@ export function createPluginRuntime(context: PluginRuntimeContext) {
     );
   }
 
+  function getStatus(row: Pick<InstalledPluginRow, "id" | "enabled">): {
+    status: PluginRuntimeStatus;
+    detail: string | null;
+  } {
+    return (
+      statuses.get(row.id) ?? {
+        status: row.enabled ? "starting" : "disabled",
+        detail: null,
+      }
+    );
+  }
+
   function setDevBuildProblem(
     id: string,
     kind: PluginDevBuildKind,
@@ -1257,6 +1269,7 @@ export function createPluginRuntime(context: PluginRuntimeContext) {
   }
 
   async function loadOne(row: InstalledPluginRow): Promise<string | null> {
+    if (row.enabled && !loaded.has(row.id)) setStatus(row.id, "starting");
     await populateIdentity(row);
     if (!row.enabled) {
       setStatus(row.id, "disabled");
@@ -1733,11 +1746,9 @@ export function createPluginRuntime(context: PluginRuntimeContext) {
     if (!plugin) {
       const row = getInstalledPlugin(deps.db, id);
       if (!row) return { outcome: "unknown-plugin" };
-      const runtime = statuses.get(id);
       return {
         outcome: "not-running",
-        status: runtime?.status ?? (row.enabled ? "error" : "disabled"),
-        detail: runtime?.detail ?? (row.enabled ? "not loaded" : null),
+        ...getStatus(row),
       };
     }
     const value = find(plugin);
@@ -1764,6 +1775,7 @@ export function createPluginRuntime(context: PluginRuntimeContext) {
     disposeOne,
     buildQueuedMessageEventEmitter,
     emitThreadEvent,
+    getStatus,
     handlerStats,
     handleUncaughtException,
     hungServices,

--- a/apps/server/src/services/plugins/plugin-service.ts
+++ b/apps/server/src/services/plugins/plugin-service.ts
@@ -908,6 +908,7 @@ export function createPluginService(deps: PluginServiceDeps): PluginService {
     disposeOne,
     buildQueuedMessageEventEmitter,
     emitThreadEvent,
+    getStatus,
     handlerStats,
     handleUncaughtException,
     hungServices,
@@ -1244,7 +1245,7 @@ export function createPluginService(deps: PluginServiceDeps): PluginService {
     return rows
       .sort((a, b) => a.id.localeCompare(b.id))
       .map((row) => {
-        const runtime = statuses.get(row.id);
+        const runtime = getStatus(row);
         const stats = handlerStats.get(row.id);
         const loadedPlugin = loaded.get(row.id);
         const cliRegistration = loadedPlugin?.handle.cli.registration;
@@ -1294,12 +1295,8 @@ export function createPluginService(deps: PluginServiceDeps): PluginService {
             (loadedPlugin !== undefined
               ? brandingAssets.get(row.id)?.compactIcon?.url
               : identity?.brandingAssets.compactIcon?.url) ?? null,
-          status: runtime?.status ?? (row.enabled ? "error" : "disabled"),
-          statusDetail: runtime
-            ? runtime.detail
-            : row.enabled
-              ? "not loaded"
-              : null,
+          status: runtime.status,
+          statusDetail: runtime.detail,
           handlerStats: stats
             ? { ...stats }
             : { count: 0, totalMs: 0, maxMs: 0, errorCount: 0 },
@@ -2207,9 +2204,7 @@ export function createPluginService(deps: PluginServiceDeps): PluginService {
       if (!plugin) {
         const row = getInstalledPlugin(deps.db, id);
         if (!row) return fail(`unknown plugin "${id}"`);
-        const runtime = statuses.get(id);
-        const status = runtime?.status ?? (row.enabled ? "error" : "disabled");
-        const detail = runtime?.detail ?? (row.enabled ? "not loaded" : null);
+        const { status, detail } = getStatus(row);
         return fail(
           `plugin "${id}" is not running (status: ${status}${detail ? ` — ${detail}` : ""})`,
         );

--- a/apps/server/test/public/public-project-startup.test.ts
+++ b/apps/server/test/public/public-project-startup.test.ts
@@ -1,0 +1,52 @@
+import { upsertProjectExecutionDefaults } from "@bb/db";
+import { describe, expect, it } from "vitest";
+import { registerFirstPartyProviders } from "../helpers/provider-registry.js";
+import { withTestHarness } from "../helpers/test-app.js";
+
+describe("project reads during provider startup", () => {
+  it("returns saved defaults before registration and with an unavailable provider", async () => {
+    await withTestHarness(
+      { seedFirstPartyProviders: false },
+      async (harness) => {
+        const defaults = {
+          providerId: "codex",
+          model: "gpt-5",
+          reasoningLevel: "medium" as const,
+          permissionMode: "auto" as const,
+          serviceTier: "default" as const,
+        };
+        for (const phase of ["starting", "unavailable"] as const) {
+          if (phase === "unavailable") {
+            upsertProjectExecutionDefaults(harness.db, {
+              projectId: "proj_personal",
+              ...defaults,
+            });
+            await registerFirstPartyProviders(harness.deps.providerRegistry, {
+              unavailablePluginIds: ["provider-codex"],
+            });
+          }
+          const expectedDefaults = phase === "starting" ? null : defaults;
+          const sidebar = await harness.app.request(
+            "/api/v1/sidebar-bootstrap",
+          );
+          expect(sidebar.status).toBe(200);
+          expect(
+            (await sidebar.json()).personalProject.defaultExecutionOptions,
+          ).toEqual(expectedDefaults);
+          const projects = await harness.app.request(
+            "/api/v1/projects?include=threads&includePersonal=true",
+          );
+          expect(projects.status).toBe(200);
+          expect((await projects.json())[0].defaultExecutionOptions).toEqual(
+            expectedDefaults,
+          );
+          const options = await harness.app.request(
+            "/api/v1/projects/proj_personal/default-execution-options",
+          );
+          expect(options.status).toBe(200);
+          expect(await options.json()).toEqual(expectedDefaults);
+        }
+      },
+    );
+  });
+});

--- a/apps/server/test/services/plugins/plugin-service.test.ts
+++ b/apps/server/test/services/plugins/plugin-service.test.ts
@@ -26,6 +26,7 @@ import {
 } from "@bb/db";
 import { PLUGIN_SDK_VERSION, type SystemChangeKind } from "@bb/domain";
 import type { Logger } from "@bb/logger";
+import { pluginListResponseSchema } from "@bb/server-contract";
 import { createAiServiceRegistry } from "../../../src/services/ai/ai-service-registry.js";
 import {
   createPluginService,
@@ -173,6 +174,71 @@ describe("plugin service", () => {
     expect(entry.status).toBe("running");
     expect(service.getApi("greeter")).toBeDefined();
   });
+
+  it.each(["startup", "retry"])(
+    "reports starting while a %s factory is pending",
+    async (mode) => {
+      const rootDir = await writePlugin(workDir, {
+        name: "bb-plugin-starting",
+        serverSource: `export default function plugin() { throw new Error("failed"); }`,
+      });
+      expect((await service.installPath(rootDir)).status).toBe("error");
+      if (mode === "startup") {
+        await service.stop();
+        service = createTelemetryTrackedService([]);
+        expect(service.list()[0]).toMatchObject({
+          status: "starting",
+          statusDetail: null,
+        });
+      }
+      let release = () => {};
+      let entered = () => {};
+      const gate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const loading = new Promise<void>((resolve) => {
+        entered = resolve;
+      });
+      vi.stubGlobal("__startingPluginGate", gate);
+      vi.stubGlobal("__startingPluginEntered", entered);
+      await writeFile(
+        join(rootDir, "server.ts"),
+        `export default async function plugin() {
+      globalThis.__startingPluginEntered();
+      await globalThis.__startingPluginGate;
+    }`,
+      );
+      const operation =
+        mode === "startup" ? service.start() : service.reload("starting");
+      try {
+        await loading;
+        const { plugins } = pluginListResponseSchema.parse({
+          plugins: service.list(),
+        });
+        expect(plugins[0]).toMatchObject({
+          status: "starting",
+          statusDetail: null,
+        });
+        expect(service.getHttpRoute("starting", "GET", "/")).toEqual({
+          outcome: "not-running",
+          status: "starting",
+          detail: null,
+        });
+        expect(await service.runCliCommand("starting", [], {})).toMatchObject({
+          exitCode: 1,
+          stderr: 'plugin "starting" is not running (status: starting)',
+        });
+      } finally {
+        release();
+        await operation;
+        vi.unstubAllGlobals();
+      }
+      expect(service.list()[0]).toMatchObject({
+        status: "running",
+        statusDetail: null,
+      });
+    },
+  );
 
   it("summarizes user-facing capabilities and drops the live ones when disabled", async () => {
     const rootDir = join(workDir, "bb-plugin-capabilities");

--- a/packages/domain/src/plugin-sdk-version.ts
+++ b/packages/domain/src/plugin-sdk-version.ts
@@ -1,3 +1,3 @@
-export const PLUGIN_SDK_VERSION = "0.4.50";
+export const PLUGIN_SDK_VERSION = "0.4.51";
 
 export const PLUGIN_SDK_MAJOR = Number(PLUGIN_SDK_VERSION.split(".", 1)[0]);

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@get-bb/plugin-sdk",
-  "version": "0.4.50",
+  "version": "0.4.51",
   "homepage": "https://github.com/get-bb/bb#readme",
   "bugs": {
     "url": "https://github.com/get-bb/bb/issues"

--- a/packages/server-contract/src/api/plugins.ts
+++ b/packages/server-contract/src/api/plugins.ts
@@ -18,6 +18,7 @@ export {
 };
 
 export const pluginRuntimeStatusSchema = z.enum([
+  "starting",
   "running",
   "error",
   "incompatible",


### PR DESCRIPTION
## Human comments

## What was wrong

Project reads called thread-creation default resolution, which requires an available provider. The server accepts requests before plugin initialization finishes, so project lists, sidebar bootstrap, and execution-default reads could return HTTP 409 during startup. Separately, a browser could cache the initial “not loaded” plugin snapshot and miss the transient `plugins-changed` event before its WebSocket connected, leaving plugin frontends unavailable until manually reloaded.

## What changed

Project read routes now return persisted execution defaults without requiring provider registration. Thread-creation validation remains in place. Every WebSocket connection invokes the existing plugin-change handler to refresh plugin queries and reconcile frontends, covering both initial connections and reconnects. Plugins now report a neutral `starting` status through the existing API, SDK, and CLI while initialization is pending. The sidebar shows loading placeholders on first launch and retains remembered panel labels until server startup and frontend reconciliation finish. The plugin SDK is bumped to `0.4.51` so the changed generated status type reaches npm consumers. No server/daemon wire changes.

## How you verified

Reproduced on a fresh worktree from `origin/main` at `6cdb4ba` before applying the fixes: the project-startup regression failed with HTTP 409, initial-connection and reconnect frontend regressions failed, and the manual-reload control passed. After applying the fixes:

- Server tests: 45 passed via `pnpm exec turbo run test --filter=@bb/server -- test/public/public-project-startup.test.ts test/public/public-threads.defaults.test.ts test/threads/thread-default-policy.test.ts`.
- App tests: 119 passed via `pnpm exec turbo run test --filter=@bb/app -- src/hooks/plugin-startup-recovery.test.ts src/hooks/realtime-cache-effects.test.ts src/hooks/system-cache-effects.test.ts src/lib/plugin-frontend-reload.test.ts src/lib/plugin-frontend-lazy.test.ts`.
- `pnpm exec turbo run typecheck --filter=@bb/app --filter=@bb/server`, formatting, and `git diff --check` passed.
- Installed eight additional plugins in an isolated source app. All 24 enabled plugins ran after a cold restart. Two startup probes successfully read projects, sidebar bootstrap, and execution defaults before provider plugins loaded, recovering the persisted project with one initialization per boot.
- A controlled browser race served the initial unavailable-plugin snapshot and delayed WebSocket connection. Releasing the connection recovered all 16 frontends without a page or plugin reload. Opened both probe panels, Tasks, and ThreadChat demo through browser clicks after restart.

Live coverage is the source web app, not the packaged desktop app. The controlled proxy produced an unrelated daemon-status CORS error; direct-app panel checks had no page exceptions. The verification inventory also reports a pre-existing unmapped `browser` CLI family on the unchanged base.

Independent review of `b1a11fa`: restoring the pre-fix project route and connection handler reproduced HTTP 409 on sidebar bootstrap and failed frontend recovery on initial connection and reconnection; the reload-notification control passed. The final implementation passed 77 selected server tests, 189 selected app tests, and app/server typechecks. These independent reproductions used server and simulated-browser test harnesses.

Close-out validation after rebasing and the SDK version bump: SDK build and npm publication guard passed; app/server typechecks passed; 46 selected app tests and 35 selected server tests passed. The working tree and commit-range private-name scan was clean.

> AGENT GENERATED
