### PR TITLE
Add Account Pool usage refresh CLI

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -642,6 +642,7 @@ bb pool account login-poll --session <id>
 bb pool account add --provider claude --import
 bb pool account add --provider codex --import
 printf '%s\n' "$ANTHROPIC_API_KEY" | bb pool account add --provider claude --api-key-stdin [--label <text>] [--priority <n>]
+bb pool account refresh <id>
 ```
 
 The Claude login start command creates a ten-minute in-memory PKCE session,
@@ -679,16 +680,18 @@ login. Rotate one machine's token with
 `bb pool token rotate --machine <id-or-name>`; the prior token remains valid
 for ten minutes so in-flight requests can drain. Bypass or restore routing for
 one thread with `bb pool bypass <thread-id>` or
-`bb pool bypass <thread-id> --off`. Account listing, enable, disable, and
-removal are available through `bb pool account list|enable|disable|remove`.
+`bb pool bypass <thread-id> --off`. Account listing, enable, disable, removal,
+priority changes, and usage refreshes are available through
+`bb pool account list|enable|disable|remove|priority|refresh`.
 Provider routing is independently persisted and defaults on. Use
 `bb pool routing <claude|codex> --off` to stop contributing pool environment
 and health for one provider, and omit `--off` to enable it again.
 OAuth accounts refresh quota from Anthropic's usage endpoint when added or
-enabled and every five minutes while idle. `account list` adds columns for the
-family buckets Anthropic reports; JSON status exposes their utilization,
-reset, status, observation time, and `header` or `usage` source under
-`familyWeekly`. Requests route around an account spent for their model family
+enabled and every five minutes while idle. Use `bb pool account refresh <id>`
+to request an immediate refresh for one account. `account list` adds columns
+for the family buckets Anthropic reports; JSON status exposes their
+utilization, reset, status, observation time, and `header` or `usage` source
+under `familyWeekly`. Requests route around an account spent for their model family
 without disabling that account for other families. Imported and newly signed-in
 accounts retain their Anthropic account UUID, and the hub aligns a present
 `metadata.user_id` account component with the selected account.

--- a/packages/templates/src/templates/bb-guide-plugins.md
+++ b/packages/templates/src/templates/bb-guide-plugins.md
@@ -41,6 +41,7 @@ bb pool account enable <id>
 bb pool account disable <id>
 bb pool account priority <id> <n>
 bb pool account reorder <claude|codex> <id>...
+bb pool account refresh <id>
 bb pool status [--json]
 bb pool routing <claude|codex> [--off]
 bb pool config
@@ -75,10 +76,11 @@ safely. Rotation keeps the prior token valid for ten minutes. Agents should use
 input. The compatibility form `--api-key <key>` exposes the key in process
 arguments, shell history, and agent transcripts. Prefer `--import` when Claude
 Code is already signed in. OAuth quota refreshes on add or enable and every
-five minutes while the account is idle. Account tables add columns for the
-family buckets Anthropic reports, and JSON status exposes the same observations
-under `familyWeekly`. Selection skips an account only for a spent requested
-family while retaining it for other families. When Claude Code supplies an
+five minutes while the account is idle. Use `bb pool account refresh <id>` to
+request an immediate refresh for one account. Account tables add columns for
+the family buckets Anthropic reports, and JSON status exposes the same
+observations under `familyWeekly`. Selection skips an account only for a spent
+requested family while retaining it for other families. When Claude Code supplies an
 account UUID in `metadata.user_id`, the hub aligns it with the selected OAuth
 account. `bb pool config` prints the quota switch threshold and both upstream
 URLs. Use `bb pool config set <key> <value>` to change one; the two URL values

--- a/plugins/account-pool/skills/account-pool/SKILL.md
+++ b/plugins/account-pool/skills/account-pool/SKILL.md
@@ -9,8 +9,9 @@ Use `bb pool` for this plugin's accounts and routes. Inspect current state with
 `bb pool status --json` and `bb pool account list --json` before changing routing.
 Use `bb pool --help` for available commands.
 
-For account login/import, secret handling, routing settings, ordering, or failover,
-read [references/accounts-and-routing.md](references/accounts-and-routing.md).
+For account login/import, secret handling, quota refresh, routing settings,
+ordering, or failover, read
+[references/accounts-and-routing.md](references/accounts-and-routing.md).
 
 Use stdin or supported login/import flows for credentials; never put secret values
 in command arguments or chat. Confirm the resulting account and routing state.

--- a/plugins/account-pool/skills/account-pool/references/accounts-and-routing.md
+++ b/plugins/account-pool/skills/account-pool/references/accounts-and-routing.md
@@ -17,6 +17,7 @@ bb pool account enable <id>
 bb pool account disable <id>
 bb pool account priority <id> <n>
 bb pool account reorder <claude|codex> <id>...
+bb pool account refresh <id>
 bb pool status [--json]
 bb pool routing <claude|codex> [--off]
 bb pool config
@@ -46,12 +47,14 @@ prior token valid for ten minutes. Agents should pipe API keys to
 process arguments, shell history, and agent transcripts. Prefer `--import` for
 an existing Claude Code login. The CLI Codex import path reads
 `~/.codex/auth.json` on the bb server host. OAuth quota refreshes on add or
-enable and every five minutes while an account is idle. Account tables add columns for observed
-model-family buckets; JSON status exposes their utilization, reset, status,
-observation time, and source under `familyWeekly`. Selection skips an account
-whose requested family is spent while retaining it for other families. A
-present `metadata.user_id` account UUID is aligned with the selected OAuth
-account. Use `bb pool config` to inspect the full routing configuration and
+enable and every five minutes while an account is idle. Use
+`bb pool account refresh <id>` to request an immediate refresh for one account.
+Account tables add columns for observed model-family buckets; JSON status
+exposes their utilization, reset, status, observation time, and source under
+`familyWeekly`. Selection skips an account whose requested family is spent
+while retaining it for other families. A present `metadata.user_id` account
+UUID is aligned with the selected OAuth account. Use `bb pool config` to
+inspect the full routing configuration and
 `bb pool config set <key> <value>` to update one value. The upstream URL keys
 are QA-only overrides; `switchThreshold` must be greater than 0 and at most 1.
 

--- a/plugins/account-pool/src/cli.ts
+++ b/plugins/account-pool/src/cli.ts
@@ -45,6 +45,7 @@ const HELP = [
   "  bb pool account disable <id>",
   "  bb pool account priority <id> <n>",
   "  bb pool account reorder <claude|codex> <id>...",
+  "  bb pool account refresh <id>",
   "  bb pool status [--json]",
   "  bb pool routing <claude|codex> [--off]",
   "  bb pool config",
@@ -304,6 +305,11 @@ export function registerPoolCli(
         usage: "bb pool account reorder <claude|codex> <id>...",
       },
       {
+        name: "account-refresh",
+        summary: "Refresh one account's observed usage",
+        usage: "bb pool account refresh <id>",
+      },
+      {
         name: "status",
         summary: "Show hub, machine token, routing, and account status",
         usage: "bb pool status [--json]",
@@ -367,6 +373,13 @@ export function registerPoolCli(
             exitCode: 0,
             stdout: `Updated ${input.provider} account order.\n`,
           };
+        }
+        if (argv[0] === "account" && argv[1] === "refresh") {
+          if (argv.length !== 3) throw new Error(HELP);
+          const { id } = accountIdInputSchema.parse({ id: argv[2] });
+          if ((await operations.refreshUsage(id)) === null)
+            throw new Error("Account not found.");
+          return { exitCode: 0, stdout: `Refreshed usage for ${id}.\n` };
         }
         if (argv[0] === "account" && argv[1] === "add") {
           const flags = parseFlags(

--- a/plugins/account-pool/src/server.test.ts
+++ b/plugins/account-pool/src/server.test.ts
@@ -1016,6 +1016,7 @@ describe("Account Pool plugin", () => {
     expect(help.stdout).toContain("--code-stdin");
     expect(help.stdout).toContain("--api-key-stdin");
     expect(help.stdout).toContain("Unsafe: exposes the key");
+    expect(help.stdout).toContain("account refresh <id>");
     const list = await fixture.host.harness.behavior.runCli([
       "account",
       "list",
@@ -1028,6 +1029,13 @@ describe("Account Pool plugin", () => {
     const account = listed.accounts[0];
     if (account === undefined) throw new Error("CLI account was not listed.");
     expect(account).toMatchObject({ label: "Claude API key", priority: 100 });
+    expect(
+      await fixture.host.harness.behavior.runCli([
+        "account",
+        "refresh",
+        account.id,
+      ]),
+    ).toMatchObject({ exitCode: 0 });
     expect(
       (
         await fixture.host.harness.behavior.runCli([


### PR DESCRIPTION
## Human comments

## What was wrong

Account Pool settings could refresh one account's observed usage through an existing typed operation, but the `bb pool` CLI exposed no matching action. Agents therefore could not discover or perform the refresh and had to send users to the settings screen.

## What changed

Added `bb pool account refresh <id>` using the existing account ID schema and `refreshUsage` operation. The command is registered in plugin help and documented in the Guide, configuration reference, and owning Account Pool skill. Current `main` already contains the priority and reorder commands, so the stale fix was narrowed during rebase to refresh only. No RPC or host-daemon wire contract changed.

## How you verified

- `pnpm exec turbo run test typecheck --filter=bb-plugin-account-pool --force` (261 tests passed; typecheck passed)
- `pnpm exec turbo run test --filter=@bb/templates --force -- test/templates.test.ts` (7 tests passed)
- `pnpm exec turbo run typecheck --filter=@bb/templates --force`
- `pnpm exec turbo run typecheck build --filter=@bb/server --force`
- Targeted formatting and `git diff --check origin/main...HEAD` passed


> AGENT GENERATED