### PR TITLE
Retry transient desktop startup probes

### DIFF
--- a/apps/desktop/src/server-probe.ts
+++ b/apps/desktop/src/server-probe.ts
@@ -49,6 +49,7 @@ interface ProbeBbServerArgs {
 }
 
 interface WaitForCompatibleServerArgs {
+  fetchImpl?: ServerProbeFetch;
   intervalMs: number;
   serverUrl: string;
   timeoutMs: number;
@@ -197,6 +198,14 @@ export async function probeBbServer(
     url: endpointUrl(args.serverUrl, "/api/v1/system/config"),
   });
 
+  if (configResult.kind === "network-error") {
+    return {
+      kind: "unavailable",
+      reason: `/api/v1/system/config returned ${formatFetchFailure(configResult)}`,
+      serverUrl: args.serverUrl,
+    };
+  }
+
   if (configResult.kind !== "success") {
     return {
       kind: "incompatible",
@@ -224,6 +233,7 @@ export async function waitForCompatibleServer(
 
   while (Date.now() <= deadline) {
     lastResult = await probeBbServer({
+      ...(args.fetchImpl === undefined ? {} : { fetchImpl: args.fetchImpl }),
       serverUrl: args.serverUrl,
       timeoutMs: Math.min(args.intervalMs, 1_000),
     });

--- a/apps/desktop/test/server-probe.test.ts
+++ b/apps/desktop/test/server-probe.test.ts
@@ -4,7 +4,11 @@ import {
   type ServerResponse,
 } from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { probeBbServer, type ServerProbeFetch } from "../src/server-probe.js";
+import {
+  probeBbServer,
+  type ServerProbeFetch,
+  waitForCompatibleServer,
+} from "../src/server-probe.js";
 
 interface TestServer {
   close(): Promise<void>;
@@ -221,5 +225,37 @@ describe("probeBbServer", () => {
     });
 
     expect(result.kind).toBe("unavailable");
+  });
+});
+
+describe("waitForCompatibleServer", () => {
+  it("retries when system config is transiently unavailable", async () => {
+    const fetchImpl = vi
+      .fn<ServerProbeFetch>()
+      .mockResolvedValueOnce(Response.json({ ok: true }))
+      .mockRejectedValueOnce(
+        new DOMException("This operation was aborted", "AbortError"),
+      )
+      .mockResolvedValueOnce(Response.json({ ok: true }))
+      .mockResolvedValueOnce(
+        Response.json({
+          hostDaemonPort: 4_242,
+          voiceTranscriptionEnabled: false,
+        }),
+      );
+
+    await expect(
+      waitForCompatibleServer({
+        fetchImpl,
+        intervalMs: 1,
+        serverUrl: "http://127.0.0.1:65535",
+        timeoutMs: 100,
+      }),
+    ).resolves.toEqual({
+      dataDir: null,
+      kind: "compatible",
+      serverUrl: "http://127.0.0.1:65535",
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(4);
   });
 });


### PR DESCRIPTION
## Human comments

## What was wrong

The desktop startup probe treated a successful `/health` response followed by a network failure from `/api/v1/system/config` as proof that the listening process was an incompatible non-bb server. The startup loop gives each probe the 250 ms polling interval as its request deadline, so scheduler contention could let bb-app reach health and begin its host daemon while the config request was aborted. `waitForCompatibleServer` returned that result immediately, and the desktop then stopped its own healthy-starting runtime. The AppImage smoke correctly observed the resulting supervisor exit.

This is the sequence exposed in the [first current-main failure](https://github.com/get-bb/bb/actions/runs/34274904721/job/102225396374) and made explicit by startup logging in [run 34279226033](https://github.com/get-bb/bb/actions/runs/34279226033) and [run 34280422213](https://github.com/get-bb/bb/actions/runs/34280422213): port 65535 was listening, bb-app was starting the host daemon, and the config probe reported `This operation was aborted`. Port 65535 is the smoke's intentionally reserved non-ephemeral port, not a collision.

This is distinct from the earlier AppImage fixes: the maintained runtime and AppRun bridge both launch successfully, the allocated port belongs to the new server, and `/health` has already established server readiness. The failure is the desktop's transient second-stage probe classification.

## What changed

- Classify network failures from the system-config probe as temporarily unavailable, consistent with network failures from the health probe.
- Let the existing startup loop retry that state while preserving immediate rejection for HTTP and schema evidence of an incompatible service.
- Add fetch injection to the wait helper and a deterministic regression matching the observed health-success/config-abort/next-probe-success sequence.

No timeout, polling interval, retry ceiling, smoke assertion, CLI surface, wire contract, or host-daemon protocol changed.

## How you verified

- Regression test red on the original classifier: it returned `incompatible` after the abort with `/api/v1/system/config returned This operation was aborted`; green after the change with four fetches and a compatible result.
- `pnpm exec turbo run test --filter=@bb/desktop --output-logs=new-only -- --run test/server-probe.test.ts` — 7/7 passed.
- `pnpm exec turbo run build typecheck test --filter=@bb/desktop --concurrency=2 --output-logs=new-only` in an Intel x86_64 Ubuntu 24.04 VM — 16/16 Turbo tasks, 39/39 test files, and 295/295 tests passed.
- `pnpm exec turbo run desktop:build:linux --filter=@bb/desktop --concurrency=2 --output-logs=new-only` — 14/14 Turbo tasks passed and rebuilt the x64 AppImage.
- Five consecutive rebuilt-AppImage lifecycle smokes passed in 58.3 s, 35.5 s, 31.8 s, 31.7 s, and 30.4 s.
- Bounded overload retained hang detection: with 8 CPU workers on 4 vCPUs, two lifecycle runs passed before a third reached the unchanged 60-second startup detector with the runtime still alive, rather than reproducing the owned-runtime exit. No clock was increased.
- Final cleanup found no AppImage/FUSE mounts, AppImage processes, load workers, or smoke temp roots.
- [PR CI run 34284078332](https://github.com/get-bb/bb/actions/runs/34284078332) passed every required check; the exact Linux Package Smoke lifecycle step passed in 19 seconds.

> AGENT GENERATED: by GPT-5.6-Sol
