### PR TITLE
Fix provider session identity mixups during concurrent thread starts

### DIFF
--- a/apps/server/test/threads/thread-checkpoint-identity.test.ts
+++ b/apps/server/test/threads/thread-checkpoint-identity.test.ts
@@ -1,0 +1,209 @@
+import { fileURLToPath } from "node:url";
+import { createScriptedEchoRuntime } from "@bb/agent-runtime/test";
+import { getThread, listEvents } from "@bb/db";
+import type { PromptInput, ThreadEvent } from "@bb/domain";
+import { groupHostDaemonEvents } from "@bb/host-daemon-contract";
+import { describe, expect, it, vi } from "vitest";
+import { appendClientTurnEvent } from "../../src/services/threads/thread-events.js";
+import { editThreadMessage } from "../../src/services/threads/thread-edit-message.js";
+import {
+  internalAuthHeaders,
+  reportQueuedCommandSuccess,
+  waitForQueuedCommand,
+} from "../helpers/commands.js";
+import {
+  seedEnvironment,
+  seedHostSession,
+  seedProjectWithSource,
+  seedThread,
+} from "../helpers/seed.js";
+import { withTestHarness } from "../helpers/test-app.js";
+
+const bridgePath = fileURLToPath(
+  new URL(
+    "../../../../plugins/provider-codex/src/bridge/bridge.ts",
+    import.meta.url,
+  ),
+);
+const appServerPath = fileURLToPath(
+  new URL(
+    "../../../../plugins/provider-codex/src/bridge/fake-codex-app-server.mjs",
+    import.meta.url,
+  ),
+);
+const execution = {
+  model: "test-model",
+  serviceTier: "default",
+  reasoningLevel: "medium",
+  permissionMode: "full",
+  source: "client/turn/requested",
+} as const;
+const options = {
+  ...execution,
+  permissionScope: "full",
+  providerOptions: {},
+  approvalReviewer: null,
+  permissionEscalation: null,
+} as const;
+
+describe("checkpoint identity through runtime, ingestion, and editing", () => {
+  it.each(["fork", "resume"] as const)(
+    "preserves the %s session and checkpoint through SQLite and rewind preparation",
+    async (construction) => {
+      await withTestHarness(async (harness) => {
+        const { host, session } = seedHostSession(harness.deps);
+        const { project } = seedProjectWithSource(harness.deps, {
+          hostId: host.id,
+        });
+        const environment = seedEnvironment(harness.deps, {
+          hostId: host.id,
+          projectId: project.id,
+          status: "ready",
+        });
+        const source = seedThread(harness.deps, {
+          projectId: project.id,
+          environmentId: environment.id,
+        });
+        const sibling = seedThread(harness.deps, {
+          projectId: project.id,
+          environmentId: environment.id,
+        });
+        const events: ThreadEvent[] = [];
+        const runtime = createScriptedEchoRuntime({
+          launch: { modulePath: bridgePath },
+          runtime: {
+            workspacePath: harness.config.dataDir,
+            env: {
+              BB_CODEX_BRIDGE_APP_SERVER_COMMAND: process.execPath,
+              BB_CODEX_BRIDGE_APP_SERVER_ARGS: JSON.stringify([appServerPath]),
+            },
+            onEvent: (event) => events.push(event),
+          },
+        });
+        let posted = 0;
+        async function ingest() {
+          const batch = events.slice(posted);
+          const response = await harness.app.request(
+            "/internal/session/events",
+            {
+              method: "POST",
+              headers: internalAuthHeaders(harness),
+              body: JSON.stringify({
+                sessionId: session.id,
+                eventGroups: groupHostDaemonEvents(
+                  batch.map((event) => ({ threadId: event.threadId, event })),
+                ),
+              }),
+            },
+          );
+          expect(response.status, await response.text()).toBe(200);
+          posted = events.length;
+        }
+        const args = {
+          environmentId: environment.id,
+          projectId: project.id,
+          providerId: "codex",
+          options,
+          threadId: source.id,
+        };
+        try {
+          const original =
+            construction === "fork"
+              ? await runtime.startThread({
+                  ...args,
+                  fork: { sourceProviderThreadId: "historical-source" },
+                })
+              : await runtime.resumeThread({
+                  ...args,
+                  providerThreadId: "historical-source",
+                });
+          await runtime.startThread({ ...args, threadId: sibling.id });
+          await ingest();
+          const requests: number[] = [];
+          for (const text of ["first", "second"]) {
+            const input: PromptInput[] = [{ type: "text", text, mentions: [] }];
+            const request = appendClientTurnEvent(harness.deps, {
+              type: "client/turn/requested",
+              threadId: source.id,
+              environmentId: environment.id,
+              execution,
+              initiator: "user",
+              senderThreadId: null,
+              input,
+              target: { kind: "new-turn" },
+              requestMethod: "turn/start",
+              source: "tell",
+            });
+            requests.push(request.sequence);
+            const start = events.length;
+            await runtime.runTurn({
+              threadId: source.id,
+              input,
+              options,
+              clientRequestId: request.requestId,
+            });
+            await vi.waitFor(() =>
+              expect(
+                events
+                  .slice(start)
+                  .some((event) => event.type === "turn/completed"),
+              ).toBe(true),
+            );
+            await ingest();
+          }
+          const storedCompletions = listEvents(harness.db, {
+            threadId: source.id,
+          }).filter((event) => event.type === "turn/completed");
+          const thread = getThread(harness.db, source.id);
+          if (!thread) throw new Error("Missing source thread");
+          const edit = editThreadMessage(harness.deps, {
+            environment,
+            thread,
+            payload: {
+              operationId: `edit-identity-${construction}`,
+              expectedRequestSequence: requests[1],
+              input: [{ type: "text", text: "replacement", mentions: [] }],
+            },
+          });
+          const rewind = await waitForQueuedCommand(
+            harness,
+            (queued) => queued.command.type === "thread.rewind.prepare",
+          );
+          if (rewind.command.type !== "thread.rewind.prepare")
+            throw new Error("Expected rewind preparation");
+          const prepared = await runtime.prepareThreadRewind({
+            ...args,
+            leaseId: rewind.command.leaseId,
+            sourceProviderThreadId: rewind.command.sourceProviderThreadId,
+            retainThroughProviderCheckpoint:
+              rewind.command.retainThroughProviderCheckpoint,
+          });
+          await reportQueuedCommandSuccess(harness, rewind, prepared);
+          await expect(edit).resolves.toMatchObject({ ok: true });
+          await runtime.discardThreadRewind({
+            leaseId: rewind.command.leaseId,
+          });
+          expect(
+            storedCompletions.map((event) => JSON.parse(event.data)),
+          ).toEqual([
+            expect.objectContaining({
+              providerThreadId: original.providerThreadId,
+              providerCheckpointId: "turn-fx-1",
+            }),
+            expect.objectContaining({
+              providerThreadId: original.providerThreadId,
+              providerCheckpointId: "turn-fx-2",
+            }),
+          ]);
+          expect(rewind.command).toMatchObject({
+            sourceProviderThreadId: original.providerThreadId,
+            retainThroughProviderCheckpoint: "turn-fx-1",
+          });
+        } finally {
+          await runtime.shutdown();
+        }
+      });
+    },
+    20_000,
+  );
+});

--- a/apps/server/test/threads/thread-edit-message.test.ts
+++ b/apps/server/test/threads/thread-edit-message.test.ts
@@ -1381,36 +1381,49 @@ describe("editThreadMessage", () => {
     },
   );
 
-  it("leaves the original suffix untouched when Codex cannot stage the rewind", async () => {
-    await withTestHarness(async (harness) => {
-      const { environment, thread } = seedEditableThread(harness);
-      const editPromise = editThreadMessage(harness.deps, {
-        environment,
-        thread,
-        payload: {
-          operationId: "edit-op-failure",
-          expectedRequestSequence: 7,
-          input: [{ type: "text", text: "Replacement", mentions: [] }],
-        },
-      });
-      const rejectedEdit =
-        expect(editPromise).rejects.toThrow("Codex fork failed");
-      const rewind = await waitForQueuedCommand(
-        harness,
-        (queued) => queued.command.type === "thread.rewind.prepare",
-      );
-      await reportQueuedCommandError(harness, rewind, {
-        errorCode: "provider_error",
-        errorMessage: "Codex fork failed",
-      });
+  it.each(["provider-original", "provider-other-session"])(
+    "preserves history without guessing a repair when checkpoint session %s cannot stage the rewind",
+    async (firstProviderThreadId) => {
+      await withTestHarness(async (harness) => {
+        const { environment, thread } = seedEditableThread(harness, {
+          firstProviderThreadId,
+        });
+        const originalEvents = listEvents(harness.db, { threadId: thread.id });
+        const editPromise = editThreadMessage(harness.deps, {
+          environment,
+          thread,
+          payload: {
+            operationId: "edit-op-failure",
+            expectedRequestSequence: 7,
+            input: [{ type: "text", text: "Replacement", mentions: [] }],
+          },
+        });
+        const rejectedEdit = expect(editPromise).rejects.toThrow(
+          "turn not found: checkpoint-first",
+        );
+        const rewind = await waitForQueuedCommand(
+          harness,
+          (queued) => queued.command.type === "thread.rewind.prepare",
+        );
+        await reportQueuedCommandError(harness, rewind, {
+          errorCode: "provider_error",
+          errorMessage: "turn not found: checkpoint-first",
+        });
 
-      await rejectedEdit;
-      expect(listEvents(harness.db, { threadId: thread.id })).toHaveLength(11);
-      expect(
-        listQueuedThreadCommands(harness, "thread.start", thread.id),
-      ).toHaveLength(0);
-    });
-  });
+        await rejectedEdit;
+        expect(rewind.command).toMatchObject({
+          sourceProviderThreadId: firstProviderThreadId,
+          retainThroughProviderCheckpoint: "checkpoint-first",
+        });
+        expect(listEvents(harness.db, { threadId: thread.id })).toEqual(
+          originalEvents,
+        );
+        expect(
+          listQueuedThreadCommands(harness, "thread.start", thread.id),
+        ).toHaveLength(0);
+      });
+    },
+  );
 
   it("rejects an edit on a provider that declares no session rewind", async () => {
     await withTestHarness(async (harness) => {

--- a/packages/agent-runtime/src/runtime-thread-identity.test.ts
+++ b/packages/agent-runtime/src/runtime-thread-identity.test.ts
@@ -14,7 +14,6 @@ describe("RuntimeThreadIdentityRegistry", () => {
     registry.registerThreadProvider({
       providerId: "codex",
       providerState,
-      expectsIdentityNotification: true,
       threadId: "thread-1",
     });
     registry.recordProviderThreadIdentity({
@@ -39,13 +38,11 @@ describe("RuntimeThreadIdentityRegistry", () => {
     registry.registerThreadProvider({
       providerId: "codex",
       providerState,
-      expectsIdentityNotification: false,
       threadId: "thread-1",
     });
     registry.registerThreadProvider({
       providerId: "codex",
       providerState,
-      expectsIdentityNotification: false,
       threadId: "thread-2",
     });
     registry.recordProviderThreadIdentity({
@@ -89,7 +86,6 @@ describe("RuntimeThreadIdentityRegistry", () => {
     registry.registerThreadProvider({
       providerId: "claude-code",
       providerState: singleThreadState,
-      expectsIdentityNotification: false,
       threadId: "thread-3",
     });
     expect(
@@ -129,5 +125,86 @@ describe("RuntimeThreadIdentityRegistry", () => {
       providerThreadId: "provider-thread-1",
       scope: turnScope("turn-1"),
     });
+  });
+
+  it("preserves an explicit checkpoint/session pair when the current session differs", () => {
+    const event: ThreadEvent = {
+      type: "turn/completed",
+      threadId: "provider-source",
+      providerThreadId: "provider-source",
+      providerCheckpointId: "source-checkpoint",
+      status: "completed",
+      scope: turnScope("source-turn"),
+    };
+    expect(
+      stampThreadEventScope({
+        event,
+        threadId: "source",
+        providerThreadId: "provider-fork",
+      }),
+    ).toEqual({ ...event, threadId: "source" });
+    expect(
+      stampThreadEventScope({
+        event: { ...event, providerThreadId: "" },
+        threadId: "source",
+        providerThreadId: "provider-source",
+      }),
+    ).toEqual({ ...event, threadId: "source" });
+  });
+
+  it("requires explicit ownership for identities even with one unresolved thread", () => {
+    const registry = new RuntimeThreadIdentityRegistry();
+    const providerState = registry.createProviderState({ providerId: "codex" });
+    registry.registerThreadProvider({
+      providerId: "codex",
+      providerState,
+      threadId: "source",
+    });
+    expect(
+      registry.resolveProviderIdentityThreadId({
+        providerState,
+        eventThreadId: "unknown",
+        sourceThreadId: undefined,
+      }),
+    ).toBeUndefined();
+    expect(
+      registry.resolveProviderIdentityThreadId({
+        providerState,
+        eventThreadId: "unstamped",
+        sourceThreadId: "source",
+      }),
+    ).toBe("source");
+    registry.recordProviderThreadIdentity({
+      providerState,
+      threadId: "source",
+      providerThreadId: "provider-source",
+    });
+    expect(
+      registry.resolveProviderIdentityThreadId({
+        providerState,
+        eventThreadId: "provider-source",
+        sourceThreadId: undefined,
+      }),
+    ).toBe("source");
+    registry.forgetThread({ providerState, threadId: "source" });
+    registry.registerThreadProvider({
+      providerId: "codex",
+      providerState,
+      threadId: "fork",
+    });
+    expect(
+      registry.resolveProviderIdentityThreadId({
+        providerState,
+        eventThreadId: "provider-source",
+        sourceThreadId: "source",
+      }),
+    ).toBeUndefined();
+    expect(() =>
+      registry.recordProviderThreadIdentity({
+        providerState,
+        threadId: "source",
+        providerThreadId: "provider-source",
+      }),
+    ).toThrow("No provider associated");
   });
 });

--- a/packages/agent-runtime/src/runtime-thread-identity.ts
+++ b/packages/agent-runtime/src/runtime-thread-identity.ts
@@ -2,7 +2,6 @@ import type { ThreadEvent } from "@bb/domain";
 import type { AgentRuntimeProviderSession } from "./types.js";
 
 export interface RuntimeProviderIdentityState {
-  pendingIdentityThreadIds: string[];
   providerId: string;
   threadIds: Set<string>;
 }
@@ -14,7 +13,6 @@ interface CreateRuntimeProviderIdentityStateArgs {
 interface RegisterThreadProviderArgs {
   providerId: string;
   providerState: RuntimeProviderIdentityState;
-  expectsIdentityNotification: boolean;
   threadId: string;
 }
 
@@ -54,7 +52,6 @@ export class RuntimeThreadIdentityRegistry {
     args: CreateRuntimeProviderIdentityStateArgs,
   ): RuntimeProviderIdentityState {
     return {
-      pendingIdentityThreadIds: [],
       providerId: args.providerId,
       threadIds: new Set(),
     };
@@ -63,9 +60,6 @@ export class RuntimeThreadIdentityRegistry {
   registerThreadProvider(args: RegisterThreadProviderArgs): void {
     this.threadToProvider.set(args.threadId, args.providerId);
     args.providerState.threadIds.add(args.threadId);
-    if (args.expectsIdentityNotification) {
-      args.providerState.pendingIdentityThreadIds.push(args.threadId);
-    }
   }
 
   resolveProviderForThread(threadId: string): string {
@@ -90,6 +84,9 @@ export class RuntimeThreadIdentityRegistry {
   }
 
   recordProviderThreadIdentity(args: RecordProviderThreadIdentityArgs): void {
+    if (!args.providerState.threadIds.has(args.threadId)) {
+      throw new Error(`No provider associated with thread "${args.threadId}"`);
+    }
     this.threadToProviderThread.set(args.threadId, args.providerThreadId);
   }
 
@@ -113,7 +110,7 @@ export class RuntimeThreadIdentityRegistry {
     return undefined;
   }
 
-  resolveProviderEventThreadId(
+  resolveProviderIdentityThreadId(
     args: ResolveProviderEventThreadIdArgs,
   ): string | undefined {
     if (
@@ -143,6 +140,17 @@ export class RuntimeThreadIdentityRegistry {
       }
     }
 
+    return undefined;
+  }
+
+  resolveProviderEventThreadId(
+    args: ResolveProviderEventThreadIdArgs,
+  ): string | undefined {
+    const explicitThreadId = this.resolveProviderIdentityThreadId(args);
+    if (explicitThreadId !== undefined) {
+      return explicitThreadId;
+    }
+
     if (
       args.providerState.threadIds.size === 1 &&
       !this.namesForeignThread(args.providerState, args.eventThreadId) &&
@@ -167,12 +175,6 @@ export class RuntimeThreadIdentityRegistry {
     );
   }
 
-  resolvePendingProviderThreadIdentity(
-    providerState: RuntimeProviderIdentityState,
-  ): string | undefined {
-    return providerState.pendingIdentityThreadIds.shift();
-  }
-
   clearThread(threadId: string): void {
     this.threadToProvider.delete(threadId);
     this.threadToProviderThread.delete(threadId);
@@ -180,10 +182,6 @@ export class RuntimeThreadIdentityRegistry {
 
   forgetThread(args: ForgetThreadArgs): void {
     args.providerState.threadIds.delete(args.threadId);
-    args.providerState.pendingIdentityThreadIds =
-      args.providerState.pendingIdentityThreadIds.filter(
-        (pendingThreadId) => pendingThreadId !== args.threadId,
-      );
     this.clearThread(args.threadId);
   }
 }
@@ -191,7 +189,11 @@ export class RuntimeThreadIdentityRegistry {
 export function stampThreadEventScope(
   args: StampThreadEventScopeArgs,
 ): ThreadEvent {
-  if ("providerThreadId" in args.event && args.providerThreadId) {
+  if (
+    "providerThreadId" in args.event &&
+    !args.event.providerThreadId &&
+    args.providerThreadId
+  ) {
     return {
       ...args.event,
       providerThreadId: args.providerThreadId,

--- a/packages/agent-runtime/src/runtime.codex-topology.test.ts
+++ b/packages/agent-runtime/src/runtime.codex-topology.test.ts
@@ -11,6 +11,7 @@ import {
   fullRuntimeOptions,
   waitForRuntimeState,
   waitForThreadAgentMessageText,
+  waitForThreadTurnCompleted,
   withBridgeLaunch,
   type LaunchBoundAgentRuntime,
 } from "./test/runtime-test-harness.js";
@@ -149,6 +150,41 @@ describe("codex process topology", () => {
     });
     return providerThreadId;
   }
+
+  it("keeps a fork checkpoint paired with its session after another thread starts", async () => {
+    const { runtime, events } = createCodexTopologyRuntime();
+    const source = await runtime.startThread({
+      environmentId: "env-1",
+      providerId: "codex",
+      threadId: "source",
+      projectId: "p1",
+      options: fullRuntimeOptions,
+      fork: { sourceProviderThreadId: "historical-session" },
+    });
+    const sibling = await startCodexThread(runtime, "sibling");
+    await runtime.runTurn({
+      clientRequestId: "creq_cdxtpgy328",
+      threadId: "source",
+      input: [promptTextInput({ text: "continue source" })],
+      options: fullRuntimeOptions,
+    });
+    await waitForThreadTurnCompleted({
+      events,
+      providerId: "codex",
+      runtime,
+      threadId: "source",
+    });
+    expect(source.providerThreadId).not.toBe(sibling);
+    expect(
+      events.find((event) => event.type === "turn/completed"),
+    ).toMatchObject({
+      providerThreadId: source.providerThreadId,
+      providerCheckpointId: "turn-fx-1",
+    });
+    expect(runtime.getProviderSession("source")?.providerThreadId).toBe(
+      source.providerThreadId,
+    );
+  });
 
   it("runs N codex threads on one bridge process with one app-server child each, and reaps the children on stop, archive, and bridge retirement", async () => {
     const topology = createCodexTopologyRuntime();

--- a/packages/agent-runtime/src/runtime.identity-ordering.test.ts
+++ b/packages/agent-runtime/src/runtime.identity-ordering.test.ts
@@ -1,0 +1,221 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ThreadEvent } from "@bb/domain";
+import { describe, expect, it } from "vitest";
+import {
+  createScriptedEchoRuntime,
+  fullRuntimeOptions,
+  waitForThreadTurnCompleted,
+} from "./test/runtime-test-harness.js";
+import { promptTextInput } from "./test/prompt-input.js";
+
+describe("runtime identity ordering", () => {
+  it("preserves resolved fork sessions when native identity deltas arrive in reverse registration order", async () => {
+    const workspacePath = mkdtempSync(join(tmpdir(), "bb-identity-reverse-"));
+    const events: ThreadEvent[] = [];
+    const runtime = createScriptedEchoRuntime({
+      runtime: { workspacePath, onEvent: (event) => events.push(event) },
+      launch: {
+        scripted: {
+          identityNotificationsBeforeTurn: [
+            { threadId: "second", providerThreadId: "prov-2", asDelta: true },
+            { threadId: "first", providerThreadId: "prov-1", asDelta: true },
+          ],
+        },
+      },
+    });
+    try {
+      for (const threadId of ["first", "second"]) {
+        await runtime.startThread({
+          environmentId: "env",
+          projectId: "project",
+          providerId: "fake",
+          options: fullRuntimeOptions,
+          threadId,
+          fork: { sourceProviderThreadId: "historical-session" },
+        });
+      }
+      await runtime.runTurn({
+        threadId: "second",
+        clientRequestId: "creq_222222222e",
+        input: [promptTextInput({ text: "hello" })],
+        options: fullRuntimeOptions,
+      });
+      await waitForThreadTurnCompleted({ events, runtime, threadId: "second" });
+      expect(runtime.getProviderSession("first")?.providerThreadId).toBe(
+        "prov-1",
+      );
+      expect(runtime.getProviderSession("second")?.providerThreadId).toBe(
+        "prov-2",
+      );
+      expect(
+        events.find((event) => event.type === "turn/completed"),
+      ).toMatchObject({ threadId: "second", providerThreadId: "prov-2" });
+    } finally {
+      await runtime.shutdown();
+      rmSync(workspacePath, { recursive: true, force: true });
+    }
+  });
+
+  it.each([false, true])(
+    "preserves source/fork ownership with identityAfterResponse=%s and duplicate or unknown notifications",
+    async (identityAfterResponse) => {
+      const workspacePath = mkdtempSync(
+        join(tmpdir(), "bb-identity-ordering-"),
+      );
+      const events: ThreadEvent[] = [];
+      const runtime = createScriptedEchoRuntime({
+        runtime: { workspacePath, onEvent: (event) => events.push(event) },
+        launch: {
+          scripted: {
+            identityAfterResponse,
+            identityNotificationsBeforeTurn: [
+              { threadId: "prov-2", providerThreadId: "prov-2" },
+              { threadId: "unknown", providerThreadId: "foreign-session" },
+              { threadId: "fork", providerThreadId: "prov-2" },
+            ],
+          },
+        },
+      });
+      const args = {
+        environmentId: "env",
+        projectId: "project",
+        providerId: "fake",
+        options: fullRuntimeOptions,
+      };
+      try {
+        const source = await runtime.startThread({
+          ...args,
+          threadId: "source",
+        });
+        const fork = await runtime.startThread({
+          ...args,
+          threadId: "fork",
+          fork: { sourceProviderThreadId: source.providerThreadId },
+        });
+        for (const threadId of ["source", "fork"]) {
+          await runtime.runTurn({
+            threadId,
+            clientRequestId:
+              threadId === "source" ? "creq_222222222a" : "creq_222222222b",
+            input: [promptTextInput({ text: "hello" })],
+            options: fullRuntimeOptions,
+          });
+          await waitForThreadTurnCompleted({ events, runtime, threadId });
+        }
+        expect(runtime.getProviderSession("source")?.providerThreadId).toBe(
+          source.providerThreadId,
+        );
+        expect(runtime.getProviderSession("fork")?.providerThreadId).toBe(
+          fork.providerThreadId,
+        );
+        expect(
+          events.filter((event) => event.type === "turn/completed"),
+        ).toMatchObject([
+          { threadId: "source", providerThreadId: source.providerThreadId },
+          { threadId: "fork", providerThreadId: fork.providerThreadId },
+        ]);
+        expect(
+          events.some(
+            (event) =>
+              "providerThreadId" in event &&
+              event.providerThreadId === "foreign-session",
+          ),
+        ).toBe(false);
+      } finally {
+        await runtime.shutdown();
+        rmSync(workspacePath, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it("does not assign a retired thread's late identity to the only remaining thread", async () => {
+    const workspacePath = mkdtempSync(join(tmpdir(), "bb-identity-late-"));
+    const events: ThreadEvent[] = [];
+    const runtime = createScriptedEchoRuntime({
+      runtime: { workspacePath, onEvent: (event) => events.push(event) },
+      launch: {
+        scripted: {
+          identityNotificationsBeforeTurn: [
+            { threadId: "retired", providerThreadId: "prov-1" },
+          ],
+        },
+      },
+    });
+    const args = {
+      environmentId: "env",
+      projectId: "project",
+      providerId: "fake",
+      options: fullRuntimeOptions,
+    };
+    try {
+      await runtime.startThread({ ...args, threadId: "retired" });
+      const remaining = await runtime.startThread({
+        ...args,
+        threadId: "remaining",
+      });
+      await runtime.stopThread({ threadId: "retired" });
+      const start = events.length;
+      await runtime.runTurn({
+        threadId: "remaining",
+        clientRequestId: "creq_222222222c",
+        input: [promptTextInput({ text: "hello" })],
+        options: fullRuntimeOptions,
+      });
+      await waitForThreadTurnCompleted({
+        events,
+        runtime,
+        threadId: "remaining",
+      });
+      expect(
+        events.slice(start).filter((event) => event.type === "thread/identity"),
+      ).toEqual([]);
+      expect(runtime.getProviderSession("remaining")?.providerThreadId).toBe(
+        remaining.providerThreadId,
+      );
+    } finally {
+      await runtime.shutdown();
+      rmSync(workspacePath, { recursive: true, force: true });
+    }
+  });
+
+  it("stamps a completion before applying the following scoped replacement identity in the same batch", async () => {
+    const workspacePath = mkdtempSync(join(tmpdir(), "bb-identity-batch-"));
+    const events: ThreadEvent[] = [];
+    const runtime = createScriptedEchoRuntime({
+      runtime: { workspacePath, onEvent: (event) => events.push(event) },
+      launch: { scripted: { completionIdentity: "replacement-session" } },
+    });
+    try {
+      const original = await runtime.startThread({
+        environmentId: "env",
+        projectId: "project",
+        providerId: "fake",
+        options: fullRuntimeOptions,
+        threadId: "source",
+      });
+      await runtime.runTurn({
+        threadId: "source",
+        clientRequestId: "creq_222222222d",
+        input: [promptTextInput({ text: "hello" })],
+        options: fullRuntimeOptions,
+      });
+      await waitForThreadTurnCompleted({ events, runtime, threadId: "source" });
+      expect(
+        events.find((event) => event.type === "turn/completed"),
+      ).toMatchObject({ providerThreadId: original.providerThreadId });
+      expect(events.at(-1)).toMatchObject({
+        type: "thread/identity",
+        providerThreadId: "replacement-session",
+        threadId: "source",
+      });
+      expect(runtime.getProviderSession("source")?.providerThreadId).toBe(
+        "replacement-session",
+      );
+    } finally {
+      await runtime.shutdown();
+      rmSync(workspacePath, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/agent-runtime/src/runtime.ts
+++ b/packages/agent-runtime/src/runtime.ts
@@ -1181,39 +1181,15 @@ export function createAgentRuntime(options: AgentRuntimeOptions): AgentRuntime {
 
   function emitTranslatedEvents(args: EmitTranslatedEventsArgs): void {
     for (const event of args.events) {
-      if (event.type !== "thread/identity" || !event.providerThreadId) {
-        continue;
-      }
-
-      if (args.proc.identity.threadIds.has(event.threadId)) {
-        recordProviderThreadIdentity(
-          args.proc,
-          event.threadId,
-          event.providerThreadId,
-        );
-        continue;
-      }
-
-      const bbThreadId =
-        threadIdentityRegistry.resolvePendingProviderThreadIdentity(
-          args.proc.identity,
-        );
-      if (bbThreadId) {
-        recordProviderThreadIdentity(
-          args.proc,
-          bbThreadId,
-          event.providerThreadId,
-        );
-      }
-    }
-
-    for (const event of args.events) {
+      const scope = {
+        eventThreadId: event.threadId,
+        providerState: args.proc.identity,
+        sourceThreadId: args.sourceThreadId,
+      };
       const resolvedBbThreadId =
-        threadIdentityRegistry.resolveProviderEventThreadId({
-          eventThreadId: event.threadId,
-          providerState: args.proc.identity,
-          sourceThreadId: args.sourceThreadId,
-        });
+        event.type === "thread/identity"
+          ? threadIdentityRegistry.resolveProviderIdentityThreadId(scope)
+          : threadIdentityRegistry.resolveProviderEventThreadId(scope);
 
       if (!resolvedBbThreadId) {
         options.onStderr?.(
@@ -1225,6 +1201,13 @@ export function createAgentRuntime(options: AgentRuntimeOptions): AgentRuntime {
 
       if (suppressedThreadEventIds.has(targetThreadId)) {
         continue;
+      }
+      if (event.type === "thread/identity" && event.providerThreadId) {
+        recordProviderThreadIdentity(
+          args.proc,
+          targetThreadId,
+          event.providerThreadId,
+        );
       }
       const stampedEvent = stampThreadEventScope({
         event,
@@ -1506,7 +1489,6 @@ export function createAgentRuntime(options: AgentRuntimeOptions): AgentRuntime {
           threadIdentityRegistry.registerThreadProvider({
             providerId,
             providerState: proc.identity,
-            expectsIdentityNotification: true,
             threadId,
           });
           setThreadRuntimeConfig(threadId, {
@@ -1671,7 +1653,6 @@ export function createAgentRuntime(options: AgentRuntimeOptions): AgentRuntime {
           threadIdentityRegistry.registerThreadProvider({
             providerId,
             providerState: proc.identity,
-            expectsIdentityNotification: true,
             threadId: stagingThreadId,
           });
           let retainedForDiscard = false;
@@ -1831,7 +1812,6 @@ export function createAgentRuntime(options: AgentRuntimeOptions): AgentRuntime {
           threadIdentityRegistry.registerThreadProvider({
             providerId,
             providerState: proc.identity,
-            expectsIdentityNotification: providerThreadId === undefined,
             threadId,
           });
           setThreadRuntimeConfig(threadId, {

--- a/packages/agent-runtime/src/test/runtime-test-harness.ts
+++ b/packages/agent-runtime/src/test/runtime-test-harness.ts
@@ -45,6 +45,13 @@ export const scriptedEchoBridgeModulePath = join(
 export interface ScriptedEchoLaunchScript {
   startDelayMs?: number;
   answerStartWithoutIdentity?: boolean;
+  identityAfterResponse?: boolean;
+  identityNotificationsBeforeTurn?: {
+    threadId: string;
+    providerThreadId: string;
+    asDelta?: boolean;
+  }[];
+  completionIdentity?: string;
   archivedSession?: boolean;
   unarchiveFails?: boolean;
   exitAfterArchivedError?: boolean;

--- a/packages/host-daemon-contract/src/protocol.ts
+++ b/packages/host-daemon-contract/src/protocol.ts
@@ -1,3 +1,3 @@
-export const HOST_DAEMON_PROTOCOL_VERSION = 199 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 200 as const;
 
 export const HOST_ARTIFACT_MAX_BYTES = 256 * 1024 * 1024;

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -1000,7 +1000,7 @@ const CONTRIBUTED_ENV = [
 
 describe("host-daemon command schemas", () => {
   it("uses the current host-daemon protocol version", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(199);
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(200);
     expect(HOST_ARTIFACT_MAX_BYTES).toBe(256 * 1024 * 1024);
   });
 

--- a/tests/scripted-echo-provider/src/provider-bridge.ts
+++ b/tests/scripted-echo-provider/src/provider-bridge.ts
@@ -54,6 +54,17 @@ export const scriptedEchoOptionsSchema = z
     startDelayMs: z.number().int().nonnegative().optional(),
     turnStartResponseDelayMs: z.number().int().nonnegative().optional(),
     answerStartWithoutIdentity: z.boolean().optional(),
+    identityAfterResponse: z.boolean().optional(),
+    identityNotificationsBeforeTurn: z
+      .array(
+        z.object({
+          threadId: z.string().min(1),
+          providerThreadId: z.string().min(1),
+          asDelta: z.boolean().optional(),
+        }),
+      )
+      .optional(),
+    completionIdentity: z.string().min(1).optional(),
     archivedSession: z.boolean().optional(),
     unarchiveFails: z.boolean().optional(),
     exitAfterArchivedError: z.boolean().optional(),
@@ -434,6 +445,13 @@ function completeTurn(
     status,
     providerTurnId: turn.providerTurnId,
   });
+  if (session.options.completionIdentity !== undefined) {
+    session.providerThreadId = session.options.completionIdentity;
+    deltas.push({
+      kind: "thread.identity",
+      providerThreadId: session.providerThreadId,
+    });
+  }
   emitDeltas(session.threadId, deltas);
 }
 
@@ -505,6 +523,22 @@ function beginTurn(args: {
   clientRequestId?: ClientTurnRequestId;
 }): void {
   const { session } = args;
+  for (const identity of session.options.identityNotificationsBeforeTurn ??
+    []) {
+    if (identity.asDelta === true) {
+      emitDeltas(identity.threadId, [
+        {
+          kind: "thread.identity",
+          providerThreadId: identity.providerThreadId,
+        },
+      ]);
+    } else {
+      notify(BRIDGE_NOTIFICATION_METHODS.threadIdentity, {
+        threadId: identity.threadId,
+        providerThreadId: identity.providerThreadId,
+      });
+    }
+  }
   clearActiveTurn(session);
   const plan = parseTurnPlan(promptText(args.input));
   if (plan.failure !== null && plan.failure.beforeTurn) {
@@ -780,15 +814,21 @@ function openSession(args: {
     options: args.options,
   };
   sessions.set(args.threadId, session);
-  notify(BRIDGE_NOTIFICATION_METHODS.threadIdentity, {
-    threadId: args.threadId,
-    providerThreadId: args.providerThreadId,
-    ...(args.options.sessionRestorable === undefined
-      ? {}
-      : { sessionRestorable: args.options.sessionRestorable }),
-  });
+  if (args.options.identityAfterResponse !== true) {
+    notifySessionIdentity(session);
+  }
   emitDeltas(args.threadId, [{ kind: "session.reset" }]);
   return session;
+}
+
+function notifySessionIdentity(session: Session): void {
+  notify(BRIDGE_NOTIFICATION_METHODS.threadIdentity, {
+    threadId: session.threadId,
+    providerThreadId: session.providerThreadId,
+    ...(session.options.sessionRestorable === undefined
+      ? {}
+      : { sessionRestorable: session.options.sessionRestorable }),
+  });
 }
 
 function mintProviderThreadId(options: ScriptedEchoOptions): string {
@@ -961,6 +1001,9 @@ const handlers: Record<string, RequestHandler> = {
       });
       logProcessStep(`thread/start:${process.pid}:${parsed.data.threadId}`);
       io.sendResult(id, identityResult(session));
+      if (session.options.identityAfterResponse === true) {
+        notifySessionIdentity(session);
+      }
       if (parsed.data.input !== undefined && parsed.data.input.length > 0) {
         beginTurn({ session, input: parsed.data.input });
       }
@@ -991,6 +1034,9 @@ const handlers: Record<string, RequestHandler> = {
         `thread/resume:${process.pid}:${parsed.data.threadId}:${parsed.data.providerThreadId}`,
       );
       io.sendResult(id, identityResult(session));
+      if (session.options.identityAfterResponse === true) {
+        notifySessionIdentity(session);
+      }
     });
   },
 
@@ -1011,6 +1057,9 @@ const handlers: Record<string, RequestHandler> = {
         options,
       });
       io.sendResult(id, identityResult(session));
+      if (session.options.identityAfterResponse === true) {
+        notifySessionIdentity(session);
+      }
     });
   },
 


### PR DESCRIPTION
## Human comments

## What was wrong

When Codex forks started concurrently, BB could save a completed turn from one conversation with another conversation's provider session ID. Editing a later message then failed with `HTTP 502: turn not found`. The shared runtime ignored an identity delta's explicit BB thread owner and assigned it using a FIFO whose entries survived construction-result identity resolution. It also applied all identities in a batch before stamping earlier events and overwrote explicit event session IDs. This is a core runtime bookkeeping defect; native Codex notifications in the live reproduction named the correct sessions. See #3281 and the [original incident report](https://get-bb.github.io/reports/issues/3281.html).

## What changed

- Remove pending-identity FIFO assignment. Resolve identities through explicit thread ownership or an existing provider mapping; unknown and retired identities cannot claim another thread.
- Process identity updates and event stamping in order, filling only missing session IDs so explicit checkpoint/session pairs remain intact. Preserve legitimate scoped session replacement and late/duplicate notifications.
- Add runtime, actual Codex bridge, and server ingestion/edit regressions using real in-memory SQLite, including reverse-order native identity deltas and failed-rewind history preservation.
- Bump `HOST_DAEMON_PROTOCOL_VERSION` from 199 to 200 because daemon-emitted identity/checkpoint semantics change. No new wire fields, CLI/UI surface, or data migration.

Existing corrupt history is intentionally not rewritten: previous sessions and forks may legitimately share checkpoints, so a generic reassignment could lose history or replay ambiguous work. This fixes identity ownership; it does not implement the separate native-rewind or child-correlation proposals.

## How you verified

**Real authenticated Codex 0.153.3, `gpt-5.6-luna`, low reasoning:** launched an isolated worktree server with `pnpm start:worktree`, scratch BB data and `CODEX_HOME`, then drove it through the source CLI. Three concurrent forks plus one ordinary start produced a mismatched SQLite checkpoint on the original runtime. Native completion records and scratch rollout membership independently confirmed the correct owner. Send → Stop → edit returned native `turn not found`, preserving all prior events. After applying the patch, all four fresh concurrent conversations passed send → Stop → edit, and a separate resume after daemon restart passed. Retrying the already-corrupt scratch thread still failed without altering its history. The exact timing of the reporter's private incident remains unverified.

**Browser follow-up:** used dev-browser on the same isolated patched server to edit the latest message in a fork. Luna low returned the replacement response; it persisted after reload, the thread returned to idle, and the native completion/session pair matched SQLite. Before/after screenshots were retained locally.

**Fail before / pass after:** native bridge fork/sibling checkpoint pairing; runtime → authenticated server ingestion → SQLite → edit consumption; duplicate/late identity handling, explicit pair preservation, same-batch ordering, and reverse registration-order native deltas.

**Passing checks:** 1,545 tests across selected runtime, server edit/fork/stop, Codex/Claude/Pi/ACP provider, host contract, and scripted-provider suites. Turbo typecheck and server/daemon build, changed-file formatting, and `git diff --check` passed. Representative commands:

```sh
pnpm exec turbo run test --filter=@bb/agent-runtime
pnpm exec turbo run test --filter=@bb/server -- thread-checkpoint-identity.test.ts thread-edit-message.test.ts thread-fork thread-stop
pnpm exec turbo run typecheck --filter=@bb/agent-runtime --filter=@bb/server --filter=@bb/host-daemon --filter=@bb/host-daemon-contract --filter=bb-plugin-scripted-echo-provider
pnpm exec turbo run build --filter=@bb/host-daemon --filter=@bb/server
```

Fixes #3281

> AGENT GENERATED
