### PR TITLE
Fix local Markdown images with shared preview and file-serving routing

### DIFF
--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanelTabContent.markdown-images.test.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanelTabContent.markdown-images.test.tsx
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  HostFilePreviewTabContent,
+  HostScopedFilePreviewTabContent,
+  ProjectFilePreviewTabContent,
+  ThreadStorageFilePreviewTabContent,
+  WorkspaceFilePreviewTabContent,
+} from "./ThreadSecondaryPanelTabContent";
+import type { FilePreview } from "@bb/client-core";
+
+function markdownPreview(path: string, url = `/content/${path}`): FilePreview {
+  return {
+    kind: "text",
+    content: [
+      "![absolute](/workspace/generated.png)",
+      "![relative](images/chart.png)",
+      "![escape](../../outside.png)",
+    ].join("\n\n"),
+    mimeType: "text/markdown",
+    name: path.split("/").at(-1),
+    path,
+    url,
+  };
+}
+
+function previewQuery(path: string, url?: string) {
+  return {
+    data: markdownPreview(path, url),
+    error: null,
+    isFetching: false,
+    isLoading: false,
+    refetch: vi.fn(),
+  };
+}
+
+vi.mock("@/hooks/queries/environment-queries", () => ({
+  useEnvironment: () => ({
+    data: { path: "/workspace", projectId: "proj_preview" },
+  }),
+  useEnvironmentDiffFiles: vi.fn(),
+  useEnvironmentFilePreview: (_environmentId: string, path: string) =>
+    previewQuery(path),
+}));
+
+vi.mock("@/hooks/queries/project-queries", () => ({
+  useProjectFilePreview: (_projectId: string, path: string) =>
+    previewQuery(path),
+}));
+
+vi.mock("@/hooks/queries/thread-queries", () => ({
+  useThreadHostFilePreview: (
+    _threadId: string,
+    _environmentId: string,
+    path: string,
+  ) => previewQuery(path),
+  useThreadStorageFilePreview: (_threadId: string, path: string) =>
+    previewQuery(path),
+}));
+
+vi.mock("@/hooks/queries/host-file-preview-query", () => ({
+  useHostFilePreview: (_hostId: string, path: string) =>
+    previewQuery(path, "/api/v1/file-previews/lease_preview/readme.md"),
+}));
+
+afterEach(cleanup);
+
+function imageSrc(name: string): string | null {
+  return screen.getByRole("img", { name }).getAttribute("src");
+}
+
+describe("secondary-panel Markdown image routing", () => {
+  it("routes workspace images when the preview caller supplies no routing", () => {
+    render(
+      <WorkspaceFilePreviewTabContent
+        activePath="docs/readme.md"
+        environmentId="env_preview"
+        isPanelOpen
+        lineRange={null}
+        source={{ kind: "working-tree" }}
+        statusLabel={null}
+        threadId="thr_preview"
+      />,
+    );
+
+    expect(imageSrc("absolute")).toBe(
+      "/api/v1/threads/thr_preview/host-files/content?path=%2Fworkspace%2Fgenerated.png",
+    );
+    expect(imageSrc("relative")).toBe(
+      "/api/v1/threads/thr_preview/worktree/files/docs/images/chart.png",
+    );
+    expect(imageSrc("escape")).toBe("../../outside.png");
+  });
+
+  it("routes project images through the selected project source", () => {
+    render(
+      <ProjectFilePreviewTabContent
+        activePath="docs/readme.md"
+        environmentId={null}
+        hostId="host_preview"
+        isPanelOpen
+        lineRange={null}
+        projectId="proj_preview"
+        rootPath="/workspace"
+      />,
+    );
+
+    expect(imageSrc("absolute")).toContain(
+      "/api/v1/projects/proj_preview/files/content?",
+    );
+    expect(imageSrc("absolute")).toContain("path=generated.png");
+    expect(imageSrc("relative")).toContain("path=docs%2Fimages%2Fchart.png");
+    expect(imageSrc("absolute")).toContain("hostId=host_preview");
+    expect(imageSrc("escape")).toBe("../../outside.png");
+  });
+
+  it("routes thread host-file images through the host content endpoint", () => {
+    render(
+      <HostFilePreviewTabContent
+        activePath="/workspace/docs/readme.md"
+        copyPath="/workspace/docs/readme.md"
+        environmentId="env_preview"
+        isPanelOpen
+        lineRange={null}
+        threadId="thr_preview"
+      />,
+    );
+
+    expect(imageSrc("absolute")).toBe(
+      "/api/v1/threads/thr_preview/host-files/content?path=%2Fworkspace%2Fgenerated.png",
+    );
+    expect(imageSrc("relative")).toBe(
+      "/api/v1/threads/thr_preview/host-files/content?path=%2Fworkspace%2Fdocs%2Fimages%2Fchart.png",
+    );
+    expect(imageSrc("escape")).toBe("../../outside.png");
+  });
+
+  it("confines host-scoped relative images to the preview lease root", () => {
+    render(
+      <HostScopedFilePreviewTabContent
+        activePath="/workspace/docs/readme.md"
+        hostId="host_preview"
+        isPanelOpen
+        lineRange={null}
+      />,
+    );
+
+    expect(imageSrc("absolute")).toBe("/workspace/generated.png");
+    expect(imageSrc("relative")).toBe(
+      "/api/v1/file-previews/lease_preview/images/chart.png",
+    );
+    expect(imageSrc("escape")).toBe("../../outside.png");
+  });
+
+  it("routes thread-storage images when the preview caller supplies no routing", () => {
+    render(
+      <ThreadStorageFilePreviewTabContent
+        activePath="docs/readme.md"
+        isPanelOpen
+        lineRange={null}
+        threadId="thr_preview"
+      />,
+    );
+
+    expect(imageSrc("absolute")).toBe(
+      "/api/v1/threads/thr_preview/host-files/content?path=%2Fworkspace%2Fgenerated.png",
+    );
+    expect(imageSrc("relative")).toBe(
+      "/api/v1/threads/thr_preview/thread-storage/files/docs/images/chart.png",
+    );
+    expect(imageSrc("escape")).toBe("../../outside.png");
+  });
+});

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanelTabContent.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanelTabContent.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import type { DiffPresentation } from "@/components/code/code-rendering";
 import type { WorkspaceDiffTarget } from "@bb/domain";
 import type { MarkdownLinkRouting } from "@/components/ui/markdown-link-routing.js";
@@ -6,6 +6,7 @@ import { Skeleton } from "@bb/shared-ui/skeleton";
 import { EmptyStatePanel } from "@bb/shared-ui/empty-state";
 import {
   useEnvironmentDiffFiles,
+  useEnvironment,
   useEnvironmentFilePreview,
 } from "@/hooks/queries/environment-queries";
 import { useProjectFilePreview } from "@/hooks/queries/project-queries";
@@ -15,7 +16,10 @@ import {
 } from "@/hooks/queries/thread-queries";
 import { useHostFilePreview } from "@/hooks/queries/host-file-preview-query";
 import {
+  buildProjectFileContentUrl,
   buildRawFilesystemHtmlContentUrl,
+  buildThreadHostFileContentUrl,
+  buildThreadStorageRawContentUrl,
   buildThreadWorktreeRawContentUrl,
 } from "@/lib/file-content-urls";
 import type {
@@ -32,6 +36,11 @@ import {
   SecondaryPanelFilePreview,
   ThreadStorageFilePreview,
 } from "./ThreadStorageFilePreview";
+import {
+  buildMarkdownFileImageRouting,
+  buildMarkdownLeaseImageRouting,
+} from "@/components/ui/markdown-file-image-routing";
+import { getAbsoluteDirname } from "@/lib/absolute-file-path";
 
 const GIT_DIFF_SKELETON_FILE_COUNT = 3;
 const PANEL_SCROLL_SLOT_CLASS =
@@ -72,9 +81,12 @@ interface ProjectFilePreviewTabContentProps {
   environmentId: string | null;
   hostId: string | null;
   lineRange: FilePreviewLineRange | null;
+  markdownLinkRouting?: MarkdownLinkRouting;
   onSelectionAddToChat?: (text: string) => void;
   onOpenInEditor?: (path: string) => void;
   projectId: string;
+  rootPath?: string | null;
+  threadId?: string | null;
 }
 
 interface HostFilePreviewTabContentProps {
@@ -309,6 +321,13 @@ export function WorkspaceFilePreviewTabContent({
   statusLabel,
   threadId,
 }: WorkspaceFilePreviewTabContentProps) {
+  const environmentQuery = useEnvironment(environmentId ?? null, {
+    enabled:
+      environmentId !== null &&
+      environmentId !== undefined &&
+      markdownLinkRouting?.localImage === undefined,
+    staleTime: 5_000,
+  });
   const {
     data: workspaceFilePreview,
     error: workspaceFilePreviewError,
@@ -318,6 +337,42 @@ export function WorkspaceFilePreviewTabContent({
   } = useEnvironmentFilePreview(environmentId, activePath, source, {
     enabled: isPanelOpen,
   });
+  const environmentRootPath = environmentQuery.data?.path ?? null;
+  const environmentProjectId = environmentQuery.data?.projectId;
+  const resolvedMarkdownLinkRouting = useMemo(() => {
+    if (
+      source === null ||
+      environmentId === null ||
+      environmentId === undefined ||
+      (!threadId && environmentProjectId === undefined)
+    ) {
+      return markdownLinkRouting;
+    }
+    return buildMarkdownFileImageRouting({
+      path: activePath,
+      rootPath: environmentRootPath,
+      threadId: threadId ?? null,
+      linkRouting: markdownLinkRouting,
+      resolveRelativeSrc: (path) => {
+        if (threadId && source.kind === "working-tree") {
+          return buildThreadWorktreeRawContentUrl(threadId, path);
+        }
+        return environmentProjectId === undefined
+          ? path
+          : buildProjectFileContentUrl(environmentProjectId, path, {
+              environmentId,
+            });
+      },
+    });
+  }, [
+    activePath,
+    environmentId,
+    environmentProjectId,
+    environmentRootPath,
+    markdownLinkRouting,
+    source,
+    threadId,
+  ]);
 
   return (
     <SecondaryPanelFilePreview
@@ -333,7 +388,7 @@ export function WorkspaceFilePreviewTabContent({
       isLoading={isWorkspaceFilePreviewLoading}
       isRefreshing={isWorkspaceFilePreviewFetching}
       lineRange={lineRange}
-      markdownLinkRouting={markdownLinkRouting}
+      markdownLinkRouting={resolvedMarkdownLinkRouting}
       onSelectionAddToChat={onSelectionAddToChat}
       onOpenInEditor={onOpenInEditor}
       onRefresh={() => void refetchWorkspaceFilePreview()}
@@ -349,9 +404,12 @@ export function ProjectFilePreviewTabContent({
   hostId,
   isPanelOpen,
   lineRange,
+  markdownLinkRouting,
   onSelectionAddToChat,
   onOpenInEditor,
   projectId,
+  rootPath = null,
+  threadId = null,
 }: ProjectFilePreviewTabContentProps) {
   const {
     data: projectFilePreview,
@@ -365,6 +423,30 @@ export function ProjectFilePreviewTabContent({
     { environmentId, hostId },
     { enabled: isPanelOpen },
   );
+  const resolvedMarkdownLinkRouting = useMemo(() => {
+    return buildMarkdownFileImageRouting({
+      path: activePath,
+      rootPath,
+      threadId,
+      linkRouting: markdownLinkRouting,
+      resolveRelativeSrc: (path) =>
+        buildProjectFileContentUrl(projectId, path, {
+          ...(environmentId !== null
+            ? { environmentId }
+            : hostId !== null
+              ? { hostId }
+              : {}),
+        }),
+    });
+  }, [
+    activePath,
+    environmentId,
+    hostId,
+    markdownLinkRouting,
+    projectId,
+    rootPath,
+    threadId,
+  ]);
 
   return (
     <SecondaryPanelFilePreview
@@ -375,6 +457,7 @@ export function ProjectFilePreviewTabContent({
       isLoading={isProjectFilePreviewLoading}
       isRefreshing={isProjectFilePreviewFetching}
       lineRange={lineRange}
+      markdownLinkRouting={resolvedMarkdownLinkRouting}
       onSelectionAddToChat={onSelectionAddToChat}
       onOpenInEditor={onOpenInEditor}
       onRefresh={() => void refetchProjectFilePreview()}
@@ -403,6 +486,18 @@ export function HostFilePreviewTabContent({
   } = useThreadHostFilePreview(threadId, environmentId, activePath, {
     enabled: isPanelOpen,
   });
+  const resolvedMarkdownLinkRouting = useMemo(() => {
+    return buildMarkdownFileImageRouting({
+      path: activePath,
+      rootPath:
+        markdownLinkRouting?.localFile?.relativeLinks?.rootPath ??
+        getAbsoluteDirname({ path: activePath }),
+      threadId,
+      linkRouting: markdownLinkRouting,
+      resolveRelativeSrc: (_relativePath, path) =>
+        buildThreadHostFileContentUrl(threadId, path),
+    });
+  }, [activePath, markdownLinkRouting, threadId]);
 
   return (
     <SecondaryPanelFilePreview
@@ -414,7 +509,7 @@ export function HostFilePreviewTabContent({
       isLoading={isHostFilePreviewLoading}
       isRefreshing={isHostFilePreviewFetching}
       lineRange={lineRange}
-      markdownLinkRouting={markdownLinkRouting}
+      markdownLinkRouting={resolvedMarkdownLinkRouting}
       onSelectionAddToChat={onSelectionAddToChat}
       onOpenInEditor={onOpenInEditor}
       onRefresh={() => void refetchHostFilePreview()}
@@ -437,6 +532,13 @@ export function HostScopedFilePreviewTabContent({
     isLoading,
     refetch,
   } = useHostFilePreview(hostId, activePath, { enabled: isPanelOpen });
+  const markdownLinkRouting = useMemo(() => {
+    return buildMarkdownLeaseImageRouting({
+      path: activePath,
+      rootPath: getAbsoluteDirname({ path: activePath }),
+      previewUrl: hostFilePreview?.url,
+    });
+  }, [activePath, hostFilePreview?.url]);
   return (
     <SecondaryPanelFilePreview
       activePath={activePath}
@@ -447,6 +549,7 @@ export function HostScopedFilePreviewTabContent({
       isLoading={isLoading}
       isRefreshing={isFetching}
       lineRange={lineRange}
+      markdownLinkRouting={markdownLinkRouting}
       onOpenInEditor={onOpenInEditor}
       onRefresh={() => void refetch()}
       statusLabel={null}
@@ -473,6 +576,16 @@ export function ThreadStorageFilePreviewTabContent({
   } = useThreadStorageFilePreview(threadId, activePath, {
     enabled: isPanelOpen,
   });
+  const resolvedMarkdownLinkRouting = useMemo(() => {
+    return buildMarkdownFileImageRouting({
+      path: activePath,
+      rootPath: null,
+      threadId,
+      linkRouting: markdownLinkRouting,
+      resolveRelativeSrc: (path) =>
+        buildThreadStorageRawContentUrl(threadId, path),
+    });
+  }, [activePath, markdownLinkRouting, threadId]);
 
   return (
     <ThreadStorageFilePreview
@@ -483,7 +596,7 @@ export function ThreadStorageFilePreviewTabContent({
       isLoading={isThreadStorageFilePreviewLoading}
       isRefreshing={isThreadStorageFilePreviewFetching}
       lineRange={lineRange}
-      markdownLinkRouting={markdownLinkRouting}
+      markdownLinkRouting={resolvedMarkdownLinkRouting}
       onSelectionAddToChat={onSelectionAddToChat}
       onOpenInEditor={onOpenInEditor}
       onRefresh={() => void refetchThreadStorageFilePreview()}

--- a/apps/app/src/components/thread/timeline/ConversationMessageContent.test.tsx
+++ b/apps/app/src/components/thread/timeline/ConversationMessageContent.test.tsx
@@ -62,6 +62,43 @@ describe("ConversationMessageContent assistant images", () => {
   });
 });
 
+describe("ConversationMessageContent user images", () => {
+  it("uses the same local image routing as assistant messages", () => {
+    render(
+      <MemoryRouter>
+        <RouteNavigationProvider>
+          <ConversationMessageContent
+            role="user"
+            attachments={null}
+            initiator="user"
+            mentions={[]}
+            originKind={null}
+            senderThreadId={null}
+            senderThreadTitle={null}
+            senderIsPluginSideChat={false}
+            systemMessageKind="unlabeled"
+            systemMessageSubject={null}
+            text="![diagram](output/diagram.png)"
+            threadId="thr_image"
+            turnRequest={{
+              isGrouped: false,
+              kind: "message",
+              status: "accepted",
+            }}
+            workspaceRootPath="/workspace"
+          />
+        </RouteNavigationProvider>
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByRole("img", { name: "diagram" }).getAttribute("src"),
+    ).toBe(
+      "/api/v1/threads/thr_image/host-files/content?path=%2Fworkspace%2Foutput%2Fdiagram.png",
+    );
+  });
+});
+
 describe("ConversationMessageContent assistant thread mentions", () => {
   it("renders an agent-authored thread token with the referenced thread title", () => {
     const mentionedThread = threadListEntry({

--- a/apps/app/src/components/thread/timeline/ConversationMessageContent.tsx
+++ b/apps/app/src/components/thread/timeline/ConversationMessageContent.tsx
@@ -68,7 +68,7 @@ import {
 } from "./SelectableMessageProse.js";
 import type { ThreadTimelinePluginMessageAction } from "./types.js";
 import type { PromptDraftAttachment } from "@bb/client-core";
-import { buildThreadHostFileContentUrl } from "@/lib/file-content-urls";
+import { buildMarkdownMessageLinkRouting } from "@/components/ui/markdown-message-link-routing";
 
 interface ConversationMessageContentBaseProps {
   attachments: TimelineConversationAttachments | null;
@@ -78,6 +78,7 @@ interface ConversationMessageContentBaseProps {
   projectId?: string;
   resolveUserAttachmentImageSrc?: UserAttachmentImageSrcResolver;
   text: string;
+  workspaceRootPath?: string;
 }
 
 interface ConversationMessageContentUserProps extends ConversationMessageContentBaseProps {
@@ -98,6 +99,7 @@ interface ConversationMessageContentUserProps extends ConversationMessageContent
   senderIsPluginSideChat: boolean;
   systemMessageKind: TimelineUserConversationRow["systemMessageKind"];
   systemMessageSubject: TimelineUserConversationRow["systemMessageSubject"];
+  threadId?: string;
   turnRequest: TimelineUserConversationRow["turnRequest"];
 }
 
@@ -164,7 +166,9 @@ interface UserConversationMessageProps {
   systemMessageKind: TimelineUserConversationRow["systemMessageKind"];
   systemMessageSubject: TimelineUserConversationRow["systemMessageSubject"];
   text: string;
+  threadId?: string;
   turnRequest: TimelineUserConversationRow["turnRequest"];
+  workspaceRootPath?: string;
 }
 
 interface AssistantConversationMessageProps extends AssistantMessageRowIdentity {
@@ -188,19 +192,19 @@ interface AssistantConversationMessageProps extends AssistantMessageRowIdentity 
 }
 
 interface CollapsibleMessageTextProps {
+  linkRouting?: MarkdownLinkRouting;
   mentions: readonly PromptTextMention[];
   resolveMentionLink?: PromptMentionLinkResolver;
   resolveSegmentLinkHref?: TimelineTitleLinkResolver;
-  onOpenLink?: ThreadTimelineLinkHandler;
   text: string;
   mutePrefixLength?: number;
 }
 
 function CollapsibleMessageText({
+  linkRouting,
   mentions,
   resolveMentionLink,
   resolveSegmentLinkHref,
-  onOpenLink,
   text,
   mutePrefixLength,
 }: CollapsibleMessageTextProps) {
@@ -244,11 +248,6 @@ function CollapsibleMessageText({
     }),
     [body.mentions],
   );
-  const linkRouting = useMemo<MarkdownLinkRouting | undefined>(
-    () => (onOpenLink ? { onOpenLink } : undefined),
-    [onOpenLink],
-  );
-
   const isOverflowing = useIsOverflowing({
     elementRef: bodyRef,
     enabled: !isExpanded,
@@ -347,8 +346,20 @@ function UserConversationMessage({
   systemMessageKind,
   systemMessageSubject,
   text,
+  threadId,
   turnRequest,
+  workspaceRootPath,
 }: UserConversationMessageProps) {
+  const linkRouting = useMemo(
+    () =>
+      buildMarkdownMessageLinkRouting({
+        onOpenLink,
+        onOpenLocalFileLink,
+        threadId,
+        workspaceRootPath,
+      }),
+    [onOpenLink, onOpenLocalFileLink, threadId, workspaceRootPath],
+  );
   if (initiator === "agent" && senderThreadId !== null) {
     const body = generatedConversationBodySlice({ initiator, text });
     const bodyMentions = shiftMentionsToTextRange({
@@ -377,7 +388,9 @@ function UserConversationMessage({
         systemMessageKind={systemMessageKind}
         systemMessageSubject={systemMessageSubject}
         text={body.text}
+        threadId={threadId}
         turnRequest={turnRequest}
+        workspaceRootPath={workspaceRootPath}
       />
     );
   }
@@ -408,7 +421,9 @@ function UserConversationMessage({
         systemMessageKind={systemMessageKind}
         systemMessageSubject={systemMessageSubject}
         text={body.text}
+        threadId={threadId}
         turnRequest={turnRequest}
+        workspaceRootPath={workspaceRootPath}
       />
     );
   }
@@ -436,7 +451,7 @@ function UserConversationMessage({
                 mentions={mentions}
                 resolveMentionLink={resolveMentionLink}
                 resolveSegmentLinkHref={resolveSegmentLinkHref}
-                onOpenLink={onOpenLink}
+                linkRouting={linkRouting}
                 text={text}
                 mutePrefixLength={mutePrefixLength || undefined}
               />
@@ -494,41 +509,16 @@ function AssistantConversationMessage({
     () => (streaming ? splitStreamingMarkdown(text) : null),
     [streaming, text],
   );
-  const linkRouting = useMemo<MarkdownLinkRouting>(() => {
-    const localImage: NonNullable<MarkdownLinkRouting["localImage"]> = {
-      absolutePaths: {
-        kind: "trusted-host",
-      },
-      resolveSrc: ({ path }) => buildThreadHostFileContentUrl(threadId, path),
-    };
-    const routing: MarkdownLinkRouting = {
-      localImage,
-    };
-    if (workspaceRootPath !== undefined) {
-      localImage.relativePaths = {
-        baseDir: workspaceRootPath,
-        rootPath: workspaceRootPath,
-      };
-    }
-    if (onOpenLink) {
-      routing.onOpenLink = onOpenLink;
-    }
-    if (onOpenLocalFileLink) {
-      routing.localFile = {
-        absoluteLinks: {
-          kind: "trusted-host",
-        },
-        onOpenLink: onOpenLocalFileLink,
-      };
-      if (workspaceRootPath !== undefined) {
-        routing.localFile.relativeLinks = {
-          baseDir: workspaceRootPath,
-          rootPath: workspaceRootPath,
-        };
-      }
-    }
-    return routing;
-  }, [onOpenLink, onOpenLocalFileLink, threadId, workspaceRootPath]);
+  const linkRouting = useMemo(
+    () =>
+      buildMarkdownMessageLinkRouting({
+        onOpenLink,
+        onOpenLocalFileLink,
+        threadId,
+        workspaceRootPath,
+      }),
+    [onOpenLink, onOpenLocalFileLink, threadId, workspaceRootPath],
+  );
 
   const messageDirectiveRegistry = useMessageDirectiveRegistry();
   const openDirectiveWorkspaceFile = useMemo<
@@ -689,7 +679,9 @@ export function ConversationMessageContent(
         systemMessageKind={props.systemMessageKind}
         systemMessageSubject={props.systemMessageSubject}
         text={text}
+        threadId={props.threadId}
         turnRequest={props.turnRequest}
+        workspaceRootPath={props.workspaceRootPath}
       />
     );
   }

--- a/apps/app/src/components/thread/timeline/GeneratedConversationMessage.test.tsx
+++ b/apps/app/src/components/thread/timeline/GeneratedConversationMessage.test.tsx
@@ -72,7 +72,9 @@ function renderChildCompleted(text = MARKDOWN_BODY) {
           attachments={null}
           mentions={mentions}
           text={text}
+          threadId="thr_parent"
           turnRequest={{ kind: "message", status: "accepted" }}
+          workspaceRootPath="/workspace"
           projectId="proj_demo"
         />
       </RouteNavigationProvider>
@@ -84,6 +86,18 @@ afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
+});
+
+describe("GeneratedConversationMessage images", () => {
+  it("routes images in generated system messages through the current thread", () => {
+    renderChildCompleted("![report](reports/result.png)");
+
+    expect(
+      screen.getByRole("img", { name: "report" }).getAttribute("src"),
+    ).toBe(
+      "/api/v1/threads/thr_parent/host-files/content?path=%2Fworkspace%2Freports%2Fresult.png",
+    );
+  });
 });
 
 const AGENT_BODY = "# notes\nedited path:src/app.ts here";

--- a/apps/app/src/components/thread/timeline/GeneratedConversationMessage.tsx
+++ b/apps/app/src/components/thread/timeline/GeneratedConversationMessage.tsx
@@ -10,6 +10,7 @@ import type { TimelineTitle, TimelineTitleSegment } from "@bb/thread-view";
 import { type IconName } from "@bb/shared-ui/icon";
 import { MarkdownPreview } from "@/components/ui/markdown-preview.js";
 import type { MarkdownLinkRouting } from "@/components/ui/markdown-link-routing.js";
+import { buildMarkdownMessageLinkRouting } from "@/components/ui/markdown-message-link-routing";
 import { cn } from "@bb/shared-ui/lib/utils";
 import type { PromptMentionLinkResolver } from "@/components/promptbox/editor/prompt-mention-link";
 import {
@@ -62,7 +63,9 @@ interface GeneratedConversationMessageProps {
   systemMessageKind: SystemMessageKind;
   systemMessageSubject: SystemMessageSubject | null;
   text: string;
+  threadId?: string;
   turnRequest: TimelineUserConversationRow["turnRequest"];
+  workspaceRootPath?: string;
 }
 
 type GeneratedConversationSourceKind = "agent" | "system";
@@ -447,7 +450,9 @@ export const GeneratedConversationMessage = memo(
     systemMessageKind,
     systemMessageSubject,
     text,
+    threadId,
     turnRequest,
+    workspaceRootPath,
   }: GeneratedConversationMessageProps) {
     const trimStartLength = text.length - text.trimStart().length;
     const messageText = text.trim();
@@ -461,9 +466,16 @@ export const GeneratedConversationMessage = memo(
       [mentions, messageText.length, trimStartLength],
     );
     const requestLabel = turnRequestLabel(turnRequest);
-    const linkRouting = useMemo<MarkdownLinkRouting | undefined>(() => {
-      return onOpenLink === undefined ? undefined : { onOpenLink };
-    }, [onOpenLink]);
+    const linkRouting = useMemo<MarkdownLinkRouting | undefined>(
+      () =>
+        buildMarkdownMessageLinkRouting({
+          onOpenLink,
+          onOpenLocalFileLink,
+          threadId,
+          workspaceRootPath,
+        }),
+      [onOpenLink, onOpenLocalFileLink, threadId, workspaceRootPath],
+    );
     const title = useMemo(
       () =>
         generatedConversationTitle({

--- a/apps/app/src/components/thread/timeline/ThreadTimelineNavigationContext.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineNavigationContext.tsx
@@ -10,6 +10,7 @@ interface ThreadTimelineNavigation {
   onOpenLink: ThreadTimelineLinkHandler;
   onOpenLocalFileLink: ThreadTimelineLocalFileLinkHandler;
   resolveMentionLink: PromptMentionLinkResolver;
+  threadId?: string;
   workspaceRootPath: string | undefined;
 }
 
@@ -22,6 +23,7 @@ export function ThreadTimelineNavigationProvider({
   onOpenLink,
   onOpenLocalFileLink,
   resolveMentionLink,
+  threadId,
   workspaceRootPath,
 }: ThreadTimelineNavigation & { children: ReactNode }) {
   const navigation = useMemo<ThreadTimelineNavigation>(
@@ -30,6 +32,7 @@ export function ThreadTimelineNavigationProvider({
       onOpenLink,
       onOpenLocalFileLink,
       resolveMentionLink,
+      threadId,
       workspaceRootPath,
     }),
     [
@@ -37,6 +40,7 @@ export function ThreadTimelineNavigationProvider({
       onOpenLink,
       onOpenLocalFileLink,
       resolveMentionLink,
+      threadId,
       workspaceRootPath,
     ],
   );

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
@@ -1023,7 +1023,9 @@ const ConversationRowContent = memo(function ConversationRowContent({
         systemMessageSubject={row.systemMessageSubject}
         pluginActions={rowPluginActions}
         text={row.text}
+        threadId={row.threadId}
         turnRequest={row.turnRequest}
+        workspaceRootPath={workspaceRootPath}
       />
     );
   }

--- a/apps/app/src/components/tools/SkillDetailView.tsx
+++ b/apps/app/src/components/tools/SkillDetailView.tsx
@@ -20,6 +20,7 @@ import {
 import { FilePreview } from "@/components/secondary-panel/FilePreview.js";
 import { ProvenancePill } from "@/components/tools/ProvenancePill";
 import { useClipboardCopy } from "@/lib/clipboard";
+import type { MarkdownLinkRouting } from "@/components/ui/markdown-link-routing";
 
 type SkillDetailTitleBadge = {
   label: string;
@@ -45,6 +46,7 @@ interface SkillDetailViewProps {
   onSelectFile: (path: string) => void;
   contentState: SkillDetailContentState;
   footer?: ReactNode;
+  markdownLinkRouting?: MarkdownLinkRouting;
 }
 
 function SkillPath({ path, href }: { path: string; href?: string }) {
@@ -160,10 +162,12 @@ function ScrollingSkillContent({
   path,
   content,
   markdown,
+  markdownLinkRouting,
 }: {
   path: string;
   content: string;
   markdown: boolean;
+  markdownLinkRouting?: MarkdownLinkRouting;
 }) {
   const chunks = useMemo(
     () => (markdown ? splitMarkdownIntoChunks(content) : [content]),
@@ -183,6 +187,7 @@ function ScrollingSkillContent({
             key={index}
             path={path}
             headerMode="none"
+            markdownLinkRouting={markdownLinkRouting}
             state={{
               kind: "ready",
               file: {
@@ -220,6 +225,7 @@ export function SkillDetailView({
   onSelectFile,
   contentState,
   footer,
+  markdownLinkRouting,
 }: SkillDetailViewProps) {
   const directoryPath = getSkillDirectoryPath(path);
   const selectedDisplayPath = formatHomePathForDisplay(selectedPath);
@@ -292,6 +298,7 @@ export function SkillDetailView({
               path={selectedPath}
               content={contentState.content}
               markdown={selectedFileIsMarkdown}
+              markdownLinkRouting={markdownLinkRouting}
             />
           )}
         </ResourceDefinitionSection>

--- a/apps/app/src/components/tools/SkillsCollection.tsx
+++ b/apps/app/src/components/tools/SkillsCollection.tsx
@@ -31,6 +31,7 @@ import { skillScopeLabel } from "@/components/tools/skill-taxonomy";
 import type { ProviderInfo } from "@bb/domain";
 import { ProviderIconMark } from "@/components/settings/ProviderIconMark";
 import { getProviderIconInfo } from "@/lib/provider-icon";
+import type { MarkdownLinkRouting } from "@/components/ui/markdown-link-routing";
 
 type ResourceProviderFilter = "bb" | SkillProvider;
 export type ProviderRoster = ReadonlyMap<string, ProviderInfo>;
@@ -609,6 +610,7 @@ interface SkillDetailDialogViewProps {
   canDelete: boolean;
   canOpenInEditor: boolean;
   isDeleting: boolean;
+  markdownLinkRouting?: MarkdownLinkRouting;
   onEdit: () => void;
   onRetry: () => void;
   onDelete: () => void;
@@ -628,6 +630,7 @@ export function SkillDetailDialogView({
   canDelete,
   canOpenInEditor,
   isDeleting,
+  markdownLinkRouting,
   onEdit,
   onRetry,
   onDelete,
@@ -728,6 +731,7 @@ export function SkillDetailDialogView({
               : undefined
       }
       files={files.length > 0 ? files : ["SKILL.md"]}
+      markdownLinkRouting={markdownLinkRouting}
       selectedPath={selectedPath}
       onSelectFile={onSelectPath}
       contentState={

--- a/apps/app/src/components/tools/SkillsLibrary.tsx
+++ b/apps/app/src/components/tools/SkillsLibrary.tsx
@@ -26,6 +26,10 @@ import {
 import { useSystemProviders } from "@/hooks/queries/system-queries";
 import { isSkillEditable } from "@/components/tools/skill-taxonomy";
 import { CREATE_SKILL_PROMPT } from "@bb/client-core";
+import { usePrimaryHost } from "@/hooks/queries/host-queries";
+import { useHostFilePreview } from "@/hooks/queries/host-file-preview-query";
+import { getAbsoluteDirname } from "@/lib/absolute-file-path";
+import { buildMarkdownLeaseImageRouting } from "@/components/ui/markdown-file-image-routing";
 import {
   buildRegistrySkillReferencePrompt,
   fetchRegistrySkillDetail,
@@ -84,6 +88,14 @@ function SkillDetailPage({
   }, [skill?.id]);
   const filesQuery = useSkillFiles(projectId, skill);
   const contentQuery = useSkillContent(projectId, skill, selectedPath);
+  const primaryHost = usePrimaryHost({ enabled: skill !== null });
+  const previewHostId =
+    primaryHost?.status === "connected" ? primaryHost.id : null;
+  const skillFilePreview = useHostFilePreview(
+    previewHostId,
+    skill?.filePath ?? null,
+    { enabled: skill !== null && previewHostId !== null },
+  );
   const deleteSkill = useDeleteSkill(projectId);
   const { canOpenPreferredFileTarget, openPathInPreferredFileTarget } =
     useLocalOpenTargets({ enabled: skill !== null });
@@ -92,6 +104,14 @@ function SkillDetailPage({
     skill && skill.manageable && isSkillEditable(skill) ? skill.scope : null;
   const editableScope: EditableSkillScope | null =
     skill && isSkillEditable(skill) ? skill.scope : null;
+  const markdownLinkRouting = useMemo(() => {
+    if (skill === null) return undefined;
+    return buildMarkdownLeaseImageRouting({
+      path: selectedPath,
+      rootPath: getAbsoluteDirname({ path: skill.filePath }),
+      previewUrl: skillFilePreview.data?.url,
+    });
+  }, [selectedPath, skill, skillFilePreview.data?.url]);
 
   return (
     <SkillDetailDialogView
@@ -107,6 +127,7 @@ function SkillDetailPage({
       canDelete={deletableScope !== null}
       canOpenInEditor={editableScope !== null && canOpenPreferredFileTarget}
       isDeleting={deleteSkill.isPending}
+      markdownLinkRouting={markdownLinkRouting}
       onEdit={() => {
         if (skill) onEdit(skill);
       }}

--- a/apps/app/src/components/tools/detail-page-recipes.test.tsx
+++ b/apps/app/src/components/tools/detail-page-recipes.test.tsx
@@ -95,6 +95,7 @@ import {
   makePluginListItem,
   makePluginRegistrationSet,
 } from "@/test/fixtures/plugins";
+import { buildMarkdownFileImageRouting } from "@/components/ui/markdown-file-image-routing";
 
 afterEach(() => {
   cleanup();
@@ -611,6 +612,33 @@ function renderSkill(files: readonly string[]) {
 }
 
 describe("Skill detail recipe", () => {
+  it("routes relative images from Markdown skill files", () => {
+    const markdownLinkRouting = buildMarkdownFileImageRouting({
+      path: "/skills/writing-voice/SKILL.md",
+      rootPath: "/skills/writing-voice",
+      threadId: null,
+      resolveRelativeSrc: (path) => `/skill-preview/${path}`,
+    });
+    render(
+      <SkillDetailView
+        title="writing-voice"
+        path="/skills/writing-voice/SKILL.md"
+        files={["SKILL.md"]}
+        selectedPath="SKILL.md"
+        onSelectFile={() => {}}
+        contentState={{
+          kind: "ready",
+          content: "![example](assets/example.png)",
+        }}
+        markdownLinkRouting={markdownLinkRouting}
+      />,
+    );
+
+    expect(
+      screen.getByRole("img", { name: "example" }).getAttribute("src"),
+    ).toBe("/skill-preview/assets/example.png");
+  });
+
   it("shows only Definition for a single-file skill", () => {
     const { container } = renderSkill(["/skills/writing-voice/SKILL.md"]);
 

--- a/apps/app/src/components/ui/markdown-file-image-routing.test.tsx
+++ b/apps/app/src/components/ui/markdown-file-image-routing.test.tsx
@@ -1,0 +1,169 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { FilePreview } from "@/components/secondary-panel/FilePreview";
+import {
+  buildMarkdownFileImageRouting,
+  buildMarkdownLeaseImageRouting,
+} from "./markdown-file-image-routing";
+import type { MarkdownLinkRouting } from "./markdown-link-routing";
+import {
+  buildThreadStorageRawContentUrl,
+  buildThreadWorktreeRawContentUrl,
+} from "@/lib/file-content-urls";
+
+afterEach(cleanup);
+
+function renderMarkdownFilePreview({
+  content,
+  imageContent,
+  path,
+  rootPath,
+}: {
+  content: string;
+  imageContent: {
+    kind: "thread-storage" | "worktree";
+    threadId: string;
+  };
+  path: string;
+  rootPath: string;
+}) {
+  render(
+    <FilePreview
+      headerMode="none"
+      markdownLinkRouting={buildMarkdownFileImageRouting({
+        path,
+        threadId: imageContent.threadId,
+        resolveRelativeSrc: (relativePath) =>
+          imageContent.kind === "thread-storage"
+            ? buildThreadStorageRawContentUrl(
+                imageContent.threadId,
+                relativePath,
+              )
+            : buildThreadWorktreeRawContentUrl(
+                imageContent.threadId,
+                relativePath,
+              ),
+        rootPath,
+      })}
+      path={path}
+      state={{
+        kind: "ready",
+        file: { contents: content, name: path },
+        lineRange: null,
+        textPreviewKind: "markdown",
+      }}
+    />,
+  );
+}
+
+describe("Markdown file preview image routing", () => {
+  it("preserves explicit image routing and file-link handlers", () => {
+    const linkRouting: MarkdownLinkRouting = {
+      onOpenLink: vi.fn(() => false),
+      localImage: {
+        absolutePaths: { kind: "trusted-host" },
+        resolveSrc: vi.fn(() => "/custom/image.png"),
+      },
+    };
+    expect(
+      buildMarkdownFileImageRouting({
+        path: "docs/report.md",
+        rootPath: "/workspace",
+        threadId: "thr_preview",
+        linkRouting,
+        resolveRelativeSrc: vi.fn(),
+      }),
+    ).toBe(linkRouting);
+  });
+
+  it("resolves nested skill and host files within their shared preview lease", () => {
+    render(
+      <FilePreview
+        headerMode="none"
+        markdownLinkRouting={buildMarkdownLeaseImageRouting({
+          path: "references/guide.md",
+          rootPath: "/skills/example",
+          previewUrl: "/api/v1/file-previews/lease_skill/SKILL.md",
+        })}
+        path="references/guide.md"
+        state={{
+          kind: "ready",
+          file: {
+            contents:
+              "![relative](../assets/chart.png)\n\n![absolute](/skills/example/assets/chart.png)\n\n![escape](../../outside.png)",
+            name: "guide.md",
+          },
+          lineRange: null,
+          textPreviewKind: "markdown",
+        }}
+      />,
+    );
+    for (const name of ["relative", "absolute"]) {
+      expect(screen.getByRole("img", { name }).getAttribute("src")).toBe(
+        "/api/v1/file-previews/lease_skill/assets/chart.png",
+      );
+    }
+    expect(
+      screen.getByRole("img", { name: "escape" }).getAttribute("src"),
+    ).toBe("../../outside.png");
+  });
+
+  it("routes absolute and file-relative images in thread-storage Markdown previews", () => {
+    renderMarkdownFilePreview({
+      content: [
+        "![absolute](/Users/me/.bb/thread-storage/thr_preview/generated.png)",
+        "![relative](screenshots/chart.png)",
+      ].join("\n\n"),
+      imageContent: { kind: "thread-storage", threadId: "thr_preview" },
+      path: "reports/nested/report.md",
+      rootPath: "/Users/me/.bb/thread-storage/thr_preview",
+    });
+
+    expect(
+      screen.getByRole("img", { name: "absolute" }).getAttribute("src"),
+    ).toBe(
+      "/api/v1/threads/thr_preview/host-files/content?path=%2FUsers%2Fme%2F.bb%2Fthread-storage%2Fthr_preview%2Fgenerated.png",
+    );
+    expect(
+      screen.getByRole("img", { name: "relative" }).getAttribute("src"),
+    ).toBe(
+      "/api/v1/threads/thr_preview/thread-storage/files/reports/nested/screenshots/chart.png",
+    );
+  });
+
+  it("routes absolute and file-relative images in workspace Markdown previews", () => {
+    renderMarkdownFilePreview({
+      content: [
+        "![absolute](/Users/me/project/generated.png)",
+        "![relative](../assets/chart.png)",
+      ].join("\n\n"),
+      imageContent: { kind: "worktree", threadId: "thr_preview" },
+      path: "docs/guides/report.md",
+      rootPath: "/Users/me/project",
+    });
+
+    expect(
+      screen.getByRole("img", { name: "absolute" }).getAttribute("src"),
+    ).toBe(
+      "/api/v1/threads/thr_preview/host-files/content?path=%2FUsers%2Fme%2Fproject%2Fgenerated.png",
+    );
+    expect(
+      screen.getByRole("img", { name: "relative" }).getAttribute("src"),
+    ).toBe("/api/v1/threads/thr_preview/worktree/files/docs/assets/chart.png");
+  });
+
+  it("does not rewrite relative images that escape the workspace root", () => {
+    renderMarkdownFilePreview({
+      content: "![escape](../../outside.png)",
+      imageContent: { kind: "worktree", threadId: "thr_preview" },
+      path: "docs/report.md",
+      rootPath: "/Users/me/project",
+    });
+
+    expect(
+      screen.getByRole("img", { name: "escape" }).getAttribute("src"),
+    ).toBe("../../outside.png");
+  });
+});

--- a/apps/app/src/components/ui/markdown-file-image-routing.ts
+++ b/apps/app/src/components/ui/markdown-file-image-routing.ts
@@ -1,0 +1,80 @@
+import type { MarkdownLinkRouting } from "./markdown-link-routing";
+import {
+  getAbsoluteDirname,
+  buildAbsoluteFilePath,
+  normalizeAbsoluteFilePath,
+} from "@/lib/absolute-file-path";
+import {
+  buildFilePreviewLeaseContentUrl,
+  buildThreadHostFileContentUrl,
+  getFilePreviewLeaseBaseUrl,
+} from "@/lib/file-content-urls";
+
+const ROUTE_ROOT = "/__bb_markdown_file_root__";
+
+export function buildMarkdownFileImageRouting({
+  path,
+  rootPath,
+  threadId,
+  linkRouting,
+  resolveRelativeSrc,
+}: {
+  path: string;
+  rootPath: string | null;
+  threadId: string | null;
+  linkRouting?: MarkdownLinkRouting;
+  resolveRelativeSrc: (
+    rootRelativePath: string,
+    absolutePath: string,
+  ) => string;
+}): MarkdownLinkRouting | undefined {
+  if (linkRouting?.localImage !== undefined) return linkRouting;
+  const root = normalizeAbsoluteFilePath({ path: rootPath ?? ROUTE_ROOT });
+  if (root === null) return linkRouting;
+  const filePath = buildAbsoluteFilePath({
+    path: rootPath === null ? path.replace(/^\/+/, "") : path,
+    rootPath: root,
+  });
+  return {
+    ...linkRouting,
+    localImage: {
+      absolutePaths:
+        threadId === null
+          ? { kind: "contained", rootPath: root }
+          : { kind: "trusted-host" },
+      relativePaths: {
+        baseDir: getAbsoluteDirname({ path: filePath }),
+        rootPath: root,
+      },
+      resolveSrc: (image, sourceKind) => {
+        if (sourceKind === "absolute" && threadId !== null) {
+          return buildThreadHostFileContentUrl(threadId, image.path);
+        }
+        return resolveRelativeSrc(
+          image.path.slice(root === "/" ? 1 : root.length + 1),
+          image.path,
+        );
+      },
+    },
+  };
+}
+
+export function buildMarkdownLeaseImageRouting({
+  path,
+  rootPath,
+  previewUrl,
+}: {
+  path: string;
+  rootPath: string;
+  previewUrl: string | undefined;
+}): MarkdownLinkRouting | undefined {
+  const baseUrl = getFilePreviewLeaseBaseUrl(previewUrl ?? "");
+  if (baseUrl === null) return undefined;
+  return buildMarkdownFileImageRouting({
+    path,
+    rootPath,
+    threadId: null,
+    resolveRelativeSrc: (relativePath) =>
+      buildFilePreviewLeaseContentUrl(baseUrl, relativePath),
+  });
+}

--- a/apps/app/src/components/ui/markdown-link-routing.ts
+++ b/apps/app/src/components/ui/markdown-link-routing.ts
@@ -50,7 +50,10 @@ export interface MarkdownLocalFileLinkRouting {
 export interface MarkdownLocalImageRouting {
   absolutePaths: MarkdownAbsoluteLocalFileLinkRouting;
   relativePaths?: MarkdownRelativeLocalFileLinkRouting;
-  resolveSrc: (image: MarkdownPreviewLocalFileLink) => string;
+  resolveSrc: (
+    image: MarkdownPreviewLocalFileLink,
+    sourceKind: "absolute" | "relative",
+  ) => string;
 }
 
 export interface MarkdownLinkRouting {

--- a/apps/app/src/components/ui/markdown-message-link-routing.ts
+++ b/apps/app/src/components/ui/markdown-message-link-routing.ts
@@ -1,0 +1,62 @@
+import type {
+  MarkdownLinkRouting,
+  MarkdownLocalFileLinkRouting,
+} from "./markdown-link-routing.js";
+import type { MarkdownPreviewLinkHandler } from "./markdown-link.js";
+import type { MarkdownPreviewLocalFileLinkHandler } from "./markdown-local-file-link.js";
+import { buildThreadHostFileContentUrl } from "@/lib/file-content-urls";
+
+interface BuildMarkdownMessageLinkRoutingArgs {
+  onOpenLink?: MarkdownPreviewLinkHandler;
+  onOpenLocalFileLink?: MarkdownPreviewLocalFileLinkHandler;
+  threadId?: string;
+  workspaceRootPath?: string;
+}
+
+export function buildMarkdownMessageLinkRouting({
+  onOpenLink,
+  onOpenLocalFileLink,
+  threadId,
+  workspaceRootPath,
+}: BuildMarkdownMessageLinkRoutingArgs): MarkdownLinkRouting | undefined {
+  if (
+    onOpenLink === undefined &&
+    onOpenLocalFileLink === undefined &&
+    threadId === undefined
+  ) {
+    return undefined;
+  }
+
+  const routing: MarkdownLinkRouting = {};
+  if (onOpenLink !== undefined) {
+    routing.onOpenLink = onOpenLink;
+  }
+  if (threadId !== undefined) {
+    routing.localImage = {
+      absolutePaths: { kind: "trusted-host" },
+      resolveSrc: ({ path }) => buildThreadHostFileContentUrl(threadId, path),
+      ...(workspaceRootPath === undefined
+        ? {}
+        : {
+            relativePaths: {
+              baseDir: workspaceRootPath,
+              rootPath: workspaceRootPath,
+            },
+          }),
+    };
+  }
+  if (onOpenLocalFileLink !== undefined) {
+    const localFile: MarkdownLocalFileLinkRouting = {
+      absoluteLinks: { kind: "trusted-host" },
+      onOpenLink: onOpenLocalFileLink,
+    };
+    if (workspaceRootPath !== undefined) {
+      localFile.relativeLinks = {
+        baseDir: workspaceRootPath,
+        rootPath: workspaceRootPath,
+      };
+    }
+    routing.localFile = localFile;
+  }
+  return routing;
+}

--- a/apps/app/src/components/ui/markdown-preview.tsx
+++ b/apps/app/src/components/ui/markdown-preview.tsx
@@ -166,6 +166,11 @@ interface BuildLocalAwareUrlTransformArgs {
   localImageRouting: MarkdownLocalImageRouting | undefined;
 }
 
+interface ResolvedMarkdownLocalPath {
+  image: MarkdownPreviewLocalFileLink;
+  sourceKind: "absolute" | "relative";
+}
+
 interface MarkdownImageRendererArgs {
   alt: ComponentPropsWithoutRef<"img">["alt"];
   imageAttributes: MarkdownImageRenderAttributes;
@@ -451,25 +456,38 @@ function resolveMarkdownLocalPath(
   value: string,
   absolutePaths: MarkdownAbsoluteLocalFileLinkRouting,
   relativePaths: MarkdownRelativeLocalFileLinkRouting | undefined,
-): MarkdownPreviewLocalFileLink | null {
+): ResolvedMarkdownLocalPath | null {
   const absolutePath = parseLocalFileHref({
     absoluteLinks: absolutePaths,
     href: value,
   });
-  if (absolutePath !== null || relativePaths === undefined) {
-    return absolutePath;
+  if (absolutePath !== null) {
+    return {
+      image: absolutePath,
+      sourceKind: "absolute",
+    };
+  }
+  if (relativePaths === undefined) {
+    return null;
   }
 
   const resolvedHref = resolveRelativeLocalFileHref({
     href: value,
     ...relativePaths,
   });
-  return resolvedHref === null
+  if (resolvedHref === null) {
+    return null;
+  }
+  const relativePath = parseLocalFileHref({
+    absoluteLinks: absolutePaths,
+    href: resolvedHref,
+  });
+  return relativePath === null
     ? null
-    : parseLocalFileHref({
-        absoluteLinks: absolutePaths,
-        href: resolvedHref,
-      });
+    : {
+        image: relativePath,
+        sourceKind: "relative",
+      };
 }
 
 function buildLocalAwareUrlTransform({
@@ -512,7 +530,10 @@ function buildLocalAwareUrlTransform({
         localImageRouting.relativePaths,
       );
       if (localImage !== null) {
-        return localImageRouting.resolveSrc(localImage);
+        return localImageRouting.resolveSrc(
+          localImage.image,
+          localImage.sourceKind,
+        );
       }
     }
 

--- a/apps/app/src/lib/file-content-urls.test.ts
+++ b/apps/app/src/lib/file-content-urls.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { getFilePreviewLeaseBaseUrl } from "./file-content-urls";
+
+describe("getFilePreviewLeaseBaseUrl", () => {
+  it.each([
+    [
+      "/api/v1/file-previews/lease-1/readme.md",
+      "/api/v1/file-previews/lease-1",
+    ],
+    [
+      "https://bb.test/api/v1/file-previews/lease-2/docs/readme.md",
+      "https://bb.test/api/v1/file-previews/lease-2",
+    ],
+    ["/workspace/file-previews/not-a-lease/readme.md", null],
+  ])("extracts only a file-preview API lease from %s", (url, expected) => {
+    expect(getFilePreviewLeaseBaseUrl(url)).toBe(expected);
+  });
+});

--- a/apps/app/src/lib/file-content-urls.ts
+++ b/apps/app/src/lib/file-content-urls.ts
@@ -99,3 +99,18 @@ export function buildEnvironmentDiffFileContentUrl(
     }),
   );
 }
+
+export function getFilePreviewLeaseBaseUrl(url: string): string | null {
+  return (
+    /^((?:https?:\/\/[^/?#]+)?\/api\/v1\/file-previews\/[^/?#]+)(?:\/|$)/u.exec(
+      url,
+    )?.[1] ?? null
+  );
+}
+
+export function buildFilePreviewLeaseContentUrl(
+  baseUrl: string,
+  path: string,
+): string {
+  return `${baseUrl.replace(/\/+$/u, "")}/${encodePathSegments(path)}`;
+}

--- a/apps/app/src/lib/plugin-sdk-app-impl.test.tsx
+++ b/apps/app/src/lib/plugin-sdk-app-impl.test.tsx
@@ -126,9 +126,10 @@ describe("plugin SDK Markdown", () => {
           onOpenLink={onOpenLink}
           onOpenLocalFileLink={onOpenLocalFileLink}
           resolveMentionLink={() => null}
+          threadId="thr_plugin"
           workspaceRootPath="/workspace"
         >
-          <Markdown content="Open [README](README.md) or [the docs](https://example.com/docs)." />
+          <Markdown content="Open [README](README.md), ![chart](images/chart.png), or [the docs](https://example.com/docs)." />
         </ThreadTimelineNavigationProvider>
       </AppNavigationHostProvider>,
     );
@@ -140,6 +141,9 @@ describe("plugin SDK Markdown", () => {
       lineRange: null,
       path: "/workspace/README.md",
     });
+    expect(screen.getByRole("img", { name: "chart" }).getAttribute("src")).toBe(
+      "/api/v1/threads/thr_plugin/host-files/content?path=%2Fworkspace%2Fimages%2Fchart.png",
+    );
 
     fireEvent.click(screen.getByRole("link", { name: "the docs" }));
     expect(openUrl).toHaveBeenCalledWith({

--- a/apps/app/src/lib/plugin-sdk-app-impl.tsx
+++ b/apps/app/src/lib/plugin-sdk-app-impl.tsx
@@ -9,10 +9,8 @@ import { PluginThreadChat } from "@/components/plugin/PluginThreadChat";
 import { PluginUrlLink } from "@/components/plugin/PluginUrlLink";
 import { ExperimentalFileLink } from "@/components/plugin/ExperimentalFileLink";
 import { MarkdownPreview } from "@/components/ui/markdown-preview";
-import type {
-  MarkdownLinkRouting,
-  MarkdownLocalFileLinkRouting,
-} from "@/components/ui/markdown-link-routing";
+import type { MarkdownLinkRouting } from "@/components/ui/markdown-link-routing";
+import { buildMarkdownMessageLinkRouting } from "@/components/ui/markdown-message-link-routing";
 import type { MarkdownPreviewLinkHandler } from "@/components/ui/markdown-link";
 import { useThreadTimelineNavigation } from "@/components/thread/timeline/ThreadTimelineNavigationContext";
 import { definePluginApp } from "./plugin-app-definition";
@@ -74,6 +72,7 @@ export const pluginSdkAppImplementation = installDeprecatedAliases(
 function PluginMarkdown({ content, className }: MarkdownProps) {
   const timelineNavigation = useThreadTimelineNavigation();
   const onOpenLocalFileLink = timelineNavigation?.onOpenLocalFileLink;
+  const threadId = timelineNavigation?.threadId;
   const workspaceRootPath = timelineNavigation?.workspaceRootPath;
   const navigation = useAppNavigationHost();
   const onOpenLink = useCallback<MarkdownPreviewLinkHandler>(
@@ -81,21 +80,15 @@ function PluginMarkdown({ content, className }: MarkdownProps) {
     [navigation],
   );
   const linkRouting = useMemo<MarkdownLinkRouting>(() => {
-    if (onOpenLocalFileLink === undefined) {
-      return { onOpenLink };
-    }
-    const localFile: MarkdownLocalFileLinkRouting = {
-      absoluteLinks: { kind: "trusted-host" },
-      onOpenLink: onOpenLocalFileLink,
-    };
-    if (workspaceRootPath !== undefined) {
-      localFile.relativeLinks = {
-        baseDir: workspaceRootPath,
-        rootPath: workspaceRootPath,
-      };
-    }
-    return { localFile, onOpenLink };
-  }, [onOpenLink, onOpenLocalFileLink, workspaceRootPath]);
+    return (
+      buildMarkdownMessageLinkRouting({
+        onOpenLink,
+        onOpenLocalFileLink,
+        threadId,
+        workspaceRootPath,
+      }) ?? { onOpenLink }
+    );
+  }, [onOpenLink, onOpenLocalFileLink, threadId, workspaceRootPath]);
 
   return (
     <MarkdownPreview

--- a/apps/app/src/views/RootComposePanelTabContent.tsx
+++ b/apps/app/src/views/RootComposePanelTabContent.tsx
@@ -297,6 +297,7 @@ function RootComposeFilePreviewTabContent({
     staleTime: 5_000,
   });
   const environment = environmentQuery.data;
+  const imageThreadId = fileOpenerSource?.threadId ?? rootPanelThreadId;
   const storageThreadId =
     tab.kind === "thread-storage-file-preview"
       ? fileOpenerSource === null
@@ -436,7 +437,7 @@ function RootComposeFilePreviewTabContent({
             onSelectionAddToChat={onSelectionAddToChat}
             source={tab.source}
             statusLabel={tab.statusLabel}
-            threadId={rootPanelThreadId}
+            threadId={imageThreadId}
           />
         ) : projectPreviewId !== null ? (
           <LazyProjectFilePreviewTabContent
@@ -449,6 +450,8 @@ function RootComposeFilePreviewTabContent({
             onOpenInEditor={onOpenInEditor}
             onSelectionAddToChat={onSelectionAddToChat}
             projectId={projectPreviewId}
+            rootPath={projectPreviewRootPath}
+            threadId={imageThreadId}
           />
         ) : (
           <LazyFilePreview

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -630,11 +630,10 @@ function ThreadDetailViewInternal(props: ThreadRoutePathArgs) {
     },
   );
   const pendingInteractions = pendingInteractionsQuery.data ?? [];
-  const pendingInteractionsInitialLoading =
-    isPendingInteractionStateUnknown(
-      pendingInteractionsQuery.data,
-      pendingInteractionsQuery.isFetching,
-    );
+  const pendingInteractionsInitialLoading = isPendingInteractionStateUnknown(
+    pendingInteractionsQuery.data,
+    pendingInteractionsQuery.isFetching,
+  );
   const hasPendingInteraction =
     getLatestPendingInteraction(pendingInteractions) !== null;
   const { data: queuedMessagesForEditEligibility = [] } =
@@ -2682,6 +2681,7 @@ function ThreadDetailViewInternal(props: ThreadRoutePathArgs) {
             onOpenLink={handleOpenTimelineLink}
             onOpenLocalFileLink={handleOpenTimelineLocalFileLink}
             resolveMentionLink={resolveMentionLink}
+            threadId={thread.id}
             workspaceRootPath={environment?.path ?? undefined}
           >
             <PluginPanelTabContent

--- a/apps/server/src/routes/files.ts
+++ b/apps/server/src/routes/files.ts
@@ -19,6 +19,7 @@ import {
   createDaemonFileContentResponse,
   type DaemonFileReadResult,
   remapDaemonFileRouteError,
+  serveDaemonFileContent,
 } from "../services/hosts/daemon-file-response.js";
 import {
   assertUsableHostId,
@@ -132,19 +133,14 @@ async function serveRawFilesystemHtmlFile(
   const filePath = parseRawFilesystemPath(rawPath);
   assertHtmlPreviewPath(filePath);
   const { environment } = requirePublicThreadEnvironment(deps.db, threadId);
-  try {
-    const result = await callHostRetryableOnlineRpc(deps, {
+  return serveDaemonFileContent(
+    deps,
+    {
       hostId: environment.hostId,
-      timeoutMs: COMMAND_TIMEOUT_MS,
-      command: {
-        type: "host.read_file",
-        path: filePath,
-      },
-    });
-    return createRawFilesystemHtmlPreviewResponse(result);
-  } catch (error) {
-    return remapDaemonFileRouteError(error);
-  }
+      path: filePath,
+    },
+    createRawFilesystemHtmlPreviewResponse,
+  );
 }
 
 export function registerFileRoutes(app: Hono, deps: AppDeps): void {
@@ -409,28 +405,25 @@ export function registerFileRoutes(app: Hono, deps: AppDeps): void {
     ) {
       throw new ApiError(400, "invalid_path", "Invalid preview path", false);
     }
-    try {
-      const result = await callHostRetryableOnlineRpc(deps, {
+    return serveDaemonFileContent(
+      deps,
+      {
         hostId: lease.hostId,
-        timeoutMs: COMMAND_TIMEOUT_MS,
-        command: {
-          type: "host.read_file",
-          path: joinHostPath(lease.rootPath, segments),
-          rootPath: lease.rootPath,
-        },
-      });
-      const headers = new Headers({
-        "cache-control": "no-store",
-        "x-content-type-options": "nosniff",
-      });
-      if (isHtmlMimeType(result.mimeType)) {
-        assertRawFilesystemHtmlPreviewResult(result);
-        headers.set("content-security-policy", HTML_PREVIEW_CSP);
-        headers.set("content-type", HTML_PREVIEW_CONTENT_TYPE);
-      }
-      return createDaemonFileContentResponse(result, { headers });
-    } catch (error) {
-      return remapDaemonFileRouteError(error);
-    }
+        path: joinHostPath(lease.rootPath, segments),
+        rootPath: lease.rootPath,
+      },
+      (result) => {
+        const headers = new Headers({
+          "cache-control": "no-store",
+          "x-content-type-options": "nosniff",
+        });
+        if (isHtmlMimeType(result.mimeType)) {
+          assertRawFilesystemHtmlPreviewResult(result);
+          headers.set("content-security-policy", HTML_PREVIEW_CSP);
+          headers.set("content-type", HTML_PREVIEW_CONTENT_TYPE);
+        }
+        return createDaemonFileContentResponse(result, { headers });
+      },
+    );
   });
 }

--- a/apps/server/src/routes/projects.ts
+++ b/apps/server/src/routes/projects.ts
@@ -61,7 +61,7 @@ import {
 } from "../services/skills/skill-listing.js";
 import {
   createDaemonFileContentResponse,
-  remapDaemonFileRouteError,
+  serveDaemonFileContent,
   requestMatchesEntityTag,
 } from "../services/hosts/daemon-file-response.js";
 import { parseBoundedPositiveOptionalInteger } from "../services/lib/validation.js";
@@ -648,23 +648,19 @@ export function registerProjectRoutes(app: Hono, deps: AppDeps): void {
     });
     const filePath = parseSafeRelativeRoutePath(query.path);
 
-    try {
-      const result = await callHostRetryableOnlineRpc(deps, {
+    return serveDaemonFileContent(
+      deps,
+      {
         hostId: target.hostId,
-        timeoutMs: COMMAND_TIMEOUT_MS,
-        command: {
-          type: "host.read_file",
-          path: path.join(target.path, filePath.relativePath),
-          rootPath: target.path,
-        },
-      });
-      return createDaemonFileContentResponse(result, {
-        headers: { "x-bb-content-encoding": result.contentEncoding },
-        ifNoneMatch: context.req.header("if-none-match"),
-      });
-    } catch (error) {
-      return remapDaemonFileRouteError(error);
-    }
+        path: path.join(target.path, filePath.relativePath),
+        rootPath: target.path,
+      },
+      (result) =>
+        createDaemonFileContentResponse(result, {
+          headers: { "x-bb-content-encoding": result.contentEncoding },
+          ifNoneMatch: context.req.header("if-none-match"),
+        }),
+    );
   });
 
   get(routes.paths, async (context, query) => {

--- a/apps/server/src/routes/threads/data.ts
+++ b/apps/server/src/routes/threads/data.ts
@@ -38,7 +38,7 @@ import { callHostRetryableOnlineRpc } from "../../services/hosts/online-rpc.js";
 import {
   createDaemonFileContentResponse,
   type DaemonFileReadResult,
-  remapDaemonFileRouteError,
+  serveDaemonFileContent,
 } from "../../services/hosts/daemon-file-response.js";
 import { requireThreadStoragePath } from "../../services/threads/thread-storage.js";
 import { toThreadQueuedMessage } from "../../services/threads/thread-queued-messages.js";
@@ -248,20 +248,15 @@ async function serveThreadStorageRawFile(
   const filePath = parseSafeRelativeRoutePath(rawPath);
   const target = await requireThreadStorageTarget(deps, { threadId });
 
-  try {
-    const result = await callHostRetryableOnlineRpc(deps, {
+  return serveDaemonFileContent(
+    deps,
+    {
       hostId: target.hostId,
-      timeoutMs: COMMAND_TIMEOUT_MS,
-      command: {
-        type: "host.read_file",
-        path: path.join(target.storagePath, filePath.relativePath),
-        rootPath: target.storagePath,
-      },
-    });
-    return createRawFilePreviewResponse(result, filePath.relativePath);
-  } catch (error) {
-    return remapDaemonFileRouteError(error);
-  }
+      path: path.join(target.storagePath, filePath.relativePath),
+      rootPath: target.storagePath,
+    },
+    (result) => createRawFilePreviewResponse(result, filePath.relativePath),
+  );
 }
 
 async function serveThreadWorktreeRawFile(
@@ -276,20 +271,15 @@ async function serveThreadWorktreeRawFile(
   }
   const environment = requireReadyEnvironment(deps.db, thread.environmentId);
 
-  try {
-    const result = await callHostRetryableOnlineRpc(deps, {
+  return serveDaemonFileContent(
+    deps,
+    {
       hostId: environment.hostId,
-      timeoutMs: COMMAND_TIMEOUT_MS,
-      command: {
-        type: "host.read_file",
-        path: path.join(environment.path, filePath.relativePath),
-        rootPath: environment.path,
-      },
-    });
-    return createRawFilePreviewResponse(result, filePath.relativePath);
-  } catch (error) {
-    return remapDaemonFileRouteError(error);
-  }
+      path: path.join(environment.path, filePath.relativePath),
+      rootPath: environment.path,
+    },
+    (result) => createRawFilePreviewResponse(result, filePath.relativePath),
+  );
 }
 
 export function registerThreadDataRoutes(app: Hono, deps: AppDeps): void {
@@ -653,22 +643,18 @@ export function registerThreadDataRoutes(app: Hono, deps: AppDeps): void {
       threadId: context.req.param("id"),
     });
 
-    try {
-      const result = await callHostRetryableOnlineRpc(deps, {
+    return serveDaemonFileContent(
+      deps,
+      {
         hostId: target.hostId,
-        timeoutMs: COMMAND_TIMEOUT_MS,
-        command: {
-          type: "host.read_file",
-          path: path.join(target.storagePath, query.path),
-          rootPath: target.storagePath,
-        },
-      });
-      return createDaemonFileContentResponse(result, {
-        ifNoneMatch: context.req.header("if-none-match"),
-      });
-    } catch (error) {
-      return remapDaemonFileRouteError(error);
-    }
+        path: path.join(target.storagePath, query.path),
+        rootPath: target.storagePath,
+      },
+      (result) =>
+        createDaemonFileContentResponse(result, {
+          ifNoneMatch: context.req.header("if-none-match"),
+        }),
+    );
   });
 
   get(routes.hostFileContent, async (context, query) => {
@@ -680,20 +666,16 @@ export function registerThreadDataRoutes(app: Hono, deps: AppDeps): void {
     }
     const environment = requireEnvironment(deps.db, thread.environmentId);
 
-    try {
-      const result = await callHostRetryableOnlineRpc(deps, {
+    return serveDaemonFileContent(
+      deps,
+      {
         hostId: environment.hostId,
-        timeoutMs: COMMAND_TIMEOUT_MS,
-        command: {
-          type: "host.read_file",
-          path: query.path,
-        },
-      });
-      return createDaemonFileContentResponse(result, {
-        ifNoneMatch: context.req.header("if-none-match"),
-      });
-    } catch (error) {
-      return remapDaemonFileRouteError(error);
-    }
+        path: query.path,
+      },
+      (result) =>
+        createDaemonFileContentResponse(result, {
+          ifNoneMatch: context.req.header("if-none-match"),
+        }),
+    );
   });
 }

--- a/apps/server/src/services/hosts/daemon-file-response.ts
+++ b/apps/server/src/services/hosts/daemon-file-response.ts
@@ -1,6 +1,9 @@
 import { Buffer } from "node:buffer";
 import type { HostDaemonOnlineRpcResultByType } from "@bb/host-daemon-contract";
 import { ApiError } from "../../errors.js";
+import { COMMAND_TIMEOUT_MS } from "../../constants.js";
+import type { LoggedWorkSessionDeps } from "../../types.js";
+import { callHostRetryableOnlineRpc } from "./online-rpc.js";
 
 const OCTET_STREAM_MIME_TYPE = "application/octet-stream";
 const REVALIDATE_CACHE_CONTROL = "private, no-cache";
@@ -12,6 +15,24 @@ export type DaemonFileReadResult =
 interface CreateDaemonFileContentResponseOptions {
   headers?: HeadersInit;
   ifNoneMatch?: string | undefined;
+}
+
+export async function serveDaemonFileContent(
+  deps: LoggedWorkSessionDeps,
+  target: { hostId: string; path: string; rootPath?: string },
+  createResponse: (result: DaemonFileReadResult) => Response,
+): Promise<Response> {
+  const { hostId, ...file } = target;
+  try {
+    const result = await callHostRetryableOnlineRpc(deps, {
+      hostId,
+      timeoutMs: COMMAND_TIMEOUT_MS,
+      command: { type: "host.read_file", ...file },
+    });
+    return createResponse(result);
+  } catch (error) {
+    return remapDaemonFileRouteError(error);
+  }
 }
 
 function daemonFileEntityTag(result: DaemonFileReadResult): string {


### PR DESCRIPTION
## Human comments

## What was wrong

Markdown image URLs were only routed to host files when a caller supplied `linkRouting.localImage`. Assistant messages supplied it, but file previews and several other Markdown surfaces did not. Consequently, absolute host paths were requested from the app origin and relative paths were resolved against the SPA URL instead of the Markdown file's directory. For example, `docs/report.md` containing `![chart](images/chart.png)` should load `docs/images/chart.png`.

## What changed

- Share file-image routing across workspace, project, thread-host, host-scoped, and thread-storage previews. Resolve relative images from the Markdown directory using the existing local-path resolver, and use existing content endpoints for each source.
- Share lease routing with local skill previews and message routing across assistant, user, generated/system, and thread-context Plugin SDK Markdown. Preserve intentionally suppressed images and explicit caller routing overrides.
- Preserve existing root restrictions for scoped relative paths and existing trusted absolute-host access. These restrictions are endpoint constraints, not a sandbox for Markdown that can also reference absolute host paths.
- Consolidate seven backend file-serving handlers through one host-read/error-handling function, retaining their existing target selection, caching, HTML sandbox headers, and size limits.

No public plugin API, CLI, endpoint contract, or server/daemon wire behavior changes; no daemon protocol bump is needed.

## How you verified

- Added rendered-preview regression coverage for absolute and file-relative images, all five preview adapters, root escapes, explicit routing overrides, nested lease paths, user/system messages, Plugin SDK Markdown, and local skill files.
- `pnpm exec turbo run typecheck lint test --filter=@bb/app`: 481 test files passed; 3,890 tests passed and 3 skipped. App lint completed with 182 warnings and 0 errors.
- `pnpm exec turbo run typecheck lint --filter=@bb/server`: typecheck passed (the server package has no lint task).
- `pnpm exec turbo run test --filter=@bb/server -- test/hosts/daemon-file-response.test.ts test/files/host-file-routes.test.ts test/public/public-projects-local-host.test.ts test/public/public-project-workspace-routing.test.ts test/public/public-thread-data.test.ts`: 5 files / 100 tests passed, including byte responses, root propagation, host selection, validators, HTML policies, and error mapping.
- Rebuilt and started the final code with `pnpm start:worktree`; confirmed HTTP 200 and daemon connectivity. The dev QA thread has workspace and thread-storage fixtures; the other preview types are covered by automated tests, not completed manual demos.

No linked GitHub issue.

> AGENT GENERATED
