### PR TITLE
Keep older timeline details expandable after late completions

### DIFF
--- a/apps/server/src/services/threads/timeline.ts
+++ b/apps/server/src/services/threads/timeline.ts
@@ -41,6 +41,7 @@ import {
   listRecentStoredEventRows,
   listStoredConversationOutlineEventRows,
   listStoredClientTurnRequestIdsInRange,
+  listStoredEventRows,
   listStoredEventRowsByParentToolCallIds,
   isTimelineCursorSequencePresent,
   listItemEventSpansByItems,
@@ -1458,6 +1459,17 @@ function selectStandardTimelineEventRows(
           threadId: thread.id,
           rows: selectedRowsWithParentedTurnStarts,
         });
+  const nextPageBoundaryRows =
+    page.kind === "older" &&
+    !window.requiresWholeItemClosure &&
+    beforeSequence !== undefined
+      ? listStoredEventRows(db, {
+          afterSequence: beforeSequence - 1,
+          beforeSequence: beforeSequence + 1,
+          threadId: thread.id,
+          types: ["client/turn/requested"],
+        })
+      : [];
 
   return {
     byteWindowSequenceEnd:
@@ -1481,9 +1493,12 @@ function selectStandardTimelineEventRows(
           },
     responsePageKind: page.kind,
     oversizedEventPlaceholder: window.oversizedEventPlaceholder,
-    rows: selectedRowsWithParentedTurnLifecycle.filter(
-      (row) => row.sequence >= epochSequenceStart,
-    ),
+    rows: mergeStoredEventRowsById([
+      ...selectedRowsWithParentedTurnLifecycle.filter(
+        (row) => row.sequence >= epochSequenceStart,
+      ),
+      ...nextPageBoundaryRows,
+    ]),
     strategy:
       sequenceStart === 0 && beforeSequence === undefined
         ? "full"
@@ -1729,8 +1744,18 @@ function buildThreadTimelineInternal(
         },
       }),
   );
+  const projectionBoundarySequence =
+    options.page.kind === "older" &&
+    readSequenceCursor(options.page.beforeCursor, thread.id) === null
+      ? options.page.beforeCursor.anchorSeq
+      : null;
   const projectedTimelineRows = applyRetainedOutputPreviews(
-    buildSequencePageTimelineRows(timeline.rows, eventSelection),
+    buildSequencePageTimelineRows(
+      timeline.rows.filter(
+        (row) => row.sourceSeqStart !== projectionBoundarySequence,
+      ),
+      eventSelection,
+    ),
     decodedRawEvents,
     "available",
   );

--- a/apps/server/test/services/threads/timeline-in-turn-window.test.ts
+++ b/apps/server/test/services/threads/timeline-in-turn-window.test.ts
@@ -1972,6 +1972,28 @@ describe("turn details for an item that finishes in a later turn", () => {
         sourceSeqEnd: firstSequence + 5,
       }),
     ]);
+    const older = buildPage(
+      db,
+      thread,
+      LARGE_BUDGET,
+      latest.timelinePage.olderCursor!,
+      1,
+    ).response;
+    const olderTurn = older.rows.find(
+      (row) => row.kind === "turn" && row.turnId === turnId,
+    );
+    expect(olderTurn).toBeDefined();
+    if (!olderTurn || olderTurn.kind !== "turn") {
+      throw new Error("Expected the older turn summary");
+    }
+    expect(
+      buildTimelineTurnSummaryDetails(db, thread, {
+        includeDiagnosticOperations: false,
+        sourceSeqEnd: olderTurn.sourceSeqEnd,
+        sourceSeqStart: olderTurn.sourceSeqStart,
+        turnId,
+      }).rows,
+    ).toEqual(after?.details);
     expect(collectTurnDetailsAndChildren(db, thread).get(turnId)).toEqual(
       after,
     );


### PR DESCRIPTION
## Human comments

## What was wrong

An older timeline page could correctly keep an item that completed late beside the prompt where it started, but omit the newer user prompt that separates the two responses while rebuilding the older row. The older summary and its details endpoint then calculated different source ranges (`1–9` versus `4–8`), so exact detail lookup failed with “Failed to load turn details.” This completes the behavior introduced by [PR #3110](https://github.com/get-bb/bb/pull/3110); the reproduced case is documented in the [fixer handoff](https://ymichael.getbb.app/projects/proj_qrv2s45kmq/threads/thr_qtzru86rhh).

## What changed

Standard older-page selection now includes the next prompt only as projection context when an item or turn lifecycle was backfilled past the cursor. The prompt establishes the same response boundary used by full-history and details projection, then is removed before the older page is returned. Existing late-item ownership, normal latest pages, byte and sequence pagination, interruption current work, and retained-output previews remain unchanged.

The regression expands the older summary returned by the real server timeline builder and proves it returns the same details as the complete timeline.

## How you verified

- The focused regression failed before the fix with `Timeline turn summary details could not match range 1-9` and passes after it.
- The exact database/server reproduction reproduced `1–9` versus `4–8` before the fix and `4–8` versus `4–8` with no error after it.
- `pnpm exec turbo run test --filter=@bb/server -- test/services/threads/timeline-in-turn-window.test.ts` — 30/30 passed after rebasing onto current local `origin/main`.
- `pnpm exec turbo run typecheck --filter=@bb/server` — passed.
- Earlier adjacent validation passed 91 server pagination/route tests and 26 DB query-plan tests; the boundary lookup uses the existing thread/type/sequence index.

Fixes: no linked issue.

> AGENT GENERATED
