### PR TITLE
Fix archiving of nested thread descendants

### DIFF
--- a/apps/server/src/services/threads/thread-archive.ts
+++ b/apps/server/src/services/threads/thread-archive.ts
@@ -4,7 +4,7 @@ import {
 } from "../environments/provider-orchestration.js";
 import {
   listLiveThreadsInEnvironment,
-  listUnarchivedAssignedChildThreads,
+  listNonDeletedChildThreads,
   listUnarchivedHiddenSourceThreads,
 } from "@bb/db";
 import type { EnvironmentRow } from "@bb/db";
@@ -159,18 +159,44 @@ export function archiveThreadAndChildren(
   deps: AppDeps,
   args: ArchiveThreadAndChildrenArgs,
 ): string[] {
-  const childThreads = listUnarchivedAssignedChildThreads(deps.db, {
-    parentThreadId: args.parentThread.id,
-  });
-  const hiddenSourceThreads = listUnarchivedHiddenSourceThreads(deps.db, {
-    sourceThreadId: args.parentThread.id,
-  });
-  const threads: ArchiveThreadWithLifecycleEffectsArgs["thread"][] = [
-    ...childThreads,
-    ...hiddenSourceThreads,
-  ].filter((thread) => thread.id !== args.parentThread.id);
-  if (args.parentThread.archivedAt === null) {
-    threads.push(args.parentThread);
+  type ArchiveCandidate = Pick<
+    Thread,
+    "id" | "environmentId" | "status" | "archivedAt"
+  >;
+  const pending: { thread: ArchiveCandidate; expanded: boolean }[] = [
+    { thread: args.parentThread, expanded: false },
+  ];
+  const visited = new Set<string>();
+  const threads: ArchiveCandidate[] = [];
+
+  while (pending.length > 0) {
+    const entry = pending.pop();
+    if (!entry) {
+      break;
+    }
+    const { thread, expanded } = entry;
+    if (expanded) {
+      if (thread.archivedAt === null) {
+        threads.push(thread);
+      }
+      continue;
+    }
+    if (visited.has(thread.id)) {
+      continue;
+    }
+    visited.add(thread.id);
+    pending.push({ thread, expanded: true });
+    const descendants = [
+      ...listNonDeletedChildThreads(deps.db, {
+        parentThreadId: thread.id,
+      }),
+      ...listUnarchivedHiddenSourceThreads(deps.db, {
+        sourceThreadId: thread.id,
+      }),
+    ];
+    for (const descendant of descendants.reverse()) {
+      pending.push({ thread: descendant, expanded: false });
+    }
   }
   const archivedThreadIds: string[] = [];
 

--- a/apps/server/test/public/public-thread-parenting.test.ts
+++ b/apps/server/test/public/public-thread-parenting.test.ts
@@ -1,4 +1,4 @@
-import { getThread } from "@bb/db";
+import { archiveThread, getThread } from "@bb/db";
 import { threadSchema } from "@bb/domain";
 import {
   apiErrorSchema,
@@ -491,6 +491,104 @@ describe("public thread parenting routes", () => {
       expect(sideChat?.parentThreadId).toBeNull();
     });
   });
+
+  it.each([false, true])(
+    "archives all descendants once and preserves their parents (archived intermediary: %s)",
+    async (archivedIntermediary) => {
+      await withTestHarness(async (harness) => {
+        const { host } = seedHostSession(harness.deps);
+        const { project } = seedProjectWithSource(harness.deps, {
+          hostId: host.id,
+        });
+        const environment = seedEnvironment(harness.deps, {
+          hostId: host.id,
+          projectId: project.id,
+        });
+        const defaults = {
+          environmentId: environment.id,
+          projectId: project.id,
+        };
+        const root = seedThread(harness.deps, defaults);
+        const child = seedThread(harness.deps, {
+          ...defaults,
+          parentThreadId: root.id,
+        });
+        const grandchild = seedThread(harness.deps, {
+          ...defaults,
+          parentThreadId: child.id,
+        });
+        const greatGrandchild = seedThread(harness.deps, {
+          ...defaults,
+          parentThreadId: grandchild.id,
+        });
+        const hiddenFork = seedThread(harness.deps, {
+          ...defaults,
+          originKind: "fork",
+          visibility: "hidden",
+          sourceThreadId: child.id,
+          parentThreadId: child.id,
+        });
+        const forkChild = seedThread(harness.deps, {
+          ...defaults,
+          parentThreadId: hiddenFork.id,
+        });
+        if (archivedIntermediary) {
+          archiveThread(harness.db, harness.deps.hub, grandchild.id);
+        }
+        const unrelated = seedThread(harness.deps, defaults);
+        const visibleFork = seedThread(harness.deps, {
+          ...defaults,
+          originKind: "fork",
+          sourceThreadId: child.id,
+        });
+        const archived = [
+          root,
+          child,
+          grandchild,
+          greatGrandchild,
+          hiddenFork,
+          forkChild,
+        ];
+
+        const response = await harness.app.request(
+          `/api/v1/threads/${root.id}/archive-all`,
+          { method: "POST" },
+        );
+
+        expect(response.status).toBe(200);
+        const { archivedThreadIds } = threadArchiveAllResponseSchema.parse(
+          await readJson(response),
+        );
+        expect([...archivedThreadIds].sort()).toEqual(
+          archived
+            .filter(
+              (thread) => !archivedIntermediary || thread.id !== grandchild.id,
+            )
+            .map((thread) => thread.id)
+            .sort(),
+        );
+        for (const thread of archived) {
+          expect(getThread(harness.db, thread.id)).toMatchObject({
+            archivedAt: expect.any(Number),
+            parentThreadId: thread.parentThreadId,
+            sourceThreadId: thread.sourceThreadId,
+          });
+          if (
+            thread.parentThreadId !== null &&
+            archivedThreadIds.includes(thread.parentThreadId) &&
+            archivedThreadIds.includes(thread.id)
+          ) {
+            expect(archivedThreadIds.indexOf(thread.id)).toBeLessThan(
+              archivedThreadIds.indexOf(thread.parentThreadId),
+            );
+          }
+        }
+        for (const thread of [unrelated, visibleFork]) {
+          expect(getThread(harness.db, thread.id)?.archivedAt).toBeNull();
+        }
+      });
+    },
+  );
 
   it("excludes side chats from thread list results", async () => {
     await withTestHarness(async (harness) => {


### PR DESCRIPTION
## Human comments

## What was wrong

Archiving a thread and its children collected only immediate children and hidden source forks. Archiving each child then released its unarchived children, leaving grandchildren active and detached from their parents.

## What changed

Collect the descendant tree before archiving, then archive children before their parents. Traverse archived hierarchy intermediaries, include hidden source forks at each level, and deduplicate threads reached through both relationships. Preserve parent relationships and leave unrelated threads and visible source forks untouched.

## How you verified

Added public API regression coverage for four hierarchy levels, hidden forks with children, duplicate relationships, and an already-archived intermediary. The nested regression failed before the fix. All 17 tests in the selected suites pass afterward.

- `pnpm exec turbo run test --filter=@bb/server -- test/public/public-thread-parenting.test.ts test/threads/archive-pruned-environment.test.ts`
- `pnpm exec turbo run typecheck --filter=@bb/server`
- `git diff --check`

> AGENT GENERATED
