### PR TITLE
Fix mobile follow-up taps stopping active threads

### DIFF
--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -2398,6 +2398,80 @@ describe("PromptBoxInternal compact layout", () => {
     }
   });
 
+  it.each([false, true])(
+    "does not stop from the trailing click of a touch submit (already running: %s)",
+    (isRunning) => {
+      const restoreMatchMedia = mockPointerCoarse(true);
+      try {
+        const onSubmit = vi.fn();
+        const onStop = vi.fn();
+        const props = createPromptBoxProps({
+          value: "Send this follow-up",
+          onSubmit,
+          submission: { isRunning, onStop },
+          compact: { isCompact: true, placeholder: "Ask a follow-up" },
+        });
+        const { rerender } = render(<PromptBoxInternal {...props} />);
+        const submit = screen.getByRole("button", { name: "Submit (Enter)" });
+        vi.spyOn(submit, "getBoundingClientRect").mockReturnValue(
+          new DOMRect(0, 0, 40, 40),
+        );
+        const touch = {
+          button: 0,
+          pointerType: "touch",
+          pointerId: 1,
+          isPrimary: true,
+          clientX: 20,
+          clientY: 20,
+        };
+        fireEvent.pointerDown(submit, touch);
+        fireEvent.pointerUp(submit, touch);
+        expect(onSubmit).toHaveBeenCalledOnce();
+
+        rerender(
+          <PromptBoxInternal
+            {...props}
+            value=""
+            submission={{ isRunning: true, onStop }}
+          />,
+        );
+        const stop = screen.getByRole("button", { name: "Stop run" });
+        expect(stop).not.toBe(submit);
+        fireEvent.click(stop, { detail: 1 });
+        expect(onStop).not.toHaveBeenCalled();
+        expect(onSubmit).toHaveBeenCalledOnce();
+
+        fireEvent.pointerDown(stop, touch);
+        fireEvent.pointerUp(stop, touch);
+        fireEvent.click(stop, { detail: 1 });
+        expect(onStop).toHaveBeenCalledOnce();
+      } finally {
+        restoreMatchMedia();
+      }
+    },
+  );
+
+  it.each(["mouse", "touch", "keyboard"])(
+    "stops a run for deliberate %s activation",
+    (input) => {
+      const onStop = vi.fn();
+      render(
+        <PromptBoxInternal
+          {...createPromptBoxProps({
+            submission: { isRunning: true, onStop },
+          })}
+        />,
+      );
+      const stop = screen.getByRole("button", { name: "Stop run" });
+      if (input !== "keyboard") {
+        fireEvent.pointerDown(stop, { button: 0, pointerType: input });
+        fireEvent.pointerUp(stop, { button: 0, pointerType: input });
+      }
+      fireEvent.click(stop, { detail: input === "keyboard" ? 0 : 1 });
+      expect(onStop).toHaveBeenCalledOnce();
+    },
+  );
+
   it("starts voice input once for a deliberate touch tap on the voice action", () => {
     const restoreMatchMedia = mockPointerCoarse(true);
     try {

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -2602,6 +2602,23 @@ export function PromptBoxInternal({
     !isAttaching &&
     !hasSubmittableInput &&
     canStartVoiceInput;
+  const stopGestureButtonRef = useRef<HTMLButtonElement | null>(null);
+  const handleStopPointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLButtonElement>) => {
+      if (event.button !== 0) return;
+      stopGestureButtonRef.current = event.currentTarget;
+    },
+    [],
+  );
+  const handleStopClick = useCallback(
+    (event: ReactMouseEvent<HTMLButtonElement>) => {
+      const gestureButton = stopGestureButtonRef.current;
+      stopGestureButtonRef.current = null;
+      if (event.detail > 0 && gestureButton !== event.currentTarget) return;
+      onStop?.();
+    },
+    [onStop],
+  );
   const voiceGestureButtonRef = useRef<HTMLButtonElement | null>(null);
   const handleVoicePointerDown = useCallback(
     (event: ReactPointerEvent<HTMLButtonElement>) => {
@@ -3312,7 +3329,8 @@ export function PromptBoxInternal({
                         size="icon"
                         variant="secondary"
                         aria-label="Stop run"
-                        onClick={onStop}
+                        onPointerDown={handleStopPointerDown}
+                        onClick={handleStopClick}
                         className={
                           showCompactLayout
                             ? COMPACT_PROMPT_ACTION_BUTTON_CLASS


### PR DESCRIPTION
## Human comments

## What was wrong

Mobile submit runs on touch release. Clearing the composer during an active thread replaces Send with Stop before the browser dispatches the trailing click, so the same tap sends the follow-up and stops the thread. The existing voice-action fix guarded this replacement case for Voice, but Stop still accepted the click unconditionally.

## What changed

Require pointer clicks on Stop to originate from a pointer-down on that same button, matching the existing voice-action guard. Keyboard and accessibility activation remain available. Add regression coverage for both an already-running thread and a newly started run, plus deliberate touch, mouse, and keyboard Stop actions.

## Before / After

Current screenshots captured from the `pnpm start:worktree` build of final PR head **`4573d1f75bfca1ba180d8d6ef85d1339bf0d9965`**, using **synthetic fixture threads** and Chromium mobile touch input (390 × 844). Both use the same initial task and follow-up. Before restores only the original Stop handler in the browser response to reproduce the bug; After uses the unmodified final build. The PR head is unchanged.

| Before — trailing tap interrupts the run | After — follow-up leaves the run active |
| --- | --- |
| ![Before: synthetic mobile fixture shows interrupted sleep, Stopped manually, and an idle composer](https://raw.githubusercontent.com/get-bb/bb/a4c12074f8a36cb28b524417f3a8888f2651f0bc/before.png) | ![After: synthetic mobile fixture shows the follow-up, running sleep, Working indicator, and Stop button](https://raw.githubusercontent.com/get-bb/bb/a4c12074f8a36cb28b524417f3a8888f2651f0bc/after.png) |

Before: the real server recorded one manual-stop interruption; its pending steer then completed, leaving the captured thread idle. After: one follow-up persisted while the thread stayed active, with zero interruptions. Both captures observed trusted pointer-down/up on Steer followed by the same tap's trusted click on Stop. No screenshot contents were edited. [Capture provenance and exact baseline substitution](https://github.com/get-bb/bb/blob/a4c12074f8a36cb28b524417f3a8888f2651f0bc/README.md).

## How you verified

- Both trailing-click regressions failed before the fix and pass afterward.
- `pnpm exec turbo run test --filter=@bb/app -- src/components/promptbox/PromptBoxInternal.test.tsx src/components/promptbox/PromptBoxInternal.ipados.test.tsx src/components/promptbox/FollowUpPromptBox.test.tsx`: 169 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/app`: passed.
- Isolated source app with a real active thread and Chromium touch input at 390×844: observed trusted pointer-down/up on Steer followed by a trusted click targeting Stop. Exactly one follow-up persisted, and the thread remained active. A subsequent deliberate Stop click produced the manual-stop event and idle state.
- During the deliberate-stop check, the first tap emitted pointer events without a click; a second tap emitted the click and stopped the run. This change addresses the trailing-click interruption. Native iOS/Android were not tested.
- `pnpm start:worktree` built and started successfully for user testing; app and daemon health checks passed.

> AGENT GENERATED
