### PR TITLE
Stabilize installed-only provider discovery deadline test

### DIFF
--- a/apps/server/test/system/execution-options.test.ts
+++ b/apps/server/test/system/execution-options.test.ts
@@ -625,9 +625,8 @@ describe("resolveSystemExecutionOptions", () => {
           );
         } finally {
           harness.hub.unregisterDaemon(session.id);
-          await vi.runAllTimersAsync();
-          await pendingProviders?.catch(() => undefined);
           vi.useRealTimers();
+          await pendingProviders?.catch(() => undefined);
         }
       },
     );

--- a/apps/server/test/system/execution-options.test.ts
+++ b/apps/server/test/system/execution-options.test.ts
@@ -12,6 +12,7 @@ import {
 } from "../../src/services/system/execution-options.js";
 import { ApiError } from "../../src/errors.js";
 import { availableModelFixture } from "../helpers/available-models.js";
+import { listQueuedCommands } from "../helpers/commands.js";
 import {
   registerHostRpcResponder,
   registerProviderHostRpcResponder,
@@ -32,6 +33,30 @@ import {
 import { createProviderRegistryService } from "../../src/services/providers/provider-registry.js";
 
 const registry = await createTestProviderRegistry();
+
+const INSTALLED_ONLY_PROVIDER_IDS = [
+  "acp-opencode",
+  "acp-omp",
+  "acp-grok",
+  "acp-hermes-agent",
+] as const;
+
+function registerInstalledOnlyProviderFixtures(harness: TestAppHarness): void {
+  const pluginId = "provider-acp";
+  harness.deps.pluginHostArtifacts.set(pluginId, {
+    digest: "a".repeat(64),
+    byteLength: 1,
+    path: "/unused/provider-acp.mjs",
+    generation: "test-provider-discovery",
+  });
+  for (const providerId of INSTALLED_ONLY_PROVIDER_IDS) {
+    const registration = registry.get(providerId);
+    if (registration === null) {
+      throw new Error(`Missing provider fixture ${providerId}`);
+    }
+    harness.deps.providerRegistry.register(registration);
+  }
+}
 
 function providerDiscoveryHealth(installed: boolean) {
   return {
@@ -562,42 +587,50 @@ describe("resolveSystemExecutionOptions", () => {
   });
 
   it("spends one command timeout across installed-only provider discovery", async () => {
-    vi.useFakeTimers();
-    try {
-      await withTestHarness({}, async (harness) => {
+    await withTestHarness(
+      { seedFirstPartyProviders: false },
+      async (harness) => {
+        registerInstalledOnlyProviderFixtures(harness);
         const { host, session } = seedHostSession(harness.deps, {
           id: "host-execution-options-provider-discovery-budget",
         });
-        const responder = registerHostRpcResponder(harness, {
-          hostId: host.id,
-          sessionId: session.id,
-          handle: () => new Promise(() => undefined),
-        });
+        let pendingProviders: ReturnType<
+          typeof listSystemProviderInfos
+        > | null = null;
+        vi.useFakeTimers();
+        try {
+          let settled = false;
+          pendingProviders = listSystemProviderInfos(harness.deps, {
+            hostId: host.id,
+          }).then((providers) => {
+            settled = true;
+            return providers;
+          });
 
-        let settled = false;
-        const pendingProviders = listSystemProviderInfos(harness.deps, {
-          hostId: host.id,
-        }).then((providers) => {
-          settled = true;
-          return providers;
-        });
+          await vi.advanceTimersByTimeAsync(0);
+          expect(listQueuedCommands(harness, "provider.health")).toHaveLength(
+            3,
+          );
+          await vi.advanceTimersByTimeAsync(29_999);
+          expect(settled).toBe(false);
 
-        await vi.advanceTimersByTimeAsync(0);
-        expect(responder.requests).toHaveLength(3);
-        await vi.advanceTimersByTimeAsync(29_999);
-        expect(settled).toBe(false);
-
-        await vi.advanceTimersByTimeAsync(1);
-        const providers = await pendingProviders;
-        expect(settled).toBe(true);
-        expect(responder.requests).toHaveLength(6);
-        expect(providers.map((provider) => provider.id)).not.toContain(
-          "acp-opencode",
-        );
-      });
-    } finally {
-      vi.useRealTimers();
-    }
+          await vi.advanceTimersByTimeAsync(1);
+          const providers = await pendingProviders;
+          expect(settled).toBe(true);
+          expect(listQueuedCommands(harness, "provider.health")).toHaveLength(
+            6,
+          );
+          expect(providers.map((provider) => provider.id)).not.toContain(
+            "acp-opencode",
+          );
+        } finally {
+          harness.hub.unregisterDaemon(session.id);
+          await vi.runAllTimersAsync();
+          await pendingProviders?.catch(() => undefined);
+          vi.useRealTimers();
+        }
+      },
+    );
   });
 
   it.each([


### PR DESCRIPTION
## Human comments

## What was wrong

The provider-discovery deadline assertion coupled a deterministic retry/concurrency check to repeated full first-party provider registration inside a complete server harness. It also installed a responder whose six timeout-path handlers returned promises that never settled. Under package-shard and Vitest worker contention, this avoidable setup and dangling asynchronous work consumed the test's real 5-second wrapper even though advancing the 30-second command budget is logical time. The publish workflow runs the config, server, and bb-app test tasks together through Turbo while their Vitest suites retain their own worker pools; that contention is a reproduction condition, while the test's heavyweight and uncontained setup is the root cause. On the 8-thread Intel reproduction host, the test body measured 335 ms unloaded, 1.122 s with 16 CPU burners, 3.646 s with 32, and 3.943 s with 40.

The first PR head exposed a cleanup regression: `vi.runAllTimersAsync()` globally drained recurring timers owned by the shared server harness and hit Vitest's 10,000-timer guard. Cleanup must cancel this test's RPC work without advancing unrelated timers.

## What changed

The deadline test now skips per-test first-party provider loading and reuses the file's already-built registrations for the four installed-only ACP providers. It uses the harness's existing RPC capture instead of never-settling responder promises and scopes fake timers to the deadline assertion.

Cleanup unregisters only the test daemon, restores real timers before rejected retryable RPC branches can schedule their transport waits, and awaits only the provider-list promise. It does not globally drain the shared worker's timers. The behavioral coverage is unchanged: three concurrent initial health requests, no settlement at 29,999 ms, six total requests after retry exhaustion at 30,000 ms, and omission of `acp-opencode` all remain asserted. No timeout, polling deadline, retry budget, or Vitest timer limit was increased. This is a test-only change with no CLI, SDK, server/daemon wire, or protocol-version impact.

## How you verified

- Matched 40-burner Intel reproduction before the change: 3.943-second test body.
- Revised test under 40 Intel CPU burners: passed in 2.03 seconds; all stress and test process groups were reaped.
- Deliberately forced the first request-count assertion to fail: cleanup completed in 2.306 seconds with only the intended assertion error, without the 10,000-timer abort; the bounded test process group was reaped and the original assertion was restored.
- `pnpm exec turbo run test --filter=@bb/server --output-logs=full --concurrency=2 -- test/system/execution-options.test.ts`: 8/8 Turbo tasks and 38/38 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/server --output-logs=full --concurrency=2`: 5/5 tasks passed.
- `pnpm exec turbo run build --filter=@bb/server --output-logs=full --concurrency=2`: 5/5 tasks passed.
- Exact-head CI at `5640dd2008f9b301941619107a1d52e1d808efa9`: [run 34626076276](https://github.com/get-bb/bb/actions/runs/34626076276) passed, including the complete server shard.
- `git diff --check` passed.
- Every workload had an external process-group ceiling; final descendant scans found no Vitest, Turbo, pnpm test, or stress process from this work.

> AGENT GENERATED: by GPT-5.6-Sol
