### PR TITLE
Mute finished failed tool rows in timeline

### DIFF
--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.dim.test.ts
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.dim.test.ts
@@ -37,11 +37,24 @@ describe("pastRowDimClassName", () => {
     );
   });
 
-  it("keeps running, errored, and interrupted work rows at full strength", () => {
-    for (const status of ["pending", "error", "interrupted"] as const) {
+  it("recedes a failed work row alongside its completed neighbours", () => {
+    const row = viewRow([toolRow({ status: "error" })]);
+    expect(pastRowDimClassName({ ...inactiveScope, row })).toBe(
+      PAST_ROW_DIM_CLASS_NAME,
+    );
+  });
+
+  it("keeps running and interrupted work rows at full strength", () => {
+    for (const status of ["pending", "interrupted"] as const) {
       const row = viewRow([toolRow({ status })]);
       expect(pastRowDimClassName({ ...inactiveScope, row })).toBeUndefined();
     }
+  });
+
+  it("keeps a failed system row at full strength", () => {
+    const row = viewRow([systemRow({ status: "error" })]);
+    expect(row.kind).toBe("system");
+    expect(pastRowDimClassName({ ...inactiveScope, row })).toBeUndefined();
   });
 
   it.each(["generic", "reasoning"] as const)(

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
@@ -1407,6 +1407,9 @@ export function pastRowDimClassName({
         return undefined;
       return row.status === "completed" ? PAST_ROW_DIM_CLASS_NAME : undefined;
     case "work":
+      return row.status === "completed" || row.status === "error"
+        ? PAST_ROW_DIM_CLASS_NAME
+        : undefined;
     case "turn":
     case "bundle-summary":
     case "step-summary":


### PR DESCRIPTION
## Human comments

## What was wrong

Completed successful timeline work rows receded into the existing past-row treatment, but completed failed work rows stayed at full strength. Inside an expanded Exploring group, old failures therefore appeared more prominent than equally finished neighboring work.

## What changed

Completed `work` rows with `error` status now use the same existing past-row opacity class as completed successful work. Pending and interrupted tools, bundle and step summaries, and system/fatal error rows retain their existing prominence. Error labels, counts, expansion, and detail content are unchanged. This is presentation-only; there are no server/daemon wire, CLI, or public Plugin SDK changes.

## How you verified

- Updated the dimming regression to cover failed work rows and added a boundary test that failed system rows remain full strength.
- `pnpm exec turbo run test typecheck lint --filter=@bb/app --force`: 496 files and 4,100 tests passed, with 3 skipped; Turbo typecheck and lint passed.
- Targeted Oxfmt and `git diff --check` passed.
- Reproduced before editing and verified after on desktop 1440×900 and compact 390×844 in light and dark themes, including expanded failure details and a live `Exploring…` group.

> AGENT GENERATED