### PR TITLE
Bound filesystem watcher crash retries and verify packaged watcher

### DIFF
--- a/apps/desktop/scripts/prepare-native-modules.cjs
+++ b/apps/desktop/scripts/prepare-native-modules.cjs
@@ -2,6 +2,7 @@ const { spawn } = require("node:child_process");
 const { chmod, readFile, readdir, writeFile } = require("node:fs/promises");
 const { createRequire } = require("node:module");
 const path = require("node:path");
+const { verifyPackagedWatcher } = require("./verify-packaged-watcher.cjs");
 
 const desktopPackageRoot = path.resolve(__dirname, "..");
 
@@ -270,6 +271,29 @@ async function afterPack(context) {
     arch: resolveArchName(context),
     electronVersion: resolveElectronVersion(),
     platform: context.electronPlatformName ?? process.platform,
+  });
+  const productFilename = context.packager.appInfo.productFilename;
+  const executablePath =
+    context.electronPlatformName === "darwin"
+      ? path.join(
+          context.appOutDir,
+          `${productFilename}.app`,
+          "Contents",
+          "MacOS",
+          productFilename,
+        )
+      : path.join(context.appOutDir, context.packager.executableName);
+  await verifyPackagedWatcher({
+    executablePath,
+    childEntry: path.join(
+      context.packager.getResourcesDir(context.appOutDir),
+      "app.asar.unpacked",
+      "node_modules",
+      "bb-app",
+      "host-daemon",
+      "dist",
+      "bb-parcel-watcher-child.mjs",
+    ),
   });
 }
 

--- a/apps/desktop/scripts/verify-packaged-watcher.cjs
+++ b/apps/desktop/scripts/verify-packaged-watcher.cjs
@@ -1,0 +1,132 @@
+const { fork } = require("node:child_process");
+const { mkdtemp, realpath, rm, writeFile } = require("node:fs/promises");
+const { tmpdir } = require("node:os");
+const path = require("node:path");
+const { finished } = require("node:stream/promises");
+
+async function verifyPackagedWatcher({
+  executablePath,
+  childEntry,
+  timeoutMs = 15_000,
+}) {
+  const scratch = await mkdtemp(path.join(tmpdir(), "bb-packaged-watcher-"));
+  try {
+    const root = await realpath(scratch);
+    const marker = path.join(root, "watcher-probe.txt");
+    await new Promise((resolve, reject) => {
+      let stderr = "";
+      let failure = null;
+      let ready = false;
+      let subscribed = false;
+      let observed = false;
+      let unsubscribed = false;
+      const child = fork(childEntry, [], {
+        execPath: executablePath,
+        execArgv: [],
+        cwd: root,
+        env: { PATH: process.env.PATH, ELECTRON_RUN_AS_NODE: "1" },
+        stdio: ["ignore", "ignore", "pipe", "ipc"],
+      });
+      function fail(error) {
+        failure ??= error;
+        child.kill("SIGKILL");
+      }
+      function send(message) {
+        child.send(message, (error) => {
+          if (error) fail(error);
+        });
+      }
+      const timer = setTimeout(() => {
+        fail(
+          new Error(
+            `Watcher probe timed out after ${timeoutMs}ms (ready=${ready}, subscribed=${subscribed}, observed=${observed}, unsubscribed=${unsubscribed})`,
+          ),
+        );
+      }, timeoutMs);
+      child.stderr.on("data", (chunk) => {
+        stderr = (stderr + chunk.toString()).slice(-16_384);
+      });
+      child.on("error", (error) => {
+        fail(error);
+        if (child.pid === undefined) complete(null, null);
+      });
+      child.on("message", (message) => {
+        if (failure !== null || message === null || typeof message !== "object")
+          return;
+        if (message.kind === "ready" && !ready) {
+          ready = true;
+          send({
+            kind: "subscribe",
+            id: "packaging-probe",
+            dir: root,
+            rescan: false,
+          });
+        } else if (
+          message.kind === "subscribed" &&
+          message.id === "packaging-probe" &&
+          !subscribed
+        ) {
+          subscribed = true;
+          writeFile(marker, "packaged native watcher works\n").catch(fail);
+        } else if (
+          message.kind === "events" &&
+          message.id === "packaging-probe" &&
+          subscribed &&
+          !observed &&
+          Array.isArray(message.events)
+        ) {
+          observed = message.events.some(
+            (event) =>
+              event !== null &&
+              typeof event === "object" &&
+              event.path === marker &&
+              (event.type === "create" || event.type === "update"),
+          );
+          if (observed) send({ kind: "unsubscribe", id: "packaging-probe" });
+        } else if (
+          message.kind === "unsubscribed" &&
+          message.id === "packaging-probe" &&
+          observed
+        ) {
+          unsubscribed = true;
+          child.disconnect();
+        } else if (
+          message.kind === "subscribe-failed" ||
+          message.kind === "watch-error"
+        ) {
+          fail(
+            new Error(
+              `Watcher probe ${message.kind}: ${String(message.message)}`,
+            ),
+          );
+        }
+      });
+      async function complete(code, signal) {
+        clearTimeout(timer);
+        await finished(child.stderr).catch(() => {});
+        if (
+          failure === null &&
+          code === 0 &&
+          ready &&
+          subscribed &&
+          observed &&
+          unsubscribed
+        ) {
+          resolve();
+          return;
+        }
+        reject(
+          new Error(
+            `Packaged filesystem watcher verification failed: ${failure?.message ?? `child exited (${signal ?? code}) before completing the probe`}. ` +
+              `Verify the target @parcel/watcher native package is shipped and loads under ${executablePath}.\n${stderr}`,
+          ),
+        );
+      }
+      child.on("exit", complete);
+    });
+  } finally {
+    await rm(scratch, { recursive: true, force: true });
+  }
+}
+
+module.exports = { verifyPackagedWatcher };

--- a/apps/desktop/test/verify-packaged-watcher.test.ts
+++ b/apps/desktop/test/verify-packaged-watcher.test.ts
@@ -1,0 +1,147 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const require = createRequire(join(process.cwd(), "package.json"));
+const {
+  verifyPackagedWatcher,
+}: {
+  verifyPackagedWatcher(options: {
+    executablePath: string;
+    childEntry: string;
+    timeoutMs?: number;
+  }): Promise<void>;
+} = require("./scripts/verify-packaged-watcher.cjs");
+
+async function fixture(
+  source: string,
+  run: (childEntry: string) => Promise<void>,
+) {
+  const root = await mkdtemp(join(tmpdir(), "bb-watcher-probe-test-"));
+  try {
+    const childEntry = join(root, "child.cjs");
+    await writeFile(childEntry, source);
+    await run(childEntry);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+describe("packaged watcher verification", () => {
+  it("rejects a missing packaged executable", async () => {
+    await fixture("", async (childEntry) => {
+      await expect(
+        verifyPackagedWatcher({
+          executablePath: childEntry + ".missing",
+          childEntry,
+        }),
+      ).rejects.toThrow("ENOENT");
+    });
+  });
+
+  it("rejects a clean exit that never delivered a file event", async () => {
+    await fixture(
+      `
+      process.send({ kind: 'ready' });
+      process.on('message', message => {
+        process.send({ kind: 'subscribed', id: message.id }, () => process.exit(0));
+      });
+    `,
+      async (childEntry) => {
+        await expect(
+          verifyPackagedWatcher({
+            executablePath: process.execPath,
+            childEntry,
+          }),
+        ).rejects.toThrow("before completing the probe");
+      },
+    );
+  });
+
+  it("rejects a native import failure with its stderr diagnostic", async () => {
+    await fixture(
+      'throw new Error("No prebuild or local build of @parcel/watcher found");',
+      async (childEntry) => {
+        await expect(
+          verifyPackagedWatcher({
+            executablePath: process.execPath,
+            childEntry,
+          }),
+        ).rejects.toThrow(
+          "No prebuild or local build of @parcel/watcher found",
+        );
+      },
+    );
+  });
+
+  it("rejects subscription failure after a successful import", async () => {
+    await fixture(
+      `
+      process.send({ kind: 'ready' });
+      process.on('message', message => {
+        process.send({ kind: 'subscribe-failed', id: message.id, message: 'native backend unavailable' });
+      });
+    `,
+      async (childEntry) => {
+        await expect(
+          verifyPackagedWatcher({
+            executablePath: process.execPath,
+            childEntry,
+          }),
+        ).rejects.toThrow("native backend unavailable");
+      },
+    );
+  });
+
+  it("kills a child that reports ready but never confirms its subscription", async () => {
+    await fixture(
+      `process.send({ kind: 'ready' }); setInterval(() => {}, 1000);`,
+      async (childEntry) => {
+        await expect(
+          verifyPackagedWatcher({
+            executablePath: process.execPath,
+            childEntry,
+            timeoutMs: 500,
+          }),
+        ).rejects.toThrow("subscribed=false");
+      },
+    );
+  });
+
+  it("requires an actual file event after subscription and removes its temporary root", async () => {
+    await fixture(
+      `
+      const fs = require('node:fs');
+      const path = require('node:path');
+      let watcher;
+      process.send({ kind: 'ready' });
+      process.on('message', message => {
+        if (message.kind === 'subscribe') {
+          fs.writeFileSync(__filename + '.root', message.dir);
+          watcher = fs.watch(message.dir, (event, file) => {
+            if (file !== 'watcher-probe.txt') return;
+            process.send({ kind: 'events', id: message.id, events: [{ path: path.join(message.dir, file), type: 'create' }] });
+          });
+          process.send({ kind: 'subscribed', id: message.id });
+        } else if (message.kind === 'unsubscribe') {
+          watcher.close();
+          process.send({ kind: 'unsubscribed', id: message.id });
+        }
+      });
+      process.on('disconnect', () => process.exit(0));
+    `,
+      async (childEntry) => {
+        await verifyPackagedWatcher({
+          executablePath: process.execPath,
+          childEntry,
+        });
+        const root = await readFile(childEntry + ".root", "utf8");
+        await expect(
+          readFile(join(root, "watcher-probe.txt")),
+        ).rejects.toMatchObject({ code: "ENOENT" });
+      },
+    );
+  });
+});

--- a/docs/debugging-and-qa.md
+++ b/docs/debugging-and-qa.md
@@ -10,6 +10,27 @@
 - Use `curl` against the server API to isolate frontend issues from server behavior.
 - Use the CLI to inspect state: `pnpm bb thread show <id>`, `pnpm bb project list`, `pnpm bb status`. From source, use `pnpm bb:dev`.
 
+## Filesystem Watcher Startup Failures
+
+The daemon runs the native filesystem watcher in a child process. A child has
+15 seconds to report ready. Exits, startup timeouts, spawn failures, and
+unresponsive children share a budget of five automatic restarts; a successful
+heartbeat resets the budget. After six consecutive failures, the daemon stops
+spawning watchers and reports an actionable error to existing and new watch
+subscribers. Live file updates remain disabled for that daemon process. Inspect
+`host-daemon-stdio.log` for the child's original error, update or repair the BB
+installation, then restart that host daemon (or relaunch BB for its local host).
+Adding another watched path does not bypass the failure budget.
+
+Desktop `afterPack` checks the actual packaged watcher child using the packaged
+Electron executable with `ELECTRON_RUN_AS_NODE=1`. The check requires readiness,
+a successful subscription, a real file event, unsubscribe acknowledgement, and
+clean exit in a fresh temporary directory. It launches no BB server or daemon
+and reads no BB store. Packaging therefore requires a host that can execute the
+target binary and use its native filesystem watcher; missing bindings, native
+load failures, and unavailable backends fail the build. A sandbox that denies
+FSEvents cannot verify macOS packaging.
+
 ## Local Dev QA Launcher
 
 Use `scripts/bb-dev-app` when validating changes in the desktop dev app or helping QA from this checkout:

--- a/packages/host-watcher/src/parcel-subprocess/parcel-watcher-proxy.ts
+++ b/packages/host-watcher/src/parcel-subprocess/parcel-watcher-proxy.ts
@@ -54,6 +54,8 @@ const DEFAULT_PING_INTERVAL_MS = 5_000;
 const DEFAULT_PING_TIMEOUT_MS = 15_000;
 const DEFAULT_BASE_RESTART_DELAY_MS = 250;
 const DEFAULT_MAX_RESTART_DELAY_MS = 30_000;
+const STARTUP_TIMEOUT_MS = 15_000;
+const MAX_CONSECUTIVE_RESTARTS = 5;
 
 function toEventBatch(
   events: SerializedParcelEvent[],
@@ -76,7 +78,9 @@ export function createParcelWatcherProxy(
   let channel: ChildChannel | null = null;
   let childReady = false;
   let disposed = false;
+  let terminalError: Error | null = null;
   let consecutiveRestarts = 0;
+  let startupTimer: ReturnType<typeof setTimeout> | null = null;
   let respawnTimer: ReturnType<typeof setTimeout> | null = null;
   let restarting = false;
   let idCounter = 0;
@@ -94,6 +98,38 @@ export function createParcelWatcherProxy(
     if (pingTimer !== null) {
       clearInterval(pingTimer);
       pingTimer = null;
+    }
+  }
+
+  function stopStartupTimer(): void {
+    if (startupTimer !== null) {
+      clearTimeout(startupTimer);
+      startupTimer = null;
+    }
+  }
+
+  function failSubscriptions(): void {
+    terminalError = new Error(
+      `Filesystem watcher unavailable after ${MAX_CONSECUTIVE_RESTARTS + 1} consecutive child failures. ` +
+        "Live file updates are disabled. Update or repair BB, then restart the BB host daemon to retry.",
+    );
+    log("error", terminalError.message, {
+      activeSubscriptions: subscriptions.size,
+    });
+    const failed = [...subscriptions.values()];
+    subscriptions.clear();
+    for (const record of failed) {
+      try {
+        record.callback(terminalError, []);
+      } catch (error) {
+        log(
+          "warn",
+          "Watcher subscriber failed while reporting unavailability",
+          {
+            watchError: error instanceof Error ? error.message : String(error),
+          },
+        );
+      }
     }
   }
 
@@ -145,18 +181,41 @@ export function createParcelWatcherProxy(
   }
 
   function startChild(): void {
-    if (disposed) {
+    if (disposed || terminalError !== null) {
       return;
     }
     childReady = false;
-    const spawned = options.spawnChannel();
+    let spawned: ChildChannel;
+    try {
+      spawned = options.spawnChannel();
+    } catch (error) {
+      log("warn", "Watcher child could not start", {
+        watchError: error instanceof Error ? error.message : String(error),
+      });
+      scheduleRespawn();
+      return;
+    }
     channel = spawned;
+    startupTimer = setTimeout(() => {
+      log("warn", "Watcher child did not become ready; killing");
+      killAndRespawn();
+    }, STARTUP_TIMEOUT_MS);
+    startupTimer.unref?.();
     spawned.onMessage((message) => handleChildMessage(spawned, message));
     spawned.onExit(() => handleChildExit(spawned));
   }
 
   function scheduleRespawn(): void {
-    if (disposed || channel !== null || respawnTimer !== null) {
+    if (
+      disposed ||
+      terminalError !== null ||
+      channel !== null ||
+      respawnTimer !== null
+    ) {
+      return;
+    }
+    if (consecutiveRestarts >= MAX_CONSECUTIVE_RESTARTS) {
+      failSubscriptions();
       return;
     }
     restarting = true;
@@ -188,6 +247,7 @@ export function createParcelWatcherProxy(
     const dying = channel;
     channel = null;
     childReady = false;
+    stopStartupTimer();
     stopPing();
     dying.kill();
     scheduleRespawn();
@@ -199,11 +259,12 @@ export function createParcelWatcherProxy(
     }
     channel = null;
     childReady = false;
+    stopStartupTimer();
     stopPing();
     if (disposed) {
       return;
     }
-    log("warn", "Watcher child exited; respawning", {
+    log("warn", "Watcher child exited", {
       activeSubscriptions: subscriptions.size,
     });
     scheduleRespawn();
@@ -218,8 +279,12 @@ export function createParcelWatcherProxy(
     }
     switch (message.kind) {
       case "ready":
+        stopStartupTimer();
         childReady = true;
         replaySubscriptions(restarting);
+        if (source !== channel) {
+          return;
+        }
         restarting = false;
         startPing();
         break;
@@ -268,6 +333,10 @@ export function createParcelWatcherProxy(
     if (disposed) {
       return Promise.reject(new Error("Parcel watcher proxy is disposed"));
     }
+    if (terminalError !== null) {
+      callback(terminalError, []);
+      return Promise.resolve({ async unsubscribe() {} });
+    }
     const id = nextId();
     subscriptions.set(id, { id, dir, opts, callback });
     if (channel !== null && childReady) {
@@ -285,6 +354,7 @@ export function createParcelWatcherProxy(
 
   function dispose(): void {
     disposed = true;
+    stopStartupTimer();
     stopPing();
     if (respawnTimer !== null) {
       clearTimeout(respawnTimer);

--- a/packages/host-watcher/test/parcel-watcher-proxy.test.ts
+++ b/packages/host-watcher/test/parcel-watcher-proxy.test.ts
@@ -473,7 +473,7 @@ describe("createParcelWatcherProxy", () => {
     }
   });
 
-  it("backs off a rapid respawn but never permanently gives up", async () => {
+  it("backs off rapid respawns while the retry budget remains", async () => {
     vi.useFakeTimers();
     try {
       const { proxy, children, current } = createHarness({

--- a/packages/host-watcher/test/parcel-watcher-startup.test.ts
+++ b/packages/host-watcher/test/parcel-watcher-startup.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ChildToParentMessage } from "../src/parcel-subprocess/messages.js";
+import {
+  createParcelWatcherProxy,
+  type ChildChannel,
+} from "../src/parcel-subprocess/parcel-watcher-proxy.js";
+
+function harness() {
+  const children: {
+    exit: () => void;
+    message: (message: ChildToParentMessage) => void;
+    send: ReturnType<typeof vi.fn>;
+    kill: ReturnType<typeof vi.fn>;
+  }[] = [];
+  const log = vi.fn();
+  const proxy = createParcelWatcherProxy({
+    spawnChannel() {
+      const child = {
+        exit: () => {},
+        message: (_message: ChildToParentMessage) => {},
+        send: vi.fn(),
+        kill: vi.fn(),
+      };
+      children.push(child);
+      const channel: ChildChannel = {
+        send: child.send,
+        kill: child.kill,
+        onMessage(listener) {
+          child.message = listener;
+        },
+        onExit(listener) {
+          child.exit = listener;
+        },
+      };
+      return channel;
+    },
+    log,
+  });
+  return { proxy, children, log };
+}
+
+afterEach(() => vi.useRealTimers());
+
+describe("watcher child failure budget", () => {
+  it("stops pre-ready crash loops, reports all subscribers once, and rejects retry bypasses", async () => {
+    vi.useFakeTimers();
+    const { proxy, children, log } = harness();
+    const callback = vi.fn();
+    const removed = vi.fn();
+    try {
+      await proxy.subscribe("/first", callback);
+      await proxy.subscribe("/second", callback);
+      await (await proxy.subscribe("/removed", removed)).unsubscribe();
+      for (let failure = 0; failure < 6; failure += 1) {
+        children.at(-1)!.exit();
+        await vi.advanceTimersByTimeAsync(2_000);
+      }
+      expect(children).toHaveLength(6);
+      expect(callback).toHaveBeenCalledTimes(2);
+      expect(callback.mock.calls[0]?.[0].message).toContain(
+        "restart the BB host daemon",
+      );
+      expect(removed).not.toHaveBeenCalled();
+      expect(
+        children
+          .flatMap((child) => child.send.mock.calls)
+          .filter(([message]) => message.kind === "subscribe"),
+      ).toEqual([]);
+      expect(
+        log.mock.calls.filter(([level]) => level === "error"),
+      ).toHaveLength(1);
+      const late = vi.fn();
+      await proxy.subscribe("/late", late);
+      expect(late).toHaveBeenCalledOnce();
+      await vi.advanceTimersByTimeAsync(3_600_000);
+      expect(children).toHaveLength(6);
+      expect(callback).toHaveBeenCalledTimes(2);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      proxy.dispose();
+    }
+  });
+
+  it("times out children that never become ready and stops after the same budget", async () => {
+    vi.useFakeTimers();
+    const { proxy, children } = harness();
+    const callback = vi.fn();
+    try {
+      await proxy.subscribe("/root", callback);
+      await vi.advanceTimersByTimeAsync(180_000);
+      expect(children).toHaveLength(6);
+      expect(
+        children.every((child) => child.kill.mock.calls.length === 1),
+      ).toBe(true);
+      expect(callback).toHaveBeenCalledOnce();
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      proxy.dispose();
+    }
+  });
+
+  it("recovers before exhaustion, resets after a pong, and ignores stale exits", async () => {
+    vi.useFakeTimers();
+    const { proxy, children } = harness();
+    const callback = vi.fn();
+    try {
+      await proxy.subscribe("/root", callback);
+      for (let failure = 0; failure < 5; failure += 1) {
+        children.at(-1)!.exit();
+        await vi.advanceTimersByTimeAsync(2_000);
+      }
+      const healthy = children.at(-1)!;
+      healthy.message({ kind: "ready" });
+      expect(healthy.send).toHaveBeenCalledWith(
+        expect.objectContaining({ kind: "subscribe", rescan: true }),
+      );
+      healthy.message({ kind: "pong", nonce: 1 });
+      children[0]!.exit();
+      expect(children).toHaveLength(6);
+      healthy.exit();
+      expect(children).toHaveLength(7);
+      expect(callback).not.toHaveBeenCalled();
+    } finally {
+      proxy.dispose();
+    }
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("bounds synchronous spawn failures without throwing from a retry timer", async () => {
+    vi.useFakeTimers();
+    const spawnChannel = vi.fn(() => {
+      throw new Error("entry missing");
+    });
+    const proxy = createParcelWatcherProxy({ spawnChannel });
+    const callback = vi.fn();
+    try {
+      await proxy.subscribe("/root", callback);
+      await vi.advanceTimersByTimeAsync(180_000);
+      expect(spawnChannel).toHaveBeenCalledTimes(6);
+      expect(callback).toHaveBeenCalledOnce();
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      proxy.dispose();
+    }
+  });
+
+  it("reports other subscribers even if one error callback throws", async () => {
+    vi.useFakeTimers();
+    const { proxy, children } = harness();
+    const callback = vi.fn();
+    try {
+      await proxy.subscribe("/throwing", () => {
+        throw new Error("callback failed");
+      });
+      await proxy.subscribe("/root", callback);
+      for (let failure = 0; failure < 6; failure += 1) {
+        children.at(-1)!.exit();
+        await vi.advanceTimersByTimeAsync(2_000);
+      }
+      expect(callback).toHaveBeenCalledOnce();
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      proxy.dispose();
+    }
+  });
+
+  it("cancels a delayed respawn on disposal", async () => {
+    vi.useFakeTimers();
+    const { proxy, children } = harness();
+    await proxy.subscribe("/root", vi.fn());
+    children[0]!.exit();
+    children[1]!.exit();
+    proxy.dispose();
+    await vi.advanceTimersByTimeAsync(180_000);
+    expect(children).toHaveLength(2);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("cancels startup deadlines on disposal", async () => {
+    vi.useFakeTimers();
+    const { proxy, children } = harness();
+    await proxy.subscribe("/root", vi.fn());
+    proxy.dispose();
+    await vi.advanceTimersByTimeAsync(180_000);
+    expect(children).toHaveLength(1);
+    expect(children[0]!.kill).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/packages/host-watcher/vitest.config.ts
+++ b/packages/host-watcher/vitest.config.ts
@@ -1,10 +1,15 @@
-import { defineWorkspaceTestConfig } from "../../vitest.shared.js";
+import {
+  defineWorkspaceTestConfig,
+  sharedWorkerProjects,
+} from "../../vitest.shared.js";
 
 export default defineWorkspaceTestConfig({
   test: {
     silent: "passed-only",
-    name: "@bb/host-watcher",
-    include: ["test/**/*.test.ts"],
-    exclude: ["dist/**", "node_modules/**"],
+    projects: sharedWorkerProjects({
+      pkgDir: __dirname,
+      name: "@bb/host-watcher",
+      include: ["test/**/*.test.ts"],
+    }),
   },
 });


### PR DESCRIPTION
## Human comments

## What was wrong

A filesystem watcher child that failed before readiness was restarted indefinitely, with no error delivered to its subscribers. The baseline reproduction created 251 children after 250 simulated startup failures, reaching the 30-second delay cap without sending any subscriptions or subscriber errors. A child that never reported ready also had no startup deadline, and synchronous spawn failures were not handled by the recovery loop. See the [earlier reproduction report](https://get-bb.github.io/reports/issues/3362.html).

The official 0.42.1 macOS ZIP and DMG both contain working native watcher packages: their actual packaged children subscribed and delivered file events under bundled Electron. Removing the native package in a disposable fixture reproduces exit-before-ready; restoring it recovers. The reported installed-package omission and the causal connection to UI freezes, ignore discovery failures, and RPC timeouts remain unverified. An import-failing child receives no subscription replay.

Related to #3362.

## What changed

- Limit the proxy to five automatic restarts after the initial attempt. Six failures without a successful heartbeat stop the loop and deliver an actionable terminal error to existing and new subscribers. A new subscription cannot bypass the exhausted budget.
- Give each child 15 seconds to become ready, handle synchronous spawn failures, clean up timers, and preserve subscription replay and heartbeat-based recovery before exhaustion. A throwing subscriber cannot prevent other subscribers from receiving the terminal error.
- Run the shipped watcher child under packaged Electron during `afterPack`, requiring readiness, subscription, a real file event, unsubscribe acknowledgement, and clean exit in a fresh temporary directory. Missing or unusable native dependencies fail packaging.
- Document the recovery behavior and packaging prerequisites; add failure-mode tests and use shared worker partitioning for watcher tests.

**Recovery tradeoff:** after exhaustion, live file updates remain disabled until the BB host daemon restarts. Repairing the installation alone no longer triggers an automatic retry in that process. Packaging must run where the target executable and native watcher can operate; a sandbox denying FSEvents cannot pass the macOS check.

No server/daemon wire contract or public CLI/configuration surface changes; no protocol version bump is needed.

## How you verified

Verified on commit `7b64b8a8a8ae341d4a08570693972066bc3c71d4`, based on upstream main `7ba69eb050c4a800db9255c8fbaaa23ca4bab32d`, using Node 22.23.2 and pnpm 9.15.0:

- `pnpm exec turbo run test typecheck --env-mode=loose --filter=@bb/host-watcher`: 56 tests pass, one opt-in benchmark skipped, typecheck passes. The initial regression suite failed on the baseline for unlimited retries, missing startup deadlines, and synchronous spawn errors.
- `pnpm exec turbo run test --env-mode=loose --filter=@bb/desktop -- --run test/verify-packaged-watcher.test.ts test/electron-builder-config.test.ts`: 28 tests pass.
- `pnpm exec turbo run build typecheck --env-mode=loose --filter=@bb/host-daemon --filter=@bb/desktop`: 15 tasks pass. Desktop typecheck also passes after the final test additions.
- `pnpm exec turbo run test --env-mode=loose --filter=@bb/host-daemon -- --run test/parcel-watcher-not-loaded-in-parent.test.ts`: two tests pass; the native module stays out of the daemon parent.
- Fresh Linux directory packaging with publication disabled passes the actual `afterPack` watcher check.
- macOS: the new packaging probe passes the official ZIP and DMG through both ASAR and unpacked paths and rejects both missing-native fixtures. The patched proxy, using actual missing-native children and default delays, stops after six failures at approximately 4.35 seconds, notifies existing and late subscribers, and emits one terminal error log with zero subscription messages.
- Formatting and diff checks pass. Secret-model scan clean for working tree, HEAD, push range, and public PR text.

All runtime probes used disposable app copies and temporary directories. No production app, daemon, repository, or BB store was used. Full UI responsiveness, macOS signing, and a full macOS `afterPack` build were not verified.

> AGENT GENERATED
