### PR TITLE
Fix Browser Automation in Linux AppImage

### DIFF
--- a/plugins/browser-automation/process.test.ts
+++ b/plugins/browser-automation/process.test.ts
@@ -1,11 +1,98 @@
-import { spawn } from "node:child_process";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { execFile, spawn } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import { supervise } from "./process.js";
 
 describe("process ownership", () => {
+  it.each([false, true])(
+    "runs the supervisor in Node mode without leaking it to external children (Electron: %s)",
+    async (electron) => {
+      const root = await mkdtemp(join(tmpdir(), "db-supervisor-environment-"));
+      const launcher = join(root, "runtime");
+      const supervisorEnvironment = join(root, "supervisor.json");
+      const childEnvironment = join(root, "child.json");
+      await writeFile(
+        launcher,
+        `#!${process.execPath}
+const { writeFileSync } = require("node:fs");
+const { spawnSync } = require("node:child_process");
+if (process.env.ELECTRON_RUN_AS_NODE !== ${electron ? '"1"' : "undefined"}) process.exit(42);
+writeFileSync(${JSON.stringify(supervisorEnvironment)}, JSON.stringify(process.env));
+const result = spawnSync(${JSON.stringify(process.execPath)}, process.argv.slice(2), { stdio: "inherit", env: process.env });
+process.exit(result.status ?? 1);
+`,
+        { mode: 0o700 },
+      );
+      const childCode = `require("node:fs").writeFileSync(${JSON.stringify(childEnvironment)}, JSON.stringify(process.env)); setInterval(() => {}, 1000);`;
+      const code = `
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { setTimeout as delay } from "node:timers/promises";
+import { supervise, execute } from ${JSON.stringify(new URL("./process.ts", import.meta.url).href)};
+import { runtimeEnvironment } from ${JSON.stringify(new URL("./runtime.ts", import.meta.url).href)};
+Object.defineProperty(process, "execPath", { value: ${JSON.stringify(launcher)} });
+${electron ? 'Object.defineProperty(process.versions, "electron", { value: "41.0.0" });' : ""}
+const env = runtimeEnvironment(${JSON.stringify(root)});
+assert.equal(env.ELECTRON_RUN_AS_NODE, undefined);
+const original = { ...env };
+const child = supervise(${JSON.stringify(process.execPath)}, ["-e", ${JSON.stringify(childCode)}], env);
+try {
+  const deadline = AbortSignal.timeout(5000);
+  while (true) {
+    deadline.throwIfAborted();
+    assert.ok(child.alive(), "Supervisor exited before external child started");
+    try { await readFile(${JSON.stringify(childEnvironment)}, "utf8"); break; } catch {}
+    await delay(25);
+  }
+  assert.deepEqual(env, original);
+  const output = await execute(${JSON.stringify(process.execPath)}, ["-e", "process.stdout.write(JSON.stringify(process.env))"], env, deadline);
+  assert.deepEqual(JSON.parse(output), original);
+} finally {
+  await child.close();
+}
+`;
+      try {
+        await promisify(execFile)(
+          process.execPath,
+          [
+            "--conditions=source",
+            "--import",
+            "tsx",
+            "--input-type=module",
+            "-e",
+            code,
+          ],
+          {
+            env: {
+              ...process.env,
+              ELECTRON_RUN_AS_NODE: "1",
+              TSX_TSCONFIG_PATH: fileURLToPath(
+                new URL("./tsconfig.smoke.json", import.meta.url),
+              ),
+            },
+            timeout: 10_000,
+          },
+        );
+        const supervisorEnv = JSON.parse(
+          await readFile(supervisorEnvironment, "utf8"),
+        );
+        const childEnv = JSON.parse(await readFile(childEnvironment, "utf8"));
+        expect(supervisorEnv.ELECTRON_RUN_AS_NODE).toBe(
+          electron ? "1" : undefined,
+        );
+        expect(childEnv.ELECTRON_RUN_AS_NODE).toBeUndefined();
+        expect(childEnv.DEV_BROWSER_HOME).toBe(root);
+        expect(childEnv.DEV_BROWSER_SOCKET).toBe(join(root, "daemon.sock"));
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    },
+    12_000,
+  );
   it("worker death closes the supervisor pipe and kills its child", async () => {
     const root = await mkdtemp(join(tmpdir(), "db-worker-death-"));
     const file = join(root, "pid");

--- a/plugins/browser-automation/process.ts
+++ b/plugins/browser-automation/process.ts
@@ -2,7 +2,9 @@ import { spawn } from "node:child_process";
 
 const supervisor = `
 const { spawn } = require('node:child_process');
-const child = spawn(process.argv[1], process.argv.slice(2), { detached: true, stdio: 'ignore', env: process.env });
+const env = { ...process.env };
+delete env.ELECTRON_RUN_AS_NODE;
+const child = spawn(process.argv[1], process.argv.slice(2), { detached: true, stdio: 'ignore', env });
 let stopping = false;
 function kill(signal) { if (child.pid) { try { process.kill(-child.pid, signal); } catch {} } }
 function stop() {
@@ -25,7 +27,9 @@ export function supervise(
   env: NodeJS.ProcessEnv,
 ) {
   const child = spawn(process.execPath, ["-e", supervisor, command, ...args], {
-    env,
+    env: process.versions.electron
+      ? { ...env, ELECTRON_RUN_AS_NODE: "1" }
+      : env,
     stdio: ["pipe", "ignore", "ignore"],
   });
   child.stdin.on("error", () => {});

--- a/plugins/browser-automation/vitest.config.ts
+++ b/plugins/browser-automation/vitest.config.ts
@@ -1,8 +1,15 @@
-import { defineWorkspaceTestConfig } from "../../vitest.shared.js";
+import { fileURLToPath } from "node:url";
+import {
+  defineWorkspaceTestConfig,
+  sharedWorkerProjects,
+} from "../../vitest.shared.js";
 export default defineWorkspaceTestConfig({
   test: {
-    name: "bb-plugin-browser-automation",
-    include: ["**/*.test.ts"],
-    exclude: ["dist/**", "node_modules/**"],
+    projects: sharedWorkerProjects({
+      pkgDir: fileURLToPath(new URL(".", import.meta.url)),
+      name: "bb-plugin-browser-automation",
+      include: ["**/*.test.ts"],
+      exclude: ["dist/**", "node_modules/**"],
+    }),
   },
 });


### PR DESCRIPTION
## Human comments

## What was wrong

Browser Automation sanitizes the environment used for Chrome and DevBrowser, then launches its supervisor through `process.execPath`. In packaged Linux AppImage host workers that executable is Electron, so removing `ELECTRON_RUN_AS_NODE` prevents the `-e` supervisor from running as Node and leaves the host call pending until its deadline. See #3516.

## What changed

- Enable `ELECTRON_RUN_AS_NODE=1` only when starting the supervisor through Electron.
- Copy and sanitize the supervisor environment before launching Chrome or DevBrowser so Electron Node mode cannot leak into external children.
- Add real subprocess coverage for both packaged-Electron and ordinary-Node semantics, including caller-environment immutability and the direct execution path.
- Move the plugin's Vitest config to the repository-standard `sharedWorkerProjects` setup required by the process-global regression fixture.

There are no host-daemon wire, CLI, SDK, or documentation changes, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

## How you verified

- `BB_DATA_DIR=/tmp/bb-browser-upstream-check-data pnpm exec turbo run test typecheck build --filter=bb-plugin-browser-automation --env-mode=loose`
  - 6 test files and 38 tests passed
  - typecheck passed
  - server and host plugin bundles built
- Mutation checks independently removed the supervisor flag, leaked it to children, and applied it unconditionally; the regression test rejected each defect.
- A disposable harness imported the patched source while running under the mounted AppImage Electron executable, then started real Chrome and the pinned DevBrowser runtime. Navigation, clicking, snapshots, JPEG capture, environment isolation, and cleanup passed.
- A separate disposable BB stack installed and reloaded the patched bundled plugin. The next real CLI → server → host-daemon → host-worker call opened a headless session and returned the expected page snapshot. The production BB server was not restarted or modified.
- `pnpm exec oxfmt plugins/browser-automation/process.ts plugins/browser-automation/process.test.ts plugins/browser-automation/vitest.config.ts --check`
- `git diff --check`

Fixes #3516

> AGENT GENERATED
