### PR TITLE
Make Connect machine revocation retries idempotent

### DIFF
--- a/apps/web/src/server/api.test.ts
+++ b/apps/web/src/server/api.test.ts
@@ -589,6 +589,49 @@ describe("server-authenticated machine-code round trip", () => {
       db.select().from(machine).where(eq(machine.id, redeemed.machineId)).get()
         ?.revokedAt,
     ).not.toBeNull();
+    const revokedAt = db.select().from(machine).get()?.revokedAt;
+    for (const token of [serverCredential, "bbcred_other"]) {
+      await expect(
+        revokeMachineForServerCredential(deps, token, redeemed.machineId),
+      ).resolves.toEqual({ ok: true });
+    }
+    expect(db.select().from(machine).get()?.revokedAt).toEqual(revokedAt);
+    await expect(
+      revokeMachineForServerCredential(deps, serverCredential, "missing"),
+    ).resolves.toEqual({ error: "not-found", status: 404 });
+    seedUser("foreign");
+    db.insert(machine)
+      .values({
+        id: "foreign-device",
+        userId: "foreign",
+        credentialHash: "foreign-hash",
+        createdAt: new Date(),
+        revokedAt: new Date(),
+      })
+      .run();
+    await expect(
+      revokeMachineForServerCredential(
+        deps,
+        serverCredential,
+        "foreign-device",
+      ),
+    ).resolves.toEqual({ error: "not-found", status: 404 });
+    for (const token of ["", "bogus"]) {
+      await expect(
+        revokeMachineForServerCredential(deps, token, redeemed.machineId),
+      ).resolves.toEqual({ error: "unauthorized", status: 401 });
+    }
+    db.update(server)
+      .set({ revokedAt: new Date() })
+      .where(eq(server.id, target.server.id))
+      .run();
+    await expect(
+      revokeMachineForServerCredential(
+        deps,
+        serverCredential,
+        redeemed.machineId,
+      ),
+    ).resolves.toEqual({ error: "unauthorized", status: 401 });
     await expect(redeemMachineCode(deps, minted.code)).resolves.toMatchObject({
       error: "already-used",
       status: 409,
@@ -652,6 +695,10 @@ describe("dashboard machine recovery", () => {
     expect(closeTunnel).toHaveBeenCalledWith("lost-laptop:lost-generation");
     expect(closeTunnel).toHaveBeenCalledTimes(1);
     expect((await getAccountState(deps, "u1")).machines).toEqual([]);
+    await expect(revokeMachine(deps, "u1", "machine-owner")).resolves.toEqual({
+      ok: true,
+    });
+    expect(closeTunnel).toHaveBeenCalledTimes(1);
     expect(
       db.select().from(machine).where(eq(machine.id, "machine-owner")).get()
         ?.subdomain,

--- a/apps/web/src/server/api.ts
+++ b/apps/web/src/server/api.ts
@@ -279,7 +279,6 @@ export async function revokeMachine(
       and(eq(labelClaim.kind, "machine"), eq(labelClaim.ownerId, machineId)),
     )
     .get();
-  if (!claim && existing.revokedAt !== null) return { error: "not-found" };
 
   if (claim) {
     try {


### PR DESCRIPTION
## Human comments

## What was wrong

Connect machine cleanup could become permanently stuck after the remote revocation had already succeeded but its response was lost, or after local grant cleanup failed. On retry, the owned machine row was already revoked and no longer held a label claim, so `revokeMachine` returned `not-found` instead of acknowledging the completed revocation. The provider retained its local grant and every later retry failed the same way.

## What changed

- Make revocation idempotent for an already-revoked machine owned by the authenticated account.
- Preserve existing authentication and account-ownership checks: missing devices, foreign devices, bogus credentials, and revoked server credentials still fail.
- Preserve label-claim tunnel closure and its retry behavior; a completed retry does not close the tunnel twice.
- No UI, public API shape, CLI, configuration, or server/daemon wire contract changed. No protocol-version bump is needed.

## How you verified

- Added a regression that fails with the previous 404 behavior and passes when a completed owned revocation is retried through both dashboard and server-credential paths.
- `pnpm exec turbo run test --filter=@bb/web --force -- src/server/api.test.ts`: 31/31 passed.
- `pnpm exec turbo run test --filter=bb-plugin-connect --force -- src/server-access.test.ts src/tunnel-lifecycle.test.ts`: 20/20 passed.
- `pnpm exec turbo run typecheck build --filter=@bb/web --force`: passed.
- `bb plugin build plugins/connect`: passed.
- Targeted formatting and `git diff --check` passed.
- Independently exercised response-loss, real SQLite deletion-failure, pending reconciliation, authorization, and socket-cleanup recovery cases with owned local fixtures; no cloud credentials or vendor resources were used.

Follow-up to #3274.

> AGENT GENERATED
