### PR TITLE
Accept Ctrl+Enter as the modifier submit shortcut on non-Mac keyboards

### DIFF
--- a/apps/app/src/components/promptbox/FollowUpPromptBox.test.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.test.tsx
@@ -108,7 +108,7 @@ vi.mock("@/components/promptbox/PromptBoxInternal", () => ({
         focusEnd: () => void;
       } | null;
     };
-    submission?: { onModifierSubmit?: () => void };
+    submission?: { onModifierSubmit?: () => void; title?: string };
     suppressPluginComposerCustomizations?: boolean;
     onCollapse?: () => void;
     heightAnimationKey?: string | number;
@@ -157,7 +157,11 @@ vi.mock("@/components/promptbox/PromptBoxInternal", () => ({
       >
         Submit
       </button>
-      <button type="button" onClick={submission?.onModifierSubmit}>
+      <button
+        type="button"
+        title={submission?.title}
+        onClick={submission?.onModifierSubmit}
+      >
         Modifier submit
       </button>
       {onCollapse ? (
@@ -748,6 +752,38 @@ describe("FollowUpPromptBox", () => {
       fireEvent.click(screen.getByText("Modifier submit"));
       expect(expectedModifier).toHaveBeenCalledOnce();
       expect(mocks.scrollToBottom).toHaveBeenCalledOnce();
+    },
+  );
+
+  it.each([
+    { setting: false, title: "Queue follow-up (Enter), Ctrl + Enter to steer" },
+    {
+      setting: true,
+      title: "Steer current run (Enter), Ctrl + Enter to queue",
+    },
+  ])(
+    "shows the platform modifier shortcut in the submit title when steer-on-Enter is $setting",
+    ({ setting, title }) => {
+      const platformMock = vi
+        .spyOn(navigator, "platform", "get")
+        .mockReturnValue("Win32");
+      try {
+        const props = createFollowUpPromptBoxProps({
+          kind: "queue",
+          onStop: vi.fn(),
+        });
+        if (!props.composer) {
+          throw new Error("Expected follow-up composer props");
+        }
+        props.composer.steerActiveThreadOnEnter = setting;
+        render(<FollowUpPromptBox {...props} />);
+
+        expect(screen.getByText("Modifier submit").getAttribute("title")).toBe(
+          title,
+        );
+      } finally {
+        platformMock.mockRestore();
+      }
     },
   );
 

--- a/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
@@ -20,6 +20,7 @@ import type {
 } from "@bb/domain";
 import type { ComposerView, PluginComposerScope } from "@get-bb/plugin-sdk";
 import type { ComposerTextEffectSource } from "@/lib/composer-text-effects";
+import { modifierSubmitShortcutLabel } from "./modifier-submit-shortcut";
 import { isKeyboardFocusTarget } from "@/components/layout/useMobileVisualViewportHeight";
 import { ComposerBannersSlot } from "@/components/plugin/PluginComposerBanners";
 import {
@@ -595,6 +596,8 @@ function FollowUpPromptBoxWithComposer({
       ? composer.onSubmit
       : composer.onModifierSubmit
     : undefined;
+  const modifierSubmitHint = (action: "queue" | "steer"): string =>
+    onModifierSubmit ? `, ${modifierSubmitShortcutLabel()} to ${action}` : "";
   const executionControlsDisabled =
     (executionReadOnly ?? readOnly ?? false) || hasPendingInteraction;
   const footerStart = useMemo(
@@ -739,9 +742,9 @@ function FollowUpPromptBoxWithComposer({
               : canQueueFollowUp
                 ? steerOnPrimarySubmit
                   ? isSteeringWhenReady
-                    ? "Steer when ready (Enter)"
-                    : "Steer current run (Enter)"
-                  : "Queue follow-up (Enter)"
+                    ? `Steer when ready (Enter)${modifierSubmitHint("queue")}`
+                    : `Steer current run (Enter)${modifierSubmitHint("queue")}`
+                  : `Queue follow-up (Enter)${modifierSubmitHint("steer")}`
                 : isStopping
                   ? "Stopping run..."
                   : isLoadingExecutionOptions

--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -1449,6 +1449,60 @@ describe("PromptBoxInternal submit shortcuts", () => {
     }
   });
 
+  it("routes Control+Enter to modifier submit and labels the shortcut for the platform", () => {
+    const platformMock = vi
+      .spyOn(navigator, "platform", "get")
+      .mockReturnValue("Linux x86_64");
+    try {
+      const onModifierSubmit = vi.fn();
+      const onSubmit = vi.fn();
+      render(
+        <PromptBoxInternal
+          {...createPromptBoxProps({
+            value: "Follow up",
+            onSubmit,
+            submission: { onModifierSubmit },
+          })}
+        />,
+      );
+
+      const editor = getPromptEditorElement();
+      expect(editor.getAttribute("aria-keyshortcuts")).toBe("Control+Enter");
+      act(() => editor.focus());
+      fireEvent.keyDown(editor, {
+        key: "Enter",
+        code: "Enter",
+        ctrlKey: true,
+      });
+
+      expect(onModifierSubmit).toHaveBeenCalledOnce();
+      expect(onSubmit).not.toHaveBeenCalled();
+    } finally {
+      platformMock.mockRestore();
+    }
+  });
+
+  it("labels the modifier submit shortcut with Meta on Mac", () => {
+    const platformMock = vi
+      .spyOn(navigator, "platform", "get")
+      .mockReturnValue("MacIntel");
+    try {
+      render(
+        <PromptBoxInternal
+          {...createPromptBoxProps({
+            value: "Follow up",
+            submission: { onModifierSubmit: vi.fn() },
+          })}
+        />,
+      );
+      expect(getPromptEditorElement().getAttribute("aria-keyshortcuts")).toBe(
+        "Meta+Enter",
+      );
+    } finally {
+      platformMock.mockRestore();
+    }
+  });
+
   it("does not submit a hardware Enter that is committing IME composition", () => {
     const restoreMatchMedia = mockPointerCoarse(true);
     const restoreNavigator = mockIPadOSWebKit();

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -129,6 +129,10 @@ import {
 import { parsePromptMentionClipboardElement } from "./mentions/prompt-mention-clipboard";
 import { ComposerEditorSlot } from "./ComposerEditorSlot";
 import { QueuedEditorTypeaheadLayoutContext } from "./queued-editor-typeahead-layout";
+import {
+  isModifierSubmitKeyEvent,
+  modifierSubmitShortcutAria,
+} from "./modifier-submit-shortcut";
 
 const PROMPTBOX_MIN_HEIGHT = 68;
 const PROMPTBOX_SELECTION_REVEAL_MARGIN = 12;
@@ -1658,7 +1662,9 @@ export function PromptBoxInternal({
         attributes: {
           "aria-label": effectivePlaceholder,
           "data-placeholder": effectivePlaceholder,
-          ...(onModifierSubmit ? { "aria-keyshortcuts": "Meta+Enter" } : {}),
+          ...(onModifierSubmit
+            ? { "aria-keyshortcuts": modifierSubmitShortcutAria() }
+            : {}),
           autocomplete: "off",
           class: cn(
             "min-h-full whitespace-pre-wrap break-words outline-none",
@@ -2926,13 +2932,7 @@ export function PromptBoxInternal({
         }
       }
 
-      const isModifierSubmitKey =
-        event.key === "Enter" &&
-        event.metaKey &&
-        !event.shiftKey &&
-        !event.altKey &&
-        !event.ctrlKey;
-      if (isModifierSubmitKey && onModifierSubmit) {
+      if (isModifierSubmitKeyEvent(event) && onModifierSubmit) {
         event.preventDefault();
         submitModifierPrompt();
         return true;

--- a/apps/app/src/components/promptbox/modifier-submit-shortcut.test.ts
+++ b/apps/app/src/components/promptbox/modifier-submit-shortcut.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  isModifierSubmitKeyEvent,
+  modifierSubmitShortcutAria,
+  modifierSubmitShortcutLabel,
+} from "./modifier-submit-shortcut";
+
+function mockPlatform(platform: string): () => void {
+  const originalNavigator = globalThis.navigator;
+  vi.stubGlobal("navigator", { ...originalNavigator, platform });
+  return () => vi.unstubAllGlobals();
+}
+
+describe("modifier submit shortcut", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("accepts Control+Enter and Meta+Enter without other modifiers", () => {
+    const base = {
+      key: "Enter",
+      metaKey: false,
+      ctrlKey: false,
+      altKey: false,
+      shiftKey: false,
+    };
+    expect(isModifierSubmitKeyEvent({ ...base, ctrlKey: true })).toBe(true);
+    expect(isModifierSubmitKeyEvent({ ...base, metaKey: true })).toBe(true);
+    expect(isModifierSubmitKeyEvent(base)).toBe(false);
+    expect(
+      isModifierSubmitKeyEvent({ ...base, ctrlKey: true, shiftKey: true }),
+    ).toBe(false);
+    expect(
+      isModifierSubmitKeyEvent({ ...base, metaKey: true, altKey: true }),
+    ).toBe(false);
+    expect(isModifierSubmitKeyEvent({ ...base, key: "a", ctrlKey: true })).toBe(
+      false,
+    );
+  });
+
+  it("presents the shortcut as Control on Windows and Linux", () => {
+    mockPlatform("Linux x86_64");
+    expect(modifierSubmitShortcutLabel()).toBe("Ctrl + Enter");
+    expect(modifierSubmitShortcutAria()).toBe("Control+Enter");
+  });
+
+  it("presents the shortcut as Command on Mac", () => {
+    mockPlatform("MacIntel");
+    expect(modifierSubmitShortcutLabel()).toBe("⌘ Enter");
+    expect(modifierSubmitShortcutAria()).toBe("Meta+Enter");
+  });
+});

--- a/apps/app/src/components/promptbox/modifier-submit-shortcut.ts
+++ b/apps/app/src/components/promptbox/modifier-submit-shortcut.ts
@@ -1,0 +1,41 @@
+import type { AppShortcut } from "@bb/domain";
+import {
+  formatAppShortcut,
+  formatAppShortcutAria,
+} from "@/lib/app-keybindings";
+
+const MODIFIER_SUBMIT_SHORTCUT: AppShortcut = {
+  key: "Enter",
+  mod: true,
+  meta: false,
+  control: false,
+  alt: false,
+  shift: false,
+};
+
+function currentPlatform(): string {
+  return typeof navigator === "undefined" ? "" : navigator.platform;
+}
+
+export function isModifierSubmitKeyEvent(event: {
+  key: string;
+  metaKey: boolean;
+  ctrlKey: boolean;
+  altKey: boolean;
+  shiftKey: boolean;
+}): boolean {
+  return (
+    event.key === "Enter" &&
+    (event.metaKey || event.ctrlKey) &&
+    !event.altKey &&
+    !event.shiftKey
+  );
+}
+
+export function modifierSubmitShortcutLabel(): string {
+  return formatAppShortcut(MODIFIER_SUBMIT_SHORTCUT, currentPlatform());
+}
+
+export function modifierSubmitShortcutAria(): string {
+  return formatAppShortcutAria(MODIFIER_SUBMIT_SHORTCUT, currentPlatform());
+}

--- a/apps/app/src/views/SettingsView.tsx
+++ b/apps/app/src/views/SettingsView.tsx
@@ -587,13 +587,13 @@ const FOLLOW_UP_BEHAVIOR_OPTIONS = [
     steerOnEnter: false,
     label: "Queue",
     description:
-      "Enter adds a follow-up. It runs when the agent stops. Command+Enter steers the run.",
+      "Enter adds a follow-up. It runs when the agent stops. Command+Enter (Ctrl+Enter on Windows and Linux) steers the run.",
   },
   {
     steerOnEnter: true,
     label: "Steer",
     description:
-      "Enter steers the run now. Command+Enter adds a follow-up for later.",
+      "Enter steers the run now. Command+Enter (Ctrl+Enter on Windows and Linux) adds a follow-up for later.",
   },
 ] as const;
 const STREAMER_MODE_SETTING_LABEL = "Streamer mode";

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -221,7 +221,8 @@ active-thread composer shortcuts when no typeahead suggestion is active. A
 queued message waits and then runs when the agent stops. A steer message goes
 to the agent during the current run. The picker defaults to "Steer" for a new
 install: Enter steers and Command+Enter queues. "Queue" swaps them: Enter
-queues and Command+Enter steers. An earlier install with saved settings or work
+queues and Command+Enter steers. Ctrl+Enter is the same modifier shortcut on
+Windows and Linux. An earlier install with saved settings or work
 keeps "Queue" because a one-time migration stamps the old default onto it. Set
 it with
 `bb settings general steerActiveThreadOnEnter <true|false>`, where `true` is


### PR DESCRIPTION
## Human comments

## What was wrong

The follow-up prompt box only recognised Meta+Enter as the modifier submit (`PromptBoxInternal.tsx` explicitly required `metaKey` and rejected `ctrlKey`). On Windows and Linux there was no working key for the secondary action: in Queue mode nothing steered, in Steer mode nothing queued. Worse, Ctrl+Enter fell through to the plain-submit branch, which only checks Shift, so it silently performed the primary action instead. The `aria-keyshortcuts` attribute, the Settings picker descriptions, and `docs/configuration.md` all described the shortcut as Command+Enter only. The tasks plugin editor already accepted either Meta or Ctrl plus Enter; the composer was the odd one out.

## What changed

- `apps/app/src/components/promptbox/modifier-submit-shortcut.ts` (new): `isModifierSubmitKeyEvent` accepts Enter with Meta or Ctrl and no Alt/Shift, plus platform-aware label and aria helpers built on the existing `formatAppShortcut`/`formatAppShortcutAria` mapping ("⌘ Enter" / "Meta+Enter" on Mac, "Ctrl + Enter" / "Control+Enter" elsewhere).
- `PromptBoxInternal.tsx`: uses the shared key check and sets `aria-keyshortcuts` from the platform helper instead of a hard-coded "Meta+Enter".
- `FollowUpPromptBox.tsx`: the queue/steer submit tooltips now include the modifier shortcut and what it does, e.g. "Queue follow-up (Enter), Ctrl + Enter to steer", shown only when a modifier submit is available.
- `SettingsView.tsx` and `docs/configuration.md`: mention Ctrl+Enter on Windows and Linux alongside Command+Enter.

No wire or CLI changes.

## How you verified

- New `modifier-submit-shortcut.test.ts` covers key matching (Ctrl+Shift+Enter and Meta+Alt+Enter rejected) and the platform labels.
- New `PromptBoxInternal.test.tsx` cases: Ctrl+Enter on a Linux platform calls `onModifierSubmit` and not `onSubmit`, and `aria-keyshortcuts` reads "Control+Enter" on Linux and "Meta+Enter" on Mac. The Ctrl+Enter case fails before this change (it called `onSubmit`).
- New `FollowUpPromptBox.test.tsx` cases assert the tooltip text for both steer-on-Enter settings on Win32.
- `pnpm exec vitest run` on the three promptbox test files: 163 passed.
- `pnpm exec turbo run typecheck lint --filter=@bb/app`: passes.

> AGENT GENERATED
