### PR TITLE
Add close-other and close-to-the-right actions to right panel tabs

### DIFF
--- a/apps/app/src/components/plugin/PluginPanelRightPanelHost.test.tsx
+++ b/apps/app/src/components/plugin/PluginPanelRightPanelHost.test.tsx
@@ -415,6 +415,16 @@ vi.mock("@/components/secondary-panel/ThreadSecondaryPanel", () => ({
             {tab.title}
           </button>
         ))}
+        <button
+          type="button"
+          onClick={() => {
+            for (const tab of tabs) {
+              tab.onClose();
+            }
+          }}
+        >
+          Close all tabs
+        </button>
         <button type="button" onClick={onOpenNewTab}>
           Add tab
         </button>
@@ -822,6 +832,27 @@ describe("PluginPanelRightPanelHost", () => {
     fireEvent.click(screen.getByRole("button", { name: "Secrets" }));
     expect(await screen.findByText("Details for secrets")).toBeTruthy();
     expect(catalogQueryState.queries).toEqual(["secrets"]);
+  });
+
+  it("closes every plugin detail tab when several close in one event", async () => {
+    renderHost("board", "", createStore(), true);
+
+    fireEvent.click(screen.getByRole("link", { name: "Open Secrets plugin" }));
+    expect(await screen.findByText("Details for secrets")).toBeTruthy();
+    fireEvent.click(
+      screen.getByRole("link", { name: "Open Automations plugin" }),
+    );
+    expect(await screen.findByText("Details for automations")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Close all tabs" }));
+
+    await waitFor(() =>
+      expect(secondaryPanelState.tabKinds).not.toContain(
+        "marketplace-plugin-detail",
+      ),
+    );
+    expect(screen.queryByRole("button", { name: "Secrets" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Automations" })).toBeNull();
   });
 
   it("keeps split navigation for plugin-detail links outside the Plugin Guide", () => {

--- a/apps/app/src/components/plugin/PluginPanelRightPanelHost.tsx
+++ b/apps/app/src/components/plugin/PluginPanelRightPanelHost.tsx
@@ -733,11 +733,15 @@ export function PluginPanelRightPanelHost({
       const nextPluginIds = openedPluginIds.filter(
         (candidate) => candidate !== closingPluginId,
       );
-      setOpenedPluginIds(nextPluginIds);
+      setOpenedPluginIds((current) =>
+        current.filter((candidate) => candidate !== closingPluginId),
+      );
       if (activePluginDetailId !== closingPluginId) return;
       const nextActivePluginId =
         nextPluginIds[Math.min(closingIndex, nextPluginIds.length - 1)] ?? null;
-      setActivePluginDetailId(nextActivePluginId);
+      setActivePluginDetailId((current) =>
+        current === closingPluginId ? nextActivePluginId : current,
+      );
       setIsPluginDetailFullPage(false);
       if (
         nextActivePluginId === null &&

--- a/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.test.ts
+++ b/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.test.ts
@@ -1,12 +1,20 @@
 // @vitest-environment jsdom
 
-import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import { createElement } from "react";
 import { afterEach, vi } from "vitest";
 import { describe, expect, it } from "vitest";
 import {
   SecondaryPanelTabStrip,
   SECONDARY_PANEL_TAB_STRIP_FADE_TONE,
+  secondaryPanelTabsToClose,
+  type SecondaryPanelTabStripProps,
 } from "./SecondaryPanelTabStrip";
 
 afterEach(() => {
@@ -244,5 +252,94 @@ describe("secondary panel tab-strip edge fades", () => {
     expect(document.activeElement).toBe(
       container.querySelector('button[aria-pressed="true"]'),
     );
+  });
+});
+
+function makeCloseMenuTabs(
+  pinnedIndexes: readonly number[] = [],
+): SecondaryPanelTabStripProps["tabs"] {
+  return Array.from({ length: 4 }, (_, index) => ({
+    label: `file-${index}.ts`,
+    isPinned: pinnedIndexes.includes(index),
+    leadingVisual: null,
+    statusLabel: null,
+    onSelect: vi.fn(),
+    onClose: vi.fn(),
+    renderContent: () => null,
+    tab: { id: `tab-${index}`, kind: "new-tab" as const },
+  }));
+}
+
+function closeCounts(tabs: SecondaryPanelTabStripProps["tabs"]) {
+  return tabs.map((tab) => vi.mocked(tab.onClose).mock.calls.length);
+}
+
+function renderCloseMenuStrip(tabs: SecondaryPanelTabStripProps["tabs"]) {
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      disconnect() {}
+    },
+  );
+  render(
+    createElement(SecondaryPanelTabStrip, {
+      activeTabId: "tab-3",
+      tabs,
+      onReorderTab: vi.fn(),
+      usesDesktopChrome: false,
+      isPanelOpen: true,
+    }),
+  );
+}
+
+describe("secondary panel tab close menu", () => {
+  it("selects other tabs and tabs to the right, skipping pinned tabs", () => {
+    const tabs = makeCloseMenuTabs([0, 3]);
+    const closeIds = (tabId: string, scope: "self" | "others" | "right") =>
+      secondaryPanelTabsToClose(tabs, tabId, scope).map((tab) => tab.tab.id);
+    expect(closeIds("tab-1", "others")).toEqual(["tab-2"]);
+    expect(closeIds("tab-1", "right")).toEqual(["tab-2"]);
+    expect(closeIds("tab-0", "self")).toEqual([]);
+    expect(closeIds("missing", "others")).toEqual([]);
+  });
+
+  it("closes the right-clicked tab", () => {
+    const tabs = makeCloseMenuTabs();
+    renderCloseMenuStrip(tabs);
+
+    fireEvent.contextMenu(screen.getByRole("button", { name: "file-2.ts" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Close tab" }));
+
+    expect(closeCounts(tabs)).toEqual([0, 0, 1, 0]);
+  });
+
+  it("closes tabs to the right and selects the clicked tab when the active tab closes", () => {
+    const tabs = makeCloseMenuTabs();
+    renderCloseMenuStrip(tabs);
+
+    fireEvent.contextMenu(screen.getByRole("button", { name: "file-1.ts" }));
+    fireEvent.click(
+      screen.getByRole("menuitem", { name: "Close tabs to the right" }),
+    );
+
+    expect(tabs[1]?.onSelect).toHaveBeenCalledTimes(1);
+    expect(closeCounts(tabs)).toEqual([0, 0, 1, 1]);
+  });
+
+  it("closes other tabs and disables close-to-the-right on the last tab", () => {
+    const tabs = makeCloseMenuTabs();
+    renderCloseMenuStrip(tabs);
+
+    fireEvent.contextMenu(screen.getByRole("button", { name: "file-3.ts" }));
+    expect(
+      screen
+        .getByRole("menuitem", { name: "Close tabs to the right" })
+        .getAttribute("data-disabled"),
+    ).not.toBeNull();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Close other tabs" }));
+
+    expect(tabs[3]?.onSelect).not.toHaveBeenCalled();
+    expect(closeCounts(tabs)).toEqual([1, 1, 1, 0]);
   });
 });

--- a/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.tsx
+++ b/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.tsx
@@ -31,6 +31,14 @@ import { CSS } from "@dnd-kit/utilities";
 import { Button } from "@bb/shared-ui/button";
 import { Icon } from "@bb/shared-ui/icon";
 import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from "@bb/shared-ui/context-menu";
+import { useIsCompactViewport } from "@bb/shared-ui/hooks/use-compact-viewport";
+import {
   OverflowFade,
   type OverflowFadeTone,
 } from "@/components/ui/overflow-fade";
@@ -85,11 +93,34 @@ export interface SecondaryPanelTabStripProps {
   isPanelOpen: boolean;
 }
 
+export type SecondaryPanelTabCloseScope = "self" | "others" | "right";
+
+export function secondaryPanelTabsToClose(
+  tabs: readonly SecondaryPanelRenderableTab[],
+  tabId: string,
+  scope: SecondaryPanelTabCloseScope,
+): SecondaryPanelRenderableTab[] {
+  const index = tabs.findIndex((tab) => tab.tab.id === tabId);
+  if (index === -1) {
+    return [];
+  }
+  const candidates =
+    scope === "self"
+      ? tabs.slice(index, index + 1)
+      : scope === "right"
+        ? tabs.slice(index + 1)
+        : tabs.filter((tab) => tab.tab.id !== tabId);
+  return candidates.filter((tab) => !tab.isPinned);
+}
+
 interface SortablePanelTabProps {
   isActive: boolean;
   activeTabRef: RefObject<HTMLDivElement | null>;
+  contextMenuDisabled: boolean;
   dragDisabled: boolean;
   noDragClass: string | null;
+  onCloseTabs: (tabId: string, scope: SecondaryPanelTabCloseScope) => void;
+  tabs: readonly SecondaryPanelRenderableTab[];
   onBeginTabDrag?: (
     tabId: string,
     event: ReactPointerEvent<HTMLElement>,
@@ -330,6 +361,23 @@ export function SecondaryPanelTabStrip({
     [consumeDragClickSuppression],
   );
 
+  const isCompactViewport = useIsCompactViewport();
+  const handleCloseTabs = useCallback(
+    (tabId: string, scope: SecondaryPanelTabCloseScope) => {
+      const tabsToClose = secondaryPanelTabsToClose(tabs, tabId, scope);
+      const closesActiveTab = tabsToClose.some(
+        (tab) => tab.tab.id === activeTabId,
+      );
+      if (scope !== "self" && closesActiveTab) {
+        tabs.find((tab) => tab.tab.id === tabId)?.onSelect();
+      }
+      for (const tab of tabsToClose) {
+        tab.onClose();
+      }
+    },
+    [activeTabId, tabs],
+  );
+
   const noDragClass = usesDesktopChrome ? MACOS_WINDOW_NO_DRAG_CLASS : null;
   const chevronNoDragClass = usesDesktopChrome
     ? MACOS_APP_REGION_NO_DRAG_CLASS
@@ -351,11 +399,14 @@ export function SecondaryPanelTabStrip({
             <SortablePanelTab
               key={tab.tab.id}
               activeTabRef={activeTabRef}
+              contextMenuDisabled={isCompactViewport}
               dragDisabled={dragDisabled}
               isActive={tab.tab.id === activeTabId}
               noDragClass={noDragClass}
               onBeginTabDrag={onBeginTabDrag}
+              onCloseTabs={handleCloseTabs}
               tab={tab}
+              tabs={tabs}
             />
           ))}
         </SortableContext>
@@ -381,8 +432,10 @@ export function SecondaryPanelTabStrip({
       tabIds,
       tabs,
       dragDisabled,
+      isCompactViewport,
       noDragClass,
       onBeginTabDrag,
+      handleCloseTabs,
       draggingTab,
       activeTabId,
     ],
@@ -451,11 +504,14 @@ export function SecondaryPanelTabStrip({
 
 function SortablePanelTab({
   activeTabRef,
+  contextMenuDisabled,
   dragDisabled,
   isActive,
   noDragClass,
   onBeginTabDrag,
+  onCloseTabs,
   tab,
+  tabs,
 }: SortablePanelTabProps) {
   const { isDragging, listeners, setNodeRef, transform, transition } =
     useSortable({
@@ -481,24 +537,57 @@ function SortablePanelTab({
     [transform, transition],
   );
 
+  const tabId = tab.tab.id;
+  const canCloseSelf =
+    secondaryPanelTabsToClose(tabs, tabId, "self").length > 0;
+  const canCloseOthers =
+    secondaryPanelTabsToClose(tabs, tabId, "others").length > 0;
+  const canCloseRight =
+    secondaryPanelTabsToClose(tabs, tabId, "right").length > 0;
+
   return (
-    <div
-      ref={setTabRef}
-      style={style}
-      className={cn(
-        "shrink-0",
-        !dragDisabled && "cursor-grab active:cursor-grabbing",
-        isDragging && "opacity-40",
-        noDragClass,
-      )}
-      onPointerDown={(event) => {
-        onBeginTabDrag?.(tab.tab.id, event);
-        sortablePointerDown?.(event);
-      }}
-      {...sortableListeners}
-    >
-      <PanelTab tab={tab} isActive={isActive} />
-    </div>
+    <ContextMenu>
+      <ContextMenuTrigger asChild disabled={contextMenuDisabled}>
+        <div
+          ref={setTabRef}
+          style={style}
+          className={cn(
+            "shrink-0",
+            !dragDisabled && "cursor-grab active:cursor-grabbing",
+            isDragging && "opacity-40",
+            noDragClass,
+          )}
+          onPointerDown={(event) => {
+            onBeginTabDrag?.(tabId, event);
+            sortablePointerDown?.(event);
+          }}
+          {...sortableListeners}
+        >
+          <PanelTab tab={tab} isActive={isActive} />
+        </div>
+      </ContextMenuTrigger>
+      <ContextMenuContent aria-label={`${tab.label} tab actions`}>
+        <ContextMenuItem
+          disabled={!canCloseSelf}
+          onSelect={() => onCloseTabs(tabId, "self")}
+        >
+          Close tab
+        </ContextMenuItem>
+        <ContextMenuSeparator />
+        <ContextMenuItem
+          disabled={!canCloseOthers}
+          onSelect={() => onCloseTabs(tabId, "others")}
+        >
+          Close other tabs
+        </ContextMenuItem>
+        <ContextMenuItem
+          disabled={!canCloseRight}
+          onSelect={() => onCloseTabs(tabId, "right")}
+        >
+          Close tabs to the right
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
   );
 }
 


### PR DESCRIPTION
## Human comments

## What was wrong

Tabs in the right sidebar could only be closed one at a time, with each tab's close button or a middle-click. `SecondaryPanelTabStrip.tsx` had no context menu, so there was no way to close several tabs at once the way Chrome and VS Code allow with "Close other tabs" and "Close tabs to the right".

## What changed

- `apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.tsx`: right-clicking a tab opens a context menu with **Close tab**, **Close other tabs**, and **Close tabs to the right**. The new `secondaryPanelTabsToClose` helper picks which tabs each action closes. Options with nothing to close are disabled.
  - Each action calls the tab's existing `onClose`, so terminal tabs still shut down their terminal instead of just disappearing.
  - Pinned tabs, which have no close button, are never closed by these actions.
  - If the active tab would be closed, the right-clicked tab is selected first, as in Chrome.
  - The menu is disabled on compact viewports (below 768px), where a long press would conflict with touch drag-to-reorder.
- `apps/app/src/components/plugin/PluginPanelRightPanelHost.tsx`: `closePluginDetailTab` now uses functional state updates. It used to overwrite the open plugin detail tab list with the one saved at the last render. So when the menu closed several plugin detail tabs in one event, each close undid the one before it and some tabs stayed open. It could also override the tab the menu had just selected with a neighbouring plugin tab.
- `SecondaryPanelTabStrip.test.ts`: coverage for the helper and for each menu action.
- `PluginPanelRightPanelHost.test.tsx`: regression test that closes two plugin detail tabs in one event.

No wire, CLI, or configuration changes.

Decisions for review:

- **Three actions only.** "Close tabs to the left" and "Close all" are left out; Chrome has neither, VS Code has "Close All". Either is easy to add.
- **No CLI or SDK surface.** There is no existing CLI or SDK command for right-panel tabs (`bb browser close` only closes native browser tabs), so a bulk-close command would need a new contract. Left for a follow-up.
- **No menu on compact screens.** The thread list uses a long-press menu there, but on this tab strip a long press also starts drag-to-reorder.

## How you verified

- The new tests right-click a rendered tab and click each menu item. They check which tabs' `onClose` and `onSelect` fire, that pinned tabs are skipped, and that "Close tabs to the right" is disabled on the last tab.
- `pnpm exec vitest run src/components/secondary-panel/SecondaryPanelTabStrip` (in `apps/app`): 2 files, 9 tests passed.
- The plugin detail regression test fails on the previous `PluginPanelRightPanelHost.tsx` (`expected [ 'marketplace-plugin-detail' ] to not include 'marketplace-plugin-detail'`) and passes with the fix. The case where "Close other tabs" closes the active plugin tab was checked by reading the code; the test's stand-in tab strip can't reproduce it.
- `pnpm exec vitest run src/components/plugin/PluginPanelRightPanelHost.test.tsx src/components/secondary-panel/SecondaryPanelTabStrip` (in `apps/app`): 3 files, 28 tests passed.
- Coverage on the changed lines of `SecondaryPanelTabStrip.tsx`: 75 of 75 executable lines hit.
- `pnpm exec turbo run typecheck --filter=@bb/app`: passed.
- Started a source dev app with `scripts/bb-dev-app current` for manual testing; the app and server both responded with HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> AGENT GENERATED
