### PR TITLE
fix(acp): recover runtime after agent session exits

### DIFF
--- a/packages/agent-runtime/src/runtime.acp-topology.test.ts
+++ b/packages/agent-runtime/src/runtime.acp-topology.test.ts
@@ -3,11 +3,14 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { ThreadEvent } from "@bb/domain";
+import { promptTextInput } from "./test/prompt-input.js";
 import { createAgentRuntime } from "./runtime.js";
 import {
   createScriptedEchoLaunch,
   fullRuntimeOptions,
   waitForRuntimeState,
+  waitForThreadAgentMessageText,
   withBridgeLaunch,
 } from "./test/runtime-test-harness.js";
 import type { AgentRuntime } from "./types.js";
@@ -34,6 +37,73 @@ describe("acp process topology", () => {
     await Promise.all(runtimes.splice(0).map((runtime) => runtime.shutdown()));
     rmSync(workspaceDir, { recursive: true, force: true });
   });
+
+  it("resumes an exited idle ACP session before the next request", async () => {
+    const requestLog = join(workspaceDir, "requests.jsonl");
+    const events: ThreadEvent[] = [];
+    const runtime = withBridgeLaunch(
+      createAgentRuntime({
+        workspacePath: workspaceDir,
+        env: {},
+        onEvent: (event) => events.push(event),
+        onToolCall: async () => ({ contentItems: [], success: true }),
+      }),
+      createScriptedEchoLaunch({
+        pluginId: "provider-acp",
+        digest: "acp-v1",
+        modulePath: acpBridgeModulePath,
+        capabilities: { fork: "tip" },
+        providerOptions: {
+          acpLaunchSpec: {
+            displayName: "Fake ACP",
+            command: process.execPath,
+            args: [fakeAgentPath],
+            env: {
+              FAKE_ACP_REQUEST_LOG: requestLog,
+              FAKE_ACP_LOAD_SESSION: "1",
+            },
+          },
+        },
+      }),
+    );
+    runtimes.push(runtime);
+    await runtime.startThread({
+      environmentId: "env-1",
+      projectId: "p1",
+      providerId: "acp",
+      threadId: "t-recover",
+      options: fullRuntimeOptions,
+    });
+    const session = runtime.getProviderSession("t-recover");
+    if (!session) throw new Error("Missing ACP session");
+    const pid = Number(session.providerThreadId.replace("fake-sess-", ""));
+    expect(Number.isSafeInteger(pid) && pid > 0).toBe(true);
+    process.kill(pid, "SIGTERM");
+    await waitForRuntimeState({
+      label: "the exited ACP session is loaded in a fresh process",
+      predicate: () =>
+        readFileSync(requestLog, "utf8").includes('"method":"session/load"'),
+      runtime,
+      timeoutMs: 10_000,
+    });
+    await runtime.runTurn({
+      clientRequestId: "creq_acprecvry2",
+      threadId: "t-recover",
+      input: [promptTextInput({ text: "after recovery" })],
+      options: fullRuntimeOptions,
+    });
+    await waitForThreadAgentMessageText({
+      events,
+      providerId: "acp",
+      runtime,
+      threadId: "t-recover",
+      text: "echo:after recovery",
+    });
+    expect(runtime.getProviderSession("t-recover")).toEqual(session);
+    expect(
+      readFileSync(requestLog, "utf8").split('"method":"session/prompt"'),
+    ).toHaveLength(2);
+  }, 30_000);
 
   it("releases the thread on the bridge when a construction times out on the runtime's side", async () => {
     const readyFile = join(workspaceDir, "agent-ready");

--- a/packages/provider-bridge-acp/src/bridge/bridge.test.ts
+++ b/packages/provider-bridge-acp/src/bridge/bridge.test.ts
@@ -3154,19 +3154,86 @@ describe("acp bridge", () => {
     expect(threadEventsOfType("provider/warning")).not.toHaveLength(0);
   });
 
-  it("reports unexpected agent exits as a single provider error", async () => {
-    const { bbThreadId, providerThreadId } = await startThread();
-    const turnId = sendTurnRequest("turn/start", providerThreadId, {
-      input: [{ type: "text", text: "die", mentions: [] }],
-    });
-    await waitForResponse(turnId);
+  it.each(["die", "die-zero"])(
+    "requests recovery after an unexpected agent exit (%s)",
+    async (text) => {
+      const { bbThreadId, providerThreadId } = await startThread();
+      const turnId = sendTurnRequest("turn/start", providerThreadId, {
+        input: [{ type: "text", text, mentions: [] }],
+      });
+      await waitForResponse(turnId);
 
-    const errors = await waitFor(() => {
-      const errorNotifications = notifications("error");
-      return errorNotifications.length > 0 ? errorNotifications : undefined;
-    }, "agent exit error notification");
-    expect(errors).toHaveLength(1);
-    expect(errors[0]?.params).toMatchObject({ threadId: bbThreadId });
+      const errors = await waitFor(() => {
+        const errorNotifications = notifications("error");
+        return errorNotifications.length > 0 ? errorNotifications : undefined;
+      }, "agent exit error notification");
+      expect(errors).toHaveLength(1);
+      expect(errors[0]?.params).toMatchObject({ threadId: bbThreadId });
+      expect(notifications("provider/recovery")).toMatchObject([
+        {
+          params: {
+            threadId: bbThreadId,
+            providerThreadId,
+            kind: "restartRecommended",
+            retryable: false,
+          },
+        },
+      ]);
+      for (const method of ["turn/start", "turn/steer"] as const) {
+        const retry = sendTurnRequest(method, providerThreadId, {
+          expectedTurnId: "old-turn",
+          input: [{ type: "text", text: "next request", mentions: [] }],
+        });
+        expect((await waitForResponse(retry)).error).toMatchObject({
+          message: "No active ACP session",
+          data: {
+            recovery: {
+              kind: "restartRecommended",
+              message: "No active ACP session",
+              retryable: false,
+            },
+          },
+        });
+      }
+      startedProviderThreadIds.pop();
+    },
+  );
+
+  it("requests recovery when an idle agent exits with code zero", async () => {
+    const { bbThreadId, providerThreadId } = await startThread();
+    const pid = Number(providerThreadId.replace("fake-sess-", ""));
+    expect(Number.isSafeInteger(pid) && pid > 0).toBe(true);
+    process.kill(pid, "SIGTERM");
+    await waitFor(
+      () => notifications("provider/recovery")[0],
+      "idle exit recovery",
+    );
+    expect(notifications("provider/recovery")).toMatchObject([
+      {
+        params: {
+          threadId: bbThreadId,
+          providerThreadId,
+          kind: "restartRecommended",
+          message: expect.stringContaining("(code 0)"),
+          retryable: false,
+        },
+      },
+    ]);
+    expect(threadEventsOfType("turn/completed")).toHaveLength(0);
+    startedProviderThreadIds.pop();
+  });
+
+  it("does not recommend restarting an intentionally released session", async () => {
+    const { bbThreadId, providerThreadId } = await startThread();
+    const stop = sendRequest("thread/stop", {
+      threadId: bbThreadId,
+      providerThreadId,
+      intent: "release",
+      activeTurnId: null,
+    });
+    expect((await waitForResponse(stop)).result).toEqual({ ok: true });
+    expect(notifications("provider/recovery")).toEqual([]);
+    expect(notifications("error")).toEqual([]);
     startedProviderThreadIds.pop();
   });
 

--- a/packages/provider-bridge-acp/src/bridge/bridge.ts
+++ b/packages/provider-bridge-acp/src/bridge/bridge.ts
@@ -1689,12 +1689,18 @@ async function startAgentSession(
         return;
       }
       void releaseCursorMcpApproval(session);
-      emitSessionError(
-        session,
+      const message =
         `ACP agent "${agentLabel}" exited unexpectedly` +
-          `${info.code !== null ? ` (code ${info.code})` : ""}` +
-          `${info.stderrTail ? `: ${info.stderrTail}` : ""}`,
-      );
+        `${info.code !== null ? ` (code ${info.code})` : ""}` +
+        `${info.stderrTail ? `: ${info.stderrTail}` : ""}`;
+      emitSessionError(session, message);
+      sendNotification(BRIDGE_NOTIFICATION_METHODS.providerRecovery, {
+        threadId: session.bbThreadId,
+        providerThreadId: session.providerThreadId,
+        kind: "restartRecommended",
+        message,
+        retryable: false,
+      });
     },
   });
   session = {
@@ -2592,7 +2598,10 @@ async function handleRequest(
       const params = request.params;
       const session = liveSessionForThread(params.threadId);
       if (session === undefined) {
-        sendError(request.id, -32000, "No active ACP session");
+        const message = "No active ACP session";
+        sendError(request.id, -32000, message, {
+          recovery: { kind: "restartRecommended", message, retryable: false },
+        });
         return;
       }
       if (session.activePromptKind !== null) {
@@ -2616,7 +2625,10 @@ async function handleRequest(
       const params = request.params;
       const session = liveSessionForThread(params.threadId);
       if (session === undefined) {
-        sendError(request.id, -32000, "No active ACP session");
+        const message = "No active ACP session";
+        sendError(request.id, -32000, message, {
+          recovery: { kind: "restartRecommended", message, retryable: false },
+        });
         return;
       }
       if (session.activePromptKind !== "turn") {

--- a/packages/provider-bridge-acp/src/bridge/fake-acp-agent.mjs
+++ b/packages/provider-bridge-acp/src/bridge/fake-acp-agent.mjs
@@ -528,7 +528,7 @@ async function handlePrompt(message) {
     // Stay pending until the client sends session/cancel.
     return;
   } else if (text.includes("die")) {
-    process.exit(7);
+    process.exit(text.includes("die-zero") ? 0 : 7);
   } else if (text.includes("slow")) {
     notifyUpdate(messageChunk(`echo:${text}`));
     await sleep(300);


### PR DESCRIPTION
## Human comments

## What was wrong

When an established ACP agent exited, the bridge removed its local session and emitted a generic error. The host retained runtime configuration without being told to restart. A later user request or delegate completion could therefore fail with `No active ACP session`. This was observed with Kilo on BB 0.42.0, including child exits with code 0. The reason for those original exits is not established by this fix.

## What changed

Emit the existing `restartRecommended` recovery notification after an unexpected established-session exit. Missing-session `turn/start` and `turn/steer` rejections now carry the same structured hint. The existing runtime handles restart serialization, preserves the provider session identity, and defers restart around active work. Intentional release and incomplete initialization retain their existing guards. Hints are non-retryable: this does not replay accepted work or automatically retry upstream API errors.

No wire fields or recovery semantics are added; the existing hint is supported by the shipped 0.42.0 host, so no protocol version bump is needed. No CLI or UI surface changes.

## How you verified

- `pnpm exec turbo run test typecheck --filter=@bb/provider-bridge-acp --filter=@bb/agent-runtime`: both typechecks and all 633 tests pass (314 ACP, 319 runtime).
- Regression covers unexpected exits with codes 0 and 7, missing-session start/steer hints, idle process exit, and intentional release without recovery.
- Real ACP bridge/runtime test kills the fake agent, observes `session/load`, sends the next prompt successfully, preserves session identity, and asserts a single prompt dispatch.
- Restoring the original bridge implementation makes the new runtime regression time out waiting for session recovery. Restoring the fix makes it pass.
- Formatting and `git diff --check` pass.

Not yet installed into the running BB desktop app; validation uses the source checkout and real local subprocesses.

> AGENT GENERATED
