### PR TITLE
Fix line navigation through plugin file openers

### DIFF
--- a/apps/app/bundle-budget.json
+++ b/apps/app/bundle-budget.json
@@ -46,7 +46,7 @@
     "`node scripts/why-eager.mjs --from=views/SplitWorkspaceRoute.tsx <package>`",
     "to print the static chain that pulled a package into the closure."
   ],
-  "maxBootBytes": 1723617,
+  "maxBootBytes": 1723745,
   "maxBootBrotliBytes": 429072,
   "forbiddenBootPackages": [
     "@pierre/diffs",

--- a/apps/app/src/components/plugin/PluginPanelActions.tsx
+++ b/apps/app/src/components/plugin/PluginPanelActions.tsx
@@ -327,11 +327,12 @@ function FileOpenerTabContent({
     () => parseFileOpenerParams(tab.paramsJson),
     [tab.paramsJson],
   );
-  if (
-    file === null ||
-    tab.fileOpenerOwner === undefined ||
-    original === undefined
-  ) {
+  const owner = tab.fileOpenerOwner;
+  const lineRange = useMemo(() => {
+    const range = owner?.tab.lineRange;
+    return range == null ? null : { ...range };
+  }, [owner]);
+  if (file === null || owner === undefined || original === undefined) {
     return <UnavailableFileOpenerTab />;
   }
   return (
@@ -348,6 +349,7 @@ function FileOpenerTabContent({
           <opener.component
             path={file.path}
             source={file.source}
+            experimental_lineRange={lineRange}
             Original={BoundOriginal}
             experimental_Original={deprecatedOriginalAlias(BoundOriginal)}
           />

--- a/apps/app/src/components/plugin/plugin-slot-mounts.test.tsx
+++ b/apps/app/src/components/plugin/plugin-slot-mounts.test.tsx
@@ -2039,7 +2039,14 @@ describe("plugin file opener tabs", () => {
             id: "editor",
             title: "Notes editor",
             extensions: ["md"],
-            component: MarkdownEditorProbe,
+            component: (props) => (
+              <>
+                <MarkdownEditorProbe {...props} />
+                <output data-testid="opener-target">
+                  {JSON.stringify(props.experimental_lineRange)}
+                </output>
+              </>
+            ),
           },
         ],
       }),
@@ -2084,7 +2091,108 @@ describe("plugin file opener tabs", () => {
     expect(
       screen.getByText("editor notes/todo.md @ workspace:env_1"),
     ).toBeDefined();
+    expect(screen.getByTestId("opener-target").textContent).toBe(
+      '{"startLineNumber":7,"endLineNumber":9}',
+    );
   });
+
+  it.each(["workspace", "host", "thread-storage"] as const)(
+    "forwards %s targets and refreshes only when the owner changes",
+    (kind) => {
+      const seen = vi.fn<(props: PluginFileOpenerProps) => void>();
+      setPluginSlotRegistrations(
+        "notes",
+        registrationSet({
+          fileOpeners: [
+            {
+              id: "editor",
+              title: "Notes editor",
+              extensions: ["md"],
+              component: (props) => {
+                seen(props);
+                return <div>editor</div>;
+              },
+            },
+          ],
+        }),
+      );
+      const makeTab = (
+        lineRange: { startLineNumber: number; endLineNumber: number } | null,
+      ) =>
+        buildFileOpenerPanelTab(
+          { id: "editor", pluginId: "notes" },
+          {
+            path: "notes/todo.md",
+            source: {
+              kind,
+              environmentId: "env_1",
+              projectId: null,
+              threadId: "thr_1",
+            },
+          },
+          kind === "workspace"
+            ? {
+                kind: "workspace-file-preview",
+                environmentId: "env_1",
+                projectId: null,
+                threadId: "thr_1",
+                tab: {
+                  path: "notes/todo.md",
+                  lineRange,
+                  source: { kind: "working-tree" },
+                  statusLabel: null,
+                },
+              }
+            : kind === "host"
+              ? {
+                  kind: "host-file-preview",
+                  environmentId: "env_1",
+                  hostId: null,
+                  threadId: "thr_1",
+                  tab: { path: "notes/todo.md", lineRange },
+                }
+              : {
+                  kind: "thread-storage-file-preview",
+                  environmentId: "env_1",
+                  threadId: "thr_1",
+                  tab: { path: "notes/todo.md", lineRange },
+                },
+        );
+      let tab = makeTab({ startLineNumber: 12, endLineNumber: 12 });
+      const content = () => (
+        <PluginPanelTabContent
+          tab={tab}
+          context={{ kind: "thread", threadId: "thr_1" }}
+          fileOpenerOriginal={<div>native</div>}
+        />
+      );
+      const mounted = render(content());
+      const first = seen.mock.lastCall?.[0];
+      expect(first?.experimental_lineRange).toEqual({
+        startLineNumber: 12,
+        endLineNumber: 12,
+      });
+      mounted.rerender(content());
+      expect(seen.mock.lastCall?.[0].experimental_lineRange).toBe(
+        first?.experimental_lineRange,
+      );
+      tab = makeTab({ startLineNumber: 12, endLineNumber: 12 });
+      mounted.rerender(content());
+      expect(seen.mock.lastCall?.[0].experimental_lineRange).not.toBe(
+        first?.experimental_lineRange,
+      );
+      expect(seen.mock.lastCall?.[0].source).toBe(first?.source);
+      tab = makeTab({ startLineNumber: 20, endLineNumber: 24 });
+      mounted.rerender(content());
+      expect(seen.mock.lastCall?.[0].experimental_lineRange).toEqual({
+        startLineNumber: 20,
+        endLineNumber: 24,
+      });
+      tab = makeTab(null);
+      mounted.rerender(content());
+      expect(seen.mock.lastCall?.[0].experimental_lineRange).toBeNull();
+    },
+  );
 
   it("lets an opener delegate to the exact native preview node", () => {
     function DelegatingEditor({ Original }: PluginFileOpenerProps) {

--- a/apps/app/src/components/secondary-panel/useThreadFileTabs.test.ts
+++ b/apps/app/src/components/secondary-panel/useThreadFileTabs.test.ts
@@ -1028,6 +1028,40 @@ describe("useThreadFileTabs file opener diversion", () => {
     });
   });
 
+  it("refreshes an identical target in the active opener tab", () => {
+    registerNotesOpener();
+    const { result } = renderThreadHook(() =>
+      useThreadFileTabs({
+        panelStateId: "opener-repeat",
+        syncThreadId: "opener-repeat",
+        environmentId: "env_1",
+        storageFiles: undefined,
+        terminalSessions: undefined,
+      }),
+    );
+    const open = () =>
+      result.current.openTab({
+        kind: "workspace-file-preview",
+        tab: {
+          lineRange: { startLineNumber: 15, endLineNumber: 15 },
+          path: "notes/todo.md",
+          source: { kind: "working-tree" },
+          statusLabel: null,
+        },
+      });
+    act(open);
+    const first = result.current.activePluginPanelTab;
+    act(open);
+    expect(result.current.activePluginPanelTab?.id).toBe(first?.id);
+    expect(result.current.activePluginPanelTab?.fileOpenerOwner).not.toBe(
+      first?.fileOpenerOwner,
+    );
+    expect(result.current.activeWorkspaceFileLineRange).toEqual({
+      startLineNumber: 15,
+      endLineNumber: 15,
+    });
+  });
+
   it("preserves native host and thread-storage preview state", () => {
     registerNotesOpener();
     const { result } = renderThreadHook(() =>

--- a/apps/app/src/lib/live-file-navigation.test.ts
+++ b/apps/app/src/lib/live-file-navigation.test.ts
@@ -96,6 +96,49 @@ describe("normalizeExperimentalFileOpenOptions", () => {
     ).toBeNull();
   });
 
+  it.each([0, -1, 1.5, NaN, Infinity, Number.MAX_SAFE_INTEGER + 1, "12", null])(
+    "rejects invalid line, range endpoint, and column values: %s",
+    (value) => {
+      const target = {
+        kind: "workspace",
+        environmentId: "env_1",
+        path: "src/app.tsx",
+      };
+      for (const location of [
+        { kind: "line", line: value, column: null },
+        { kind: "range", startLine: value, endLine: 20 },
+        { kind: "range", startLine: 1, endLine: value },
+        ...(value === null ? [] : [{ kind: "line", line: 12, column: value }]),
+      ]) {
+        expect(
+          normalizeExperimentalFileOpenOptions({ target, location }),
+        ).toBeNull();
+      }
+    },
+  );
+
+  it("preserves ranges and explicit absence at the preview boundary", () => {
+    const target = {
+      kind: "workspace",
+      environmentId: "env_1",
+      path: "src/app.tsx",
+    };
+    const location = { kind: "range" as const, startLine: 7, endLine: 9 };
+    expect(normalizeExperimentalFileOpenOptions({ target, location })).toEqual({
+      target,
+      location,
+    });
+    expect(toFilePreviewLineRange(location)).toEqual({
+      startLineNumber: 7,
+      endLineNumber: 9,
+    });
+    expect(
+      normalizeExperimentalFileOpenOptions({ target, location: null }),
+    ).toEqual({ target, location: null });
+    expect(toFilePreviewLineRange(null)).toBeNull();
+    expect(normalizeExperimentalFileOpenOptions({ target })).toBeNull();
+  });
+
   it("maps a valid line location to the existing preview range", () => {
     expect(
       toFilePreviewLineRange({ kind: "line", line: 42, column: 7 }),

--- a/apps/server/test/services/plugins/plugin-authoring-docs.test.ts
+++ b/apps/server/test/services/plugins/plugin-authoring-docs.test.ts
@@ -230,7 +230,9 @@ const THREAD_EVENT_PAYLOAD_FIELDS = {
     "attemptNumber",
   ],
 } as const satisfies {
-  [E in keyof PluginThreadEventPayloads]: readonly (keyof PluginThreadEventPayloads[E])[];
+  [
+    E in keyof PluginThreadEventPayloads
+  ]: readonly (keyof PluginThreadEventPayloads[E])[];
 };
 
 type MissingThreadEventField = {
@@ -347,7 +349,13 @@ const FRONTEND_SLOT_PROP_FIELDS = {
     "projectId",
     "isCompactViewport",
   ],
-  fileOpener: ["path", "source", "Original", "experimental_Original"],
+  fileOpener: [
+    "path",
+    "source",
+    "experimental_lineRange",
+    "Original",
+    "experimental_Original",
+  ],
   experimental_sourceCodeRenderer: [
     "content",
     "path",

--- a/docs/api_to_audit.md
+++ b/docs/api_to_audit.md
@@ -2567,3 +2567,30 @@ routing; malformed context does not fall back to the ambient workspace.
 Explicit absolute paths retain existing host-file behavior. HTML is unaffected.
 Stabilize after plugin consumers verify nested paths, source identity, missing
 files, containment and line locations, then rename and remove this audit entry.
+
+## `PluginFileOpenerProps.experimental_lineRange` (`@get-bb/plugin-sdk/app`)
+
+**What it does.** Passes the owning file tab's latest one-based, inclusive
+`{ startLineNumber, endLineNumber }` range to its opener. `null` means no
+requested navigation; older hosts may omit the optional property. The app
+supplies a new object on each targeted open, even when the active file and
+line numbers match. Openers should observe that identity, reveal the latest
+range after asynchronous loading, and navigate without replacing an existing
+editor model. Monaco selects the complete lines and clamps targets past EOF.
+Columns are not part of the existing preview range contract.
+
+The range uses the existing tab owner and persistence policy. This adds no
+RPC fields, server-daemon messages, file permissions, or new CLI syntax.
+Existing `bb thread open <thread> <path> --line <line>` / SDK thread-open requests
+and plugin file navigation feed the same opener boundary.
+
+**Audit before stabilizing.**
+
+1. Verify first, changed, identical, and rapid targets across workspace, host,
+   and thread-storage files, tab remounts, and server synchronization.
+2. Validate the identity-based repeat signal with third-party openers and
+   decide whether an explicit request sequence is needed before stabilization.
+3. Confirm absent-target, inclusive selection, EOF clamping, column support,
+   file-tree navigation, and unsaved-edit behavior with more editor consumers.
+4. Verify older hosts omit the prop safely and older plugins ignore it; audit
+   reload restoration and cross-client range updates under the existing tab policy.

--- a/packages/client-core/src/panel/secondaryPanelTabState.ts
+++ b/packages/client-core/src/panel/secondaryPanelTabState.ts
@@ -236,6 +236,7 @@ function getPreviousActiveTabIdAfterActivation({
 function upsertSecondaryPanelTab(
   tabs: readonly FixedPanelTab[],
   tab: FixedPanelTab,
+  refreshTarget: boolean,
 ): readonly FixedPanelTab[] {
   const existingTabIndex = tabs.findIndex(
     (currentTab) => currentTab.id === tab.id,
@@ -245,7 +246,11 @@ function upsertSecondaryPanelTab(
   }
 
   const existingTab = tabs[existingTabIndex];
-  if (existingTab && areFixedPanelTabsEquivalent(existingTab, tab)) {
+  if (
+    !refreshTarget &&
+    existingTab &&
+    areFixedPanelTabsEquivalent(existingTab, tab)
+  ) {
     return tabs;
   }
 
@@ -266,7 +271,13 @@ export function openSecondaryPanelTabInState({
   state,
   tab,
 }: OpenSecondaryPanelTabInStateArgs): FixedPanelTabsState {
-  const tabs = upsertSecondaryPanelTab(state.secondary.tabs, tab);
+  const refreshTarget =
+    tab.kind === "plugin-panel" && tab.fileOpenerOwner?.tab.lineRange != null;
+  const tabs = upsertSecondaryPanelTab(
+    state.secondary.tabs,
+    tab,
+    refreshTarget,
+  );
   if (
     tabs === state.secondary.tabs &&
     state.secondary.activeTabId === tab.id &&
@@ -307,7 +318,7 @@ export function replaceNewTabWithSecondaryPanelTabInState({
 
   const tabs =
     newTab === null
-      ? upsertSecondaryPanelTab(tabsWithoutNewTab, tab)
+      ? upsertSecondaryPanelTab(tabsWithoutNewTab, tab, false)
       : state.secondary.tabs.map((currentTab) =>
           currentTab.id === newTab.id ? tab : currentTab,
         );
@@ -325,7 +336,7 @@ export function updateSecondaryPanelTabInState({
   state,
   tab,
 }: UpdateSecondaryPanelTabInStateArgs): FixedPanelTabsState {
-  const tabs = upsertSecondaryPanelTab(state.secondary.tabs, tab);
+  const tabs = upsertSecondaryPanelTab(state.secondary.tabs, tab, false);
   if (tabs === state.secondary.tabs) {
     return state;
   }

--- a/packages/domain/src/plugin-sdk-version.ts
+++ b/packages/domain/src/plugin-sdk-version.ts
@@ -1,3 +1,3 @@
-export const PLUGIN_SDK_VERSION = "0.4.55";
+export const PLUGIN_SDK_VERSION = "0.4.56";
 
 export const PLUGIN_SDK_MAJOR = Number(PLUGIN_SDK_VERSION.split(".", 1)[0]);

--- a/packages/plugin-api-map/src/surfaces.ts
+++ b/packages/plugin-api-map/src/surfaces.ts
@@ -244,9 +244,10 @@ export const SURFACE_GROUPS: SurfaceGroup[] = [
           "Declare the file extensions it handles, for example `.csv` or `.excalidraw`",
           "Render its own viewer or editor whenever a file of that type is opened in bb",
           "Receive the file's path, then read it however the plugin already reads files",
+          "Reveal linked lines with experimental_lineRange, including repeated targets in an already open editor",
         ],
-        apiSymbols: ["PluginFileOpenerRegistration"],
-        firstParty: ["Docs"],
+        apiSymbols: ["PluginFileOpenerRegistration", "PluginFileOpenerProps"],
+        firstParty: ["Docs", "File Editor"],
       },
       {
         id: "app-overlay",

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@get-bb/plugin-sdk",
-  "version": "0.4.55",
+  "version": "0.4.56",
   "homepage": "https://github.com/get-bb/bb#readme",
   "bugs": {
     "url": "https://github.com/get-bb/bb/issues"

--- a/packages/plugin-sdk/src/app-contract.ts
+++ b/packages/plugin-sdk/src/app-contract.ts
@@ -252,6 +252,18 @@ export interface PluginFileOpenerProps {
   path: string;
   source: PluginFileOpenerSource;
   /**
+   * One-based, inclusive lines requested by the latest file open, or null when
+   * untargeted. BB supplies a new object for each targeted open, including an
+   * identical target in the active tab. Observe object identity to navigate
+   * again; keep the editor model intact. Older hosts may omit this prop.
+   *
+   * @experimental Audit navigation, remount, and persistence semantics before stabilizing.
+   */
+  experimental_lineRange?: {
+    startLineNumber: number;
+    endLineNumber: number;
+  } | null;
+  /**
    * BB's file preview, bound to this file. Render it to delegate conditionally
    * without re-entering plugin replacement resolution.
    *

--- a/plugins/bb-guide/skills/bb-plugin-authoring/references/frontend-core-slots.md
+++ b/plugins/bb-guide/skills/bb-plugin-authoring/references/frontend-core-slots.md
@@ -237,7 +237,7 @@ target? })`. Inside the fixed-tab component,
   `experimental_activate`, and `experimental_Original`. Search activation opens
   the quick palette. No inline search field or query state exists. BB keeps the
   drawer, thread list, footer, resize handle, and shortcut ownership.
-- `fileOpener` → `{ path: string, source, Original }` — register as a viewer/editor
+- `fileOpener` → `{ path: string, source, experimental_lineRange?, Original }` — register as a viewer/editor
   for file extensions: `{ id, title, extensions: ["md"], component }`.
   Matching files use the first applicable opener in deterministic slot order
   by default. Users can pin BB's preview or a specific opener per extension
@@ -252,6 +252,12 @@ projectId, experimental_hostId? }` (nullable fields). The optional host ID
   selects a project-backed workspace host and persists in opener-tab parameters.
   The `path` follows the source (workspace:
   worktree-relative; host: absolute; thread-storage: storage-relative).
+  `experimental_lineRange` (SDK 0.4.56) is a nullable, one-based inclusive
+  `{ startLineNumber, endLineNumber }` target; older hosts may omit it. Observe
+  object identity: each targeted open supplies a new object, including an
+  identical range in the active tab. Apply the latest target after loading
+  and on subsequent requests without replacing the editor model; null means
+  no requested navigation.
   `Original` is BB's preview bound to this file; render it to
   delegate conditionally without re-entering plugin replacement resolution.
   Applies only to live file content — git-ref snapshots and deleted files

--- a/plugins/monaco-editor/app.test.tsx
+++ b/plugins/monaco-editor/app.test.tsx
@@ -1,0 +1,194 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { loadPluginApp, renderSlot } from "@get-bb/plugin-sdk/testing/app";
+import type { PluginFileOpenerProps } from "@get-bb/plugin-sdk/app";
+
+const editor = vi.hoisted(() => ({
+  setSelection: vi.fn(),
+  revealRangeInCenter: vi.fn(),
+  focus: vi.fn(),
+  getModel: vi.fn(() => ({
+    getLineCount: () => 160,
+    getLineMaxColumn: () => 42,
+    dispose: vi.fn(),
+  })),
+  onDidFocusEditorWidget: vi.fn(),
+  onDidChangeModelContent: vi.fn(),
+  addCommand: vi.fn(),
+  updateOptions: vi.fn(),
+  dispose: vi.fn(),
+}));
+const create = vi.hoisted(() => vi.fn(() => editor));
+vi.mock("./lib/monaco-loader.js", () => ({
+  loadMonaco: async () => ({
+    editor: { create },
+    KeyMod: { CtrlCmd: 1 },
+    KeyCode: { KeyS: 2 },
+  }),
+  overflowWidgetsNode: () => document.body,
+  setOverflowWidgetsTheme: vi.fn(),
+}));
+vi.mock("./lib/monaco-theme.js", () => ({
+  applyCodeTheme: () => ({ name: "test", base: "vs-dark" }),
+  editorBackground: () => "black",
+}));
+
+const app = await loadPluginApp(() => import("./app"));
+const registration = app.fileOpeners[0]!;
+const Component = registration.component;
+const base: PluginFileOpenerProps = {
+  path: "target.ts",
+  source: {
+    kind: "workspace",
+    environmentId: "env_1",
+    projectId: null,
+    threadId: null,
+  },
+  Original: () => <div>native</div>,
+};
+const file = {
+  kind: "text",
+  content: "fixture",
+  sha256: "hash",
+  absolutePath: "/fixture/target.ts",
+  relativePath: "target.ts",
+};
+function mount(
+  range: PluginFileOpenerProps["experimental_lineRange"],
+  read: () => unknown = () => file,
+) {
+  return renderSlot(
+    registration,
+    { ...base, experimental_lineRange: range },
+    {
+      rpc: { assets: () => ({ baseUrl: "/assets", expiresAtMs: 99999 }), read },
+    },
+  );
+}
+const range = (startLineNumber: number, endLineNumber = startLineNumber) => ({
+  startLineNumber,
+  endLineNumber,
+});
+
+beforeEach(() => vi.clearAllMocks());
+afterEach(cleanup);
+
+it.each([range(80), range(120, 124)])(
+  "selects and reveals the initial target %j after loading",
+  async (target) => {
+    mount(target);
+    await waitFor(() =>
+      expect(editor.setSelection).toHaveBeenCalledWith({
+        ...target,
+        startColumn: 1,
+        endColumn: 42,
+      }),
+    );
+    expect(editor.revealRangeInCenter).toHaveBeenCalledWith({
+      ...target,
+      startColumn: 1,
+      endColumn: 42,
+    });
+  },
+);
+
+it.each([null, undefined])(
+  "leaves an untargeted initial open alone (%s)",
+  async (target) => {
+    mount(target);
+    await waitFor(() => expect(create).toHaveBeenCalledOnce());
+    expect(editor.setSelection).not.toHaveBeenCalled();
+  },
+);
+
+it("navigates changed and repeated targets without recreating the editor", async () => {
+  const slot = mount(range(80));
+  await waitFor(() => expect(create).toHaveBeenCalledOnce());
+  const target = range(120, 124);
+  slot.lifecycle.rerender(
+    <Component {...base} experimental_lineRange={target} />,
+  );
+  await waitFor(() =>
+    expect(editor.setSelection).toHaveBeenLastCalledWith({
+      ...target,
+      startColumn: 1,
+      endColumn: 42,
+    }),
+  );
+  editor.setSelection.mockClear();
+  slot.lifecycle.rerender(
+    <Component {...base} experimental_lineRange={target} />,
+  );
+  expect(editor.setSelection).not.toHaveBeenCalled();
+  slot.lifecycle.rerender(
+    <Component {...base} experimental_lineRange={{ ...target }} />,
+  );
+  expect(editor.setSelection).toHaveBeenCalledOnce();
+  slot.lifecycle.rerender(
+    <Component {...base} experimental_lineRange={null} />,
+  );
+  expect(editor.setSelection).toHaveBeenCalledOnce();
+  expect(create).toHaveBeenCalledOnce();
+  expect(editor.dispose).not.toHaveBeenCalled();
+});
+
+it("uses only the latest target when several arrive before the file loads", async () => {
+  let resolveRead = (_value: typeof file) => {};
+  const pending = new Promise<typeof file>((resolve) => {
+    resolveRead = resolve;
+  });
+  const slot = mount(range(30), () => pending);
+  slot.lifecycle.rerender(
+    <Component {...base} experimental_lineRange={range(90)} />,
+  );
+  slot.lifecycle.rerender(
+    <Component {...base} experimental_lineRange={range(140)} />,
+  );
+  await act(async () => resolveRead(file));
+  await waitFor(() => expect(editor.setSelection).toHaveBeenCalledOnce());
+  expect(editor.setSelection).toHaveBeenLastCalledWith({
+    ...range(140),
+    startColumn: 1,
+    endColumn: 42,
+  });
+  expect(create).toHaveBeenCalledOnce();
+});
+
+it("clamps a target beyond EOF to the final line", async () => {
+  mount(range(200, 220));
+  await waitFor(() =>
+    expect(editor.setSelection).toHaveBeenCalledWith({
+      ...range(160),
+      startColumn: 1,
+      endColumn: 42,
+    }),
+  );
+});
+
+it("does not create or navigate a disposed loading editor", async () => {
+  let resolveRead = (_value: typeof file) => {};
+  const pending = new Promise<typeof file>((resolve) => {
+    resolveRead = resolve;
+  });
+  const slot = mount(range(80), () => pending);
+  slot.lifecycle.unmount();
+  await act(async () => resolveRead(file));
+  expect(create).not.toHaveBeenCalled();
+  expect(editor.setSelection).not.toHaveBeenCalled();
+});
+
+it("does not apply a stale target cleared during loading", async () => {
+  let resolveRead = (_value: typeof file) => {};
+  const pending = new Promise<typeof file>((resolve) => {
+    resolveRead = resolve;
+  });
+  const slot = mount(range(80), () => pending);
+  slot.lifecycle.rerender(
+    <Component {...base} experimental_lineRange={null} />,
+  );
+  await act(async () => resolveRead(file));
+  await waitFor(() => expect(create).toHaveBeenCalledOnce());
+  expect(editor.setSelection).not.toHaveBeenCalled();
+});

--- a/plugins/monaco-editor/app.tsx
+++ b/plugins/monaco-editor/app.tsx
@@ -33,7 +33,33 @@ type SaveState =
   | { kind: "error"; message: string }
   | { kind: "conflict" };
 
-function MonacoFileOpener({ path, source, Original }: PluginFileOpenerProps) {
+function revealLineRange(
+  editor: MonacoNs.editor.IStandaloneCodeEditor,
+  lineRange: PluginFileOpenerProps["experimental_lineRange"],
+) {
+  const model = editor.getModel();
+  if (lineRange == null || model === null) return;
+  const startLineNumber = Math.min(
+    lineRange.startLineNumber,
+    model.getLineCount(),
+  );
+  const endLineNumber = Math.min(lineRange.endLineNumber, model.getLineCount());
+  const selection = {
+    startLineNumber,
+    startColumn: 1,
+    endLineNumber,
+    endColumn: model.getLineMaxColumn(endLineNumber),
+  };
+  editor.setSelection(selection);
+  editor.revealRangeInCenter(selection);
+}
+
+function MonacoFileOpener({
+  path,
+  source,
+  Original,
+  experimental_lineRange,
+}: PluginFileOpenerProps) {
   const rpc = useRpc<typeof rpcContract>();
   const codeTheme = experimental_useCodeTheme();
   const codeThemeRef = useRef(codeTheme);
@@ -41,6 +67,8 @@ function MonacoFileOpener({ path, source, Original }: PluginFileOpenerProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const monacoRef = useRef<typeof MonacoNs | null>(null);
   const editorRef = useRef<MonacoNs.editor.IStandaloneCodeEditor | null>(null);
+
+  const navigationRef = useRef({ path, lineRange: experimental_lineRange });
 
   const [activePath, setActivePath] = useState(path);
   useEffect(() => setActivePath(path), [path]);
@@ -251,6 +279,9 @@ function MonacoFileOpener({ path, source, Original }: PluginFileOpenerProps) {
           overflowWidgetsDomNode: overflowWidgetsNode(),
         });
         editorRef.current = editor;
+        if (activePath === navigationRef.current.path) {
+          revealLineRange(editor, navigationRef.current.lineRange);
+        }
         const active = {
           editor,
           absolutePath: file.absolutePath,
@@ -287,6 +318,14 @@ function MonacoFileOpener({ path, source, Original }: PluginFileOpenerProps) {
       editorRef.current = null;
     };
   }, [activePath, rpc, setSaveState, source]);
+
+  useEffect(() => {
+    navigationRef.current = { path, lineRange: experimental_lineRange };
+    const editor = editorRef.current;
+    if (editor !== null && activePath === path) {
+      revealLineRange(editor, experimental_lineRange);
+    }
+  }, [activePath, path, experimental_lineRange]);
 
   useEffect(() => {
     const monaco = monacoRef.current;


### PR DESCRIPTION
## Human comments

## What was wrong

File-opener tabs retained a linked line range in their owner, but the plugin props and mount omitted it. Monaco therefore opened line-linked files at the top and could not navigate subsequent targets. Tab equivalence also discarded identical targeted opens of an already active file. This reproduces on pristine main at `b04091eca6` through a real seeded plugin: clicking line 80 and then range 120–124 leaves Monaco at line 1. See #2770 and its [investigation report](https://get-bb.github.io/reports/issues/2770.html).

## What changed

- Add optional `PluginFileOpenerProps.experimental_lineRange` and forward the owner's one-based, inclusive range. Each targeted open supplies a new range object so plugins can observe identical repeat requests.
- Preserve explicit targeted opener requests through tab deduplication while retaining tab identity and general persistence/equality behavior.
- Apply the latest target after Monaco finishes loading and on subsequent requests, selecting/revealing lines without recreating the editor or losing unsaved edits. Clamp targets past EOF and leave untargeted opens alone.
- Update the existing Plugin Guide card, authoring skill, exhaustive prop inventory, and API audit entry. Bump the Plugin SDK to 0.4.56 for the new public surface. The prop remains experimental and older hosts may omit it.

The boot payload measures 1,723,696 raw bytes, 79 bytes over the existing limit. Increase only the raw boot budget by 128 bytes (to 1,723,745) to accommodate the targeted-navigation handling. Compressed and route budgets and forbidden-package guards remain unchanged; the bundle gate passes.

The identical-target refresh extends the issue's proposed forwarding fix. No server-daemon wire changes, authentication or containment changes, or new CLI syntax; no `HOST_DAEMON_PROTOCOL_VERSION` bump is required. Existing SDK/CLI thread-open requests reach the same fixed boundary.

## How you verified

- Added fail-before regressions: two app tests failed at prop forwarding and identical-request retention; five Monaco tests failed at initial/repeated/pending/EOF navigation. All now pass.
- 862 focused and adjacent tests passed across 72 files: app 241, Monaco 34, client core 264, Plugin API map 74, Plugin SDK 249. Covers line/range/absent/invalid targets, workspace/host/storage prop forwarding, repeated requests, pending target changes and cancellation, tab synchronization, Markdown parsing, and app WebSocket signals.
- `pnpm exec turbo run build typecheck lint --filter=@bb/app --filter=@bb/client-core --filter=@get-bb/plugin-sdk --filter=@bb/plugin-api-map --filter=bb-plugin-monaco-editor --filter=bb-plugin-plugin-api-docs` passed; reran Monaco test/typecheck after the final refinement. SDK declarations and Monaco/Guide plugin bundles build successfully.
- After reproducing the CI failures locally, the SDK version gate passed, all 111 tasks in the full `pnpm exec turbo run build typecheck lint --concurrency=4` run passed, and the server authoring-contract tests (22) and SDK version test (1) passed.
- Formatting and `git diff --check` passed. Lint has zero errors and existing warnings.
- Started `pnpm start:worktree` in an isolated persistent BB terminal and drove the real installed plugin with dev-browser. Before/after screenshots and actual Monaco selections confirm initial line 80, range 120–124, identical repeats after moving the cursor, and rapid targets ending at line 140. With the read RPC delayed 700 ms, only the latest target is selected. An unsaved edit survives with the same editor/model IDs.
- Verified CLI `thread open ... --line 65`, identical repeat, reload restoration, and the updated Guide card. Live traversal, untrusted-Origin, and line-zero requests remain rejected. Final served Monaco bundle hash matches a fresh source build.

Native platforms were not exercised. A Monaco close/disposal console exception also reproduces with the unchanged main plugin bundle; this patch leaves that pre-existing disposal behavior unchanged. Detailed logs, screenshots, and the seeded verification environment are retained in the originating BB thread.

Fixes #2770

> AGENT GENERATED
