### PR TITLE
Close streaming inline code before emphasis

### DIFF
--- a/apps/app/src/components/thread/timeline/ConversationMessageContent.streaming-render.test.tsx
+++ b/apps/app/src/components/thread/timeline/ConversationMessageContent.streaming-render.test.tsx
@@ -95,6 +95,25 @@ describe("assistant streaming Markdown rendering", () => {
     },
   );
 
+  it.each([
+    ["**Live bold and `live code", ["strong"]],
+    ["__Live bold and `live code", ["strong"]],
+    ["*Live italic and `live code", ["em"]],
+    ["_Live italic and `live code", ["em"]],
+    ["***Live bold italic and `live code", ["strong", "em"]],
+  ])(
+    "keeps repaired inline code inside outer emphasis: %s",
+    (source, outer) => {
+      const view = render(assistant(source));
+      for (const selector of outer) {
+        expect(
+          view.container.querySelector(`${selector} code`)?.textContent,
+        ).toBe("live code");
+      }
+      expect(view.container.textContent).not.toMatch(/[*_]/u);
+    },
+  );
+
   it("shows incomplete links as text and mounts links only after their destination completes", () => {
     const view = render(assistant("Read [the docs](https://example"));
     expect(screen.queryByRole("link")).toBeNull();

--- a/apps/app/src/components/thread/timeline/ConversationMessageContent.tsx
+++ b/apps/app/src/components/thread/timeline/ConversationMessageContent.tsx
@@ -517,7 +517,7 @@ function AssistantConversationMessage({
     if (!streaming || STREAMING_MARKDOWN_BYPASS_PATTERN.test(tail)) {
       return tail;
     }
-    return remend(tail, {
+    return remend(closeUnterminatedMarkdownCodeSpan(tail), {
       linkMode: "text-only",
       comparisonOperators: false,
       htmlTags: false,


### PR DESCRIPTION
## Human comments

## What was wrong

During streaming, `remend` repairs outer bold and italic markers before it closes an unfinished inline-code span. When an emphasized phrase ended in partial inline code, the generated emphasis closer could therefore land inside the code span, leaving raw outer markers visible and applying the wrong styling.

## What changed

The live Markdown tail now passes through the existing shared `closeUnterminatedMarkdownCodeSpan` helper before `remend` repairs the remaining Markdown. Regression cases cover asterisk and underscore bold, italic, and bold-italic forms while preserving the existing directive, link, image, completion, interruption, and settled-tail behavior.

## How you verified

- `pnpm exec turbo run test --filter=@bb/app --force -- src/components/thread/timeline/ConversationMessageContent.streaming.test.tsx src/components/thread/timeline/ConversationMessageContent.streaming-render.test.tsx src/components/thread/timeline/ConversationMessageContent.test.tsx src/components/thread/timeline/GeneratedConversationMessage.test.tsx src/components/thread/timeline/streaming-markdown-split.test.ts src/components/ui/markdown-message-directives.test.tsx src/components/ui/markdown-local-file-link-normalize.test.ts` (102 tests passed after rebasing onto the directive-bypass fix)
- `pnpm exec turbo run typecheck lint build --filter=@bb/app --force` (5 tasks passed; lint had 0 errors)
- Targeted formatting and `git diff --check origin/main...HEAD` passed
- Replayed the affected rendering in desktop and 390×844 compact browser viewports during implementation


> AGENT GENERATED