### PR TITLE
Restore stale on-demand diff loading

### DIFF
--- a/apps/app/src/hooks/queries/use-environment-diff-patches.test.tsx
+++ b/apps/app/src/hooks/queries/use-environment-diff-patches.test.tsx
@@ -360,6 +360,44 @@ describe("useEnvironmentDiffPatches", () => {
     );
   });
 
+  it("loads on demand after a failed generation becomes stale", async () => {
+    const { wrapper } = createQueryClientTestHarness();
+    const patch: DiffPatchEntry = {
+      path: PATH,
+      patch: "fresh",
+      truncated: false,
+    };
+    vi.mocked(sdk.environments.diffPatch)
+      .mockRejectedValueOnce(new Error("Failed to fetch"))
+      .mockResolvedValueOnce(availableResponse(patch));
+    const { result } = renderHook(
+      () => useEnvironmentDiffPatches(ENVIRONMENT_ID, { target: TARGET }),
+      { wrapper },
+    );
+
+    act(() => result.current.loadPath(PATH));
+    await waitFor(() =>
+      expect(result.current.getPatchState(PATH)).toMatchObject({
+        status: "error",
+        error: "Failed to fetch",
+      }),
+    );
+
+    act(() => bumpDiffPatchFreshnessGeneration(ENVIRONMENT_ID));
+    expect(result.current.getPatchState(PATH).status).toBe("idle");
+    act(() => result.current.loadPath(PATH));
+
+    await waitFor(() =>
+      expect(sdk.environments.diffPatch).toHaveBeenCalledTimes(2),
+    );
+    await waitFor(() =>
+      expect(result.current.getPatchState(PATH)).toMatchObject({
+        status: "loaded",
+        patch: patch.patch,
+      }),
+    );
+  });
+
   it("rejects an older response and starts a newer request after a freshness change", async () => {
     const { wrapper, queryClient } = createQueryClientTestHarness();
     const staleRequest = createDeferredPromise<EnvironmentDiffPatchResponse>();

--- a/apps/app/src/hooks/queries/use-environment-diff-patches.ts
+++ b/apps/app/src/hooks/queries/use-environment-diff-patches.ts
@@ -372,6 +372,8 @@ export function useEnvironmentDiffPatches(
 
   const loadPath = useCallback(
     (path: string) => {
+      const currentFreshnessGeneration =
+        getDiffPatchFreshnessGeneration(environmentId);
       if (
         readDiffPatchEntry({ queryClient, identity, path }) !== undefined &&
         isDiffPatchEntryFresh({ queryClient, identity, path })
@@ -382,9 +384,10 @@ export function useEnvironmentDiffPatches(
         isLoadingForCurrentGeneration(
           inFlightRef.current.loading,
           path,
-          getDiffPatchFreshnessGeneration(environmentId),
+          currentFreshnessGeneration,
         ) ||
-        inFlightRef.current.errors.has(path)
+        inFlightRef.current.errors.get(path)?.generation ===
+          currentFreshnessGeneration
       ) {
         return;
       }


### PR DESCRIPTION
## Human comments

## What was wrong

`getPatchState` correctly hid an on-demand diff error after the workspace freshness generation advanced, but `loadPath` still rejected every path present in the error map. After a large-file diff request failed and a later workspace edit made that failure stale, the UI changed back to **Load diff** while the action remained inert until the panel was recreated.

## What changed

- Make `loadPath` block only errors from the current freshness generation, matching the existing automatic loader and rendered-state rules.
- Reuse one captured current generation for both the loading and error guards.
- Add a regression that fails a request, advances freshness, invokes `loadPath` again, and verifies that the fresh request and patch complete.
- This is app-local query state only; there are no host-daemon wire, SDK, CLI, guide, or protocol-version changes.

## How you verified

- The focused regression failed before the production change because the second request never started, then passed after the fix.
- `pnpm exec turbo run test --filter=@bb/app --force -- src/hooks/queries/use-environment-diff-patches.test.tsx src/hooks/cache-owners/environment-workspace-cache-owner.test.ts src/hooks/cache-owners/cache-owner-registry.test.ts src/hooks/environment-cache-effects.test.ts src/hooks/realtime-cache-effects.test.ts src/hooks/system-cache-effects.test.ts` — 6 files, 88 tests passed.
- `pnpm exec turbo run typecheck build lint --filter=@bb/app --force` — passed; lint reported 187 existing warnings and 0 errors.
- Exact changed-file formatting and `git diff --check` passed.
- Desktop and 390×844 coarse-pointer QA reproduced the inert action before the fix and loaded the 1,200-line patches after it.


> AGENT GENERATED