### PR TITLE
Make Machines row chevrons open machine details

### DIFF
--- a/apps/app/src/components/settings/MachinesSettingsSection.test.tsx
+++ b/apps/app/src/components/settings/MachinesSettingsSection.test.tsx
@@ -12,7 +12,7 @@ import { makeHost } from "@bb/test-helpers/domain-fixtures";
 import { RETRY_ACTION_ICON } from "@bb/domain/update-state";
 import { HOST_DAEMON_PROTOCOL_VERSION } from "@bb/host-daemon-contract";
 import type { SystemConfigResponse } from "@bb/server-contract";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, useLocation } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { sdk } from "@/lib/sdk";
 import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
@@ -99,11 +99,17 @@ function stubSidebarBootstrapFetch(): void {
   );
 }
 
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-testid="location">{location.pathname}</div>;
+}
+
 function renderSection() {
   const { wrapper } = createQueryClientTestHarness();
   return render(
     <MemoryRouter>
       <MachinesSettingsSection />
+      <LocationProbe />
     </MemoryRouter>,
     { wrapper },
   );
@@ -366,6 +372,46 @@ describe("MachinesSettingsSection", () => {
           )
         : false,
     ).toBe(true);
+  });
+
+  it("navigates to the machine detail route when the row caret is clicked", async () => {
+    vi.mocked(sdk.system.config).mockResolvedValue(systemConfig());
+    vi.mocked(sdk.hosts.list).mockResolvedValue([primaryHost, offlineHost]);
+    stubSidebarBootstrapFetch();
+
+    renderSection();
+
+    const machineLink = await screen.findByRole("link", {
+      name: "Open dev-vm",
+    });
+    const row = machineLink.closest("[data-machine-row]");
+    const caret = row?.querySelector('[data-icon="ChevronRight"]');
+    expect(caret).not.toBeNull();
+    if (caret === null || caret === undefined) return;
+
+    fireEvent.click(caret);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("location").textContent).toBe(
+        "/settings/machines/host_remote",
+      );
+    });
+  });
+
+  it("keeps the row menu open without navigating when its trigger is clicked", async () => {
+    vi.mocked(sdk.system.config).mockResolvedValue(systemConfig());
+    vi.mocked(sdk.hosts.list).mockResolvedValue([primaryHost, offlineHost]);
+    stubSidebarBootstrapFetch();
+
+    renderSection();
+
+    await screen.findByText("dev-vm");
+    await openHostMenu("dev-vm");
+
+    expect(
+      await screen.findByRole("menuitem", { name: "Rename" }),
+    ).toBeDefined();
+    expect(screen.getByTestId("location").textContent).toBe("/");
   });
 
   it("renames a machine through the row menu", async () => {

--- a/apps/app/src/components/settings/MachinesSettingsSection.tsx
+++ b/apps/app/src/components/settings/MachinesSettingsSection.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import type { Host, PermissionMode } from "@bb/domain";
 import { RETRY_ACTION_ICON } from "@bb/domain/update-state";
 import type { HostPlatform } from "@bb/host-daemon-contract";
@@ -18,7 +18,10 @@ import {
 } from "@bb/shared-ui/dropdown-menu";
 import { Icon } from "@bb/shared-ui/icon";
 import { cn } from "@bb/shared-ui/lib/utils";
-import { ResourceRowDetailChevron } from "@bb/shared-ui/resource-list";
+import {
+  ResourceRowDetailChevron,
+  targetsResourceAction,
+} from "@bb/shared-ui/resource-list";
 import {
   Tooltip,
   TooltipContent,
@@ -102,6 +105,8 @@ function MachineRow({
   onRetryUpdate,
   retryUpdatePending,
 }: MachineRowProps) {
+  const navigate = useNavigate();
+  const detailPath = getSettingsMachineRoutePath(host.id);
   const permission = PERMISSION_MODE_PRESENTATION[host.maxPermissionMode];
   const projectLabel = `${projectCount} ${projectCount === 1 ? "project" : "projects"}`;
   const connectionLabel =
@@ -136,10 +141,14 @@ function MachineRow({
     <SettingsRow>
       <div
         data-machine-row
-        className="group group/machine -mx-2 flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-2 transition-colors hover:bg-state-hover focus-within:bg-state-hover"
+        className="group group/machine -mx-2 flex min-w-0 flex-1 cursor-pointer items-center gap-2 rounded-md px-2 py-2 transition-colors hover:bg-state-hover focus-within:bg-state-hover"
+        onClick={(event) => {
+          if (targetsResourceAction(event.target)) return;
+          navigate(detailPath);
+        }}
       >
         <Link
-          to={getSettingsMachineRoutePath(host.id)}
+          to={detailPath}
           aria-label={`Open ${host.name}`}
           className="flex min-w-0 flex-1 items-center rounded-md outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >

--- a/packages/shared-ui/src/components/ui/resource-list.tsx
+++ b/packages/shared-ui/src/components/ui/resource-list.tsx
@@ -34,6 +34,7 @@ export {
   type ResourceOverflowMenuItem,
   ResourceRow,
   ResourceRowDetailChevron,
+  targetsResourceAction,
 } from "./resource/row";
 export {
   ResourceDetailActionRow,

--- a/packages/shared-ui/src/components/ui/resource/row.tsx
+++ b/packages/shared-ui/src/components/ui/resource/row.tsx
@@ -18,7 +18,7 @@ import {
 } from "../tooltip";
 import { cn } from "../../../lib/utils";
 
-function targetsResourceAction(target: EventTarget): boolean {
+export function targetsResourceAction(target: EventTarget): boolean {
   return (
     target instanceof Element &&
     target.closest("a, button, [data-row-action]") !== null


### PR DESCRIPTION
## Human comments

## What was wrong

The Machines settings row displayed a detail chevron outside the row's only link, so clicking the chevron or the whitespace beside it did nothing. Unlike shared resource rows, the machine row had no row-level navigation handler and therefore did not guard nested actions while making the remaining row surface clickable.

## What changed

- Navigates to the machine detail route when the non-action area of a machine row is clicked.
- Reuses and exports the shared resource-row action-target guard so links, buttons, and row actions retain their own behavior.
- Adds focused regression coverage for chevron navigation and for the overflow menu remaining on the list page.
- No wire, CLI, guide, or public plugin API changes.

## How you verified

- `pnpm exec turbo run test --filter=@bb/app --force -- MachinesSettingsSection` (14 tests passed)
- `pnpm exec turbo run typecheck lint --filter=@bb/app --filter=@bb/shared-ui --force` (passed; lint reported 0 errors)
- `pnpm exec oxfmt --check apps/app/src/components/settings/MachinesSettingsSection.tsx apps/app/src/components/settings/MachinesSettingsSection.test.tsx packages/shared-ui/src/components/ui/resource/row.tsx packages/shared-ui/src/components/ui/resource-list.tsx`
- `git diff --check origin/main...HEAD`
- Manually verified chevron, row whitespace, name-link, overflow-menu, and keyboard behavior at desktop and 390px mobile widths.

> AGENT GENERATED
