### PR TITLE
Show cached Account Pooler usage while status loads

### DIFF
--- a/plugins/account-pool/app.test.tsx
+++ b/plugins/account-pool/app.test.tsx
@@ -13,7 +13,18 @@ afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
+  window.localStorage.clear();
 });
+
+const STATUS_CACHE_KEY = "account-pool:status";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
 
 function measureAccountRows() {
   vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
@@ -84,7 +95,6 @@ function status(accounts: AccountSummary[] = [account()]): PoolStatus {
     hosts: [
       { hostId: "host-one", hostName: "bee", mintedAt: 1, lastUsedAt: 2 },
     ],
-    routedThreadsWithoutLocalLogin: [],
     accounts,
     routing: { claude: true, codex: true },
   };
@@ -101,7 +111,7 @@ function config(overrides: Partial<AccountPoolConfig> = {}): AccountPoolConfig {
 
 function render(
   accounts = [account()],
-  extraRpc: Record<string, () => object | null> = {},
+  extraRpc: Record<string, () => object | null | Promise<object | null>> = {},
 ) {
   return renderSlot(
     app.settingsSections[0]!,
@@ -118,6 +128,54 @@ function render(
 }
 
 describe("Account Pool settings", () => {
+  it("renders cached accounts as refreshing until live status arrives, then caches it", async () => {
+    window.localStorage.setItem(
+      STATUS_CACHE_KEY,
+      JSON.stringify(status([account({ fiveHourUtilization: 0.21 })])),
+    );
+    const live = deferred<PoolStatus>();
+    const slot = render([], { "status.get": () => live.promise });
+    expect(slot.getByText("person@example.com")).toBeTruthy();
+    expect(slot.getByText("21%")).toBeTruthy();
+    expect(slot.getByText("refreshing usage…")).toBeTruthy();
+    expect(slot.getByText(/· refreshing…$/)).toBeTruthy();
+    expect(slot.queryByText("Loading…")).toBeNull();
+    expect(slot.queryByText("No accounts in the pool")).toBeNull();
+    live.resolve(status([account({ fiveHourUtilization: 0.6 })]));
+    expect(await slot.findByText("60%")).toBeTruthy();
+    expect(slot.queryByText("refreshing usage…")).toBeNull();
+    expect(slot.queryByText(/· refreshing…$/)).toBeNull();
+    const cached = JSON.parse(
+      window.localStorage.getItem(STATUS_CACHE_KEY) ?? "null",
+    ) as PoolStatus;
+    expect(cached.accounts[0]?.fiveHourUtilization).toBe(0.6);
+  });
+
+  it("ignores a malformed status cache and shows the loading state", async () => {
+    window.localStorage.setItem(STATUS_CACHE_KEY, '{"accounts":"nope"}');
+    const live = deferred<PoolStatus>();
+    const slot = render([], { "status.get": () => live.promise });
+    expect(slot.getAllByText("Loading…")).toHaveLength(2);
+    live.resolve(status());
+    expect(await slot.findByText("person@example.com")).toBeTruthy();
+  });
+
+  it("marks a row as refreshing while its usage refresh is in flight", async () => {
+    const refresh = deferred<{ account: null }>();
+    const slot = render([account()], {
+      "account.refreshUsage": () => refresh.promise,
+    });
+    fireEvent.pointerDown(
+      await slot.findByRole("button", { name: "person@example.com actions" }),
+    );
+    fireEvent.click(await slot.findByText("Refresh usage"));
+    expect(await slot.findByText("refreshing usage…")).toBeTruthy();
+    refresh.resolve({ account: null });
+    await waitFor(() =>
+      expect(slot.queryByText("refreshing usage…")).toBeNull(),
+    );
+  });
+
   it("renders fixed quota slots with missing buckets as em dashes", async () => {
     const slot = render();
     expect(await slot.findByText("person@example.com")).toBeTruthy();

--- a/plugins/account-pool/app.tsx
+++ b/plugins/account-pool/app.tsx
@@ -66,6 +66,7 @@ import type {
   PoolStatus,
 } from "./src/contracts.js";
 import type { accountPoolRpcContract } from "./src/rpc.js";
+import { statusSchema } from "./src/contracts.js";
 import { blockingResetAt } from "./src/quota.js";
 import {
   ACCOUNT_POOL_ACCOUNTS_CHANGED,
@@ -191,6 +192,27 @@ function resetLabel(timestamp: number | null): string {
     return `resets in ${minutes >= 60 ? `${Math.floor(minutes / 60)}h ${minutes % 60}m` : `${minutes}m`}`;
   return `resets ${new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric" }).format(timestamp)}`;
 }
+const STATUS_CACHE_KEY = "account-pool:status";
+
+function readCachedStatus(): PoolStatus | null {
+  try {
+    const raw = window.localStorage.getItem(STATUS_CACHE_KEY);
+    if (raw === null) return null;
+    const parsed = statusSchema.safeParse(JSON.parse(raw));
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeCachedStatus(status: PoolStatus): void {
+  try {
+    window.localStorage.setItem(STATUS_CACHE_KEY, JSON.stringify(status));
+  } catch {
+    return;
+  }
+}
+
 function statusPresentation(
   account: AccountSummary,
   threshold: number,
@@ -315,12 +337,19 @@ function quotaToneClass(slot: QuotaSlot, threshold: number): string {
 function QuotaValue({
   slot,
   threshold,
+  refreshing,
 }: {
   slot: QuotaSlot;
   threshold: number;
+  refreshing: boolean;
 }) {
   return (
-    <div className="w-16 text-left tabular-nums sm:text-right">
+    <div
+      className={cn(
+        "w-16 text-left tabular-nums transition-opacity sm:text-right",
+        refreshing && "opacity-50",
+      )}
+    >
       <div className="text-2xs uppercase tracking-wide text-subtle-foreground/75">
         {slot.label}
       </div>
@@ -343,6 +372,7 @@ function AccountRow({
   account,
   threshold,
   pending,
+  refreshing,
   onAction,
   onOpen,
   reorderDisabled,
@@ -350,6 +380,7 @@ function AccountRow({
   account: AccountSummary;
   threshold: number;
   pending: boolean;
+  refreshing: boolean;
   onAction: (action: "toggle" | "priority" | "refresh" | "remove") => void;
   onOpen: () => void;
   reorderDisabled: boolean;
@@ -414,11 +445,17 @@ function AccountRow({
               {account.lastUsedAt === null ? null : (
                 <span>used {relative(account.lastUsedAt)}</span>
               )}
+              {refreshing ? <span>refreshing usage…</span> : null}
             </div>
           </div>
           <div className="flex flex-wrap items-center gap-x-4 gap-y-1 sm:flex-nowrap sm:gap-1">
             {slots.map((slot) => (
-              <QuotaValue key={slot.key} slot={slot} threshold={threshold} />
+              <QuotaValue
+                key={slot.key}
+                slot={slot}
+                threshold={threshold}
+                refreshing={refreshing}
+              />
             ))}
           </div>
         </button>
@@ -670,7 +707,8 @@ function ConfigFieldRow({
 function AccountPoolSettings() {
   const rpc = useRpc<typeof accountPoolRpcContract>();
   const navigate = useBbNavigate();
-  const [status, setStatus] = useState<PoolStatus | null>(null);
+  const [status, setStatus] = useState<PoolStatus | null>(readCachedStatus);
+  const [statusIsCached, setStatusIsCached] = useState(status !== null);
   const [config, setConfig] = useState<AccountPoolConfig | null>(null);
   const [drafts, setDrafts] = useState<ConfigDrafts>({
     anthropicUpstreamBaseUrl: "",
@@ -711,7 +749,10 @@ function AccountPoolSettings() {
   const refresh = useCallback(async () => {
     try {
       const next = await rpc.call("status.get", null);
-      if (mounted.current) setStatus(next);
+      writeCachedStatus(next);
+      if (!mounted.current) return;
+      setStatus(next);
+      setStatusIsCached(false);
     } catch (loadError) {
       if (mounted.current) setError(errorText(loadError));
     }
@@ -947,6 +988,7 @@ function AccountPoolSettings() {
       <p className="text-xs text-subtle-foreground/75">
         Hub {status?.accepting ? "accepting" : "not accepting"} ·{" "}
         {status?.inFlight ?? 0} in flight · used by {hubHosts}
+        {statusIsCached ? " · refreshing…" : null}
       </p>
       {error === null ? null : (
         <div
@@ -956,7 +998,7 @@ function AccountPoolSettings() {
           {error}
         </div>
       )}
-      {status !== null && accounts.length === 0 ? (
+      {status !== null && !statusIsCached && accounts.length === 0 ? (
         <div className="rounded-lg border border-dashed border-border px-5 py-6 text-center">
           <h2 className="text-sm font-semibold text-foreground">
             No accounts in the pool
@@ -1047,6 +1089,9 @@ function AccountPoolSettings() {
                         account={account}
                         threshold={threshold}
                         pending={pending !== null}
+                        refreshing={
+                          statusIsCached || pending === `refresh-${account.id}`
+                        }
                         reorderDisabled={providerAccounts.length < 2}
                         onAction={(action) =>
                           void accountAction(account, action)

--- a/plugins/account-pool/src/cli.ts
+++ b/plugins/account-pool/src/cli.ts
@@ -18,7 +18,7 @@ import {
   type FamilyQuota,
   type LimitWindow,
   type ModelFamily,
-  type PoolStatus,
+  type PoolStatusReport,
 } from "./contracts.js";
 import type { PoolOperations } from "./operations.js";
 import type { ClaudeOAuthLogin } from "./oauth-login.js";
@@ -180,7 +180,7 @@ function formatAccounts(accounts: readonly AccountSummary[]): string {
   ].join("\n");
 }
 
-function formatStatus(status: PoolStatus): string {
+function formatStatus(status: PoolStatusReport): string {
   return [
     `Route: ${status.route}`,
     `Accepting: ${status.accepting}`,
@@ -556,7 +556,15 @@ export function registerPoolCli(
         }
         if (argv[0] === "status") {
           const flags = parseFlags(argv.slice(1), ["json"], []);
-          const status = await operations.status();
+          const [poolStatus, routedThreadsWithoutLocalLogin] =
+            await Promise.all([
+              operations.status(),
+              operations.routedThreadsWithoutLocalLogin(),
+            ]);
+          const status: PoolStatusReport = {
+            ...poolStatus,
+            routedThreadsWithoutLocalLogin,
+          };
           return {
             exitCode: 0,
             stdout: flags.booleans.has("json")

--- a/plugins/account-pool/src/contracts.ts
+++ b/plugins/account-pool/src/contracts.ts
@@ -222,13 +222,20 @@ export const statusSchema = z
     inFlight: z.number().int().nonnegative(),
     accepting: z.boolean(),
     hosts: z.array(hubTokenSummarySchema),
-    routedThreadsWithoutLocalLogin: z.array(routedThreadStatusSchema),
     accounts: z.array(accountSummarySchema),
     routing: z.object({ claude: z.boolean(), codex: z.boolean() }).strict(),
   })
   .strict();
 
 export type PoolStatus = z.infer<typeof statusSchema>;
+
+export const routedThreadStatusListSchema = z.array(routedThreadStatusSchema);
+
+export const statusReportSchema = statusSchema
+  .extend({ routedThreadsWithoutLocalLogin: routedThreadStatusListSchema })
+  .strict();
+
+export type PoolStatusReport = z.infer<typeof statusReportSchema>;
 
 export const accountAddInputSchema = z
   .object({

--- a/plugins/account-pool/src/hub.ts
+++ b/plugins/account-pool/src/hub.ts
@@ -275,9 +275,7 @@ export class AccountPoolHub {
     }
   }
 
-  async status(): Promise<
-    Omit<PoolStatus, "routedThreadsWithoutLocalLogin" | "routing">
-  > {
+  async status(): Promise<Omit<PoolStatus, "routing">> {
     const settings = this.options.getSettings();
     const now = this.options.now();
     const accounts = (await this.options.accounts.list()).sort(

--- a/plugins/account-pool/src/operations.ts
+++ b/plugins/account-pool/src/operations.ts
@@ -214,10 +214,7 @@ export class PoolOperations {
   async status(): Promise<PoolStatus> {
     const hosts = await this.listHosts();
     await this.hubTokens.prune(hosts.map((host) => host.id));
-    const [status, routedThreadsWithoutLocalLogin] = await Promise.all([
-      this.hub.status(),
-      this.routedThreadsWithoutLocalLogin(),
-    ]);
+    const status = await this.hub.status();
     const hostNames = new Map(hosts.map((host) => [host.id, host.name]));
     const [claude, codex] = await Promise.all([
       this.routing.isProviderEnabled("claude"),
@@ -237,7 +234,6 @@ export class PoolOperations {
             : (hostNames.get(account.lastUsedHostId) ?? null),
       })),
       routing: { claude, codex },
-      routedThreadsWithoutLocalLogin,
     };
   }
 

--- a/plugins/account-pool/src/rpc.ts
+++ b/plugins/account-pool/src/rpc.ts
@@ -18,6 +18,7 @@ import {
   hubTokenSummarySchema,
   loginCompleteInputSchema,
   loginStartSchema,
+  routedThreadStatusListSchema,
   statusSchema,
   tokenRotateInputSchema,
   routingSetInputSchema,
@@ -98,6 +99,10 @@ export const accountPoolRpcContract = defineRpcContract({
     input: z.null(),
     output: statusSchema,
   },
+  "status.routedThreads": {
+    input: z.null(),
+    output: routedThreadStatusListSchema,
+  },
   "token.rotate": {
     input: tokenRotateInputSchema,
     output: hubTokenSummarySchema,
@@ -168,6 +173,7 @@ export function createRpcHandlers(
       cancelled: codexLogin.cancel(input),
     }),
     "status.get": () => operations.status(),
+    "status.routedThreads": () => operations.routedThreadsWithoutLocalLogin(),
     "token.rotate": ({ machine }: { machine: string }) =>
       operations.rotateToken(machine),
     "bypass.set": ({

--- a/plugins/account-pool/src/server.test.ts
+++ b/plugins/account-pool/src/server.test.ts
@@ -13,6 +13,8 @@ import {
   accountPoolConfigSetInputSchema,
   codexLoginPollSchema,
   codexLoginStartSchema,
+  routedThreadStatusListSchema,
+  statusReportSchema,
   statusSchema,
   type AccountSummary,
 } from "./contracts.js";
@@ -217,10 +219,12 @@ async function createFixture(args: {
   await vi.waitFor(async () => {
     const result = await host.harness.behavior.runCli(["status", "--json"]);
     expect(result.exitCode).toBe(0);
-    expect(statusSchema.parse(JSON.parse(result.stdout)).accepting).toBe(true);
+    expect(statusReportSchema.parse(JSON.parse(result.stdout)).accepting).toBe(
+      true,
+    );
   });
   const statusResult = await host.harness.behavior.runCli(["status", "--json"]);
-  const status = statusSchema.parse(JSON.parse(statusResult.stdout));
+  const status = statusReportSchema.parse(JSON.parse(statusResult.stdout));
   const account = status.accounts.find(
     (candidate) => candidate.id === accountMetadata.id,
   );
@@ -1020,7 +1024,7 @@ describe("Account Pool plugin", () => {
       "status",
       "--json",
     ]);
-    const status = statusSchema.parse(JSON.parse(statusResult.stdout));
+    const status = statusReportSchema.parse(JSON.parse(statusResult.stdout));
     expect(status.accepting).toBe(true);
     expect(status.hosts).toEqual([]);
     expect(
@@ -1130,7 +1134,7 @@ describe("Account Pool plugin", () => {
         ])
       ).exitCode,
     ).toBe(0);
-    const publicStatus = statusSchema.parse(
+    const publicStatus = statusReportSchema.parse(
       JSON.parse(
         (await fixture.host.harness.behavior.runCli(["status", "--json"]))
           .stdout,
@@ -1675,10 +1679,10 @@ describe("Account Pool plugin", () => {
         ],
       }),
     );
-    const status = statusSchema.parse(
-      await fixture.host.harness.behavior.callRpc("status.get", null),
+    const routedThreads = routedThreadStatusListSchema.parse(
+      await fixture.host.harness.behavior.callRpc("status.routedThreads", null),
     );
-    expect(status.routedThreadsWithoutLocalLogin).toEqual([
+    expect(routedThreads).toEqual([
       {
         threadId: "thread-one",
         hostId: "host-one",
@@ -1763,10 +1767,10 @@ describe("Account Pool plugin", () => {
         },
       ],
     }));
-    const status = statusSchema.parse(
-      await fixture.host.harness.behavior.callRpc("status.get", null),
+    const routedThreads = routedThreadStatusListSchema.parse(
+      await fixture.host.harness.behavior.callRpc("status.routedThreads", null),
     );
-    expect(status.routedThreadsWithoutLocalLogin).toEqual([
+    expect(routedThreads).toEqual([
       {
         threadId: "thread-one",
         hostId: "host-one",


### PR DESCRIPTION
## Human comments

## What was wrong

Opening Account Pooler settings sat on "Loading…" for a long time. The `status.get` RPC assembled `routedThreadsWithoutLocalLogin`, which calls `system.providerStates` over host RPC for every machine that routed a thread in the last window. A sleeping or offline machine stalls that call up to the host RPC deadline, and the UI rendered nothing until the whole status returned. Every action afterward (toggle, refresh usage, reorder) re-ran the same slow status call.

## What changed

- `plugins/account-pool/src/operations.ts`, `rpc.ts`, `contracts.ts`: `status.get` no longer waits on host RPCs. The routed-thread inspection is its own `status.routedThreads` RPC. `statusSchema` drops `routedThreadsWithoutLocalLogin`; a new `statusReportSchema` / `PoolStatusReport` keeps the combined shape.
- `plugins/account-pool/src/cli.ts`: `bb pool status` calls both operations and prints the same text and `--json` output as before.
- `plugins/account-pool/app.tsx`: the settings view caches the last `PoolStatus` in `localStorage` (validated with `statusSchema` on read) and renders it immediately. While the live status is in flight the hub line shows "refreshing…", rows show "refreshing usage…", and quota values are dimmed. A row also shows the refreshing state while its manual "Refresh usage" RPC is pending. The empty-state card only renders from live status so a stale cache never flashes "No accounts in the pool".

No wire changes to the host daemon protocol; this is plugin-internal RPC.

## How you verified

- New tests in `plugins/account-pool/app.test.tsx`: cached accounts render with the refreshing indicator before `status.get` resolves and the cache is rewritten afterward; a malformed cache entry falls back to the loading state; a row shows "refreshing usage…" while `account.refreshUsage` is pending. The first and third fail on main (no cache, no indicator).
- `plugins/account-pool/src/server.test.ts` updated to read routed threads from `status.routedThreads` and parse CLI JSON with `statusReportSchema`.
- `pnpm exec turbo run test typecheck --filter=bb-plugin-account-pool` passes (10 files, 274 tests).
- Bundled the plugin app once through `buildPluginApp` to confirm the runtime `statusSchema` import bundles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> AGENT GENERATED
