### PR TITLE
Group creation actions in the composer menu

### DIFF
--- a/apps/app/src/components/promptbox/NewThreadPromptBox.stories.tsx
+++ b/apps/app/src/components/promptbox/NewThreadPromptBox.stories.tsx
@@ -139,6 +139,7 @@ function PromptStage({ children }: PromptStageProps) {
 function DefaultRow() {
   const { value, mentionRanges, onChange } = useControlledValue("");
   const execution = useInteractiveExecutionControls(baseExecution);
+  const [commandQuery, setCommandQuery] = useState<string | null>(null);
   return (
     <PromptStage>
       <NewThreadPromptBoxUI
@@ -150,7 +151,28 @@ function DefaultRow() {
         isSubmitting={false}
         disabled={false}
         history={baseHistory}
-        typeahead={makeTypeahead()}
+        typeahead={makeTypeahead(
+          {},
+          {
+            trigger: "/",
+            onQueryChange: setCommandQuery,
+            suggestions:
+              commandQuery !== null &&
+              "moss-hardening-review".includes(commandQuery.toLowerCase())
+                ? [
+                    {
+                      kind: "command",
+                      name: "moss-hardening-review",
+                      source: "skill",
+                      origin: "user",
+                      description:
+                        "Run a hardening review for Moss persistence paths",
+                      argumentHint: "[branch | staged] [base=<ref>]",
+                    },
+                  ]
+                : [],
+          },
+        )}
         attachments={makeAttachments()}
         promptActions={promptActions}
         modeConfig={baseModeConfig}
@@ -547,7 +569,7 @@ export function Overview() {
       <StoryCard>
         <StoryRow
           label="default"
-          hint="interactive provider, model, reasoning, and fast mode"
+          hint="open + to use a skill, insert Plan/Goal, or start creating an Automation/Plugin; provider controls are interactive"
         >
           <DefaultRow />
         </StoryRow>

--- a/apps/app/src/components/promptbox/PromptBoxActionsMenu.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxActionsMenu.test.tsx
@@ -73,6 +73,7 @@ describe("PromptBoxActionsMenu", () => {
       <PromptBoxActionsMenu
         actions={withAppPromptActions([{ kind: "plan", text: "/plan " }])}
         onAction={onAction}
+        onAttach={() => {}}
       />,
     );
 
@@ -82,10 +83,28 @@ describe("PromptBoxActionsMenu", () => {
     );
     const menuItems = await screen.findAllByRole("menuitem");
     expect(menuItems.map((item) => item.textContent)).toEqual([
+      "Attach files",
+      "Use skill…",
       "Plan",
       "Automation",
       "Plugin",
     ]);
+    expect(
+      menuItems.map((item) =>
+        item.querySelector("[data-icon]")?.getAttribute("data-icon"),
+      ),
+    ).toEqual(["Paperclip", "Zap", "ListTodo", "Repeat", "ElectricPlugs"]);
+    const createLabel = screen.getByText("Create");
+    expect(screen.getAllByRole("separator")).toHaveLength(2);
+    expect(menuItems[0].nextElementSibling?.getAttribute("role")).toBe(
+      "separator",
+    );
+    expect(createLabel.previousElementSibling?.getAttribute("role")).toBe(
+      "separator",
+    );
+    expect(createLabel.nextElementSibling).toBe(
+      screen.getByRole("menuitem", { name: "Automation" }),
+    );
 
     fireEvent.click(screen.getByRole("menuitem", { name: "Plugin" }));
 
@@ -104,6 +123,54 @@ describe("PromptBoxActionsMenu", () => {
       },
     ]);
   });
+
+  it("omits creation chrome when no creation actions are visible", async () => {
+    render(
+      <PromptBoxActionsMenu
+        actions={[
+          { kind: "skills", text: "/" },
+          { kind: "plan", text: "/plan " },
+          { kind: "automation", text: "" },
+        ]}
+        onAction={() => {}}
+        onAttach={() => {}}
+      />,
+    );
+
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: "Prompt actions" }),
+      { button: 0 },
+    );
+    await screen.findByRole("menuitem", { name: "Use skill…" });
+    expect(screen.queryByText("Create")).toBeNull();
+    expect(screen.getAllByRole("separator")).toHaveLength(1);
+    expect(screen.getByRole("separator").previousElementSibling).toBe(
+      screen.getByRole("menuitem", { name: "Attach files" }),
+    );
+  });
+
+  it.each([false, true])(
+    "avoids extra dividers for a lone creation action with attachments %s",
+    async (withAttachments) => {
+      render(
+        <PromptBoxActionsMenu
+          actions={[CREATE_PLUGIN_PROMPT_ACTION]}
+          onAction={() => {}}
+          onAttach={withAttachments ? () => {} : undefined}
+        />,
+      );
+
+      fireEvent.pointerDown(
+        screen.getByRole("button", { name: "Prompt actions" }),
+        { button: 0 },
+      );
+      const plugin = await screen.findByRole("menuitem", { name: "Plugin" });
+      expect(screen.getByText("Create").nextElementSibling).toBe(plugin);
+      expect(screen.queryAllByRole("separator")).toHaveLength(
+        withAttachments ? 1 : 0,
+      );
+    },
+  );
 
   it("restores composer focus after an update-only plugin item", async () => {
     const view: ComposerView = {

--- a/apps/app/src/components/promptbox/PromptBoxActionsMenu.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxActionsMenu.test.tsx
@@ -71,7 +71,10 @@ describe("PromptBoxActionsMenu", () => {
     const onAction = vi.fn();
     render(
       <PromptBoxActionsMenu
-        actions={withAppPromptActions([{ kind: "plan", text: "/plan " }])}
+        actions={withAppPromptActions([
+          { kind: "skills", text: "/skills " },
+          { kind: "plan", text: "/plan " },
+        ])}
         onAction={onAction}
         onAttach={() => {}}
       />,

--- a/apps/app/src/components/promptbox/PromptBoxActionsMenu.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxActionsMenu.tsx
@@ -1,10 +1,11 @@
-import { useCallback, useRef } from "react";
+import { Fragment, useCallback, useRef } from "react";
 import { Button } from "@bb/shared-ui/button";
 import { cn } from "@bb/shared-ui/lib/utils";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@bb/shared-ui/dropdown-menu";
@@ -73,7 +74,7 @@ const PROMPT_ACTION_ORDER: readonly PromptBoxActionKind[] = [
 
 const PROMPT_ACTION_PRESENTATION = {
   skills: {
-    label: "Skills",
+    label: "Use skill…",
     icon: "Zap",
   },
   plan: {
@@ -132,6 +133,9 @@ export function PromptBoxActionsMenu({
   );
   const visibleActions = orderedPromptActions(actions).filter(
     (action) => action.text.length > 0,
+  );
+  const firstCreateActionIndex = visibleActions.findIndex(
+    (action) => action.kind === "automation" || action.kind === "plugin",
   );
   const clearSelectedActionAfterClose = useCallback(() => {
     const clear = () => {
@@ -207,45 +211,52 @@ export function PromptBoxActionsMenu({
         }}
       >
         {onAttach ? (
-          <>
-            <DropdownMenuItem
-              disabled={isAttaching}
-              onSelect={() => {
-                selectedItemRef.current = true;
-                onAttach();
-              }}
-            >
-              <Icon
-                name={isAttaching ? "Spinner" : "Paperclip"}
-                className={cn(
-                  "size-4 text-muted-foreground",
-                  isAttaching && "animate-spin",
-                )}
-                aria-hidden
-              />
-              Attach files
-            </DropdownMenuItem>
-            {visibleActions.length > 0 ? <DropdownMenuSeparator /> : null}
-          </>
+          <DropdownMenuItem
+            disabled={isAttaching}
+            onSelect={() => {
+              selectedItemRef.current = true;
+              onAttach();
+            }}
+          >
+            <Icon
+              name={isAttaching ? "Spinner" : "Paperclip"}
+              className={cn(
+                "size-4 text-muted-foreground",
+                isAttaching && "animate-spin",
+              )}
+              aria-hidden
+            />
+            Attach files
+          </DropdownMenuItem>
         ) : null}
-        {visibleActions.map((action) => {
+        {onAttach && visibleActions.length > 0 ? (
+          <DropdownMenuSeparator />
+        ) : null}
+        {visibleActions.map((action, index) => {
           const presentation = PROMPT_ACTION_PRESENTATION[action.kind];
           return (
-            <DropdownMenuItem
-              key={action.kind}
-              disabled={action.disabled}
-              onSelect={() => {
-                selectedItemRef.current = true;
-                onAction(action);
-              }}
-            >
-              <Icon
-                name={presentation.icon}
-                className="size-4 text-muted-foreground"
-                aria-hidden
-              />
-              {action.label ?? presentation.label}
-            </DropdownMenuItem>
+            <Fragment key={action.kind}>
+              {index === firstCreateActionIndex ? (
+                <>
+                  {index > 0 ? <DropdownMenuSeparator /> : null}
+                  <DropdownMenuLabel>Create</DropdownMenuLabel>
+                </>
+              ) : null}
+              <DropdownMenuItem
+                disabled={action.disabled}
+                onSelect={() => {
+                  selectedItemRef.current = true;
+                  onAction(action);
+                }}
+              >
+                <Icon
+                  name={presentation.icon}
+                  className="size-4 text-muted-foreground"
+                  aria-hidden
+                />
+                {action.label ?? presentation.label}
+              </DropdownMenuItem>
+            </Fragment>
           );
         })}
         {pluginItems.length > 0 ? <DropdownMenuSeparator /> : null}

--- a/apps/app/src/components/promptbox/PromptBoxActionsMenu.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxActionsMenu.tsx
@@ -211,26 +211,26 @@ export function PromptBoxActionsMenu({
         }}
       >
         {onAttach ? (
-          <DropdownMenuItem
-            disabled={isAttaching}
-            onSelect={() => {
-              selectedItemRef.current = true;
-              onAttach();
-            }}
-          >
-            <Icon
-              name={isAttaching ? "Spinner" : "Paperclip"}
-              className={cn(
-                "size-4 text-muted-foreground",
-                isAttaching && "animate-spin",
-              )}
-              aria-hidden
-            />
-            Attach files
-          </DropdownMenuItem>
-        ) : null}
-        {onAttach && visibleActions.length > 0 ? (
-          <DropdownMenuSeparator />
+          <>
+            <DropdownMenuItem
+              disabled={isAttaching}
+              onSelect={() => {
+                selectedItemRef.current = true;
+                onAttach();
+              }}
+            >
+              <Icon
+                name={isAttaching ? "Spinner" : "Paperclip"}
+                className={cn(
+                  "size-4 text-muted-foreground",
+                  isAttaching && "animate-spin",
+                )}
+                aria-hidden
+              />
+              Attach files
+            </DropdownMenuItem>
+            {visibleActions.length > 0 ? <DropdownMenuSeparator /> : null}
+          </>
         ) : null}
         {visibleActions.map((action, index) => {
           const presentation = PROMPT_ACTION_PRESENTATION[action.kind];

--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -3595,7 +3595,7 @@ describe("PromptBoxInternal prompt actions", () => {
   it("inserts the skills trigger with no trailing space", async () => {
     const { changes, onCommandQueryChange } = renderPromptBox("");
 
-    await selectPromptAction("Skills");
+    await selectPromptAction("Use skill…");
 
     await waitFor(() => expect(latestValue(changes)).toBe("/"));
     await waitFor(() =>
@@ -3607,7 +3607,7 @@ describe("PromptBoxInternal prompt actions", () => {
   it("does not duplicate the skills trigger when it is already active", async () => {
     const { changes } = renderPromptBox("/");
 
-    await selectPromptAction("Skills");
+    await selectPromptAction("Use skill…");
 
     expect(changes).toHaveLength(0);
   });
@@ -3780,7 +3780,7 @@ describe("PromptBoxInternal prompt actions", () => {
     const { changes, promptBoxRef } = renderPromptBox("");
 
     await focusPromptEnd(promptBoxRef);
-    await selectPromptAction("Skills");
+    await selectPromptAction("Use skill…");
     await waitFor(() => expect(latestValue(changes)).toBe("/"));
     await waitForPromptFocus();
 
@@ -3864,7 +3864,7 @@ describe("PromptBoxInternal prompt actions", () => {
     await waitFor(() => expect(latestValue(changes)).toBe("/goal "));
     await waitForPromptFocus();
 
-    await selectPromptAction("Skills");
+    await selectPromptAction("Use skill…");
 
     await waitFor(() => expect(latestValue(changes)).toBe("/"));
     expect(latestChange(changes)?.mentions).toEqual([]);


### PR DESCRIPTION
## Human comments

## What was wrong

- The composer + menu mixed skill insertion and agent controls with resource creation, without explaining the distinction.

## What changed

- Rename the default Skills action to “Use skill…” and group Automation and Plugin beneath a “Create” label and divider.
- Preserve the existing divider below Attach files. Keep Plan and Goal outside Create, and Send later in its separate section.
- Preserve current main's icons, prompt insertion, focus, disabled states, and plugin contribution behavior.
- Extend the existing contextual composer story with an interactive skill picker. This is a standalone four-file change against main; it does not include the sidebar split.

## How you verified

- [Remote CI](https://github.com/get-bb/bb/actions/runs/34437600681) on `97f28447625f1436f50671d35243fa560f59af53`: passed. Menu tests cover preserved attachment dividers, creation grouping, and no duplicate separators.
- Chrome for Testing 151.0.7922.71, root composer, light theme: verified all three menu dividers at 1440×900; keyboard navigation skips separators and the Create heading. At 390×844, verified the phone sheet layout, Plugin prompt insertion, sheet dismissal, and restored editor focus. Cleared the draft; nothing submitted or scheduled.
- [Contextual Ladle story](https://brsbl--61001.getbb.app/?story=promptbox--new-thread-prompt-box--overview&theme=light): verified the same attachment divider and Create grouping in the existing Overview.
- Fresh screenshots from the isolated branch web app use the same data, root route, empty composer, Codex 5.6-Sol / Medium, light theme, and open + menu. Before: main merge base `04f4e6a21c1efa6d82d9d62a094b87796c36439c`. After: exact PR head `97f28447625f1436f50671d35243fa560f59af53`.

| Before — web/desktop · 1440×900 | After — web/desktop · 1440×900 | After — mobile · 390×844 |
| --- | --- | --- |
| ![Before](https://github.com/user-attachments/assets/e79ec61b-b4ee-4516-a453-1d6a99040bea) | ![After desktop](https://github.com/user-attachments/assets/192d307d-6a0e-4f9e-bae8-6dc30ee02570) | ![After mobile](https://github.com/user-attachments/assets/3ab578e9-666a-4041-ba90-6c042724333a) |

BB-Thread-ID: thr_g27ypnz5wu

> AGENT GENERATED