### PR TITLE
fix(host): contain proxy resets and distinguish reconnect interruptions

### DIFF
--- a/apps/host-daemon/src/machine-auth-proxy.test.ts
+++ b/apps/host-daemon/src/machine-auth-proxy.test.ts
@@ -1,4 +1,5 @@
 import http from "node:http";
+import { once } from "node:events";
 import net, { type AddressInfo } from "node:net";
 import { afterEach, describe, expect, it } from "vitest";
 import { WebSocket, WebSocketServer, type RawData } from "ws";
@@ -31,6 +32,48 @@ afterEach(async () => {
 });
 
 describe("startMachineAuthProxy", () => {
+  it.each(["upstream", "client"])(
+    "contains a %s connection reset after a WebSocket upgrade",
+    async (resetSide) => {
+      const upstream = net.createServer((socket) => {
+        socket.once("data", () => {
+          socket.write(
+            "HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n\r\n",
+          );
+          socket.once("data", () => socket.resetAndDestroy());
+        });
+      });
+      const upstreamConnected = once(upstream, "connection");
+      const upstreamPort = await listen(upstream);
+      const proxy = await startMachineAuthProxy({
+        machineCredential: "bbcm_machine",
+        serverUrl: `http://127.0.0.1:${upstreamPort}`,
+      });
+      proxies.push(proxy);
+      const proxyUrl = new URL(proxy.serverUrl);
+      const client = net.connect(Number(proxyUrl.port), proxyUrl.hostname);
+      try {
+        await once(client, "connect");
+        client.write(
+          `GET /ws HTTP/1.1\r\nHost: ${proxyUrl.host}\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n\r\n`,
+        );
+        await once(client, "data");
+        const [upstreamSocket] = await upstreamConnected;
+        const upstreamClosed = once(upstreamSocket, "close");
+        const closed = once(client, "close");
+        if (resetSide === "upstream") {
+          client.write("trigger reset");
+        } else {
+          client.resetAndDestroy();
+        }
+        await Promise.all([closed, upstreamClosed]);
+        expect(client.destroyed).toBe(true);
+      } finally {
+        client.destroy();
+      }
+    },
+  );
+
   it("forwards HTTP requests to the configured origin with authentication and caller headers", async () => {
     const upstream = http.createServer((request, response) => {
       expect(request.method).toBe("POST");

--- a/apps/host-daemon/src/machine-auth-proxy.ts
+++ b/apps/host-daemon/src/machine-auth-proxy.ts
@@ -191,6 +191,13 @@ function proxyUpgrade(args: {
     ),
   });
   upstreamRequest.on("upgrade", (response, upstreamSocket, upstreamHead) => {
+    upstreamSocket.on("error", () => upstreamSocket.destroy());
+    upstreamSocket.on("close", () => args.clientSocket.destroy());
+    args.clientSocket.on("close", () => upstreamSocket.destroy());
+    if (args.clientSocket.destroyed) {
+      upstreamSocket.destroy();
+      return;
+    }
     const statusLine = `HTTP/${response.httpVersion} ${response.statusCode ?? 101} ${response.statusMessage ?? "Switching Protocols"}\r\n`;
     const headerLines = response.rawHeaders
       .reduce<string[]>((lines, value, index) => {
@@ -208,6 +215,8 @@ function proxyUpgrade(args: {
     writeRejectedSocket(args.clientSocket, 400),
   );
   upstreamRequest.on("error", () => args.clientSocket.destroy());
+  args.clientSocket.on("error", () => args.clientSocket.destroy());
+  args.clientSocket.on("close", () => upstreamRequest.destroy());
   upstreamRequest.end();
 }
 

--- a/apps/server/src/internal/session-owner-side-effects.ts
+++ b/apps/server/src/internal/session-owner-side-effects.ts
@@ -85,12 +85,12 @@ export async function handleHostSessionOpened(
     "Session opened",
   );
 
+  const sameDaemonInstance =
+    args.previousSession?.instanceId === args.openedSession.instanceId;
   if (
     args.previousSession &&
     args.previousSession.id !== args.openedSession.id
   ) {
-    const sameDaemonInstance =
-      args.previousSession.instanceId === args.openedSession.instanceId;
     deps.hub.cancelPendingDaemonDisconnect(args.previousSession.id);
 
     if (args.previousSession.status === "active") {
@@ -120,6 +120,7 @@ export async function handleHostSessionOpened(
   await reconcileDaemonReportedThreads(deps, {
     activeThreadIds: args.activeThreads.map((thread) => thread.threadId),
     hostId: args.hostId,
+    sameDaemonInstance,
   });
 }
 

--- a/apps/server/src/services/threads/thread-lifecycle.ts
+++ b/apps/server/src/services/threads/thread-lifecycle.ts
@@ -270,6 +270,7 @@ interface InterruptActiveThreadsResult {
 interface ReconcileDaemonReportedThreadsArgs {
   activeThreadIds: readonly string[];
   hostId: string;
+  sameDaemonInstance: boolean;
 }
 
 interface DispatchSettledArchivedThreadProviderArchiveCommandArgs {
@@ -1868,6 +1869,7 @@ export async function reconcileDaemonReportedThreads(
       threadId: thread.id,
     })),
     reason: "host-daemon-restarted",
+    cause: args.sameDaemonInstance ? "host-connection-lost" : undefined,
   });
 
   if (args.activeThreadIds.length === 0) {

--- a/apps/server/test/internal/background-task-reconciliation.test.ts
+++ b/apps/server/test/internal/background-task-reconciliation.test.ts
@@ -492,55 +492,64 @@ describe("active thread disconnect reconciliation triggers", () => {
     });
   });
 
-  it("records a confirmed daemon restart when a different daemon instance registers", async () => {
-    await withTestHarness(async (harness) => {
-      const { host, session, thread } = seedActiveTurnThread(harness);
+  it.each(["instance-1", "instance-restarted"])(
+    "distinguishes a missing turn from a daemon restart for %s",
+    async (instanceId) => {
+      await withTestHarness(async (harness) => {
+        const { host, session, thread } = seedActiveTurnThread(harness);
 
-      handleDaemonSocketClosed(harness.deps, { sessionId: session.id });
+        handleDaemonSocketClosed(harness.deps, { sessionId: session.id });
 
-      const response = await harness.app.request("/internal/session/open", {
-        method: "POST",
-        headers: internalAuthHeaders(harness, {
-          hostId: host.id,
-          hostType: host.type,
-        }),
-        body: JSON.stringify({
-          hostId: host.id,
-          instanceId: "instance-restarted",
-          hostName: host.name,
-          hostType: host.type,
-          hasMachineCredential: false,
-          platform: "darwin",
-          dataDir: "/tmp/host-daemon-active-restarted-instance",
-          localApiPort: null,
-          protocolVersion: HOST_DAEMON_PROTOCOL_VERSION,
-          activeThreads: [],
-        }),
-      });
+        const response = await harness.app.request("/internal/session/open", {
+          method: "POST",
+          headers: internalAuthHeaders(harness, {
+            hostId: host.id,
+            hostType: host.type,
+          }),
+          body: JSON.stringify({
+            hostId: host.id,
+            instanceId,
+            hostName: host.name,
+            hostType: host.type,
+            hasMachineCredential: false,
+            platform: "darwin",
+            dataDir: "/tmp/host-daemon-active-restarted-instance",
+            localApiPort: null,
+            protocolVersion: HOST_DAEMON_PROTOCOL_VERSION,
+            activeThreads: [],
+          }),
+        });
 
-      expect(response.status).toBe(201);
-      expect(getThread(harness.deps.db, thread.id)?.status).toBe("error");
-      const rows = listEvents(harness.deps.db, { threadId: thread.id }).filter(
-        (row) => row.type !== "turn/started",
-      );
-      expect(rows.map((row) => row.type)).toEqual([
-        "turn/completed",
-        "system/error",
-        "system/thread/interrupted",
-      ]);
-      expect(JSON.parse(rows[0]!.data)).toMatchObject({
-        status: "interrupted",
+        expect(response.status).toBe(201);
+        expect(getThread(harness.deps.db, thread.id)?.status).toBe("error");
+        const rows = listEvents(harness.deps.db, {
+          threadId: thread.id,
+        }).filter((row) => row.type !== "turn/started");
+        expect(rows.map((row) => row.type)).toEqual([
+          "turn/completed",
+          "system/error",
+          "system/thread/interrupted",
+        ]);
+        expect(JSON.parse(rows[0]!.data)).toMatchObject({
+          status: "interrupted",
+        });
+        expect(JSON.parse(rows[1]!.data)).toMatchObject({
+          code: "thread_command_failed",
+          message:
+            instanceId === "instance-1"
+              ? "Thread interrupted because the connection to the host was lost"
+              : "Thread interrupted because the host daemon disconnected",
+          detail: "Please retry the thread to continue.",
+        });
+        expect(JSON.parse(rows[2]!.data)).toEqual({
+          reason: "host-daemon-restarted",
+          ...(instanceId === "instance-1"
+            ? { cause: "host-connection-lost" }
+            : {}),
+        });
       });
-      expect(JSON.parse(rows[1]!.data)).toMatchObject({
-        code: "thread_command_failed",
-        message: "Thread interrupted because the host daemon disconnected",
-        detail: "Please retry the thread to continue.",
-      });
-      expect(JSON.parse(rows[2]!.data)).toEqual({
-        reason: "host-daemon-restarted",
-      });
-    });
-  });
+    },
+  );
 
   it("records a lost host connection after the live event window elapses without a reconnect", async () => {
     await withTestHarness(async (harness) => {


### PR DESCRIPTION
## Human comments

## What was wrong

The machine authentication proxy piped upgraded WebSocket sockets without handling their errors or closing the peer. An upstream reset could therefore raise an uncaught `ECONNRESET` in the host daemon. Separately, reconnect reconciliation labeled a missing active turn as a daemon restart even when the reconnecting process had the same instance ID.

## What changed

Handle errors and close both sides of upgraded proxy connections, including clients that disconnect during the upgrade. When the same daemon reconnects without a previously active turn, emit the existing `host-connection-lost` cause so the timeline reports a lost connection; preserve the restart message for a different daemon instance. No server/daemon wire fields or public API changed, so no protocol bump is needed. These fixes do not address the underlying Connect tunnel instability.

## How you verified

- Reproduced an uncaught `read ECONNRESET` with a real upstream TCP reset before the proxy fix; the regression passes afterward. Coverage also exercises client-side resets and peer cleanup.
- `pnpm exec turbo run test --filter=@bb/host-daemon -- --run src/machine-auth-proxy.test.ts` — 10 passed.
- `pnpm exec turbo run test --filter=@bb/server -- --run test/internal/background-task-reconciliation.test.ts` — 12 passed, covering missing/still-active turns on same-instance reconnect, actual daemon replacement, and disconnect grace behavior.
- `pnpm exec turbo run typecheck --filter=@bb/host-daemon --filter=@bb/server` — passed.
- `git diff --check` — passed. EAP codename scan: clean working tree, HEAD, added lines, and commit messages in the push range.

> AGENT GENERATED
