### PR TITLE
Account Pooler: rebuild Codex WebSocket history from streamed output items

### DIFF
--- a/plugins/account-pool/src/codex-websocket.test.ts
+++ b/plugins/account-pool/src/codex-websocket.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ExperimentalPluginWebSocket } from "@get-bb/plugin-sdk";
+import { createCodexWebSocketHandlers } from "./codex-websocket.js";
+import type { AccountPoolHub } from "./hub.js";
+
+function sse(events: ReadonlyArray<Record<string, unknown>>): string {
+  return `${events
+    .map(
+      (event) => `event: ${String(event.type)}\ndata: ${JSON.stringify(event)}`,
+    )
+    .join("\n\n")}\n\ndata: [DONE]\n\n`;
+}
+
+function createFixture(upstreamBodies: string[]) {
+  const forwarded: unknown[] = [];
+  const hub = {
+    authenticate: async () => "host-one",
+    handleAuthenticated: async (request: Request) => {
+      forwarded.push(await request.json());
+      const body = upstreamBodies.shift();
+      if (body === undefined) throw new Error("No upstream body queued.");
+      return new Response(body, {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      });
+    },
+  };
+  const sent: string[] = [];
+  const socket: ExperimentalPluginWebSocket = {
+    readyState: 1,
+    send(data) {
+      sent.push(String(data));
+    },
+    close: vi.fn(),
+  };
+  const request = new Request("http://account-pool/v1/responses");
+  const handlers = createCodexWebSocketHandlers(
+    { request, url: new URL(request.url), headers: new Headers() },
+    hub as unknown as AccountPoolHub,
+    { debug: () => undefined },
+  );
+  return { handlers, socket, sent, forwarded };
+}
+
+async function frame(
+  fixture: ReturnType<typeof createFixture>,
+  payload: Record<string, unknown>,
+  expectedSent: number,
+): Promise<void> {
+  await fixture.handlers.onMessage?.(
+    fixture.socket,
+    JSON.stringify({ type: "response.create", ...payload }),
+  );
+  await vi.waitFor(() => expect(fixture.sent).toHaveLength(expectedSent));
+}
+
+describe("createCodexWebSocketHandlers", () => {
+  it("replays streamed output items when response.completed omits them", async () => {
+    const message = { type: "message", id: "msg-1", role: "assistant" };
+    const toolCall = { type: "custom_tool_call", call_id: "call-1" };
+    const fixture = createFixture([
+      sse([
+        { type: "response.created", response: { id: "resp-1" } },
+        { type: "response.output_item.done", item: message },
+        { type: "response.output_item.done", item: toolCall },
+        { type: "response.completed", response: { id: "resp-1", output: [] } },
+      ]),
+      sse([
+        { type: "response.created", response: { id: "resp-2" } },
+        { type: "response.completed", response: { id: "resp-2", output: [] } },
+      ]),
+    ]);
+    await fixture.handlers.onOpen?.(fixture.socket);
+    await frame(fixture, { input: [{ type: "message", id: "user-1" }] }, 4);
+    const toolOutput = { type: "custom_tool_call_output", call_id: "call-1" };
+    await frame(
+      fixture,
+      { previous_response_id: "resp-1", input: [toolOutput] },
+      6,
+    );
+    expect(fixture.forwarded[1]).toMatchObject({
+      input: [{ type: "message", id: "user-1" }, message, toolCall, toolOutput],
+    });
+  });
+
+  it("keeps the previous answer across turns after a full request", async () => {
+    const answer = { type: "message", id: "msg-1", role: "assistant" };
+    const fixture = createFixture([
+      sse([
+        { type: "response.output_item.done", item: answer },
+        { type: "response.completed", response: { id: "resp-1", output: [] } },
+      ]),
+      sse([
+        { type: "response.completed", response: { id: "resp-2", output: [] } },
+      ]),
+    ]);
+    await fixture.handlers.onOpen?.(fixture.socket);
+    await frame(fixture, { input: [{ type: "message", id: "question-1" }] }, 2);
+    await frame(
+      fixture,
+      {
+        previous_response_id: "resp-1",
+        input: [{ type: "message", id: "question-2" }],
+      },
+      3,
+    );
+    expect(fixture.forwarded[1]).toMatchObject({
+      input: [
+        { type: "message", id: "question-1" },
+        answer,
+        { type: "message", id: "question-2" },
+      ],
+    });
+  });
+
+  it("falls back to the completed output when no items were streamed", async () => {
+    const answer = { type: "message", id: "msg-1", role: "assistant" };
+    const fixture = createFixture([
+      sse([
+        {
+          type: "response.completed",
+          response: { id: "resp-1", output: [answer] },
+        },
+      ]),
+      sse([
+        { type: "response.completed", response: { id: "resp-2", output: [] } },
+      ]),
+    ]);
+    await fixture.handlers.onOpen?.(fixture.socket);
+    await frame(fixture, { input: [{ type: "message", id: "question-1" }] }, 1);
+    await frame(
+      fixture,
+      {
+        previous_response_id: "resp-1",
+        input: [{ type: "message", id: "question-2" }],
+      },
+      2,
+    );
+    expect(fixture.forwarded[1]).toMatchObject({
+      input: [
+        { type: "message", id: "question-1" },
+        answer,
+        { type: "message", id: "question-2" },
+      ],
+    });
+  });
+});

--- a/plugins/account-pool/src/codex-websocket.ts
+++ b/plugins/account-pool/src/codex-websocket.ts
@@ -22,6 +22,13 @@ const completedSchema = z
       .passthrough(),
   })
   .passthrough();
+const outputItemDoneSchema = z
+  .object({
+    type: z.literal("response.output_item.done"),
+    item: z.json(),
+  })
+  .passthrough();
+type ResponseInput = z.infer<typeof envelopeSchema>["input"];
 
 interface SocketLog {
   debug(message: string): void;
@@ -34,8 +41,8 @@ export function createCodexWebSocketHandlers(
 ): ExperimentalPluginWebSocketHandlers {
   let authenticatedHostId: string | null = null;
   let lastId: string | null = null;
-  let lastInput: z.infer<typeof envelopeSchema>["input"] = [];
-  let lastOutput: z.infer<typeof envelopeSchema>["input"] = [];
+  let lastInput: ResponseInput = [];
+  let lastOutput: ResponseInput = [];
   let prewarms = 0;
   let closed = false;
   let activeForward: AbortController | null = null;
@@ -150,6 +157,7 @@ export function createCodexWebSocketHandlers(
     const decoder = new TextDecoder();
     let buffered = "";
     let reachedEof = false;
+    const streamedOutput: ResponseInput = [];
     const emit = (block: string) => {
       const data = block
         .split(/\r?\n/u)
@@ -158,10 +166,15 @@ export function createCodexWebSocketHandlers(
         .join("\n");
       if (data.length === 0 || data === "[DONE]") return;
       const event = JSON.parse(data);
+      const outputItemDone = outputItemDoneSchema.safeParse(event);
+      if (outputItemDone.success) streamedOutput.push(outputItemDone.data.item);
       const completed = completedSchema.safeParse(event);
       if (completed.success) {
         lastId = completed.data.response.id;
-        lastOutput = completed.data.response.output;
+        lastOutput =
+          streamedOutput.length > 0
+            ? [...streamedOutput]
+            : completed.data.response.output;
       }
       send(socket, JSON.stringify(event));
     };

--- a/plugins/account-pool/src/server.test.ts
+++ b/plugins/account-pool/src/server.test.ts
@@ -528,12 +528,12 @@ describe("Account Pool plugin", () => {
         `event: response.created\ndata: ${JSON.stringify({
           type: "response.created",
           response: { id },
+        })}\n\nevent: response.output_item.done\ndata: ${JSON.stringify({
+          type: "response.output_item.done",
+          item: { type: "message", id: `message-${responseNumber}` },
         })}\n\nevent: response.completed\ndata: ${JSON.stringify({
           type: "response.completed",
-          response: {
-            id,
-            output: [{ type: "message", id: `message-${responseNumber}` }],
-          },
+          response: { id, output: [] },
         })}\n\ndata: [DONE]\n\n`,
       );
     });
@@ -677,11 +677,12 @@ describe("Account Pool plugin", () => {
         input: [{ type: "message", id: "delta-one" }],
       }),
     );
-    await vi.waitFor(() => expect(socket.sent).toHaveLength(3));
+    await vi.waitFor(() => expect(socket.sent).toHaveLength(4));
     expect(JSON.parse(String(socket.sent[1]))).toMatchObject({
       type: "response.created",
     });
-    const first = completedResponse(socket.sent[2]);
+    const first = completedResponse(socket.sent[3]);
+    expect(first.response.output).toEqual([]);
     await socket.receive(
       JSON.stringify({
         type: "response.create",
@@ -690,12 +691,14 @@ describe("Account Pool plugin", () => {
         input: [{ type: "message", id: "delta-two" }],
       }),
     );
-    await vi.waitFor(() => expect(socket.sent).toHaveLength(5));
+    await vi.waitFor(() => expect(socket.sent).toHaveLength(7));
     expect(socket.sent.map((frame) => JSON.parse(String(frame)).type)).toEqual([
       "response.completed",
       "response.created",
+      "response.output_item.done",
       "response.completed",
       "response.created",
+      "response.output_item.done",
       "response.completed",
     ]);
     expect(seen[1]?.accountId).not.toBe(seen[2]?.accountId);


### PR DESCRIPTION
## Human comments

## What was wrong

Codex talks to the Account Pooler over its Responses WebSocket transport: after the first request on a socket it sends `previous_response_id` plus only the new input items, and the pooler rebuilds the full history itself before forwarding one HTTPS request upstream. The pooler took the previous response's items from the `response.completed` event, but the ChatGPT Codex backend streams them only as `response.output_item.done` events and sends `"output": []` in `response.completed` (verified with a direct probe through the pooler). Every incremental request therefore lost the previous response. Within a turn the API rejected the orphaned tool output with "No tool call found for custom tool call output" and Codex silently retried on a fresh socket, which is why Codex logs show a reconnect for almost every request. At a turn boundary the request is valid without the previous answer, so the model saw the earlier question unanswered and answered it again before the new one. Codex's own log database (`~/.codex/logs_2.sqlite`) records hundreds of these rejections per day since the WebSocket routing landed in #3056.

## What changed

`plugins/account-pool/src/codex-websocket.ts` accumulates `response.output_item.done` items in stream order for each forwarded response and uses them as the previous output when the next frame carries `previous_response_id`. It falls back to the completed event's `output` only when no items were streamed. This mirrors how Codex builds its own delta baseline. No wire, CLI, or documentation changes.

## How you verified

- New `plugins/account-pool/src/codex-websocket.test.ts` drives the handler with a fake hub: a tool-call continuation within a turn, a follow-up question across a turn boundary, and the completed-output fallback. The first two fail on the previous handler and pass now.
- The existing integration test's fake upstream now streams `response.output_item.done` and sends an empty `output` in `response.completed`, matching the real backend, and its history assertion still holds.
- `pnpm exec turbo run test typecheck lint --filter=bb-plugin-account-pool` passes.

> AGENT GENERATED

🤖 Generated with [Claude Code](https://claude.com/claude-code)
