### PR TITLE
Show pooled account quotas in usage settings

### DIFF
--- a/apps/app/src/components/plugin/PluginSettingsSections.test.tsx
+++ b/apps/app/src/components/plugin/PluginSettingsSections.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, expect, it } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { makePluginRegistrationSet } from "@/test/fixtures/plugins";
+import {
+  resetPluginSlotStoreForTest,
+  setPluginSlotRegistrations,
+} from "@/lib/plugin-slots";
+import {
+  PluginSettingsSections,
+  PluginUsageSettingsSections,
+} from "./PluginSettingsSections";
+
+afterEach(() => {
+  cleanup();
+  resetPluginSlotStoreForTest();
+});
+
+it("keeps account controls on the plugin page and removes usage when the plugin unloads", () => {
+  setPluginSlotRegistrations(
+    "pool",
+    makePluginRegistrationSet({
+      settingsSections: [
+        { id: "accounts", component: () => <p>Account controls</p> },
+        {
+          id: "usage",
+          experimental_placement: "usage",
+          component: () => <p>Pool quotas</p>,
+        },
+      ],
+    }),
+  );
+  const view = render(
+    <MemoryRouter>
+      <PluginSettingsSections pluginId="pool" />
+    </MemoryRouter>,
+  );
+  expect(screen.getByText("Account controls")).toBeTruthy();
+  expect(screen.queryByText("Pool quotas")).toBeNull();
+  view.rerender(
+    <MemoryRouter>
+      <PluginUsageSettingsSections />
+    </MemoryRouter>,
+  );
+  expect(screen.getByText("Pool quotas")).toBeTruthy();
+  expect(screen.queryByText("Account controls")).toBeNull();
+  act(() => resetPluginSlotStoreForTest());
+  expect(screen.queryByText("Pool quotas")).toBeNull();
+});

--- a/apps/app/src/components/plugin/PluginSettingsSections.tsx
+++ b/apps/app/src/components/plugin/PluginSettingsSections.tsx
@@ -7,7 +7,18 @@ import { PluginSlotMount } from "./PluginSlotMount";
 export function PluginSettingsSections({ pluginId }: { pluginId: string }) {
   const { settingsSections } = usePluginSlots();
   const sections = settingsSections.filter(
-    (section) => section.pluginId === pluginId,
+    (section) =>
+      section.pluginId === pluginId &&
+      section.experimental_placement !== "usage",
+  );
+  if (sections.length === 0) return null;
+  return <PluginSettingsSectionList sections={sections} />;
+}
+
+export function PluginUsageSettingsSections() {
+  const { settingsSections } = usePluginSlots();
+  const sections = settingsSections.filter(
+    (section) => section.experimental_placement === "usage",
   );
   if (sections.length === 0) return null;
   return <PluginSettingsSectionList sections={sections} />;

--- a/apps/app/src/lib/plugin-app-definition.test.ts
+++ b/apps/app/src/lib/plugin-app-definition.test.ts
@@ -15,6 +15,35 @@ function Component() {
   return null;
 }
 
+describe("settings section placement", () => {
+  it("preserves usage placement through collection", () => {
+    const definition = definePluginApp((app) => {
+      app.slots.settingsSection({
+        id: "usage",
+        experimental_placement: "usage",
+        component: Component,
+      });
+    });
+    expect(
+      collectPluginAppRegistrations(definition).settingsSections[0]
+        ?.experimental_placement,
+    ).toBe("usage");
+  });
+
+  it("rejects unknown placements at the plugin boundary", () => {
+    const definition = definePluginApp((app) => {
+      app.slots.settingsSection({
+        id: "usage",
+        experimental_placement: "other" as never,
+        component: Component,
+      });
+    });
+    expect(() => collectPluginAppRegistrations(definition)).toThrow(
+      /experimental_placement/,
+    );
+  });
+});
+
 describe("definePluginApp", () => {
   it("brands the setup for host detection", () => {
     const definition = definePluginApp(() => {});

--- a/apps/app/src/views/SettingsView.tsx
+++ b/apps/app/src/views/SettingsView.tsx
@@ -44,6 +44,7 @@ import {
   type ThemePreference,
 } from "@/hooks/useTheme";
 import { useHostDaemon, useLocalHostDaemonAccess } from "@/hooks/useHostDaemon";
+import { PluginUsageSettingsSections } from "@/components/plugin/PluginSettingsSections";
 import { UsageLimitsSettingsSection } from "@/components/settings/UsageLimitsSettingsSection";
 import { ProvidersSettingsSection } from "@/components/settings/ProvidersSettingsSection";
 import { CodeRendererSettings } from "@/components/settings/CodeRendererSettings";
@@ -1141,7 +1142,12 @@ export function SettingsView() {
       />
     );
   } else if (activeSection === "usage") {
-    content = <UsageLimitsSettingsSection />;
+    content = (
+      <div className="space-y-6">
+        <UsageLimitsSettingsSection />
+        <PluginUsageSettingsSections />
+      </div>
+    );
   } else if (activeSection === "keyboard") {
     content = <KeyboardSettingsSection />;
   } else if (activeSection === "files") {

--- a/docs/api_to_audit.md
+++ b/docs/api_to_audit.md
@@ -1,5 +1,17 @@
 # APIs To Audit
 
+## `PluginSettingsSectionRegistration.experimental_placement`
+
+**What it does.** Selects the host page for a settings section. Omitted or
+`"plugin"` preserves the plugin settings page; `"usage"` mounts the section
+below provider limits in Settings → Usage, with the same plugin context and
+crash isolation. Usage sections receive no machine filter: pooled quotas may
+be shared across machines.
+
+**Audit before stabilizing.** Confirm the page destinations, whether usage
+sections need host selection or a shared refresh contract, and discoverability
+for plugins that only register a usage section.
+
 ## `bb.http.experimental_websocket`
 
 **What it does.** Registers an exact-path WebSocket upgrade in the plugin's

--- a/packages/domain/src/plugin-sdk-version.ts
+++ b/packages/domain/src/plugin-sdk-version.ts
@@ -1,3 +1,3 @@
-export const PLUGIN_SDK_VERSION = "0.4.48";
+export const PLUGIN_SDK_VERSION = "0.4.49";
 
 export const PLUGIN_SDK_MAJOR = Number(PLUGIN_SDK_VERSION.split(".", 1)[0]);

--- a/packages/plugin-api-map/src/surfaces.ts
+++ b/packages/plugin-api-map/src/surfaces.ts
@@ -507,6 +507,7 @@ export const SURFACE_GROUPS: SurfaceGroup[] = [
           "Render whatever UI it needs, such as a connect-account button, a test-connection result, or a preview",
           "Run in the browser, so it stores nothing itself. It calls the plugin's own backend to do that",
           "Supply a heading and a one-line description for bb to render above it",
+          'Set experimental_placement to "usage" to render below provider limits in Settings → Usage instead of the plugin page; omitted or "plugin" preserves the existing page',
         ],
         apiSymbols: ["PluginSettingsSectionRegistration"],
         firstParty: ["Account Pooler", "Keep Awake", "Memory", "Remote access"],

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@get-bb/plugin-sdk",
-  "version": "0.4.48",
+  "version": "0.4.49",
   "homepage": "https://github.com/get-bb/bb#readme",
   "bugs": {
     "url": "https://github.com/get-bb/bb/issues"

--- a/packages/plugin-sdk/src/app-contract.ts
+++ b/packages/plugin-sdk/src/app-contract.ts
@@ -443,6 +443,8 @@ export interface PluginHomepageSectionRegistration {
 }
 
 export interface PluginSettingsSectionRegistration {
+  /** Render on Settings → Usage instead of the plugin page. Defaults to "plugin". */
+  experimental_placement?: "plugin" | "usage";
   /** Unique within the plugin; letters, digits, `-`, `_`. */
   id: string;
   /** Optional host-rendered section heading. */

--- a/packages/plugin-sdk/src/internal/plugin-app-collector.ts
+++ b/packages/plugin-sdk/src/internal/plugin-app-collector.ts
@@ -399,8 +399,21 @@ export function collectPluginAppRegistrations(
           "description",
           registration.description,
         );
+        const placement = registration.experimental_placement;
+        if (
+          placement !== undefined &&
+          placement !== "plugin" &&
+          placement !== "usage"
+        ) {
+          throw new Error(
+            `${kind}: "experimental_placement" must be "plugin" or "usage" when set`,
+          );
+        }
         collected.settingsSections.push({
           id,
+          ...(placement === undefined
+            ? {}
+            : { experimental_placement: placement }),
           ...(title !== undefined ? { title } : {}),
           ...(description !== undefined ? { description } : {}),
           component: requireComponent(kind, registration.component),

--- a/packages/templates/src/templates/bb-guide-plugins.md
+++ b/packages/templates/src/templates/bb-guide-plugins.md
@@ -36,6 +36,7 @@ bb pool account add --provider codex --import
 printf '%s\n' "$ANTHROPIC_API_KEY" | bb pool account add --provider claude --api-key-stdin [--label <text>] [--priority <n>]
 bb pool account add --provider claude --api-key <key> [--label <text>] [--priority <n>]
 bb pool account list [--json]
+bb pool account refresh <id> [--json]
 bb pool account remove <id>
 bb pool account enable <id>
 bb pool account disable <id>

--- a/plugins/account-pool/PLUGIN_OVERVIEW.md
+++ b/plugins/account-pool/PLUGIN_OVERVIEW.md
@@ -23,3 +23,8 @@ This plugin is experimental. Routing behavior, stored data, and the CLI can chan
 ## For agents
 
 `bb pool account add|list|remove|enable|disable|priority|reorder`, `bb pool status`, `bb pool routing <claude|codex> [--off]`, `bb pool config`, `bb pool config set`, `bb pool token rotate`, and `bb pool bypass <thread-id>`. `list` and `status` take `--json`.
+
+Settings → Usage includes a pooled-account section with Claude and Codex quota
+windows, reset times, account status, and a reload action. These accounts are
+shared across machines. Use `bb pool account list --json` to inspect the same
+data and `bb pool account refresh <id> --json` to refresh one account.

--- a/plugins/account-pool/app.test.tsx
+++ b/plugins/account-pool/app.test.tsx
@@ -452,3 +452,124 @@ describe("Account Pool settings", () => {
     },
   );
 });
+
+function renderUsage(
+  accounts: AccountSummary[],
+  extraRpc: Record<string, (input: { accountId: string }) => unknown> = {},
+) {
+  const registration = app.settingsSections.find(
+    (section) => section.experimental_placement === "usage",
+  );
+  if (registration === undefined)
+    throw new Error("Missing pooled usage section");
+  return renderSlot(
+    registration,
+    {},
+    {
+      rpc: {
+        "account.list": () => accounts,
+        "config.get": () => config(),
+        ...extraRpc,
+      },
+    },
+  );
+}
+
+describe("Pooled account usage", () => {
+  it("updates quotas when the pool reports background changes", async () => {
+    const accounts = [account()];
+    const slot = renderUsage(accounts);
+    expect(await slot.findByText(/21%/)).toBeTruthy();
+    accounts[0] = account({ fiveHourUtilization: 0.56 });
+    await slot.behavior.emitRealtime("accounts-changed", null);
+    expect(await slot.findByText("56%")).toBeTruthy();
+  });
+
+  it("shows Claude and Codex quotas, resets, disabled accounts and errors", async () => {
+    const slot = renderUsage([
+      account({
+        label: "Claude work",
+        sevenDayUtilization: 0.45,
+        fiveHourResetAt: Date.now() + 3_600_000,
+      }),
+      account({
+        id: "22222222-2222-4222-8222-222222222222",
+        label: "Codex personal",
+        provider: "codex",
+        enabled: false,
+        status: "disabled",
+        subscriptionType: "Pro",
+        error: "Sign in again",
+        limitWindows: [
+          {
+            slot: "secondary",
+            windowMinutes: 10080,
+            utilization: 0.73,
+            resetAt: null,
+            status: "allowed",
+            observedAt: 1,
+            source: "usage",
+          },
+        ],
+      }),
+    ]);
+    expect(await slot.findByText("Claude work")).toBeTruthy();
+    expect(slot.getByText("Codex personal")).toBeTruthy();
+    expect(slot.getByText("Weekly")).toBeTruthy();
+    expect(slot.getByText(/21%.*resets in/)).toBeTruthy();
+    expect(slot.getByText("73%")).toBeTruthy();
+    expect(slot.getByText("Disabled")).toBeTruthy();
+    expect(slot.getByText("Sign in again")).toBeTruthy();
+    expect(slot.queryByText(/will be skipped/)).toBeNull();
+  });
+
+  it("refreshes remaining accounts after a failure and retains refreshed quotas", async () => {
+    const accounts = [
+      account({ label: "First" }),
+      account({ id: "22222222-2222-4222-8222-222222222222", label: "Second" }),
+    ];
+    const refresh = vi.fn(({ accountId }: { accountId: string }) => {
+      if (accountId === accounts[0]!.id) throw new Error("Refresh unavailable");
+      accounts[1] = account({ ...accounts[1], fiveHourUtilization: 0.67 });
+      return { account: accounts[1] };
+    });
+    const slot = renderUsage(accounts, { "account.refreshUsage": refresh });
+    await slot.findByText("First");
+    fireEvent.click(slot.getByRole("button", { name: "Reload pooled usage" }));
+    expect(await slot.findByText("67%")).toBeTruthy();
+    expect(slot.getByRole("alert").textContent).toContain(
+      "First: Refresh unavailable",
+    );
+    expect(refresh).toHaveBeenCalledTimes(2);
+  });
+
+  it("distinguishes empty pools from missing usage", async () => {
+    const slot = renderUsage([]);
+    expect(
+      await slot.findByText("No pooled accounts configured."),
+    ).toBeTruthy();
+    slot.lifecycle.unmount();
+    const unknown = renderUsage([
+      account({ provider: "codex", observedAt: null, limitWindows: [] }),
+    ]);
+    expect(
+      await unknown.findByText("No usage limits observed yet."),
+    ).toBeTruthy();
+    expect(unknown.getByText("Usage has not been observed yet.")).toBeTruthy();
+    expect(unknown.queryByText("0%")).toBeNull();
+  });
+
+  it("recovers from an initial load error using reload", async () => {
+    const list = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Pool unavailable"))
+      .mockResolvedValue([]);
+    const slot = renderUsage([], { "account.list": list });
+    expect(await slot.findByRole("alert")).toBeTruthy();
+    fireEvent.click(slot.getByRole("button", { name: "Reload pooled usage" }));
+    expect(
+      await slot.findByText("No pooled accounts configured."),
+    ).toBeTruthy();
+    expect(slot.queryByRole("alert")).toBeNull();
+  });
+});

--- a/plugins/account-pool/app.tsx
+++ b/plugins/account-pool/app.tsx
@@ -558,10 +558,12 @@ function QuotaDetail({
   label,
   quota,
   threshold,
+  showRoutingHint = true,
 }: {
   label: string;
   quota: FamilyQuota | null;
   threshold: number;
+  showRoutingHint?: boolean;
 }) {
   const utilization = quota?.utilization ?? null;
   return (
@@ -588,7 +590,9 @@ function QuotaDetail({
           {quota?.resetAt === null || quota === null
             ? ""
             : ` · ${resetLabel(quota.resetAt)}`}{" "}
-          · will be skipped at {Math.round(threshold * 100)}%
+          {showRoutingHint
+            ? ` · will be skipped at ${Math.round(threshold * 100)}%`
+            : null}
         </div>
       </div>
     </div>
@@ -1353,16 +1357,14 @@ function AccountPoolSettings() {
   );
 }
 
-function AccountDrawer({
+function AccountQuotaDetails({
   account,
   threshold,
-  close,
-  act,
+  showRoutingHint = true,
 }: {
   account: AccountSummary;
   threshold: number;
-  close: () => void;
-  act: (action: "toggle" | "refresh" | "remove") => void;
+  showRoutingHint?: boolean;
 }) {
   const shared = (
     utilization: number | null,
@@ -1375,6 +1377,76 @@ function AccountDrawer({
     observedAt: account.observedAt ?? 0,
     source: "header",
   });
+  return (
+    <div className="space-y-4">
+      {account.provider === "codex" ? (
+        account.limitWindows.length === 0 ? (
+          <div className="text-sm text-muted-foreground">
+            No usage limits observed yet.
+          </div>
+        ) : (
+          account.limitWindows.map((window) => (
+            <QuotaDetail
+              key={window.slot}
+              label={windowLongLabel(window)}
+              quota={window}
+              threshold={threshold}
+              showRoutingHint={showRoutingHint}
+            />
+          ))
+        )
+      ) : (
+        <>
+          <QuotaDetail
+            label="5 hour"
+            quota={shared(
+              account.fiveHourUtilization,
+              account.fiveHourResetAt,
+              account.fiveHourStatus,
+            )}
+            threshold={threshold}
+            showRoutingHint={showRoutingHint}
+          />
+          <QuotaDetail
+            label="7 day"
+            quota={shared(
+              account.sevenDayUtilization,
+              account.sevenDayResetAt,
+              account.sevenDayStatus,
+            )}
+            threshold={threshold}
+            showRoutingHint={showRoutingHint}
+          />
+          {MODEL_FAMILIES.flatMap((family) =>
+            account.familyWeekly[family] === null
+              ? []
+              : [
+                  <QuotaDetail
+                    key={family}
+                    label={FAMILY_LABELS[family]}
+                    quota={account.familyWeekly[family]}
+                    threshold={threshold}
+                    showRoutingHint={showRoutingHint}
+                  />,
+                ],
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function AccountDrawer({
+  account,
+  threshold,
+  close,
+  act,
+}: {
+  account: AccountSummary;
+  threshold: number;
+  close: () => void;
+  act: (action: "toggle" | "refresh" | "remove") => void;
+}) {
   const providerId =
     account.provider === "claude"
       ? account.accountUuid
@@ -1407,57 +1479,7 @@ function AccountDrawer({
         <SettingsBadge>{tier(account)}</SettingsBadge>
         <SettingsBadge>{statusPresentation(account).label}</SettingsBadge>
       </div>
-      <div className="space-y-4">
-        {account.provider === "codex" ? (
-          account.limitWindows.length === 0 ? (
-            <div className="text-sm text-muted-foreground">
-              No usage limits observed yet.
-            </div>
-          ) : (
-            account.limitWindows.map((window) => (
-              <QuotaDetail
-                key={window.slot}
-                label={windowLongLabel(window)}
-                quota={window}
-                threshold={threshold}
-              />
-            ))
-          )
-        ) : (
-          <>
-            <QuotaDetail
-              label="5 hour"
-              quota={shared(
-                account.fiveHourUtilization,
-                account.fiveHourResetAt,
-                account.fiveHourStatus,
-              )}
-              threshold={threshold}
-            />
-            <QuotaDetail
-              label="7 day"
-              quota={shared(
-                account.sevenDayUtilization,
-                account.sevenDayResetAt,
-                account.sevenDayStatus,
-              )}
-              threshold={threshold}
-            />
-            {MODEL_FAMILIES.flatMap((family) =>
-              account.familyWeekly[family] === null
-                ? []
-                : [
-                    <QuotaDetail
-                      key={family}
-                      label={FAMILY_LABELS[family]}
-                      quota={account.familyWeekly[family]}
-                      threshold={threshold}
-                    />,
-                  ],
-            )}
-          </>
-        )}
-      </div>
+      <AccountQuotaDetails account={account} threshold={threshold} />
       <dl className="grid grid-cols-[7rem_1fr] gap-x-3 gap-y-2 border-t border-border pt-4 text-sm">
         <dt className="text-muted-foreground">Kind</dt>
         <dd>
@@ -1632,9 +1654,149 @@ function LoginDrawer({
   );
 }
 
+function AccountPoolUsage() {
+  const rpc = useRpc<typeof accountPoolRpcContract>();
+  const [accounts, setAccounts] = useState<AccountSummary[] | null>(null);
+  const [threshold, setThreshold] = useState(0.98);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const mounted = useRef(false);
+  const request = useRef(0);
+  const load = useCallback(async () => {
+    const current = ++request.current;
+    try {
+      const [next, config] = await Promise.all([
+        rpc.call("account.list", null),
+        rpc.call("config.get", null),
+      ]);
+      if (!mounted.current || current !== request.current) return;
+      setAccounts(next);
+      setThreshold(config.switchThreshold);
+      setError(null);
+    } catch (loadError) {
+      if (mounted.current && current === request.current)
+        setError(errorText(loadError));
+    }
+  }, [rpc]);
+  useEffect(() => {
+    mounted.current = true;
+    void load();
+    return () => {
+      mounted.current = false;
+      request.current++;
+    };
+  }, [load]);
+  useRealtime(ACCOUNT_POOL_ACCOUNTS_CHANGED, () => void load());
+  useRealtime(ACCOUNT_POOL_CONFIG_CHANGED, () => void load());
+
+  const refresh = async () => {
+    setRefreshing(true);
+    setError(null);
+    const failures: string[] = [];
+    try {
+      const current = await rpc.call("account.list", null);
+      for (const account of current) {
+        if (!mounted.current) return;
+        try {
+          await rpc.call("account.refreshUsage", { accountId: account.id });
+        } catch (refreshError) {
+          failures.push(`${account.label}: ${errorText(refreshError)}`);
+        }
+      }
+      await load();
+      if (mounted.current && failures.length > 0) setError(failures.join("; "));
+    } catch (refreshError) {
+      if (mounted.current) setError(errorText(refreshError));
+    } finally {
+      if (mounted.current) setRefreshing(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-end">
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={refreshing}
+          onClick={() => void refresh()}
+        >
+          {refreshing ? "Reloading pooled usage…" : "Reload pooled usage"}
+        </Button>
+      </div>
+      {error === null ? null : (
+        <p role="alert" className="text-sm text-destructive-text">
+          {error}
+        </p>
+      )}
+      {accounts === null ? (
+        error === null ? (
+          <p className="text-sm text-muted-foreground">
+            Loading pooled accounts…
+          </p>
+        ) : null
+      ) : accounts.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          No pooled accounts configured.
+        </p>
+      ) : (
+        <div className="divide-y divide-border">
+          {accounts.map((account) => (
+            <section
+              key={account.id}
+              aria-label={account.label}
+              className="space-y-3 py-4 first:pt-0 last:pb-0"
+            >
+              <div className="flex flex-wrap items-start justify-between gap-2">
+                <div className="min-w-0">
+                  <h3 className="break-words text-sm font-semibold">
+                    {account.label}
+                  </h3>
+                  <p className="text-xs text-muted-foreground">
+                    {account.provider === "claude" ? "Claude" : "Codex"}
+                    {account.email !== null && account.email !== account.label
+                      ? ` · ${account.email}`
+                      : ""}
+                  </p>
+                </div>
+                <div className="flex flex-wrap gap-1.5">
+                  <SettingsBadge>{tier(account)}</SettingsBadge>
+                  <SettingsBadge>
+                    {statusPresentation(account).label}
+                  </SettingsBadge>
+                </div>
+              </div>
+              <AccountQuotaDetails
+                account={account}
+                threshold={threshold}
+                showRoutingHint={false}
+              />
+              {account.error === null ? null : (
+                <p className="text-xs text-destructive-text">{account.error}</p>
+              )}
+              <p className="text-xs text-muted-foreground">
+                {account.observedAt === null
+                  ? "Usage has not been observed yet."
+                  : `Updated ${relative(account.observedAt)}`}
+              </p>
+            </section>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export default definePluginApp((app) => {
   app.slots.settingsSection({
     id: "accounts",
     component: AccountPoolSettings,
+  });
+  app.slots.settingsSection({
+    id: "usage",
+    title: "Pooled accounts",
+    description: "Account pool usage shared across all machines.",
+    experimental_placement: "usage",
+    component: AccountPoolUsage,
   });
 });

--- a/plugins/account-pool/package.json
+++ b/plugins/account-pool/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "description": "Routes Claude and Codex API traffic across provider account pools.",
   "engines": {
-    "bb": ">=0.0"
+    "bb": ">=0.0",
+    "bbPluginSdk": "^0.4.49"
   },
   "bb": {
     "name": "Account Pooler [Experimental]",

--- a/plugins/account-pool/skills/account-pool/SKILL.md
+++ b/plugins/account-pool/skills/account-pool/SKILL.md
@@ -9,6 +9,12 @@ Use `bb pool` for this plugin's accounts and routes. Inspect current state with
 `bb pool status --json` and `bb pool account list --json` before changing routing.
 Use `bb pool --help` for available commands.
 
+Settings → Usage shows pooled accounts across all machines, including their
+quota windows, reset times, and status. Reload pooled usage refreshes each account.
+The same data is available through `bb pool account list --json` and plugin RPC
+`account.list`; refresh one account with `bb pool account refresh <id>` or RPC
+`account.refreshUsage`.
+
 For account login/import, secret handling, routing settings, ordering, or failover,
 read [references/accounts-and-routing.md](references/accounts-and-routing.md).
 

--- a/plugins/account-pool/src/cli.ts
+++ b/plugins/account-pool/src/cli.ts
@@ -40,6 +40,7 @@ const HELP = [
   "  bb pool account add --provider claude --api-key-stdin [--label <text>] [--priority <n>]",
   "  bb pool account add --provider claude --api-key <key> [--label <text>] [--priority <n>]  Unsafe: exposes the key in process arguments.",
   "  bb pool account list [--json]",
+  "  bb pool account refresh <id> [--json]",
   "  bb pool account remove <id>",
   "  bb pool account enable <id>",
   "  bb pool account disable <id>",
@@ -507,6 +508,19 @@ export function registerPoolCli(
           return {
             exitCode: 0,
             stdout: `Added ${account.label} (${account.id}).\n`,
+          };
+        }
+        if (argv[0] === "account" && argv[1] === "refresh") {
+          const { id } = accountIdInputSchema.parse({ id: argv[2] });
+          const flags = parseFlags(argv.slice(3), ["json"], []);
+          const account = await operations.refreshUsage(id);
+          if (account === null)
+            throw new Error(`Account ${id} does not exist.`);
+          return {
+            exitCode: 0,
+            stdout: flags.booleans.has("json")
+              ? json({ account })
+              : `${formatAccounts([account])}\n`,
           };
         }
         if (argv[0] === "account" && argv[1] === "list") {

--- a/plugins/account-pool/src/server.test.ts
+++ b/plugins/account-pool/src/server.test.ts
@@ -1217,6 +1217,27 @@ describe("Account Pool plugin", () => {
     const account = listed.accounts[0];
     if (account === undefined) throw new Error("CLI account was not listed.");
     expect(account).toMatchObject({ label: "Claude API key", priority: 100 });
+    const refreshed = await fixture.host.harness.behavior.runCli([
+      "account",
+      "refresh",
+      account.id,
+      "--json",
+    ]);
+    expect(refreshed.exitCode).toBe(0);
+    expect(
+      z
+        .object({ account: accountSummarySchema })
+        .strict()
+        .parse(JSON.parse(refreshed.stdout)).account.id,
+    ).toBe(account.id);
+    const missing = await fixture.host.harness.behavior.runCli([
+      "account",
+      "refresh",
+      "00000000-0000-4000-8000-000000000000",
+      "--json",
+    ]);
+    expect(missing.exitCode).toBe(1);
+
     expect(
       (
         await fixture.host.harness.behavior.runCli([


### PR DESCRIPTION
## Human comments

## What was wrong

Settings → Usage queried only the selected machine's provider login. Account Pooler tracks Claude and Codex quotas separately, but registered only an account-management section, so pooled accounts never appeared on the Usage screen. See #3243.

## What changed

- Added a Pooled accounts section below provider limits, with identity, plan, account status, quota windows, resets, and last-observed time. It includes disabled/error accounts and labels the pool as shared across machines.
- Reused the pooler's quota display and existing RPCs. Reload refreshes accounts sequentially, continues after an individual failure, and reports errors while retaining usage. Background account/configuration events update the section.
- Added opt-in `PluginSettingsSectionRegistration.experimental_placement: "usage"`, validated at registration and mounted through the existing plugin context and crash boundary. Existing settings sections retain their placement. Bumped Plugin SDK to 0.4.49 and documented the experimental API and required version.
- Added `bb pool account refresh <id> [--json]` for CLI parity and updated the guide and pooler skill. No daemon wire or account-routing changes.

## How you verified

- `pnpm exec turbo run typecheck --filter=@bb/app --filter=bb-plugin-account-pool --filter=@get-bb/plugin-sdk` — passed.
- `pnpm exec turbo run test --filter=@bb/app -- UsageLimitsSettingsSection PluginSettingsSections plugin-app-definition` — 60 tests passed, including placement validation, account controls staying on the plugin page, and usage removal on plugin unload.
- `pnpm exec turbo run test --filter=bb-plugin-account-pool -- app.test.tsx` — 18 tests passed, including mixed-provider quotas, disabled/error accounts, missing data, refresh failure isolation, initial-load recovery, and realtime updates.
- `pnpm exec turbo run test --filter=@bb/plugin-api-map -- surfaces.test.ts` — 12 tests passed.
- `bb plugin build <checkout>/plugins/account-pool` — backend/frontend bundles generated successfully. Generated artifacts/declarations are not committed.
- Formatting and whitespace checks passed; the SDK version-bump check passed.
- Full pooler suite: 256 tests passed, with one existing timeout in `evicts the least recently used binding after 4096 sessions` (20-second limit). The same test copied unchanged from upstream commit `06aeaa994942ae7527dc49d2268c1f801e8542a0` also times out when run alone on this Linux host. The routing implementation is unchanged. The added CLI refresh assertions passed in the full run. A subsequently added realtime UI test passed in the focused 18-test run above.
- No live browser QA or change to the user's running BB installation.

Fixes #3243

> AGENT GENERATED
