### PR TITLE
Make machine lifecycle cleanup test event-driven

### DIFF
--- a/apps/server/test/helpers/commands.ts
+++ b/apps/server/test/helpers/commands.ts
@@ -104,6 +104,9 @@ interface RegisterTestHostRpcCaptureArgs {
   hostId: string;
   sessionId: string;
   queueBranchOptions?: boolean;
+  onPluginHostCall?: (
+    command: Extract<HostDaemonRpcCommand, { type: "plugin.host.call" }>,
+  ) => Promise<HostDaemonOnlineRpcResult<"plugin.host.call">>;
   onEnvironmentHook?: (
     command: Extract<HostDaemonRpcCommand, { type: "environment.hook.run" }>,
   ) => Promise<void>;
@@ -417,6 +420,38 @@ export function registerTestHostRpcCapture(
                 sessionId: args.sessionId,
               }),
           );
+        return;
+      }
+      if (
+        command.type === "plugin.host.call" &&
+        args.onPluginHostCall !== undefined
+      ) {
+        void args.onPluginHostCall(command).then(
+          (result) =>
+            deps.hub.recordHostOnlineRpcResponse({
+              message: hostDaemonOnlineRpcResponseMessageSchema.parse({
+                type: "host-rpc.response",
+                requestId: message.requestId,
+                commandType: command.type,
+                ok: true,
+                result,
+              }),
+              sessionId: args.sessionId,
+            }),
+          (error: unknown) =>
+            deps.hub.recordHostOnlineRpcResponse({
+              message: hostDaemonOnlineRpcResponseMessageSchema.parse({
+                type: "host-rpc.response",
+                requestId: message.requestId,
+                commandType: command.type,
+                ok: false,
+                errorCode: "test_plugin_host_call_failed",
+                errorMessage:
+                  error instanceof Error ? error.message : String(error),
+              }),
+              sessionId: args.sessionId,
+            }),
+        );
         return;
       }
       if (respondToRuntimeWorkspaceFileCommand(deps, args, message)) {

--- a/apps/server/test/services/machines/lifecycle-recovery.test.ts
+++ b/apps/server/test/services/machines/lifecycle-recovery.test.ts
@@ -26,11 +26,7 @@ import { setPluginEnvironmentProviderBridge } from "../../../src/services/plugin
 import { callPluginHostRpc } from "../../../src/services/plugins/plugin-host-rpc.js";
 import { callHostOnlineRpcForWork } from "../../../src/services/hosts/online-rpc.js";
 import { createMachineEnrollmentService } from "../../../src/services/machines/enrollments.js";
-import {
-  registerTestHostRpcCapture,
-  reportQueuedCommandSuccess,
-  waitForQueuedCommand,
-} from "../../helpers/commands.js";
+import { registerTestHostRpcCapture } from "../../helpers/commands.js";
 import { readJson } from "../../helpers/json.js";
 import {
   seedHostSession,
@@ -158,10 +154,6 @@ it.each(["active", "suspended"] as const)(
   async (phase) =>
     withTestHarness(async (harness) => {
       const target = seedHostSession(harness.deps, { id: "review-removing" });
-      registerTestHostRpcCapture(harness, {
-        hostId: target.host.id,
-        sessionId: target.session.id,
-      });
       const { project } = seedProjectWithSource(harness.deps, {
         hostId: target.host.id,
       });
@@ -177,6 +169,14 @@ it.each(["active", "suspended"] as const)(
           }),
         },
       }).forOwner("test-machine-plugin");
+      const cleanupCall = vi.fn(async () => ({ output: {} }));
+      const registerCleanupCapture = (sessionId: string) =>
+        registerTestHostRpcCapture(harness, {
+          hostId: target.host.id,
+          sessionId,
+          onPluginHostCall: cleanupCall,
+        });
+      registerCleanupCapture(target.session.id);
       const resume = vi.fn(async () => {
         expect(
           await enrollment.prepare({
@@ -184,7 +184,8 @@ it.each(["active", "suspended"] as const)(
             key: "cleanup-machine",
           }),
         ).toMatchObject({ state: "enrolled" });
-        seedSession(harness.deps, target.host.id);
+        const session = seedSession(harness.deps, target.host.id);
+        registerCleanupCapture(session.id);
         await enrollment.waitForConnection({
           enrollmentId: target.host.id,
           timeoutMs: 100,
@@ -272,11 +273,6 @@ it.each(["active", "suspended"] as const)(
         decisionTimeoutMs: 1000,
       });
       expect(requestMachineRemoval(harness.deps, target.host.id)).toBe(true);
-      const sweeping = sweepProviderMachine(harness.deps, target.host.id);
-      const call = await waitForQueuedCommand(
-        harness,
-        ({ command }) => command.type === "plugin.host.call",
-      );
       expect(getHost(harness.db, target.host.id)?.phase).toBe("removing");
       await expect(
         callHostOnlineRpcForWork(harness.deps, {
@@ -291,13 +287,13 @@ it.each(["active", "suspended"] as const)(
           key: "cleanup-machine",
         }),
       ).rejects.toThrow("cancelled");
-      await reportQueuedCommandSuccess(harness, call, { output: {} });
-      await sweeping;
+      await sweepProviderMachine(harness.deps, target.host.id);
       expect(getEnvironment(harness.db, environment.id)).toMatchObject({
         status: "destroyed",
         teardownStatus: "removed",
       });
       expect(getHost(harness.db, target.host.id)?.phase).toBe("destroyed");
+      expect(cleanupCall).toHaveBeenCalledOnce();
       expect(resume).toHaveBeenCalledTimes(phase === "suspended" ? 1 : 0);
       expect(machineRemove).toHaveBeenCalledOnce();
     }),


### PR DESCRIPTION
## Human comments

## What was wrong

The persistent-machine lifecycle test started the machine sweep without awaiting it, polled the shared host-RPC capture every 10 ms behind a 1-second wall-clock deadline, and manually completed the eventual plugin host call. Under scheduler delay, that observer could exhaust its deadline before the cleanup call was visible even though cleanup behavior was progressing. The rejected test then left its sweep waiting for a response, allowing unfinished asynchronous work to spill into the suspended parameterized case. This produced the two-failure signature in [CI run 34644625045](https://github.com/get-bb/bb/actions/runs/34644625045/job/103412317693).

## What changed

- Added an opt-in plugin host call responder to the test daemon capture.
- Asserted removal admission policy immediately after the removal transition.
- Awaited the machine sweep directly while the capture completes the real environment-provider host RPC.
- Kept the environment teardown hook, plugin host call, machine resume path, and final lifecycle assertions intact.
- Did not change a timeout, retry budget, production behavior, assertion strength, or server/daemon wire contract. No protocol-version bump is needed.

## How you verified

- Frozen base and merge-base: 232a5e256e45a8bcdeaae1a8ad83ce3e8d9733c4.
- Before the change, the focused file under 16 bounded CPU burners reproduced both CI failures: active failed after 1,090 ms with captured: none; suspended exhausted the unchanged 5,000 ms whole-test ceiling.
- After the change under the identical bounded contention, all 6 tests passed; active completed in 1,071 ms, beyond the removed 1-second observer deadline, and suspended completed in 958 ms.
- Final unloaded focused run: 6/6 passed.
- pnpm exec turbo run typecheck --filter=@bb/server --output-logs=full --concurrency=4: passed, 5/5 tasks.
- pnpm exec turbo run build --filter=@bb/server --output-logs=full --concurrency=4: passed, 5/5 tasks.
- pnpm exec turbo run test --filter=@bb/server --output-logs=full --concurrency=4: the changed lifecycle file passed 6/6 in 3.646 seconds. The full local Intel shard was not green: 15 unrelated existing whole-test timeouts occurred across install-machine-script, timeline, server-access, and plugin-update tests. The 253-file shard showed broad host saturation with 1,425.46 aggregate test-seconds in 254.06 wall-seconds, so this is recorded as systemic package-shard contention on this Intel host rather than a scoped regression.
- [PR CI run 34647154244](https://github.com/get-bb/bb/actions/runs/34647154244): all required checks passed; the server shard passed in 3m02s.
- Every focused, stress, Turbo test, build, and typecheck process ran in its own externally bounded process group with signal/exit cleanup. All before/after survivor checks reported no matching processes.

> AGENT GENERATED
