### PR TITLE
fix(skills): Resolve installed skill aliases in status hashing

### DIFF
--- a/apps/host-daemon/src/command-handlers/install-global-skills.test.ts
+++ b/apps/host-daemon/src/command-handlers/install-global-skills.test.ts
@@ -1,10 +1,12 @@
 import { createHash } from "node:crypto";
 import {
+  lstat,
   mkdtemp,
   mkdir,
   readFile,
   readdir,
   rm,
+  symlink,
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -94,6 +96,42 @@ describe("install global skills", () => {
         ),
       ).resolves.toBe("# bb-cli\n");
     }
+  });
+
+  it("reports matching status through a valid .claude skill alias after install", async () => {
+    const dataDir = await makeTempDir();
+    const homeDir = await makeTempDir();
+    const agentsRoot = path.join(homeDir, ".agents", "skills");
+    const claudeRoot = path.join(homeDir, ".claude", "skills");
+    const payload = createTreePayload("bb-cli", "aliased body");
+    const command = {
+      type: "host.install_global_skills" as const,
+      skills: [
+        { name: "bb-cli", treeHash: payload.treeHash, entryPath: "SKILL.md" },
+      ],
+    };
+
+    await installGlobalSkills(command, {
+      dataDir,
+      fetchSkillTree: async () => payload,
+      homeDir,
+    });
+    const agentsSkillPath = path.join(agentsRoot, "bb-cli");
+    const claudeSkillPath = path.join(claudeRoot, "bb-cli");
+    await rm(claudeSkillPath, { force: true, recursive: true });
+    await symlink(agentsSkillPath, claudeSkillPath, "dir");
+
+    const status = await readGlobalSkillsStatus(
+      { type: "host.global_skills_status", names: ["bb-cli"] },
+      { homeDir },
+    );
+    expect(status.entries.map((entry) => entry.treeHash)).toEqual([
+      payload.treeHash,
+      payload.treeHash,
+    ]);
+    await expect(
+      lstat(claudeSkillPath).then((stat) => stat.isSymbolicLink()),
+    ).resolves.toBe(true);
   });
 
   it("replaces a stale copy without leaving its removed files or staging dirs behind", async () => {

--- a/apps/host-daemon/src/injected-skills.test.ts
+++ b/apps/host-daemon/src/injected-skills.test.ts
@@ -23,6 +23,7 @@ import type {
 import {
   cleanupInjectedSkillStagingDirs,
   ensureDataDirSkillsRootPath,
+  hashInstalledSkillDirectory,
   MAX_SKILL_STORE_TREES,
   stageInjectedSkillSources,
 } from "./injected-skills.js";
@@ -655,6 +656,39 @@ describe("injected skill staging", () => {
     }
   });
 
+  it("skips symlinked source roots during staging", async () => {
+    const dataDir = await makeTempDir();
+    const realSkillRoot = await writeSkill({
+      rootPath: path.join(dataDir, "real-skills"),
+      name: "release-notes",
+    });
+    const symlinkedSkillRoot = path.join(dataDir, "linked-skill");
+    await symlink(realSkillRoot, symlinkedSkillRoot, "dir");
+    const warnings: CapturedWarning[] = [];
+
+    const staged = await stageInjectedSkillSources({
+      dataDir,
+      injectedSkillSources: [
+        createDataDirSource({
+          dataDir,
+          skillName: "release-notes",
+          skillRootPath: symlinkedSkillRoot,
+        }),
+      ],
+      logger: {
+        debug: () => undefined,
+        warn: (context, message) => warnings.push({ context, message }),
+      },
+    });
+
+    expect(staged.skillRoots).toEqual([]);
+    expect(warnings).toEqual([
+      expect.objectContaining({
+        message: "Skipping injected skill during staging",
+      }),
+    ]);
+  });
+
   it("skips symlinked files during staging", async () => {
     const dataDir = await makeTempDir();
     const outsideDir = await makeTempDir();
@@ -692,6 +726,77 @@ describe("injected skill staging", () => {
         message: "Skipping injected skill during staging",
       }),
     ]);
+  });
+});
+
+describe("installed skill hashing", () => {
+  it("resolves a valid root alias before hashing", async () => {
+    const dataDir = await makeTempDir();
+    const agentsRoot = path.join(dataDir, ".agents", "skills");
+    const skillRootPath = await writeSkill({
+      rootPath: agentsRoot,
+      name: "release-notes",
+    });
+    const claudeRoot = path.join(dataDir, ".claude", "skills");
+    await mkdir(claudeRoot, { recursive: true });
+    const aliasedSkillRoot = path.join(claudeRoot, "release-notes");
+    await symlink(skillRootPath, aliasedSkillRoot, "dir");
+
+    const expected = await hashInstalledSkillDirectory({
+      name: "release-notes",
+      skillDirectoryPath: skillRootPath,
+    });
+    const actual = await hashInstalledSkillDirectory({
+      name: "release-notes",
+      skillDirectoryPath: aliasedSkillRoot,
+    });
+
+    expect(expected).not.toBeNull();
+    expect(actual).toBe(expected);
+  });
+
+  it("returns null for a broken root alias", async () => {
+    const dataDir = await makeTempDir();
+    const claudeRoot = path.join(dataDir, ".claude", "skills");
+    await mkdir(claudeRoot, { recursive: true });
+    await symlink(
+      path.join(dataDir, "missing-skill"),
+      path.join(claudeRoot, "release-notes"),
+      "dir",
+    );
+
+    await expect(
+      hashInstalledSkillDirectory({
+        name: "release-notes",
+        skillDirectoryPath: path.join(claudeRoot, "release-notes"),
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("returns null when a descendant is a symlink", async () => {
+    const dataDir = await makeTempDir();
+    const outsideDir = await makeTempDir();
+    const skillRootPath = await writeSkill({
+      rootPath: path.join(dataDir, "agents", "skills"),
+      name: "release-notes",
+    });
+    const outsideFilePath = path.join(outsideDir, "escape.md");
+    await writeFile(outsideFilePath, "escape\n", "utf8");
+    await symlink(
+      outsideFilePath,
+      path.join(skillRootPath, "references", "escape.md"),
+    );
+    const claudeSkillRoot = path.join(dataDir, ".claude", "skills");
+    await mkdir(claudeSkillRoot, { recursive: true });
+    const aliasedSkillRoot = path.join(claudeSkillRoot, "release-notes");
+    await symlink(skillRootPath, aliasedSkillRoot, "dir");
+
+    await expect(
+      hashInstalledSkillDirectory({
+        name: "release-notes",
+        skillDirectoryPath: aliasedSkillRoot,
+      }),
+    ).resolves.toBeNull();
   });
 });
 

--- a/apps/host-daemon/src/injected-skills.ts
+++ b/apps/host-daemon/src/injected-skills.ts
@@ -613,15 +613,29 @@ function hashStoredTreeFiles(files: readonly CollectedSkillFile[]): string {
   return hash.digest("hex");
 }
 
+async function resolveInstalledSkillDirectoryPath(
+  skillDirectoryPath: string,
+): Promise<string> {
+  if (!path.isAbsolute(skillDirectoryPath)) {
+    throw new Error(
+      `Injected skill source root must be absolute: ${skillDirectoryPath}`,
+    );
+  }
+  return fs.realpath(skillDirectoryPath);
+}
+
 export async function hashInstalledSkillDirectory(args: {
   name: string;
   skillDirectoryPath: string;
 }): Promise<string | null> {
   try {
+    const skillDirectoryPath = await resolveInstalledSkillDirectoryPath(
+      args.skillDirectoryPath,
+    );
     const tree = await collectSkillDirectory({
       name: args.name,
-      sourceRootPath: args.skillDirectoryPath,
-      skillFilePath: path.join(args.skillDirectoryPath, SKILL_FILE_NAME),
+      sourceRootPath: skillDirectoryPath,
+      skillFilePath: path.join(skillDirectoryPath, SKILL_FILE_NAME),
     });
     return hashStoredTreeFiles(
       [...tree.files].sort((left, right) =>


### PR DESCRIPTION
Resolve valid installed skill root aliases before computing their status hash. A `.claude/skills` symlink to a matching installation now reports the same hash; broken aliases and unsafe descendants still fail, and staging retains its strict symlink rules.

Validation: 26 focused tests, host-daemon typecheck, and formatting passed on the original candidate. All three submitted source/test files are byte-identical to that tested candidate.
