### PR TITLE
Fix notification drawer mobile width

### DIFF
--- a/apps/app/src/components/notifications/NotificationCenter.tsx
+++ b/apps/app/src/components/notifications/NotificationCenter.tsx
@@ -189,7 +189,7 @@ export function NotificationCenter() {
         mobileTitle="Notifications"
         aria-label="Notifications"
         data-testid="notification-center"
-        className="w-96 max-w-[calc(100vw-2rem)] p-0"
+        className="w-full md:w-96 md:max-w-[calc(100vw-2rem)] p-0"
         mobileClassName="p-0"
       >
         <div className="flex items-center justify-between gap-2 border-b border-border px-3 py-2">


### PR DESCRIPTION
## Human comments

## What was wrong

`NotificationCenter` passed its fixed desktop popover width classes into `PopoverContent`. The compact implementation reuses that class on the inner element of an already full-width drawer, leaving a visible unused strip on mobile.

## What changed

The notification content now uses the full available width below 768px and applies its existing 384px width and viewport cap only at `md` and wider. This preserves desktop sizing and leaves the shared persistent drawer, deferred realization, app-root accessibility behavior, scrolling, actions, and safe-area behavior unchanged. A broader compact `PopoverContent` width-neutralization issue affecting other consumers remains separately owned; this PR stays scoped to notifications. There are no server/daemon wire, CLI, or public Plugin SDK changes.

## How you verified

- After rebasing, both notification-focused app test files passed (5 tests), and Turbo app typecheck/lint passed with zero errors.
- Targeted Oxfmt and `git diff --check` passed.
- The original full app suite passed before the conflict-free rebase: 496 files and 4,098 tests passed, with 3 skipped.
- Reproduced and measured before/after at 360×780, 390×844, and 430×932; content now fills the drawer minus borders. Desktop remained 384px at 1280×900.
- Verified open/close, scrolling, clear-all, the close button, no app-root `inert`/`aria-hidden`, Playwright WebKit interaction, and an iOS Simulator Safari render.

> AGENT GENERATED