### PR TITLE
Fix lost environment launch rechecks

### DIFF
--- a/apps/server/src/services/threads/thread-environment-providers.ts
+++ b/apps/server/src/services/threads/thread-environment-providers.ts
@@ -75,12 +75,25 @@ function reaskLater(
         return;
       }
       ask.nextAskTimer = null;
-      void advanceThreadProvisioning(deps, { threadId }).catch((error) => {
-        deps.logger.warn(
-          { threadId, ...runtimeErrorLogFields(deps.config, error) },
-          "Failed to re-ask an environment provider",
-        );
-      });
+      void advanceThreadProvisioning(deps, { threadId })
+        .catch((error) => {
+          deps.logger.warn(
+            { threadId, ...runtimeErrorLogFields(deps.config, error) },
+            "Failed to re-ask an environment provider",
+          );
+        })
+        .finally(() => {
+          const askIsActive = listActiveThreadProviderAsks().some(
+            (entry) => entry.threadId === threadId && entry.ask === ask,
+          );
+          if (
+            askIsActive &&
+            ask.recheckRequested &&
+            ask.nextAskTimer === null
+          ) {
+            ask.nextAskTimer = reaskLater(deps, ask, threadId, Date.now());
+          }
+        });
     },
     Math.min(Math.max(0, at - Date.now()), MAX_TIMER_DELAY_MS),
   );

--- a/apps/server/test/threads/environment-providers.test.ts
+++ b/apps/server/test/threads/environment-providers.test.ts
@@ -508,6 +508,70 @@ describe("environment providers are asked inside provisioning", () => {
     });
   });
 
+  it("preserves a launch recheck that overlaps an in-flight provisioning advance", async () => {
+    await withTestHarness(async (harness) => {
+      const createReady = createDeferredPromise<void>();
+      const firstAdvanceFinished = createDeferredPromise<void>();
+      const releaseFirstAdvance = createDeferredPromise<void>();
+      const { environment, host, project } = seedTargetFixture(
+        harness,
+        "host-target-overlapping-recheck",
+        { environmentProviderId: PROVIDER_ID },
+      );
+      installTarget({
+        provision: async () => {
+          await createReady.promise;
+          return readyAt(host);
+        },
+      });
+
+      let pendingAdvance: Promise<void> | null = null;
+      let coalescedAdvanceCount = 0;
+      harness.deps.lifecycleDedupers.threadProvisionAdvance = {
+        run(_threadId, task) {
+          if (pendingAdvance !== null) {
+            coalescedAdvanceCount += 1;
+            return pendingAdvance;
+          }
+          const started = (async () => {
+            await task();
+            firstAdvanceFinished.resolve();
+            await releaseFirstAdvance.promise;
+          })();
+          pendingAdvance = started.finally(() => {
+            pendingAdvance = null;
+          });
+          return pendingAdvance;
+        },
+      };
+
+      try {
+        const created = await createTargetThread(harness, {
+          projectId: project.id,
+        });
+        await firstAdvanceFinished.promise;
+        createReady.resolve();
+        await vi.waitFor(() => {
+          expect(getEnvironmentLaunch(harness.db, created.id)?.phase).toBe(
+            "ready",
+          );
+        });
+        await vi.waitFor(() => {
+          expect(coalescedAdvanceCount).toBeGreaterThan(0);
+        });
+        releaseFirstAdvance.resolve();
+        await vi.waitFor(() => {
+          expect(getThread(harness.db, created.id)?.environmentId).toBe(
+            environment.id,
+          );
+        });
+      } finally {
+        createReady.resolve();
+        releaseFirstAdvance.resolve();
+      }
+    });
+  });
+
   it("refuses a host answer naming a path another provider's row holds", async () => {
     await withTestHarness(async (harness) => {
       const { host, project, session } = seedTargetFixture(


### PR DESCRIPTION
## Human comments

## What was wrong

Environment-provider completion calls `recheckEnvironmentLaunch`, which clears the fallback timer and schedules an immediate provisioning advance. If that timer fires while another advance for the thread is still in the lifecycle deduper, the deduper returns the in-flight promise without running the new task. The completion signal is then lost, leaving the durable launch ready but the thread permanently in `starting`. CPU contention changes the likelihood but is not the root cause. This matches the failed [CI run](https://github.com/get-bb/bb/actions/runs/34287478642) and [job](https://github.com/get-bb/bb/actions/runs/34287478642/job/102266289404), where the second turn ended with the checkout restoration step started and no terminal provisioning event.

## What changed

The provider re-ask timer now checks, after an advance settles, whether its recheck signal was left unconsumed. It schedules another immediate advance only when that exact provider ask is still active and has no timer, preserving cancellation and context replacement.

A server lifecycle regression test holds the first deduped advance open, completes the provider launch during that overlap, proves a second advance was coalesced, and verifies that the thread still attaches to the ready environment.

This is server-local lifecycle scheduling. It changes no server/host-daemon wire fields or semantics, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged. The integration test, assertions, polling deadlines, retries, and wrapper timeouts are unchanged. The verified frozen merge-base is `eaf8304a00e966a66eee6eda3be0b0e64e958e88`; later `origin/main` advances were not merged.

## How you verified

- Red on the frozen base: the new forced-overlap test failed in 2.219s because `environmentId` remained `null` after the launch became ready.
- Green after the fix: the same test passed in 0.838s.
- `pnpm exec turbo run test --filter=@bb/server -- test/threads/environment-providers.test.ts`: 37/37 passed.
- Focused original integration test under Node 22: passed in 10.085s unloaded.
- Forced uncached focused test with eight CPU load workers: passed in 16.710s; all workers were killed and waited by shell traps.
- `pnpm exec turbo run test --filter=@bb/integration-tests --concurrency=4`: 29/29 files and 81/81 tests passed; the original test passed in 13.929s.
- `pnpm exec turbo run build typecheck --filter=@bb/server --filter=@bb/integration-tests --concurrency=4`: 8/8 Turbo tasks succeeded.
- `pnpm exec oxfmt --check` on both changed files passed.
- Cleanup audit found no surviving load, Vitest, fake server/daemon processes, or `bb-integration-*` temp directories.

Natural timing did not trigger the race in five unloaded and three CPU-contention samples before the fix, which is consistent with the intermittent main evidence. The regression instead controls the deduper boundary to reproduce the lost wakeup deterministically.


> AGENT GENERATED