### PR TITLE
Exclude bundled stages from workspace discovery

### DIFF
--- a/.github/actions/install-appimage-fuse/action.yml
+++ b/.github/actions/install-appimage-fuse/action.yml
@@ -12,11 +12,20 @@ runs:
         FUSE_PACKAGE: ${{ inputs.package }}
       run: |
         set -euo pipefail
+        mirrorlist=/etc/apt/blacksmith-ubuntu-mirrors.txt
+        if [ -f "$mirrorlist" ]; then
+          printf '%s\n' 'https://mirrors.edge.kernel.org/ubuntu/' | sudo tee "$mirrorlist" >/dev/null
+        fi
         for source in /etc/apt/sources.list /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources /etc/apt/blacksmith-ubuntu-mirrors.txt; do
           if [ -f "$source" ]; then
             sudo sed -E -i 's#http://((([a-z0-9-]+\.)?archive|security)\.ubuntu\.com/ubuntu|mirrors\.sonic\.net/ubuntu)#https://\1#g' "$source"
           fi
         done
-        apt_options=(-o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 -o Acquire::Retries=1)
+        apt_options=(
+          -o Acquire::http::Timeout=10
+          -o Acquire::https::Timeout=10
+          -o Acquire::Retries=1
+          -o Acquire::IndexTargets::deb::DEP-11::DefaultEnabled=false
+        )
         sudo apt-get "${apt_options[@]}" update
         sudo apt-get "${apt_options[@]}" install --yes "$FUSE_PACKAGE"

--- a/packages/plugin-build/src/bundled-workspace.test.ts
+++ b/packages/plugin-build/src/bundled-workspace.test.ts
@@ -1,0 +1,74 @@
+import { spawnSync } from "node:child_process";
+import { cp, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { expect, it } from "vitest";
+
+const repositoryRoot = resolve(import.meta.dirname, "../../..");
+
+it("keeps bundled stages out of discovery without hiding real plugin packages", async () => {
+  const root = await mkdtemp(join(tmpdir(), "bb-bundled-workspace-"));
+  const graph = () =>
+    spawnSync(
+      join(repositoryRoot, "node_modules/.bin/turbo"),
+      ["run", "build", "--dry=json"],
+      { cwd: root, encoding: "utf8", timeout: 15_000 },
+    );
+  const writePackage = async (directory: string, name: string) => {
+    await mkdir(join(root, directory), { recursive: true });
+    await writeFile(
+      join(root, directory, "package.json"),
+      JSON.stringify({
+        name,
+        version: "1.0.0",
+        scripts: { build: "node -e ''" },
+      }),
+    );
+  };
+  const expectPackages = () => {
+    const result = graph();
+    expect(result.status, result.stderr).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      packages: ["bundled-plugin", "example-plugin"],
+    });
+  };
+  try {
+    await cp(
+      join(repositoryRoot, "pnpm-workspace.yaml"),
+      join(root, "pnpm-workspace.yaml"),
+    );
+    await writeFile(
+      join(root, "package.json"),
+      JSON.stringify({
+        name: "workspace-fixture",
+        private: true,
+        packageManager: "pnpm@9.15.0",
+      }),
+    );
+    await writeFile(
+      join(root, "turbo.json"),
+      JSON.stringify({ tasks: { build: {} } }),
+    );
+    await writePackage("plugins/real", "bundled-plugin");
+    await writePackage("examples/plugins/real", "example-plugin");
+    expectPackages();
+    for (const parent of ["plugins", "examples/plugins"]) {
+      await cp(
+        join(root, parent, "real"),
+        join(root, parent, ".bundled-stage-owned"),
+        { recursive: true },
+      );
+    }
+    expectPackages();
+    for (const parent of ["plugins", "examples/plugins"]) {
+      await rm(join(root, parent, ".bundled-stage-owned"), { recursive: true });
+    }
+    expectPackages();
+    await writePackage("plugins/duplicate", "bundled-plugin");
+    const duplicate = graph();
+    expect(duplicate.status).not.toBe(0);
+    expect(duplicate.stderr).toContain("Failed to add workspace");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}, 60_000);

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
   - "apps/*"
   - "tests/*"
   - "plugins/*"
+  - "!**/.bundled-stage-*"
   # Bundled and example plugins are workspace members so their declared
   # dependencies are installed into each plugin's own node_modules — plugins
   # bring their own dependencies.

--- a/turbo.json
+++ b/turbo.json
@@ -621,6 +621,7 @@
       // The SVG validator suite reads every first-party branding SVG.
       "inputs": [
         "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/pnpm-workspace.yaml",
         "$TURBO_ROOT$/vitest.shared.ts",
         "$TURBO_ROOT$/plugins/*/icons/**",
         "$TURBO_ROOT$/examples/plugins/*/icons/**"


### PR DESCRIPTION
## Human comments

## What was wrong

Plugin runtime preparation creates temporary `.bundled-stage-*` directories beside first-party plugins and copies each plugin's `package.json` into the stage. Those directories still matched the repository's `plugins/*` workspace glob, so Turbo could discover the copied manifest as a second package while preparation was active or after an interrupted build left the owned stage behind. The duplicate package then blocked unrelated workspace commands. This was introduced by [PR #3474](https://github.com/get-bb/bb/pull/3474).

Separately, the Linux package smoke's FUSE setup fetched optional Ubuntu DEP-11 metadata even though it only needs package indexes. A stalled first mirror could therefore consume the action's entire five-minute network bound before packaging started.

## What changed

- Exclude the reserved `.bundled-stage-*` prefix from pnpm workspace discovery across bundled and example plugin paths.
- Add `pnpm-workspace.yaml` to the plugin-build test task inputs so workspace-rule changes invalidate the relevant Turbo cache.
- Add a regression that runs the real Turbo graph against owned fixture packages, proving active and abandoned stages stay hidden while genuine bundled/example plugins remain discoverable and real duplicate package names still fail.
- Pin Blacksmith's FUSE setup to the reachable kernel.org Ubuntu mirror and skip optional DEP-11 metadata, while retaining package-index updates and the real FUSE package install.

The change does not delete stages or alter runtime layout, caching, signals, CLI/SDK behavior, or the host-daemon wire contract.

## How you verified

- Before the fix, both an active real preparation stage and a SIGTERM-abandoned stage caused Turbo's duplicate-workspace failure; removing only the owned stage restored success.
- After the fix, active and abandoned stages no longer enter discovery, while real Monaco and example plugin packages remain present.
- `pnpm exec turbo run test --filter=@bb/plugin-build --force` — 11 files passed, 138 tests passed, one existing skip.
- Plugin-build Turbo typecheck and build passed in the original fixer verification.
- Source dry runs, cold-cache preparation, and warm-cache reuse passed for all 33 bundled plugins.
- Targeted Oxfmt, Prettier, and `git diff --check` passed after the final formatting amendment.
- Prettier and `git diff --check` pass for the FUSE action hardening; the pinned Noble `InRelease` endpoint returns HTTP 200, and the exact-head Linux package smoke exercises the action end to end.

> AGENT GENERATED
