### PR TITLE
Keep environment picker open during composer updates

### DIFF
--- a/apps/app/src/components/pickers/EnvironmentPicker.tsx
+++ b/apps/app/src/components/pickers/EnvironmentPicker.tsx
@@ -62,6 +62,8 @@ export interface EnvironmentPickerUIProps {
   disabled?: boolean;
   isLoading?: boolean;
   className?: string;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
   defaultOpen?: boolean;
   modal?: boolean;
   machines?: EnvironmentPickerMachines | null;
@@ -141,6 +143,8 @@ export function EnvironmentPickerUI({
   disabled = false,
   isLoading = false,
   className,
+  open,
+  onOpenChange,
   defaultOpen,
   modal,
   machines,
@@ -239,7 +243,12 @@ export function EnvironmentPickerUI({
   ]);
 
   return (
-    <DropdownMenu defaultOpen={defaultOpen} modal={modal}>
+    <DropdownMenu
+      open={open}
+      onOpenChange={onOpenChange}
+      defaultOpen={defaultOpen}
+      modal={modal}
+    >
       <DropdownMenuTrigger asChild disabled={disabled}>
         <Button
           type="button"

--- a/apps/app/src/components/plugin/PluginNewThreadComposer.test.tsx
+++ b/apps/app/src/components/plugin/PluginNewThreadComposer.test.tsx
@@ -36,10 +36,7 @@ import {
   resetPluginSlotStoreForTest,
   setPluginSlotRegistrations,
 } from "@/lib/plugin-slots";
-import {
-  encodeReuseValue,
-  REUSE_VALUE_WITHOUT_ENVIRONMENT,
-} from "@/components/pickers/environment-picker-value";
+import { encodeReuseValue } from "@/components/pickers/environment-picker-value";
 import { useRootComposeReuseEnvironment } from "@/lib/root-compose-selection";
 import { getPromptDraftAccessor } from "@/hooks/usePromptDraftStorage";
 import { buildThreadHandoffLocationState } from "@bb/client-core";
@@ -1008,7 +1005,7 @@ describe("PluginNewThreadComposer seeding", () => {
     ).toBe(true);
   });
 
-  it("keeps a seeded fork's reuse selection pending until the sidebar bootstrap settles", async () => {
+  it("keeps a seeded fork's exact reuse selection while the sidebar bootstrap settles", async () => {
     mocks.sidebarNavigationSettled = false;
     const submitted: NewThreadRequest[] = [];
     const seed = {
@@ -1039,7 +1036,7 @@ describe("PluginNewThreadComposer seeding", () => {
 
     await waitFor(() => {
       expect(latestPromptBoxProps().modeConfig.environment.value).toBe(
-        REUSE_VALUE_WITHOUT_ENVIRONMENT,
+        encodeReuseValue("env-source"),
       );
     });
     expect(latestPromptBoxProps().modeConfig.worktree.options).toEqual([]);

--- a/apps/app/src/components/promptbox/NewThreadPromptBox.test.tsx
+++ b/apps/app/src/components/promptbox/NewThreadPromptBox.test.tsx
@@ -6,10 +6,7 @@ import type { Host } from "@bb/domain";
 import { makeHost } from "@bb/test-helpers/domain-fixtures";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SystemEnvironmentProvider } from "@bb/server-contract";
-import {
-  ProjectlessEnvSlot,
-  ProjectlessMachineSlot,
-} from "./NewThreadPromptBox";
+import { EnvironmentSlot, ProjectlessMachineSlot } from "./NewThreadPromptBox";
 
 const host = makeHost({
   id: "host_test",
@@ -162,7 +159,7 @@ describe("ProjectlessMachineSlot", () => {
   });
 });
 
-describe("ProjectlessEnvSlot", () => {
+describe("EnvironmentSlot", () => {
   const secondHost: Host = {
     ...host,
     id: "host_second",
@@ -250,7 +247,8 @@ describe("ProjectlessEnvSlot", () => {
 
   it("shows environment loading before resolving to the machine slot", () => {
     const { rerender } = render(
-      <ProjectlessEnvSlot
+      <EnvironmentSlot
+        projectless
         environment={makeEnvironment({ providers: [], isLoading: true })}
         worktree={makeWorktree()}
       />,
@@ -258,7 +256,8 @@ describe("ProjectlessEnvSlot", () => {
     expect(screen.getByRole("button", { name: "Environment" })).not.toBeNull();
     expect(screen.queryByRole("button", { name: "Machine" })).toBeNull();
     rerender(
-      <ProjectlessEnvSlot
+      <EnvironmentSlot
+        projectless
         environment={makeEnvironment({
           providers: [personalProvider],
           isLoading: false,
@@ -272,7 +271,8 @@ describe("ProjectlessEnvSlot", () => {
 
   it("keeps the machine slot when only one provider is available", () => {
     render(
-      <ProjectlessEnvSlot
+      <EnvironmentSlot
+        projectless
         environment={makeEnvironment({ providers: [personalProvider] })}
         worktree={makeWorktree()}
       />,
@@ -284,7 +284,8 @@ describe("ProjectlessEnvSlot", () => {
 
   it("omits project-only providers from the projectless picker", () => {
     render(
-      <ProjectlessEnvSlot
+      <EnvironmentSlot
+        projectless
         environment={makeEnvironment({
           value: "provider:personal-workspace",
           providers: [personalProvider, sandboxProvider],
@@ -301,7 +302,8 @@ describe("ProjectlessEnvSlot", () => {
   it("shows the reused environment instead of the machine slot when a thread reuses one", () => {
     render(
       <QueryClientProvider client={new QueryClient()}>
-        <ProjectlessEnvSlot
+        <EnvironmentSlot
+          projectless
           environment={makeEnvironment({
             value: "reuse:env_personal",
             providers: [personalProvider],
@@ -316,5 +318,47 @@ describe("ProjectlessEnvSlot", () => {
     expect(triggers).toHaveLength(2);
     expect(triggers[0]?.textContent).toContain("Reuse");
     expect(triggers[1]?.textContent).toContain("Scratch space");
+  });
+
+  it("keeps an open environment menu mounted while project scope replays", () => {
+    const projectProvider = {
+      ...sandboxProvider,
+      requires: {
+        ...sandboxProvider.requires,
+        projectless: false,
+      },
+    };
+    const environment = makeEnvironment({
+      value: "reuse:env_personal",
+      providers: [personalProvider, projectProvider],
+    });
+    const queryClient = new QueryClient();
+    const { rerender } = render(
+      <QueryClientProvider client={queryClient}>
+        <EnvironmentSlot
+          projectless={false}
+          environment={environment}
+          worktree={makeWorktree("env_personal")}
+        />
+      </QueryClientProvider>,
+    );
+    const trigger = screen.getAllByRole("button", { name: "Environment" })[0];
+    fireEvent.pointerDown(trigger!, { button: 0 });
+    expect(screen.getByRole("menu")).toBeTruthy();
+
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <EnvironmentSlot
+          projectless
+          environment={environment}
+          worktree={makeWorktree("env_personal")}
+        />
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByRole("menu")).toBeTruthy();
+    expect(document.querySelector('button[aria-label="Environment"]')).toBe(
+      trigger,
+    );
   });
 });

--- a/apps/app/src/components/promptbox/NewThreadPromptBox.test.tsx
+++ b/apps/app/src/components/promptbox/NewThreadPromptBox.test.tsx
@@ -361,4 +361,42 @@ describe("EnvironmentSlot", () => {
       trigger,
     );
   });
+
+  it("keeps an open environment menu mounted while projectless options settle", () => {
+    const loadingEnvironment = makeEnvironment({
+      providers: [personalProvider],
+      isLoading: true,
+    });
+    const queryClient = new QueryClient();
+    const { rerender } = render(
+      <QueryClientProvider client={queryClient}>
+        <EnvironmentSlot
+          projectless
+          environment={loadingEnvironment}
+          worktree={makeWorktree()}
+        />
+      </QueryClientProvider>,
+    );
+    const trigger = screen.getByRole("button", { name: "Environment" });
+    fireEvent.pointerDown(trigger, { button: 0 });
+    expect(screen.getByRole("menu")).toBeTruthy();
+
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <EnvironmentSlot
+          projectless
+          environment={{ ...loadingEnvironment, isLoading: false }}
+          worktree={makeWorktree()}
+        />
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByRole("menu")).toBeTruthy();
+    expect(document.querySelector('button[aria-label="Environment"]')).toBe(
+      trigger,
+    );
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByRole("button", { name: "Environment" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Machine" })).toBeTruthy();
+  });
 });

--- a/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
+++ b/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
@@ -421,12 +421,14 @@ export function EnvironmentSlot({
         )
       : undefined;
   const showReuseEnvironmentPicker = parsedEnvironment?.type === "reuse";
-  if (
-    projectless &&
-    !environment.isLoading &&
-    providers.length <= 1 &&
-    !showReuseEnvironmentPicker
-  ) {
+  const [environmentPickerOpen, setEnvironmentPickerOpen] = useState(false);
+  const showEnvironmentPicker =
+    !projectless ||
+    environment.isLoading ||
+    providers.length > 1 ||
+    showReuseEnvironmentPicker ||
+    environmentPickerOpen;
+  if (!showEnvironmentPicker) {
     return <ProjectlessMachineSlot environment={environment} />;
   }
 
@@ -435,6 +437,8 @@ export function EnvironmentSlot({
       <EnvironmentPickerUI
         value={environment.value}
         projectless={projectless}
+        open={environmentPickerOpen}
+        onOpenChange={setEnvironmentPickerOpen}
         sources={environment.sources}
         host={environment.host}
         isLocal={environment.isLocal}

--- a/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
+++ b/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
@@ -369,23 +369,14 @@ const DefaultNewThreadComposer = memo(function DefaultNewThreadComposer({
               className="shrink-0"
             />
           ) : null}
-          {project?.value !== null ? (
-            <ThreadEnvSlot
-              environment={modeConfig.environment}
-              worktree={modeConfig.worktree}
-              environmentProviderInputsSlot={
-                modeConfig.environmentProviderInputsSlot
-              }
-            />
-          ) : (
-            <ProjectlessEnvSlot
-              environment={modeConfig.environment}
-              worktree={modeConfig.worktree}
-              environmentProviderInputsSlot={
-                modeConfig.environmentProviderInputsSlot
-              }
-            />
-          )}
+          <EnvironmentSlot
+            projectless={project?.value === null}
+            environment={modeConfig.environment}
+            worktree={modeConfig.worktree}
+            environmentProviderInputsSlot={
+              modeConfig.environmentProviderInputsSlot
+            }
+          />
         </div>
         <div className="flex shrink-0 items-center gap-2">
           <PermissionModePicker
@@ -403,80 +394,21 @@ const DefaultNewThreadComposer = memo(function DefaultNewThreadComposer({
   );
 });
 
-interface ThreadEnvSlotProps {
+interface EnvironmentSlotProps {
+  projectless: boolean;
   environment: NewThreadEnvironmentConfig;
   worktree: NewThreadWorktreeConfig;
   environmentProviderInputsSlot?: ReactNode;
 }
 
-export function ThreadEnvSlot({
+export function EnvironmentSlot({
+  projectless,
   environment,
   worktree,
   environmentProviderInputsSlot,
-}: ThreadEnvSlotProps) {
-  const parsedEnvironment = useMemo(
-    () => parseEnvironmentValue(environment.value),
-    [environment.value],
-  );
-  const selectedProvider = useMemo(
-    () =>
-      parsedEnvironment?.type === "provider"
-        ? environment.providers?.find(
-            (provider) =>
-              provider.id === parsedEnvironment.environmentProviderId,
-          )
-        : undefined,
-    [environment.providers, parsedEnvironment],
-  );
-  const showReuseEnvironmentPicker = parsedEnvironment?.type === "reuse";
-  return (
-    <>
-      <EnvironmentPickerUI
-        value={environment.value}
-        sources={environment.sources}
-        host={environment.host}
-        isLocal={environment.isLocal}
-        machines={environment.machines}
-        onRequestMachineSetup={environment.onRequestMachineSetup}
-        disabled={environment.disabled}
-        isLoading={environment.isLoading}
-        providers={environment.providers}
-        providersByHostId={environment.providersByHostId}
-        selectedProviderHostId={environment.selectedProviderHostId}
-        inputsControlProviderIds={environment.inputsControlProviderIds}
-        onSelectProvider={environment.onSelectProvider}
-        className="shrink-0"
-        muted
-      />
-      {showReuseEnvironmentPicker ? (
-        <ReuseEnvironmentPicker
-          muted
-          options={worktree.options}
-          value={worktree.value}
-          onChange={worktree.onChange}
-          disabled={worktree.disabled}
-        />
-      ) : null}
-      {selectedProvider !== undefined && selectedProvider.inputs !== null
-        ? environmentProviderInputsSlot
-        : null}
-    </>
-  );
-}
-
-interface ProjectlessEnvSlotProps {
-  environment: NewThreadEnvironmentConfig;
-  worktree: NewThreadWorktreeConfig;
-  environmentProviderInputsSlot?: ReactNode;
-}
-
-export function ProjectlessEnvSlot({
-  environment,
-  worktree,
-  environmentProviderInputsSlot,
-}: ProjectlessEnvSlotProps) {
+}: EnvironmentSlotProps) {
   const providers = (environment.providers ?? []).filter(
-    (provider) => provider.requires.projectless,
+    (provider) => provider.requires.projectless === projectless,
   );
   const parsedEnvironment = useMemo(
     () => parseEnvironmentValue(environment.value),
@@ -490,6 +422,7 @@ export function ProjectlessEnvSlot({
       : undefined;
   const showReuseEnvironmentPicker = parsedEnvironment?.type === "reuse";
   if (
+    projectless &&
     !environment.isLoading &&
     providers.length <= 1 &&
     !showReuseEnvironmentPicker
@@ -501,11 +434,14 @@ export function ProjectlessEnvSlot({
     <>
       <EnvironmentPickerUI
         value={environment.value}
-        projectless
+        projectless={projectless}
         sources={environment.sources}
         host={environment.host}
         isLocal={environment.isLocal}
         machines={environment.machines}
+        {...(!projectless && environment.onRequestMachineSetup
+          ? { onRequestMachineSetup: environment.onRequestMachineSetup }
+          : {})}
         disabled={environment.disabled}
         isLoading={environment.isLoading}
         providers={providers}

--- a/apps/app/src/views/RootComposeView.test.ts
+++ b/apps/app/src/views/RootComposeView.test.ts
@@ -939,7 +939,7 @@ describe("resolveRootComposeEffectiveEnvironmentValue", () => {
     ).toBe("provider:project-checkout");
   });
 
-  it("holds specific reuse values as incomplete while project worktrees load", () => {
+  it("holds a specific reuse selection while project worktrees load", () => {
     expect(
       resolveRootComposeEffectiveEnvironmentValue({
         knownHostIds: new Set(["host_1"]),
@@ -951,7 +951,7 @@ describe("resolveRootComposeEffectiveEnvironmentValue", () => {
         reuseThreadOptions: [],
         reuseThreadOptionsLoading: true,
       }),
-    ).toBe("reuse");
+    ).toBe("reuse:env_pending");
   });
 
   it("keeps a projectless reuse selection when the environment is one of its own", () => {

--- a/apps/app/src/views/root-compose-environment-selection.ts
+++ b/apps/app/src/views/root-compose-environment-selection.ts
@@ -14,7 +14,6 @@ import {
 import {
   encodeProviderValue,
   parseEnvironmentValue,
-  REUSE_VALUE_WITHOUT_ENVIRONMENT,
 } from "@/components/pickers/environment-picker-value";
 import type { ReuseThreadOption } from "@/components/pickers/ReuseEnvironmentPicker";
 import { getThreadDisplayTitle } from "@/lib/thread-title";
@@ -228,7 +227,7 @@ export function resolveRootComposeEffectiveEnvironmentValue({
     }
 
     if (reuseThreadOptionsLoading) {
-      return REUSE_VALUE_WITHOUT_ENVIRONMENT;
+      return environmentSelectionValue;
     }
 
     return reuseThreadOptions.some(


### PR DESCRIPTION
## Human comments

## What was wrong

The new-thread composer rendered different environment-slot component types for project and projectless scope, and the dropdown owned its open state internally. Transient scope replay, provider loading, or provider-count changes could therefore unmount the open picker and recreate it closed. Loading reusable environments also temporarily collapsed a specific reuse selection to the generic reuse value.

## What changed

Project and projectless composers now share one stable EnvironmentSlot. It controls the dropdown open state and keeps the picker mounted while open even if projectless options settle to the machine-only layout; the compact machine control returns after normal dismissal. Specific reuse selections are retained while their options load.

## How you verified

- Focused Turbo app tests: 95/95 passed across NewThreadPromptBox, RootComposeView, and EnvironmentPicker.
- Regression tests assert the same trigger DOM node and open menu survive scope replay and projectless option settling.
- Turbo app typecheck passed.
- Formatting and git diff checks passed.

> AGENT GENERATED