### PR TITLE
Adjust model reasoning with Left and Right arrow keys

### DIFF
--- a/apps/app/src/components/pickers/ModelReasoningPicker.test.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.test.tsx
@@ -250,6 +250,107 @@ afterEach(() => {
 });
 
 describe("ModelReasoningPicker", () => {
+  it.each([
+    ["ArrowRight", "medium", "high"],
+    ["ArrowLeft", "high", "medium"],
+  ] as const)(
+    "adjusts reasoning with %s on the focused trigger",
+    (key, value, next) => {
+      const { onReasoningChange } = renderPicker({ reasoningValue: value });
+      const trigger = screen.getByRole("button", {
+        name: "Provider, model and reasoning",
+      });
+      trigger.focus();
+      fireEvent.keyDown(trigger, { key });
+      expect(onReasoningChange).toHaveBeenCalledExactlyOnceWith(next);
+      expect(document.activeElement).toBe(trigger);
+    },
+  );
+
+  it.each([
+    ["ArrowLeft", "medium"],
+    ["ArrowRight", "high"],
+  ] as const)("stops at the reasoning limit for %s", (key, value) => {
+    const { onReasoningChange } = renderPicker({ reasoningValue: value });
+    fireEvent.keyDown(
+      screen.getByRole("button", {
+        name: "Provider, model and reasoning",
+      }),
+      { key },
+    );
+    expect(onReasoningChange).not.toHaveBeenCalled();
+  });
+
+  it("adjusts reasoning in an empty search but preserves text navigation", () => {
+    const { onReasoningChange, onModelChange } = renderPicker({
+      modelOptions: manyCodexModels,
+    });
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Provider, model and reasoning",
+      }),
+    );
+    const search = screen.getByPlaceholderText("Search models");
+    fireEvent.keyDown(search, { key: "ArrowRight" });
+    expect(onReasoningChange).toHaveBeenCalledExactlyOnceWith("high");
+    fireEvent.change(search, { target: { value: "o4" } });
+    fireEvent.keyDown(search, { key: "ArrowRight" });
+    expect(onReasoningChange).toHaveBeenCalledTimes(1);
+    expect(onModelChange).not.toHaveBeenCalled();
+  });
+
+  it("adjusts reasoning from a model row without changing the model", () => {
+    const { onReasoningChange, onModelChange } = renderPicker();
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Provider, model and reasoning",
+      }),
+    );
+    const model = screen.getByRole("button", { name: "5.5" });
+    model.focus();
+    fireEvent.keyDown(model, { key: "ArrowRight" });
+    expect(onReasoningChange).toHaveBeenCalledExactlyOnceWith("high");
+    expect(onModelChange).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(model);
+  });
+
+  it("does not change reasoning when the submenu handles an arrow", () => {
+    const { onReasoningChange } = renderPicker({
+      moreModelOptions: [{ value: "legacy", label: "Legacy" }],
+    });
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Provider, model and reasoning",
+      }),
+    );
+    const moreModels = screen.getByRole("button", { name: "More models" });
+    act(() => moreModels.focus());
+    fireEvent.keyDown(moreModels, {
+      key: "ArrowRight",
+    });
+    expect(onReasoningChange).not.toHaveBeenCalled();
+  });
+
+  it("leaves modified arrows and models without reasoning alone", () => {
+    const { onReasoningChange } = renderPicker();
+    const trigger = screen.getByRole("button", {
+      name: "Provider, model and reasoning",
+    });
+    for (const modifier of ["altKey", "ctrlKey", "metaKey", "shiftKey"]) {
+      fireEvent.keyDown(trigger, { key: "ArrowRight", [modifier]: true });
+    }
+    expect(onReasoningChange).not.toHaveBeenCalled();
+    cleanup();
+    renderPicker({ pickerReasoningOptions: [], onReasoningChange });
+    fireEvent.keyDown(
+      screen.getByRole("button", {
+        name: "Provider, model and reasoning",
+      }),
+      { key: "ArrowRight" },
+    );
+    expect(onReasoningChange).not.toHaveBeenCalled();
+  });
+
   it("uses the lower-emphasis chrome token for the composer caret", () => {
     renderPicker({ muted: true });
 

--- a/apps/app/src/components/pickers/ModelReasoningPicker.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.tsx
@@ -678,6 +678,42 @@ export function ModelReasoningPicker({
     ],
   );
 
+  const handleReasoningArrowKeyDown: KeyboardEventHandler<HTMLElement> = (
+    event,
+  ) => {
+    if (
+      event.defaultPrevented ||
+      event.altKey ||
+      event.ctrlKey ||
+      event.metaKey ||
+      event.shiftKey ||
+      disabled ||
+      !showReasoningSection ||
+      previewSelectionBlocked ||
+      (event.key !== "ArrowLeft" && event.key !== "ArrowRight")
+    ) {
+      return;
+    }
+    if (
+      isEditableKeyboardTarget(event.target) &&
+      (event.target !== searchInputRef.current || searchQuery.length > 0)
+    ) {
+      return;
+    }
+    const value = isPreviewing
+      ? previewSelection?.reasoningLevel
+      : reasoningValue;
+    const index = activeReasoningOptions.findIndex(
+      (option) => option.value === value,
+    );
+    if (index < 0) return;
+    event.preventDefault();
+    event.stopPropagation();
+    const next =
+      activeReasoningOptions[index + (event.key === "ArrowRight" ? 1 : -1)];
+    if (next) handleReasoningSelect(next.value);
+  };
+
   const handleFooterActionClick = useCallback(() => {
     if (!footerAction || footerAction.disabled) {
       return;
@@ -765,6 +801,7 @@ export function ModelReasoningPicker({
       }
       aria-keyshortcuts={toggleShortcut?.ariaKeyshortcuts}
       disabled={disabled}
+      onKeyDown={handleReasoningArrowKeyDown}
       className={cn(
         OPTION_BASE_CLASS_NAME,
         OPTION_INTERACTIVE_CLASS_NAME,
@@ -866,6 +903,7 @@ export function ModelReasoningPicker({
       <PopoverContent
         align={align}
         mobileTitle="Model"
+        onKeyDown={handleReasoningArrowKeyDown}
         onMobileContentAnimationEnd={handleMobileContentAnimationEnd}
         autoFocusRef={showSearchInput ? searchInputRef : undefined}
         className={cn(
@@ -1105,10 +1143,7 @@ export function ModelReasoningPicker({
                       checked={fastModeEnabled}
                       onCheckedChange={onFastModeChange}
                       aria-label={fastModeText}
-                      className={cn(
-                        LIST_HOVER_TRANSITION,
-                        "[&>span]:size-3.5",
-                      )}
+                      className={cn(LIST_HOVER_TRANSITION, "[&>span]:size-3.5")}
                     />
                   </div>
                 </div>


### PR DESCRIPTION
## Human comments

## What was wrong

The model picker did not handle Left/Right arrows for reasoning, so adjusting reasoning while browsing models required clicking the reasoning controls or using a separate shortcut.

## What changed

Left decreases and Right increases the selected model's reasoning while the picker button or menu is focused, stopping at the supported limits. Search text retains cursor navigation, modified arrows remain available to shortcuts, and events already handled by submenu controls are respected.

## How you verified

- All 37 ModelReasoningPicker tests pass through `pnpm exec turbo run test --filter=@bb/app -- ModelReasoningPicker.test.tsx`, including direction, limits, model-row focus, search input, modifiers, and submenu handling.
- `pnpm exec turbo run typecheck --filter=@bb/app` passes.
- Verified both directions on the trigger and open picker in an isolated source app using Browser Automation; typing search text preserves reasoning during arrow navigation.
- Secret-model scan: zero hits in the working tree, tracked HEAD, added lines, and commit messages.
- SlopCop skipped as requested.

> AGENT GENERATED
