### PR TITLE
Link needs-configuration banners to plugin settings

### DIFF
--- a/apps/app/src/components/tools/PluginCapabilities.tsx
+++ b/apps/app/src/components/tools/PluginCapabilities.tsx
@@ -500,6 +500,12 @@ function PluginRuntimeStatusAlert({
   onReload: () => void;
   reloadPending: boolean;
 }) {
+  const { settingsSections } = usePluginSlots();
+  const hasSettingsPage =
+    plugin.hasSettings ||
+    settingsSections.some((section) => section.pluginId === plugin.id);
+  const canOpenSettings =
+    plugin.status === "needs-configuration" && hasSettingsPage;
   const canReload =
     plugin.status === "error" ||
     plugin.status === "degraded" ||
@@ -524,23 +530,38 @@ function PluginRuntimeStatusAlert({
       detail={detail}
       separator={plugin.status !== "degraded"}
       action={
-        canReload ? (
-          <Button
-            type="button"
-            size="sm"
-            disabled={reloadPending}
-            className="h-7 px-2.5 text-xs"
-            onClick={onReload}
-          >
-            {reloadPending ? (
-              <Icon
-                name="Loading"
-                className="size-3.5 animate-spin"
-                aria-hidden
-              />
+        canOpenSettings || canReload ? (
+          <span className="flex items-center gap-2">
+            {canOpenSettings ? (
+              <Button asChild size="sm" className="h-7 gap-0.5 px-2.5 text-xs">
+                <Link
+                  to={getPluginConfigurationRoutePath({ pluginId: plugin.id })}
+                >
+                  Open settings
+                  <Icon name="ChevronRight" className="size-3.5" aria-hidden />
+                </Link>
+              </Button>
             ) : null}
-            {reloadPending ? "Reloading\u2026" : "Reload"}
-          </Button>
+            {canReload ? (
+              <Button
+                type="button"
+                size="sm"
+                variant={canOpenSettings ? "outline" : "default"}
+                disabled={reloadPending}
+                className="h-7 px-2.5 text-xs"
+                onClick={onReload}
+              >
+                {reloadPending ? (
+                  <Icon
+                    name="Loading"
+                    className="size-3.5 animate-spin"
+                    aria-hidden
+                  />
+                ) : null}
+                {reloadPending ? "Reloading\u2026" : "Reload"}
+              </Button>
+            ) : null}
+          </span>
         ) : undefined
       }
     />

--- a/apps/app/src/components/tools/plugin-detail-banner.tsx
+++ b/apps/app/src/components/tools/plugin-detail-banner.tsx
@@ -34,13 +34,13 @@ export function PluginBannerBar({
         separator && "border-b border-border",
       )}
     >
-      <div className="mx-auto flex w-full min-w-0 max-w-5xl items-start gap-3 px-4 py-2.5 md:px-5">
+      <div className="mx-auto flex w-full min-w-0 max-w-5xl flex-wrap items-start gap-x-3 gap-y-2 px-4 py-2.5 md:px-5">
         <Icon
           name={icon}
           className={cn("mt-0.5 size-4 shrink-0", TONE_ICON[tone])}
           aria-hidden
         />
-        <div className="min-w-0 flex-1">
+        <div className="min-w-0 flex-1 basis-64">
           <p className="text-sm font-medium text-foreground">{title}</p>
           {detail === null || detail === undefined ? null : (
             <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">
@@ -49,7 +49,9 @@ export function PluginBannerBar({
           )}
         </div>
         {action ? (
-          <span className="flex shrink-0 items-center pt-0.5">{action}</span>
+          <span className="ms-auto flex shrink-0 items-center pt-0.5">
+            {action}
+          </span>
         ) : null}
       </div>
     </div>

--- a/apps/app/src/views/ToolsView.plugin-detail.test.tsx
+++ b/apps/app/src/views/ToolsView.plugin-detail.test.tsx
@@ -1292,7 +1292,7 @@ describe("PluginDetail runtime health", () => {
     },
   );
 
-  it("keeps needs-configuration actionless because saving Settings retries it", () => {
+  it("sends needs-configuration to the plugin settings page instead of Reload", () => {
     renderRuntimeStatus("needs-configuration", {
       statusDetail: "An API token is required.",
       hasSettings: true,
@@ -1303,6 +1303,10 @@ describe("PluginDetail runtime health", () => {
     expect(alert.textContent).toContain(
       "Complete the Configuration section; bb reloads the plugin after you save.",
     );
+    const settingsLink = within(alert).getByRole("link", {
+      name: "Open settings",
+    });
+    expect(settingsLink.getAttribute("href")).toBe("/settings/plugins/github");
     expect(screen.queryByRole("button", { name: "Reload" })).toBeNull();
   });
 
@@ -1320,6 +1324,65 @@ describe("PluginDetail runtime health", () => {
       "Add the required configuration, then reload the plugin.",
     );
     expect(screen.getByRole("button", { name: "Reload" })).toBeTruthy();
+    expect(
+      within(alert).queryByRole("link", { name: "Open settings" }),
+    ).toBeNull();
+  });
+
+  it("links to a settings page contributed by the plugin frontend and keeps Reload", () => {
+    setPluginSlotRegistrations(
+      "github",
+      makePluginRegistrationSet({
+        settingsSections: [
+          { id: "accounts", title: "Accounts", component: () => null },
+        ],
+        navPanels: [],
+        threadPanelActions: [],
+        composerCustomizations: [],
+        pendingInteractions: [],
+        sidebarFooterActions: [],
+        fileOpeners: [],
+        messageDirectives: [],
+      }),
+    );
+
+    renderRuntimeStatus("needs-configuration", {
+      statusDetail: "Add and enable an account.",
+      hasSettings: false,
+    });
+
+    const alert = screen.getByRole("alert");
+    const settingsLink = within(alert).getByRole("link", {
+      name: "Open settings",
+    });
+    expect(settingsLink.getAttribute("href")).toBe("/settings/plugins/github");
+    expect(within(alert).getByRole("button", { name: "Reload" })).toBeTruthy();
+  });
+
+  it("does not offer a settings link for other runtime failures", () => {
+    setPluginSlotRegistrations(
+      "github",
+      makePluginRegistrationSet({
+        settingsSections: [
+          { id: "accounts", title: "Accounts", component: () => null },
+        ],
+        navPanels: [],
+        threadPanelActions: [],
+        composerCustomizations: [],
+        pendingInteractions: [],
+        sidebarFooterActions: [],
+        fileOpeners: [],
+        messageDirectives: [],
+      }),
+    );
+
+    renderRuntimeStatus("error");
+
+    const alert = screen.getByRole("alert");
+    expect(
+      within(alert).queryByRole("link", { name: "Open settings" }),
+    ).toBeNull();
+    expect(within(alert).getByRole("button", { name: "Reload" })).toBeTruthy();
   });
 
   it("reloads the affected plugin and reflects its pending state", async () => {


### PR DESCRIPTION
## Human comments

## What was wrong

The `needs-configuration` plugin banner knew whether a plugin exposed in-app settings, but its actions did not provide a route to those settings. Plugins configured through a frontend-contributed settings section also still need an explicit reload after configuration, and the banner's single-row layout left too little width for its recovery copy once both actions were present on compact screens.

## What changed

- Adds an **Open settings** action for `needs-configuration` plugins with either declarative settings or a frontend-contributed settings section.
- Keeps **Reload** for plugins whose configuration is not automatically applied, including plugins with frontend-contributed settings.
- Lets banner content wrap so the actions move below the message when horizontal space is limited.
- Adds focused coverage for declarative settings, frontend-contributed settings, config-less plugins, and unrelated runtime failures.
- No wire, CLI, guide, or public plugin API changes.

## How you verified

- `pnpm exec turbo run test --filter=@bb/app --force -- ToolsView.plugin-detail` (36 tests passed)
- `pnpm exec turbo run typecheck lint --filter=@bb/app --force` (passed; lint reported 0 errors)
- `pnpm exec oxfmt --check apps/app/src/components/tools/PluginCapabilities.tsx apps/app/src/components/tools/plugin-detail-banner.tsx apps/app/src/views/ToolsView.plugin-detail.test.tsx`
- `git diff --check origin/main...HEAD`
- Manually verified the link destination, retained reload action, and compact 390px wrapping in the isolated review app.

> AGENT GENERATED
