### PR TITLE
Recover iOS sidebar swipes after interrupted touch sessions

### DIFF
--- a/apps/app/src/components/ui/sidebar.test.tsx
+++ b/apps/app/src/components/ui/sidebar.test.tsx
@@ -37,8 +37,8 @@ function settleMobileToggle() {
   });
 }
 
-function createTouch(clientX: number, clientY: number): Touch {
-  return { identifier: 1, clientX, clientY } as Touch;
+function createTouch(clientX: number, clientY: number, identifier = 1): Touch {
+  return { identifier, clientX, clientY } as Touch;
 }
 
 function createTouchList(...touches: Touch[]): TouchList {
@@ -76,15 +76,17 @@ function fireTouchEnd(target: Element | Document | Window, touch: Touch) {
 
 function firePointer(
   target: Element | Document | Window,
-  type: "pointerdown" | "pointermove",
+  type: "pointerdown" | "pointermove" | "pointerup",
   clientX: number,
   clientY: number,
+  pointerId = 1,
+  isPrimary = true,
 ) {
   const event = new Event(type, { bubbles: true, cancelable: true });
   Object.defineProperties(event, {
-    pointerId: { value: 1 },
+    pointerId: { value: pointerId },
     pointerType: { value: "touch" },
-    isPrimary: { value: true },
+    isPrimary: { value: isPrimary },
     button: { value: 0 },
     buttons: { value: 1 },
     clientX: { value: clientX },
@@ -774,6 +776,79 @@ describe("mobile sidebar swipe-open touch listener scoping", () => {
     fireEvent(window, move);
     expect(getMobilePanel()?.dataset.state).toBe("open");
     expect(move.defaultPrevented).toBe(true);
+  });
+});
+
+describe("mobile sidebar interrupted swipe sessions", () => {
+  it.each([1, 2])(
+    "opens after Send detaches the touch target with next identifier %s",
+    (identifier) => {
+      renderSelectableSwipeHarness();
+      const prose = screen.getByText("Selectable message prose");
+      const send = document.createElement("button");
+      prose.parentElement?.append(send);
+      send.addEventListener("pointerdown", (event) => event.preventDefault());
+      send.addEventListener("pointerup", () => send.remove());
+
+      firePointer(send, "pointerdown", 320, 600);
+      fireTouch(send, "touchstart", createTouch(320, 600));
+      firePointer(send, "pointerup", 320, 600);
+      fireTouchEnd(send, createTouch(320, 600));
+      expect(send.isConnected).toBe(false);
+
+      firePointer(prose, "pointerdown", 120, 160, identifier);
+      fireTouch(prose, "touchstart", createTouch(120, 160, identifier));
+      fireTouch(window, "touchmove", createTouch(260, 164, identifier));
+      expect(getMobilePanel()?.dataset.state).toBe("open");
+      fireTouchEnd(window, createTouch(260, 164, identifier));
+    },
+  );
+
+  it.each(["pointer", "touch"] as const)(
+    "replaces a %s session when its terminal event never arrives",
+    (kind) => {
+      renderSelectableSwipeHarness();
+      const prose = screen.getByText("Selectable message prose");
+      if (kind === "pointer") {
+        firePointer(prose, "pointerdown", 320, 600);
+        firePointer(prose, "pointerdown", 120, 160, 2);
+        firePointer(window, "pointermove", 260, 164, 2);
+        firePointer(window, "pointerup", 260, 164, 2);
+      } else {
+        fireTouch(prose, "touchstart", createTouch(320, 600));
+        fireTouch(prose, "touchstart", createTouch(120, 160, 2));
+        fireTouch(window, "touchmove", createTouch(260, 164, 2));
+        fireTouchEnd(window, createTouch(260, 164, 2));
+      }
+      expect(getMobilePanel()?.dataset.state).toBe("open");
+    },
+  );
+
+  it("allows vertical scrolling after replacing an interrupted touch", () => {
+    renderSelectableSwipeHarness();
+    const prose = screen.getByText("Selectable message prose");
+    fireTouch(prose, "touchstart", createTouch(320, 600));
+    fireTouch(prose, "touchstart", createTouch(120, 160, 2));
+    const move = new Event("touchmove", { bubbles: true, cancelable: true });
+    Object.defineProperties(move, {
+      touches: { value: createTouchList(createTouch(124, 240, 2)) },
+      changedTouches: { value: createTouchList(createTouch(124, 240, 2)) },
+    });
+    fireEvent(window, move);
+    expect(move.defaultPrevented).toBe(false);
+    expect(getMobilePanel()?.dataset.state).toBe("closed");
+    fireTouch(prose, "touchstart", createTouch(120, 160, 3));
+    fireTouch(window, "touchmove", createTouch(260, 164, 3));
+    expect(getMobilePanel()?.dataset.state).toBe("open");
+  });
+
+  it("keeps the primary pointer session when a second finger lands", () => {
+    renderSelectableSwipeHarness();
+    const prose = screen.getByText("Selectable message prose");
+    firePointer(prose, "pointerdown", 120, 160);
+    firePointer(prose, "pointerdown", 320, 600, 2, false);
+    firePointer(window, "pointermove", 260, 164);
+    expect(getMobilePanel()?.dataset.state).toBe("open");
   });
 });
 

--- a/apps/app/src/components/ui/sidebar.tsx
+++ b/apps/app/src/components/ui/sidebar.tsx
@@ -1356,13 +1356,7 @@ const SidebarInset = React.forwardRef<
         return;
       }
 
-      const currentSession = swipeSessionRef.current;
-      if (currentSession !== null) {
-        if (currentSession.kind !== "pointer") {
-          return;
-        }
-        clearSwipeSession();
-      }
+      clearSwipeSession();
 
       const canPreventDefault = isSidebarSwipeEdgeZoneTouch(touch.clientX);
       swipeSessionRef.current = createSidebarInsetSwipeSession({
@@ -1403,15 +1397,16 @@ const SidebarInset = React.forwardRef<
         !isCompactViewport ||
         openMobile ||
         event.pointerType !== "touch" ||
+        !event.isPrimary ||
         event.button !== 0 ||
         event.clientX < SIDEBAR_MOBILE_SWIPE_BROWSER_EDGE_GUARD_PX ||
-        swipeSessionRef.current !== null ||
         !isSidebarInsetSwipeTarget(event.target) ||
         shouldIgnoreSidebarSwipeTarget(event.target)
       ) {
         return;
       }
 
+      clearSwipeSession();
       swipeSessionRef.current = createSidebarInsetSwipeSession({
         kind: "pointer",
         id: event.pointerId,
@@ -1434,7 +1429,13 @@ const SidebarInset = React.forwardRef<
       window.addEventListener("pointercancel", handleSwipeEnd);
       removeSwipeListenersRef.current = removeListeners;
     },
-    [handleSwipeEnd, handleSwipeMove, isCompactViewport, openMobile],
+    [
+      clearSwipeSession,
+      handleSwipeEnd,
+      handleSwipeMove,
+      isCompactViewport,
+      openMobile,
+    ],
   );
 
   React.useEffect(() => {

--- a/apps/mobile/e2e/flows/shell-send-sidebar-swipe.yaml
+++ b/apps/mobile/e2e/flows/shell-send-sidebar-swipe.yaml
@@ -1,0 +1,49 @@
+appId: app.getbb.mobile
+env:
+  METRO_URL: "http://127.0.0.1:8082"
+  SERVER_URL: "http://127.0.0.1:41999"
+---
+- runFlow: ../subflows/launch-app.yaml
+- runFlow: ../subflows/pair-direct-server.yaml
+- runFlow:
+    file: ../subflows/open-bb-link.yaml
+    env:
+      LINK: "bb://"
+- extendedWaitUntil:
+    visible: ".*Idle thread.*"
+    timeout: 60000
+- tapOn: ".*Idle thread.*"
+- extendedWaitUntil:
+    visible: ".*follow-up.*"
+    timeout: 60000
+- startRecording:
+    path: "../../../../e2e-artifacts/maestro/shell-send-sidebar-swipe/sidebar-send-repro"
+    label: "Sidebar swipe before and after Send"
+- takeScreenshot: sidebar-before-baseline-swipe
+- swipe:
+    start: 10%, 45%
+    end: 85%, 45%
+    duration: 500
+- extendedWaitUntil:
+    visible: ".*Settings.*"
+    timeout: 10000
+- takeScreenshot: sidebar-baseline-open
+- tapOn: ".*Toggle sidebar.*"
+- waitForAnimationToEnd:
+    timeout: 5000
+- tapOn: ".*follow-up.*"
+- waitForAnimationToEnd:
+    timeout: 5000
+- inputText: "reproduce sidebar swipe after send"
+- tapOn: ".*Submit.*"
+- extendedWaitUntil:
+    visible: ".*Response to: reproduce sidebar swipe after send.*"
+    timeout: 90000
+- takeScreenshot: sidebar-after-send-before-swipe
+- swipe:
+    start: 10%, 45%
+    end: 85%, 45%
+    duration: 500
+- takeScreenshot: sidebar-after-send-swipe
+- stopRecording
+- assertVisible: ".*Settings.*"

--- a/apps/mobile/e2e/scripts/ci-run-flows.sh
+++ b/apps/mobile/e2e/scripts/ci-run-flows.sh
@@ -9,10 +9,11 @@
 #   e2e/scripts/ci-run-flows.sh <simulator udid> <artifacts dir> [flow...]
 #
 # Default flows (in this order): shell-launch, shell-deep-link, shell-send,
-# shell-unreachable-server. Every one drives the WebView shell, so the backend
-# must be started with BB_MOBILE_E2E_SERVE_APP=1 and apps/app must be built
-# (`pnpm exec turbo run build --filter=@bb/app`); without them the server
-# answers API routes only and the shell shows its native error state.
+# shell-send-sidebar-swipe, shell-unreachable-server. Every one drives the
+# WebView shell, so the backend must be started with
+# BB_MOBILE_E2E_SERVE_APP=1 and apps/app must be built (`pnpm exec turbo run
+# build --filter=@bb/app`); without them the server answers API routes only and
+# the shell shows its native error state.
 #
 # shell-connect is not in the default set: it needs the connect stub backend
 # (`pnpm --filter @bb/integration-tests e2e:mobile-connect-stub`), so it runs
@@ -41,7 +42,7 @@ ARTIFACTS="${2:?artifacts dir}"
 shift 2
 FLOWS=("$@")
 if [ ${#FLOWS[@]} -eq 0 ]; then
-  FLOWS=(shell-launch shell-deep-link shell-send shell-unreachable-server)
+  FLOWS=(shell-launch shell-deep-link shell-send shell-send-sidebar-swipe shell-unreachable-server)
 fi
 
 export SERVER_URL="${SERVER_URL:-http://127.0.0.1:41999}"

--- a/apps/mobile/src/lib/e2e/mobile-e2e-flows.test.ts
+++ b/apps/mobile/src/lib/e2e/mobile-e2e-flows.test.ts
@@ -31,6 +31,7 @@ describe("Mobile E2E flow boundaries", () => {
       "flows/shell-launch.yaml",
       "flows/shell-deep-link.yaml",
       "flows/shell-send.yaml",
+      "flows/shell-send-sidebar-swipe.yaml",
     ]) {
       expect(flowSource(flow), flow).toContain(
         "- runFlow: ../subflows/pair-direct-server.yaml",


### PR DESCRIPTION
## Human comments

## What was wrong

The compact sidebar installs capture listeners before the Send control handles its pointer event. In iOS WKWebView, submitting a follow-up can blur the composer and detach the Send target before the matching terminal touch event reaches the window listener. That leaves `swipeSessionRef` occupied, so every later sidebar gesture is rejected until the page reloads.

## What changed

- Replace unfinished sidebar tracking when a fresh primary pointer or single-touch gesture begins.
- Ignore non-primary pointer starts so a second finger cannot replace a valid gesture.
- Keep the existing edge guard, swipe thresholds, passive vertical-scroll behavior, and target exclusions unchanged.
- Add focused interrupted-session regression coverage, including the detached Send target sequence, missing pointer/touch terminal events, touch identifier reuse, vertical scrolling, and secondary fingers.
- Add a Maestro iOS flow that records video and screenshots before Send and after Send, then asserts that the sidebar still opens.
- Include that flow in the label-gated Mobile E2E default set so its media is uploaded with the workflow artifacts.

There are no server/daemon wire, CLI, SDK, configuration, or protocol changes.

## How you verified

- `pnpm exec turbo run test --filter=@bb/app -- src/components/ui/sidebar.test.tsx src/components/promptbox/PromptBoxInternal.test.tsx`: 166 tests passed. Five new regression cases fail without the implementation change.
- `pnpm exec turbo run typecheck --filter=@bb/app`: passed.
- `pnpm exec turbo run test --filter=@bb/mobile -- src/lib/e2e/mobile-e2e-flows.test.ts src/lib/e2e/ci-run-flows.test.ts`: 4 tests passed.
- `bash -n apps/mobile/e2e/scripts/ci-run-flows.sh`: passed.
- Physical iPhone, TestFlight shell, current source bundle served from an isolated direct server: before the patch, swipe-open worked after reload and stopped immediately after Send; with the patched bundle, swipe-open continued working after multiple sends.
- Upstream CI passed before the Mobile E2E wiring follow-up; the updated CI run is linked on this PR.

Maintainer action for simulator media: add the `mobile-e2e` label. Contributor permissions cannot apply repository labels.

> AGENT GENERATED