### PR TITLE
Scale GitHub plugin sync interval with tracked repo count

### DIFF
--- a/plugins/github/PLUGIN_OVERVIEW.md
+++ b/plugins/github/PLUGIN_OVERVIEW.md
@@ -9,7 +9,7 @@ See the open issues and pull requests of your repositories inside bb. Hand one t
 
 ## How it works
 
-The plugin tracks every bb project whose checkout has a GitHub `origin` remote. Add more repositories in the Extra repositories setting as a comma-separated `owner/repo` list. Choose a Default project for repositories that are not attached to a project. A background service refreshes the cache every 5 minutes. Press Refresh in the panel to update now.
+The plugin tracks every bb project whose checkout has a GitHub `origin` remote. Add more repositories in the Extra repositories setting as a comma-separated `owner/repo` list. Choose a Default project for repositories that are not attached to a project. A background service refreshes the cache on an interval that grows with the number of tracked repositories (5–60 minutes) so a large project list does not exhaust the GitHub rate limit. Press Refresh in the panel to update now.
 
 ## For agents
 

--- a/plugins/github/README.md
+++ b/plugins/github/README.md
@@ -45,8 +45,12 @@ bb plugin config github set extraRepos "owner/repo, owner/other"
 bb plugin reload github
 ```
 
-A background service refreshes the issue/PR cache every 5 minutes; the
-panel's Refresh button (or `bb github sync`) forces it.
+A background service refreshes the issue/PR cache on a cadence that scales
+with how many repositories are tracked (each sync is four `gh` list calls per
+repo). One or two projects stay on a 5-minute refresh; a catalog of ~34
+repos lands around 20 minutes, so the plugin stays near 400 GitHub list calls
+per hour instead of burning the shared token. Floor is 5 minutes, cap is 60.
+The panel's Refresh button (or `bb github sync`) forces a sync now.
 
 ## Development
 

--- a/plugins/github/server.sync-interval.test.ts
+++ b/plugins/github/server.sync-interval.test.ts
@@ -1,0 +1,108 @@
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createFakePluginHost } from "@get-bb/plugin-sdk/testing";
+import plugin, { syncIntervalMinutesForRepoCount } from "./server";
+
+let binDir: string;
+const originalPath = process.env.PATH;
+const originalSetTimeout = globalThis.setTimeout;
+
+let parkDelays: number[] = [];
+
+beforeEach(() => {
+  binDir = mkdtempSync(join(tmpdir(), "bb-gh-interval-"));
+  writeFileSync(
+    join(binDir, "gh"),
+    `#!/usr/bin/env bash
+case "$1 $2" in
+  "--version ") echo "gh version 2.96.0 (fake)"; exit 0;;
+  "auth status") echo "github.com"; echo "  ✓ Logged in to github.com account someone (keyring)"; exit 0;;
+  *) echo "[]"; exit 0;;
+esac
+`,
+  );
+  chmodSync(join(binDir, "gh"), 0o755);
+  process.env.PATH = `${binDir}:${originalPath ?? ""}`;
+  parkDelays = [];
+  vi.stubGlobal("setTimeout", ((
+    handler: () => void,
+    delay?: number,
+    ...args: unknown[]
+  ) => {
+    if (typeof delay === "number" && delay >= 60_000) {
+      parkDelays.push(delay);
+      return originalSetTimeout(handler, 1);
+    }
+    return originalSetTimeout(handler, delay, ...args);
+  }) as typeof globalThis.setTimeout);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  process.env.PATH = originalPath;
+  rmSync(binDir, { recursive: true, force: true });
+});
+
+async function collectParkDelays(settings?: Record<string, string>) {
+  const { bb, harness } = createFakePluginHost({
+    pluginId: "github",
+    settings,
+  });
+  await plugin(bb);
+  const { controller, done } = harness.runService("sync");
+  await vi.waitFor(() => expect(parkDelays.length).toBeGreaterThan(0), {
+    timeout: 8_000,
+  });
+  return { harness, controller, done };
+}
+
+describe("syncIntervalMinutesForRepoCount", () => {
+  it("stays at 5 minutes for an empty or tiny catalog", () => {
+    expect(syncIntervalMinutesForRepoCount(0)).toBe(5);
+    expect(syncIntervalMinutesForRepoCount(1)).toBe(5);
+    expect(syncIntervalMinutesForRepoCount(8)).toBe(5);
+  });
+
+  it("grows with repo count so list-call volume stays near 400/hour", () => {
+    expect(syncIntervalMinutesForRepoCount(34)).toBe(21);
+    expect(syncIntervalMinutesForRepoCount(50)).toBe(30);
+    expect(syncIntervalMinutesForRepoCount(200)).toBe(60);
+  });
+
+  it("clamps nonsense counts", () => {
+    expect(syncIntervalMinutesForRepoCount(-3)).toBe(5);
+    expect(syncIntervalMinutesForRepoCount(Number.NaN)).toBe(5);
+  });
+});
+
+describe("github sync interval auto-scale", () => {
+  it("parks 5 minutes when no repos are tracked", async () => {
+    const { controller, done } = await collectParkDelays();
+    controller.abort();
+    await done;
+    expect(parkDelays[0]).toBe(5 * 60_000);
+  });
+
+  it("parks longer when many extraRepos are tracked", async () => {
+    const repos = Array.from(
+      { length: 34 },
+      (_, i) => `owner/repo-${i}`,
+    ).join(", ");
+    const { controller, done } = await collectParkDelays({
+      extraRepos: repos,
+    });
+    controller.abort();
+    await done;
+    expect(parkDelays[0]).toBe(21 * 60_000);
+  });
+
+  it("does not expose a manual interval setting", async () => {
+    const { bb, harness } = createFakePluginHost({ pluginId: "github" });
+    await plugin(bb);
+    expect(
+      harness.registrations.settingsDescriptors.syncIntervalMinutes,
+    ).toBeUndefined();
+  });
+});

--- a/plugins/github/server.ts
+++ b/plugins/github/server.ts
@@ -2,12 +2,31 @@ import { execFile } from "node:child_process";
 import { defineRpcContract, type BbPluginApi } from "@get-bb/plugin-sdk";
 import { z } from "zod";
 
-const SYNC_INTERVAL_MS = 5 * 60_000;
 const SYNC_RETRY_BASE_MS = 30_000;
 const ISSUE_PAGE = 100;
 const CLOSED_ISSUE_PAGE = 50;
 const PR_PAGE = 50;
 const CLOSED_PR_PAGE = 30;
+// Each tracked repo costs four `gh` list calls per sync (open/closed issues and
+// PRs). Aim for ~400 of those per hour so a machine with many BB projects does
+// not spend the shared GitHub token on catalog refresh. Floor 5 min so a
+// one-project install stays fresh; cap 60 min so a huge catalog still moves.
+const GH_CALLS_PER_REPO_PER_SYNC = 4;
+const TARGET_SYNC_CALLS_PER_HOUR = 400;
+const MIN_SYNC_INTERVAL_MINUTES = 5;
+const MAX_SYNC_INTERVAL_MINUTES = 60;
+
+export function syncIntervalMinutesForRepoCount(repoCount: number): number {
+  const n = Number.isFinite(repoCount) ? Math.max(0, Math.floor(repoCount)) : 0;
+  if (n === 0) return MIN_SYNC_INTERVAL_MINUTES;
+  const minutes = Math.ceil(
+    (n * GH_CALLS_PER_REPO_PER_SYNC * 60) / TARGET_SYNC_CALLS_PER_HOUR,
+  );
+  return Math.min(
+    MAX_SYNC_INTERVAL_MINUTES,
+    Math.max(MIN_SYNC_INTERVAL_MINUTES, minutes),
+  );
+}
 
 const GH_HINT =
   "Install the GitHub CLI (https://cli.github.com) and run `gh auth login`, " +
@@ -857,17 +876,25 @@ export default async function plugin(bb: BbPluginApi) {
   bb.background.service("sync", {
     async start(signal) {
       let failures = 0;
+      let lastRepoCount = 0;
       while (!signal.aborted) {
-        let delayMs = SYNC_INTERVAL_MS;
+        let delayMs =
+          syncIntervalMinutesForRepoCount(lastRepoCount) * 60_000;
         try {
-          await syncAll();
+          const result = await syncAll();
+          lastRepoCount = result.repos;
+          delayMs = syncIntervalMinutesForRepoCount(lastRepoCount) * 60_000;
           failures = 0;
+          bb.log.info(
+            `next sync in ${Math.round(delayMs / 60_000)} min ` +
+              `(${lastRepoCount} repo(s))`,
+          );
         } catch (error) {
           if (!isGhUnavailableError(error)) throw error;
           failures += 1;
           delayMs = Math.min(
             SYNC_RETRY_BASE_MS * 2 ** (failures - 1),
-            SYNC_INTERVAL_MS,
+            delayMs,
           );
           bb.log.warn(
             `sync failed (retry in ${Math.round(delayMs / 1000)}s): ${


### PR DESCRIPTION
## Human comments

<!-- Agents: Do not fill in this section. This is for human users to fill in. -->

## What was wrong

The builtin GitHub plugin refreshed every 5 minutes with four `gh` list calls per tracked repository. On a machine with dozens of BB projects that is well over a thousand GraphQL invocations per hour, a large slice of the shared personal GitHub token.

## What changed

- Drop the fixed 5-minute `SYNC_INTERVAL_MS`.
- Auto-scale the park from tracked repo count, targeting ~400 list calls per hour, clamped 5–60 minutes. A 34-repo catalog now parks ~21 minutes.
- Document the scaling in README and PLUGIN_OVERVIEW.

## How you verified

- `pnpm exec turbo run test --filter=bb-plugin-github` — 34 passed, including new interval unit and service tests.
- Live overlay on this machine logged `next sync in 21 min (34 repo(s))`.

<!-- Agents: end with the line below. -->
<!-- > AGENT GENERATED -->