### PR TITLE
Fix new-thread machine preference persistence

### DIFF
--- a/apps/app/src/components/plugin/PluginNewThreadComposer.test.tsx
+++ b/apps/app/src/components/plugin/PluginNewThreadComposer.test.tsx
@@ -99,6 +99,16 @@ const PROJECT = makeProjectWithThreadsResponse({
       createdAt: 0,
       updatedAt: 0,
     },
+    {
+      id: "src_remote",
+      projectId: "proj_1",
+      type: "local_path",
+      hostId: "host_2",
+      path: "/remote-repo",
+      isDefault: false,
+      createdAt: 0,
+      updatedAt: 0,
+    },
   ],
 });
 
@@ -143,7 +153,10 @@ vi.mock("@/hooks/queries/sidebar-navigation-query", () => ({
 
 vi.mock("@/hooks/queries/host-queries", () => ({
   useHosts: () => ({
-    data: [{ id: "host_1", name: "Machine" }],
+    data: [
+      { id: "host_1", name: "Machine" },
+      { id: "host_2", name: "Other machine" },
+    ],
   }),
   selectPersistentHosts: <T,>(hosts: T[] | undefined) => hosts ?? [],
   selectPrimaryHost: (
@@ -570,6 +583,101 @@ describe("PluginNewThreadComposer seeding", () => {
   afterEach(() => {
     cleanup();
     vi.restoreAllMocks();
+  });
+
+  function newThreadElement(projectId: string) {
+    return (
+      <Provider>
+        <MemoryRouter>
+          <NewThreadComposer
+            projectId={projectId}
+            onProjectChange={() => undefined}
+            draftStorage={{ kind: "new-thread" }}
+            selectionScope="new-thread"
+            onSubmit={() => undefined}
+          >
+            {(composer) => composer.renderPromptBox({})}
+          </NewThreadComposer>
+        </MemoryRouter>
+      </Provider>
+    );
+  }
+
+  it("restores the environment type and machine after reload and project switching", async () => {
+    const first = render(newThreadElement("proj_1"));
+    await act(async () => {
+      latestPromptBoxProps().modeConfig.environment.onSelectProvider(
+        MANAGED_WORKTREE_SUGAR_PROVIDER,
+        "host_2",
+      );
+    });
+    expect(latestPromptBoxProps().modeConfig.environment.value).toBe(
+      "provider:git-worktree",
+    );
+    expect(
+      latestPromptBoxProps().modeConfig.environment.selectedProviderHostId,
+    ).toBe("host_2");
+    first.rerender(newThreadElement("proj_2"));
+    expect(
+      latestPromptBoxProps().modeConfig.environment.selectedProviderHostId,
+    ).toBe("host_1");
+    first.rerender(newThreadElement("proj_1"));
+    expect(latestPromptBoxProps().modeConfig.environment.value).toBe(
+      "provider:git-worktree",
+    );
+    expect(
+      latestPromptBoxProps().modeConfig.environment.selectedProviderHostId,
+    ).toBe("host_2");
+    first.unmount();
+    render(newThreadElement("proj_1"));
+    await waitFor(() => {
+      expect(latestPromptBoxProps().modeConfig.environment.value).toBe(
+        "provider:git-worktree",
+      );
+      expect(
+        latestPromptBoxProps().modeConfig.environment.selectedProviderHostId,
+      ).toBe("host_2");
+    });
+  });
+
+  it.each(["host_deleted", "host_2"])(
+    "falls back when remembered machine %s cannot run the project",
+    async (hostId) => {
+      window.localStorage.setItem(
+        "bb.promptbox.environment-proj_2-1",
+        "provider:git-worktree",
+      );
+      window.localStorage.setItem("bb.promptbox.machine-proj_2-1", hostId);
+      render(newThreadElement("proj_2"));
+      await waitFor(() => {
+        expect(latestPromptBoxProps().modeConfig.environment.value).toBe(
+          "provider:git-worktree",
+        );
+        expect(
+          latestPromptBoxProps().modeConfig.environment.selectedProviderHostId,
+        ).toBe("host_1");
+      });
+      expect(window.localStorage.getItem("bb.promptbox.machine-proj_2-1")).toBe(
+        hostId,
+      );
+    },
+  );
+
+  it("keeps a plugin composer's machine separate from the new-thread preference", async () => {
+    window.localStorage.setItem("bb.promptbox.machine-proj_1-1", "host_2");
+    renderComposer(STORED_REQUEST, () => undefined, "local-machine");
+    expect(
+      latestPromptBoxProps().modeConfig.environment.selectedProviderHostId,
+    ).toBe("host_1");
+    await act(async () => {
+      latestPromptBoxProps().modeConfig.environment.onSelectProvider(
+        CHECKOUT_PROVIDER,
+        "host_1",
+      );
+    });
+    expect(window.localStorage.getItem("bb.promptbox.machine-proj_1-1")).toBe(
+      "host_2",
+    );
   });
 
   it("round-trips a stored request submitted untouched", async () => {

--- a/apps/app/src/components/promptbox/NewThreadComposer.tsx
+++ b/apps/app/src/components/promptbox/NewThreadComposer.tsx
@@ -69,6 +69,7 @@ import {
   type PromptDraftScope,
 } from "@/hooks/usePromptDraftStorage";
 import { usePromptMentions } from "@/hooks/usePromptMentions";
+import { usePromptBoxMachinePreference } from "@/hooks/thread-creation-options/persisted-selection-fields";
 import { useThreadCreationOptions } from "@/hooks/useThreadCreationOptions";
 import { useComposerTextEffects } from "@/lib/composer-text-effects";
 import { getMutationErrorMessage } from "@/lib/mutation-errors";
@@ -489,6 +490,7 @@ export function NewThreadComposer({
     [availableHosts, environmentProviders, projectGitRemoteUrl, projectSources],
   );
   const seedSignature = JSON.stringify([
+    projectId,
     resetKey ?? null,
     seed?.providerId ?? null,
     seed?.model ?? null,
@@ -504,6 +506,8 @@ export function NewThreadComposer({
         : newThreadEnvironmentArgsToSeed(seed.environment),
     [seed?.environment],
   );
+  const { value: storedMachineId, setValue: setStoredMachineId } =
+    usePromptBoxMachinePreference(projectId);
   const [activeSeedSignature, setActiveSeedSignature] = useState(seedSignature);
   const [seedOverridden, setBranchSeedOverridden] = useState(false);
   const [pickedProviderMachine, setPickedProviderMachine] = useState<{
@@ -547,7 +551,11 @@ export function NewThreadComposer({
         environmentSeed.selectionValue === effectiveValue
           ? environmentSeed.providerMachine
           : null;
-      const candidate = picked ?? seeded;
+      const remembered: EnvironmentMachineSelection | null =
+        selectionScope === "new-thread" && storedMachineId !== ""
+          ? { type: "existing", hostId: storedMachineId }
+          : null;
+      const candidate = picked ?? seeded ?? remembered;
       if (usable(candidate?.hostId ?? null)) {
         return { provider, machine: candidate };
       }
@@ -566,6 +574,8 @@ export function NewThreadComposer({
       isProjectless,
       knownHostIds,
       pickedProviderMachine,
+      selectionScope,
+      storedMachineId,
       primaryHostId,
       projectSources,
     ],
@@ -730,12 +740,22 @@ export function NewThreadComposer({
           ? null
           : { selectionValue: value, machine: providerMachine },
       );
+      if (
+        selectionScope === "new-thread" &&
+        parseEnvironmentValue(value)?.type === "provider"
+      ) {
+        setStoredMachineId(
+          providerMachine?.type === "existing" ? providerMachine.hostId : "",
+        );
+      }
       setCreationEnvironmentSelectionValue(value);
     },
     [
       environmentSelectionValue,
       pickedProviderMachine,
       setCreationEnvironmentSelectionValue,
+      selectionScope,
+      setStoredMachineId,
       snapshotDraftBeforeOptionChange,
     ],
   );

--- a/apps/app/src/hooks/thread-creation-options/persisted-selection-fields.test.tsx
+++ b/apps/app/src/hooks/thread-creation-options/persisted-selection-fields.test.tsx
@@ -6,6 +6,7 @@ import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   usePromptBoxEnvironmentPreference,
+  usePromptBoxMachinePreference,
   usePromptBoxModelPreference,
   usePromptBoxPermissionModePreference,
   usePromptBoxProviderPreference,
@@ -69,6 +70,7 @@ function renderSelections(projectId = "project-a") {
         serviceTier: usePromptBoxServiceTierPreference(),
         permission: usePromptBoxPermissionModePreference(),
         environment: usePromptBoxEnvironmentPreference(projectId),
+        machine: usePromptBoxMachinePreference(projectId),
       };
     },
     { wrapper, initialProps: { projectId } },
@@ -76,6 +78,12 @@ function renderSelections(projectId = "project-a") {
 }
 
 const selections = [
+  {
+    field: "machine",
+    key: "bb.promptbox.machine-project-a-1",
+    initial: "host-a",
+    remote: "host-b",
+  },
   {
     field: "provider",
     key: "bb.promptbox.provider",
@@ -164,6 +172,7 @@ describe("tab-local composer selections", () => {
     rerender({ projectId: "project-b" });
     act(() => {
       result.current.environment.setValue("provider:git-worktree");
+      result.current.machine.setValue("host-b");
       window.localStorage.setItem("bb.promptbox.model-codex-1", "remote-model");
       window.localStorage.setItem("bb.promptbox.reasoning-codex-1", "low");
       window.localStorage.setItem(
@@ -176,11 +185,13 @@ describe("tab-local composer selections", () => {
     expect(result.current.model.value).toBe("model-a");
     expect(result.current.reasoning.value).toBe("high");
     expect(result.current.environment.value).toBe("provider:project-checkout");
+    expect(result.current.machine.value).toBe("host-a");
     act(() => result.current.provider.setValue("claude-code"));
     rerender({ projectId: "project-b" });
     expect(result.current.model.value).toBe("claude-model");
     expect(result.current.reasoning.value).toBe("medium");
     expect(result.current.environment.value).toBe("provider:git-worktree");
+    expect(result.current.machine.value).toBe("host-b");
   });
 
   it("pins legacy provider model and reasoning before another tab changes the legacy owner", () => {

--- a/apps/app/src/hooks/thread-creation-options/persisted-selection-fields.ts
+++ b/apps/app/src/hooks/thread-creation-options/persisted-selection-fields.ts
@@ -14,6 +14,7 @@ const SERVICE_TIER_STORAGE_KEY = "bb.promptbox.service-tier";
 const REASONING_STORAGE_KEY = "bb.promptbox.reasoning";
 const PERMISSION_MODE_STORAGE_KEY = "bb.promptbox.permission-mode";
 const ENVIRONMENT_STORAGE_KEY = "bb.promptbox.environment";
+const MACHINE_STORAGE_KEY = "bb.promptbox.machine";
 const PROVIDER_STORAGE_KEY = "bb.promptbox.provider";
 const PROVIDER_SELECTION_STORAGE_VERSION = "1";
 
@@ -214,6 +215,26 @@ const projectEnvironmentSelectionAtomFamily = atomFamily((projectId: string) =>
     { getOnInit: true },
   ),
 );
+
+const machineSelectionAtomFamily = atomFamily((projectId: string) =>
+  atomWithStorage<string>(
+    getProjectScopedStorageKey(MACHINE_STORAGE_KEY, projectId),
+    "",
+    stringSelectionStorage,
+    { getOnInit: true },
+  ),
+);
+
+export function usePromptBoxMachinePreference(
+  projectId: string,
+): PersistedStringSelectionField {
+  const [value, setAtomValue] = useAtom(machineSelectionAtomFamily(projectId));
+  const setValue = useCallback(
+    (nextValue: string) => setAtomValue(nextValue),
+    [setAtomValue],
+  );
+  return { value, setValue };
+}
 
 export function usePromptBoxProviderPreference(): PersistedStringSelectionField {
   const [value, setAtomValue] = useAtom(providerIdAtom);


### PR DESCRIPTION
## Human comments

## What was wrong

The new-thread composer persisted the environment provider but kept its selected machine only in component state. Returning to the page or reloading therefore restored the provider on the primary machine. A picked machine could also carry over when changing projects.

## What changed

Persist the selected existing machine per project using the same tab-local storage behavior as the other composer preferences. Restore it alongside the environment provider, reset transient selections when changing projects, and retain the existing fallback for deleted machines or machines without the required project checkout. Plugin composers keep their selections separate.

## How you verified

- 49 focused tests passed, including remount/reload persistence, project switching, unusable-machine fallback, tab isolation, and plugin-composer isolation.
- `pnpm exec turbo run typecheck lint --filter=@bb/app` passed (lint: no errors).
- Focused Vitest tests ran directly after the Turbo test precheck reported unrelated stale generated PWA icons; a Node 22 retry was blocked by native-module setup exiting 137.
- Live UI verification was blocked because the dev launcher requires `lsof`, which is unavailable on this host.
- Secret-model scan: working tree and push range clean, zero matches.
- SlopCop skipped at the user's request.

> AGENT GENERATED
