### PR TITLE
Test Account Pool family failover after inline retry

### DIFF
--- a/plugins/account-pool/src/server.test.ts
+++ b/plugins/account-pool/src/server.test.ts
@@ -2239,6 +2239,52 @@ describe("Account Pool plugin", () => {
     });
   });
 
+  it("rotates when a same-account retry reveals a family limit", async () => {
+    const keys: string[] = [];
+    const fixture = await createFixture({
+      upstreamUrl: "https://upstream.example",
+      apiKey: "sk-one",
+      options: {
+        fetch: async (_input, init) => {
+          keys.push(new Headers(init?.headers).get("x-api-key") ?? "");
+          if (keys.length === 1) {
+            return Response.json(
+              { minute: true },
+              { status: 429, headers: { "retry-after": "0" } },
+            );
+          }
+          if (keys.length === 2) {
+            return Response.json(
+              { family: true },
+              {
+                status: 429,
+                headers: {
+                  "anthropic-ratelimit-unified-5h-status": "allowed",
+                  "anthropic-ratelimit-unified-7d-status": "allowed",
+                  "anthropic-ratelimit-unified-7d_oi-reset": "4102452000",
+                  "anthropic-ratelimit-unified-7d_oi-status": "rejected",
+                },
+              },
+            );
+          }
+          return Response.json({ rotated: true });
+        },
+      },
+    });
+    await addApiAccount(fixture, "sk-two");
+    const response = await fixture.host.harness.behavior.fetchHttp(
+      "POST",
+      "/v1/messages",
+      {
+        headers: authHeaders(fixture.key),
+        body: JSON.stringify({ model: "claude-fable-5" }),
+      },
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ rotated: true });
+    expect(keys).toEqual(["sk-one", "sk-one", "sk-two"]);
+  });
+
   it("refreshes usage on import and routes from its family observations", async () => {
     const authorizations: Array<string | undefined> = [];
     const usageCalls = new Map<string, number>();


### PR DESCRIPTION
## Human comments

## What was wrong

[PR #3053](https://github.com/get-bb/bb/pull/3053) correctly switched accounts when the first upstream response declared a model-family limit, but its short same-account retry used a separate response path. If the first response was an ordinary short 429 and the retry then declared a family limit, that second path returned the 429 without trying another eligible account. [PR #3117](https://github.com/get-bb/bb/pull/3117) later consolidated attempts into one loop and incidentally fixed the root cause on current `main`, but no regression test covered the original two-stage response sequence.

## What changed

Added a shipped Account Pooler plugin test using the Plugin SDK fake-host harness. It drives the exact sequence `sk-one` ordinary short 429, `sk-one` family-limit 429, then `sk-two` success, and asserts the client receives HTTP 200. There is no production, wire-contract, CLI, guide, documentation, credential, quota, or unrelated-provider change.

## How you verified

- Red on the [original landing](https://github.com/get-bb/bb/commit/c2d5bd3e810775144a5e08766a13021a9e29a1f2): HTTP 429 with attempts `sk-one, sk-one`; `sk-two` was not tried.
- Green on current `main`: the focused harness test passed with `sk-one, sk-one, sk-two` and HTTP 200.
- `pnpm exec turbo run test typecheck build --filter=bb-plugin-account-pool --concurrency=1 --continue --force` — 6 tasks passed; 10 test files and 262 tests passed; typecheck passed.
- `pnpm exec oxfmt --check plugins/account-pool/src/server.test.ts` and `git diff --check origin/main...HEAD` passed.

Part of #1552

> AGENT GENERATED
