### PR TITLE
Fix tooltip context for plugin app overlays

### DIFF
--- a/apps/app/src/components/layout/AppLayout.test.tsx
+++ b/apps/app/src/components/layout/AppLayout.test.tsx
@@ -491,8 +491,19 @@ describe("AppLayout plugin overlay contexts", () => {
         }),
       );
 
-      renderLayout();
+      renderLayout(
+        "/",
+        <Tooltip>
+          <TooltipTrigger>Page action</TooltipTrigger>
+          <TooltipContent>Page tooltip</TooltipContent>
+        </Tooltip>,
+      );
 
+      expect(screen.getByRole("button", { name: "Page action" })).toBeDefined();
+      const overlayHost = document.querySelector("[data-bb-plugin-app-overlays]");
+      expect(overlayHost).not.toBeNull();
+      expect(overlayHost?.parentElement).toBe(getRoot().parentElement);
+      expect(getRoot().contains(overlayHost)).toBe(false);
       expect(errors).not.toHaveBeenCalled();
       expect(screen.getByRole("button", { name: "Overlay action" })).toBeDefined();
       expect((await screen.findByRole("tooltip")).textContent).toBe(

--- a/apps/app/src/components/layout/AppLayout.test.tsx
+++ b/apps/app/src/components/layout/AppLayout.test.tsx
@@ -10,6 +10,18 @@ import {
 } from "@testing-library/react";
 import { defaultAppSettings } from "@bb/domain";
 import { Popover, PopoverContent, PopoverTrigger } from "@bb/shared-ui/popover";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@bb/shared-ui/tooltip";
+import { createPortal } from "react-dom";
+import {
+  resetPluginSlotStoreForTest,
+  setPluginSlotRegistrations,
+} from "@/lib/plugin-slots";
+import { resetAllCrashedPluginSlotsForTest } from "@/components/plugin/PluginSlotMount";
+import { makePluginRegistrationSet } from "@/test/fixtures/plugins";
 import type { MouseEvent as ReactMouseEvent, ReactNode } from "react";
 import { Link, MemoryRouter, useLocation } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -200,6 +212,8 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  resetPluginSlotStoreForTest();
+  resetAllCrashedPluginSlotsForTest();
   setCompactSecondaryPanelPresentation("closed");
   vi.restoreAllMocks();
   window.localStorage.clear();
@@ -453,4 +467,42 @@ describe("AppLayout sidebar resize drag", () => {
       document.querySelector('[data-testid="iframe-drag-guard-overlay"]'),
     ).toBeNull();
   });
+});
+
+describe("AppLayout plugin overlay contexts", () => {
+  it.each([false, true])(
+    "provides host tooltips to an overlay (portal: %s)",
+    async (portaled) => {
+      const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+      const warnings = vi.spyOn(console, "warn").mockImplementation(() => {});
+      function Overlay() {
+        const content = (
+          <Tooltip open>
+            <TooltipTrigger>Overlay action</TooltipTrigger>
+            <TooltipContent>Overlay tooltip</TooltipContent>
+          </Tooltip>
+        );
+        return portaled ? createPortal(content, document.body) : content;
+      }
+      setPluginSlotRegistrations(
+        "tooltip-overlay",
+        makePluginRegistrationSet({
+          appOverlays: [{ id: "tooltip", component: Overlay }],
+        }),
+      );
+
+      renderLayout();
+
+      expect(errors).not.toHaveBeenCalled();
+      expect(screen.getByRole("button", { name: "Overlay action" })).toBeDefined();
+      expect((await screen.findByRole("tooltip")).textContent).toBe(
+        "Overlay tooltip",
+      );
+      fireEvent.click(screen.getByRole("link", { name: SETTINGS_ROUTE }));
+      expect(screen.getByRole("button", { name: "Overlay action" })).toBeDefined();
+      expect(screen.getByRole("tooltip").textContent).toBe("Overlay tooltip");
+      expect(errors).not.toHaveBeenCalled();
+      expect(warnings).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/apps/app/src/components/layout/AppLayout.tsx
+++ b/apps/app/src/components/layout/AppLayout.tsx
@@ -762,8 +762,8 @@ export function AppLayout({ children }: AppLayoutProps) {
               reserveMacosTrafficLights={reserveMacosTrafficLights}
               usesDesktopChrome={usesDesktopChrome}
             />
+            <PluginAppOverlays />
           </SidebarStateBridge>
-          <PluginAppOverlays />
           <IframeDragGuardOverlay
             active={isSidebarResizing}
             cursor="col-resize"

--- a/apps/app/src/components/layout/AppLayout.tsx
+++ b/apps/app/src/components/layout/AppLayout.tsx
@@ -6,6 +6,7 @@ import { atomWithStorage } from "jotai/utils";
 import { Link, matchPath, useLocation, useNavigate } from "react-router-dom";
 import type { ProjectResponse } from "@bb/server-contract";
 import { Icon } from "@bb/shared-ui/icon";
+import { TooltipProvider } from "@bb/shared-ui/tooltip";
 import { RESOURCE_ROUTE_LABEL_EVENT } from "@bb/shared-ui/resource-route-label";
 import {
   SidebarInset,
@@ -711,80 +712,82 @@ export function AppLayout({ children }: AppLayoutProps) {
   }, [documentTitle]);
 
   return (
-    <ProjectActionsProvider>
-      <ThreadTitleMentionResourcesProvider {...titleMentionResources}>
-        <ThreadActionsProvider>
-          <SidebarStateBridge>
-            {backToAppRoutePath !== null && !isSidebarResizing ? (
-              <BackToAppCommandHandler routePath={backToAppRoutePath} />
-            ) : null}
-            <AppLayoutSidebar
-              mode={
-                isGlobalSettingsView
-                  ? "settings"
-                  : isPluginsWorkspace
-                    ? "plugins"
-                    : isSkillsWorkspace
-                      ? "skills"
-                      : "app"
-              }
-              onResizeMouseDown={handleResizeMouseDown}
-              isResizing={isSidebarResizing}
-              appRoutePath={appRoutePath}
-              settingsRoutePath={settingsRoutePath}
-              toolsBackRoutePath={toolsBackRoutePath}
-              toolsRoutePath={toolsRoutePath}
-            />
-            <SidebarInset>
-              <div
-                ref={contentShellRef}
-                data-testid="app-layout-content-shell"
-                className="relative flex h-full min-h-0 min-w-0 w-full flex-col pt-[env(safe-area-inset-top)] pr-[env(safe-area-inset-right)] pb-[var(--bb-safe-area-bottom,env(safe-area-inset-bottom))] pl-[env(safe-area-inset-left)]"
-              >
-                {showHeader ? (
-                  <AppHeader
-                    usesDesktopChrome={usesDesktopChrome}
-                    usesProjectChromeStyle={isRootView || isArchivedView}
-                    projectId={projectId}
-                    project={project}
-                    pluginPanel={pluginPanel}
-                    pluginPanelChrome={pluginPanelChrome}
-                    pluginPanelSubPath={pluginPanelSubPath}
-                    meta={meta}
-                  />
-                ) : null}
-                <main className="flex min-h-0 flex-1 flex-col p-4 md:p-5">
-                  {children}
-                </main>
-              </div>
-            </SidebarInset>
-            <SidebarTriggerOverlay
-              reserveMacosTrafficLights={reserveMacosTrafficLights}
-              usesDesktopChrome={usesDesktopChrome}
-            />
+    <TooltipProvider delayDuration={300} disableHoverableContent>
+      <ProjectActionsProvider>
+        <ThreadTitleMentionResourcesProvider {...titleMentionResources}>
+          <ThreadActionsProvider>
+            <SidebarStateBridge>
+              {backToAppRoutePath !== null && !isSidebarResizing ? (
+                <BackToAppCommandHandler routePath={backToAppRoutePath} />
+              ) : null}
+              <AppLayoutSidebar
+                mode={
+                  isGlobalSettingsView
+                    ? "settings"
+                    : isPluginsWorkspace
+                      ? "plugins"
+                      : isSkillsWorkspace
+                        ? "skills"
+                        : "app"
+                }
+                onResizeMouseDown={handleResizeMouseDown}
+                isResizing={isSidebarResizing}
+                appRoutePath={appRoutePath}
+                settingsRoutePath={settingsRoutePath}
+                toolsBackRoutePath={toolsBackRoutePath}
+                toolsRoutePath={toolsRoutePath}
+              />
+              <SidebarInset>
+                <div
+                  ref={contentShellRef}
+                  data-testid="app-layout-content-shell"
+                  className="relative flex h-full min-h-0 min-w-0 w-full flex-col pt-[env(safe-area-inset-top)] pr-[env(safe-area-inset-right)] pb-[var(--bb-safe-area-bottom,env(safe-area-inset-bottom))] pl-[env(safe-area-inset-left)]"
+                >
+                  {showHeader ? (
+                    <AppHeader
+                      usesDesktopChrome={usesDesktopChrome}
+                      usesProjectChromeStyle={isRootView || isArchivedView}
+                      projectId={projectId}
+                      project={project}
+                      pluginPanel={pluginPanel}
+                      pluginPanelChrome={pluginPanelChrome}
+                      pluginPanelSubPath={pluginPanelSubPath}
+                      meta={meta}
+                    />
+                  ) : null}
+                  <main className="flex min-h-0 flex-1 flex-col p-4 md:p-5">
+                    {children}
+                  </main>
+                </div>
+              </SidebarInset>
+              <SidebarTriggerOverlay
+                reserveMacosTrafficLights={reserveMacosTrafficLights}
+                usesDesktopChrome={usesDesktopChrome}
+              />
+            </SidebarStateBridge>
             <PluginAppOverlays />
-          </SidebarStateBridge>
-          <IframeDragGuardOverlay
-            active={isSidebarResizing}
-            cursor="col-resize"
-          />
-          <CommandPalette
-            threadId={threadId ?? null}
-            projectId={projectId ?? null}
-          />
-          <NotificationCenter />
-          <ProjectPathDialog
-            target={quickCreateProject.projectPathDialog.target}
-            pending={quickCreateProject.isCreating}
-            platform={quickCreateProject.platform}
-            hostId={quickCreateProject.hostId}
-            hostName={quickCreateProject.hostName}
-            hosts={quickCreateProject.hosts}
-            onOpenChange={quickCreateProject.projectPathDialog.onOpenChange}
-            onSubmit={quickCreateProject.submitProjectPath}
-          />
-        </ThreadActionsProvider>
-      </ThreadTitleMentionResourcesProvider>
-    </ProjectActionsProvider>
+            <IframeDragGuardOverlay
+              active={isSidebarResizing}
+              cursor="col-resize"
+            />
+            <CommandPalette
+              threadId={threadId ?? null}
+              projectId={projectId ?? null}
+            />
+            <NotificationCenter />
+            <ProjectPathDialog
+              target={quickCreateProject.projectPathDialog.target}
+              pending={quickCreateProject.isCreating}
+              platform={quickCreateProject.platform}
+              hostId={quickCreateProject.hostId}
+              hostName={quickCreateProject.hostName}
+              hosts={quickCreateProject.hosts}
+              onOpenChange={quickCreateProject.projectPathDialog.onOpenChange}
+              onSubmit={quickCreateProject.submitProjectPath}
+            />
+          </ThreadActionsProvider>
+        </ThreadTitleMentionResourcesProvider>
+      </ProjectActionsProvider>
+    </TooltipProvider>
   );
 }

--- a/apps/app/src/components/sidebar/SidebarPluginAttentionGlyph.test.tsx
+++ b/apps/app/src/components/sidebar/SidebarPluginAttentionGlyph.test.tsx
@@ -2,6 +2,7 @@
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { Provider } from "jotai";
+import { TooltipProvider } from "@bb/shared-ui/tooltip";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { SidebarProvider } from "@/components/ui/sidebar.js";
@@ -35,9 +36,11 @@ function renderGlyph(plugins: PluginListItem[]) {
   return render(
     <Provider>
       <MemoryRouter>
-        <SidebarProvider>
-          <SidebarPluginAttentionGlyph className="footer-action" />
-        </SidebarProvider>
+        <TooltipProvider delayDuration={300} disableHoverableContent>
+          <SidebarProvider>
+            <SidebarPluginAttentionGlyph className="footer-action" />
+          </SidebarProvider>
+        </TooltipProvider>
       </MemoryRouter>
     </Provider>,
   );

--- a/apps/app/src/components/ui/sidebar.tsx
+++ b/apps/app/src/components/ui/sidebar.tsx
@@ -11,7 +11,6 @@ import { Icon } from "@bb/shared-ui/icon";
 import {
   Tooltip,
   TooltipContent,
-  TooltipProvider,
   TooltipTrigger,
 } from "@bb/shared-ui/tooltip";
 import { setCompactSidebarDrawerShowing } from "./sidebar-mobile-drawer-visibility.js";
@@ -658,25 +657,23 @@ const SidebarProvider = React.forwardRef<
         <SidebarShowingContext.Provider value={isSidebarShowing}>
           <SidebarWidthContext.Provider value={width}>
             {}
-            <TooltipProvider delayDuration={300} disableHoverableContent>
-              <div
-                style={
-                  {
-                    "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
-                    ...sidebarMobileWidthStyle,
-                    ...style,
-                  } as React.CSSProperties
-                }
-                className={cn(
-                  "group/sidebar-wrapper flex h-full min-h-0 w-full has-[[data-variant=inset]]:bg-sidebar max-md:overflow-clip",
-                  className,
-                )}
-                ref={ref}
-                {...props}
-              >
-                {children}
-              </div>
-            </TooltipProvider>
+            <div
+              style={
+                {
+                  "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
+                  ...sidebarMobileWidthStyle,
+                  ...style,
+                } as React.CSSProperties
+              }
+              className={cn(
+                "group/sidebar-wrapper flex h-full min-h-0 w-full has-[[data-variant=inset]]:bg-sidebar max-md:overflow-clip",
+                className,
+              )}
+              ref={ref}
+              {...props}
+            >
+              {children}
+            </div>
           </SidebarWidthContext.Provider>
         </SidebarShowingContext.Provider>
       </SidebarContext.Provider>

--- a/docs/api_to_audit.md
+++ b/docs/api_to_audit.md
@@ -2050,7 +2050,11 @@ window, outside route-owned layout regions and inside `PluginSlotMount`. The
 component receives no props and owns its chrome, positioning, visibility,
 focus, and responsive behavior. It can call app-level SDK hooks and either
 render fixed UI directly or create a React portal without losing plugin,
-router, query, realtime, or sidebar thread/action context. Hooks whose contract
+router, query, realtime, or sidebar thread/action context. Overlays share the
+app's tooltip provider (300 ms delay, hoverable content disabled), including
+through portals; host SDK components need no plugin-owned tooltip provider.
+The pane-local code-highlighting worker pool is not inherited here; its hooks
+support rendering without a pool. Hooks whose contract
 requires a particular surface, including `useComposer` and `useComposerView`,
 remain limited to that surface. One overlay crash hides only that registration;
 sibling overlays remain mounted.


### PR DESCRIPTION
## Human comments

## What was wrong

Plugin app overlays mounted outside `SidebarProvider`, which owned the app's tooltip context. Rendering host components such as `ThreadChat` in an overlay could throw “`Tooltip` must be used within `TooltipProvider`” and disable that slot for the session.

## What changed

Move the existing tooltip provider to `AppLayout`, above both the sidebar and plugin overlays, retaining the 300 ms delay and disabled hoverable content. Overlays keep their original DOM placement outside the sidebar container, avoiding changes to flex layout or mobile clipping. Update the standalone sidebar test fixture and document the overlay context contract. The pane-local highlighting worker pool remains absent; its hooks support that fallback.

## How you verified

- Added real-layout regression cases with registered overlays rendering host tooltips inline and through a portal. Both reproduced the exact missing-provider error before the fix. They now verify rendering across navigation to Settings, tooltip availability in page content, and overlay placement outside the sidebar DOM container.
- Focused `pnpm exec turbo run test --filter=@bb/app -- …` run: all 247 tests across 20 selected files passed, covering layout, sidebar consumers, plugin overlays and crash boundaries, host chat/composer adapters, and worker-pool behavior.
- `pnpm exec turbo run typecheck --filter=@bb/app`: passed.
- `git diff --check`: passed.
- Pre-push secret-model scan: clean for the working tree, tracked HEAD, and `origin/main..HEAD`.
- Checks ran on Node 22.23.2. No live-browser verification was performed.

> AGENT GENERATED
