### PR TITLE
Reduce GitHub background polling and batch repository queries

### DIFF
--- a/plugins/github/PLUGIN_OVERVIEW.md
+++ b/plugins/github/PLUGIN_OVERVIEW.md
@@ -9,7 +9,7 @@ See the open issues and pull requests of your repositories inside bb. Hand one t
 
 ## How it works
 
-The plugin tracks every bb project whose checkout has a GitHub `origin` remote. Add more repositories in the Extra repositories setting as a comma-separated `owner/repo` list. Choose a Default project for repositories that are not attached to a project. A background service refreshes the cache every 5 minutes. Press Refresh in the panel to update now.
+The plugin tracks every bb project whose checkout has a GitHub `origin` remote. Add more repositories in the Extra repositories setting as a comma-separated `owner/repo` list. Choose a Default project for repositories that are not attached to a project. A background service refreshes the cache at startup, then waits 15 minutes after each completed sync to reduce background GitHub traffic. Press Refresh in the panel to update now.
 
 ## For agents
 

--- a/plugins/github/README.md
+++ b/plugins/github/README.md
@@ -45,8 +45,24 @@ bb plugin config github set extraRepos "owner/repo, owner/other"
 bb plugin reload github
 ```
 
-A background service refreshes the issue/PR cache every 5 minutes; the
-panel's Refresh button (or `bb github sync`) forces it.
+A background service refreshes immediately on startup, then waits 15 minutes
+after each completed sync. Each tracked repository uses one bounded `gh api graphql`
+request per sweep, using the existing GitHub CLI authentication. It fetches
+100 open and 50 closed issues, plus 50 open and 30 closed or merged PRs,
+ordered by creation time descending. Labels and assignees are each limited to
+100 per item, matching the previous list commands. Repositories with Issues
+disabled still sync PRs. Failed or incomplete repository responses retain that
+repository’s cached rows.
+
+Batching reduces list-fetch process invocations from four to one per repository
+(75%). This does not measure GraphQL rate-limit point savings.
+Background data may take 15 minutes plus sync time to refresh. The panel's
+Refresh button, the `refresh` RPC, or `bb github sync` starts a sync immediately.
+
+Transient authentication failures and failures across all repositories retain
+the existing retry backoff: 30 seconds, doubling to a five-minute cap, reset
+after a successful sync. Partial repository failures use the normal interval.
+The interval is internal policy; there is no polling setting.
 
 ## Development
 

--- a/plugins/github/server.auth-latch.test.ts
+++ b/plugins/github/server.auth-latch.test.ts
@@ -66,9 +66,9 @@ case "$1 $2" in
       esac
     fi
     echo "github.com"; echo "  ✓ Logged in to github.com account someone (keyring)"; exit 0;;
-  "issue list"|"pr list")
+  "api graphql")
     if [ -e "${apiDownFlag}" ]; then echo "error connecting to api.github.com" >&2; exit 1; fi
-    echo "[]"; exit 0;;
+    echo '{"data":{"repository":{"hasIssuesEnabled":true,"openIssues":{"nodes":[]},"closedIssues":{"nodes":[]},"openPrs":{"nodes":[]},"closedPrs":{"nodes":[]}}}}'; exit 0;;
   *) echo "[]"; exit 0;;
 esac
 `,

--- a/plugins/github/server.batching.test.ts
+++ b/plugins/github/server.batching.test.ts
@@ -1,0 +1,221 @@
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { createFakePluginHost } from "@get-bb/plugin-sdk/testing";
+import plugin, { githubRpcContract } from "./server";
+
+const fake = vi.hoisted(() => ({
+  responses: new Map<string, string | Error>(),
+  calls: [] as string[][],
+}));
+vi.mock("node:child_process", () => ({
+  execFile(
+    file: string,
+    args: string[],
+    options: { timeout: number; maxBuffer: number },
+    callback: (error: Error | null, stdout: string, stderr: string) => void,
+  ) {
+    if (file !== "gh") throw new Error(`Unexpected executable ${file}`);
+    fake.calls.push(args);
+    if (args[0] === "--version" || args[0] === "auth")
+      return callback(null, "ok", "");
+    expect(options).toEqual({ timeout: 30_000, maxBuffer: 16 * 1024 * 1024 });
+    const name = args.find((arg) => arg.startsWith("name="))?.slice(5);
+    const response = fake.responses.get(name ?? "");
+    if (response === undefined)
+      return callback(new Error("unexpected command"), "", "");
+    if (response instanceof Error)
+      return callback(response, "", response.message);
+    callback(null, response, "");
+  },
+}));
+
+function node(number: number, state = "OPEN") {
+  return {
+    number,
+    state,
+    title: `Title ${number}`,
+    author: { login: "robot[bot]" },
+    labels: { nodes: [{ name: "bug" }] },
+    assignees: { nodes: [{ login: "alice" }] },
+    body: "Body\ntext",
+    url: `https://github.com/acme/one/issues/${number}`,
+    updatedAt: "2026-09-10T00:00:00Z",
+  };
+}
+function repository() {
+  return {
+    hasIssuesEnabled: true,
+    openIssues: { nodes: [node(1)] },
+    closedIssues: { nodes: [node(2, "CLOSED")] },
+    openPrs: { nodes: [node(3)] },
+    closedPrs: { nodes: [node(4, "CLOSED"), node(5, "MERGED")] },
+  };
+}
+function response(repo = repository()) {
+  return JSON.stringify({ data: { repository: repo } });
+}
+const hosts: ReturnType<typeof createFakePluginHost>[] = [];
+beforeEach(() => {
+  fake.responses.clear();
+  fake.calls = [];
+});
+afterEach(async () => {
+  for (const host of hosts.splice(0)) await host.harness.lifecycle.dispose();
+});
+async function start(repos = "acme/one") {
+  const host = createFakePluginHost({
+    pluginId: "github",
+    settings: { extraRepos: repos },
+    sdk: { projects: { list: async () => [] } },
+  });
+  hosts.push(host);
+  await plugin(host.bb);
+  return host;
+}
+
+it("maps all four lists into SQLite and preserves closed/merged filtering", async () => {
+  fake.responses.set("one", response());
+  const { harness, bb } = await start();
+  expect(await harness.behavior.callRpc("refresh")).toEqual({
+    repos: 1,
+    items: 5,
+  });
+  expect(
+    bb.storage.database().prepare("SELECT count(*) AS n FROM items").get(),
+  ).toEqual({ n: 5 });
+  const { items } = githubRpcContract.listItems.output.parse(
+    await harness.behavior.callRpc("listItems", { state: "closed" }),
+  );
+  expect(items.map((item: { state: string }) => item.state).sort()).toEqual([
+    "CLOSED",
+    "CLOSED",
+    "MERGED",
+  ]);
+  expect(
+    await harness.behavior.callRpc("listItems", {
+      kind: "issue",
+      state: "open",
+    }),
+  ).toEqual({
+    items: [
+      {
+        repo: "acme/one",
+        kind: "issue",
+        number: 1,
+        state: "OPEN",
+        title: "Title 1",
+        author: "app/robot[bot]",
+        labels: ["bug"],
+        assignees: ["alice"],
+        body: "Body\ntext",
+        url: "https://github.com/acme/one/issues/1",
+        updatedAt: "2026-09-10T00:00:00Z",
+      },
+    ],
+  });
+  expect(fake.calls.filter((args) => args[1] === "graphql")).toHaveLength(1);
+});
+
+it("accepts deleted authors and empty connections, discards disabled issues, and clears stale rows on success", async () => {
+  fake.responses.set("one", response());
+  const { harness } = await start();
+  await harness.behavior.callRpc("refresh");
+  const repo = {
+    ...repository(),
+    hasIssuesEnabled: false,
+    openPrs: {
+      nodes: [
+        {
+          ...node(3),
+          author: null,
+          labels: { nodes: [] },
+          assignees: { nodes: [] },
+        },
+      ],
+    },
+    closedPrs: { nodes: [] },
+  };
+  fake.responses.set("one", JSON.stringify({ data: { repository: repo } }));
+  expect(await harness.behavior.callRpc("refresh")).toEqual({
+    repos: 1,
+    items: 1,
+  });
+  expect(await harness.behavior.callRpc("listItems", {})).toMatchObject({
+    items: [{ number: 3, author: "app/", labels: [], assignees: [] }],
+  });
+  fake.responses.set(
+    "one",
+    response({
+      hasIssuesEnabled: true,
+      openIssues: { nodes: [] },
+      closedIssues: { nodes: [] },
+      openPrs: { nodes: [] },
+      closedPrs: { nodes: [] },
+    }),
+  );
+  expect(await harness.behavior.callRpc("refresh")).toEqual({
+    repos: 1,
+    items: 0,
+  });
+  expect(await harness.behavior.callRpc("listItems", {})).toEqual({
+    items: [],
+  });
+});
+
+it.each([
+  ["process failure", new Error("timeout")],
+  ["invalid JSON", "broken"],
+  ["null repository", JSON.stringify({ data: { repository: null } })],
+  [
+    "missing alias",
+    JSON.stringify({
+      data: { repository: { ...repository(), closedPrs: undefined } },
+    }),
+  ],
+  [
+    "partial GraphQL error",
+    JSON.stringify({
+      data: { repository: repository() },
+      errors: [
+        { message: "resource limit", path: ["repository", "openIssues"] },
+      ],
+    }),
+  ],
+  [
+    "null connection",
+    JSON.stringify({
+      data: { repository: { ...repository(), openIssues: null } },
+    }),
+  ],
+  [
+    "malformed node",
+    response({
+      ...repository(),
+      openIssues: { nodes: [{ ...node(1), number: -1 }] },
+    }),
+  ],
+])(
+  "retains repository rows and cursor after %s, then allows another repository to succeed",
+  async (_name, failed) => {
+    fake.responses.set("one", response());
+    const { harness, bb } = await start();
+    await harness.behavior.callRpc("refresh");
+    const before = await harness.behavior.callRpc("listItems", {});
+    const cursor = await bb.storage.kv.get("sync-cursor");
+    fake.responses.set("one", failed);
+    await expect(harness.behavior.callRpc("refresh")).rejects.toThrow();
+    expect(await harness.behavior.callRpc("listItems", {})).toEqual(before);
+    expect(await bb.storage.kv.get("sync-cursor")).toEqual(cursor);
+    await harness.behavior.setSettings({ extraRepos: "acme/one,acme/two" });
+    fake.responses.set("two", response());
+    expect(await harness.behavior.callRpc("refresh")).toEqual({
+      repos: 2,
+      items: 5,
+    });
+    expect(
+      await harness.behavior.callRpc("listItems", { repo: "acme/one" }),
+    ).toEqual(before);
+    expect(
+      bb.storage.database().prepare("SELECT count(*) AS n FROM items").get(),
+    ).toEqual({ n: 10 });
+  },
+);

--- a/plugins/github/server.polling.test.ts
+++ b/plugins/github/server.polling.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { createFakePluginHost } from "@get-bb/plugin-sdk/testing";
+import plugin from "./server";
+
+const fake = vi.hoisted(() => ({
+  calls: [] as string[][],
+  failedRepos: new Set<string>(),
+  latency: 0,
+}));
+
+vi.mock("node:child_process", () => ({
+  execFile(
+    file: string,
+    args: string[],
+    _options: object,
+    callback: (error: Error | null, stdout: string, stderr: string) => void,
+  ) {
+    if (file !== "gh") throw new Error(`Unexpected executable: ${file}`);
+    fake.calls.push(args);
+    const list = args[1] === "graphql";
+    const failed =
+      list &&
+      fake.failedRepos.has(
+        `owner/${args.find((arg) => arg.startsWith("name="))?.slice(5)}`,
+      );
+    const finish = () =>
+      callback(
+        failed ? new Error("offline") : null,
+        JSON.stringify({
+          data: {
+            repository: {
+              hasIssuesEnabled: true,
+              openIssues: { nodes: [] },
+              closedIssues: { nodes: [] },
+              openPrs: { nodes: [] },
+              closedPrs: { nodes: [] },
+            },
+          },
+        }),
+        "",
+      );
+    if (list && fake.latency) setTimeout(finish, fake.latency);
+    else finish();
+  },
+}));
+
+const hosts: ReturnType<typeof createFakePluginHost>[] = [];
+const lists = () => fake.calls.filter((args) => args[1] === "graphql");
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  fake.calls = [];
+  fake.failedRepos.clear();
+  fake.latency = 0;
+});
+
+afterEach(async () => {
+  for (const host of hosts.splice(0)) await host.harness.lifecycle.dispose();
+  vi.useRealTimers();
+});
+
+async function start(count: number) {
+  const host = createFakePluginHost({
+    pluginId: "github",
+    settings: {
+      extraRepos: Array.from(
+        { length: count },
+        (_, i) => `owner/repo-${i}`,
+      ).join(","),
+    },
+    sdk: { projects: { list: async () => [] } },
+  });
+  hosts.push(host);
+  await plugin(host.bb);
+  const service = host.harness.runService("sync");
+  await vi.advanceTimersByTimeAsync(0);
+  return { ...host, ...service };
+}
+
+it.each([0, 1, 34])(
+  "waits fifteen minutes between sweeps for %i repos",
+  async (count) => {
+    const { controller, done } = await start(count);
+    expect(lists()).toHaveLength(count);
+    await vi.advanceTimersByTimeAsync(15 * 60_000 - 1);
+    expect(lists()).toHaveLength(count);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(lists()).toHaveLength(2 * count);
+    expect(fake.calls.filter((args) => args[0] === "auth")).toHaveLength(3);
+    controller.abort();
+    await done;
+    expect(vi.getTimerCount()).toBe(0);
+  },
+);
+
+it("uses one bounded GraphQL request for each repository", async () => {
+  await start(2);
+  expect(lists()).toHaveLength(2);
+  for (const [i, args] of lists().entries()) {
+    expect(args.slice(0, 4)).toEqual([
+      "api",
+      "graphql",
+      "--hostname",
+      "github.com",
+    ]);
+    expect(args).toContain("owner=owner");
+    expect(args).toContain(`name=repo-${i}`);
+    expect(args).not.toContain("--paginate");
+    const query = args.find((arg) => arg.startsWith("query="))!;
+    expect(query).toContain("openIssues: issues(first: 100, states: [OPEN]");
+    expect(query).toContain("closedIssues: issues(first: 50, states: [CLOSED]");
+    expect(query).toContain("openPrs: pullRequests(first: 50, states: [OPEN]");
+    expect(query).toContain(
+      "closedPrs: pullRequests(first: 30, states: [CLOSED, MERGED]",
+    );
+    expect(
+      query.match(/orderBy: {field: CREATED_AT, direction: DESC}/g),
+    ).toHaveLength(4);
+    expect(query).toContain("labels(first: 100)");
+    expect(query).toContain("assignees(first: 100)");
+  }
+});
+
+it("allows immediate RPC and CLI refresh during the background wait", async () => {
+  const { harness } = await start(1);
+  await vi.advanceTimersByTimeAsync(60_000);
+  expect(await harness.callRpc("refresh")).toEqual({ repos: 1, items: 0 });
+  expect(lists()).toHaveLength(2);
+  expect((await harness.runCli(["sync"])).exitCode).toBe(0);
+  expect(lists()).toHaveLength(3);
+  await vi.advanceTimersByTimeAsync(14 * 60_000 - 1);
+  expect(lists()).toHaveLength(3);
+  await vi.advanceTimersByTimeAsync(1);
+  expect(lists()).toHaveLength(4);
+});
+
+it("measures the wait from completion and does not overlap repository sweeps", async () => {
+  fake.latency = 1000;
+  await start(2);
+  expect(lists()).toHaveLength(1);
+  await vi.advanceTimersByTimeAsync(1000);
+  expect(lists()).toHaveLength(2);
+  await vi.advanceTimersByTimeAsync(1000);
+  fake.latency = 0;
+  await vi.advanceTimersByTimeAsync(15 * 60_000 - 1);
+  expect(lists()).toHaveLength(2);
+  await vi.advanceTimersByTimeAsync(1);
+  expect(lists()).toHaveLength(4);
+});
+
+it("finishes an in-flight sweep on abort without scheduling another", async () => {
+  fake.latency = 1000;
+  const { controller, done } = await start(2);
+  controller.abort();
+  await vi.advanceTimersByTimeAsync(2000);
+  await done;
+  expect(lists()).toHaveLength(2);
+  expect(vi.getTimerCount()).toBe(0);
+  await vi.advanceTimersByTimeAsync(60 * 60_000);
+  expect(lists()).toHaveLength(2);
+});
+
+it("preserves all-repository failure backoff and resets it after recovery", async () => {
+  fake.failedRepos.add("owner/repo-0");
+  const { bb } = await start(1);
+  let count = 1;
+  for (const delay of [30, 60, 120, 240, 300, 300]) {
+    await vi.advanceTimersByTimeAsync(delay * 1000 - 1);
+    expect(lists()).toHaveLength(count);
+    await vi.advanceTimersByTimeAsync(1);
+    count += 1;
+    expect(lists()).toHaveLength(count);
+  }
+  expect(await bb.storage.kv.get("sync-cursor")).toBeUndefined();
+  fake.failedRepos.clear();
+  await vi.advanceTimersByTimeAsync(300_000);
+  count += 1;
+  expect(await bb.storage.kv.get("sync-cursor")).toBeDefined();
+  fake.failedRepos.add("owner/repo-0");
+  await vi.advanceTimersByTimeAsync(15 * 60_000);
+  count += 1;
+  expect(lists()).toHaveLength(count);
+  await vi.advanceTimersByTimeAsync(30_000);
+  expect(lists()).toHaveLength(count + 1);
+});
+
+it("uses the normal background wait after a partial repository failure", async () => {
+  fake.failedRepos.add("owner/repo-0");
+  const { bb } = await start(2);
+  expect(await bb.storage.kv.get("sync-cursor")).toBeDefined();
+  await vi.advanceTimersByTimeAsync(15 * 60_000 - 1);
+  expect(lists()).toHaveLength(2);
+  await vi.advanceTimersByTimeAsync(1);
+  expect(lists()).toHaveLength(4);
+});

--- a/plugins/github/server.rpc.test.ts
+++ b/plugins/github/server.rpc.test.ts
@@ -24,32 +24,43 @@ function ghCalls(): string[] {
 beforeEach(() => {
   binDir = mkdtempSync(join(tmpdir(), "bb-github-rpc-"));
   callLog = join(binDir, "gh-calls.log");
-  const openIssue = JSON.stringify([
+  const openIssue = [
     {
       number: 7,
       title: "Cache mutations",
       state: "OPEN",
-      author: { login: "alice" },
-      labels: [{ name: "bug" }, { name: "old" }],
-      assignees: [{ login: "octocat" }],
+      author: { login: "alice", id: "user-alice" },
+      labels: { nodes: [{ name: "bug" }, { name: "old" }] },
+      assignees: { nodes: [{ login: "octocat" }] },
       url: "https://github.com/acme/widgets/issues/7",
       body: "Keep the cache synchronized.",
       updatedAt: "2026-08-19T12:00:00Z",
     },
-  ]);
-  const openPull = JSON.stringify([
+  ];
+  const openPull = [
     {
       number: 42,
       title: "Normalize pull details",
       state: "OPEN",
-      author: { login: "bob" },
-      labels: [{ name: "enhancement" }],
-      assignees: [],
+      author: { login: "bob", id: "user-bob" },
+      labels: { nodes: [{ name: "enhancement" }] },
+      assignees: { nodes: [] },
       url: "https://github.com/acme/widgets/pull/42",
       body: "Normalize every GitHub shape.",
       updatedAt: "2026-08-19T13:00:00Z",
     },
-  ]);
+  ];
+  const lists = JSON.stringify({
+    data: {
+      repository: {
+        hasIssuesEnabled: true,
+        openIssues: { nodes: openIssue },
+        closedIssues: { nodes: [] },
+        openPrs: { nodes: openPull },
+        closedPrs: { nodes: [] },
+      },
+    },
+  });
   const issueDetail = JSON.stringify({
     number: 7,
     title: "Cache mutations",
@@ -172,10 +183,7 @@ case "$*" in
   "api user") printf '%s\n' '{"login":"octocat"}';;
   "api repos/acme/widgets/assignees?per_page=100") printf '%s\n' '[{"login":"zoe"},{"login":"alice"},{"login":""}]';;
   "api repos/acme/widgets/labels?per_page=100") printf '%s\n' '[{"name":"triage"},{"name":" bug "},{"name":""}]';;
-  "issue list -R acme/widgets --state open"*) printf '%s\n' '${openIssue}';;
-  "issue list -R acme/widgets --state closed"*) printf '%s\n' '[]';;
-  "pr list -R acme/widgets --state open"*) printf '%s\n' '${openPull}';;
-  "pr list -R acme/widgets --state closed"*) printf '%s\n' '[]';;
+  "api graphql "*) printf '%s\n' '${lists}';;
   "issue view 7 -R acme/widgets --json labels") printf '%s\n' '{"labels":[{"name":"bug"},{"name":"old"}]}';;
   "issue view 7 -R acme/widgets --json"*) printf '%s\n' '${issueDetail}';;
   "pr view 42 -R acme/widgets --json"*) printf '%s\n' '${pullDetail}';;

--- a/plugins/github/server.test.ts
+++ b/plugins/github/server.test.ts
@@ -81,32 +81,37 @@ function assertGithubFrontendInference(
 describe("GitHub RPC contract", () => {
   it("keeps pull requests when a repository has GitHub Issues disabled", async () => {
     const calls: string[][] = [];
-    const openPulls = JSON.stringify([
-      {
-        number: 17,
-        title: "Keep syncing pull requests",
-        state: "OPEN",
-        author: { login: "octocat" },
-        labels: [{ name: "bug" }],
-        assignees: [],
-        url: "https://github.com/acme/widgets/pull/17",
-        body: "",
-        updatedAt: "2026-08-10T00:00:00Z",
-      },
-    ]);
-
     const items = await fetchRepoItems(async (args) => {
       calls.push(args);
-      if (args[0] === "issue") {
-        throw new Error(
-          "gh issue list failed: the 'acme/widgets' repository has disabled Issues",
-        );
-      }
-      return args.includes("open") ? openPulls : "[]";
+      return JSON.stringify({
+        data: {
+          repository: {
+            hasIssuesEnabled: false,
+            openIssues: { nodes: [] },
+            closedIssues: { nodes: [] },
+            openPrs: {
+              nodes: [
+                {
+                  number: 17,
+                  title: "Keep syncing pull requests",
+                  state: "OPEN",
+                  author: { login: "octocat" },
+                  labels: { nodes: [{ name: "bug" }] },
+                  assignees: { nodes: [] },
+                  url: "https://github.com/acme/widgets/pull/17",
+                  body: "",
+                  updatedAt: "2026-08-10T00:00:00Z",
+                },
+              ],
+            },
+            closedPrs: { nodes: [] },
+          },
+        },
+      });
     }, "acme/widgets");
 
-    expect(calls).toHaveLength(4);
-    expect(calls.filter(([kind]) => kind === "pr")).toHaveLength(2);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.slice(0, 2)).toEqual(["api", "graphql"]);
     expect(items).toEqual([
       expect.objectContaining({
         repo: "acme/widgets",

--- a/plugins/github/server.ts
+++ b/plugins/github/server.ts
@@ -2,7 +2,8 @@ import { execFile } from "node:child_process";
 import { defineRpcContract, type BbPluginApi } from "@get-bb/plugin-sdk";
 import { z } from "zod";
 
-const SYNC_INTERVAL_MS = 5 * 60_000;
+const SYNC_INTERVAL_MS = 15 * 60_000;
+const SYNC_RETRY_MAX_MS = 5 * 60_000;
 const SYNC_RETRY_BASE_MS = 30_000;
 const ISSUE_PAGE = 100;
 const CLOSED_ISSUE_PAGE = 50;
@@ -416,100 +417,119 @@ export function validateGithubCliArgs(argv: string[]): string | null {
   return null;
 }
 
-function toItems(
-  raw: string,
-  repo: string,
-  kind: "issue" | "pr",
-): CachedItem[] {
-  const entries = JSON.parse(raw) as GhListEntry[];
-  return entries
-    .filter(
-      (entry): entry is GhListEntry & { number: number } =>
-        typeof entry?.number === "number",
-    )
-    .map((entry) => ({
-      repo,
-      number: entry.number,
-      kind,
-      title: String(entry.title ?? ""),
-      state: String(entry.state ?? "OPEN"),
-      author: String(entry.author?.login ?? ""),
-      labels: (entry.labels ?? []).map((label) => String(label?.name ?? "")),
-      assignees: (entry.assignees ?? []).map((user) =>
-        String(user?.login ?? ""),
-      ),
-      url: String(entry.url ?? ""),
-      body: typeof entry.body === "string" ? entry.body : "",
-      updatedAt: String(entry.updatedAt ?? ""),
-    }));
-}
+const listNodeSchema = z.object({
+  number: itemNumberSchema,
+  title: z.string(),
+  state: z.enum(["OPEN", "CLOSED", "MERGED"]),
+  author: z.object({ login: z.string(), id: z.string().optional() }).nullable(),
+  labels: z.object({ nodes: z.array(z.object({ name: z.string() })).max(100) }),
+  assignees: z.object({
+    nodes: z.array(z.object({ login: z.string() })).max(100),
+  }),
+  url: z.string(),
+  body: z.string(),
+  updatedAt: z.string(),
+});
+const repositoryListsSchema = z.object({
+  data: z.object({
+    repository: z.object({
+      hasIssuesEnabled: z.boolean(),
+      openIssues: z.object({
+        nodes: z
+          .array(listNodeSchema.extend({ state: z.literal("OPEN") }))
+          .max(ISSUE_PAGE),
+      }),
+      closedIssues: z.object({
+        nodes: z
+          .array(listNodeSchema.extend({ state: z.literal("CLOSED") }))
+          .max(CLOSED_ISSUE_PAGE),
+      }),
+      openPrs: z.object({
+        nodes: z
+          .array(listNodeSchema.extend({ state: z.literal("OPEN") }))
+          .max(PR_PAGE),
+      }),
+      closedPrs: z.object({
+        nodes: z
+          .array(listNodeSchema.extend({ state: z.enum(["CLOSED", "MERGED"]) }))
+          .max(CLOSED_PR_PAGE),
+      }),
+    }),
+  }),
+  errors: z.array(z.unknown()).max(0).optional(),
+});
+const listFields = `
+  number title state author { login ... on User { id } }
+  labels(first: 100) { nodes { name } }
+  assignees(first: 100) { nodes { login } }
+  url body updatedAt
+`;
+const repositoryListsQuery = `query RepositoryLists($owner: String!, $name: String!) {
+  repository(owner: $owner, name: $name) {
+    hasIssuesEnabled
+    openIssues: issues(first: ${ISSUE_PAGE}, states: [OPEN], orderBy: {field: CREATED_AT, direction: DESC}) {
+      nodes { ${listFields} }
+    }
+    closedIssues: issues(first: ${CLOSED_ISSUE_PAGE}, states: [CLOSED], orderBy: {field: CREATED_AT, direction: DESC}) {
+      nodes { ${listFields} }
+    }
+    openPrs: pullRequests(first: ${PR_PAGE}, states: [OPEN], orderBy: {field: CREATED_AT, direction: DESC}) {
+      nodes { ${listFields} }
+    }
+    closedPrs: pullRequests(first: ${CLOSED_PR_PAGE}, states: [CLOSED, MERGED], orderBy: {field: CREATED_AT, direction: DESC}) {
+      nodes { ${listFields} }
+    }
+  }
+}`;
 
 export async function fetchRepoItems(
   gh: GhRunner,
   repo: string,
 ): Promise<CachedItem[]> {
-  const fields =
-    "number,title,state,author,labels,assignees,url,body,updatedAt";
-  const ghIssuesTolerant = (args: string[]) =>
-    gh(args).catch((error: unknown) => {
-      if (String(error).toLowerCase().includes("disabled issues")) return "[]";
-      throw error;
-    });
-  const [openIssues, closedIssues, openPrs, closedPrs] = await Promise.all([
-    ghIssuesTolerant([
-      "issue",
-      "list",
-      "-R",
-      repo,
-      "--state",
-      "open",
-      "--limit",
-      String(ISSUE_PAGE),
-      "--json",
-      fields,
-    ]),
-    ghIssuesTolerant([
-      "issue",
-      "list",
-      "-R",
-      repo,
-      "--state",
-      "closed",
-      "--limit",
-      String(CLOSED_ISSUE_PAGE),
-      "--json",
-      fields,
-    ]),
-    gh([
-      "pr",
-      "list",
-      "-R",
-      repo,
-      "--state",
-      "open",
-      "--limit",
-      String(PR_PAGE),
-      "--json",
-      fields,
-    ]),
-    gh([
-      "pr",
-      "list",
-      "-R",
-      repo,
-      "--state",
-      "closed",
-      "--limit",
-      String(CLOSED_PR_PAGE),
-      "--json",
-      fields,
-    ]),
+  const [owner, name] = repoNameSchema.parse(repo).split("/");
+  const raw = await gh([
+    "api",
+    "graphql",
+    "--hostname",
+    GH_HOST,
+    "-f",
+    `query=${repositoryListsQuery}`,
+    "-f",
+    `owner=${owner}`,
+    "-f",
+    `name=${name}`,
   ]);
+  const {
+    data: { repository },
+  } = repositoryListsSchema.parse(JSON.parse(raw));
+  const toItems = (
+    nodes: z.infer<typeof listNodeSchema>[],
+    kind: "issue" | "pr",
+  ): CachedItem[] =>
+    nodes.map((entry) => ({
+      repo,
+      number: entry.number,
+      kind,
+      title: entry.title,
+      state: entry.state,
+      author: entry.author?.id
+        ? entry.author.login
+        : `app/${entry.author?.login ?? ""}`,
+      labels: entry.labels.nodes.map((label) => label.name),
+      assignees: entry.assignees.nodes.map((user) => user.login),
+      url: entry.url,
+      body: entry.body,
+      updatedAt: entry.updatedAt,
+    }));
   return [
-    ...toItems(openIssues, repo, "issue"),
-    ...toItems(closedIssues, repo, "issue"),
-    ...toItems(openPrs, repo, "pr"),
-    ...toItems(closedPrs, repo, "pr"),
+    ...(repository.hasIssuesEnabled
+      ? [
+          ...toItems(repository.openIssues.nodes, "issue"),
+          ...toItems(repository.closedIssues.nodes, "issue"),
+        ]
+      : []),
+    ...toItems(repository.openPrs.nodes, "pr"),
+    ...toItems(repository.closedPrs.nodes, "pr"),
   ];
 }
 
@@ -867,7 +887,7 @@ export default async function plugin(bb: BbPluginApi) {
           failures += 1;
           delayMs = Math.min(
             SYNC_RETRY_BASE_MS * 2 ** (failures - 1),
-            SYNC_INTERVAL_MS,
+            SYNC_RETRY_MAX_MS,
           );
           bb.log.warn(
             `sync failed (retry in ${Math.round(delayMs / 1000)}s): ${


### PR DESCRIPTION
## Human comments

## What was wrong

The GitHub plugin launched four list processes for every tracked repository and repeated successful sweeps after a five-minute wait, even when the catalog was unchanged. A deterministic 34-repository reproduction launched 136 list processes per sweep. This proves polling amplification; it does not establish quota exhaustion or interactive failures.

## What changed

Batch each repository's four bounded issue/PR lists into one `gh api graphql` call, and wait 15 minutes after successful sweeps. Preserve creation order, result limits, closed/merged PRs, gh author serialization, disabled-issues handling, cached rows on failed responses, immediate manual refresh, and the existing five-minute retry cap. Validate GraphQL responses before replacing repository rows.

The interval remains internal policy with no new configuration or CLI/SDK member. README and marketplace overview document the behavior. HOST_DAEMON_PROTOCOL_VERSION is unchanged because no server/daemon wire contract changes.

For 34 repositories, fetch process launches drop from 136 to 34 per sweep. Combined with the longer wait, the negligible-duration steady-state projection drops from 1,632 to 136 fetch processes/hour, excluding startup, manual refresh, retries and authentication. HTTP request counts are source-derived, not live-measured; GraphQL point savings are unmeasured.

## How you verified

- Deterministic fake-process/fake-clock regressions failed against the original cadence and separate-list implementation before the changes.
- Real SQLite tests cover mapping, disabled issues, empty results, malformed/partial responses, cache retention and cross-repository failure isolation.
- Timing tests preserve manual RPC/CLI refresh, retry/reset behavior and parked shutdown. Existing in-flight sweeps still finish on abort.
- Offline query validation against GitHub's public GraphQL schema; no live polling requests used in regression tests.
- 46 tests passed across 8 files; Turbo test/typecheck/build completed successfully (7 tasks). Targeted lint, formatting and diff checks passed.

Fixes #3406

> AGENT GENERATED
