### PR TITLE
Sync collapsed sidebar rows and sections through the server

### DIFF
--- a/apps/app/src/components/sidebar/sidebarCollapsedAtoms.ts
+++ b/apps/app/src/components/sidebar/sidebarCollapsedAtoms.ts
@@ -1,23 +1,8 @@
-import { atomWithStorage } from "jotai/utils";
-import type { CollapsibleSidebarSectionId } from "@bb/client-core";
 import type {
   SidebarChronologicalSort,
   SidebarOrganizationMode,
 } from "@bb/domain";
-import {
-  createJsonLocalStorage,
-  type SyncStorage,
-} from "@/lib/browser-storage";
 import { createSyncedPreferenceAtom } from "@/lib/ui-preferences/synced-preference-atom";
-
-const COLLAPSED_PROJECTS_STORAGE_KEY = "bb.sidebar.collapsedProjects";
-const COLLAPSED_THREADS_STORAGE_KEY = "bb.sidebar.collapsedThreads";
-const COLLAPSED_ENVIRONMENTS_STORAGE_KEY = "bb.sidebar.collapsedEnvironments";
-const COLLAPSED_SIDEBAR_SECTIONS_STORAGE_KEY = "bb.sidebar.collapsedSections";
-const COLLAPSED_THREAD_SECTIONS_STORAGE_KEY =
-  "bb.sidebar.collapsedThreadSections";
-const LEGACY_COLLAPSED_FOLDERS_STORAGE_KEY = "bb.sidebar.collapsedFolders";
-const COLLAPSED_MACHINES_STORAGE_KEY = "bb.sidebar.collapsedMachines";
 
 export type {
   CollapsibleSidebarSectionId,
@@ -26,85 +11,20 @@ export type {
 
 export type { SidebarChronologicalSort, SidebarOrganizationMode };
 
-function createLegacyMigratingStringArrayStorage(
-  legacyKey: string,
-  migrateItem: (item: string) => string,
-): SyncStorage<string[]> {
-  const storage = createJsonLocalStorage<string[]>();
-
-  return {
-    getItem(key, initialValue) {
-      if (
-        typeof window === "undefined" ||
-        window.localStorage.getItem(key) !== null
-      ) {
-        return storage.getItem(key, initialValue);
-      }
-
-      const legacyJson = window.localStorage.getItem(legacyKey);
-      if (legacyJson === null) {
-        return initialValue;
-      }
-      let parsedLegacyValue: unknown;
-      try {
-        parsedLegacyValue = JSON.parse(legacyJson);
-      } catch {
-        storage.removeItem(legacyKey);
-        return initialValue;
-      }
-      if (!Array.isArray(parsedLegacyValue)) {
-        storage.removeItem(legacyKey);
-        return initialValue;
-      }
-      const migratedValue = parsedLegacyValue
-        .filter((item): item is string => typeof item === "string")
-        .map(migrateItem);
-      storage.setItem(key, migratedValue);
-      storage.removeItem(legacyKey);
-      return migratedValue;
-    },
-    setItem: storage.setItem,
-    removeItem(key) {
-      storage.removeItem(key);
-      storage.removeItem(legacyKey);
-    },
-    subscribe: storage.subscribe,
-  };
-}
-
-const collapsedThreadSectionsStorage = createLegacyMigratingStringArrayStorage(
-  LEGACY_COLLAPSED_FOLDERS_STORAGE_KEY,
-  (item) => item,
+export const collapsedProjectIdsAtom = createSyncedPreferenceAtom(
+  "sidebar.collapsedProjects",
 );
 
-export const collapsedProjectIdsAtom = atomWithStorage<string[]>(
-  COLLAPSED_PROJECTS_STORAGE_KEY,
-  [],
-  createJsonLocalStorage<string[]>(),
-  { getOnInit: true },
+export const collapsedThreadIdsAtom = createSyncedPreferenceAtom(
+  "sidebar.collapsedThreads",
 );
 
-export const collapsedThreadIdsAtom = atomWithStorage<string[]>(
-  COLLAPSED_THREADS_STORAGE_KEY,
-  [],
-  createJsonLocalStorage<string[]>(),
-  { getOnInit: true },
+export const collapsedEnvironmentIdsAtom = createSyncedPreferenceAtom(
+  "sidebar.collapsedEnvironments",
 );
 
-export const collapsedEnvironmentIdsAtom = atomWithStorage<string[]>(
-  COLLAPSED_ENVIRONMENTS_STORAGE_KEY,
-  [],
-  createJsonLocalStorage<string[]>(),
-  { getOnInit: true },
-);
-
-export const collapsedSidebarSectionIdsAtom = atomWithStorage<
-  CollapsibleSidebarSectionId[]
->(
-  COLLAPSED_SIDEBAR_SECTIONS_STORAGE_KEY,
-  [],
-  createJsonLocalStorage<CollapsibleSidebarSectionId[]>(),
-  { getOnInit: true },
+export const collapsedSidebarSectionIdsAtom = createSyncedPreferenceAtom(
+  "sidebar.collapsedSections",
 );
 
 export const sidebarSectionOrderAtom = createSyncedPreferenceAtom(
@@ -127,16 +47,10 @@ export const sidebarChronologicalSortAtom = createSyncedPreferenceAtom(
   "sidebar.chronologicalSort",
 );
 
-export const sidebarCollapsedThreadSectionsAtom = atomWithStorage<string[]>(
-  COLLAPSED_THREAD_SECTIONS_STORAGE_KEY,
-  [],
-  collapsedThreadSectionsStorage,
-  { getOnInit: true },
+export const sidebarCollapsedThreadSectionsAtom = createSyncedPreferenceAtom(
+  "sidebar.collapsedThreadSections",
 );
 
-export const sidebarCollapsedMachinesAtom = atomWithStorage<string[]>(
-  COLLAPSED_MACHINES_STORAGE_KEY,
-  [],
-  createJsonLocalStorage<string[]>(),
-  { getOnInit: true },
+export const sidebarCollapsedMachinesAtom = createSyncedPreferenceAtom(
+  "sidebar.collapsedMachines",
 );

--- a/apps/app/src/views/RootComposeMobileRecents.test.tsx
+++ b/apps/app/src/views/RootComposeMobileRecents.test.tsx
@@ -4,6 +4,8 @@ import type { ThreadListEntry } from "@bb/domain";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
+import { Provider, createStore } from "jotai";
+import { collapsedThreadIdsAtom } from "@/components/sidebar/sidebarCollapsedAtoms";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it } from "vitest";
 import type { SystemEnvironmentProvider } from "@bb/server-contract";
@@ -32,12 +34,26 @@ const personalProvider: SystemEnvironmentProvider = {
   inputs: null,
 };
 
-function TestProviders({ children }: { children: ReactNode }) {
+function TestProviders({
+  children,
+  store = createStore(),
+}: {
+  children: ReactNode;
+  store?: ReturnType<typeof createStore>;
+}) {
   return (
-    <QueryClientProvider client={new QueryClient()}>
-      <MemoryRouter>{children}</MemoryRouter>
-    </QueryClientProvider>
+    <Provider store={store}>
+      <QueryClientProvider client={new QueryClient()}>
+        <MemoryRouter>{children}</MemoryRouter>
+      </QueryClientProvider>
+    </Provider>
   );
+}
+
+function storeWithCollapsedThreads(threadIds: string[]) {
+  const store = createStore();
+  store.set(collapsedThreadIdsAtom, threadIds);
+  return store;
 }
 
 function makeThread(overrides: Partial<ThreadListEntry> = {}): ThreadListEntry {
@@ -351,13 +367,8 @@ describe("mobile recents hierarchy interaction", () => {
   ])(
     "renders child-only $label state on a collapsed parent",
     ({ child, label }) => {
-      window.localStorage.setItem(
-        "bb.sidebar.collapsedThreads",
-        JSON.stringify(["thr_parent"]),
-      );
-
       render(
-        <TestProviders>
+        <TestProviders store={storeWithCollapsedThreads(["thr_parent"])}>
           <RootComposeMobileRecents
             highlightedThreadId={null}
             projectNamesById={new Map()}
@@ -389,13 +400,8 @@ describe("mobile recents hierarchy interaction", () => {
       "bb.promptbox.contents-proj_mobile-thr_child-3",
       JSON.stringify({ text: "Continue child work", attachments: [] }),
     );
-    window.localStorage.setItem(
-      "bb.sidebar.collapsedThreads",
-      JSON.stringify(["thr_parent"]),
-    );
-
     render(
-      <TestProviders>
+      <TestProviders store={storeWithCollapsedThreads(["thr_parent"])}>
         <RootComposeMobileRecents
           highlightedThreadId={null}
           projectNamesById={new Map()}
@@ -427,13 +433,9 @@ describe("mobile recents hierarchy interaction", () => {
   });
 
   it("reveals a highlighted thread whose parent is collapsed", () => {
-    window.localStorage.setItem(
-      "bb.sidebar.collapsedThreads",
-      JSON.stringify(["thr_parent"]),
-    );
-
+    const store = storeWithCollapsedThreads(["thr_parent"]);
     render(
-      <TestProviders>
+      <TestProviders store={store}>
         <RootComposeMobileRecents
           highlightedThreadId="thr_child"
           projectNamesById={new Map()}
@@ -457,9 +459,7 @@ describe("mobile recents hierarchy interaction", () => {
     );
 
     expect(screen.getByText("Audit folder query paths")).not.toBeNull();
-    expect(window.localStorage.getItem("bb.sidebar.collapsedThreads")).toBe(
-      "[]",
-    );
+    expect(store.get(collapsedThreadIdsAtom)).toEqual([]);
   });
 
   it("de-emphasizes the provider tile on child rows only", () => {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -653,8 +653,7 @@ reach a server that has never stored a key uploads the value it finds in the
 old browser storage once, then deletes that copy, so an existing layout
 survives the upgrade; a second device that loses that race adopts the server
 value. A change on one device reaches every other connected window through the
-`ui-preferences-changed` broadcast without a reload. Collapsed rows and
-sections still live in the browser and move to the server in a follow-up.
+`ui-preferences-changed` broadcast without a reload.
 
 Sidebar width and open state stay in the browser because they depend on the
 window size.


### PR DESCRIPTION
## Human comments

## What was wrong

After #3304 the structural sidebar settings sync, but the six collapsed-id lists (projects, threads, environments, built-in sections, thread sections, machines) still live only in localStorage.

## What changed

Layer 3 of 3 (stack #3306). Base: #3304.

- `sidebarCollapsedAtoms.ts`: the six collapsed atoms become in-memory synced preferences; their `atomWithStorage` wrappers and the folder-era storage adapter are deleted. Every existing toggle site already uses functional updates, so conflicting writes from two devices re-apply on top of the server list instead of clobbering it, and toggles made while a request is in flight compose into the next one. `RootComposeMobileRecents.test.tsx` seeds the atom through a jotai store instead of localStorage.
- Ids of deleted entities are not pruned server-side. The client already drops a deleted project's id on the delete broadcast, a stale id renders nothing, and the registry caps each list at 10,000 entries.

## Review

One GPT-6 Astra review round requested changes. All three findings were in the layer 2 sync controller (writes rebased onto the submitted revision, composed functional updates through a conflict, and reconciling the authoritative response after pending writes settle). They are fixed and tested in #3304. A later simplification pass removed this layer's server-side pruning and write debounce as not worth their code.

## How you verified

- Sidebar, cache-owner, and mobile-recents suites plus the full `@bb/app`, `@bb/db`, and `@bb/server` public-route suites green; `pnpm exec turbo run typecheck --filter='...[origin/main]'` green.
- Live in the dev app: clicking a project chevron in one window stores the id on the server and a fresh window opens with the row collapsed; a CLI write containing an unknown id is stored as sent.

> AGENT GENERATED

🤖 Generated with [Claude Code](https://claude.com/claude-code)
