### PR TITLE
fix(app): cancel debounced values on unmount

### DIFF
--- a/apps/app/src/components/pickers/BranchPicker.tsx
+++ b/apps/app/src/components/pickers/BranchPicker.tsx
@@ -6,7 +6,6 @@ import {
   useState,
   type RefObject,
 } from "react";
-import { useDebounceValue } from "usehooks-ts";
 import { Button } from "@bb/shared-ui/button";
 import { Icon, type IconName } from "@bb/shared-ui/icon";
 import { LIST_HOVER_TRANSITION } from "@bb/shared-ui/motion";
@@ -23,6 +22,7 @@ import {
 import { Input } from "@bb/shared-ui/input";
 import { blurActiveKeyboardInputWithin } from "@bb/shared-ui/overlay-trigger";
 import { Popover, PopoverContent, PopoverTrigger } from "@bb/shared-ui/popover";
+import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import {
   OPTION_BASE_CLASS_NAME,
   OPTION_INTERACTIVE_CLASS_NAME,
@@ -438,7 +438,7 @@ export function BranchPicker({
   const inputRef = useRef<HTMLInputElement>(null);
   const normalizedQuery = deferredQuery.trim().toLowerCase();
   const isSearching = normalizedQuery.length > 0;
-  const [debouncedNormalizedQuery] = useDebounceValue(
+  const debouncedNormalizedQuery = useDebouncedValue(
     normalizedQuery,
     BRANCH_SEARCH_DEBOUNCE_MS,
   );

--- a/apps/app/src/components/plugin/management/BrowsePluginsTab.tsx
+++ b/apps/app/src/components/plugin/management/BrowsePluginsTab.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "react-router-dom";
-import { useDebounceValue } from "usehooks-ts";
 import { Button } from "@bb/shared-ui/button";
 import { PLUGIN_CATALOG_CATEGORIES, pluginCatalogCategory } from "@bb/domain";
 import {
@@ -11,6 +10,7 @@ import {
 } from "@bb/shared-ui/dropdown-menu";
 import { Icon } from "@bb/shared-ui/icon";
 import { cn } from "@bb/shared-ui/lib/utils";
+import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import {
   ResourceBrowseCard,
   ResourceBrowseGrid,
@@ -87,7 +87,7 @@ export function BrowsePluginsTab({
   const [expandedShelves, setExpandedShelves] = useState<Set<string>>(
     () => new Set(),
   );
-  const [debouncedQuery] = useDebounceValue(query.trim(), 300);
+  const debouncedQuery = useDebouncedValue(query.trim(), 300);
   const searchQuery = usePluginCatalogSearch(debouncedQuery, { enabled: true });
   const catalog = searchQuery.data ?? { entries: [], collections: [] };
   const entries = useMemo(

--- a/apps/app/src/components/plugin/management/PluginAuthorPage.tsx
+++ b/apps/app/src/components/plugin/management/PluginAuthorPage.tsx
@@ -1,6 +1,5 @@
 import { useMemo } from "react";
 import { Link, useSearchParams } from "react-router-dom";
-import { useDebounceValue } from "usehooks-ts";
 import { Icon } from "@bb/shared-ui/icon";
 import {
   ResourceCollectionViewport,
@@ -10,6 +9,7 @@ import {
 } from "@bb/shared-ui/resource-list";
 import { cn } from "@bb/shared-ui/lib/utils";
 import { TOOLS_PAGE_BAND_CLASSES } from "@/components/tools/tools-navigation";
+import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import {
   type PluginCatalogSearchEntry,
   usePluginCatalogSearch,
@@ -80,7 +80,7 @@ export function PluginAuthorPage({
 }) {
   const [searchParams, setSearchParams] = useSearchParams();
   const query = searchParams.get("query") ?? "";
-  const [debouncedQuery] = useDebounceValue(query.trim(), 300);
+  const debouncedQuery = useDebouncedValue(query.trim(), 300);
   const selectedCategories = searchParams.getAll("category");
   const requestedSort = pluginBrowseSort(searchParams.get("sort"));
   const sortDirection =

--- a/apps/app/src/hooks/queries/thread-queries.ts
+++ b/apps/app/src/hooks/queries/thread-queries.ts
@@ -5,7 +5,6 @@ import {
   type QueryClient,
 } from "@tanstack/react-query";
 import { useCallback, useMemo } from "react";
-import { useDebounceValue } from "usehooks-ts";
 import { COMPACT_VIEWPORT_QUERY } from "@bb/shared-ui/hooks/use-compact-viewport";
 import { getMediaQuerySnapshot } from "@bb/shared-ui/hooks/use-media-query";
 import type { PendingInteraction, ThreadListEntry } from "@bb/domain";
@@ -24,6 +23,7 @@ import type {
   ThreadTimelineResponse,
   TimelineTurnSummaryDetailsResponse,
 } from "@bb/server-contract";
+import { useDebouncedValue } from "../useDebouncedValue";
 import { applyTimelineDelta } from "@bb/server-contract";
 import type { ThreadListFilters } from "@bb/client-core";
 import type { FilePreview } from "@bb/client-core";
@@ -577,7 +577,7 @@ export function useThreadSearch({
   limitPerGroup = THREAD_SEARCH_LIMIT_PER_GROUP,
   query,
 }: UseThreadSearchArgs): UseThreadSearchResult {
-  const [debouncedRawQuery] = useDebounceValue(
+  const debouncedRawQuery = useDebouncedValue(
     query,
     THREAD_SEARCH_DEBOUNCE_MS,
   );

--- a/apps/app/src/hooks/useDebouncedValue.test.tsx
+++ b/apps/app/src/hooks/useDebouncedValue.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useDebouncedValue } from "./useDebouncedValue";
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("useDebouncedValue", () => {
+  it("cancels its pending update when unmounted", () => {
+    vi.useFakeTimers();
+    const { rerender, unmount } = renderHook(
+      ({ value }) => useDebouncedValue(value, 120),
+      { initialProps: { value: "main" } },
+    );
+
+    rerender({ value: "feature/one" });
+    expect(vi.getTimerCount()).toBe(1);
+
+    unmount();
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("publishes only the latest value after the delay", () => {
+    vi.useFakeTimers();
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebouncedValue(value, 120),
+      { initialProps: { value: "main" } },
+    );
+
+    rerender({ value: "feature/one" });
+    rerender({ value: "feature/two" });
+    act(() => vi.advanceTimersByTime(119));
+    expect(result.current).toBe("main");
+
+    act(() => vi.advanceTimersByTime(1));
+    expect(result.current).toBe("feature/two");
+  });
+});

--- a/apps/app/src/hooks/useDebouncedValue.ts
+++ b/apps/app/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from "react";
+
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(() => value);
+
+  useEffect(() => {
+    if (Object.is(value, debouncedValue)) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setDebouncedValue(() => value);
+    }, delayMs);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [debouncedValue, delayMs, value]);
+
+  return debouncedValue;
+}

--- a/apps/app/src/hooks/usePathSuggestions.ts
+++ b/apps/app/src/hooks/usePathSuggestions.ts
@@ -1,11 +1,11 @@
 import { useMemo } from "react";
 import type { WorkspacePathEntry } from "@bb/server-contract";
-import { useDebounceValue } from "usehooks-ts";
 import { useEnvironmentPathSuggestions } from "./queries/environment-queries";
 import { useProjectPathSuggestions } from "./queries/project-queries";
 import { useThreadStoragePaths } from "./queries/thread-queries";
 import { isProjectlessProjectId } from "@/lib/route-paths";
 import type { PathListOptions } from "@/lib/path-list-options";
+import { useDebouncedValue } from "./useDebouncedValue";
 
 export const PATH_SUGGESTION_DEBOUNCE_MS = 120;
 
@@ -146,7 +146,7 @@ export function usePathSuggestions(
 ): UsePathSuggestionsResult {
   const limit = args.limit ?? DEFAULT_PATH_SUGGESTION_LIMIT;
   const oversampleLimit = limit * SOURCE_OVERSAMPLE_MULTIPLIER;
-  const [debouncedNonNullQuery] = useDebounceValue(
+  const debouncedNonNullQuery = useDebouncedValue(
     args.query,
     PATH_SUGGESTION_DEBOUNCE_MS,
   );

--- a/apps/app/src/hooks/usePromptMentions.ts
+++ b/apps/app/src/hooks/usePromptMentions.ts
@@ -1,6 +1,5 @@
 import { useCallback, useMemo, useState } from "react";
 import type { SidebarBootstrapResponse } from "@bb/server-contract";
-import { useDebounceValue } from "usehooks-ts";
 import {
   buildSectionMentionSuggestions,
   type SectionMentionCandidate,
@@ -22,6 +21,7 @@ import {
   usePathSuggestions,
   PATH_SUGGESTION_DEBOUNCE_MS,
 } from "./usePathSuggestions";
+import { useDebouncedValue } from "./useDebouncedValue";
 import {
   DEFAULT_PLUGIN_MENTION_TRIGGER,
   PLUGIN_MENTION_TRIGGER_VALUES,
@@ -158,7 +158,7 @@ export function usePromptMentions(
       ),
     [pluginContributions.data?.mentionProviders],
   );
-  const [debouncedQuery] = useDebounceValue(
+  const debouncedQuery = useDebouncedValue(
     trimmedQuery,
     PATH_SUGGESTION_DEBOUNCE_MS,
   );


### PR DESCRIPTION
## Human comments

## What was wrong

`usehooks-ts@3.1.1` does not cancel the lodash debounce instance that its `useDebounceValue` path actually invokes. `useDebounceCallback` returns a wrapper around one instance created in `useMemo`, but its unmount effect cancels a separate instance assigned to a ref. When a search value changed immediately before unmount, the trailing callback could therefore call React state after Vitest had torn down jsdom, producing the observed `ReferenceError: window is not defined` from `BranchPicker.scroll.test.tsx`.

## What changed

- Added an app-owned `useDebouncedValue` hook whose effect creates one timer and clears that exact handle on value changes and unmount.
- Migrated all six app consumers away from the defective upstream value-debounce path: branch search, plugin browse search, plugin author search, thread search, prompt mentions, and path suggestions.
- Added regression coverage for unmount cancellation and trailing latest-value behavior.

This is app-local behavior only. There are no server/daemon wire changes, CLI changes, or `HOST_DAEMON_PROTOCOL_VERSION` implications.

A test-only timer drain, sleep, retry, timeout increase, or quarantine would hide the lifecycle bug. A BranchPicker-only cleanup would leave the same defect in five other consumers. Updating `usehooks-ts` is not an available fix because 3.1.1 is its latest release and contains the mismatch.

## How you verified

- Red regression on the prior upstream-backed implementation: `cancels its pending update when unmounted` failed with one timer remaining (`expected 1 to be 0`).
- Green affected Turbo suite: `pnpm exec turbo run test --filter=@bb/app --concurrency=4 -- ... --maxWorkers=2 --no-file-parallelism` — 4/4 tasks, 8/8 files, 54/54 tests.
- Intel stress: five consecutive focused runs under 16 CPU load workers — all 25 test executions passed; exact PID cleanup reported no surviving Vitest or load processes.
- `pnpm exec turbo run typecheck --filter=@bb/app --concurrency=4` — 3/3 tasks passed.
- `pnpm exec turbo run build --filter=@bb/app --concurrency=4` — 3/3 tasks passed.
- `pnpm exec turbo run lint --filter=@bb/app --concurrency=4` — passed with the existing warning baseline and zero errors.
- Two complete `@bb/app` test attempts exercised all 494 files. The first reached 4,053 passing tests before an unrelated plugin browse timeout and Sonner/AppToaster teardown errors; those two files passed 26/26 when rerun together. The second, capped at four Vitest workers, had no unhandled teardown errors and reached 4,052 passing tests before unrelated PluginsOverview/FilePreview timeouts; those files passed 40/40 when rerun together.

> AGENT GENERATED