### PR TITLE
Split Provider Usage footer test by behavior

### DIFF
--- a/plugins/provider-usage/app.test.tsx
+++ b/plugins/provider-usage/app.test.tsx
@@ -50,9 +50,13 @@ function threadOnMachine(
   };
 }
 
+const app = await loadPluginApp(() => import("./app"));
+const item = app.experimentalSidebarFooterItems[0];
+if (item?.kind !== "disclosure") throw new Error("missing disclosure");
+
 describe("provider usage footer disclosure", () => {
-  it("aggregates every machine and keeps machine and provider selection local to the card", async () => {
-    const fetchMock = vi.fn(
+  function createFetchMock() {
+    return vi.fn(
       async (_input: RequestInfo | URL, _init?: RequestInit) =>
         new Response(
           JSON.stringify({
@@ -153,35 +157,65 @@ describe("provider usage footer disclosure", () => {
             },
           }),
           { status: 200, headers: { "content-type": "application/json" } },
-        ),
+      ),
     );
-    vi.stubGlobal("fetch", fetchMock);
-    const app = await loadPluginApp(() => import("./app"));
-    const mounted = await mountPluginContentScripts(app, {
-      pluginId: "provider-usage",
-    });
-    const item = app.experimentalSidebarFooterItems[0];
+  }
+
+  it("registers the footer disclosure", () => {
     expect(item).toMatchObject({
       kind: "disclosure",
       id: "usage",
       label: "Provider usage",
       icon: "ChartColumn",
     });
-    if (item?.kind !== "disclosure") throw new Error("missing disclosure");
+  });
 
-    await waitFor(() =>
-      expect(fetchMock).toHaveBeenCalledWith(
-        "/api/v1/plugins/provider-usage/rpc/getUsage",
+  it("preloads usage and refreshes after an extended focus loss", async () => {
+    const fetchMock = createFetchMock();
+    vi.stubGlobal("fetch", fetchMock);
+    const mounted = await mountPluginContentScripts(app, {
+      pluginId: "provider-usage",
+    });
+    try {
+      await waitFor(() =>
+        expect(fetchMock).toHaveBeenCalledWith(
+          "/api/v1/plugins/provider-usage/rpc/getUsage",
+          expect.objectContaining({
+            method: "POST",
+            body: JSON.stringify({
+              force: false,
+              machineIds: null,
+              maxAgeMs: 30 * 60_000,
+            }),
+          }),
+        ),
+      );
+
+      const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
+      window.dispatchEvent(new Event("blur"));
+      now.mockReturnValue(5 * 60_000 + 1_001);
+      const callsBeforeFocus = fetchMock.mock.calls.length;
+      window.dispatchEvent(new Event("focus"));
+      await waitFor(() =>
+        expect(fetchMock).toHaveBeenCalledTimes(callsBeforeFocus + 1),
+      );
+      expect(fetchMock.mock.calls.at(-1)?.[1]).toEqual(
         expect.objectContaining({
-          method: "POST",
           body: JSON.stringify({
             force: false,
             machineIds: null,
-            maxAgeMs: 30 * 60_000,
+            maxAgeMs: 5 * 60_000,
           }),
         }),
-      ),
-    );
+      );
+    } finally {
+      await mounted.lifecycle.dispose();
+    }
+  });
+
+  it("shows disconnected usage and scopes manual refresh to that machine", async () => {
+    const fetchMock = createFetchMock();
+    vi.stubGlobal("fetch", fetchMock);
     const dismiss = vi.fn();
     const slot = renderSlot(
       item,
@@ -189,50 +223,12 @@ describe("provider usage footer disclosure", () => {
       {
         context: { threadId: "thread-active" },
         sidebarThreads: {
-          threads: [threadOnMachine("host-m5", "M5")],
+          threads: [threadOnMachine("host-intel", "Intel")],
         },
       },
     );
-    const machinePicker = slot.getByRole("button", {
-      name: "Usage machine: M5",
-    });
-    expect(slot.getByRole("heading", { name: "Codex" })).toBeTruthy();
-    expect(slot.getByText("codex@example.com")).toBeTruthy();
-    expect(slot.getByText("97% used")).toBeTruthy();
-
-    fireEvent.pointerDown(machinePicker, { button: 0 });
-    fireEvent.click(slot.getByRole("menuitemradio", { name: "M4" }));
-    const claudeTab = slot.getByRole("tab", { name: "Claude Code" });
-    const codexTab = slot.getByRole("tab", { name: "Codex" });
     expect(
-      slot
-        .getByRole("button", { name: "Usage machine: M4" })
-        .closest('[data-provider-usage-header=""]'),
-    ).toBe(claudeTab.closest('[data-provider-usage-header=""]'));
-    expect(
-      claudeTab.querySelector("[data-provider-logo*='claude-code']"),
-    ).not.toBeNull();
-    expect(
-      codexTab.querySelector("[data-provider-logo*='/codex/']"),
-    ).not.toBeNull();
-    expect(slot.getByRole("heading", { name: "Claude Code" })).toBeTruthy();
-    expect(slot.getByText("claude@example.com")).toBeTruthy();
-    expect(slot.getByText("82% used")).toBeTruthy();
-
-    fireEvent.click(codexTab);
-    expect(slot.getByRole("heading", { name: "Codex" })).toBeTruthy();
-    expect(slot.getByText("codex@example.com")).toBeTruthy();
-    expect(slot.getByText("37% used")).toBeTruthy();
-    fireEvent.keyDown(codexTab, { key: "ArrowLeft" });
-    expect(claudeTab.getAttribute("aria-selected")).toBe("true");
-
-    fireEvent.pointerDown(
-      slot.getByRole("button", { name: "Usage machine: M4" }),
-      { button: 0 },
-    );
-    fireEvent.click(slot.getByRole("menuitemradio", { name: "Intel" }));
-    expect(
-      slot.getByText(
+      await slot.findByText(
         "Intel is offline. Usage will refresh when it reconnects.",
       ),
     ).toBeTruthy();
@@ -258,25 +254,54 @@ describe("provider usage footer disclosure", () => {
         }),
       }),
     );
+  });
 
-    const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
-    window.dispatchEvent(new Event("blur"));
-    now.mockReturnValue(5 * 60_000 + 1_001);
-    const callsBeforeFocus = fetchMock.mock.calls.length;
-    window.dispatchEvent(new Event("focus"));
-    await waitFor(() =>
-      expect(fetchMock).toHaveBeenCalledTimes(callsBeforeFocus + 1),
+  it("aggregates machines and keeps provider selection local to the card", async () => {
+    const fetchMock = createFetchMock();
+    vi.stubGlobal("fetch", fetchMock);
+    const slot = renderSlot(
+      item,
+      { dismiss: vi.fn() },
+      {
+        context: { threadId: "thread-active" },
+        sidebarThreads: {
+          threads: [threadOnMachine("host-m5", "M5")],
+        },
+      },
     );
-    expect(fetchMock.mock.calls.at(-1)?.[1]).toEqual(
-      expect.objectContaining({
-        body: JSON.stringify({
-          force: false,
-          machineIds: null,
-          maxAgeMs: 5 * 60_000,
-        }),
-      }),
-    );
+    const machinePicker = await slot.findByRole("button", {
+      name: "Usage machine: M5",
+    });
+    expect(slot.getByRole("heading", { name: "Codex" })).toBeTruthy();
+    expect(slot.getByText("codex@example.com")).toBeTruthy();
+    expect(slot.getByText("97% used")).toBeTruthy();
 
-    await mounted.lifecycle.dispose();
+    fireEvent.pointerDown(machinePicker, { button: 0 });
+    expect(slot.getByRole("menuitemradio", { name: "M5" })).toBeTruthy();
+    expect(slot.getByRole("menuitemradio", { name: "Intel" })).toBeTruthy();
+    fireEvent.click(slot.getByRole("menuitemradio", { name: "M4" }));
+    const claudeTab = slot.getByRole("tab", { name: "Claude Code" });
+    const codexTab = slot.getByRole("tab", { name: "Codex" });
+    expect(
+      slot
+        .getByRole("button", { name: "Usage machine: M4" })
+        .closest('[data-provider-usage-header=""]'),
+    ).toBe(claudeTab.closest('[data-provider-usage-header=""]'));
+    expect(
+      claudeTab.querySelector("[data-provider-logo*='claude-code']"),
+    ).not.toBeNull();
+    expect(
+      codexTab.querySelector("[data-provider-logo*='/codex/']"),
+    ).not.toBeNull();
+    expect(slot.getByRole("heading", { name: "Claude Code" })).toBeTruthy();
+    expect(slot.getByText("claude@example.com")).toBeTruthy();
+    expect(slot.getByText("82% used")).toBeTruthy();
+
+    fireEvent.click(codexTab);
+    expect(slot.getByRole("heading", { name: "Codex" })).toBeTruthy();
+    expect(slot.getByText("codex@example.com")).toBeTruthy();
+    expect(slot.getByText("37% used")).toBeTruthy();
+    fireEvent.keyDown(codexTab, { key: "ArrowLeft" });
+    expect(claudeTab.getAttribute("aria-selected")).toBe("true");
   });
 });


### PR DESCRIPTION
## Human comments

## What was wrong

The Provider Usage footer coverage put plugin import/registration, the content-script preload and focus listener lifecycle, disclosure rendering, two Radix machine-menu sessions, provider mouse and keyboard navigation, disconnected state, dismiss, manual refresh, and disposal inside one asynchronous test with the default 5-second budget. Package-shard concurrency and Vitest worker oversubscription made that serial UI sequence slow enough to expose the test architecture: the unchanged test reproduced at 6.610 seconds under bounded Intel contention and timed out at 5 seconds. The CI failure was therefore not a deterministic regression in PR #3449, and scheduler contention was the trigger rather than the root cause.

## What changed

`plugins/provider-usage/app.test.tsx` now loads and captures the plugin registration once outside test clocks, reuses one response fixture, and divides coverage into registration, content-script focus refresh, disconnected/manual refresh, and connected machine/provider interaction scenarios. Content-script disposal is protected by `finally`. The disconnected case starts from the active Intel machine, removing a second Radix menu lifecycle while the connected case still proves all machines are aggregated and exercises machine selection plus provider mouse and keyboard navigation. No assertions were disabled, no timeout was increased, and there are no wire, CLI, or documentation changes.

## How you verified

- Before: on enrolled Intel host `host_nwqfteeqz4`, a warmed run with 12 bounded CPU competitors reproduced the exact failure: 6.610 seconds and `Test timed out in 5000ms`.
- After: the same 12-worker warmed stress passed all four scenarios; the slowest scenario was 833 ms.
- After: five fresh focused iterations under 12 CPU competitors passed 20/20 scenario executions; the slowest scenario was 1.202 seconds.
- `pnpm exec turbo run test --filter=bb-plugin-provider-usage` — 3 files and 7 tests passed.
- `pnpm exec turbo run typecheck --filter=bb-plugin-provider-usage` — passed.
- `pnpm exec turbo run build --filter=bb-plugin-provider-usage` — passed the package's available upstream generator tasks; this package has no build script.
- `bb plugin build` from `plugins/provider-usage` — emitted validated server and app bundles.
- Every test/build/load command ran in a bounded process group; teardown and the final process scan found no surviving Vitest, Turbo, plugin-build, or load workers.

> AGENT GENERATED
