### PR TITLE
fix(server): wake queued message dispatch on interrupted turn reaching idle

### DIFF
--- a/apps/server/src/internal/events.ts
+++ b/apps/server/src/internal/events.ts
@@ -420,10 +420,7 @@ async function applyEventEffects(
             });
           }
         }
-        if (
-          event.status === "completed" &&
-          turnCompleted.nextStatus === "idle"
-        ) {
+        if (turnCompleted.nextStatus === "idle") {
           followUps.push({
             kind: "queued-message-dispatch",
             wake: { kind: "thread-ready", threadId: entry.threadId },

--- a/apps/server/test/internal/internal-events-turn-interrupted-queue-wake.test.ts
+++ b/apps/server/test/internal/internal-events-turn-interrupted-queue-wake.test.ts
@@ -1,0 +1,89 @@
+import { listQueuedThreadMessages } from "@bb/db";
+import { turnScope } from "@bb/domain";
+import { groupHostDaemonEvents } from "@bb/host-daemon-contract";
+import { describe, expect, it } from "vitest";
+import {
+  createTestDaemonEventEnvelope,
+  internalAuthHeaders,
+  waitForQueuedCommand,
+} from "../helpers/commands.js";
+import { textInput } from "../helpers/prompt-input.js";
+import {
+  seedEnvironment,
+  seedHostSession,
+  seedProjectWithSource,
+  seedQueuedMessage,
+  seedThread,
+  seedTurnStarted,
+} from "../helpers/seed.js";
+import { withTestHarness } from "../helpers/test-app.js";
+
+describe("internal turn/completed queue dispatch wake", () => {
+  it("wakes queued message dispatch when a turn finishes with status interrupted and transitions to idle", async () => {
+    await withTestHarness(async (harness) => {
+      const { host, session } = seedHostSession(harness.deps, {
+        id: "host-interrupted-turn-wake",
+      });
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.id,
+      });
+      const environment = seedEnvironment(harness.deps, {
+        hostId: host.id,
+        projectId: project.id,
+      });
+      const thread = seedThread(harness.deps, {
+        projectId: project.id,
+        environmentId: environment.id,
+        status: "stopping",
+      });
+
+      seedTurnStarted(harness.deps, {
+        environmentId: environment.id,
+        providerThreadId: "provider-thread-1",
+        sequence: 1,
+        threadId: thread.id,
+        turnId: "turn-interrupted-1",
+      });
+
+      seedQueuedMessage(harness.deps, {
+        content: textInput("queued message waiting for thread to be idle"),
+        threadId: thread.id,
+        waitingOn: { kind: "thread-busy" },
+      });
+
+      expect(listQueuedThreadMessages(harness.db, thread.id)).toHaveLength(1);
+
+      const response = await harness.app.request("/internal/session/events", {
+        method: "POST",
+        headers: internalAuthHeaders(harness, { hostId: host.id }),
+        body: JSON.stringify({
+          sessionId: session.id,
+          eventGroups: groupHostDaemonEvents([
+            createTestDaemonEventEnvelope({
+              threadId: thread.id,
+              event: {
+                type: "turn/completed",
+                threadId: thread.id,
+                providerThreadId: "provider-thread-1",
+                scope: turnScope("turn-interrupted-1"),
+                status: "interrupted",
+              },
+            }),
+          ]),
+        }),
+      });
+
+      expect(response.status).toBe(200);
+
+      const command = await waitForQueuedCommand(
+        harness,
+        (queued) =>
+          queued.command.type === "turn.submit" &&
+          queued.command.threadId === thread.id,
+      );
+
+      expect(command.command.type).toBe("turn.submit");
+      expect(listQueuedThreadMessages(harness.db, thread.id)).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
### Summary

When a turn completed with `event.status === 'interrupted'` (for example, when steered during execution or interrupted by a cancellation), `turnCompleted.nextStatus` transitioned the thread to `'idle'`, but the server never scheduled a `queued-message-dispatch` follow-up. This was because the wake condition was strictly gated on:
```typescript
if (event.status === 'completed' && turnCompleted.nextStatus === 'idle')
```

As a result, any messages queued while waiting for the thread to be idle (or steers waiting in the queue) remained stranded in `queued_thread_messages` with `waitingOn: { kind: 'thread-busy' }` until the user manually triggered another turn.

### Changes
- Updated the turn completion follow-up trigger in `apps/server/src/internal/events.ts` to schedule `queued-message-dispatch` whenever `turnCompleted.nextStatus === 'idle'`, regardless of whether `event.status` was `'completed'` or `'interrupted'`.
- Added a full regression test in `apps/server/test/internal/internal-events-turn-interrupted-queue-wake.test.ts` verifying that an interrupted turn transitioning to idle immediately wakes the queue and dispatches the queued message.

### Verification
- Tested with Vitest on `@bb/server`:
  - New test `internal-events-turn-interrupted-queue-wake.test.ts` passes.
  - Verified negative case: fails with command timeout without this fix.
  - Full `test/internal/` suite (17 files, 107 tests) passes.
  - `test/threads/requested-queue-drain.test.ts` & `thread-send-dispatch.test.ts` pass.
  - `tsc --noEmit` and `oxlint` pass with 0 errors.