### PR TITLE
Clear stale compact panel selection on close

### DIFF
--- a/apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.test.tsx
+++ b/apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.test.tsx
@@ -200,6 +200,47 @@ describe("CompactSecondaryPanelShelf", () => {
     },
   );
 
+  it("clears only its selected text on close so reopening restores swiping", () => {
+    const onClose = vi.fn();
+    const view = (open: boolean) => (
+      <>
+        <div data-testid="outside-selection">Outside selection</div>
+        <CompactSecondaryPanelShelf
+          open={open}
+          onClose={onClose}
+          presentation="shelf"
+          srLabel="Right panel"
+        >
+          <div data-testid="panel-body">Preview selection</div>
+        </CompactSecondaryPanelShelf>
+      </>
+    );
+    const selectContents = (element: Element) => {
+      const range = document.createRange();
+      range.selectNodeContents(element);
+      window.getSelection()?.removeAllRanges();
+      window.getSelection()?.addRange(range);
+    };
+    const { rerender } = render(view(true));
+
+    selectContents(screen.getByTestId("outside-selection"));
+    rerender(view(false));
+    expect(window.getSelection()?.toString()).toBe("Outside selection");
+
+    rerender(view(true));
+    const shelf = screen.getByTestId("secondary-panel-shelf");
+    Object.defineProperty(shelf, "clientWidth", { value: 300 });
+    selectContents(screen.getByTestId("panel-body"));
+    rerender(view(false));
+    expect(window.getSelection()?.isCollapsed).toBe(true);
+
+    rerender(view(true));
+    fireTouch(shelf, "touchstart", createTouch(60, 160));
+    fireTouch(window, "touchmove", createTouch(240, 164));
+    fireTouch(window, "touchend", createTouch(240, 164));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
   it("ignores a closing swipe from the left browser edge", () => {
     const { onClose } = renderShelf(true);
     const shelf = screen.getByTestId("secondary-panel-shelf");

--- a/apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.tsx
+++ b/apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.tsx
@@ -116,6 +116,20 @@ export function CompactSecondaryPanelShelf({
     requestClose,
   });
 
+  useLayoutEffect(() => {
+    if (open) return;
+    const panel = panelRef.current;
+    if (panel === null) return;
+    const selection = panel.ownerDocument.getSelection();
+    if (selection === null || selection.isCollapsed) return;
+    if (
+      (selection.anchorNode !== null && panel.contains(selection.anchorNode)) ||
+      (selection.focusNode !== null && panel.contains(selection.focusNode))
+    ) {
+      selection.removeAllRanges();
+    }
+  }, [open]);
+
   useEffect(() => {
     setCompactSecondaryPanelPresentation(state);
     return () => setCompactSecondaryPanelPresentation("closed");


### PR DESCRIPTION
## Human comments

## What was wrong

Compact right-panel previews remain mounted after closing, so a browser text selection inside the shelf also remained alive. Reopening restored that stale selection, and the selection-protection behavior correctly treated the next swipe as text interaction instead of dismissing the panel.

## What changed

When the compact shelf closes, it now synchronously clears a noncollapsed selection only if the selection's anchor or focus is inside that shelf. Collapsed selections and selections entirely elsewhere on the page are preserved. The persistent shelf, generic drag hook, sibling sidebar, and desktop panel behavior are unchanged. There are no wire, CLI, SDK, guide, or configuration-surface changes.

## How you verified

- The owner regression failed before the fix because close/reopen retained the shelf selection; after the fix it proves outside selections remain, shelf selections clear on close, and the next swipe dismisses after reopen.
- `pnpm exec turbo run test --filter=@bb/app --force -- src/components/secondary-panel/CompactSecondaryPanelShelf.test.tsx` — 17/17 tests passed after rebasing onto current `origin/main`.
- `pnpm exec turbo run typecheck build --filter=@bb/app --force` — 4/4 Turbo tasks passed after refreshing the frozen install.
- Earlier broader focused panel/sidebar/layout validation passed 76/76 tests, and matched compact-browser QA verified selection protection while open, close-time clearing, focus restoration, reopen, and swipe dismissal.
- `pnpm exec oxfmt --check apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.tsx apps/app/src/components/secondary-panel/CompactSecondaryPanelShelf.test.tsx` — passed.
- `git diff --check origin/main...HEAD` — passed.

Fixes: no linked issue.

> AGENT GENERATED
