### PR TITLE
Drag threads onto threads to nest them in the sidebar

### DIFF
--- a/apps/app/src/components/sidebar/PinnedThreadTree.tsx
+++ b/apps/app/src/components/sidebar/PinnedThreadTree.tsx
@@ -1,4 +1,10 @@
-import { memo, useCallback, useMemo, type CSSProperties } from "react";
+import {
+  Fragment,
+  memo,
+  useCallback,
+  useMemo,
+  type CSSProperties,
+} from "react";
 import { DndContext, useDroppable } from "@dnd-kit/core";
 import {
   SortableContext,
@@ -17,7 +23,10 @@ import {
   type UseNeighborReorderSortableArgs,
 } from "./useNeighborReorderSortable";
 import { useChronologicalSectionThreadDnd } from "./SectionThreadDndContext";
-import { PINNED_THREAD_PARENT_KEY } from "./useSectionThreadDnd";
+import {
+  PINNED_THREAD_PARENT_KEY,
+  type SectionThreadDndState,
+} from "./useSectionThreadDnd";
 
 interface PinnedThreadRootReorderCallbacks {
   onSettled: () => void;
@@ -42,16 +51,18 @@ interface SortablePinnedRootItemProps {
   collapsedEnvironmentIds: Set<string>;
   collapsedThreadIds: Set<string>;
   disabled: boolean;
+  displace?: boolean;
   node: ProjectThreadNode;
   onProjectSelect?: () => void;
   onToggleEnvironmentCollapsed: (environmentId: string) => void;
   onToggleThreadCollapsed: (threadId: string) => void;
+  sectionDnd?: SectionThreadDndState | null;
   selectedThreadId?: string;
 }
 
 interface PinnedRootItemProps extends Omit<
   SortablePinnedRootItemProps,
-  "disabled"
+  "disabled" | "displace"
 > {
   consumeClickSuppression?: () => boolean;
   dragBindings?: SidebarSortableDragBindings;
@@ -72,6 +83,7 @@ const PinnedRootItem = memo(function PinnedRootItem({
   onProjectSelect,
   onToggleEnvironmentCollapsed,
   onToggleThreadCollapsed,
+  sectionDnd,
   selectedThreadId,
   sortableRef,
   sortableStyle,
@@ -82,6 +94,7 @@ const PinnedRootItem = memo(function PinnedRootItem({
       node={node}
       depthOffset={0}
       isEnvGrouped={false}
+      sectionDnd={sectionDnd}
       selectedThreadId={selectedThreadId}
       collapsedThreadIds={collapsedThreadIds}
       collapsedEnvironmentIds={collapsedEnvironmentIds}
@@ -99,12 +112,14 @@ const PinnedRootItem = memo(function PinnedRootItem({
 
 const SortablePinnedRootItem = memo(function SortablePinnedRootItem({
   disabled,
+  displace = true,
   node,
   ...props
 }: SortablePinnedRootItemProps) {
   const { dragBindings, setNodeRef, style } = useSidebarSortable({
     id: getPinnedRootNodeId(node),
     disabled,
+    displace,
   });
 
   return (
@@ -175,8 +190,13 @@ export const PinnedThreadTree = memo(function PinnedThreadTree({
   }
 
   if (chronologicalDnd) {
+    const previewBeforeKey =
+      chronologicalDnd.dropPreview?.parentKey === PINNED_THREAD_PARENT_KEY
+        ? chronologicalDnd.dropPreview.beforeItemKey
+        : null;
     const showDropPreview =
-      chronologicalDnd.dragOverParentKey === PINNED_THREAD_PARENT_KEY;
+      chronologicalDnd.dragOverParentKey === PINNED_THREAD_PARENT_KEY &&
+      previewBeforeKey === null;
     return (
       <div
         ref={setPinnedParentRef}
@@ -189,17 +209,23 @@ export const PinnedThreadTree = memo(function PinnedThreadTree({
           strategy={verticalListSortingStrategy}
         >
           {chronologicalRootNodes.map((node) => (
-            <SortablePinnedRootItem
-              key={getPinnedRootNodeId(node)}
-              node={node}
-              disabled={chronologicalDnd.pinnedReorderPending}
-              selectedThreadId={selectedThreadId}
-              collapsedThreadIds={collapsedThreadIds}
-              collapsedEnvironmentIds={collapsedEnvironmentIds}
-              onProjectSelect={onProjectSelect}
-              onToggleThreadCollapsed={onToggleThreadCollapsed}
-              onToggleEnvironmentCollapsed={onToggleEnvironmentCollapsed}
-            />
+            <Fragment key={getPinnedRootNodeId(node)}>
+              {previewBeforeKey === `thread:${getPinnedRootNodeId(node)}` ? (
+                <DropPreviewRow depth={0} />
+              ) : null}
+              <SortablePinnedRootItem
+                node={node}
+                disabled={chronologicalDnd.pinnedReorderPending}
+                displace={false}
+                sectionDnd={chronologicalDnd}
+                selectedThreadId={selectedThreadId}
+                collapsedThreadIds={collapsedThreadIds}
+                collapsedEnvironmentIds={collapsedEnvironmentIds}
+                onProjectSelect={onProjectSelect}
+                onToggleThreadCollapsed={onToggleThreadCollapsed}
+                onToggleEnvironmentCollapsed={onToggleEnvironmentCollapsed}
+              />
+            </Fragment>
           ))}
         </SortableContext>
         <DropPreviewRow depth={0} visible={showDropPreview} />

--- a/apps/app/src/components/sidebar/PinnedThreadTree.tsx
+++ b/apps/app/src/components/sidebar/PinnedThreadTree.tsx
@@ -196,6 +196,7 @@ export const PinnedThreadTree = memo(function PinnedThreadTree({
         : null;
     const showDropPreview =
       chronologicalDnd.dragOverParentKey === PINNED_THREAD_PARENT_KEY &&
+      chronologicalDnd.reorderTarget === null &&
       previewBeforeKey === null;
     return (
       <div

--- a/apps/app/src/components/sidebar/ProjectList.modes.test.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.modes.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import { useMemo, type ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   act,
   cleanup,
@@ -43,6 +44,8 @@ vi.mock("@/hooks/queries/host-queries", () => ({
 vi.mock("@/hooks/queries/system-queries", () => ({
   useSystemConfig: () => ({ data: undefined }),
 }));
+
+const queryClient = new QueryClient();
 
 vi.mock("@bb/client-core", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@bb/client-core")>();
@@ -153,24 +156,30 @@ function MachineModeProbe({ threads = [] }: { threads?: ThreadListEntry[] }) {
   };
 
   return (
-    <MachineModeSections
-      threads={threads}
-      draftThreadIds={new Set()}
-      effectivePinnedThreadIds={new Set()}
-      status="ready"
-      showPinnedSection={false}
-      pinnedSection={{ label: "Pinned", content: null }}
-      threadsSection={{ label: "Threads" }}
-      collapsedSectionIds={collapsedSectionIdSet}
-      collapsedThreadIds={new Set()}
-      collapsedEnvironmentIds={new Set()}
-      compareThreads={() => 0}
-      renderSectionDisplayOptions={() => null}
-      isSectionDisplayOptionsOpen={() => false}
-      onToggleCollapsed={handleToggleCollapsed}
-      onToggleThreadCollapsed={vi.fn()}
-      onToggleEnvironmentCollapsed={vi.fn()}
-    />
+    <QueryClientProvider client={queryClient}>
+      <MachineModeSections
+        threads={threads}
+        draftThreadIds={new Set()}
+        effectivePinnedThreadIds={new Set()}
+        status="ready"
+        showPinnedSection={false}
+        pinnedSection={{ label: "Pinned", content: null }}
+        pinnedReorderPending={false}
+        pinnedRootNodes={[]}
+        pinnedThreads={[]}
+        onReorderPinnedThread={vi.fn()}
+        threadsSection={{ label: "Threads" }}
+        collapsedSectionIds={collapsedSectionIdSet}
+        collapsedThreadIds={new Set()}
+        collapsedEnvironmentIds={new Set()}
+        compareThreads={() => 0}
+        renderSectionDisplayOptions={() => null}
+        isSectionDisplayOptionsOpen={() => false}
+        onToggleCollapsed={handleToggleCollapsed}
+        onToggleThreadCollapsed={vi.fn()}
+        onToggleEnvironmentCollapsed={vi.fn()}
+      />
+    </QueryClientProvider>
   );
 }
 

--- a/apps/app/src/components/sidebar/ProjectList.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.tsx
@@ -41,9 +41,13 @@ import { useHosts, usePrimaryHost } from "@/hooks/queries/host-queries";
 import { useDialogState } from "@/hooks/useDialogState";
 import { usePromptDraftInputThreadIds } from "@/hooks/usePromptDraftStorage";
 import {
+  buildProjectThreadGroups,
   getCollapsedChildActivity,
+  getProjectThreadItemDescendants,
   type ProjectThreadNode,
 } from "@bb/client-core";
+import { useSectionThreadDnd } from "./useSectionThreadDnd";
+import { useRenderedSectionThreadDnd } from "./useRenderedSectionThreadDnd";
 import { getRootComposeRoutePath } from "@/lib/route-paths";
 import { getThreadDisplayTitle } from "@/lib/thread-title";
 import { getMutationErrorMessage } from "@/lib/mutation-errors";
@@ -288,6 +292,7 @@ const EMPTY_PROJECT_THREAD_LIST_STATE: ProjectThreadListState = {
 };
 
 const EMPTY_PROJECTS: readonly ProjectResponse[] = [];
+const EMPTY_THREAD_LIST: ThreadListEntry[] = [];
 const EMPTY_SECTION_DEFINITIONS: readonly ThreadSectionResponse[] = [];
 
 function getProjectThreadListState({
@@ -633,7 +638,98 @@ function useSidebarProgressiveDisclosureEnabled(): boolean {
   );
 }
 
-interface ProjectModeSectionsProps extends BuiltInSectionRenderState {
+interface GroupedModePinnedProps {
+  pinnedReorderPending: boolean;
+  pinnedRootNodes: readonly ProjectThreadNode[];
+  pinnedThreads: readonly ThreadListEntry[];
+  onReorderPinnedThread: NonNullable<
+    PinnedThreadTreeProps["onReorderPinnedRoot"]
+  >;
+}
+
+function buildGroupSectionItem(
+  id: string,
+  key: SidebarSectionId,
+  name: string,
+  threads: readonly ThreadListEntry[],
+  compareThreads: ThreadComparator,
+  draftThreadIds: ReadonlySet<string>,
+): ProjectThreadItem {
+  const items = buildProjectThreadGroups(
+    threads,
+    compareThreads,
+    draftThreadIds,
+  );
+  return {
+    kind: "section",
+    group: {
+      id,
+      key,
+      name,
+      items,
+      threadCount: getProjectThreadItemDescendants(items).length,
+      activity: getCollapsedChildActivity(threads, draftThreadIds),
+    },
+  };
+}
+
+function useGroupedModeThreadDnd({
+  collapsedThreadIds,
+  compareThreads,
+  draftThreadIds,
+  onToggleThreadCollapsed,
+  order,
+  onOrderChange,
+  pinned,
+  rootItems,
+  threads,
+}: {
+  collapsedThreadIds: Set<string>;
+  compareThreads: ThreadComparator;
+  draftThreadIds: ReadonlySet<string>;
+  onToggleThreadCollapsed: ToggleCollapsedId;
+  order: readonly SidebarSectionId[];
+  onOrderChange: (order: SidebarSectionId[]) => void;
+  pinned: GroupedModePinnedProps;
+  rootItems: readonly ProjectThreadItem[];
+  threads: readonly ThreadListEntry[];
+}) {
+  const expandThread = useCallback(
+    (threadId: string) => {
+      if (collapsedThreadIds.has(threadId)) {
+        onToggleThreadCollapsed(threadId);
+      }
+    },
+    [collapsedThreadIds, onToggleThreadCollapsed],
+  );
+  const threadDnd = useSectionThreadDnd({
+    containerId: CHRONOLOGICAL_CONTAINER_ID,
+    enabled: true,
+    rootItems,
+    topLevelSectionOrder: order,
+    onTopLevelSectionOrderChange: onOrderChange,
+    onExpandThread: expandThread,
+    groups: true,
+    pinnedReorderPending: pinned.pinnedReorderPending,
+    pinnedThreads: pinned.pinnedThreads,
+    pinnedRootNodes: pinned.pinnedRootNodes,
+    onReorderPinnedThread: pinned.onReorderPinnedThread,
+  });
+  return useRenderedSectionThreadDnd({
+    compareThreads,
+    draftThreadIds,
+    groups: true,
+    pinnedRootNodes: pinned.pinnedRootNodes,
+    pinnedThreads: pinned.pinnedThreads,
+    rootItems,
+    sectionDnd: threadDnd,
+    sections: EMPTY_SECTION_DEFINITIONS,
+    threads,
+  });
+}
+
+interface ProjectModeSectionsProps
+  extends BuiltInSectionRenderState, GroupedModePinnedProps {
   collapsedEnvironmentIds: Set<string>;
   collapsedThreadIds: Set<string>;
   compareThreads: ThreadComparator;
@@ -663,7 +759,11 @@ function ProjectModeSections({
   onToggleCollapsed,
   onToggleEnvironmentCollapsed,
   onToggleThreadCollapsed,
+  pinnedReorderPending,
+  pinnedRootNodes,
   pinnedSection,
+  pinnedThreads,
+  onReorderPinnedThread,
   projects,
   selectedThreadId,
   showPinnedSection,
@@ -769,9 +869,13 @@ function ProjectModeSections({
     }
     return rows;
   }, [projectRows]);
-  const personalThreads =
-    threadsByProject.get(PERSONAL_PROJECT_ID)?.filter(isSidebarProjectThread) ??
-    [];
+  const personalThreads = useMemo(
+    () =>
+      threadsByProject
+        .get(PERSONAL_PROJECT_ID)
+        ?.filter(isSidebarProjectThread) ?? EMPTY_THREAD_LIST,
+    [threadsByProject],
+  );
   const { onOrderChange, order, persistedOrder } = useSidebarModeSectionOrder({
     mode: "project",
     entitySectionIds: projectSectionIds,
@@ -779,6 +883,48 @@ function ProjectModeSections({
     showPinnedSection,
   });
   const reorderDisabled = order.length < 2;
+  const groupRootItems = useMemo<ProjectThreadItem[]>(
+    () => [
+      ...buildProjectThreadGroups(
+        personalThreads,
+        compareThreads,
+        draftThreadIds,
+      ),
+      ...projectRows.map((row) =>
+        buildGroupSectionItem(
+          row.project.id,
+          buildSidebarEntitySectionId("project", row.project.id),
+          row.project.name,
+          row.threadListState.status === "ready"
+            ? row.threadListState.threads
+            : EMPTY_THREAD_LIST,
+          compareThreads,
+          draftThreadIds,
+        ),
+      ),
+    ],
+    [compareThreads, draftThreadIds, personalThreads, projectRows],
+  );
+  const nonPinnedThreads = useMemo(
+    () => threads.filter((thread) => !effectivePinnedThreadIds.has(thread.id)),
+    [effectivePinnedThreadIds, threads],
+  );
+  const threadDnd = useGroupedModeThreadDnd({
+    collapsedThreadIds,
+    compareThreads,
+    draftThreadIds,
+    onToggleThreadCollapsed,
+    order: persistedOrder,
+    onOrderChange,
+    pinned: {
+      pinnedReorderPending,
+      pinnedRootNodes,
+      pinnedThreads,
+      onReorderPinnedThread,
+    },
+    rootItems: groupRootItems,
+    threads: nonPinnedThreads,
+  });
   const builtInSections: BuiltInSidebarSectionOptionsById = {
     pinned: pinnedSection,
     threads: {
@@ -788,6 +934,7 @@ function ProjectModeSections({
       content: (
         <ProjectThreadTree
           projectId={PERSONAL_PROJECT_ID}
+          dndParentKey={CHRONOLOGICAL_CONTAINER_ID}
           threadListState={getProjectThreadListState({
             status,
             threads: personalThreads,
@@ -811,6 +958,7 @@ function ProjectModeSections({
       order={order}
       reorderOrder={persistedOrder}
       onOrderChange={onOrderChange}
+      threadDnd={threadDnd}
     >
       {(sectionId, consumeClickSuppression) => {
         const builtInSection = renderBuiltInSidebarSection({
@@ -971,7 +1119,8 @@ function SectionModeSections({
   );
 }
 
-interface MachineModeSectionsProps extends BuiltInSectionRenderState {
+interface MachineModeSectionsProps
+  extends BuiltInSectionRenderState, GroupedModePinnedProps {
   collapsedEnvironmentIds: Set<string>;
   collapsedThreadIds: Set<string>;
   compareThreads: ThreadComparator;
@@ -1004,7 +1153,11 @@ export function MachineModeSections({
   onToggleCollapsed,
   onToggleEnvironmentCollapsed,
   onToggleThreadCollapsed,
+  pinnedReorderPending,
+  pinnedRootNodes,
   pinnedSection,
+  pinnedThreads,
+  onReorderPinnedThread,
   renderSectionDisplayOptions,
   selectedThreadId,
   showPinnedSection,
@@ -1079,6 +1232,44 @@ export function MachineModeSections({
     showPinnedSection,
   });
   const reorderDisabled = order.length < 2;
+  const groupRootItems = useMemo<ProjectThreadItem[]>(
+    () => [
+      ...(machineSections.length === 0
+        ? buildProjectThreadGroups(
+            nonPinnedThreads,
+            compareThreads,
+            draftThreadIds,
+          )
+        : []),
+      ...machineSections.map((section) =>
+        buildGroupSectionItem(
+          section.key,
+          buildSidebarEntitySectionId("machine", section.key),
+          section.label,
+          section.threadListState.threads,
+          compareThreads,
+          draftThreadIds,
+        ),
+      ),
+    ],
+    [compareThreads, draftThreadIds, machineSections, nonPinnedThreads],
+  );
+  const threadDnd = useGroupedModeThreadDnd({
+    collapsedThreadIds,
+    compareThreads,
+    draftThreadIds,
+    onToggleThreadCollapsed,
+    order: persistedOrder,
+    onOrderChange,
+    pinned: {
+      pinnedReorderPending,
+      pinnedRootNodes,
+      pinnedThreads,
+      onReorderPinnedThread,
+    },
+    rootItems: groupRootItems,
+    threads: nonPinnedThreads,
+  });
   const builtInSections: BuiltInSidebarSectionOptionsById = {
     pinned: pinnedSection,
     threads: {
@@ -1087,6 +1278,7 @@ export function MachineModeSections({
       collapsedThreads: nonPinnedThreads,
       content: (
         <ProjectThreadTree
+          dndParentKey={CHRONOLOGICAL_CONTAINER_ID}
           threadListState={allThreadsListState}
           progressiveDisclosureEnabled={progressiveDisclosureEnabled}
           compareThreads={compareThreads}
@@ -1107,6 +1299,7 @@ export function MachineModeSections({
       order={order}
       reorderOrder={persistedOrder}
       onOrderChange={onOrderChange}
+      threadDnd={threadDnd}
     >
       {(sectionId, consumeClickSuppression) => {
         const builtInSection = renderBuiltInSidebarSection({
@@ -1139,6 +1332,7 @@ export function MachineModeSections({
             consumeClickSuppression={consumeClickSuppression}
           >
             <ProjectThreadTree
+              dndParentKey={sectionId}
               threadListState={section.threadListState}
               progressiveDisclosureEnabled={progressiveDisclosureEnabled}
               compareThreads={compareThreads}
@@ -1670,6 +1864,10 @@ function ProjectListComponent({
               status={projectsState.status}
               showPinnedSection={hasPinnedSection}
               pinnedSection={pinnedSection}
+              pinnedReorderPending={isPinnedReorderPending}
+              pinnedRootNodes={pinnedSidebarState.rootNodes}
+              pinnedThreads={pinnedRootThreads}
+              onReorderPinnedThread={handleReorderPinnedRoot}
               threadsSection={threadsSection}
               selectedThreadId={selectedThreadId}
               collapsedSectionIds={collapsedSidebarSectionIds}
@@ -1727,6 +1925,10 @@ function ProjectListComponent({
                 status={projectsState.status}
                 showPinnedSection={hasPinnedSection}
                 pinnedSection={pinnedSection}
+                pinnedReorderPending={isPinnedReorderPending}
+                pinnedRootNodes={pinnedSidebarState.rootNodes}
+                pinnedThreads={pinnedRootThreads}
+                onReorderPinnedThread={handleReorderPinnedRoot}
                 threadsSection={threadsSection}
                 selectedThreadId={selectedThreadId}
                 collapsedSectionIds={collapsedSidebarSectionIds}

--- a/apps/app/src/components/sidebar/ProjectList.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.tsx
@@ -654,7 +654,7 @@ function buildGroupSectionItem(
   threads: readonly ThreadListEntry[],
   compareThreads: ThreadComparator,
   draftThreadIds: ReadonlySet<string>,
-): ProjectThreadItem {
+): Extract<ProjectThreadItem, { kind: "section" }> {
   const items = buildProjectThreadGroups(
     threads,
     compareThreads,
@@ -883,14 +883,14 @@ function ProjectModeSections({
     showPinnedSection,
   });
   const reorderDisabled = order.length < 2;
-  const groupRootItems = useMemo<ProjectThreadItem[]>(
-    () => [
-      ...buildProjectThreadGroups(
-        personalThreads,
-        compareThreads,
-        draftThreadIds,
-      ),
-      ...projectRows.map((row) =>
+  const personalItems = useMemo(
+    () =>
+      buildProjectThreadGroups(personalThreads, compareThreads, draftThreadIds),
+    [compareThreads, draftThreadIds, personalThreads],
+  );
+  const projectGroups = useMemo(
+    () =>
+      projectRows.map((row) =>
         buildGroupSectionItem(
           row.project.id,
           buildSidebarEntitySectionId("project", row.project.id),
@@ -902,8 +902,18 @@ function ProjectModeSections({
           draftThreadIds,
         ),
       ),
-    ],
-    [compareThreads, draftThreadIds, personalThreads, projectRows],
+    [compareThreads, draftThreadIds, projectRows],
+  );
+  const projectItemsByProjectId = useMemo(
+    () =>
+      new Map(
+        projectGroups.map((group) => [group.group.id, group.group.items]),
+      ),
+    [projectGroups],
+  );
+  const groupRootItems = useMemo<ProjectThreadItem[]>(
+    () => [...personalItems, ...projectGroups],
+    [personalItems, projectGroups],
   );
   const nonPinnedThreads = useMemo(
     () => threads.filter((thread) => !effectivePinnedThreadIds.has(thread.id)),
@@ -935,6 +945,7 @@ function ProjectModeSections({
         <ProjectThreadTree
           projectId={PERSONAL_PROJECT_ID}
           dndParentKey={CHRONOLOGICAL_CONTAINER_ID}
+          rootItems={personalItems}
           threadListState={getProjectThreadListState({
             status,
             threads: personalThreads,
@@ -954,12 +965,7 @@ function ProjectModeSections({
   };
 
   return (
-    <ReorderableSidebarSectionOrderList
-      order={order}
-      reorderOrder={persistedOrder}
-      onOrderChange={onOrderChange}
-      threadDnd={threadDnd}
-    >
+    <ReorderableSidebarSectionOrderList order={order} threadDnd={threadDnd}>
       {(sectionId, consumeClickSuppression) => {
         const builtInSection = renderBuiltInSidebarSection({
           sectionId,
@@ -978,6 +984,7 @@ function ProjectModeSections({
             key={sectionId}
             sortableId={sectionId}
             project={row.project}
+            rootItems={projectItemsByProjectId.get(row.project.id)}
             threadListState={row.threadListState}
             progressiveDisclosureEnabled={progressiveDisclosureEnabled}
             selectedThreadId={selectedThreadId}
@@ -1232,16 +1239,20 @@ export function MachineModeSections({
     showPinnedSection,
   });
   const reorderDisabled = order.length < 2;
-  const groupRootItems = useMemo<ProjectThreadItem[]>(
-    () => [
-      ...(machineSections.length === 0
+  const allThreadItems = useMemo(
+    () =>
+      machineSections.length === 0
         ? buildProjectThreadGroups(
             nonPinnedThreads,
             compareThreads,
             draftThreadIds,
           )
-        : []),
-      ...machineSections.map((section) =>
+        : [],
+    [compareThreads, draftThreadIds, machineSections.length, nonPinnedThreads],
+  );
+  const machineGroups = useMemo(
+    () =>
+      machineSections.map((section) =>
         buildGroupSectionItem(
           section.key,
           buildSidebarEntitySectionId("machine", section.key),
@@ -1251,8 +1262,18 @@ export function MachineModeSections({
           draftThreadIds,
         ),
       ),
-    ],
-    [compareThreads, draftThreadIds, machineSections, nonPinnedThreads],
+    [compareThreads, draftThreadIds, machineSections],
+  );
+  const machineItemsBySectionId = useMemo(
+    () =>
+      new Map(
+        machineGroups.map((group) => [group.group.key, group.group.items]),
+      ),
+    [machineGroups],
+  );
+  const groupRootItems = useMemo<ProjectThreadItem[]>(
+    () => [...allThreadItems, ...machineGroups],
+    [allThreadItems, machineGroups],
   );
   const threadDnd = useGroupedModeThreadDnd({
     collapsedThreadIds,
@@ -1279,6 +1300,7 @@ export function MachineModeSections({
       content: (
         <ProjectThreadTree
           dndParentKey={CHRONOLOGICAL_CONTAINER_ID}
+          rootItems={allThreadItems}
           threadListState={allThreadsListState}
           progressiveDisclosureEnabled={progressiveDisclosureEnabled}
           compareThreads={compareThreads}
@@ -1295,12 +1317,7 @@ export function MachineModeSections({
   };
 
   return (
-    <ReorderableSidebarSectionOrderList
-      order={order}
-      reorderOrder={persistedOrder}
-      onOrderChange={onOrderChange}
-      threadDnd={threadDnd}
-    >
+    <ReorderableSidebarSectionOrderList order={order} threadDnd={threadDnd}>
       {(sectionId, consumeClickSuppression) => {
         const builtInSection = renderBuiltInSidebarSection({
           sectionId,
@@ -1333,6 +1350,7 @@ export function MachineModeSections({
           >
             <ProjectThreadTree
               dndParentKey={sectionId}
+              rootItems={machineItemsBySectionId.get(sectionId)}
               threadListState={section.threadListState}
               progressiveDisclosureEnabled={progressiveDisclosureEnabled}
               compareThreads={compareThreads}

--- a/apps/app/src/components/sidebar/ProjectList.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.tsx
@@ -40,7 +40,10 @@ import {
 import { useHosts, usePrimaryHost } from "@/hooks/queries/host-queries";
 import { useDialogState } from "@/hooks/useDialogState";
 import { usePromptDraftInputThreadIds } from "@/hooks/usePromptDraftStorage";
-import { getCollapsedChildActivity } from "@bb/client-core";
+import {
+  getCollapsedChildActivity,
+  type ProjectThreadNode,
+} from "@bb/client-core";
 import { getRootComposeRoutePath } from "@/lib/route-paths";
 import { getThreadDisplayTitle } from "@/lib/thread-title";
 import { getMutationErrorMessage } from "@/lib/mutation-errors";
@@ -863,6 +866,7 @@ interface SectionModeSectionsProps extends BuiltInSectionRenderState {
   onToggleThreadCollapsed: ToggleCollapsedId;
   pinnedSection: BuiltInSidebarSectionOptions;
   pinnedReorderPending: boolean;
+  pinnedRootNodes: readonly ProjectThreadNode[];
   pinnedThreads: readonly ThreadListEntry[];
   onReorderPinnedThread: NonNullable<
     PinnedThreadTreeProps["onReorderPinnedRoot"]
@@ -890,6 +894,7 @@ function SectionModeSections({
   onToggleThreadCollapsed,
   pinnedSection,
   pinnedReorderPending,
+  pinnedRootNodes,
   pinnedThreads,
   onReorderPinnedThread,
   selectedThreadId,
@@ -952,6 +957,7 @@ function SectionModeSections({
         topLevelSectionOrder={order}
         onTopLevelSectionOrderChange={onOrderChange}
         pinnedReorderPending={pinnedReorderPending}
+        pinnedRootNodes={pinnedRootNodes}
         pinnedThreads={pinnedThreads}
         onReorderPinnedThread={onReorderPinnedThread}
         builtInSections={{
@@ -1690,6 +1696,7 @@ function ProjectListComponent({
                 sections={sections}
                 pinnedSection={pinnedSection}
                 pinnedReorderPending={isPinnedReorderPending}
+                pinnedRootNodes={pinnedSidebarState.rootNodes}
                 pinnedThreads={pinnedRootThreads}
                 onReorderPinnedThread={handleReorderPinnedRoot}
                 threadsSection={threadsSection}

--- a/apps/app/src/components/sidebar/ProjectRow.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.tsx
@@ -9,6 +9,7 @@ import {
   SIDEBAR_GROUP_TEXT_CLASS,
 } from "./sidebarRowClasses";
 import {
+  Fragment,
   memo,
   useCallback,
   useMemo,
@@ -141,11 +142,20 @@ import type { NeighborReorderRequest } from "@bb/client-core";
 import { SidebarChildToggleChevron } from "./SidebarChildToggleChevron";
 import { SidebarSectionOrderList } from "./SidebarSectionOrderList";
 import {
-  collectSectionThreadDndLookup,
   PINNED_THREAD_PARENT_KEY,
   useSectionThreadDnd,
   type SectionThreadDndState,
 } from "./useSectionThreadDnd";
+import {
+  getSidebarThreadRowDroppableId,
+  type ThreadRowNestDrop,
+} from "./sidebarThreadRowDroppable";
+import {
+  getSidebarItemKey,
+  getSidebarNestParentKey,
+  resolveSidebarDropPreviewPlacement,
+  type SidebarDropPreviewTarget,
+} from "./sidebarDropPreviewPlacement";
 import {
   getBuiltInSidebarSectionNode,
   renderBuiltInSidebarSection,
@@ -232,6 +242,7 @@ interface ChronologicalSectionThreadSectionsProps extends SectionThreadTreeProps
   topLevelSectionOrder: readonly SidebarSectionId[];
   onTopLevelSectionOrderChange: (order: SidebarSectionId[]) => void;
   pinnedReorderPending: boolean;
+  pinnedRootNodes?: readonly ProjectThreadNode[];
   pinnedThreads: readonly ThreadListEntry[];
   onReorderPinnedThread: (
     request: NeighborReorderRequest,
@@ -271,6 +282,43 @@ export function shouldSuppressPinnedThreadDropPreview({
   );
 }
 
+const EMPTY_PINNED_ROOT_NODES: readonly ProjectThreadNode[] = [];
+
+function resolveDropPreviewTarget({
+  dragOverParentKey,
+  nestTarget,
+  rootItems,
+}: {
+  dragOverParentKey: string | null;
+  nestTarget: SectionThreadDndState["nestTarget"];
+  rootItems: readonly ProjectThreadItem[];
+}): SidebarDropPreviewTarget | null {
+  if (nestTarget?.state === "valid") {
+    return { kind: "nest", parentThreadId: nestTarget.threadId };
+  }
+  if (dragOverParentKey === null) return null;
+  if (dragOverParentKey === PINNED_THREAD_PARENT_KEY) {
+    return { kind: "pinned", parentKey: PINNED_THREAD_PARENT_KEY };
+  }
+  if (dragOverParentKey === CHRONOLOGICAL_CONTAINER_ID) {
+    return {
+      kind: "container",
+      parentKey: CHRONOLOGICAL_CONTAINER_ID,
+      sectionId: null,
+    };
+  }
+  for (const item of rootItems) {
+    if (item.kind === "section" && item.group.key === dragOverParentKey) {
+      return {
+        kind: "container",
+        parentKey: item.group.key,
+        sectionId: item.group.id,
+      };
+    }
+  }
+  return null;
+}
+
 interface ProjectThreadTreeGroupProps {
   children: ReactNode;
   variant: ProjectThreadTreeVariant;
@@ -291,6 +339,7 @@ interface ThreadTreeNodeRowProps {
   onToggleEnvironmentCollapsed: (environmentId: string) => void;
   consumeClickSuppression?: ConsumeDragClickSuppression;
   dragBindings?: SidebarSortableDragBindings;
+  sectionDnd?: SectionThreadDndState | null;
   sortableRef?: (element: HTMLDivElement | null) => void;
   sortableStyle?: CSSProperties;
 }
@@ -336,17 +385,6 @@ interface SectionTreeItemRowProps {
   sectionDnd?: SectionThreadDndState;
   sortableRef?: (element: HTMLDivElement | null) => void;
   sortableStyle?: CSSProperties;
-}
-
-function getItemKey(item: ProjectThreadItem): string {
-  switch (item.kind) {
-    case "thread":
-      return `thread:${item.node.thread.id}`;
-    case "environment":
-      return `env:${item.group.environmentId}`;
-    case "section":
-      return `section:${item.group.key}`;
-  }
 }
 
 function getItemProjectId(item: ProjectThreadItem): string {
@@ -522,6 +560,7 @@ function getThreadRowOptions({
   isCollapsed,
   isEnvGrouped,
   isParent,
+  nestDrop,
   nodeDepth,
   onToggleThreadCollapsed,
   stickyLevel,
@@ -533,6 +572,7 @@ function getThreadRowOptions({
     isCompact: nodeDepth > 0 || isEnvGrouped,
     ...(consumeClickSuppression ? { consumeClickSuppression } : {}),
     ...(dragBindings ? { dragBindings } : {}),
+    ...(nestDrop ? { nestDrop } : {}),
   };
 
   if (!isParent) {
@@ -562,6 +602,7 @@ interface GetThreadRowOptionsArgs {
   isEnvGrouped: boolean;
   isParent: boolean;
   depthOffset: number;
+  nestDrop?: ThreadRowNestDrop;
   nodeDepth: number;
   onToggleThreadCollapsed: (threadId: string) => void;
   stickyLevel?: number;
@@ -687,6 +728,7 @@ const DraggableSectionThreadItemRow = memo(
     const { dragBindings, setNodeRef, style } = useSidebarSortable({
       id: itemId,
       disabled: false,
+      displace: false,
     });
 
     return (
@@ -1240,6 +1282,7 @@ const ThreadTreeItemRow = memo(function ThreadTreeItemRow({
         onToggleEnvironmentCollapsed={onToggleEnvironmentCollapsed}
         consumeClickSuppression={consumeClickSuppression}
         dragBindings={dragBindings}
+        sectionDnd={sectionDnd}
         sortableRef={sortableRef}
         sortableStyle={sortableStyle}
       />
@@ -1263,29 +1306,52 @@ const ThreadTreeItemRow = memo(function ThreadTreeItemRow({
   );
 });
 
+function getDropPreviewRowStyle({
+  depth,
+  nest,
+  visible,
+}: {
+  depth: number;
+  nest: boolean;
+  visible: boolean;
+}): CSSProperties {
+  const indent = nest
+    ? getSidebarThreadRowPaddingLeft(depth) - getSidebarThreadRowPaddingLeft(0)
+    : 0;
+  return {
+    paddingLeft: getSidebarThreadRowPaddingLeft(nest ? 0 : depth),
+    marginLeft: indent > 0 ? indent : undefined,
+    width: indent > 0 ? `calc(100% - ${indent}px)` : undefined,
+    marginTop: visible ? undefined : 0,
+  };
+}
+
 export function DropPreviewRow({
   depth,
+  nest = false,
   visible = true,
 }: {
   depth: number;
+  nest?: boolean;
   visible?: boolean;
 }) {
   return (
     <div
       aria-hidden="true"
       data-sidebar-section-drop-preview="true"
+      data-sidebar-nest-drop-preview={nest ? "true" : undefined}
       data-visible={visible ? "true" : "false"}
-      style={{
-        paddingLeft: getSidebarThreadRowPaddingLeft(depth),
-        marginTop: visible ? undefined : 0,
-      }}
+      style={getDropPreviewRowStyle({ depth, nest, visible })}
       className={cn(
         SIDEBAR_ROW_BASE_CLASS,
         "pointer-events-none overflow-hidden transition-[height,margin,opacity,border-width] duration-150 ease-out",
         visible
           ? cn(
               COARSE_POINTER_COMPACT_ROW_HEIGHT_CLASS,
-              "border border-dashed border-sidebar-border bg-sidebar-accent/40 opacity-100",
+              "border border-dashed opacity-100",
+              nest
+                ? "border-sidebar-ring bg-sidebar-accent/70"
+                : "border-sidebar-border bg-sidebar-accent/40",
             )
           : "h-0 border-0 opacity-0 max-md:pointer-coarse:h-0",
       )}
@@ -1348,7 +1414,19 @@ const SectionTreeItemRow = memo(function SectionTreeItemRow({
   const headerDepth = getThreadRowDepth({ depthOffset, nodeDepth: 0, variant });
   const stickyLevel =
     depthOffset < SIDEBAR_STICKY_PARENT_DEPTH_CAP ? depthOffset : undefined;
-  const showDropPreview = sectionDnd?.dragOverParentKey === sectionKey;
+  const inlinePreviewBeforeKey =
+    sectionDnd?.dropPreview?.parentKey === sectionKey
+      ? sectionDnd.dropPreview.beforeItemKey
+      : null;
+  const showDropPreview =
+    sectionDnd?.dragOverParentKey === sectionKey &&
+    inlinePreviewBeforeKey === null;
+  const previewDepth = getThreadRowDepth({
+    depthOffset:
+      variant === "section" && depthOffset === 0 ? 0 : depthOffset + 1,
+    nodeDepth: 0,
+    variant,
+  });
   const showChildren = !isCollapsed && section.items.length > 0;
   const showChildrenArea =
     showChildren || (sectionDnd?.activeThread != null && !isCollapsed);
@@ -1381,43 +1459,40 @@ const SectionTreeItemRow = memo(function SectionTreeItemRow({
               if (!item) {
                 return null;
               }
+              const itemKey = getSidebarItemKey(item);
               return (
-                <SectionDndItemRow
-                  key={getItemKey(item)}
-                  projectId={getItemProjectId(item)}
-                  item={item}
-                  depthOffset={
-                    variant === "section" && depthOffset === 0
-                      ? 0
-                      : depthOffset + 1
-                  }
-                  selectedThreadId={selectedThreadId}
-                  collapsedThreadIds={collapsedThreadIds}
-                  collapsedEnvironmentIds={collapsedEnvironmentIds}
-                  variant={variant}
-                  onProjectSelect={onProjectSelect}
-                  onCreateThreadInSection={onCreateThreadInSection}
-                  onRenameSection={onRenameSection}
-                  onRemoveSection={onRemoveSection}
-                  onToggleThreadCollapsed={onToggleThreadCollapsed}
-                  onToggleEnvironmentCollapsed={onToggleEnvironmentCollapsed}
-                  sectionDnd={sectionDnd}
-                />
+                <Fragment key={itemKey}>
+                  {inlinePreviewBeforeKey === itemKey ? (
+                    <DropPreviewRow depth={previewDepth} />
+                  ) : null}
+                  <SectionDndItemRow
+                    projectId={getItemProjectId(item)}
+                    item={item}
+                    depthOffset={
+                      variant === "section" && depthOffset === 0
+                        ? 0
+                        : depthOffset + 1
+                    }
+                    selectedThreadId={selectedThreadId}
+                    collapsedThreadIds={collapsedThreadIds}
+                    collapsedEnvironmentIds={collapsedEnvironmentIds}
+                    variant={variant}
+                    onProjectSelect={onProjectSelect}
+                    onCreateThreadInSection={onCreateThreadInSection}
+                    onRenameSection={onRenameSection}
+                    onRemoveSection={onRemoveSection}
+                    onToggleThreadCollapsed={onToggleThreadCollapsed}
+                    onToggleEnvironmentCollapsed={onToggleEnvironmentCollapsed}
+                    sectionDnd={sectionDnd}
+                  />
+                </Fragment>
               );
             }}
           />
         </SectionDndSortableList>
       ) : null}
       {sectionDnd ? (
-        <DropPreviewRow
-          visible={showDropPreview}
-          depth={getThreadRowDepth({
-            depthOffset:
-              variant === "section" && depthOffset === 0 ? 0 : depthOffset + 1,
-            nodeDepth: 0,
-            variant,
-          })}
-        />
+        <DropPreviewRow visible={showDropPreview} depth={previewDepth} />
       ) : null}
     </div>
   ) : null;
@@ -1517,12 +1592,46 @@ export const ThreadTreeNodeRow = memo(function ThreadTreeNodeRow({
   onToggleEnvironmentCollapsed,
   consumeClickSuppression,
   dragBindings,
+  sectionDnd,
   sortableRef,
   sortableStyle,
 }: ThreadTreeNodeRowProps) {
   const isCollapsed = collapsedThreadIds.has(node.thread.id);
   const hasChildren = node.children.length > 0;
   const isParent = hasChildren;
+  const nestDropEnabled = Boolean(sectionDnd);
+  const { setNodeRef: setNestDropNodeRef } = useDroppable({
+    id: getSidebarThreadRowDroppableId(node.thread.id),
+    disabled: !nestDropEnabled,
+    resizeObserverConfig: { disabled: !nestDropEnabled },
+  });
+  const nestTargetState =
+    sectionDnd?.nestTarget?.threadId === node.thread.id
+      ? sectionDnd.nestTarget.state
+      : null;
+  const showNestPreview =
+    nestTargetState === "valid" && (!hasChildren || !isCollapsed);
+  const nestPreviewBeforeKey =
+    showNestPreview &&
+    sectionDnd?.dropPreview?.parentKey ===
+      getSidebarNestParentKey(node.thread.id)
+      ? sectionDnd.dropPreview.beforeItemKey
+      : null;
+  const reorderPlacement =
+    sectionDnd?.reorderTarget?.threadId === node.thread.id
+      ? sectionDnd.reorderTarget.placement
+      : null;
+  const nestDrop = useMemo<ThreadRowNestDrop | undefined>(
+    () =>
+      nestDropEnabled
+        ? {
+            setNodeRef: setNestDropNodeRef,
+            state: nestTargetState,
+            reorderPlacement,
+          }
+        : undefined,
+    [nestDropEnabled, nestTargetState, reorderPlacement, setNestDropNodeRef],
+  );
   const parentRowDepth = getThreadRowDepth({
     depthOffset,
     nodeDepth: node.depth,
@@ -1539,6 +1648,7 @@ export const ThreadTreeNodeRow = memo(function ThreadTreeNodeRow({
         isCollapsed,
         isEnvGrouped,
         isParent,
+        nestDrop,
         nodeDepth: node.depth,
         onToggleThreadCollapsed,
         stickyLevel: hasChildren
@@ -1554,6 +1664,7 @@ export const ThreadTreeNodeRow = memo(function ThreadTreeNodeRow({
       isEnvGrouped,
       isParent,
       hasChildren,
+      nestDrop,
       node,
       onToggleThreadCollapsed,
       variant,
@@ -1586,7 +1697,7 @@ export const ThreadTreeNodeRow = memo(function ThreadTreeNodeRow({
     />
   );
 
-  if (!hasChildren && !sortableRef) {
+  if (!hasChildren && !sortableRef && !showNestPreview) {
     return row;
   }
 
@@ -1597,36 +1708,49 @@ export const ThreadTreeNodeRow = memo(function ThreadTreeNodeRow({
       className="space-y-0.5"
     >
       {row}
-      {showChildren ? (
+      {showChildren || showNestPreview ? (
         <div className="relative space-y-px">
           <ThreadTreeGroupLine parentRowDepth={parentRowDepth} />
-          <SidebarWindowedItems
-            itemKeys={itemKeys}
-            estimateRows={estimateRows}
-            getNavigationEntries={getNavigationEntries}
-            alwaysMountedKeys={alwaysMountedKeys}
-            renderItem={(index) => {
-              const item = node.children[index];
-              if (!item) {
-                return null;
-              }
-              return (
-                <ThreadTreeItemRow
-                  key={getItemKey(item)}
-                  projectId={rowProjectId}
-                  item={item}
-                  depthOffset={depthOffset}
-                  selectedThreadId={selectedThreadId}
-                  collapsedThreadIds={collapsedThreadIds}
-                  collapsedEnvironmentIds={collapsedEnvironmentIds}
-                  variant={variant}
-                  onProjectSelect={onProjectSelect}
-                  onToggleThreadCollapsed={onToggleThreadCollapsed}
-                  onToggleEnvironmentCollapsed={onToggleEnvironmentCollapsed}
-                />
-              );
-            }}
-          />
+          {showChildren ? (
+            <SidebarWindowedItems
+              itemKeys={itemKeys}
+              estimateRows={estimateRows}
+              getNavigationEntries={getNavigationEntries}
+              alwaysMountedKeys={alwaysMountedKeys}
+              renderItem={(index) => {
+                const item = node.children[index];
+                if (!item) {
+                  return null;
+                }
+                const itemKey = getSidebarItemKey(item);
+                return (
+                  <Fragment key={itemKey}>
+                    {nestPreviewBeforeKey === itemKey ? (
+                      <DropPreviewRow depth={parentRowDepth + 1} nest />
+                    ) : null}
+                    <SectionDndItemRow
+                      projectId={rowProjectId}
+                      item={item}
+                      depthOffset={depthOffset}
+                      selectedThreadId={selectedThreadId}
+                      collapsedThreadIds={collapsedThreadIds}
+                      collapsedEnvironmentIds={collapsedEnvironmentIds}
+                      variant={variant}
+                      onProjectSelect={onProjectSelect}
+                      onToggleThreadCollapsed={onToggleThreadCollapsed}
+                      onToggleEnvironmentCollapsed={
+                        onToggleEnvironmentCollapsed
+                      }
+                      sectionDnd={sectionDnd ?? undefined}
+                    />
+                  </Fragment>
+                );
+              }}
+            />
+          ) : null}
+          {showNestPreview && nestPreviewBeforeKey === null ? (
+            <DropPreviewRow depth={parentRowDepth + 1} nest />
+          ) : null}
         </div>
       ) : null}
     </SidebarStickyGroup>
@@ -1644,6 +1768,7 @@ function ThreadTreeLoadingSkeleton() {
 interface SectionThreadTreeItemsProps {
   items: readonly ProjectThreadItem[];
   sectionDnd: SectionThreadDndState | null;
+  previewBeforeKey?: string | null;
   focusItemKey?: string;
   variant: ProjectThreadTreeVariant;
   projectId?: string;
@@ -1674,7 +1799,7 @@ function useWindowedThreadItems({
   const collapsedSectionKeyList = useAtomValue(
     sidebarCollapsedThreadSectionsAtom,
   );
-  const itemKeys = useMemo(() => items.map(getItemKey), [items]);
+  const itemKeys = useMemo(() => items.map(getSidebarItemKey), [items]);
   const rowCountContext = useMemo<ProjectThreadItemRowCountContext>(
     () => ({
       collapsedThreadIds,
@@ -1706,7 +1831,7 @@ function useWindowedThreadItems({
     const activeItem = items.find((item) =>
       projectThreadItemContainsThread(item, selectedThreadId),
     );
-    return activeItem ? new Set([getItemKey(activeItem)]) : undefined;
+    return activeItem ? new Set([getSidebarItemKey(activeItem)]) : undefined;
   }, [items, selectedThreadId]);
   return { itemKeys, estimateRows, getNavigationEntries, alwaysMountedKeys };
 }
@@ -1715,6 +1840,7 @@ function SectionThreadTreeItems({
   items,
   focusItemKey,
   sectionDnd,
+  previewBeforeKey = null,
   variant,
   projectId,
   depthOffset = 0,
@@ -1748,24 +1874,35 @@ function SectionThreadTreeItems({
         if (!item) {
           return null;
         }
+        const itemKey = getSidebarItemKey(item);
         return (
-          <SectionDndItemRow
-            key={getItemKey(item)}
-            projectId={projectId ?? getItemProjectId(item)}
-            item={item}
-            depthOffset={depthOffset}
-            selectedThreadId={selectedThreadId}
-            collapsedThreadIds={collapsedThreadIds}
-            collapsedEnvironmentIds={collapsedEnvironmentIds}
-            variant={variant}
-            onProjectSelect={onProjectSelect}
-            onToggleThreadCollapsed={onToggleThreadCollapsed}
-            onToggleEnvironmentCollapsed={onToggleEnvironmentCollapsed}
-            onCreateThreadInSection={onCreateThreadInSection}
-            onRenameSection={onRenameSection}
-            onRemoveSection={onRemoveSection}
-            sectionDnd={sectionDnd ?? undefined}
-          />
+          <Fragment key={itemKey}>
+            {previewBeforeKey === itemKey ? (
+              <DropPreviewRow
+                depth={getThreadRowDepth({
+                  depthOffset,
+                  nodeDepth: 0,
+                  variant,
+                })}
+              />
+            ) : null}
+            <SectionDndItemRow
+              projectId={projectId ?? getItemProjectId(item)}
+              item={item}
+              depthOffset={depthOffset}
+              selectedThreadId={selectedThreadId}
+              collapsedThreadIds={collapsedThreadIds}
+              collapsedEnvironmentIds={collapsedEnvironmentIds}
+              variant={variant}
+              onProjectSelect={onProjectSelect}
+              onToggleThreadCollapsed={onToggleThreadCollapsed}
+              onToggleEnvironmentCollapsed={onToggleEnvironmentCollapsed}
+              onCreateThreadInSection={onCreateThreadInSection}
+              onRenameSection={onRenameSection}
+              onRemoveSection={onRemoveSection}
+              sectionDnd={sectionDnd ?? undefined}
+            />
+          </Fragment>
         );
       }}
     />
@@ -1844,7 +1981,7 @@ export const ProjectThreadTree = memo(function ProjectThreadTree({
     return allRootItems.filter(
       (item, index) =>
         index < THREAD_ITEMS_INITIAL_LIMIT ||
-        revealedItemKeys.has(getItemKey(item)) ||
+        revealedItemKeys.has(getSidebarItemKey(item)) ||
         isAttentionProjectThreadItem(item, selectedThreadId),
     );
   }, [
@@ -1853,9 +1990,9 @@ export const ProjectThreadTree = memo(function ProjectThreadTree({
     revealedItemKeys,
     progressiveDisclosureEnabled,
   ]);
-  const visibleItemKeys = new Set(rootItems.map(getItemKey));
+  const visibleItemKeys = new Set(rootItems.map(getSidebarItemKey));
   const hiddenItems = allRootItems.filter(
-    (item) => !visibleItemKeys.has(getItemKey(item)),
+    (item) => !visibleItemKeys.has(getSidebarItemKey(item)),
   );
   const hasMoreItems = hiddenItems.length > 0;
   const handleShowMore: MouseEventHandler<HTMLButtonElement> = (event) => {
@@ -1864,11 +2001,13 @@ export const ProjectThreadTree = memo(function ProjectThreadTree({
       new Set([
         ...revealedItemKeys,
         ...visibleItemKeys,
-        ...nextItems.map(getItemKey),
+        ...nextItems.map(getSidebarItemKey),
       ]),
     );
     setFocusItemKey(
-      event.detail === 0 && nextItems[0] ? getItemKey(nextItems[0]) : undefined,
+      event.detail === 0 && nextItems[0]
+        ? getSidebarItemKey(nextItems[0])
+        : undefined,
     );
   };
 
@@ -1954,6 +2093,7 @@ export const ChronologicalSectionThreadSections = memo(
     topLevelSectionOrder,
     onTopLevelSectionOrderChange,
     pinnedReorderPending,
+    pinnedRootNodes,
     pinnedThreads,
     onReorderPinnedThread,
     renderPinnedSection,
@@ -1963,6 +2103,14 @@ export const ChronologicalSectionThreadSections = memo(
       threadListState.status === "ready"
         ? threadListState.threads
         : EMPTY_PROJECT_THREADS;
+    const expandThread = useCallback(
+      (threadId: string) => {
+        if (collapsedThreadIds.has(threadId)) {
+          onToggleThreadCollapsed(threadId);
+        }
+      },
+      [collapsedThreadIds, onToggleThreadCollapsed],
+    );
     const draftThreadIds = usePromptDraftInputThreadIds(threads);
     const rootItems = useMemo(
       () =>
@@ -1984,88 +2132,69 @@ export const ChronologicalSectionThreadSections = memo(
       rootItems,
       topLevelSectionOrder,
       onTopLevelSectionOrderChange,
+      onExpandThread: expandThread,
       pinnedReorderPending,
       pinnedThreads,
+      pinnedRootNodes,
       onReorderPinnedThread,
     });
-    const renderedRootItems = useMemo(() => {
-      const activeThread = sectionDnd?.activeThread;
-      const projectedSectionId = sectionDnd?.projectedSectionId;
-      if (!activeThread || projectedSectionId === undefined) {
-        return rootItems;
-      }
-
-      const hasProjectedThread = threads.some(
-        (thread) => thread.id === activeThread.id,
-      );
-      return buildSectionThreadList(
-        hasProjectedThread
-          ? threads.map((thread) =>
-              thread.id === activeThread.id
-                ? { ...thread, sectionId: projectedSectionId }
-                : thread,
-            )
-          : [...threads, { ...activeThread, sectionId: projectedSectionId }],
-        compareThreads,
-        sections,
-        draftThreadIds,
-      );
-    }, [
-      compareThreads,
-      draftThreadIds,
-      sectionDnd,
-      sections,
-      rootItems,
-      threads,
-    ]);
     const renderedSectionDnd = useMemo<SectionThreadDndState | null>(() => {
       if (!sectionDnd) {
         return null;
       }
+      const activeThread = sectionDnd.activeThread;
       const suppressPinnedDropPreview = shouldSuppressPinnedThreadDropPreview({
-        activeThreadId: sectionDnd.activeThread?.id,
+        activeThreadId: activeThread?.id,
         dragOverParentKey: sectionDnd.dragOverParentKey,
         pinnedThreads,
       });
-      if (renderedRootItems === rootItems) {
+      if (suppressPinnedDropPreview || !activeThread) {
         return suppressPinnedDropPreview
-          ? { ...sectionDnd, dragOverParentKey: null }
+          ? { ...sectionDnd, dragOverParentKey: null, dropPreview: null }
           : sectionDnd;
       }
-
-      if (suppressPinnedDropPreview) {
-        return { ...sectionDnd, dragOverParentKey: null };
-      }
-
-      const activeThreadId = sectionDnd.activeThread?.id;
-      const renderedPinnedThreads = activeThreadId
-        ? pinnedThreads.filter((thread) => thread.id !== activeThreadId)
-        : pinnedThreads;
-      const renderedLookup = collectSectionThreadDndLookup(
-        renderedRootItems,
-        CHRONOLOGICAL_CONTAINER_ID,
-        renderedPinnedThreads,
-      );
+      const target = resolveDropPreviewTarget({
+        dragOverParentKey: sectionDnd.dragOverParentKey,
+        nestTarget: sectionDnd.nestTarget,
+        rootItems,
+      });
       return {
         ...sectionDnd,
-        dragOverParentKey: null,
-        itemIdsByParentKey: renderedLookup.itemIdsByParentKey,
-        pinnedItemIds:
-          renderedLookup.itemIdsByParentKey.get(PINNED_THREAD_PARENT_KEY) ?? [],
+        dropPreview: target
+          ? resolveSidebarDropPreviewPlacement({
+              activeThread,
+              compareThreads,
+              draftThreadIds,
+              pinnedRootNodes: pinnedRootNodes ?? EMPTY_PINNED_ROOT_NODES,
+              sections,
+              target,
+              threads,
+            })
+          : null,
       };
-    }, [sectionDnd, pinnedThreads, renderedRootItems, rootItems]);
-    const sectionItems = renderedRootItems.filter(
-      (item) => item.kind === "section",
-    );
-    const looseItems = renderedRootItems.filter(
-      (item) => item.kind !== "section",
-    );
+    }, [
+      compareThreads,
+      draftThreadIds,
+      pinnedRootNodes,
+      pinnedThreads,
+      rootItems,
+      sectionDnd,
+      sections,
+      threads,
+    ]);
+    const sectionItems = rootItems.filter((item) => item.kind === "section");
+    const looseItems = rootItems.filter((item) => item.kind !== "section");
+    const loosePreviewBeforeKey =
+      renderedSectionDnd?.dropPreview?.parentKey === CHRONOLOGICAL_CONTAINER_ID
+        ? renderedSectionDnd.dropPreview.beforeItemKey
+        : null;
     const looseThreads = getProjectThreadItemDescendants(looseItems);
 
     const renderItems = (items: readonly ProjectThreadItem[]) => (
       <SectionThreadTreeItems
         items={items}
         sectionDnd={renderedSectionDnd}
+        previewBeforeKey={loosePreviewBeforeKey}
         variant="section"
         selectedThreadId={selectedThreadId}
         collapsedThreadIds={collapsedThreadIds}
@@ -2080,7 +2209,8 @@ export const ChronologicalSectionThreadSections = memo(
     );
 
     const showLoosePreview =
-      renderedSectionDnd?.dragOverParentKey === CHRONOLOGICAL_CONTAINER_ID;
+      renderedSectionDnd?.dragOverParentKey === CHRONOLOGICAL_CONTAINER_ID &&
+      loosePreviewBeforeKey === null;
     const looseEmptyState = (
       <EmptyState
         message={

--- a/apps/app/src/components/sidebar/ProjectRow.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.tsx
@@ -287,10 +287,12 @@ const EMPTY_PINNED_ROOT_NODES: readonly ProjectThreadNode[] = [];
 function resolveDropPreviewTarget({
   dragOverParentKey,
   nestTarget,
+  reorderTarget,
   rootItems,
 }: {
   dragOverParentKey: string | null;
   nestTarget: SectionThreadDndState["nestTarget"];
+  reorderTarget: SectionThreadDndState["reorderTarget"];
   rootItems: readonly ProjectThreadItem[];
 }): SidebarDropPreviewTarget | null {
   if (nestTarget?.state === "valid") {
@@ -298,7 +300,9 @@ function resolveDropPreviewTarget({
   }
   if (dragOverParentKey === null) return null;
   if (dragOverParentKey === PINNED_THREAD_PARENT_KEY) {
-    return { kind: "pinned", parentKey: PINNED_THREAD_PARENT_KEY };
+    return reorderTarget
+      ? null
+      : { kind: "pinned", parentKey: PINNED_THREAD_PARENT_KEY };
   }
   if (dragOverParentKey === CHRONOLOGICAL_CONTAINER_ID) {
     return {
@@ -2156,6 +2160,7 @@ export const ChronologicalSectionThreadSections = memo(
       const target = resolveDropPreviewTarget({
         dragOverParentKey: sectionDnd.dragOverParentKey,
         nestTarget: sectionDnd.nestTarget,
+        reorderTarget: sectionDnd.reorderTarget,
         rootItems,
       });
       return {

--- a/apps/app/src/components/sidebar/ProjectRow.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.tsx
@@ -2079,7 +2079,7 @@ export const ChronologicalSectionThreadSections = memo(
     topLevelSectionOrder,
     onTopLevelSectionOrderChange,
     pinnedReorderPending,
-    pinnedRootNodes,
+    pinnedRootNodes = EMPTY_PINNED_ROOT_NODES,
     pinnedThreads,
     onReorderPinnedThread,
     renderPinnedSection,
@@ -2127,7 +2127,7 @@ export const ChronologicalSectionThreadSections = memo(
     const renderedSectionDnd = useRenderedSectionThreadDnd({
       compareThreads,
       draftThreadIds,
-      pinnedRootNodes: pinnedRootNodes ?? EMPTY_PINNED_ROOT_NODES,
+      pinnedRootNodes,
       pinnedThreads,
       rootItems,
       sectionDnd,

--- a/apps/app/src/components/sidebar/ProjectRow.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.tsx
@@ -183,6 +183,7 @@ export type ProjectThreadListState =
 export interface ProjectRowProps {
   project: ProjectResponse;
   threadListState: ProjectThreadListState;
+  rootItems?: readonly ProjectThreadItem[];
   progressiveDisclosureEnabled: boolean;
   selectedThreadId?: string;
   isActive: boolean;
@@ -205,6 +206,7 @@ export interface ProjectRowProps {
 interface ProjectThreadTreeProps {
   projectId?: string;
   dndParentKey?: string;
+  rootItems?: readonly ProjectThreadItem[];
   threadListState: ProjectThreadListState;
   progressiveDisclosureEnabled: boolean;
   compareThreads: ThreadComparator;
@@ -1914,6 +1916,7 @@ function isAttentionProjectThreadItem(
 export const ProjectThreadTree = memo(function ProjectThreadTree({
   projectId,
   dndParentKey,
+  rootItems: providedRootItems,
   threadListState,
   progressiveDisclosureEnabled,
   compareThreads,
@@ -1946,8 +1949,9 @@ export const ProjectThreadTree = memo(function ProjectThreadTree({
   const [focusItemKey, setFocusItemKey] = useState<string>();
   const allRootItems = useMemo(
     () =>
+      providedRootItems ??
       buildProjectThreadGroups(projectThreads, compareThreads, draftThreadIds),
-    [compareThreads, draftThreadIds, projectThreads],
+    [compareThreads, draftThreadIds, projectThreads, providedRootItems],
   );
   const rootItems = useMemo(() => {
     if (!progressiveDisclosureEnabled) {
@@ -2300,6 +2304,7 @@ export const ChronologicalSectionThreadSections = memo(
 function ProjectRowComponent({
   project,
   threadListState,
+  rootItems,
   progressiveDisclosureEnabled,
   selectedThreadId,
   isCollapsed,
@@ -2414,6 +2419,7 @@ function ProjectRowComponent({
           <ProjectThreadTree
             projectId={project.id}
             dndParentKey={buildSidebarEntitySectionId("project", project.id)}
+            rootItems={rootItems}
             threadListState={threadListState}
             progressiveDisclosureEnabled={progressiveDisclosureEnabled}
             selectedThreadId={selectedThreadId}
@@ -2509,6 +2515,7 @@ function areProjectRowPropsEqual(
   if (
     prev.project !== next.project ||
     prev.threadListState !== next.threadListState ||
+    prev.rootItems !== next.rootItems ||
     prev.progressiveDisclosureEnabled !== next.progressiveDisclosureEnabled ||
     prev.isActive !== next.isActive ||
     prev.isCollapsed !== next.isCollapsed ||

--- a/apps/app/src/components/sidebar/ProjectRow.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.tsx
@@ -153,9 +153,10 @@ import {
 import {
   getSidebarItemKey,
   getSidebarNestParentKey,
-  resolveSidebarDropPreviewPlacement,
-  type SidebarDropPreviewTarget,
 } from "./sidebarDropPreviewPlacement";
+import { useRenderedSectionThreadDnd } from "./useRenderedSectionThreadDnd";
+import { useChronologicalSectionThreadDnd } from "./SectionThreadDndContext";
+export { shouldSuppressPinnedThreadDropPreview } from "./useRenderedSectionThreadDnd";
 import {
   getBuiltInSidebarSectionNode,
   renderBuiltInSidebarSection,
@@ -203,6 +204,7 @@ export interface ProjectRowProps {
 
 interface ProjectThreadTreeProps {
   projectId?: string;
+  dndParentKey?: string;
   threadListState: ProjectThreadListState;
   progressiveDisclosureEnabled: boolean;
   compareThreads: ThreadComparator;
@@ -262,66 +264,8 @@ type ProjectThreadTreeVariant = "project" | "section";
 type ProjectThreadListClickCaptureHandler = MouseEventHandler<HTMLDivElement>;
 
 const EMPTY_PROJECT_THREADS: ThreadListEntry[] = [];
-const EMPTY_THREAD_SECTIONS: readonly SidebarSectionDefinition[] = [];
-
-interface ShouldSuppressPinnedThreadDropPreviewArgs {
-  activeThreadId: string | undefined;
-  dragOverParentKey: string | null;
-  pinnedThreads: readonly Pick<ThreadListEntry, "id">[];
-}
-
-export function shouldSuppressPinnedThreadDropPreview({
-  activeThreadId,
-  dragOverParentKey,
-  pinnedThreads,
-}: ShouldSuppressPinnedThreadDropPreviewArgs): boolean {
-  return (
-    activeThreadId !== undefined &&
-    dragOverParentKey === PINNED_THREAD_PARENT_KEY &&
-    pinnedThreads.some((thread) => thread.id === activeThreadId)
-  );
-}
-
 const EMPTY_PINNED_ROOT_NODES: readonly ProjectThreadNode[] = [];
-
-function resolveDropPreviewTarget({
-  dragOverParentKey,
-  nestTarget,
-  reorderTarget,
-  rootItems,
-}: {
-  dragOverParentKey: string | null;
-  nestTarget: SectionThreadDndState["nestTarget"];
-  reorderTarget: SectionThreadDndState["reorderTarget"];
-  rootItems: readonly ProjectThreadItem[];
-}): SidebarDropPreviewTarget | null {
-  if (nestTarget?.state === "valid") {
-    return { kind: "nest", parentThreadId: nestTarget.threadId };
-  }
-  if (dragOverParentKey === null) return null;
-  if (dragOverParentKey === PINNED_THREAD_PARENT_KEY) {
-    return reorderTarget
-      ? null
-      : { kind: "pinned", parentKey: PINNED_THREAD_PARENT_KEY };
-  }
-  if (dragOverParentKey === CHRONOLOGICAL_CONTAINER_ID) {
-    return {
-      kind: "container",
-      parentKey: CHRONOLOGICAL_CONTAINER_ID,
-      sectionId: null,
-    };
-  }
-  for (const item of rootItems) {
-    if (item.kind === "section" && item.group.key === dragOverParentKey) {
-      return {
-        kind: "container",
-        parentKey: item.group.key,
-        sectionId: item.group.id,
-      };
-    }
-  }
-  return null;
-}
+const EMPTY_THREAD_SECTIONS: readonly SidebarSectionDefinition[] = [];
 
 interface ProjectThreadTreeGroupProps {
   children: ReactNode;
@@ -1363,6 +1307,22 @@ export function DropPreviewRow({
   );
 }
 
+export function SectionThreadDragOverlayPortal({
+  activeThread,
+}: {
+  activeThread: ThreadListEntry | null;
+}) {
+  return createPortal(
+    <DragOverlay
+      className="cursor-grabbing"
+      dropAnimation={activeThread ? SIDEBAR_DRAG_OVERLAY_DROP_ANIMATION : null}
+    >
+      {activeThread ? <SectionThreadDragOverlay thread={activeThread} /> : null}
+    </DragOverlay>,
+    document.body,
+  );
+}
+
 function SectionThreadDragOverlay({ thread }: { thread: ThreadListEntry }) {
   return (
     <div
@@ -1953,6 +1913,7 @@ function isAttentionProjectThreadItem(
 
 export const ProjectThreadTree = memo(function ProjectThreadTree({
   projectId,
+  dndParentKey,
   threadListState,
   progressiveDisclosureEnabled,
   compareThreads,
@@ -1968,6 +1929,16 @@ export const ProjectThreadTree = memo(function ProjectThreadTree({
     threadListState.status === "ready"
       ? threadListState.threads
       : EMPTY_PROJECT_THREADS;
+  const sectionDnd = useChronologicalSectionThreadDnd();
+  const treePreviewBeforeKey =
+    dndParentKey !== undefined &&
+    sectionDnd?.dropPreview?.parentKey === dndParentKey
+      ? sectionDnd.dropPreview.beforeItemKey
+      : null;
+  const showTreeEndPreview =
+    dndParentKey !== undefined &&
+    sectionDnd?.dragOverParentKey === dndParentKey &&
+    treePreviewBeforeKey === null;
   const draftThreadIds = usePromptDraftInputThreadIds(projectThreads);
   const [revealedItemKeys, setRevealedItemKeys] = useState<ReadonlySet<string>>(
     () => new Set(),
@@ -2050,7 +2021,8 @@ export const ProjectThreadTree = memo(function ProjectThreadTree({
       <SectionThreadTreeItems
         items={rootItems}
         focusItemKey={focusItemKey}
-        sectionDnd={null}
+        sectionDnd={dndParentKey !== undefined ? sectionDnd : null}
+        previewBeforeKey={treePreviewBeforeKey}
         variant={variant}
         projectId={projectId}
         sortableParentKey={projectId}
@@ -2061,6 +2033,16 @@ export const ProjectThreadTree = memo(function ProjectThreadTree({
         onToggleThreadCollapsed={onToggleThreadCollapsed}
         onToggleEnvironmentCollapsed={onToggleEnvironmentCollapsed}
       />
+      {dndParentKey !== undefined && sectionDnd ? (
+        <DropPreviewRow
+          visible={showTreeEndPreview}
+          depth={getThreadRowDepth({
+            depthOffset: getProjectThreadTreeRootDepthOffset(variant),
+            nodeDepth: 0,
+            variant,
+          })}
+        />
+      ) : null}
       {hasMoreItems ? (
         <button
           type="button"
@@ -2142,51 +2124,16 @@ export const ChronologicalSectionThreadSections = memo(
       pinnedRootNodes,
       onReorderPinnedThread,
     });
-    const renderedSectionDnd = useMemo<SectionThreadDndState | null>(() => {
-      if (!sectionDnd) {
-        return null;
-      }
-      const activeThread = sectionDnd.activeThread;
-      const suppressPinnedDropPreview = shouldSuppressPinnedThreadDropPreview({
-        activeThreadId: activeThread?.id,
-        dragOverParentKey: sectionDnd.dragOverParentKey,
-        pinnedThreads,
-      });
-      if (suppressPinnedDropPreview || !activeThread) {
-        return suppressPinnedDropPreview
-          ? { ...sectionDnd, dragOverParentKey: null, dropPreview: null }
-          : sectionDnd;
-      }
-      const target = resolveDropPreviewTarget({
-        dragOverParentKey: sectionDnd.dragOverParentKey,
-        nestTarget: sectionDnd.nestTarget,
-        reorderTarget: sectionDnd.reorderTarget,
-        rootItems,
-      });
-      return {
-        ...sectionDnd,
-        dropPreview: target
-          ? resolveSidebarDropPreviewPlacement({
-              activeThread,
-              compareThreads,
-              draftThreadIds,
-              pinnedRootNodes: pinnedRootNodes ?? EMPTY_PINNED_ROOT_NODES,
-              sections,
-              target,
-              threads,
-            })
-          : null,
-      };
-    }, [
+    const renderedSectionDnd = useRenderedSectionThreadDnd({
       compareThreads,
       draftThreadIds,
-      pinnedRootNodes,
+      pinnedRootNodes: pinnedRootNodes ?? EMPTY_PINNED_ROOT_NODES,
       pinnedThreads,
       rootItems,
       sectionDnd,
       sections,
       threads,
-    ]);
+    });
     const sectionItems = rootItems.filter((item) => item.kind === "section");
     const looseItems = rootItems.filter((item) => item.kind !== "section");
     const loosePreviewBeforeKey =
@@ -2339,21 +2286,9 @@ export const ChronologicalSectionThreadSections = memo(
       <DndContext {...sectionDnd.dndContextProps}>
         <SectionThreadDndProvider value={renderedSectionDnd}>
           {orderedSections}
-          {createPortal(
-            <DragOverlay
-              className="cursor-grabbing"
-              dropAnimation={
-                sectionDnd.activeThread
-                  ? SIDEBAR_DRAG_OVERLAY_DROP_ANIMATION
-                  : null
-              }
-            >
-              {sectionDnd.activeThread ? (
-                <SectionThreadDragOverlay thread={sectionDnd.activeThread} />
-              ) : null}
-            </DragOverlay>,
-            document.body,
-          )}
+          <SectionThreadDragOverlayPortal
+            activeThread={sectionDnd.activeThread}
+          />
         </SectionThreadDndProvider>
       </DndContext>
     ) : (
@@ -2478,6 +2413,7 @@ function ProjectRowComponent({
         >
           <ProjectThreadTree
             projectId={project.id}
+            dndParentKey={buildSidebarEntitySectionId("project", project.id)}
             threadListState={threadListState}
             progressiveDisclosureEnabled={progressiveDisclosureEnabled}
             selectedThreadId={selectedThreadId}

--- a/apps/app/src/components/sidebar/ReorderableSidebarSectionOrderList.tsx
+++ b/apps/app/src/components/sidebar/ReorderableSidebarSectionOrderList.tsx
@@ -5,6 +5,9 @@ import type { SidebarSectionId } from "./sidebarCollapsedAtoms";
 import { SidebarSectionOrderList } from "./SidebarSectionOrderList";
 import { reorderSidebarSectionOrder } from "@bb/client-core";
 import { useSidebarReorderDnd } from "./useSidebarReorderDnd";
+import { SectionThreadDndProvider } from "./SectionThreadDndContext";
+import { SectionThreadDragOverlayPortal } from "./ProjectRow";
+import type { SectionThreadDndState } from "./useSectionThreadDnd";
 
 interface ReorderableSidebarSectionOrderListProps {
   children: (
@@ -14,6 +17,7 @@ interface ReorderableSidebarSectionOrderListProps {
   onOrderChange: (order: SidebarSectionId[]) => void;
   order: readonly SidebarSectionId[];
   reorderOrder?: readonly SidebarSectionId[];
+  threadDnd?: SectionThreadDndState | null;
 }
 
 export function ReorderableSidebarSectionOrderList({
@@ -21,6 +25,7 @@ export function ReorderableSidebarSectionOrderList({
   onOrderChange,
   order,
   reorderOrder = order,
+  threadDnd = null,
 }: ReorderableSidebarSectionOrderListProps) {
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
@@ -43,6 +48,26 @@ export function ReorderableSidebarSectionOrderList({
   const { dndContextProps, consumeClickSuppression } = useSidebarReorderDnd({
     onDragEnd: handleDragEnd,
   });
+
+  if (threadDnd) {
+    return (
+      <SectionThreadDndProvider value={threadDnd}>
+        <SidebarSectionOrderList
+          order={order}
+          dndContextProps={threadDnd.dndContextProps}
+          trailing={
+            <SectionThreadDragOverlayPortal
+              activeThread={threadDnd.activeThread}
+            />
+          }
+        >
+          {(sectionId) =>
+            children(sectionId, threadDnd.consumeClickSuppression)
+          }
+        </SidebarSectionOrderList>
+      </SectionThreadDndProvider>
+    );
+  }
 
   return (
     <SidebarSectionOrderList order={order} dndContextProps={dndContextProps}>

--- a/apps/app/src/components/sidebar/ReorderableSidebarSectionOrderList.tsx
+++ b/apps/app/src/components/sidebar/ReorderableSidebarSectionOrderList.tsx
@@ -1,10 +1,7 @@
-import { useCallback, type ReactNode } from "react";
-import type { DragEndEvent } from "@dnd-kit/core";
+import type { ReactNode } from "react";
 import type { ConsumeDragClickSuppression } from "@/components/ui/use-drag-click-suppression";
 import type { SidebarSectionId } from "./sidebarCollapsedAtoms";
 import { SidebarSectionOrderList } from "./SidebarSectionOrderList";
-import { reorderSidebarSectionOrder } from "@bb/client-core";
-import { useSidebarReorderDnd } from "./useSidebarReorderDnd";
 import { SectionThreadDndProvider } from "./SectionThreadDndContext";
 import { SectionThreadDragOverlayPortal } from "./ProjectRow";
 import type { SectionThreadDndState } from "./useSectionThreadDnd";
@@ -14,64 +11,36 @@ interface ReorderableSidebarSectionOrderListProps {
     sectionId: SidebarSectionId,
     consumeClickSuppression: ConsumeDragClickSuppression,
   ) => ReactNode;
-  onOrderChange: (order: SidebarSectionId[]) => void;
   order: readonly SidebarSectionId[];
-  reorderOrder?: readonly SidebarSectionId[];
-  threadDnd?: SectionThreadDndState | null;
+  threadDnd: SectionThreadDndState | null;
 }
 
 export function ReorderableSidebarSectionOrderList({
   children,
-  onOrderChange,
   order,
-  reorderOrder = order,
-  threadDnd = null,
+  threadDnd,
 }: ReorderableSidebarSectionOrderListProps) {
-  const handleDragEnd = useCallback(
-    (event: DragEndEvent) => {
-      if (
-        !event.over ||
-        typeof event.active.id !== "string" ||
-        typeof event.over.id !== "string"
-      ) {
-        return;
-      }
-      const nextOrder = reorderSidebarSectionOrder({
-        activeId: event.active.id,
-        overId: event.over.id,
-        order: reorderOrder,
-      });
-      if (nextOrder) onOrderChange(nextOrder);
-    },
-    [onOrderChange, reorderOrder],
-  );
-  const { dndContextProps, consumeClickSuppression } = useSidebarReorderDnd({
-    onDragEnd: handleDragEnd,
-  });
-
-  if (threadDnd) {
+  if (!threadDnd) {
     return (
-      <SectionThreadDndProvider value={threadDnd}>
-        <SidebarSectionOrderList
-          order={order}
-          dndContextProps={threadDnd.dndContextProps}
-          trailing={
-            <SectionThreadDragOverlayPortal
-              activeThread={threadDnd.activeThread}
-            />
-          }
-        >
-          {(sectionId) =>
-            children(sectionId, threadDnd.consumeClickSuppression)
-          }
-        </SidebarSectionOrderList>
-      </SectionThreadDndProvider>
+      <SidebarSectionOrderList order={order}>
+        {(sectionId) => children(sectionId, () => false)}
+      </SidebarSectionOrderList>
     );
   }
 
   return (
-    <SidebarSectionOrderList order={order} dndContextProps={dndContextProps}>
-      {(sectionId) => children(sectionId, consumeClickSuppression)}
-    </SidebarSectionOrderList>
+    <SectionThreadDndProvider value={threadDnd}>
+      <SidebarSectionOrderList
+        order={order}
+        dndContextProps={threadDnd.dndContextProps}
+        trailing={
+          <SectionThreadDragOverlayPortal
+            activeThread={threadDnd.activeThread}
+          />
+        }
+      >
+        {(sectionId) => children(sectionId, threadDnd.consumeClickSuppression)}
+      </SidebarSectionOrderList>
+    </SectionThreadDndProvider>
   );
 }

--- a/apps/app/src/components/sidebar/SidebarSectionOrderList.tsx
+++ b/apps/app/src/components/sidebar/SidebarSectionOrderList.tsx
@@ -11,12 +11,14 @@ interface SidebarSectionOrderListProps {
   children: (sectionId: SidebarSectionId) => ReactNode;
   dndContextProps?: SidebarReorderDndContextProps;
   order: readonly SidebarSectionId[];
+  trailing?: ReactNode;
 }
 
 export function SidebarSectionOrderList({
   children,
   dndContextProps,
   order,
+  trailing,
 }: SidebarSectionOrderListProps) {
   const content = (
     <SortableContext items={[...order]} strategy={verticalListSortingStrategy}>
@@ -25,7 +27,10 @@ export function SidebarSectionOrderList({
   );
 
   return dndContextProps ? (
-    <DndContext {...dndContextProps}>{content}</DndContext>
+    <DndContext {...dndContextProps}>
+      {content}
+      {trailing}
+    </DndContext>
   ) : (
     content
   );

--- a/apps/app/src/components/sidebar/ThreadRow.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.tsx
@@ -70,6 +70,12 @@ import {
 } from "./sidebarRowClasses";
 import type { ConsumeDragClickSuppression } from "@/components/ui/use-drag-click-suppression";
 import type { SidebarSortableDragBindings } from "./sortableMotion";
+import { useComposedRefs } from "@radix-ui/react-compose-refs";
+import type {
+  SidebarNestTargetState,
+  SidebarReorderPlacement,
+  ThreadRowNestDrop,
+} from "./sidebarThreadRowDroppable";
 import { SidebarChildToggleChevron } from "./SidebarChildToggleChevron";
 import { useSidebarThreadShortcut } from "./sidebarThreadShortcuts";
 import { SplitPaneMiniMap } from "./SplitPaneMiniMap";
@@ -108,6 +114,7 @@ interface ThreadRowBaseOptions {
   isCompact: boolean;
   consumeClickSuppression?: ConsumeDragClickSuppression;
   dragBindings?: SidebarSortableDragBindings;
+  nestDrop?: ThreadRowNestDrop;
 }
 
 export type ThreadRowOptions =
@@ -138,12 +145,29 @@ type ThreadRowClickCaptureHandler = MouseEventHandler<HTMLDivElement>;
 interface ThreadRowContainerArgs {
   children: ReactNode;
   className: string;
+  containerRef: (element: HTMLDivElement | null) => void;
   dragBindings?: SidebarSortableDragBindings;
+  nestTargetState: SidebarNestTargetState | null;
+  reorderPlacement: SidebarReorderPlacement | null;
   onClickCapture?: ThreadRowClickCaptureHandler;
   onSplitDragPointerDown?: PointerEventHandler<HTMLElement>;
   stickyLevel?: number;
   style: CSSProperties;
 }
+
+const NEST_TARGET_STATE_CLASS: Record<SidebarNestTargetState, string> = {
+  valid:
+    "bg-sidebar-accent text-sidebar-accent-foreground ring-1 ring-inset ring-sidebar-ring",
+  blocked: "ring-1 ring-inset ring-destructive/60",
+  unchanged: "ring-1 ring-inset ring-sidebar-border",
+};
+
+const REORDER_PLACEMENT_CLASS: Record<SidebarReorderPlacement, string> = {
+  before:
+    "before:pointer-events-none before:absolute before:inset-x-1 before:-top-px before:h-0.5 before:rounded-full before:bg-sidebar-ring before:content-['']",
+  after:
+    "after:pointer-events-none after:absolute after:inset-x-1 after:-bottom-px after:h-0.5 after:rounded-full after:bg-sidebar-ring after:content-['']",
+};
 
 function ThreadDraftIndicator({
   hideIdleLabel = false,
@@ -225,20 +249,25 @@ function getThreadRowStyle(depth: number): CSSProperties {
 function renderThreadRowContainer({
   children,
   className,
+  containerRef,
   dragBindings,
+  nestTargetState,
   onClickCapture,
   onSplitDragPointerDown,
+  reorderPlacement,
   stickyLevel,
   style,
 }: ThreadRowContainerArgs) {
   if (stickyLevel !== undefined) {
     return (
       <SidebarStickyTier
-        ref={dragBindings?.setActivatorNodeRef}
+        ref={containerRef}
         tier="parent"
         level={stickyLevel}
         className={className}
         style={style}
+        data-sidebar-nest-target={nestTargetState ?? undefined}
+        data-sidebar-reorder-placement={reorderPlacement ?? undefined}
         {...dragBindings?.attributes}
         {...(dragBindings?.listeners ?? {})}
         onClickCapture={onClickCapture}
@@ -251,9 +280,11 @@ function renderThreadRowContainer({
 
   return (
     <div
-      ref={dragBindings?.setActivatorNodeRef}
+      ref={containerRef}
       className={className}
       style={style}
+      data-sidebar-nest-target={nestTargetState ?? undefined}
+      data-sidebar-reorder-placement={reorderPlacement ?? undefined}
       {...dragBindings?.attributes}
       {...(dragBindings?.listeners ?? {})}
       onClickCapture={onClickCapture}
@@ -647,6 +678,12 @@ function ThreadRowComponent({
     ? `Open ${labelTitle} (unsubmitted draft)`
     : `Open ${labelTitle}`;
   const rowDragBindings = options.dragBindings;
+  const nestTargetState = options.nestDrop?.state ?? null;
+  const reorderPlacement = options.nestDrop?.reorderPlacement ?? null;
+  const containerRef = useComposedRefs<HTMLDivElement>(
+    rowDragBindings?.setActivatorNodeRef,
+    options.nestDrop?.setNodeRef,
+  );
   const rowClassName = cn(
     SIDEBAR_HOVER_ACTIONS_ROW_CLASS,
     "group/thread-row",
@@ -664,6 +701,8 @@ function ThreadRowComponent({
       SIDEBAR_ROW_OPEN_IN_SPLIT_STATE_CLASS,
     !showActive && "has-[[data-state=open]]:bg-sidebar-accent",
     rowDragBindings && !rowDragBindings.disabled && "select-none",
+    nestTargetState && NEST_TARGET_STATE_CLASS[nestTargetState],
+    reorderPlacement && REORDER_PLACEMENT_CLASS[reorderPlacement],
   );
   const rowStyle = getThreadRowStyle(options.depth);
   const isActionsOpen = isDropdownActionsOpen || isContextActionsOpen;
@@ -844,7 +883,10 @@ function ThreadRowComponent({
   const row = renderThreadRowContainer({
     children: rowContent,
     className: rowClassName,
+    containerRef,
     dragBindings: rowDragBindings,
+    nestTargetState,
+    reorderPlacement,
     onClickCapture: options.consumeClickSuppression
       ? handleRowClickCapture
       : undefined,

--- a/apps/app/src/components/sidebar/sidebarDropPreviewPlacement.test.ts
+++ b/apps/app/src/components/sidebar/sidebarDropPreviewPlacement.test.ts
@@ -1,0 +1,173 @@
+import type { ThreadListEntry } from "@bb/domain";
+import { describe, expect, it } from "vitest";
+import {
+  buildPinnedSidebarState,
+  buildSectionThreadList,
+  CHRONOLOGICAL_CONTAINER_ID,
+} from "@bb/client-core";
+import { makeThreadListEntry } from "@bb/test-helpers/domain-fixtures";
+import {
+  getSidebarNestParentKey,
+  resolveSidebarDropPreviewPlacement,
+} from "./sidebarDropPreviewPlacement";
+import { PINNED_THREAD_PARENT_KEY } from "./useSectionThreadDnd";
+
+function createThread(overrides: Partial<ThreadListEntry>): ThreadListEntry {
+  return makeThreadListEntry({
+    id: "thread",
+    projectId: "project",
+    title: "Thread",
+    titleFallback: "Thread",
+    lastReadAt: 0,
+    latestAttentionAt: 0,
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  });
+}
+
+const SECTIONS = [{ id: "a", name: "Section A" }];
+const newest = createThread({ id: "newest", createdAt: 9, updatedAt: 9 });
+const middle = createThread({ id: "middle", createdAt: 5, updatedAt: 5 });
+const oldest = createThread({ id: "oldest", createdAt: 1, updatedAt: 1 });
+const parent = createThread({
+  id: "parent",
+  sectionId: "a",
+  createdAt: 8,
+  updatedAt: 8,
+});
+const childNew = createThread({
+  id: "child-new",
+  parentThreadId: "parent",
+  sectionId: "a",
+  createdAt: 7,
+  updatedAt: 7,
+});
+const childOld = createThread({
+  id: "child-old",
+  parentThreadId: "parent",
+  sectionId: "a",
+  createdAt: 2,
+  updatedAt: 2,
+});
+const THREADS = [newest, middle, oldest, parent, childNew, childOld];
+const NO_DRAFTS = new Set<string>();
+
+function placement(
+  activeThread: ThreadListEntry,
+  target: Parameters<typeof resolveSidebarDropPreviewPlacement>[0]["target"],
+  pinnedRootNodes = buildPinnedSidebarState({ threads: [] }).rootNodes,
+) {
+  return resolveSidebarDropPreviewPlacement({
+    activeThread,
+    compareThreads: undefined,
+    draftThreadIds: NO_DRAFTS,
+    pinnedRootNodes,
+    sections: SECTIONS,
+    target,
+    threads: THREADS,
+  });
+}
+
+describe("resolveSidebarDropPreviewPlacement", () => {
+  it("places a thread moved into Threads by its sort position", () => {
+    const moved = createThread({
+      id: "moved",
+      sectionId: "a",
+      createdAt: 4,
+      updatedAt: 4,
+    });
+    expect(
+      resolveSidebarDropPreviewPlacement({
+        activeThread: moved,
+        compareThreads: undefined,
+        draftThreadIds: NO_DRAFTS,
+        pinnedRootNodes: [],
+        sections: SECTIONS,
+        target: {
+          kind: "container",
+          parentKey: CHRONOLOGICAL_CONTAINER_ID,
+          sectionId: null,
+        },
+        threads: [...THREADS, moved],
+      }),
+    ).toEqual({
+      parentKey: CHRONOLOGICAL_CONTAINER_ID,
+      beforeItemKey: "thread:oldest",
+    });
+  });
+
+  it("places the newest thread first and the oldest at the end", () => {
+    const sectionKey = buildSectionThreadList(
+      THREADS,
+      undefined,
+      SECTIONS,
+    ).find((item) => item.kind === "section");
+    expect(sectionKey?.kind).toBe("section");
+    const key = sectionKey?.kind === "section" ? sectionKey.group.key : "";
+    expect(
+      placement(newest, { kind: "container", parentKey: key, sectionId: "a" }),
+    ).toEqual({ parentKey: key, beforeItemKey: "thread:parent" });
+    expect(
+      placement(oldest, { kind: "container", parentKey: key, sectionId: "a" }),
+    ).toEqual({ parentKey: key, beforeItemKey: null });
+  });
+
+  it("places a nested thread among the parent's children", () => {
+    expect(
+      placement(middle, { kind: "nest", parentThreadId: "parent" }),
+    ).toEqual({
+      parentKey: getSidebarNestParentKey("parent"),
+      beforeItemKey: "thread:child-old",
+    });
+    expect(
+      placement(oldest, { kind: "nest", parentThreadId: "parent" }),
+    ).toEqual({
+      parentKey: getSidebarNestParentKey("parent"),
+      beforeItemKey: null,
+    });
+  });
+
+  it("places a newly pinned thread at the top of the pinned list", () => {
+    const pinnedRootNodes = buildPinnedSidebarState({
+      threads: [
+        createThread({ id: "pin-1", pinnedAt: 10, pinSortKey: "1" }),
+        createThread({ id: "pin-2", pinnedAt: 9, pinSortKey: "3" }),
+      ],
+    }).rootNodes;
+    expect(
+      placement(
+        middle,
+        { kind: "pinned", parentKey: PINNED_THREAD_PARENT_KEY },
+        pinnedRootNodes,
+      ),
+    ).toEqual({
+      parentKey: PINNED_THREAD_PARENT_KEY,
+      beforeItemKey: "thread:pin-1",
+    });
+  });
+
+  it("places a thread nested under a pinned parent among its children", () => {
+    const pinnedRootNodes = buildPinnedSidebarState({
+      threads: [
+        createThread({ id: "pin-1", pinnedAt: 10 }),
+        createThread({
+          id: "pin-child",
+          parentThreadId: "pin-1",
+          createdAt: 3,
+          updatedAt: 3,
+        }),
+      ],
+    }).rootNodes;
+    expect(
+      placement(
+        middle,
+        { kind: "nest", parentThreadId: "pin-1" },
+        pinnedRootNodes,
+      ),
+    ).toEqual({
+      parentKey: getSidebarNestParentKey("pin-1"),
+      beforeItemKey: "thread:pin-child",
+    });
+  });
+});

--- a/apps/app/src/components/sidebar/sidebarDropPreviewPlacement.ts
+++ b/apps/app/src/components/sidebar/sidebarDropPreviewPlacement.ts
@@ -1,0 +1,221 @@
+import type { ThreadListEntry } from "@bb/domain";
+import {
+  buildPinnedSidebarState,
+  buildSectionThreadList,
+  CHRONOLOGICAL_CONTAINER_ID,
+  type ProjectThreadItem,
+  type ProjectThreadNode,
+  type SidebarSectionDefinition,
+  type ThreadComparator,
+} from "@bb/client-core";
+
+export type SidebarDropPreviewTarget =
+  | { kind: "container"; parentKey: string; sectionId: string | null }
+  | { kind: "nest"; parentThreadId: string }
+  | { kind: "pinned"; parentKey: string };
+
+export interface SidebarDropPreviewPlacement {
+  parentKey: string;
+  beforeItemKey: string | null;
+}
+
+interface ResolveSidebarDropPreviewPlacementArgs {
+  activeThread: ThreadListEntry;
+  compareThreads: ThreadComparator | undefined;
+  draftThreadIds: ReadonlySet<string>;
+  pinnedRootNodes: readonly ProjectThreadNode[];
+  sections: readonly SidebarSectionDefinition[];
+  target: SidebarDropPreviewTarget;
+  threads: readonly ThreadListEntry[];
+}
+
+export function getSidebarItemKey(item: ProjectThreadItem): string {
+  switch (item.kind) {
+    case "thread":
+      return `thread:${item.node.thread.id}`;
+    case "environment":
+      return `env:${item.group.environmentId}`;
+    case "section":
+      return `section:${item.group.key}`;
+  }
+}
+
+export function getSidebarNestParentKey(parentThreadId: string): string {
+  return `nest:${parentThreadId}`;
+}
+
+function flattenNodeThreads(
+  items: readonly ProjectThreadItem[],
+  out: ThreadListEntry[] = [],
+): ThreadListEntry[] {
+  for (const item of items) {
+    if (item.kind === "thread") {
+      out.push(item.node.thread);
+      flattenNodeThreads(item.node.children, out);
+    } else if (item.kind === "environment") {
+      for (const node of item.group.nodes) {
+        out.push(node.thread);
+        flattenNodeThreads(node.children, out);
+      }
+    } else {
+      flattenNodeThreads(item.group.items, out);
+    }
+  }
+  return out;
+}
+
+function findThreadNode(
+  items: readonly ProjectThreadItem[],
+  threadId: string,
+): ProjectThreadNode | null {
+  for (const item of items) {
+    if (item.kind === "thread") {
+      if (item.node.thread.id === threadId) return item.node;
+      const nested = findThreadNode(item.node.children, threadId);
+      if (nested) return nested;
+    } else if (item.kind === "environment") {
+      for (const node of item.group.nodes) {
+        if (node.thread.id === threadId) return node;
+        const nested = findThreadNode(node.children, threadId);
+        if (nested) return nested;
+      }
+    } else {
+      const nested = findThreadNode(item.group.items, threadId);
+      if (nested) return nested;
+    }
+  }
+  return null;
+}
+
+function itemHoldsThread(item: ProjectThreadItem, threadId: string): boolean {
+  if (item.kind === "thread") return item.node.thread.id === threadId;
+  if (item.kind === "environment") {
+    return item.group.nodes.some((node) => node.thread.id === threadId);
+  }
+  return false;
+}
+
+function beforeKeyAfterThread(
+  siblings: readonly ProjectThreadItem[],
+  threadId: string,
+): string | null {
+  const index = siblings.findIndex((item) => itemHoldsThread(item, threadId));
+  if (index === -1) return null;
+  const next = siblings[index + 1];
+  return next ? getSidebarItemKey(next) : null;
+}
+
+function withPatchedThread(
+  threads: readonly ThreadListEntry[],
+  patched: ThreadListEntry,
+): ThreadListEntry[] {
+  const others = threads.filter((thread) => thread.id !== patched.id);
+  return [...others, patched];
+}
+
+function findSectionItems(
+  items: readonly ProjectThreadItem[],
+  sectionKey: string,
+): readonly ProjectThreadItem[] {
+  for (const item of items) {
+    if (item.kind === "section" && item.group.key === sectionKey) {
+      return item.group.items;
+    }
+  }
+  return [];
+}
+
+function nodesToItems(
+  nodes: readonly ProjectThreadNode[],
+): ProjectThreadItem[] {
+  return nodes.map((node) => ({ kind: "thread", node }));
+}
+
+export function resolveSidebarDropPreviewPlacement({
+  activeThread,
+  compareThreads,
+  draftThreadIds,
+  pinnedRootNodes,
+  sections,
+  target,
+  threads,
+}: ResolveSidebarDropPreviewPlacementArgs): SidebarDropPreviewPlacement {
+  const pinnedItems = nodesToItems(pinnedRootNodes);
+  if (target.kind === "pinned") {
+    const projected = buildPinnedSidebarState({
+      draftThreadIds,
+      threads: withPatchedThread(flattenNodeThreads(pinnedItems), {
+        ...activeThread,
+        parentThreadId: null,
+        pinnedAt: Number.MAX_SAFE_INTEGER,
+        pinSortKey: null,
+      }),
+    });
+    return {
+      parentKey: target.parentKey,
+      beforeItemKey: beforeKeyAfterThread(
+        nodesToItems(projected.rootNodes),
+        activeThread.id,
+      ),
+    };
+  }
+
+  if (target.kind === "nest") {
+    const parentKey = getSidebarNestParentKey(target.parentThreadId);
+    if (findThreadNode(pinnedItems, target.parentThreadId)) {
+      const projected = buildPinnedSidebarState({
+        draftThreadIds,
+        threads: withPatchedThread(flattenNodeThreads(pinnedItems), {
+          ...activeThread,
+          parentThreadId: target.parentThreadId,
+          pinnedAt: null,
+        }),
+      });
+      const parentNode = findThreadNode(
+        nodesToItems(projected.rootNodes),
+        target.parentThreadId,
+      );
+      return {
+        parentKey,
+        beforeItemKey: parentNode
+          ? beforeKeyAfterThread(parentNode.children, activeThread.id)
+          : null,
+      };
+    }
+    const projected = buildSectionThreadList(
+      withPatchedThread(threads, {
+        ...activeThread,
+        parentThreadId: target.parentThreadId,
+      }),
+      compareThreads,
+      sections,
+      draftThreadIds,
+    );
+    const parentNode = findThreadNode(projected, target.parentThreadId);
+    return {
+      parentKey,
+      beforeItemKey: parentNode
+        ? beforeKeyAfterThread(parentNode.children, activeThread.id)
+        : null,
+    };
+  }
+
+  const projected = buildSectionThreadList(
+    withPatchedThread(threads, {
+      ...activeThread,
+      parentThreadId: null,
+      sectionId: target.sectionId,
+    }),
+    compareThreads,
+    sections,
+    draftThreadIds,
+  );
+  const siblings =
+    target.parentKey === CHRONOLOGICAL_CONTAINER_ID
+      ? projected.filter((item) => item.kind !== "section")
+      : findSectionItems(projected, target.parentKey);
+  return {
+    parentKey: target.parentKey,
+    beforeItemKey: beforeKeyAfterThread(siblings, activeThread.id),
+  };
+}

--- a/apps/app/src/components/sidebar/sidebarDropPreviewPlacement.ts
+++ b/apps/app/src/components/sidebar/sidebarDropPreviewPlacement.ts
@@ -4,6 +4,7 @@ import {
   buildProjectThreadGroups,
   buildSectionThreadList,
   CHRONOLOGICAL_CONTAINER_ID,
+  getProjectThreadItemDescendants,
   type ProjectThreadItem,
   type ProjectThreadNode,
   type SidebarSectionDefinition,
@@ -44,26 +45,6 @@ export function getSidebarItemKey(item: ProjectThreadItem): string {
 
 export function getSidebarNestParentKey(parentThreadId: string): string {
   return `nest:${parentThreadId}`;
-}
-
-function flattenNodeThreads(
-  items: readonly ProjectThreadItem[],
-  out: ThreadListEntry[] = [],
-): ThreadListEntry[] {
-  for (const item of items) {
-    if (item.kind === "thread") {
-      out.push(item.node.thread);
-      flattenNodeThreads(item.node.children, out);
-    } else if (item.kind === "environment") {
-      for (const node of item.group.nodes) {
-        out.push(node.thread);
-        flattenNodeThreads(node.children, out);
-      }
-    } else {
-      flattenNodeThreads(item.group.items, out);
-    }
-  }
-  return out;
 }
 
 function findThreadNode(
@@ -146,7 +127,7 @@ export function resolveSidebarDropPreviewPlacement({
   if (target.kind === "pinned") {
     const projected = buildPinnedSidebarState({
       draftThreadIds,
-      threads: withPatchedThread(flattenNodeThreads(pinnedItems), {
+      threads: withPatchedThread(getProjectThreadItemDescendants(pinnedItems), {
         ...activeThread,
         parentThreadId: null,
         pinnedAt: Number.MAX_SAFE_INTEGER,
@@ -164,7 +145,7 @@ export function resolveSidebarDropPreviewPlacement({
 
   if (target.kind === "group") {
     const projected = buildProjectThreadGroups(
-      withPatchedThread(flattenNodeThreads(target.items), {
+      withPatchedThread(getProjectThreadItemDescendants(target.items), {
         ...activeThread,
         parentThreadId: null,
       }),
@@ -182,11 +163,14 @@ export function resolveSidebarDropPreviewPlacement({
     if (findThreadNode(pinnedItems, target.parentThreadId)) {
       const projected = buildPinnedSidebarState({
         draftThreadIds,
-        threads: withPatchedThread(flattenNodeThreads(pinnedItems), {
-          ...activeThread,
-          parentThreadId: target.parentThreadId,
-          pinnedAt: null,
-        }),
+        threads: withPatchedThread(
+          getProjectThreadItemDescendants(pinnedItems),
+          {
+            ...activeThread,
+            parentThreadId: target.parentThreadId,
+            pinnedAt: null,
+          },
+        ),
       });
       const parentNode = findThreadNode(
         nodesToItems(projected.rootNodes),

--- a/apps/app/src/components/sidebar/sidebarDropPreviewPlacement.ts
+++ b/apps/app/src/components/sidebar/sidebarDropPreviewPlacement.ts
@@ -1,6 +1,7 @@
 import type { ThreadListEntry } from "@bb/domain";
 import {
   buildPinnedSidebarState,
+  buildProjectThreadGroups,
   buildSectionThreadList,
   CHRONOLOGICAL_CONTAINER_ID,
   type ProjectThreadItem,
@@ -11,6 +12,7 @@ import {
 
 export type SidebarDropPreviewTarget =
   | { kind: "container"; parentKey: string; sectionId: string | null }
+  | { kind: "group"; parentKey: string; items: readonly ProjectThreadItem[] }
   | { kind: "nest"; parentThreadId: string }
   | { kind: "pinned"; parentKey: string };
 
@@ -157,6 +159,21 @@ export function resolveSidebarDropPreviewPlacement({
         nodesToItems(projected.rootNodes),
         activeThread.id,
       ),
+    };
+  }
+
+  if (target.kind === "group") {
+    const projected = buildProjectThreadGroups(
+      withPatchedThread(flattenNodeThreads(target.items), {
+        ...activeThread,
+        parentThreadId: null,
+      }),
+      compareThreads,
+      draftThreadIds,
+    );
+    return {
+      parentKey: target.parentKey,
+      beforeItemKey: beforeKeyAfterThread(projected, activeThread.id),
     };
   }
 

--- a/apps/app/src/components/sidebar/sidebarThreadRowDroppable.ts
+++ b/apps/app/src/components/sidebar/sidebarThreadRowDroppable.ts
@@ -1,0 +1,21 @@
+const SIDEBAR_THREAD_ROW_DROPPABLE_PREFIX = "sidebar:thread-row:";
+
+export type SidebarNestTargetState = "valid" | "blocked" | "unchanged";
+
+export type SidebarReorderPlacement = "before" | "after";
+
+export interface ThreadRowNestDrop {
+  setNodeRef: (element: HTMLElement | null) => void;
+  state: SidebarNestTargetState | null;
+  reorderPlacement: SidebarReorderPlacement | null;
+}
+
+export function getSidebarThreadRowDroppableId(threadId: string): string {
+  return `${SIDEBAR_THREAD_ROW_DROPPABLE_PREFIX}${threadId}`;
+}
+
+export function parseSidebarThreadRowDroppableId(id: string): string | null {
+  return id.startsWith(SIDEBAR_THREAD_ROW_DROPPABLE_PREFIX)
+    ? id.slice(SIDEBAR_THREAD_ROW_DROPPABLE_PREFIX.length)
+    : null;
+}

--- a/apps/app/src/components/sidebar/sortableMotion.ts
+++ b/apps/app/src/components/sidebar/sortableMotion.ts
@@ -28,6 +28,7 @@ export interface SidebarSortableDragBindings {
 interface UseSidebarSortableArgs {
   id: string;
   disabled: boolean;
+  displace?: boolean;
 }
 
 interface UseSidebarSortableResult {
@@ -40,6 +41,7 @@ interface UseSidebarSortableResult {
 export function useSidebarSortable({
   id,
   disabled,
+  displace = true,
 }: UseSidebarSortableArgs): UseSidebarSortableResult {
   const {
     attributes,
@@ -53,13 +55,13 @@ export function useSidebarSortable({
   } = useSortable({ id, disabled, transition: SIDEBAR_SORTABLE_TRANSITION });
   const style = useMemo<CSSProperties>(
     () => ({
-      transform: CSS.Translate.toString(transform),
-      transition,
+      transform: displace ? CSS.Translate.toString(transform) : undefined,
+      transition: displace ? transition : undefined,
       position: isDragging ? "relative" : undefined,
       zIndex: isDragging ? 100 : undefined,
       opacity: isDragging ? 0.8 : undefined,
     }),
-    [isDragging, transform, transition],
+    [displace, isDragging, transform, transition],
   );
   const dragBindings = useMemo<SidebarSortableDragBindings>(
     () => ({ attributes, disabled, listeners, setActivatorNodeRef }),

--- a/apps/app/src/components/sidebar/useRenderedSectionThreadDnd.ts
+++ b/apps/app/src/components/sidebar/useRenderedSectionThreadDnd.ts
@@ -1,0 +1,159 @@
+import { useMemo } from "react";
+import type { ThreadListEntry } from "@bb/domain";
+import {
+  CHRONOLOGICAL_CONTAINER_ID,
+  type ProjectThreadItem,
+  type ProjectThreadNode,
+  type SidebarSectionDefinition,
+  type ThreadComparator,
+} from "@bb/client-core";
+import {
+  resolveSidebarDropPreviewPlacement,
+  type SidebarDropPreviewTarget,
+} from "./sidebarDropPreviewPlacement";
+import {
+  PINNED_THREAD_PARENT_KEY,
+  type SectionThreadDndState,
+} from "./useSectionThreadDnd";
+
+interface ShouldSuppressPinnedThreadDropPreviewArgs {
+  activeThreadId: string | undefined;
+  dragOverParentKey: string | null;
+  pinnedThreads: readonly Pick<ThreadListEntry, "id">[];
+}
+
+export function shouldSuppressPinnedThreadDropPreview({
+  activeThreadId,
+  dragOverParentKey,
+  pinnedThreads,
+}: ShouldSuppressPinnedThreadDropPreviewArgs): boolean {
+  return (
+    activeThreadId !== undefined &&
+    dragOverParentKey === PINNED_THREAD_PARENT_KEY &&
+    pinnedThreads.some((thread) => thread.id === activeThreadId)
+  );
+}
+
+interface ResolveDropPreviewTargetArgs {
+  dragOverParentKey: string | null;
+  groups: boolean;
+  nestTarget: SectionThreadDndState["nestTarget"];
+  reorderTarget: SectionThreadDndState["reorderTarget"];
+  rootItems: readonly ProjectThreadItem[];
+}
+
+export function resolveDropPreviewTarget({
+  dragOverParentKey,
+  groups,
+  nestTarget,
+  reorderTarget,
+  rootItems,
+}: ResolveDropPreviewTargetArgs): SidebarDropPreviewTarget | null {
+  if (nestTarget?.state === "valid") {
+    return { kind: "nest", parentThreadId: nestTarget.threadId };
+  }
+  if (dragOverParentKey === null) return null;
+  if (dragOverParentKey === PINNED_THREAD_PARENT_KEY) {
+    return reorderTarget
+      ? null
+      : { kind: "pinned", parentKey: PINNED_THREAD_PARENT_KEY };
+  }
+  if (dragOverParentKey === CHRONOLOGICAL_CONTAINER_ID) {
+    return groups
+      ? {
+          kind: "group",
+          parentKey: CHRONOLOGICAL_CONTAINER_ID,
+          items: rootItems.filter((item) => item.kind !== "section"),
+        }
+      : {
+          kind: "container",
+          parentKey: CHRONOLOGICAL_CONTAINER_ID,
+          sectionId: null,
+        };
+  }
+  for (const item of rootItems) {
+    if (item.kind === "section" && item.group.key === dragOverParentKey) {
+      return groups
+        ? { kind: "group", parentKey: item.group.key, items: item.group.items }
+        : {
+            kind: "container",
+            parentKey: item.group.key,
+            sectionId: item.group.id,
+          };
+    }
+  }
+  return null;
+}
+
+interface UseRenderedSectionThreadDndArgs {
+  compareThreads: ThreadComparator;
+  draftThreadIds: ReadonlySet<string>;
+  groups?: boolean;
+  pinnedRootNodes: readonly ProjectThreadNode[];
+  pinnedThreads: readonly ThreadListEntry[];
+  rootItems: readonly ProjectThreadItem[];
+  sectionDnd: SectionThreadDndState | null;
+  sections: readonly SidebarSectionDefinition[];
+  threads: readonly ThreadListEntry[];
+}
+
+export function useRenderedSectionThreadDnd({
+  compareThreads,
+  draftThreadIds,
+  groups = false,
+  pinnedRootNodes,
+  pinnedThreads,
+  rootItems,
+  sectionDnd,
+  sections,
+  threads,
+}: UseRenderedSectionThreadDndArgs): SectionThreadDndState | null {
+  return useMemo<SectionThreadDndState | null>(() => {
+    if (!sectionDnd) {
+      return null;
+    }
+    const activeThread = sectionDnd.activeThread;
+    const suppressPinnedDropPreview = shouldSuppressPinnedThreadDropPreview({
+      activeThreadId: activeThread?.id,
+      dragOverParentKey: sectionDnd.dragOverParentKey,
+      pinnedThreads,
+    });
+    if (suppressPinnedDropPreview) {
+      return { ...sectionDnd, dragOverParentKey: null, dropPreview: null };
+    }
+    if (!activeThread) {
+      return sectionDnd;
+    }
+    const target = resolveDropPreviewTarget({
+      dragOverParentKey: sectionDnd.dragOverParentKey,
+      groups,
+      nestTarget: sectionDnd.nestTarget,
+      reorderTarget: sectionDnd.reorderTarget,
+      rootItems,
+    });
+    return {
+      ...sectionDnd,
+      dropPreview: target
+        ? resolveSidebarDropPreviewPlacement({
+            activeThread,
+            compareThreads,
+            draftThreadIds,
+            pinnedRootNodes,
+            sections,
+            target,
+            threads,
+          })
+        : null,
+    };
+  }, [
+    compareThreads,
+    draftThreadIds,
+    groups,
+    pinnedRootNodes,
+    pinnedThreads,
+    rootItems,
+    sectionDnd,
+    sections,
+    threads,
+  ]);
+}

--- a/apps/app/src/components/sidebar/useSectionThreadDnd.projection.test.tsx
+++ b/apps/app/src/components/sidebar/useSectionThreadDnd.projection.test.tsx
@@ -16,6 +16,7 @@ import {
 } from "@bb/client-core";
 import {
   collectSectionThreadDndLookup,
+  PINNED_NEST_LINGER_MS,
   SectionThreadProjectionGate,
   useSectionThreadDnd,
 } from "./useSectionThreadDnd";
@@ -65,7 +66,7 @@ function dragOver(activeId: string, overId: string): DragOverEvent {
   return { active: { id: activeId }, over: { id: overId } } as DragOverEvent;
 }
 
-function renderSectionThreadDnd() {
+function renderSectionThreadDnd(pinnedThreads: ThreadListEntry[] = []) {
   const queryClient = new QueryClient();
   const wrapper = ({ children }: { children: ReactNode }) => (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
@@ -79,11 +80,49 @@ function renderSectionThreadDnd() {
         topLevelSectionOrder: ["pinned", "section:a", "section:b", "threads"],
         onTopLevelSectionOrderChange: vi.fn(),
         pinnedReorderPending: false,
-        pinnedThreads: [],
+        pinnedThreads,
         onReorderPinnedThread: vi.fn(),
       }),
     { wrapper },
   );
+}
+
+const ROW_RECT = {
+  top: 100,
+  left: 0,
+  width: 200,
+  height: 28,
+  right: 200,
+  bottom: 128,
+};
+
+function collide(
+  collisionDetection: NonNullable<
+    ReturnType<typeof renderSectionThreadDnd>["result"]["current"]
+  >["dndContextProps"]["collisionDetection"],
+  activeId: string,
+  overThreadId: string,
+) {
+  const rowId = getSidebarThreadRowDroppableId(overThreadId);
+  const containers = [rowId, overThreadId].map((id) => ({
+    id,
+    key: id,
+    disabled: false,
+    node: { current: null },
+    rect: { current: ROW_RECT },
+    data: { current: {} },
+  }));
+  return collisionDetection?.({
+    active: {
+      id: activeId,
+      data: { current: {} },
+      rect: { current: { initial: null, translated: null } },
+    },
+    collisionRect: ROW_RECT,
+    droppableRects: new Map(containers.map((c) => [c.id, ROW_RECT])),
+    droppableContainers: containers as never,
+    pointerCoordinates: { x: 20, y: 114 },
+  });
 }
 
 function notePointerMove() {
@@ -186,6 +225,36 @@ describe("useSectionThreadDnd nest projection", () => {
       } as DragCancelEvent),
     );
     expect(result.current?.nestTarget).toBeNull();
+  });
+});
+
+describe("useSectionThreadDnd pinned linger", () => {
+  it("keeps a pinned row as a reorder target until the pointer lingers", () => {
+    vi.useFakeTimers();
+    try {
+      const pinned = [
+        createThread({ id: "pinned-1", pinnedAt: 10 }),
+        createThread({ id: "pinned-2", pinnedAt: 9 }),
+      ];
+      const { result } = renderSectionThreadDnd(pinned);
+      const props = () => result.current!.dndContextProps;
+      act(() => props().onDragStart?.(dragStart("pinned-1")));
+
+      const early = collide(props().collisionDetection, "pinned-1", "pinned-2");
+      expect(early?.[0]?.id).toBe("pinned-2");
+
+      act(() => {
+        vi.advanceTimersByTime(PINNED_NEST_LINGER_MS + 5);
+      });
+      const late = collide(props().collisionDetection, "pinned-1", "pinned-2");
+      expect(late?.[0]?.id).toBe(getSidebarThreadRowDroppableId("pinned-2"));
+
+      act(() => props().onDragStart?.(dragStart("loose")));
+      const loose = collide(props().collisionDetection, "loose", "pinned-2");
+      expect(loose?.[0]?.id).toBe(getSidebarThreadRowDroppableId("pinned-2"));
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/apps/app/src/components/sidebar/useSectionThreadDnd.projection.test.tsx
+++ b/apps/app/src/components/sidebar/useSectionThreadDnd.projection.test.tsx
@@ -20,6 +20,7 @@ import {
   useSectionThreadDnd,
 } from "./useSectionThreadDnd";
 import { makeThreadListEntry } from "@bb/test-helpers/domain-fixtures";
+import { getSidebarThreadRowDroppableId } from "./sidebarThreadRowDroppable";
 
 function createThread(overrides: Partial<ThreadListEntry>): ThreadListEntry {
   return makeThreadListEntry({
@@ -103,20 +104,16 @@ describe("useSectionThreadDnd projection feedback loop (#1830)", () => {
     act(() => props().onDragStart?.(dragStart("dragged")));
     act(() => props().onDragOver?.(dragOver("dragged", "section:b")));
     expect(result.current?.dragOverParentKey).toBe(SECTION_B_PARENT_KEY);
-    expect(result.current?.projectedSectionId).toBe("b");
 
     act(() => props().onDragOver?.(dragOver("dragged", "peer-a")));
     expect(result.current?.dragOverParentKey).toBe(SECTION_B_PARENT_KEY);
-    expect(result.current?.projectedSectionId).toBe("b");
 
     act(() => props().onDragOver?.(dragOver("dragged", "loose")));
     expect(result.current?.dragOverParentKey).toBe(CHRONOLOGICAL_CONTAINER_ID);
-    expect(result.current?.projectedSectionId).toBeNull();
 
     act(() => notePointerMove());
     act(() => props().onDragOver?.(dragOver("dragged", "peer-a")));
     expect(result.current?.dragOverParentKey).toBeNull();
-    expect(result.current?.projectedSectionId).toBeUndefined();
 
     act(() => notePointerMove());
     act(() => props().onDragOver?.(dragOver("dragged", "section:b")));
@@ -147,6 +144,48 @@ describe("useSectionThreadDnd projection feedback loop (#1830)", () => {
     ).toHaveLength(2);
     addSpy.mockRestore();
     removeSpy.mockRestore();
+  });
+});
+
+describe("useSectionThreadDnd nest projection", () => {
+  it("projects a nest target from a row collision and keeps it through self-collision", () => {
+    const { result } = renderSectionThreadDnd();
+    const props = () => result.current!.dndContextProps;
+
+    act(() => props().onDragStart?.(dragStart("dragged")));
+    act(() =>
+      props().onDragOver?.(
+        dragOver("dragged", getSidebarThreadRowDroppableId("in-b")),
+      ),
+    );
+    expect(result.current?.nestTarget).toEqual({
+      threadId: "in-b",
+      state: "valid",
+    });
+    expect(result.current?.dragOverParentKey).toBeNull();
+
+    act(() => notePointerMove());
+    act(() => props().onDragOver?.(dragOver("dragged", "dragged")));
+    expect(result.current?.nestTarget).toEqual({
+      threadId: "in-b",
+      state: "valid",
+    });
+
+    act(() => notePointerMove());
+    act(() => props().onDragOver?.(dragOver("dragged", "section:b")));
+    expect(result.current?.nestTarget).toBeNull();
+    expect(result.current?.dragOverParentKey).toBe(SECTION_B_PARENT_KEY);
+
+    act(() => notePointerMove());
+    act(() => props().onDragOver?.(dragOver("dragged", "peer-a")));
+    expect(result.current?.dragOverParentKey).toBeNull();
+
+    act(() =>
+      props().onDragCancel?.({
+        active: { id: "dragged" },
+      } as DragCancelEvent),
+    );
+    expect(result.current?.nestTarget).toBeNull();
   });
 });
 

--- a/apps/app/src/components/sidebar/useSectionThreadDnd.projection.test.tsx
+++ b/apps/app/src/components/sidebar/useSectionThreadDnd.projection.test.tsx
@@ -16,7 +16,6 @@ import {
 } from "@bb/client-core";
 import {
   collectSectionThreadDndLookup,
-  PINNED_NEST_LINGER_MS,
   SectionThreadProjectionGate,
   useSectionThreadDnd,
 } from "./useSectionThreadDnd";
@@ -66,7 +65,7 @@ function dragOver(activeId: string, overId: string): DragOverEvent {
   return { active: { id: activeId }, over: { id: overId } } as DragOverEvent;
 }
 
-function renderSectionThreadDnd(pinnedThreads: ThreadListEntry[] = []) {
+function renderSectionThreadDnd() {
   const queryClient = new QueryClient();
   const wrapper = ({ children }: { children: ReactNode }) => (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
@@ -80,49 +79,11 @@ function renderSectionThreadDnd(pinnedThreads: ThreadListEntry[] = []) {
         topLevelSectionOrder: ["pinned", "section:a", "section:b", "threads"],
         onTopLevelSectionOrderChange: vi.fn(),
         pinnedReorderPending: false,
-        pinnedThreads,
+        pinnedThreads: [],
         onReorderPinnedThread: vi.fn(),
       }),
     { wrapper },
   );
-}
-
-const ROW_RECT = {
-  top: 100,
-  left: 0,
-  width: 200,
-  height: 28,
-  right: 200,
-  bottom: 128,
-};
-
-function collide(
-  collisionDetection: NonNullable<
-    ReturnType<typeof renderSectionThreadDnd>["result"]["current"]
-  >["dndContextProps"]["collisionDetection"],
-  activeId: string,
-  overThreadId: string,
-) {
-  const rowId = getSidebarThreadRowDroppableId(overThreadId);
-  const containers = [rowId, overThreadId].map((id) => ({
-    id,
-    key: id,
-    disabled: false,
-    node: { current: null },
-    rect: { current: ROW_RECT },
-    data: { current: {} },
-  }));
-  return collisionDetection?.({
-    active: {
-      id: activeId,
-      data: { current: {} },
-      rect: { current: { initial: null, translated: null } },
-    },
-    collisionRect: ROW_RECT,
-    droppableRects: new Map(containers.map((c) => [c.id, ROW_RECT])),
-    droppableContainers: containers as never,
-    pointerCoordinates: { x: 20, y: 114 },
-  });
 }
 
 function notePointerMove() {
@@ -225,36 +186,6 @@ describe("useSectionThreadDnd nest projection", () => {
       } as DragCancelEvent),
     );
     expect(result.current?.nestTarget).toBeNull();
-  });
-});
-
-describe("useSectionThreadDnd pinned linger", () => {
-  it("keeps a pinned row as a reorder target until the pointer lingers", () => {
-    vi.useFakeTimers();
-    try {
-      const pinned = [
-        createThread({ id: "pinned-1", pinnedAt: 10 }),
-        createThread({ id: "pinned-2", pinnedAt: 9 }),
-      ];
-      const { result } = renderSectionThreadDnd(pinned);
-      const props = () => result.current!.dndContextProps;
-      act(() => props().onDragStart?.(dragStart("pinned-1")));
-
-      const early = collide(props().collisionDetection, "pinned-1", "pinned-2");
-      expect(early?.[0]?.id).toBe("pinned-2");
-
-      act(() => {
-        vi.advanceTimersByTime(PINNED_NEST_LINGER_MS + 5);
-      });
-      const late = collide(props().collisionDetection, "pinned-1", "pinned-2");
-      expect(late?.[0]?.id).toBe(getSidebarThreadRowDroppableId("pinned-2"));
-
-      act(() => props().onDragStart?.(dragStart("loose")));
-      const loose = collide(props().collisionDetection, "loose", "pinned-2");
-      expect(loose?.[0]?.id).toBe(getSidebarThreadRowDroppableId("pinned-2"));
-    } finally {
-      vi.useRealTimers();
-    }
   });
 });
 

--- a/apps/app/src/components/sidebar/useSectionThreadDnd.test.ts
+++ b/apps/app/src/components/sidebar/useSectionThreadDnd.test.ts
@@ -1,17 +1,23 @@
 import type { ThreadListEntry } from "@bb/domain";
 import { describe, expect, it } from "vitest";
 import {
+  buildPinnedSidebarState,
   buildSectionThreadList,
   CHRONOLOGICAL_CONTAINER_ID,
 } from "@bb/client-core";
 import {
   collectSectionThreadDndLookup,
+  NEST_BAND_ARMED_FRACTION,
+  NEST_BAND_FRACTION,
   PINNED_THREAD_PARENT_KEY,
+  resolvePinnedReorderPlacement,
   resolveSectionThreadDropDecision,
   resolveSectionThreadDropTarget,
   resolveSectionThreadSectionOverId,
   resolveProjectedSectionThreadDropTarget,
+  resolveThreadRowNestCollisions,
 } from "./useSectionThreadDnd";
+import { getSidebarThreadRowDroppableId } from "./sidebarThreadRowDroppable";
 import { makeThreadListEntry } from "@bb/test-helpers/domain-fixtures";
 
 function createThread(overrides: Partial<ThreadListEntry>): ThreadListEntry {
@@ -188,7 +194,7 @@ describe("section thread pin drop decisions", () => {
         "loose",
         "pinned",
       ),
-    ).toEqual({ kind: "pin", activeId: "loose" });
+    ).toEqual({ kind: "pin", activeId: "loose", detach: false });
   });
 
   it("preserves a projected Pinned destination through self-collision", () => {
@@ -199,7 +205,7 @@ describe("section thread pin drop decisions", () => {
         "loose",
         PINNED_THREAD_PARENT_KEY,
       ),
-    ).toEqual({ kind: "pin", activeId: "loose" });
+    ).toEqual({ kind: "pin", activeId: "loose", detach: false });
   });
 
   it("unpins a pinned thread into Threads and clears its section", () => {
@@ -244,5 +250,285 @@ describe("section thread pin drop decisions", () => {
       activeId: "pinned-1",
       overId: "pinned-2",
     });
+  });
+});
+
+function createNestedLookup(pinnedThreads: ThreadListEntry[] = []) {
+  return collectSectionThreadDndLookup(
+    buildSectionThreadList(
+      [
+        createThread({ id: "parent-a", title: "Parent A", sectionId: "a" }),
+        createThread({
+          id: "child-a",
+          title: "Child A",
+          sectionId: "a",
+          parentThreadId: "parent-a",
+          createdAt: 2,
+        }),
+        createThread({
+          id: "grandchild-a",
+          title: "Grandchild A",
+          sectionId: "a",
+          parentThreadId: "child-a",
+          createdAt: 3,
+        }),
+        createThread({ id: "loose", title: "Loose", createdAt: 4 }),
+        createThread({
+          id: "other-project",
+          title: "Other project",
+          projectId: "project-2",
+          createdAt: 5,
+        }),
+      ],
+      undefined,
+      [
+        { id: "a", name: "Section A" },
+        { id: "b", name: "Empty Section B" },
+      ],
+    ),
+    CHRONOLOGICAL_CONTAINER_ID,
+    pinnedThreads,
+  );
+}
+
+const rowId = getSidebarThreadRowDroppableId;
+
+describe("section thread nest drop decisions", () => {
+  it("nests a loose thread under a section thread's row and adopts its section", () => {
+    expect(
+      resolveSectionThreadDropDecision(
+        createNestedLookup(),
+        "loose",
+        rowId("parent-a"),
+      ),
+    ).toEqual({
+      kind: "nest",
+      activeId: "loose",
+      parentThreadId: "parent-a",
+      sectionId: "a",
+      unpin: false,
+    });
+  });
+
+  it("nests under deeper rows and across projects", () => {
+    expect(
+      resolveSectionThreadDropDecision(
+        createNestedLookup(),
+        "other-project",
+        rowId("grandchild-a"),
+      ),
+    ).toEqual({
+      kind: "nest",
+      activeId: "other-project",
+      parentThreadId: "grandchild-a",
+      sectionId: "a",
+      unpin: false,
+    });
+    expect(
+      resolveSectionThreadDropDecision(
+        createNestedLookup(),
+        "grandchild-a",
+        rowId("loose"),
+      ),
+    ).toEqual({
+      kind: "nest",
+      activeId: "grandchild-a",
+      parentThreadId: "loose",
+      sectionId: null,
+      unpin: false,
+    });
+  });
+
+  it("rejects nesting a thread inside its own subtree", () => {
+    expect(
+      resolveSectionThreadDropDecision(
+        createNestedLookup(),
+        "parent-a",
+        rowId("grandchild-a"),
+      ),
+    ).toEqual({
+      kind: "rejected",
+      activeId: "parent-a",
+      overThreadId: "grandchild-a",
+      reason: "own-subtree",
+    });
+  });
+
+  it("reports an unchanged drop onto the current parent", () => {
+    expect(
+      resolveSectionThreadDropDecision(
+        createNestedLookup(),
+        "child-a",
+        rowId("parent-a"),
+      ),
+    ).toEqual({
+      kind: "rejected",
+      activeId: "child-a",
+      overThreadId: "parent-a",
+      reason: "already-child",
+    });
+  });
+
+  it("keeps a projected nest through self-collision", () => {
+    expect(
+      resolveSectionThreadDropDecision(
+        createNestedLookup(),
+        "loose",
+        rowId("loose"),
+        null,
+        "parent-a",
+      ),
+    ).toMatchObject({ kind: "nest", parentThreadId: "parent-a" });
+    expect(
+      resolveSectionThreadDropDecision(
+        createNestedLookup(),
+        "loose",
+        "loose",
+        null,
+        "parent-a",
+      ),
+    ).toMatchObject({ kind: "nest", parentThreadId: "parent-a" });
+  });
+
+  it("detaches a nested thread dropped onto its own section or the Threads container", () => {
+    const lookup = createNestedLookup();
+    const sectionAKey = lookup.sectionParentKeyBySectionId.get("section:a");
+    expect(
+      resolveSectionThreadDropDecision(lookup, "child-a", sectionAKey ?? null),
+    ).toEqual({ kind: "detach", activeId: "child-a", sectionId: "a" });
+    expect(
+      resolveSectionThreadDropDecision(lookup, "grandchild-a", "threads"),
+    ).toEqual({ kind: "detach", activeId: "grandchild-a", sectionId: null });
+    expect(
+      resolveSectionThreadDropTarget(lookup, "child-a", sectionAKey ?? null),
+    ).toMatchObject({ activeId: "child-a", toParentKey: sectionAKey });
+  });
+
+  it("detaches before pinning a nested thread", () => {
+    expect(
+      resolveSectionThreadDropDecision(
+        createNestedLookup(),
+        "child-a",
+        "pinned",
+      ),
+    ).toEqual({ kind: "pin", activeId: "child-a", detach: true });
+  });
+
+  it("detaches a child of a pinned thread dropped on the Pinned header", () => {
+    const pinnedRoot = createThread({ id: "pinned-1", pinnedAt: 10 });
+    const pinnedChild = createThread({
+      id: "pinned-child",
+      parentThreadId: "pinned-1",
+      createdAt: 2,
+    });
+    const pinnedState = buildPinnedSidebarState({
+      threads: [pinnedRoot, pinnedChild],
+    });
+    const lookup = collectSectionThreadDndLookup(
+      buildSectionThreadList([], undefined, []),
+      CHRONOLOGICAL_CONTAINER_ID,
+      [pinnedRoot],
+      pinnedState.rootNodes,
+    );
+    expect(
+      resolveSectionThreadDropDecision(lookup, "pinned-child", "pinned"),
+    ).toEqual({ kind: "pin", activeId: "pinned-child", detach: true });
+    expect(
+      resolveSectionThreadDropDecision(lookup, "pinned-child", "threads"),
+    ).toEqual({ kind: "detach", activeId: "pinned-child", sectionId: null });
+  });
+
+  it("unpins a pinned thread that nests under a section thread", () => {
+    const lookup = createNestedLookup([
+      createThread({ id: "pinned-1", pinnedAt: 10 }),
+      createThread({ id: "pinned-2", pinnedAt: 9 }),
+    ]);
+    expect(
+      resolveSectionThreadDropDecision(lookup, "pinned-1", rowId("parent-a")),
+    ).toEqual({
+      kind: "nest",
+      activeId: "pinned-1",
+      parentThreadId: "parent-a",
+      sectionId: "a",
+      unpin: true,
+    });
+    expect(
+      resolveSectionThreadDropDecision(lookup, "pinned-1", rowId("pinned-2")),
+    ).toEqual({
+      kind: "nest",
+      activeId: "pinned-1",
+      parentThreadId: "pinned-2",
+      sectionId: null,
+      unpin: true,
+    });
+    expect(resolvePinnedReorderPlacement(lookup, "pinned-1", "pinned-2")).toBe(
+      "after",
+    );
+    expect(resolvePinnedReorderPlacement(lookup, "pinned-2", "pinned-1")).toBe(
+      "before",
+    );
+    expect(resolvePinnedReorderPlacement(lookup, "loose", "pinned-1")).toBe(
+      null,
+    );
+    expect(
+      resolveSectionThreadDropDecision(lookup, "loose", rowId("pinned-2")),
+    ).toEqual({
+      kind: "nest",
+      activeId: "loose",
+      parentThreadId: "pinned-2",
+      sectionId: null,
+      unpin: false,
+    });
+  });
+});
+
+describe("thread row nest collisions", () => {
+  const rect = {
+    top: 100,
+    left: 0,
+    width: 200,
+    height: 28,
+    right: 200,
+    bottom: 128,
+  };
+  const rowCollision = { id: rowId("parent-a") };
+  const groupCollision = { id: "parent-a" };
+  const droppableRects = new Map([[rowId("parent-a"), rect]]);
+  const resolve = (y: number, band: number | null) =>
+    resolveThreadRowNestCollisions({
+      collisions: [rowCollision, groupCollision],
+      droppableRects,
+      pointerCoordinates: { x: 20, y },
+      getBandFraction: () => band,
+    });
+
+  it("keeps the row target only inside the center band", () => {
+    expect(resolve(114, NEST_BAND_FRACTION)).toEqual([
+      rowCollision,
+      groupCollision,
+    ]);
+    expect(resolve(103, NEST_BAND_FRACTION)).toEqual([groupCollision]);
+    expect(resolve(125, NEST_BAND_FRACTION)).toEqual([groupCollision]);
+  });
+
+  it("widens the band once the row is armed", () => {
+    expect(resolve(104, NEST_BAND_FRACTION)).toEqual([groupCollision]);
+    expect(resolve(104, NEST_BAND_ARMED_FRACTION)).toEqual([
+      rowCollision,
+      groupCollision,
+    ]);
+  });
+
+  it("drops the row target when it is not nestable or the pointer is outside", () => {
+    expect(resolve(114, null)).toEqual([groupCollision]);
+    expect(resolve(140, 1)).toEqual([groupCollision]);
+    expect(
+      resolveThreadRowNestCollisions({
+        collisions: [rowCollision, groupCollision],
+        droppableRects,
+        pointerCoordinates: null,
+        getBandFraction: () => 1,
+      }),
+    ).toEqual([groupCollision]);
   });
 });

--- a/apps/app/src/components/sidebar/useSectionThreadDnd.test.ts
+++ b/apps/app/src/components/sidebar/useSectionThreadDnd.test.ts
@@ -6,6 +6,7 @@ import {
   CHRONOLOGICAL_CONTAINER_ID,
 } from "@bb/client-core";
 import {
+  buildPinInsertRequest,
   collectSectionThreadDndLookup,
   NEST_BAND_ARMED_FRACTION,
   NEST_BAND_FRACTION,
@@ -482,6 +483,38 @@ describe("section thread nest drop decisions", () => {
   });
 });
 
+describe("pin insert requests", () => {
+  it("pins before or after the hovered pinned root", () => {
+    const lookup = createLookupWithPinnedThread();
+    expect(
+      buildPinInsertRequest(lookup, "loose", {
+        threadId: "pinned-2",
+        placement: "before",
+      }),
+    ).toEqual({
+      itemId: "loose",
+      previousItemId: "pinned-1",
+      nextItemId: "pinned-2",
+    });
+    expect(
+      buildPinInsertRequest(lookup, "loose", {
+        threadId: "pinned-2",
+        placement: "after",
+      }),
+    ).toEqual({
+      itemId: "loose",
+      previousItemId: "pinned-2",
+      nextItemId: null,
+    });
+    expect(
+      buildPinInsertRequest(lookup, "loose", {
+        threadId: "in-a",
+        placement: "after",
+      }),
+    ).toBeNull();
+  });
+});
+
 describe("thread row nest collisions", () => {
   const rect = {
     top: 100,
@@ -516,6 +549,20 @@ describe("thread row nest collisions", () => {
     expect(resolve(104, NEST_BAND_ARMED_FRACTION)).toEqual([
       rowCollision,
       groupCollision,
+    ]);
+  });
+
+  it("reports where the pointer sits on the row", () => {
+    const seen: unknown[] = [];
+    resolveThreadRowNestCollisions({
+      collisions: [rowCollision, groupCollision],
+      droppableRects,
+      pointerCoordinates: { x: 20, y: 103 },
+      getBandFraction: () => NEST_BAND_FRACTION,
+      onRowPointer: (info) => seen.push(info),
+    });
+    expect(seen).toEqual([
+      { threadId: "parent-a", relativeY: 3 / 28, nesting: false },
     ]);
   });
 

--- a/apps/app/src/components/sidebar/useSectionThreadDnd.test.ts
+++ b/apps/app/src/components/sidebar/useSectionThreadDnd.test.ts
@@ -13,9 +13,7 @@ import {
   PINNED_THREAD_PARENT_KEY,
   resolvePinnedReorderPlacement,
   resolveSectionThreadDropDecision,
-  resolveSectionThreadDropTarget,
   resolveSectionThreadSectionOverId,
-  resolveProjectedSectionThreadDropTarget,
   resolveThreadRowNestCollisions,
 } from "./useSectionThreadDnd";
 import { getSidebarThreadRowDroppableId } from "./sidebarThreadRowDroppable";
@@ -87,10 +85,11 @@ describe("section thread drop targets", () => {
 
     expect(sectionBKey).toBeDefined();
     expect(
-      resolveSectionThreadDropTarget(lookup, "loose", sectionBKey ?? null),
+      resolveSectionThreadDropDecision(lookup, "loose", sectionBKey ?? null),
     ).toEqual({
+      kind: "move",
       activeId: "loose",
-      fromParentKey: CHRONOLOGICAL_CONTAINER_ID,
+      sectionId: "b",
       toParentKey: sectionBKey,
     });
   });
@@ -100,23 +99,26 @@ describe("section thread drop targets", () => {
     const sectionBKey = lookup.sectionParentKeyBySectionId.get("section:b");
 
     expect(
-      resolveSectionThreadDropTarget(lookup, "loose", "section:b"),
+      resolveSectionThreadDropDecision(lookup, "loose", "section:b"),
     ).toEqual({
+      kind: "move",
       activeId: "loose",
-      fromParentKey: CHRONOLOGICAL_CONTAINER_ID,
+      sectionId: "b",
       toParentKey: sectionBKey,
     });
   });
 
   it("moves a section thread back to the loose Threads section", () => {
     const lookup = createLookup();
-    const sectionAKey = lookup.sectionParentKeyBySectionId.get("section:a");
 
-    expect(resolveSectionThreadDropTarget(lookup, "in-a", "threads")).toEqual({
-      activeId: "in-a",
-      fromParentKey: sectionAKey,
-      toParentKey: CHRONOLOGICAL_CONTAINER_ID,
-    });
+    expect(resolveSectionThreadDropDecision(lookup, "in-a", "threads")).toEqual(
+      {
+        kind: "move",
+        activeId: "in-a",
+        sectionId: null,
+        toParentKey: CHRONOLOGICAL_CONTAINER_ID,
+      },
+    );
   });
 
   it("preserves a projected destination through self-collision", () => {
@@ -125,14 +127,16 @@ describe("section thread drop targets", () => {
 
     expect(sectionBKey).toBeDefined();
     expect(
-      resolveProjectedSectionThreadDropTarget(
+      resolveSectionThreadDropDecision(
         lookup,
+        "loose",
         "loose",
         sectionBKey ?? null,
       ),
     ).toEqual({
+      kind: "move",
       activeId: "loose",
-      fromParentKey: CHRONOLOGICAL_CONTAINER_ID,
+      sectionId: "b",
       toParentKey: sectionBKey,
     });
   });
@@ -142,10 +146,10 @@ describe("section thread drop targets", () => {
     const sectionAKey = lookup.sectionParentKeyBySectionId.get("section:a");
 
     expect(
-      resolveSectionThreadDropTarget(lookup, "in-a", sectionAKey ?? null),
+      resolveSectionThreadDropDecision(lookup, "in-a", sectionAKey ?? null),
     ).toBeNull();
     expect(
-      resolveSectionThreadDropTarget(
+      resolveSectionThreadDropDecision(
         lookup,
         sectionAKey ?? "section:a",
         "threads",
@@ -221,6 +225,7 @@ describe("section thread pin drop decisions", () => {
       activeId: "pinned-1",
       sectionId: null,
       move: true,
+      toParentKey: CHRONOLOGICAL_CONTAINER_ID,
     });
   });
 
@@ -236,6 +241,10 @@ describe("section thread pin drop decisions", () => {
       activeId: "pinned-1",
       sectionId: "a",
       move: false,
+      toParentKey:
+        createLookupWithPinnedThread().sectionParentKeyBySectionId.get(
+          "section:a",
+        ),
     });
   });
 
@@ -396,13 +405,20 @@ describe("section thread nest drop decisions", () => {
     const sectionAKey = lookup.sectionParentKeyBySectionId.get("section:a");
     expect(
       resolveSectionThreadDropDecision(lookup, "child-a", sectionAKey ?? null),
-    ).toEqual({ kind: "detach", activeId: "child-a", sectionId: "a" });
+    ).toEqual({
+      kind: "detach",
+      activeId: "child-a",
+      sectionId: "a",
+      toParentKey: sectionAKey,
+    });
     expect(
       resolveSectionThreadDropDecision(lookup, "grandchild-a", "threads"),
-    ).toEqual({ kind: "detach", activeId: "grandchild-a", sectionId: null });
-    expect(
-      resolveSectionThreadDropTarget(lookup, "child-a", sectionAKey ?? null),
-    ).toMatchObject({ activeId: "child-a", toParentKey: sectionAKey });
+    ).toEqual({
+      kind: "detach",
+      activeId: "grandchild-a",
+      sectionId: null,
+      toParentKey: CHRONOLOGICAL_CONTAINER_ID,
+    });
   });
 
   it("detaches before pinning a nested thread", () => {
@@ -436,7 +452,12 @@ describe("section thread nest drop decisions", () => {
     ).toEqual({ kind: "pin", activeId: "pinned-child", detach: true });
     expect(
       resolveSectionThreadDropDecision(lookup, "pinned-child", "threads"),
-    ).toEqual({ kind: "detach", activeId: "pinned-child", sectionId: null });
+    ).toEqual({
+      kind: "detach",
+      activeId: "pinned-child",
+      sectionId: null,
+      toParentKey: CHRONOLOGICAL_CONTAINER_ID,
+    });
   });
 
   it("unpins a pinned thread that nests under a section thread", () => {

--- a/apps/app/src/components/sidebar/useSectionThreadDnd.ts
+++ b/apps/app/src/components/sidebar/useSectionThreadDnd.ts
@@ -12,6 +12,7 @@ import type {
   Collision,
   CollisionDetection,
   DragEndEvent,
+  DragMoveEvent,
   DragOverEvent,
   DragStartEvent,
   UniqueIdentifier,
@@ -52,6 +53,8 @@ import type { SidebarDropPreviewPlacement } from "./sidebarDropPreviewPlacement"
 export const PINNED_THREAD_PARENT_KEY = "sidebar:pinned-threads";
 export const NEST_BAND_FRACTION = 0.6;
 export const NEST_BAND_ARMED_FRACTION = 0.8;
+export const PINNED_NEST_BAND_FRACTION = 0.4;
+export const PINNED_NEST_BAND_ARMED_FRACTION = 0.5;
 
 export interface SectionThreadNestTarget {
   threadId: string;
@@ -137,11 +140,18 @@ export type SectionThreadDropDecision =
       reason: "own-subtree" | "already-child";
     };
 
+interface ThreadRowPointerInfo {
+  threadId: string;
+  relativeY: number;
+  nesting: boolean;
+}
+
 interface ResolveThreadRowNestCollisionsArgs {
   collisions: Collision[];
   droppableRects: ReadonlyMap<UniqueIdentifier, ClientRect>;
   pointerCoordinates: { x: number; y: number } | null;
   getBandFraction: (threadId: string) => number | null;
+  onRowPointer?: (info: ThreadRowPointerInfo) => void;
 }
 
 interface RowDropState {
@@ -267,6 +277,7 @@ export function resolveThreadRowNestCollisions({
   droppableRects,
   pointerCoordinates,
   getBandFraction,
+  onRowPointer,
 }: ResolveThreadRowNestCollisionsArgs): Collision[] {
   let rowCollision: Collision | null = null;
   let rowThreadId: string | null = null;
@@ -286,11 +297,8 @@ export function resolveThreadRowNestCollisions({
   if (rowCollision === null || rowThreadId === null || !pointerCoordinates) {
     return otherCollisions;
   }
-  const bandFraction = getBandFraction(rowThreadId);
   const rect = droppableRects.get(rowCollision.id);
-  if (bandFraction === null || !rect || rect.height <= 0) {
-    return otherCollisions;
-  }
+  if (!rect || rect.height <= 0) return otherCollisions;
   const { x, y } = pointerCoordinates;
   const withinRect =
     x >= rect.left &&
@@ -298,10 +306,34 @@ export function resolveThreadRowNestCollisions({
     y >= rect.top &&
     y <= rect.top + rect.height;
   if (!withinRect) return otherCollisions;
-  const offsetFromCenter = Math.abs((y - rect.top) / rect.height - 0.5);
-  return offsetFromCenter <= bandFraction / 2
-    ? [rowCollision, ...otherCollisions]
-    : otherCollisions;
+  const relativeY = (y - rect.top) / rect.height;
+  const bandFraction = getBandFraction(rowThreadId);
+  const nesting =
+    bandFraction !== null && Math.abs(relativeY - 0.5) <= bandFraction / 2;
+  onRowPointer?.({ threadId: rowThreadId, relativeY, nesting });
+  return nesting ? [rowCollision, ...otherCollisions] : otherCollisions;
+}
+
+export function buildPinInsertRequest(
+  lookup: SectionThreadDndLookup,
+  activeId: string,
+  target: SectionThreadReorderTarget,
+): NeighborReorderRequest | null {
+  const pinnedIds = lookup.itemIdsByParentKey.get(PINNED_THREAD_PARENT_KEY);
+  if (!pinnedIds) return null;
+  const index = pinnedIds.indexOf(target.threadId);
+  if (index === -1 || target.threadId === activeId) return null;
+  return target.placement === "before"
+    ? {
+        itemId: activeId,
+        previousItemId: pinnedIds[index - 1] ?? null,
+        nextItemId: target.threadId,
+      }
+    : {
+        itemId: activeId,
+        previousItemId: target.threadId,
+        nextItemId: pinnedIds[index + 1] ?? null,
+      };
 }
 
 function resolveSectionThreadDropParentKey(
@@ -592,17 +624,50 @@ export function useSectionThreadDnd({
   const activeIdRef = useRef<string | null>(null);
   const armedNestThreadIdRef = useRef<string | null>(null);
   const coarsePointerRef = useRef(false);
+  const pinnedInsertRef = useRef<SectionThreadReorderTarget | null>(null);
+  const isPinnedItem = useCallback(
+    (itemId: string) =>
+      lookup.parentKeyByItemId.get(itemId) === PINNED_THREAD_PARENT_KEY,
+    [lookup],
+  );
+  const isPinnedRoot = useCallback(
+    (itemId: string) =>
+      isPinnedItem(itemId) && !lookup.nestParentIdByItemId.has(itemId),
+    [isPinnedItem, lookup],
+  );
   const getNestBandFraction = useCallback(
     (threadId: string): number | null => {
       const activeId = activeIdRef.current;
       if (activeId === null || threadId === activeId) return null;
       if (lookup.itemKindById.get(threadId) !== "thread") return null;
+      const armed = armedNestThreadIdRef.current === threadId;
+      if (isPinnedItem(threadId)) {
+        return armed
+          ? PINNED_NEST_BAND_ARMED_FRACTION
+          : PINNED_NEST_BAND_FRACTION;
+      }
       if (coarsePointerRef.current) return 1;
-      return armedNestThreadIdRef.current === threadId
-        ? NEST_BAND_ARMED_FRACTION
-        : NEST_BAND_FRACTION;
+      return armed ? NEST_BAND_ARMED_FRACTION : NEST_BAND_FRACTION;
     },
-    [lookup],
+    [isPinnedItem, lookup],
+  );
+  const handleRowPointer = useCallback(
+    ({ threadId, relativeY, nesting }: ThreadRowPointerInfo) => {
+      const activeId = activeIdRef.current;
+      if (
+        activeId === null ||
+        nesting ||
+        isPinnedRoot(activeId) ||
+        !isPinnedRoot(threadId)
+      ) {
+        return;
+      }
+      pinnedInsertRef.current = {
+        threadId,
+        placement: relativeY < 0.5 ? "before" : "after",
+      };
+    },
+    [isPinnedRoot],
   );
   const collisionDetection = useCallback<CollisionDetection>(
     (args) => {
@@ -617,18 +682,20 @@ export function useSectionThreadDnd({
           ),
         });
       }
+      pinnedInsertRef.current = null;
       const collisions = resolveThreadRowNestCollisions({
         collisions: sidebarReorderCollisionDetection(args),
         droppableRects: args.droppableRects,
         pointerCoordinates: args.pointerCoordinates,
         getBandFraction: getNestBandFraction,
+        onRowPointer: handleRowPointer,
       });
       const nestedCollisions = collisions.filter(({ id }) =>
         typeof id === "string" ? !topLevelSectionIds.has(id) : true,
       );
       return nestedCollisions.length > 0 ? nestedCollisions : collisions;
     },
-    [getNestBandFraction, topLevelSectionIds],
+    [getNestBandFraction, handleRowPointer, topLevelSectionIds],
   );
   const updateThread = useUpdateThread();
   const pinThread = usePinThread();
@@ -698,6 +765,7 @@ export function useSectionThreadDnd({
     setReorderTarget(null);
     armedNestThreadIdRef.current = null;
     activeIdRef.current = null;
+    pinnedInsertRef.current = null;
   }, []);
   const clearProjectedDrag = useCallback(() => {
     clearDropSettle();
@@ -723,6 +791,7 @@ export function useSectionThreadDnd({
       draggingThreadRef.current = thread !== null;
       activeIdRef.current = thread ? activeId : null;
       armedNestThreadIdRef.current = null;
+      pinnedInsertRef.current = null;
       coarsePointerRef.current = isCoarseActivator(
         event.activatorEvent ?? null,
       );
@@ -803,7 +872,7 @@ export function useSectionThreadDnd({
       armedNestThreadIdRef.current = nextRowDrop?.threadId ?? null;
       setDragOverParentKey(targetParentKey);
       setRowDrop(nextRowDrop);
-      setReorderTarget(nextReorderTarget);
+      if (isPinnedRoot(activeId)) setReorderTarget(nextReorderTarget);
       if (nextRowDrop?.state === "valid") {
         const parentThreadId = nextRowDrop.threadId;
         dwellTimerRef.current = setTimeout(() => {
@@ -846,11 +915,29 @@ export function useSectionThreadDnd({
       containerId,
       dragOverParentKey,
       enabled,
+      isPinnedRoot,
       lookup,
       onExpandThread,
       projectedNestParentId,
       setCollapsedSections,
     ],
+  );
+
+  const handleDragMove = useCallback(
+    (event: DragMoveEvent) => {
+      if (!enabled || !draggingThreadRef.current) return;
+      const activeId =
+        typeof event.active.id === "string" ? event.active.id : null;
+      if (activeId === null || isPinnedRoot(activeId)) return;
+      const next = pinnedInsertRef.current;
+      setReorderTarget((current) =>
+        current?.threadId === next?.threadId &&
+        current?.placement === next?.placement
+          ? current
+          : next,
+      );
+    },
+    [enabled, isPinnedRoot],
   );
 
   const commitNest = useCallback(
@@ -928,16 +1015,28 @@ export function useSectionThreadDnd({
         case "nest":
           commitNest(decision);
           break;
-        case "pin":
+        case "pin": {
+          const insertRequest = reorderTarget
+            ? buildPinInsertRequest(lookup, decision.activeId, reorderTarget)
+            : null;
+          const pin = () =>
+            pinThread.mutateAsync({ id: decision.activeId }).then(() => {
+              if (insertRequest) {
+                onReorderPinnedThread(insertRequest, {
+                  onSettled: () => undefined,
+                });
+              }
+            });
           if (decision.detach) {
             updateThread
               .mutateAsync({ id: decision.activeId, parentThreadId: null })
-              .then(() => pinThread.mutate({ id: decision.activeId }))
+              .then(pin)
               .catch(() => undefined);
           } else {
-            pinThread.mutate({ id: decision.activeId });
+            pin().catch(() => undefined);
           }
           break;
+        }
         case "unpin":
           if (decision.move) {
             unpinAndMoveThread.mutate({
@@ -972,9 +1071,11 @@ export function useSectionThreadDnd({
       enabled,
       handlePinnedDragEnd,
       lookup,
+      onReorderPinnedThread,
       onTopLevelSectionOrderChange,
       pinThread,
       projectedNestParentId,
+      reorderTarget,
       stopProjectionInputTracking,
       topLevelSectionIds,
       topLevelSectionOrder,
@@ -996,6 +1097,7 @@ export function useSectionThreadDnd({
       collisionDetection,
       onDragEnd: handleDragEnd,
       onDragStart: handleDragStart,
+      onDragMove: handleDragMove,
       onDragOver: handleDragOver,
       onDragCancel: handleDragCancel,
     });

--- a/apps/app/src/components/sidebar/useSectionThreadDnd.ts
+++ b/apps/app/src/components/sidebar/useSectionThreadDnd.ts
@@ -8,10 +8,13 @@ import {
 } from "react";
 import { useSetAtom } from "jotai";
 import type {
+  ClientRect,
+  Collision,
   CollisionDetection,
   DragEndEvent,
   DragOverEvent,
   DragStartEvent,
+  UniqueIdentifier,
 } from "@dnd-kit/core";
 import type { ThreadListEntry } from "@bb/domain";
 import {
@@ -26,6 +29,7 @@ import {
   getSidebarDndItemId,
   reorderSidebarSectionOrder,
   type ProjectThreadItem,
+  type ProjectThreadNode,
 } from "@bb/client-core";
 import {
   sidebarCollapsedThreadSectionsAtom,
@@ -38,8 +42,26 @@ import {
 } from "./useSidebarReorderDnd";
 import type { ConsumeDragClickSuppression } from "@/components/ui/use-drag-click-suppression";
 import { useNeighborReorderSortable } from "./useNeighborReorderSortable";
+import {
+  parseSidebarThreadRowDroppableId,
+  type SidebarNestTargetState,
+  type SidebarReorderPlacement,
+} from "./sidebarThreadRowDroppable";
+import type { SidebarDropPreviewPlacement } from "./sidebarDropPreviewPlacement";
 
 export const PINNED_THREAD_PARENT_KEY = "sidebar:pinned-threads";
+export const NEST_BAND_FRACTION = 0.6;
+export const NEST_BAND_ARMED_FRACTION = 0.8;
+
+export interface SectionThreadNestTarget {
+  threadId: string;
+  state: SidebarNestTargetState;
+}
+
+export interface SectionThreadReorderTarget {
+  threadId: string;
+  placement: SidebarReorderPlacement;
+}
 
 export interface SectionThreadDndState {
   activeThread: ThreadListEntry | null;
@@ -48,7 +70,9 @@ export interface SectionThreadDndState {
   itemIdsByParentKey: ReadonlyMap<string, readonly string[]>;
   onClickCapture: MouseEventHandler<HTMLElement>;
   dragOverParentKey: string | null;
-  projectedSectionId: string | null | undefined;
+  dropPreview: SidebarDropPreviewPlacement | null;
+  nestTarget: SectionThreadNestTarget | null;
+  reorderTarget: SectionThreadReorderTarget | null;
   pinnedItemIds: readonly string[];
   pinnedReorderPending: boolean;
 }
@@ -59,8 +83,10 @@ interface UseSectionThreadDndArgs {
   rootItems: readonly ProjectThreadItem[];
   topLevelSectionOrder: readonly SidebarSectionId[];
   onTopLevelSectionOrderChange: (order: SidebarSectionId[]) => void;
+  onExpandThread?: (threadId: string) => void;
   pinnedReorderPending: boolean;
   pinnedThreads: readonly ThreadListEntry[];
+  pinnedRootNodes?: readonly ProjectThreadNode[];
   onReorderPinnedThread: (
     request: NeighborReorderRequest,
     callbacks: { onSettled: () => void },
@@ -71,10 +97,13 @@ interface SectionThreadDndLookup {
   sectionParentKeyBySectionId: Map<string, string>;
   sectionSectionIdByParentKey: Map<string, SidebarSectionId>;
   sectionIdByParentKey: Map<string, string | null>;
+  sectionNameByParentKey: Map<string, string>;
   itemIdsByParentKey: Map<string, string[]>;
   itemKindById: Map<string, ProjectThreadItem["kind"]>;
   parentKeyByItemId: Map<string, string>;
   threadByItemId: Map<string, ThreadListEntry>;
+  nodeByItemId: Map<string, ProjectThreadNode>;
+  nestParentIdByItemId: Map<string, string>;
 }
 
 interface SectionThreadDropTarget {
@@ -83,21 +112,49 @@ interface SectionThreadDropTarget {
   toParentKey: string;
 }
 
-type SectionThreadDropDecision =
+export type SectionThreadDropDecision =
   | { kind: "move"; activeId: string; sectionId: string | null }
-  | { kind: "pin"; activeId: string }
+  | { kind: "detach"; activeId: string; sectionId: string | null }
+  | { kind: "pin"; activeId: string; detach: boolean }
   | {
       kind: "unpin";
       activeId: string;
       sectionId: string | null;
       move: boolean;
     }
-  | { kind: "reorder-pinned"; activeId: string; overId: string };
+  | { kind: "reorder-pinned"; activeId: string; overId: string }
+  | {
+      kind: "nest";
+      activeId: string;
+      parentThreadId: string;
+      sectionId: string | null;
+      unpin: boolean;
+    }
+  | {
+      kind: "rejected";
+      activeId: string;
+      overThreadId: string;
+      reason: "own-subtree" | "already-child";
+    };
+
+interface ResolveThreadRowNestCollisionsArgs {
+  collisions: Collision[];
+  droppableRects: ReadonlyMap<UniqueIdentifier, ClientRect>;
+  pointerCoordinates: { x: number; y: number } | null;
+  getBandFraction: (threadId: string) => number | null;
+}
+
+interface RowDropState {
+  threadId: string;
+  sectionId: string | null;
+  state: SidebarNestTargetState;
+}
 
 export function collectSectionThreadDndLookup(
   items: readonly ProjectThreadItem[],
   containerId: string,
   pinnedThreads: readonly ThreadListEntry[] = [],
+  pinnedRootNodes: readonly ProjectThreadNode[] = [],
 ): SectionThreadDndLookup {
   const lookup: SectionThreadDndLookup = {
     sectionParentKeyBySectionId: new Map([
@@ -109,18 +166,44 @@ export function collectSectionThreadDndLookup(
       [PINNED_THREAD_PARENT_KEY, "pinned"],
     ]),
     sectionIdByParentKey: new Map([[containerId, null]]),
+    sectionNameByParentKey: new Map([
+      [containerId, "Threads"],
+      [PINNED_THREAD_PARENT_KEY, "Pinned"],
+    ]),
     itemIdsByParentKey: new Map([
       [PINNED_THREAD_PARENT_KEY, pinnedThreads.map((thread) => thread.id)],
     ]),
     itemKindById: new Map(),
     parentKeyByItemId: new Map(),
     threadByItemId: new Map(),
+    nodeByItemId: new Map(),
+    nestParentIdByItemId: new Map(),
+  };
+
+  const registerNestedChildren = (
+    node: ProjectThreadNode,
+    parentKey: string,
+  ) => {
+    for (const child of node.children) {
+      if (child.kind !== "thread") continue;
+      const childId = child.node.thread.id;
+      lookup.itemKindById.set(childId, "thread");
+      lookup.parentKeyByItemId.set(childId, parentKey);
+      lookup.threadByItemId.set(childId, child.node.thread);
+      lookup.nodeByItemId.set(childId, child.node);
+      lookup.nestParentIdByItemId.set(childId, node.thread.id);
+      registerNestedChildren(child.node, parentKey);
+    }
   };
 
   for (const thread of pinnedThreads) {
     lookup.itemKindById.set(thread.id, "thread");
     lookup.parentKeyByItemId.set(thread.id, PINNED_THREAD_PARENT_KEY);
     lookup.threadByItemId.set(thread.id, thread);
+  }
+  for (const node of pinnedRootNodes) {
+    lookup.nodeByItemId.set(node.thread.id, node);
+    registerNestedChildren(node, PINNED_THREAD_PARENT_KEY);
   }
 
   const walk = (
@@ -137,11 +220,14 @@ export function collectSectionThreadDndLookup(
       lookup.parentKeyByItemId.set(itemId, parentKey);
       if (item.kind === "thread") {
         lookup.threadByItemId.set(itemId, item.node.thread);
+        lookup.nodeByItemId.set(itemId, item.node);
+        registerNestedChildren(item.node, parentKey);
       } else if (item.kind === "section") {
         const sectionId = buildSidebarEntitySectionId("section", item.group.id);
         lookup.sectionParentKeyBySectionId.set(sectionId, item.group.key);
         lookup.sectionSectionIdByParentKey.set(item.group.key, sectionId);
         lookup.sectionIdByParentKey.set(item.group.key, item.group.id);
+        lookup.sectionNameByParentKey.set(item.group.key, item.group.name);
         walk(item.group.items, item.group.key);
       }
     }
@@ -149,6 +235,73 @@ export function collectSectionThreadDndLookup(
 
   walk(items, containerId);
   return lookup;
+}
+
+export function isThreadWithinSubtree(
+  lookup: SectionThreadDndLookup,
+  rootThreadId: string,
+  candidateThreadId: string,
+): boolean {
+  if (rootThreadId === candidateThreadId) return true;
+  const stack: ProjectThreadItem[] = [
+    ...(lookup.nodeByItemId.get(rootThreadId)?.children ?? []),
+  ];
+  while (stack.length > 0) {
+    const item = stack.pop();
+    if (!item) continue;
+    if (item.kind === "thread") {
+      if (item.node.thread.id === candidateThreadId) return true;
+      stack.push(...item.node.children);
+    } else if (item.kind === "environment") {
+      for (const node of item.group.nodes) {
+        if (node.thread.id === candidateThreadId) return true;
+        stack.push(...node.children);
+      }
+    }
+  }
+  return false;
+}
+
+export function resolveThreadRowNestCollisions({
+  collisions,
+  droppableRects,
+  pointerCoordinates,
+  getBandFraction,
+}: ResolveThreadRowNestCollisionsArgs): Collision[] {
+  let rowCollision: Collision | null = null;
+  let rowThreadId: string | null = null;
+  const otherCollisions: Collision[] = [];
+  for (const collision of collisions) {
+    const threadId =
+      typeof collision.id === "string"
+        ? parseSidebarThreadRowDroppableId(collision.id)
+        : null;
+    if (threadId === null) {
+      otherCollisions.push(collision);
+    } else if (rowCollision === null) {
+      rowCollision = collision;
+      rowThreadId = threadId;
+    }
+  }
+  if (rowCollision === null || rowThreadId === null || !pointerCoordinates) {
+    return otherCollisions;
+  }
+  const bandFraction = getBandFraction(rowThreadId);
+  const rect = droppableRects.get(rowCollision.id);
+  if (bandFraction === null || !rect || rect.height <= 0) {
+    return otherCollisions;
+  }
+  const { x, y } = pointerCoordinates;
+  const withinRect =
+    x >= rect.left &&
+    x <= rect.left + rect.width &&
+    y >= rect.top &&
+    y <= rect.top + rect.height;
+  if (!withinRect) return otherCollisions;
+  const offsetFromCenter = Math.abs((y - rect.top) / rect.height - 0.5);
+  return offsetFromCenter <= bandFraction / 2
+    ? [rowCollision, ...otherCollisions]
+    : otherCollisions;
 }
 
 function resolveSectionThreadDropParentKey(
@@ -178,8 +331,53 @@ export function resolveSectionThreadDropTarget(
   const fromParentKey = lookup.parentKeyByItemId.get(activeId);
   if (activeKind !== "thread" || !fromParentKey) return null;
   const toParentKey = resolveSectionThreadDropParentKey(lookup, overId);
-  if (!toParentKey || fromParentKey === toParentKey) return null;
+  if (!toParentKey) return null;
+  if (
+    fromParentKey === toParentKey &&
+    !lookup.nestParentIdByItemId.has(activeId)
+  ) {
+    return null;
+  }
   return { activeId, fromParentKey, toParentKey };
+}
+
+function resolveNestDecision(
+  lookup: SectionThreadDndLookup,
+  activeId: string,
+  parentThreadId: string,
+): SectionThreadDropDecision | null {
+  const parentThread = lookup.threadByItemId.get(parentThreadId);
+  const fromParentKey = lookup.parentKeyByItemId.get(activeId);
+  const parentKey = lookup.parentKeyByItemId.get(parentThreadId);
+  if (!parentThread || !fromParentKey || !parentKey) return null;
+  const fromPinned = fromParentKey === PINNED_THREAD_PARENT_KEY;
+  const parentPinned = parentKey === PINNED_THREAD_PARENT_KEY;
+  if (isThreadWithinSubtree(lookup, activeId, parentThreadId)) {
+    return {
+      kind: "rejected",
+      activeId,
+      overThreadId: parentThreadId,
+      reason: "own-subtree",
+    };
+  }
+  if (lookup.nestParentIdByItemId.get(activeId) === parentThreadId) {
+    return {
+      kind: "rejected",
+      activeId,
+      overThreadId: parentThreadId,
+      reason: "already-child",
+    };
+  }
+  const sectionId = parentPinned
+    ? (parentThread.sectionId ?? null)
+    : (lookup.sectionIdByParentKey.get(parentKey) ?? null);
+  return {
+    kind: "nest",
+    activeId,
+    parentThreadId,
+    sectionId,
+    unpin: fromPinned,
+  };
 }
 
 export function resolveSectionThreadDropDecision(
@@ -187,26 +385,38 @@ export function resolveSectionThreadDropDecision(
   activeId: string,
   overId: string | null,
   projectedParentKey: string | null = null,
+  projectedNestParentId: string | null = null,
 ): SectionThreadDropDecision | null {
   const activeThread = lookup.threadByItemId.get(activeId);
   const fromParentKey = lookup.parentKeyByItemId.get(activeId);
   if (!activeThread || !fromParentKey) return null;
 
-  const directParentKey =
-    overId === activeId
-      ? null
-      : resolveSectionThreadDropParentKey(lookup, overId);
+  const overRowThreadId =
+    overId === null ? null : parseSidebarThreadRowDroppableId(overId);
+  if (overRowThreadId !== null && overRowThreadId !== activeId) {
+    return resolveNestDecision(lookup, activeId, overRowThreadId);
+  }
+  const isSelfCollision = overId === activeId || overRowThreadId === activeId;
+  if (isSelfCollision && projectedNestParentId !== null) {
+    return resolveNestDecision(lookup, activeId, projectedNestParentId);
+  }
+
+  const directParentKey = isSelfCollision
+    ? null
+    : resolveSectionThreadDropParentKey(lookup, overId);
   const toParentKey =
     directParentKey ??
-    (overId === activeId && projectedParentKey !== null
+    (isSelfCollision && projectedParentKey !== null
       ? projectedParentKey
       : null);
   if (!toParentKey) return null;
 
   const fromPinned = fromParentKey === PINNED_THREAD_PARENT_KEY;
   const toPinned = toParentKey === PINNED_THREAD_PARENT_KEY;
+  const nested = lookup.nestParentIdByItemId.has(activeId);
   if (toPinned) {
-    if (!fromPinned) return { kind: "pin", activeId };
+    if (nested) return { kind: "pin", activeId, detach: true };
+    if (!fromPinned) return { kind: "pin", activeId, detach: false };
     if (
       overId !== null &&
       overId !== activeId &&
@@ -219,6 +429,7 @@ export function resolveSectionThreadDropDecision(
 
   if (!lookup.sectionIdByParentKey.has(toParentKey)) return null;
   const sectionId = lookup.sectionIdByParentKey.get(toParentKey) ?? null;
+  if (nested) return { kind: "detach", activeId, sectionId };
   if (fromPinned) {
     return {
       kind: "unpin",
@@ -229,6 +440,21 @@ export function resolveSectionThreadDropDecision(
   }
   if (fromParentKey === toParentKey) return null;
   return { kind: "move", activeId, sectionId };
+}
+
+export function resolvePinnedReorderPlacement(
+  lookup: SectionThreadDndLookup,
+  activeId: string,
+  overId: string,
+): SidebarReorderPlacement | null {
+  const pinnedIds = lookup.itemIdsByParentKey.get(PINNED_THREAD_PARENT_KEY);
+  if (!pinnedIds) return null;
+  const activeIndex = pinnedIds.indexOf(activeId);
+  const overIndex = pinnedIds.indexOf(overId);
+  if (activeIndex === -1 || overIndex === -1 || activeIndex === overIndex) {
+    return null;
+  }
+  return activeIndex < overIndex ? "after" : "before";
 }
 
 export function resolveSectionThreadSectionOverId(
@@ -255,7 +481,8 @@ export function resolveProjectedSectionThreadDropTarget(
   if (
     lookup.itemKindById.get(activeId) !== "thread" ||
     !fromParentKey ||
-    fromParentKey === projectedParentKey ||
+    (fromParentKey === projectedParentKey &&
+      !lookup.nestParentIdByItemId.has(activeId)) ||
     !lookup.sectionIdByParentKey.has(projectedParentKey)
   ) {
     return null;
@@ -305,6 +532,34 @@ function getEventIds(event: DragOverEvent | DragEndEvent) {
   };
 }
 
+function resolveRowDropState(
+  decision: SectionThreadDropDecision | null,
+): RowDropState | null {
+  if (decision?.kind === "nest") {
+    return {
+      threadId: decision.parentThreadId,
+      sectionId: decision.sectionId,
+      state: "valid",
+    };
+  }
+  if (decision?.kind === "rejected") {
+    return {
+      threadId: decision.overThreadId,
+      sectionId: null,
+      state: decision.reason === "own-subtree" ? "blocked" : "unchanged",
+    };
+  }
+  return null;
+}
+
+function getRowDropTargetKey(rowDrop: RowDropState): string {
+  return `row:${rowDrop.threadId}:${rowDrop.state}`;
+}
+
+function isCoarseActivator(activatorEvent: Event | null): boolean {
+  return activatorEvent !== null && "touches" in activatorEvent;
+}
+
 const SECTION_AUTO_EXPAND_MS = 200;
 const DROP_SETTLE_MS = 220;
 
@@ -314,17 +569,40 @@ export function useSectionThreadDnd({
   rootItems,
   topLevelSectionOrder,
   onTopLevelSectionOrderChange,
+  onExpandThread,
   pinnedReorderPending,
   pinnedThreads,
+  pinnedRootNodes,
   onReorderPinnedThread,
 }: UseSectionThreadDndArgs): SectionThreadDndState | null {
   const lookup = useMemo(
-    () => collectSectionThreadDndLookup(rootItems, containerId, pinnedThreads),
-    [containerId, pinnedThreads, rootItems],
+    () =>
+      collectSectionThreadDndLookup(
+        rootItems,
+        containerId,
+        pinnedThreads,
+        pinnedRootNodes,
+      ),
+    [containerId, pinnedRootNodes, pinnedThreads, rootItems],
   );
   const topLevelSectionIds = useMemo(
     () => new Set<string>(topLevelSectionOrder),
     [topLevelSectionOrder],
+  );
+  const activeIdRef = useRef<string | null>(null);
+  const armedNestThreadIdRef = useRef<string | null>(null);
+  const coarsePointerRef = useRef(false);
+  const getNestBandFraction = useCallback(
+    (threadId: string): number | null => {
+      const activeId = activeIdRef.current;
+      if (activeId === null || threadId === activeId) return null;
+      if (lookup.itemKindById.get(threadId) !== "thread") return null;
+      if (coarsePointerRef.current) return 1;
+      return armedNestThreadIdRef.current === threadId
+        ? NEST_BAND_ARMED_FRACTION
+        : NEST_BAND_FRACTION;
+    },
+    [lookup],
   );
   const collisionDetection = useCallback<CollisionDetection>(
     (args) => {
@@ -339,13 +617,18 @@ export function useSectionThreadDnd({
           ),
         });
       }
-      const collisions = sidebarReorderCollisionDetection(args);
+      const collisions = resolveThreadRowNestCollisions({
+        collisions: sidebarReorderCollisionDetection(args),
+        droppableRects: args.droppableRects,
+        pointerCoordinates: args.pointerCoordinates,
+        getBandFraction: getNestBandFraction,
+      });
       const nestedCollisions = collisions.filter(({ id }) =>
         typeof id === "string" ? !topLevelSectionIds.has(id) : true,
       );
       return nestedCollisions.length > 0 ? nestedCollisions : collisions;
     },
-    [topLevelSectionIds],
+    [getNestBandFraction, topLevelSectionIds],
   );
   const updateThread = useUpdateThread();
   const pinThread = usePinThread();
@@ -365,10 +648,13 @@ export function useSectionThreadDnd({
   const [dragOverParentKey, setDragOverParentKey] = useState<string | null>(
     null,
   );
+  const [rowDrop, setRowDrop] = useState<RowDropState | null>(null);
+  const [reorderTarget, setReorderTarget] =
+    useState<SectionThreadReorderTarget | null>(null);
   const draggingThreadRef = useRef(false);
   const dwellTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const dropSettleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const dwellParentKeyRef = useRef<string | null>(null);
+  const dwellTargetKeyRef = useRef<string | null>(null);
   const projectionGateRef = useRef(new SectionThreadProjectionGate());
   const stopProjectionInputTrackingRef = useRef<(() => void) | null>(null);
 
@@ -397,7 +683,7 @@ export function useSectionThreadDnd({
   const clearDropDwell = useCallback(() => {
     if (dwellTimerRef.current !== null) clearTimeout(dwellTimerRef.current);
     dwellTimerRef.current = null;
-    dwellParentKeyRef.current = null;
+    dwellTargetKeyRef.current = null;
   }, []);
   const clearDropSettle = useCallback(() => {
     if (dropSettleTimerRef.current !== null) {
@@ -405,11 +691,18 @@ export function useSectionThreadDnd({
     }
     dropSettleTimerRef.current = null;
   }, []);
-  const clearProjectedDrag = useCallback(() => {
-    clearDropSettle();
+  const clearDropState = useCallback(() => {
     setActiveThread(null);
     setDragOverParentKey(null);
-  }, [clearDropSettle]);
+    setRowDrop(null);
+    setReorderTarget(null);
+    armedNestThreadIdRef.current = null;
+    activeIdRef.current = null;
+  }, []);
+  const clearProjectedDrag = useCallback(() => {
+    clearDropSettle();
+    clearDropState();
+  }, [clearDropSettle, clearDropState]);
 
   useEffect(
     () => () => {
@@ -428,20 +721,38 @@ export function useSectionThreadDnd({
         ? (lookup.threadByItemId.get(activeId) ?? null)
         : null;
       draggingThreadRef.current = thread !== null;
+      activeIdRef.current = thread ? activeId : null;
+      armedNestThreadIdRef.current = null;
+      coarsePointerRef.current = isCoarseActivator(
+        event.activatorEvent ?? null,
+      );
       clearDropSettle();
       clearDropDwell();
       startProjectionInputTracking();
       setActiveThread(thread);
       setDragOverParentKey(null);
+      setRowDrop(null);
+      setReorderTarget(null);
     },
     [clearDropDwell, clearDropSettle, lookup, startProjectionInputTracking],
   );
+
+  const projectedNestParentId =
+    rowDrop?.state === "valid" ? rowDrop.threadId : null;
 
   const handleDragOver = useCallback(
     (event: DragOverEvent) => {
       if (!enabled || !draggingThreadRef.current) return;
       const { activeId, overId } = getEventIds(event);
       if (activeId === null) return;
+      const decision = resolveSectionThreadDropDecision(
+        lookup,
+        activeId,
+        overId,
+        dragOverParentKey,
+        projectedNestParentId,
+      );
+      const nextRowDrop = resolveRowDropState(decision);
       const directDrop = resolveSectionThreadDropTarget(
         lookup,
         activeId,
@@ -456,30 +767,57 @@ export function useSectionThreadDnd({
               dragOverParentKey,
             )
           : null);
-      const decision = resolveSectionThreadDropDecision(
-        lookup,
-        activeId,
-        overId,
-        dragOverParentKey,
-      );
       const targetParentKey =
-        decision?.kind === "reorder-pinned"
+        nextRowDrop !== null || decision?.kind === "reorder-pinned"
           ? null
           : (drop?.toParentKey ??
             (decision?.kind === "pin" ? PINNED_THREAD_PARENT_KEY : null));
-      if (targetParentKey === dwellParentKeyRef.current) return;
+      const nextReorderTarget =
+        decision?.kind === "reorder-pinned"
+          ? (() => {
+              const placement = resolvePinnedReorderPlacement(
+                lookup,
+                activeId,
+                decision.overId,
+              );
+              return placement
+                ? { threadId: decision.overId, placement }
+                : null;
+            })()
+          : null;
+      const targetKey =
+        nextRowDrop !== null
+          ? getRowDropTargetKey(nextRowDrop)
+          : nextReorderTarget !== null
+            ? `reorder:${nextReorderTarget.threadId}:${nextReorderTarget.placement}`
+            : targetParentKey;
+      if (targetKey === dwellTargetKeyRef.current) return;
       if (
-        !projectionGateRef.current.allow(
-          dwellParentKeyRef.current,
-          targetParentKey,
-        )
+        !projectionGateRef.current.allow(dwellTargetKeyRef.current, targetKey)
       ) {
         return;
       }
 
       clearDropDwell();
-      dwellParentKeyRef.current = targetParentKey;
+      dwellTargetKeyRef.current = targetKey;
+      armedNestThreadIdRef.current = nextRowDrop?.threadId ?? null;
       setDragOverParentKey(targetParentKey);
+      setRowDrop(nextRowDrop);
+      setReorderTarget(nextReorderTarget);
+      if (nextRowDrop?.state === "valid") {
+        const parentThreadId = nextRowDrop.threadId;
+        dwellTimerRef.current = setTimeout(() => {
+          dwellTimerRef.current = null;
+          if (
+            !draggingThreadRef.current ||
+            dwellTargetKeyRef.current !== targetKey
+          ) {
+            return;
+          }
+          onExpandThread?.(parentThreadId);
+        }, SECTION_AUTO_EXPAND_MS);
+        return;
+      }
       if (
         targetParentKey === null ||
         targetParentKey === containerId ||
@@ -492,7 +830,7 @@ export function useSectionThreadDnd({
         dwellTimerRef.current = null;
         if (
           !draggingThreadRef.current ||
-          dwellParentKeyRef.current !== targetParentKey
+          dwellTargetKeyRef.current !== targetKey
         ) {
           return;
         }
@@ -509,8 +847,30 @@ export function useSectionThreadDnd({
       dragOverParentKey,
       enabled,
       lookup,
+      onExpandThread,
+      projectedNestParentId,
       setCollapsedSections,
     ],
+  );
+
+  const commitNest = useCallback(
+    (decision: Extract<SectionThreadDropDecision, { kind: "nest" }>) => {
+      const applyNest = () =>
+        updateThread.mutate({
+          id: decision.activeId,
+          parentThreadId: decision.parentThreadId,
+          sectionId: decision.sectionId,
+        });
+      if (decision.unpin) {
+        unpinThread
+          .mutateAsync({ id: decision.activeId })
+          .then(applyNest)
+          .catch(() => undefined);
+      } else {
+        applyNest();
+      }
+    },
+    [unpinThread, updateThread],
   );
 
   const handleDragEnd = useCallback(
@@ -545,6 +905,7 @@ export function useSectionThreadDnd({
         activeId,
         overId,
         dragOverParentKey,
+        projectedNestParentId,
       );
       if (!decision) {
         clearProjectedDrag();
@@ -557,8 +918,25 @@ export function useSectionThreadDnd({
             sectionId: decision.sectionId,
           });
           break;
+        case "detach":
+          updateThread.mutate({
+            id: decision.activeId,
+            parentThreadId: null,
+            sectionId: decision.sectionId,
+          });
+          break;
+        case "nest":
+          commitNest(decision);
+          break;
         case "pin":
-          pinThread.mutate({ id: decision.activeId });
+          if (decision.detach) {
+            updateThread
+              .mutateAsync({ id: decision.activeId, parentThreadId: null })
+              .then(() => pinThread.mutate({ id: decision.activeId }))
+              .catch(() => undefined);
+          } else {
+            pinThread.mutate({ id: decision.activeId });
+          }
           break;
         case "unpin":
           if (decision.move) {
@@ -574,24 +952,29 @@ export function useSectionThreadDnd({
           handlePinnedDragEnd(event);
           clearProjectedDrag();
           return;
+        case "rejected":
+          clearProjectedDrag();
+          return;
       }
       clearDropSettle();
       dropSettleTimerRef.current = setTimeout(() => {
         dropSettleTimerRef.current = null;
-        setActiveThread(null);
-        setDragOverParentKey(null);
+        clearDropState();
       }, DROP_SETTLE_MS);
     },
     [
       clearDropDwell,
       clearDropSettle,
+      clearDropState,
       clearProjectedDrag,
+      commitNest,
       dragOverParentKey,
       enabled,
       handlePinnedDragEnd,
       lookup,
       onTopLevelSectionOrderChange,
       pinThread,
+      projectedNestParentId,
       stopProjectionInputTracking,
       topLevelSectionIds,
       topLevelSectionOrder,
@@ -625,10 +1008,11 @@ export function useSectionThreadDnd({
     itemIdsByParentKey: lookup.itemIdsByParentKey,
     onClickCapture,
     dragOverParentKey,
-    projectedSectionId:
-      activeThread && dragOverParentKey !== null
-        ? lookup.sectionIdByParentKey.get(dragOverParentKey)
-        : undefined,
+    dropPreview: null,
+    nestTarget: rowDrop
+      ? { threadId: rowDrop.threadId, state: rowDrop.state }
+      : null,
+    reorderTarget,
     pinnedItemIds,
     pinnedReorderPending,
   };

--- a/apps/app/src/components/sidebar/useSectionThreadDnd.ts
+++ b/apps/app/src/components/sidebar/useSectionThreadDnd.ts
@@ -596,7 +596,7 @@ export function useSectionThreadDnd({
     null,
   );
   const lingerTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const [lingerTick, setLingerTick] = useState(0);
+  const [, setLingerTick] = useState(0);
   const clearPinnedLinger = useCallback(() => {
     if (lingerTimerRef.current !== null) clearTimeout(lingerTimerRef.current);
     lingerTimerRef.current = null;
@@ -664,7 +664,7 @@ export function useSectionThreadDnd({
       );
       return nestedCollisions.length > 0 ? nestedCollisions : collisions;
     },
-    [getNestBandFraction, lingerTick, topLevelSectionIds],
+    [getNestBandFraction, topLevelSectionIds],
   );
   const updateThread = useUpdateThread();
   const pinThread = usePinThread();

--- a/apps/app/src/components/sidebar/useSectionThreadDnd.ts
+++ b/apps/app/src/components/sidebar/useSectionThreadDnd.ts
@@ -109,21 +109,26 @@ interface SectionThreadDndLookup {
   nestParentIdByItemId: Map<string, string>;
 }
 
-interface SectionThreadDropTarget {
-  activeId: string;
-  fromParentKey: string;
-  toParentKey: string;
-}
-
 export type SectionThreadDropDecision =
-  | { kind: "move"; activeId: string; sectionId: string | null }
-  | { kind: "detach"; activeId: string; sectionId?: string | null }
+  | {
+      kind: "move";
+      activeId: string;
+      sectionId: string | null;
+      toParentKey: string;
+    }
+  | {
+      kind: "detach";
+      activeId: string;
+      sectionId?: string | null;
+      toParentKey: string;
+    }
   | { kind: "pin"; activeId: string; detach: boolean }
   | {
       kind: "unpin";
       activeId: string;
       sectionId: string | null;
       move: boolean;
+      toParentKey: string;
     }
   | { kind: "reorder-pinned"; activeId: string; overId: string }
   | {
@@ -363,26 +368,6 @@ function resolveSectionThreadDropParentKey(
   return parentKey ?? null;
 }
 
-export function resolveSectionThreadDropTarget(
-  lookup: SectionThreadDndLookup,
-  activeId: string,
-  overId: string | null,
-): SectionThreadDropTarget | null {
-  if (overId === null || activeId === overId) return null;
-  const activeKind = lookup.itemKindById.get(activeId);
-  const fromParentKey = lookup.parentKeyByItemId.get(activeId);
-  if (activeKind !== "thread" || !fromParentKey) return null;
-  const toParentKey = resolveSectionThreadDropParentKey(lookup, overId);
-  if (!toParentKey) return null;
-  if (
-    fromParentKey === toParentKey &&
-    !lookup.nestParentIdByItemId.has(activeId)
-  ) {
-    return null;
-  }
-  return { activeId, fromParentKey, toParentKey };
-}
-
 interface ResolveSectionThreadDropDecisionOptions {
   groups?: boolean;
 }
@@ -485,24 +470,31 @@ export function resolveSectionThreadDropDecision(
 
   if (!lookup.sectionIdByParentKey.has(toParentKey)) return null;
   if (options.groups) {
-    if (nested) return { kind: "detach", activeId };
+    if (nested) return { kind: "detach", activeId, toParentKey };
     if (fromPinned) {
-      return { kind: "unpin", activeId, sectionId: null, move: false };
+      return {
+        kind: "unpin",
+        activeId,
+        sectionId: null,
+        move: false,
+        toParentKey,
+      };
     }
     return null;
   }
   const sectionId = lookup.sectionIdByParentKey.get(toParentKey) ?? null;
-  if (nested) return { kind: "detach", activeId, sectionId };
+  if (nested) return { kind: "detach", activeId, sectionId, toParentKey };
   if (fromPinned) {
     return {
       kind: "unpin",
       activeId,
       sectionId,
       move: activeThread.sectionId !== sectionId,
+      toParentKey,
     };
   }
   if (fromParentKey === toParentKey) return null;
-  return { kind: "move", activeId, sectionId };
+  return { kind: "move", activeId, sectionId, toParentKey };
 }
 
 export function resolvePinnedReorderPlacement(
@@ -532,25 +524,6 @@ export function resolveSectionThreadSectionOverId(
       : undefined) ??
     overId
   );
-}
-
-export function resolveProjectedSectionThreadDropTarget(
-  lookup: SectionThreadDndLookup,
-  activeId: string,
-  projectedParentKey: string | null,
-): SectionThreadDropTarget | null {
-  if (projectedParentKey === null) return null;
-  const fromParentKey = lookup.parentKeyByItemId.get(activeId);
-  if (
-    lookup.itemKindById.get(activeId) !== "thread" ||
-    !fromParentKey ||
-    (fromParentKey === projectedParentKey &&
-      !lookup.nestParentIdByItemId.has(activeId)) ||
-    !lookup.sectionIdByParentKey.has(projectedParentKey)
-  ) {
-    return null;
-  }
-  return { activeId, fromParentKey, toParentKey: projectedParentKey };
 }
 
 export class SectionThreadProjectionGate {
@@ -622,6 +595,53 @@ function resolvePinnedReorderTarget(
     decision.overId,
   );
   return placement ? { threadId: decision.overId, placement } : null;
+}
+
+function resolveTargetParentKey(
+  decision: SectionThreadDropDecision | null,
+): string | null {
+  switch (decision?.kind) {
+    case "pin":
+      return PINNED_THREAD_PARENT_KEY;
+    case "move":
+    case "detach":
+    case "unpin":
+      return decision.toParentKey;
+    default:
+      return null;
+  }
+}
+
+function resolveDwellExpansion({
+  containerId,
+  onExpandThread,
+  rowDrop,
+  setCollapsedSections,
+  targetParentKey,
+}: {
+  containerId: string;
+  onExpandThread: ((threadId: string) => void) | undefined;
+  rowDrop: RowDropState | null;
+  setCollapsedSections: (update: (current: string[]) => string[]) => void;
+  targetParentKey: string | null;
+}): (() => void) | null {
+  if (rowDrop?.state === "valid") {
+    const parentThreadId = rowDrop.threadId;
+    return onExpandThread ? () => onExpandThread(parentThreadId) : null;
+  }
+  if (
+    targetParentKey === null ||
+    targetParentKey === containerId ||
+    targetParentKey === PINNED_THREAD_PARENT_KEY
+  ) {
+    return null;
+  }
+  return () =>
+    setCollapsedSections((current) =>
+      current.includes(targetParentKey)
+        ? current.filter((key) => key !== targetParentKey)
+        : current,
+    );
 }
 
 function getRowDropTargetKey(rowDrop: RowDropState): string {
@@ -866,28 +886,7 @@ export function useSectionThreadDnd({
         decisionOptions,
       );
       const nextRowDrop = resolveRowDropState(decision);
-      const directDrop = resolveSectionThreadDropTarget(
-        lookup,
-        activeId,
-        overId,
-      );
-      const drop =
-        directDrop ??
-        (overId === activeId && dragOverParentKey !== null
-          ? resolveProjectedSectionThreadDropTarget(
-              lookup,
-              activeId,
-              dragOverParentKey,
-            )
-          : null);
-      const targetParentKey =
-        decision === null ||
-        nextRowDrop !== null ||
-        decision.kind === "reorder-pinned"
-          ? null
-          : decision.kind === "pin"
-            ? PINNED_THREAD_PARENT_KEY
-            : (drop?.toParentKey ?? null);
+      const targetParentKey = resolveTargetParentKey(decision);
       const nextReorderTarget = resolvePinnedReorderTarget(
         lookup,
         activeId,
@@ -912,41 +911,22 @@ export function useSectionThreadDnd({
       setDragOverParentKey(targetParentKey);
       setRowDrop(nextRowDrop);
       if (isPinnedRoot(activeId)) setReorderTarget(nextReorderTarget);
-      if (nextRowDrop?.state === "valid") {
-        const parentThreadId = nextRowDrop.threadId;
-        dwellTimerRef.current = setTimeout(() => {
-          dwellTimerRef.current = null;
-          if (
-            !draggingThreadRef.current ||
-            dwellTargetKeyRef.current !== targetKey
-          ) {
-            return;
-          }
-          onExpandThread?.(parentThreadId);
-        }, SECTION_AUTO_EXPAND_MS);
-        return;
-      }
-      if (
-        targetParentKey === null ||
-        targetParentKey === containerId ||
-        targetParentKey === PINNED_THREAD_PARENT_KEY
-      ) {
-        return;
-      }
-
+      const expand = resolveDwellExpansion({
+        containerId,
+        onExpandThread,
+        rowDrop: nextRowDrop,
+        setCollapsedSections,
+        targetParentKey,
+      });
+      if (!expand) return;
       dwellTimerRef.current = setTimeout(() => {
         dwellTimerRef.current = null;
         if (
-          !draggingThreadRef.current ||
-          dwellTargetKeyRef.current !== targetKey
+          draggingThreadRef.current &&
+          dwellTargetKeyRef.current === targetKey
         ) {
-          return;
+          expand();
         }
-        setCollapsedSections((current) =>
-          current.includes(targetParentKey)
-            ? current.filter((key) => key !== targetParentKey)
-            : current,
-        );
       }, SECTION_AUTO_EXPAND_MS);
     },
     [

--- a/apps/app/src/components/sidebar/useSectionThreadDnd.ts
+++ b/apps/app/src/components/sidebar/useSectionThreadDnd.ts
@@ -87,6 +87,7 @@ interface UseSectionThreadDndArgs {
   topLevelSectionOrder: readonly SidebarSectionId[];
   onTopLevelSectionOrderChange: (order: SidebarSectionId[]) => void;
   onExpandThread?: (threadId: string) => void;
+  groups?: boolean;
   pinnedReorderPending: boolean;
   pinnedThreads: readonly ThreadListEntry[];
   pinnedRootNodes?: readonly ProjectThreadNode[];
@@ -117,7 +118,7 @@ interface SectionThreadDropTarget {
 
 export type SectionThreadDropDecision =
   | { kind: "move"; activeId: string; sectionId: string | null }
-  | { kind: "detach"; activeId: string; sectionId: string | null }
+  | { kind: "detach"; activeId: string; sectionId?: string | null }
   | { kind: "pin"; activeId: string; detach: boolean }
   | {
       kind: "unpin";
@@ -130,7 +131,7 @@ export type SectionThreadDropDecision =
       kind: "nest";
       activeId: string;
       parentThreadId: string;
-      sectionId: string | null;
+      sectionId?: string | null;
       unpin: boolean;
     }
   | {
@@ -160,11 +161,28 @@ interface RowDropState {
   state: SidebarNestTargetState;
 }
 
+interface CollectSectionThreadDndLookupOptions {
+  groups?: boolean;
+}
+
+function parseGroupSectionId(key: string): SidebarSectionId {
+  if (key === "pinned" || key === "threads") return key;
+  if (
+    key.startsWith("project:") ||
+    key.startsWith("section:") ||
+    key.startsWith("machine:")
+  ) {
+    return key as SidebarSectionId;
+  }
+  return buildSidebarEntitySectionId("section", key);
+}
+
 export function collectSectionThreadDndLookup(
   items: readonly ProjectThreadItem[],
   containerId: string,
   pinnedThreads: readonly ThreadListEntry[] = [],
   pinnedRootNodes: readonly ProjectThreadNode[] = [],
+  options: CollectSectionThreadDndLookupOptions = {},
 ): SectionThreadDndLookup {
   const lookup: SectionThreadDndLookup = {
     sectionParentKeyBySectionId: new Map([
@@ -233,7 +251,9 @@ export function collectSectionThreadDndLookup(
         lookup.nodeByItemId.set(itemId, item.node);
         registerNestedChildren(item.node, parentKey);
       } else if (item.kind === "section") {
-        const sectionId = buildSidebarEntitySectionId("section", item.group.id);
+        const sectionId = options.groups
+          ? parseGroupSectionId(item.group.key)
+          : buildSidebarEntitySectionId("section", item.group.id);
         lookup.sectionParentKeyBySectionId.set(sectionId, item.group.key);
         lookup.sectionSectionIdByParentKey.set(item.group.key, sectionId);
         lookup.sectionIdByParentKey.set(item.group.key, item.group.id);
@@ -373,10 +393,15 @@ export function resolveSectionThreadDropTarget(
   return { activeId, fromParentKey, toParentKey };
 }
 
+interface ResolveSectionThreadDropDecisionOptions {
+  groups?: boolean;
+}
+
 function resolveNestDecision(
   lookup: SectionThreadDndLookup,
   activeId: string,
   parentThreadId: string,
+  options: ResolveSectionThreadDropDecisionOptions,
 ): SectionThreadDropDecision | null {
   const parentThread = lookup.threadByItemId.get(parentThreadId);
   const fromParentKey = lookup.parentKeyByItemId.get(activeId);
@@ -400,6 +425,9 @@ function resolveNestDecision(
       reason: "already-child",
     };
   }
+  if (options.groups) {
+    return { kind: "nest", activeId, parentThreadId, unpin: fromPinned };
+  }
   const sectionId = parentPinned
     ? (parentThread.sectionId ?? null)
     : (lookup.sectionIdByParentKey.get(parentKey) ?? null);
@@ -418,6 +446,7 @@ export function resolveSectionThreadDropDecision(
   overId: string | null,
   projectedParentKey: string | null = null,
   projectedNestParentId: string | null = null,
+  options: ResolveSectionThreadDropDecisionOptions = {},
 ): SectionThreadDropDecision | null {
   const activeThread = lookup.threadByItemId.get(activeId);
   const fromParentKey = lookup.parentKeyByItemId.get(activeId);
@@ -426,11 +455,16 @@ export function resolveSectionThreadDropDecision(
   const overRowThreadId =
     overId === null ? null : parseSidebarThreadRowDroppableId(overId);
   if (overRowThreadId !== null && overRowThreadId !== activeId) {
-    return resolveNestDecision(lookup, activeId, overRowThreadId);
+    return resolveNestDecision(lookup, activeId, overRowThreadId, options);
   }
   const isSelfCollision = overId === activeId || overRowThreadId === activeId;
   if (isSelfCollision && projectedNestParentId !== null) {
-    return resolveNestDecision(lookup, activeId, projectedNestParentId);
+    return resolveNestDecision(
+      lookup,
+      activeId,
+      projectedNestParentId,
+      options,
+    );
   }
 
   const directParentKey = isSelfCollision
@@ -460,6 +494,13 @@ export function resolveSectionThreadDropDecision(
   }
 
   if (!lookup.sectionIdByParentKey.has(toParentKey)) return null;
+  if (options.groups) {
+    if (nested) return { kind: "detach", activeId };
+    if (fromPinned) {
+      return { kind: "unpin", activeId, sectionId: null, move: false };
+    }
+    return null;
+  }
   const sectionId = lookup.sectionIdByParentKey.get(toParentKey) ?? null;
   if (nested) return { kind: "detach", activeId, sectionId };
   if (fromPinned) {
@@ -570,7 +611,7 @@ function resolveRowDropState(
   if (decision?.kind === "nest") {
     return {
       threadId: decision.parentThreadId,
-      sectionId: decision.sectionId,
+      sectionId: decision.sectionId ?? null,
       state: "valid",
     };
   }
@@ -602,6 +643,7 @@ export function useSectionThreadDnd({
   topLevelSectionOrder,
   onTopLevelSectionOrderChange,
   onExpandThread,
+  groups = false,
   pinnedReorderPending,
   pinnedThreads,
   pinnedRootNodes,
@@ -614,9 +656,11 @@ export function useSectionThreadDnd({
         containerId,
         pinnedThreads,
         pinnedRootNodes,
+        { groups },
       ),
-    [containerId, pinnedRootNodes, pinnedThreads, rootItems],
+    [containerId, groups, pinnedRootNodes, pinnedThreads, rootItems],
   );
+  const decisionOptions = useMemo(() => ({ groups }), [groups]);
   const topLevelSectionIds = useMemo(
     () => new Set<string>(topLevelSectionOrder),
     [topLevelSectionOrder],
@@ -820,6 +864,7 @@ export function useSectionThreadDnd({
         overId,
         dragOverParentKey,
         projectedNestParentId,
+        decisionOptions,
       );
       const nextRowDrop = resolveRowDropState(decision);
       const directDrop = resolveSectionThreadDropTarget(
@@ -837,10 +882,13 @@ export function useSectionThreadDnd({
             )
           : null);
       const targetParentKey =
-        nextRowDrop !== null || decision?.kind === "reorder-pinned"
+        decision === null ||
+        nextRowDrop !== null ||
+        decision.kind === "reorder-pinned"
           ? null
-          : (drop?.toParentKey ??
-            (decision?.kind === "pin" ? PINNED_THREAD_PARENT_KEY : null));
+          : decision.kind === "pin"
+            ? PINNED_THREAD_PARENT_KEY
+            : (drop?.toParentKey ?? null);
       const nextReorderTarget =
         decision?.kind === "reorder-pinned"
           ? (() => {
@@ -913,6 +961,7 @@ export function useSectionThreadDnd({
     [
       clearDropDwell,
       containerId,
+      decisionOptions,
       dragOverParentKey,
       enabled,
       isPinnedRoot,
@@ -946,7 +995,9 @@ export function useSectionThreadDnd({
         updateThread.mutate({
           id: decision.activeId,
           parentThreadId: decision.parentThreadId,
-          sectionId: decision.sectionId,
+          ...(decision.sectionId !== undefined
+            ? { sectionId: decision.sectionId }
+            : {}),
         });
       if (decision.unpin) {
         unpinThread
@@ -976,7 +1027,9 @@ export function useSectionThreadDnd({
       }
 
       if (overId !== null && topLevelSectionIds.has(activeId)) {
-        const sectionOverId = resolveSectionThreadSectionOverId(lookup, overId);
+        const sectionOverId = topLevelSectionIds.has(overId)
+          ? overId
+          : resolveSectionThreadSectionOverId(lookup, overId);
         const nextOrder = reorderSidebarSectionOrder({
           activeId,
           overId: sectionOverId,
@@ -993,6 +1046,7 @@ export function useSectionThreadDnd({
         overId,
         dragOverParentKey,
         projectedNestParentId,
+        decisionOptions,
       );
       if (!decision) {
         clearProjectedDrag();
@@ -1009,7 +1063,9 @@ export function useSectionThreadDnd({
           updateThread.mutate({
             id: decision.activeId,
             parentThreadId: null,
-            sectionId: decision.sectionId,
+            ...(decision.sectionId !== undefined
+              ? { sectionId: decision.sectionId }
+              : {}),
           });
           break;
         case "nest":
@@ -1067,6 +1123,7 @@ export function useSectionThreadDnd({
       clearDropState,
       clearProjectedDrag,
       commitNest,
+      decisionOptions,
       dragOverParentKey,
       enabled,
       handlePinnedDragEnd,

--- a/apps/app/src/components/sidebar/useSectionThreadDnd.ts
+++ b/apps/app/src/components/sidebar/useSectionThreadDnd.ts
@@ -52,6 +52,7 @@ import type { SidebarDropPreviewPlacement } from "./sidebarDropPreviewPlacement"
 export const PINNED_THREAD_PARENT_KEY = "sidebar:pinned-threads";
 export const NEST_BAND_FRACTION = 0.6;
 export const NEST_BAND_ARMED_FRACTION = 0.8;
+export const PINNED_NEST_LINGER_MS = 450;
 
 export interface SectionThreadNestTarget {
   threadId: string;
@@ -286,11 +287,8 @@ export function resolveThreadRowNestCollisions({
   if (rowCollision === null || rowThreadId === null || !pointerCoordinates) {
     return otherCollisions;
   }
-  const bandFraction = getBandFraction(rowThreadId);
   const rect = droppableRects.get(rowCollision.id);
-  if (bandFraction === null || !rect || rect.height <= 0) {
-    return otherCollisions;
-  }
+  if (!rect || rect.height <= 0) return otherCollisions;
   const { x, y } = pointerCoordinates;
   const withinRect =
     x >= rect.left &&
@@ -298,6 +296,8 @@ export function resolveThreadRowNestCollisions({
     y >= rect.top &&
     y <= rect.top + rect.height;
   if (!withinRect) return otherCollisions;
+  const bandFraction = getBandFraction(rowThreadId);
+  if (bandFraction === null) return otherCollisions;
   const offsetFromCenter = Math.abs((y - rect.top) / rect.height - 0.5);
   return offsetFromCenter <= bandFraction / 2
     ? [rowCollision, ...otherCollisions]
@@ -592,17 +592,53 @@ export function useSectionThreadDnd({
   const activeIdRef = useRef<string | null>(null);
   const armedNestThreadIdRef = useRef<string | null>(null);
   const coarsePointerRef = useRef(false);
+  const pinnedLingerRef = useRef<{ threadId: string; since: number } | null>(
+    null,
+  );
+  const lingerTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [lingerTick, setLingerTick] = useState(0);
+  const clearPinnedLinger = useCallback(() => {
+    if (lingerTimerRef.current !== null) clearTimeout(lingerTimerRef.current);
+    lingerTimerRef.current = null;
+    pinnedLingerRef.current = null;
+  }, []);
+  const scheduleLingerTick = useCallback((delayMs: number) => {
+    if (lingerTimerRef.current !== null) clearTimeout(lingerTimerRef.current);
+    lingerTimerRef.current = setTimeout(() => {
+      lingerTimerRef.current = null;
+      setLingerTick((tick) => tick + 1);
+    }, delayMs);
+  }, []);
   const getNestBandFraction = useCallback(
     (threadId: string): number | null => {
       const activeId = activeIdRef.current;
       if (activeId === null || threadId === activeId) return null;
       if (lookup.itemKindById.get(threadId) !== "thread") return null;
-      if (coarsePointerRef.current) return 1;
-      return armedNestThreadIdRef.current === threadId
-        ? NEST_BAND_ARMED_FRACTION
-        : NEST_BAND_FRACTION;
+      const bothPinned =
+        lookup.parentKeyByItemId.get(activeId) === PINNED_THREAD_PARENT_KEY &&
+        lookup.parentKeyByItemId.get(threadId) === PINNED_THREAD_PARENT_KEY;
+      if (!bothPinned) {
+        pinnedLingerRef.current = null;
+        if (coarsePointerRef.current) return 1;
+        return armedNestThreadIdRef.current === threadId
+          ? NEST_BAND_ARMED_FRACTION
+          : NEST_BAND_FRACTION;
+      }
+      const now = Date.now();
+      const linger = pinnedLingerRef.current;
+      if (linger === null || linger.threadId !== threadId) {
+        pinnedLingerRef.current = { threadId, since: now };
+        scheduleLingerTick(PINNED_NEST_LINGER_MS);
+        return null;
+      }
+      const remaining = PINNED_NEST_LINGER_MS - (now - linger.since);
+      if (remaining > 0) {
+        scheduleLingerTick(remaining);
+        return null;
+      }
+      return 1;
     },
-    [lookup],
+    [lookup, scheduleLingerTick],
   );
   const collisionDetection = useCallback<CollisionDetection>(
     (args) => {
@@ -628,7 +664,7 @@ export function useSectionThreadDnd({
       );
       return nestedCollisions.length > 0 ? nestedCollisions : collisions;
     },
-    [getNestBandFraction, topLevelSectionIds],
+    [getNestBandFraction, lingerTick, topLevelSectionIds],
   );
   const updateThread = useUpdateThread();
   const pinThread = usePinThread();
@@ -698,7 +734,8 @@ export function useSectionThreadDnd({
     setReorderTarget(null);
     armedNestThreadIdRef.current = null;
     activeIdRef.current = null;
-  }, []);
+    clearPinnedLinger();
+  }, [clearPinnedLinger]);
   const clearProjectedDrag = useCallback(() => {
     clearDropSettle();
     clearDropState();
@@ -708,9 +745,15 @@ export function useSectionThreadDnd({
     () => () => {
       clearDropDwell();
       clearDropSettle();
+      clearPinnedLinger();
       stopProjectionInputTracking();
     },
-    [clearDropDwell, clearDropSettle, stopProjectionInputTracking],
+    [
+      clearDropDwell,
+      clearDropSettle,
+      clearPinnedLinger,
+      stopProjectionInputTracking,
+    ],
   );
 
   const handleDragStart = useCallback(
@@ -723,6 +766,7 @@ export function useSectionThreadDnd({
       draggingThreadRef.current = thread !== null;
       activeIdRef.current = thread ? activeId : null;
       armedNestThreadIdRef.current = null;
+      clearPinnedLinger();
       coarsePointerRef.current = isCoarseActivator(
         event.activatorEvent ?? null,
       );
@@ -734,7 +778,13 @@ export function useSectionThreadDnd({
       setRowDrop(null);
       setReorderTarget(null);
     },
-    [clearDropDwell, clearDropSettle, lookup, startProjectionInputTracking],
+    [
+      clearDropDwell,
+      clearDropSettle,
+      clearPinnedLinger,
+      lookup,
+      startProjectionInputTracking,
+    ],
   );
 
   const projectedNestParentId =

--- a/apps/app/src/components/sidebar/useSectionThreadDnd.ts
+++ b/apps/app/src/components/sidebar/useSectionThreadDnd.ts
@@ -52,7 +52,6 @@ import type { SidebarDropPreviewPlacement } from "./sidebarDropPreviewPlacement"
 export const PINNED_THREAD_PARENT_KEY = "sidebar:pinned-threads";
 export const NEST_BAND_FRACTION = 0.6;
 export const NEST_BAND_ARMED_FRACTION = 0.8;
-export const PINNED_NEST_LINGER_MS = 450;
 
 export interface SectionThreadNestTarget {
   threadId: string;
@@ -287,8 +286,11 @@ export function resolveThreadRowNestCollisions({
   if (rowCollision === null || rowThreadId === null || !pointerCoordinates) {
     return otherCollisions;
   }
+  const bandFraction = getBandFraction(rowThreadId);
   const rect = droppableRects.get(rowCollision.id);
-  if (!rect || rect.height <= 0) return otherCollisions;
+  if (bandFraction === null || !rect || rect.height <= 0) {
+    return otherCollisions;
+  }
   const { x, y } = pointerCoordinates;
   const withinRect =
     x >= rect.left &&
@@ -296,8 +298,6 @@ export function resolveThreadRowNestCollisions({
     y >= rect.top &&
     y <= rect.top + rect.height;
   if (!withinRect) return otherCollisions;
-  const bandFraction = getBandFraction(rowThreadId);
-  if (bandFraction === null) return otherCollisions;
   const offsetFromCenter = Math.abs((y - rect.top) / rect.height - 0.5);
   return offsetFromCenter <= bandFraction / 2
     ? [rowCollision, ...otherCollisions]
@@ -592,53 +592,17 @@ export function useSectionThreadDnd({
   const activeIdRef = useRef<string | null>(null);
   const armedNestThreadIdRef = useRef<string | null>(null);
   const coarsePointerRef = useRef(false);
-  const pinnedLingerRef = useRef<{ threadId: string; since: number } | null>(
-    null,
-  );
-  const lingerTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const [, setLingerTick] = useState(0);
-  const clearPinnedLinger = useCallback(() => {
-    if (lingerTimerRef.current !== null) clearTimeout(lingerTimerRef.current);
-    lingerTimerRef.current = null;
-    pinnedLingerRef.current = null;
-  }, []);
-  const scheduleLingerTick = useCallback((delayMs: number) => {
-    if (lingerTimerRef.current !== null) clearTimeout(lingerTimerRef.current);
-    lingerTimerRef.current = setTimeout(() => {
-      lingerTimerRef.current = null;
-      setLingerTick((tick) => tick + 1);
-    }, delayMs);
-  }, []);
   const getNestBandFraction = useCallback(
     (threadId: string): number | null => {
       const activeId = activeIdRef.current;
       if (activeId === null || threadId === activeId) return null;
       if (lookup.itemKindById.get(threadId) !== "thread") return null;
-      const bothPinned =
-        lookup.parentKeyByItemId.get(activeId) === PINNED_THREAD_PARENT_KEY &&
-        lookup.parentKeyByItemId.get(threadId) === PINNED_THREAD_PARENT_KEY;
-      if (!bothPinned) {
-        pinnedLingerRef.current = null;
-        if (coarsePointerRef.current) return 1;
-        return armedNestThreadIdRef.current === threadId
-          ? NEST_BAND_ARMED_FRACTION
-          : NEST_BAND_FRACTION;
-      }
-      const now = Date.now();
-      const linger = pinnedLingerRef.current;
-      if (linger === null || linger.threadId !== threadId) {
-        pinnedLingerRef.current = { threadId, since: now };
-        scheduleLingerTick(PINNED_NEST_LINGER_MS);
-        return null;
-      }
-      const remaining = PINNED_NEST_LINGER_MS - (now - linger.since);
-      if (remaining > 0) {
-        scheduleLingerTick(remaining);
-        return null;
-      }
-      return 1;
+      if (coarsePointerRef.current) return 1;
+      return armedNestThreadIdRef.current === threadId
+        ? NEST_BAND_ARMED_FRACTION
+        : NEST_BAND_FRACTION;
     },
-    [lookup, scheduleLingerTick],
+    [lookup],
   );
   const collisionDetection = useCallback<CollisionDetection>(
     (args) => {
@@ -734,8 +698,7 @@ export function useSectionThreadDnd({
     setReorderTarget(null);
     armedNestThreadIdRef.current = null;
     activeIdRef.current = null;
-    clearPinnedLinger();
-  }, [clearPinnedLinger]);
+  }, []);
   const clearProjectedDrag = useCallback(() => {
     clearDropSettle();
     clearDropState();
@@ -745,15 +708,9 @@ export function useSectionThreadDnd({
     () => () => {
       clearDropDwell();
       clearDropSettle();
-      clearPinnedLinger();
       stopProjectionInputTracking();
     },
-    [
-      clearDropDwell,
-      clearDropSettle,
-      clearPinnedLinger,
-      stopProjectionInputTracking,
-    ],
+    [clearDropDwell, clearDropSettle, stopProjectionInputTracking],
   );
 
   const handleDragStart = useCallback(
@@ -766,7 +723,6 @@ export function useSectionThreadDnd({
       draggingThreadRef.current = thread !== null;
       activeIdRef.current = thread ? activeId : null;
       armedNestThreadIdRef.current = null;
-      clearPinnedLinger();
       coarsePointerRef.current = isCoarseActivator(
         event.activatorEvent ?? null,
       );
@@ -778,13 +734,7 @@ export function useSectionThreadDnd({
       setRowDrop(null);
       setReorderTarget(null);
     },
-    [
-      clearDropDwell,
-      clearDropSettle,
-      clearPinnedLinger,
-      lookup,
-      startProjectionInputTracking,
-    ],
+    [clearDropDwell, clearDropSettle, lookup, startProjectionInputTracking],
   );
 
   const projectedNestParentId =

--- a/apps/app/src/components/sidebar/useSectionThreadDnd.ts
+++ b/apps/app/src/components/sidebar/useSectionThreadDnd.ts
@@ -101,7 +101,6 @@ interface SectionThreadDndLookup {
   sectionParentKeyBySectionId: Map<string, string>;
   sectionSectionIdByParentKey: Map<string, SidebarSectionId>;
   sectionIdByParentKey: Map<string, string | null>;
-  sectionNameByParentKey: Map<string, string>;
   itemIdsByParentKey: Map<string, string[]>;
   itemKindById: Map<string, ProjectThreadItem["kind"]>;
   parentKeyByItemId: Map<string, string>;
@@ -155,11 +154,7 @@ interface ResolveThreadRowNestCollisionsArgs {
   onRowPointer?: (info: ThreadRowPointerInfo) => void;
 }
 
-interface RowDropState {
-  threadId: string;
-  sectionId: string | null;
-  state: SidebarNestTargetState;
-}
+type RowDropState = SectionThreadNestTarget;
 
 interface CollectSectionThreadDndLookupOptions {
   groups?: boolean;
@@ -194,10 +189,6 @@ export function collectSectionThreadDndLookup(
       [PINNED_THREAD_PARENT_KEY, "pinned"],
     ]),
     sectionIdByParentKey: new Map([[containerId, null]]),
-    sectionNameByParentKey: new Map([
-      [containerId, "Threads"],
-      [PINNED_THREAD_PARENT_KEY, "Pinned"],
-    ]),
     itemIdsByParentKey: new Map([
       [PINNED_THREAD_PARENT_KEY, pinnedThreads.map((thread) => thread.id)],
     ]),
@@ -257,7 +248,6 @@ export function collectSectionThreadDndLookup(
         lookup.sectionParentKeyBySectionId.set(sectionId, item.group.key);
         lookup.sectionSectionIdByParentKey.set(item.group.key, sectionId);
         lookup.sectionIdByParentKey.set(item.group.key, item.group.id);
-        lookup.sectionNameByParentKey.set(item.group.key, item.group.name);
         walk(item.group.items, item.group.key);
       }
     }
@@ -609,20 +599,29 @@ function resolveRowDropState(
   decision: SectionThreadDropDecision | null,
 ): RowDropState | null {
   if (decision?.kind === "nest") {
-    return {
-      threadId: decision.parentThreadId,
-      sectionId: decision.sectionId ?? null,
-      state: "valid",
-    };
+    return { threadId: decision.parentThreadId, state: "valid" };
   }
   if (decision?.kind === "rejected") {
     return {
       threadId: decision.overThreadId,
-      sectionId: null,
       state: decision.reason === "own-subtree" ? "blocked" : "unchanged",
     };
   }
   return null;
+}
+
+function resolvePinnedReorderTarget(
+  lookup: SectionThreadDndLookup,
+  activeId: string,
+  decision: SectionThreadDropDecision | null,
+): SectionThreadReorderTarget | null {
+  if (decision?.kind !== "reorder-pinned") return null;
+  const placement = resolvePinnedReorderPlacement(
+    lookup,
+    activeId,
+    decision.overId,
+  );
+  return placement ? { threadId: decision.overId, placement } : null;
 }
 
 function getRowDropTargetKey(rowDrop: RowDropState): string {
@@ -889,19 +888,11 @@ export function useSectionThreadDnd({
           : decision.kind === "pin"
             ? PINNED_THREAD_PARENT_KEY
             : (drop?.toParentKey ?? null);
-      const nextReorderTarget =
-        decision?.kind === "reorder-pinned"
-          ? (() => {
-              const placement = resolvePinnedReorderPlacement(
-                lookup,
-                activeId,
-                decision.overId,
-              );
-              return placement
-                ? { threadId: decision.overId, placement }
-                : null;
-            })()
-          : null;
+      const nextReorderTarget = resolvePinnedReorderTarget(
+        lookup,
+        activeId,
+        decision,
+      );
       const targetKey =
         nextRowDrop !== null
           ? getRowDropTargetKey(nextRowDrop)
@@ -995,9 +986,7 @@ export function useSectionThreadDnd({
         updateThread.mutate({
           id: decision.activeId,
           parentThreadId: decision.parentThreadId,
-          ...(decision.sectionId !== undefined
-            ? { sectionId: decision.sectionId }
-            : {}),
+          sectionId: decision.sectionId,
         });
       if (decision.unpin) {
         unpinThread
@@ -1063,9 +1052,7 @@ export function useSectionThreadDnd({
           updateThread.mutate({
             id: decision.activeId,
             parentThreadId: null,
-            ...(decision.sectionId !== undefined
-              ? { sectionId: decision.sectionId }
-              : {}),
+            sectionId: decision.sectionId,
           });
           break;
         case "nest":
@@ -1168,9 +1155,7 @@ export function useSectionThreadDnd({
     onClickCapture,
     dragOverParentKey,
     dropPreview: null,
-    nestTarget: rowDrop
-      ? { threadId: rowDrop.threadId, state: rowDrop.state }
-      : null,
+    nestTarget: rowDrop,
     reorderTarget,
     pinnedItemIds,
     pinnedReorderPending,

--- a/apps/app/src/components/sidebar/useSidebarReorderDnd.ts
+++ b/apps/app/src/components/sidebar/useSidebarReorderDnd.ts
@@ -81,6 +81,7 @@ export class SidebarTouchSensor extends TouchSensor {
 export function useSidebarReorderDnd({
   onDragEnd,
   onDragStart,
+  onDragMove,
   onDragOver,
   onDragCancel,
   collisionDetection = sidebarReorderCollisionDetection,
@@ -113,6 +114,7 @@ export function useSidebarReorderDnd({
   return useReorderDnd({
     onDragEnd: handleDragEnd,
     onDragStart: handleDragStart,
+    onDragMove,
     onDragOver,
     onDragCancel: handleDragCancel,
     collisionDetection,

--- a/apps/app/src/components/ui/useReorderDnd.ts
+++ b/apps/app/src/components/ui/useReorderDnd.ts
@@ -16,6 +16,7 @@ import {
   type CollisionDetection,
   type DndContextProps,
   type DragEndEvent,
+  type DragMoveEvent,
   type DragOverEvent,
   type DragStartEvent,
   type Modifier,
@@ -43,6 +44,7 @@ const REORDER_MODIFIERS: Modifier[] = [restrictDragToVerticalAxis];
 export interface UseReorderDndArgs {
   onDragEnd: (event: DragEndEvent) => void;
   onDragStart?: (event: DragStartEvent) => void;
+  onDragMove?: (event: DragMoveEvent) => void;
   onDragOver?: (event: DragOverEvent) => void;
   onDragCancel?: () => void;
   collisionDetection?: CollisionDetection;
@@ -54,6 +56,7 @@ export type ReorderDndContextProps = Pick<
   | "sensors"
   | "collisionDetection"
   | "onDragStart"
+  | "onDragMove"
   | "onDragOver"
   | "onDragCancel"
   | "onDragEnd"
@@ -69,6 +72,7 @@ export interface UseReorderDndResult {
 export function useReorderDnd({
   onDragEnd,
   onDragStart,
+  onDragMove,
   onDragOver,
   onDragCancel,
   collisionDetection = reorderCollisionDetection,
@@ -142,6 +146,7 @@ export function useReorderDnd({
       collisionDetection,
       modifiers: REORDER_MODIFIERS,
       onDragStart: handleDragStart,
+      onDragMove,
       onDragOver,
       onDragCancel: handleDragCancel,
       onDragEnd: handleDragEnd,
@@ -151,6 +156,7 @@ export function useReorderDnd({
       handleDragCancel,
       handleDragEnd,
       handleDragStart,
+      onDragMove,
       onDragOver,
       sensors,
     ],

--- a/apps/app/src/hooks/cache-owners/thread-state-cache-owner.ts
+++ b/apps/app/src/hooks/cache-owners/thread-state-cache-owner.ts
@@ -66,6 +66,7 @@ interface BeginThreadReadStateTransactionArgs extends ThreadIdCacheArgs {
 }
 
 interface BeginThreadMetadataTransactionArgs extends ThreadIdCacheArgs {
+  parentThreadId?: string | null;
   sectionId?: string | null;
   title?: string | null;
 }
@@ -389,6 +390,7 @@ export function beginThreadReadStateTransaction({
 }
 
 export function beginThreadMetadataTransaction({
+  parentThreadId,
   sectionId,
   queryClient,
   threadId,
@@ -397,6 +399,7 @@ export function beginThreadMetadataTransaction({
   const patch = {
     ...(title !== undefined ? { title } : {}),
     ...(sectionId !== undefined ? { sectionId } : {}),
+    ...(parentThreadId !== undefined ? { parentThreadId } : {}),
   };
   return runOptimisticThreadFieldTransaction({
     applyToLists: (queryClient, threadId) =>

--- a/apps/app/src/hooks/mutations/thread-state-mutations.ts
+++ b/apps/app/src/hooks/mutations/thread-state-mutations.ts
@@ -84,15 +84,21 @@ export function useUpdateThread(options?: UpdateThreadMutationOptions) {
     mutationFn: ({ id, ...request }: UpdateThreadMutationRequest) =>
       sdk.threads.update({ threadId: id, ...request }),
     onMutate: ({
+      parentThreadId,
       sectionId,
       id,
       title,
     }): Promise<ThreadListMutationTransaction | undefined> | undefined => {
-      if (title === undefined && sectionId === undefined) {
+      if (
+        title === undefined &&
+        sectionId === undefined &&
+        parentThreadId === undefined
+      ) {
         return undefined;
       }
 
       return beginThreadMetadataTransaction({
+        parentThreadId,
         sectionId,
         queryClient,
         threadId: id,


### PR DESCRIPTION
## Human comments

## What was wrong

The Custom sidebar drag only had three outcomes: move a thread to a section, pin it, or reorder pinned threads. Dropping onto a thread row resolved to that row's section, so there was no drag path to `parentThreadId` even though the server, SDK, and CLI already support reparenting. Reparenting was only reachable through the select in the thread metadata panel, and only for root threads.

## What changed

- `useSectionThreadDnd.ts`: every thread row registers a droppable (`sidebarThreadRowDroppable.ts`). The collision detector keeps a row collision only while the pointer is in the row's center band (60% of the row, 80% once armed for hysteresis, the whole row on touch), so row edges, section headers, and gaps still mean "into this section". New decisions: `nest`, `detach`, `pin` with `detach`, and `rejected` for a thread's own subtree or its current parent. Pinned rows nest too, with a smaller 40% band (50% once armed) since reordering is the common drag there. A thread dragged into the pinned list from outside shows the insertion line on the hovered half of a pinned row and is pinned at that position (pin, then the existing pin-order reorder); children of pinned threads detach first. Cross-project nesting is allowed. A collapsed parent auto-expands after 200ms.
- `ProjectRow.tsx` / `ThreadRow.tsx` / `PinnedThreadTree.tsx`: nested rows are draggable, so a child dropped on a section header detaches and one dropped on Pinned detaches and pins. The target row gets a ring (red when blocked). Nothing moves while dragging: sortable displacement is off for section and pinned rows (`sortableMotion.ts` `displace`), and the live section projection that moved the dragged row is gone. A dashed placeholder opens at the slot where the thread will land, computed from the active sort order by `sidebarDropPreviewPlacement.ts` for sections, the loose list, children of a parent, and the pinned list. Pinned reorder shows an insertion line instead of displacing rows.
- `thread-state-mutations.ts` / `thread-state-cache-owner.ts`: `parentThreadId` is applied optimistically like `sectionId`.
- Project and machine modes get the same drags. `ReorderableSidebarSectionOrderList` can be driven by the hook in a `groups` mode (`useSectionThreadDnd`, `useRenderedSectionThreadDnd`): group headers only detach and never assign a section, nesting leaves `sectionId` alone, the placeholder is placed within the group's sorted items, and section reordering still goes through the same context. `ProjectThreadTree` reads the drag state from context and renders the group's items built once in `ProjectList`, which the drag lookup shares.

No wire changes. No CLI or config changes; `bb thread --parent` already covers this.

## How you verified

- New unit tests: nest, detach, rejected, pinned-child, and detach-and-pin decisions; pin-at-position neighbor requests; the center-band collision filter with hysteresis; pinned reorder placement; sorted placeholder placement for sections, nesting, pinned parents, and pinning; a hook-level nest projection test.
- A simplicity review (Codex gpt-6-astra) was applied: no fallback drag hook in the section order list, one tree build per group, the destination parent key returned with the drop decision, the shared descendants helper for placement, and one dwell timer for auto-expand.
- `pnpm exec turbo run typecheck --filter=@bb/app`, `pnpm exec turbo run lint --filter=@bb/app` (no new warnings), and the full app vitest suite (508 files, 4302 tests).
- Manual checks through the bb browser automation plugin against the dev stack with a seeded thread tree: nest, section move from a row edge, blocked drop on a descendant, unchanged drop on the current parent, Escape, detach onto Threads and onto Pinned from both section and pinned parents, pinned-onto-pinned nest, pinned edge reorder, positional pinning from a section thread and from a nested pinned child, and a check that no existing row moves while hovering. In project mode and machine mode: nest, detach onto the group header, positional pin, and group header reorder. Placeholder slot compared equal to the final slot after release for a section move, a nest, a pin, and a move back to Threads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> AGENT GENERATED
