### PR TITLE
Approve noih to contribute pull requests

### DIFF
--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -67,3 +67,4 @@ aivanov93
 MayankBansal12
 vznh
 MacHatter1
+noih


### PR DESCRIPTION
## Human comments

## What was wrong

The contributor gate closed #2738 because its author, @noih, was not on the approved contributor list.

## What changed

Add `noih` to `.github/APPROVED_CONTRIBUTORS` so #2738 can be reopened and future contributions can pass the gate.

## How you verified

Verified that the case-insensitive gate lookup finds `noih` exactly once. `git diff --check` passed. The working tree and commit range passed the EAP codename scan.

> AGENT GENERATED
