### PR TITLE
Test Pi Bun delivery in packages CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,12 @@ jobs:
           pnpm-version: ${{ env.PNPM_VERSION }}
           cache-prefix: test-${{ matrix.shard }}
 
+      - name: Setup Bun
+        if: ${{ matrix.shard == 'packages' }}
+        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76
+        with:
+          bun-version: "1.3.14"
+
       - name: Test
         run: pnpm exec turbo run test ${{ matrix.filter }} --cache-dir=.turbo/cache --output-logs=new-only --concurrency=4 ${{ matrix.args }}
 

--- a/plugins/provider-pi/src/bridge/bridge.bun-runtime.test.ts
+++ b/plugins/provider-pi/src/bridge/bridge.bun-runtime.test.ts
@@ -24,9 +24,12 @@ afterEach(async () => {
 });
 
 function bunBinary(): string | null {
-  // spawnSync failure (bun absent) and a broken-but-present bun both skip.
   const probe = spawnSync("bun", ["--version"], { encoding: "utf8" });
-  if (probe.status !== 0 || !probe.stdout?.trim()) return null;
+  if (probe.status !== 0 || !probe.stdout?.trim()) {
+    if (process.env.CI)
+      throw new Error("Bun is required for the Pi runtime regression in CI");
+    return null;
+  }
   return "bun";
 }
 
@@ -38,65 +41,75 @@ function bunBinary(): string | null {
 it.skipIf(bunBinary() === null)(
   "delivers dynamic tool results when pi runs under the Bun runtime",
   async () => {
-  const bun = "bun";
-  vi.stubEnv(PI_BRIDGE_COMMAND_ENV, bun);
-  vi.stubEnv(PI_BRIDGE_ARGS_ENV, JSON.stringify([fakePiPath]));
+    const bun = "bun";
+    vi.stubEnv(PI_BRIDGE_COMMAND_ENV, bun);
+    vi.stubEnv(PI_BRIDGE_ARGS_ENV, JSON.stringify([fakePiPath]));
 
-  const threadId = "thr_bun_dyn_tool";
-  const started = await harness.request((nextId += 1), "thread/start", {
-    threadId,
-    cwd: harness.workspaceDir,
-    instructionMode: "append",
-    options: FULL_PERMISSION_OPTIONS,
-    dynamicTools: [
-      {
-        name: "bb_probe",
-        description: "A bb tool.",
-        inputSchema: { type: "object", properties: { value: { type: "string" } } },
-      },
-    ],
-  });
-  expect(started.error, JSON.stringify(started)).toBeUndefined();
+    const threadId = "thr_bun_dyn_tool";
+    const started = await harness.request((nextId += 1), "thread/start", {
+      threadId,
+      cwd: harness.workspaceDir,
+      instructionMode: "append",
+      options: FULL_PERMISSION_OPTIONS,
+      dynamicTools: [
+        {
+          name: "bb_probe",
+          description: "A bb tool.",
+          inputSchema: {
+            type: "object",
+            properties: { value: { type: "string" } },
+          },
+        },
+      ],
+    });
+    expect(started.error, JSON.stringify(started)).toBeUndefined();
 
-  handleLine(
-    JSON.stringify({
-      jsonrpc: "2.0",
-      id: (nextId += 1),
-      method: "turn/start",
-      params: {
-        threadId,
-        providerThreadId: threadId,
-        clientRequestId: "creq_bu23456789",
-        input: [{ type: "text", text: `/tool bb_probe ${JSON.stringify({ value: "hi" })}`, mentions: [] }],
-        options: FULL_PERMISSION_OPTIONS,
-      },
-    }),
-  );
-  const toolCall = await harness.waitForMessage(
-    (m) => m.method === "item/tool/call",
-    "the dynamic tool call",
-  );
-  handleLine(
-    JSON.stringify({
-      jsonrpc: "2.0",
-      id: toolCall.id,
-      result: {
-        contentItems: [{ type: "inputText", text: "bun-result-text" }],
-        success: true,
-      },
-    }),
-  );
-  await harness.waitForMessage(
-    () =>
-      harness
-        .deltasOf(threadId)
-        .some(
-          (d) =>
-            d.kind === "item.textDelta" && String(d.text).includes("Tool said: bun-result-text"),
-        ),
-    "the tool result to reach pi under Bun",
-  );
-  await harness.waitForDelta(threadId, (d) => d.kind === "turn.boundary");
+    handleLine(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: (nextId += 1),
+        method: "turn/start",
+        params: {
+          threadId,
+          providerThreadId: threadId,
+          clientRequestId: "creq_bu23456789",
+          input: [
+            {
+              type: "text",
+              text: `/tool bb_probe ${JSON.stringify({ value: "hi" })}`,
+              mentions: [],
+            },
+          ],
+          options: FULL_PERMISSION_OPTIONS,
+        },
+      }),
+    );
+    const toolCall = await harness.waitForMessage(
+      (m) => m.method === "item/tool/call",
+      "the dynamic tool call",
+    );
+    handleLine(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: toolCall.id,
+        result: {
+          contentItems: [{ type: "inputText", text: "bun-result-text" }],
+          success: true,
+        },
+      }),
+    );
+    await harness.waitForMessage(
+      () =>
+        harness
+          .deltasOf(threadId)
+          .some(
+            (d) =>
+              d.kind === "item.textDelta" &&
+              String(d.text).includes("Tool said: bun-result-text"),
+          ),
+      "the tool result to reach pi under Bun",
+    );
+    await harness.waitForDelta(threadId, (d) => d.kind === "turn.boundary");
   },
   90_000,
 );


### PR DESCRIPTION
## Human comments

## What was wrong

The real-Bun regression test introduced with [PR #3095](https://github.com/get-bb/bb/pull/3095) skipped when Bun was absent, while the packages CI shard did not provision Bun. A regression in Pi's shipped Bun-specific dynamic tool-result delivery could therefore pass CI unnoticed.

## What changed

- Provision Bun 1.3.14 only for the packages test shard through an immutable `oven-sh/setup-bun` action commit.
- Make missing or broken Bun fail the regression suite under CI while retaining the skip for ordinary Bun-less local runs.
- Format the affected test file.

There are no production, wire-contract, CLI, SDK, or documentation changes, so no host daemon protocol bump is needed.

## How you verified

- Red: `CI=true` with Bun removed from `PATH` fails with `Bun is required for the Pi runtime regression in CI`.
- Green: the focused test passes with an isolated Bun 1.3.14 binary; without CI and Bun it still skips.
- `pnpm exec turbo run test typecheck --filter=bb-plugin-provider-pi --force` — 156/156 tests and 6/6 tasks passed.
- `pnpm exec turbo run build --filter=bb-app` — 12/12 tasks passed.
- The CI workflow tests passed 2/2; affected formatting, YAML parsing, and diff checks passed.
- The exact packages-shard command was attempted twice locally and stopped only on an unrelated macOS concurrent Electron `SIGABRT`; that desktop test passed 1/1 in isolation. GitHub's Ubuntu packages job is the authoritative exact-shard run.


> AGENT GENERATED