### PR TITLE
Make Theme Preview tooltip delay test deterministic

### DIFF
--- a/plugins/theme-preview/app.test.tsx
+++ b/plugins/theme-preview/app.test.tsx
@@ -713,20 +713,19 @@ describe("Theme Preview", () => {
       expect(found).not.toBeNull();
       return found as HTMLButtonElement;
     });
-    const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-
     // Keyboard focus opens it, not just hover.
     fireEvent.focus(trigger);
     await waitFor(() => expect(document.querySelector("[data-tp-tooltip-content]")).not.toBeNull());
 
     // Pointer-out does not dismiss immediately: it survives normal movement.
+    vi.useFakeTimers();
     fireEvent.mouseLeave(trigger);
-    await act(async () => { await sleep(250); });
+    await act(async () => { await vi.advanceTimersByTimeAsync(699); });
     expect(document.querySelector("[data-tp-tooltip-content]")).not.toBeNull();
 
     // ...and is gone once the dismissal delay elapses.
-    await act(async () => { await sleep(700); });
-    await waitFor(() => expect(document.querySelector("[data-tp-tooltip-content]")).toBeNull());
+    await act(async () => { await vi.advanceTimersByTimeAsync(1); });
+    expect(document.querySelector("[data-tp-tooltip-content]")).toBeNull();
   });
 
   it("reports neutral contrast ratios without accessibility verdicts or authoring actions", async () => {


### PR DESCRIPTION
## Human comments

## What was wrong

The tooltip test compared a 250 ms real-time sleep with the production 700 ms dismissal timer. If the test worker was suspended past 700 ms, React's async `act` could process the already-due dismissal before returning from the shorter sleep, so the intermediate assertion observed null even though production retained the correct 700 ms delay. A bounded 750 ms event-loop suspension reproduced the exact current-main assertion failure.

## What changed

Theme Preview's test now switches to fake timers only after focus has opened the tooltip, then checks the exact dismissal boundary: content remains at 699 ms and disappears after the final 1 ms. Production code and its 700 ms delay are unchanged.

## How you verified

- Before: focused current-main test passed unloaded and in 6 contended runs; a bounded 750 ms event-loop suspension reproduced `expected null not to be null` at the intermediate assertion.
- After: focused regression test passed.
- After: 10/10 focused runs passed with four bounded CPU-load workers and two concurrent single-worker Vitest lanes; cleanup left zero load or Vitest processes.
- `pnpm exec turbo run test --filter=bb-plugin-theme-preview --concurrency=2 --output-logs=full --summarize=false` (74 tests passed)
- `pnpm exec turbo run typecheck --filter=bb-plugin-theme-preview --concurrency=2 --output-logs=full --summarize=false`
- `pnpm exec turbo run build --filter=bb-app --concurrency=2 --output-logs=full --summarize=false` (12 tasks passed)
- `git diff --check`

> AGENT GENERATED: by GPT-5.6-Sol