### PR TITLE
Fix Docs vault loading with complete host records

### DIFF
--- a/plugins/docs/server.test.ts
+++ b/plugins/docs/server.test.ts
@@ -5,7 +5,10 @@ import path from "node:path";
 import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
 import { defineRpcContract } from "@get-bb/plugin-sdk";
 import type { PluginRpcClient, PluginRpcHandlers } from "@get-bb/plugin-sdk";
-import { createFakePluginHost } from "@get-bb/plugin-sdk/testing";
+import {
+  createFakePluginHost,
+  makeHostResponse,
+} from "@get-bb/plugin-sdk/testing";
 import simpleNotes, { docsRpcContract } from "./server";
 
 const temporaryDirectories: string[] = [];
@@ -514,6 +517,37 @@ describe("Docs mention provider", () => {
 });
 
 describe("Docs vault operations", () => {
+  it.each([false, true])(
+    "lists vaults with current host records when file listing fails: %s",
+    async (listingFails) => {
+      const { harness } = await loadNotebook({ "draft.md": "# Draft" });
+      const host = makeHostResponse();
+      harness.sdk.stub("hosts.list", async () => [host]);
+      if (listingFails) {
+        harness.sdk.stub("files.listPaths", async () => {
+          throw new Error("Host unavailable");
+        });
+      }
+
+      await expect(
+        harness.behavior.callRpc("listNotes", { vaultId: "personal" }),
+      ).resolves.toMatchObject({
+        vaults: [expect.objectContaining({ id: "personal" })],
+        hosts: [
+          expect.objectContaining({
+            id: host.id,
+            name: host.name,
+            status: host.status,
+          }),
+        ],
+        notes: listingFails
+          ? []
+          : [expect.objectContaining({ path: "draft.md" })],
+        error: listingFails ? "Host unavailable" : null,
+      });
+    },
+  );
+
   it("creates the initial Personal vault without exposing a folder setting", async () => {
     const host = createFakePluginHost({
       pluginId: "simple-notes",

--- a/plugins/docs/server.ts
+++ b/plugins/docs/server.ts
@@ -180,7 +180,7 @@ const hostSchema = z
     createdAt: z.number(),
     updatedAt: z.number(),
   })
-  .strict();
+  .strip();
 const pathResultSchema = z.object({ path: z.string().min(1) }).strict();
 const okResultSchema = z.object({ ok: z.literal(true) }).strict();
 const syncScopeSchema = z.discriminatedUnion("kind", [


### PR DESCRIPTION
## Human comments

## What was wrong

Docs could not load any vault when the host list was nonempty: `listNotes` returned `rpc output validation failed`. PR #3227 removed `type` from Docs' strict host schema, while the SDK continued returning that field. Existing Docs fixtures returned empty host lists, hiding the regression.

## What changed

Strip additional host properties from the Docs RPC response while continuing to validate its declared fields. Add regression coverage using the complete SDK host fixture for both successful file listing and the unavailable-vault fallback.

## How you verified

- Both new regression cases failed before the fix with `Unrecognized key: "type"`; all 68 Docs tests pass afterward.
- `pnpm exec turbo run test typecheck build --filter=bb-plugin-simple-notes` passed.
- Verified in an isolated source dev app with a connected host and synthetic vault. Temporarily restoring the original validator reproduced the exact error in both the browser and real RPC. Rebuilding/reloading the fixed plugin loaded the vault and opened its Markdown note through browser input. Captured before/after screenshots and RPC responses.
- Secret-model scan clean for the working tree, HEAD, added lines, and commit messages in the push range.
- SlopCop skipped as requested.

> AGENT GENERATED
