### PR TITLE
Approve samanthar0se to open pull requests

### DIFF
--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -45,6 +45,7 @@ ratulsarna
 Roystbeef
 ryanbbrown
 salemsayed
+samanthar0se
 SawyerHood
 sholub-dev
 smsunarto


### PR DESCRIPTION
## Human comments

## What was wrong

The PR gate did not recognize `samanthar0se` as an approved contributor.

## What changed

Added `samanthar0se` to `.github/APPROVED_CONTRIBUTORS` so the PR gate permits their pull requests.

## How you verified

Verified exactly one matching allow-list entry and ran `git diff --check`. EAP codename scan passed for the working tree, HEAD, and push range. CI and SlopCop review skipped at the user’s request.

> AGENT GENERATED
