### PR TITLE
Bound compact environment picker labels

### DIFF
--- a/apps/app/src/app.css
+++ b/apps/app/src/app.css
@@ -368,6 +368,10 @@
     [data-promptbox] [data-promptbox-icon-only-control] {
       flex-shrink: 0;
     }
+
+    [data-promptbox] [data-promptbox-shrinkable-control] {
+      flex-shrink: 1 !important;
+    }
   }
 
   @container promptbox-shell (max-width: 34rem) {
@@ -383,6 +387,10 @@
 
     [data-promptbox-shell] [data-promptbox-icon-only-control] {
       flex-shrink: 0;
+    }
+
+    [data-promptbox-shell] [data-promptbox-shrinkable-control] {
+      flex-shrink: 1 !important;
     }
 
     [data-promptbox-shell] [data-promptbox-project-control] {

--- a/apps/app/src/app.css.test.ts
+++ b/apps/app/src/app.css.test.ts
@@ -14,6 +14,16 @@ describe("app.css chrome geometry", () => {
   });
 });
 
+describe("app.css compact prompt controls", () => {
+  it("lets designated controls shrink in both compact containers", () => {
+    expect(
+      css.match(
+        /\[data-promptbox(?:-shell)?\] \[data-promptbox-shrinkable-control\] \{\s*flex-shrink: 1 !important;\s*\}/g,
+      ),
+    ).toHaveLength(2);
+  });
+});
+
 describe("app.css sidebar drag cursor", () => {
   it("scopes the grabbing cursor to the sidebar panel on fine pointers only", () => {
     expect(css).not.toMatch(/body\[data-sidebar-dragging="true"\]\s*\*/);

--- a/apps/app/src/components/pickers/EnvironmentPicker.test.tsx
+++ b/apps/app/src/components/pickers/EnvironmentPicker.test.tsx
@@ -110,6 +110,40 @@ afterEach(() => {
 });
 
 describe("EnvironmentPickerUI", () => {
+  it("bounds arbitrary provider labels without changing selection", () => {
+    const verboseProvider = {
+      ...checkoutProvider,
+      displayName: "Project checkout with a deliberately long provider label",
+    };
+    const onSelectProvider = vi.fn();
+    render(
+      <EnvironmentPickerUI
+        value="provider:project-checkout"
+        sources={sources}
+        host={host}
+        isLocal
+        providers={[verboseProvider, branchProvider]}
+        selectedProviderHostId={host.id}
+        onSelectProvider={onSelectProvider}
+        className="shrink-0"
+        modal={false}
+      />,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Environment" });
+    expect(trigger.dataset.promptboxShrinkableControl).toBe("");
+    expect(
+      trigger.querySelector<HTMLElement>("[data-promptbox-compact-label]")
+        ?.classList,
+    ).toContain("truncate");
+
+    fireEvent.pointerDown(trigger, { button: 0 });
+    fireEvent.click(
+      screen.getByRole("menuitem", { name: /New branch workspace/u }),
+    );
+    expect(onSelectProvider).toHaveBeenCalledWith(branchProvider, host.id);
+  });
+
   it("omits providers absent from scoped eligibility and retains eligible setup rows", () => {
     const setupProvider = {
       ...optionalInputsProvider,

--- a/apps/app/src/components/pickers/EnvironmentPicker.tsx
+++ b/apps/app/src/components/pickers/EnvironmentPicker.tsx
@@ -249,7 +249,7 @@ export function EnvironmentPickerUI({
           size="sm"
           aria-label="Environment"
           disabled={disabled}
-          data-promptbox-icon-only-control=""
+          data-promptbox-shrinkable-control=""
           className={cn(
             OPTION_BASE_CLASS_NAME,
             !disabled && OPTION_INTERACTIVE_CLASS_NAME,


### PR DESCRIPTION
## Human comments

## What was wrong

The compact prompt-box layout forced the Environment trigger not to shrink, even though provider display names can be arbitrarily long. A long label could therefore extend over the neighboring Permission control, causing pointer input in the apparent Environment area to activate Permission instead.

## What changed

The Environment trigger now opts into a dedicated shrinkable-control contract. Both compact prompt-box container owners allow that control to shrink so its existing ellipsis behavior can bound the label, while the base `shrink-0` behavior remains unchanged outside compact containers. Regression coverage checks the marker, both compact CSS rules, truncation, accessible lookup, and provider selection.

## How you verified

- `pnpm exec turbo run test --filter=@bb/app --force -- src/components/pickers/EnvironmentPicker.test.tsx src/app.css.test.ts` (26 tests passed)
- `pnpm exec turbo run typecheck lint build --filter=@bb/app --force` (5 tasks passed; lint had 0 errors)
- Targeted formatting and `git diff --check origin/main...HEAD` passed
- Verified pointer routing, keyboard selection, truncation, and focus restoration at 390×844, plus the desktop selection flow at 1280×900 during implementation


> AGENT GENERATED