### PR TITLE
Fix Account Pool dropping Codex replies from conversation history

### DIFF
--- a/plugins/account-pool/src/codex-websocket.ts
+++ b/plugins/account-pool/src/codex-websocket.ts
@@ -22,6 +22,10 @@ const completedSchema = z
       .passthrough(),
   })
   .passthrough();
+const outputItemDoneSchema = z.object({
+  type: z.literal("response.output_item.done"),
+  item: z.json(),
+});
 
 interface SocketLog {
   debug(message: string): void;
@@ -150,6 +154,7 @@ export function createCodexWebSocketHandlers(
     const decoder = new TextDecoder();
     let buffered = "";
     let reachedEof = false;
+    const streamedOutput: z.infer<typeof envelopeSchema>["input"] = [];
     const emit = (block: string) => {
       const data = block
         .split(/\r?\n/u)
@@ -158,10 +163,15 @@ export function createCodexWebSocketHandlers(
         .join("\n");
       if (data.length === 0 || data === "[DONE]") return;
       const event = JSON.parse(data);
+      const outputItem = outputItemDoneSchema.safeParse(event);
+      if (outputItem.success) streamedOutput.push(outputItem.data.item);
       const completed = completedSchema.safeParse(event);
       if (completed.success) {
         lastId = completed.data.response.id;
-        lastOutput = completed.data.response.output;
+        lastOutput =
+          streamedOutput.length > 0
+            ? streamedOutput
+            : completed.data.response.output;
       }
       send(socket, JSON.stringify(event));
     };

--- a/plugins/account-pool/src/server.test.ts
+++ b/plugins/account-pool/src/server.test.ts
@@ -4509,6 +4509,88 @@ describe("Account Pool plugin", () => {
       }
     });
 
+    it.each(["empty", "omitted", "populated"])(
+      "preserves streamed Codex answers when completion output is %s",
+      async (completionOutput) => {
+        const seen: string[] = [];
+        const output = [
+          {
+            type: "reasoning",
+            id: "reasoning-one",
+            encrypted_content: "opaque",
+          },
+          {
+            type: "message",
+            id: "answer-one",
+            role: "assistant",
+            phase: "final_answer",
+            content: [{ type: "output_text", text: "The retry was broken." }],
+          },
+        ];
+        const fixture = await affinityFixture("codex", async (_input, init) => {
+          seen.push(
+            new TextDecoder().decode(
+              init?.body instanceof ArrayBuffer
+                ? init.body
+                : new ArrayBuffer(0),
+            ),
+          );
+          const events = [
+            ...output.map((item, output_index) => ({
+              type: "response.output_item.done",
+              output_index,
+              item,
+            })),
+            {
+              type: "response.completed",
+              response: {
+                id: `response-${seen.length}`,
+                ...(completionOutput === "omitted"
+                  ? {}
+                  : { output: completionOutput === "empty" ? [] : output }),
+              },
+            },
+          ];
+          return new Response(
+            events
+              .map((event) => `data: ${JSON.stringify(event)}\n\n`)
+              .join(""),
+            { headers: { "content-type": "text/event-stream" } },
+          );
+        });
+        const socket = await fixture.host.harness.experimental_openWebSocket(
+          "/v1/responses",
+          { headers: authHeaders(fixture.key) },
+        );
+        try {
+          const question = {
+            role: "user",
+            content: "Is the bug deterministic?",
+          };
+          const followup = { role: "user", content: "Please put up a PR" };
+          await socket.receive(
+            JSON.stringify({ type: "response.create", input: [question] }),
+          );
+          await vi.waitFor(() => expect(socket.sent).toHaveLength(3));
+          await socket.receive(
+            JSON.stringify({
+              type: "response.create",
+              previous_response_id: "response-1",
+              input: [followup],
+            }),
+          );
+          await vi.waitFor(() => expect(socket.sent).toHaveLength(6));
+          expect(JSON.parse(seen[1] ?? "{}").input).toEqual([
+            question,
+            ...output,
+            followup,
+          ]);
+        } finally {
+          await socket.close(1000, "done");
+        }
+      },
+    );
+
     it("keeps native Codex HTTP and WebSocket compaction continuations on the same account", async () => {
       const seen: Array<{ headers: Headers; body: string }> = [];
       const compacted = {


### PR DESCRIPTION
## Human comments

## What was wrong

Account Pool's Codex WebSocket-to-HTTP adapter reconstructed incremental requests from previous input, `response.completed.output`, and the new input. Real Codex streams deliver assistant messages in `response.output_item.done` but can finish with `response.completed.output: []`. The adapter therefore omitted the preceding answer from the next upstream request, even though Codex and BB displayed it correctly. This can cause the model to answer an earlier question again before addressing the latest request; streamed reasoning and tool calls were subject to the same loss.

## What changed

Collect completed output items from the SSE stream and retain them for `previous_response_id` continuations. Preserve each item intact, including message phases and encrypted reasoning. Fall back to the completion's output array when no streamed items were received, and avoid duplicating items when both event forms contain output.

## How you verified

- Added plugin-harness regression cases for empty, omitted, and populated completion output. Empty and omitted output failed before the fix; all three pass afterward. The assertion checks the actual forwarded input, including the answer and encrypted reasoning.
- Reproduced against the running pool with `gpt-5.6-sol`: ask for `ORCHID`, then ask for the preceding assistant message or `MISSING` if absent. The second answer was `MISSING`.
- Ran a temporary local WebSocket server using the source adapter, forwarding HTTP to the real upstream through the existing pool. Captured the second upstream request before and after the fix:

  ```text
  Before: user: reply ORCHID → user: inspect preceding assistant
  Result: MISSING

  After:  user: reply ORCHID → assistant: ORCHID (final_answer) → user: inspect preceding assistant
  Result: ORCHID
  ```

- `pnpm exec turbo run test typecheck --filter=bb-plugin-account-pool`: all 264 tests and typecheck passed.
- `bb plugin build plugins/account-pool`: passed.
- Formatting and `git diff --check`: passed.

> AGENT GENERATED
