### PR TITLE
fix(browser-automation): launch owned Chrome with --no-sandbox

### DIFF
--- a/plugins/browser-automation/README.md
+++ b/plugins/browser-automation/README.md
@@ -92,8 +92,9 @@ Headless sessions need Chrome/Chromium on that host. The plugin checks
 `<plugin host dataDir>/runtime/chrome`, the standard macOS Chrome path, then
 `google-chrome`, `google-chrome-stable`, `chromium`, and `chromium-browser` on
 PATH. The `runtime/chrome` entry can be a symlink to an installed executable.
-Normal operation never passes `--no-sandbox`. Chrome must be able to launch with
-its sandbox on the enrolled host.
+Plugin-owned local/headless Chrome always launches with `--no-sandbox`, disabling
+Chrome's sandbox so it can run on hosts that restrict unprivileged user namespaces.
+Desktop sessions attach to an existing browser and do not change its launch flags.
 
 ## CLI and agent workflow
 
@@ -201,9 +202,9 @@ real Chrome, without starting a BB core or using an existing browser profile.
 It verifies named pages, navigation, clicking, JPEG bytes, serialization,
 independent session cancellation, a synchronous infinite-loop timeout,
 reopening, stop, and preservation of an attached browser and its page state.
-On an isolated CI host that cannot use Chrome's sandbox, the smoke-only
-`DEV_BROWSER_SMOKE_NO_SANDBOX=1` adds a temporary Chrome wrapper for either
-smoke. That setting is never read by the plugin runtime.
+Both smokes link directly to Chrome and exercise the production launch flags
+without a wrapper. The attachment smoke also launches its separate browser
+fixture with `--no-sandbox` so it works on hosts with restricted user namespaces.
 
 Build with a current BB CLI: an older installed CLI can successfully bundle the
 sources while stamping old SDK metadata. Inspect `dist/*.meta.json` before any

--- a/plugins/browser-automation/runtime.ts
+++ b/plugins/browser-automation/runtime.ts
@@ -214,7 +214,7 @@ export async function createRuntime(args: {
       startup.throwIfAborted();
       if (processes.some((child) => !child.alive()))
         throw new Error(
-          "Browser runtime exited during startup; check Chrome installation and sandbox support.",
+          "Browser runtime exited during startup; check Chrome installation and runtime dependencies.",
         );
       try {
         return await readFile(path, "utf8");
@@ -233,6 +233,7 @@ export async function createRuntime(args: {
           chrome,
           [
             "--headless=new",
+            "--no-sandbox",
             "--remote-debugging-port=0",
             "--remote-debugging-address=127.0.0.1",
             `--user-data-dir=${profile}`,

--- a/plugins/browser-automation/skills/browser-automation/SKILL.md
+++ b/plugins/browser-automation/skills/browser-automation/SKILL.md
@@ -11,6 +11,8 @@ an enrolled host. Choose `--backend desktop --machine <host-id> --desktop
 <instance-id>` for a new dedicated desktop automation tab. Starting desktop
 control opens and focuses the browser panel; new pages created through that
 controller are selected automatically. Headless sessions remain headless.
+Plugin-owned local/headless Chrome launches with `--no-sandbox`, disabling Chrome's
+sandbox. Desktop attachment does not change the browser's launch flags.
 Resolve the explicit instance with `bb browser instances --host <host-id> --json`
 first. Never silently choose a different host, mode, or login profile.
 Adding `--tab <tab-id>` hands off an existing tab and its profile's logged-in

--- a/plugins/browser-automation/smoke-install.ts
+++ b/plugins/browser-automation/smoke-install.ts
@@ -1,11 +1,4 @@
-import {
-  readFile,
-  mkdir,
-  mkdtemp,
-  rm,
-  symlink,
-  writeFile,
-} from "node:fs/promises";
+import { readFile, mkdir, mkdtemp, rm, symlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { strict as assert } from "node:assert";
@@ -18,14 +11,7 @@ const chrome = z.string().min(1).parse(process.env.DEV_BROWSER_SMOKE_CHROME);
 const root = await mkdtemp(join(tmpdir(), "bb-dev-browser-install-smoke-"));
 const dataDir = join(root, "data");
 await mkdir(join(dataDir, "runtime"), { recursive: true });
-if (process.env.DEV_BROWSER_SMOKE_NO_SANDBOX === "1") {
-  const escaped = `'${resolve(chrome).replaceAll("'", "'\\''")}'`;
-  await writeFile(
-    join(dataDir, "runtime", "chrome"),
-    `#!/bin/sh\nexec ${escaped} --no-sandbox "$@"\n`,
-    { mode: 0o700 },
-  );
-} else await symlink(resolve(chrome), join(dataDir, "runtime", "chrome"));
+await symlink(resolve(chrome), join(dataDir, "runtime", "chrome"));
 const signal = new AbortController().signal;
 const progress: string[] = [];
 try {

--- a/plugins/browser-automation/smoke.ts
+++ b/plugins/browser-automation/smoke.ts
@@ -5,7 +5,6 @@ import {
   readFile,
   rm,
   symlink,
-  writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
@@ -31,14 +30,7 @@ const version = z
     (await promisify(execFile)(runtimeBinary, ["--version"])).stdout.trim(),
   )
   .split(" ")[1]!;
-if (process.env.DEV_BROWSER_SMOKE_NO_SANDBOX === "1") {
-  const escaped = `'${resolve(chrome).replaceAll("'", "'\\''")}'`;
-  await writeFile(
-    join(dataDir, "runtime", "chrome"),
-    `#!/bin/sh\nexec ${escaped} --no-sandbox "$@"\n`,
-    { mode: 0o700 },
-  );
-} else await symlink(resolve(chrome), join(dataDir, "runtime", "chrome"));
+await symlink(resolve(chrome), join(dataDir, "runtime", "chrome"));
 const attachedBrowsers: ReturnType<typeof supervise>[] = [];
 const sessions: Awaited<ReturnType<typeof createRuntime>>[] = [];
 try {
@@ -122,6 +114,7 @@ try {
     join(dataDir, "runtime", "chrome"),
     [
       "--headless=new",
+      "--no-sandbox",
       "--remote-debugging-port=0",
       `--user-data-dir=${profile}`,
       "--no-first-run",

--- a/plugins/browser-automation/turbo.json
+++ b/plugins/browser-automation/turbo.json
@@ -15,19 +15,12 @@
     "smoke": {
       "cache": false,
       "dependsOn": ["@get-bb/plugin-sdk#build:types"],
-      "passThroughEnv": [
-        "DEV_BROWSER_SMOKE_BINARY",
-        "DEV_BROWSER_SMOKE_CHROME",
-        "DEV_BROWSER_SMOKE_NO_SANDBOX"
-      ]
+      "passThroughEnv": ["DEV_BROWSER_SMOKE_BINARY", "DEV_BROWSER_SMOKE_CHROME"]
     },
     "smoke:install": {
       "cache": false,
       "dependsOn": ["@get-bb/plugin-sdk#build:types"],
-      "passThroughEnv": [
-        "DEV_BROWSER_SMOKE_CHROME",
-        "DEV_BROWSER_SMOKE_NO_SANDBOX"
-      ]
+      "passThroughEnv": ["DEV_BROWSER_SMOKE_CHROME"]
     }
   }
 }


### PR DESCRIPTION
## Human comments

## What was wrong

Plugin-owned headless Chrome started without `--no-sandbox`, so local Browser Automation sessions failed on Ubuntu hosts such as bee where AppArmor restricts unprivileged user namespaces. The smoke-only wrapper could bypass this failure without exercising the production launch behavior.

## What changed

The owned local/headless Chrome launch now always passes `--no-sandbox`, as explicitly requested. This disables Chrome's sandbox. Desktop attachment continues to use the existing browser without changing its launch flags.

Updated the README, bundled skill, and startup diagnostic. Removed the smoke-only wrapper and environment override from both smoke scripts and Turbo configuration: owned Chrome now uses a direct executable symlink. The attachment smoke's separate browser fixture passes the flag explicitly. No CLI or SDK signatures or server/daemon wire contracts changed.

## How you verified

- `pnpm exec turbo run test typecheck build --filter=bb-plugin-browser-automation` passed: 36 tests, typecheck, and plugin build.
- `pnpm exec turbo run smoke --filter=bb-plugin-browser-automation` passed on bee using the verified `dev-browser@1.0.0-rc.3` binary and cached Playwright Chromium 1228. No test-only no-sandbox wrapper: navigation/click, JPEG, serialization, cancellation isolation, infinite-loop timeout, reopening, stop, and attached browser/page preservation all passed.
- `pnpm exec turbo run smoke:install --filter=bb-plugin-browser-automation` passed on bee: disposable cold install with provenance verification, warm reuse without npm on PATH, iframe snapshot, and JPEG capture through the production Chrome launcher.
- Both smokes used disposable storage; live plugin state was not changed.
- Formatting and `git diff --check` passed. Public-code hygiene scanner found zero EAP codename mentions in the working tree, HEAD, added lines, and commit messages for `origin/main..HEAD`.

> AGENT GENERATED
