### PR TITLE
Keep plugin-panel browser tabs out of daemon snapshots

### DIFF
--- a/apps/desktop/src/desktop-browser-broker.ts
+++ b/apps/desktop/src/desktop-browser-broker.ts
@@ -3,6 +3,7 @@ import type {
   BbDesktopBrowserControlState,
   BbDesktopBrowserTarget,
 } from "@bb/desktop-contract";
+import { isRawThreadId } from "@bb/domain";
 import type {
   DesktopBrowserChanged,
   DesktopBrowserCommand,
@@ -118,7 +119,8 @@ export function createDesktopBrowserBroker(args: {
     const serialized = JSON.stringify(event);
     if (snapshots.get(key) === serialized) return;
     snapshots.set(key, serialized);
-    for (const listener of listeners) listener(event);
+    if (isRawThreadId(threadId))
+      for (const listener of listeners) listener(event);
     if (
       instance.window.isDestroyed() ||
       instance.window.webContents.isDestroyed()

--- a/apps/desktop/test/desktop-browser-broker-snapshots.test.ts
+++ b/apps/desktop/test/desktop-browser-broker-snapshots.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Session } from "electron";
+import type { DesktopBrowserChanged } from "@bb/host-daemon-contract";
+
+vi.mock("electron", () => ({
+  BrowserWindow: class {},
+  WebContentsView: class {},
+  session: { fromPartition: () => ({}) },
+  nativeImage: { createFromBuffer: () => ({}) },
+}));
+
+import { createDesktopBrowserBroker } from "../src/desktop-browser-broker.js";
+import type {
+  DesktopBrowserNativeTab,
+  DesktopBrowserViewManager,
+} from "../src/desktop-browser-view.js";
+
+const THREAD_ID = "thr_23456789ab";
+const PLUGIN_PANEL_ID = "plugin-panel:cloud-sandbox:cloud-machines:pane-1";
+
+function nativeTab(tabId: string, threadId: string): DesktopBrowserNativeTab {
+  return {
+    tabId,
+    threadId,
+    url: "https://example.com",
+    title: "Example",
+    isLoading: false,
+    canGoBack: false,
+    canGoForward: false,
+    errorText: null,
+    generation: "tab-generation",
+    profile: { kind: "personal" },
+    presentation: "reveal",
+  };
+}
+
+function createFakeWindow() {
+  return {
+    webContents: {
+      id: 7,
+      isDestroyed: () => false,
+      send: vi.fn(),
+    },
+    isDestroyed: () => false,
+    focus: () => undefined,
+    show: () => undefined,
+    restore: () => undefined,
+    isMinimized: () => false,
+    getContentBounds: () => ({ x: 0, y: 0, width: 800, height: 600 }),
+    contentView: {
+      addChildView: () => undefined,
+      removeChildView: () => undefined,
+    },
+  };
+}
+
+describe("desktop browser broker snapshots", () => {
+  it("publishes snapshots only for real threads and keeps plugin-panel tabs local", () => {
+    let tabs = [
+      nativeTab("thread-tab", THREAD_ID),
+      nativeTab("panel-tab", PLUGIN_PANEL_ID),
+    ];
+    let notifyTabsChanged: () => void = () => undefined;
+    const manager: Pick<
+      DesktopBrowserViewManager,
+      "listTabs" | "subscribeAutomationTabs" | "profileSession" | "destroyAll"
+    > = {
+      listTabs: ({ threadId }) =>
+        tabs.filter((tab) => threadId === null || tab.threadId === threadId),
+      subscribeAutomationTabs: (listener) => {
+        notifyTabsChanged = listener;
+        return () => undefined;
+      },
+      profileSession: () => ({}) as Session,
+      destroyAll: () => undefined,
+    };
+    const broker = createDesktopBrowserBroker({
+      manager: manager as DesktopBrowserViewManager,
+      product: "Chrome/1",
+    });
+    const events: DesktopBrowserChanged[] = [];
+    broker.subscribe((event) => events.push(event));
+    const window = createFakeWindow();
+
+    broker.registerWindow(window as never);
+    broker.setHostId("host_local");
+    tabs = [
+      { ...tabs[0]!, title: "Navigated" },
+      { ...tabs[1]!, title: "Navigated" },
+    ];
+    notifyTabsChanged();
+
+    expect(events.length).toBeGreaterThan(0);
+    expect(new Set(events.map((event) => event.threadId))).toEqual(
+      new Set([THREAD_ID]),
+    );
+    expect(
+      events.flatMap((event) => event.tabs.map((tab) => tab.tabId)),
+    ).not.toContain("panel-tab");
+  });
+});

--- a/apps/desktop/test/desktop-browser-view-manager.test.ts
+++ b/apps/desktop/test/desktop-browser-view-manager.test.ts
@@ -866,6 +866,7 @@ interface AttachBrowserTabArgs {
   hostWindow: FakeHostWindow;
   manager: DesktopBrowserViewManager;
   tabId: string;
+  threadId?: string;
   url: string;
 }
 
@@ -873,7 +874,7 @@ function attachBrowserTab(args: AttachBrowserTabArgs): void {
   args.manager.attach({
     hostWindow: args.hostWindow,
     request: {
-      threadId: "thread-1",
+      threadId: args.threadId ?? "thread-1",
       tabId: args.tabId,
       url: args.url,
       bounds: { x: 100, y: 50, width: 500, height: 350 },
@@ -893,7 +894,10 @@ function requireFakeView(
   return view;
 }
 
-function createRendererRecoveryFixture(webContentsId: number) {
+function createRendererRecoveryFixture(
+  webContentsId: number,
+  threadId = "thread-1",
+) {
   const manager = createDesktopBrowserViewManager({
     partition: "persist:test",
   });
@@ -904,6 +908,7 @@ function createRendererRecoveryFixture(webContentsId: number) {
   attachBrowserTab({
     manager,
     hostWindow,
+    threadId,
     tabId: "browser:a",
     url: "https://example.com/original",
   });
@@ -1410,7 +1415,12 @@ describe("DesktopBrowserViewManager", () => {
   it.each(["local", "enrolled"])(
     "preserves same-server reconnect tabs but clears them before a different server registration (%s daemon)",
     async (daemon) => {
-      const { manager, hostWindow } = createRendererRecoveryFixture(91);
+      const threadId = "thr_23456789ab";
+      const newServerThreadId = "thr_3456789abc";
+      const { manager, hostWindow } = createRendererRecoveryFixture(
+        91,
+        threadId,
+      );
       const broker = createDesktopBrowserBroker({
         manager,
         product: "Chrome/test",
@@ -1498,7 +1508,7 @@ describe("DesktopBrowserViewManager", () => {
         client.reconnect();
         await vi.waitFor(() => expect(hasOriginalTab(2)).toBe(true));
         expect(
-          manager.listTabs({ hostWebContentsId: 91, threadId: "thread-1" }),
+          manager.listTabs({ hostWebContentsId: 91, threadId }),
         ).toHaveLength(1);
         const target = broker.getTarget(91);
         if (!target) throw new Error("Expected connected desktop");
@@ -1506,7 +1516,7 @@ describe("DesktopBrowserViewManager", () => {
           type: "desktop.browser.acquire_control",
           instanceId: target.instanceId,
           generation: target.generation,
-          threadId: "thread-1",
+          threadId,
           leaseId: "origin-lease",
           tabIds: ["browser:a"],
           controllerLabel: "Test",
@@ -1533,7 +1543,7 @@ describe("DesktopBrowserViewManager", () => {
           hostWindow,
           request: {
             tabId: "new-server-tab",
-            threadId: "thread-new",
+            threadId: newServerThreadId,
             url: "about:blank",
             bounds: { x: 0, y: 0, width: 640, height: 400 },
             visible: false,
@@ -1545,7 +1555,7 @@ describe("DesktopBrowserViewManager", () => {
               ({ peer, frame }) =>
                 peer === 3 &&
                 frame.type === "desktop-browser.changed" &&
-                frame.threadId === "thread-new",
+                frame.threadId === newServerThreadId,
             ),
           ).toBe(true),
         );
@@ -1554,7 +1564,8 @@ describe("DesktopBrowserViewManager", () => {
             .filter(({ peer }) => peer === 3)
             .every(
               ({ frame }) =>
-                frame.type === "register" || frame.threadId === "thread-new",
+                frame.type === "register" ||
+                frame.threadId === newServerThreadId,
             ),
         ).toBe(true);
         expect(hasOriginalTab(3)).toBe(false);


### PR DESCRIPTION
## Human comments

See human comments in [get-bb/bb#3450](https://github.com/get-bb/bb/pull/3450) for more context

## What was wrong

Plugin pages reuse the shared browser deck with `threadId={panelStateId}` (`PluginPanelRightPanelHost.tsx`). So a native browser tab opened in a plugin page's right panel is scoped to a synthetic id such as `plugin-panel:cloud-sandbox:cloud-machines:pane-1`. The desktop browser broker published a `desktop-browser.changed` snapshot for every scope it had seen. These synthetic scopes therefore went through the host daemon to the server, which has no thread to attach them to. #3450 makes the server drop such snapshots instead of closing the daemon session. This PR stops the desktop app sending them in the first place.

## What changed

- `apps/desktop/src/desktop-browser-broker.ts`: `publish()` notifies its daemon-bound listeners only when the scope is a real thread id (`isRawThreadId` from `@bb/domain`). Plugin-panel browser tabs stay local to the desktop app. The renderer's local control-state IPC is unchanged.
- `apps/desktop/test/desktop-browser-broker-snapshots.test.ts` (new): with one real-thread tab and one plugin-panel tab, only the real thread's snapshot is published across window registration, host connect and a tab change.
- `apps/desktop/test/desktop-browser-view-manager.test.ts`: the reconnect test checks daemon-bound snapshots, so it now uses real-format thread ids. The fixture helper gained an optional `threadId`, which still defaults to `"thread-1"` for every other test.
- No server/daemon wire change; `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

## How you verified

- New test, before the broker change: `AssertionError: expected Set{ 'thr_23456789ab', …(1) } to deeply equal Set{ 'thr_23456789ab' }`. After the change it passes.
- `pnpm exec turbo run test --filter=@bb/desktop` → `Test Files 42 passed (42)`, `Tests 318 passed | 1 skipped (319)`.
- `pnpm exec turbo run typecheck --filter=@bb/desktop` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> AGENT GENERATED
