### PR TITLE
Approve MacHatter1 for pull requests

### DIFF
--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -66,3 +66,4 @@ danielbachhuber
 aivanov93
 MayankBansal12
 vznh
+MacHatter1


### PR DESCRIPTION
## Human comments

## What was wrong

MacHatter1 was absent from the approved contributors list, so the PR gate would close their pull requests without approval.

## What changed

Added MacHatter1 to `.github/APPROVED_CONTRIBUTORS`.

## How you verified

Verified the entry appears exactly once and matches the PR gate’s case-insensitive lookup. `git diff --check` passed. The pre-push scan found no EAP codename mentions in the working tree, HEAD, or push range.

> AGENT GENERATED
