### PR TITLE
Fix Codex Fast reset and stale defaults after queued dispatch

### DIFF
--- a/apps/app/bundle-budget.json
+++ b/apps/app/bundle-budget.json
@@ -46,7 +46,7 @@
     "`node scripts/why-eager.mjs --from=views/SplitWorkspaceRoute.tsx <package>`",
     "to print the static chain that pulled a package into the closure."
   ],
-  "maxBootBytes": 1723617,
+  "maxBootBytes": 1723745,
   "maxBootBrotliBytes": 429072,
   "forbiddenBootPackages": [
     "@pierre/diffs",

--- a/apps/app/src/hooks/cache-owners/realtime-cache-registry.ts
+++ b/apps/app/src/hooks/cache-owners/realtime-cache-registry.ts
@@ -347,8 +347,7 @@ export const REALTIME_THREAD_CHANGE_REGISTRY = {
       dirtyThreadSearchQueriesForCompletedTurn,
       dirtyThreadTimelineQueries,
       dirtyThreadPullRequestQueryForCompletedTurn,
-      dirtyThreadPromptHistoryQueriesForTurnRequests,
-      dirtyThreadExecutionOptionsForTurnRequests,
+      dirtyThreadTurnRequestQueries,
     ],
   },
   "history-rewritten": {
@@ -883,7 +882,7 @@ function dirtyThreadTimelineQueries({
   }
 }
 
-function dirtyThreadExecutionOptionsForTurnRequests({
+function dirtyThreadTurnRequestQueries({
   eventTypes,
   queryClient,
   threadId,
@@ -891,17 +890,10 @@ function dirtyThreadExecutionOptionsForTurnRequests({
   if (!threadId || !eventTypes?.includes("client/turn/requested")) return [];
   const queryKey = threadDefaultExecutionOptionsQueryKey(threadId);
   void queryClient.cancelQueries({ queryKey });
-  return [queryKey];
-}
-
-function dirtyThreadPromptHistoryQueriesForTurnRequests({
-  eventTypes,
-  threadId,
-}: ThreadRealtimeDirtyContext): QueryKey[] {
-  if (!eventTypes?.includes("client/turn/requested")) {
-    return [];
-  }
-  return getThreadPromptHistoryInvalidationQueryKeys({ threadId });
+  return [
+    queryKey,
+    ...getThreadPromptHistoryInvalidationQueryKeys({ threadId }),
+  ];
 }
 
 function dirtyThreadPullRequestQueryForCompletedTurn({

--- a/apps/app/src/hooks/cache-owners/realtime-cache-registry.ts
+++ b/apps/app/src/hooks/cache-owners/realtime-cache-registry.ts
@@ -348,6 +348,7 @@ export const REALTIME_THREAD_CHANGE_REGISTRY = {
       dirtyThreadTimelineQueries,
       dirtyThreadPullRequestQueryForCompletedTurn,
       dirtyThreadPromptHistoryQueriesForTurnRequests,
+      dirtyThreadExecutionOptionsForTurnRequests,
     ],
   },
   "history-rewritten": {
@@ -880,6 +881,17 @@ function dirtyThreadTimelineQueries({
       queryKeys: outlineQueryKeys,
     });
   }
+}
+
+function dirtyThreadExecutionOptionsForTurnRequests({
+  eventTypes,
+  queryClient,
+  threadId,
+}: ThreadRealtimeDirtyContext): QueryKey[] {
+  if (!threadId || !eventTypes?.includes("client/turn/requested")) return [];
+  const queryKey = threadDefaultExecutionOptionsQueryKey(threadId);
+  void queryClient.cancelQueries({ queryKey });
+  return [queryKey];
 }
 
 function dirtyThreadPromptHistoryQueriesForTurnRequests({

--- a/apps/app/src/hooks/queries/thread-default-execution-options-query.test.tsx
+++ b/apps/app/src/hooks/queries/thread-default-execution-options-query.test.tsx
@@ -1,7 +1,12 @@
 // @vitest-environment jsdom
-import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import type { ResolvedThreadExecutionOptions } from "@bb/domain";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { threadDefaultExecutionOptionsQueryKey } from "./query-keys";
+import {
+  readCachedThreadExecutionOptions,
+  threadExecutionOptionsCacheKey,
+} from "@/lib/thread-execution-options-cache";
 import { sdk } from "@/lib/sdk";
 import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
 import { useThreadDefaultExecutionOptions } from "./thread-default-execution-options-query";
@@ -101,6 +106,39 @@ describe("useThreadDefaultExecutionOptions", () => {
       { wrapper: reload.wrapper },
     );
     expect(result.current.data).toBeUndefined();
+  });
+
+  it("does not persist a canceled response over newer execution defaults", async () => {
+    let resolveOld!: (value: ResolvedThreadExecutionOptions) => void;
+    vi.mocked(sdk.threads.defaultExecutionOptions)
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveOld = resolve;
+          }),
+      )
+      .mockResolvedValue(RESOLVED);
+    const { queryClient, wrapper } = createQueryClientTestHarness();
+    const { result } = renderHook(
+      () => useThreadDefaultExecutionOptions("thr_1"),
+      { wrapper },
+    );
+    await waitFor(() =>
+      expect(sdk.threads.defaultExecutionOptions).toHaveBeenCalledTimes(1),
+    );
+    const queryKey = threadDefaultExecutionOptionsQueryKey("thr_1");
+    await act(async () => {
+      await queryClient.cancelQueries({ queryKey });
+      await queryClient.invalidateQueries({ queryKey });
+    });
+    await waitFor(() => expect(result.current.data).toEqual(RESOLVED));
+    await act(async () => {
+      resolveOld({ ...RESOLVED, serviceTier: "fast" });
+    });
+    expect(result.current.data).toEqual(RESOLVED);
+    expect(
+      readCachedThreadExecutionOptions(threadExecutionOptionsCacheKey("thr_1")),
+    ).toEqual(RESOLVED);
   });
 
   it("ignores a stored value that no longer matches the schema", async () => {

--- a/apps/app/src/hooks/queries/thread-default-execution-options-query.ts
+++ b/apps/app/src/hooks/queries/thread-default-execution-options-query.ts
@@ -30,7 +30,7 @@ async function fetchThreadDefaultExecutionOptions(
     threadId,
     signal,
   });
-  if (options !== null) {
+  if (options !== null && !signal?.aborted) {
     writeCachedThreadExecutionOptions(
       threadExecutionOptionsCacheKey(threadId),
       options,

--- a/apps/app/src/hooks/realtime-cache-effects.test.ts
+++ b/apps/app/src/hooks/realtime-cache-effects.test.ts
@@ -1472,6 +1472,49 @@ describe("createRealtimeCacheEffects", () => {
     effects.dispose();
   });
 
+  it("refreshes execution defaults on accepted turns and supersedes an older read", async () => {
+    vi.useFakeTimers();
+    const { effects, queryClient } = createRealtimeEffectsTestContext();
+    const key = threadDefaultExecutionOptionsQueryKey("thr_1");
+    const signals: AbortSignal[] = [];
+    const pending: Array<(value: { serviceTier: string }) => void> = [];
+    const queryFn = vi.fn(({ signal }: { signal: AbortSignal }) => {
+      signals.push(signal);
+      return new Promise<{ serviceTier: string }>((resolve) =>
+        pending.push(resolve),
+      );
+    });
+    const observer = new QueryObserver(queryClient, { queryKey: key, queryFn });
+    const unsubscribe = observer.subscribe(() => {});
+    effects.handleChanged({
+      type: "changed",
+      entity: "thread",
+      id: "thr_1",
+      changes: ["events-appended"],
+      metadata: { eventTypes: ["item/agentMessage/delta"] },
+    });
+    await vi.advanceTimersByTimeAsync(50);
+    expect(queryFn).toHaveBeenCalledTimes(1);
+    expect(signals[0]?.aborted).toBe(false);
+    effects.handleChanged({
+      type: "changed",
+      entity: "thread",
+      id: "thr_1",
+      changes: ["events-appended"],
+      metadata: { eventTypes: ["client/turn/requested"] },
+    });
+    await vi.advanceTimersByTimeAsync(50);
+    expect(signals[0]?.aborted).toBe(true);
+    expect(queryFn).toHaveBeenCalledTimes(2);
+    pending[1]?.({ serviceTier: "default" });
+    await vi.advanceTimersByTimeAsync(0);
+    pending[0]?.({ serviceTier: "fast" });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(queryClient.getQueryData(key)).toEqual({ serviceTier: "default" });
+    unsubscribe();
+    effects.dispose();
+  });
+
   it("does not invalidate timeline queries for status-only thread changes", () => {
     const { effects, queryClient } = createRealtimeEffectsTestContext();
     const timelineKey = threadTimelineQueryKey("thr_1");

--- a/apps/app/src/hooks/useThreadCreationOptions.test.tsx
+++ b/apps/app/src/hooks/useThreadCreationOptions.test.tsx
@@ -627,6 +627,30 @@ describe("useThreadCreationOptions", () => {
     });
   });
 
+  it("refreshes untouched Fast defaults but preserves an unsent choice until thread reset", async () => {
+    const { wrapper } = createQueryClientTestHarness();
+    const { result, rerender } = renderHook(
+      ({ tier, threadId }: { tier: "fast" | "default"; threadId: string }) =>
+        useThreadCreationOptions({
+          scope: "component-local",
+          resetKey: threadId,
+          initialProviderId: GLOBAL_PROVIDER_ID,
+          initialModel: "global-model",
+          initialServiceTier: tier,
+        }),
+      { wrapper, initialProps: { tier: "fast", threadId: "thr_one" } },
+    );
+    await waitFor(() => expect(result.current.serviceTier).toBe("fast"));
+    rerender({ tier: "default", threadId: "thr_one" });
+    expect(result.current.serviceTier).toBe("default");
+    act(() => result.current.setServiceTier("fast"));
+    rerender({ tier: "fast", threadId: "thr_one" });
+    rerender({ tier: "default", threadId: "thr_one" });
+    expect(result.current.serviceTier).toBe("fast");
+    rerender({ tier: "default", threadId: "thr_two" });
+    expect(result.current.serviceTier).toBe("default");
+  });
+
   it("keeps provider selections local in component-local composers", async () => {
     vi.mocked(sdk.system.executionOptions).mockImplementation(async (args) =>
       providerExecutionOptionsResponse(args?.providerId),

--- a/apps/server/test/threads/thread-send-dispatch.test.ts
+++ b/apps/server/test/threads/thread-send-dispatch.test.ts
@@ -12,6 +12,7 @@ import type { EnvironmentRow } from "@bb/db";
 import {
   changedMessageSchema,
   turnScope,
+  type ServiceTier,
   type Thread,
   type ThreadChangedMessage,
 } from "@bb/domain";
@@ -22,6 +23,7 @@ import * as threadEvents from "../../src/services/threads/thread-events.js";
 import { runQueuedMessageDispatch } from "../../src/services/threads/queued-message-dispatch.js";
 import {
   createAutomaticQueuedMessageGroupEligibility,
+  createQueuedMessageForThread,
   sendQueuedMessage,
   sendQueuedMessageNow,
 } from "../../src/services/threads/queued-messages.js";
@@ -29,6 +31,7 @@ import { queueParentSystemMessage } from "../../src/services/threads/parent-syst
 import { acceptThreadSendRequest } from "../../src/services/threads/thread-send-request.js";
 import { handleUpdateEnvironmentDirectoryToolCall } from "../../src/services/threads/thread-environment-directory.js";
 import { applyLoggedThreadLifecycleEvent } from "../../src/services/threads/lifecycle-outcome.js";
+import { resolveExecutionOptions } from "../../src/services/threads/thread-runtime-config.js";
 import { sendThreadMessage } from "../../src/services/threads/thread-send.js";
 import {
   internalAuthHeaders,
@@ -63,6 +66,7 @@ interface SeedIdleThreadFixtureArgs {
 
 interface SeedProviderThreadFixtureArgs extends SeedIdleThreadFixtureArgs {
   status?: "active" | "idle" | "starting";
+  serviceTier?: ServiceTier;
 }
 
 afterEach(() => vi.restoreAllMocks());
@@ -91,6 +95,7 @@ function seedProviderThreadFixture(
   seedThreadRuntimeState(args.harness.deps, {
     environmentId: environment.id,
     providerThreadId: `provider-send-dispatch-${args.value}`,
+    serviceTier: args.serviceTier,
     threadId: thread.id,
   });
 
@@ -1251,6 +1256,179 @@ describe("idle cold-start activation", () => {
       expect(
         listQueuedThreadCommands(harness, "thread.start", thread.id),
       ).toHaveLength(0);
+    });
+  });
+});
+
+describe("service tier execution lifecycle", () => {
+  it.each(["fast", "default"] as const)(
+    "uses an accepted direct %s choice as the next default",
+    async (serviceTier) => {
+      await withTestHarness(async (harness) => {
+        const { thread } = seedProviderThreadFixture({
+          harness,
+          value: 80,
+          serviceTier: serviceTier === "fast" ? "default" : "fast",
+        });
+        await expect(
+          acceptThreadSendRequest(harness.deps, {
+            thread,
+            payload: {
+              input: textInput("change tier"),
+              mode: "start",
+              serviceTier,
+            },
+          }),
+        ).resolves.toMatchObject({ delivery: "sent" });
+        expect(
+          threadEvents.getLastExecutionOptions(harness.deps, thread.id),
+        ).toMatchObject({ serviceTier });
+        await expect(
+          resolveExecutionOptions(harness.deps, {
+            threadId: thread.id,
+            requestedExecution: { source: "client/turn/requested" },
+          }),
+        ).resolves.toMatchObject({ serviceTier });
+        expect(
+          listQueuedThreadCommands(harness, "turn.submit", thread.id),
+        ).toContainEqual(
+          expect.objectContaining({
+            options: expect.objectContaining({ serviceTier }),
+          }),
+        );
+      });
+    },
+  );
+
+  it("keeps queued choices separate until dispatch and preserves the next row", async () => {
+    await withTestHarness(async (harness) => {
+      const { thread } = seedProviderThreadFixture({
+        harness,
+        value: 81,
+        serviceTier: "fast",
+      });
+      const older = await createQueuedMessageForThread(harness.deps, {
+        thread,
+        payload: {
+          input: textInput("older standard turn"),
+          serviceTier: "default",
+        },
+      });
+      const newer = await createQueuedMessageForThread(harness.deps, {
+        thread,
+        payload: { input: textInput("newer fast turn"), serviceTier: "fast" },
+      });
+      expect(listQueuedThreadMessages(harness.db, thread.id)).toMatchObject([
+        { id: older.id, serviceTier: "default" },
+        { id: newer.id, serviceTier: "fast" },
+      ]);
+      await expect(
+        resolveExecutionOptions(harness.deps, {
+          threadId: thread.id,
+          requestedExecution: { source: "client/turn/requested" },
+        }),
+      ).resolves.toMatchObject({ serviceTier: "fast" });
+      await sendQueuedMessage(harness.deps, {
+        claimPolicy: {
+          kind: "automatic",
+          isGroupEligible: createAutomaticQueuedMessageGroupEligibility(
+            harness.deps,
+            { now: Date.now(), thread },
+          ),
+        },
+        threadId: thread.id,
+        queuedMessageId: older.id,
+        mode: "auto",
+      });
+      expect(
+        threadEvents.getLastExecutionOptions(harness.deps, thread.id),
+      ).toMatchObject({ serviceTier: "default" });
+      await expect(
+        resolveExecutionOptions(harness.deps, {
+          threadId: thread.id,
+          requestedExecution: { source: "client/turn/requested" },
+        }),
+      ).resolves.toMatchObject({ serviceTier: "default" });
+      expect(listQueuedThreadMessages(harness.db, thread.id)).toMatchObject([
+        { id: newer.id, serviceTier: "fast" },
+      ]);
+      expect(
+        listQueuedThreadCommands(harness, "turn.submit", thread.id),
+      ).toContainEqual(
+        expect.objectContaining({
+          options: expect.objectContaining({ serviceTier: "default" }),
+        }),
+      );
+    });
+  });
+
+  it("snapshots a busy follow-up without changing the active tier", async () => {
+    await withTestHarness(async (harness) => {
+      const { thread } = seedProviderThreadFixture({
+        harness,
+        value: 83,
+        status: "active",
+        serviceTier: "fast",
+      });
+      const result = await acceptThreadSendRequest(harness.deps, {
+        thread,
+        payload: {
+          input: textInput("wait for standard"),
+          mode: "queue-if-active",
+          serviceTier: "default",
+        },
+      });
+      expect(result).toMatchObject({
+        delivery: "queued",
+        queuedMessage: { serviceTier: "default" },
+      });
+      expect(
+        threadEvents.getLastExecutionOptions(harness.deps, thread.id),
+      ).toMatchObject({ serviceTier: "fast" });
+      expect(
+        listQueuedThreadCommands(harness, "turn.submit", thread.id),
+      ).toEqual([]);
+    });
+  });
+
+  it("does not save a rejected default choice or consume its queued snapshot", async () => {
+    await withTestHarness(async (harness) => {
+      const { thread } = seedProviderThreadFixture({
+        harness,
+        value: 82,
+        serviceTier: "fast",
+      });
+      const queued = await createQueuedMessageForThread(harness.deps, {
+        thread,
+        payload: { input: textInput("standard turn"), serviceTier: "default" },
+      });
+      archiveThread(harness.db, harness.hub, thread.id);
+      await expect(
+        acceptThreadSendRequest(harness.deps, {
+          thread,
+          payload: {
+            input: textInput("rejected"),
+            mode: "start",
+            serviceTier: "default",
+          },
+        }),
+      ).rejects.toMatchObject({ status: 409 });
+      await expect(
+        sendQueuedMessageNow(harness.deps, {
+          threadId: thread.id,
+          queuedMessageId: queued.id,
+          mode: "auto",
+        }),
+      ).rejects.toMatchObject({ status: 409 });
+      expect(
+        threadEvents.getLastExecutionOptions(harness.deps, thread.id),
+      ).toMatchObject({ serviceTier: "fast" });
+      expect(getQueuedThreadMessage(harness.db, queued.id)).toMatchObject({
+        serviceTier: "default",
+      });
+      expect(
+        listQueuedThreadCommands(harness, "turn.submit", thread.id),
+      ).toEqual([]);
     });
   });
 });

--- a/plugins/provider-codex/src/bridge/bridge.session-signature.test.ts
+++ b/plugins/provider-codex/src/bridge/bridge.session-signature.test.ts
@@ -1,9 +1,10 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { experimental_createBridgeJsonRpcTestHarness as createBridgeJsonRpcTestHarness } from "@get-bb/plugin-sdk/provider-bridge/testing";
+import { z } from "zod";
 import { handleLine } from "./bridge.js";
 
 const THREAD_ID = "thr_signature_1";
@@ -33,13 +34,17 @@ const autoDenySessionOptions = {
 
 let harness: ReturnType<typeof createBridgeJsonRpcTestHarness>;
 let workspaceDir: string;
+let requestLogPath: string;
 
 beforeEach(() => {
   workspaceDir = mkdtempSync(join(tmpdir(), "bb-codex-signature-ws-"));
+  requestLogPath = join(workspaceDir, "requests.jsonl");
+  const scriptPath = join(workspaceDir, "script.json");
+  writeFileSync(scriptPath, JSON.stringify({ requestLogPath }));
   vi.stubEnv("BB_CODEX_BRIDGE_APP_SERVER_COMMAND", process.execPath);
   vi.stubEnv(
     "BB_CODEX_BRIDGE_APP_SERVER_ARGS",
-    JSON.stringify([fakeAppServerPath]),
+    JSON.stringify([fakeAppServerPath, scriptPath]),
   );
   harness = createBridgeJsonRpcTestHarness(handleLine);
 });
@@ -66,8 +71,9 @@ it("keeps the constructed session for a turn whose options carry no envVars", as
     options: { ...sessionOptions, envVars: { PATH: "/usr/bin:/bin" } },
   });
   const started = await harness.waitForResponse(1);
-  const providerThreadId = (started.result as { providerThreadId: string })
-    .providerThreadId;
+  const { providerThreadId } = z
+    .object({ providerThreadId: z.string() })
+    .parse(started.result);
 
   harness.sendRequest(2, "turn/start", {
     threadId: THREAD_ID,
@@ -92,8 +98,9 @@ it("keeps an auto-reviewed session when only escalation intent changes", async (
     options: autoAskSessionOptions,
   });
   const started = await harness.waitForResponse(1);
-  const providerThreadId = (started.result as { providerThreadId: string })
-    .providerThreadId;
+  const { providerThreadId } = z
+    .object({ providerThreadId: z.string() })
+    .parse(started.result);
 
   harness.sendRequest(2, "turn/start", {
     threadId: THREAD_ID,
@@ -109,3 +116,69 @@ it("keeps an auto-reviewed session when only escalation intent changes", async (
     harness.messages.filter((message) => message.method === "session/replaced"),
   ).toEqual([]);
 }, 30_000);
+
+function recordedRequests() {
+  const schema = z.object({
+    method: z.string(),
+    params: z.looseObject({ serviceTier: z.string().nullable().optional() }),
+  });
+  return readFileSync(requestLogPath, "utf8")
+    .trim()
+    .split("\n")
+    .map((line) => schema.parse(JSON.parse(line)));
+}
+
+it("clears Fast for the next turn without replacing the session", async () => {
+  harness.sendRequest(1, "thread/start", {
+    threadId: THREAD_ID,
+    cwd: workspaceDir,
+    instructionMode: "append",
+    options: { ...sessionOptions, serviceTier: "fast" },
+  });
+  const started = await harness.waitForResponse(1);
+  expect(started.error).toBeUndefined();
+  const { providerThreadId } = z
+    .object({ providerThreadId: z.string() })
+    .parse(started.result);
+
+  for (const [index, serviceTier] of ["fast", "default", "fast"].entries()) {
+    const id = index + 2;
+    harness.sendRequest(id, "turn/start", {
+      threadId: THREAD_ID,
+      providerThreadId,
+      clientRequestId: `creq_tiertestx${id}`,
+      input: [{ type: "text", text: "say hello", mentions: [] }],
+      options: { ...sessionOptions, serviceTier },
+    });
+    expect((await harness.waitForResponse(id)).error).toBeUndefined();
+    expect(recordedRequests().at(-1)).toEqual({
+      method: "turn/start",
+      params: expect.objectContaining({
+        serviceTier: serviceTier === "default" ? null : "fast",
+      }),
+    });
+  }
+  expect(
+    harness.messages.filter((message) => message.method === "session/replaced"),
+  ).toEqual([]);
+}, 30_000);
+
+it.each(["start", "resume", "fork"] as const)(
+  "sends an explicit default reset when constructing a %s session",
+  async (kind) => {
+    harness.sendRequest(1, `thread/${kind}`, {
+      threadId: THREAD_ID,
+      ...(kind === "resume" ? { providerThreadId: "provider-fast" } : {}),
+      ...(kind === "fork" ? { sourceProviderThreadId: "provider-fast" } : {}),
+      cwd: workspaceDir,
+      instructionMode: "append",
+      options: { ...sessionOptions, serviceTier: "default" },
+    });
+    expect((await harness.waitForResponse(1)).error).toBeUndefined();
+    expect(recordedRequests()).toContainEqual({
+      method: `thread/${kind}`,
+      params: expect.objectContaining({ serviceTier: null }),
+    });
+  },
+  30_000,
+);

--- a/plugins/provider-codex/src/session-params.test.ts
+++ b/plugins/provider-codex/src/session-params.test.ts
@@ -721,7 +721,7 @@ describe("toCodexReasoningEffort", () => {
 describe("toCodexServiceTier", () => {
   it("forwards only the fast tier", () => {
     expect(toCodexServiceTier("fast")).toBe("fast");
-    expect(toCodexServiceTier("default")).toBeUndefined();
+    expect(toCodexServiceTier("default")).toBeNull();
     expect(toCodexServiceTier(undefined)).toBeUndefined();
   });
 });

--- a/plugins/provider-codex/src/session-params.ts
+++ b/plugins/provider-codex/src/session-params.ts
@@ -554,8 +554,8 @@ export function toCodexPermissionSettings(
 
 export function toCodexServiceTier(
   tier: ServiceTier | undefined,
-): "fast" | undefined {
-  return tier === "fast" ? "fast" : undefined;
+): "fast" | null | undefined {
+  return tier === "default" ? null : tier;
 }
 
 export function toCodexReasoningEffort(


### PR DESCRIPTION
## Human comments

## What was wrong

After a Fast Codex turn, disabling Fast and sending another message saved `default` in BB but omitted `serviceTier` from Codex's request. Omission leaves the provider's existing tier unchanged. Separately, dispatching a queued message did not invalidate execution defaults, so an untouched picker could keep showing Fast after a default-tier message started.

## What changed

- Serialize explicit `default` as `null` on Codex's downstream JSON-RPC wire; retain `fast` and preserve omission when no tier is supplied.
- Refresh execution defaults on `client/turn/requested`, cancel older reads, and prevent canceled responses from overwriting the last-known cache.
- Preserve local unsent choices, queued execution snapshots, queue ordering, and existing failure/retry behavior.

Unlike the selection-time save proposed in #3403, this follows the lifecycle established by #3267: picker changes remain local until submission/dispatch. Switching threads without sending still restores the last recorded defaults. No new persistent override, database migration, SDK/CLI surface, or server/daemon wire change; no `HOST_DAEMON_PROTOCOL_VERSION` bump is needed.

The accepted-turn cache work shares one handler with prompt-history invalidation. The raw boot budget increases deliberately by 128 bytes (1,723,617 → 1,723,745): pristine main measures exactly 1,723,617 bytes, and the simplified fix measures 1,723,707 (+90). This accommodates the measured eager cache logic; compressed and dependency budgets are unchanged.

## How you verified

Reproduced on pristine `origin/main` at `b04091eca67bb463cce16b9bfa318660bd20ab69` using dev-browser, a fresh isolated database, and `pnpm start:worktree` in a persistent BB terminal. The exact unsent-toggle/navigation behavior reproduces, while direct-send BB persistence already works.

Recorded real Codex 0.153.3 JSON-RPC traffic from browser-submitted turns:

| Step | Before | After |
| --- | --- | --- |
| Fast turn | `turn/start` sends `serviceTier: "fast"`; Codex reports `"priority"` | Same |
| Disable Fast and send | `turn/start` omits `serviceTier`; last reported setting remains `"priority"` | Sends `serviceTier: null`; Codex emits `thread/settings/updated` with `serviceTier: "default"` |

This verifies provider configuration, not billing or measured latency. Raw recordings and screenshots remain local because they include machine and model-catalog details.

The real queued lifecycle also passed: queue default during Fast work, reload while waiting, leave the picker untouched, then observe it switch off when the queued message automatically dispatches. Before the cache fix it stayed on despite the server reporting default. Codex→Pi→Codex selection hides Fast for the unsupported provider.

- Five provider regressions failed against the original converter; the same focused suite passes 42 tests after the fix. Full Codex suite: 272 passed.
- Two cache regressions failed before and pass after: accepted-turn refresh and canceled-response persistence. Selected app suites: 155 distinct tests passed, including preservation of unsent selections.
- Adjacent server suites: 60 passed, including direct/busy sends, queued snapshots, dispatch, errors, retries, and override recovery. Final dispatch suite: 26 passed.
- Turbo app/server/provider typechecks, applicable builds and lint passed. Changed-file formatting, lint, and `git diff --check` passed. App lint retains 190 existing warnings; builds retain chunk-size/timing warnings.
- Native Electron and iOS Safari were not tested. Bridge tests cover start/resume/fork reset; live provider proof covers subsequent turns.

CI follow-up: reproduced the raw bundle-budget failure locally, consolidated duplicate accepted-turn handlers, and compared a pristine-main build. The correction passed 110 focused cache/selection/bundle-budget tests; the explicit bundle checker, app build/typecheck/lint, formatting, and diff checks were rerun.

Fixes #3403

> AGENT GENERATED
