### PR TITLE
Preserve the former parent's section when unparenting threads

### DIFF
--- a/apps/app/src/hooks/cache-owners/thread-state-cache-owner.test.ts
+++ b/apps/app/src/hooks/cache-owners/thread-state-cache-owner.test.ts
@@ -70,6 +70,95 @@ function makeSidebarNavigation(
 }
 
 describe("thread state cache owner", () => {
+  it.each([
+    {
+      source: "sidebar",
+      parentSection: "parent-section",
+      sectionId: undefined,
+    },
+    { source: "detail", parentSection: "parent-section", sectionId: undefined },
+    { source: "list", parentSection: "parent-section", sectionId: undefined },
+    { source: "sidebar", parentSection: null, sectionId: undefined },
+    {
+      source: "sidebar",
+      parentSection: "parent-section",
+      sectionId: "destination",
+    },
+    { source: "sidebar", parentSection: "parent-section", sectionId: null },
+    {
+      source: "missing",
+      parentSection: "parent-section",
+      sectionId: undefined,
+    },
+  ])(
+    "unparents without flashing the old section ($source, $parentSection, $sectionId)",
+    async ({ source, parentSection, sectionId }) => {
+      const { queryClient } = createQueryClientTestHarness();
+      const child = makeThreadWithRuntime({
+        parentThreadId: "parent",
+        sectionId: "old-section",
+      });
+      const childEntry = makeThreadListEntry(child);
+      const parent = makeThreadListEntry({
+        id: "parent",
+        sectionId: parentSection,
+      });
+      const listKey = threadListQueryKey({
+        archived: false,
+        projectId: "project-1",
+      });
+      queryClient.setQueryData(threadQueryKey(child.id), child);
+      queryClient.setQueryData(
+        listKey,
+        source === "list" ? [childEntry, parent] : [childEntry],
+      );
+      queryClient.setQueryData(
+        sidebarNavigationQueryKey(),
+        makeSidebarNavigation(
+          source === "sidebar" ? [childEntry, parent] : [childEntry],
+        ),
+      );
+      if (source === "detail") {
+        queryClient.setQueryData(
+          threadQueryKey(parent.id),
+          makeThreadWithRuntime(parent),
+        );
+      }
+      const transaction = await beginThreadMetadataTransaction({
+        queryClient,
+        threadId: child.id,
+        parentThreadId: null,
+        sectionId,
+      });
+      const expected =
+        source === "missing"
+          ? { parentThreadId: "parent", sectionId: "old-section" }
+          : {
+              parentThreadId: null,
+              sectionId: sectionId === undefined ? parentSection : sectionId,
+            };
+      const cachedChild = () => [
+        queryClient.getQueryData<ThreadWithRuntime>(threadQueryKey(child.id)),
+        queryClient.getQueryData<ThreadListEntry[]>(listKey)?.[0],
+        queryClient.getQueryData<SidebarBootstrapResponse>(
+          sidebarNavigationQueryKey(),
+        )?.projects[0]?.threads[0],
+      ];
+      for (const cached of cachedChild())
+        expect(cached).toMatchObject(expected);
+      rollbackThreadListMutationTransaction({
+        queryClient,
+        threadId: child.id,
+        transaction,
+      });
+      for (const cached of cachedChild())
+        expect(cached).toMatchObject({
+          parentThreadId: "parent",
+          sectionId: "old-section",
+        });
+    },
+  );
+
   it("optimistically renames thread in thread, list, and sidebar caches", async () => {
     const { queryClient } = createQueryClientTestHarness();
     const threadId = "thread-1";

--- a/apps/app/src/hooks/cache-owners/thread-state-cache-owner.ts
+++ b/apps/app/src/hooks/cache-owners/thread-state-cache-owner.ts
@@ -22,12 +22,14 @@ import {
 } from "./mutation-cache-effects";
 import {
   applyToCachedThreadListsAndSidebarNavigation,
+  getCachedSidebarNavigationThreads,
   restoreCachedSidebarNavigation,
   snapshotCachedSidebarNavigation,
   type CachedSidebarNavigationSnapshot,
 } from "./query-cache";
 import {
   getCachedThreadLists,
+  iterateThreadListCacheEntries,
   restoreCachedThreadLists,
   type CachedThreadListSnapshot,
 } from "./thread-list-cache-data";
@@ -389,6 +391,28 @@ export function beginThreadReadStateTransaction({
   });
 }
 
+function findThreadMetadataInCache(
+  queryClient: QueryClient,
+  threadId: string,
+): Pick<ThreadWithRuntime, "parentThreadId" | "sectionId"> | undefined {
+  const thread = queryClient.getQueryData<ThreadWithRuntime>(
+    threadQueryKey(threadId),
+  );
+  if (thread) return thread;
+  const sidebarThread = getCachedSidebarNavigationThreads(queryClient).find(
+    (entry) => entry.id === threadId,
+  );
+  if (sidebarThread) return sidebarThread;
+  for (const { data } of getCachedThreadLists(queryClient, {
+    queryKey: threadsQueryKey(),
+  })) {
+    for (const entry of iterateThreadListCacheEntries(data)) {
+      if (entry.id === threadId) return entry;
+    }
+  }
+  return undefined;
+}
+
 export function beginThreadMetadataTransaction({
   parentThreadId,
   sectionId,
@@ -396,6 +420,20 @@ export function beginThreadMetadataTransaction({
   threadId,
   title,
 }: BeginThreadMetadataTransactionArgs): Promise<ThreadListMutationTransaction> {
+  if (parentThreadId === null && sectionId === undefined) {
+    const thread = findThreadMetadataInCache(queryClient, threadId);
+    if (thread?.parentThreadId) {
+      const parent = findThreadMetadataInCache(
+        queryClient,
+        thread.parentThreadId,
+      );
+      if (parent) {
+        sectionId = parent.sectionId;
+      } else {
+        parentThreadId = undefined;
+      }
+    }
+  }
   const patch = {
     ...(title !== undefined ? { title } : {}),
     ...(sectionId !== undefined ? { sectionId } : {}),

--- a/apps/server/src/routes/threads/actions.ts
+++ b/apps/server/src/routes/threads/actions.ts
@@ -64,11 +64,7 @@ import {
   toThreadListEntryResponses,
   toThreadResponseFromThread,
 } from "../../services/threads/thread-runtime-display.js";
-import {
-  archiveThreadAndChildren,
-  archiveThreadAndHiddenSourceForks,
-  resolveArchiveThreadEnvironment,
-} from "../../services/threads/thread-archive.js";
+import { archiveThreadAndChildren } from "../../services/threads/thread-archive.js";
 import {
   requireThreadCommandEnvironment,
   requireThreadHostCommandEnvironment,
@@ -535,25 +531,6 @@ export function registerThreadActionRoutes(app: Hono, deps: AppDeps): void {
       }),
     );
     return context.json(buildActivePinnedThreadRootListResponse(deps));
-  });
-
-  post(routes.archive, async (context) => {
-    const thread = requirePublicThread(deps.db, context.req.param("id"));
-    if (thread.archivedAt !== null) {
-      deps.terminalSessions.closeArchivedThreadTerminals({
-        threadId: thread.id,
-      });
-      return context.json({ ok: true });
-    }
-    const environment = resolveArchiveThreadEnvironment(deps, { thread });
-    const archiveResult = archiveThreadAndHiddenSourceForks(deps, {
-      environment,
-      thread,
-    });
-    if (!archiveResult) {
-      throw new ApiError(404, "thread_not_found", "Thread not found");
-    }
-    return context.json({ ok: true });
   });
 
   post(routes.archiveAll, (context) => {

--- a/apps/server/src/routes/threads/base.ts
+++ b/apps/server/src/routes/threads/base.ts
@@ -5,6 +5,7 @@ import {
   countNonDeletedAssignedChildThreads,
   countThreads,
   getEnvironment,
+  getThread,
   getThreadSectionById,
   listThreadMentionRowsByIds,
   listThreadsWithPendingInteractionState,
@@ -413,6 +414,12 @@ export function registerThreadBaseRoutes(app: Hono, deps: AppDeps): void {
         requireThreadSection(deps, sectionId);
       }
       metadataUpdate.sectionId = sectionId;
+    } else if (
+      payload.parentThreadId === null &&
+      thread.parentThreadId !== null
+    ) {
+      metadataUpdate.sectionId =
+        getThread(deps.db, thread.parentThreadId)?.sectionId ?? null;
     }
     if ("parentThreadId" in payload) {
       metadataUpdate.parentThreadId = payload.parentThreadId;

--- a/apps/server/src/services/threads/thread-archive.ts
+++ b/apps/server/src/services/threads/thread-archive.ts
@@ -126,25 +126,6 @@ function archiveThreadWithLifecycleEffects(
   return archivedThread;
 }
 
-export function archiveThreadAndHiddenSourceForks(
-  deps: AppDeps,
-  args: ArchiveThreadWithLifecycleEffectsArgs,
-): Thread | null {
-  const archivedThread = archiveThreadWithLifecycleEffects(deps, args);
-  if (!archivedThread) {
-    return null;
-  }
-  for (const fork of listUnarchivedHiddenSourceThreads(deps.db, {
-    sourceThreadId: archivedThread.id,
-  })) {
-    archiveThreadWithLifecycleEffects(deps, {
-      environment: resolveArchiveThreadEnvironment(deps, { thread: fork }),
-      thread: fork,
-    });
-  }
-  return archivedThread;
-}
-
 export function archiveEnvironmentThreads(
   deps: AppDeps,
   args: ArchiveEnvironmentThreadsArgs,

--- a/apps/server/src/services/threads/thread-ownership.ts
+++ b/apps/server/src/services/threads/thread-ownership.ts
@@ -47,6 +47,7 @@ interface HandleThreadOwnershipChangeArgs {
 
 interface ReleaseUnarchivedChildrenFromArchivedThreadArgs {
   parentThreadId: string;
+  sectionId: string | null;
 }
 
 interface ArchiveThreadAndReleaseChildrenArgs {
@@ -160,6 +161,7 @@ function releaseUnarchivedChildrenFromArchivedThreadInTransaction(
   for (const childThread of childThreads) {
     const updatedThread = updateThread(deps.db, deps.hub, childThread.id, {
       parentThreadId: null,
+      sectionId: args.sectionId,
     });
     if (!updatedThread) {
       continue;
@@ -196,6 +198,7 @@ export function archiveThreadAndReleaseChildren(
         },
         {
           parentThreadId: archivedThread.id,
+          sectionId: archivedThread.sectionId,
         },
       );
 

--- a/apps/server/test/public/public-terminals.test.ts
+++ b/apps/server/test/public/public-terminals.test.ts
@@ -1578,7 +1578,7 @@ describe("public terminal routes", () => {
     fixture.harness.hub.registerTerminalClient(stored.id, browserSocket);
 
     const response = await fixture.harness.app.request(
-      `/api/v1/threads/${fixture.thread.id}/archive`,
+      `/api/v1/threads/${fixture.thread.id}/archive-all`,
       {
         method: "POST",
       },

--- a/apps/server/test/public/public-thread-parenting.test.ts
+++ b/apps/server/test/public/public-thread-parenting.test.ts
@@ -1,4 +1,9 @@
-import { archiveThread, getThread } from "@bb/db";
+import {
+  archiveThread,
+  createThread,
+  createThreadSection,
+  getThread,
+} from "@bb/db";
 import { threadSchema } from "@bb/domain";
 import {
   apiErrorSchema,
@@ -17,9 +22,109 @@ import {
   seedThread,
   seedThreadRuntimeState,
 } from "../helpers/seed.js";
+import { archiveThreadAndReleaseChildren } from "../../src/services/threads/thread-ownership.js";
 import { withTestHarness } from "../helpers/test-app.js";
 
 describe("public thread parenting routes", () => {
+  it.each([
+    { mode: "inherit", parentSection: true },
+    { mode: "inherit", parentSection: false },
+    { mode: "explicit", parentSection: true },
+    { mode: "clear", parentSection: true },
+    { mode: "root", parentSection: true },
+    { mode: "reparent", parentSection: true },
+    { mode: "archive", parentSection: true },
+    { mode: "archive", parentSection: false },
+  ] as const)(
+    "preserves section policy on $mode (parent section: $parentSection)",
+    async ({ mode, parentSection }) => {
+      await withTestHarness(async (harness) => {
+        const { host } = seedHostSession(harness.deps);
+        const { project } = seedProjectWithSource(harness.deps, {
+          hostId: host.id,
+        });
+        const section = createThreadSection(harness.db, harness.deps.hub, {
+          name: "Parent section",
+        }).section;
+        const original = createThreadSection(harness.db, harness.deps.hub, {
+          name: "Child section",
+        }).section;
+        const parent = createThread(harness.db, harness.deps.hub, {
+          projectId: project.id,
+          providerId: "codex",
+          sectionId: parentSection ? section.id : null,
+        });
+        const child = createThread(harness.db, harness.deps.hub, {
+          projectId: project.id,
+          providerId: "codex",
+          parentThreadId: mode === "root" ? null : parent.id,
+          sectionId: original.id,
+        });
+        const nextParent = seedThread(harness.deps, { projectId: project.id });
+        const expectedSectionId =
+          mode === "clear"
+            ? null
+            : ["explicit", "root", "reparent"].includes(mode)
+              ? original.id
+              : parent.sectionId;
+        const expectedParentId = mode === "reparent" ? nextParent.id : null;
+
+        if (mode === "archive") {
+          archiveThreadAndReleaseChildren(harness.deps, {
+            threadId: parent.id,
+          });
+        } else {
+          const response = await harness.app.request(
+            `/api/v1/threads/${child.id}`,
+            {
+              method: "PATCH",
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify({
+                parentThreadId: expectedParentId,
+                ...(mode === "explicit" ? { sectionId: original.id } : {}),
+                ...(mode === "clear" ? { sectionId: null } : {}),
+              }),
+            },
+          );
+          expect(response.status).toBe(200);
+          expect(threadSchema.parse(await readJson(response))).toMatchObject({
+            parentThreadId: expectedParentId,
+            sectionId: expectedSectionId,
+          });
+        }
+        expect(getThread(harness.db, child.id)).toMatchObject({
+          parentThreadId: expectedParentId,
+          sectionId: expectedSectionId,
+          archivedAt: null,
+        });
+      });
+    },
+  );
+
+  it("does not expose the removed parent-only archive endpoint", async () => {
+    await withTestHarness(async (harness) => {
+      const { host } = seedHostSession(harness.deps);
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.id,
+      });
+      const parent = seedThread(harness.deps, { projectId: project.id });
+      const child = seedThread(harness.deps, {
+        projectId: project.id,
+        parentThreadId: parent.id,
+      });
+      const response = await harness.app.request(
+        `/api/v1/threads/${parent.id}/archive`,
+        { method: "POST" },
+      );
+      expect(response.status).toBe(404);
+      expect(getThread(harness.db, parent.id)?.archivedAt).toBeNull();
+      expect(getThread(harness.db, child.id)).toMatchObject({
+        archivedAt: null,
+        parentThreadId: parent.id,
+      });
+    });
+  });
+
   it("creates a child thread under a parent", async () => {
     await withTestHarness(async (harness) => {
       const { host } = seedHostSession(harness.deps);
@@ -402,42 +507,6 @@ describe("public thread parenting routes", () => {
       const archivedChildThread = getThread(harness.db, childThread.id);
       expect(archivedChildThread?.archivedAt).not.toBeNull();
       expect(archivedChildThread?.parentThreadId).toBe(parentThread.id);
-    });
-  });
-
-  it("archives hidden source-derived forks when archiving a single thread", async () => {
-    await withTestHarness(async (harness) => {
-      const { host } = seedHostSession(harness.deps);
-      const { project } = seedProjectWithSource(harness.deps, {
-        hostId: host.id,
-      });
-      const environment = seedEnvironment(harness.deps, {
-        hostId: host.id,
-        projectId: project.id,
-      });
-      const sourceThread = seedThread(harness.deps, {
-        environmentId: environment.id,
-        projectId: project.id,
-      });
-      const sideChatThread = seedThread(harness.deps, {
-        environmentId: environment.id,
-        originKind: "fork",
-        originPluginId: "side-chat",
-        visibility: "hidden",
-        projectId: project.id,
-        sourceThreadId: sourceThread.id,
-      });
-
-      const response = await harness.app.request(
-        `/api/v1/threads/${sourceThread.id}/archive`,
-        { method: "POST" },
-      );
-
-      expect(response.status).toBe(200);
-      expect(getThread(harness.db, sourceThread.id)?.archivedAt).not.toBeNull();
-      expect(
-        getThread(harness.db, sideChatThread.id)?.archivedAt,
-      ).not.toBeNull();
     });
   });
 

--- a/apps/server/test/services/machines/lifecycle-recovery.test.ts
+++ b/apps/server/test/services/machines/lifecycle-recovery.test.ts
@@ -389,7 +389,7 @@ it("removes a suspended machine when its last thread is archived with an offline
       listThreadIdsWithHostOfflineQueueWaits(harness.db, target.host.id),
     ).toEqual([thread.id]);
     const response = await harness.app.request(
-      `/api/v1/threads/${thread.id}/archive`,
+      `/api/v1/threads/${thread.id}/archive-all`,
       { method: "POST" },
     );
     expect(response.status).toBe(200);

--- a/apps/server/test/services/plugins/plugin-thread-events.test.ts
+++ b/apps/server/test/services/plugins/plugin-thread-events.test.ts
@@ -440,7 +440,7 @@ describe("plugin thread lifecycle events", () => {
       });
 
       const response = await harness.app.request(
-        `/api/v1/threads/${thread.id}/archive`,
+        `/api/v1/threads/${thread.id}/archive-all`,
         { method: "POST" },
       );
 

--- a/apps/server/test/system/event-pruning.test.ts
+++ b/apps/server/test/system/event-pruning.test.ts
@@ -428,7 +428,7 @@ describe("thread event pruning", () => {
       });
 
       const response = await harness.app.request(
-        `/api/v1/threads/${thread.id}/archive`,
+        `/api/v1/threads/${thread.id}/archive-all`,
         {
           method: "POST",
         },

--- a/apps/server/test/threads/archive-pruned-environment.test.ts
+++ b/apps/server/test/threads/archive-pruned-environment.test.ts
@@ -72,10 +72,9 @@ function seedPointerlessThread(
 async function expectArchiveRefused(
   harness: TestAppHarness,
   threadId: string,
-  route: "archive" | "archive-all",
 ): Promise<void> {
   const response = await harness.app.request(
-    `/api/v1/threads/${threadId}/${route}`,
+    `/api/v1/threads/${threadId}/archive-all`,
     { method: "POST" },
   );
   expect(response.status).toBe(409);
@@ -87,19 +86,6 @@ async function expectArchiveRefused(
 }
 
 describe("archive after environment prune", () => {
-  it("POST /threads/:id/archive succeeds for a thread whose environment was pruned", async () => {
-    await withTestHarness(async (harness) => {
-      const { thread } = seedThreadWithPrunedEnvironment(harness.deps);
-      const response = await harness.app.request(
-        `/api/v1/threads/${thread.id}/archive`,
-        { method: "POST" },
-      );
-      expect(response.status).toBe(200);
-      expect(await readJson(response)).toEqual({ ok: true });
-      expect(getThread(harness.deps.db, thread.id)?.archivedAt).not.toBeNull();
-    });
-  });
-
   it("POST /threads/:id/archive-all succeeds for a thread whose environment was pruned", async () => {
     await withTestHarness(async (harness) => {
       const { thread } = seedThreadWithPrunedEnvironment(harness.deps);
@@ -121,8 +107,7 @@ describe("archive after environment prune", () => {
     async (status) => {
       await withTestHarness(async (harness) => {
         const thread = seedPointerlessThread(harness.deps, status);
-        await expectArchiveRefused(harness, thread.id, "archive");
-        await expectArchiveRefused(harness, thread.id, "archive-all");
+        await expectArchiveRefused(harness, thread.id);
       });
     },
   );

--- a/apps/server/test/threads/environment-providers.test.ts
+++ b/apps/server/test/threads/environment-providers.test.ts
@@ -2642,9 +2642,12 @@ describe("a provider-produced environment over its life", () => {
         });
         expect(
           (
-            await harness.app.request(`/api/v1/threads/${thread.id}/archive`, {
-              method: "POST",
-            })
+            await harness.app.request(
+              `/api/v1/threads/${thread.id}/archive-all`,
+              {
+                method: "POST",
+              },
+            )
           ).status,
         ).toBe(200);
         expect(

--- a/apps/server/test/threads/machine-lifecycle.test.ts
+++ b/apps/server/test/threads/machine-lifecycle.test.ts
@@ -336,7 +336,7 @@ describe("composed machine thread lifecycle", () => {
         expect(listQueuedThreadMessages(harness.db, thread.id)).toEqual([]);
         if (archiveFrom === "suspended") await pause();
         const archive = await harness.app.request(
-          `/api/v1/threads/${thread.id}/archive`,
+          `/api/v1/threads/${thread.id}/archive-all`,
           { method: "POST" },
         );
         expect(archive.status).toBe(200);

--- a/apps/server/test/threads/thread-live-start-handoff.test.ts
+++ b/apps/server/test/threads/thread-live-start-handoff.test.ts
@@ -157,7 +157,7 @@ describe("live thread start handoff", () => {
       });
       try {
         const response = await harness.app.request(
-          `/api/v1/threads/${fixture.thread.id}/archive`,
+          `/api/v1/threads/${fixture.thread.id}/archive-all`,
           { method: "POST" },
         );
 
@@ -384,7 +384,7 @@ describe("live thread start handoff", () => {
       });
 
       const response = await harness.app.request(
-        `/api/v1/threads/${fixture.thread.id}/archive`,
+        `/api/v1/threads/${fixture.thread.id}/archive-all`,
         { method: "POST" },
       );
       expect(response.status).toBe(200);

--- a/packages/server-contract/src/public-api.ts
+++ b/packages/server-contract/src/public-api.ts
@@ -1411,12 +1411,6 @@ export const publicApiRoutes = {
       request: noRequest<PathThreadInteractionId>(),
       response: jsonResponse<PendingInteraction>(),
     }),
-    archive: defineRoute({
-      path: "/threads/:id/archive",
-      method: "post",
-      request: noRequest<PathId>(),
-      response: jsonResponse<{ ok: true }>(),
-    }),
     archiveAll: defineRoute({
       path: "/threads/:id/archive-all",
       method: "post",

--- a/packages/templates/src/templates/bb-guide-threads.md
+++ b/packages/templates/src/templates/bb-guide-threads.md
@@ -284,6 +284,10 @@ Ownership:
     --reasoning-level <level>              Set the sticky reasoning level (provider-dependent)
     --visibility <visibility>              Set visible or hidden
 
+  Clearing a parent inherits the former parent's section unless --section or
+  --clear-section is also supplied. Children released by environment archiving
+  also inherit their former parent's section.
+
   Model and reasoning updates stay within the thread's current provider. BB
   validates them against that provider's current model catalog, applies them on
   the next turn, and keeps using them on later turns until changed.

--- a/plugins/bb-guide/skills/bb-cli/references/thread-operation.md
+++ b/plugins/bb-guide/skills/bb-cli/references/thread-operation.md
@@ -177,3 +177,5 @@ For review or fix pipelines, get the environment ID from
   `bb terminal close <terminal-id>` when the process is no longer needed.
 - `bb terminal restart <terminal-id>` replaces the session with a shell in the
   same scope, size, and title. It does not replay the original launch command.
+
+Clearing a thread's parent with `bb thread update --clear-parent-thread` inherits the former parent's section unless the update explicitly supplies a section. Children released by environment archiving also inherit their former parent's section.

--- a/tests/integration/helpers/api.ts
+++ b/tests/integration/helpers/api.ts
@@ -161,7 +161,7 @@ export async function archiveThread(
   api: PublicApiClient,
   threadId: string,
 ): Promise<void> {
-  const response = await api.threads[":id"].archive.$post({
+  const response = await api.threads[":id"]["archive-all"].$post({
     param: { id: threadId },
   });
   await expectStatus(response, 200, `archive thread ${threadId}`);


### PR DESCRIPTION
## Human comments

## What was wrong

Removing a thread's parent retained the child's old section. After the server inherited the former parent's section, the app's optimistic update still briefly rendered the child in its old section while the request was pending.

## What changed

- Inherit the former parent's section when unparenting unless the request explicitly supplies a section. Apply the same inheritance to children released by environment archiving.
- Update parent and section together in optimistic caches, with rollback on failure. If the parent is not cached, defer the optimistic unparenting until the server responds.
- Remove the unused parent-only `POST /api/v1/threads/:id/archive` endpoint and helper. Migrate its lifecycle tests to `/archive-all`; the app, CLI, and SDK already use that endpoint.
- Update CLI guidance. No server/daemon wire changes.

## Before / after

Both screenshots were captured 250 ms into the same deliberately delayed `PATCH /api/v1/threads/:id` request. The baseline is the rebased PR head's parent (`6aa2208163`); the after image is the final pushed head (`91cb9a6060`).

| Before — child flashes in its old section | After — child immediately appears in its former parent's section |
| --- | --- |
| <img src="https://raw.githubusercontent.com/get-bb/bb/c1e04dba32/docs/pr-evidence/thr_5rf4irm6z4/before.png" width="320" alt="Baseline pending frame with child in old child section"> | <img src="https://raw.githubusercontent.com/get-bb/bb/c1e04dba32/docs/pr-evidence/thr_5rf4irm6z4/after.png" width="320" alt="Fixed pending frame with child in former parent's section"> |

## How you verified

- 156 server tests passed across the nine affected parenting, archive, terminal, plugin-event, and machine/environment lifecycle suites, run through `pnpm exec turbo run test --filter=@bb/server -- <affected files>`.
- 16 app cache and mutation tests passed through `pnpm exec turbo run test --filter=@bb/app -- src/hooks/cache-owners/thread-state-cache-owner.test.ts src/hooks/mutations/thread-state-mutations.test.tsx`.
- 10 integration tests passed across the three archive-dependent suites after migrating the shared helper to `/archive-all`.
- 387 CLI tests passed through `pnpm exec turbo run test --filter=@bb/cli -- src/__tests__/json-flag-enforcement.test.ts src/__tests__/command-output`.
- Typechecks passed through `pnpm exec turbo run typecheck --filter=@bb/server --filter=@bb/sdk --filter=@bb/cli --filter=@bb/app --filter=@bb/server-contract --filter=@bb/integration-tests`.
- Built and served the worktree app, created the fixture through the source CLI, and clicked Clear parent thread in Chromium. Held the request for 1.2 seconds: none of 118 sampled frames placed the child in its old section. Confirmed persisted state through the CLI.
- Repeated the delayed-request capture against the exact baseline and final head; the child resolved to the old section before and the former parent's section after. Both immutable screenshot URLs were downloaded and verified byte-for-byte against the reviewed captures.

> AGENT GENERATED
