### PR TITLE
perf(plugin-sdk): share declaration emit work

### DIFF
--- a/packages/plugin-sdk/scripts/build-bundled-dts.mjs
+++ b/packages/plugin-sdk/scripts/build-bundled-dts.mjs
@@ -24,17 +24,14 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { availableParallelism } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import {
-  Worker,
-  isMainThread,
-  parentPort,
-  workerData,
-} from "node:worker_threads";
 import { rollup } from "rollup";
 import { dts } from "rollup-plugin-dts";
+import {
+  declarationId,
+  sharedDeclarationEmit,
+} from "./shared-declaration-emit.mjs";
 
 import { normalizeBundledDts } from "./normalize-bundled-dts.mjs";
 
@@ -149,11 +146,17 @@ const inlineWorkspace = {
   },
 };
 
+const emitDeclarations = sharedDeclarationEmit(
+  Object.values(outputs),
+  pkgsDir,
+  inlineWorkspace.resolveId,
+);
+
 async function bundle(input) {
   const build = await rollup({
-    input,
+    input: declarationId(input),
     external: EXTERNAL,
-    plugins: [inlineWorkspace, dts({ respectExternal: false })],
+    plugins: [emitDeclarations, dts({ respectExternal: false })],
     onwarn(warning) {
       // Circular type references are fine in .d.ts output; surface everything
       // else so a genuinely broken bundle is visible.
@@ -161,9 +164,12 @@ async function bundle(input) {
       console.warn(`[build-bundled-dts] ${warning.code}: ${warning.message}`);
     },
   });
-  const { output } = await build.generate({ format: "es" });
-  await build.close();
-  return output[0].code;
+  try {
+    const { output } = await build.generate({ format: "es" });
+    return output[0].code;
+  } finally {
+    await build.close();
+  }
 }
 
 const HEADER = [
@@ -181,49 +187,11 @@ function generateBundle(entry) {
   );
 }
 
-// Each bundle builds its own TypeScript program, which is CPU-bound and
-// single-threaded inside rollup-plugin-dts; the six large entries take 2–7s
-// apiece. They are independent, so this file re-runs itself as a worker per
-// entry, as many at a time as there are cores, and the serial ~27s becomes
-// roughly the longest single bundle.
-if (!isMainThread) {
-  parentPort.postMessage(await generateBundle(workerData.entry));
-} else {
-  await main();
+const generated = {};
+for (const [name, entry] of Object.entries(outputs)) {
+  generated[name] = await generateBundle(entry);
 }
-
-async function main() {
-  const generated = {};
-  const queue = Object.entries(outputs);
-  const workers = Math.min(queue.length, availableParallelism());
-  await Promise.all(
-    Array.from({ length: workers }, async () => {
-      for (let next = queue.shift(); next; next = queue.shift()) {
-        const [fileName, entry] = next;
-        generated[fileName] = await generateInWorker(entry);
-      }
-    }),
-  );
-  // Keep the declared order so a diff of the outputs stays readable.
-  writeOutputs(
-    Object.fromEntries(
-      Object.keys(outputs).map((fileName) => [fileName, generated[fileName]]),
-    ),
-  );
-}
-
-function generateInWorker(entry) {
-  return new Promise((resolve, reject) => {
-    const worker = new Worker(new URL(import.meta.url), {
-      workerData: { entry },
-    });
-    worker.once("message", resolve);
-    worker.once("error", reject);
-    worker.once("exit", (code) => {
-      if (code !== 0) reject(new Error(`bundle worker exited with ${code}`));
-    });
-  });
-}
+writeOutputs(generated);
 
 function writeOutputs(generated) {
   mkdirSync(outDir, { recursive: true });

--- a/packages/plugin-sdk/scripts/shared-declaration-emit.mjs
+++ b/packages/plugin-sdk/scripts/shared-declaration-emit.mjs
@@ -1,0 +1,170 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import ts from "typescript";
+
+export const declarationId = (id) =>
+  /\.d\.[cm]?ts$/.test(id)
+    ? id
+    : id.replace(/\.([cm]?ts|tsx)$/, ".d.$1").replace(/\.d\.tsx$/, ".d.ts");
+
+export function sharedDeclarationEmit(entries, workspaceDir, resolveSource) {
+  const configCache = new Map();
+  const programs = new Map();
+
+  function compilerConfig(file) {
+    const configPath = ts.findConfigFile(path.dirname(file), ts.sys.fileExists);
+    if (!configPath) throw new Error(`Missing tsconfig for ${file}`);
+    if (configCache.has(configPath)) return configCache.get(configPath);
+    const config = ts.getParsedCommandLineOfConfigFile(
+      configPath,
+      {
+        declaration: true,
+        noEmit: false,
+        emitDeclarationOnly: true,
+        noEmitOnError: true,
+        checkJs: false,
+        declarationMap: false,
+        skipLibCheck: true,
+        preserveSymlinks: false,
+        target: ts.ScriptTarget.ESNext,
+        resolveJsonModule: true,
+      },
+      {
+        ...ts.sys,
+        onUnRecoverableConfigFileDiagnostic(diagnostic) {
+          throw new Error(
+            ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"),
+          );
+        },
+      },
+    );
+    if (!config || config.errors.length) {
+      throw new Error(
+        `Invalid tsconfig ${configPath}: ${config?.errors.map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n")).join("\n")}`,
+      );
+    }
+    const options = { ...config.options };
+    for (const key of [
+      "rootDir",
+      "outDir",
+      "configFilePath",
+      "tsBuildInfoFile",
+    ]) {
+      delete options[key];
+    }
+    const ambientFiles = config.fileNames.filter((fileName) =>
+      /\.d\.[cm]?ts$/.test(fileName),
+    );
+    const result = {
+      options,
+      ambientFiles,
+      key: JSON.stringify([
+        Object.entries(options).sort(([a], [b]) => a.localeCompare(b)),
+        ambientFiles,
+      ]),
+    };
+    configCache.set(configPath, result);
+    return result;
+  }
+
+  const initialConfig = compilerConfig(entries[0]);
+  const discovery = ts.createProgram(
+    [...entries, ...initialConfig.ambientFiles],
+    initialConfig.options,
+  );
+  const roots = discovery
+    .getSourceFiles()
+    .map((source) => source.fileName)
+    .filter(
+      (id) =>
+        id.startsWith(workspaceDir + path.sep) &&
+        !id.includes(`${path.sep}node_modules${path.sep}`) &&
+        !/\.d\.[cm]?ts$/.test(id),
+    );
+
+  function programFor(file) {
+    const config = compilerConfig(file);
+    const previous = programs.get(config.key);
+    if (!previous || !previous.getRootFileNames().includes(file)) {
+      programs.set(
+        config.key,
+        ts.createProgram(
+          [
+            ...new Set([
+              ...roots,
+              ...config.ambientFiles,
+              ...(previous?.getRootFileNames() ?? []),
+              file,
+            ]),
+          ],
+          config.options,
+          undefined,
+          previous ?? discovery,
+        ),
+      );
+    }
+    return programs.get(config.key);
+  }
+
+  const declarations = new Map();
+  const sources = new Map(
+    discovery
+      .getSourceFiles()
+      .map((source) => [path.resolve(source.fileName), source]),
+  );
+  const sourceIds = new Map(
+    [...sources.keys()].map((id) => [declarationId(id), id]),
+  );
+
+  return {
+    name: "shared-declaration-emit",
+    resolveId(id, importer) {
+      const source = resolveSource(id, importer && sourceIds.get(importer));
+      if (source) {
+        sourceIds.set(declarationId(source), source);
+        return declarationId(source);
+      }
+      if (!importer) return declarationId(id);
+      if (id.startsWith(".")) {
+        const resolved = ts.resolveModuleName(
+          id,
+          sourceIds.get(importer) ?? importer,
+          { moduleResolution: ts.ModuleResolutionKind.Node10 },
+          ts.sys,
+        ).resolvedModule;
+        if (resolved) {
+          const real = path.resolve(resolved.resolvedFileName);
+          sourceIds.set(declarationId(real), real);
+          return declarationId(real);
+        }
+      }
+    },
+    load(id) {
+      const sourceId = sourceIds.get(id);
+      if (!sourceId) return null;
+      if (/\.d\.[cm]?ts$/.test(sourceId)) return readFileSync(sourceId, "utf8");
+      if (declarations.has(id)) return declarations.get(id);
+      const program = programFor(sourceId);
+      const source = program.getSourceFile(sourceId);
+      if (!source) throw new Error(`Missing source ${sourceId}`);
+      let declaration;
+      const result = program.emit(
+        source,
+        (name, text) => {
+          if (!name.endsWith(".map")) declaration = text;
+        },
+        undefined,
+        true,
+        undefined,
+        true,
+      );
+      if (!declaration || result.emitSkipped) {
+        throw new Error(
+          `Failed emit ${sourceId}: ${result.diagnostics.map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n")).join("\n")}`,
+        );
+      }
+      declarations.set(id, declaration);
+      return declaration;
+    },
+  };
+}

--- a/packages/plugin-sdk/scripts/shared-declaration-emit.test.mjs
+++ b/packages/plugin-sdk/scripts/shared-declaration-emit.test.mjs
@@ -1,0 +1,94 @@
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { rollup } from "rollup";
+import { dts } from "rollup-plugin-dts";
+import { expect, it } from "vitest";
+import {
+  declarationId,
+  sharedDeclarationEmit,
+} from "./shared-declaration-emit.mjs";
+import { normalizeBundledDts } from "./normalize-bundled-dts.mjs";
+
+it("preserves inferred types, ambient declarations, and distinct workspace compiler options", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "bb-shared-declarations-"));
+  try {
+    const sdk = path.join(root, "sdk");
+    const contract = path.join(root, "contract");
+    await mkdir(path.join(sdk, "node_modules/@bb"), { recursive: true });
+    await mkdir(contract);
+    await symlink(contract, path.join(sdk, "node_modules/@bb/contract"), "dir");
+    await writeFile(
+      path.join(contract, "package.json"),
+      JSON.stringify({ name: "@bb/contract", types: "index.ts" }),
+    );
+    const entries = [path.join(sdk, "index.ts"), path.join(sdk, "other.ts")];
+    await writeFile(
+      entries[0],
+      'export { value, nullable, ambientValue } from "@bb/contract";\nexport const own = [1, null];',
+    );
+    await writeFile(
+      entries[1],
+      'export { value } from "@bb/contract";\nexport const other = "second" as const;',
+    );
+    await writeFile(
+      path.join(contract, "index.ts"),
+      'export const value = { label: "hello", count: 1 } as const;\nexport const nullable = [1, null];\nexport const ambientValue = ambient;',
+    );
+    await writeFile(
+      path.join(contract, "ambient.d.ts"),
+      'declare const ambient: "ambient";',
+    );
+    await writeFile(
+      path.join(sdk, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          strict: true,
+          moduleResolution: "node",
+          target: "es2022",
+        },
+      }),
+    );
+    const resolveSource = (id) =>
+      id === "@bb/contract" ? path.join(contract, "index.ts") : null;
+    async function bundle(entry, plugins) {
+      const build = await rollup({ input: entry, plugins });
+      try {
+        const { output } = await build.generate({ format: "es" });
+        return normalizeBundledDts(output[0].code);
+      } finally {
+        await build.close();
+      }
+    }
+    for (const strictNullChecks of [false, true]) {
+      await writeFile(
+        path.join(contract, "tsconfig.json"),
+        JSON.stringify({
+          compilerOptions: {
+            strictNullChecks,
+            moduleResolution: "node",
+            target: "es2022",
+          },
+        }),
+      );
+      const shared = sharedDeclarationEmit(entries, root, resolveSource);
+      for (const entry of entries) {
+        const actual = await bundle(declarationId(entry), [shared, dts()]);
+        const expected = await bundle(entry, [
+          { name: "workspace", resolveId: resolveSource },
+          dts({ compilerOptions: { strictNullChecks } }),
+        ]);
+        expect(actual).toContain('readonly label: "hello"');
+        if (entry === entries[0]) {
+          expect(actual).toContain('declare const ambientValue: "ambient"');
+          expect(actual.match(/declare const nullable: ([^;]+);/)[1]).toBe(
+            expected.match(/declare const nullable: ([^;]+);/)[1],
+          );
+          expect(actual).toContain("declare const own: (number | null)[]");
+        }
+      }
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}, 30_000);


### PR DESCRIPTION
## Human comments

## What was wrong

The portable Plugin SDK declaration task launched one worker and built one independent TypeScript program for each of its 16 public entrypoints. Large parts of the same workspace declaration graph were therefore discovered, parsed, and emitted repeatedly, making the task CPU- and memory-heavy even though Rollup ultimately produced independent declaration bundles.

## What changed

Added a shared declaration-emission plugin that discovers reachable workspace sources once, groups TypeScript programs by compiler options and ambient declarations, and caches each in-memory source declaration for reuse by the existing Rollup declaration bundles. The implementation retains the current JavaScript TypeScript compiler, `rollup-plugin-dts`, all 16 public outputs, workspace flattening, external-package handling, server-contract stubs, diagnostics, forced declaration emission, deterministic normalization, and atomic write-if-unchanged behavior.

Added an equivalence fixture covering inferred types under distinct compiler configurations and ambient declarations. There are no protocol, CLI, runtime-policy, native-toolchain, or public API changes.

Matched forced Turbo measurements on the same source reduced median full-task wall time from 13.458 seconds to 9.096 seconds and approximate peak summed descendant RSS from 13,634 MiB to 2,944 MiB. The declaration-stage median changed from 12.779 seconds to 8.403 seconds. A direct baseline sample reached 49.037 seconds during unusually high shared-host load, so it is retained as a limitation rather than used for a clean speedup claim.

## How you verified

- `pnpm exec turbo run test typecheck --filter=@get-bb/plugin-sdk --filter=@bb/templates --output-logs=errors-only`
- SDK: 250 tests across 24 files and typecheck passed.
- Templates: 44 tests across 7 files and typecheck passed, including external packed/scaffold consumers and backend/frontend testing runtimes.
- Compared all 16 generated declarations byte-for-byte with fresh `origin/main` output after every matched baseline/final run.
- Verified source, ambient declaration, and TypeScript configuration edits each invalidate and execute declaration generation, while reverting restores the original declarations.
- Verified one deliberately missing output restores from Turbo in 0.240 seconds without starting the generator; an unchanged whole-task hit took 0.237 seconds.
- `git diff --check`

> AGENT GENERATED
