### PR TITLE
Improve image preview sizing and lightbox support

### DIFF
--- a/apps/app/src/components/secondary-panel/FilePreview.tsx
+++ b/apps/app/src/components/secondary-panel/FilePreview.tsx
@@ -19,6 +19,7 @@ import { useAppCommandShortcut } from "@/components/commands/AppCommandProvider"
 import { AppCommandShortcutHint } from "@/components/commands/AppCommandShortcutHint";
 import type { MarkdownLinkRouting } from "@/components/ui/markdown-link-routing.js";
 import { MarkdownPreview } from "@/components/ui/markdown-preview.js";
+import { ImageLightbox } from "@/components/ui/image-lightbox.js";
 import {
   Tooltip,
   TooltipContent,
@@ -1040,12 +1041,23 @@ function CsvFilePreview({ file, onSelectionAddToChat }: CsvFilePreviewProps) {
 }
 
 function FilePreviewImage({ url, alt }: FilePreviewImageProps) {
+  const [isLightboxOpen, setIsLightboxOpen] = useState(false);
+
   return (
     <div className="pt-4">
-      <img
-        src={url}
-        alt={alt}
-        className="block max-h-[34rem] w-full object-contain"
+      <button
+        type="button"
+        className="block w-full cursor-zoom-in"
+        aria-label={`Open ${alt} in full screen preview`}
+        onClick={() => setIsLightboxOpen(true)}
+      >
+        <img src={url} alt={alt} className="mx-auto block h-auto max-w-full" />
+      </button>
+      <ImageLightbox
+        title={alt}
+        imageSrc={isLightboxOpen ? url : null}
+        imageAlt={alt}
+        onClose={() => setIsLightboxOpen(false)}
       />
     </div>
   );


### PR DESCRIPTION
## Human comments

## What was wrong

Image files in the secondary-panel preview were forced to the pane width and capped at a fixed height. That stretched small images and shrank larger images instead of showing them at their natural size within the available width. The preview also had no path to inspect the image at full size.

## What changed

Size image previews at their natural dimensions up to the panel width, center smaller images, and make the preview an accessible button that opens the existing image lightbox.

## How you verified

- Compared small and large image previews at desktop and compact widths and confirmed small images are not upscaled while large images remain constrained to the pane.
- Verified click, tap, and keyboard activation open the existing lightbox and that its close behavior works.
- Ran the full Turbo app test, typecheck, and lint gates: all 496 test files passed and lint reported zero errors.
- Ran targeted formatting and git diff checks on the one-file patch.

> AGENT GENERATED