### PR TITLE
Add plugin settings loading skeleton

### DIFF
--- a/apps/app/src/components/plugin/PluginSettings.test.tsx
+++ b/apps/app/src/components/plugin/PluginSettings.test.tsx
@@ -647,6 +647,118 @@ describe("PluginSettingsPage", () => {
     ).toBeTruthy();
   });
 
+  it("shows a skeleton while the plugin list loads, then the real settings", async () => {
+    let resolveList: (response: Response) => void = () => {
+      throw new Error("Plugin list request did not start");
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (url === "/api/v1/plugins/linear/settings")
+          return jsonOk(SETTINGS_VIEW);
+        return new Promise<Response>((resolve) => {
+          resolveList = resolve;
+        });
+      }),
+    );
+
+    const { wrapper: QueryClientWrapper } = createQueryClientTestHarness();
+    render(
+      <MemoryRouter>
+        <QueryClientWrapper>
+          <PluginSettingsPage pluginId="linear" />
+        </QueryClientWrapper>
+      </MemoryRouter>,
+    );
+
+    const skeleton = await screen.findByTestId("plugin-settings-skeleton");
+    expect(skeleton.getAttribute("role")).toBe("status");
+    expect(screen.getByText("Loading plugin settings…")).toBeTruthy();
+
+    resolveList(jsonOk({ plugins: [installedPlugin(true)] }));
+
+    expect(await screen.findByRole("heading", { name: "Linear" })).toBeTruthy();
+    expect(screen.queryByTestId("plugin-settings-skeleton")).toBeNull();
+  });
+
+  it("reports a failed plugin list instead of a skeleton or a missing plugin", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("offline");
+      }),
+    );
+
+    const { wrapper: QueryClientWrapper } = createQueryClientTestHarness();
+    render(
+      <MemoryRouter>
+        <QueryClientWrapper>
+          <PluginSettingsPage pluginId="linear" />
+        </QueryClientWrapper>
+      </MemoryRouter>,
+    );
+
+    expect(
+      await screen.findByText("Could not load plugin settings."),
+    ).toBeTruthy();
+    expect(screen.queryByTestId("plugin-settings-skeleton")).toBeNull();
+  });
+
+  it("keeps loaded settings visible when a background plugin-list refresh fails", async () => {
+    let pluginListRequests = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (url === "/api/v1/plugins/linear/settings") {
+          return jsonOk(SETTINGS_VIEW);
+        }
+        pluginListRequests += 1;
+        if (pluginListRequests === 1) {
+          return jsonOk({ plugins: [installedPlugin(true)] });
+        }
+        throw new Error("offline");
+      }),
+    );
+
+    const { queryClient, wrapper: QueryClientWrapper } =
+      createQueryClientTestHarness();
+    render(
+      <MemoryRouter>
+        <QueryClientWrapper>
+          <PluginSettingsPage pluginId="linear" />
+        </QueryClientWrapper>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByRole("heading", { name: "Linear" })).toBeTruthy();
+
+    await queryClient.invalidateQueries();
+
+    expect(screen.getByRole("heading", { name: "Linear" })).toBeTruthy();
+    expect(screen.queryByText("Could not load plugin settings.")).toBeNull();
+  });
+
+  it("keeps the not-installed message free of loading affordances", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonOk({ plugins: [] })),
+    );
+
+    const { wrapper: QueryClientWrapper } = createQueryClientTestHarness();
+    render(
+      <MemoryRouter>
+        <QueryClientWrapper>
+          <PluginSettingsPage pluginId="linear" />
+        </QueryClientWrapper>
+      </MemoryRouter>,
+    );
+
+    expect(
+      await screen.findByText("This plugin is not installed."),
+    ).toBeTruthy();
+    expect(screen.queryByTestId("plugin-settings-skeleton")).toBeNull();
+  });
+
   it("omits Configuration for an enabled plugin with no available settings", async () => {
     vi.stubGlobal(
       "fetch",

--- a/apps/app/src/components/plugin/PluginSettings.tsx
+++ b/apps/app/src/components/plugin/PluginSettings.tsx
@@ -15,6 +15,7 @@ import { Textarea } from "@bb/shared-ui/textarea";
 import { Link } from "react-router-dom";
 import { SettingsWithControl } from "@/components/ui/settings-section.js";
 import { getPluginDetailRoutePath } from "@/lib/route-paths";
+import { Skeleton } from "@bb/shared-ui/skeleton";
 import { Switch } from "@bb/shared-ui/switch";
 import {
   ResourceDetailConfigurationSection,
@@ -448,16 +449,80 @@ const PLUGIN_STATUSES_WITH_SETTINGS = [
   "degraded",
 ];
 
+function PluginSettingsFieldSkeleton() {
+  return (
+    <div className="min-w-0 space-y-2">
+      <div className="flex h-5 items-center">
+        <Skeleton className="h-3.5 w-40 max-w-[60%]" />
+      </div>
+      <div className="flex h-4 items-center">
+        <Skeleton className="h-3 w-72 max-w-full" />
+      </div>
+    </div>
+  );
+}
+
+function PluginSettingsPageSkeleton() {
+  return (
+    <div
+      className="mx-auto w-full max-w-5xl"
+      data-testid="plugin-settings-skeleton"
+      role="status"
+      aria-busy="true"
+    >
+      <span className="sr-only">Loading plugin settings…</span>
+      <div aria-hidden>
+        <header className="flex items-center justify-between gap-4">
+          <div className="flex min-w-0 items-center gap-3">
+            <Skeleton className="size-9 shrink-0" />
+            <div className="min-w-0">
+              <div className="flex h-7 items-center">
+                <Skeleton className="h-4 w-44 max-w-full" />
+              </div>
+              <div className="flex h-4 items-center">
+                <Skeleton className="h-3 w-80 max-w-full" />
+              </div>
+            </div>
+          </div>
+          <Skeleton className="h-5 w-9 shrink-0 rounded-full" />
+        </header>
+        <ResourceDetailStack className="mt-6">
+          <ResourceDetailConfigurationSection
+            label={<Skeleton className="h-3.5 w-24" />}
+          >
+            <ResourceDetailPanel surface="recessed" className="px-3 py-3">
+              <div className="space-y-4">
+                <PluginSettingsFieldSkeleton />
+                <PluginSettingsFieldSkeleton />
+              </div>
+            </ResourceDetailPanel>
+          </ResourceDetailConfigurationSection>
+          <ResourceDetailOverviewSection
+            label={<Skeleton className="h-3.5 w-28" />}
+          >
+            <div className="flex h-5 items-center">
+              <Skeleton className="h-3 w-96 max-w-full" />
+            </div>
+          </ResourceDetailOverviewSection>
+        </ResourceDetailStack>
+      </div>
+    </div>
+  );
+}
+
 export function PluginSettingsPage({ pluginId }: { pluginId: string }) {
   const listQuery = usePluginList({ enabled: true });
   const plugin =
     listQuery.data?.plugins.find(
       (entry: PluginListItem) => entry.id === pluginId,
     ) ?? null;
-  if (listQuery.isFetching && listQuery.data === undefined) {
+  if (listQuery.data === undefined && !listQuery.isError) {
+    return <PluginSettingsPageSkeleton />;
+  }
+  if (listQuery.data === undefined && listQuery.isError) {
     return (
       <p className="text-sm text-muted-foreground" role="status">
-        Loading plugin settings…
+        Could not load plugin settings.
       </p>
     );
   }


### PR DESCRIPTION
## Human comments

## What was wrong

Opening an installed plugin settings route while the plugin list was loading showed only a small “Loading plugin settings…” line in an otherwise blank pane. The eventual content appeared all at once, and an initial list failure was incorrectly presented as if the plugin were not installed.

## What changed

Replace the blank loading state with an accessible skeleton shaped like the loaded plugin settings page: icon, title, description, enable switch, Configuration fields, and Plugin details. Distinguish an initial list failure from a genuinely missing plugin while preserving already-loaded settings if a later background refresh fails.

## How you verified

- Reproduced the loading state by delaying the plugin-list request in the browser and checked desktop and compact layouts in light and dark themes.
- Measured the skeleton and loaded layout positions to confirm the header and Configuration section do not shift.
- Added regressions for the loading-to-loaded transition, initial failure, missing plugin, and failed background refresh with cached data.
- Ran the full Turbo app suite before final review: 497 files and 4,119 tests passed.
- After the review correction, ran the focused PluginSettings suite (20 tests), Turbo app typecheck and lint (zero errors), targeted formatting, and git diff checks.

> AGENT GENERATED