### PR TITLE
Balance Machines list padding

### DIFF
--- a/apps/app/src/components/settings/MachinesSettingsSection.tsx
+++ b/apps/app/src/components/settings/MachinesSettingsSection.tsx
@@ -269,12 +269,14 @@ export function MachinesSettingsSection() {
   const now = Date.now();
   const primaryHostPlatform = systemConfig.data?.primaryHostPlatform ?? null;
   const showMachineIdentityBadges = (hosts?.length ?? 0) > 1;
+  const hasMachineRows = hosts !== undefined && hosts.length > 0;
 
   return (
     <>
       <SettingsSection
         title="Machines"
         description={MACHINES_SECTION_DESCRIPTION}
+        bodyClassName={hasMachineRows ? "py-2" : undefined}
         action={
           <Button
             size="sm"


### PR DESCRIPTION
## Human comments

## What was wrong

Each machine row extends its hover surface 8px into the surrounding card padding. The Machines card retained the default 16px horizontal and 14px vertical padding, leaving the visible row surface 9px from the side borders but 15px from the top and bottom borders.

## What changed

Use 8px vertical body padding when the section contains machine rows, balancing the visible row surface at 9px from all four card borders. Loading and empty states retain their existing padding; row navigation, the overflow menu, the Add a machine action, dividers, and responsive behavior are unchanged.

## How you verified

- Measured 9px visible row inset on all four sides at 1280×900 and 390×844, with both one and three machine rows
- Verified row navigation, overflow actions, the navigation chevron, and Add a machine behavior in the review app
- `pnpm exec turbo run typecheck lint --filter=@bb/app` passed with 0 errors
- Focused app tests passed: 14/14
- `git diff --check` passed

No linked issue.

> AGENT GENERATED