### PR TITLE
Fix Codex subagent events leaking into the main feed

### DIFF
--- a/packages/thread-view/src/build-event-projection.ts
+++ b/packages/thread-view/src/build-event-projection.ts
@@ -905,7 +905,11 @@ function buildFlatProjectionData(
       continue;
     }
 
-    const compactionEvent = parseCompactionLifecycleEvent(decoded, meta);
+    const compactionEvent = parseCompactionLifecycleEvent(
+      decoded,
+      meta,
+      eventParentToolCallId,
+    );
     if (compactionEvent) {
       flushToolActivityBeforeNonToolMessage(state);
       if (compactionEvent.kind === "begin") {

--- a/packages/thread-view/src/compaction-lifecycle.ts
+++ b/packages/thread-view/src/compaction-lifecycle.ts
@@ -7,6 +7,7 @@ export interface CompactionLifecycleEvent {
   key: string;
   kind: "begin" | "end";
   detail?: string;
+  parentToolCallId?: string;
 }
 
 export function getCompactionKey(
@@ -29,6 +30,7 @@ export function getCompactionKey(
 export function parseCompactionLifecycleEvent(
   decoded: ThreadEvent,
   meta: EventMeta,
+  parentToolCallId: string | undefined,
 ): CompactionLifecycleEvent | null {
   if (
     (decoded.type === "item/started" || decoded.type === "item/completed") &&
@@ -37,6 +39,7 @@ export function parseCompactionLifecycleEvent(
     return {
       key: getCompactionKey(decoded, meta),
       kind: decoded.type === "item/started" ? "begin" : "end",
+      ...(parentToolCallId ? { parentToolCallId } : {}),
     };
   }
 
@@ -44,6 +47,7 @@ export function parseCompactionLifecycleEvent(
     return {
       key: getCompactionKey(decoded, meta),
       kind: "end",
+      ...(parentToolCallId ? { parentToolCallId } : {}),
     };
   }
 

--- a/packages/thread-view/src/operation-projection.ts
+++ b/packages/thread-view/src/operation-projection.ts
@@ -818,6 +818,8 @@ export function onCompactionBegin(
     existing.status = "pending";
     existing.title = "Compacting context";
     existing.detail = payload.detail ?? existing.detail;
+    existing.parentToolCallId =
+      payload.parentToolCallId ?? existing.parentToolCallId;
     return;
   }
 
@@ -836,6 +838,9 @@ export function onCompactionBegin(
     opType: "compaction",
     title: "Compacting context",
     detail: payload.detail,
+    ...(payload.parentToolCallId
+      ? { parentToolCallId: payload.parentToolCallId }
+      : {}),
     status: "pending",
   };
   state.openCompactionsByKey.set(payload.key, message);
@@ -857,6 +862,8 @@ export function onCompactionEnd(
     existing.status = "completed";
     existing.title = "Context compacted";
     existing.detail = payload.detail ?? existing.detail;
+    existing.parentToolCallId =
+      payload.parentToolCallId ?? existing.parentToolCallId;
     state.openCompactionsByKey.delete(payload.key);
     state.finalizedCompactionKeys.add(payload.key);
     return;
@@ -881,6 +888,9 @@ export function onCompactionEnd(
     opType: "compaction",
     title: "Context compacted",
     detail: payload.detail,
+    ...(payload.parentToolCallId
+      ? { parentToolCallId: payload.parentToolCallId }
+      : {}),
     status: "completed",
   });
   state.finalizedCompactionKeys.add(payload.key);

--- a/packages/thread-view/test/delegation-item-projection.test.ts
+++ b/packages/thread-view/test/delegation-item-projection.test.ts
@@ -36,6 +36,81 @@ function findDelegationRow(
 }
 
 describe("delegation item projection", () => {
+  it.each(["explicit", "inherited", "completion-only"] as const)(
+    "keeps %s child compactions inside the delegation and root compactions in the main feed",
+    (mode) => {
+      const event = createTimelineEventFactory({ threadId: "thread-1" });
+      const childScope = {
+        turnId: "child-turn",
+        ...(mode === "inherited" ? {} : { parentToolCallId: "call-1" }),
+      };
+      const timeline = renderTimelineFixture({
+        events: [
+          event.turnStarted({ turnId: "parent-turn", createdAt: 0 }),
+          event.delegationStarted({
+            turnId: "parent-turn",
+            itemId: "call-1",
+            childRef: "child",
+            label: "/root/review",
+            createdAt: 1_000,
+          }),
+          event.turnStarted({
+            turnId: "child-turn",
+            ...(mode === "inherited" ? { parentToolCallId: "call-1" } : {}),
+            createdAt: 2_000,
+          }),
+          ...(mode === "completion-only"
+            ? []
+            : [
+                event.contextCompactionStarted({
+                  ...childScope,
+                  createdAt: 3_000,
+                }),
+              ]),
+          event.contextCompactionStarted({
+            turnId: "parent-turn",
+            itemId: "root-compaction",
+            createdAt: 4_000,
+          }),
+          event.contextCompactionCompleted({ ...childScope, createdAt: 5_000 }),
+          event.contextCompactionCompleted({
+            turnId: "parent-turn",
+            itemId: "root-compaction",
+            createdAt: 6_000,
+          }),
+        ],
+        projectionOptions: {
+          threadStatus: "active",
+          turnMessageDetail: "full",
+        },
+      });
+      const delegation = findDelegationRow(timeline.rows, "call-1");
+      expect(delegation.childRows).toContainEqual(
+        expect.objectContaining({
+          kind: "system",
+          operationKind: "compaction",
+          status: "completed",
+          startedAt: mode === "completion-only" ? 5_000 : 3_000,
+          completedAt: 5_000,
+        }),
+      );
+      const rootRows = timeline.rows.flatMap((row) =>
+        row.kind === "turn" ? (row.children ?? []) : [row],
+      );
+      const compactions = rootRows.filter(
+        (row) =>
+          row.kind === "system" &&
+          row.systemKind === "operation" &&
+          row.operationKind === "compaction",
+      );
+      expect(compactions).toHaveLength(1);
+      expect(compactions[0]).toMatchObject({
+        startedAt: 4_000,
+        completedAt: 6_000,
+      });
+    },
+  );
+
   it("renders a delegation item as a delegation row with its child content nested", () => {
     const event = createTimelineEventFactory({ threadId: "thread-1" });
     const timeline = renderTimelineFixture({

--- a/packages/thread-view/test/timeline-test-harness.ts
+++ b/packages/thread-view/test/timeline-test-harness.ts
@@ -740,6 +740,9 @@ export function createTimelineEventFactory(
           item: {
             type: "contextCompaction",
             id: args.itemId ?? "compact-1",
+            ...(args.parentToolCallId
+              ? { parentToolCallId: args.parentToolCallId }
+              : {}),
           },
         },
       };
@@ -757,6 +760,9 @@ export function createTimelineEventFactory(
           item: {
             type: "contextCompaction",
             id: args.itemId ?? "compact-1",
+            ...(args.parentToolCallId
+              ? { parentToolCallId: args.parentToolCallId }
+              : {}),
           },
         },
       };

--- a/plugins/provider-codex/src/schemas.ts
+++ b/plugins/provider-codex/src/schemas.ts
@@ -334,7 +334,7 @@ export const codexSubAgentActivityItemSchema = z
   .object({
     type: z.literal("subAgentActivity"),
     id: z.string(),
-    kind: z.enum(["started", "interacted", "interrupted"]),
+    kind: z.enum(["started", "interacted", "interrupted", "completed"]),
     agentThreadId: z.string(),
     agentPath: z.string(),
   })

--- a/plugins/provider-codex/src/translator.test.ts
+++ b/plugins/provider-codex/src/translator.test.ts
@@ -664,7 +664,7 @@ describe("codex subagent activity correlation", () => {
   function subAgentActivity(args: {
     agentThreadId?: string;
     id: string;
-    kind: "started" | "interacted" | "interrupted";
+    kind: "started" | "interacted" | "interrupted" | "completed";
   }) {
     const agentThreadId = args.agentThreadId ?? "agent-thread-1";
     return {
@@ -719,6 +719,31 @@ describe("codex subagent activity correlation", () => {
         .translate(childTurnCompleted("child-turn-1"))
         .map((event) => event.type),
     ).toEqual(["turn/completed", "item/completed"]);
+  });
+
+  it("consumes completion activity notifications without duplicating the finished agent", () => {
+    const harness = createHarness();
+    harness.translate(subAgentActivity({ id: "spawn-1", kind: "started" }));
+    harness.translate(childTurnStarted("child-turn-1"));
+    const settled = harness.translate(childTurnCompleted("child-turn-1"));
+    expect(settled).toContainEqual(
+      expect.objectContaining({
+        type: "item/completed",
+        item: expect.objectContaining({
+          type: "delegation",
+          status: "completed",
+        }),
+      }),
+    );
+    const completion = subAgentActivity({
+      id: "subagent-completed-1",
+      kind: "completed",
+    });
+    expect(
+      harness.translate({ ...completion, method: "item/started" }),
+    ).toEqual([]);
+    expect(harness.translate(completion)).toEqual([]);
+    expect(harness.translate(completion)).toEqual([]);
   });
 
   it("materializes subagent activity as a nested delegation lifecycle", () => {

--- a/plugins/provider-codex/src/translator.ts
+++ b/plugins/provider-codex/src/translator.ts
@@ -1214,6 +1214,8 @@ export function createCodexEventTranslator(
     }
 
     switch (activity.item.kind) {
+      case "completed":
+        return [];
       case "started": {
         if (trackedSubAgentsByCallId.has(activity.item.id)) {
           return [];


### PR DESCRIPTION
## Human comments

## What was wrong

The timeline discarded parent links while projecting compaction lifecycle events, so subagent compactions appeared in the main feed. The Codex adapter also rejected `subAgentActivity` items with `kind: "completed"`, producing duplicate “Unhandled Codex event” diagnostics alongside the existing agent completion summary.

## What changed

Preserve explicit and inherited parent links throughout compaction projection, including completion-only events. Recognize Codex's completion activity notifications and consume them without duplicating the delegation lifecycle already settled by the child turn. Root-agent compactions remain visible in the main feed. Previously persisted diagnostic rows are unchanged.

## How you verified

- `pnpm exec turbo run test typecheck --filter=@bb/thread-view --filter=bb-plugin-provider-codex`: 651 tests and both typechecks passed.
- Added regression coverage for explicit/inherited nesting, completion-only compactions, concurrent root compaction, and duplicate Codex completion notifications.
- Replayed the reported thread's saved events locally: all three compactions remain nested, zero compactions appear at the root, and all 18 completion activity notifications produce zero unhandled deltas. Raw thread data was not committed.
- Formatting and `git diff --check` passed.
- Secret-model scan: clean working tree, HEAD, added lines, and commit messages for `origin/main..HEAD`.

> AGENT GENERATED
