### PR TITLE
Fix stalled thread read tracking

### DIFF
--- a/apps/app/src/components/thread/ThreadActionsProvider.tsx
+++ b/apps/app/src/components/thread/ThreadActionsProvider.tsx
@@ -356,7 +356,7 @@ export function ThreadActionsProvider({
   const toggleRead = useCallback(
     (thread: Thread) => {
       if (getThreadReadToggleAction(thread) === "mark_unread") {
-        markUnreadMutate(thread.id, {
+        markUnreadMutate({ threadId: thread.id }, {
           onError: (error) => {
             showMutationErrorToast({
               error,
@@ -366,7 +366,7 @@ export function ThreadActionsProvider({
         });
         return;
       }
-      markReadMutate(thread.id, {
+      markReadMutate({ threadId: thread.id }, {
         onError: (error) => {
           showMutationErrorToast({
             error,

--- a/apps/app/src/hooks/mutations/thread-state-mutations.ts
+++ b/apps/app/src/hooks/mutations/thread-state-mutations.ts
@@ -66,6 +66,11 @@ interface DeleteThreadMutationRequest {
   childThreadsConfirmed: boolean;
 }
 
+interface ThreadReadMutationInput {
+  signal?: AbortSignal;
+  threadId: string;
+}
+
 export function useUpdateThread(options?: UpdateThreadMutationOptions) {
   const queryClient = useQueryClient();
 
@@ -375,17 +380,18 @@ export function useMarkThreadRead() {
       errorMessage: "Failed to mark thread read.",
       showErrorToast: false,
     },
-    mutationFn: (threadId: string) => sdk.threads.markRead({ threadId }),
-    onMutate: (threadId): Promise<ThreadListMutationTransaction> =>
+    mutationFn: (input: ThreadReadMutationInput) =>
+      sdk.threads.markRead(input),
+    onMutate: (input): Promise<ThreadListMutationTransaction> =>
       beginThreadReadStateTransaction({
         lastReadAt: Date.now(),
         queryClient,
-        threadId,
+        threadId: input.threadId,
       }),
-    onError: (_error, threadId, context) => {
+    onError: (_error, input, context) => {
       rollbackThreadListMutationTransaction({
         queryClient,
-        threadId,
+        threadId: input.threadId,
         transaction: context,
       });
     },
@@ -403,17 +409,18 @@ export function useMarkThreadUnread() {
       errorMessage: "Failed to mark thread unread.",
       showErrorToast: false,
     },
-    mutationFn: (threadId: string) => sdk.threads.markUnread({ threadId }),
-    onMutate: (threadId): Promise<ThreadListMutationTransaction> =>
+    mutationFn: (input: ThreadReadMutationInput) =>
+      sdk.threads.markUnread(input),
+    onMutate: (input): Promise<ThreadListMutationTransaction> =>
       beginThreadReadStateTransaction({
         lastReadAt: null,
         queryClient,
-        threadId,
+        threadId: input.threadId,
       }),
-    onError: (_error, threadId, context) => {
+    onError: (_error, input, context) => {
       rollbackThreadListMutationTransaction({
         queryClient,
-        threadId,
+        threadId: input.threadId,
         transaction: context,
       });
     },

--- a/apps/app/src/hooks/useThreadReadTracking.test.tsx
+++ b/apps/app/src/hooks/useThreadReadTracking.test.tsx
@@ -72,7 +72,7 @@ describe("useThreadReadTracking", () => {
 
     expect(markThreadRead.mutate).toHaveBeenCalledTimes(1);
     expect(markThreadRead.mutate).toHaveBeenLastCalledWith(
-      "thr_mobile_restore",
+      expect.objectContaining({ threadId: "thr_mobile_restore" }),
       expect.objectContaining({ onError: expect.any(Function) }),
     );
   });
@@ -94,7 +94,7 @@ describe("useThreadReadTracking", () => {
 
     expect(markThreadRead.mutate).toHaveBeenCalledTimes(1);
     expect(markThreadRead.mutate).toHaveBeenLastCalledWith(
-      "thr_side_chat",
+      expect.objectContaining({ threadId: "thr_side_chat" }),
       expect.objectContaining({ onError: expect.any(Function) }),
     );
 
@@ -206,7 +206,7 @@ describe("useThreadReadTracking", () => {
 
     expect(markThreadRead.mutate).toHaveBeenCalledTimes(1);
     expect(markThreadRead.mutate).toHaveBeenLastCalledWith(
-      "thr_side_chat",
+      expect.objectContaining({ threadId: "thr_side_chat" }),
       expect.objectContaining({ onError: expect.any(Function) }),
     );
   });
@@ -246,5 +246,50 @@ describe("useThreadReadTracking", () => {
     rerender({ lastReadAt: null, visible: true });
 
     expect(markThreadRead.mutate).toHaveBeenCalledTimes(2);
+  });
+
+  it("cancels a pending read when switching threads and retries when reopened", () => {
+    const markThreadRead = makeMarkThreadRead();
+    type ThreadProps = { thread: TestThread };
+    const { rerender } = renderHook(
+      ({ thread }: ThreadProps) =>
+        useThreadReadTracking({ markThreadRead, thread }),
+      {
+        initialProps: {
+          thread: {
+            id: "thr_first",
+            lastReadAt: 10,
+            latestAttentionAt: 20,
+          },
+        },
+      },
+    );
+
+    const firstInput = markThreadRead.mutate.mock.calls[0]?.[0];
+    expect(firstInput?.signal?.aborted).toBe(false);
+
+    rerender({
+      thread: {
+        id: "thr_second",
+        lastReadAt: 20,
+        latestAttentionAt: 20,
+      },
+    });
+
+    expect(firstInput?.signal?.aborted).toBe(true);
+
+    rerender({
+      thread: {
+        id: "thr_first",
+        lastReadAt: 10,
+        latestAttentionAt: 20,
+      },
+    });
+
+    expect(markThreadRead.mutate).toHaveBeenCalledTimes(2);
+    expect(markThreadRead.mutate).toHaveBeenLastCalledWith(
+      expect.objectContaining({ threadId: "thr_first" }),
+      expect.objectContaining({ onError: expect.any(Function) }),
+    );
   });
 });

--- a/apps/app/src/hooks/useThreadReadTracking.ts
+++ b/apps/app/src/hooks/useThreadReadTracking.ts
@@ -10,7 +10,7 @@ type ThreadReadTrackingState = ThreadReadState & Pick<Thread, "id">;
 
 interface MarkThreadReadMutation {
   mutate: (
-    threadId: string,
+    input: { signal?: AbortSignal; threadId: string },
     options?: { onError?: () => void; onSettled?: () => void },
   ) => void;
 }
@@ -32,7 +32,9 @@ export function useThreadReadTracking({
   thread,
 }: UseThreadReadTrackingParams) {
   const failedReadKeysRef = useRef<Set<string>>(new Set());
-  const pendingReadKeysRef = useRef<Set<string>>(new Set());
+  const pendingReadControllersRef = useRef<Map<string, AbortController>>(
+    new Map(),
+  );
   const suppressedManualUnreadKeysRef = useRef<Set<string>>(new Set());
   const previousSnapshotRef = useRef<ReadTrackingSnapshot | null>(null);
   const visibilityRevision = useDocumentVisibilityRevision();
@@ -48,6 +50,16 @@ export function useThreadReadTracking({
       threadId: thread?.id ?? null,
     };
     previousSnapshotRef.current = currentSnapshot;
+
+    if (previousSnapshot?.threadId !== currentSnapshot.threadId) {
+      const previousMarker = previousSnapshot?.threadId
+        ? `${previousSnapshot.threadId}:${previousSnapshot.latestAttentionAt}`
+        : null;
+      if (previousMarker) {
+        pendingReadControllersRef.current.get(previousMarker)?.abort();
+        pendingReadControllersRef.current.delete(previousMarker);
+      }
+    }
 
     if (!isVisible) {
       return;
@@ -68,7 +80,7 @@ export function useThreadReadTracking({
 
     if (threadIsRead) {
       failedReadKeysRef.current.delete(marker);
-      pendingReadKeysRef.current.delete(marker);
+      pendingReadControllersRef.current.delete(marker);
       suppressedManualUnreadKeysRef.current.delete(marker);
       return;
     }
@@ -98,20 +110,24 @@ export function useThreadReadTracking({
     if (!isOpenedThread && !hasNewAttention && !becameVisible && !isRetry) {
       return;
     }
-    if (pendingReadKeysRef.current.has(marker)) {
+    if (pendingReadControllersRef.current.has(marker)) {
       return;
     }
 
     failedReadKeysRef.current.delete(marker);
-    pendingReadKeysRef.current.add(marker);
-    markThreadRead.mutate(thread.id, {
-      onError: () => {
-        pendingReadKeysRef.current.delete(marker);
-        failedReadKeysRef.current.add(marker);
+    const controller = new AbortController();
+    pendingReadControllersRef.current.set(marker, controller);
+    markThreadRead.mutate(
+      { signal: controller.signal, threadId: thread.id },
+      {
+        onError: () => {
+          pendingReadControllersRef.current.delete(marker);
+          failedReadKeysRef.current.add(marker);
+        },
+        onSettled: () => {
+          pendingReadControllersRef.current.delete(marker);
+        },
       },
-      onSettled: () => {
-        pendingReadKeysRef.current.delete(marker);
-      },
-    });
+    );
   }, [isVisible, markThreadRead, thread, visibilityRevision]);
 }

--- a/packages/sdk/src/areas/threads.ts
+++ b/packages/sdk/src/areas/threads.ts
@@ -271,6 +271,7 @@ export interface ThreadRetryArgs {
 }
 
 export interface ThreadActionArgs {
+  signal?: AbortSignal;
   threadId: string;
 }
 
@@ -1132,14 +1133,14 @@ export function createThreadsArea(args: CreateSdkAreaArgs): ThreadsArea {
       return transport.readJson(
         transport.api.v1.threads[":id"].read.$post({
           param: { id: input.threadId },
-        }),
+        }, ...signalRequestArgs(input.signal)),
       );
     },
     async markUnread(input) {
       return transport.readJson(
         transport.api.v1.threads[":id"].unread.$post({
           param: { id: input.threadId },
-        }),
+        }, ...signalRequestArgs(input.signal)),
       );
     },
     async output(input) {

--- a/packages/sdk/test/sdk.test.ts
+++ b/packages/sdk/test/sdk.test.ts
@@ -317,6 +317,29 @@ describe("@bb/sdk", () => {
     expect(receivedSignal).toBe(controller.signal);
   });
 
+  it("forwards thread read action abort signals to fetch", async () => {
+    const controller = new AbortController();
+    let receivedSignal: AbortSignal | null | undefined;
+    const fetch: FetchImplementation = async (_input, init) => {
+      receivedSignal = init?.signal;
+      return jsonResponse({ body: {} });
+    };
+    const sdk = createBbSdk({
+      transport: createHttpTransport({
+        baseUrl: "http://bb.test",
+        fetch,
+        runtime: "node",
+      }),
+    });
+
+    await sdk.threads.markRead({
+      signal: controller.signal,
+      threadId: "thr_test",
+    });
+
+    expect(receivedSignal).toBe(controller.signal);
+  });
+
   it("maps personal-project list options while forwarding the abort signal", async () => {
     const controller = new AbortController();
     let receivedSignal: AbortSignal | null | undefined;


### PR DESCRIPTION
## Human comments

## What was wrong

A pending automatic mark-read request was tracked indefinitely by the desktop app. The view component is reused while switching threads, so returning to the affected thread saw the stale pending marker and skipped every subsequent read request.

## What changed

Auto-read tracking now attaches an AbortController to each read request and aborts the previous thread’s request on a thread transition, allowing a reopened thread to issue a fresh read. Thread read-state SDK actions now accept and forward an optional abort signal. Manual read/unread callers pass the structured action input.

## How you verified

- Added a regression that holds the first read request pending, switches A → B → A, confirms cancellation, and confirms a retry.
- Added SDK coverage that confirms `threads.markRead` forwards its abort signal.
- `pnpm exec turbo run test --filter=@bb/app -- src/hooks/useThreadReadTracking.test.tsx`
- `pnpm exec turbo run test --filter=@bb/app -- src/components/thread/ThreadActionsProvider.test.tsx src/components/thread/ThreadActionsProvider.navigation.test.tsx src/components/thread/embedded-chat/EmbeddedThreadChat.test.tsx`
- `pnpm exec turbo run test --filter=@bb/sdk -- test/sdk.test.ts`
- `pnpm exec turbo run typecheck lint --filter=@bb/app --filter=@bb/sdk`

Fixes #

> AGENT GENERATED