### PR TITLE
Stabilize timed-out Codex construction cleanup

### DIFF
--- a/packages/agent-runtime/src/runtime.codex-topology.test.ts
+++ b/packages/agent-runtime/src/runtime.codex-topology.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ThreadEvent } from "@bb/domain";
 import { createAgentRuntime } from "./runtime.js";
 import {
@@ -286,18 +286,58 @@ describe("codex process topology", () => {
   }, 30_000);
 
   it("releases the thread on the bridge when a construction times out on the runtime's side", async () => {
+    const realSetTimeout = setTimeout;
+    const sleepReal = (ms: number): Promise<void> =>
+      new Promise((resolve) => {
+        realSetTimeout(resolve, ms);
+      });
     const topology = createCodexTopologyRuntime({
-      fakeScript: { startDelayMs: 800 },
+      fakeScript: { stallThreadStart: true },
       threadCreationTimeoutMs: 200,
     });
     const { runtime } = topology;
-    await expect(startCodexThread(runtime, "t1")).rejects.toThrow(/timed out/i);
+    await runtime.ensureProvider({ providerId: "codex" });
+    vi.useFakeTimers();
+    try {
+      const startOutcome = startCodexThread(runtime, "t1").then(
+        (providerThreadId) => ({
+          status: "resolved" as const,
+          providerThreadId,
+        }),
+        (error: unknown) => ({ status: "rejected" as const, error }),
+      );
+      for (let attempt = 0; topology.spawned() === 0; attempt += 1) {
+        if (attempt >= 1_000) {
+          throw new Error("The fake app-server child never started");
+        }
+        await sleepReal(10);
+      }
+
+      await vi.advanceTimersByTimeAsync(201);
+      const outcome = await startOutcome;
+      if (outcome.status === "resolved") {
+        throw new Error(
+          `Expected thread construction to time out, but it resolved as ${outcome.providerThreadId}`,
+        );
+      }
+      expect(outcome.error).toBeInstanceOf(Error);
+      expect(String(outcome.error)).toMatch(/timed out: thread\/start/i);
+    } finally {
+      vi.useRealTimers();
+    }
+
     expect(runtime.hasThread("t1")).toBe(false);
+    const [childPid] = topology.childPids();
+    if (childPid === undefined) {
+      throw new Error("Expected the stalled construction to spawn a child");
+    }
     await waitForRuntimeState({
-      label: "the late-constructed child was released",
-      predicate: () => topology.spawned() === 1 && topology.exited() === 1,
+      label: "the stalled construction child exited gracefully",
+      predicate: () => topology.exited() === 1 && !isAlive(childPid),
       timeoutMs: 10_000,
     });
+    expect(topology.spawned()).toBe(1);
+    expect(topology.exited()).toBe(1);
     expect(runtime.listRunningProviders()).toEqual([]);
     expect(topology.bridgeExits).toEqual([{ expected: true }]);
   }, 30_000);

--- a/plugins/provider-codex/src/bridge/app-server-connection.test.ts
+++ b/plugins/provider-codex/src/bridge/app-server-connection.test.ts
@@ -1,0 +1,198 @@
+import { setTimeout as delay } from "node:timers/promises";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import {
+  CodexAppServerExitedError,
+  createCodexAppServerConnection,
+  type CodexAppServerConnection,
+  type CodexAppServerExitInfo,
+} from "./app-server-connection.js";
+
+const EPIPE_PAYLOAD_SIZE = 1024 * 1024;
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve(value: T): void;
+} {
+  let resolvePromise: ((value: T) => void) | undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return {
+    promise,
+    resolve(value) {
+      resolvePromise?.(value);
+    },
+  };
+}
+
+async function stopConnection(
+  connection: CodexAppServerConnection,
+  exit: Promise<CodexAppServerExitInfo>,
+): Promise<void> {
+  await connection.kill();
+  await exit;
+}
+
+function childRequestLine(): string {
+  return `${JSON.stringify({
+    jsonrpc: "2.0",
+    id: "child-request",
+    method: "fixture/approval",
+    params: {},
+  })}\n`;
+}
+
+describe("codex app-server connection", () => {
+  it("preserves final output and exit details while stdio drains", async () => {
+    const exited = deferred<CodexAppServerExitInfo>();
+    const lateResponseLine = `${JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      result: { thread: { id: "thread-from-final-output" } },
+    })}\n`;
+    const descendantScript = [
+      `const line = ${JSON.stringify(lateResponseLine)};`,
+      "setTimeout(() => process.stdout.write(line, () => process.exit(0)), 250);",
+    ].join("");
+    const childScript = [
+      'const { spawn } = require("node:child_process");',
+      'process.stdin.once("data", () => {',
+      'process.stderr.write("fixture stderr\\n");',
+      `process.stdout.write(${JSON.stringify(childRequestLine())}, () => {`,
+      `spawn(process.execPath, ["-e", ${JSON.stringify(descendantScript)}], { stdio: ["ignore", 1, "ignore"] });`,
+      "process.exit(7);",
+      "});",
+      "});",
+    ].join("");
+    const connection = createCodexAppServerConnection({
+      command: process.execPath,
+      args: ["-e", childScript],
+      cwd: process.cwd(),
+      env: process.env,
+      recordThreadId: null,
+      onNotification: () => undefined,
+      onRequest: (_method, _params, responder) => {
+        setTimeout(() => responder.result({ decision: "accept" }), 100);
+      },
+      onExit: exited.resolve,
+    });
+
+    try {
+      await expect(
+        connection.request({
+          method: "thread/start",
+          resultSchema: z.object({
+            thread: z.object({ id: z.string() }),
+          }),
+        }),
+      ).resolves.toEqual({
+        thread: { id: "thread-from-final-output" },
+      });
+      await expect(exited.promise).resolves.toEqual({
+        code: 7,
+        signal: null,
+        stderrTail: "fixture stderr",
+        spawnFailed: false,
+      });
+    } finally {
+      await stopConnection(connection, exited.promise);
+    }
+  }, 30_000);
+
+  it("preserves a natural exit status when EPIPE precedes exit", async () => {
+    const exited = deferred<CodexAppServerExitInfo>();
+    const connection = createCodexAppServerConnection({
+      command: process.execPath,
+      args: [
+        "-e",
+        'process.stderr.write("fixture stderr\\n"); process.exit(7);',
+      ],
+      cwd: process.cwd(),
+      env: process.env,
+      recordThreadId: null,
+      onNotification: () => undefined,
+      onRequest: () => undefined,
+      onExit: exited.resolve,
+    });
+
+    try {
+      await expect(
+        connection.request({
+          method: "thread/start",
+          params: { payload: "x".repeat(EPIPE_PAYLOAD_SIZE) },
+          resultSchema: z.unknown(),
+        }),
+      ).rejects.toThrow(/codex app-server exited \(code 7, signal null\)/);
+      await expect(exited.promise).resolves.toMatchObject({
+        code: 7,
+        signal: null,
+        stderrTail: expect.stringContaining("fixture stderr"),
+        spawnFailed: false,
+      });
+    } finally {
+      await stopConnection(connection, exited.promise);
+    }
+  }, 30_000);
+
+  it("makes a broken child stdin immediately terminal", async () => {
+    const ready = deferred<void>();
+    const exited = deferred<CodexAppServerExitInfo>();
+    const connection = createCodexAppServerConnection({
+      command: process.execPath,
+      args: [
+        "-e",
+        [
+          'require("node:fs").closeSync(0);',
+          `process.stdout.write(${JSON.stringify(
+            `${JSON.stringify({ jsonrpc: "2.0", method: "ready" })}\n`,
+          )});`,
+          'process.on("SIGTERM", () => {});',
+          "setTimeout(() => process.exit(0), 1000);",
+        ].join(""),
+      ],
+      cwd: process.cwd(),
+      env: process.env,
+      recordThreadId: null,
+      onNotification(method) {
+        if (method === "ready") ready.resolve();
+      },
+      onRequest: () => undefined,
+      onExit: exited.resolve,
+    });
+
+    try {
+      await ready.promise;
+      const pendingRequest = connection.request({
+        method: "thread/start",
+        params: { payload: "x".repeat(EPIPE_PAYLOAD_SIZE) },
+        resultSchema: z.unknown(),
+      });
+      await expect(
+        Promise.race([
+          pendingRequest,
+          delay(500).then(() => {
+            throw new Error(
+              "Codex request remained pending after stdin closed",
+            );
+          }),
+        ]),
+      ).rejects.toBeInstanceOf(CodexAppServerExitedError);
+      expect(connection.exited).toBe(true);
+      await expect(
+        connection.request({
+          method: "thread/resume",
+          resultSchema: z.unknown(),
+        }),
+      ).rejects.toBeInstanceOf(CodexAppServerExitedError);
+      await expect(exited.promise).resolves.toMatchObject({
+        code: null,
+        signal: "SIGKILL",
+        stderrTail: expect.stringMatching(/stdin failed \(EPIPE\)/),
+        spawnFailed: false,
+      });
+    } finally {
+      await stopConnection(connection, exited.promise);
+    }
+  }, 30_000);
+});

--- a/plugins/provider-codex/src/bridge/app-server-connection.ts
+++ b/plugins/provider-codex/src/bridge/app-server-connection.ts
@@ -6,6 +6,7 @@ import type { z } from "zod";
 const STDERR_TAIL_MAX_CHUNKS = 40;
 const CLOSE_AFTER_EXIT_GRACE_MS = 1_000;
 const KILL_ESCALATION_MS = 4_000;
+const CLOSED_STDIN_ERROR_CODES = new Set(["EPIPE", "ERR_STREAM_DESTROYED"]);
 
 export interface CodexAppServerRequestResponder {
   result(value: unknown): void;
@@ -89,6 +90,14 @@ function parseChildLine(line: string): ParsedChildMessage | null {
   return parsed as ParsedChildMessage;
 }
 
+function isClosedChildStdinError(error: Error): boolean {
+  return (
+    "code" in error &&
+    typeof error.code === "string" &&
+    CLOSED_STDIN_ERROR_CODES.has(error.code)
+  );
+}
+
 export function createCodexAppServerConnection(
   options: CreateCodexAppServerConnectionOptions,
 ): CodexAppServerConnection {
@@ -110,6 +119,8 @@ export function createCodexAppServerConnection(
     code: number | null;
     signal: NodeJS.Signals | null;
   } | null = null;
+  let killStarted = false;
+  let stdinFailure: CodexAppServerExitedError | null = null;
   let closeGraceTimer: NodeJS.Timeout | null = null;
   let stdoutLines: Interface | null = null;
   let resolveExit!: () => void;
@@ -117,12 +128,11 @@ export function createCodexAppServerConnection(
     resolveExit = resolve;
   });
 
-  function writeLine(message: object): void {
-    const stdin = child.stdin;
-    if (!stdin || stdin.destroyed || !stdin.writable) {
-      return;
+  function pushStderrChunk(chunk: string): void {
+    stderrChunks.push(chunk);
+    if (stderrChunks.length > STDERR_TAIL_MAX_CHUNKS) {
+      stderrChunks.shift();
     }
-    stdin.write(JSON.stringify(message) + "\n");
   }
 
   function rejectAllPending(error: Error): void {
@@ -133,6 +143,50 @@ export function createCodexAppServerConnection(
       request.reject(error);
     }
     pending.clear();
+  }
+
+  function killChild(): Promise<void> {
+    if (finalized || killStarted) {
+      return exitPromise;
+    }
+    killStarted = true;
+    const escalation = setTimeout(() => {
+      if (!finalized) {
+        child.kill("SIGKILL");
+      }
+    }, KILL_ESCALATION_MS);
+    escalation.unref?.();
+    child.kill("SIGTERM");
+    return exitPromise;
+  }
+
+  function handleBrokenStdin(error: Error): void {
+    if (finalized || exitStatus !== null || stdinFailure !== null) {
+      return;
+    }
+    const code =
+      "code" in error && typeof error.code === "string"
+        ? ` (${error.code})`
+        : "";
+    const detail = `stdin failed${code}: ${error.message}`;
+    stdinFailure = new CodexAppServerExitedError(`codex app-server ${detail}`);
+    pushStderrChunk(detail);
+    killStarted = true;
+    child.kill("SIGKILL");
+  }
+
+  function writeLine(message: object): void {
+    if (stdinFailure !== null) {
+      return;
+    }
+    const stdin = child.stdin;
+    if (!stdin || stdin.destroyed || !stdin.writable) {
+      if (exitStatus === null) {
+        handleBrokenStdin(new Error("stdin is not writable"));
+      }
+      return;
+    }
+    stdin.write(JSON.stringify(message) + "\n");
   }
 
   function finalizeExit(status: {
@@ -239,17 +293,21 @@ export function createCodexAppServerConnection(
       terminal: false,
     });
     stderrLines.on("line", (line) => {
-      stderrChunks.push(line);
-      if (stderrChunks.length > STDERR_TAIL_MAX_CHUNKS) {
-        stderrChunks.shift();
-      }
+      pushStderrChunk(line);
     });
   }
 
   child.on("error", (error) => {
     spawnFailed = true;
-    stderrChunks.push(error.message);
+    pushStderrChunk(error.message);
     finalizeExit({ code: null, signal: null });
+  });
+
+  child.stdin?.on("error", (error) => {
+    if (!isClosedChildStdinError(error)) {
+      throw error;
+    }
+    handleBrokenStdin(error);
   });
 
   child.on("exit", (code, signal) => {
@@ -266,7 +324,7 @@ export function createCodexAppServerConnection(
 
   return {
     get exited() {
-      return finalized;
+      return finalized || stdinFailure !== null;
     },
 
     request({ method, params, resultSchema, timeoutMs }) {
@@ -276,6 +334,9 @@ export function createCodexAppServerConnection(
             spawnFailed,
           }),
         );
+      }
+      if (stdinFailure !== null) {
+        return Promise.reject(stdinFailure);
       }
       const id = nextRequestId;
       nextRequestId += 1;
@@ -313,24 +374,14 @@ export function createCodexAppServerConnection(
     },
 
     notify(method, params) {
-      if (finalized) {
+      if (finalized || stdinFailure !== null) {
         return;
       }
       writeLine({ jsonrpc: "2.0", method, params });
     },
 
     kill() {
-      if (finalized) {
-        return exitPromise;
-      }
-      const escalation = setTimeout(() => {
-        if (!finalized) {
-          child.kill("SIGKILL");
-        }
-      }, KILL_ESCALATION_MS);
-      escalation.unref?.();
-      child.kill("SIGTERM");
-      return exitPromise;
+      return killChild();
     },
   };
 }

--- a/plugins/provider-codex/src/bridge/fake-codex-app-server.mjs
+++ b/plugins/provider-codex/src/bridge/fake-codex-app-server.mjs
@@ -165,8 +165,7 @@ const archivedThreadIds = new Set();
  * see the children die on release, archive, and bridge shutdown.
  */
 const processLogPath = script?.processLogPath ?? null;
-/** `startDelayMs`: answer `thread/start` only after this many milliseconds. */
-const startDelayMs = script?.startDelayMs ?? 0;
+const stallThreadStart = script?.stallThreadStart ?? false;
 const sigtermDelayMs = script?.sigtermDelayMs ?? 0;
 
 function logProcessStep(step) {
@@ -176,7 +175,6 @@ function logProcessStep(step) {
   appendFileSync(processLogPath, `${step}:${process.pid}:${process.ppid}\n`);
 }
 
-logProcessStep("spawn");
 function exitCleanly() {
   logProcessStep("exit");
   process.exit(0);
@@ -189,6 +187,7 @@ process.on("SIGTERM", () => {
   }
   exitCleanly();
 });
+logProcessStep("spawn");
 let scriptedTurnIndex = 0;
 
 function readArchivedThreadIds() {
@@ -354,8 +353,8 @@ async function handleRequest(message) {
       respond(id, {});
       return;
     case "thread/start": {
-      if (startDelayMs > 0) {
-        await new Promise((resolve) => setTimeout(resolve, startDelayMs));
+      if (stallThreadStart) {
+        await new Promise(() => undefined);
       }
       threadCounter += 1;
       const threadId = `codex-fx-${process.pid}-${threadCounter}`;


### PR DESCRIPTION
## Human comments

## What was wrong

The recurring [packages job failure](https://github.com/get-bb/bb/actions/runs/34275422905/job/102227127822) was triggered by package-shard CPU contention but rooted in a lifecycle mismatch in the test. The runtime started its 200 ms `thread/start` request deadline after provider initialization but before the bridge necessarily handled the request and spawned the app-server child. The test then required `spawned === 1 && exited === 1`; when cancellation retired the bridge before its request handler ran, no child could ever publish either marker. An instrumented 24-run stress reproduced 22 exact failures, all with `spawned=0`, `exited=0`, no child PID, and an expected bridge exit. The predicate-before-deadline polling fix from #2352 remains present; this was an impossible lifecycle state rather than a missed final poll.

The audit of closed PR #2506 also confirmed that its adjacent child-stdin finding remains real on current `main`: a live app-server child that closes fd 0 produced an unhandled `EPIPE` and left its request pending. Current `main` has since made `kill()` awaitable in #3025, so the old patch could not be reused unchanged.

The package shard's nested concurrency is systemic: CI runs four Turbo package tasks on a 4-vCPU runner, and each package's Vitest process independently schedules worker pools. That explains the reproduction condition, but it is not the root cause addressed here.

The independently verified merge base is `06047280e04e6ce57554052ec788a1c5defe7d1e`.

## What changed

- Pre-start the shared Codex bridge outside the construction deadline scenario, stall the fake `thread/start`, hold only the runtime's request clock until the real child publishes its spawn marker, then advance the unchanged 200 ms deadline. The test still requires the child to record its SIGTERM exit and verifies its PID is gone.
- Publish the fake child's spawn marker only after its SIGTERM handler is installed, and replace the elapsed 800 ms response delay with a construction that remains pending until release.
- Treat child-stdin `EPIPE` and `ERR_STREAM_DESTROYED` as terminal connection failures. New work is rejected immediately, the unusable child is force-stopped, and pending work still finalizes on the observable child exit/close boundary so natural exit status, stderr, and final stdout are preserved. The current awaitable `kill()` contract remains intact.
- Add real-child regressions for post-exit stdout draining, EPIPE immediately before a natural exit, and containment of a live child with closed stdin.

No request, polling, release, or test timeout was increased. There is no server/daemon wire change, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged. There are no CLI, SDK, guide, or configuration-surface changes.

## How you verified

- Original red-capable exact stress on the enrolled 8-logical-CPU Intel host, 64 runs at 32-way parallelism:
  - Before: 5/64 passed; 59/64 failed with the exact `Timed out after 10000ms waiting for the late-constructed child was released` signature.
  - Instrumented classification: 22/24 exact failures; every failure recorded `spawned=0`, `exited=0`, no child PID, and `bridgeExits=[{expected:true}]`.
  - Final: 64/64 passed with no timeout, EPIPE, or survivor; test-body p50/p95/max were 21.48 s / 24.16 s / 24.51 s under deliberate 4x oversubscription.
- Closed-stdin regression before the connection change: failed deterministically because the request remained pending past 500 ms and Vitest captured an unhandled `write EPIPE`. After: the three-test connection file passed, then passed 32/32 parallel stress runs with no unhandled error or survivor.
- `pnpm exec turbo run test --filter=@bb/agent-runtime -- --run src/runtime.codex-topology.test.ts` — 1 file / 4 tests passed.
- `pnpm exec turbo run test --filter=bb-plugin-provider-codex -- --run src/bridge/app-server-connection.test.ts` — 1 file / 3 tests passed.
- `pnpm exec turbo run test --filter=@bb/agent-runtime --force` — 22 files / 318 tests passed.
- `pnpm exec turbo run test --filter=bb-plugin-provider-codex --force` — 27 files / 264 tests passed.
- A combined two-package test run made nested contention visible: the Codex provider passed, while agent-runtime hit three unrelated existing failures in ACP topology and process-lifecycle tests. Both package suites passed independently, and the changed focused tests remained green.
- `pnpm exec turbo run typecheck --filter=@bb/agent-runtime --filter=bb-plugin-provider-codex --force` — passed.
- `pnpm exec turbo run build --filter=@bb/agent-runtime --filter=bb-plugin-provider-codex --force` — passed (the scoped packages have no direct build tasks; their applicable dependency graph passed).
- `pnpm exec prettier --check packages/agent-runtime/src/runtime.codex-topology.test.ts plugins/provider-codex/src/bridge/app-server-connection.ts plugins/provider-codex/src/bridge/app-server-connection.test.ts plugins/provider-codex/src/bridge/fake-codex-app-server.mjs` — passed.
- Every reproduction, stress, test, typecheck, and build command ran inside a bounded process group on `host_nwqfteeqz4`; cleanup checks reported no surviving group or matching test/fake-child process.

Fixes: no issue — exact path/signature searches found no open issue or PR, and the prior BB owners are archived without environments.

> AGENT GENERATED