### PR TITLE
Simplify Account Pooler sign-in dialog

### DIFF
--- a/plugins/account-pool/app.test.tsx
+++ b/plugins/account-pool/app.test.tsx
@@ -12,6 +12,7 @@ const app = await loadPluginApp(() => import("./app"));
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
 function measureAccountRows() {
@@ -336,16 +337,31 @@ describe("Account Pool settings", () => {
     expect(slot.getByText("Opus 7 day")).toBeTruthy();
   });
 
+  function codexLoginStart() {
+    return {
+      sessionId: "33333333-3333-4333-8333-333333333333",
+      verificationUri: "https://auth.openai.com/codex/device",
+      userCode: "ABCD-1234",
+      expiresAt: Date.now() + 600_000,
+      intervalMs: 60_000,
+    };
+  }
+
+  function mockCompactViewport(matches: boolean) {
+    vi.stubGlobal("matchMedia", (query: string) => ({
+      matches: query === "(max-width: 767px)" && matches,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }));
+  }
+
   it("names the sign-in dialog once and keeps the step instructions", async () => {
-    const slot = render([], {
-      "codexLogin.start": () => ({
-        sessionId: "33333333-3333-4333-8333-333333333333",
-        verificationUri: "https://auth.openai.com/codex/device",
-        userCode: "ABCD-1234",
-        expiresAt: Date.now() + 600_000,
-        intervalMs: 60_000,
-      }),
-    });
+    const slot = render([], { "codexLogin.start": codexLoginStart });
     fireEvent.click(
       await slot.findByRole("button", { name: "Sign in to Codex" }),
     );
@@ -361,7 +377,42 @@ describe("Account Pool settings", () => {
     expect(
       (await slot.findByLabelText("Codex user code")).textContent,
     ).toContain("ABCD-1234");
+    expect(slot.queryByRole("button", { name: "Cancel" })).toBeNull();
   });
+
+  it.each([false, true])(
+    "cancels the pending sign-in from the header close with compact viewport %s",
+    async (compact) => {
+      mockCompactViewport(compact);
+      const slot = render([], {
+        "codexLogin.start": codexLoginStart,
+        "codexLogin.poll": () => ({ status: "pending" }),
+        "codexLogin.cancel": () => ({ cancelled: true }),
+      });
+      fireEvent.click(
+        await slot.findByRole("button", { name: "Sign in to Codex" }),
+      );
+      await slot.findByRole("dialog", { name: "Sign in to Codex" });
+      fireEvent.click(slot.getByRole("button", { name: "Close" }));
+      await waitFor(() =>
+        expect(slot.rpcCalls).toContainEqual({
+          method: "codexLogin.cancel",
+          input: { sessionId: codexLoginStart().sessionId },
+        }),
+      );
+      await waitFor(() =>
+        expect(slot.queryByRole("dialog", { name: "Sign in to Codex" })).toBe(
+          null,
+        ),
+      );
+      const polls = () =>
+        slot.rpcCalls.filter((call) => call.method === "codexLogin.poll")
+          .length;
+      const settled = polls();
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(polls()).toBe(settled);
+    },
+  );
 
   it("offers a fresh Codex login after device-code polling fails", async () => {
     let starts = 0;

--- a/plugins/account-pool/app.test.tsx
+++ b/plugins/account-pool/app.test.tsx
@@ -336,6 +336,33 @@ describe("Account Pool settings", () => {
     expect(slot.getByText("Opus 7 day")).toBeTruthy();
   });
 
+  it("names the sign-in dialog once and keeps the step instructions", async () => {
+    const slot = render([], {
+      "codexLogin.start": () => ({
+        sessionId: "33333333-3333-4333-8333-333333333333",
+        verificationUri: "https://auth.openai.com/codex/device",
+        userCode: "ABCD-1234",
+        expiresAt: Date.now() + 600_000,
+        intervalMs: 60_000,
+      }),
+    });
+    fireEvent.click(
+      await slot.findByRole("button", { name: "Sign in to Codex" }),
+    );
+    const dialog = await slot.findByRole("dialog", {
+      name: "Sign in to Codex",
+    });
+    expect(
+      slot.getAllByRole("heading", { name: "Sign in to Codex" }),
+    ).toHaveLength(1);
+    expect(dialog.textContent).toContain(
+      "Open the verification page, sign in to ChatGPT, and enter this code.",
+    );
+    expect(
+      (await slot.findByLabelText("Codex user code")).textContent,
+    ).toContain("ABCD-1234");
+  });
+
   it("offers a fresh Codex login after device-code polling fails", async () => {
     let starts = 0;
     const slot = render([], {

--- a/plugins/account-pool/app.tsx
+++ b/plugins/account-pool/app.tsx
@@ -37,6 +37,7 @@ import {
 } from "@bb/shared-ui/collapsible";
 import {
   Dialog,
+  DialogClose,
   DialogContent,
   DialogFooter,
   DialogHeader,
@@ -612,18 +613,25 @@ function DialogFrame({
 }) {
   return (
     <DialogContent
+      hideCloseButton
       className={cn(
         "max-h-[85vh] grid-rows-[auto_minmax(0,1fr)_auto]",
         className,
       )}
     >
-      <DialogHeader className="pr-6">
+      <DialogHeader className="flex-row items-start justify-between gap-4 space-y-0">
         <DialogTitle>{title}</DialogTitle>
+        <DialogClose className="-mr-1 shrink-0 cursor-pointer rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2">
+          <Icon name="X" className="size-4" />
+          <span className="sr-only">Close</span>
+        </DialogClose>
       </DialogHeader>
       <div className="min-h-0 space-y-5 overflow-y-auto">{children}</div>
-      <DialogFooter className="flex-row items-center gap-2 sm:space-x-0">
-        {footer}
-      </DialogFooter>
+      {footer === null ? null : (
+        <DialogFooter className="flex-row items-center gap-2 sm:space-x-0">
+          {footer}
+        </DialogFooter>
+      )}
     </DialogContent>
   );
 }
@@ -1524,35 +1532,27 @@ function LoginDialog({
       title={`Sign in to ${name}`}
       className="sm:max-w-xl"
       footer={
-        <>
-          <span className="flex-1" />
-          {loginDone === null ? (
-            <>
-              <Button variant="ghost" onClick={close}>
-                Cancel
-              </Button>
-              {provider === "claude" ? (
-                <Button
-                  disabled={
-                    loginStep === null ||
-                    pastedCode.trim().length === 0 ||
-                    pending
-                  }
-                  onClick={complete}
-                >
-                  Complete
-                </Button>
-              ) : null}
-            </>
-          ) : (
-            <>
-              <Button variant="outline" onClick={addAnother}>
-                Add another
-              </Button>
-              <Button onClick={close}>Done</Button>
-            </>
-          )}
-        </>
+        loginDone !== null ? (
+          <>
+            <span className="flex-1" />
+            <Button variant="outline" onClick={addAnother}>
+              Add another
+            </Button>
+            <Button onClick={close}>Done</Button>
+          </>
+        ) : provider === "claude" ? (
+          <>
+            <span className="flex-1" />
+            <Button
+              disabled={
+                loginStep === null || pastedCode.trim().length === 0 || pending
+              }
+              onClick={complete}
+            >
+              Complete
+            </Button>
+          </>
+        ) : null
       }
     >
       <StepIndicator step={loginDone === null ? 2 : 3} />

--- a/plugins/account-pool/app.tsx
+++ b/plugins/account-pool/app.tsx
@@ -1577,14 +1577,11 @@ function LoginDialog({
         )
       ) : (
         <>
-          <div>
-            <h3 className="text-base font-semibold">Sign in to {name}</h3>
-            <p className="mt-1 text-sm text-muted-foreground">
-              {provider === "claude"
-                ? "Sign in at claude.ai, then paste the code from the final page."
-                : "Open the verification page, sign in to ChatGPT, and enter this code."}
-            </p>
-          </div>
+          <p className="text-sm text-muted-foreground">
+            {provider === "claude"
+              ? "Sign in at claude.ai, then paste the code from the final page."
+              : "Open the verification page, sign in to ChatGPT, and enter this code."}
+          </p>
           {codexStep === null ? null : (
             <div
               className="rounded-lg border border-border bg-surface-recessed px-5 py-5 text-center font-mono text-2xl font-semibold tracking-widest"


### PR DESCRIPTION
## Human comments

## What was wrong

The Account Pooler sign-in flow rendered the provider sign-in label twice: once as the accessible dialog title and again as a visual step heading. The footer Cancel button duplicated the dialog close action, while the compact drawer did not expose the corresponding header close control.

## What changed

- Keep one accessible `Sign in to …` title and retain the provider-specific instruction copy.
- Remove Cancel from the active sign-in footer; Codex now omits the empty footer while Claude retains Complete and the connected step retains Add another/Done.
- Put the shared responsive `DialogClose` in the Account Pooler dialog header so both desktop dialogs and compact drawers retain an explicit close action.
- Add regressions for the single heading, absent Cancel action, and pending-session cancellation/poll teardown across wide and compact layouts.

No host-daemon wire, CLI, guide, or public plugin API contract changes are involved.

## How you verified

- `pnpm exec turbo run test typecheck --filter=bb-plugin-account-pool --force` — 269 tests passed; typecheck passed.
- `pnpm exec oxfmt --check plugins/account-pool/app.tsx plugins/account-pool/app.test.tsx`
- `git diff --check`
- Browser QA at 1280×900 and 390×844 with a local fake device-auth fixture confirmed the single title, absent Cancel button, responsive header close, preserved device code/copy/open/countdown behavior, and preserved Claude/final-step actions.

> AGENT GENERATED
