### PR TITLE
Preserve overlapping thread provisioning advances

### DIFF
--- a/apps/server/src/lifecycle-dedupers.ts
+++ b/apps/server/src/lifecycle-dedupers.ts
@@ -1,7 +1,9 @@
 import type { AvailableModel } from "@bb/domain";
 import {
   createAsyncDeduper,
+  createAsyncRerunner,
   type AsyncDeduper,
+  type AsyncRerunner,
 } from "./services/lib/async-deduper.js";
 import {
   createAsyncTtlMemo,
@@ -20,7 +22,7 @@ export interface LifecycleDedupers {
   environmentCleanupAdvance: AsyncDeduper<string, void>;
   providerModelList: AsyncTtlMemo<string, ProviderModelListMemoValue>;
   queuedMessageDispatch: AsyncDeduper<string, void>;
-  threadProvisionAdvance: AsyncDeduper<string, void>;
+  threadProvisionAdvance: AsyncRerunner<string>;
 }
 
 export function createLifecycleDedupers(): LifecycleDedupers {
@@ -31,6 +33,6 @@ export function createLifecycleDedupers(): LifecycleDedupers {
       ttlMs: PROVIDER_MODEL_LIST_MEMO_TTL_MS,
     }),
     queuedMessageDispatch: createAsyncDeduper<string, void>(),
-    threadProvisionAdvance: createAsyncDeduper<string, void>(),
+    threadProvisionAdvance: createAsyncRerunner<string>(),
   };
 }

--- a/apps/server/src/services/lib/async-deduper.ts
+++ b/apps/server/src/services/lib/async-deduper.ts
@@ -2,6 +2,10 @@ export interface AsyncDeduper<TKey, TValue> {
   run(key: TKey, task: () => Promise<TValue>): Promise<TValue>;
 }
 
+export interface AsyncRerunner<TKey> {
+  run(key: TKey, task: () => Promise<void>): Promise<void>;
+}
+
 export function createAsyncDeduper<TKey, TValue>(): AsyncDeduper<TKey, TValue> {
   const pendingByKey = new Map<TKey, Promise<TValue>>();
 
@@ -19,6 +23,57 @@ export function createAsyncDeduper<TKey, TValue>(): AsyncDeduper<TKey, TValue> {
       });
       pendingByKey.set(key, startedTask);
       return startedTask;
+    },
+  };
+}
+
+export function createAsyncRerunner<TKey>(): AsyncRerunner<TKey> {
+  type State = {
+    nextTask: (() => Promise<void>) | null;
+    promise: Promise<void>;
+  };
+  const pendingByKey = new Map<TKey, State>();
+
+  return {
+    run(key, task) {
+      const pending = pendingByKey.get(key);
+      if (pending !== undefined) {
+        pending.nextTask = task;
+        return pending.promise;
+      }
+
+      const state: State = {
+        nextTask: task,
+        promise: Promise.resolve(),
+      };
+      const drain = async (): Promise<void> => {
+        let failed = false;
+        let firstError: unknown;
+        while (state.nextTask !== null) {
+          const nextTask = state.nextTask;
+          state.nextTask = null;
+          try {
+            await nextTask();
+          } catch (error) {
+            if (!failed) {
+              failed = true;
+              firstError = error;
+            }
+          }
+        }
+        if (failed) {
+          throw firstError;
+        }
+      };
+      state.promise = Promise.resolve()
+        .then(drain)
+        .finally(() => {
+          if (pendingByKey.get(key) === state) {
+            pendingByKey.delete(key);
+          }
+        });
+      pendingByKey.set(key, state);
+      return state.promise;
     },
   };
 }

--- a/apps/server/src/services/lib/async-deduper.ts
+++ b/apps/server/src/services/lib/async-deduper.ts
@@ -28,8 +28,9 @@ export function createAsyncDeduper<TKey, TValue>(): AsyncDeduper<TKey, TValue> {
 }
 
 export function createAsyncRerunner<TKey>(): AsyncRerunner<TKey> {
+  type Task = () => Promise<void>;
   type State = {
-    nextTask: (() => Promise<void>) | null;
+    nextTask: Task | null;
     promise: Promise<void>;
   };
   const pendingByKey = new Map<TKey, State>();
@@ -42,15 +43,26 @@ export function createAsyncRerunner<TKey>(): AsyncRerunner<TKey> {
         return pending.promise;
       }
 
+      let resolveCompletion: (() => void) | null = null;
+      let rejectCompletion: ((reason?: unknown) => void) | null = null;
+      const completion = new Promise<void>((resolve, reject) => {
+        resolveCompletion = resolve;
+        rejectCompletion = reject;
+      });
+      if (resolveCompletion === null || rejectCompletion === null) {
+        throw new Error("Failed to create rerunner completion promise");
+      }
       const state: State = {
-        nextTask: task,
-        promise: Promise.resolve(),
+        nextTask: null,
+        promise: completion,
       };
-      const drain = async (): Promise<void> => {
+      pendingByKey.set(key, state);
+
+      const drain = async (firstTask: Task): Promise<void> => {
         let failed = false;
         let firstError: unknown;
-        while (state.nextTask !== null) {
-          const nextTask = state.nextTask;
+        let nextTask: Task | null = firstTask;
+        while (nextTask !== null) {
           state.nextTask = null;
           try {
             await nextTask();
@@ -60,20 +72,17 @@ export function createAsyncRerunner<TKey>(): AsyncRerunner<TKey> {
               firstError = error;
             }
           }
+          nextTask = state.nextTask;
+        }
+        if (pendingByKey.get(key) === state) {
+          pendingByKey.delete(key);
         }
         if (failed) {
           throw firstError;
         }
       };
-      state.promise = Promise.resolve()
-        .then(drain)
-        .finally(() => {
-          if (pendingByKey.get(key) === state) {
-            pendingByKey.delete(key);
-          }
-        });
-      pendingByKey.set(key, state);
-      return state.promise;
+      void drain(task).then(resolveCompletion, rejectCompletion);
+      return completion;
     },
   };
 }

--- a/apps/server/test/services/async-rerunner.test.ts
+++ b/apps/server/test/services/async-rerunner.test.ts
@@ -4,6 +4,40 @@ import { createLifecycleDedupers } from "../../src/lifecycle-dedupers.js";
 import { createAsyncRerunner } from "../../src/services/lib/async-deduper.js";
 
 describe("createAsyncRerunner", () => {
+  it("starts the first task synchronously", async () => {
+    const runner = createAsyncRerunner<string>();
+    const calls: string[] = [];
+
+    const completion = runner.run("thread", async () => {
+      calls.push("task");
+    });
+
+    expect(calls).toEqual(["task"]);
+    await completion;
+  });
+
+  it("runs a task requested as the completed drain is settling", async () => {
+    const runner = createAsyncRerunner<string>();
+    const calls: string[] = [];
+    const trailing = createDeferredPromise<void>();
+
+    const first = runner.run("thread", async () => {
+      calls.push("first");
+    });
+    queueMicrotask(() => {
+      queueMicrotask(() => {
+        void runner
+          .run("thread", async () => {
+            calls.push("trailing");
+          })
+          .then(trailing.resolve, trailing.reject);
+      });
+    });
+
+    await Promise.all([first, trailing.promise]);
+    expect(calls).toEqual(["first", "trailing"]);
+  });
+
   it("runs the latest task requested while the key is in flight", async () => {
     const runner = createLifecycleDedupers().threadProvisionAdvance;
     const firstStarted = createDeferredPromise<void>();

--- a/apps/server/test/services/async-rerunner.test.ts
+++ b/apps/server/test/services/async-rerunner.test.ts
@@ -1,0 +1,56 @@
+import { createDeferredPromise } from "@bb/test-helpers";
+import { describe, expect, it } from "vitest";
+import { createLifecycleDedupers } from "../../src/lifecycle-dedupers.js";
+import { createAsyncRerunner } from "../../src/services/lib/async-deduper.js";
+
+describe("createAsyncRerunner", () => {
+  it("runs the latest task requested while the key is in flight", async () => {
+    const runner = createLifecycleDedupers().threadProvisionAdvance;
+    const firstStarted = createDeferredPromise<void>();
+    const releaseFirst = createDeferredPromise<void>();
+    const calls: string[] = [];
+
+    const first = runner.run("thread", async () => {
+      calls.push("first");
+      firstStarted.resolve();
+      await releaseFirst.promise;
+    });
+    await firstStarted.promise;
+    const superseded = runner.run("thread", async () => {
+      calls.push("superseded");
+    });
+    const latest = runner.run("thread", async () => {
+      calls.push("latest");
+    });
+
+    expect(calls).toEqual(["first"]);
+    releaseFirst.resolve();
+    await Promise.all([first, superseded, latest]);
+    expect(calls).toEqual(["first", "latest"]);
+  });
+
+  it("runs a pending task after the in-flight task rejects", async () => {
+    const runner = createAsyncRerunner<string>();
+    const firstStarted = createDeferredPromise<void>();
+    const releaseFirst = createDeferredPromise<void>();
+    const calls: string[] = [];
+
+    const first = runner.run("thread", async () => {
+      calls.push("first");
+      firstStarted.resolve();
+      await releaseFirst.promise;
+      throw new Error("first failed");
+    });
+    await firstStarted.promise;
+    const pending = runner.run("thread", async () => {
+      calls.push("pending");
+    });
+    releaseFirst.resolve();
+
+    await Promise.all([
+      expect(first).rejects.toThrow("first failed"),
+      expect(pending).rejects.toThrow("first failed"),
+    ]);
+    expect(calls).toEqual(["first", "pending"]);
+  });
+});


### PR DESCRIPTION
## Human comments

## What was wrong

Thread provisioning advances are state-reconciliation requests, but the original `threadProvisionAdvance` async deduper discarded overlapping requests. PR #3320 preserved one provider-timer recheck after a specific overlap, but it did not change that underlying edge-dropping contract.

The first revision of this PR introduced a trailing-edge rerunner, but its drain still had a lost-wakeup window: after the drain observed no pending task and resolved, keyed state remained visible until a later promise `finally` callback removed it. An advance arriving in that microtask window attached its task to the already-completed drain, then cleanup discarded it. The implementation also deferred the first task by one microtask instead of preserving the original synchronous start ordering. Hosted server CI exposed the cleanup race deterministically as seven provisioning tests that never reached the host command boundary.

## What changed

The keyed rerunner now installs its completion state before starting work, invokes the first task synchronously, and consumes the latest overlapping task after each pass. When no task remains, it removes the keyed state synchronously in the same continuation that observed the empty queue, before settling caller completion. There is therefore no visible completed drain to which a later request can attach. Pending work is still drained after an earlier pass rejects, and callers still observe the first error.

Only `threadProvisionAdvance` uses this behavior; existing dedupers retain their contracts. The server/host-daemon wire contract is unchanged, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged. No test, polling, retry, or wrapper timeout was increased.

## How you verified

- On PR head `e4a919fc58c9cbd032b1d42ce9717e13ee0ea921`, the seven hosted failures reproduced locally 7/7 with the same `captured: none` command-boundary signature.
- Two deterministic rerunner regressions were red before the correction: the first task had not started synchronously, and a task requested between drain completion and cleanup was lost. After the correction, the rerunner suite passes 4/4.
- The seven focused provisioning regressions pass 7/7 under Turbo without changing their clocks.
- `pnpm exec turbo run test --filter=@bb/server -- test/services/async-rerunner.test.ts test/threads/environment-providers.test.ts`: 41/41 passed, including the #3320 recheck coverage.
- `pnpm exec turbo run test --filter=@bb/integration-tests -- fake/smoke/reuse-and-reprovision.test.ts`: 4/4 passed; the assigned case completed in 3.830s.
- Full server Turbo test ran 2,361 tests: 2,350 passed, while 11 unrelated whole-test timeouts were confined to `install-machine-script.test.ts` and `plugin-update.test.ts`. The latter passed 27/27 in focused follow-up; installer follow-up passed 20/22, with two subprocess-heavy cases exceeding their existing five-second ceilings. No clocks were changed.
- Full integration Turbo test ran 81 tests: 80 passed, including all four reuse/reprovision cases; the sole unrelated `custom-models` whole-test timeout passed 2/2 in focused follow-up without changing clocks.
- Hosted CI run `34394258233` passed completely on corrected head `4e2e1ee2119b347718c724f84b5bfbca195a4730`, including both the server and integration jobs.
- `pnpm exec turbo run build typecheck --filter=@bb/server --filter=@bb/integration-tests`: all 8 tasks passed.
- `pnpm exec oxfmt apps/server/src/services/lib/async-deduper.ts apps/server/test/services/async-rerunner.test.ts --check` and `git diff --check` passed.
- Every test process used an external process-group deadline and signal cleanup. Audits found no surviving Vitest/Turbo/load process and no `bb-integration-*` temp directory.
- Work remains based on frozen SHA `b88f3c2249c2601d9ea29fe91c71e18310cb9e01`; the verified merge-base remains that exact SHA after `origin/main` advanced.

> AGENT GENERATED: by GPT-5.6-Sol