### PR TITLE
Fix subprocess environment assertions on macOS

### DIFF
--- a/plugins/browser-automation/process.test.ts
+++ b/plugins/browser-automation/process.test.ts
@@ -50,7 +50,12 @@ try {
   }
   assert.deepEqual(env, original);
   const output = await execute(${JSON.stringify(process.execPath)}, ["-e", "process.stdout.write(JSON.stringify(process.env))"], env, deadline);
-  assert.deepEqual(JSON.parse(output), original);
+  const executedEnv = JSON.parse(output);
+  for (const [key, value] of Object.entries(original)) {
+    assert.equal(executedEnv[key], value);
+  }
+  assert.equal(executedEnv.ELECTRON_RUN_AS_NODE, undefined);
+  assert.deepEqual(env, original);
 } finally {
   await child.close();
 }


### PR DESCRIPTION
## Human comments

## What was wrong

The browser-automation subprocess tests compared the child environment to the supplied environment as an exact object. On macOS, Node adds `__CF_USER_TEXT_ENCODING` to spawned processes, so the assertions failed even though every supplied value was preserved and `ELECTRON_RUN_AS_NODE` was correctly excluded from external children.

## What changed

The test now verifies every supplied environment entry individually, continues to assert that `ELECTRON_RUN_AS_NODE` does not leak, and confirms the caller-owned environment object remains unchanged. Production behavior is unchanged.

Follow-up to #3517.

## How you verified

- `pnpm exec turbo run test typecheck build --filter=bb-plugin-browser-automation --force`
  - 38/38 tests passed across 6 files
  - Turbo typecheck passed
  - Plugin build passed
- `pnpm exec oxfmt --check plugins/browser-automation/process.test.ts`
- `git diff --check origin/main...HEAD`

> AGENT GENERATED
