### PR TITLE
Show account emails in the Account Pooler

### DIFF
--- a/plugins/account-pool/app.test.tsx
+++ b/plugins/account-pool/app.test.tsx
@@ -395,6 +395,24 @@ describe("Account Pool settings", () => {
     expect(slot.getByText("Opus 7 day")).toBeTruthy();
   });
 
+  it("shows the email beside a display-name label in the row and detail dialog", async () => {
+    const slot = render([
+      account({ label: "Person Example", email: "person@example.com" }),
+      account({
+        id: "22222222-2222-4222-8222-222222222222",
+        label: "Claude API key",
+        email: null,
+      }),
+    ]);
+    expect(await slot.findByText("Person Example")).toBeTruthy();
+    expect(slot.getAllByText("person@example.com")).toHaveLength(1);
+    fireEvent.click(
+      slot.getByRole("button", { name: "Open Person Example details" }),
+    );
+    expect(await slot.findByText("Email")).toBeTruthy();
+    expect(slot.getAllByText("person@example.com")).toHaveLength(2);
+  });
+
   function codexLoginStart() {
     return {
       sessionId: "33333333-3333-4333-8333-333333333333",

--- a/plugins/account-pool/app.tsx
+++ b/plugins/account-pool/app.tsx
@@ -244,6 +244,11 @@ function tier(account: AccountSummary): string {
     (account.kind === "api-key" ? "API key" : "OAuth")
   );
 }
+function secondaryEmail(account: AccountSummary): string | null {
+  return account.email === null || account.email === account.label
+    ? null
+    : account.email;
+}
 function SettingsBadge({ children }: { children: ReactNode }) {
   return (
     <span className="shrink-0 rounded-sm border border-border bg-muted/40 px-1.5 py-0.5 text-2xs leading-none text-subtle-foreground">
@@ -387,6 +392,7 @@ function AccountRow({
 }) {
   const status = statusPresentation(account, threshold);
   const slots = quotaSlots(account);
+  const email = secondaryEmail(account);
   const {
     attributes,
     isDragging,
@@ -435,6 +441,11 @@ function AccountRow({
               <span className="truncate text-sm font-medium text-foreground">
                 {account.label}
               </span>
+              {email === null ? null : (
+                <span className="min-w-0 truncate text-xs text-subtle-foreground/75">
+                  {email}
+                </span>
+              )}
               <SettingsBadge>{tier(account)}</SettingsBadge>
             </div>
             <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-0.5 text-xs text-subtle-foreground/75">
@@ -1633,6 +1644,12 @@ function AccountDialog({
         )}
       </div>
       <dl className="grid grid-cols-[7rem_1fr] gap-x-3 gap-y-2 border-t border-border pt-4 text-sm">
+        {account.email === null ? null : (
+          <>
+            <dt className="text-muted-foreground">Email</dt>
+            <dd className="break-all">{account.email}</dd>
+          </>
+        )}
         <dt className="text-muted-foreground">Kind</dt>
         <dd>
           {account.kind === "oauth"

--- a/plugins/account-pool/src/cli.ts
+++ b/plugins/account-pool/src/cli.ts
@@ -146,6 +146,7 @@ function formatAccounts(accounts: readonly AccountSummary[]): string {
     [
       "ID",
       "Label",
+      "Email",
       "Provider",
       "Kind",
       "Enabled",
@@ -162,6 +163,7 @@ function formatAccounts(accounts: readonly AccountSummary[]): string {
       [
         account.id,
         account.label,
+        account.email ?? "-",
         account.provider,
         account.kind,
         String(account.enabled),


### PR DESCRIPTION
## Human comments

## What was wrong

Claude accounts added through the Account Pooler's sign-in flow are labeled with the profile `display_name` (falling back to email only when it is missing). The settings UI and `bb pool account list` only rendered `label`, so a pool of Claude accounts showed people's names with no way to tell which login each row was. The email was already stored on every OAuth account; it just was never displayed.

## What changed

- `plugins/account-pool/app.tsx`: account rows show the email in muted text beside the label, omitted when the email is null (API keys) or identical to the label (imported accounts). The account detail dialog gains an **Email** row.
- `plugins/account-pool/src/cli.ts`: `bb pool account list` adds an **Email** column after **Label** (`-` when absent). Scripts parsing the TSV output by column position need to account for the new column.
- No contract, wire, or storage changes.

## How you verified

- Added an `app.test.tsx` case rendering a display-name-labeled account plus an API-key account: the email appears once in the rows (not for the API key), and the detail dialog shows the Email row.
- `pnpm exec turbo run typecheck test --filter=bb-plugin-account-pool --continue`: typecheck clean, 10 files / 280 tests passed.
- Not manually checked in a running app.

> AGENT GENERATED

🤖 Generated with [Claude Code](https://claude.com/claude-code)
