### PR TITLE
Fix scrolling in machine picker menus

### DIFF
--- a/apps/app/src/components/pickers/EnvironmentPicker.stories.tsx
+++ b/apps/app/src/components/pickers/EnvironmentPicker.stories.tsx
@@ -206,3 +206,28 @@ export function MachineMenu() {
     </StoryCard>
   );
 }
+
+export function ManyMachines() {
+  const hosts = Array.from({ length: 12 }, (_, index) =>
+    makeHost({ id: `host_scroll_${index}`, name: `Machine ${index + 1}` }),
+  );
+  return (
+    <EnvironmentPickerUI
+      value="provider:project-checkout"
+      sources={hosts.map((host, index) =>
+        makeSource(`src_scroll_${index}`, host.id, "/projects/bb"),
+      )}
+      host={hosts[0] ?? null}
+      isLocal={false}
+      providers={STORY_ENVIRONMENT_PROVIDERS}
+      onSelectProvider={noop}
+      machines={{
+        hosts,
+        localDaemonHostId: null,
+        primaryHostId: hosts[0]?.id ?? null,
+      }}
+      defaultOpen
+      modal={false}
+    />
+  );
+}

--- a/apps/app/src/components/pickers/MachinePicker.test.tsx
+++ b/apps/app/src/components/pickers/MachinePicker.test.tsx
@@ -64,7 +64,9 @@ describe("MachinePickerUI", () => {
     expect(menu.className).toContain(
       "max-h-[min(var(--radix-dropdown-menu-content-available-height),calc(100dvh-0.5rem))]",
     );
-    expect(menu.className).toContain("overflow-y-auto");
+    expect(menu.className).toContain("overflow-auto");
+    expect(menu.className).toContain("overflow-x-hidden");
+    expect(menu.className).not.toContain("overflow-hidden");
     expect(menu.className).toContain("overscroll-contain");
   });
 

--- a/packages/shared-ui/src/components/ui/option-display.tsx
+++ b/packages/shared-ui/src/components/ui/option-display.tsx
@@ -9,7 +9,7 @@ export const OPTION_INTERACTIVE_CLASS_NAME =
 export const OPTION_CONTENT_CLASS_NAME = "flex min-w-0 items-center gap-1.5";
 export const OPTION_TRIGGER_CONTENT_CLASS_NAME = "contents";
 export const OPTION_MENU_CONTENT_CLASS_NAME =
-  "max-h-[min(var(--radix-dropdown-menu-content-available-height),calc(100dvh-0.5rem))] w-max min-w-0 max-w-96 overflow-y-auto overscroll-contain";
+  "max-h-[min(var(--radix-dropdown-menu-content-available-height),calc(100dvh-0.5rem))] w-max min-w-0 max-w-96 overflow-auto overflow-x-hidden overscroll-contain";
 export const OPTION_MUTED_CLASS_NAME =
   "text-muted-foreground hover:text-muted-foreground";
 


### PR DESCRIPTION
## Human comments

## What was wrong

Picker menus retained both `overflow-hidden` and `overflow-y-auto` after class merging. A later-loaded overflow utility stylesheet could make the shorthand win, clipping the machines list and preventing wheel scrolling to the remaining checkout and worktree options. The conflict was reproduced in an isolated browser fixture with a later `overflow-hidden` utility rule.

## What changed

Use `overflow-auto overflow-x-hidden` in the shared picker menu classes so class merging removes the conflicting `overflow-hidden` shorthand while retaining vertical scrolling and horizontal clipping. Extend the machine picker regression assertion and add a 12-machine Environment Picker story for browser verification.

## How you verified

- `pnpm exec turbo run test --filter=@bb/app -- EnvironmentPicker.test.tsx MachinePicker.test.tsx`: 28 tests passed using Node 22.23.2.
- Chromium, 1000 × 500 viewport, 12-machine story: the conflicting stylesheet prevented wheel scrolling before the fix (`scrollTop: 0`); after the fix, wheel input reached the bottom (`scrollTop: 482`) and clicking the final machine's Worktree option closed the menu.
- Mobile Chrome emulation, 390 × 600: touch input scrolled the compact drawer (`scrollTop: 393`). Native iOS Safari was not tested.
- `git diff --check` passed. Working-tree and push-range scan clean: no EAP codename mentions found.

> AGENT GENERATED
