### PR TITLE
Continue work after environment directory switches

### DIFF
--- a/apps/server/src/services/threads/thread-environment-directory.ts
+++ b/apps/server/src/services/threads/thread-environment-directory.ts
@@ -32,7 +32,7 @@ const updateEnvironmentDirectoryInputSchema = z
 export const UPDATE_ENVIRONMENT_DIRECTORY_TOOL: DynamicTool = {
   name: UPDATE_ENVIRONMENT_DIRECTORY_TOOL_NAME,
   description:
-    "Move this bb thread to a different working directory for subsequent turns. Use this when the user asks to switch to a new checkout, worktree, or local directory. The path must be an absolute existing directory on the current host. The tool reuses this project's existing bb environment for that host/path, otherwise it creates an unmanaged environment after validating the path. Another project may hold its own environment for the same directory; that is allowed, except for a bb-managed worktree owned by another project, which this tool refuses. After a successful switch, stop the current turn because the running provider cwd will not change until the next turn.",
+    "Move this bb thread to a different working directory. Use this when the user asks to switch to a new checkout, worktree, or local directory. The path must be an absolute existing directory on the current host. The tool reuses this project's existing bb environment for that host/path, otherwise it creates an unmanaged environment after validating the path. Another project may hold its own environment for the same directory; that is allowed, except for a bb-managed worktree owned by another project, which this tool refuses. The running provider cwd does not change during the current turn. After a successful switch, continue the current task in the new directory by using absolute paths or explicit working-directory changes in commands; future turns start there automatically.",
   inputSchema: {
     type: "object",
     properties: {
@@ -138,7 +138,7 @@ function resolveReadyEnvironment(
 }
 
 function successMessage(path: string): string {
-  return `Environment directory updated to ${path}. This applies to future turns; stop work in this turn so the next turn can run from the updated directory.`;
+  return `Environment directory updated to ${path}. The running provider cwd is unchanged for this turn; continue the current task in ${path} using absolute paths or explicit working-directory changes in commands. Future turns start there automatically.`;
 }
 
 function attachReadyEnvironment(

--- a/apps/server/src/services/threads/thread-runtime-config.ts
+++ b/apps/server/src/services/threads/thread-runtime-config.ts
@@ -44,7 +44,7 @@ import {
 import { resolveDeprecatedWorkspaceProvisionType } from "../environments/environment-response.js";
 
 const UPDATE_ENVIRONMENT_DIRECTORY_INSTRUCTIONS =
-  "If the user asks you to move this thread to another checkout, worktree, or directory, make sure the target directory exists, then call `update_environment_directory` with its absolute path. After it succeeds, stop work in the current turn; future turns will run in the updated environment.";
+  "If the user asks you to move this thread to another checkout, worktree, or directory, make sure the target directory exists, then call `update_environment_directory` with its absolute path. The running provider cwd does not change during the current turn. After it succeeds, continue the current task in the new directory by using absolute paths or explicit working-directory changes in commands; future turns start there automatically.";
 
 const PLUGIN_INSTRUCTION_CONTRIBUTION_MAX_CHARS = 4096;
 

--- a/apps/server/test/internal/internal-events-tool-calls.test.ts
+++ b/apps/server/test/internal/internal-events-tool-calls.test.ts
@@ -1149,9 +1149,7 @@ describe("internal event and tool-call routes", () => {
         contentItems: [
           {
             type: "inputText",
-            text: expect.stringContaining(
-              "Environment directory updated to /tmp/existing-managed-worktree",
-            ),
+            text: "Environment directory updated to /tmp/existing-managed-worktree. The running provider cwd is unchanged for this turn; continue the current task in /tmp/existing-managed-worktree using absolute paths or explicit working-directory changes in commands. Future turns start there automatically.",
           },
         ],
       });

--- a/apps/server/test/threads/thread-runtime-config.test.ts
+++ b/apps/server/test/threads/thread-runtime-config.test.ts
@@ -1184,6 +1184,9 @@ describe("thread runtime config", () => {
       expect(runtimeConfig.dynamicTools).toEqual([
         expect.objectContaining({
           name: "update_environment_directory",
+          description: expect.stringContaining(
+            "continue the current task in the new directory",
+          ),
           inputSchema: expect.objectContaining({
             required: ["path"],
           }),
@@ -1197,6 +1200,12 @@ describe("thread runtime config", () => {
       expect(runtimeConfig.instructions).not.toContain("Markdown links");
       expect(runtimeConfig.instructions).toContain(
         "update_environment_directory",
+      );
+      expect(runtimeConfig.instructions).toContain(
+        "continue the current task in the new directory",
+      );
+      expect(runtimeConfig.instructions).not.toContain(
+        "stop work in the current turn",
       );
       expect(pluginContexts[0]?.environment.workspaceProvisionType).toBe(
         "unmanaged",


### PR DESCRIPTION
## Human comments

## What was wrong

The built-in `update_environment_directory` tool explicitly instructed agents to stop the current turn after a successful switch. Because bb cannot change the running provider process's cwd mid-turn, agents treated an implementation detail as a reason to hand control back to the user, forcing an unnecessary extra message before work continued.

## What changed

Updated the server-owned tool description, runtime instructions, and successful tool response to tell agents to continue the current task using absolute paths or explicit working-directory changes. Future turns still start in the selected environment automatically. This is an instruction-only server change with no host daemon wire changes.

## How you verified

- Added assertions that tool and runtime guidance tell the agent to continue and no longer tell it to stop.
- Tightened the successful tool response assertion to cover the continuation guidance.
- `pnpm exec turbo run test --filter=@bb/server -- test/internal/internal-events-tool-calls.test.ts test/threads/thread-runtime-config.test.ts` (55 tests passed)
- `pnpm exec turbo run typecheck --filter=@bb/server`
- `pnpm exec oxfmt apps/server/src/services/threads/thread-environment-directory.ts apps/server/src/services/threads/thread-runtime-config.ts apps/server/test/internal/internal-events-tool-calls.test.ts apps/server/test/threads/thread-runtime-config.test.ts --check`
- `git diff --check`

> AGENT GENERATED