### PR TITLE
Stabilize git marketplace lifecycle test

### DIFF
--- a/apps/server/test/services/plugin-catalog/third-party-marketplaces.test.ts
+++ b/apps/server/test/services/plugin-catalog/third-party-marketplaces.test.ts
@@ -184,74 +184,81 @@ describe("third-party marketplaces", () => {
     return repo;
   }
 
-  it("adds, refreshes, and removes a git marketplace read from a real checkout", async () => {
-    const repo = await gitMarketplace({
-      name: "acme-plugins",
-      plugins: [entry({ icon: { url: "./icons/notes.svg" } })],
-      icon: VALID_SVG,
-    });
-    const catalog = service({ fetch: marketplaceFetch({}) });
+  describe("git marketplace lifecycle", () => {
+    let repo: string;
 
-    const added = await catalog.addMarketplace(`git:${repo}@main`);
-    expect(added).toMatchObject({
-      name: "acme-plugins",
-      displayName: "Acme Plugins",
-      official: false,
-      sourceKind: "git",
-      source: `git:${repo}@main`,
-      entryCount: 1,
+    beforeEach(async () => {
+      repo = await gitMarketplace({
+        name: "acme-plugins",
+        plugins: [entry({ icon: { url: "./icons/notes.svg" } })],
+        icon: VALID_SVG,
+      });
     });
-    expect(added.resolvedCommit).toMatch(/^[0-9a-f]{40}$/u);
-    expect(installedCatalogEntries).toEqual([]);
-    expect(
-      getPluginMarketplaceIcon(db, "acme-plugins", "notes")?.contentType,
-    ).toBe("image/svg+xml");
-    expect(
-      await rm(join(dataDir, "marketplaces", "staging"), {
-        recursive: true,
-        force: true,
-      }).then(() => true),
-    ).toBe(true);
 
-    await writeFile(
-      join(repo, "marketplace.json"),
-      JSON.stringify(
-        manifest("acme-plugins", [
-          entry({ icon: { url: "./icons/notes.svg" } }),
-          entry({ id: "status", displayName: "Acme Status", icon: "Zap" }),
-        ]),
-      ),
-    );
-    await run("git", ["commit", "-qam", "second"], { cwd: repo });
-    const [refreshed] = await catalog.refreshMarketplaces({
-      name: "acme-plugins",
+    it("adds, refreshes, and removes a git marketplace read from a real checkout", async () => {
+      const catalog = service({ fetch: marketplaceFetch({}) });
+
+      const added = await catalog.addMarketplace(`git:${repo}@main`);
+      expect(added).toMatchObject({
+        name: "acme-plugins",
+        displayName: "Acme Plugins",
+        official: false,
+        sourceKind: "git",
+        source: `git:${repo}@main`,
+        entryCount: 1,
+      });
+      expect(added.resolvedCommit).toMatch(/^[0-9a-f]{40}$/u);
+      expect(installedCatalogEntries).toEqual([]);
+      expect(
+        getPluginMarketplaceIcon(db, "acme-plugins", "notes")?.contentType,
+      ).toBe("image/svg+xml");
+      expect(
+        await rm(join(dataDir, "marketplaces", "staging"), {
+          recursive: true,
+          force: true,
+        }).then(() => true),
+      ).toBe(true);
+
+      await writeFile(
+        join(repo, "marketplace.json"),
+        JSON.stringify(
+          manifest("acme-plugins", [
+            entry({ icon: { url: "./icons/notes.svg" } }),
+            entry({ id: "status", displayName: "Acme Status", icon: "Zap" }),
+          ]),
+        ),
+      );
+      await run("git", ["commit", "-qam", "second"], { cwd: repo });
+      const [refreshed] = await catalog.refreshMarketplaces({
+        name: "acme-plugins",
+      });
+      expect(refreshed).toMatchObject({ name: "acme-plugins", ok: true });
+      expect(refreshed?.marketplace.entryCount).toBe(2);
+      expect(refreshed?.marketplace.resolvedCommit).not.toBe(
+        added.resolvedCommit,
+      );
+
+      const removed = await catalog.removeMarketplace("acme-plugins");
+      expect(removed.convertedPluginIds).toEqual([]);
+      expect(getPluginMarketplace(db, "acme-plugins")).toBeUndefined();
+      expect(
+        getPluginMarketplaceIcon(db, "acme-plugins", "notes"),
+      ).toBeUndefined();
+      expect(catalog.listMarketplaces().map((row) => row.name)).toEqual([
+        "bb-official",
+        "bb-community",
+      ]);
+
+      const readded = await catalog.addMarketplace(`git:${repo}@main`);
+      expect(readded).toMatchObject({
+        name: "acme-plugins",
+        entryCount: 2,
+        resolvedCommit: refreshed?.marketplace.resolvedCommit,
+      });
+      expect(
+        getPluginMarketplaceIcon(db, "acme-plugins", "notes")?.contentType,
+      ).toBe("image/svg+xml");
     });
-    expect(refreshed).toMatchObject({ name: "acme-plugins", ok: true });
-    expect(refreshed?.marketplace.entryCount).toBe(2);
-    expect(refreshed?.marketplace.resolvedCommit).not.toBe(
-      added.resolvedCommit,
-    );
-
-    const removed = await catalog.removeMarketplace("acme-plugins");
-    expect(removed.convertedPluginIds).toEqual([]);
-    expect(getPluginMarketplace(db, "acme-plugins")).toBeUndefined();
-    expect(
-      getPluginMarketplaceIcon(db, "acme-plugins", "notes"),
-    ).toBeUndefined();
-    expect(catalog.listMarketplaces().map((row) => row.name)).toEqual([
-      "bb-official",
-      "bb-community",
-    ]);
-
-    const readded = await catalog.addMarketplace(`git:${repo}@main`);
-    expect(readded).toMatchObject({
-      name: "acme-plugins",
-      entryCount: 2,
-      resolvedCommit: refreshed?.marketplace.resolvedCommit,
-    });
-    expect(
-      getPluginMarketplaceIcon(db, "acme-plugins", "notes")?.contentType,
-    ).toBe("image/svg+xml");
   });
 
   it("removes a checkout left by a prior process crash", async () => {


### PR DESCRIPTION
## Human comments

## What was wrong

The git marketplace lifecycle test built its source repository inside the five-second test body before exercising three real checkout materializations for add, refresh, and re-add. Repository initialization, configuration, staging, commits, and those checkouts are serial child-process work, so normal full-suite contention could exhaust the test budget even though marketplace behavior was correct. The evidence-backed failure reached 5.093 seconds in [main CI run 34630120164](https://github.com/get-bb/bb/actions/runs/34630120164), while nearby main runs passed the unchanged test in 2.808 and 3.138 seconds.

## What changed

`third-party-marketplaces.test.ts` now constructs the real git source repository in a scoped setup hook. The timed test still performs and asserts the full add, new commit, refresh, removal, and re-add lifecycle, including resolved commits, catalog persistence, icon persistence/removal, staging cleanup, and installed-plugin behavior. No timeout, polling, retry, production code, CLI, SDK, server/daemon wire contract, or documentation changed, so `HOST_DAEMON_PROTOCOL_VERSION` does not need a bump.

## How you verified

- Before the change, a bounded 16-copy reproduction with 24 CPU burners produced the same 5,000 ms timeout in 16/16 copies. Phase timing showed failures during refresh or re-add after source-repository setup consumed 0.74–1.95 seconds and the first materialization consumed up to another 2.83 seconds.
- After the change, the identical bounded 16-copy/24-burner workload passed 16/16 copies with zero surviving processes. Whole-test times remained 9.33–10.72 seconds because they include the separately bounded setup hook, demonstrating that the change isolates fixture construction rather than relaxing the behavior deadline.
- `pnpm exec turbo run test --filter=@bb/server -- test/services/plugin-catalog/third-party-marketplaces.test.ts` — 23/23 tests passed; all 8 Turbo tasks passed.
- `pnpm exec turbo run typecheck build --filter=@bb/server` — all 6 Turbo tasks passed.
- `pnpm exec prettier --check apps/server/test/services/plugin-catalog/third-party-marketplaces.test.ts` and `git diff --check` passed.
- The full `@bb/server` Turbo suite was attempted twice. The changed file passed 23/23 both times, including the lifecycle test in 2.231 and 2.557 seconds, but the overall runs remained red from unrelated timeouts in six and seven other files on this Intel host.

> AGENT GENERATED: by GPT-5.6-Sol
