### PR TITLE
Cut startup JavaScript by 81 KiB and restore 5% bundle headroom

### DIFF
--- a/apps/app/bundle-budget.json
+++ b/apps/app/bundle-budget.json
@@ -8,8 +8,9 @@
     "Chunks behind a dynamic import are deliberately not counted. Moving code",
     "behind React.lazy or import() is the fix this budget exists to encourage.",
     "",
-    "maxBootBytes / maxBootBrotliBytes are a ratchet set 10% above the measured",
-    "payload: enough for a normal feature's worth of shell code and for build",
+    "maxBootBytes is set 5% above the measured raw payload;",
+    "maxBootBrotliBytes retains its 10% ratchet above the compressed payload.",
+    "These allowances leave room for normal shell feature work and build",
     "noise, tight enough that a barrel regression cannot hide inside it. Lower",
     "them when a change wins headroom. Raising one is a deliberate decision",
     "that needs a reason in the pull request, not a routine edit.",
@@ -46,7 +47,7 @@
     "`node scripts/why-eager.mjs --from=views/SplitWorkspaceRoute.tsx <package>`",
     "to print the static chain that pulled a package into the closure."
   ],
-  "maxBootBytes": 1809933,
+  "maxBootBytes": 1722912,
   "maxBootBrotliBytes": 429072,
   "forbiddenBootPackages": [
     "@pierre/diffs",
@@ -67,6 +68,7 @@
     "prosemirror-model",
     "prosemirror-state",
     "prosemirror-view",
+    "react-resizable-panels",
     "rehype-katex",
     "shiki"
   ],

--- a/apps/app/src/components/layout/AppLayout.tsx
+++ b/apps/app/src/components/layout/AppLayout.tsx
@@ -13,7 +13,7 @@ import { atomWithStorage } from "jotai/utils";
 import { Link, matchPath, useLocation, useNavigate } from "react-router-dom";
 import type { ProjectResponse } from "@bb/server-contract";
 import { Icon } from "@bb/shared-ui/icon";
-import { RESOURCE_ROUTE_LABEL_EVENT } from "@bb/shared-ui/resource-list";
+import { RESOURCE_ROUTE_LABEL_EVENT } from "@bb/shared-ui/resource-route-label";
 import {
   SidebarInset,
   SidebarProvider,

--- a/apps/app/src/main.tsx
+++ b/apps/app/src/main.tsx
@@ -2,7 +2,6 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter } from "react-router-dom";
-import { disableGlobalCursorStyles } from "react-resizable-panels";
 import { App } from "./App";
 import { AppErrorBoundary } from "./components/AppErrorBoundary";
 import { AppToaster } from "./components/AppToaster";
@@ -25,7 +24,6 @@ registerProviderCliInstallQueryClient(appQueryClient);
 initializePreferredTheme();
 applyCachedAppThemeCss();
 initializeFavicon();
-disableGlobalCursorStyles();
 
 createRoot(document.getElementById("root")!, {
   onUncaughtError: (error, errorInfo) => {

--- a/apps/app/src/views/SplitWorkspaceRoute.tsx
+++ b/apps/app/src/views/SplitWorkspaceRoute.tsx
@@ -1,4 +1,5 @@
 import { lazy, useMemo } from "react";
+import { disableGlobalCursorStyles } from "react-resizable-panels";
 import { matchPath, Navigate, useLocation } from "react-router-dom";
 import { useAtomValue } from "jotai";
 import { splitLayoutAtom } from "@/lib/split-layout/atoms";
@@ -14,6 +15,8 @@ import type { PaneContent } from "@/lib/split-layout";
 import { useRouteState } from "@/hooks/useRouteState";
 import { LegacyProjectComposeRedirect } from "./RootComposeView";
 import { SplitThreadArea } from "./thread-detail/SplitThreadArea";
+
+disableGlobalCursorStyles();
 
 const ROOT_COMPOSE_CONTENT = { kind: "new-thread" } as const;
 

--- a/packages/shared-ui/package.json
+++ b/packages/shared-ui/package.json
@@ -219,6 +219,11 @@
       "types": "./src/components/ui/progress.tsx",
       "default": "./src/components/ui/progress.tsx"
     },
+    "./resource-route-label": {
+      "source": "./src/components/ui/resource-route-label.ts",
+      "types": "./src/components/ui/resource-route-label.ts",
+      "default": "./src/components/ui/resource-route-label.ts"
+    },
     "./resource-list": {
       "source": "./src/components/ui/resource-list.tsx",
       "types": "./src/components/ui/resource-list.tsx",

--- a/packages/shared-ui/src/components/ui/resource-route-label.ts
+++ b/packages/shared-ui/src/components/ui/resource-route-label.ts
@@ -1,0 +1,26 @@
+import { useEffect } from "react";
+
+export const RESOURCE_ROUTE_LABEL_EVENT = "bb:resource-route-label";
+
+export function useResourceRouteLabel(label: string | null | undefined) {
+  useEffect(() => {
+    if (!label || typeof window === "undefined") return;
+
+    let active = true;
+    queueMicrotask(() => {
+      if (!active) return;
+      window.dispatchEvent(
+        new CustomEvent(RESOURCE_ROUTE_LABEL_EVENT, { detail: { label } }),
+      );
+    });
+
+    return () => {
+      active = false;
+      window.dispatchEvent(
+        new CustomEvent(RESOURCE_ROUTE_LABEL_EVENT, {
+          detail: { label: null },
+        }),
+      );
+    };
+  }, [label]);
+}

--- a/packages/shared-ui/src/components/ui/resource/atoms.tsx
+++ b/packages/shared-ui/src/components/ui/resource/atoms.tsx
@@ -1,4 +1,4 @@
-import { useEffect, type CSSProperties, type ReactNode } from "react";
+import type { CSSProperties, ReactNode } from "react";
 import { Icon, type IconName } from "../icon";
 import {
   Tooltip,
@@ -10,30 +10,10 @@ import { cn } from "../../../lib/utils";
 
 export type ResourceStatusTone = "success" | "warning" | "error" | "muted";
 
-export const RESOURCE_ROUTE_LABEL_EVENT = "bb:resource-route-label";
-
-export function useResourceRouteLabel(label: string | null | undefined) {
-  useEffect(() => {
-    if (!label || typeof window === "undefined") return;
-
-    let active = true;
-    queueMicrotask(() => {
-      if (!active) return;
-      window.dispatchEvent(
-        new CustomEvent(RESOURCE_ROUTE_LABEL_EVENT, { detail: { label } }),
-      );
-    });
-
-    return () => {
-      active = false;
-      window.dispatchEvent(
-        new CustomEvent(RESOURCE_ROUTE_LABEL_EVENT, {
-          detail: { label: null },
-        }),
-      );
-    };
-  }, [label]);
-}
+export {
+  RESOURCE_ROUTE_LABEL_EVENT,
+  useResourceRouteLabel,
+} from "../resource-route-label";
 
 export function ResourceState({
   tone,


### PR DESCRIPTION
## Human comments

## What was wrong

The app shell imported `RESOURCE_ROUTE_LABEL_EVENT` through the resource-list UI barrel, pulling unused resource components into startup. `main.tsx` also imported the resizable-panel runtime solely to configure cursor styles before any workspace panels existed. Accumulated growth exhausted the boot budget; #3475 temporarily raised its raw ceiling by 5%.

## What changed

- Extract the resource-label event/hook into a small internal shared-UI entry and import it directly from the shell. Preserve the existing resource-list exports and event lifecycle.
- Configure panel cursor styles when the lazy workspace route evaluates, before its panels render.
- Forbid `react-resizable-panels` in the boot closure to prevent the eager import returning.
- Reduce the raw boot ceiling to 1,722,912 bytes, exactly 5% above the reduced measurement (rounded up). Compressed and route ceilings remain unchanged.

| Boot payload | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| Raw | 1,723,786 B | 1,640,868 B | 82,918 B (4.8%) |
| Brotli | 421,071 B | 402,476 B | 18,595 B (4.4%) |

The reduced payload has 10.3% headroom under #3475's temporary ceiling before this PR resets the allowance to 5%. The thread-route closure remains within budget, and combined boot-plus-route raw JavaScript also falls by approximately 56 KiB. No public SDK/CLI behavior or server-daemon wire change.

## How you verified

- [CI](https://github.com/get-bb/bb/actions/runs/34569017363) passes, including build/typecheck/lint, bundle budgets, all six test shards, and Linux/macOS package smoke jobs.

- Used the actual Vite module graph to trace both eager imports; built before and after through Turbo and checked the measured production bundle.
- `pnpm exec turbo run build --filter=@bb/app --output-logs=errors-only` and `node apps/app/scripts/check-bundle-budget.mjs` pass.
- Turbo app/shared-UI typechecks and lint pass. Seven focused app suites pass 53 tests covering routes, layout, panel layout, and bundle guards.
- SDK npm version guard passes: 0.4.56 has not yet been published.
- Fresh isolated Chromium browser: plugin browsing/details/full-screen navigation work; resource labels reset on close and emit the plugin name on reopen. A real divider drag changes panel widths from 480/480 to 400/560 pixels with no global cursor override stylesheet during drag.
- Formatting and `git diff --check` pass. Native Electron and iOS Safari were not exercised. Verification inventory preflight reports the pre-existing unmapped `browser` CLI family; no inventory baseline was changed.

> AGENT GENERATED
