### PR TITLE
feat(threads): expose modelIsExplicit on resolved execution options

### DIFF
--- a/apps/server/src/services/threads/thread-commands.ts
+++ b/apps/server/src/services/threads/thread-commands.ts
@@ -209,6 +209,7 @@ function toRuntimeExecutionOptions(
     }) ?? {};
   const base = {
     model: args.execution.model,
+    modelIsExplicit: args.execution.modelIsExplicit,
     serviceTier: args.execution.serviceTier,
     reasoningLevel: args.execution.reasoningLevel,
     ...(promptMode !== undefined ? { promptMode } : {}),

--- a/apps/server/src/services/threads/thread-execution-plan.ts
+++ b/apps/server/src/services/threads/thread-execution-plan.ts
@@ -278,6 +278,12 @@ export async function resolveExistingThreadExecutionPlan(
     parentThread !== null
       ? getLastExecutionOptions(deps, parentThread.id)
       : null;
+  // Only a caller-supplied model marked `explicit` (or a sticky thread-level
+  // override) is a deliberate user choice. Remembered defaults are not.
+  const modelIsExplicit =
+    (args.input.model?.source === "explicit" &&
+      args.input.model?.value !== undefined) ||
+    thread.modelOverride !== null;
   const model = resolveRequiredField<string>([
     args.input.model?.value,
     thread.modelOverride ?? undefined,
@@ -338,6 +344,7 @@ export async function resolveExistingThreadExecutionPlan(
 
   const resolvedExecution = {
     model,
+    modelIsExplicit,
     permissionMode,
     reasoningLevel,
     serviceTier,

--- a/apps/server/test/services/threads/thread-execution-plan.test.ts
+++ b/apps/server/test/services/threads/thread-execution-plan.test.ts
@@ -1,4 +1,4 @@
-import { updateHost, upsertProjectExecutionDefaults } from "@bb/db";
+import { updateHost, upsertProjectExecutionDefaults, setThreadExecutionOverride } from "@bb/db";
 import type { PermissionMode } from "@bb/domain";
 import { describe, expect, it } from "vitest";
 import {
@@ -272,6 +272,127 @@ describe("machine permission ceiling", () => {
       });
 
       expect(plan.resolvedExecution.permissionMode).toBe("full");
+    });
+  });
+});
+
+describe("thread execution plan model explicitness", () => {
+  it("marks remembered project-default model as not explicit", async () => {
+    await withTestHarness(async (harness) => {
+      const { host } = seedHostSession(harness.deps, {
+        id: "host-model-explicit-default",
+      });
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.id,
+      });
+      upsertProjectExecutionDefaults(harness.deps.db, {
+        projectId: project.id,
+        providerId: "codex",
+        model: "gpt-5",
+        reasoningLevel: "medium",
+        permissionMode: "auto",
+        serviceTier: "default",
+      });
+      const thread = seedThread(harness.deps, {
+        projectId: project.id,
+        providerId: "codex",
+      });
+
+      // No caller-supplied model: resolution falls through to the remembered
+      // project default. That is not a deliberate user choice.
+      const plan = await resolveExistingThreadExecutionPlan(harness.deps, {
+        executionSource: "client/turn/requested",
+        input: {},
+        projectDefaults: {
+          providerId: "codex",
+          model: "gpt-5",
+          reasoningLevel: "medium",
+          permissionMode: "auto",
+          serviceTier: "default",
+        },
+        threadId: thread.id,
+      });
+
+      expect(plan.resolvedExecution.model).toBe("gpt-5");
+      expect(plan.resolvedExecution.modelIsExplicit).toBe(false);
+    });
+  });
+
+  it("marks a caller-supplied explicit model as explicit", async () => {
+    await withTestHarness(async (harness) => {
+      const { host } = seedHostSession(harness.deps, {
+        id: "host-model-explicit-supplied",
+      });
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.id,
+      });
+      const thread = seedThread(harness.deps, {
+        projectId: project.id,
+        providerId: "codex",
+      });
+
+      const plan = await resolveExistingThreadExecutionPlan(harness.deps, {
+        executionSource: "client/turn/requested",
+        input: { model: { source: "explicit", value: "xai/grok-4.6" } },
+        threadId: thread.id,
+      });
+
+      expect(plan.resolvedExecution.model).toBe("xai/grok-4.6");
+      expect(plan.resolvedExecution.modelIsExplicit).toBe(true);
+    });
+  });
+
+  it("marks a caller-supplied client-preference model as not explicit", async () => {
+    await withTestHarness(async (harness) => {
+      const { host } = seedHostSession(harness.deps, {
+        id: "host-model-explicit-preference",
+      });
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.id,
+      });
+      const thread = seedThread(harness.deps, {
+        projectId: project.id,
+        providerId: "codex",
+      });
+
+      const plan = await resolveExistingThreadExecutionPlan(harness.deps, {
+        executionSource: "client/turn/requested",
+        input: {
+          model: { source: "client-preference", value: "xai/grok-4.6" },
+        },
+        threadId: thread.id,
+      });
+
+      expect(plan.resolvedExecution.model).toBe("xai/grok-4.6");
+      expect(plan.resolvedExecution.modelIsExplicit).toBe(false);
+    });
+  });
+
+  it("marks a sticky thread model override as explicit", async () => {
+    await withTestHarness(async (harness) => {
+      const { host } = seedHostSession(harness.deps, {
+        id: "host-model-explicit-override",
+      });
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.id,
+      });
+      const thread = seedThread(harness.deps, {
+        projectId: project.id,
+        providerId: "codex",
+      });
+      setThreadExecutionOverride(harness.deps.db, {
+        threadId: thread.id,
+        modelOverride: "xai/grok-4.6",
+      });
+
+      const plan = await resolveExistingThreadExecutionPlan(harness.deps, {
+        executionSource: "client/turn/requested",
+        input: {},
+        threadId: thread.id,
+      });
+
+      expect(plan.resolvedExecution.model).toBe("xai/grok-4.6");
+      expect(plan.resolvedExecution.modelIsExplicit).toBe(true);
     });
   });
 });

--- a/packages/domain/src/shared-types.ts
+++ b/packages/domain/src/shared-types.ts
@@ -465,6 +465,13 @@ export type ThreadExecutionOptions = z.infer<
 export const resolvedThreadExecutionOptionsSchema =
   threadExecutionOptionsSchema.extend({
     model: z.string().min(1),
+    /**
+     * True when the resolved model is a deliberate user choice: a caller
+     * supplied it with the `explicit` source, or a sticky thread-level
+     * override exists. Remembered defaults (last execution, project
+     * defaults) are not user choices.
+     */
+    modelIsExplicit: z.boolean().optional(),
     serviceTier: serviceTierSchema,
     reasoningLevel: reasoningLevelSchema,
     permissionMode: permissionModeSchema,
@@ -520,6 +527,12 @@ export type PromptMode = z.infer<typeof promptModeSchema>;
 
 const runtimeThreadExecutionBaseOptionsSchema = z.object({
   model: z.string().min(1),
+  /**
+   * Whether `model` is a deliberate user choice (see
+   * `resolvedThreadExecutionOptionsSchema`). Providers whose agents carry
+   * their own configured model may honor that config when this is false.
+   */
+  modelIsExplicit: z.boolean().optional(),
   serviceTier: serviceTierSchema,
   reasoningLevel: reasoningLevelSchema,
   promptMode: promptModeSchema.optional(),


### PR DESCRIPTION
## Problem

BB substitutes a remembered model (last execution → project remembered default) when a caller does not supply a model explicitly. Provider plugins receive that concrete model and cannot distinguish it from a deliberate user choice.

For providers whose agents carry their own configured model (e.g. the OpenCode provider, where an agent's frontmatter declares `model:`), this means the agent-configured model is **never** applied: BB always sends a concrete model, so the provider bridge pins it. Observed live: a BB-spawned child thread ran on the project's remembered default (`openai/gpt-5.6-sol`) while the effective agent configuration declared `ollama-cloud/glm-5.3-flash` — confirmed with request/assistant message metadata from the OpenCode session export and BB's recorded `execution.model`.

## Change

- `resolveExistingThreadExecutionPlan` now reports `modelIsExplicit` on the resolved plan: `true` only when the caller supplied the model with the `explicit` caller source **or** a sticky thread-level model override exists (a deliberate user choice). Remembered defaults (last execution, project defaults) resolve to `false`.
- `RuntimeThreadExecutionOptions` carries `modelIsExplicit` (optional) to provider bridges, so provider plugins can honor agent-configured models when the model was not a user choice.
- `modelIsExplicit` is optional in the resolved/runtime schemas to keep legacy constructors and tests compatible.

No behavior change in the resolved model value itself, validation, or persistence — this only exposes provenance.

## Deliberate choices preserved

- Explicit `--model` / turn-supplied model → `modelIsExplicit: true` → provider pins it (unchanged).
- `thread update --model` (sticky override) → `true` → provider pins it (unchanged).
- Client-preference / remembered default fallback → `false` → provider may now apply its agent configuration.

## Tests

- `apps/server/test/services/threads/thread-execution-plan.test.ts`: 4 new cases — project-default fallback is not explicit; explicit caller model is explicit; `client-preference` source is not explicit; sticky thread override is explicit.
- Suite: `test/services/threads/thread-execution-plan.test.ts` 14/14, full `test/threads/` 310/310, `@bb/domain` 199/199, typecheck clean for `@bb/domain`, `@bb/server`, `@bb/host-daemon`.

## Consumer note

The OpenCode provider plugin (separate repo) will consume `modelIsExplicit` to prefer the selected agent's configured model on non-explicit turns. That follow-up is tracked in the plugin repository PR referencing this change.