### PR TITLE
Remove plugin sidebar startup loading placeholders

### DIFF
--- a/apps/app/src/components/plugin/PluginNavSidebarItems.test.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.test.tsx
@@ -244,17 +244,15 @@ afterEach(() => {
 });
 
 describe("PluginNavSidebarItems", () => {
-  it("shows placeholders on first launch and removes them when startup settles", () => {
+  it("keeps built-in actions visible without placeholders during startup", () => {
     resetPluginFrontendBootStateForTest();
     renderSidebarItems({
       builtInEntries: [builtInEntry("new-thread", "New thread")],
     });
     expect(
-      screen.getByRole("status", { name: "Loading plugins" }),
-    ).toBeTruthy();
-    expect(
-      screen.getByTestId("plugin-nav-loading-placeholders").children,
-    ).toHaveLength(3);
+      screen.queryByRole("status", { name: "Loading plugins" }),
+    ).toBeNull();
+    expect(screen.queryByTestId("plugin-nav-loading-placeholders")).toBeNull();
     expect(screen.getByRole("button", { name: "New thread" })).toBeTruthy();
     act(() => markPluginFrontendsSettled());
     expect(
@@ -277,11 +275,6 @@ describe("PluginNavSidebarItems", () => {
     renderSidebarItems();
     const row = screen.getByRole("button", { name: "Docs" });
     expect(row.getAttribute("aria-busy")).toBe("true");
-    expect(
-      screen
-        .getByTestId("plugin-nav-sidebar-items")
-        .classList.contains("bb-plugin-nav-loading"),
-    ).toBe(true);
     expect(screen.queryByTestId("plugin-nav-loading-placeholders")).toBeNull();
     act(() => {
       setPluginFrontendReconcilePending(true);
@@ -291,17 +284,12 @@ describe("PluginNavSidebarItems", () => {
     expect(screen.getByRole("button", { name: "Docs" })).toBe(row);
     expect(row.hasAttribute("aria-busy")).toBe(false);
     expect(
-      screen.getByRole("status", { name: "Loading plugins" }),
-    ).toBeTruthy();
+      screen.queryByRole("status", { name: "Loading plugins" }),
+    ).toBeNull();
     act(() => setPluginFrontendReconcilePending(false));
     expect(
       screen.queryByRole("status", { name: "Loading plugins" }),
     ).toBeNull();
-    expect(
-      screen
-        .getByTestId("plugin-nav-sidebar-items")
-        .classList.contains("bb-plugin-nav-loading"),
-    ).toBe(false);
   });
 
   it("collapses the entire subsection with zero traditional plugins", () => {

--- a/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
@@ -22,7 +22,6 @@ import {
 import { Button } from "@bb/shared-ui/button";
 import { Checkbox } from "@bb/shared-ui/checkbox";
 import { Icon } from "@bb/shared-ui/icon";
-import { usePluginFrontendsSettled } from "@/lib/plugin-frontend-boot-state";
 import {
   ContextMenu,
   ContextMenuContent,
@@ -138,7 +137,6 @@ export function PluginNavSidebarItems(props: {
   onNavigate?: () => void;
   splitEnabled?: boolean;
 }) {
-  const pluginsLoading = !usePluginFrontendsSettled();
   const discoveredEntries = usePluginNavPanelChrome();
   const entries = props.entries ?? discoveredEntries;
   const rows = useMemo<SidebarNavRow[]>(
@@ -165,10 +163,9 @@ export function PluginNavSidebarItems(props: {
       (props.builtInEntries ?? []).map(getPluginNavPanelKey),
     [props.builtInEntries, props.leadingOrderKeys],
   );
-  if (rows.length === 0 && !pluginsLoading) return null;
+  if (rows.length === 0) return null;
   return (
     <PluginNavSidebarItemList
-      pluginsLoading={pluginsLoading}
       rows={rows}
       leadingOrderKeys={leadingOrderKeys}
       splitEnabled={props.splitEnabled ?? false}
@@ -186,7 +183,6 @@ export function PluginNavSidebarItems(props: {
 }
 
 function PluginNavSidebarItemList({
-  pluginsLoading,
   compactCustomizeMode,
   leadingOrderKeys,
   onCompactCustomizeModeChange,
@@ -194,7 +190,6 @@ function PluginNavSidebarItemList({
   rows,
   splitEnabled = false,
 }: {
-  pluginsLoading: boolean;
   compactCustomizeMode?: boolean;
   leadingOrderKeys: readonly string[];
   onCompactCustomizeModeChange?: (isCustomizing: boolean) => void;
@@ -431,10 +426,7 @@ function PluginNavSidebarItemList({
   return (
     <div
       ref={containerRef}
-      className={cn(
-        "relative shrink-0 space-y-0.5 px-2 py-2 group-data-[collapsible=icon]:hidden",
-        pluginsLoading && "bb-plugin-nav-loading",
-      )}
+      className="relative shrink-0 space-y-0.5 px-2 py-2 group-data-[collapsible=icon]:hidden"
       data-testid="plugin-nav-sidebar-items"
       onClickCapture={onClickCapture}
     >
@@ -462,29 +454,6 @@ function PluginNavSidebarItemList({
           )}
         </SortableContext>
       </DndContext>
-      {pluginsLoading ? (
-        <div role="status" aria-label="Loading plugins">
-          {rows.every((row) => !isPluginSidebarNavRow(row)) ? (
-            <div
-              aria-hidden="true"
-              data-testid="plugin-nav-loading-placeholders"
-              className="space-y-0.5"
-            >
-              {["w-18", "w-26", "w-14"].map((width) => (
-                <div key={width} className="flex h-8 items-center gap-2 px-2">
-                  <div className="size-4 shrink-0 rounded-sm bg-sidebar-foreground/10" />
-                  <div
-                    className={cn(
-                      "h-2 rounded-full bg-sidebar-foreground/10",
-                      width,
-                    )}
-                  />
-                </div>
-              ))}
-            </div>
-          ) : null}
-        </div>
-      ) : null}
       {hidden.length > 0 ? (
         <SidebarNavigationMoreRow
           hiddenRows={hidden}

--- a/apps/app/src/components/ui/theme.css
+++ b/apps/app/src/components/ui/theme.css
@@ -1051,39 +1051,6 @@ body.sidebar-resizing [data-sidebar="panel"] {
     animation: indeterminate-progress 1.5s ease-in-out infinite;
   }
 
-  /*
-   * Sidebar plugin rows while plugin frontends boot: placeholder or remembered
-   * rows sit at reduced contrast and one accent-colored wash sweeps the whole
-   * group, so the section reads as a single pending block instead of several
-   * independently animating rows. The overlay is a compositor-driven transform
-   * on its own layer; the rows beneath never repaint.
-   */
-  .bb-plugin-nav-loading {
-    overflow: hidden;
-  }
-
-  .bb-plugin-nav-loading::after {
-    content: "";
-    position: absolute;
-    inset: 0;
-    width: 60%;
-    pointer-events: none;
-    background: linear-gradient(
-      90deg,
-      transparent 0%,
-      color-mix(in oklab, var(--sidebar-accent) 70%, transparent) 50%,
-      transparent 100%
-    );
-    animation: plugin-nav-wash 1.8s ease-in-out infinite;
-    will-change: transform;
-  }
-
-  [inert] .bb-plugin-nav-loading::after,
-  [aria-hidden="true"] .bb-plugin-nav-loading::after {
-    animation-play-state: paused;
-    will-change: auto;
-  }
-
   /* Reduced motion: drop the shimmer sweep and render the active cue as plain
      full-strength foreground text/glyph instead of a frozen gradient/mask. */
   @media (prefers-reduced-motion: reduce) {
@@ -1106,10 +1073,6 @@ body.sidebar-resizing [data-sidebar="panel"] {
       mask-image: none;
       will-change: auto;
     }
-
-    .bb-plugin-nav-loading::after {
-      display: none;
-    }
   }
 }
 
@@ -1119,15 +1082,6 @@ body.sidebar-resizing [data-sidebar="panel"] {
   }
   100% {
     background-position: -200% 0%;
-  }
-}
-
-@keyframes plugin-nav-wash {
-  0% {
-    transform: translateX(-100%);
-  }
-  100% {
-    transform: translateX(170%);
   }
 }
 


### PR DESCRIPTION
## Human comments

## What was wrong

While plugin frontends started, the sidebar displayed placeholder rows and swept a rectangular gradient across the navigation section, adding an unwanted loading effect.

## What changed

Remove the plugin list's startup placeholders, loading status wrapper, and gradient animation. Built-in actions and remembered plugin entries remain visible, and an empty plugin subsection stays collapsed. Other sidebar loading states are unchanged.

## How you verified

- Updated startup tests to verify built-in actions remain visible without placeholders and remembered plugin rows become ready in place.
- `pnpm exec turbo run test --filter=@bb/app -- src/components/plugin/PluginNavSidebarItems.test.tsx src/components/ui/theme.test.ts`: 58 tests passed.
- `pnpm exec turbo run typecheck lint --filter=@bb/app`: passed; lint reports 190 warnings and no errors.
- Secret-model scan: clean working tree, tracked files, added lines, and commit messages.
- In-app browser screenshots were unavailable because no desktop browser window was connected.
- SlopCop skipped at the user's request.

> AGENT GENERATED
