### PR TITLE
Fix Docs table autosave jsdom geometry

### DIFF
--- a/plugins/docs/app.test.tsx
+++ b/plugins/docs/app.test.tsx
@@ -17,8 +17,26 @@ const navigationRegistration = {
   ...docsRegistration,
   component: navigationView.component,
 };
+const rangeGetBoundingClientRectDescriptor = Object.getOwnPropertyDescriptor(
+  Range.prototype,
+  "getBoundingClientRect",
+);
+const rangeGetClientRectsDescriptor = Object.getOwnPropertyDescriptor(
+  Range.prototype,
+  "getClientRects",
+);
 
 beforeEach(() => {
+  Object.defineProperties(Range.prototype, {
+    getBoundingClientRect: {
+      configurable: true,
+      value: () => new DOMRect(),
+    },
+    getClientRects: {
+      configurable: true,
+      value: () => ({ length: 0, item: () => null }),
+    },
+  });
   Object.defineProperty(window, "matchMedia", {
     writable: true,
     value: vi.fn((query: string) => ({
@@ -37,6 +55,24 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   vi.unstubAllGlobals();
+  if (rangeGetBoundingClientRectDescriptor) {
+    Object.defineProperty(
+      Range.prototype,
+      "getBoundingClientRect",
+      rangeGetBoundingClientRectDescriptor,
+    );
+  } else {
+    Reflect.deleteProperty(Range.prototype, "getBoundingClientRect");
+  }
+  if (rangeGetClientRectsDescriptor) {
+    Object.defineProperty(
+      Range.prototype,
+      "getClientRects",
+      rangeGetClientRectsDescriptor,
+    );
+  } else {
+    Reflect.deleteProperty(Range.prototype, "getClientRects");
+  }
 });
 
 interface NoteSummary {


### PR DESCRIPTION
## Human comments

## What was wrong

The Docs jsdom suite provided `matchMedia` but no Range geometry boundary. jsdom 29 exposes Element geometry while omitting `Range.getClientRects()` and `Range.getBoundingClientRect()`. ProseMirror 1.41.8 calls those methods while reconciling an edited table and scrolling its selection, so the uncaught TypeError aborted the editor update before the existing 700 ms autosave could call `saveNote`. The 2-second assertion in [the failing current-main run](https://github.com/get-bb/bb/actions/runs/33923531372) reported that upstream exception rather than a slow save.

## What changed

The Docs app test setup now provides zero-sized, browser-shaped Range geometry for jsdom and restores the original property descriptors after every test. No app behavior, timer, assertion, wire contract, CLI, or documentation changed.

## How you verified

- Confirmed the cited push run failed at `c49ba3f546d1049f0d0f4e51850908028a318d52` with `TypeError: target.getClientRects is not a function` from ProseMirror `singleRect` / `coordsAtPos`.
- Confirmed directly against the installed jsdom 29 environment that both Range geometry methods are undefined while Element geometry exists.
- `pnpm exec vitest run --config plugins/docs/vitest.config.ts plugins/docs/app.test.tsx -t "renders and autosaves editable Markdown tables" --reporter verbose --maxWorkers=2` (1 passed; unchanged 2-second wait).
- `pnpm exec turbo run test --filter=bb-plugin-simple-notes --concurrency=2 -- --maxWorkers=2` (66 passed).
- `pnpm exec turbo run typecheck --filter=bb-plugin-simple-notes --concurrency=2`.
- `pnpm exec turbo run build --filter=bb-plugin-simple-notes --concurrency=2 --force`.
- `pnpm exec prettier --check plugins/docs/app.test.tsx`.

> AGENT GENERATED: by GPT-5.6-Sol