### PR TITLE
Use file icon for Files settings

### DIFF
--- a/apps/app/src/components/settings/settings-nav.test.tsx
+++ b/apps/app/src/components/settings/settings-nav.test.tsx
@@ -77,8 +77,8 @@ describe("useSettingsNavState", () => {
       wrapper: wrapperFor("/settings/files"),
     });
 
-    expect(result.current.sections.map((section) => section.id)).toContain(
-      "files",
+    expect(result.current.sections).toContainEqual(
+      expect.objectContaining({ icon: "File", id: "files" }),
     );
   });
 

--- a/apps/app/src/components/settings/settings-sections.ts
+++ b/apps/app/src/components/settings/settings-sections.ts
@@ -7,7 +7,7 @@ export const SETTINGS_NAV_SECTIONS = [
   { icon: "Palette", id: "appearance", label: "Appearance" },
   { icon: "SlidersHorizontal", id: "keyboard", label: "Keyboard" },
   { icon: "ChartColumn", id: "usage", label: "Usage limits" },
-  { icon: "Folder", id: "files", label: "Files" },
+  { icon: "File", id: "files", label: "Files" },
   { icon: "Laptop", id: "machines", label: "Machines" },
   { icon: "PackageReceive", id: "updates", label: "Updates" },
   { icon: "ElectricPlugs", id: "plugins", label: "Installed plugins" },


### PR DESCRIPTION
## Summary

Root cause: the Files settings navigation item used the folder icon instead of the existing file icon used by file @-mention rows.

Change: use the shared `File` icon and assert that navigation metadata in the settings test.

## Verification

- `pnpm exec turbo run test --filter=@bb/app -- --run src/components/settings/settings-nav.test.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/app --filter=@bb/shared-ui`

> AGENT GENERATED