### PR TITLE
Quiet the sidebar plugin loading state

### DIFF
--- a/apps/app/src/components/plugin/PluginNavSidebarItems.test.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.test.tsx
@@ -277,9 +277,11 @@ describe("PluginNavSidebarItems", () => {
     renderSidebarItems();
     const row = screen.getByRole("button", { name: "Docs" });
     expect(row.getAttribute("aria-busy")).toBe("true");
-    expect(screen.getByText("Docs").classList.contains("animate-shine")).toBe(
-      true,
-    );
+    expect(
+      screen
+        .getByTestId("plugin-nav-sidebar-items")
+        .classList.contains("bb-plugin-nav-loading"),
+    ).toBe(true);
     expect(screen.queryByTestId("plugin-nav-loading-placeholders")).toBeNull();
     act(() => {
       setPluginFrontendReconcilePending(true);
@@ -295,9 +297,11 @@ describe("PluginNavSidebarItems", () => {
     expect(
       screen.queryByRole("status", { name: "Loading plugins" }),
     ).toBeNull();
-    expect(screen.getByText("Docs").classList.contains("animate-shine")).toBe(
-      false,
-    );
+    expect(
+      screen
+        .getByTestId("plugin-nav-sidebar-items")
+        .classList.contains("bb-plugin-nav-loading"),
+    ).toBe(false);
   });
 
   it("collapses the entire subsection with zero traditional plugins", () => {

--- a/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
@@ -22,7 +22,6 @@ import {
 import { Button } from "@bb/shared-ui/button";
 import { Checkbox } from "@bb/shared-ui/checkbox";
 import { Icon } from "@bb/shared-ui/icon";
-import { Skeleton } from "@bb/shared-ui/skeleton";
 import { usePluginFrontendsSettled } from "@/lib/plugin-frontend-boot-state";
 import {
   ContextMenu,
@@ -432,7 +431,10 @@ function PluginNavSidebarItemList({
   return (
     <div
       ref={containerRef}
-      className="shrink-0 space-y-0.5 px-2 py-2 group-data-[collapsible=icon]:hidden"
+      className={cn(
+        "relative shrink-0 space-y-0.5 px-2 py-2 group-data-[collapsible=icon]:hidden",
+        pluginsLoading && "bb-plugin-nav-loading",
+      )}
       data-testid="plugin-nav-sidebar-items"
       onClickCapture={onClickCapture}
     >
@@ -461,18 +463,19 @@ function PluginNavSidebarItemList({
         </SortableContext>
       </DndContext>
       {pluginsLoading ? (
-        <div role="status" aria-label="Loading plugins" className="space-y-0.5">
+        <div role="status" aria-label="Loading plugins">
           {rows.every((row) => !isPluginSidebarNavRow(row)) ? (
             <div
               aria-hidden="true"
               data-testid="plugin-nav-loading-placeholders"
+              className="space-y-0.5"
             >
-              {["w-24", "w-32", "w-20"].map((width) => (
+              {["w-18", "w-26", "w-14"].map((width) => (
                 <div key={width} className="flex h-8 items-center gap-2 px-2">
-                  <Skeleton className="size-4 shrink-0 rounded-md bg-sidebar-border/60 motion-reduce:animate-none" />
-                  <Skeleton
+                  <div className="size-4 shrink-0 rounded-sm bg-sidebar-foreground/10" />
+                  <div
                     className={cn(
-                      "h-2.5 rounded-full bg-sidebar-border/60 motion-reduce:animate-none",
+                      "h-2 rounded-full bg-sidebar-foreground/10",
                       width,
                     )}
                   />
@@ -480,14 +483,6 @@ function PluginNavSidebarItemList({
               ))}
             </div>
           ) : null}
-          <div className="flex items-center gap-2 px-2 py-1.5 text-xs text-muted-foreground">
-            <Icon
-              name="Loading"
-              className="size-3 motion-safe:animate-spin"
-              aria-hidden="true"
-            />
-            <span className="animate-shine">Loading plugins…</span>
-          </div>
         </div>
       ) : null}
       {hidden.length > 0 ? (
@@ -1172,6 +1167,8 @@ function SidebarNavRowChrome({
               "w-full pr-7",
               accessory && "pr-18",
               isActive && "bg-sidebar-accent text-sidebar-foreground",
+              loading &&
+                "text-sidebar-foreground/55 dark:text-sidebar-foreground/55 [&_svg]:opacity-60",
             )}
             aria-busy={loading || undefined}
             aria-current={isActive ? "page" : undefined}
@@ -1183,11 +1180,7 @@ function SidebarNavRowChrome({
           >
             {icon}
             <span className="flex min-w-0 flex-1 items-center gap-1.5 text-left">
-              <span
-                className={cn("min-w-0 truncate", loading && "animate-shine")}
-              >
-                {title}
-              </span>
+              <span className="min-w-0 truncate">{title}</span>
               {splitMiniMap ? (
                 <SplitPaneMiniMap
                   slots={splitMiniMap}

--- a/apps/app/src/components/ui/theme.css
+++ b/apps/app/src/components/ui/theme.css
@@ -1053,6 +1053,39 @@ body.sidebar-resizing [data-sidebar="panel"] {
     animation: indeterminate-progress 1.5s ease-in-out infinite;
   }
 
+  /*
+   * Sidebar plugin rows while plugin frontends boot: placeholder or remembered
+   * rows sit at reduced contrast and one accent-colored wash sweeps the whole
+   * group, so the section reads as a single pending block instead of several
+   * independently animating rows. The overlay is a compositor-driven transform
+   * on its own layer; the rows beneath never repaint.
+   */
+  .bb-plugin-nav-loading {
+    overflow: hidden;
+  }
+
+  .bb-plugin-nav-loading::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    width: 60%;
+    pointer-events: none;
+    background: linear-gradient(
+      90deg,
+      transparent 0%,
+      color-mix(in oklab, var(--sidebar-accent) 70%, transparent) 50%,
+      transparent 100%
+    );
+    animation: plugin-nav-wash 1.8s ease-in-out infinite;
+    will-change: transform;
+  }
+
+  [inert] .bb-plugin-nav-loading::after,
+  [aria-hidden="true"] .bb-plugin-nav-loading::after {
+    animation-play-state: paused;
+    will-change: auto;
+  }
+
   /* Reduced motion: drop the shimmer sweep and render the active cue as plain
      full-strength foreground text/glyph instead of a frozen gradient/mask. */
   @media (prefers-reduced-motion: reduce) {
@@ -1075,6 +1108,10 @@ body.sidebar-resizing [data-sidebar="panel"] {
       mask-image: none;
       will-change: auto;
     }
+
+    .bb-plugin-nav-loading::after {
+      display: none;
+    }
   }
 }
 
@@ -1084,6 +1121,15 @@ body.sidebar-resizing [data-sidebar="panel"] {
   }
   100% {
     background-position: -200% 0%;
+  }
+}
+
+@keyframes plugin-nav-wash {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(170%);
   }
 }
 


### PR DESCRIPTION
## Human comments

## What was wrong

The sidebar plugin nav section stacked three loading signals while plugin frontends booted: pulsing skeleton rows, a spinning icon, and a shimmering "Loading plugins…" caption. The caption row added height that vanished once plugins arrived, so the rows below it jumped. On a warm start the remembered panel names shimmered individually, which read as several unrelated things animating instead of one pending section.

## What changed

- `apps/app/src/components/plugin/PluginNavSidebarItems.tsx`: removed the spinner and caption. First launch shows three static ghost rows in real row geometry. Remembered rows render at reduced contrast with a dimmed glyph (light and dark) instead of `animate-shine` on the label. The section container gets `bb-plugin-nav-loading` while frontends boot. The `role="status"` wrapper and placeholder test id are unchanged.
- `apps/app/src/components/ui/theme.css`: new `bb-plugin-nav-loading` utility. One accent-colored wash sweeps the whole section on a compositor-driven transform, paused under `[inert]` / `[aria-hidden]` hosts and removed under `prefers-reduced-motion`, matching the existing shine rules. Translucent mixes use oklab per the theme test.
- `apps/app/src/components/plugin/PluginNavSidebarItems.test.tsx`: asserts the container loading class instead of the label shine class.

No wire, CLI, or doc changes.

## How you verified

- `pnpm exec turbo run typecheck --filter=@bb/app` passes.
- `PluginNavSidebarItems.test.tsx` and `theme.test.ts` pass (58 tests).
- Loaded the dev app with the `plugin-frontend.ts` module request stalled so the loading state holds, and captured first-launch, warm-start light, and warm-start dark. Warm-start dark initially did not dim because the row base sets a `dark:` text color; added the matching `dark:` override and re-captured.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

> AGENT GENERATED
