### PR TITLE
Keep mobile dictation visible and composer buttons stable

### DIFF
--- a/apps/app/src/components/promptbox/FollowUpPromptBox.test.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.test.tsx
@@ -889,7 +889,7 @@ describe("FollowUpPromptBox", () => {
     );
     fireEvent.pointerUp(submit, { button: 0, pointerType: "mouse" });
     fireEvent.click(submit);
-    expect(props.composer.onSubmit).toHaveBeenCalledOnce();
+    expect(props.composer?.onSubmit).toHaveBeenCalledOnce();
   });
 
   it("toggles between focused and collapsed with the composer shortcut", () => {
@@ -1228,7 +1228,7 @@ describe("FollowUpPromptBox", () => {
         ).toBe("false");
         fireEvent.pointerUp(control, { button: 0, pointerType: "touch" });
         fireEvent.click(control);
-        expect(props.composer.onSubmit).toHaveBeenCalledOnce();
+        expect(props.composer?.onSubmit).toHaveBeenCalledOnce();
       } finally {
         vi.useRealTimers();
         if (originalDescriptor) {

--- a/apps/app/src/components/promptbox/FollowUpPromptBox.test.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.test.tsx
@@ -1240,6 +1240,38 @@ describe("FollowUpPromptBox", () => {
     },
   );
 
+  it.each(["pointerUp", "pointerCancel"] as const)(
+    "resumes deferred focus loss after a control gesture ends with %s",
+    (releaseEvent) => {
+      mocks.isCompactViewport = true;
+      vi.useFakeTimers();
+      try {
+        render(
+          <FollowUpPromptBox
+            {...createFollowUpPromptBoxProps({ kind: "ready" })}
+          />,
+        );
+        const input = screen.getByRole("textbox", { name: "Follow-up prompt" });
+        const control = screen.getByRole("button", { name: "Submit" });
+        act(() => input.focus());
+        fireEvent.pointerDown(control);
+        act(() => input.blur());
+        act(() => vi.advanceTimersByTime(20));
+        expect(
+          screen.getByTestId("prompt-box").getAttribute("data-compact"),
+        ).toBe("false");
+
+        fireEvent[releaseEvent](control);
+        act(() => vi.advanceTimersByTime(20));
+        expect(
+          screen.getByTestId("prompt-box").getAttribute("data-compact"),
+        ).toBe("true");
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
+
   it("stays expanded after pressing a non-focusable composer control", () => {
     mocks.isCompactViewport = true;
     const props = createFollowUpPromptBoxProps({ kind: "ready" });

--- a/apps/app/src/components/promptbox/FollowUpPromptBox.test.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.test.tsx
@@ -873,6 +873,25 @@ describe("FollowUpPromptBox", () => {
     expect(screen.getByText("Local environment")).toBeTruthy();
   });
 
+  it("keeps a collapsed composer steady while a pointer focuses an action", () => {
+    const props = createFollowUpPromptBoxProps({ kind: "ready" });
+    render(<FollowUpPromptBox {...props} />);
+    fireEvent.click(
+      screen.getByRole("button", { name: "Collapse prompt box" }),
+    );
+    const submit = screen.getByRole("button", { name: "Submit" });
+
+    fireEvent.pointerDown(submit, { button: 0, pointerType: "mouse" });
+    act(() => submit.focus());
+
+    expect(screen.getByTestId("prompt-box").getAttribute("data-compact")).toBe(
+      "true",
+    );
+    fireEvent.pointerUp(submit, { button: 0, pointerType: "mouse" });
+    fireEvent.click(submit);
+    expect(props.composer.onSubmit).toHaveBeenCalledOnce();
+  });
+
   it("toggles between focused and collapsed with the composer shortcut", () => {
     const props = createFollowUpPromptBoxProps({ kind: "ready" });
     props.environmentSummary = <span>Local environment</span>;
@@ -1169,6 +1188,57 @@ describe("FollowUpPromptBox", () => {
       vi.useRealTimers();
     }
   });
+
+  it.each([false, true])(
+    "cancels a pending keyboard collapse when pressing a control (overlay: %s)",
+    (isOverlay) => {
+      mocks.isCompactViewport = true;
+      mocks.isPointerCoarse = true;
+      vi.useFakeTimers();
+      const originalDescriptor = Object.getOwnPropertyDescriptor(
+        window,
+        "visualViewport",
+      );
+      const visualViewport = Object.assign(new EventTarget(), { height: 500 });
+      Object.defineProperty(window, "visualViewport", {
+        configurable: true,
+        value: visualViewport,
+      });
+
+      try {
+        const props = createFollowUpPromptBoxProps({ kind: "ready" });
+        render(<FollowUpPromptBox {...props} />);
+        const input = screen.getByRole("textbox", { name: "Follow-up prompt" });
+        const control = screen.getByRole("button", { name: "Submit" });
+        if (isOverlay) control.setAttribute("aria-haspopup", "menu");
+        act(() => input.focus());
+        act(() => {
+          visualViewport.height = 300;
+          visualViewport.dispatchEvent(new Event("resize"));
+          vi.advanceTimersByTime(20);
+        });
+        act(() => input.blur());
+        act(() => vi.advanceTimersByTime(550));
+
+        fireEvent.pointerDown(control, { button: 0, pointerType: "touch" });
+        act(() => vi.advanceTimersByTime(300));
+
+        expect(
+          screen.getByTestId("prompt-box").getAttribute("data-compact"),
+        ).toBe("false");
+        fireEvent.pointerUp(control, { button: 0, pointerType: "touch" });
+        fireEvent.click(control);
+        expect(props.composer.onSubmit).toHaveBeenCalledOnce();
+      } finally {
+        vi.useRealTimers();
+        if (originalDescriptor) {
+          Object.defineProperty(window, "visualViewport", originalDescriptor);
+        } else {
+          Reflect.deleteProperty(window, "visualViewport");
+        }
+      }
+    },
+  );
 
   it("stays expanded after pressing a non-focusable composer control", () => {
     mocks.isCompactViewport = true;

--- a/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
@@ -116,6 +116,7 @@ const FOLLOW_UP_PROMPT_BOX_DEFAULT_MIN_HEIGHT = 68;
 const FOLLOW_UP_PROMPT_BOX_ELASTIC_TARGET_HEIGHT =
   FOLLOW_UP_PROMPT_BOX_DEFAULT_MIN_HEIGHT +
   THREAD_PROMPT_CONTEXT_BANNER_ROW_HEIGHT;
+const COMPOSER_CONTROL_SELECTOR = "button, [role='button'], [aria-haspopup]";
 const COMPOSER_OVERLAY_TRIGGER_SELECTOR = "[aria-haspopup]";
 const OPEN_COMPOSER_OVERLAY_TRIGGER_SELECTOR = `${COMPOSER_OVERLAY_TRIGGER_SELECTOR}[aria-expanded="true"]`;
 const MOBILE_KEYBOARD_VIEWPORT_MIN_DELTA_PX = 80;
@@ -299,8 +300,9 @@ function FollowUpPromptBoxWithComposer({
   const interactionExpandedRef = useRef(false);
   const pendingFocusExpansionCleanupRef = useRef<(() => void) | null>(null);
   const pendingFocusLossCleanupRef = useRef<(() => void) | null>(null);
-  const pressedOverlayTriggerRef = useRef(false);
-  const pressedOverlayTriggerCleanupRef = useRef<(() => void) | null>(null);
+  const deferredControlFocusLossRef = useRef<(() => void) | null>(null);
+  const pressedComposerControlRef = useRef(false);
+  const pressedComposerControlCleanupRef = useRef<(() => void) | null>(null);
   const [isInteractionExpanded, setIsInteractionExpanded] = useState(false);
   const [widePromptBoxCollapsedFor, setWidePromptBoxCollapsedFor] = useState<
     string | number | null
@@ -335,13 +337,14 @@ function FollowUpPromptBoxWithComposer({
     pendingFocusExpansionCleanupRef.current = null;
   }, []);
   const cancelPendingFocusLoss = useCallback(() => {
+    deferredControlFocusLossRef.current = null;
     const cleanup = pendingFocusLossCleanupRef.current;
     pendingFocusLossCleanupRef.current = null;
     cleanup?.();
   }, []);
-  const cancelPressedOverlayTrigger = useCallback(() => {
-    const cleanup = pressedOverlayTriggerCleanupRef.current;
-    pressedOverlayTriggerCleanupRef.current = null;
+  const cancelPressedComposerControl = useCallback(() => {
+    const cleanup = pressedComposerControlCleanupRef.current;
+    pressedComposerControlCleanupRef.current = null;
     cleanup?.();
   }, []);
   const handleComposerPointerDown = useCallback(
@@ -349,13 +352,15 @@ function FollowUpPromptBoxWithComposer({
       const target = event.target;
       if (
         !(target instanceof Element) ||
-        !target.closest(COMPOSER_OVERLAY_TRIGGER_SELECTOR)
+        !target.closest(COMPOSER_CONTROL_SELECTOR)
       ) {
         return;
       }
 
-      cancelPressedOverlayTrigger();
-      pressedOverlayTriggerRef.current = true;
+      cancelPendingFocusExpansion();
+      cancelPendingFocusLoss();
+      cancelPressedComposerControl();
+      pressedComposerControlRef.current = true;
       let releaseTimeout: number | null = null;
       const removeReleaseListeners = () => {
         window.removeEventListener("pointerup", finishRelease, true);
@@ -365,8 +370,11 @@ function FollowUpPromptBoxWithComposer({
         removeReleaseListeners();
         releaseTimeout = window.setTimeout(() => {
           releaseTimeout = null;
-          pressedOverlayTriggerRef.current = false;
-          pressedOverlayTriggerCleanupRef.current = null;
+          pressedComposerControlRef.current = false;
+          pressedComposerControlCleanupRef.current = null;
+          const resumeFocusLoss = deferredControlFocusLossRef.current;
+          deferredControlFocusLossRef.current = null;
+          resumeFocusLoss?.();
         });
       };
       const cleanup = () => {
@@ -374,7 +382,7 @@ function FollowUpPromptBoxWithComposer({
         if (releaseTimeout !== null) {
           window.clearTimeout(releaseTimeout);
         }
-        pressedOverlayTriggerRef.current = false;
+        pressedComposerControlRef.current = false;
       };
 
       window.addEventListener("pointerup", finishRelease, {
@@ -385,13 +393,18 @@ function FollowUpPromptBoxWithComposer({
         capture: true,
         once: true,
       });
-      pressedOverlayTriggerCleanupRef.current = cleanup;
+      pressedComposerControlCleanupRef.current = cleanup;
     },
-    [cancelPressedOverlayTrigger],
+    [
+      cancelPendingFocusExpansion,
+      cancelPendingFocusLoss,
+      cancelPressedComposerControl,
+    ],
   );
   const handleComposerFocus = useCallback(
     (event: ReactFocusEvent) => {
       cancelPendingFocusLoss();
+      if (pressedComposerControlRef.current) return;
       setWidePromptBoxCollapsedFor(null);
       if (interactionExpandedRef.current) return;
       if (
@@ -462,14 +475,23 @@ function FollowUpPromptBoxWithComposer({
     (event: ReactFocusEvent) => {
       cancelPendingFocusLoss();
       const dismissedKeyboard = isKeyboardFocusTarget(event.target);
-      const focusLossFrame = window.requestAnimationFrame(() => {
+      const scheduleFocusLoss = () => {
+        const frame = window.requestAnimationFrame(checkFocusLoss);
+        pendingFocusLossCleanupRef.current = () => {
+          window.cancelAnimationFrame(frame);
+        };
+      };
+      const checkFocusLoss = () => {
         pendingFocusLossCleanupRef.current = null;
         const composerElement = composerInteractionRef.current;
         if (!composerElement) return;
 
         if (composerElement.contains(document.activeElement)) return;
 
-        if (pressedOverlayTriggerRef.current) return;
+        if (pressedComposerControlRef.current) {
+          deferredControlFocusLossRef.current = scheduleFocusLoss;
+          return;
+        }
 
         if (
           composerElement.querySelector(OPEN_COMPOSER_OVERLAY_TRIGGER_SELECTOR)
@@ -529,10 +551,8 @@ function FollowUpPromptBoxWithComposer({
           MOBILE_KEYBOARD_DISMISSAL_FALLBACK_MS,
         );
         pendingFocusLossCleanupRef.current = cleanup;
-      });
-      pendingFocusLossCleanupRef.current = () => {
-        window.cancelAnimationFrame(focusLossFrame);
       };
+      scheduleFocusLoss();
     },
     [
       cancelPendingFocusExpansion,
@@ -574,12 +594,12 @@ function FollowUpPromptBoxWithComposer({
     () => () => {
       cancelPendingFocusExpansion();
       cancelPendingFocusLoss();
-      cancelPressedOverlayTrigger();
+      cancelPressedComposerControl();
     },
     [
       cancelPendingFocusExpansion,
       cancelPendingFocusLoss,
-      cancelPressedOverlayTrigger,
+      cancelPressedComposerControl,
     ],
   );
   const steerOnPrimarySubmit =

--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -2234,7 +2234,7 @@ describe("PromptBoxInternal compact layout", () => {
     expect(form.style.height).toBe("");
   });
 
-  it("keeps only the one-line editor and primary action", () => {
+  it("keeps the one-line editor, voice input, and submit action", () => {
     const voice: PromptVoiceConfig = {
       state: "idle",
       isSupported: true,
@@ -2268,8 +2268,8 @@ describe("PromptBoxInternal compact layout", () => {
     expect(screen.queryByRole("button", { name: "Model selector" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Attach files" })).toBeNull();
     expect(
-      screen.queryByRole("button", { name: "Start voice input" }),
-    ).toBeNull();
+      screen.getByRole("button", { name: "Start voice input" }),
+    ).toBeTruthy();
     expect(
       screen.queryByRole("button", { name: /Make prompt box/u }),
     ).toBeNull();
@@ -2376,6 +2376,52 @@ describe("PromptBoxInternal compact layout", () => {
         });
         fireEvent.click(stopButton, { detail: 1 });
         expect(onStop).toHaveBeenCalledOnce();
+      } finally {
+        restoreMatchMedia();
+      }
+    },
+  );
+
+  it.each([false, true])(
+    "dictates into a compact draft without submitting (running: %s)",
+    (isRunning) => {
+      const restoreMatchMedia = mockPointerCoarse(true);
+      try {
+        const start = vi.fn();
+        const onSubmit = vi.fn();
+        render(
+          <PromptBoxInternal
+            {...createPromptBoxProps({
+              value: "Please also check the mobile layout.",
+              onSubmit,
+              submission: { isRunning, onStop: vi.fn() },
+              compact: { isCompact: true, placeholder: "Ask a follow-up" },
+              voice: {
+                state: "idle",
+                isSupported: true,
+                stream: null,
+                start,
+                stop: vi.fn(),
+                cancel: vi.fn(),
+              },
+            })}
+          />,
+        );
+
+        const voiceButton = screen.getByRole("button", {
+          name: "Start voice input",
+        });
+        expect(screen.getByRole("button", { name: "Submit (Enter)" })).toBeTruthy();
+        fireEvent.pointerDown(voiceButton, {
+          button: 0,
+          pointerType: "touch",
+        });
+        fireEvent.click(voiceButton, { detail: 1 });
+        expect(start).toHaveBeenCalledOnce();
+        expect(onSubmit).not.toHaveBeenCalled();
+        expect(getPromptEditorElement().textContent).toBe(
+          "Please also check the mobile layout.",
+        );
       } finally {
         restoreMatchMedia();
       }

--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -2119,8 +2119,8 @@ describe("PromptBoxInternal compact layout", () => {
       expect(submit.hasAttribute("disabled")).toBe(true);
       expect(submit.querySelector('[data-icon="Spinner"]')).not.toBeNull();
       expect(
-        screen.queryByRole("button", { name: "Start voice input" }),
-      ).toBeNull();
+        screen.getByRole("button", { name: "Start voice input" }),
+      ).toBeTruthy();
     } finally {
       restoreMatchMedia();
     }

--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -2333,6 +2333,55 @@ describe("PromptBoxInternal compact layout", () => {
     }
   });
 
+  it.each([false, true])(
+    "keeps voice input available beside stop while running (compact: %s)",
+    (isCompact) => {
+      const restoreMatchMedia = mockPointerCoarse(true);
+      try {
+        const start = vi.fn();
+        const onStop = vi.fn();
+        render(
+          <PromptBoxInternal
+            {...createPromptBoxProps({
+              submission: { isRunning: true, onStop },
+              compact: { isCompact, placeholder: "Ask a follow-up" },
+              voice: {
+                state: "idle",
+                isSupported: true,
+                stream: null,
+                start,
+                stop: vi.fn(),
+                cancel: vi.fn(),
+              },
+            })}
+          />,
+        );
+
+        const voiceButton = screen.getByRole("button", {
+          name: "Start voice input",
+        });
+        const stopButton = screen.getByRole("button", { name: "Stop run" });
+        expect(voiceButton.hasAttribute("disabled")).toBe(false);
+        fireEvent.pointerDown(voiceButton, {
+          button: 0,
+          pointerType: "touch",
+        });
+        fireEvent.click(voiceButton, { detail: 1 });
+        expect(start).toHaveBeenCalledOnce();
+        expect(onStop).not.toHaveBeenCalled();
+
+        fireEvent.pointerDown(stopButton, {
+          button: 0,
+          pointerType: "touch",
+        });
+        fireEvent.click(stopButton, { detail: 1 });
+        expect(onStop).toHaveBeenCalledOnce();
+      } finally {
+        restoreMatchMedia();
+      }
+    },
+  );
+
   it("does not start voice input from the trailing click of a touch submit", () => {
     const restoreMatchMedia = mockPointerCoarse(true);
     try {

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -2602,6 +2602,8 @@ export function PromptBoxInternal({
     !isAttaching &&
     !hasSubmittableInput &&
     canStartVoiceInput;
+  const showCompactVoiceAction =
+    showCompactLayout && showStop && canStartVoiceInput;
   const stopGestureButtonRef = useRef<HTMLButtonElement | null>(null);
   const handleStopPointerDown = useCallback(
     (event: ReactPointerEvent<HTMLButtonElement>) => {
@@ -3118,7 +3120,11 @@ export function PromptBoxInternal({
           ) : null}
           <div
             data-promptbox-input-region=""
-            className={cn("relative", showCompactLayout && "min-w-0 flex-1")}
+            className={cn(
+              "relative",
+              showCompactLayout && "min-w-0 flex-1",
+              showCompactVoiceAction && "pr-9",
+            )}
           >
             {!showCompactLayout ? (
               <>
@@ -3289,13 +3295,15 @@ export function PromptBoxInternal({
                     !showCompactLayout && !suppressPluginComposerCustomizations
                   }
                 >
-                  {!showCompactLayout ? (
+                  {!showCompactLayout || showCompactVoiceAction ? (
                     <>
                       {voice &&
                       !showVoiceActionGroup &&
                       (!showVoiceAsPrimaryAction || showStop) ? (
                         <Button
-                          data-promptbox-expanded-only=""
+                          data-promptbox-expanded-only={
+                            showCompactLayout ? undefined : ""
+                          }
                           type="button"
                           size="icon"
                           variant="ghost"
@@ -3310,7 +3318,9 @@ export function PromptBoxInternal({
                           onPointerDown={handleVoicePointerDown}
                           onClick={handleVoiceClick}
                           className={
-                            COARSE_POINTER_PROMPT_ICON_ACTION_BUTTON_CLASS
+                            showCompactLayout
+                              ? COMPACT_PROMPT_ACTION_BUTTON_CLASS
+                              : COARSE_POINTER_PROMPT_ICON_ACTION_BUTTON_CLASS
                           }
                         >
                           <Icon name="Mic" className="size-4" />

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -2603,7 +2603,9 @@ export function PromptBoxInternal({
     !hasSubmittableInput &&
     canStartVoiceInput;
   const showCompactVoiceAction =
-    showCompactLayout && showStop && canStartVoiceInput;
+    showCompactLayout &&
+    canStartVoiceInput &&
+    (!showVoiceAsPrimaryAction || showStop);
   const stopGestureButtonRef = useRef<HTMLButtonElement | null>(null);
   const handleStopPointerDown = useCallback(
     (event: ReactPointerEvent<HTMLButtonElement>) => {


### PR DESCRIPTION
## Human comments

## What was wrong

- Compact mobile composers hid the microphone whenever Stop or Submit occupied the action slot.
- Focus transitions could move controls mid-gesture: clicking a collapsed desktop microphone expanded the composer before mouse-up, while a pending mobile keyboard-dismissal timer could collapse expanded controls during a press.

## What changed

- Keep the microphone beside Stop or Submit when voice input is available, reserving space for both controls.
- Hold the current composer layout during button gestures and cancel stale focus transitions when a press begins. Resume deferred focus loss after release or cancellation; keyboard focus still expands the composer normally.
- Reuse the existing recording flow so dictation preserves the draft without submitting it or stopping the thread.

## How you verified

- Focused existing-text check on mobile: expanded and compact composers each start recording once from one touch tap; the transcript is inserted after the existing draft, survives reload, and invokes neither Submit nor Stop. Two recordings produced two transcription requests; no page errors. Test microphone and controlled transcript response, with recordings exceeding the existing one-second minimum. [Interaction results](https://github.com/brsbl/bb/releases/download/pr-evidence-thr_mriku4dahg/27275d09f-mobile-existing-text-verification.json).
- All remote CI checks passed at `27275d09f`, including tests, build, typecheck, lint, and Linux/macOS packaging. [CI run](https://github.com/get-bb/bb/actions/runs/34620993581).
- Three new focus-transition regressions failed before the fix and pass afterward; additional coverage checks gesture release and cancellation. Existing regressions cover microphone access beside Stop and Submit and preservation of draft text. [Pre-fix failures](https://github.com/get-bb/bb/actions/runs/34620285188/job/103332268416).
- Chrome for Testing 153.0.8010.36: one mouse gesture starts recording from the collapsed desktop composer; mobile recording/cancellation preserves text, and the model picker stays in place and opens when pressed during pending keyboard dismissal. Reload preserves the draft. Used touch emulation, scripted keyboard dismissal, test audio, and stubbed transcription; no physical phone or real transcription service was tested.
- Screenshots compare merge base `fa1f44ebe` with final head `27275d09f`, using matching fixtures, route, draft, light theme, and viewport. Working-thread status is an API response fixture. Fresh captures use 2× pixel density: mobile 390 × 844 CSS pixels produces 780 × 1688 PNGs; desktop 1440 × 900 produces 2880 × 1800 PNGs.

Composer close-ups at 2× resolution:

| State | Before | After |
| --- | --- | --- |
| Mobile compact, working thread, empty draft | <img src="https://github.com/brsbl/bb/releases/download/pr-evidence-thr_mriku4dahg/fa1f44ebe-2x-mobile-empty-detail.png" width="390" alt="Before: Mobile compact, working thread, empty draft, 2× resolution" /> | <img src="https://github.com/brsbl/bb/releases/download/pr-evidence-thr_mriku4dahg/27275d09f-2x-mobile-empty-detail.png" width="390" alt="After: Mobile compact, working thread, empty draft, 2× resolution" /> |
| Mobile compact, working thread, text | <img src="https://github.com/brsbl/bb/releases/download/pr-evidence-thr_mriku4dahg/fa1f44ebe-2x-mobile-text-detail.png" width="390" alt="Before: Mobile compact, working thread, text, 2× resolution" /> | <img src="https://github.com/brsbl/bb/releases/download/pr-evidence-thr_mriku4dahg/27275d09f-2x-mobile-text-detail.png" width="390" alt="After: Mobile compact, working thread, text, 2× resolution" /> |
| Mobile expanded, working thread, text | <img src="https://github.com/brsbl/bb/releases/download/pr-evidence-thr_mriku4dahg/fa1f44ebe-2x-mobile-expanded-text-detail.png" width="390" alt="Before: Mobile expanded, working thread, text, 2× resolution" /> | <img src="https://github.com/brsbl/bb/releases/download/pr-evidence-thr_mriku4dahg/27275d09f-2x-mobile-expanded-text-detail.png" width="390" alt="After: Mobile expanded, working thread, text, 2× resolution" /> |
| Desktop expanded, working thread, text | <img src="https://github.com/brsbl/bb/releases/download/pr-evidence-thr_mriku4dahg/fa1f44ebe-2x-desktop-text-detail.png" width="600" alt="Before: Desktop expanded, working thread, text, 2× resolution" /> | <img src="https://github.com/brsbl/bb/releases/download/pr-evidence-thr_mriku4dahg/27275d09f-2x-desktop-text-settled-detail.png" width="600" alt="After: Desktop expanded, working thread, text, 2× resolution" /> |

<details>
<summary>Full-page comparisons at 2× resolution</summary>

| State | Before | After |
| --- | --- | --- |
| Mobile compact, working thread, empty draft | <img src="https://github.com/brsbl/bb/releases/download/pr-evidence-thr_mriku4dahg/fa1f44ebe-2x-mobile-empty.png" width="390" alt="Before: Mobile compact, working thread, empty draft, 2× resolution" /> | <img src="https://github.com/brsbl/bb/releases/download/pr-evidence-thr_mriku4dahg/27275d09f-2x-mobile-empty.png" width="390" alt="After: Mobile compact, working thread, empty draft, 2× resolution" /> |
| Mobile compact, working thread, text | <img src="https://github.com/brsbl/bb/releases/download/pr-evidence-thr_mriku4dahg/fa1f44ebe-2x-mobile-text.png" width="390" alt="Before: Mobile compact, working thread, text, 2× resolution" /> | <img src="https://github.com/brsbl/bb/releases/download/pr-evidence-thr_mriku4dahg/27275d09f-2x-mobile-text.png" width="390" alt="After: Mobile compact, working thread, text, 2× resolution" /> |
| Mobile expanded, working thread, text | <img src="https://github.com/brsbl/bb/releases/download/pr-evidence-thr_mriku4dahg/fa1f44ebe-2x-mobile-expanded-text.png" width="390" alt="Before: Mobile expanded, working thread, text, 2× resolution" /> | <img src="https://github.com/brsbl/bb/releases/download/pr-evidence-thr_mriku4dahg/27275d09f-2x-mobile-expanded-text.png" width="390" alt="After: Mobile expanded, working thread, text, 2× resolution" /> |
| Desktop expanded, working thread, text | <img src="https://github.com/brsbl/bb/releases/download/pr-evidence-thr_mriku4dahg/fa1f44ebe-2x-desktop-text.png" width="600" alt="Before: Desktop expanded, working thread, text, 2× resolution" /> | <img src="https://github.com/brsbl/bb/releases/download/pr-evidence-thr_mriku4dahg/27275d09f-2x-desktop-text-settled.png" width="600" alt="After: Desktop expanded, working thread, text, 2× resolution" /> |

</details>

BB-Thread-ID: thr_mriku4dahg

> AGENT GENERATED
