### PR TITLE
Preserve thread title pills in narrow sidebars and headers

### DIFF
--- a/apps/app/src/components/sidebar/ThreadRow.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.tsx
@@ -724,7 +724,7 @@ function ThreadRowComponent({
           </span>
         ) : (
           <span
-            className="bb-sidebar-thread-title min-w-0 truncate"
+            className="bb-thread-title"
             title={labelTitle}
             onDoubleClick={startTitleEditing}
           >

--- a/apps/app/src/components/thread/ThreadTitleMentions.tsx
+++ b/apps/app/src/components/thread/ThreadTitleMentions.tsx
@@ -839,7 +839,7 @@ function ResolvingThreadTitleMention({
         serializedText={serializedText}
       />
     ) : (
-      threadId
+      <span className="truncate">{threadId}</span>
     );
   }
   return (
@@ -862,15 +862,16 @@ function ThreadTitleMentionsContent({ title }: { title: string }) {
         threadId={segment.unresolvedThreadId}
       />
     ) : segment.resource === null || segment.serializedText === null ? (
-      segment.text
-    ) : (
-      <span key={`${index}:${segment.serializedText}`}>
-        <PromptMentionPill
-          interactive={false}
-          resource={segment.resource}
-          serializedText={segment.serializedText}
-        />
+      <span key={`${index}:text`} className="truncate whitespace-pre">
+        {segment.text}
       </span>
+    ) : (
+      <PromptMentionPill
+        key={`${index}:${segment.serializedText}`}
+        interactive={false}
+        resource={segment.resource}
+        serializedText={segment.serializedText}
+      />
     ),
   );
 }

--- a/apps/app/src/components/ui/theme.css
+++ b/apps/app/src/components/ui/theme.css
@@ -960,8 +960,8 @@ body.sidebar-resizing [data-sidebar="panel"] {
   }
 
   .bb-thread-title .prompt-mention-pill {
-    flex: 1 1 0%;
-    min-width: 0;
+    @apply min-w-10;
+    flex: 1 1 auto;
     max-width: max-content;
   }
 

--- a/apps/app/src/components/ui/theme.css
+++ b/apps/app/src/components/ui/theme.css
@@ -955,16 +955,14 @@ body.sidebar-resizing [data-sidebar="panel"] {
 }
 
 @layer utilities {
-  /* Let the title's outer ellipsis clip through rich pills in reading order
-   * instead of treating each inline-flex pill as one replaceable box. */
-  .bb-sidebar-thread-title .prompt-mention-pill {
-    display: inline;
+  .bb-thread-title {
+    @apply flex min-w-0 items-baseline;
   }
 
-  .bb-sidebar-thread-title .prompt-mention-pill > :first-child {
-    display: inline-block;
-    margin-inline-end: 0.125rem;
-    vertical-align: -0.2em;
+  .bb-thread-title .prompt-mention-pill {
+    flex: 1 1 0%;
+    min-width: 0;
+    max-width: max-content;
   }
 
   /*

--- a/apps/app/src/components/ui/theme.css
+++ b/apps/app/src/components/ui/theme.css
@@ -961,7 +961,7 @@ body.sidebar-resizing [data-sidebar="panel"] {
 
   .bb-thread-title .prompt-mention-pill {
     @apply min-w-10;
-    flex: 1 1 auto;
+    flex: 1 1 0%;
     max-width: max-content;
   }
 

--- a/apps/app/src/views/thread-detail/ThreadDetailHeader.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailHeader.tsx
@@ -168,7 +168,7 @@ export function ThreadDetailHeader({
         <p
           className={cn(
             "relative min-w-0 text-sm font-normal transition-colors",
-            isEditing ? "overflow-visible" : "truncate",
+            isEditing ? "overflow-visible" : "bb-thread-title",
             isSplitPaneHeader &&
               !isFocused &&
               dimsInactiveSplits &&


### PR DESCRIPTION
## Human comments

## What was wrong

Title truncation clipped sidebar pills and hid whole pills in headers.

## What changed

Use a shared flex layout so only pill text ellipsizes, preserving the full pill shape in sidebars and headers.

## How you verified

Passed in Chrome for Testing 153.0.8010.36: narrow/normal widths, long labels/prefixes, split panes, resizing, reload, and title editing. One review finding fixed: reserve minimum pill width. Automated checks run in PR CI.

Same fixtures and viewports below. Before: `2c57aa391`; after: `643649a47`.

| Surface | Before | After |
| --- | --- | --- |
| Sidebar, 240 px | <img src="https://github.com/brsbl/bb/releases/download/pr-evidence-thr_r8baz4g4ju/thr_r8baz4g4ju-before-sidebar.png" width="240" alt="Before: Sidebar, 240 px" /> | <img src="https://github.com/brsbl/bb/releases/download/pr-evidence-thr_r8baz4g4ju/after-643649a47-sidebar.png" width="240" alt="After: Sidebar, 240 px" /> |
| Regular header, 480 px | <img src="https://github.com/brsbl/bb/releases/download/pr-evidence-thr_r8baz4g4ju/thr_r8baz4g4ju-before-header.png" width="480" alt="Before: Regular header, 480 px" /> | <img src="https://github.com/brsbl/bb/releases/download/pr-evidence-thr_r8baz4g4ju/after-643649a47-header.png" width="480" alt="After: Regular header, 480 px" /> |
| Split-pane headers, 960 px total | <img src="https://github.com/brsbl/bb/releases/download/pr-evidence-thr_r8baz4g4ju/thr_r8baz4g4ju-before-split.png" width="960" alt="Before: Split-pane headers, 960 px total" /> | <img src="https://github.com/brsbl/bb/releases/download/pr-evidence-thr_r8baz4g4ju/after-643649a47-split.png" width="960" alt="After: Split-pane headers, 960 px total" /> |

BB-Thread-ID: thr_r8baz4g4ju

> AGENT GENERATED
