### PR TITLE
fix(provider-pi): surface Pi extension dialogs as answerable bb interactions

### DIFF
--- a/plugins/provider-pi/README.md
+++ b/plugins/provider-pi/README.md
@@ -15,6 +15,15 @@ What lives here:
 - `src/delta-translation.ts` — pi's session events become bb's thread deltas.
 - `src/bridge/provider-maintenance.ts` — the install gate (`pi --version`
   ≥ 0.84.0) and the npm install/update actions.
+- `src/bridge/extension-ui.ts` — pi extension dialogs reach the user:
+  `ctx.ui.select/confirm/input/editor` inside a pi extension arrive as pi RPC
+  `extension_ui_request` lines, the bridge forwards each dialog as a
+  `provider-pi/extension-ui` interaction request, and the plugin's pending
+  interaction renderer (`app.tsx`) shows it and returns the answer to pi.
+  Fire-and-forget requests (`notify`, `setStatus`, `setWidget`, `setTitle`,
+  `set_editor_text`) are accepted and dropped. A dialog left pending when the
+  session closes is answered cancelled. Requests that fail validation are
+  answered cancelled, never forwarded.
 
 ## Skills
 

--- a/plugins/provider-pi/README.md
+++ b/plugins/provider-pi/README.md
@@ -23,7 +23,9 @@ What lives here:
   Fire-and-forget requests (`notify`, `setStatus`, `setWidget`, `setTitle`,
   `set_editor_text`) are accepted and dropped. A dialog left pending when the
   session closes is answered cancelled. Requests that fail validation are
-  answered cancelled, never forwarded.
+  answered cancelled, never forwarded. Select answers must match an offered
+  option. Helper sessions without a dialog handler automatically cancel dialogs
+  so extensions cannot block helper startup waiting for user input.
 
 ## Skills
 

--- a/plugins/provider-pi/app.test.tsx
+++ b/plugins/provider-pi/app.test.tsx
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { loadPluginApp, renderSlot } from "@get-bb/plugin-sdk/testing/app";
+import { PI_EXTENSION_UI_KIND } from "./src/extension-ui-contract.js";
+
+const app = await loadPluginApp(() => import("./app"));
+
+afterEach(cleanup);
+
+function render(
+  data: unknown,
+  handlers: {
+    submit?: (value: unknown) => Promise<void>;
+    cancel?: () => Promise<void>;
+  } = {},
+  payload: unknown = data,
+) {
+  return renderSlot(app.pendingInteractions[0]!, {
+    interaction: {
+      id: "pint_test",
+      threadId: "thr_test",
+      title: "Allow access?",
+      payload: payload as never,
+      createdAt: 0,
+      expiresAt: null,
+    },
+    submit: handlers.submit ?? (async () => undefined),
+    cancel: handlers.cancel ?? (async () => undefined),
+  });
+}
+
+describe("pi extension ui interaction", () => {
+  it("submits the chosen option label for a select dialog", async () => {
+    const submit = vi.fn(async () => undefined);
+    const view = render(
+      { requestId: "ui-1", method: "select", options: ["Allow once", "Deny"] },
+      { submit },
+    );
+    fireEvent.click(view.getByText("Allow once"));
+    fireEvent.click(view.getByText("Submit"));
+    await vi.waitFor(() => expect(submit).toHaveBeenCalledWith("Allow once"));
+  });
+
+  it("keeps submit disabled until a select option is chosen", () => {
+    const view = render({
+      requestId: "ui-1",
+      method: "select",
+      options: ["A", "B"],
+    });
+    expect((view.getByText("Submit") as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.click(view.getByText("B"));
+    expect((view.getByText("Submit") as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("submits a boolean for a confirm dialog", async () => {
+    const submit = vi.fn(async () => undefined);
+    const view = render(
+      { requestId: "ui-2", method: "confirm", message: "This modifies files." },
+      { submit },
+    );
+    expect(view.getByText("This modifies files.")).toBeDefined();
+    fireEvent.click(view.getByText("No"));
+    await vi.waitFor(() => expect(submit).toHaveBeenCalledWith(false));
+  });
+
+  it("submits typed text for an input dialog", async () => {
+    const submit = vi.fn(async () => undefined);
+    const view = render(
+      { requestId: "ui-3", method: "input", placeholder: "type here" },
+      { submit },
+    );
+    fireEvent.change(view.getByPlaceholderText("type here"), {
+      target: { value: "hello" },
+    });
+    fireEvent.click(view.getByText("Submit"));
+    await vi.waitFor(() => expect(submit).toHaveBeenCalledWith("hello"));
+  });
+
+  it("renders editor prefill and submits the edited text", async () => {
+    const submit = vi.fn(async () => undefined);
+    const view = render(
+      { requestId: "ui-4", method: "editor", prefill: "line one" },
+      { submit },
+    );
+    const editor = view.container.querySelector("textarea")!;
+    fireEvent.change(editor, { target: { value: "line one\nline two" } });
+    fireEvent.click(view.getByText("Submit"));
+    await vi.waitFor(() =>
+      expect(submit).toHaveBeenCalledWith("line one\nline two"),
+    );
+  });
+
+  it("renders the unwrapped payload the host passes to plugin components", async () => {
+    const submit = vi.fn(async () => undefined);
+    const view = render(
+      { requestId: "ui-1", method: "select", options: ["Allow once", "Keep blocked"] },
+      { submit },
+    );
+    fireEvent.click(view.getByText("Allow once"));
+    fireEvent.click(view.getByText("Submit"));
+    await vi.waitFor(() => expect(submit).toHaveBeenCalledWith("Allow once"));
+  });
+
+  it("still renders the wrapped stored-payload shape for robustness", async () => {
+    const submit = vi.fn(async () => undefined);
+    const view = render(
+      undefined,
+      { submit },
+      {
+        kind: PI_EXTENSION_UI_KIND,
+        title: "Allow access?",
+        data: { requestId: "ui-1", method: "select", options: ["A"] },
+      },
+    );
+    fireEvent.click(view.getByText("A"));
+    fireEvent.click(view.getByText("Submit"));
+    await vi.waitFor(() => expect(submit).toHaveBeenCalledWith("A"));
+  });
+
+  it("offers cancel for an unrenderable payload", async () => {
+    const cancel = vi.fn(async () => undefined);
+    const view = render({ broken: true }, { cancel });
+    expect(view.getByText(/could not be displayed/)).toBeDefined();
+    fireEvent.click(view.getByText("Cancel"));
+    await vi.waitFor(() => expect(cancel).toHaveBeenCalled());
+  });
+
+  it("offers cancel for a rendered dialog", async () => {
+    const cancel = vi.fn(async () => undefined);
+    const view = render(
+      { requestId: "ui-1", method: "select", options: ["A"] },
+      { cancel },
+    );
+    fireEvent.click(view.getByText("Cancel"));
+    await vi.waitFor(() => expect(cancel).toHaveBeenCalled());
+  });
+});

--- a/plugins/provider-pi/app.tsx
+++ b/plugins/provider-pi/app.tsx
@@ -1,0 +1,162 @@
+import { useMemo, useState, type FormEvent } from "react";
+import {
+  definePluginApp,
+  type PluginPendingInteractionProps,
+} from "@get-bb/plugin-sdk/app";
+import { Button } from "@bb/shared-ui/button";
+import { cn } from "@bb/shared-ui/lib/utils";
+import {
+  PI_EXTENSION_UI_RENDERER_ID,
+  piExtensionUiPayloadDataSchema,
+  type PiExtensionUiMethod,
+} from "./src/extension-ui-contract.js";
+
+interface ParsedRequest {
+  requestId: string;
+  method: PiExtensionUiMethod;
+  options?: string[];
+  message?: string;
+  placeholder?: string;
+  prefill?: string;
+}
+
+function parseRequest(payload: unknown): ParsedRequest | null {
+  if (typeof payload !== "object" || payload === null) return null;
+  const direct = piExtensionUiPayloadDataSchema.safeParse(payload);
+  if (direct.success) return direct.data;
+  const data = (payload as { data?: unknown }).data;
+  const wrapped = piExtensionUiPayloadDataSchema.safeParse(data);
+  return wrapped.success ? wrapped.data : null;
+}
+
+function ExtensionUiInteraction({
+  interaction,
+  submit,
+  cancel,
+}: PluginPendingInteractionProps) {
+  const request = useMemo(() => parseRequest(interaction.payload), [interaction.payload]);
+  const [text, setText] = useState(request?.prefill ?? "");
+  const [selected, setSelected] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  if (!request) {
+    return (
+      <div className="space-y-3 text-xs text-muted-foreground">
+        <p>This request could not be displayed.</p>
+        <Button type="button" size="sm" variant="outline" onClick={() => void cancel()}>
+          Cancel
+        </Button>
+      </div>
+    );
+  }
+
+  const finish = (value: unknown) => {
+    if (busy) return;
+    setBusy(true);
+    void (async () => {
+      try {
+        await submit(value as never);
+      } catch {
+      } finally {
+        setBusy(false);
+      }
+    })();
+  };
+
+  const onSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    if (request.method === "confirm") return;
+    if (request.method === "select") {
+      if (selected !== null) finish(selected);
+      return;
+    }
+    finish(text);
+  };
+
+  return (
+    <form
+      onSubmit={onSubmit}
+      className="flex flex-col gap-3 text-xs text-muted-foreground"
+    >
+      {request.message ? <p className="text-sm text-foreground">{request.message}</p> : null}
+      {request.method === "select" ? (
+        <fieldset className="flex flex-col gap-1.5" disabled={busy}>
+          {(request.options ?? []).map((option) => (
+            <label
+              key={option}
+              className={cn(
+                "flex cursor-pointer items-center gap-2 rounded-md border border-border px-3 py-2 text-sm text-foreground",
+                selected === option && "border-ring bg-surface-raised",
+              )}
+            >
+              <input
+                type="radio"
+                name={request.requestId}
+                className="size-3.5"
+                checked={selected === option}
+                onChange={() => setSelected(option)}
+              />
+              <span>{option}</span>
+            </label>
+          ))}
+        </fieldset>
+      ) : null}
+      {request.method === "input" ? (
+        <input
+          type="text"
+          className="w-full rounded-md border border-border bg-surface-raised px-3 py-2 text-sm text-foreground focus-visible:border-ring/50 focus-visible:outline-none"
+          value={text}
+          placeholder={request.placeholder}
+          autoFocus
+          disabled={busy}
+          onChange={(event) => setText(event.target.value)}
+        />
+      ) : null}
+      {request.method === "editor" ? (
+        <textarea
+          className="min-h-32 w-full resize-y rounded-md border border-border bg-surface-raised px-3 py-2 font-mono text-sm text-foreground focus-visible:border-ring/50 focus-visible:outline-none"
+          value={text}
+          disabled={busy}
+          onChange={(event) => setText(event.target.value)}
+        />
+      ) : null}
+      {request.method === "confirm" ? (
+        <div className="flex items-center justify-end gap-2">
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            disabled={busy}
+            onClick={() => finish(false)}
+          >
+            No
+          </Button>
+          <Button type="button" size="sm" disabled={busy} onClick={() => finish(true)}>
+            Yes
+          </Button>
+        </div>
+      ) : null}
+      {request.method !== "confirm" ? (
+        <div className="flex items-center justify-between gap-2">
+          <Button type="button" size="sm" variant="ghost" disabled={busy} onClick={() => void cancel()}>
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            size="sm"
+            disabled={busy || (request.method === "select" && selected === null)}
+          >
+            Submit
+          </Button>
+        </div>
+      ) : null}
+    </form>
+  );
+}
+
+export default definePluginApp((app) => {
+  app.slots.pendingInteraction({
+    id: PI_EXTENSION_UI_RENDERER_ID,
+    component: ExtensionUiInteraction,
+  });
+});

--- a/plugins/provider-pi/package.json
+++ b/plugins/provider-pi/package.json
@@ -14,7 +14,8 @@
       "icon": "./icons/pi.svg"
     },
     "server": "./server.ts",
-    "host": "./src/host.ts"
+    "host": "./src/host.ts",
+    "app": "./app.tsx"
   },
   "keywords": [
     "bb-plugin"
@@ -23,19 +24,25 @@
     "test": "vitest run --config vitest.config.ts",
     "typecheck": "tsc --noEmit"
   },
+  "dependencies": {
+    "@bb/shared-ui": "workspace:*",
+    "@get-bb/plugin-sdk": "workspace:*",
+    "zod": "^4.3.6"
+  },
   "devDependencies": {
     "@bb/domain": "workspace:*",
     "@bb/provider-bridge-protocol": "workspace:*",
     "@earendil-works/pi-ai": "0.84.0",
     "@earendil-works/pi-coding-agent": "0.84.0",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^22.0.0",
-    "typescript": "npm:@typescript/typescript6@^6.0.2",
+    "@types/react": "^19.0.0",
+    "jsdom": "^29.0.1",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "typebox": "1.3.7",
+    "typescript": "npm:@typescript/typescript6@^6.0.2",
     "typescript-7": "npm:typescript@^7.0.2",
     "vitest": "^4.1.1"
-  },
-  "dependencies": {
-    "@get-bb/plugin-sdk": "workspace:*",
-    "zod": "^4.3.6"
   }
 }

--- a/plugins/provider-pi/src/bridge/bridge.ts
+++ b/plugins/provider-pi/src/bridge/bridge.ts
@@ -52,6 +52,11 @@ import {
 } from "../session-params.js";
 import { BB_PI_EXTENSION_SOURCE } from "./bb-pi-extension.js";
 import {
+  createExtensionUiCoordinator,
+  type ExtensionUiCoordinator,
+} from "./extension-ui.js";
+import { type InteractionUiRequest } from "../extension-ui-contract.js";
+import {
   getPiInstallGate,
   getPiProviderInstallationRun,
   getPiProviderInstallationStatus,
@@ -200,13 +205,17 @@ let sessionSerialCounter = 0;
 const THREAD_STOP_CLOSE_TIMEOUT_MS = 8_000;
 
 const { send, sendResult, sendError } = createBridgeIo<
-  BridgeEventNotification | BridgeToolCallRequest
+  BridgeEventNotification | BridgeToolCallRequest | InteractionUiRequest
 >();
 
 const sessions = new Map<string, ThreadSession>();
 const closingSessions = new Map<string, Promise<string | undefined>>();
 const { forwardToolCall, handleToolCallResponse, resolvePendingToolCalls } =
   createPendingToolCallTracker({ sendToolCall: send });
+
+const extensionUi: ExtensionUiCoordinator = createExtensionUiCoordinator({
+  sendInteractionRequest: send,
+});
 
 let configuredSkillPaths: string[] | null = null;
 
@@ -274,6 +283,7 @@ async function closeThreadSession(args: {
   }
   threadSession.closing = true;
   resolvePendingToolCalls(threadSession, args.message);
+  extensionUi.cancelPendingForScope(threadSession);
   const closePromise = Promise.resolve()
     .then(() =>
       threadSession.session.closeGracefully(THREAD_STOP_CLOSE_TIMEOUT_MS),
@@ -416,6 +426,23 @@ function createOnPiEvent(
     if (event.type === "turn_end" || event.type === "compaction_end") {
       emitContextWindowUsage(args.threadId);
     }
+  };
+}
+
+function createOnExtensionUiRequest(
+  args: CurrentThreadSessionArgs,
+): (request: Record<string, unknown>) => void {
+  return (request) => {
+    const threadSession = getCurrentThreadSession(args);
+    if (!threadSession || threadSession.closing) return;
+    extensionUi.handle({
+      scope: threadSession,
+      request,
+      threadId: args.threadId,
+      providerThreadId: threadSession.providerThreadId,
+      respond: (requestId, fields) =>
+        threadSession.session.respondToExtensionUi(requestId, fields),
+    });
   };
 }
 
@@ -699,6 +726,7 @@ async function buildSessionOptions(args: {
   params: PiSessionParams;
   providerThreadId: string;
   threadId: string;
+  sessionSerial: number;
 }): Promise<PiRpcSessionOptions> {
   return {
     cwd: args.params.cwd,
@@ -725,6 +753,10 @@ async function buildSessionOptions(args: {
     scratchDir: requireScratchDir(),
     extensionPath: requireExtensionPath(),
     recordThreadId: args.threadId,
+    onExtensionUiRequest: createOnExtensionUiRequest({
+      sessionSerial: args.sessionSerial,
+      threadId: args.threadId,
+    }),
   };
 }
 
@@ -738,6 +770,7 @@ async function constructPiThreadSession(
     params,
     providerThreadId,
     threadId,
+    sessionSerial,
   });
   const session = new PiRpcSession(
     sessionOptions,
@@ -802,6 +835,7 @@ function retireReplacedPiChild(replaced: ThreadSession): void {
     replaced,
     "Pi thread session replaced while tool call was pending",
   );
+  extensionUi.cancelPendingForScope(replaced);
   void replaced.session
     .closeGracefully(THREAD_STOP_CLOSE_TIMEOUT_MS)
     .catch(() => undefined);
@@ -1189,8 +1223,13 @@ function extractInput(input: TurnStartParams["input"]): ExtractedInput {
 
 function handleParsedMessage(parsed: unknown): void {
   const response = decodeBridgeJsonRpcResponse(parsed);
-  if (response && handleToolCallResponse(response)) {
-    return;
+  if (response) {
+    if (extensionUi.handleRuntimeResponse(response)) {
+      return;
+    }
+    if (handleToolCallResponse(response)) {
+      return;
+    }
   }
   const decoded = decodePiJsonRpcRequest(parsed);
   if (decoded.kind === "ignored") {

--- a/plugins/provider-pi/src/bridge/extension-ui.test.ts
+++ b/plugins/provider-pi/src/bridge/extension-ui.test.ts
@@ -1,0 +1,209 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { handleLine } from "./bridge.js";
+import {
+  FULL_PERMISSION_OPTIONS,
+  type FakePiBridgeHarness,
+  startFakePiBridge,
+} from "./test-support.js";
+
+let harness: FakePiBridgeHarness;
+let nextId = 2000;
+
+beforeEach(async () => {
+  harness = await startFakePiBridge({
+    prefix: "bb-pi-ext-ui-",
+    initialize: true,
+    processLog: true,
+  });
+});
+
+afterEach(async () => {
+  await harness.teardown();
+});
+
+function turnStart(threadId: string, text: string): void {
+  handleLine(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      id: (nextId += 1),
+      method: "turn/start",
+      params: {
+        threadId,
+        providerThreadId: threadId,
+        clientRequestId: "creq_ui23456789",
+        input: [{ type: "text", text, mentions: [] }],
+        options: FULL_PERMISSION_OPTIONS,
+      },
+    }),
+  );
+}
+
+interface InteractionRequest {
+  id: string | number;
+  params: {
+    providerThreadId: string;
+    threadId: string;
+    payload: {
+      kind: string;
+      title: string;
+      data: {
+        requestId: string;
+        method: string;
+        options?: string[];
+        message?: string;
+        placeholder?: string;
+        prefill?: string;
+      };
+    };
+  };
+}
+
+async function waitForInteractionRequest(
+  threadId: string,
+): Promise<InteractionRequest> {
+  return (await harness.waitForMessage(
+    (message) =>
+      message.method === "interaction/request" &&
+      JSON.stringify(message.params ?? {}).includes(threadId),
+    `the interaction/request for ${threadId}`,
+  )) as unknown as InteractionRequest;
+}
+
+function resolveInteraction(
+  interactionId: string | number,
+  result: unknown,
+): void {
+  handleLine(JSON.stringify({ jsonrpc: "2.0", id: interactionId, result }));
+}
+
+async function extensionUiReplyOf(threadId: string): Promise<string> {
+  await harness.waitForTurnBoundary(threadId);
+  const textDeltas = harness
+    .deltasOf(threadId)
+    .filter((delta) => delta.kind === "item.textDelta")
+    .map((delta) => String(delta.text))
+    .join("");
+  return textDeltas;
+}
+
+it("forwards a select dialog to the runtime and returns the chosen option to pi", async () => {
+  const threadId = "thr_ui_select";
+  await harness.startThread(threadId);
+  turnStart(
+    threadId,
+    '/ui {"method":"select","title":"Allow access?","options":["Allow once","Deny"]}',
+  );
+  const interaction = await waitForInteractionRequest(threadId);
+  expect(interaction.params.payload.kind).toBe("provider-pi/extension-ui");
+  expect(interaction.params.payload.title).toBe("Allow access?");
+  expect(interaction.params.payload.data.method).toBe("select");
+  expect(interaction.params.payload.data.options).toEqual([
+    "Allow once",
+    "Deny",
+  ]);
+  resolveInteraction(interaction.id, {
+    kind: "request_answer",
+    value: "Allow once",
+  });
+  expect(await extensionUiReplyOf(threadId)).toContain(
+    '"value":"Allow once"',
+  );
+}, 90_000);
+
+it("maps a boolean answer to confirmed for a confirm dialog", async () => {
+  const threadId = "thr_ui_confirm";
+  await harness.startThread(threadId);
+  turnStart(
+    threadId,
+    '/ui {"method":"confirm","title":"Run command?","message":"This modifies files."}',
+  );
+  const interaction = await waitForInteractionRequest(threadId);
+  expect(interaction.params.payload.data.method).toBe("confirm");
+  expect(interaction.params.payload.data.message).toBe(
+    "This modifies files.",
+  );
+  resolveInteraction(interaction.id, { kind: "request_answer", value: true });
+  expect(await extensionUiReplyOf(threadId)).toContain('"confirmed":true');
+}, 90_000);
+
+it("answers a select with a value the user never chose as cancelled", async () => {
+  const threadId = "thr_ui_badvalue";
+  await harness.startThread(threadId);
+  turnStart(
+    threadId,
+    '/ui {"method":"select","title":"Pick","options":["A","B"]}',
+  );
+  const interaction = await waitForInteractionRequest(threadId);
+  resolveInteraction(interaction.id, { kind: "request_answer", value: 42 });
+  expect(await extensionUiReplyOf(threadId)).toContain('"cancelled":true');
+}, 90_000);
+
+it("answers an interaction error as cancelled", async () => {
+  const threadId = "thr_ui_error";
+  await harness.startThread(threadId);
+  turnStart(threadId, '/ui {"method":"input","title":"Enter a value"}');
+  const interaction = await waitForInteractionRequest(threadId);
+  handleLine(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      id: interaction.id,
+      error: { code: -32000, message: "interaction cancelled" },
+    }),
+  );
+  expect(await extensionUiReplyOf(threadId)).toContain('"cancelled":true');
+}, 90_000);
+
+it("cancels a pending dialog when the thread is stopped mid-prompt", async () => {
+  const threadId = "thr_ui_stop";
+  const uiLogPath = join(harness.workspaceDir, "ui.log");
+  vi.stubEnv("FAKE_PI_UI_LOG", uiLogPath);
+  await harness.startThread(threadId);
+  turnStart(
+    threadId,
+    '/ui {"method":"select","title":"Pick","options":["A","B"]}',
+  );
+  const interaction = await waitForInteractionRequest(threadId);
+  const stopResponse = await harness.request((nextId += 1), "thread/stop", {
+    threadId,
+    providerThreadId: threadId,
+    intent: "interrupt",
+    activeTurnId: null,
+  });
+  expect(stopResponse.result).toMatchObject({ ok: true });
+  const response = JSON.parse(readFileSync(uiLogPath, "utf8"));
+  expect(response).toMatchObject({
+    id: interaction.params.payload.data.requestId,
+    cancelled: true,
+  });
+  vi.unstubAllEnvs();
+}, 90_000);
+
+it("answers an invalid dialog request cancelled instead of forwarding it", async () => {
+  const threadId = "thr_ui_invalid";
+  await harness.startThread(threadId);
+  turnStart(threadId, '/ui {"method":"select","title":"Pick"}');
+  await harness.waitForTurnBoundary(threadId);
+  expect(
+    harness.messages.some(
+      (message) =>
+        message.method === "interaction/request" &&
+        JSON.stringify(message.params ?? {}).includes(threadId),
+    ),
+  ).toBe(false);
+}, 90_000);
+
+it("drops fire-and-forget extension ui requests without a runtime round trip", async () => {
+  const threadId = "thr_ui_notify";
+  await harness.startThread(threadId);
+  turnStart(threadId, '/ui {"method":"notify","title":"Ignored"}');
+  await harness.waitForTurnBoundary(threadId);
+  expect(
+    harness.messages.some(
+      (message) =>
+        message.method === "interaction/request" &&
+        JSON.stringify(message.params ?? {}).includes(threadId),
+    ),
+  ).toBe(false);
+}, 90_000);

--- a/plugins/provider-pi/src/bridge/extension-ui.test.ts
+++ b/plugins/provider-pi/src/bridge/extension-ui.test.ts
@@ -128,17 +128,21 @@ it("maps a boolean answer to confirmed for a confirm dialog", async () => {
   expect(await extensionUiReplyOf(threadId)).toContain('"confirmed":true');
 }, 90_000);
 
-it("answers a select with a value the user never chose as cancelled", async () => {
-  const threadId = "thr_ui_badvalue";
-  await harness.startThread(threadId);
-  turnStart(
-    threadId,
-    '/ui {"method":"select","title":"Pick","options":["A","B"]}',
-  );
-  const interaction = await waitForInteractionRequest(threadId);
-  resolveInteraction(interaction.id, { kind: "request_answer", value: 42 });
-  expect(await extensionUiReplyOf(threadId)).toContain('"cancelled":true');
-}, 90_000);
+it.each([42, "not-an-option"])(
+  "answers an invalid select value %j as cancelled",
+  async (value) => {
+    const threadId = "thr_ui_badvalue";
+    await harness.startThread(threadId);
+    turnStart(
+      threadId,
+      '/ui {"method":"select","title":"Pick","options":["A","B"]}',
+    );
+    const interaction = await waitForInteractionRequest(threadId);
+    resolveInteraction(interaction.id, { kind: "request_answer", value });
+    expect(await extensionUiReplyOf(threadId)).toContain('"cancelled":true');
+  },
+  90_000,
+);
 
 it("answers an interaction error as cancelled", async () => {
   const threadId = "thr_ui_error";

--- a/plugins/provider-pi/src/bridge/extension-ui.ts
+++ b/plugins/provider-pi/src/bridge/extension-ui.ts
@@ -1,0 +1,148 @@
+import {
+  PI_EXTENSION_UI_KIND,
+  piExtensionUiPayloadDataSchema,
+  piExtensionUiRequestSchema,
+  piExtensionUiResolutionSchema,
+  resolveExtensionUiResponseFields,
+  type InteractionUiRequest,
+  type PiExtensionUiMethod,
+  type PiExtensionUiRequest,
+  type PiExtensionUiResponseFields,
+  type RuntimeInteractionUiResponse,
+} from "../extension-ui-contract.js";
+
+const FIRE_AND_FORGET_METHODS = new Set([
+  "notify",
+  "setStatus",
+  "setWidget",
+  "setTitle",
+  "set_editor_text",
+]);
+
+interface PendingExtensionUiRequest {
+  scope: object;
+  method: PiExtensionUiMethod;
+  piRequestId: string | number;
+  respond: (
+    requestId: string | number,
+    fields: PiExtensionUiResponseFields,
+  ) => void;
+}
+
+export interface ExtensionUiCoordinatorOptions {
+  sendInteractionRequest: (request: InteractionUiRequest) => void;
+}
+
+export interface HandleExtensionUiRequestArgs {
+  scope: object;
+  request: Record<string, unknown>;
+  threadId: string;
+  providerThreadId: string;
+  respond: (
+    requestId: string | number,
+    fields: PiExtensionUiResponseFields,
+  ) => void;
+}
+
+export interface ExtensionUiCoordinator {
+  handle(args: HandleExtensionUiRequestArgs): void;
+  handleRuntimeResponse(response: RuntimeInteractionUiResponse): boolean;
+  cancelPendingForScope(scope: object): void;
+}
+
+function rawMethod(request: Record<string, unknown>): unknown {
+  return request.method;
+}
+
+function rawId(request: Record<string, unknown>): string | number | null {
+  const id = request.id;
+  return typeof id === "string" || typeof id === "number" ? id : null;
+}
+
+export function createExtensionUiCoordinator(
+  options: ExtensionUiCoordinatorOptions,
+): ExtensionUiCoordinator {
+  const pending = new Map<string, PendingExtensionUiRequest>();
+  let nextRequestId = 0;
+
+  return {
+    handle(args) {
+      if (FIRE_AND_FORGET_METHODS.has(String(rawMethod(args.request)))) {
+        return;
+      }
+      const parsed = piExtensionUiRequestSchema.safeParse(args.request);
+      if (!parsed.success) {
+        const id = rawId(args.request);
+        if (id !== null) {
+          args.respond(id, { cancelled: true });
+        }
+        return;
+      }
+      const request: PiExtensionUiRequest = parsed.data;
+      const data = piExtensionUiPayloadDataSchema.parse({
+        requestId: String(request.id),
+        method: request.method,
+        ...(request.options ? { options: request.options } : {}),
+        ...(request.message !== undefined ? { message: request.message } : {}),
+        ...(request.placeholder !== undefined
+          ? { placeholder: request.placeholder }
+          : {}),
+        ...(request.prefill !== undefined ? { prefill: request.prefill } : {}),
+      });
+      nextRequestId += 1;
+      const interactionId = `pi-ui-${nextRequestId}`;
+      pending.set(interactionId, {
+        scope: args.scope,
+        method: request.method,
+        piRequestId: request.id,
+        respond: args.respond,
+      });
+      try {
+        options.sendInteractionRequest({
+          jsonrpc: "2.0",
+          id: interactionId,
+          method: "interaction/request",
+          params: {
+            providerThreadId: args.providerThreadId,
+            threadId: args.threadId,
+            turnId: null,
+            payload: {
+              kind: PI_EXTENSION_UI_KIND,
+              title: request.title,
+              data,
+            },
+          },
+        });
+      } catch {
+        pending.delete(interactionId);
+        args.respond(request.id, { cancelled: true });
+      }
+    },
+
+    handleRuntimeResponse(response) {
+      const entry = pending.get(String(response.id));
+      if (!entry) {
+        return false;
+      }
+      pending.delete(String(response.id));
+      const parsed = piExtensionUiResolutionSchema.safeParse(response.result);
+      entry.respond(
+        entry.piRequestId,
+        parsed.success
+          ? resolveExtensionUiResponseFields(entry.method, parsed.data)
+          : { cancelled: true },
+      );
+      return true;
+    },
+
+    cancelPendingForScope(scope) {
+      for (const [interactionId, entry] of pending) {
+        if (entry.scope !== scope) {
+          continue;
+        }
+        pending.delete(interactionId);
+        entry.respond(entry.piRequestId, { cancelled: true });
+      }
+    },
+  };
+}

--- a/plugins/provider-pi/src/bridge/extension-ui.ts
+++ b/plugins/provider-pi/src/bridge/extension-ui.ts
@@ -5,7 +5,6 @@ import {
   piExtensionUiResolutionSchema,
   resolveExtensionUiResponseFields,
   type InteractionUiRequest,
-  type PiExtensionUiMethod,
   type PiExtensionUiRequest,
   type PiExtensionUiResponseFields,
   type RuntimeInteractionUiResponse,
@@ -21,8 +20,7 @@ const FIRE_AND_FORGET_METHODS = new Set([
 
 interface PendingExtensionUiRequest {
   scope: object;
-  method: PiExtensionUiMethod;
-  piRequestId: string | number;
+  request: PiExtensionUiRequest;
   respond: (
     requestId: string | number,
     fields: PiExtensionUiResponseFields,
@@ -93,8 +91,7 @@ export function createExtensionUiCoordinator(
       const interactionId = `pi-ui-${nextRequestId}`;
       pending.set(interactionId, {
         scope: args.scope,
-        method: request.method,
-        piRequestId: request.id,
+        request,
         respond: args.respond,
       });
       try {
@@ -127,9 +124,9 @@ export function createExtensionUiCoordinator(
       pending.delete(String(response.id));
       const parsed = piExtensionUiResolutionSchema.safeParse(response.result);
       entry.respond(
-        entry.piRequestId,
+        entry.request.id,
         parsed.success
-          ? resolveExtensionUiResponseFields(entry.method, parsed.data)
+          ? resolveExtensionUiResponseFields(entry.request, parsed.data)
           : { cancelled: true },
       );
       return true;
@@ -141,7 +138,7 @@ export function createExtensionUiCoordinator(
           continue;
         }
         pending.delete(interactionId);
-        entry.respond(entry.piRequestId, { cancelled: true });
+        entry.respond(entry.request.id, { cancelled: true });
       }
     },
   };

--- a/plugins/provider-pi/src/bridge/fake-pi-rpc.mjs
+++ b/plugins/provider-pi/src/bridge/fake-pi-rpc.mjs
@@ -190,6 +190,8 @@ let holdAbort = null;
 const followUp = [];
 /** Steering queue: steers that arrived while a run was live. */
 const steering = [];
+/** Extension UI dialogs awaiting the host's extension_ui_response. */
+const extensionUiWaiters = new Map();
 let endedWithStreamingFlag = false;
 
 /** A line held back to go out in one write with the next one. */
@@ -358,6 +360,54 @@ async function runPrompt(text) {
   if (text === "/die") {
     // Mid-run death without an answer: the bridge's next write hits EPIPE.
     process.exit(0);
+  }
+  const uiMatch = text.match(/^\/ui (\{.*\})$/su);
+  if (uiMatch) {
+    const spec = JSON.parse(uiMatch[1]);
+    const uiId = `ui-${turnCounter}`;
+    const fireAndForget = [
+      "notify",
+      "setStatus",
+      "setWidget",
+      "setTitle",
+      "set_editor_text",
+    ].includes(spec.method);
+    const response = fireAndForget
+      ? null
+      : await new Promise((resolve) => {
+          extensionUiWaiters.set(uiId, resolve);
+          send({
+            type: "extension_ui_request",
+            id: uiId,
+            method: spec.method,
+            title: spec.title,
+            ...(spec.options ? { options: spec.options } : {}),
+            ...(spec.message ? { message: spec.message } : {}),
+            ...(spec.placeholder ? { placeholder: spec.placeholder } : {}),
+            ...(spec.prefill ? { prefill: spec.prefill } : {}),
+          });
+        });
+    const reply = `UI said: ${JSON.stringify(response)}`;
+    const assistant = {
+      role: "assistant",
+      content: [{ type: "text", text: reply }],
+      provider: model.provider,
+      model: model.id,
+      usage: { input: 12, output: 5, totalTokens: 17 },
+      stopReason: "stop",
+    };
+    event({ type: "message_start", message: { role: "assistant", content: [] } });
+    event({ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: reply, contentIndex: 0 }, message: assistant });
+    event({ type: "message_end", message: assistant });
+    event({ type: "turn_end", message: assistant, toolResults: [] });
+    tokens += 17;
+    leafCounter += 1;
+    leafId = `leaf-${leafCounter}`;
+    const messages = [{ role: "user", content: text }, assistant];
+    await emitExtensionEvent("agent_end", { messages });
+    event({ type: "agent_end", messages });
+    isStreaming = false;
+    return;
   }
   let toolResultText = "";
   const toolMatch = text.match(/^\/tool (\S+) ?(.*)$/su);
@@ -572,6 +622,16 @@ readLines(process.stdin, (line) => {
   try {
     command = JSON.parse(trimmed);
   } catch {
+    return;
+  }
+  if (command.type === "extension_ui_response") {
+    const waiter = extensionUiWaiters.get(command.id);
+    extensionUiWaiters.delete(command.id);
+    const uiLogPath = process.env.FAKE_PI_UI_LOG;
+    if (uiLogPath) {
+      appendFileSync(uiLogPath, `${JSON.stringify(command)}\n`);
+    }
+    waiter?.(command);
     return;
   }
   // Commands are handled in order, but `prompt` runs its scripted turn

--- a/plugins/provider-pi/src/bridge/rpc-child.extension-ui.test.ts
+++ b/plugins/provider-pi/src/bridge/rpc-child.extension-ui.test.ts
@@ -1,0 +1,114 @@
+import { expect, it, vi } from "vitest";
+import { PiRpcChild } from "./rpc-child.js";
+
+function childScript(script: string): { command: string; args: string[] } {
+  return { command: process.execPath, args: ["-e", script] };
+}
+
+it("auto-cancels extension ui requests when no handler is installed", async () => {
+  vi.stubEnv(
+    "BB_PI_BRIDGE_COMMAND",
+    process.execPath,
+  );
+  vi.stubEnv(
+    "BB_PI_BRIDGE_ARGS",
+    JSON.stringify([
+      "-e",
+      [
+        "process.stdin.setEncoding('utf8');",
+        "let input='';",
+        "process.stdin.on('data', (chunk) => {",
+        "  input += chunk;",
+        "  const newline = input.indexOf('\\n');",
+        "  if (newline < 0) return;",
+        "  process.stdout.write(JSON.stringify({ type: 'probe_result', response: JSON.parse(input.slice(0, newline)) }) + '\\n');",
+        "  process.exit();",
+        "});",
+        "process.stdout.write(JSON.stringify({ type: 'extension_ui_request', id: 'ui-1', method: 'select', title: 'Allow?', options: ['Allow'] }) + '\\n');",
+      ].join("\n"),
+    ]),
+  );
+  const events: Record<string, unknown>[] = [];
+  const child = new PiRpcChild({
+    cwd: process.cwd(),
+    env: process.env,
+    args: [],
+    recordThreadId: null,
+    onEvent: (event) => events.push(event),
+    onChannelMessage: () => undefined,
+    onExit: () => undefined,
+  });
+  await child.waitForExit();
+  const probe = events.find((event) => event.type === "probe_result");
+  expect(probe).toMatchObject({
+    response: { type: "extension_ui_response", id: "ui-1", cancelled: true },
+  });
+  vi.unstubAllEnvs();
+});
+
+it("forwards extension ui requests to the installed handler", async () => {
+  const forwarded: Record<string, unknown>[] = [];
+  const script = [
+    "process.stdout.write(JSON.stringify({ type: 'extension_ui_request', id: 'ui-2', method: 'confirm', title: 'Go?' }) + '\\n');",
+    "setTimeout(() => process.exit(), 50);",
+  ].join("\n");
+  const { command, args } = childScript(script);
+  vi.stubEnv("BB_PI_BRIDGE_COMMAND", command);
+  vi.stubEnv("BB_PI_BRIDGE_ARGS", JSON.stringify(args));
+  const child = new PiRpcChild({
+    cwd: process.cwd(),
+    env: process.env,
+    args: [],
+    recordThreadId: null,
+    onEvent: () => undefined,
+    onChannelMessage: () => undefined,
+    onExit: () => undefined,
+    onExtensionUiRequest: (request) => forwarded.push(request),
+  });
+  await child.waitForExit();
+  expect(forwarded).toEqual([
+    { type: "extension_ui_request", id: "ui-2", method: "confirm", title: "Go?" },
+  ]);
+  vi.unstubAllEnvs();
+});
+
+it("respondToExtensionUi writes the response line to pi stdin", async () => {
+  vi.stubEnv("BB_PI_BRIDGE_COMMAND", process.execPath);
+  vi.stubEnv(
+    "BB_PI_BRIDGE_ARGS",
+    JSON.stringify([
+      "-e",
+      [
+        "process.stdin.setEncoding('utf8');",
+        "let input='';",
+        "process.stdin.on('data', (chunk) => {",
+        "  input += chunk;",
+        "  const newline = input.indexOf('\\n');",
+        "  if (newline < 0) return;",
+        "  process.stdout.write(JSON.stringify({ type: 'probe_result', response: JSON.parse(input.slice(0, newline)) }) + '\\n');",
+        "  process.exit();",
+        "});",
+        "process.stdout.write(JSON.stringify({ type: 'extension_ui_request', id: 7, method: 'select', title: 'Allow?', options: ['Allow'] }) + '\\n');",
+      ].join("\n"),
+    ]),
+  );
+  const events: Record<string, unknown>[] = [];
+  const child = new PiRpcChild({
+    cwd: process.cwd(),
+    env: process.env,
+    args: [],
+    recordThreadId: null,
+    onEvent: (event) => events.push(event),
+    onChannelMessage: () => undefined,
+    onExit: () => undefined,
+    onExtensionUiRequest: (request) => {
+      child.respondToExtensionUi(request.id as string, { value: "Allow" });
+    },
+  });
+  await child.waitForExit();
+  const probe = events.find((event) => event.type === "probe_result");
+  expect(probe).toMatchObject({
+    response: { type: "extension_ui_response", id: 7, value: "Allow" },
+  });
+  vi.unstubAllEnvs();
+});

--- a/plugins/provider-pi/src/bridge/rpc-child.ts
+++ b/plugins/provider-pi/src/bridge/rpc-child.ts
@@ -43,6 +43,7 @@ export interface SpawnPiRpcChildArgs {
   onChannelMessage: (message: Record<string, unknown>) => void;
   onExit: (info: PiRpcChildExitInfo) => void;
   recordThreadId: string | null;
+  onExtensionUiRequest?: (request: Record<string, unknown>) => void;
 }
 
 export class PiRpcChildExitedError extends Error {
@@ -280,6 +281,15 @@ export class PiRpcChild {
     this.child.kill("SIGTERM");
   }
 
+  respondToExtensionUi(
+    id: string | number,
+    fields: Record<string, unknown>,
+  ): void {
+    this.writeStdin(
+      `${JSON.stringify({ type: "extension_ui_response", id, ...fields })}\n`,
+    );
+  }
+
   private endWriters(): void {
     try {
       this.child.stdin?.end();
@@ -345,13 +355,17 @@ export class PiRpcChild {
       return;
     }
     if (message.type === "extension_ui_request") {
-      this.writeStdin(
-        `${JSON.stringify({
-          type: "extension_ui_response",
-          id: message.id,
-          cancelled: true,
-        })}\n`,
-      );
+      if (this.args.onExtensionUiRequest) {
+        this.args.onExtensionUiRequest(message);
+      } else {
+        this.writeStdin(
+          `${JSON.stringify({
+            type: "extension_ui_response",
+            id: message.id,
+            cancelled: true,
+          })}\n`,
+        );
+      }
       return;
     }
     if (typeof message.type === "string") {

--- a/plugins/provider-pi/src/bridge/rpc-session.extension-ui.test.ts
+++ b/plugins/provider-pi/src/bridge/rpc-session.extension-ui.test.ts
@@ -1,0 +1,62 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, it, vi } from "vitest";
+import { PI_BRIDGE_ARGS_ENV, PI_BRIDGE_COMMAND_ENV } from "./rpc-child.js";
+import { PiRpcSession } from "./rpc-session.js";
+
+it("auto-cancels extension dialogs in a helper session without a UI handler", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "bb-pi-helper-ui-"));
+  const log = join(dir, "responses.jsonl");
+  const script = `
+    const fs = require("node:fs");
+    const input = require("node:readline").createInterface({ input: process.stdin });
+    const send = (message) => process.stdout.write(JSON.stringify(message) + "\\n");
+    input.on("line", (line) => {
+      const message = JSON.parse(line);
+      if (message.type === "get_state") {
+        send({ type: "response", id: message.id, success: true, data: {
+          model: { provider: "test", id: "test" }, isStreaming: false, isCompacting: false,
+        } });
+      }
+      if (message.type === "extension_ui_response") {
+        fs.appendFileSync(${JSON.stringify(log)}, JSON.stringify(message) + "\\n");
+        fs.writeSync(3, JSON.stringify({ kind: "ready" }) + "\\n");
+      }
+    });
+    input.on("close", () => process.exit(0));
+    send({ type: "extension_ui_request", id: "ui-helper", method: "confirm", title: "Startup confirmation", message: "Continue?" });
+  `;
+  vi.stubEnv(PI_BRIDGE_COMMAND_ENV, process.execPath);
+  vi.stubEnv(PI_BRIDGE_ARGS_ENV, JSON.stringify(["-e", script, "--"]));
+  vi.stubEnv("BB_PI_BRIDGE_READINESS_TIMEOUT_MS", "1000");
+  const session = new PiRpcSession(
+    {
+      cwd: dir,
+      sessionFilePath: join(dir, "session.jsonl"),
+      sessionDir: dir,
+      scratchDir: dir,
+      extensionPath: join(dir, "extension.mjs"),
+      recordThreadId: "thr_helper_ui",
+      noSession: true,
+    },
+    async () => ({ content: "", isError: true }),
+    () => undefined,
+    () => undefined,
+  );
+  try {
+    await session.start();
+    expect(JSON.parse(readFileSync(log, "utf8"))).toEqual({
+      type: "extension_ui_response",
+      id: "ui-helper",
+      cancelled: true,
+    });
+  } finally {
+    try {
+      await session.closeGracefully(1000);
+    } finally {
+      vi.unstubAllEnvs();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});

--- a/plugins/provider-pi/src/bridge/rpc-session.ts
+++ b/plugins/provider-pi/src/bridge/rpc-session.ts
@@ -25,6 +25,7 @@ export interface PiRpcSessionOptions {
   extensionPath: string;
   recordThreadId: string;
   noSession?: boolean;
+  onExtensionUiRequest?: (request: Record<string, unknown>) => void;
 }
 
 export interface DynamicToolDefinition {
@@ -163,6 +164,13 @@ export class PiRpcSession {
     return this.isCompacting;
   }
 
+  respondToExtensionUi(
+    id: string | number,
+    fields: Record<string, unknown>,
+  ): void {
+    this.child?.respondToExtensionUi(id, fields);
+  }
+
   getLiveModel(): PiRpcSessionState["model"] | undefined {
     return this.liveModel;
   }
@@ -248,6 +256,9 @@ export class PiRpcSession {
         if (child === this.child) this.handleExit(info);
       },
       recordThreadId: this.options.recordThreadId,
+      onExtensionUiRequest: (request) => {
+        if (child === this.child) this.options.onExtensionUiRequest?.(request);
+      },
     });
     this.child = child;
 

--- a/plugins/provider-pi/src/bridge/rpc-session.ts
+++ b/plugins/provider-pi/src/bridge/rpc-session.ts
@@ -238,6 +238,7 @@ export class PiRpcSession {
     }
 
     this.ready = createDeferred();
+    const onExtensionUiRequest = this.options.onExtensionUiRequest;
     const child = new PiRpcChild({
       cwd: this.options.cwd,
       env: buildPiChildEnv({
@@ -256,9 +257,11 @@ export class PiRpcSession {
         if (child === this.child) this.handleExit(info);
       },
       recordThreadId: this.options.recordThreadId,
-      onExtensionUiRequest: (request) => {
-        if (child === this.child) this.options.onExtensionUiRequest?.(request);
-      },
+      onExtensionUiRequest: onExtensionUiRequest
+        ? (request) => {
+            if (child === this.child) onExtensionUiRequest(request);
+          }
+        : undefined,
     });
     this.child = child;
 

--- a/plugins/provider-pi/src/extension-ui-contract.ts
+++ b/plugins/provider-pi/src/extension-ui-contract.ts
@@ -1,0 +1,107 @@
+import { z } from "zod";
+
+export const PI_PLUGIN_ID = "provider-pi";
+
+export const PI_EXTENSION_UI_KIND = `${PI_PLUGIN_ID}/extension-ui`;
+
+export const PI_EXTENSION_UI_RENDERER_ID = "extension-ui";
+
+const PLUGIN_TITLE_MAX = 200;
+
+const dialogMethodSchema = z.enum(["select", "confirm", "input", "editor"]);
+
+const boundedText = (max: number) => z.string().max(max);
+
+export const PI_EXTENSION_UI_MAX_OPTIONS = 64;
+
+const baseExtensionUiRequestSchema = z.object({
+  id: z.union([z.string(), z.number()]),
+  method: dialogMethodSchema,
+  title: boundedText(PLUGIN_TITLE_MAX).refine(
+    (value) => value.trim().length > 0,
+    "Extension UI title cannot be blank",
+  ),
+  options: z.array(boundedText(512)).max(PI_EXTENSION_UI_MAX_OPTIONS).optional(),
+  message: boundedText(8192).optional(),
+  placeholder: boundedText(1024).optional(),
+  prefill: boundedText(65536).optional(),
+  timeout: z.number().int().positive().optional(),
+});
+
+export const piExtensionUiRequestSchema = baseExtensionUiRequestSchema.refine(
+  (request) => request.method !== "select" || (request.options?.length ?? 0) > 0,
+  { message: "select requests require a non-empty options list" },
+);
+
+export type PiExtensionUiMethod = z.infer<typeof dialogMethodSchema>;
+
+export type PiExtensionUiRequest = z.infer<typeof piExtensionUiRequestSchema>;
+
+export const piExtensionUiPayloadDataSchema = z.object({
+  requestId: z.string().min(1),
+  method: dialogMethodSchema,
+  options: z.array(boundedText(512)).max(PI_EXTENSION_UI_MAX_OPTIONS).optional(),
+  message: boundedText(8192).optional(),
+  placeholder: boundedText(1024).optional(),
+  prefill: boundedText(65536).optional(),
+});
+
+export type PiExtensionUiPayloadData = z.infer<
+  typeof piExtensionUiPayloadDataSchema
+>;
+
+export const piExtensionUiResolutionSchema = z.object({
+  kind: z.literal("request_answer"),
+  value: z.unknown(),
+});
+
+export type PiExtensionUiResolution = z.infer<
+  typeof piExtensionUiResolutionSchema
+>;
+
+export type PiExtensionUiResponseFields =
+  | { value: string }
+  | { confirmed: boolean }
+  | { cancelled: true };
+
+export interface InteractionUiRequest {
+  jsonrpc: "2.0";
+  id: string;
+  method: "interaction/request";
+  params: {
+    providerThreadId: string;
+    threadId: string;
+    turnId: null;
+    payload: {
+      kind: typeof PI_EXTENSION_UI_KIND;
+      title: string;
+      data: PiExtensionUiPayloadData;
+    };
+  };
+}
+
+export type RuntimeInteractionUiResponse = {
+  id: string | number;
+  result?: unknown;
+  error?: { message?: string };
+};
+
+export function resolveExtensionUiResponseFields(
+  method: PiExtensionUiMethod,
+  result: unknown,
+): PiExtensionUiResponseFields {
+  if (
+    typeof result !== "object" ||
+    result === null ||
+    (result as { kind?: unknown }).kind !== "request_answer"
+  ) {
+    return { cancelled: true };
+  }
+  const value = (result as { value?: unknown }).value;
+  if (method === "confirm") {
+    return typeof value === "boolean"
+      ? { confirmed: value }
+      : { cancelled: true };
+  }
+  return typeof value === "string" ? { value } : { cancelled: true };
+}

--- a/plugins/provider-pi/src/extension-ui-contract.ts
+++ b/plugins/provider-pi/src/extension-ui-contract.ts
@@ -87,21 +87,20 @@ export type RuntimeInteractionUiResponse = {
 };
 
 export function resolveExtensionUiResponseFields(
-  method: PiExtensionUiMethod,
-  result: unknown,
+  request: PiExtensionUiRequest,
+  result: PiExtensionUiResolution,
 ): PiExtensionUiResponseFields {
-  if (
-    typeof result !== "object" ||
-    result === null ||
-    (result as { kind?: unknown }).kind !== "request_answer"
-  ) {
-    return { cancelled: true };
-  }
-  const value = (result as { value?: unknown }).value;
-  if (method === "confirm") {
+  const { value } = result;
+  if (request.method === "confirm") {
     return typeof value === "boolean"
       ? { confirmed: value }
       : { cancelled: true };
   }
-  return typeof value === "string" ? { value } : { cancelled: true };
+  if (typeof value !== "string") {
+    return { cancelled: true };
+  }
+  if (request.method === "select" && !request.options?.includes(value)) {
+    return { cancelled: true };
+  }
+  return { value };
 }

--- a/plugins/provider-pi/tsconfig.json
+++ b/plugins/provider-pi/tsconfig.json
@@ -4,7 +4,9 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "jsx": "react-jsx",
     "lib": ["ES2022", "DOM"],
+    "esModuleInterop": true,
     "noEmit": true,
     "skipLibCheck": true,
     "paths": {
@@ -17,5 +19,5 @@
     },
     "types": ["node"]
   },
-  "include": ["server.ts", "src", "vitest.config.ts"]
+  "include": ["server.ts", "src", "app.tsx", "app.test.tsx", "vitest.config.ts"]
 }

--- a/plugins/provider-pi/vitest.config.ts
+++ b/plugins/provider-pi/vitest.config.ts
@@ -9,7 +9,7 @@ export default defineWorkspaceTestConfig({
     projects: sharedWorkerProjects({
       pkgDir: __dirname,
       name: "bb-plugin-provider-pi",
-      include: ["*.test.ts", "src/**/*.test.ts"],
+      include: ["*.test.ts", "*.test.tsx", "src/**/*.test.ts"],
     }),
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3605,6 +3605,9 @@ importers:
 
   plugins/provider-pi:
     dependencies:
+      '@bb/shared-ui':
+        specifier: workspace:*
+        version: link:../../packages/shared-ui
       '@get-bb/plugin-sdk':
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
@@ -3624,9 +3627,24 @@ importers:
       '@earendil-works/pi-coding-agent':
         specifier: 0.84.0
         version: 0.84.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.10
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.13
+      jsdom:
+        specifier: ^29.0.1
+        version: 29.0.1(@noble/hashes@2.4.0)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.4(react@19.2.4)
       typebox:
         specifier: 1.3.7
         version: 1.3.7
@@ -3638,7 +3656,7 @@ importers:
         version: typescript@7.0.2
       vitest:
         specifier: ^4.1.1
-        version: 4.1.1(@opentelemetry/api@1.9.0)(@types/node@22.19.10)(jsdom@29.0.1(@noble/hashes@2.4.0))(msw@2.12.14(@types/node@22.19.10)(@typescript/typescript6@6.0.2))(vite@8.0.12(@types/node@22.19.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.1(@opentelemetry/api@1.9.1)(@types/node@22.19.10)(jsdom@29.0.1(@noble/hashes@2.4.0))(msw@2.12.14(@types/node@22.19.10)(@typescript/typescript6@6.0.2))(vite@8.0.12(@types/node@22.19.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.1)(yaml@2.9.0))
 
   plugins/provider-retry:
     dependencies:
@@ -5791,7 +5809,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {node: '>=0.10.0'}
+    engines: {'0': node >=0.10.0}
 
   '@expo/cli@57.0.16':
     resolution: {integrity: sha512-+HyMY2nAS6QBJb0nSeMz92p11bZ1AtWSRnhWnklznN07IRoQirisnKq2vr18Ayjb/fnb5F/um+n6FRhF0fZm1Q==}
@@ -29153,35 +29171,6 @@ snapshots:
       - terser
       - tsx
       - yaml
-
-  vitest@4.1.1(@opentelemetry/api@1.9.0)(@types/node@22.19.10)(jsdom@29.0.1(@noble/hashes@2.4.0))(msw@2.12.14(@types/node@22.19.10)(@typescript/typescript6@6.0.2))(vite@8.0.12(@types/node@22.19.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.1)(yaml@2.9.0)):
-    dependencies:
-      '@vitest/expect': 4.1.1
-      '@vitest/mocker': 4.1.1(msw@2.12.14(@types/node@22.19.10)(@typescript/typescript6@6.0.2))(vite@8.0.12(@types/node@22.19.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.1)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.1
-      '@vitest/runner': 4.1.1
-      '@vitest/snapshot': 4.1.1
-      '@vitest/spy': 4.1.1
-      '@vitest/utils': 4.1.1
-      es-module-lexer: 2.0.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.5
-      std-env: 4.0.0
-      tinybench: 2.9.0
-      tinyexec: 1.0.2
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.1
-      vite: 8.0.12(@types/node@22.19.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.1)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.0
-      '@types/node': 22.19.10
-      jsdom: 29.0.1(@noble/hashes@2.4.0)
-    transitivePeerDependencies:
-      - msw
 
   vitest@4.1.1(@opentelemetry/api@1.9.1)(@types/node@22.19.10)(jsdom@29.0.1(@noble/hashes@2.4.0))(msw@2.12.14(@types/node@22.19.10)(@typescript/typescript6@6.0.2))(vite@8.0.12(@types/node@22.19.10)(esbuild@0.19.12)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:


### PR DESCRIPTION
## Human comments

yet another PR for making the pi provider more polished here. I’ve been running this and my other PRs on my local install of bb and been working fine

<img width="1170" height="2205" alt="image" src="https://github.com/user-attachments/assets/d300ebf0-23ef-4cb0-9e0d-83832f61537a" />


## What was wrong

Pi extensions prompt the user through `ctx.ui.select`, `ctx.ui.confirm`, `ctx.ui.input`, and `ctx.ui.editor`. In RPC mode these emit an `extension_ui_request` line on stdout and block until an `extension_ui_response` arrives on stdin (see `docs/rpc.md`, "Extension UI Protocol"). bb's provider-pi bridge answered every such request with `{cancelled: true}`, so any extension that raises a permission prompt had it silently dismissed — [pi-landstrip](https://github.com/landstrip/landstrip) sandbox-approval prompts were unusable over bb. Investigation and reproduction trail: #1668.

## What changed

- `plugins/provider-pi/src/bridge/rpc-child.ts` forwards `extension_ui_request` dialogs to an optional handler; with no handler the old auto-cancel remains, so behavior is unchanged unless the bridge opts in.
- `plugins/provider-pi/src/extension-ui-contract.ts` validates dialog requests at the boundary: method enum, bounded title/options/message/placeholder/prefill, `select` requires a non-empty options list.
- `plugins/provider-pi/src/bridge/extension-ui.ts` forwards each dialog as a `provider-pi/extension-ui` pending interaction and maps resolutions back (`value` for select/input/editor, `confirmed` for confirm, `cancelled` on error, unknown value, or session close). Request ids use a `pi-ui-N` string space so they cannot collide with numeric item/tool/call ids. Pending dialogs are cancelled on thread stop, session replace, and discard. Fire-and-forget methods (`notify`, `setStatus`, `setWidget`, `setTitle`, `set_editor_text`) are dropped.
- Helper sessions such as fork helpers retain automatic dialog cancellation when no UI handler is installed. Select responses are checked against the originally offered options before reaching Pi.
- `plugins/provider-pi/app.tsx` renders the four dialog shapes in the plugin pending-interaction slot. The host passes plugin components the interaction's data object rather than the stored `{kind, title, data}` wrapper, so the renderer parses the unwrapped payload directly.

No protocol or wire changes: no `HOST_DAEMON_PROTOCOL_VERSION` bump, no new grammar, no new plugin API surface — this reuses the existing `interaction/request` plugin-extension payload kind and pending-interaction slot.

This is deliberately the minimal bridge-only subset of #2446/#2447 (both still open): thread-scoped requests outside an active turn, withdrawal notifications, and queued-before-announcement dialogs are left as follow-ups — and the behavior is strictly better than the current always-cancelled path.

## How you verified

- `pnpm exec turbo run test --filter=bb-plugin-provider-pi` (26 files, 143 tests) and `turbo run typecheck --filter=bb-plugin-provider-pi` — clean.
- Both review regressions were reproduced before the fixes: helper startup timed out waiting for a dialog response, and an unoffered select string reached Pi. Both now pass; `pnpm exec turbo run test typecheck --filter=bb-plugin-provider-pi` passed with 26 test files and 143 tests. The working-tree and commit-range secret scan was clean.
- New bridge round-trip tests over the fake Pi harness (`/ui` directive in `fake-pi-rpc.mjs`), rpc-child handler unit tests, and jsdom renderer tests covering select/confirm/input/editor and the host-unwrapped payload shape.
- Live: pi-landstrip read/write permission prompts render the full option list over bb, and user answers propagate back and drive the sandbox decision (e.g. "Keep blocked" denies the underlying write).

Fixes: partial groundwork for #1668


---

<sub><em>Generated with "Omen Alpha" (Opencode Go) via BB / Pi</em></sub>

> AGENT GENERATED
