### PR TITLE
Fix single-pane split-drag drop zones and default a center drop to split

### DIFF
--- a/apps/app/src/components/secondary-panel/SecondaryPanelLayout.tsx
+++ b/apps/app/src/components/secondary-panel/SecondaryPanelLayout.tsx
@@ -92,6 +92,8 @@ export function SecondaryPanelLayout({
 }: SecondaryPanelLayoutProps) {
   const paneContext = useOptionalPaneContext();
   const secondaryPanelHost = paneContext?.secondaryPanelHost ?? null;
+  const inlinePaneTargetId =
+    secondaryPanelHost === null ? paneContext?.paneId : undefined;
   const renderAsDrawer = useIsCompactViewport();
   const sidebarDrawerShowing = useSyncExternalStore(
     subscribeCompactSidebarDrawerShowing,
@@ -297,6 +299,7 @@ export function SecondaryPanelLayout({
 
   const mainContent = (
     <div
+      data-split-pane-id={inlinePaneTargetId}
       data-conversation-collapsed={isMainCollapsed}
       inert={isMainCollapsed}
       className={cn(

--- a/apps/app/src/components/sidebar/usePaneContentSplitDrag.ts
+++ b/apps/app/src/components/sidebar/usePaneContentSplitDrag.ts
@@ -127,6 +127,7 @@ export function usePaneContentSplitActions() {
             zone,
             threadAlreadyOpen: findPaneByContent(layout.root, content) !== null,
             atMaxPanes: countPanes(layout.root) >= MAX_PANES,
+            singlePane: countPanes(layout.root) === 1,
           });
         },
         onDrop: (target) => {

--- a/apps/app/src/components/sidebar/useThreadRowSplitDrag.ts
+++ b/apps/app/src/components/sidebar/useThreadRowSplitDrag.ts
@@ -82,6 +82,7 @@ export function useThreadRowSplitDrag({
             threadAlreadyOpen:
               findPaneByThread(layout.root, projectId, threadId) !== null,
             atMaxPanes: countPanes(layout.root) >= MAX_PANES,
+            singlePane: countPanes(layout.root) === 1,
           });
         },
         onDrop: (target) => {

--- a/apps/app/src/lib/split-drag/zones.test.ts
+++ b/apps/app/src/lib/split-drag/zones.test.ts
@@ -89,6 +89,17 @@ describe("decideThreadDrop", () => {
     ).toEqual({ zone: "center", label: "Replace this chat" });
   });
 
+  it("splits a center zone when the workspace has a single pane", () => {
+    expect(
+      decideThreadDrop({
+        zone: "center",
+        threadAlreadyOpen: false,
+        atMaxPanes: false,
+        singlePane: true,
+      }),
+    ).toEqual({ zone: "right", label: "Split right" });
+  });
+
   it("coerces edges to center-replace at the pane cap", () => {
     expect(
       decideThreadDrop({

--- a/apps/app/src/lib/split-drag/zones.ts
+++ b/apps/app/src/lib/split-drag/zones.ts
@@ -85,12 +85,14 @@ interface ThreadDropInput {
   zone: SplitZone;
   threadAlreadyOpen: boolean;
   atMaxPanes: boolean;
+  singlePane?: boolean;
 }
 
 export function decideThreadDrop({
   zone,
   threadAlreadyOpen,
   atMaxPanes,
+  singlePane = false,
 }: ThreadDropInput): ZoneDecision {
   if (threadAlreadyOpen) {
     return { zone: "center", label: "Already open — focus pane" };
@@ -98,9 +100,13 @@ export function decideThreadDrop({
   if (atMaxPanes) {
     return { zone: "center", label: "Replace this chat" };
   }
+  const resolvedZone = singlePane && zone === "center" ? "right" : zone;
   return {
-    zone,
-    label: zone === "center" ? "Replace this chat" : `Split ${zone}`,
+    zone: resolvedZone,
+    label:
+      resolvedZone === "center"
+        ? "Replace this chat"
+        : `Split ${resolvedZone}`,
   };
 }
 


### PR DESCRIPTION
## What was wrong

In a single-pane workspace, dragging a thread from the sidebar onto the chat pane splits or replaces depending on whether the right panel is open. Root cause: the single-pane chat region has no `data-split-pane-id`, so `beginSplitDrag` falls back to the whole `<main>` for its drop rect. In the inline single-pane layout `<main>` also contains the right secondary panel (a sibling `react-resizable-panels` panel), so the zones are measured over chat + panel. With the panel open the visible chat is the left half of `<main>`, so the visual center lands in the `left` band (25% < 28%) and splits; with the panel closed the visual center is 50% and replaces.

Repro, root cause, and code permalinks: #3481.

## What changed

- `apps/app/src/components/secondary-panel/SecondaryPanelLayout.tsx`: tag the inline pane's chat region with `data-split-pane-id` so drops are measured against the pane that owns them. The tagged element is the chat column, which excludes the right panel. Behavior no longer depends on the right panel.
- `apps/app/src/lib/split-drag/zones.ts` and the two sidebar drag hooks (`useThreadRowSplitDrag`, `usePaneContentSplitDrag`): when the workspace has exactly one pane, a center drop resolves to a split to the right instead of replace. Replace stays available via an edge drop, the pane cap, and clicking the thread.
- `apps/app/src/lib/split-drag/zones.test.ts`: unit test for the single-pane center case.

No wire, CLI, or guide changes.

## How you verified

- Unit: new `zones.test.ts` case "splits a center zone when the workspace has a single pane"; existing `decideThreadDrop` cases are unchanged because `singlePane` defaults to `false`.
- Manual against the running 0.42.1 UI (local server, Playwright): injecting the equivalent `data-split-pane-id` on the inline chat region and re-running a real sidebar drag gives panel-open center → `Replace this chat`, panel-open left → `Split left`, panel-closed center → `Replace`, panel-closed right → `Split right`. Before the fix, panel-open center → `Split left`.
- I could not run the monorepo test suite locally (no `node_modules` installed here); CI should run the `@bb/app` typecheck/test filters.

Fixes #3481

> AGENT GENERATED
