### PR TITLE
Manual machine plugin: enroll existing computers

### DIFF
--- a/apps/server/src/services/plugins/builtin-registry.ts
+++ b/apps/server/src/services/plugins/builtin-registry.ts
@@ -23,6 +23,7 @@ export const BUILTIN_PLUGINS_DIRECTORY_NAME = "builtin-plugins";
 const REPO_PLUGINS_DIRECTORY_NAME = "plugins";
 
 export const BUILTIN_PLUGINS = [
+  { name: "machine-manual", pluginId: "machine-manual", defaultEnabled: true },
   {
     name: "account-pool",
     pluginId: "account-pool",

--- a/apps/server/test/services/machines/manual-provider-transcripts.test.ts
+++ b/apps/server/test/services/machines/manual-provider-transcripts.test.ts
@@ -1,0 +1,197 @@
+import { expect, it, vi } from "vitest";
+import { defaultAppSettings } from "@bb/domain";
+import { getMachineLaunch, setAppSettings, listEvents } from "@bb/db";
+import { withTestHarness } from "../../helpers/test-app.js";
+import { seedHostSession, seedProjectWithSource } from "../../helpers/seed.js";
+import { textInput } from "../../helpers/prompt-input.js";
+import { createThreadFromRequest } from "../../../src/services/threads/thread-create.js";
+import { advanceThreadProvisioning } from "../../../src/services/threads/thread-provisioning.js";
+import {
+  cancelMachineLaunch,
+  requestMachineRemoval,
+  sweepProviderMachine,
+} from "../../../src/services/machines/provider-orchestration.js";
+
+it.each(["cancel", "enroll"])(
+  "never persists manual credentials in launches or provisioning transcripts after %s",
+  async (settlement) => {
+    await withTestHarness(async (h) => {
+      setAppSettings(h.db, {
+        ...defaultAppSettings,
+        defaultMachineAccess: "direct",
+        machineServerUrl: "https://machine.example.test",
+      });
+      await h.pluginService.install("builtin:machine-manual", { kind: "root" });
+      const host = seedHostSession(h.deps, { id: "review-local" }).host;
+      const { project } = seedProjectWithSource(h.deps, { hostId: host.id });
+      const thread = await createThreadFromRequest(h.deps, {
+        environment: {
+          type: "provider",
+          environmentProviderId: "project-checkout",
+          machine: { type: "new", machineProviderId: "manual", inputs: null },
+          inputs: {},
+        },
+        input: textInput("Manual enrollment"),
+        origin: "app",
+        projectId: project.id,
+        providerId: "codex",
+        model: "requested-model",
+        startedOnBehalfOf: null,
+      });
+      await vi.waitFor(() =>
+        expect(getMachineLaunch(h.db, thread.id)?.stepText).toBe(
+          "Run the enrollment command shown in the picker",
+        ),
+      );
+      const api = h.pluginService.getApi("machine-manual");
+      if (!api) throw new Error("Missing plugin");
+      const enrollment = await api.experimental_machines.prepareEnrollment({
+        key: thread.id,
+      });
+      if (enrollment.state !== "pending")
+        throw new Error("Expected pending enrollment");
+      const url = `/api/v1/hosts/launches/${thread.id}/enrollment-command`;
+      expect((await (await h.app.request(url)).json()).command).toContain(
+        enrollment.bootstrap.credential,
+      );
+      await advanceThreadProvisioning(h.deps, { threadId: thread.id });
+      const assertRedacted = () => {
+        const events = listEvents(h.db, { threadId: thread.id });
+        expect(
+          events.some((event) =>
+            JSON.stringify(event).includes(
+              "Run the enrollment command shown in the picker",
+            ),
+          ),
+        ).toBe(true);
+        expect(JSON.stringify(events)).not.toContain(
+          enrollment.bootstrap.credential,
+        );
+        expect(JSON.stringify(getMachineLaunch(h.db, thread.id))).not.toContain(
+          enrollment.bootstrap.credential,
+        );
+        expect(JSON.stringify(events)).not.toContain("BB_ENROLLMENT=");
+      };
+      assertRedacted();
+      if (settlement === "enroll") {
+        expect(
+          await h.deps.machineAuth.enrollHost({
+            hostId: enrollment.hostId,
+            token: enrollment.bootstrap.credential,
+            allowPublicEnrollment: true,
+          }),
+        ).not.toBeNull();
+      } else await cancelMachineLaunch(h.deps, thread.id);
+      expect(await (await h.app.request(url)).json()).toEqual({
+        command: null,
+      });
+      assertRedacted();
+      await cancelMachineLaunch(h.deps, thread.id);
+    });
+  },
+);
+
+it("returns the current thread replacement command without reviving consumed launches", async () => {
+  await withTestHarness(async (h) => {
+    setAppSettings(h.db, {
+      ...defaultAppSettings,
+      defaultMachineAccess: "direct",
+      machineServerUrl: "https://machine.example.test",
+    });
+    await h.pluginService.install("builtin:machine-manual", { kind: "root" });
+    const host = seedHostSession(h.deps, { id: "replacement-local" }).host;
+    const { project } = seedProjectWithSource(h.deps, { hostId: host.id });
+    const thread = await createThreadFromRequest(h.deps, {
+      environment: {
+        type: "provider",
+        environmentProviderId: "project-checkout",
+        machine: { type: "new", machineProviderId: "manual", inputs: null },
+        inputs: {},
+      },
+      input: textInput("Manual replacement enrollment"),
+      origin: "app",
+      projectId: project.id,
+      providerId: "codex",
+      model: "requested-model",
+      startedOnBehalfOf: null,
+    });
+    const api = h.pluginService.getApi("machine-manual");
+    if (!api) throw new Error("Missing plugin");
+    const url = (id: string) =>
+      `/api/v1/hosts/launches/${encodeURIComponent(id)}/enrollment-command`;
+    const threadUrl = `${url(thread.id)}?scope=thread`;
+    const consumedKeys: string[] = [];
+    let key = thread.id;
+    for (let generation = 0; generation < 3; generation++) {
+      await vi.waitFor(() =>
+        expect(getMachineLaunch(h.db, key)?.stepText).toBe(
+          "Run the enrollment command shown in the picker",
+        ),
+      );
+      const enrollment = await api.experimental_machines.prepareEnrollment({
+        key,
+      });
+      if (enrollment.state !== "pending")
+        throw new Error("Expected enrollment");
+      const response = await h.app.request(threadUrl);
+      expect(response.headers.get("cache-control")).toBe("no-store");
+      expect((await response.json()).command).toContain(
+        enrollment.bootstrap.credential,
+      );
+      expect((await (await h.app.request(url(key))).json()).command).toContain(
+        enrollment.bootstrap.credential,
+      );
+      for (const consumed of consumedKeys) {
+        expect(await (await h.app.request(url(consumed))).json()).toEqual({
+          command: null,
+        });
+      }
+      expect((await h.app.request(`${url(key)}?scope=invalid`)).status).toBe(
+        400,
+      );
+      const forbidden = await h.app.request(threadUrl, {
+        headers: {
+          "x-bb-gate-auth": "machine",
+          "x-bb-gate-machine-id": enrollment.hostId,
+        },
+      });
+      expect(forbidden.status).toBe(403);
+      if (generation === 2) {
+        await cancelMachineLaunch(h.deps, key);
+        expect(await (await h.app.request(threadUrl)).json()).toEqual({
+          command: null,
+        });
+        break;
+      }
+      expect(
+        await h.deps.machineAuth.enrollHost({
+          hostId: enrollment.hostId,
+          token: enrollment.bootstrap.credential,
+          allowPublicEnrollment: true,
+        }),
+      ).not.toBeNull();
+      h.hub.registerDaemon(
+        `replacement-session-${generation}`,
+        enrollment.hostId,
+        {
+          close() {},
+          send() {},
+        },
+      );
+      await vi.waitFor(() =>
+        expect(getMachineLaunch(h.db, key)?.phase).toBe("ready"),
+      );
+      expect(await (await h.app.request(threadUrl)).json()).toEqual({
+        command: null,
+      });
+      expect(requestMachineRemoval(h.deps, enrollment.hostId)).toBe(true);
+      await sweepProviderMachine(h.deps, enrollment.hostId);
+      consumedKeys.push(key);
+      key = `${thread.id}:replacement:${enrollment.hostId}`;
+      expect(await (await h.app.request(threadUrl)).json()).toEqual({
+        command: null,
+      });
+      await advanceThreadProvisioning(h.deps, { threadId: thread.id });
+    }
+  });
+});

--- a/apps/server/test/services/machines/manual-provider.test.ts
+++ b/apps/server/test/services/machines/manual-provider.test.ts
@@ -1,0 +1,240 @@
+import { buildHostDaemonWebSocketProtocols } from "@bb/host-daemon-contract";
+import {
+  onDaemonSocketMessage,
+  validateDaemonWebSocket,
+} from "../../../src/ws/daemon-protocol.js";
+import { expect, it, vi } from "vitest";
+import { defaultAppSettings } from "@bb/domain";
+import {
+  getHost,
+  getMachineLaunch,
+  machineEnrollments,
+  setAppSettings,
+  hosts,
+  openSession,
+  getSessionById,
+} from "@bb/db";
+import { withTestHarness } from "../../helpers/test-app.js";
+import {
+  submitMachine,
+  cancelMachineLaunch,
+  requestMachineRemoval,
+  sweepProviderMachine,
+} from "../../../src/services/machines/provider-orchestration.js";
+import { serverAccess } from "../../../src/services/machines/server-access.js";
+
+it("creates, cancels, and removes manual machines through the production lifecycle", async () => {
+  await withTestHarness(async (h) => {
+    setAppSettings(h.db, {
+      ...defaultAppSettings,
+      defaultMachineAccess: "direct",
+      machineServerUrl: "https://machine.example.test",
+    });
+    const installed = await h.pluginService.install("builtin:machine-manual", {
+      kind: "root",
+    });
+    expect(installed.status).toBe("running");
+    const api = h.pluginService.getApi("machine-manual");
+    if (!api) throw new Error("Manual provider did not load");
+    const release = vi.spyOn(serverAccess, "release");
+    try {
+      for (const key of [
+        "manual-cancel",
+        "manual-cancel-connected",
+        "manual-connect",
+      ]) {
+        await submitMachine(h.deps, {
+          key,
+          machineProviderId: "manual",
+          projectId: null,
+          inputs: null,
+        });
+        await vi.waitFor(() =>
+          expect(getMachineLaunch(h.db, key)?.stepText).not.toContain(
+            "Run the enrollment command shown in the picker",
+          ),
+        );
+        const enrollment = await api.experimental_machines.prepareEnrollment({
+          key,
+        });
+        if (enrollment.state !== "pending")
+          throw new Error("Expected pending enrollment");
+        expect(getMachineLaunch(h.db, key)?.stepText).not.toContain(
+          enrollment.bootstrap.credential,
+        );
+        const commandUrl = `/api/v1/hosts/launches/${key}/enrollment-command`;
+        const commandResponse = await h.app.request(commandUrl);
+        expect(commandResponse.headers.get("cache-control")).toBe("no-store");
+        expect((await commandResponse.json()).command).toContain(
+          enrollment.bootstrap.credential,
+        );
+        const denied = await h.app.request(commandUrl, {
+          headers: {
+            "x-bb-gate-auth": "machine",
+            "x-bb-gate-machine-id": "other-machine",
+          },
+        });
+        expect(denied.status).toBe(403);
+        let daemonKey: string | null = null;
+        const close = vi.fn();
+        const sent: string[] = [];
+        const socket = {
+          close,
+          send(value: string) {
+            sent.push(value);
+          },
+        };
+        let sessionId: string | null = null;
+        if (key !== "manual-cancel") {
+          const enrolled = await h.deps.machineAuth.enrollHost({
+            hostId: enrollment.hostId,
+            token: enrollment.bootstrap.credential,
+            allowPublicEnrollment: true,
+          });
+          if (!enrolled) throw new Error("Enrollment failed");
+          daemonKey = enrolled.hostKey;
+          expect(await (await h.app.request(commandUrl)).json()).toEqual({
+            command: null,
+          });
+          const session = openSession(h.db, {
+            hostId: enrollment.hostId,
+            instanceId: key,
+            hostName: "Manual",
+            dataDir: "/tmp/manual-test",
+            protocolVersion: 1,
+            heartbeatIntervalMs: 5000,
+            leaseTimeoutMs: 30000,
+          });
+          sessionId = session.id;
+          h.hub.registerDaemon(session.id, enrollment.hostId, socket);
+          expect(
+            await validateDaemonWebSocket(h.deps, {
+              sessionId,
+              authorizationHeader: `Bearer ${daemonKey}`,
+              protocolHeader: buildHostDaemonWebSocketProtocols().join(","),
+            }),
+          ).toMatchObject({ hostId: enrollment.hostId });
+          onDaemonSocketMessage(h.deps, {
+            hostId: enrollment.hostId,
+            sessionId,
+            socket,
+            raw: JSON.stringify({ type: "heartbeat" }),
+          });
+          expect(sent).toContain(JSON.stringify({ type: "heartbeat-ack" }));
+          sent.length = 0;
+        }
+        if (key.startsWith("manual-cancel")) {
+          await cancelMachineLaunch(h.deps, key);
+          expect(getMachineLaunch(h.db, key)).toMatchObject({
+            phase: "cancelled",
+            cancelPending: false,
+          });
+          expect(getHost(h.db, enrollment.hostId)?.destroyedAt).not.toBeNull();
+        } else {
+          await vi.waitFor(() =>
+            expect(getMachineLaunch(h.db, key)?.phase).toBe("ready"),
+          );
+          expect(getHost(h.db, enrollment.hostId)).toMatchObject({
+            machineProviderId: "manual",
+            resource: { version: 1, hostId: enrollment.hostId },
+            retireAt: null,
+          });
+          expect(requestMachineRemoval(h.deps, enrollment.hostId)).toBe(true);
+          await sweepProviderMachine(h.deps, enrollment.hostId);
+          expect(getHost(h.db, enrollment.hostId)).toMatchObject({
+            phase: "destroyed",
+            resource: null,
+            serverAccessGrantId: null,
+          });
+        }
+        expect(await (await h.app.request(commandUrl)).json()).toEqual({
+          command: null,
+        });
+        expect(JSON.stringify(getMachineLaunch(h.db, key))).not.toContain(
+          enrollment.bootstrap.credential,
+        );
+        if (sessionId !== null) {
+          onDaemonSocketMessage(h.deps, {
+            hostId: enrollment.hostId,
+            sessionId,
+            socket,
+            raw: JSON.stringify({ type: "heartbeat" }),
+          });
+          expect(getSessionById(h.db, { sessionId })).toMatchObject({
+            status: "closed",
+            closeReason: "expired",
+          });
+          expect(close).toHaveBeenCalledWith(1000, "expired");
+          await expect(
+            validateDaemonWebSocket(h.deps, {
+              sessionId,
+              authorizationHeader: `Bearer ${daemonKey}`,
+              protocolHeader: buildHostDaemonWebSocketProtocols().join(","),
+            }),
+          ).rejects.toMatchObject({ status: 401 });
+          expect(sent).not.toContain(JSON.stringify({ type: "heartbeat-ack" }));
+          expect(h.hub.hasDaemonForHost(enrollment.hostId)).toBe(false);
+        }
+        if (daemonKey !== null)
+          expect(
+            await h.deps.machineAuth.verifyDaemonHostKey(daemonKey),
+          ).toBeNull();
+        expect(
+          h.db
+            .select()
+            .from(machineEnrollments)
+            .all()
+            .find((row) => row.hostId === enrollment.hostId),
+        ).toMatchObject({ state: "cancelled", encryptedBootstrap: null });
+        expect(
+          await h.deps.machineAuth.enrollHost({
+            hostId: enrollment.hostId,
+            token: enrollment.bootstrap.credential,
+            allowPublicEnrollment: true,
+          }),
+        ).toBeNull();
+      }
+      expect(release).toHaveBeenCalledTimes(3);
+    } finally {
+      release.mockRestore();
+    }
+  });
+});
+
+it("releases legacy Connect access when removing a backfilled manual host", async () => {
+  await withTestHarness(async (h) => {
+    await h.pluginService.install("builtin:machine-manual", { kind: "root" });
+    const api = h.pluginService.getApi("machine-manual");
+    if (!api) throw new Error("Manual provider did not load");
+    const release = vi.fn(async () => {});
+    api.experimental_serverAccess.register({
+      id: "connect",
+      displayName: "Legacy access",
+      availability: () => ({ status: "available" }),
+      acquire: async () => {
+        throw new Error("Must not acquire during removal");
+      },
+      release,
+    });
+    h.db
+      .insert(hosts)
+      .values({
+        id: "legacy-manual",
+        name: "Legacy",
+        connectMachineId: "legacy-cloud-machine",
+        machineProviderId: "manual",
+        resource: { version: 1, hostId: "legacy-manual" },
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      })
+      .run();
+    expect(requestMachineRemoval(h.deps, "legacy-manual")).toBe(true);
+    await sweepProviderMachine(h.deps, "legacy-manual");
+    expect(release).toHaveBeenCalledWith({
+      key: "legacy-manual",
+      grantId: "legacy-manual",
+      hostId: "legacy-manual",
+    });
+    expect(getHost(h.db, "legacy-manual")?.phase).toBe("destroyed");
+  });
+});

--- a/apps/server/test/services/plugins/builtin-plugins.test.ts
+++ b/apps/server/test/services/plugins/builtin-plugins.test.ts
@@ -224,6 +224,7 @@ describe("builtin plugin reconciliation", () => {
 
   it("gives every builtin plugin a deliberate settings icon", async () => {
     const expectedIcons = new Map([
+      ["machine-manual", "Terminal"],
       ["account-pool", "Layers"],
       ["ask-user-question", "MessageQuestion"],
       ["automations", "Clock"],

--- a/plugins/bb-official.json
+++ b/plugins/bb-official.json
@@ -133,5 +133,9 @@
   "environment-personal-workspace": {
     "category": "environments",
     "screenshots": []
+  },
+  "machine-manual": {
+    "category": "environments",
+    "screenshots": []
   }
 }

--- a/plugins/machine-manual/README.md
+++ b/plugins/machine-manual/README.md
@@ -1,0 +1,23 @@
+# Existing machine
+
+The built-in `manual` machine provider uses the public machine registration and
+inputs-slot contracts. It prepares core enrollment, reports a redacted step,
+and waits for the daemon. Cancellation and removal use core credential and access
+cleanup. A host is identity plus daemon connection; a machine adds a provider-owned
+lifecycle. The local host remains provider-less.
+
+Run `bb machine create --provider manual` or select Existing machine in Settings
+or the composer picker. `--no-wait` returns a durable launch ID and command;
+`bb machine status <id>` retrieves it and `bb machine cancel <id>` cancels it.
+Closing the dialog or interrupting the follower leaves creation running.
+
+No idle suspend, automatic retirement, or suspend/resume. Removal cannot execute
+on the box: run `bb machine uninstall --host-id <host-id>` there with the original
+`BB_DATA_DIR` if configured under `~/.bb-machines`. This stops and uninstalls
+only the matching identity.
+
+The UI and CLI fetch the private command transiently through the authorized
+launch endpoint. It decrypts only the pending encrypted bundle, sets no-store,
+and returns no command after enrollment or cancellation. Credentials never enter
+progress logs or provisioning transcripts. Removal and cancellation expire live
+daemon sessions through core host-removal effects.

--- a/plugins/machine-manual/app.tsx
+++ b/plugins/machine-manual/app.tsx
@@ -1,0 +1,27 @@
+import { definePluginApp } from "@get-bb/plugin-sdk/app";
+
+export function ManualMachineInputs() {
+  return (
+    <details className="max-w-sm text-sm text-muted-foreground">
+      <summary className="cursor-pointer">Enrollment instructions</summary>
+      <div className="mt-2 space-y-2">
+        <p>
+          Run the enrollment command on an existing machine; bb is installed if
+          needed. Keep this window open while it connects.
+        </p>
+        <p>
+          Removing this machine revokes its access. Uninstall bb on the machine
+          manually with{" "}
+          <code>bb machine uninstall --host-id &lt;host-id&gt;</code>.
+        </p>
+      </div>
+    </details>
+  );
+}
+
+export default definePluginApp((app) => {
+  app.slots.experimental_machineProviderInputs({
+    machineProviderId: "manual",
+    component: ManualMachineInputs,
+  });
+});

--- a/plugins/machine-manual/package.json
+++ b/plugins/machine-manual/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "bb-plugin-machine-manual",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Enroll an existing machine by running a command",
+  "engines": {
+    "bb": ">=0.0"
+  },
+  "bb": {
+    "name": "Existing machine",
+    "description": "Enroll an existing machine by running a command",
+    "branding": {
+      "icon": "Terminal"
+    },
+    "server": "./server.ts",
+    "app": "./app.tsx"
+  },
+  "keywords": [
+    "bb-plugin"
+  ],
+  "scripts": {
+    "lint": "oxlint .",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@get-bb/plugin-sdk": "workspace:*",
+    "@types/node": "^22.0.0",
+    "@types/react": "^19.0.0",
+    "react": "^19.0.0",
+    "typescript": "npm:@typescript/typescript6@^6.0.2"
+  }
+}

--- a/plugins/machine-manual/server.ts
+++ b/plugins/machine-manual/server.ts
@@ -1,0 +1,41 @@
+import type { BbPluginApi } from "@get-bb/plugin-sdk";
+
+export default function manualMachinePlugin(bb: BbPluginApi): void {
+  bb.experimental_machines.register({
+    id: "manual",
+    displayName: "Existing machine",
+    icon: "Terminal",
+    policy: {
+      idleSuspendMs: null,
+      retire: { after: "never" },
+      removeRetryMs: 60_000,
+    },
+    async create(context) {
+      context.signal.throwIfAborted();
+      const enrollment = await bb.experimental_machines.enrollments.prepare({
+        key: context.key,
+      });
+      const resource = { version: 1, hostId: enrollment.hostId };
+      await context.checkpoint(resource);
+      context.signal.throwIfAborted();
+      context.report.step("Run the enrollment command shown in the picker");
+      const { hostId } =
+        await bb.experimental_machines.enrollments.waitForConnection({
+          enrollmentId: enrollment.id,
+          timeoutMs: 15 * 60_000,
+          signal: context.signal,
+        });
+      context.report.step("Machine connected");
+      return { status: "created", hostId, resource };
+    },
+    async experimental_reconcileCleanup() {
+      return { status: "removed" };
+    },
+    async remove(context) {
+      context.report.step(
+        `Uninstall manually on the machine: bb machine uninstall --host-id ${context.hostId}`,
+      );
+      return { status: "removed" };
+    },
+  });
+}

--- a/plugins/machine-manual/tsconfig.json
+++ b/plugins/machine-manual/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "esModuleInterop": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["*.ts", "*.tsx"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3455,6 +3455,24 @@ importers:
         specifier: ^4.1.1
         version: 4.1.1(@opentelemetry/api@1.9.1)(@types/node@22.19.10)(jsdom@29.0.1(@noble/hashes@2.4.0))(msw@2.12.14(@types/node@22.19.10)(@typescript/typescript6@6.0.2))(vite@8.0.12(@types/node@22.19.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.1)(yaml@2.9.0))
 
+  plugins/machine-manual:
+    devDependencies:
+      '@get-bb/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.10
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.13
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+      typescript:
+        specifier: npm:@typescript/typescript6@^6.0.2
+        version: '@typescript/typescript6@6.0.2'
+
   plugins/memory:
     dependencies:
       '@bb/shared-ui':

--- a/turbo.json
+++ b/turbo.json
@@ -818,6 +818,9 @@
     "bb-plugin-environment-personal-workspace#typecheck": {
       "dependsOn": ["@get-bb/plugin-sdk#build:types", "topo"]
     },
+    "bb-plugin-machine-manual#typecheck": {
+      "dependsOn": ["@get-bb/plugin-sdk#build:types", "topo"]
+    },
     "bb-plugin-connect#typecheck": {
       "dependsOn": ["@get-bb/plugin-sdk#build:types", "topo"]
     },


### PR DESCRIPTION
## Human comments

## What was wrong

Users need to enroll an existing computer through the same durable machine flow as other machine providers.

## What changed

Adds the built-in manual provider and Existing machine picker inputs, plus production-server lifecycle and transient enrollment-command tests. Closing the creation UI leaves the launch running; explicit cancellation settles it. Includes only its catalog/registration and build-task wiring. This companion should land with the base for backfilled remote machines.

Split from #3231. Depends directly on https://github.com/get-bb/bb/pull/3274 (`bb/machine-provider-apis`); the GitHub diff contains this integration only. Retarget to main after the base merges.

## How you verified

Plugin typecheck/lint; server/app bundles with the source CLI; 36 server lifecycle, transcript, and built-in-plugin tests passed.

No live vendor allocation, machine adoption, or Cloud deployment was performed for this split.

> AGENT GENERATED
