### PR TITLE
Restore Installed plugins in Settings alongside Plugins

### DIFF
--- a/apps/app/src/App.legacy-skill-route.test.tsx
+++ b/apps/app/src/App.legacy-skill-route.test.tsx
@@ -42,14 +42,14 @@ afterEach(cleanup);
 
 describe("legacy resource redirects", () => {
   it.each(["github", "plugin with spaces"])(
-    "redirects legacy installed detail for %s without changing configuration routes",
+    "opens workspace installed detail for %s alongside Settings routes",
     async (pluginId) => {
       const settingsPath = `/settings/plugins/${encodeURIComponent(pluginId)}`;
       render(
         <MemoryRouter
           initialEntries={[
             settingsPath,
-            `${settingsPath}?view=installed&from=bookmark#details`,
+            `/plugins/${encodeURIComponent(pluginId)}?view=installed&from=bookmark#details`,
           ]}
           initialIndex={1}
         >
@@ -77,11 +77,8 @@ describe("legacy resource redirects", () => {
   );
 
   it.each([
-    ["/settings/plugins", "/plugins?view=installed"],
-    [
-      "/extensions?view=installed#catalog",
-      "/plugins?view=installed#catalog",
-    ],
+    ["/settings/plugins", "/settings/plugins"],
+    ["/extensions?view=installed#catalog", "/plugins?view=installed#catalog"],
     ["/extensions/plugins", "/plugins"],
     [
       "/extensions/plugins/browse?sort=name#catalog",

--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -60,10 +60,8 @@ import {
   getAutomationDetailRoutePath,
   getAutomationEditRoutePath,
   getAutomationsRoutePath,
-  getPluginDetailRoutePath,
   getSettingsRoutePath,
   getSettingsProjectRoutePath,
-  isLegacyInstalledPluginsRoute,
 } from "./lib/route-paths";
 import { AppCommandProvider } from "./components/commands/AppCommandProvider";
 import { ProviderCliInstallLogDialogHost } from "./components/provider-cli/provider-cli-install";
@@ -165,34 +163,6 @@ export function PluginsLandingRedirect() {
       }}
       replace
     />
-  );
-}
-
-export function LegacyInstalledPluginsRedirect() {
-  const { pluginId } = useParams<{ pluginId?: string }>();
-  const { search, hash } = useLocation();
-  const searchParams = new URLSearchParams(search);
-  searchParams.set("view", "installed");
-  return (
-    <Navigate
-      to={{
-        pathname: pluginId
-          ? getPluginDetailRoutePath({ pluginId })
-          : PLUGINS_ROUTE_PATH,
-        search: `?${searchParams.toString()}`,
-        hash,
-      }}
-      replace
-    />
-  );
-}
-
-function PluginSettingsRoute() {
-  const location = useLocation();
-  return isLegacyInstalledPluginsRoute(location) ? (
-    <LegacyInstalledPluginsRedirect />
-  ) : (
-    <SettingsView />
   );
 }
 
@@ -332,12 +302,9 @@ export function AppRoutes() {
           />
           <Route
             path={SETTINGS_PLUGINS_ROUTE_PATH}
-            element={<LegacyInstalledPluginsRedirect />}
+            element={<SettingsView />}
           />
-          <Route
-            path={SETTINGS_PLUGIN_ROUTE_PATH}
-            element={<PluginSettingsRoute />}
-          />
+          <Route path={SETTINGS_PLUGIN_ROUTE_PATH} element={<SettingsView />} />
           <Route
             path={SETTINGS_MACHINE_ROUTE_PATH}
             element={<MachineSettingsView />}

--- a/apps/app/src/components/commands/CommandPalette.test.tsx
+++ b/apps/app/src/components/commands/CommandPalette.test.tsx
@@ -483,7 +483,7 @@ describe("CommandPalette", () => {
   });
 
   it.each([false, true])(
-    "opens Installed plugins in its workspace (compact: %s)",
+    "opens Installed plugins in Settings (compact: %s)",
     async (isCompactViewport) => {
       renderPalette(isCompactViewport);
       openPalette();
@@ -498,8 +498,8 @@ describe("CommandPalette", () => {
       await waitFor(() =>
         expect(screen.getByTestId("location").textContent).toBe(
           JSON.stringify({
-            pathname: "/plugins",
-            search: "?view=installed",
+            pathname: "/settings/plugins",
+            search: "",
             state: null,
           }),
         ),

--- a/apps/app/src/components/commands/CommandPalette.tsx
+++ b/apps/app/src/components/commands/CommandPalette.tsx
@@ -38,7 +38,6 @@ import { buildPluginPagePaletteActions } from "@/lib/command-palette/palette-plu
 import { usePluginSlots } from "@/lib/plugin-slots";
 import { getActiveThreadPanelOpener } from "@/components/plugin/plugin-thread-panel-navigation";
 import { getThreadRoutePath } from "@/lib/route-paths";
-import { getToolsOwnedCollectionRoutePath } from "@/components/tools/tools-navigation";
 import { pluginListQueryOptions } from "@/hooks/queries/plugin-settings-queries";
 import {
   buildPluginSettingsEntries,
@@ -175,21 +174,8 @@ export function CommandPalette({ threadId, projectId }: CommandPaletteProps) {
   const mode: PaletteMode = query.startsWith(">") ? "commands" : "threads";
   const modeQuery = mode === "commands" ? query.slice(1) : query;
   const commandActions = useMemo<readonly PaletteAction[]>(
-    () => [
-      ...actions,
-      ...settingsActions,
-      {
-        id: "settings:plugins",
-        group: "Plugins",
-        title: "Installed plugins",
-        shortcut: null,
-        run: () => {
-          void navigate(getToolsOwnedCollectionRoutePath("plugins"));
-        },
-      },
-      ...pluginPageActions,
-    ],
-    [actions, navigate, pluginPageActions, settingsActions],
+    () => [...actions, ...settingsActions, ...pluginPageActions],
+    [actions, pluginPageActions, settingsActions],
   );
   const rankedCommands = useMemo(
     () =>

--- a/apps/app/src/components/dialogs/AddMachineDialog.test.tsx
+++ b/apps/app/src/components/dialogs/AddMachineDialog.test.tsx
@@ -322,7 +322,9 @@ describe("AddMachineDialog", () => {
     const link = screen.getByRole("link", {
       name: "Enable the Connect plugin",
     });
-    expect(link.getAttribute("href")).toBe("/plugins/connect?view=installed");
+    expect(link.getAttribute("href")).toBe(
+      "/settings/plugins/connect?view=installed",
+    );
     expect(screen.queryByText("Remote access isn't ready yet.")).toBeNull();
     expect(screen.queryByRole("button", { name: "Try again" })).toBeNull();
     expect(

--- a/apps/app/src/components/layout/AppLayout.tools-breadcrumbs.test.ts
+++ b/apps/app/src/components/layout/AppLayout.tools-breadcrumbs.test.ts
@@ -71,7 +71,7 @@ describe("resolveToolsBreadcrumbs", () => {
       ),
     ).toEqual([
       { label: "Plugins", to: "/plugins" },
-      { label: "Installed", to: "/plugins?view=installed" },
+      { label: "Installed", to: "/settings/plugins" },
       { label: "UI Patterns" },
     ]);
     expect(

--- a/apps/app/src/components/plugin/PluginsOverview.test.tsx
+++ b/apps/app/src/components/plugin/PluginsOverview.test.tsx
@@ -53,7 +53,7 @@ function responseJson(body: unknown, status = 200): Response {
 const AUTOMATIONS_PLUGIN = {
   id: "automations",
   source: "builtin:automations",
-  rootDir: "/plugins/automations",
+  rootDir: "/settings/plugins/automations",
   version: "0.1.0",
   enabled: true,
   status: "running",
@@ -168,7 +168,7 @@ function installFetch(plugins: readonly unknown[] = [AUTOMATIONS_PLUGIN]) {
             ...AUTOMATIONS_PLUGIN,
             id: "github",
             source: GITHUB_CATALOG_ENTRY.source,
-            rootDir: "/plugins/github",
+            rootDir: "/settings/plugins/github",
             name: GITHUB_CATALOG_ENTRY.displayName,
             description: GITHUB_CATALOG_ENTRY.description,
             icon: GITHUB_CATALOG_ENTRY.icon,
@@ -398,14 +398,17 @@ describe("PluginsOverview", () => {
     ).toBeTruthy();
   });
 
-  it("opens installed resources on the canonical Plugins detail route", async () => {
+  it("opens installed resources on the canonical Settings detail route", async () => {
     installFetch();
     const { wrapper: QueryClientWrapper } = createQueryClientTestHarness();
     render(
-      <MemoryRouter initialEntries={["/plugins?view=installed"]}>
+      <MemoryRouter initialEntries={["/settings/plugins"]}>
         <QueryClientWrapper>
           <Routes>
-            <Route path="/plugins" element={<PluginsOverview />} />
+            <Route
+              path="/settings/plugins"
+              element={<PluginsOverview mode="installed" />}
+            />
             <Route path="*" element={<LocationPath />} />
           </Routes>
         </QueryClientWrapper>
@@ -418,7 +421,7 @@ describe("PluginsOverview", () => {
       }),
     );
     expect(screen.getByTestId("location-path").textContent).toBe(
-      "/plugins/automations",
+      "/settings/plugins/automations",
     );
   });
 
@@ -445,7 +448,7 @@ describe("PluginsOverview", () => {
     fireEvent.click(screen.getByRole("button", { name: "Install GitHub" }));
 
     expect((await screen.findByTestId("location-path")).textContent).toBe(
-      "/plugins/github",
+      "/settings/plugins/github",
     );
   });
 

--- a/apps/app/src/components/plugin/PluginsOverview.tsx
+++ b/apps/app/src/components/plugin/PluginsOverview.tsx
@@ -38,7 +38,9 @@ import {
 
 export function PluginsOverview({
   onOpenPlugin,
+  mode,
 }: {
+  mode?: "installed" | "browse";
   onOpenPlugin?: (pluginId: string, trigger: HTMLButtonElement) => void;
 } = {}) {
   const navigate = useNavigate();
@@ -49,7 +51,7 @@ export function PluginsOverview({
     [listQuery.data?.plugins],
   );
   const activeMode =
-    searchParams.get("view") === "installed" ? "installed" : "browse";
+    mode ?? (searchParams.get("view") === "installed" ? "installed" : "browse");
   const authorKey = searchParams.get("author");
   const [installedQuery, setInstalledQuery] = useState("");
   const [installedViewport, setInstalledViewport] =

--- a/apps/app/src/components/plugin/management/InstalledPluginsTab.tsx
+++ b/apps/app/src/components/plugin/management/InstalledPluginsTab.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { EmptyState } from "@bb/shared-ui/empty-state";
 import { Switch } from "@bb/shared-ui/switch";
 import {
@@ -17,7 +17,10 @@ import {
 } from "@/hooks/queries/plugin-settings-queries";
 import { pluginNeedsAttention } from "@/hooks/usePluginAttention";
 import { cn } from "@bb/shared-ui/lib/utils";
-import { getPluginDetailRoutePath } from "@/lib/route-paths";
+import {
+  getPluginDetailRoutePath,
+  isPluginsRoutePath,
+} from "@/lib/route-paths";
 import {
   pluginRowSignal,
   pluginRuntimeStatusPresentation,
@@ -77,6 +80,7 @@ export function InstalledPluginRow({
   onUpdateClick: () => void;
 }) {
   const navigate = useNavigate();
+  const location = useLocation();
   const queryClient = useQueryClient();
   const toggle = useMutation({
     meta: { showErrorToast: false },
@@ -110,7 +114,9 @@ export function InstalledPluginRow({
 
   const openDetail = () =>
     navigate(
-      getPluginDetailRoutePath({ pluginId: plugin.id, view: "installed" }),
+      isPluginsRoutePath(location.pathname)
+        ? `${getPluginDetailRoutePath({ pluginId: plugin.id })}?view=installed`
+        : getPluginDetailRoutePath({ pluginId: plugin.id, view: "installed" }),
     );
   return (
     <div data-testid={`plugin-row-${plugin.id}`}>

--- a/apps/app/src/components/plugin/management/UpdatePluginDialog.test.tsx
+++ b/apps/app/src/components/plugin/management/UpdatePluginDialog.test.tsx
@@ -229,7 +229,7 @@ describe("UpdatePluginDialog", () => {
     render(<MemoryRouter>{notification?.description}</MemoryRouter>);
     expect(
       screen.getByRole("link", { name: "Linear" }).getAttribute("href"),
-    ).toBe("/plugins/linear?view=installed");
+    ).toBe("/settings/plugins/linear?view=installed");
     expect(
       screen.getByRole("link", { name: "Linear" }).parentElement?.textContent,
     ).toBe("Linear — plugin source is unavailable");

--- a/apps/app/src/components/settings/SettingsSidebar.test.tsx
+++ b/apps/app/src/components/settings/SettingsSidebar.test.tsx
@@ -38,11 +38,13 @@ function renderSidebar(activePluginId: string | null = null) {
 afterEach(cleanup);
 
 describe("SettingsSidebarContent plugin navigation", () => {
-  it("offers configurable plugin settings without installed-plugin management", () => {
+  it("offers installed-plugin management and configurable plugin settings", () => {
     renderSidebar();
     expect(
-      screen.queryByRole("link", { name: "Installed plugins" }),
-    ).toBeNull();
+      screen
+        .getByRole("link", { name: "Installed plugins" })
+        .getAttribute("href"),
+    ).toBe("/settings/plugins");
     expect(
       screen.getByRole("link", { name: "Linear" }).getAttribute("href"),
     ).toBe("/settings/plugins/linear");

--- a/apps/app/src/components/settings/settings-nav.test.tsx
+++ b/apps/app/src/components/settings/settings-nav.test.tsx
@@ -93,13 +93,13 @@ describe("useSettingsNavState", () => {
     );
   });
 
-  it("does not treat the legacy installed-plugin collection as a settings section", () => {
+  it("recognizes installed plugins as a settings section", () => {
     const { result } = renderHook(() => useSettingsNavState(), {
       wrapper: wrapperFor("/settings/plugins"),
     });
 
-    expect(result.current.hasUnknownSection).toBe(true);
-    expect(result.current.sections.map((section) => section.id)).not.toContain(
+    expect(result.current.hasUnknownSection).toBe(false);
+    expect(result.current.sections.map((section) => section.id)).toContain(
       "plugins",
     );
   });

--- a/apps/app/src/components/settings/settings-nav.tsx
+++ b/apps/app/src/components/settings/settings-nav.tsx
@@ -58,7 +58,11 @@ export function useSettingsNavState(): SettingsNavState {
     location.pathname,
   );
   const pluginMatch = matchPath(SETTINGS_PLUGIN_ROUTE_PATH, location.pathname);
-  const activePluginId = pluginMatch?.params.pluginId ?? null;
+  const isInstalledDetail =
+    new URLSearchParams(location.search).get("view") === "installed";
+  const activePluginId = isInstalledDetail
+    ? null
+    : (pluginMatch?.params.pluginId ?? null);
   const machineMatch = matchPath(
     SETTINGS_MACHINE_ROUTE_PATH,
     location.pathname,
@@ -73,15 +77,17 @@ export function useSettingsNavState(): SettingsNavState {
   const hasUnknownSection =
     sectionParam !== undefined && !isSettingsSectionId(sectionParam);
   const activeSection: SettingsSectionId | null =
-    activeMachineId !== null
-      ? "machines"
-      : activeProjectId !== null
-        ? "projects"
-        : activePluginId !== null
-          ? null
-          : sectionParam !== undefined && isSettingsSectionId(sectionParam)
-            ? sectionParam
-            : "general";
+    isInstalledDetail && pluginMatch !== null
+      ? "plugins"
+      : activeMachineId !== null
+        ? "machines"
+        : activeProjectId !== null
+          ? "projects"
+          : activePluginId !== null
+            ? null
+            : sectionParam !== undefined && isSettingsSectionId(sectionParam)
+              ? sectionParam
+              : "general";
 
   const installedPlugins = pluginListQuery.data?.plugins ?? [];
   const pluginEntries = buildPluginSettingsEntries({

--- a/apps/app/src/components/settings/settings-sections.ts
+++ b/apps/app/src/components/settings/settings-sections.ts
@@ -12,6 +12,7 @@ export const SETTINGS_NAV_SECTIONS = [
   { icon: "FolderGit", id: "projects", label: "Projects" },
   { icon: "Laptop", id: "machines", label: "Machines" },
   { icon: "PackageReceive", id: "updates", label: "Updates" },
+  { icon: "ElectricPlugs", id: "plugins", label: "Installed plugins" },
   { icon: "Puzzle", id: "marketplaces", label: "Plugin marketplaces" },
   { icon: "Beaker", id: "experiments", label: "Experiments" },
   { icon: "MessageSquare", id: "community", label: "Community" },

--- a/apps/app/src/components/sidebar/SidebarPluginAttentionGlyph.test.tsx
+++ b/apps/app/src/components/sidebar/SidebarPluginAttentionGlyph.test.tsx
@@ -60,7 +60,7 @@ describe("SidebarPluginAttentionGlyph", () => {
     expect(el.getAttribute("aria-label")).toBe(
       "Notify is incompatible: requires bb >=0.38.0 <0.39.0, this is 0.39.0",
     );
-    expect(el.getAttribute("href")).toBe("/plugins?view=installed");
+    expect(el.getAttribute("href")).toBe("/settings/plugins");
     expect(el.className).toContain("text-warning-text");
     expect(el.querySelector('[data-icon="AlertTriangle"]')).not.toBeNull();
   });

--- a/apps/app/src/components/tools/tools-navigation.ts
+++ b/apps/app/src/components/tools/tools-navigation.ts
@@ -7,6 +7,7 @@ import {
   REGISTRY_SKILLS_ROUTE_PATH,
   REGISTRY_SKILL_DETAIL_ROUTE_PATH,
   SKILL_DETAIL_ROUTE_PATH,
+  SETTINGS_PLUGINS_ROUTE_PATH,
   AUTOMATIONS_BROWSE_ROUTE_PATH,
   AUTOMATIONS_ROUTE_PATH,
   AUTOMATION_DETAIL_ROUTE_PATH,
@@ -49,7 +50,9 @@ const TOOLS_OWNED_COLLECTION_VIEW = {
 } as const satisfies Record<ToolsSectionId, string>;
 
 export function getToolsOwnedCollectionRoutePath(id: ToolsSectionId): string {
-  return `${TOOLS_SECTIONS[id].to}?view=${TOOLS_OWNED_COLLECTION_VIEW[id]}`;
+  return id === "plugins"
+    ? SETTINGS_PLUGINS_ROUTE_PATH
+    : `${TOOLS_SECTIONS[id].to}?view=${TOOLS_OWNED_COLLECTION_VIEW[id]}`;
 }
 
 interface ToolsBreadcrumbSegment {

--- a/apps/app/src/hooks/useAppSettingsRouteMemory.test.tsx
+++ b/apps/app/src/hooks/useAppSettingsRouteMemory.test.tsx
@@ -32,9 +32,6 @@ function RouteMemoryTestSurface() {
       <Link to="/projects/proj_one/settings">Legacy project settings</Link>
       <Link to="/settings/projects/proj_one">Project detail</Link>
       <Link to="/settings/plugins">Legacy plugin collection</Link>
-      <Link to="/settings/plugins/ui-patterns?view=installed#source">
-        Legacy installed plugin detail
-      </Link>
       <Link to="/settings/plugins/ui-patterns">Legacy plugin detail</Link>
     </>
   );
@@ -128,49 +125,31 @@ describe("useAppSettingsRouteMemory", () => {
     expect(screen.getByTestId("location").textContent).toBe("/plugins");
   });
 
-  it.each(["Legacy plugin collection", "Legacy installed plugin detail"])(
-    "does not remember %s as Settings or app context",
-    (linkName) => {
-      render(
-        <MemoryRouter
-          initialEntries={[
-            "/projects/proj_one/threads/thr_one?message=12#event-12",
-          ]}
-        >
-          <RouteMemoryTestSurface />
-        </MemoryRouter>,
-      );
-
-      fireEvent.click(screen.getByRole("link", { name: "Settings" }));
-      fireEvent.click(screen.getByRole("link", { name: "Codex settings" }));
-      fireEvent.click(screen.getByRole("link", { name: "App" }));
-      fireEvent.click(screen.getByRole("link", { name: linkName }));
-
-      expect(
-        screen.getByRole("link", { name: "Settings" }).getAttribute("href"),
-      ).toBe("/settings/providers/codex?tab=models#preferred");
-      expect(
-        screen.getByRole("link", { name: "Tools" }).getAttribute("href"),
-      ).toBe("/plugins");
-      expect(
-        screen.getByRole("link", { name: "Tools back" }).getAttribute("href"),
-      ).toBe("/projects/proj_one/threads/thr_one?message=12#event-12");
-      fireEvent.click(screen.getByRole("link", { name: "Plugin detail" }));
-      fireEvent.click(screen.getByRole("link", { name: "Tools back" }));
-      fireEvent.click(screen.getByRole("link", { name: "Settings" }));
-      expect(screen.getByTestId("location").textContent).toBe(
-        "/settings/providers/codex?tab=models#preferred",
-      );
-    },
-  );
-
-  it.each([
-    "/settings/plugins",
-    "/settings/plugins/ui-patterns?view=installed#source",
-    "/settings/plugins/%40example%2Fplugin?from=bookmark&view=installed",
-  ])("uses safe defaults when opened directly at %s", (path) => {
+  it("remembers installed plugin management as Settings and preserves the app destination", () => {
     render(
-      <MemoryRouter initialEntries={[path]}>
+      <MemoryRouter initialEntries={["/projects/proj_one/threads/thr_one"]}>
+        <RouteMemoryTestSurface />
+      </MemoryRouter>,
+    );
+    fireEvent.click(
+      screen.getByRole("link", { name: "Legacy plugin collection" }),
+    );
+    expect(
+      screen.getByRole("link", { name: "Settings" }).getAttribute("href"),
+    ).toBe("/settings/plugins");
+    fireEvent.click(screen.getByRole("link", { name: "App" }));
+    expect(screen.getByTestId("location").textContent).toBe(
+      "/projects/proj_one/threads/thr_one",
+    );
+    fireEvent.click(screen.getByRole("link", { name: "Settings" }));
+    expect(screen.getByTestId("location").textContent).toBe(
+      "/settings/plugins",
+    );
+  });
+
+  it("uses safe defaults when opened directly at the installed plugins list", () => {
+    render(
+      <MemoryRouter initialEntries={["/settings/plugins"]}>
         <RouteMemoryTestSurface />
       </MemoryRouter>,
     );
@@ -180,24 +159,19 @@ describe("useAppSettingsRouteMemory", () => {
     );
     expect(
       screen.getByRole("link", { name: "Settings" }).getAttribute("href"),
-    ).toBe("/settings");
+    ).toBe("/settings/plugins");
     expect(
       screen.getByRole("link", { name: "Tools" }).getAttribute("href"),
     ).toBe("/plugins");
     expect(
       screen.getByRole("link", { name: "Tools back" }).getAttribute("href"),
-    ).toBe("/");
-
-    fireEvent.click(screen.getByRole("link", { name: "Plugin detail" }));
-    fireEvent.click(screen.getByRole("link", { name: "Tools back" }));
-    fireEvent.click(screen.getByRole("link", { name: "Settings" }));
-    expect(screen.getByTestId("location").textContent).toBe("/settings");
+    ).toBe("/settings/plugins");
   });
 
   it.each([
     "/settings/plugins/ui-patterns",
-    "/settings/plugins/ui-patterns?view=settings#source",
-  ])("remembers %s as a real Settings route", (path) => {
+    "/settings/plugins/ui-patterns?view=installed#source",
+  ])("remembers %s as a Settings route", (path) => {
     render(
       <MemoryRouter initialEntries={[path]}>
         <RouteMemoryTestSurface />

--- a/apps/app/src/hooks/useAppSettingsRouteMemory.ts
+++ b/apps/app/src/hooks/useAppSettingsRouteMemory.ts
@@ -3,7 +3,6 @@ import { matchPath, useLocation } from "react-router-dom";
 import {
   getRootComposeRoutePath,
   getPluginsRoutePath,
-  isLegacyInstalledPluginsRoute,
   isToolsRoutePath,
   SETTINGS_ROUTE_PATH,
   LEGACY_PROJECT_SETTINGS_ROUTE_PATH,
@@ -34,17 +33,13 @@ function isSettingsRoutePath(pathname: string): boolean {
 export function useAppSettingsRouteMemory(): AppSettingsRouteMemory {
   const location = useLocation();
   const currentRoutePath = getLocationRoutePath(location);
-  const isCompatibilityRoute = isLegacyInstalledPluginsRoute(location);
-  const isSettingsRoute =
-    !isCompatibilityRoute && isSettingsRoutePath(location.pathname);
+  const isSettingsRoute = isSettingsRoutePath(location.pathname);
   const isCurrentToolsRoute = isToolsRoutePath(location.pathname);
   const lastAppRoutePathRef = useRef(
-    isSettingsRoute || isCompatibilityRoute
-      ? getRootComposeRoutePath()
-      : currentRoutePath,
+    isSettingsRoute ? getRootComposeRoutePath() : currentRoutePath,
   );
   const lastCoreAppRoutePathRef = useRef(
-    isSettingsRoute || isCurrentToolsRoute || isCompatibilityRoute
+    isSettingsRoute || isCurrentToolsRoute
       ? getRootComposeRoutePath()
       : currentRoutePath,
   );
@@ -53,9 +48,6 @@ export function useAppSettingsRouteMemory(): AppSettingsRouteMemory {
   );
 
   useEffect(() => {
-    if (isCompatibilityRoute) {
-      return;
-    }
     if (isSettingsRoute) {
       lastSettingsRoutePathRef.current = currentRoutePath;
       return;
@@ -65,27 +57,20 @@ export function useAppSettingsRouteMemory(): AppSettingsRouteMemory {
       return;
     }
     lastCoreAppRoutePathRef.current = currentRoutePath;
-  }, [
-    currentRoutePath,
-    isCompatibilityRoute,
-    isCurrentToolsRoute,
-    isSettingsRoute,
-  ]);
+  }, [currentRoutePath, isCurrentToolsRoute, isSettingsRoute]);
 
   return {
-    appRoutePath:
-      isSettingsRoute || isCompatibilityRoute
-        ? lastAppRoutePathRef.current
-        : currentRoutePath,
+    appRoutePath: isSettingsRoute
+      ? lastAppRoutePathRef.current
+      : currentRoutePath,
     settingsRoutePath: isSettingsRoute
       ? currentRoutePath
       : lastSettingsRoutePathRef.current,
     toolsRoutePath: isCurrentToolsRoute
       ? currentRoutePath
       : getPluginsRoutePath(),
-    toolsBackRoutePath:
-      isCurrentToolsRoute || isCompatibilityRoute
-        ? lastCoreAppRoutePathRef.current
-        : currentRoutePath,
+    toolsBackRoutePath: isCurrentToolsRoute
+      ? lastCoreAppRoutePathRef.current
+      : currentRoutePath,
   };
 }

--- a/apps/app/src/lib/route-paths.test.ts
+++ b/apps/app/src/lib/route-paths.test.ts
@@ -94,7 +94,7 @@ describe("route path helpers", () => {
     );
     expect(
       getPluginDetailRoutePath({ pluginId: "github", view: "installed" }),
-    ).toBe("/plugins/github?view=installed");
+    ).toBe("/settings/plugins/github?view=installed");
     expect(getPluginConfigurationRoutePath({ pluginId: "github" })).toBe(
       "/settings/plugins/github",
     );

--- a/apps/app/src/lib/route-paths.ts
+++ b/apps/app/src/lib/route-paths.ts
@@ -6,8 +6,6 @@ import {
   REGISTRY_SKILL_DETAIL_ROUTE_PATH,
   REGISTRY_SKILLS_ROUTE_PATH,
   ROUTE_PATTERNS,
-  SETTINGS_PLUGIN_ROUTE_PATH,
-  SETTINGS_PLUGINS_ROUTE_PATH,
   SKILL_DETAIL_ROUTE_PATH,
   SKILLS_ROUTE_PATH,
   TOOLS_ROUTE_PATH,
@@ -103,20 +101,6 @@ export function isToolsRoutePath(pathname: string): boolean {
     isSkillsRoutePath(pathname) ||
     pathname === TOOLS_ROUTE_PATH ||
     matchPath(`${TOOLS_ROUTE_PATH}/*`, pathname) !== null
-  );
-}
-
-export function isLegacyInstalledPluginsRoute({
-  pathname,
-  search,
-}: {
-  pathname: string;
-  search: string;
-}): boolean {
-  return (
-    matchPath(SETTINGS_PLUGINS_ROUTE_PATH, pathname) !== null ||
-    (matchPath(SETTINGS_PLUGIN_ROUTE_PATH, pathname) !== null &&
-      new URLSearchParams(search).get("view") === "installed")
   );
 }
 

--- a/apps/app/src/views/SettingsView.tsx
+++ b/apps/app/src/views/SettingsView.tsx
@@ -1,5 +1,10 @@
 import { useMemo, useRef, useState, type ReactNode } from "react";
-import { Navigate, useNavigate } from "react-router-dom";
+import {
+  Navigate,
+  useNavigate,
+  useLocation,
+  matchPath,
+} from "react-router-dom";
 import "@bb/shared-ui/icon-extended";
 import {
   builtInThemes,
@@ -47,6 +52,9 @@ import { SidebarThreadListSetting } from "@/components/settings/SidebarThreadLis
 import { SidebarNavigationSetting } from "@/components/settings/SidebarNavigationSetting";
 import { SplitDimmingSetting } from "@/components/settings/SplitDimmingSetting";
 import { useSettingsNavState } from "@/components/settings/settings-nav";
+import { PluginsOverview } from "@/components/plugin/PluginsOverview";
+import { PluginDetailPaneView } from "@/views/ToolsView";
+import { SETTINGS_PLUGIN_ROUTE_PATH } from "@/lib/route-paths";
 import { PluginSettingsPage } from "@/components/plugin/PluginSettings";
 import { FileOpenersSettingsSection } from "@/components/settings/FileOpenersSettingsSection";
 import { VoiceInputSettingsSection } from "@/components/settings/VoiceInputSettingsSection";
@@ -1108,10 +1116,27 @@ export function SettingsView() {
   const appearance = systemConfigQuery.data?.appearance ?? defaultAppTheme;
   const updateAppearanceMutation = useUpdateAppearance();
   const appThemePreview = useAppThemePreview();
+  const location = useLocation();
   const { activePluginId, activeSection, hasUnknownSection } =
     useSettingsNavState();
   if (hasUnknownSection) {
     return <Navigate to={SETTINGS_ROUTE_PATH} replace />;
+  }
+
+  if (activeSection === "plugins") {
+    const pluginId = matchPath(SETTINGS_PLUGIN_ROUTE_PATH, location.pathname)
+      ?.params.pluginId;
+    return (
+      <div className="-mx-4 -mt-4 flex min-h-0 flex-1 flex-col overflow-hidden md:-mx-5 md:-mt-5">
+        {pluginId ? (
+          <PluginDetailPaneView pluginId={pluginId} />
+        ) : (
+          <div className="flex min-h-0 flex-1 flex-col pt-4 md:pt-5">
+            <PluginsOverview mode="installed" />
+          </div>
+        )}
+      </div>
+    );
   }
 
   let content: ReactNode = null;

--- a/apps/app/src/views/ToolsView.plugin-detail.test.tsx
+++ b/apps/app/src/views/ToolsView.plugin-detail.test.tsx
@@ -27,7 +27,8 @@ import {
   resetPluginSlotStoreForTest,
   setPluginSlotRegistrations,
 } from "@/lib/plugin-slots";
-import { PluginsView } from "./ToolsView";
+import { PluginsOverview } from "@/components/plugin/PluginsOverview";
+import { PluginDetailPaneView, PluginsView } from "./ToolsView";
 import { AppRoutes } from "../App";
 import {
   CatalogPluginDetail,
@@ -102,14 +103,23 @@ const GITHUB_CATALOG_ENTRY = {
 
 function RoutedPluginsView() {
   const location = useLocation();
-  const prefix = "/plugins/";
+  const isSettings = location.pathname.startsWith("/settings/plugins");
+  const prefix = isSettings ? "/settings/plugins/" : "/plugins/";
   const pluginId = location.pathname.startsWith(prefix)
     ? decodeURIComponent(location.pathname.slice(prefix.length))
     : undefined;
   return (
     <>
       <TooltipProvider>
-        <PluginsView pluginId={pluginId} />
+        {isSettings ? (
+          pluginId ? (
+            <PluginDetailPaneView pluginId={pluginId} />
+          ) : (
+            <PluginsOverview mode="installed" />
+          )
+        ) : (
+          <PluginsView pluginId={pluginId} />
+        )}
       </TooltipProvider>
       <LocationProbe />
     </>
@@ -742,106 +752,113 @@ describe("BB Official plugin detail routing", () => {
     });
   });
 
-  it.each(["/plugins/github?view=installed", "/plugins?view=installed"])(
-    "opens installed plugin settings from %s",
-    async (path) => {
-      const author = {
-        name: "BB",
-        github: "get-bb",
-        url: "https://github.com/get-bb",
-      };
-      const catalogEntries = [
-        { ...GITHUB_CATALOG_ENTRY, author, installed: true },
-        {
-          ...GITHUB_CATALOG_ENTRY,
-          entryId: "automations",
-          pluginId: "automations",
-          displayName: "Automations",
-          author,
-        },
-      ];
-      vi.stubGlobal(
-        "fetch",
-        vi.fn(async (input: RequestInfo | URL) => {
-          const url = String(input);
-          if (url === "/api/v1/plugins") {
-            return new Response(
-              JSON.stringify({
-                enabled: true,
-                plugins: [
-                  {
-                    ...GITHUB_PLUGIN,
-                    iconUrl: null,
-                    screenshots: [],
-                    collections: [],
-                    providerIds: [],
-                    icons: {},
-                    updateState: {},
-                  },
-                ],
-              }),
-              { headers: { "content-type": "application/json" } },
-            );
-          }
-          if (url.startsWith("/api/v1/plugin-catalog/search")) {
-            return new Response(
-              JSON.stringify({ results: catalogEntries, collections: [] }),
-              { headers: { "content-type": "application/json" } },
-            );
-          }
-          return new Response(JSON.stringify({ error: "not found" }), {
-            status: 404,
-            headers: { "content-type": "application/json" },
-          });
-        }),
-      );
-
-      const { wrapper: QueryClientWrapper } = createQueryClientTestHarness();
-      render(
-        <MemoryRouter initialEntries={[path]}>
-          <Routes>
-            <Route path="/plugins/*" element={<RoutedPluginsView />} />
-          </Routes>
-        </MemoryRouter>,
-        { wrapper: QueryClientWrapper },
-      );
-
-      if (path === "/plugins?view=installed") {
-        expect(
-          await screen.findByRole("textbox", {
-            name: "Search installed plugins",
-          }),
-        ).toBeTruthy();
-        expect(screen.getByTestId("route-path").textContent).toBe("/plugins");
-        const pluginButton = await screen.findByRole("button", {
-          name: "GitHub plugin details",
+  it.each([
+    "/settings/plugins/github?view=installed",
+    "/settings/plugins",
+    "/plugins/github?view=installed",
+    "/plugins?view=installed",
+  ])("opens installed plugin settings from %s", async (path) => {
+    const author = {
+      name: "BB",
+      github: "get-bb",
+      url: "https://github.com/get-bb",
+    };
+    const catalogEntries = [
+      { ...GITHUB_CATALOG_ENTRY, author, installed: true },
+      {
+        ...GITHUB_CATALOG_ENTRY,
+        entryId: "automations",
+        pluginId: "automations",
+        displayName: "Automations",
+        author,
+      },
+    ];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url === "/api/v1/plugins") {
+          return new Response(
+            JSON.stringify({
+              enabled: true,
+              plugins: [
+                {
+                  ...GITHUB_PLUGIN,
+                  iconUrl: null,
+                  screenshots: [],
+                  collections: [],
+                  providerIds: [],
+                  icons: {},
+                  updateState: {},
+                },
+              ],
+            }),
+            { headers: { "content-type": "application/json" } },
+          );
+        }
+        if (url.startsWith("/api/v1/plugin-catalog/search")) {
+          return new Response(
+            JSON.stringify({ results: catalogEntries, collections: [] }),
+            { headers: { "content-type": "application/json" } },
+          );
+        }
+        return new Response(JSON.stringify({ error: "not found" }), {
+          status: 404,
+          headers: { "content-type": "application/json" },
         });
-        expect(
-          vi.mocked(fetch).mock.calls.some(([input]) =>
+      }),
+    );
+
+    const { wrapper: QueryClientWrapper } = createQueryClientTestHarness();
+    render(
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route path="/plugins/*" element={<RoutedPluginsView />} />
+          <Route path="/settings/plugins/*" element={<RoutedPluginsView />} />
+        </Routes>
+      </MemoryRouter>,
+      { wrapper: QueryClientWrapper },
+    );
+
+    if (path === "/settings/plugins" || path === "/plugins?view=installed") {
+      expect(
+        await screen.findByRole("textbox", {
+          name: "Search installed plugins",
+        }),
+      ).toBeTruthy();
+      expect(screen.getByTestId("route-path").textContent).toBe(
+        path.split("?")[0],
+      );
+      const pluginButton = await screen.findByRole("button", {
+        name: "GitHub plugin details",
+      });
+      expect(
+        vi
+          .mocked(fetch)
+          .mock.calls.some(([input]) =>
             String(input).startsWith("/api/v1/plugin-catalog/search"),
           ),
-        ).toBe(false);
-        fireEvent.click(pluginButton);
-      }
+      ).toBe(false);
+      fireEvent.click(pluginButton);
+    }
 
-      const relatedPluginButton = await screen.findByRole("button", {
-        name: "Open Automations details",
-      });
-      expect(screen.getAllByText("GitHub", { selector: "h1" })).toHaveLength(1);
-      fireEvent.click(relatedPluginButton);
-      await waitFor(() => {
-        expect(screen.getByTestId("route-path").textContent).toBe(
-          "/plugins/automations",
-        );
-      });
-      expect(screen.getByTestId("route-search").textContent).toBe(
-        "?view=installed",
+    const relatedPluginButton = await screen.findByRole("button", {
+      name: "Open Automations details",
+    });
+    expect(screen.getAllByText("GitHub", { selector: "h1" })).toHaveLength(1);
+    fireEvent.click(relatedPluginButton);
+    await waitFor(() => {
+      expect(screen.getByTestId("route-path").textContent).toBe(
+        "/plugins/automations",
       );
-      expect(
-        screen.queryByRole("button", { name: "Close Automations" }),
-      ).toBeNull();
-    },
-  );
+    });
+    expect(screen.getByTestId("route-search").textContent).toBe(
+      "?view=installed",
+    );
+    expect(
+      screen.queryByRole("button", { name: "Close Automations" }),
+    ).toBeNull();
+  });
 
   it("opens an author from a card and returns to the prior Browse filters", async () => {
     const author = {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -610,23 +610,23 @@ schema, a default, and a revision that increments on every write. Writes name
 the revision they expect and receive `409 ui_preference_conflict` when another
 client wrote first, so a stale window cannot silently clobber a newer value.
 
-| Key                               | Value                                                        |
-| --------------------------------- | ------------------------------------------------------------ |
-| `sidebar.organizationMode`        | `project`, `chronological`, or `machine`                     |
-| `sidebar.chronologicalSort`       | `updated`, `created`, `alpha`, or `none`                     |
-| `sidebar.sectionOrder`            | Section id list for **By project**                           |
-| `sidebar.manualSectionOrder`      | Section id list for **Manually**                             |
-| `sidebar.machineSectionOrder`     | Section id list for **By machine**                           |
-| `sidebar.collapsedSections`       | Collapsed built-in sections (`pinned`, `threads`)            |
-| `sidebar.collapsedProjects`       | Collapsed project ids                                        |
-| `sidebar.collapsedThreads`        | Thread ids whose children are collapsed                      |
-| `sidebar.collapsedEnvironments`   | Collapsed environment ids                                    |
-| `sidebar.collapsedThreadSections` | Collapsed thread section ids                                 |
-| `sidebar.collapsedMachines`       | Collapsed machine ids                                        |
-| `sidebar.pluginPanelOrder`        | Navigation entry order                                       |
-| `sidebar.visiblePluginPanels`     | Navigation entries shown, or `null` for every entry          |
-| `sidebar.navigationProvider`      | Plugin key, `__automatic__`, or `__builtin__`                |
-| `sidebar.threadListProvider`      | Plugin key, `__automatic__`, or `__builtin__`                |
+| Key                               | Value                                               |
+| --------------------------------- | --------------------------------------------------- |
+| `sidebar.organizationMode`        | `project`, `chronological`, or `machine`            |
+| `sidebar.chronologicalSort`       | `updated`, `created`, `alpha`, or `none`            |
+| `sidebar.sectionOrder`            | Section id list for **By project**                  |
+| `sidebar.manualSectionOrder`      | Section id list for **Manually**                    |
+| `sidebar.machineSectionOrder`     | Section id list for **By machine**                  |
+| `sidebar.collapsedSections`       | Collapsed built-in sections (`pinned`, `threads`)   |
+| `sidebar.collapsedProjects`       | Collapsed project ids                               |
+| `sidebar.collapsedThreads`        | Thread ids whose children are collapsed             |
+| `sidebar.collapsedEnvironments`   | Collapsed environment ids                           |
+| `sidebar.collapsedThreadSections` | Collapsed thread section ids                        |
+| `sidebar.collapsedMachines`       | Collapsed machine ids                               |
+| `sidebar.pluginPanelOrder`        | Navigation entry order                              |
+| `sidebar.visiblePluginPanels`     | Navigation entries shown, or `null` for every entry |
+| `sidebar.navigationProvider`      | Plugin key, `__automatic__`, or `__builtin__`       |
+| `sidebar.threadListProvider`      | Plugin key, `__automatic__`, or `__builtin__`       |
 
 Read and write them with:
 
@@ -1024,7 +1024,7 @@ retries structured provider overloads with exponential backoff and jitter.
 Prior output or tool activity does not block recovery. If the provider accepted
 the failed input, core sends an agent-only continuation; if it rejected the
 input before starting, core re-sends the original message as agent-only. Disable
-the plugin under Plugins → Installed plugins or with
+the plugin under Settings → Installed plugins or with
 `bb plugin disable provider-retry`.
 
 It never blocks a send. A remembered rate limit is a stale picture of the
@@ -1054,7 +1054,7 @@ nothing, because waiting does not fix them.
 ### Workflows plugin
 
 The builtin Workflows plugin is disabled on fresh installations. Enable it
-under Plugins → Installed plugins or with `bb plugin enable workflows`. Its six
+under Settings → Installed plugins or with `bb plugin enable workflows`. Its six
 settings are bounded integers, edited with numeric inputs under Plugins →
 Installed plugins or with `bb plugin config workflows set <key> <value>`:
 
@@ -1230,7 +1230,7 @@ For isolated development smoke tests only, `DEV_BROWSER_SMOKE_BINARY` selects th
 
 ## Agent guidance plugin settings
 
-BB guide is installed and enabled by default. In Plugins → Installed plugins
+BB guide is installed and enabled by default. In Settings → Installed plugins
 → BB guide, `introduction` controls the BB introduction, `skills` controls all
 four bundled skills, and `bbCli`, `pluginAuthoring`, `skillCreator`, and `submitPlugin` control
 individual skills. All default to true. Disabling BB guide removes its

--- a/docs/debugging-and-qa.md
+++ b/docs/debugging-and-qa.md
@@ -299,7 +299,7 @@ worktree-specific local origin serves the dashboard at `bb.localhost` and
 routes `<handle>.bb.localhost` through the Connect worker. Email/password auth
 is enabled only for this loopback workflow; production remains GitHub-only.
 `pnpm dev` automatically sets `BB_DEV_CONNECT_BASE_URL` to that worktree's
-local Cloud origin. While the bb is unpaired, Plugins → Installed plugins → Connect
+local Cloud origin. While the bb is unpaired, Settings → Installed plugins → Connect
 therefore opens the local dashboard and a pasted code redeems locally. An
 explicit `bb connect --server ...` or `--base-url ...` still wins, so the dev bb
 can still pair with getbb.app.

--- a/docs/worktrees.md
+++ b/docs/worktrees.md
@@ -30,7 +30,7 @@ branch. Under the hood it's `git worktree add` plus some bookkeeping:
   worktree; after it elapses the worktree is removed the same way.
 
 Worktrees are created by bb's built-in **Worktree** plugin, which is enabled by
-default. Disabling it in Plugins → Installed plugins leaves existing worktrees alone
+default. Disabling it in Settings → Installed plugins leaves existing worktrees alone
 but stops bb from making new ones: a thread that asks for one waits until the
 plugin is running again.
 

--- a/packages/client-core/src/routes/route-paths.ts
+++ b/packages/client-core/src/routes/route-paths.ts
@@ -140,7 +140,9 @@ export function getPluginDetailRoutePath({
   view,
 }: PluginDetailRoutePathArgs): string {
   const path = `${PLUGINS_ROUTE_PATH}/${encodeURIComponent(pluginId)}`;
-  return view === "installed" ? `${path}?view=installed` : path;
+  return view === "installed"
+    ? `${SETTINGS_PLUGINS_ROUTE_PATH}/${encodeURIComponent(pluginId)}?view=installed`
+    : path;
 }
 
 export function getPluginConfigurationRoutePath(

--- a/packages/templates/src/templates/bb-guide-agent-configuration.md
+++ b/packages/templates/src/templates/bb-guide-agent-configuration.md
@@ -95,7 +95,7 @@ BB guide plugin:
 
 Connect agent instructions:
 
-  Plugins → Installed plugins → Connect → Tell agents about remote access
+  Settings → Installed plugins → Connect → Tell agents about remote access
   controls the message telling remotely used agents to expose public server
   links. It defaults to true and still requires active/recent remote usage.
   Use `bb plugin config connect set sendRemoteInstructions false` to turn it

--- a/packages/templates/src/templates/bb-guide-customization.md
+++ b/packages/templates/src/templates/bb-guide-customization.md
@@ -70,14 +70,14 @@ Server-backed General settings
 
 Settings → General includes app-wide preferences stored server-side so every
 window and restart sees the same value. Keep Awake is instead owned by its
-builtin plugin: use its autosaving page under Plugins → Installed plugins or run
+builtin plugin: use its autosaving page under Settings → Installed plugins or run
 `bb keep-awake enable` or `bb keep-awake disable`. Choose every host with `bb
 keep-awake hosts all`, or name individual host ids after `bb keep-awake hosts`.
 On macOS it prevents system idle sleep while bb is running; closing the lid or
 choosing Sleep still sleeps the Mac.
 
 Concurrency limit is also owned by its builtin plugin. Its autosaving page
-under Plugins → Installed plugins leaves the overall limit unlimited by default and
+under Settings → Installed plugins leaves the overall limit unlimited by default and
 uses an automatic per-host limit of one thread per available processor. Use
 `bb concurrency-limit global [unlimited|<limit>]` and `bb
 concurrency-limit host <host-id> [auto|<limit>]`; 0 pauses new work.

--- a/packages/templates/src/templates/bb-guide-plugins.md
+++ b/packages/templates/src/templates/bb-guide-plugins.md
@@ -149,7 +149,7 @@ block recovery. Its `maximumWait` setting defaults to `6 hours`; choose
 
 The builtin Workflows plugin runs durable provider-independent JavaScript
 orchestration. It is disabled on fresh installations; enable `workflows` under
-Plugins → Installed plugins or run `bb plugin enable workflows` before using:
+Settings → Installed plugins or run `bb plugin enable workflows` before using:
 
   bb workflows validate (--script '<javascript>'|--source '<javascript>'|
                         --file <path>|--name <name>)
@@ -734,7 +734,8 @@ Everything else (zod included) bundles from the plugin's node_modules (`npm inst
 release packages with their declared production dependencies). A crashing slot collapses to a
 "plugin <id> crashed" chip without
 touching the rest of the app. Installed plugins and their declared settings
-(same data as `bb plugin config`) also appear under Plugins → Installed plugins.
+(same data as `bb plugin config`) appear under both Settings → Installed plugins
+and Plugins → Installed plugins. Both locations manage the same installed plugins.
 
 Plugin CLI commands: a plugin can register one top-level subcommand (for
 example `bb github …`). Unknown `bb` commands are looked up against installed

--- a/plugins/bb-guide/skills/bb-cli/references/configuration.md
+++ b/plugins/bb-guide/skills/bb-cli/references/configuration.md
@@ -81,7 +81,7 @@
 
 ## BB guide instructions and skills
 
-Plugins → Installed plugins → BB guide controls the BB introduction and the
+Settings → Installed plugins → BB guide controls the BB introduction and the
 four bundled skills. All settings default to true. Use
 `bb plugin config bb-guide set <key> true|false` with `introduction`, `skills`
 (the master skill switch), `bbCli`, `pluginAuthoring`, `skillCreator`, or `submitPlugin`.

--- a/plugins/bb-guide/skills/bb-cli/references/plugins.md
+++ b/plugins/bb-guide/skills/bb-cli/references/plugins.md
@@ -205,7 +205,7 @@
     useBbNavigate, useComposer for scoped text editing / quote / mention /
     focus access); components are vendored shadcn source the
     plugin owns. Installed
-    plugins and their settings also appear under Plugins → Installed plugins.
+    plugins and their settings also appear under Settings → Installed plugins.
 - **Writing a plugin?** Use the `bb-plugin-authoring` skill — the complete
   authoring reference for the backend `BbPluginApi` (settings, storage, sdk,
   http/rpc/realtime, background services and schedules, CLI commands, agent

--- a/plugins/bb-guide/skills/bb-plugin-authoring/references/backend-foundation.md
+++ b/plugins/bb-guide/skills/bb-plugin-authoring/references/backend-foundation.md
@@ -39,7 +39,7 @@ are additive, so registering multiple listeners is supported.
 ### bb.settings
 
 `bb.settings.define(descriptors)` declares settings descriptors (rendered
-in Plugins → Installed plugins and editable via `bb plugin config <id> set <key>
+in Settings → Installed plugins and editable via `bb plugin config <id> set <key>
 <value>`). Five descriptor types:
 
 ```ts

--- a/plugins/connect/skills/share-server-links/SKILL.md
+++ b/plugins/connect/skills/share-server-links/SKILL.md
@@ -30,7 +30,7 @@ remove and re-add it under Settings > Machines.
 
 ## Agent instructions setting
 
-Plugins → Installed plugins → Connect has a "Tell agents about remote access"
+Settings → Installed plugins → Connect has a "Tell agents about remote access"
 toggle, enabled by default. Use
 `bb plugin config connect set sendRemoteInstructions false` to suppress the
 remote-access message, or `true` to restore it. This controls only the message;


### PR DESCRIPTION
## Human comments

## What was wrong

Splitting Plugins and Skills into separate workspaces removed installed-plugin management from Settings and redirected its existing routes into Plugins.

## What changed

Restore Settings → Installed plugins while retaining Plugins → Installed plugins. Both locations manage the same installed plugins, and opening a list row keeps its detail page in the originating section. Restore Settings navigation memory and route the command palette and general installed-plugin links to Settings. Keep individual plugin configuration pages and legacy workspace routes working. Update the agent guide and navigation documentation.

## How you verified

- Turbo app typecheck and lint passed (lint has existing warnings, no errors).
- Focused Turbo app tests passed: 86 tests covering both installed-plugin collections/details, Settings and Plugins sidebars, canonical routes, and compatibility navigation. Earlier focused checks also covered command palette, Settings route memory, notification links, and update/configuration links.
- Browser verification in an isolated source dev app: clicked Installed plugins and BB guide from both Settings and Plugins, checked destination URLs and a single detail heading, and confirmed Settings stays selected for its detail page.
- EAP codename scanner passed for the working tree, tracked HEAD, added lines, and commit messages in the push range.
- SlopCop skipped at the user's request.

> AGENT GENERATED
