### PR TITLE
Show navigation chevrons on touch devices

### DIFF
--- a/packages/shared-ui/package.json
+++ b/packages/shared-ui/package.json
@@ -84,6 +84,11 @@
       "types": "./src/components/ui/coarse-pointer-sizing.ts",
       "default": "./src/components/ui/coarse-pointer-sizing.ts"
     },
+    "./coarse-pointer-visibility": {
+      "source": "./src/components/ui/coarse-pointer-visibility.ts",
+      "types": "./src/components/ui/coarse-pointer-visibility.ts",
+      "default": "./src/components/ui/coarse-pointer-visibility.ts"
+    },
     "./collapsible": {
       "source": "./src/components/ui/collapsible.tsx",
       "types": "./src/components/ui/collapsible.tsx",

--- a/packages/shared-ui/src/components/ui/coarse-pointer-visibility.ts
+++ b/packages/shared-ui/src/components/ui/coarse-pointer-visibility.ts
@@ -1,0 +1,2 @@
+export const COARSE_POINTER_HOVER_REVEAL_VISIBLE_CLASS =
+  "pointer-coarse:opacity-100 [@media(hover:none)]:opacity-100";

--- a/packages/shared-ui/src/components/ui/resource/row.tsx
+++ b/packages/shared-ui/src/components/ui/resource/row.tsx
@@ -17,6 +17,7 @@ import {
   TooltipTrigger,
 } from "../tooltip";
 import { cn } from "../../../lib/utils";
+import { COARSE_POINTER_HOVER_REVEAL_VISIBLE_CLASS } from "../coarse-pointer-visibility";
 
 export function targetsResourceAction(target: EventTarget): boolean {
   return (
@@ -313,7 +314,10 @@ export function ResourceRowDetailChevron() {
   return (
     <Icon
       name="ChevronRight"
-      className="size-3.5 text-subtle-foreground opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
+      className={cn(
+        "size-3.5 text-subtle-foreground opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100",
+        COARSE_POINTER_HOVER_REVEAL_VISIBLE_CLASS,
+      )}
       aria-hidden
     />
   );

--- a/plugins/automations/detail-view.tsx
+++ b/plugins/automations/detail-view.tsx
@@ -16,6 +16,7 @@ import {
 } from "@get-bb/plugin-sdk/app";
 import { RUN_STATE_PRESENTATION } from "@bb/domain/update-state";
 import { Button } from "@bb/shared-ui/button";
+import { COARSE_POINTER_HOVER_REVEAL_VISIBLE_CLASS } from "@bb/shared-ui/coarse-pointer-visibility";
 import { DelayedLoading } from "@bb/shared-ui/delayed-loading";
 import { Icon, type IconName } from "@bb/shared-ui/icon";
 import {
@@ -468,7 +469,10 @@ function RunRow({
       {openable ? (
         <Icon
           name="ChevronRight"
-          className="size-3.5 shrink-0 text-subtle-foreground opacity-0 transition-opacity group-hover/run:opacity-100 group-focus-visible/run:opacity-100"
+          className={cn(
+            "size-3.5 shrink-0 text-subtle-foreground opacity-0 transition-opacity group-hover/run:opacity-100 group-focus-visible/run:opacity-100",
+            COARSE_POINTER_HOVER_REVEAL_VISIBLE_CLASS,
+          )}
           aria-hidden
         />
       ) : null}


### PR DESCRIPTION
## Human comments

## What was wrong

Rows that navigate to detail views reserve space for a trailing chevron, but the chevron was revealed only by hover or keyboard focus. Touch and coarse-pointer devices cannot hover, so the affordance stayed invisible while its empty slot still reduced the available label width.

## What changed

Add a shared capability-based visibility utility for hover-revealed affordances and apply it to `ResourceRowDetailChevron`, covering plugin, marketplace, skill, machine, project, Automations, and Account Pool rows. Apply the same utility to the Automations run-history row's bespoke chevron. Fine-pointer desktop hover and focus behavior remains unchanged; the rule is based on `(pointer: coarse)` and `(hover: none)`, not viewport width.

## How you verified

- Reproduced invisible, space-reserving chevrons on coarse-pointer mobile and tablet viewports before the fix, then verified all affected shared rows expose the chevron afterward.
- Verified fine-pointer desktop rows remain hidden at rest and reveal the chevron on hover and keyboard focus.
- Verified row navigation and nested toggle interactions on touch-sized viewports.
- Rebased onto current `main`, then ran Turbo test, typecheck, and lint gates for `@bb/shared-ui`, `@bb/app`, and `bb-plugin-automations`: 4,109 app tests and 80 Automations tests passed; all ten Turbo tasks passed with zero lint errors.
- Built the packaged Automations plugin and confirmed its scoped CSS contains both capability rules.
- Ran targeted Oxfmt and `git diff --check` on the four-file patch.

> AGENT GENERATED
