### PR TITLE
Reject extra values passed to plugin config unset

### DIFF
--- a/apps/cli/src/__tests__/command-output/plugin-config.test.ts
+++ b/apps/cli/src/__tests__/command-output/plugin-config.test.ts
@@ -74,6 +74,45 @@ describe("bb plugin config", () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ["ordinary extra value", ["extra"]],
+    ["negative value after --", ["--", "-1"]],
+  ])("rejects the %s passed to unset", async (_, extraArgs) => {
+    const stderr = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+
+    await expect(
+      runCommand(
+        ["plugin", "config", "demo", "unset", "retries", ...extraArgs],
+        register,
+      ),
+    ).rejects.toThrow("process.exit:1");
+
+    expect(stderr).toHaveBeenCalledWith(
+      "error: too many arguments for 'config'. Expected 3 arguments but got 4.\n",
+    );
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("unsets a setting when no value is passed", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(settingsResponse(3));
+
+    await runCommand(
+      ["plugin", "config", "demo", "unset", "retries"],
+      register,
+    );
+
+    expect(fetch).toHaveBeenCalledOnce();
+    expect(fetch).toHaveBeenCalledWith(
+      "http://server/api/v1/plugins/demo/settings",
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({ values: { retries: null } }),
+      }),
+    );
+  });
+
   it("rejects a non-finite number before sending an update", async () => {
     vi.mocked(fetch).mockResolvedValueOnce(settingsResponse(3));
 

--- a/apps/cli/src/commands/plugin.ts
+++ b/apps/cli/src/commands/plugin.ts
@@ -1589,9 +1589,10 @@ export function registerPluginCommands(
             ) ?? (valueIsUnknownOption ? value : undefined);
           if (unknownOption !== undefined)
             command.error(`error: unknown option '${unknownOption}'`);
-          if (command.args.length > 4)
+          const expectedArgumentCount = actionName === "unset" ? 3 : 4;
+          if (command.args.length > expectedArgumentCount)
             command.error(
-              `error: too many arguments for 'config'. Expected 4 arguments but got ${command.args.length}.`,
+              `error: too many arguments for 'config'. Expected ${expectedArgumentCount} arguments but got ${command.args.length}.`,
             );
           const settingsPath = `/${encodeURIComponent(id)}/settings`;
           if (actionName === undefined) {


### PR DESCRIPTION
## Human comments

## What was wrong

`bb plugin config` shares an optional value position between `set` and `unset`, but its excess-argument check always allowed the four arguments required by `set`. As a result, `unset` accepted one ordinary extra value—or a negative value after `--`—and contacted the server to delete the setting instead of rejecting malformed input locally.

## What changed

The CLI now chooses the allowed parsed-argument count from the action before making any settings request: four for `set`, three for `unset`. Regressions cover ordinary and post-terminator extra values, verify no request is sent, and retain the valid value-free `unset` path. The existing command description and usage text already document `config <id> unset <key>`, so no guide or skill text changes are needed. There are no wire, SDK, or configuration-contract changes.

## How you verified

- Both new no-request regressions failed before the fix because the malformed `unset` commands completed and called the server; they pass after the fix.
- `pnpm exec turbo run test --filter=@bb/cli --force -- src/__tests__/command-output/plugin-config.test.ts` — 6/6 tests passed after rebasing onto current `origin/main`.
- `pnpm exec turbo run typecheck build --filter=@bb/cli --force` — 5/5 Turbo tasks passed.
- `pnpm exec oxfmt --check apps/cli/src/commands/plugin.ts apps/cli/src/__tests__/command-output/plugin-config.test.ts` — passed.
- `git diff --check origin/main...HEAD` — passed.

Fixes: no linked issue.

> AGENT GENERATED
