### PR TITLE
Fix browser supervisor child reaping race

### DIFF
--- a/plugins/browser-automation/process.test.ts
+++ b/plugins/browser-automation/process.test.ts
@@ -4,7 +4,11 @@ import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
-import { supervise } from "./process.js";
+import {
+  PROCESS_REAP_CONFIRMATION_TIMEOUT_MS,
+  ProcessReapingUnconfirmedError,
+  supervise,
+} from "./process.js";
 
 async function stopWorker(worker: ChildProcess): Promise<void> {
   if (worker.exitCode !== null || worker.signalCode !== null) return;
@@ -98,4 +102,57 @@ describe("process ownership", () => {
       await rm(root, { recursive: true, force: true });
     }
   }, 10_000);
+  it("bounds close while the supervisor independently finishes reaping", async () => {
+    const root = await mkdtemp(join(tmpdir(), "db-close-deadline-"));
+    const file = join(root, "pid");
+    const code =
+      'require("node:fs").writeFileSync(process.argv[1], `${String(process.pid)}:${String(process.ppid)}`); process.on("SIGTERM", () => {}); setInterval(() => {}, 1000);';
+    let expireDeadline = (): void => {
+      throw new Error("Close deadline was not scheduled");
+    };
+    let deadlineScheduled = false;
+    let deadlineMs = 0;
+    const owned = supervise(process.execPath, ["-e", code, file], process.env, {
+      scheduleCloseDeadline(callback, timeoutMs) {
+        expireDeadline = callback;
+        deadlineScheduled = true;
+        deadlineMs = timeoutMs;
+        return { cancel() {} };
+      },
+    });
+    let childPid = 0;
+    let supervisorPid = 0;
+    try {
+      await vi.waitFor(
+        async () => {
+          const pids = (await readFile(file, "utf8")).split(":").map(Number);
+          childPid = pids[0] ?? 0;
+          supervisorPid = pids[1] ?? 0;
+          expect(childPid).toBeGreaterThan(0);
+          expect(supervisorPid).toBeGreaterThan(0);
+        },
+        { timeout: 5000 },
+      );
+      const closing = owned.close();
+      expect(deadlineMs).toBe(PROCESS_REAP_CONFIRMATION_TIMEOUT_MS);
+      expect(deadlineScheduled).toBe(true);
+      const rejected = expect(closing).rejects.toBeInstanceOf(
+        ProcessReapingUnconfirmedError,
+      );
+      expireDeadline();
+      await rejected;
+      await expect(closing).rejects.toThrow("child reaping was not confirmed");
+      expect(owned.alive()).toBe(true);
+      expect(() => process.kill(childPid, 0)).not.toThrow();
+      await vi.waitFor(() => expect(owned.alive()).toBe(false), {
+        timeout: 5000,
+      });
+      expect(() => process.kill(childPid, 0)).toThrow();
+    } finally {
+      if (childPid > 0 && isProcessAlive(childPid)) killProcessGroup(childPid);
+      if (supervisorPid > 0 && isProcessAlive(supervisorPid))
+        process.kill(supervisorPid, "SIGKILL");
+      await rm(root, { recursive: true, force: true });
+    }
+  }, 8_000);
 });

--- a/plugins/browser-automation/process.test.ts
+++ b/plugins/browser-automation/process.test.ts
@@ -1,9 +1,35 @@
-import { spawn } from "node:child_process";
+import { type ChildProcess, spawn } from "node:child_process";
+import { once } from "node:events";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { supervise } from "./process.js";
+
+async function stopWorker(worker: ChildProcess): Promise<void> {
+  if (worker.exitCode !== null || worker.signalCode !== null) return;
+  const exited = once(worker, "exit");
+  worker.kill("SIGKILL");
+  await exited;
+}
+
+function killProcessGroup(pid: number): void {
+  try {
+    process.kill(-pid, "SIGKILL");
+  } catch {}
+  try {
+    process.kill(pid, "SIGKILL");
+  } catch {}
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 describe("process ownership", () => {
   it("worker death closes the supervisor pipe and kills its child", async () => {
@@ -17,15 +43,15 @@ describe("process ownership", () => {
       ["--import", "tsx", "--input-type=module", "-e", code],
       { stdio: "ignore" },
     );
+    let pid = 0;
     try {
-      let pid = 0;
       await vi.waitFor(
         async () => {
           pid = Number(await readFile(file, "utf8"));
         },
         { timeout: 5000 },
       );
-      worker.kill("SIGKILL");
+      await stopWorker(worker);
       await vi.waitFor(
         () => {
           expect(() => process.kill(pid, 0)).toThrow();
@@ -33,7 +59,8 @@ describe("process ownership", () => {
         { timeout: 5000 },
       );
     } finally {
-      worker.kill("SIGKILL");
+      await stopWorker(worker);
+      if (pid > 0 && isProcessAlive(pid)) killProcessGroup(pid);
       await rm(root, { recursive: true, force: true });
     }
   }, 12_000);

--- a/plugins/browser-automation/process.ts
+++ b/plugins/browser-automation/process.ts
@@ -1,5 +1,36 @@
 import { spawn } from "node:child_process";
 
+interface CloseDeadline {
+  cancel(): void;
+}
+
+interface SuperviseOptions {
+  scheduleCloseDeadline?: (
+    callback: () => void,
+    timeoutMs: number,
+  ) => CloseDeadline;
+}
+
+export const PROCESS_REAP_CONFIRMATION_TIMEOUT_MS = 5_000;
+
+export class ProcessReapingUnconfirmedError extends Error {
+  constructor(timeoutMs: number) {
+    super(
+      `Browser process shutdown exceeded ${String(timeoutMs)} ms; child reaping was not confirmed`,
+    );
+    this.name = "ProcessReapingUnconfirmedError";
+  }
+}
+
+function scheduleCloseDeadline(
+  callback: () => void,
+  timeoutMs: number,
+): CloseDeadline {
+  const timer = setTimeout(callback, timeoutMs);
+  timer.unref();
+  return { cancel: () => clearTimeout(timer) };
+}
+
 const supervisor = `
 const { spawn } = require('node:child_process');
 const child = spawn(process.argv[1], process.argv.slice(2), { detached: true, stdio: 'ignore', env: process.env });
@@ -28,6 +59,7 @@ export function supervise(
   command: string,
   args: string[],
   env: NodeJS.ProcessEnv,
+  options: SuperviseOptions = {},
 ) {
   const child = spawn(process.execPath, ["-e", supervisor, command, ...args], {
     env,
@@ -45,12 +77,39 @@ export function supervise(
       resolve();
     });
   });
+  let closing: Promise<void> | null = null;
+  const close = (): Promise<void> => {
+    if (closing !== null) return closing;
+    child.stdin.end();
+    closing = new Promise<void>((resolve, reject) => {
+      let settled = false;
+      let cancelDeadline = (): void => {};
+      completion.then(() => {
+        if (settled) return;
+        settled = true;
+        cancelDeadline();
+        resolve();
+      });
+      cancelDeadline = (options.scheduleCloseDeadline ?? scheduleCloseDeadline)(
+        () => {
+          if (settled) return;
+          settled = true;
+          child.stdin.destroy();
+          child.unref();
+          reject(
+            new ProcessReapingUnconfirmedError(
+              PROCESS_REAP_CONFIRMATION_TIMEOUT_MS,
+            ),
+          );
+        },
+        PROCESS_REAP_CONFIRMATION_TIMEOUT_MS,
+      ).cancel;
+    });
+    return closing;
+  };
   return {
     alive: () => !exited,
-    async close() {
-      child.stdin.end();
-      await completion;
-    },
+    close,
   };
 }
 

--- a/plugins/browser-automation/process.ts
+++ b/plugins/browser-automation/process.ts
@@ -4,15 +4,20 @@ const supervisor = `
 const { spawn } = require('node:child_process');
 const child = spawn(process.argv[1], process.argv.slice(2), { detached: true, stdio: 'ignore', env: process.env });
 let stopping = false;
+let childClosed = false;
 function kill(signal) { if (child.pid) { try { process.kill(-child.pid, signal); } catch {} } }
+function finish(code) {
+  if (childClosed) process.exit(code);
+  child.once('close', () => process.exit(code));
+}
 function stop() {
   if (stopping) return;
   stopping = true;
   kill('SIGTERM');
-  setTimeout(() => { kill('SIGKILL'); setTimeout(() => process.exit(0), 100); }, 1500);
+  setTimeout(() => { kill('SIGKILL'); finish(0); }, 1500);
 }
 child.on('error', () => process.exit(1));
-child.on('exit', () => { if (!stopping) { kill('SIGKILL'); process.exit(1); } });
+child.on('close', () => { childClosed = true; if (!stopping) { kill('SIGKILL'); process.exit(1); } });
 process.stdin.resume();
 process.stdin.on('end', stop);
 process.on('SIGTERM', stop);


### PR DESCRIPTION
## Human comments

## What was wrong

The process-ownership test and the supervisor both treated signal submission as process termination. The test began its five-second child-reaping assertion immediately after `worker.kill("SIGKILL")`, although that API only submits the signal and the worker could still own the supervisor pipe. After the pipe closed, the supervisor submitted `SIGKILL` to its child group but exited on an unrelated 100 ms timer instead of the child's `close` event, so under contention the child could still be observable, including as an unreaped zombie. This produced the unchanged-main failure in [CI run 34404843507](https://github.com/get-bb/bb/actions/runs/34404843507/job/102645239410): `worker death closes the supervisor pipe and kills its child` exhausted the existing 5,000 ms assertion at 6,036 ms. The first event-driven revision correctly waited for reaping, but made the app-facing `close()` wait unbounded if the operating system never delivered that boundary. The unrelated PR #2902 did not change either process file.

## What changed

- Keep the supervisor alive after forced termination until the direct child emits `close`, replacing the 100 ms scheduling guess with the lifecycle event that follows exit and reaping.
- Wait for the killed worker's `exit` event before asserting that pipe closure reaped the supervised child.
- Bound the app-facing `close()` operation at 5,000 ms. Normal completion cancels its unref'd timer. If the deadline wins, `close()` rejects with `ProcessReapingUnconfirmedError`, explicitly stating that child reaping was not confirmed; it closes the already-ended parent pipe and unreferences the supervisor handle so neither can pin the app.
- Leave the supervisor running after an app-side deadline. The deadline does not signal or terminate it, so it remains the child's parent and can still observe `close`, reap the child, and exit independently. A single settled-state gate contains completion immediately before, during, or after deadline delivery without changing the already-returned result or creating an unhandled continuation.
- Make the test's `finally` path wait for worker exit and force-kill the detached child group if it is still observable, so a failed or interrupted assertion cannot leak the tested process tree.
- Preserve the TERM-resistant child-reaping assertion and all existing test deadlines; no timeout, retry, or polling budget was increased.
- No `HOST_DAEMON_PROTOCOL_VERSION` bump is needed because this changes only an internal plugin-local subprocess and its test. No server/daemon command, session payload, WebSocket field, RPC field, default, or meaning changes.

The 5,000 ms production ceiling contains the existing 1,500 ms graceful TERM stage plus 3,500 ms for forced-kill exit and reap notification. Under 12 CPU burners with eight concurrent test processes, the complete worker-death ownership case measured 2.18–2.33 s; the ceiling is more than twice that measured worst case and does not alter any assertion clock.

## How you verified

- Red: the linked Linux packages job failed on unchanged process code with the exact child-still-observable assertion after its full 5,000 ms wait.
- Green CI: the final bounded-shutdown head passed every applicable check in [PR run 34509139160](https://github.com/get-bb/bb/actions/runs/34509139160), including `Tests (packages, ubuntu-latest, Node 22.x)` in 3m48s, Linux package smoke in 3m59s, and macOS package smoke in 2m25s.
- Green: 24 exact worker-death lifecycle cases and 16 deterministic app-deadline/late-reap cases passed under 12 CPU-contention workers with up to eight concurrent test processes; each externally bounded harness reported zero survivors.
- `pnpm exec vitest run process.test.ts --config vitest.config.ts --reporter=verbose` — 3/3 passed: normal close/reap, bounded truthful deadline with independent late reap, and worker-death ownership.
- `pnpm exec turbo run test --filter=bb-plugin-browser-automation` — 37/37 passed.
- `pnpm exec turbo run typecheck --filter=bb-plugin-browser-automation` — passed.
- `pnpm exec turbo run build --filter=bb-plugin-browser-automation` — passed.
- `pnpm exec prettier --check plugins/browser-automation/process.ts plugins/browser-automation/process.test.ts` and `git diff --check` — passed.
- All stress and validation commands were externally bounded and ended with zero browser-process survivors on `host_nwqfteeqz4` (`x86_64`, Intel Core i5-1038NG7).
- Work began from and retains merge-base `2e5f34b8c6a9ac617c92123388b0f49bb3bc11d5`; `origin/main` advanced afterward, and this branch was deliberately not rebased off the frozen required SHA.

> AGENT GENERATED: by GPT-5.6-Sol
