### PR TITLE
test(account-pool): bound affinity eviction coverage

### DIFF
--- a/plugins/account-pool/src/hub.ts
+++ b/plugins/account-pool/src/hub.ts
@@ -69,6 +69,7 @@ interface HubOptions {
   accounts: AccountStore;
   quotas: QuotaStore;
   affinity: PoolAffinityStore;
+  maxAffinityBindings: number;
   hubTokens: HubTokenStore;
   getSettings: () => HubSettings;
   adapters: ReadonlyMap<PoolProvider, ProviderAdapter>;
@@ -747,7 +748,7 @@ export class AccountPoolHub {
         this.affinityBindings.set(affinityKey, binding);
       }
     }
-    while (this.affinityBindings.size > MAX_AFFINITY_BINDINGS) {
+    while (this.affinityBindings.size > this.options.maxAffinityBindings) {
       const oldest = this.affinityBindings.keys().next();
       if (!oldest.done) {
         this.affinityBindings.delete(oldest.value);
@@ -1139,6 +1140,7 @@ export function createHub(options: {
   profileUrl?: string;
   usageRefreshIntervalMs?: number;
   drainTimeoutMs?: number;
+  maxAffinityBindings?: number;
   onAccountsChanged?: () => void;
   onUpstreamError?: (provider: PoolProvider, error: unknown) => void;
 }): AccountPoolHub {
@@ -1165,6 +1167,7 @@ export function createHub(options: {
     accounts: options.accounts,
     quotas: options.quotas,
     affinity: options.affinity,
+    maxAffinityBindings: options.maxAffinityBindings ?? MAX_AFFINITY_BINDINGS,
     hubTokens: options.hubTokens,
     getSettings: options.getSettings,
     adapters,

--- a/plugins/account-pool/src/server.test.ts
+++ b/plugins/account-pool/src/server.test.ts
@@ -4800,7 +4800,7 @@ describe("Account Pool plugin", () => {
       }
     });
 
-    it("evicts the least recently used binding after 4096 sessions", async () => {
+    it("evicts the least recently used binding at capacity", async () => {
       let lastKey: string | null = null;
       let attempts = 0;
       const fixture = await createFixture({
@@ -4808,6 +4808,7 @@ describe("Account Pool plugin", () => {
         apiKey: "sk-first",
         options: {
           now: () => 1_800_000_000_000,
+          maxAffinityBindings: 4,
           fetch: async (_input, init) => {
             lastKey = new Headers(init?.headers).get("x-api-key");
             attempts += 1;
@@ -4838,7 +4839,7 @@ describe("Account Pool plugin", () => {
       );
       try {
         await movePoolToOtherAccount(fixture, "claude");
-        for (let index = 1; index < 4096; index += 1)
+        for (let index = 1; index < 4; index += 1)
           await send(`session-${index}`);
         const touched = await send("oldest");
         await send("newest");
@@ -4856,7 +4857,7 @@ describe("Account Pool plugin", () => {
       } finally {
         if (!held.bodyUsed) await held.body?.cancel();
       }
-    }, 60_000);
+    });
   });
 
   it("serializes refresh, writes new tokens with 0600 mode, and uses them", async () => {

--- a/plugins/account-pool/src/server.ts
+++ b/plugins/account-pool/src/server.ts
@@ -42,6 +42,7 @@ export interface AccountPoolPluginOptions {
   usageUrl?: string;
   usageRefreshIntervalMs?: number;
   drainTimeoutMs?: number;
+  maxAffinityBindings?: number;
   disposeTimeoutMs?: number;
   importCredentials?: () => Promise<ImportedClaudeCredentials>;
   importCodexCredentials?: () => Promise<ImportedCodexCredentials>;
@@ -117,6 +118,7 @@ export function createAccountPoolPlugin(
       importCodexCredentials: options.importCodexCredentials,
       usageRefreshIntervalMs: options.usageRefreshIntervalMs,
       drainTimeoutMs: options.drainTimeoutMs,
+      maxAffinityBindings: options.maxAffinityBindings,
       onUpstreamError: (provider, error) =>
         bb.log.warn(
           `Account Pooler ${provider} transport failed: ${transportErrorCode(error)}.`,


### PR DESCRIPTION
## Human comments

## What was wrong

The affinity-eviction integration test filled the production capacity by sending 4,095 sequential requests through the complete fake plugin host. Each request repeated parsing, account/quota selection, persistence, routing, and response consumption even though the eviction itself is an O(1) `Map` operation. On the untouched Intel baseline the single test took 10.7–12.2 seconds without real network I/O, leaving little headroom under its original 20-second timeout. The [current-main failure](https://github.com/get-bb/bb/actions/runs/34256473278/job/102163451056) ran the packages shard with four concurrent Turbo package tasks on four vCPUs while Account Pool Vitest also parallelized its ten files; that systemic nested CPU oversubscription made the serial test intermittently exceed 20 seconds. The merged 60-second timeout only masked this structural cost.

## What changed

Thread an internal `maxAffinityBindings` construction option into the hub and apply the existing 4,096 production default once at that boundary. The end-to-end LRU test injects a capacity of four and keeps the same recency refresh, retention, next-oldest, and eviction assertions while removing 4,092 redundant HTTP requests. The custom 60-second timeout is removed, restoring the normal test timeout as the hang detector.

There are no CLI, user configuration, SDK, server/daemon wire, migration, or protocol-version changes.

## How you verified

- Before the change, the focused untouched-main case took 12,163ms unloaded and 10,700–10,820ms in two bounded contention samples; CI independently recorded the exact 20-second timeout under the packages shard.
- After the change, the focused case passed in 125–131ms through Turbo on the rebased commit.
- `pnpm exec turbo run test typecheck --filter=bb-plugin-account-pool --concurrency=2 --force`: 10 files and 261 tests passed; typecheck passed.
- `pnpm exec turbo run typecheck --filter=bb-plugin-account-pool --concurrency=2 --force`: passed after rebasing onto current main.
- `pnpm exec turbo run build --filter=@bb/server --concurrency=2 --force`: passed before and after the rebase.
- Scoped Oxlint, Oxfmt check, and `git diff --check`: passed.
- Final merge-base: `d9f2ac5a4390b8b8507da3cc32a3bae01fc3f868`.

> AGENT GENERATED: by GPT-5.6-Sol