### PR TITLE
Keep mobile workspace sidebar controls reachable

### DIFF
--- a/apps/app/src/components/layout/AppLayout.plugin-panel-header.test.tsx
+++ b/apps/app/src/components/layout/AppLayout.plugin-panel-header.test.tsx
@@ -210,17 +210,22 @@ describe("AppLayout plugin panel header", () => {
     ).toBe(true);
   });
 
-  it("shows the fixed left trigger only while the compact right panel is closed", () => {
+  it("keeps the fixed left trigger above compact panels", () => {
     viewportState.compact = true;
     renderPluginPanelRoute();
 
     const trigger = screen.getByTestId("app-sidebar-trigger-overlay");
-    expect(trigger.style.zIndex).toBe(String(APP_OVERLAY_LAYER.sidebarTrigger));
+    expect(trigger.style.zIndex).toBe(
+      String(APP_OVERLAY_LAYER.compactSidebarTrigger),
+    );
+    expect(Number(trigger.style.zIndex)).toBeGreaterThan(
+      APP_OVERLAY_LAYER.secondaryPanelFullPage,
+    );
     act(() => setCompactSecondaryPanelPresentation("shelf"));
-    expect(screen.queryByTestId("app-sidebar-trigger-overlay")).toBeNull();
+    expect(screen.getByTestId("app-sidebar-trigger-overlay")).toBe(trigger);
 
     act(() => setCompactSecondaryPanelPresentation("full"));
-    expect(screen.queryByTestId("app-sidebar-trigger-overlay")).toBeNull();
+    expect(screen.getByTestId("app-sidebar-trigger-overlay")).toBe(trigger);
 
     act(() => setCompactSecondaryPanelPresentation("closed"));
     expect(screen.getByTestId("app-sidebar-trigger-overlay")).not.toBeNull();

--- a/apps/app/src/components/layout/AppLayout.test.tsx
+++ b/apps/app/src/components/layout/AppLayout.test.tsx
@@ -15,6 +15,8 @@ import { Link, MemoryRouter, useLocation } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AppCommandProvider } from "@/components/commands/AppCommandProvider";
 import { AppLayout } from "./AppLayout";
+import { CompactViewportOverrideProvider } from "@bb/shared-ui/hooks/use-compact-viewport";
+import { setCompactSecondaryPanelPresentation } from "@/components/ui/secondary-panel-shelf-visibility";
 
 const SIDEBAR_WIDTH_STORAGE_KEY = "bb.sidebar.width";
 const APP_ROUTE = "/projects/proj_one/threads/thr_one?message=12#event-12";
@@ -43,8 +45,7 @@ vi.mock("./AppLayoutSidebar", async () => {
 vi.mock("@/hooks/queries/system-queries", () => ({
   useSystemConfig: () => ({
     data: {
-      experiments: {
-      },
+      experiments: {},
       generalSettings: defaultAppSettings,
       keybindings: [
         {
@@ -198,8 +199,46 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  setCompactSecondaryPanelPresentation("closed");
   vi.restoreAllMocks();
   window.localStorage.clear();
+});
+
+describe("mobile workspace sidebar access", () => {
+  it.each([
+    "/plugins",
+    "/plugins/plugin-api-docs",
+    "/plugins/plugin-api-docs/plugin-api",
+    "/settings",
+    "/skills",
+  ])(
+    "opens and collapses the sidebar on %s with a full detail panel",
+    async (route) => {
+      setCompactSecondaryPanelPresentation("full");
+      render(
+        <CompactViewportOverrideProvider isCompactViewport>
+          <MemoryRouter initialEntries={[route]}>
+            <AppCommandProvider>
+              <AppLayout>
+                <div>Workspace content</div>
+              </AppLayout>
+            </AppCommandProvider>
+          </MemoryRouter>
+        </CompactViewportOverrideProvider>,
+      );
+      const toggle = screen.getByRole("button", { name: /^Toggle sidebar/ });
+      expect(toggle.getAttribute("aria-expanded")).toBe("false");
+      fireEvent.click(toggle);
+      await waitFor(() =>
+        expect(toggle.getAttribute("aria-expanded")).toBe("true"),
+      );
+      fireEvent.click(toggle);
+      await waitFor(() =>
+        expect(toggle.getAttribute("aria-expanded")).toBe("false"),
+      );
+      expect(getRoot().hasAttribute("inert")).toBe(false);
+    },
+  );
 });
 
 describe("AppLayout Back to app", () => {

--- a/apps/app/src/components/layout/AppLayout.tsx
+++ b/apps/app/src/components/layout/AppLayout.tsx
@@ -1,12 +1,5 @@
 import { type MouseEvent as ReactMouseEvent, type ReactNode } from "react";
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  useSyncExternalStore,
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { flushSync } from "react-dom";
 import { atom, useAtom, useAtomValue, useStore } from "jotai";
 import { atomWithStorage } from "jotai/utils";
@@ -48,10 +41,6 @@ import { useRouteState } from "@/hooks/useRouteState";
 import { getThreadDisplayTitle } from "@/lib/thread-title";
 import { cn } from "@bb/shared-ui/lib/utils";
 import { APP_OVERLAY_LAYER } from "@/components/ui/app-overlay-layers";
-import {
-  getCompactSecondaryPanelPresentation,
-  subscribeCompactSecondaryPanelShelfShowing,
-} from "@/components/ui/secondary-panel-shelf-visibility";
 import { ProjectPathDialog } from "@/components/dialogs/ProjectPathDialog";
 import { ProjectActionsMenu } from "@/components/project/ProjectActionsMenu";
 import { ProjectActionsProvider } from "@/components/project/ProjectActionsProvider";
@@ -208,15 +197,7 @@ function SidebarTriggerOverlay({
   usesDesktopChrome,
 }: SidebarTriggerOverlayProps) {
   const isCompactViewport = useIsCompactViewport();
-  const compactSecondaryPanelPresentation = useSyncExternalStore(
-    subscribeCompactSecondaryPanelShelfShowing,
-    getCompactSecondaryPanelPresentation,
-    () => "closed",
-  );
   const shortcut = useAppCommandShortcut("sidebar.toggle");
-  if (isCompactViewport && compactSecondaryPanelPresentation !== "closed") {
-    return null;
-  }
   const triggerProps = {
     "aria-label": shortcut
       ? `Toggle sidebar (${shortcut.label})`
@@ -256,7 +237,11 @@ function SidebarTriggerOverlay({
   return (
     <div
       data-testid="app-sidebar-trigger-overlay"
-      style={{ zIndex: APP_OVERLAY_LAYER.sidebarTrigger }}
+      style={{
+        zIndex: isCompactViewport
+          ? APP_OVERLAY_LAYER.compactSidebarTrigger
+          : APP_OVERLAY_LAYER.sidebarTrigger,
+      }}
       className={cn(
         "fixed top-[env(safe-area-inset-top)] left-[env(safe-area-inset-left)]",
         CHROME_ROW_CLASS,

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.collapseControl.test.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.collapseControl.test.tsx
@@ -195,6 +195,11 @@ describe("ThreadSecondaryPanel compact file content", () => {
     );
 
     expect(screen.getByText("Recovered tab body")).toBeTruthy();
+    expect(
+      screen
+        .getByTestId("thread-secondary-panel-top-chrome")
+        .classList.contains("pl-14"),
+    ).toBe(true);
   });
 
   it("renders arbitrary fixed-tab content through the shared surface", () => {
@@ -702,6 +707,11 @@ describe("ThreadSecondaryPanel hide control glyph", () => {
 
     const hideControl = view.getByRole("button", { name: "Hide right panel" });
     expect(hideControl.querySelector('[data-icon="PanelRight"]')).toBeTruthy();
+    expect(
+      screen
+        .getByTestId("thread-secondary-panel-top-chrome")
+        .classList.contains("pl-14"),
+    ).toBe(false);
   });
 
   it("shows the side-panel glyph on a wide viewport", () => {

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
@@ -38,6 +38,7 @@ import {
   THREAD_SECONDARY_PANEL_MIN_SIZE_PERCENT,
 } from "./secondaryPanelSizing";
 import {
+  getCompactPanelPresentation,
   RIGHT_PANEL_TOGGLE_ICON_NAME,
   resolveConversationCollapseControl,
 } from "./panelToggleControlState";
@@ -258,6 +259,12 @@ function ThreadSecondaryPanelContent({
     () => tabs.filter((tab) => tab.isHidden !== true),
     [tabs],
   );
+  const reservesCompactSidebarToggle =
+    renderAsDrawer &&
+    getCompactPanelPresentation(
+      activeTab?.kind,
+      fixedTabs[0]?.tab.kind ?? visibleTabs[0]?.tab.kind,
+    ) === "full";
   const activeRenderableTab =
     tabs.find((tab) => tab.tab.id === activeTab?.id) ??
     (activeTab === null && fixedTabs.length === 0 ? visibleTabs[0] : undefined);
@@ -717,6 +724,7 @@ function ThreadSecondaryPanelContent({
             className={cn(
               CHROME_ROW_CLASS,
               "min-w-0 justify-between gap-2 px-4",
+              reservesCompactSidebarToggle && "pl-14",
               usesDesktopChrome && usesWindowChrome && MACOS_WINDOW_DRAG_CLASS,
               usesDesktopChrome &&
                 usesWindowChrome &&

--- a/apps/app/src/components/ui/app-overlay-layers.ts
+++ b/apps/app/src/components/ui/app-overlay-layers.ts
@@ -3,5 +3,6 @@ export const APP_OVERLAY_LAYER = {
   secondaryPanelDismiss: 40,
   sidebarTrigger: 44,
   secondaryPanelFullPage: 45,
+  compactSidebarTrigger: 46,
   sharedPortaledOverlay: 50,
 } as const;


### PR DESCRIPTION
## Human comments

## What was wrong

- Full-screen mobile detail panels hid the left sidebar toggle, making workspace navigation unavailable until the right panel was closed.

## What changed

- **Consolidated into #2916** at `ec3051b18d14208194e2e15a1966d3e010aa5cdd` at the user's request. Use that PR and its `localhost:16770` app for combined QA. The user approved closing this original layer as superseded; its branch and review history are preserved. Do not merge this duplicate layer independently.

- Keeps the shared mobile sidebar toggle above full-screen detail panels and reserves space beside their tabs so the controls do not overlap.
- Covers Plugins, plugin detail and plugin-page routes, Settings, and Skills. Their existing open/collapse behavior stays available; desktop stacking and partial-height shelf spacing remain unchanged.
- No sidebar menu, workspace layout, palette, or persisted/public-contract changes.

## How you verified

- **Inherited disable-flow fix (2026-09-11):** current head `55f06c8856abf69291f2e8856b4178d63cf92826` replays this unchanged layer onto #2916's fix: close only the disabled plugin's workspace panes before unloading, preserve other splits, and replace the active route with its survivor or New thread. Remote [CI 34561965981](https://github.com/get-bb/bb/actions/runs/34561965981) completed: all tests, build/typecheck/lint, and Linux/macOS package smoke passed; only the startup bundle guard failed, at 1696.1 KB versus 1683.2 KB (12.9 KB over). The #2916 exact-head regression run is green; its current-main merge candidate has a 0.7 KB startup bundle overage. Existing layer-specific bundle/QA blockers are unchanged. No additional deliberate review ran. Current Chrome for Testing launch is blocked after one recovery attempt; historical screenshots are not exact-current-head proof.

- **Rebase update (2026-09-10):** current head `271985bd6e20392a1ddf5fe5515805752e782992` includes `main@10bacbc0fb1ead6c1f1a728b395bdb1f60e52f93`, including the muted navigation More styling. All commits replayed unchanged (`git range-diff`); no conflict resolutions, additional code review, or product changes. Remote [CI run 34530485238](https://github.com/get-bb/bb/actions/runs/34530485238) finished: all tests, build, typecheck, lint, and Linux/macOS package smoke passed; the existing startup bundle guard failed at 1694.3 KB versus 1683.2 KB (11.0 KB over). The comparison screenshots and UI results below belong to the explicitly recorded pre-rebase revisions and are retained as historical evidence, not exact-current-head verification. Existing readiness gaps remain open.
- Added mobile route coverage for opening and collapsing the sidebar across all five surfaces, plus full-screen stacking and tab-spacing assertions.
- Chrome for Testing **153.0.8010.36**, exact parent/head: the mobile plugin-detail page changes from zero left toggles to one hit-testable control. Its right edge is 48 px; tabs begin at 56 px, leaving an 8 px gap. The app root stays non-inert.
- Exact-head mobile opening/collapse cycles passed on Plugins, plugin details, the Automations plugin workspace, Settings, and Skills. Opening the sidebar from full-screen plugin details preserves the existing single-shelf behavior: the detail panel closes and the Plugins sidebar opens. Desktop retains the existing layout and the Automations route/content alongside details.
- Remote [CI run 34528272301](https://github.com/get-bb/bb/actions/runs/34528272301) on `e1e397aea612193351587af1b1319aa96c02dc11`: all app/server/integration/package tests, typecheck, lint, build, and Linux/macOS package smoke passed. Checks failed only on the inherited startup bundle overage: 1692.7 KB raw versus the 1683.2 KB budget, over by 9.5 KB. No local CI-equivalent checks.
- **HOLD:** inherited bundle failure and the detail-tab parent's loading-time fallback remain unresolved. This layer has no observed mobile-control defect, but remains draft and unmerged. No additional deliberate code review ran.
- Evidence uses this task's isolated source app, the same enabled `builtin:plugin-api-docs` fixture and empty Automations workspace, light theme, scale 1, and matching routes/interactions. Mobile compares direct `/plugins/plugin-api-docs` navigation; desktop starts at `/plugins/automations/automations` and selects Plugin Guide → View details after the workspace settles. Inspected screenshots are GitHub attachments, not product commits; `get-bb/reports` was not used.

Before: parent `497d201a48565a2494ef4d58eff9b254bd7e8b18`.

After: head `e1e397aea612193351587af1b1319aa96c02dc11`.

| Layout | Before | After |
|---|---|---|
| Web/desktop — 1440×900, unchanged | ![Before: plugin workspace and details tab](https://github.com/user-attachments/assets/b0e8f30a-4205-494f-8a45-5e3d75125508) | ![After: desktop plugin workspace and details tab unchanged](https://github.com/user-attachments/assets/860be963-24b4-4f07-b130-584ad68a1af2) |
| Mobile — 390×844, touch | ![Before: full-screen plugin details hides the left sidebar control](https://github.com/user-attachments/assets/0af71829-65ee-4173-ad83-3b5b6e967a9e) | ![After: sidebar control remains accessible beside the detail tabs](https://github.com/user-attachments/assets/89a6a857-56a5-489d-ab1b-4b502f819518) |

- Additional exact-head mobile coverage at the same 390×844 viewport confirms existing Settings and Skills controls remain reachable:

| Settings | Skills |
|---|---|
| ![Settings sidebar control](https://github.com/user-attachments/assets/c675b376-4a9d-46bd-89f4-c3f013f39b0a) | ![Skills sidebar control](https://github.com/user-attachments/assets/426c9c85-173e-4cf4-8c11-fabc18ac24dc) |

- **Post-rebase UI check — `271985bd6`:** Chrome for Testing 153.0.8010.36, light theme, empty synthetic workspace at `/`, desktop 1440×900 and mobile 390×844. More uses the muted token at rest and sidebar foreground while open. The open/close cycle passed on both viewports and the app root stayed non-inert. These inspected current-head snapshots verify inherited main styling, not a refresh of the historical feature comparisons above.

| Post-rebase web/desktop | Post-rebase mobile |
|---|---|
| ![Current-head muted More on desktop](https://github.com/user-attachments/assets/57461869-2531-44a7-b383-ad61aec41a9a) | ![Current-head muted More on mobile](https://github.com/user-attachments/assets/705d6759-b571-43b7-9106-d46559cc6e0b) |

BB-Thread-ID: thr_fckf9yhnnx

> AGENT GENERATED

