### PR TITLE
Avoid redundant packaged builtin fixture copies

### DIFF
--- a/apps/server/test/services/plugins/builtin-plugins.test.ts
+++ b/apps/server/test/services/plugins/builtin-plugins.test.ts
@@ -28,7 +28,6 @@ import {
 } from "../../../src/services/plugins/plugin-service.js";
 import { readPluginManifest } from "../../../src/services/plugins/manifest.js";
 import {
-  BUILTIN_PLUGIN_NAMES,
   BUILTIN_PLUGINS,
   OFFICIAL_PLUGINS,
   resolveBuiltinPluginRootPath,
@@ -57,11 +56,14 @@ function packagedLoadCount(): number {
   return (globals.__packagedBuiltinLoads as number | undefined) ?? 0;
 }
 
-async function writePackagedBuiltinSource(workDir: string): Promise<{
+async function writePackagedBuiltinSource(
+  workDir: string,
+  names: readonly string[],
+): Promise<{
   sourceModuleDir: string;
 }> {
   const sourceModuleDir = join(workDir, "source-module");
-  for (const name of BUILTIN_PLUGIN_NAMES) {
+  for (const name of names) {
     const sourceRoot = join(sourceModuleDir, "builtin-plugins", name);
     const usesPluginOwnedIcon = name === "automations";
     const usesDeclaredIcons = name === "provider-acp";
@@ -142,6 +144,21 @@ async function writePackagedBuiltinSource(workDir: string): Promise<{
     );
   }
   return { sourceModuleDir };
+}
+
+async function copyPackagedBuiltinRuntime(
+  workDir: string,
+  names: readonly string[],
+): Promise<{ targetRoot: string }> {
+  const { sourceModuleDir } = await writePackagedBuiltinSource(workDir, names);
+  const targetRoot = join(workDir, "builtin-plugins");
+  for (const name of names) {
+    await copyPluginRuntime({
+      sourceRoot: join(sourceModuleDir, "builtin-plugins", name),
+      targetDir: join(targetRoot, name),
+    });
+  }
+  return { targetRoot };
 }
 
 function createService(args: {
@@ -933,14 +950,9 @@ describe("builtin plugin reconciliation", () => {
   });
 
   it("installs and loads a packaged builtin whose source files are omitted", async () => {
-    const { sourceModuleDir } = await writePackagedBuiltinSource(workDir);
-    const targetRoot = join(workDir, "builtin-plugins");
-    for (const { name } of BUILTIN_PLUGINS) {
-      await copyPluginRuntime({
-        sourceRoot: join(sourceModuleDir, "builtin-plugins", name),
-        targetDir: join(targetRoot, name),
-      });
-    }
+    const { targetRoot } = await copyPackagedBuiltinRuntime(workDir, [
+      "automations",
+    ]);
     const copiedRoot = join(targetRoot, "automations");
 
     service = createService({
@@ -970,15 +982,10 @@ describe("builtin plugin reconciliation", () => {
   });
 
   it("registers but does not load a packaged builtin with stale backend metadata", async () => {
-    const { sourceModuleDir } = await writePackagedBuiltinSource(workDir);
+    const { targetRoot } = await copyPackagedBuiltinRuntime(workDir, [
+      "automations",
+    ]);
     const incompatibleMajor = PLUGIN_SDK_MAJOR + 1;
-    const targetRoot = join(workDir, "builtin-plugins");
-    for (const { name } of BUILTIN_PLUGINS) {
-      await copyPluginRuntime({
-        sourceRoot: join(sourceModuleDir, "builtin-plugins", name),
-        targetDir: join(targetRoot, name),
-      });
-    }
     const copiedRoot = join(targetRoot, "automations");
     await writeFile(
       join(copiedRoot, "dist", "server.meta.json"),
@@ -1011,14 +1018,9 @@ describe("builtin plugin reconciliation", () => {
   });
 
   it("explicitly installs a packaged builtin without rebuilding its app bundle", async () => {
-    const { sourceModuleDir } = await writePackagedBuiltinSource(workDir);
-    const targetRoot = join(workDir, "builtin-plugins");
-    for (const { name } of BUILTIN_PLUGINS) {
-      await copyPluginRuntime({
-        sourceRoot: join(sourceModuleDir, "builtin-plugins", name),
-        targetDir: join(targetRoot, name),
-      });
-    }
+    const { targetRoot } = await copyPackagedBuiltinRuntime(workDir, [
+      "automations",
+    ]);
     const copiedRoot = join(targetRoot, "automations");
 
     service = createService({
@@ -1052,15 +1054,11 @@ describe("builtin plugin packaging", () => {
   });
 
   it("copies only the runtime layout for packaged builtins", async () => {
-    const { sourceModuleDir } = await writePackagedBuiltinSource(workDir);
-    const targetRoot = join(workDir, "builtin-plugins");
-
-    for (const { name } of BUILTIN_PLUGINS) {
-      await copyPluginRuntime({
-        sourceRoot: join(sourceModuleDir, "builtin-plugins", name),
-        targetDir: join(targetRoot, name),
-      });
-    }
+    const { targetRoot } = await copyPackagedBuiltinRuntime(workDir, [
+      "automations",
+      "provider-acp",
+      "connect",
+    ]);
 
     const copiedRoot = join(targetRoot, "automations");
     const packageJson = JSON.parse(


### PR DESCRIPTION
## Human comments

## What was wrong

Four packaged-builtin tests each synthesized source fixtures for all 27 auto-installed builtins and then copied all 27 runtime layouts sequentially, although three tests only exercised `automations` and the packaging test only asserted three representative layouts. That repeated filesystem work made the tests scale with unrelated registry growth and pushed the lifecycle cases from roughly 0.6 seconds unloaded to 5.4–6.2 seconds under scheduler contention, beyond their unchanged 5-second ceiling.

## What changed

The packaged-builtin fixture helpers now accept the exact builtin names a test needs. The three reconciliation lifecycle tests prepare only `automations`; the packaging test prepares `automations`, `provider-acp`, and `connect`.

This preserves the real runtime-copy transform and the packaged load, stale SDK compatibility, no-app-rebuild, source omission, plugin-owned icon, declared icon, runtime layout, and official-plugin omission assertions. It reduces source generation and runtime copying from 27 plugins per test to 1, 1, 1, and 3 without increasing a timeout, retry, polling interval, or deadline.

This is test-only and changes no server/daemon wire behavior, so `HOST_DAEMON_PROTOCOL_VERSION` does not need a bump.

## How you verified

- Before the change, the four selected cases took 6.199 s, 5.727 s, 5.419 s, and 1.663 s under a bounded 40-worker scheduler-contention profile; the first three exceeded the unchanged 5-second ceiling.
- Under the identical bounded profile after the change, they took 2.945 s, 2.391 s, 2.692 s, and 0.233 s. Both profiles used signal-safe process-group cleanup and ended with zero surviving stress processes.
- Unloaded selected-test time fell from 2.34 s to 0.74 s.
- `pnpm exec turbo run test --filter=@bb/server --force -- test/services/plugins/builtin-plugins.test.ts` — passed all 31 tests and all 8 Turbo tasks.
- `pnpm exec turbo run typecheck --filter=@bb/server --cache-dir=.turbo/cache --output-logs=new-only` — passed.
- `pnpm exec turbo run build --filter=@bb/server --cache-dir=.turbo/cache --output-logs=new-only` — passed.
- The full server Turbo suite was attempted twice on the Intel host. The changed file passed 31/31 in both runs, while unrelated suites had 46 and 25 host-contention timeouts respectively.

> AGENT GENERATED: by GPT-5.6-Sol