### PR TITLE
Fix stale built-in plugins overriding prepared bundles

### DIFF
--- a/apps/server/src/services/plugin-catalog/bundled-marketplace.ts
+++ b/apps/server/src/services/plugin-catalog/bundled-marketplace.ts
@@ -19,8 +19,8 @@ export function resolveBundledMarketplaceDirectory(
   baseDirectory = moduleDirectory,
 ): string {
   const candidates = [
-    path.resolve(baseDirectory, "builtin-plugins"),
     path.resolve(baseDirectory, "../../../packages/bundled-plugins/dist"),
+    path.resolve(baseDirectory, "builtin-plugins"),
     path.resolve(
       baseDirectory,
       "../../generated",

--- a/apps/server/src/services/plugins/builtin-registry.ts
+++ b/apps/server/src/services/plugins/builtin-registry.ts
@@ -222,19 +222,19 @@ export function builtinPluginSource(name: string): string {
 export function resolveBuiltinPluginRootPathForModuleDir(
   args: ResolveBuiltinPluginRootPathArgs,
 ): string {
-  const packagedCandidate = path.resolve(
-    args.moduleDir,
-    BUILTIN_PLUGINS_DIRECTORY_NAME,
-    args.name,
-  );
-  if (existsSync(packagedCandidate)) return packagedCandidate;
-
   const preparedCandidate = path.resolve(
     args.moduleDir,
     "../../../packages/bundled-plugins/dist",
     args.name,
   );
   if (existsSync(preparedCandidate)) return preparedCandidate;
+
+  const packagedCandidate = path.resolve(
+    args.moduleDir,
+    BUILTIN_PLUGINS_DIRECTORY_NAME,
+    args.name,
+  );
+  if (existsSync(packagedCandidate)) return packagedCandidate;
 
   const builtCheckoutCandidate = path.resolve(
     args.moduleDir,

--- a/apps/server/test/services/plugins/builtin-registry.test.ts
+++ b/apps/server/test/services/plugins/builtin-registry.test.ts
@@ -1,0 +1,61 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resolveBuiltinPluginRootPathForModuleDir } from "../../../src/services/plugins/builtin-registry.js";
+import { resolveBundledMarketplaceDirectory } from "../../../src/services/plugin-catalog/bundled-marketplace.js";
+
+describe("bundled plugin artifact resolution", () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "bb-builtin-resolution-"));
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  async function writeBundle(directory: string) {
+    await mkdir(join(directory, "connect"), { recursive: true });
+    await writeFile(join(directory, "marketplace.json"), "{}");
+  }
+
+  it("uses newly prepared plugins and catalog when an upgrade leaves old server artifacts", async () => {
+    const moduleDir = join(root, "apps/server/dist");
+    const stale = join(moduleDir, "builtin-plugins");
+    const prepared = join(root, "packages/bundled-plugins/dist");
+    await writeBundle(stale);
+    await writeBundle(prepared);
+
+    expect(
+      resolveBuiltinPluginRootPathForModuleDir({ moduleDir, name: "connect" }),
+    ).toBe(join(prepared, "connect"));
+    expect(resolveBundledMarketplaceDirectory(moduleDir)).toBe(prepared);
+  });
+
+  it("loads the bundled artifacts shipped inside an installed package", async () => {
+    const moduleDir = join(root, "node_modules/bb-app/server/dist");
+    const packaged = join(moduleDir, "builtin-plugins");
+    await writeBundle(packaged);
+
+    expect(
+      resolveBuiltinPluginRootPathForModuleDir({ moduleDir, name: "connect" }),
+    ).toBe(join(packaged, "connect"));
+    expect(resolveBundledMarketplaceDirectory(moduleDir)).toBe(packaged);
+  });
+
+  it("retains source development plugin and generated catalog resolution", async () => {
+    const moduleDir = join(root, "apps/server/src/services/plugins");
+    const plugin = join(root, "plugins/connect");
+    const catalog = join(root, "apps/server/src/generated/bb-official-marketplace");
+    await mkdir(plugin, { recursive: true });
+    await mkdir(catalog, { recursive: true });
+    await writeFile(join(catalog, "marketplace.json"), "{}");
+
+    expect(
+      resolveBuiltinPluginRootPathForModuleDir({ moduleDir, name: "connect" }),
+    ).toBe(plugin);
+    expect(resolveBundledMarketplaceDirectory(moduleDir)).toBe(catalog);
+  });
+});

--- a/docs/debugging-and-qa.md
+++ b/docs/debugging-and-qa.md
@@ -395,3 +395,10 @@ generated modules and SDK artifacts arrive through explicit dependency edges.
 The source preparation runner supplies `BB_BUILD_TOOLCHAIN` with Node, OS, and
 architecture to partition Turbo cache entries; callers should use the runner
 rather than set this internal build identity themselves.
+
+Built source servers resolve plugins and the bundled marketplace from
+`packages/bundled-plugins/dist` before looking beside the server bundle.
+This prevents legacy `apps/server/dist/builtin-plugins` artifacts left by a
+Turbo cache restore from overriding newly prepared plugins. Installed packages
+use their shipped `server/dist/builtin-plugins` directory. Built-in plugins
+update with the server; users do not update them separately.


### PR DESCRIPTION
## Human comments

## What was wrong

After bundled-plugin preparation moved to `packages/bundled-plugins/dist` in #3474, the runtime resolver still preferred `apps/server/dist/builtin-plugins`. An existing checkout can retain that old directory when Turbo restores cached server outputs without deleting extra files. The server then loads stale plugins despite successfully preparing current bundles. On the affected server, Connect was paired and connected, but its old bundle lacked the machine-access provider registration, so Machine access offered only Manual. The current prepared Connect bundle already contained the registration. The bundled marketplace resolver had the same precedence bug.

## What changed

Prefer prepared checkout plugins and their marketplace catalog over legacy artifacts beside the server bundle. Installed packages continue using their shipped `server/dist/builtin-plugins` directory, and source development retains its existing fallback. Document the resolution order and that built-in plugins update with the server without a separate user update step.

## How you verified

- Added filesystem regression coverage with both old and newly prepared directories present. It failed before the fix by selecting the old Connect directory and passes afterward. Also cover installed-package and source-development layouts.
- `pnpm exec turbo run test --filter=@bb/server -- test/services/plugins/builtin-registry.test.ts test/services/plugins/builtin-plugins.test.ts test/services/plugin-catalog/marketplace-manifest.test.ts` — 65 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/server` — passed.
- Read-only inspection of the affected server confirmed the stale loaded plugin path, healthy Connect tunnel, Manual-only server-access response, and current integration in the prepared bundle. The running server has not been restarted with this change.

> AGENT GENERATED
