### PR TITLE
Preview thread-storage and Markdown artifacts inline

### DIFF
--- a/plugins/inline-vis/PLUGIN_OVERVIEW.md
+++ b/plugins/inline-vis/PLUGIN_OVERVIEW.md
@@ -1,21 +1,27 @@
-See an agent's chart, demo, or report in the conversation without opening a side panel. The agent writes an HTML file to the workspace. The plugin shows that file inside the assistant message.
+See an agent's chart, demo, or report in the conversation without opening a side panel. The agent writes an HTML file to the workspace or the thread's storage directory. The plugin shows that file inside the assistant message.
 
 ## What you get
 
 - A live preview card in the message. Scripts and styles in the file run.
 - A default viewport height of 224 pixels. The agent can set a height from 120 to 1200 pixels.
-- A header action that opens the source HTML file in the workspace viewer.
+- A header action that opens workspace source HTML in the workspace viewer. Thread-storage previews omit this action.
 - A clear inline error when the file is missing, too large, or not HTML.
 
 ## How it works
 
-The agent emits a message directive that names a workspace-relative `.html` or `.htm` file:
+The agent emits a message directive that names a source-relative `.html` or `.htm` file. Omitting `source` defaults to the workspace, and explicit `source="workspace"` is equivalent:
 
 ```text
 ::inline-vis{file="charts/out.html" height="480"}
 ```
 
-The plugin confirms the file exists in the thread workspace before it renders. Files must be UTF-8 text with a maximum size of 5 MiB. Relative assets next to the file load as usual.
+Read-only artifacts in the thread's storage directory can be rendered without resolving the workspace:
+
+```text
+::inline-vis{source="thread-storage" file="reports/result.html"}
+```
+
+The plugin confirms the file exists in the selected source before it renders. Files must be UTF-8 text with a maximum size of 5 MiB. Relative assets next to the file load as usual.
 
 The preview runs in a sandboxed iframe with an opaque origin. Scripts in the file cannot read the bb page, its cookies, or its storage.
 

--- a/plugins/inline-vis/PLUGIN_OVERVIEW.md
+++ b/plugins/inline-vis/PLUGIN_OVERVIEW.md
@@ -1,18 +1,19 @@
-See an agent's chart, demo, or report in the conversation without opening a side panel. The agent writes an HTML file to the workspace or the thread's storage directory. The plugin shows that file inside the assistant message.
+See an agent's chart, demo, report, or Markdown document in the conversation without opening a side panel. The agent writes an HTML or Markdown file to the workspace or the thread's storage directory. The plugin shows that file inside the assistant message.
 
 ## What you get
 
-- A live preview card in the message. Scripts and styles in the file run.
+- A live HTML preview or formatted Markdown document in the message.
 - A default viewport height of 224 pixels. The agent can set a height from 120 to 1200 pixels.
-- A header action that opens workspace source HTML in the workspace viewer. Thread-storage previews omit this action.
-- A clear inline error when the file is missing, too large, or not HTML.
+- A header action that opens workspace source files in the workspace viewer. Thread-storage previews omit this action.
+- A clear inline error when the file is missing, too large, or unsupported.
 
 ## How it works
 
-The agent emits a message directive that names a source-relative `.html` or `.htm` file. Omitting `source` defaults to the workspace, and explicit `source="workspace"` is equivalent:
+The agent emits a message directive that names a source-relative `.html`, `.htm`, `.md`, or `.markdown` file. Omitting `source` defaults to the workspace, and explicit `source="workspace"` is equivalent:
 
 ```text
 ::inline-vis{file="charts/out.html" height="480"}
+::inline-vis{file="reports/summary.md"}
 ```
 
 Read-only artifacts in the thread's storage directory can be rendered without resolving the workspace:
@@ -21,9 +22,9 @@ Read-only artifacts in the thread's storage directory can be rendered without re
 ::inline-vis{source="thread-storage" file="reports/result.html"}
 ```
 
-The plugin confirms the file exists in the selected source before it renders. Files must be UTF-8 text with a maximum size of 5 MiB. Relative assets next to the file load as usual.
+The plugin confirms the file exists in the selected source before it renders. Files must be UTF-8 text with a maximum size of 5 MiB. Relative assets next to HTML files load as usual.
 
-The preview runs in a sandboxed iframe with an opaque origin. Scripts in the file cannot read the bb page, its cookies, or its storage.
+HTML runs in a sandboxed iframe with an opaque origin. Scripts in the file cannot read the bb page, its cookies, or its storage. Markdown uses bb's renderer with raw HTML disabled.
 
 ## For agents
 

--- a/plugins/inline-vis/README.md
+++ b/plugins/inline-vis/README.md
@@ -7,6 +7,13 @@ Builtin plugin for the assistant **message directive** slot
 ::inline-vis{file="demo.html"}
 ```
 
+The omitted `source` defaults to `workspace`; `source="workspace"` is equivalent.
+For a read-only artifact in the current thread's storage directory, use:
+
+```text
+::inline-vis{source="thread-storage" file="reports/result.html"}
+```
+
 Set an optional iframe viewport height in pixels with `height`:
 
 ```text
@@ -17,13 +24,14 @@ The default is 224px; accepted values are whole numbers from 120 through 1200.
 
 bb replaces that leaf with this plugin's React component, which:
 
-1. Validates the untrusted `file` attribute.
-2. Calls the plugin RPC `prepareHtmlPreview` with the message `threadId` and
-   file path to validate the target and surface clean inline errors.
-3. Shows loading / error states and a header action that opens the source HTML
-   file in bb's sidebar workspace viewer.
-4. Points a sandboxed iframe at bb's path-shaped worktree preview route. This
-   matches the sidebar HTML preview: relative sibling assets work, scripts are
+1. Validates the untrusted `source` and `file` attributes.
+2. Calls the plugin RPC `prepareHtmlPreview` with the message `threadId`, source,
+   and file path to validate the target and surface clean inline errors.
+3. Shows loading / error states. Workspace previews include a header action
+   that opens the source HTML file in bb's sidebar workspace viewer;
+   thread-storage previews do not.
+4. Points a sandboxed iframe at bb's existing path-shaped worktree or thread
+   storage route. Relative sibling assets work, scripts are
    enabled, and normal web loading is allowed. The iframe keeps an opaque
    origin (no `allow-same-origin`) so scripts cannot access the bb page, its
    cookies, or storage. Remote scripts, styles, images, fonts, media, fetches,
@@ -33,16 +41,18 @@ bb replaces that leaf with this plugin's React component, which:
 ## Backend security
 
 `prepareHtmlPreview` narrows `unknown` input immediately (rejects unknown
-keys), loads the thread with `include: "environment"`, requires a live
-workspace `path` and `hostId`, confines the workspace-relative `.html`/`.htm`
-path under that root, and preflights it through `bb.sdk.files` (host-routed).
-Absolute paths, traversal, non-html extensions, missing files, non-UTF-8
-content, and files over 5 MiB are rejected. The iframe then uses bb's existing
-confined worktree preview route to serve the document and relative assets.
+keys and source values). Workspace previews load the thread with
+`include: "environment"` and require its live `path` and `hostId`. Thread
+storage previews use `bb.sdk.threads.storageLocation` instead and do not resolve
+the workspace. Both sources confine the relative `.html`/`.htm` path under the
+returned root and preflight it through `bb.sdk.files` (host-routed). Absolute
+paths, traversal, non-html extensions, missing files, non-UTF-8 content, and
+files over 5 MiB are rejected. The iframe then uses bb's existing confined
+worktree or thread-storage route to serve the document and relative assets.
 
 It ships with bb and is reconciled through the builtin plugin lifecycle. Ship
-a workspace HTML file, then ask the agent to visualize it with the directive
-(see the bundled `inline-vis` skill).
+an HTML file in either supported source, then ask the agent to visualize it
+with the directive (see the bundled `inline-vis` skill).
 
 ## Tests
 

--- a/plugins/inline-vis/README.md
+++ b/plugins/inline-vis/README.md
@@ -5,6 +5,7 @@ Builtin plugin for the assistant **message directive** slot
 
 ```text
 ::inline-vis{file="demo.html"}
+::inline-vis{file="notes.md"}
 ```
 
 The omitted `source` defaults to `workspace`; `source="workspace"` is equivalent.
@@ -14,7 +15,7 @@ For a read-only artifact in the current thread's storage directory, use:
 ::inline-vis{source="thread-storage" file="reports/result.html"}
 ```
 
-Set an optional iframe viewport height in pixels with `height`:
+Set an optional preview height in pixels with `height`:
 
 ```text
 ::inline-vis{file="demo.html" height="480"}
@@ -25,34 +26,37 @@ The default is 224px; accepted values are whole numbers from 120 through 1200.
 bb replaces that leaf with this plugin's React component, which:
 
 1. Validates the untrusted `source` and `file` attributes.
-2. Calls the plugin RPC `prepareHtmlPreview` with the message `threadId`, source,
+2. Calls the plugin RPC `preparePreview` with the message `threadId`, source,
    and file path to validate the target and surface clean inline errors.
 3. Shows loading / error states. Workspace previews include a header action
-   that opens the source HTML file in bb's sidebar workspace viewer;
-   thread-storage previews do not.
-4. Points a sandboxed iframe at bb's existing path-shaped worktree or thread
-   storage route. Relative sibling assets work, scripts are
+   that opens the source file in bb's sidebar workspace viewer; thread-storage
+   previews do not.
+4. Points HTML files at bb's existing path-shaped worktree or thread storage
+   route inside a sandboxed iframe. Relative sibling assets work, scripts are
    enabled, and normal web loading is allowed. The iframe keeps an opaque
    origin (no `allow-same-origin`) so scripts cannot access the bb page, its
    cookies, or storage. Remote scripts, styles, images, fonts, media, fetches,
    and WebSockets work subject to ordinary browser CORS, mixed-content, and
    remote-server policies.
+5. Renders Markdown files with bb's Markdown renderer. Raw HTML is disabled.
 
 ## Backend security
 
-`prepareHtmlPreview` narrows `unknown` input immediately (rejects unknown
-keys and source values). Workspace previews load the thread with
+`preparePreview` narrows `unknown` input immediately (rejects unknown keys and
+source values). Workspace previews load the thread with
 `include: "environment"` and require its live `path` and `hostId`. Thread
 storage previews use `bb.sdk.threads.storageLocation` instead and do not resolve
-the workspace. Both sources confine the relative `.html`/`.htm` path under the
-returned root and preflight it through `bb.sdk.files` (host-routed). Absolute
-paths, traversal, non-html extensions, missing files, non-UTF-8 content, and
-files over 5 MiB are rejected. The iframe then uses bb's existing confined
-worktree or thread-storage route to serve the document and relative assets.
+the workspace. Both sources confine the relative `.html`, `.htm`, `.md`, or
+`.markdown` path under the returned root and read it through `bb.sdk.files`
+(host-routed). Absolute paths, traversal, unsupported extensions, missing files,
+non-UTF-8 content, and files over 5 MiB are rejected. HTML previews then use
+bb's existing confined worktree or thread-storage route to serve the document
+and relative assets; Markdown previews render the validated content returned by
+the RPC.
 
 It ships with bb and is reconciled through the builtin plugin lifecycle. Ship
-an HTML file in either supported source, then ask the agent to visualize it
-with the directive (see the bundled `inline-vis` skill).
+a supported file in either source, then ask the agent to show it with the
+directive (see the bundled `inline-vis` skill).
 
 ## Tests
 

--- a/plugins/inline-vis/app.test.tsx
+++ b/plugins/inline-vis/app.test.tsx
@@ -39,6 +39,48 @@ describe("InlineVisDirective", () => {
     expect(slot.rpcCalls).toEqual([]);
   });
 
+  it("shows the rpc validation error for an unknown source", async () => {
+    const slot = renderSlot(
+      app.messageDirectives[0]!,
+      {
+        attributes: { file: "demo.html", source: "project" },
+        source: '::inline-vis{source="project" file="demo.html"}',
+        message,
+        openWorkspaceFile: vi.fn(() => true),
+      },
+      {
+        rpc: {
+          prepareHtmlPreview: (input) => {
+            expect(input).toEqual({
+              threadId: "thr_1",
+              file: "demo.html",
+              source: "project",
+            });
+            throw new Error(
+              'Invalid option: expected "workspace"|"thread-storage"',
+            );
+          },
+        },
+      },
+    );
+
+    const alert = await slot.findByRole("alert");
+    expect(alert.textContent).toMatch(
+      /expected "workspace"\|"thread-storage"/i,
+    );
+    expect(slot.container.querySelector("iframe")).toBeNull();
+    expect(slot.rpcCalls).toEqual([
+      {
+        method: "prepareHtmlPreview",
+        input: {
+          threadId: "thr_1",
+          file: "demo.html",
+          source: "project",
+        },
+      },
+    ]);
+  });
+
   it("uses the sidebar worktree route with an opaque-origin script sandbox", async () => {
     const openWorkspaceFile = vi.fn(() => true);
     const slot = renderSlot(
@@ -56,7 +98,7 @@ describe("InlineVisDirective", () => {
               threadId: "thr_1",
               file: "charts/demo file.html",
             });
-            return { file: "charts/demo file.html" };
+            return { file: "charts/demo file.html", source: "workspace" };
           },
         },
       },
@@ -88,9 +130,59 @@ describe("InlineVisDirective", () => {
     expect(slot.rpcCalls).toEqual([
       {
         method: "prepareHtmlPreview",
-        input: { threadId: "thr_1", file: "charts/demo file.html" },
+        input: {
+          threadId: "thr_1",
+          file: "charts/demo file.html",
+        },
       },
     ]);
+  });
+
+  it("uses the thread-storage route without a workspace action", async () => {
+    const openWorkspaceFile = vi.fn(() => true);
+    const slot = renderSlot(
+      app.messageDirectives[0]!,
+      {
+        attributes: {
+          source: "thread-storage",
+          file: "reports/result file.html",
+        },
+        source:
+          '::inline-vis{source="thread-storage" file="reports/result file.html"}',
+        message,
+        openWorkspaceFile,
+      },
+      {
+        rpc: {
+          prepareHtmlPreview: (input) => {
+            expect(input).toEqual({
+              threadId: "thr_1",
+              file: "reports/result file.html",
+              source: "thread-storage",
+            });
+            return {
+              file: "reports/result file.html",
+              source: "thread-storage",
+            };
+          },
+        },
+      },
+    );
+
+    const iframe = await waitFor(() => {
+      const el = slot.container.querySelector("iframe");
+      expect(el).toBeTruthy();
+      return el as HTMLIFrameElement;
+    });
+
+    expect(iframe.getAttribute("src")).toBe(
+      "/api/v1/threads/thr_1/thread-storage/files/reports/result%20file.html",
+    );
+    expect(iframe.getAttribute("sandbox")).toBe("allow-scripts");
+    expect(
+      slot.queryByRole("button", { name: /open .* in sidebar/i }),
+    ).toBeNull();
+    expect(openWorkspaceFile).not.toHaveBeenCalled();
   });
 
   it("uses an optional bounded height attribute", async () => {
@@ -104,7 +196,10 @@ describe("InlineVisDirective", () => {
       },
       {
         rpc: {
-          prepareHtmlPreview: () => ({ file: "demo.html" }),
+          prepareHtmlPreview: () => ({
+            file: "demo.html",
+            source: "workspace",
+          }),
         },
       },
     );
@@ -118,8 +213,14 @@ describe("InlineVisDirective", () => {
   });
 
   it("reserves the preview height while loading so the timeline does not jump", async () => {
-    let resolvePreview = (_result: { file: string }) => {};
-    const pendingPreview = new Promise<{ file: string }>((resolve) => {
+    let resolvePreview = (_result: {
+      file: string;
+      source: "workspace" | "thread-storage";
+    }) => {};
+    const pendingPreview = new Promise<{
+      file: string;
+      source: "workspace" | "thread-storage";
+    }>((resolve) => {
       resolvePreview = resolve;
     });
     const slot = renderSlot(
@@ -152,7 +253,7 @@ describe("InlineVisDirective", () => {
     const loadingHeader = loadingCard.firstElementChild!;
     const loadingHeaderHtml = loadingHeader.outerHTML;
 
-    resolvePreview({ file: "demo.html" });
+    resolvePreview({ file: "demo.html", source: "workspace" });
 
     const iframe = await waitFor(() => {
       const el = slot.container.querySelector("iframe");

--- a/plugins/inline-vis/app.test.tsx
+++ b/plugins/inline-vis/app.test.tsx
@@ -50,7 +50,7 @@ describe("InlineVisDirective", () => {
       },
       {
         rpc: {
-          prepareHtmlPreview: (input) => {
+          preparePreview: (input) => {
             expect(input).toEqual({
               threadId: "thr_1",
               file: "demo.html",
@@ -71,7 +71,7 @@ describe("InlineVisDirective", () => {
     expect(slot.container.querySelector("iframe")).toBeNull();
     expect(slot.rpcCalls).toEqual([
       {
-        method: "prepareHtmlPreview",
+        method: "preparePreview",
         input: {
           threadId: "thr_1",
           file: "demo.html",
@@ -93,12 +93,16 @@ describe("InlineVisDirective", () => {
       },
       {
         rpc: {
-          prepareHtmlPreview: (input) => {
+          preparePreview: (input) => {
             expect(input).toEqual({
               threadId: "thr_1",
               file: "charts/demo file.html",
             });
-            return { file: "charts/demo file.html", source: "workspace" };
+            return {
+              kind: "html",
+              file: "charts/demo file.html",
+              source: "workspace",
+            };
           },
         },
       },
@@ -129,7 +133,7 @@ describe("InlineVisDirective", () => {
     expect(openWorkspaceFile).toHaveBeenCalledWith("charts/demo file.html");
     expect(slot.rpcCalls).toEqual([
       {
-        method: "prepareHtmlPreview",
+        method: "preparePreview",
         input: {
           threadId: "thr_1",
           file: "charts/demo file.html",
@@ -154,13 +158,14 @@ describe("InlineVisDirective", () => {
       },
       {
         rpc: {
-          prepareHtmlPreview: (input) => {
+          preparePreview: (input) => {
             expect(input).toEqual({
               threadId: "thr_1",
               file: "reports/result file.html",
               source: "thread-storage",
             });
             return {
+              kind: "html",
               file: "reports/result file.html",
               source: "thread-storage",
             };
@@ -196,7 +201,8 @@ describe("InlineVisDirective", () => {
       },
       {
         rpc: {
-          prepareHtmlPreview: () => ({
+          preparePreview: () => ({
+            kind: "html",
             file: "demo.html",
             source: "workspace",
           }),
@@ -213,14 +219,13 @@ describe("InlineVisDirective", () => {
   });
 
   it("reserves the preview height while loading so the timeline does not jump", async () => {
-    let resolvePreview = (_result: {
+    type HtmlPreview = {
+      kind: "html";
       file: string;
       source: "workspace" | "thread-storage";
-    }) => {};
-    const pendingPreview = new Promise<{
-      file: string;
-      source: "workspace" | "thread-storage";
-    }>((resolve) => {
+    };
+    let resolvePreview = (_result: HtmlPreview) => {};
+    const pendingPreview = new Promise<HtmlPreview>((resolve) => {
       resolvePreview = resolve;
     });
     const slot = renderSlot(
@@ -233,7 +238,7 @@ describe("InlineVisDirective", () => {
       },
       {
         rpc: {
-          prepareHtmlPreview: () => pendingPreview,
+          preparePreview: () => pendingPreview,
         },
       },
     );
@@ -253,7 +258,7 @@ describe("InlineVisDirective", () => {
     const loadingHeader = loadingCard.firstElementChild!;
     const loadingHeaderHtml = loadingHeader.outerHTML;
 
-    resolvePreview({ file: "demo.html", source: "workspace" });
+    resolvePreview({ kind: "html", file: "demo.html", source: "workspace" });
 
     const iframe = await waitFor(() => {
       const el = slot.container.querySelector("iframe");
@@ -273,6 +278,154 @@ describe("InlineVisDirective", () => {
       true,
     );
     expect(loadingHeaderHtml).toContain("size-5");
+  });
+
+  it("renders a Markdown document with the host renderer and no iframe", async () => {
+    const openWorkspaceFile = vi.fn(() => true);
+    const slot = renderSlot(
+      app.messageDirectives[0]!,
+      {
+        attributes: { file: "reports/notes.md" },
+        source: '::inline-vis{file="reports/notes.md"}',
+        message,
+        openWorkspaceFile,
+      },
+      {
+        rpc: {
+          preparePreview: (input) => {
+            expect(input).toEqual({
+              threadId: "thr_1",
+              file: "reports/notes.md",
+            });
+            return {
+              kind: "markdown",
+              file: "reports/notes.md",
+              source: "workspace",
+              content: "# Notes\n\nReady for review.",
+            };
+          },
+        },
+      },
+    );
+
+    const markdown = await slot.findByTestId("bb-markdown");
+    expect(markdown.textContent).toBe("# Notes\n\nReady for review.");
+    expect(slot.container.querySelector("iframe")).toBeNull();
+    expect(markdown.parentElement?.style.height).toBe("224px");
+    expect(markdown.parentElement?.className).toContain("overflow-auto");
+
+    fireEvent.click(
+      slot.getByRole("button", {
+        name: "Open reports/notes.md in sidebar",
+      }),
+    );
+    expect(openWorkspaceFile).toHaveBeenCalledWith("reports/notes.md");
+  });
+
+  it("renders thread-storage Markdown without a workspace action", async () => {
+    const openWorkspaceFile = vi.fn(() => true);
+    const slot = renderSlot(
+      app.messageDirectives[0]!,
+      {
+        attributes: { source: "thread-storage", file: "reports/notes.md" },
+        source: '::inline-vis{source="thread-storage" file="reports/notes.md"}',
+        message,
+        openWorkspaceFile,
+      },
+      {
+        rpc: {
+          preparePreview: () => ({
+            kind: "markdown",
+            file: "reports/notes.md",
+            source: "thread-storage",
+            content: "# Notes",
+          }),
+        },
+      },
+    );
+
+    const markdown = await slot.findByTestId("bb-markdown");
+    expect(markdown.textContent).toBe("# Notes");
+    expect(slot.container.querySelector("iframe")).toBeNull();
+    expect(
+      slot.queryByRole("button", { name: /open .* in sidebar/i }),
+    ).toBeNull();
+    expect(openWorkspaceFile).not.toHaveBeenCalled();
+  });
+
+  it("uses an optional bounded height for Markdown", async () => {
+    const slot = renderSlot(
+      app.messageDirectives[0]!,
+      {
+        attributes: { file: "notes.md", height: "480" },
+        source: '::inline-vis{file="notes.md" height="480"}',
+        message,
+        openWorkspaceFile: null,
+      },
+      {
+        rpc: {
+          preparePreview: () => ({
+            kind: "markdown",
+            file: "notes.md",
+            source: "workspace",
+            content: "# Notes",
+          }),
+        },
+      },
+    );
+
+    const markdown = await slot.findByTestId("bb-markdown");
+    expect(markdown.parentElement?.style.height).toBe("480px");
+  });
+
+  it("reserves the Markdown preview height while loading", async () => {
+    type MarkdownPreview = {
+      kind: "markdown";
+      file: string;
+      source: "workspace";
+      content: string;
+    };
+    let resolvePreview = (_result: MarkdownPreview) => {};
+    const pendingPreview = new Promise<MarkdownPreview>((resolve) => {
+      resolvePreview = resolve;
+    });
+    const slot = renderSlot(
+      app.messageDirectives[0]!,
+      {
+        attributes: { file: "notes.md", height: "480" },
+        source: '::inline-vis{file="notes.md" height="480"}',
+        message,
+        openWorkspaceFile: vi.fn(() => true),
+      },
+      {
+        rpc: {
+          preparePreview: () => pendingPreview,
+        },
+      },
+    );
+
+    const loading = await waitFor(() => {
+      const el = slot.container.querySelector('[aria-busy="true"]');
+      if (!(el instanceof HTMLElement)) {
+        throw new Error("Expected the inline visualization loader to render");
+      }
+      return el;
+    });
+    expect(loading.style.height).toBe("480px");
+    const loadingCard = loading.parentElement!;
+
+    resolvePreview({
+      kind: "markdown",
+      file: "notes.md",
+      source: "workspace",
+      content: "# Notes",
+    });
+
+    const markdown = await slot.findByTestId("bb-markdown");
+    const markdownBody = markdown.parentElement!;
+    expect(markdownBody.style.height).toBe("480px");
+    expect(slot.queryByRole("status")).toBeNull();
+    expect(markdownBody.parentElement!.className).toBe(loadingCard.className);
   });
 
   it("rejects an invalid height without calling rpc", async () => {
@@ -305,15 +458,15 @@ describe("InlineVisDirective", () => {
       },
       {
         rpc: {
-          prepareHtmlPreview: () => {
-            throw new Error("HTML file not found: missing.html");
+          preparePreview: () => {
+            throw new Error("Preview file not found: missing.html");
           },
         },
       },
     );
 
     const alert = await slot.findByRole("alert");
-    expect(alert.textContent).toMatch(/HTML file not found: missing\.html/);
+    expect(alert.textContent).toMatch(/Preview file not found: missing\.html/);
     expect(slot.container.querySelector("iframe")).toBeNull();
   });
 });

--- a/plugins/inline-vis/app.tsx
+++ b/plugins/inline-vis/app.tsx
@@ -8,11 +8,24 @@ import {
 } from "@get-bb/plugin-sdk/app";
 import type { inlineVisRpcContract } from "./server.js";
 
+type PreviewSource = "workspace" | "thread-storage";
+
+const PREVIEW_SOURCE_CONFIG = {
+  workspace: { route: "worktree/files", opensWorkspace: true },
+  "thread-storage": {
+    route: "thread-storage/files",
+    opensWorkspace: false,
+  },
+} as const satisfies Record<
+  PreviewSource,
+  { route: string; opensWorkspace: boolean }
+>;
+
 type LoadState =
   | { status: "missing-file" }
   | { status: "invalid-height"; message: string }
   | { status: "loading"; file: string }
-  | { status: "ready"; file: string }
+  | { status: "ready"; file: string; source: PreviewSource }
   | { status: "error"; file: string; message: string };
 
 const DEFAULT_HEIGHT_PX = 224;
@@ -23,8 +36,13 @@ function encodePathSegments(file: string): string {
   return file.split("/").map(encodeURIComponent).join("/");
 }
 
-function buildWorktreePreviewUrl(threadId: string, file: string): string {
-  return `/api/v1/threads/${encodeURIComponent(threadId)}/worktree/files/${encodePathSegments(file)}`;
+function buildPreviewUrl(
+  threadId: string,
+  file: string,
+  source: PreviewSource,
+): string {
+  const route = PREVIEW_SOURCE_CONFIG[source].route;
+  return `/api/v1/threads/${encodeURIComponent(threadId)}/${route}/${encodePathSegments(file)}`;
 }
 
 function parsePreviewHeight(value: string | undefined): number | null {
@@ -70,6 +88,7 @@ function InlineVisDirective({
 }: PluginMessageDirectiveProps) {
   const rpc = useRpc<typeof inlineVisRpcContract>();
   const fileAttr = attributes.file?.trim() ?? "";
+  const sourceAttr = attributes.source;
   const heightAttr = attributes.height;
   const previewHeight = parsePreviewHeight(heightAttr);
   const heightError =
@@ -93,7 +112,6 @@ function InlineVisDirective({
       setState({ status: "missing-file" });
       return;
     }
-
     let cancelled = false;
     setState({ status: "loading", file: fileAttr });
 
@@ -102,11 +120,13 @@ function InlineVisDirective({
         const result = await rpc.call("prepareHtmlPreview", {
           threadId: message.threadId,
           file: fileAttr,
+          ...(sourceAttr === undefined ? {} : { source: sourceAttr }),
         });
         if (cancelled) return;
         setState({
           status: "ready",
           file: result.file,
+          source: result.source,
         });
       } catch (error) {
         if (cancelled) return;
@@ -121,7 +141,7 @@ function InlineVisDirective({
     return () => {
       cancelled = true;
     };
-  }, [fileAttr, heightError, message.threadId, rpc]);
+  }, [fileAttr, heightError, message.threadId, rpc, sourceAttr]);
 
   if (state.status === "missing-file") {
     return (
@@ -183,13 +203,18 @@ function InlineVisDirective({
     );
   }
 
-  const previewUrl = buildWorktreePreviewUrl(message.threadId, state.file);
+  const sourceConfig = PREVIEW_SOURCE_CONFIG[state.source];
+  const previewUrl = buildPreviewUrl(
+    message.threadId,
+    state.file,
+    state.source,
+  );
 
   return (
     <PreviewCard
       file={state.file}
       action={
-        openWorkspaceFile === null ? null : (
+        !sourceConfig.opensWorkspace || openWorkspaceFile === null ? null : (
           <button
             type="button"
             aria-label={`Open ${state.file} in sidebar`}

--- a/plugins/inline-vis/app.tsx
+++ b/plugins/inline-vis/app.tsx
@@ -3,6 +3,7 @@ import { Icon } from "@bb/shared-ui/icon";
 import { Skeleton } from "@bb/shared-ui/skeleton";
 import {
   definePluginApp,
+  Markdown,
   useRpc,
   type PluginMessageDirectiveProps,
 } from "@get-bb/plugin-sdk/app";
@@ -25,7 +26,14 @@ type LoadState =
   | { status: "missing-file" }
   | { status: "invalid-height"; message: string }
   | { status: "loading"; file: string }
-  | { status: "ready"; file: string; source: PreviewSource }
+  | { status: "ready"; kind: "html"; file: string; source: PreviewSource }
+  | {
+      status: "ready";
+      kind: "markdown";
+      file: string;
+      source: PreviewSource;
+      content: string;
+    }
   | { status: "error"; file: string; message: string };
 
 const DEFAULT_HEIGHT_PX = 224;
@@ -117,17 +125,13 @@ function InlineVisDirective({
 
     void (async () => {
       try {
-        const result = await rpc.call("prepareHtmlPreview", {
+        const result = await rpc.call("preparePreview", {
           threadId: message.threadId,
           file: fileAttr,
           ...(sourceAttr === undefined ? {} : { source: sourceAttr }),
         });
         if (cancelled) return;
-        setState({
-          status: "ready",
-          file: result.file,
-          source: result.source,
-        });
+        setState({ status: "ready", ...result });
       } catch (error) {
         if (cancelled) return;
         setState({
@@ -204,11 +208,6 @@ function InlineVisDirective({
   }
 
   const sourceConfig = PREVIEW_SOURCE_CONFIG[state.source];
-  const previewUrl = buildPreviewUrl(
-    message.threadId,
-    state.file,
-    state.source,
-  );
 
   return (
     <PreviewCard
@@ -229,13 +228,22 @@ function InlineVisDirective({
         )
       }
     >
-      <iframe
-        title={`inline-vis: ${state.file}`}
-        src={previewUrl}
-        sandbox="allow-scripts"
-        style={{ height: previewHeight ?? DEFAULT_HEIGHT_PX }}
-        className="block w-full border-0 bg-background"
-      />
+      {state.kind === "markdown" ? (
+        <div
+          style={{ height: previewHeight ?? DEFAULT_HEIGHT_PX }}
+          className="overflow-auto p-3"
+        >
+          <Markdown content={state.content} />
+        </div>
+      ) : (
+        <iframe
+          title={`inline-vis: ${state.file}`}
+          src={buildPreviewUrl(message.threadId, state.file, state.source)}
+          sandbox="allow-scripts"
+          style={{ height: previewHeight ?? DEFAULT_HEIGHT_PX }}
+          className="block w-full border-0 bg-background"
+        />
+      )}
     </PreviewCard>
   );
 }

--- a/plugins/inline-vis/package.json
+++ b/plugins/inline-vis/package.json
@@ -3,13 +3,13 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "description": "Render workspace HTML visualizations inline in assistant messages.",
+  "description": "Render workspace or thread-storage HTML visualizations inline in assistant messages.",
   "engines": {
     "bb": ">=0.0"
   },
   "bb": {
     "name": "Inline visualizations",
-    "description": "Render workspace HTML visualizations inline in assistant messages.",
+    "description": "Render workspace or thread-storage HTML visualizations inline in assistant messages.",
     "branding": {
       "icon": "AppWindow"
     },

--- a/plugins/inline-vis/package.json
+++ b/plugins/inline-vis/package.json
@@ -3,13 +3,13 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "description": "Render workspace or thread-storage HTML visualizations inline in assistant messages.",
+  "description": "Render workspace or thread-storage HTML visualizations and Markdown documents inline in assistant messages.",
   "engines": {
     "bb": ">=0.0"
   },
   "bb": {
     "name": "Inline visualizations",
-    "description": "Render workspace or thread-storage HTML visualizations inline in assistant messages.",
+    "description": "Render workspace or thread-storage HTML visualizations and Markdown documents inline in assistant messages.",
     "branding": {
       "icon": "AppWindow"
     },

--- a/plugins/inline-vis/server.test.ts
+++ b/plugins/inline-vis/server.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { createFakePluginHost } from "@get-bb/plugin-sdk/testing";
 import plugin, {
   MAX_HTML_BYTES,
-  requireWorkspaceHtmlFile,
+  requireRelativeHtmlFile,
   resolveContainedHtmlPath,
 } from "./server";
 
@@ -22,7 +22,10 @@ function threadWithEnv(overrides?: { path?: string | null; hostId?: string }) {
 }
 
 async function load(sdk: {
-  threads?: { get: (args: unknown) => unknown };
+  threads?: {
+    get?: (args: unknown) => unknown;
+    storageLocation?: (args: unknown) => unknown;
+  };
   files?: { read: (args: unknown) => unknown };
 }) {
   const host = createFakePluginHost({
@@ -33,25 +36,25 @@ async function load(sdk: {
   return host;
 }
 
-describe("requireWorkspaceHtmlFile", () => {
+describe("requireRelativeHtmlFile", () => {
   it("accepts nested html paths", () => {
-    expect(requireWorkspaceHtmlFile("demo.html")).toBe("demo.html");
-    expect(requireWorkspaceHtmlFile("charts/out.HTML")).toBe("charts/out.HTML");
+    expect(requireRelativeHtmlFile("demo.html")).toBe("demo.html");
+    expect(requireRelativeHtmlFile("charts/out.HTML")).toBe("charts/out.HTML");
   });
 
   it("rejects absolute, traversal, and non-html paths", () => {
-    expect(() => requireWorkspaceHtmlFile("/etc/passwd.html")).toThrow(
-      /workspace-relative/,
+    expect(() => requireRelativeHtmlFile("/etc/passwd.html")).toThrow(
+      /source-relative/,
     );
-    expect(() => requireWorkspaceHtmlFile("../secret.html")).toThrow(
+    expect(() => requireRelativeHtmlFile("../secret.html")).toThrow(
       /traversal|escape/,
     );
-    expect(() => requireWorkspaceHtmlFile("..\\secret.html")).toThrow();
-    expect(() => requireWorkspaceHtmlFile("charts/../secret.html")).toThrow(
+    expect(() => requireRelativeHtmlFile("..\\secret.html")).toThrow();
+    expect(() => requireRelativeHtmlFile("charts/../secret.html")).toThrow(
       /traversal/,
     );
-    expect(() => requireWorkspaceHtmlFile("demo.md")).toThrow(/\.html/);
-    expect(() => requireWorkspaceHtmlFile("")).toThrow(/non-empty/);
+    expect(() => requireRelativeHtmlFile("demo.md")).toThrow(/\.html/);
+    expect(() => requireRelativeHtmlFile("")).toThrow(/non-empty/);
   });
 });
 
@@ -85,6 +88,24 @@ describe("prepareHtmlPreview rpc", () => {
       code: "invalid_input",
       issues: expect.any(Array),
     });
+  });
+
+  it("rejects an unknown source during input validation", async () => {
+    const { harness } = await load({
+      threads: { get: () => threadWithEnv() },
+      files: { read: () => ({ content: "", contentEncoding: "utf8" }) },
+    });
+    await expect(
+      harness.callRpc("prepareHtmlPreview", {
+        threadId: "thr_1",
+        file: "demo.html",
+        source: "project",
+      }),
+    ).rejects.toMatchObject({
+      code: "invalid_input",
+      issues: expect.any(Array),
+    });
+    expect(harness.sdk.calls).toHaveLength(0);
   });
 
   it("rejects missing fields and non-object input", async () => {
@@ -158,8 +179,52 @@ describe("prepareHtmlPreview rpc", () => {
     const result = await harness.callRpc("prepareHtmlPreview", {
       threadId: "thr_1",
       file: "charts/demo.html",
+      source: "workspace",
     });
-    expect(result).toEqual({ file: "charts/demo.html" });
+    expect(result).toEqual({
+      file: "charts/demo.html",
+      source: "workspace",
+    });
+    expect(harness.sdk.callsTo("files.read")).toHaveLength(1);
+  });
+
+  it("reads thread storage without resolving the workspace", async () => {
+    const storageRootPath = "/thread-storage/thr_1";
+    const { harness } = await load({
+      threads: {
+        storageLocation: (args) => {
+          expect(args).toEqual({ threadId: "thr_1" });
+          return { hostId: HOST_ID, storageRootPath };
+        },
+      },
+      files: {
+        read: (args) => {
+          expect(args).toEqual({
+            path: path.resolve(storageRootPath, "reports/result.html"),
+            rootPath: storageRootPath,
+            hostId: HOST_ID,
+          });
+          return {
+            content: "<html><body>ok</body></html>",
+            contentEncoding: "utf8",
+            sizeBytes: 32,
+            sha256: "abc",
+          };
+        },
+      },
+    });
+
+    const result = await harness.callRpc("prepareHtmlPreview", {
+      threadId: "thr_1",
+      file: "reports/result.html",
+      source: "thread-storage",
+    });
+    expect(result).toEqual({
+      file: "reports/result.html",
+      source: "thread-storage",
+    });
+    expect(harness.sdk.callsTo("threads.storageLocation")).toHaveLength(1);
+    expect(harness.sdk.callsTo("threads.get")).toHaveLength(0);
     expect(harness.sdk.callsTo("files.read")).toHaveLength(1);
   });
 
@@ -177,7 +242,7 @@ describe("prepareHtmlPreview rpc", () => {
         threadId: "thr_1",
         file: "/tmp/x.html",
       }),
-    ).rejects.toThrow(/workspace-relative/);
+    ).rejects.toThrow(/source-relative/);
     await expect(
       harness.callRpc("prepareHtmlPreview", {
         threadId: "thr_1",

--- a/plugins/inline-vis/server.test.ts
+++ b/plugins/inline-vis/server.test.ts
@@ -2,9 +2,9 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { createFakePluginHost } from "@get-bb/plugin-sdk/testing";
 import plugin, {
-  MAX_HTML_BYTES,
-  requireRelativeHtmlFile,
-  resolveContainedHtmlPath,
+  MAX_PREVIEW_BYTES,
+  requireRelativePreviewFile,
+  resolveContainedPreviewPath,
 } from "./server";
 
 const ROOT = "/workspace/project";
@@ -36,50 +36,128 @@ async function load(sdk: {
   return host;
 }
 
-describe("requireRelativeHtmlFile", () => {
-  it("accepts nested html paths", () => {
-    expect(requireRelativeHtmlFile("demo.html")).toBe("demo.html");
-    expect(requireRelativeHtmlFile("charts/out.HTML")).toBe("charts/out.HTML");
+describe("requireRelativePreviewFile", () => {
+  it("accepts nested preview paths", () => {
+    expect(requireRelativePreviewFile("demo.html")).toBe("demo.html");
+    expect(requireRelativePreviewFile("charts/out.HTML")).toBe(
+      "charts/out.HTML",
+    );
+    expect(requireRelativePreviewFile("notes.md")).toBe("notes.md");
+    expect(requireRelativePreviewFile("docs/summary.MARKDOWN")).toBe(
+      "docs/summary.MARKDOWN",
+    );
   });
 
-  it("rejects absolute, traversal, and non-html paths", () => {
-    expect(() => requireRelativeHtmlFile("/etc/passwd.html")).toThrow(
+  it("rejects absolute, traversal, and unsupported paths", () => {
+    expect(() => requireRelativePreviewFile("/etc/passwd.html")).toThrow(
       /source-relative/,
     );
-    expect(() => requireRelativeHtmlFile("../secret.html")).toThrow(
+    expect(() => requireRelativePreviewFile("../secret.html")).toThrow(
       /traversal|escape/,
     );
-    expect(() => requireRelativeHtmlFile("..\\secret.html")).toThrow();
-    expect(() => requireRelativeHtmlFile("charts/../secret.html")).toThrow(
+    expect(() => requireRelativePreviewFile("..\\secret.html")).toThrow();
+    expect(() => requireRelativePreviewFile("charts/../secret.html")).toThrow(
       /traversal/,
     );
-    expect(() => requireRelativeHtmlFile("demo.md")).toThrow(/\.html/);
-    expect(() => requireRelativeHtmlFile("")).toThrow(/non-empty/);
+    expect(() => requireRelativePreviewFile("demo.txt")).toThrow(/\.html/);
+    expect(() => requireRelativePreviewFile("notes.mdx")).toThrow(/\.md/);
+    expect(() => requireRelativePreviewFile("")).toThrow(/non-empty/);
   });
 });
 
-describe("resolveContainedHtmlPath", () => {
+describe("resolveContainedPreviewPath", () => {
   it("resolves under the root", () => {
-    expect(resolveContainedHtmlPath(ROOT, "demo.html")).toBe(
+    expect(resolveContainedPreviewPath(ROOT, "demo.html")).toBe(
       path.resolve(ROOT, "demo.html"),
     );
   });
 
   it("rejects resolved paths outside the root", () => {
     expect(() =>
-      resolveContainedHtmlPath(ROOT, path.join("..", "outside.html")),
+      resolveContainedPreviewPath(ROOT, path.join("..", "outside.html")),
     ).toThrow(/escape/);
   });
 });
 
-describe("prepareHtmlPreview rpc", () => {
+describe("preparePreview rpc", () => {
+  it("returns Markdown content for a workspace document", async () => {
+    const { harness } = await load({
+      threads: { get: () => threadWithEnv() },
+      files: {
+        read: (args) => {
+          expect(args).toEqual({
+            path: path.resolve(ROOT, "notes.md"),
+            rootPath: ROOT,
+            hostId: HOST_ID,
+          });
+          return {
+            content: "# Notes\n\nReady for review.",
+            contentEncoding: "utf8",
+            sizeBytes: 26,
+            sha256: "abc",
+          };
+        },
+      },
+    });
+
+    await expect(
+      harness.callRpc("preparePreview", {
+        threadId: "thr_1",
+        file: "notes.md",
+      }),
+    ).resolves.toEqual({
+      kind: "markdown",
+      file: "notes.md",
+      source: "workspace",
+      content: "# Notes\n\nReady for review.",
+    });
+  });
+
+  it("returns Markdown content for a thread-storage document", async () => {
+    const storageRootPath = "/thread-storage/thr_1";
+    const { harness } = await load({
+      threads: {
+        storageLocation: () => ({ hostId: HOST_ID, storageRootPath }),
+      },
+      files: {
+        read: (args) => {
+          expect(args).toEqual({
+            path: path.resolve(storageRootPath, "reports/summary.markdown"),
+            rootPath: storageRootPath,
+            hostId: HOST_ID,
+          });
+          return {
+            content: "# Report",
+            contentEncoding: "utf8",
+            sizeBytes: 8,
+            sha256: "abc",
+          };
+        },
+      },
+    });
+
+    await expect(
+      harness.callRpc("preparePreview", {
+        threadId: "thr_1",
+        file: "reports/summary.markdown",
+        source: "thread-storage",
+      }),
+    ).resolves.toEqual({
+      kind: "markdown",
+      file: "reports/summary.markdown",
+      source: "thread-storage",
+      content: "# Report",
+    });
+    expect(harness.sdk.callsTo("threads.get")).toHaveLength(0);
+  });
+
   it("rejects unknown input fields immediately", async () => {
     const { harness } = await load({
       threads: { get: () => threadWithEnv() },
       files: { read: () => ({ content: "", contentEncoding: "utf8" }) },
     });
     await expect(
-      harness.callRpc("prepareHtmlPreview", {
+      harness.callRpc("preparePreview", {
         threadId: "thr_1",
         file: "demo.html",
         extra: true,
@@ -96,7 +174,7 @@ describe("prepareHtmlPreview rpc", () => {
       files: { read: () => ({ content: "", contentEncoding: "utf8" }) },
     });
     await expect(
-      harness.callRpc("prepareHtmlPreview", {
+      harness.callRpc("preparePreview", {
         threadId: "thr_1",
         file: "demo.html",
         source: "project",
@@ -113,20 +191,20 @@ describe("prepareHtmlPreview rpc", () => {
       threads: { get: () => threadWithEnv() },
       files: { read: () => ({ content: "", contentEncoding: "utf8" }) },
     });
+    await expect(harness.callRpc("preparePreview", null)).rejects.toMatchObject(
+      {
+        code: "invalid_input",
+        issues: expect.any(Array),
+      },
+    );
     await expect(
-      harness.callRpc("prepareHtmlPreview", null),
+      harness.callRpc("preparePreview", { threadId: "thr_1" }),
     ).rejects.toMatchObject({
       code: "invalid_input",
       issues: expect.any(Array),
     });
     await expect(
-      harness.callRpc("prepareHtmlPreview", { threadId: "thr_1" }),
-    ).rejects.toMatchObject({
-      code: "invalid_input",
-      issues: expect.any(Array),
-    });
-    await expect(
-      harness.callRpc("prepareHtmlPreview", { file: "demo.html" }),
+      harness.callRpc("preparePreview", { file: "demo.html" }),
     ).rejects.toMatchObject({
       code: "invalid_input",
       issues: expect.any(Array),
@@ -141,7 +219,7 @@ describe("prepareHtmlPreview rpc", () => {
       files: { read: () => ({ content: "<p>x</p>", contentEncoding: "utf8" }) },
     });
     await expect(
-      harness.callRpc("prepareHtmlPreview", {
+      harness.callRpc("preparePreview", {
         threadId: "thr_1",
         file: "demo.html",
       }),
@@ -176,12 +254,13 @@ describe("prepareHtmlPreview rpc", () => {
       },
     });
 
-    const result = await harness.callRpc("prepareHtmlPreview", {
+    const result = await harness.callRpc("preparePreview", {
       threadId: "thr_1",
       file: "charts/demo.html",
       source: "workspace",
     });
     expect(result).toEqual({
+      kind: "html",
       file: "charts/demo.html",
       source: "workspace",
     });
@@ -214,12 +293,13 @@ describe("prepareHtmlPreview rpc", () => {
       },
     });
 
-    const result = await harness.callRpc("prepareHtmlPreview", {
+    const result = await harness.callRpc("preparePreview", {
       threadId: "thr_1",
       file: "reports/result.html",
       source: "thread-storage",
     });
     expect(result).toEqual({
+      kind: "html",
       file: "reports/result.html",
       source: "thread-storage",
     });
@@ -238,17 +318,23 @@ describe("prepareHtmlPreview rpc", () => {
       },
     });
     await expect(
-      harness.callRpc("prepareHtmlPreview", {
+      harness.callRpc("preparePreview", {
         threadId: "thr_1",
         file: "/tmp/x.html",
       }),
     ).rejects.toThrow(/source-relative/);
     await expect(
-      harness.callRpc("prepareHtmlPreview", {
+      harness.callRpc("preparePreview", {
         threadId: "thr_1",
         file: "../etc/passwd.html",
       }),
     ).rejects.toThrow(/traversal|escape/);
+    await expect(
+      harness.callRpc("preparePreview", {
+        threadId: "thr_1",
+        file: "notes.txt",
+      }),
+    ).rejects.toThrow(/\.html/);
     expect(harness.sdk.callsTo("files.read")).toHaveLength(0);
   });
 
@@ -262,7 +348,7 @@ describe("prepareHtmlPreview rpc", () => {
       },
     });
     await expect(
-      missingHost.harness.callRpc("prepareHtmlPreview", {
+      missingHost.harness.callRpc("preparePreview", {
         threadId: "thr_1",
         file: "gone.html",
       }),
@@ -279,7 +365,7 @@ describe("prepareHtmlPreview rpc", () => {
       },
     });
     await expect(
-      binaryHost.harness.callRpc("prepareHtmlPreview", {
+      binaryHost.harness.callRpc("preparePreview", {
         threadId: "thr_1",
         file: "bin.html",
       }),
@@ -291,12 +377,12 @@ describe("prepareHtmlPreview rpc", () => {
         read: () => ({
           content: "",
           contentEncoding: "utf8",
-          sizeBytes: MAX_HTML_BYTES + 1,
+          sizeBytes: MAX_PREVIEW_BYTES + 1,
         }),
       },
     });
     await expect(
-      hugeHost.harness.callRpc("prepareHtmlPreview", {
+      hugeHost.harness.callRpc("preparePreview", {
         threadId: "thr_1",
         file: "big.html",
       }),

--- a/plugins/inline-vis/server.ts
+++ b/plugins/inline-vis/server.ts
@@ -8,6 +8,7 @@ const HTML_EXTENSIONS = new Set([".html", ".htm"]);
 
 interface PrepareHtmlPreviewResult {
   file: string;
+  source: "workspace" | "thread-storage";
 }
 
 function requireNonEmptyString(value: unknown, field: string): string {
@@ -21,13 +22,13 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-export function requireWorkspaceHtmlFile(value: unknown): string {
+export function requireRelativeHtmlFile(value: unknown): string {
   const file = requireNonEmptyString(value, "file");
   if (path.isAbsolute(file)) {
-    throw new Error(`"file" must be workspace-relative, not absolute: ${file}`);
+    throw new Error(`"file" must be source-relative, not absolute: ${file}`);
   }
   if (/^[a-zA-Z]:[\\/]/.test(file) || file.startsWith("\\\\")) {
-    throw new Error(`"file" must be workspace-relative, not absolute: ${file}`);
+    throw new Error(`"file" must be source-relative, not absolute: ${file}`);
   }
   const slashNormalized = file.replace(/\\/g, "/");
   if (slashNormalized.split("/").includes("..")) {
@@ -41,7 +42,7 @@ export function requireWorkspaceHtmlFile(value: unknown): string {
     normalized === "." ||
     normalized.startsWith("/")
   ) {
-    throw new Error(`"file" must not escape the workspace: ${file}`);
+    throw new Error(`"file" must not escape its source: ${file}`);
   }
   const ext = path.posix.extname(normalized).toLowerCase();
   if (!HTML_EXTENSIONS.has(ext)) {
@@ -64,7 +65,7 @@ export function resolveContainedHtmlPath(
     relative.startsWith(`..${path.sep}`) ||
     path.isAbsolute(relative)
   ) {
-    throw new Error(`"file" must not escape the workspace: ${relativeFile}`);
+    throw new Error(`"file" must not escape its source: ${relativeFile}`);
   }
   return absolute;
 }
@@ -82,10 +83,20 @@ export const inlineVisRpcContract = defineRpcContract({
     input: z
       .object({
         threadId: z.string().trim().min(1),
-        file: z.string().transform((value) => requireWorkspaceHtmlFile(value)),
+        file: z.string().transform((value) => requireRelativeHtmlFile(value)),
+        source: z
+          .string()
+          .trim()
+          .pipe(z.enum(["workspace", "thread-storage"]))
+          .default("workspace"),
       })
       .strict(),
-    output: z.object({ file: z.string() }).strict(),
+    output: z
+      .object({
+        file: z.string(),
+        source: z.enum(["workspace", "thread-storage"]),
+      })
+      .strict(),
   },
 });
 
@@ -94,32 +105,44 @@ export default async function plugin(bb: BbPluginApi) {
     async prepareHtmlPreview({
       threadId,
       file,
+      source,
     }): Promise<PrepareHtmlPreviewResult> {
-      const thread = await bb.sdk.threads.get({
-        threadId,
-        include: "environment",
-      });
+      let rootPath: string;
+      let hostId: string;
 
-      if (!("environment" in thread)) {
-        throw new Error(
-          "Thread environment was not returned — inline-vis needs a live environment.",
-        );
-      }
+      if (source === "thread-storage") {
+        const storage = await bb.sdk.threads.storageLocation({ threadId });
+        rootPath = storage.storageRootPath;
+        hostId = storage.hostId;
+      } else {
+        const thread = await bb.sdk.threads.get({
+          threadId,
+          include: "environment",
+        });
 
-      const environment = thread.environment;
-      const rootPath =
-        typeof environment?.path === "string" ? environment.path : null;
-      if (!rootPath) {
-        throw new Error(
-          "This thread has no workspace path — inline-vis needs a live environment.",
-        );
-      }
-      const hostId =
-        typeof environment?.hostId === "string" ? environment.hostId : null;
-      if (!hostId) {
-        throw new Error(
-          "This thread's environment has no hostId — cannot read workspace files.",
-        );
+        if (!("environment" in thread)) {
+          throw new Error(
+            "Thread environment was not returned — inline-vis needs a live environment.",
+          );
+        }
+
+        const environment = thread.environment;
+        const workspacePath =
+          typeof environment?.path === "string" ? environment.path : null;
+        if (!workspacePath) {
+          throw new Error(
+            "This thread has no workspace path — inline-vis needs a live environment.",
+          );
+        }
+        const workspaceHostId =
+          typeof environment?.hostId === "string" ? environment.hostId : null;
+        if (!workspaceHostId) {
+          throw new Error(
+            "This thread's environment has no hostId — cannot read workspace files.",
+          );
+        }
+        rootPath = workspacePath;
+        hostId = workspaceHostId;
       }
 
       const absolutePath = resolveContainedHtmlPath(rootPath, file);
@@ -150,7 +173,7 @@ export default async function plugin(bb: BbPluginApi) {
         );
       }
 
-      return { file };
+      return { file, source };
     },
   });
 }

--- a/plugins/inline-vis/server.ts
+++ b/plugins/inline-vis/server.ts
@@ -2,14 +2,21 @@ import path from "node:path";
 import { defineRpcContract, type BbPluginApi } from "@get-bb/plugin-sdk";
 import { z } from "zod";
 
-export const MAX_HTML_BYTES = 5 * 1024 * 1024;
+export const MAX_PREVIEW_BYTES = 5 * 1024 * 1024;
 
-const HTML_EXTENSIONS = new Set([".html", ".htm"]);
+type PreviewKind = "html" | "markdown";
+type PreviewSource = "workspace" | "thread-storage";
 
-interface PrepareHtmlPreviewResult {
-  file: string;
-  source: "workspace" | "thread-storage";
-}
+const PREVIEW_KIND_BY_EXTENSION: ReadonlyMap<string, PreviewKind> = new Map([
+  [".html", "html"],
+  [".htm", "html"],
+  [".md", "markdown"],
+  [".markdown", "markdown"],
+]);
+
+type PreparePreviewResult =
+  | { kind: "html"; file: string; source: PreviewSource }
+  | { kind: "markdown"; file: string; source: PreviewSource; content: string };
 
 function requireNonEmptyString(value: unknown, field: string): string {
   if (typeof value !== "string" || value.trim().length === 0) {
@@ -22,7 +29,18 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-export function requireRelativeHtmlFile(value: unknown): string {
+function previewKind(file: string): PreviewKind {
+  const extension = path.posix.extname(file).toLowerCase();
+  const kind = PREVIEW_KIND_BY_EXTENSION.get(extension);
+  if (kind === undefined) {
+    throw new Error(
+      `"file" must end with .html, .htm, .md, or .markdown, got ${JSON.stringify(file)}`,
+    );
+  }
+  return kind;
+}
+
+export function requireRelativePreviewFile(value: unknown): string {
   const file = requireNonEmptyString(value, "file");
   if (path.isAbsolute(file)) {
     throw new Error(`"file" must be source-relative, not absolute: ${file}`);
@@ -44,16 +62,11 @@ export function requireRelativeHtmlFile(value: unknown): string {
   ) {
     throw new Error(`"file" must not escape its source: ${file}`);
   }
-  const ext = path.posix.extname(normalized).toLowerCase();
-  if (!HTML_EXTENSIONS.has(ext)) {
-    throw new Error(
-      `"file" must end with .html or .htm, got ${JSON.stringify(file)}`,
-    );
-  }
+  previewKind(normalized);
   return normalized;
 }
 
-export function resolveContainedHtmlPath(
+export function resolveContainedPreviewPath(
   rootPath: string,
   relativeFile: string,
 ): string {
@@ -79,11 +92,13 @@ function httpStatus(error: unknown): number | null {
 }
 
 export const inlineVisRpcContract = defineRpcContract({
-  prepareHtmlPreview: {
+  preparePreview: {
     input: z
       .object({
         threadId: z.string().trim().min(1),
-        file: z.string().transform((value) => requireRelativeHtmlFile(value)),
+        file: z
+          .string()
+          .transform((value) => requireRelativePreviewFile(value)),
         source: z
           .string()
           .trim()
@@ -91,22 +106,33 @@ export const inlineVisRpcContract = defineRpcContract({
           .default("workspace"),
       })
       .strict(),
-    output: z
-      .object({
-        file: z.string(),
-        source: z.enum(["workspace", "thread-storage"]),
-      })
-      .strict(),
+    output: z.discriminatedUnion("kind", [
+      z
+        .object({
+          kind: z.literal("html"),
+          file: z.string(),
+          source: z.enum(["workspace", "thread-storage"]),
+        })
+        .strict(),
+      z
+        .object({
+          kind: z.literal("markdown"),
+          file: z.string(),
+          source: z.enum(["workspace", "thread-storage"]),
+          content: z.string(),
+        })
+        .strict(),
+    ]),
   },
 });
 
 export default async function plugin(bb: BbPluginApi) {
   bb.rpc.register(inlineVisRpcContract, {
-    async prepareHtmlPreview({
+    async preparePreview({
       threadId,
       file,
       source,
-    }): Promise<PrepareHtmlPreviewResult> {
+    }): Promise<PreparePreviewResult> {
       let rootPath: string;
       let hostId: string;
 
@@ -145,7 +171,7 @@ export default async function plugin(bb: BbPluginApi) {
         hostId = workspaceHostId;
       }
 
-      const absolutePath = resolveContainedHtmlPath(rootPath, file);
+      const absolutePath = resolveContainedPreviewPath(rootPath, file);
 
       let result;
       try {
@@ -156,24 +182,27 @@ export default async function plugin(bb: BbPluginApi) {
         });
       } catch (error) {
         if (httpStatus(error) === 404) {
-          throw new Error(`HTML file not found: ${file}`);
+          throw new Error(`Preview file not found: ${file}`);
         }
         throw error;
       }
 
       if (result.contentEncoding !== "utf8") {
         throw new Error(
-          `HTML file is not valid UTF-8 text (encoding=${result.contentEncoding}).`,
+          `Preview file is not valid UTF-8 text (encoding=${result.contentEncoding}).`,
         );
       }
       const sizeBytes = result.sizeBytes;
-      if (sizeBytes > MAX_HTML_BYTES) {
+      if (sizeBytes > MAX_PREVIEW_BYTES) {
         throw new Error(
-          `HTML file is too large (${sizeBytes} bytes; max ${MAX_HTML_BYTES}).`,
+          `Preview file is too large (${sizeBytes} bytes; max ${MAX_PREVIEW_BYTES}).`,
         );
       }
 
-      return { file, source };
+      const kind = previewKind(file);
+      return kind === "markdown"
+        ? { kind, file, source, content: result.content }
+        : { kind, file, source };
     },
   });
 }

--- a/plugins/inline-vis/skills/inline-vis/SKILL.md
+++ b/plugins/inline-vis/skills/inline-vis/SKILL.md
@@ -1,23 +1,33 @@
 ---
 name: inline-vis
-description: "Render a workspace HTML artifact inline in BB chat using the inline-vis directive."
+description: "Render a workspace or thread-storage HTML artifact inline in BB chat using the inline-vis directive."
 ---
 
 # Inline HTML visualizations
 
 When the user should see a small HTML demo, chart, or report **inline in the
-assistant message**, write (or update) a workspace-relative `.html` file, then
-emit this **message directive** as its own block (not inside a fenced code
-block):
+assistant message**, write (or update) a source-relative `.html` file, then emit
+this **message directive** as its own block (not inside a fenced code block):
 
 ```text
 ::inline-vis{file="demo.html"}
 ```
 
+Omitting `source` defaults to the workspace. Explicit `source="workspace"` is
+equivalent. For a read-only thread-storage artifact, write the document to
+`$BB_THREAD_STORAGE/reports/result.html`, then emit its storage-relative path:
+
+```text
+::inline-vis{source="thread-storage" file="reports/result.html"}
+```
+
 ## Rules
 
-- `file` is **workspace-relative** (e.g. `demo.html`, `charts/out.html`). Never
-  use absolute paths.
+- `source` is optional and must be `workspace` or `thread-storage`.
+- `file` is relative to the selected source (e.g. `demo.html`,
+  `charts/out.html`). Workspace paths are relative to the current workspace;
+  thread-storage paths are relative to `$BB_THREAD_STORAGE`. Never put an
+  absolute path in the directive.
 - `height` is optional and sets the iframe viewport height in pixels. It must be
   a whole number from 120 through 1200; omit it for the 224px default.
 - Only `.html` / `.htm` files are accepted.
@@ -26,8 +36,9 @@ block):
   CORS, mixed-content, and remote-server policies. Scripts execute in an
   opaque-origin iframe and cannot access the bb page, cookies, or storage.
 - Keep files small (under the sidebar preview's 5 MiB document limit).
-- Emit the directive only after the file exists on disk in the current thread
-  workspace.
+- Emit the directive only after the file exists on disk in the selected source.
+- Prefer `thread-storage` for read-only generated reports and other artifacts
+  that should not modify the workspace.
 - Do **not** put the directive inside backticks or a markdown code fence, or it
   stays literal text.
 - Incomplete streaming syntax stays literal until the closing `}` arrives — emit

--- a/plugins/inline-vis/skills/inline-vis/SKILL.md
+++ b/plugins/inline-vis/skills/inline-vis/SKILL.md
@@ -1,16 +1,17 @@
 ---
 name: inline-vis
-description: "Render a workspace or thread-storage HTML artifact inline in BB chat using the inline-vis directive."
+description: "Show a newly created or updated HTML demo, chart, or report, or Markdown plan, summary, or notes from the workspace or thread storage inline in BB chat with the inline-vis directive."
 ---
 
-# Inline HTML visualizations
+# Inline previews
 
-When the user should see a small HTML demo, chart, or report **inline in the
-assistant message**, write (or update) a source-relative `.html` file, then emit
-this **message directive** as its own block (not inside a fenced code block):
+When the user should see an HTML demo or a Markdown document **inline in the
+assistant message**, write (or update) a source-relative file, then emit this
+**message directive** as its own block (not inside a fenced code block):
 
 ```text
 ::inline-vis{file="demo.html"}
+::inline-vis{file="notes.md"}
 ```
 
 Omitting `source` defaults to the workspace. Explicit `source="workspace"` is
@@ -25,16 +26,17 @@ equivalent. For a read-only thread-storage artifact, write the document to
 
 - `source` is optional and must be `workspace` or `thread-storage`.
 - `file` is relative to the selected source (e.g. `demo.html`,
-  `charts/out.html`). Workspace paths are relative to the current workspace;
-  thread-storage paths are relative to `$BB_THREAD_STORAGE`. Never put an
-  absolute path in the directive.
-- `height` is optional and sets the iframe viewport height in pixels. It must be
-  a whole number from 120 through 1200; omit it for the 224px default.
-- Only `.html` / `.htm` files are accepted.
-- Inline and external CSS/JavaScript are supported. Remote images, fonts,
-  media, fetches, and WebSockets are also allowed subject to normal browser
-  CORS, mixed-content, and remote-server policies. Scripts execute in an
+  `charts/out.html`, `notes.md`). Workspace paths are relative to the current
+  workspace; thread-storage paths are relative to `$BB_THREAD_STORAGE`. Never
+  put an absolute path in the directive.
+- `height` is optional and sets the preview height in pixels. It must be a whole
+  number from 120 through 1200; omit it for the 224px default.
+- `.html`, `.htm`, `.md`, and `.markdown` files are accepted.
+- Inline and external CSS/JavaScript are supported in HTML. Remote images,
+  fonts, media, fetches, and WebSockets are also allowed subject to normal
+  browser CORS, mixed-content, and remote-server policies. Scripts execute in an
   opaque-origin iframe and cannot access the bb page, cookies, or storage.
+  Markdown uses BB's renderer with raw HTML disabled.
 - Keep files small (under the sidebar preview's 5 MiB document limit).
 - Emit the directive only after the file exists on disk in the selected source.
 - Prefer `thread-storage` for read-only generated reports and other artifacts
@@ -44,6 +46,6 @@ equivalent. For a read-only thread-storage artifact, write the document to
 - Incomplete streaming syntax stays literal until the closing `}` arrives — emit
   a complete directive in one piece when possible.
 
-The bb app replaces the directive with a sandboxed preview. If the plugin is
+The bb app replaces the directive with an inline preview. If the plugin is
 disabled or the path is invalid, users see the original directive source or an
 inline error from the plugin.


### PR DESCRIPTION
## Human comments

Integration of #3163 and #3165 by @IlyaM, which conflicted in every file of the inline-vis plugin. Both are credited as co-author on the commits.

## What was wrong

The inline-vis plugin assumed every artifact was an HTML file in the thread workspace. Its RPC always resolved the thread environment, its frontend always used the worktree file route, and its extension check only accepted `.html`/`.htm`. Read-only artifacts written to `$BB_THREAD_STORAGE` could not be rendered inline (#3158), and Markdown reports had to be converted to HTML or pasted into the message (#3159).

## What changed

- Added `source="workspace" | "thread-storage"` to the directive; omitted `source` defaults to `workspace`. Thread-storage previews resolve their root through `bb.sdk.threads.storageLocation()`, confine the file under that root, and use the existing thread-storage file route. They omit the open-in-workspace action.
- Accepted `.md` and `.markdown` files alongside HTML. The plugin-private RPC was renamed from `prepareHtmlPreview` to `preparePreview` and returns a discriminated `html` or `markdown` result with the normalized `source`. Markdown results include the validated UTF-8 content, which the frontend renders with the host `Markdown` component (raw HTML disabled) inside the same bounded, scrollable preview card. HTML keeps the sandboxed iframe.
- Updated the README, plugin overview, package metadata, and bundled skill for both features.

Only the plugin-local RPC contract changed. No server/daemon wire fields changed, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged. No new public plugin API surface.

## How you verified

Combined the tests from both PRs and added cross-feature coverage: Markdown from thread storage on the backend, and thread-storage Markdown suppressing the workspace action on the frontend.

```
pnpm exec turbo run test typecheck --filter=bb-plugin-inline-vis
```

- 27 tests passed across 2 files; typecheck passed; 6 Turbo tasks succeeded
- `bb plugin build plugins/inline-vis` succeeded
- `git diff --check` passed

Fixes #3158
Fixes #3159

Supersedes #3163 and #3165.

> AGENT GENERATED
