### PR TITLE
Report the active Account Pool blocking reset

### DIFF
--- a/plugins/account-pool/app.test.tsx
+++ b/plugins/account-pool/app.test.tsx
@@ -130,20 +130,23 @@ describe("Account Pool settings", () => {
   });
 
   it("renders only the windows a Codex account reports and no Fable slot", async () => {
+    const blockingResetAt = Date.now() + 6 * 24 * 60 * 60 * 1_000;
     const slot = render([
       account({
         id: "22222222-2222-4222-8222-222222222222",
         provider: "codex",
         label: "pro@example.com",
         codexAccountId: "chatgpt-account",
-        fiveHourUtilization: null,
+        status: "exhausted",
+        fiveHourUtilization: 0.25,
+        fiveHourResetAt: Date.now() + 60 * 60 * 1_000,
         limitWindows: [
           {
             slot: "primary",
             windowMinutes: 10_080,
-            utilization: 0.48,
-            resetAt: Date.now() + 3_600_000,
-            status: "allowed",
+            utilization: 1,
+            resetAt: blockingResetAt,
+            status: "rejected",
             observedAt: 1,
             source: "usage",
           },
@@ -152,9 +155,14 @@ describe("Account Pool settings", () => {
     ]);
     expect(await slot.findByText("pro@example.com")).toBeTruthy();
     expect(slot.getByText("7D")).toBeTruthy();
-    expect(slot.getByText("48%")).toBeTruthy();
+    expect(slot.getByText("100%")).toBeTruthy();
     expect(slot.queryByText("5H")).toBeNull();
     expect(slot.queryByText("FABLE")).toBeNull();
+    expect(
+      slot.getByText(
+        `Exhausted · resets ${new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric" }).format(blockingResetAt)}`,
+      ),
+    ).toBeTruthy();
     fireEvent.click(
       await slot.findByRole("button", { name: "Open pro@example.com details" }),
     );

--- a/plugins/account-pool/app.tsx
+++ b/plugins/account-pool/app.tsx
@@ -59,6 +59,7 @@ import type {
   PoolStatus,
 } from "./src/contracts.js";
 import type { accountPoolRpcContract } from "./src/rpc.js";
+import { blockingResetAt } from "./src/quota.js";
 import {
   ACCOUNT_POOL_ACCOUNTS_CHANGED,
   ACCOUNT_POOL_CONFIG_CHANGED,
@@ -176,14 +177,6 @@ function windowLongLabel(window: LimitWindow): string {
     return `${window.windowMinutes / 60} hour`;
   return `${window.windowMinutes} minute`;
 }
-function exhaustedResetAt(account: AccountSummary): number | null {
-  return (
-    account.fiveHourResetAt ??
-    account.sevenDayResetAt ??
-    account.limitWindows.find((window) => window.resetAt !== null)?.resetAt ??
-    null
-  );
-}
 function resetLabel(timestamp: number | null): string {
   if (timestamp === null) return "";
   const minutes = Math.max(1, Math.round((timestamp - Date.now()) / 60_000));
@@ -191,7 +184,10 @@ function resetLabel(timestamp: number | null): string {
     return `resets in ${minutes >= 60 ? `${Math.floor(minutes / 60)}h ${minutes % 60}m` : `${minutes}m`}`;
   return `resets ${new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric" }).format(timestamp)}`;
 }
-function statusPresentation(account: AccountSummary): {
+function statusPresentation(
+  account: AccountSummary,
+  threshold: number,
+): {
   label: string;
   dot: string;
 } {
@@ -200,11 +196,13 @@ function statusPresentation(account: AccountSummary): {
       label: `Held${account.heldUntil === null ? "" : ` · retry at ${new Intl.DateTimeFormat(undefined, { hour: "2-digit", minute: "2-digit" }).format(account.heldUntil)}`}`,
       dot: "bg-warning",
     };
-  if (account.status === "exhausted")
+  if (account.status === "exhausted") {
+    const resetAt = blockingResetAt(account, null, threshold, Date.now());
     return {
-      label: `Exhausted${exhaustedResetAt(account) === null ? "" : ` · ${resetLabel(exhaustedResetAt(account))}`}`,
+      label: `Exhausted${resetAt === null ? "" : ` · ${resetLabel(resetAt)}`}`,
       dot: "bg-destructive",
     };
+  }
   if (account.status === "error")
     return { label: "Error", dot: "bg-destructive" };
   if (account.status === "disabled")
@@ -311,7 +309,7 @@ function AccountRow({
   onOpen: () => void;
   reorderDisabled: boolean;
 }) {
-  const status = statusPresentation(account);
+  const status = statusPresentation(account, threshold);
   const {
     attributes,
     isDragging,
@@ -1405,7 +1403,9 @@ function AccountDrawer({
     >
       <div className="flex items-center gap-2">
         <SettingsBadge>{tier(account)}</SettingsBadge>
-        <SettingsBadge>{statusPresentation(account).label}</SettingsBadge>
+        <SettingsBadge>
+          {statusPresentation(account, threshold).label}
+        </SettingsBadge>
       </div>
       <div className="space-y-4">
         {account.provider === "codex" ? (

--- a/plugins/account-pool/src/hub.ts
+++ b/plugins/account-pool/src/hub.ts
@@ -21,6 +21,7 @@ import type {
 } from "./credentials.js";
 import {
   accountStatus,
+  blockingResetAt,
   governingWeeklyResetAt,
   isQuotaExhausted,
   isSharedQuotaExhausted,
@@ -1106,17 +1107,20 @@ export class AccountPoolHub {
       );
     }
     const now = this.options.now();
+    const threshold = this.options.getSettings().switchThreshold;
     const next = accounts
       .filter((account) => account.enabled)
       .flatMap((account) => {
         const quota = this.options.quotas.get(account.id);
-        return [
-          quota.heldUntil,
-          quota.fiveHourResetAt,
-          quota.sevenDayResetAt,
-          ...quota.limitWindows.map((window) => window.resetAt),
-          governingWeeklyResetAt(quota, family),
-        ].filter((value): value is number => value !== null && value > now);
+        if (quota.error !== null) return [];
+        const quotaResetAt = blockingResetAt(quota, family, threshold, now);
+        if (
+          quotaResetAt === null &&
+          isQuotaExhausted(quota, family, threshold, now)
+        )
+          return [];
+        const resetAt = Math.max(quota.heldUntil ?? 0, quotaResetAt ?? 0);
+        return resetAt > now ? [resetAt] : [];
       })
       .sort((left, right) => left - right)[0];
     const retryAfter = Math.max(

--- a/plugins/account-pool/src/quota.ts
+++ b/plugins/account-pool/src/quota.ts
@@ -156,6 +156,43 @@ function activeFamilyWindow(
   );
 }
 
+export function blockingResetAt(
+  quota: AccountQuota | AccountSummary,
+  family: ModelFamily | null,
+  threshold: number,
+  now: number,
+): number | null {
+  let latest: number | null = null;
+  let unknown = false;
+  const include = (
+    utilization: number | null,
+    status: string | null,
+    resetAt: number | null,
+  ) => {
+    if (!activeWindow(utilization, status, resetAt, threshold, now)) return;
+    if (resetAt === null) unknown = true;
+    else latest = Math.max(latest ?? resetAt, resetAt);
+  };
+  include(
+    quota.fiveHourUtilization,
+    quota.fiveHourStatus,
+    quota.fiveHourResetAt,
+  );
+  include(
+    quota.sevenDayUtilization,
+    quota.sevenDayStatus,
+    quota.sevenDayResetAt,
+  );
+  for (const window of quota.limitWindows)
+    include(window.utilization, window.status, window.resetAt);
+  if (family !== null) {
+    const familyQuota = quota.familyWeekly[family];
+    if (familyQuota !== null)
+      include(familyQuota.utilization, familyQuota.status, familyQuota.resetAt);
+  }
+  return unknown ? null : latest;
+}
+
 export function isSharedQuotaExhausted(
   quota: AccountQuota,
   threshold: number,

--- a/plugins/account-pool/src/server.test.ts
+++ b/plugins/account-pool/src/server.test.ts
@@ -500,7 +500,7 @@ describe("Account Pool plugin", () => {
       if (responseNumber === 2) {
         response.writeHead(429, {
           "content-type": "application/json",
-          "x-codex-primary-used-percent": "100",
+          "x-codex-secondary-used-percent": "100",
         });
         response.end('{"error":{"message":"quota exhausted"}}');
         return;
@@ -684,15 +684,15 @@ describe("Account Pool plugin", () => {
         {
           slot: "primary",
           windowMinutes: 300,
-          utilization: 1,
-          status: "rejected",
+          utilization: 0.25,
+          status: null,
           source: "header",
         },
         {
           slot: "secondary",
           windowMinutes: 10_080,
-          utilization: 0.4,
-          status: null,
+          utilization: 1,
+          status: "rejected",
           source: "header",
         },
       ],
@@ -714,6 +714,24 @@ describe("Account Pool plugin", () => {
         },
       ],
     });
+    const secondCodex = status.accounts.find(
+      (account) =>
+        account.provider === "codex" && account.id !== firstCodex?.id,
+    );
+    if (secondCodex === undefined) throw new Error("Missing second account.");
+    await host.harness.behavior.callRpc("account.disable", {
+      id: secondCodex.id,
+    });
+    const blocked = await host.harness.behavior.fetchHttp(
+      "POST",
+      "/v1/responses",
+      {
+        headers: { "x-bb-account-pool-token": routed.token },
+        body: JSON.stringify({ model: "gpt-5", input: [] }),
+      },
+    );
+    expect(blocked.status).toBe(429);
+    expect(Number(blocked.headers.get("retry-after"))).toBeGreaterThan(80_000);
     const secret = accountSecretSchema.parse(
       JSON.parse(
         await fs.readFile(


### PR DESCRIPTION
## Human comments

## What was wrong

Account Pool recovery time came from any reset on an account instead of the quota windows currently preventing use. When a healthy short window reset before an exhausted longer window, the account row and the hub's 429 response told users and clients to retry too early.

## What changed

The shared `blockingResetAt` helper now applies the same threshold, rejection, and expiry rules used by account selection. It chooses the latest active reset required for one account to recover and returns no timestamp when a blocker has no known reset. Both the Settings account status and hub retry calculation use that result.

The rebase preserves current main's draggable account ordering and passes the configured threshold into the corrected status calculation. This is plugin-local behavior with no host-daemon wire change, CLI change, or documentation surface change.

## How you verified

- The focused regression assertions failed before the fix with the short-window reset and passed after the fix with the actual blocking reset.
- `pnpm exec turbo run test typecheck --filter=bb-plugin-account-pool --force` passed 261/261 tests and all six Turbo tasks.
- `bb plugin build plugins/account-pool` emitted both app and server bundles successfully.
- Targeted `oxfmt --check` and `git diff --check origin/main...HEAD` passed.
- Existing desktop and compact Settings QA from the originating fixer passed; the rebase conflict retained current main's reorder implementation.


> AGENT GENERATED