### PR TITLE
Display reasoning choices as wrapping pills

### DIFF
--- a/apps/app/src/components/pickers/ModelReasoningPicker.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.tsx
@@ -1055,17 +1055,30 @@ export function ModelReasoningPicker({
                 <div className="shrink-0 border-t border-border" />
                 <div className="shrink-0 px-1 pb-1 pt-0">
                   <MenuSectionLabel>Reasoning</MenuSectionLabel>
-                  {activeReasoningOptions.map((option) => (
-                    <MenuRowButton
-                      key={option.value}
-                      label={option.label}
-                      selected={
-                        !isPreviewing && option.value === reasoningValue
-                      }
-                      disabled={previewSelectionBlocked}
-                      onClick={() => handleReasoningSelect(option.value)}
-                    />
-                  ))}
+                  <div
+                    role="group"
+                    aria-label="Reasoning"
+                    className="flex flex-wrap gap-1.5 px-2 pb-2"
+                  >
+                    {activeReasoningOptions.map((option) => (
+                      <button
+                        key={option.value}
+                        type="button"
+                        aria-pressed={
+                          !isPreviewing && option.value === reasoningValue
+                        }
+                        className={cn(
+                          "rounded-full border border-border px-3 py-1 text-xs whitespace-nowrap outline-none hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 aria-pressed:border-primary aria-pressed:bg-primary aria-pressed:text-primary-foreground",
+                          isCompactViewport && "min-h-9 text-sm",
+                          LIST_HOVER_TRANSITION,
+                        )}
+                        disabled={previewSelectionBlocked}
+                        onClick={() => handleReasoningSelect(option.value)}
+                      >
+                        {option.label}
+                      </button>
+                    ))}
+                  </div>
                 </div>
               </>
             ) : null}


### PR DESCRIPTION
## Human comments

## What was wrong

Reasoning choices used full-width menu rows, making the model picker unnecessarily tall when a provider offered several effort levels.

## What changed

Display reasoning choices as clickable pills arranged horizontally with wrapping. Highlight the selected level and expose its state with `aria-pressed`, retain disabled and selection behavior, and use larger touch targets in compact layouts.

## How you verified

- `pnpm exec turbo run test --filter=@bb/app -- ModelReasoningPicker.test.tsx`: all 29 tests pass on Node 22.23.2.
- Browser checks in the interactive component preview confirmed selection updates, selected styling, and wrapping at a 320px viewport.
- Started the source dev app for user testing; app and server/daemon health checks pass.
- `git diff --check` passes.
- Secret-model scan: zero hits in the working tree, tracked HEAD, added lines, and commit messages for `origin/main..HEAD`.

> AGENT GENERATED
