### PR TITLE
Truncate long machine names in the mobile composer

### DIFF
--- a/apps/app/src/components/pickers/MachinePicker.tsx
+++ b/apps/app/src/components/pickers/MachinePicker.tsx
@@ -83,7 +83,7 @@ export function MachinePickerUI({
           size="sm"
           aria-label="Machine"
           disabled={disabled}
-          data-promptbox-icon-only-control=""
+          data-promptbox-shrinkable-control=""
           className={cn(
             OPTION_BASE_CLASS_NAME,
             !disabled && OPTION_INTERACTIVE_CLASS_NAME,

--- a/apps/app/src/components/promptbox/NewThreadPromptBox.stories.tsx
+++ b/apps/app/src/components/promptbox/NewThreadPromptBox.stories.tsx
@@ -528,7 +528,7 @@ function ProjectlessThreadRow() {
   const execution = useInteractiveExecutionControls(baseExecution);
   const [permission, setPermission] = useState<PermissionMode>("auto");
   const [projectId, setProjectId] = useState<string | null>(null);
-  const [hostId, setHostId] = useState<string>(HOST_IDS.remote);
+  const [hostId, setHostId] = useState<string | null>(HOST_IDS.remote);
   const [environmentValue, setEnvironmentValue] = useState(
     "provider:personal-workspace",
   );

--- a/apps/app/src/components/promptbox/NewThreadPromptBox.stories.tsx
+++ b/apps/app/src/components/promptbox/NewThreadPromptBox.stories.tsx
@@ -24,6 +24,7 @@ import {
   HOST_IDS,
   PROJECT_IDS,
   STORY_CLAUDE_CODE_MORE_MODELS,
+  STORY_ENVIRONMENT_PROVIDERS,
   STORY_PROJECTS,
   STORY_PROJECT_SOURCES,
   STORY_WORKTREE_OPTIONS,
@@ -514,8 +515,24 @@ function FullAccessRow() {
   );
 }
 
+const projectlessHosts = [
+  makeHost({ id: HOST_IDS.local, name: "MacBook Air" }),
+  makeHost({
+    id: HOST_IDS.remote,
+    name: "Bersabel’s development MacBook Air with a long machine name",
+  }),
+];
+
 function ProjectlessThreadRow() {
   const { value, mentionRanges, onChange } = useControlledValue("");
+  const execution = useInteractiveExecutionControls(baseExecution);
+  const [permission, setPermission] = useState<PermissionMode>("auto");
+  const [projectId, setProjectId] = useState<string | null>(null);
+  const [hostId, setHostId] = useState<string>(HOST_IDS.remote);
+  const [environmentValue, setEnvironmentValue] = useState(
+    "provider:personal-workspace",
+  );
+  const [worktreeId, setWorktreeId] = useState<string | null>(null);
   return (
     <PromptStage>
       <NewThreadPromptBoxUI
@@ -529,13 +546,48 @@ function ProjectlessThreadRow() {
         history={baseHistory}
         typeahead={makeTypeahead()}
         attachments={makeAttachments()}
-        modeConfig={baseModeConfig}
+        modeConfig={{
+          environment: {
+            ...baseEnvironment,
+            value: environmentValue,
+            onChange: setEnvironmentValue,
+            machines: {
+              hosts: projectlessHosts,
+              localDaemonHostId: HOST_IDS.local,
+              primaryHostId: HOST_IDS.local,
+            },
+            providers: STORY_ENVIRONMENT_PROVIDERS,
+            selectedProviderHostId: hostId,
+            onSelectProvider: (provider, selectedHostId) => {
+              setEnvironmentValue(`provider:${provider.id}`);
+              setHostId(selectedHostId);
+            },
+          },
+          worktree: {
+            ...baseWorktree,
+            value: worktreeId,
+            onChange: setWorktreeId,
+          },
+          permission: {
+            ...basePermission,
+            value: permission,
+            onChange: setPermission,
+          },
+        }}
         project={{
           ...baseProject,
-          value: null,
+          value: projectId,
+          onChange: (selectedProjectId) => {
+            setProjectId(selectedProjectId);
+            setEnvironmentValue(
+              selectedProjectId === null
+                ? "provider:personal-workspace"
+                : "provider:project-checkout",
+            );
+          },
           allowNoProject: true,
         }}
-        execution={baseExecution}
+        execution={execution}
       />
     </PromptStage>
   );
@@ -604,7 +656,7 @@ export function Overview() {
         </StoryRow>
         <StoryRow
           label="projectless"
-          hint="host picker replaces environment picker"
+          hint="interactive machine, project, model, and permissions; long machine label truncates"
         >
           <ProjectlessThreadRow />
         </StoryRow>
@@ -624,6 +676,16 @@ export function UnsupportedCodexCli() {
           <UnsupportedCodexCliRow />
         </StoryRow>
       </StoryCard>
+    </ModelPickerStoryQueryProvider>
+  );
+}
+
+export function Mobile() {
+  return (
+    <ModelPickerStoryQueryProvider>
+      <div className="mx-auto w-full max-w-[390px] p-4">
+        <ProjectlessThreadRow />
+      </div>
     </ModelPickerStoryQueryProvider>
   );
 }

--- a/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
+++ b/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
@@ -354,8 +354,8 @@ const DefaultNewThreadComposer = memo(function DefaultNewThreadComposer({
         footerStart={<ExecutionControls {...execution} />}
       />
       {}
-      <div className="mt-1 flex select-none items-start justify-between gap-2 px-3.5">
-        <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1">
+      <div className="mt-1 flex select-none items-center justify-between gap-2 px-3.5">
+        <div className="flex min-w-0 flex-1 items-center gap-1">
           {project ? (
             <ProjectSelector
               projects={project.projects}

--- a/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
+++ b/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
@@ -354,8 +354,8 @@ const DefaultNewThreadComposer = memo(function DefaultNewThreadComposer({
         footerStart={<ExecutionControls {...execution} />}
       />
       {}
-      <div className="mt-1 flex select-none items-center justify-between gap-2 px-3.5">
-        <div className="flex min-w-0 flex-1 items-center gap-1">
+      <div className="mt-1 flex select-none items-start justify-between gap-2 px-3.5">
+        <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1">
           {project ? (
             <ProjectSelector
               projects={project.projects}


### PR DESCRIPTION
## Human comments

## What was wrong

- With no project selected, the machine picker could not shrink within the compact composer controls row. A long machine name overlapped permissions and extended beyond the phone viewport.

## What changed

- Let the machine picker use the existing shrinkable-control layout so its label truncates and leaves room for permissions on one line.
- Make the existing projectless Ladle example interactive and add a mobile story using the production composer and pickers, with short/long machine names and real permission options.

## How you verified

- Chrome for Testing 153.0.8010.36: verified the branch web app at 320 × 844 and 390 × 844. The long machine label overlapped permissions before; after, it ellipsizes with an 8 px gap before permissions. Checked reload and resizing; opened and selected permissions on the final head. The machine picker also opened and dismissed correctly in the prior bounded pass.
- Ladle: verified 12 selected project/machine/permission combinations at 320 px and 390 px, using production components with menus closed. No control overlap in those fixtures.
- [Remote PR CI](https://github.com/get-bb/bb/actions/runs/34621008840) passed for `f9f228fcf`: build, typecheck, lint, all test groups, and Linux/macOS package smoke. Version and contributor checks passed. No local CI-equivalent checks were run.
- Screenshots show the same empty draft, long machine name, Full Access permission, light theme, and root composer. Mobile before/after pairs use identical viewports and crops. Before: merge base `9882e4a79`; after: PR head `f9f228fcf`.

| State / viewport | Before | After |
| --- | --- | --- |
| No project · long machine · mobile 320 × 844 | <img src="https://github.com/brsbl/bb/releases/download/pr-evidence-thr_xqfqv839un/before-9882e4a79-320.png" width="320" alt="Before: machine label overlaps permissions at 320px" /> | <img src="https://github.com/brsbl/bb/releases/download/pr-evidence-thr_xqfqv839un/after-f9f228fcf-320.png" width="320" alt="After — mobile: machine label truncates at 320px" /> |
| No project · long machine · mobile 390 × 844 | <img src="https://github.com/brsbl/bb/releases/download/pr-evidence-thr_xqfqv839un/before-9882e4a79-390.png" width="390" alt="Before: machine label overlaps permissions at 390px" /> | <img src="https://github.com/brsbl/bb/releases/download/pr-evidence-thr_xqfqv839un/after-f9f228fcf-390.png" width="390" alt="After — mobile: machine label truncates at 390px" /> |

BB-Thread-ID: thr_xqfqv839un

> AGENT GENERATED

