### PR TITLE
Remove the outer card from Plugin marketplaces

### DIFF
--- a/apps/app/src/components/settings/MarketplacesSettingsSection.tsx
+++ b/apps/app/src/components/settings/MarketplacesSettingsSection.tsx
@@ -100,6 +100,7 @@ export function MarketplacesSettingsSection() {
     <SettingsSection
       title="Plugin marketplaces"
       description="bb reads plugin catalogs from these marketplaces. Adding one validates and caches its catalog; it never installs, updates, or runs plugin code."
+      bodyClassName="border-0 bg-transparent p-0"
     >
       <div className="space-y-1.5">
         <div className="flex items-start gap-2">
@@ -125,7 +126,7 @@ export function MarketplacesSettingsSection() {
         </p>
       </div>
 
-      <ul className="space-y-2 pt-1">
+      <ul className="space-y-2 pt-3">
         {marketplaces.map((marketplace) => (
           <li
             key={marketplace.name}


### PR DESCRIPTION
## Human comments

## What was wrong

The Plugin marketplaces settings section used the default bordered `SettingsSection` body while each marketplace already rendered as its own bordered row. That produced a visually redundant card-inside-a-card layout and unnecessarily indented the add form.

## What changed

Remove the outer body border, background, and padding for this section while retaining every individual marketplace row card. Increase the gap above the marketplace list so the unwrapped form and rows keep clear visual separation. Adding, refreshing, and removing marketplaces are unchanged.

## How you verified

- `pnpm exec turbo run test --filter=@bb/app --force -- MarketplacesSettingsSection` — 4/4 passed.
- `pnpm exec turbo run typecheck build lint --filter=@bb/app --force` — passed; lint reported no errors.
- `pnpm exec oxfmt --check apps/app/src/components/settings/MarketplacesSettingsSection.tsx`
- `git diff --check origin/main...HEAD`
- Reproduced the nested-card layout before the change and verified the updated layout and existing Add/Refresh interactions in the worktree app.

> AGENT GENERATED
