### PR TITLE
Make resource toolbars responsive on compact screens

### DIFF
--- a/apps/app/src/components/plugin/PluginsOverview.tsx
+++ b/apps/app/src/components/plugin/PluginsOverview.tsx
@@ -149,7 +149,6 @@ export function PluginsOverview({
 
   const installedActions = (
     <>
-      {plugins.length > 0 ? <CheckPluginUpdatesButton /> : null}
       <CreateWithTemplatesButton
         kind="plugin"
         label="New plugin"
@@ -219,6 +218,7 @@ export function PluginsOverview({
                     )
                   }
                 />
+                {plugins.length > 0 ? <CheckPluginUpdatesButton /> : null}
               </>
             }
           />

--- a/packages/shared-ui/src/components/ui/resource/toolbar.tsx
+++ b/packages/shared-ui/src/components/ui/resource/toolbar.tsx
@@ -39,7 +39,7 @@ export function ResourceToolbar({
 }) {
   return (
     <div className="flex flex-wrap items-center gap-2">
-      <div className="relative min-w-0 flex-1">
+      <div className="relative w-full min-w-0 sm:w-auto sm:flex-1">
         <Icon
           name="Search"
           className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground"


### PR DESCRIPTION
## Human comments

## What was wrong

The shared resource toolbar always kept its search field on the same row as every filter and action. On compact screens, the fixed-width controls squeezed search down to an unusable width. In the installed-plugins toolbar, the visually related refresh, filter, and sort controls were also split across the row because refresh lived in the primary-action group.

## What changed

- Makes resource-toolbar search occupy the full first row below the `sm` breakpoint while preserving the existing desktop layout.
- Groups the installed-plugin refresh control with the filter and sort controls, leaving **New plugin** as the primary action on the right.
- No behavior, wire, CLI, guide, or public plugin API changes.

## How you verified

- `pnpm exec turbo run test --filter=@bb/shared-ui --force`
- `pnpm exec turbo run test --filter=@bb/app --force -- --run src/components/plugin` (47 files, 376 tests passed)
- `pnpm exec turbo run typecheck lint --filter=@bb/app --filter=@bb/shared-ui --force` (passed; lint reported 0 errors)
- `pnpm exec oxfmt --check packages/shared-ui/src/components/ui/resource/toolbar.tsx apps/app/src/components/plugin/PluginsOverview.tsx`
- `git diff --check origin/main...HEAD`
- Manually verified the installed-plugins toolbar at 360px, 421px, and 1280px, plus the other resource-toolbar consumers at compact width.

> AGENT GENERATED
