### PR TITLE
Use shared dialogs for Account Pooler panels

### DIFF
--- a/plugins/account-pool/app.test.tsx
+++ b/plugins/account-pool/app.test.tsx
@@ -308,7 +308,7 @@ describe("Account Pool settings", () => {
     );
   });
 
-  it("shows every observed family bucket in the detail drawer", async () => {
+  it("shows every observed family bucket in the detail dialog", async () => {
     const fable = {
       utilization: 0.91,
       resetAt: Date.now() + 3_600_000,

--- a/plugins/account-pool/app.tsx
+++ b/plugins/account-pool/app.tsx
@@ -36,6 +36,13 @@ import {
   CollapsibleTrigger,
 } from "@bb/shared-ui/collapsible";
 import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@bb/shared-ui/dialog";
+import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -46,7 +53,6 @@ import { Icon } from "@bb/shared-ui/icon";
 import { Input } from "@bb/shared-ui/input";
 import { cn } from "@bb/shared-ui/lib/utils";
 import { ResourceRowDetailChevron } from "@bb/shared-ui/resource-list";
-import { ResponsiveDrawerShell } from "@bb/shared-ui/responsive-overlay";
 import { Switch } from "@bb/shared-ui/switch";
 import type {
   AccountSummary,
@@ -76,7 +82,7 @@ interface CodexLoginStep {
   expiresAt: number;
   intervalMs: number;
 }
-type DrawerState =
+type DialogState =
   | { kind: "account" | "priority" | "remove"; accountId: string }
   | { kind: "claude-login" | "codex-login" | "api-key" }
   | null;
@@ -593,39 +599,32 @@ function QuotaDetail({
     </div>
   );
 }
-function DrawerFrame({
+function DialogFrame({
   title,
-  onClose,
   children,
   footer,
+  className,
 }: {
   title: string;
-  onClose: () => void;
   children: ReactNode;
-  footer?: ReactNode;
+  footer: ReactNode;
+  className?: string;
 }) {
   return (
-    <div className="flex min-h-0 flex-1 flex-col">
-      <div className="flex items-center justify-between border-b border-border px-5 pb-4">
-        <h2 className="text-base font-semibold text-foreground">{title}</h2>
-        <Button
-          variant="ghost"
-          size="icon"
-          aria-label="Close"
-          onClick={onClose}
-        >
-          <Icon name="X" />
-        </Button>
-      </div>
-      <div className="min-h-0 flex-1 space-y-5 overflow-y-auto px-5 py-5">
-        {children}
-      </div>
-      {footer ? (
-        <div className="flex items-center gap-2 border-t border-border px-5 py-4">
-          {footer}
-        </div>
-      ) : null}
-    </div>
+    <DialogContent
+      className={cn(
+        "max-h-[85vh] grid-rows-[auto_minmax(0,1fr)_auto]",
+        className,
+      )}
+    >
+      <DialogHeader className="pr-6">
+        <DialogTitle>{title}</DialogTitle>
+      </DialogHeader>
+      <div className="min-h-0 space-y-5 overflow-y-auto">{children}</div>
+      <DialogFooter className="flex-row items-center gap-2 sm:space-x-0">
+        {footer}
+      </DialogFooter>
+    </DialogContent>
   );
 }
 
@@ -675,7 +674,7 @@ function AccountPoolSettings() {
     codexUpstreamBaseUrl: null,
     switchThreshold: null,
   });
-  const [drawer, setDrawer] = useState<DrawerState>(null);
+  const [dialog, setDialog] = useState<DialogState>(null);
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState<string | null>(null);
   const [optimisticOrder, setOptimisticOrder] = useState<{
@@ -771,10 +770,10 @@ function AccountPoolSettings() {
   }, [codexStep, loginDone, refresh, rpc]);
   const accounts = status?.accounts ?? [];
   const selectedAccount =
-    drawer?.kind === "account" ||
-    drawer?.kind === "priority" ||
-    drawer?.kind === "remove"
-      ? (accounts.find((account) => account.id === drawer.accountId) ?? null)
+    dialog?.kind === "account" ||
+    dialog?.kind === "priority" ||
+    dialog?.kind === "remove"
+      ? (accounts.find((account) => account.id === dialog.accountId) ?? null)
       : null;
   async function run(key: string, action: () => Promise<void>): Promise<void> {
     if (pending !== null) return;
@@ -843,7 +842,7 @@ function AccountPoolSettings() {
     }
   }
   async function startClaude(): Promise<void> {
-    setDrawer({ kind: "claude-login" });
+    setDialog({ kind: "claude-login" });
     setLoginDone(null);
     await run("claude-login", async () => {
       const started = await rpc.call("login.start", null);
@@ -852,7 +851,7 @@ function AccountPoolSettings() {
     });
   }
   async function startCodex(): Promise<void> {
-    setDrawer({ kind: "codex-login" });
+    setDialog({ kind: "codex-login" });
     setLoginDone(null);
     await run("codex-login", async () => {
       setCodexStep(await rpc.call("codexLogin.start", null));
@@ -868,7 +867,7 @@ function AccountPoolSettings() {
       return;
     }
     if (choice === "api-key") {
-      setDrawer({ kind: "api-key" });
+      setDialog({ kind: "api-key" });
       return;
     }
     await run(`import-${provider}`, async () => {
@@ -886,11 +885,11 @@ function AccountPoolSettings() {
   ): Promise<void> {
     if (action === "priority") {
       setPriority(String(account.priority));
-      setDrawer({ kind: "priority", accountId: account.id });
+      setDialog({ kind: "priority", accountId: account.id });
       return;
     }
     if (action === "remove") {
-      setDrawer({ kind: "remove", accountId: account.id });
+      setDialog({ kind: "remove", accountId: account.id });
       return;
     }
     await run(`${action}-${account.id}`, async () => {
@@ -923,10 +922,10 @@ function AccountPoolSettings() {
       setOptimisticOrder(null);
     }
   }
-  function closeDrawer(): void {
-    if (drawer?.kind === "codex-login" && codexStep !== null)
+  function closeDialog(): void {
+    if (dialog?.kind === "codex-login" && codexStep !== null)
       void rpc.call("codexLogin.cancel", { sessionId: codexStep.sessionId });
-    setDrawer(null);
+    setDialog(null);
     setLoginStep(null);
     setCodexStep(null);
     setLoginDone(null);
@@ -1045,7 +1044,7 @@ function AccountPoolSettings() {
                           void accountAction(account, action)
                         }
                         onOpen={() =>
-                          setDrawer({ kind: "account", accountId: account.id })
+                          setDialog({ kind: "account", accountId: account.id })
                         }
                       />
                     ))}
@@ -1167,30 +1166,27 @@ function AccountPoolSettings() {
           </div>
         </CollapsibleContent>
       </Collapsible>
-      <ResponsiveDrawerShell
-        open={drawer !== null}
+      <Dialog
+        open={dialog !== null}
         onOpenChange={(open) => {
-          if (!open) closeDrawer();
+          if (!open) closeDialog();
         }}
-        srLabel="Account Pooler details"
-        contentClassName="mx-auto w-full max-w-2xl"
       >
-        {drawer?.kind === "account" && selectedAccount !== null ? (
-          <AccountDrawer
+        {dialog?.kind === "account" && selectedAccount !== null ? (
+          <AccountDialog
             account={selectedAccount}
             threshold={threshold}
-            close={closeDrawer}
+            close={closeDialog}
             act={(action) => void accountAction(selectedAccount, action)}
           />
         ) : null}
-        {drawer?.kind === "priority" && selectedAccount !== null ? (
-          <DrawerFrame
+        {dialog?.kind === "priority" && selectedAccount !== null ? (
+          <DialogFrame
             title="Set priority"
-            onClose={closeDrawer}
             footer={
               <>
                 <span className="flex-1" />
-                <Button variant="outline" onClick={closeDrawer}>
+                <Button variant="outline" onClick={closeDialog}>
                   Cancel
                 </Button>
                 <Button
@@ -1203,7 +1199,7 @@ function AccountPoolSettings() {
                         accountId: selectedAccount.id,
                         priority: Number(priority),
                       });
-                      setDrawer(null);
+                      setDialog(null);
                     })
                   }
                 >
@@ -1222,16 +1218,15 @@ function AccountPoolSettings() {
               value={priority}
               onChange={(event) => setPriority(event.target.value)}
             />
-          </DrawerFrame>
+          </DialogFrame>
         ) : null}
-        {drawer?.kind === "api-key" ? (
-          <DrawerFrame
+        {dialog?.kind === "api-key" ? (
+          <DialogFrame
             title="Add an Anthropic API key"
-            onClose={closeDrawer}
             footer={
               <>
                 <span className="flex-1" />
-                <Button variant="outline" onClick={closeDrawer}>
+                <Button variant="outline" onClick={closeDialog}>
                   Cancel
                 </Button>
                 <Button
@@ -1245,7 +1240,7 @@ function AccountPoolSettings() {
                         priority: 100,
                       });
                       setApiKey("");
-                      setDrawer(null);
+                      setDialog(null);
                     })
                   }
                 >
@@ -1266,16 +1261,15 @@ function AccountPoolSettings() {
               value={apiKey}
               onChange={(event) => setApiKey(event.target.value)}
             />
-          </DrawerFrame>
+          </DialogFrame>
         ) : null}
-        {drawer?.kind === "remove" && selectedAccount !== null ? (
-          <DrawerFrame
+        {dialog?.kind === "remove" && selectedAccount !== null ? (
+          <DialogFrame
             title={`Remove ${selectedAccount.label}?`}
-            onClose={closeDrawer}
             footer={
               <>
                 <span className="flex-1" />
-                <Button variant="outline" onClick={closeDrawer}>
+                <Button variant="outline" onClick={closeDialog}>
                   Cancel
                 </Button>
                 <Button
@@ -1286,7 +1280,7 @@ function AccountPoolSettings() {
                       await rpc.call("account.remove", {
                         id: selectedAccount.id,
                       });
-                      setDrawer(null);
+                      setDialog(null);
                     })
                   }
                 >
@@ -1299,10 +1293,10 @@ function AccountPoolSettings() {
               This deletes the account&apos;s secret file. Threads fall back to
               their machine login when no other pooled account is available.
             </p>
-          </DrawerFrame>
+          </DialogFrame>
         ) : null}
-        {drawer?.kind === "claude-login" ? (
-          <LoginDrawer
+        {dialog?.kind === "claude-login" ? (
+          <LoginDialog
             provider="claude"
             loginStep={loginStep}
             codexStep={null}
@@ -1311,7 +1305,7 @@ function AccountPoolSettings() {
             pastedCode={pastedCode}
             countdown={0}
             error={error}
-            close={closeDrawer}
+            close={closeDialog}
             openUrl={navigate.openUrl}
             setPastedCode={setPastedCode}
             complete={() =>
@@ -1329,8 +1323,8 @@ function AccountPoolSettings() {
             retry={() => void startClaude()}
           />
         ) : null}
-        {drawer?.kind === "codex-login" ? (
-          <LoginDrawer
+        {dialog?.kind === "codex-login" ? (
+          <LoginDialog
             provider="codex"
             loginStep={null}
             codexStep={codexStep}
@@ -1339,7 +1333,7 @@ function AccountPoolSettings() {
             pastedCode=""
             countdown={countdown}
             error={error}
-            close={closeDrawer}
+            close={closeDialog}
             openUrl={navigate.openUrl}
             setPastedCode={() => {}}
             complete={() => {}}
@@ -1347,12 +1341,12 @@ function AccountPoolSettings() {
             retry={() => void startCodex()}
           />
         ) : null}
-      </ResponsiveDrawerShell>
+      </Dialog>
     </div>
   );
 }
 
-function AccountDrawer({
+function AccountDialog({
   account,
   threshold,
   close,
@@ -1379,9 +1373,9 @@ function AccountDrawer({
       ? account.accountUuid
       : account.codexAccountId;
   return (
-    <DrawerFrame
+    <DialogFrame
       title={account.label}
-      onClose={close}
+      className="sm:max-w-xl"
       footer={
         <>
           <Button size="sm" variant="outline" onClick={() => act("toggle")}>
@@ -1485,11 +1479,11 @@ function AccountDrawer({
           </>
         )}
       </dl>
-    </DrawerFrame>
+    </DialogFrame>
   );
 }
 
-function LoginDrawer({
+function LoginDialog({
   provider,
   loginStep,
   codexStep,
@@ -1526,9 +1520,9 @@ function LoginDrawer({
       ? loginStep?.authorizeUrl
       : codexStep?.verificationUri;
   return (
-    <DrawerFrame
+    <DialogFrame
       title={`Sign in to ${name}`}
-      onClose={close}
+      className="sm:max-w-xl"
       footer={
         <>
           <span className="flex-1" />
@@ -1629,7 +1623,7 @@ function LoginDrawer({
           )}
         </>
       )}
-    </DrawerFrame>
+    </DialogFrame>
   );
 }
 


### PR DESCRIPTION
## Human comments

## What was wrong

The Account Pooler settings rendered its account details, priority, API key, remove, and sign-in panels through `ResponsiveDrawerShell` directly, with a hand-rolled header, close button, and footer. On desktop they slid out as bottom drawers while every other plugin (automations, scheduled-send, docs, connect) shows a centered modal through the shared `Dialog`, which already falls back to the drawer shell on compact viewports.

## What changed

- `plugins/account-pool/app.tsx`: the drawer shell and `DrawerFrame` are replaced with `Dialog`/`DialogContent`/`DialogHeader`/`DialogTitle`/`DialogFooter` from `@bb/shared-ui/dialog`. The frame caps height at 85vh and scrolls the body; the account detail and sign-in dialogs use `sm:max-w-xl` for their wider content. The close button now comes from `DialogContent`.
- Drawer identifiers (`DrawerState`, `AccountDrawer`, `LoginDrawer`, `closeDrawer`, `setDrawer`) are renamed to dialog names; the test description follows.
- No wire, CLI, or doc changes. Compact viewports keep the drawer presentation through the Dialog's built-in fallback.

## How you verified

- `pnpm exec turbo run typecheck test --filter=bb-plugin-account-pool`: typecheck clean, 10 files / 266 tests pass, including the existing test that clicks the dialog's Close button.
- Prettier clean on both files.
- Live check in the dev app from this branch in the BB browser: the account detail dialog renders as a centered modal at a 1280px viewport, and falls back to the drawer under 768px like other dialogs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> AGENT GENERATED
