### PR TITLE
Fix desktop browser discovery for remote servers

### DIFF
--- a/apps/desktop/src/desktop-browser-broker-client.ts
+++ b/apps/desktop/src/desktop-browser-broker-client.ts
@@ -32,9 +32,35 @@ async function readBrokerDescriptor(dataDir: string) {
   }
 }
 
+async function readServerBrokerDescriptor(args: {
+  dataDir: string;
+  homeDir: string;
+  serverOrigin: string;
+}) {
+  const serverHost = new URL(args.serverOrigin).host.replace(
+    /[^a-zA-Z0-9.-]/gu,
+    "-",
+  );
+  const dataDirs = new Set([
+    args.dataDir,
+    join(args.homeDir, ".bb-machines", serverHost),
+  ]);
+  for (const dataDir of dataDirs) {
+    try {
+      const descriptor = await readBrokerDescriptor(dataDir);
+      if (new URL(descriptor.serverUrl).origin === args.serverOrigin)
+        return descriptor;
+    } catch {
+      continue;
+    }
+  }
+  throw new Error("No desktop broker found for the selected server");
+}
+
 export function createDesktopBrowserBrokerClient(args: {
   broker: DesktopBrowserBroker;
   dataDir: string;
+  homeDir: string;
   getServerUrl(): string;
 }) {
   let socket: WebSocket | null = null;
@@ -72,14 +98,16 @@ export function createDesktopBrowserBrokerClient(args: {
       )
         args.broker.resetServer();
       registryServerOrigin = serverOrigin;
-      const descriptor = await readBrokerDescriptor(args.dataDir);
+      const descriptor = await readServerBrokerDescriptor({
+        dataDir: args.dataDir,
+        homeDir: args.homeDir,
+        serverOrigin,
+      });
       if (stopped || generation !== currentGeneration) return;
       if (new URL(args.getServerUrl()).origin !== serverOrigin) {
         schedule();
         return;
       }
-      if (new URL(descriptor.serverUrl).origin !== serverOrigin)
-        throw new Error("Desktop broker belongs to a different server");
       const connection = new WebSocket(descriptor.url, {
         headers: { authorization: `Bearer ${descriptor.token}` },
         maxPayload: 1024 * 1024,

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -2316,6 +2316,7 @@ async function runDesktopApp(): Promise<void> {
   desktopBrowserBrokerClient = createDesktopBrowserBrokerClient({
     broker: desktopBrowserBroker,
     dataDir: resolveDataDirFromEnv({ env: process.env, homeDir: homedir() }),
+    homeDir: homedir(),
     getServerUrl() {
       const target = serverTargetStore?.getTarget();
       if (target?.kind === "connect") return target.server.url;

--- a/apps/desktop/test/desktop-browser-view-manager.test.ts
+++ b/apps/desktop/test/desktop-browser-view-manager.test.ts
@@ -1,6 +1,6 @@
 import type { RenderProcessGoneDetails, WebContentsView } from "electron";
 import { once } from "node:events";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { WebSocket, WebSocketServer } from "ws";
@@ -1407,144 +1407,167 @@ describe("DesktopBrowserCdpAdapter", () => {
 });
 
 describe("DesktopBrowserViewManager", () => {
-  it("preserves same-server reconnect tabs but clears them before a different server registration", async () => {
-    const { manager, hostWindow } = createRendererRecoveryFixture(91);
-    const broker = createDesktopBrowserBroker({
-      manager,
-      product: "Chrome/test",
-    });
-    broker.registerWindow(
-      Object.assign(hostWindow, {
-        focus() {},
-        show() {},
-        restore() {},
-        isMinimized: () => false,
-      }),
-    );
-    const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
-    await once(server, "listening");
-    const address = server.address();
-    if (typeof address === "string" || address === null)
-      throw new Error("Expected TCP address");
-    const dataDir = await mkdtemp(join(tmpdir(), "bb-native-origin-"));
-    const frameSchema = z.union([
-      desktopBrowserRegistrationSchema,
-      desktopBrowserChangedSchema,
-    ]);
-    const messages: Array<{
-      peer: number;
-      frame: z.infer<typeof frameSchema>;
-    }> = [];
-    let peers = 0;
-    server.on("connection", (socket) => {
-      const peer = ++peers;
-      socket.on("message", (data) =>
-        messages.push({
-          peer,
-          frame: frameSchema.parse(JSON.parse(data.toString())),
-        }),
-      );
-    });
-    let serverUrl = "https://first.example";
-    const writeDescriptor = () =>
-      writeFile(
-        join(dataDir, DESKTOP_BROWSER_BROKER_DESCRIPTOR_FILE),
-        JSON.stringify({
-          version: 1,
-          hostId: "host-1",
-          serverUrl,
-          url: `ws://127.0.0.1:${address.port}/desktop-browser`,
-          token: "a".repeat(64),
-        }),
-        { mode: 0o600 },
-      );
-    await writeDescriptor();
-    const client = createDesktopBrowserBrokerClient({
-      broker,
-      dataDir,
-      getServerUrl: () => serverUrl,
-    });
-    const hasOriginalTab = (peer: number) =>
-      messages.some(
-        (message) =>
-          message.peer === peer &&
-          message.frame.type === "desktop-browser.changed" &&
-          message.frame.tabs.some((tab) => tab.tabId === "browser:a"),
-      );
-    try {
-      await vi.waitFor(() => expect(hasOriginalTab(1)).toBe(true));
-      client.reconnect();
-      await vi.waitFor(() => expect(hasOriginalTab(2)).toBe(true));
-      expect(
-        manager.listTabs({ hostWebContentsId: 91, threadId: "thread-1" }),
-      ).toHaveLength(1);
-      const target = broker.getTarget(91);
-      if (!target) throw new Error("Expected connected desktop");
-      await broker.execute({
-        type: "desktop.browser.acquire_control",
-        instanceId: target.instanceId,
-        generation: target.generation,
-        threadId: "thread-1",
-        leaseId: "origin-lease",
-        tabIds: ["browser:a"],
-        controllerLabel: "Test",
-        expiresAt: Date.now() + 60_000,
+  it.each(["local", "enrolled"])(
+    "preserves same-server reconnect tabs but clears them before a different server registration (%s daemon)",
+    async (daemon) => {
+      const { manager, hostWindow } = createRendererRecoveryFixture(91);
+      const broker = createDesktopBrowserBroker({
+        manager,
+        product: "Chrome/test",
       });
-      serverUrl = "https://second.example";
+      broker.registerWindow(
+        Object.assign(hostWindow, {
+          focus() {},
+          show() {},
+          restore() {},
+          isMinimized: () => false,
+        }),
+      );
+      const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+      await once(server, "listening");
+      const address = server.address();
+      if (typeof address === "string" || address === null)
+        throw new Error("Expected TCP address");
+      const dataDir = await mkdtemp(join(tmpdir(), "bb-native-origin-"));
+      const frameSchema = z.union([
+        desktopBrowserRegistrationSchema,
+        desktopBrowserChangedSchema,
+      ]);
+      const messages: Array<{
+        peer: number;
+        frame: z.infer<typeof frameSchema>;
+      }> = [];
+      let peers = 0;
+      server.on("connection", (socket) => {
+        const peer = ++peers;
+        socket.on("message", (data) =>
+          messages.push({
+            peer,
+            frame: frameSchema.parse(JSON.parse(data.toString())),
+          }),
+        );
+      });
+      let serverUrl = "https://first.example";
+      if (daemon === "enrolled") {
+        await writeFile(
+          join(dataDir, DESKTOP_BROWSER_BROKER_DESCRIPTOR_FILE),
+          JSON.stringify({
+            version: 1,
+            hostId: "local-host",
+            serverUrl: "http://127.0.0.1:38886",
+            url: `ws://127.0.0.1:${address.port}/desktop-browser`,
+            token: "b".repeat(64),
+          }),
+          { mode: 0o600 },
+        );
+      }
+      const writeDescriptor = async () => {
+        const directory =
+          daemon === "local"
+            ? dataDir
+            : join(dataDir, ".bb-machines", new URL(serverUrl).host);
+        await mkdir(directory, { recursive: true });
+        await writeFile(
+          join(directory, DESKTOP_BROWSER_BROKER_DESCRIPTOR_FILE),
+          JSON.stringify({
+            version: 1,
+            hostId: "host-1",
+            serverUrl,
+            url: `ws://127.0.0.1:${address.port}/desktop-browser`,
+            token: "a".repeat(64),
+          }),
+          { mode: 0o600 },
+        );
+      };
       await writeDescriptor();
-      client.reconnect();
-      expect(
-        manager.listTabs({ hostWebContentsId: 91, threadId: null }),
-      ).toEqual([]);
-      expect(broker.getControl(91, "browser:a")).toBeNull();
-      await vi.waitFor(() =>
-        expect(
-          messages.some(
-            ({ peer, frame }) =>
-              peer === 3 &&
-              frame.type === "register" &&
-              frame.serverUrl === serverUrl,
-          ),
-        ).toBe(true),
-      );
-      manager.attach({
-        hostWindow,
-        request: {
-          tabId: "new-server-tab",
-          threadId: "thread-new",
-          url: "about:blank",
-          bounds: { x: 0, y: 0, width: 640, height: 400 },
-          visible: false,
-        },
+      const client = createDesktopBrowserBrokerClient({
+        broker,
+        dataDir,
+        homeDir: dataDir,
+        getServerUrl: () => serverUrl,
       });
-      await vi.waitFor(() =>
+      const hasOriginalTab = (peer: number) =>
+        messages.some(
+          (message) =>
+            message.peer === peer &&
+            message.frame.type === "desktop-browser.changed" &&
+            message.frame.tabs.some((tab) => tab.tabId === "browser:a"),
+        );
+      try {
+        await vi.waitFor(() => expect(hasOriginalTab(1)).toBe(true));
+        client.reconnect();
+        await vi.waitFor(() => expect(hasOriginalTab(2)).toBe(true));
         expect(
-          messages.some(
-            ({ peer, frame }) =>
-              peer === 3 &&
-              frame.type === "desktop-browser.changed" &&
-              frame.threadId === "thread-new",
-          ),
-        ).toBe(true),
-      );
-      expect(
-        messages
-          .filter(({ peer }) => peer === 3)
-          .every(
-            ({ frame }) =>
-              frame.type === "register" || frame.threadId === "thread-new",
-          ),
-      ).toBe(true);
-      expect(hasOriginalTab(3)).toBe(false);
-    } finally {
-      client.stop();
-      broker.dispose();
-      manager.destroyAll();
-      for (const socket of server.clients) socket.terminate();
-      await new Promise<void>((resolve) => server.close(() => resolve()));
-      await rm(dataDir, { recursive: true, force: true });
-    }
-  });
+          manager.listTabs({ hostWebContentsId: 91, threadId: "thread-1" }),
+        ).toHaveLength(1);
+        const target = broker.getTarget(91);
+        if (!target) throw new Error("Expected connected desktop");
+        await broker.execute({
+          type: "desktop.browser.acquire_control",
+          instanceId: target.instanceId,
+          generation: target.generation,
+          threadId: "thread-1",
+          leaseId: "origin-lease",
+          tabIds: ["browser:a"],
+          controllerLabel: "Test",
+          expiresAt: Date.now() + 60_000,
+        });
+        serverUrl = "https://second.example";
+        await writeDescriptor();
+        client.reconnect();
+        expect(
+          manager.listTabs({ hostWebContentsId: 91, threadId: null }),
+        ).toEqual([]);
+        expect(broker.getControl(91, "browser:a")).toBeNull();
+        await vi.waitFor(() =>
+          expect(
+            messages.some(
+              ({ peer, frame }) =>
+                peer === 3 &&
+                frame.type === "register" &&
+                frame.serverUrl === serverUrl,
+            ),
+          ).toBe(true),
+        );
+        manager.attach({
+          hostWindow,
+          request: {
+            tabId: "new-server-tab",
+            threadId: "thread-new",
+            url: "about:blank",
+            bounds: { x: 0, y: 0, width: 640, height: 400 },
+            visible: false,
+          },
+        });
+        await vi.waitFor(() =>
+          expect(
+            messages.some(
+              ({ peer, frame }) =>
+                peer === 3 &&
+                frame.type === "desktop-browser.changed" &&
+                frame.threadId === "thread-new",
+            ),
+          ).toBe(true),
+        );
+        expect(
+          messages
+            .filter(({ peer }) => peer === 3)
+            .every(
+              ({ frame }) =>
+                frame.type === "register" || frame.threadId === "thread-new",
+            ),
+        ).toBe(true);
+        expect(hasOriginalTab(3)).toBe(false);
+      } finally {
+        client.stop();
+        broker.dispose();
+        manager.destroyAll();
+        for (const socket of server.clients) socket.terminate();
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+        await rm(dataDir, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("captures an unpainted hidden page without detaching another controller", async () => {
     const { manager, view } = createRendererRecoveryFixture(91);

--- a/apps/desktop/test/fixtures/browser-broker-smoke.ts
+++ b/apps/desktop/test/fixtures/browser-broker-smoke.ts
@@ -38,6 +38,7 @@ async function main() {
   const client = createDesktopBrowserBrokerClient({
     broker,
     dataDir: config.dataDir,
+    homeDir: config.artifacts,
     getServerUrl: () => config.serverUrl,
   });
   writeFileSync(


### PR DESCRIPTION
## Human comments

## What was wrong

When the Mac desktop app displayed a remote BB server, browser automation reported no desktop windows even though a browser tab was open. The desktop broker client only read the local data directory's descriptor, which belonged to the local server. The remote server's enrolled daemon stored its matching descriptor under `~/.bb-machines/<server-host>`.

## What changed

The desktop client also checks the selected server's enrollment directory and connects only to a descriptor with a matching server origin. Existing descriptor validation and file permission checks still apply. No wire contract changes.

## How you verified

- Confirmed the mismatch on the affected Mac: the local descriptor targeted localhost, while the enrollment descriptor targeted the remote server and correct host ID.
- Extended the WebSocket registration regression test to cover local and enrolled daemons, same-server reconnection, and switching server origins.
- `pnpm exec turbo run test typecheck --filter=@bb/desktop` passed: 317 desktop tests and typechecking.
- Secret-model scan of the working tree, HEAD, added lines, and commit messages passed with zero findings.

- Built commit `3c7359c7b0` on the affected MacBook Pro with Node 22.23.1, packaged and installed the app, then restarted it. From bee, `bb browser instances` returned the Mac desktop window and `bb browser tabs` returned the existing Google tab in the affected thread; both were undiscoverable before the fix.

> AGENT GENERATED
