### PR TITLE
Drop unusable desktop browser snapshots instead of closing daemon sessions

### DIFF
--- a/apps/server/src/ws/daemon-protocol.ts
+++ b/apps/server/src/ws/daemon-protocol.ts
@@ -185,16 +185,24 @@ export function onDaemonSocketMessage(
         return;
       }
       if (result.data.type === "desktop-browser.changed") {
-        syncDesktopBrowserTabs(
-          deps,
-          {
-            hostId: args.hostId,
-            instanceId: result.data.instanceId,
-            generation: result.data.generation,
-            threadId: result.data.threadId,
-          },
-          result.data.tabs,
-        );
+        const scope = {
+          hostId: args.hostId,
+          instanceId: result.data.instanceId,
+          generation: result.data.generation,
+          threadId: result.data.threadId,
+        };
+        try {
+          syncDesktopBrowserTabs(deps, scope, result.data.tabs);
+        } catch (error) {
+          deps.logger.warn(
+            {
+              sessionId: args.sessionId,
+              ...scope,
+              ...runtimeErrorLogFields(deps.config, error),
+            },
+            "Dropping desktop browser snapshot the server cannot apply",
+          );
+        }
         return;
       }
       if (result.data.type === "plugin-host.worker-exited") {
@@ -258,9 +266,10 @@ export function onDaemonSocketMessage(
     deps.logger.warn(
       {
         sessionId: args.sessionId,
+        messageType: result.data.type,
         ...runtimeErrorLogFields(deps.config, error),
       },
-      "Daemon heartbeat rejected, closing socket",
+      "Daemon message rejected, closing socket",
     );
     args.socket.close(1008, "inactive-session");
   }

--- a/apps/server/test/desktop-browsers.test.ts
+++ b/apps/server/test/desktop-browsers.test.ts
@@ -882,6 +882,28 @@ describe("desktop browser public API", () => {
       expect(test.stored()).toEqual([]);
     });
   });
+  it("drops snapshots for synthetic, missing, or deleted threads without closing the daemon session", async () => {
+    await withBrowserTest(async (test, harness) => {
+      const deleted = seedThread(harness.deps, {
+        projectId: test.project.id,
+        environmentId: test.environment.id,
+      });
+      markThreadDeleted(harness.db, harness.hub, { threadId: deleted.id });
+      for (const threadId of [
+        "plugin-panel:cloud-sandbox:cloud-machines:pane-1",
+        "thr_missing",
+        deleted.id,
+      ]) {
+        const socket = test.change({ threadId }, [{ ...test.tab(), threadId }]);
+        expect(socket.close, threadId).not.toHaveBeenCalled();
+        expect(test.stored(threadId), threadId).toEqual([]);
+      }
+      expect(test.change({}, [test.tab()]).close).not.toHaveBeenCalled();
+      expect(test.stored()).toEqual([
+        expect.objectContaining({ id: test.tab().tabId }),
+      ]);
+    });
+  });
   it("revokes native control when acquisition completes after its deadline", async () => {
     await withBrowserTest(async (test) => {
       const gate = deferred<HostRpcHandlerResult>();


### PR DESCRIPTION
## Human comments

Currently, we synchronize browser tabs between desktop app main processes, host daemon processes, and the server process. Each browser tab is associated with a thread ID. We do this so that agents can interact with browser tabs that might be opened in a desktop app window elsewhere (note you can have multiple desktop apps across multiple machines, but only ever 1 server process). 

If we try to synchronize a browser tab associated with a thread ID that the server doesn't have, the server process will throw an error, and the host daemon which forwarded this message to the server will be forcibly disconnected. Moreover this will happen in a loop because on reconnect we will retry browser tabs synchronization through that host daemon.

Today, you can open browser tabs inside a plugin pane, which gets a fake thread ID of the form `plugin-panel:cloud-sandbox:cloud-machines:pane-1`. The server won't be able to find any such thread ID and so using the browser inside the plugin pane trivially trips this bug and can cause the local machine/daemon to get disconnected. This PR should fix that bug by making the server just ignore these browser tabs instead of forcibly disconnecting the host daemon.

## What was wrong

The server handles every host-daemon WebSocket message inside a single `try/catch` in `onDaemonSocketMessage`, and any handler error closes the daemon session (`1008 inactive-session`). The desktop app forwards `desktop-browser.changed` tab snapshots through the host daemon, and `syncDesktopBrowserTabs` starts with `requirePublicThread`, which throws `thread_not_found` when the snapshot's scope isn't a live thread. Browser tabs opened in a plugin page's right panel report their panel-state id (for example `plugin-panel:cloud-sandbox:cloud-machines:pane-1`) as their thread id, so one such tab made the server drop the whole host session. The desktop broker re-sends every known scope after each reconnect, so the host got stuck in a loop: connect, snapshot, session closed. It showed as offline, and each drop was logged as the misleading `Daemon heartbeat rejected, closing socket`.

## What changed

- `apps/server/src/ws/daemon-protocol.ts`: errors from `syncDesktopBrowserTabs` are now caught. The server logs `Dropping desktop browser snapshot the server cannot apply` with host, instance, generation, thread id and the error, and drops the snapshot. The daemon session stays open.
- The catch-all log is now `Daemon message rejected, closing socket` and includes `messageType`, so the next unexpected rejection names the message that caused it.
- No wire change; `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.
- The desktop-side fix, which stops the broker publishing plugin-panel browser tabs at all, is in a stacked follow-up PR.

## How you verified

- Added `drops snapshots for synthetic, missing, or deleted threads without closing the daemon session` to `apps/server/test/desktop-browsers.test.ts`. It sends snapshots scoped to a plugin-panel id, a missing `thr_` id and a deleted thread. It asserts the socket is not closed and nothing is stored, and that a valid snapshot on the same session is still applied.
  - Before the fix: `AssertionError: plugin-panel:cloud-sandbox:cloud-machines:pane-1: expected "vi.fn()" to not be called at all, but actually been called 1 times`
  - After the fix: `pnpm exec turbo run test --filter=@bb/server -- test/desktop-browsers.test.ts` → `Tests 18 passed (18)`
- `pnpm exec turbo run typecheck --filter=@bb/server` passes.
- Found on bb Nightly `0.42.2-nightly`: `server.log` showed a `thread_not_found` "heartbeat rejected" about every 30s for the local host. Local Storage had browser-panel state for `plugin-panel:cloud-sandbox:cloud-machines:pane-1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> AGENT GENERATED
