### PR TITLE
Remove gap above plugin configuration banner

### DIFF
--- a/apps/app/src/views/SettingsView.tsx
+++ b/apps/app/src/views/SettingsView.tsx
@@ -1126,11 +1126,13 @@ export function SettingsView() {
     const pluginId = matchPath(SETTINGS_PLUGIN_ROUTE_PATH, location.pathname)
       ?.params.pluginId;
     return (
-      <div className="-mx-4 -mt-4 flex min-h-0 flex-1 flex-col overflow-hidden pt-4 md:-mx-5 md:-mt-5 md:pt-5">
+      <div className="-mx-4 -mt-4 flex min-h-0 flex-1 flex-col overflow-hidden md:-mx-5 md:-mt-5">
         {pluginId ? (
           <PluginDetailPaneView pluginId={pluginId} />
         ) : (
-          <PluginsOverview />
+          <div className="flex min-h-0 flex-1 flex-col pt-4 md:pt-5">
+            <PluginsOverview />
+          </div>
         )}
       </div>
     );


### PR DESCRIPTION
## Human comments

## What was wrong

The Settings plugin pane's full-bleed wrapper canceled the page padding and then immediately added top padding back. That padding sat outside the plugin detail pane, leaving a blank strip between the Settings header and the full-width “Needs configuration” banner.

## What changed

Let the shared plugin pane bleed to the top edge, matching its layout outside Settings, and move the top padding onto the installed-plugins overview—the child that does not provide its own page spacing. Plugin-detail banners now sit flush below the header while the overview keeps its existing spacing.

## How you verified

- Reproduced and measured the gap before the change, then verified the banner starts at the header divider on desktop and compact layouts.
- Verified the banner remains sticky, wraps at 320px, and its Open settings and Reload actions still work.
- Verified healthy plugin details and the installed-plugins overview retain the intended spacing.
- Ran Turbo app test, typecheck, and lint gates: all 496 test files passed and lint reported zero errors.
- Ran formatting and `git diff --check` on the one-file patch.

> AGENT GENERATED
