### PR TITLE
Drop placeholder Codex secondary limit windows in Account Pooler

### DIFF
--- a/plugins/account-pool/src/codex-adapter.test.ts
+++ b/plugins/account-pool/src/codex-adapter.test.ts
@@ -187,6 +187,84 @@ describe("codex header quotas", () => {
     expect(isQuotaExhausted(fromUsage, "other", 0.9, 2_000)).toBe(false);
   });
 
+  it("drops a placeholder secondary window with zero usage and no reset", () => {
+    const quota = adapter.quotaFromHeaders(
+      ACCOUNT_ID,
+      new Headers({
+        "x-codex-primary-used-percent": "47",
+        "x-codex-primary-window-minutes": "10080",
+        "x-codex-primary-reset-at": "4102452000",
+        "x-codex-secondary-used-percent": "0",
+        "x-codex-secondary-reset-at": "0",
+      }),
+      emptyQuota(),
+      "other",
+      5_000,
+    );
+    expect(quota.limitWindows.map((window) => window.slot)).toEqual([
+      "primary",
+    ]);
+  });
+
+  it("clears a stored placeholder window when the headers repeat it", () => {
+    const previous: AccountQuota = {
+      ...emptyQuota(),
+      limitWindows: [
+        {
+          slot: "primary",
+          windowMinutes: 10_080,
+          utilization: 0.47,
+          resetAt: 4_102_452_000_000,
+          status: null,
+          observedAt: 1_000,
+          source: "header",
+        },
+        {
+          slot: "secondary",
+          windowMinutes: null,
+          utilization: 0,
+          resetAt: 0,
+          status: null,
+          observedAt: 1_000,
+          source: "header",
+        },
+      ],
+    };
+    const quota = adapter.quotaFromHeaders(
+      ACCOUNT_ID,
+      new Headers({
+        "x-codex-primary-used-percent": "48",
+        "x-codex-secondary-used-percent": "0",
+        "x-codex-secondary-reset-at": "0",
+      }),
+      previous,
+      "other",
+      5_000,
+    );
+    expect(quota.limitWindows.map((window) => window.slot)).toEqual([
+      "primary",
+    ]);
+  });
+
+  it("keeps a zero-usage window that reports a length or a reset", () => {
+    const quota = adapter.quotaFromHeaders(
+      ACCOUNT_ID,
+      new Headers({
+        "x-codex-primary-used-percent": "0",
+        "x-codex-primary-window-minutes": "300",
+        "x-codex-secondary-used-percent": "0",
+        "x-codex-secondary-reset-after-seconds": "60",
+      }),
+      emptyQuota(),
+      "other",
+      5_000,
+    );
+    expect(quota.limitWindows.map((window) => window.slot)).toEqual([
+      "primary",
+      "secondary",
+    ]);
+  });
+
   it("reads both windows and their lengths from response headers", () => {
     const quota = adapter.quotaFromHeaders(
       ACCOUNT_ID,

--- a/plugins/account-pool/src/codex-adapter.ts
+++ b/plugins/account-pool/src/codex-adapter.ts
@@ -56,7 +56,7 @@ function numberHeader(headers: Headers, name: string): number | null {
 
 function resetAt(headers: Headers, prefix: string, now: number): number | null {
   const raw = numberHeader(headers, `${prefix}-reset-at`);
-  if (raw !== null)
+  if (raw !== null && raw > 0)
     return Math.round(raw < 1_000_000_000_000 ? raw * 1_000 : raw);
   const after = numberHeader(headers, `${prefix}-reset-after-seconds`);
   return after === null ? null : now + Math.round(after * 1_000);
@@ -95,20 +95,29 @@ function windowFromHeaders(
     usedPercent === null
       ? (previous?.utilization ?? null)
       : Math.max(0, Math.min(1, usedPercent / 100));
+  const windowMinutes =
+    minutes !== null && minutes > 0
+      ? Math.round(minutes)
+      : (previous?.windowMinutes ?? null);
+  const nextReset =
+    reset ??
+    (previous?.resetAt !== null &&
+    previous?.resetAt !== undefined &&
+    previous.resetAt > now
+      ? previous.resetAt
+      : null);
+  if (
+    windowMinutes === null &&
+    nextReset === null &&
+    !overLimit &&
+    (utilization === null || utilization === 0)
+  )
+    return null;
   return {
     slot,
-    windowMinutes:
-      minutes !== null && minutes > 0
-        ? Math.round(minutes)
-        : (previous?.windowMinutes ?? null),
+    windowMinutes,
     utilization,
-    resetAt:
-      reset ??
-      (previous?.resetAt !== null &&
-      previous?.resetAt !== undefined &&
-      previous.resetAt > now
-        ? previous.resetAt
-        : null),
+    resetAt: nextReset,
     status:
       overLimit || (utilization !== null && utilization >= 1)
         ? "rejected"


### PR DESCRIPTION
## Human comments

## What was wrong

The ChatGPT backend returns `x-codex-secondary-*` rate-limit headers alongside the weekly window even for accounts that have no secondary limit. Those headers carry `used-percent: 0`, `reset-at: 0`, and no `window-minutes`. The Codex adapter in the Account Pooler stored that as a real limit window, so the settings row showed a second pill labelled `LIMIT 2` at 0% next to the 7D pill, and the detail sheet reported a reset at the Unix epoch (rendered as "resets in 1m"). Accounts whose quota last came from the usage endpoint, which only returns `primary_window`, did not show it, which is why only one of two Codex accounts in the same pool had the extra pill.

## What changed

`plugins/account-pool/src/codex-adapter.ts`:

- A `reset-at` header that is zero or negative is treated as no reset time.
- A header-sourced window that ends up with no length, no reset, zero or unknown usage, and no over-limit flag is dropped instead of stored. Real windows always carry at least a length or a reset.
- Because the drop happens on every header pass, a placeholder already persisted in `account_quota` clears the next time the backend repeats it.

Windows at 0% that report a length or a reset are kept. No wire, CLI, or doc changes.

## How you verified

Added three tests in `plugins/account-pool/src/codex-adapter.test.ts`: the placeholder secondary window is dropped, a stored placeholder is cleared when the headers repeat it, and a zero-usage window with a length or reset is kept. The first two fail before the change.

```
pnpm exec turbo run test typecheck --filter=bb-plugin-account-pool --continue
```

275 tests pass, typecheck clean, Prettier clean. Confirmed against the live pool that the affected account's stored secondary window was exactly `{ windowMinutes: null, utilization: 0, resetAt: 0, source: "header" }`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> AGENT GENERATED
