### PR TITLE
Narrow streaming directive bypass

### DIFF
--- a/apps/app/src/components/thread/timeline/ConversationMessageContent.streaming.test.tsx
+++ b/apps/app/src/components/thread/timeline/ConversationMessageContent.streaming.test.tsx
@@ -101,8 +101,25 @@ describe("ConversationMessageContent streaming split", () => {
     expect(markdownRenders).toEqual(["Second paragraph.\n\n`live code grows`"]);
   });
 
+  it("repairs unfinished formatting after ordinary double-colon text", () => {
+    const source = "Call Namespace::Method, then **live bold";
+    const { view, update } = renderAssistantMessage(source, true);
+    expect(documents(view.container)).toEqual([
+      "Call Namespace::Method, then **live bold**",
+    ]);
+
+    update(`Settled.\n\nSecond paragraph.\n\n${source}`, true);
+    expect(documents(view.container)).toEqual([
+      "Settled.\n\n",
+      `Second paragraph.\n\n${source}**`,
+    ]);
+  });
+
   it.each([
     "::inline-vis[label",
+    "  ::inline-vis[label",
+    "> ::inline-vis[label",
+    "- ::inline-vis[label",
     '::inline-vis{file="[draft.html"}',
     '::inline-vis{file="a__b.html"}',
     '::unknown{title="**source"}',

--- a/apps/app/src/components/thread/timeline/ConversationMessageContent.tsx
+++ b/apps/app/src/components/thread/timeline/ConversationMessageContent.tsx
@@ -124,6 +124,8 @@ const ASSISTANT_THREAD_MENTIONS: MarkdownThreadMentions = {
 const STREAMING_SETTLED_MARKDOWN_CLASS_NAME = "[&>p:last-child]:mb-2";
 const STREAMING_TAIL_MARKDOWN_CLASS_NAME =
   "[&>h1:first-child]:mt-4 [&>h2:first-child]:mt-4 [&>h3:first-child]:mt-3 [&>h4:first-child]:mt-3 [&>h5:first-child]:mt-2 [&>h6:first-child]:mt-2";
+const STREAMING_MARKDOWN_BYPASS_PATTERN =
+  /^(?:[ \t]*(?:>|[-+*]|\d{1,9}[.)]))*[ \t]*::[a-zA-Z]|`{3}|~{3}/mu;
 
 interface ConversationMessageContentAssistantProps
   extends ConversationMessageContentBaseProps, AssistantMessageRowIdentity {
@@ -512,7 +514,7 @@ function AssistantConversationMessage({
   );
   const liveMarkdown = useMemo(() => {
     const tail = streamingSplit?.tail ?? text;
-    if (!streaming || /::[a-zA-Z]|`{3}|~{3}/.test(tail)) {
+    if (!streaming || STREAMING_MARKDOWN_BYPASS_PATTERN.test(tail)) {
       return tail;
     }
     return remend(tail, {


### PR DESCRIPTION
## Human comments

## What was wrong

The streaming Markdown repair guard treated any `::` followed by a letter anywhere in the live tail as a directive. Ordinary scoped names such as `Namespace::Method` therefore disabled repair for unrelated unfinished formatting later in a streaming response.

## What changed

Directive detection is now anchored to Markdown block positions, including indentation, blockquotes, and list prefixes, while the existing fenced-code bypass remains unchanged. The regression coverage verifies that scoped names no longer suppress streaming repair and that real directives in supported block positions still bypass it.

## How you verified

- `pnpm exec turbo run test --filter=@bb/app --force -- src/components/thread/timeline/ConversationMessageContent.streaming.test.tsx src/components/thread/timeline/ConversationMessageContent.streaming-render.test.tsx src/components/thread/timeline/ConversationMessageContent.test.tsx src/components/thread/timeline/streaming-markdown-split.test.ts src/components/ui/markdown-message-directives.test.tsx src/components/ui/markdown-local-file-link-normalize.test.ts` (77 tests passed)
- `pnpm exec turbo run typecheck lint build --filter=@bb/app --force` (5 tasks passed; lint had 0 errors)
- Targeted formatting and `git diff --check origin/main...HEAD` passed
- Replayed the streaming case in desktop and 390×844 compact browser viewports during implementation


> AGENT GENERATED