### PR TITLE
Share host response test fixtures

### DIFF
--- a/packages/domain/src/plugin-sdk-version.ts
+++ b/packages/domain/src/plugin-sdk-version.ts
@@ -1,3 +1,3 @@
-export const PLUGIN_SDK_VERSION = "0.4.51";
+export const PLUGIN_SDK_VERSION = "0.4.52";
 
 export const PLUGIN_SDK_MAJOR = Number(PLUGIN_SDK_VERSION.split(".", 1)[0]);

--- a/packages/plugin-sdk/README.md
+++ b/packages/plugin-sdk/README.md
@@ -149,7 +149,8 @@ await host.harness.lifecycle.dispose();
 ```
 
 `makePluginAgentConfigurationContext`, `makeMessageDispatchHookContext`,
-`makeThreadResponse`, `makeQueueEntry`, and `makeTurnFailedEvent` return
+`makeHostResponse`, `makeThreadResponse`, `makeQueueEntry`, and
+`makeTurnFailedEvent` return
 complete deterministic SDK objects. Pass partial overrides so a behavioral
 test shows only the values relevant to its scenario. Nested context
 members merge partial overrides against complete defaults, so required contract

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@get-bb/plugin-sdk",
-  "version": "0.4.51",
+  "version": "0.4.52",
   "homepage": "https://github.com/get-bb/bb#readme",
   "bugs": {
     "url": "https://github.com/get-bb/bb/issues"

--- a/packages/plugin-sdk/src/testing/__tests__/fake-plugin-host.test.ts
+++ b/packages/plugin-sdk/src/testing/__tests__/fake-plugin-host.test.ts
@@ -14,6 +14,7 @@ import {
 } from "../../internal/host-policy.js";
 import {
   createFakePluginHost,
+  makeHostResponse,
   makeMessageDispatchHookContext,
   makePluginAgentConfigurationContext,
   makeQueueEntry,
@@ -21,6 +22,20 @@ import {
 } from "../index.js";
 
 describe("fixtures", () => {
+  it("builds complete host responses with targeted overrides", () => {
+    expect(makeHostResponse({ id: "host-target", name: "Target" })).toEqual({
+      id: "host-target",
+      name: "Target",
+      status: "connected",
+      type: "persistent",
+      maxPermissionMode: "full",
+      lastSeenAt: null,
+      lastRejectedProtocolVersion: null,
+      createdAt: 0,
+      updatedAt: 0,
+    });
+  });
+
   it("derives linked dispatch identities unless explicitly overridden", () => {
     const inherited = makeMessageDispatchHookContext({
       project: { id: "project-target" },

--- a/packages/plugin-sdk/src/testing/fixtures.ts
+++ b/packages/plugin-sdk/src/testing/fixtures.ts
@@ -1,9 +1,13 @@
 import type {
+  BbPluginApi,
   MessageDispatchHookContext,
   PluginAgentConfigurationContext,
   PluginThreadEventPayloads,
 } from "@get-bb/plugin-sdk";
 
+type HostResponse = Awaited<
+  ReturnType<BbPluginApi["sdk"]["hosts"]["list"]>
+>[number];
 type ThreadResponse = PluginThreadEventPayloads["thread.created"]["thread"];
 type QueueEntry = PluginThreadEventPayloads["message.queued"]["entry"];
 type TurnFailedEvent = PluginThreadEventPayloads["turn.failed"];
@@ -48,6 +52,29 @@ type MessageDispatchHookContextOverrides = Omit<
     NonNullable<MessageDispatchHookContext["queuedMessage"]>
   > | null;
 };
+
+/**
+ * A complete, deterministic host response for faking `bb.sdk.hosts.list()`
+ * and environment-provider contexts. Override only the fields the test cares
+ * about. If the contract grows a required field, this builder fails
+ * typecheck — update the default here.
+ */
+export function makeHostResponse(
+  overrides: Partial<HostResponse> = {},
+): HostResponse {
+  return {
+    id: "host-1",
+    name: "Test host",
+    status: "connected",
+    type: "persistent",
+    maxPermissionMode: "full",
+    lastSeenAt: null,
+    lastRejectedProtocolVersion: null,
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
 
 /**
  * A complete, deterministic `ThreadResponse` for thread lifecycle event

--- a/packages/plugin-sdk/src/testing/index.ts
+++ b/packages/plugin-sdk/src/testing/index.ts
@@ -35,6 +35,7 @@ export {
   type FakeSdkOverrides,
 } from "./fake-sdk.js";
 export {
+  makeHostResponse,
   makeMessageDispatchHookContext,
   makePluginAgentConfigurationContext,
   makeQueueEntry,

--- a/plugins/bb-guide/skills/bb-plugin-authoring/references/backend-api-index.md
+++ b/plugins/bb-guide/skills/bb-plugin-authoring/references/backend-api-index.md
@@ -341,6 +341,7 @@ Read the installed declarations for exact current signatures.
 - `createFakePluginHost`
 - `createFakeSdk`
 - `experimental_scanPublicSdkOnly`
+- `makeHostResponse`
 - `makeMessageDispatchHookContext`
 - `makePluginAgentConfigurationContext`
 - `makeQueueEntry`

--- a/plugins/bb-guide/skills/bb-plugin-authoring/references/testing.md
+++ b/plugins/bb-guide/skills/bb-plugin-authoring/references/testing.md
@@ -72,12 +72,12 @@ await harness.lifecycle.dispose(); // abort services, hooks LIFO, close database
 ```
 
 The exported `makePluginAgentConfigurationContext`,
-`makeMessageDispatchHookContext`, `makeThreadResponse`, `makeQueueEntry`, and
-`makeTurnFailedEvent` fixtures return complete deterministic SDK objects with
-partial overrides, including nested context members. Use them in behavioral
-tests so a new required contract field changes one shared default. Keep schema,
-serialization, and command-output fixtures explicit when their exact complete
-shape is the assertion.
+`makeMessageDispatchHookContext`, `makeHostResponse`, `makeThreadResponse`,
+`makeQueueEntry`, and `makeTurnFailedEvent` fixtures return complete
+deterministic SDK objects with partial overrides, including nested context
+members. Use them in behavioral tests so a new required contract field changes
+one shared default. Keep schema, serialization, and command-output fixtures
+explicit when their exact complete shape is the assertion.
 
 New tests should use the named views: `harness.behavior` drives host inputs,
 `harness.inspection` exposes observable state, and `harness.lifecycle` owns

--- a/plugins/concurrency-limit/server.test.ts
+++ b/plugins/concurrency-limit/server.test.ts
@@ -5,18 +5,17 @@ import type {
 } from "@get-bb/plugin-sdk";
 import {
   createFakePluginHost,
+  makeHostResponse,
   makeMessageDispatchHookContext,
   makeThreadResponse,
 } from "@get-bb/plugin-sdk/testing";
 import { describe, expect, it, vi } from "vitest";
 import plugin from "./server.js";
 
-type HostRecord = Awaited<
-  ReturnType<BbPluginApi["sdk"]["hosts"]["list"]>
->[number];
 type RunningThread = Awaited<
   ReturnType<BbPluginApi["sdk"]["threads"]["listRunning"]>
 >[number];
+type HostResponse = ReturnType<typeof makeHostResponse>;
 type SdkSubscription = Parameters<BbPluginApi["sdk"]["subscribe"]>[0];
 type HostChangedSubscription = Extract<
   SdkSubscription,
@@ -32,20 +31,10 @@ function isHostChangedSubscription(
 const PLUGIN_ID = "concurrency-limit";
 function hostRecord(
   id: string,
-  status: HostRecord["status"] = "connected",
+  status: "connected" | "disconnected" = "connected",
   name = id,
-): HostRecord {
-  return {
-    id,
-    name,
-    status,
-    type: "persistent",
-    maxPermissionMode: "full",
-    lastSeenAt: null,
-    lastRejectedProtocolVersion: null,
-    createdAt: 1,
-    updatedAt: 1,
-  };
+): HostResponse {
+  return makeHostResponse({ id, name, status });
 }
 
 function running(overrides: Partial<RunningThread> = {}): RunningThread {
@@ -81,7 +70,7 @@ interface SetupOptions {
     hostOverrides: Array<{ hostId: string; limit: number }>;
   };
   capacities?: Array<{ hostId: string; availableParallelism: number }>;
-  hosts?: HostRecord[] | (() => HostRecord[]);
+  hosts?: HostResponse[] | (() => HostResponse[]);
   running?: RunningThread[];
   detectedParallelism?: number;
   subscribe?: BbPluginApi["sdk"]["subscribe"];
@@ -263,7 +252,7 @@ describe("configuration", () => {
 
   it("detects a host when it connects after startup", async () => {
     const changes = hostChanges();
-    let status: HostRecord["status"] = "disconnected";
+    let status: HostResponse["status"] = "disconnected";
     const { harness } = await setup({
       hosts: () => [hostRecord("host-a", status)],
       subscribe: changes.subscribe,

--- a/plugins/environment-git-worktree/server.test.ts
+++ b/plugins/environment-git-worktree/server.test.ts
@@ -4,6 +4,7 @@ import type {
 } from "@get-bb/plugin-sdk/environment-provider";
 import {
   createFakePluginHost,
+  makeHostResponse,
   makeThreadResponse,
   type FakePluginHarness,
 } from "@get-bb/plugin-sdk/testing";
@@ -12,7 +13,6 @@ import { worktreeHostContract } from "./contract.js";
 import { GIT_WORKTREE_ENVIRONMENT_PROVIDER_ID } from "./provider-id.js";
 import plugin, { worktreeInputsSchema } from "./server.js";
 
-type Host = NonNullable<PluginEnvironmentProviderCreateContext["host"]>;
 type Project = PluginEnvironmentProviderCreateContext["project"];
 type HostRpcCall = FakePluginHarness["experimental_hostRpcCalls"][number];
 
@@ -23,17 +23,7 @@ const SOURCE_PATH = "/checkouts/bb";
 const WORKTREE_PATH =
   "/data/plugins/environment-git-worktree/worktrees/thr_1/bb";
 
-const PROVISION_HOST: Host = {
-  id: HOST_ID,
-  name: "Fake machine",
-  status: "connected",
-  type: "persistent",
-  maxPermissionMode: "full",
-  lastSeenAt: null,
-  lastRejectedProtocolVersion: null,
-  createdAt: 0,
-  updatedAt: 0,
-};
+const PROVISION_HOST = makeHostResponse({ id: HOST_ID, name: "Fake machine" });
 
 const PROJECT: Project = {
   id: PROJECT_ID,

--- a/plugins/environment-personal-workspace/server.test.ts
+++ b/plugins/environment-personal-workspace/server.test.ts
@@ -4,12 +4,12 @@ import type {
 } from "@get-bb/plugin-sdk/environment-provider";
 import {
   createFakePluginHost,
+  makeHostResponse,
   makeThreadResponse,
   type FakePluginHarness,
 } from "@get-bb/plugin-sdk/testing";
 import { describe, expect, it } from "vitest";
 import plugin from "./server.js";
-type Host = NonNullable<PluginEnvironmentProviderCreateContext["host"]>;
 type Project = PluginEnvironmentProviderCreateContext["project"];
 type HostRpcCall = FakePluginHarness["experimental_hostRpcCalls"][number];
 import { personalWorkspaceHostContract } from "./contract.js";
@@ -25,17 +25,7 @@ function workspacePathFor(pathKey: string): string {
 
 const WORKSPACE_PATH = workspacePathFor(THREAD_ID);
 
-const PROVISION_HOST: Host = {
-  id: HOST_ID,
-  name: "Fake machine",
-  status: "connected",
-  type: "persistent",
-  maxPermissionMode: "full",
-  lastSeenAt: null,
-  lastRejectedProtocolVersion: null,
-  createdAt: 0,
-  updatedAt: 0,
-};
+const PROVISION_HOST = makeHostResponse({ id: HOST_ID, name: "Fake machine" });
 
 const PERSONAL_PROJECT: Project = {
   id: PROJECT_ID,

--- a/plugins/environment-project-checkout/server.test.ts
+++ b/plugins/environment-project-checkout/server.test.ts
@@ -2,7 +2,10 @@ import type {
   PluginEnvironmentProviderCreateContext,
   PluginEnvironmentProviderValidateContext,
 } from "@get-bb/plugin-sdk/environment-provider";
-import { createFakePluginHost } from "@get-bb/plugin-sdk/testing";
+import {
+  createFakePluginHost,
+  makeHostResponse,
+} from "@get-bb/plugin-sdk/testing";
 import { describe, expect, it } from "vitest";
 import { PROJECT_CHECKOUT_ENVIRONMENT_PROVIDER_ID } from "./provider-id.js";
 import plugin from "./server.js";
@@ -12,17 +15,7 @@ type Environment = NonNullable<
 >["environment"];
 type ThreadRow = { id: string; environmentId: string | null; status: string };
 
-const HOST: NonNullable<PluginEnvironmentProviderCreateContext["host"]> = {
-  id: "host-a",
-  name: "Fake machine",
-  status: "connected",
-  type: "persistent",
-  maxPermissionMode: "full",
-  lastSeenAt: null,
-  lastRejectedProtocolVersion: null,
-  createdAt: 0,
-  updatedAt: 0,
-};
+const HOST = makeHostResponse({ id: "host-a", name: "Fake machine" });
 const PROJECT: PluginEnvironmentProviderCreateContext["project"] = {
   id: "project-1",
   kind: "standard",

--- a/plugins/keep-awake/server.test.ts
+++ b/plugins/keep-awake/server.test.ts
@@ -1,5 +1,8 @@
 import type { BbPluginApi } from "@get-bb/plugin-sdk";
-import { createFakePluginHost } from "@get-bb/plugin-sdk/testing";
+import {
+  createFakePluginHost,
+  makeHostResponse,
+} from "@get-bb/plugin-sdk/testing";
 import { describe, expect, it, vi } from "vitest";
 import plugin from "./server.js";
 
@@ -13,9 +16,7 @@ type RealtimeConnectionSubscription = Extract<
   { event: "realtime:connection" }
 >;
 type SdkSubscription = Parameters<BbPluginApi["sdk"]["subscribe"]>[0];
-type HostRecord = Awaited<
-  ReturnType<BbPluginApi["sdk"]["hosts"]["list"]>
->[number];
+type HostResponse = ReturnType<typeof makeHostResponse>;
 
 function isHostChangedSubscription(
   subscription: SdkSubscription,
@@ -31,19 +32,9 @@ function isRealtimeConnectionSubscription(
 
 function hostRecord(
   id: string,
-  status: HostRecord["status"] = "connected",
-): HostRecord {
-  return {
-    id,
-    name: id,
-    status,
-    type: "persistent",
-    maxPermissionMode: "full",
-    lastSeenAt: null,
-    lastRejectedProtocolVersion: null,
-    createdAt: 1,
-    updatedAt: 1,
-  };
+  status: "connected" | "disconnected" = "connected",
+): HostResponse {
+  return makeHostResponse({ id, name: id, status });
 }
 
 function enabledInput(input: unknown): boolean {
@@ -179,7 +170,7 @@ describe("builtin Keep Awake server entry", () => {
 
   it("reconciles when a host connects after startup", async () => {
     const subscriptions = lifecycleSubscriptions();
-    let status: HostRecord["status"] = "disconnected";
+    let status: HostResponse["status"] = "disconnected";
     const host = createFakePluginHost({
       pluginId: "keep-awake",
       sdk: {


### PR DESCRIPTION
## Human comments

## What was wrong

Plugin tests repeatedly built complete host response objects. Every required Host contract change therefore forced mechanical fixture edits across independently consumable plugins.

## What changed

Added a typed `makeHostResponse(overrides)` builder to `@get-bb/plugin-sdk/testing`, documented it in the SDK and plugin-authoring guide, and bumped the Plugin SDK to 0.4.52. Migrated the concurrency-limit, keep-awake, environment-git-worktree, environment-personal-workspace, and environment-project-checkout tests to specify only behaviorally meaningful host fields.

There are no host-daemon wire changes, CLI changes, or unrelated API changes.

## How you verified

- Rebuilt portable Plugin SDK declarations
- Turbo tests and typechecks for the Plugin SDK, Plugin Guide, API map, and five affected plugins: 438 tests passed across all affected suites
- Targeted oxfmt check
- `git diff --check`

No linked issue.

> AGENT GENERATED