### PR TITLE
Add aur package

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ with `npx` instead. On Windows, run bb inside
 install WSL2 first, then run the same `npx` command below from your WSL2 (Linux)
 shell. Native Windows PowerShell and CMD are not supported.
 
+### Arch Linux (AUR)
+
+Arch Linux users can install the community-maintained
+[`bb-bin`](https://aur.archlinux.org/packages/bb-bin) package from the AUR with
+their preferred AUR helper:
+
+```bash
+yay -S bb-bin
+```
+
 Early adopters can install
 **[bb Nightly](https://github.com/get-bb/bb/releases/tag/desktop-nightly)**
 alongside the stable desktop app. It has a separate application identity,

--- a/packaging/aur/bb-bin/.SRCINFO
+++ b/packaging/aur/bb-bin/.SRCINFO
@@ -1,0 +1,20 @@
+pkgbase = bb-bin
+	pkgdesc = Agentic IDE that builds itself
+	pkgver = 0.42.1
+	pkgrel = 2
+	url = https://github.com/get-bb/bb
+	arch = x86_64
+	license = MIT
+	provides = bb
+	conflicts = bb
+	noextract = bb-bin-0.42.1.AppImage
+	options = !strip
+	options = !debug
+	source = bb-bin-0.42.1.AppImage::https://github.com/get-bb/bb/releases/download/desktop-v0.42.1/bb-0.42.1-x86_64.AppImage
+	source = bb-launcher.sh
+	source = LICENSE
+	sha256sums = b29165f5cd2f06feeba51c36ca86b96006bfc6c48521903367c004ae63c86976
+	sha256sums = 67d10f7a6daac6bfbd947bbc2af59bcc42589d5e37637a504ffce9c89074d173
+	sha256sums = d10816aa30183af920bdd789a81b16847bcf3e287e1b3419dd7d85f6e3e8e7b0
+
+pkgname = bb-bin

--- a/packaging/aur/bb-bin/LICENSE
+++ b/packaging/aur/bb-bin/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Michael Yong
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packaging/aur/bb-bin/PKGBUILD
+++ b/packaging/aur/bb-bin/PKGBUILD
@@ -1,0 +1,39 @@
+# Maintainer: James LeBaron <jimmleb178@gmail.com>
+
+pkgname=bb-bin
+pkgver=0.42.1
+pkgrel=2
+pkgdesc="Agentic IDE that builds itself"
+arch=('x86_64')
+url='https://github.com/get-bb/bb'
+license=('MIT')
+provides=('bb')
+conflicts=('bb')
+options=(!strip !debug)
+source=(
+  "$pkgname-$pkgver.AppImage::https://github.com/get-bb/bb/releases/download/desktop-v$pkgver/bb-$pkgver-x86_64.AppImage"
+  'bb-launcher.sh'
+  'LICENSE'
+)
+noextract=("$pkgname-$pkgver.AppImage")
+sha256sums=('b29165f5cd2f06feeba51c36ca86b96006bfc6c48521903367c004ae63c86976'
+            '67d10f7a6daac6bfbd947bbc2af59bcc42589d5e37637a504ffce9c89074d173'
+            'd10816aa30183af920bdd789a81b16847bcf3e287e1b3419dd7d85f6e3e8e7b0')
+
+prepare() {
+  chmod +x "$srcdir/$pkgname-$pkgver.AppImage"
+  "$srcdir/$pkgname-$pkgver.AppImage" --appimage-extract
+}
+
+package() {
+  install -dm755 "$pkgdir/opt/bb"
+  cp -a --no-preserve=ownership "$srcdir/squashfs-root/." "$pkgdir/opt/bb/"
+  install -Dm755 "$srcdir/bb-launcher.sh" "$pkgdir/usr/bin/bb"
+
+  install -Dm644 "$srcdir/squashfs-root/bb.desktop" \
+    "$pkgdir/usr/share/applications/bb.desktop"
+  sed -i 's|^Exec=AppRun|Exec=bb|' "$pkgdir/usr/share/applications/bb.desktop"
+  install -Dm644 "$srcdir/squashfs-root/usr/share/icons/hicolor/1024x1024/apps/bb.png" \
+    "$pkgdir/usr/share/icons/hicolor/1024x1024/apps/bb.png"
+  install -Dm644 "$srcdir/LICENSE" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}

--- a/packaging/aur/bb-bin/bb-launcher.sh
+++ b/packaging/aur/bb-bin/bb-launcher.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+prefix=/opt/bb
+unset APPIMAGE APPDIR
+export PATH="$prefix:$prefix/usr/sbin${PATH:+:$PATH}"
+export LD_LIBRARY_PATH="$prefix/usr/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+export GSETTINGS_SCHEMA_DIR="$prefix/usr/share/glib-2.0/schemas${GSETTINGS_SCHEMA_DIR:+:$GSETTINGS_SCHEMA_DIR}"
+if [ -n "${XDG_DATA_DIRS:-}" ]; then
+  export XDG_DATA_DIRS="$prefix/usr/share:$XDG_DATA_DIRS"
+else
+  export XDG_DATA_DIRS="$prefix/usr/share:/usr/local/share:/usr/share"
+fi
+exec "$prefix/bb" "$@"


### PR DESCRIPTION
## Human comments

link to the AUR package here https://aur.archlinux.org/packages/bb-bin

  ## What was wrong

  Arch Linux users had no documented AUR installation path for bb. Installing the upstream Linux AppImage directly also requires FUSE on some systems.

  ## What changed

  - Added a release-pinned `bb-bin` AUR recipe under `packaging/aur/bb-bin/`.
  - The recipe extracts the upstream x86_64 AppImage into `/opt/bb`, installs a normal `bb` launcher, desktop entry, icon, and MIT license.
  - The launcher runs the extracted application directly, avoiding a runtime `fuse2` dependency.
  - Added a README section linking to the community-maintained `bb-bin` AUR package and showing installation with an AUR helper.

  ## How you verified

  - Ran `makepkg --cleanbuild --force` successfully.
  - Confirmed the generated `.SRCINFO` matches the PKGBUILD.
  - Installed the built package locally and launched `bb` successfully.
  - Verified the desktop entry, icon, executable, and installed license are present in the package archive.