### PR TITLE
Fix inline Markdown links and images relative to their document

### DIFF
--- a/apps/app/src/components/ui/markdown-document-link-routing.ts
+++ b/apps/app/src/components/ui/markdown-document-link-routing.ts
@@ -1,0 +1,82 @@
+import type { ExperimentalFileOpenOptions } from "@get-bb/plugin-sdk";
+import { normalizeExperimentalLiveFileTarget } from "@/lib/live-file-navigation";
+import {
+  buildAbsoluteFilePath,
+  isAbsoluteFilePathWithinRoot,
+  normalizeAbsoluteFilePath,
+} from "@/lib/absolute-file-path";
+import {
+  buildThreadStorageRawContentUrl,
+  buildThreadWorktreeRawContentUrl,
+} from "@/lib/file-content-urls";
+import { buildMarkdownFileImageRouting } from "./markdown-file-image-routing";
+import type { MarkdownLinkRouting } from "./markdown-link-routing";
+
+export function buildMarkdownDocumentLinkRouting({
+  document,
+  messageRouting,
+  openFilePreview,
+}: {
+  document: unknown;
+  messageRouting: MarkdownLinkRouting;
+  openFilePreview: (intent: ExperimentalFileOpenOptions) => boolean;
+}): MarkdownLinkRouting {
+  if (typeof document !== "object" || document === null) return {};
+  if (
+    !("target" in document) ||
+    !("rootPath" in document) ||
+    !("threadId" in document)
+  )
+    return {};
+  const target = normalizeExperimentalLiveFileTarget(document.target);
+  if (
+    target === null ||
+    target.kind === "host" ||
+    typeof document.rootPath !== "string" ||
+    typeof document.threadId !== "string" ||
+    !document.threadId.trim() ||
+    (target.kind === "thread-storage" && target.threadId !== document.threadId)
+  )
+    return {};
+  const rootPath = normalizeAbsoluteFilePath({ path: document.rootPath });
+  if (rootPath === null) return {};
+  const threadId = document.threadId;
+  const routing = buildMarkdownFileImageRouting({
+    path: buildAbsoluteFilePath({ path: target.path, rootPath }),
+    rootPath,
+    threadId,
+    resolveRelativeSrc: (path) =>
+      target.kind === "workspace"
+        ? buildThreadWorktreeRawContentUrl(threadId, path)
+        : buildThreadStorageRawContentUrl(threadId, path),
+  });
+  return {
+    ...routing,
+    onOpenLink: messageRouting.onOpenLink,
+    localFile: {
+      absoluteLinks: { kind: "trusted-host" },
+      relativeLinks: routing?.localImage?.relativePaths,
+      onOpenLink: (link) => {
+        if (
+          !isAbsoluteFilePathWithinRoot({ candidatePath: link.path, rootPath })
+        ) {
+          return messageRouting.localFile?.onOpenLink(link) ?? false;
+        }
+        return openFilePreview({
+          target: {
+            ...target,
+            path: link.path.slice(rootPath === "/" ? 1 : rootPath.length + 1),
+          },
+          location:
+            link.lineRange === null
+              ? null
+              : {
+                  kind: "range",
+                  startLine: link.lineRange.startLineNumber,
+                  endLine: link.lineRange.endLineNumber,
+                },
+        });
+      },
+    },
+  };
+}

--- a/apps/app/src/lib/plugin-sdk-app-impl.test.tsx
+++ b/apps/app/src/lib/plugin-sdk-app-impl.test.tsx
@@ -152,6 +152,119 @@ describe("plugin SDK Markdown", () => {
     expect(onOpenLink).not.toHaveBeenCalled();
   });
 
+  it.each(["workspace", "thread-storage"] as const)(
+    "resolves nested %s document destinations independently of message context",
+    (kind) => {
+      const openFilePreview = vi.fn(() => true);
+      const openUrl = vi.fn(() => true);
+      const Markdown = pluginSdkAppImplementation.Markdown;
+      const rootPath = kind === "workspace" ? "/workspace" : "/storage";
+      const target =
+        kind === "workspace"
+          ? {
+              kind,
+              environmentId: "env_document",
+              path: "reports/nested/report.md",
+            }
+          : {
+              kind,
+              threadId: "thr_document",
+              path: "reports/nested/report.md",
+            };
+      const props = {
+        content:
+          "[Sibling](sibling.md#L2-L4) ![Chart](../chart%20one.svg) [Parent](../summary.md) [Missing](missing.md) [Web](https://example.com)",
+        experimental_document: { target, rootPath, threadId: "thr_document" },
+      };
+      render(
+        <AppNavigationHostProvider capabilities={{ openFilePreview, openUrl }}>
+          <ThreadTimelineNavigationProvider
+            environmentId="env_other"
+            onOpenLink={() => false}
+            onOpenLocalFileLink={() => {
+              throw new Error("Used ambient workspace");
+            }}
+            resolveMentionLink={() => null}
+            threadId="thr_other"
+            workspaceRootPath="/wrong-workspace"
+          >
+            <Markdown {...props} />
+          </ThreadTimelineNavigationProvider>
+        </AppNavigationHostProvider>,
+      );
+      fireEvent.click(screen.getByRole("link", { name: "Sibling" }));
+      expect(openFilePreview).toHaveBeenLastCalledWith({
+        target: { ...target, path: "reports/nested/sibling.md" },
+        location: { kind: "range", startLine: 2, endLine: 4 },
+      });
+      expect(
+        screen.getByRole("img", { name: "Chart" }).getAttribute("src"),
+      ).toBe(
+        `/api/v1/threads/thr_document/${kind === "workspace" ? "worktree" : kind}/files/reports/chart%20one.svg`,
+      );
+      fireEvent.click(screen.getByRole("link", { name: "Parent" }));
+      expect(openFilePreview).toHaveBeenLastCalledWith({
+        target: { ...target, path: "reports/summary.md" },
+        location: null,
+      });
+      fireEvent.click(screen.getByRole("link", { name: "Missing" }));
+      expect(openFilePreview).toHaveBeenLastCalledWith({
+        target: { ...target, path: "reports/nested/missing.md" },
+        location: null,
+      });
+      fireEvent.click(screen.getByRole("link", { name: "Web" }));
+      expect(openUrl).toHaveBeenCalledWith({ url: "https://example.com" });
+    },
+  );
+
+  it("keeps escaping relative paths out of file navigation and preserves absolute links", () => {
+    const openFilePreview = vi.fn(() => true);
+    const onOpenLocalFileLink = vi.fn(() => true);
+    const Markdown = pluginSdkAppImplementation.Markdown;
+    render(
+      <AppNavigationHostProvider capabilities={{ openFilePreview }}>
+        <ThreadTimelineNavigationProvider
+          environmentId={null}
+          onOpenLink={() => false}
+          onOpenLocalFileLink={onOpenLocalFileLink}
+          resolveMentionLink={() => null}
+          threadId="thr_document"
+          workspaceRootPath="/workspace"
+        >
+          <Markdown
+            content="[Escape](../../../outside.md) ![Escape](../../../outside.svg) [Absolute](/outside.md) ![Absolute](/outside.svg)"
+            experimental_document={{
+              rootPath: "/storage",
+              threadId: "thr_document",
+              target: {
+                kind: "thread-storage",
+                threadId: "thr_document",
+                path: "reports/report.md",
+              },
+            }}
+          />
+        </ThreadTimelineNavigationProvider>
+      </AppNavigationHostProvider>,
+    );
+    expect(
+      screen.getByRole("link", { name: "Escape" }).getAttribute("href"),
+    ).toBe("../../../outside.md");
+    expect(
+      screen.getByRole("img", { name: "Escape" }).getAttribute("src"),
+    ).toBe("../../../outside.svg");
+    expect(openFilePreview).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("link", { name: "Absolute" }));
+    expect(onOpenLocalFileLink).toHaveBeenCalledWith({
+      path: "/outside.md",
+      lineRange: null,
+    });
+    expect(
+      screen.getByRole("img", { name: "Absolute" }).getAttribute("src"),
+    ).toBe(
+      "/api/v1/threads/thr_document/host-files/content?path=%2Foutside.svg",
+    );
+  });
+
   it("routes web links without requiring a thread navigation context", () => {
     const openUrl = vi.fn(() => true);
     const Markdown = pluginSdkAppImplementation.Markdown;

--- a/apps/app/src/lib/plugin-sdk-app-impl.tsx
+++ b/apps/app/src/lib/plugin-sdk-app-impl.tsx
@@ -15,6 +15,7 @@ import { PluginUrlLink } from "@/components/plugin/PluginUrlLink";
 import { ExperimentalFileLink } from "@/components/plugin/ExperimentalFileLink";
 import { MarkdownPreview } from "@/components/ui/markdown-preview";
 import type { MarkdownLinkRouting } from "@/components/ui/markdown-link-routing";
+import { buildMarkdownDocumentLinkRouting } from "@/components/ui/markdown-document-link-routing";
 import { buildMarkdownMessageLinkRouting } from "@/components/ui/markdown-message-link-routing";
 import type { MarkdownPreviewLinkHandler } from "@/components/ui/markdown-link";
 import { useThreadTimelineNavigation } from "@/components/thread/timeline/ThreadTimelineNavigationContext";
@@ -77,7 +78,11 @@ export const pluginSdkAppImplementation = installDeprecatedAliases(
   { experimental_UrlLink: "UrlLink" },
 );
 
-function PluginMarkdown({ content, className }: MarkdownProps) {
+function PluginMarkdown({
+  content,
+  className,
+  experimental_document,
+}: MarkdownProps) {
   const timelineNavigation = useThreadTimelineNavigation();
   const onOpenLocalFileLink = timelineNavigation?.onOpenLocalFileLink;
   const threadId = timelineNavigation?.threadId;
@@ -88,15 +93,27 @@ function PluginMarkdown({ content, className }: MarkdownProps) {
     [navigation],
   );
   const linkRouting = useMemo<MarkdownLinkRouting>(() => {
-    return (
-      buildMarkdownMessageLinkRouting({
-        onOpenLink,
-        onOpenLocalFileLink,
-        threadId,
-        workspaceRootPath,
-      }) ?? { onOpenLink }
-    );
-  }, [onOpenLink, onOpenLocalFileLink, threadId, workspaceRootPath]);
+    const messageRouting = buildMarkdownMessageLinkRouting({
+      onOpenLink,
+      onOpenLocalFileLink,
+      threadId,
+      workspaceRootPath,
+    }) ?? { onOpenLink };
+    return experimental_document === undefined
+      ? messageRouting
+      : buildMarkdownDocumentLinkRouting({
+          document: experimental_document,
+          messageRouting,
+          openFilePreview: navigation.openFilePreview,
+        });
+  }, [
+    experimental_document,
+    navigation.openFilePreview,
+    onOpenLink,
+    onOpenLocalFileLink,
+    threadId,
+    workspaceRootPath,
+  ]);
 
   return (
     <MarkdownPreview

--- a/docs/api_to_audit.md
+++ b/docs/api_to_audit.md
@@ -2554,3 +2554,16 @@ describing it as merely too large.
    boolean indicating whether a detail read can succeed.
 3. Verify old persisted previews and mixed-version clients still receive a
    deterministic state before making the field stable.
+
+## Document Markdown (`MarkdownProps.experimental_document`)
+
+The existing Markdown component accepts explicit `{ target, rootPath, threadId }`
+document context. `target` is an existing workspace or thread-storage live-file
+identity; `rootPath` is its resolved filesystem root. Relative links and images
+resolve from the document directory within that root. Links open the explicit
+file target; images use the selected thread's existing source-confined route.
+Thread-storage targets must name the same thread. Omission retains message
+routing; malformed context does not fall back to the ambient workspace.
+Explicit absolute paths retain existing host-file behavior. HTML is unaffected.
+Stabilize after plugin consumers verify nested paths, source identity, missing
+files, containment and line locations, then rename and remove this audit entry.

--- a/packages/domain/src/plugin-sdk-version.ts
+++ b/packages/domain/src/plugin-sdk-version.ts
@@ -1,3 +1,3 @@
-export const PLUGIN_SDK_VERSION = "0.4.54";
+export const PLUGIN_SDK_VERSION = "0.4.55";
 
 export const PLUGIN_SDK_MAJOR = Number(PLUGIN_SDK_VERSION.split(".", 1)[0]);

--- a/packages/plugin-api-map/src/surfaces.ts
+++ b/packages/plugin-api-map/src/surfaces.ts
@@ -915,11 +915,13 @@ export const SURFACE_GROUPS: SurfaceGroup[] = [
         bullets: [
           "Embed the thread view and the new-thread prompt box as components",
           "Render message text with the same Markdown renderer bb uses",
+          "Resolve document links and images beside a workspace or thread-storage file with Markdown.experimental_document",
           "Inherit bb's styling, so embedded UI matches the rest of the app",
         ],
         apiSymbols: [
           "ThreadChat",
           "Markdown",
+          "MarkdownProps.experimental_document",
           "experimental_NewThreadComposer",
         ],
         firstParty: ["Side chat"],

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@get-bb/plugin-sdk",
-  "version": "0.4.54",
+  "version": "0.4.55",
   "homepage": "https://github.com/get-bb/bb#readme",
   "bugs": {
     "url": "https://github.com/get-bb/bb/issues"

--- a/packages/plugin-sdk/src/app-contract.ts
+++ b/packages/plugin-sdk/src/app-contract.ts
@@ -2241,6 +2241,12 @@ export interface MarkdownProps {
   /** Markdown source, rendered exactly like a chat message body. */
   content: string;
   className?: string;
+  /** Resolve local destinations from this document; omission keeps message routing. */
+  experimental_document?: {
+    threadId: string;
+    rootPath: string;
+    target: Exclude<ExperimentalLiveFileTarget, { kind: "host" }>;
+  };
 }
 
 /**

--- a/plugins/inline-vis/README.md
+++ b/plugins/inline-vis/README.md
@@ -63,3 +63,8 @@ directive (see the bundled `inline-vis` skill).
 ```bash
 pnpm exec turbo run test typecheck --filter=bb-plugin-inline-vis
 ```
+
+Markdown links and images resolve relative to the document's directory in the
+selected source. For `::inline-vis{source="thread-storage" file="reports/report.md"}`,
+`[Notes](notes.md)` and `![Chart](chart.svg)` refer to files under `reports/`
+in that thread's storage. The same rule applies to workspace reports.

--- a/plugins/inline-vis/app.tsx
+++ b/plugins/inline-vis/app.tsx
@@ -6,6 +6,7 @@ import {
   Markdown,
   useRpc,
   type PluginMessageDirectiveProps,
+  type MarkdownProps,
 } from "@get-bb/plugin-sdk/app";
 import type { inlineVisRpcContract } from "./server.js";
 
@@ -33,6 +34,7 @@ type LoadState =
       file: string;
       source: PreviewSource;
       content: string;
+      document: NonNullable<MarkdownProps["experimental_document"]>;
     }
   | { status: "error"; file: string; message: string };
 
@@ -233,7 +235,10 @@ function InlineVisDirective({
           style={{ height: previewHeight ?? DEFAULT_HEIGHT_PX }}
           className="overflow-auto p-3"
         >
-          <Markdown content={state.content} />
+          <Markdown
+            content={state.content}
+            experimental_document={state.document}
+          />
         </div>
       ) : (
         <iframe

--- a/plugins/inline-vis/server.test.ts
+++ b/plugins/inline-vis/server.test.ts
@@ -110,6 +110,11 @@ describe("preparePreview rpc", () => {
       file: "notes.md",
       source: "workspace",
       content: "# Notes\n\nReady for review.",
+      document: {
+        rootPath: ROOT,
+        threadId: "thr_1",
+        target: { kind: "workspace", environmentId: "env_1", path: "notes.md" },
+      },
     });
   });
 
@@ -147,6 +152,15 @@ describe("preparePreview rpc", () => {
       file: "reports/summary.markdown",
       source: "thread-storage",
       content: "# Report",
+      document: {
+        rootPath: storageRootPath,
+        threadId: "thr_1",
+        target: {
+          kind: "thread-storage",
+          threadId: "thr_1",
+          path: "reports/summary.markdown",
+        },
+      },
     });
     expect(harness.sdk.callsTo("threads.get")).toHaveLength(0);
   });

--- a/plugins/inline-vis/server.ts
+++ b/plugins/inline-vis/server.ts
@@ -1,11 +1,14 @@
 import path from "node:path";
-import { defineRpcContract, type BbPluginApi } from "@get-bb/plugin-sdk";
+import {
+  defineRpcContract,
+  type BbPluginApi,
+  type MarkdownProps,
+} from "@get-bb/plugin-sdk";
 import { z } from "zod";
 
 export const MAX_PREVIEW_BYTES = 5 * 1024 * 1024;
 
 type PreviewKind = "html" | "markdown";
-type PreviewSource = "workspace" | "thread-storage";
 
 const PREVIEW_KIND_BY_EXTENSION: ReadonlyMap<string, PreviewKind> = new Map([
   [".html", "html"],
@@ -13,10 +16,6 @@ const PREVIEW_KIND_BY_EXTENSION: ReadonlyMap<string, PreviewKind> = new Map([
   [".md", "markdown"],
   [".markdown", "markdown"],
 ]);
-
-type PreparePreviewResult =
-  | { kind: "html"; file: string; source: PreviewSource }
-  | { kind: "markdown"; file: string; source: PreviewSource; content: string };
 
 function requireNonEmptyString(value: unknown, field: string): string {
   if (typeof value !== "string" || value.trim().length === 0) {
@@ -120,6 +119,28 @@ export const inlineVisRpcContract = defineRpcContract({
           file: z.string(),
           source: z.enum(["workspace", "thread-storage"]),
           content: z.string(),
+          document: z
+            .object({
+              rootPath: z.string(),
+              threadId: z.string(),
+              target: z.discriminatedUnion("kind", [
+                z
+                  .object({
+                    kind: z.literal("workspace"),
+                    environmentId: z.string(),
+                    path: z.string(),
+                  })
+                  .strict(),
+                z
+                  .object({
+                    kind: z.literal("thread-storage"),
+                    threadId: z.string(),
+                    path: z.string(),
+                  })
+                  .strict(),
+              ]),
+            })
+            .strict(),
         })
         .strict(),
     ]),
@@ -128,18 +149,16 @@ export const inlineVisRpcContract = defineRpcContract({
 
 export default async function plugin(bb: BbPluginApi) {
   bb.rpc.register(inlineVisRpcContract, {
-    async preparePreview({
-      threadId,
-      file,
-      source,
-    }): Promise<PreparePreviewResult> {
+    async preparePreview({ threadId, file, source }) {
       let rootPath: string;
       let hostId: string;
+      let target: NonNullable<MarkdownProps["experimental_document"]>["target"];
 
       if (source === "thread-storage") {
         const storage = await bb.sdk.threads.storageLocation({ threadId });
         rootPath = storage.storageRootPath;
         hostId = storage.hostId;
+        target = { kind: source, threadId, path: file };
       } else {
         const thread = await bb.sdk.threads.get({
           threadId,
@@ -155,7 +174,7 @@ export default async function plugin(bb: BbPluginApi) {
         const environment = thread.environment;
         const workspacePath =
           typeof environment?.path === "string" ? environment.path : null;
-        if (!workspacePath) {
+        if (!environment || !workspacePath) {
           throw new Error(
             "This thread has no workspace path — inline-vis needs a live environment.",
           );
@@ -169,6 +188,7 @@ export default async function plugin(bb: BbPluginApi) {
         }
         rootPath = workspacePath;
         hostId = workspaceHostId;
+        target = { kind: source, environmentId: environment.id, path: file };
       }
 
       const absolutePath = resolveContainedPreviewPath(rootPath, file);
@@ -201,7 +221,13 @@ export default async function plugin(bb: BbPluginApi) {
 
       const kind = previewKind(file);
       return kind === "markdown"
-        ? { kind, file, source, content: result.content }
+        ? {
+            kind,
+            file,
+            source,
+            content: result.content,
+            document: { rootPath, threadId, target },
+          }
         : { kind, file, source };
     },
   });


### PR DESCRIPTION
## Human comments

## What was wrong

The inline Markdown preview added in #3439 passed only text to the message renderer, discarding the report’s directory and storage source. A nested `reports/report.md` linking to `sibling.md` or `chart.svg` therefore resolved from the workspace root, even when the report lived in thread storage.

## What changed

Pass server-resolved document context through the private inline-vis response into `Markdown.experimental_document`. Reuse existing file-image routing and explicit file navigation so links and images resolve beside the document within the selected source. Preserve line ranges, message rendering without document context, and existing HTML sandbox behavior.

Document the experimental SDK prop in the Plugin Guide and API audit, add an inline-vis example, and bump the Plugin SDK from `0.4.54` to `0.4.55` so consumers can require a host that supports the new surface. No daemon wire changes or new CLI commands; existing SDK/CLI message directives retain their delivery path.

## How you verified

- Added real-renderer regressions for nested workspace/thread-storage links and images, conflicting ambient workspace context, line ranges, parent-directory references, missing destinations, and escape/absolute-path controls. Both destination cases and both RPC context assertions failed before the change and passed afterward.
- Turbo test/typecheck passed for `bb-plugin-inline-vis`, `@get-bb/plugin-sdk`, and `@bb/plugin-api-map`; app build/typecheck and the Plugin Guide build passed.
- Focused app tests passed, including 13 renderer/image checks after rebasing. The broad app suite was interrupted under load; all five observed failures passed focused reruns with two workers. No full-suite pass claimed.
- Verified the actual source app with a connected daemon and synthetic reports: correct sibling documents and charts from both storage roots, desktop pointer activation, reload and keyboard activation at 390×844 with coarse pointer/no hover, and no horizontal overflow.
- Source browser/filesystem fixtures covered loading, stale/error states, HTML sandbox preservation, and missing/binary/oversized/traversal/symlink controls. Safari, Electron, and remote authentication were not verified.
- `node .github/workflows/check-plugin-sdk-version.mjs` passed after the `0.4.55` lockstep bump.

## Before and after

Matching 1280×900 source-component fixtures for a thread-storage report. Before uses parent `1d20e5f9ccd9f85cf5e9f56461d8f5e4fc25c5f3`; After captures the UI behavior now present at final pushed head `5dd24812ac6a208688b6ed4d9a0f93af0c4d5c21`. The subsequent rebase and SDK-version correction did not change the rendered UI. Navigation/RPC are fixture adapters; the actual inline component and renderer are built from the compared revisions. After requests the chart beside the report and opens `reports/sibling.md` in thread storage.

| Before — wrong workspace destination, broken chart | After — document-relative destination, chart loaded |
| --- | --- |
| ![Before: broken chart](https://raw.githubusercontent.com/get-bb/bb/acbb8b2ca20cd3573966584973c05a905de011c6/pr-before.png) | ![After: chart loaded](https://raw.githubusercontent.com/get-bb/bb/acbb8b2ca20cd3573966584973c05a905de011c6/pr-after.png) |

> AGENT GENERATED
