### PR TITLE
Fix branch picker empty-state spacing

### DIFF
--- a/apps/app/src/components/pickers/BranchPicker.scroll.test.tsx
+++ b/apps/app/src/components/pickers/BranchPicker.scroll.test.tsx
@@ -63,4 +63,15 @@ describe("BranchPicker search", () => {
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).not.toBe(0);
   });
+
+  it("keeps an empty result in the branches section", () => {
+    render(
+      <BranchPicker value={null} options={[]} onChange={vi.fn()} modal={false} />,
+    );
+
+    fireEvent.click(screen.getByRole("combobox", { name: "Branch" }));
+
+    expect(screen.getByText("Branches")).toBeTruthy();
+    expect(screen.getByText("No branches found.").className).toContain("py-3");
+  });
 });

--- a/apps/app/src/components/pickers/BranchPicker.stories.tsx
+++ b/apps/app/src/components/pickers/BranchPicker.stories.tsx
@@ -28,7 +28,10 @@ const noop = () => {};
 type BranchPickerStoryConfig = Omit<
   BranchPickerProps,
   "onChange" | "options" | "variant"
-> & { currentBranch?: string | null };
+> & {
+  branchOptions?: readonly string[];
+  currentBranch?: string | null;
+};
 
 interface BranchPickerStoryRowProps {
   label: string;
@@ -190,6 +193,7 @@ function BranchPickerStoryRow({
   const [state, setState] = useState(() =>
     getInitialBranchPickerStoryState({ picker }),
   );
+  const { branchOptions, ...branchPickerProps } = picker;
   const triggerLabel = getStoryTriggerLabel({ picker, state });
   const triggerTitle = getStoryTriggerTitle({ picker, state });
   const handleCreate = picker.onCreate
@@ -221,10 +225,10 @@ function BranchPickerStoryRow({
   return (
     <StoryRow label={label} hint={hint}>
       <BranchPicker
-        {...picker}
+        {...branchPickerProps}
         value={state.value}
         isCreatingNew={state.isCreatingNew}
-        options={branches}
+        options={branchOptions ?? branches}
         remoteOptions={includeRemoteOptions ? remoteBranches : undefined}
         triggerLabel={triggerLabel}
         triggerTitle={triggerTitle}
@@ -291,6 +295,38 @@ export function Overview() {
         label="open long branches"
         hint="branch names wrap inside the popover"
         picker={longBranchPicker}
+      />
+    </StoryCard>
+  );
+}
+
+export function EmptyStates() {
+  return (
+    <StoryCard labelWidth="190px">
+      <BranchPickerStoryRow
+        label="loading branches"
+        hint="branch options are still loading"
+        includeRemoteOptions={false}
+        picker={{
+          value: null,
+          loading: true,
+          branchOptions: [],
+          defaultOpen: true,
+          modal: false,
+          triggerLabel: "Loading branches...",
+        }}
+      />
+      <BranchPickerStoryRow
+        label="no branches found"
+        hint="the repository has no selectable branches"
+        includeRemoteOptions={false}
+        picker={{
+          value: null,
+          branchOptions: [],
+          defaultOpen: true,
+          modal: false,
+          triggerLabel: "Select branch",
+        }}
       />
     </StoryCard>
   );

--- a/apps/app/src/components/pickers/BranchPicker.tsx
+++ b/apps/app/src/components/pickers/BranchPicker.tsx
@@ -813,6 +813,7 @@ export function BranchPicker({
     loading ||
     showCreateItem ||
     hasBranchOptions ||
+    (!hasCurrentItem && !branchChooserDisabled) ||
     ((branchOptionsDisabled || createDisabled) &&
       options.length + remoteOptions.length > 0);
   const showOptionsSearch = showBranchChooser && !branchChooserDisabled;
@@ -1157,7 +1158,7 @@ export function BranchPicker({
                     )}
                   </>
                 ) : hasCurrentItem ? null : (
-                  <p className="px-2 py-6 text-center text-xs text-muted-foreground">
+                  <p className="px-2 py-3 text-center text-xs text-muted-foreground">
                     {loading ? "Loading branches..." : "No branches found."}
                   </p>
                 )}


### PR DESCRIPTION
## Human comments

## What was wrong

The loaded-empty branch picker followed a terminal fallback that omitted the Branches section and used double vertical padding (`py-6`), while the loading state rendered within the section with the standard compact row spacing.

## What changed

Loaded-empty results without a current selection now remain in the options section, preserving the Branches heading and the same spacing as loading. The terminal fallback also uses the compact row padding. Added an Empty states Ladle story and a regression test.

## How you verified

- `pnpm exec turbo run test --filter=@bb/app -- --run src/components/pickers/BranchPicker.scroll.test.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run lint --filter=@bb/app` (passes with existing warnings)
- Captured before/after Ladle screenshots using SawyerHood/doobie.

Fixes #

> AGENT GENERATED