### PR TITLE
Configurable voice transcription limits + local models Settings UI

### DIFF
--- a/apps/app/src/components/promptbox/usePromptVoice.test.tsx
+++ b/apps/app/src/components/promptbox/usePromptVoice.test.tsx
@@ -15,14 +15,20 @@ vi.mock("@/hooks/useVoiceInput", () => ({
   useVoiceInput: vi.fn(),
 }));
 
+vi.mock("@/hooks/queries/system-queries", () => ({
+  useSystemConfig: vi.fn(() => ({ data: undefined })),
+}));
+
 const voiceInput = {
   state: "transcribing" as const,
   isSupported: true,
   unsupportedReason: null,
   stream: null,
+  canRetry: false,
   start: vi.fn(),
   stop: vi.fn(),
   cancel: vi.fn(),
+  retry: vi.fn(),
 };
 
 afterEach(() => {

--- a/apps/app/src/components/promptbox/usePromptVoice.ts
+++ b/apps/app/src/components/promptbox/usePromptVoice.ts
@@ -1,6 +1,8 @@
-import { useCallback, useMemo, type RefObject } from "react";
+import { useCallback, useMemo, useRef, type RefObject } from "react";
+import { isLargeAudioService } from "@bb/config/voice-transcription-limit";
 import { useVoiceInput } from "@/hooks/useVoiceInput";
 import { transcribeVoiceInput } from "@/lib/api";
+import { useSystemConfig } from "@/hooks/queries/system-queries";
 import type { PromptBoxHandle, PromptVoiceConfig } from "./PromptBoxInternal";
 
 async function requestVoiceTranscription({
@@ -35,6 +37,29 @@ export function usePromptVoice(
     [promptBoxRef],
   );
 
+  const systemConfig = useSystemConfig().data;
+  const pinnedAudioBitsPerSecond = useMemo(() => {
+    if (systemConfig === undefined) {
+      return null;
+    }
+    const ai = systemConfig.aiServices;
+    const activeServiceId = ai.transcription.split("/", 1)[0];
+    const activeService = ai.services.find(
+      (service) => service.id === activeServiceId,
+    );
+    const effectiveCap = activeService?.effectiveVoiceMaxBytes ?? null;
+    if (!isLargeAudioService(effectiveCap)) {
+      return null;
+    }
+    return ai.recordingBitrate;
+  }, [systemConfig]);
+  const pinnedAudioBitsPerSecondRef = useRef(pinnedAudioBitsPerSecond);
+  pinnedAudioBitsPerSecondRef.current = pinnedAudioBitsPerSecond;
+  const getAudioBitsPerSecond = useCallback(
+    () => pinnedAudioBitsPerSecondRef.current,
+    [],
+  );
+
   const transcribeAfterCompletionTransition = useCallback(
     async (args: Parameters<typeof requestVoiceTranscription>[0]) => {
       const text = await requestVoiceTranscription(args);
@@ -51,6 +76,7 @@ export function usePromptVoice(
     onTranscript,
     onTranscribe: transcribeAfterCompletionTransition,
     getPromptContext,
+    getAudioBitsPerSecond,
   });
 
   return useMemo<PromptVoiceConfig>(

--- a/apps/app/src/components/settings/VoiceInputSettingsSection.test.tsx
+++ b/apps/app/src/components/settings/VoiceInputSettingsSection.test.tsx
@@ -1,61 +1,429 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { TooltipProvider } from "@bb/shared-ui/tooltip";
-import { afterEach, describe, expect, it } from "vitest";
-import { VoiceInputSettingsSectionContent } from "./VoiceInputSettingsSection";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/plugin-sdk-hooks", () => ({
+  callPluginRpc: vi.fn(),
+}));
+
+import { callPluginRpc } from "@/lib/plugin-sdk-hooks";
+import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
+import {
+  composeModelForProvider,
+  LocalModelsSubsection,
+  VoiceInputSettingsSectionContent,
+  type VoiceTranscriptionStatus,
+} from "./VoiceInputSettingsSection";
+
+const mockRpc = vi.mocked(callPluginRpc);
 
 const devices = [
   { deviceId: "macbook-mic", label: "MacBook Pro Microphone" },
   { deviceId: "studio-mic", label: "Studio Display Microphone" },
 ];
 
+const transcription: VoiceTranscriptionStatus = {
+  model: "codex/gpt-transcribe",
+  enabled: true,
+  ceilingBytes: 25 * 1024 * 1024,
+  timeoutMaxMs: 300_000,
+  recordingBitrate: 32_000,
+  voiceServices: [
+    {
+      id: "codex",
+      displayName: "Codex (ChatGPT account or API key)",
+      pluginId: "provider-codex",
+    },
+    {
+      id: "local",
+      displayName: "Local",
+      pluginId: "local-transcribe",
+    },
+  ],
+};
+
+function renderContent(
+  overrides: Partial<
+    Parameters<typeof VoiceInputSettingsSectionContent>[0]
+  > = {},
+) {
+  const onUpdateTranscription = vi.fn();
+  render(
+    <TooltipProvider>
+      <VoiceInputSettingsSectionContent
+        devices={devices}
+        errorMessage={null}
+        isLoading={false}
+        isSupported={true}
+        onDeviceChange={() => undefined}
+        onRefresh={() => undefined}
+        preferredDeviceId={null}
+        transcription={transcription}
+        onUpdateTranscription={onUpdateTranscription}
+        localModelsSlot={<div>local-models-slot</div>}
+        {...overrides}
+      />
+    </TooltipProvider>,
+  );
+  return onUpdateTranscription;
+}
+
+function expandAdvanced(): void {
+  fireEvent.click(screen.getByRole("button", { name: "Advanced" }));
+}
+
+function openDropdown(label: string): void {
+  fireEvent.pointerDown(screen.getByLabelText(label), { button: 0 });
+}
+
+async function chooseOption(optionLabel: string): Promise<void> {
+  await waitFor(() =>
+    expect(screen.getByRole("menuitem", { name: optionLabel })).toBeDefined(),
+  );
+  fireEvent.click(screen.getByRole("menuitem", { name: optionLabel }));
+}
+
 afterEach(() => {
   cleanup();
+  vi.clearAllMocks();
+});
+
+describe("composeModelForProvider", () => {
+  it("keeps the current model when the provider is unchanged", () => {
+    expect(composeModelForProvider("codex", "codex/gpt-4o-mini-transcribe")).toBe(
+      "codex/gpt-4o-mini-transcribe",
+    );
+  });
+
+  it("uses the Codex default model when switching to Codex", () => {
+    expect(composeModelForProvider("codex", "local/parakeet-v2")).toBe(
+      "codex/gpt-transcribe",
+    );
+  });
+
+  it("always sets local/parakeet-v2 for the Local provider", () => {
+    expect(composeModelForProvider("local", "codex/gpt-transcribe")).toBe(
+      "local/parakeet-v2",
+    );
+  });
+
+  it("leaves unknown providers untouched", () => {
+    expect(composeModelForProvider("openai", "openai/whisper-1")).toBe(
+      "openai/whisper-1",
+    );
+  });
+
+  it("carries the model id across to a third provider", () => {
+    expect(composeModelForProvider("acme", "openai/whisper-1")).toBe(
+      "acme/whisper-1",
+    );
+  });
+
+  it("returns null when no valid model string can be composed", () => {
+    expect(composeModelForProvider("acme", "openai")).toBeNull();
+    expect(composeModelForProvider("acme", "")).toBeNull();
+  });
 });
 
 describe("VoiceInputSettingsSectionContent", () => {
-  it("keeps the refresh action inline with the heading on mobile", () => {
-    render(
-      <TooltipProvider>
-        <VoiceInputSettingsSectionContent
-          devices={devices}
-          errorMessage={null}
-          isLoading={false}
-          isSupported={true}
-          onDeviceChange={() => undefined}
-          onRefresh={() => undefined}
-          preferredDeviceId={null}
-        />
-      </TooltipProvider>,
-    );
+  it("offers Codex and Local with no model textbox and no Active badge", async () => {
+    renderContent();
+    expect(
+      (screen.getByLabelText("Transcription provider") as HTMLElement)
+        .textContent,
+    ).toContain("Codex");
+    expect(screen.queryByLabelText("Transcription model id")).toBeNull();
+    expect(screen.queryByText("Active")).toBeNull();
+    expect(screen.queryByText("Unavailable")).toBeNull();
 
-    const refreshAction = screen.getByRole("button", {
-      name: "Load microphones",
-    });
-    const sectionHeader = refreshAction.parentElement?.parentElement;
-    expect(sectionHeader?.classList.contains("flex-row")).toBe(true);
-    expect(sectionHeader?.classList.contains("flex-col")).toBe(false);
+    openDropdown("Transcription provider");
+    await waitFor(() =>
+      expect(
+        screen.getByRole("menuitem", {
+          name: "Codex (ChatGPT account or API key)",
+        }),
+      ).toBeDefined(),
+    );
+    expect(screen.getByRole("menuitem", { name: "Local" })).toBeDefined();
+    expect(screen.queryByRole("menuitem", { name: "OpenAI" })).toBeNull();
   });
 
-  it("keeps a stale selected microphone visible as unavailable", () => {
+  it("offers only registered services, not a hardcoded universe", async () => {
+    cleanup();
+    renderContent({
+      transcription: {
+        ...transcription,
+        voiceServices: [transcription.voiceServices[0]],
+      },
+    });
+    openDropdown("Transcription provider");
+    await waitFor(() =>
+      expect(
+        screen.getByRole("menuitem", {
+          name: "Codex (ChatGPT account or API key)",
+        }),
+      ).toBeDefined(),
+    );
+    expect(screen.queryByRole("menuitem", { name: "Local" })).toBeNull();
+  });
+
+  it("switching provider commits the composed model string", async () => {
+    const onUpdate = renderContent();
+    openDropdown("Transcription provider");
+    await chooseOption("Local");
+    expect(onUpdate).toHaveBeenCalledWith({
+      transcriptionModel: "local/parakeet-v2",
+    });
+  });
+
+  it("does not show per-service cap ledger rows", () => {
+    renderContent();
+    expect(screen.queryByText("Service audio limits")).toBeNull();
+    expect(screen.queryByText(/effective/i)).toBeNull();
+  });
+
+  it("keeps advanced controls collapsed until expanded", () => {
+    renderContent();
+    expect(screen.queryByLabelText("Recording limit")).toBeNull();
+
+    expandAdvanced();
+
+    expect(screen.getByLabelText("Recording limit")).toBeDefined();
+    expect(
+      screen.getByText(/How large a recording can be/),
+    ).toBeDefined();
+  });
+
+  it("commits a recording limit from the dropdown", async () => {
+    const onUpdate = renderContent();
+    expandAdvanced();
+    openDropdown("Recording limit");
+    await chooseOption("10 MB");
+    expect(onUpdate).toHaveBeenCalledWith({
+      transcriptionMaxBytes: 10 * 1024 * 1024,
+    });
+  });
+
+  it("commits a recording quality from the dropdown with a minutes hint", async () => {
+    const onUpdate = renderContent();
+    expandAdvanced();
+    expect(screen.getByText(/About 109 minutes/)).toBeDefined();
+    openDropdown("Recording quality");
+    await chooseOption("64 kbps");
+    expect(onUpdate).toHaveBeenCalledWith({ recordingBitrate: 64_000 });
+  });
+
+  it("keeps the timeout input with plain-language copy", () => {
+    renderContent();
+    expandAdvanced();
+    expect(
+      screen.getByText(/does not respond by that time/),
+    ).toBeDefined();
+    expect(
+      (screen.getByLabelText("Transcription timeout in seconds") as HTMLInputElement)
+        .value,
+    ).toBe("300");
+  });
+
+  it("renders the local-models slot only when the provider is Local", () => {
+    renderContent();
+    expect(screen.queryByText("local-models-slot")).toBeNull();
+
+    cleanup();
+    renderContent({
+      transcription: { ...transcription, model: "local/parakeet-v2" },
+    });
+    expect(screen.getByText("local-models-slot")).toBeDefined();
+  });
+});
+
+describe("LocalModelsSubsection", () => {
+  function renderSubsection(pluginId: string | null) {
+    const { wrapper } = createQueryClientTestHarness();
     render(
       <TooltipProvider>
-        <VoiceInputSettingsSectionContent
-          devices={devices}
-          errorMessage={null}
-          isLoading={false}
-          isSupported={true}
-          onDeviceChange={() => undefined}
-          onRefresh={() => undefined}
-          preferredDeviceId="missing-mic"
+        <LocalModelsSubsection pluginId={pluginId} />
+      </TooltipProvider>,
+      { wrapper },
+    );
+  }
+
+  it("shows the plugin-missing fallback when no local plugin is installed", () => {
+    renderSubsection(null);
+    expect(screen.getByText(/local-transcribe plugin/)).toBeDefined();
+    expect(screen.getByText(/isn't installed/)).toBeDefined();
+    expect(mockRpc).not.toHaveBeenCalled();
+  });
+
+  it("shows the plugin error fallback when the RPC fails", async () => {
+    mockRpc.mockRejectedValue(new Error("plugin offline"));
+    renderSubsection("local-stt");
+    await waitFor(() =>
+      expect(screen.getByText(/Couldn't load local models/)).toBeDefined(),
+    );
+  });
+
+  it("shows an empty state when no models are downloadable", async () => {
+    mockRpc.mockResolvedValue({ models: [] });
+    renderSubsection("local-stt");
+    await waitFor(() =>
+      expect(
+        screen.getByText("No local models are available to download yet."),
+      ).toBeDefined(),
+    );
+  });
+
+  it("renders state-driven actions for each model", async () => {
+    mockRpc.mockResolvedValue({
+      models: [
+        {
+          id: "parakeet-v2",
+          displayName: "Parakeet v2 English",
+          state: "missing",
+          infoUrl: "https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2",
+        },
+        { id: "ready-one", displayName: "Ready One", state: "ready" },
+        {
+          id: "busy-one",
+          displayName: "Busy One",
+          state: "downloading",
+          progressPercent: 42,
+        },
+        { id: "weird", displayName: "Weird One", state: "verifying" },
+      ],
+    });
+    renderSubsection("local-stt");
+
+    await waitFor(() =>
+      expect(screen.getByText("Parakeet v2 English")).toBeDefined(),
+    );
+    expect(screen.getByRole("button", { name: "Download" })).toBeDefined();
+    expect(screen.getByRole("button", { name: "Use" })).toBeDefined();
+    expect(screen.getByText("42%")).toBeDefined();
+    expect(screen.getByText("verifying")).toBeDefined();
+    expect(screen.getByText("1/4 downloaded")).toBeDefined();
+    expect(
+      screen.getByRole("button", { name: "Open model card on Hugging Face" }),
+    ).toBeDefined();
+  });
+
+  it("marks the active model with a check and selects another on Use", async () => {
+    mockRpc.mockResolvedValue({
+      models: [
+        { id: "parakeet-v2", displayName: "Parakeet v2", state: "ready" },
+        { id: "parakeet-v3", displayName: "Parakeet v3", state: "ready" },
+      ],
+    });
+    const onSelectModel = vi.fn();
+    const { wrapper } = createQueryClientTestHarness();
+    render(
+      <TooltipProvider>
+        <LocalModelsSubsection
+          pluginId="local-stt"
+          activeModelId="parakeet-v2"
+          onSelectModel={onSelectModel}
         />
       </TooltipProvider>,
+      { wrapper },
     );
 
-    expect(screen.getByText("Unavailable microphone")).toBeDefined();
-    expect(
-      screen.getByText("Selected microphone is unavailable."),
-    ).toBeDefined();
+    await waitFor(() =>
+      expect(screen.getByLabelText("Selected model")).toBeDefined(),
+    );
+    expect(screen.queryByText("In use")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Use" }));
+    expect(onSelectModel).toHaveBeenCalledWith("parakeet-v3");
+  });
+
+  it("starts a download via models_setup on click", async () => {
+    mockRpc.mockImplementation(async (_fetch, _pluginId, method) => {
+      if (method === "models_setup") {
+        return { started: true };
+      }
+      return {
+        models: [
+          { id: "parakeet-v2", displayName: "Parakeet v2", state: "missing" },
+        ],
+      };
+    });
+    renderSubsection("local-stt");
+
+    const button = await screen.findByRole("button", { name: "Download" });
+    fireEvent.click(button);
+
+    await waitFor(() =>
+      expect(mockRpc).toHaveBeenCalledWith(
+        expect.anything(),
+        "local-stt",
+        "models_setup",
+        { id: "parakeet-v2" },
+      ),
+    );
+  });
+
+  it("deletes a downloaded model via models_remove", async () => {
+    mockRpc.mockImplementation(async (_fetch, _pluginId, method) => {
+      if (method === "models_remove") {
+        return { removed: true };
+      }
+      return {
+        models: [
+          { id: "parakeet-v2", displayName: "Parakeet v2", state: "ready" },
+        ],
+      };
+    });
+    const { wrapper } = createQueryClientTestHarness();
+    render(
+      <TooltipProvider>
+        <LocalModelsSubsection pluginId="local-stt" />
+      </TooltipProvider>,
+      { wrapper },
+    );
+
+    const button = await screen.findByRole("button", { name: "Delete Parakeet v2" });
+    fireEvent.click(button);
+
+    await waitFor(() =>
+      expect(mockRpc).toHaveBeenCalledWith(
+        expect.anything(),
+        "local-stt",
+        "models_remove",
+        { id: "parakeet-v2" },
+      ),
+    );
+  });
+
+  it("surfaces a failed download with its error and a retry action", async () => {
+    mockRpc.mockImplementation(async (_fetch, _pluginId, method) => {
+      if (method === "models_setup") {
+        return { started: true };
+      }
+      return {
+        models: [
+          {
+            id: "parakeet-v2",
+            displayName: "Parakeet v2 English",
+            state: "failed",
+            error: "download failed (500)",
+          },
+        ],
+      };
+    });
+    renderSubsection("local-stt");
+
+    await waitFor(() =>
+      expect(screen.getByText("download failed (500)")).toBeDefined(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    await waitFor(() =>
+      expect(mockRpc).toHaveBeenCalledWith(
+        expect.anything(),
+        "local-stt",
+        "models_setup",
+        { id: "parakeet-v2" },
+      ),
+    );
   });
 });

--- a/apps/app/src/components/settings/VoiceInputSettingsSection.tsx
+++ b/apps/app/src/components/settings/VoiceInputSettingsSection.tsx
@@ -1,3 +1,11 @@
+import { useState, type ReactNode } from "react";
+import { isDecimalIntegerString } from "@bb/config/voice-transcription-limit";
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+import { z } from "zod";
 import { Button } from "@bb/shared-ui/button";
 import { COARSE_POINTER_ICON_SIZE_CLASS } from "@bb/shared-ui/coarse-pointer-sizing";
 import {
@@ -8,9 +16,16 @@ import {
   DropdownMenuTrigger,
 } from "@bb/shared-ui/dropdown-menu";
 import { Icon } from "@bb/shared-ui/icon";
+import { Input } from "@bb/shared-ui/input";
 import { cn } from "@bb/shared-ui/lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@bb/shared-ui/tooltip";
+import type { SystemTranscriptionSettingsUpdate } from "@bb/server-contract";
 import {
+  getCollapsibleHeaderToneClass,
+  CollapsibleHeader,
+} from "@/components/ui/disclosure";
+import {
+  SettingsBadge,
   SettingsSection,
   SettingsWithControl,
 } from "@/components/ui/settings-section";
@@ -18,10 +33,36 @@ import {
   useAudioInputDevices,
   type AudioInputDeviceOption,
 } from "@/hooks/useAudioInputDevices";
+import { invalidateVoiceLocalModels } from "@/hooks/cache-owners/voice-cache-owner";
+import { useSystemConfig } from "@/hooks/queries/system-queries";
+import { voiceLocalModelsQueryKey } from "@/hooks/queries/query-keys";
+import { useUpdateTranscriptionSettings } from "@/hooks/mutations/settings-mutations";
+import { callPluginRpc } from "@/lib/plugin-sdk-hooks";
+import { fetchWithAppSurface } from "@/lib/app-surface";
+import { openUrlInExternalBrowser } from "@/lib/url-open-routing";
 import {
   useAudioInputDevicePreference,
   type PreferredAudioInputDeviceId,
 } from "@/lib/audio-input-device-preference";
+
+export interface VoiceTranscriptionServiceStatus {
+  id: string;
+  displayName: string;
+  pluginId: string;
+}
+
+export interface VoiceTranscriptionStatus {
+  model: string;
+  enabled: boolean;
+  ceilingBytes: number;
+  timeoutMaxMs: number;
+  recordingBitrate: number;
+  voiceServices: readonly VoiceTranscriptionServiceStatus[];
+}
+
+type OnUpdateTranscription = (
+  update: SystemTranscriptionSettingsUpdate,
+) => void;
 
 interface VoiceInputSettingsSectionContentProps {
   devices: readonly AudioInputDeviceOption[];
@@ -31,6 +72,10 @@ interface VoiceInputSettingsSectionContentProps {
   onDeviceChange: (deviceId: PreferredAudioInputDeviceId) => void;
   onRefresh: (requestPermission: boolean) => void;
   preferredDeviceId: PreferredAudioInputDeviceId;
+  transcription?: VoiceTranscriptionStatus;
+  onUpdateTranscription?: OnUpdateTranscription;
+  isSavingTranscription?: boolean;
+  localModelsSlot?: ReactNode;
 }
 
 const SETTINGS_DROPDOWN_TRIGGER_CLASS =
@@ -95,6 +140,696 @@ function microphoneSettingDescription({
   return "Used for prompt voice input.";
 }
 
+const MB = 1024 * 1024;
+/**
+ * Recording-limit choices offered in Settings, within the 10MB overall voice
+ * cap the plugin transport can carry.
+ */
+const AUDIO_LIMIT_MB_OPTIONS = [2, 5, 10] as const;
+const TIMEOUT_MIN_S = 10;
+const TIMEOUT_MAX_S = 900;
+const BITRATE_KBPS_OPTIONS = [24, 32, 64, 128] as const;
+
+const NUMBER_INPUT_CLASS = "h-7 w-20 text-right text-xs";
+
+export const LOCAL_TRANSCRIPTION_PROVIDER_ID = "local";
+export const LOCAL_TRANSCRIPTION_MODEL = "local/parakeet-v2";
+export const CODEX_TRANSCRIPTION_PROVIDER_ID = "codex";
+export const CODEX_TRANSCRIPTION_MODEL = "codex/gpt-transcribe";
+
+const PROVIDER_DEFAULT_MODELS: Record<string, string> = {
+  [CODEX_TRANSCRIPTION_PROVIDER_ID]: CODEX_TRANSCRIPTION_MODEL,
+  [LOCAL_TRANSCRIPTION_PROVIDER_ID]: LOCAL_TRANSCRIPTION_MODEL,
+};
+
+export interface TranscriptionProviderOption {
+  provider: string;
+  label: string;
+}
+
+/**
+ * Provider dropdown options derived from the voice services actually
+ * registered by loaded plugins — never a hardcoded universe. A provider with
+ * no registered service simply has no option, instead of a dead entry.
+ */
+export function transcriptionProviderOptions(
+  transcription: VoiceTranscriptionStatus,
+): TranscriptionProviderOption[] {
+  return transcription.voiceServices.map((service) => ({
+    provider: service.id,
+    label: service.displayName,
+  }));
+}
+
+function approxMinutesText(ceilingBytes: number, bitrateBps: number): string {
+  if (bitrateBps <= 0) {
+    return "";
+  }
+  const minutes = Math.max(
+    1,
+    Math.round((ceilingBytes * 8) / bitrateBps / 60),
+  );
+  return `About ${minutes} minutes at the current limit.`;
+}
+
+function splitModel(model: string): { provider: string; modelId: string } {
+  const separator = model.indexOf("/");
+  if (separator < 0) {
+    return { provider: model, modelId: "" };
+  }
+  return {
+    provider: model.slice(0, separator),
+    modelId: model.slice(separator + 1),
+  };
+}
+
+export function composeModelForProvider(
+  nextProvider: string,
+  currentModel: string,
+): string | null {
+  const { provider, modelId } = splitModel(currentModel);
+  if (nextProvider === provider) {
+    return currentModel;
+  }
+  const knownDefault = PROVIDER_DEFAULT_MODELS[nextProvider];
+  if (knownDefault !== undefined) {
+    return knownDefault;
+  }
+  // Carry the model id across to a third provider instead of clobbering it.
+  // With no model id there is nothing valid to compose, so report that rather
+  // than writing a broken value or silently doing nothing.
+  if (modelId.length > 0) {
+    return `${nextProvider}/${modelId}`;
+  }
+  return null;
+}
+
+function TranscriptionProviderControl({
+  transcription,
+  options,
+  onUpdate,
+  disabled,
+}: {
+  transcription: VoiceTranscriptionStatus;
+  options: TranscriptionProviderOption[];
+  onUpdate: OnUpdateTranscription;
+  disabled: boolean;
+}) {
+  const { provider } = splitModel(transcription.model);
+  const activeLabel =
+    options.find((option) => option.provider === provider)?.label ??
+    (provider.length > 0 ? provider : "Select provider");
+
+  function select(nextProvider: string): void {
+    const nextModel = composeModelForProvider(nextProvider, transcription.model);
+    if (nextModel !== null && nextModel !== transcription.model) {
+      onUpdate({ transcriptionModel: nextModel });
+    }
+  }
+
+  return (
+    <SettingsWithControl
+      label="Transcription provider"
+      description="Who turns your voice into text. Codex runs in the cloud, Local runs on this machine."
+    >
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="outline"
+            size="sm"
+            className={SETTINGS_DROPDOWN_TRIGGER_CLASS}
+            aria-label="Transcription provider"
+            disabled={disabled}
+          >
+            <span className="min-w-0 truncate">{activeLabel}</span>
+            <Icon
+              name="ChevronDown"
+              className="size-3.5 shrink-0 text-muted-foreground"
+            />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          align="end"
+          className={SETTINGS_DROPDOWN_CONTENT_CLASS}
+          mobileTitle="Transcription provider"
+        >
+          {options.map((option) => (
+            <DropdownMenuItem
+              key={option.provider}
+              onSelect={() => select(option.provider)}
+            >
+              <span className="min-w-0 truncate">{option.label}</span>
+              <Icon
+                name="Check"
+                className={cn(
+                  "ml-auto",
+                  provider !== option.provider && "opacity-0",
+                  COARSE_POINTER_ICON_SIZE_CLASS,
+                )}
+              />
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </SettingsWithControl>
+  );
+}
+
+interface SettingOption {
+  value: number;
+  label: string;
+}
+
+function OptionSettingControl({
+  label,
+  description,
+  ariaLabel,
+  options,
+  currentValue,
+  currentLabel,
+  disabled,
+  onCommit,
+}: {
+  label: string;
+  description: ReactNode;
+  ariaLabel: string;
+  options: readonly SettingOption[];
+  currentValue: number;
+  currentLabel: string;
+  disabled: boolean;
+  onCommit: (value: number) => void;
+}) {
+  return (
+    <SettingsWithControl label={label} description={description}>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="outline"
+            size="sm"
+            className={SETTINGS_DROPDOWN_TRIGGER_CLASS}
+            aria-label={ariaLabel}
+            disabled={disabled}
+          >
+            <span className="min-w-0 truncate">{currentLabel}</span>
+            <Icon
+              name="ChevronDown"
+              className="size-3.5 shrink-0 text-muted-foreground"
+            />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          align="end"
+          className={SETTINGS_DROPDOWN_CONTENT_CLASS}
+          mobileTitle={label}
+        >
+          {options.map((option) => (
+            <DropdownMenuItem
+              key={option.value}
+              onSelect={() => {
+                if (option.value !== currentValue) {
+                  onCommit(option.value);
+                }
+              }}
+            >
+              <span className="min-w-0 truncate">{option.label}</span>
+              <Icon
+                name="Check"
+                className={cn(
+                  "ml-auto",
+                  option.value !== currentValue && "opacity-0",
+                  COARSE_POINTER_ICON_SIZE_CLASS,
+                )}
+              />
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </SettingsWithControl>
+  );
+}
+
+function NumericSettingControl({
+  label,
+  description,
+  ariaLabel,
+  unitSuffix,
+  currentValue,
+  min,
+  max,
+  disabled,
+  onCommit,
+}: {
+  label: string;
+  description: string;
+  ariaLabel: string;
+  unitSuffix: string;
+  currentValue: number;
+  min: number;
+  max: number;
+  disabled: boolean;
+  onCommit: (value: number) => void;
+}) {
+  const [text, setText] = useState(String(currentValue));
+  const [error, setError] = useState<string | null>(null);
+
+  function validate(raw: string): string | null {
+    if (!isDecimalIntegerString(raw)) {
+      return `Enter a whole number of ${unitSuffix}.`;
+    }
+    const parsed = Number(raw.trim());
+    if (parsed < min || parsed > max) {
+      return `Must be between ${min} and ${max} ${unitSuffix}.`;
+    }
+    return null;
+  }
+
+  function commit(): void {
+    const nextError = validate(text);
+    setError(nextError);
+    if (nextError !== null) {
+      return;
+    }
+    const parsed = Number(text.trim());
+    if (parsed !== currentValue) {
+      onCommit(parsed);
+    }
+  }
+
+  return (
+    <SettingsWithControl label={label} description={description}>
+      <div className="flex flex-col items-stretch gap-1 sm:items-end">
+        <div className="flex items-center gap-1.5">
+          <Input
+            type="text"
+            inputMode="numeric"
+            className={NUMBER_INPUT_CLASS}
+            value={text}
+            aria-label={ariaLabel}
+            aria-invalid={error !== null}
+            disabled={disabled}
+            onChange={(event) => {
+              setText(event.target.value);
+              setError(validate(event.target.value));
+            }}
+            onBlur={commit}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                event.preventDefault();
+                commit();
+              }
+            }}
+          />
+          <span className="text-xs text-muted-foreground">{unitSuffix}</span>
+        </div>
+        {error ? (
+          <p role="alert" className="text-2xs text-destructive">
+            {error}
+          </p>
+        ) : null}
+      </div>
+    </SettingsWithControl>
+  );
+}
+
+function AdvancedTranscriptionControls({
+  transcription,
+  onUpdate,
+  isSaving,
+}: {
+  transcription: VoiceTranscriptionStatus;
+  onUpdate: OnUpdateTranscription;
+  isSaving: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const ceilingMb = Math.round(transcription.ceilingBytes / MB);
+  const timeoutSeconds = Math.round(transcription.timeoutMaxMs / 1000);
+  const bitrateKbps = Math.round(transcription.recordingBitrate / 1000);
+
+  return (
+    <div className="space-y-3">
+      <CollapsibleHeader
+        summaryContent="Advanced"
+        toneClassName={getCollapsibleHeaderToneClass(open)}
+        isExpanded={open}
+        forceChevronVisible
+        onToggle={() => setOpen((value) => !value)}
+      />
+      {open ? (
+        <div className="space-y-4">
+          <OptionSettingControl
+            label="Recording limit"
+            description="How large a recording can be before it is rejected."
+            ariaLabel="Recording limit"
+            options={AUDIO_LIMIT_MB_OPTIONS.map((mb) => ({
+              value: mb,
+              label: `${mb} MB`,
+            }))}
+            currentValue={ceilingMb}
+            currentLabel={`${ceilingMb} MB`}
+            disabled={isSaving}
+            onCommit={(mb) => onUpdate({ transcriptionMaxBytes: mb * MB })}
+          />
+          <NumericSettingControl
+            key={`timeout-${transcription.timeoutMaxMs}`}
+            label="Transcription timeout"
+            description="Times out if transcription does not respond by that time."
+            ariaLabel="Transcription timeout in seconds"
+            unitSuffix="s"
+            currentValue={timeoutSeconds}
+            min={TIMEOUT_MIN_S}
+            max={TIMEOUT_MAX_S}
+            disabled={isSaving}
+            onCommit={(seconds) =>
+              onUpdate({ transcriptionTimeoutMaxMs: seconds * 1000 })
+            }
+          />
+          <OptionSettingControl
+            label="Recording quality"
+            description={`Affects the quality of your transcription. ${approxMinutesText(transcription.ceilingBytes, transcription.recordingBitrate)}`}
+            ariaLabel="Recording quality"
+            options={BITRATE_KBPS_OPTIONS.map((kbps) => ({
+              value: kbps,
+              label: `${kbps} kbps`,
+            }))}
+            currentValue={bitrateKbps}
+            currentLabel={`${bitrateKbps} kbps`}
+            disabled={isSaving}
+            onCommit={(kbps) => onUpdate({ recordingBitrate: kbps * 1000 })}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+const LOCAL_PLUGIN_MISSING_FALLBACK =
+  "Local transcription needs the local-transcribe plugin, which isn't installed. Install the plugin, then download a model here.";
+const LOCAL_MODELS_ERROR_FALLBACK =
+  "Couldn't load local models from the local-transcribe plugin.";
+
+const localModelSchema = z.object({  id: z.string().min(1),
+  displayName: z.string().min(1),
+  description: z.string().optional(),
+  infoUrl: z.string().optional(),
+  downloadBytes: z.number().optional(),
+  state: z.string(),
+  error: z.string().optional(),
+  progressPercent: z.number().optional(),
+});
+const localModelsResponseSchema = z.object({
+  models: z.array(localModelSchema),
+});
+type LocalModel = z.infer<typeof localModelSchema>;
+
+function LocalSetupFallback({ message }: { message: string }) {
+  return (
+    <div className="rounded-md border border-border bg-muted/30 px-3 py-2.5 text-xs leading-snug text-subtle-foreground/75">
+      {message}
+    </div>
+  );
+}
+
+function ModelIconButton({
+  label,
+  tooltip,
+  icon,
+  onClick,
+  disabled,
+  destructive = false,
+}: {
+  label: string;
+  tooltip: string;
+  icon: "Download" | "Trash2";
+  onClick: () => void;
+  disabled?: boolean;
+  destructive?: boolean;
+}) {
+  return (
+    <Tooltip delayDuration={300} disableHoverableContent>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className={cn(
+            "size-7 shrink-0 text-muted-foreground hover:text-foreground",
+            destructive && "hover:text-destructive",
+          )}
+          aria-label={label}
+          disabled={disabled}
+          onClick={onClick}
+        >
+          <Icon name={icon} className="size-3.5" />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">{tooltip}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+function ModelCardLink({ url }: { url?: string }) {
+  if (!url) {
+    return null;
+  }
+  return (
+    <button
+      type="button"
+      className="mt-0.5 inline-flex min-w-0 items-center gap-1 text-xs text-subtle-foreground/75 hover:text-foreground hover:underline"
+      onClick={() => openUrlInExternalBrowser(url)}
+      aria-label="Open model card on Hugging Face"
+    >
+      <span className="truncate">Model card</span>
+      <Icon name="ExternalLink" className="size-3 shrink-0" />
+    </button>
+  );
+}
+
+function LocalModelRow({
+  model,
+  isActive,
+  onSelect,
+  onDownload,
+  onRemove,
+  isStarting,
+  isRemoving,
+}: {
+  model: LocalModel;
+  isActive: boolean;
+  onSelect: (id: string) => void;
+  onDownload: (id: string) => void;
+  onRemove: (id: string) => void;
+  isStarting: boolean;
+  isRemoving: boolean;
+}) {
+  function action(): ReactNode {
+    if (model.state === "ready") {
+      // The selected model shows a checkmark instead of actions: it cannot
+      // be deleted while in use, so switch first to delete it.
+      if (isActive) {
+        return null;
+      }
+      return (
+        <span className="flex shrink-0 items-center gap-1.5">
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className="h-7 shrink-0 px-2 text-xs"
+            onClick={() => onSelect(model.id)}
+          >
+            Use
+          </Button>
+          <ModelIconButton
+            label={`Delete ${model.displayName}`}
+            tooltip="Delete model"
+            icon="Trash2"
+            destructive
+            disabled={isRemoving}
+            onClick={() => onRemove(model.id)}
+          />
+        </span>
+      );
+    }
+    if (model.state === "downloading") {
+      return (
+        <span className="flex shrink-0 items-center gap-1.5 text-xs text-muted-foreground">
+          <Icon name="Spinner" className="size-3.5 animate-spin" />
+          {typeof model.progressPercent === "number"
+            ? `${Math.round(model.progressPercent)}%`
+            : "Downloading…"}
+        </span>
+      );
+    }
+    if (model.state === "failed") {
+      return (
+        <span className="flex shrink-0 items-center gap-1.5">
+          <span className="max-w-44 truncate text-xs text-destructive" title={model.error ?? "Download failed"}>
+            {model.error ?? "Download failed"}
+          </span>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className="h-7 shrink-0 px-2 text-xs"
+            disabled={isStarting}
+            onClick={() => onDownload(model.id)}
+          >
+            <Icon name="Download" className="size-3.5" />
+            Retry
+          </Button>
+        </span>
+      );
+    }
+    if (model.state === "missing") {
+      return (
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className="h-7 shrink-0 px-2 text-xs"
+          disabled={isStarting}
+          onClick={() => onDownload(model.id)}
+        >
+          <Icon name="Download" className="size-3.5" />
+          Download
+        </Button>
+      );
+    }
+    return (
+      <SettingsBadge>{model.state.length > 0 ? model.state : "—"}</SettingsBadge>
+    );
+  }
+
+  const selected = model.state === "ready" && isActive;
+  return (
+    <li className="flex items-center gap-2.5 px-3 py-2.5">
+      {selected ? (
+        <span role="img" aria-label="Selected model" className="shrink-0">
+          <Icon name="Check" className="size-4 text-success" />
+        </span>
+      ) : null}
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-sm font-normal text-foreground">
+          {model.displayName}
+        </span>
+        <ModelCardLink url={model.infoUrl} />
+      </span>
+      {action()}
+    </li>
+  );
+}
+
+export function LocalModelsSubsection({
+  pluginId,
+  activeModelId,
+  onSelectModel,
+}: {
+  pluginId: string | null;
+  activeModelId?: string | null;
+  onSelectModel?: (id: string) => void;
+}) {
+  const queryClient = useQueryClient();
+  const query = useQuery({
+    enabled: pluginId !== null,
+    queryKey: voiceLocalModelsQueryKey(pluginId ?? ""),
+    queryFn: async () => {
+      const raw = await callPluginRpc(
+        fetchWithAppSurface,
+        pluginId ?? "",
+        "models_list",
+        null,
+      );
+      return localModelsResponseSchema.parse(raw);
+    },
+    refetchInterval: (queryState) =>
+      queryState.state.data?.models.some(
+        (model) => model.state === "downloading",
+      )
+        ? 2_000
+        : false,
+  });
+  const setup = useMutation({
+    meta: { errorMessage: "Failed to start the local model download." },
+    mutationFn: (id: string) =>
+      callPluginRpc(fetchWithAppSurface, pluginId ?? "", "models_setup", {
+        id,
+      }),
+    onSuccess: () => {
+      if (pluginId !== null) {
+        invalidateVoiceLocalModels({ pluginId, queryClient });
+      }
+    },
+  });
+  const remove = useMutation({
+    meta: { errorMessage: "Failed to delete the local model." },
+    mutationFn: (id: string) =>
+      callPluginRpc(fetchWithAppSurface, pluginId ?? "", "models_remove", {
+        id,
+      }),
+    onSuccess: () => {
+      if (pluginId !== null) {
+        invalidateVoiceLocalModels({ pluginId, queryClient });
+      }
+    },
+  });
+
+  function body(): ReactNode {
+    if (pluginId === null) {
+      return <LocalSetupFallback message={LOCAL_PLUGIN_MISSING_FALLBACK} />;
+    }
+    if (query.isError) {
+      return <LocalSetupFallback message={LOCAL_MODELS_ERROR_FALLBACK} />;
+    }
+    if (!query.isSuccess) {
+      return (
+        <p className="text-xs text-subtle-foreground/75">
+          Checking local models…
+        </p>
+      );
+    }
+    if (query.data.models.length === 0) {
+      return (
+        <LocalSetupFallback message="No local models are available to download yet." />
+      );
+    }
+    return (
+      <ul className="max-h-64 divide-y divide-border overflow-y-auto rounded-lg border border-border bg-muted/30">
+        {query.data.models.map((model) => (
+          <LocalModelRow
+            key={model.id}
+            model={model}
+            isActive={activeModelId === model.id}
+            onSelect={(id) => onSelectModel?.(id)}
+            onDownload={(id) => setup.mutate(id)}
+            onRemove={(id) => remove.mutate(id)}
+            isStarting={setup.isPending && setup.variables === model.id}
+            isRemoving={remove.isPending && remove.variables === model.id}
+          />
+        ))}
+      </ul>
+    );
+  }
+
+  const readyCount = query.data?.models.filter(
+    (model) => model.state === "ready",
+  ).length;
+  const totalCount = query.data?.models.length ?? 0;
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex min-w-0 items-center justify-between gap-2">
+        <p className="text-sm font-normal text-foreground">Local models</p>
+        {query.isSuccess ? (
+          <SettingsBadge>
+            {`${readyCount ?? 0}/${totalCount} downloaded`}
+          </SettingsBadge>
+        ) : null}
+      </div>
+      {body()}
+    </div>
+  );
+}
+
 export function VoiceInputSettingsSectionContent({
   devices,
   errorMessage,
@@ -103,12 +838,21 @@ export function VoiceInputSettingsSectionContent({
   onDeviceChange,
   onRefresh,
   preferredDeviceId,
+  transcription,
+  onUpdateTranscription,
+  isSavingTranscription = false,
+  localModelsSlot,
 }: VoiceInputSettingsSectionContentProps) {
   const triggerLabel = selectedMicrophoneLabel({
     devices,
     isSupported,
     preferredDeviceId,
   });
+  const showTranscription =
+    transcription !== undefined && onUpdateTranscription !== undefined;
+  const isLocalProvider =
+    transcription !== undefined &&
+    splitModel(transcription.model).provider === LOCAL_TRANSCRIPTION_PROVIDER_ID;
 
   return (
     <SettingsSection
@@ -136,6 +880,7 @@ export function VoiceInputSettingsSectionContent({
           <TooltipContent side="bottom">Load microphones</TooltipContent>
         </Tooltip>
       }
+      bodyClassName="space-y-4"
     >
       <SettingsWithControl
         label={MICROPHONE_SETTING_LABEL}
@@ -208,13 +953,65 @@ export function VoiceInputSettingsSectionContent({
           </DropdownMenuContent>
         </DropdownMenu>
       </SettingsWithControl>
+      {showTranscription ? (
+        <>
+          <TranscriptionProviderControl
+            transcription={transcription}
+            options={transcriptionProviderOptions(transcription)}
+            onUpdate={onUpdateTranscription}
+            disabled={isSavingTranscription}
+          />
+          {isLocalProvider ? localModelsSlot : null}
+          <AdvancedTranscriptionControls
+            transcription={transcription}
+            onUpdate={onUpdateTranscription}
+            isSaving={isSavingTranscription}
+          />
+        </>
+      ) : null}
     </SettingsSection>
   );
+}
+
+function useVoiceTranscriptionStatus(): VoiceTranscriptionStatus | undefined {
+  const { data } = useSystemConfig();
+  if (data === undefined) {
+    return undefined;
+  }
+  const ai = data.aiServices;
+  return {
+    model: ai.transcription,
+    enabled: data.voiceTranscriptionEnabled,
+    ceilingBytes: ai.transcriptionMaxBytes,
+    timeoutMaxMs: ai.transcriptionTimeoutMaxMs,
+    recordingBitrate: ai.recordingBitrate,
+    voiceServices: ai.services
+      .filter((service) => service.kinds.includes("voice"))
+      .map((service) => ({
+        id: service.id,
+        displayName: service.displayName,
+        pluginId: service.pluginId,
+      })),
+  };
+}
+
+function resolveLocalPluginId(
+  transcription: VoiceTranscriptionStatus | undefined,
+): string | null {
+  if (transcription === undefined) {
+    return null;
+  }
+  const service = transcription.voiceServices.find(
+    (candidate) => candidate.id === LOCAL_TRANSCRIPTION_PROVIDER_ID,
+  );
+  return service?.pluginId ?? null;
 }
 
 export function VoiceInputSettingsSection() {
   const [preferredDeviceId, setPreferredDeviceId] =
     useAudioInputDevicePreference();
+  const transcription = useVoiceTranscriptionStatus();
+  const updateTranscription = useUpdateTranscriptionSettings();
   const { devices, errorMessage, isLoading, isSupported, refresh } =
     useAudioInputDevices();
 
@@ -229,6 +1026,21 @@ export function VoiceInputSettingsSection() {
         void refresh({ requestPermission });
       }}
       preferredDeviceId={preferredDeviceId}
+      isSavingTranscription={updateTranscription.isPending}
+      onUpdateTranscription={(update) => updateTranscription.mutate(update)}
+      localModelsSlot={
+        <LocalModelsSubsection
+          pluginId={resolveLocalPluginId(transcription)}
+          activeModelId={
+            transcription !== undefined &&
+            splitModel(transcription.model).provider === LOCAL_TRANSCRIPTION_PROVIDER_ID
+              ? (splitModel(transcription.model).modelId || null)
+              : null
+          }
+          onSelectModel={(id) => updateTranscription.mutate({ transcriptionModel: `local/${id}` })}
+        />
+      }
+      {...(transcription === undefined ? {} : { transcription })}
     />
   );
 }

--- a/apps/app/src/hooks/cache-owners/cache-owner-registry.test.ts
+++ b/apps/app/src/hooks/cache-owners/cache-owner-registry.test.ts
@@ -221,6 +221,7 @@ const CACHE_OWNER_QUERY_KEY_IMPORTS: CacheOwnerQueryKeyImportRegistry = {
     "TerminalQueryScope",
     "terminalsQueryKey",
   ],
+  "hooks/cache-owners/voice-cache-owner.ts": ["voiceLocalModelsQueryKey"],
   "hooks/cache-owners/thread-archive-cache.ts": [
     "threadQueryKey",
     "threadsQueryKey",

--- a/apps/app/src/hooks/cache-owners/voice-cache-owner.ts
+++ b/apps/app/src/hooks/cache-owners/voice-cache-owner.ts
@@ -1,0 +1,16 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { voiceLocalModelsQueryKey } from "../queries/query-keys";
+
+interface InvalidateVoiceLocalModelsArgs {
+  pluginId: string;
+  queryClient: QueryClient;
+}
+
+export function invalidateVoiceLocalModels({
+  pluginId,
+  queryClient,
+}: InvalidateVoiceLocalModelsArgs): void {
+  void queryClient.invalidateQueries({
+    queryKey: voiceLocalModelsQueryKey(pluginId),
+  });
+}

--- a/apps/app/src/hooks/mutations/settings-mutations.test.tsx
+++ b/apps/app/src/hooks/mutations/settings-mutations.test.tsx
@@ -26,6 +26,7 @@ import {
 import {
   useUpdateGeneralSettings,
   useUpdateKeyboardSettings,
+  useUpdateTranscriptionSettings,
 } from "./settings-mutations";
 
 vi.mock("@/lib/sdk", () => {
@@ -34,6 +35,7 @@ vi.mock("@/lib/sdk", () => {
       system: {
         updateGeneralSettings: vi.fn(),
         updateKeyboardSettings: vi.fn(),
+        updateTranscriptionSettings: vi.fn(),
       },
     },
   };
@@ -166,6 +168,28 @@ describe("general settings mutation", () => {
       expect(queryClient.getQueryData(executionOptionsKey)).toBeUndefined(),
     );
     expect(readCachedModelCatalog(catalogCacheKey)).toBeNull();
+  });
+});
+
+describe("transcription settings mutation", () => {
+  it("sends the update and invalidates system config on success", async () => {
+    const { queryClient, wrapper } = createQueryClientTestHarness();
+    const configKey = systemConfigQueryKey();
+    queryClient.setQueryData(configKey, systemConfig());
+    vi.mocked(sdk.system.updateTranscriptionSettings).mockResolvedValue(
+      systemConfig().aiServices,
+    );
+    const { result } = renderHook(() => useUpdateTranscriptionSettings(), {
+      wrapper,
+    });
+
+    act(() => result.current.mutate({ transcriptionMaxBytes: 10 * 1024 * 1024 }));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(sdk.system.updateTranscriptionSettings).toHaveBeenCalledWith({
+      transcriptionMaxBytes: 10 * 1024 * 1024,
+    });
+    expect(queryClient.getQueryState(configKey)?.isInvalidated).toBe(true);
   });
 });
 

--- a/apps/app/src/hooks/mutations/settings-mutations.ts
+++ b/apps/app/src/hooks/mutations/settings-mutations.ts
@@ -5,7 +5,10 @@ import {
   type AppThemeSelection,
   type Experiments,
 } from "@bb/domain";
-import type { SystemInstallCliSkillsRequest } from "@bb/server-contract";
+import type {
+  SystemInstallCliSkillsRequest,
+  SystemTranscriptionSettingsUpdate,
+} from "@bb/server-contract";
 import { sdk } from "@/lib/sdk";
 import {
   invalidateGeneralSettingsDependencies,
@@ -60,6 +63,21 @@ export function useUpdateGeneralSettings() {
       if (providerOrderChanged) {
         void invalidateSystemProviders({ queryClient });
       }
+    },
+  });
+}
+
+export function useUpdateTranscriptionSettings() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    meta: {
+      errorMessage: "Failed to update transcription settings.",
+    },
+    mutationFn: (update: SystemTranscriptionSettingsUpdate) =>
+      sdk.system.updateTranscriptionSettings(update),
+    onSuccess: () => {
+      invalidateSystemConfig({ queryClient });
     },
   });
 }

--- a/apps/app/src/hooks/queries/query-keys.ts
+++ b/apps/app/src/hooks/queries/query-keys.ts
@@ -62,6 +62,7 @@ const SYSTEM_THEME_QUERY_KEY = "systemTheme";
 export const SYSTEM_EXECUTION_OPTIONS_QUERY_KEY = "systemExecutionOptions";
 const SYSTEM_CLI_SKILLS_QUERY_KEY = "systemCliSkills";
 const SYSTEM_VERSION_QUERY_KEY = "systemVersion";
+const VOICE_LOCAL_MODELS_QUERY_KEY = "voiceLocalModels";
 const HOST_PROVIDER_CLI_STATUS_QUERY_KEY = "hostProviderCliStatus";
 const SYSTEM_USAGE_LIMITS_QUERY_KEY = "systemUsageLimits";
 const SYSTEM_PROVIDER_STATES_QUERY_KEY = "systemProviderStates";
@@ -452,6 +453,10 @@ type SystemThemeQueryKey = readonly [typeof SYSTEM_THEME_QUERY_KEY, string];
 type AllSystemThemesQueryKeyPrefix = readonly [typeof SYSTEM_THEME_QUERY_KEY];
 type SystemCliSkillsQueryKey = readonly [typeof SYSTEM_CLI_SKILLS_QUERY_KEY];
 type SystemVersionQueryKey = readonly [typeof SYSTEM_VERSION_QUERY_KEY];
+type VoiceLocalModelsQueryKey = readonly [
+  typeof VOICE_LOCAL_MODELS_QUERY_KEY,
+  string,
+];
 type HostProviderCliStatusQueryKey = readonly [
   typeof HOST_PROVIDER_CLI_STATUS_QUERY_KEY,
   string | null,
@@ -1097,6 +1102,12 @@ export function allSystemThemesQueryKeyPrefix(): AllSystemThemesQueryKeyPrefix {
 
 export function systemVersionQueryKey(): SystemVersionQueryKey {
   return [SYSTEM_VERSION_QUERY_KEY];
+}
+
+export function voiceLocalModelsQueryKey(
+  pluginId: string,
+): VoiceLocalModelsQueryKey {
+  return [VOICE_LOCAL_MODELS_QUERY_KEY, pluginId];
 }
 
 export function hostProviderCliStatusQueryKey(

--- a/apps/app/src/hooks/useVoiceInput.test.tsx
+++ b/apps/app/src/hooks/useVoiceInput.test.tsx
@@ -1,0 +1,153 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useVoiceInput } from "@/hooks/useVoiceInput";
+
+vi.mock("@/components/ui/app-toast", () => ({
+  appToast: {
+    error: vi.fn(),
+    success: vi.fn(),
+    message: vi.fn(),
+    warning: vi.fn(),
+    loading: vi.fn(),
+    dismiss: vi.fn(),
+  },
+}));
+
+class MockMediaRecorder {
+  static isTypeSupported = vi.fn(() => true);
+  static instances: MockMediaRecorder[] = [];
+  readonly mimeType: string;
+  readonly options: MediaRecorderOptions | undefined;
+  state = "inactive";
+  onstart: (() => void) | null = null;
+  onstop: (() => void | Promise<void>) | null = null;
+  onerror: (() => void) | null = null;
+  ondataavailable: ((event: { data: Blob }) => void) | null = null;
+
+  constructor(_stream: MediaStream, options?: MediaRecorderOptions) {
+    this.options = options;
+    this.mimeType = options?.mimeType ?? "audio/webm";
+    MockMediaRecorder.instances.push(this);
+  }
+
+  start(): void {
+    this.state = "recording";
+    this.onstart?.();
+  }
+
+  stop(): void {
+    this.state = "inactive";
+    this.ondataavailable?.({
+      data: new Blob(["audio-bytes"], { type: this.mimeType }),
+    });
+    void this.onstop?.();
+  }
+}
+
+let now = 0;
+
+function defineNavigatorMediaDevices(): void {
+  const stream = { getTracks: () => [] } as unknown as MediaStream;
+  Object.defineProperty(navigator, "mediaDevices", {
+    configurable: true,
+    value: { getUserMedia: vi.fn(async () => stream) },
+  });
+}
+
+beforeEach(() => {
+  now = 0;
+  MockMediaRecorder.instances = [];
+  vi.spyOn(Date, "now").mockImplementation(() => now);
+  vi.stubGlobal("MediaRecorder", MockMediaRecorder);
+  Object.defineProperty(window, "isSecureContext", {
+    configurable: true,
+    value: true,
+  });
+  defineNavigatorMediaDevices();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+async function recordAndStop(result: {
+  current: ReturnType<typeof useVoiceInput>;
+}): Promise<void> {
+  await act(async () => {
+    await result.current.start();
+  });
+  await waitFor(() => expect(result.current.state).toBe("recording"));
+  now = 2_000;
+  await act(async () => {
+    result.current.stop();
+    await Promise.resolve();
+  });
+}
+
+describe("useVoiceInput", () => {
+  it("pins the recorder bitrate when a large-audio service supplies one", async () => {
+    const onTranscribe = vi.fn(async () => "hello world");
+    const { result } = renderHook(() =>
+      useVoiceInput({
+        onTranscript: vi.fn(),
+        onTranscribe,
+        getAudioBitsPerSecond: () => 32_000,
+      }),
+    );
+
+    await recordAndStop(result);
+
+    expect(MockMediaRecorder.instances).toHaveLength(1);
+    expect(MockMediaRecorder.instances[0]?.options?.audioBitsPerSecond).toBe(
+      32_000,
+    );
+  });
+
+  it("leaves the recorder bitrate untouched when none is supplied", async () => {
+    const { result } = renderHook(() =>
+      useVoiceInput({
+        onTranscript: vi.fn(),
+        onTranscribe: vi.fn(async () => "hello world"),
+        getAudioBitsPerSecond: () => null,
+      }),
+    );
+
+    await recordAndStop(result);
+
+    expect(
+      MockMediaRecorder.instances[0]?.options?.audioBitsPerSecond,
+    ).toBeUndefined();
+  });
+
+  it("retains the recording on failure and retries the same audio", async () => {
+    const onTranscript = vi.fn();
+    const onTranscribe = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Local transcription timed out"))
+      .mockResolvedValueOnce("recovered transcript");
+    const { result } = renderHook(() =>
+      useVoiceInput({ onTranscript, onTranscribe }),
+    );
+
+    await recordAndStop(result);
+
+    await waitFor(() => expect(result.current.state).toBe("error"));
+    expect(result.current.canRetry).toBe(true);
+    const firstFile = onTranscribe.mock.calls[0]?.[0]?.file as File;
+
+    await act(async () => {
+      result.current.retry();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(result.current.state).toBe("idle"));
+    expect(onTranscribe).toHaveBeenCalledTimes(2);
+    expect(onTranscribe.mock.calls[1]?.[0]?.file).toBe(firstFile);
+    expect(onTranscript).toHaveBeenCalledWith("recovered transcript");
+    expect(result.current.canRetry).toBe(false);
+  });
+});

--- a/apps/app/src/hooks/useVoiceInput.ts
+++ b/apps/app/src/hooks/useVoiceInput.ts
@@ -25,6 +25,17 @@ interface UseVoiceInputOptions {
     signal?: AbortSignal;
   }) => Promise<string>;
   getPromptContext?: () => string | undefined;
+  /**
+   * Recorder bitrate to pin, or null to leave the browser default untouched.
+   * Read at recording start; pinned only for large-audio transcription
+   * services so Codex and openai/* keep the browser default.
+   */
+  getAudioBitsPerSecond?: () => number | null;
+}
+
+interface RetainedRecording {
+  file: File;
+  promptContext?: string;
 }
 
 const MIN_RECORDING_DURATION_MS = 1_000;
@@ -124,8 +135,11 @@ export function useVoiceInput(options: UseVoiceInputOptions) {
   const wakeLockSentinelRef = useRef<WakeLockSentinel | null>(null);
   const wakeLockRequestRef = useRef<Promise<void> | null>(null);
   const shouldHoldWakeLockRef = useRef(false);
+  const retainedRecordingRef = useRef<RetainedRecording | null>(null);
+  const retryRef = useRef<() => void>(() => {});
 
   const [state, setState] = useState<VoiceInputState>("idle");
+  const [canRetry, setCanRetry] = useState(false);
   const [isSupported, setIsSupported] = useState(false);
   const [unsupportedReason, setUnsupportedReason] =
     useState<VoiceUnsupportedReason | null>("unsupported-browser");
@@ -135,6 +149,65 @@ export function useVoiceInput(options: UseVoiceInputOptions) {
     setState("error");
     appToast.error("Voice input failed", { description: message });
   }, []);
+
+  const clearRetainedRecording = useCallback(() => {
+    retainedRecordingRef.current = null;
+    setCanRetry(false);
+  }, []);
+
+  const runTranscription = useCallback(
+    async (recording: RetainedRecording) => {
+      setState("transcribing");
+      const abortController = new AbortController();
+      transcriptionAbortRef.current = abortController;
+      try {
+        const transcript = await options.onTranscribe({
+          file: recording.file,
+          promptContext: recording.promptContext,
+          signal: abortController.signal,
+        });
+        const normalized = normalizeTranscript(transcript);
+        if (normalized.length === 0) {
+          throw new Error("Voice transcription returned an empty result.");
+        }
+        options.onTranscript(normalized);
+        clearRetainedRecording();
+        setState("idle");
+      } catch (error) {
+        if (error instanceof DOMException && error.name === "AbortError") {
+          setState("idle");
+          return;
+        }
+        retainedRecordingRef.current = recording;
+        setCanRetry(true);
+        setState("error");
+        appToast.error("Voice input failed", {
+          description: resolveRecordingErrorMessage(error),
+          action: {
+            label: "Retry",
+            onClick: () => retryRef.current(),
+          },
+        });
+      } finally {
+        if (transcriptionAbortRef.current === abortController) {
+          transcriptionAbortRef.current = null;
+        }
+      }
+    },
+    [clearRetainedRecording, options],
+  );
+
+  const retry = useCallback(() => {
+    const recording = retainedRecordingRef.current;
+    if (recording === null || state === "recording" || state === "transcribing") {
+      return;
+    }
+    void runTranscription(recording);
+  }, [runTranscription, state]);
+
+  useEffect(() => {
+    retryRef.current = retry;
+  }, [retry]);
 
   const stopMediaStream = useCallback(() => {
     const stream = streamRef.current;
@@ -260,12 +333,22 @@ export function useVoiceInput(options: UseVoiceInputOptions) {
       promptContextRef.current = options.getPromptContext?.();
       shouldTranscribeRef.current = true;
       shouldHoldWakeLockRef.current = true;
+      clearRetainedRecording();
       requestRecordingWakeLock();
 
       const preferredMimeType = resolvePreferredAudioMimeType();
-      const recorder = preferredMimeType
-        ? new MediaRecorder(stream, { mimeType: preferredMimeType })
-        : new MediaRecorder(stream);
+      const audioBitsPerSecond = options.getAudioBitsPerSecond?.() ?? null;
+      const recorderOptions: MediaRecorderOptions = {};
+      if (preferredMimeType) {
+        recorderOptions.mimeType = preferredMimeType;
+      }
+      if (audioBitsPerSecond !== null) {
+        recorderOptions.audioBitsPerSecond = audioBitsPerSecond;
+      }
+      const recorder =
+        Object.keys(recorderOptions).length > 0
+          ? new MediaRecorder(stream, recorderOptions)
+          : new MediaRecorder(stream);
       mediaRecorderRef.current = recorder;
 
       recorder.onstart = () => {
@@ -320,32 +403,7 @@ export function useVoiceInput(options: UseVoiceInputOptions) {
         const promptContext = promptContextRef.current;
         promptContextRef.current = undefined;
 
-        setState("transcribing");
-        const abortController = new AbortController();
-        transcriptionAbortRef.current = abortController;
-        try {
-          const transcript = await options.onTranscribe({
-            file: audioFile,
-            promptContext,
-            signal: abortController.signal,
-          });
-          const normalized = normalizeTranscript(transcript);
-          if (normalized.length === 0) {
-            throw new Error("Voice transcription returned an empty result.");
-          }
-          options.onTranscript(normalized);
-          setState("idle");
-        } catch (error) {
-          if (error instanceof DOMException && error.name === "AbortError") {
-            setState("idle");
-            return;
-          }
-          showError(resolveRecordingErrorMessage(error));
-        } finally {
-          if (transcriptionAbortRef.current === abortController) {
-            transcriptionAbortRef.current = null;
-          }
-        }
+        await runTranscription({ file: audioFile, promptContext });
       };
 
       recorder.start(CHUNK_TIMESLICE_MS);
@@ -366,8 +424,10 @@ export function useVoiceInput(options: UseVoiceInputOptions) {
       );
     }
   }, [
+    clearRetainedRecording,
     isSupported,
     options,
+    runTranscription,
     unsupportedReason,
     preferredAudioInputDeviceId,
     releaseRecordingWakeLock,
@@ -414,9 +474,10 @@ export function useVoiceInput(options: UseVoiceInputOptions) {
         abortController.abort();
         transcriptionAbortRef.current = null;
       }
+      clearRetainedRecording();
       setState("idle");
     }
-  }, [showError, state]);
+  }, [clearRetainedRecording, showError, state]);
 
   return {
     state,
@@ -426,8 +487,10 @@ export function useVoiceInput(options: UseVoiceInputOptions) {
     isRecording: state === "recording",
     isProcessing: state === "transcribing",
     isListening: state === "recording" || state === "transcribing",
+    canRetry,
     start,
     stop,
     cancel,
+    retry,
   };
 }

--- a/apps/app/src/lib/system-config-atoms.ts
+++ b/apps/app/src/lib/system-config-atoms.ts
@@ -1,5 +1,10 @@
 import { atom } from "jotai";
 import { DEFAULTS } from "@bb/config/defaults";
+import {
+  DEFAULT_PLUGIN_TRANSCRIPTION_MAX_BYTES,
+  DEFAULT_VOICE_RECORDING_BITRATE,
+  DEFAULT_VOICE_TRANSCRIPTION_TIMEOUT_MAX_MS,
+} from "@bb/config/voice-transcription-limit";
 import { defaultAppSettings, defaultAppTheme } from "@bb/domain";
 import type { WorkspaceOpenTarget } from "@bb/host-daemon-contract";
 import type { HostDaemonStatusSnapshot } from "./api-host-daemon";
@@ -43,6 +48,9 @@ const unavailableSystemConfig: SystemConfigResponse = {
     inference: DEFAULTS.inferenceModel,
     inferenceFallback: DEFAULTS.inferenceFallbackModel,
     transcription: DEFAULTS.transcriptionModel,
+    transcriptionMaxBytes: DEFAULT_PLUGIN_TRANSCRIPTION_MAX_BYTES,
+    transcriptionTimeoutMaxMs: DEFAULT_VOICE_TRANSCRIPTION_TIMEOUT_MAX_MS,
+    recordingBitrate: DEFAULT_VOICE_RECORDING_BITRATE,
     services: [],
   },
   dataDir: "",

--- a/apps/app/src/test/fixtures/system-config.ts
+++ b/apps/app/src/test/fixtures/system-config.ts
@@ -1,5 +1,10 @@
 import { DEFAULTS } from "@bb/config/defaults";
 import {
+  DEFAULT_PLUGIN_TRANSCRIPTION_MAX_BYTES,
+  DEFAULT_VOICE_RECORDING_BITRATE,
+  DEFAULT_VOICE_TRANSCRIPTION_TIMEOUT_MAX_MS,
+} from "@bb/config/voice-transcription-limit";
+import {
   defaultAppSettings,
   defaultAppTheme,
   defaultExperiments,
@@ -30,6 +35,9 @@ export function makeSystemConfig(
       inference: DEFAULTS.inferenceModel,
       inferenceFallback: DEFAULTS.inferenceFallbackModel,
       transcription: DEFAULTS.transcriptionModel,
+      transcriptionMaxBytes: DEFAULT_PLUGIN_TRANSCRIPTION_MAX_BYTES,
+      transcriptionTimeoutMaxMs: DEFAULT_VOICE_TRANSCRIPTION_TIMEOUT_MAX_MS,
+      recordingBitrate: DEFAULT_VOICE_RECORDING_BITRATE,
       services: [],
     },
     dataDir: "/tmp/bb-test",

--- a/apps/app/src/views/SettingsView.stories.tsx
+++ b/apps/app/src/views/SettingsView.stories.tsx
@@ -261,6 +261,26 @@ function VoiceInputStory() {
       onDeviceChange={state.setPreferredAudioInputDeviceId}
       onRefresh={() => undefined}
       preferredDeviceId={state.preferredAudioInputDeviceId}
+      onUpdateTranscription={() => undefined}
+      transcription={{
+        model: "codex/gpt-transcribe",
+        enabled: true,
+        ceilingBytes: 10 * 1024 * 1024,
+        timeoutMaxMs: 300_000,
+        recordingBitrate: 32_000,
+        voiceServices: [
+          {
+            id: "codex",
+            displayName: "Codex (ChatGPT account or API key)",
+            pluginId: "provider-codex",
+          },
+          {
+            id: "local",
+            displayName: "Local (Parakeet)",
+            pluginId: "local-stt",
+          },
+        ],
+      }}
     />
   );
 }

--- a/apps/cli/src/commands/settings.ts
+++ b/apps/cli/src/commands/settings.ts
@@ -16,6 +16,7 @@ import {
   type UiPreferenceValue,
 } from "@bb/domain";
 import { BbHttpError } from "@bb/sdk";
+import type { SystemTranscriptionSettingsUpdate } from "@bb/server-contract";
 import { action } from "../action.js";
 import { createCliBbSdk } from "../client.js";
 import { outputJson } from "./helpers.js";
@@ -34,6 +35,44 @@ function parseBoolean(value: string): boolean {
   if (value === "true" || value === "on") return true;
   if (value === "false" || value === "off") return false;
   throw new Error("value must be true, false, on, or off.");
+}
+
+function formatMebibytes(bytes: number): string {
+  const mib = bytes / (1024 * 1024);
+  const rounded = Math.round(mib * 100) / 100;
+  return `${rounded}MB (${bytes} bytes)`;
+}
+
+function parseIntegerSetting(key: string, value: string): number {
+  const trimmed = value.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    throw new Error(`${key} must be a positive integer.`);
+  }
+  const parsed = Number(trimmed);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${key} must be a positive integer.`);
+  }
+  return parsed;
+}
+
+function buildTranscriptionSettingsUpdate(
+  key: string,
+  value: string,
+): SystemTranscriptionSettingsUpdate {
+  switch (key) {
+    case "model":
+      return { transcriptionModel: value.trim() };
+    case "max-bytes":
+      return { transcriptionMaxBytes: parseIntegerSetting(key, value) };
+    case "timeout-ms":
+      return { transcriptionTimeoutMaxMs: parseIntegerSetting(key, value) };
+    case "recording-bitrate":
+      return { recordingBitrate: parseIntegerSetting(key, value) };
+    default:
+      throw new Error(
+        `Unknown transcription setting "${key}". Use model, max-bytes, timeout-ms, or recording-bitrate.`,
+      );
+  }
 }
 
 function parseShortcut(value: string): AppShortcut {
@@ -171,16 +210,27 @@ export function registerSettingsCommands(
   settings
     .command("ai-services")
     .description(
-      "Show the AI-service settings (BB_INFERENCE, BB_INFERENCE_FALLBACK, BB_TRANSCRIPTION) and the plugin services they may name",
+      "Show the AI-service settings (BB_INFERENCE, BB_INFERENCE_FALLBACK, BB_TRANSCRIPTION, BB_TRANSCRIPTION_MAX_BYTES, BB_TRANSCRIPTION_TIMEOUT_MAX_MS, BB_TRANSCRIPTION_RECORDING_BITRATE) and the plugin services they may name, with each voice service's effective audio-size limit",
     )
     .option("--json", "Print machine-readable JSON output")
     .action(
       action(async (opts: JsonOptions) => {
         const { aiServices } = await createCliBbSdk(getUrl()).system.config();
         if (outputJson(opts, aiServices)) return;
-        console.log(`BB_INFERENCE          ${aiServices.inference}`);
-        console.log(`BB_INFERENCE_FALLBACK ${aiServices.inferenceFallback}`);
-        console.log(`BB_TRANSCRIPTION      ${aiServices.transcription}`);
+        console.log(`BB_INFERENCE               ${aiServices.inference}`);
+        console.log(
+          `BB_INFERENCE_FALLBACK      ${aiServices.inferenceFallback}`,
+        );
+        console.log(`BB_TRANSCRIPTION           ${aiServices.transcription}`);
+        console.log(
+          `BB_TRANSCRIPTION_MAX_BYTES ${formatMebibytes(aiServices.transcriptionMaxBytes)}`,
+        );
+        console.log(
+          `BB_TRANSCRIPTION_TIMEOUT_MAX_MS ${aiServices.transcriptionTimeoutMaxMs} (scales with audio size)`,
+        );
+        console.log(
+          `BB_TRANSCRIPTION_RECORDING_BITRATE ${aiServices.recordingBitrate} (pinned only for large-audio services)`,
+        );
         console.log("");
         if (aiServices.services.length === 0) {
           console.log("No plugin registers an AI service.");
@@ -193,7 +243,38 @@ export function registerSettingsCommands(
           console.log(
             `  ${service.id}  ${service.displayName}  [${service.kinds.join(", ")}]  plugin ${service.pluginId}`,
           );
+          if (service.kinds.includes("voice")) {
+            const declared =
+              service.maxVoiceBytes === null
+                ? "no service limit"
+                : formatMebibytes(service.maxVoiceBytes);
+            const effective =
+              service.effectiveVoiceMaxBytes === null
+                ? "n/a"
+                : formatMebibytes(service.effectiveVoiceMaxBytes);
+            console.log(
+              `      voice audio limit: ${effective} effective (service cap: ${declared})`,
+            );
+          }
         }
+      }),
+    );
+
+  settings
+    .command("transcription <key> <value>")
+    .description(
+      "Set a voice transcription setting: model (<service>/<model>), max-bytes, timeout-ms, or recording-bitrate",
+    )
+    .option("--json", "Print machine-readable JSON output")
+    .action(
+      action(async (key: string, value: string, opts: JsonOptions) => {
+        const update = buildTranscriptionSettingsUpdate(key, value);
+        const result =
+          await createCliBbSdk(getUrl()).system.updateTranscriptionSettings(
+            update,
+          );
+        if (outputJson(opts, result)) return;
+        console.log(`${key} updated`);
       }),
     );
 

--- a/apps/server/src/routes/system.ts
+++ b/apps/server/src/routes/system.ts
@@ -26,15 +26,24 @@ import {
   type PublicApiSchema,
 } from "@bb/server-contract";
 import type { Hono } from "hono";
+import { validateTranscriptionModel } from "@bb/config/inference-model";
+import type { BbAppManagedConfigKey } from "@bb/config/bb-app-managed-config";
+import {
+  validatePluginTranscriptionMaxBytes,
+  validateVoiceRecordingBitrate,
+  validateVoiceTranscriptionTimeoutMaxMs,
+} from "@bb/config/voice-transcription-limit";
 import { pluginImageResponse } from "./plugin-image-response.js";
 import {
   getEnvironmentProvider,
   listEnvironmentProviders,
 } from "../services/plugins/plugin-environment-provider-registry.js";
+import { writeBbAppManagedConfigValues } from "../services/system/bb-app-managed-config.js";
 import type { ServerAppDeps, ServerRuntimeConfig } from "../types.js";
 import type { PluginService } from "../services/plugins/plugin-service.js";
 import { ApiError } from "../errors.js";
 import {
+  resolveServiceVoiceMaxBytes,
   resolveVoiceTranscriptionEnabled,
   transcribeVoiceInput,
 } from "../services/ai/voice-transcription.js";
@@ -193,18 +202,32 @@ export function registerSystemRoutes(
           ? null
           : deps.hub.getDaemonPlatformForHost(primaryHostId),
       voiceTranscriptionEnabled: resolveVoiceTranscriptionEnabled(deps),
-      aiServices: {
-        inference: deps.config.inferenceModel,
-        inferenceFallback: deps.config.inferenceFallbackModel,
-        transcription: deps.config.transcriptionModel,
-        services: deps.aiServices.list().map((service) => ({
+      aiServices: buildAiServicesResponse(),
+      dataDir: deps.config.dataDir,
+    };
+  }
+
+  function buildAiServicesResponse() {
+    return {
+      inference: deps.config.inferenceModel,
+      inferenceFallback: deps.config.inferenceFallbackModel,
+      transcription: deps.config.transcriptionModel,
+      transcriptionMaxBytes: deps.config.pluginTranscriptionMaxBytes,
+      transcriptionTimeoutMaxMs: deps.config.voiceTranscriptionTimeoutMaxMs,
+      recordingBitrate: deps.config.voiceTranscriptionRecordingBitrate,
+      services: deps.aiServices.list().map((service) => {
+        const servesVoice = service.kinds.includes("voice");
+        return {
           id: service.id,
           displayName: service.displayName,
           kinds: [...service.kinds],
           pluginId: service.pluginId,
-        })),
-      },
-      dataDir: deps.config.dataDir,
+          maxVoiceBytes: service.experimental_maxVoiceBytes ?? null,
+          effectiveVoiceMaxBytes: servesVoice
+            ? resolveServiceVoiceMaxBytes(deps, service)
+            : null,
+        };
+      }),
     };
   }
 
@@ -311,6 +334,65 @@ export function registerSystemRoutes(
       throw new ApiError(422, "invalid_config", message);
     }
     return context.json({ ok: true });
+  });
+
+  put(routes.transcriptionSettings, async (context, payload) => {
+    const values: Partial<Record<BbAppManagedConfigKey, string>> = {};
+    try {
+      if (payload.transcriptionModel !== undefined) {
+        values.BB_TRANSCRIPTION = validateTranscriptionModel(
+          payload.transcriptionModel,
+        );
+      }
+      if (payload.transcriptionMaxBytes !== undefined) {
+        values.BB_TRANSCRIPTION_MAX_BYTES = String(
+          validatePluginTranscriptionMaxBytes(
+            "BB_TRANSCRIPTION_MAX_BYTES",
+            payload.transcriptionMaxBytes,
+          ),
+        );
+      }
+      if (payload.transcriptionTimeoutMaxMs !== undefined) {
+        values.BB_TRANSCRIPTION_TIMEOUT_MAX_MS = String(
+          validateVoiceTranscriptionTimeoutMaxMs(
+            "BB_TRANSCRIPTION_TIMEOUT_MAX_MS",
+            payload.transcriptionTimeoutMaxMs,
+          ),
+        );
+      }
+      if (payload.recordingBitrate !== undefined) {
+        values.BB_TRANSCRIPTION_RECORDING_BITRATE = String(
+          validateVoiceRecordingBitrate(
+            "BB_TRANSCRIPTION_RECORDING_BITRATE",
+            payload.recordingBitrate,
+          ),
+        );
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new ApiError(400, "invalid_request", message);
+    }
+
+    if (Object.keys(values).length === 0) {
+      throw new ApiError(
+        400,
+        "invalid_request",
+        "No transcription settings were provided",
+      );
+    }
+
+    try {
+      await writeBbAppManagedConfigValues({
+        dataDir: deps.config.dataDir,
+        values,
+      });
+      await deps.bbAppManagedConfig.reload({ notify: true });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new ApiError(422, "invalid_config", message);
+    }
+
+    return context.json(buildAiServicesResponse());
   });
 
   get(routes.cliSkillsStatus, async (context, query) =>

--- a/apps/server/src/services/ai/ai-service-registry.ts
+++ b/apps/server/src/services/ai/ai-service-registry.ts
@@ -70,6 +70,9 @@ export function createAiServiceRegistry(): AiServiceRegistry {
         displayName: service.displayName,
         kinds: service.kinds,
         pluginId: service.pluginId,
+        ...(service.experimental_maxVoiceBytes === undefined
+          ? {}
+          : { experimental_maxVoiceBytes: service.experimental_maxVoiceBytes }),
       }));
     },
   };

--- a/apps/server/src/services/ai/voice-transcription.ts
+++ b/apps/server/src/services/ai/voice-transcription.ts
@@ -4,12 +4,19 @@ import {
   parseProviderModelConfig,
   type ProviderModelInfo,
 } from "@bb/config/inference-model";
+import {
+  resolveVoiceTranscriptionTimeoutMs,
+  VOICE_TRANSCRIPTION_MAX_BYTES,
+} from "@bb/config/voice-transcription-limit";
 import type { LoggedWorkSessionDeps } from "../../types.js";
 import { ApiError } from "../../errors.js";
 import { requireConnectedPrimaryHostId } from "../hosts/primary-host.js";
 import { runtimeErrorLogFields } from "../lib/error-log-fields.js";
 import { AiServiceCallError } from "./ai-service-call.js";
-import type { AiServiceRegistration } from "./ai-service-registry.js";
+import type {
+  AiServiceInfo,
+  AiServiceRegistration,
+} from "./ai-service-registry.js";
 import {
   INFERENCE_POLICY,
   inferenceCompleteWithFallback,
@@ -24,8 +31,6 @@ interface TranscribeVoiceInputArgs {
 type OptionalJsonValue = JsonValue | null | undefined;
 
 const OPENAI_TRANSCRIPTION_PROVIDER = "openai";
-const VOICE_TRANSCRIPTION_MAX_BYTES = 25 * 1024 * 1024;
-const AI_SERVICE_VOICE_MAX_BYTES = 5 * 1024 * 1024;
 const voiceTranscriptionSchema = Type.Object({ text: Type.String() });
 
 function parseTranscriptionModel(model: string): ProviderModelInfo {
@@ -41,6 +46,16 @@ function voiceService(
 ): AiServiceRegistration | null {
   const service = deps.aiServices.get(modelInfo.provider);
   return service !== null && service.kinds.includes("voice") ? service : null;
+}
+
+export function resolveServiceVoiceMaxBytes(
+  deps: LoggedWorkSessionDeps,
+  service: AiServiceRegistration | AiServiceInfo,
+): number {
+  const ceiling = deps.config.pluginTranscriptionMaxBytes;
+  return service.experimental_maxVoiceBytes === undefined
+    ? ceiling
+    : Math.min(ceiling, service.experimental_maxVoiceBytes);
 }
 
 function isPrimaryHostConnected(deps: LoggedWorkSessionDeps): boolean {
@@ -92,13 +107,12 @@ function openAiErrorMessage(payload: OptionalJsonValue): string {
   return jsonStringProperty(error, "message") ?? "Voice transcription failed";
 }
 
-async function readJsonValue(response: Response): Promise<JsonValue | null> {
-  const text = await response.text();
-  if (text.trim().length === 0) {
+function parseJsonBody(rawBody: string): JsonValue | null {
+  if (rawBody.trim().length === 0) {
     return null;
   }
   try {
-    return jsonValueSchema.parse(JSON.parse(text));
+    return jsonValueSchema.parse(JSON.parse(rawBody));
   } catch {
     return null;
   }
@@ -128,11 +142,12 @@ async function transcribeWithAiService(
   modelInfo: ProviderModelInfo,
   args: TranscribeVoiceInputArgs,
 ): Promise<string> {
-  if (args.file.size > AI_SERVICE_VOICE_MAX_BYTES) {
+  const maxBytes = resolveServiceVoiceMaxBytes(deps, service);
+  if (args.file.size > maxBytes) {
     throw new ApiError(
       400,
       "invalid_request",
-      `Audio file exceeds the ${AI_SERVICE_VOICE_MAX_BYTES / (1024 * 1024)}MB limit for plugin-served transcription`,
+      `Audio file exceeds the ${maxBytes / (1024 * 1024)}MB limit for plugin-served transcription`,
     );
   }
   const hostId = requireConnectedPrimaryHostId(deps);
@@ -141,8 +156,14 @@ async function transcribeWithAiService(
   );
   const prompt = trimPrompt(args.prompt) ?? "";
   const transcriptionModel = `${modelInfo.provider}/${modelInfo.modelId}`;
+  const timeoutBudgetMs = resolveVoiceTranscriptionTimeoutMs({
+    audioBytes: args.file.size,
+    maxMs: deps.config.voiceTranscriptionTimeoutMaxMs,
+  });
   const transcription = await inferenceCompleteWithFallback(deps, {
-    ...INFERENCE_POLICY.voiceTranscription,
+    maxAttempts: INFERENCE_POLICY.voiceTranscription.maxAttempts,
+    retryDelayMs: INFERENCE_POLICY.voiceTranscription.retryDelayMs,
+    timeoutMs: timeoutBudgetMs,
     complete: async (model, attemptPrompt, timeoutMs) => {
       const attemptModel = parseTranscriptionModel(model);
       const result = await service.transcribeVoice(
@@ -213,12 +234,16 @@ async function transcribeWithOpenAi(
     formData.set("prompt", prompt);
   }
 
+  const timeoutBudgetMs = resolveVoiceTranscriptionTimeoutMs({
+    audioBytes: args.file.size,
+    maxMs: deps.config.voiceTranscriptionTimeoutMaxMs,
+  });
   const abortController = new AbortController();
   let timedOut = false;
   const timer = setTimeout(() => {
     timedOut = true;
     abortController.abort();
-  }, INFERENCE_POLICY.voiceTranscription.timeoutMs);
+  }, timeoutBudgetMs);
   timer.unref();
 
   let response: Response;
@@ -248,8 +273,19 @@ async function transcribeWithOpenAi(
     clearTimeout(timer);
   }
 
-  const payload = await readJsonValue(response);
+  const rawBody = await response.text();
+  const payload = parseJsonBody(rawBody);
   if (!response.ok) {
+    if (payload === null) {
+      deps.logger.warn(
+        {
+          ...runtimeErrorLogFields(deps.config, new Error("unparseable provider error payload")),
+          status: response.status,
+          bodySnippet: rawBody.slice(0, 500),
+        },
+        "OpenAI voice transcription returned an unparseable error payload",
+      );
+    }
     throw new ApiError(502, "provider_rpc_error", openAiErrorMessage(payload));
   }
 
@@ -269,7 +305,11 @@ export async function transcribeVoiceInput(
     throw new ApiError(400, "invalid_request", "Audio file must not be empty");
   }
   if (args.file.size > VOICE_TRANSCRIPTION_MAX_BYTES) {
-    throw new ApiError(400, "invalid_request", "Audio file exceeds 25MB limit");
+    throw new ApiError(
+      400,
+      "invalid_request",
+      `Audio file exceeds ${VOICE_TRANSCRIPTION_MAX_BYTES / (1024 * 1024)}MB limit`,
+    );
   }
 
   const modelInfo = parseTranscriptionModel(deps.config.transcriptionModel);

--- a/apps/server/src/services/plugins/plugin-host-rpc.ts
+++ b/apps/server/src/services/plugins/plugin-host-rpc.ts
@@ -7,12 +7,17 @@ import type {
 } from "@get-bb/plugin-sdk";
 import type { JsonValue } from "@bb/domain";
 import { COMMAND_TIMEOUT_MS } from "../../constants.js";
+import { ApiError } from "../../errors.js";
 import type { WorkSessionDeps } from "../../types.js";
 import { callHostOnlineRpc } from "../hosts/online-rpc.js";
 import type { PluginHostArtifactSnapshot } from "./plugin-service-internal.js";
 
 const HOST_RPC_TRANSPORT_GRACE_MS = 6_000;
-const HOST_RPC_PAYLOAD_MAX_BYTES = 8 * 1024 * 1024;
+// Raised from 8 MiB for the voice-transcription limits change: base64 audio
+// (+33%) plus the JSON envelope around it made 8 MiB unserviceable for the
+// local STT path. This is a shared transport cap — see the payload-cap audit
+// entry in docs/api_to_audit.md before raising it again.
+const HOST_RPC_PAYLOAD_MAX_BYTES = 16 * 1024 * 1024;
 
 async function validateValue(
   schema: StandardSchemaV1,
@@ -46,7 +51,12 @@ function normalizeJson(value: unknown, label: string): JsonValue {
     throw new Error(`${label} is not JSON-serializable`);
   }
   if (Buffer.byteLength(serialized) > HOST_RPC_PAYLOAD_MAX_BYTES) {
-    throw new Error(`${label} exceeds ${HOST_RPC_PAYLOAD_MAX_BYTES} bytes`);
+    const maxMb = HOST_RPC_PAYLOAD_MAX_BYTES / (1024 * 1024);
+    throw new ApiError(
+      413,
+      "invalid_request",
+      `${label} exceeds the ${maxMb}MB host RPC payload limit`,
+    );
   }
   return JSON.parse(serialized) as JsonValue;
 }

--- a/apps/server/src/services/system/bb-app-managed-config.ts
+++ b/apps/server/src/services/system/bb-app-managed-config.ts
@@ -1,10 +1,13 @@
-import { readFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
+import { join } from "node:path";
 import {
   bbAppManagedEnvFileSchema,
   formatBbAppConfigPath,
   formatBbAppEnvPath,
   parseBbAppManagedConfig,
   type BbAppManagedConfig,
+  type BbAppManagedConfigKey,
   type BbAppManagedEnvConfig,
   type BbAppManagedEnvFile,
 } from "@bb/config/bb-app-managed-config";
@@ -14,6 +17,11 @@ import {
   validateTranscriptionModel,
 } from "@bb/config/inference-model";
 import { validateOptionalUrl } from "@bb/config/public-url";
+import {
+  parsePluginTranscriptionMaxBytes,
+  parseVoiceRecordingBitrate,
+  parseVoiceTranscriptionTimeoutMaxMs,
+} from "@bb/config/voice-transcription-limit";
 import type { ServerLogger, ServerRuntimeConfig } from "../../types.js";
 import type { NotificationHub } from "../../ws/hub.js";
 
@@ -117,6 +125,27 @@ export function applyBbAppManagedConfig(
     managedConfig.BB_TRANSCRIPTION !== undefined
       ? validateTranscriptionModel(managedConfig.BB_TRANSCRIPTION)
       : args.baseConfig.transcriptionModel;
+  args.targetConfig.pluginTranscriptionMaxBytes =
+    managedConfig.BB_TRANSCRIPTION_MAX_BYTES !== undefined
+      ? parsePluginTranscriptionMaxBytes(
+          "BB_TRANSCRIPTION_MAX_BYTES",
+          managedConfig.BB_TRANSCRIPTION_MAX_BYTES,
+        )
+      : args.baseConfig.pluginTranscriptionMaxBytes;
+  args.targetConfig.voiceTranscriptionTimeoutMaxMs =
+    managedConfig.BB_TRANSCRIPTION_TIMEOUT_MAX_MS !== undefined
+      ? parseVoiceTranscriptionTimeoutMaxMs(
+          "BB_TRANSCRIPTION_TIMEOUT_MAX_MS",
+          managedConfig.BB_TRANSCRIPTION_TIMEOUT_MAX_MS,
+        )
+      : args.baseConfig.voiceTranscriptionTimeoutMaxMs;
+  args.targetConfig.voiceTranscriptionRecordingBitrate =
+    managedConfig.BB_TRANSCRIPTION_RECORDING_BITRATE !== undefined
+      ? parseVoiceRecordingBitrate(
+          "BB_TRANSCRIPTION_RECORDING_BITRATE",
+          managedConfig.BB_TRANSCRIPTION_RECORDING_BITRATE,
+        )
+      : args.baseConfig.voiceTranscriptionRecordingBitrate;
   args.targetConfig.openAiApiKey =
     managedEnv.OPENAI_API_KEY ?? args.baseConfig.openAiApiKey;
 
@@ -126,6 +155,68 @@ export function applyBbAppManagedConfig(
       ? validateOptionalUrl("BB_APP_URL", managedConfig.BB_APP_URL)
       : args.baseConfig.appUrl,
   );
+}
+
+interface WriteBbAppManagedConfigValuesArgs {
+  dataDir: string;
+  values: Partial<Record<BbAppManagedConfigKey, string>>;
+}
+
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export async function writeBbAppManagedConfigValues(
+  args: WriteBbAppManagedConfigValuesArgs,
+): Promise<void> {
+  const configPath = formatBbAppConfigPath(args.dataDir);
+  let rawConfig: Record<string, unknown> = {};
+  try {
+    const text = await readFile(configPath, "utf8");
+    const parsed: unknown = JSON.parse(text);
+    if (!isJsonObject(parsed)) {
+      throw new Error(`Invalid bb-app config JSON at ${configPath}`);
+    }
+    rawConfig = parsed;
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      throw new Error(`Invalid bb-app config JSON at ${configPath}`);
+    }
+    if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) {
+      throw error;
+    }
+  }
+
+  const existingConfig = rawConfig.config;
+  if (existingConfig !== undefined && !isJsonObject(existingConfig)) {
+    throw new Error(`Invalid bb-app config JSON at ${configPath}`);
+  }
+  const nextValues: Record<string, unknown> = { ...(existingConfig ?? {}) };
+  for (const [key, value] of Object.entries(args.values)) {
+    if (value !== undefined) {
+      nextValues[key] = value;
+    }
+  }
+  const nextRawConfig: Record<string, unknown> = {
+    ...rawConfig,
+    config: nextValues,
+  };
+
+  await mkdir(args.dataDir, { recursive: true });
+  const tempPath = join(
+    args.dataDir,
+    `.config.json.${process.pid}.${randomUUID()}.tmp`,
+  );
+  try {
+    await writeFile(tempPath, `${JSON.stringify(nextRawConfig, null, 2)}\n`, {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+    await rename(tempPath, configPath);
+  } catch (error) {
+    await unlink(tempPath).catch(() => undefined);
+    throw error;
+  }
 }
 
 async function readBbAppManagedConfig(

--- a/apps/server/src/start-server.ts
+++ b/apps/server/src/start-server.ts
@@ -81,9 +81,14 @@ export async function runServer(serverConfig: ServerConfig): Promise<void> {
     inferenceModel: serverConfig.BB_INFERENCE,
     isDevelopment: !isProduction,
     openAiApiKey: serverConfig.OPENAI_API_KEY,
+    pluginTranscriptionMaxBytes: serverConfig.BB_TRANSCRIPTION_MAX_BYTES,
     serverPort: serverConfig.BB_SERVER_PORT,
     sharedSkillRoots: { user: [], project: [] },
     transcriptionModel: serverConfig.BB_TRANSCRIPTION,
+    voiceTranscriptionRecordingBitrate:
+      serverConfig.BB_TRANSCRIPTION_RECORDING_BITRATE,
+    voiceTranscriptionTimeoutMaxMs:
+      serverConfig.BB_TRANSCRIPTION_TIMEOUT_MAX_MS,
   };
 
   const providerRegistry = createProviderRegistryService({

--- a/apps/server/src/types.ts
+++ b/apps/server/src/types.ts
@@ -34,9 +34,12 @@ export interface ServerRuntimeConfig {
   isDevelopment: boolean;
   marketplaceUrl: string;
   openAiApiKey: string;
+  pluginTranscriptionMaxBytes: number;
   serverPort: number;
   sharedSkillRoots: ProviderNativeSkillRoots;
   transcriptionModel: string;
+  voiceTranscriptionRecordingBitrate: number;
+  voiceTranscriptionTimeoutMaxMs: number;
   appUrl?: string;
   devAppPort?: number;
   launchId?: string;

--- a/apps/server/test/ai/voice-transcription.test.ts
+++ b/apps/server/test/ai/voice-transcription.test.ts
@@ -44,14 +44,24 @@ async function createServiceTranscriptionHarness(
   transcribe: (
     input: ExperimentalAiVoiceTranscribeInput,
   ) => ExperimentalAiVoiceTranscribeOutput,
+  overrides: {
+    pluginTranscriptionMaxBytes?: number;
+    serviceMaxVoiceBytes?: number;
+  } = {},
 ): Promise<ServiceTranscriptionHarness> {
   const harness = await createTestAppHarness({
     inferenceFallbackModel: "codex/gpt-5.4-mini",
     transcriptionModel: "codex/gpt-transcribe",
+    ...(overrides.pluginTranscriptionMaxBytes === undefined
+      ? {}
+      : { pluginTranscriptionMaxBytes: overrides.pluginTranscriptionMaxBytes }),
   });
   seedHostSession(harness.deps);
   const fake = registerFakeAiService(harness.deps.aiServices, {
     transcribeVoice: transcribe,
+    ...(overrides.serviceMaxVoiceBytes === undefined
+      ? {}
+      : { maxVoiceBytes: overrides.serviceMaxVoiceBytes }),
   });
   return {
     app: harness.app,
@@ -135,6 +145,143 @@ describe("voice transcription", () => {
         },
       });
       expect(harness.calls).toHaveLength(0);
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("forwards audio above the default cap when the configured limit is raised", async () => {
+    const harness = await createServiceTranscriptionHarness(
+      (input) => ({ ok: true, model: input.model, text: "long transcript" }),
+      { pluginTranscriptionMaxBytes: 10 * 1024 * 1024 },
+    );
+    try {
+      const file = new File([Buffer.alloc(5 * 1024 * 1024 + 1)], "long.webm", {
+        type: "audio/webm",
+      });
+      await expect(
+        transcribeVoiceInput(harness.deps, { file }),
+      ).resolves.toBe("long transcript");
+      expect(harness.calls).toHaveLength(1);
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("rejects audio above the configured plugin-served cap using the configured size", async () => {
+    const harness = await createServiceTranscriptionHarness(
+      () => {
+        throw new Error("Oversized audio must not reach the service");
+      },
+      { pluginTranscriptionMaxBytes: 8 * 1024 * 1024 },
+    );
+    try {
+      const file = new File([Buffer.alloc(8 * 1024 * 1024 + 1)], "long.webm", {
+        type: "audio/webm",
+      });
+      const error = await transcribeVoiceInput(harness.deps, { file }).catch(
+        (caught: unknown) => caught,
+      );
+      expect(error).toBeInstanceOf(ApiError);
+      expect(error).toMatchObject({
+        status: 400,
+        body: {
+          code: "invalid_request",
+          message:
+            "Audio file exceeds the 8MB limit for plugin-served transcription",
+        },
+      });
+      expect(harness.calls).toHaveLength(0);
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("enforces the service-declared cap even when the global ceiling is higher", async () => {
+    const harness = await createServiceTranscriptionHarness(
+      () => {
+        throw new Error("Oversized audio must not reach the service");
+      },
+      {
+        pluginTranscriptionMaxBytes: 25 * 1024 * 1024,
+        serviceMaxVoiceBytes: 5 * 1024 * 1024,
+      },
+    );
+    try {
+      const file = new File([Buffer.alloc(5 * 1024 * 1024 + 1)], "long.webm", {
+        type: "audio/webm",
+      });
+      const error = await transcribeVoiceInput(harness.deps, { file }).catch(
+        (caught: unknown) => caught,
+      );
+      expect(error).toBeInstanceOf(ApiError);
+      expect(error).toMatchObject({
+        status: 400,
+        body: {
+          code: "invalid_request",
+          message:
+            "Audio file exceeds the 5MB limit for plugin-served transcription",
+        },
+      });
+      expect(harness.calls).toHaveLength(0);
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("forwards audio up to the service cap when the global ceiling is higher", async () => {
+    const harness = await createServiceTranscriptionHarness(
+      (input) => ({ ok: true, model: input.model, text: "within service cap" }),
+      {
+        pluginTranscriptionMaxBytes: 25 * 1024 * 1024,
+        serviceMaxVoiceBytes: 8 * 1024 * 1024,
+      },
+    );
+    try {
+      const file = new File([Buffer.alloc(6 * 1024 * 1024)], "long.webm", {
+        type: "audio/webm",
+      });
+      await expect(
+        transcribeVoiceInput(harness.deps, { file }),
+      ).resolves.toBe("within service cap");
+      expect(harness.calls).toHaveLength(1);
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("scales the per-attempt timeout with the audio size", async () => {
+    const harness = await createServiceTranscriptionHarness((input) => ({
+      ok: true,
+      model: input.model,
+      text: "long transcript",
+    }));
+    try {
+      const file = new File([Buffer.alloc(2 * 1024 * 1024)], "long.webm", {
+        type: "audio/webm",
+      });
+      await expect(
+        transcribeVoiceInput(harness.deps, { file }),
+      ).resolves.toBe("long transcript");
+      expect(harness.calls).toHaveLength(1);
+      expect(harness.calls[0]?.input.timeoutMs).toBe(30_000);
+      expect(harness.calls[0]?.options.timeoutMs).toBe(31_000);
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("keeps the 10s floor for short clips", async () => {
+    const harness = await createServiceTranscriptionHarness((input) => ({
+      ok: true,
+      model: input.model,
+      text: "short transcript",
+    }));
+    try {
+      await expect(
+        transcribeVoiceInput(harness.deps, { file: voiceFile() }),
+      ).resolves.toBe("short transcript");
+      expect(harness.calls[0]?.input.timeoutMs).toBe(10_000);
     } finally {
       await harness.cleanup();
     }

--- a/apps/server/test/helpers/ai-services.ts
+++ b/apps/server/test/helpers/ai-services.ts
@@ -20,6 +20,7 @@ export function registerFakeAiService(
   args: {
     id?: string;
     kinds?: readonly PluginAiServiceKind[];
+    maxVoiceBytes?: number;
     completeInference?: (
       input: ExperimentalAiInferenceCompleteInput,
     ) =>
@@ -45,6 +46,9 @@ export function registerFakeAiService(
     displayName: "Fake service",
     kinds: args.kinds ?? ["inference", "voice"],
     pluginId: "provider-fake",
+    ...(args.maxVoiceBytes === undefined
+      ? {}
+      : { experimental_maxVoiceBytes: args.maxVoiceBytes }),
     async completeInference(input, options) {
       inferenceCalls.push({ input, options });
       if (!args.completeInference) {

--- a/apps/server/test/helpers/test-app.ts
+++ b/apps/server/test/helpers/test-app.ts
@@ -204,9 +204,12 @@ export async function createTestAppHarness(
     inferenceModel: "test/mock-model",
     isDevelopment: true,
     openAiApiKey: "test-openai-key",
+    pluginTranscriptionMaxBytes: 5 * 1024 * 1024,
     serverPort: 3334,
     sharedSkillRoots: { user: [], project: [] },
     transcriptionModel: "test/mock-transcription",
+    voiceTranscriptionRecordingBitrate: 32_000,
+    voiceTranscriptionTimeoutMaxMs: 300_000,
     appUrl: "https://bb.example.test",
     ...configOverrides,
   };

--- a/apps/server/test/services/plugins/plugin-ai-services.test.ts
+++ b/apps/server/test/services/plugins/plugin-ai-services.test.ts
@@ -131,6 +131,35 @@ describe("bb.experimental_aiServices.register (server)", () => {
     });
   });
 
+  it("carries a declared experimental_maxVoiceBytes through to the registry", async () => {
+    await withTestHarness(async (harness) => {
+      const rootDir = await writePlugin(workDir, {
+        name: "bb-plugin-capped-ai",
+        serverSource: `
+          export default function plugin(bb: any) {
+            bb.experimental_aiServices.register({
+              id: "capped-ai",
+              displayName: "Capped AI",
+              kinds: ["voice"],
+              experimental_maxVoiceBytes: 5 * 1024 * 1024,
+            });
+          }
+        `,
+      });
+      const entry = await harness.pluginService.installPath(rootDir);
+      expect(entry.status).toBe("running");
+      expect(harness.deps.aiServices.list()).toEqual([
+        {
+          id: "capped-ai",
+          displayName: "Capped AI",
+          kinds: ["voice"],
+          pluginId: "capped-ai",
+          experimental_maxVoiceBytes: 5 * 1024 * 1024,
+        },
+      ]);
+    });
+  });
+
   it("fails the load of a plugin that registers a service without a bb.host entry", async () => {
     await withTestHarness(async (harness) => {
       const rootDir = await writePlugin(workDir, {

--- a/apps/server/test/system/bb-app-managed-config.test.ts
+++ b/apps/server/test/system/bb-app-managed-config.test.ts
@@ -10,6 +10,7 @@ import { describe, expect, it } from "vitest";
 import {
   applyBbAppManagedConfig,
   createBbAppManagedConfigReloader,
+  writeBbAppManagedConfigValues,
 } from "../../src/services/system/bb-app-managed-config.js";
 import { NotificationHub } from "../../src/ws/hub.js";
 import type { ServerLogger, ServerRuntimeConfig } from "../../src/types.js";
@@ -73,9 +74,12 @@ function createRuntimeConfig(): ServerRuntimeConfig {
     inferenceModel: "openai/gpt-4o-mini",
     isDevelopment: false,
     openAiApiKey: "ambient-openai-key",
+    pluginTranscriptionMaxBytes: 5 * 1024 * 1024,
     serverPort: 38886,
     sharedSkillRoots: { user: [], project: [] },
     transcriptionModel: "openai/gpt-4o-transcribe",
+    voiceTranscriptionRecordingBitrate: 32_000,
+    voiceTranscriptionTimeoutMaxMs: 300_000,
   };
 }
 
@@ -250,6 +254,135 @@ describe("bb-app managed config", () => {
     ).toThrow(/BB_INFERENCE_FALLBACK/u);
   });
 
+  it("applies and restores the plugin transcription byte limit", () => {
+    const baseConfig = createRuntimeConfig();
+    const targetConfig = createRuntimeConfig();
+
+    applyBbAppManagedConfig({
+      baseConfig,
+      managedConfig: {
+        config: {
+          BB_TRANSCRIPTION_MAX_BYTES: String(8 * 1024 * 1024),
+        },
+      },
+      managedEnvFile: {},
+      targetConfig,
+    });
+    expect(targetConfig.pluginTranscriptionMaxBytes).toBe(8 * 1024 * 1024);
+
+    applyBbAppManagedConfig({
+      baseConfig,
+      managedConfig: {},
+      managedEnvFile: {},
+      targetConfig,
+    });
+    expect(targetConfig.pluginTranscriptionMaxBytes).toBe(5 * 1024 * 1024);
+  });
+
+  it("rejects an out-of-range plugin transcription byte limit", () => {
+    const baseConfig = createRuntimeConfig();
+    const targetConfig = createRuntimeConfig();
+
+    expect(() =>
+      applyBbAppManagedConfig({
+        baseConfig,
+        managedConfig: {
+          config: {
+            BB_TRANSCRIPTION_MAX_BYTES: String(25 * 1024 * 1024 + 1),
+          },
+        },
+        managedEnvFile: {},
+        targetConfig,
+      }),
+    ).toThrow(/BB_TRANSCRIPTION_MAX_BYTES/u);
+  });
+
+  it("applies and restores the voice transcription timeout ceiling", () => {
+    const baseConfig = createRuntimeConfig();
+    const targetConfig = createRuntimeConfig();
+
+    applyBbAppManagedConfig({
+      baseConfig,
+      managedConfig: {
+        config: {
+          BB_TRANSCRIPTION_TIMEOUT_MAX_MS: "120000",
+        },
+      },
+      managedEnvFile: {},
+      targetConfig,
+    });
+    expect(targetConfig.voiceTranscriptionTimeoutMaxMs).toBe(120_000);
+
+    applyBbAppManagedConfig({
+      baseConfig,
+      managedConfig: {},
+      managedEnvFile: {},
+      targetConfig,
+    });
+    expect(targetConfig.voiceTranscriptionTimeoutMaxMs).toBe(300_000);
+  });
+
+  it("rejects an out-of-range voice transcription timeout ceiling", () => {
+    const baseConfig = createRuntimeConfig();
+    const targetConfig = createRuntimeConfig();
+
+    expect(() =>
+      applyBbAppManagedConfig({
+        baseConfig,
+        managedConfig: {
+          config: {
+            BB_TRANSCRIPTION_TIMEOUT_MAX_MS: "9999",
+          },
+        },
+        managedEnvFile: {},
+        targetConfig,
+      }),
+    ).toThrow(/BB_TRANSCRIPTION_TIMEOUT_MAX_MS/u);
+  });
+
+  it("applies and restores the voice recording bitrate", () => {
+    const baseConfig = createRuntimeConfig();
+    const targetConfig = createRuntimeConfig();
+
+    applyBbAppManagedConfig({
+      baseConfig,
+      managedConfig: {
+        config: {
+          BB_TRANSCRIPTION_RECORDING_BITRATE: "48000",
+        },
+      },
+      managedEnvFile: {},
+      targetConfig,
+    });
+    expect(targetConfig.voiceTranscriptionRecordingBitrate).toBe(48_000);
+
+    applyBbAppManagedConfig({
+      baseConfig,
+      managedConfig: {},
+      managedEnvFile: {},
+      targetConfig,
+    });
+    expect(targetConfig.voiceTranscriptionRecordingBitrate).toBe(32_000);
+  });
+
+  it("rejects an out-of-range voice recording bitrate", () => {
+    const baseConfig = createRuntimeConfig();
+    const targetConfig = createRuntimeConfig();
+
+    expect(() =>
+      applyBbAppManagedConfig({
+        baseConfig,
+        managedConfig: {
+          config: {
+            BB_TRANSCRIPTION_RECORDING_BITRATE: "999",
+          },
+        },
+        managedEnvFile: {},
+        targetConfig,
+      }),
+    ).toThrow(/BB_TRANSCRIPTION_RECORDING_BITRATE/u);
+  });
+
   it("reloads config file changes and notifies clients", async () => {
     const dataDir = mkdtempSync(join(tmpdir(), "bb-managed-config-"));
     const socket = createMockHubSocket();
@@ -377,8 +510,7 @@ describe("bb-app managed config", () => {
     }
   });
 
-  it("throws on invalid managed config during explicit reload", async () => {
-    const dataDir = mkdtempSync(join(tmpdir(), "bb-managed-config-"));
+  it("throws on invalid managed config during explicit reload", async () => {    const dataDir = mkdtempSync(join(tmpdir(), "bb-managed-config-"));
     const config = {
       ...createRuntimeConfig(),
       dataDir,
@@ -400,6 +532,22 @@ describe("bb-app managed config", () => {
         /BB_INFERENCE/u,
       );
       expect(config.inferenceModel).toBe("openai/gpt-4o-mini");
+    } finally {
+      rmSync(dataDir, { force: true, recursive: true });
+    }
+  });
+
+  it("refuses to overwrite non-object managed config content", async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), "bb-managed-config-"));
+    try {
+      writeFileSync(formatBbAppConfigPath(dataDir), `["not", "an", "object"]\n`, "utf8");
+
+      await expect(
+        writeBbAppManagedConfigValues({
+          dataDir,
+          values: { BB_INFERENCE: "openai/gpt-4o-mini" },
+        }),
+      ).rejects.toThrow(/Invalid bb-app config JSON/u);
     } finally {
       rmSync(dataDir, { force: true, recursive: true });
     }

--- a/apps/server/test/system/transcription-settings.test.ts
+++ b/apps/server/test/system/transcription-settings.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import {
+  systemAiServicesSchema,
+  systemConfigResponseSchema,
+} from "@bb/server-contract";
+import { readJson } from "../helpers/json.js";
+import { withTestHarness, type TestAppHarness } from "../helpers/test-app.js";
+
+async function putTranscription(
+  harness: TestAppHarness,
+  body: unknown,
+): Promise<Response> {
+  return harness.app.request("/api/v1/settings/transcription", {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("transcription settings", () => {
+  it("persists validated values and reflects them in /system/config", async () => {
+    await withTestHarness(async (harness) => {
+      const response = await putTranscription(harness, {
+        transcriptionModel: "codex/gpt-transcribe",
+        transcriptionMaxBytes: 10 * 1024 * 1024,
+        transcriptionTimeoutMaxMs: 120_000,
+        recordingBitrate: 48_000,
+      });
+      expect(response.status).toBe(200);
+      const aiServices = systemAiServicesSchema.parse(await readJson(response));
+      expect(aiServices).toMatchObject({
+        transcription: "codex/gpt-transcribe",
+        transcriptionMaxBytes: 10 * 1024 * 1024,
+        transcriptionTimeoutMaxMs: 120_000,
+        recordingBitrate: 48_000,
+      });
+
+      const config = await harness.app.request("/api/v1/system/config");
+      const parsed = systemConfigResponseSchema.parse(await readJson(config));
+      expect(parsed.aiServices).toMatchObject({
+        transcription: "codex/gpt-transcribe",
+        transcriptionMaxBytes: 10 * 1024 * 1024,
+        transcriptionTimeoutMaxMs: 120_000,
+        recordingBitrate: 48_000,
+      });
+    });
+  });
+
+  it("updates only the provided field, leaving others unchanged", async () => {
+    await withTestHarness(async (harness) => {
+      const before = systemConfigResponseSchema.parse(
+        await readJson(await harness.app.request("/api/v1/system/config")),
+      );
+
+      const response = await putTranscription(harness, {
+        recordingBitrate: 64_000,
+      });
+      expect(response.status).toBe(200);
+      const aiServices = systemAiServicesSchema.parse(await readJson(response));
+      expect(aiServices.recordingBitrate).toBe(64_000);
+      expect(aiServices.transcription).toBe(before.aiServices.transcription);
+      expect(aiServices.transcriptionMaxBytes).toBe(
+        before.aiServices.transcriptionMaxBytes,
+      );
+    });
+  });
+
+  it("rejects an audio limit above the 10MB cap without persisting", async () => {
+    await withTestHarness(async (harness) => {
+      const before = systemConfigResponseSchema.parse(
+        await readJson(await harness.app.request("/api/v1/system/config")),
+      );
+      const response = await putTranscription(harness, {
+        transcriptionMaxBytes: 10 * 1024 * 1024 + 1,
+      });
+      expect(response.status).toBe(400);
+      await expect(readJson(response)).resolves.toMatchObject({
+        code: "invalid_request",
+      });
+
+      const after = systemConfigResponseSchema.parse(
+        await readJson(await harness.app.request("/api/v1/system/config")),
+      );
+      expect(after.aiServices.transcriptionMaxBytes).toBe(
+        before.aiServices.transcriptionMaxBytes,
+      );
+    });
+  });
+
+  it("rejects a model without provider/model format", async () => {
+    await withTestHarness(async (harness) => {
+      const response = await putTranscription(harness, {
+        transcriptionModel: "gpt-transcribe",
+      });
+      expect(response.status).toBe(400);
+    });
+  });
+
+  it("rejects a timeout below the floor", async () => {
+    await withTestHarness(async (harness) => {
+      const response = await putTranscription(harness, {
+        transcriptionTimeoutMaxMs: 9_999,
+      });
+      expect(response.status).toBe(400);
+    });
+  });
+
+  it("rejects an empty update", async () => {
+    await withTestHarness(async (harness) => {
+      const response = await putTranscription(harness, {});
+      expect(response.status).toBe(400);
+    });
+  });
+
+  it("rejects unknown fields", async () => {
+    await withTestHarness(async (harness) => {
+      const response = await putTranscription(harness, {
+        transcriptionModel: "codex/gpt-transcribe",
+        unexpected: true,
+      });
+      expect(response.status).toBe(400);
+    });
+  });
+});

--- a/docs/api_to_audit.md
+++ b/docs/api_to_audit.md
@@ -2178,7 +2178,9 @@ options.
    registered services (a picker needs per-service model lists, which the
    contract does not carry yet).
 2. **Payload cap.** A plugin-served transcription travels as base64 inside one
-   host RPC call (8 MiB JSON cap → 5 MB audio), a regression from the 25 MB
+   host RPC call (16 MiB JSON cap → 10 MB audio; raised from 8 MiB in the
+   voice-transcription limits change because the base64 overhead made the old
+   cap unserviceable for the local STT path), a regression from the 25 MB
    the server-direct path accepts for long recordings (owner decision: keep
    for now). The alternative is a host pull: the server stores the audio
    under a short-lived token and the call carries the token, so the host
@@ -2549,3 +2551,27 @@ describing it as merely too large.
    boolean indicating whether a detail read can succeed.
 3. Verify old persisted previews and mixed-version clients still receive a
    deterministic state before making the field stable.
+
+## `PluginAiServiceDeclaration.experimental_maxVoiceBytes`
+
+**What it does.** Lets an AI service that declares the `voice` kind cap the
+largest audio payload it will accept, in bytes. The server rejects a larger
+recording with HTTP 400 before the host call, enforcing the smaller of this
+value and the user's `BB_TRANSCRIPTION_MAX_BYTES` ceiling. Omitting it accepts
+audio up to the user's ceiling. `validatePluginAiServiceDeclaration` requires a
+positive integer no greater than the 10MB overall voice cap
+(`AI_SERVICE_MAX_VOICE_BYTES_CEILING`) and only on a service that declares the
+`voice` kind. The effective and declared caps surface in the system config
+response (`SystemAiService.effectiveVoiceMaxBytes` / `maxVoiceBytes`), in
+`bb settings ai-services`, and in Settings → General → Voice Input.
+
+**Audit before stabilizing.**
+
+1. Confirm bytes is the right unit versus a duration or a coarse capability
+   flag (e.g. `largeAudio`), given plugins reason about recording length.
+2. Decide whether a service should be able to raise its cap above the 10MB
+   overall voice cap if that cap ever becomes configurable.
+3. Confirm the min(ceiling, service) enforcement and its 400 message are the
+   right behavior versus transparently downsampling or chunking long audio.
+4. Decide whether the field belongs on the per-service declaration or on the
+   per-request `ai.voice.transcribe` contract.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -139,7 +139,10 @@ signal it, so a stale file left by a crash cannot stop an unrelated process.
 | `BB_APP_URL`            | `bb-app config`                                    | Optional for remote use | Human-facing app URL used for generated links and allowed browser origins. Leave empty for local-only use.                                                                                                                                                                                                                                                                                                     |
 | `BB_INFERENCE`          | `bb-app config`                                    | Optional                | Primary server-side helper model in `<service>/<model>` format, where `<service>` is an AI service a loaded plugin registers (`bb settings ai-services` lists them; `codex` comes with the codex plugin and uses the codex CLI's credentials with no reasoning) or a pi-ai provider the server calls directly with its API key. Defaults to `codex/gpt-5.6-luna`.                                              |
 | `BB_INFERENCE_FALLBACK` | `bb-app config`                                    | Optional                | Helper model used after a transient primary timeout, rate limit, or service-unavailable failure. Defaults to `codex/gpt-5.4-mini`.                                                                                                                                                                                                                                                                             |
-| `BB_TRANSCRIPTION`      | `bb-app config`                                    | Optional                | Voice transcription model in `<service>/<model>` format: a plugin-registered AI service (`codex` with the codex plugin; audio up to 5MB) or `openai/<model>` with `OPENAI_API_KEY`. Defaults to `codex/gpt-transcribe`.                                                                                                                                                                                        |
+| `BB_TRANSCRIPTION`      | `bb-app config`                                    | Optional                | Voice transcription model in `<service>/<model>` format: a plugin-registered AI service (`codex` with the codex plugin; audio up to the `BB_TRANSCRIPTION_MAX_BYTES` limit) or `openai/<model>` with `OPENAI_API_KEY`. Defaults to `codex/gpt-transcribe`.                                                                                                                                                     |
+| `BB_TRANSCRIPTION_MAX_BYTES` | `bb-app config`                               | Optional                | Ceiling, in bytes, on audio forwarded to a plugin-registered AI service for voice transcription. Defaults to `5242880` (5MB) and must be a positive integer no greater than the overall 10MB voice cap (`10485760`) — the largest audio the plugin transport can carry (16MB host-RPC payloads minus base64 inflation and envelope). Each voice service may also declare its own `experimental_maxVoiceBytes`; the server enforces the smaller of the two, so raising this ceiling only helps services that accept larger audio (bundled Codex caps itself at 5MB). Raise it for a local on-device STT plugin that accepts longer dictations. `bb settings ai-services` shows the ceiling and each service's effective cap. |
+| `BB_TRANSCRIPTION_TIMEOUT_MAX_MS` | `bb-app config`                          | Optional                | Ceiling, in milliseconds, on the per-attempt voice transcription timeout. The budget scales with recording size — roughly 15s per MB, with a 10s floor for short clips — then clamps to this ceiling, and each request retries once. Defaults to `300000` (5 min); must be an integer between `10000` (the floor; setting it here disables scaling) and `900000` (15 min). Raise it for slow local speech-to-text backends whose long recordings time out. Applies to both plugin-served and `openai/<model>` transcription. |
+| `BB_TRANSCRIPTION_RECORDING_BITRATE` | `bb-app config`                       | Optional                | Opus recorder bitrate, in bits/second, the browser pins **only** when the active transcription service accepts large audio (its effective cap is above 5MB). Defaults to `32000` (~2.4MB for 10 min of speech); must be an integer between `8000` and `320000`. Codex and `openai/<model>` are left at the browser default, so their recordings are unchanged. The transcription pipeline resamples to 16kHz mono, so the quality cost on clean speech is negligible. |
 | `BB_MARKETPLACE_URL`    | `bb-app env`, or environment                       | Startup-only testing    | Manifest URL of the reserved `bb-community` plugin marketplace. It defaults to `https://getbb.app/marketplace/v2/marketplace.json`. If the default v2 request returns 404, the server requests v1. Set another URL to test catalog refreshes. The server requests that URL without fallback. It changes only `bb-community`. Add other marketplaces with `bb marketplace add`. Restart the app after a change. |
 | `BB_SERVER_URL`         | `bb-app config`                                    | Remote CLI/host use     | Server URL for standalone `bb` CLI and `host-daemon` commands on the current machine. The CLI defaults to `http://127.0.0.1:38886` when unset.                                                                                                                                                                                                                                                                 |
 | `BB_SERVER_BIND_HOST`   | `bb-app env`, environment, or `--server-bind-host` | Startup-only            | Server listener host. Defaults to `127.0.0.1`; accepts only `127.0.0.1` or `0.0.0.0`. A full launcher or desktop app restart is required; until then, a previous `0.0.0.0` listener remains exposed. This is not a `bb-app config` key.                                                                                                                                                                        |
@@ -152,6 +155,20 @@ By default, helper inference and voice transcription use Codex credentials from
 the host daemon. Run `codex login` on the host for the default path. Set
 provider env keys only when opting into a non-Codex provider route.
 
+A recording must clear every layer of the voice pipeline, so the smallest limit
+wins:
+
+1. The overall audio file cap of 10MB (`10485760` bytes), rejected first.
+2. For a plugin-served service, `min(BB_TRANSCRIPTION_MAX_BYTES, the service's
+   declared cap)` — bundled Codex pins itself at 5MB.
+3. The audio is base64-encoded (~+33%) to cross the host RPC, which caps
+   payloads at 16MB — the 10MB overall cap already accounts for this, so any
+   audio that clears layers 1–2 fits the transport.
+
+Pinning `BB_TRANSCRIPTION_RECORDING_BITRATE` (~32kbps) for large-audio services
+keeps a 10-minute recording near 2.4MB raw / ~3.2MB over RPC, comfortably inside
+every layer. `bb settings ai-services` prints the effective caps.
+
 With a ChatGPT subscription login, `codex/` voice transcription posts to a
 `chatgpt.com` endpoint that sits behind Cloudflare bot protection. On some
 networks Cloudflare challenges that request; bb retries, then reports
@@ -160,9 +177,17 @@ challenge on the server. If that happens often, route transcription through an
 API key instead: `codex login --with-api-key`, or set `BB_TRANSCRIPTION` to
 `openai/gpt-transcribe` with `OPENAI_API_KEY`.
 
-The microphone picker in Settings → Voice Input is client-local. It stores the
-selected browser `MediaDevices` device id in localStorage as
-`bb.voiceInput.audioInputDeviceId`; it does not change `bb-app config` or the
+Settings → Voice Input has native controls: a Transcription provider dropdown
+(Codex or Local), a Local-models sub-section for downloading on-device
+models (shown only when the provider is Local), and an Advanced group with the
+recording limit (2/5/10 MB), timeout ceiling (seconds), and recording quality
+(24/32/64/128 kbps).
+Editing these writes BB-managed config server-side and applies live — the same
+effect as `bb settings transcription <key> <value>` or the `bb-app config` keys
+above. Per-service audio caps are maintainer detail and appear only in
+`bb settings ai-services`, not the UI. The microphone picker in that section is
+client-local: it stores the selected browser `MediaDevices` device id in
+localStorage as `bb.voiceInput.audioInputDeviceId` and does not change the
 server-side transcription model.
 
 The built-in Push notifications plugin uses `expoPushUrl` for its relay URL.

--- a/packages/bb-app/src/launcher.ts
+++ b/packages/bb-app/src/launcher.ts
@@ -56,6 +56,11 @@ import {
 } from "@bb/config/inference-model";
 import { validateLogLevel } from "@bb/config/log-level";
 import { validateOptionalUrl } from "@bb/config/public-url";
+import {
+  parsePluginTranscriptionMaxBytes,
+  parseVoiceRecordingBitrate,
+  parseVoiceTranscriptionTimeoutMaxMs,
+} from "@bb/config/voice-transcription-limit";
 import { parseServerBindHost, type ServerBindHost } from "@bb/config/server";
 import { toOptionalString } from "@bb/config/strings";
 import {
@@ -119,6 +124,9 @@ const STARTUP_ONLY_MANAGED_ENV_KEYS = new Set<string>([
   "BB_SERVER_PORT",
   "BB_TELEMETRY",
   "BB_TRANSCRIPTION",
+  "BB_TRANSCRIPTION_MAX_BYTES",
+  "BB_TRANSCRIPTION_TIMEOUT_MAX_MS",
+  "BB_TRANSCRIPTION_RECORDING_BITRATE",
 ]);
 const PORTABLE_ENV_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/u;
 const SECRET_SHAPED_ENV_NAME_PATTERN =
@@ -1222,6 +1230,24 @@ function validateManagedConfigForWrite(config: ManagedConfigForWrite): void {
   if (configValues.BB_TRANSCRIPTION !== undefined) {
     validateTranscriptionModel(configValues.BB_TRANSCRIPTION);
   }
+  if (configValues.BB_TRANSCRIPTION_MAX_BYTES !== undefined) {
+    parsePluginTranscriptionMaxBytes(
+      "BB_TRANSCRIPTION_MAX_BYTES",
+      configValues.BB_TRANSCRIPTION_MAX_BYTES,
+    );
+  }
+  if (configValues.BB_TRANSCRIPTION_TIMEOUT_MAX_MS !== undefined) {
+    parseVoiceTranscriptionTimeoutMaxMs(
+      "BB_TRANSCRIPTION_TIMEOUT_MAX_MS",
+      configValues.BB_TRANSCRIPTION_TIMEOUT_MAX_MS,
+    );
+  }
+  if (configValues.BB_TRANSCRIPTION_RECORDING_BITRATE !== undefined) {
+    parseVoiceRecordingBitrate(
+      "BB_TRANSCRIPTION_RECORDING_BITRATE",
+      configValues.BB_TRANSCRIPTION_RECORDING_BITRATE,
+    );
+  }
   if (configValues.BB_LOG_LEVEL !== undefined) {
     validateLogLevel(configValues.BB_LOG_LEVEL);
   }
@@ -1536,11 +1562,13 @@ Startup-only server and launcher keys:
   BB_INHERITED_SKILLS_ROOTS, BB_LOG_LEVEL,
   BB_MANAGED_DEV_BUILTIN_PLUGIN_HOT_RELOAD, BB_POSTHOG_API_KEY,
   BB_SERVER_BIND_HOST, BB_SERVER_PORT, BB_TELEMETRY, BB_TRANSCRIPTION,
-  and BB_FF_* feature flags.
+  BB_TRANSCRIPTION_MAX_BYTES, BB_TRANSCRIPTION_TIMEOUT_MAX_MS,
+  BB_TRANSCRIPTION_RECORDING_BITRATE, and BB_FF_* feature flags.
   Changes require a full bb-app restart with bb-app stop && bb-app start,
   or a desktop app restart. BB_APP_URL, BB_INFERENCE,
-  BB_INFERENCE_FALLBACK, and BB_TRANSCRIPTION can instead be changed live
-  with bb-app config.
+  BB_INFERENCE_FALLBACK, BB_TRANSCRIPTION, BB_TRANSCRIPTION_MAX_BYTES,
+  BB_TRANSCRIPTION_TIMEOUT_MAX_MS, and BB_TRANSCRIPTION_RECORDING_BITRATE can
+  instead be changed live with bb-app config.
 
 Env file:
   ${formatBbAppEnvPath(dataDir)}

--- a/packages/bb-app/test/index.test.ts
+++ b/packages/bb-app/test/index.test.ts
@@ -155,6 +155,21 @@ const invalidConfigCommandCases: InvalidConfigCommandCase[] = [
     key: "BB_LOG_LEVEL",
     value: "bogus",
   },
+  {
+    expectedError: /BB_TRANSCRIPTION_MAX_BYTES/u,
+    key: "BB_TRANSCRIPTION_MAX_BYTES",
+    value: "not-a-number",
+  },
+  {
+    expectedError: /BB_TRANSCRIPTION_TIMEOUT_MAX_MS/u,
+    key: "BB_TRANSCRIPTION_TIMEOUT_MAX_MS",
+    value: "9999",
+  },
+  {
+    expectedError: /BB_TRANSCRIPTION_RECORDING_BITRATE/u,
+    key: "BB_TRANSCRIPTION_RECORDING_BITRATE",
+    value: "999",
+  },
 ];
 
 const startupOnlyManagedEnvCases: StartupOnlyManagedEnvCase[] = [
@@ -179,6 +194,18 @@ const startupOnlyManagedEnvCases: StartupOnlyManagedEnvCase[] = [
   { key: "BB_SERVER_PORT", value: "48886" },
   { key: "BB_TELEMETRY", value: "false" },
   { key: "BB_TRANSCRIPTION", value: "codex/test-transcription" },
+  {
+    key: "BB_TRANSCRIPTION_MAX_BYTES",
+    value: String(10 * 1024 * 1024),
+  },
+  {
+    key: "BB_TRANSCRIPTION_TIMEOUT_MAX_MS",
+    value: "120000",
+  },
+  {
+    key: "BB_TRANSCRIPTION_RECORDING_BITRATE",
+    value: "48000",
+  },
 ];
 
 const packageMetadataSchema = z.object({

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -127,6 +127,11 @@
       "source": "./src/verified-process-stop.ts",
       "types": "./src/verified-process-stop.ts",
       "default": "./src/verified-process-stop.ts"
+    },
+    "./voice-transcription-limit": {
+      "source": "./src/voice-transcription-limit.ts",
+      "types": "./src/voice-transcription-limit.ts",
+      "default": "./src/voice-transcription-limit.ts"
     }
   },
   "scripts": {

--- a/packages/config/src/bb-app-managed-config.ts
+++ b/packages/config/src/bb-app-managed-config.ts
@@ -25,7 +25,10 @@ export type BbAppManagedConfigKey =
   | "BB_INFERENCE"
   | "BB_INFERENCE_FALLBACK"
   | "BB_LOG_LEVEL"
-  | "BB_TRANSCRIPTION";
+  | "BB_TRANSCRIPTION"
+  | "BB_TRANSCRIPTION_MAX_BYTES"
+  | "BB_TRANSCRIPTION_TIMEOUT_MAX_MS"
+  | "BB_TRANSCRIPTION_RECORDING_BITRATE";
 
 export const BB_APP_MANAGED_CONFIG_KEYS: BbAppManagedConfigKey[] = [
   "BB_APP_URL",
@@ -33,6 +36,9 @@ export const BB_APP_MANAGED_CONFIG_KEYS: BbAppManagedConfigKey[] = [
   "BB_INFERENCE_FALLBACK",
   "BB_LOG_LEVEL",
   "BB_TRANSCRIPTION",
+  "BB_TRANSCRIPTION_MAX_BYTES",
+  "BB_TRANSCRIPTION_TIMEOUT_MAX_MS",
+  "BB_TRANSCRIPTION_RECORDING_BITRATE",
 ];
 
 export const PORTABLE_ENV_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/u;
@@ -54,6 +60,9 @@ const bbAppManagedConfigValuesSchema = z
     BB_INFERENCE_FALLBACK: z.string().optional(),
     BB_LOG_LEVEL: z.string().optional(),
     BB_TRANSCRIPTION: z.string().optional(),
+    BB_TRANSCRIPTION_MAX_BYTES: z.string().optional(),
+    BB_TRANSCRIPTION_TIMEOUT_MAX_MS: z.string().optional(),
+    BB_TRANSCRIPTION_RECORDING_BITRATE: z.string().optional(),
   })
   .strict();
 

--- a/packages/config/src/env-vars.ts
+++ b/packages/config/src/env-vars.ts
@@ -17,6 +17,14 @@ import {
 import { validateLogLevel } from "./log-level.js";
 import { validateOptionalUrl, validateRequiredUrl } from "./public-url.js";
 import { BB_LOOPBACK_HOST, parsePortValue } from "./runtime.js";
+import {
+  DEFAULT_PLUGIN_TRANSCRIPTION_MAX_BYTES,
+  DEFAULT_VOICE_RECORDING_BITRATE,
+  DEFAULT_VOICE_TRANSCRIPTION_TIMEOUT_MAX_MS,
+  parsePluginTranscriptionMaxBytes,
+  parseVoiceRecordingBitrate,
+  parseVoiceTranscriptionTimeoutMaxMs,
+} from "./voice-transcription-limit.js";
 
 export type ServerBindHost = "127.0.0.1" | "0.0.0.0";
 
@@ -139,6 +147,20 @@ function parseTranscriptionModelValue(args: EnvVarParseArgs): string {
   return validateTranscriptionModel(args.value);
 }
 
+function parseTranscriptionMaxBytesValue(args: EnvVarParseArgs): number {
+  return parsePluginTranscriptionMaxBytes(args.name, args.value);
+}
+
+function parseTranscriptionTimeoutMaxMsValue(args: EnvVarParseArgs): number {
+  return parseVoiceTranscriptionTimeoutMaxMs(args.name, args.value);
+}
+
+function parseTranscriptionRecordingBitrateValue(
+  args: EnvVarParseArgs,
+): number {
+  return parseVoiceRecordingBitrate(args.name, args.value);
+}
+
 function parseHostTypeValue(args: EnvVarParseArgs): HostType | undefined {
   const trimmedValue = args.value.trim();
   if (trimmedValue.length === 0) {
@@ -242,6 +264,27 @@ export const BB_TRANSCRIPTION_ENV = defineEnvVar<string>({
   description: "Speech-to-text model used for voice transcription",
   name: "BB_TRANSCRIPTION",
   parse: parseTranscriptionModelValue,
+});
+
+export const BB_TRANSCRIPTION_MAX_BYTES_ENV = defineEnvVar<number>({
+  description:
+    "Maximum audio file size in bytes forwarded to a plugin-registered AI service for voice transcription. Defaults to 5MB; must not exceed the 10MB overall voice cap (the largest audio the plugin transport can carry).",
+  name: "BB_TRANSCRIPTION_MAX_BYTES",
+  parse: parseTranscriptionMaxBytesValue,
+});
+
+export const BB_TRANSCRIPTION_TIMEOUT_MAX_MS_ENV = defineEnvVar<number>({
+  description:
+    "Ceiling in milliseconds on the per-attempt voice transcription timeout, which scales with recorded audio size. Defaults to 300000 (5 min); raise it for slow local speech-to-text backends.",
+  name: "BB_TRANSCRIPTION_TIMEOUT_MAX_MS",
+  parse: parseTranscriptionTimeoutMaxMsValue,
+});
+
+export const BB_TRANSCRIPTION_RECORDING_BITRATE_ENV = defineEnvVar<number>({
+  description:
+    "Opus recorder bitrate in bits/second pinned by the browser only for transcription services that accept large audio (effective cap above 5MB). Defaults to 32000; leaves the browser default untouched for Codex and openai/*.",
+  name: "BB_TRANSCRIPTION_RECORDING_BITRATE",
+  parse: parseTranscriptionRecordingBitrateValue,
 });
 
 export const OPENAI_API_KEY_ENV = defineEnvVar<string>({
@@ -377,6 +420,12 @@ export const DEFAULT_BB_MARKETPLACE_URL =
 export const DEFAULT_BB_INFERENCE = DEFAULTS.inferenceModel;
 export const DEFAULT_BB_INFERENCE_FALLBACK = DEFAULTS.inferenceFallbackModel;
 export const DEFAULT_BB_TRANSCRIPTION = DEFAULTS.transcriptionModel;
+export const DEFAULT_BB_TRANSCRIPTION_MAX_BYTES =
+  DEFAULT_PLUGIN_TRANSCRIPTION_MAX_BYTES;
+export const DEFAULT_BB_TRANSCRIPTION_TIMEOUT_MAX_MS =
+  DEFAULT_VOICE_TRANSCRIPTION_TIMEOUT_MAX_MS;
+export const DEFAULT_BB_TRANSCRIPTION_RECORDING_BITRATE =
+  DEFAULT_VOICE_RECORDING_BITRATE;
 export const DEFAULT_BB_FF_PLACEHOLDER = defaultFeatureFlags.placeholder;
 export const DEFAULT_BB_FF_TIMELINE_WINDOW_EVENT_BUDGET =
   defaultFeatureFlags.timelineWindowEventBudget;

--- a/packages/config/src/server.ts
+++ b/packages/config/src/server.ts
@@ -26,6 +26,9 @@ import {
   BB_SERVER_LAUNCH_ID_ENV,
   BB_TELEMETRY_ENV,
   BB_TRANSCRIPTION_ENV,
+  BB_TRANSCRIPTION_MAX_BYTES_ENV,
+  BB_TRANSCRIPTION_TIMEOUT_MAX_MS_ENV,
+  BB_TRANSCRIPTION_RECORDING_BITRATE_ENV,
   DEFAULT_BB_APP_URL,
   DEFAULT_BB_APP_SURFACE,
   DEFAULT_BB_APP_VERSION,
@@ -37,6 +40,9 @@ import {
   DEFAULT_BB_SERVER_BIND_HOST,
   DEFAULT_BB_TELEMETRY,
   DEFAULT_BB_TRANSCRIPTION,
+  DEFAULT_BB_TRANSCRIPTION_MAX_BYTES,
+  DEFAULT_BB_TRANSCRIPTION_TIMEOUT_MAX_MS,
+  DEFAULT_BB_TRANSCRIPTION_RECORDING_BITRATE,
   DEFAULT_OPENAI_API_KEY,
   OPENAI_API_KEY_ENV,
   parseServerBindHost,
@@ -64,6 +70,9 @@ export interface ServerConfig
   BB_SERVER_LAUNCH_ID?: string;
   BB_TELEMETRY: boolean;
   BB_TRANSCRIPTION: string;
+  BB_TRANSCRIPTION_MAX_BYTES: number;
+  BB_TRANSCRIPTION_TIMEOUT_MAX_MS: number;
+  BB_TRANSCRIPTION_RECORDING_BITRATE: number;
   OPENAI_API_KEY: string;
   featureFlags: FeatureFlags;
 }
@@ -181,6 +190,24 @@ export function loadServerConfig(
       context: loader.context,
       defaultValue: DEFAULT_BB_TRANSCRIPTION,
       definition: BB_TRANSCRIPTION_ENV,
+      env: loader.env,
+    }),
+    BB_TRANSCRIPTION_MAX_BYTES: readEnvVarWithDefault({
+      context: loader.context,
+      defaultValue: DEFAULT_BB_TRANSCRIPTION_MAX_BYTES,
+      definition: BB_TRANSCRIPTION_MAX_BYTES_ENV,
+      env: loader.env,
+    }),
+    BB_TRANSCRIPTION_TIMEOUT_MAX_MS: readEnvVarWithDefault({
+      context: loader.context,
+      defaultValue: DEFAULT_BB_TRANSCRIPTION_TIMEOUT_MAX_MS,
+      definition: BB_TRANSCRIPTION_TIMEOUT_MAX_MS_ENV,
+      env: loader.env,
+    }),
+    BB_TRANSCRIPTION_RECORDING_BITRATE: readEnvVarWithDefault({
+      context: loader.context,
+      defaultValue: DEFAULT_BB_TRANSCRIPTION_RECORDING_BITRATE,
+      definition: BB_TRANSCRIPTION_RECORDING_BITRATE_ENV,
       env: loader.env,
     }),
     OPENAI_API_KEY: readEnvVarWithDefault({

--- a/packages/config/src/voice-transcription-limit.ts
+++ b/packages/config/src/voice-transcription-limit.ts
@@ -1,0 +1,178 @@
+/**
+ * Overall voice-transcription audio cap (10MB raw). This is the largest audio
+ * the plugin transport can actually carry: host RPC caps JSON payloads at
+ * 16MB, base64 inflates raw audio by 4/3 (16MB -> 12MB), and the JSON envelope
+ * around the payload takes the rest. Values above this cannot succeed on any
+ * plugin-served path, so the validator rejects them instead of failing later
+ * with a transport 413.
+ */
+export const VOICE_TRANSCRIPTION_MAX_BYTES = 10 * 1024 * 1024;
+export const DEFAULT_PLUGIN_TRANSCRIPTION_MAX_BYTES = 5 * 1024 * 1024;
+
+/**
+ * Single source of truth for the "large-audio service" bitrate policy: the
+ * browser pins a low opus bitrate only when the active transcription service
+ * accepts more than the default ceiling, so long recordings stay small. An
+ * unknown service (null cap) uses the browser default. Client and server must
+ * both go through here instead of re-implementing the tripwire.
+ */
+export function isLargeAudioService(
+  effectiveCapBytes: number | null,
+): boolean {
+  return (
+    effectiveCapBytes !== null &&
+    effectiveCapBytes > DEFAULT_PLUGIN_TRANSCRIPTION_MAX_BYTES
+  );
+}
+
+const DECIMAL_INTEGER = /^\d+$/;
+
+/** Shared grammar check so UI, CLI, and server agree on what an integer is. */
+export function isDecimalIntegerString(rawValue: string): boolean {
+  return DECIMAL_INTEGER.test(rawValue.trim());
+}
+
+function parseDecimalInteger(
+  name: string,
+  rawValue: string,
+  unit: string,
+): number {
+  const trimmed = rawValue.trim();
+  if (!DECIMAL_INTEGER.test(trimmed)) {
+    throw new Error(`${name} must be a positive integer of ${unit}`);
+  }
+  return Number(trimmed);
+}
+
+export function validatePluginTranscriptionMaxBytes(
+  name: string,
+  value: number,
+): number {
+  if (
+    !Number.isInteger(value) ||
+    value <= 0 ||
+    value > VOICE_TRANSCRIPTION_MAX_BYTES
+  ) {
+    throw new Error(
+      `${name} must be a positive integer of bytes no greater than ${VOICE_TRANSCRIPTION_MAX_BYTES} (10MB)`,
+    );
+  }
+  return value;
+}
+
+export function parsePluginTranscriptionMaxBytes(
+  name: string,
+  rawValue: string,
+): number {
+  return validatePluginTranscriptionMaxBytes(
+    name,
+    parseDecimalInteger(name, rawValue, "bytes"),
+  );
+}
+
+const BYTES_PER_MB = 1024 * 1024;
+
+/**
+ * Default recorder bitrate (bits/second) pinned for large-audio transcription
+ * services. ~32kbps opus keeps 10 minutes of speech near 2.4MB raw while the
+ * 16kHz-mono transcription pipeline makes the quality cost negligible.
+ */
+export const DEFAULT_VOICE_RECORDING_BITRATE = 32_000;
+export const VOICE_RECORDING_BITRATE_MIN = 8_000;
+export const VOICE_RECORDING_BITRATE_MAX = 320_000;
+
+export function validateVoiceRecordingBitrate(
+  name: string,
+  value: number,
+): number {
+  if (
+    !Number.isInteger(value) ||
+    value < VOICE_RECORDING_BITRATE_MIN ||
+    value > VOICE_RECORDING_BITRATE_MAX
+  ) {
+    throw new Error(
+      `${name} must be an integer between ${VOICE_RECORDING_BITRATE_MIN} and ${VOICE_RECORDING_BITRATE_MAX} bits per second`,
+    );
+  }
+  return value;
+}
+
+export function parseVoiceRecordingBitrate(
+  name: string,
+  rawValue: string,
+): number {
+  return validateVoiceRecordingBitrate(
+    name,
+    parseDecimalInteger(name, rawValue, "bits per second"),
+  );
+}
+
+/**
+ * Per-attempt timeout floor. Short clips keep this budget so a genuinely stuck
+ * backend still fails fast; longer recordings scale above it.
+ */
+export const VOICE_TRANSCRIPTION_TIMEOUT_FLOOR_MS = 10_000;
+
+/**
+ * Budget allowed per megabyte of input audio. Local transcription runs at
+ * roughly realtime * a small factor plus fixed model-load and ffmpeg overhead,
+ * so budget grows with recording length (approximated from byte size). Short
+ * clips whose per-megabyte estimate falls below the floor use the floor.
+ */
+export const VOICE_TRANSCRIPTION_TIMEOUT_MS_PER_MB = 15_000;
+
+/** Default ceiling on the per-attempt timeout, before user override (5 min). */
+export const DEFAULT_VOICE_TRANSCRIPTION_TIMEOUT_MAX_MS = 300_000;
+
+/** Hard upper bound on the configurable per-attempt timeout ceiling (15 min). */
+export const VOICE_TRANSCRIPTION_TIMEOUT_MAX_CEILING_MS = 900_000;
+
+export function validateVoiceTranscriptionTimeoutMaxMs(
+  name: string,
+  value: number,
+): number {
+  if (
+    !Number.isInteger(value) ||
+    value < VOICE_TRANSCRIPTION_TIMEOUT_FLOOR_MS ||
+    value > VOICE_TRANSCRIPTION_TIMEOUT_MAX_CEILING_MS
+  ) {
+    throw new Error(
+      `${name} must be an integer between ${VOICE_TRANSCRIPTION_TIMEOUT_FLOOR_MS} and ${VOICE_TRANSCRIPTION_TIMEOUT_MAX_CEILING_MS} milliseconds`,
+    );
+  }
+  return value;
+}
+
+export function parseVoiceTranscriptionTimeoutMaxMs(
+  name: string,
+  rawValue: string,
+): number {
+  return validateVoiceTranscriptionTimeoutMaxMs(
+    name,
+    parseDecimalInteger(name, rawValue, "milliseconds"),
+  );
+}
+
+interface ResolveVoiceTranscriptionTimeoutArgs {
+  audioBytes: number;
+  maxMs: number;
+}
+
+/**
+ * Per-attempt transcription timeout scaled from the input audio size: a
+ * per-megabyte estimate, floored for short clips and clamped to the configured
+ * ceiling. Setting the ceiling to the floor opts out of scaling.
+ */
+export function resolveVoiceTranscriptionTimeoutMs(
+  args: ResolveVoiceTranscriptionTimeoutArgs,
+): number {
+  const scaled = Math.ceil(
+    (Math.max(0, args.audioBytes) / BYTES_PER_MB) *
+      VOICE_TRANSCRIPTION_TIMEOUT_MS_PER_MB,
+  );
+  const ceiling = Math.max(VOICE_TRANSCRIPTION_TIMEOUT_FLOOR_MS, args.maxMs);
+  return Math.min(
+    Math.max(scaled, VOICE_TRANSCRIPTION_TIMEOUT_FLOOR_MS),
+    ceiling,
+  );
+}

--- a/packages/config/test/config.test.ts
+++ b/packages/config/test/config.test.ts
@@ -22,6 +22,12 @@ import {
 import { loadServerPortConfig } from "../src/server-port.js";
 import { loadServerConfig } from "../src/server.js";
 import { loadViteDevConfig } from "../src/vite-dev.js";
+import { resolveVoiceTranscriptionTimeoutMs } from "../src/voice-transcription-limit.js";
+import {
+  parsePluginTranscriptionMaxBytes,
+  parseVoiceRecordingBitrate,
+  parseVoiceTranscriptionTimeoutMaxMs,
+} from "../src/voice-transcription-limit.js";
 
 async function importConfigModules(): Promise<void> {
   vi.resetModules();
@@ -307,6 +313,9 @@ describe("consumer-specific config", () => {
     expect(serverConfig.BB_INFERENCE).toBe("codex/gpt-5.6-luna");
     expect(serverConfig.BB_INFERENCE_FALLBACK).toBe("codex/gpt-5.4-mini");
     expect(serverConfig.BB_TRANSCRIPTION).toBe("codex/gpt-transcribe");
+    expect(serverConfig.BB_TRANSCRIPTION_MAX_BYTES).toBe(5 * 1024 * 1024);
+    expect(serverConfig.BB_TRANSCRIPTION_TIMEOUT_MAX_MS).toBe(300_000);
+    expect(serverConfig.BB_TRANSCRIPTION_RECORDING_BITRATE).toBe(32_000);
     expect(serverConfig.OPENAI_API_KEY).toBe("test-openai-key");
     expect(serverConfig.featureFlags).toEqual({
       placeholder: false,
@@ -513,6 +522,108 @@ describe("consumer-specific config", () => {
         }),
       }),
     ).toThrow(/BB_TRANSCRIPTION/u);
+  });
+
+  it("parses an explicit BB_TRANSCRIPTION_MAX_BYTES", () => {
+    const serverConfig = loadServerConfig({
+      env: createServerRuntimeEnv({
+        BB_TRANSCRIPTION_MAX_BYTES: String(10 * 1024 * 1024),
+      }),
+    });
+
+    expect(serverConfig.BB_TRANSCRIPTION_MAX_BYTES).toBe(10 * 1024 * 1024);
+  });
+
+  it("rejects a non-positive BB_TRANSCRIPTION_MAX_BYTES", () => {
+    expect(() =>
+      loadServerConfig({
+        env: createServerRuntimeEnv({
+          BB_TRANSCRIPTION_MAX_BYTES: "0",
+        }),
+      }),
+    ).toThrow(/BB_TRANSCRIPTION_MAX_BYTES/u);
+  });
+
+  it("rejects a non-integer BB_TRANSCRIPTION_MAX_BYTES", () => {
+    expect(() =>
+      loadServerConfig({
+        env: createServerRuntimeEnv({
+          BB_TRANSCRIPTION_MAX_BYTES: "not-a-number",
+        }),
+      }),
+    ).toThrow(/BB_TRANSCRIPTION_MAX_BYTES/u);
+  });
+
+  it("rejects a BB_TRANSCRIPTION_MAX_BYTES above the 10MB voice cap", () => {
+    expect(() =>
+      loadServerConfig({
+        env: createServerRuntimeEnv({
+          BB_TRANSCRIPTION_MAX_BYTES: String(10 * 1024 * 1024 + 1),
+        }),
+      }),
+    ).toThrow(/BB_TRANSCRIPTION_MAX_BYTES/u);
+  });
+
+  it("parses an explicit BB_TRANSCRIPTION_TIMEOUT_MAX_MS", () => {
+    const serverConfig = loadServerConfig({
+      env: createServerRuntimeEnv({
+        BB_TRANSCRIPTION_TIMEOUT_MAX_MS: "120000",
+      }),
+    });
+
+    expect(serverConfig.BB_TRANSCRIPTION_TIMEOUT_MAX_MS).toBe(120_000);
+  });
+
+  it("rejects a BB_TRANSCRIPTION_TIMEOUT_MAX_MS below the 10s floor", () => {
+    expect(() =>
+      loadServerConfig({
+        env: createServerRuntimeEnv({
+          BB_TRANSCRIPTION_TIMEOUT_MAX_MS: "9999",
+        }),
+      }),
+    ).toThrow(/BB_TRANSCRIPTION_TIMEOUT_MAX_MS/u);
+  });
+
+  it("rejects a BB_TRANSCRIPTION_TIMEOUT_MAX_MS above the 15 minute cap", () => {
+    expect(() =>
+      loadServerConfig({
+        env: createServerRuntimeEnv({
+          BB_TRANSCRIPTION_TIMEOUT_MAX_MS: String(900_000 + 1),
+        }),
+      }),
+    ).toThrow(/BB_TRANSCRIPTION_TIMEOUT_MAX_MS/u);
+  });
+
+  it("rejects a non-integer BB_TRANSCRIPTION_TIMEOUT_MAX_MS", () => {
+    expect(() =>
+      loadServerConfig({
+        env: createServerRuntimeEnv({
+          BB_TRANSCRIPTION_TIMEOUT_MAX_MS: "soon",
+        }),
+      }),
+    ).toThrow(/BB_TRANSCRIPTION_TIMEOUT_MAX_MS/u);
+  });
+
+  it("parses an explicit BB_TRANSCRIPTION_RECORDING_BITRATE", () => {
+    const serverConfig = loadServerConfig({
+      env: createServerRuntimeEnv({
+        BB_TRANSCRIPTION_RECORDING_BITRATE: "48000",
+      }),
+    });
+
+    expect(serverConfig.BB_TRANSCRIPTION_RECORDING_BITRATE).toBe(48_000);
+  });
+
+  it("rejects a BB_TRANSCRIPTION_RECORDING_BITRATE outside the supported range", () => {
+    for (const value of ["7999", "320001", "not-a-number"]) {
+      expect(() =>
+        loadServerConfig({
+          env: createServerRuntimeEnv({
+            BB_TRANSCRIPTION_RECORDING_BITRATE: value,
+          }),
+        }),
+      ).toThrow(/BB_TRANSCRIPTION_RECORDING_BITRATE/u);
+    }
   });
 
   it("requires a valid server URL for the daemon and CLI", () => {
@@ -815,5 +926,67 @@ describe("provider model config", () => {
         }),
       ).toThrow(/BB_INFERENCE/u);
     }
+  });
+});
+
+describe("resolveVoiceTranscriptionTimeoutMs", () => {
+  it("keeps the 10s floor for short clips", () => {
+    expect(
+      resolveVoiceTranscriptionTimeoutMs({ audioBytes: 4_096, maxMs: 300_000 }),
+    ).toBe(10_000);
+  });
+
+  it("scales the budget with audio size above the floor", () => {
+    expect(
+      resolveVoiceTranscriptionTimeoutMs({
+        audioBytes: 2 * 1024 * 1024,
+        maxMs: 300_000,
+      }),
+    ).toBe(30_000);
+  });
+
+  it("clamps the scaled budget to the configured ceiling", () => {
+    expect(
+      resolveVoiceTranscriptionTimeoutMs({
+        audioBytes: 25 * 1024 * 1024,
+        maxMs: 120_000,
+      }),
+    ).toBe(120_000);
+  });
+
+  it("collapses to a fixed budget when the ceiling equals the floor", () => {
+    expect(
+      resolveVoiceTranscriptionTimeoutMs({
+        audioBytes: 25 * 1024 * 1024,
+        maxMs: 10_000,
+      }),
+    ).toBe(10_000);
+  });
+});
+
+describe("voice transcription numeric parsing", () => {
+  it.each([
+    ["0x10", "hex"],
+    ["1e6", "exponent"],
+    ["10.5", "decimal"],
+    ["  ", "blank"],
+    ["-5", "negative sign"],
+    ["10mb", "unit suffix"],
+  ])("rejects %j (%s) for every numeric voice setting", (raw) => {
+    expect(() => parsePluginTranscriptionMaxBytes("t", raw)).toThrow(
+      /positive integer/,
+    );
+    expect(() => parseVoiceRecordingBitrate("t", raw)).toThrow(
+      /positive integer/,
+    );
+    expect(() => parseVoiceTranscriptionTimeoutMaxMs("t", raw)).toThrow(
+      /positive integer/,
+    );
+  });
+
+  it("accepts plain decimal integers with surrounding whitespace", () => {
+    expect(parsePluginTranscriptionMaxBytes("t", " 1048576 ")).toBe(1_048_576);
+    expect(parseVoiceRecordingBitrate("t", "32000")).toBe(32_000);
+    expect(parseVoiceTranscriptionTimeoutMaxMs("t", "300000")).toBe(300_000);
   });
 });

--- a/packages/plugin-api-map/src/surfaces.ts
+++ b/packages/plugin-api-map/src/surfaces.ts
@@ -895,6 +895,7 @@ export const SURFACE_GROUPS: SurfaceGroup[] = [
         bullets: [
           "Serve those calls from an enrolled machine, so bb's helper model can be one the plugin holds the credentials for",
           "Serve voice transcription the same way, for the microphone button in the prompt box",
+          "Cap the audio size it accepts with experimental_maxVoiceBytes, which bb enforces beneath the user's overall limit",
           "Appear as a choice in the AI-service settings, alongside the models bb reaches itself",
         ],
         apiSymbols: ["PluginAiServices", "PluginAiServiceDeclaration"],

--- a/packages/plugin-sdk/src/__tests__/ai-service-declaration.test.ts
+++ b/packages/plugin-sdk/src/__tests__/ai-service-declaration.test.ts
@@ -79,6 +79,48 @@ describe("validatePluginAiServiceDeclaration", () => {
       }),
     ).toThrow(/declares kind "voice" twice/u);
   });
+
+  it("carries a valid experimental_maxVoiceBytes on a voice service", () => {
+    const normalized = validatePluginAiServiceDeclaration({
+      id: "acme-ai",
+      displayName: "Acme",
+      kinds: ["voice"],
+      experimental_maxVoiceBytes: 5 * 1024 * 1024,
+    });
+    expect(normalized).toEqual({
+      id: "acme-ai",
+      displayName: "Acme",
+      kinds: ["voice"],
+      experimental_maxVoiceBytes: 5 * 1024 * 1024,
+    });
+  });
+
+  it("rejects experimental_maxVoiceBytes without the voice kind", () => {
+    expect(() =>
+      validatePluginAiServiceDeclaration({
+        id: "acme-ai",
+        displayName: "Acme",
+        kinds: ["inference"],
+        experimental_maxVoiceBytes: 1024,
+      }),
+    ).toThrow(/experimental_maxVoiceBytes without the "voice" kind/u);
+  });
+
+  it.each([
+    [0, "zero"],
+    [-1, "negative"],
+    [1.5, "non-integer"],
+    [10 * 1024 * 1024 + 1, "above the 10MB ceiling"],
+  ])("rejects experimental_maxVoiceBytes %j (%s)", (maxVoiceBytes) => {
+    expect(() =>
+      validatePluginAiServiceDeclaration({
+        id: "acme-ai",
+        displayName: "Acme",
+        kinds: ["voice"],
+        experimental_maxVoiceBytes: maxVoiceBytes,
+      }),
+    ).toThrow(/experimental_maxVoiceBytes must be a positive integer/u);
+  });
 });
 
 describe("assertAiServiceRegistrable", () => {

--- a/packages/plugin-sdk/src/backend-contract.ts
+++ b/packages/plugin-sdk/src/backend-contract.ts
@@ -1677,6 +1677,14 @@ export interface PluginAiServiceDeclaration {
   readonly displayName: string;
   /** Which kinds this service answers; a kind it lacks is not offered. */
   readonly kinds: readonly PluginAiServiceKind[];
+  /**
+   * Largest audio payload, in bytes, this service reliably transcribes. The
+   * server rejects larger recordings before the host call, enforcing the
+   * smaller of this and the user's `BB_TRANSCRIPTION_MAX_BYTES` ceiling.
+   * Declare it only for a `voice` service; omit it to accept up to the user's
+   * ceiling. Must be a positive integer no greater than 25MB (26214400).
+   */
+  readonly experimental_maxVoiceBytes?: number;
 }
 
 export interface PluginAiServices {

--- a/packages/plugin-sdk/src/internal/host-policy.ts
+++ b/packages/plugin-sdk/src/internal/host-policy.ts
@@ -1047,6 +1047,14 @@ function validateProviderFallbackModels(
 const AI_SERVICE_KINDS = new Set<PluginAiServiceKind>(["inference", "voice"]);
 
 /**
+ * Hard ceiling for a voice service's declared `experimental_maxVoiceBytes`,
+ * matching the server's overall voice transcription cap (10MB). A declaration
+ * cannot promise more than bb accepts — and bb cannot accept more than the
+ * plugin transport can carry.
+ */
+export const AI_SERVICE_MAX_VOICE_BYTES_CEILING = 10 * 1024 * 1024;
+
+/**
  * AI-service ids the server serves itself: `openai` transcription and the
  * builtin inference providers (pi-ai 0.84). A plugin cannot register one —
  * it would capture the user's prompts and audio. This list is the one source
@@ -1139,10 +1147,31 @@ export function validatePluginAiServiceDeclaration(
     }
     seen.add(kind as PluginAiServiceKind);
   }
+  const maxVoiceBytes = declaration.experimental_maxVoiceBytes;
+  if (maxVoiceBytes !== undefined) {
+    if (!seen.has("voice")) {
+      throw new Error(
+        `AI service "${id}" declares experimental_maxVoiceBytes without the "voice" kind`,
+      );
+    }
+    if (
+      typeof maxVoiceBytes !== "number" ||
+      !Number.isInteger(maxVoiceBytes) ||
+      maxVoiceBytes <= 0 ||
+      maxVoiceBytes > AI_SERVICE_MAX_VOICE_BYTES_CEILING
+    ) {
+      throw new Error(
+        `AI service "${id}" experimental_maxVoiceBytes must be a positive integer of bytes no greater than ${AI_SERVICE_MAX_VOICE_BYTES_CEILING}`,
+      );
+    }
+  }
   return Object.freeze({
     id,
     displayName,
     kinds: Object.freeze([...seen]),
+    ...(maxVoiceBytes === undefined
+      ? {}
+      : { experimental_maxVoiceBytes: maxVoiceBytes }),
   });
 }
 

--- a/packages/sdk/src/areas/system.ts
+++ b/packages/sdk/src/areas/system.ts
@@ -18,6 +18,8 @@ import type {
   SystemInstallCliSkillsResponse,
   SystemProviderStatesResponse,
   SystemProvidersQuery,
+  SystemAiServices,
+  SystemTranscriptionSettingsUpdate,
   SystemUsageLimitsQuery,
   SystemVersionQuery,
   SystemVersionResponse,
@@ -71,6 +73,7 @@ export type SystemUpdateExperimentsResult = Experiments;
 export type SystemUpdateGeneralSettingsResult = AppSettings & {
   showUnhandledProviderEvents?: boolean;
 };
+export type SystemUpdateTranscriptionSettingsResult = SystemAiServices;
 export type SystemUpdateKeyboardSettingsResult = AppKeybindingOverrides;
 export type SystemUsageLimitsResult = ProviderUsageResponse;
 export interface SystemProviderStatesArgs extends SystemProvidersQuery {
@@ -125,6 +128,9 @@ export interface SystemArea {
   updateGeneralSettings(
     args: AppSettingsUpdate,
   ): Promise<SystemUpdateGeneralSettingsResult>;
+  updateTranscriptionSettings(
+    args: SystemTranscriptionSettingsUpdate,
+  ): Promise<SystemUpdateTranscriptionSettingsResult>;
   updateKeyboardSettings(
     args: AppKeybindingOverrides,
   ): Promise<SystemUpdateKeyboardSettingsResult>;
@@ -253,6 +259,11 @@ export function createSystemArea(args: CreateSdkAreaArgs): SystemArea {
     async updateGeneralSettings(input) {
       return transport.readJson(
         transport.api.v1.settings.general.$put({ json: input }),
+      );
+    },
+    async updateTranscriptionSettings(input) {
+      return transport.readJson(
+        transport.api.v1.settings.transcription.$put({ json: input }),
       );
     },
     async updateKeyboardSettings(input) {

--- a/packages/sdk/test/public-types.test.ts
+++ b/packages/sdk/test/public-types.test.ts
@@ -344,6 +344,7 @@ type ExpectedSystemKey =
   | "uiPreferences"
   | "updateExperiments"
   | "updateGeneralSettings"
+  | "updateTranscriptionSettings"
   | "updateKeyboardSettings"
   | "providerStates"
   | "usageLimits"

--- a/packages/server-contract/src/api/system.ts
+++ b/packages/server-contract/src/api/system.ts
@@ -112,13 +112,30 @@ export const systemAiServiceSchema = z.object({
   displayName: z.string().min(1),
   kinds: z.array(z.enum(["inference", "voice"])),
   pluginId: z.string().min(1),
+  maxVoiceBytes: z.number().int().positive().nullable(),
+  effectiveVoiceMaxBytes: z.number().int().positive().nullable(),
 });
 export type SystemAiService = z.infer<typeof systemAiServiceSchema>;
+
+export const systemTranscriptionSettingsUpdateSchema = z
+  .object({
+    transcriptionModel: z.string().min(1).optional(),
+    transcriptionMaxBytes: z.number().int().positive().optional(),
+    transcriptionTimeoutMaxMs: z.number().int().positive().optional(),
+    recordingBitrate: z.number().int().positive().optional(),
+  })
+  .strict();
+export type SystemTranscriptionSettingsUpdate = z.infer<
+  typeof systemTranscriptionSettingsUpdateSchema
+>;
 
 export const systemAiServicesSchema = z.object({
   inference: z.string().min(1),
   inferenceFallback: z.string().min(1),
   transcription: z.string().min(1),
+  transcriptionMaxBytes: z.number().int().positive(),
+  transcriptionTimeoutMaxMs: z.number().int().positive(),
+  recordingBitrate: z.number().int().positive(),
   services: z.array(systemAiServiceSchema),
 });
 export type SystemAiServices = z.infer<typeof systemAiServicesSchema>;

--- a/packages/server-contract/src/public-api.ts
+++ b/packages/server-contract/src/public-api.ts
@@ -177,6 +177,8 @@ import type {
   SystemProviderInfo,
   SystemProvidersQuery,
   SystemProviderStatesResponse,
+  SystemAiServices,
+  SystemTranscriptionSettingsUpdate,
   SystemUsageLimitsQuery,
   SystemVersionQuery,
   SystemVersionResponse,
@@ -338,6 +340,7 @@ import {
   threadTimelineQuerySchema,
   systemCliSkillsStatusQuerySchema,
   systemInstallCliSkillsRequestSchema,
+  systemTranscriptionSettingsUpdateSchema,
   timelineTurnSummaryDetailsQuerySchema,
   listEnvironmentsQuerySchema,
   updateEnvironmentRequestSchema,
@@ -1594,6 +1597,14 @@ export const publicApiRoutes = {
       method: "post",
       request: noRequest(),
       response: jsonResponse<SystemConfigReloadResponse>(),
+    }),
+    transcriptionSettings: defineRoute({
+      path: "/settings/transcription",
+      method: "put",
+      request: jsonRequest<EmptyInput, SystemTranscriptionSettingsUpdate>(
+        systemTranscriptionSettingsUpdateSchema,
+      ),
+      response: jsonResponse<SystemAiServices>(),
     }),
     cliSkillsStatus: defineRoute({
       path: "/system/cli-skills",

--- a/packages/templates/src/templates/bb-guide-customization.md
+++ b/packages/templates/src/templates/bb-guide-customization.md
@@ -48,7 +48,9 @@ but the CLI identifies server and launcher settings that are startup-only,
 including binding/ports, data and the dev-app port, telemetry, inherited skill
 roots, and `BB_FF_*` flags. `BB_LOG_LEVEL` is also startup-only. Use
 `bb-app config`, not `bb-app env`, to change `BB_APP_URL`, `BB_INFERENCE`,
-`BB_INFERENCE_FALLBACK`, or `BB_TRANSCRIPTION` live. After a startup-only
+`BB_INFERENCE_FALLBACK`, `BB_TRANSCRIPTION`, `BB_TRANSCRIPTION_MAX_BYTES`,
+`BB_TRANSCRIPTION_TIMEOUT_MAX_MS`, or `BB_TRANSCRIPTION_RECORDING_BITRATE`
+live. After a startup-only
 change, run `bb-app stop && bb-app start` or restart the desktop app. Until
 then, changing or unsetting `BB_SERVER_BIND_HOST` does not close a previous
 `0.0.0.0` listener.
@@ -207,8 +209,33 @@ Host files and voice transcription
   bb voice transcribe <audio-file> [--prompt <context>]
 
 Voice transcription uses the `BB_TRANSCRIPTION` model, which defaults to
-`codex/gpt-transcribe`. Override it with
-`bb-app config set BB_TRANSCRIPTION <provider/model>`.
+`codex/gpt-transcribe`. Edit it in Settings → Voice Input, or from the CLI with
+`bb settings transcription model <provider/model>` (also `max-bytes`,
+`timeout-ms`, and `recording-bitrate` keys); both persist to BB-managed config
+and apply live. `bb-app config set BB_TRANSCRIPTION <provider/model>` remains
+for startup/env-file use. When the model names a
+plugin-registered AI service, the server rejects audio larger than the smaller
+of `BB_TRANSCRIPTION_MAX_BYTES` (default `5242880`, i.e. 5MB) and any per-service
+cap the plugin declares, before the host call. Raise the ceiling up to the 25MB
+overall voice cap with `bb-app config set BB_TRANSCRIPTION_MAX_BYTES <bytes>`
+for longer dictations; `bb settings ai-services` shows the ceiling and each
+voice service's effective limit (bundled Codex caps itself at 5MB).
+
+Each transcription attempt's timeout scales with recording size (roughly 15s
+per MB with a 10s floor) and clamps to `BB_TRANSCRIPTION_TIMEOUT_MAX_MS` (default
+`300000`, i.e. 5 min). Raise it with
+`bb-app config set BB_TRANSCRIPTION_TIMEOUT_MAX_MS <ms>` (up to 15 min) when a
+slow local speech-to-text backend times out on long audio; set it to the 10000
+floor to disable scaling. It applies to both plugin-served and `openai/*`
+transcription.
+
+For services that accept large audio (effective cap above 5MB), the browser
+records at `BB_TRANSCRIPTION_RECORDING_BITRATE` (default `32000` bps) so a
+10-minute dictation stays small enough to clear every layer: the 25MB file cap,
+`min(ceiling, service cap)`, then base64 (+33%) under the 16MB host-RPC payload
+cap (~11MB raw physical max). Codex and `openai/*` keep the browser default. A
+failed transcription keeps the recording and offers Retry, so a transient
+failure does not force re-dictation.
 
 `bb file` supports `--host` for remote machines and `--root` on mutating
 commands to confine access beneath an absolute directory. Use `--json` for

--- a/plugins/bb-guide/skills/bb-cli/references/command-index.md
+++ b/plugins/bb-guide/skills/bb-cli/references/command-index.md
@@ -11,6 +11,7 @@ This index lists every command path that the core CLI registers. Read the task-s
 - `bb settings`
 - `bb settings show`
 - `bb settings ai-services`
+- `bb settings transcription`
 - `bb settings general`
 - `bb settings experiment`
 - `bb settings keyboard`

--- a/plugins/bb-guide/skills/bb-cli/references/configuration.md
+++ b/plugins/bb-guide/skills/bb-cli/references/configuration.md
@@ -27,6 +27,12 @@
 - Use `bb settings show` and `bb settings ai-services` for current values.
 - Use `bb settings general <key> <value>` or
   `bb settings experiment <key> <value>` for updates.
+- Use `bb settings transcription <key> <value>` to change voice transcription
+  settings (also editable in Settings → Voice Input). Keys: `model`
+  (`<service>/<model>`), `max-bytes`, `timeout-ms`, `recording-bitrate`. Values
+  are validated server-side and persist to BB-managed config. This is the
+  live-update path; `bb-app config set BB_TRANSCRIPTION*` remains for
+  startup/env-file use.
 - Use `bb settings keyboard list`, `set`, and `reset` for shortcut overrides.
 - Use `bb settings usage [--machine <id-or-name>]` for provider limits.
   `--host` is an alias for `--machine`.

--- a/plugins/bb-guide/skills/bb-plugin-authoring/references/backend-cli-agents.md
+++ b/plugins/bb-guide/skills/bb-plugin-authoring/references/backend-cli-agents.md
@@ -228,7 +228,15 @@ time.
 
 Inference input includes `serviceId`, `model`, `reasoningEffort: "none"`,
 `prompt`, `outputSchema`, and `timeoutMs`. Plugin-served voice input has a
-5 MiB limit. The server rejects a larger file before a host call. Voice input
+size limit: the user's `BB_TRANSCRIPTION_MAX_BYTES` ceiling (default 5 MiB, up
+to the 25 MiB overall voice cap) and, optionally, a per-service
+`experimental_maxVoiceBytes` on the `register` declaration. The server enforces
+the smaller of the two and rejects a larger file before a host call, so a voice
+service that returns empty or degraded transcripts on long audio should declare
+`experimental_maxVoiceBytes` rather than rely on the global ceiling. Voice input
 includes `serviceId`, `model`, `audioBase64`, `mimeType`, `filename`, `prompt`,
-and `timeoutMs`. The inference success value must be a JSON object. Voice
-`prompt` can be `null`.
+and `timeoutMs`. The voice `timeoutMs` is not fixed: it scales with the audio
+size (roughly 15s per MB with a 10s floor, clamped to `BB_TRANSCRIPTION_TIMEOUT_MAX_MS`,
+default 5 min), so a slow host backend receives a proportionate budget on long
+recordings; a timed-out attempt is retried once and stays retryable. The
+inference success value must be a JSON object. Voice `prompt` can be `null`.

--- a/plugins/provider-codex/server.ts
+++ b/plugins/provider-codex/server.ts
@@ -7,6 +7,7 @@ export default function plugin(bb: BbPluginApi) {
     id: "codex",
     displayName: "Codex (ChatGPT account or API key)",
     kinds: ["inference", "voice"],
+    experimental_maxVoiceBytes: 5 * 1024 * 1024,
   });
 
   bb.settings.define({

--- a/tests/integration/helpers/harness.ts
+++ b/tests/integration/helpers/harness.ts
@@ -231,9 +231,12 @@ async function startIntegrationServer(
     marketplaceUrl: "https://marketplace.invalid/marketplace.json",
     openAiApiKey: process.env.OPENAI_API_KEY ?? "test-openai-key",
     appUrl: "https://bb.example.test",
+    pluginTranscriptionMaxBytes: 5 * 1024 * 1024,
     serverPort: 0,
     sharedSkillRoots: { user: [], project: [] },
     transcriptionModel: "test/mock-transcription",
+    voiceTranscriptionRecordingBitrate: 32_000,
+    voiceTranscriptionTimeoutMaxMs: 300_000,
     isDevelopment: false,
   };
   const terminalSessions = new TerminalSessionLifecycle({


### PR DESCRIPTION
End-to-end configurable voice transcription, built and tested against the local on-device STT engine at https://github.com/bhushit/bb-plugin-local-stt (proposed to move in-tree as a first-party `plugins/` built-in during review).

## Core (commit 1)
- 10MB overall audio cap derived from transport reality (16MB host-RPC payloads minus base64 inflation), documented at the constant; same 10MB in the SDK host-policy ceiling.
- Per-service `experimental_maxVoiceBytes` with `min()` enforcement; scaled per-attempt timeouts; pinned recorder bitrate for large-audio services via a shared `isLargeAudioService()` policy.
- Strict decimal-integer parsing in config parsers, CLI, and Settings inputs.
- `PUT /api/v1/settings/transcription` + `bb settings transcription`; config writer throws `invalid_config` on non-object content; OpenAI error payloads logged with status + snippet.
- Host-RPC payload cap 8MB to 16MB with justification comment + audit-doc update.

## Settings UI (commit 2)
- Provider options derived from registered voice services (no hardcoded universe, no silent no-ops, third providers carry their model id).
- Local models card: divider rows, Hugging Face model-card links, selected-model checkmark, failed-download errors with retry, missing-plugin fallback naming the plugin.

## Verification
- Full repo typecheck 94/94 green; targeted suites green (152 app/server/config tests); plugin 22/22 green + tsc clean.
- Three internal review rounds (strict brief: no silent fallbacks, no unjustified assumptions, native conventions); core judged PR-ready, plugin down to addressed mediums/lows.
- Tested live against the published plugin: local transcription works end to end.

## Test companion
Install https://github.com/bhushit/bb-plugin-local-stt, download a Parakeet model from Settings Voice Input, and transcribe. Without the plugin, Local explains itself (missing-plugin fallback) instead of failing silently.