### PR TITLE
Separate hover from selection in the model picker's reasoning toggles

### DIFF
--- a/apps/app/src/components/pickers/ModelReasoningPicker.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.tsx
@@ -1106,7 +1106,7 @@ export function ModelReasoningPicker({
                         value={option.value}
                         aria-label={option.label}
                         className={cn(
-                          "h-6 min-w-0 flex-auto shrink-0 whitespace-nowrap rounded-sm px-1 text-xs font-normal shadow-none data-[state=on]:bg-state-active data-[state=on]:text-foreground",
+                          "h-6 min-w-0 flex-auto shrink-0 whitespace-nowrap rounded-sm px-1 text-xs font-normal shadow-none hover:bg-state-hover hover:text-foreground data-[state=on]:bg-state-active data-[state=on]:text-foreground data-[state=on]:hover:bg-state-active",
                           isCompactViewport && "h-9 text-sm",
                           LIST_HOVER_TRANSITION,
                         )}


### PR DESCRIPTION
## Human comments

## What was wrong

- In the model picker's reasoning row, hovering a level looked the same as the selected level. The picker is one shared component, so this showed everywhere it renders: the follow-up composer, the new-thread composer, side chats, the queued-message and sent-message inline editors, and the plugin provider/model picker. The `ToggleGroupItem` base styles fill a hovered item with the muted surface, and the picker fills the selected item with the shared active state. In the light theme those are ink at 11% over the canvas and ink at 11.8% translucent, which render as the same grey.
- Hover also dropped the label to the muted text colour while the selected label stayed at the foreground colour, so the only difference was a slightly dimmer word that is easy to miss.
- Example: with Medium selected, resting the pointer on High showed two filled pills side by side, and a screenshot of that state read as two selected levels.

## What changed

- `apps/app/src/components/pickers/ModelReasoningPicker.tsx`: the reasoning toggle items now hover with `bg-state-hover` and keep `text-foreground`, while the selected item keeps `bg-state-active` and no longer changes when hovered. This is the same hover-versus-active pairing the sidebar uses for its row controls in `sidebarRowClasses.ts`, and the same `state-active` surface its selected thread row paints through `CONTEXT_SELECTION_SURFACE_CLASS`; the picker's own model rows already hover with `state-hover`.
- In the light theme the hovered fill is now ink at 5.9% against the selected 11.8%; in the dark theme the tokens are 13.8% against 22.5%. Hovering the selected level leaves it at the selected fill.
- The override lives on the picker's own toggle items, so every surface that renders the picker gets it with no per-surface changes, and the shared toggle-group base styles stay as they are for any other toggle.

## How you verified

- Remote CI on the PR head `ba1958496`: every test, check, and macOS package smoke job passed. The Ubuntu Package Smoke job timed out while installing the AppImage FUSE runtime before any smoke test ran; the same job fails the same way on `main` at `9ece01e61`, the merge base, so it is a runner problem rather than this branch.
- Browser QA in Chrome for Testing 151.0.7922.71 against the branch web app launched with `scripts/bb-dev-app current` from an isolated worktree, on the follow-up composer's instance of the picker in the light theme, with Medium selected and the pointer resting on High. The other composers render the same component with the same classes and were not captured separately.
- Desktop 1280×900 popover: before, the selected fill computed to `oklab(0.3211 0 0 / 0.118)` and the hovered fill to the opaque muted surface `oklch(0.9253 0 0)`; after, the hovered fill computes to `oklab(0.3211 0 0 / 0.059)` with the label at the foreground colour, and hovering Medium itself keeps it at the selected fill.
- Mobile 390×844 drawer (the compact layout at the `(max-width: 767px)` breakpoint): same before and after values, with the drawer's larger pills.
- Not exercised: the dark theme, which uses the same token pair at 13.8% and 22.5%, and Safari, since nothing here is browser-specific. No tests cover these class names, so none were added or changed.

Before: merge base `9ece01e61`. After: PR head `ba1958496`. Same thread, route, picker state, hovered item, theme, and viewports.

| Before — desktop 1280×900 | After — desktop 1280×900 |
| --- | --- |
| ![Before: Medium selected and High hovered show the same grey fill](https://github.com/brsbl/bb/releases/download/pr-evidence-thr_rmmwartzsr/picker-before-9ece01e61.png) | ![After: Medium keeps the selected fill while hovered High shows the lighter hover fill](https://github.com/brsbl/bb/releases/download/pr-evidence-thr_rmmwartzsr/picker-after-ba1958496.png) |

| Before — mobile 390×844 | After — mobile 390×844 |
| --- | --- |
| ![Before on mobile: the drawer shows Medium and hovered High with matching fills](https://github.com/brsbl/bb/releases/download/pr-evidence-thr_rmmwartzsr/picker-mobile-before-9ece01e61.png) | ![After on mobile: hovered High is visibly lighter than selected Medium](https://github.com/brsbl/bb/releases/download/pr-evidence-thr_rmmwartzsr/picker-mobile-after-ba1958496.png) |

BB-Thread-ID: thr_rmmwartzsr

> AGENT GENERATED

🤖 Generated with [Claude Code](https://claude.com/claude-code)


