### PR TITLE
test(account-pool): isolate routing fixture from external I/O

### DIFF
--- a/plugins/account-pool/src/server.test.ts
+++ b/plugins/account-pool/src/server.test.ts
@@ -5232,14 +5232,10 @@ describe("Account Pool plugin", () => {
   });
 
   it("suppresses env and health only for the provider whose routing is off", async () => {
-    const upstream = await startUpstream((_request, response) => {
-      response.writeHead(200, { "content-type": "application/json" });
-      response.end("{}");
-    });
-    cleanups.push(upstream.close);
     const fixture = await createFixture({
-      upstreamUrl: upstream.url,
+      upstreamUrl: "https://upstream.example",
       options: {
+        fetch: async () => Response.json({}),
         codexUsageUrl: EMPTY_USAGE_URL,
         importCodexCredentials: async () => ({
           accessToken: "codex-access",


### PR DESCRIPTION
## Human comments

## What was wrong

The provider-routing test combined deterministic RPC, CLI, provider-env, health, token, and status assertions with I/O unrelated to those assertions: it bound a real TCP upstream that received no request, then used the runtime `fetch` implementation for the forced Codex usage refresh triggered by `account.add`. Under the packages shard's nested worker pressure, that awaited refresh made the otherwise deterministic test scheduler-sensitive enough to hit Vitest's unchanged 5,000 ms ceiling. The shard is still systemically oversubscribed because four Turbo package tasks can each start a Vitest worker pool on four vCPUs, but that is the reproduction condition rather than the test's root cause. The stable failure is recorded in [main run 34314303775](https://github.com/get-bb/bb/actions/runs/34314303775/job/102347186637).

## What changed

The routing test now uses the suite's in-memory `Response.json({})` fetch fixture and a non-listening placeholder upstream URL. This removes the unused socket lifecycle and external runtime fetch while preserving the imported Codex account, forced usage-refresh result, CLI routing mutation, Claude env and health suppression, Codex token/base URL assertion, final status assertion, and the global 5,000 ms timeout.

Current main advanced from the frozen verified base `4ae0a7c893e9922721e0e367c72aa3a1a2990e7c` to `210645bc2095553028f629b50e5414858383177b` through non-overlapping changes; the branch intentionally remains based on the independently verified frozen commit.

## How you verified

- Before the fix, a process-group-bounded delayed 512-way Intel contention run reproduced `Test timed out in 5000ms`; Vitest reported 8,263 ms.
- With the same contention harness after the fix, the exact test passed in 62 ms with the 5,000 ms ceiling unchanged. An unloaded focused run passed in 70 ms; the original unloaded baseline was 405 ms.
- `pnpm exec turbo run test --filter=bb-plugin-account-pool --force --output-logs=new-only` — 10 files and 264 tests passed.
- `pnpm exec turbo run typecheck --filter=bb-plugin-account-pool --force --output-logs=new-only` — passed.
- `pnpm exec turbo run build --filter=bb-plugin-account-pool --force --output-logs=new-only` — scoped generated prerequisites passed; the plugin has no standalone build script.
- `pnpm exec turbo run build --filter=bb-app --force --output-logs=new-only` — 12 tasks passed, including the built-in plugin consumer path.
- `pnpm exec oxfmt plugins/account-pool/src/server.test.ts --check` and `git diff --check` — passed.
- Every stress, test, typecheck, and build command ran in a bounded process group. Final process inspection found no burner, Vitest, Turbo, or build survivors.

> AGENT GENERATED
