### PR TITLE
Prevent terminal backpressure from blocking service logs

### DIFF
--- a/docs/debugging-and-qa.md
+++ b/docs/debugging-and-qa.md
@@ -4,6 +4,7 @@
 - `pnpm start:worktree` builds production artifacts and serves the optimized app bundle from the checkout-specific dev server URL, while keeping the same dev data directory and deterministic server/host-daemon ports. It has no Vite dev server or hot reload.
 - `pnpm start:worktree-remote` is the trusted-network variant of `pnpm start:worktree`; it binds that server to all IPv4 interfaces.
 - The packaged app defaults to server/frontend `:38886`, host daemon `:38887`, data dir `~/.bb/`, and logs under `~/.bb/logs/`.
+- `bb-app` (including `pnpm start`), `bb-server`, and `bb-host-daemon` capture service stdout and stderr directly in `logs/server-stdio.log` and `logs/host-daemon-stdio.log` under the selected data directory. These append across restarts and are separate from rotating application logs. Use `tail -F` on these files for console output and early startup errors; service output is no longer forwarded to the launcher's terminal.
 - Entity IDs in URLs (`proj_*`, `thr_*`) are primary keys. Query them directly against the active data dir: `sqlite3 <data>/bb.db "SELECT * FROM threads WHERE id = 'thr_xxx';"`.
 - API routes are under `/api/v1/`, for example `GET /api/v1/threads/:id`.
 - Use `curl` against the server API to isolate frontend issues from server behavior.

--- a/packages/bb-app/README.md
+++ b/packages/bb-app/README.md
@@ -91,6 +91,19 @@ local host daemon, and serves the web app. It stores bb-managed state under
 launcher restarts that child without stopping the other one. Press `Ctrl+C` in
 the terminal to stop both processes and exit with status `0`.
 
+Server and host-daemon output goes directly to `logs/server-stdio.log` and
+`logs/host-daemon-stdio.log` under the data directory, including startup errors
+and console output. These files append across restarts; they are separate from
+the rotating application logs. The launcher prints status and log locations
+without forwarding service output to the terminal, so a stalled terminal cannot
+block service logging. To follow output with the default data directory:
+
+```bash
+tail -F ~/.bb/logs/server-stdio.log ~/.bb/logs/host-daemon-stdio.log
+```
+
+The same output capture applies to `bb-server` and `bb-host-daemon`.
+
 To stop a bb that runs in another terminal or in the background:
 
 ```bash

--- a/packages/bb-app/scripts/smoke-tarball.mjs
+++ b/packages/bb-app/scripts/smoke-tarball.mjs
@@ -225,12 +225,24 @@ async function waitForHttp({ label, processRef, url }) {
   );
 }
 
-async function waitForHostPluginWorker({ pluginId, processRef }) {
+async function waitForHostPluginWorker({ dataDir, pluginId, processRef }) {
+  const logPath = join(dataDir, "logs", "host-daemon-stdio.log");
+  let daemonOutput = "";
   const deadline = Date.now() + HOST_PLUGIN_WORKER_TIMEOUT_MS;
   while (Date.now() <= deadline) {
+    try {
+      daemonOutput = await readFile(logPath, "utf8");
+    } catch (error) {
+      if (error.code !== "ENOENT") throw error;
+    }
     if (
-      processRef.output.stdout.includes("Host plugin worker ready") &&
-      processRef.output.stdout.includes(pluginId)
+      daemonOutput
+        .split("\n")
+        .some(
+          (line) =>
+            line.includes("Host plugin worker ready") &&
+            line.includes(pluginId),
+        )
     ) {
       return;
     }
@@ -239,13 +251,13 @@ async function waitForHostPluginWorker({ pluginId, processRef }) {
       processRef.childProcess.signalCode !== null
     ) {
       throw new Error(
-        `${processRef.label} exited before host plugin ${pluginId} started\n${formatProcessOutput(processRef.output)}`,
+        `${processRef.label} exited before host plugin ${pluginId} started\n${formatProcessOutput(processRef.output)}\n${logPath}:\n${daemonOutput}`,
       );
     }
     await delay(HTTP_WAIT_INTERVAL_MS);
   }
   throw new Error(
-    `Timed out waiting for host plugin ${pluginId} on ${processRef.label}\n${formatProcessOutput(processRef.output)}`,
+    `Timed out waiting for host plugin ${pluginId} on ${processRef.label}\n${formatProcessOutput(processRef.output)}\n${logPath}:\n${daemonOutput}`,
   );
 }
 
@@ -945,6 +957,7 @@ async function smokeFullStack(binDir, sdkDir) {
     // log proves the packed daemon found its companion worker, downloaded the
     // plugin artifact, and started the worker for a host RPC call.
     await waitForHostPluginWorker({
+      dataDir,
       pluginId: "keep-awake",
       processRef: stack,
     });
@@ -1053,8 +1066,9 @@ async function smokeDaemonJoin(binDir) {
     // Ready workers on both prove host-plugin artifacts and calls fan out to
     // enrolled machines instead of assuming server-local paths.
     await Promise.all(
-      daemons.map((daemon) =>
+      daemons.map((daemon, index) =>
         waitForHostPluginWorker({
+          dataDir: daemonSpecs[index].dataDir,
           pluginId: "keep-awake",
           processRef: daemon,
         }),

--- a/packages/bb-app/src/launcher.ts
+++ b/packages/bb-app/src/launcher.ts
@@ -3,6 +3,7 @@ import type { ChildProcess } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { spawn } from "node:child_process";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { spawnLoggedProcess } from "./logged-process.js";
 import {
   access,
   mkdir,
@@ -307,25 +308,12 @@ interface ParsedLauncherArgs {
   positionals: string[];
 }
 
-interface ManagedSpawnArgs {
-  args: string[];
-  command: string;
-  env: NodeJS.ProcessEnv;
-  outputBuffer: OutputBuffer;
-}
-
-interface OutputBuffer {
-  flush(): void;
-  handler(chunk: OutputChunk): void;
-}
-
 export interface ProcessExitResult {
   code: number | null;
   signal: NodeJS.Signals | null;
 }
 
 export type ManagedProcessName = "daemon" | "server";
-type OutputChunk = Buffer | string;
 type WaitForProcessExitWithTimeoutResult = "exited" | "timed-out";
 type StartManagedProcess = () => Promise<ManagedProcessRun>;
 export type DelayMillisecondsFn = (
@@ -381,10 +369,10 @@ export interface ManagedFullStackProcesses {
 }
 
 interface SpawnNamedManagedProcessArgs {
+  logDir: string;
   args: string[];
   command: string;
   env: NodeJS.ProcessEnv;
-  outputBuffer: OutputBuffer;
   processName: ManagedProcessName;
 }
 
@@ -392,14 +380,12 @@ interface StartFullStackServerProcessArgs {
   beforeStart?: () => Promise<void> | void;
   context: BbAppStartContext;
   env: NodeJS.ProcessEnv;
-  outputBuffer: OutputBuffer;
   processes: ManagedFullStackProcesses;
 }
 
 interface StartFullStackDaemonProcessArgs {
   autoJoinEnv: NodeJS.ProcessEnv;
   context: BbAppStartContext;
-  outputBuffer: OutputBuffer;
   processes: ManagedFullStackProcesses;
 }
 
@@ -2405,52 +2391,13 @@ export async function waitForHostDaemonStatus(
   );
 }
 
-function toChunkString(chunk: OutputChunk): string {
-  return typeof chunk === "string" ? chunk : chunk.toString("utf8");
-}
-
-function createOutputBuffer(): OutputBuffer {
-  const chunks: OutputChunk[] = [];
-  let passthrough = false;
-
-  return {
-    handler(chunk) {
-      if (passthrough) {
-        process.stdout.write(chunk);
-        return;
-      }
-      chunks.push(chunk);
-    },
-    flush() {
-      process.stdout.write("\n");
-      for (const chunk of chunks) {
-        process.stdout.write(toChunkString(chunk));
-      }
-      chunks.length = 0;
-      passthrough = true;
-    },
-  };
-}
-
-function spawnManagedProcess(args: ManagedSpawnArgs): ChildProcess {
-  const child = spawn(args.command, args.args, {
-    cwd: process.cwd(),
-    env: args.env,
-    stdio: ["ignore", "pipe", "inherit"],
-  });
-
-  if (child.stdout === null) {
-    throw new Error("Expected managed process stdout to be piped");
-  }
-
-  child.stdout.on("data", args.outputBuffer.handler);
-  return child;
-}
-
 function spawnNamedManagedProcess(
   args: SpawnNamedManagedProcessArgs,
 ): ChildManagedProcessRun {
-  const childProcess = spawnManagedProcess(args);
+  const childProcess = spawnLoggedProcess({
+    ...args,
+    logName: args.processName === "server" ? "server" : "host-daemon",
+  });
   return {
     childProcess,
     exit: waitForNamedProcessExit({
@@ -2795,6 +2742,8 @@ export async function runBbServer(
 
 Usage:
   bb-server [--data-dir <path>] [--server-bind-host <host>] [--server-port <port>]
+
+Service stdout and stderr append to <data-dir>/logs/server-stdio.log.
 `);
     return;
   }
@@ -2831,13 +2780,16 @@ Usage:
   }
   assertBbAppArtifacts(runtime.context);
 
-  const childProcess = spawn(process.execPath, [runtime.context.serverEntry], {
-    cwd: process.cwd(),
+  log(" ", dim(`logs: ${runtime.context.logDir}/server-stdio.log`));
+  const childProcess = spawnLoggedProcess({
+    command: process.execPath,
+    args: [runtime.context.serverEntry],
+    logDir: runtime.context.logDir,
+    logName: "server",
     env: createServerEnv({
       context: runtime.context,
       env: runtime.serverEnv,
     }),
-    stdio: "inherit",
   });
   process.exitCode = toExitCode(await waitForProcessExit(childProcess));
 }
@@ -2895,12 +2847,12 @@ async function runHostDaemonOnly(args: RunHostDaemonOnlyArgs): Promise<void> {
     enrollment.enrolled ? "Starting daemon" : "Enrolling and starting daemon",
   );
 
-  const outputBuffer = createOutputBuffer();
-  const daemonProcess = spawnManagedProcess({
+  const daemonProcess = spawnLoggedProcess({
     args: [args.context.daemonEntry],
     command: process.execPath,
     env: daemonEnv,
-    outputBuffer,
+    logDir: args.context.logDir,
+    logName: "host-daemon",
   });
 
   let shuttingDown = false;
@@ -2938,7 +2890,6 @@ async function runHostDaemonOnly(args: RunHostDaemonOnlyArgs): Promise<void> {
       endStep(red("✗"), "Host daemon failed to start");
       log(" ", dim(`lock: ${args.context.daemonLockDir}`));
       log(" ", dim(`logs: ${args.context.logDir}/`));
-      outputBuffer.flush();
       process.exitCode = 1;
       await shutdown("SIGTERM");
       return;
@@ -2964,7 +2915,6 @@ async function runHostDaemonOnly(args: RunHostDaemonOnlyArgs): Promise<void> {
     process.stdout.write("\n");
     log(" ", dim("Press Ctrl+C to stop"));
 
-    outputBuffer.flush();
     process.exitCode = toExitCode(await daemonExit);
   } finally {
     removeSignalForwarding();
@@ -3055,7 +3005,7 @@ export async function startFullStackServerProcess(
     args: [args.context.serverEntry],
     command: process.execPath,
     env: { ...args.env, BB_SERVER_LAUNCH_ID: launchId },
-    outputBuffer: args.outputBuffer,
+    logDir: args.context.logDir,
     processName: "server",
   });
   args.processes.serverRun = serverRun;
@@ -3089,7 +3039,7 @@ async function startFullStackDaemonProcess(
     args: [args.context.daemonEntry],
     command: process.execPath,
     env: createDaemonEnv(args.context, args.autoJoinEnv),
-    outputBuffer: args.outputBuffer,
+    logDir: args.context.logDir,
     processName: "daemon",
   });
   args.processes.daemonRun = daemonRun;
@@ -3438,7 +3388,6 @@ export async function runBbApp(
     bindHost: runtime.serverEnv.BB_SERVER_BIND_HOST,
     port: context.serverPort,
   });
-  const outputBuffer = createOutputBuffer();
   const serverEnv = createServerEnv({
     context,
     env: runtime.serverEnv,
@@ -3495,7 +3444,6 @@ export async function runBbApp(
         : { beforeStart: options.beforeServerStart }),
       context,
       env: serverEnv,
-      outputBuffer,
       processes,
     });
 
@@ -3516,7 +3464,6 @@ export async function runBbApp(
         context,
         processName: "server",
       });
-      outputBuffer.flush();
       process.exitCode = 1;
       await shutdown("SIGTERM");
       return;
@@ -3534,7 +3481,6 @@ export async function runBbApp(
       startFullStackDaemonProcess({
         autoJoinEnv,
         context,
-        outputBuffer,
         processes,
       });
 
@@ -3546,7 +3492,6 @@ export async function runBbApp(
         context,
         processName: "daemon",
       });
-      outputBuffer.flush();
       process.exitCode = 1;
       await shutdown("SIGTERM");
       return;
@@ -3566,7 +3511,6 @@ export async function runBbApp(
     process.stdout.write("\n");
     log(" ", dim("Press Ctrl+C to stop"));
 
-    outputBuffer.flush();
     const supervisionResult = await superviseFullStackProcesses({
       context,
       delayMilliseconds,

--- a/packages/bb-app/src/logged-process.ts
+++ b/packages/bb-app/src/logged-process.ts
@@ -1,0 +1,29 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { closeSync, mkdirSync, openSync } from "node:fs";
+import { join } from "node:path";
+
+interface SpawnLoggedProcessArgs {
+  args: string[];
+  command: string;
+  env: NodeJS.ProcessEnv;
+  logDir: string;
+  logName: "server" | "host-daemon";
+}
+
+export function spawnLoggedProcess(args: SpawnLoggedProcessArgs): ChildProcess {
+  mkdirSync(args.logDir, { recursive: true });
+  const fd = openSync(
+    join(args.logDir, `${args.logName}-stdio.log`),
+    "a",
+    0o600,
+  );
+  try {
+    return spawn(args.command, args.args, {
+      cwd: process.cwd(),
+      env: args.env,
+      stdio: ["ignore", fd, fd],
+    });
+  } finally {
+    closeSync(fd);
+  }
+}

--- a/packages/bb-app/test/logged-process.test.ts
+++ b/packages/bb-app/test/logged-process.test.ts
@@ -1,0 +1,122 @@
+import type { ChildProcess } from "node:child_process";
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { spawnLoggedProcess } from "../src/logged-process.js";
+
+const scratchDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of scratchDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function scratchDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "bb-logged-process-"));
+  scratchDirs.push(dir);
+  return dir;
+}
+
+function waitForExit(child: ChildProcess): Promise<number | null> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error("Child stalled while writing logs"));
+    }, 5_000);
+    child.once("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.once("exit", (code) => {
+      clearTimeout(timer);
+      resolve(code);
+    });
+  });
+}
+
+describe("spawnLoggedProcess", () => {
+  it.each(["server", "host-daemon"] as const)(
+    "captures %s stdout and stderr bursts without a parent stream reader",
+    async (logName) => {
+      const logDir = join(scratchDir(), "logs");
+      const child = spawnLoggedProcess({
+        command: process.execPath,
+        args: [
+          "-e",
+          `
+            const { fstatSync } = require("node:fs");
+            if (!fstatSync(1).isFile() || !fstatSync(2).isFile()) process.exit(2);
+            console.log("o".repeat(2 * 1024 * 1024));
+            console.error("e".repeat(2 * 1024 * 1024));
+            setImmediate(() => console.log("event loop responsive"));
+          `,
+        ],
+        env: process.env,
+        logDir,
+        logName,
+      });
+
+      expect(await waitForExit(child)).toBe(0);
+      const logPath = join(logDir, `${logName}-stdio.log`);
+      expect(readFileSync(logPath, "utf8")).toBe(
+        `${"o".repeat(2 * 1024 * 1024)}\n${"e".repeat(2 * 1024 * 1024)}\nevent loop responsive\n`,
+      );
+      expect(statSync(logPath).mode & 0o777).toBe(0o600);
+    },
+  );
+
+  it("preserves output across child restarts, including early failures", async () => {
+    const logDir = scratchDir();
+    for (const message of ["first startup", "second startup"]) {
+      const child = spawnLoggedProcess({
+        command: process.execPath,
+        args: [
+          "-e",
+          `console.error(${JSON.stringify(message)}); process.exit(1);`,
+        ],
+        env: process.env,
+        logDir,
+        logName: "server",
+      });
+      expect(await waitForExit(child)).toBe(1);
+    }
+    expect(readFileSync(join(logDir, "server-stdio.log"), "utf8")).toBe(
+      "first startup\nsecond startup\n",
+    );
+  });
+
+  it("fails instead of falling back to terminal output when logs cannot be opened", () => {
+    const logDir = scratchDir();
+    const blockedPath = join(logDir, "not-a-directory");
+    writeFileSync(blockedPath, "occupied");
+    expect(() =>
+      spawnLoggedProcess({
+        command: process.execPath,
+        args: ["-e", "process.exit(0)"],
+        env: process.env,
+        logDir: blockedPath,
+        logName: "server",
+      }),
+    ).toThrow();
+  });
+
+  it("reports executable spawn failures", async () => {
+    const logDir = scratchDir();
+    const child = spawnLoggedProcess({
+      command: join(logDir, "missing-executable"),
+      args: [],
+      env: process.env,
+      logDir,
+      logName: "server",
+    });
+    await expect(waitForExit(child)).rejects.toThrow("ENOENT");
+  });
+});

--- a/packages/bb-app/test/server-health-identity.test.ts
+++ b/packages/bb-app/test/server-health-identity.test.ts
@@ -6,7 +6,7 @@ import {
   type ServerResponse,
 } from "node:http";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import type {
   BbAppStartContext,
@@ -74,7 +74,7 @@ function createStartContext(args: {
   serverEntry: string;
   serverPort: number;
 }): BbAppStartContext {
-  const dataDir = "/tmp/bb-app-health-test";
+  const dataDir = dirname(args.serverEntry);
   return {
     appDistDir: `${dataDir}/app/dist`,
     appVersion: "0.0.0-test",
@@ -94,11 +94,6 @@ function createStartContext(args: {
     serverUrl: `http://127.0.0.1:${args.serverPort}`,
   };
 }
-
-const silentOutputBuffer = {
-  flush(): void {},
-  handler(): void {},
-};
 
 describe("waitForServerHealth", () => {
   it("does not accept another server's /health while the child is still booting", async () => {
@@ -218,7 +213,6 @@ describe("startFullStackServerProcess", () => {
         BB_SERVER_PORT: String(context.serverPort),
         PATH: process.env.PATH,
       },
-      outputBuffer: silentOutputBuffer,
       processes,
     });
     try {
@@ -257,7 +251,6 @@ describe("startFullStackServerProcess", () => {
           BB_SERVER_PORT: String(context.serverPort),
           PATH: process.env.PATH,
         },
-        outputBuffer: silentOutputBuffer,
         processes,
       }),
     ).rejects.toBe(preflightError);
@@ -285,7 +278,6 @@ describe("startFullStackServerProcess", () => {
             BB_SERVER_PORT: String(context.serverPort),
             PATH: process.env.PATH,
           },
-          outputBuffer: silentOutputBuffer,
           processes,
         }),
       ).rejects.toThrow(

--- a/packages/templates/src/templates/bb-guide-machines.md
+++ b/packages/templates/src/templates/bb-guide-machines.md
@@ -30,6 +30,12 @@ To opt out, remove `--auto-update` from the launchd plist or systemd user unit
 and reload that service. Foreground/manual `bb-app host-daemon` runs leave it off
 unless you pass `--auto-update` explicitly.
 
+`bb-app`, `bb-server`, and `bb-host-daemon` capture service stdout and stderr
+directly under the selected data directory in `logs/server-stdio.log` and
+`logs/host-daemon-stdio.log`. These files append across restarts and contain
+console output and startup errors; rotating application logs remain separate.
+Use `tail -F` to follow them without coupling service logging to the terminal.
+
   bb machine list                         List machines with ID, connection
                                           status, and relative last-seen time
     --json                                Print the raw host list

--- a/plugins/bb-guide/skills/bb-cli/SKILL.md
+++ b/plugins/bb-guide/skills/bb-cli/SKILL.md
@@ -69,6 +69,10 @@ BB_HOST_DAEMON_PORT only for an intentional non-default target.
 - Treat plugin commands as normal top-level commands after installation.
 
 - Inspect real status, logs, API results, or diffs instead of assumptions.
+- For launcher startup errors and console output, read `logs/server-stdio.log`
+  or `logs/host-daemon-stdio.log` under the selected bb data directory. These
+  append across restarts; `bb-app`, `bb-server`, and `bb-host-daemon` capture
+  service output there instead of forwarding it to their terminal.
 - Keep file paths on the machine that owns the selected workspace.
 
 ## Common checks


### PR DESCRIPTION
## Human comments

## What was wrong

The launcher forwarded service stdout from a data callback into `process.stdout.write()` and inherited terminal stderr. On macOS, a stalled terminal can block that synchronous write and stop the launcher from draining child output. A log burst can consequently freeze the service. Replacing the callback with `pipe()` still blocks in the terminal write; an isolated pseudo-terminal reproduction confirmed this.

## What changed

Send both service stdout and stderr directly to private append-only `server-stdio.log` and `host-daemon-stdio.log` files in the selected logs directory. Apply this to full-stack launches and the standalone server and host-daemon commands, and remove the launcher output buffer and forwarding callbacks. Close the parent's log descriptor after spawning each child.

Update launcher help, the package README, debugging docs, CLI guide, and skill with the capture locations and `tail -F` usage. Existing application logs retain their rotation and remain the desktop log viewer's source. The new capture files append across restarts without automatic rotation. There are no server/daemon wire changes.

## How you verified

- `pnpm exec turbo run smoke:tarball --filter=bb-app` — passed locally, including full-stack startup and separate daemon enrollment. The smoke harness now checks each daemon capture file for its plugin-ready message and includes that output on failure.

- `pnpm exec turbo run test typecheck --filter=bb-app` — passed; 79 tests across four files.
- New real-child tests cover multi-megabyte stdout/stderr bursts without parent stream readers, file permissions, retained output across restarts and early failures, inaccessible log paths, and executable spawn failures.
- Isolated macOS pseudo-terminal check: leave terminal output undrained, write 8 MiB across child stdout/stderr, and verify the child health endpoint responds and the launcher heartbeat advances. All 8,388,610 output bytes were captured.
- `git diff --check` — passed. No production processes were restarted; desktop UI was not exercised.

> AGENT GENERATED
