### PR TITLE
Keep rendered diff cards during refresh

### DIFF
--- a/apps/app/src/components/secondary-panel/git-diff/DiffFilesPanel.tsx
+++ b/apps/app/src/components/secondary-panel/git-diff/DiffFilesPanel.tsx
@@ -61,14 +61,24 @@ export function DiffFilesPanel({
   onSelectionAddToChat,
 }: DiffFilesPanelProps) {
   const scrollRef = useRef<HTMLDivElement | null>(null);
-  const { requestPaths, getPatchState, retry, loadPath, seedInitialPatches } =
-    useEnvironmentDiffPatches(environmentId, { target });
+  const {
+    requestPaths,
+    getPatchState,
+    retry,
+    loadPath,
+    seedInitialPatches,
+    prunePaths,
+  } = useEnvironmentDiffPatches(environmentId, { target });
 
   useEffect(() => {
     if (initialPatches.length > 0) {
       seedInitialPatches(initialPatches);
     }
   }, [seedInitialPatches, initialPatches, filesUpdatedAt]);
+
+  useEffect(() => {
+    prunePaths(files.map((file) => file.path));
+  }, [files, prunePaths]);
 
   const virtualizer = useVirtualizer({
     count: files.length,

--- a/apps/app/src/hooks/cache-owners/environment-diff-patch-cache-owner.ts
+++ b/apps/app/src/hooks/cache-owners/environment-diff-patch-cache-owner.ts
@@ -13,6 +13,7 @@ export interface PatchQueryIdentity {
 }
 
 const diffPatchEvictionGenerations = new Map<string, number>();
+const diffPatchFreshnessGenerations = new Map<string, number>();
 
 let allEnvironmentsEvictionGeneration = 0;
 
@@ -28,6 +29,18 @@ export function bumpDiffPatchEvictionGeneration(environmentId: string): void {
     environmentId,
     (diffPatchEvictionGenerations.get(environmentId) ?? 0) + 1,
   );
+  bumpDiffPatchFreshnessGeneration(environmentId);
+}
+
+export function getDiffPatchFreshnessGeneration(environmentId: string): number {
+  return diffPatchFreshnessGenerations.get(environmentId) ?? 0;
+}
+
+export function bumpDiffPatchFreshnessGeneration(environmentId: string): void {
+  diffPatchFreshnessGenerations.set(
+    environmentId,
+    getDiffPatchFreshnessGeneration(environmentId) + 1,
+  );
 }
 
 export function bumpAllDiffPatchEvictionGenerations(): void {
@@ -38,6 +51,52 @@ interface ReadDiffPatchEntryArgs {
   queryClient: QueryClient;
   identity: PatchQueryIdentity;
   path: string;
+}
+
+const diffPatchFreshnessByClient = new WeakMap<
+  QueryClient,
+  Map<string, Map<string, number>>
+>();
+
+function getDiffPatchFreshnessEntries(
+  queryClient: QueryClient,
+  environmentId: string,
+): Map<string, number> {
+  let entriesByEnvironment = diffPatchFreshnessByClient.get(queryClient);
+  if (entriesByEnvironment === undefined) {
+    entriesByEnvironment = new Map();
+    diffPatchFreshnessByClient.set(queryClient, entriesByEnvironment);
+  }
+  let entries = entriesByEnvironment.get(environmentId);
+  if (entries === undefined) {
+    entries = new Map();
+    entriesByEnvironment.set(environmentId, entries);
+  }
+  return entries;
+}
+
+function diffPatchEntryFreshnessKey(
+  identity: PatchQueryIdentity,
+  path: string,
+): string {
+  return JSON.stringify([identity.targetType, identity.targetKey, path]);
+}
+
+export function isDiffPatchEntryFresh({
+  queryClient,
+  identity,
+  path,
+}: ReadDiffPatchEntryArgs): boolean {
+  const freshnessGeneration = getDiffPatchFreshnessGeneration(
+    identity.environmentId,
+  );
+  const entryGeneration = getDiffPatchFreshnessEntries(
+    queryClient,
+    identity.environmentId,
+  ).get(diffPatchEntryFreshnessKey(identity, path));
+  return entryGeneration === undefined
+    ? freshnessGeneration === 0
+    : entryGeneration === freshnessGeneration;
 }
 
 export function readDiffPatchEntry({
@@ -59,12 +118,14 @@ interface WriteDiffPatchEntryArgs {
   queryClient: QueryClient;
   identity: PatchQueryIdentity;
   entry: DiffPatchEntry;
+  freshnessGeneration?: number;
 }
 
 export function writeDiffPatchEntry({
   queryClient,
   identity,
   entry,
+  freshnessGeneration = getDiffPatchFreshnessGeneration(identity.environmentId),
 }: WriteDiffPatchEntryArgs): void {
   const queryKey = environmentDiffPatchQueryKey(
     identity.environmentId,
@@ -76,6 +137,50 @@ export function writeDiffPatchEntry({
     .getQueryCache()
     .build(queryClient, { queryKey, gcTime: Infinity });
   queryClient.setQueryData<DiffPatchEntry>(queryKey, entry);
+  getDiffPatchFreshnessEntries(queryClient, identity.environmentId).set(
+    diffPatchEntryFreshnessKey(identity, entry.path),
+    freshnessGeneration,
+  );
+}
+
+export function pruneDiffPatchEntries({
+  queryClient,
+  identity,
+  paths,
+}: {
+  queryClient: QueryClient;
+  identity: PatchQueryIdentity;
+  paths: readonly string[];
+}): void {
+  const retainedPaths = new Set(paths);
+  const entries = getDiffPatchFreshnessEntries(
+    queryClient,
+    identity.environmentId,
+  );
+  for (const key of Array.from(entries.keys())) {
+    const [targetType, targetKey, path] = JSON.parse(key) as [
+      string | null,
+      string | null,
+      string,
+    ];
+    if (
+      targetType !== identity.targetType ||
+      targetKey !== identity.targetKey ||
+      retainedPaths.has(path)
+    ) {
+      continue;
+    }
+    entries.delete(key);
+    queryClient.removeQueries({
+      exact: true,
+      queryKey: environmentDiffPatchQueryKey(
+        identity.environmentId,
+        identity.targetType,
+        identity.targetKey,
+        path,
+      ),
+    });
+  }
 }
 
 interface DiffPatchRetentionLease {
@@ -134,6 +239,7 @@ export function retainDiffPatchQueries({
       }
       leases.delete(environmentId);
       bumpDiffPatchEvictionGeneration(environmentId);
+      diffPatchFreshnessByClient.get(queryClient)?.delete(environmentId);
       queryClient.removeQueries({
         queryKey: environmentDiffPatchQueryKeyPrefix(environmentId),
       });

--- a/apps/app/src/hooks/cache-owners/realtime-cache-registry.ts
+++ b/apps/app/src/hooks/cache-owners/realtime-cache-registry.ts
@@ -22,10 +22,10 @@ import {
   getEnvironmentWorkspaceStateInvalidationQueryKeys,
   getFetchingThreadListQueryKeys,
   isArchivedThreadListQueryKey,
-  removeEnvironmentDiffPatchQueries,
   updateCachedThreadListPendingInteractionState,
   updateCachedThreadListStatusState,
 } from "./query-cache";
+import { bumpDiffPatchFreshnessGeneration } from "./environment-diff-patch-cache-owner";
 import {
   getCachedThreadLists,
   iterateThreadListCacheEntries,
@@ -1022,18 +1022,19 @@ function dirtyEnvironmentRecordQueries(
 function dirtyEnvironmentWorkspaceStateQueries(
   context: EnvironmentRealtimeDirtyContext,
 ): void {
+  bumpDiffPatchFreshnessGeneration(context.environmentId);
   for (const queryKey of getEnvironmentWorkspaceStateInvalidationQueryKeys(
     context,
   )) {
     context.queryClient.invalidateQueries({ queryKey });
   }
-  removeEnvironmentDiffPatchQueries(context);
 }
 
 function dirtyEnvironmentLiveWorkspaceStateQueries({
   environmentId,
   queryClient,
 }: EnvironmentRealtimeDirtyContext): void {
+  bumpDiffPatchFreshnessGeneration(environmentId);
   invalidateQueryKeyWithThrottledActiveRefetch({
     exact: false,
     minIntervalMs: WORK_STATUS_REFETCH_MIN_INTERVAL_MS,
@@ -1046,20 +1047,19 @@ function dirtyEnvironmentLiveWorkspaceStateQueries({
   queryClient.invalidateQueries({
     queryKey: environmentDiffFilesQueryKeyPrefix(environmentId),
   });
-  removeEnvironmentDiffPatchQueries({ environmentId, queryClient });
 }
 
 function dirtyEnvironmentRefDerivedWorkspaceStateQueries({
   environmentId,
   queryClient,
 }: EnvironmentRealtimeDirtyContext): void {
+  bumpDiffPatchFreshnessGeneration(environmentId);
   for (const queryKey of getCachedEnvironmentRefWorkspaceStateInvalidationQueryKeys(
     queryClient,
     { environmentId },
   )) {
     queryClient.invalidateQueries({ queryKey });
   }
-  removeEnvironmentDiffPatchQueries({ environmentId, queryClient });
 }
 
 function dirtyEnvironmentBranchListQueries(

--- a/apps/app/src/hooks/queries/use-environment-diff-patches.test.tsx
+++ b/apps/app/src/hooks/queries/use-environment-diff-patches.test.tsx
@@ -11,7 +11,10 @@ import { sdk } from "@/lib/sdk";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
 import { removeEnvironmentDiffPatchQueries } from "../cache-owners/query-cache";
-import { bumpAllDiffPatchEvictionGenerations } from "../cache-owners/environment-diff-patch-cache-owner";
+import {
+  bumpAllDiffPatchEvictionGenerations,
+  bumpDiffPatchFreshnessGeneration,
+} from "../cache-owners/environment-diff-patch-cache-owner";
 import { environmentDiffPatchQueryKey } from "./query-keys";
 import { HEAVY_PAYLOAD_GC_TIME_MS } from "./query-policies";
 import { useEnvironmentDiffPatches } from "./use-environment-diff-patches";
@@ -303,6 +306,106 @@ describe("useEnvironmentDiffPatches", () => {
       expect(state.patch).toBe(patch.patch);
     });
     expect(queryClient.getQueryData<DiffPatchEntry>(patchKey())).toEqual(patch);
+  });
+
+  it("refreshes a retained patch without returning its card to loading", async () => {
+    const { wrapper, queryClient } = createQueryClientTestHarness();
+    const currentPatch: DiffPatchEntry = {
+      path: PATH,
+      patch: "diff --git a/file.ts b/file.ts\n+current\n",
+      truncated: false,
+    };
+    const refreshedPatch: DiffPatchEntry = {
+      path: PATH,
+      patch: "diff --git a/file.ts b/file.ts\n+refreshed\n",
+      truncated: false,
+    };
+    const refresh = createDeferredPromise<EnvironmentDiffPatchResponse>();
+    vi.mocked(sdk.environments.diffPatch).mockReturnValue(refresh.promise);
+
+    const { result } = renderHook(
+      () => useEnvironmentDiffPatches(ENVIRONMENT_ID, { target: TARGET }),
+      { wrapper },
+    );
+    act(() => {
+      result.current.seedInitialPatches([currentPatch]);
+      bumpDiffPatchFreshnessGeneration(ENVIRONMENT_ID);
+      result.current.requestPaths({
+        visible: [PATH],
+        overscan: [],
+      });
+    });
+
+    await waitFor(() => {
+      expect(sdk.environments.diffPatch).toHaveBeenCalledTimes(1);
+    });
+    expect(result.current.getPatchState(PATH)).toMatchObject({
+      status: "loaded",
+      patch: currentPatch.patch,
+    });
+
+    await act(async () => {
+      refresh.resolve(availableResponse(refreshedPatch));
+      await refresh.promise;
+    });
+
+    await waitFor(() => {
+      expect(result.current.getPatchState(PATH)).toMatchObject({
+        status: "loaded",
+        patch: refreshedPatch.patch,
+      });
+    });
+    expect(queryClient.getQueryData<DiffPatchEntry>(patchKey())).toEqual(
+      refreshedPatch,
+    );
+  });
+
+  it("rejects an older response and starts a newer request after a freshness change", async () => {
+    const { wrapper, queryClient } = createQueryClientTestHarness();
+    const staleRequest = createDeferredPromise<EnvironmentDiffPatchResponse>();
+    const freshRequest = createDeferredPromise<EnvironmentDiffPatchResponse>();
+    const stalePatch: DiffPatchEntry = {
+      path: PATH,
+      patch: "stale",
+      truncated: false,
+    };
+    const freshPatch: DiffPatchEntry = {
+      path: PATH,
+      patch: "fresh",
+      truncated: false,
+    };
+    vi.mocked(sdk.environments.diffPatch)
+      .mockReturnValueOnce(staleRequest.promise)
+      .mockReturnValueOnce(freshRequest.promise);
+    const { result } = renderHook(
+      () => useEnvironmentDiffPatches(ENVIRONMENT_ID, { target: TARGET }),
+      { wrapper },
+    );
+    act(() => {
+      result.current.requestPaths({ visible: [PATH], overscan: [] });
+    });
+    await waitFor(() =>
+      expect(sdk.environments.diffPatch).toHaveBeenCalledTimes(1),
+    );
+    act(() => {
+      bumpDiffPatchFreshnessGeneration(ENVIRONMENT_ID);
+      result.current.requestPaths({ visible: [PATH], overscan: [] });
+    });
+    await waitFor(() =>
+      expect(sdk.environments.diffPatch).toHaveBeenCalledTimes(2),
+    );
+    await act(async () => {
+      staleRequest.resolve(availableResponse(stalePatch));
+      await staleRequest.promise;
+    });
+    expect(queryClient.getQueryData(patchKey())).toBeUndefined();
+    await act(async () => {
+      freshRequest.resolve(availableResponse(freshPatch));
+      await freshRequest.promise;
+    });
+    await waitFor(() =>
+      expect(result.current.getPatchState(PATH).patch).toBe(freshPatch.patch),
+    );
   });
 });
 

--- a/apps/app/src/hooks/queries/use-environment-diff-patches.ts
+++ b/apps/app/src/hooks/queries/use-environment-diff-patches.ts
@@ -11,6 +11,9 @@ import { extractErrorMessage } from "@bb/core-ui";
 import {
   type PatchQueryIdentity,
   getDiffPatchEvictionGeneration,
+  getDiffPatchFreshnessGeneration,
+  isDiffPatchEntryFresh,
+  pruneDiffPatchEntries,
   readDiffPatchEntry,
   retainDiffPatchQueries,
   writeDiffPatchEntry,
@@ -42,6 +45,7 @@ type GetDiffPatchState = (path: string) => DiffPatchState;
 export type RetryDiffPatchPath = (path: string) => void;
 export type LoadDiffPatchPath = (path: string) => void;
 type SeedDiffPatchEntries = (entries: DiffPatchEntry[]) => void;
+type PruneDiffPatchEntries = (paths: readonly string[]) => void;
 
 interface UseEnvironmentDiffPatchesResult {
   requestPaths: RequestDiffPatchPaths;
@@ -49,6 +53,7 @@ interface UseEnvironmentDiffPatchesResult {
   retry: RetryDiffPatchPath;
   loadPath: LoadDiffPatchPath;
   seedInitialPatches: SeedDiffPatchEntries;
+  prunePaths: PruneDiffPatchEntries;
 }
 
 const IDLE_STATE: DiffPatchState = { status: "idle" };
@@ -60,7 +65,7 @@ interface PendingPaths {
 
 interface InFlightState {
   loading: ReadonlyMap<string, number>;
-  errors: ReadonlyMap<string, string>;
+  errors: ReadonlyMap<string, { generation: number; message: string }>;
 }
 
 const EMPTY_IN_FLIGHT: InFlightState = {
@@ -137,8 +142,12 @@ export function useEnvironmentDiffPatches(
   );
 
   const [inFlight, setInFlight] = useState<InFlightState>(EMPTY_IN_FLIGHT);
+  const [, setPatchCacheRevision] = useState(0);
 
-  const pendingPathsRef = useRef<PendingPaths>({ visible: [], overscan: [] });
+  const pendingPathsRef = useRef<PendingPaths>({
+    visible: [],
+    overscan: [],
+  });
   const targetIdentityRef = useRef(targetIdentity);
   const inFlightRef = useRef(inFlight);
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -177,7 +186,11 @@ export function useEnvironmentDiffPatches(
   }, [environmentId, queryClient]);
 
   const fetchPage = useCallback(
-    async (paths: string[], generationTarget: string) => {
+    async (
+      paths: string[],
+      generationTarget: string,
+      freshnessGeneration: number,
+    ) => {
       if (!environmentId || target === undefined) {
         return;
       }
@@ -198,24 +211,31 @@ export function useEnvironmentDiffPatches(
           return;
         }
         if (
-          getDiffPatchEvictionGeneration(environmentId) !== evictionGeneration
+          getDiffPatchEvictionGeneration(environmentId) !==
+            evictionGeneration ||
+          getDiffPatchFreshnessGeneration(environmentId) !== freshnessGeneration
         ) {
           setInFlight((previous) =>
-            clearLoading(previous, paths, evictionGeneration),
+            clearLoading(previous, paths, freshnessGeneration),
           );
           return;
         }
         if (response.outcome === "available") {
           const returnedPaths = new Set<string>();
           for (const entry of response.patches) {
-            writeDiffPatchEntry({ queryClient, identity, entry });
+            writeDiffPatchEntry({
+              queryClient,
+              identity,
+              entry,
+              freshnessGeneration,
+            });
             returnedPaths.add(entry.path);
           }
           setInFlight((previous) =>
             settlePage({
               previous,
               paths,
-              loadingGeneration: evictionGeneration,
+              loadingGeneration: freshnessGeneration,
               returnedPaths,
             }),
           );
@@ -224,7 +244,7 @@ export function useEnvironmentDiffPatches(
             settlePage({
               previous,
               paths,
-              loadingGeneration: evictionGeneration,
+              loadingGeneration: freshnessGeneration,
               error: patchPageError(response),
             }),
           );
@@ -237,10 +257,12 @@ export function useEnvironmentDiffPatches(
           return;
         }
         if (
-          getDiffPatchEvictionGeneration(environmentId) !== evictionGeneration
+          getDiffPatchEvictionGeneration(environmentId) !==
+            evictionGeneration ||
+          getDiffPatchFreshnessGeneration(environmentId) !== freshnessGeneration
         ) {
           setInFlight((previous) =>
-            clearLoading(previous, paths, evictionGeneration),
+            clearLoading(previous, paths, freshnessGeneration),
           );
           return;
         }
@@ -250,7 +272,7 @@ export function useEnvironmentDiffPatches(
           settlePage({
             previous,
             paths,
-            loadingGeneration: evictionGeneration,
+            loadingGeneration: freshnessGeneration,
             error: message,
           }),
         );
@@ -271,22 +293,28 @@ export function useEnvironmentDiffPatches(
     }
     const ordered = dedupeOrderedPaths(pendingPathsRef.current);
 
-    const currentEvictionGeneration =
-      getDiffPatchEvictionGeneration(environmentId);
+    const currentFreshnessGeneration =
+      getDiffPatchFreshnessGeneration(environmentId);
     const toFetch = ordered.filter((path) => {
-      if (readDiffPatchEntry({ queryClient, identity, path }) !== undefined) {
+      if (
+        readDiffPatchEntry({ queryClient, identity, path }) !== undefined &&
+        isDiffPatchEntryFresh({ queryClient, identity, path })
+      ) {
         return false;
       }
       if (
         isLoadingForCurrentGeneration(
           inFlightRef.current.loading,
           path,
-          currentEvictionGeneration,
+          currentFreshnessGeneration,
         )
       ) {
         return false;
       }
-      if (inFlightRef.current.errors.has(path)) {
+      if (
+        inFlightRef.current.errors.get(path)?.generation ===
+        currentFreshnessGeneration
+      ) {
         return false;
       }
       return true;
@@ -297,11 +325,11 @@ export function useEnvironmentDiffPatches(
     }
 
     setInFlight((previous) =>
-      markLoading(previous, toFetch, currentEvictionGeneration),
+      markLoading(previous, toFetch, currentFreshnessGeneration),
     );
 
     for (const page of chunkPaths(toFetch)) {
-      void fetchPage(page, targetIdentity);
+      void fetchPage(page, targetIdentity, currentFreshnessGeneration);
     }
   }, [environmentId, target, targetIdentity, identity, queryClient, fetchPage]);
 
@@ -325,11 +353,11 @@ export function useEnvironmentDiffPatches(
   const loadPathNow = useCallback(
     (path: string) => {
       const generationTarget = targetIdentityRef.current;
-      const loadingGeneration = getDiffPatchEvictionGeneration(environmentId);
+      const loadingGeneration = getDiffPatchFreshnessGeneration(environmentId);
       setInFlight((previous) =>
         markLoading(previous, [path], loadingGeneration),
       );
-      void fetchPage([path], generationTarget);
+      void fetchPage([path], generationTarget, loadingGeneration);
     },
     [environmentId, fetchPage],
   );
@@ -344,14 +372,17 @@ export function useEnvironmentDiffPatches(
 
   const loadPath = useCallback(
     (path: string) => {
-      if (readDiffPatchEntry({ queryClient, identity, path }) !== undefined) {
+      if (
+        readDiffPatchEntry({ queryClient, identity, path }) !== undefined &&
+        isDiffPatchEntryFresh({ queryClient, identity, path })
+      ) {
         return;
       }
       if (
         isLoadingForCurrentGeneration(
           inFlightRef.current.loading,
           path,
-          getDiffPatchEvictionGeneration(environmentId),
+          getDiffPatchFreshnessGeneration(environmentId),
         ) ||
         inFlightRef.current.errors.has(path)
       ) {
@@ -373,27 +404,58 @@ export function useEnvironmentDiffPatches(
         };
       }
       const error = inFlight.errors.get(path);
-      if (error !== undefined) {
-        return { status: "error", error };
+      if (
+        error?.generation === getDiffPatchFreshnessGeneration(environmentId)
+      ) {
+        return { status: "error", error: error.message };
       }
       if (inFlight.loading.has(path)) {
         return { status: "loading" };
       }
       return IDLE_STATE;
     },
-    [queryClient, identity, inFlight],
+    [queryClient, identity, inFlight, environmentId],
   );
 
   const seedInitialPatches = useCallback(
     (entries: DiffPatchEntry[]) => {
+      let changed = false;
       for (const entry of entries) {
+        const previous = readDiffPatchEntry({
+          queryClient,
+          identity,
+          path: entry.path,
+        });
+        if (
+          previous?.patch !== entry.patch ||
+          previous.truncated !== entry.truncated
+        ) {
+          changed = true;
+        }
         writeDiffPatchEntry({ queryClient, identity, entry });
+      }
+      if (changed) {
+        setPatchCacheRevision((revision) => revision + 1);
       }
     },
     [queryClient, identity],
   );
 
-  return { requestPaths, getPatchState, retry, loadPath, seedInitialPatches };
+  const prunePaths = useCallback(
+    (paths: readonly string[]) => {
+      pruneDiffPatchEntries({ queryClient, identity, paths });
+    },
+    [queryClient, identity],
+  );
+
+  return {
+    requestPaths,
+    getPatchState,
+    retry,
+    loadPath,
+    seedInitialPatches,
+    prunePaths,
+  };
 }
 
 function markLoading(
@@ -446,9 +508,12 @@ function settlePage({
       loading.delete(path);
     }
     if (error !== undefined) {
-      errors.set(path, error);
+      errors.set(path, { generation: loadingGeneration, message: error });
     } else if (returnedPaths !== undefined && !returnedPaths.has(path)) {
-      errors.set(path, MISSING_PATCH_MESSAGE);
+      errors.set(path, {
+        generation: loadingGeneration,
+        message: MISSING_PATCH_MESSAGE,
+      });
     } else {
       errors.delete(path);
     }

--- a/apps/app/src/hooks/realtime-cache-effects.test.ts
+++ b/apps/app/src/hooks/realtime-cache-effects.test.ts
@@ -1162,7 +1162,7 @@ describe("createRealtimeCacheEffects", () => {
     effects.dispose();
   });
 
-  it("refetches the active diff TOC and work-status queries but evicts the observer-less patch cache for work-status changes", async () => {
+  it("refetches the active diff TOC and work-status queries while retaining rendered patch cache for work-status changes", async () => {
     vi.useFakeTimers();
     const { effects, queryClient } = createRealtimeEffectsTestContext();
     const diffFilesKey = environmentDiffFilesQueryKey("env-1", "all", "main");
@@ -1217,7 +1217,11 @@ describe("createRealtimeCacheEffects", () => {
 
     expect(diffFilesQueryFn).toHaveBeenCalledTimes(1);
     expect(workStatusQueryFn).toHaveBeenCalledTimes(1);
-    expect(queryClient.getQueryData(diffPatchKey)).toBeUndefined();
+    expect(queryClient.getQueryData(diffPatchKey)).toEqual({
+      path: "file.ts",
+      patch: "diff --git a/file.ts b/file.ts\n",
+      truncated: false,
+    });
 
     unsubscribeDiffFiles();
     unsubscribeWorkStatus();


### PR DESCRIPTION
## Human comments


## What was wrong

Realtime workspace-change invalidation deleted every cached per-file patch before the refreshed diff table of contents could establish whether its contents had changed. Visible cards therefore regressed from rendered content to loading skeletons, including for filesystem changes that produced the same Git diff.

## What changed

Retain per-file patch cache across realtime workspace invalidations. When the diff table of contents refreshes, refresh visible cached patches in place while retaining their rendered content; replacement patch content is rendered only after it arrives. Initial patch seeding only notifies React when its patch payload actually changed. No wire or CLI changes.

## How you verified

- `pnpm exec turbo run test --filter=@bb/app -- --run src/hooks/realtime-cache-effects.test.ts src/hooks/queries/use-environment-diff-patches.test.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run lint --filter=@bb/app`
- `git diff --check`

Fixes #

> AGENT GENERATED