### PR TITLE
Scale Markdown image height cap with the viewport

### DIFF
--- a/apps/app/src/components/ui/markdown-preview.tsx
+++ b/apps/app/src/components/ui/markdown-preview.tsx
@@ -955,7 +955,7 @@ function renderMarkdownImage({
       {...imageAttributes}
       src={imageUrl}
       alt={typeof alt === "string" ? alt : "Image"}
-      className="my-2 max-h-96 max-w-full cursor-zoom-in object-contain"
+      className="my-2 max-h-[max(384px,50vh)] max-w-full cursor-zoom-in object-contain"
       loading="lazy"
       onClick={() => setExpandedImageUrl(imageUrl)}
     />


### PR DESCRIPTION
## Human comments

## What was wrong

Markdown images used a fixed 384px height cap, keeping large screenshots small even when the viewport had room to display them larger.

## What changed

Changed the shared image renderer in `apps/app/src/components/ui/markdown-preview.tsx` to use `max-height: max(384px, 50vh)`. The cap applies consistently, including HTML images with `width="100%"`, while retaining max-width, aspect-ratio containment, lazy loading, and click-to-zoom.

## How you verified

- `pnpm exec turbo run test --filter=@bb/app -- markdown`: all 180 tests in 18 files passed.
- Chromium with the real `MarkdownPreview` component and app Tailwind CSS in an isolated temporary Vite fixture: a 1200×1800 image measured 256×384 at 1280×600 and 1280×768, and approximately 333.33×500 at 1280×1000.
- At 240×1000, the image measured 208×312 with no horizontal overflow. HTML `width="100%"` images obeyed the same cap, retained `object-contain`, and preserved their visible aspect ratio; screenshots were visually reviewed.
- Browser input opened the image lightbox and Escape dismissed it. Lazy loading and the zoom cursor remained present.
- `git diff --check` passed. Temporary fixtures were removed and the browser/server stopped.

Verification was limited to Chromium component rendering; the full BB app and native platforms were not exercised. The verification inventory check reported pre-existing drift: `Unmapped CLI family: browser; add recipes and an explicit owner`.

> AGENT GENERATED
