### PR TITLE
Show environment picker loading state

### DIFF
--- a/apps/app/src/components/pickers/EnvironmentPicker.stories.tsx
+++ b/apps/app/src/components/pickers/EnvironmentPicker.stories.tsx
@@ -46,6 +46,16 @@ const noop = () => {};
 export function Overview() {
   return (
     <StoryCard>
+      <StoryRow label="loading" hint="waiting for environment availability">
+        <EnvironmentPickerUI
+          value=""
+          sources={localProjectSources}
+          host={localHost}
+          isLocal
+          isLoading
+          muted
+        />
+      </StoryRow>
       <StoryRow label="local checkout" hint="selected: Project checkout">
         <EnvironmentPickerUI
           value="provider:project-checkout"

--- a/apps/app/src/components/pickers/EnvironmentPicker.test.tsx
+++ b/apps/app/src/components/pickers/EnvironmentPicker.test.tsx
@@ -110,6 +110,65 @@ afterEach(() => {
 });
 
 describe("EnvironmentPickerUI", () => {
+  it.each([false, true])(
+    "shows loading instead of empty options (multiple machines: %s)",
+    (multipleMachines) => {
+      const props = {
+        value: "provider:project-checkout",
+        sources: [],
+        host,
+        isLocal: true,
+        machines: multipleMachines
+          ? {
+              hosts: [host, makeHost({ id: "host_second" })],
+              localDaemonHostId: host.id,
+              primaryHostId: host.id,
+            }
+          : null,
+        onSelectProvider: vi.fn(),
+        modal: false,
+      };
+      const { rerender } = render(<EnvironmentPickerUI {...props} isLoading />);
+      const trigger = screen.getByRole("button", {
+        name: "Environment",
+      });
+      expect(trigger.getAttribute("aria-busy")).toBe("true");
+      expect(
+        trigger.querySelector("[data-environment-loading-placeholder]"),
+      ).not.toBeNull();
+      expect(trigger.textContent).not.toContain("Loading environments…");
+      fireEvent.pointerDown(trigger, { button: 0 });
+      const status = screen.getByRole("status", {
+        name: "Loading environments",
+      });
+      expect(
+        status.querySelectorAll("[data-environment-loading-row]"),
+      ).toHaveLength(4);
+      expect(screen.queryByText("Not set up for this project")).toBeNull();
+      expect(screen.queryByRole("menuitem")).toBeNull();
+
+      rerender(
+        <EnvironmentPickerUI {...props} providers={[checkoutProvider]} />,
+      );
+      expect(screen.queryByRole("status")).toBeNull();
+      expect(
+        trigger.querySelector("[data-environment-loading-placeholder]"),
+      ).toBeNull();
+      expect(
+        screen
+          .getByRole("button", { name: "Environment" })
+          .getAttribute("aria-busy"),
+      ).toBe("false");
+      fireEvent.click(
+        screen.getAllByRole("menuitem", { name: /Project checkout/u })[0]!,
+      );
+      expect(props.onSelectProvider).toHaveBeenCalledWith(
+        checkoutProvider,
+        host.id,
+      );
+    },
+  );
+
   it("bounds arbitrary provider labels without changing selection", () => {
     const verboseProvider = {
       ...checkoutProvider,

--- a/apps/app/src/components/pickers/EnvironmentPicker.tsx
+++ b/apps/app/src/components/pickers/EnvironmentPicker.tsx
@@ -6,6 +6,8 @@ import { Icon, type IconName } from "@bb/shared-ui/icon";
 import { findLocalPathProjectSourceForHost } from "@bb/domain";
 import { pluginIconName } from "@/components/plugin/PluginIcon";
 import { Button } from "@bb/shared-ui/button";
+import { Skeleton } from "@bb/shared-ui/skeleton";
+import { useIsCompactViewport } from "@bb/shared-ui/hooks/use-compact-viewport";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -58,6 +60,7 @@ export interface EnvironmentPickerUIProps {
   isLocal: boolean;
   muted?: boolean;
   disabled?: boolean;
+  isLoading?: boolean;
   className?: string;
   defaultOpen?: boolean;
   modal?: boolean;
@@ -142,6 +145,7 @@ export function EnvironmentPickerUI({
   isLocal,
   muted,
   disabled = false,
+  isLoading = false,
   className,
   defaultOpen,
   modal,
@@ -248,6 +252,7 @@ export function EnvironmentPickerUI({
           variant="ghost"
           size="sm"
           aria-label="Environment"
+          aria-busy={isLoading}
           disabled={disabled}
           data-promptbox-shrinkable-control=""
           className={cn(
@@ -262,8 +267,11 @@ export function EnvironmentPickerUI({
           <span className={OPTION_TRIGGER_CONTENT_CLASS_NAME}>
             {selectedProvider === undefined ? (
               <Icon
-                name={selected.icon}
-                className={COARSE_POINTER_COMPACT_ICON_SIZE_SHRINK_CLASS}
+                name={isLoading ? "Spinner" : selected.icon}
+                className={cn(
+                  COARSE_POINTER_COMPACT_ICON_SIZE_SHRINK_CLASS,
+                  isLoading && "animate-spin",
+                )}
               />
             ) : (
               <EnvironmentProviderIcon
@@ -271,16 +279,29 @@ export function EnvironmentPickerUI({
                 className={COARSE_POINTER_COMPACT_ICON_SIZE_SHRINK_CLASS}
               />
             )}
-            <span className="min-w-0 truncate" data-promptbox-full-label="">
-              {selected.modeLabel}
-            </span>
-            <span
-              className="min-w-0 truncate"
-              data-promptbox-compact-label=""
-              data-promptbox-hide-tiny=""
-            >
-              {selected.compactModeLabel}
-            </span>
+            {isLoading ? (
+              <>
+                <span className="sr-only">Loading environments</span>
+                <Skeleton
+                  aria-hidden
+                  data-environment-loading-placeholder="trigger"
+                  className="h-3 w-20 shrink-0 rounded-sm"
+                />
+              </>
+            ) : (
+              <>
+                <span className="min-w-0 truncate" data-promptbox-full-label="">
+                  {selected.modeLabel}
+                </span>
+                <span
+                  className="min-w-0 truncate"
+                  data-promptbox-compact-label=""
+                  data-promptbox-hide-tiny=""
+                >
+                  {selected.compactModeLabel}
+                </span>
+              </>
+            )}
           </span>
           {disabled ? null : (
             <Icon
@@ -295,10 +316,16 @@ export function EnvironmentPickerUI({
       </DropdownMenuTrigger>
       <DropdownMenuContent
         align="start"
-        className={cn(OPTION_MENU_CONTENT_CLASS_NAME, "max-w-80")}
+        className={cn(
+          OPTION_MENU_CONTENT_CLASS_NAME,
+          "max-w-80",
+          isLoading && "min-w-52",
+        )}
         mobileTitle="Environment"
       >
-        {isMachineMenu && availableMachines ? (
+        {isLoading ? (
+          <EnvironmentPickerLoadingRows />
+        ) : isMachineMenu && availableMachines ? (
           <MachineGroupedEnvironmentOptions
             machines={availableMachines}
             sources={sources}
@@ -328,6 +355,38 @@ export function EnvironmentPickerUI({
         )}
       </DropdownMenuContent>
     </DropdownMenu>
+  );
+}
+
+const ENVIRONMENT_LOADING_ROW_WIDTHS = [
+  "w-20",
+  "w-28",
+  "w-24",
+  "w-32",
+] as const;
+
+function EnvironmentPickerLoadingRows() {
+  const isCompactViewport = useIsCompactViewport();
+
+  return (
+    <div role="status" aria-label="Loading environments" className="pb-1">
+      <span className="sr-only">Loading environments</span>
+      {ENVIRONMENT_LOADING_ROW_WIDTHS.map((widthClassName) => (
+        <div
+          key={widthClassName}
+          data-environment-loading-row=""
+          aria-hidden
+          className={cn(
+            "flex items-center rounded-sm px-2",
+            isCompactViewport ? "py-2" : "py-[0.3125rem]",
+          )}
+        >
+          <Skeleton
+            className={cn("h-3 max-w-[75%] rounded-sm", widthClassName)}
+          />
+        </div>
+      ))}
+    </div>
   );
 }
 

--- a/apps/app/src/components/promptbox/NewThreadComposer.tsx
+++ b/apps/app/src/components/promptbox/NewThreadComposer.tsx
@@ -1465,6 +1465,7 @@ export function NewThreadComposer({
               onChange: changeEnvironment,
               sources: projectSources,
               disabled: locks.environment,
+              isLoading: environmentProviders === undefined,
               providers: environmentProviders ?? [],
               providersByHostId: environmentProvidersByHostId,
               selectedProviderHostId: providerHostId,

--- a/apps/app/src/components/promptbox/NewThreadPromptBox.test.tsx
+++ b/apps/app/src/components/promptbox/NewThreadPromptBox.test.tsx
@@ -204,6 +204,7 @@ describe("ProjectlessEnvSlot", () => {
   };
 
   function makeEnvironment(overrides: {
+    isLoading?: boolean;
     value?: string;
     providers?: readonly SystemEnvironmentProvider[];
     onSelectProvider?: (
@@ -222,6 +223,7 @@ describe("ProjectlessEnvSlot", () => {
         localDaemonHostId: host.id,
         primaryHostId: host.id,
       },
+      isLoading: overrides.isLoading ?? false,
       providers: overrides.providers ?? [personalProvider],
       selectedProviderHostId: host.id,
       onSelectProvider: overrides.onSelectProvider ?? vi.fn(),
@@ -245,6 +247,28 @@ describe("ProjectlessEnvSlot", () => {
       disabled: false,
     };
   }
+
+  it("shows environment loading before resolving to the machine slot", () => {
+    const { rerender } = render(
+      <ProjectlessEnvSlot
+        environment={makeEnvironment({ providers: [], isLoading: true })}
+        worktree={makeWorktree()}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Environment" })).not.toBeNull();
+    expect(screen.queryByRole("button", { name: "Machine" })).toBeNull();
+    rerender(
+      <ProjectlessEnvSlot
+        environment={makeEnvironment({
+          providers: [personalProvider],
+          isLoading: false,
+        })}
+        worktree={makeWorktree()}
+      />,
+    );
+    expect(screen.queryByRole("button", { name: "Environment" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Machine" })).not.toBeNull();
+  });
 
   it("keeps the machine slot when only one provider is available", () => {
     render(

--- a/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
+++ b/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
@@ -82,6 +82,7 @@ export interface NewThreadEnvironmentConfig {
   machines?: EnvironmentPickerMachines | null;
   onRequestMachineSetup?: (host: Host) => void;
   disabled?: boolean;
+  isLoading?: boolean;
   providers?: readonly SystemEnvironmentProvider[];
   providersByHostId?: EnvironmentPickerUIProps["providersByHostId"];
   selectedProviderHostId?: string | null;
@@ -438,6 +439,7 @@ export function ThreadEnvSlot({
         machines={environment.machines}
         onRequestMachineSetup={environment.onRequestMachineSetup}
         disabled={environment.disabled}
+        isLoading={environment.isLoading}
         providers={environment.providers}
         providersByHostId={environment.providersByHostId}
         selectedProviderHostId={environment.selectedProviderHostId}
@@ -487,7 +489,11 @@ export function ProjectlessEnvSlot({
         )
       : undefined;
   const showReuseEnvironmentPicker = parsedEnvironment?.type === "reuse";
-  if (providers.length <= 1 && !showReuseEnvironmentPicker) {
+  if (
+    !environment.isLoading &&
+    providers.length <= 1 &&
+    !showReuseEnvironmentPicker
+  ) {
     return <ProjectlessMachineSlot environment={environment} />;
   }
 
@@ -501,6 +507,7 @@ export function ProjectlessEnvSlot({
         isLocal={environment.isLocal}
         machines={environment.machines}
         disabled={environment.disabled}
+        isLoading={environment.isLoading}
         providers={providers}
         providersByHostId={environment.providersByHostId}
         selectedProviderHostId={environment.selectedProviderHostId}


### PR DESCRIPTION
## Human comments

## What was wrong

The new-thread environment picker waited for environment-provider availability but rendered the pending result as an empty provider list. Its trigger showed the generic Environment label, and opening the picker could show an empty menu or a premature “Not set up for this project” message.

## What changed

Carry the provider-loading state into the environment picker. Match the model picker pattern with a skeleton trigger and four skeleton menu rows while keeping the control interactive. Suppress empty/setup messaging until providers resolve, including in projectless prompts, then transition to the normal environment or machine control.

## How you verified

- Delayed environment responses in the browser and compared before/after screenshots with the model picker loading state.
- Verified the loading control transitions to selectable provider options and that projectless prompts transition to their machine slot when appropriate.
- Added focused single- and multi-machine loading coverage plus the projectless transition regression.
- Ran 34 focused picker/prompt-box tests, Turbo app typecheck and lint with zero errors, targeted formatting, and git diff checks.

> AGENT GENERATED