### PR TITLE
Fix collapsed model picker after chat handoff

### DIFF
--- a/apps/app/src/components/pickers/ModelReasoningPicker.test.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.test.tsx
@@ -503,7 +503,7 @@ describe("ModelReasoningPicker", () => {
     ).toBe("");
   });
 
-  it("caps the desktop picker and scrolls only the model list", () => {
+  it("keeps desktop models from collapsing and lets all controls scroll", () => {
     renderPicker({ modelOptions: manyCodexModels });
 
     fireEvent.click(
@@ -521,11 +521,13 @@ describe("ModelReasoningPicker", () => {
       ...menu.querySelectorAll<HTMLElement>("[class*='overflow-y-auto']"),
     ];
     expect(scrollers).toHaveLength(1);
+    expect(scrollers[0].contains(screen.getByText("High"))).toBe(true);
 
     const models = screen.getByRole("listbox", { name: "Models" });
-    expect(scrollers[0]).toBe(models);
-    expect(models.className).toContain("overscroll-contain");
-    expect(models.className).toContain("max-h-64");
+    expect(scrollers[0].contains(models)).toBe(true);
+    expect(models.className).toContain("shrink-0");
+    expect(scrollers[0].className).toContain("overscroll-contain");
+    expect(models.className).not.toContain("max-h-");
     expect(models.contains(screen.getByText("High"))).toBe(false);
   });
 
@@ -673,11 +675,13 @@ describe("ModelReasoningPicker", () => {
 
     const search = screen.getByPlaceholderText("Search models");
     const list = screen.getByRole("listbox", { name: "Models" });
-    list.scrollTop = 120;
+    const viewport = list.parentElement;
+    if (!viewport) throw new Error("Missing model picker scroll viewport");
+    viewport.scrollTop = 120;
 
     fireEvent.change(search, { target: { value: "o4" } });
 
-    expect(list.scrollTop).toBe(0);
+    expect(viewport.scrollTop).toBe(0);
   });
 
   it("resets retained mobile browse state after the drawer closes", () => {

--- a/apps/app/src/components/pickers/ModelReasoningPicker.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.tsx
@@ -941,22 +941,21 @@ export function ModelReasoningPicker({
 
         <MenuHoverProvider>
           <div
+            key={activeProviderId || "no-provider"}
+            ref={isCompactViewport ? undefined : listRef}
             className={cn(
               !isCompactViewport &&
-                "min-h-0 flex flex-1 flex-col overflow-hidden",
+                "min-h-0 flex flex-1 flex-col overflow-y-auto overscroll-contain",
             )}
           >
             <div
-              ref={listRef}
-              key={activeProviderId || "no-provider"}
+              ref={isCompactViewport ? listRef : undefined}
               role={showSearchInput ? "listbox" : undefined}
               id={showSearchInput ? listboxId : undefined}
               aria-label={showSearchInput ? "Models" : undefined}
               className={cn(
                 "px-1 pb-1 pt-0",
-                isCompactViewport
-                  ? "overflow-y-auto"
-                  : "min-h-0 max-h-64 flex-1 overflow-y-auto overscroll-contain",
+                isCompactViewport ? "overflow-y-auto" : "shrink-0",
               )}
             >
               {isShowingModelError ? null : (

--- a/apps/app/src/components/plugin/PluginNewThreadComposer.test.tsx
+++ b/apps/app/src/components/plugin/PluginNewThreadComposer.test.tsx
@@ -991,6 +991,19 @@ describe("PluginNewThreadComposer seeding", () => {
       ),
     ).toBe(false);
     expect(latestPromptBoxProps().attachments.items).toEqual([]);
+    await act(async () => {
+      latestPromptBoxProps().execution.model.onChange("gpt-5.6-sol");
+    });
+    expect(latestPromptBoxProps().execution.model.selected).toBe("gpt-5.6-sol");
+    expect(latestPromptBoxProps().value).toBe(
+      "Continue from @thread:thr_source",
+    );
+    await act(async () => {
+      latestPromptBoxProps().execution.provider.onChange("claude-code");
+    });
+    expect(latestPromptBoxProps().execution.provider.selectedId).toBe(
+      "claude-code",
+    );
   });
 
   it("applies a replacing initial prompt from location state exactly once", async () => {


### PR DESCRIPTION
## Human comments

## What was wrong

After handing a chat off to the new-thread composer, the model picker could appear to prevent model changes in a short window. Its reasoning and service-tier sections could not shrink, while the model list could shrink to almost zero height. The catalog loaded successfully, but its model rows were clipped and could not receive clicks.

## What changed

Make the desktop picker body one scrollable area for models, reasoning, service tier, and the handoff action. Keep the model list from shrinking, and reset the actual scroll viewport when searching or switching providers. Update picker regression coverage and check that model/provider changes preserve the handoff draft.

## How you verified

- 50 tests passed: `pnpm exec turbo run test --env-mode=loose --filter=@bb/app -- --run src/components/pickers/ModelReasoningPicker.test.tsx src/components/plugin/PluginNewThreadComposer.test.tsx`. A writable `TMPDIR` was supplied because the host's shared `/tmp` was full.
- Reproduced the collapsed list in Chromium at 780 × 437. After the fix, clicked **Handoff to new thread**, selected another model, scrolled to reasoning/service-tier controls, and searched for another model. Selection and the source-thread mention survived reload.
- Captured the comparison below by clicking **Handoff to new thread** on the original picker, then restoring the fix and testing the same handoff draft at the same 780 × 437 viewport. Before: the list was 4 px tall, and attempting to click Terra left Sol selected. After: the list was 189 px tall and clicking Terra changed the selection. Compact-drawer component tests pass; native iOS Safari was not run.

### Before: after Handoff to new thread

The composer contains **Continue from Reply only with ok.**, confirming the handoff. The model list is clipped to 4 px. Attempting to select **5.6-Terra** leaves **5.6-Sol** selected.

![Before: handoff draft is present but other models cannot be clicked](https://raw.githubusercontent.com/MateoCerquetella/bb/079ae6cd9d0fb5748466a18bfa7f2ecec866546c/before.png)

### After: a different model selected in the same handoff draft

At the same window size, the model choices are visible and **5.6-Terra** is selected. The source-thread mention stays intact.

![After: selecting 5.6-Terra in the handoff draft](https://raw.githubusercontent.com/MateoCerquetella/bb/079ae6cd9d0fb5748466a18bfa7f2ecec866546c/after.png)



