### PR TITLE
Dismiss notifications after the thread finishes loading

### DIFF
--- a/apps/app/src/lib/native-shell/NativeThreadReady.test.tsx
+++ b/apps/app/src/lib/native-shell/NativeThreadReady.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NativeThreadReady } from "./NativeThreadReady";
+
+const mocks = vi.hoisted(() => ({ post: vi.fn(), available: true }));
+vi.mock("./native-shell", () => ({
+  getNativeShell: () => mocks.available ? { post: mocks.post } : null,
+}));
+
+describe("NativeThreadReady", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mocks.available = true;
+    mocks.post.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  function mount() {
+    return render(
+      <MemoryRouter initialEntries={["/projects/proj_1/threads/thr_1"]}>
+        <NativeThreadReady threadId="thr_1" />
+      </MemoryRouter>,
+    );
+  }
+
+  it("reports the destination only after its content has had a paint opportunity", () => {
+    mount();
+    act(() => vi.advanceTimersToNextFrame());
+    expect(mocks.post).not.toHaveBeenCalled();
+    act(() => vi.advanceTimersToNextFrame());
+    expect(mocks.post).toHaveBeenCalledExactlyOnceWith({
+      type: "thread-ready",
+      threadId: "thr_1",
+      path: "/projects/proj_1/threads/thr_1",
+    });
+  });
+
+  it("does not report a page that unmounts before painting", () => {
+    const view = mount();
+    act(() => vi.advanceTimersToNextFrame());
+    view.unmount();
+    act(() => vi.advanceTimersToNextFrame());
+    expect(mocks.post).not.toHaveBeenCalled();
+  });
+
+  it("does not require a native bridge in the web app", () => {
+    mocks.available = false;
+    mount();
+    act(() => vi.advanceTimersByTime(100));
+    expect(mocks.post).not.toHaveBeenCalled();
+  });
+});

--- a/apps/app/src/lib/native-shell/NativeThreadReady.tsx
+++ b/apps/app/src/lib/native-shell/NativeThreadReady.tsx
@@ -1,0 +1,24 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+import { getNativeShell } from "./native-shell";
+
+export function NativeThreadReady({ threadId }: { threadId: string }) {
+  const { pathname, search } = useLocation();
+
+  useEffect(() => {
+    const shell = getNativeShell();
+    if (shell === null) return;
+    let frame = requestAnimationFrame(() => {
+      frame = requestAnimationFrame(() => {
+        shell.post({
+          type: "thread-ready",
+          threadId,
+          path: `${pathname}${search}`,
+        });
+      });
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [pathname, search, threadId]);
+
+  return null;
+}

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -11,6 +11,7 @@ import { useSystemProviderInfo } from "@/hooks/queries/system-queries";
 import { useNavigate } from "react-router-dom";
 import { useAtom } from "jotai";
 import { useDesktopBrowserReveal } from "@/lib/use-desktop-browser-reveal";
+import { NativeThreadReady } from "@/lib/native-shell/NativeThreadReady";
 import { atomWithStorage } from "jotai/utils";
 import {
   isRunningThreadRuntimeDisplayStatus,
@@ -3016,6 +3017,9 @@ function ThreadDetailViewInternal(props: ThreadRoutePathArgs) {
   );
   return (
     <>
+      {isFocused && !timelineLoading && !timelineError ? (
+        <NativeThreadReady threadId={thread.id} />
+      ) : null}
       <ThreadArchiveCommandHandler thread={thread} />
       <ThreadRenameCommandHandler thread={thread} />
       <ThreadProviderContext.Provider value={threadProviderContextValue}>

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -696,11 +696,16 @@ add-root-cert`). Env: `BB_MOBILE_E2E_GATE_PORT` (42998),
   characters in `tokenSuffix`. A token can receive pushes but cannot read
   server data.
 - Handling: a foreground arrival becomes a toast with "Open" (no system
-  banner). Open dismisses that toast 500 ms after resolving its server and
-  navigating. A failed lookup overlays an error for two seconds, then reveals
+  banner). Open dismisses that toast 100 ms after the destination conversation has painted and
+  the native navigation transition has finished. A failed lookup overlays an error for two seconds, then reveals
   the original notification's Open action for retry. Its expiry pauses during
-  lookup and restarts for eight seconds on failure. Repeated taps do not repeat
+  lookup and page loading, and restarts for eight seconds on failure or leaving
+  the page before completion. Repeated taps do not repeat
   navigation. Unopened toasts keep their eight-second lifetime.
+  Bridge version 3 adds an optional `thread-ready` message after the conversation
+  paints. Versions 1 and 2 remain supported; older shells ignore the new message.
+  An older server without the message leaves the opened toast available for
+  manual dismissal.
   A tap on a background / cold-start notification opens
   `/threads/<threadId>` on the profile that owns it. The phone first matches
   the optional `serverUrl` hint. It probes saved profiles for the thread only

--- a/apps/mobile/e2e/flows/notification-loading.yaml
+++ b/apps/mobile/e2e/flows/notification-loading.yaml
@@ -13,9 +13,13 @@ env:
 - tapOn:
     id: "add-server-submit"
 - extendedWaitUntil:
-    visible: "Turn on notifications"
-    timeout: 30000
-- tapOn: "Turn on notifications"
+    visible: ".*(Turn on notifications|Ask anything).*"
+    timeout: 60000
+- runFlow:
+    when:
+      visible: "Turn on notifications"
+    commands:
+      - tapOn: "Turn on notifications"
 - extendedWaitUntil:
     visible: ".*Ask anything.*"
     timeout: 60000

--- a/apps/mobile/e2e/flows/notification-loading.yaml
+++ b/apps/mobile/e2e/flows/notification-loading.yaml
@@ -1,0 +1,52 @@
+appId: app.getbb.mobile
+env:
+  SERVER_URL: "http://127.0.0.1:42995"
+---
+- runFlow: ../subflows/launch-app.yaml
+- tapOn:
+    id: "server-url-input"
+- inputText: "${SERVER_URL}"
+- tapOn:
+    id: "server-label-input"
+- inputText: "E2E backend"
+- tapOn: "Server URL"
+- tapOn:
+    id: "add-server-submit"
+- extendedWaitUntil:
+    visible: "Turn on notifications"
+    timeout: 30000
+- tapOn: "Turn on notifications"
+- extendedWaitUntil:
+    visible: ".*Ask anything.*"
+    timeout: 60000
+- startRecording: notification-loading
+- runScript:
+    file: ../scripts/send-notification.js
+    env:
+      SCENARIO: slow-completed
+- extendedWaitUntil:
+    visible: "Thread finished"
+    timeout: 5000
+- takeScreenshot: notification-arrived
+- tapOn:
+    text: "Open"
+    waitToSettleTimeoutMs: 0
+- runScript:
+    file: ../scripts/send-notification.js
+    env:
+      SCENARIO: wait-for-timeline
+- takeScreenshot: notification-loading
+- assertNotVisible: ".*Response to: Hello from the seed.*"
+- runScript:
+    file: ../scripts/send-notification.js
+    env:
+      SCENARIO: release-timeline
+- extendedWaitUntil:
+    visible: ".*Response to: Hello from the seed.*"
+    timeout: 30000
+- takeScreenshot: notification-thread
+- extendedWaitUntil:
+    notVisible: "Thread finished"
+    timeout: 12000
+- takeScreenshot: notification-dismissed
+- stopRecording

--- a/apps/mobile/e2e/scripts/ci-run-flows.sh
+++ b/apps/mobile/e2e/scripts/ci-run-flows.sh
@@ -47,7 +47,7 @@ fi
 export SERVER_URL="${SERVER_URL:-http://127.0.0.1:41999}"
 mkdir -p "$ARTIFACTS"
 
-if [[ " ${FLOWS[*]} " == *" notification-open "* || " ${FLOWS[*]} " == *" notification-retry "* ]]; then
+if [[ " ${FLOWS[*]} " == *" notification-open "* || " ${FLOWS[*]} " == *" notification-retry "* || " ${FLOWS[*]} " == *" notification-loading "* ]]; then
   node scripts/notification-control.mjs "$UDID" "$ARTIFACTS" "$ARTIFACTS/../backend.log" > "$ARTIFACTS/notification-control.log" 2>&1 &
   notification_control_pid=$!
   trap 'kill "$notification_control_pid" 2>/dev/null || true' EXIT

--- a/apps/mobile/e2e/scripts/notification-control.mjs
+++ b/apps/mobile/e2e/scripts/notification-control.mjs
@@ -20,7 +20,11 @@ const proxy = createServer((request, response) => {
   const forward = () => {
     const upstream = proxyRequest(new URL(request.url, details.serverUrl), {
       method: request.method,
-      headers: { ...request.headers, host: new URL(details.serverUrl).host },
+      headers: {
+        ...request.headers,
+        host: new URL(details.serverUrl).host,
+        ...(request.headers.origin ? { origin: new URL(details.serverUrl).origin } : {}),
+      },
     }, (result) => {
       response.writeHead(result.statusCode, result.headers);
       result.pipe(response);
@@ -40,7 +44,8 @@ proxy.on("upgrade", (request, socket, head) => {
   const upstream = connect(Number(target.port), target.hostname, () => {
     upstream.write(`${request.method} ${request.url} HTTP/1.1\r\n`);
     for (const [key, value] of Object.entries(request.headers)) {
-      upstream.write(`${key}: ${key === "host" ? target.host : value}\r\n`);
+      const forwarded = key === "host" ? target.host : key === "origin" ? target.origin : value;
+      upstream.write(`${key}: ${forwarded}\r\n`);
     }
     upstream.write("\r\n");
     upstream.write(head);

--- a/apps/mobile/e2e/scripts/notification-control.mjs
+++ b/apps/mobile/e2e/scripts/notification-control.mjs
@@ -1,6 +1,7 @@
 import { execFileSync } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
-import { createServer } from "node:http";
+import { createServer, request as proxyRequest } from "node:http";
+import { connect } from "node:net";
 import { join } from "node:path";
 
 const [udid, artifacts, backendLog] = process.argv.slice(2);
@@ -13,14 +14,68 @@ if (!udid || !artifacts || !details?.threads?.completed) {
   throw new Error("Expected simulator, artifacts directory and seeded backend details");
 }
 
+let holdTimeline = false;
+const held = [];
+const proxy = createServer((request, response) => {
+  const forward = () => {
+    const upstream = proxyRequest(new URL(request.url, details.serverUrl), {
+      method: request.method,
+      headers: { ...request.headers, host: new URL(details.serverUrl).host },
+    }, (result) => {
+      response.writeHead(result.statusCode, result.headers);
+      result.pipe(response);
+    });
+    upstream.on("error", () => response.writeHead(502).end());
+    request.pipe(upstream);
+  };
+  if (holdTimeline && request.url.includes(`/threads/${details.threads.completed}/timeline`)) {
+    held.push(forward);
+    console.log("holding timeline", request.url);
+  } else {
+    forward();
+  }
+});
+proxy.on("upgrade", (request, socket, head) => {
+  const target = new URL(details.serverUrl);
+  const upstream = connect(Number(target.port), target.hostname, () => {
+    upstream.write(`${request.method} ${request.url} HTTP/1.1\r\n`);
+    for (const [key, value] of Object.entries(request.headers)) {
+      upstream.write(`${key}: ${key === "host" ? target.host : value}\r\n`);
+    }
+    upstream.write("\r\n");
+    upstream.write(head);
+    socket.pipe(upstream).pipe(socket);
+  });
+  upstream.on("error", () => socket.destroy());
+  socket.on("error", () => upstream.destroy());
+});
+proxy.listen(42995, "127.0.0.1");
+
 const server = createServer((request, response) => {
   const scenario = request.url?.slice(1);
-  if (request.method !== "POST" || !["completed", "missing"].includes(scenario)) {
+  if (request.method === "POST" && scenario === "wait-for-timeline") {
+    const started = Date.now();
+    const timer = setInterval(() => {
+      if (held.length > 0 || Date.now() - started > 15_000) {
+        clearInterval(timer);
+        setTimeout(() => response.writeHead(held.length > 0 ? 200 : 504).end(), 1_000);
+      }
+    }, 50);
+    return;
+  }
+  if (request.method === "POST" && scenario === "release-timeline") {
+    holdTimeline = false;
+    for (const forward of held.splice(0)) forward();
+    response.writeHead(200).end();
+    return;
+  }
+  if (request.method !== "POST" || !["completed", "missing", "slow-completed"].includes(scenario)) {
     response.writeHead(404).end();
     return;
   }
   try {
     const missing = scenario === "missing";
+    holdTimeline = scenario === "slow-completed";
     const payload = {
       aps: {
         alert: {
@@ -35,7 +90,7 @@ const server = createServer((request, response) => {
         threadId: missing ? "thr_notification_missing" : details.threads.completed,
         ...(missing ? {} : {
           projectId: details.projectId,
-          serverUrl: details.serverUrl,
+          serverUrl: holdTimeline ? "http://127.0.0.1:42995" : details.serverUrl,
         }),
       },
     };

--- a/apps/mobile/src/notifications/PushNotificationsHost.test.ts
+++ b/apps/mobile/src/notifications/PushNotificationsHost.test.ts
@@ -331,6 +331,19 @@ describe("PushNotificationsHost", () => {
     expect(mocks.toastDismiss).not.toHaveBeenCalled();
   });
 
+  it("does not restore a toast the user dismissed while the page was loading", async () => {
+    vi.useFakeTimers();
+    receive({ serverUrl: "https://bb.example.test", threadId: "thr_1" }).onClick();
+    await vi.advanceTimersByTimeAsync(0);
+    mocks.toastMessage.mock.calls.at(-1)?.[1]?.onDismiss?.();
+    const shown = mocks.toastMessage.mock.calls.length;
+    finishNotificationNavigation(navigationId(), "cancelled");
+    setNotificationNavigationReady(navigationId(), true);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(mocks.toastMessage).toHaveBeenCalledTimes(shown);
+    expect(mocks.toastDismiss).not.toHaveBeenCalled();
+  });
+
   it("ignores a notification without a valid thread target", () => {
     mocks.receivedListener({ request: { content: { data: {} } } });
     expect(mocks.toastMessage).not.toHaveBeenCalled();

--- a/apps/mobile/src/notifications/PushNotificationsHost.test.ts
+++ b/apps/mobile/src/notifications/PushNotificationsHost.test.ts
@@ -117,6 +117,10 @@ vi.mock("./use-push-store", () => ({
 }));
 
 import { PushNotificationsHost } from "./PushNotificationsHost";
+import {
+  finishNotificationNavigation,
+  setNotificationNavigationReady,
+} from "./notification-navigation";
 
 describe("PushNotificationsHost", () => {
   beforeEach(() => {
@@ -129,8 +133,14 @@ describe("PushNotificationsHost", () => {
   });
 
   afterEach(() => {
+    finishNotificationNavigation(navigationId(), "cancelled");
+    finishNotificationNavigation("foreground-2:1", "cancelled");
     vi.useRealTimers();
   });
+
+  function navigationId(): string {
+    return mocks.push.mock.calls.at(-1)?.[0]?.params.notificationId ?? "foreground-1:1";
+  }
 
   function receive(data: Record<string, string>, id = "foreground-1") {
     mocks.toastMessage.mockReturnValueOnce(id);
@@ -153,7 +163,7 @@ describe("PushNotificationsHost", () => {
   it.each([
     ["proj_1", "/projects/proj_1/threads/thr_1"],
     [null, "/threads/thr_1"],
-  ])("dismisses the opened %s notification after 500 ms", async (projectId, path) => {
+  ])("dismisses the opened %s notification after 100 ms", async (projectId, path) => {
     vi.useFakeTimers();
     const action = receive({
       ...(projectId ? { projectId } : {}),
@@ -164,16 +174,17 @@ describe("PushNotificationsHost", () => {
     await vi.advanceTimersByTimeAsync(0);
     expect(mocks.push).toHaveBeenCalledWith({
       pathname: "/webview",
-      params: { path, profileId: "profile-1" },
+      params: { path, profileId: "profile-1", notificationId: "foreground-1:1" },
     });
     expect(mocks.toastDismiss).not.toHaveBeenCalled();
-    await vi.advanceTimersByTimeAsync(499);
+    setNotificationNavigationReady(navigationId(), true);
+    await vi.advanceTimersByTimeAsync(99);
     expect(mocks.toastDismiss).not.toHaveBeenCalled();
     await vi.advanceTimersByTimeAsync(1);
     expect(mocks.toastDismiss).toHaveBeenCalledExactlyOnceWith("foreground-1");
   });
 
-  it("starts the dismissal delay after resolving the target profile", async () => {
+  it("waits for the thread page after a slow profile lookup", async () => {
     vi.useFakeTimers();
     let resolveProbe: (found: boolean) => void = () => {};
     mocks.hasThread.mockImplementationOnce(
@@ -192,7 +203,10 @@ describe("PushNotificationsHost", () => {
     resolveProbe(true);
     await vi.advanceTimersByTimeAsync(0);
     expect(mocks.push).toHaveBeenCalledOnce();
-    await vi.advanceTimersByTimeAsync(499);
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(mocks.toastDismiss).not.toHaveBeenCalled();
+    setNotificationNavigationReady(navigationId(), true);
+    await vi.advanceTimersByTimeAsync(99);
     expect(mocks.toastDismiss).not.toHaveBeenCalled();
     await vi.advanceTimersByTimeAsync(1);
     expect(mocks.toastDismiss).toHaveBeenCalledExactlyOnceWith("foreground-1");
@@ -212,7 +226,9 @@ describe("PushNotificationsHost", () => {
     });
     mocks.hasThread.mockResolvedValue(true);
     action.onClick();
-    await vi.advanceTimersByTimeAsync(500);
+    await vi.advanceTimersByTimeAsync(0);
+    setNotificationNavigationReady(navigationId(), true);
+    await vi.advanceTimersByTimeAsync(100);
     expect(mocks.push).toHaveBeenCalledOnce();
     expect(mocks.toastDismiss).toHaveBeenCalledExactlyOnceWith("foreground-1");
   });
@@ -232,7 +248,9 @@ describe("PushNotificationsHost", () => {
     expect(mocks.toastDismiss).not.toHaveBeenCalled();
     mocks.hasThread.mockResolvedValue(true);
     action.onClick();
-    await vi.advanceTimersByTimeAsync(500);
+    await vi.advanceTimersByTimeAsync(0);
+    setNotificationNavigationReady(navigationId(), true);
+    await vi.advanceTimersByTimeAsync(100);
     expect(mocks.push).toHaveBeenCalledOnce();
     expect(mocks.toastDismiss).toHaveBeenCalledExactlyOnceWith("foreground-1");
   });
@@ -245,9 +263,11 @@ describe("PushNotificationsHost", () => {
     });
     action.onClick();
     action.onClick();
-    await vi.advanceTimersByTimeAsync(250);
+    await vi.advanceTimersByTimeAsync(0);
+    setNotificationNavigationReady(navigationId(), true);
+    await vi.advanceTimersByTimeAsync(50);
     action.onClick();
-    await vi.advanceTimersByTimeAsync(250);
+    await vi.advanceTimersByTimeAsync(50);
     expect(mocks.push).toHaveBeenCalledOnce();
     expect(mocks.toastDismiss).toHaveBeenCalledExactlyOnceWith("foreground-1");
   });
@@ -255,12 +275,50 @@ describe("PushNotificationsHost", () => {
   it("dismisses only the opened toast when another notification arrives", async () => {
     vi.useFakeTimers();
     receive({ serverUrl: "https://bb.example.test", threadId: "thr_1" }).onClick();
-    await vi.advanceTimersByTimeAsync(250);
+    await vi.advanceTimersByTimeAsync(0);
+    setNotificationNavigationReady(navigationId(), true);
+    await vi.advanceTimersByTimeAsync(50);
     receive(
       { serverUrl: "https://bb.example.test", threadId: "thr_2" },
       "foreground-2",
     );
-    await vi.advanceTimersByTimeAsync(250);
+    await vi.advanceTimersByTimeAsync(50);
+    expect(mocks.toastDismiss).toHaveBeenCalledExactlyOnceWith("foreground-1");
+  });
+
+  it("keeps the toast through loading and ignores another page's readiness", async () => {
+    vi.useFakeTimers();
+    receive({ serverUrl: "https://bb.example.test", threadId: "thr_1" }).onClick();
+    await vi.advanceTimersByTimeAsync(0);
+    setNotificationNavigationReady("another-navigation", true);
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(mocks.toastDismiss).not.toHaveBeenCalled();
+    setNotificationNavigationReady(navigationId(), true);
+    await vi.advanceTimersByTimeAsync(50);
+    setNotificationNavigationReady(navigationId(), false);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(mocks.toastDismiss).not.toHaveBeenCalled();
+    setNotificationNavigationReady(navigationId(), true);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(mocks.toastDismiss).toHaveBeenCalledExactlyOnceWith("foreground-1");
+  });
+
+  it("cancels dismissal and restores Open when navigation fails or the user leaves", async () => {
+    vi.useFakeTimers();
+    const action = receive({ serverUrl: "https://bb.example.test", threadId: "thr_1" });
+    action.onClick();
+    await vi.advanceTimersByTimeAsync(0);
+    setNotificationNavigationReady(navigationId(), true);
+    await vi.advanceTimersByTimeAsync(50);
+    finishNotificationNavigation(navigationId(), "cancelled");
+    await vi.advanceTimersByTimeAsync(100);
+    expect(mocks.toastDismiss).not.toHaveBeenCalled();
+    expect(mocks.toastMessage.mock.calls.at(-1)?.[1]).toMatchObject({ duration: 8_000, action });
+    action.onClick();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(mocks.push).toHaveBeenCalledTimes(2);
+    setNotificationNavigationReady(navigationId(), true);
+    await vi.advanceTimersByTimeAsync(100);
     expect(mocks.toastDismiss).toHaveBeenCalledExactlyOnceWith("foreground-1");
   });
 

--- a/apps/mobile/src/notifications/PushNotificationsHost.tsx
+++ b/apps/mobile/src/notifications/PushNotificationsHost.tsx
@@ -124,10 +124,16 @@ export function PushNotificationsHost() {
         if (!target) return;
         let opening = false;
         let attempt = 0;
+        let dismissed = false;
+        let stopWaiting: (() => void) | undefined;
         const title = content.title ?? "bb";
         const options: ToastOptions = {
           description: content.body ?? undefined,
           duration: 8_000,
+          onDismiss: () => {
+            dismissed = true;
+            stopWaiting?.();
+          },
           action: {
             label: "Open",
             onClick: async () => {
@@ -151,11 +157,15 @@ export function PushNotificationsHost() {
                   }
                 },
               );
+              stopWaiting = () => {
+                stop();
+                pending.delete(stop);
+              };
               pending.add(stop);
               if (!(await openTarget(target, notificationId))) {
                 stop();
                 pending.delete(stop);
-                toast.message(title, { ...options, id: toastId });
+                if (!dismissed) toast.message(title, { ...options, id: toastId });
                 opening = false;
                 return;
               }

--- a/apps/mobile/src/notifications/PushNotificationsHost.tsx
+++ b/apps/mobile/src/notifications/PushNotificationsHost.tsx
@@ -21,6 +21,7 @@ import { getPushRegistrationController } from "./push-controller";
 import { getPushStore } from "./push-storage";
 import { hasThreadOnServer } from "./thread-probe";
 import { usePushStoreSnapshot } from "./use-push-store";
+import { watchNotificationNavigation } from "./notification-navigation";
 
 export function PushNotificationsHost() {
   const { status, profiles, activeProfile, connection } = useProfiles();
@@ -65,7 +66,7 @@ export function PushNotificationsHost() {
   }, []);
 
   const openTarget = useCallback(
-    async (target: PushNotificationTarget) => {
+    async (target: PushNotificationTarget, notificationId?: string) => {
       const profile = await resolvePushTargetProfile(target, {
         profiles: profilesRef.current,
         activeProfileId: activeProfileIdRef.current,
@@ -82,6 +83,7 @@ export function PushNotificationsHost() {
       router.push(
         webViewShellHref({
           profileId: profile.id,
+          notificationId,
           path:
             target.projectId === null
               ? `/threads/${target.threadId}`
@@ -114,12 +116,14 @@ export function PushNotificationsHost() {
   }, [openTarget]);
 
   useEffect(() => {
+    const pending = new Set<() => void>();
     const subscription = Notifications.addNotificationReceivedListener(
       (notification) => {
         const content = notification.request.content;
         const target = parsePushNotificationData(content.data);
         if (!target) return;
         let opening = false;
+        let attempt = 0;
         const title = content.title ?? "bb";
         const options: ToastOptions = {
           description: content.body ?? undefined,
@@ -134,19 +138,37 @@ export function PushNotificationsHost() {
                 id: toastId,
                 duration: Infinity,
               });
-              if (!(await openTarget(target))) {
+              const notificationId = `${toastId}:${++attempt}`;
+              const stop = watchNotificationNavigation(
+                notificationId,
+                (outcome) => {
+                  pending.delete(stop);
+                  if (outcome === "ready") {
+                    toast.dismiss(toastId);
+                  } else {
+                    toast.message(title, { ...options, id: toastId });
+                    opening = false;
+                  }
+                },
+              );
+              pending.add(stop);
+              if (!(await openTarget(target, notificationId))) {
+                stop();
+                pending.delete(stop);
                 toast.message(title, { ...options, id: toastId });
                 opening = false;
                 return;
               }
-              setTimeout(() => toast.dismiss(toastId), 500);
             },
           },
         };
         const toastId = toast.message(title, options);
       },
     );
-    return () => subscription.remove();
+    return () => {
+      subscription.remove();
+      for (const stop of pending) stop();
+    };
   }, [openTarget]);
 
   useEffect(() => {

--- a/apps/mobile/src/notifications/notification-navigation.ts
+++ b/apps/mobile/src/notifications/notification-navigation.ts
@@ -1,0 +1,42 @@
+type NavigationOutcome = "ready" | "cancelled";
+
+interface PendingNavigation {
+  listener(outcome: NavigationOutcome): void;
+  timer: ReturnType<typeof setTimeout> | null;
+}
+
+const pending = new Map<string, PendingNavigation>();
+
+export function watchNotificationNavigation(
+  id: string,
+  listener: (outcome: NavigationOutcome) => void,
+): () => void {
+  const entry: PendingNavigation = { listener, timer: null };
+  pending.set(id, entry);
+  return () => {
+    if (entry.timer !== null) clearTimeout(entry.timer);
+    if (pending.get(id) === entry) pending.delete(id);
+  };
+}
+
+export function setNotificationNavigationReady(id: string, ready: boolean): void {
+  const entry = pending.get(id);
+  if (!entry) return;
+  if (!ready) {
+    if (entry.timer !== null) clearTimeout(entry.timer);
+    entry.timer = null;
+  } else if (entry.timer === null) {
+    entry.timer = setTimeout(() => finishNotificationNavigation(id, "ready"), 100);
+  }
+}
+
+export function finishNotificationNavigation(
+  id: string,
+  outcome: NavigationOutcome,
+): void {
+  const entry = pending.get(id);
+  if (!entry) return;
+  if (entry.timer !== null) clearTimeout(entry.timer);
+  pending.delete(id);
+  entry.listener(outcome);
+}

--- a/apps/mobile/src/screens/shell/hrefs.ts
+++ b/apps/mobile/src/screens/shell/hrefs.ts
@@ -29,11 +29,12 @@ export function rawPathHref(path: string): Href {
 }
 
 export function webViewShellHref(
-  params: { profileId?: string; path?: string } = {},
+  params: { profileId?: string; path?: string; notificationId?: string } = {},
 ): Href {
   return untypedHref("/webview", {
     profileId: params.profileId,
     path: params.path,
+    notificationId: params.notificationId,
   });
 }
 

--- a/apps/mobile/src/screens/webview/ProfileWebViewScreen.tsx
+++ b/apps/mobile/src/screens/webview/ProfileWebViewScreen.tsx
@@ -27,6 +27,7 @@ import { useTheme } from "@/theme";
 import { Button, EmptyStatePanel, Spinner, Text } from "@/ui";
 import { Linking } from "react-native";
 import { useShellBridge } from "./useShellBridge";
+import { useNotificationNavigation } from "./useNotificationNavigation";
 
 const APP_VERSION = String(Constants.expoConfig?.version ?? "0.0.0");
 
@@ -40,7 +41,11 @@ export function ProfileWebViewScreen() {
   const { tokens } = useTheme();
   const router = useRouter();
   const insets = useSafeAreaInsets();
-  const params = useLocalSearchParams<{ profileId?: string; path?: string }>();
+  const params = useLocalSearchParams<{
+    profileId?: string;
+    path?: string;
+    notificationId?: string;
+  }>();
   const { status, profiles, activeProfile, connection, setActiveProfile } =
     useProfiles();
   const preferences = getShellPreferenceStore();
@@ -60,6 +65,13 @@ export function ProfileWebViewScreen() {
   const webViewRef = useRef<WebView>(null);
   const [load, setLoad] = useState<ShellLoadPhase>({ kind: "loading" });
   const [reloadKey, setReloadKey] = useState(0);
+  const [readyThread, setReadyThread] = useState<{
+    threadId: string;
+    path: string;
+    sourceUrl: string | null;
+    reloadKey: number;
+  } | null>(null);
+  const [pagePath, setPagePath] = useState<string | null>(null);
   const currentPathRef = useRef<string>("/");
 
   const initialPath = useMemo(() => {
@@ -79,6 +91,7 @@ export function ProfileWebViewScreen() {
   const rememberPath = useCallback(
     (path: string) => {
       currentPathRef.current = path;
+      setPagePath(path);
       if (profile !== null) preferences.setLastPath(profile.id, path);
     },
     [preferences, profile],
@@ -94,10 +107,28 @@ export function ProfileWebViewScreen() {
       rememberPath(path);
     },
     onPath: rememberPath,
+    onThreadReady: (threadId, path) => {
+      setReadyThread({ threadId, path, sourceUrl, reloadKey });
+    },
     onOpenNative: (screen) => {
       if (screen === "device-settings") openDeviceSettings();
     },
   });
+
+  useNotificationNavigation(
+    firstParam(params.notificationId),
+    readyThread !== null &&
+      readyThread.sourceUrl === sourceUrl &&
+      readyThread.reloadKey === reloadKey &&
+      readyThread.path === pagePath &&
+      requestedPath?.split("?")[0]?.endsWith(`/threads/${readyThread.threadId}`) === true &&
+      profile?.id === requestedProfileId &&
+      load.kind === "ready",
+    load.kind === "failed" ||
+      load.kind === "http-error" ||
+      session.status === "error" ||
+      session.status === "auth-required",
+  );
 
   useEffect(
     () =>

--- a/apps/mobile/src/screens/webview/useNotificationNavigation.ts
+++ b/apps/mobile/src/screens/webview/useNotificationNavigation.ts
@@ -1,0 +1,56 @@
+import {
+  useFocusEffect,
+  useNavigation,
+  type NativeStackNavigationProp,
+} from "expo-router";
+import { useCallback, useEffect, useState } from "react";
+import {
+  finishNotificationNavigation,
+  setNotificationNavigationReady,
+} from "@/notifications/notification-navigation";
+
+export function useNotificationNavigation(
+  notificationId: string | undefined,
+  ready: boolean,
+  failed: boolean,
+): void {
+  const navigation =
+    useNavigation<NativeStackNavigationProp<Record<string, object | undefined>>>();
+  const [focused, setFocused] = useState(false);
+  const [settled, setSettled] = useState(false);
+
+  useEffect(() => {
+    const start = navigation.addListener("transitionStart", () => {
+      setSettled(false);
+    });
+    const end = navigation.addListener("transitionEnd", ({ data }) => {
+      setSettled(!data.closing);
+    });
+    return () => {
+      start();
+      end();
+    };
+  }, [navigation]);
+
+  useFocusEffect(
+    useCallback(() => {
+      setFocused(true);
+      return () => {
+        setFocused(false);
+        if (notificationId) {
+          finishNotificationNavigation(notificationId, "cancelled");
+        }
+      };
+    }, [notificationId]),
+  );
+
+  useEffect(() => {
+    if (!notificationId || !focused) return;
+    if (failed) {
+      finishNotificationNavigation(notificationId, "cancelled");
+      return;
+    }
+    setNotificationNavigationReady(notificationId, ready && settled);
+    return () => setNotificationNavigationReady(notificationId, false);
+  }, [failed, focused, notificationId, ready, settled]);
+}

--- a/apps/mobile/src/screens/webview/useShellBridge.ts
+++ b/apps/mobile/src/screens/webview/useShellBridge.ts
@@ -15,6 +15,7 @@ import { updateAppBadgeCount } from "@/notifications/AppBadgeSync";
 
 export interface ShellBridgeCallbacks {
   onReady(path: string): void;
+  onThreadReady(threadId: string, path: string): void;
   onPath(path: string): void;
   onOpenNative(screen: NativeScreen): void;
 }
@@ -50,6 +51,9 @@ export function useShellBridge(
       switch (message.type) {
         case "ready":
           callbacksRef.current.onReady(message.path);
+          return;
+        case "thread-ready":
+          callbacksRef.current.onThreadReady(message.threadId, message.path);
           return;
         case "title":
           callbacksRef.current.onPath(message.path);

--- a/apps/mobile/src/ui/Toast.tsx
+++ b/apps/mobile/src/ui/Toast.tsx
@@ -13,6 +13,7 @@ export interface ToastOptions {
   action?: { label: string; onClick: () => void };
   id?: ToastId;
   overlay?: boolean;
+  onDismiss?: () => void;
 }
 
 function show(
@@ -26,6 +27,7 @@ function show(
     action: options?.action,
     id: options?.id,
     toasterId: options?.overlay ? "overlay" : undefined,
+    onDismiss: options?.onDismiss,
   };
   switch (kind) {
     case "success":

--- a/packages/mobile-bridge/src/messages.ts
+++ b/packages/mobile-bridge/src/messages.ts
@@ -51,6 +51,13 @@ export const pageToShellMessageSchema = z.discriminatedUnion("type", [
   z.object({ type: z.literal("ready"), path: z.string() }).strict(),
   z
     .object({
+      type: z.literal("thread-ready"),
+      threadId: z.string().min(1),
+      path: z.string(),
+    })
+    .strict(),
+  z
+    .object({
       type: z.literal("title"),
       title: z.string().max(300),
       path: z.string(),

--- a/packages/mobile-bridge/src/version.ts
+++ b/packages/mobile-bridge/src/version.ts
@@ -1,4 +1,4 @@
-export const MOBILE_BRIDGE_VERSION = 2;
+export const MOBILE_BRIDGE_VERSION = 3;
 
 export const MINIMUM_MOBILE_BRIDGE_VERSION = 1;
 

--- a/packages/mobile-bridge/test/messages.test.ts
+++ b/packages/mobile-bridge/test/messages.test.ts
@@ -30,6 +30,7 @@ describe("parsePageToShellMessage", () => {
   it("accepts every message kind the contract defines", () => {
     const cases: unknown[] = [
       { type: "ready", path: "/threads/thr_1" },
+      { type: "thread-ready", threadId: "thr_1", path: "/threads/thr_1" },
       { type: "title", title: "bb", path: "/" },
       { type: "haptic", kind: "impact-medium" },
       { type: "badge", count: 0 },


### PR DESCRIPTION
## Human comments

## What was wrong

Open started the dismissal timer when navigation was requested, so the notification could disappear before the conversation loaded.

## What changed

- Keep the notification until the conversation paints and native navigation finishes, then wait 100 ms before starting dismissal.
- Restore Open when native navigation fails or is interrupted.
- Mobile bridge version 3 adds an optional `thread-ready` message and preserves support for earlier peers.

Older servers without readiness reporting leave the opened toast available for manual dismissal.

## How you verified

- [Remote CI](https://github.com/get-bb/bb/actions/runs/34645603555) passed, including 15 notification tests and three paint-readiness tests.
- Normal iOS Open passed; recording shows dismissal starting about 118 ms after conversation paint.
- [iOS slow-loading flow](https://github.com/get-bb/bb/actions/runs/34644192640) passed with the conversation response deliberately held, then released. The recording shows dismissal starting about 133 ms after conversation paint; the toast stays visible throughout loading.

Before: parent head `cfc575101`. After: PR head `2aedc00b4`. iPhone 17 Pro, iOS 26.2, 402 × 874 pt at 3×.

| State | Before | After |
| --- | --- | --- |
| Conversation loading | ![Before — Conversation loading](https://github.com/get-bb/bb/releases/download/pr-evidence/thr-vhbcifyc3p-loaded-cfc575101-before-loading.png) | ![After — Conversation loading](https://github.com/get-bb/bb/releases/download/pr-evidence/thr-vhbcifyc3p-loaded-2aedc00b4-after-loading.png) |
| Conversation first paint | ![Before — Conversation first paint](https://github.com/get-bb/bb/releases/download/pr-evidence/thr-vhbcifyc3p-loaded-cfc575101-before-first-paint.png) | ![After — Conversation first paint](https://github.com/get-bb/bb/releases/download/pr-evidence/thr-vhbcifyc3p-loaded-2aedc00b4-after-first-paint.png) |
| After dismissal | ![Before — After dismissal](https://github.com/get-bb/bb/releases/download/pr-evidence/thr-vhbcifyc3p-loaded-cfc575101-before-dismissed.png) | ![After — After dismissal](https://github.com/get-bb/bb/releases/download/pr-evidence/thr-vhbcifyc3p-loaded-2aedc00b4-after-dismissed.png) |

BB-Thread-ID: thr_vhbcifyc3p

> AGENT GENERATED
