### PR TITLE
Stabilize provider installation deadline test

### DIFF
--- a/apps/server/src/services/system/provider-installations.ts
+++ b/apps/server/src/services/system/provider-installations.ts
@@ -2,6 +2,7 @@ import type {
   ProviderCliStatus,
   ProviderCliStatusResponse,
 } from "@bb/host-daemon-contract";
+import type { ProviderInfo } from "@bb/domain";
 import { ZodError } from "zod";
 import type { AppDeps } from "../../types.js";
 import { COMMAND_TIMEOUT_MS } from "../../constants.js";
@@ -14,7 +15,22 @@ import { listSystemProviderInfos } from "./execution-options.js";
 import { resolveBridgeLaunchForProviderId } from "./provider-bridge-launch.js";
 import { mapProviderMaintenanceRequests } from "./provider-maintenance-concurrency.js";
 
-const PROVIDER_INSTALLATION_STATUS_TIMEOUT_MS = 70_000;
+export const PROVIDER_INSTALLATION_STATUS_TIMEOUT_MS = 70_000;
+
+type InstallationProvider = Pick<ProviderInfo, "displayName" | "id">;
+type ProviderInstallationStatus = Omit<ProviderCliStatus, "displayName">;
+type PreparedProviderInstallationRequest = (
+  timeoutMs: number,
+) => Promise<ProviderInstallationStatus | null>;
+
+interface ProviderInstallationAggregationOptions {
+  deadlineMs: number;
+  now: () => number;
+  onDeadlineExceeded: (provider: InstallationProvider) => void;
+  prepare: (
+    provider: InstallationProvider,
+  ) => PreparedProviderInstallationRequest | null;
+}
 
 function canOmitProviderInstallationStatusError(error: unknown): boolean {
   if (error instanceof ZodError) return true;
@@ -22,6 +38,33 @@ function canOmitProviderInstallationStatusError(error: unknown): boolean {
     error instanceof ApiError &&
     !isHostUnavailableApiError(error) &&
     (error.status === 502 || error.status === 504)
+  );
+}
+
+export async function aggregateProviderInstallations(
+  providers: readonly InstallationProvider[],
+  options: ProviderInstallationAggregationOptions,
+): Promise<ProviderCliStatusResponse> {
+  const entries = await mapProviderMaintenanceRequests(
+    providers,
+    async (provider): Promise<[string, ProviderCliStatus] | null> => {
+      const request = options.prepare(provider);
+      if (request === null) return null;
+      const remainingMs = options.deadlineMs - options.now();
+      if (remainingMs <= 0) {
+        options.onDeadlineExceeded(provider);
+        return null;
+      }
+      const status = await request(Math.min(COMMAND_TIMEOUT_MS, remainingMs));
+      return status === null
+        ? null
+        : [provider.id, { displayName: provider.displayName, ...status }];
+    },
+  );
+  return Object.fromEntries(
+    entries.filter(
+      (entry): entry is [string, ProviderCliStatus] => entry !== null,
+    ),
   );
 }
 
@@ -34,9 +77,20 @@ export async function getProviderInstallations(
     hostId: args.hostId,
     capability: "installation",
   });
-  const entries = await mapProviderMaintenanceRequests(
-    providers,
-    async (provider): Promise<[string, ProviderCliStatus] | null> => {
+  return aggregateProviderInstallations(providers, {
+    deadlineMs: deadline,
+    now: Date.now,
+    onDeadlineExceeded: (provider) => {
+      deps.logger.warn(
+        {
+          failure: "aggregate_deadline_exceeded",
+          hostId: args.hostId,
+          providerId: provider.id,
+        },
+        "Failed to load provider installation status; omitting provider",
+      );
+    },
+    prepare: (provider) => {
       const bridgeLaunch = resolveBridgeLaunchForProviderId(deps, provider.id);
       if (bridgeLaunch === null) {
         deps.logger.warn(
@@ -49,48 +103,32 @@ export async function getProviderInstallations(
         );
         return null;
       }
-      const remainingMs = deadline - Date.now();
-      if (remainingMs <= 0) {
-        deps.logger.warn(
-          {
-            failure: "aggregate_deadline_exceeded",
+      return async (timeoutMs) => {
+        try {
+          return await callHostRetryableOnlineRpc(deps, {
             hostId: args.hostId,
-            providerId: provider.id,
-          },
-          "Failed to load provider installation status; omitting provider",
-        );
-        return null;
-      }
-      try {
-        const status = await callHostRetryableOnlineRpc(deps, {
-          hostId: args.hostId,
-          timeoutMs: Math.min(COMMAND_TIMEOUT_MS, remainingMs),
-          command: {
-            type: "provider.installation.status",
-            providerId: provider.id,
-            bridgeLaunch,
-          },
-        });
-        return [provider.id, { displayName: provider.displayName, ...status }];
-      } catch (error) {
-        if (!canOmitProviderInstallationStatusError(error)) {
-          throw error;
+            timeoutMs,
+            command: {
+              type: "provider.installation.status",
+              providerId: provider.id,
+              bridgeLaunch,
+            },
+          });
+        } catch (error) {
+          if (!canOmitProviderInstallationStatusError(error)) {
+            throw error;
+          }
+          deps.logger.warn(
+            {
+              failure: "status_request_failed",
+              hostId: args.hostId,
+              providerId: provider.id,
+            },
+            "Failed to load provider installation status; omitting provider",
+          );
+          return null;
         }
-        deps.logger.warn(
-          {
-            failure: "status_request_failed",
-            hostId: args.hostId,
-            providerId: provider.id,
-          },
-          "Failed to load provider installation status; omitting provider",
-        );
-        return null;
-      }
+      };
     },
-  );
-  return Object.fromEntries(
-    entries.filter(
-      (entry): entry is [string, ProviderCliStatus] => entry !== null,
-    ),
-  );
+  });
 }

--- a/apps/server/test/public/public-provider-installations.test.ts
+++ b/apps/server/test/public/public-provider-installations.test.ts
@@ -8,7 +8,10 @@ import { validatePluginProviderDeclaration } from "@get-bb/plugin-sdk/internal/h
 import { describe, expect, it, vi } from "vitest";
 import { COMMAND_TIMEOUT_MS } from "../../src/constants.js";
 import { buildPluginProviderRegistration } from "../../src/services/providers/plugin-provider-registration.js";
-import { HostOnlineRpcTimeoutError } from "../../src/ws/hub.js";
+import {
+  aggregateProviderInstallations,
+  PROVIDER_INSTALLATION_STATUS_TIMEOUT_MS,
+} from "../../src/services/system/provider-installations.js";
 import { registerHostRpcResponder } from "../helpers/host-rpc.js";
 import { readJson } from "../helpers/json.js";
 import { seedHostSession } from "../helpers/seed.js";
@@ -261,69 +264,67 @@ describe("public provider installation routes", () => {
   });
 
   it("finishes stalled provider aggregation before the SDK request timeout", async () => {
-    await withTestHarness(async (harness) => {
-      registerInstallationProviders(
-        harness,
-        Array.from(
-          { length: 7 },
-          (_, index) => `stalled-installation-${index + 1}`,
-        ),
-      );
-      const { host, session } = seedHostSession(harness.deps, {
-        id: "provider-installation-deadline-host",
+    const statusRequestBatchSize = 3;
+    const expectedStatusRequestCount = 9;
+    const providers = Array.from({ length: 11 }, (_, index) => ({
+      id: `stalled-installation-${index + 1}`,
+      displayName: `Stalled installation ${index + 1}`,
+    }));
+    const statusTimeouts: number[] = [];
+    const deadlineExceededProviderIds: string[] = [];
+    const pendingStatusRequests: Array<{
+      resolve: (value: null) => void;
+      timeoutMs: number;
+    }> = [];
+    let now = 0;
+    let resolveStatusRequestBatch: (() => void) | null = null;
+    const waitForStatusRequestBatch = async (): Promise<void> => {
+      if (pendingStatusRequests.length === statusRequestBatchSize) return;
+      await new Promise<void>((resolve) => {
+        resolveStatusRequestBatch = resolve;
       });
-      registerHostRpcResponder(harness, {
-        hostId: host.id,
-        sessionId: session.id,
-        handle: handleProviderInstallationRpc,
-      });
-      const requestHostOnlineRpc = harness.hub.requestHostOnlineRpc.bind(
-        harness.hub,
-      );
-      const statusTimeouts: number[] = [];
-      vi.spyOn(harness.hub, "requestHostOnlineRpc").mockImplementation(
-        async (args) => {
-          if (args.message.command.type !== "provider.installation.status") {
-            return requestHostOnlineRpc(args);
+    };
+    const responsePromise = aggregateProviderInstallations(providers, {
+      deadlineMs: PROVIDER_INSTALLATION_STATUS_TIMEOUT_MS,
+      now: () => now,
+      onDeadlineExceeded: (provider) => {
+        deadlineExceededProviderIds.push(provider.id);
+      },
+      prepare: () => async (timeoutMs) => {
+        statusTimeouts.push(timeoutMs);
+        return new Promise<null>((resolve) => {
+          pendingStatusRequests.push({ resolve, timeoutMs });
+          if (pendingStatusRequests.length === statusRequestBatchSize) {
+            resolveStatusRequestBatch?.();
+            resolveStatusRequestBatch = null;
           }
-          statusTimeouts.push(args.timeoutMs);
-          return new Promise((_, reject) => {
-            setTimeout(
-              () => reject(new HostOnlineRpcTimeoutError()),
-              args.timeoutMs,
-            );
-          });
-        },
-      );
-
-      vi.useFakeTimers();
-      try {
-        const startedAt = Date.now();
-        let resolvedAt: number | null = null;
-        const responsePromise = Promise.resolve(
-          harness.app.request(`${API}/hosts/${host.id}/provider-clis/status`),
-        ).then((response) => {
-          resolvedAt = Date.now();
-          return response;
         });
-
-        await vi.advanceTimersByTimeAsync(150_000);
-        const response = await responsePromise;
-
-        expect(response.status).toBe(200);
-        expect(await readJson(response)).toEqual({});
-        expect(resolvedAt).not.toBeNull();
-        expect(resolvedAt! - startedAt).toBeLessThan(
-          DEFAULT_BB_REQUEST_TIMEOUT_MS,
-        );
-        expect(statusTimeouts).toHaveLength(18);
-        expect(
-          statusTimeouts.some((timeout) => timeout < COMMAND_TIMEOUT_MS),
-        ).toBe(true);
-      } finally {
-        vi.useRealTimers();
-      }
+      },
     });
+
+    for (
+      let completedRequests = 0;
+      completedRequests < expectedStatusRequestCount;
+      completedRequests += statusRequestBatchSize
+    ) {
+      await waitForStatusRequestBatch();
+      const batch = pendingStatusRequests.splice(0, statusRequestBatchSize);
+      now += Math.max(...batch.map(({ timeoutMs }) => timeoutMs));
+      for (const { resolve } of batch) resolve(null);
+    }
+
+    await expect(responsePromise).resolves.toEqual({});
+    expect(now).toBe(PROVIDER_INSTALLATION_STATUS_TIMEOUT_MS);
+    expect(now).toBeLessThan(DEFAULT_BB_REQUEST_TIMEOUT_MS);
+    expect(statusTimeouts).toHaveLength(expectedStatusRequestCount);
+    expect(statusTimeouts.some((timeout) => timeout < COMMAND_TIMEOUT_MS)).toBe(
+      true,
+    );
+    expect(deadlineExceededProviderIds).toEqual([
+      "stalled-installation-10",
+      "stalled-installation-11",
+    ]);
+    expect(pendingStatusRequests).toEqual([]);
   });
 
   it("dispatches install/update by registered provider id", async () => {


### PR DESCRIPTION
## Human comments

## What was wrong

The provider-installation deadline regression combined three independent layers in one 5-second test body: a full server route harness, provider registry setup, and retryable host RPC timers. It scheduled every stalled wire attempt with fake `setTimeout`, then advanced the entire harness clock by 150 seconds even though the aggregate policy only needs to model three concurrent provider requests across a 70-second budget. Under normal server-shard CPU contention, processing that avoidable timer/lifecycle work could consume the test's real 5-second ceiling. This recurred on current main at `cb3aaf57ddf46ec9cd27e18fc4d99084fb75917e` ([run 34277635721](https://github.com/get-bb/bb/actions/runs/34277635721), [job 102235437825](https://github.com/get-bb/bb/actions/runs/34277635721/job/102235437825)) and on unrelated PR #2920 ([run 34277790348](https://github.com/get-bb/bb/actions/runs/34277790348), [job 102234989200](https://github.com/get-bb/bb/actions/runs/34277790348/job/102234989200)). Retryable RPC attempt budgeting is already covered by `online-rpc.test.ts`, so replaying both attempts for every provider here duplicated coverage while making the aggregation regression timing-sensitive.

## What changed

- Extracted the existing provider aggregation policy into `aggregateProviderInstallations`: it preserves three-way concurrency and registry order, prepares each provider request, applies the remaining aggregate budget, omits providers after the deadline, and assembles the response.
- Kept `getProviderInstallations` responsible for provider discovery, bridge resolution, host RPC dispatch, error classification, and logging. Its 70-second production deadline and 30-second command ceiling are unchanged.
- Reworked the deadline regression to drive the production aggregation helper through observable batches of three deferred provider requests. The test advances an injected logical clock once per concurrent batch, resolves every deferred request, and still proves an empty result, nine provider requests, a shortened final request budget, completion at 70 seconds before the SDK's 75-second deadline, and omission of providers 10 and 11.
- No host-daemon wire, SDK, CLI, route, request deadline, retry budget, or test timeout changed.

## How you verified

- Current-main red: the exact test failed at 5,063ms under a bounded 48-hog profile on an 8-logical-CPU Intel host (at least 50 runnable compute processes, 6.25x oversubscription). Five unloaded current-main runs took 695-1,157ms in the test body.
- Matched green: the rewritten test passed in 13ms under the same 48-hog profile and in 5ms without generated load. Every load/test harness had a hard deadline and process-group cleanup; survivor checks were empty.
- `pnpm exec turbo run test --filter=@bb/server -- test/public/public-provider-installations.test.ts` passed: 1 file, 6 tests.
- `pnpm exec turbo run typecheck build --filter=@bb/server` passed both server tasks.
- A serial one-worker rerun passed `online-rpc.test.ts` (9 tests), `plugin-update.test.ts` (27), `timeline-in-turn-window.test.ts` (28), and `timeline-perf.test.ts` (1); one unrelated macOS launch-agent test timed out while the Intel host's virtualization workload remained elevated.
- Three broader server runs all passed `public-provider-installations.test.ts` (6 tests). The full shards did not go green on this host: depending on worker count and concurrent virtualization load, unrelated install/plugin/timeline tests hit their existing 5-second ceilings (best run: 4 failed files, 18 failed and 2,310 passed tests). The server package itself used seven Vitest workers plus one coordinator on eight logical CPUs, so it did not oversubscribe the host by itself.
- `pnpm exec prettier --check apps/server/src/services/system/provider-installations.ts apps/server/test/public/public-provider-installations.test.ts` and `git diff --check` passed.


> AGENT GENERATED