### PR TITLE
Remove redundant child startup from dry-run test

### DIFF
--- a/packages/bb-app/test/dry-run.test.ts
+++ b/packages/bb-app/test/dry-run.test.ts
@@ -1,11 +1,26 @@
-import { execFileSync } from "node:child_process";
 import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { pathToFileURL } from "node:url";
-import { expect, it } from "vitest";
+import { expect, it, vi } from "vitest";
 import { z } from "zod";
+import { runBbApp } from "../src/launcher.js";
+
+async function captureStdout(run: () => Promise<void>): Promise<string> {
+  const chunks: string[] = [];
+  const write = vi
+    .spyOn(process.stdout, "write")
+    .mockImplementation((chunk) => {
+      chunks.push(typeof chunk === "string" ? chunk : chunk.toString());
+      return true;
+    });
+  try {
+    await run();
+  } finally {
+    write.mockRestore();
+  }
+  return chunks.join("");
+}
 
 it("previews occupied ports without creating data or starting services", async () => {
   const root = mkdtempSync(join(tmpdir(), "bb-start-dryrun-"));
@@ -25,24 +40,17 @@ it("previews occupied ports without creating data or starting services", async (
       String(address.port),
       "--host-daemon-port",
       String(address.port),
+      "--server-bind-host",
+      "127.0.0.1",
     ];
-    const moduleUrl = pathToFileURL(
-      join(import.meta.dirname, "../src/launcher.ts"),
-    ).href;
-    const output = execFileSync(
-      process.execPath,
-      [
-        "--conditions=source",
-        "--import",
-        "tsx",
-        "--input-type=module",
-        "--eval",
-        `import { runBbApp } from ${JSON.stringify(moduleUrl)}; await runBbApp(${JSON.stringify(args)}, {dryRun: true, worktreePolicy: null, beforeServerStart() { throw new Error("Started services"); }});`,
-      ],
-      {
-        encoding: "utf8",
-        env: { ...process.env, BB_SERVER_BIND_HOST: "127.0.0.1" },
-      },
+    const output = await captureStdout(() =>
+      runBbApp(args, {
+        dryRun: true,
+        worktreePolicy: null,
+        beforeServerStart() {
+          throw new Error("Started services");
+        },
+      }),
     );
     const preview = z
       .object({


### PR DESCRIPTION
## Human comments

## What was wrong

The deterministic dry-run unit test synchronously launched a fresh Node process with `tsx` and reloaded the full TypeScript launcher inside Vitest's unchanged 5-second test clock. The [evidence-backed packages failure](https://github.com/get-bb/bb/actions/runs/34618375551/job/103325870801) occurred while the 4-vCPU packages shard ran four Turbo package tasks concurrently, each with its own test workers; that nested CPU oversubscription delayed the redundant child startup until the test timed out. Process isolation was not part of the behavior under test, and the separate packed-tarball smoke already exercises the real `bb-app` executable plus server/daemon lifecycle.

## What changed

- Invoke `runBbApp` directly in the Vitest worker instead of starting a second Node + `tsx` process.
- Capture and restore stdout in the test and pass the bind host as an explicit launcher argument, avoiding global environment mutation.
- Preserve the occupied TCP listener for both ports, exact preview parsing/assertions, nonexistent data-directory assertion, and throwing pre-server-start hook.

No timeout, production behavior, CLI surface, documentation, or server/daemon wire contract changed.

## How you verified

- Before the change, five unloaded focused runs took 1,026 ms cold and 424–457 ms warm inside the test body. Under 64 bounded CPU workers on an 8-logical-CPU Intel host, the unchanged test timed out in its first three contended attempts at 5,590 ms, 8,322 ms, and 7,613 ms.
- After the change, five unloaded focused runs passed in 17–22 ms. Three runs under the same 64-worker contention all passed in 491 ms, 451 ms, and 455 ms, with Vitest's 5-second test timeout unchanged.
- `pnpm exec turbo run build typecheck test --filter=bb-app --cache-dir=.turbo/cache --output-logs=new-only`: 50/50 tasks succeeded; all 5 bb-app test files and 80 tests passed. The repaired test took 31 ms in the full suite.
- `pnpm exec oxfmt packages/bb-app/test/dry-run.test.ts --check`: passed.
- Every reproduction, stress, and validation run used externally bounded process groups. Final scans reported no surviving descendants, including `SURVIVORS=[]` for all 67 PGIDs in the after-change contention run and for the Turbo validation group.

> AGENT GENERATED
