### PR TITLE
Stabilize plugin update scheduler completion

### DIFF
--- a/apps/server/src/services/plugins/plugin-service-internal.ts
+++ b/apps/server/src/services/plugins/plugin-service-internal.ts
@@ -127,7 +127,10 @@ export interface PluginServiceDeps {
     durationMs: number,
     onElapsed: () => void,
   ) => () => void;
-  scheduleUpdateCheck?: (delayMs: number, onElapsed: () => void) => () => void;
+  scheduleUpdateCheck?: (
+    delayMs: number,
+    onElapsed: () => Promise<void>,
+  ) => () => void;
   afterPluginRollbackStateRestored?: (args: {
     pluginId: string;
     snapshotId: string;

--- a/apps/server/src/services/plugins/plugin-updates.ts
+++ b/apps/server/src/services/plugins/plugin-updates.ts
@@ -383,21 +383,20 @@ export function createPluginUpdates(
     return Math.max(0, PLUGIN_UPDATE_CHECK_INTERVAL_MS - (now() - oldest));
   }
 
-  function runPeriodicCheck(): void {
+  async function runPeriodicCheck(): Promise<void> {
     if (periodicChecksStopped) return;
-    void updates
-      .checkForUpdates()
-      .catch((error: unknown) => {
-        deps.logger.warn({ err: error }, "periodic plugin update check failed");
-      })
-      .finally(() => {
-        if (!periodicChecksStopped) {
-          cancelPeriodicCheck = scheduleUpdateCheck(
-            PLUGIN_UPDATE_CHECK_INTERVAL_MS,
-            runPeriodicCheck,
-          );
-        }
-      });
+    try {
+      await updates.checkForUpdates();
+    } catch (error: unknown) {
+      deps.logger.warn({ err: error }, "periodic plugin update check failed");
+    } finally {
+      if (!periodicChecksStopped) {
+        cancelPeriodicCheck = scheduleUpdateCheck(
+          PLUGIN_UPDATE_CHECK_INTERVAL_MS,
+          runPeriodicCheck,
+        );
+      }
+    }
   }
 
   async function checkRows(

--- a/apps/server/test/services/plugins/plugin-update.test.ts
+++ b/apps/server/test/services/plugins/plugin-update.test.ts
@@ -111,6 +111,151 @@ describe("plugin update scheduling", () => {
       emptyDb.$client.close();
     }
   });
+
+  it("sweeps on start when a plugin was never checked, then waits out the interval across restarts", async () => {
+    const HOUR = 60 * 60 * 1_000;
+    const schedulingDb = createConnection(":memory:");
+    migrate(schedulingDb);
+    const schedulingWorkDir = await mkdtemp(
+      join(tmpdir(), "bb-plugin-update-scheduling-"),
+    );
+    let clock = Date.now();
+    let service: PluginService | undefined;
+    let scheduled: Array<{
+      delayMs: number;
+      onElapsed: () => Promise<void>;
+    }> = [];
+    let firstFetch = true;
+    let resolveFirstFetch!: (response: Response) => void;
+    const deferredFetch = new Promise<Response>((resolve) => {
+      resolveFirstFetch = resolve;
+    });
+    const packumentResponse = () =>
+      new Response(
+        JSON.stringify({
+          versions: {
+            "1.0.0": {
+              version: "1.0.0",
+              dist: { integrity: "sha512-current" },
+            },
+            "1.1.0": {
+              version: "1.1.0",
+              dist: { integrity: "sha512-next" },
+            },
+          },
+          "dist-tags": { latest: "1.1.0" },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    vi.stubGlobal("fetch", () => {
+      if (!firstFetch) return Promise.resolve(packumentResponse());
+      firstFetch = false;
+      return deferredFetch;
+    });
+
+    const upsertNpmRow = (id: string) => {
+      const packageName = `bb-plugin-${id}`;
+      upsertInstalledPlugin(schedulingDb, {
+        id,
+        source: `npm:${packageName}`,
+        provenance: { kind: "direct" },
+        sourceIntent: {
+          kind: "npm",
+          packageName,
+          registry: "https://updates.test",
+          requestedSpec: "",
+          specKind: "default",
+        },
+        exactResolution: {
+          kind: "npm",
+          version: "1.0.0",
+          integrity: "sha512-current",
+        },
+        updateState: {
+          lastCheckAt: null,
+          availableCompatibleVersion: null,
+          newestIncompatibleVersion: null,
+          statusDetail: null,
+        },
+        activeArtifactId: null,
+        rootDir: join(schedulingWorkDir, id),
+        version: "1.0.0",
+        enabled: false,
+      });
+    };
+    const restartWithScheduler = async () => {
+      await service?.stop();
+      scheduled = [];
+      service = createPluginService({
+        aiServices: createAiServiceRegistry(),
+        telemetry: createNoopTelemetryService(),
+        db: schedulingDb,
+        hub: {
+          getDaemonSessionIdForHost: () => null,
+          notifyPluginSignal: () => 0,
+          notifySystem: () => {},
+        },
+        logger,
+        dataDir: join(schedulingWorkDir, "data"),
+        appVersion: "1.0.0",
+        bundledPlugins: [],
+        stabilizationWindowMs: 0,
+        now: () => clock,
+        scheduleUpdateCheck: (delayMs, onElapsed) => {
+          const entry = { delayMs, onElapsed };
+          scheduled.push(entry);
+          return () => {
+            const index = scheduled.indexOf(entry);
+            if (index !== -1) scheduled.splice(index, 1);
+          };
+        },
+      });
+      await service.start();
+    };
+
+    try {
+      upsertNpmRow("scheduled");
+      await restartWithScheduler();
+      service?.startPeriodicUpdateChecks();
+      expect(scheduled.map((entry) => entry.delayMs)).toEqual([0]);
+      const initial = scheduled.shift();
+      if (initial === undefined)
+        throw new Error("missing initial update check");
+      const sweep = initial.onElapsed();
+      expect(getInstalledPlugin(schedulingDb, "scheduled")).toMatchObject({
+        lastUpdateCheckAt: null,
+        availableCompatibleVersion: null,
+      });
+      resolveFirstFetch(packumentResponse());
+      expect(sweep).toBeInstanceOf(Promise);
+      await sweep;
+      expect(getInstalledPlugin(schedulingDb, "scheduled")).toMatchObject({
+        lastUpdateCheckAt: clock,
+        availableCompatibleVersion: "1.1.0",
+      });
+      expect(scheduled.map((entry) => entry.delayMs)).toEqual([6 * HOUR]);
+      await service?.stopPeriodicUpdateChecks();
+      expect(scheduled).toHaveLength(0);
+
+      clock += 2 * HOUR;
+      await restartWithScheduler();
+      service?.startPeriodicUpdateChecks();
+      expect(scheduled.map((entry) => entry.delayMs)).toEqual([4 * HOUR]);
+      await service?.stopPeriodicUpdateChecks();
+
+      upsertNpmRow("never-checked");
+      await service?.checkForUpdates("scheduled");
+      service?.startPeriodicUpdateChecks();
+      expect(scheduled.map((entry) => entry.delayMs)).toEqual([0]);
+      await service?.stopPeriodicUpdateChecks();
+    } finally {
+      await service?.stopPeriodicUpdateChecks();
+      await service?.stop();
+      schedulingDb.$client.close();
+      vi.unstubAllGlobals();
+      await rm(schedulingWorkDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("plugin update service and routes", () => {
@@ -772,70 +917,6 @@ describe("plugin update service and routes", () => {
       enabled: false,
     });
   }
-
-  async function restartWithScheduler(clock: () => number) {
-    const scheduled: Array<{ delayMs: number; onElapsed: () => void }> = [];
-    await service.stop();
-    service = createPluginService({
-      aiServices: createAiServiceRegistry(),
-      telemetry: createNoopTelemetryService(),
-      db,
-      hub: {
-        getDaemonSessionIdForHost: () => null,
-        notifyPluginSignal: () => 0,
-        notifySystem: () => {},
-      },
-      logger,
-      dataDir: join(workDir, "data"),
-      appVersion: "1.0.0",
-      stabilizationWindowMs: 0,
-      now: clock,
-      scheduleUpdateCheck: (delayMs, onElapsed) => {
-        const entry = { delayMs, onElapsed };
-        scheduled.push(entry);
-        return () => {
-          const index = scheduled.indexOf(entry);
-          if (index !== -1) scheduled.splice(index, 1);
-        };
-      },
-    });
-    await service.start();
-    return scheduled;
-  }
-
-  it("sweeps on start when a plugin was never checked, then waits out the interval across restarts", async () => {
-    const HOUR = 60 * 60 * 1_000;
-    let clock = Date.now();
-    let scheduled = await restartWithScheduler(() => clock);
-    const nextCommit = await commitPlugin(repo, "1.1.0");
-
-    service.startPeriodicUpdateChecks();
-    expect(scheduled.map((entry) => entry.delayMs)).toEqual([0]);
-    scheduled.shift()?.onElapsed();
-    await vi.waitFor(() =>
-      expect(getInstalledPlugin(db, "updater")).toMatchObject({
-        lastUpdateCheckAt: clock,
-        availableCompatibleVersion: nextCommit,
-      }),
-    );
-    await vi.waitFor(() =>
-      expect(scheduled.map((entry) => entry.delayMs)).toEqual([6 * HOUR]),
-    );
-    await service.stopPeriodicUpdateChecks();
-    expect(scheduled).toHaveLength(0);
-
-    clock += 2 * HOUR;
-    scheduled = await restartWithScheduler(() => clock);
-    service.startPeriodicUpdateChecks();
-    expect(scheduled.map((entry) => entry.delayMs)).toEqual([4 * HOUR]);
-    await service.stopPeriodicUpdateChecks();
-
-    upsertNpmRow("never-checked", "https://never-checked.test");
-    await service.checkForUpdates("updater");
-    service.startPeriodicUpdateChecks();
-    expect(scheduled.map((entry) => entry.delayMs)).toEqual([0]);
-    await service.stopPeriodicUpdateChecks();
-  }, 60_000);
 
   it("shares one in-flight full sweep between concurrent callers", async () => {
     const first = service.checkForUpdates();


### PR DESCRIPTION
## Human comments

## What was wrong

The periodic plugin-update regression triggered an injected timer callback whose `void` contract discarded the full sweep's retained promise, then polled durable SQLite state with `vi.waitFor` while the sweep performed real Git resolution and candidate staging. Under contention, that Git work could finish after the polling window even though it was still live: the failing main run had five simultaneous unrelated Git/build timeouts, and a deterministic deferred resolver reproduced the boundary by showing the callback returned `undefined` while update state remained null. The existing stop path awaits the retained full-sweep promise, ruling out cancellation or a leaked sweep. The scheduler test also inherited the file's full Git-plugin install/load fixture and restarted it several times for behavior that does not depend on Git.

## What changed

The internal update scheduler callback now returns `Promise<void>`, and the periodic runner awaits the existing full-sweep promise before its unchanged six-hour reschedule. Error logging, initial zero delay, stop gating, shared in-flight sweeps, and durable update-state writes are unchanged.

The scheduling regression now owns an in-memory database, a disabled npm registration, a deferred in-memory registry response, and an injected scheduler. It awaits the elapsed callback directly and retains exact coverage for never-checked startup, persisted check time and candidate, six-hour scheduling, four-hour restart remainder, never-checked priority after restart, and timer cancellation. Real Git update and lifecycle behavior remains covered by the surrounding integration tests. The test no longer carries a 60-second override, and no polling, retry, scheduler, or test deadline was increased.

This changes only a server-internal dependency seam. There is no server/daemon wire-field or meaning change, so `HOST_DAEMON_PROTOCOL_VERSION` does not need a bump. There is no CLI, SDK, configuration, or documentation surface change.

## How you verified

- Before the runtime change, the new deterministic regression failed in 287ms with `expected undefined to be an instance of Promise`, while the deferred sweep was still in flight.
- After the runtime change, the same focused regression passed in 342ms.
- With 24 externally bounded CPU burners, the regression passed in 2.660s; the controller reported `owned_process_survivors=[]` and `marker_survivors=none`.
- `pnpm exec turbo run test --filter=@bb/server -- test/services/plugins/plugin-update.test.ts` — all 27 tests passed; 118.483s test time, with no survivor.
- `pnpm exec turbo run typecheck build --filter=@bb/server` — both tasks passed, with no survivor.
- `git diff --check` — passed.

A complete server-suite attempt was intentionally terminated after another BB thread started a second full server suite on the same Intel host and unrelated timeline tests began failing under the resulting contention. The owned process group was removed completely. The isolated 27-test plugin-update suite was rerun without competing workload and passed in full. No matching GitHub issue or PR was found, so there is no `Fixes` reference.

> AGENT GENERATED: by GPT-5.6-Sol
