### PR TITLE
Deflake Account Pool kebab action test

### DIFF
--- a/plugins/account-pool/app.test.tsx
+++ b/plugins/account-pool/app.test.tsx
@@ -178,46 +178,48 @@ describe("Account Pool settings", () => {
     expect(slot.queryByText("7 day")).toBeNull();
   });
 
-  it("dispatches kebab actions to their RPC contracts", async () => {
-    const slot = render([account()], {
-      "account.disable": () => ({ account: null }),
-      "account.refreshUsage": () => ({ account: null }),
-      "account.remove": () => ({ removed: true }),
-    });
-    const open = async () => {
+  it.each([
+    {
+      action: "Disable",
+      method: "account.disable",
+      input: { id: account().id },
+    },
+    {
+      action: "Refresh usage",
+      method: "account.refreshUsage",
+      input: { accountId: account().id },
+    },
+  ])(
+    "dispatches $action to its RPC contract",
+    async ({ action, method, input }) => {
+      const slot = render([account()], {
+        [method]: () => ({ account: null }),
+      });
       fireEvent.pointerDown(
         await slot.findByRole("button", { name: "person@example.com actions" }),
       );
-    };
-    await open();
-    fireEvent.click(await slot.findByText("Disable"));
-    await waitFor(() =>
-      expect(slot.rpcCalls).toContainEqual({
-        method: "account.disable",
-        input: { id: account().id },
-      }),
+      fireEvent.click(await slot.findByText(action));
+      expect(slot.rpcCalls).toContainEqual({ method, input });
+    },
+  );
+
+  it("confirms Remove before dispatching its RPC contract", async () => {
+    const slot = render([account()], {
+      "account.remove": () => ({ removed: true }),
+    });
+    fireEvent.pointerDown(
+      await slot.findByRole("button", { name: "person@example.com actions" }),
     );
-    await open();
-    fireEvent.click(await slot.findByText("Refresh usage"));
-    await waitFor(() =>
-      expect(slot.rpcCalls).toContainEqual({
-        method: "account.refreshUsage",
-        input: { accountId: account().id },
-      }),
-    );
-    await open();
     fireEvent.click(await slot.findByText("Remove"));
     expect(await slot.findByText("Remove person@example.com?")).toBeTruthy();
     expect(slot.rpcCalls.some((call) => call.method === "account.remove")).toBe(
       false,
     );
     fireEvent.click(slot.getByRole("button", { name: "Remove" }));
-    await waitFor(() =>
-      expect(slot.rpcCalls).toContainEqual({
-        method: "account.remove",
-        input: { id: account().id },
-      }),
-    );
+    expect(slot.rpcCalls).toContainEqual({
+      method: "account.remove",
+      input: { id: account().id },
+    });
   });
 
   it("opens the correct provider sign-in flow from each Add account menu", async () => {


### PR DESCRIPTION
## Human comments

## What was wrong

The Account Pool settings test serialized Disable, Refresh usage, and Remove through three Radix dropdown lifecycles, two post-action refreshes, and a confirmation drawer under one 5-second test budget. The RPC harness records dispatch synchronously, but the test repeatedly waited and reopened the same menu. Under package-shard scheduler contention this accumulated past the deadline; the packages job in [run 34394846940](https://github.com/get-bb/bb/actions/runs/34394846940/job/102611877853) timed out at 5,364 ms even though the PR branch did not change the Account Pool app or test.

## What changed

Split the independent Disable and Refresh usage contracts into parameterized cases and the destructive Remove confirmation into its own case. Each case now owns one render and one menu lifecycle. Assertions inspect the synchronous RPC call log directly, while the Remove case still proves the confirmation prevents premature dispatch.

## How you verified

- Reproduced the unchanged test on Intel under 48 bounded CPU workers: timeout at 5,189 ms.
- Repeated the same 48-worker stress after the change: all three cases passed at 3,166 ms, 1,337 ms, and 1,649 ms; combined test work exceeded 5 seconds without any individual case sharing that budget.
- `pnpm exec turbo run test --filter=bb-plugin-account-pool`: 10 files and 266 tests passed.
- `pnpm exec turbo run typecheck --filter=bb-plugin-account-pool`: 4 Turbo tasks passed.
- Every stress and test process group ran under a TERM/KILL watchdog and was confirmed empty afterward.

> AGENT GENERATED: by GPT-5.6-Sol
