### PR TITLE
Fix project directory picker scroll reset

### DIFF
--- a/apps/app/src/components/dialogs/RemotePathBrowser.createFolder.test.tsx
+++ b/apps/app/src/components/dialogs/RemotePathBrowser.createFolder.test.tsx
@@ -248,6 +248,53 @@ describe("RemotePathBrowser new folder", () => {
 });
 
 describe("RemotePathBrowser entry list", () => {
+  it("returns to the top when browsing into another large directory", async () => {
+    const names = Array.from(
+      { length: 4999 },
+      (_, i) => `file_${String(i).padStart(5, "0")}`,
+    );
+    const rootEntries = [...names, "next"];
+    directory.mockImplementation(({ path }) =>
+      Promise.resolve(
+        listing(
+          path === "/home/me/manyfiles/next"
+            ? "/home/me/manyfiles/next"
+            : "/home/me/manyfiles",
+          path === "/home/me/manyfiles/next" ? names : rootEntries,
+        ),
+      ),
+    );
+    const { wrapper: Wrapper } = createQueryClientTestHarness();
+
+    const { container } = render(
+      <Wrapper>
+        <RemotePathBrowser
+          hostId="host_atum"
+          allowCreateFolder={false}
+          onDirectoryChange={vi.fn()}
+        />
+      </Wrapper>,
+    );
+
+    await screen.findByText("file_00000");
+    const list = container.querySelector("ul");
+    const scrollBox = list?.parentElement;
+    if (!(scrollBox instanceof HTMLElement)) throw new Error("no scroll box");
+    Object.defineProperty(scrollBox, "scrollTo", {
+      configurable: true,
+      value: ({ top }: ScrollToOptions) => {
+        scrollBox.scrollTop = top ?? scrollBox.scrollTop;
+        scrollBox.dispatchEvent(new Event("scroll"));
+      },
+    });
+    scrollBox.scrollTop = 4_999 * ENTRY_TEST_ROW_HEIGHT_PX;
+    fireEvent.scroll(scrollBox);
+    fireEvent.click(await screen.findByRole("button", { name: "next" }));
+
+    expect(scrollBox.scrollTop).toBe(0);
+    expect(await screen.findByText("file_00000")).not.toBeNull();
+  });
+
   it("mounts only the entries near the viewport for a huge directory", async () => {
     const names = Array.from(
       { length: 5000 },

--- a/apps/app/src/components/dialogs/RemotePathBrowser.tsx
+++ b/apps/app/src/components/dialogs/RemotePathBrowser.tsx
@@ -1,4 +1,10 @@
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { normalizeProjectPathInput } from "@bb/domain";
@@ -96,13 +102,33 @@ export function RemotePathBrowser({
 
   const entries = data?.entries ?? NO_ENTRIES;
   const scrollRef = useRef<HTMLDivElement>(null);
+  const getScrollElement = useCallback(() => scrollRef.current, []);
+  const estimateEntrySize = useCallback(
+    () => DIRECTORY_ENTRY_ROW_HEIGHT_PX,
+    [],
+  );
+  const getEntryKey = useCallback(
+    (index: number) => entries[index]?.path ?? index,
+    [entries],
+  );
   const entryVirtualizer = useVirtualizer({
     count: entries.length,
-    getScrollElement: () => scrollRef.current,
-    estimateSize: () => DIRECTORY_ENTRY_ROW_HEIGHT_PX,
-    getItemKey: (index) => entries[index]?.path ?? index,
+    getScrollElement,
+    estimateSize: estimateEntrySize,
+    getItemKey: getEntryKey,
     overscan: DIRECTORY_ENTRY_OVERSCAN_ROWS,
   });
+
+  const cancelCreatingFolder = () => {
+    setIsCreatingFolder(false);
+    setNewFolderError(null);
+  };
+
+  const navigateTo = (path: string) => {
+    cancelCreatingFolder();
+    entryVirtualizer.scrollToOffset(0);
+    setCurrentPath(path);
+  };
 
   const startCreatingFolder = () => {
     if (
@@ -118,16 +144,6 @@ export function RemotePathBrowser({
     setNewFolderName("");
     setNewFolderError(null);
     setIsCreatingFolder(true);
-  };
-
-  const cancelCreatingFolder = () => {
-    setIsCreatingFolder(false);
-    setNewFolderError(null);
-  };
-
-  const navigateTo = (path: string) => {
-    cancelCreatingFolder();
-    setCurrentPath(path);
   };
 
   const createFolder = useMutation({


### PR DESCRIPTION
## Human comments

## What was wrong

When a user opened a child folder after scrolling deeply through a large directory, the virtualized folder browser retained the prior directory's scroll offset. A similarly large child therefore opened partway down rather than at its first entry.

## What changed

The shared remote path browser now resets its virtualizer offset whenever it navigates to a directory. Its virtualizer option callbacks are also stable between unrelated renders, avoiding unnecessary measurement churn. Added a regression for browsing between two large directories. No wire, CLI, guide, or protocol changes.

## How you verified

- `pnpm exec turbo run test --filter=@bb/app --force -- --run src/components/dialogs/RemotePathBrowser.createFolder.test.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec oxfmt --check apps/app/src/components/dialogs/RemotePathBrowser.tsx apps/app/src/components/dialogs/RemotePathBrowser.createFolder.test.tsx`
- `git diff --check`

Fixes #

> AGENT GENERATED