### PR TITLE
feat(git-diff): persist diff view mode and line wrap across reloads

### DIFF
--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
@@ -49,10 +49,7 @@ import type {
   SecondaryPanelTabReorderHandler,
 } from "./secondaryPanelTab";
 import { useEnvironmentDiffFiles } from "@/hooks/queries/environment-queries";
-import {
-  DEFAULT_CODE_OVERFLOW_MODE,
-  type CodeOverflowMode,
-} from "@/lib/code-overflow-mode";
+import { useGitDiffLineOverflowModePreference } from "@/lib/git-diff-view-preferences";
 import type { DiffPresentation } from "@/components/code/code-rendering";
 import { useGitDiffPanelState } from "./git-diff/useGitDiffPanelState";
 import { useResponsiveGitDiffPanelDisplay } from "./git-diff/useResponsiveGitDiffPanelDisplay";
@@ -267,11 +264,10 @@ export function ThreadSecondaryPanel({
   const {
     gitDiffDisplayMode,
     handleGitDiffDisplayModeChange,
-    handleSecondaryPanelResizeStart,
     handleSecondaryPanelWidthChange,
   } = useResponsiveGitDiffPanelDisplay({ isSecondaryPanelOpen: isOpen });
   const {
-    handleSecondaryPanelDragging: handleResizeDragging,
+    handleSecondaryPanelDragging,
     handleSecondaryPanelResize,
     handleSecondaryPanelResizePointerDownCapture,
     persistedWidthPercent,
@@ -281,16 +277,6 @@ export function ThreadSecondaryPanel({
     isSecondaryPanelOpen: isOpen,
     onPanelWidthChange: handleSecondaryPanelWidthChange,
   });
-  const handleSecondaryPanelDragging: SecondaryPanelDraggingHandler =
-    useCallback(
-      (isDragging) => {
-        if (isDragging) {
-          handleSecondaryPanelResizeStart();
-        }
-        handleResizeDragging(isDragging);
-      },
-      [handleResizeDragging, handleSecondaryPanelResizeStart],
-    );
   const hasPanelExpandedRef = useRef(false);
   useLayoutEffect(() => {
     hasPanelExpandedRef.current = false;
@@ -395,7 +381,7 @@ export function ThreadSecondaryPanel({
   );
   const [desktopInfo] = useState(getBbDesktopInfo);
   const [gitDiffLineOverflowMode, setGitDiffLineOverflowMode] =
-    useState<CodeOverflowMode>(DEFAULT_CODE_OVERFLOW_MODE);
+    useGitDiffLineOverflowModePreference();
   const usesDesktopChrome = shouldUseMacosDesktopChrome(desktopInfo);
   const desktopWindowState = useDesktopWindowState();
   const isSidebarShowing = useOptionalIsSidebarShowing();

--- a/apps/app/src/components/secondary-panel/git-diff/useResponsiveGitDiffPanelDisplay.test.tsx
+++ b/apps/app/src/components/secondary-panel/git-diff/useResponsiveGitDiffPanelDisplay.test.tsx
@@ -1,0 +1,228 @@
+// @vitest-environment jsdom
+
+import { CompactViewportOverrideProvider } from "@bb/shared-ui/hooks/use-compact-viewport";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, expect, it } from "vitest";
+import {
+  GIT_DIFF_DISPLAY_MODE_STORAGE_KEY,
+  GIT_DIFF_LINE_OVERFLOW_MODE_STORAGE_KEY,
+  useGitDiffLineOverflowModePreference,
+} from "@/lib/git-diff-view-preferences";
+import {
+  resolveGitDiffDisplayMode,
+  useResponsiveGitDiffPanelDisplay,
+} from "./useResponsiveGitDiffPanelDisplay";
+
+const NARROW_WIDTH_PX = 500;
+const WIDE_WIDTH_PX = 900;
+
+afterEach(() => {
+  cleanup();
+  window.localStorage.clear();
+});
+
+function renderDisplay() {
+  return renderHook(() =>
+    useResponsiveGitDiffPanelDisplay({ isSecondaryPanelOpen: true }),
+  );
+}
+
+function renderCompactDisplay() {
+  return renderHook(
+    () => useResponsiveGitDiffPanelDisplay({ isSecondaryPanelOpen: true }),
+    {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <CompactViewportOverrideProvider isCompactViewport>
+          {children}
+        </CompactViewportOverrideProvider>
+      ),
+    },
+  );
+}
+
+it("follows panel width while no explicit preference is stored", () => {
+  const { result } = renderDisplay();
+
+  act(() => {
+    result.current.handleSecondaryPanelWidthChange(WIDE_WIDTH_PX);
+  });
+  expect(result.current.gitDiffDisplayMode).toBe("split");
+
+  act(() => {
+    result.current.handleSecondaryPanelWidthChange(NARROW_WIDTH_PX);
+  });
+  expect(result.current.gitDiffDisplayMode).toBe("unified");
+
+  expect(
+    window.localStorage.getItem(GIT_DIFF_DISPLAY_MODE_STORAGE_KEY),
+  ).toBeNull();
+});
+
+it("honors an explicit choice at any panel width", () => {
+  const { result } = renderDisplay();
+
+  act(() => {
+    result.current.handleSecondaryPanelWidthChange(WIDE_WIDTH_PX);
+  });
+  act(() => {
+    result.current.handleGitDiffDisplayModeChange("unified");
+  });
+  act(() => {
+    result.current.handleSecondaryPanelWidthChange(NARROW_WIDTH_PX);
+  });
+  act(() => {
+    result.current.handleSecondaryPanelWidthChange(WIDE_WIDTH_PX);
+  });
+
+  expect(result.current.gitDiffDisplayMode).toBe("unified");
+});
+
+it("keeps a stored split choice on a panel narrower than the breakpoint", () => {
+  const { result } = renderDisplay();
+
+  act(() => {
+    result.current.handleSecondaryPanelWidthChange(WIDE_WIDTH_PX);
+  });
+  act(() => {
+    result.current.handleGitDiffDisplayModeChange("split");
+  });
+  act(() => {
+    result.current.handleSecondaryPanelWidthChange(NARROW_WIDTH_PX);
+  });
+
+  expect(result.current.gitDiffDisplayMode).toBe("split");
+});
+
+it("restores the stored display mode on a fresh mount", () => {
+  const first = renderDisplay();
+  act(() => {
+    first.result.current.handleSecondaryPanelWidthChange(NARROW_WIDTH_PX);
+  });
+  act(() => {
+    first.result.current.handleGitDiffDisplayModeChange("split");
+  });
+  cleanup();
+
+  const { result } = renderDisplay();
+  expect(result.current.gitDiffDisplayMode).toBe("split");
+});
+
+it("ignores an unrecognized stored display mode", () => {
+  window.localStorage.setItem(GIT_DIFF_DISPLAY_MODE_STORAGE_KEY, "sideways");
+
+  const { result } = renderDisplay();
+  act(() => {
+    result.current.handleSecondaryPanelWidthChange(WIDE_WIDTH_PX);
+  });
+
+  expect(result.current.gitDiffDisplayMode).toBe("split");
+});
+
+it("does not track width changes while the panel is closed", () => {
+  const { result } = renderHook(() =>
+    useResponsiveGitDiffPanelDisplay({ isSecondaryPanelOpen: false }),
+  );
+
+  act(() => {
+    result.current.handleSecondaryPanelWidthChange(WIDE_WIDTH_PX);
+  });
+
+  expect(result.current.gitDiffDisplayMode).toBe("unified");
+});
+
+it("defaults a compact viewport to unified even with split stored", () => {
+  window.localStorage.setItem(GIT_DIFF_DISPLAY_MODE_STORAGE_KEY, "split");
+
+  const { result } = renderCompactDisplay();
+
+  expect(result.current.gitDiffDisplayMode).toBe("unified");
+});
+
+it("lets a compact viewport toggle to split", () => {
+  const { result } = renderCompactDisplay();
+
+  act(() => {
+    result.current.handleGitDiffDisplayModeChange("split");
+  });
+
+  expect(result.current.gitDiffDisplayMode).toBe("split");
+});
+
+it("does not persist a compact viewport toggle", () => {
+  const first = renderCompactDisplay();
+  act(() => {
+    first.result.current.handleGitDiffDisplayModeChange("split");
+  });
+  expect(
+    window.localStorage.getItem(GIT_DIFF_DISPLAY_MODE_STORAGE_KEY),
+  ).toBeNull();
+  cleanup();
+
+  const { result } = renderCompactDisplay();
+  expect(result.current.gitDiffDisplayMode).toBe("unified");
+});
+
+it("leaves an existing stored preference untouched when toggling on compact", () => {
+  window.localStorage.setItem(GIT_DIFF_DISPLAY_MODE_STORAGE_KEY, "split");
+
+  const compact = renderCompactDisplay();
+  act(() => {
+    compact.result.current.handleGitDiffDisplayModeChange("unified");
+  });
+  cleanup();
+
+  expect(window.localStorage.getItem(GIT_DIFF_DISPLAY_MODE_STORAGE_KEY)).toBe(
+    "split",
+  );
+
+  const { result } = renderDisplay();
+  expect(result.current.gitDiffDisplayMode).toBe("split");
+});
+
+it("resolves display mode from viewport, preference, and width", () => {
+  const resolve = (
+    isCompactViewport: boolean,
+    compactDisplayMode: "unified" | "split" | null,
+    displayModePreference: "unified" | "split" | null,
+    isWideEnoughForSplit: boolean | null,
+  ) =>
+    resolveGitDiffDisplayMode({
+      isCompactViewport,
+      compactDisplayMode,
+      displayModePreference,
+      isWideEnoughForSplit,
+    });
+
+  expect(resolve(true, null, "split", true)).toBe("unified");
+  expect(resolve(true, "split", "unified", false)).toBe("split");
+  expect(resolve(true, "unified", "split", true)).toBe("unified");
+
+  expect(resolve(false, null, null, null)).toBe("unified");
+  expect(resolve(false, null, null, false)).toBe("unified");
+  expect(resolve(false, null, null, true)).toBe("split");
+  expect(resolve(false, "split", null, false)).toBe("unified");
+  expect(resolve(false, null, "split", false)).toBe("split");
+  expect(resolve(false, null, "unified", true)).toBe("unified");
+});
+
+it("restores the stored line overflow mode on a fresh mount", () => {
+  const first = renderHook(() => useGitDiffLineOverflowModePreference());
+  act(() => {
+    first.result.current[1]("wrap");
+  });
+  expect(
+    window.localStorage.getItem(GIT_DIFF_LINE_OVERFLOW_MODE_STORAGE_KEY),
+  ).toBe("wrap");
+  cleanup();
+
+  const { result } = renderHook(() => useGitDiffLineOverflowModePreference());
+  expect(result.current[0]).toBe("wrap");
+});
+
+it("falls back to scroll for an unrecognized stored line overflow mode", () => {
+  window.localStorage.setItem(GIT_DIFF_LINE_OVERFLOW_MODE_STORAGE_KEY, "fold");
+
+  const { result } = renderHook(() => useGitDiffLineOverflowModePreference());
+  expect(result.current[0]).toBe("scroll");
+});

--- a/apps/app/src/components/secondary-panel/git-diff/useResponsiveGitDiffPanelDisplay.ts
+++ b/apps/app/src/components/secondary-panel/git-diff/useResponsiveGitDiffPanelDisplay.ts
@@ -1,4 +1,6 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useIsCompactViewport } from "@bb/shared-ui/hooks/use-compact-viewport";
+import { useCallback, useState } from "react";
+import { useGitDiffDisplayModePreference } from "@/lib/git-diff-view-preferences";
 import type {
   GitDiffDisplayMode,
   GitDiffDisplayModeChangeHandler,
@@ -7,7 +9,29 @@ import type { SecondaryPanelWidthChangeHandler } from "../useSecondaryPanelResiz
 
 const GIT_DIFF_SPLIT_VIEW_MIN_WIDTH_PX = 760;
 
-type SecondaryPanelResizeStartHandler = () => void;
+export const COMPACT_GIT_DIFF_DISPLAY_MODE: GitDiffDisplayMode = "unified";
+
+interface ResolveGitDiffDisplayModeArgs {
+  isCompactViewport: boolean;
+  compactDisplayMode: GitDiffDisplayMode | null;
+  displayModePreference: GitDiffDisplayMode | null;
+  isWideEnoughForSplit: boolean | null;
+}
+
+export function resolveGitDiffDisplayMode({
+  isCompactViewport,
+  compactDisplayMode,
+  displayModePreference,
+  isWideEnoughForSplit,
+}: ResolveGitDiffDisplayModeArgs): GitDiffDisplayMode {
+  if (isCompactViewport) {
+    return compactDisplayMode ?? COMPACT_GIT_DIFF_DISPLAY_MODE;
+  }
+  if (displayModePreference !== null) {
+    return displayModePreference;
+  }
+  return isWideEnoughForSplit === true ? "split" : "unified";
+}
 
 interface UseResponsiveGitDiffPanelDisplayArgs {
   isSecondaryPanelOpen: boolean;
@@ -16,10 +40,14 @@ interface UseResponsiveGitDiffPanelDisplayArgs {
 export function useResponsiveGitDiffPanelDisplay({
   isSecondaryPanelOpen,
 }: UseResponsiveGitDiffPanelDisplayArgs) {
-  const [gitDiffDisplayMode, setGitDiffDisplayMode] =
-    useState<GitDiffDisplayMode>("unified");
-  const lastDiffViewWideEnoughRef = useRef<boolean | null>(null);
-  const hasExplicitDisplayModeRef = useRef(false);
+  const isCompactViewport = useIsCompactViewport();
+  const [displayModePreference, setDisplayModePreference] =
+    useGitDiffDisplayModePreference();
+  const [compactDisplayMode, setCompactDisplayMode] =
+    useState<GitDiffDisplayMode | null>(null);
+  const [isWideEnoughForSplit, setIsWideEnoughForSplit] = useState<
+    boolean | null
+  >(null);
 
   const handleSecondaryPanelWidthChange =
     useCallback<SecondaryPanelWidthChangeHandler>(
@@ -28,52 +56,34 @@ export function useResponsiveGitDiffPanelDisplay({
           return;
         }
 
-        const isWideEnough = nextWidth >= GIT_DIFF_SPLIT_VIEW_MIN_WIDTH_PX;
-        const previousWideEnough = lastDiffViewWideEnoughRef.current;
-        const crossedBreakpoint =
-          previousWideEnough !== null && previousWideEnough !== isWideEnough;
-
-        if (crossedBreakpoint && hasExplicitDisplayModeRef.current) {
-          hasExplicitDisplayModeRef.current = false;
-        }
-
-        if (!hasExplicitDisplayModeRef.current || crossedBreakpoint) {
-          const nextMode = isWideEnough ? "split" : "unified";
-          setGitDiffDisplayMode((current) =>
-            current === nextMode ? current : nextMode,
-          );
-        }
-
-        lastDiffViewWideEnoughRef.current = isWideEnough;
+        const nextWideEnough = nextWidth >= GIT_DIFF_SPLIT_VIEW_MIN_WIDTH_PX;
+        setIsWideEnoughForSplit((current) =>
+          current === nextWideEnough ? current : nextWideEnough,
+        );
       },
-      [isSecondaryPanelOpen, setGitDiffDisplayMode],
+      [isSecondaryPanelOpen],
     );
-
-  useEffect(() => {
-    if (!isSecondaryPanelOpen) {
-      hasExplicitDisplayModeRef.current = false;
-      lastDiffViewWideEnoughRef.current = null;
-    }
-  }, [isSecondaryPanelOpen]);
 
   const handleGitDiffDisplayModeChange =
     useCallback<GitDiffDisplayModeChangeHandler>(
       (nextMode) => {
-        hasExplicitDisplayModeRef.current = true;
-        setGitDiffDisplayMode(nextMode);
+        if (isCompactViewport) {
+          setCompactDisplayMode(nextMode);
+          return;
+        }
+        setDisplayModePreference(nextMode);
       },
-      [setGitDiffDisplayMode],
+      [isCompactViewport, setDisplayModePreference],
     );
 
-  const handleSecondaryPanelResizeStart =
-    useCallback<SecondaryPanelResizeStartHandler>(() => {
-      hasExplicitDisplayModeRef.current = false;
-    }, []);
-
   return {
-    gitDiffDisplayMode,
+    gitDiffDisplayMode: resolveGitDiffDisplayMode({
+      isCompactViewport,
+      compactDisplayMode,
+      displayModePreference,
+      isWideEnoughForSplit,
+    }),
     handleGitDiffDisplayModeChange,
-    handleSecondaryPanelResizeStart,
     handleSecondaryPanelWidthChange,
   };
 }

--- a/apps/app/src/lib/git-diff-view-preferences.ts
+++ b/apps/app/src/lib/git-diff-view-preferences.ts
@@ -1,0 +1,47 @@
+import { useAtom } from "jotai";
+import { atomWithStorage } from "jotai/utils";
+import type { GitDiffDisplayMode } from "@/components/secondary-panel/GitDiffToolbar";
+import {
+  createLocalStorageEnumStorage,
+  createNullableLocalStorageEnumStorage,
+} from "./browser-storage";
+import {
+  DEFAULT_CODE_OVERFLOW_MODE,
+  type CodeOverflowMode,
+} from "./code-overflow-mode";
+
+export const GIT_DIFF_DISPLAY_MODE_STORAGE_KEY =
+  "bb.thread.gitDiff.displayMode";
+export const GIT_DIFF_LINE_OVERFLOW_MODE_STORAGE_KEY =
+  "bb.thread.gitDiff.lineOverflowMode";
+
+function isGitDiffDisplayMode(value: string): value is GitDiffDisplayMode {
+  return value === "unified" || value === "split";
+}
+
+function isCodeOverflowMode(value: string): value is CodeOverflowMode {
+  return value === "wrap" || value === "scroll";
+}
+
+const gitDiffDisplayModePreferenceAtom =
+  atomWithStorage<GitDiffDisplayMode | null>(
+    GIT_DIFF_DISPLAY_MODE_STORAGE_KEY,
+    null,
+    createNullableLocalStorageEnumStorage(isGitDiffDisplayMode),
+    { getOnInit: true },
+  );
+
+const gitDiffLineOverflowModePreferenceAtom = atomWithStorage<CodeOverflowMode>(
+  GIT_DIFF_LINE_OVERFLOW_MODE_STORAGE_KEY,
+  DEFAULT_CODE_OVERFLOW_MODE,
+  createLocalStorageEnumStorage(isCodeOverflowMode),
+  { getOnInit: true },
+);
+
+export function useGitDiffDisplayModePreference() {
+  return useAtom(gitDiffDisplayModePreferenceAtom);
+}
+
+export function useGitDiffLineOverflowModePreference() {
+  return useAtom(gitDiffLineOverflowModePreferenceAtom);
+}


### PR DESCRIPTION
## Human comments

From https://discord.com/channels/1522478522332090528/1545179385194356856/1545395969603014657

## What was wrong

Both git-diff toolbar preferences were component state, so they reset on remount and reload. #3868 had already made an explicit split or unified choice win at every panel width, including resize, breakpoint, and close/reopen transitions, but that choice remained in memory only for the mounted panel.

## What changed

Persist git-diff display mode and line overflow mode in device-local localStorage. This adds reload persistence on top of #3868's explicit-choice-at-every-width rule while keeping compact viewport choices session-only.

`apps/app/src/lib/git-diff-view-preferences.ts` adds validated Jotai `atomWithStorage` preferences, read on initialization with `{ getOnInit: true }`: nullable `bb.thread.gitDiff.displayMode` (`unified | split`) and `bb.thread.gitDiff.lineOverflowMode` (`wrap | scroll`, defaulting to `scroll`). [`apps/app/src/components/secondary-panel/git-diff/useResponsiveGitDiffPanelDisplay.ts`](https://github.com/get-bb/bb/pull/3271/changes#diff-28cd9e28802c7dd45a9959bd40a02922008cfb2e5741048cfaa50f9c9874a6b2) uses the stored display preference and exports `resolveGitDiffDisplayMode`; `apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx` uses the stored line-overflow preference for its wrap toggle. `apps/app/src/components/secondary-panel/git-diff/useResponsiveGitDiffPanelDisplay.test.tsx` now has 14 tests.

<details>
<summary>Decisions and scope</summary>

- These are device-local view preferences, so they use Jotai localStorage rather than `AppSettings` or `PUT /settings/general`; server and CLI access are not needed.
- `createNullableLocalStorageEnumStorage` and `createLocalStorageEnumStorage` validate the stored string unions.
- Outside compact viewports, a stored display preference overrides the 760px (`GIT_DIFF_SPLIT_VIEW_MIN_WIDTH_PX`) rule at every width. The width rule supplies the default only when the nullable preference is unset, so a stored `split` can be cramped below 760px.
- Compact viewports (`useIsCompactViewport()`, `max-width: 767px`) use a session-only display choice that defaults to `unified`. A desktop `split` preference does not carry into a phone-width drawer, and a mobile selection does not overwrite the desktop preference. The compact toggle can still select `split` for the session.
- The stored preference replaces main's `hasExplicitDisplayModeRef` and its width-change guard. The hook continues tracking width to supply the fallback when no preference is stored.
- `resolveGitDiffDisplayMode({ isCompactViewport, compactDisplayMode, displayModePreference, isWideEnoughForSplit })` is a pure export so its combinations can be tested without rendering.
- The collapse-all chevron remains unpersisted because its default depends on each diff's file count and delete status. `FilePreview.tsx` and `markdown-preview.tsx` keep independent unpersisted wrap toggles; sharing them is a separate product decision.
- This adds no settings-panel UI and no UI to return a non-compact display mode to unset. Cross-tab sync comes from the storage subscription but is untested. Compact session choices surviving viewport changes within one hook instance are intended but untested. localStorage is per origin, so preferences do not carry between the packaged app and a checkout's dev app on another port.
- After merging main, `git diff upstream/main --stat` shows changes only in the four files above. #3819's `ThreadSecondaryPanel.tsx` changes do not touch display mode or wrap state.

</details>

## How you verified

- `pnpm exec vitest run --config vitest.config.ts src/components/secondary-panel` in `apps/app`: 41 files and 405 tests passed.
- `pnpm exec tsc --noEmit -p .` in `apps/app`: passed.
- `pnpm exec turbo run typecheck lint test --filter=@bb/app`: typecheck passed; lint reported 0 errors and 191 warnings, with none new in these files; tests passed in 551 of 552 files.

`ThreadTerminalView.test.ts` was the remaining failure. It also fails when run alone and this PR does not touch it. The local Node version was v20.19.3, while the repository requires `>=22.19.0`; the likely Node v20 attribution is inferred from the stack trace, where xterm reads a global `navigator`, and is not confirmed on Node 22.

No manual reload check was performed in a running app. Reviewers should toggle both controls and reload within one app instance.

> AGENT GENERATED
