### PR TITLE
Show push notification history in Settings

### DIFF
--- a/packages/templates/src/templates/bb-guide-customization.md
+++ b/packages/templates/src/templates/bb-guide-customization.md
@@ -189,6 +189,7 @@ windows must stay open; browser permission is requested in the plugin settings.
       --platform <ios|android> --label <device-name>
   bb push-notifications remove <id>
   bb push-notifications status
+  bb push-notifications history [--json]
   bb push-notifications test <web|desktop>
   bb plugin config push-notifications set <mobileEnabled|webEnabled|desktopEnabled> <true|false>
 
@@ -201,6 +202,13 @@ config push-notifications set expoPushUrl <url>`. Add `--json` to `list` or
 The three channel switches default to true and apply immediately across this
 server. `test` broadcasts to all connected clients of the selected type with
 permission; OS notification settings still control whether a banner appears.
+
+**Settings → Push notifications → Show history** lists the latest 200 push
+dispatches from this server session, including their outgoing text and channels
+attempted. The palette's **Push notifications settings** entry opens the same
+page. History clears when the server or plugin restarts and does not confirm OS
+delivery or read state. `history --json` and the plugin RPC
+`notifications.history` return `{ notifications: [...] }` with the same entries.
 
 Host files and voice transcription
 

--- a/plugins/push-notifications/PLUGIN_OVERVIEW.md
+++ b/plugins/push-notifications/PLUGIN_OVERVIEW.md
@@ -17,11 +17,9 @@ Channel switches apply to this server and save immediately. Browser permission i
 
 ## Push notification history
 
-Open **Settings → Push notifications → Show history**, or search for **Push notifications settings** in the command palette's **Plugin settings** group. History lists the latest 200 push dispatches from the current server session, newest first. **Refresh** fetches recent dispatches; select a thread title to open it.
+Open **Settings → Push notifications → Show history**, or choose **Push notifications settings** under **Plugin settings** in the command palette. **Refresh** loads recent dispatches; select a title to open its thread.
 
-Each entry contains the outgoing title and body, time, and channels attempted. Mobile is included only when a send is attempted with registered devices. Coalesced updates appear once across channels. Test notifications are included. Suppressed events and in-app toasts are excluded.
-
-History is held in server memory and clears when the server or plugin restarts. It does not read the operating system's notification inbox or confirm device delivery, display, or read state. Earlier notifications cannot be recovered.
+History keeps the latest 200 outgoing messages and attempted channels in server memory, newest first. Coalesced updates appear once across channels; tests are included. Suppressed events and in-app toasts are excluded. Server or plugin restart clears history. This is not the OS inbox or proof of delivery/read status.
 
 ## CLI and SDK
 
@@ -35,4 +33,4 @@ History is held in server memory and clears when the server or plugin restarts. 
 
 Agents can use the SDK’s plugin settings API for the same switches and `sdk.plugins.callRpc({ pluginId: "push-notifications", method: "notifications.test", input: { channel: "web" }, outputSchema: z.object({ ok: z.literal(true) }) })` to send a test. RPC input is validated by `pushNotificationsRpcContract`. Permission requests still require a click in the target client.
 
-History uses `sdk.plugins.callRpc({ pluginId: "push-notifications", method: "notifications.history", input: {}, outputSchema: listPushNotificationHistoryOutputSchema })`. The output schema in `contract.ts` describes each entry's `id`, `title`, `body`, nullable `threadId`, `createdAt` timestamp, and attempted `channels` (`web`, `desktop`, or `mobile`).
+Read history with `sdk.plugins.callRpc({ pluginId: "push-notifications", method: "notifications.history", input: {}, outputSchema: listPushNotificationHistoryOutputSchema })`. See `contract.ts` for the entry schema.

--- a/plugins/push-notifications/PLUGIN_OVERVIEW.md
+++ b/plugins/push-notifications/PLUGIN_OVERVIEW.md
@@ -15,6 +15,14 @@ Click a notification to open its thread. Events arriving together are combined, 
 
 Channel switches apply to this server and save immediately. Browser permission is granted separately on each device with **Allow notifications**. If blocked, change the browser or operating system notification settings. **Send test notification** sends to all connected, permitted clients of the current type. A successful test request confirms broadcast, not OS display; system settings and Focus modes can suppress banners.
 
+## Push notification history
+
+Open **Settings → Push notifications → Show history**, or search for **Push notifications settings** in the command palette's **Plugin settings** group. History lists the latest 200 push dispatches from the current server session, newest first. **Refresh** fetches recent dispatches; select a thread title to open it.
+
+Each entry contains the outgoing title and body, time, and channels attempted. Mobile is included only when a send is attempted with registered devices. Coalesced updates appear once across channels. Test notifications are included. Suppressed events and in-app toasts are excluded.
+
+History is held in server memory and clears when the server or plugin restarts. It does not read the operating system's notification inbox or confirm device delivery, display, or read state. Earlier notifications cannot be recovered.
+
 ## CLI and SDK
 
 - `bb push-notifications list [--json]`: registered mobile devices, with redacted tokens.
@@ -22,6 +30,9 @@ Channel switches apply to this server and save immediately. Browser permission i
 - `bb push-notifications remove <id>`: remove a mobile device.
 - `bb push-notifications status [--json]`: channel switches, mobile relay, subscription count, and last mobile send result.
 - `bb push-notifications test <web|desktop>`: broadcast a test to connected clients of that type. Fails if the channel is disabled.
+- `bb push-notifications history [--json]`: list the current server session's push dispatch history. JSON returns `{ notifications: [...] }`.
 - `bb plugin config push-notifications set <mobileEnabled|webEnabled|desktopEnabled> <true|false>`: change a channel.
 
 Agents can use the SDK’s plugin settings API for the same switches and `sdk.plugins.callRpc({ pluginId: "push-notifications", method: "notifications.test", input: { channel: "web" }, outputSchema: z.object({ ok: z.literal(true) }) })` to send a test. RPC input is validated by `pushNotificationsRpcContract`. Permission requests still require a click in the target client.
+
+History uses `sdk.plugins.callRpc({ pluginId: "push-notifications", method: "notifications.history", input: {}, outputSchema: listPushNotificationHistoryOutputSchema })`. The output schema in `contract.ts` describes each entry's `id`, `title`, `body`, nullable `threadId`, `createdAt` timestamp, and attempted `channels` (`web`, `desktop`, or `mobile`).

--- a/plugins/push-notifications/app.test.tsx
+++ b/plugins/push-notifications/app.test.tsx
@@ -50,3 +50,47 @@ describe("device notification settings", () => {
     expect(requestPermission).not.toHaveBeenCalled();
   });
 });
+
+it("loads push history on demand, recovers from failure, and opens its thread", async () => {
+  let fail = true;
+  const view = renderSlot(
+    app.settingsSections.find((section) => section.id === "history")!,
+    {},
+    {
+      rpc: {
+        "notifications.history": () => {
+          if (fail) throw new Error("Connection lost");
+          return {
+            notifications: [
+              {
+                id: "push-1",
+                title: "Release ready",
+                body: "Run `deploy --dry-run` to preview.",
+                threadId: "thread-1",
+                createdAt: 1_789_200_000_000,
+                channels: ["mobile"],
+              },
+            ],
+          };
+        },
+      },
+    },
+  );
+  expect(view.inspection.rpcCalls).toEqual([]);
+  fireEvent.click(view.getByRole("button", { name: "Show history" }));
+  expect(await view.findByRole("alert")).toHaveProperty(
+    "textContent",
+    "Connection lost",
+  );
+  fail = false;
+  fireEvent.click(view.getByRole("button", { name: "Refresh" }));
+  const thread = await view.findByRole("button", { name: "Release ready" });
+  expect(view.getByText("Run `deploy --dry-run` to preview.")).toBeTruthy();
+  expect(view.getByText(/Channels attempted: mobile/)).toBeTruthy();
+  fireEvent.click(thread);
+  expect(view.inspection.navigateCalls).toEqual([
+    { method: "toThread", threadId: "thread-1" },
+  ]);
+  fireEvent.click(view.getByRole("button", { name: "Hide history" }));
+  expect(view.queryByRole("button", { name: "Release ready" })).toBeNull();
+});

--- a/plugins/push-notifications/app.tsx
+++ b/plugins/push-notifications/app.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import {
   definePluginApp,
   useBbNavigate,
@@ -8,6 +8,7 @@ import {
 } from "@get-bb/plugin-sdk/app";
 import {
   CLIENT_NOTIFICATION_CHANNEL,
+  type PushNotificationHistoryEntry,
   type pushNotificationsRpcContract,
 } from "./contract.js";
 import {
@@ -137,10 +138,113 @@ function NotificationSettings() {
   );
 }
 
+function NotificationHistory() {
+  const rpc = useRpc<typeof pushNotificationsRpcContract>();
+  const navigate = useBbNavigate();
+  const historyId = useId();
+  const [open, setOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [notifications, setNotifications] = useState<
+    PushNotificationHistoryEntry[]
+  >([]);
+
+  async function loadHistory() {
+    setBusy(true);
+    setError(null);
+    try {
+      const result = await rpc.call("notifications.history", {});
+      setNotifications(result.notifications);
+    } catch (error) {
+      setError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="space-y-3 text-sm">
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          className="rounded-md border border-border px-3 py-2 disabled:opacity-50"
+          aria-expanded={open}
+          aria-controls={historyId}
+          disabled={busy}
+          onClick={() => {
+            setOpen(!open);
+            if (!open) void loadHistory();
+          }}
+        >
+          {open ? "Hide history" : "Show history"}
+        </button>
+        {open ? (
+          <button
+            type="button"
+            className="rounded-md border border-border px-3 py-2 disabled:opacity-50"
+            disabled={busy}
+            onClick={() => void loadHistory()}
+          >
+            Refresh
+          </button>
+        ) : null}
+      </div>
+      <div id={historyId} hidden={!open} aria-busy={busy}>
+        {busy ? <p role="status">Loading history…</p> : null}
+        {error !== null ? (
+          <p role="alert" className="text-muted-foreground">
+            {error}
+          </p>
+        ) : !busy && notifications.length === 0 ? (
+          <p className="text-muted-foreground">No push notifications yet.</p>
+        ) : (
+          <ol className="divide-y divide-border">
+            {notifications.map((entry) => (
+              <li key={entry.id} className="space-y-1 py-3">
+                {entry.threadId === null ? (
+                  <p className="break-words font-medium">{entry.title}</p>
+                ) : (
+                  <button
+                    type="button"
+                    className="break-words text-left font-medium underline underline-offset-2"
+                    onClick={() => {
+                      if (entry.threadId !== null)
+                        navigate.toThread(entry.threadId);
+                    }}
+                  >
+                    {entry.title}
+                  </button>
+                )}
+                <p className="whitespace-pre-wrap break-words text-muted-foreground">
+                  {entry.body}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  <time dateTime={new Date(entry.createdAt).toISOString()}>
+                    {new Date(entry.createdAt).toLocaleString()}
+                  </time>
+                  {" · Channels attempted: "}
+                  {entry.channels.join(", ")}
+                </p>
+              </li>
+            ))}
+          </ol>
+        )}
+      </div>
+    </div>
+  );
+}
+
 export default definePluginApp((app) => {
   app.slots.experimental_appOverlay({
     id: "delivery",
     component: NotificationDelivery,
   });
   app.slots.settingsSection({ id: "device", component: NotificationSettings });
+  app.slots.settingsSection({
+    id: "history",
+    title: "Push notification history",
+    description:
+      "Latest 200 push dispatches from this server session. Clears when the server or plugin restarts. Dispatch does not confirm OS delivery or that a notification was read.",
+    component: NotificationHistory,
+  });
 });

--- a/plugins/push-notifications/contract.ts
+++ b/plugins/push-notifications/contract.ts
@@ -48,12 +48,29 @@ export const clientNotificationSchema = z
   .strict();
 export type ClientNotification = z.infer<typeof clientNotificationSchema>;
 
+export const pushNotificationHistoryEntrySchema = clientNotificationSchema
+  .extend({
+    createdAt: z.number().int().nonnegative(),
+    channels: z.array(z.enum(["web", "desktop", "mobile"])).min(1),
+  })
+  .strict();
+export type PushNotificationHistoryEntry = z.infer<
+  typeof pushNotificationHistoryEntrySchema
+>;
+export const listPushNotificationHistoryOutputSchema = z
+  .object({ notifications: z.array(pushNotificationHistoryEntrySchema) })
+  .strict();
+
 const emptyInputSchema = z.object({}).strict();
 export const listPushSubscriptionsOutputSchema = z
   .object({ subscriptions: z.array(pushSubscriptionSummarySchema) })
   .strict();
 
 export const pushNotificationsRpcContract = defineRpcContract({
+  "notifications.history": {
+    input: emptyInputSchema,
+    output: listPushNotificationHistoryOutputSchema,
+  },
   "notifications.test": {
     input: z.object({ channel: clientChannelSchema }).strict(),
     output: z.object({ ok: z.literal(true) }).strict(),

--- a/plugins/push-notifications/history.test.ts
+++ b/plugins/push-notifications/history.test.ts
@@ -1,0 +1,29 @@
+import { expect, it } from "vitest";
+import { createPushNotificationHistory } from "./history.js";
+import type { PushNotificationHistoryEntry } from "./contract.js";
+
+it("caps dispatches at 200, merges channel attempts by identity, and resets per instance", () => {
+  const history = createPushNotificationHistory();
+  const first: PushNotificationHistoryEntry = {
+    id: "first",
+    title: "Finished",
+    body: "Ready to review",
+    threadId: "thread-1",
+    createdAt: 1,
+    channels: ["web"],
+  };
+  history.record(first);
+  history.record({ ...first, id: "second", createdAt: 2 });
+  history.record({ ...first, channels: ["web", "mobile"] });
+  expect(history.list().map((entry) => [entry.id, entry.channels])).toEqual([
+    ["second", ["web"]],
+    ["first", ["web", "mobile"]],
+  ]);
+  for (let index = 3; index <= 201; index += 1) {
+    history.record({ ...first, id: String(index), createdAt: index });
+  }
+  expect(history.list()).toHaveLength(200);
+  expect(history.list()[0]?.id).toBe("201");
+  expect(history.list().at(-1)?.id).toBe("second");
+  expect(createPushNotificationHistory().list()).toEqual([]);
+});

--- a/plugins/push-notifications/history.ts
+++ b/plugins/push-notifications/history.ts
@@ -1,0 +1,23 @@
+import type { PushNotificationHistoryEntry } from "./contract.js";
+
+const HISTORY_LIMIT = 200;
+
+export function createPushNotificationHistory() {
+  const entries = new Map<string, PushNotificationHistoryEntry>();
+  return {
+    record(entry: PushNotificationHistoryEntry): void {
+      entries.set(entry.id, entry);
+      if (entries.size > HISTORY_LIMIT) {
+        const oldest = entries.keys().next();
+        if (!oldest.done) entries.delete(oldest.value);
+      }
+    },
+    list(): PushNotificationHistoryEntry[] {
+      return [...entries.values()].reverse();
+    },
+  };
+}
+
+export type PushNotificationHistory = ReturnType<
+  typeof createPushNotificationHistory
+>;

--- a/plugins/push-notifications/sender.ts
+++ b/plugins/push-notifications/sender.ts
@@ -12,6 +12,7 @@ import {
   type PushSubscription,
 } from "./contract.js";
 import type { PushSubscriptionStore } from "./subscriptions.js";
+import type { PushNotificationHistory } from "./history.js";
 
 type ThreadResponse = PluginThreadEventPayloads["thread.idle"]["thread"];
 type PendingInteraction =
@@ -131,6 +132,7 @@ export interface PushSender {
 
 export interface CreatePushSenderArgs {
   bb: BbPluginApi;
+  history: PushNotificationHistory;
   subscriptions: PushSubscriptionStore;
   getExpoPushUrl(): Promise<string>;
   getDeliverySettings(): Promise<{
@@ -332,18 +334,23 @@ export function createPushSender(args: CreatePushSenderArgs): PushSender {
     if (resolved === null) return;
     const title = truncate(threadDisplayTitle(thread), PUSH_TITLE_MAX_LENGTH);
     const body = truncate(resolved.body, PUSH_BODY_MAX_LENGTH);
+    const notification = {
+      id: randomUUID(),
+      title,
+      body,
+      threadId: thread.id,
+    };
+    const createdAt = now();
     const config = await args.getDeliverySettings();
     const channels: ClientNotification["channels"] = [];
     if (config.webEnabled) channels.push("web");
     if (config.desktopEnabled) channels.push("desktop");
     if (channels.length > 0) {
       bb.realtime.publish(CLIENT_NOTIFICATION_CHANNEL, {
-        id: randomUUID(),
-        title,
-        body,
-        threadId: thread.id,
+        ...notification,
         channels,
       } satisfies ClientNotification);
+      args.history.record({ ...notification, createdAt, channels });
     }
     if (!config.mobileEnabled) return;
     const rows = await subscriptions.list();
@@ -368,6 +375,13 @@ export function createPushSender(args: CreatePushSenderArgs): PushSender {
     }));
     let sentCount = 0;
     let failure: string | null = null;
+    if (dispatcher !== null) {
+      args.history.record({
+        ...notification,
+        createdAt,
+        channels: [...channels, "mobile"],
+      });
+    }
     for (const batch of chunks(deliveries, EXPO_PUSH_BATCH_SIZE)) {
       const result = await sendBatch(batch);
       sentCount += result.sentCount;

--- a/plugins/push-notifications/server.test.ts
+++ b/plugins/push-notifications/server.test.ts
@@ -8,7 +8,10 @@ import {
 } from "@get-bb/plugin-sdk/testing";
 import { EnvHttpProxyAgent } from "undici";
 import { describe, expect, it, vi } from "vitest";
-import { listPushSubscriptionsOutputSchema } from "./contract.js";
+import {
+  listPushNotificationHistoryOutputSchema,
+  listPushSubscriptionsOutputSchema,
+} from "./contract.js";
 import { createPushNotificationsPlugin } from "./server.js";
 import type { ExpoPushMessage, PushSenderFetch } from "./sender.js";
 
@@ -302,6 +305,24 @@ describe("push sender", () => {
         priority: "high",
       });
       expect(host.expo.requests[0]?.[0]?.data).not.toHaveProperty("serverUrl");
+      const history = listPushNotificationHistoryOutputSchema.parse(
+        await host.harness.behavior.callRpc("notifications.history", {}),
+      );
+      expect(history.notifications).toEqual([
+        {
+          id: expect.any(String),
+          createdAt: expect.any(Number),
+          title: "Fix the flaky test",
+          body: "Done: the timer race is fixed.",
+          threadId: thread.id,
+          channels: ["web", "desktop", "mobile"],
+        },
+      ]);
+      const historyCli = await host.harness.behavior.runCli([
+        "history",
+        "--json",
+      ]);
+      expect(JSON.parse(historyCli.stdout)).toEqual(history);
       await vi.waitFor(async () => {
         const result = await host.harness.behavior.runCli(["status", "--json"]);
         expect(JSON.parse(result.stdout).lastSendOutcome).toMatchObject({
@@ -434,6 +455,16 @@ describe("push sender", () => {
       host.interactions.set(answered.id, []);
       await waitForCoalesce();
       expect(host.expo.requests).toHaveLength(1);
+      const history = listPushNotificationHistoryOutputSchema.parse(
+        await host.harness.behavior.callRpc("notifications.history", {}),
+      );
+      expect(history.notifications).toEqual([
+        expect.objectContaining({
+          title: "Release",
+          body: "Ship to staging or production?",
+          channels: ["web", "desktop", "mobile"],
+        }),
+      ]);
     } finally {
       await host.cleanup();
     }
@@ -616,4 +647,56 @@ describe("web and desktop delivery", () => {
       await host.cleanup();
     }
   });
+});
+
+it("records only attempted push channels, including failed mobile requests", async () => {
+  const host = await setup({
+    fetch: async () => {
+      throw new Error("offline");
+    },
+  });
+  try {
+    await host.harness.behavior.setSettings({ desktopEnabled: false });
+    const webThread = host.setThread();
+    await host.harness.behavior.emitThreadEvent("thread.idle", {
+      thread: webThread,
+      lastAssistantText: "Web only without mobile subscriptions",
+    });
+    await waitForCoalesce();
+    await host.addSubscription();
+    await host.harness.behavior.setSettings({ webEnabled: false });
+    const mobileThread = host.setThread();
+    await host.harness.behavior.emitThreadEvent("thread.idle", {
+      thread: mobileThread,
+      lastAssistantText: "Mobile request fails",
+    });
+    await waitForCoalesce();
+    await host.harness.behavior.setSettings({ mobileEnabled: false });
+    const disabledThread = host.setThread();
+    await host.harness.behavior.emitThreadEvent("thread.idle", {
+      thread: disabledThread,
+      lastAssistantText: "All channels disabled",
+    });
+    await waitForCoalesce();
+    const history = listPushNotificationHistoryOutputSchema.parse(
+      await host.harness.behavior.callRpc("notifications.history", {}),
+    );
+    expect(history.notifications).toEqual([
+      expect.objectContaining({
+        threadId: mobileThread.id,
+        channels: ["mobile"],
+        body: "Mobile request fails",
+      }),
+      expect.objectContaining({
+        threadId: webThread.id,
+        channels: ["web"],
+        body: "Web only without mobile subscriptions",
+      }),
+    ]);
+    const text = await host.harness.behavior.runCli(["history"]);
+    expect(text.stdout).toContain("OS delivery is not confirmed");
+    expect(text.stdout).toContain("Mobile request fails");
+  } finally {
+    await host.cleanup();
+  }
 });

--- a/plugins/push-notifications/server.ts
+++ b/plugins/push-notifications/server.ts
@@ -17,6 +17,7 @@ import {
   type LastSendOutcome,
 } from "./sender.js";
 import { createPushSubscriptionStore } from "./subscriptions.js";
+import { createPushNotificationHistory } from "./history.js";
 
 interface PushNotificationsPluginOptions {
   coalesceMs?: number;
@@ -164,8 +165,10 @@ export function createPushNotificationsPlugin(
       ...(options.now === undefined ? {} : { now: options.now }),
       ...(options.createId === undefined ? {} : { createId: options.createId }),
     });
+    const history = createPushNotificationHistory();
     const sender = createPushSender({
       bb,
+      history,
       subscriptions,
       getDeliverySettings: () => settings.get(),
       getExpoPushUrl: async () => (await settings.get()).expoPushUrl,
@@ -195,17 +198,23 @@ export function createPushNotificationsPlugin(
       if (!(channel === "web" ? config.webEnabled : config.desktopEnabled)) {
         throw new Error(`${channel} notifications are disabled`);
       }
-      bb.realtime.publish(CLIENT_NOTIFICATION_CHANNEL, {
+      const notification: ClientNotification = {
         id: randomUUID(),
         title: "bb notifications are working",
         body: "You’ll be notified when a thread needs your attention.",
         threadId: null,
         channels: [channel],
-      } satisfies ClientNotification);
+      };
+      bb.realtime.publish(CLIENT_NOTIFICATION_CHANNEL, notification);
+      history.record({
+        ...notification,
+        createdAt: (options.now ?? Date.now)(),
+      });
       return { ok: true as const };
     }
 
     bb.rpc.register(pushNotificationsRpcContract, {
+      "notifications.history": () => ({ notifications: history.list() }),
       "notifications.test": ({ channel }) => sendTest(channel),
       "pushSubscriptions.list": async () => ({
         subscriptions: await subscriptions.listSummaries(),
@@ -223,6 +232,11 @@ export function createPushNotificationsPlugin(
       name: "push-notifications",
       summary: "Manage mobile, web, and desktop notifications",
       commands: [
+        {
+          name: "history",
+          summary: "List push dispatches from the current server session",
+          usage: "bb push-notifications history [--json]",
+        },
         {
           name: "test",
           summary:
@@ -253,6 +267,28 @@ export function createPushNotificationsPlugin(
       ],
       async run(argv) {
         const [command, ...args] = argv;
+        if (
+          command === "history" &&
+          (args.length === 0 || (args.length === 1 && args[0] === "--json"))
+        ) {
+          const notifications = history.list();
+          return {
+            exitCode: 0,
+            stdout:
+              args[0] === "--json"
+                ? JSON.stringify({ notifications })
+                : [
+                    "Push notification history — current server session, latest 200 dispatches. Clears on restart; OS delivery is not confirmed.",
+                    ...notifications.map(
+                      (entry) =>
+                        `${new Date(entry.createdAt).toISOString()} [${entry.channels.join(", ")}] ${entry.title}\n${entry.body}`,
+                    ),
+                    ...(notifications.length === 0
+                      ? ["No push notifications yet."]
+                      : []),
+                  ].join("\n\n"),
+          };
+        }
         if (command === "test" && args.length === 1) {
           const channel = clientChannelSchema.safeParse(args[0]);
           if (!channel.success)
@@ -316,7 +352,7 @@ export function createPushNotificationsPlugin(
         return {
           exitCode: 1,
           stderr:
-            "Usage: bb push-notifications <list|add|remove|status|test> [options]",
+            "Usage: bb push-notifications <list|add|remove|status|test|history> [options]",
         };
       },
     });


### PR DESCRIPTION
## Human comments

## What was wrong

Push notifications had no history in BB. The plugin retained device registrations and the latest mobile send outcome, so notification text disappeared after a banner was dismissed.

## What changed

- Settings → Push notifications → Show history lists the latest 200 dispatches from the current server session.
- Each entry shows outgoing text and attempted channels. Server or plugin restart clears history; OS delivery/read status remains unknown.
- `bb push-notifications history [--json]` and `notifications.history` RPC expose the same list; CLI guide and plugin documentation updated.

The existing palette entry **Plugin settings → Push notifications settings** opens the same page. Core toast history and `notifications.open` are unchanged.

<details>
<summary>Research rationale</summary>

| Reference | Discovery / Settings | Naming and relevance |
| --- | --- | --- |
| [Linear](https://linear.app/docs/notifications) | Inbox holds activity; Account → Notifications controls delivery channels. | [Inbox](https://linear.app/docs/inbox) is distinct from delivery preferences. |
| [Slack](https://slack.com/help/articles/201355156-Configure-your-Slack-notifications) | Activity holds notifications; Preferences → Notifications controls delivery. | [Activity](https://slack.com/help/articles/46751260742035-Introducing-the-new-Activity-view-in-Slack) defaults to All notifications. |
| [Android](https://support.google.com/android/answer/9079661?hl=en) | Supported devices expose notification history through system Settings. | OS-owned history is separate from individual app delivery settings. |

BB therefore adds an explicitly labeled history action beside its existing push preferences. This is BB dispatch history: [Expo](https://docs.expo.dev/versions/latest/sdk/notifications/#getpresentednotificationsasync) exposes only notifications currently in the device tray, while the [web standard](https://notifications.spec.whatwg.org/#dom-serviceworkerregistration-getnotifications) limits enumeration to a service-worker registration. BB's web/desktop delivery uses the Notification constructor. No OS inbox reconstruction or persistent storage is introduced.
</details>

## How you verified

- [Remote CI passed](https://github.com/get-bb/bb/actions/runs/34632975041) at `ec0f8a848`: build/typecheck/lint, all test shards (including 24 push-plugin tests), and Linux/macOS package smoke. The packages shard passed on rerun after an unchanged Connect test timeout. No local tests, typechecks, or lint checks ran.
- One bounded real UI pass in isolated Chrome for Testing **152.0.7977.64**, source web app launched with `scripts/bb-dev-app current`. Verified Settings entry, Show/Hide/Refresh, palette navigation, compact Settings navigation without an inert app root, reload retention, and source CLI/RPC agreement.
- Fresh 2× captures compare base `8127e507338e046ca3a54917f7c6b15d3084b074` with this PR head using the same dev data, Settings route, default light theme, and CSS viewports (1440×1000 desktop; 390×844 compact). Paired files: `before-desktop.png` / `after-desktop.png`, `before-mobile.png` / `after-mobile.png`, and `before-palette.png` / `after-palette.png`. Additional expanded history: `after-desktop-history.png`, `after-mobile-history.png`.

**Draft evidence gaps:** full-resolution PNGs and their SHA-256 manifest are preserved in the task's managed worktree and handed to the originating thread via BB files.read. No durable image uploader is available, so required inline PR-body before/after images remain unhosted. Chrome 152 was used consistently; current Stable is 153.0.8010.36, which was not rerun under host pressure. Compact captures show responsive web Settings UI; native mobile/desktop push display was not verified here. No code review or merge has been performed.

BB-Thread-ID: thr_8nxtrd56vb

> AGENT GENERATED
