### PR TITLE
Show mobile queued message actions inline

### DIFF
--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.test.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.test.tsx
@@ -520,6 +520,55 @@ describe("QueuedMessagesList", () => {
     expect(firstActions.getAttribute("aria-expanded")).toBe("false");
   });
 
+  it.each([
+    { sendDisabled: false, expectedAction: "Send queued message 1 now" },
+    { sendDisabled: true, expectedAction: "Edit queued message 1" },
+  ])(
+    "focuses $expectedAction after keyboard expansion",
+    ({ sendDisabled, expectedAction }) => {
+      const { getByRole } = render(
+        <QueuedMessagesList
+          queuedMessages={[makeQueuedMessage("q_one", "First queued message")]}
+          sendDisabled={sendDisabled}
+          actionDisabled={false}
+          processingMessageId={null}
+          processingAction={null}
+          onSend={noop}
+          onReorder={noop}
+          onSetGroupBoundary={noop}
+          onEdit={noop}
+          onDelete={noop}
+        />,
+      );
+      const trigger = getByRole("button", {
+        name: "Queued message 1 actions",
+      });
+
+      focusWithKeyboard(trigger);
+      fireEvent.click(trigger, { detail: 0 });
+
+      expect(document.activeElement).toBe(
+        getByRole("button", { name: expectedAction }),
+      );
+    },
+  );
+
+  it("does not move focus into actions after pointer expansion", () => {
+    const { getByRole } = renderQueuedMessages([
+      makeQueuedMessage("q_one", "First queued message"),
+    ]);
+    const reorderButton = getByRole("button", {
+      name: "Reorder queued message 1",
+    });
+    focusWithKeyboard(reorderButton);
+
+    fireEvent.click(getByRole("button", { name: "Queued message 1 actions" }), {
+      detail: 1,
+    });
+
+    expect(document.activeElement).toBe(reorderButton);
+  });
+
   it("replaces the edited row with the real inline composer", () => {
     const onDismiss = vi.fn();
     const queuedMessages = [

--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.test.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.test.tsx
@@ -443,7 +443,7 @@ describe("QueuedMessagesList", () => {
     ).toBe("collapsed");
   });
 
-  it("uses labeled hover-revealed icon actions on desktop and an overflow menu on mobile widths", async () => {
+  it("uses labeled inline icon actions with tooltips", async () => {
     const { container, findByRole, getByRole, queryByRole } =
       renderQueuedMessages([
         makeQueuedMessage("q_one", "First queued message"),
@@ -486,6 +486,38 @@ describe("QueuedMessagesList", () => {
         expect(queryByRole("tooltip")).toBeNull();
       });
     }
+  });
+
+  it("expands one row's actions inline and resets them outside the queue", () => {
+    const { getByRole, getByText, queryByRole } = renderQueuedMessages([
+      makeQueuedMessage("q_one", "First queued message"),
+      makeQueuedMessage("q_two", "Second queued message"),
+    ]);
+    const firstActions = getByRole("button", {
+      name: "Queued message 1 actions",
+    });
+    const secondActions = getByRole("button", {
+      name: "Queued message 2 actions",
+    });
+
+    fireEvent.click(firstActions);
+    expect(firstActions.getAttribute("aria-expanded")).toBe("true");
+    expect(queryByRole("menu")).toBeNull();
+    expect(queryByRole("dialog")).toBeNull();
+
+    fireEvent.pointerDown(getByText("Second queued message"));
+    expect(firstActions.getAttribute("aria-expanded")).toBe("true");
+    fireEvent.click(secondActions);
+    expect(firstActions.getAttribute("aria-expanded")).toBe("false");
+    expect(secondActions.getAttribute("aria-expanded")).toBe("true");
+
+    fireEvent.pointerDown(document.body);
+    expect(secondActions.getAttribute("aria-expanded")).toBe("false");
+
+    fireEvent.click(firstActions);
+    fireEvent.click(getByRole("button", { name: "Collapse queued messages" }));
+    fireEvent.click(getByRole("button", { name: "Show queued messages" }));
+    expect(firstActions.getAttribute("aria-expanded")).toBe("false");
   });
 
   it("replaces the edited row with the real inline composer", () => {

--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
@@ -55,13 +55,6 @@ import type {
   ThreadQueuedMessage,
 } from "@bb/domain";
 import { Button } from "@bb/shared-ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@bb/shared-ui/dropdown-menu";
 import { Icon } from "@bb/shared-ui/icon";
 import {
   PROMPT_STACK_EDGE_CARET_BUTTON_WIDTH_CLASS,
@@ -161,6 +154,8 @@ interface QueuedMessageRowProps {
   sendAction: QueuedMessageSendAction;
   sendDisabled: boolean;
   actionDisabled: boolean;
+  mobileActionsExpanded: boolean;
+  onExpandMobileActions: (id: string) => void;
   onSend: (id: string) => void;
   onEdit: (request: QueuedMessageEditRequest) => void;
   onDelete: (id: string) => void;
@@ -756,6 +751,8 @@ const QueuedMessageRow = memo(function QueuedMessageRow({
   sendAction,
   sendDisabled,
   actionDisabled,
+  mobileActionsExpanded,
+  onExpandMobileActions,
   onSend,
   onEdit,
   onDelete,
@@ -926,7 +923,10 @@ const QueuedMessageRow = memo(function QueuedMessageRow({
                 data-queued-message-actions=""
                 className={cn(
                   QUEUED_MESSAGE_ACTION_TAKEOVER_CLASS,
-                  "pointer-events-none absolute right-2.5 top-1/2 hidden -translate-y-1/2 items-center gap-0.5 rounded-md opacity-0 transition-opacity duration-[120ms] ease-out md:flex",
+                  "pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 items-center gap-0.5 rounded-md opacity-0 transition-opacity duration-[120ms] ease-out md:flex",
+                  mobileActionsExpanded
+                    ? "flex max-md:pointer-events-auto max-md:opacity-100"
+                    : "hidden",
                   "group-hover/dispatch-row:pointer-events-auto group-hover/dispatch-row:opacity-100",
                   "group-focus-within/dispatch-row:pointer-events-auto group-focus-within/dispatch-row:opacity-100",
                 )}
@@ -999,60 +999,26 @@ const QueuedMessageRow = memo(function QueuedMessageRow({
                 </Tooltip>
               </div>
             </TooltipProvider>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  type="button"
-                  size="icon"
-                  variant="ghost"
-                  className={cn(
-                    QUEUED_MESSAGE_ACTION_TAKEOVER_CLASS,
-                    "pointer-events-none absolute right-2.5 top-1/2 shrink-0 -translate-y-1/2 text-muted-foreground opacity-0 transition-opacity duration-[120ms] ease-out md:hidden",
-                    "group-hover/dispatch-row:pointer-events-auto group-hover/dispatch-row:opacity-100",
-                    "group-focus-within/dispatch-row:pointer-events-auto group-focus-within/dispatch-row:opacity-100",
-                    "data-[state=open]:pointer-events-auto data-[state=open]:opacity-100",
-                    "[@media(hover:none)]:pointer-events-auto [@media(hover:none)]:opacity-100",
-                    compact ? "size-7" : "size-8",
-                  )}
-                  disabled={actionDisabled}
-                  aria-label={`Queued message ${index + 1} actions`}
-                >
-                  <Icon name="MoreHorizontal" className="size-4" aria-hidden />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="min-w-[7rem]">
-                {sendAllowed ? (
-                  <DropdownMenuItem
-                    disabled={sendDisabled}
-                    onSelect={() => onSend(queuedMessage.id)}
-                  >
-                    <Icon name="Sent" aria-hidden />
-                    {sendLabel}
-                  </DropdownMenuItem>
-                ) : null}
-                {queuedMessage.editable ? (
-                  <DropdownMenuItem
-                    onSelect={() =>
-                      onEdit({
-                        queuedMessageId: queuedMessage.id,
-                        queuedMessageIndex: index,
-                      })
-                    }
-                  >
-                    <Icon name="Edit" aria-hidden />
-                    Edit
-                  </DropdownMenuItem>
-                ) : null}
-                <DropdownMenuSeparator />
-                <DropdownMenuItem
-                  variant="destructive"
-                  onSelect={() => onDelete(queuedMessage.id)}
-                >
-                  <Icon name="Trash2" aria-hidden />
-                  Delete
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
+            <Button
+              type="button"
+              size="icon"
+              variant="ghost"
+              className={cn(
+                QUEUED_MESSAGE_ACTION_TAKEOVER_CLASS,
+                "pointer-events-none absolute right-2.5 top-1/2 shrink-0 -translate-y-1/2 text-muted-foreground opacity-0 transition-opacity duration-[120ms] ease-out md:hidden",
+                "group-hover/dispatch-row:pointer-events-auto group-hover/dispatch-row:opacity-100",
+                "group-focus-within/dispatch-row:pointer-events-auto group-focus-within/dispatch-row:opacity-100",
+                "[@media(hover:none)]:pointer-events-auto [@media(hover:none)]:opacity-100",
+                compact ? "size-7" : "size-8",
+                mobileActionsExpanded && "hidden",
+              )}
+              disabled={actionDisabled}
+              aria-label={`Queued message ${index + 1} actions`}
+              aria-expanded={mobileActionsExpanded}
+              onClick={() => onExpandMobileActions(queuedMessage.id)}
+            >
+              <Icon name="MoreHorizontal" className="size-4" aria-hidden />
+            </Button>
           </>
         )}
       </div>
@@ -1223,6 +1189,9 @@ export function QueuedMessagesList({
   const [mode, setMode] = useState<QueueSurfaceMode>(
     queuedMessages.length > 0 ? "drawer" : "collapsed",
   );
+  const [expandedMobileActionsId, setExpandedMobileActionsId] = useState<
+    string | null
+  >(null);
   const [surfaceDragging, setSurfaceDragging] = useState(false);
   const [surfaceDragOffset, setSurfaceDragOffset] = useState(0);
   const [inlineEditorMaxHeight, setInlineEditorMaxHeight] = useState<
@@ -1241,6 +1210,22 @@ export function QueuedMessagesList({
   const wasInlineEditingRef = useRef(false);
   const inlineEditorDismissModeRef = useRef<QueueSurfaceMode | null>(null);
   const previousMessageCountRef = useRef(queuedMessages.length);
+  useEffect(() => {
+    if (expandedMobileActionsId === null) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (
+        event.target instanceof Node &&
+        !surfaceRef.current?.contains(event.target)
+      ) {
+        setExpandedMobileActionsId(null);
+      }
+    };
+    document.addEventListener("pointerdown", handlePointerDown, true);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown, true);
+    };
+  }, [expandedMobileActionsId]);
   const {
     aboveOverflow,
     belowOverflow,
@@ -1547,6 +1532,7 @@ export function QueuedMessagesList({
     surfaceDragOffsetRef.current = 0;
   }, [inlineEditor]);
   const collapseDrawer = useCallback(() => {
+    setExpandedMobileActionsId(null);
     setMode("collapsed");
     inlineEditorDismissModeRef.current = "collapsed";
     inlineEditor?.onDismiss();
@@ -1560,6 +1546,7 @@ export function QueuedMessagesList({
   }, []);
   const handleEdit = useCallback(
     (request: QueuedMessageEditRequest) => {
+      setExpandedMobileActionsId(null);
       openWorkspace();
       onEdit(request);
     },
@@ -1710,6 +1697,8 @@ export function QueuedMessagesList({
           sendAction={sendAction}
           sendDisabled={sendDisabled}
           actionDisabled={actionDisabled}
+          mobileActionsExpanded={expandedMobileActionsId === queuedMessage.id}
+          onExpandMobileActions={setExpandedMobileActionsId}
           compact={mode !== "workspace"}
           isGroupBoundary={messageIndex === groupBoundaryIndex}
           onSend={onSend}

--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
@@ -759,6 +759,15 @@ const QueuedMessageRow = memo(function QueuedMessageRow({
   compact,
   isGroupBoundary,
 }: QueuedMessageRowProps) {
+  const actionsRef = useRef<HTMLDivElement>(null);
+  const focusActionsOnExpandRef = useRef(false);
+  useLayoutEffect(() => {
+    if (!mobileActionsExpanded || !focusActionsOnExpandRef.current) return;
+    focusActionsOnExpandRef.current = false;
+    actionsRef.current
+      ?.querySelector<HTMLButtonElement>("button:not(:disabled)")
+      ?.focus({ preventScroll: true });
+  }, [mobileActionsExpanded]);
   const attachmentCount = useMemo(
     () => countQueuedMessageAttachments(queuedMessage.content),
     [queuedMessage.content],
@@ -920,6 +929,7 @@ const QueuedMessageRow = memo(function QueuedMessageRow({
           <>
             <TooltipProvider delayDuration={300}>
               <div
+                ref={actionsRef}
                 data-queued-message-actions=""
                 className={cn(
                   QUEUED_MESSAGE_ACTION_TAKEOVER_CLASS,
@@ -1015,7 +1025,10 @@ const QueuedMessageRow = memo(function QueuedMessageRow({
               disabled={actionDisabled}
               aria-label={`Queued message ${index + 1} actions`}
               aria-expanded={mobileActionsExpanded}
-              onClick={() => onExpandMobileActions(queuedMessage.id)}
+              onClick={(event) => {
+                focusActionsOnExpandRef.current = event.detail === 0;
+                onExpandMobileActions(queuedMessage.id);
+              }}
             >
               <Icon name="MoreHorizontal" className="size-4" aria-hidden />
             </Button>

--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
@@ -999,7 +999,7 @@ const QueuedMessageRow = memo(function QueuedMessageRow({
                       size="icon"
                       variant="ghost"
                       className={cn(
-                        "shrink-0 text-muted-foreground hover:text-destructive",
+                        "shrink-0 text-muted-foreground hover:text-destructive max-md:text-destructive",
                         compact ? "size-7" : "size-8",
                       )}
                       disabled={actionDisabled}

--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
@@ -959,7 +959,9 @@ const QueuedMessageRow = memo(function QueuedMessageRow({
                         <Icon name="Sent" className="size-4" aria-hidden />
                       </Button>
                     </TooltipTrigger>
-                    <TooltipContent>{sendLabel}</TooltipContent>
+                    <TooltipContent className="max-md:hidden">
+                      {sendLabel}
+                    </TooltipContent>
                   </Tooltip>
                 ) : null}
                 {queuedMessage.editable ? (
@@ -985,7 +987,9 @@ const QueuedMessageRow = memo(function QueuedMessageRow({
                         <Icon name="Edit" className="size-4" aria-hidden />
                       </Button>
                     </TooltipTrigger>
-                    <TooltipContent>Edit</TooltipContent>
+                    <TooltipContent className="max-md:hidden">
+                      Edit
+                    </TooltipContent>
                   </Tooltip>
                 ) : null}
                 <Tooltip>
@@ -1005,7 +1009,9 @@ const QueuedMessageRow = memo(function QueuedMessageRow({
                       <Icon name="Trash2" className="size-4" aria-hidden />
                     </Button>
                   </TooltipTrigger>
-                  <TooltipContent>Delete</TooltipContent>
+                  <TooltipContent className="max-md:hidden">
+                    Delete
+                  </TooltipContent>
                 </Tooltip>
               </div>
             </TooltipProvider>
@@ -1092,7 +1098,9 @@ function SortableGroupBoundaryHandle({ disabled }: { disabled: boolean }) {
                   />
                 </button>
               </TooltipTrigger>
-              <TooltipContent>Messages above send together</TooltipContent>
+              <TooltipContent className="max-md:hidden">
+                Messages above send together
+              </TooltipContent>
             </Tooltip>
           </TooltipProvider>
         </div>
@@ -1820,7 +1828,9 @@ export function QueuedMessagesList({
                   />
                 </Button>
               </TooltipTrigger>
-              <TooltipContent>{caretLabel}</TooltipContent>
+              <TooltipContent className="max-md:hidden">
+                {caretLabel}
+              </TooltipContent>
             </Tooltip>
           </TooltipProvider>
         </div>


### PR DESCRIPTION
## Human comments

## What was wrong

The mobile queued-message ellipsis used a responsive dropdown, opening a second drawer over the queue.

## What changed

- Mobile ellipsis buttons reveal Send, Edit, and a red Delete icon inline.
- Outside taps, collapse, and editing reset expansion; opening another row closes the previous row’s actions.
- Keyboard activation focuses the first enabled action. Queued-drawer tooltips appear only on desktop.

## How you verified

- [Remote CI passed](https://github.com/get-bb/bb/actions/runs/34635581169) on `22244e3d8`.
- Regression coverage includes single-row expansion, outside/collapse reset, keyboard focus, disabled-action skipping, and pointer focus preservation.
- Chrome for Testing 153.0.8010.36: mobile touch and keyboard at 390 × 844; unchanged desktop icon colors at 1024 × 844.

Fresh 2× captures from the branch web app. Mobile comparisons use identical fixture data, route, viewport, theme, and ellipsis-tap interaction: merge base `9882e4a79`, head `22244e3d8`.

| Before — mobile, 390 × 844 | After — mobile, 390 × 844 |
| --- | --- |
| ![Mobile ellipsis opens another drawer](https://github.com/get-bb/bb/releases/download/pr-evidence/thr_ic4cqxeqku-9882e4a79-before-mobile-red-trash.png) | ![Mobile actions appear inline without tooltips](https://github.com/get-bb/bb/releases/download/pr-evidence/thr_ic4cqxeqku-22244e3d8-after-mobile.png) |

<details>
<summary>Outside reset and keyboard focus without mobile tooltips</summary>

An outside tap restores the ellipsis:

![Outside-tap reset restores ellipsis](https://github.com/get-bb/bb/releases/download/pr-evidence/thr_ic4cqxeqku-22244e3d8-reset-mobile.png)

Keyboard activation focuses Send without a tooltip. Tab advances through Edit and Delete:

![Keyboard focus without a mobile tooltip](https://github.com/get-bb/bb/releases/download/pr-evidence/thr_ic4cqxeqku-22244e3d8-keyboard-focus.png)

Touch and keyboard activation retain inline actions without mobile tooltips.

</details>

BB-Thread-ID: thr_ic4cqxeqku

> AGENT GENERATED
