### PR TITLE
Avoid highlighting a project when picker opens

### DIFF
--- a/apps/app/src/components/pickers/ProjectSelector.test.tsx
+++ b/apps/app/src/components/pickers/ProjectSelector.test.tsx
@@ -34,10 +34,13 @@ describe("ProjectSelector", () => {
     const alpha = screen.getByRole("option", { name: "Alpha Web" });
     const bravo = screen.getByRole("option", { name: "Bravo API" });
     const charlie = screen.getByRole("option", { name: "Charlie Docs" });
-    expect(alpha.getAttribute("aria-selected")).toBe("true");
+    expect(screen.queryByRole("option", { selected: true })).toBeNull();
     expect(charlie.getAttribute("aria-selected")).toBe("false");
     expect(charlie.getAttribute("aria-current")).toBe("true");
 
+    fireEvent.keyDown(search, { key: "ArrowDown" });
+
+    expect(alpha.getAttribute("aria-selected")).toBe("true");
     fireEvent.keyDown(search, { key: "ArrowDown" });
 
     expect(bravo.getAttribute("aria-selected")).toBe("true");
@@ -119,10 +122,13 @@ describe("ProjectSelector", () => {
     expect(document.activeElement).toBe(command);
 
     if (command === null) return;
+    expect(screen.queryByRole("option", { selected: true })).toBeNull();
+    fireEvent.keyDown(command, { key: "Enter" });
+    expect(onChange).not.toHaveBeenCalled();
     fireEvent.keyDown(command, { key: "ArrowDown" });
     fireEvent.keyDown(command, { key: "Enter" });
 
-    expect(onChange).toHaveBeenCalledWith("proj_bravo");
+    expect(onChange).toHaveBeenCalledWith("proj_alpha");
   });
 
   it("keeps project actions visible and resets search after closing", () => {
@@ -167,6 +173,7 @@ describe("ProjectSelector", () => {
       }).value,
     ).toBe("");
     expect(screen.getByRole("option", { name: "Alpha Web" })).toBeTruthy();
+    expect(screen.queryByRole("option", { selected: true })).toBeNull();
   });
 
   it("keeps empty-list actions in the project group", () => {
@@ -188,6 +195,7 @@ describe("ProjectSelector", () => {
       "Project",
     );
     expect(groups[0]?.querySelectorAll("[cmdk-item]")).toHaveLength(2);
+    expect(screen.queryByRole("option", { selected: true })).toBeNull();
   });
 
   it("keeps the search fixed while the project results scroll", () => {

--- a/apps/app/src/components/pickers/ProjectSelector.tsx
+++ b/apps/app/src/components/pickers/ProjectSelector.tsx
@@ -21,6 +21,7 @@ import { searchPickerOptions } from "./picker-search";
 import { useResetPickerScroll } from "./useResetPickerScroll";
 
 const PROJECT_SEARCH_MIN_OPTIONS = 5;
+const NO_HIGHLIGHT_VALUE = "__project-picker-idle__";
 const PROJECT_PICKER_ITEM_CLASS_NAME = "py-[0.3125rem] text-xs max-md:py-2";
 
 export interface ProjectSelectorOption {
@@ -63,6 +64,7 @@ export function ProjectSelector({
 }: ProjectSelectorProps) {
   const [open, setOpen] = useState(defaultOpen ?? false);
   const [searchQuery, setSearchQuery] = useState("");
+  const [highlightedValue, setHighlightedValue] = useState(NO_HIGHLIGHT_VALUE);
   const commandRef = useRef<HTMLDivElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const listRef = useResetPickerScroll<HTMLDivElement>(searchQuery);
@@ -97,6 +99,7 @@ export function ProjectSelector({
     projects.length > 0 && (Boolean(createProjectAction) || allowNoProject);
   const handleOpenChange = (nextOpen: boolean) => {
     setOpen(nextOpen);
+    setHighlightedValue(NO_HIGHLIGHT_VALUE);
     if (!nextOpen) {
       setSearchQuery("");
     }
@@ -165,6 +168,8 @@ export function ProjectSelector({
           ref={commandRef}
           label="Search projects"
           shouldFilter={false}
+          value={highlightedValue}
+          onValueChange={setHighlightedValue}
           className="min-h-0"
         >
           {showSearch ? (


### PR DESCRIPTION
## Human comments

## What was wrong

The project selector let cmdk choose its first item whenever the picker opened. That made the first project look keyboard-highlighted before the user had navigated, even when the current-project checkmark represented a different concept, so opening the menu appeared to preselect an action.

## What changed

- Control the command menu's highlighted value with an internal idle sentinel.
- Reset that highlight whenever the picker opens or closes, while preserving the current-project checkmark, search, and keyboard navigation.
- Add regressions for initial open, Enter before navigation, ArrowDown selection, reopen, and empty-list actions.

No API, CLI, persistence, or server/daemon wire contract changed.

## Before / after

Matched Ladle `pickers/Project Selector` captures at 620×270. The checkmark still identifies the current project; only the automatic filled highlight is removed.

| Before — first project automatically highlighted | After — no project highlighted until navigation |
| --- | --- |
| ![Before: the bb row has a filled highlight immediately after opening](https://raw.githubusercontent.com/get-bb/bb/c61a9a69275ad0f6704b219c2ccbf6d8d962c95d/docs/pr-evidence/thr_w6gmkeft9b/before.png) | ![After: neither project row is highlighted immediately after opening](https://raw.githubusercontent.com/get-bb/bb/c61a9a69275ad0f6704b219c2ccbf6d8d962c95d/docs/pr-evidence/thr_w6gmkeft9b/after.png) |

## How you verified

- `pnpm exec turbo run test --filter=@bb/app --force -- ProjectSelector.test.tsx` — 7/7 tests passed.
- `pnpm exec turbo run typecheck lint --filter=@bb/app --force` — passed; lint reported 0 errors.
- Targeted Oxfmt and `git diff --check` passed.
- Browser semantics matched the visuals: the baseline exposed selected option `bb`; the fixed head exposed no selected option before keyboard navigation.
- Both immutable screenshot URLs return HTTP 200 and bytes identical to the reviewed local captures.

> AGENT GENERATED
