### PR TITLE
Show human-readable timestamps in the server and daemon log viewer

### DIFF
--- a/apps/desktop/src/log-viewer.ts
+++ b/apps/desktop/src/log-viewer.ts
@@ -3,6 +3,7 @@ import { mkdir, readdir, stat } from "node:fs/promises";
 import { watch, type FSWatcher } from "node:fs";
 import { join } from "node:path";
 import { escapeHtmlText } from "@bb/domain";
+import { z } from "zod";
 import {
   LOG_VIEWER_VISIBLE_LINE_LIMIT,
   type LogViewerComponent,
@@ -15,6 +16,76 @@ export const LOG_VIEWER_IPC_BATCH_LINE_LIMIT = 250;
 const LOG_VIEWER_INITIAL_TAIL_LINES = 400;
 const LOG_VIEWER_ROTATION_POLL_INTERVAL_MS = 2_000;
 const LOG_VIEWER_COMPONENTS: LogViewerComponent[] = ["server", "host-daemon"];
+const PINO_LEVEL_LABELS = new Map<number, string>([
+  [10, "trace"],
+  [20, "debug"],
+  [30, "info"],
+  [40, "warn"],
+  [50, "error"],
+  [60, "fatal"],
+]);
+
+const pinoLogRecordSchema = z
+  .object({
+    component: z.string().optional(),
+    level: z.number(),
+    msg: z.string().optional(),
+    time: z.number(),
+  })
+  .loose();
+
+interface FormatLogLineArgs {
+  component: LogViewerComponent;
+  line: string;
+}
+
+function padNumber(value: number, length: number): string {
+  return String(value).padStart(length, "0");
+}
+
+function formatLogTimestamp(timeMs: number): string {
+  const date = new Date(timeMs);
+  const datePart = `${date.getFullYear()}-${padNumber(date.getMonth() + 1, 2)}-${padNumber(date.getDate(), 2)}`;
+  const timePart = `${padNumber(date.getHours(), 2)}:${padNumber(date.getMinutes(), 2)}:${padNumber(date.getSeconds(), 2)}.${padNumber(date.getMilliseconds(), 3)}`;
+  return `${datePart} ${timePart}`;
+}
+
+function parseJsonObject(line: string): unknown {
+  if (!line.startsWith("{")) {
+    return null;
+  }
+  try {
+    return JSON.parse(line);
+  } catch {
+    return null;
+  }
+}
+
+export function formatLogLine(args: FormatLogLineArgs): string {
+  const parsed = pinoLogRecordSchema.safeParse(parseJsonObject(args.line));
+  if (!parsed.success) {
+    return `[${args.component}] ${args.line}`;
+  }
+
+  const { component, level, msg, time, ...fields } = parsed.data;
+  const levelLabel = PINO_LEVEL_LABELS.get(level) ?? `level ${level}`;
+  const sourceLabel =
+    component === undefined || component === args.component
+      ? args.component
+      : `${args.component}:${component}`;
+  const parts = [
+    formatLogTimestamp(time),
+    `[${levelLabel}]`,
+    `[${sourceLabel}]`,
+  ];
+  if (msg !== undefined && msg.length > 0) {
+    parts.push(msg);
+  }
+  if (Object.keys(fields).length > 0) {
+    parts.push(JSON.stringify(fields));
+  }
+  return parts.join(" ");
+}
 
 interface CreateLogViewerViewUrlArgs {
   logDir: string;
@@ -506,7 +577,7 @@ export function createLogTailer(args: CreateLogTailerArgs): LogTailer {
         .filter((line) => line.length > 0)
         .map((line) => ({
           source: emitArgs.component,
-          text: `[${emitArgs.component}] ${line}`,
+          text: formatLogLine({ component: emitArgs.component, line }),
         })),
     );
   }

--- a/apps/desktop/test/log-viewer.test.ts
+++ b/apps/desktop/test/log-viewer.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   createLogLineBuffer,
   createLogTailer,
+  formatLogLine,
   resolveCurrentLogFile,
   type LogTailer,
 } from "../src/log-viewer.js";
@@ -73,6 +74,63 @@ function createTestLogLine(args: CreateTestLogLineArgs): LogViewerLine {
     text: `line-${args.index}`,
   };
 }
+
+describe("formatLogLine", () => {
+  const timeMs = new Date(2026, 8, 9, 9, 25, 50, 443).getTime();
+
+  it("renders pino records with a local timestamp, level, message, and remaining fields", () => {
+    const line = JSON.stringify({
+      level: 40,
+      time: timeMs,
+      component: "server",
+      errorCode: "host_unavailable",
+      errorDetails: { reason: "disconnected" },
+      msg: "Failed to resolve host",
+    });
+
+    expect(formatLogLine({ component: "server", line })).toBe(
+      '2026-09-09 09:25:50.443 [warn] [server] Failed to resolve host {"errorCode":"host_unavailable","errorDetails":{"reason":"disconnected"}}',
+    );
+  });
+
+  it("omits the field suffix when only core fields are present", () => {
+    const line = JSON.stringify({
+      level: 30,
+      time: timeMs,
+      component: "server",
+      msg: "Daemon WebSocket closed",
+    });
+
+    expect(formatLogLine({ component: "server", line })).toBe(
+      "2026-09-09 09:25:50.443 [info] [server] Daemon WebSocket closed",
+    );
+  });
+
+  it("keeps a sub-component that differs from the log file component", () => {
+    const line = JSON.stringify({
+      level: 50,
+      time: timeMs,
+      component: "provider",
+      msg: "boom",
+    });
+
+    expect(formatLogLine({ component: "host-daemon", line })).toBe(
+      "2026-09-09 09:25:50.443 [error] [host-daemon:provider] boom",
+    );
+  });
+
+  it("falls back to the raw line for non-pino output", () => {
+    expect(formatLogLine({ component: "server", line: "plain text" })).toBe(
+      "[server] plain text",
+    );
+    expect(formatLogLine({ component: "server", line: '{"msg":"x"}' })).toBe(
+      '[server] {"msg":"x"}',
+    );
+    expect(formatLogLine({ component: "server", line: "{not json" })).toBe(
+      "[server] {not json",
+    );
+  });
+});
 
 describe("log viewer", () => {
   it("selects the newest matching server log file", async () => {


### PR DESCRIPTION
## Human comments

## What was wrong

The desktop "Open server and daemon logs" viewer printed raw pino JSON lines prefixed with `[server]`/`[host-daemon]`, so timestamps showed as epoch milliseconds (`"time":1789079985901`) and levels as numbers (`"level":40`), making the log hard to scan.

## What changed

- `apps/desktop/src/log-viewer.ts`: new `formatLogLine` parses each tailed line as a pino record and renders `YYYY-MM-DD HH:mm:ss.SSS [level] [component] msg {remaining fields}` in local time. `component` is omitted when it matches the log file's component and shown as `[host-daemon:<sub>]` otherwise. Non-pino lines fall back to the previous `[component] <raw line>` format. Copy Logs uses the formatted text.
- No wire, CLI, or protocol changes.

Example:
```
2026-09-09 09:25:59.311 [warn] [server] Failed to resolve host for provider discovery {"errorCode":"host_unavailable","errorMessage":"Host is not connected",...}
```

## How you verified

- Added `formatLogLine` tests in `apps/desktop/test/log-viewer.test.ts` (pino formatting, core-only records, differing sub-component, non-JSON / non-pino fallback); `vitest run test/log-viewer.test.ts` passes (11 tests).
- `pnpm exec turbo run typecheck --filter=@bb/desktop` passes.
- Not yet checked manually in the running desktop app.

> AGENT GENERATED

🤖 Generated with [Claude Code](https://claude.com/claude-code)
