### PR TITLE
Teach plugin authoring skill to push changes

### DIFF
--- a/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/SKILL.md
@@ -18,6 +18,14 @@ Inspect the affected package and current SDK declarations to select backend,
 frontend, or both. Build the plugin and verify the affected contracts and user
 workflow. Install or reload when a live check is needed for the requested work.
 
+Treat delivery as part of every plugin source change. Unless the user explicitly
+requests local-only work or repository instructions prohibit it, commit only the
+scoped plugin changes and push the current branch after verification. Never
+force-push or include unrelated changes. Verify that the remote branch SHA
+matches the local commit before calling the change complete. If the configured
+remote rejects the push, use an authorized fork and open a pull request when the
+repository workflow supports it; otherwise report the exact blocker.
+
 Use bb plugin new <name> for a new plugin. The scaffold includes frontend files.
 Remove `bb.app` and those files when the plugin is headless.
 


### PR DESCRIPTION
## Human comments

The plugin-authoring workflow should deliver source changes instead of leaving verified fixes only in a local checkout.

## What was wrong

The built-in skill stopped at build, verification, installation, and reload. It did not tell agents that a plugin source change includes committing and pushing the scoped diff, so completed fixes could remain local.

## What changed

The skill now defaults every plugin source change to a scoped commit and current-branch push after verification. It forbids force-pushes and unrelated changes, requires remote SHA parity before completion, and uses an authorized fork plus pull request when direct upstream push is unavailable. An explicit local-only request or repository prohibition still takes precedence.

## How you verified

- `pnpm exec turbo run test --filter=@bb/server -- test/skills/shipped-skills-quality.test.ts` — 21 tests passed.
- `git diff --check` passed.
- The pushed branch SHA matches the local commit.

> AGENT GENERATED