### PR TITLE
Revalidate local Markdown images through the host daemon

### DIFF
--- a/apps/host-daemon/src/command-handlers/file-read.ts
+++ b/apps/host-daemon/src/command-handlers/file-read.ts
@@ -2,7 +2,10 @@ import { isUtf8 } from "node:buffer";
 import fs from "node:fs/promises";
 import path from "node:path";
 import mimeTypes from "mime-types";
-import type { HostReadFileRelativeDotfilePolicy } from "@bb/host-daemon-contract";
+import type {
+  HostReadFileIfNoneMatch,
+  HostReadFileRelativeDotfilePolicy,
+} from "@bb/host-daemon-contract";
 import {
   readGitBlob,
   WorkspaceError,
@@ -21,8 +24,7 @@ export const NON_IMAGE_FILE_SIZE_LIMIT_BYTES = 25 * 1024 * 1024;
 
 type FileContentEncoding = "base64" | "utf8";
 
-interface ReadFileForTransportResult {
-  content: string;
+interface ReadFileForTransportMetadata {
   contentEncoding: FileContentEncoding;
   mimeType?: string;
   modifiedAtMs?: number;
@@ -31,6 +33,18 @@ interface ReadFileForTransportResult {
   sizeBytes: number;
 }
 
+export interface ReadFileContentForTransportResult extends ReadFileForTransportMetadata {
+  content: string;
+}
+
+interface ReadFileNotModifiedForTransportResult extends ReadFileForTransportMetadata {
+  notModified: true;
+}
+
+export type ReadFileForTransportResult =
+  | ReadFileContentForTransportResult
+  | ReadFileNotModifiedForTransportResult;
+
 interface ReadFileMetadataForTransportResult {
   modifiedAtMs: number;
   path: string;
@@ -38,6 +52,7 @@ interface ReadFileMetadataForTransportResult {
 }
 
 interface ReadFileForTransportArgs {
+  ifNoneMatch?: HostReadFileIfNoneMatch;
   resolvedPath: string;
   resultPath: string;
   rootPath?: string;
@@ -65,6 +80,7 @@ interface ValidatedRootRelativePath {
 }
 
 interface ReadFileFromGitRefArgs extends GitProcessOptions {
+  ifNoneMatch?: HostReadFileIfNoneMatch;
   rootPath: string;
   resolvedPath: string;
   resultPath: string;
@@ -106,6 +122,65 @@ function getContentEncoding(
     return "utf8";
   }
   return "base64";
+}
+
+interface ReadFileBytes {
+  contents: Buffer;
+  mimeType?: string;
+  modifiedAtMs?: number;
+  path: string;
+  sizeBytes: number;
+}
+
+function createReadFileForTransportMetadata(
+  args: ReadFileBytes,
+): ReadFileForTransportMetadata {
+  const contentEncoding = getContentEncoding(args.contents, args.mimeType);
+  return {
+    contentEncoding,
+    ...(args.mimeType ? { mimeType: args.mimeType } : {}),
+    ...(args.modifiedAtMs !== undefined
+      ? { modifiedAtMs: args.modifiedAtMs }
+      : {}),
+    path: args.path,
+    sha256: sha256Hex(args.contents),
+    sizeBytes: args.sizeBytes,
+  };
+}
+
+function addFileContent(
+  metadata: ReadFileForTransportMetadata,
+  contents: Buffer,
+): ReadFileContentForTransportResult {
+  return {
+    ...metadata,
+    content:
+      metadata.contentEncoding === "utf8"
+        ? contents.toString("utf8")
+        : contents.toString("base64"),
+  };
+}
+
+function createReadFileForTransportResult(
+  args: ReadFileBytes & { ifNoneMatch?: HostReadFileIfNoneMatch },
+): ReadFileForTransportResult {
+  const metadata = createReadFileForTransportMetadata(args);
+  if (
+    args.ifNoneMatch?.kind === "any" ||
+    args.ifNoneMatch?.values.includes(metadata.sha256)
+  ) {
+    return { ...metadata, notModified: true };
+  }
+  return addFileContent(metadata, args.contents);
+}
+
+function createUnconditionalReadFileForTransportResult(
+  args: ReadFileBytes,
+): ReadFileContentForTransportResult {
+  return addFileContent(
+    createReadFileForTransportMetadata(args),
+    args.contents,
+  );
 }
 
 export function createMissingTargetError(
@@ -253,28 +328,26 @@ export async function readFileFromGitRef(
   }
 
   if (blob.contents === null) {
-    return {
+    return createReadFileForTransportResult({
+      contents: Buffer.alloc(0),
+      ...(args.ifNoneMatch !== undefined
+        ? { ifNoneMatch: args.ifNoneMatch }
+        : {}),
+      mimeType,
       path: args.resultPath,
-      content: "",
-      contentEncoding: "utf8",
-      ...(mimeType ? { mimeType } : {}),
-      sha256: sha256Hex(Buffer.alloc(0)),
       sizeBytes: 0,
-    };
+    });
   }
 
-  const contentEncoding = getContentEncoding(blob.contents, mimeType);
-  return {
+  return createReadFileForTransportResult({
+    contents: blob.contents,
+    ...(args.ifNoneMatch !== undefined
+      ? { ifNoneMatch: args.ifNoneMatch }
+      : {}),
+    mimeType,
     path: args.resultPath,
-    content:
-      contentEncoding === "utf8"
-        ? blob.contents.toString("utf8")
-        : blob.contents.toString("base64"),
-    contentEncoding,
-    ...(mimeType ? { mimeType } : {}),
-    sha256: sha256Hex(blob.contents),
     sizeBytes: blob.sizeBytes,
-  };
+  });
 }
 
 export async function readFileForTransport(
@@ -303,24 +376,19 @@ export async function readFileForTransport(
   const fileContents = await fs
     .readFile(readablePath)
     .catch((error: unknown) => throwMissingTargetOrRethrow(args, error));
-  const contentEncoding = getContentEncoding(fileContents, mimeType);
-  return {
-    path: args.resultPath,
-    content:
-      contentEncoding === "utf8"
-        ? fileContents.toString("utf8")
-        : fileContents.toString("base64"),
-    contentEncoding,
-    ...(mimeType ? { mimeType } : {}),
+  return createReadFileForTransportResult({
+    contents: fileContents,
+    ifNoneMatch: args.ifNoneMatch,
+    mimeType,
     modifiedAtMs: stat.mtimeMs,
-    sha256: sha256Hex(fileContents),
+    path: args.resultPath,
     sizeBytes: stat.size,
-  };
+  });
 }
 
 export async function readRootRelativeFileForTransport(
   args: ReadRootRelativeFileForTransportArgs,
-): Promise<ReadFileForTransportResult> {
+): Promise<ReadFileContentForTransportResult> {
   if (!path.isAbsolute(args.rootPath)) {
     throw new CommandDispatchError("invalid_path", "rootPath must be absolute");
   }
@@ -350,19 +418,13 @@ export async function readRootRelativeFileForTransport(
   const fileContents = await fs
     .readFile(readablePath)
     .catch((error: unknown) => throwMissingTargetOrRethrow(readArgs, error));
-  const contentEncoding = getContentEncoding(fileContents, mimeType);
-  return {
-    path: relativePath.resultPath,
-    content:
-      contentEncoding === "utf8"
-        ? fileContents.toString("utf8")
-        : fileContents.toString("base64"),
-    contentEncoding,
-    ...(mimeType ? { mimeType } : {}),
+  return createUnconditionalReadFileForTransportResult({
+    contents: fileContents,
+    mimeType,
     modifiedAtMs: stat.mtimeMs,
-    sha256: sha256Hex(fileContents),
+    path: relativePath.resultPath,
     sizeBytes: stat.size,
-  };
+  });
 }
 
 export async function readFileMetadataForTransport(

--- a/apps/host-daemon/src/command-handlers/host-files.test.ts
+++ b/apps/host-daemon/src/command-handlers/host-files.test.ts
@@ -1,4 +1,5 @@
 import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -105,6 +106,39 @@ describe("readHostFile (no ref — disk read)", () => {
     expect(result.content).toBe("hello world");
     expect(result.contentEncoding).toBe("utf8");
     expect(result.sizeBytes).toBe(11);
+  });
+
+  it("omits unchanged file content from conditional reads", async () => {
+    const repoPath = await initRepo();
+    const filePath = path.join(repoPath, "large.png");
+    const contents = Buffer.alloc(1024, "a");
+    const sha256 = createHash("sha256").update(contents).digest("hex");
+    await fs.writeFile(filePath, contents);
+
+    const result = await readHostFile({
+      type: "host.read_file",
+      path: filePath,
+      rootPath: repoPath,
+      ifNoneMatch: { kind: "sha256", values: [sha256] },
+    });
+
+    expect(result).toMatchObject({
+      path: filePath,
+      sha256,
+      sizeBytes: contents.byteLength,
+      notModified: true,
+    });
+    expect("content" in result).toBe(false);
+
+    const changed = await readHostFile({
+      type: "host.read_file",
+      path: filePath,
+      rootPath: repoPath,
+      ifNoneMatch: { kind: "sha256", values: ["0".repeat(64)] },
+    });
+    expect("content" in changed ? changed.content : undefined).toBe(
+      contents.toString("base64"),
+    );
   });
 
   it("rejects relative paths", async () => {

--- a/apps/host-daemon/src/command-handlers/host-files.ts
+++ b/apps/host-daemon/src/command-handlers/host-files.ts
@@ -24,6 +24,7 @@ import {
   readFileFromGitRef,
   readFileMetadataForTransport,
   readRootRelativeFileForTransport,
+  type ReadFileContentForTransportResult,
 } from "./file-read.js";
 import { resolveNonSymlinkDirectoryPath } from "./root-path.js";
 
@@ -185,6 +186,14 @@ export async function checkHostPathsExist(
   return { existence: Object.fromEntries(entries) };
 }
 
+export function readHostFile(
+  command: CommandOf<"host.read_file"> & { ifNoneMatch?: undefined },
+  options?: Pick<CommandDispatchOptions, "runtimeManager">,
+): Promise<ReadFileContentForTransportResult>;
+export function readHostFile(
+  command: CommandOf<"host.read_file">,
+  options?: Pick<CommandDispatchOptions, "runtimeManager">,
+): Promise<HostDaemonOnlineRpcResult<"host.read_file">>;
 export async function readHostFile(
   command: CommandOf<"host.read_file">,
   options?: Pick<CommandDispatchOptions, "runtimeManager">,
@@ -200,6 +209,9 @@ export async function readHostFile(
     }
     assertSafeGitRef(command.ref);
     return readFileFromGitRef({
+      ...(command.ifNoneMatch !== undefined
+        ? { ifNoneMatch: command.ifNoneMatch }
+        : {}),
       rootPath: command.rootPath,
       resolvedPath: command.path,
       resultPath: command.path,
@@ -211,6 +223,9 @@ export async function readHostFile(
   }
 
   return readFileForTransport({
+    ...(command.ifNoneMatch !== undefined
+      ? { ifNoneMatch: command.ifNoneMatch }
+      : {}),
     resolvedPath: command.path,
     resultPath: command.path,
     ...(command.rootPath !== undefined ? { rootPath: command.rootPath } : {}),

--- a/apps/host-daemon/test/command/workspace-dispatch.test.ts
+++ b/apps/host-daemon/test/command/workspace-dispatch.test.ts
@@ -496,7 +496,9 @@ describe("workspace command dispatch", () => {
     );
 
     expect(result.path).toBe(filePath);
-    expect(result.content).toBe("durable thread notes");
+    expect("content" in result ? result.content : undefined).toBe(
+      "durable thread notes",
+    );
     expect(result.contentEncoding).toBe("utf8");
     expect(result.sizeBytes).toBe("durable thread notes".length);
   });
@@ -516,7 +518,9 @@ describe("workspace command dispatch", () => {
     );
 
     expect(result.path).toBe(filePath);
-    expect(result.content).toBe("explicit host notes");
+    expect("content" in result ? result.content : undefined).toBe(
+      "explicit host notes",
+    );
     expect(result.contentEncoding).toBe("utf8");
     expect(result.sizeBytes).toBe("explicit host notes".length);
   });
@@ -558,7 +562,9 @@ describe("workspace command dispatch", () => {
     );
 
     expect(result.path).toBe(imagePath);
-    expect(result.content).toBe(imageBytes.toString("base64"));
+    expect("content" in result ? result.content : undefined).toBe(
+      imageBytes.toString("base64"),
+    );
     expect(result.contentEncoding).toBe("base64");
     expect(result.mimeType).toBe("image/png");
     expect(result.sizeBytes).toBe(imageBytes.length);
@@ -894,7 +900,7 @@ describe("workspace command dispatch", () => {
 
     expect(result.mimeType).toBe("image/svg+xml");
     expect(result.contentEncoding).toBe("utf8");
-    expect(result.content).toBe(svg);
+    expect("content" in result ? result.content : undefined).toBe(svg);
   });
 
   it("falls back to base64 for declared text files whose bytes are not valid utf8", async () => {
@@ -915,6 +921,8 @@ describe("workspace command dispatch", () => {
 
     expect(result.mimeType).toBe("text/plain");
     expect(result.contentEncoding).toBe("base64");
-    expect(result.content).toBe(bytes.toString("base64"));
+    expect("content" in result ? result.content : undefined).toBe(
+      bytes.toString("base64"),
+    );
   });
 });

--- a/apps/server/src/routes/environments.ts
+++ b/apps/server/src/routes/environments.ts
@@ -36,6 +36,7 @@ import {
 } from "../services/lib/entity-lookup.js";
 import { runLiveCommandAndWait } from "../services/hosts/live-command-wait.js";
 import { callHostRetryableOnlineRpc } from "../services/hosts/online-rpc.js";
+import { requireDaemonFileContentResult } from "../services/hosts/daemon-file-response.js";
 import { generateCommitMessage } from "../services/ai/commit-message.js";
 import { archiveEnvironmentThreads } from "../services/threads/thread-archive.js";
 import {
@@ -546,12 +547,13 @@ export function registerEnvironmentRoutes(app: Hono, deps: AppDeps): void {
         ...(ref !== undefined ? { ref } : {}),
       },
     });
+    const contentResult = requireDaemonFileContentResult(result);
     return context.json({
-      path: result.path,
-      content: result.content,
-      contentEncoding: result.contentEncoding,
-      ...(result.mimeType ? { mimeType: result.mimeType } : {}),
-      sizeBytes: result.sizeBytes,
+      path: contentResult.path,
+      content: contentResult.content,
+      contentEncoding: contentResult.contentEncoding,
+      ...(contentResult.mimeType ? { mimeType: contentResult.mimeType } : {}),
+      sizeBytes: contentResult.sizeBytes,
     });
   });
 

--- a/apps/server/src/routes/files.ts
+++ b/apps/server/src/routes/files.ts
@@ -18,6 +18,7 @@ import {
 import {
   createDaemonFileContentResponse,
   type DaemonFileReadResult,
+  requireDaemonFileContentResult,
   remapDaemonFileRouteError,
   serveDaemonFileContent,
 } from "../services/hosts/daemon-file-response.js";
@@ -217,7 +218,7 @@ export function registerFileRoutes(app: Hono, deps: AppDeps): void {
             : {}),
         },
       });
-      return context.json(result);
+      return context.json(requireDaemonFileContentResult(result));
     } catch (error) {
       return remapDaemonFileRouteError(error);
     }
@@ -405,10 +406,14 @@ export function registerFileRoutes(app: Hono, deps: AppDeps): void {
     ) {
       throw new ApiError(400, "invalid_path", "Invalid preview path", false);
     }
+    const isHtmlPath = isHtmlMimeType(mimeTypes.lookup(rawPath) || null);
     return serveDaemonFileContent(
       deps,
       {
         hostId: lease.hostId,
+        ...(!isHtmlPath
+          ? { ifNoneMatch: context.req.header("if-none-match") }
+          : {}),
         path: joinHostPath(lease.rootPath, segments),
         rootPath: lease.rootPath,
       },

--- a/apps/server/src/routes/files.ts
+++ b/apps/server/src/routes/files.ts
@@ -413,16 +413,18 @@ export function registerFileRoutes(app: Hono, deps: AppDeps): void {
         rootPath: lease.rootPath,
       },
       (result) => {
-        const headers = new Headers({
-          "cache-control": "no-store",
-          "x-content-type-options": "nosniff",
-        });
-        if (isHtmlMimeType(result.mimeType)) {
+        const headers = new Headers({ "x-content-type-options": "nosniff" });
+        const isHtml = isHtmlMimeType(result.mimeType);
+        if (isHtml) {
           assertRawFilesystemHtmlPreviewResult(result);
+          headers.set("cache-control", "no-store");
           headers.set("content-security-policy", HTML_PREVIEW_CSP);
           headers.set("content-type", HTML_PREVIEW_CONTENT_TYPE);
         }
-        return createDaemonFileContentResponse(result, { headers });
+        return createDaemonFileContentResponse(result, {
+          headers,
+          ifNoneMatch: isHtml ? undefined : context.req.header("if-none-match"),
+        });
       },
     );
   });

--- a/apps/server/src/routes/projects.ts
+++ b/apps/server/src/routes/projects.ts
@@ -655,6 +655,7 @@ export function registerProjectRoutes(app: Hono, deps: AppDeps): void {
       deps,
       {
         hostId: target.hostId,
+        ifNoneMatch: context.req.header("if-none-match"),
         path: path.join(target.path, filePath.relativePath),
         rootPath: target.path,
       },

--- a/apps/server/src/routes/threads/data.ts
+++ b/apps/server/src/routes/threads/data.ts
@@ -228,23 +228,29 @@ function assertHtmlPreviewSize(relativePath: string, sizeBytes: number): void {
 function createRawFilePreviewResponse(
   result: DaemonFileReadResult,
   relativePath: string,
+  ifNoneMatch: string | undefined,
 ): Response {
   assertHtmlPreviewSize(relativePath, result.sizeBytes);
   const headers = new Headers({
-    "cache-control": RAW_FILE_NO_STORE_CACHE_CONTROL,
     "x-content-type-options": RAW_FILE_CONTENT_TYPE_OPTIONS,
   });
-  if (isHtmlPreviewPath(relativePath)) {
+  const isHtml = isHtmlPreviewPath(relativePath);
+  if (isHtml) {
+    headers.set("cache-control", RAW_FILE_NO_STORE_CACHE_CONTROL);
     headers.set("content-security-policy", GENERIC_HTML_PREVIEW_CSP);
     headers.set("content-type", RAW_FILE_HTML_CONTENT_TYPE);
   }
-  return createDaemonFileContentResponse(result, { headers });
+  return createDaemonFileContentResponse(result, {
+    headers,
+    ifNoneMatch: isHtml ? undefined : ifNoneMatch,
+  });
 }
 
 async function serveThreadStorageRawFile(
   deps: LoggedWorkSessionDeps,
   threadId: string,
   rawPath: string,
+  ifNoneMatch: string | undefined,
 ): Promise<Response> {
   const filePath = parseSafeRelativeRoutePath(rawPath);
   const target = await requireThreadStorageTarget(deps, { threadId });
@@ -256,7 +262,8 @@ async function serveThreadStorageRawFile(
       path: path.join(target.storagePath, filePath.relativePath),
       rootPath: target.storagePath,
     },
-    (result) => createRawFilePreviewResponse(result, filePath.relativePath),
+    (result) =>
+      createRawFilePreviewResponse(result, filePath.relativePath, ifNoneMatch),
   );
 }
 
@@ -264,6 +271,7 @@ async function serveThreadWorktreeRawFile(
   deps: LoggedWorkSessionDeps,
   threadId: string,
   rawPath: string,
+  ifNoneMatch: string | undefined,
 ): Promise<Response> {
   const filePath = parseSafeRelativeRoutePath(rawPath);
   const thread = requirePublicThread(deps.db, threadId);
@@ -279,7 +287,8 @@ async function serveThreadWorktreeRawFile(
       path: path.join(environment.path, filePath.relativePath),
       rootPath: environment.path,
     },
-    (result) => createRawFilePreviewResponse(result, filePath.relativePath),
+    (result) =>
+      createRawFilePreviewResponse(result, filePath.relativePath, ifNoneMatch),
   );
 }
 
@@ -567,6 +576,7 @@ export function registerThreadDataRoutes(app: Hono, deps: AppDeps): void {
       deps,
       context.req.param("id"),
       context.req.param("filePath"),
+      context.req.header("if-none-match"),
     ),
   );
 
@@ -619,6 +629,7 @@ export function registerThreadDataRoutes(app: Hono, deps: AppDeps): void {
       deps,
       context.req.param("id"),
       context.req.param("filePath"),
+      context.req.header("if-none-match"),
     ),
   );
 

--- a/apps/server/src/routes/threads/data.ts
+++ b/apps/server/src/routes/threads/data.ts
@@ -259,6 +259,7 @@ async function serveThreadStorageRawFile(
     deps,
     {
       hostId: target.hostId,
+      ...(!isHtmlPreviewPath(filePath.relativePath) ? { ifNoneMatch } : {}),
       path: path.join(target.storagePath, filePath.relativePath),
       rootPath: target.storagePath,
     },
@@ -284,6 +285,7 @@ async function serveThreadWorktreeRawFile(
     deps,
     {
       hostId: environment.hostId,
+      ...(!isHtmlPreviewPath(filePath.relativePath) ? { ifNoneMatch } : {}),
       path: path.join(environment.path, filePath.relativePath),
       rootPath: environment.path,
     },
@@ -683,6 +685,7 @@ export function registerThreadDataRoutes(app: Hono, deps: AppDeps): void {
       deps,
       {
         hostId: target.hostId,
+        ifNoneMatch: context.req.header("if-none-match"),
         path: path.join(target.storagePath, query.path),
         rootPath: target.storagePath,
       },
@@ -706,6 +709,7 @@ export function registerThreadDataRoutes(app: Hono, deps: AppDeps): void {
       deps,
       {
         hostId: environment.hostId,
+        ifNoneMatch: context.req.header("if-none-match"),
         path: query.path,
       },
       (result) =>

--- a/apps/server/src/services/hosts/daemon-file-response.ts
+++ b/apps/server/src/services/hosts/daemon-file-response.ts
@@ -1,5 +1,8 @@
 import { Buffer } from "node:buffer";
-import type { HostDaemonOnlineRpcResultByType } from "@bb/host-daemon-contract";
+import type {
+  HostDaemonOnlineRpcResultByType,
+  HostReadFileIfNoneMatch,
+} from "@bb/host-daemon-contract";
 import { ApiError } from "../../errors.js";
 import { COMMAND_TIMEOUT_MS } from "../../constants.js";
 import type { LoggedWorkSessionDeps } from "../../types.js";
@@ -8,8 +11,12 @@ import { callHostRetryableOnlineRpc } from "./online-rpc.js";
 const OCTET_STREAM_MIME_TYPE = "application/octet-stream";
 const REVALIDATE_CACHE_CONTROL = "private, no-cache";
 
+type HostReadFileResult = HostDaemonOnlineRpcResultByType["host.read_file"];
+export type DaemonFileContentResult =
+  | Exclude<HostReadFileResult, { notModified: true }>
+  | HostDaemonOnlineRpcResultByType["host.read_file_relative"];
 export type DaemonFileReadResult =
-  | HostDaemonOnlineRpcResultByType["host.read_file"]
+  | HostReadFileResult
   | HostDaemonOnlineRpcResultByType["host.read_file_relative"];
 
 interface CreateDaemonFileContentResponseOptions {
@@ -19,20 +26,49 @@ interface CreateDaemonFileContentResponseOptions {
 
 export async function serveDaemonFileContent(
   deps: LoggedWorkSessionDeps,
-  target: { hostId: string; path: string; rootPath?: string },
+  target: {
+    hostId: string;
+    ifNoneMatch?: string | undefined;
+    path: string;
+    rootPath?: string;
+  },
   createResponse: (result: DaemonFileReadResult) => Response,
 ): Promise<Response> {
-  const { hostId, ...file } = target;
+  const { hostId, ifNoneMatch, ...file } = target;
+  const daemonIfNoneMatch = parseDaemonIfNoneMatch(ifNoneMatch);
   try {
     const result = await callHostRetryableOnlineRpc(deps, {
       hostId,
       timeoutMs: COMMAND_TIMEOUT_MS,
-      command: { type: "host.read_file", ...file },
+      command: {
+        type: "host.read_file",
+        ...file,
+        ...(daemonIfNoneMatch !== undefined
+          ? { ifNoneMatch: daemonIfNoneMatch }
+          : {}),
+      },
     });
     return createResponse(result);
   } catch (error) {
     return remapDaemonFileRouteError(error);
   }
+}
+
+function parseDaemonIfNoneMatch(
+  ifNoneMatch: string | undefined,
+): HostReadFileIfNoneMatch | undefined {
+  if (ifNoneMatch === undefined) {
+    return undefined;
+  }
+  if (ifNoneMatch.trim() === "*") {
+    return { kind: "any" };
+  }
+  const values = ifNoneMatch
+    .split(",")
+    .map((tag) => tag.trim().replace(/^W\//u, ""))
+    .map((tag) => /^"([a-f0-9]{64})"$/u.exec(tag)?.[1])
+    .filter((value): value is string => value !== undefined);
+  return values.length > 0 ? { kind: "sha256", values } : undefined;
 }
 
 function daemonFileEntityTag(result: DaemonFileReadResult): string {
@@ -56,6 +92,15 @@ export function requestMatchesEntityTag(
     .includes(entityTag);
 }
 
+export function requireDaemonFileContentResult(
+  result: HostReadFileResult,
+): Exclude<HostReadFileResult, { notModified: true }> {
+  if ("notModified" in result) {
+    throw new Error("Unconditional daemon file read returned not modified");
+  }
+  return result;
+}
+
 function buildFileContentHeaders(
   result: DaemonFileReadResult,
   options: CreateDaemonFileContentResponseOptions,
@@ -75,6 +120,9 @@ function buildFileContentHeaders(
 }
 
 function decodeDaemonFileContent(result: DaemonFileReadResult): ArrayBuffer {
+  if ("notModified" in result) {
+    throw new Error("Cannot decode a not-modified daemon file result");
+  }
   const bytes =
     result.contentEncoding === "utf8"
       ? Buffer.from(result.content, "utf8")
@@ -89,6 +137,7 @@ export function createDaemonFileContentResponse(
 ): Response {
   const headers = buildFileContentHeaders(result, options);
   if (
+    "notModified" in result ||
     requestMatchesEntityTag(options.ifNoneMatch, daemonFileEntityTag(result))
   ) {
     return new Response(null, { status: 304, headers });

--- a/apps/server/src/services/skills/workspace-skills.ts
+++ b/apps/server/src/services/skills/workspace-skills.ts
@@ -4,6 +4,7 @@ import { COMMAND_TIMEOUT_MS } from "../../constants.js";
 import { ApiError } from "../../errors.js";
 import type { LoggedWorkSessionDeps } from "../../types.js";
 import { callHostRetryableOnlineRpc } from "../hosts/online-rpc.js";
+import { requireDaemonFileContentResult } from "../hosts/daemon-file-response.js";
 import {
   resolveProjectSkillSourceFromContent,
   type ProjectInjectedSkillSource,
@@ -48,7 +49,8 @@ async function readProjectSkill(
     throw error;
   }
 
-  if (result.sizeBytes > MAX_PROJECT_SKILL_FILE_BYTES) {
+  const contentResult = requireDaemonFileContentResult(result);
+  if (contentResult.sizeBytes > MAX_PROJECT_SKILL_FILE_BYTES) {
     deps.logger.warn(
       {
         candidatePath,
@@ -60,9 +62,9 @@ async function readProjectSkill(
     return null;
   }
   const content =
-    result.contentEncoding === "utf8"
-      ? result.content
-      : Buffer.from(result.content, "base64").toString("utf8");
+    contentResult.contentEncoding === "utf8"
+      ? contentResult.content
+      : Buffer.from(contentResult.content, "base64").toString("utf8");
   return resolveProjectSkillSourceFromContent(deps.logger, {
     candidatePath,
     content,

--- a/apps/server/src/services/threads/workspace-agent-instructions.ts
+++ b/apps/server/src/services/threads/workspace-agent-instructions.ts
@@ -5,6 +5,7 @@ import { COMMAND_TIMEOUT_MS } from "../../constants.js";
 import { ApiError } from "../../errors.js";
 import type { LoggedWorkSessionDeps, ServerLogger } from "../../types.js";
 import { callHostRetryableOnlineRpc } from "../hosts/online-rpc.js";
+import { requireDaemonFileContentResult } from "../hosts/daemon-file-response.js";
 import { isFsErrorWithCode } from "../lib/fs-errors.js";
 
 export const DATA_DIR_AGENT_INSTRUCTIONS_RELATIVE_PATH = "AGENTS.md";
@@ -75,10 +76,11 @@ export async function readWorkspaceAgentInstructions(
     throw error;
   }
 
+  const contentResult = requireDaemonFileContentResult(result);
   const content =
-    result.contentEncoding === "utf8"
-      ? result.content
-      : Buffer.from(result.content, "base64").toString("utf8");
+    contentResult.contentEncoding === "utf8"
+      ? contentResult.content
+      : Buffer.from(contentResult.content, "base64").toString("utf8");
   const trimmed = content.trim();
   return trimmed.length > 0 ? trimmed : null;
 }

--- a/apps/server/test/files/host-file-routes.test.ts
+++ b/apps/server/test/files/host-file-routes.test.ts
@@ -83,7 +83,7 @@ describe("host file routes", () => {
     });
   });
 
-  it("creates opaque path-shaped preview leases and serves sandboxed HTML", async () => {
+  it("revalidates preview files while keeping sandboxed HTML uncached", async () => {
     await withTestHarness(async (harness) => {
       const { host, session } = seedHostSession(harness.deps);
       seedPrimaryHost(harness.deps, host.id);
@@ -93,6 +93,22 @@ describe("host file routes", () => {
         sessionId: session.id,
         handle: (request) => {
           commands.push(request.command);
+          if (
+            request.command.type === "host.read_file" &&
+            request.command.path.endsWith(".png")
+          ) {
+            return {
+              ok: true,
+              result: {
+                path: "/notes/chart.png",
+                content: "iVBORw==",
+                contentEncoding: "base64",
+                mimeType: "image/png",
+                sha256: "d".repeat(64),
+                sizeBytes: 4,
+              },
+            };
+          }
           return {
             ok: true,
             result: {
@@ -124,14 +140,26 @@ describe("host file routes", () => {
         throw new Error("Preview response missing baseUrl");
       }
 
-      const content = await harness.app.request(`${lease.baseUrl}/report.html`);
+      const image = await harness.app.request(`${lease.baseUrl}/chart.png`, {
+        headers: { "if-none-match": `"${"d".repeat(64)}"` },
+      });
+      expect(image.status).toBe(304);
+      expect(image.headers.get("cache-control")).toBe("private, no-cache");
+
+      const content = await harness.app.request(
+        `${lease.baseUrl}/report.html`,
+        {
+          headers: { "if-none-match": `"${"c".repeat(64)}"` },
+        },
+      );
       expect(content.status).toBe(200);
+      expect(content.headers.get("cache-control")).toBe("no-store");
       expect(content.headers.get("content-security-policy")).toBe(
         "sandbox allow-scripts",
       );
       expect(content.headers.get("x-content-type-options")).toBe("nosniff");
       await expect(content.text()).resolves.toContain("<h1>Report</h1>");
-      expect(commands).toEqual([
+      expect(commands.slice(-1)).toEqual([
         {
           type: "host.read_file",
           path: "/notes/report.html",

--- a/apps/server/test/files/host-file-routes.test.ts
+++ b/apps/server/test/files/host-file-routes.test.ts
@@ -101,11 +101,11 @@ describe("host file routes", () => {
               ok: true,
               result: {
                 path: "/notes/chart.png",
-                content: "iVBORw==",
                 contentEncoding: "base64",
                 mimeType: "image/png",
                 sha256: "d".repeat(64),
                 sizeBytes: 4,
+                notModified: true,
               },
             };
           }
@@ -159,7 +159,16 @@ describe("host file routes", () => {
       );
       expect(content.headers.get("x-content-type-options")).toBe("nosniff");
       await expect(content.text()).resolves.toContain("<h1>Report</h1>");
-      expect(commands.slice(-1)).toEqual([
+      expect(commands).toEqual([
+        {
+          type: "host.read_file",
+          path: "/notes/chart.png",
+          rootPath: "/notes",
+          ifNoneMatch: {
+            kind: "sha256",
+            values: ["d".repeat(64)],
+          },
+        },
         {
           type: "host.read_file",
           path: "/notes/report.html",

--- a/apps/server/test/hosts/daemon-file-response.test.ts
+++ b/apps/server/test/hosts/daemon-file-response.test.ts
@@ -57,6 +57,20 @@ describe("createDaemonFileContentResponse", () => {
     expect(changed.status).toBe(200);
   });
 
+  it("answers 304 when the daemon omitted unchanged content", async () => {
+    const response = createDaemonFileContentResponse({
+      path: IMAGE_RESULT.path,
+      contentEncoding: IMAGE_RESULT.contentEncoding,
+      mimeType: IMAGE_RESULT.mimeType,
+      sizeBytes: IMAGE_RESULT.sizeBytes,
+      sha256: IMAGE_RESULT.sha256,
+      notModified: true,
+    });
+    expect(response.status).toBe(304);
+    expect(response.headers.get("etag")).toBe('"abc123"');
+    expect((await response.arrayBuffer()).byteLength).toBe(0);
+  });
+
   it("omits Last-Modified when the daemon has no mtime", () => {
     const response = createDaemonFileContentResponse({
       path: IMAGE_RESULT.path,

--- a/apps/server/test/public/public-thread-data.test.ts
+++ b/apps/server/test/public/public-thread-data.test.ts
@@ -4442,17 +4442,26 @@ describe("public thread data routes", () => {
       registerHostRpcResponder(harness, {
         hostId: host.id,
         sessionId: session.id,
-        handle: () => ({
-          ok: true,
-          result: {
-            path: `${environment.path}/public/chart.png`,
-            content: "iVBORw==",
-            contentEncoding: "base64",
-            mimeType: "image/png",
-            sizeBytes: 4,
-            sha256: "0".repeat(64),
-          },
-        }),
+        handle: (request) => {
+          expect(request.command).toMatchObject({
+            type: "host.read_file",
+            ifNoneMatch: {
+              kind: "sha256",
+              values: ["0".repeat(64)],
+            },
+          });
+          return {
+            ok: true,
+            result: {
+              path: `${environment.path}/public/chart.png`,
+              contentEncoding: "base64",
+              mimeType: "image/png",
+              sizeBytes: 4,
+              sha256: "0".repeat(64),
+              notModified: true,
+            },
+          };
+        },
       });
 
       const fileResponse = await harness.app.request(

--- a/apps/server/test/public/public-thread-data.test.ts
+++ b/apps/server/test/public/public-thread-data.test.ts
@@ -4436,6 +4436,36 @@ describe("public thread data routes", () => {
     });
   });
 
+  it("privately revalidates worktree images", async () => {
+    await withTestHarness(async (harness) => {
+      const { host, session, environment, thread } = seedThreadFixture(harness);
+      registerHostRpcResponder(harness, {
+        hostId: host.id,
+        sessionId: session.id,
+        handle: () => ({
+          ok: true,
+          result: {
+            path: `${environment.path}/public/chart.png`,
+            content: "iVBORw==",
+            contentEncoding: "base64",
+            mimeType: "image/png",
+            sizeBytes: 4,
+            sha256: "0".repeat(64),
+          },
+        }),
+      });
+
+      const fileResponse = await harness.app.request(
+        `/api/v1/threads/${thread.id}/worktree/files/public/chart.png`,
+        { headers: { "if-none-match": `"${"0".repeat(64)}"` } },
+      );
+      expect(fileResponse.status).toBe(304);
+      expect(fileResponse.headers.get("cache-control")).toBe(
+        "private, no-cache",
+      );
+    });
+  });
+
   it("serves worktree HTML preview content as raw text/html without app bridge injection", async () => {
     await withTestHarness(async (harness) => {
       const { host } = seedHostSession(harness.deps);

--- a/packages/host-daemon-contract/src/commands.ts
+++ b/packages/host-daemon-contract/src/commands.ts
@@ -409,12 +409,26 @@ const interactiveResolveCommandSchema = hostDaemonThreadTargetSchema
   })
   .strict();
 
+const hostReadFileIfNoneMatchSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("any") }).strict(),
+  z
+    .object({
+      kind: z.literal("sha256"),
+      values: z.array(z.string().regex(/^[a-f0-9]{64}$/u)).min(1),
+    })
+    .strict(),
+]);
+export type HostReadFileIfNoneMatch = z.infer<
+  typeof hostReadFileIfNoneMatchSchema
+>;
+
 const hostReadFileCommandSchema = z
   .object({
     type: z.literal("host.read_file"),
     path: z.string().min(1),
     rootPath: z.string().min(1).optional(),
     ref: z.string().min(1).optional(),
+    ifNoneMatch: hostReadFileIfNoneMatchSchema.optional(),
   })
   .superRefine((command, context) => {
     if (command.ref !== undefined && command.rootPath === undefined) {
@@ -959,6 +973,15 @@ const fileReadResultSchema = z.object({
   modifiedAtMs: z.number().nonnegative().optional(),
   sha256: z.string(),
 });
+
+const fileReadNotModifiedResultSchema = fileReadResultSchema
+  .omit({ content: true })
+  .extend({ notModified: z.literal(true) });
+
+const hostReadFileResultSchema = z.union([
+  fileReadResultSchema,
+  fileReadNotModifiedResultSchema,
+]);
 
 const fileWriteResultSchema = z.discriminatedUnion("outcome", [
   z
@@ -1717,7 +1740,7 @@ export const hostDaemonCommandRegistry = {
   "host.read_file": defineHostDaemonCommandDescriptor({
     type: "host.read_file",
     schema: hostReadFileCommandSchema,
-    resultSchema: fileReadResultSchema,
+    resultSchema: hostReadFileResultSchema,
     transport: "onlineRpc",
     retryable: true,
     flushEventsBeforeResult: false,

--- a/packages/host-daemon-contract/src/protocol.ts
+++ b/packages/host-daemon-contract/src/protocol.ts
@@ -1,3 +1,3 @@
-export const HOST_DAEMON_PROTOCOL_VERSION = 194 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 195 as const;
 
 export const HOST_ARTIFACT_MAX_BYTES = 256 * 1024 * 1024;

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -545,6 +545,18 @@ const WORKSPACE_DIFF_PATCH_AVAILABLE_RESULT: JsonObject = {
 const ADDITIONAL_ONLINE_RPC_RESPONSE_ROUND_TRIP_CASES: OnlineRpcResponseRoundTripCase[] =
   [
     {
+      name: "host.read_file not-modified result",
+      commandType: "host.read_file",
+      result: {
+        path: "/tmp/preview.png",
+        contentEncoding: "base64",
+        mimeType: "image/png",
+        sizeBytes: 1024,
+        sha256: "a".repeat(64),
+        notModified: true,
+      },
+    },
+    {
       name: "workspace.status available result",
       commandType: "workspace.status",
       result: WORKSPACE_STATUS_AVAILABLE_RESULT,
@@ -655,6 +667,8 @@ const INTENTIONAL_OPTIONAL_HOST_DAEMON_FIELDS: Record<string, string> = {
     "project.clone omits targetPath when the daemon should derive its default checkout location for the project.",
   "hostDaemonOnlineRpcCommandSchema.expectedSha256":
     "host.write_file may omit expectedSha256 for unconditional writes; a hash is the compare-and-swap guard and null means create-only.",
+  "hostDaemonOnlineRpcCommandSchema.ifNoneMatch":
+    "host.read_file omits ifNoneMatch for unconditional reads; when present the daemon may omit unchanged file content.",
   "hostDaemonOnlineRpcCommandSchema.mode":
     "host.write_file may omit mode to preserve existing permissions; when present it only controls newly created files.",
   "hostDaemonOnlineRpcCommandSchema.mergeBaseBranch":
@@ -965,7 +979,7 @@ const CONTRIBUTED_ENV = [
 
 describe("host-daemon command schemas", () => {
   it("uses the current host-daemon protocol version", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(194);
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(195);
     expect(HOST_ARTIFACT_MAX_BYTES).toBe(256 * 1024 * 1024);
   });
 
@@ -1397,11 +1411,19 @@ describe("host-daemon command schemas", () => {
         type: "host.read_file",
         path: "/tmp/bb-data/thread-storage/thread-123/notes.md",
         rootPath: "/tmp/bb-data/thread-storage/thread-123",
+        ifNoneMatch: {
+          kind: "sha256",
+          values: ["a".repeat(64)],
+        },
       }),
     ).toMatchObject({
       type: "host.read_file",
       path: "/tmp/bb-data/thread-storage/thread-123/notes.md",
       rootPath: "/tmp/bb-data/thread-storage/thread-123",
+      ifNoneMatch: {
+        kind: "sha256",
+        values: ["a".repeat(64)],
+      },
     });
 
     expect(
@@ -2783,6 +2805,21 @@ describe("host-daemon command schemas", () => {
       path: "/tmp/bb-data/thread-storage/thread-123/notes.md",
       content: "# Notes",
       contentEncoding: "utf8",
+    });
+
+    expect(
+      hostDaemonOnlineRpcResultSchemaByType["host.read_file"].parse({
+        path: "/tmp/bb-data/thread-storage/thread-123/notes.md",
+        contentEncoding: "utf8",
+        mimeType: "text/markdown",
+        sizeBytes: 13,
+        sha256: "d".repeat(64),
+        notModified: true,
+      }),
+    ).toMatchObject({
+      path: "/tmp/bb-data/thread-storage/thread-123/notes.md",
+      sha256: "d".repeat(64),
+      notModified: true,
     });
 
     expect(

--- a/packages/server-contract/src/api/files.ts
+++ b/packages/server-contract/src/api/files.ts
@@ -92,8 +92,10 @@ export interface CreateFilePreviewResponse {
   expiresAtMs: number;
 }
 
-export type HostFileReadResponse =
-  HostDaemonOnlineRpcResultByType["host.read_file"];
+export type HostFileReadResponse = Exclude<
+  HostDaemonOnlineRpcResultByType["host.read_file"],
+  { notModified: true }
+>;
 export type HostFileWriteResponse =
   HostDaemonOnlineRpcResultByType["host.write_file"];
 export type HostFileListResponse =

--- a/plugins/provider-pi/src/bridge/bridge.skill-command.test.ts
+++ b/plugins/provider-pi/src/bridge/bridge.skill-command.test.ts
@@ -8,6 +8,8 @@ import {
   startFakePiBridge,
 } from "./test-support.js";
 
+vi.setConfig({ testTimeout: 30_000 });
+
 let harness: FakePiBridgeHarness;
 let requestId: number;
 let threadId: number;


### PR DESCRIPTION
## Human comments

## What was wrong

Working-tree Markdown images used raw file routes that disabled browser caching. The first repair enabled HTTP ETag revalidation, but unchanged file bytes still traveled from the host daemon to the server before the server returned `304 Not Modified`.

## What changed

- Enable private ETag revalidation for non-HTML worktree, thread-storage, preview-lease, and project file routes.
- Pass validated SHA-256 entity tags through `host.read_file`.
- Let the host daemon return metadata with `notModified: true` and no `content` when the local hash matches.
- Return the complete file and its new hash when it changed.
- Keep executable HTML previews on their existing `no-store` path.
- Preserve full-content public file-read responses for unconditional callers.
- Bump `HOST_DAEMON_PROTOCOL_VERSION` from 194 to 195 for the changed server/daemon wire contract.
- Give the newly landed Pi skill-command bridge tests a file-local 30-second timeout because real child-process round trips exceeded Vitest's generic 5-second limit under full package CI load.

## How you verified

- `pnpm exec turbo run typecheck --filter=@bb/host-daemon-contract --filter=@bb/host-daemon --filter=@bb/server-contract --filter=@bb/server --force`
- `pnpm exec turbo run test --filter=@bb/host-daemon-contract --force -- test/contract.test.ts` — 38 passed
- `pnpm exec turbo run test --filter=@bb/host-daemon --force -- src/command-handlers/host-files.test.ts test/command/workspace-dispatch.test.ts` — 54 passed
- `pnpm exec turbo run test --filter=@bb/server --force -- test/hosts/daemon-file-response.test.ts test/files/host-file-routes.test.ts test/public/public-thread-data.test.ts test/public/public-project-workspace-routing.test.ts` — 99 passed
- `pnpm exec turbo run build --filter=@bb/host-daemon --filter=@bb/server --force`
- Real source browser/server/daemon check: first load returned `200`; unchanged reload returned `304` with zero response bytes; editing the image returned `200` with the complete new file and a new ETag; the next reload returned `304`.
- Formatting and `git diff --check` passed.
- `pnpm exec turbo run test --filter=bb-plugin-provider-pi --force -- src/bridge/bridge.skill-command.test.ts` — 11 passed

The verification inventory currently reports the unrelated existing gap `Unmapped CLI family: browser`.

> AGENT GENERATED
