### PR TITLE
Fix Personal project lookup and environment file access

### DIFF
--- a/apps/server/src/routes/projects.ts
+++ b/apps/server/src/routes/projects.ts
@@ -563,7 +563,7 @@ export function registerProjectRoutes(app: Hono, deps: AppDeps): void {
 
   get(routes.files, async (context, query) => {
     const projectId = context.req.param("id");
-    requirePublicStandardProject(deps.db, projectId);
+    requirePublicProject(deps.db, projectId);
 
     const limit = parseFileListLimit(query.limit);
 
@@ -592,7 +592,7 @@ export function registerProjectRoutes(app: Hono, deps: AppDeps): void {
 
   get(routes.fileContent, async (context, query) => {
     const projectId = context.req.param("id");
-    requirePublicStandardProject(deps.db, projectId);
+    requirePublicProject(deps.db, projectId);
     const target = resolveProjectWorkspaceTarget(deps, {
       projectId,
       ...(query.environmentId !== undefined
@@ -620,7 +620,7 @@ export function registerProjectRoutes(app: Hono, deps: AppDeps): void {
 
   get(routes.paths, async (context, query) => {
     const projectId = context.req.param("id");
-    requirePublicStandardProject(deps.db, projectId);
+    requirePublicProject(deps.db, projectId);
 
     const limit = parseFileListLimit(query.limit);
 

--- a/apps/server/src/routes/projects.ts
+++ b/apps/server/src/routes/projects.ts
@@ -378,7 +378,11 @@ export function registerProjectRoutes(app: Hono, deps: AppDeps): void {
   });
 
   get(routes.get, (context) =>
-    context.json(buildProjectResponses(deps, context.req.param("id"))[0]),
+    context.json(
+      buildProjectResponsesFromRows(deps, [
+        requirePublicProject(deps.db, context.req.param("id")),
+      ])[0],
+    ),
   );
 
   get(routes.defaultExecutionOptions, (context) => {

--- a/apps/server/test/public/public-project-personal-files.test.ts
+++ b/apps/server/test/public/public-project-personal-files.test.ts
@@ -1,0 +1,157 @@
+import { PERSONAL_PROJECT_ID } from "@bb/domain";
+import { describe, expect, it } from "vitest";
+import { registerHostRpcResponder } from "../helpers/host-rpc.js";
+import {
+  seedEnvironment,
+  seedHostSession,
+  seedPrimaryHost,
+  seedProjectWithSource,
+} from "../helpers/seed.js";
+import { withTestHarness } from "../helpers/test-app.js";
+
+const routes = [
+  {
+    path: "files",
+    query: "",
+    body: {
+      files: [{ name: "hello.txt", path: "hello.txt" }],
+      truncated: false,
+    },
+  },
+  {
+    path: "paths",
+    query: "includeFiles=true&includeDirectories=true",
+    body: {
+      paths: [
+        {
+          path: "hello.txt",
+          name: "hello.txt",
+          kind: "file",
+          positions: [],
+          score: 1,
+        },
+      ],
+      truncated: false,
+    },
+  },
+  { path: "files/content", query: "path=hello.txt", body: "hi\n" },
+];
+
+describe("Personal project file access", () => {
+  it.each(routes)(
+    "routes $path to the selected Personal environment",
+    async (route) => {
+      await withTestHarness(async (harness) => {
+        const { host, session } = seedHostSession(harness.deps);
+        seedPrimaryHost(harness.deps, host.id);
+        const environment = seedEnvironment(harness.deps, {
+          projectId: PERSONAL_PROJECT_ID,
+          hostId: host.id,
+          path: "/personal/workspace",
+        });
+        const responder = registerHostRpcResponder(harness, {
+          hostId: host.id,
+          sessionId: session.id,
+          handle(request) {
+            switch (request.command.type) {
+              case "host.list_files":
+                expect(request.command.path).toBe(environment.path);
+                return {
+                  ok: true,
+                  result: {
+                    files: [{ name: "hello.txt", path: "hello.txt" }],
+                    truncated: false,
+                  },
+                };
+              case "host.list_paths":
+                expect(request.command.path).toBe(environment.path);
+                return {
+                  ok: true,
+                  result: {
+                    paths: [
+                      {
+                        path: "hello.txt",
+                        name: "hello.txt",
+                        kind: "file",
+                        positions: [],
+                        score: 1,
+                      },
+                    ],
+                    truncated: false,
+                  },
+                };
+              case "host.read_file":
+                expect(request.command.path).toBe(
+                  "/personal/workspace/hello.txt",
+                );
+                expect(request.command.rootPath).toBe(environment.path);
+                return {
+                  ok: true,
+                  result: {
+                    path: request.command.path,
+                    content: "hi\n",
+                    contentEncoding: "utf8",
+                    mimeType: "text/plain",
+                    sizeBytes: 3,
+                    sha256: "1".repeat(64),
+                  },
+                };
+              default:
+                throw new Error(`Unexpected RPC ${request.command.type}`);
+            }
+          },
+        });
+        const response = await harness.app.request(
+          `/api/v1/projects/${PERSONAL_PROJECT_ID}/${route.path}?environmentId=${environment.id}&${route.query}`,
+        );
+        expect(response.status).toBe(200);
+        expect(
+          typeof route.body === "string"
+            ? await response.text()
+            : await response.json(),
+        ).toEqual(route.body);
+        expect(responder.requests).toHaveLength(1);
+      });
+    },
+  );
+
+  it.each(routes)("preserves workspace validation for $path", async (route) => {
+    await withTestHarness(async (harness) => {
+      const { host, session } = seedHostSession(harness.deps);
+      seedPrimaryHost(harness.deps, host.id);
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.id,
+      });
+      const foreign = seedEnvironment(harness.deps, {
+        projectId: project.id,
+        hostId: host.id,
+      });
+      const unready = seedEnvironment(harness.deps, {
+        projectId: PERSONAL_PROJECT_ID,
+        hostId: host.id,
+        status: "creating",
+        path: null,
+      });
+      const responder = registerHostRpcResponder(harness, {
+        hostId: host.id,
+        sessionId: session.id,
+        handle(request) {
+          throw new Error(`Unexpected RPC ${request.command.type}`);
+        },
+      });
+      for (const [selector, status, code] of [
+        [`environmentId=${foreign.id}`, 404, "environment_not_found"],
+        [`environmentId=${unready.id}`, 409, "environment_not_ready"],
+        ["environmentId=env_missing", 404, "environment_not_found"],
+        ["", 409, "invalid_request"],
+      ] as const) {
+        const response = await harness.app.request(
+          `/api/v1/projects/${PERSONAL_PROJECT_ID}/${route.path}?${route.query}&${selector}`,
+        );
+        expect(response.status, selector).toBe(status);
+        expect(await response.json()).toMatchObject({ code });
+      }
+      expect(responder.requests).toHaveLength(0);
+    });
+  });
+});

--- a/apps/server/test/public/public-project-startup.test.ts
+++ b/apps/server/test/public/public-project-startup.test.ts
@@ -4,6 +4,35 @@ import { registerFirstPartyProviders } from "../helpers/provider-registry.js";
 import { withTestHarness } from "../helpers/test-app.js";
 
 describe("project reads during provider startup", () => {
+  it("reads Personal by id while preserving project mutation restrictions", async () => {
+    await withTestHarness(async (harness) => {
+      const projectPath = "/api/v1/projects/proj_personal";
+      const response = await harness.app.request(projectPath);
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({
+        id: "proj_personal",
+        kind: "personal",
+        name: "Personal",
+        sources: [],
+      });
+
+      const rename = await harness.app.request(projectPath, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "Renamed" }),
+      });
+      expect(rename.status).toBe(404);
+      const deletion = await harness.app.request(projectPath, {
+        method: "DELETE",
+      });
+      expect(deletion.status).toBe(409);
+      const missing = await harness.app.request(
+        "/api/v1/projects/proj_missing",
+      );
+      expect(missing.status).toBe(404);
+    });
+  });
+
   it("returns saved defaults before registration and with an unavailable provider", async () => {
     await withTestHarness(
       { seedFirstPartyProviders: false },

--- a/apps/server/test/services/plugins/automations-personal.test.ts
+++ b/apps/server/test/services/plugins/automations-personal.test.ts
@@ -1,0 +1,74 @@
+import { PERSONAL_PROJECT_ID } from "@bb/domain";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { startTestServer } from "../../helpers/test-app.js";
+
+describe("Personal automations", () => {
+  it("creates and updates an hourly script through the real project SDK", async () => {
+    const server = await startTestServer();
+    try {
+      server.pluginService.bindSdk({ baseUrl: server.baseUrl });
+      const entry = await server.pluginService.install("builtin:automations", {
+        kind: "root",
+      });
+      expect(entry.status, entry.statusDetail ?? undefined).toBe("running");
+
+      const created = await server.app.request(
+        "/api/v1/plugins/automations/rpc/automations_create",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            projectId: PERSONAL_PROJECT_ID,
+            name: "Say hi every hour",
+            enabled: false,
+            trigger: {
+              triggerType: "schedule",
+              cron: "0 * * * *",
+              timezone: "America/Los_Angeles",
+            },
+            execution: {
+              mode: "script",
+              script: 'printf "hi\\n"',
+              interpreter: "sh",
+            },
+            origin: "human",
+          }),
+        },
+      );
+      const createdBody: unknown = await created.json();
+      expect(created.status, JSON.stringify(createdBody)).toBe(200);
+      const { result } = z
+        .object({ result: z.object({ id: z.string() }) })
+        .parse(createdBody);
+      expect(createdBody).toMatchObject({
+        result: {
+          projectId: PERSONAL_PROJECT_ID,
+          name: "Say hi every hour",
+          trigger: { cron: "0 * * * *" },
+          execution: { mode: "script", interpreter: "sh" },
+        },
+      });
+
+      const updated = await server.app.request(
+        "/api/v1/plugins/automations/rpc/automations_update",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            projectId: PERSONAL_PROJECT_ID,
+            automationId: result.id,
+            name: "Hourly greeting",
+          }),
+        },
+      );
+      expect(updated.status).toBe(200);
+      expect(await updated.json()).toMatchObject({
+        result: { id: result.id, name: "Hourly greeting" },
+      });
+    } finally {
+      await server.pluginService.stop();
+      await server.close();
+    }
+  });
+});

--- a/apps/server/test/services/plugins/plugin-sdk.test.ts
+++ b/apps/server/test/services/plugins/plugin-sdk.test.ts
@@ -478,6 +478,9 @@ describe("plugin bb.sdk against a running server", () => {
         PERSONAL_PROJECT_ID,
         project.id,
       ]);
+      expect(
+        await api.sdk.projects.get({ projectId: PERSONAL_PROJECT_ID }),
+      ).toEqual(projectsWithPersonal[0]);
       const projectsWithThreadsAndPersonal = await api.sdk.projects.list({
         include: "threads",
         includePersonal: true,

--- a/packages/templates/src/templates/bb-guide-projects.md
+++ b/packages/templates/src/templates/bb-guide-projects.md
@@ -49,6 +49,10 @@ Discovery:
   machine selects that machine's project source. Omitting both intentionally
   falls back to the primary machine's project source.
 
+  Personal file access (`paths`, `files`, `content`) requires an explicit
+  --environment <id> belonging to Personal. Personal has no default project
+  source; the selected environment must be ready.
+
 Attachments:
 
   bb project attachment upload <id>       Upload bytes from the CLI machine

--- a/packages/templates/src/templates/bb-guide-projects.md
+++ b/packages/templates/src/templates/bb-guide-projects.md
@@ -25,6 +25,7 @@ A project maps to a code repository. All threads belong to a project.
   local CLI machine fallback (normally the primary machine).
 
   bb project show <id>                    Show project details
+    Accepts proj_personal to inspect Personal.
   bb project update <id>                  Update a project
     --name <name>                         New name
 

--- a/plugins/automations/skills/automations/SKILL.md
+++ b/plugins/automations/skills/automations/SKILL.md
@@ -14,6 +14,8 @@ Use the top-level `bb automation` command. The CLI routes it to this plugin.
 
 Pass `--project` explicitly for every automation command. Inside a thread, automations are stamped origin `agent` and record the creating thread automatically. Automation-spawned threads cannot create automations.
 
+Personal supports automations with `--project proj_personal`. Use `bb project list --include-personal --json` to include it in discovery; an empty default project list does not mean Personal is unavailable.
+
 Choosing a mode:
 
 Use `script` when the output is fully determined by code: watchdogs, threshold alerts, health checks, heartbeats, and API pollers with a fixed output shape. Scripts run on the bb server, with cwd inside the plugin data directory's `scripts/` area. Script automations do not have an environment field and do not accept environment flags.

--- a/plugins/bb-guide/skills/bb-cli/references/command-index.md
+++ b/plugins/bb-guide/skills/bb-cli/references/command-index.md
@@ -46,9 +46,11 @@ This index lists every command path that the core CLI registers. Read the task-s
 - `bb project files`
 - `bb project content`
 - `bb project create`
-- `bb project show <id>` (including `proj_personal`)
+- `bb project show`
 - `bb project update`
 - `bb project delete`
+
+`bb project show <id>` accepts `proj_personal` to inspect Personal.
 
 ## provider
 

--- a/plugins/bb-guide/skills/bb-cli/references/command-index.md
+++ b/plugins/bb-guide/skills/bb-cli/references/command-index.md
@@ -46,7 +46,7 @@ This index lists every command path that the core CLI registers. Read the task-s
 - `bb project files`
 - `bb project content`
 - `bb project create`
-- `bb project show`
+- `bb project show <id>` (including `proj_personal`)
 - `bb project update`
 - `bb project delete`
 

--- a/plugins/bb-guide/skills/bb-cli/references/thread-creation.md
+++ b/plugins/bb-guide/skills/bb-cli/references/thread-creation.md
@@ -217,3 +217,7 @@ Maintenance interrupts active turns and closes terminals before saving. Submit a
 new continuation turn after restore; interrupted turns are never reported successful.
 
 Resuming a machine restores its provider state without rerunning environment setup.
+
+Personal file access: `bb project paths|files|content proj_personal` requires
+an explicit `--environment <id>` belonging to Personal. Personal has no default
+project source; the selected environment must be ready.


### PR DESCRIPTION
## Human comments

## What was wrong

Automation creation and updates validate the project through `sdk.projects.get()`. That endpoint rejected Personal as a non-standard project, returning “Project not found” for `proj_personal`. The default project list also excludes Personal, leading agents to incorrectly ask users to create a project. Project file listing, path search, and file content endpoints had the same restriction, rejecting Personal before resolving an explicitly selected environment.

## What changed

Direct project reads and the project `files`, `paths`, and `files/content` endpoints now accept Personal. File operations resolve an explicit environment through the existing workspace resolver, preserving project ownership and readiness checks. Requests without an environment still fail because Personal has no default project source. Unavailable-project validation and standard-only mutation restrictions remain intact. Added a real Automations plugin integration test for creating and updating an hourly script in Personal, plus project route and SDK coverage. Added Personal file-access regressions covering successful routing, foreign/missing/unready environments, and missing selectors. Updated the CLI guide and skills to explain Personal lookup, discovery, and explicit environment selection. No server/daemon wire changes.

## How you verified

- `pnpm exec turbo run test --filter=@bb/server -- test/services/plugins/plugin-sdk.test.ts` — 9 tests passed.
- `pnpm exec turbo run test --filter=@bb/server -- test/services/plugins/automations-personal.test.ts test/public/public-project-startup.test.ts` — 3 tests passed.
- `pnpm exec turbo run test --filter=@bb/server -- test/public/public-project-personal-files.test.ts test/public/public-project-workspace-routing.test.ts` — 10 tests passed.
- `pnpm exec turbo run test --filter=@bb/cli -- src/__tests__/bb-cli-skill-coverage.test.ts` — 2 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/server` — passed.

- Started an isolated `pnpm start:worktree` instance with no standard projects. The built CLI returned `[]` from `project list`, successfully read `proj_personal`, and created the original hourly greeting command. A manual run succeeded with exit code 0 and stdout `hi\n`.

> AGENT GENERATED

