### PR TITLE
Open plugin details without leaving the workspace

### DIFF
--- a/apps/app/src/components/plugin/PluginNavSidebarItems.test.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.test.tsx
@@ -54,6 +54,7 @@ import {
   findPaneByContent,
   type SplitLayout,
 } from "@/lib/split-layout";
+import { usePublishPluginDetailOpener } from "./plugin-detail-navigation";
 vi.mock("@/components/ui/app-toast", () => ({
   appToast: {
     dismiss: vi.fn(),
@@ -518,6 +519,28 @@ describe("PluginNavSidebarItems", () => {
     );
     expect(screen.getByTestId("location-path").textContent).toBe(
       "/plugins/docs",
+    );
+  });
+
+  it("opens details in the active workspace without changing its route", async () => {
+    const open = vi.fn(() => true);
+    function Workspace() {
+      usePublishPluginDetailOpener(open, true);
+      return null;
+    }
+    render(<Workspace />);
+    registerPanel("docs", "Docs");
+    renderSidebarItems({ initialEntry: "/plugins/docs/main" });
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: "Docs panel options" }),
+      { button: 0 },
+    );
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: "View details" }),
+    );
+    expect(open).toHaveBeenCalledWith({ pluginId: "docs", title: "Docs" });
+    expect(screen.getByTestId("location-path").textContent).toBe(
+      "/plugins/docs/main",
     );
   });
 

--- a/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
@@ -108,6 +108,7 @@ import {
   togglePluginNavPanelVisibility,
 } from "./pluginNavSidebarOrder";
 import { haveSameOrder, reorderStoredOrder } from "@/lib/stored-order";
+import { openPluginDetailsInWorkspace } from "./plugin-detail-navigation";
 
 const MORE_TRIGGER_TEST_ID = "sidebar-navigation-more-trigger";
 
@@ -1206,6 +1207,13 @@ function PluginNavSidebarItem({
       onOpenInSplit={splitEnabled ? openInSplit : undefined}
       onOpenDetails={() => {
         onNavigate?.();
+        if (
+          openPluginDetailsInWorkspace({
+            pluginId: chrome.pluginId,
+            title: chrome.title,
+          })
+        )
+          return;
         void navigate(getPluginDetailRoutePath({ pluginId: chrome.pluginId }));
       }}
       onDisable={() => onDisable(row)}

--- a/apps/app/src/components/plugin/PluginPanelRightPanelHost.tsx
+++ b/apps/app/src/components/plugin/PluginPanelRightPanelHost.tsx
@@ -1,6 +1,4 @@
 import {
-  lazy,
-  Suspense,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -98,6 +96,7 @@ import { PluginPanelTabContent } from "./PluginPanelActions";
 import { PluginDetailRouteNavigationProvider } from "@/components/ui/app-route-anchor";
 import { usePluginCatalogSearch } from "@/hooks/queries/plugin-catalog-queries";
 import { usePluginList } from "@/hooks/queries/plugin-settings-queries";
+import { PluginDetailTabContent } from "./plugin-detail-navigation";
 
 const TERMINAL_COLS = 100;
 const TERMINAL_ROWS = 30;
@@ -121,25 +120,11 @@ const fixedTabTargetAtomFamily = atomFamily((_targetId: string) =>
   atom<FixedTabSessionTarget | null>(null),
 );
 
-const LazyPluginDetailPaneView = lazy(() =>
-  import("@/views/ToolsView").then(({ PluginDetailPaneView }) => ({
-    default: PluginDetailPaneView,
-  })),
-);
-
 function marketplacePluginDetailTab(pluginId: string) {
   return {
     id: `${MARKETPLACE_PLUGIN_DETAIL_TAB_PREFIX}${pluginId}`,
     kind: "marketplace-plugin-detail" as const,
   };
-}
-
-function PluginDetailPanelContent({ pluginId }: { pluginId: string }) {
-  return (
-    <Suspense fallback={<SecondaryPanelContentSkeleton />}>
-      <LazyPluginDetailPaneView pluginId={pluginId} />
-    </Suspense>
-  );
 }
 
 function PluginFixedTabContent({
@@ -785,7 +770,7 @@ export function PluginPanelRightPanelHost({
             revealPanel();
           },
           renderContent: () => (
-            <PluginDetailPanelContent pluginId={tabPluginId} />
+            <PluginDetailTabContent pluginId={tabPluginId} />
           ),
           statusLabel: null,
           tab: marketplacePluginDetailTab(tabPluginId),

--- a/apps/app/src/components/plugin/PluginPanelRightPanelHost.tsx
+++ b/apps/app/src/components/plugin/PluginPanelRightPanelHost.tsx
@@ -30,7 +30,6 @@ import {
   LazyBrowserTabDeck,
   LazyHostScopedFilePreviewTabContent,
   LazyNewTabPage,
-  SecondaryPanelContentSkeleton,
   LazyThreadSecondaryPanel,
   LazyThreadStorageFilePreviewTabContent,
   LazyThreadTerminalPanel,

--- a/apps/app/src/components/plugin/plugin-detail-navigation.test.tsx
+++ b/apps/app/src/components/plugin/plugin-detail-navigation.test.tsx
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ThreadSecondaryPanelProps } from "@/components/secondary-panel/ThreadSecondaryPanel";
+import {
+  openPluginDetailsInWorkspace,
+  PluginDetailPanelContext,
+  usePluginDetailPanelProps,
+  usePluginDetailPanelState,
+} from "./plugin-detail-navigation";
+
+const selectExisting = vi.fn();
+const closePanel = vi.fn();
+const existingTab = { id: "new-tab:existing", kind: "new-tab" as const };
+const baseProps: ThreadSecondaryPanelProps = {
+  activeTab: existingTab,
+  canUseGitUi: false,
+  metadataContent: null,
+  tabs: [
+    {
+      tab: existingTab,
+      label: "Existing tab",
+      leadingVisual: null,
+      statusLabel: null,
+      renderContent: () => null,
+      onClose: vi.fn(),
+      onSelect: selectExisting,
+    },
+  ],
+  fixedTabs: [],
+  isOpen: false,
+  onTabReorder: vi.fn(),
+  onPanelFocus: vi.fn(),
+  onClose: closePanel,
+  onCollapse: closePanel,
+  onOpenNewTab: vi.fn(),
+  isConversationCollapsed: false,
+  onToggleConversationCollapse: vi.fn(),
+  renderAsDrawer: false,
+};
+
+function PanelProbe({ id }: { id: string }) {
+  const props = usePluginDetailPanelProps(baseProps);
+  return (
+    <div
+      data-testid={id}
+      data-active={props.activeTab?.id}
+      data-open={props.isOpen}
+    >
+      {props.tabs.map((tab) => (
+        <div key={tab.tab.id}>
+          <button onClick={tab.onSelect}>{tab.label}</button>
+          <button onClick={tab.onClose}>Close {tab.label}</button>
+        </div>
+      ))}
+      <button onClick={props.onClose}>Hide panel</button>
+    </div>
+  );
+}
+
+function Workspace({
+  id,
+  focused,
+  revision = id,
+}: {
+  id: string;
+  focused: boolean;
+  revision?: string;
+}) {
+  const state = usePluginDetailPanelState(revision, focused);
+  return (
+    <PluginDetailPanelContext.Provider value={state}>
+      <PanelProbe id={id} />
+    </PluginDetailPanelContext.Provider>
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("plugin details in the active workspace", () => {
+  it("opens and focuses a single detail tab without replacing existing tabs", () => {
+    render(<Workspace id="workspace" focused />);
+    act(() => {
+      expect(
+        openPluginDetailsInWorkspace({ pluginId: "docs", title: "Docs" }),
+      ).toBe(true);
+    });
+    expect(screen.getByTestId("workspace").dataset.active).toBe(
+      "marketplace-plugin:docs",
+    );
+    expect(screen.getByTestId("workspace").dataset.open).toBe("true");
+    act(() => screen.getByRole("button", { name: "Existing tab" }).click());
+    expect(selectExisting).toHaveBeenCalledOnce();
+    expect(screen.getByTestId("workspace").dataset.active).toBe(existingTab.id);
+    act(() =>
+      openPluginDetailsInWorkspace({ pluginId: "docs", title: "Docs" }),
+    );
+    expect(screen.getAllByRole("button", { name: "Docs" })).toHaveLength(1);
+    act(() => screen.getByRole("button", { name: "Close Docs" }).click());
+    expect(screen.getByTestId("workspace").dataset.active).toBe(existingTab.id);
+    expect(screen.getByTestId("workspace").dataset.open).toBe("false");
+  });
+
+  it("targets only the focused pane and unregisters after it unmounts", () => {
+    const view = render(
+      <>
+        <Workspace id="left" focused />
+        <Workspace id="right" focused={false} />
+      </>,
+    );
+    act(() =>
+      openPluginDetailsInWorkspace({ pluginId: "docs", title: "Docs" }),
+    );
+    expect(screen.getByTestId("left").dataset.active).toBe(
+      "marketplace-plugin:docs",
+    );
+    expect(screen.getByTestId("right").dataset.active).toBe(existingTab.id);
+    view.rerender(
+      <>
+        <Workspace id="left" focused={false} />
+        <Workspace id="right" focused />
+      </>,
+    );
+    act(() =>
+      openPluginDetailsInWorkspace({ pluginId: "tasks", title: "Tasks" }),
+    );
+    expect(screen.getByTestId("right").dataset.active).toBe(
+      "marketplace-plugin:tasks",
+    );
+    view.unmount();
+    expect(
+      openPluginDetailsInWorkspace({ pluginId: "docs", title: "Docs" }),
+    ).toBe(false);
+  });
+
+  it("closes to the adjacent detail tab, then clears when the workspace changes", () => {
+    const view = render(<Workspace id="workspace" focused />);
+    act(() =>
+      openPluginDetailsInWorkspace({ pluginId: "docs", title: "Docs" }),
+    );
+    act(() =>
+      openPluginDetailsInWorkspace({ pluginId: "tasks", title: "Tasks" }),
+    );
+    act(() => screen.getByRole("button", { name: "Close Tasks" }).click());
+    expect(screen.getByTestId("workspace").dataset.active).toBe(
+      "marketplace-plugin:docs",
+    );
+    act(() => screen.getByRole("button", { name: "Hide panel" }).click());
+    expect(closePanel).toHaveBeenCalledOnce();
+    expect(screen.getByTestId("workspace").dataset.open).toBe("false");
+    view.rerender(
+      <Workspace id="workspace" focused revision="different-workspace" />,
+    );
+    expect(screen.queryByRole("button", { name: "Docs" })).toBeNull();
+  });
+});

--- a/apps/app/src/components/plugin/plugin-detail-navigation.tsx
+++ b/apps/app/src/components/plugin/plugin-detail-navigation.tsx
@@ -1,0 +1,186 @@
+import {
+  createContext,
+  lazy,
+  Suspense,
+  useCallback,
+  useContext,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type Key,
+} from "react";
+import { PluginIcon } from "./PluginIcon";
+import type { ThreadSecondaryPanelProps } from "@/components/secondary-panel/ThreadSecondaryPanel";
+import { SecondaryPanelContentSkeleton } from "@/components/secondary-panel/lazySecondaryPanelComponents";
+
+interface PluginDetailDestination {
+  pluginId: string;
+  title: string;
+}
+
+type PluginDetailOpener = (destination: PluginDetailDestination) => boolean;
+
+const focusedOpeners = new Map<symbol, PluginDetailOpener>();
+
+export function openPluginDetailsInWorkspace(
+  destination: PluginDetailDestination,
+): boolean {
+  for (const open of [...focusedOpeners.values()].reverse()) {
+    if (open(destination)) return true;
+  }
+  return false;
+}
+
+export function usePublishPluginDetailOpener(
+  open: PluginDetailOpener,
+  isActive: boolean,
+): void {
+  const openRef = useRef(open);
+  useLayoutEffect(() => {
+    openRef.current = open;
+  }, [open]);
+  useLayoutEffect(() => {
+    if (!isActive) return;
+    const token = Symbol("plugin-detail-opener");
+    focusedOpeners.set(token, (destination) => openRef.current(destination));
+    return () => {
+      focusedOpeners.delete(token);
+    };
+  }, [isActive]);
+}
+
+const LazyPluginDetailPaneView = lazy(() =>
+  import("@/views/ToolsView").then(({ PluginDetailPaneView }) => ({
+    default: PluginDetailPaneView,
+  })),
+);
+
+export function PluginDetailTabContent({ pluginId }: { pluginId: string }) {
+  return (
+    <Suspense fallback={<SecondaryPanelContentSkeleton />}>
+      <LazyPluginDetailPaneView pluginId={pluginId} />
+    </Suspense>
+  );
+}
+
+interface PluginDetailPanelState {
+  activePluginId: string | null;
+  destinations: readonly PluginDetailDestination[];
+  dismiss: () => void;
+  close: (pluginId: string) => void;
+  open: PluginDetailOpener;
+}
+
+export const PluginDetailPanelContext =
+  createContext<PluginDetailPanelState | null>(null);
+
+export function usePluginDetailPanelState(resetKey: Key, isFocused: boolean) {
+  const [destinations, setDestinations] = useState<PluginDetailDestination[]>(
+    [],
+  );
+  const [activePluginId, setActivePluginId] = useState<string | null>(null);
+  useLayoutEffect(() => {
+    // oxlint-disable-next-line react/set-state-in-effect
+    setDestinations([]);
+    // oxlint-disable-next-line react/set-state-in-effect
+    setActivePluginId(null);
+  }, [resetKey]);
+  const dismiss = useCallback(() => setActivePluginId(null), []);
+  const open = useCallback<PluginDetailOpener>((destination) => {
+    setDestinations((current) =>
+      current.some((entry) => entry.pluginId === destination.pluginId)
+        ? current
+        : [...current, destination],
+    );
+    setActivePluginId(destination.pluginId);
+    return true;
+  }, []);
+  const close = useCallback(
+    (pluginId: string) => {
+      const index = destinations.findIndex(
+        (entry) => entry.pluginId === pluginId,
+      );
+      const remaining = destinations.filter(
+        (entry) => entry.pluginId !== pluginId,
+      );
+      setDestinations(remaining);
+      if (activePluginId === pluginId) {
+        setActivePluginId(
+          remaining[Math.min(index, remaining.length - 1)]?.pluginId ?? null,
+        );
+      }
+    },
+    [activePluginId, destinations],
+  );
+  usePublishPluginDetailOpener(open, isFocused);
+  return useMemo(
+    () => ({ activePluginId, destinations, dismiss, close, open }),
+    [activePluginId, destinations, dismiss, close, open],
+  );
+}
+
+export function usePluginDetailPanelProps(
+  props: ThreadSecondaryPanelProps,
+): ThreadSecondaryPanelProps {
+  const details = useContext(PluginDetailPanelContext);
+  const activeTabId = props.activeTab?.id;
+  const previousActiveTabId = useRef(activeTabId);
+  const dismiss = details?.dismiss;
+  useLayoutEffect(() => {
+    if (previousActiveTabId.current !== activeTabId) dismiss?.();
+    previousActiveTabId.current = activeTabId;
+  }, [activeTabId, dismiss]);
+  if (details === null || details.destinations.length === 0) return props;
+  const active = details.activePluginId;
+  const selectExisting = (select: () => void) => () => {
+    details.dismiss();
+    select();
+  };
+  return {
+    ...props,
+    activeTab:
+      active === null
+        ? props.activeTab
+        : {
+            id: `marketplace-plugin:${active}`,
+            kind: "marketplace-plugin-detail",
+          },
+    isOpen: active !== null || props.isOpen,
+    splitPanelStateId: active === null ? props.splitPanelStateId : undefined,
+    onClose: selectExisting(props.onClose),
+    onCollapse: selectExisting(props.onCollapse),
+    onOpenNewTab: selectExisting(props.onOpenNewTab),
+    fixedTabs: props.fixedTabs.map((tab) => ({
+      ...tab,
+      onSelect: selectExisting(tab.onSelect),
+    })),
+    tabs: [
+      ...props.tabs.map((tab) => ({
+        ...tab,
+        onSelect: selectExisting(tab.onSelect),
+      })),
+      ...details.destinations.map((destination) => ({
+        contentFillsRegion: true,
+        label: destination.title,
+        leadingVisual: (
+          <PluginIcon
+            pluginId={destination.pluginId}
+            icon={null}
+            className="size-3.5"
+          />
+        ),
+        onClose: () => details.close(destination.pluginId),
+        onSelect: () => details.open(destination),
+        renderContent: () => (
+          <PluginDetailTabContent pluginId={destination.pluginId} />
+        ),
+        statusLabel: null,
+        tab: {
+          id: `marketplace-plugin:${destination.pluginId}`,
+          kind: "marketplace-plugin-detail" as const,
+        },
+      })),
+    ],
+  };
+}

--- a/apps/app/src/components/secondary-panel/SecondaryPanelLayout.test.tsx
+++ b/apps/app/src/components/secondary-panel/SecondaryPanelLayout.test.tsx
@@ -677,6 +677,24 @@ describe("SecondaryPanelLayout", () => {
 });
 
 describe("compact sidebar and right panel", () => {
+  it("keeps a newly requested panel open while the sidebar is dismissing", () => {
+    const onClose = vi.fn();
+    const view = renderLayout({
+      isCompactViewport: true,
+      onClose,
+      open: false,
+      renderPanel: createPanelRenderer(),
+      resetKey: "thread-1",
+    });
+    act(() => setCompactSidebarDrawerShowing(true));
+    view.rerenderWith({ open: true });
+    act(() => setCompactSidebarDrawerShowing(false));
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByTestId("responsive-drawer-shell").dataset.open).toBe(
+      "true",
+    );
+  });
+
   it("closes the right panel when the sidebar drawer opens so only one shelf is engaged", () => {
     const onClose = vi.fn();
     renderLayout({

--- a/apps/app/src/components/secondary-panel/SecondaryPanelLayout.tsx
+++ b/apps/app/src/components/secondary-panel/SecondaryPanelLayout.tsx
@@ -1,5 +1,6 @@
 import {
   useCallback,
+  useContext,
   useEffect,
   useLayoutEffect,
   useMemo,
@@ -36,6 +37,7 @@ import {
   isCompactSidebarDrawerShowing,
   subscribeCompactSidebarDrawerShowing,
 } from "@/components/ui/sidebar-mobile-drawer-visibility";
+import { PluginDetailPanelContext } from "@/components/plugin/plugin-detail-navigation";
 
 const FULL_PANEL_SIZE_PERCENT = 100;
 const MAIN_PANEL_MIN_SIZE_PERCENT = 30;
@@ -85,12 +87,26 @@ export function SecondaryPanelLayout({
   mainHeader,
   main,
   collapse,
-  renderPanel,
+  renderPanel: renderWorkspacePanel,
   renderHostedPanel,
   composerHost,
-  compactPresentation,
+  compactPresentation: workspaceCompactPresentation,
 }: SecondaryPanelLayoutProps) {
   const paneContext = useOptionalPaneContext();
+  const pluginDetails = useContext(PluginDetailPanelContext);
+  const isPluginDetailOpen =
+    pluginDetails !== null && pluginDetails.activePluginId !== null;
+  const compactPresentation = isPluginDetailOpen
+    ? "full"
+    : workspaceCompactPresentation;
+  const renderPanel = useCallback(
+    (args: SecondaryPanelRenderArgs) => (
+      <PluginDetailPanelContext.Provider value={pluginDetails}>
+        {renderWorkspacePanel(args)}
+      </PluginDetailPanelContext.Provider>
+    ),
+    [pluginDetails, renderWorkspacePanel],
+  );
   const secondaryPanelHost = paneContext?.secondaryPanelHost ?? null;
   const renderAsDrawer = useIsCompactViewport();
   const sidebarDrawerShowing = useSyncExternalStore(
@@ -98,8 +114,12 @@ export function SecondaryPanelLayout({
     isCompactSidebarDrawerShowing,
     () => false,
   );
+  const previousSidebarDrawerShowing = useRef(sidebarDrawerShowing);
   useEffect(() => {
-    if (!renderAsDrawer || !open || !sidebarDrawerShowing) return;
+    const sidebarOpened =
+      sidebarDrawerShowing && !previousSidebarDrawerShowing.current;
+    previousSidebarDrawerShowing.current = sidebarDrawerShowing;
+    if (!renderAsDrawer || !open || !sidebarOpened) return;
     onClose();
   }, [onClose, open, renderAsDrawer, sidebarDrawerShowing]);
   const transitionsReady = usePanelCollapseTransitionsReady(

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
@@ -1,3 +1,4 @@
+import { usePluginDetailPanelProps } from "@/components/plugin/plugin-detail-navigation";
 import {
   type CSSProperties,
   type FocusEvent,
@@ -210,7 +211,12 @@ export interface ThreadSecondaryPanelProps {
   renderAsDrawer: boolean;
 }
 
-export function ThreadSecondaryPanel({
+export function ThreadSecondaryPanel(props: ThreadSecondaryPanelProps) {
+  const panelProps = usePluginDetailPanelProps(props);
+  return <ThreadSecondaryPanelContent {...panelProps} />;
+}
+
+function ThreadSecondaryPanelContent({
   activeTab,
   canUseGitUi,
   gitDiffTabStatus,

--- a/apps/app/src/components/ui/app-route-anchor.tsx
+++ b/apps/app/src/components/ui/app-route-anchor.tsx
@@ -18,6 +18,8 @@ import { isRoutePath, resolveRouteHref } from "@/lib/route-paths";
 import { getDesktopBrowserApi } from "@/lib/bb-desktop";
 import { openPaneContentInSplit } from "@/lib/split-layout/openPaneContentInSplit";
 import { paneContentForPathname } from "@/views/thread-detail/splitThreadNavigation";
+import { useOptionalPaneContext } from "@/views/thread-detail/PaneContext";
+import { usePublishPluginDetailOpener } from "@/components/plugin/plugin-detail-navigation";
 
 interface RouteNavigationProviderProps {
   children: ReactNode;
@@ -159,6 +161,11 @@ export function PluginDetailRouteNavigationProvider({
   children: ReactNode;
   onOpenPluginDetail: (pluginId: string) => boolean;
 }) {
+  const pane = useOptionalPaneContext();
+  usePublishPluginDetailOpener(
+    ({ pluginId }) => onOpenPluginDetail(pluginId),
+    pane?.isFocused ?? true,
+  );
   return (
     <PluginDetailRouteNavigationContext.Provider value={onOpenPluginDetail}>
       {children}

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -181,6 +181,10 @@ import {
   useAppCommandShortcut,
 } from "@/components/commands/AppCommandProvider";
 import { useOptionalPaneContext } from "./thread-detail/PaneContext";
+import {
+  PluginDetailPanelContext,
+  usePluginDetailPanelState,
+} from "@/components/plugin/plugin-detail-navigation";
 import { RootComposePanelCommandHandlers } from "./RootComposePanelCommandHandlers";
 import {
   ROOT_COMPOSE_FIXED_PANEL_STATE_ID,
@@ -650,6 +654,10 @@ function RootComposeSurface({
 }: RootComposeSurfaceProps) {
   const paneContext = useOptionalPaneContext();
   const isFocusedPane = paneContext?.isFocused ?? true;
+  const pluginDetails = usePluginDetailPanelState(
+    ROOT_COMPOSE_FIXED_PANEL_STATE_ID,
+    isFocusedPane,
+  );
   const location = useLocation();
   const navigate = useNavigate();
   const isPointerCoarse = usePointerCoarse();
@@ -910,9 +918,11 @@ function RootComposeSurface({
       isCompactViewport,
       threadId: ROOT_COMPOSE_FIXED_PANEL_STATE_ID,
     });
-  const isSecondaryPanelOpen = isCompactViewport
+  const isWorkspacePanelOpen = isCompactViewport
     ? secondaryPanelDrawerVisibility.isDrawerVisible
     : isPersistedSecondaryPanelOpen;
+  const isSecondaryPanelOpen =
+    isWorkspacePanelOpen || pluginDetails.activePluginId !== null;
   const touchFixedPanelTabsState = useTouchFixedPanelTabsState(
     ROOT_COMPOSE_FIXED_PANEL_STATE_ID,
     null,
@@ -1138,7 +1148,7 @@ function RootComposeSurface({
     openTab({ kind: "new-tab" });
   }, [closeRootSecondaryPanel, isPersistedSecondaryPanelOpen, openTab]);
   const {
-    closePanel: closeSecondaryPanel,
+    closePanel: closeWorkspacePanel,
     openCompactDrawer,
     openHostFile,
     openStorageFile,
@@ -1157,6 +1167,10 @@ function RootComposeSurface({
     openPersistedWorkspaceFile,
     togglePersistedPanel: toggleRootPersistedSecondaryPanel,
   });
+  const closeSecondaryPanel = useCallback(() => {
+    pluginDetails.dismiss();
+    closeWorkspacePanel();
+  }, [pluginDetails.dismiss, closeWorkspacePanel]);
   const handleOpenLiveFilePreview = useCallback(
     (intent: AppFilePreviewIntent): boolean => {
       const normalized = normalizeExperimentalFileOpenOptions(intent);
@@ -1958,7 +1972,7 @@ function RootComposeSurface({
   });
 
   return (
-    <>
+    <PluginDetailPanelContext.Provider value={pluginDetails}>
       <RootComposePanelCommandHandlers
         isFocused={isFocusedPane}
         onClose={handleCloseWindowRequest}
@@ -2035,6 +2049,6 @@ function RootComposeSurface({
           </AppNavigationHostProvider>
         </UrlOpenRoutingProvider>
       </PluginComposerHostProvider>
-    </>
+    </PluginDetailPanelContext.Provider>
   );
 }

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -1167,10 +1167,11 @@ function RootComposeSurface({
     openPersistedWorkspaceFile,
     togglePersistedPanel: toggleRootPersistedSecondaryPanel,
   });
+  const dismissPluginDetails = pluginDetails.dismiss;
   const closeSecondaryPanel = useCallback(() => {
-    pluginDetails.dismiss();
+    dismissPluginDetails();
     closeWorkspacePanel();
-  }, [pluginDetails.dismiss, closeWorkspacePanel]);
+  }, [dismissPluginDetails, closeWorkspacePanel]);
   const handleOpenLiveFilePreview = useCallback(
     (intent: AppFilePreviewIntent): boolean => {
       const normalized = normalizeExperimentalFileOpenOptions(intent);

--- a/apps/app/src/views/thread-detail/SplitThreadArea.test.tsx
+++ b/apps/app/src/views/thread-detail/SplitThreadArea.test.tsx
@@ -672,7 +672,7 @@ describe("SplitThreadArea", () => {
     expect(host.dataset.pluginId).toBe("docs");
     expect(host.dataset.panelPath).toBe("docs");
     expect(host.dataset.flushPageInsets).toBe("true");
-    expect(host.dataset.pluginDetailTabsEnabled).toBe("false");
+    expect(host.dataset.pluginDetailTabsEnabled).toBe("true");
   });
 
   it("preserves detail state within the Guide and clears it for another plugin page", async () => {

--- a/apps/app/src/views/thread-detail/SplitThreadArea.tsx
+++ b/apps/app/src/views/thread-detail/SplitThreadArea.tsx
@@ -119,9 +119,6 @@ const LazyPluginPanelRightPanelHost = lazy(() =>
   ),
 );
 
-const PLUGIN_GUIDE_PLUGIN_ID = "plugin-api-docs";
-const PLUGIN_GUIDE_PANEL_PATH = "plugin-api";
-
 const LazyPluginDetailPaneView = lazy(() =>
   import("@/views/ToolsView").then(({ PluginDetailPaneView }) => ({
     default: PluginDetailPaneView,
@@ -152,10 +149,7 @@ function PluginPagePanelHost({
       <LazyPluginPanelRightPanelHost
         key={`${props.pluginId}/${props.panelPath}`}
         {...props}
-        pluginDetailTabsEnabled={
-          props.pluginId === PLUGIN_GUIDE_PLUGIN_ID &&
-          props.panelPath === PLUGIN_GUIDE_PANEL_PATH
-        }
+        pluginDetailTabsEnabled
       >
         {children}
       </LazyPluginPanelRightPanelHost>

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -1283,10 +1283,11 @@ function ThreadDetailViewInternal(props: ThreadRoutePathArgs) {
     openPersistedWorkspaceFile,
     togglePersistedPanel: toggleDefaultPersistedSecondaryPanel,
   });
+  const dismissPluginDetails = pluginDetails.dismiss;
   const closeSecondaryPanel = useCallback(() => {
-    pluginDetails.dismiss();
+    dismissPluginDetails();
     closeWorkspacePanel();
-  }, [pluginDetails.dismiss, closeWorkspacePanel]);
+  }, [dismissPluginDetails, closeWorkspacePanel]);
   const toggleSecondaryPanel = useCallback(() => {
     if (pluginDetails.activePluginId !== null) closeSecondaryPanel();
     else toggleWorkspacePanel();

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -44,6 +44,10 @@ import type { WorkspaceOpenTarget } from "@bb/host-daemon-contract";
 import { appToast } from "@/components/ui/app-toast";
 import { copyToClipboardWithToast } from "@/lib/clipboard";
 import type { ThreadSecondaryPanel as ThreadSecondaryPanelTab } from "@/lib/thread-secondary-panel";
+import {
+  PluginDetailPanelContext,
+  usePluginDetailPanelState,
+} from "@/components/plugin/plugin-detail-navigation";
 import { useForkThreadFromMessage } from "@/hooks/useForkThreadFromMessage";
 import { isThreadForkable } from "@bb/client-core";
 import { useRequestEnvironmentAction } from "../../hooks/mutations/environment-mutations";
@@ -586,9 +590,12 @@ function ThreadDetailViewInternal(props: ThreadRoutePathArgs) {
       isCompactViewport: renderSecondaryPanelAsDrawer,
       threadId,
     });
-  const isSecondaryPanelOpen = renderSecondaryPanelAsDrawer
+  const pluginDetails = usePluginDetailPanelState(threadId, isFocused);
+  const isWorkspacePanelOpen = renderSecondaryPanelAsDrawer
     ? secondaryPanelDrawerVisibility.isDrawerVisible
     : isPersistedSecondaryPanelOpen;
+  const isSecondaryPanelOpen =
+    isWorkspacePanelOpen || pluginDetails.activePluginId !== null;
   const touchFixedPanelTabsState = useTouchFixedPanelTabsState(
     threadId,
     threadId,
@@ -1252,7 +1259,7 @@ function ThreadDetailViewInternal(props: ThreadRoutePathArgs) {
     threadId,
   });
   const {
-    closePanel: closeSecondaryPanel,
+    closePanel: closeWorkspacePanel,
     openCommitDiff: openGitDiffCommitDestination,
     openCompactDrawer,
     openDiffFile: openGitDiffFileDestination,
@@ -1261,7 +1268,7 @@ function ThreadDetailViewInternal(props: ThreadRoutePathArgs) {
     openPanel: openFixedViewDestination,
     openStorageFile,
     openWorkspaceFile,
-    togglePanel: toggleSecondaryPanel,
+    togglePanel: toggleWorkspacePanel,
   } = useThreadSecondaryPanelVisibility({
     closePersistedPanel: closeThreadSecondaryPanel,
     drawerVisibility: secondaryPanelDrawerVisibility,
@@ -1276,6 +1283,14 @@ function ThreadDetailViewInternal(props: ThreadRoutePathArgs) {
     openPersistedWorkspaceFile,
     togglePersistedPanel: toggleDefaultPersistedSecondaryPanel,
   });
+  const closeSecondaryPanel = useCallback(() => {
+    pluginDetails.dismiss();
+    closeWorkspacePanel();
+  }, [pluginDetails.dismiss, closeWorkspacePanel]);
+  const toggleSecondaryPanel = useCallback(() => {
+    if (pluginDetails.activePluginId !== null) closeSecondaryPanel();
+    else toggleWorkspacePanel();
+  }, [pluginDetails.activePluginId, closeSecondaryPanel, toggleWorkspacePanel]);
   const fixedTabDestinations = useMemo(
     () => [
       createThreadInfoFixedTabDestination(() =>
@@ -3001,7 +3016,9 @@ function ThreadDetailViewInternal(props: ThreadRoutePathArgs) {
         <PluginThreadPanelNavigationProvider
           openThreadPanel={handleOpenTimelinePluginPanel}
         >
-          {threadDetailContent}
+          <PluginDetailPanelContext.Provider value={pluginDetails}>
+            {threadDetailContent}
+          </PluginDetailPanelContext.Provider>
         </PluginThreadPanelNavigationProvider>
       </ThreadProviderContext.Provider>
     </>


### PR DESCRIPTION
## Human comments

## What was wrong

- View details in a plugin row switched to the Plugins workspace, interrupting the current thread or plugin page. Detail tabs were available only inside Plugin Guide.

## What changed

- **Consolidated into #2916** at `ec3051b18d14208194e2e15a1966d3e010aa5cdd` at the user's request. Use that PR and its `localhost:16770` app for combined QA. The user approved closing this original layer as superseded; its branch and review history are preserved. Do not merge this duplicate layer independently.

- Opens or focuses a plugin detail tab in the current new-thread, thread, or plugin workspace without changing its route. Existing panel tabs remain available; closing details returns to them.
- Reuses the existing detail content and panel layout. Detail tabs are local to the mounted workspace, like the previous Plugin Guide detail tabs; no persisted tab, SDK, server, or daemon contracts change.
- Keeps direct plugin launch and Disable unchanged. This layer does not change mobile sidebar controls.

## How you verified

- **User QA pass (2026-09-11):** the user explicitly reported that #3431 detail tabs passes QA against the running layer dev app (checkout `351f6834db8c6cae76ef4781bab27ef3aa66b112`). Browser/version/viewport were not supplied. Reuse this result for the unchanged detail-tab flow during the requested consolidation into #2916; do not count it as a new code review or a complete screenshot refresh.

- **Inherited disable-flow fix (2026-09-11):** current head `351f6834db8c6cae76ef4781bab27ef3aa66b112` replays this unchanged layer onto #2916's fix: close only the disabled plugin's workspace panes before unloading, preserve other splits, and replace the active route with its survivor or New thread. Remote [CI 34561965770](https://github.com/get-bb/bb/actions/runs/34561965770) completed: all tests, build/typecheck/lint, and Linux/macOS package smoke passed; only the startup bundle guard failed, at 1696.1 KB versus 1683.2 KB (12.9 KB over). The #2916 exact-head regression run is green; its current-main merge candidate has a 0.7 KB startup bundle overage. Existing layer-specific bundle/QA blockers are unchanged. No additional deliberate review ran. Current Chrome for Testing launch is blocked after one recovery attempt; historical screenshots are not exact-current-head proof.

- **Rebase update (2026-09-10):** current head `50a209ff01051afbcbef6a4299f3c3a1e8035c3a` includes `main@10bacbc0fb1ead6c1f1a728b395bdb1f60e52f93`, including the muted navigation More styling. All commits replayed unchanged (`git range-diff`); no conflict resolutions, additional code review, or product changes. Remote [CI run 34530483287](https://github.com/get-bb/bb/actions/runs/34530483287) finished: all tests, build, typecheck, lint, and Linux/macOS package smoke passed; the existing startup bundle guard failed at 1694.3 KB versus 1683.2 KB (11.0 KB over). The comparison screenshots and UI results below belong to the explicitly recorded pre-rebase revisions and are retained as historical evidence, not exact-current-head verification. Existing readiness gaps remain open.
- Added regression coverage for focused-workspace targeting, repeated opens, existing-tab selection, detail-tab closing, workspace reset, route preservation, and the sidebar-to-panel mobile transition.
- Remote [CI run 34527856620](https://github.com/get-bb/bb/actions/runs/34527856620) on `497d201a48565a2494ef4d58eff9b254bd7e8b18`: all app/server/integration/package tests, typecheck, lint, build, and Linux/macOS package smoke passed. The startup bundle guard failed: 1692.8 KB raw versus a 1683.2 KB budget, over by 9.5 KB. No budget increase or local CI-equivalent checks.
- Chrome for Testing **153.0.8010.36**: exact-head desktop and mobile View details retains `/`; a settled Automations workspace retains `/plugins/automations/automations` and its content. Existing New tab remains selectable alongside details. Mobile details render without making the app root inert. Focus, deduplication, closing, and workspace reset have passing remote regression coverage.
- **HOLD:** clicking View details before a plugin workspace finishes mounting can still take the old `/plugins/plugin-api-docs` fallback. A real existing-thread UI flow remains unrun; shared state and focused-pane targeting are covered remotely. Both this loading-time edge case and the bundle guard need resolution before readiness. No additional deliberate code review ran; this PR remains draft and unmerged.
- Screenshots below use the same isolated source app and enabled first-party `builtin:plugin-api-docs` fixture, light theme, scale 1, and action sequence: start at `/`, open the Plugin Guide row menu, select View details. Mobile opens the sidebar first. Before changes workspace to Plugins; its mobile sidebar-dismissal race also closes the details. After remains at `/` and keeps details open. Captures were inspected and uploaded as GitHub attachments, outside product commits; `get-bb/reports` was not used.

Before: parent `9ff3761403f5feab1548d229b537d2c0221b5cb1`.

After: head `497d201a48565a2494ef4d58eff9b254bd7e8b18`.

| Layout | Before | After |
|---|---|---|
| Web/desktop — 1440×900 | ![Before: details switches to Plugins](https://github.com/user-attachments/assets/beb37d03-6d80-4bf3-889c-776f7c952559) | ![After: details tab alongside the unchanged new-thread workspace](https://github.com/user-attachments/assets/7ae88812-4b33-496b-b299-d7d4f360c35c) |
| Mobile — 390×844, touch | ![Before: switching workspaces and dismissing the sidebar loses the detail panel](https://github.com/user-attachments/assets/97fd3d8a-f7dd-4a6b-b1aa-ffc3dfb95c78) | ![After: detail tab remains open in the current workspace](https://github.com/user-attachments/assets/ef606a67-9137-4131-a3a7-17abfd48abbf) |

BB-Thread-ID: thr_fckf9yhnnx

> AGENT GENERATED

