### PR TITLE
Apply later-turn provider environment to Pi and ACP

### DIFF
--- a/packages/provider-bridge-acp/src/bridge/bridge.test.ts
+++ b/packages/provider-bridge-acp/src/bridge/bridge.test.ts
@@ -1561,6 +1561,23 @@ describe("acp bridge", () => {
     expect(agentMessageTexts()).toContain("echo:hello there");
   });
 
+  it("rebuilds the agent with environment from a later turn", async () => {
+    const envVars = { FAKE_ACP_LOAD_SESSION: "1", FAKE_ACP_PROMPT_ERROR: "1" };
+    const { providerThreadId } = await startThread({ envVars });
+    const turnId = sendTurnRequest("turn/start", providerThreadId, {
+      input: [{ type: "text", text: "fresh environment", mentions: [] }],
+      options: executionOptions({
+        envVars: { FAKE_ACP_PROMPT_ERROR: "0" },
+        providerOptions: { acpLaunchSpec: acpLaunchSpec({ envVars }) },
+      }),
+    });
+
+    expect((await waitForResponse(turnId)).error).toBeUndefined();
+    expect(await waitForTurnCompleted()).toMatchObject({ status: "completed" });
+    expect(agentMessageTexts()).toContain("echo:fresh environment");
+    expect(notifications("session/replaced")).toHaveLength(1);
+  });
+
   it("authenticates ACP sessions with cached tokens when advertised", async () => {
     const { providerThreadId } = await startThread({
       envVars: { FAKE_ACP_AUTH_METHODS: "cached_token" },

--- a/packages/provider-bridge-acp/src/bridge/bridge.ts
+++ b/packages/provider-bridge-acp/src/bridge/bridge.ts
@@ -36,6 +36,7 @@ import { promises as fs, readFileSync } from "node:fs";
 import { createServer, type Server, type Socket } from "node:net";
 import { dirname, isAbsolute, basename, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { isDeepStrictEqual } from "node:util";
 import { z } from "zod";
 
 type DecodedToolCallResponse = ReturnType<typeof decodeToolCallResponsePayload>;
@@ -159,6 +160,7 @@ interface AcpPendingTurnInput {
 
 interface AcpThreadSession {
   bbThreadId: string;
+  construction: AcpSessionParams;
   providerThreadId: string;
   cwd: string;
   dialect: AcpDialect;
@@ -1699,6 +1701,7 @@ async function startAgentSession(
   });
   session = {
     bbThreadId,
+    construction: params,
     providerThreadId: "",
     cwd: params.cwd,
     dialect,
@@ -2590,7 +2593,7 @@ async function handleRequest(
 
     case "turn/start": {
       const params = request.params;
-      const session = liveSessionForThread(params.threadId);
+      let session = liveSessionForThread(params.threadId);
       if (session === undefined) {
         sendError(request.id, -32000, "No active ACP session");
         return;
@@ -2598,6 +2601,27 @@ async function handleRequest(
       if (session.activePromptKind !== null) {
         sendError(request.id, -32000, "A turn is already active");
         return;
+      }
+      if (Object.keys(params.options.envVars ?? {}).length > 0) {
+        const envVars = {
+          ...(decodeLaunchSpec(params.options.providerOptions)?.env ?? {}),
+          ...params.options.envVars,
+        };
+        if (!isDeepStrictEqual(envVars, session.construction.envVars ?? {})) {
+          const previousProviderThreadId = session.providerThreadId;
+          session = await startAgentSession({
+            kind: "resume",
+            params: { ...session.construction, envVars },
+            resumeProviderThreadId: previousProviderThreadId,
+          });
+          sendNotification(BRIDGE_NOTIFICATION_METHODS.sessionReplaced, {
+            threadId: params.threadId,
+            providerThreadId: session.providerThreadId,
+            reason:
+              "Execution settings changed; the ACP session was rebuilt to apply them.",
+            contextLost: session.providerThreadId !== previousProviderThreadId,
+          });
+        }
       }
       const pending: AcpPendingTurnInput = {
         clientRequestId: params.clientRequestId,

--- a/plugins/provider-pi/src/bridge/bridge.ts
+++ b/plugins/provider-pi/src/bridge/bridge.ts
@@ -9,6 +9,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { isDeepStrictEqual } from "node:util";
 import { z } from "zod";
 import {
   BRIDGE_JSON_RPC_ERRORS,
@@ -16,6 +17,7 @@ import {
   PROVIDER_BRIDGE_PROTOCOL_VERSION,
   THREAD_DELTA_GRAMMAR_V3,
   THREAD_DELTA_NOTIFICATION_METHOD,
+  buildShellEnvOverrides,
   bridgeRequestEnvelopeSchema,
   createBridgeIo,
   createBridgeLineHandler,
@@ -1031,6 +1033,13 @@ async function reconcileTurnOptions(
 ): Promise<ThreadSession> {
   const turnOptions = buildPiTurnOptions(options);
   const construction = threadSession.construction;
+  const shellEnvOverrides =
+    options.envVars && Object.keys(options.envVars).length > 0
+      ? { BB_THREAD_ID: threadId, ...buildShellEnvOverrides(options.envVars) }
+      : undefined;
+  const environmentChanged =
+    shellEnvOverrides !== undefined &&
+    !isDeepStrictEqual(shellEnvOverrides, construction.shellEnvOverrides);
   const changedModelRequest =
     turnOptions.model !== undefined && turnOptions.model !== construction.model
       ? turnOptions.model
@@ -1038,7 +1047,11 @@ async function reconcileTurnOptions(
   const thinkingLevelChanged =
     turnOptions.thinkingLevel !== undefined &&
     turnOptions.thinkingLevel !== construction.thinkingLevel;
-  if (changedModelRequest === undefined && !thinkingLevelChanged) {
+  if (
+    !environmentChanged &&
+    changedModelRequest === undefined &&
+    !thinkingLevelChanged
+  ) {
     return threadSession;
   }
   const nextModel =
@@ -1050,11 +1063,12 @@ async function reconcileTurnOptions(
     (threadSession.constructionModel === undefined ||
       threadSession.constructionModel.provider !== nextModel.provider ||
       threadSession.constructionModel.id !== nextModel.id);
-  if (!modelChanged && !thinkingLevelChanged) {
+  if (!environmentChanged && !modelChanged && !thinkingLevelChanged) {
     return threadSession;
   }
   const replacement = await rebuildThreadSession(threadId, threadSession, {
     ...construction,
+    ...(shellEnvOverrides === undefined ? {} : { shellEnvOverrides }),
     ...(turnOptions.model === undefined ? {} : { model: turnOptions.model }),
     ...(turnOptions.thinkingLevel === undefined
       ? {}

--- a/plugins/provider-pi/src/bridge/bridge.turn-options.test.ts
+++ b/plugins/provider-pi/src/bridge/bridge.turn-options.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { z } from "zod";
 import type {
@@ -70,6 +72,35 @@ function turnStart(
     options,
   });
 }
+
+it(
+  "rebuilds the session with environment from a later turn",
+  async () => {
+    const threadId = "thr_turn_options_env";
+    const envLog = join(harness.workspaceDir, "env.log");
+    const options = (marker: string) => ({
+      ...MINI,
+      envVars: { FAKE_PI_ENV_LOG: envLog, FAKE_PI_ENV_MARKER: marker },
+    });
+    await harness.startThread(threadId, { options: options("first") });
+
+    expect(
+      (await turnStart(1, threadId, "first", options("first"))).error,
+    ).toBeUndefined();
+    const seen = await harness.waitForTurnBoundary(threadId, 0);
+    expect(
+      (await turnStart(2, threadId, "second", options("second"))).error,
+    ).toBeUndefined();
+    await harness.waitForTurnBoundary(threadId, seen);
+
+    expect(readFileSync(envLog, "utf8").trim().split("\n")).toEqual([
+      "first",
+      "second",
+    ]);
+    expect(sessionReplacements(threadId)).toHaveLength(1);
+  },
+  TURN_OPTIONS_TEST_TIMEOUT_MS,
+);
 
 it(
   "rebuilds the session on the model a later turn carries",

--- a/plugins/provider-pi/src/bridge/fake-pi-rpc.mjs
+++ b/plugins/provider-pi/src/bridge/fake-pi-rpc.mjs
@@ -101,6 +101,12 @@ const extensionPath = flag("--extension");
 const processLogPath = process.env.FAKE_PI_PROCESS_LOG;
 const commandLogPath = process.env.FAKE_PI_COMMAND_LOG;
 const promptDumpPath = process.env.FAKE_PI_PROMPT_DUMP;
+if (process.env.FAKE_PI_ENV_LOG) {
+  appendFileSync(
+    process.env.FAKE_PI_ENV_LOG,
+    `${process.env.FAKE_PI_ENV_MARKER ?? ""}\n`,
+  );
+}
 if (sessionFile !== undefined) {
   mkdirSync(dirname(sessionFile), { recursive: true });
   if (!existsSync(sessionFile)) {


### PR DESCRIPTION
## Human comments

## What was wrong

[PR #3035](https://github.com/get-bb/bb/pull/3035) made plugin-contributed provider environments available on every command, but Pi reconciled only model and reasoning changes while ACP ignored later `turn/start` options. Their long-lived child processes therefore kept the environment from session creation even after BB accepted and recorded new credentials or endpoints, so a later turn could use the wrong account or fail with stale credentials.

## What changed

Pi now compares the effective turn environment with its construction environment and uses its existing rollback-safe rebuild and resume path when values differ. ACP now retains its construction parameters, merges current launch and turn environments, and restarts through its existing resume path; it reports context loss only when fallback changes the provider thread id. Identical environments do not trigger replacement, and legacy empty replay payloads keep their existing no-change behavior.

The rebase preserves current main's deterministic Pi skill-input coverage and drops the now-obsolete timeout-only commit for the deleted process-backed test. No public contract, CLI, documentation, or host-daemon wire behavior changed, so no protocol bump is required.

## How you verified

- Added red-first Pi and ACP regressions that reproduce stale child environments and pass after the fix.
- Full provider suites passed: Pi 157/157 tests and ACP 312/312 tests.
- Focused post-format reruns passed: Pi turn options 7/7 and ACP bridge 96/96.
- `pnpm exec turbo run test typecheck --filter=bb-plugin-provider-pi --filter=@bb/provider-bridge-acp --force` passed all eight Turbo tasks.
- `bb plugin build plugins/provider-pi` and `bb plugin build plugins/provider-acp` emitted their packages successfully.
- Targeted formatting for the four normally formatted source/test files and `git diff --check origin/main...HEAD` passed. The three-line fake-Pi fixture addition follows formatter output; the remainder of that legacy fixture is unchanged.

No linked issue; this is a follow-up to #3035.


> AGENT GENERATED