### PR TITLE
Route Codex standalone search through the Account Pooler

### DIFF
--- a/plugins/account-pool/src/server.test.ts
+++ b/plugins/account-pool/src/server.test.ts
@@ -420,21 +420,40 @@ describe("Account Pool plugin", () => {
     });
   });
 
-  it.each(["generations", "edits"])(
-    "routes native Codex image %s with pool authentication",
-    async (operation) => {
+  it.each([
+    {
+      path: "images/generations",
+      request: { prompt: "A fox astronaut", images: [] },
+      result: { data: [{ b64_json: "generated-image" }] },
+    },
+    {
+      path: "images/edits",
+      request: { prompt: "A fox astronaut", images: [] },
+      result: { data: [{ b64_json: "generated-image" }] },
+    },
+    {
+      path: "alpha/search",
+      request: {
+        id: "search-1",
+        model: "gpt-5.5",
+        commands: { search_query: [{ q: "bb account pooler" }] },
+      },
+      result: { encrypted_output: "encrypted-search-output" },
+    },
+  ])(
+    "routes native Codex $path with pool authentication",
+    async ({ path, request, result }) => {
       const requests: Request[] = [];
-      const image = { data: [{ b64_json: "generated-image" }] };
       const fixture = await createOAuthRequestFixture(
         "codex",
         async (input, init) => {
           requests.push(new Request(input, init));
-          return Response.json(image);
+          return Response.json(result);
         },
         Date.now,
       );
-      const route = `/v1/images/${operation}`;
-      const body = JSON.stringify({ prompt: "A fox astronaut", images: [] });
+      const route = `/v1/${path}`;
+      const body = JSON.stringify(request);
       const denied = await fixture.host.harness.behavior.fetchHttp(
         "POST",
         route,
@@ -455,11 +474,9 @@ describe("Account Pool plugin", () => {
         },
       );
       expect(response.status).toBe(200);
-      expect(await response.json()).toEqual(image);
+      expect(await response.json()).toEqual(result);
       expect(requests).toHaveLength(1);
-      expect(requests[0]?.url).toBe(
-        `https://upstream.example/images/${operation}`,
-      );
+      expect(requests[0]?.url).toBe(`https://upstream.example/${path}`);
       expect(requests[0]?.headers.get("authorization")).toBe(
         "Bearer oauth-old",
       );

--- a/plugins/account-pool/src/server.ts
+++ b/plugins/account-pool/src/server.ts
@@ -287,6 +287,7 @@ export function createAccountPoolPlugin(
       "/v1/responses",
       "/v1/images/generations",
       "/v1/images/edits",
+      "/v1/alpha/search",
     ]) {
       bb.http.route(
         "POST",


### PR DESCRIPTION
## Human comments

## What was wrong

Codex web search (the `web.run` tool) sends a standalone request to `${CODEX_OPENAI_BASE_URL}/alpha/search`. The Account Pooler contributes `CODEX_OPENAI_BASE_URL` as `/api/v1/plugins/account-pool/http/v1`, so the request reaches the plugin as `POST /v1/alpha/search`. Plugin HTTP routes match exactly, and the pool registered only `/v1/responses`, the two image routes, and `GET /v1/models` for Codex. Every search from a pooled Codex thread stopped at the plugin router with `plugin "account-pool" has no POST route for "/v1/alpha/search"` and never reached the hub. Codex logs on bee show this 404 in production threads on 2026-09-08, 09-09 and 09-10. See #3528 and the [reproduction report](https://get-bb.github.io/reports/issues/3528.html).

## What changed

- `plugins/account-pool/src/server.ts`: registers `POST /v1/alpha/search` next to the other Codex routes and sends it to `hub.handle(..., "codex")`. The hub already forwards by path (`mountedUpstreamUrl(..., "v1/")`), so the request reaches `<codexUpstreamBaseUrl>/alpha/search` with the usual pool token check, account selection, credential replacement, failover and quota accounting. This is the fix proposed in the issue.
- `plugins/account-pool/src/server.test.ts`: the native Codex route test now covers `alpha/search` as well as the image routes. It checks that a request without the pool token gets 401, and that an authenticated request reaches the upstream path with account credentials, no pool token header, an unchanged body, and the upstream response passed through.

No wire, CLI, or configuration changes.

## How you verified

- `pnpm exec turbo run test typecheck --filter=bb-plugin-account-pool`: 281 tests pass and typecheck is clean.
- Fail-before: with the old `server.ts`, the new `alpha/search` case fails with `no http route POST /v1/alpha/search is registered`.
- End to end with real Codex CLI 0.154.0 against a dev bb app from this branch. The Account Pooler routed a real Codex account (production access token with a fake refresh token, removed afterwards), and each thread was asked to find the latest Node.js LTS version with web search. Codex's own request log (`~/.codex/logs_2.sqlite`) recorded:

  | Pool code | `POST …/account-pool/http/v1/alpha/search` | Thread result |
  |---|---|---|
  | this fix | `200 OK` (Cloudflare headers from the ChatGPT upstream) | answered with version and source URL |
  | route removed, plugin reloaded | `404 Not Found`: `plugin "account-pool" has no POST route for "/v1/alpha/search"` | "the web tool returned a 404 error" |
  | fix restored, plugin reloaded | `200 OK` | answered with version and source URL |

Fixes #3528

> AGENT GENERATED

🤖 Generated with [Claude Code](https://claude.com/claude-code)
