### PR TITLE
Raise raw boot bundle budget by 5%

### DIFF
--- a/apps/app/bundle-budget.json
+++ b/apps/app/bundle-budget.json
@@ -46,7 +46,7 @@
     "`node scripts/why-eager.mjs --from=views/SplitWorkspaceRoute.tsx <package>`",
     "to print the static chain that pulled a package into the closure."
   ],
-  "maxBootBytes": 1723745,
+  "maxBootBytes": 1809933,
   "maxBootBrotliBytes": 429072,
   "forbiddenBootPackages": [
     "@pierre/diffs",


### PR DESCRIPTION
## Human comments

## What was wrong

Main's boot payload is 1,723,786 raw bytes, exceeding its 1,723,745-byte limit by 41 bytes. The original 10% allowance has been consumed by accumulated startup code. The two latest fixes independently increased the same baseline budget while their code growth combined.

## What changed

Raise only the raw boot ceiling by the requested 5%, from 1,723,745 to 1,809,933 bytes (rounded up). Compressed, route, and forbidden-package guards are unchanged. This restores CI while a follow-up reduces the payload to recover 10% headroom and then recalibrates the ceiling to 5% above the reduced measurement.

## How you verified

- Reproduced the existing bundle-budget failure locally against main.
- `pnpm exec turbo run build --filter=@bb/app --output-logs=errors-only` passed.
- `node apps/app/scripts/check-bundle-budget.mjs` passes with the revised ceiling; raw boot is 1,723,786 bytes and Brotli boot is 421,071 bytes.
- `git diff --check` passed.

> AGENT GENERATED
