### PR TITLE
fix(account-pool): synchronize short-hold session retries

### DIFF
--- a/plugins/account-pool/src/hub.ts
+++ b/plugins/account-pool/src/hub.ts
@@ -90,6 +90,11 @@ interface ActiveAccount {
   accountId: string;
 }
 
+interface PacingFlight {
+  heldUntil: number;
+  result: Promise<void>;
+}
+
 interface RoutingAttempt {
   binding: AccountBinding | null;
   active: ActiveAccount | null;
@@ -130,6 +135,7 @@ export class AccountPoolHub {
   private readonly activeControllers = new Set<AbortController>();
   private readonly refreshes = new Map<string, SecretFlight>();
   private readonly refreshBackoffs = new Map<string, RefreshBackoff>();
+  private readonly pacingByAccount = new Map<string, PacingFlight>();
   private affinityBindings = new Map<string, AccountBinding>();
   private activeAccounts = new Map<PoolProvider, ActiveAccount>();
   private readonly usageRefreshes = new Map<string, Promise<void>>();
@@ -144,6 +150,7 @@ export class AccountPoolHub {
       MAX_AFFINITY_BINDINGS,
     );
     this.activeAccounts = this.options.affinity.loadActiveAccounts();
+    this.pacingByAccount.clear();
     this.stopped = new AbortController();
     this.accepting = true;
     while (!signal.aborted) {
@@ -348,9 +355,25 @@ export class AccountPoolHub {
           signal,
         );
         if (selected === null) break;
+        let pacing: PacingFlight | null = null;
         const heldMs = (selected.quota.heldUntil ?? 0) - this.options.now();
+        let activePacing = this.pacingByAccount.get(selected.account.id);
+        if (
+          activePacing !== undefined &&
+          (activePacing.heldUntil !== selected.quota.heldUntil || heldMs <= 0)
+        ) {
+          this.releasePacing(selected.account.id, activePacing);
+          activePacing = undefined;
+        }
         if (heldMs > 0) {
-          if (heldMs > MAX_INLINE_HOLD_MS || waited.has(selected.account.id)) {
+          if (activePacing !== undefined) {
+            pacing = activePacing;
+            waited.add(selected.account.id);
+            await abortable(activePacing.result, signal);
+          } else if (
+            heldMs > MAX_INLINE_HOLD_MS ||
+            waited.has(selected.account.id)
+          ) {
             failure = {
               status: 429,
               message:
@@ -366,10 +389,11 @@ export class AccountPoolHub {
             attempted.add(selected.account.id);
             previousAccountId = selected.account.id;
             continue;
+          } else {
+            waited.add(selected.account.id);
+            await waitForDelay(heldMs, signal);
+            continue;
           }
-          waited.add(selected.account.id);
-          await waitForDelay(heldMs, signal);
-          continue;
         }
         previousAccountId = selected.account.id;
         attempted.add(selected.account.id);
@@ -389,6 +413,10 @@ export class AccountPoolHub {
             signal,
           );
         } catch (error) {
+          if (pacing !== null) {
+            this.releasePacing(selected.account.id, pacing);
+            pacing = null;
+          }
           signal.throwIfAborted();
           if (error instanceof TransientOAuthRefreshError) {
             failure = { status: 503, message: error.message, headers: {} };
@@ -411,6 +439,10 @@ export class AccountPoolHub {
               adapter,
             );
           } catch (error) {
+            if (pacing !== null) {
+              this.releasePacing(selected.account.id, pacing);
+              pacing = null;
+            }
             signal.throwIfAborted();
             if (!(error instanceof UpstreamConnectionError)) throw error;
             failure = {
@@ -434,6 +466,10 @@ export class AccountPoolHub {
             this.options.now(),
           );
           this.options.quotas.put(observed);
+          if (pacing !== null && !response.ok) {
+            this.releasePacing(selected.account.id, pacing);
+            pacing = null;
+          }
           if (response.status === 429) {
             if (adapter.isQuotaRejection(response.headers)) {
               await this.discardUpstream(upstream, false);
@@ -443,14 +479,20 @@ export class AccountPoolHub {
               response.headers.get("retry-after"),
               this.options.now(),
             );
+            const heldUntil = this.options.now() + waitMs;
             this.options.quotas.put({
               ...observed,
-              heldUntil: this.options.now() + waitMs,
+              heldUntil,
             });
             if (!paced && waitMs <= MAX_INLINE_HOLD_MS) {
               paced = true;
+              pacing = {
+                heldUntil,
+                result: waitForDelay(waitMs, this.stopped.signal),
+              };
+              this.pacingByAccount.set(selected.account.id, pacing);
               await this.discardUpstream(upstream, false);
-              await waitForDelay(waitMs, signal);
+              await abortable(pacing.result, signal);
               continue;
             }
             if (!selected.keepAffinity) {
@@ -1085,6 +1127,11 @@ export class AccountPoolHub {
   private markError(accountId: string, message: string): void {
     const quota = this.options.quotas.get(accountId);
     this.options.quotas.put({ ...quota, error: message.slice(0, 1_000) });
+  }
+
+  private releasePacing(accountId: string, pacing: PacingFlight): void {
+    if (this.pacingByAccount.get(accountId) === pacing)
+      this.pacingByAccount.delete(accountId);
   }
 
   private adapter(provider: PoolProvider): ProviderAdapter {

--- a/plugins/account-pool/src/server.test.ts
+++ b/plugins/account-pool/src/server.test.ts
@@ -5501,10 +5501,12 @@ describe("sequential pool recovery", () => {
 
   it("keeps a paced session on its account when another request arrives during a short hold", async () => {
     const attempts: Array<string | null> = [];
+    let now = 1_800_000_000_000;
     const fixture = await createFixture({
       upstreamUrl: "https://upstream.example",
       apiKey: "sk-first",
       options: {
+        now: () => now,
         fetch: async (_input, init) => {
           attempts.push(new Headers(init?.headers).get("x-api-key"));
           return attempts.length === 2
@@ -5534,7 +5536,12 @@ describe("sequential pool recovery", () => {
             ?.status,
         ).toBe("held");
       });
-      await (await send()).text();
+      const duringHold = send();
+      now += 249;
+      const duringHoldResponse = await duringHold;
+      expect(duringHoldResponse.status).toBe(200);
+      await duringHoldResponse.text();
+      now += 1;
       await (await paced).text();
       await (await send()).text();
       expect(attempts).toEqual([


### PR DESCRIPTION
## Human comments

## What was wrong

A pinned request that received a short per-minute 429 waited independently from another request for the same session. The second request could finish its remaining hold timer while the wall clock still reported the account as held; because routing tracked only that it had waited once, it returned 429 without making its permitted retry. This produced the four-attempt sequence seen in [current-main CI](https://github.com/get-bb/bb/actions/runs/33977434733) and again in [an unrelated PR run](https://github.com/get-bb/bb/actions/runs/34155037225).

## What changed

Account Pool now records the active per-account pacing flight with its exact hold deadline. Requests that arrive during that hold join the same completion promise and then make their one permitted retry. A completed successful flight remains observable until the wall deadline expires, while a renewed or failed attempt releases it so repeated hold extensions stay bounded. Hub restart also clears the in-memory flights.

The regression keeps the original 250 ms hold and pins the clock one millisecond before the deadline, proving the concurrent request follows the pacing completion event instead of returning a clock-bound 429. No hold duration, retry budget, timeout, wire contract, CLI, or public API changed. The separate 4096-session LRU timeout is not part of this change.

## How you verified

- Red: the controlled-clock regression failed before the implementation with `expected 429 to be 200`.
- Green focused: the short-hold regression and repeated-hold bound both passed.
- `pnpm exec turbo run test --filter=bb-plugin-account-pool --concurrency=1 -- --maxWorkers=1 --no-file-parallelism` — 9 files and 253 tests passed.
- `pnpm exec turbo run typecheck --filter=bb-plugin-account-pool --concurrency=1` — 4 Turbo tasks passed.
- `pnpm exec turbo run build --filter=bb-plugin-account-pool --concurrency=1` — the two generated prerequisites passed; this source plugin has no package build script.
- `pnpm exec oxfmt --check plugins/account-pool/src/hub.ts plugins/account-pool/src/server.test.ts` and `git diff --check` passed.

> AGENT GENERATED: by GPT-5.6-Sol