### PR TITLE
Show queued message senders

### DIFF
--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.stories.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.stories.tsx
@@ -1,6 +1,11 @@
 import { useCallback, useState, type ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { threadsQueryKey } from "@/hooks/queries/query-keys";
 import type { ThreadQueuedMessage } from "@bb/domain";
-import { makeThreadQueuedMessage } from "@bb/test-helpers/domain-fixtures";
+import {
+  makeThreadListEntry,
+  makeThreadQueuedMessage,
+} from "@bb/test-helpers/domain-fixtures";
 import {
   applyQueuedMessageReorder,
   type QueuedMessageReorderRequest,
@@ -804,5 +809,47 @@ export function NarrowSurface() {
         </PromptStage>
       </StoryRow>
     </StoryCard>
+  );
+}
+
+export function SenderMetadata() {
+  const [queryClient] = useState(() => {
+    const client = new QueryClient();
+    client.setQueryData(threadsQueryKey(), [
+      makeThreadListEntry({ id: "thr_review", title: "Code review" }),
+    ]);
+    return client;
+  });
+  const messages = [
+    makeQueuedMessage({
+      id: "q_user",
+      text: "Please review the final changes.",
+    }),
+    makeQueuedMessage({
+      id: "q_agent",
+      text: "The review is complete. All checks passed.",
+      initiator: "agent",
+      senderThreadId: "thr_review",
+    }),
+    makeQueuedMessage({
+      id: "q_system",
+      text: "The background task has completed.",
+      initiator: "system",
+      waitingOn: { kind: "provisioning" },
+    }),
+  ];
+  return (
+    <QueryClientProvider client={queryClient}>
+      <StoryCard>
+        <StoryRow
+          label="sender metadata"
+          hint="Non-user senders share the second line with wait metadata."
+        >
+          <ResponsivePromptStage>
+            <StaticQueuedMessagesList queuedMessages={messages} />
+          </ResponsivePromptStage>
+        </StoryRow>
+      </StoryCard>
+    </QueryClientProvider>
   );
 }

--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.test.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.test.tsx
@@ -8,9 +8,14 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { useContext, useLayoutEffect } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { threadsQueryKey } from "@/hooks/queries/query-keys";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ThreadQueuedMessage } from "@bb/domain";
-import { makeThreadQueuedMessage } from "@bb/test-helpers/domain-fixtures";
+import {
+  makeThreadListEntry,
+  makeThreadQueuedMessage,
+} from "@bb/test-helpers/domain-fixtures";
 import type { Active, DroppableContainer } from "@dnd-kit/core";
 import {
   QueuedMessagesList as QueuedMessagesListComponent,
@@ -158,6 +163,89 @@ afterEach(() => {
 });
 
 describe("QueuedMessagesList", () => {
+  it("labels non-user senders and refreshes their names from the thread cache", async () => {
+    const queryClient = new QueryClient();
+    const messages = [
+      makeQueuedMessage("q_user", "User follow-up"),
+      makeThreadQueuedMessage({
+        id: "q_agent",
+        initiator: "agent",
+        senderThreadId: "thr_sender",
+      }),
+      makeThreadQueuedMessage({
+        id: "q_system",
+        initiator: "system",
+        waitingOn: { kind: "provisioning" },
+      }),
+    ];
+    const { container, getByText, getByRole } = render(
+      <QueryClientProvider client={queryClient}>
+        <QueuedMessagesList
+          queuedMessages={messages}
+          sendDisabled={false}
+          actionDisabled={false}
+          processingMessageId={null}
+          processingAction={null}
+          onSend={noop}
+          onReorder={noop}
+          onSetGroupBoundary={noop}
+          onEdit={noop}
+          onDelete={noop}
+        />
+      </QueryClientProvider>,
+    );
+    expect(
+      container.querySelector(
+        '[data-queued-message-id="q_user"] [data-queued-message-sender]',
+      ),
+    ).toBeNull();
+    expect(
+      getByText("thr_sender").closest("[data-queued-message-metadata]"),
+    ).not.toBeNull();
+    expect(
+      getByText("System")
+        .closest("[data-queued-message-metadata]")
+        ?.querySelector("[data-queued-message-wait]"),
+    ).not.toBeNull();
+    expect(
+      getByText("thr_sender").closest(".prompt-mention-pill"),
+    ).not.toBeNull();
+    act(() => {
+      queryClient.setQueryData(threadsQueryKey(), [
+        makeThreadListEntry({ id: "thr_sender", title: "Code review" }),
+      ]);
+    });
+    await waitFor(() => expect(getByText("Code review")).toBeTruthy());
+    fireEvent.keyDown(
+      getByRole("button", { name: "Drag up to open the queue workspace" }),
+      { key: "ArrowUp" },
+    );
+    expect(getByText("Code review")).toBeTruthy();
+    expect(getByText("System")).toBeTruthy();
+    queryClient.clear();
+  });
+
+  it.each([
+    { initiator: "system" as const, senderThreadId: null, height: "104px" },
+    {
+      initiator: "agent" as const,
+      senderThreadId: "thr_sender",
+      height: "110px",
+    },
+  ])(
+    "reserves the metadata height for $initiator senders",
+    ({ initiator, senderThreadId, height }) => {
+      const { container } = renderQueuedMessages([
+        makeThreadQueuedMessage({ initiator, senderThreadId }),
+      ]);
+      expect(
+        container.querySelector<HTMLElement>(
+          'section[aria-label="Queued messages"]',
+        )?.style.height,
+      ).toBe(height);
+    },
+  );
+
   it("renders as a standalone card when it is not attached to the composer", () => {
     const { container } = renderQueuedMessages(
       [makeQueuedMessage("q_one", "First queued message")],

--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
@@ -14,6 +14,7 @@ import {
 import ReactMarkdown from "react-markdown";
 import type { Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { useSenderThreadMetadataById } from "@/hooks/useSenderThreadMetadataById";
 import { useSecondTick } from "@/hooks/useSecondTick";
 import { usePluginDisplayName } from "@/lib/plugin-logos";
 import {
@@ -88,7 +89,10 @@ import {
   type QueuedMessageReorderRequest,
 } from "@/lib/queued-message-reorder";
 import type { PromptMentionLinkResolver } from "@/components/promptbox/editor/prompt-mention-link";
-import { shiftMentionsToTextRange } from "@/components/thread/timeline/ConversationMessageMentions";
+import {
+  PromptMentionPill,
+  shiftMentionsToTextRange,
+} from "@/components/thread/timeline/ConversationMessageMentions";
 import {
   buildPromptMentionComponent,
   remarkPromptMentions,
@@ -147,6 +151,7 @@ interface QueuedMessagePreviewText {
 }
 
 interface QueuedMessageRowProps {
+  senderLabel: string | null;
   queuedMessage: ThreadQueuedMessage;
   resolveMentionLink?: PromptMentionLinkResolver;
   index: number;
@@ -171,6 +176,7 @@ const DRAWER_CHROME_HEIGHT = 1 + 32 + 12 + 2;
 const DRAWER_LIST_PADDING = 8;
 const DRAWER_ROW_HEIGHT = 33;
 const DRAWER_SECOND_LINE_HEIGHT = 16;
+const DRAWER_SENDER_PILL_LINE_HEIGHT = 22;
 const WORKSPACE_MIN_HEIGHT = 240;
 const WORKSPACE_MAX_HEIGHT = 360;
 const WORKSPACE_CHROME_HEIGHT = 56;
@@ -195,9 +201,13 @@ function getDrawerHeight({
           (total, queuedMessage) =>
             total +
             DRAWER_ROW_HEIGHT +
-            (queuedMessageHasWaitLine(queuedMessage) ||
+            (queuedMessage.initiator !== "user" ||
+            queuedMessageHasWaitLine(queuedMessage) ||
             queuedMessage.id === processingMessageId
-              ? DRAWER_SECOND_LINE_HEIGHT
+              ? queuedMessage.initiator === "agent" &&
+                queuedMessage.senderThreadId !== null
+                ? DRAWER_SENDER_PILL_LINE_HEIGHT
+                : DRAWER_SECOND_LINE_HEIGHT
               : 0),
           0,
         );
@@ -704,7 +714,7 @@ function QueuedMessageWaitLine({
       data-queued-message-wait=""
       data-queued-message-failed={failed ? "" : undefined}
       className={cn(
-        "mt-0.5 flex min-w-0 items-center gap-1 text-2xs",
+        "flex min-w-0 items-center gap-1 text-2xs",
         failed ? "text-destructive-text" : "text-subtle-foreground",
       )}
     >
@@ -723,7 +733,7 @@ function QueuedMessageProcessingLine({ label }: { label: string }) {
   return (
     <div
       data-queued-message-processing=""
-      className="mt-0.5 flex min-w-0 items-center gap-1 text-2xs text-muted-foreground"
+      className="flex min-w-0 items-center gap-1 text-2xs text-muted-foreground"
     >
       <Icon
         name="Spinner"
@@ -736,6 +746,7 @@ function QueuedMessageProcessingLine({ label }: { label: string }) {
 }
 
 const QueuedMessageRow = memo(function QueuedMessageRow({
+  senderLabel,
   queuedMessage,
   resolveMentionLink,
   index,
@@ -830,7 +841,7 @@ const QueuedMessageRow = memo(function QueuedMessageRow({
         <div
           className={cn(
             "min-w-0 flex-1 py-1",
-            (hasWaitLine || isProcessing) && "py-1.5",
+            (senderLabel !== null || hasWaitLine || isProcessing) && "py-1.5",
           )}
         >
           <div className="flex min-w-0 items-center gap-1">
@@ -859,13 +870,53 @@ const QueuedMessageRow = memo(function QueuedMessageRow({
               </span>
             ) : null}
           </div>
-          {isProcessing ? (
-            <QueuedMessageProcessingLine label={processingLabel} />
-          ) : hasWaitLine ? (
-            <QueuedMessageWaitLine
-              pluginDisplayName={pluginDisplayName}
-              queuedMessage={queuedMessage}
-            />
+          {senderLabel !== null || isProcessing || hasWaitLine ? (
+            <div
+              data-queued-message-metadata=""
+              className="mt-0.5 flex min-w-0 items-center gap-1 text-2xs text-subtle-foreground"
+            >
+              {senderLabel === null ? null : (
+                <span
+                  data-queued-message-sender=""
+                  className={cn(
+                    "inline-flex min-w-0 items-center gap-1",
+                    (isProcessing || hasWaitLine) && "max-w-[40%] shrink-0",
+                  )}
+                  title={`From ${senderLabel}`}
+                >
+                  <span className="shrink-0">From</span>
+                  {queuedMessage.initiator === "agent" &&
+                  queuedMessage.senderThreadId !== null ? (
+                    <span className="flex min-w-0 [&>.prompt-mention-pill]:text-2xs">
+                      <PromptMentionPill
+                        interactive={false}
+                        resource={{
+                          kind: "thread",
+                          threadId: queuedMessage.senderThreadId,
+                          label: senderLabel,
+                        }}
+                        serializedText={`@thread:${queuedMessage.senderThreadId}`}
+                      />
+                    </span>
+                  ) : (
+                    <span className="min-w-0 truncate">{senderLabel}</span>
+                  )}
+                </span>
+              )}
+              {senderLabel !== null && (isProcessing || hasWaitLine) ? (
+                <span aria-hidden className="shrink-0">
+                  ·
+                </span>
+              ) : null}
+              {isProcessing ? (
+                <QueuedMessageProcessingLine label={processingLabel} />
+              ) : hasWaitLine ? (
+                <QueuedMessageWaitLine
+                  pluginDisplayName={pluginDisplayName}
+                  queuedMessage={queuedMessage}
+                />
+              ) : null}
+            </div>
           ) : null}
         </div>
         {isProcessing ? null : (
@@ -1154,6 +1205,7 @@ export function QueuedMessagesList({
   onEdit,
   onDelete,
 }: QueuedMessagesListProps) {
+  const senderThreadMetadataById = useSenderThreadMetadataById();
   const processingLabel =
     processingAction === "edit"
       ? "Editing…"
@@ -1639,6 +1691,17 @@ export function QueuedMessagesList({
         <QueuedMessageRow
           key={queuedMessage.id}
           queuedMessage={queuedMessage}
+          senderLabel={
+            queuedMessage.initiator === "system"
+              ? "System"
+              : queuedMessage.initiator === "agent"
+                ? (senderThreadMetadataById.get(
+                    queuedMessage.senderThreadId ?? "",
+                  )?.title ??
+                  queuedMessage.senderThreadId ??
+                  "Agent")
+                : null
+          }
           resolveMentionLink={resolveMentionLink}
           index={messageIndex}
           isProcessing={processingMessageId === queuedMessage.id}

--- a/apps/app/src/hooks/cache-owners/thread-runtime-cache-owner.ts
+++ b/apps/app/src/hooks/cache-owners/thread-runtime-cache-owner.ts
@@ -406,6 +406,8 @@ function buildOptimisticQueuedMessage({
 
   return {
     id: `optimistic-queued-${nanoid()}`,
+    initiator: "user",
+    senderThreadId: null,
     threadId: request.id,
     content: request.input,
     model: request.model ?? defaultExecutionOptions?.model ?? "pending",

--- a/apps/cli/src/__tests__/command-output/thread-organization.test.ts
+++ b/apps/cli/src/__tests__/command-output/thread-organization.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import type { ThreadQueuedMessage } from "@bb/domain";
 import {
   runCommand,
   setupCommandOutputTestEnvironment,
@@ -6,6 +7,31 @@ import {
 } from "../helpers/command-output-harness.js";
 import type { CommandRegistrar } from "../helpers/command-output-harness.js";
 import { registerThreadCommands } from "../../commands/thread/index.js";
+
+function queuedMessage(
+  overrides: Partial<ThreadQueuedMessage>,
+): ThreadQueuedMessage {
+  return {
+    id: "queued-1",
+    initiator: "user",
+    senderThreadId: null,
+    threadId: "thread-1",
+    content: [{ type: "text", text: "Follow up", mentions: [] }],
+    model: "gpt-5",
+    reasoningLevel: "medium",
+    permissionMode: "auto",
+    serviceTier: "default",
+    groupWithNext: false,
+    sendAt: null,
+    waitingOn: null,
+    failureReason: null,
+    payload: { kind: "inline" },
+    editable: true,
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  };
+}
 
 describe("bb thread organization commands", () => {
   setupCommandOutputTestEnvironment();
@@ -52,6 +78,29 @@ describe("bb thread organization commands", () => {
         input: [{ type: "text", text: "next task", mentions: [] }],
       },
     });
+  });
+
+  it("shows agent and system senders in queued message rows", async () => {
+    const list = vi.fn(async () => [
+      queuedMessage({ id: "queued-user" }),
+      queuedMessage({
+        id: "queued-agent",
+        initiator: "agent",
+        senderThreadId: "thr_sender",
+      }),
+      queuedMessage({ id: "queued-system", initiator: "system" }),
+    ]);
+    stubServerApi({ "v1.queued-messages.$get": list });
+
+    await runCommand(["thread", "queue", "list"], register);
+
+    const output = vi
+      .mocked(console.log)
+      .mock.calls.map((args) => args.join(" "))
+      .join("\n");
+    expect(output).toContain("Sender");
+    expect(output).toContain("thr_sender");
+    expect(output).toContain("System");
   });
 
   it("updates a queued message in place", async () => {

--- a/apps/cli/src/commands/thread/organization.ts
+++ b/apps/cli/src/commands/thread/organization.ts
@@ -106,6 +106,11 @@ function printQueueTable(rows: ThreadQueuedMessagesResult): void {
   const table = rows.map((row) => [
     row.id,
     row.threadId,
+    row.initiator === "user"
+      ? ""
+      : row.initiator === "system"
+        ? "System"
+        : (row.senderThreadId ?? "Agent"),
     truncateQueueCell(queuedMessagePreview(row.content)),
     truncateQueueCell(describeQueueWait(row)),
     formatQueueSendCountdown(row.sendAt, now),
@@ -114,13 +119,14 @@ function printQueueTable(rows: ThreadQueuedMessagesResult): void {
   console.log(
     renderBorderlessTable(
       {
-        head: ["ID", "Thread", "Message", "Waiting on", "Send at"],
+        head: ["ID", "Thread", "Sender", "Message", "Waiting on", "Send at"],
         colWidths: [
           queueColumnWidth(table, 0, 2),
           queueColumnWidth(table, 1, 6),
-          queueColumnWidth(table, 2, 7),
-          queueColumnWidth(table, 3, 10),
-          queueColumnWidth(table, 4, 7),
+          queueColumnWidth(table, 2, 6),
+          queueColumnWidth(table, 3, 7),
+          queueColumnWidth(table, 4, 10),
+          queueColumnWidth(table, 5, 7),
         ],
       },
       table,

--- a/apps/demo-server/src/fixtures/world.ts
+++ b/apps/demo-server/src/fixtures/world.ts
@@ -197,6 +197,8 @@ export function queuedMessage(args: {
   return {
     id: args.id,
     threadId: args.threadId,
+    initiator: "user",
+    senderThreadId: null,
     content: args.content,
     model: THREAD_DEFAULT_EXECUTION_OPTIONS.model,
     reasoningLevel: THREAD_DEFAULT_EXECUTION_OPTIONS.reasoningLevel,

--- a/apps/server/src/services/threads/thread-queued-messages.ts
+++ b/apps/server/src/services/threads/thread-queued-messages.ts
@@ -30,6 +30,8 @@ interface StoredQueuedThreadMessageRow {
   permissionMode: PermissionMode;
   sendAt: number | null;
   serviceTier: string;
+  senderThreadId: string | null;
+  systemNotice: string | null;
   threadId: string;
   updatedAt: number;
   waitingOn: string | null;
@@ -123,6 +125,13 @@ export function toThreadQueuedMessage(
 ): ThreadQueuedMessage {
   return threadQueuedMessageSchema.parse({
     id: row.id,
+    initiator:
+      row.systemNotice !== null
+        ? "system"
+        : row.senderThreadId !== null
+          ? "agent"
+          : "user",
+    senderThreadId: row.senderThreadId,
     threadId: row.threadId,
     content: parseStoredQueuedThreadMessageContent(row),
     model: row.model,

--- a/apps/server/test/threads/requested-queue-drain.test.ts
+++ b/apps/server/test/threads/requested-queue-drain.test.ts
@@ -1,4 +1,5 @@
 import {
+  createQueuedThreadMessage,
   listEvents,
   listQueuedThreadMessages,
   setQueuedThreadMessageFailureReason,
@@ -123,6 +124,63 @@ async function stopThread(harness: TestAppHarness, threadId: string) {
 }
 
 describe("the requested queue drain", () => {
+  it("preserves user, agent, and system senders in queue API responses", async () => {
+    await withTestHarness(async (harness) => {
+      const { thread } = seedRunnableThread(harness, {
+        hostId: "host-queue-senders",
+        status: "active",
+      });
+      const user = seedQueuedMessage(harness.deps, {
+        threadId: thread.id,
+        content: textInput("User follow-up"),
+      });
+      const agent = seedQueuedMessage(harness.deps, {
+        threadId: thread.id,
+        content: textInput("Agent follow-up"),
+        senderThreadId: "thr_sender",
+      });
+      const system = createQueuedThreadMessage(harness.db, harness.deps.hub, {
+        threadId: thread.id,
+        content: textInput("System notice"),
+        model: "gpt-5",
+        reasoningLevel: "medium",
+        permissionMode: "auto",
+        serviceTier: "default",
+        senderThreadId: null,
+        waitingOn: null,
+        sendAt: null,
+        payload: { kind: "inline" },
+        systemNotice: { kind: "unlabeled", subject: null },
+      });
+      for (const path of [
+        `/api/v1/threads/${thread.id}/queued-messages`,
+        "/api/v1/queued-messages",
+      ]) {
+        const response = await harness.app.request(path);
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              id: user.id,
+              initiator: "user",
+              senderThreadId: null,
+            }),
+            expect.objectContaining({
+              id: agent.id,
+              initiator: "agent",
+              senderThreadId: "thr_sender",
+            }),
+            expect.objectContaining({
+              id: system.id,
+              initiator: "system",
+              senderThreadId: null,
+            }),
+          ]),
+        );
+      }
+    });
+  });
+
   it("does not dispatch a scheduled group tail while its lead is postponed", async () => {
     await withTestHarness(async (harness) => {
       vi.useFakeTimers();

--- a/packages/domain/src/thread.ts
+++ b/packages/domain/src/thread.ts
@@ -336,6 +336,8 @@ export type ThreadPullRequest = z.infer<typeof threadPullRequestSchema>;
 
 export const threadQueuedMessageSchema = z.object({
   id: z.string(),
+  initiator: z.enum(["user", "agent", "system"]),
+  senderThreadId: z.string().nullable(),
   /**
    * The thread this row is waiting on. Redundant on the thread-scoped list
    * route that first served this DTO, and load-bearing everywhere else it is

--- a/packages/domain/test/thread.test.ts
+++ b/packages/domain/test/thread.test.ts
@@ -6,6 +6,8 @@ describe("thread queued message schema", () => {
     expect(
       threadQueuedMessageSchema.parse({
         id: "qmsg_123",
+        initiator: "user",
+        senderThreadId: null,
         threadId: "thread_1",
         content: [{ type: "text", text: "Queued message", mentions: [] }],
         model: "gpt-5",
@@ -29,6 +31,8 @@ describe("thread queued message schema", () => {
     expect(() =>
       threadQueuedMessageSchema.parse({
         id: "qmsg_123",
+        initiator: "user",
+        senderThreadId: null,
         threadId: "thread_1",
         content: [{ type: "text", text: "Queued message", mentions: [] }],
         model: "gpt-5",

--- a/packages/plugin-sdk/src/testing/fixtures.ts
+++ b/packages/plugin-sdk/src/testing/fixtures.ts
@@ -284,6 +284,8 @@ export function makeQueueEntry(
 ): QueueEntry {
   return {
     id: "queued_1",
+    initiator: "user",
+    senderThreadId: null,
     threadId: "thread-1",
     content: [{ type: "text", text: "Queued turn", mentions: [] }],
     model: "test-model",

--- a/packages/templates/src/templates/bb-guide-threads.md
+++ b/packages/templates/src/templates/bb-guide-threads.md
@@ -322,6 +322,9 @@ Queued messages:
   bb thread queue group <thread-id> <boundary-id> --prefix <comma-separated-ids>
   bb thread queue delete <thread-id> <message-id>
 
+  The `Sender` column identifies agent threads and system notices; user messages
+  leave it blank. The SDK and `--json` include `initiator` and `senderThreadId`.
+
   A queued message is one that could not dispatch yet. Every one carries a
   typed reason in its `Waiting on` column: waiting for the current turn to
   finish, for the workspace, for a pending interaction, for a clock (`Send at`),

--- a/packages/test-helpers/src/domain-fixtures.ts
+++ b/packages/test-helpers/src/domain-fixtures.ts
@@ -190,6 +190,8 @@ export function makeThreadQueuedMessage(
 ): ThreadQueuedMessage {
   return {
     id: "qmsg_test",
+    initiator: "user",
+    senderThreadId: null,
     threadId: "thr_test",
     content: [{ type: "text", text: "Queued message", mentions: [] }],
     model: "gpt-5.5",

--- a/plugins/bb-guide/skills/bb-cli/references/thread-operation.md
+++ b/plugins/bb-guide/skills/bb-cli/references/thread-operation.md
@@ -37,6 +37,8 @@
   scheduled tell neither sends nor runs. Both report `delivery: "queued"` and
   dispatch on the sweep after the requested time. The SDK equivalent is `sendAt`
   (epoch ms) on `threads.spawn` / `threads.send`.
+- `bb thread queue list` shows a Sender for agent threads and system notices.
+  SDK queue rows and `--json` include `initiator` and nullable `senderThreadId`.
 - A send that cannot run right now does not fail: it joins the thread's queue
   with a typed reason. `--json` reports `delivery: "queued"` plus
   the complete `queuedMessage` row, so a script can inspect its `id`,


### PR DESCRIPTION
## Human comments

## What was wrong

Queued-message storage already retained the originating thread and system-notice metadata, but the public queued-message DTO discarded it. The app and CLI therefore rendered every queued row as if it came directly from the user, making agent-generated and system-generated queue entries indistinguishable.

## What changed

The server now derives an explicit `initiator` and `senderThreadId` at the queue API boundary and carries those required fields through the domain contract, SDK fixtures, optimistic app rows, and test helpers. Non-user senders appear on the queue row's second metadata line: agent threads use the existing timeline mention-pill styling and cached thread title, while system messages show `System`. The CLI queue table includes a Sender column, and both CLI Guide surfaces document the fields.

This changes the HTTP/SDK queued-message response but not any server/host-daemon message, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

## How you verified

- App queue tests: 48/48 passed, including cached sender-name refresh, system labels, pill styling, compact sizing, and truncation.
- Server queue-drain tests: 17/17 passed for both thread-scoped and cross-thread API responses.
- CLI command-output tests: 7/7 passed, including agent and system Sender-column coverage.
- Domain schema test: 1/1 passed; Guide template tests: 7/7 passed.
- Turbo typechecks passed all 12 tasks across app, server, CLI, domain, SDK, templates, and test helpers.
- Turbo lint passed with zero errors; targeted formatting and `git diff --check` passed.
- Before/after and final typography screenshots were captured with Doobie in the assigned BB thread, including narrow-screen truncation.


> AGENT GENERATED