### PR TITLE
Delay sidebar drag-to-reparent until the pointer rests on a row

### DIFF
--- a/apps/app/src/components/sidebar/useSectionThreadDnd.projection.test.tsx
+++ b/apps/app/src/components/sidebar/useSectionThreadDnd.projection.test.tsx
@@ -3,6 +3,7 @@
 import { act, cleanup, renderHook } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type {
+  CollisionDetection,
   DragCancelEvent,
   DragOverEvent,
   DragStartEvent,
@@ -16,6 +17,7 @@ import {
 } from "@bb/client-core";
 import {
   collectSectionThreadDndLookup,
+  NEST_HOVER_DELAY_MS,
   SectionThreadProjectionGate,
   useSectionThreadDnd,
 } from "./useSectionThreadDnd";
@@ -186,6 +188,54 @@ describe("useSectionThreadDnd nest projection", () => {
       } as DragCancelEvent),
     );
     expect(result.current?.nestTarget).toBeNull();
+  });
+});
+
+describe("useSectionThreadDnd nest hover delay", () => {
+  const rowRect = {
+    top: 100,
+    left: 0,
+    width: 200,
+    height: 28,
+    right: 200,
+    bottom: 128,
+  };
+  const rowDroppableId = getSidebarThreadRowDroppableId("in-b");
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("only offers the row as a nest target after the pointer rests on it", () => {
+    vi.useFakeTimers();
+    const { result } = renderSectionThreadDnd();
+    const props = () => result.current!.dndContextProps;
+    const collide = (y: number) =>
+      props().collisionDetection!({
+        active: { id: "dragged" },
+        collisionRect: rowRect,
+        droppableRects: new Map([[rowDroppableId, rowRect]]),
+        droppableContainers: [{ id: rowDroppableId }],
+        pointerCoordinates: { x: 20, y },
+      } as unknown as Parameters<CollisionDetection>[0]).map(({ id }) => id);
+
+    act(() => props().onDragStart?.(dragStart("dragged")));
+    expect(collide(114)).toEqual([]);
+    act(() => vi.advanceTimersByTime(NEST_HOVER_DELAY_MS - 1));
+    expect(collide(114)).toEqual([]);
+    act(() => vi.advanceTimersByTime(1));
+    expect(collide(114)).toEqual([rowDroppableId]);
+
+    expect(collide(140)).toEqual([]);
+    expect(collide(114)).toEqual([]);
+    act(() => vi.advanceTimersByTime(NEST_HOVER_DELAY_MS));
+    expect(collide(114)).toEqual([rowDroppableId]);
+
+    act(() =>
+      props().onDragCancel?.({ active: { id: "dragged" } } as DragCancelEvent),
+    );
+    act(() => props().onDragStart?.(dragStart("dragged")));
+    expect(collide(114)).toEqual([]);
   });
 });
 

--- a/apps/app/src/components/sidebar/useSectionThreadDnd.test.ts
+++ b/apps/app/src/components/sidebar/useSectionThreadDnd.test.ts
@@ -587,6 +587,33 @@ describe("thread row nest collisions", () => {
     ]);
   });
 
+  it("holds the row target until the candidate is ready", () => {
+    const held: (string | null)[] = [];
+    const seen: unknown[] = [];
+    const resolveHeld = (y: number, ready: boolean) =>
+      resolveThreadRowNestCollisions({
+        collisions: [rowCollision, groupCollision],
+        droppableRects,
+        pointerCoordinates: { x: 20, y },
+        getBandFraction: () => NEST_BAND_FRACTION,
+        onRowPointer: (info) => seen.push(info),
+        holdNestCandidate: (threadId) => {
+          held.push(threadId);
+          return ready;
+        },
+      });
+    expect(resolveHeld(114, false)).toEqual([groupCollision]);
+    expect(resolveHeld(114, true)).toEqual([rowCollision, groupCollision]);
+    expect(resolveHeld(103, true)).toEqual([groupCollision]);
+    expect(resolveHeld(140, true)).toEqual([groupCollision]);
+    expect(held).toEqual(["parent-a", "parent-a", null, null]);
+    expect(seen).toEqual([
+      { threadId: "parent-a", relativeY: 0.5, nesting: false },
+      { threadId: "parent-a", relativeY: 0.5, nesting: true },
+      { threadId: "parent-a", relativeY: 3 / 28, nesting: false },
+    ]);
+  });
+
   it("drops the row target when it is not nestable or the pointer is outside", () => {
     expect(resolve(114, null)).toEqual([groupCollision]);
     expect(resolve(140, 1)).toEqual([groupCollision]);

--- a/apps/app/src/components/sidebar/useSectionThreadDnd.ts
+++ b/apps/app/src/components/sidebar/useSectionThreadDnd.ts
@@ -55,6 +55,7 @@ export const NEST_BAND_FRACTION = 0.6;
 export const NEST_BAND_ARMED_FRACTION = 0.8;
 export const PINNED_NEST_BAND_FRACTION = 0.4;
 export const PINNED_NEST_BAND_ARMED_FRACTION = 0.5;
+export const NEST_HOVER_DELAY_MS = 700;
 
 export interface SectionThreadNestTarget {
   threadId: string;
@@ -157,6 +158,11 @@ interface ResolveThreadRowNestCollisionsArgs {
   pointerCoordinates: { x: number; y: number } | null;
   getBandFraction: (threadId: string) => number | null;
   onRowPointer?: (info: ThreadRowPointerInfo) => void;
+  holdNestCandidate?: (threadId: string | null) => boolean;
+}
+
+interface NestHoverCandidate {
+  threadId: string;
 }
 
 type RowDropState = SectionThreadNestTarget;
@@ -293,6 +299,7 @@ export function resolveThreadRowNestCollisions({
   pointerCoordinates,
   getBandFraction,
   onRowPointer,
+  holdNestCandidate = (threadId) => threadId !== null,
 }: ResolveThreadRowNestCollisionsArgs): Collision[] {
   let rowCollision: Collision | null = null;
   let rowThreadId: string | null = null;
@@ -309,24 +316,49 @@ export function resolveThreadRowNestCollisions({
       rowThreadId = threadId;
     }
   }
-  if (rowCollision === null || rowThreadId === null || !pointerCoordinates) {
-    return otherCollisions;
+  const rowPointer =
+    rowCollision === null || rowThreadId === null
+      ? null
+      : locateThreadRowPointer(
+          rowThreadId,
+          droppableRects.get(rowCollision.id),
+          pointerCoordinates,
+          getBandFraction,
+        );
+  const candidateThreadId = rowPointer?.inNestBand ? rowPointer.threadId : null;
+  const nesting =
+    holdNestCandidate(candidateThreadId) && candidateThreadId !== null;
+  if (rowPointer) {
+    onRowPointer?.({
+      threadId: rowPointer.threadId,
+      relativeY: rowPointer.relativeY,
+      nesting,
+    });
   }
-  const rect = droppableRects.get(rowCollision.id);
-  if (!rect || rect.height <= 0) return otherCollisions;
+  return nesting && rowCollision !== null
+    ? [rowCollision, ...otherCollisions]
+    : otherCollisions;
+}
+
+function locateThreadRowPointer(
+  threadId: string,
+  rect: ClientRect | undefined,
+  pointerCoordinates: { x: number; y: number } | null,
+  getBandFraction: (threadId: string) => number | null,
+): { threadId: string; relativeY: number; inNestBand: boolean } | null {
+  if (!rect || rect.height <= 0 || !pointerCoordinates) return null;
   const { x, y } = pointerCoordinates;
   const withinRect =
     x >= rect.left &&
     x <= rect.left + rect.width &&
     y >= rect.top &&
     y <= rect.top + rect.height;
-  if (!withinRect) return otherCollisions;
+  if (!withinRect) return null;
   const relativeY = (y - rect.top) / rect.height;
-  const bandFraction = getBandFraction(rowThreadId);
-  const nesting =
+  const bandFraction = getBandFraction(threadId);
+  const inNestBand =
     bandFraction !== null && Math.abs(relativeY - 0.5) <= bandFraction / 2;
-  onRowPointer?.({ threadId: rowThreadId, relativeY, nesting });
-  return nesting ? [rowCollision, ...otherCollisions] : otherCollisions;
+  return { threadId, relativeY, inNestBand };
 }
 
 export function buildPinInsertRequest(
@@ -688,6 +720,37 @@ export function useSectionThreadDnd({
   const armedNestThreadIdRef = useRef<string | null>(null);
   const coarsePointerRef = useRef(false);
   const pinnedInsertRef = useRef<SectionThreadReorderTarget | null>(null);
+  const nestCandidateRef = useRef<NestHoverCandidate | null>(null);
+  const nestCandidateTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+  const [readyNestCandidate, setReadyNestCandidate] =
+    useState<NestHoverCandidate | null>(null);
+  const clearNestCandidate = useCallback(() => {
+    if (nestCandidateTimerRef.current !== null) {
+      clearTimeout(nestCandidateTimerRef.current);
+    }
+    nestCandidateTimerRef.current = null;
+    nestCandidateRef.current = null;
+  }, []);
+  const holdNestCandidate = useCallback(
+    (threadId: string | null): boolean => {
+      const current = nestCandidateRef.current;
+      if (current !== null && current.threadId === threadId) {
+        return current === readyNestCandidate;
+      }
+      clearNestCandidate();
+      if (threadId === null) return false;
+      const candidate: NestHoverCandidate = { threadId };
+      nestCandidateRef.current = candidate;
+      nestCandidateTimerRef.current = setTimeout(() => {
+        nestCandidateTimerRef.current = null;
+        setReadyNestCandidate(candidate);
+      }, NEST_HOVER_DELAY_MS);
+      return false;
+    },
+    [clearNestCandidate, readyNestCandidate],
+  );
   const isPinnedItem = useCallback(
     (itemId: string) =>
       lookup.parentKeyByItemId.get(itemId) === PINNED_THREAD_PARENT_KEY,
@@ -752,13 +815,19 @@ export function useSectionThreadDnd({
         pointerCoordinates: args.pointerCoordinates,
         getBandFraction: getNestBandFraction,
         onRowPointer: handleRowPointer,
+        holdNestCandidate,
       });
       const nestedCollisions = collisions.filter(({ id }) =>
         typeof id === "string" ? !topLevelSectionIds.has(id) : true,
       );
       return nestedCollisions.length > 0 ? nestedCollisions : collisions;
     },
-    [getNestBandFraction, handleRowPointer, topLevelSectionIds],
+    [
+      getNestBandFraction,
+      handleRowPointer,
+      holdNestCandidate,
+      topLevelSectionIds,
+    ],
   );
   const updateThread = useUpdateThread();
   const pinThread = usePinThread();
@@ -826,10 +895,12 @@ export function useSectionThreadDnd({
     setDragOverParentKey(null);
     setRowDrop(null);
     setReorderTarget(null);
+    setReadyNestCandidate(null);
+    clearNestCandidate();
     armedNestThreadIdRef.current = null;
     activeIdRef.current = null;
     pinnedInsertRef.current = null;
-  }, []);
+  }, [clearNestCandidate]);
   const clearProjectedDrag = useCallback(() => {
     clearDropSettle();
     clearDropState();
@@ -839,9 +910,15 @@ export function useSectionThreadDnd({
     () => () => {
       clearDropDwell();
       clearDropSettle();
+      clearNestCandidate();
       stopProjectionInputTracking();
     },
-    [clearDropDwell, clearDropSettle, stopProjectionInputTracking],
+    [
+      clearDropDwell,
+      clearDropSettle,
+      clearNestCandidate,
+      stopProjectionInputTracking,
+    ],
   );
 
   const handleDragStart = useCallback(
@@ -860,13 +937,21 @@ export function useSectionThreadDnd({
       );
       clearDropSettle();
       clearDropDwell();
+      clearNestCandidate();
       startProjectionInputTracking();
       setActiveThread(thread);
       setDragOverParentKey(null);
       setRowDrop(null);
       setReorderTarget(null);
+      setReadyNestCandidate(null);
     },
-    [clearDropDwell, clearDropSettle, lookup, startProjectionInputTracking],
+    [
+      clearDropDwell,
+      clearDropSettle,
+      clearNestCandidate,
+      lookup,
+      startProjectionInputTracking,
+    ],
   );
 
   const projectedNestParentId =
@@ -984,6 +1069,7 @@ export function useSectionThreadDnd({
     (event: DragEndEvent) => {
       draggingThreadRef.current = false;
       clearDropDwell();
+      clearNestCandidate();
       stopProjectionInputTracking();
       if (!enabled) {
         clearProjectedDrag();
@@ -1088,6 +1174,7 @@ export function useSectionThreadDnd({
       clearDropDwell,
       clearDropSettle,
       clearDropState,
+      clearNestCandidate,
       clearProjectedDrag,
       commitNest,
       decisionOptions,


### PR DESCRIPTION
## Human comments

## What was wrong

A sidebar row became a nest target as soon as a dragged thread's pointer crossed the middle of the row. `resolveThreadRowNestCollisions` returned the row's droppable right away, so moving a thread past other rows nested it into whichever row it was over when dropped.

## What changed

`apps/app/src/components/sidebar/useSectionThreadDnd.ts`

- A row now only becomes a nest target after the pointer stays in its nest band for `NEST_HOVER_DELAY_MS` (700 ms). Until then the row collision is left out, so the drag acts as a normal move and dropping early does not nest.
- `resolveThreadRowNestCollisions` takes a new `holdNestCandidate(threadId | null)` callback, which it calls with the row the pointer is resting on (or `null`). The default keeps the old immediate behavior.
- `useSectionThreadDnd` tracks the candidate row in a ref and starts a timer. When the timer fires it stores the candidate in state. That gives `collisionDetection` a new identity, so dnd-kit recomputes collisions and the row highlights without any pointer movement. Leaving the row or moving to another row clears the candidate, so returning means another full wait. Drag start, end, cancel and unmount clear the timer.
- The "blocked" and "unchanged" indicators wait the same 700 ms, and the widened nest band applies once a row is armed. Pinned rows and touch drags use the same delay.

No wire, CLI, or plugin API changes.

## How you verified

- New hook test `useSectionThreadDnd nest hover delay`: calls the real `collisionDetection` and checks that no row target appears at 699 ms, the row target appears at 700 ms, and leaving and re-entering needs another full delay, as does a new drag. With `holdNestCandidate` removed from the hook the test fails; with it restored the test passes.
- New unit test for `resolveThreadRowNestCollisions` that checks the gating, the candidate reported to the callback, and the `onRowPointer` nesting flag.
- `pnpm exec vitest run src/components/sidebar/useSectionThreadDnd` (34 passed)
- `pnpm exec turbo run typecheck --filter=@bb/app`, oxlint, prettier
- Manual: Sawyer tried it in a dev app seeded with sections, nested children and pinned threads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> AGENT GENERATED
